### PR TITLE
Wrong scale is shown for first layer

### DIFF
--- a/src/app/legend/qgslegend.cpp
+++ b/src/app/legend/qgslegend.cpp
@@ -937,7 +937,10 @@ void QgsLegend::addLayers( QList<QgsMapLayer *> theLayerList )
   {
     QgsMapLayer * myFirstLayer = theLayerList.at( 0 );
     if ( !mMapCanvas->mapRenderer()->hasCrsTransformEnabled() )
+    {
       mMapCanvas->mapRenderer()->setDestinationCrs( myFirstLayer->crs() );
+      mMapCanvas->mapRenderer()->setMapUnits( myFirstLayer->crs().mapUnits() );
+    }
     mMapCanvas->zoomToFullExtent();
     mMapCanvas->clearExtentHistory();
   }


### PR DESCRIPTION
When a first layer (with known srs) is loaded, the mapcanvas srs is set but NOT the measureUnit

This means when you load a layer in a srs with meters, the scale is very wrong (because the default measureUnit is decimalDegrees)
