### PR TITLE
Add option to use custom QSettings for QgsCollapsibleGroupBox

### DIFF
--- a/python/gui/qgscollapsiblegroupbox.sip
+++ b/python/gui/qgscollapsiblegroupbox.sip
@@ -4,9 +4,12 @@ class QgsCollapsibleGroupBox : QGroupBox
 #include <qgscollapsiblegroupbox.h>
 %End
   public:
-    QgsCollapsibleGroupBox( QWidget *parent = 0 );
-    QgsCollapsibleGroupBox( const QString &title, QWidget *parent = 0 );
+    QgsCollapsibleGroupBox( QWidget *parent = 0, QSettings* settings = 0 );
+    QgsCollapsibleGroupBox( const QString &title, QWidget *parent = 0, QSettings* settings = 0 );
     ~QgsCollapsibleGroupBox();
+
+    // set custom QSettings pointer if group box was already created from QtDesigner promotion
+    void setSettings( QSettings* settings );
 
     bool isCollapsed() const;
     void setCollapsed( bool collapse );

--- a/src/gui/qgscollapsiblegroupbox.cpp
+++ b/src/gui/qgscollapsiblegroupbox.cpp
@@ -29,15 +29,15 @@
 QIcon QgsCollapsibleGroupBox::mCollapseIcon;
 QIcon QgsCollapsibleGroupBox::mExpandIcon;
 
-QgsCollapsibleGroupBox::QgsCollapsibleGroupBox( QWidget *parent )
-    : QGroupBox( parent )
+QgsCollapsibleGroupBox::QgsCollapsibleGroupBox( QWidget *parent, QSettings* settings )
+    : QGroupBox( parent ), mSettings( settings )
 {
   init();
 }
 
 QgsCollapsibleGroupBox::QgsCollapsibleGroupBox( const QString &title,
-    QWidget *parent )
-    : QGroupBox( title, parent )
+    QWidget *parent, QSettings* settings )
+    : QGroupBox( title, parent ), mSettings( settings )
 {
   init();
 }
@@ -45,10 +45,16 @@ QgsCollapsibleGroupBox::QgsCollapsibleGroupBox( const QString &title,
 QgsCollapsibleGroupBox::~QgsCollapsibleGroupBox()
 {
   saveState();
+  delete mSettings;
 }
 
 void QgsCollapsibleGroupBox::init()
 {
+  // use pointer to app qsettings if no custom qsettings specified
+  if ( !mSettings )
+  {
+    mSettings = new QSettings();
+  }
   // variables
   mCollapsed = false;
   mSaveCollapsedState = true;
@@ -188,18 +194,17 @@ void QgsCollapsibleGroupBox::loadState()
 
   setUpdatesEnabled( false );
 
-  QSettings settings;
   QString key = saveKey();
   QVariant val;
   if ( mSaveCheckedState )
   {
-    val = settings.value( key + "/checked" );
+    val = mSettings->value( key + "/checked" );
     if ( ! val.isNull() )
       setChecked( val.toBool() );
   }
   if ( mSaveCollapsedState )
   {
-    val = settings.value( key + "/collapsed" );
+    val = mSettings->value( key + "/collapsed" );
     if ( ! val.isNull() )
       setCollapsed( val.toBool() );
   }
@@ -212,13 +217,12 @@ void QgsCollapsibleGroupBox::saveState()
   if ( !isEnabled() || ( !mSaveCollapsedState && !mSaveCheckedState ) )
     return;
 
-  QSettings settings;
   QString key = saveKey();
 
   if ( mSaveCheckedState )
-    settings.setValue( key + "/checked", isChecked() );
+    mSettings->setValue( key + "/checked", isChecked() );
   if ( mSaveCollapsedState )
-    settings.setValue( key + "/collapsed", isCollapsed() );
+    mSettings->setValue( key + "/collapsed", isCollapsed() );
 }
 
 void QgsCollapsibleGroupBox::checkToggled( bool chkd )
@@ -340,4 +344,3 @@ void QgsCollapsibleGroupBox::setCollapsed( bool collapse )
   }
   emit collapsedStateChanged( this );
 }
-

--- a/src/gui/qgscollapsiblegroupbox.cpp
+++ b/src/gui/qgscollapsiblegroupbox.cpp
@@ -45,8 +45,19 @@ QgsCollapsibleGroupBox::QgsCollapsibleGroupBox( const QString &title,
 QgsCollapsibleGroupBox::~QgsCollapsibleGroupBox()
 {
   saveState();
-  if ( mDelSettings )
+  if ( mDelSettings ) // local settings obj to delete
     delete mSettings;
+  mSettings = 0; // null the pointer (in case of outside settings obj)
+  delete mSettings; // delete the null pointer
+}
+
+
+void QgsCollapsibleGroupBox::setSettings( QSettings* settings )
+{
+  if ( mDelSettings ) // local settings obj to delete
+    delete mSettings;
+  mSettings = settings;
+  mDelSettings = false; // don't delete outside obj
 }
 
 void QgsCollapsibleGroupBox::init()

--- a/src/gui/qgscollapsiblegroupbox.cpp
+++ b/src/gui/qgscollapsiblegroupbox.cpp
@@ -45,15 +45,18 @@ QgsCollapsibleGroupBox::QgsCollapsibleGroupBox( const QString &title,
 QgsCollapsibleGroupBox::~QgsCollapsibleGroupBox()
 {
   saveState();
-  delete mSettings;
+  if ( mDelSettings )
+    delete mSettings;
 }
 
 void QgsCollapsibleGroupBox::init()
 {
   // use pointer to app qsettings if no custom qsettings specified
+  mDelSettings = false;
   if ( !mSettings )
   {
     mSettings = new QSettings();
+    mDelSettings = true; // only delete obj created by class
   }
   // variables
   mCollapsed = false;

--- a/src/gui/qgscollapsiblegroupbox.h
+++ b/src/gui/qgscollapsiblegroupbox.h
@@ -26,6 +26,7 @@
  */
 
 #include <QGroupBox>
+#include <QSettings>
 
 class QToolButton;
 class QScrollArea;
@@ -35,9 +36,12 @@ class GUI_EXPORT QgsCollapsibleGroupBox : public QGroupBox
     Q_OBJECT
 
   public:
-    QgsCollapsibleGroupBox( QWidget *parent = 0 );
-    QgsCollapsibleGroupBox( const QString &title, QWidget *parent = 0 );
+    QgsCollapsibleGroupBox( QWidget *parent = 0, QSettings* settings = 0 );
+    QgsCollapsibleGroupBox( const QString &title, QWidget *parent = 0, QSettings* settings = 0 );
     ~QgsCollapsibleGroupBox();
+
+    // set custom QSettings pointer if group box was already created from QtDesigner promotion
+    void setSettings( QSettings* settings ) { mSettings = settings ;}
 
     bool isCollapsed() const { return mCollapsed; }
     void setCollapsed( bool collapse );
@@ -79,6 +83,9 @@ class GUI_EXPORT QgsCollapsibleGroupBox : public QGroupBox
     void updateStyle();
     QRect titleRect() const;
     QString saveKey() const;
+
+    // pointer to app or custom QSettings
+    QSettings* mSettings;
 
     bool mCollapsed;
     bool mSaveCollapsedState;

--- a/src/gui/qgscollapsiblegroupbox.h
+++ b/src/gui/qgscollapsiblegroupbox.h
@@ -86,6 +86,7 @@ class GUI_EXPORT QgsCollapsibleGroupBox : public QGroupBox
 
     // pointer to app or custom QSettings
     QSettings* mSettings;
+    bool mDelSettings;
 
     bool mCollapsed;
     bool mSaveCollapsedState;

--- a/src/gui/qgscollapsiblegroupbox.h
+++ b/src/gui/qgscollapsiblegroupbox.h
@@ -41,7 +41,7 @@ class GUI_EXPORT QgsCollapsibleGroupBox : public QGroupBox
     ~QgsCollapsibleGroupBox();
 
     // set custom QSettings pointer if group box was already created from QtDesigner promotion
-    void setSettings( QSettings* settings ) { mSettings = settings ;}
+    void setSettings( QSettings* settings );
 
     bool isCollapsed() const { return mCollapsed; }
     void setCollapsed( bool collapse );


### PR DESCRIPTION
- Useful for plugins that may want to store collapsed state in their own QSettings file

This was in response to an inquiry from Alex about whether a custom QSettings could be used to save the collapsed state.

Alex, could you test this to see if it works for your Python (or maybe it's C++) project?

Note the convenience function for setting the QSettings pointer if the group box was already created via including a .ui in C++; otherwise, you should be able to specify the pointer to a custom QSettings object on construction of the group box in code in either C++ or Python.
