### PR TITLE
Update to usability of rule-based styles widgets.

### DIFF
--- a/src/gui/symbology-ng/qgsrulebasedrendererv2widget.h
+++ b/src/gui/symbology-ng/qgsrulebasedrendererv2widget.h
@@ -107,6 +107,9 @@ class GUI_EXPORT QgsRuleBasedRendererV2Widget : public QgsRendererV2Widget, priv
 
     void currentRuleChanged( const QModelIndex& current = QModelIndex(), const QModelIndex& previous = QModelIndex() );
 
+    void saveSectionWidth( int section, int oldSize, int newSize );
+    void restoreSectionWidths();
+
   protected:
 
     void refineRule( int type );

--- a/src/ui/qgsrendererrulepropsdialogbase.ui
+++ b/src/ui/qgsrendererrulepropsdialogbase.ui
@@ -16,6 +16,9 @@
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
     <layout class="QFormLayout" name="formLayout">
+     <property name="fieldGrowthPolicy">
+      <enum>QFormLayout::ExpandingFieldsGrow</enum>
+     </property>
      <item row="0" column="0">
       <widget class="QLabel" name="label_1">
        <property name="text">

--- a/src/ui/qgsrulebasedrendererv2widget.ui
+++ b/src/ui/qgsrulebasedrendererv2widget.ui
@@ -37,6 +37,12 @@
      <property name="allColumnsShowFocus">
       <bool>true</bool>
      </property>
+     <attribute name="headerMinimumSectionSize">
+      <number>100</number>
+     </attribute>
+     <attribute name="headerStretchLastSection">
+      <bool>true</bool>
+     </attribute>
     </widget>
    </item>
    <item>


### PR DESCRIPTION
Rule-based tree widget:
- Label and expression header sections have a larger initial width of 200, with new minimum width of 100 for all sections.
- Resizing of first 3 sections are saved to/restored from QSettings. Last section stretches, so is not saved/restored.
- All items now have tool tips of their content (good for small screens).

Rule editing dialog:
- Expanded width for initial form fields
- Added tool tips for expression and description fields.
