### PR TITLE
Allow loading plugins from output dir

### DIFF
--- a/src/python/qgspythonutilsimpl.cpp
+++ b/src/python/qgspythonutilsimpl.cpp
@@ -445,9 +445,6 @@ QString QgsPythonUtilsImpl::pythonPath()
 
 QString QgsPythonUtilsImpl::pluginsPath()
 {
-  if ( QgsApplication::isRunningFromBuildDir() )
-    return QString(); // plugins not used
-  else
     return pythonPath() + "/plugins";
 }
 


### PR DESCRIPTION
Simpler version of #286, to fix (partially) http://hub.qgis.org/issues/5879

To complete the fix we'll need to get all plugins installed into the output dir.
