### PR TITLE
Fixes for issues #5753 and #5754

### DIFF
--- a/python/plugins/GdalTools/GdalTools.py
+++ b/python/plugins/GdalTools/GdalTools.py
@@ -264,11 +264,6 @@ class GdalTools:
     QObject.connect( self.settings, SIGNAL( "triggered()" ), self.doSettings )
     self.menu.addAction( self.settings )
 
-    menu_bar = self.iface.mainWindow().menuBar()
-    actions = menu_bar.actions()
-    lastAction = actions[ len( actions ) - 1 ]
-    menu_bar.insertMenu( lastAction, self.menu )
-
   def unload( self ):
     if not valid: return
     pass

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1169,7 +1169,7 @@ void QgisApp::createMenus()
 
   // Window Menu
 
-  mWindowMenu = menuBar()->addMenu( tr( "&Window" ) );
+  mWindowMenu = new QMenu( tr( "Window" ), this );
 
   mWindowMenu->addAction( mActionWindowMinimize );
   mWindowMenu->addAction( mActionWindowZoom );
@@ -1177,6 +1177,9 @@ void QgisApp::createMenus()
 
   mWindowMenu->addAction( mActionWindowAllToFront );
   mWindowMenu->addSeparator();
+
+  // insert before Help menu, as per Mac OS convention
+  menuBar()->insertMenu( mHelpMenu->menuAction(), mWindowMenu );
 #endif
 
   // Database Menu
@@ -5793,7 +5796,7 @@ void QgisApp::addPluginToDatabaseMenu( QString name, QAction* action )
       before = actions.at( i );
       break;
     }
-    else if ( actions.at( i )->menu() == mHelpMenu )
+    else if ( actions.at( i )->menu() == firstRightStandardMenu() )
     {
       before = actions.at( i );
       break;
@@ -5855,7 +5858,7 @@ void QgisApp::addPluginToWebMenu( QString name, QAction* action )
   {
     if ( actions.at( i )->menu() == mWebMenu )
       return;
-    if ( actions.at( i )->menu() == mHelpMenu )
+    if ( actions.at( i )->menu() == firstRightStandardMenu() )
     {
       before = actions.at( i );
       break;

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -928,6 +928,12 @@ void QgisApp::createActions()
   connect( mActionCustomization, SIGNAL( triggered() ), this, SLOT( customize() ) );
 
 #ifdef Q_WS_MAC
+  // copy of Options action that gets moved to app Preferences...
+  mActionOptionsMac = new QAction( mActionOptions->text(), this );
+  mActionOptionsMac->setMenuRole( QAction::NoRole );
+  mActionOptionsMac->setIcon( mActionOptions->icon() );
+  connect( mActionOptionsMac, SIGNAL( triggered() ), this, SLOT( options() ) );
+
   // Window Menu Items
 
   mActionWindowMinimize = new QAction( tr( "Minimize" ), this );
@@ -1158,6 +1164,9 @@ void QgisApp::createMenus()
   }
 
 #ifdef Q_WS_MAC
+  // copy back the Options action after assigned to app Preferences...
+  mSettingsMenu->addAction( mActionOptionsMac );
+
   // Window Menu
 
   mWindowMenu = menuBar()->addMenu( tr( "&Window" ) );

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -978,6 +978,7 @@ class QgisApp : public QMainWindow, private Ui::MainWindow
     // actions for menus and toolbars -----------------
 
 #ifdef Q_WS_MAC
+    QAction *mActionOptionsMac;
     QAction *mActionWindowMinimize;
     QAction *mActionWindowZoom;
     QAction *mActionWindowSeparator1;

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -1378,6 +1378,9 @@
    <property name="text">
     <string>Configure shortcuts...</string>
    </property>
+   <property name="menuRole">
+    <enum>QAction::NoRole</enum>
+   </property>
   </action>
   <action name="mActionLocalHistogramStretch">
    <property name="icon">


### PR DESCRIPTION
Additional info is in the commit messages. No new strings added.

Commit f01c6ad8 only fixes the issue as far as QGIS src code is concerned. It doesn't keep plugins, that are added by user, from hijacking the About or Preferences... menu actions, under QGIS application menu on Mac.

For example, SEXTANTE hijacks the About menu, if installed. The last plugin to load that has a QAction with a name that starts with 'about*' will be the winning hijacker. This is only if the plugin installs its own top-level menu in the menu bar; submenus are ignored by Qt for the Mac-only merge 'feature'.

To fix this issue, a function needs added that can be called whenever/wherever a plugin is added to a top-level menubar menu. It should check if any of the QActions added has a role of QAction::TextHeuristicRole and, if so, set it to QAction::NoRole, as all menu roles are already explicitly defined for AboutRole and PreferencesRole (in src/ui/qgisapp.ui). Any new QAction's menu role, excepting maybe in the future ApplicationSpecificRole, should not be allowed to heuristically hijack the QGIS.app's main application menu actions, just because their action's title starts with a particular text.

QAction::TextHeuristicRole is basically a bad idea and its functionality should be removed from Qt, or least Qt should offer a way to turn it off from being the default role.
