### PR TITLE
 Fix Valgrind warnings about use of initialized memory

### DIFF
--- a/src/app/legend/qgslegend.cpp
+++ b/src/app/legend/qgslegend.cpp
@@ -81,6 +81,7 @@ QgsLegend::QgsLegend( QgsMapCanvas *canvas, QWidget * parent, const char *name )
     , mMapCanvas( canvas )
     , mMinimumIconSize( 20, 20 )
     , mChanging( false )
+    , mUpdateDrawingOrder( false )
 {
   setObjectName( name );
 

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -66,11 +66,14 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas* mapCanvas, QWidget *pa
   QGis::UnitType myUnit = myRenderer->mapUnits();
   setMapUnits( myUnit );
 
+  // we need to initialize it, since the on_cbxProjectionEnabled_stateChanged()
+  // callback triggered by setChecked() might use it.
+  mProjectSrsId = myRenderer->destinationCrs().srsid();
+
   //see if the user wants on the fly projection enabled
   bool myProjectionEnabled = myRenderer->hasCrsTransformEnabled();
   cbxProjectionEnabled->setChecked( myProjectionEnabled );
 
-  mProjectSrsId = myRenderer->destinationCrs().srsid();
   QgsDebugMsg( "Read project CRSID: " + QString::number( mProjectSrsId ) );
   projectionSelector->setSelectedCrsId( mProjectSrsId );
   projectionSelector->setEnabled( myProjectionEnabled );

--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -47,17 +47,25 @@ CUSTOM_CRS_VALIDATION QgsCoordinateReferenceSystem::mCustomSrsValidation = NULL;
 //--------------------------
 
 QgsCoordinateReferenceSystem::QgsCoordinateReferenceSystem()
-    : mMapUnits( QGis::UnknownUnit )
+    : mSrsId( 0 )
+    , mGeoFlag( false )
+    , mMapUnits( QGis::UnknownUnit )
+    , mSRID( 0 )
     , mIsValidFlag( 0 )
     , mValidationHint( "" )
+    , mAxisInverted( false)
 {
   mCRS = OSRNewSpatialReference( NULL );
 }
 
 QgsCoordinateReferenceSystem::QgsCoordinateReferenceSystem( QString theDefinition )
-    : mMapUnits( QGis::UnknownUnit )
+    : mSrsId( 0 )
+    , mGeoFlag( false )
+    , mMapUnits( QGis::UnknownUnit )
+    , mSRID( 0 )
     , mIsValidFlag( 0 )
     , mValidationHint( "" )
+    , mAxisInverted( false)
 {
   mCRS = OSRNewSpatialReference( NULL );
   createFromString( theDefinition );
@@ -65,9 +73,13 @@ QgsCoordinateReferenceSystem::QgsCoordinateReferenceSystem( QString theDefinitio
 
 
 QgsCoordinateReferenceSystem::QgsCoordinateReferenceSystem( const long theId, CrsType theType )
-    : mMapUnits( QGis::UnknownUnit )
+    : mSrsId( 0 )
+    , mGeoFlag( false )
+    , mMapUnits( QGis::UnknownUnit )
+    , mSRID( 0 )
     , mIsValidFlag( 0 )
     , mValidationHint( "" )
+    , mAxisInverted( false)
 {
   mCRS = OSRNewSpatialReference( NULL );
   createFromId( theId, theType );

--- a/src/core/qgsmaprenderer.cpp
+++ b/src/core/qgsmaprenderer.cpp
@@ -43,6 +43,7 @@
 
 QgsMapRenderer::QgsMapRenderer()
 {
+  mScale = 1;
   mScaleCalculator = new QgsScaleCalculator;
   mDistArea = new QgsDistanceArea;
   mCachedTrForLayer = 0;

--- a/src/core/qgsrendercontext.cpp
+++ b/src/core/qgsrendercontext.cpp
@@ -26,6 +26,7 @@ QgsRenderContext::QgsRenderContext()
     mRenderingStopped( false ),
     mScaleFactor( 1.0 ),
     mRasterScaleFactor( 1.0 ),
+    mRendererScale( 1.0 ),
     mLabelingEngine( NULL )
 {
 

--- a/src/gui/qgsscalecombobox.cpp
+++ b/src/gui/qgsscalecombobox.cpp
@@ -24,7 +24,7 @@
 #include <QSettings>
 #include <QLineEdit>
 
-QgsScaleComboBox::QgsScaleComboBox( QWidget* parent ) : QComboBox( parent )
+QgsScaleComboBox::QgsScaleComboBox( QWidget* parent ) : QComboBox( parent ), mScale( 1.0 )
 {
   updateScales();
 


### PR DESCRIPTION
I'm not sure about the change in qgsprojectproperties.cpp. I don't believe it will hurt more than the current state of the code, but a cleaner approach might be necessary : the fact that a callback is triggered by the constructor is a bit dangerous, the object not being fully initialized.
