### PR TITLE
Add extra check on project close for any layer in edit mode with unsaved edits

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -6076,6 +6076,41 @@ void QgisApp::setExtent( QgsRectangle theRect )
  */
 bool QgisApp::saveDirty()
 {
+  QString whyDirty = "";
+  bool hasUnsavedEdits = false;
+  // extra check to see if there are any vector layers with unsaved provider edits
+  // to ensure user has opportunity to save any editing
+  if ( QgsMapLayerRegistry::instance()->count() > 0 )
+  {
+    QMap<QString, QgsMapLayer*> layers = QgsMapLayerRegistry::instance()->mapLayers();
+    for ( QMap<QString, QgsMapLayer*>::iterator it = layers.begin(); it != layers.end(); it++ )
+    {
+      if ( hasUnsavedEdits )
+      {
+        break;
+      }
+
+      QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( it.value() );
+      if ( !vl )
+      {
+        continue;
+      }
+
+      if ( !hasUnsavedEdits )
+      {
+        hasUnsavedEdits = ( vl->isEditable() && vl->isModified() );
+      }
+    }
+
+    if ( hasUnsavedEdits )
+    {
+      markDirty();
+      whyDirty = "<p style='color:darkred;'>";
+      whyDirty += tr( "Project has layer(s) in edit mode with unsaved edits, which will NOT be saved!" );
+      whyDirty += "</p>";
+    }
+  }
+
   QMessageBox::StandardButton answer( QMessageBox::Discard );
   mMapCanvas->freeze( true );
 
@@ -6096,8 +6131,10 @@ bool QgisApp::saveDirty()
 
     // prompt user to save
     answer = QMessageBox::information( this, tr( "Save?" ),
-                                       tr( "Do you want to save the current project?" ),
-                                       QMessageBox::Save | QMessageBox::Cancel | QMessageBox::Discard );
+                                       tr( "Do you want to save the current project?%1" )
+                                       .arg( whyDirty ),
+                                       QMessageBox::Save | QMessageBox::Cancel | QMessageBox::Discard,
+                                       hasUnsavedEdits ? QMessageBox::Cancel : QMessageBox::Save );
     if ( QMessageBox::Save == answer )
     {
       if ( !fileSave() )


### PR DESCRIPTION
- Ensures user has opportunity to save provider edits
- Make project dirty if any unsaved edits found
- Add red notification to project save prompt dialog, and set Cancel to default
- Fix for #6054 and #6732
