### PR TITLE
Keep attribute editor QComboBox/QLineEdit synchronization from affecting editing

### DIFF
--- a/src/gui/qgsattributeeditor.h
+++ b/src/gui/qgsattributeeditor.h
@@ -90,10 +90,7 @@ class QgsStringRelay : public QObject
         : QObject( parent ) {}
 
   public slots:
-    void changeText( QString str )
-    {
-      emit textChanged( str );
-    }
+    void changeText( QString str );
 
   signals:
     void textChanged( QString );


### PR DESCRIPTION
- Cursor no longer jumps to end of text after each edit (on Mac)
- Move QgsStringRelay::changeText slot into cpp file
- Fill editable QComboBox with attribute's value in custom forms

Please see http://hub.qgis.org/issues/6647
