### PR TITLE
Symbol levels in Rule-Based renderer

### DIFF
--- a/src/core/symbology-ng/qgsrendererv2.cpp
+++ b/src/core/symbology-ng/qgsrendererv2.cpp
@@ -348,7 +348,7 @@ QgsFeatureRendererV2* QgsFeatureRendererV2::load( QDomElement& element )
   QgsFeatureRendererV2* r = m->createRenderer( element );
   if ( r )
     r->setUsingSymbolLevels( element.attribute( "symbollevels", "0" ).toInt() );
-
+    r->setUsingFirstRule( element.attribute( "firstrule", "0" ).toInt() );
   return r;
 }
 

--- a/src/core/symbology-ng/qgsrendererv2.h
+++ b/src/core/symbology-ng/qgsrendererv2.h
@@ -84,6 +84,10 @@ class CORE_EXPORT QgsFeatureRendererV2
     bool usingSymbolLevels() const { return mUsingSymbolLevels; }
     void setUsingSymbolLevels( bool usingSymbolLevels ) { mUsingSymbolLevels = usingSymbolLevels; }
 
+    bool usingFirstRule() const { return mUsingFirstRule; }
+    void setUsingFirstRule( bool usingFirstRule ) { mUsingFirstRule = usingFirstRule; }
+
+
     //! create a renderer from XML element
     static QgsFeatureRendererV2* load( QDomElement& symbologyElem );
 
@@ -117,6 +121,7 @@ class CORE_EXPORT QgsFeatureRendererV2
     QString mType;
 
     bool mUsingSymbolLevels;
+    bool mUsingFirstRule;
 
     /** The current type of editing marker */
     int mCurrentVertexMarkerType;

--- a/src/core/symbology-ng/qgsrulebasedrendererv2.h
+++ b/src/core/symbology-ng/qgsrulebasedrendererv2.h
@@ -44,7 +44,8 @@ class CORE_EXPORT QgsRuleBasedRendererV2 : public QgsFeatureRendererV2
     {
       public:
         //! Constructor takes ownership of the symbol
-        Rule( QgsSymbolV2* symbol, int scaleMinDenom = 0, int scaleMaxDenom = 0, QString filterExp = QString(), QString label = QString(), QString description = QString() );
+        Rule( QgsSymbolV2* symbol, int scaleMinDenom = 0, int scaleMaxDenom = 0, QString filterExp = QString(),
+          QString label = QString(), QString description = QString() );
         Rule( const Rule& other );
         ~Rule();
         QString dump() const;
@@ -127,6 +128,8 @@ class CORE_EXPORT QgsRuleBasedRendererV2 : public QgsFeatureRendererV2
     void updateRuleAt( int index, const Rule& rule );
     //! remove the rule at the specified index
     void removeRuleAt( int index );
+    //! swap the two rules specified by the indices
+    void swapRules( int index1,  int index2);
 
     //////
 
@@ -147,6 +150,7 @@ class CORE_EXPORT QgsRuleBasedRendererV2 : public QgsFeatureRendererV2
     QList<Rule*> mCurrentRules;
     QgsFieldMap mCurrentFields;
     QgsSymbolV2* mCurrentSymbol;
+
 };
 
 #endif // QGSRULEBASEDRENDERERV2_H

--- a/src/gui/symbology-ng/qgsrendererv2propertiesdialog.cpp
+++ b/src/gui/symbology-ng/qgsrendererv2propertiesdialog.cpp
@@ -201,11 +201,29 @@ void QgsRendererV2PropertiesDialog::showSymbolLevels()
   QgsSymbolV2List symbols = r->symbols();
 
   QgsSymbolLevelsV2Dialog dlg( symbols, r->usingSymbolLevels(), this );
+  connect( this, SIGNAL( forceChkUsingFirstRule() ), mActiveWidget, SLOT( forceUsingFirstRule() ), Qt::UniqueConnection );
+  connect( this, SIGNAL( forceUncheckSymbolLevels() ), mActiveWidget, SLOT( forceNoSymbolLevels() ), Qt::UniqueConnection );
+
   if ( dlg.exec() )
   {
     r->setUsingSymbolLevels( dlg.usingLevels() );
+
+    if ( r->type() == "RuleRenderer" )
+    {
+      if( dlg.usingLevels() )
+      {
+        r->setUsingFirstRule( true );
+        emit forceChkUsingFirstRule();
+      }
+      else
+      {
+        emit forceUncheckSymbolLevels();
+      }
+    }
   }
+
 }
+
 
 void QgsRendererV2PropertiesDialog::useOldSymbology()
 {

--- a/src/gui/symbology-ng/qgsrendererv2propertiesdialog.h
+++ b/src/gui/symbology-ng/qgsrendererv2propertiesdialog.h
@@ -34,6 +34,8 @@ class GUI_EXPORT QgsRendererV2PropertiesDialog : public QDialog, private Ui::Qgs
 
   signals:
     void useNewSymbology( bool );
+    void forceChkUsingFirstRule();
+    void forceUncheckSymbolLevels();
 
   protected:
 

--- a/src/gui/symbology-ng/qgsrulebasedrendererv2widget.h
+++ b/src/gui/symbology-ng/qgsrulebasedrendererv2widget.h
@@ -78,12 +78,23 @@ class GUI_EXPORT QgsRuleBasedRendererV2Widget : public QgsRendererV2Widget, priv
     void addRule();
     void editRule();
     void removeRule();
+    void increasePriority();
+    void decreasePriority();
 
     void setGrouping();
 
     void refineRuleScales();
     void refineRuleCategories();
     void refineRuleRanges();
+
+    void usingFirstRuleChanged( );
+    void symbolLevelsEnabledChanged();
+    void forceNoSymbolLevels();
+    void forceUsingFirstRule();
+
+  signals:
+
+    void forceChkUsingFirstRule();
 
   protected:
 

--- a/src/ui/qgsrulebasedrendererv2widget.ui
+++ b/src/ui/qgsrulebasedrendererv2widget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>622</width>
-    <height>273</height>
+    <width>640</width>
+    <height>401</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -16,6 +16,9 @@
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">
     <widget class="QgsRendererRulesTreeWidget" name="treeRules">
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
      <property name="rootIsDecorated">
       <bool>false</bool>
      </property>
@@ -51,6 +54,17 @@
        <set>AlignHCenter|AlignVCenter|AlignCenter</set>
       </property>
      </column>
+     <column>
+      <property name="text">
+       <string>Priority</string>
+      </property>
+      <property name="toolTip">
+       <string>Priority when symbol levels are enabled (only first matching rule will be applied)</string>
+      </property>
+      <property name="textAlignment">
+       <set>AlignHCenter|AlignVCenter|AlignCenter</set>
+      </property>
+     </column>
     </widget>
    </item>
    <item row="0" column="1">
@@ -59,13 +73,6 @@
       <widget class="QPushButton" name="btnAddRule">
        <property name="text">
         <string>Add</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="btnRefineRule">
-       <property name="text">
-        <string>Refine</string>
        </property>
       </widget>
      </item>
@@ -83,18 +90,104 @@
        </property>
       </widget>
      </item>
+     <item>
+      <widget class="QPushButton" name="btnRefineRule">
+       <property name="text">
+        <string>Refine</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnIncreasePriority">
+       <property name="text">
+        <string>Increase priority</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnDecreasePriority">
+       <property name="text">
+        <string>Decrease priority</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
-   <item row="1" column="0" colspan="2">
+   <item row="3" column="0" colspan="2">
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>35</height>
+      </size>
+     </property>
+     <property name="baseSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="title">
+      <string/>
+     </property>
+     <widget class="QCheckBox" name="chkEnableSymbolLevels">
+      <property name="geometry">
+       <rect>
+        <x>113</x>
+        <y>10</y>
+        <width>231</width>
+        <height>24</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Enable symbol levels</string>
+      </property>
+     </widget>
+     <widget class="QCheckBox" name="chkUsingFirstRule">
+      <property name="geometry">
+       <rect>
+        <x>360</x>
+        <y>10</y>
+        <width>271</width>
+        <height>24</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Use only first matched rule</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_2">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>10</y>
+        <width>84</width>
+        <height>24</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Behavior</string>
+      </property>
+     </widget>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="2">
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
-      <string>Rule grouping</string>
+      <string notr="true"/>
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout">
       <item>
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Rule grouping</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QRadioButton" name="radNoGrouping">
         <property name="text">
-         <string>No grouping</string>
+         <string comment="No grouping for displaying rules">None</string>
         </property>
         <property name="checked">
          <bool>true</bool>
@@ -104,14 +197,14 @@
       <item>
        <widget class="QRadioButton" name="radGroupFilter">
         <property name="text">
-         <string>Group by filter</string>
+         <string comment="Group rules by filter">By filter</string>
         </property>
        </widget>
       </item>
       <item>
        <widget class="QRadioButton" name="radGroupScale">
         <property name="text">
-         <string>Group by scale</string>
+         <string comment="Group rules by scale">By scale</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
Apply the following patch on first version of release-1_7_0 (just after branching):
http://trac.osgeo.org/qgis/raw-attachment/ticket/3222/patch_on_r15676-rbr_symbol-levels_reordering_1st-rule_buttons.diff
Complete description here:
 http://trac.osgeo.org/qgis/ticket/3222#comment:18
