### PR TITLE
Debugging of all files in a directory

### DIFF
--- a/src/core/qgslogger.cpp
+++ b/src/core/qgslogger.cpp
@@ -35,7 +35,7 @@ void QgsLogger::debug( const QString& msg, int debuglevel, const char* file, con
   const char* dfile = debugFile();
   if ( dfile ) //exit if QGIS_DEBUG_FILE is set and the message comes from the wrong file
   {
-    if ( !file || strcmp( dfile, file ) != 0 )
+    if ( !file || strncmp( dfile, file, strlen( dfile ) ) != 0 )
     {
       return;
     }
@@ -82,7 +82,7 @@ void QgsLogger::debug( const QString& var, int val, int debuglevel, const char* 
   const char* dfile = debugFile();
   if ( dfile ) //exit if QGIS_DEBUG_FILE is set and the message comes from the wrong file
   {
-    if ( !file || strcmp( dfile, file ) != 0 )
+    if ( !file || strncmp( dfile, file, strlen( dfile ) ) != 0 )
     {
       return;
     }
@@ -123,7 +123,7 @@ void QgsLogger::debug( const QString& var, double val, int debuglevel, const cha
   const char* dfile = debugFile();
   if ( dfile ) //exit if QGIS_DEBUG_FILE is set and the message comes from the wrong file
   {
-    if ( !file || strcmp( dfile, file ) != 0 )
+    if ( !file || strncmp( dfile, file, strlen( dfile ) ) != 0 )
     {
       return;
     }

--- a/src/mapserver/qgshttprequesthandler.cpp
+++ b/src/mapserver/qgshttprequesthandler.cpp
@@ -29,7 +29,6 @@
 #include <QStringList>
 #include <QUrl>
 #include <fcgi_stdio.h>
-#include "qgslogger.h"
 
 QgsHttpRequestHandler::QgsHttpRequestHandler(): QgsRequestHandler()
 {

--- a/src/mapserver/qgswfsserver.cpp
+++ b/src/mapserver/qgswfsserver.cpp
@@ -39,7 +39,6 @@
 #include "qgsrenderer.h"
 #include "qgslegendmodel.h"
 #include "qgscomposerlegenditem.h"
-#include "qgslogger.h"
 #include "qgsrequesthandler.h"
 #include <QImage>
 #include <QPainter>

--- a/src/mapserver/qgswmsserver.cpp
+++ b/src/mapserver/qgswmsserver.cpp
@@ -39,7 +39,6 @@
 #include "qgsrendererv2.h"
 #include "qgslegendmodel.h"
 #include "qgscomposerlegenditem.h"
-#include "qgslogger.h"
 #include "qgspaintenginehack.h"
 
 #include <QImage>


### PR DESCRIPTION
old style:
SET QGIS_DEBUG_FILE=D:\git\qgis\src\providers\wfs\qgswfsdata.cpp

new style:
SET QGIS_DEBUG_FILE=D:\git\qgis\src\providers\wfs\

log file look like:

```
D:\git\qgis\src\providers\wfs\qgswfsdata.cpp(66) : (QgsWFSData::QgsWFSData) mTypeName is: OEKOLENTFLOGD
D:\git\qgis\src\providers\wfs\qgswfsprovider.cpp(789) : (QgsWFSProvider::getFeatureGET) feature count after request is: 0
D:\git\qgis\src\providers\wfs\qgswfsprovider.cpp(790) : (QgsWFSProvider::getFeatureGET) mExtent after request is: Empty
D:\git\qgis\src\providers\wfs\qgswfssourceselect.cpp(75) : (QgsWFSSourceSelect::~QgsWFSSourceSelect) saving geometry
```
