### PR TITLE
Change properties of several symbols in one go

### DIFF
--- a/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.h
+++ b/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.h
@@ -120,6 +120,8 @@ class CORE_EXPORT QgsGraduatedSymbolRendererV2 : public QgsFeatureRendererV2
     //! @note added in 1.6
     QString sizeScaleField() const { return mSizeScaleField; }
 
+
+
   protected:
     QString mAttrName;
     QgsRangeList mRanges;

--- a/src/gui/symbology-ng/qgscategorizedsymbolrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgscategorizedsymbolrendererv2widget.cpp
@@ -144,12 +144,10 @@ void QgsCategorizedSymbolRendererV2Widget::changeCategorizedSymbol()
 
   selectedSymbols.append( mCategorizedSymbol );
   QgsSymbolV2SelectorDialog dlg( selectedSymbols, mStyle, mLayer, this );
-  if( !dlg.exec() )
-  {
-    return;
-  }
+  dlg.exec();
 
   updateCategorizedSymbolIcon();
+  populateCategories();
 }
 
 void QgsCategorizedSymbolRendererV2Widget::updateCategorizedSymbolIcon()

--- a/src/gui/symbology-ng/qgscategorizedsymbolrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgscategorizedsymbolrendererv2widget.cpp
@@ -54,6 +54,7 @@ QgsCategorizedSymbolRendererV2Widget::QgsCategorizedSymbolRendererV2Widget( QgsV
   labels << tr( "Symbol" ) << tr( "Value" ) << tr( "Label" );
   m->setHorizontalHeaderLabels( labels );
   viewCategories->setModel( m );
+  viewCategories->setSelectionMode( QAbstractItemView::MultiSelection );
 
   mCategorizedSymbol = QgsSymbolV2::defaultSymbol( mLayer->geometryType() );
 
@@ -122,9 +123,31 @@ QgsFeatureRendererV2* QgsCategorizedSymbolRendererV2Widget::renderer()
 
 void QgsCategorizedSymbolRendererV2Widget::changeCategorizedSymbol()
 {
-  QgsSymbolV2SelectorDialog dlg( mCategorizedSymbol, mStyle, mLayer, this );
-  if ( !dlg.exec() )
+  QItemSelectionModel* m = viewCategories->selectionModel();
+  QModelIndexList selectedIndexes = m->selectedRows( 1 );
+
+  QList<QgsSymbolV2*> selectedSymbols;
+
+  if( m && selectedIndexes.size() > 0 )
+  {
+    const QgsCategoryList& categories = mRenderer->categories();
+    QModelIndexList::const_iterator indexIt = selectedIndexes.constBegin();
+    for(; indexIt != selectedIndexes.constEnd(); ++indexIt )
+    {
+      QStandardItem* currentItem = qobject_cast<const QStandardItemModel*>(m->model())->itemFromIndex ( *indexIt );
+      if( currentItem || currentItem->row() == 1 )
+      {
+        selectedSymbols.append( categories[mRenderer->categoryIndexForValue( currentItem->data() )].symbol() );
+      }
+    }
+  }
+
+  selectedSymbols.append( mCategorizedSymbol );
+  QgsSymbolV2SelectorDialog dlg( selectedSymbols, mStyle, mLayer, this );
+  if( !dlg.exec() )
+  {
     return;
+  }
 
   updateCategorizedSymbolIcon();
 }

--- a/src/gui/symbology-ng/qgsgraduatedsymbolrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgsgraduatedsymbolrendererv2widget.cpp
@@ -223,12 +223,10 @@ void QgsGraduatedSymbolRendererV2Widget::changeGraduatedSymbol()
 
   selectedSymbols.append( mGraduatedSymbol );
   QgsSymbolV2SelectorDialog dlg( selectedSymbols, mStyle, mLayer, this );
-  if( !dlg.exec() )
-  {
-    return;
-  }
+  dlg.exec();
 
   updateGraduatedSymbolIcon();
+  populateRanges();
 }
 
 QgsSymbolV2* QgsGraduatedSymbolRendererV2Widget::findSymbolForRange( double lowerBound, double upperBound, const QgsRangeList& ranges ) const

--- a/src/gui/symbology-ng/qgsgraduatedsymbolrendererv2widget.h
+++ b/src/gui/symbology-ng/qgsgraduatedsymbolrendererv2widget.h
@@ -1,10 +1,9 @@
 #ifndef QGSGRADUATEDSYMBOLRENDERERV2WIDGET_H
 #define QGSGRADUATEDSYMBOLRENDERERV2WIDGET_H
 
+#include "qgsgraduatedsymbolrendererv2.h"
 #include "qgsrendererv2widget.h"
 #include <QStandardItem>
-
-class QgsGraduatedSymbolRendererV2;
 
 #include "ui_qgsgraduatedsymbolrendererv2widget.h"
 
@@ -53,7 +52,7 @@ class GUI_EXPORT QgsGraduatedSymbolRendererV2Widget : public QgsRendererV2Widget
     void changeRangeSymbol( int rangeIdx );
     void changeRange( int rangeIdx );
 
-
+    QgsSymbolV2* findSymbolForRange( double lowerBound, double upperBound, const QgsRangeList& ranges ) const;
 
 
   protected:

--- a/src/gui/symbology-ng/qgssymbolv2selectordialog.h
+++ b/src/gui/symbology-ng/qgssymbolv2selectordialog.h
@@ -18,6 +18,8 @@ class GUI_EXPORT QgsSymbolV2SelectorDialog : public QDialog, private Ui::QgsSymb
 
   public:
     QgsSymbolV2SelectorDialog( QgsSymbolV2* symbol, QgsStyleV2* style, const QgsVectorLayer* vl, QWidget* parent = NULL, bool embedded = false );
+    //constructor for multi symbol editing
+    QgsSymbolV2SelectorDialog( QList<QgsSymbolV2*> symbols, QgsStyleV2* style, const QgsVectorLayer* vl, QWidget* parent = NULL, bool embedded = false );
 
     //! return menu for "advanced" button - create it if doesn't exist and show the advanced button
     QMenu* advancedMenu();
@@ -32,6 +34,7 @@ class GUI_EXPORT QgsSymbolV2SelectorDialog : public QDialog, private Ui::QgsSymb
     void keyPressEvent( QKeyEvent * event );
 
   private:
+    void init( bool embedded );
     /**Displays alpha value as transparency in mTransparencyLabel*/
     void displayTransparency( double alpha );
 
@@ -53,7 +56,7 @@ class GUI_EXPORT QgsSymbolV2SelectorDialog : public QDialog, private Ui::QgsSymb
 
   protected:
     QgsStyleV2* mStyle;
-    QgsSymbolV2* mSymbol;
+    QList<QgsSymbolV2*> mSymbols;
     QMenu* mAdvancedMenu;
     const QgsVectorLayer* mVectorLayer;
 };


### PR DESCRIPTION
One thing that I often miss in the symbology-ng dialogs is the possibility to select multiple symbols at once and change properties like color, transparency, etc. for the whole selection.
The following patch changes the symbol selector dialog to work on several symbols at once. This is then used in the categorized and graduated renderer dialog.
Martin, could you review the changes?

Regards,
Marco
