### PR TITLE
sip binding for QgsLabelingEngineInterface::labelsWithinRect()

### DIFF
--- a/python/core/qgsmaprenderer.sip
+++ b/python/core/qgsmaprenderer.sip
@@ -28,6 +28,9 @@ public:
   //! return infos about labels at a given (map) position
   //! @note: this method was added in version 1.7
   virtual QList<QgsLabelPosition> labelsAtPosition( const QgsPoint& p )= 0;
+  //! return infos about labels within a given (map) rectangle
+  //! @note: this method was added in version 1.9
+  virtual QList<QgsLabelPosition> labelsWithinRect( const QgsRectangle& r ) = 0;
 
 
   //! called when passing engine among map renderers

--- a/src/core/qgsmaprenderer.h
+++ b/src/core/qgsmaprenderer.h
@@ -89,6 +89,9 @@ class QgsLabelingEngineInterface
     //! return infos about labels at a given (map) position
     //! @note: this method was added in version 1.7
     virtual QList<QgsLabelPosition> labelsAtPosition( const QgsPoint& p ) = 0;
+    //! return infos about labels within a given (map) rectangle
+    //! @note: this method was added in version 1.9
+    virtual QList<QgsLabelPosition> labelsWithinRect( const QgsRectangle& r ) = 0;
 
     //! called when passing engine among map renderers
     virtual QgsLabelingEngineInterface* clone() = 0;


### PR DESCRIPTION
canvas = qgis.utils.iface.mapCanvas()
ext = canvas.extent()
labels = canvas.mapRenderer().labelingEngine().labelsWithinRect(ext)

returns labels shown within the canvas (QList of QgsLabelPosition)
