### PR TITLE
Transfer ownership of widgets to C++ when pushed to the QgsMessageBar

### DIFF
--- a/python/gui/qgsmessagebar.sip
+++ b/python/gui/qgsmessagebar.sip
@@ -13,7 +13,7 @@ class QgsMessageBar: QFrame
      * @param widget widget to add
      * @param level is 0 for information, 1 for warning, 2 for critical
      */
-    void pushWidget( QWidget *widget, int level = 0 );
+    void pushWidget( QWidget *widget /Transfer/, int level = 0 );
 
     /*! remove the passed widget from the bar (if previously added),
      *  then display the next one in the stack if any or hide the bar

--- a/src/gui/qgsmessagebar.cpp
+++ b/src/gui/qgsmessagebar.cpp
@@ -90,6 +90,11 @@ void QgsMessageBar::popItem( QgsMessageBarItem *item )
     {
       mLayout->removeWidget( mCurrentItem->widget() );
       mCurrentItem->widget()->hide();
+      if ( mCurrentItem->widget()->parent() == this )
+      {
+        delete mCurrentItem->widget();
+      }
+      delete mCurrentItem;
       mCurrentItem = 0;
     }
 
@@ -126,6 +131,10 @@ bool QgsMessageBar::popWidget( QWidget *widget )
     if ( item->widget() == widget )
     {
       mList.removeOne( item );
+      if ( item->widget()->parent() == this )
+      {
+        delete item->widget();
+      }
       delete item;
       return true;
     }
@@ -141,7 +150,6 @@ bool QgsMessageBar::popWidget()
 
   QgsMessageBarItem *item = mCurrentItem;
   popItem( item );
-  delete item;
 
   return true;
 }


### PR DESCRIPTION
Right now, createMessage transfers ownership of the created widget to python, but when pushed to the message bar, ownership is not transfered back.
This creates the need for python to keep a reference to the message until this gets removed from the messagebar. This is too much overhead for a simple message to be shown.

I'm not sure if the widget needs to be deleted only if its parent is the QgsMessageBar (as in the pull-request now) or in any case, because python will loose ownership anyway and memory will be leaked.

Any help from a sip expert is appreciated.
