### PR TITLE
better fix for #4550 change itemchanged event for simple clicked event

### DIFF
--- a/src/gui/qgsprojectionselector.cpp
+++ b/src/gui/qgsprojectionselector.cpp
@@ -859,16 +859,11 @@ void QgsProjectionSelector::on_cbxHideDeprecated_stateChanged()
     hideDeprecated( lstCoordinateSystems->topLevelItem( i ) );
 }
 
-void QgsProjectionSelector::on_lstRecent_currentItemChanged( QTreeWidgetItem *current, QTreeWidgetItem *previous )
+void QgsProjectionSelector::on_lstRecent_itemClicked(QTreeWidgetItem * item)
 {
-  // we receive a change event when we make dialog visible,
-  // on only when there is also a'previous' it is a real user induced event
-  if ( current && previous )
-  {
-    setSelectedCrsId( current->text( QGIS_CRS_ID_COLUMN ).toLong() );
-  }
+  setSelectedCrsId( item->text( QGIS_CRS_ID_COLUMN ).toLong() );
+  item->setSelected(true);
 }
-
 
 void QgsProjectionSelector::on_leSearch_textChanged( const QString & theFilterTxt )
 {

--- a/src/gui/qgsprojectionselector.h
+++ b/src/gui/qgsprojectionselector.h
@@ -113,7 +113,7 @@ class GUI_EXPORT QgsProjectionSelector: public QWidget, private Ui::QgsProjectio
      * \warning This function's behaviour is undefined if it is called after the widget is shown.
      */
     void setOgcWmsCrsFilter( QSet<QString> crsFilter );
-    void on_lstRecent_currentItemChanged( QTreeWidgetItem *, QTreeWidgetItem * );
+    void on_lstRecent_itemClicked(QTreeWidgetItem * );
     void on_cbxHideDeprecated_stateChanged();
     void on_leSearch_textChanged(const QString &);
 


### PR DESCRIPTION
just removed the itemchanged event into a click event

for the itemchangedevent it was not 100% clear when the previous item was null or not (sometimes the dialog came up with a 'previous' selection, and sometimes without, depending on different paths)

should close #4550
