### PR TITLE
Allow the rubberband to display points

### DIFF
--- a/python/gui/qgsrubberband.sip
+++ b/python/gui/qgsrubberband.sip
@@ -5,13 +5,15 @@ class QgsRubberBand: QgsMapCanvasItem
 %End
 
   public:
-    QgsRubberBand( QgsMapCanvas* mapCanvas /TransferThis/, bool isPolygon = false );
+    QgsRubberBand( QgsMapCanvas* mapCanvas /TransferThis/, QGis::GeometryType geometryType = QGis::Line );
+    QgsRubberBand( QgsMapCanvas* mapCanvas /TransferThis/, bool isPolygon );
     ~QgsRubberBand();
 
     void setColor( const QColor & color );
     void setWidth( int width );
 
-    void reset( bool isPolygon = false );
+    void reset( QGis::GeometryType geometryType = QGis::Line );
+    void reset( bool isPolygon );
 
     //! Add point to rubberband and update canvas
     //! If adding more points consider using update=false for better performance

--- a/src/app/nodetool/qgsmaptoolnodetool.cpp
+++ b/src/app/nodetool/qgsmaptoolnodetool.cpp
@@ -78,7 +78,7 @@ void QgsMapToolNodeTool::createMovingRubberBands()
       }
       // we have first vertex of moving part
       // create rubberband and set default paramaters
-      QgsRubberBand* rb = new QgsRubberBand( mCanvas, false );
+      QgsRubberBand* rb = new QgsRubberBand( mCanvas, QGis::Line );
       rb->setWidth( 2 );
       rb->setColor( Qt::blue );
       int index = 0;
@@ -137,7 +137,7 @@ void QgsMapToolNodeTool::createTopologyRubberBands( QgsVectorLayer* vlayer, cons
           continue;
         }
       }
-      QgsRubberBand* trb = new QgsRubberBand( mCanvas, false );
+      QgsRubberBand* trb = new QgsRubberBand( mCanvas, QGis::Line );
       mTopologyRubberBand.append( trb );
       int rbId = mTopologyRubberBand.size() - 1;
       trb->setWidth( 1 );
@@ -701,7 +701,7 @@ void QgsMapToolNodeTool::keyReleaseEvent( QKeyEvent* e )
 QgsRubberBand* QgsMapToolNodeTool::createRubberBandMarker( QgsPoint center, QgsVectorLayer* vlayer )
 {
   // create rubberband marker for moving points
-  QgsRubberBand* marker = new QgsRubberBand( mCanvas, true );
+  QgsRubberBand* marker = new QgsRubberBand( mCanvas, QGis::Polygon );
   marker->setColor( Qt::red );
   marker->setWidth( 2 );
   double movement = 4;

--- a/src/app/qgsmaptoolcapture.cpp
+++ b/src/app/qgsmaptoolcapture.cpp
@@ -204,7 +204,7 @@ int QgsMapToolCapture::addVertex( const QPoint &p )
 
   if ( !mRubberBand )
   {
-    mRubberBand = createRubberBand( mCaptureMode == CapturePolygon );
+    mRubberBand = createRubberBand( mCaptureMode == CapturePolygon ? QGis::Polygon : QGis::Line );
   }
 
   mRubberBand->addPoint( mapPoint );

--- a/src/app/qgsmaptooledit.cpp
+++ b/src/app/qgsmaptooledit.cpp
@@ -66,10 +66,10 @@ QgsPoint QgsMapToolEdit::snapPointFromResults( const QList<QgsSnappingResult>& s
   }
 }
 
-QgsRubberBand* QgsMapToolEdit::createRubberBand( bool isPolygon )
+QgsRubberBand* QgsMapToolEdit::createRubberBand( QGis::GeometryType geometryType )
 {
   QSettings settings;
-  QgsRubberBand* rb = new QgsRubberBand( mCanvas, isPolygon );
+  QgsRubberBand* rb = new QgsRubberBand( mCanvas, geometryType );
   QColor color( settings.value( "/qgis/digitizing/line_color_red", 255 ).toInt(),
                 settings.value( "/qgis/digitizing/line_color_green", 0 ).toInt(),
                 settings.value( "/qgis/digitizing/line_color_blue", 0 ).toInt() );

--- a/src/app/qgsmaptooledit.h
+++ b/src/app/qgsmaptooledit.h
@@ -53,7 +53,7 @@ class QgsMapToolEdit: public QgsMapTool
     /**Creates a rubber band with the color/line width from
      the QGIS settings. The caller takes ownership of the
     returned object*/
-    QgsRubberBand* createRubberBand( bool isPolygon = false );
+    QgsRubberBand* createRubberBand( QGis::GeometryType geometryType = QGis::Line );
 
     /**Returns the current vector layer of the map canvas or 0*/
     QgsVectorLayer* currentVectorLayer();

--- a/src/app/qgsmaptoollabel.cpp
+++ b/src/app/qgsmaptoollabel.cpp
@@ -59,7 +59,7 @@ void QgsMapToolLabel::createRubberBands( )
 
   //label rubber band
   QgsRectangle rect = mCurrentLabelPos.labelRect;
-  mLabelRubberBand = new QgsRubberBand( mCanvas, false );
+  mLabelRubberBand = new QgsRubberBand( mCanvas, QGis::Line );
   mLabelRubberBand->addPoint( QgsPoint( rect.xMinimum(), rect.yMinimum() ) );
   mLabelRubberBand->addPoint( QgsPoint( rect.xMinimum(), rect.yMaximum() ) );
   mLabelRubberBand->addPoint( QgsPoint( rect.xMaximum(), rect.yMaximum() ) );
@@ -79,7 +79,7 @@ void QgsMapToolLabel::createRubberBands( )
       QgsGeometry* geom = f.geometry();
       if ( geom )
       {
-        mFeatureRubberBand = new QgsRubberBand( mCanvas, geom->type() == QGis::Polygon );
+        mFeatureRubberBand = new QgsRubberBand( mCanvas, geom->type() );
         mFeatureRubberBand->setColor( Qt::red );
         mFeatureRubberBand->setToGeometry( geom, vlayer );
         mFeatureRubberBand->show();
@@ -100,7 +100,7 @@ void QgsMapToolLabel::createRubberBands( )
       }
 
       QgsGeometry* pointGeom = QgsGeometry::fromPoint( fixPoint );
-      mFixPointRubberBand = new QgsRubberBand( mCanvas, false );
+      mFixPointRubberBand = new QgsRubberBand( mCanvas, QGis::Line );
       mFixPointRubberBand->setColor( Qt::blue );
       mFixPointRubberBand->setToGeometry( pointGeom, vlayer );
       mFixPointRubberBand->show();

--- a/src/app/qgsmaptoolmeasureangle.cpp
+++ b/src/app/qgsmaptoolmeasureangle.cpp
@@ -126,7 +126,7 @@ void QgsMapToolMeasureAngle::deactivate()
 void QgsMapToolMeasureAngle::createRubberBand()
 {
   delete mRubberBand;
-  mRubberBand = new QgsRubberBand( mCanvas, false );
+  mRubberBand = new QgsRubberBand( mCanvas, QGis::Line );
 
   QSettings settings;
   int myRed = settings.value( "/qgis/default_measure_color_red", 180 ).toInt();

--- a/src/app/qgsmaptoolpinlabels.cpp
+++ b/src/app/qgsmaptoolpinlabels.cpp
@@ -52,7 +52,7 @@ void QgsMapToolPinLabels::canvasPressEvent( QMouseEvent * e )
   mSelectRect.setRect( 0, 0, 0, 0 );
   mSelectRect.setTopLeft( e->pos() );
   mSelectRect.setBottomRight( e->pos() );
-  mRubberBand = new QgsRubberBand( mCanvas, true );
+  mRubberBand = new QgsRubberBand( mCanvas, QGis::Polygon );
 }
 
 void QgsMapToolPinLabels::canvasMoveEvent( QMouseEvent * e )
@@ -105,7 +105,7 @@ void QgsMapToolPinLabels::canvasReleaseEvent( QMouseEvent * e )
 
     delete selectGeom;
 
-    mRubberBand->reset( true );
+    mRubberBand->reset( QGis::Polygon );
     delete mRubberBand;
     mRubberBand = 0;
   }

--- a/src/app/qgsmaptoolrotatelabel.cpp
+++ b/src/app/qgsmaptoolrotatelabel.cpp
@@ -197,7 +197,7 @@ QgsRubberBand* QgsMapToolRotateLabel::createRotationPreviewBox()
     return 0;
   }
 
-  mRotationPreviewBox = new QgsRubberBand( mCanvas, false );
+  mRotationPreviewBox = new QgsRubberBand( mCanvas, QGis::Line );
   mRotationPreviewBox->setColor( Qt::blue );
   mRotationPreviewBox->setWidth( 3 );
   setRotationPreviewBox( mCurrentRotation - mStartRotation );

--- a/src/app/qgsmaptoolselect.cpp
+++ b/src/app/qgsmaptoolselect.cpp
@@ -40,7 +40,7 @@ void QgsMapToolSelect::canvasReleaseEvent( QMouseEvent * e )
   {
     return;
   }
-  QgsRubberBand rubberBand( mCanvas, true );
+  QgsRubberBand rubberBand( mCanvas, QGis::Polygon );
   QRect selectRect( 0, 0, 0, 0 );
   QgsMapToolSelectUtils::expandSelectRectangle( selectRect, vlayer, e->pos() );
   QgsMapToolSelectUtils::setRubberBand( mCanvas, selectRect, &rubberBand );
@@ -48,5 +48,5 @@ void QgsMapToolSelect::canvasReleaseEvent( QMouseEvent * e )
   bool doDifference = e->modifiers() & Qt::ControlModifier ? true : false;
   QgsMapToolSelectUtils::setSelectFeatures( mCanvas, selectGeom, false, doDifference, true );
   delete selectGeom;
-  rubberBand.reset( true );
+  rubberBand.reset( QGis::Polygon );
 }

--- a/src/app/qgsmaptoolselectfreehand.cpp
+++ b/src/app/qgsmaptoolselectfreehand.cpp
@@ -43,7 +43,7 @@ void QgsMapToolSelectFreehand::canvasPressEvent( QMouseEvent * e )
   }
   if ( mRubberBand == NULL )
   {
-    mRubberBand = new QgsRubberBand( mCanvas, true );
+    mRubberBand = new QgsRubberBand( mCanvas, QGis::Polygon );
   }
   mRubberBand->addPoint( toMapCoordinates( e->pos() ) );
   mDragging = true;
@@ -72,7 +72,7 @@ void QgsMapToolSelectFreehand::canvasReleaseEvent( QMouseEvent * e )
     QgsMapToolSelectUtils::setSelectFeatures( mCanvas, shapeGeom, e );
     delete shapeGeom;
   }
-  mRubberBand->reset( true );
+  mRubberBand->reset( QGis::Polygon );
   delete mRubberBand;
   mRubberBand = 0;
   mDragging = false;

--- a/src/app/qgsmaptoolselectpolygon.cpp
+++ b/src/app/qgsmaptoolselectpolygon.cpp
@@ -39,7 +39,7 @@ void QgsMapToolSelectPolygon::canvasPressEvent( QMouseEvent * e )
 {
   if ( mRubberBand == NULL )
   {
-    mRubberBand = new QgsRubberBand( mCanvas, true );
+    mRubberBand = new QgsRubberBand( mCanvas, QGis::Polygon );
   }
   if ( e->button() == Qt::LeftButton )
   {
@@ -53,7 +53,7 @@ void QgsMapToolSelectPolygon::canvasPressEvent( QMouseEvent * e )
       QgsMapToolSelectUtils::setSelectFeatures( mCanvas, polygonGeom, e );
       delete polygonGeom;
     }
-    mRubberBand->reset( true );
+    mRubberBand->reset( QGis::Polygon );
     delete mRubberBand;
     mRubberBand = 0;
   }

--- a/src/app/qgsmaptoolselectradius.cpp
+++ b/src/app/qgsmaptoolselectradius.cpp
@@ -62,7 +62,7 @@ void QgsMapToolSelectRadius::canvasMoveEvent( QMouseEvent * e )
   {
     if ( mRubberBand == NULL )
     {
-      mRubberBand = new QgsRubberBand( mCanvas, true );
+      mRubberBand = new QgsRubberBand( mCanvas, QGis::Polygon );
     }
     mDragging = true;
   }
@@ -81,7 +81,7 @@ void QgsMapToolSelectRadius::canvasReleaseEvent( QMouseEvent * e )
   {
     if ( mRubberBand == NULL )
     {
-      mRubberBand = new QgsRubberBand( mCanvas, true );
+      mRubberBand = new QgsRubberBand( mCanvas, QGis::Polygon );
     }
     mRadiusCenter = toMapCoordinates( e->pos() );
     QgsPoint radiusEdge = toMapCoordinates( QPoint( e->pos().x() + 1, e->pos().y() + 1 ) );
@@ -90,7 +90,7 @@ void QgsMapToolSelectRadius::canvasReleaseEvent( QMouseEvent * e )
   QgsGeometry* radiusGeometry = mRubberBand->asGeometry();
   QgsMapToolSelectUtils::setSelectFeatures( mCanvas, radiusGeometry, e );
   delete radiusGeometry;
-  mRubberBand->reset( true );
+  mRubberBand->reset( QGis::Polygon );
   delete mRubberBand;
   mRubberBand = 0;
   mDragging = false;
@@ -100,7 +100,7 @@ void QgsMapToolSelectRadius::canvasReleaseEvent( QMouseEvent * e )
 void QgsMapToolSelectRadius::setRadiusRubberBand( QgsPoint & radiusEdge )
 {
   double r = sqrt( mRadiusCenter.sqrDist( radiusEdge ) );
-  mRubberBand->reset( true );
+  mRubberBand->reset( QGis::Polygon );
   for ( int i = 0; i <= RADIUS_SEGMENTS; ++i )
   {
     double theta = i * ( 2.0 * M_PI / RADIUS_SEGMENTS );

--- a/src/app/qgsmaptoolselectrectangle.cpp
+++ b/src/app/qgsmaptoolselectrectangle.cpp
@@ -42,7 +42,7 @@ void QgsMapToolSelectRectangle::canvasPressEvent( QMouseEvent *e )
 {
   Q_UNUSED( e );
   mSelectRect.setRect( 0, 0, 0, 0 );
-  mRubberBand = new QgsRubberBand( mCanvas, true );
+  mRubberBand = new QgsRubberBand( mCanvas, QGis::Polygon );
 }
 
 
@@ -97,7 +97,7 @@ void QgsMapToolSelectRectangle::canvasReleaseEvent( QMouseEvent *e )
     QgsMapToolSelectUtils::setSelectFeatures( mCanvas, selectGeom, e );
     delete selectGeom;
 
-    mRubberBand->reset( true );
+    mRubberBand->reset( QGis::Polygon );
     delete mRubberBand;
     mRubberBand = 0;
   }

--- a/src/app/qgsmaptoolselectutils.cpp
+++ b/src/app/qgsmaptoolselectutils.cpp
@@ -51,7 +51,7 @@ void QgsMapToolSelectUtils::setRubberBand( QgsMapCanvas* canvas, QRect& selectRe
 
   if ( rubberBand )
   {
-    rubberBand->reset( true );
+    rubberBand->reset( QGis::Polygon );
     rubberBand->addPoint( ll, false );
     rubberBand->addPoint( QgsPoint( ur.x(), ll.y() ), false );
     rubberBand->addPoint( ur, false );

--- a/src/app/qgsmaptoolshowhidelabels.cpp
+++ b/src/app/qgsmaptoolshowhidelabels.cpp
@@ -45,7 +45,7 @@ void QgsMapToolShowHideLabels::canvasPressEvent( QMouseEvent * e )
   mSelectRect.setRect( 0, 0, 0, 0 );
   mSelectRect.setTopLeft( e->pos() );
   mSelectRect.setBottomRight( e->pos() );
-  mRubberBand = new QgsRubberBand( mCanvas, true );
+  mRubberBand = new QgsRubberBand( mCanvas, QGis::Polygon );
 }
 
 void QgsMapToolShowHideLabels::canvasMoveEvent( QMouseEvent * e )
@@ -93,7 +93,7 @@ void QgsMapToolShowHideLabels::canvasReleaseEvent( QMouseEvent * e )
 
     showHideLabels( e );
 
-    mRubberBand->reset( true );
+    mRubberBand->reset( QGis::Polygon );
     delete mRubberBand;
     mRubberBand = 0;
   }

--- a/src/app/qgsmeasuretool.cpp
+++ b/src/app/qgsmeasuretool.cpp
@@ -35,7 +35,7 @@ QgsMeasureTool::QgsMeasureTool( QgsMapCanvas* canvas, bool measureArea )
 {
   mMeasureArea = measureArea;
 
-  mRubberBand = new QgsRubberBand( canvas, mMeasureArea );
+  mRubberBand = new QgsRubberBand( canvas, mMeasureArea ? QGis::Polygon : QGis::Line );
 
   QPixmap myCrossHairQPixmap = QPixmap(( const char ** ) cross_hair_cursor );
   mCursor = QCursor( myCrossHairQPixmap, 8, 8 );
@@ -103,7 +103,7 @@ void QgsMeasureTool::restart()
 {
   mPoints.clear();
 
-  mRubberBand->reset( mMeasureArea );
+  mRubberBand->reset( mMeasureArea ? QGis::Polygon : QGis::Line );
 
   // re-read settings
   updateSettings();

--- a/src/gui/qgsmaptoolzoom.cpp
+++ b/src/gui/qgsmaptoolzoom.cpp
@@ -49,7 +49,7 @@ void QgsMapToolZoom::canvasMoveEvent( QMouseEvent * e )
   {
     mDragging = true;
     delete mRubberBand;
-    mRubberBand = new QgsRubberBand( mCanvas, true );
+    mRubberBand = new QgsRubberBand( mCanvas, QGis::Polygon );
     mZoomRect.setTopLeft( e->pos() );
   }
   mZoomRect.setBottomRight( e->pos() );

--- a/src/gui/qgsrubberband.h
+++ b/src/gui/qgsrubberband.h
@@ -31,13 +31,15 @@ class QPaintEvent;
 class GUI_EXPORT QgsRubberBand: public QgsMapCanvasItem
 {
   public:
-    QgsRubberBand( QgsMapCanvas* mapCanvas, bool isPolygon = false );
+    QgsRubberBand( QgsMapCanvas* mapCanvas, QGis::GeometryType geometryType = QGis::Line );
+    QgsRubberBand( QgsMapCanvas* mapCanvas, bool isPolygon );
     ~QgsRubberBand();
 
     void setColor( const QColor & color );
     void setWidth( int width );
 
-    void reset( bool isPolygon = false );
+    void reset( QGis::GeometryType geometryType = QGis::Line );
+    void reset( bool isPolygon );
 
     //! Add point to rubberband and update canvas
     //! If adding more points consider using update=false for better performance
@@ -101,9 +103,11 @@ class GUI_EXPORT QgsRubberBand: public QgsMapCanvasItem
     QBrush mBrush;
     QPen mPen;
 
+    int mWidth;
+
     /**Nested lists used for multitypes*/
     QList< QList <QgsPoint> > mPoints;
-    bool mIsPolygon;
+    QGis::GeometryType mGeometryType;
     double mTranslationOffsetX;
     double mTranslationOffsetY;
 

--- a/src/gui/qgsrubberband.h
+++ b/src/gui/qgsrubberband.h
@@ -31,14 +31,38 @@ class QPaintEvent;
 class GUI_EXPORT QgsRubberBand: public QgsMapCanvasItem
 {
   public:
+    /**
+     * Creates a new RubberBand.
+     * @param mapCanvas The map canvas to draw onto. It's CRS will be used map points onto screen coordinates.
+     * @param geometryType Defines how the data should be drawn onto the screen. (Use QGis::Line, QGis::Polygon or QGis::Point)
+     * Added in 1.9.
+     */
     QgsRubberBand( QgsMapCanvas* mapCanvas, QGis::GeometryType geometryType = QGis::Line );
+    /**
+     * Creates a new RubberBand.
+     * @deprecated
+     * @param mapCanvas The map canvas to draw onto. It's CRS will be used map points onto screen coordinates.
+     * @param isPolygon true: draw as (multi-)polygon, false draw as (multi-)linestring
+     */
     QgsRubberBand( QgsMapCanvas* mapCanvas, bool isPolygon );
     ~QgsRubberBand();
 
     void setColor( const QColor & color );
     void setWidth( int width );
 
+    /**
+     * Clears all the geometries in this rubberband.
+     * Sets the representation type according to geometryType.
+     * @param geometryType Defines how the data should be drawn onto the screen. (Use QGis::Line, QGis::Polygon or QGis::Point)
+     * Added in 1.9.
+     */
     void reset( QGis::GeometryType geometryType = QGis::Line );
+    /**
+     * @deprecated
+     * Clears all the geometries in this rubberband.
+     * Sets the representation type according to isPolygon.
+     * @param isPolygon true: draw as (multi-)polygon, false draw as (multi-)linestring
+     */
     void reset( bool isPolygon );
 
     //! Add point to rubberband and update canvas

--- a/src/plugins/coordinate_capture/coordinatecapturemaptool.cpp
+++ b/src/plugins/coordinate_capture/coordinatecapturemaptool.cpp
@@ -33,7 +33,7 @@ CoordinateCaptureMapTool::CoordinateCaptureMapTool( QgsMapCanvas* thepCanvas )
   QPixmap myCursor = QPixmap(( const char ** ) capture_point_cursor );
   mCursor = QCursor( myCursor, 8, 8 ); //8,8 is the point in the cursor where clicks register
   mpMapCanvas = thepCanvas;
-  mpRubberBand = new QgsRubberBand( mpMapCanvas, true ); //true - its a polygon
+  mpRubberBand = new QgsRubberBand( mpMapCanvas, QGis::Polygon );
   mpRubberBand->setColor( Qt::red );
   mpRubberBand->setWidth( 1 );
 }
@@ -78,7 +78,7 @@ void CoordinateCaptureMapTool::canvasReleaseEvent( QMouseEvent * thepEvent )
   QgsPoint myPoint4 =
     mCanvas->getCoordinateTransform()->toMapCoordinates( thepEvent->x() - 1, thepEvent->y() + 1 );
 
-  mpRubberBand->reset( true );
+  mpRubberBand->reset( QGis::Polygon );
   // convert screen coordinates to map coordinates
   mpRubberBand->addPoint( myPoint1, false ); //true - update canvas
   mpRubberBand->addPoint( myPoint2, false ); //true - update canvas
@@ -90,6 +90,6 @@ void CoordinateCaptureMapTool::canvasReleaseEvent( QMouseEvent * thepEvent )
 
 void CoordinateCaptureMapTool::deactivate()
 {
-  mpRubberBand->reset( false );
+  mpRubberBand->reset( QGis::Line );
   QgsMapTool::deactivate();
 }

--- a/src/plugins/roadgraph/shortestpathwidget.cpp
+++ b/src/plugins/roadgraph/shortestpathwidget.cpp
@@ -152,15 +152,15 @@ RgShortestPathWidget::RgShortestPathWidget( QWidget* theParent, RoadGraphPlugin 
   connect( mCalculate, SIGNAL( clicked( bool ) ), this, SLOT( findingPath() ) );
   connect( mClear, SIGNAL( clicked( bool ) ), this, SLOT( clear() ) );
 
-  mrbFrontPoint = new QgsRubberBand( mPlugin->iface()->mapCanvas(), true );
+  mrbFrontPoint = new QgsRubberBand( mPlugin->iface()->mapCanvas(), QGis::Polygon );
   mrbFrontPoint->setColor( Qt::green );
   mrbFrontPoint->setWidth( 2 );
 
-  mrbBackPoint = new QgsRubberBand( mPlugin->iface()->mapCanvas(), true );
+  mrbBackPoint = new QgsRubberBand( mPlugin->iface()->mapCanvas(), QGis::Polygon );
   mrbBackPoint->setColor( Qt::red );
   mrbBackPoint->setWidth( 2 );
 
-  mrbPath = new QgsRubberBand( mPlugin->iface()->mapCanvas(), false );
+  mrbPath = new QgsRubberBand( mPlugin->iface()->mapCanvas(), QGis::Line );
   mrbPath->setWidth( 2 );
 
   connect( mPlugin->iface()->mapCanvas(), SIGNAL( extentsChanged() ), this, SLOT( mapCanvasExtentsChanged() ) );
@@ -199,7 +199,7 @@ void RgShortestPathWidget::setFrontPoint( const QgsPoint& pt )
 
   double mupp = mPlugin->iface()->mapCanvas()->getCoordinateTransform()->mapUnitsPerPixel() * 2;
 
-  mrbFrontPoint->reset( true );
+  mrbFrontPoint->reset( QGis::Polygon );
   mrbFrontPoint->addPoint( QgsPoint( pt.x() - mupp, pt.y() - mupp ), false );
   mrbFrontPoint->addPoint( QgsPoint( pt.x() + mupp, pt.y() - mupp ), false );
   mrbFrontPoint->addPoint( QgsPoint( pt.x() + mupp, pt.y() + mupp ), false );
@@ -222,7 +222,7 @@ void RgShortestPathWidget::setBackPoint( const QgsPoint& pt )
 
   double mupp = mPlugin->iface()->mapCanvas()->getCoordinateTransform()->mapUnitsPerPixel() * 2;
 
-  mrbBackPoint->reset( true );
+  mrbBackPoint->reset( QGis::Polygon );
   mrbBackPoint->addPoint( QgsPoint( pt.x() - mupp, pt.y() - mupp ), false );
   mrbBackPoint->addPoint( QgsPoint( pt.x() + mupp, pt.y() - mupp ), false );
   mrbBackPoint->addPoint( QgsPoint( pt.x() + mupp, pt.y() + mupp ), false );
@@ -306,7 +306,7 @@ void RgShortestPathWidget::findingPath()
   if ( path == NULL )
     return;
 
-  mrbPath->reset( false );
+  mrbPath->reset( QGis::Line );
   double time = 0.0;
   double cost = 0.0;
 
@@ -348,10 +348,10 @@ void RgShortestPathWidget::findingPath()
 void RgShortestPathWidget::clear()
 {
   mFrontPointLineEdit->setText( QString() );
-  mrbFrontPoint->reset( true );
+  mrbFrontPoint->reset( QGis::Polygon );
   mBackPointLineEdit->setText( QString() );
-  mrbBackPoint->reset( true );
-  mrbPath->reset();
+  mrbBackPoint->reset( QGis::Polygon );
+  mrbPath->reset( QGis::Line );
   mPathCostLineEdit->setText( QString() );
   mPathTimeLineEdit->setText( QString() );
 }

--- a/src/plugins/spatialquery/qgsrubberselectid.cpp
+++ b/src/plugins/spatialquery/qgsrubberselectid.cpp
@@ -23,9 +23,9 @@
 
 QgsRubberSelectId::QgsRubberSelectId( QgsMapCanvas* mapCanvas )
 {
-  mIsPolygon = false;
+  mGeometryType = QGis::Line;
   mMapCanvas = mapCanvas;
-  mRubberBand = new QgsRubberBand( mMapCanvas, mIsPolygon );
+  mRubberBand = new QgsRubberBand( mMapCanvas, mGeometryType );
   mColorRGB[0] = 255;
   mColorRGB[1] = 0;
   mColorRGB[2] = 0;
@@ -42,7 +42,7 @@ QgsRubberSelectId::~QgsRubberSelectId()
 
 void QgsRubberSelectId::reset()
 {
-  mRubberBand->reset( mIsPolygon );
+  mRubberBand->reset( mGeometryType );
 } // void QgsRubberSelectId::reset()
 
 void QgsRubberSelectId::setStyle( int colorRed, int colorGreen, int colorBlue, int width )
@@ -56,13 +56,11 @@ void QgsRubberSelectId::setStyle( int colorRed, int colorGreen, int colorBlue, i
 
 void QgsRubberSelectId::addFeature( QgsVectorLayer* lyr, QgsFeatureId fid )
 {
-  bool isPolygon = ( lyr->geometryType() == QGis::Polygon );
-  if ( mIsPolygon != isPolygon )
+  if ( mGeometryType != lyr->geometryType() )
   {
     reset();
-    delete mRubberBand;
-    mIsPolygon = isPolygon;
-    mRubberBand = new QgsRubberBand( mMapCanvas, mIsPolygon );
+    mGeometryType = lyr->geometryType();
+    mRubberBand->reset( lyr->geometryType() );
     setStyle();
   }
   QgsFeature feat;

--- a/src/plugins/spatialquery/qgsrubberselectid.h
+++ b/src/plugins/spatialquery/qgsrubberselectid.h
@@ -72,7 +72,7 @@ class QgsRubberSelectId
     QgsRubberBand* mRubberBand;
     int mColorRGB[3];
     int mWidth;
-    bool mIsPolygon;
+    QGis::GeometryType mGeometryType;
     QgsMapCanvas* mMapCanvas;
 };
 


### PR DESCRIPTION
Alters the API. You have to (should) specify the geometry type when creating a rubberband ( As boolean did not allow to distinguish between the three different types polygon, line and point) but should be backward compatible.
