### PR TITLE
Fix for Bug #6942

### DIFF
--- a/src/core/composer/qgscomposeritem.cpp
+++ b/src/core/composer/qgscomposeritem.cpp
@@ -837,6 +837,13 @@ double QgsComposerItem::fontAscentMillimeters( const QFont& font ) const
   return ( fontMetrics.ascent() / FONT_WORKAROUND_SCALE );
 }
 
+double QgsComposerItem::fontDescentMillimeters( const QFont& font ) const
+{
+  QFont metricsFont = scaledFontPixelSize( font );
+  QFontMetricsF fontMetrics( metricsFont );
+  return ( fontMetrics.descent() / FONT_WORKAROUND_SCALE );
+}
+
 double QgsComposerItem::pixelFontSize( double pointSize ) const
 {
   return ( pointSize * 0.3527 );

--- a/src/core/composer/qgscomposeritem.h
+++ b/src/core/composer/qgscomposeritem.h
@@ -213,6 +213,9 @@ class CORE_EXPORT QgsComposerItem: public QObject, public QGraphicsRectItem
     /**Returns the font ascent in Millimeters (considers upscaling and downscaling with FONT_WORKAROUND_SCALE*/
     double fontAscentMillimeters( const QFont& font ) const;
 
+    /**Returns the font ascent in Millimeters (considers upscaling and downscaling with FONT_WORKAROUND_SCALE*/
+    double fontDescentMillimeters( const QFont& font ) const;
+
     /**Calculates font to from point size to pixel size*/
     double pixelFontSize( double pointSize ) const;
 

--- a/src/core/composer/qgscomposerlegend.cpp
+++ b/src/core/composer/qgscomposerlegend.cpp
@@ -212,7 +212,7 @@ QSizeF QgsComposerLegend::drawTitle( QPainter* painter, QPointF point, Qt::Align
   {
     // it does not draw the last world if rectangle width is exactly text width
     double width = textWidthMillimeters( mTitleFont, *titlePart ) + 1;
-    double height = fontAscentMillimeters( mTitleFont );
+    double height = fontAscentMillimeters( mTitleFont ) + fontDescentMillimeters( mTitleFont );
 
     double left = halignement == Qt::AlignLeft ?  point.x() : point.x() - width / 2;
 


### PR DESCRIPTION
While this bug is not going to break the program if it isn't fixed, if anyone wanted to add a legend with a font which has a descent > 0, the bounding box was not calculated correctly which led to letters like g and j to be cut off below the base line. I disagree strongly that a bug like this isn't really important to fix because most users will create a map and all good maps have a legend and if a letter is cut off in the legend title, it looks really unprofessional. 

... are not cut off from the legend title.
