### PR TITLE
Make "-dstalpha" parameter in GDALTools Clipper optional

### DIFF
--- a/python/plugins/GdalTools/tools/doClipper.py
+++ b/python/plugins/GdalTools/tools/doClipper.py
@@ -28,6 +28,7 @@ class GdalToolsDialog(QWidget, Ui_Widget, BasePluginWidget):
           (self.outSelector, SIGNAL("filenameChanged()") ),
           (self.noDataSpin, SIGNAL("valueChanged(int)"), self.noDataCheck, "1.7.0"),
           (self.maskSelector, SIGNAL("filenameChanged()"), self.maskModeRadio, "1.6.0"),
+          (self.alphaBandCheck, SIGNAL( "stateChanged( int )") ),
           (self.extentSelector, [SIGNAL("selectionStarted()"), SIGNAL("newExtentDefined()")], self.extentModeRadio), 
           (self.modeStackedWidget, SIGNAL("currentIndexChanged(int)"))
         ]
@@ -138,7 +139,8 @@ class GdalToolsDialog(QWidget, Ui_Widget, BasePluginWidget):
           arguments << "-q"
           arguments << "-cutline"
           arguments << mask
-          arguments << "-dstalpha"
+          if self.alphaBandCheck.isChecked():
+            arguments << "-dstalpha"
 
       outputFn = self.getOutputFileName()
       if not outputFn.isEmpty():

--- a/python/plugins/GdalTools/tools/widgetClipper.ui
+++ b/python/plugins/GdalTools/tools/widgetClipper.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>338</width>
-    <height>191</height>
+    <height>226</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -90,7 +90,7 @@
       <item row="1" column="0" colspan="2">
        <widget class="QStackedWidget" name="modeStackedWidget">
         <property name="currentIndex">
-         <number>0</number>
+         <number>1</number>
         </property>
         <widget class="QWidget" name="page">
          <layout class="QGridLayout" name="gridLayout_3">
@@ -107,7 +107,7 @@
           <property name="margin">
            <number>0</number>
           </property>
-          <item row="1" column="0">
+          <item row="2" column="0">
            <spacer name="verticalSpacer">
             <property name="orientation">
              <enum>Qt::Vertical</enum>
@@ -129,6 +129,13 @@
           </item>
           <item row="0" column="1">
            <widget class="GdalToolsInOutSelector" name="maskSelector" native="true"/>
+          </item>
+          <item row="1" column="0">
+           <widget class="QCheckBox" name="alphaBandCheck">
+            <property name="text">
+             <string>Create an output alpha band</string>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>


### PR DESCRIPTION
Clipping with "-dstalpha" option (this is default in GDALTools now) produces two bands raster. In many cases this is not desirable. Proposed patch solves this issue by creating checkbox for "-dstalpha" option, so users can enable or disable it when necessary
