### PR TITLE
Set default rubberband width

### DIFF
--- a/src/gui/qgsrubberband.cpp
+++ b/src/gui/qgsrubberband.cpp
@@ -29,6 +29,7 @@
 */
 QgsRubberBand::QgsRubberBand( QgsMapCanvas* mapCanvas, QGis::GeometryType geometryType )
     : QgsMapCanvasItem( mapCanvas )
+    , mWidth( 1 )
     , mGeometryType( geometryType )
     , mTranslationOffsetX( 0.0 )
     , mTranslationOffsetY( 0.0 )


### PR DESCRIPTION
Was uninitialized, leading to screen corruption
http://hub.qgis.org/issues/6845
