### PR TITLE
Fix for issue #3275

### DIFF
--- a/src/core/symbology-ng/qgscategorizedsymbolrendererv2.cpp
+++ b/src/core/symbology-ng/qgscategorizedsymbolrendererv2.cpp
@@ -596,3 +596,15 @@ void QgsCategorizedSymbolRendererV2::setSourceColorRamp( QgsVectorColorRampV2* r
   delete mSourceColorRamp;
   mSourceColorRamp = ramp;
 }
+
+void QgsCategorizedSymbolRendererV2::updateSymbols( QgsSymbolV2 * sym )
+{
+  int i = 0;
+  foreach( QgsRendererCategoryV2 cat, mCategories )
+  {
+    QgsSymbolV2* symbol = sym->clone();
+    symbol->setColor( cat.symbol()->color() );
+    updateCategorySymbol( i, symbol );
+    ++i;
+  }
+}

--- a/src/core/symbology-ng/qgscategorizedsymbolrendererv2.h
+++ b/src/core/symbology-ng/qgscategorizedsymbolrendererv2.h
@@ -84,6 +84,8 @@ class CORE_EXPORT QgsCategorizedSymbolRendererV2 : public QgsFeatureRendererV2
     virtual int capabilities() { return SymbolLevels | RotationField; }
 
     virtual QgsSymbolV2List symbols();
+    //! @note added in 2.0
+    void updateSymbols( QgsSymbolV2 * sym );
 
     const QgsCategoryList& categories() { return mCategories; }
 

--- a/src/gui/symbology-ng/qgscategorizedsymbolrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgscategorizedsymbolrendererv2widget.cpp
@@ -153,10 +153,16 @@ QgsFeatureRendererV2* QgsCategorizedSymbolRendererV2Widget::renderer()
 
 void QgsCategorizedSymbolRendererV2Widget::changeCategorizedSymbol()
 {
-  QgsSymbolV2SelectorDialog dlg( mCategorizedSymbol, mStyle, mLayer, this );
-  if ( !dlg.exec() )
-    return;
+  QgsSymbolV2* newSymbol = mCategorizedSymbol->clone();
 
+  QgsSymbolV2SelectorDialog dlg( newSymbol, mStyle, mLayer, this );
+  if ( !dlg.exec() )
+  {
+    delete newSymbol;
+    return;
+  }
+
+  mCategorizedSymbol = newSymbol;
   updateCategorizedSymbolIcon();
 }
 

--- a/src/gui/symbology-ng/qgscategorizedsymbolrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgscategorizedsymbolrendererv2widget.cpp
@@ -405,18 +405,41 @@ QVariant QgsCategorizedSymbolRendererV2Widget::currentCategory()
   return m->item( row, 1 )->data();
 }
 
+QList<QVariant> QgsCategorizedSymbolRendererV2Widget::selectedCategories()
+{
+  QList<QVariant> categories;
+  QModelIndexList rows = viewCategories->selectionModel()->selectedRows();
+  QStandardItemModel* m = qobject_cast<QStandardItemModel*>( viewCategories->model() );
+
+  foreach( QModelIndex r, rows )
+  {
+    if( r.isValid() )
+    {
+      categories.append( m->item( r.row(), 1 )->data() );
+    }
+  }
+
+  return categories;
+}
+
 void QgsCategorizedSymbolRendererV2Widget::deleteCategory()
 {
-  QVariant k = currentCategory();
-  if ( !k.isValid() )
+  QList<QVariant> categories = selectedCategories();
+
+  if ( !categories.size() )
     return;
 
-  int idx = mRenderer->categoryIndexForValue( k );
-  if ( idx < 0 )
-    return;
-
-  mRenderer->deleteCategory( idx );
-
+  foreach( const QVariant k, categories )
+  {
+    if ( k.isValid() )
+    {
+      int idx = mRenderer->categoryIndexForValue( k );
+      if ( idx >= 0 )
+      {
+        mRenderer->deleteCategory( idx );
+      }
+    }
+  }
   populateCategories();
 }
 

--- a/src/gui/symbology-ng/qgscategorizedsymbolrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgscategorizedsymbolrendererv2widget.cpp
@@ -164,6 +164,9 @@ void QgsCategorizedSymbolRendererV2Widget::changeCategorizedSymbol()
 
   mCategorizedSymbol = newSymbol;
   updateCategorizedSymbolIcon();
+
+  mRenderer->updateSymbols( mCategorizedSymbol );
+  populateCategories();
 }
 
 void QgsCategorizedSymbolRendererV2Widget::updateCategorizedSymbolIcon()

--- a/src/gui/symbology-ng/qgscategorizedsymbolrendererv2widget.h
+++ b/src/gui/symbology-ng/qgscategorizedsymbolrendererv2widget.h
@@ -70,6 +70,9 @@ class GUI_EXPORT QgsCategorizedSymbolRendererV2Widget : public QgsRendererV2Widg
     //! return key for the currently selected category
     QVariant currentCategory();
 
+    //! return a list of keys for the categories unders selection
+    QList<QVariant> selectedCategories();
+
     void changeCategorySymbol();
 
     QList<QgsSymbolV2*> selectedSymbols();

--- a/src/gui/symbology-ng/qgscategorizedsymbolrendererv2widget.h
+++ b/src/gui/symbology-ng/qgscategorizedsymbolrendererv2widget.h
@@ -73,6 +73,9 @@ class GUI_EXPORT QgsCategorizedSymbolRendererV2Widget : public QgsRendererV2Widg
     //! return a list of keys for the categories unders selection
     QList<QVariant> selectedCategories();
 
+    //! change the selected symbols alone for the change button, if there is a selection
+    void changeSelectedSymbols();
+
     void changeCategorySymbol();
 
     QList<QgsSymbolV2*> selectedSymbols();

--- a/src/gui/symbology-ng/qgsgraduatedsymbolrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgsgraduatedsymbolrendererv2widget.cpp
@@ -239,9 +239,17 @@ void QgsGraduatedSymbolRendererV2Widget::reapplyColorRamp()
 
 void QgsGraduatedSymbolRendererV2Widget::changeGraduatedSymbol()
 {
-  QgsSymbolV2SelectorDialog dlg( mGraduatedSymbol, mStyle, mLayer, this );
+
+  QgsSymbolV2* newSymbol = mGraduatedSymbol->clone();
+
+  QgsSymbolV2SelectorDialog dlg( newSymbol, mStyle, mLayer, this );
   if ( !dlg.exec() )
+  {
+    delete newSymbol;
     return;
+  }
+
+  mGraduatedSymbol = newSymbol;
 
   updateGraduatedSymbolIcon();
   mRenderer->updateSymbols( mGraduatedSymbol );

--- a/src/gui/symbology-ng/qgsgraduatedsymbolrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgsgraduatedsymbolrendererv2widget.cpp
@@ -239,7 +239,16 @@ void QgsGraduatedSymbolRendererV2Widget::reapplyColorRamp()
 
 void QgsGraduatedSymbolRendererV2Widget::changeGraduatedSymbol()
 {
+  // Change the selected symbols alone if anything is selected
+  QItemSelectionModel* m = viewGraduated->selectionModel();
+  QModelIndexList i = m->selectedRows();
+  if ( m && i.size() > 0 )
+  {
+    changeSelectedSymbols();
+    return;
+  }
 
+  // Otherwise change the base mGraduatedSymbol
   QgsSymbolV2* newSymbol = mGraduatedSymbol->clone();
 
   QgsSymbolV2SelectorDialog dlg( newSymbol, mStyle, mLayer, this );
@@ -326,6 +335,34 @@ void QgsGraduatedSymbolRendererV2Widget::rangesClicked( const QModelIndex & idx 
     mRowSelected = -1;
   else
     mRowSelected = idx.row();
+}
+
+void QgsGraduatedSymbolRendererV2Widget::changeSelectedSymbols()
+{
+  QItemSelectionModel* m = viewGraduated->selectionModel();
+  QModelIndexList selectedIndexes = m->selectedRows( 1 );
+  if ( m && selectedIndexes.size() > 0 )
+  {
+    QgsSymbolV2* newSymbol = mGraduatedSymbol->clone();
+    QgsSymbolV2SelectorDialog dlg( newSymbol, mStyle, mLayer, this );
+    if ( !dlg.exec() )
+    {
+      delete newSymbol;
+      return;
+    }
+
+    foreach( QModelIndex idx, selectedIndexes )
+    {
+      if( idx.isValid() )
+      {
+        int rangeIdx = idx.row();
+        QgsSymbolV2* newRangeSymbol = newSymbol->clone();
+        newRangeSymbol->setColor( mRenderer->ranges()[rangeIdx].symbol()->color() );
+        mRenderer->updateRangeSymbol( rangeIdx, newRangeSymbol );
+      }
+    }
+  }
+  refreshSymbolView();
 }
 
 void QgsGraduatedSymbolRendererV2Widget::changeRangeSymbol( int rangeIdx )

--- a/src/gui/symbology-ng/qgsgraduatedsymbolrendererv2widget.h
+++ b/src/gui/symbology-ng/qgsgraduatedsymbolrendererv2widget.h
@@ -68,6 +68,8 @@ class GUI_EXPORT QgsGraduatedSymbolRendererV2Widget : public QgsRendererV2Widget
     void changeRangeSymbol( int rangeIdx );
     void changeRange( int rangeIdx );
 
+    void changeSelectedSymbols();
+
     QList<QgsSymbolV2*> selectedSymbols();
     QgsSymbolV2* findSymbolForRange( double lowerBound, double upperBound, const QgsRangeList& ranges ) const;
     void refreshSymbolView();


### PR DESCRIPTION
This pull request contains the fix for issue #3275.

In Categorized renderer:
- Ctrl select multiple entries and delete using the `Delete` button
- Ctrl select multiple entries and click `Change` button to change the symbol for all the classes. The symbol is changed but the color of the symbol is retained to respect the colorramp. Color can be changed the old way by `right-click -> change color`

In Graduated renderer:
- Ctrl select multiple entries and click `Change` button to change the symbol for all the classes. Color is retained here as well.
