### PR TITLE
GDALTools Build Virtual Raster - allow to use loaded layers as input files (instead of file selector)

### DIFF
--- a/python/plugins/GdalTools/tools/widgetBuildVRT.ui
+++ b/python/plugins/GdalTools/tools/widgetBuildVRT.ui
@@ -26,13 +26,20 @@
       <enum>QLayout::SetNoConstraint</enum>
      </property>
      <item row="0" column="0" colspan="2">
+      <widget class="QCheckBox" name="useSelectedLayersCheck">
+       <property name="text">
+        <string>Use selected layers for input</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0" colspan="2">
       <widget class="QCheckBox" name="inputDirCheck">
        <property name="text">
         <string>Choose input directory instead of files</string>
        </property>
       </widget>
      </item>
-     <item row="1" column="0">
+     <item row="2" column="0">
       <widget class="QLabel" name="label">
        <property name="text">
         <string>&amp;Input files</string>
@@ -42,14 +49,14 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="1">
+     <item row="3" column="1">
       <widget class="QCheckBox" name="recurseCheck">
        <property name="text">
         <string>Recurse subdirectories</string>
        </property>
       </widget>
      </item>
-     <item row="3" column="0">
+     <item row="4" column="0">
       <widget class="QLabel" name="label_2">
        <property name="text">
         <string>&amp;Output file</string>
@@ -59,14 +66,14 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="0">
+     <item row="5" column="0">
       <widget class="QCheckBox" name="resolutionCheck">
        <property name="text">
         <string>&amp;Resolution</string>
        </property>
       </widget>
      </item>
-     <item row="4" column="1">
+     <item row="5" column="1">
       <widget class="QComboBox" name="resolutionComboBox">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -94,14 +101,14 @@
        </item>
       </widget>
      </item>
-     <item row="5" column="0">
+     <item row="6" column="0">
       <widget class="QCheckBox" name="srcNoDataCheck">
        <property name="text">
         <string>&amp;Source No Data</string>
        </property>
       </widget>
      </item>
-     <item row="5" column="1">
+     <item row="6" column="1">
       <widget class="QSpinBox" name="srcNoDataSpin">
        <property name="minimum">
         <number>-100000</number>
@@ -111,20 +118,20 @@
        </property>
       </widget>
      </item>
-     <item row="6" column="0">
+     <item row="7" column="0">
       <widget class="QCheckBox" name="separateCheck">
        <property name="text">
         <string>Se&amp;parate</string>
        </property>
       </widget>
      </item>
-     <item row="1" column="1">
+     <item row="2" column="1">
       <widget class="GdalToolsInOutSelector" name="inSelector" native="true"/>
      </item>
-     <item row="3" column="1">
+     <item row="4" column="1">
       <widget class="GdalToolsInOutSelector" name="outSelector" native="true"/>
      </item>
-     <item row="7" column="0" colspan="2">
+     <item row="8" column="0" colspan="2">
       <widget class="QCheckBox" name="allowProjDiffCheck">
        <property name="text">
         <string>Allow projection difference</string>


### PR DESCRIPTION
I have enhanced the GDAL Tools VRT dialog to optionally use the active layers as input, instead of manually adding the files.

This is more convenient and also allows to use rasters within subdatasets (e.g. HDF files). I have created this to add (and extend) the functionality of the deprecated RGB composition plugin.

see thread "plugin bug and patch - RGB composition plugin broken in 1.7.4 and master" on the mailing list.

Thanks, Etienne
