### PR TITLE
fixing bool QgsMapTool::gestureEvent( QGestureEvent *e )

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -643,7 +643,7 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, QWidget * parent, 
   }
 
 #ifdef HAVE_TOUCH
-  //add reacting to long click in android
+  //add reacting to long click in touch
   grabGesture( Qt::TapAndHoldGesture );
 #else
   //remove mActionTouch button

--- a/src/gui/qgsmaptool.cpp
+++ b/src/gui/qgsmaptool.cpp
@@ -145,6 +145,7 @@ void QgsMapTool::keyReleaseEvent( QKeyEvent *e )
 bool QgsMapTool::gestureEvent( QGestureEvent *e )
 {
   Q_UNUSED( e );
+  return true;
 }
 #endif
 


### PR DESCRIPTION
on M$ VC the virtual bool QgsMapTool::gestureEvent( QGestureEvent *e ) method must return a value
