### PR TITLE
Issue3243 taking crs into account with bookmarks

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -6725,7 +6725,8 @@ void QgisApp::newBookmark()
     {
       // create the bookmark
       QgsBookmarkItem *bmi = new QgsBookmarkItem( bookmarkName,
-          QgsProject::instance()->title(), mMapCanvas->extent(), -1,
+          QgsProject::instance()->title(), mMapCanvas->extent(),
+          mMapCanvas->mapRenderer()->destinationCrs().srsid(),
           QgsApplication::qgisUserDbFilePath() );
       bmi->store();
       delete bmi;

--- a/src/app/qgsbookmarks.cpp
+++ b/src/app/qgsbookmarks.cpp
@@ -58,7 +58,7 @@ QgsBookmarks::QgsBookmarks( QWidget *parent, Qt::WFlags fl )
   // Create the zoomto and delete buttons and add them to the
   // toolbar
   //
-  QPushButton * btnUpdate = new QPushButton( tr( "&Update" ) );
+  //QPushButton * btnUpdate = new QPushButton( tr( "&Update" ) );
   QPushButton * btnDelete = new QPushButton( tr( "&Delete" ) );
   QPushButton * btnZoomTo = new QPushButton( tr( "&Zoom to" ) );
   btnZoomTo->setDefault( true );
@@ -66,7 +66,7 @@ QgsBookmarks::QgsBookmarks( QWidget *parent, Qt::WFlags fl )
   buttonBox->addButton( btnDelete, QDialogButtonBox::ActionRole );
   buttonBox->addButton( btnZoomTo, QDialogButtonBox::ActionRole );
   // connect the slot up to catch when a bookmark is updated
-  connect( btnUpdate, SIGNAL( clicked() ), this, SLOT( on_btnUpdate_clicked() ) );
+  //connect( btnUpdate, SIGNAL( clicked() ), this, SLOT( on_btnUpdate_clicked() ) );
   // connect the slot up to catch when a bookmark is deleted
   connect( btnDelete, SIGNAL( clicked() ), this, SLOT( on_btnDelete_clicked() ) );
   // connect the slot up to catch when a bookmark is zoomed to
@@ -85,7 +85,6 @@ QgsBookmarks::~QgsBookmarks()
 
 void QgsBookmarks::refreshBookmarks()
 {
-  //lstBookmarks->clear();
   initialise();
 }
 // Initialise the bookmark tree from the database
@@ -94,15 +93,14 @@ void QgsBookmarks::initialise()
   this->connectDb();
   QSqlTableModel *model = new QSqlTableModel(0, db);
   model->setTable( "tbl_bookmarks" );
-  // this should work, but then the table is not editable anymore:
-  //    QSqlQuery::value: not positioned on a valid record
-  // seems a qt bug
-  //model->removeColumn(0);
-  //model->removeColumn(6);
   model->select();
   lstBookmarks->setModel( model );
+  // hide id column
   lstBookmarks->setColumnHidden(0, true);
+  // hide srid column
   lstBookmarks->setColumnHidden(7, true);
+
+  lstBookmarks->setEditTriggers(QAbstractItemView::EditKeyPressed);
 }
 
 void QgsBookmarks::restorePosition()
@@ -115,12 +113,6 @@ void QgsBookmarks::saveWindowLocation()
 {
   QSettings settings;
   settings.setValue( "/Windows/Bookmarks/geometry", saveGeometry() );
-}
-
-// REMOVE ?
-void QgsBookmarks::on_btnUpdate_clicked()
-{
-  // get the current item
 }
 
 void QgsBookmarks::on_btnDelete_clicked()
@@ -139,10 +131,25 @@ void QgsBookmarks::on_btnDelete_clicked()
   }
 }
 
+/*void QgsBookmarks::on_lstBookmarks_clicked(const QModelIndex & index)
+{
+  Q_UNUSED( index );
+  zoomToBookmark();
+}*/
+
+void QgsBookmarks::on_lstBookmarks_doubleClicked(const QModelIndex & index)
+{
+  Q_UNUSED( index );
+  zoomToBookmark();
+}
+
 void QgsBookmarks::on_btnZoomTo_clicked()
 {
-  //zoomToBookmark();
+  zoomToBookmark();
+}
 
+void QgsBookmarks::zoomToBookmark()
+{
     QModelIndex index = lstBookmarks->currentIndex();
     if ( index.isValid() )
     {
@@ -170,21 +177,6 @@ void QgsBookmarks::on_btnZoomTo_clicked()
         // redraw the map
         QgisApp::instance()->mapCanvas()->refresh();\
     }
-}
-
-// REMOVE?
-/*void QgsBookmarks::on_lstBookmarks_itemDoubleClicked( QTreeWidgetItem *lvi )
-{
-  Q_UNUSED( lvi );
-  zoomToBookmark();
-}*/
-
-// REMOVE?
-void QgsBookmarks::zoomToBookmark()
-{
-  // Need to fetch the extent for the selected bookmark and then redraw
-  // the map
-  // get the current item
 }
 
 int QgsBookmarks::connectDb()

--- a/src/app/qgsbookmarks.cpp
+++ b/src/app/qgsbookmarks.cpp
@@ -95,6 +95,13 @@ void QgsBookmarks::initialise()
   model->setTable( "tbl_bookmarks" );
   model->select();
   lstBookmarks->setModel( model );
+  // set better headers then column names from table
+  lstBookmarks->model()->setHeaderData(1, Qt::Horizontal, QObject::tr("Name"));
+  lstBookmarks->model()->setHeaderData(2, Qt::Horizontal, QObject::tr("Project"));
+  lstBookmarks->model()->setHeaderData(3, Qt::Horizontal, QObject::tr("xMin"));
+  lstBookmarks->model()->setHeaderData(4, Qt::Horizontal, QObject::tr("yMin"));
+  lstBookmarks->model()->setHeaderData(5, Qt::Horizontal, QObject::tr("xMax"));
+  lstBookmarks->model()->setHeaderData(6, Qt::Horizontal, QObject::tr("yMax"));
   // hide id column
   lstBookmarks->setColumnHidden(0, true);
   // hide srid column

--- a/src/app/qgsbookmarks.h
+++ b/src/app/qgsbookmarks.h
@@ -20,6 +20,7 @@
 #include <QDialog>
 #include <QSqlDatabase>
 #include <QSqlTableModel>
+#include <QTreeWidgetItem>
 #include "qgscontexthelp.h"
 
 class QString;
@@ -38,10 +39,10 @@ class QgsBookmarks : public QDialog, private Ui::QgsBookmarksBase
     void restorePosition();
   private slots:
     void saveWindowLocation();
-    void on_btnUpdate_clicked();
     void on_btnDelete_clicked();
     void on_btnZoomTo_clicked();
-    //void on_lstBookmarks_itemDoubleClicked( QTreeWidgetItem * );
+    //void on_lstBookmarks_clicked( const QModelIndex & );
+    void on_lstBookmarks_doubleClicked( const QModelIndex & );
     void refreshBookmarks();
     void on_buttonBox_helpRequested() { QgsContextHelp::run( metaObject()->className() ); }
 

--- a/src/app/qgsbookmarks.h
+++ b/src/app/qgsbookmarks.h
@@ -18,12 +18,16 @@
 #define QGSBOOKMARKS_H
 #include "ui_qgsbookmarksbase.h"
 #include <QDialog>
+#include <QSqlDatabase>
+#include <QSqlTableModel>
 #include "qgscontexthelp.h"
 
 class QString;
 class QWidget;
-class QTreeWidgetItem;
-struct sqlite3;
+
+const QString CRSDB = "CRSDB";
+
+
 class QgsBookmarks : public QDialog, private Ui::QgsBookmarksBase
 {
     Q_OBJECT
@@ -37,9 +41,8 @@ class QgsBookmarks : public QDialog, private Ui::QgsBookmarksBase
     void on_btnUpdate_clicked();
     void on_btnDelete_clicked();
     void on_btnZoomTo_clicked();
-    void on_lstBookmarks_itemDoubleClicked( QTreeWidgetItem * );
+    //void on_lstBookmarks_itemDoubleClicked( QTreeWidgetItem * );
     void refreshBookmarks();
-
     void on_buttonBox_helpRequested() { QgsContextHelp::run( metaObject()->className() ); }
 
   private:
@@ -47,7 +50,9 @@ class QgsBookmarks : public QDialog, private Ui::QgsBookmarksBase
     void initialise();
     int connectDb();
     void zoomToBookmark();
-    sqlite3 *db;
+    QSqlDatabase db;
 };
+
+
 #endif // QGSBOOKMARKS_H
 

--- a/src/ui/qgsbookmarksbase.ui
+++ b/src/ui/qgsbookmarksbase.ui
@@ -1,7 +1,8 @@
-<ui version="4.0" >
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
  <class>QgsBookmarksBase</class>
- <widget class="QDialog" name="QgsBookmarksBase" >
-  <property name="geometry" >
+ <widget class="QDialog" name="QgsBookmarksBase">
+  <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
@@ -9,53 +10,30 @@
     <height>370</height>
    </rect>
   </property>
-  <property name="windowTitle" >
+  <property name="windowTitle">
    <string>Geospatial Bookmarks</string>
   </property>
-  <layout class="QGridLayout" >
-   <item row="0" column="0" >
-    <widget class="QTreeWidget" name="lstBookmarks" >
-     <property name="rootIsDecorated" >
-      <bool>false</bool>
+  <layout class="QGridLayout">
+   <item row="1" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Close|QDialogButtonBox::Help</set>
      </property>
-     <property name="sortingEnabled" >
-      <bool>true</bool>
-     </property>
-     <property name="columnCount" >
-      <number>4</number>
-     </property>
-     <column>
-      <property name="text" >
-       <string>Name</string>
-      </property>
-     </column>
-     <column>
-      <property name="text" >
-       <string>Project</string>
-      </property>
-     </column>
-     <column>
-      <property name="text" >
-       <string>Extent</string>
-      </property>
-     </column>
-     <column>
-      <property name="text" >
-       <string>Id</string>
-      </property>
-     </column>
     </widget>
    </item>
-   <item row="1" column="0" >
-    <widget class="QDialogButtonBox" name="buttonBox" >
-     <property name="standardButtons" >
-      <set>QDialogButtonBox::Close|QDialogButtonBox::Help|QDialogButtonBox::NoButton</set>
+   <item row="0" column="0">
+    <widget class="QTreeView" name="lstBookmarks">
+     <property name="rootIsDecorated">
+      <bool>false</bool>
+     </property>
+     <property name="sortingEnabled">
+      <bool>true</bool>
      </property>
     </widget>
    </item>
   </layout>
  </widget>
- <layoutdefault spacing="6" margin="11" />
+ <layoutdefault spacing="6" margin="11"/>
  <tabstops>
   <tabstop>lstBookmarks</tabstop>
   <tabstop>buttonBox</tabstop>
@@ -68,11 +46,11 @@
    <receiver>QgsBookmarksBase</receiver>
    <slot>reject()</slot>
    <hints>
-    <hint type="sourcelabel" >
+    <hint type="sourcelabel">
      <x>211</x>
      <y>342</y>
     </hint>
-    <hint type="destinationlabel" >
+    <hint type="destinationlabel">
      <x>274</x>
      <y>256</y>
     </hint>


### PR DESCRIPTION
Issue 3243 is about taking crs into account with bookmarks.

So first: added valid crsid in database for every bookmark when making a bookmark
second take it into account when using 'zoomto bookmark'

In the ticket there is also the wish to be able to edit values.
When looking into that it seems easier to change the widget to a view with a QSqlTableModel model behind it,
AND using QSqlDatabase (for which I'm not sure if that is ok for QGIS)

Now you can use a bookmark (which has a crs in the db) in different projects
You can edit name, project, xyxy by clicking F2

Sorry, these are two changesets, I do not know how to merge these into one. If it is problematic I can try do this in a new branch and merge both changeset myself.
