### PR TITLE
Fix and update to Move Label tool

### DIFF
--- a/src/app/qgsmaptoollabel.cpp
+++ b/src/app/qgsmaptoollabel.cpp
@@ -399,6 +399,40 @@ bool QgsMapToolLabel::dataDefinedPosition( QgsVectorLayer* vlayer, int featureId
   return true;
 }
 
+bool QgsMapToolLabel::dataDefinedRotation( QgsVectorLayer* vlayer, int featureId, double& r, bool& rSuccess, int& rCol ) const
+{
+  rSuccess = false;
+
+  if ( !vlayer || !vlayer->isEditable() )
+  {
+    return false;
+  }
+
+  bool rColOk;
+
+  QVariant rColumn = vlayer->customProperty( "labeling/dataDefinedProperty14" );
+  if ( !rColumn.isValid() )
+  {
+    return false;
+  }
+  rCol = rColumn.toInt( &rColOk );
+  if ( !rColOk )
+  {
+    return false;
+  }
+
+  QgsFeature f;
+  if ( !vlayer->featureAtId( featureId, f, false, true ) )
+  {
+    return false;
+  }
+
+  QgsAttributeMap attributes = f.attributeMap();
+  r = attributes[rCol].toDouble( &rSuccess );
+
+  return true;
+}
+
 bool QgsMapToolLabel:: diagramMoveable( const QgsMapLayer* ml, int& xCol, int& yCol ) const
 {
   const QgsVectorLayer* vlayer = dynamic_cast<const QgsVectorLayer*>( ml );

--- a/src/app/qgsmaptoollabel.h
+++ b/src/app/qgsmaptoollabel.h
@@ -100,6 +100,15 @@ class QgsMapToolLabel: public QgsMapTool
       @return false if layer does not have data defined label position enabled*/
     bool dataDefinedPosition( QgsVectorLayer* vlayer, int featureId, double& x, bool& xSuccess, double& y, bool& ySuccess, int& xCol, int& yCol ) const;
 
+    /**Get data defined rotation of a feature
+      @param layerId layer identification string
+      @param featureId feature identification integer
+      @param r out: data defined rotation
+      @param rSuccess out: false if attribute value is NULL
+      @param rCol out: index of the rotation column
+      @return false if layer does not have data defined label rotation enabled*/
+    bool dataDefinedRotation( QgsVectorLayer* vlayer, int featureId, double& r, bool& rSuccess, int& rCol ) const;
+
   private:
     QgsPalLayerSettings mInvalidLabelSettings;
 };


### PR DESCRIPTION
- Tool now preserves calculated x, y offset for upside-down labels, when initially moved and data-defined fields have no previous data.
- Tool now stores the label's PAL solution for rotation on initial move, i.e. label's rotation is maintained in the canvas drag and stored to the attribute table, if rotation is data-defined.
