### PR TITLE
Fix for #6165 - Overlapping widgets in expression builder dialog

### DIFF
--- a/src/ui/qgsexpressionbuilder.ui
+++ b/src/ui/qgsexpressionbuilder.ui
@@ -43,7 +43,13 @@
         <bool>true</bool>
        </property>
        <layout class="QGridLayout" name="gridLayout_6">
-        <property name="margin">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
          <number>0</number>
         </property>
         <property name="spacing">
@@ -113,9 +119,6 @@
           <property name="leftMargin">
            <number>0</number>
           </property>
-          <property name="topMargin">
-           <number>3</number>
-          </property>
           <property name="rightMargin">
            <number>0</number>
           </property>
@@ -146,9 +149,6 @@
          <layout class="QGridLayout" name="gridLayout_7">
           <property name="leftMargin">
            <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>3</number>
           </property>
           <property name="rightMargin">
            <number>0</number>
@@ -271,9 +271,6 @@
       </property>
       <property name="leftMargin">
        <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>4</number>
       </property>
       <property name="rightMargin">
        <number>0</number>
@@ -472,9 +469,6 @@
       <property name="leftMargin">
        <number>0</number>
       </property>
-      <property name="topMargin">
-       <number>3</number>
-      </property>
       <property name="rightMargin">
        <number>0</number>
       </property>
@@ -509,8 +503,6 @@
    <header>qgsfilterlineedit.h</header>
   </customwidget>
  </customwidgets>
- <resources>
-  <include location="../../images/images.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
Reset the top margin of widgets to the default value
