### PR TITLE
Fix #6968, saving/rollbacking edits deselects current editing tool

### DIFF
--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1284,6 +1284,11 @@ class QgisApp : public QMainWindow, private Ui::MainWindow
     //!flag to indicate that the previous screen mode was 'maximised'
     bool mPrevScreenModeMaximized;
 
+    /** Flag to indicate an edits save/rollback for active layer is in progress
+     * @note added in QGIS 1.9
+     */
+    bool mSaveRollbackInProgress;
+
     QgsPythonUtils* mPythonUtils;
 
     static QgisApp *smInstance;


### PR DESCRIPTION
For review by Nathan (and anyone else who wants to test).

Should fix http://hub.qgis.org/issues/6968
