### PR TITLE
Abort classification upon high number of classes

### DIFF
--- a/src/gui/symbology-ng/qgscategorizedsymbolrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgscategorizedsymbolrendererv2widget.cpp
@@ -596,6 +596,19 @@ void QgsCategorizedSymbolRendererV2Widget::addCategories()
   QList<QVariant> unique_vals;
   mLayer->uniqueValues( idx, unique_vals );
 
+  // ask to abort if too many classes
+  if ( unique_vals.size() >= 1000 )
+  {
+    int res = QMessageBox::warning( 0, tr( "High number of classes!" ),
+        tr( "Classification would yield %1 entries which might not be expected. Continue?" ).arg( unique_vals.size() ),
+        QMessageBox::Ok | QMessageBox::Cancel,
+        QMessageBox::Cancel );
+    if ( res == QMessageBox::Cancel )
+    {
+      return;
+    }
+  }
+
   //DlgAddCategories dlg(mStyle, createDefaultSymbol(), unique_vals, this);
   //if (!dlg.exec())
   //  return;


### PR DESCRIPTION
Accidentally classifying a vector layer (categorized style) on an id column (with >99k unique entries) resulted in high CPU load and QGIS frozen.
I suggest to present a warning dialog when more than 1000 unique values are present and ask the user whether to continue. Patch attached – please check for usage of correct terminology.
