### PR TITLE
fixes and enhancements for GDALTools VRT, GDAL sublayer dialog and  browser dock

### DIFF
--- a/python/plugins/GdalTools/tools/widgetBuildVRT.ui
+++ b/python/plugins/GdalTools/tools/widgetBuildVRT.ui
@@ -26,13 +26,20 @@
       <enum>QLayout::SetNoConstraint</enum>
      </property>
      <item row="0" column="0" colspan="2">
+      <widget class="QCheckBox" name="useSelectedLayersCheck">
+       <property name="text">
+        <string>Use selected layers for input</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0" colspan="2">
       <widget class="QCheckBox" name="inputDirCheck">
        <property name="text">
         <string>Choose input directory instead of files</string>
        </property>
       </widget>
      </item>
-     <item row="1" column="0">
+     <item row="2" column="0">
       <widget class="QLabel" name="label">
        <property name="text">
         <string>&amp;Input files</string>
@@ -42,14 +49,14 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="1">
+     <item row="3" column="1">
       <widget class="QCheckBox" name="recurseCheck">
        <property name="text">
         <string>Recurse subdirectories</string>
        </property>
       </widget>
      </item>
-     <item row="3" column="0">
+     <item row="4" column="0">
       <widget class="QLabel" name="label_2">
        <property name="text">
         <string>&amp;Output file</string>
@@ -59,14 +66,14 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="0">
+     <item row="5" column="0">
       <widget class="QCheckBox" name="resolutionCheck">
        <property name="text">
         <string>&amp;Resolution</string>
        </property>
       </widget>
      </item>
-     <item row="4" column="1">
+     <item row="5" column="1">
       <widget class="QComboBox" name="resolutionComboBox">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -94,14 +101,14 @@
        </item>
       </widget>
      </item>
-     <item row="5" column="0">
+     <item row="6" column="0">
       <widget class="QCheckBox" name="srcNoDataCheck">
        <property name="text">
         <string>&amp;Source No Data</string>
        </property>
       </widget>
      </item>
-     <item row="5" column="1">
+     <item row="6" column="1">
       <widget class="QSpinBox" name="srcNoDataSpin">
        <property name="minimum">
         <number>-100000</number>
@@ -111,20 +118,20 @@
        </property>
       </widget>
      </item>
-     <item row="6" column="0">
+     <item row="7" column="0">
       <widget class="QCheckBox" name="separateCheck">
        <property name="text">
         <string>Se&amp;parate</string>
        </property>
       </widget>
      </item>
-     <item row="1" column="1">
+     <item row="2" column="1">
       <widget class="GdalToolsInOutSelector" name="inSelector" native="true"/>
      </item>
-     <item row="3" column="1">
+     <item row="4" column="1">
       <widget class="GdalToolsInOutSelector" name="outSelector" native="true"/>
      </item>
-     <item row="7" column="0" colspan="2">
+     <item row="8" column="0" colspan="2">
       <widget class="QCheckBox" name="allowProjDiffCheck">
        <property name="text">
         <string>Allow projection difference</string>

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2261,14 +2261,22 @@ bool QgisApp::addVectorLayers( QStringList const & theLayerQStringList, const QS
   return true;
 } // QgisApp::addVectorLayer()
 
+// present a dialog to choose GDAL raster sublayers
 void QgisApp::askUserForGDALSublayers( QgsRasterLayer *layer )
 {
-  if ( !layer )
+  if ( !layer || layer->subLayers().size() < 1 )
     return;
 
   QStringList sublayers = layer->subLayers();
-
   QgsDebugMsg( "sublayers:\n  " + sublayers.join( "  \n" ) + "\n" );
+
+  // if promptLayers=Load all, load all sublayers without prompting  
+  QSettings settings;
+  if ( settings.value( "/qgis/promptForRasterSublayers", 1 ).toInt() == 3 )
+  {
+    loadGDALSublayers( layer->source(), sublayers );
+    return;
+  }
 
   // We initialize a selection dialog and display it.
   QgsOGRSublayersDialog chooseSublayersDialog( this );
@@ -2284,19 +2292,11 @@ void QgisApp::askUserForGDALSublayers( QgsRasterLayer *layer )
 
   if ( chooseSublayersDialog.exec() )
   {
-    foreach( QString path, chooseSublayersDialog.getSelection() )
-    {
-      QString name = path;
-      name.replace( layer->source(), QFileInfo( layer->source() ).completeBaseName() );
-      QgsRasterLayer *rlayer = new QgsRasterLayer( path, name );
-      if ( rlayer && rlayer->isValid() )
-      {
-        addRasterLayer( rlayer );
-      }
-    }
+    loadGDALSublayers( layer->source(), chooseSublayersDialog.getSelection() );
   }
 }
 
+// should the GDAL sublayers dialog should be presented to the user?
 bool QgisApp::shouldAskUserForGDALSublayers( QgsRasterLayer *layer )
 {
   // return false if layer is empty or raster has no sublayers
@@ -2305,13 +2305,35 @@ bool QgisApp::shouldAskUserForGDALSublayers( QgsRasterLayer *layer )
 
   QSettings settings;
   int promptLayers = settings.value( "/qgis/promptForRasterSublayers", 1 ).toInt();
-  // 0 = always -> always ask (if there are existing sublayers)
-  // 1 = if needed -> ask if layer has no bands, but has sublayers
-  // 2 = never
 
-  return promptLayers == 0 || ( promptLayers == 1 && layer->bandCount() == 0 );
+  // return true if promptLayers=Always or if promptLayers!=Never and there are no bands    
+  return promptLayers == 0 || ( promptLayers !=2 && layer->bandCount() == 0 );
 }
 
+// This method will load with GDAL the layers in parameter.
+// It is normally triggered by the sublayer selection dialog.
+void QgisApp::loadGDALSublayers( QString uri, QStringList list )
+{
+  QString path, name;
+  QgsRasterLayer *subLayer = NULL;
+
+  //add layers in reverse order so they appear in the right order in the layer dock
+  for( int i=list.size()-1; i >= 0 ; i-- )
+  {
+    path = list[i];
+    // shorten name by replacing complete path with filename
+    name = path;
+    name.replace( uri, QFileInfo( uri ).completeBaseName() );
+    subLayer = new QgsRasterLayer( path, name );
+    if ( subLayer ) 
+    {
+      if ( subLayer->isValid() )
+        addRasterLayer( subLayer );
+      else 
+        delete subLayer;
+    }
+  }
+}
 
 // This method is the method that does the real job. If the layer given in
 // parameter is NULL, then the method tries to act on the activeLayer.

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -422,6 +422,7 @@ class QgisApp : public QMainWindow, private Ui::MainWindow
     void editPaste( QgsMapLayer * destinationLayer = 0 );
 
     void loadOGRSublayers( QString layertype, QString uri, QStringList list );
+    void loadGDALSublayers( QString uri, QStringList list );
 
     /**Deletes the selected attributes for the currently selected vector layer*/
     void deleteSelected( QgsMapLayer *layer = 0, QWidget* parent = 0 );

--- a/src/app/qgsbrowserdockwidget.cpp
+++ b/src/app/qgsbrowserdockwidget.cpp
@@ -67,17 +67,36 @@ QgsBrowserDockWidget::QgsBrowserDockWidget( QWidget * parent ) :
   setWindowTitle( tr( "Browser" ) );
 
   mBrowserView = new QgsBrowserTreeView( this );
+ 
+  QToolButton* refreshButton = new QToolButton( this );
+  refreshButton->setIcon( QgisApp::instance()->getThemeIcon( "mActionDraw.png" ) );
+  // remove this to save space
+  refreshButton->setToolButtonStyle( Qt::ToolButtonTextBesideIcon);
+  refreshButton->setText( tr( "Refresh" ) );
+  refreshButton->setToolTip( tr( "Refresh" ) );
+  refreshButton->setAutoRaise( true );
+  connect( refreshButton, SIGNAL( clicked() ), this, SLOT( refresh() ) );
 
-  mRefreshButton = new QToolButton( this );
-  mRefreshButton->setIcon( QgisApp::instance()->getThemeIcon( "mActionDraw.png" ) );
-  mRefreshButton->setText( tr( "Refresh" ) );
-  mRefreshButton->setAutoRaise( true );
-  connect( mRefreshButton, SIGNAL( clicked() ), this, SLOT( refresh() ) );
+  QToolButton* addLayersButton = new QToolButton( this );
+  addLayersButton->setIcon( QgisApp::instance()->getThemeIcon( "mActionAddLayer.png" ) );
+  // remove this to save space
+  addLayersButton->setToolButtonStyle( Qt::ToolButtonTextBesideIcon);
+  addLayersButton->setText( tr( "Add Selection" ) );
+  addLayersButton->setToolTip( tr( "Add Selected Layers" ) );
+  addLayersButton->setAutoRaise( true );
+  connect( addLayersButton, SIGNAL( clicked() ), this, SLOT( addSelectedLayers() ) );
 
   QVBoxLayout* layout = new QVBoxLayout();
+  QHBoxLayout* hlayout = new QHBoxLayout();
   layout->setContentsMargins( 0, 0, 0, 0 );
   layout->setSpacing( 0 );
-  layout->addWidget( mRefreshButton );
+  hlayout->setContentsMargins( 0, 0, 0, 0 );
+  hlayout->setSpacing( 5 );
+  hlayout->setAlignment( Qt::AlignLeft );
+
+  hlayout->addWidget( refreshButton );
+  hlayout->addWidget( addLayersButton );
+  layout->addLayout( hlayout );
   layout->addWidget( mBrowserView );
 
   QWidget* innerWidget = new QWidget( this );
@@ -109,56 +128,14 @@ void QgsBrowserDockWidget::showEvent( QShowEvent * e )
 
 
 void QgsBrowserDockWidget::itemClicked( const QModelIndex& index )
-{
-  QgsDataItem *item = mModel->dataItem( index );
-  if ( !item )
-    return;
+{ 
+  QgsDataItem *dataItem = mModel->dataItem( index );
 
-  QgsLayerItem *layerItem = qobject_cast<QgsLayerItem*>( mModel->dataItem( index ) );
-  if ( layerItem == NULL )
-    return;
-
-  QString uri = layerItem->uri();
-  if ( uri.isEmpty() )
-    return;
-
-  QgsMapLayer::LayerType type = layerItem->mapLayerType();
-  QString providerKey = layerItem->providerKey();
-
-  QgsDebugMsg( providerKey + " : " + uri );
-  if ( type == QgsMapLayer::VectorLayer )
+  if ( dataItem != NULL && dataItem->type() == QgsDataItem::Layer )
   {
-    QgisApp::instance()->addVectorLayer( uri, layerItem->name(), providerKey );
-  }
-  if ( type == QgsMapLayer::RasterLayer )
-  {
-    // This should go to WMS provider
-    QStringList URIParts = uri.split( "|" );
-    QString rasterLayerPath = URIParts.at( 0 );
-    QStringList layers;
-    QStringList styles;
-    QString format;
-    QString crs;
-    for ( int i = 1 ; i < URIParts.size(); i++ )
-    {
-      QString part = URIParts.at( i );
-      int pos = part.indexOf( "=" );
-      QString field = part.left( pos );
-      QString value = part.mid( pos + 1 );
-
-      if ( field == "layers" )
-        layers = value.split( "," );
-      if ( field == "styles" )
-        styles = value.split( "," );
-      if ( field == "format" )
-        format = value;
-      if ( field == "crs" )
-        crs = value;
-    }
-    QgsDebugMsg( "rasterLayerPath = " + rasterLayerPath );
-    QgsDebugMsg( "layers = " + layers.join( " " ) );
-
-    QgisApp::instance()->addRasterLayer( rasterLayerPath, layerItem->name(), providerKey, layers, styles, format, crs );
+    QgsLayerItem *layerItem = qobject_cast<QgsLayerItem*>( dataItem );
+    if ( layerItem != NULL )
+      addLayer( layerItem );
   }
 }
 
@@ -187,6 +164,12 @@ void QgsBrowserDockWidget::showContextMenu( const QPoint & pt )
       // only favourites can be removed
       menu->addAction( tr( "Remove favourite" ), this, SLOT( removeFavourite() ) );
     }
+  }
+
+  else if ( item->type() == QgsDataItem::Layer )
+  {
+    menu->addAction( tr( "Add Layer" ), this, SLOT( itemClicked( idx ) ) );
+    menu->addAction( tr( "Add Selected Layers" ), this, SLOT( addSelectedLayers() ) );
   }
 
   QList<QAction*> actions = item->actions();
@@ -278,4 +261,77 @@ void QgsBrowserDockWidget::refreshModel( const QModelIndex& index )
       refreshModel( idx );
     }
   }
+}
+
+void QgsBrowserDockWidget::addLayer( QgsLayerItem *layerItem )
+{
+  if ( layerItem == NULL )
+    return;
+
+  QString uri = layerItem->uri();
+  if ( uri.isEmpty() )
+    return;
+
+  QgsMapLayer::LayerType type = layerItem->mapLayerType();
+  QString providerKey = layerItem->providerKey();
+
+  QgsDebugMsg( providerKey + " : " + uri );
+  if ( type == QgsMapLayer::VectorLayer )
+  {
+    QgisApp::instance()->addVectorLayer( uri, layerItem->name(), providerKey );
+  }
+  if ( type == QgsMapLayer::RasterLayer )
+  {
+    // This should go to WMS provider
+    QStringList URIParts = uri.split( "|" );
+    QString rasterLayerPath = URIParts.at( 0 );
+    QStringList layers;
+    QStringList styles;
+    QString format;
+    QString crs;
+    for ( int i = 1 ; i < URIParts.size(); i++ )
+    {
+      QString part = URIParts.at( i );
+      int pos = part.indexOf( "=" );
+      QString field = part.left( pos );
+      QString value = part.mid( pos + 1 );
+
+      if ( field == "layers" )
+        layers = value.split( "," );
+      if ( field == "styles" )
+        styles = value.split( "," );
+      if ( field == "format" )
+        format = value;
+      if ( field == "crs" )
+        crs = value;
+    }
+    QgsDebugMsg( "rasterLayerPath = " + rasterLayerPath );
+    QgsDebugMsg( "layers = " + layers.join( " " ) );
+
+    QgisApp::instance()->addRasterLayer( rasterLayerPath, layerItem->name(), providerKey, layers, styles, format, crs );
+  }
+}
+
+void QgsBrowserDockWidget::addSelectedLayers()
+{
+  QApplication::setOverrideCursor( Qt::WaitCursor );
+
+  // get a sorted list of selected indexes
+  QModelIndexList list = mBrowserView->selectionModel()->selectedIndexes();
+  qSort( list );
+
+  // add items in reverse order so they are in correct order in the layers dock
+  for ( int i=list.size()-1; i>=0; i-- )
+  {
+    QModelIndex index = list[i];
+    QgsDataItem *dataItem = mModel->dataItem( index );
+    if ( dataItem && dataItem->type() == QgsDataItem::Layer )
+    {
+      QgsLayerItem *layerItem = qobject_cast<QgsLayerItem*>( dataItem );
+      if ( layerItem ) 
+        addLayer( layerItem );
+    }
+  }
+
+  QApplication::restoreOverrideCursor();
 }

--- a/src/app/qgsbrowserdockwidget.h
+++ b/src/app/qgsbrowserdockwidget.h
@@ -6,7 +6,7 @@
 class QgsBrowserModel;
 class QModelIndex;
 class QTreeView;
-class QToolButton;
+class QgsLayerItem;
 
 class QgsBrowserDockWidget : public QDockWidget
 {
@@ -25,14 +25,17 @@ class QgsBrowserDockWidget : public QDockWidget
 
     void refresh();
 
+    void addSelectedLayers();
+
   protected:
 
     void refreshModel( const QModelIndex& index );
 
     void showEvent( QShowEvent * event );
 
+    void addLayer( QgsLayerItem *layerItem );
+
     QTreeView* mBrowserView;
-    QToolButton* mRefreshButton;
     QgsBrowserModel* mModel;
 };
 

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -185,10 +185,15 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WFlags fl ) :
   spinBoxAttrTableRowCache->setValue( settings.value( "/qgis/attributeTableRowCache", 10000 ).toInt() );
 
   // set the prompt for raster sublayers
+  // 0 = Always -> always ask (if there are existing sublayers)
+  // 1 = If needed -> ask if layer has no bands, but has sublayers
+  // 2 = Never -> never prompt, will not load anything
+  // 4 = Load all -> never prompt, but load all sublayers
   cmbPromptRasterSublayers->clear();
   cmbPromptRasterSublayers->addItem( tr( "Always" ) );
   cmbPromptRasterSublayers->addItem( tr( "If needed" ) ); //this means, prompt if there are sublayers but no band in the main dataset
   cmbPromptRasterSublayers->addItem( tr( "Never" ) );
+  cmbPromptRasterSublayers->addItem( tr( "Load all" ) );
   cmbPromptRasterSublayers->setCurrentIndex( settings.value( "/qgis/promptForRasterSublayers", 0 ).toInt() );
 
   // set the display update threshold

--- a/src/core/qgsdataitem.cpp
+++ b/src/core/qgsdataitem.cpp
@@ -194,7 +194,8 @@ bool QgsDataItem::hasChildren()
 
 void QgsDataItem::addChildItem( QgsDataItem * child, bool refresh )
 {
-  QgsDebugMsg( "mName = " + child->mName );
+  QgsDebugMsg( QString( "add child #%1 - %2" ).arg( mChildren.size() ).arg( child->mName) );
+
   int i;
   for ( i = 0; i < mChildren.size(); i++ )
   {

--- a/src/providers/gdal/qgsgdaldataitems.cpp
+++ b/src/providers/gdal/qgsgdaldataitems.cpp
@@ -79,6 +79,12 @@ QGISEXTERN QgsDataItem * dataItem( QString thePath, QgsDataItem* parentItem )
       QgsDebugMsg( "extensions: " + extensions.join( " " ) );
       QgsDebugMsg( "wildcards: " + wildcards.join( " " ) );
     }
+    // skip *.aux.xml files (GDAL auxilary metadata files) 
+    // unless that extension is in the list (*.xml might be though)
+    if ( thePath.right(8) == ".aux.xml" && 
+         extensions.indexOf( "aux.xml" ) < 0 )
+        return 0;
+
     if ( extensions.indexOf( info.suffix().toLower() ) < 0 )
     {
       bool matches = false;
@@ -107,7 +113,8 @@ QGISEXTERN QgsDataItem * dataItem( QString thePath, QgsDataItem* parentItem )
 
     QgsDebugMsg( "GdalDataset opened " + thePath );
 
-    QString name = info.completeBaseName();
+    //extract basename with extension
+    QString name = info.completeBaseName()+"."+QFileInfo( thePath ).suffix();
     QString uri = thePath;
 
     QgsLayerItem * item = new QgsGdalLayerItem( parentItem, name, thePath, uri );
@@ -124,11 +131,10 @@ QGISEXTERN QgsDataItem * dataItem( QString thePath, QgsDataItem* parentItem )
         if ( hChildDS )
         {
           GDALClose( hChildDS );
-          QgsDebugMsg( QString( "add child #%1 - %2" ).arg( i ).arg( sublayers[i] ) );
 
           QString name = sublayers[i];
-          name.replace( thePath, QFileInfo( thePath ).completeBaseName() );
-
+          //replace full path with basename+extension
+          name.replace( thePath, QFileInfo( thePath ).completeBaseName()+"."+QFileInfo( thePath ).suffix() );
           childItem = new QgsGdalLayerItem( item, name, thePath + "/" + name, sublayers[i] );
           if ( childItem )
             item->addChildItem( childItem );

--- a/src/providers/gdal/qgsgdalprovider.cpp
+++ b/src/providers/gdal/qgsgdalprovider.cpp
@@ -1267,7 +1267,10 @@ QStringList QgsGdalProvider::subLayers( GDALDatasetH dataset )
     }
   }
 
-  QgsDebugMsg( "sublayers:\n  " + subLayers.join( "\n  " ) );
+  if ( subLayers.size() > 0 )
+  {
+    QgsDebugMsg( "sublayers:\n  " + subLayers.join( "\n  " ) );
+  }
 
   return subLayers;
 }
@@ -1800,6 +1803,13 @@ void buildSupportedRasterFileFilterAndExtensions( QString & theFileFiltersString
         QString glob = "hdr.adf";
         theFileFiltersString += ";;[GDAL] " + myGdalDriverLongName + " (" + glob.toLower() + " " + glob.toUpper() + ")";
         theWildcards << "hdr.adf";
+      }
+      else if ( myGdalDriverDescription == "HDF4" )
+      {
+        // HDF4 extension missing in driver metadata
+        QString glob = "*.hdf";
+        theFileFiltersString += ";;[GDAL] " + myGdalDriverLongName + " (" + glob.toLower() + " " + glob.toUpper() + ")";
+        theExtensions << "hdf";
       }
       else
       {


### PR DESCRIPTION
1) 3c1eb0ac 

GDALTools Build Virtual Raster - allow to use loaded layers as input files (instead of file selector)
I have enhanced the GDAL Tools VRT dialog to optionally use the active layers as input, instead of manually adding the files.

This is more convenient and also allows to use rasters within subdatasets (e.g. HDF files). I have created this to add (and extend) the functionality of the deprecated RGB composition plugin.

see thread "plugin bug and patch - RGB composition plugin broken in 1.7.4 and master" on the mailing list.

2) c73e04eb

askUserForGDALSublayers dialog: 
- fix order that items are added in the layers panel
- add option to load all sublayers from a raster with subdatasets

Jürgen graciously applied my patches for bug #5041 that are related to this.

3) aedb7dea 

fixes for browser panel:
- skip *.aux.xml files (PAM auxiliary files) to avoid unnecessary warnings from GDAL

( ERROR 4: `/data/research/work/modis/mod13/MOD13Q1.A2009353.h13v10.005.2010009131529.250m 16 days relative azimuth angle.tif.aux.xml' not recognised as a supported file format. )
- show HDF4 files: add HDF4 file suffix (.hdf) in buildSupportedRasterFileFilterAndExtensions()

4) 7d61147b

Add selected layers via context menu and tool button. This is handy when you want to load many layers.

I have added a button with the text "Add Selection" (maybe the text is not necessary) and 2 context menu items ("Add Layer" and "Add Selected Layers")

Thanks, Etienne
