### PR TITLE
a crash fix and a tiny cleanup

### DIFF
--- a/src/app/qgsmaptooladdfeature.cpp
+++ b/src/app/qgsmaptooladdfeature.cpp
@@ -242,6 +242,11 @@ void QgsMapToolAddFeature::canvasReleaseEvent( QMouseEvent * e )
           return; //unknown wkbtype
         }
 
+        if ( !g )
+        {
+          stopCapturing();
+          return; // invalid geometry; one possibility is from duplicate points
+        }
         f->setGeometry( g );
 
         int avoidIntersectionsReturn = f->geometry()->avoidIntersections();

--- a/src/app/qgsmaptooladdfeature.cpp
+++ b/src/app/qgsmaptooladdfeature.cpp
@@ -226,7 +226,6 @@ void QgsMapToolAddFeature::canvasReleaseEvent( QMouseEvent * e )
       }
       else // polygon
       {
-        QgsGeometry *g;
         if ( layerWKBType == QGis::WKBPolygon ||  layerWKBType == QGis::WKBPolygon25D )
         {
           g = QgsGeometry::fromPolygon( QgsPolygon() << points().toVector() );


### PR DESCRIPTION
from the commit message:
QgsMapToolAddFeature::canvasReleaseEvent wasn't checking if geos returned
a sane geometry. One simple way of triggering the crash is to click twice
on the same point and then complete the op by rightclicking. Of course this
is not a real polygon, so things went haywire after that.
