### PR TITLE
Reduce top and side margins for attribute table dialog

### DIFF
--- a/src/ui/qgsattributetabledialog.ui
+++ b/src/ui/qgsattributetabledialog.ui
@@ -14,6 +14,9 @@
    <string>Attribute Table</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <property name="margin">
+    <number>0</number>
+   </property>
    <item row="0" column="0">
     <widget class="QgsAttributeTableView" name="mView">
      <property name="alternatingRowColors">
@@ -23,6 +26,12 @@
    </item>
    <item row="2" column="0">
     <layout class="QHBoxLayout">
+     <property name="leftMargin">
+      <number>3</number>
+     </property>
+     <property name="rightMargin">
+      <number>3</number>
+     </property>
      <item>
       <widget class="QCheckBox" name="cbxShowSelectedOnly">
        <property name="text">
@@ -93,6 +102,12 @@
    </item>
    <item row="1" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout">
+     <property name="leftMargin">
+      <number>3</number>
+     </property>
+     <property name="rightMargin">
+      <number>3</number>
+     </property>
      <item>
       <widget class="QToolButton" name="mRemoveSelectionButton">
        <property name="toolTip">


### PR DESCRIPTION
Do we really need a 9 pixel border around all the controls in the grid layout?  Table now fits all the way to the side and top of the dialog removing unneeded space.    
