### PR TITLE
Save geometry of expression build dialog on close

### DIFF
--- a/src/gui/qgsexpressionbuilderdialog.cpp
+++ b/src/gui/qgsexpressionbuilderdialog.cpp
@@ -47,11 +47,10 @@ QString QgsExpressionBuilderDialog::expressionText()
   return builder->expressionText();
 }
 
-void QgsExpressionBuilderDialog::closeEvent( QCloseEvent *event )
+void QgsExpressionBuilderDialog::done( int r )
 {
-  QDialog::closeEvent( event );
+  QDialog::done( r );
 
-  // TODO Work out why this is not working yet.
   QSettings settings;
   settings.setValue( "/Windows/ExpressionBuilderDialog/geometry", saveGeometry() );
 }

--- a/src/gui/qgsexpressionbuilderdialog.h
+++ b/src/gui/qgsexpressionbuilderdialog.h
@@ -42,10 +42,12 @@ class GUI_EXPORT QgsExpressionBuilderDialog : public QDialog, private Ui::QgsExp
 
   protected:
     /**
-     * Handle closing of the window
-     * @param event unused
+     * Is called when the dialog get accepted or rejected
+     * Used to save geometry
+     *
+     * @param r result value (unused)
      */
-    void closeEvent( QCloseEvent * event );
+    virtual void done( int r );
 };
 
 #endif


### PR DESCRIPTION
Saves the expression builder dialog window geometry when the dialog is accepted or rejected, so when it's opened the next time it can be restored.
