### PR TITLE
[FIX]: Build rubberband completely even with incomplete input

### DIFF
--- a/src/gui/qgsrubberband.cpp
+++ b/src/gui/qgsrubberband.cpp
@@ -270,6 +270,12 @@ void QgsRubberBand::addGeometry( QgsGeometry* geom, QgsVectorLayer* layer )
       for ( int i = 0; i < mline.size(); ++i, ++idx )
       {
         QgsPolyline line = mline[i];
+
+        if ( line.size() == 0 )
+        {
+          --idx;
+        }
+
         for ( int j = 0; j < line.size(); ++j )
         {
           if ( layer )


### PR DESCRIPTION
An empty polyline in a mulipolyline led to the rubberband ignoring all further polylines.
e.g. addGeometry( [[(1,2)(2,3)][][(2,3)(3,4)]] ) was ignoring the polyline (2,3)(3,4).
