### PR TITLE
optimization code for union tool (fix #5617) - final fix for shapefile format

### DIFF
--- a/python/plugins/fTools/tools/doGeoprocessing.py
+++ b/python/plugins/fTools/tools/doGeoprocessing.py
@@ -1145,24 +1145,22 @@ class geoprocessingThread( QThread ):
               if int_geom.wkbType() == 0:
                 # intersection produced different geometry types
                 temp_list = int_geom.asGeometryCollection()
-                int_geom = []
                 for i in temp_list:
                   if i.type() == geom.type():
-                    int_geom.append( QgsGeometry( i ) )
-                  if len(int_geom) > 1:
-                    for j in int_geom:
+                      int_geom = QgsGeometry( i )
                       try:
-                        outFeat.setGeometry( j )
+                        outFeat.setGeometry( int_geom )
                         outFeat.setAttributeMap( ftools_utils.combineVectorAttributes( atMapA, atMapB ) )
                         writer.addFeature( outFeat )
                       except Exception, err:
                         FEATURE_EXCEPT = False
-              try:
-                outFeat.setGeometry( int_geom )
-                outFeat.setAttributeMap( ftools_utils.combineVectorAttributes( atMapA, atMapB ) )
-                writer.addFeature( outFeat )
-              except Exception, err:
-                FEATURE_EXCEPT = False
+              else:
+                try:
+                  outFeat.setGeometry( int_geom )
+                  outFeat.setAttributeMap( ftools_utils.combineVectorAttributes( atMapA, atMapB ) )
+                  writer.addFeature( outFeat )
+                except Exception, err:
+                  FEATURE_EXCEPT = False
             else:
               # this only happends if the bounding box
               # intersects, but the geometry doesn't

--- a/python/plugins/fTools/tools/doGeoprocessing.py
+++ b/python/plugins/fTools/tools/doGeoprocessing.py
@@ -944,7 +944,7 @@ class geoprocessingThread( QThread ):
                 if geom.intersects( tmpGeom ):
                   atMapB = inFeatB.attributeMap()
                   int_geom = QgsGeometry( geom.intersection( tmpGeom ) )
-                  if int_geom.wkbType() == 7:
+                  if int_geom.wkbType() == 0:
                     int_com = geom.combine( tmpGeom )
                     int_sym = geom.symDifference( tmpGeom )
                     int_geom = QgsGeometry( int_com.difference( int_sym ) )
@@ -973,7 +973,7 @@ class geoprocessingThread( QThread ):
               if geom.intersects( tmpGeom ):
                 atMapB = inFeatB.attributeMap()
                 int_geom = QgsGeometry( geom.intersection( tmpGeom ) )
-                if int_geom.wkbType() == 7:
+                if int_geom.wkbType() == 0:
                   int_com = geom.combine( tmpGeom )
                   int_sym = geom.symDifference( tmpGeom )
                   int_geom = QgsGeometry( int_com.difference( int_sym ) )
@@ -1010,7 +1010,7 @@ class geoprocessingThread( QThread ):
                 if geom.intersects( tmpGeom ):
                   atMapB = inFeatB.attributeMap()
                   int_geom = QgsGeometry( geom.intersection( tmpGeom ) )
-                  if int_geom.wkbType() == 7:
+                  if int_geom.wkbType() == 0:
                     int_com = geom.combine( tmpGeom )
                     int_sym = geom.symDifference( tmpGeom )
                     int_geom = QgsGeometry( int_com.difference( int_sym ) )
@@ -1039,7 +1039,7 @@ class geoprocessingThread( QThread ):
               if geom.intersects( tmpGeom ):
                 atMapB = inFeatB.attributeMap()
                 int_geom = QgsGeometry( geom.intersection( tmpGeom ) )
-                if int_geom.wkbType() == 7:
+                if int_geom.wkbType() == 0:
                   int_com = geom.combine( tmpGeom )
                   int_sym = geom.symDifference( tmpGeom )
                   int_geom = QgsGeometry( int_com.difference( int_sym ) )
@@ -1145,9 +1145,18 @@ class geoprocessingThread( QThread ):
               if int_geom.wkbType() == 0:
                 # intersection produced different geomety types
                 temp_list = int_geom.asGeometryCollection()
+                int_geom = []
                 for i in temp_list:
                   if i.type() == geom.type():
-                      int_geom = QgsGeometry( i )
+                      int_geom.append( QgsGeometry( i ) )
+                  if len(int_geom) > 1:
+                    for j in int_geom:
+                      try:
+                        outFeat.setGeometry( j )
+                        outFeat.setAttributeMap( ftools_utils.combineVectorAttributes( atMapA, atMapB ) )
+                        writer.addFeature( outFeat )
+                      except Exception, err:
+                        FEATURE_EXCEPT = False
               try:
                 outFeat.setGeometry( int_geom )
                 outFeat.setAttributeMap( ftools_utils.combineVectorAttributes( atMapA, atMapB ) )
@@ -1390,7 +1399,7 @@ class geoprocessingThread( QThread ):
             try:
               cur_geom = QgsGeometry( outFeat.geometry() )
               new_geom = QgsGeometry( geom.intersection( cur_geom ) )
-              if new_geom.wkbType() == 7:
+              if new_geom.wkbType() == 0:
                 int_com = QgsGeometry( geom.combine( cur_geom ) )
                 int_sym = QgsGeometry( geom.symDifference( cur_geom ) )
                 new_geom = QgsGeometry( int_com.difference( int_sym ) )
@@ -1434,7 +1443,7 @@ class geoprocessingThread( QThread ):
             try:
               cur_geom = QgsGeometry( outFeat.geometry() )
               new_geom = QgsGeometry( geom.intersection( cur_geom ) )
-              if new_geom.wkbType() == 7:
+              if new_geom.wkbType() == 0:
                 int_com = QgsGeometry( geom.combine( cur_geom ) )
                 int_sym = QgsGeometry( geom.symDifference( cur_geom ) )
                 new_geom = QgsGeometry( int_com.difference( int_sym ) )
@@ -1485,7 +1494,7 @@ class geoprocessingThread( QThread ):
             try:
               cur_geom = QgsGeometry( outFeat.geometry() )
               new_geom = QgsGeometry( geom.intersection( cur_geom ) )
-              if new_geom.wkbType() == 7:
+              if new_geom.wkbType() == 0:
                 int_com = QgsGeometry( geom.combine( cur_geom ) )
                 int_sym = QgsGeometry( geom.symDifference( cur_geom ) )
                 new_geom = QgsGeometry( int_com.difference( int_sym ) )
@@ -1530,7 +1539,7 @@ class geoprocessingThread( QThread ):
               try:
                 cur_geom = QgsGeometry( outFeat.geometry() )
                 new_geom = QgsGeometry( geom.intersection( cur_geom ) )
-                if new_geom.wkbType() == 7:
+                if new_geom.wkbType() == 0:
                   int_com = QgsGeometry( geom.combine( cur_geom ) )
                   int_sym = QgsGeometry( geom.symDifference( cur_geom ) )
                   new_geom = QgsGeometry( int_com.difference( int_sym ) )


### PR DESCRIPTION
Minor changes in Union tool. Now doesn't throw exception error!
Moreover, before the geometries in output file were duplicated, now no longer the case!
