### PR TITLE
Fix from 49e4e998c6 to ensure that all postgis connection parameters are 

### DIFF
--- a/src/providers/postgres/qgspostgresconnection.cpp
+++ b/src/providers/postgres/qgspostgresconnection.cpp
@@ -102,7 +102,7 @@ QgsPostgresConnection::QgsPostgresConnection( QString theConnName ) :
     uri.setConnection( host, port, database, username, password, ( QgsDataSourceURI::SSLmode ) sslmode );
   }
   uri.setUseEstimatedMetadata( useEstimatedMetadata );
-  mConnectionInfo = uri.connectionInfo();
+  mConnectionInfo = uri.uri();
 
   QgsDebugMsg( QString( "Connection info: '%1'." ).arg( mConnectionInfo ) );
 }


### PR DESCRIPTION
This patch ensures that all PostGIS connection parameters are copied in the QgsPostgresConnection constructor i.e estimatedmetadata.
