### PR TITLE
UI improvements in symbol layer widgets

### DIFF
--- a/src/gui/symbology-ng/qgsellipsesymbollayerv2widget.cpp
+++ b/src/gui/symbology-ng/qgsellipsesymbollayerv2widget.cpp
@@ -59,6 +59,9 @@ void QgsEllipseSymbolLayerV2Widget::setSymbolLayer( QgsSymbolLayerV2* layer )
   mRotationSpinBox->setValue( mLayer->angle() );
   mOutlineWidthSpinBox->setValue( mLayer->outlineWidth() );
 
+  btnChangeColorBorder->setColor( mLayer->outlineColor() );
+  btnChangeColorFill->setColor( mLayer->fillColor() );
+
   QList<QListWidgetItem *> symbolItemList = mShapeListWidget->findItems( mLayer->symbolName(), Qt::MatchExactly );
   if ( symbolItemList.size() > 0 )
   {
@@ -192,6 +195,7 @@ void QgsEllipseSymbolLayerV2Widget::on_btnChangeColorBorder_clicked()
     if ( newColor.isValid() )
     {
       mLayer->setOutlineColor( newColor );
+      btnChangeColorBorder->setColor( newColor );
       emit changed();
     }
   }
@@ -205,6 +209,7 @@ void QgsEllipseSymbolLayerV2Widget::on_btnChangeColorFill_clicked()
     if ( newColor.isValid() )
     {
       mLayer->setFillColor( newColor );
+      btnChangeColorFill->setColor( newColor );
       emit changed();
     }
   }

--- a/src/gui/symbology-ng/qgssymbollayerv2widget.cpp
+++ b/src/gui/symbology-ng/qgssymbollayerv2widget.cpp
@@ -671,6 +671,11 @@ void QgsSvgMarkerSymbolLayerV2Widget::setGuiForSvg( const QgsSvgMarkerSymbolLaye
   mChangeBorderColorButton->setEnabled( hasOutlineParam );
   mBorderWidthSpinBox->setEnabled( hasOutlineWidthParam );
 
+  if ( hasFillParam )
+    mChangeColorButton->setColor( defaultFill );
+  if ( hasOutlineParam )
+    mChangeBorderColorButton->setColor( defaultOutline );
+
   mFileLineEdit->blockSignals( true );
   mFileLineEdit->setText( layer->path() );
   mFileLineEdit->blockSignals( false );
@@ -795,6 +800,7 @@ void QgsSvgMarkerSymbolLayerV2Widget::on_mChangeColorButton_clicked()
   if ( c.isValid() )
   {
     mLayer->setFillColor( c );
+    mChangeColorButton->setColor( c );
     emit changed();
   }
 }
@@ -809,6 +815,7 @@ void QgsSvgMarkerSymbolLayerV2Widget::on_mChangeBorderColorButton_clicked()
   if ( c.isValid() )
   {
     mLayer->setOutlineColor( c );
+    mChangeBorderColorButton->setColor( c );
     emit changed();
   }
 }
@@ -886,7 +893,6 @@ QgsSVGFillSymbolLayerWidget::QgsSVGFillSymbolLayerWidget( const QgsVectorLayer* 
   setupUi( this );
   mSvgTreeView->setHeaderHidden( true );
   insertIcons();
-  updateOutlineIcon();
 
   connect( mSvgListView->selectionModel(), SIGNAL( currentChanged( const QModelIndex&, const QModelIndex& ) ), this, SLOT( setFile( const QModelIndex& ) ) );
   connect( mSvgTreeView->selectionModel(), SIGNAL( currentChanged( const QModelIndex&, const QModelIndex& ) ), this, SLOT( populateIcons( const QModelIndex& ) ) );
@@ -912,7 +918,6 @@ void QgsSVGFillSymbolLayerWidget::setSymbolLayer( QgsSymbolLayerV2* layer )
     mSVGLineEdit->setText( mLayer->svgFilePath() );
     mRotationSpinBox->setValue( mLayer->angle() );
   }
-  updateOutlineIcon();
   updateParamGui();
 }
 
@@ -989,17 +994,6 @@ void QgsSVGFillSymbolLayerWidget::populateIcons( const QModelIndex& idx )
   emit changed();
 }
 
-void QgsSVGFillSymbolLayerWidget::on_mChangeOutlinePushButton_clicked()
-{
-  QgsSymbolV2SelectorDialog dlg( mLayer->subSymbol(), QgsStyleV2::defaultStyle(), mVectorLayer, this );
-  if ( dlg.exec() == QDialog::Rejected )
-  {
-    return;
-  }
-
-  updateOutlineIcon();
-  emit changed();
-}
 
 void QgsSVGFillSymbolLayerWidget::on_mRotationSpinBox_valueChanged( double d )
 {
@@ -1010,15 +1004,6 @@ void QgsSVGFillSymbolLayerWidget::on_mRotationSpinBox_valueChanged( double d )
   emit changed();
 }
 
-void QgsSVGFillSymbolLayerWidget::updateOutlineIcon()
-{
-  if ( mLayer )
-  {
-    QIcon icon = QgsSymbolLayerV2Utils::symbolPreviewIcon( mLayer->subSymbol(), mChangeOutlinePushButton->iconSize() );
-    mChangeOutlinePushButton->setIcon( icon );
-  }
-}
-
 void QgsSVGFillSymbolLayerWidget::updateParamGui()
 {
   //activate gui for svg parameters only if supported by the svg file
@@ -1026,7 +1011,11 @@ void QgsSVGFillSymbolLayerWidget::updateParamGui()
   QColor defaultFill, defaultOutline;
   double defaultOutlineWidth;
   QgsSvgCache::instance()->containsParams( mSVGLineEdit->text(), hasFillParam, defaultFill, hasOutlineParam, defaultOutline, hasOutlineWidthParam, defaultOutlineWidth );
+  if ( hasFillParam )
+    mChangeColorButton->setColor( defaultFill );
   mChangeColorButton->setEnabled( hasFillParam );
+  if ( hasOutlineParam )
+    mChangeBorderColorButton->setColor( defaultOutline );
   mChangeBorderColorButton->setEnabled( hasOutlineParam );
   mBorderWidthSpinBox->setEnabled( hasOutlineWidthParam );
 }
@@ -1041,6 +1030,7 @@ void QgsSVGFillSymbolLayerWidget::on_mChangeColorButton_clicked()
   if ( c.isValid() )
   {
     mLayer->setSvgFillColor( c );
+    mChangeColorButton->setColor( c );
     emit changed();
   }
 }
@@ -1055,6 +1045,7 @@ void QgsSVGFillSymbolLayerWidget::on_mChangeBorderColorButton_clicked()
   if ( c.isValid() )
   {
     mLayer->setSvgOutlineColor( c );
+    mChangeBorderColorButton->setColor( c );
     emit changed();
   }
 }
@@ -1091,6 +1082,7 @@ void QgsLinePatternFillSymbolLayerWidget::setSymbolLayer( QgsSymbolLayerV2* laye
     mDistanceSpinBox->setValue( mLayer->distance() );
     mLineWidthSpinBox->setValue( mLayer->lineWidth() );
     mOffsetSpinBox->setValue( mLayer->offset() );
+    mColorPushButton->setColor( mLayer->color() );
   }
 }
 
@@ -1143,25 +1135,12 @@ void QgsLinePatternFillSymbolLayerWidget::on_mColorPushButton_clicked()
     if ( c.isValid() )
     {
       mLayer->setColor( c );
+      mColorPushButton->setColor( c );
       emit changed();
     }
   }
 }
 
-void QgsLinePatternFillSymbolLayerWidget::on_mOutlinePushButton_clicked()
-{
-  if ( mLayer )
-  {
-    QgsSymbolV2SelectorDialog dlg( mLayer->subSymbol(), QgsStyleV2::defaultStyle(), mVectorLayer, this );
-    if ( dlg.exec() == QDialog::Rejected )
-    {
-      return;
-    }
-
-    //updateOutlineIcon();
-    emit changed();
-  }
-}
 
 /////////////
 

--- a/src/gui/symbology-ng/qgssymbollayerv2widget.h
+++ b/src/gui/symbology-ng/qgssymbollayerv2widget.h
@@ -263,7 +263,6 @@ class GUI_EXPORT QgsSVGFillSymbolLayerWidget : public QgsSymbolLayerV2Widget, pr
     //sets new output unit. Is called on combo box or spin box change
     void setOutputUnit();
     void insertIcons();
-    void updateOutlineIcon();
     void updateParamGui();
 
   private slots:
@@ -272,7 +271,6 @@ class GUI_EXPORT QgsSVGFillSymbolLayerWidget : public QgsSymbolLayerV2Widget, pr
     void on_mSVGLineEdit_textChanged( const QString & text );
     void setFile( const QModelIndex& item );
     void populateIcons( const QModelIndex& item );
-    void on_mChangeOutlinePushButton_clicked();
     void on_mRotationSpinBox_valueChanged( double d );
     void on_mChangeColorButton_clicked();
     void on_mChangeBorderColorButton_clicked();
@@ -306,7 +304,6 @@ class GUI_EXPORT QgsLinePatternFillSymbolLayerWidget : public QgsSymbolLayerV2Wi
     void on_mLineWidthSpinBox_valueChanged( double d );
     void on_mOffsetSpinBox_valueChanged( double d );
     void on_mColorPushButton_clicked();
-    void on_mOutlinePushButton_clicked();
 };
 
 //////////

--- a/src/ui/symbollayer/widget_ellipse.ui
+++ b/src/ui/symbollayer/widget_ellipse.ui
@@ -220,11 +220,11 @@
          </property>
         </widget>
        </item>
-       <item row="6" column="1">
-        <widget class="QComboBox" name="mDDShapeComboBox"/>
-       </item>
        <item row="2" column="1">
         <widget class="QComboBox" name="mDDRotationComboBox"/>
+       </item>
+       <item row="6" column="1">
+        <widget class="QComboBox" name="mDDShapeComboBox"/>
        </item>
        <item row="2" column="0">
         <widget class="QLabel" name="mDDRotationLabel">
@@ -232,6 +232,19 @@
           <string>Rotation</string>
          </property>
         </widget>
+       </item>
+       <item row="7" column="0" colspan="2">
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
        </item>
       </layout>
      </widget>

--- a/src/ui/symbollayer/widget_fontmarker.ui
+++ b/src/ui/symbollayer/widget_fontmarker.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
+    <width>399</width>
     <height>300</height>
    </rect>
   </property>
@@ -31,20 +31,10 @@
      <property name="horizontalSpacing">
       <number>6</number>
      </property>
-     <item row="0" column="0">
-      <widget class="QLabel" name="label">
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_2">
        <property name="text">
-        <string>Font family</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1" colspan="2">
-      <widget class="QFontComboBox" name="cboFont"/>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="label_3">
-       <property name="text">
-        <string>Color</string>
+        <string>Size</string>
        </property>
       </widget>
      </item>
@@ -55,17 +45,10 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="label_2">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
        <property name="text">
-        <string>Size</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="label_4">
-       <property name="text">
-        <string>Rotation</string>
+        <string>Font family</string>
        </property>
       </widget>
      </item>
@@ -79,23 +62,6 @@
        </property>
        <property name="maximum">
         <double>360.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="QDoubleSpinBox" name="spinSize">
-       <property name="decimals">
-        <number>5</number>
-       </property>
-       <property name="value">
-        <double>12.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="0">
-      <widget class="QLabel" name="label_5">
-       <property name="text">
-        <string>Offset X,Y</string>
        </property>
       </widget>
      </item>
@@ -128,6 +94,40 @@
         </widget>
        </item>
       </layout>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="label_5">
+       <property name="text">
+        <string>Offset X,Y</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>Color</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QDoubleSpinBox" name="spinSize">
+       <property name="decimals">
+        <number>5</number>
+       </property>
+       <property name="value">
+        <double>12.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string>Rotation</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QFontComboBox" name="cboFont"/>
      </item>
     </layout>
    </item>

--- a/src/ui/symbollayer/widget_linedecoration.ui
+++ b/src/ui/symbollayer/widget_linedecoration.ui
@@ -19,13 +19,6 @@
    </property>
    <item>
     <layout class="QGridLayout" name="gridLayout">
-     <item row="0" column="0">
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Color</string>
-       </property>
-      </widget>
-     </item>
      <item row="0" column="1">
       <widget class="QgsColorButtonV2" name="btnChangeColor">
        <property name="sizePolicy">
@@ -36,29 +29,6 @@
        </property>
        <property name="text">
         <string>Change</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="2" rowspan="2">
-      <spacer>
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Preferred</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>112</width>
-         <height>48</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="label_2">
-       <property name="text">
-        <string>Pen width</string>
        </property>
       </widget>
      </item>
@@ -75,6 +45,20 @@
        </property>
        <property name="value">
         <double>1.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Pen width</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Color</string>
        </property>
       </widget>
      </item>

--- a/src/ui/symbollayer/widget_linepatternfill.ui
+++ b/src/ui/symbollayer/widget_linepatternfill.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>201</width>
-    <height>202</height>
+    <width>217</width>
+    <height>293</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,27 +17,6 @@
    <property name="margin">
     <number>1</number>
    </property>
-   <item row="0" column="0">
-    <widget class="QLabel" name="mAngleLabel">
-     <property name="text">
-      <string>Angle</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QDoubleSpinBox" name="mAngleSpinBox">
-     <property name="maximum">
-      <double>360.000000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="mDistanceLabel">
-     <property name="text">
-      <string>Distance</string>
-     </property>
-    </widget>
-   </item>
    <item row="1" column="1">
     <widget class="QDoubleSpinBox" name="mDistanceSpinBox">
      <property name="maximum">
@@ -45,55 +24,10 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
-    <widget class="QLabel" name="mLineWidthLabel">
-     <property name="text">
-      <string>Line width</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
-    <widget class="QDoubleSpinBox" name="mLineWidthSpinBox">
-     <property name="decimals">
-      <number>5</number>
-     </property>
+   <item row="0" column="1">
+    <widget class="QDoubleSpinBox" name="mAngleSpinBox">
      <property name="maximum">
-      <double>99999999.000000000000000</double>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="mColorLabel">
-     <property name="text">
-      <string>Color</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1">
-    <widget class="QPushButton" name="mColorPushButton">
-     <property name="text">
-      <string>Change</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0">
-    <widget class="QLabel" name="mOutlineLabel">
-     <property name="text">
-      <string>Outline</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="1">
-    <widget class="QPushButton" name="mOutlinePushButton">
-     <property name="text">
-      <string>Change</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="mOffsetLabel">
-     <property name="text">
-      <string>Offset</string>
+      <double>360.000000000000000</double>
      </property>
     </widget>
    </item>
@@ -107,8 +41,80 @@
      </property>
     </widget>
    </item>
+   <item row="2" column="1">
+    <widget class="QDoubleSpinBox" name="mLineWidthSpinBox">
+     <property name="decimals">
+      <number>5</number>
+     </property>
+     <property name="maximum">
+      <double>99999999.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="mLineWidthLabel">
+     <property name="text">
+      <string>Line width</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="mColorLabel">
+     <property name="text">
+      <string>Color</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="mAngleLabel">
+     <property name="text">
+      <string>Angle</string>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0" colspan="2">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="4" column="1">
+    <widget class="QgsColorButtonV2" name="mColorPushButton">
+     <property name="text">
+      <string>Change</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="mDistanceLabel">
+     <property name="text">
+      <string>Distance</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="mOffsetLabel">
+     <property name="text">
+      <string>Offset</string>
+     </property>
+    </widget>
+   </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsColorButtonV2</class>
+   <extends>QPushButton</extends>
+   <header>qgscolorbutton.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/ui/symbollayer/widget_pointpatternfill.ui
+++ b/src/ui/symbollayer/widget_pointpatternfill.ui
@@ -17,23 +17,17 @@
    <property name="margin">
     <number>1</number>
    </property>
-   <item row="0" column="1">
-    <widget class="QDoubleSpinBox" name="mHorizontalDistanceSpinBox">
-     <property name="decimals">
-      <number>5</number>
-     </property>
-     <property name="maximum">
-      <double>99999999.989999994635582</double>
+   <item row="0" column="0">
+    <widget class="QLabel" name="mHorizontalDistanceLabel">
+     <property name="text">
+      <string>Horizontal distance</string>
      </property>
     </widget>
    </item>
-   <item row="3" column="1">
-    <widget class="QDoubleSpinBox" name="mVerticalDisplacementSpinBox">
-     <property name="decimals">
-      <number>5</number>
-     </property>
-     <property name="maximum">
-      <double>999999999.990000009536743</double>
+   <item row="1" column="0">
+    <widget class="QLabel" name="mVerticalDistanceLabel">
+     <property name="text">
+      <string>Vertical distance</string>
      </property>
     </widget>
    </item>
@@ -54,17 +48,20 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="mHorizontalDistanceLabel">
-     <property name="text">
-      <string>Horizontal distance</string>
+   <item row="3" column="1">
+    <widget class="QDoubleSpinBox" name="mVerticalDisplacementSpinBox">
+     <property name="decimals">
+      <number>5</number>
+     </property>
+     <property name="maximum">
+      <double>999999999.990000009536743</double>
      </property>
     </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="mVerticalDistanceLabel">
+   <item row="3" column="0">
+    <widget class="QLabel" name="mVerticalDisplacementLabel">
      <property name="text">
-      <string>Vertical distance</string>
+      <string>Vertical displacement</string>
      </property>
     </widget>
    </item>
@@ -78,12 +75,28 @@
      </property>
     </widget>
    </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="mVerticalDisplacementLabel">
-     <property name="text">
-      <string>Vertical displacement</string>
+   <item row="0" column="1">
+    <widget class="QDoubleSpinBox" name="mHorizontalDistanceSpinBox">
+     <property name="decimals">
+      <number>5</number>
+     </property>
+     <property name="maximum">
+      <double>99999999.989999994635582</double>
      </property>
     </widget>
+   </item>
+   <item row="4" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>

--- a/src/ui/symbollayer/widget_simplefill.ui
+++ b/src/ui/symbollayer/widget_simplefill.ui
@@ -19,35 +19,15 @@
    </property>
    <item>
     <layout class="QGridLayout" name="gridLayout">
-     <item row="0" column="0">
-      <widget class="QLabel" name="label">
+     <item row="3" column="1">
+      <widget class="QgsPenStyleComboBox" name="cboBorderStyle"/>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_3">
        <property name="text">
-        <string>Color</string>
+        <string>Border color</string>
        </property>
       </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QgsColorButtonV2" name="btnChangeColor">
-       <property name="text">
-        <string>Change</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="2" rowspan="6">
-      <spacer>
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Preferred</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>28</width>
-         <height>158</height>
-        </size>
-       </property>
-      </spacer>
      </item>
      <item row="1" column="0">
       <widget class="QLabel" name="label_2">
@@ -59,34 +39,10 @@
      <item row="1" column="1">
       <widget class="QgsBrushStyleComboBox" name="cboFillStyle"/>
      </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="label_3">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
        <property name="text">
-        <string>Border color</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="QgsColorButtonV2" name="btnChangeBorderColor">
-       <property name="text">
-        <string>Change</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="label_4">
-       <property name="text">
-        <string>Border style</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="1">
-      <widget class="QgsPenStyleComboBox" name="cboBorderStyle"/>
-     </item>
-     <item row="4" column="0">
-      <widget class="QLabel" name="label_5">
-       <property name="text">
-        <string>Border width</string>
+        <string>Color</string>
        </property>
       </widget>
      </item>
@@ -136,6 +92,34 @@
         </widget>
        </item>
       </layout>
+     </item>
+     <item row="2" column="1">
+      <widget class="QgsColorButtonV2" name="btnChangeBorderColor">
+       <property name="text">
+        <string>Change</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QgsColorButtonV2" name="btnChangeColor">
+       <property name="text">
+        <string>Change</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string>Border style</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="0">
+      <widget class="QLabel" name="label_5">
+       <property name="text">
+        <string>Border width</string>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>

--- a/src/ui/symbollayer/widget_simpleline.ui
+++ b/src/ui/symbollayer/widget_simpleline.ui
@@ -14,9 +14,6 @@
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
-   <property name="margin">
-    <number>1</number>
-   </property>
    <item row="0" column="0">
     <layout class="QGridLayout" name="gridLayout">
      <item row="0" column="0">
@@ -26,7 +23,7 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="1" colspan="2">
+     <item row="0" column="1">
       <widget class="QgsColorButtonV2" name="btnChangeColor">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -39,22 +36,6 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="3" rowspan="3">
-      <spacer>
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Preferred</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>50</width>
-         <height>91</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
      <item row="1" column="0">
       <widget class="QLabel" name="label_2">
        <property name="text">
@@ -62,7 +43,7 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="1" colspan="2">
+     <item row="1" column="1">
       <widget class="QDoubleSpinBox" name="spinWidth">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -91,7 +72,7 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="1" colspan="2">
+     <item row="2" column="1">
       <widget class="QDoubleSpinBox" name="spinOffset">
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
@@ -114,17 +95,21 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="2">
+     <item row="3" column="1">
       <widget class="QgsPenStyleComboBox" name="cboPenStyle"/>
      </item>
-     <item row="4" column="0" colspan="4">
+    </layout>
+   </item>
+   <item row="1" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
       <widget class="QCheckBox" name="mCustomCheckBox">
        <property name="text">
         <string>Use custom dash pattern</string>
        </property>
       </widget>
      </item>
-     <item row="5" column="0" colspan="2">
+     <item>
       <widget class="QPushButton" name="mChangePatternButton">
        <property name="text">
         <string>Change</string>
@@ -133,7 +118,7 @@
      </item>
     </layout>
    </item>
-   <item row="1" column="0">
+   <item row="2" column="0">
     <spacer>
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -146,7 +131,7 @@
      </property>
     </spacer>
    </item>
-   <item row="2" column="0">
+   <item row="3" column="0">
     <layout class="QGridLayout" name="gridLayout_1">
      <item row="0" column="0">
       <widget class="QLabel" name="label_5">

--- a/src/ui/symbollayer/widget_simplemarker.ui
+++ b/src/ui/symbollayer/widget_simplemarker.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>394</width>
+    <width>378</width>
     <height>275</height>
    </rect>
   </property>
@@ -19,57 +19,6 @@
    </property>
    <item>
     <layout class="QGridLayout" name="gridLayout">
-     <item row="0" column="0">
-      <widget class="QLabel" name="label">
-       <property name="text">
-        <string>Border color</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QgsColorButtonV2" name="btnChangeColorBorder">
-       <property name="text">
-        <string>Change</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="2" rowspan="2">
-      <spacer>
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeType">
-        <enum>QSizePolicy::Preferred</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>61</width>
-         <height>61</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="label_2">
-       <property name="text">
-        <string>Fill color</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QgsColorButtonV2" name="btnChangeColorFill">
-       <property name="text">
-        <string>Change</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="label_3">
-       <property name="text">
-        <string>Size</string>
-       </property>
-      </widget>
-     </item>
      <item row="3" column="0">
       <widget class="QLabel" name="label_4">
        <property name="text">
@@ -90,10 +39,51 @@
        </property>
       </widget>
      </item>
-     <item row="4" column="0">
-      <widget class="QLabel" name="label_5">
+     <item row="0" column="1">
+      <widget class="QgsColorButtonV2" name="btnChangeColorBorder">
        <property name="text">
-        <string>Offset X,Y</string>
+        <string>Change</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QgsColorButtonV2" name="btnChangeColorFill">
+       <property name="text">
+        <string>Change</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Border color</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>Size</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Fill color</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QDoubleSpinBox" name="spinSize">
+       <property name="decimals">
+        <number>5</number>
+       </property>
+       <property name="maximum">
+        <double>100000.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>1.000000000000000</double>
        </property>
       </widget>
      </item>
@@ -121,16 +111,10 @@
        </item>
       </layout>
      </item>
-     <item row="2" column="1">
-      <widget class="QDoubleSpinBox" name="spinSize">
-       <property name="decimals">
-        <number>5</number>
-       </property>
-       <property name="maximum">
-        <double>100000.000000000000000</double>
-       </property>
-       <property name="value">
-        <double>1.000000000000000</double>
+     <item row="4" column="0">
+      <widget class="QLabel" name="label_5">
+       <property name="text">
+        <string>Offset X,Y</string>
        </property>
       </widget>
      </item>

--- a/src/ui/symbollayer/widget_svgfill.ui
+++ b/src/ui/symbollayer/widget_svgfill.ui
@@ -19,10 +19,59 @@
    </property>
    <item row="0" column="0">
     <layout class="QGridLayout" name="gridLayout">
+     <item row="3" column="0">
+      <widget class="QLabel" name="mBorderColorLabel">
+       <property name="text">
+        <string>Border color</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="mColorLabel">
+       <property name="text">
+        <string>Color</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QgsColorButtonV2" name="mChangeBorderColorButton">
+       <property name="text">
+        <string>Change</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QDoubleSpinBox" name="mRotationSpinBox">
+       <property name="maximum">
+        <double>360.000000000000000</double>
+       </property>
+      </widget>
+     </item>
      <item row="0" column="0">
       <widget class="QLabel" name="mTextureWidthLabel">
        <property name="text">
         <string>Texture width</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QgsColorButtonV2" name="mChangeColorButton">
+       <property name="text">
+        <string>Change</string>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QDoubleSpinBox" name="mBorderWidthSpinBox">
+       <property name="decimals">
+        <number>5</number>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="mRotationLabel">
+       <property name="text">
+        <string>Rotation</string>
        </property>
       </widget>
      </item>
@@ -36,73 +85,10 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="mRotationLabel">
-       <property name="text">
-        <string>Rotation</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <widget class="QDoubleSpinBox" name="mRotationSpinBox">
-       <property name="maximum">
-        <double>360.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="mColorLabel">
-       <property name="text">
-        <string>Color</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="QPushButton" name="mChangeColorButton">
-       <property name="text">
-        <string>Change</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="mBorderColorLabel">
-       <property name="text">
-        <string>Border color</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="1">
-      <widget class="QPushButton" name="mChangeBorderColorButton">
-       <property name="text">
-        <string>Change</string>
-       </property>
-      </widget>
-     </item>
      <item row="4" column="0">
       <widget class="QLabel" name="mBorderWidthLabel">
        <property name="text">
         <string>Border width</string>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="1">
-      <widget class="QDoubleSpinBox" name="mBorderWidthSpinBox">
-       <property name="decimals">
-        <number>5</number>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="0">
-      <widget class="QLabel" name="mOutlineLabel">
-       <property name="text">
-        <string>Outline</string>
-       </property>
-      </widget>
-     </item>
-     <item row="5" column="1">
-      <widget class="QPushButton" name="mChangeOutlinePushButton">
-       <property name="text">
-        <string>Change</string>
        </property>
       </widget>
      </item>
@@ -161,6 +147,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsColorButtonV2</class>
+   <extends>QPushButton</extends>
+   <header>qgscolorbutton.h</header>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>

--- a/src/ui/symbollayer/widget_svgmarker.ui
+++ b/src/ui/symbollayer/widget_svgmarker.ui
@@ -32,18 +32,19 @@
        </property>
       </widget>
      </item>
-     <item row="0" column="2" rowspan="6">
-      <spacer>
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+     <item row="3" column="1">
+      <widget class="QgsColorButtonV2" name="mChangeBorderColorButton">
+       <property name="text">
+        <string>Change</string>
        </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>115</width>
-         <height>51</height>
-        </size>
+      </widget>
+     </item>
+     <item row="5" column="0">
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string>Offset X,Y</string>
        </property>
-      </spacer>
+      </widget>
      </item>
      <item row="1" column="0">
       <widget class="QLabel" name="label_3">
@@ -52,16 +53,22 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="1">
-      <widget class="QDoubleSpinBox" name="spinAngle">
+     <item row="0" column="1">
+      <widget class="QDoubleSpinBox" name="spinSize">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
        <property name="decimals">
-        <number>2</number>
+        <number>5</number>
        </property>
        <property name="maximum">
-        <double>360.000000000000000</double>
+        <double>100000.000000000000000</double>
        </property>
-       <property name="singleStep">
-        <double>5.000000000000000</double>
+       <property name="value">
+        <double>1.000000000000000</double>
        </property>
       </widget>
      </item>
@@ -95,50 +102,10 @@
        </item>
       </layout>
      </item>
-     <item row="5" column="0">
-      <widget class="QLabel" name="label_4">
+     <item row="3" column="0">
+      <widget class="QLabel" name="mBorderColorLabel">
        <property name="text">
-        <string>Offset X,Y</string>
-       </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QDoubleSpinBox" name="spinSize">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="decimals">
-        <number>5</number>
-       </property>
-       <property name="maximum">
-        <double>100000.000000000000000</double>
-       </property>
-       <property name="value">
-        <double>1.000000000000000</double>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="QPushButton" name="mChangeColorButton">
-       <property name="text">
-        <string>Change</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="0">
-      <widget class="QLabel" name="mColorLabel">
-       <property name="text">
-        <string>Color</string>
-       </property>
-      </widget>
-     </item>
-     <item row="4" column="1">
-      <widget class="QDoubleSpinBox" name="mBorderWidthSpinBox">
-       <property name="decimals">
-        <number>5</number>
+        <string>Border color</string>
        </property>
       </widget>
      </item>
@@ -149,17 +116,37 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="1">
-      <widget class="QPushButton" name="mChangeBorderColorButton">
+     <item row="2" column="0">
+      <widget class="QLabel" name="mColorLabel">
+       <property name="text">
+        <string>Color</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QgsColorButtonV2" name="mChangeColorButton">
        <property name="text">
         <string>Change</string>
        </property>
       </widget>
      </item>
-     <item row="3" column="0">
-      <widget class="QLabel" name="mBorderColorLabel">
-       <property name="text">
-        <string>Border color</string>
+     <item row="1" column="1">
+      <widget class="QDoubleSpinBox" name="spinAngle">
+       <property name="decimals">
+        <number>2</number>
+       </property>
+       <property name="maximum">
+        <double>360.000000000000000</double>
+       </property>
+       <property name="singleStep">
+        <double>5.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="4" column="1">
+      <widget class="QDoubleSpinBox" name="mBorderWidthSpinBox">
+       <property name="decimals">
+        <number>5</number>
        </property>
       </widget>
      </item>
@@ -238,6 +225,13 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsColorButtonV2</class>
+   <extends>QPushButton</extends>
+   <header>qgscolorbutton.h</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>spinSize</tabstop>
   <tabstop>spinAngle</tabstop>


### PR DESCRIPTION
Hello @NathanW2, @wonder-sk and @etiennesky

I have made a number of UI changed in the Symbol layer properties widgets. 
- Mostly corrected the alignment of the parameter input fields to be in line with the top Layer Type combo. 
- Then removed a few buttons which were meant to call Symbol Editor for sub-symbols. 
- Tweaked the color selection buttons so that they show color on themselves properly.

Test it out and merge if you like, if there is anything bothering do let me know. I am chipping away things little be little expect small updates now and then.
