### PR TITLE
Fix to get unit tests working again on Mac.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -370,7 +370,11 @@ ELSE (WIN32)
     SET (QGIS_PLUGIN_SUBDIR_REV  ../../MacOS)
     SET (DEFAULT_INCLUDE_SUBDIR  include/qgis)
     # path for framework references
-    SET (CMAKE_INSTALL_NAME_DIR @executable_path/${QGIS_FW_SUBDIR})
+    IF (ENABLE_TESTS)
+      SET (CMAKE_INSTALL_NAME_DIR ${CMAKE_BINARY_DIR}/output/lib)
+    ELSE (ENABLE_TESTS)
+      SET (CMAKE_INSTALL_NAME_DIR @executable_path/${QGIS_FW_SUBDIR})
+    ENDIF (ENABLE_TESTS)
     IF (WITH_GLOBE)
         SET (OSG_PLUGINS_PATH "" CACHE PATH "Path to OSG plugins for bundling")
     ENDIF (WITH_GLOBE)
@@ -456,6 +460,13 @@ SET (CMAKE_LIBRARY_OUTPUT_DIRECTORY ${QGIS_OUTPUT_DIRECTORY}/${QGIS_LIB_SUBDIR})
 # write a marker with source directory path into the output's bin directory
 # if run from the build directory QGIS will detect it and alter the paths
 FILE(WRITE ${QGIS_OUTPUT_DIRECTORY}/${QGIS_BIN_SUBDIR}/source_path.txt "${CMAKE_SOURCE_DIR}")
+
+# symlink provider plugins dir for Mac unit tests
+IF (APPLE AND ENABLE_TESTS)
+  EXECUTE_PROCESS(COMMAND ${CMAKE_COMMAND} -E create_symlink
+    "${CMAKE_CURRENT_BINARY_DIR}/Plugins"
+    "${CMAKE_CURRENT_BINARY_DIR}/output/Plugins")
+ENDIF (APPLE AND ENABLE_TESTS)
 
 # manual page - makes sense only on unix systems
 IF (UNIX AND NOT APPLE)


### PR DESCRIPTION
make 'check', 'test' and 'Experimental' work from build directory to run tests.

Current caveats:
- Build will not install. Re-build with ENABLE_TESTS=FALSE to produce a functioning bundled QGIS.app.
- Temp QGIS.app in build/output/bin directory will start, but also needs a different symlink for finding providers. Even then, the app doesn't work right. It appears to be unnecessary for running tests, so there is no advantage to running it from the build directory.
