### PR TITLE
Keep attribute editor QComboBox/QlineEdit synchronization from affecting editing

### DIFF
--- a/src/gui/qgsattributeeditor.h
+++ b/src/gui/qgsattributeeditor.h
@@ -95,8 +95,21 @@ class QgsStringRelay : public QObject
       emit textChanged( str );
     }
 
+    void storeText( QString str )
+    {
+      mStoredText = str;
+    }
+
+    void sendStoredText()
+    {
+      emit textChanged( mStoredText );
+    }
+
   signals:
     void textChanged( QString );
+
+  private:
+    QString mStoredText;
 };
 
 #endif


### PR DESCRIPTION
- Cursor no longer jumps to end of text after each edit (on Mac) for either custom form QComboBox or QLineEdit in regular edit form or Attribute Table editor.
