### PR TITLE
Improved Style functionality

### DIFF
--- a/scripts/symbol_xml2db.py
+++ b/scripts/symbol_xml2db.py
@@ -90,7 +90,7 @@ for symbol in symbols:
         symdom.getElementsByTagName( "layer" )[ layerno ].appendChild( symbol )
         c.execute( "UPDATE symbol SET xml=? WHERE name=?", ( symdom.toxml(), parent_name ))
     else:
-        c.execute( "INSERT INTO symbol VALUES (?,?,?,?)", ( None, symbol_name, symbol.toxml(), None ) )
+        c.execute( "INSERT INTO symbol VALUES (?,?,?,?)", ( None, symbol_name, symbol.toxml(), 0 ) )
 conn.commit()
 
 
@@ -98,7 +98,7 @@ conn.commit()
 colorramps = dom.getElementsByTagName( "colorramp" )
 for ramp in colorramps:
     ramp_name = ramp.getAttribute( "name" )
-    c.execute( "INSERT INTO colorramp VALUES (?,?,?,?)", ( None, ramp_name, ramp.toxml(), None ) )
+    c.execute( "INSERT INTO colorramp VALUES (?,?,?,?)", ( None, ramp_name, ramp.toxml(), 0 ) )
 conn.commit()
 
 # Finally close the sqlite cursor

--- a/src/core/symbology-ng/qgsstylev2.cpp
+++ b/src/core/symbology-ng/qgsstylev2.cpp
@@ -299,8 +299,14 @@ bool QgsStyleV2::load( QString filename )
     return false;
   }
 
+  // Make sure there are no Null fields in parenting symbols ang groups
+  char *query = sqlite3_mprintf( "UPDATE symbol SET groupid=0 WHERE groupid IS NULL;"
+                                 "UPDATE colorramp SET groupid=0 WHERE groupid IS NULL;"
+                                 "UPDATE symgroup SET parent=0 WHERE parent IS NULL;");
+  runEmptyQuery( query );
+
   // First create all the main symbols
-  const char *query = "SELECT * FROM symbol";
+  query = sqlite3_mprintf( "SELECT * FROM symbol" );
 
   sqlite3_stmt *ppStmt;
   int nError = sqlite3_prepare_v2( mCurrentDB, query, -1, &ppStmt, NULL );
@@ -323,8 +329,8 @@ bool QgsStyleV2::load( QString filename )
 
   sqlite3_finalize( ppStmt );
 
-  const char *rquery = "SELECT * FROM colorramp";
-  nError = sqlite3_prepare_v2( mCurrentDB, rquery, -1, &ppStmt, NULL );
+  query = sqlite3_mprintf( "SELECT * FROM colorramp" );
+  nError = sqlite3_prepare_v2( mCurrentDB, query, -1, &ppStmt, NULL );
   while ( nError == SQLITE_OK && sqlite3_step( ppStmt ) == SQLITE_ROW )
   {
     QDomDocument doc;

--- a/src/core/symbology-ng/qgsstylev2.cpp
+++ b/src/core/symbology-ng/qgsstylev2.cpp
@@ -470,7 +470,7 @@ QgsSymbolGroupMap QgsStyleV2::childGroupNames( QString parent )
   // decide the query to be run based on parent group
   if ( parent == "" || parent == QString() )
   {
-    query = sqlite3_mprintf( "SELECT * FROM symgroup WHERE parent IS NULL" );
+    query = sqlite3_mprintf( "SELECT * FROM symgroup WHERE parent=0" );
   }
   else
   {
@@ -592,9 +592,7 @@ int QgsStyleV2::addGroup( QString groupName, int parentid )
   if ( !mCurrentDB )
     return 0;
 
-  char *query = parentid == 0
-                ? sqlite3_mprintf( "INSERT INTO symgroup VALUES (NULL, '%q', NULL)", groupName.toUtf8().constData() )
-                : sqlite3_mprintf( "INSERT INTO symgroup VALUES (NULL, '%q', %d)", groupName.toUtf8().constData(), parentid );
+  char *query = sqlite3_mprintf( "INSERT INTO symgroup VALUES (NULL, '%q', %d)", groupName.toUtf8().constData(), parentid );
 
   sqlite3_stmt *ppStmt;
   int nErr = sqlite3_prepare_v2( mCurrentDB, query, -1, &ppStmt, NULL );
@@ -662,13 +660,9 @@ char* QgsStyleV2::getGroupRemoveQuery( int id )
 
   sqlite3_finalize( ppStmt );
 
-  return parentid
-         ? sqlite3_mprintf( "UPDATE symbol SET groupid=%d WHERE groupid=%d;"
-                            "UPDATE symgroup SET parent=%d WHERE parent=%d;"
-                            "DELETE FROM symgroup WHERE id=%d", parentid, id, parentid, id, id )
-         : sqlite3_mprintf( "UPDATE symbol SET groupid=NULL WHERE groupid=%d;"
-                            "UPDATE symgroup SET parent=NULL WHERE parent=%d;"
-                            "DELETE FROM symgroup WHERE id=%d", id, id, id );
+  return sqlite3_mprintf( "UPDATE symbol SET groupid=%d WHERE groupid=%d;"
+                          "UPDATE symgroup SET parent=%d WHERE parent=%d;"
+                          "DELETE FROM symgroup WHERE id=%d", parentid, id, parentid, id, id );
 }
 
 void QgsStyleV2::remove( StyleEntity type, int id )

--- a/src/core/symbology-ng/qgsstylev2.cpp
+++ b/src/core/symbology-ng/qgsstylev2.cpp
@@ -512,15 +512,11 @@ QStringList QgsStyleV2::symbolsOfGroup( StyleEntity type, int groupid )
   char *query;
   if ( type == SymbolEntity )
   {
-    query = groupid
-            ? sqlite3_mprintf( "SELECT name FROM symbol WHERE groupid=%d", groupid )
-            : sqlite3_mprintf( "SELECT name FROM symbol WHERE groupid IS NULL" );
+    query = sqlite3_mprintf( "SELECT name FROM symbol WHERE groupid=%d", groupid );
   }
   else if ( type == ColorrampEntity )
   {
-    query = groupid
-            ? sqlite3_mprintf( "SELECT name FROM colorramp WHERE groupid=%d", groupid )
-            : sqlite3_mprintf( "SELECT name FROM colorramp WHERE groupid IS NULL" );
+    query = sqlite3_mprintf( "SELECT name FROM colorramp WHERE groupid=%d", groupid );
   }
   else
   {
@@ -734,14 +730,10 @@ bool QgsStyleV2::group( StyleEntity type, QString name, int groupid )
   switch ( type )
   {
     case SymbolEntity:
-      query = groupid
-              ? sqlite3_mprintf( "UPDATE symbol SET groupid=%d WHERE name='%q'", groupid, name.toUtf8().constData() )
-              : sqlite3_mprintf( "UPDATE symbol SET groupid=NULL WHERE name='%q'", name.toUtf8().constData() );
+      query = sqlite3_mprintf( "UPDATE symbol SET groupid=%d WHERE name='%q'", groupid, name.toUtf8().constData() );
       break;
     case ColorrampEntity:
-      query = groupid
-              ? sqlite3_mprintf( "UPDATE colorramp SET groupid=%d WHERE name='%q'", groupid, name.toUtf8().constData() )
-              : sqlite3_mprintf( "UPDATE colorramp SET groupid=NULL WHERE name='%q'", name.toUtf8().constData() );
+      query = sqlite3_mprintf( "UPDATE colorramp SET groupid=%d WHERE name='%q'", groupid, name.toUtf8().constData() );
       break;
 
     default:

--- a/src/gui/symbology-ng/qgsstylev2managerdialog.cpp
+++ b/src/gui/symbology-ng/qgsstylev2managerdialog.cpp
@@ -350,6 +350,10 @@ bool QgsStyleV2ManagerDialog::addSymbol()
   }
 
   // get symbol design
+  // NOTE : Set the parent widget as "this" to notify the Symbol selector
+  //        that, it is being called by Style Manager, so recursive calling
+  //        of style manger and symbol slector can be arrested
+  //        Look Also: editSymbol()
   QgsSymbolV2SelectorDialog dlg( symbol, mStyle, NULL, this );
   if ( dlg.exec() == 0 )
   {

--- a/src/gui/symbology-ng/qgssymbolslistwidget.cpp
+++ b/src/gui/symbology-ng/qgssymbolslistwidget.cpp
@@ -62,6 +62,13 @@ QgsSymbolsListWidget::QgsSymbolsListWidget( QgsSymbolV2* symbol, QgsStyleV2* sty
   viewSymbols->setModel( model );
   connect( viewSymbols->selectionModel(), SIGNAL( currentChanged( const QModelIndex &, const QModelIndex & ) ), this, SLOT( setSymbolFromStyle( const QModelIndex & ) ) );
 
+  if ( parent )
+  {
+    if ( dynamic_cast<QgsStyleV2ManagerDialog*>( parent->parentWidget() ) )
+    {
+      btnStyle->setVisible( false );
+    }
+  }
   // Set the Style Menu under btnStyle
   QMenu *styleMenu = new QMenu( btnStyle );
   QAction *styleMgrAction = new QAction( "Style Manager", styleMenu );

--- a/src/gui/symbology-ng/qgssymbolslistwidget.h
+++ b/src/gui/symbology-ng/qgssymbolslistwidget.h
@@ -30,7 +30,7 @@ class GUI_EXPORT QgsSymbolsListWidget : public QWidget, private Ui::SymbolsListW
     Q_OBJECT
 
   public:
-    QgsSymbolsListWidget( QgsSymbolV2* symbol, QgsStyleV2* style, QMenu* menu, QWidget* parent = NULL );
+    QgsSymbolsListWidget( QgsSymbolV2* symbol, QgsStyleV2* style, QMenu* menu, QWidget* parent );
 
   public slots:
     void setSymbolFromStyle( const QModelIndex & index );

--- a/src/gui/symbology-ng/qgssymbolv2selectordialog.cpp
+++ b/src/gui/symbology-ng/qgssymbolv2selectordialog.cpp
@@ -332,7 +332,7 @@ void QgsSymbolV2SelectorDialog::layerChanged()
   {
     // then it must be a symbol
     // Now populate symbols of that type using the symbols list widget:
-    QWidget *symbolsList = new QgsSymbolsListWidget( currentItem->symbol(), mStyle, mAdvancedMenu );
+    QWidget *symbolsList = new QgsSymbolsListWidget( currentItem->symbol(), mStyle, mAdvancedMenu, this );
     setWidget( symbolsList );
     connect( symbolsList, SIGNAL( changed() ), this, SLOT( symbolChanged() ) );
   }

--- a/src/gui/symbology-ng/qgssymbolv2selectordialog.h
+++ b/src/gui/symbology-ng/qgssymbolv2selectordialog.h
@@ -37,7 +37,7 @@ class GUI_EXPORT QgsSymbolV2SelectorDialog : public QDialog, private Ui::QgsSymb
     Q_OBJECT
 
   public:
-    QgsSymbolV2SelectorDialog( QgsSymbolV2* symbol, QgsStyleV2* style, const QgsVectorLayer* vl, QWidget* parent = NULL, bool embedded = false );
+    QgsSymbolV2SelectorDialog( QgsSymbolV2* symbol, QgsStyleV2* style, const QgsVectorLayer* vl, QWidget* parent = 0, bool embedded = false );
 
     //! return menu for "advanced" button - create it if doesn't exist and show the advanced button
     QMenu* advancedMenu();


### PR DESCRIPTION
This pull request fixes the following two issues:
1. In the symbols database the `groupid` filed of **symbol** table and the `parent` field of the **symgroup** table were using a combination of zeros and NULLs making the code longer and working inconsistent. This has been changed to use Zero only in the first two commits.
2. Even though, the new symbol selector cum editor was designed to remove the recursive opening of the dialogs. The `Style` button in the Symbol Selector provided a way to do it. The third commit in this request hides the `Style` button when the Symbol selector is called by the Style manger, thereby eliminating this path.
