### PR TITLE
Changed all QToolBox objects to QTabWidget.  Easier to see item options and less mouse movement.

### DIFF
--- a/src/app/composer/qgscomposerarrowwidget.cpp
+++ b/src/app/composer/qgscomposerarrowwidget.cpp
@@ -36,7 +36,7 @@ QgsComposerArrowWidget::QgsComposerArrowWidget( QgsComposerArrow* arrow ): QWidg
 
   //add widget for general composer item properties
   QgsComposerItemWidget* itemPropertiesWidget = new QgsComposerItemWidget( this, mArrow );
-  toolBox->addItem( itemPropertiesWidget, tr( "General options" ) );
+  toolBox->addTab( itemPropertiesWidget, tr( "General options" ) );
 
   setGuiElementValues();
 

--- a/src/app/composer/qgscomposerlabelwidget.cpp
+++ b/src/app/composer/qgscomposerlabelwidget.cpp
@@ -28,7 +28,7 @@ QgsComposerLabelWidget::QgsComposerLabelWidget( QgsComposerLabel* label ): QWidg
 
   //add widget for general composer item properties
   QgsComposerItemWidget* itemPropertiesWidget = new QgsComposerItemWidget( this, label );
-  toolBox->addItem( itemPropertiesWidget, tr( "General options" ) );
+  toolBox->addTab( itemPropertiesWidget, tr( "General options" ) );
 
   if ( mComposerLabel )
   {

--- a/src/app/composer/qgscomposerlegendwidget.cpp
+++ b/src/app/composer/qgscomposerlegendwidget.cpp
@@ -43,7 +43,7 @@ QgsComposerLegendWidget::QgsComposerLegendWidget( QgsComposerLegend* legend ): m
 
   //add widget for item properties
   QgsComposerItemWidget* itemPropertiesWidget = new QgsComposerItemWidget( this, legend );
-  toolBox->addItem( itemPropertiesWidget, tr( "Item Options" ) );
+  toolBox->addTab( itemPropertiesWidget, tr( "General options" ) );
 
   if ( legend )
   {

--- a/src/app/composer/qgscomposermapwidget.cpp
+++ b/src/app/composer/qgscomposermapwidget.cpp
@@ -28,7 +28,7 @@ QgsComposerMapWidget::QgsComposerMapWidget( QgsComposerMap* composerMap ): QWidg
 
   //add widget for general composer item properties
   QgsComposerItemWidget* itemPropertiesWidget = new QgsComposerItemWidget( this, composerMap );
-  toolBox->addItem( itemPropertiesWidget, tr( "General options" ) );
+  toolBox->addTab( itemPropertiesWidget, tr( "General options" ) );
 
   mWidthLineEdit->setValidator( new QDoubleValidator( mWidthLineEdit ) );
   mHeightLineEdit->setValidator( new QDoubleValidator( mHeightLineEdit ) );

--- a/src/app/composer/qgscomposerpicturewidget.cpp
+++ b/src/app/composer/qgscomposerpicturewidget.cpp
@@ -36,7 +36,7 @@ QgsComposerPictureWidget::QgsComposerPictureWidget( QgsComposerPicture* picture 
 
   //add widget for general composer item properties
   QgsComposerItemWidget* itemPropertiesWidget = new QgsComposerItemWidget( this, picture );
-  toolBox->addItem( itemPropertiesWidget, tr( "General options" ) );
+  toolBox->addTab( itemPropertiesWidget, tr( "General options" ) );
 
   mWidthLineEdit->setValidator( new QDoubleValidator( this ) );
   mHeightLineEdit->setValidator( new QDoubleValidator( this ) );

--- a/src/app/composer/qgscomposerscalebarwidget.cpp
+++ b/src/app/composer/qgscomposerscalebarwidget.cpp
@@ -28,7 +28,7 @@ QgsComposerScaleBarWidget::QgsComposerScaleBarWidget( QgsComposerScaleBar* scale
 
   //add widget for general composer item properties
   QgsComposerItemWidget* itemPropertiesWidget = new QgsComposerItemWidget( this, scaleBar );
-  toolBox->addItem( itemPropertiesWidget, tr( "General options" ) );
+  toolBox->addTab( itemPropertiesWidget, tr( "General options" ) );
 
   blockMemberSignals( true );
   mStyleComboBox->insertItem( 0, tr( "Single Box" ) );

--- a/src/app/composer/qgscomposershapewidget.cpp
+++ b/src/app/composer/qgscomposershapewidget.cpp
@@ -26,7 +26,7 @@ QgsComposerShapeWidget::QgsComposerShapeWidget( QgsComposerShape* composerShape 
 
   //add widget for general composer item properties
   QgsComposerItemWidget* itemPropertiesWidget = new QgsComposerItemWidget( this, composerShape );
-  toolBox->addItem( itemPropertiesWidget, tr( "General options" ) );
+  toolBox->addTab( itemPropertiesWidget, tr( "General options" ) );
 
   blockAllSignals( true );
 

--- a/src/app/composer/qgscomposertablewidget.cpp
+++ b/src/app/composer/qgscomposertablewidget.cpp
@@ -30,7 +30,7 @@ QgsComposerTableWidget::QgsComposerTableWidget( QgsComposerAttributeTable* table
   setupUi( this );
   //add widget for general composer item properties
   QgsComposerItemWidget* itemPropertiesWidget = new QgsComposerItemWidget( this, mComposerTable );
-  mToolBox->addItem( itemPropertiesWidget, tr( "General options" ) );
+  toolBox->addTab( itemPropertiesWidget, tr( "General options" ) );
 
   blockAllSignals( true );
 

--- a/src/ui/qgscomposerarrowwidgetbase.ui
+++ b/src/ui/qgscomposerarrowwidgetbase.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>196</width>
+    <width>197</width>
     <height>407</height>
    </rect>
   </property>
@@ -15,20 +15,9 @@
   </property>
   <layout class="QGridLayout" name="gridLayout_3">
    <item row="0" column="0">
-    <widget class="QToolBox" name="toolBox">
-     <property name="currentIndex">
-      <number>0</number>
-     </property>
-     <widget class="QWidget" name="page">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>178</width>
-        <height>363</height>
-       </rect>
-      </property>
-      <attribute name="label">
+    <widget class="QTabWidget" name="toolBox">
+     <widget class="QWidget" name="page" native="true">
+      <attribute name="title">
        <string>Arrow</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_2">

--- a/src/ui/qgscomposerlabelwidgetbase.ui
+++ b/src/ui/qgscomposerlabelwidgetbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>547</width>
-    <height>425</height>
+    <height>533</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -21,20 +21,9 @@
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
    <item row="0" column="0">
-    <widget class="QToolBox" name="toolBox">
-     <property name="currentIndex">
-      <number>0</number>
-     </property>
-     <widget class="QWidget" name="page">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>513</width>
-        <height>402</height>
-       </rect>
-      </property>
-      <attribute name="label">
+    <widget class="QTabWidget" name="toolBox">
+     <widget class="QWidget" name="page" native="true">
+      <attribute name="title">
        <string>Label</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout">
@@ -69,9 +58,6 @@
         <widget class="QLabel" name="mMarginTextLabel">
          <property name="text">
           <string>Margin (mm)</string>
-         </property>
-         <property name="buddy">
-          <cstring>mMarginDoubleSpinBox</cstring>
          </property>
         </widget>
        </item>

--- a/src/ui/qgscomposerlegendwidgetbase.ui
+++ b/src/ui/qgscomposerlegendwidgetbase.ui
@@ -39,20 +39,12 @@
       </property>
       <layout class="QGridLayout" name="gridLayout_3">
        <item row="0" column="0">
-        <widget class="QToolBox" name="toolBox">
+        <widget class="QTabWidget" name="toolBox">
          <property name="currentIndex">
           <number>1</number>
          </property>
-         <widget class="QWidget" name="page">
-          <property name="geometry">
-           <rect>
-            <x>0</x>
-            <y>0</y>
-            <width>338</width>
-            <height>404</height>
-           </rect>
-          </property>
-          <attribute name="label">
+         <widget class="QWidget" name="page" native="true">
+          <attribute name="title">
            <string>General</string>
           </attribute>
           <layout class="QGridLayout" name="gridLayout">
@@ -60,9 +52,6 @@
             <widget class="QLabel" name="mTitleLabel">
              <property name="text">
               <string>&amp;Title</string>
-             </property>
-             <property name="buddy">
-              <cstring>mTitleLineEdit</cstring>
              </property>
             </widget>
            </item>
@@ -178,16 +167,8 @@
            </item>
           </layout>
          </widget>
-         <widget class="QWidget" name="page_2">
-          <property name="geometry">
-           <rect>
-            <x>0</x>
-            <y>0</y>
-            <width>351</width>
-            <height>394</height>
-           </rect>
-          </property>
-          <attribute name="label">
+         <widget class="QWidget" name="page_2" native="true">
+          <attribute name="title">
            <string>Legend items</string>
           </attribute>
           <layout class="QGridLayout" name="gridLayout_2">

--- a/src/ui/qgscomposermapwidgetbase.ui
+++ b/src/ui/qgscomposermapwidgetbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>404</width>
-    <height>447</height>
+    <width>433</width>
+    <height>830</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -24,20 +24,15 @@
     <number>0</number>
    </property>
    <item row="0" column="0">
-    <widget class="QToolBox" name="toolBox">
+    <widget class="QTabWidget" name="toolBox">
+     <property name="styleSheet">
+      <string notr="true"/>
+     </property>
      <property name="currentIndex">
       <number>0</number>
      </property>
-     <widget class="QWidget" name="page">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>377</width>
-        <height>414</height>
-       </rect>
-      </property>
-      <attribute name="label">
+     <widget class="QWidget" name="page" native="true">
+      <attribute name="title">
        <string>Map</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout">
@@ -81,9 +76,6 @@
             <property name="wordWrap">
              <bool>true</bool>
             </property>
-            <property name="buddy">
-             <cstring>mWidthLineEdit</cstring>
-            </property>
            </widget>
           </item>
           <item row="1" column="1">
@@ -96,9 +88,6 @@
             </property>
             <property name="wordWrap">
              <bool>true</bool>
-            </property>
-            <property name="buddy">
-             <cstring>mHeightLineEdit</cstring>
             </property>
            </widget>
           </item>
@@ -119,9 +108,6 @@
             <property name="wordWrap">
              <bool>true</bool>
             </property>
-            <property name="buddy">
-             <cstring>mScaleLineEdit</cstring>
-            </property>
            </widget>
           </item>
           <item row="5" column="1">
@@ -138,9 +124,6 @@
             </property>
             <property name="wordWrap">
              <bool>true</bool>
-            </property>
-            <property name="buddy">
-             <cstring>mRotationSpinBox</cstring>
             </property>
            </widget>
           </item>
@@ -203,16 +186,8 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="page_2">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>394</width>
-        <height>356</height>
-       </rect>
-      </property>
-      <attribute name="label">
+     <widget class="QWidget" name="page2" native="true">
+      <attribute name="title">
        <string>Extents</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_5">
@@ -233,9 +208,6 @@
             <property name="wordWrap">
              <bool>true</bool>
             </property>
-            <property name="buddy">
-             <cstring>mXMinLineEdit</cstring>
-            </property>
            </widget>
           </item>
           <item row="1" column="0">
@@ -248,9 +220,6 @@
             </property>
             <property name="wordWrap">
              <bool>true</bool>
-            </property>
-            <property name="buddy">
-             <cstring>mXMaxLineEdit</cstring>
             </property>
            </widget>
           </item>
@@ -265,9 +234,6 @@
             <property name="wordWrap">
              <bool>true</bool>
             </property>
-            <property name="buddy">
-             <cstring>mYMinLineEdit</cstring>
-            </property>
            </widget>
           </item>
           <item row="5" column="0">
@@ -280,9 +246,6 @@
             </property>
             <property name="wordWrap">
              <bool>true</bool>
-            </property>
-            <property name="buddy">
-             <cstring>mYMaxLineEdit</cstring>
             </property>
            </widget>
           </item>
@@ -320,16 +283,8 @@
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="page_3">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>377</width>
-        <height>720</height>
-       </rect>
-      </property>
-      <attribute name="label">
+     <widget class="QWidget" name="page3" native="true">
+      <attribute name="title">
        <string>Grid</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_7">
@@ -356,9 +311,6 @@
             <property name="wordWrap">
              <bool>true</bool>
             </property>
-            <property name="buddy">
-             <cstring>mGridTypeComboBox</cstring>
-            </property>
            </widget>
           </item>
           <item row="1" column="0">
@@ -371,9 +323,6 @@
             </property>
             <property name="wordWrap">
              <bool>true</bool>
-            </property>
-            <property name="buddy">
-             <cstring>mIntervalXSpinBox</cstring>
             </property>
            </widget>
           </item>
@@ -395,9 +344,6 @@
             <property name="wordWrap">
              <bool>true</bool>
             </property>
-            <property name="buddy">
-             <cstring>mOffsetXSpinBox</cstring>
-            </property>
            </widget>
           </item>
           <item row="8" column="0">
@@ -417,9 +363,6 @@
             </property>
             <property name="wordWrap">
              <bool>true</bool>
-            </property>
-            <property name="buddy">
-             <cstring>mLineWidthSpinBox</cstring>
             </property>
            </widget>
           </item>
@@ -445,9 +388,6 @@
             <property name="wordWrap">
              <bool>true</bool>
             </property>
-            <property name="buddy">
-             <cstring>mAnnotationPositionComboBox</cstring>
-            </property>
            </widget>
           </item>
           <item row="23" column="0">
@@ -463,9 +403,6 @@
             </property>
             <property name="wordWrap">
              <bool>true</bool>
-            </property>
-            <property name="buddy">
-             <cstring>mAnnotationDirectionComboBox</cstring>
             </property>
            </widget>
           </item>
@@ -487,9 +424,6 @@
             <property name="wordWrap">
              <bool>true</bool>
             </property>
-            <property name="buddy">
-             <cstring>mDistanceToMapFrameSpinBox</cstring>
-            </property>
            </widget>
           </item>
           <item row="36" column="0">
@@ -502,9 +436,6 @@
             </property>
             <property name="wordWrap">
              <bool>true</bool>
-            </property>
-            <property name="buddy">
-             <cstring>mCoordinatePrecisionSpinBox</cstring>
             </property>
            </widget>
           </item>
@@ -536,9 +467,6 @@
             <property name="wordWrap">
              <bool>true</bool>
             </property>
-            <property name="buddy">
-             <cstring>mIntervalYSpinBox</cstring>
-            </property>
            </widget>
           </item>
           <item row="6" column="0">
@@ -559,9 +487,6 @@
             <property name="wordWrap">
              <bool>true</bool>
             </property>
-            <property name="buddy">
-             <cstring>mOffsetYSpinBox</cstring>
-            </property>
            </widget>
           </item>
           <item row="14" column="0">
@@ -571,9 +496,6 @@
             </property>
             <property name="wordWrap">
              <bool>true</bool>
-            </property>
-            <property name="buddy">
-             <cstring>mCrossWidthSpinBox</cstring>
             </property>
            </widget>
           </item>
@@ -597,9 +519,6 @@
             </property>
             <property name="wordWrap">
              <bool>true</bool>
-            </property>
-            <property name="buddy">
-             <cstring>mLineColorButton</cstring>
             </property>
            </widget>
           </item>

--- a/src/ui/qgscomposerpicturewidgetbase.ui
+++ b/src/ui/qgscomposerpicturewidgetbase.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>293</width>
+    <width>327</width>
     <height>540</height>
    </rect>
   </property>
@@ -24,21 +24,28 @@
     <number>0</number>
    </property>
    <item row="0" column="0">
-    <widget class="QToolBox" name="toolBox">
-     <property name="currentIndex">
-      <number>0</number>
+    <widget class="QTabWidget" name="toolBox">
+     <property name="enabled">
+      <bool>true</bool>
      </property>
-     <widget class="QWidget" name="page">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>-129</y>
-        <width>266</width>
-        <height>632</height>
-       </rect>
-      </property>
-      <attribute name="label">
-       <string>Picture options</string>
+     <property name="tabShape">
+      <enum>QTabWidget::Rounded</enum>
+     </property>
+     <property name="elideMode">
+      <enum>Qt::ElideNone</enum>
+     </property>
+     <property name="documentMode">
+      <bool>false</bool>
+     </property>
+     <property name="tabsClosable">
+      <bool>false</bool>
+     </property>
+     <property name="movable">
+      <bool>false</bool>
+     </property>
+     <widget class="QWidget" name="page" native="true">
+      <attribute name="title">
+       <string>Picture Options</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_2">
        <item row="0" column="0">
@@ -156,9 +163,6 @@
             <property name="text">
              <string>Load</string>
             </property>
-            <property name="buddy">
-             <cstring>mPictureLineEdit</cstring>
-            </property>
            </widget>
           </item>
           <item row="1" column="0">
@@ -201,9 +205,6 @@
             <property name="wordWrap">
              <bool>true</bool>
             </property>
-            <property name="buddy">
-             <cstring>mWidthLineEdit</cstring>
-            </property>
            </widget>
           </item>
           <item row="3" column="0">
@@ -222,9 +223,6 @@
             </property>
             <property name="wordWrap">
              <bool>true</bool>
-            </property>
-            <property name="buddy">
-             <cstring>mHeightLineEdit</cstring>
             </property>
            </widget>
           </item>
@@ -248,9 +246,6 @@
             </property>
             <property name="wordWrap">
              <bool>true</bool>
-            </property>
-            <property name="buddy">
-             <cstring>mRotationSpinBox</cstring>
             </property>
            </widget>
           </item>

--- a/src/ui/qgscomposerscalebarwidgetbase.ui
+++ b/src/ui/qgscomposerscalebarwidgetbase.ui
@@ -24,20 +24,9 @@
     <number>0</number>
    </property>
    <item row="0" column="0">
-    <widget class="QToolBox" name="toolBox">
-     <property name="currentIndex">
-      <number>0</number>
-     </property>
-     <widget class="QWidget" name="page">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>307</width>
-        <height>616</height>
-       </rect>
-      </property>
-      <attribute name="label">
+    <widget class="QTabWidget" name="toolBox">
+     <widget class="QWidget" name="page" native="true">
+      <attribute name="title">
        <string>Scale bar</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout_2">
@@ -48,9 +37,6 @@
          </property>
          <property name="wordWrap">
           <bool>true</bool>
-         </property>
-         <property name="buddy">
-          <cstring>mSegmentSizeSpinBox</cstring>
          </property>
         </widget>
        </item>
@@ -71,9 +57,6 @@
          </property>
          <property name="wordWrap">
           <bool>true</bool>
-         </property>
-         <property name="buddy">
-          <cstring>mMapUnitsPerBarUnitSpinBox</cstring>
          </property>
         </widget>
        </item>
@@ -103,9 +86,6 @@
          <property name="text">
           <string>Style</string>
          </property>
-         <property name="buddy">
-          <cstring>mStyleComboBox</cstring>
-         </property>
         </widget>
        </item>
        <item row="7" column="0">
@@ -124,9 +104,6 @@
          </property>
          <property name="wordWrap">
           <bool>true</bool>
-         </property>
-         <property name="buddy">
-          <cstring>mMapComboBox</cstring>
          </property>
         </widget>
        </item>
@@ -205,9 +182,6 @@
          </property>
          <property name="wordWrap">
           <bool>true</bool>
-         </property>
-         <property name="buddy">
-          <cstring>mUnitLabelLineEdit</cstring>
          </property>
         </widget>
        </item>

--- a/src/ui/qgscomposershapewidgetbase.ui
+++ b/src/ui/qgscomposershapewidgetbase.ui
@@ -15,20 +15,9 @@
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
    <item row="0" column="0">
-    <widget class="QToolBox" name="toolBox">
-     <property name="currentIndex">
-      <number>0</number>
-     </property>
-     <widget class="QWidget" name="Shape">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>267</width>
-        <height>377</height>
-       </rect>
-      </property>
-      <attribute name="label">
+    <widget class="QTabWidget" name="toolBox">
+     <widget class="QWidget" name="page">
+      <attribute name="title">
        <string>Shape</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout">

--- a/src/ui/qgscomposertablewidgetbase.ui
+++ b/src/ui/qgscomposertablewidgetbase.ui
@@ -15,20 +15,9 @@
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
    <item row="0" column="0">
-    <widget class="QToolBox" name="mToolBox">
-     <property name="currentIndex">
-      <number>0</number>
-     </property>
-     <widget class="QWidget" name="page">
-      <property name="geometry">
-       <rect>
-        <x>0</x>
-        <y>0</y>
-        <width>260</width>
-        <height>298</height>
-       </rect>
-      </property>
-      <attribute name="label">
+    <widget class="QTabWidget" name="toolBox">
+     <widget class="QWidget" name="page" native="true">
+      <attribute name="title">
        <string>Table</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout">
@@ -38,9 +27,6 @@
           <widget class="QLabel" name="mLayerLabel">
            <property name="text">
             <string>Layer</string>
-           </property>
-           <property name="buddy">
-            <cstring>mLayerComboBox</cstring>
            </property>
           </widget>
          </item>
@@ -83,9 +69,6 @@
            <property name="text">
             <string>Composer map</string>
            </property>
-           <property name="buddy">
-            <cstring>mComposerMapComboBox</cstring>
-           </property>
           </widget>
          </item>
          <item>
@@ -100,9 +83,6 @@
            <property name="text">
             <string>Maximum rows</string>
            </property>
-           <property name="buddy">
-            <cstring>mMaximumColumnsSpinBox</cstring>
-           </property>
           </widget>
          </item>
          <item>
@@ -116,9 +96,6 @@
           <widget class="QLabel" name="mMarginLabel">
            <property name="text">
             <string>Margin</string>
-           </property>
-           <property name="buddy">
-            <cstring>mMarginSpinBox</cstring>
            </property>
           </widget>
          </item>
@@ -141,9 +118,6 @@
            <property name="text">
             <string>Grid stroke width</string>
            </property>
-           <property name="buddy">
-            <cstring>mGridStrokeWidthSpinBox</cstring>
-           </property>
           </widget>
          </item>
          <item>
@@ -155,9 +129,6 @@
         <widget class="QLabel" name="mGridColorLabel">
          <property name="text">
           <string>Grid color</string>
-         </property>
-         <property name="buddy">
-          <cstring>mGridColorButton</cstring>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
Changed all QToolBox objects to QTabWidget.  
Easier to see item options and less mouse movement.

With the QToolBox before it was harder to see all the selected objects options at a glance and mouse movement was large as the user had to move up and down the panel to select the next set of options.  
