### PR TITLE
OGR provider: don't segfault when the layer cannot be retrieved (e.g. datasource with 0 layer)

### DIFF
--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -294,7 +294,14 @@ QgsOgrProvider::QgsOgrProvider( QString const & uri )
     }
 
     ogrLayer = ogrOrigLayer;
-    setSubsetString( mSubsetString );
+    if (ogrLayer != NULL )
+    {
+      setSubsetString( mSubsetString );
+    }
+    else
+    {
+      valid = false;
+    }
   }
   else
   {


### PR DESCRIPTION
This commit checks that the layer retrieved by OGR_DS_GetLayer() or OGR_DS_GetLayerByName() are not NULL. NULL can happen is wrong layer name or index is provided. Or in the case of an empty datasource
