### PR TITLE
[feature] added draw background checkbox in composer items

### DIFF
--- a/src/app/composer/qgscomposeritemwidget.cpp
+++ b/src/app/composer/qgscomposeritemwidget.cpp
@@ -140,7 +140,7 @@ void QgsComposerItemWidget::on_mOutlineWidthSpinBox_valueChanged( double d )
   mItem->endCommand();
 }
 
-void QgsComposerItemWidget::on_mFrameCheckBox_stateChanged( int state )
+void QgsComposerItemWidget::on_mFrameGroupBox_toggled( bool state )
 {
   if ( !mItem )
   {
@@ -148,21 +148,12 @@ void QgsComposerItemWidget::on_mFrameCheckBox_stateChanged( int state )
   }
 
   mItem->beginCommand( tr( "Item frame toggled" ) );
-  if ( state == Qt::Checked )
-  {
-    mFrameBox->setEnabled( true );
-    mItem->setFrameEnabled( true );
-  }
-  else
-  {
-    mFrameBox->setEnabled( false );
-    mItem->setFrameEnabled( false );
-  }
+  mItem->setFrameEnabled( state );
   mItem->update();
   mItem->endCommand();
 }
 
-void QgsComposerItemWidget::on_mBackgroundCheckBox_stateChanged( int state )
+void QgsComposerItemWidget::on_mBackgroundGroupBox_toggled( bool state )
 {
   if ( !mItem )
   {
@@ -170,16 +161,7 @@ void QgsComposerItemWidget::on_mBackgroundCheckBox_stateChanged( int state )
   }
 
   mItem->beginCommand( tr( "Item background toggled" ) );
-  if ( state == Qt::Checked )
-  {
-    mBackgroundBox->setEnabled( true );
-    mItem->setBackgroundEnabled( true );
-  }
-  else
-  {
-    mBackgroundBox->setEnabled( false );
-    mItem->setBackgroundEnabled( false );
-  }
+  mItem->setBackgroundEnabled( state );
   mItem->update();
   mItem->endCommand();
 }
@@ -193,7 +175,8 @@ void QgsComposerItemWidget::setValuesForGuiElements()
 
   mOpacitySlider->blockSignals( true );
   mOutlineWidthSpinBox->blockSignals( true );
-  mFrameCheckBox->blockSignals( true );
+  mFrameGroupBox->blockSignals( true );
+  mBackgroundGroupBox->blockSignals( true );
   mItemIdLineEdit->blockSignals( true );
   mOpacitySpinBox->blockSignals( true );
 
@@ -201,18 +184,13 @@ void QgsComposerItemWidget::setValuesForGuiElements()
   mOpacitySlider->setValue( mItem->brush().color().alpha() );
   mOutlineWidthSpinBox->setValue( mItem->pen().widthF() );
   mItemIdLineEdit->setText( mItem->id() );
-  if ( mItem->hasFrame() )
-  {
-    mFrameCheckBox->setCheckState( Qt::Checked );
-  }
-  else
-  {
-    mFrameCheckBox->setCheckState( Qt::Unchecked );
-  }
-
+  mFrameGroupBox->setChecked( mItem->hasFrame() );
+  mBackgroundGroupBox->setChecked( mItem->hasBackground() );
+  
   mOpacitySlider->blockSignals( false );
   mOutlineWidthSpinBox->blockSignals( false );
-  mFrameCheckBox->blockSignals( false );
+  mFrameGroupBox->blockSignals( false );
+  mBackgroundGroupBox->blockSignals( false );
   mItemIdLineEdit->blockSignals( false );
   mOpacitySpinBox->blockSignals( false );
 }

--- a/src/app/composer/qgscomposeritemwidget.cpp
+++ b/src/app/composer/qgscomposeritemwidget.cpp
@@ -150,11 +150,35 @@ void QgsComposerItemWidget::on_mFrameCheckBox_stateChanged( int state )
   mItem->beginCommand( tr( "Item frame toggled" ) );
   if ( state == Qt::Checked )
   {
+    mFrameBox->setEnabled( true );
     mItem->setFrameEnabled( true );
   }
   else
   {
+    mFrameBox->setEnabled( false );
     mItem->setFrameEnabled( false );
+  }
+  mItem->update();
+  mItem->endCommand();
+}
+
+void QgsComposerItemWidget::on_mBackgroundCheckBox_stateChanged( int state )
+{
+  if ( !mItem )
+  {
+    return;
+  }
+
+  mItem->beginCommand( tr( "Item background toggled" ) );
+  if ( state == Qt::Checked )
+  {
+    mBackgroundBox->setEnabled( true );
+    mItem->setBackgroundEnabled( true );
+  }
+  else
+  {
+    mBackgroundBox->setEnabled( false );
+    mItem->setBackgroundEnabled( false );
   }
   mItem->update();
   mItem->endCommand();

--- a/src/app/composer/qgscomposeritemwidget.h
+++ b/src/app/composer/qgscomposeritemwidget.h
@@ -37,8 +37,8 @@ class QgsComposerItemWidget: public QWidget, private Ui::QgsComposerItemWidgetBa
     void on_mOpacitySlider_sliderReleased();
     void on_mOpacitySpinBox_valueChanged( int value );
     void on_mOutlineWidthSpinBox_valueChanged( double d );
-    void on_mFrameCheckBox_stateChanged( int state );
-    void on_mBackgroundCheckBox_stateChanged( int state );
+    void on_mFrameGroupBox_toggled( bool state );
+    void on_mBackgroundGroupBox_toggled( bool state );
     void on_mPositionButton_clicked();
     void on_mItemIdLineEdit_textChanged( const QString& text );
 

--- a/src/app/composer/qgscomposeritemwidget.h
+++ b/src/app/composer/qgscomposeritemwidget.h
@@ -38,6 +38,7 @@ class QgsComposerItemWidget: public QWidget, private Ui::QgsComposerItemWidgetBa
     void on_mOpacitySpinBox_valueChanged( int value );
     void on_mOutlineWidthSpinBox_valueChanged( double d );
     void on_mFrameCheckBox_stateChanged( int state );
+    void on_mBackgroundCheckBox_stateChanged( int state );
     void on_mPositionButton_clicked();
     void on_mItemIdLineEdit_textChanged( const QString& text );
 

--- a/src/core/composer/qgscomposeritem.cpp
+++ b/src/core/composer/qgscomposeritem.cpp
@@ -46,6 +46,7 @@ QgsComposerItem::QgsComposerItem( QgsComposition* composition, bool manageZValue
     , mHAlignSnapItem( 0 )
     , mVAlignSnapItem( 0 )
     , mFrame( false )
+    , mBackground( true )
     , mItemPositionLocked( false )
     , mLastValidViewScaleFactor( -1 )
     , mRotation( 0 )
@@ -61,6 +62,7 @@ QgsComposerItem::QgsComposerItem( qreal x, qreal y, qreal width, qreal height, Q
     , mHAlignSnapItem( 0 )
     , mVAlignSnapItem( 0 )
     , mFrame( false )
+    , mBackground( true )
     , mItemPositionLocked( false )
     , mLastValidViewScaleFactor( -1 )
     , mRotation( 0 )
@@ -128,6 +130,16 @@ bool QgsComposerItem::_writeXML( QDomElement& itemElem, QDomDocument& doc ) cons
   else
   {
     composerItemElem.setAttribute( "frame", "false" );
+  }
+
+  //frame
+  if ( mBackground )
+  {
+    composerItemElem.setAttribute( "background", "true" );
+  }
+  else
+  {
+    composerItemElem.setAttribute( "background", "false" );
   }
 
   //scene rect
@@ -198,6 +210,17 @@ bool QgsComposerItem::_readXML( const QDomElement& itemElem, const QDomDocument&
   else
   {
     mFrame = false;
+  }
+
+  //frame
+  QString background = itemElem.attribute( "background" );
+  if ( background.compare( "true", Qt::CaseInsensitive ) == 0 )
+  {
+    mBackground = true;
+  }
+  else
+  {
+    mBackground = false;
   }
 
   //position lock for mouse moves/resizes
@@ -799,9 +822,9 @@ void QgsComposerItem::setSceneRect( const QRectF& rectangle )
 
 void QgsComposerItem::drawBackground( QPainter* p )
 {
-  if ( p )
+  if ( mBackground && p )
   {
-    p->setBrush( brush() );
+    p->setBrush( brush() );//this causes a problem in atlas generation
     p->setPen( Qt::NoPen );
     p->setRenderHint( QPainter::Antialiasing, true );
     p->drawRect( QRectF( 0, 0, rect().width(), rect().height() ) );

--- a/src/core/composer/qgscomposeritem.h
+++ b/src/core/composer/qgscomposeritem.h
@@ -175,6 +175,22 @@ class CORE_EXPORT QgsComposerItem: public QObject, public QGraphicsRectItem
      */
     void setFrameEnabled( bool drawFrame ) {mFrame = drawFrame;}
 
+
+    /** Whether this item has a Background or not.
+     * @returns true if there is a Background around this item, otherwise false.
+     * @note introduced since 2.0
+     * @see hasBackground
+     */
+    bool hasBackground() const {return mBackground;}
+
+    /** Set whether this item has a Background drawn around it or not.
+     * @param drawBackground draw Background
+     * @returns nothing
+     * @note introduced in 2.0
+     * @see hasBackground
+     */
+    void setBackgroundEnabled( bool drawBackground ) {mBackground = drawBackground;}
+
     /**Composite operations for item groups do nothing per default*/
     virtual void addItem( QgsComposerItem* item ) { Q_UNUSED( item ); }
     virtual void removeItems() {}
@@ -271,6 +287,8 @@ class CORE_EXPORT QgsComposerItem: public QObject, public QGraphicsRectItem
 
     /**True if item fram needs to be painted*/
     bool mFrame;
+    /**True if item background needs to be painted*/
+    bool mBackground;
 
     /**True if item position  and size cannot be changed with mouse move
     @note: this member was added in version 1.2*/

--- a/src/core/composer/qgscomposermap.cpp
+++ b/src/core/composer/qgscomposermap.cpp
@@ -227,7 +227,8 @@ void QgsComposerMap::cache( void )
   double forcedWidthScaleFactor = w / requestExtent.width() / mapUnitsToMM();
 
   mCacheImage = QImage( w, h,  QImage::Format_ARGB32 );
-  mCacheImage.fill( brush().color().rgb() ); //consider the item background brush
+  mCacheImage.fill( QColor(255,255,255,0).rgba() ); // the background is drawn by composerItem, but we still need to start with that empty fill to avoid artifacts
+
   double mapUnitsPerPixel = mExtent.width() / w;
 
   // WARNING: ymax in QgsMapToPixel is device height!!!

--- a/src/ui/qgscomposeritemwidgetbase.ui
+++ b/src/ui/qgscomposeritemwidgetbase.ui
@@ -6,103 +6,120 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>235</width>
-    <height>277</height>
+    <width>393</width>
+    <height>391</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0" colspan="3">
-    <widget class="QPushButton" name="mFrameColorButton">
-     <property name="text">
-      <string>Frame color...</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0" colspan="3">
-    <widget class="QPushButton" name="mBackgroundColorButton">
-     <property name="text">
-      <string>Background color...</string>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="0" colspan="3">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QLabel" name="mOpacityLabel">
-       <property name="text">
-        <string>Opacity</string>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-       <property name="buddy">
-        <cstring>mOpacitySlider</cstring>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QSlider" name="mOpacitySlider">
-       <property name="maximum">
-        <number>255</number>
-       </property>
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QSpinBox" name="mOpacitySpinBox">
-       <property name="maximum">
-        <number>255</number>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="mOutlineWidthLabel">
-     <property name="text">
-      <string>Outline width</string>
-     </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
-     <property name="buddy">
-      <cstring>mOutlineWidthSpinBox</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="2">
-    <widget class="QDoubleSpinBox" name="mOutlineWidthSpinBox"/>
-   </item>
-   <item row="4" column="0" colspan="3">
-    <widget class="QPushButton" name="mPositionButton">
-     <property name="text">
-      <string>Position and size...</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0" colspan="2">
+  <layout class="QFormLayout" name="formLayout_2">
+   <item row="1" column="0">
     <widget class="QCheckBox" name="mFrameCheckBox">
      <property name="text">
       <string>Show frame</string>
      </property>
     </widget>
    </item>
-   <item row="6" column="0">
+   <item row="2" column="0" colspan="2">
+    <widget class="QGroupBox" name="mFrameBox">
+     <property name="title">
+      <string>Frame settings</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_2">
+      <item row="0" column="0" colspan="2">
+       <widget class="QPushButton" name="mFrameColorButton">
+        <property name="text">
+         <string>Frame color...</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="mOutlineWidthLabel">
+        <property name="text">
+         <string>Thickness</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+        <property name="buddy">
+         <cstring>mOutlineWidthSpinBox</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QDoubleSpinBox" name="mOutlineWidthSpinBox"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QCheckBox" name="mBackgroundCheckBox">
+     <property name="text">
+      <string>Show background</string>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0" colspan="2">
+    <widget class="QGroupBox" name="mBackgroundBox">
+     <property name="title">
+      <string>Background settings</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="0" column="0" colspan="3">
+       <widget class="QPushButton" name="mBackgroundColorButton">
+        <property name="text">
+         <string>Background color...</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="mOpacityLabel">
+        <property name="text">
+         <string>Opacity</string>
+        </property>
+        <property name="wordWrap">
+         <bool>true</bool>
+        </property>
+        <property name="buddy">
+         <cstring>mOpacitySlider</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QSlider" name="mOpacitySlider">
+        <property name="maximum">
+         <number>255</number>
+        </property>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="2">
+       <widget class="QSpinBox" name="mOpacitySpinBox">
+        <property name="maximum">
+         <number>255</number>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="5" column="0" colspan="2">
+    <layout class="QHBoxLayout" name="horizontalLayout"/>
+   </item>
+   <item row="7" column="0">
     <widget class="QLabel" name="mIdLabel">
      <property name="text">
       <string>Item ID</string>
      </property>
     </widget>
    </item>
-   <item row="6" column="1" colspan="2">
+   <item row="7" column="1">
     <widget class="QLineEdit" name="mItemIdLineEdit"/>
    </item>
-   <item row="7" column="0" colspan="2">
+   <item row="8" column="0" colspan="2">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -114,6 +131,13 @@
       </size>
      </property>
     </spacer>
+   </item>
+   <item row="0" column="0" colspan="2">
+    <widget class="QPushButton" name="mPositionButton">
+     <property name="text">
+      <string>Position and size...</string>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/src/ui/qgscomposeritemwidgetbase.ui
+++ b/src/ui/qgscomposeritemwidgetbase.ui
@@ -14,17 +14,23 @@
    <string>Form</string>
   </property>
   <layout class="QFormLayout" name="formLayout_2">
-   <item row="1" column="0">
-    <widget class="QCheckBox" name="mFrameCheckBox">
+   <property name="fieldGrowthPolicy">
+    <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+   </property>
+   <item row="0" column="0" colspan="2">
+    <widget class="QPushButton" name="mPositionButton">
      <property name="text">
-      <string>Show frame</string>
+      <string>Position and size...</string>
      </property>
     </widget>
    </item>
-   <item row="2" column="0" colspan="2">
-    <widget class="QGroupBox" name="mFrameBox">
+   <item row="1" column="0" colspan="2">
+    <widget class="QgsCollapsibleGroupBox" name="mFrameGroupBox">
      <property name="title">
-      <string>Frame settings</string>
+      <string>Show frame</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
      </property>
      <layout class="QGridLayout" name="gridLayout_2">
       <item row="0" column="0" colspan="2">
@@ -53,17 +59,19 @@
      </layout>
     </widget>
    </item>
-   <item row="3" column="0">
-    <widget class="QCheckBox" name="mBackgroundCheckBox">
-     <property name="text">
+   <item row="2" column="0" colspan="2">
+    <widget class="QgsCollapsibleGroupBox" name="mBackgroundGroupBox">
+     <property name="title">
       <string>Show background</string>
      </property>
-    </widget>
-   </item>
-   <item row="4" column="0" colspan="2">
-    <widget class="QGroupBox" name="mBackgroundBox">
-     <property name="title">
-      <string>Background settings</string>
+     <property name="flat">
+      <bool>false</bool>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
      </property>
      <layout class="QGridLayout" name="gridLayout">
       <item row="0" column="0" colspan="3">
@@ -106,20 +114,20 @@
      </layout>
     </widget>
    </item>
-   <item row="5" column="0" colspan="2">
+   <item row="3" column="0" colspan="2">
     <layout class="QHBoxLayout" name="horizontalLayout"/>
    </item>
-   <item row="7" column="0">
+   <item row="5" column="0">
     <widget class="QLabel" name="mIdLabel">
      <property name="text">
       <string>Item ID</string>
      </property>
     </widget>
    </item>
-   <item row="7" column="1">
+   <item row="5" column="1">
     <widget class="QLineEdit" name="mItemIdLineEdit"/>
    </item>
-   <item row="8" column="0" colspan="2">
+   <item row="6" column="0" colspan="2">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -132,15 +140,16 @@
      </property>
     </spacer>
    </item>
-   <item row="0" column="0" colspan="2">
-    <widget class="QPushButton" name="mPositionButton">
-     <property name="text">
-      <string>Position and size...</string>
-     </property>
-    </widget>
-   </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources/>
  <connections>
   <connection>


### PR DESCRIPTION
Adds the ability to completely disable composer's items backgrounds.

This has the following benefits :
- more consistent with the way composer's items frames are treated
- allows workaround this bug with non-opaque elements http://hub.qgis.org/issues/6856

By the way, I reorganized the composer's items base widget, which wasn't very clear.

Note :
- I didn't do anything with SIP bindings or tests

![commitecompare](https://f.cloud.github.com/assets/1894106/105496/d563d946-69b3-11e2-9f6d-89f0a4161594.png)
