### PR TITLE
Additional fix for #5862 fix.

### DIFF
--- a/src/app/composer/qgscomposerlabelwidget.cpp
+++ b/src/app/composer/qgscomposerlabelwidget.cpp
@@ -42,8 +42,10 @@ void QgsComposerLabelWidget::on_mTextEdit_textChanged()
   if ( mComposerLabel )
   {
     mComposerLabel->beginCommand( tr( "Label text changed" ), QgsComposerMergeCommand::ComposerLabelSetText );
+    mComposerLabel->blockSignals( true );
     mComposerLabel->setText( mTextEdit->toPlainText() );
     mComposerLabel->update();
+    mComposerLabel->blockSignals( false );
     mComposerLabel->endCommand();
   }
 }


### PR DESCRIPTION
Editing text for composer label in text edit widget caused label to emit itemChanged(), which caused cyclical update of gui elements and the cursor to jump to end of text edit's text.
Tested update of label via Python and #5862 fix still works, i.e. text edit updates as well.
