### PR TITLE
Update to custom CRS management

### DIFF
--- a/src/app/qgscustomprojectiondialog.cpp
+++ b/src/app/qgscustomprojectiondialog.cpp
@@ -395,6 +395,17 @@ void QgsCustomProjectionDialog::on_buttonBox_accepted()
   }
   
   QgsDebugMsg( "We save the modified CRS." );
+
+  //Check if all CRS are valid:
+  for( size_t i = 0; i < customCRSids.size(); ++i )
+  {
+    if( customCRSparameters[i].isValid()==false )
+    {
+      QMessageBox::information( this, tr( "QGIS Custom Projection" ),
+                                tr( "The proj4 definition of '%1' is not valid." ).arg(customCRSnames[i]) );
+      return;
+    }
+  }
   //Modify the CRS changed:
   bool save_success;
   for( size_t i = 0; i < customCRSids.size(); ++i )
@@ -403,21 +414,17 @@ void QgsCustomProjectionDialog::on_buttonBox_accepted()
     if( customCRSids[i] == "" )
     {
       save_success = save_success && saveCRS( customCRSparameters[i],customCRSnames[i], "", true);
-      if( ! save_success )
-      {
-	QgsDebugMsg( QString( "Problem for layer %1" ).arg( customCRSparameters[i].toProj4() ));
-      }
     }
     else
     {
       if ( existingCRSnames[customCRSids[i]]!=customCRSnames[i] || existingCRSparameters[customCRSids[i]].toProj4() != customCRSparameters[i].toProj4() )
       {
-	save_success = save_success && saveCRS(customCRSparameters[i], customCRSnames[i], customCRSids[i], false );
-	if( ! save_success )
-	{
-	  QgsDebugMsg( QString( "Problem for layer %1" ).arg( customCRSparameters[i].toProj4() ));
-	}
+        save_success = save_success && saveCRS(customCRSparameters[i], customCRSnames[i], customCRSids[i], false );
       }
+    }
+    if( ! save_success )
+    {
+      QgsDebugMsg( QString( "Error when saving CRS '%1'" ).arg( customCRSnames[i] ));
     }
   }
   QgsDebugMsg( "We remove the deleted CRS." );

--- a/src/app/qgscustomprojectiondialog.cpp
+++ b/src/app/qgscustomprojectiondialog.cpp
@@ -23,6 +23,7 @@
 #include "qgisapp.h" //<--theme icons
 #include "qgsapplication.h"
 #include "qgslogger.h"
+#include "qgsgenericprojectionselector.h"
 
 //qt includes
 #include <QFileInfo>
@@ -40,7 +41,6 @@ extern "C"
 #include <proj_api.h>
 }
 
-
 QgsCustomProjectionDialog::QgsCustomProjectionDialog( QWidget *parent, Qt::WFlags fl )
     : QDialog( parent, fl )
 {
@@ -49,13 +49,8 @@ QgsCustomProjectionDialog::QgsCustomProjectionDialog( QWidget *parent, Qt::WFlag
   QSettings settings;
   restoreGeometry( settings.value( "/Windows/CustomProjection/geometry" ).toByteArray() );
 
-  pbnFirst->setIcon( QgsApplication::getThemeIcon( "mIconFirst.png" ) );
-  pbnPrevious->setIcon( QgsApplication::getThemeIcon( "mIconPrevious.png" ) );
-  pbnNext->setIcon( QgsApplication::getThemeIcon( "mIconNext.png" ) );
-  pbnLast->setIcon( QgsApplication::getThemeIcon( "mIconLast.png" ) );
-  pbnNew->setIcon( QgsApplication::getThemeIcon( "mIconNew.png" ) );
-  pbnSave->setIcon( QgsApplication::getThemeIcon( "mActionFileSave.png" ) );
-  pbnDelete->setIcon( QgsApplication::getThemeIcon( "mIconDelete.png" ) );
+  pbnAdd->setIcon( QgsApplication::getThemeIcon( "mIconNew.png" ) );
+  pbnRemove->setIcon( QgsApplication::getThemeIcon( "mIconDelete.png" ) );
   // user database is created at QGIS startup in QgisApp::createDB
   // we just check whether there is our database [MD]
   QFileInfo myFileInfo;
@@ -65,28 +60,17 @@ QgsCustomProjectionDialog::QgsCustomProjectionDialog( QWidget *parent, Qt::WFlag
     QgsDebugMsg( "The qgis.db does not exist" );
   }
 
-  //
-  // Setup member vars
-  //
-  mCurrentRecordId = "";
-
-  //
-  // Set up databound controls
-  //
-
-  // deprecated methods
-  //getProjList();
-  //getEllipsoidList();
-  mRecordCountLong = getRecordCount();
-  if ( mRecordCountLong > 0 )
-    on_pbnFirst_clicked();
-  else
-    on_pbnNew_clicked();
-  //automatically go to insert mode if there are not recs yet
-  if ( mRecordCountLong < 1 )
+  populateList();
+  if( !customCRSnames.empty() )
   {
-    on_pbnNew_clicked();
+    leName->setText( customCRSnames[0] );
+    teParameters->setPlainText( customCRSparameters[0].toProj4() );
+    leNameList->setCurrentItem( leNameList->topLevelItem( 0 ) );
   }
+  
+  //leNameList->hideColumn(QGIS_CRS_ID_COLUMN);
+  leNameList->header()->setResizeMode( QGIS_CRS_NAME_COLUMN, QHeaderView::Stretch );
+  
 }
 
 QgsCustomProjectionDialog::~QgsCustomProjectionDialog()
@@ -95,229 +79,10 @@ QgsCustomProjectionDialog::~QgsCustomProjectionDialog()
   settings.setValue( "/Windows/CustomProjection/geometry", saveGeometry() );
 }
 
-void QgsCustomProjectionDialog::on_pbnDelete_clicked()
+
+void QgsCustomProjectionDialog::populateList()
 {
-
-  if ( QMessageBox::Ok != QMessageBox::warning(
-         this,
-         tr( "Delete Projection Definition?" ),
-         tr( "Deleting a projection definition is not reversable. Do you want to delete it?" ),
-         QMessageBox::Ok | QMessageBox::Cancel ) )
-  {
-    return ;
-  }
-
-  sqlite3      *myDatabase;
-  const char   *myTail;
-  sqlite3_stmt *myPreparedStatement;
-  int           myResult;
-  QString       myName;
-  //check the db is available
-  myResult = sqlite3_open( QgsApplication::qgisUserDbFilePath().toUtf8().data(), &myDatabase );
-  if ( myResult != SQLITE_OK )
-  {
-    QgsDebugMsg( QString( "Can't open database: %1" ).arg( sqlite3_errmsg( myDatabase ) ) );
-    // XXX This will likely never happen since on open, sqlite creates the
-    //     database if it does not exist.
-    Q_ASSERT( myResult == SQLITE_OK );
-  }
-  // Set up the query to retrieve the projection information needed to populate the ELLIPSOID list
-  QString mySql = "delete from tbl_srs where srs_id=" + quotedValue( mCurrentRecordId );
-  myResult = sqlite3_prepare( myDatabase, mySql.toUtf8(), mySql.toUtf8().length(), &myPreparedStatement, &myTail );
-  // XXX Need to free memory from the error msg if one is set
-  QgsDebugMsg( QString( "Query to delete current:%1" ).arg( mySql ) );
-  if ( myResult == SQLITE_OK )
-  {
-    sqlite3_step( myPreparedStatement );
-  }
-  // close the sqlite3 statement
-  sqlite3_finalize( myPreparedStatement );
-  sqlite3_close( myDatabase );
-  //move to an appropriate rec now this one is gone
-  --mRecordCountLong;
-  if ( mRecordCountLong < 1 )
-  {
-    on_pbnNew_clicked();
-  }
-  else if ( mCurrentRecordLong == 1 )
-  {
-    on_pbnFirst_clicked();
-  }
-  else if ( mCurrentRecordLong > mRecordCountLong )
-  {
-    on_pbnLast_clicked();
-  }
-  else
-  {
-    mCurrentRecordLong = mCurrentRecordLong - 2;
-    on_pbnNext_clicked();
-  }
-  return ;
-}
-
-long QgsCustomProjectionDialog::getRecordCount()
-{
-  sqlite3      *myDatabase;
-  const char   *myTail;
-  sqlite3_stmt *myPreparedStatement;
-  int           myResult;
-  long          myRecordCount = 0;
-  //check the db is available
-  myResult = sqlite3_open_v2( QgsApplication::qgisUserDbFilePath().toUtf8().data(), &myDatabase, SQLITE_OPEN_READONLY, NULL );
-  if ( myResult != SQLITE_OK )
-  {
-    QgsDebugMsg( QString( "Can't open database: %1" ).arg( sqlite3_errmsg( myDatabase ) ) );
-    // XXX This will likely never happen since on open, sqlite creates the
-    //     database if it does not exist.
-    Q_ASSERT( myResult == SQLITE_OK );
-  }
-  // Set up the query to retrieve the projection information needed to populate the ELLIPSOID list
-  QString mySql = "select count(*) from tbl_srs";
-  myResult = sqlite3_prepare( myDatabase, mySql.toUtf8(), mySql.toUtf8().length(), &myPreparedStatement, &myTail );
-  // XXX Need to free memory from the error msg if one is set
-  if ( myResult == SQLITE_OK )
-  {
-    if ( sqlite3_step( myPreparedStatement ) == SQLITE_ROW )
-    {
-      QString myRecordCountString = QString::fromUtf8(( char * )sqlite3_column_text( myPreparedStatement, 0 ) );
-      myRecordCount = myRecordCountString.toLong();
-    }
-  }
-  // close the sqlite3 statement
-  sqlite3_finalize( myPreparedStatement );
-  sqlite3_close( myDatabase );
-  return myRecordCount;
-
-}
-
-QString QgsCustomProjectionDialog::getProjectionFamilyName( QString theProjectionFamilyAcronym )
-{
-  sqlite3      *myDatabase;
-  const char   *myTail;
-  sqlite3_stmt *myPreparedStatement;
-  int           myResult;
-  QString       myName;
-  //check the db is available
-  myResult = sqlite3_open_v2( QgsApplication::srsDbFilePath().toUtf8().data(), &myDatabase, SQLITE_OPEN_READONLY, NULL );
-  if ( myResult != SQLITE_OK )
-  {
-    QgsDebugMsg( QString( "Can't open database: %1" ).arg( sqlite3_errmsg( myDatabase ) ) );
-    // XXX This will likely never happen since on open, sqlite creates the
-    //     database if it does not exist.
-    Q_ASSERT( myResult == SQLITE_OK );
-  }
-  // Set up the query to retrieve the projection information needed to populate the PROJECTION list
-  QString mySql = "select name from tbl_projection where acronym=" + quotedValue( theProjectionFamilyAcronym );
-  myResult = sqlite3_prepare( myDatabase, mySql.toUtf8(), mySql.toUtf8().length(), &myPreparedStatement, &myTail );
-  // XXX Need to free memory from the error msg if one is set
-  if ( myResult == SQLITE_OK )
-  {
-    if ( sqlite3_step( myPreparedStatement ) == SQLITE_ROW )
-      myName = QString::fromUtf8(( char * )sqlite3_column_text( myPreparedStatement, 0 ) );
-  }
-  // close the sqlite3 statement
-  sqlite3_finalize( myPreparedStatement );
-  sqlite3_close( myDatabase );
-  return myName;
-
-}
-QString QgsCustomProjectionDialog::getEllipsoidName( QString theEllipsoidAcronym )
-{
-  sqlite3      *myDatabase;
-  const char   *myTail;
-  sqlite3_stmt *myPreparedStatement;
-  int           myResult;
-  QString       myName;
-  //check the db is available
-  myResult = sqlite3_open_v2( QgsApplication::srsDbFilePath().toUtf8().data(), &myDatabase, SQLITE_OPEN_READONLY, NULL );
-  if ( myResult != SQLITE_OK )
-  {
-    QgsDebugMsg( QString( "Can't open database: %1" ).arg( sqlite3_errmsg( myDatabase ) ) );
-    // XXX This will likely never happen since on open, sqlite creates the
-    //     database if it does not exist.
-    Q_ASSERT( myResult == SQLITE_OK );
-  }
-  // Set up the query to retrieve the projection information needed to populate the ELLIPSOID list
-  QString mySql = "select name from tbl_ellipsoid where acronym=" + quotedValue( theEllipsoidAcronym );
-  myResult = sqlite3_prepare( myDatabase, mySql.toUtf8(), mySql.toUtf8().length(), &myPreparedStatement, &myTail );
-  // XXX Need to free memory from the error msg if one is set
-  if ( myResult == SQLITE_OK )
-  {
-    if ( sqlite3_step( myPreparedStatement ) == SQLITE_ROW )
-      myName = QString::fromUtf8(( char * )sqlite3_column_text( myPreparedStatement, 0 ) );
-  }
-  // close the sqlite3 statement
-  sqlite3_finalize( myPreparedStatement );
-  sqlite3_close( myDatabase );
-  return myName;
-
-}
-QString QgsCustomProjectionDialog::getProjectionFamilyAcronym( QString theProjectionFamilyName )
-{
-  sqlite3      *myDatabase;
-  const char   *myTail;
-  sqlite3_stmt *myPreparedStatement;
-  int           myResult;
-  QString       myName;
-  //check the db is available
-  myResult = sqlite3_open_v2( QgsApplication::srsDbFilePath().toUtf8().data(), &myDatabase, SQLITE_OPEN_READONLY, NULL );
-  if ( myResult != SQLITE_OK )
-  {
-    QgsDebugMsg( QString( "Can't open database: %1" ).arg( sqlite3_errmsg( myDatabase ) ) );
-    // XXX This will likely never happen since on open, sqlite creates the
-    //     database if it does not exist.
-    Q_ASSERT( myResult == SQLITE_OK );
-  }
-  // Set up the query to retrieve the projection information needed to populate the PROJECTION list
-  QString mySql = "select acronym from tbl_projection where name=" + quotedValue( theProjectionFamilyName );
-  myResult = sqlite3_prepare( myDatabase, mySql.toUtf8(), mySql.toUtf8().length(), &myPreparedStatement, &myTail );
-  // XXX Need to free memory from the error msg if one is set
-  if ( myResult == SQLITE_OK )
-  {
-    if ( sqlite3_step( myPreparedStatement ) == SQLITE_ROW )
-      myName = QString::fromUtf8(( char * )sqlite3_column_text( myPreparedStatement, 0 ) );
-  }
-  // close the sqlite3 statement
-  sqlite3_finalize( myPreparedStatement );
-  sqlite3_close( myDatabase );
-  return myName;
-
-}
-QString QgsCustomProjectionDialog::getEllipsoidAcronym( QString theEllipsoidName )
-{
-  sqlite3      *myDatabase;
-  const char   *myTail;
-  sqlite3_stmt *myPreparedStatement;
-  int           myResult;
-  QString       myName;
-  //check the db is available
-  myResult = sqlite3_open_v2( QgsApplication::srsDbFilePath().toUtf8().data(), &myDatabase, SQLITE_OPEN_READONLY, NULL );
-  if ( myResult != SQLITE_OK )
-  {
-    QgsDebugMsg( QString( "Can't open database: %1" ).arg( sqlite3_errmsg( myDatabase ) ) );
-    // XXX This will likely never happen since on open, sqlite creates the
-    //     database if it does not exist.
-    Q_ASSERT( myResult == SQLITE_OK );
-  }
-  // Set up the query to retrieve the projection information needed to populate the ELLIPSOID list
-  QString mySql = "select acronym from tbl_ellipsoid where name=" + quotedValue( theEllipsoidName );
-  myResult = sqlite3_prepare( myDatabase, mySql.toUtf8(), mySql.toUtf8().length(), &myPreparedStatement, &myTail );
-  // XXX Need to free memory from the error msg if one is set
-  if ( myResult == SQLITE_OK )
-  {
-    if ( sqlite3_step( myPreparedStatement ) == SQLITE_ROW )
-      myName = QString::fromUtf8(( char * )sqlite3_column_text( myPreparedStatement, 0 ) );
-  }
-  // close the sqlite3 statement
-  sqlite3_finalize( myPreparedStatement );
-  sqlite3_close( myDatabase );
-  return myName;
-
-}
-
-void QgsCustomProjectionDialog::on_pbnFirst_clicked()
-{
-  QgsDebugMsg( "entered." );
+  //Setup connection to the existing custom CRS database:
   sqlite3      *myDatabase;
   const char   *myTail;
   sqlite3_stmt *myPreparedStatement;
@@ -331,436 +96,59 @@ void QgsCustomProjectionDialog::on_pbnFirst_clicked()
     //     database if it does not exist.
     Q_ASSERT( myResult == SQLITE_OK );
   }
-
-  QString mySql = "select * from tbl_srs order by srs_id limit 1";
-  QgsDebugMsg( QString( "Query to move first:%1" ).arg( mySql ) );
+  QString mySql = "select srs_id,description,parameters from tbl_srs";
+  QgsDebugMsg( QString( "Query to populate existing list:%1" ).arg( mySql ) );
   myResult = sqlite3_prepare( myDatabase, mySql.toUtf8(), mySql.toUtf8().length(), &myPreparedStatement, &myTail );
   // XXX Need to free memory from the error msg if one is set
   if ( myResult == SQLITE_OK )
   {
-    if ( sqlite3_step( myPreparedStatement ) == SQLITE_ROW )
+    QTreeWidgetItem *newItem;
+    QString id, name, parameters;
+    QgsCoordinateReferenceSystem crs;
+    while ( sqlite3_step( myPreparedStatement ) == SQLITE_ROW )
     {
-      mCurrentRecordId = QString::fromUtf8(( char * )sqlite3_column_text( myPreparedStatement, 0 ) );
-      leName->setText( QString::fromUtf8(( char * )sqlite3_column_text( myPreparedStatement, 1 ) ) );
-      //QString myProjectionFamilyId = QString::fromUtf8((char *)sqlite3_column_text(myPreparedStatement,2));
-      //cboProjectionFamily->setCurrentText(getProjectionFamilyName(myProjectionFamilyId));
-      //QString myEllipsoidId = QString::fromUtf8((char *)sqlite3_column_text(myPreparedStatement,3));
-      //cboEllipsoid->setCurrentText(getEllipsoidName(myEllipsoidId));
-      leParameters->setText( QString::fromUtf8(( char * )sqlite3_column_text( myPreparedStatement, 4 ) ) );
-      mCurrentRecordLong = 1;
-      lblRecordNo->setText( tr( "%1 of %2" ).arg( mCurrentRecordLong ).arg( mRecordCountLong ) );
+      id= QString::fromUtf8( ( char* ) sqlite3_column_text( myPreparedStatement, 0 ) );
+      name= QString::fromUtf8( ( char* ) sqlite3_column_text( myPreparedStatement, 1 ) );
+      parameters= QString::fromUtf8( ( char* ) sqlite3_column_text( myPreparedStatement, 2 ) );
+      
+      crs.createFromProj4( parameters, false );
+      existingCRSnames[id] = name;
+      existingCRSparameters[id] = crs;
+
+      newItem = new QTreeWidgetItem( leNameList, QStringList(  ) );
+      newItem->setText( QGIS_CRS_NAME_COLUMN, name );
+      newItem->setText( QGIS_CRS_ID_COLUMN, id );
+      newItem->setText( QGIS_CRS_PARAMETERS_COLUMN, crs.toProj4() );
     }
   }
   else
   {
-    QgsDebugMsg( QString( "pbnFirst query failed: %1" ).arg( mySql ) );
-
+    QgsDebugMsg( QString( "Populate list query failed: %1" ).arg( mySql ) );
   }
   sqlite3_finalize( myPreparedStatement );
   sqlite3_close( myDatabase );
-
-  //enable nav buttons as appropriate
-  pbnFirst->setEnabled( false );
-  pbnPrevious->setEnabled( false );
-  //automatically go to insert mode if there are not recs yet
-  if ( mRecordCountLong < 1 )
+  
+  leNameList->sortByColumn( QGIS_CRS_NAME_COLUMN,Qt::AscendingOrder );
+  
+  QTreeWidgetItemIterator it( leNameList );
+  while( *it )
   {
-    on_pbnNew_clicked();
-    pbnDelete->setEnabled( false );
-  }
-  else if ( mCurrentRecordLong == mRecordCountLong )
-  {
-    pbnNext->setEnabled( false );
-    pbnLast->setEnabled( false );
-    pbnDelete->setEnabled( true );
-  }
-  else
-  {
-    pbnNext->setEnabled( true );
-    pbnLast->setEnabled( true );
-    pbnDelete->setEnabled( true );
+    QString id = ( *it )->text( QGIS_CRS_ID_COLUMN );
+    customCRSids.push_back( id );
+    customCRSnames.push_back( existingCRSnames[id] );
+    customCRSparameters.push_back( existingCRSparameters[id] );
+    it++;
   }
 }
 
-
-void QgsCustomProjectionDialog::on_pbnPrevious_clicked()
-{
-  QgsDebugMsg( "entered." );
-  if ( mCurrentRecordLong <= 1 )
-  {
-    return;
-  }
+bool  QgsCustomProjectionDialog::deleteCRS( QString id ){
   sqlite3      *myDatabase;
   const char   *myTail;
   sqlite3_stmt *myPreparedStatement;
   int           myResult;
-  //check the db is available
-  myResult = sqlite3_open_v2( QgsApplication::qgisUserDbFilePath().toUtf8().data(), &myDatabase, SQLITE_OPEN_READONLY, NULL );
-  if ( myResult != SQLITE_OK )
-  {
-    QgsDebugMsg( QString( "Can't open database: %1" ).arg( sqlite3_errmsg( myDatabase ) ) );
-    // XXX This will likely never happen since on open, sqlite creates the
-    //     database if it does not exist.
-    Q_ASSERT( myResult == SQLITE_OK );
-  }
-
-  QString mySql = "select * from tbl_srs where srs_id < " + mCurrentRecordId + " order by srs_id desc limit 1";
-  QgsDebugMsg( QString( "Query to move previous:%1" ).arg( mySql ) );
-  myResult = sqlite3_prepare( myDatabase, mySql.toUtf8(), mySql.toUtf8().length(), &myPreparedStatement, &myTail );
-  // XXX Need to free memory from the error msg if one is set
-  if ( myResult == SQLITE_OK )
-  {
-    if ( sqlite3_step( myPreparedStatement ) == SQLITE_ROW )
-    {
-      mCurrentRecordId = QString::fromUtf8(( char * )sqlite3_column_text( myPreparedStatement, 0 ) );
-      leName->setText( QString::fromUtf8(( char * )sqlite3_column_text( myPreparedStatement, 1 ) ) );
-      //QString myProjectionFamilyId = QString::fromUtf8((char *)sqlite3_column_text(myPreparedStatement,2));
-      //cboProjectionFamily->setCurrentText(getProjectionFamilyName(myProjectionFamilyId));
-      //QString myEllipsoidId = QString::fromUtf8((char *)sqlite3_column_text(myPreparedStatement,3));
-      //cboEllipsoid->setCurrentText(getEllipsoidName(myEllipsoidId));
-      leParameters->setText( QString::fromUtf8(( char * )sqlite3_column_text( myPreparedStatement, 4 ) ) ),
-      --mCurrentRecordLong;
-      lblRecordNo->setText( tr( "%1 of %2" ).arg( mCurrentRecordLong ).arg( mRecordCountLong ) );
-    }
-  }
-  else
-  {
-    QgsDebugMsg( QString( "pbnPrevious query failed: %1" ).arg( mySql ) );
-
-  }
-  sqlite3_finalize( myPreparedStatement );
-  sqlite3_close( myDatabase );
-
-  //enable nav buttons as appropriate
-  if ( mCurrentRecordLong <= 1 )
-  {
-    pbnFirst->setEnabled( false );
-    pbnPrevious->setEnabled( false );
-  }
-  else
-  {
-    pbnFirst->setEnabled( true );
-    pbnPrevious->setEnabled( true );
-  }
-  if ( mCurrentRecordLong == mRecordCountLong )
-  {
-    pbnNext->setEnabled( false );
-    pbnLast->setEnabled( false );
-  }
-  else
-  {
-    pbnNext->setEnabled( true );
-    pbnLast->setEnabled( true );
-  }
-
-}
-
-
-void QgsCustomProjectionDialog::on_pbnNext_clicked()
-{
-  QgsDebugMsg( "entered." );
-  if ( mCurrentRecordLong >= mRecordCountLong )
-  {
-    return;
-  }
-  sqlite3      *myDatabase;
-  const char   *myTail;
-  sqlite3_stmt *myPreparedStatement;
-  int           myResult;
-  //check the db is available
-  myResult = sqlite3_open_v2( QgsApplication::qgisUserDbFilePath().toUtf8().data(), &myDatabase, SQLITE_OPEN_READONLY, NULL );
-  if ( myResult != SQLITE_OK )
-  {
-    QgsDebugMsg( QString( "Can't open database: %1" ).arg( sqlite3_errmsg( myDatabase ) ) );
-    // XXX This will likely never happen since on open, sqlite creates the
-    //     database if it does not exist.
-    Q_ASSERT( myResult == SQLITE_OK );
-  }
-
-  QString mySql = "select * from tbl_srs where srs_id > " + mCurrentRecordId + " order by srs_id asc limit 1";
-  QgsDebugMsg( QString( "Query to move next:%1" ).arg( mySql ) );
-  myResult = sqlite3_prepare( myDatabase, mySql.toUtf8(), mySql.toUtf8().length(), &myPreparedStatement, &myTail );
-  // XXX Need to free memory from the error msg if one is set
-  if ( myResult == SQLITE_OK )
-  {
-    if ( sqlite3_step( myPreparedStatement ) == SQLITE_ROW )
-    {
-      mCurrentRecordId = QString::fromUtf8(( char * )sqlite3_column_text( myPreparedStatement, 0 ) );
-      leName->setText( QString::fromUtf8(( char * )sqlite3_column_text( myPreparedStatement, 1 ) ) );
-      //QString myProjectionFamilyId = QString::fromUtf8((char *)sqlite3_column_text(myPreparedStatement,2));
-      //cboProjectionFamily->setCurrentText(getProjectionFamilyName(myProjectionFamilyId));
-      //QString myEllipsoidId = QString::fromUtf8((char *)sqlite3_column_text(myPreparedStatement,3));
-      //cboEllipsoid->setCurrentText(getEllipsoidName(myEllipsoidId));
-      leParameters->setText( QString::fromUtf8(( char * )sqlite3_column_text( myPreparedStatement, 4 ) ) );
-      ++mCurrentRecordLong;
-      lblRecordNo->setText( tr( "%1 of %2" ).arg( mCurrentRecordLong ).arg( mRecordCountLong ) );
-    }
-  }
-  else
-  {
-    QgsDebugMsg( QString( "pbnNext query failed: %1" ).arg( mySql ) );
-
-  }
-  sqlite3_finalize( myPreparedStatement );
-  sqlite3_close( myDatabase );
-
-  //enable nav buttons as appropriate
-  if ( mCurrentRecordLong == mRecordCountLong )
-  {
-    pbnNext->setEnabled( false );
-    pbnLast->setEnabled( false );
-  }
-  else
-  {
-    pbnNext->setEnabled( true );
-    pbnLast->setEnabled( true );
-  }
-  if ( mRecordCountLong <= 1 )
-  {
-    pbnFirst->setEnabled( false );
-    pbnPrevious->setEnabled( false );
-  }
-  else
-  {
-    pbnFirst->setEnabled( true );
-    pbnPrevious->setEnabled( true );
-  }
-
-}
-
-
-void QgsCustomProjectionDialog::on_pbnLast_clicked()
-{
-  QgsDebugMsg( "entered." );
-  sqlite3      *myDatabase;
-  const char   *myTail;
-  sqlite3_stmt *myPreparedStatement;
-  int           myResult;
-  //check the db is available
-  myResult = sqlite3_open_v2( QgsApplication::qgisUserDbFilePath().toUtf8().data(), &myDatabase, SQLITE_OPEN_READONLY, NULL );
-  if ( myResult != SQLITE_OK )
-  {
-    QgsDebugMsg( QString( "Can't open database: %1" ).arg( sqlite3_errmsg( myDatabase ) ) );
-    // XXX This will likely never happen since on open, sqlite creates the
-    //     database if it does not exist.
-    Q_ASSERT( myResult == SQLITE_OK );
-  }
-
-  QString mySql = "select * from tbl_srs order by srs_id desc limit 1";
-  QgsDebugMsg( QString( "Query to move last:%1" ).arg( mySql ) );
-  myResult = sqlite3_prepare( myDatabase, mySql.toUtf8(), mySql.toUtf8().length(), &myPreparedStatement, &myTail );
-  // XXX Need to free memory from the error msg if one is set
-  if ( myResult == SQLITE_OK )
-  {
-    if ( sqlite3_step( myPreparedStatement ) == SQLITE_ROW )
-    {
-      mCurrentRecordId = QString::fromUtf8(( char * )sqlite3_column_text( myPreparedStatement, 0 ) );
-      leName->setText( QString::fromUtf8(( char * )sqlite3_column_text( myPreparedStatement, 1 ) ) );
-      //QString myProjectionFamilyId = QString::fromUtf8((char *)sqlite3_column_text(myPreparedStatement,2));
-      //cboProjectionFamily->setCurrentText(getProjectionFamilyName(myProjectionFamilyId));
-      //QString myEllipsoidId = QString::fromUtf8((char *)sqlite3_column_text(myPreparedStatement,3));
-      //cboEllipsoid->setCurrentText(getEllipsoidName(myEllipsoidId));
-      leParameters->setText( QString::fromUtf8(( char * )sqlite3_column_text( myPreparedStatement, 4 ) ) );
-      mCurrentRecordLong = mRecordCountLong;
-      lblRecordNo->setText( tr( "%1 of %2" ).arg( mCurrentRecordLong ).arg( mRecordCountLong ) );
-    }
-  }
-  else
-  {
-    QgsDebugMsg( QString( "pbnLast query failed: %1" ).arg( mySql ) );
-
-  }
-  sqlite3_finalize( myPreparedStatement );
-  sqlite3_close( myDatabase );
-
-  //enable nav buttons as appropriate
-  pbnNext->setEnabled( false );
-  pbnLast->setEnabled( false );
-  if ( mRecordCountLong <= 1 )
-  {
-    pbnFirst->setEnabled( false );
-    pbnPrevious->setEnabled( false );
-  }
-  else
-  {
-    pbnFirst->setEnabled( true );
-    pbnPrevious->setEnabled( true );
-  }
-}
-
-
-void QgsCustomProjectionDialog::on_pbnNew_clicked()
-{
-  if ( pbnNew->text() == tr( "Abort" ) )
-  {
-    //if we get here, user has aborted add record
-    pbnNew->setIcon( QgsApplication::getThemeIcon( "mIconNew.png" ) );
-    //next line needed for new/abort logic
-    pbnNew->setText( tr( "New" ) );
-    //get back to the last used record before insert was pressed
-    if ( mCurrentRecordId.isEmpty() )
-    {
-      on_pbnFirst_clicked();
-    }
-    else
-    {
-      mCurrentRecordLong = mLastRecordLong;
-      on_pbnNext_clicked();
-    }
-  }
-  else
-  {
-    //if we get here user has elected to add new record
-    pbnFirst->setEnabled( false );
-    pbnPrevious->setEnabled( false );
-    pbnNext->setEnabled( false );
-    pbnLast->setEnabled( false );
-    pbnDelete->setEnabled( false );
-    pbnNew->setIcon( QgsApplication::getThemeIcon( "mIconNew.png" ) );
-    //next line needed for new/abort logic
-    pbnNew->setText( tr( "Abort" ) );
-    //clear the controls
-    leName->setText( "" );
-    leParameters->setText( "" );
-    //cboProjectionFamily->setCurrentItem(0);
-    //cboEllipsoid->setCurrentItem(0);
-    lblRecordNo->setText( tr( "* of %1" ).arg( mRecordCountLong ) );
-    //remember the rec we are on in case the user aborts
-    mLastRecordLong = mCurrentRecordLong;
-    mCurrentRecordId = "";
-  }
-
-}
-
-
-void QgsCustomProjectionDialog::on_pbnSave_clicked()
-{
-  QgsDebugMsg( "entered." );
-
-  QString myName = leName->text();
-  QString myParameters = leParameters->text();
-  if ( myName.isEmpty() )
-  {
-    QMessageBox::information( this, tr( "QGIS Custom Projection" ),
-                              tr( "This proj4 projection definition is not valid." )
-                              + tr( " Please give the projection a name before pressing save." ) );
-    return;
-  }
-  if ( myParameters.isEmpty() )
-  {
-    QMessageBox::information( this, tr( "QGIS Custom Projection" ),
-                              tr( "This proj4 projection definition is not valid." )
-                              + tr( " Please add the parameters before pressing save." ) );
-    return;
-  }
-
-
-  //
-  // Now make sure parameters have proj and ellipse
-  //
-
-  QString myProjectionAcronym  =  getProjFromParameters();
-  QString myEllipsoidAcronym   =  getEllipseFromParameters();
-
-  if ( myProjectionAcronym.isNull() )
-  {
-    QMessageBox::information( this, tr( "QGIS Custom Projection" ),
-                              tr( "This proj4 projection definition is not valid." )
-                              + tr( " Please add a proj= clause before pressing save." ) );
-    return;
-  }
-
-#if 0
-  /** I am commenting this check out for now because of ticket #1146
-   * In 1.0.0 we should consider doing more sophisticated checks or just
-   * removing this commented block entirely. It is possible to set the
-   * parameters for the earths figure in ways other than using ellps (which
-   * is a convenience function in proj). For example the radius and flattenning
-   * can be specified and various other parameter permutations. See the proj
-   * manual section entitled 'Specifying the Earths Figure' for more details.
-   * Tim Sutton */
-  if ( myEllipsoidAcronym.isNull() )
-  {
-    QMessageBox::information( this, tr( "QGIS Custom Projection" ),
-                              tr( "This proj4 ellipsoid definition is not valid. Please add a ellips= clause before pressing save.", "COMMENTED OUT" ) );
-    return;
-  }
-#endif
-
-  //
-  // We must check the prj def is valid!
-  // NOTE :  the test below may be bogus as the processes abpve emsired there
-  // is always at least a projection and ellpsoid - which proj will parse as acceptible
-  //
-
-  projPJ myProj = pj_init_plus( leParameters->text().toLocal8Bit().data() );
-
-  if ( myProj == NULL )
-  {
-    QMessageBox::information( this, tr( "QGIS Custom Projection" ),
-                              tr( "This proj4 projection definition is not valid." )
-                              + tr( " Please correct before pressing save." ) );
-    pj_free( myProj );
-    return;
-
-  }
-  pj_free( myProj );
-
-
-  /** TODO Check the projection is not a duplicate ! */
-
-
-  //CREATE TABLE tbl_srs (
-  //srs_id integer primary key,
-  //description varchar(255) NOT NULL,
-  //projection_acronym varchar(20) NOT NULL default '',
-  //ellipsoid_acronym varchar(20) NOT NULL default '',
-  //parameters varchar(80) NOT NULL default ''
-  //);
-
-  QString mySql;
-  //insert a record if mode is enabled
-  if ( pbnNew->text() == tr( "Abort" ) )
-  {
-    //if this is the first record we need to ensure that its srs_id is 10000. For
-    //any rec after that sqlite3 will take care of the autonumering
-    //this was done to support sqlite 3.0 as it does not yet support
-    //the autoinc related system tables.
-    if ( getRecordCount() == 0 )
-    {
-      mySql = "insert into tbl_srs (srs_id,description,projection_acronym,ellipsoid_acronym,parameters,is_geo) values ("
-              + QString::number( USER_CRS_START_ID )
-              + "," + quotedValue( myName )
-              + "," + quotedValue( myProjectionAcronym )
-              + "," + quotedValue( myEllipsoidAcronym )
-              + "," + quotedValue( myParameters )
-              + ",0)"; // <-- is_geo shamelessly hard coded for now
-    }
-    else
-    {
-      mySql = "insert into tbl_srs (description,projection_acronym,ellipsoid_acronym,parameters,is_geo) values ("
-              + quotedValue( myName )
-              + "," + quotedValue( myProjectionAcronym )
-              + "," + quotedValue( myEllipsoidAcronym )
-              + "," + quotedValue( myParameters )
-              + ",0)"; // <-- is_geo shamelessly hard coded for now
-    }
-  }
-  else //user is updating an existing record
-  {
-    mySql = "update tbl_srs set description="
-            + quotedValue( myName )
-            + ",projection_acronym=" + quotedValue( myProjectionAcronym )
-            + ",ellipsoid_acronym=" + quotedValue( myEllipsoidAcronym )
-            + ",parameters=" + quotedValue( myParameters )
-            + ",is_geo=0" // <--shamelessly hard coded for now
-            + " where srs_id=" + quotedValue( mCurrentRecordId )
-            ;
-  }
-  sqlite3      *myDatabase;
-  const char   *myTail;
-  sqlite3_stmt *myPreparedStatement;
-  int           myResult;
+  
+  QString mySql = "delete from tbl_srs where srs_id=" + quotedValue( id );
+  QgsDebugMsg( mySql );
   //check the db is available
   myResult = sqlite3_open( QgsApplication::qgisUserDbFilePath().toUtf8(), &myDatabase );
   if ( myResult != SQLITE_OK )
@@ -775,28 +163,34 @@ void QgsCustomProjectionDialog::on_pbnSave_clicked()
   // XXX Need to free memory from the error msg if one is set
   if ( myResult != SQLITE_OK )
   {
-    QgsDebugMsg( QString( "update or insert failed in custom projection dialog: %1 [%2]" ).arg( mySql ).arg( sqlite3_errmsg( myDatabase ) ) );
+    QgsDebugMsg( QString( "failed to remove CRS from database in custom projection dialog: %1 [%2]" ).arg( mySql ).arg( sqlite3_errmsg( myDatabase ) ) );
   }
-  //reinstate button if we were doing an insert
-  else if ( pbnNew->text() == tr( "Abort" ) )
-  {
-    pbnNew->setText( tr( "New" ) );
-    //get to the newly inserted record
-    ++mRecordCountLong;
-    mCurrentRecordLong = mRecordCountLong - 1;
-    on_pbnLast_clicked();
-  }
+  sqlite3_close( myDatabase );
+  return myResult == SQLITE_OK;
+}
 
-  sqlite3_finalize( myPreparedStatement );
-
-  // If we have a projection acronym not in the user db previously, add it.
-  // This is a must, or else we can't select it from the vw_srs table.
-  // Actually, add it always and let the SQL PRIMARY KEY remove duplicates.
-
-  //check the db is available
+void  QgsCustomProjectionDialog::insertProjection(QString myProjectionAcronym)
+{
+  sqlite3      *myDatabase;
+  sqlite3_stmt *myPreparedStatement;
   sqlite3      *srsDatabase;
+  QString mySql;
+  const char   *myTail;
+  //check the db is available
+  int           myResult = sqlite3_open( QgsApplication::qgisUserDbFilePath().toUtf8(), &myDatabase );
+  if ( myResult != SQLITE_OK )
+  {
+    QgsDebugMsg( QString( "Can't open database: %1 \n please notify  QGIS developers of this error \n %2 (file name) " ).arg( sqlite3_errmsg( myDatabase ) ).arg( QgsApplication::qgisUserDbFilePath() ) );
+    // XXX This will likely never happen since on open, sqlite creates the
+    //     database if it does not exist.
+    Q_ASSERT( myResult == SQLITE_OK );
+  }
   int srsResult = sqlite3_open( QgsApplication::srsDbFilePath().toUtf8(), &srsDatabase );
-  if ( myResult == SQLITE_OK )
+  if ( myResult != SQLITE_OK )
+  {
+    QgsDebugMsg( QString( "Can't open database %1 [%2]" ).arg( QgsApplication::srsDbFilePath() ).arg( sqlite3_errmsg( srsDatabase ) ) );
+  }
+  else
   {
     // Set up the query to retrieve the projection information needed to populate the PROJECTION list
     QString srsSql = "select acronym,name,notes,parameters from tbl_projection where acronym=" + quotedValue( myProjectionAcronym );
@@ -836,15 +230,236 @@ void QgsCustomProjectionDialog::on_pbnSave_clicked()
 
     sqlite3_close( srsDatabase );
   }
-  else
-  {
-    QgsDebugMsg( QString( "Can't open database %1 [%2]" ).arg( QgsApplication::srsDbFilePath() ).arg( sqlite3_errmsg( srsDatabase ) ) );
-  }
-
   // close sqlite3 db
   sqlite3_close( myDatabase );
+}
 
-  pbnDelete->setEnabled( true );
+bool QgsCustomProjectionDialog::saveCRS(QgsCoordinateReferenceSystem myParameters, QString myName, QString myId, bool newEntry)
+{
+  
+  if( ! myParameters.isValid() )
+  {
+    QMessageBox::information( this, tr( "QGIS Custom Projection" ),
+                              tr( "The proj4 projection definition for the CRS \"%1\" is not valid." ).arg( myName ) );
+//                              + tr( " Please add a proj= clause before pressing save." ) );
+    return false;
+  }
+  
+  QString myProjectionAcronym  = myParameters.projectionAcronym();
+  QString myEllipsoidAcronym   =  myParameters.ellipsoidAcronym(); 
+  
+  QString mySql;
+  if( newEntry )
+  {
+    if ( existingCRSnames.size()==0 )
+    {
+      mySql = "insert into tbl_srs (srs_id,description,projection_acronym,ellipsoid_acronym,parameters,is_geo) values ("
+              + QString::number( USER_CRS_START_ID )
+              + "," + quotedValue( myName )
+              + "," + quotedValue( myProjectionAcronym )
+              + "," + quotedValue( myEllipsoidAcronym )
+              + "," + quotedValue( myParameters.toProj4() )
+              + ",0)"; // <-- is_geo shamelessly hard coded for now
+    }
+    else
+    {
+      mySql = "insert into tbl_srs (description,projection_acronym,ellipsoid_acronym,parameters,is_geo) values ("
+              + quotedValue( myName )
+              + "," + quotedValue( myProjectionAcronym )
+              + "," + quotedValue( myEllipsoidAcronym )
+              + "," + quotedValue( myParameters.toProj4() )
+              + ",0)"; // <-- is_geo shamelessly hard coded for now
+    }
+  }
+  else
+  {
+    mySql = "update tbl_srs set description="
+          + quotedValue( myName )
+          + ",projection_acronym=" + quotedValue( myProjectionAcronym )
+          + ",ellipsoid_acronym=" + quotedValue( myEllipsoidAcronym )
+          + ",parameters=" + quotedValue( myParameters.toProj4() )
+          + ",is_geo=0" // <--shamelessly hard coded for now
+          + " where srs_id=" + quotedValue( myId )
+          ;
+  }
+  QgsDebugMsg( mySql );
+  sqlite3      *myDatabase;
+  const char   *myTail;
+  sqlite3_stmt *myPreparedStatement;
+  int           myResult;
+  //check if the db is available
+  myResult = sqlite3_open( QgsApplication::qgisUserDbFilePath().toUtf8(), &myDatabase );
+  if ( myResult != SQLITE_OK )
+  {
+    QgsDebugMsg( QString( "Can't open database: %1 \n please notify  QGIS developers of this error \n %2 (file name) " ).arg( sqlite3_errmsg( myDatabase ) ).arg( QgsApplication::qgisUserDbFilePath() ) );
+    // XXX This will likely never happen since on open, sqlite creates the
+    //     database if it does not exist.
+    Q_ASSERT( myResult == SQLITE_OK );
+  }
+  myResult = sqlite3_prepare( myDatabase, mySql.toUtf8(), mySql.toUtf8().length(), &myPreparedStatement, &myTail );
+  sqlite3_step( myPreparedStatement );
+  // XXX Need to free memory from the error msg if one is set
+  if ( myResult != SQLITE_OK )
+  {
+    QgsDebugMsg( QString( "failed to write to database in custom projection dialog: %1 [%2]" ).arg( mySql ).arg( sqlite3_errmsg( myDatabase ) ) );
+  }
+
+  sqlite3_finalize( myPreparedStatement );
+  if( newEntry )
+  {
+    int return_id = sqlite3_last_insert_rowid( myDatabase );
+    myId = QString::number( return_id );
+  }
+  // close sqlite3 db
+  sqlite3_close( myDatabase );
+  
+  existingCRSparameters[myId] = myParameters;
+  existingCRSnames[myId] = myName;
+  
+  // If we have a projection acronym not in the user db previously, add it.
+  // This is a must, or else we can't select it from the vw_srs table.
+  // Actually, add it always and let the SQL PRIMARY KEY remove duplicates.
+  insertProjection( myProjectionAcronym );
+  
+  return myResult == SQLITE_OK;
+}
+
+
+void QgsCustomProjectionDialog::on_pbnAdd_clicked()
+{
+  QString name = tr( "new CRS" );
+  QString id = "";
+  QgsCoordinateReferenceSystem parameters;
+  
+  QTreeWidgetItem* newItem = new QTreeWidgetItem( leNameList, QStringList(  ) );
+
+  newItem->setText( QGIS_CRS_NAME_COLUMN, name );
+  newItem->setText( QGIS_CRS_ID_COLUMN, id );
+  newItem->setText( QGIS_CRS_PARAMETERS_COLUMN, parameters.toProj4());
+  customCRSnames.push_back( name );
+  customCRSids.push_back ( id);
+  customCRSparameters.push_back( parameters );
+  leNameList->setCurrentItem( newItem );
+}
+
+void QgsCustomProjectionDialog::on_pbnRemove_clicked()
+{
+  int i = leNameList->currentIndex().row();
+  if( i == -1 )
+  {
+    return;
+  }
+  QTreeWidgetItem* item = leNameList->takeTopLevelItem( i );
+  delete item;
+  if( customCRSids[i] != "" )
+  {
+    deletedCRSs.push_back( customCRSids[i] );
+  }
+  customCRSids.erase( customCRSids.begin() + i );
+  customCRSnames.erase( customCRSnames.begin() + i );
+  customCRSparameters.erase( customCRSparameters.begin() + i );
+}
+
+
+void QgsCustomProjectionDialog::on_leNameList_currentItemChanged( QTreeWidgetItem *current, QTreeWidgetItem * previous )
+{
+  //Store the modifications made to the current element before moving on
+  int currentIndex, previousIndex;
+  if( previous )
+  {
+    previousIndex = leNameList->indexOfTopLevelItem( previous );
+    customCRSnames[previousIndex] = leName->text();
+    customCRSparameters[previousIndex].createFromProj4( teParameters->toPlainText(), false);
+    previous->setText( QGIS_CRS_NAME_COLUMN, leName->text() );
+    previous->setText( QGIS_CRS_PARAMETERS_COLUMN, teParameters->toPlainText() );
+  }
+  if( current )
+  {
+    currentIndex = leNameList->indexOfTopLevelItem( current );
+    leName->setText( customCRSnames[currentIndex] );
+    teParameters->setPlainText( current->text( QGIS_CRS_PARAMETERS_COLUMN ) );
+  }
+  else
+  {
+    //Can happen that current is null, for example if we just deleted the last element
+    leName->setText( "" );
+    teParameters->setPlainText( "" );
+    return;  
+  }
+  return;
+}
+
+void QgsCustomProjectionDialog::on_pbnCopyCRS_clicked()
+{  
+  QgsDebugMsg( "Entered" );
+  QgsGenericProjectionSelector *mySelector = new QgsGenericProjectionSelector( this );
+  if ( mySelector->exec() )
+  {
+    QgsCoordinateReferenceSystem srs;
+    QString id = mySelector->selectedAuthId();
+    srs.createFromOgcWmsCrs( id );
+    if (leNameList->topLevelItemCount() == 0 )
+    {
+      on_pbnAdd_clicked();
+    }
+    teParameters->setPlainText( srs.toProj4() );
+    customCRSparameters[leNameList->currentIndex().row()].createFromProj4( srs.toProj4() );
+    leNameList->currentItem()->setText( QGIS_CRS_PARAMETERS_COLUMN, srs.toProj4() );
+    
+  }
+  delete mySelector;
+}
+
+void QgsCustomProjectionDialog::on_buttonBox_accepted()
+{
+  QgsDebugMsg( "Entered" );
+  //Update the current CRS:
+  int i = leNameList->currentIndex().row();
+  if(i != -1)
+  {
+    customCRSnames[i] = leName->text();
+    customCRSparameters[i].createFromProj4( teParameters->toPlainText(), false );
+  }
+  
+  QgsDebugMsg( "We save the modified CRS." );
+  //Modify the CRS changed:
+  bool save_success;
+  for( size_t i = 0; i < customCRSids.size(); ++i )
+  {
+    //Test if we just added this CRS (if it has no existing ID)
+    if( customCRSids[i] == "" )
+    {
+      save_success = save_success && saveCRS( customCRSparameters[i],customCRSnames[i], "", true);
+      if( ! save_success )
+      {
+	QgsDebugMsg( QString( "Problem for layer %1" ).arg( customCRSparameters[i].toProj4() ));
+      }
+    }
+    else
+    {
+      if ( existingCRSnames[customCRSids[i]]!=customCRSnames[i] || existingCRSparameters[customCRSids[i]].toProj4() != customCRSparameters[i].toProj4() )
+      {
+	save_success = save_success && saveCRS(customCRSparameters[i], customCRSnames[i], customCRSids[i], false );
+	if( ! save_success )
+	{
+	  QgsDebugMsg( QString( "Problem for layer %1" ).arg( customCRSparameters[i].toProj4() ));
+	}
+      }
+    }
+  }
+  QgsDebugMsg( "We remove the deleted CRS." );
+  for( size_t i = 0; i < deletedCRSs.size(); ++i )
+  {
+    save_success=save_success && deleteCRS( deletedCRSs[i] );
+    if( ! save_success )
+    {
+      QgsDebugMsg( QString( "Problem for layer %1" ).arg( customCRSparameters[i].toProj4() ));
+    }
+  }
+  if( save_success )
+  {
+    accept();
+  }
 }
 
 void QgsCustomProjectionDialog::on_pbnCalculate_clicked()
@@ -856,9 +471,9 @@ void QgsCustomProjectionDialog::on_pbnCalculate_clicked()
   // We must check the prj def is valid!
   //
 
-  projPJ myProj = pj_init_plus( leTestParameters->text().toLocal8Bit().data() );
+  projPJ myProj = pj_init_plus( teParameters->toPlainText().toLocal8Bit().data() );
 
-  QgsDebugMsg( QString( "My proj: %1" ).arg( leTestParameters->text() ) );
+  QgsDebugMsg( QString( "My proj: %1" ).arg( teParameters->toPlainText() ) );
 
   if ( myProj == NULL )
   {
@@ -922,46 +537,6 @@ void QgsCustomProjectionDialog::on_pbnCalculate_clicked()
 
 }
 
-
-QString QgsCustomProjectionDialog::getProjFromParameters()
-{
-  QgsDebugMsg( "entered." );
-  QString myProj4String = leParameters->text();
-  QRegExp myProjRegExp( "\\+proj=[a-zA-Z]*" );
-  int myStart = 0;
-  myStart = myProjRegExp.indexIn( myProj4String, myStart );
-  if ( myStart == -1 )
-  {
-    QgsDebugMsg( "proj string supplied has no +proj argument!" );
-    return NULL;
-  }
-  else
-  {
-    int myLength = myProjRegExp.matchedLength();
-    QString myProjectionAcronym = myProj4String.mid( myStart + ( PROJ_PREFIX_LEN ), myLength - ( PROJ_PREFIX_LEN ) );//+1 for space
-    return myProjectionAcronym;
-  }
-}
-
-QString QgsCustomProjectionDialog::getEllipseFromParameters()
-{
-  QgsDebugMsg( "entered." );
-  QString myProj4String = leParameters->text();
-  QRegExp myEllipseRegExp( "\\+ellps=[a-zA-Z0-9\\-_]*" );
-  int myStart = 0;
-  myStart = myEllipseRegExp.indexIn( myProj4String, myStart );
-  if ( myStart == -1 )
-  {
-    QgsDebugMsg( "proj string supplied has no +ellps!" );
-    return NULL;
-  }
-  else //match was found
-  {
-    int myLength = myEllipseRegExp.matchedLength();
-    QString myEllipsoidAcronym = myProj4String.mid( myStart + ( ELLPS_PREFIX_LEN ), myLength - ( ELLPS_PREFIX_LEN ) );
-    return myEllipsoidAcronym;
-  }
-}
 
 QString QgsCustomProjectionDialog::quotedValue( QString value )
 {

--- a/src/app/qgscustomprojectiondialog.h
+++ b/src/app/qgscustomprojectiondialog.h
@@ -36,7 +36,7 @@ class QgsCustomProjectionDialog : public QDialog, private Ui::QgsCustomProjectio
     QgsCustomProjectionDialog( QWidget *parent = 0, Qt::WFlags fl = 0 );
     ~QgsCustomProjectionDialog();
 
-public slots:
+  public slots:
     void on_pbnCalculate_clicked();
     void on_pbnAdd_clicked();
     void on_pbnRemove_clicked();

--- a/src/app/qgscustomprojectiondialog.h
+++ b/src/app/qgscustomprojectiondialog.h
@@ -55,14 +55,14 @@ class QgsCustomProjectionDialog : public QDialog, private Ui::QgsCustomProjectio
     bool saveCRS( QgsCoordinateReferenceSystem myParameters, QString myName, QString myId, bool newEntry );
     void insertProjection( QString myProjectionAcronym );
     
-    //These two QMap store the value as it is on the database when loading
-    QMap <QString, QgsCoordinateReferenceSystem> existingCRSparameters;
+    //These two QMap store the values as they are on the database when loading
+    QMap <QString, QString> existingCRSparameters;
     QMap <QString, QString> existingCRSnames;
    
     //These three vectors store the value updated with the current modifications
     std::vector<QString> customCRSnames;
     std::vector<QString> customCRSids;
-    std::vector<QgsCoordinateReferenceSystem> customCRSparameters;
+    std::vector<QString> customCRSparameters;
 
     //vector saving the CRS to be deleted
     std::vector<QString> deletedCRSs; 

--- a/src/app/qgscustomprojectiondialog.h
+++ b/src/app/qgscustomprojectiondialog.h
@@ -20,6 +20,7 @@
 
 #include "ui_qgscustomprojectiondialogbase.h"
 #include "qgscontexthelp.h"
+#include "qgscoordinatereferencesystem.h"
 
 class QDir;
 
@@ -34,45 +35,41 @@ class QgsCustomProjectionDialog : public QDialog, private Ui::QgsCustomProjectio
   public:
     QgsCustomProjectionDialog( QWidget *parent = 0, Qt::WFlags fl = 0 );
     ~QgsCustomProjectionDialog();
-    //a recursive function to make a directory and its ancestors
-  public slots:
+
+public slots:
     void on_pbnCalculate_clicked();
-    void on_pbnDelete_clicked();
-    //
-    // Database navigation controles
-    //
-    long getRecordCount();
-    void on_pbnFirst_clicked();
-    void on_pbnPrevious_clicked();
-    void on_pbnNext_clicked();
-    void on_pbnLast_clicked();
-    void on_pbnNew_clicked();
-    void on_pbnSave_clicked();
+    void on_pbnAdd_clicked();
+    void on_pbnRemove_clicked();
+    void on_pbnCopyCRS_clicked();
+    void on_leNameList_currentItemChanged( QTreeWidgetItem *current, QTreeWidgetItem *prev );
 
     void on_buttonBox_helpRequested() { QgsContextHelp::run( metaObject()->className() ); }
-
-    //
-    // Control population
-    //
-    /* These two methods will be deprecated
-    void getProjList();
-    void getEllipsoidList();
-    */
-    QString getProjectionFamilyName( QString theProjectionFamilyAcronym );
-    QString getEllipsoidName( QString theEllipsoidAcronym );
-    QString getProjectionFamilyAcronym( QString theProjectionFamilyName );
-    QString getEllipsoidAcronym( QString theEllipsoidName );
+    void on_buttonBox_accepted();
+    
   private:
-    QString getProjFromParameters();
-    QString getEllipseFromParameters();
-
-    QString mCurrentRecordId;
-    long mCurrentRecordLong;
-    //the record previous to starting an insert operation
-    //so that we can return to it if the record insert is aborted
-    long mLastRecordLong;
-    long mRecordCountLong;
+   
+    //helper functions
+    void populateList();
     QString quotedValue( QString value );
+    bool deleteCRS( QString id );
+    bool saveCRS( QgsCoordinateReferenceSystem myParameters, QString myName, QString myId, bool newEntry );
+    void insertProjection( QString myProjectionAcronym );
+    
+    //These two QMap store the value as it is on the database when loading
+    QMap <QString, QgsCoordinateReferenceSystem> existingCRSparameters;
+    QMap <QString, QString> existingCRSnames;
+   
+    //These three vectors store the value updated with the current modifications
+    std::vector<QString> customCRSnames;
+    std::vector<QString> customCRSids;
+    std::vector<QgsCoordinateReferenceSystem> customCRSparameters;
+
+    //vector saving the CRS to be deleted
+    std::vector<QString> deletedCRSs; 
+
+    //Columns in the tree widget
+    enum columns { QGIS_CRS_NAME_COLUMN, QGIS_CRS_ID_COLUMN, QGIS_CRS_PARAMETERS_COLUMN };
 };
+
 
 #endif

--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -494,7 +494,7 @@ bool QgsCoordinateReferenceSystem::isValid() const
   return mIsValidFlag;
 }
 
-bool QgsCoordinateReferenceSystem::createFromProj4( const QString theProj4String )
+bool QgsCoordinateReferenceSystem::createFromProj4( const QString theProj4String, bool save )
 {
   //
   // Examples:

--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -27,6 +27,7 @@
 #include <QRegExp>
 #include <QTextStream>
 #include <QFile>
+#include <QSettings>
 
 #include "qgsapplication.h"
 #include "qgscrscache.h"
@@ -494,7 +495,7 @@ bool QgsCoordinateReferenceSystem::isValid() const
   return mIsValidFlag;
 }
 
-bool QgsCoordinateReferenceSystem::createFromProj4( const QString theProj4String, bool save )
+bool QgsCoordinateReferenceSystem::createFromProj4( const QString theProj4String )
 {
   //
   // Examples:
@@ -1472,8 +1473,28 @@ bool QgsCoordinateReferenceSystem::saveAsUserCRS( QString name )
 
   QgsMessageLog::logMessage( QObject::tr( "Saved user CRS [%1]" ).arg( toProj4() ), QObject::tr( "CRS" ) );
 
-  // XXX Need to free memory from the error msg if one is set
-  return myResult == SQLITE_OK;
+  int return_id;
+  if(myResult == SQLITE_OK)
+  {
+    return_id = sqlite3_last_insert_rowid( myDatabase );
+    setInternalId(return_id);
+    
+    //We add the just created user CRS to the list of recently used CRS
+    QSettings settings;
+    //QStringList recentProjections = settings.value( "/UI/recentProjections" ).toStringList();
+    QStringList projectionsProj4 = settings.value( "/UI/recentProjectionsProj4" ).toStringList();
+    QStringList projectionsAuthId = settings.value( "/UI/recentProjectionsAuthId" ).toStringList();
+    //recentProjections.append();
+    //settings.setValue( "/UI/recentProjections", recentProjections );
+    projectionsProj4.append(toProj4());
+    projectionsAuthId.append(authid());
+    settings.setValue( "/UI/recentProjectionsProj4", projectionsProj4 );
+    settings.setValue( "/UI/recentProjectionsAuthId", projectionsAuthId );
+
+  }
+  else
+    return_id = -1;
+  return return_id;
 }
 
 long QgsCoordinateReferenceSystem::getRecordCount()

--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -663,6 +663,7 @@ bool QgsCoordinateReferenceSystem::createFromProj4( const QString theProj4String
   if ( !mIsValidFlag )
   {
     QgsDebugMsg( "Projection is not found in databases." );
+    //setProj4String will set mIsValidFlag to true if there is no issue
     setProj4String( myProj4String );
   }
 

--- a/src/core/qgscoordinatereferencesystem.h
+++ b/src/core/qgscoordinatereferencesystem.h
@@ -154,7 +154,7 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      * @param theProjString A proj4 format string
      * @return bool TRUE if success else false
      */
-    bool createFromProj4( const QString theProjString );
+    bool createFromProj4( const QString theProjString, bool save=true );
 
     /*! Set up this srs from a string definition, by default a WKT definition.  Otherwise
      * the string defines a authority, followed by a colon, followed by the definition.
@@ -444,7 +444,7 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
     long    mSRID;
     //!If available the authority identifier for this srs
     QString mAuthId;
-    //! Wehter this srs is properly defined and valid
+    //! Wheter this srs is properly defined and valid
     bool mIsValidFlag;
 
     //! Work out the projection units and set the appropriate local variable

--- a/src/core/qgscoordinatereferencesystem.h
+++ b/src/core/qgscoordinatereferencesystem.h
@@ -134,7 +134,7 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      * in the parameters member. The reason for this is so that we
      * can easily present the user with 'natural language' representation
      * of the projection and ellipsoid by looking them up in the srs.bs sqlite
-     * database. Also having the ellpse and proj elements stripped out
+     * database. Also having the ellipse and proj elements stripped out
      * is helpful to speed up globbing queries (see below).
      *
      * We try to match the proj string to and srsid using the following logic:
@@ -154,7 +154,7 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      * @param theProjString A proj4 format string
      * @return bool TRUE if success else false
      */
-    bool createFromProj4( const QString theProjString, bool save=true );
+    bool createFromProj4( const QString theProjString );
 
     /*! Set up this srs from a string definition, by default a WKT definition.  Otherwise
      * the string defines a authority, followed by a colon, followed by the definition.

--- a/src/gui/qgsprojectionselector.cpp
+++ b/src/gui/qgsprojectionselector.cpp
@@ -81,19 +81,10 @@ QgsProjectionSelector::QgsProjectionSelector( QWidget* parent, const char *name,
           // No? Skip this entry
           continue;
         }
-        else
+        //If the CRS can be created but do not correspond to a CRS in the database, skip it (for example a deleted custom CRS)
+        if ( crs.srsid() == 0 )
         {
-          //TODO: createFromProj4 used to save to the user database any new CRS
-          // this behavior was changed in order to separate creation and saving.
-          // Not sure if it necessary to save it here, should be checked by someone
-          // familiar with the code (should also give a more descriptive name to the generated CRS)
-          if ( crs.srsid() == 0 )
-          {
-            QString myName = QString( " * %1 (%2)" )
-                             .arg( QObject::tr( "Generated CRS", "A CRS automatically generated from layer info get this prefix for description" ) )
-                             .arg( crs.toProj4() );
-            crs.saveAsUserCRS( myName );
-          }
+          continue;
         }
       }
       mRecentProjections << QString::number( crs.srsid() );
@@ -277,7 +268,7 @@ void QgsProjectionSelector::applySelection( int column, QString value )
   }
   else
   {
-    QgsDebugMsg( "nothing found" );
+    QgsDebugMsg( QString("nothing found for %1,%2" ).arg( column ).arg( value ) );
     // unselect the selected item to avoid confusing the user
     lstCoordinateSystems->clearSelection();
     lstRecent->clearSelection();

--- a/src/providers/wcs/qgswcsprovider.cpp
+++ b/src/providers/wcs/qgswcsprovider.cpp
@@ -556,7 +556,7 @@ void QgsWcsProvider::readBlock( int bandNo, QgsRectangle  const & viewExtent, in
     // It may happen (Geoserver) that if requested BBOX is larger than coverage
     // extent, the returned data cover intersection of requested BBOX and coverage
     // extent scaled to requested WIDTH/HEIGHT => check extent
-    // Unfortunately if received raster does not hac CRS, the extent is raster size
+    // Unfortunately if the received raster does not have a CRS, the extent is the raster size
     // and in that case it cannot be used to verify extent
     QgsCoordinateReferenceSystem cacheCrs;
     if ( !cacheCrs.createFromWkt( GDALGetProjectionRef( mCachedGdalDataset ) ) &&

--- a/src/ui/qgscustomprojectiondialogbase.ui
+++ b/src/ui/qgscustomprojectiondialogbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>474</width>
-    <height>548</height>
+    <width>542</width>
+    <height>650</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -25,7 +25,41 @@
       <string>Define</string>
      </property>
      <layout class="QGridLayout">
-      <item row="0" column="0" colspan="2">
+      <item row="2" column="0" colspan="4">
+       <widget class="QTreeWidget" name="leNameList">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="alternatingRowColors">
+         <bool>true</bool>
+        </property>
+        <property name="sortingEnabled">
+         <bool>false</bool>
+        </property>
+        <attribute name="headerShowSortIndicator" stdset="0">
+         <bool>false</bool>
+        </attribute>
+        <column>
+         <property name="text">
+          <string>Name</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>ID</string>
+         </property>
+        </column>
+        <column>
+         <property name="text">
+          <string>Parameters</string>
+         </property>
+        </column>
+       </widget>
+      </item>
+      <item row="1" column="0" colspan="4">
        <widget class="QLabel" name="label">
         <property name="text">
          <string>You can define your own custom Coordinate Reference System (CRS) here. The definition must conform to the proj4 format for specifying a CRS.</string>
@@ -35,118 +69,83 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="textLabel1">
-        <property name="text">
-         <string>Name</string>
+      <item row="5" column="3">
+       <widget class="QPlainTextEdit" name="teParameters">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
         </property>
-        <property name="buddy">
-         <cstring>leName</cstring>
+        <property name="maximumSize">
+         <size>
+          <width>16777215</width>
+          <height>70</height>
+         </size>
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
+      <item row="4" column="3">
        <widget class="QLineEdit" name="leName"/>
       </item>
-      <item row="2" column="0">
-       <widget class="QLabel" name="textLabel3_2">
+      <item row="4" column="2">
+       <widget class="QLabel" name="label_3">
         <property name="text">
-         <string>Parameters</string>
-        </property>
-        <property name="buddy">
-         <cstring>leParameters</cstring>
+         <string>Name:</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
-       <widget class="QLineEdit" name="leParameters"/>
+      <item row="5" column="2">
+       <layout class="QVBoxLayout" name="verticalLayout">
+        <property name="sizeConstraint">
+         <enum>QLayout::SetMinimumSize</enum>
+        </property>
+        <item>
+         <widget class="QLabel" name="label_4">
+          <property name="text">
+           <string>Parameters:</string>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QPushButton" name="pbnCopyCRS">
+          <property name="text">
+           <string>Copy
+ existing CRS</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
-      <item row="3" column="1">
-       <layout class="QHBoxLayout">
+      <item row="3" column="1" colspan="3">
+       <layout class="QHBoxLayout" name="horizontalLayout_2">
+        <property name="spacing">
+         <number>6</number>
+        </property>
         <item>
-         <widget class="QToolButton" name="pbnFirst">
+         <widget class="QPushButton" name="pbnAdd">
           <property name="text">
-           <string>|&lt;</string>
-          </property>
-          <property name="icon">
-           <iconset>
-            <normaloff>../../images/themes/default/mIconFirst.png</normaloff>../../images/themes/default/mIconFirst.png</iconset>
+           <string>Add new CRS</string>
           </property>
          </widget>
         </item>
         <item>
-         <widget class="QToolButton" name="pbnPrevious">
-          <property name="text">
-           <string>&lt;</string>
+         <spacer name="horizontalSpacer">
+          <property name="orientation">
+           <enum>Qt::Horizontal</enum>
           </property>
-          <property name="icon">
-           <iconset>
-            <normaloff>../../images/themes/default/mIconPrevious.png</normaloff>../../images/themes/default/mIconPrevious.png</iconset>
+          <property name="sizeHint" stdset="0">
+           <size>
+            <width>40</width>
+            <height>20</height>
+           </size>
           </property>
-         </widget>
+         </spacer>
         </item>
         <item>
-         <widget class="QLabel" name="lblRecordNo">
+         <widget class="QPushButton" name="pbnRemove">
           <property name="text">
-           <string>1 of 1</string>
-          </property>
-          <property name="alignment">
-           <set>Qt::AlignCenter</set>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QToolButton" name="pbnNext">
-          <property name="text">
-           <string>&gt;</string>
-          </property>
-          <property name="icon">
-           <iconset>
-            <normaloff>../../images/themes/default/mIconNext.png</normaloff>../../images/themes/default/mIconNext.png</iconset>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QToolButton" name="pbnLast">
-          <property name="text">
-           <string>&gt;|</string>
-          </property>
-          <property name="icon">
-           <iconset>
-            <normaloff>../../images/themes/default/mIconLast.png</normaloff>../../images/themes/default/mIconLast.png</iconset>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QToolButton" name="pbnNew">
-          <property name="text">
-           <string>*</string>
-          </property>
-          <property name="icon">
-           <iconset>
-            <normaloff>../../images/themes/default/mIconNew.png</normaloff>../../images/themes/default/mIconNew.png</iconset>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QToolButton" name="pbnSave">
-          <property name="text">
-           <string>S</string>
-          </property>
-          <property name="icon">
-           <iconset>
-            <normaloff>../../images/themes/default/mActionFileSave.png</normaloff>../../images/themes/default/mActionFileSave.png</iconset>
-          </property>
-         </widget>
-        </item>
-        <item>
-         <widget class="QToolButton" name="pbnDelete">
-          <property name="text">
-           <string>X</string>
-          </property>
-          <property name="icon">
-           <iconset>
-            <normaloff>../../images/themes/default/mIconDelete.png</normaloff>../../images/themes/default/mIconDelete.png</iconset>
+           <string>Remove</string>
           </property>
          </widget>
         </item>
@@ -155,12 +154,29 @@
      </layout>
     </widget>
    </item>
+   <item row="2" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
    <item row="1" column="0">
     <widget class="QGroupBox" name="groupBox_2">
      <property name="title">
       <string>Test</string>
      </property>
      <layout class="QGridLayout">
+      <item row="3" column="0">
+       <widget class="QLabel" name="textLabel2_2_2">
+        <property name="text">
+         <string>East</string>
+        </property>
+        <property name="buddy">
+         <cstring>eastWGS84</cstring>
+        </property>
+       </widget>
+      </item>
       <item row="0" column="0" colspan="3">
        <widget class="QLabel" name="label_2">
         <property name="text">
@@ -171,34 +187,21 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="textLabel3_2_2">
-        <property name="text">
-         <string>Parameters</string>
-        </property>
-        <property name="buddy">
-         <cstring>leTestParameters</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1" colspan="2">
-       <widget class="QLineEdit" name="leTestParameters"/>
-      </item>
-      <item row="2" column="1">
+      <item row="1" column="1">
        <widget class="QLabel" name="textLabel1_3">
         <property name="text">
          <string>Geographic / WGS84</string>
         </property>
        </widget>
       </item>
-      <item row="2" column="2">
+      <item row="1" column="2">
        <widget class="QLabel" name="textLabel2_3">
         <property name="text">
          <string>Destination CRS        </string>
         </property>
        </widget>
       </item>
-      <item row="3" column="0">
+      <item row="2" column="0">
        <widget class="QLabel" name="textLabel2_2">
         <property name="text">
          <string>North</string>
@@ -208,14 +211,14 @@
         </property>
        </widget>
       </item>
-      <item row="3" column="1">
+      <item row="2" column="1">
        <widget class="QLineEdit" name="northWGS84">
         <property name="enabled">
          <bool>true</bool>
         </property>
        </widget>
       </item>
-      <item row="3" column="2">
+      <item row="2" column="2">
        <widget class="QLabel" name="projectedX">
         <property name="enabled">
          <bool>true</bool>
@@ -228,20 +231,10 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="0">
-       <widget class="QLabel" name="textLabel2_2_2">
-        <property name="text">
-         <string>East</string>
-        </property>
-        <property name="buddy">
-         <cstring>eastWGS84</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="4" column="1">
+      <item row="3" column="1">
        <widget class="QLineEdit" name="eastWGS84"/>
       </item>
-      <item row="4" column="2">
+      <item row="3" column="2">
        <widget class="QLabel" name="projectedY">
         <property name="enabled">
          <bool>true</bool>
@@ -257,7 +250,7 @@
         </property>
        </widget>
       </item>
-      <item row="5" column="0" colspan="3">
+      <item row="4" column="0" colspan="3">
        <widget class="QPushButton" name="pbnCalculate">
         <property name="text">
          <string>Calculate</string>
@@ -267,27 +260,10 @@
      </layout>
     </widget>
    </item>
-   <item row="2" column="0">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
  <tabstops>
-  <tabstop>leName</tabstop>
-  <tabstop>leParameters</tabstop>
-  <tabstop>pbnFirst</tabstop>
-  <tabstop>pbnPrevious</tabstop>
-  <tabstop>pbnNext</tabstop>
-  <tabstop>pbnLast</tabstop>
-  <tabstop>pbnNew</tabstop>
-  <tabstop>pbnSave</tabstop>
-  <tabstop>pbnDelete</tabstop>
-  <tabstop>leTestParameters</tabstop>
   <tabstop>northWGS84</tabstop>
   <tabstop>eastWGS84</tabstop>
   <tabstop>pbnCalculate</tabstop>
@@ -297,17 +273,17 @@
  <connections>
   <connection>
    <sender>buttonBox</sender>
-   <signal>accepted()</signal>
+   <signal>rejected()</signal>
    <receiver>QgsCustomProjectionDialogBase</receiver>
-   <slot>accept()</slot>
+   <slot>reject()</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>436</x>
-     <y>522</y>
+     <x>270</x>
+     <y>590</y>
     </hint>
     <hint type="destinationlabel">
-     <x>471</x>
-     <y>501</y>
+     <x>270</x>
+     <y>306</y>
     </hint>
    </hints>
   </connection>

--- a/src/ui/qgsprojectionselectorbase.ui
+++ b/src/ui/qgsprojectionselectorbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>574</width>
-    <height>390</height>
+    <width>820</width>
+    <height>591</height>
    </rect>
   </property>
   <property name="sizePolicy">


### PR DESCRIPTION
Hello developers,

I work a lot with custom CRS (not by choice !), and the current interface is quite cumbersome to use: the CRS can only be seen one by one, the saving behavior is quite unintuitive, parameters from an existing CRS cannot be seen easily, etc. 

I tried to improve the UI and to update the code to use the QgsCoordinateReferenceSystem class. This reduces the code size and duplication, should improve the CRS validity check and later easily allow inputs other than proj4.

One issueI ran into is that QgsCoordinateReferenceSystem is not very fit to work with CRS not yet saved. The createFromProj4() function will automatically save a CRS if it is not found in the database, behavior that I had to slightly change by adding an optional argument to the function. 

Currently, I minimized the changes to QgsCoordinateReferenceSystem. If more changes are allowed, I think it would be cleaner to separate the creation and saving to database: essentially make a function saveAsUserCRS(QString name) publicly available. The name could be used to convey more information than the current "Generated ..." default message.

Any comment ? Criticism ? On the code, the UI, the coding style, the pull request process ?
