### PR TITLE
Move setting of projection to after we have features for identify feature tool.

### DIFF
--- a/src/app/qgsmaptoolidentify.cpp
+++ b/src/app/qgsmaptoolidentify.cpp
@@ -211,12 +211,6 @@ bool QgsMapToolIdentify::identifyVectorLayer( QgsVectorLayer *layer, int x, int 
 
   int featureCount = 0;
 
-  // init distance/area calculator
-  QgsDistanceArea calc;
-  calc.setProjectionsEnabled( mCanvas->hasCrsTransformEnabled() ); // project?
-  calc.setEllipsoid( ellipsoid );
-  calc.setSourceCrs( layer->crs().srsid() );
-
   QgsFeatureList featureList;
 
   // toLayerCoordinates will throw an exception for an 'invalid' point.
@@ -247,6 +241,14 @@ bool QgsMapToolIdentify::identifyVectorLayer( QgsVectorLayer *layer, int x, int 
     QgsDebugMsg( QString( "Caught CRS exception %1" ).arg( cse.what() ) );
   }
 
+  // init distance/area calculator
+  QgsDistanceArea calc;
+  if ( !featureList.count() == 0 )
+  {
+      calc.setProjectionsEnabled( mCanvas->hasCrsTransformEnabled() ); // project?
+      calc.setEllipsoid( ellipsoid );
+      calc.setSourceCrs( layer->crs().srsid() );
+  }
   QgsFeatureList::iterator f_it = featureList.begin();
 
   for ( ; f_it != featureList.end(); ++f_it )


### PR DESCRIPTION
We were setting the projection for the identify tool regardless of if we have features or not, seemed to have performance hit on Windows.  Made using Top Down identity very slow.   

Calling

```
QgsDistanceArea calc;
calc.setProjectionsEnabled( mCanvas->hasCrsTransformEnabled() ); // project?
calc.setEllipsoid( ellipsoid );
calc.setSourceCrs( layer->crs().srsid() );
```

seems to have performance hits on Windows. Moved till after we have features to avoid unnecessary overhead. 
