### PR TITLE
Better fix for #5754. More of a hack but works well.

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -928,12 +928,6 @@ void QgisApp::createActions()
   connect( mActionCustomization, SIGNAL( triggered() ), this, SLOT( customize() ) );
 
 #ifdef Q_WS_MAC
-  // copy of Options action that gets moved to app Preferences...
-  mActionOptionsMac = new QAction( mActionOptions->text(), this );
-  mActionOptionsMac->setMenuRole( QAction::NoRole );
-  mActionOptionsMac->setIcon( mActionOptions->icon() );
-  connect( mActionOptionsMac, SIGNAL( triggered() ), this, SLOT( options() ) );
-
   // Window Menu Items
 
   mActionWindowMinimize = new QAction( tr( "Minimize" ), this );
@@ -1164,8 +1158,11 @@ void QgisApp::createMenus()
   }
 
 #ifdef Q_WS_MAC
-  // copy back the Options action after assigned to app Preferences...
-  mSettingsMenu->addAction( mActionOptionsMac );
+
+  // keep plugins from hijacking About and Preferences application menus
+  // these duplicate actions will be moved to application menus by Qt
+  mFileMenu->addAction( mActionAbout );
+  mFileMenu->addAction( mActionOptions );
 
   // Window Menu
 

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -978,7 +978,6 @@ class QgisApp : public QMainWindow, private Ui::MainWindow
     // actions for menus and toolbars -----------------
 
 #ifdef Q_WS_MAC
-    QAction *mActionOptionsMac;
     QAction *mActionWindowMinimize;
     QAction *mActionWindowZoom;
     QAction *mActionWindowSeparator1;


### PR DESCRIPTION
Keeps all plugins from hijacking About or Preferences application menus on Mac.

See http://hub.qgis.org/issues/5754 for more details.

Tested on Mac OS X 10.6.8 and 10.7.4.
