### PR TITLE
Update to freeze/thaw label tool

### DIFF
--- a/doc/CONTRIBUTORS
+++ b/doc/CONTRIBUTORS
@@ -29,9 +29,10 @@ Giuseppe Sucameli
 Horst Duester
 Hyao (IRC nickname)
 Ivan Lucena
-Jean-Denis Giguere 
+Jean-Denis Giguere
 Jeremy Palmer
 Jerrit Collord
+Larry Shaffer
 Luiz Motta
 Magnus Homann
 Marco Pasetti
@@ -53,5 +54,5 @@ Tamas Szekeres
 Tom Russo
 Tyler Mitchell
 Vita Cizek
-Yann Chemin 
+Yann Chemin
 Includes Map icons CC-0 from SJJB Management

--- a/src/app/qgsmaptoolfreezelabels.h
+++ b/src/app/qgsmaptoolfreezelabels.h
@@ -95,6 +95,9 @@ class QgsMapToolFreezeLabels: public QgsMapToolLabel
     bool freezeThawLabel( QgsVectorLayer* vlayer,
                           const QgsLabelPosition& labelpos,
                           bool freeze );
+
+    //! Hide chosen label by setting font size to 0
+    bool hideLabel( QgsVectorLayer* vlayer, const QgsLabelPosition& labelpos );
 };
 
 #endif // QGSMAPTOOLFREEZELABELS_H

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -1716,13 +1716,9 @@
    <property name="text">
     <string>Freeze or Thaw Labels</string>
    </property>
-   <property name="whatsThis">
-    <string>Freeze (write label location and optionally rotation) to attribute table.
-
-Click on individual labels, or draw a marquee (labels touching will be included). Actions on in-memory attribute table fields are immediate.
-
-Hold Shift key down to Thaw (write NULLs to attribute table), reverting label to dynamic.
-Hold Alt key down to toggle selected labels between Frozen and Thawed states.</string>
+   <property name="toolTip">
+    <string>Freeze or Thaw Labels
+Shift thaws, Alt toggles, Ctl (Cmd) hides</string>
    </property>
   </action>
   <action name="mActionShowFrozenLabels">


### PR DESCRIPTION
Added ability to hide label(s), i.e. set font size to 0, by holding Ctl (Cmd on Mac) modifier key.
This is a temporary convenience function, until there is a specifically mapped field for showing/hiding a label.
Silently fails if no font size field is mapped.

Dropped What's This? text in favor of concise tool tip for freeze/thaw tool.

Added self to CONTRIBUTORS. Stripped trailing whitespace from that file.
