### PR TITLE
Fix for #5753, for all platforms.

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5744,22 +5744,31 @@ void QgisApp::addPluginToDatabaseMenu( QString name, QAction* action )
   {
     if ( actions.at( i )->menu() == mDatabaseMenu )
       return;
+
+    // goes before Web menu, if present
     if ( actions.at( i )->menu() == mWebMenu )
     {
       before = actions.at( i );
       break;
     }
-    else if ( actions.at( i )->menu() == firstRightStandardMenu() )
+  }
+  for ( int i = 0; i < actions.count(); i++ )
+  {
+    // defaults to after Raster menu, which is already in qgisapp.ui
+    if ( actions.at( i )->menu() == mRasterMenu )
     {
-      before = actions.at( i );
-      break;
+      if ( !before )
+      {
+        before = actions.at( i += 1 );
+        break;
+      }
     }
   }
-
   if ( before )
     menuBar()->insertMenu( before, mDatabaseMenu );
   else
-    menuBar()->addMenu( mDatabaseMenu );
+    // fallback insert
+    menuBar()->insertMenu( firstRightStandardMenu()->menuAction(), mDatabaseMenu );
 }
 
 void QgisApp::addPluginToRasterMenu( QString name, QAction* action )
@@ -5783,6 +5792,8 @@ void QgisApp::addPluginToVectorMenu( QString name, QAction* action )
   {
     if ( actions.at( i )->menu() == mVectorMenu )
       return;
+
+    // goes before Raster menu, which is already in qgisapp.ui
     if ( actions.at( i )->menu() == mRasterMenu )
     {
       before = actions.at( i );
@@ -5793,7 +5804,8 @@ void QgisApp::addPluginToVectorMenu( QString name, QAction* action )
   if ( before )
     menuBar()->insertMenu( before, mVectorMenu );
   else
-    menuBar()->addMenu( mVectorMenu );
+    // fallback insert
+    menuBar()->insertMenu( firstRightStandardMenu()->menuAction(), mVectorMenu );
 }
 
 void QgisApp::addPluginToWebMenu( QString name, QAction* action )
@@ -5809,19 +5821,34 @@ void QgisApp::addPluginToWebMenu( QString name, QAction* action )
   QList<QAction*> actions = menuBar()->actions();
   for ( int i = 0; i < actions.count(); i++ )
   {
+    // goes after Database menu, if present
+    if ( actions.at( i )->menu() == mDatabaseMenu )
+    {
+      before = actions.at( i += 1 );
+      // don't break here
+    }
+
     if ( actions.at( i )->menu() == mWebMenu )
       return;
-    if ( actions.at( i )->menu() == firstRightStandardMenu() )
+  }
+  for ( int i = 0; i < actions.count(); i++ )
+  {
+    // defaults to after Raster menu, which is already in qgisapp.ui
+    if ( actions.at( i )->menu() == mRasterMenu )
     {
-      before = actions.at( i );
-      break;
+      if ( !before )
+      {
+        before = actions.at( i += 1 );
+        break;
+      }
     }
   }
 
   if ( before )
     menuBar()->insertMenu( before, mWebMenu );
   else
-    menuBar()->addMenu( mWebMenu );
+    // fallback insert
+    menuBar()->insertMenu( firstRightStandardMenu()->menuAction(), mWebMenu );
 }
 
 void QgisApp::removePluginDatabaseMenu( QString name, QAction* action )


### PR DESCRIPTION
This fix takes a different approach to dynamically building standard plugin category menus, by putting them after or before the Raster menu, which is already in /src/ui/qgisapp.ui.

If third-party plugins use firstRightStandardMenu() as a key for placing their plugin menus before it, this fix should now keep the menubar properly ordered, with dynamically added/removed standard plugin category menus, as such:

File, Edit, View, Layer, Settings, Plugins, [Vector], Raster, [Database], [Web], [Plugin-added-menus], Window (on Mac), Help

See note at http://hub.qgis.org/issues/5753 referencing this pull request for a more in-depth explanation.

It would be good to have this backported to any point release of 1.8.x, as it is still slightly broken in 1.8 branch.
