### PR TITLE
Rulebased rendering gui tweaks

### DIFF
--- a/src/gui/symbology-ng/qgsrulebasedrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgsrulebasedrendererv2widget.cpp
@@ -203,13 +203,18 @@ void QgsRuleBasedRendererV2Widget::increasePriority()
   {
     if ( rule_index > 0 ) // do not increase priority of first rule
     {
+      // we need the string width of the index (which is a string) for finding it back
+      int indexWidth = item->data(4, Qt::EditRole).toString().length();
       mRenderer->swapRules( rule_index, rule_index - 1 );
       treeRules->populateRules();
-      // TODO: find out where the moved rule goes and reselect it (at least for non-grouped display)
-      // maybe based on the following functions :
-      //  findItems(QString(rule_index - 1), Qt::MatchExactly, 4).first.index)
-      //  setCurrentItem, setSelected, scrollToItem
+      QList<QTreeWidgetItem *> items = treeRules->findItems(
+            QString("%1").arg(rule_index, indexWidth), Qt::MatchExactly, 4 );
+      if (items.length()==1)
+      {
+        treeRules->setCurrentItem(items.first());
+      }
     }
+
   }
 
 }
@@ -228,8 +233,16 @@ void QgsRuleBasedRendererV2Widget::decreasePriority()
   {
     if ( rule_index + 1 < mRenderer->ruleCount() ) // do not increase priority of last rule
     {
+      // we need the string width of the index (which is a string) for finding it back
+      int indexWidth = item->data(4, Qt::EditRole).toString().length();
       mRenderer->swapRules( rule_index, rule_index + 1 );
       treeRules->populateRules();
+      QList<QTreeWidgetItem *> items = treeRules->findItems(
+            QString("%1").arg(rule_index+2, indexWidth), Qt::MatchExactly, 4 );
+      if (items.length()==1)
+      {
+        treeRules->setCurrentItem(items.first());
+      }
     }
   }
 }

--- a/src/gui/symbology-ng/qgsrulebasedrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgsrulebasedrendererv2widget.cpp
@@ -59,6 +59,7 @@ QgsRuleBasedRendererV2Widget::QgsRuleBasedRendererV2Widget( QgsVectorLayer* laye
   setupUi( this );
 
   treeRules->setRenderer( mRenderer );
+  treeRules->setSelectionMode(QAbstractItemView::SingleSelection);
   mRefineMenu = new QMenu( btnRefineRule );
   mRefineMenu->addAction( tr( "Add scales" ), this, SLOT( refineRuleScales() ) );
   mRefineMenu->addAction( tr( "Add categories" ), this, SLOT( refineRuleCategories() ) );

--- a/src/gui/symbology-ng/qgsrulebasedrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgsrulebasedrendererv2widget.cpp
@@ -216,7 +216,7 @@ void QgsRuleBasedRendererV2Widget::increasePriority()
     }
 
   }
-
+  treeRules->sortByColumn(4, Qt::AscendingOrder);  // busy with priority: more clear if we order by prio now
 }
 
 
@@ -245,6 +245,7 @@ void QgsRuleBasedRendererV2Widget::decreasePriority()
       }
     }
   }
+  treeRules->sortByColumn(4, Qt::AscendingOrder);  // busy with priority: more clear if we order by prio now
 }
 
 


### PR DESCRIPTION
When using increasing/decreasing buttons in rulebaserendering widget, the selection is lost for the increased/decreased item. Making it a pia to upgrade eg a rule wit prio 20 in rule with prio 1.

This fix:
- makes the increased/decreased item current selection again
- makes the rules single selection only (all actions on rules only work on one rule at a time)
- sorts rules on priority after increasing/decreasing (makes it more clear what is happening_

see also http://hub.qgis.org/issues/4480

after this pull I think 4480 can be closed
