### PR TITLE
Fixed an error in QgsVectorLayer::extent().

### DIFF
--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -1504,7 +1504,7 @@ QgsRectangle QgsVectorLayer::extent()
     if ( mDataProvider->featureCount() != 0 )
     {
       QgsRectangle r = mDataProvider->extent();
-      rect.combineExtentWith( &r );
+      rect.set ( r.xMinimum(), r.yMinimum(), r.xMaximum(), r.yMaximum() );
     }
 
     for ( QgsFeatureList::iterator it = mAddedFeatures.begin(); it != mAddedFeatures.end(); it++ )


### PR DESCRIPTION
To see the error in action do the following:
- create a new vector layer (e.g shape line)
- add a new feature in a bounding box like (100,100,200,200)
- zoom full

or simply take a look to the c++ code.
