### PR TITLE
Add default font-family and size to output area - PyQGIS Console

### DIFF
--- a/python/console_help.py
+++ b/python/console_help.py
@@ -52,5 +52,5 @@ class HelpDialog(QDialog, Ui_Help):
                                                 lang=" + locale \
                                                 + "&pkgDir=" + qgisDataDir
 
-        url = QtCore.QUrl(filename)
+        url = QUrl(filename)
         self.webView.load(url)

--- a/python/console_output.py
+++ b/python/console_output.py
@@ -121,8 +121,8 @@ class EditorOutput(QsciScintilla):
         self.lexer = QsciLexerPython()
         
         settings = QSettings()
-        loadFont = settings.value("pythonConsole/fontfamilytext").toString()
-        fontSize = settings.value("pythonConsole/fontsize").toInt()[0]
+        loadFont = settings.value("pythonConsole/fontfamilytext", "Monospace").toString()
+        fontSize = settings.value("pythonConsole/fontsize", 10).toInt()[0]
         font = QFont(loadFont)
         font.setFixedPitch(True)
         font.setPointSize(fontSize)


### PR DESCRIPTION
fix for help dialog
