### PR TITLE
Measure cleanup and fix #5156

### DIFF
--- a/src/app/qgsdecorationscalebar.h
+++ b/src/app/qgsdecorationscalebar.h
@@ -21,6 +21,7 @@ email                : sbr00pwb@users.sourceforge.net
 #ifndef QGSCALEBARPLUGIN
 #define QGSCALEBARPLUGIN
 
+#include "qgis.h"
 #include "qgsdecorationitem.h"
 
 class QPainter;

--- a/src/app/qgsdisplayangle.cpp
+++ b/src/app/qgsdisplayangle.cpp
@@ -26,9 +26,6 @@ QgsDisplayAngle::QgsDisplayAngle( QgsMapToolMeasureAngle * tool, Qt::WFlags f )
   setupUi( this );
   QSettings settings;
 
-  // Update when the ellipsoidal button has changed state.
-  connect( mcbProjectionEnabled, SIGNAL( stateChanged( int ) ),
-           this, SLOT( ellipsoidalButton() ) );
   // Update whenever the canvas has refreshed. Maybe more often than needed,
   // but at least every time any canvas related settings changes
   connect( mTool->canvas(), SIGNAL( mapCanvasRefreshed() ),
@@ -42,10 +39,6 @@ QgsDisplayAngle::~QgsDisplayAngle()
 
 }
 
-bool QgsDisplayAngle::projectionEnabled()
-{
-  return mcbProjectionEnabled->isChecked();
-}
 
 void QgsDisplayAngle::setValueInRadians( double value )
 {
@@ -53,52 +46,13 @@ void QgsDisplayAngle::setValueInRadians( double value )
   updateUi();
 }
 
-void QgsDisplayAngle::ellipsoidalButton()
-{
-  QSettings settings;
-
-  // We set check state to Unchecked and button to Disabled when disabling CRS,
-  // which generates a call here. Ignore that event!
-  if ( mcbProjectionEnabled->isEnabled() )
-  {
-    if ( mcbProjectionEnabled->isChecked() )
-    {
-      settings.setValue( "/qgis/measure/projectionEnabled", 2 );
-    }
-    else
-    {
-      settings.setValue( "/qgis/measure/projectionEnabled", 0 );
-    }
-    updateSettings();
-  }
-}
-
 void QgsDisplayAngle::updateSettings()
 {
-  QSettings settings;
-
-  int s = settings.value( "/qgis/measure/projectionEnabled", "2" ).toInt();
-  if ( s == 2 )
-  {
-    mEllipsoidal = true;
-  }
-  else
-  {
-    mEllipsoidal = false;
-  }
-  QgsDebugMsg( "****************" );
-  QgsDebugMsg( QString( "Ellipsoidal: %1" ).arg( mEllipsoidal ? "true" : "false" ) );
-
-  updateUi();
   emit changeProjectionEnabledState();
-
 }
 
 void QgsDisplayAngle::updateUi()
 {
-  mcbProjectionEnabled->setEnabled( mTool->canvas()->hasCrsTransformEnabled() );
-  mcbProjectionEnabled->setCheckState( mTool->canvas()->hasCrsTransformEnabled()
-                                       && mEllipsoidal ? Qt::Checked : Qt::Unchecked );
 
   QSettings settings;
   QString unitString = settings.value( "/qgis/measure/angleunits", "degrees" ).toString();

--- a/src/app/qgsdisplayangle.h
+++ b/src/app/qgsdisplayangle.h
@@ -16,6 +16,7 @@
 #ifndef QGSDISPLAYANGLE_H
 #define QGSDISPLAYANGLE_H
 
+#include "qgsmaptoolmeasureangle.h"
 #include "ui_qgsdisplayanglebase.h"
 
 /**A class that displays results of angle measurements with the proper unit*/
@@ -24,7 +25,7 @@ class QgsDisplayAngle: public QDialog, private Ui::QgsDisplayAngleBase
     Q_OBJECT
 
   public:
-    QgsDisplayAngle( QWidget * parent = 0, Qt::WindowFlags f = 0 );
+    QgsDisplayAngle( QgsMapToolMeasureAngle * tool = 0, Qt::WindowFlags f = 0 );
     ~QgsDisplayAngle();
     /**Sets the measured angle value (in radians). The value is going to
       be converted to degrees / gon automatically if necessary*/
@@ -32,12 +33,30 @@ class QgsDisplayAngle: public QDialog, private Ui::QgsDisplayAngleBase
 
     bool projectionEnabled();
 
+
   signals:
     void changeProjectionEnabledState();
 
   private slots:
-    void changeState();
 
+    //! When the ellipsoidal button is pressed/toggled.
+    void ellipsoidalButton();
+
+    //! When any external settings change
+    void updateSettings();
+
+  private:
+    //! pointer to tool which owns this dialog
+    QgsMapToolMeasureAngle * mTool;
+
+    //! Holds what the user last set ellipsoid button to.
+    bool mEllipsoidal;
+
+    //! The value we're showing
+    double mValue;
+
+    //! Updates UI according to user settings.
+    void updateUi();
 };
 
 #endif // QGSDISPLAYANGLE_H

--- a/src/app/qgsdisplayangle.h
+++ b/src/app/qgsdisplayangle.h
@@ -31,16 +31,10 @@ class QgsDisplayAngle: public QDialog, private Ui::QgsDisplayAngleBase
       be converted to degrees / gon automatically if necessary*/
     void setValueInRadians( double value );
 
-    bool projectionEnabled();
-
-
   signals:
     void changeProjectionEnabledState();
 
   private slots:
-
-    //! When the ellipsoidal button is pressed/toggled.
-    void ellipsoidalButton();
 
     //! When any external settings change
     void updateSettings();
@@ -48,9 +42,6 @@ class QgsDisplayAngle: public QDialog, private Ui::QgsDisplayAngleBase
   private:
     //! pointer to tool which owns this dialog
     QgsMapToolMeasureAngle * mTool;
-
-    //! Holds what the user last set ellipsoid button to.
-    bool mEllipsoidal;
 
     //! The value we're showing
     double mValue;

--- a/src/app/qgsmaptoolfeatureaction.cpp
+++ b/src/app/qgsmaptoolfeatureaction.cpp
@@ -15,7 +15,6 @@
 
 #include "qgsmaptoolfeatureaction.h"
 
-#include "qgsdistancearea.h"
 #include "qgsfeature.h"
 #include "qgsfield.h"
 #include "qgsgeometry.h"
@@ -111,7 +110,6 @@ bool QgsMapToolFeatureAction::doAction( QgsVectorLayer *layer, int x, int y )
   // load identify radius from settings
   QSettings settings;
   double identifyValue = settings.value( "/Map/identifyRadius", QGis::DEFAULT_IDENTIFY_RADIUS ).toDouble();
-  QString ellipsoid = settings.value( "/qgis/measure/ellipsoid", "WGS84" ).toString();
 
   if ( identifyValue <= 0.0 )
     identifyValue = QGis::DEFAULT_IDENTIFY_RADIUS;

--- a/src/app/qgsmaptoolidentify.cpp
+++ b/src/app/qgsmaptoolidentify.cpp
@@ -204,7 +204,7 @@ bool QgsMapToolIdentify::identifyVectorLayer( QgsVectorLayer *layer, int x, int 
   // load identify radius from settings
   QSettings settings;
   double identifyValue = settings.value( "/Map/identifyRadius", QGis::DEFAULT_IDENTIFY_RADIUS ).toDouble();
-  QString ellipsoid = settings.value( "/qgis/measure/ellipsoid", "WGS84" ).toString();
+  QString ellipsoid = settings.value( "/qgis/measure/ellipsoid", GEO_NONE ).toString();
 
   if ( identifyValue <= 0.0 )
     identifyValue = QGis::DEFAULT_IDENTIFY_RADIUS;

--- a/src/app/qgsmaptoolidentify.cpp
+++ b/src/app/qgsmaptoolidentify.cpp
@@ -392,17 +392,7 @@ void QgsMapToolIdentify::convertMeasurement( QgsDistanceArea &calc, double &meas
 
   // Get the units for display
   QSettings settings;
-  QString myDisplayUnitsTxt = settings.value( "/qgis/measure/displayunits", "meters" ).toString();
-
-  QGis::UnitType displayUnits;
-  if ( myDisplayUnitsTxt == "feet" )
-  {
-    displayUnits = QGis::Feet;
-  }
-  else
-  {
-    displayUnits = QGis::Meters;
-  }
+  QGis::UnitType displayUnits = QGis::fromLiteral( settings.value( "/qgis/measure/displayunits", QGis::toLiteral( QGis::Meters ) ).toString() );
 
   calc.convertMeasurement( measure, myUnits, displayUnits, isArea );
   u = myUnits;

--- a/src/app/qgsmaptoolmeasureangle.cpp
+++ b/src/app/qgsmaptoolmeasureangle.cpp
@@ -85,7 +85,7 @@ void QgsMapToolMeasureAngle::canvasReleaseEvent( QMouseEvent * e )
   {
     if ( mResultDisplay == NULL )
     {
-      mResultDisplay = new QgsDisplayAngle( mCanvas->topLevelWidget() );
+      mResultDisplay = new QgsDisplayAngle( this );
       QObject::connect( mResultDisplay, SIGNAL( rejected() ), this, SLOT( stopMeasuring() ) );
       QObject::connect( mResultDisplay, SIGNAL( changeProjectionEnabledState() ),
                         this, SLOT( changeProjectionEnabledState() ) );
@@ -183,7 +183,15 @@ void QgsMapToolMeasureAngle::configureDistanceArea()
   QString ellipsoidId = settings.value( "/qgis/measure/ellipsoid", "WGS84" ).toString();
   mDa.setSourceCrs( mCanvas->mapRenderer()->destinationCrs().srsid() );
   mDa.setEllipsoid( ellipsoidId );
-  mDa.setEllipsoidalMode( mResultDisplay->projectionEnabled() ); // FIXME (not when proj is turned off)
+  int s = settings.value( "/qgis/measure/projectionEnabled", "2" ).toInt();
+  if ( s == 2 )
+  {
+    mDa.setEllipsoidalMode( mResultDisplay->projectionEnabled() );
+  }
+  else
+  {
+    mDa.setEllipsoidalMode( mResultDisplay->projectionEnabled() );
+  }
 }
 
 

--- a/src/app/qgsmaptoolmeasureangle.cpp
+++ b/src/app/qgsmaptoolmeasureangle.cpp
@@ -180,17 +180,17 @@ void QgsMapToolMeasureAngle::changeProjectionEnabledState()
 void QgsMapToolMeasureAngle::configureDistanceArea()
 {
   QSettings settings;
-  QString ellipsoidId = settings.value( "/qgis/measure/ellipsoid", "WGS84" ).toString();
+  QString ellipsoidId = settings.value( "/qgis/measure/ellipsoid", GEO_NONE ).toString();
   mDa.setSourceCrs( mCanvas->mapRenderer()->destinationCrs().srsid() );
   mDa.setEllipsoid( ellipsoidId );
-  int s = settings.value( "/qgis/measure/projectionEnabled", "2" ).toInt();
-  if ( s == 2 )
+  // Only use ellipsoidal calculation when project wide transformation is enabled.
+  if ( mCanvas->mapRenderer()->hasCrsTransformEnabled() )
   {
-    mDa.setEllipsoidalMode( mResultDisplay->projectionEnabled() );
+    mDa.setEllipsoidalMode( true );
   }
   else
   {
-    mDa.setEllipsoidalMode( mResultDisplay->projectionEnabled() );
+    mDa.setEllipsoidalMode( false );
   }
 }
 

--- a/src/app/qgsmaptoolmeasureangle.h
+++ b/src/app/qgsmaptoolmeasureangle.h
@@ -32,7 +32,7 @@ class QgsMapToolMeasureAngle: public QgsMapTool
     QgsMapToolMeasureAngle( QgsMapCanvas* canvas );
     ~QgsMapToolMeasureAngle();
 
-    //! Mouse move event for overriding
+    //! Mouse move event for overridingqgs
     void canvasMoveEvent( QMouseEvent * e );
 
     //! Mouse release event for overriding

--- a/src/app/qgsmeasuredialog.cpp
+++ b/src/app/qgsmeasuredialog.cpp
@@ -278,7 +278,10 @@ void QgsMeasureDialog::updateUi()
   editTotal->setToolTip( toolTip );
   mTable->setToolTip( toolTip );
 
-  mTable->setHeaderLabels( QStringList( tr( "Segments [%1]" ).arg( QGis::tr( mDisplayUnits ) ) ) );
+  QGis::UnitType newDisplayUnits;
+  double dummy = 1.0;
+  convertMeasurement( dummy, newDisplayUnits, true );
+  mTable->setHeaderLabels( QStringList( tr( "Segments [%1]" ).arg( QGis::tr( newDisplayUnits ) ) ) );
 
   if ( mMeasureArea )
   {

--- a/src/app/qgsmeasuredialog.h
+++ b/src/app/qgsmeasuredialog.h
@@ -63,16 +63,19 @@ class QgsMeasureDialog : public QDialog, private Ui::QgsMeasureBase
     //! Show the help for the dialog
     void on_buttonBox_helpRequested() { QgsContextHelp::run( metaObject()->className() ); }
 
-    //! on change state projection/ellipsoid enable
-    void changeProjectionEnabledState();
+    //! When the ellipsoidal button is pressed/toggled.
+    void ellipsoidalButton();
+
+    //! When any external settings change
+    void updateSettings();
 
   private:
 
     //! formats distance to most appropriate units
-    QString formatDistance( double distance, int decimalPlaces );
+    QString formatDistance( double distance );
 
     //! formats area to most appropriate units
-    QString formatArea( double area, int decimalPlaces );
+    QString formatArea( double area );
 
     //! shows/hides table, shows correct units
     void updateUi();
@@ -87,7 +90,20 @@ class QgsMeasureDialog : public QDialog, private Ui::QgsMeasureBase
 
     //! indicates whether we're measuring distances or areas
     bool mMeasureArea;
+    
+    //! indicates whether user wants ellipsoidal or flat
+    bool mEllipsoidal;
 
+    //! Number of decimal places we want.
+    int mDecimalPlaces;
+
+    //! Current unit for input values
+    QGis::UnitType mCanvasUnits;
+
+    //! Current unit for output values
+    QGis::UnitType mDisplayUnits;
+
+    //! Our measurement object
     QgsDistanceArea mDa;
 
     //! pointer to measure tool which owns this dialog

--- a/src/app/qgsmeasuredialog.h
+++ b/src/app/qgsmeasuredialog.h
@@ -63,9 +63,6 @@ class QgsMeasureDialog : public QDialog, private Ui::QgsMeasureBase
     //! Show the help for the dialog
     void on_buttonBox_helpRequested() { QgsContextHelp::run( metaObject()->className() ); }
 
-    //! When the ellipsoidal button is pressed/toggled.
-    void ellipsoidalButton();
-
     //! When any external settings change
     void updateSettings();
 
@@ -83,16 +80,10 @@ class QgsMeasureDialog : public QDialog, private Ui::QgsMeasureBase
     //! Converts the measurement, depending on settings in options and current transformation
     void convertMeasurement( double &measure, QGis::UnitType &u, bool isArea );
 
-    //! Configures distance area objects with ellipsoid / output crs
-    void configureDistanceArea();
-
     double mTotal;
 
     //! indicates whether we're measuring distances or areas
     bool mMeasureArea;
-    
-    //! indicates whether user wants ellipsoidal or flat
-    bool mEllipsoidal;
 
     //! Number of decimal places we want.
     int mDecimalPlaces;

--- a/src/app/qgsmeasuretool.cpp
+++ b/src/app/qgsmeasuretool.cpp
@@ -42,7 +42,7 @@ QgsMeasureTool::QgsMeasureTool( QgsMapCanvas* canvas, bool measureArea )
 
   mDone = false;
   // Append point we will move
-  mPoints.append( QgsPoint (0, 0) );
+  mPoints.append( QgsPoint( 0, 0 ) );
 
   mDialog = new QgsMeasureDialog( this );
   mSnapper.setMapCanvas( canvas );
@@ -91,6 +91,7 @@ void QgsMeasureTool::activate()
 void QgsMeasureTool::deactivate()
 {
   mDialog->close();
+  mRubberBand->reset();
   QgsMapTool::deactivate();
 }
 
@@ -99,7 +100,7 @@ void QgsMeasureTool::restart()
 {
   mPoints.clear();
   // Append point we will move
-  mPoints.append( QgsPoint (0, 0) );
+  mPoints.append( QgsPoint( 0, 0 ) );
 
   mRubberBand->reset( mMeasureArea );
 
@@ -144,7 +145,7 @@ void QgsMeasureTool::canvasMoveEvent( QMouseEvent * e )
     QgsPoint point = snapPoint( e->pos() );
 
     mRubberBand->movePoint( point );
-    if( ! mPoints.isEmpty() )
+    if ( ! mPoints.isEmpty() )
     {
       // Update last point
       mPoints.removeLast();

--- a/src/app/qgsmeasuretool.h
+++ b/src/app/qgsmeasuretool.h
@@ -40,6 +40,10 @@ class QgsMeasureTool : public QgsMapTool
     //! returns whether measuring distance or area
     bool measureArea() { return mMeasureArea; }
 
+    //! When we hvae added our last point, and not following 
+    // Added in 2.0
+    bool done() { return mDone; }
+
     //! Reset and start new
     void restart();
 
@@ -83,7 +87,7 @@ class QgsMeasureTool : public QgsMapTool
     bool mMeasureArea;
 
     //! indicates whether we've just done a right mouse click
-    bool mRightMouseClicked;
+    bool mDone;
 
     //! indicates whether we've recently warned the user about having the wrong
     // project projection

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -298,8 +298,8 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WFlags fl ) :
   }
 
   // Set the units for measuring
-  QString myUnitsTxt = QGis::fromLiteral( settings.value( "/qgis/measure/displayunits", QGis::toLiteral( QGis::Meters ) ).toString() );
-  if ( myUnitsTxt == QGis::Feet )
+  QGis::UnitType myDisplayUnits = QGis::fromLiteral( settings.value( "/qgis/measure/displayunits", QGis::toLiteral( QGis::Meters ) ).toString() );
+  if ( myDisplayUnits == QGis::Feet )
   {
     radFeet->setChecked( true );
   }
@@ -948,7 +948,7 @@ void QgsOptions::saveOptions()
   }
   else
   {
-    settings.setValue( "/qgis/measure/displayunits", QGis::toLiteral( QGis::Feet ) );
+    settings.setValue( "/qgis/measure/displayunits", QGis::toLiteral( QGis::Meters ) );
   }
 
   QString angleUnitString = "degrees";

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -298,8 +298,8 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WFlags fl ) :
   }
 
   // Set the units for measuring
-  QString myUnitsTxt = settings.value( "/qgis/measure/displayunits", "meters" ).toString();
-  if ( myUnitsTxt == "feet" )
+  QString myUnitsTxt = QGis::fromLiteral( settings.value( "/qgis/measure/displayunits", QGis::toLiteral( QGis::Meters ) ).toString() );
+  if ( myUnitsTxt == QGis::Feet )
   {
     radFeet->setChecked( true );
   }
@@ -944,11 +944,11 @@ void QgsOptions::saveOptions()
 
   if ( radFeet->isChecked() )
   {
-    settings.setValue( "/qgis/measure/displayunits", "feet" );
+    settings.setValue( "/qgis/measure/displayunits", QGis::toLiteral( QGis::Feet ) );
   }
   else
   {
-    settings.setValue( "/qgis/measure/displayunits", "meters" );
+    settings.setValue( "/qgis/measure/displayunits", QGis::toLiteral( QGis::Feet ) );
   }
 
   QString angleUnitString = "degrees";

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -283,7 +283,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WFlags fl ) :
 
   getEllipsoidList();
   // Pre-select current ellipsoid
-  QString myEllipsoidId = settings.value( "/qgis/measure/ellipsoid", "WGS84" ).toString();
+  QString myEllipsoidId = settings.value( "/qgis/measure/ellipsoid", GEO_NONE ).toString();
   cmbEllipsoid->setCurrentIndex( cmbEllipsoid->findText( getEllipsoidName( myEllipsoidId ), Qt::MatchExactly ) );
   // Check if CRS transformation is on, or else turn combobox off
   if ( QgisApp::instance()->mapCanvas()->mapRenderer()->hasCrsTransformEnabled() )

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -19,6 +19,8 @@
 #include "qgsoptions.h"
 #include "qgis.h"
 #include "qgisapp.h"
+#include "qgsmapcanvas.h"
+#include "qgsmaprenderer.h"
 #include "qgsgenericprojectionselector.h"
 #include "qgscoordinatereferencesystem.h"
 #include "qgstolerance.h"
@@ -47,8 +49,6 @@
 #include <limits>
 #include <sqlite3.h>
 #include "qgslogger.h"
-#define ELLIPS_FLAT "NONE"
-#define ELLIPS_FLAT_DESC "None / Planimetric"
 
 #define CPL_SUPRESS_CPLUSPLUS
 #include <gdal.h>
@@ -56,6 +56,7 @@
 #include <cpl_conv.h> // for setting gdal options
 
 #include "qgsconfig.h"
+const char * QgsOptions::GEO_NONE_DESC = QT_TRANSLATE_NOOP( "QgsOptions", "None / Planimetric" );
 
 /**
  * \class QgsOptions - Set user options and preferences
@@ -278,9 +279,23 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WFlags fl ) :
   leProjectGlobalCrs->setText( mDefaultCrs.authid() + " - " + mDefaultCrs.description() );
 
   // populate combo box with ellipsoids
+  QgsDebugMsg( "Setting upp ellipsoid" );
+
   getEllipsoidList();
+  // Pre-select current ellipsoid
   QString myEllipsoidId = settings.value( "/qgis/measure/ellipsoid", "WGS84" ).toString();
-  cmbEllipsoid->setItemText( cmbEllipsoid->currentIndex(), getEllipsoidName( myEllipsoidId ) );
+  cmbEllipsoid->setCurrentIndex( cmbEllipsoid->findText( getEllipsoidName( myEllipsoidId ), Qt::MatchExactly ) );
+  // Check if CRS transformation is on, or else turn combobox off
+  if ( QgisApp::instance()->mapCanvas()->mapRenderer()->hasCrsTransformEnabled() )
+  {
+    cmbEllipsoid->setEnabled( true );
+    cmbEllipsoid->setToolTip( "" );
+  }
+  else
+  {
+    cmbEllipsoid->setEnabled( false );
+    cmbEllipsoid->setToolTip( "Can only use ellipsoidal calculations when CRS transformation is enabled" );
+  }
 
   // Set the units for measuring
   QString myUnitsTxt = settings.value( "/qgis/measure/displayunits", "meters" ).toString();
@@ -935,7 +950,6 @@ void QgsOptions::saveOptions()
   {
     settings.setValue( "/qgis/measure/displayunits", "meters" );
   }
-  settings.setValue( "/qgis/measure/ellipsoid", getEllipsoidAcronym( cmbEllipsoid->currentText() ) );
 
   QString angleUnitString = "degrees";
   if ( mRadiansRadioButton->isChecked() )
@@ -1163,7 +1177,7 @@ void QgsOptions::getEllipsoidList()
   int           myResult;
 
 
-  cmbEllipsoid->addItem( ELLIPS_FLAT_DESC );
+  cmbEllipsoid->addItem( tr( GEO_NONE_DESC ) );
   //check the db is available
   myResult = sqlite3_open_v2( QgsApplication::srsDbFilePath().toUtf8().data(), &myDatabase, SQLITE_OPEN_READONLY, NULL );
   if ( myResult )
@@ -1196,7 +1210,8 @@ QString QgsOptions::getEllipsoidAcronym( QString theEllipsoidName )
   const char   *myTail;
   sqlite3_stmt *myPreparedStatement;
   int           myResult;
-  QString       myName( ELLIPS_FLAT );
+  QString       myName = GEO_NONE;
+
   //check the db is available
   myResult = sqlite3_open_v2( QgsApplication::srsDbFilePath().toUtf8().data(), &myDatabase, SQLITE_OPEN_READONLY, NULL );
   if ( myResult )
@@ -1228,7 +1243,9 @@ QString QgsOptions::getEllipsoidName( QString theEllipsoidAcronym )
   const char   *myTail;
   sqlite3_stmt *myPreparedStatement;
   int           myResult;
-  QString       myName( ELLIPS_FLAT_DESC );
+  QString       myName;
+
+  myName = tr( GEO_NONE_DESC );
   //check the db is available
   myResult = sqlite3_open_v2( QgsApplication::srsDbFilePath().toUtf8().data(), &myDatabase, SQLITE_OPEN_READONLY, NULL );
   if ( myResult )

--- a/src/app/qgsoptions.h
+++ b/src/app/qgsoptions.h
@@ -194,6 +194,8 @@ class QgsOptions : public QDialog, private Ui::QgsOptionsBase
     QgsCoordinateReferenceSystem mDefaultCrs;
     QgsCoordinateReferenceSystem mLayerDefaultCrs;
     bool mLoadedGdalDriverList;
+
+    static const char * GEO_NONE_DESC;
 };
 
 #endif // #ifndef QGSOPTIONS_H

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -97,11 +97,14 @@ class CORE_EXPORT QGis
       DegreesDecimalMinutes = 2,  // was 5
     };
 
-    // Provides the canonical name of the type value
+    //! Provides the canonical name of the type value
+    // Added in version 2.0
     static QString toLiteral( QGis::UnitType unit );
-    // Converts from the canonical name to the type value
+    //! Converts from the canonical name to the type value
+    // Added in version 2.0
     static UnitType fromLiteral( QString  literal, QGis::UnitType defaultType = UnknownUnit );
-    // Provides translated version of the type value
+    //! Provides translated version of the type value
+    // Added in version 2.0
     static QString tr( QGis::UnitType unit );
 
     //! User defined event types
@@ -196,6 +199,10 @@ const int LAT_PREFIX_LEN = 7;
 /** Magick number that determines whether a projection crsid is a system (srs.db)
  *  or user (~/.qgis.qgis.db) defined projection. */
 const int USER_CRS_START_ID = 100000;
+
+//! Constant that holds the string representation for "No ellips/No CRS"
+// Added in version 2.0
+const QString GEO_NONE = "NONE";
 
 //
 // Constants for point symbols

--- a/src/core/qgsdistancearea.cpp
+++ b/src/core/qgsdistancearea.cpp
@@ -124,9 +124,9 @@ bool QgsDistanceArea::setEllipsoid( const QString& ellipsoid )
   int           myResult;
 
   // Shortcut if ellipsoid is none.
-  if ( ellipsoid == "NONE" )
+  if ( ellipsoid == GEO_NONE )
   {
-    mEllipsoid = "NONE";
+    mEllipsoid = GEO_NONE;
     return true;
   }
 
@@ -386,14 +386,14 @@ double QgsDistanceArea::measureLine( const QList<QgsPoint>& points )
 
   try
   {
-    if ( mEllipsoidalMode && ( mEllipsoid != "NONE" ) )
+    if ( mEllipsoidalMode && ( mEllipsoid != GEO_NONE ) )
       p1 = mCoordTransform->transform( points[0] );
     else
       p1 = points[0];
 
     for ( QList<QgsPoint>::const_iterator i = points.begin(); i != points.end(); ++i )
     {
-      if ( mEllipsoidalMode && ( mEllipsoid != "NONE" ) )
+      if ( mEllipsoidalMode && ( mEllipsoid != GEO_NONE ) )
       {
         p2 = mCoordTransform->transform( *i );
         total += computeDistanceBearing( p1, p2 );
@@ -427,7 +427,7 @@ double QgsDistanceArea::measureLine( const QgsPoint& p1, const QgsPoint& p2 )
     QgsPoint pp1 = p1, pp2 = p2;
 
     QgsDebugMsg( QString( "Measuring from %1 to %2" ).arg( p1.toString( 4 ) ).arg( p2.toString( 4 ) ) );
-    if ( mEllipsoidalMode && ( mEllipsoid != "NONE" ) )
+    if ( mEllipsoidalMode && ( mEllipsoid != GEO_NONE ) )
     {
       QgsDebugMsg( QString( "Ellipsoidal calculations is enabled, using ellipsoid %1" ).arg( mEllipsoid ) );
       QgsDebugMsg( QString( "From proj4 : %1" ).arg( mCoordTransform->sourceCrs().toProj4() ) );
@@ -496,7 +496,7 @@ unsigned char* QgsDistanceArea::measurePolygon( unsigned char* feature, double* 
 
         pnt = QgsPoint( x, y );
 
-        if ( mEllipsoidalMode && ( mEllipsoid != "NONE" ) )
+        if ( mEllipsoidalMode && ( mEllipsoid != GEO_NONE ) )
         {
           pnt = mCoordTransform->transform( pnt );
         }
@@ -548,7 +548,7 @@ double QgsDistanceArea::measurePolygon( const QList<QgsPoint>& points )
 
   try
   {
-    if ( mEllipsoidalMode && ( mEllipsoid != "NONE" ) )
+    if ( mEllipsoidalMode && ( mEllipsoid != GEO_NONE ) )
     {
       QList<QgsPoint> pts;
       for ( QList<QgsPoint>::const_iterator i = points.begin(); i != points.end(); ++i )
@@ -576,7 +576,7 @@ double QgsDistanceArea::bearing( const QgsPoint& p1, const QgsPoint& p2 )
   QgsPoint pp1 = p1, pp2 = p2;
   double bearing;
 
-  if ( mEllipsoidalMode && ( mEllipsoid != "NONE" ) )
+  if ( mEllipsoidalMode && ( mEllipsoid != GEO_NONE ) )
   {
     pp1 = mCoordTransform->transform( p1 );
     pp2 = mCoordTransform->transform( p2 );
@@ -738,7 +738,7 @@ double QgsDistanceArea::computePolygonArea( const QList<QgsPoint>& points )
   double area;
 
   QgsDebugMsgLevel( "Ellipsoid: " + mEllipsoid, 3 );
-  if (( ! mEllipsoidalMode ) || ( mEllipsoid == "NONE" ) )
+  if (( ! mEllipsoidalMode ) || ( mEllipsoid == GEO_NONE ) )
   {
     return computePolygonFlatArea( points );
   }
@@ -934,7 +934,7 @@ void QgsDistanceArea::convertMeasurement( double &measure, QGis::UnitType &measu
   // The parameters measure and measureUnits are in/out
 
   if (( measureUnits == QGis::Degrees || measureUnits == QGis::Feet ) &&
-      mEllipsoid != "NONE" &&
+      mEllipsoid != GEO_NONE &&
       mEllipsoidalMode )
   {
     // Measuring on an ellipsoid returned meters. Force!

--- a/src/core/qgsdistancearea.cpp
+++ b/src/core/qgsdistancearea.cpp
@@ -44,7 +44,7 @@ QgsDistanceArea::QgsDistanceArea()
   mEllipsoidalMode = false;
   mCoordTransform = new QgsCoordinateTransform;
   setSourceCrs( GEOCRS_ID ); // WGS 84
-  setEllipsoid( "WGS84" );
+  setEllipsoid( GEO_NONE );
 }
 
 

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -773,15 +773,15 @@ static QVariant fcnRound( const QVariantList& values , QgsFeature *f, QgsExpress
   Q_UNUSED( f );
   if ( values.length() == 2 )
   {
-      double number = getDoubleValue( values.at( 0 ), parent );
-      double scaler = pow( 10.0, getIntValue( values.at( 1 ), parent ) );
-      return QVariant( qRound( number * scaler ) / scaler );
+    double number = getDoubleValue( values.at( 0 ), parent );
+    double scaler = pow( 10.0, getIntValue( values.at( 1 ), parent ) );
+    return QVariant( round( number * scaler ) / scaler );
   }
 
   if ( values.length() == 1 )
   {
-      double number = getIntValue( values.at( 0 ), parent );
-      return QVariant( qRound( number) ).toInt();
+    double number = getIntValue( values.at( 0 ), parent );
+    return QVariant( round( number ) ).toInt();
   }
 
   return QVariant();
@@ -950,10 +950,10 @@ bool QgsExpression::needsGeometry()
 void QgsExpression::initGeomCalculator()
 {
   mCalc = new QgsDistanceArea;
-  mCalc->setEllipsoidalMode( false );
   QSettings settings;
-  QString ellipsoid = settings.value( "/qgis/measure/ellipsoid", "WGS84" ).toString();
+  QString ellipsoid = settings.value( "/qgis/measure/ellipsoid", GEO_NONE ).toString();
   mCalc->setEllipsoid( ellipsoid );
+  mCalc->setEllipsoidalMode( false );
 }
 
 bool QgsExpression::prepare( const QgsFieldMap& fields )

--- a/src/ui/qgsdisplayanglebase.ui
+++ b/src/ui/qgsdisplayanglebase.ui
@@ -44,13 +44,6 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="0">
-    <widget class="QCheckBox" name="mcbProjectionEnabled">
-     <property name="text">
-      <string>Ellipsoidal</string>
-     </property>
-    </widget>
-   </item>
   </layout>
  </widget>
  <resources/>

--- a/src/ui/qgsmeasurebase.ui
+++ b/src/ui/qgsmeasurebase.ui
@@ -98,13 +98,6 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="0" colspan="3">
-    <widget class="QCheckBox" name="mcbProjectionEnabled">
-     <property name="text">
-      <string>Ellipsoidal</string>
-     </property>
-    </widget>
-   </item>
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>

--- a/tests/src/core/testqgsdistancearea.cpp
+++ b/tests/src/core/testqgsdistancearea.cpp
@@ -52,7 +52,7 @@ void TestQgsDistanceArea::basic()
   QgsDistanceArea daA;
   double resultA, resultB, resultC;
 
-  daA.setEllipsoid( "NONE" );
+  daA.setEllipsoid( GEO_NONE );
   resultA = daA.measureLine( p1, p2 );
   QCOMPARE( resultA, 5.0 );
 
@@ -139,7 +139,7 @@ void TestQgsDistanceArea::unit_conversions()
 {
   // Do some very simple test of conversion and units
   QgsDistanceArea myDa;
-  myDa.setEllipsoidalMode( "NONE" );
+  myDa.setEllipsoidalMode( false );
 
   double inputValue;
   QGis::UnitType inputUnit;


### PR DESCRIPTION
I have cleaned up the measurement tools, and set up the GUI so that the "Ellipsoidal" button is removed from the mesure tool dialogs. Instead, one uses the Options... dialog and set ellipsoid to "None / Planimetric". All map tools are now consistent. Fixed #5156 when I was around. :-)

TODO (not in this pull request!)
- Figure out a way to configure QgsExpression's wuth the correct ellipsoid and projection status.
- Change scale bar to use the same settings.
