### PR TITLE
The QgslegendInterface implementation manages only top level items

### DIFF
--- a/src/app/legend/qgsapplegendinterface.h
+++ b/src/app/legend/qgsapplegendinterface.h
@@ -94,6 +94,7 @@ class QgsAppLegendInterface : public QgsLegendInterface
 
     //! Pointer to QgsLegend object
     QgsLegend *mLegend;
+		QTreeWidgetItem *getItem(int itemIndex);
 };
 
 #endif //QGSLEGENDAPPIFACE_H

--- a/src/app/legend/qgslegend.cpp
+++ b/src/app/legend/qgslegend.cpp
@@ -231,8 +231,27 @@ int QgsLegend::addGroup( QString name, bool expand, QTreeWidgetItem* parent )
 
 int QgsLegend::addGroup( QString name, bool expand, int groupIndex )
 {
-  QgsLegendGroup * lg = dynamic_cast<QgsLegendGroup *>( topLevelItem( groupIndex ) );
-  return addGroup( name, expand, lg );
+  QTreeWidgetItem * parentItem = invisibleRootItem();
+
+	int itemCount = 0;
+	for ( QTreeWidgetItem* theItem = firstItem(); theItem; theItem = nextItem( theItem ) )
+	{
+		QgsLegendItem* legendItem = dynamic_cast<QgsLegendItem *>( theItem );
+		if (legendItem->type() == QgsLegendItem::LEGEND_GROUP) {
+			if (itemCount == groupIndex) 
+			{
+				// this is the matching group
+				parentItem = legendItem;
+				break;
+			}
+			else 
+			{
+				itemCount = itemCount + 1;
+			}
+		}
+	}
+
+  return addGroup( name, expand, parentItem );
 }
 
 void QgsLegend::removeAll()
@@ -276,7 +295,26 @@ void QgsLegend::setLayersVisible( bool visible )
 
 void QgsLegend::removeGroup( int groupIndex )
 {
-  QgsLegendGroup * lg = dynamic_cast<QgsLegendGroup *>( topLevelItem( groupIndex ) );
+  QgsLegendGroup * lg = NULL;
+	int itemCount = 0;
+
+	for ( QTreeWidgetItem* theItem = firstItem(); theItem; theItem = nextItem( theItem ) )
+	{
+		QgsLegendItem* legendItem = dynamic_cast<QgsLegendItem *>( theItem );
+		if (legendItem->type() == QgsLegendItem::LEGEND_GROUP) {
+			if (itemCount == groupIndex) 
+			{
+				// this is the matching group
+				lg = dynamic_cast<QgsLegendGroup*>( legendItem );
+				break;
+			}
+			else 
+			{
+				itemCount = itemCount + 1;
+			}
+		}
+	}
+
   if ( lg )
   {
     removeGroup( lg );
@@ -1252,8 +1290,28 @@ void QgsLegend::moveLayer( QgsMapLayer *ml, int groupIndex )
   if ( !layer )
     return;
 
-  QgsLegendGroup *group = dynamic_cast<QgsLegendGroup*>( topLevelItem( groupIndex ) );
-  if ( !group )
+	int itemCount = 0;
+	QgsLegendGroup *group = NULL;
+
+	for ( QTreeWidgetItem* theItem = firstItem(); theItem; theItem = nextItem( theItem ) )
+	{
+
+		QgsLegendItem* legendItem = dynamic_cast<QgsLegendItem *>( theItem );
+		if (legendItem->type() == QgsLegendItem::LEGEND_GROUP) {
+			if (itemCount == groupIndex) 
+			{
+				// this is the matching group
+				group = dynamic_cast<QgsLegendGroup*>( legendItem );
+				break;
+			}
+			else 
+			{
+				itemCount = itemCount + 1;
+			}
+		}
+	}
+
+	if ( group == NULL)
     return;
 
   insertItem( layer, group );


### PR DESCRIPTION
I need to create a groups/layers hierarchy starting from a third-party xml file. The QgslegendInterface implementation is limited to manage only top level item. I've no chance to create sub groups other than inside a top level group or add a layer into a sub-group.
The groupIndex/parentIndex used by the members of QgslegendInterface is used as an item index to top level items in the legend. So far the following members are limited to work only with top level items:
- addGroup(QString name, bool expand, int parentIndex)
- groupExists(int groupIndex)
- isGroupExpanded(int groupIndex)
- isGroupVisible(int groupIndex)
- moveLayer(QgsMapLayer *ml, int groupIndex)
- removeGroup(int groupIndex)
- setGroupExpanded(int groupIndex, bool expand)
- setGroupVisible(int groupIndex, bool visible)

I've modified the previous members in the way the groupIndex is a true index to all group hierarchy. Now the groupIndex values are in range 0 to len(QgslegendInterface.groups()). 

Furthermore it would be usefull a moveLayer/moveGroup member to move a layer/group after or before another layer/group. In this way it would be possible to create a new project with an exact groups/layers hierarchy or integrate an existing project with a fragment o groups/layers hierarchy.
