### PR TITLE
Adds an extra Right click menu item in legend

### DIFF
--- a/src/app/legend/qgslegend.cpp
+++ b/src/app/legend/qgslegend.cpp
@@ -631,9 +631,17 @@ void QgsLegend::handleRightClickEvent( QTreeWidgetItem* item, const QPoint& posi
     {
       theMenu.addAction( tr( "Re&name" ), this, SLOT( openEditor() ) );
     }
+    //
+    // Option to group layers, if the selection is more than one
+    //
+    if( selectedLayers().length() > 1 )
+    {
+      theMenu.addAction( tr( "&Group selected" ), this, SLOT( groupSelectedLayers() ) );
+    }
+    // ends here
   }
 
-  theMenu.addAction( QgisApp::getThemeIcon( "/folder_new.png" ), tr( "&Add group" ), this, SLOT( addGroupToCurrentItem() ) );
+  theMenu.addAction( QgisApp::getThemeIcon( "/folder_new.png" ), tr( "&Add new group" ), this, SLOT( addGroupToCurrentItem() ) );
   theMenu.addAction( QgisApp::getThemeIcon( "/mActionExpandTree.png" ), tr( "&Expand all" ), this, SLOT( expandAll() ) );
   theMenu.addAction( QgisApp::getThemeIcon( "/mActionCollapseTree.png" ), tr( "&Collapse all" ), this, SLOT( collapseAll() ) );
 
@@ -2417,3 +2425,24 @@ void QgsLegend::toggleDrawingOrderUpdate()
 {
   setUpdateDrawingOrder( !mUpdateDrawingOrder );
 }
+
+void QgsLegend::groupSelectedLayers()
+{
+  //avoid multiple refreshes of map canvas because of itemChanged signal
+  blockSignals( true );
+
+  QgsLegendGroup *group;
+
+  group = new QgsLegendGroup( this, tr( "group" ) );
+
+  foreach( QTreeWidgetItem * item, selectedItems() )
+  {
+    insertItem( item, group );
+    continue;
+  }
+  editItem( group, 0 );
+
+  blockSignals( false );
+
+}
+

--- a/src/app/legend/qgslegend.cpp
+++ b/src/app/legend/qgslegend.cpp
@@ -2431,14 +2431,25 @@ void QgsLegend::groupSelectedLayers()
   //avoid multiple refreshes of map canvas because of itemChanged signal
   blockSignals( true );
 
+  QTreeWidgetItem * parent;
+  foreach( QTreeWidgetItem* item, selectedItems() )
+  {
+    parent = item->parent();
+  }
   QgsLegendGroup *group;
 
-  group = new QgsLegendGroup( this, tr( "group" ) );
+  if( parent )
+  {
+    group = new QgsLegendGroup( parent, tr( "sub-group" ) );
+  }
+  else
+  {
+    group = new QgsLegendGroup( this, tr( "group" ) );
+  }
 
   foreach( QTreeWidgetItem * item, selectedItems() )
   {
     insertItem( item, group );
-    continue;
   }
   editItem( group, 0 );
 

--- a/src/app/legend/qgslegend.cpp
+++ b/src/app/legend/qgslegend.cpp
@@ -2449,7 +2449,11 @@ void QgsLegend::groupSelectedLayers()
 
   foreach( QTreeWidgetItem * item, selectedItems() )
   {
-    insertItem( item, group );
+    QgsLegendLayer* layer = dynamic_cast<QgsLegendLayer *>( item );
+    if ( layer )
+    {
+      insertItem( item, group );
+    }
   }
   editItem( group, 0 );
 

--- a/src/app/legend/qgslegend.h
+++ b/src/app/legend/qgslegend.h
@@ -313,6 +313,10 @@ class QgsLegend : public QTreeWidget
     /** Update drawing order */
     void unsetUpdateDrawingOrder( bool dontUpdateDrawingOrder ) { setUpdateDrawingOrder( !dontUpdateDrawingOrder ); }
 
+    // Teco's work
+    /** Create a new group for the selected items **/
+    void groupSelectedLayers();
+
   protected:
 
     /*!Event handler for mouse movements.


### PR DESCRIPTION
An extra menu item is added called "Group Selected" in the legend. This menu item is shown when multiple layers are selected in the legend tree.
- When clicked, it creates a new group and puts all the selected layers into it.
- When all the selected items are inside the same group, a subgroup will be created for the selected layers.
- When layers from various groups and top level are selected, the **last selected** item's parent is used as the new group's parent. This is because there is _no_ logical way to determine, what the user actually intends to do.
- When groups themselves are selected along with the layers, again logically its difficult to determine what user intends and hence groups are generally skipped. So creating a group of groups is not possible.

**Use case:**
This improves usability when multiple layers are to be grouped. Instead of creating a new group and dragging the layers (sometimes one by one), a user can simply control-click the required layers and select "Group Selected"
