### PR TITLE
Symbol levels in Rule-Based renderer on release-1_7_0

### DIFF
--- a/src/core/symbology-ng/qgsrendererv2.cpp
+++ b/src/core/symbology-ng/qgsrendererv2.cpp
@@ -347,8 +347,10 @@ QgsFeatureRendererV2* QgsFeatureRendererV2::load( QDomElement& element )
 
   QgsFeatureRendererV2* r = m->createRenderer( element );
   if ( r )
+  {
     r->setUsingSymbolLevels( element.attribute( "symbollevels", "0" ).toInt() );
-
+    r->setUsingFirstRule( element.attribute( "firstrule", "0" ).toInt() );
+  }
   return r;
 }
 

--- a/src/core/symbology-ng/qgsrendererv2.h
+++ b/src/core/symbology-ng/qgsrendererv2.h
@@ -84,6 +84,10 @@ class CORE_EXPORT QgsFeatureRendererV2
     bool usingSymbolLevels() const { return mUsingSymbolLevels; }
     void setUsingSymbolLevels( bool usingSymbolLevels ) { mUsingSymbolLevels = usingSymbolLevels; }
 
+    bool usingFirstRule() const { return mUsingFirstRule; }
+    void setUsingFirstRule( bool usingFirstRule ) { mUsingFirstRule = usingFirstRule; }
+
+
     //! create a renderer from XML element
     static QgsFeatureRendererV2* load( QDomElement& symbologyElem );
 
@@ -117,6 +121,7 @@ class CORE_EXPORT QgsFeatureRendererV2
     QString mType;
 
     bool mUsingSymbolLevels;
+    bool mUsingFirstRule;
 
     /** The current type of editing marker */
     int mCurrentVertexMarkerType;

--- a/src/core/symbology-ng/qgsrulebasedrendererv2.cpp
+++ b/src/core/symbology-ng/qgsrulebasedrendererv2.cpp
@@ -128,7 +128,19 @@ QgsRuleBasedRendererV2::QgsRuleBasedRendererV2( QgsSymbolV2* defaultSymbol )
 
 QgsSymbolV2* QgsRuleBasedRendererV2::symbolForFeature( QgsFeature& feature )
 {
-  return mCurrentSymbol;
+
+  if( ! usingFirstRule() )
+    return mCurrentSymbol;
+
+  for ( QList<Rule*>::iterator it = mCurrentRules.begin(); it != mCurrentRules.end(); ++it )
+  {
+    Rule* rule = *it;
+
+    if ( rule->isFilterOK( mCurrentFields, feature ) )
+    {
+      return rule->symbol(); //works with levels but takes only first rule
+    }
+  }
 }
 
 void QgsRuleBasedRendererV2::renderFeature( QgsFeature& feature,
@@ -200,6 +212,10 @@ QgsFeatureRendererV2* QgsRuleBasedRendererV2::clone()
   QgsSymbolV2* s = mDefaultSymbol->clone();
   QgsRuleBasedRendererV2* r = new QgsRuleBasedRendererV2( s );
   r->mRules = mRules;
+  r->setUsingSymbolLevels( usingSymbolLevels() );
+  r->setUsingFirstRule( usingFirstRule() );
+  setUsingFirstRule( usingFirstRule() );
+  setUsingSymbolLevels( usingSymbolLevels() );
   return r;
 }
 
@@ -219,6 +235,8 @@ QDomElement QgsRuleBasedRendererV2::save( QDomDocument& doc )
 {
   QDomElement rendererElem = doc.createElement( RENDERER_TAG_NAME );
   rendererElem.setAttribute( "type", "RuleRenderer" );
+  rendererElem.setAttribute( "symbollevels", ( mUsingSymbolLevels ? "1" : "0" ) );
+  rendererElem.setAttribute( "firstrule", ( mUsingFirstRule ? "1" : "0" ) );
 
   QDomElement rulesElem = doc.createElement( "rules" );
 
@@ -345,6 +363,12 @@ void QgsRuleBasedRendererV2::removeRuleAt( int index )
 {
   mRules.removeAt( index );
 }
+
+void QgsRuleBasedRendererV2::swapRules( int index1,  int index2 )
+{
+  mRules.swap( index1, index2 );
+}
+
 
 #include "qgscategorizedsymbolrendererv2.h"
 #include "qgsgraduatedsymbolrendererv2.h"

--- a/src/core/symbology-ng/qgsrulebasedrendererv2.h
+++ b/src/core/symbology-ng/qgsrulebasedrendererv2.h
@@ -44,7 +44,8 @@ class CORE_EXPORT QgsRuleBasedRendererV2 : public QgsFeatureRendererV2
     {
       public:
         //! Constructor takes ownership of the symbol
-        Rule( QgsSymbolV2* symbol, int scaleMinDenom = 0, int scaleMaxDenom = 0, QString filterExp = QString(), QString label = QString(), QString description = QString() );
+        Rule( QgsSymbolV2* symbol, int scaleMinDenom = 0, int scaleMaxDenom = 0, QString filterExp = QString(),
+          QString label = QString(), QString description = QString() );
         Rule( const Rule& other );
         ~Rule();
         QString dump() const;
@@ -127,6 +128,8 @@ class CORE_EXPORT QgsRuleBasedRendererV2 : public QgsFeatureRendererV2
     void updateRuleAt( int index, const Rule& rule );
     //! remove the rule at the specified index
     void removeRuleAt( int index );
+    //! swap the two rules specified by the indices
+    void swapRules( int index1,  int index2);
 
     //////
 
@@ -147,6 +150,7 @@ class CORE_EXPORT QgsRuleBasedRendererV2 : public QgsFeatureRendererV2
     QList<Rule*> mCurrentRules;
     QgsFieldMap mCurrentFields;
     QgsSymbolV2* mCurrentSymbol;
+
 };
 
 #endif // QGSRULEBASEDRENDERERV2_H

--- a/src/gui/symbology-ng/qgsrendererv2propertiesdialog.cpp
+++ b/src/gui/symbology-ng/qgsrendererv2propertiesdialog.cpp
@@ -201,11 +201,29 @@ void QgsRendererV2PropertiesDialog::showSymbolLevels()
   QgsSymbolV2List symbols = r->symbols();
 
   QgsSymbolLevelsV2Dialog dlg( symbols, r->usingSymbolLevels(), this );
+  connect( this, SIGNAL( forceChkUsingFirstRule() ), mActiveWidget, SLOT( forceUsingFirstRule() ), Qt::UniqueConnection );
+  connect( this, SIGNAL( forceUncheckSymbolLevels() ), mActiveWidget, SLOT( forceNoSymbolLevels() ), Qt::UniqueConnection );
+
   if ( dlg.exec() )
   {
     r->setUsingSymbolLevels( dlg.usingLevels() );
+
+    if ( r->type() == "RuleRenderer" )
+    {
+      if( dlg.usingLevels() )
+      {
+        r->setUsingFirstRule( true );
+        emit forceChkUsingFirstRule();
+      }
+      else
+      {
+        emit forceUncheckSymbolLevels();
+      }
+    }
   }
+
 }
+
 
 void QgsRendererV2PropertiesDialog::useOldSymbology()
 {

--- a/src/gui/symbology-ng/qgsrendererv2propertiesdialog.h
+++ b/src/gui/symbology-ng/qgsrendererv2propertiesdialog.h
@@ -34,6 +34,8 @@ class GUI_EXPORT QgsRendererV2PropertiesDialog : public QDialog, private Ui::Qgs
 
   signals:
     void useNewSymbology( bool );
+    void forceChkUsingFirstRule();
+    void forceUncheckSymbolLevels();
 
   protected:
 

--- a/src/gui/symbology-ng/qgsrulebasedrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgsrulebasedrendererv2widget.cpp
@@ -22,6 +22,8 @@
 #include "qgsapplication.h"
 #include "qgssearchtreenode.h"
 #include "qgssymbolv2selectordialog.h"
+#include "qgslogger.h"
+#include "qstring.h"
 
 #include <QMenu>
 #include <QTreeWidgetItem>
@@ -66,16 +68,29 @@ QgsRuleBasedRendererV2Widget::QgsRuleBasedRendererV2Widget( QgsVectorLayer* laye
   btnAddRule->setIcon( QIcon( QgsApplication::iconPath( "symbologyAdd.png" ) ) );
   btnEditRule->setIcon( QIcon( QgsApplication::iconPath( "symbologyEdit.png" ) ) );
   btnRemoveRule->setIcon( QIcon( QgsApplication::iconPath( "symbologyRemove.png" ) ) );
+  btnIncreasePriority->setIcon( QIcon( QgsApplication::iconPath( "symbologyUp.png" ) ) );
+  btnDecreasePriority->setIcon( QIcon( QgsApplication::iconPath( "symbologyDown.png" ) ) );
 
   connect( treeRules, SIGNAL( itemDoubleClicked( QTreeWidgetItem*, int ) ), this, SLOT( editRule() ) );
 
   connect( btnAddRule, SIGNAL( clicked() ), this, SLOT( addRule() ) );
   connect( btnEditRule, SIGNAL( clicked() ), this, SLOT( editRule() ) );
   connect( btnRemoveRule, SIGNAL( clicked() ), this, SLOT( removeRule() ) );
+  connect( btnIncreasePriority, SIGNAL( clicked() ), this, SLOT( increasePriority() ) );
+  connect( btnDecreasePriority, SIGNAL( clicked() ), this, SLOT( decreasePriority() ) );
 
   connect( radNoGrouping, SIGNAL( clicked() ), this, SLOT( setGrouping() ) );
   connect( radGroupFilter, SIGNAL( clicked() ), this, SLOT( setGrouping() ) );
   connect( radGroupScale, SIGNAL( clicked() ), this, SLOT( setGrouping() ) );
+
+  // Make sure buttons are always in the correct state
+  chkUsingFirstRule->setChecked( mRenderer->usingFirstRule() );
+  chkEnableSymbolLevels->setChecked( mRenderer->usingSymbolLevels() );
+  // If symbol levels are used, forcefully check and gray-out the chkUsingFirstRule checkbox
+  if (mRenderer->usingSymbolLevels() ) { forceUsingFirstRule(); }
+  connect( chkUsingFirstRule, SIGNAL( clicked() ), this, SLOT( usingFirstRuleChanged() ));
+  connect( chkEnableSymbolLevels, SIGNAL( clicked() ), this, SLOT( symbolLevelsEnabledChanged() ) );
+  connect( this, SIGNAL( forceChkUsingFirstRule() ), this, SLOT( forceUsingFirstRule() ) );
 
   treeRules->populateRules();
 }
@@ -169,6 +184,99 @@ void QgsRuleBasedRendererV2Widget::removeRule()
 
   treeRules->populateRules();
 }
+
+
+void QgsRuleBasedRendererV2Widget::increasePriority()
+{
+  QTreeWidgetItem * item = treeRules->currentItem();
+    if ( ! item ) return; // No rule selected, exit
+  int rule_index = item->data( 0, Qt::UserRole + 1 ).toInt();
+  if ( rule_index < 0 )
+  {
+    return;// Group of rules selected, exit
+  }
+  else
+  {
+   if ( rule_index > 0 ) // do not increase priority of first rule
+   {
+      mRenderer->swapRules(rule_index, rule_index - 1);
+      treeRules->populateRules();
+    // TODO: find out where the moved rule goes and reselect it (at least for non-grouped display)
+    // maybe based on the following functions :
+    //  findItems(QString(rule_index - 1), Qt::MatchExactly, 4).first.index)
+    //  setCurrentItem, setSelected, scrollToItem
+   }
+  }
+
+}
+
+
+void QgsRuleBasedRendererV2Widget::decreasePriority()
+{
+  QTreeWidgetItem * item = treeRules->currentItem();
+    if ( ! item ) return; // No rule selected, exit
+  int rule_index = item->data( 0, Qt::UserRole + 1 ).toInt();
+  if ( rule_index < 0 )
+  {
+    return;// Group of rules selected, exit
+  }
+  else
+  {
+   if ( rule_index +1 < mRenderer->ruleCount() ) // do not increase priority of last rule
+   {
+     mRenderer->swapRules(rule_index, rule_index + 1);
+     treeRules->populateRules();
+   }
+  }
+}
+
+
+void QgsRuleBasedRendererV2Widget::usingFirstRuleChanged()
+{
+  if ( chkUsingFirstRule->checkState() == Qt::Checked )
+  {
+    mRenderer->setUsingFirstRule(true);
+  }
+  else
+  {
+    mRenderer->setUsingFirstRule(false);
+  }
+
+}
+
+
+void QgsRuleBasedRendererV2Widget::forceUsingFirstRule()
+{
+  chkEnableSymbolLevels->setChecked( true );
+  chkUsingFirstRule->setChecked( true );
+  chkUsingFirstRule->setEnabled(false);
+  mRenderer->setUsingFirstRule(true);
+}
+
+
+void QgsRuleBasedRendererV2Widget::forceNoSymbolLevels()
+{
+    chkEnableSymbolLevels->setChecked( false );
+    chkUsingFirstRule->setEnabled( true );
+    mRenderer->setUsingSymbolLevels( false );
+}
+
+
+void QgsRuleBasedRendererV2Widget::symbolLevelsEnabledChanged()
+{
+  if ( chkEnableSymbolLevels->checkState() == Qt::Checked )
+  {
+    mRenderer->setUsingSymbolLevels(true);
+    emit forceChkUsingFirstRule();
+  }
+  else
+  {
+   mRenderer->setUsingSymbolLevels(false);
+   chkUsingFirstRule->setEnabled(true);
+  }
+}
+
+
 
 
 #include "qgscategorizedsymbolrendererv2.h"
@@ -487,6 +595,9 @@ void QgsRendererRulesTreeWidget::populateRulesNoGrouping()
     //item->setBackground( 1, Qt::lightGray );
     //item->setBackground( 3, Qt::lightGray );
 
+    // Priority (Id): add 1 to rule number and convert to string
+    item->setText( 4,  QString("%1").arg( i+1, 4 ) );
+    item->setTextAlignment (4, Qt::AlignRight);
     lst << item;
   }
 
@@ -550,6 +661,11 @@ void QgsRendererRulesTreeWidget::populateRulesGroupByScale()
 
     //item->setBackground( 1, Qt::lightGray );
     //item->setBackground( 3, Qt::lightGray );
+
+    // Priority (Id): add 1 to rule number and convert to string
+    item->setText( 4,  QString("%1").arg( i+1, 4 ) );
+    item->setTextAlignment (4, Qt::AlignRight);
+
   }
   addTopLevelItems( scale_items.values() );
 }
@@ -601,6 +717,10 @@ void QgsRendererRulesTreeWidget::populateRulesGroupByFilter()
       item->setTextAlignment( 2, Qt::AlignRight );
       item->setTextAlignment( 3, Qt::AlignRight );
     }
+
+    // Priority (Id): add 1 to rule number and convert to string
+    item->setText( 4,  QString("%1").arg( i+1, 4 ) );
+    item->setTextAlignment (4, Qt::AlignRight);
   }
 
   addTopLevelItems( filter_items.values() );

--- a/src/gui/symbology-ng/qgsrulebasedrendererv2widget.h
+++ b/src/gui/symbology-ng/qgsrulebasedrendererv2widget.h
@@ -78,12 +78,23 @@ class GUI_EXPORT QgsRuleBasedRendererV2Widget : public QgsRendererV2Widget, priv
     void addRule();
     void editRule();
     void removeRule();
+    void increasePriority();
+    void decreasePriority();
 
     void setGrouping();
 
     void refineRuleScales();
     void refineRuleCategories();
     void refineRuleRanges();
+
+    void usingFirstRuleChanged( );
+    void symbolLevelsEnabledChanged();
+    void forceNoSymbolLevels();
+    void forceUsingFirstRule();
+
+  signals:
+
+    void forceChkUsingFirstRule();
 
   protected:
 

--- a/src/ui/qgsrulebasedrendererv2widget.ui
+++ b/src/ui/qgsrulebasedrendererv2widget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>622</width>
-    <height>273</height>
+    <width>640</width>
+    <height>401</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -16,6 +16,9 @@
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">
     <widget class="QgsRendererRulesTreeWidget" name="treeRules">
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
      <property name="rootIsDecorated">
       <bool>false</bool>
      </property>
@@ -51,6 +54,17 @@
        <set>AlignHCenter|AlignVCenter|AlignCenter</set>
       </property>
      </column>
+     <column>
+      <property name="text">
+       <string>Priority</string>
+      </property>
+      <property name="toolTip">
+       <string>Priority when symbol levels are enabled (only first matching rule will be applied)</string>
+      </property>
+      <property name="textAlignment">
+       <set>AlignHCenter|AlignVCenter|AlignCenter</set>
+      </property>
+     </column>
     </widget>
    </item>
    <item row="0" column="1">
@@ -59,13 +73,6 @@
       <widget class="QPushButton" name="btnAddRule">
        <property name="text">
         <string>Add</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="btnRefineRule">
-       <property name="text">
-        <string>Refine</string>
        </property>
       </widget>
      </item>
@@ -83,18 +90,104 @@
        </property>
       </widget>
      </item>
+     <item>
+      <widget class="QPushButton" name="btnRefineRule">
+       <property name="text">
+        <string>Refine</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnIncreasePriority">
+       <property name="text">
+        <string>Increase priority</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnDecreasePriority">
+       <property name="text">
+        <string>Decrease priority</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
-   <item row="1" column="0" colspan="2">
+   <item row="3" column="0" colspan="2">
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="minimumSize">
+      <size>
+       <width>0</width>
+       <height>35</height>
+      </size>
+     </property>
+     <property name="baseSize">
+      <size>
+       <width>0</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="title">
+      <string/>
+     </property>
+     <widget class="QCheckBox" name="chkEnableSymbolLevels">
+      <property name="geometry">
+       <rect>
+        <x>113</x>
+        <y>10</y>
+        <width>231</width>
+        <height>24</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Enable symbol levels</string>
+      </property>
+     </widget>
+     <widget class="QCheckBox" name="chkUsingFirstRule">
+      <property name="geometry">
+       <rect>
+        <x>360</x>
+        <y>10</y>
+        <width>271</width>
+        <height>24</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Use only first matched rule</string>
+      </property>
+     </widget>
+     <widget class="QLabel" name="label_2">
+      <property name="geometry">
+       <rect>
+        <x>10</x>
+        <y>10</y>
+        <width>84</width>
+        <height>24</height>
+       </rect>
+      </property>
+      <property name="text">
+       <string>Behavior</string>
+      </property>
+     </widget>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="2">
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
-      <string>Rule grouping</string>
+      <string notr="true"/>
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout">
       <item>
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Rule grouping</string>
+        </property>
+       </widget>
+      </item>
+      <item>
        <widget class="QRadioButton" name="radNoGrouping">
         <property name="text">
-         <string>No grouping</string>
+         <string comment="No grouping for displaying rules">None</string>
         </property>
         <property name="checked">
          <bool>true</bool>
@@ -104,14 +197,14 @@
       <item>
        <widget class="QRadioButton" name="radGroupFilter">
         <property name="text">
-         <string>Group by filter</string>
+         <string comment="Group rules by filter">By filter</string>
         </property>
        </widget>
       </item>
       <item>
        <widget class="QRadioButton" name="radGroupScale">
         <property name="text">
-         <string>Group by scale</string>
+         <string comment="Group rules by scale">By scale</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
Symbol levels in Rule-Based renderer: Apply the following patch (ticket 3222) on HEAD release-1_7_0 : http://trac.osgeo.org/qgis/attachment/ticket/3222/patch_on_first_1_7_0_symbol-levels_rbr_jef.diff 
