### PR TITLE
Issue4550

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -343,7 +343,9 @@ static void customSrsValidation_( QgsCoordinateReferenceSystem* srs )
       mySelector->setSelectedCrsId( defaultCrs.srsid() );
     }
 
-    QApplication::setOverrideCursor( Qt::ArrowCursor );
+    // why is this: it overrides the default cursor in the splitter in the dialog
+    // commenting it now till somebody tells us why it is neccesary :-)
+    //QApplication::setOverrideCursor( Qt::ArrowCursor );
 
     if ( mySelector->exec() )
     {
@@ -352,7 +354,7 @@ static void customSrsValidation_( QgsCoordinateReferenceSystem* srs )
       srs->createFromOgcWmsCrs( mySelector->selectedAuthId() );
     }
 
-    QApplication::restoreOverrideCursor();
+    //QApplication::restoreOverrideCursor();
 
     delete mySelector;
   }

--- a/src/gui/qgsprojectionselector.cpp
+++ b/src/gui/qgsprojectionselector.cpp
@@ -861,9 +861,11 @@ void QgsProjectionSelector::on_cbxHideDeprecated_stateChanged()
 
 void QgsProjectionSelector::on_lstRecent_currentItemChanged( QTreeWidgetItem *current, QTreeWidgetItem *previous )
 {
-  Q_UNUSED( previous );
-  if ( current )
-    setSelectedCrsId( current->text( QGIS_CRS_ID_COLUMN ).toLong() );
+    // we receive a change event when we make dialog visible,
+    // on only when there is also a'previous' it is a real user induced event
+    if ( current && previous ) {
+        setSelectedCrsId( current->text( QGIS_CRS_ID_COLUMN ).toLong() );
+    }
 }
 
 

--- a/src/gui/qgsprojectionselector.cpp
+++ b/src/gui/qgsprojectionselector.cpp
@@ -108,7 +108,7 @@ QgsProjectionSelector::~QgsProjectionSelector()
     mRecentProjections.removeAll( QString::number( crsId ) );
     mRecentProjections.prepend( QString::number( crsId ) );
     // Prune size of list
-    while ( mRecentProjections.size() > 4 )
+    while ( mRecentProjections.size() > 8 )
     {
       mRecentProjections.removeLast();
     }

--- a/src/ui/qgsprojectionselectorbase.ui
+++ b/src/ui/qgsprojectionselectorbase.ui
@@ -191,12 +191,6 @@
    </item>
    <item row="3" column="0">
     <widget class="QTextEdit" name="teProjection">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
      <property name="minimumSize">
       <size>
        <width>0</width>
@@ -206,7 +200,7 @@
      <property name="maximumSize">
       <size>
        <width>16777215</width>
-       <height>50</height>
+       <height>90</height>
       </size>
      </property>
      <property name="baseSize">


### PR DESCRIPTION
this should fix the following little things in #4550 (projection widget):
- resizing of bottom proj4js area now possible (comment 5 and 8)
- 4 recent crs's is a  little low
- wrong crs get selected when widget shows (comment 10)
- cursor not changing when moving over Qsplitter between 2 crs-blocks (comment 7)
