### PR TITLE
Update to usability of rule-based styles widgets.

### DIFF
--- a/src/gui/symbology-ng/qgsrulebasedrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgsrulebasedrendererv2widget.cpp
@@ -89,6 +89,14 @@ QgsRuleBasedRendererV2Widget::QgsRuleBasedRendererV2Widget( QgsVectorLayer* laye
   connect( btnRenderingOrder, SIGNAL( clicked() ), this, SLOT( setRenderingOrder() ) );
 
   currentRuleChanged();
+
+  //expand headerview to width of widget by streching expression column
+  viewRules->header()->resizeSection( 0, 200 );
+  viewRules->header()->setResizeMode( 0, QHeaderView::Interactive );
+  viewRules->header()->setResizeMode( 1, QHeaderView::Stretch );
+  viewRules->header()->setResizeMode( 2, QHeaderView::Interactive );
+  viewRules->header()->setResizeMode( 3, QHeaderView::Interactive );
+
 }
 
 QgsRuleBasedRendererV2Widget::~QgsRuleBasedRendererV2Widget()
@@ -379,8 +387,10 @@ QgsRendererRulePropsDialog::QgsRendererRulePropsDialog( QgsRuleBasedRendererV2::
   connect( buttonBox, SIGNAL( rejected() ), this, SLOT( reject() ) );
 
   editFilter->setText( mRule->filterExpression() );
+  editFilter->setToolTip( mRule->filterExpression() );
   editLabel->setText( mRule->label() );
   editDescription->setText( mRule->description() );
+  editDescription->setToolTip( mRule->description() );
 
   if ( mRule->dependsOnScale() )
   {
@@ -518,7 +528,7 @@ QVariant QgsRuleBasedRendererV2Model::data( const QModelIndex &index, int role )
 
   QgsRuleBasedRendererV2::Rule* rule = ruleForIndex( index );
 
-  if ( role == Qt::DisplayRole )
+  if ( role == Qt::DisplayRole || role == Qt::ToolTipRole )
   {
     switch ( index.column() )
     {

--- a/src/ui/qgsrendererrulepropsdialogbase.ui
+++ b/src/ui/qgsrendererrulepropsdialogbase.ui
@@ -16,6 +16,9 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QFormLayout" name="formLayout">
+     <property name="fieldGrowthPolicy">
+      <enum>QFormLayout::ExpandingFieldsGrow</enum>
+     </property>
      <item row="0" column="0">
       <widget class="QLabel" name="label_1">
        <property name="text">

--- a/src/ui/qgsrulebasedrendererv2widget.ui
+++ b/src/ui/qgsrulebasedrendererv2widget.ui
@@ -37,6 +37,12 @@
      <property name="allColumnsShowFocus">
       <bool>true</bool>
      </property>
+     <attribute name="headerMinimumSectionSize">
+      <number>100</number>
+     </attribute>
+     <attribute name="headerStretchLastSection">
+      <bool>false</bool>
+     </attribute>
     </widget>
    </item>
    <item>


### PR DESCRIPTION
Previously, last column was stretching, causing repetitive resizing of columns to view rule name and expressions.
Now, label column has a larger initial width and expression column stretches. All items now have tool tips of their content (good for small screens).
Rule editing dialog now has expanding width for initial form fields and tool tips for expression and description fields.
