### PR TITLE
Implement #3430: fill pattern missing for point markers in new symbology

### DIFF
--- a/src/app/qgsdecorationgrid.cpp
+++ b/src/app/qgsdecorationgrid.cpp
@@ -158,7 +158,7 @@ void QgsDecorationGrid::projectRead()
     // set default symbol : cross with width=20
     QgsSymbolLayerV2List symbolList;
     symbolList << new QgsSimpleMarkerSymbolLayerV2( "cross", DEFAULT_SIMPLEMARKER_COLOR,
-        DEFAULT_SIMPLEMARKER_BORDERCOLOR, 20, 0 );
+        DEFAULT_SIMPLEMARKER_STYLE , DEFAULT_SIMPLEMARKER_BORDERCOLOR, 20, 0 );
     mMarkerSymbol = new QgsMarkerSymbolV2( symbolList );
     // mMarkerSymbol = new QgsMarkerSymbolV2();
   }

--- a/src/core/symbology-ng/qgsfillsymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgsfillsymbollayerv2.cpp
@@ -80,12 +80,16 @@ void QgsSimpleFillSymbolLayerV2::startRender( QgsSymbolV2RenderContext& context 
   }
 
   QColor selColor = context.selectionColor();
-  // selColor.setAlphaF( context.alpha() );
+  QColor selPenColor = selColor == mColor ? selColor : mBorderColor;
+  if ( ! selectionIsOpaque ) selColor.setAlphaF( context.alpha() );
   mSelBrush = QBrush( selColor );
+  // N.B. unless a "selection line colour" is implemented in addition to the "selection colour" option
+  // this would mean symbols with "no fill" look the same whether or not they are selected
   if ( selectFillStyle )
     mSelBrush.setStyle( mBrushStyle );
   mBorderColor.setAlphaF( context.alpha() );
   mPen = QPen( mBorderColor );
+  mSelPen = QPen( selPenColor );
   mPen.setStyle( mBorderStyle );
   mPen.setWidthF( context.outputLineWidth( mBorderWidth ) );
 }
@@ -105,6 +109,7 @@ void QgsSimpleFillSymbolLayerV2::renderPolygon( const QPolygonF& points, QList<Q
 
   p->setBrush( context.selected() ? mSelBrush : mBrush );
   p->setPen( mPen );
+  p->setPen( context.selected() ? mSelPen : mPen );
 
   if ( !mOffset.isNull() )
     p->translate( mOffset );
@@ -213,8 +218,9 @@ void QgsImageFillSymbolLayer::renderPolygon( const QPolygonF& points, QList<QPol
   if ( context.selected() )
   {
     QColor selColor = context.selectionColor();
-    if ( ! selectionIsOpaque )
-      selColor.setAlphaF( context.alpha() );
+    // Alister - this doesn't seem to work here
+    //if ( ! selectionIsOpaque )
+    //  selColor.setAlphaF( context.alpha() );
     p->setBrush( QBrush( selColor ) );
     _renderPolygon( p, points, rings );
   }

--- a/src/core/symbology-ng/qgsfillsymbollayerv2.h
+++ b/src/core/symbology-ng/qgsfillsymbollayerv2.h
@@ -80,6 +80,7 @@ class CORE_EXPORT QgsSimpleFillSymbolLayerV2 : public QgsFillSymbolLayerV2
     Qt::PenStyle mBorderStyle;
     double mBorderWidth;
     QPen mPen;
+    QPen mSelPen;
 
     QPointF mOffset;
 };

--- a/src/core/symbology-ng/qgsmarkersymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgsmarkersymbollayerv2.cpp
@@ -513,6 +513,7 @@ QgsSymbolLayerV2* QgsSimpleMarkerSymbolLayerV2::createFromSld( QDomElement &elem
   //Does SLD support marker symbol fill styles?  If so then we'll need more work to import them.
   //But I guess they wouldn't match the QT fill patterns anyway.
   QgsMarkerSymbolLayerV2 *m = new QgsSimpleMarkerSymbolLayerV2( name, color, DEFAULT_SIMPLEMARKER_STYLE, borderColor, size);
+  m->setAngle( angle );
   m->setOffset( offset );
   return m;
 }

--- a/src/core/symbology-ng/qgsmarkersymbollayerv2.h
+++ b/src/core/symbology-ng/qgsmarkersymbollayerv2.h
@@ -20,6 +20,7 @@
 
 #define DEFAULT_SIMPLEMARKER_NAME         "circle"
 #define DEFAULT_SIMPLEMARKER_COLOR        QColor(255,0,0)
+#define DEFAULT_SIMPLEMARKER_STYLE        Qt::SolidPattern
 #define DEFAULT_SIMPLEMARKER_BORDERCOLOR  QColor(0,0,0)
 #define DEFAULT_SIMPLEMARKER_SIZE         DEFAULT_POINT_SIZE
 #define DEFAULT_SIMPLEMARKER_ANGLE        0
@@ -35,6 +36,7 @@ class CORE_EXPORT QgsSimpleMarkerSymbolLayerV2 : public QgsMarkerSymbolLayerV2
   public:
     QgsSimpleMarkerSymbolLayerV2( QString name = DEFAULT_SIMPLEMARKER_NAME,
                                   QColor color = DEFAULT_SIMPLEMARKER_COLOR,
+                                  Qt::BrushStyle style = DEFAULT_SIMPLEMARKER_STYLE,
                                   QColor borderColor = DEFAULT_SIMPLEMARKER_BORDERCOLOR,
                                   double size = DEFAULT_SIMPLEMARKER_SIZE,
                                   double angle = DEFAULT_SIMPLEMARKER_ANGLE );
@@ -57,6 +59,9 @@ class CORE_EXPORT QgsSimpleMarkerSymbolLayerV2 : public QgsMarkerSymbolLayerV2
     QgsStringMap properties() const;
 
     QgsSymbolLayerV2* clone() const;
+
+    Qt::BrushStyle brushStyle() const { return mBrushStyle; }
+    void setBrushStyle( Qt::BrushStyle style ) { mBrushStyle = style; }
 
     void writeSldMarker( QDomDocument &doc, QDomElement &element, QgsStringMap props ) const;
 
@@ -81,6 +86,7 @@ class CORE_EXPORT QgsSimpleMarkerSymbolLayerV2 : public QgsMarkerSymbolLayerV2
     QPolygonF mPolygon;
     QPainterPath mPath;
     QString mName;
+    Qt::BrushStyle mBrushStyle;
     QImage mCache;
     QPen mSelPen;
     QBrush mSelBrush;

--- a/src/core/symbology-ng/qgssymbologyv2conversion.cpp
+++ b/src/core/symbology-ng/qgssymbologyv2conversion.cpp
@@ -46,7 +46,8 @@ QgsSymbolV2* QgsSymbologyV2Conversion::symbolV1toV2( const QgsSymbol* s )
         QColor color = s->fillColor();
         QColor borderColor = s->color();
         QString name = symbolName.mid( 5 );
-        sl = new QgsSimpleMarkerSymbolLayerV2( name, color, borderColor, size, angle );
+        Qt::BrushStyle brushStyle = s->brush().style();
+        sl = new QgsSimpleMarkerSymbolLayerV2( name, color, brushStyle, borderColor, size, angle );
       }
       else
       {

--- a/src/gui/symbology-ng/qgssymbollayerv2widget.cpp
+++ b/src/gui/symbology-ng/qgssymbollayerv2widget.cpp
@@ -192,9 +192,10 @@ QgsSimpleMarkerSymbolLayerV2Widget::QgsSimpleMarkerSymbolLayerV2Widget( const Qg
   names << "circle" << "rectangle" << "diamond" << "pentagon" << "cross" << "cross2" << "triangle"
   << "equilateral_triangle" << "star" << "regular_star" << "arrow" << "line" << "arrowhead" << "filled_arrowhead";
   double markerSize = DEFAULT_POINT_SIZE * 2;
+  Qt::BrushStyle brushStyle =   DEFAULT_SIMPLEFILL_STYLE ;
   for ( int i = 0; i < names.count(); ++i )
   {
-    QgsSimpleMarkerSymbolLayerV2* lyr = new QgsSimpleMarkerSymbolLayerV2( names[i], QColor( 200, 200, 200 ), QColor( 0, 0, 0 ), markerSize );
+    QgsSimpleMarkerSymbolLayerV2* lyr = new QgsSimpleMarkerSymbolLayerV2( names[i], QColor( 200, 200, 200 ), brushStyle, QColor( 0, 0, 0 ), markerSize );
     QIcon icon = QgsSymbolLayerV2Utils::symbolLayerPreviewIcon( lyr, QgsSymbolV2::MM, size );
     QListWidgetItem* item = new QListWidgetItem( icon, QString(), lstNames );
     item->setData( Qt::UserRole, names[i] );
@@ -206,6 +207,7 @@ QgsSimpleMarkerSymbolLayerV2Widget::QgsSimpleMarkerSymbolLayerV2Widget( const Qg
   connect( btnChangeColorFill, SIGNAL( clicked() ), this, SLOT( setColorFill() ) );
   connect( spinSize, SIGNAL( valueChanged( double ) ), this, SLOT( setSize() ) );
   connect( spinAngle, SIGNAL( valueChanged( double ) ), this, SLOT( setAngle() ) );
+   connect( cboFillStyleMarker,SIGNAL( currentIndexChanged( int ) ), this, SLOT( setBrushStyle() )) ;
   connect( spinOffsetX, SIGNAL( valueChanged( double ) ), this, SLOT( setOffset() ) );
   connect( spinOffsetY, SIGNAL( valueChanged( double ) ), this, SLOT( setOffset() ) );
 }
@@ -232,6 +234,7 @@ void QgsSimpleMarkerSymbolLayerV2Widget::setSymbolLayer( QgsSymbolLayerV2* layer
   btnChangeColorFill->setColor( mLayer->color() );
   spinSize->setValue( mLayer->size() );
   spinAngle->setValue( mLayer->angle() );
+  cboFillStyleMarker->setBrushStyle( mLayer->brushStyle() );
 
   // without blocking signals the value gets changed because of slot setOffset()
   spinOffsetX->blockSignals( true );
@@ -284,6 +287,12 @@ void QgsSimpleMarkerSymbolLayerV2Widget::setColorFill()
     return;
   mLayer->setColor( color );
   btnChangeColorFill->setColor( mLayer->color() );
+  emit changed();
+}
+
+void QgsSimpleMarkerSymbolLayerV2Widget::setBrushStyle()
+{
+  mLayer->setBrushStyle( cboFillStyleMarker->brushStyle() );
   emit changed();
 }
 

--- a/src/gui/symbology-ng/qgssymbollayerv2widget.h
+++ b/src/gui/symbology-ng/qgssymbollayerv2widget.h
@@ -19,6 +19,7 @@
 
 #include <QWidget>
 
+#define DEFAULT_SIMPLEFILL_STYLE        Qt::SolidPattern
 class QgsSymbolLayerV2;
 class QgsVectorLayer;
 
@@ -99,6 +100,7 @@ class GUI_EXPORT QgsSimpleMarkerSymbolLayerV2Widget : public QgsSymbolLayerV2Wid
     void setName();
     void setColorBorder();
     void setColorFill();
+    void setBrushStyle();
     void setSize();
     void setAngle();
     void setOffset();

--- a/src/ui/symbollayer/widget_simplemarker.ui
+++ b/src/ui/symbollayer/widget_simplemarker.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>394</width>
-    <height>275</height>
+    <height>305</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -63,21 +63,21 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="0">
+     <item row="3" column="0">
       <widget class="QLabel" name="label_3">
        <property name="text">
         <string>Size</string>
        </property>
       </widget>
      </item>
-     <item row="3" column="0">
+     <item row="5" column="0">
       <widget class="QLabel" name="label_4">
        <property name="text">
         <string>Angle</string>
        </property>
       </widget>
      </item>
-     <item row="3" column="1">
+     <item row="5" column="1">
       <widget class="QDoubleSpinBox" name="spinAngle">
        <property name="decimals">
         <number>2</number>
@@ -90,14 +90,14 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="0">
+     <item row="6" column="0">
       <widget class="QLabel" name="label_5">
        <property name="text">
         <string>Offset X,Y</string>
        </property>
       </widget>
      </item>
-     <item row="4" column="1">
+     <item row="6" column="1">
       <layout class="QHBoxLayout" name="horizontalLayout">
        <item>
         <widget class="QDoubleSpinBox" name="spinOffsetX">
@@ -121,7 +121,7 @@
        </item>
       </layout>
      </item>
-     <item row="2" column="1">
+     <item row="3" column="1">
       <widget class="QDoubleSpinBox" name="spinSize">
        <property name="decimals">
         <number>5</number>
@@ -133,6 +133,16 @@
         <double>1.000000000000000</double>
        </property>
       </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_6">
+       <property name="text">
+        <string>Fill Style</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QgsBrushStyleComboBox" name="cboFillStyleMarker"/>
      </item>
     </layout>
    </item>
@@ -158,9 +168,6 @@
      </property>
      <property name="flow">
       <enum>QListView::LeftToRight</enum>
-     </property>
-     <property name="resizeMode">
-      <enum>QListView::Adjust</enum>
      </property>
      <property name="spacing">
       <number>4</number>
@@ -199,6 +206,11 @@
  </widget>
  <customwidgets>
   <customwidget>
+   <class>Q3ComboBox</class>
+   <extends>QWidget</extends>
+   <header>Qt3Support/Q3ComboBox</header>
+  </customwidget>
+   <customwidget>   
    <class>QgsColorButtonV2</class>
    <extends>QPushButton</extends>
    <header>qgscolorbutton.h</header>


### PR DESCRIPTION
N.B. technically the second commit is unrelated to #3430
