### PR TITLE
Ability to set id of any composer item moved from just qgscomposerlabel t

### DIFF
--- a/python/core/qgscomposeritem.sip
+++ b/python/core/qgscomposeritem.sip
@@ -147,7 +147,7 @@ class QgsComposerItem: QObject, QGraphicsRectItem
 
     /** \brief Set selected, selected item should be highlighted */
     virtual void setSelected( bool s );
-
+sipCppRet
     /** \brief Is selected */
     virtual bool selected();
 
@@ -255,6 +255,16 @@ class QgsComposerItem: QObject, QGraphicsRectItem
 
     /**Updates item, with the possibility to do custom update for subclasses*/
     virtual void updateItem();
+
+    /**Get label identification name
+      @note this method was added in version 1.7*/
+    QString id() const;
+
+    /**Set label identification name
+      @note this method was added in version 1.7
+                      This method was moved from qgscomposerlabel so that every object can have a
+                       id (NathanW)*/
+    void setId( const QString& id );
 
   public slots:
     virtual void setRotation( double r);

--- a/python/core/qgscomposerlabel.sip
+++ b/python/core/qgscomposerlabel.sip
@@ -48,12 +48,4 @@ class QgsComposerLabel: QgsComposerItem
        * @param node is Dom node corresponding to 'ComposerLabel' tag
        */
     bool readXML( const QDomElement& itemElem, const QDomDocument& doc );
-
-    /**Get label identification number
-      @note this method was added in version 1.7*/
-    QString id() const;
-
-    /**Set label identification number
-      @note this method was added in version 1.7*/
-    void setId( const QString& id );
 };

--- a/src/app/composer/qgscomposeritemwidget.cpp
+++ b/src/app/composer/qgscomposeritemwidget.cpp
@@ -150,9 +150,11 @@ void QgsComposerItemWidget::setValuesForGuiElements()
   mOpacitySlider->blockSignals( true );
   mOutlineWidthSpinBox->blockSignals( true );
   mFrameCheckBox->blockSignals( true );
+  mItemIdLineEdit->blockSignals( true );
 
   mOpacitySlider->setValue( mItem->brush().color().alpha() );
   mOutlineWidthSpinBox->setValue( mItem->pen().widthF() );
+  mItemIdLineEdit->setText( mItem->id() );
   if ( mItem->frame() )
   {
     mFrameCheckBox->setCheckState( Qt::Checked );
@@ -165,7 +167,7 @@ void QgsComposerItemWidget::setValuesForGuiElements()
   mOpacitySlider->blockSignals( false );
   mOutlineWidthSpinBox->blockSignals( false );
   mFrameCheckBox->blockSignals( false );
-
+  mItemIdLineEdit->blockSignals( false );
 }
 
 void QgsComposerItemWidget::on_mPositionButton_clicked()
@@ -185,4 +187,14 @@ void QgsComposerItemWidget::on_mPositionButton_clicked()
   {
     mItem->cancelCommand();
   }
+}
+
+void QgsComposerItemWidget::on_mItemIdLineEdit_textChanged(const QString &text)
+{
+    if ( mItem )
+    {
+      mItem->beginCommand( tr( "Item id changed" ), QgsComposerMergeCommand::ComposerLabelSetId );
+      mItem->setId( text );
+      mItem->endCommand();
+    }
 }

--- a/src/app/composer/qgscomposeritemwidget.h
+++ b/src/app/composer/qgscomposeritemwidget.h
@@ -38,6 +38,7 @@ class QgsComposerItemWidget: public QWidget, private Ui::QgsComposerItemWidgetBa
     void on_mOutlineWidthSpinBox_valueChanged( double d );
     void on_mFrameCheckBox_stateChanged( int state );
     void on_mPositionButton_clicked();
+    void on_mItemIdLineEdit_textChanged( const QString& text );
 
   private:
     QgsComposerItemWidget();

--- a/src/app/composer/qgscomposerlabelwidget.cpp
+++ b/src/app/composer/qgscomposerlabelwidget.cpp
@@ -183,7 +183,6 @@ void QgsComposerLabelWidget::setGuiElementValues()
   mLeftRadioButton->setChecked( mComposerLabel->hAlign() == Qt::AlignLeft );
   mCenterRadioButton->setChecked( mComposerLabel->hAlign() == Qt::AlignHCenter );
   mRightRadioButton->setChecked( mComposerLabel->hAlign() == Qt::AlignRight );
-  mLabelIdLineEdit->setText( mComposerLabel->id() );
   blockAllSignals( false );
 }
 
@@ -197,5 +196,5 @@ void QgsComposerLabelWidget::blockAllSignals( bool block )
   mLeftRadioButton->blockSignals( block );
   mCenterRadioButton->blockSignals( block );
   mRightRadioButton->blockSignals( block );
-  mLabelIdLineEdit->blockSignals( block );
+
 }

--- a/src/core/composer/qgscomposeritem.cpp
+++ b/src/core/composer/qgscomposeritem.cpp
@@ -141,7 +141,7 @@ bool QgsComposerItem::_writeXML( QDomElement& itemElem, QDomDocument& doc ) cons
   composerItemElem.setAttribute( "zValue", QString::number( zValue() ) );
   composerItemElem.setAttribute( "outlineWidth", QString::number( pen().widthF() ) );
   composerItemElem.setAttribute( "rotation", mRotation );
-
+  composerItemElem.setAttribute( "id", mId );
   //position lock for mouse moves/resizes
   if ( mItemPositionLocked )
   {
@@ -188,6 +188,9 @@ bool QgsComposerItem::_readXML( const QDomElement& itemElem, const QDomDocument&
 
   //rotation
   mRotation = itemElem.attribute( "rotation", "0" ).toDouble();
+
+  //id
+  mId = itemElem.attribute( "id", "" );
 
   //frame
   QString frame = itemElem.attribute( "frame" );

--- a/src/core/composer/qgscomposeritem.h
+++ b/src/core/composer/qgscomposeritem.h
@@ -158,8 +158,6 @@ class CORE_EXPORT QgsComposerItem: public QObject, public QGraphicsRectItem
     /**Reads parameter that are not subclass specific in document. Usually called from readXML methods of subclasses*/
     bool _readXML( const QDomElement& itemElem, const QDomDocument& doc );
 
-
-
     bool frame() const {return mFrame;}
     void setFrame( bool drawFrame ) {mFrame = drawFrame;}
 
@@ -219,6 +217,16 @@ class CORE_EXPORT QgsComposerItem: public QObject, public QGraphicsRectItem
 
     /**Updates item, with the possibility to do custom update for subclasses*/
     virtual void updateItem() { QGraphicsRectItem::update(); }
+
+    /**Get item identification name
+      @note this method was added in version 1.7*/
+    QString id() const { return mId; }
+
+    /**Set item identification name
+      @note this method was added in version 1.7
+                     This method was moved from qgscomposerlabel so that every object can have a
+                      id (NathanW)*/
+    void setId( const QString& id ) { mId = id; }
 
   public slots:
     virtual void setRotation( double r );
@@ -322,6 +330,9 @@ class CORE_EXPORT QgsComposerItem: public QObject, public QGraphicsRectItem
     void rotationChanged( double newRotation );
     /**Used e.g. by the item widgets to update the gui elements*/
     void itemChanged();
+private:
+    // Label id (unique within the same composition)
+    QString mId;
 };
 
 #endif

--- a/src/core/composer/qgscomposerlabel.cpp
+++ b/src/core/composer/qgscomposerlabel.cpp
@@ -129,8 +129,6 @@ bool QgsComposerLabel::writeXML( QDomElement& elem, QDomDocument & doc ) const
 
   composerLabelElem.setAttribute( "halign", mHAlignment );
   composerLabelElem.setAttribute( "valign", mVAlignment );
-  composerLabelElem.setAttribute( "id", mId );
-
 
   //font
   QDomElement labelFontElem = doc.createElement( "LabelFont" );
@@ -170,9 +168,6 @@ bool QgsComposerLabel::readXML( const QDomElement& itemElem, const QDomDocument&
 
   //Vertical alignment
   mVAlignment = ( Qt::AlignmentFlag )( itemElem.attribute( "valign" ).toInt() );
-
-  //id
-  mId = itemElem.attribute( "id", "" );
 
   //font
   QDomNodeList labelFontList = itemElem.elementsByTagName( "LabelFont" );

--- a/src/core/composer/qgscomposerlabel.h
+++ b/src/core/composer/qgscomposerlabel.h
@@ -72,14 +72,6 @@ class CORE_EXPORT QgsComposerLabel: public QgsComposerItem
        */
     bool readXML( const QDomElement& itemElem, const QDomDocument& doc );
 
-    /**Get label identification number
-      @note this method was added in version 1.7*/
-    QString id() const { return mId; }
-
-    /**Set label identification number
-      @note this method was added in version 1.7*/
-    void setId( const QString& id ) { mId = id; }
-
   private:
     // Text
     QString mText;
@@ -98,9 +90,6 @@ class CORE_EXPORT QgsComposerLabel: public QgsComposerItem
 
     // Vertical Alignment
     Qt::AlignmentFlag mVAlignment;
-
-    // Label id (unique within the same composition)
-    QString mId;
 
     /**Replaces replace '$CURRENT_DATE<(FORMAT)>' with the current date (e.g. $CURRENT_DATE(d 'June' yyyy)*/
     void replaceDateText( QString& text ) const;

--- a/src/ui/qgscomposeritemwidgetbase.ui
+++ b/src/ui/qgscomposeritemwidgetbase.ui
@@ -6,22 +6,22 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>236</width>
-    <height>314</height>
+    <width>233</width>
+    <height>361</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
+   <item row="0" column="0" colspan="2">
     <widget class="QPushButton" name="mFrameColorButton">
      <property name="text">
       <string>Frame color...</string>
      </property>
     </widget>
    </item>
-   <item row="1" column="0">
+   <item row="1" column="0" colspan="2">
     <widget class="QPushButton" name="mBackgroundColorButton">
      <property name="text">
       <string>Background color...</string>
@@ -41,7 +41,7 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
+   <item row="3" column="0" colspan="2">
     <widget class="QSlider" name="mOpacitySlider">
      <property name="maximum">
       <number>255</number>
@@ -51,7 +51,7 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="0">
+   <item row="4" column="0" colspan="2">
     <widget class="QLabel" name="mOutlineWidthLabel">
      <property name="text">
       <string>Outline width</string>
@@ -67,29 +67,39 @@
    <item row="5" column="0">
     <widget class="QDoubleSpinBox" name="mOutlineWidthSpinBox"/>
    </item>
-   <item row="6" column="0">
+   <item row="6" column="0" colspan="2">
     <widget class="QPushButton" name="mPositionButton">
      <property name="text">
       <string>Position and size...</string>
      </property>
     </widget>
    </item>
-   <item row="7" column="0">
+   <item row="8" column="0" colspan="2">
     <widget class="QCheckBox" name="mFrameCheckBox">
      <property name="text">
       <string>Show frame</string>
      </property>
     </widget>
    </item>
-   <item row="8" column="0">
+   <item row="10" column="0">
+    <widget class="QLabel" name="mIdLabel">
+     <property name="text">
+      <string>Item ID</string>
+     </property>
+    </widget>
+   </item>
+   <item row="11" column="0" colspan="2">
+    <widget class="QLineEdit" name="mItemIdLineEdit"/>
+   </item>
+   <item row="12" column="0" colspan="2">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
      </property>
      <property name="sizeHint" stdset="0">
       <size>
-       <width>215</width>
-       <height>57</height>
+       <width>143</width>
+       <height>87</height>
       </size>
      </property>
     </spacer>

--- a/src/ui/qgscomposerlabelwidgetbase.ui
+++ b/src/ui/qgscomposerlabelwidgetbase.ui
@@ -30,8 +30,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>513</width>
-        <height>402</height>
+        <width>529</width>
+        <height>376</height>
        </rect>
       </property>
       <attribute name="label">
@@ -139,16 +139,6 @@
            </widget>
           </item>
          </layout>
-        </widget>
-       </item>
-       <item row="9" column="0">
-        <widget class="QLineEdit" name="mLabelIdLineEdit"/>
-       </item>
-       <item row="8" column="0">
-        <widget class="QLabel" name="mIdLabel">
-         <property name="text">
-          <string>Label id</string>
-         </property>
         </widget>
        </item>
       </layout>


### PR DESCRIPTION
Ability to set id of any composer item moved from just qgscomposerlabel to qgscomposeritem
All items can now have a user set id.  Good for plugin automation eg mapbook builder

Ability to add a user defined ID to labels was added to support qgis-mapserver printing, adding the ID to the base class allows identification of any composer widget via plugins.  Something that EasyPrint might be able to use in the future.  
