### PR TITLE
Copy / paste of styles

### DIFF
--- a/src/app/legend/qgslegend.cpp
+++ b/src/app/legend/qgslegend.cpp
@@ -42,6 +42,7 @@
 #include <QMouseEvent>
 #include <QPixmap>
 #include <QTreeWidgetItem>
+#include <QClipboard>
 
 const int AUTOSCROLL_MARGIN = 16;
 
@@ -695,6 +696,16 @@ void QgsLegend::handleRightClickEvent( QTreeWidgetItem* item, const QPoint& posi
       theMenu.addAction( tr( "&Group Selected" ), this, SLOT( groupSelectedLayers() ) );
     }
     // ends here
+  }
+
+  if ( selectedLayers().length() == 1 )
+  {
+    QgisApp* app = QgisApp::instance();
+    theMenu.addAction( tr( "Copy Style" ), app, SLOT( copyStyle() ) );
+    if ( QApplication::clipboard()->mimeData()->hasFormat( "application/qgis.style" ) )
+    {
+      theMenu.addAction( tr( "Paste Style" ), app, SLOT( pasteStyle() ) );
+    }
   }
 
   theMenu.addAction( QgisApp::getThemeIcon( "/folder_new.png" ), tr( "&Add New Group" ), this, SLOT( addGroupToCurrentItem() ) );

--- a/src/app/legend/qgslegend.cpp
+++ b/src/app/legend/qgslegend.cpp
@@ -33,6 +33,7 @@
 #include "qgsrasterlayer.h"
 #include "qgsvectorlayer.h"
 #include "qgsgenericprojectionselector.h"
+#include "qgsclipboard.h"
 
 #include <QFont>
 #include <QDomDocument>
@@ -702,7 +703,7 @@ void QgsLegend::handleRightClickEvent( QTreeWidgetItem* item, const QPoint& posi
   {
     QgisApp* app = QgisApp::instance();
     theMenu.addAction( tr( "Copy Style" ), app, SLOT( copyStyle() ) );
-    if ( QApplication::clipboard()->mimeData()->hasFormat( "application/qgis.style" ) )
+    if ( app->clipboard()->hasFormat( QGSCLIPBOARD_STYLE_MIME ) )
     {
       theMenu.addAction( tr( "Paste Style" ), app, SLOT( pasteStyle() ) );
     }

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -824,6 +824,8 @@ void QgisApp::createActions()
   connect( mActionCutFeatures, SIGNAL( triggered() ), this, SLOT( editCut() ) );
   connect( mActionCopyFeatures, SIGNAL( triggered() ), this, SLOT( editCopy() ) );
   connect( mActionPasteFeatures, SIGNAL( triggered() ), this, SLOT( editPaste() ) );
+  connect( mActionCopyStyle, SIGNAL( triggered() ), this, SLOT( copyStyle() ) );
+  connect( mActionPasteStyle, SIGNAL( triggered() ), this, SLOT( pasteStyle() ) );
   connect( mActionAddFeature, SIGNAL( triggered() ), this, SLOT( addFeature() ) );
   connect( mActionMoveFeature, SIGNAL( triggered() ), this, SLOT( moveFeature() ) );
   connect( mActionReshapeFeatures, SIGNAL( triggered() ), this, SLOT( reshapeFeatures() ) );
@@ -4294,7 +4296,6 @@ void QgisApp::editCut( QgsMapLayer * layerContainingSelection )
   }
 }
 
-
 void QgisApp::editCopy( QgsMapLayer * layerContainingSelection )
 {
   if ( mMapCanvas && mMapCanvas->isDrawing() )
@@ -4373,6 +4374,76 @@ void QgisApp::editPaste( QgsMapLayer *destinationLayer )
   }
 }
 
+void QgisApp::copyStyle( QgsMapLayer * sourceLayer )
+{
+  QgsMapLayer *selectionLayer = sourceLayer ? sourceLayer : activeLayer();
+  if ( selectionLayer )
+  {
+    QDomImplementation DomImplementation;
+    QDomDocumentType documentType =
+      DomImplementation.createDocumentType(
+					   "qgis", "http://mrcc.com/qgis.dtd", "SYSTEM" );
+    QDomDocument doc( documentType );
+    QDomElement rootNode = doc.createElement( "qgis" );
+    rootNode.setAttribute( "version", QString( "%1" ).arg( QGis::QGIS_VERSION ) );
+    doc.appendChild( rootNode );
+    QString errorMsg;
+    if ( !selectionLayer->writeSymbology( rootNode, doc, errorMsg ) )
+    {
+      QMessageBox::warning( this,
+			    tr( "Error" ),
+			    tr( "Cannot copy style: %1" )
+			    .arg( errorMsg ),
+			    QMessageBox::Ok );
+      return;
+    }
+    QClipboard* clipboard = QApplication::clipboard();
+    QMimeData *mimeData = new QMimeData();
+    mimeData->setData( "application/qgis.style", doc.toByteArray() );
+    // transfers the ownership to the clipboard object
+    clipboard->setMimeData( mimeData );
+  }
+}
+
+void QgisApp::pasteStyle( QgsMapLayer * destinationLayer )
+{
+  QgsMapLayer *selectionLayer = destinationLayer ? destinationLayer : activeLayer();
+  if ( selectionLayer )
+  {
+    QClipboard* clipboard = QApplication::clipboard();
+
+    const QMimeData* mimeData = clipboard->mimeData();
+    if ( mimeData->hasFormat( "application/qgis.style" ) )
+    {
+      QDomDocument doc( "qgis" );
+      QString errorMsg;
+      int errorLine, errorColumn;
+      if ( !doc.setContent ( mimeData->data( "application/qgis.style" ), false, &errorMsg, &errorLine, &errorColumn ) )
+      {
+	QMessageBox::information( this,
+				  tr( "Error" ),
+				  tr( "Cannot parse style: %1:%2:%3" )
+				  .arg( errorMsg )
+				  .arg( errorLine )
+				  .arg( errorColumn ),
+				  QMessageBox::Ok );
+	return;
+      }
+      QDomElement rootNode = doc.firstChildElement( "qgis" );
+      if ( !selectionLayer->readSymbology( rootNode, errorMsg ) )
+      {
+	QMessageBox::information( this,
+				  tr( "Error" ),
+				  tr( "Cannot read style: %1" )
+				  .arg( errorMsg ),
+				  QMessageBox::Ok );
+	return;
+      }
+
+      mMapLegend->refreshLayerSymbology( selectionLayer->id(), false );
+    }
+  }
+}
 
 void QgisApp::pasteTransformations()
 {
@@ -6296,6 +6367,8 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer* layer )
     mActionCutFeatures->setEnabled( false );
     mActionCopyFeatures->setEnabled( false );
     mActionPasteFeatures->setEnabled( false );
+    mActionCopyStyle->setEnabled( false );
+    mActionPasteStyle->setEnabled( false );
 
     mActionUndo->setEnabled( false );
     mActionRedo->setEnabled( false );
@@ -6325,6 +6398,9 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer* layer )
   mActionLayerProperties->setEnabled( true );
   mActionAddToOverview->setEnabled( true );
   mActionZoomToLayer->setEnabled( true );
+
+  mActionCopyStyle->setEnabled( true );
+  mActionPasteStyle->setEnabled( QApplication::clipboard()->mimeData()->hasFormat( "application/qgis.style" ) );
 
   /***********Vector layers****************/
   if ( layer->type() == QgsMapLayer::VectorLayer )

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -4397,11 +4397,10 @@ void QgisApp::copyStyle( QgsMapLayer * sourceLayer )
 			    QMessageBox::Ok );
       return;
     }
-    QClipboard* clipboard = QApplication::clipboard();
-    QMimeData *mimeData = new QMimeData();
-    mimeData->setData( "application/qgis.style", doc.toByteArray() );
-    // transfers the ownership to the clipboard object
-    clipboard->setMimeData( mimeData );
+    // Copies data in text form as well, so the XML can be pasted into a text editor
+    clipboard()->setData( QGSCLIPBOARD_STYLE_MIME, doc.toByteArray(), doc.toString() );
+    // Enables the paste menu element
+    mActionPasteStyle->setEnabled( true );
   }
 }
 
@@ -4410,15 +4409,12 @@ void QgisApp::pasteStyle( QgsMapLayer * destinationLayer )
   QgsMapLayer *selectionLayer = destinationLayer ? destinationLayer : activeLayer();
   if ( selectionLayer )
   {
-    QClipboard* clipboard = QApplication::clipboard();
-
-    const QMimeData* mimeData = clipboard->mimeData();
-    if ( mimeData->hasFormat( "application/qgis.style" ) )
+    if ( clipboard()->hasFormat( QGSCLIPBOARD_STYLE_MIME ) )
     {
       QDomDocument doc( "qgis" );
       QString errorMsg;
       int errorLine, errorColumn;
-      if ( !doc.setContent ( mimeData->data( "application/qgis.style" ), false, &errorMsg, &errorLine, &errorColumn ) )
+      if ( !doc.setContent ( clipboard()->data( QGSCLIPBOARD_STYLE_MIME ), false, &errorMsg, &errorLine, &errorColumn ) )
       {
 	QMessageBox::information( this,
 				  tr( "Error" ),
@@ -6400,7 +6396,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer* layer )
   mActionZoomToLayer->setEnabled( true );
 
   mActionCopyStyle->setEnabled( true );
-  mActionPasteStyle->setEnabled( QApplication::clipboard()->mimeData()->hasFormat( "application/qgis.style" ) );
+  mActionPasteStyle->setEnabled( clipboard()->hasFormat( QGSCLIPBOARD_STYLE_MIME ) );
 
   /***********Vector layers****************/
   if ( layer->type() == QgsMapLayer::VectorLayer )

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -429,6 +429,17 @@ class QgisApp : public QMainWindow, private Ui::MainWindow
      */
     void editPaste( QgsMapLayer * destinationLayer = 0 );
 
+    /**
+       \param sourceLayer  The layer where the style will be taken from
+                                        (defaults to the active layer on the legend)
+     */
+    void copyStyle( QgsMapLayer * sourceLayer = 0 );
+    //! copies style on the clipboard to the active layer
+    /**
+       \param destinatioLayer  The layer that the clipboard will be pasted to
+                                (defaults to the active layer on the legend)
+     */
+    void pasteStyle( QgsMapLayer * destinationLayer = 0 );
     void loadOGRSublayers( QString layertype, QString uri, QStringList list );
     void loadGDALSublayers( QString uri, QStringList list );
 

--- a/src/app/qgsclipboard.h
+++ b/src/app/qgsclipboard.h
@@ -41,6 +41,11 @@
   TODO: Make it work
 */
 
+/*
+ * Constants used to describe copy-paste MIME types
+ */
+#define QGSCLIPBOARD_STYLE_MIME "application/qgis.style"
+
 class QgsClipboard
 {
   public:
@@ -98,6 +103,32 @@ class QgsClipboard
      */
     QgsCoordinateReferenceSystem crs();
 
+    /*
+     * Stores a MimeData together with a text into the system clipboard
+     */
+    void setData( const QString& mimeType, const QByteArray& data, const QString* text = 0 );
+    /*
+     * Stores a MimeData together with a text into the system clipboard
+     */
+    void setData( const QString& mimeType, const QByteArray& data, const QString& text );
+    /*
+     * Stores a MimeData into the system clipboard
+     */
+    void setData( const QString& mimeType, const QByteArray& data );
+    /*
+     * Stores a text into the system clipboard
+     */
+    void setText( const QString& text );
+    /*
+     * Proxy to QMimeData::hasFormat
+     * Tests whether the system clipboard contains data of a given MIME type
+     */
+    bool hasFormat( const QString& mimeType );
+    /*
+     * Retrieve data from the system clipboard.
+     * No copy is involved, since the return QByteArray is implicitly shared
+     */
+    QByteArray data( const QString& mimeType );
   private:
 
     /** QGIS-internal vector feature clipboard.

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -17,7 +17,7 @@
      <x>0</x>
      <y>0</y>
      <width>1052</width>
-     <height>21</height>
+     <height>25</height>
     </rect>
    </property>
    <widget class="QMenu" name="mEditMenu">
@@ -151,6 +151,9 @@
     <addaction name="mActionAddWmsLayer"/>
     <addaction name="mActionAddLayerSeparator"/>
     <addaction name="mActionAddWfsLayer"/>
+    <addaction name="separator"/>
+    <addaction name="mActionCopyStyle"/>
+    <addaction name="mActionPasteStyle"/>
     <addaction name="separator"/>
     <addaction name="mActionOpenTable"/>
     <addaction name="mActionSaveEdits"/>
@@ -1646,6 +1649,24 @@
    </property>
    <property name="text">
     <string>Offset Curve</string>
+   </property>
+  </action>
+  <action name="mActionCopyStyle">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionEditCopy.png</normaloff>:/images/themes/default/mActionEditCopy.png</iconset>
+   </property>
+   <property name="text">
+    <string>Copy style</string>
+   </property>
+  </action>
+  <action name="mActionPasteStyle">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionEditPaste.png</normaloff>:/images/themes/default/mActionEditPaste.png</iconset>
+   </property>
+   <property name="text">
+    <string>Paste style</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
Implementation of copy/paste of styles between layers.

Partially address ticket http://hub.qgis.org/issues/3691, since it works between two instances of QGIS.

The added code reuses and enhances the QgsClipboard class.
