### PR TITLE
small gui fix

### DIFF
--- a/src/core/qgssearchtreenode.cpp
+++ b/src/core/qgssearchtreenode.cpp
@@ -717,7 +717,7 @@ QgsSearchTreeValue QgsSearchTreeNode::valueAgainst( const QgsFieldMap& fields, Q
 
           if ( idx < 0 || idx >= p.size() )
           {
-            return QgsSearchTreeValue( 2, QObject::tr( "Index %1 out of range [0;%2[" ).arg( idx ).arg( p.size() ) );
+            return QgsSearchTreeValue( 2, QObject::tr( "Index %1 out of range [0;%2]" ).arg( idx ).arg( p.size() ) );
           }
 
           return QgsSearchTreeValue( mOp == opXAT ? p[idx].x() : p[idx].y() );

--- a/src/ui/qgscompositionwidgetbase.ui
+++ b/src/ui/qgscompositionwidgetbase.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>352</width>
+    <width>435</width>
     <height>570</height>
    </rect>
   </property>
@@ -42,7 +42,7 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>352</width>
+        <width>435</width>
         <height>570</height>
        </rect>
       </property>
@@ -98,11 +98,11 @@
            </widget>
           </item>
           <item row="1" column="0" colspan="2">
-           <layout class="QHBoxLayout" name="horizontalLayout">
+           <layout class="QHBoxLayout" name="horizontalLayout" stretch="1,1,0">
             <item>
              <widget class="QDoubleSpinBox" name="mPaperWidthDoubleSpinBox">
               <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+               <sizepolicy hsizetype="Minimum" vsizetype="Expanding">
                 <horstretch>0</horstretch>
                 <verstretch>0</verstretch>
                </sizepolicy>
@@ -121,7 +121,7 @@
             <item>
              <widget class="QDoubleSpinBox" name="mPaperHeightDoubleSpinBox">
               <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+               <sizepolicy hsizetype="Expanding" vsizetype="Minimum">
                 <horstretch>0</horstretch>
                 <verstretch>0</verstretch>
                </sizepolicy>


### PR DESCRIPTION
In the composer window, composition tab in the 'size' part. The Width and Height parts have a  fixed width, making it impossible to read the content of the dropdowns for width and height. Actually third dropdown (mm, inch) resizes, even if you resize the Composition-tab to full width.

Given ui makes width and height more readable.

I've put s screenshot here: http://i1156.photobucket.com/albums/p569/rduivenvoorde/printcomposer.png

The lower one is the old situation, as you see the actual numbers cannot be read. The upper part of the screenshot is after the fix: the mm-dropdown has a fixed size, while the Width and Height selectors resize with the tabwidth..
