### PR TITLE
QgsFillSymbolLayerV2 descendants missing from sip

### DIFF
--- a/python/core/core.sip
+++ b/python/core/core.sip
@@ -96,6 +96,9 @@
 %Include qgsnetworkaccessmanager.sip
 
 %Include symbology-ng-core.sip
+%Include qgsmarkersymbollayer.sip
+%Include qgslinesymbollayer.sip
+%Include qgsfillsymbollayer.sip
 
 %Include qgsgpsconnection.sip
 %Include qgsgpsconnectionregistry.sip

--- a/python/core/qgsfillsymbollayer.sip
+++ b/python/core/qgsfillsymbollayer.sip
@@ -1,0 +1,223 @@
+class QgsFillSymbolLayerV2 : QgsSymbolLayerV2
+{
+%TypeHeaderCode
+#include <qgssymbollayerv2.h>
+%End
+
+%ConvertToSubClassCode
+  if (dynamic_cast<QgsSimpleFillSymbolLayerV2*>(sipCpp) != NULL)
+    sipClass = sipClass_QgsSimpleFillSymbolLayerV2;
+  else if (dynamic_cast<QgsImageFillSymbolLayer*>(sipCpp) != NULL)
+    sipClass = sipClass_QgsImageFillSymbolLayer;
+  else if (dynamic_cast<QgsCentroidFillSymbolLayerV2*>(sipCpp) != NULL)
+    sipClass = sipClass_QgsCentroidFillSymbolLayerV2;  
+  else
+    sipClass = 0;
+%End
+
+public:
+  virtual void renderPolygon(const QPolygonF& points, QList<QPolygonF>* rings, QgsSymbolV2RenderContext& context) = 0;
+
+  void drawPreviewIcon(QgsSymbolV2RenderContext& context, QSize size);
+
+  void setAngle( double angle );
+  double angle() const;
+
+protected:
+  QgsFillSymbolLayerV2(bool locked = false);
+};
+
+///////////////
+
+class QgsCentroidFillSymbolLayerV2:QgsFillSymbolLayerV2
+{
+%TypeHeaderCode
+#include <qgsfillsymbollayerv2.h>
+%End
+
+public:
+  QgsCentroidFillSymbolLayerV2();
+  ~QgsCentroidFillSymbolLayerV2();
+
+  //! static stuff
+  static QgsSymbolLayerV2* create( const QgsStringMap& properties = QgsStringMap() );
+  static QgsSymbolLayerV2* createFromSld( QDomElement &element );
+
+  //! implemented from base classes
+  QString layerType() const;
+  void startRender( QgsSymbolV2RenderContext& context );
+  void stopRender( QgsSymbolV2RenderContext& context );
+  void renderPolygon( const QPolygonF& points, QList<QPolygonF>* rings, QgsSymbolV2RenderContext& context );
+  QgsStringMap properties() const;
+  QgsSymbolLayerV2* clone() const;
+  void toSld( QDomDocument &doc, QDomElement &element, QgsStringMap props ) const;
+  void setColor( const QColor& color );
+  QgsSymbolV2* subSymbol();
+  bool setSubSymbol( QgsSymbolV2* symbol );
+
+};
+
+///////////////
+class QgsSimpleFillSymbolLayerV2:QgsFillSymbolLayerV2
+{
+%TypeHeaderCode
+#include <qgsfillsymbollayerv2.h>
+%End
+
+public:
+		QgsSimpleFillSymbolLayerV2(QColor color = DEFAULT_SIMPLEFILL_COLOR,
+                                Qt::BrushStyle style = DEFAULT_SIMPLEFILL_STYLE,
+                                QColor borderColor = DEFAULT_SIMPLEFILL_BORDERCOLOR,
+                                Qt::PenStyle borderStyle = DEFAULT_SIMPLEFILL_BORDERSTYLE,
+                                double borderWidth = DEFAULT_SIMPLEFILL_BORDERWIDTH);
+		QString layerType() const;
+    void startRender( QgsSymbolV2RenderContext& context );
+    void stopRender( QgsSymbolV2RenderContext& context );
+    void renderPolygon( const QPolygonF& points, QList<QPolygonF>* rings, QgsSymbolV2RenderContext& context );
+    QgsStringMap properties() const;
+    QgsSymbolLayerV2* clone() const;
+    void toSld( QDomDocument &doc, QDomElement &element, QgsStringMap props ) const;
+    Qt::BrushStyle brushStyle() const;
+    void setBrushStyle( Qt::BrushStyle style );
+    QColor borderColor() const;
+    void setBorderColor( QColor borderColor );
+    Qt::PenStyle borderStyle() const ;
+    void setBorderStyle( Qt::PenStyle borderStyle );
+    double borderWidth() const;
+    void setBorderWidth( double borderWidth );
+    void setOffset( QPointF offset ) ;
+    QPointF offset() ;
+};
+
+
+class QgsImageFillSymbolLayer:QgsFillSymbolLayerV2
+{
+%TypeHeaderCode
+#include <qgsfillsymbollayerv2.h>
+%End
+
+%ConvertToSubClassCode
+  if (dynamic_cast<QgsLinePatternFillSymbolLayer*>(sipCpp) != NULL)
+    sipClass = sipClass_QgsLinePatternFillSymbolLayer;
+  else if (dynamic_cast<QgsPointPatternFillSymbolLayer*>(sipCpp) != NULL)
+    sipClass = sipClass_QgsPointPatternFillSymbolLayer;
+  else if (dynamic_cast<QgsSVGFillSymbolLayer*>(sipCpp) != NULL)
+    sipClass = sipClass_QgsSVGFillSymbolLayer;  
+  else
+    sipClass = 0;
+%End
+
+public:
+ 	QgsImageFillSymbolLayer ();
+	virtual 	~QgsImageFillSymbolLayer ();
+	
+	void renderPolygon (const QPolygonF &points, QList< QPolygonF > *rings, QgsSymbolV2RenderContext &context);
+	virtual QgsSymbolV2 * subSymbol ();
+	virtual bool setSubSymbol (QgsSymbolV2 *symbol);
+	 	
+};
+
+
+///////////////
+
+class QgsSVGFillSymbolLayer:QgsImageFillSymbolLayer
+{
+%TypeHeaderCode
+#include <qgsfillsymbollayerv2.h>
+%End
+
+public:
+  QgsSVGFillSymbolLayer( const QString& svgFilePath = "", double width = 20, double rotation = 0.0 );
+  QgsSVGFillSymbolLayer( const QByteArray& svgData, double width = 20, double rotation = 0.0 );
+  ~QgsSVGFillSymbolLayer();
+
+  static QgsSymbolLayerV2* create( const QgsStringMap& properties = QgsStringMap() );
+  static QgsSymbolLayerV2* createFromSld( QDomElement &element );
+
+  //! implemented from base classes
+  QString layerType() const;
+  void startRender( QgsSymbolV2RenderContext& context );
+  void stopRender( QgsSymbolV2RenderContext& context );
+  QgsStringMap properties() const;
+  QgsSymbolLayerV2* clone() const;
+  void toSld( QDomDocument &doc, QDomElement &element, QgsStringMap props ) const;
+
+  //! getters and setters
+  void setSvgFilePath( const QString& svgPath );
+  QString svgFilePath() const;
+  void setPatternWidth( double width );
+  double patternWidth() const;
+
+  void setSvgFillColor( const QColor& c );
+  QColor svgFillColor() const;
+  void setSvgOutlineColor( const QColor& c );
+  QColor svgOutlineColor() const;
+  void setSvgOutlineWidth( double w );
+  double svgOutlineWidth() const;
+  
+};
+    
+///////////////
+
+class QgsPointPatternFillSymbolLayer:QgsImageFillSymbolLayer
+{
+%TypeHeaderCode
+#include <qgsfillsymbollayerv2.h>
+%End
+
+	public:
+    QgsPointPatternFillSymbolLayer();
+    ~QgsPointPatternFillSymbolLayer();
+
+    static QgsSymbolLayerV2* create( const QgsStringMap& properties = QgsStringMap() );
+    static QgsSymbolLayerV2* createFromSld( QDomElement &element );
+    QString layerType() const;
+    void startRender( QgsSymbolV2RenderContext& context );
+    void stopRender( QgsSymbolV2RenderContext& context );
+    QgsStringMap properties() const;
+    QgsSymbolLayerV2* clone() const;
+    void toSld( QDomDocument &doc, QDomElement &element, QgsStringMap props ) const;
+    //! getters and setters
+    double distanceX() const;
+    void setDistanceX( double d );
+    double distanceY() const;
+    void setDistanceY( double d );
+    double displacementX() const;
+    void setDisplacementX( double d );
+    double displacementY() const;
+    void setDisplacementY( double d );
+    bool setSubSymbol( QgsSymbolV2* symbol );
+    virtual QgsSymbolV2* subSymbol();
+};
+
+///////////////
+
+class QgsLinePatternFillSymbolLayer:QgsImageFillSymbolLayer
+{
+%TypeHeaderCode
+#include <qgsfillsymbollayerv2.h>
+%End
+
+public:
+    QgsLinePatternFillSymbolLayer();
+    ~QgsLinePatternFillSymbolLayer();
+
+    static QgsSymbolLayerV2* create( const QgsStringMap& properties = QgsStringMap() );
+    static QgsSymbolLayerV2* createFromSld( QDomElement &element );
+    QString layerType() const;
+    void startRender( QgsSymbolV2RenderContext& context );
+    void stopRender( QgsSymbolV2RenderContext& context );
+    QgsStringMap properties() const;
+    QgsSymbolLayerV2* clone() const;
+    void toSld( QDomDocument &doc, QDomElement &element, QgsStringMap props ) const;
+    void setLineAngle( double a );
+    double lineAngle() const;
+    void setDistance( double d );
+    double distance() const;
+    void setLineWidth( double w );
+    double lineWidth() const;
+    void setColor( const QColor& c );
+    QColor color() const;
+    void setOffset( double offset );
+    double offset() const;
+};

--- a/python/core/qgslinesymbollayer.sip
+++ b/python/core/qgslinesymbollayer.sip
@@ -1,0 +1,165 @@
+class QgsLineSymbolLayerV2 : QgsSymbolLayerV2
+{
+%TypeHeaderCode
+#include <qgssymbollayerv2.h>
+%End
+
+%ConvertToSubClassCode
+  if (dynamic_cast<QgsLineDecorationSymbolLayerV2*>(sipCpp) != NULL)
+    sipClass = sipClass_QgsLineDecorationSymbolLayerV2;
+  else if (dynamic_cast<QgsMarkerLineSymbolLayerV2*>(sipCpp) != NULL)
+    sipClass = sipClass_QgsMarkerLineSymbolLayerV2;
+  else if (dynamic_cast<QgsSimpleLineSymbolLayerV2*>(sipCpp) != NULL)
+    sipClass = sipClass_QgsSimpleLineSymbolLayerV2;  
+  else
+    sipClass = 0;
+%End
+
+
+public:
+  virtual void renderPolyline(const QPolygonF& points, QgsSymbolV2RenderContext& context) = 0;
+
+  //! @note added in v1.7
+  virtual void renderPolygonOutline( const QPolygonF& points, QList<QPolygonF>* rings, QgsSymbolV2RenderContext& context );
+
+  void setWidth(double width);
+  double width() const;
+  	
+  void drawPreviewIcon(QgsSymbolV2RenderContext& context, QSize size);
+
+protected:
+  QgsLineSymbolLayerV2(bool locked = false);
+
+};
+
+///////////////
+
+class QgsLineDecorationSymbolLayerV2:QgsLineSymbolLayerV2
+{
+%TypeHeaderCode
+#include <qgslinesymbollayerv2.h>
+%End
+  
+public:
+  QgsLineDecorationSymbolLayerV2( QColor color = DEFAULT_LINEDECORATION_COLOR,
+                                  double width = DEFAULT_LINEDECORATION_WIDTH );
+
+  ~QgsLineDecorationSymbolLayerV2();
+
+  static QgsSymbolLayerV2* create( const QgsStringMap& properties = QgsStringMap() );
+  
+  // missing implementation in .cpp
+  //static QgsSymbolLayerV2* createFromSld( QDomElement &element );
+
+  QString layerType() const;
+  void startRender( QgsSymbolV2RenderContext& context );
+  void stopRender( QgsSymbolV2RenderContext& context );
+  void renderPolyline( const QPolygonF& points, QgsSymbolV2RenderContext& context );
+  QgsStringMap properties() const;
+  QgsSymbolLayerV2* clone() const;
+  void toSld( QDomDocument &doc, QDomElement &element, QgsStringMap props ) const;
+
+};
+
+///////////////
+
+class QgsMarkerLineSymbolLayerV2:QgsLineSymbolLayerV2
+{
+%TypeHeaderCode
+#include <qgslinesymbollayerv2.h>
+%End
+
+public:
+  QgsMarkerLineSymbolLayerV2( bool rotateMarker = DEFAULT_MARKERLINE_ROTATE,
+                              double interval = DEFAULT_MARKERLINE_INTERVAL );
+
+  ~QgsMarkerLineSymbolLayerV2();
+
+  enum Placement
+  {
+    Interval,
+    Vertex,
+    LastVertex,
+    FirstVertex,
+    CentralPoint
+  };
+
+  // static stuff
+
+  static QgsSymbolLayerV2* create( const QgsStringMap& properties = QgsStringMap() );
+  static QgsSymbolLayerV2* createFromSld( QDomElement &element );
+
+  // implemented from base classes
+
+  QString layerType() const;
+  void startRender( QgsSymbolV2RenderContext& context );
+  void stopRender( QgsSymbolV2RenderContext& context );
+  void renderPolyline( const QPolygonF& points, QgsSymbolV2RenderContext& context );
+  QgsStringMap properties() const;
+  QgsSymbolLayerV2* clone() const;
+  void toSld( QDomDocument &doc, QDomElement &element, QgsStringMap props ) const;
+  void setColor( const QColor& color );
+  QgsSymbolV2* subSymbol();
+  bool setSubSymbol( QgsSymbolV2* symbol );
+  virtual void setWidth( double width );
+  virtual double width() const;
+
+  bool rotateMarker() const;
+  void setRotateMarker( bool rotate );
+  double interval() const;
+  void setInterval( double interval );
+  double offset() const;
+  void setOffset( double offset );
+  Placement placement() const;
+  void setPlacement( Placement p );
+
+protected:
+
+  void renderPolylineInterval( const QPolygonF& points, QgsSymbolV2RenderContext& context );
+  void renderPolylineVertex( const QPolygonF& points, QgsSymbolV2RenderContext& context );
+  void renderPolylineCentral( const QPolygonF& points, QgsSymbolV2RenderContext& context );
+
+};
+
+///////////////
+
+class QgsSimpleLineSymbolLayerV2:QgsLineSymbolLayerV2
+{
+%TypeHeaderCode
+#include <qgslinesymbollayerv2.h>
+%End
+
+public:
+	QgsSimpleLineSymbolLayerV2( QColor color = DEFAULT_SIMPLELINE_COLOR,
+                              double width = DEFAULT_SIMPLELINE_WIDTH,
+                              Qt::PenStyle penStyle = DEFAULT_SIMPLELINE_PENSTYLE );
+
+  // static stuff
+
+  static QgsSymbolLayerV2* create( const QgsStringMap& properties = QgsStringMap() );
+  static QgsSymbolLayerV2* createFromSld( QDomElement &element );
+
+  // implemented from base classes
+
+  QString layerType() const;
+  void startRender( QgsSymbolV2RenderContext& context );
+  void stopRender( QgsSymbolV2RenderContext& context );
+  void renderPolyline( const QPolygonF& points, QgsSymbolV2RenderContext& context );
+  QgsStringMap properties() const;
+  QgsSymbolLayerV2* clone() const;
+  void toSld( QDomDocument &doc, QDomElement &element, QgsStringMap props ) const;
+
+  Qt::PenStyle penStyle() const;
+  void setPenStyle( Qt::PenStyle style );
+  Qt::PenJoinStyle penJoinStyle() const;
+  void setPenJoinStyle( Qt::PenJoinStyle style );
+  Qt::PenCapStyle penCapStyle() const;
+  void setPenCapStyle( Qt::PenCapStyle style );
+  double offset() const;
+  void setOffset( double offset );
+  bool useCustomDashPattern() const;
+  void setUseCustomDashPattern( bool b );
+  QVector<qreal> customDashVector() const;
+  void setCustomDashVector( const QVector<qreal>& vector );
+
+};

--- a/python/core/qgsmarkersymbollayer.sip
+++ b/python/core/qgsmarkersymbollayer.sip
@@ -1,0 +1,240 @@
+class QgsMarkerSymbolLayerV2 : QgsSymbolLayerV2
+{
+%TypeHeaderCode
+#include <qgssymbollayerv2.h>
+%End
+
+
+%ConvertToSubClassCode
+  if (dynamic_cast<QgsEllipseSymbolLayerV2*>(sipCpp) != NULL)
+    sipClass = sipClass_QgsEllipseSymbolLayerV2;
+  else if (dynamic_cast<QgsFontMarkerSymbolLayerV2*>(sipCpp) != NULL)
+    sipClass = sipClass_QgsFontMarkerSymbolLayerV2;
+  else if (dynamic_cast<QgsSimpleMarkerSymbolLayerV2*>(sipCpp) != NULL)
+    sipClass = sipClass_QgsSimpleMarkerSymbolLayerV2;  
+  else if (dynamic_cast<QgsSvgMarkerSymbolLayerV2*>(sipCpp) != NULL)
+    sipClass = sipClass_QgsSvgMarkerSymbolLayerV2;
+  else if (dynamic_cast<QgsVectorFieldSymbolLayer*>(sipCpp) != NULL)
+    sipClass = sipClass_QgsVectorFieldSymbolLayer;
+  else
+    sipClass = 0;
+%End
+
+
+public:
+  virtual void renderPoint(const QPointF& point, QgsSymbolV2RenderContext& context) = 0;
+
+  void drawPreviewIcon(QgsSymbolV2RenderContext& context, QSize size);
+
+  void setAngle(double angle);
+  double angle() const;
+
+  void setSize(double size);
+  double size() const;
+
+protected:
+  QgsMarkerSymbolLayerV2(bool locked = false);
+
+};
+
+///////////////
+
+class QgsEllipseSymbolLayerV2:QgsMarkerSymbolLayerV2
+{
+%TypeHeaderCode
+#include <qgsellipsesymbollayerv2.h>
+%End
+
+  public:
+    QgsEllipseSymbolLayerV2();
+    ~QgsEllipseSymbolLayerV2();
+
+    static QgsSymbolLayerV2* create( const QgsStringMap& properties = QgsStringMap() );
+    static QgsSymbolLayerV2* createFromSld( QDomElement &element );
+
+    void renderPoint( const QPointF& point, QgsSymbolV2RenderContext& context );
+    QString layerType() const;
+    void startRender( QgsSymbolV2RenderContext& context );
+    void stopRender( QgsSymbolV2RenderContext& context );
+    QgsSymbolLayerV2* clone() const;
+    QgsStringMap properties() const;
+
+    void toSld( QDomDocument& doc, QDomElement &element, QgsStringMap props ) const;
+    void writeSldMarker( QDomDocument& doc, QDomElement &element, QgsStringMap props ) const;
+
+    void setSymbolName( const QString& name );
+    QString symbolName() const;
+
+    void setSymbolNameField( const QString& field );
+    const QString& symbolNameField() const;
+
+    void setSymbolWidth( double w );
+    double symbolWidth() const;
+
+    void setWidthField( const QString& field );
+    const QString& widthField() const;
+
+    void setSymbolHeight( double h );
+    double symbolHeight() const;
+
+    void setHeightField( const QString& field );
+    const QString& heightField() const;
+
+    void setRotationField( const QString& field );
+    const QString& rotationField() const;
+
+    void setOutlineWidth( double w );
+    double outlineWidth() const;
+
+    void setOutlineWidthField( const QString& field );
+    const QString& outlineWidthField() const;
+
+    void setFillColor( const QColor& c );
+    QColor fillColor() const;
+
+    void setFillColorField( const QString& field );
+    const QString& fillColorField() const;
+
+    void setOutlineColor( const QColor& c );
+    QColor outlineColor() const;
+
+    void setOutlineColorField( const QString& field );
+    const QString& outlineColorField() const;
+
+    QSet<QString> usedAttributes() const;
+
+};
+
+///////////////
+
+
+class QgsFontMarkerSymbolLayerV2:QgsMarkerSymbolLayerV2
+{
+%TypeHeaderCode
+#include <qgsmarkersymbollayerv2.h>
+%End
+
+public:
+    QgsFontMarkerSymbolLayerV2( QString fontFamily = DEFAULT_FONTMARKER_FONT,
+                                QChar chr = DEFAULT_FONTMARKER_CHR,
+                                double pointSize = DEFAULT_FONTMARKER_SIZE,
+                                QColor color = DEFAULT_FONTMARKER_COLOR,
+                                double angle = DEFAULT_FONTMARKER_ANGLE );
+
+    // static stuff
+
+    static QgsSymbolLayerV2* create( const QgsStringMap& properties = QgsStringMap() );
+    static QgsSymbolLayerV2* createFromSld( QDomElement &element );
+
+    // implemented from base classes
+
+    QString layerType() const;
+    void startRender( QgsSymbolV2RenderContext& context );
+    void stopRender( QgsSymbolV2RenderContext& context );
+    void renderPoint( const QPointF& point, QgsSymbolV2RenderContext& context );
+    QgsStringMap properties() const;
+    QgsSymbolLayerV2* clone() const;
+    void writeSldMarker( QDomDocument &doc, QDomElement &element, QgsStringMap props ) const;
+    // new methods
+    QString fontFamily() const;
+    void setFontFamily( QString family );
+    QChar character() const;
+    void setCharacter( QChar ch );
+
+};
+
+///////////////
+
+
+class QgsSimpleMarkerSymbolLayerV2:QgsMarkerSymbolLayerV2
+{
+%TypeHeaderCode
+#include <qgsmarkersymbollayerv2.h>
+%End
+
+  public:
+    QgsSimpleMarkerSymbolLayerV2( QString name = DEFAULT_SIMPLEMARKER_NAME,
+                                  QColor color = DEFAULT_SIMPLEMARKER_COLOR,
+                                  QColor borderColor = DEFAULT_SIMPLEMARKER_BORDERCOLOR,
+                                  double size = DEFAULT_SIMPLEMARKER_SIZE,
+                                  double angle = DEFAULT_SIMPLEMARKER_ANGLE );
+
+    // static stuff
+
+    static QgsSymbolLayerV2* create( const QgsStringMap& properties = QgsStringMap() );
+    static QgsSymbolLayerV2* createFromSld( QDomElement &element );
+
+    // implemented from base classes
+
+    QString layerType() const;
+
+    void startRender( QgsSymbolV2RenderContext& context );
+    void stopRender( QgsSymbolV2RenderContext& context );
+    void renderPoint( const QPointF& point, QgsSymbolV2RenderContext& context );
+    QgsStringMap properties() const;
+    QgsSymbolLayerV2* clone() const;
+    void writeSldMarker( QDomDocument &doc, QDomElement &element, QgsStringMap props ) const;
+    QString name() const;
+    void setName( QString name );
+    QColor borderColor() const;
+    void setBorderColor( QColor color );
+
+  protected:
+
+    void drawMarker( QPainter* p, QgsSymbolV2RenderContext& context );
+    bool prepareShape();
+    bool preparePath();
+    void prepareCache( QgsSymbolV2RenderContext& context );
+
+};
+
+///////////////
+
+
+class QgsSvgMarkerSymbolLayerV2:QgsMarkerSymbolLayerV2
+{
+%TypeHeaderCode
+#include <qgsmarkersymbollayerv2.h>
+%End
+
+  public:
+    QgsSvgMarkerSymbolLayerV2( QString name = DEFAULT_SVGMARKER_NAME,
+                               double size = DEFAULT_SVGMARKER_SIZE,
+                               double angle = DEFAULT_SVGMARKER_ANGLE );
+
+    // static stuff
+
+    static QgsSymbolLayerV2* create( const QgsStringMap& properties = QgsStringMap() );
+    static QgsSymbolLayerV2* createFromSld( QDomElement &element );
+
+    //! Return a list of all available svg files
+    static QStringList listSvgFiles();
+
+    //! Get symbol's path from its name
+    static QString symbolNameToPath( QString name );
+
+    //! Get symbols's name from its path
+    static QString symbolPathToName( QString path );
+
+    // implemented from base classes
+
+    QString layerType() const;
+    void startRender( QgsSymbolV2RenderContext& context );
+    void stopRender( QgsSymbolV2RenderContext& context );
+    void renderPoint( const QPointF& point, QgsSymbolV2RenderContext& context );
+    QgsStringMap properties() const;
+    QgsSymbolLayerV2* clone() const;
+    void writeSldMarker( QDomDocument &doc, QDomElement &element, QgsStringMap props ) const;
+    QString path() const;
+    void setPath( QString path );
+
+    QColor fillColor() const;
+    void setFillColor( const QColor& c );
+    QColor outlineColor() const;
+    void setOutlineColor( const QColor& c );
+    double outlineWidth() const;
+    void setOutlineWidth( double w );
+
+};
+
+///////////////

--- a/python/core/symbology-ng-core.sip
+++ b/python/core/symbology-ng-core.sip
@@ -566,6 +566,7 @@ class QgsRuleBasedRendererV2 : QgsFeatureRendererV2
 
     /////
 
+		Rule* rootRule();
 
     //////
 
@@ -641,71 +642,6 @@ protected:
   QgsSymbolLayerV2(QgsSymbolV2::SymbolType type, bool locked = false);
 
 };
-
-///////////////
-
-class QgsMarkerSymbolLayerV2 : QgsSymbolLayerV2
-{
-%TypeHeaderCode
-#include <qgssymbollayerv2.h>
-%End
-
-public:
-  virtual void renderPoint(const QPointF& point, QgsSymbolV2RenderContext& context) = 0;
-
-  void drawPreviewIcon(QgsSymbolV2RenderContext& context, QSize size);
-
-  void setAngle(double angle);
-  double angle() const;
-
-  void setSize(double size);
-  double size() const;
-
-protected:
-  QgsMarkerSymbolLayerV2(bool locked = false);
-
-};
-
-class QgsLineSymbolLayerV2 : QgsSymbolLayerV2
-{
-%TypeHeaderCode
-#include <qgssymbollayerv2.h>
-%End
-
-public:
-  virtual void renderPolyline(const QPolygonF& points, QgsSymbolV2RenderContext& context) = 0;
-
-  //! @note added in v1.7
-  virtual void renderPolygonOutline( const QPolygonF& points, QList<QPolygonF>* rings, QgsSymbolV2RenderContext& context );
-
-  void setWidth(double width);
-  double width() const;
-  	
-  void drawPreviewIcon(QgsSymbolV2RenderContext& context, QSize size);
-
-protected:
-  QgsLineSymbolLayerV2(bool locked = false);
-
-};
-
-class QgsFillSymbolLayerV2 : QgsSymbolLayerV2
-{
-%TypeHeaderCode
-#include <qgssymbollayerv2.h>
-%End
-
-public:
-  virtual void renderPolygon(const QPolygonF& points, QList<QPolygonF>* rings, QgsSymbolV2RenderContext& context) = 0;
-
-  void drawPreviewIcon(QgsSymbolV2RenderContext& context, QSize size);
-
-  void setAngle( double angle );
-  double angle() const;
-
-protected:
-  QgsFillSymbolLayerV2(bool locked = false);
-};
-
 
 ///////////////
 
@@ -905,7 +841,6 @@ public:
 
   virtual QgsSymbolV2* clone() const /Factory/;
 };
-
 
 
 class QgsFillSymbolV2 : QgsSymbolV2


### PR DESCRIPTION
I've added the missing classes derived from QgsFillSymbolLayerV2, QgsLineSymbolLayerV2 and QgsMarkerSymbolLayerV2 to QGis Python API.
The definitions have been splitted over three different .sip files
Now the APIs cover the entire QgsSymbolLayer hierarchy.
See also http://osgeo-org.1560.n6.nabble.com/QgsFillSymbolLayerV2-descendants-missing-from-sip-tt5002739.html
