### PR TITLE
Improve "Actions" section in vector layer properties context help

### DIFF
--- a/resources/context_help/QgsVectorLayerProperties-en_US
+++ b/resources/context_help/QgsVectorLayerProperties-en_US
@@ -104,11 +104,31 @@ The <label>Metadata</label> tab contains information about the layer, including 
 <h4>Actions</h4>
 </a>
 QGIS provides the ability to perform an action based on the attributes of a feature. This can be used to perform any number of actions, for example, running a program with arguments built from the attributes of a feature or passing parameters to a web reporting tool. <br/>
-Actions are useful when you frequently want to run an external application or view a web page based on one or more values in your vector layer. An example is performing a search based on an attribute value.<p>
+Actions are useful when you frequently want to run an external application or view a web page based on one or more values in your vector layer.<p>
+
+The new implementation of actions uses the QGis expression engine to do evaluations. Each expression is evaluated and replaced by its result at runtime.<p>
+An expression must be enclosed between <code>[%</code> and <code>%]</code>, anyway the GUI has some buttons which do that for you.  
+The <label>Insert expression...</label> button launches the <label>Expression builder</label> which allows to write an expression in a easy way, the <label>Insert field</label> button inserts into the action a placeholder like <code>[% "fieldname" %]</code> where fieldname is the name of the field selected in the dropdown list close to the button.<p>
+
 See the User Guide for further information.
 
 <h5>Using Actions</h5>
-Actions can be invoked from the <label>Identify Results</label> dialog.
+Actions can be invoked from the <label>Identify Results</label> dialog or using the <label>Run feature action</label> tool.<p>
+
+Each of them adds a little set of custom expressions to the default set available in the <label>Expression builder</label>.<br/>
+While running actions from the <label>Identify Results</label> dialog the custom expression <code>$currfield</code> will be replaced with the value of the selected field in the dialog, using the <label>Run feature action</label> tool the following custom expression are instead available:
+<ul>
+<li><code>$clickx</code> returns the x coordinate of the clicked point in canvas</li>
+<li><code>$clicky</code> returns the y coordinate of the clicked point in canvas</li>
+<li><code>$layerid</code> returns the ID of the selected layer in the legend</li>
+</ul>
+
+Note: the <label>Run feature action</label> tool execute the actions on all the matching features, the <label>Identify Results</label> allows you to select which feature to run action on.<p>
+
+
+<h5>Action Examples</h5>
+You can add some example actions by clicking on the <label>Add default actions</label> button.
+
 
 <a name="diagram">
 <h4>Diagram Overlay</h4>


### PR DESCRIPTION
The same of the previous pull request (102), but I removed the action examples from the context help since now examples can be added to the action list by clicking on the "Add default actions" button.

Before being applied, it needs a review by a well-spoken English guy.
