### PR TITLE
Add line layer support for dissolve function

### DIFF
--- a/python/plugins/fTools/tools/doGeoprocessing.py
+++ b/python/plugins/fTools/tools/doGeoprocessing.py
@@ -195,7 +195,7 @@ class GeoprocessingDialog( QDialog, Ui_Dialog ):
     self.inShapeB.clear()
 
     if self.myFunction == 4:
-      myListA = ftools_utils.getLayerNames( [ QGis.Polygon ] )
+      myListA = ftools_utils.getLayerNames( [ QGis.Line, QGis.Polygon ] )
       myListB = []
     else:
       myListA = ftools_utils.getLayerNames( [ QGis.Point, QGis.Line, QGis.Polygon ] )


### PR DESCRIPTION
QgsGeometry.combine method support line merge for line type geometry. (from qgis/Quantum-GIS@092a1bf)

Geoprocessing-dissolve function use QgsGeometry.combine method,
so, I think that dissolve function can support line layers by this modification.
