### PR TITLE
Shortcuts dialog now remembers window state between uses

### DIFF
--- a/src/app/qgsconfigureshortcutsdialog.cpp
+++ b/src/app/qgsconfigureshortcutsdialog.cpp
@@ -43,7 +43,32 @@ QgsConfigureShortcutsDialog::QgsConfigureShortcutsDialog( QWidget* parent )
            this, SLOT( actionChanged( QTreeWidgetItem*, QTreeWidgetItem* ) ) );
 
   populateActions();
+
+  restoreState();
 }
+
+QgsConfigureShortcutsDialog::~QgsConfigureShortcutsDialog()
+{
+    saveState();
+}
+
+/*!
+ * Function to save dialog window state
+ */
+void QgsConfigureShortcutsDialog::saveState()
+{
+    QSettings settings;
+    settings.setValue( "/Windows/ShortcutsDialog/geometry", saveGeometry() );
+}
+
+/*!
+ * Function to restore dialog window state
+ */
+void QgsConfigureShortcutsDialog::restoreState()
+{
+    QSettings settings;
+    restoreGeometry( settings.value( "/Windows/ShortcutsDialog/geometry" ).toByteArray() );
+}       
 
 void QgsConfigureShortcutsDialog::populateActions()
 {

--- a/src/app/qgsconfigureshortcutsdialog.h
+++ b/src/app/qgsconfigureshortcutsdialog.h
@@ -26,7 +26,8 @@ class QgsConfigureShortcutsDialog : public QDialog, private Ui::QgsConfigureShor
 
   public:
     QgsConfigureShortcutsDialog( QWidget* parent = NULL );
-
+    ~QgsConfigureShortcutsDialog();
+    
     void populateActions();
 
   protected:
@@ -51,6 +52,18 @@ class QgsConfigureShortcutsDialog : public QDialog, private Ui::QgsConfigureShor
   protected:
     bool mGettingShortcut;
     int mModifiers, mKey;
+
+  private:
+    /*!
+     * Function to save dialog window state
+     */
+    void saveState();
+    
+    /*!
+     * Function to restore dialog window state
+     */
+    void restoreState();
+
 };
 
 #endif


### PR DESCRIPTION
I've been setting up my own keyboard shortcuts in QGIS and was frustrated by the fact that the Shortcuts Dialog kept forgetting how I had resized it. This patch addresses that issue. I used the same approach that the Project Properties dialog uses.
