### PR TITLE
Decoration grid

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -19,6 +19,7 @@ SET(QGIS_APP_SRCS
   qgsconfigureshortcutsdialog.cpp
   qgscustomization.cpp
   qgscustomprojectiondialog.cpp
+  qgsdecorationitem.cpp
   qgsdecorationcopyright.cpp
   qgsdecorationcopyrightdialog.cpp
   qgsdecorationnortharrow.cpp
@@ -169,6 +170,7 @@ SET (QGIS_APP_MOC_HDRS
   qgscontinuouscolordialog.h
   qgscustomization.h
   qgscustomprojectiondialog.h
+  qgsdecorationitem.h
   qgsdecorationcopyright.h
   qgsdecorationcopyrightdialog.h
   qgsdecorationnortharrow.h

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -25,6 +25,8 @@ SET(QGIS_APP_SRCS
   qgsdecorationnortharrowdialog.cpp
   qgsdecorationscalebar.cpp
   qgsdecorationscalebardialog.cpp
+  qgsdecorationgrid.cpp
+  qgsdecorationgriddialog.cpp
   qgsembedlayerdialog.cpp
   qgsformannotationdialog.cpp
   qgsdelattrdialog.cpp
@@ -173,6 +175,8 @@ SET (QGIS_APP_MOC_HDRS
   qgsdecorationnortharrowdialog.h
   qgsdecorationscalebar.h
   qgsdecorationscalebardialog.h
+  qgsdecorationgrid.h
+  qgsdecorationgriddialog.h
   qgsdelattrdialog.h
   qgsdisplayangle.h
   qgsembedlayerdialog.h

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2022,6 +2022,7 @@ void QgisApp::createDecorations()
   addDecorationItem( mDecorationNorthArrow );
   addDecorationItem( mDecorationScaleBar );
   connect( mMapCanvas, SIGNAL( renderComplete( QPainter * ) ), this, SLOT( renderDecorationItems( QPainter * ) ) );
+  connect( this, SIGNAL( newProject() ), this, SLOT( projectReadDecorationItems() ) );
   connect( this, SIGNAL( projectRead() ), this, SLOT( projectReadDecorationItems() ) );
 }
 
@@ -5026,11 +5027,13 @@ void QgisApp::setProjectCRSFromLayer()
 
   QgsCoordinateReferenceSystem crs = mMapLegend->currentLayer()->crs();
   QgsMapRenderer* myRenderer = mMapCanvas->mapRenderer();
+  mMapCanvas->freeze();
   myRenderer->setDestinationCrs( crs );
   if ( crs.mapUnits() != QGis::UnknownUnit )
   {
     myRenderer->setMapUnits( crs.mapUnits() );
   }
+  mMapCanvas->freeze( false );
   mMapCanvas->refresh();
 }
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2004,26 +2004,41 @@ void QgisApp::createMapTips()
 
 void QgisApp::createDecorations()
 {
-  mDecorationCopyright = new QgsDecorationCopyright( this );
+  QgsDecorationCopyright* mDecorationCopyright = new QgsDecorationCopyright( this );
   connect( mActionDecorationCopyright, SIGNAL( triggered() ), mDecorationCopyright, SLOT( run() ) );
-  connect( mMapCanvas, SIGNAL( renderComplete( QPainter * ) ), mDecorationCopyright, SLOT( renderLabel( QPainter * ) ) );
-  connect( this, SIGNAL( projectRead() ), mDecorationCopyright, SLOT( projectRead() ) );
 
-  mDecorationNorthArrow = new QgsDecorationNorthArrow( this );
+  QgsDecorationNorthArrow* mDecorationNorthArrow = new QgsDecorationNorthArrow( this );
   connect( mActionDecorationNorthArrow, SIGNAL( triggered() ), mDecorationNorthArrow, SLOT( run() ) );
-  connect( mMapCanvas, SIGNAL( renderComplete( QPainter * ) ), mDecorationNorthArrow, SLOT( renderNorthArrow( QPainter * ) ) );
-  connect( this, SIGNAL( projectRead() ), mDecorationNorthArrow, SLOT( projectRead() ) );
 
-  mDecorationScaleBar = new QgsDecorationScaleBar( this );
+  QgsDecorationScaleBar* mDecorationScaleBar = new QgsDecorationScaleBar( this );
   connect( mActionDecorationScaleBar, SIGNAL( triggered() ), mDecorationScaleBar, SLOT( run() ) );
-  connect( mMapCanvas, SIGNAL( renderComplete( QPainter * ) ), mDecorationScaleBar, SLOT( renderScaleBar( QPainter * ) ) );
-  connect( this, SIGNAL( projectRead() ), mDecorationScaleBar, SLOT( projectRead() ) );
 
-  // TODO draw the decorations in a particular order - perhaps use a vector or decoration objects?
-  mDecorationGrid = new QgsDecorationGrid( this );
+  QgsDecorationGrid* mDecorationGrid = new QgsDecorationGrid( this );
   connect( mActionDecorationGrid, SIGNAL( triggered() ), mDecorationGrid, SLOT( run() ) );
-  connect( mMapCanvas, SIGNAL( renderComplete( QPainter * ) ), mDecorationGrid, SLOT( renderGrid( QPainter * ) ) );
-  connect( this, SIGNAL( projectRead() ), mDecorationGrid, SLOT( projectRead() ) );
+
+  // add the decorations in a particular order so they are rendered in that order
+  addDecorationItem( mDecorationGrid );
+  addDecorationItem( mDecorationCopyright );
+  addDecorationItem( mDecorationNorthArrow );
+  addDecorationItem( mDecorationScaleBar );
+  connect( mMapCanvas, SIGNAL( renderComplete( QPainter * ) ), this, SLOT( renderDecorationItems( QPainter * ) ) );
+  connect( this, SIGNAL( projectRead() ), this, SLOT( projectReadDecorationItems() ) );
+}
+
+void QgisApp::renderDecorationItems( QPainter *p )
+{
+  foreach( QgsDecorationItem* item, mDecorationItems )
+  {
+    item->render( p );
+  }
+}
+
+void QgisApp::projectReadDecorationItems()
+{
+  foreach( QgsDecorationItem* item, mDecorationItems )
+  {
+    item->projectRead( );
+  }
 }
 
 // Update file menu with the current list of recently accessed projects

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -117,6 +117,7 @@
 #include "qgsdecorationcopyright.h"
 #include "qgsdecorationnortharrow.h"
 #include "qgsdecorationscalebar.h"
+#include "qgsdecorationgrid.h"
 #include "qgsembedlayerdialog.h"
 #include "qgsencodingfiledialog.h"
 #include "qgsexception.h"
@@ -1609,6 +1610,7 @@ void QgisApp::setTheme( QString theThemeName )
   mActionDecorationCopyright->setIcon( getThemeIcon( "/plugins/copyright_label.png" ) );
   mActionDecorationNorthArrow->setIcon( getThemeIcon( "/plugins/north_arrow.png" ) );
   mActionDecorationScaleBar->setIcon( getThemeIcon( "/plugins/scale_bar.png" ) );
+  mActionDecorationGrid->setIcon( getThemeIcon( "/transformed.png" ) );
 
   //change themes of all composers
   QSet<QgsComposer*>::iterator composerIt = mPrintComposers.begin();
@@ -2016,6 +2018,12 @@ void QgisApp::createDecorations()
   connect( mActionDecorationScaleBar, SIGNAL( triggered() ), mDecorationScaleBar, SLOT( run() ) );
   connect( mMapCanvas, SIGNAL( renderComplete( QPainter * ) ), mDecorationScaleBar, SLOT( renderScaleBar( QPainter * ) ) );
   connect( this, SIGNAL( projectRead() ), mDecorationScaleBar, SLOT( projectRead() ) );
+
+  // TODO draw the decorations in a particular order - perhaps use a vector or decoration objects?
+  mDecorationGrid = new QgsDecorationGrid( this );
+  connect( mActionDecorationGrid, SIGNAL( triggered() ), mDecorationGrid, SLOT( run() ) );
+  connect( mMapCanvas, SIGNAL( renderComplete( QPainter * ) ), mDecorationGrid, SLOT( renderGrid( QPainter * ) ) );
+  connect( this, SIGNAL( projectRead() ), mDecorationGrid, SLOT( projectRead() ) );
 }
 
 // Update file menu with the current list of recently accessed projects

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -69,10 +69,7 @@ class QgsBrowserDockWidget;
 class QgsSnappingDialog;
 class QgsGPSInformationWidget;
 
-class QgsDecorationCopyright;
-class QgsDecorationNorthArrow;
-class QgsDecorationScaleBar;
-class QgsDecorationGrid;
+class QgsDecorationItem;
 
 class QgsMessageLogViewer;
 
@@ -380,6 +377,9 @@ class QgisApp : public QMainWindow, private Ui::MainWindow
     void completeInitialization();
 
     void emitCustomSrsValidation( QgsCoordinateReferenceSystem *crs );
+
+    QList<QgsDecorationItem*> decorationItems() { return mDecorationItems; }
+    void addDecorationItem( QgsDecorationItem* item ) { mDecorationItems.append( item ); }
 
   public slots:
     //! Zoom to full extent
@@ -869,6 +869,9 @@ class QgisApp : public QMainWindow, private Ui::MainWindow
     //! Activates label property tool
     void changeLabelProperties();
 
+    void renderDecorationItems( QPainter *p );
+    void projectReadDecorationItems( );
+
   signals:
     /** emitted when a key is pressed and we want non widget sublasses to be able
       to pick up on this (e.g. maplayer) */
@@ -1185,10 +1188,10 @@ class QgisApp : public QMainWindow, private Ui::MainWindow
 
     QgsSnappingDialog* mSnappingDialog;
 
-    QgsDecorationCopyright* mDecorationCopyright;
-    QgsDecorationNorthArrow* mDecorationNorthArrow;
-    QgsDecorationScaleBar* mDecorationScaleBar;
-    QgsDecorationGrid* mDecorationGrid;
+    //! Persistent tile scale slider
+    QgsTileScaleWidget * mpTileScaleWidget;
+
+    QList<QgsDecorationItem*> mDecorationItems;
 
     int mLastComposerId;
 
@@ -1214,6 +1217,7 @@ class QgisApp : public QMainWindow, private Ui::MainWindow
     bool gestureEvent( QGestureEvent *event );
     void tapAndHoldTriggered( QTapAndHoldGesture *gesture );
 #endif
+
 };
 
 #ifdef ANDROID

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -72,6 +72,7 @@ class QgsGPSInformationWidget;
 class QgsDecorationCopyright;
 class QgsDecorationNorthArrow;
 class QgsDecorationScaleBar;
+class QgsDecorationGrid;
 
 class QgsMessageLogViewer;
 
@@ -1187,6 +1188,7 @@ class QgisApp : public QMainWindow, private Ui::MainWindow
     QgsDecorationCopyright* mDecorationCopyright;
     QgsDecorationNorthArrow* mDecorationNorthArrow;
     QgsDecorationScaleBar* mDecorationScaleBar;
+    QgsDecorationGrid* mDecorationGrid;
 
     int mLastComposerId;
 

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -76,6 +76,7 @@ class QgsMessageLogViewer;
 class QgsScaleComboBox;
 
 class QgsDataItem;
+class QgsTileScaleWidget;
 
 #include <QMainWindow>
 #include <QToolBar>

--- a/src/app/qgsdecorationcopyright.h
+++ b/src/app/qgsdecorationcopyright.h
@@ -19,6 +19,8 @@
 #ifndef QGSCOPYRIGHTLABELPLUGIN
 #define QGSCOPYRIGHTLABELPLUGIN
 
+#include "qgsdecorationitem.h"
+
 #include <QColor>
 #include <QFont>
 #include <QObject>
@@ -27,7 +29,7 @@ class QPainter;
 
 class QgsDecorationCopyrightDialog;
 
-class QgsDecorationCopyright : public QObject
+class QgsDecorationCopyright : public QgsDecorationItem
 {
     Q_OBJECT
   public:
@@ -46,7 +48,7 @@ class QgsDecorationCopyright : public QObject
     //! Show the dialog box
     void run();
     //! render the copyright label
-    void renderLabel( QPainter * );
+    void render( QPainter * );
 
   private:
     //! This is the font that will be used for the copyright label
@@ -58,8 +60,6 @@ class QgsDecorationCopyright : public QObject
     //! Placement of the copyright label - index and translated label names
     int mPlacementIndex;
     QStringList mPlacementLabels;
-    //! Copyright label enabled
-    bool mEnable;
 
     friend class QgsDecorationCopyrightDialog;
 };

--- a/src/app/qgsdecorationcopyrightdialog.cpp
+++ b/src/app/qgsdecorationcopyrightdialog.cpp
@@ -33,7 +33,7 @@ QgsDecorationCopyrightDialog::QgsDecorationCopyrightDialog( QgsDecorationCopyrig
   cboOrientation->hide();
   textLabel15->hide();
 
-  cboxEnabled->setChecked( mDeco.mEnable );
+  cboxEnabled->setChecked( mDeco.enabled() );
   // text
   txtCopyrightText->setPlainText( mDeco.mLabelQString );
   // placement
@@ -60,7 +60,7 @@ void QgsDecorationCopyrightDialog::on_buttonBox_accepted()
   mDeco.mLabelQString = txtCopyrightText->toPlainText();
   mDeco.mLabelQColor = pbnColorChooser->color();
   mDeco.mPlacementIndex = cboPlacement->currentIndex();
-  mDeco.mEnable = cboxEnabled->isChecked();
+  mDeco.setEnabled( cboxEnabled->isChecked() );
 
   accept();
 }

--- a/src/app/qgsdecorationgrid.cpp
+++ b/src/app/qgsdecorationgrid.cpp
@@ -1,0 +1,608 @@
+/***************************************************************************
+                         qgsdecorationgrid.h
+                         ----------------------
+    begin                : May 10, 2012
+    copyright            : (C) 2012 by Etienne Tourigny
+    email                : etourigny.dev at gmail dot com
+
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsdecorationgrid.h"
+#include "qgsdecorationgriddialog.h"
+
+#include "qgisapp.h"
+#include "qgslogger.h"
+#include "qgsmapcanvas.h"
+#include "qgsmaplayer.h"
+#include "qgsmaptopixel.h"
+#include "qgspoint.h"
+#include "qgsproject.h"
+#include "qgssymbollayerv2utils.h" //for pointOnLineWithDistance
+
+#include <QPainter>
+#include <QAction>
+#include <QPen>
+#include <QPolygon>
+#include <QString>
+#include <QFontMetrics>
+#include <QFont>
+#include <QColor>
+#include <QMenu>
+#include <QFile>
+#include <QLocale>
+
+//non qt includes
+#include <cmath>
+
+
+#ifdef _MSC_VER
+#define round(x)  ((x) >= 0 ? floor((x)+0.5) : floor((x)-0.5))
+#endif
+
+#define FONT_WORKAROUND_SCALE 10 //scale factor for upscaling fontsize and downscaling painter
+
+
+QgsDecorationGrid::QgsDecorationGrid( QObject* parent )
+    : QObject( parent )
+{
+  projectRead();
+}
+
+QgsDecorationGrid::~QgsDecorationGrid()
+{
+
+}
+
+void QgsDecorationGrid::update()
+{
+  QgisApp::instance()->mapCanvas()->refresh();
+}
+
+void QgsDecorationGrid::projectRead()
+{
+  mGridEnabled = QgsProject::instance()->readBoolEntry( "Grid", "/Enabled", false );
+  mGridStyle = ( GridStyle ) QgsProject::instance()->readNumEntry( "Grid", "/Style", 0 );
+  mGridIntervalX = QgsProject::instance()->readDoubleEntry( "Grid", "/IntervalX", 0 );
+  mGridIntervalY = QgsProject::instance()->readDoubleEntry( "Grid", "/IntervalY", 0 );
+  mGridOffsetX = QgsProject::instance()->readDoubleEntry( "Grid", "/OffsetX", 0 );
+  mGridOffsetY = QgsProject::instance()->readDoubleEntry( "Grid", "/OffsetY", 0 );
+  mCrossLength = QgsProject::instance()->readDoubleEntry( "Grid", "/CrossLength", 0 );
+  // missing mGridPen, mGridAnnotationFont
+  mGridAnnotationPrecision = ( GridAnnotationPosition ) QgsProject::instance()->readNumEntry( "Grid", "/AnnotationPrecision", 3 );
+  mShowGridAnnotation = QgsProject::instance()->readBoolEntry( "Grid", "/ShowAnnotation", false );
+  // mGridAnnotationPosition = (GridAnnotationPosition) QgsProject::instance()->readNumEntry( "Grid", "/AnnotationPosition", 0 );
+  mAnnotationFrameDistance = QgsProject::instance()->readDoubleEntry( "Grid", "/AnnotationFrameDistance", 0 );
+  mGridAnnotationDirection = ( GridAnnotationDirection ) QgsProject::instance()->readNumEntry( "Grid", "/AnnotationDirection", 0 );
+}
+
+void QgsDecorationGrid::saveToProject()
+{
+  QgsProject::instance()->writeEntry( "Grid", "/Enabled", mGridEnabled );
+  QgsProject::instance()->writeEntry( "Grid", "/IntervalX", mGridIntervalX );
+  QgsProject::instance()->writeEntry( "Grid", "/IntervalY", mGridIntervalY );
+  QgsProject::instance()->writeEntry( "Grid", "/OffsetX", mGridOffsetX );
+  QgsProject::instance()->writeEntry( "Grid", "/OffsetX", mGridOffsetY );
+  QgsProject::instance()->writeEntry( "Grid", "/CrossLength", mCrossLength );
+  // missing mGridPen, mGridAnnotationFont
+  QgsProject::instance()->writeEntry( "Grid", "/AnnotationPrecision", mGridAnnotationPrecision );
+  QgsProject::instance()->writeEntry( "Grid", "/ShowAnnotation", mShowGridAnnotation );
+  // QgsProject::instance()->writeEntry( "Grid", "/AnnotationPosition", mGridAnnotationPosition );
+  QgsProject::instance()->writeEntry( "Grid", "/AnnotationFrameDistance", mAnnotationFrameDistance );
+  QgsProject::instance()->writeEntry( "Grid", "/AnnotationDirection", mGridAnnotationDirection );
+}
+
+
+void QgsDecorationGrid::run()
+{
+  QgsDecorationGridDialog dlg( *this );
+
+  if ( dlg.exec() )
+  {
+    saveToProject();
+    QgisApp::instance()->mapCanvas()->refresh();
+  }
+}
+
+
+
+void QgsDecorationGrid::renderGrid( QPainter * p )
+{
+  if ( ! mGridEnabled )
+    return;
+
+  p->setPen( mGridPen );
+
+  QList< QPair< double, QLineF > > verticalLines;
+  yGridLines( verticalLines, p );
+  QList< QPair< double, QLineF > >::const_iterator vIt = verticalLines.constBegin();
+  QList< QPair< double, QLineF > > horizontalLines;
+  xGridLines( horizontalLines, p );
+  QList< QPair< double, QLineF > >::const_iterator hIt = horizontalLines.constBegin();
+
+  // QRectF thisPaintRect = QRectF( 0, 0, QGraphicsRectItem::rect().width(), QGraphicsRectItem::rect().height() );
+  // p->setClipRect( thisPaintRect );
+
+  //simpler approach: draw vertical lines first, then horizontal ones
+  if ( mGridStyle == QgsDecorationGrid::Solid )
+  {
+    for ( ; vIt != verticalLines.constEnd(); ++vIt )
+    {
+      p->drawLine( vIt->second );
+    }
+
+    for ( ; hIt != horizontalLines.constEnd(); ++hIt )
+    {
+      p->drawLine( hIt->second );
+    }
+  }
+  else //cross
+  {
+    QPointF intersectionPoint, crossEnd1, crossEnd2;
+    for ( ; vIt != verticalLines.constEnd(); ++vIt )
+    {
+      //start mark
+      crossEnd1 = QgsSymbolLayerV2Utils::pointOnLineWithDistance( vIt->second.p1(), vIt->second.p2(), mCrossLength );
+      p->drawLine( vIt->second.p1(), crossEnd1 );
+
+      //test for intersection with every horizontal line
+      hIt = horizontalLines.constBegin();
+      for ( ; hIt != horizontalLines.constEnd(); ++hIt )
+      {
+        if ( hIt->second.intersect( vIt->second, &intersectionPoint ) == QLineF::BoundedIntersection )
+        {
+          crossEnd1 = QgsSymbolLayerV2Utils::pointOnLineWithDistance( intersectionPoint, vIt->second.p1(), mCrossLength );
+          crossEnd2 = QgsSymbolLayerV2Utils::pointOnLineWithDistance( intersectionPoint, vIt->second.p2(), mCrossLength );
+          p->drawLine( crossEnd1, crossEnd2 );
+        }
+      }
+      //end mark
+      QPointF crossEnd2 = QgsSymbolLayerV2Utils::pointOnLineWithDistance( vIt->second.p2(), vIt->second.p1(), mCrossLength );
+      p->drawLine( vIt->second.p2(), crossEnd2 );
+    }
+
+    hIt = horizontalLines.constBegin();
+    for ( ; hIt != horizontalLines.constEnd(); ++hIt )
+    {
+      //start mark
+      crossEnd1 = QgsSymbolLayerV2Utils::pointOnLineWithDistance( hIt->second.p1(), hIt->second.p2(), mCrossLength );
+      p->drawLine( hIt->second.p1(), crossEnd1 );
+
+      vIt = verticalLines.constBegin();
+      for ( ; vIt != verticalLines.constEnd(); ++vIt )
+      {
+        if ( vIt->second.intersect( hIt->second, &intersectionPoint ) == QLineF::BoundedIntersection )
+        {
+          crossEnd1 = QgsSymbolLayerV2Utils::pointOnLineWithDistance( intersectionPoint, hIt->second.p1(), mCrossLength );
+          crossEnd2 = QgsSymbolLayerV2Utils::pointOnLineWithDistance( intersectionPoint, hIt->second.p2(), mCrossLength );
+          p->drawLine( crossEnd1, crossEnd2 );
+        }
+      }
+      //end mark
+      crossEnd1 = QgsSymbolLayerV2Utils::pointOnLineWithDistance( hIt->second.p2(), hIt->second.p1(), mCrossLength );
+      p->drawLine( hIt->second.p2(), crossEnd1 );
+    }
+
+
+  }
+
+  // p->setClipRect( thisPaintRect , Qt::NoClip );
+
+  if ( mShowGridAnnotation )
+  {
+    drawCoordinateAnnotations( p, horizontalLines, verticalLines );
+  }
+}
+
+void QgsDecorationGrid::drawCoordinateAnnotations( QPainter* p, const QList< QPair< double, QLineF > >& hLines, const QList< QPair< double, QLineF > >& vLines )
+{
+  if ( !p )
+  {
+    return;
+  }
+
+  QString currentAnnotationString;
+  QList< QPair< double, QLineF > >::const_iterator it = hLines.constBegin();
+  for ( ; it != hLines.constEnd(); ++it )
+  {
+    currentAnnotationString = QString::number( it->first, 'f', mGridAnnotationPrecision );
+    drawCoordinateAnnotation( p, it->second.p1(), currentAnnotationString );
+    drawCoordinateAnnotation( p, it->second.p2(), currentAnnotationString );
+  }
+
+  it = vLines.constBegin();
+  for ( ; it != vLines.constEnd(); ++it )
+  {
+    currentAnnotationString = QString::number( it->first, 'f', mGridAnnotationPrecision );
+    drawCoordinateAnnotation( p, it->second.p1(), currentAnnotationString );
+    drawCoordinateAnnotation( p, it->second.p2(), currentAnnotationString );
+  }
+}
+
+void QgsDecorationGrid::drawCoordinateAnnotation( QPainter* p, const QPointF& pos, QString annotationString )
+{
+  Border frameBorder = borderForLineCoord( pos, p );
+  double textWidth = textWidthMillimeters( mGridAnnotationFont, annotationString );
+  //relevant for annotations is the height of digits
+  double textHeight = fontHeightCharacterMM( mGridAnnotationFont, QChar( '0' ) );
+  double xpos = pos.x();
+  double ypos = pos.y();
+  int rotation = 0;
+
+  if ( frameBorder == Left )
+  {
+
+    if ( mGridAnnotationPosition == InsideMapFrame )
+    {
+      if ( mGridAnnotationDirection == Vertical || mGridAnnotationDirection == BoundaryDirection )
+      {
+        xpos += textHeight + mAnnotationFrameDistance;
+        ypos += textWidth / 2.0;
+        rotation = 270;
+      }
+      else
+      {
+        xpos += mAnnotationFrameDistance;
+        ypos += textHeight / 2.0;
+      }
+    }
+    else //Outside map frame
+    {
+      if ( mGridAnnotationDirection == Vertical || mGridAnnotationDirection == BoundaryDirection )
+      {
+        xpos -= mAnnotationFrameDistance;
+        ypos += textWidth / 2.0;
+        rotation = 270;
+      }
+      else
+      {
+        xpos -= textWidth + mAnnotationFrameDistance;
+        ypos += textHeight / 2.0;
+      }
+    }
+
+  }
+  else if ( frameBorder == Right )
+  {
+    if ( mGridAnnotationPosition == InsideMapFrame )
+    {
+      if ( mGridAnnotationDirection == Vertical || mGridAnnotationDirection == BoundaryDirection )
+      {
+        xpos -= mAnnotationFrameDistance;
+        ypos += textWidth / 2.0;
+        rotation = 270;
+      }
+      else //Horizontal
+      {
+        xpos -= textWidth + mAnnotationFrameDistance;
+        ypos += textHeight / 2.0;
+      }
+    }
+    else //OutsideMapFrame
+    {
+      if ( mGridAnnotationDirection == Vertical || mGridAnnotationDirection == BoundaryDirection )
+      {
+        xpos += textHeight + mAnnotationFrameDistance;
+        ypos += textWidth / 2.0;
+        rotation = 270;
+      }
+      else //Horizontal
+      {
+        xpos += mAnnotationFrameDistance;
+        ypos += textHeight / 2.0;
+      }
+    }
+  }
+  else if ( frameBorder == Bottom )
+  {
+    if ( mGridAnnotationPosition == InsideMapFrame )
+    {
+      if ( mGridAnnotationDirection == Horizontal || mGridAnnotationDirection == BoundaryDirection )
+      {
+        ypos -= mAnnotationFrameDistance;
+        xpos -= textWidth / 2.0;
+      }
+      else //Vertical
+      {
+        xpos += textHeight / 2.0;
+        ypos -= mAnnotationFrameDistance;
+        rotation = 270;
+      }
+    }
+    else //OutsideMapFrame
+    {
+      if ( mGridAnnotationDirection == Horizontal || mGridAnnotationDirection == BoundaryDirection )
+      {
+        ypos += mAnnotationFrameDistance + textHeight;
+        xpos -= textWidth / 2.0;
+      }
+      else //Vertical
+      {
+        xpos += textHeight / 2.0;
+        ypos += textWidth + mAnnotationFrameDistance;
+        rotation = 270;
+      }
+    }
+  }
+  else //Top
+  {
+    if ( mGridAnnotationPosition == InsideMapFrame )
+    {
+      if ( mGridAnnotationDirection == Horizontal || mGridAnnotationDirection == BoundaryDirection )
+      {
+        xpos -= textWidth / 2.0;
+        ypos += textHeight + mAnnotationFrameDistance;
+      }
+      else //Vertical
+      {
+        xpos += textHeight / 2.0;
+        ypos += textWidth + mAnnotationFrameDistance;
+        rotation = 270;
+      }
+    }
+    else //OutsideMapFrame
+    {
+      if ( mGridAnnotationDirection == Horizontal || mGridAnnotationDirection == BoundaryDirection )
+      {
+        xpos -= textWidth / 2.0;
+        ypos -= mAnnotationFrameDistance;
+      }
+      else //Vertical
+      {
+        xpos += textHeight / 2.0;
+        ypos -= mAnnotationFrameDistance;
+        rotation = 270;
+      }
+    }
+  }
+
+  drawAnnotation( p, QPointF( xpos, ypos ), rotation, annotationString );
+}
+
+void QgsDecorationGrid::drawAnnotation( QPainter* p, const QPointF& pos, int rotation, const QString& annotationText )
+{
+  p->save();
+  p->translate( pos );
+  p->rotate( rotation );
+  p->setPen( QColor( 0, 0, 0 ) );
+  drawText( p, 0, 0, annotationText, mGridAnnotationFont );
+  p->restore();
+}
+
+QPolygonF canvasExtent()
+{
+  QPolygonF poly;
+  QgsRectangle extent = QgisApp::instance()->mapCanvas()->extent();
+  poly << QPointF( extent.xMinimum(), extent.yMaximum() );
+  poly << QPointF( extent.xMaximum(), extent.yMaximum() );
+  poly << QPointF( extent.xMaximum(), extent.yMinimum() );
+  poly << QPointF( extent.xMinimum(), extent.yMinimum() );
+  return poly;
+}
+
+int QgsDecorationGrid::xGridLines( QList< QPair< double, QLineF > >& lines, QPainter * p ) const
+{
+  lines.clear();
+  if ( mGridIntervalY <= 0.0 )
+  {
+    return 1;
+  }
+
+  // QPolygonF mapPolygon = transformedMapPolygon();
+  QPolygonF mapPolygon = canvasExtent();
+  QRectF mapBoundingRect = mapPolygon.boundingRect();
+
+  //consider to round up to the next step in case the left boundary is > 0
+  double roundCorrection = mapBoundingRect.top() > 0 ? 1.0 : 0.0;
+  double currentLevel = ( int )(( mapBoundingRect.top() - mGridOffsetY ) / mGridIntervalY + roundCorrection ) * mGridIntervalY + mGridOffsetY;
+
+  // if ( doubleNear( mRotation, 0.0 ) )
+  // {
+  //no rotation. Do it 'the easy way'
+
+  double yCanvasCoord;
+
+  while ( currentLevel <= mapBoundingRect.bottom() )
+  {
+    yCanvasCoord = p->device()->height() * ( 1 - ( currentLevel - mapBoundingRect.top() ) / mapBoundingRect.height() );
+    lines.push_back( qMakePair( currentLevel, QLineF( 0, yCanvasCoord, p->device()->width(), yCanvasCoord ) ) );
+    currentLevel += mGridIntervalY;
+  }
+  // }
+
+  //the four border lines
+  QVector<QLineF> borderLines;
+  borderLines << QLineF( mapPolygon.at( 0 ), mapPolygon.at( 1 ) );
+  borderLines << QLineF( mapPolygon.at( 1 ), mapPolygon.at( 2 ) );
+  borderLines << QLineF( mapPolygon.at( 2 ), mapPolygon.at( 3 ) );
+  borderLines << QLineF( mapPolygon.at( 3 ), mapPolygon.at( 0 ) );
+
+  QList<QPointF> intersectionList; //intersects between border lines and grid lines
+
+  while ( currentLevel <= mapBoundingRect.bottom() )
+  {
+    intersectionList.clear();
+    QLineF gridLine( mapBoundingRect.left(), currentLevel, mapBoundingRect.right(), currentLevel );
+
+    QVector<QLineF>::const_iterator it = borderLines.constBegin();
+    for ( ; it != borderLines.constEnd(); ++it )
+    {
+      QPointF intersectionPoint;
+      if ( it->intersect( gridLine, &intersectionPoint ) == QLineF::BoundedIntersection )
+      {
+        intersectionList.push_back( intersectionPoint );
+        if ( intersectionList.size() >= 2 )
+        {
+          break; //we already have two intersections, skip further tests
+        }
+      }
+    }
+
+    if ( intersectionList.size() >= 2 )
+    {
+      lines.push_back( qMakePair( currentLevel, QLineF( intersectionList.at( 0 ), intersectionList.at( 1 ) ) ) );
+    }
+    currentLevel += mGridIntervalY;
+  }
+
+
+  return 0;
+}
+
+int QgsDecorationGrid::yGridLines( QList< QPair< double, QLineF > >& lines, QPainter * p ) const
+{
+  lines.clear();
+  if ( mGridIntervalX <= 0.0 )
+  {
+    return 1;
+  }
+
+  // QPolygonF mapPolygon = transformedMapPolygon();
+  QPolygonF mapPolygon = canvasExtent();
+  QRectF mapBoundingRect = mapPolygon.boundingRect();
+
+  //consider to round up to the next step in case the left boundary is > 0
+  double roundCorrection = mapBoundingRect.left() > 0 ? 1.0 : 0.0;
+  double currentLevel = ( int )(( mapBoundingRect.left() - mGridOffsetX ) / mGridIntervalX + roundCorrection ) * mGridIntervalX + mGridOffsetX;
+
+  // if ( doubleNear( mRotation, 0.0 ) )
+  // {
+  //   //no rotation. Do it 'the easy way'
+  double xCanvasCoord;
+
+  while ( currentLevel <= mapBoundingRect.right() )
+  {
+    xCanvasCoord = p->device()->width() * ( currentLevel - mapBoundingRect.left() ) / mapBoundingRect.width();
+    lines.push_back( qMakePair( currentLevel, QLineF( xCanvasCoord, 0, xCanvasCoord, p->device()->height() ) ) );
+    currentLevel += mGridIntervalX;
+  }
+  // }
+
+  //the four border lines
+  QVector<QLineF> borderLines;
+  borderLines << QLineF( mapPolygon.at( 0 ), mapPolygon.at( 1 ) );
+  borderLines << QLineF( mapPolygon.at( 1 ), mapPolygon.at( 2 ) );
+  borderLines << QLineF( mapPolygon.at( 2 ), mapPolygon.at( 3 ) );
+  borderLines << QLineF( mapPolygon.at( 3 ), mapPolygon.at( 0 ) );
+
+  QList<QPointF> intersectionList; //intersects between border lines and grid lines
+
+  while ( currentLevel <= mapBoundingRect.right() )
+  {
+    intersectionList.clear();
+    QLineF gridLine( currentLevel, mapBoundingRect.bottom(), currentLevel, mapBoundingRect.top() );
+
+    QVector<QLineF>::const_iterator it = borderLines.constBegin();
+    for ( ; it != borderLines.constEnd(); ++it )
+    {
+      QPointF intersectionPoint;
+      if ( it->intersect( gridLine, &intersectionPoint ) == QLineF::BoundedIntersection )
+      {
+        intersectionList.push_back( intersectionPoint );
+        if ( intersectionList.size() >= 2 )
+        {
+          break; //we already have two intersections, skip further tests
+        }
+      }
+    }
+
+    if ( intersectionList.size() >= 2 )
+    {
+      lines.push_back( qMakePair( currentLevel, QLineF( intersectionList.at( 0 ), intersectionList.at( 1 ) ) ) );
+    }
+    currentLevel += mGridIntervalX;
+  }
+
+  return 0;
+}
+
+QgsDecorationGrid::Border QgsDecorationGrid::borderForLineCoord( const QPointF& point, QPainter* p ) const
+{
+  if ( point.x() <= mGridPen.widthF() )
+  {
+    return Left;
+  }
+  else if ( point.x() >= ( p->device()->width() - mGridPen.widthF() ) )
+  {
+    return Right;
+  }
+  else if ( point.y() <= mGridPen.widthF() )
+  {
+    return Top;
+  }
+  else
+  {
+    return Bottom;
+  }
+}
+
+void QgsDecorationGrid::drawText( QPainter* p, double x, double y, const QString& text, const QFont& font ) const
+{
+  QFont textFont = scaledFontPixelSize( font );
+
+  p->save();
+  p->setFont( textFont );
+  p->setPen( QColor( 0, 0, 0 ) ); //draw text always in black
+  double scaleFactor = 1.0 / FONT_WORKAROUND_SCALE;
+  p->scale( scaleFactor, scaleFactor );
+  p->drawText( QPointF( x * FONT_WORKAROUND_SCALE, y * FONT_WORKAROUND_SCALE ), text );
+  p->restore();
+}
+
+void QgsDecorationGrid::drawText( QPainter* p, const QRectF& rect, const QString& text, const QFont& font, Qt::AlignmentFlag halignement, Qt::AlignmentFlag valignment ) const
+{
+  QFont textFont = scaledFontPixelSize( font );
+
+  QRectF scaledRect( rect.x() * FONT_WORKAROUND_SCALE, rect.y() * FONT_WORKAROUND_SCALE,
+                     rect.width() * FONT_WORKAROUND_SCALE, rect.height() * FONT_WORKAROUND_SCALE );
+
+  p->save();
+  p->setFont( textFont );
+  double scaleFactor = 1.0 / FONT_WORKAROUND_SCALE;
+  p->scale( scaleFactor, scaleFactor );
+  p->drawText( scaledRect, halignement | valignment | Qt::TextWordWrap, text );
+  p->restore();
+}
+
+double QgsDecorationGrid::textWidthMillimeters( const QFont& font, const QString& text ) const
+{
+  QFont metricsFont = scaledFontPixelSize( font );
+  QFontMetrics fontMetrics( metricsFont );
+  return ( fontMetrics.width( text ) / FONT_WORKAROUND_SCALE );
+}
+
+double QgsDecorationGrid::fontHeightCharacterMM( const QFont& font, const QChar& c ) const
+{
+  QFont metricsFont = scaledFontPixelSize( font );
+  QFontMetricsF fontMetrics( metricsFont );
+  return ( fontMetrics.boundingRect( c ).height() / FONT_WORKAROUND_SCALE );
+}
+
+double QgsDecorationGrid::fontAscentMillimeters( const QFont& font ) const
+{
+  QFont metricsFont = scaledFontPixelSize( font );
+  QFontMetricsF fontMetrics( metricsFont );
+  return ( fontMetrics.ascent() / FONT_WORKAROUND_SCALE );
+}
+
+double QgsDecorationGrid::pixelFontSize( double pointSize ) const
+{
+  return ( pointSize * 0.3527 );
+}
+
+QFont QgsDecorationGrid::scaledFontPixelSize( const QFont& font ) const
+{
+  QFont scaledFont = font;
+  double pixelSize = pixelFontSize( font.pointSizeF() ) * FONT_WORKAROUND_SCALE + 0.5;
+  scaledFont.setPixelSize( pixelSize );
+  return scaledFont;
+}
+

--- a/src/app/qgsdecorationgrid.cpp
+++ b/src/app/qgsdecorationgrid.cpp
@@ -111,9 +111,19 @@ void QgsDecorationGrid::projectRead()
                             "/AnnotationPosition", 0 );
   mGridAnnotationDirection = ( GridAnnotationDirection ) QgsProject::instance()->readNumEntry( mNameConfig,
                              "/AnnotationDirection", 0 );
-  mGridAnnotationFont.fromString( QgsProject::instance()->readEntry( mNameConfig, "/AnnotationFont", "" ) );
+  QString fontStr = QgsProject::instance()->readEntry( mNameConfig, "/AnnotationFont", "" );
+  if ( fontStr != "" )
+  {
+    mGridAnnotationFont.fromString( fontStr );
+  }
+  else
+  {
+    mGridAnnotationFont = QFont();
+    // TODO fix font scaling problem - put a slightly large font for now
+    mGridAnnotationFont.setPointSize( 16 );
+  }
   mAnnotationFrameDistance = QgsProject::instance()->readDoubleEntry( mNameConfig, "/AnnotationFrameDistance", 0 );
-  mGridAnnotationPrecision = QgsProject::instance()->readNumEntry( mNameConfig, "/AnnotationPrecision", 3 );
+  mGridAnnotationPrecision = QgsProject::instance()->readNumEntry( mNameConfig, "/AnnotationPrecision", 0 );
 
   // read symbol info from xml
   QDomDocument doc;
@@ -715,7 +725,9 @@ double QgsDecorationGrid::fontAscentMillimeters( const QFont& font ) const
 
 double QgsDecorationGrid::pixelFontSize( double pointSize ) const
 {
-  return ( pointSize * 0.3527 );
+  // return ( pointSize * 0.3527 );
+  // TODO fix font scaling problem - this seems to help, but text seems still a bit too small (about 5/6)
+  return pointSize;
 }
 
 QFont QgsDecorationGrid::scaledFontPixelSize( const QFont& font ) const

--- a/src/app/qgsdecorationgrid.cpp
+++ b/src/app/qgsdecorationgrid.cpp
@@ -86,13 +86,13 @@ void QgsDecorationGrid::setMarkerSymbol( QgsMarkerSymbolV2* symbol )
 void QgsDecorationGrid::projectRead()
 {
   QgsDecorationItem::projectRead();
-  mGridStyle = ( GridStyle ) QgsProject::instance()->readNumEntry( mNameConfig, "/Style", 0 );
-  mGridIntervalX = QgsProject::instance()->readDoubleEntry( mNameConfig, "/IntervalX", 0 );
-  mGridIntervalY = QgsProject::instance()->readDoubleEntry( mNameConfig, "/IntervalY", 0 );
+  mGridStyle = ( GridStyle ) QgsProject::instance()->readNumEntry( mNameConfig, "/Style",
+               QgsDecorationGrid::Solid );
+  mGridIntervalX = QgsProject::instance()->readDoubleEntry( mNameConfig, "/IntervalX", 10 );
+  mGridIntervalY = QgsProject::instance()->readDoubleEntry( mNameConfig, "/IntervalY", 10 );
   mGridOffsetX = QgsProject::instance()->readDoubleEntry( mNameConfig, "/OffsetX", 0 );
   mGridOffsetY = QgsProject::instance()->readDoubleEntry( mNameConfig, "/OffsetY", 0 );
-  // missing mGridPen, but should use styles anyway
-  mCrossLength = QgsProject::instance()->readDoubleEntry( mNameConfig, "/CrossLength", 0 );
+  mCrossLength = QgsProject::instance()->readDoubleEntry( mNameConfig, "/CrossLength", 3 );
   mShowGridAnnotation = QgsProject::instance()->readBoolEntry( mNameConfig, "/ShowAnnotation", false );
   mGridAnnotationPosition = ( GridAnnotationPosition ) QgsProject::instance()->readNumEntry( mNameConfig, "/AnnotationPosition", 0 );
   mGridAnnotationDirection = ( GridAnnotationDirection ) QgsProject::instance()->readNumEntry( mNameConfig, "/AnnotationDirection", 0 );
@@ -104,6 +104,7 @@ void QgsDecorationGrid::projectRead()
   QDomDocument doc;
   QDomElement elem;
   QString xml;
+
   xml = QgsProject::instance()->readEntry( mNameConfig, "/LineSymbol" );
   if ( xml != "" )
   {
@@ -112,9 +113,10 @@ void QgsDecorationGrid::projectRead()
     if ( mLineSymbol )
       delete mLineSymbol;
     mLineSymbol = dynamic_cast<QgsLineSymbolV2*>( QgsSymbolLayerV2Utils::loadSymbol( elem ) );
-    if ( ! mLineSymbol )
-      mLineSymbol = new QgsLineSymbolV2();
   }
+  if ( ! mLineSymbol )
+    mLineSymbol = new QgsLineSymbolV2();
+
   xml = QgsProject::instance()->readEntry( mNameConfig, "/MarkerSymbol" );
   if ( xml != "" )
   {
@@ -123,10 +125,9 @@ void QgsDecorationGrid::projectRead()
     if ( mMarkerSymbol )
       delete mMarkerSymbol;
     mMarkerSymbol = dynamic_cast<QgsMarkerSymbolV2*>( QgsSymbolLayerV2Utils::loadSymbol( elem ) );
-    if ( ! mMarkerSymbol )
-      mMarkerSymbol = new QgsMarkerSymbolV2();
   }
-
+  if ( ! mMarkerSymbol )
+    mMarkerSymbol = new QgsMarkerSymbolV2();
 }
 
 void QgsDecorationGrid::saveToProject()

--- a/src/app/qgsdecorationgrid.h
+++ b/src/app/qgsdecorationgrid.h
@@ -21,6 +21,8 @@
 #include "qgsdecorationitem.h"
 
 class QPainter;
+class QgsLineSymbolV2;
+class QgsMarkerSymbolV2;
 
 #include <QColor>
 #include <QPen>
@@ -38,7 +40,8 @@ class QgsDecorationGrid: public QgsDecorationItem
     enum GridStyle
     {
       Solid = 0, //solid lines
-      Cross //only draw line crossings
+      Cross = 1, //only draw line crossings
+      Marker = 2 //user-defined marker
     };
 
     enum GridAnnotationPosition
@@ -126,6 +129,14 @@ class QgsDecorationGrid: public QgsDecorationItem
     void setCrossLength( double l ) {mCrossLength = l;}
     double crossLength() {return mCrossLength;}
 
+    /**Set symbol that is used to draw grid lines. Takes ownership*/
+    void setLineSymbol( QgsLineSymbolV2* symbol );
+    const QgsLineSymbolV2* lineSymbol() const { return mLineSymbol; }
+
+    /**Set symbol that is used to draw markers. Takes ownership*/
+    void setMarkerSymbol( QgsMarkerSymbolV2* symbol );
+    const QgsMarkerSymbolV2* markerSymbol() const { return mMarkerSymbol; }
+
   public slots:
     //! set values on the gui when a project is read or the gui first loaded
     void projectRead();
@@ -174,6 +185,9 @@ class QgsDecorationGrid: public QgsDecorationItem
     GridAnnotationDirection mGridAnnotationDirection;
     /**The length of the cross sides for mGridStyle Cross*/
     double mCrossLength;
+
+    QgsLineSymbolV2* mLineSymbol;
+    QgsMarkerSymbolV2* mMarkerSymbol;
 
     /**Draw coordinates for mGridAnnotationType Coordinate
         @param p drawing painter

--- a/src/app/qgsdecorationgrid.h
+++ b/src/app/qgsdecorationgrid.h
@@ -18,14 +18,15 @@
 #ifndef QGSDECORATIONGRID_H
 #define QGSDECORATIONGRID_H
 
+#include "qgsdecorationitem.h"
+
 class QPainter;
 
 #include <QColor>
-#include <QObject>
 #include <QPen>
 #include <QFont>
 
-class QgsDecorationGrid: public QObject
+class QgsDecorationGrid: public QgsDecorationItem
 {
     Q_OBJECT
   public:
@@ -53,11 +54,6 @@ class QgsDecorationGrid: public QObject
       HorizontalAndVertical,
       BoundaryDirection
     };
-
-    /**Enables a coordinate grid that is shown on top of this composermap.
-        @note this function was added in version 1.4*/
-    void setGridEnabled( bool enabled ) {mGridEnabled = enabled;}
-    bool gridEnabled() const { return mGridEnabled; }
 
     /**Sets coordinate grid style to solid or cross
         @note this function was added in version 1.4*/
@@ -130,8 +126,6 @@ class QgsDecorationGrid: public QObject
     void setCrossLength( double l ) {mCrossLength = l;}
     double crossLength() {return mCrossLength;}
 
-    void update();
-
   public slots:
     //! set values on the gui when a project is read or the gui first loaded
     void projectRead();
@@ -139,7 +133,7 @@ class QgsDecorationGrid: public QObject
     void saveToProject();
 
     //! this does the meaty bit of the work
-    void renderGrid( QPainter * );
+    void render( QPainter * );
     //! Show the dialog box
     void run();
 
@@ -154,8 +148,6 @@ class QgsDecorationGrid: public QObject
       Top
     };
 
-    /**True if coordinate grid has to be displayed*/
-    bool mGridEnabled;
     /**Solid or crosses*/
     GridStyle mGridStyle;
     /**Grid line interval in x-direction (map units)*/

--- a/src/app/qgsdecorationgrid.h
+++ b/src/app/qgsdecorationgrid.h
@@ -19,6 +19,7 @@
 #define QGSDECORATIONGRID_H
 
 #include "qgsdecorationitem.h"
+#include <qgis.h>
 
 class QPainter;
 class QgsLineSymbolV2;
@@ -87,38 +88,31 @@ class QgsDecorationGrid: public QgsDecorationItem
     /**Sets the color of the grid pen */
     void setGridPenColor( const QColor& c ) {  mGridPen.setColor( c ); }
 
-    /**Sets font for grid annotations
-    @note this function was added in version 1.4*/
+    /**Sets font for grid annotations */
     void setGridAnnotationFont( const QFont& f ) { mGridAnnotationFont = f; }
     QFont gridAnnotationFont() const { return mGridAnnotationFont; }
 
-    /**Sets coordinate precision for grid annotations
-    @note this function was added in version 1.4*/
+    /**Sets coordinate precision for grid annotations */
     void setGridAnnotationPrecision( int p ) {mGridAnnotationPrecision = p;}
     int gridAnnotationPrecision() const {return mGridAnnotationPrecision;}
 
-    /**Sets flag if grid annotation should be shown
-    @note this function was added in version 1.4*/
+    /**Sets flag if grid annotation should be shown */
     void setShowGridAnnotation( bool show ) {mShowGridAnnotation = show;}
     bool showGridAnnotation() const {return mShowGridAnnotation;}
 
-    /**Sets position of grid annotations. Possibilities are inside or outside of the map frame
-    @note this function was added in version 1.4*/
+    /**Sets position of grid annotations. Possibilities are inside or outside of the map frame */
     void setGridAnnotationPosition( GridAnnotationPosition p ) {mGridAnnotationPosition = p;}
     GridAnnotationPosition gridAnnotationPosition() const {return mGridAnnotationPosition;}
 
-    /**Sets distance between map frame and annotations
-    @note this function was added in version 1.4*/
+    /**Sets distance between map frame and annotations */
     void setAnnotationFrameDistance( double d ) {mAnnotationFrameDistance = d;}
     double annotationFrameDistance() const {return mAnnotationFrameDistance;}
 
-    /**Sets grid annotation direction. Can be horizontal, vertical, direction of axis and horizontal and vertical
-    @note this function was added in version 1.4*/
+    /**Sets grid annotation direction. Can be horizontal, vertical, direction of axis and horizontal and vertical */
     void setGridAnnotationDirection( GridAnnotationDirection d ) {mGridAnnotationDirection = d;}
     GridAnnotationDirection gridAnnotationDirection() const {return mGridAnnotationDirection;}
 
-    /**Sets length of the cros segments (if grid style is cross)
-    @note this function was added in version 1.4*/
+    /**Sets length of the cros segments (if grid style is cross) */
     void setCrossLength( double l ) {mCrossLength = l;}
     double crossLength() {return mCrossLength;}
 
@@ -130,6 +124,21 @@ class QgsDecorationGrid: public QgsDecorationItem
     void setMarkerSymbol( QgsMarkerSymbolV2* symbol );
     const QgsMarkerSymbolV2* markerSymbol() const { return mMarkerSymbol; }
 
+    /**Sets map unit type */
+    void setMapUnits( QGis::UnitType t ) { mMapUnits = t; }
+    QGis::UnitType mapUnits() { return mMapUnits; }
+
+    /**Set mapUnits value */
+    void setDirty( bool dirty = true );
+    bool isDirty();
+
+    /**Computes interval that is approx. 1/5 of canvas extent */
+    bool getIntervalFromExtent( double* values, bool useXAxis = true );
+    /**Computes interval from current raster layer */
+    bool getIntervalFromCurrentLayer( double* values );
+
+    double getDefaultInterval( bool useXAxis = true );
+
   public slots:
     //! set values on the gui when a project is read or the gui first loaded
     void projectRead();
@@ -140,6 +149,9 @@ class QgsDecorationGrid: public QgsDecorationItem
     void render( QPainter * );
     //! Show the dialog box
     void run();
+
+    //! check that map units changed and disable if necessary
+    void checkMapUnitsChanged();
 
   private:
 
@@ -181,6 +193,8 @@ class QgsDecorationGrid: public QgsDecorationItem
 
     QgsLineSymbolV2* mLineSymbol;
     QgsMarkerSymbolV2* mMarkerSymbol;
+
+    QGis::UnitType mMapUnits;
 
     /**Draw coordinates for mGridAnnotationType Coordinate
         @param p drawing painter

--- a/src/app/qgsdecorationgrid.h
+++ b/src/app/qgsdecorationgrid.h
@@ -58,40 +58,33 @@ class QgsDecorationGrid: public QgsDecorationItem
       BoundaryDirection
     };
 
-    /**Sets coordinate grid style to solid or cross
-        @note this function was added in version 1.4*/
+    /**Sets coordinate grid style.
+    @note this function (and all others) was added in version 2.0 */
     void setGridStyle( GridStyle style ) {mGridStyle = style;}
     GridStyle gridStyle() const { return mGridStyle; }
 
-    /**Sets coordinate interval in x-direction for composergrid.
-        @note this function was added in version 1.4*/
+    /**Sets coordinate interval in x-direction for composergrid. */
     void setGridIntervalX( double interval ) { mGridIntervalX = interval;}
     double gridIntervalX() const { return mGridIntervalX; }
 
-    /**Sets coordinate interval in y-direction for composergrid.
-    @note this function was added in version 1.4*/
+    /**Sets coordinate interval in y-direction for composergrid. */
     void setGridIntervalY( double interval ) { mGridIntervalY = interval;}
     double gridIntervalY() const { return mGridIntervalY; }
 
-    /**Sets x-coordinate offset for composer grid
-    @note this function was added in version 1.4*/
+    /**Sets x-coordinate offset for composer grid */
     void setGridOffsetX( double offset ) { mGridOffsetX = offset; }
     double gridOffsetX() const { return mGridOffsetX; }
 
-    /**Sets y-coordinate offset for composer grid
-    @note this function was added in version 1.4*/
+    /**Sets y-coordinate offset for composer grid */
     void setGridOffsetY( double offset ) { mGridOffsetY = offset; }
     double gridOffsetY() const { return mGridOffsetY; }
 
-    /**Sets the pen to draw composer grid
-    @note this function was added in version 1.4*/
+    /**Sets the pen to draw composer grid */
     void setGridPen( const QPen& p ) { mGridPen = p; }
     QPen gridPen() const { return mGridPen; }
-    /**Sets with of grid pen
-    @note this function was added in version 1.4*/
+    /**Sets with of grid pen */
     void setGridPenWidth( double w ) { mGridPen.setWidthF( w ); }
-    /**Sets the color of the grid pen
-    @note this function was added in version 1.4*/
+    /**Sets the color of the grid pen */
     void setGridPenColor( const QColor& c ) {  mGridPen.setColor( c ); }
 
     /**Sets font for grid annotations
@@ -217,8 +210,7 @@ class QgsDecorationGrid: public QgsDecorationItem
     void drawText( QPainter* p, const QRectF& rect, const QString& text, const QFont& font, Qt::AlignmentFlag halignement = Qt::AlignLeft, Qt::AlignmentFlag valignement = Qt::AlignTop ) const;
     /**Returns the font width in millimeters (considers upscaling and downscaling with FONT_WORKAROUND_SCALE*/
     double textWidthMillimeters( const QFont& font, const QString& text ) const;
-    /**Returns the font height of a character in millimeters
-      @note this method was added in version 1.7*/
+    /**Returns the font height of a character in millimeters. */
     double fontHeightCharacterMM( const QFont& font, const QChar& c ) const;
     /**Returns the font ascent in Millimeters (considers upscaling and downscaling with FONT_WORKAROUND_SCALE*/
     double fontAscentMillimeters( const QFont& font ) const;

--- a/src/app/qgsdecorationgrid.h
+++ b/src/app/qgsdecorationgrid.h
@@ -1,0 +1,227 @@
+/***************************************************************************
+                         qgsdecorationgrid.h
+                         ----------------------
+    begin                : May 10, 2012
+    copyright            : (C) 2012 by Etienne Tourigny
+    email                : etourigny.dev at gmail dot com
+
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSDECORATIONGRID_H
+#define QGSDECORATIONGRID_H
+
+class QPainter;
+
+#include <QColor>
+#include <QObject>
+#include <QPen>
+#include <QFont>
+
+class QgsDecorationGrid: public QObject
+{
+    Q_OBJECT
+  public:
+    //! Constructor
+    QgsDecorationGrid( QObject* parent = NULL );
+    //! Destructor
+    virtual ~ QgsDecorationGrid();
+
+    enum GridStyle
+    {
+      Solid = 0, //solid lines
+      Cross //only draw line crossings
+    };
+
+    enum GridAnnotationPosition
+    {
+      InsideMapFrame = 0,
+      OutsideMapFrame
+    };
+
+    enum GridAnnotationDirection
+    {
+      Horizontal = 0,
+      Vertical,
+      HorizontalAndVertical,
+      BoundaryDirection
+    };
+
+    /**Enables a coordinate grid that is shown on top of this composermap.
+        @note this function was added in version 1.4*/
+    void setGridEnabled( bool enabled ) {mGridEnabled = enabled;}
+    bool gridEnabled() const { return mGridEnabled; }
+
+    /**Sets coordinate grid style to solid or cross
+        @note this function was added in version 1.4*/
+    void setGridStyle( GridStyle style ) {mGridStyle = style;}
+    GridStyle gridStyle() const { return mGridStyle; }
+
+    /**Sets coordinate interval in x-direction for composergrid.
+        @note this function was added in version 1.4*/
+    void setGridIntervalX( double interval ) { mGridIntervalX = interval;}
+    double gridIntervalX() const { return mGridIntervalX; }
+
+    /**Sets coordinate interval in y-direction for composergrid.
+    @note this function was added in version 1.4*/
+    void setGridIntervalY( double interval ) { mGridIntervalY = interval;}
+    double gridIntervalY() const { return mGridIntervalY; }
+
+    /**Sets x-coordinate offset for composer grid
+    @note this function was added in version 1.4*/
+    void setGridOffsetX( double offset ) { mGridOffsetX = offset; }
+    double gridOffsetX() const { return mGridOffsetX; }
+
+    /**Sets y-coordinate offset for composer grid
+    @note this function was added in version 1.4*/
+    void setGridOffsetY( double offset ) { mGridOffsetY = offset; }
+    double gridOffsetY() const { return mGridOffsetY; }
+
+    /**Sets the pen to draw composer grid
+    @note this function was added in version 1.4*/
+    void setGridPen( const QPen& p ) { mGridPen = p; }
+    QPen gridPen() const { return mGridPen; }
+    /**Sets with of grid pen
+    @note this function was added in version 1.4*/
+    void setGridPenWidth( double w ) { mGridPen.setWidthF( w ); }
+    /**Sets the color of the grid pen
+    @note this function was added in version 1.4*/
+    void setGridPenColor( const QColor& c ) {  mGridPen.setColor( c ); }
+
+    /**Sets font for grid annotations
+    @note this function was added in version 1.4*/
+    void setGridAnnotationFont( const QFont& f ) { mGridAnnotationFont = f; }
+    QFont gridAnnotationFont() const { return mGridAnnotationFont; }
+
+    /**Sets coordinate precision for grid annotations
+    @note this function was added in version 1.4*/
+    void setGridAnnotationPrecision( int p ) {mGridAnnotationPrecision = p;}
+    int gridAnnotationPrecision() const {return mGridAnnotationPrecision;}
+
+    /**Sets flag if grid annotation should be shown
+    @note this function was added in version 1.4*/
+    void setShowGridAnnotation( bool show ) {mShowGridAnnotation = show;}
+    bool showGridAnnotation() const {return mShowGridAnnotation;}
+
+    /**Sets position of grid annotations. Possibilities are inside or outside of the map frame
+    @note this function was added in version 1.4*/
+    void setGridAnnotationPosition( GridAnnotationPosition p ) {mGridAnnotationPosition = p;}
+    GridAnnotationPosition gridAnnotationPosition() const {return mGridAnnotationPosition;}
+
+    /**Sets distance between map frame and annotations
+    @note this function was added in version 1.4*/
+    void setAnnotationFrameDistance( double d ) {mAnnotationFrameDistance = d;}
+    double annotationFrameDistance() const {return mAnnotationFrameDistance;}
+
+    /**Sets grid annotation direction. Can be horizontal, vertical, direction of axis and horizontal and vertical
+    @note this function was added in version 1.4*/
+    void setGridAnnotationDirection( GridAnnotationDirection d ) {mGridAnnotationDirection = d;}
+    GridAnnotationDirection gridAnnotationDirection() const {return mGridAnnotationDirection;}
+
+    /**Sets length of the cros segments (if grid style is cross)
+    @note this function was added in version 1.4*/
+    void setCrossLength( double l ) {mCrossLength = l;}
+    double crossLength() {return mCrossLength;}
+
+    void update();
+
+  public slots:
+    //! set values on the gui when a project is read or the gui first loaded
+    void projectRead();
+    //! save values to the project
+    void saveToProject();
+
+    //! this does the meaty bit of the work
+    void renderGrid( QPainter * );
+    //! Show the dialog box
+    void run();
+
+  private:
+
+    /**Enum for different frame borders*/
+    enum Border
+    {
+      Left,
+      Right,
+      Bottom,
+      Top
+    };
+
+    /**True if coordinate grid has to be displayed*/
+    bool mGridEnabled;
+    /**Solid or crosses*/
+    GridStyle mGridStyle;
+    /**Grid line interval in x-direction (map units)*/
+    double mGridIntervalX;
+    /**Grid line interval in y-direction (map units)*/
+    double mGridIntervalY;
+    /**Grid line offset in x-direction*/
+    double mGridOffsetX;
+    /**Grid line offset in y-direction*/
+    double mGridOffsetY;
+    /**Grid line pen*/
+    QPen mGridPen;
+    /**Font for grid line annotation*/
+    QFont mGridAnnotationFont;
+    /**Digits after the dot*/
+    int mGridAnnotationPrecision;
+    /**True if coordinate values should be drawn*/
+    bool mShowGridAnnotation;
+    /**Annotation position inside or outside of map frame*/
+    GridAnnotationPosition mGridAnnotationPosition;
+    /**Distance between map frame and annotation*/
+    double mAnnotationFrameDistance;
+    /**Annotation can be horizontal / vertical or different for axes*/
+    GridAnnotationDirection mGridAnnotationDirection;
+    /**The length of the cross sides for mGridStyle Cross*/
+    double mCrossLength;
+
+    /**Draw coordinates for mGridAnnotationType Coordinate
+        @param p drawing painter
+    @param hLines horizontal coordinate lines in item coordinates
+        @param vLines vertical coordinate lines in item coordinates*/
+    void drawCoordinateAnnotations( QPainter* p, const QList< QPair< double, QLineF > >& hLines, const QList< QPair< double, QLineF > >& vLines );
+    void drawCoordinateAnnotation( QPainter* p, const QPointF& pos, QString annotationString );
+    /**Draws a single annotation
+        @param p drawing painter
+        @param pos item coordinates where to draw
+        @param rotation text rotation
+        @param annotationText the text to draw*/
+    void drawAnnotation( QPainter* p, const QPointF& pos, int rotation, const QString& annotationText );
+    /**Returns the grid lines with associated coordinate value
+        @return 0 in case of success*/
+    int xGridLines( QList< QPair< double, QLineF > >& lines, QPainter* p ) const;
+    /**Returns the grid lines for the y-coordinates. Not vertical in case of rotation
+        @return 0 in case of success*/
+    int yGridLines( QList< QPair< double, QLineF > >& lines, QPainter* p ) const;
+    /**Returns the item border of a point (in item coordinates)*/
+    Border borderForLineCoord( const QPointF& point, QPainter* p ) const;
+
+    /**Draws Text. Takes care about all the composer specific issues (calculation to pixel, scaling of font and painter
+     to work around the Qt font bug)*/
+    void drawText( QPainter* p, double x, double y, const QString& text, const QFont& font ) const;
+    /**Like the above, but with a rectangle for multiline text*/
+    void drawText( QPainter* p, const QRectF& rect, const QString& text, const QFont& font, Qt::AlignmentFlag halignement = Qt::AlignLeft, Qt::AlignmentFlag valignement = Qt::AlignTop ) const;
+    /**Returns the font width in millimeters (considers upscaling and downscaling with FONT_WORKAROUND_SCALE*/
+    double textWidthMillimeters( const QFont& font, const QString& text ) const;
+    /**Returns the font height of a character in millimeters
+      @note this method was added in version 1.7*/
+    double fontHeightCharacterMM( const QFont& font, const QChar& c ) const;
+    /**Returns the font ascent in Millimeters (considers upscaling and downscaling with FONT_WORKAROUND_SCALE*/
+    double fontAscentMillimeters( const QFont& font ) const;
+    /**Calculates font to from point size to pixel size*/
+    double pixelFontSize( double pointSize ) const;
+    /**Returns a font where size is in pixel and font size is upscaled with FONT_WORKAROUND_SCALE*/
+    QFont scaledFontPixelSize( const QFont& font ) const;
+
+    /* friend class QgsDecorationGridDialog; */
+};
+
+#endif

--- a/src/app/qgsdecorationgrid.h
+++ b/src/app/qgsdecorationgrid.h
@@ -40,9 +40,9 @@ class QgsDecorationGrid: public QgsDecorationItem
 
     enum GridStyle
     {
-      Solid = 0, //solid lines
-      Cross = 1, //only draw line crossings
-      Marker = 2 //user-defined marker
+      Line = 0, //solid lines
+      //      Cross = 1, //only draw line crossings
+      Marker = 1 //user-defined marker
     };
 
     enum GridAnnotationPosition
@@ -113,8 +113,8 @@ class QgsDecorationGrid: public QgsDecorationItem
     GridAnnotationDirection gridAnnotationDirection() const {return mGridAnnotationDirection;}
 
     /**Sets length of the cros segments (if grid style is cross) */
-    void setCrossLength( double l ) {mCrossLength = l;}
-    double crossLength() {return mCrossLength;}
+    /* void setCrossLength( double l ) {mCrossLength = l;} */
+    /* double crossLength() {return mCrossLength;} */
 
     /**Set symbol that is used to draw grid lines. Takes ownership*/
     void setLineSymbol( QgsLineSymbolV2* symbol );
@@ -164,7 +164,7 @@ class QgsDecorationGrid: public QgsDecorationItem
       Top
     };
 
-    /**Solid or crosses*/
+    /** Line or Symbol */
     GridStyle mGridStyle;
     /**Grid line interval in x-direction (map units)*/
     double mGridIntervalX;
@@ -189,7 +189,7 @@ class QgsDecorationGrid: public QgsDecorationItem
     /**Annotation can be horizontal / vertical or different for axes*/
     GridAnnotationDirection mGridAnnotationDirection;
     /**The length of the cross sides for mGridStyle Cross*/
-    double mCrossLength;
+    /* double mCrossLength; */
 
     QgsLineSymbolV2* mLineSymbol;
     QgsMarkerSymbolV2* mMarkerSymbol;

--- a/src/app/qgsdecorationgriddialog.cpp
+++ b/src/app/qgsdecorationgriddialog.cpp
@@ -1,0 +1,313 @@
+/***************************************************************************
+                         qgsdecorationgriddialog.cpp
+                         ----------------------
+    begin                : May 10, 2012
+    copyright            : (C) 2012 by Etienne Tourigny
+    email                : etourigny.dev at gmail dot com
+
+ ***************************************************************************/
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsdecorationgriddialog.h"
+
+#include "qgsdecorationgrid.h"
+
+#include "qgslogger.h"
+#include "qgscontexthelp.h"
+#include "qgsstylev2.h"
+#include "qgssymbolv2.h"
+#include "qgssymbolv2selectordialog.h"
+#include "qgssymbolv2propertiesdialog.h"
+
+#include <QFontDialog>
+#include <QColorDialog>
+#include <QSettings>
+
+QgsDecorationGridDialog::QgsDecorationGridDialog( QgsDecorationGrid& deco, QWidget* parent )
+  : QDialog( parent ), mDeco( deco ), mLineSymbol( 0 ), mMarkerSymbol( 0 )
+{
+  setupUi( this );
+
+  QSettings settings;
+  restoreGeometry( settings.value( "/Windows/DecorationGrid/geometry" ).toByteArray() );
+
+  chkEnable->setChecked( mDeco.enabled() );
+
+  // mXMinLineEdit->setValidator( new QDoubleValidator( mXMinLineEdit ) );
+
+  mGridTypeComboBox->insertItem( 0, tr( "Solid" ) );
+  mGridTypeComboBox->insertItem( 1, tr( "Cross" ) );
+  mGridTypeComboBox->insertItem( 2, tr( "Marker" ) );
+
+  mAnnotationPositionComboBox->insertItem( 0, tr( "Inside frame" ) );
+  // mAnnotationPositionComboBox->insertItem( 1, tr( "Outside frame" ) );
+
+  mAnnotationDirectionComboBox->insertItem( 0, tr( "Horizontal" ) );
+  mAnnotationDirectionComboBox->insertItem( 1, tr( "Vertical" ) );
+  mAnnotationDirectionComboBox->insertItem( 2, tr( "Horizontal and Vertical" ) );
+  mAnnotationDirectionComboBox->insertItem( 2, tr( "Boundary direction" ) );
+
+  updateGuiElements();
+
+  connect( buttonBox->button( QDialogButtonBox::Apply ), SIGNAL( clicked() ), this, SLOT( apply() ) );
+
+}
+
+void QgsDecorationGridDialog::updateGuiElements()
+{
+  // blockAllSignals( true );
+
+  chkEnable->setChecked( mDeco.enabled() );
+
+  mIntervalXSpinBox->setValue( mDeco.gridIntervalX() );
+  mIntervalYSpinBox->setValue( mDeco.gridIntervalY() );
+  mOffsetXSpinBox->setValue( mDeco.gridOffsetX() );
+  mOffsetYSpinBox->setValue( mDeco.gridOffsetY() );
+
+  QgsDecorationGrid::GridStyle gridStyle = mDeco.gridStyle();
+  if ( gridStyle == QgsDecorationGrid::Cross )
+  {
+    mGridTypeComboBox->setCurrentIndex( mGridTypeComboBox->findText( tr( "Cross" ) ) );
+  }
+  else if ( gridStyle == QgsDecorationGrid::Marker )
+  {
+    mGridTypeComboBox->setCurrentIndex( mGridTypeComboBox->findText( tr( "Marker" ) ) );
+  }
+  else
+  {
+    mGridTypeComboBox->setCurrentIndex( mGridTypeComboBox->findText( tr( "Solid" ) ) );
+  }
+  
+  mCrossWidthSpinBox->setValue( mDeco.crossLength() );
+
+  QgsDecorationGrid::GridAnnotationPosition annotationPos = mDeco.gridAnnotationPosition();
+  if ( annotationPos == QgsDecorationGrid::InsideMapFrame )
+  {
+    mAnnotationPositionComboBox->setCurrentIndex( mAnnotationPositionComboBox->findText( tr( "Inside frame" ) ) );
+  }
+  else
+  {
+    mAnnotationPositionComboBox->setCurrentIndex( mAnnotationPositionComboBox->findText( tr( "Outside frame" ) ) );
+  }
+  
+  mDrawAnnotationCheckBox->setChecked( mDeco.showGridAnnotation() );
+  
+  QgsDecorationGrid::GridAnnotationDirection dir = mDeco.gridAnnotationDirection();
+  if ( dir == QgsDecorationGrid::Horizontal )
+  {
+    mAnnotationDirectionComboBox->setCurrentIndex( mAnnotationDirectionComboBox->findText( tr( "Horizontal" ) ) );
+  }
+  else if ( dir == QgsDecorationGrid::Vertical )
+  {
+    mAnnotationDirectionComboBox->setCurrentIndex( mAnnotationDirectionComboBox->findText( tr( "Vertical" ) ) );
+    }
+  else if ( dir == QgsDecorationGrid::HorizontalAndVertical )
+  {
+    mAnnotationDirectionComboBox->setCurrentIndex( mAnnotationDirectionComboBox->findText( tr( "Horizontal and Vertical" ) ) );
+  }
+  else //BoundaryDirection
+  {
+    mAnnotationDirectionComboBox->setCurrentIndex( mAnnotationDirectionComboBox->findText( tr( "Boundary direction" ) ) );
+  }
+  
+  mCoordinatePrecisionSpinBox->setValue( mDeco.gridAnnotationPrecision() );
+
+  // QPen gridPen = mDeco.gridPen();
+  // mLineWidthSpinBox->setValue( gridPen.widthF() );
+  // mLineColorButton->setColor( gridPen.color() );
+
+  if ( mLineSymbol )
+    delete mLineSymbol;
+  if ( mDeco.lineSymbol() )
+  {
+    mLineSymbol = dynamic_cast<QgsLineSymbolV2*>( mDeco.lineSymbol()->clone() );
+    QIcon icon = QgsSymbolLayerV2Utils::symbolPreviewIcon( mLineSymbol, mLineSymbolButton->iconSize() );
+    mLineSymbolButton->setIcon( icon );
+  }
+
+  if ( mMarkerSymbol )
+    delete mMarkerSymbol;
+  if ( mDeco.markerSymbol() )
+  {
+    mMarkerSymbol = dynamic_cast<QgsMarkerSymbolV2*>( mDeco.markerSymbol()->clone() );
+    QIcon icon = QgsSymbolLayerV2Utils::symbolPreviewIcon( mMarkerSymbol, mMarkerSymbolButton->iconSize() );
+    mMarkerSymbolButton->setIcon( icon );
+  }
+  
+  // blockAllSignals( false );
+}
+
+void QgsDecorationGridDialog::updateDecoFromGui()
+{
+  mDeco.setEnabled( chkEnable->isChecked() );
+
+  mDeco.setGridIntervalX( mIntervalXSpinBox->value() );
+  mDeco.setGridIntervalY( mIntervalYSpinBox->value() );
+  mDeco.setGridOffsetX( mOffsetXSpinBox->value() );
+  mDeco.setGridOffsetY( mOffsetYSpinBox->value() );
+  // mDeco.setGridPenWidth( mLineWidthSpinBox->value() );
+  if ( mGridTypeComboBox->currentText() == tr( "Cross" ) )
+  {
+    mDeco.setGridStyle( QgsDecorationGrid::Cross );
+  }
+  else if ( mGridTypeComboBox->currentText() == tr( "Marker" ) )
+  {
+    mDeco.setGridStyle( QgsDecorationGrid::Marker );
+  }
+  else
+  {
+    mDeco.setGridStyle( QgsDecorationGrid::Solid );
+  }
+  mDeco.setCrossLength( mCrossWidthSpinBox->value() );
+  mDeco.setAnnotationFrameDistance( mDistanceToMapFrameSpinBox->value() );
+  if ( mAnnotationPositionComboBox->currentText() == tr( "Inside frame" ) )
+  {
+    mDeco.setGridAnnotationPosition( QgsDecorationGrid::InsideMapFrame );
+  }
+  else
+  {
+    mDeco.setGridAnnotationPosition( QgsDecorationGrid::OutsideMapFrame );
+  }
+  mDeco.setShowGridAnnotation( mDrawAnnotationCheckBox->isChecked() );
+  QString text = mAnnotationDirectionComboBox->currentText();
+  if ( text == tr( "Horizontal" ) )
+  {
+    mDeco.setGridAnnotationDirection( QgsDecorationGrid::Horizontal );
+  }
+  else if ( text == tr( "Vertical" ) )
+  {
+    mDeco.setGridAnnotationDirection( QgsDecorationGrid::Vertical );
+  }
+  else if ( text == tr( "Horizontal and Vertical" ) )
+  {
+    mDeco.setGridAnnotationDirection( QgsDecorationGrid::HorizontalAndVertical );
+  }
+  else //BoundaryDirection
+  {
+    mDeco.setGridAnnotationDirection( QgsDecorationGrid::BoundaryDirection );
+  }
+  mDeco.setGridAnnotationPrecision( mCoordinatePrecisionSpinBox->value() );
+  if ( mLineSymbol )
+  {
+    mDeco.setLineSymbol( mLineSymbol ); 
+    mLineSymbol = dynamic_cast<QgsLineSymbolV2*>( mDeco.lineSymbol()->clone() );
+  }
+  if ( mMarkerSymbol )
+  {
+    mDeco.setMarkerSymbol( mMarkerSymbol ); 
+    mMarkerSymbol = dynamic_cast<QgsMarkerSymbolV2*>( mDeco.markerSymbol()->clone() );
+  }
+}
+
+QgsDecorationGridDialog::~QgsDecorationGridDialog()
+{
+  QSettings settings;
+  settings.setValue( "/Windows/DecorationGrid/geometry", saveGeometry() );
+  if ( mLineSymbol )
+    delete mLineSymbol;
+  if ( mMarkerSymbol )
+    delete mMarkerSymbol;
+}
+
+void QgsDecorationGridDialog::on_buttonBox_helpRequested()
+{
+  QgsContextHelp::run( metaObject()->className() );
+}
+
+void QgsDecorationGridDialog::on_buttonBox_accepted()
+{
+  updateDecoFromGui();
+  // mDeco.update();
+  accept();
+}
+
+void QgsDecorationGridDialog::apply()
+{
+  updateDecoFromGui();
+  mDeco.update();
+  //accept();  
+}
+
+void QgsDecorationGridDialog::on_buttonBox_rejected()
+{
+  reject();
+}
+
+
+// void QgsDecorationGridDialog::on_mLineColorButton_clicked()
+// {
+  // QColor newColor = QColorDialog::getColor( mLineColorButton->color() );
+  // if ( newColor.isValid() )
+  // {
+  //   mLineColorButton->setColor( newColor );
+  //   mDeco.setGridPenColor( newColor );
+  // }
+// }
+
+void QgsDecorationGridDialog::on_mLineSymbolButton_clicked()
+{
+  if ( ! mLineSymbol )
+    return;
+
+  QgsLineSymbolV2* lineSymbol = dynamic_cast<QgsLineSymbolV2*>( mLineSymbol->clone() );
+  QgsSymbolV2PropertiesDialog dlg( lineSymbol, 0, this );
+  if ( dlg.exec() == QDialog::Rejected )
+  {
+    delete lineSymbol;
+  }
+  else
+  {
+    delete mLineSymbol;
+    mLineSymbol = lineSymbol;
+    if ( mLineSymbol )
+    {
+      QIcon icon = QgsSymbolLayerV2Utils::symbolPreviewIcon( mLineSymbol, mLineSymbolButton->iconSize() );
+      mLineSymbolButton->setIcon( icon );
+    }
+  }
+}
+
+void QgsDecorationGridDialog::on_mMarkerSymbolButton_clicked()
+{
+  if ( ! mMarkerSymbol )
+    return;
+
+  QgsMarkerSymbolV2* markerSymbol = dynamic_cast<QgsMarkerSymbolV2*>( mMarkerSymbol->clone() );
+  QgsSymbolV2PropertiesDialog dlg( markerSymbol, 0, this );
+  if ( dlg.exec() == QDialog::Rejected )
+  {
+    delete markerSymbol;
+  }
+  else
+  {
+    delete mMarkerSymbol;
+    mMarkerSymbol = markerSymbol;
+    if ( mMarkerSymbol )
+    {
+      QIcon icon = QgsSymbolLayerV2Utils::symbolPreviewIcon( mMarkerSymbol, mMarkerSymbolButton->iconSize() );
+      mMarkerSymbolButton->setIcon( icon );
+    }
+  }
+}
+
+void QgsDecorationGridDialog::on_mAnnotationFontButton_clicked()
+{
+  bool ok;
+#if defined(Q_WS_MAC) && QT_VERSION >= 0x040500 && defined(QT_MAC_USE_COCOA)
+  // Native Mac dialog works only for Qt Carbon
+  QFont newFont = QFontDialog::getFont( &ok, mDeco.gridAnnotationFont(), this, QString(), QFontDialog::DontUseNativeDialog );
+#else
+  QFont newFont = QFontDialog::getFont( &ok, mDeco.gridAnnotationFont() );
+#endif
+  if ( ok )
+  {
+    mDeco.setGridAnnotationFont( newFont );
+  }
+}

--- a/src/app/qgsdecorationgriddialog.cpp
+++ b/src/app/qgsdecorationgriddialog.cpp
@@ -71,14 +71,12 @@ void QgsDecorationGridDialog::updateGuiElements()
 
   chkEnable->setChecked( mDeco.enabled() );
 
-  mIntervalXSpinBox->setValue( mDeco.gridIntervalX() );
-  mIntervalYSpinBox->setValue( mDeco.gridIntervalY() );
-  mOffsetXSpinBox->setValue( mDeco.gridOffsetX() );
-  mOffsetYSpinBox->setValue( mDeco.gridOffsetY() );
+  mIntervalXEdit->setText( QString::number( mDeco.gridIntervalX() ) );
+  mIntervalYEdit->setText( QString::number( mDeco.gridIntervalY() ) );
+  mOffsetXEdit->setText( QString::number( mDeco.gridOffsetX() ) );
+  mOffsetYEdit->setText( QString::number( mDeco.gridOffsetY() ) );
 
   mGridTypeComboBox->setCurrentIndex(( int ) mDeco.gridStyle() );
-  // mCrossWidthSpinBox->setValue( mDeco.crossLength() );
-  // mAnnotationPositionComboBox->setCurrentIndex(( int ) mDeco.gridAnnotationPosition() );
   mDrawAnnotationCheckBox->setChecked( mDeco.showGridAnnotation() );
   mAnnotationDirectionComboBox->setCurrentIndex(( int ) mDeco.gridAnnotationDirection() );
   mCoordinatePrecisionSpinBox->setValue( mDeco.gridAnnotationPrecision() );
@@ -113,15 +111,11 @@ void QgsDecorationGridDialog::updateDecoFromGui()
 {
   mDeco.setDirty( false );
   mDeco.setEnabled( chkEnable->isChecked() );
-  mDeco.setGridIntervalX( mIntervalXSpinBox->value() );
-  mDeco.setGridIntervalY( mIntervalYSpinBox->value() );
-  mDeco.setGridOffsetX( mOffsetXSpinBox->value() );
-  mDeco.setGridOffsetY( mOffsetYSpinBox->value() );
-  // mDeco.setGridPenWidth( mLineWidthSpinBox->value() );
-  // if ( mGridTypeComboBox->currentText() == tr( "Cross" ) )
-  // {
-  //   mDeco.setGridStyle( QgsDecorationGrid::Cross );
-  // }
+
+  mDeco.setGridIntervalX( mIntervalXEdit->text().toDouble() );
+  mDeco.setGridIntervalY( mIntervalYEdit->text().toDouble() );
+  mDeco.setGridOffsetX( mOffsetXEdit->text().toDouble() );
+  mDeco.setGridOffsetY( mOffsetYEdit->text().toDouble() );
   if ( mGridTypeComboBox->currentText() == tr( "Marker" ) )
   {
     mDeco.setGridStyle( QgsDecorationGrid::Marker );
@@ -130,7 +124,6 @@ void QgsDecorationGridDialog::updateDecoFromGui()
   {
     mDeco.setGridStyle( QgsDecorationGrid::Line );
   }
-  // mDeco.setCrossLength( mCrossWidthSpinBox->value() );
   mDeco.setAnnotationFrameDistance( mDistanceToMapFrameSpinBox->value() );
   // if ( mAnnotationPositionComboBox->currentText() == tr( "Inside frame" ) )
   // {
@@ -205,17 +198,6 @@ void QgsDecorationGridDialog::on_buttonBox_rejected()
   reject();
 }
 
-
-// void QgsDecorationGridDialog::on_mLineColorButton_clicked()
-// {
-// QColor newColor = QColorDialog::getColor( mLineColorButton->color() );
-// if ( newColor.isValid() )
-// {
-//   mLineColorButton->setColor( newColor );
-//   mDeco.setGridPenColor( newColor );
-// }
-// }
-
 void QgsDecorationGridDialog::on_mGridTypeComboBox_currentIndexChanged( int index )
 {
   mLineSymbolButton->setEnabled( index == QgsDecorationGrid::Line );
@@ -231,7 +213,6 @@ void QgsDecorationGridDialog::on_mLineSymbolButton_clicked()
 
   QgsLineSymbolV2* lineSymbol = dynamic_cast<QgsLineSymbolV2*>( mLineSymbol->clone() );
   QgsSymbolV2PropertiesDialog dlg( lineSymbol, 0, this );
-  // QgsSymbolV2SelectorDialog dlg( lineSymbol, 0, this );
   if ( dlg.exec() == QDialog::Rejected )
   {
     delete lineSymbol;
@@ -255,7 +236,6 @@ void QgsDecorationGridDialog::on_mMarkerSymbolButton_clicked()
 
   QgsMarkerSymbolV2* markerSymbol = dynamic_cast<QgsMarkerSymbolV2*>( mMarkerSymbol->clone() );
   QgsSymbolV2PropertiesDialog dlg( markerSymbol, 0, this );
-  // QgsSymbolV2SelectorDialog dlg( markerSymbol, 0, this );
   if ( dlg.exec() == QDialog::Rejected )
   {
     delete markerSymbol;
@@ -282,10 +262,10 @@ void QgsDecorationGridDialog::on_mPbtnUpdateFromLayer_clicked()
   double values[4];
   if ( mDeco.getIntervalFromCurrentLayer( values ) )
   {
-    mIntervalXSpinBox->setValue( values[0] );
-    mIntervalYSpinBox->setValue( values[1] );
-    mOffsetXSpinBox->setValue( values[2] );
-    mOffsetYSpinBox->setValue( values[3] );
+    mIntervalXEdit->setText( QString::number( values[0] ) );
+    mIntervalYEdit->setText( QString::number( values[1] ) );
+    mOffsetXEdit->setText( QString::number( values[2] ) );
+    mOffsetYEdit->setText( QString::number( values[3] ) );
     if ( values[0] >= 1 )
       mCoordinatePrecisionSpinBox->setValue( 0 );
     else
@@ -315,10 +295,10 @@ void QgsDecorationGridDialog::updateInterval( bool force )
     double values[4];
     if ( mDeco.getIntervalFromExtent( values, true ) )
     {
-      mIntervalXSpinBox->setValue( values[0] );
-      mIntervalYSpinBox->setValue( values[1] );
-      mOffsetXSpinBox->setValue( values[2] );
-      mOffsetYSpinBox->setValue( values[3] );
+      mIntervalXEdit->setText( QString::number( values[0] ) );
+      mIntervalYEdit->setText( QString::number( values[1] ) );
+      mOffsetXEdit->setText( QString::number( values[2] ) );
+      mOffsetYEdit->setText( QString::number( values[3] ) );
       // also update coord. precision
       // if interval >= 1, set precision=0 because we have a rounded value
       // else set it to previous default of 3

--- a/src/app/qgsdecorationgriddialog.cpp
+++ b/src/app/qgsdecorationgriddialog.cpp
@@ -31,28 +31,32 @@
 #include <QSettings>
 
 QgsDecorationGridDialog::QgsDecorationGridDialog( QgsDecorationGrid& deco, QWidget* parent )
-  : QDialog( parent ), mDeco( deco ), mLineSymbol( 0 ), mMarkerSymbol( 0 )
+    : QDialog( parent ), mDeco( deco ), mLineSymbol( 0 ), mMarkerSymbol( 0 )
 {
   setupUi( this );
 
   QSettings settings;
-  restoreGeometry( settings.value( "/Windows/DecorationGrid/geometry" ).toByteArray() );
+  //  restoreGeometry( settings.value( "/Windows/DecorationGrid/geometry" ).toByteArray() );
 
   chkEnable->setChecked( mDeco.enabled() );
 
   // mXMinLineEdit->setValidator( new QDoubleValidator( mXMinLineEdit ) );
 
-  mGridTypeComboBox->insertItem( 0, tr( "Solid" ) );
-  mGridTypeComboBox->insertItem( 1, tr( "Cross" ) );
-  mGridTypeComboBox->insertItem( 2, tr( "Marker" ) );
+  mGridTypeComboBox->insertItem( QgsDecorationGrid::Solid, tr( "Lines" ) );
+  mGridTypeComboBox->insertItem( QgsDecorationGrid::Cross, tr( "Cross" ) );
+  mGridTypeComboBox->insertItem( QgsDecorationGrid::Marker, tr( "Marker" ) );
 
-  mAnnotationPositionComboBox->insertItem( 0, tr( "Inside frame" ) );
-  // mAnnotationPositionComboBox->insertItem( 1, tr( "Outside frame" ) );
+  mAnnotationPositionComboBox->insertItem( QgsDecorationGrid::InsideMapFrame, tr( "Inside frame" ) );
+  // mAnnotationPositionComboBox->insertItem( QgsDecorationGrid::OutsideMapFrame, tr( "Outside frame" ) );
 
-  mAnnotationDirectionComboBox->insertItem( 0, tr( "Horizontal" ) );
-  mAnnotationDirectionComboBox->insertItem( 1, tr( "Vertical" ) );
-  mAnnotationDirectionComboBox->insertItem( 2, tr( "Horizontal and Vertical" ) );
-  mAnnotationDirectionComboBox->insertItem( 2, tr( "Boundary direction" ) );
+  mAnnotationDirectionComboBox->insertItem( QgsDecorationGrid::Horizontal,
+      tr( "Horizontal" ) );
+  mAnnotationDirectionComboBox->insertItem( QgsDecorationGrid::Vertical,
+      tr( "Vertical" ) );
+  mAnnotationDirectionComboBox->insertItem( QgsDecorationGrid::HorizontalAndVertical,
+      tr( "Horizontal and Vertical" ) );
+  mAnnotationDirectionComboBox->insertItem( QgsDecorationGrid::BoundaryDirection,
+      tr( "Boundary direction" ) );
 
   updateGuiElements();
 
@@ -71,52 +75,16 @@ void QgsDecorationGridDialog::updateGuiElements()
   mOffsetXSpinBox->setValue( mDeco.gridOffsetX() );
   mOffsetYSpinBox->setValue( mDeco.gridOffsetY() );
 
-  QgsDecorationGrid::GridStyle gridStyle = mDeco.gridStyle();
-  if ( gridStyle == QgsDecorationGrid::Cross )
-  {
-    mGridTypeComboBox->setCurrentIndex( mGridTypeComboBox->findText( tr( "Cross" ) ) );
-  }
-  else if ( gridStyle == QgsDecorationGrid::Marker )
-  {
-    mGridTypeComboBox->setCurrentIndex( mGridTypeComboBox->findText( tr( "Marker" ) ) );
-  }
-  else
-  {
-    mGridTypeComboBox->setCurrentIndex( mGridTypeComboBox->findText( tr( "Solid" ) ) );
-  }
-  
+  mGridTypeComboBox->setCurrentIndex(( int ) mDeco.gridStyle() );
+
   mCrossWidthSpinBox->setValue( mDeco.crossLength() );
 
-  QgsDecorationGrid::GridAnnotationPosition annotationPos = mDeco.gridAnnotationPosition();
-  if ( annotationPos == QgsDecorationGrid::InsideMapFrame )
-  {
-    mAnnotationPositionComboBox->setCurrentIndex( mAnnotationPositionComboBox->findText( tr( "Inside frame" ) ) );
-  }
-  else
-  {
-    mAnnotationPositionComboBox->setCurrentIndex( mAnnotationPositionComboBox->findText( tr( "Outside frame" ) ) );
-  }
-  
+  mAnnotationPositionComboBox->setCurrentIndex(( int ) mDeco.gridAnnotationPosition() );
+
   mDrawAnnotationCheckBox->setChecked( mDeco.showGridAnnotation() );
-  
-  QgsDecorationGrid::GridAnnotationDirection dir = mDeco.gridAnnotationDirection();
-  if ( dir == QgsDecorationGrid::Horizontal )
-  {
-    mAnnotationDirectionComboBox->setCurrentIndex( mAnnotationDirectionComboBox->findText( tr( "Horizontal" ) ) );
-  }
-  else if ( dir == QgsDecorationGrid::Vertical )
-  {
-    mAnnotationDirectionComboBox->setCurrentIndex( mAnnotationDirectionComboBox->findText( tr( "Vertical" ) ) );
-    }
-  else if ( dir == QgsDecorationGrid::HorizontalAndVertical )
-  {
-    mAnnotationDirectionComboBox->setCurrentIndex( mAnnotationDirectionComboBox->findText( tr( "Horizontal and Vertical" ) ) );
-  }
-  else //BoundaryDirection
-  {
-    mAnnotationDirectionComboBox->setCurrentIndex( mAnnotationDirectionComboBox->findText( tr( "Boundary direction" ) ) );
-  }
-  
+
+  mAnnotationDirectionComboBox->setCurrentIndex(( int ) mDeco.gridAnnotationDirection() );
+
   mCoordinatePrecisionSpinBox->setValue( mDeco.gridAnnotationPrecision() );
 
   // QPen gridPen = mDeco.gridPen();
@@ -140,7 +108,7 @@ void QgsDecorationGridDialog::updateGuiElements()
     QIcon icon = QgsSymbolLayerV2Utils::symbolPreviewIcon( mMarkerSymbol, mMarkerSymbolButton->iconSize() );
     mMarkerSymbolButton->setIcon( icon );
   }
-  
+
   // blockAllSignals( false );
 }
 
@@ -196,12 +164,12 @@ void QgsDecorationGridDialog::updateDecoFromGui()
   mDeco.setGridAnnotationPrecision( mCoordinatePrecisionSpinBox->value() );
   if ( mLineSymbol )
   {
-    mDeco.setLineSymbol( mLineSymbol ); 
+    mDeco.setLineSymbol( mLineSymbol );
     mLineSymbol = dynamic_cast<QgsLineSymbolV2*>( mDeco.lineSymbol()->clone() );
   }
   if ( mMarkerSymbol )
   {
-    mDeco.setMarkerSymbol( mMarkerSymbol ); 
+    mDeco.setMarkerSymbol( mMarkerSymbol );
     mMarkerSymbol = dynamic_cast<QgsMarkerSymbolV2*>( mDeco.markerSymbol()->clone() );
   }
 }
@@ -232,7 +200,7 @@ void QgsDecorationGridDialog::apply()
 {
   updateDecoFromGui();
   mDeco.update();
-  //accept();  
+  //accept();
 }
 
 void QgsDecorationGridDialog::on_buttonBox_rejected()
@@ -243,13 +211,21 @@ void QgsDecorationGridDialog::on_buttonBox_rejected()
 
 // void QgsDecorationGridDialog::on_mLineColorButton_clicked()
 // {
-  // QColor newColor = QColorDialog::getColor( mLineColorButton->color() );
-  // if ( newColor.isValid() )
-  // {
-  //   mLineColorButton->setColor( newColor );
-  //   mDeco.setGridPenColor( newColor );
-  // }
+// QColor newColor = QColorDialog::getColor( mLineColorButton->color() );
+// if ( newColor.isValid() )
+// {
+//   mLineColorButton->setColor( newColor );
+//   mDeco.setGridPenColor( newColor );
 // }
+// }
+
+void QgsDecorationGridDialog::on_mGridTypeComboBox_currentIndexChanged( int index )
+{
+  mLineSymbolButton->setEnabled( index == QgsDecorationGrid::Solid );
+  mCrossWidthSpinBox->setEnabled( index == QgsDecorationGrid::Cross );
+  mMarkerSymbolButton->setEnabled( index == QgsDecorationGrid::Marker );
+}
+
 
 void QgsDecorationGridDialog::on_mLineSymbolButton_clicked()
 {

--- a/src/app/qgsdecorationgriddialog.cpp
+++ b/src/app/qgsdecorationgriddialog.cpp
@@ -284,6 +284,10 @@ void QgsDecorationGridDialog::on_mPbtnUpdateFromLayer_clicked()
     mIntervalYSpinBox->setValue( values[1] );
     mOffsetXSpinBox->setValue( values[2] );
     mOffsetYSpinBox->setValue( values[3] );
+    if ( values[0] >= 1 )
+      mCoordinatePrecisionSpinBox->setValue( 0 );
+    else
+      mCoordinatePrecisionSpinBox->setValue( 3 );
   }
 }
 
@@ -313,6 +317,13 @@ void QgsDecorationGridDialog::updateInterval( bool force )
       mIntervalYSpinBox->setValue( values[1] );
       mOffsetXSpinBox->setValue( values[2] );
       mOffsetYSpinBox->setValue( values[3] );
+      // also update coord. precision
+      // if interval >= 1, set precision=0 because we have a rounded value
+      // else set it to previous default of 3
+      if ( values[0] >= 1 )
+        mCoordinatePrecisionSpinBox->setValue( 0 );
+      else
+        mCoordinatePrecisionSpinBox->setValue( 3 );
     }
   }
 }

--- a/src/app/qgsdecorationgriddialog.cpp
+++ b/src/app/qgsdecorationgriddialog.cpp
@@ -43,11 +43,11 @@ QgsDecorationGridDialog::QgsDecorationGridDialog( QgsDecorationGrid& deco, QWidg
 
   // mXMinLineEdit->setValidator( new QDoubleValidator( mXMinLineEdit ) );
 
-  mGridTypeComboBox->insertItem( QgsDecorationGrid::Solid, tr( "Lines" ) );
-  mGridTypeComboBox->insertItem( QgsDecorationGrid::Cross, tr( "Cross" ) );
+  mGridTypeComboBox->insertItem( QgsDecorationGrid::Line, tr( "Line" ) );
+  // mGridTypeComboBox->insertItem( QgsDecorationGrid::Cross, tr( "Cross" ) );
   mGridTypeComboBox->insertItem( QgsDecorationGrid::Marker, tr( "Marker" ) );
 
-  mAnnotationPositionComboBox->insertItem( QgsDecorationGrid::InsideMapFrame, tr( "Inside frame" ) );
+  // mAnnotationPositionComboBox->insertItem( QgsDecorationGrid::InsideMapFrame, tr( "Inside frame" ) );
   // mAnnotationPositionComboBox->insertItem( QgsDecorationGrid::OutsideMapFrame, tr( "Outside frame" ) );
 
   mAnnotationDirectionComboBox->insertItem( QgsDecorationGrid::Horizontal,
@@ -77,8 +77,8 @@ void QgsDecorationGridDialog::updateGuiElements()
   mOffsetYSpinBox->setValue( mDeco.gridOffsetY() );
 
   mGridTypeComboBox->setCurrentIndex(( int ) mDeco.gridStyle() );
-  mCrossWidthSpinBox->setValue( mDeco.crossLength() );
-  mAnnotationPositionComboBox->setCurrentIndex(( int ) mDeco.gridAnnotationPosition() );
+  // mCrossWidthSpinBox->setValue( mDeco.crossLength() );
+  // mAnnotationPositionComboBox->setCurrentIndex(( int ) mDeco.gridAnnotationPosition() );
   mDrawAnnotationCheckBox->setChecked( mDeco.showGridAnnotation() );
   mAnnotationDirectionComboBox->setCurrentIndex(( int ) mDeco.gridAnnotationDirection() );
   mCoordinatePrecisionSpinBox->setValue( mDeco.gridAnnotationPrecision() );
@@ -118,28 +118,28 @@ void QgsDecorationGridDialog::updateDecoFromGui()
   mDeco.setGridOffsetX( mOffsetXSpinBox->value() );
   mDeco.setGridOffsetY( mOffsetYSpinBox->value() );
   // mDeco.setGridPenWidth( mLineWidthSpinBox->value() );
-  if ( mGridTypeComboBox->currentText() == tr( "Cross" ) )
-  {
-    mDeco.setGridStyle( QgsDecorationGrid::Cross );
-  }
-  else if ( mGridTypeComboBox->currentText() == tr( "Marker" ) )
+  // if ( mGridTypeComboBox->currentText() == tr( "Cross" ) )
+  // {
+  //   mDeco.setGridStyle( QgsDecorationGrid::Cross );
+  // }
+  if ( mGridTypeComboBox->currentText() == tr( "Marker" ) )
   {
     mDeco.setGridStyle( QgsDecorationGrid::Marker );
   }
-  else
+  else if ( mGridTypeComboBox->currentText() == tr( "Line" ) )
   {
-    mDeco.setGridStyle( QgsDecorationGrid::Solid );
+    mDeco.setGridStyle( QgsDecorationGrid::Line );
   }
-  mDeco.setCrossLength( mCrossWidthSpinBox->value() );
+  // mDeco.setCrossLength( mCrossWidthSpinBox->value() );
   mDeco.setAnnotationFrameDistance( mDistanceToMapFrameSpinBox->value() );
-  if ( mAnnotationPositionComboBox->currentText() == tr( "Inside frame" ) )
-  {
-    mDeco.setGridAnnotationPosition( QgsDecorationGrid::InsideMapFrame );
-  }
-  else
-  {
-    mDeco.setGridAnnotationPosition( QgsDecorationGrid::OutsideMapFrame );
-  }
+  // if ( mAnnotationPositionComboBox->currentText() == tr( "Inside frame" ) )
+  // {
+  //   mDeco.setGridAnnotationPosition( QgsDecorationGrid::InsideMapFrame );
+  // }
+  // else
+  // {
+  //   mDeco.setGridAnnotationPosition( QgsDecorationGrid::OutsideMapFrame );
+  // }
   mDeco.setShowGridAnnotation( mDrawAnnotationCheckBox->isChecked() );
   QString text = mAnnotationDirectionComboBox->currentText();
   if ( text == tr( "Horizontal" ) )
@@ -218,8 +218,8 @@ void QgsDecorationGridDialog::on_buttonBox_rejected()
 
 void QgsDecorationGridDialog::on_mGridTypeComboBox_currentIndexChanged( int index )
 {
-  mLineSymbolButton->setEnabled( index == QgsDecorationGrid::Solid );
-  mCrossWidthSpinBox->setEnabled( index == QgsDecorationGrid::Cross );
+  mLineSymbolButton->setEnabled( index == QgsDecorationGrid::Line );
+  // mCrossWidthSpinBox->setEnabled( index == QgsDecorationGrid::Cross );
   mMarkerSymbolButton->setEnabled( index == QgsDecorationGrid::Marker );
 }
 
@@ -231,6 +231,7 @@ void QgsDecorationGridDialog::on_mLineSymbolButton_clicked()
 
   QgsLineSymbolV2* lineSymbol = dynamic_cast<QgsLineSymbolV2*>( mLineSymbol->clone() );
   QgsSymbolV2PropertiesDialog dlg( lineSymbol, 0, this );
+  // QgsSymbolV2SelectorDialog dlg( lineSymbol, 0, this );
   if ( dlg.exec() == QDialog::Rejected )
   {
     delete lineSymbol;
@@ -254,6 +255,7 @@ void QgsDecorationGridDialog::on_mMarkerSymbolButton_clicked()
 
   QgsMarkerSymbolV2* markerSymbol = dynamic_cast<QgsMarkerSymbolV2*>( mMarkerSymbol->clone() );
   QgsSymbolV2PropertiesDialog dlg( markerSymbol, 0, this );
+  // QgsSymbolV2SelectorDialog dlg( markerSymbol, 0, this );
   if ( dlg.exec() == QDialog::Rejected )
   {
     delete markerSymbol;

--- a/src/app/qgsdecorationgriddialog.h
+++ b/src/app/qgsdecorationgriddialog.h
@@ -41,6 +41,7 @@ class QgsDecorationGridDialog : public QDialog, private Ui::QgsDecorationGridDia
     void on_buttonBox_accepted();
     void on_buttonBox_rejected();
     void on_buttonBox_helpRequested();
+    void on_mGridTypeComboBox_currentIndexChanged( int index );
     void on_mLineSymbolButton_clicked();
     void on_mMarkerSymbolButton_clicked();
 
@@ -49,7 +50,7 @@ class QgsDecorationGridDialog : public QDialog, private Ui::QgsDecorationGridDia
     void on_mAnnotationFontButton_clicked();
 
   private:
-    QgsDecorationGrid& mDeco;    
+    QgsDecorationGrid& mDeco;
     QgsLineSymbolV2* mLineSymbol;
     QgsMarkerSymbolV2* mMarkerSymbol;
 

--- a/src/app/qgsdecorationgriddialog.h
+++ b/src/app/qgsdecorationgriddialog.h
@@ -44,6 +44,8 @@ class QgsDecorationGridDialog : public QDialog, private Ui::QgsDecorationGridDia
     void on_mGridTypeComboBox_currentIndexChanged( int index );
     void on_mLineSymbolButton_clicked();
     void on_mMarkerSymbolButton_clicked();
+    void on_mPbtnUpdateFromExtents_clicked();
+    void on_mPbtnUpdateFromLayer_clicked();
 
     // from composer map
     /* void on_mLineColorButton_clicked(); */
@@ -56,6 +58,7 @@ class QgsDecorationGridDialog : public QDialog, private Ui::QgsDecorationGridDia
 
     void updateGuiElements();
     void updateDecoFromGui();
+    void updateInterval( bool force = false );
 
 };
 

--- a/src/app/qgsdecorationgriddialog.h
+++ b/src/app/qgsdecorationgriddialog.h
@@ -1,0 +1,61 @@
+/***************************************************************************
+                         qgsdecorationgriddialog.h
+                         ----------------------
+    begin                : May 10, 2012
+    copyright            : (C) 2012 by Etienne Tourigny
+    email                : etourigny.dev at gmail dot com
+
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSDECORATIONGRIDDIALOG_H
+#define QGSDECORATIONGRIDDIALOG_H
+
+#include "ui_qgsdecorationgriddialog.h"
+#include <QDialog>
+
+class QgsDecorationGrid;
+class QgsLineSymbolV2;
+class QgsMarkerSymbolV2;
+
+/**
+@author Etienne Tourigny
+*/
+class QgsDecorationGridDialog : public QDialog, private Ui::QgsDecorationGridDialog
+{
+    Q_OBJECT
+
+  public:
+    QgsDecorationGridDialog( QgsDecorationGrid& decoGrid, QWidget* parent = 0 );
+    ~QgsDecorationGridDialog();
+
+  private slots:
+    void apply();
+    void on_buttonBox_accepted();
+    void on_buttonBox_rejected();
+    void on_buttonBox_helpRequested();
+    void on_mLineSymbolButton_clicked();
+    void on_mMarkerSymbolButton_clicked();
+
+    // from composer map
+    /* void on_mLineColorButton_clicked(); */
+    void on_mAnnotationFontButton_clicked();
+
+  private:
+    QgsDecorationGrid& mDeco;    
+    QgsLineSymbolV2* mLineSymbol;
+    QgsMarkerSymbolV2* mMarkerSymbol;
+
+    void updateGuiElements();
+    void updateDecoFromGui();
+
+};
+
+#endif

--- a/src/app/qgsdecorationitem.cpp
+++ b/src/app/qgsdecorationitem.cpp
@@ -1,0 +1,80 @@
+/***************************************************************************
+                         qgsdecorationitem.cpp
+                         ----------------------
+    begin                : May 10, 2012
+    copyright            : (C) 2012 by Etienne Tourigny
+    email                : etourigny.dev at gmail dot com
+
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsdecorationitem.h"
+
+#include "qgisapp.h"
+#include "qgslogger.h"
+#include "qgsmapcanvas.h"
+#include "qgsmaplayer.h"
+#include "qgsmaptopixel.h"
+#include "qgspoint.h"
+#include "qgsproject.h"
+#include "qgssymbollayerv2utils.h" //for pointOnLineWithDistance
+
+#include <QPainter>
+#include <QAction>
+#include <QPen>
+#include <QPolygon>
+#include <QString>
+#include <QFontMetrics>
+#include <QFont>
+#include <QColor>
+#include <QMenu>
+#include <QFile>
+#include <QLocale>
+
+//non qt includes
+#include <cmath>
+
+QgsDecorationItem::QgsDecorationItem( QObject* parent )
+    : QObject( parent )
+{
+  mEnabled = false;
+}
+
+QgsDecorationItem::~QgsDecorationItem()
+{
+
+}
+
+void QgsDecorationItem::update() 
+{ 
+  saveToProject();
+  QgisApp::instance()->mapCanvas()->refresh(); 
+}
+
+void QgsDecorationItem::projectRead()
+{
+  QgsDebugMsg( "Entered" );
+  mEnabled = QgsProject::instance()->readBoolEntry( mNameConfig, "/Enabled", false );
+}
+
+void QgsDecorationItem::saveToProject()
+{
+  QgsDebugMsg( "Entered" );
+  QgsProject::instance()->writeEntry( mNameConfig, "/Enabled", mEnabled );
+}
+void QgsDecorationItem::setName( const char *name ) 
+{ 
+  mName = name; 
+  mNameConfig = name;
+  mNameConfig.remove( " " );
+  mNameTranslated = tr( name );
+  QgsDebugMsg( QString( "name=%1 nameconfig=%2 nametrans=%3").arg(mName).arg(mNameConfig).arg(mNameTranslated) );
+}

--- a/src/app/qgsdecorationitem.h
+++ b/src/app/qgsdecorationitem.h
@@ -1,0 +1,67 @@
+/***************************************************************************
+                         qgsdecorationitem.h
+                         ----------------------
+    begin                : May 10, 2012
+    copyright            : (C) 2012 by Etienne Tourigny
+    email                : etourigny.dev at gmail dot com
+
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSDECORATIONITEM_H
+#define QGSDECORATIONITEM_H
+
+#include <QObject>
+#include "qgslogger.h"
+
+class QPainter;
+
+class QgsDecorationItem: public QObject
+{
+    Q_OBJECT
+  public:
+    //! Constructor
+    QgsDecorationItem( QObject* parent = NULL );
+    //! Destructor
+    virtual ~ QgsDecorationItem();
+
+    void setEnabled( bool enabled ) { mEnabled = enabled; }
+    bool enabled() const { return mEnabled; }
+
+    void update();
+
+  signals:
+    void toggled( bool t );
+
+  public slots:
+    //! set values on the gui when a project is read or the gui first loaded
+    virtual void projectRead();
+    //! save values to the project
+    virtual void saveToProject();
+
+    //! this does the meaty bit of the work
+    virtual void render( QPainter * ) {}
+    //! Show the dialog box
+    virtual void run() {}
+
+    virtual void setName( const char *name );
+    virtual QString name() { return mName; }
+
+  protected:
+
+    /**True if decoration item has to be displayed*/
+    bool mEnabled;
+
+    QString mName;
+    QString mNameConfig;
+    QString mNameTranslated;
+};
+
+#endif

--- a/src/app/qgsdecorationnortharrow.cpp
+++ b/src/app/qgsdecorationnortharrow.cpp
@@ -59,13 +59,14 @@ const double QgsDecorationNorthArrow::TOL = 1e-8;
  * @param _qI Pointer to the QGIS interface object
  */
 QgsDecorationNorthArrow::QgsDecorationNorthArrow( QObject* parent )
-    : QObject( parent )
+    : QgsDecorationItem( parent )
 {
   mRotationInt = 0;
   mAutomatic = true;
   mPlacementLabels << tr( "Bottom Left" ) << tr( "Top Left" )
   << tr( "Top Right" ) << tr( "Bottom Right" );
 
+  setName( "North Arrow" );
   projectRead();
 }
 
@@ -75,20 +76,18 @@ QgsDecorationNorthArrow::~QgsDecorationNorthArrow()
 
 void QgsDecorationNorthArrow::projectRead()
 {
-  //default text to start with - try to fetch it from qgsproject
-
-  mRotationInt = QgsProject::instance()->readNumEntry( "NorthArrow", "/Rotation", 0 );
-  mPlacementIndex = QgsProject::instance()->readNumEntry( "NorthArrow", "/Placement", 0 );
-  mEnable = QgsProject::instance()->readBoolEntry( "NorthArrow", "/Enabled", false );
-  mAutomatic = QgsProject::instance()->readBoolEntry( "NorthArrow", "/Automatic", true );
+  QgsDecorationItem::projectRead();
+  mRotationInt = QgsProject::instance()->readNumEntry( mNameConfig, "/Rotation", 0 );
+  mPlacementIndex = QgsProject::instance()->readNumEntry( mNameConfig, "/Placement", 0 );
+  mAutomatic = QgsProject::instance()->readBoolEntry( mNameConfig, "/Automatic", true );
 }
 
 void QgsDecorationNorthArrow::saveToProject()
 {
-  QgsProject::instance()->writeEntry( "NorthArrow", "/Rotation", mRotationInt );
-  QgsProject::instance()->writeEntry( "NorthArrow", "/Placement", mPlacementIndex );
-  QgsProject::instance()->writeEntry( "NorthArrow", "/Enabled", mEnable );
-  QgsProject::instance()->writeEntry( "NorthArrow", "/Automatic", mAutomatic );
+  QgsDecorationItem::saveToProject();
+  QgsProject::instance()->writeEntry( mNameConfig, "/Rotation", mRotationInt );
+  QgsProject::instance()->writeEntry( mNameConfig, "/Placement", mPlacementIndex );
+  QgsProject::instance()->writeEntry( mNameConfig, "/Automatic", mAutomatic );
 }
 
 // Slot called when the buffer menu item is activated
@@ -98,16 +97,15 @@ void QgsDecorationNorthArrow::run()
 
   if ( dlg.exec() )
   {
-    saveToProject();
-    QgisApp::instance()->mapCanvas()->refresh();
+    update();
   }
 }
 
-void QgsDecorationNorthArrow::renderNorthArrow( QPainter * theQPainter )
+void QgsDecorationNorthArrow::render( QPainter * theQPainter )
 {
 
   //Large IF statement controlled by enable check box
-  if ( mEnable )
+  if ( enabled() )
   {
     if ( theQPainter->isActive() )
     {

--- a/src/app/qgsdecorationnortharrow.h
+++ b/src/app/qgsdecorationnortharrow.h
@@ -19,14 +19,15 @@
 #ifndef QGSNORTHARROWPLUGIN
 #define QGSNORTHARROWPLUGIN
 
-#include <QObject>
+#include "qgsdecorationitem.h"
+
 #include <QStringList>
 
 class QAction;
 class QToolBar;
 class QPainter;
 
-class QgsDecorationNorthArrow: public QObject
+class QgsDecorationNorthArrow: public QgsDecorationItem
 {
     Q_OBJECT
 
@@ -45,7 +46,7 @@ class QgsDecorationNorthArrow: public QObject
     //! Show the dialog box
     void run();
     //! draw some arbitary text to the screen
-    void renderNorthArrow( QPainter * );
+    void render( QPainter * );
 
     //! try to calculate the direction for the north arrow. Sets the
     //! private class rotation variable. If unable to calculate the
@@ -62,8 +63,6 @@ class QgsDecorationNorthArrow: public QObject
     // The amount of rotation for the north arrow
     int mRotationInt;
     int pluginType;
-    // enable or disable north arrow
-    bool mEnable;
     //! enable or disable the automatic setting of the arrow direction
     bool mAutomatic;
     // The placement index and translated text

--- a/src/app/qgsdecorationnortharrowdialog.cpp
+++ b/src/app/qgsdecorationnortharrowdialog.cpp
@@ -41,7 +41,7 @@ QgsDecorationNorthArrowDialog::QgsDecorationNorthArrowDialog( QgsDecorationNorth
   cboPlacement->setCurrentIndex( mDeco.mPlacementIndex );
 
   // enabled
-  cboxShow->setChecked( mDeco.mEnable );
+  cboxShow->setChecked( mDeco.enabled() );
 
   // automatic
   cboxAutomatic->setChecked( mDeco.mAutomatic );
@@ -62,7 +62,7 @@ void QgsDecorationNorthArrowDialog::on_buttonBox_accepted()
 {
   mDeco.mRotationInt = sliderRotation->value();
   mDeco.mPlacementIndex = cboPlacement->currentIndex();
-  mDeco.mEnable = cboxShow->isChecked();
+  mDeco.setEnabled( cboxShow->isChecked() );
   mDeco.mAutomatic = cboxAutomatic->isChecked();
 
   accept();

--- a/src/app/qgsdecorationscalebar.cpp
+++ b/src/app/qgsdecorationscalebar.cpp
@@ -54,7 +54,7 @@ email                : sbr00pwb@users.sourceforge.net
 
 
 QgsDecorationScaleBar::QgsDecorationScaleBar( QObject* parent )
-    : QObject( parent )
+    : QgsDecorationItem( parent )
 {
   mPlacementLabels << tr( "Bottom Left" ) << tr( "Top Left" )
   << tr( "Top Right" ) << tr( "Bottom Right" );
@@ -62,6 +62,7 @@ QgsDecorationScaleBar::QgsDecorationScaleBar( QObject* parent )
   mStyleLabels << tr( "Tick Down" ) << tr( "Tick Up" )
   << tr( "Bar" ) << tr( "Box" );
 
+  setName( "Scale Bar" );
   projectRead();
 }
 
@@ -72,27 +73,29 @@ QgsDecorationScaleBar::~QgsDecorationScaleBar()
 
 void QgsDecorationScaleBar::projectRead()
 {
-  mPreferredSize = QgsProject::instance()->readNumEntry( "ScaleBar", "/PreferredSize", 30 );
-  mStyleIndex = QgsProject::instance()->readNumEntry( "ScaleBar", "/Style", 0 );
-  mPlacementIndex = QgsProject::instance()->readNumEntry( "ScaleBar", "/Placement", 2 );
-  mEnabled = QgsProject::instance()->readBoolEntry( "ScaleBar", "/Enabled", false );
-  mSnapping = QgsProject::instance()->readBoolEntry( "ScaleBar", "/Snapping", true );
-  int myRedInt = QgsProject::instance()->readNumEntry( "ScaleBar", "/ColorRedPart", 0 );
-  int myGreenInt = QgsProject::instance()->readNumEntry( "ScaleBar", "/ColorGreenPart", 0 );
-  int myBlueInt = QgsProject::instance()->readNumEntry( "ScaleBar", "/ColorBluePart", 0 );
+  QgsDecorationItem::projectRead();
+  mPreferredSize = QgsProject::instance()->readNumEntry( mNameConfig, "/PreferredSize", 30 );
+  mStyleIndex = QgsProject::instance()->readNumEntry( mNameConfig, "/Style", 0 );
+  mPlacementIndex = QgsProject::instance()->readNumEntry( mNameConfig, "/Placement", 2 );
+  // mEnabled = QgsProject::instance()->readBoolEntry( mNameConfig, "/Enabled", false );
+  mSnapping = QgsProject::instance()->readBoolEntry( mNameConfig, "/Snapping", true );
+  int myRedInt = QgsProject::instance()->readNumEntry( mNameConfig, "/ColorRedPart", 0 );
+  int myGreenInt = QgsProject::instance()->readNumEntry( mNameConfig, "/ColorGreenPart", 0 );
+  int myBlueInt = QgsProject::instance()->readNumEntry( mNameConfig, "/ColorBluePart", 0 );
   mColor = QColor( myRedInt, myGreenInt, myBlueInt );
 }
 
 void QgsDecorationScaleBar::saveToProject()
 {
-  QgsProject::instance()->writeEntry( "ScaleBar", "/Placement", mPlacementIndex );
-  QgsProject::instance()->writeEntry( "ScaleBar", "/PreferredSize", mPreferredSize );
-  QgsProject::instance()->writeEntry( "ScaleBar", "/Snapping", mSnapping );
-  QgsProject::instance()->writeEntry( "ScaleBar", "/Enabled", mEnabled );
-  QgsProject::instance()->writeEntry( "ScaleBar", "/Style", mStyleIndex );
-  QgsProject::instance()->writeEntry( "ScaleBar", "/ColorRedPart", mColor.red() );
-  QgsProject::instance()->writeEntry( "ScaleBar", "/ColorGreenPart", mColor.green() );
-  QgsProject::instance()->writeEntry( "ScaleBar", "/ColorBluePart", mColor.blue() );
+  QgsDecorationItem::saveToProject();
+  QgsProject::instance()->writeEntry( mNameConfig, "/Placement", mPlacementIndex );
+  QgsProject::instance()->writeEntry( mNameConfig, "/PreferredSize", mPreferredSize );
+  QgsProject::instance()->writeEntry( mNameConfig, "/Snapping", mSnapping );
+  // QgsProject::instance()->writeEntry( mNameConfig, "/Enabled", mEnabled );
+  QgsProject::instance()->writeEntry( mNameConfig, "/Style", mStyleIndex );
+  QgsProject::instance()->writeEntry( mNameConfig, "/ColorRedPart", mColor.red() );
+  QgsProject::instance()->writeEntry( mNameConfig, "/ColorGreenPart", mColor.green() );
+  QgsProject::instance()->writeEntry( mNameConfig, "/ColorBluePart", mColor.blue() );
 }
 
 
@@ -102,13 +105,12 @@ void QgsDecorationScaleBar::run()
 
   if ( dlg.exec() )
   {
-    saveToProject();
-    QgisApp::instance()->mapCanvas()->refresh();
+    update();
   }
 }
 
 
-void QgsDecorationScaleBar::renderScaleBar( QPainter * theQPainter )
+void QgsDecorationScaleBar::render( QPainter * theQPainter )
 {
   QgsMapCanvas* canvas = QgisApp::instance()->mapCanvas();
 
@@ -129,7 +131,7 @@ void QgsDecorationScaleBar::renderScaleBar( QPainter * theQPainter )
     return;
 
   //Large if statement which determines whether to render the scale bar
-  if ( mEnabled )
+  if ( enabled() )
   {
     // Hard coded sizes
     int myMajorTickSize = 8;

--- a/src/app/qgsdecorationscalebar.h
+++ b/src/app/qgsdecorationscalebar.h
@@ -21,12 +21,13 @@ email                : sbr00pwb@users.sourceforge.net
 #ifndef QGSCALEBARPLUGIN
 #define QGSCALEBARPLUGIN
 
+#include "qgsdecorationitem.h"
+
 class QPainter;
 
 #include <QColor>
-#include <QObject>
 
-class QgsDecorationScaleBar: public QObject
+class QgsDecorationScaleBar: public QgsDecorationItem
 {
     Q_OBJECT
   public:
@@ -42,7 +43,7 @@ class QgsDecorationScaleBar: public QObject
     void saveToProject();
 
     //! this does the meaty bit of the work
-    void renderScaleBar( QPainter * );
+    void render( QPainter * );
     //! Show the dialog box
     void run();
 
@@ -55,8 +56,6 @@ class QgsDecorationScaleBar: public QObject
     int mPreferredSize;
     //! Should we snap to integer times power of 10?
     bool mSnapping;
-    //! Scale bar enabled?
-    bool mEnabled;
     //! Style of scale bar. An index and the translated text
     int mStyleIndex;
     QStringList mStyleLabels;

--- a/src/app/qgsdecorationscalebardialog.cpp
+++ b/src/app/qgsdecorationscalebardialog.cpp
@@ -51,7 +51,7 @@ QgsDecorationScaleBarDialog::QgsDecorationScaleBarDialog( QgsDecorationScaleBar&
   cboPlacement->addItems( mDeco.mPlacementLabels );
   cboPlacement->setCurrentIndex( mDeco.mPlacementIndex );
 
-  chkEnable->setChecked( mDeco.mEnabled );
+  chkEnable->setChecked( mDeco.enabled() );
 
   cboStyle->clear();
   cboStyle->addItems( mDeco.mStyleLabels );
@@ -77,7 +77,7 @@ void QgsDecorationScaleBarDialog::on_buttonBox_accepted()
   mDeco.mPlacementIndex = cboPlacement->currentIndex();
   mDeco.mPreferredSize = spnSize->value();
   mDeco.mSnapping = chkSnapping->isChecked();
-  mDeco.mEnabled = chkEnable->isChecked();
+  mDeco.setEnabled( chkEnable->isChecked() );
   mDeco.mStyleIndex = cboStyle->currentIndex();
   mDeco.mColor = pbnChangeColor->color();
 

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -1111,8 +1111,7 @@ bool QgsRasterLayer::hasStatistics( int theBandNo )
 bool QgsRasterLayer::identify( const QgsPoint& thePoint, QMap<QString, QString>& theResults )
 {
   theResults.clear();
-
-  QgsDebugMsg( "identify provider : " + mProviderKey ) ;
+  // QgsDebugMsg( "identify provider : " + mProviderKey ) ;
   return ( mDataProvider->identify( thePoint, theResults ) );
 }
 

--- a/src/providers/gdal/qgsgdalprovider.cpp
+++ b/src/providers/gdal/qgsgdalprovider.cpp
@@ -1119,7 +1119,7 @@ int QgsGdalProvider::ySize() const { return mHeight; }
 
 bool QgsGdalProvider::identify( const QgsPoint& thePoint, QMap<QString, QString>& theResults )
 {
-  QgsDebugMsg( "Entered" );
+  // QgsDebugMsg( "Entered" );
   if ( !mExtent.contains( thePoint ) )
   {
     // Outside the raster

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -103,10 +103,10 @@
      <property name="title">
       <string>&amp;Decorations</string>
      </property>
-     <addaction name="mActionDecorationCopyright"/>
-     <addaction name="mActionDecorationNorthArrow"/>
-     <addaction name="mActionDecorationScaleBar"/>
      <addaction name="mActionDecorationGrid"/>
+     <addaction name="mActionDecorationScaleBar"/>
+     <addaction name="mActionDecorationNorthArrow"/>
+     <addaction name="mActionDecorationCopyright"/>
     </widget>
     <addaction name="mActionPan"/>
     <addaction name="mActionPanToSelected"/>

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -17,7 +17,7 @@
      <x>0</x>
      <y>0</y>
      <width>1052</width>
-     <height>28</height>
+     <height>26</height>
     </rect>
    </property>
    <widget class="QMenu" name="mEditMenu">
@@ -106,6 +106,7 @@
      <addaction name="mActionDecorationCopyright"/>
      <addaction name="mActionDecorationNorthArrow"/>
      <addaction name="mActionDecorationScaleBar"/>
+     <addaction name="mActionDecorationGrid"/>
     </widget>
     <addaction name="mActionPan"/>
     <addaction name="mActionPanToSelected"/>
@@ -1679,6 +1680,21 @@
    </property>
    <property name="text">
     <string>Add WCS Layer...</string>
+   </property>
+  </action>
+  <action name="mActionDecorationGrid">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/transformed.png</normaloff>:/images/themes/default/transformed.png</iconset>
+   </property>
+   <property name="text">
+    <string>&amp;Grid</string>
+   </property>
+   <property name="toolTip">
+    <string>Grid</string>
+   </property>
+   <property name="whatsThis">
+    <string>Creates a scale bar that is displayed on the map canvas</string>
    </property>
   </action>
  </widget>

--- a/src/ui/qgsdecorationgriddialog.ui
+++ b/src/ui/qgsdecorationgriddialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>531</width>
-    <height>349</height>
+    <width>484</width>
+    <height>367</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -18,152 +18,7 @@
     <enum>QLayout::SetMinimumSize</enum>
    </property>
    <item>
-    <layout class="QGridLayout" name="gridLayout_3" columnminimumwidth="125,0,0,0,0">
-     <item row="1" column="0">
-      <widget class="QLabel" name="mGridTypeLabel">
-       <property name="accessibleName">
-        <string extracomment="Hello translotor"/>
-       </property>
-       <property name="text">
-        <string>Grid type</string>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="2">
-      <widget class="QComboBox" name="mGridTypeComboBox"/>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="mIntervalXLabel">
-       <property name="text">
-        <string>Interval X</string>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="2">
-      <widget class="QDoubleSpinBox" name="mIntervalXSpinBox">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="decimals">
-        <number>5</number>
-       </property>
-       <property name="maximum">
-        <double>9999999.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="mIntervalYLabel">
-       <property name="text">
-        <string>Interval Y</string>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="2">
-      <widget class="QDoubleSpinBox" name="mIntervalYSpinBox">
-       <property name="decimals">
-        <number>5</number>
-       </property>
-       <property name="maximum">
-        <double>9999999.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="0">
-      <widget class="QLabel" name="mOffsetXLabel">
-       <property name="text">
-        <string>Offset X</string>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="2">
-      <widget class="QDoubleSpinBox" name="mOffsetXSpinBox">
-       <property name="decimals">
-        <number>5</number>
-       </property>
-       <property name="maximum">
-        <double>9999999.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="0">
-      <widget class="QLabel" name="mOffsetYLabel">
-       <property name="text">
-        <string>Offset Y</string>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="2">
-      <widget class="QDoubleSpinBox" name="mOffsetYSpinBox">
-       <property name="decimals">
-        <number>5</number>
-       </property>
-       <property name="maximum">
-        <double>9999999.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="0">
-      <widget class="QLabel" name="mCrossWidthLabel">
-       <property name="text">
-        <string>Cross width</string>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="2">
-      <widget class="QDoubleSpinBox" name="mCrossWidthSpinBox">
-       <property name="decimals">
-        <number>5</number>
-       </property>
-      </widget>
-     </item>
-     <item row="7" column="0">
-      <widget class="QLabel" name="mLineSymbolLabel">
-       <property name="text">
-        <string>Line symbol</string>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="3">
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Fixed</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>10</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
+    <layout class="QGridLayout" name="gridLayout_3" columnstretch="0,0,0,0" columnminimumwidth="125,100,0,0">
      <item row="0" column="0">
       <widget class="QCheckBox" name="chkEnable">
        <property name="sizePolicy">
@@ -183,7 +38,23 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="4" rowspan="9">
+     <item row="0" column="2">
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Fixed</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>10</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="0" column="3" rowspan="11">
       <widget class="QGroupBox" name="mDrawAnnotationCheckBox">
        <property name="title">
         <string>Draw annotation</string>
@@ -266,36 +137,249 @@
        </layout>
       </widget>
      </item>
-     <item row="8" column="0">
+     <item row="1" column="0">
+      <widget class="QLabel" name="mIntervalXLabel">
+       <property name="text">
+        <string>Interval X</string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="mIntervalYLabel">
+       <property name="text">
+        <string>Interval Y</string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0" colspan="2">
+      <widget class="Line" name="line_2">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="mGridTypeLabel">
+       <property name="accessibleName">
+        <string extracomment="Hello translotor"/>
+       </property>
+       <property name="text">
+        <string>Grid type</string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="mLineSymbolLabel">
+       <property name="text">
+        <string>Line symbol</string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="0">
+      <widget class="QLabel" name="mCrossWidthLabel">
+       <property name="text">
+        <string>Cross width</string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="0">
       <widget class="QLabel" name="mMarkerSymbolLabel">
        <property name="text">
         <string>Marker symbol</string>
        </property>
       </widget>
      </item>
-     <item row="7" column="2">
-      <widget class="QPushButton" name="mLineSymbolButton">
+     <item row="4" column="1">
+      <widget class="QComboBox" name="mGridTypeComboBox">
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>100</width>
+         <height>0</height>
+        </size>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="1">
+      <widget class="QPushButton" name="mLineSymbolButton">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>100</width>
+         <height>0</height>
+        </size>
        </property>
        <property name="text">
         <string/>
        </property>
       </widget>
      </item>
-     <item row="8" column="2">
+     <item row="6" column="1">
+      <widget class="QDoubleSpinBox" name="mCrossWidthSpinBox">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>100</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="decimals">
+        <number>5</number>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="1">
       <widget class="QPushButton" name="mMarkerSymbolButton">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
        <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+        <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
          <horstretch>0</horstretch>
          <verstretch>0</verstretch>
         </sizepolicy>
        </property>
+       <property name="minimumSize">
+        <size>
+         <width>100</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="text">
         <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="0" colspan="2">
+      <widget class="Line" name="line_3">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="0">
+      <widget class="QLabel" name="mOffsetXLabel">
+       <property name="text">
+        <string>Offset X</string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="10" column="0">
+      <widget class="QLabel" name="mOffsetYLabel">
+       <property name="text">
+        <string>Offset Y</string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="1">
+      <widget class="QDoubleSpinBox" name="mOffsetXSpinBox">
+       <property name="minimumSize">
+        <size>
+         <width>100</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="decimals">
+        <number>5</number>
+       </property>
+       <property name="maximum">
+        <double>9999999.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="10" column="1">
+      <widget class="QDoubleSpinBox" name="mOffsetYSpinBox">
+       <property name="minimumSize">
+        <size>
+         <width>100</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="decimals">
+        <number>5</number>
+       </property>
+       <property name="maximum">
+        <double>9999999.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QDoubleSpinBox" name="mIntervalXSpinBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>100</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="decimals">
+        <number>5</number>
+       </property>
+       <property name="maximum">
+        <double>9999999.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QDoubleSpinBox" name="mIntervalYSpinBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>100</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="decimals">
+        <number>5</number>
+       </property>
+       <property name="maximum">
+        <double>9999999.000000000000000</double>
        </property>
       </widget>
      </item>

--- a/src/ui/qgsdecorationgriddialog.ui
+++ b/src/ui/qgsdecorationgriddialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>628</width>
+    <width>603</width>
     <height>335</height>
    </rect>
   </property>
@@ -123,50 +123,6 @@
        </property>
        <property name="text">
         <string/>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QDoubleSpinBox" name="mIntervalXSpinBox">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>125</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="decimals">
-        <number>5</number>
-       </property>
-       <property name="maximum">
-        <double>9999999.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="QDoubleSpinBox" name="mIntervalYSpinBox">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>100</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="decimals">
-        <number>5</number>
-       </property>
-       <property name="maximum">
-        <double>9999999.000000000000000</double>
        </property>
       </widget>
      </item>
@@ -302,22 +258,6 @@
        </property>
       </widget>
      </item>
-     <item row="8" column="1">
-      <widget class="QDoubleSpinBox" name="mOffsetXSpinBox">
-       <property name="minimumSize">
-        <size>
-         <width>100</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="decimals">
-        <number>5</number>
-       </property>
-       <property name="maximum">
-        <double>9999999.000000000000000</double>
-       </property>
-      </widget>
-     </item>
      <item row="9" column="0">
       <widget class="QLabel" name="mOffsetYLabel">
        <property name="text">
@@ -325,22 +265,6 @@
        </property>
        <property name="wordWrap">
         <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="9" column="1">
-      <widget class="QDoubleSpinBox" name="mOffsetYSpinBox">
-       <property name="minimumSize">
-        <size>
-         <width>100</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="decimals">
-        <number>5</number>
-       </property>
-       <property name="maximum">
-        <double>9999999.000000000000000</double>
        </property>
       </widget>
      </item>
@@ -366,6 +290,18 @@
         </item>
        </layout>
       </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="mIntervalXEdit"/>
+     </item>
+     <item row="2" column="1">
+      <widget class="QLineEdit" name="mIntervalYEdit"/>
+     </item>
+     <item row="8" column="1">
+      <widget class="QLineEdit" name="mOffsetXEdit"/>
+     </item>
+     <item row="9" column="1">
+      <widget class="QLineEdit" name="mOffsetYEdit"/>
      </item>
     </layout>
    </item>

--- a/src/ui/qgsdecorationgriddialog.ui
+++ b/src/ui/qgsdecorationgriddialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>613</width>
-    <height>367</height>
+    <width>628</width>
+    <height>335</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -88,23 +88,6 @@
        </property>
       </widget>
      </item>
-     <item row="6" column="0">
-      <widget class="QLabel" name="mCrossWidthLabel">
-       <property name="text">
-        <string>Cross width</string>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="7" column="0">
-      <widget class="QLabel" name="mMarkerSymbolLabel">
-       <property name="text">
-        <string>Marker symbol</string>
-       </property>
-      </widget>
-     </item>
      <item row="4" column="1">
       <widget class="QComboBox" name="mGridTypeComboBox">
        <property name="sizePolicy">
@@ -140,103 +123,6 @@
        </property>
        <property name="text">
         <string/>
-       </property>
-      </widget>
-     </item>
-     <item row="6" column="1">
-      <widget class="QDoubleSpinBox" name="mCrossWidthSpinBox">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>100</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="decimals">
-        <number>5</number>
-       </property>
-      </widget>
-     </item>
-     <item row="7" column="1">
-      <widget class="QPushButton" name="mMarkerSymbolButton">
-       <property name="enabled">
-        <bool>false</bool>
-       </property>
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>100</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-      </widget>
-     </item>
-     <item row="8" column="0" colspan="2">
-      <widget class="Line" name="line_3">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-      </widget>
-     </item>
-     <item row="9" column="0">
-      <widget class="QLabel" name="mOffsetXLabel">
-       <property name="text">
-        <string>Offset X</string>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="10" column="0">
-      <widget class="QLabel" name="mOffsetYLabel">
-       <property name="text">
-        <string>Offset Y</string>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="9" column="1">
-      <widget class="QDoubleSpinBox" name="mOffsetXSpinBox">
-       <property name="minimumSize">
-        <size>
-         <width>100</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="decimals">
-        <number>5</number>
-       </property>
-       <property name="maximum">
-        <double>9999999.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="10" column="1">
-      <widget class="QDoubleSpinBox" name="mOffsetYSpinBox">
-       <property name="minimumSize">
-        <size>
-         <width>100</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="decimals">
-        <number>5</number>
-       </property>
-       <property name="maximum">
-        <double>9999999.000000000000000</double>
        </property>
       </widget>
      </item>
@@ -319,19 +205,6 @@
          <enum>QLayout::SetMinimumSize</enum>
         </property>
         <item row="0" column="0">
-         <widget class="QLabel" name="mAnnotationPositionLabel">
-          <property name="text">
-           <string>Annotation position</string>
-          </property>
-          <property name="wordWrap">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QComboBox" name="mAnnotationPositionComboBox"/>
-        </item>
-        <item row="1" column="0">
          <widget class="QLabel" name="mAnnotationDirectionLabel">
           <property name="frameShape">
            <enum>QFrame::NoFrame</enum>
@@ -344,17 +217,17 @@
           </property>
          </widget>
         </item>
-        <item row="1" column="1">
+        <item row="0" column="1">
          <widget class="QComboBox" name="mAnnotationDirectionComboBox"/>
         </item>
-        <item row="2" column="0" colspan="2">
+        <item row="1" column="0" colspan="2">
          <widget class="QPushButton" name="mAnnotationFontButton">
           <property name="text">
            <string>Font...</string>
           </property>
          </widget>
         </item>
-        <item row="3" column="0">
+        <item row="2" column="0">
          <widget class="QLabel" name="mDistanceToFrameLabel">
           <property name="text">
            <string>Distance to map frame</string>
@@ -364,10 +237,10 @@
           </property>
          </widget>
         </item>
-        <item row="3" column="1">
+        <item row="2" column="1">
          <widget class="QDoubleSpinBox" name="mDistanceToMapFrameSpinBox"/>
         </item>
-        <item row="4" column="0">
+        <item row="3" column="0">
          <widget class="QLabel" name="mCoordinatePrecisionLabel">
           <property name="text">
            <string>Coordinate precision</string>
@@ -377,40 +250,121 @@
           </property>
          </widget>
         </item>
-        <item row="4" column="1">
+        <item row="3" column="1">
          <widget class="QSpinBox" name="mCoordinatePrecisionSpinBox"/>
         </item>
        </layout>
       </widget>
      </item>
-     <item row="9" column="3" colspan="2">
-      <widget class="QLabel" name="label">
-       <property name="midLineWidth">
-        <number>0</number>
-       </property>
+     <item row="6" column="0">
+      <widget class="QLabel" name="mMarkerSymbolLabel">
        <property name="text">
-        <string>Update Interval:</string>
-       </property>
-       <property name="textFormat">
-        <enum>Qt::PlainText</enum>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignCenter</set>
+        <string>Marker symbol</string>
        </property>
       </widget>
      </item>
-     <item row="10" column="4">
-      <widget class="QPushButton" name="mPbtnUpdateFromLayer">
+     <item row="6" column="1">
+      <widget class="QPushButton" name="mMarkerSymbolButton">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="minimumSize">
+        <size>
+         <width>100</width>
+         <height>0</height>
+        </size>
+       </property>
        <property name="text">
-        <string>From Layer</string>
+        <string/>
        </property>
       </widget>
      </item>
-     <item row="10" column="3">
-      <widget class="QPushButton" name="mPbtnUpdateFromExtents">
-       <property name="text">
-        <string>From Extents</string>
+     <item row="7" column="0" colspan="2">
+      <widget class="Line" name="line_3">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
        </property>
+      </widget>
+     </item>
+     <item row="8" column="0">
+      <widget class="QLabel" name="mOffsetXLabel">
+       <property name="text">
+        <string>Offset X</string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="1">
+      <widget class="QDoubleSpinBox" name="mOffsetXSpinBox">
+       <property name="minimumSize">
+        <size>
+         <width>100</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="decimals">
+        <number>5</number>
+       </property>
+       <property name="maximum">
+        <double>9999999.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="0">
+      <widget class="QLabel" name="mOffsetYLabel">
+       <property name="text">
+        <string>Offset Y</string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="9" column="1">
+      <widget class="QDoubleSpinBox" name="mOffsetYSpinBox">
+       <property name="minimumSize">
+        <size>
+         <width>100</width>
+         <height>0</height>
+        </size>
+       </property>
+       <property name="decimals">
+        <number>5</number>
+       </property>
+       <property name="maximum">
+        <double>9999999.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="3" rowspan="2" colspan="2">
+      <widget class="QGroupBox" name="groupBox">
+       <property name="title">
+        <string>Update Interval / Offset from</string>
+       </property>
+       <layout class="QGridLayout" name="gridLayout_2">
+        <item row="0" column="0">
+         <widget class="QPushButton" name="mPbtnUpdateFromExtents">
+          <property name="text">
+           <string>Canvas Extents</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QPushButton" name="mPbtnUpdateFromLayer">
+          <property name="text">
+           <string>Active Raster Layer</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </widget>
      </item>
     </layout>

--- a/src/ui/qgsdecorationgriddialog.ui
+++ b/src/ui/qgsdecorationgriddialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>511</width>
-    <height>353</height>
+    <width>531</width>
+    <height>349</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -18,7 +18,7 @@
     <enum>QLayout::SetMinimumSize</enum>
    </property>
    <item>
-    <layout class="QGridLayout" name="gridLayout_3">
+    <layout class="QGridLayout" name="gridLayout_3" columnminimumwidth="125,0,0,0,0">
      <item row="1" column="0">
       <widget class="QLabel" name="mGridTypeLabel">
        <property name="accessibleName">
@@ -139,42 +139,12 @@
       </widget>
      </item>
      <item row="7" column="0">
-      <widget class="QLabel" name="mLineWidthLabel">
+      <widget class="QLabel" name="mLineSymbolLabel">
        <property name="text">
-        <string>Line width</string>
+        <string>Line symbol</string>
        </property>
        <property name="wordWrap">
         <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="7" column="2">
-      <widget class="QDoubleSpinBox" name="mLineWidthSpinBox">
-       <property name="decimals">
-        <number>5</number>
-       </property>
-      </widget>
-     </item>
-     <item row="8" column="0">
-      <widget class="QLabel" name="mLineColorLabel">
-       <property name="text">
-        <string>Line color</string>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item row="8" column="2">
-      <widget class="QgsColorButton" name="mLineColorButton">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string/>
        </property>
       </widget>
      </item>
@@ -296,6 +266,39 @@
        </layout>
       </widget>
      </item>
+     <item row="8" column="0">
+      <widget class="QLabel" name="mMarkerSymbolLabel">
+       <property name="text">
+        <string>Marker symbol</string>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="2">
+      <widget class="QPushButton" name="mLineSymbolButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="2">
+      <widget class="QPushButton" name="mMarkerSymbolButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
    <item>
@@ -310,13 +313,6 @@
    </item>
   </layout>
  </widget>
- <customwidgets>
-  <customwidget>
-   <class>QgsColorButton</class>
-   <extends>QToolButton</extends>
-   <header>qgscolorbutton.h</header>
-  </customwidget>
- </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/ui/qgsdecorationgriddialog.ui
+++ b/src/ui/qgsdecorationgriddialog.ui
@@ -1,0 +1,322 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsDecorationGridDialog</class>
+ <widget class="QDialog" name="QgsDecorationGridDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>511</width>
+    <height>353</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="sizeConstraint">
+    <enum>QLayout::SetMinimumSize</enum>
+   </property>
+   <item>
+    <layout class="QGridLayout" name="gridLayout_3">
+     <item row="1" column="0">
+      <widget class="QLabel" name="mGridTypeLabel">
+       <property name="accessibleName">
+        <string extracomment="Hello translotor"/>
+       </property>
+       <property name="text">
+        <string>Grid type</string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <widget class="QComboBox" name="mGridTypeComboBox"/>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="mIntervalXLabel">
+       <property name="text">
+        <string>Interval X</string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="2">
+      <widget class="QDoubleSpinBox" name="mIntervalXSpinBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="decimals">
+        <number>5</number>
+       </property>
+       <property name="maximum">
+        <double>9999999.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="mIntervalYLabel">
+       <property name="text">
+        <string>Interval Y</string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="2">
+      <widget class="QDoubleSpinBox" name="mIntervalYSpinBox">
+       <property name="decimals">
+        <number>5</number>
+       </property>
+       <property name="maximum">
+        <double>9999999.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="mOffsetXLabel">
+       <property name="text">
+        <string>Offset X</string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="2">
+      <widget class="QDoubleSpinBox" name="mOffsetXSpinBox">
+       <property name="decimals">
+        <number>5</number>
+       </property>
+       <property name="maximum">
+        <double>9999999.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="mOffsetYLabel">
+       <property name="text">
+        <string>Offset Y</string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="2">
+      <widget class="QDoubleSpinBox" name="mOffsetYSpinBox">
+       <property name="decimals">
+        <number>5</number>
+       </property>
+       <property name="maximum">
+        <double>9999999.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="0">
+      <widget class="QLabel" name="mCrossWidthLabel">
+       <property name="text">
+        <string>Cross width</string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="6" column="2">
+      <widget class="QDoubleSpinBox" name="mCrossWidthSpinBox">
+       <property name="decimals">
+        <number>5</number>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="0">
+      <widget class="QLabel" name="mLineWidthLabel">
+       <property name="text">
+        <string>Line width</string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="7" column="2">
+      <widget class="QDoubleSpinBox" name="mLineWidthSpinBox">
+       <property name="decimals">
+        <number>5</number>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="0">
+      <widget class="QLabel" name="mLineColorLabel">
+       <property name="text">
+        <string>Line color</string>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="8" column="2">
+      <widget class="QgsColorButton" name="mLineColorButton">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="3">
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Fixed</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>10</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="0" column="0">
+      <widget class="QCheckBox" name="chkEnable">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Minimum" vsizetype="Minimum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="layoutDirection">
+        <enum>Qt::LeftToRight</enum>
+       </property>
+       <property name="text">
+        <string>Enable grid</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="4" rowspan="9">
+      <widget class="QGroupBox" name="mDrawAnnotationCheckBox">
+       <property name="title">
+        <string>Draw annotation</string>
+       </property>
+       <property name="flat">
+        <bool>false</bool>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+       <property name="checked">
+        <bool>false</bool>
+       </property>
+       <layout class="QGridLayout" name="gridLayout">
+        <property name="sizeConstraint">
+         <enum>QLayout::SetMinimumSize</enum>
+        </property>
+        <item row="0" column="0">
+         <widget class="QLabel" name="mAnnotationPositionLabel">
+          <property name="text">
+           <string>Annotation position</string>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QComboBox" name="mAnnotationPositionComboBox"/>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="mAnnotationDirectionLabel">
+          <property name="frameShape">
+           <enum>QFrame::NoFrame</enum>
+          </property>
+          <property name="text">
+           <string>Annotation direction</string>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QComboBox" name="mAnnotationDirectionComboBox"/>
+        </item>
+        <item row="2" column="0" colspan="2">
+         <widget class="QPushButton" name="mAnnotationFontButton">
+          <property name="text">
+           <string>Font...</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="mDistanceToFrameLabel">
+          <property name="text">
+           <string>Distance to map frame</string>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <widget class="QDoubleSpinBox" name="mDistanceToMapFrameSpinBox"/>
+        </item>
+        <item row="4" column="0">
+         <widget class="QLabel" name="mCoordinatePrecisionLabel">
+          <property name="text">
+           <string>Coordinate precision</string>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="1">
+         <widget class="QSpinBox" name="mCoordinatePrecisionSpinBox"/>
+        </item>
+       </layout>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Apply|QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsColorButton</class>
+   <extends>QToolButton</extends>
+   <header>qgscolorbutton.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/src/ui/qgsdecorationgriddialog.ui
+++ b/src/ui/qgsdecorationgriddialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>484</width>
+    <width>613</width>
     <height>367</height>
    </rect>
   </property>
@@ -18,7 +18,7 @@
     <enum>QLayout::SetMinimumSize</enum>
    </property>
    <item>
-    <layout class="QGridLayout" name="gridLayout_3" columnstretch="0,0,0,0" columnminimumwidth="125,100,0,0">
+    <layout class="QGridLayout" name="gridLayout_3" columnstretch="0,0,0,0,0" columnminimumwidth="125,100,0,0,0">
      <item row="0" column="0">
       <widget class="QCheckBox" name="chkEnable">
        <property name="sizePolicy">
@@ -36,105 +36,6 @@
        <property name="checked">
         <bool>true</bool>
        </property>
-      </widget>
-     </item>
-     <item row="0" column="2">
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Fixed</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>10</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item row="0" column="3" rowspan="11">
-      <widget class="QGroupBox" name="mDrawAnnotationCheckBox">
-       <property name="title">
-        <string>Draw annotation</string>
-       </property>
-       <property name="flat">
-        <bool>false</bool>
-       </property>
-       <property name="checkable">
-        <bool>true</bool>
-       </property>
-       <property name="checked">
-        <bool>false</bool>
-       </property>
-       <layout class="QGridLayout" name="gridLayout">
-        <property name="sizeConstraint">
-         <enum>QLayout::SetMinimumSize</enum>
-        </property>
-        <item row="0" column="0">
-         <widget class="QLabel" name="mAnnotationPositionLabel">
-          <property name="text">
-           <string>Annotation position</string>
-          </property>
-          <property name="wordWrap">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="0" column="1">
-         <widget class="QComboBox" name="mAnnotationPositionComboBox"/>
-        </item>
-        <item row="1" column="0">
-         <widget class="QLabel" name="mAnnotationDirectionLabel">
-          <property name="frameShape">
-           <enum>QFrame::NoFrame</enum>
-          </property>
-          <property name="text">
-           <string>Annotation direction</string>
-          </property>
-          <property name="wordWrap">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="1" column="1">
-         <widget class="QComboBox" name="mAnnotationDirectionComboBox"/>
-        </item>
-        <item row="2" column="0" colspan="2">
-         <widget class="QPushButton" name="mAnnotationFontButton">
-          <property name="text">
-           <string>Font...</string>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="0">
-         <widget class="QLabel" name="mDistanceToFrameLabel">
-          <property name="text">
-           <string>Distance to map frame</string>
-          </property>
-          <property name="wordWrap">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="3" column="1">
-         <widget class="QDoubleSpinBox" name="mDistanceToMapFrameSpinBox"/>
-        </item>
-        <item row="4" column="0">
-         <widget class="QLabel" name="mCoordinatePrecisionLabel">
-          <property name="text">
-           <string>Coordinate precision</string>
-          </property>
-          <property name="wordWrap">
-           <bool>true</bool>
-          </property>
-         </widget>
-        </item>
-        <item row="4" column="1">
-         <widget class="QSpinBox" name="mCoordinatePrecisionSpinBox"/>
-        </item>
-       </layout>
       </widget>
      </item>
      <item row="1" column="0">
@@ -349,7 +250,7 @@
        </property>
        <property name="minimumSize">
         <size>
-         <width>100</width>
+         <width>125</width>
          <height>0</height>
         </size>
        </property>
@@ -380,6 +281,135 @@
        </property>
        <property name="maximum">
         <double>9999999.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="2">
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Fixed</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>10</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="0" column="3" rowspan="8" colspan="2">
+      <widget class="QGroupBox" name="mDrawAnnotationCheckBox">
+       <property name="title">
+        <string>Draw annotation</string>
+       </property>
+       <property name="flat">
+        <bool>false</bool>
+       </property>
+       <property name="checkable">
+        <bool>true</bool>
+       </property>
+       <property name="checked">
+        <bool>false</bool>
+       </property>
+       <layout class="QGridLayout" name="gridLayout">
+        <property name="sizeConstraint">
+         <enum>QLayout::SetMinimumSize</enum>
+        </property>
+        <item row="0" column="0">
+         <widget class="QLabel" name="mAnnotationPositionLabel">
+          <property name="text">
+           <string>Annotation position</string>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QComboBox" name="mAnnotationPositionComboBox"/>
+        </item>
+        <item row="1" column="0">
+         <widget class="QLabel" name="mAnnotationDirectionLabel">
+          <property name="frameShape">
+           <enum>QFrame::NoFrame</enum>
+          </property>
+          <property name="text">
+           <string>Annotation direction</string>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QComboBox" name="mAnnotationDirectionComboBox"/>
+        </item>
+        <item row="2" column="0" colspan="2">
+         <widget class="QPushButton" name="mAnnotationFontButton">
+          <property name="text">
+           <string>Font...</string>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="0">
+         <widget class="QLabel" name="mDistanceToFrameLabel">
+          <property name="text">
+           <string>Distance to map frame</string>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="3" column="1">
+         <widget class="QDoubleSpinBox" name="mDistanceToMapFrameSpinBox"/>
+        </item>
+        <item row="4" column="0">
+         <widget class="QLabel" name="mCoordinatePrecisionLabel">
+          <property name="text">
+           <string>Coordinate precision</string>
+          </property>
+          <property name="wordWrap">
+           <bool>true</bool>
+          </property>
+         </widget>
+        </item>
+        <item row="4" column="1">
+         <widget class="QSpinBox" name="mCoordinatePrecisionSpinBox"/>
+        </item>
+       </layout>
+      </widget>
+     </item>
+     <item row="9" column="3" colspan="2">
+      <widget class="QLabel" name="label">
+       <property name="midLineWidth">
+        <number>0</number>
+       </property>
+       <property name="text">
+        <string>Update Interval:</string>
+       </property>
+       <property name="textFormat">
+        <enum>Qt::PlainText</enum>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="10" column="4">
+      <widget class="QPushButton" name="mPbtnUpdateFromLayer">
+       <property name="text">
+        <string>From Layer</string>
+       </property>
+      </widget>
+     </item>
+     <item row="10" column="3">
+      <widget class="QPushButton" name="mPbtnUpdateFromExtents">
+       <property name="text">
+        <string>From Extents</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
This pull request implements a simple grid decoration in the main canvas, similar to the grid in the print composer. Most UI and logic is similar to that in the print composer, but this uses the new symbology for lines and symbols.  

Refactored all the decoration items into a new class QgsDecorationItem.  A further step would be to unify the canvas decorations  with the composer decorations so that both would benefit from any development and to make both the main canvas and print composer similar.
