### PR TITLE
GdalTools clipper, crop to mask layer extent

### DIFF
--- a/python/plugins/GdalTools/tools/doClipper.py
+++ b/python/plugins/GdalTools/tools/doClipper.py
@@ -139,6 +139,8 @@ class GdalToolsDialog(QWidget, Ui_Widget, BasePluginWidget):
           arguments << "-q"
           arguments << "-cutline"
           arguments << mask
+          if Utils.GdalConfig.version() >= "1.8.0":
+            arguments << "-crop_to_cutline"
           if self.alphaBandCheck.isChecked():
             arguments << "-dstalpha"
 


### PR DESCRIPTION
This patch improves GdalTools clipper to crop to mask layer extent (gdal >= 1.8)
