### PR TITLE
Added fine transparency settings for vectors.

### DIFF
--- a/src/core/symbology-ng/qgsfillsymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgsfillsymbollayerv2.cpp
@@ -69,8 +69,9 @@ QString QgsSimpleFillSymbolLayerV2::layerType() const
 
 void QgsSimpleFillSymbolLayerV2::startRender( QgsSymbolV2RenderContext& context )
 {
-  mColor.setAlphaF( context.alpha() );
-  mBrush = QBrush( mColor, mBrushStyle );
+  QColor fillColor = mColor;
+  fillColor.setAlphaF( context.alpha() * mColor.alphaF() );
+  mBrush = QBrush( fillColor, mBrushStyle );
 
   // scale brush content for printout
   double rasterScaleFactor = context.renderContext().rasterScaleFactor();
@@ -87,8 +88,10 @@ void QgsSimpleFillSymbolLayerV2::startRender( QgsSymbolV2RenderContext& context 
   // this would mean symbols with "no fill" look the same whether or not they are selected
   if ( selectFillStyle )
     mSelBrush.setStyle( mBrushStyle );
-  mBorderColor.setAlphaF( context.alpha() );
-  mPen = QPen( mBorderColor );
+
+  QColor borderColor = mBorderColor;
+  borderColor.setAlphaF( context.alpha() * mBorderColor.alphaF());
+  mPen = QPen( borderColor );
   mSelPen = QPen( selPenColor );
   mPen.setStyle( mBorderStyle );
   mPen.setWidthF( context.outputLineWidth( mBorderWidth ) );

--- a/src/core/symbology-ng/qgslinesymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgslinesymbollayerv2.cpp
@@ -76,7 +76,7 @@ QString QgsSimpleLineSymbolLayerV2::layerType() const
 void QgsSimpleLineSymbolLayerV2::startRender( QgsSymbolV2RenderContext& context )
 {
   QColor penColor = mColor;
-  penColor.setAlphaF( context.alpha() );
+  penColor.setAlphaF( mColor.alphaF() * context.alpha() );
   mPen.setColor( penColor );
   double scaledWidth = context.outputLineWidth( mWidth );
   mPen.setWidthF( scaledWidth );

--- a/src/core/symbology-ng/qgsmarkersymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgsmarkersymbollayerv2.cpp
@@ -97,11 +97,10 @@ void QgsSimpleMarkerSymbolLayerV2::startRender( QgsSymbolV2RenderContext& contex
 {
   QColor brushColor = mColor;
   QColor penColor = mBorderColor;
-  if ( context.alpha() < 1 )
-  {
-    penColor.setAlphaF( context.alpha() );
-    brushColor.setAlphaF( context.alpha() );
-  }
+
+  brushColor.setAlphaF( mColor.alphaF() * context.alpha() );
+  penColor.setAlphaF( mBorderColor.alphaF() * context.alpha() );
+
   mBrush = QBrush( brushColor );
   mPen = QPen( penColor );
   mPen.setWidthF( context.outputLineWidth( mPen.widthF() ) );

--- a/src/gui/symbology-ng/qgssymbollayerv2widget.cpp
+++ b/src/gui/symbology-ng/qgssymbollayerv2widget.cpp
@@ -110,9 +110,9 @@ void QgsSimpleLineSymbolLayerV2Widget::colorChanged()
   // Native Mac dialog works only for Qt Carbon
   // Qt bug: http://bugreports.qt.nokia.com/browse/QTBUG-14889
   // FIXME need to also check max QT_VERSION when Qt bug fixed
-  QColor color = QColorDialog::getColor( mLayer->color(), this, "", QColorDialog::DontUseNativeDialog );
+  QColor color = QColorDialog::getColor( mLayer->color(), this, "", QColorDialog::DontUseNativeDialog | QColorDialog::ShowAlphaChannel);
 #else
-  QColor color = QColorDialog::getColor( mLayer->color(), this );
+  QColor color = QColorDialog::getColor( mLayer->color(), this, "", QColorDialog::ShowAlphaChannel);
 #endif
   if ( !color.isValid() )
     return;
@@ -259,9 +259,9 @@ void QgsSimpleMarkerSymbolLayerV2Widget::setColorBorder()
   // Native Mac dialog works only for Qt Carbon
   // Qt bug: http://bugreports.qt.nokia.com/browse/QTBUG-14889
   // FIXME need to also check max QT_VERSION when Qt bug fixed
-  QColor borderColor = QColorDialog::getColor( mLayer->borderColor(), this, "", QColorDialog::DontUseNativeDialog );
+  QColor borderColor = QColorDialog::getColor( mLayer->borderColor(), this, "", QColorDialog::DontUseNativeDialog | QColorDialog::ShowAlphaChannel );
 #else
-  QColor borderColor = QColorDialog::getColor( mLayer->borderColor(), this );
+  QColor borderColor = QColorDialog::getColor( mLayer->borderColor(), this, "", QColorDialog::ShowAlphaChannel );
 #endif
   if ( !borderColor.isValid() )
     return;
@@ -276,9 +276,9 @@ void QgsSimpleMarkerSymbolLayerV2Widget::setColorFill()
   // Native Mac dialog works only for Qt Carbon
   // Qt bug: http://bugreports.qt.nokia.com/browse/QTBUG-14889
   // FIXME need to also check max QT_VERSION when Qt bug fixed
-  QColor color = QColorDialog::getColor( mLayer->color(), this, "", QColorDialog::DontUseNativeDialog );
+  QColor color = QColorDialog::getColor( mLayer->color(), this, "", QColorDialog::DontUseNativeDialog | QColorDialog::ShowAlphaChannel );
 #else
-  QColor color = QColorDialog::getColor( mLayer->color(), this );
+  QColor color = QColorDialog::getColor( mLayer->color(), this, "", QColorDialog::ShowAlphaChannel );
 #endif
   if ( !color.isValid() )
     return;
@@ -357,9 +357,9 @@ void QgsSimpleFillSymbolLayerV2Widget::setColor()
   // Native Mac dialog works only for Qt Carbon
   // Qt bug: http://bugreports.qt.nokia.com/browse/QTBUG-14889
   // FIXME need to also check max QT_VERSION when Qt bug fixed
-  QColor color = QColorDialog::getColor( mLayer->color(), this, "", QColorDialog::DontUseNativeDialog );
+  QColor color = QColorDialog::getColor( mLayer->color(), this, "", QColorDialog::DontUseNativeDialog | QColorDialog::ShowAlphaChannel);
 #else
-  QColor color = QColorDialog::getColor( mLayer->color(), this );
+  QColor color = QColorDialog::getColor( mLayer->color(), this, "", QColorDialog::ShowAlphaChannel);
 #endif
   if ( !color.isValid() )
     return;
@@ -374,9 +374,9 @@ void QgsSimpleFillSymbolLayerV2Widget::setBorderColor()
   // Native Mac dialog works only for Qt Carbon
   // Qt bug: http://bugreports.qt.nokia.com/browse/QTBUG-14889
   // FIXME need to also check max QT_VERSION when Qt bug fixed
-  QColor color = QColorDialog::getColor( mLayer->borderColor(), this, "", QColorDialog::DontUseNativeDialog );
+  QColor color = QColorDialog::getColor( mLayer->borderColor(), this, "", QColorDialog::DontUseNativeDialog | QColorDialog::ShowAlphaChannel);
 #else
-  QColor color = QColorDialog::getColor( mLayer->borderColor(), this );
+  QColor color = QColorDialog::getColor( mLayer->borderColor(), this, "", QColorDialog::ShowAlphaChannel);
 #endif
   if ( !color.isValid() )
     return;


### PR DESCRIPTION
Now the user can specify the alpha channel for outlines, border and
fill colors of polygons and markers.
The overall layer alpha channel is used as multiplier for these
values.
Selections are not affected.

Work done for Regione Toscana-SITA.
