### PR TITLE
Ftools vector grid improvements

### DIFF
--- a/python/plugins/fTools/tools/doVectorGrid.py
+++ b/python/plugins/fTools/tools/doVectorGrid.py
@@ -33,6 +33,7 @@ from PyQt4.QtGui import *
 import ftools_utils
 from qgis.core import *
 from ui_frmVectorGrid import Ui_Dialog
+import math
 
 class Dialog(QDialog, Ui_Dialog):
     def __init__(self, iface):
@@ -44,6 +45,7 @@ class Dialog(QDialog, Ui_Dialog):
         #QObject.connect(self.inShape, SIGNAL("currentIndexChanged(QString)"), self.updateInput)
         QObject.connect(self.btnUpdate, SIGNAL("clicked()"), self.updateLayer)
         QObject.connect(self.btnCanvas, SIGNAL("clicked()"), self.updateCanvas)
+        QObject.connect(self.chkAlign, SIGNAL("toggled(bool)"), self.chkAlignToggled)
         self.buttonOk = self.buttonBox_2.button( QDialogButtonBox.Ok )
         self.setWindowTitle(self.tr("Vector grid"))
         self.xMin.setValidator(QDoubleValidator(self.xMin))
@@ -66,12 +68,50 @@ class Dialog(QDialog, Ui_Dialog):
         mLayerName = self.inShape.currentText()
         if not mLayerName == "":
             mLayer = ftools_utils.getMapLayerByName( unicode( mLayerName ) )
+            # get layer extents
             boundBox = mLayer.extent()
+            # if "align extents and resolution..." button is checked
+            if self.chkAlign.isChecked():
+                if not mLayer.type() == QgsMapLayer.RasterLayer:
+                    QMessageBox.information(self, self.tr("Vector grid"), self.tr("Please select a raster layer"))
+                else:
+                    dx = math.fabs(boundBox.xMaximum()-boundBox.xMinimum()) / mLayer.width()
+                    dy = math.fabs(boundBox.yMaximum()-boundBox.yMinimum()) / mLayer.height()
+                    self.spnX.setValue(dx)
+                    self.spnY.setValue(dy)
             self.updateExtents( boundBox )
 
     def updateCanvas( self ):
         canvas = self.iface.mapCanvas()
         boundBox = canvas.extent()
+        # if "align extents and resolution..." button is checked
+        if self.chkAlign.isChecked():
+            mLayerName = self.inShape.currentText()
+            if not mLayerName == "":
+                mLayer = ftools_utils.getMapLayerByName( unicode( mLayerName ) )
+                if not mLayer.type() == QgsMapLayer.RasterLayer:
+                    QMessageBox.information(self, self.tr("Vector grid"), self.tr("Please select a raster layer"))
+                else:
+                    # get extents and pixel size
+                    xMin = boundBox.xMinimum()
+                    yMin = boundBox.yMinimum()
+                    xMax = boundBox.xMaximum()
+                    yMax = boundBox.yMaximum()
+                    boundBox2 = mLayer.extent()
+                    dx = math.fabs(boundBox2.xMaximum()-boundBox2.xMinimum()) / mLayer.width()
+                    dy = math.fabs(boundBox2.yMaximum()-boundBox2.yMinimum()) / mLayer.height()
+                    # get pixels from the raster that are closest to the desired extent
+                    newXMin = self.getClosestPixel( boundBox2.xMinimum(), boundBox.xMinimum(), dx, True )
+                    newXMax = self.getClosestPixel( boundBox2.xMaximum(), boundBox.xMaximum(), dx, False )
+                    newYMin = self.getClosestPixel( boundBox2.yMinimum(), boundBox.yMinimum(), dy, True )
+                    newYMax = self.getClosestPixel( boundBox2.yMaximum(), boundBox.yMaximum(), dy, False )
+                    # apply new values if found all min/max
+                    if newXMin is not None and newXMax is not None and newYMin is not None and newYMax is not None:
+                        boundBox.set( newXMin, newYMin, newXMax, newYMax )
+                        self.spnX.setValue(dx)
+                        self.spnY.setValue(dy)
+                    else:
+                        QMessageBox.information(self, self.tr("Vector grid"), self.tr("Unable to compute extents aligned on selected raster layer"))
         self.updateExtents( boundBox )
 
     def updateExtents( self, boundBox ):
@@ -185,3 +225,39 @@ class Dialog(QDialog, Ui_Dialog):
         if self.shapefileName is None or self.encoding is None:
             return
         self.outShape.setText( QString( self.shapefileName ) )
+
+    def chkAlignToggled(self):
+        if self.chkAlign.isChecked():
+            self.spnX.setEnabled( False )
+            self.lblX.setEnabled( False )
+            self.spnY.setEnabled( False )
+            self.lblY.setEnabled( False )
+        else:
+            self.spnX.setEnabled( True )
+            self.lblX.setEnabled( True )
+            self.spnY.setEnabled( not self.chkLock.isChecked() )
+            self.lblY.setEnabled( not self.chkLock.isChecked() )
+
+    def getClosestPixel(self, startVal, targetVal, step, isMin ):
+        foundVal = None
+        tmpVal = startVal
+        # find pixels covering the extent - slighlyt inneficient b/c loop on all elements before xMin
+        if targetVal < startVal:
+            backOneStep = not isMin
+            step = - step
+            while foundVal is None:
+                if tmpVal <= targetVal:
+                    if backOneStep:
+                        tmpVal -= step 
+                    foundVal = tmpVal
+                tmpVal += step
+        else:
+            backOneStep = isMin
+            while foundVal is None:
+                if tmpVal >= targetVal:
+                    if backOneStep:
+                        tmpVal -= step 
+                    foundVal = tmpVal
+                tmpVal += step
+        return foundVal           
+

--- a/python/plugins/fTools/tools/frmVectorGrid.ui
+++ b/python/plugins/fTools/tools/frmVectorGrid.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>438</width>
-    <height>459</height>
+    <width>489</width>
+    <height>475</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -29,7 +29,7 @@
       <item row="0" column="0" colspan="2">
        <widget class="QComboBox" name="inShape"/>
       </item>
-      <item row="1" column="0">
+      <item row="2" column="0">
        <widget class="QToolButton" name="btnUpdate">
         <property name="minimumSize">
          <size>
@@ -42,7 +42,7 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
+      <item row="2" column="1">
        <widget class="QToolButton" name="btnCanvas">
         <property name="minimumSize">
          <size>
@@ -55,7 +55,7 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="0">
+      <item row="3" column="0">
        <layout class="QHBoxLayout">
         <item>
          <widget class="QLabel" name="label">
@@ -82,7 +82,7 @@
         </item>
        </layout>
       </item>
-      <item row="2" column="1">
+      <item row="3" column="1">
        <layout class="QHBoxLayout">
         <item>
          <widget class="QLabel" name="label_4">
@@ -109,7 +109,7 @@
         </item>
        </layout>
       </item>
-      <item row="3" column="0">
+      <item row="4" column="0">
        <layout class="QHBoxLayout">
         <item>
          <widget class="QLabel" name="label_3">
@@ -136,7 +136,7 @@
         </item>
        </layout>
       </item>
-      <item row="3" column="1">
+      <item row="4" column="1">
        <layout class="QHBoxLayout">
         <item>
          <widget class="QLabel" name="label_5">
@@ -163,6 +163,13 @@
         </item>
        </layout>
       </item>
+      <item row="1" column="0" colspan="2">
+       <widget class="QCheckBox" name="chkAlign">
+        <property name="text">
+         <string>Align extents and resolution to selected raster layer</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
@@ -186,7 +193,7 @@
        </spacer>
       </item>
       <item row="0" column="1">
-       <widget class="QLabel" name="label_7">
+       <widget class="QLabel" name="lblX">
         <property name="text">
          <string>X</string>
         </property>
@@ -245,7 +252,7 @@
        </spacer>
       </item>
       <item row="1" column="1">
-       <widget class="QLabel" name="label_8">
+       <widget class="QLabel" name="lblY">
         <property name="enabled">
          <bool>false</bool>
         </property>
@@ -385,7 +392,7 @@
   </connection>
   <connection>
    <sender>chkLock</sender>
-   <signal>clicked(bool)</signal>
+   <signal>toggled(bool)</signal>
    <receiver>spnY</receiver>
    <slot>setDisabled(bool)</slot>
    <hints>
@@ -402,7 +409,7 @@
   <connection>
    <sender>chkLock</sender>
    <signal>toggled(bool)</signal>
-   <receiver>label_8</receiver>
+   <receiver>lblY</receiver>
    <slot>setDisabled(bool)</slot>
    <hints>
     <hint type="sourcelabel">

--- a/python/plugins/fTools/tools/frmVectorGrid.ui
+++ b/python/plugins/fTools/tools/frmVectorGrid.ui
@@ -286,7 +286,7 @@
          <string>Output grid as polygons</string>
         </property>
         <property name="checked">
-         <bool>true</bool>
+         <bool>false</bool>
         </property>
        </widget>
       </item>
@@ -294,6 +294,9 @@
        <widget class="QRadioButton" name="rdoLines">
         <property name="text">
          <string>Output grid as lines</string>
+        </property>
+        <property name="checked">
+         <bool>true</bool>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
7f71a7d3    ftools vector grid: Align extents and resolution to selected raster l…

Align extents and resolution to selected raster layer

This allows support for the grid to be aligned _exactly_ with the selected raster layer. The extents are shifted slightly so they coincide with that of the raster layer and the resolution of the raster are used also.

8966899d    ftools vector grid: UI improvements

1) Use the layer selected in the legend as the one intitially selected in the "grid extent" selector

2) Use the wait cursor as some operations can be long (esp. when using polygon output)

3) Update the progress bar at every 5%

4) Set "Output grid as lines" the default as it is much faster and light-weight than "Output grid as polygons" and better suited fo the default case
