### PR TITLE
skip vrt-in-zip test for gdal<1.7

### DIFF
--- a/tests/src/core/testziplayer.cpp
+++ b/tests/src/core/testziplayer.cpp
@@ -406,6 +406,9 @@ void TestZipLayer::testZipItemSubfolder()
 
 void TestZipLayer::testZipItemVRT()
 {
+#if GDAL_VERSION_NUM < 1700
+  QSKIP( "This test requires GDAL > 1.7", SkipSingle );
+#endif
   QSettings settings;
   for ( int i = 2 ; i <= mMaxScanZipSetting ; i++ )
   {


### PR DESCRIPTION
fixes test failure in autobuilds running gdal 1.6.3
