### PR TITLE
MapToolIdentify moved to gui to make it accessible in python

### DIFF
--- a/python/gui/gui.sip
+++ b/python/gui/gui.sip
@@ -39,6 +39,7 @@
 %Include qgsmaptip.sip
 %Include qgsmaptool.sip
 %Include qgsmaptoolemitpoint.sip
+%Include qgsmaptoolidentify.sip
 %Include qgsmaptoolpan.sip
 %Include qgsmaptooltouch.sip
 %Include qgsmaptoolzoom.sip

--- a/python/gui/qgsmaptool.sip
+++ b/python/gui/qgsmaptool.sip
@@ -6,6 +6,7 @@
 #include <qgsmaptoolzoom.h>
 #include <qgsmaptoolpan.h>
 #include <qgsmaptoolemitpoint.h>
+#include <qgsmaptoolidentify.h>
 %End
 
 %Feature HAVE_TOUCH
@@ -23,6 +24,8 @@ class QgsMapTool : QObject
     sipClass = sipClass_QgsMapToolPan;
   else if (dynamic_cast<QgsMapToolEmitPoint*>(sipCpp) != NULL)
     sipClass = sipClass_QgsMapToolEmitPoint;
+  else if (dynamic_cast<QgsMapToolIdentify*>(sipCpp) != NULL)
+    sipClass = sipClass_QgsMapToolIdentify;
   else
     sipClass = NULL;
 %End

--- a/python/gui/qgsmaptoolidentify.sip
+++ b/python/gui/qgsmaptoolidentify.sip
@@ -92,21 +92,6 @@ class QgsMapToolIdentify : QgsMapTool
     void identifyMessage( QString );
 
   private:
-    /** Performs the identification.
-    To avoid beeing forced to specify IdentifyMode with a list of layers
-    this has been made private and two publics methods are offered
-    @param x x coordinates of mouseEvent
-    @param y y coordinates of mouseEvent
-    @param mode Identification mode. Can use Qgis default settings or a defined mode.
-    @param layerList Performs the identification within the given list of layers.
-    @param layerType Only performs identification in a certain type of layers (raster, vector).
-    @return true if identification succeeded and a feature has been found, false otherwise.*/
-    bool identify(int x, int y, IdentifyMode mode, QList<QgsMapLayer*> layerList, LayerType layerType = AllLayers);
-    
-    bool identifyLayer( QgsMapLayer *layer, int x, int y, LayerType layerType = AllLayers );
-    bool identifyRasterLayer( QgsRasterLayer *layer, int x, int y );
-    bool identifyVectorLayer( QgsVectorLayer *layer, int x, int y );
-
     //! Private helper
     virtual void convertMeasurement( QgsDistanceArea &calc, double &measure, QGis::UnitType &u, bool isArea );
 

--- a/python/gui/qgsmaptoolidentify.sip
+++ b/python/gui/qgsmaptoolidentify.sip
@@ -1,0 +1,115 @@
+
+class QgsMapToolIdentify : QgsMapTool
+{
+%TypeHeaderCode
+#include <qgsmaptoolidentify.h>
+%End
+
+  public:
+    enum IdentifyMode
+    {
+        DefaultQgsSetting=-1,
+        ActiveLayer,
+        TopDownStopAtFirst,
+        TopDownAll,
+    };
+
+    enum LayerType
+    {
+        AllLayers=-1,
+        VectorLayer,
+        RasterLayer,
+    };
+
+    struct VectorResult
+    {
+        VectorResult();
+        VectorResult(QgsVectorLayer* layer, QgsFeature feature, QMap< QString, QString > derivedAttributes);
+        QgsVectorLayer* mLayer;
+        QgsFeature mFeature;
+        QMap< QString, QString > mDerivedAttributes;
+    };
+    
+    struct RasterResult
+    {
+        RasterResult();
+        RasterResult( QgsRasterLayer* layer, QString label, QMap< QString, QString > attributes, QMap< QString, QString > derivedAttributes);
+        QgsRasterLayer* mLayer;
+        QString mLabel;
+        QMap< QString, QString > mAttributes;
+        QMap< QString, QString > mDerivedAttributes;
+    };
+
+    struct IdentifyResults
+    {
+        IdentifyResults();
+        IdentifyResults ( QList<QgsMapToolIdentify::VectorResult> vectorResults , QList<QgsMapToolIdentify::RasterResult> rasterResults); 
+        QList<QgsMapToolIdentify::VectorResult> mVectorResults;
+        QList<QgsMapToolIdentify::RasterResult> mRasterResults;
+    };
+
+	//! constructor
+    QgsMapToolIdentify( QgsMapCanvas* canvas );
+
+    //! Overridden mouse move event
+    virtual void canvasMoveEvent( QMouseEvent * e );
+
+    //! Overridden mouse press event
+    virtual void canvasPressEvent( QMouseEvent * e );
+
+    //! Overridden mouse release event
+    virtual void canvasReleaseEvent( QMouseEvent * e );
+
+    virtual void activate();
+
+    virtual void deactivate();
+
+    //QgsMapLayer::LayerType LayerType;
+
+    /** Performs the identification.
+    @param x x coordinates of mouseEvent
+    @param y y coordinates of mouseEvent
+    @param layerList Performs the identification within the given list of layers. Default value is an empty list, i.e. uses all the layers.
+    @param mode Identification mode. Can use Qgis default settings or a defined mode. Default mode is DefaultQgsSetting.
+    @return true if identification succeeded and a feature has been found, false otherwise.*/
+    bool identify(int x, int y, QList<QgsMapLayer*> layerList = QList<QgsMapLayer*>(), IdentifyMode mode = DefaultQgsSetting);
+
+    /** Performs the identification.
+    To avoid beeing forced to specify IdentifyMode with a list of layers
+    this has been made private and two publics methods are offered
+    @param x x coordinates of mouseEvent
+    @param y y coordinates of mouseEvent
+    @param mode Identification mode. Can use Qgis default settings or a defined mode.
+    @param layerType Only performs identification in a certain type of layers (raster, vector). Default value is AllLayers.
+    @return true if identification succeeded and a feature has been found, false otherwise.*/
+    bool identify(int x, int y, IdentifyMode mode, LayerType layerType = AllLayers);
+
+    /** Access to results */
+    IdentifyResults &results();
+
+  signals:
+    void identifyProgress( int, int );
+    void identifyMessage( QString );
+
+  private:
+    /** Performs the identification.
+    To avoid beeing forced to specify IdentifyMode with a list of layers
+    this has been made private and two publics methods are offered
+    @param x x coordinates of mouseEvent
+    @param y y coordinates of mouseEvent
+    @param mode Identification mode. Can use Qgis default settings or a defined mode.
+    @param layerList Performs the identification within the given list of layers.
+    @param layerType Only performs identification in a certain type of layers (raster, vector).
+    @return true if identification succeeded and a feature has been found, false otherwise.*/
+    bool identify(int x, int y, IdentifyMode mode, QList<QgsMapLayer*> layerList, LayerType layerType = AllLayers);
+    
+    bool identifyLayer( QgsMapLayer *layer, int x, int y, LayerType layerType = AllLayers );
+    bool identifyRasterLayer( QgsRasterLayer *layer, int x, int y );
+    bool identifyVectorLayer( QgsVectorLayer *layer, int x, int y );
+
+    //! Private helper
+    virtual void convertMeasurement( QgsDistanceArea &calc, double &measure, QGis::UnitType &u, bool isArea );
+
+    /** Transforms the measurements of derived attributes in the desired units*/
+    virtual QGis::UnitType displayUnits();
+};

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -38,7 +38,7 @@ SET(QGIS_APP_SRCS
   qgsfieldcalculator.cpp
   qgsfieldsproperties.cpp
   qgsgraduatedsymboldialog.cpp
-  qgsidentifyresults.cpp
+  qgsidentifyresultsdialog.cpp
   qgsfeatureaction.cpp
   qgslabeldialog.cpp
   qgslabelpropertydialog.cpp
@@ -62,7 +62,7 @@ SET(QGIS_APP_SRCS
   qgsmaptoolhtmlannotation.cpp
   qgsmaptoolpinlabels.cpp
   qgsmaptoolshowhidelabels.cpp
-  qgsmaptoolidentify.cpp
+  qgsmaptoolidentifyaction.cpp
   qgsmaptoollabel.cpp
   qgsmaptoolmeasureangle.cpp
   qgsmaptoolmovefeature.cpp
@@ -203,7 +203,7 @@ SET (QGIS_APP_MOC_HDRS
   qgsformannotationdialog.h
   qgshtmlannotationdialog.h
   qgsgraduatedsymboldialog.h
-  qgsidentifyresults.h
+  qgsidentifyresultsdialog.h
   qgslabeldialog.h
   qgslabelengineconfigdialog.h
   qgslabelinggui.h
@@ -222,7 +222,7 @@ SET (QGIS_APP_MOC_HDRS
   qgsmaptoolfeatureaction.h
   qgsmaptoolpinlabels.h
   qgsmaptoolshowhidelabels.h
-  qgsmaptoolidentify.h
+  qgsmaptoolidentifyaction.h
   qgsmaptoolmeasureangle.h
   qgsmaptoolmovefeature.h
   qgsmaptoolmovelabel.h

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -224,7 +224,7 @@
 #include "qgsmaptoolfeatureaction.h"
 #include "qgsmaptoolformannotation.h"
 #include "qgsmaptoolhtmlannotation.h"
-#include "qgsmaptoolidentify.h"
+#include "qgsmaptoolidentifyaction.h"
 #include "qgsmaptoolmeasureangle.h"
 #include "qgsmaptoolmovefeature.h"
 #include "qgsmaptoolrotatefeature.h"
@@ -1861,7 +1861,7 @@ void QgisApp::createCanvasTools()
   mMapTools.mTouch = new QgsMapToolTouch( mMapCanvas );
   mMapTools.mTouch->setAction( mActionTouch );
 #endif
-  mMapTools.mIdentify = new QgsMapToolIdentify( mMapCanvas );
+  mMapTools.mIdentify = new QgsMapToolIdentifyAction( mMapCanvas );
   mMapTools.mIdentify->setAction( mActionIdentify );
   mMapTools.mFeatureAction = new QgsMapToolFeatureAction( mMapCanvas );
   mMapTools.mFeatureAction->setAction( mActionFeatureAction );

--- a/src/app/qgsfeatureaction.cpp
+++ b/src/app/qgsfeatureaction.cpp
@@ -18,7 +18,7 @@
 #include "qgsfeatureaction.h"
 #include "qgsvectorlayer.h"
 #include "qgsvectordataprovider.h"
-#include "qgsidentifyresults.h"
+#include "qgsidentifyresultsdialog.h"
 #include "qgsattributedialog.h"
 #include "qgslogger.h"
 

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -16,7 +16,7 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "qgsidentifyresults.h"
+#include "qgsidentifyresultsdialog.h"
 #include "qgsapplication.h"
 #include "qgisapp.h"
 #include "qgsmaplayer.h"
@@ -114,7 +114,7 @@ class QgsIdentifyResultsDock : public QDockWidget
 //       action
 //     name value
 
-QgsIdentifyResults::QgsIdentifyResults( QgsMapCanvas *canvas, QWidget *parent, Qt::WFlags f )
+QgsIdentifyResultsDialog::QgsIdentifyResultsDialog( QgsMapCanvas *canvas, QWidget *parent, Qt::WFlags f )
     : QDialog( parent, f )
     , mActionPopup( 0 )
     , mCanvas( canvas )
@@ -157,14 +157,14 @@ QgsIdentifyResults::QgsIdentifyResults( QgsMapCanvas *canvas, QWidget *parent, Q
            this, SLOT( printCurrentItem() ) );
 }
 
-QgsIdentifyResults::~QgsIdentifyResults()
+QgsIdentifyResultsDialog::~QgsIdentifyResultsDialog()
 {
   clearHighlights();
   if ( mActionPopup )
     delete mActionPopup;
 }
 
-QTreeWidgetItem *QgsIdentifyResults::layerItem( QObject *layer )
+QTreeWidgetItem *QgsIdentifyResultsDialog::layerItem( QObject *layer )
 {
   for ( int i = 0; i < lstResults->topLevelItemCount(); i++ )
   {
@@ -177,7 +177,7 @@ QTreeWidgetItem *QgsIdentifyResults::layerItem( QObject *layer )
   return 0;
 }
 
-void QgsIdentifyResults::addFeature( QgsVectorLayer *vlayer,
+void QgsIdentifyResultsDialog::addFeature( QgsVectorLayer *vlayer,
                                      const QgsFeature &f,
                                      const QMap<QString, QString> &derivedAttributes )
 {
@@ -290,7 +290,7 @@ void QgsIdentifyResults::addFeature( QgsVectorLayer *vlayer,
   highlightFeature( featItem );
 }
 
-void QgsIdentifyResults::addFeature( QgsRasterLayer *layer,
+void QgsIdentifyResultsDialog::addFeature( QgsRasterLayer *layer,
                                      QString label,
                                      const QMap<QString, QString> &attributes,
                                      const QMap<QString, QString> &derivedAttributes )
@@ -345,7 +345,7 @@ void QgsIdentifyResults::addFeature( QgsRasterLayer *layer,
   }
 }
 
-void QgsIdentifyResults::editingToggled()
+void QgsIdentifyResultsDialog::editingToggled()
 {
   QTreeWidgetItem *layItem = layerItem( sender() );
   QgsVectorLayer *vlayer = vectorLayer( layItem );
@@ -380,7 +380,7 @@ void QgsIdentifyResults::editingToggled()
 }
 
 // Call to show the dialog box.
-void QgsIdentifyResults::show()
+void QgsIdentifyResultsDialog::show()
 {
   // Enforce a few things before showing the dialog box
   lstResults->sortItems( 0, Qt::AscendingOrder );
@@ -424,7 +424,7 @@ void QgsIdentifyResults::show()
 
 // Slot called when user clicks the Close button
 // (saves the current window size/position)
-void QgsIdentifyResults::close()
+void QgsIdentifyResultsDialog::close()
 {
   clear();
 
@@ -439,14 +439,14 @@ void QgsIdentifyResults::close()
 
 // Save the current window size/position before closing
 // from window menu or X in titlebar
-void QgsIdentifyResults::closeEvent( QCloseEvent *e )
+void QgsIdentifyResultsDialog::closeEvent( QCloseEvent *e )
 {
   // We'll close in our own good time thanks...
   e->ignore();
   close();
 }
 
-void QgsIdentifyResults::itemClicked( QTreeWidgetItem *item, int column )
+void QgsIdentifyResultsDialog::itemClicked( QTreeWidgetItem *item, int column )
 {
   Q_UNUSED( column );
   if ( item->data( 0, Qt::UserRole ).toString() == "edit" )
@@ -464,7 +464,7 @@ void QgsIdentifyResults::itemClicked( QTreeWidgetItem *item, int column )
 // actions that can be applied to the data in the identify results
 // dialog box.
 
-void QgsIdentifyResults::contextMenuEvent( QContextMenuEvent* event )
+void QgsIdentifyResultsDialog::contextMenuEvent( QContextMenuEvent* event )
 {
   QTreeWidgetItem *item = lstResults->itemAt( lstResults->viewport()->mapFrom( this, event->pos() ) );
   // if the user clicked below the end of the attribute list, just return
@@ -535,25 +535,25 @@ void QgsIdentifyResults::contextMenuEvent( QContextMenuEvent* event )
 }
 
 // Save the current window location (store in ~/.qt/qgisrc)
-void QgsIdentifyResults::saveWindowLocation()
+void QgsIdentifyResultsDialog::saveWindowLocation()
 {
   QSettings settings;
   settings.setValue( "/Windows/Identify/geometry", saveGeometry() );
 }
 
-void QgsIdentifyResults::setColumnText( int column, const QString & label )
+void QgsIdentifyResultsDialog::setColumnText( int column, const QString & label )
 {
   QTreeWidgetItem* header = lstResults->headerItem();
   header->setText( column, label );
 }
 
-void QgsIdentifyResults::expandColumnsToFit()
+void QgsIdentifyResultsDialog::expandColumnsToFit()
 {
   lstResults->resizeColumnToContents( 0 );
   lstResults->resizeColumnToContents( 1 );
 }
 
-void QgsIdentifyResults::clearHighlights()
+void QgsIdentifyResultsDialog::clearHighlights()
 {
   foreach ( QgsHighlight *h, mHighlights )
   {
@@ -563,7 +563,7 @@ void QgsIdentifyResults::clearHighlights()
   mHighlights.clear();
 }
 
-void QgsIdentifyResults::clear()
+void QgsIdentifyResultsDialog::clear()
 {
   for ( int i = 0; i < lstResults->topLevelItemCount(); i++ )
   {
@@ -577,7 +577,7 @@ void QgsIdentifyResults::clear()
   mPrintToolButton->setHidden( true );
 }
 
-void QgsIdentifyResults::activate()
+void QgsIdentifyResultsDialog::activate()
 {
 #if 0
   foreach ( QgsRubberBand *rb, mRubberBands )
@@ -593,7 +593,7 @@ void QgsIdentifyResults::activate()
   }
 }
 
-void QgsIdentifyResults::deactivate()
+void QgsIdentifyResultsDialog::deactivate()
 {
 #if 0
   foreach ( QgsRubberBand *rb, mRubberBands )
@@ -603,7 +603,7 @@ void QgsIdentifyResults::deactivate()
 #endif
 }
 
-void QgsIdentifyResults::doAction( QTreeWidgetItem *item, int action )
+void QgsIdentifyResultsDialog::doAction( QTreeWidgetItem *item, int action )
 {
   QTreeWidgetItem *featItem = featureItem( item );
   if ( !featItem )
@@ -633,7 +633,7 @@ void QgsIdentifyResults::doAction( QTreeWidgetItem *item, int action )
   layer->actions()->doAction( action, mFeatures[ featIdx ], idx );
 }
 
-QTreeWidgetItem *QgsIdentifyResults::featureItem( QTreeWidgetItem *item )
+QTreeWidgetItem *QgsIdentifyResultsDialog::featureItem( QTreeWidgetItem *item )
 {
   if ( !item )
     return 0;
@@ -672,7 +672,7 @@ QTreeWidgetItem *QgsIdentifyResults::featureItem( QTreeWidgetItem *item )
   return featItem;
 }
 
-QTreeWidgetItem *QgsIdentifyResults::layerItem( QTreeWidgetItem *item )
+QTreeWidgetItem *QgsIdentifyResultsDialog::layerItem( QTreeWidgetItem *item )
 {
   if ( item && item->parent() )
   {
@@ -683,7 +683,7 @@ QTreeWidgetItem *QgsIdentifyResults::layerItem( QTreeWidgetItem *item )
 }
 
 
-QgsVectorLayer *QgsIdentifyResults::vectorLayer( QTreeWidgetItem *item )
+QgsVectorLayer *QgsIdentifyResultsDialog::vectorLayer( QTreeWidgetItem *item )
 {
   item = layerItem( item );
   if ( !item )
@@ -692,7 +692,7 @@ QgsVectorLayer *QgsIdentifyResults::vectorLayer( QTreeWidgetItem *item )
 }
 
 
-QTreeWidgetItem *QgsIdentifyResults::retrieveAttributes( QTreeWidgetItem *item, QgsAttributeMap &attributes, int &idx )
+QTreeWidgetItem *QgsIdentifyResultsDialog::retrieveAttributes( QTreeWidgetItem *item, QgsAttributeMap &attributes, int &idx )
 {
   QTreeWidgetItem *featItem = featureItem( item );
   if ( !featItem )
@@ -714,13 +714,13 @@ QTreeWidgetItem *QgsIdentifyResults::retrieveAttributes( QTreeWidgetItem *item, 
   return featItem;
 }
 
-void QgsIdentifyResults::itemExpanded( QTreeWidgetItem *item )
+void QgsIdentifyResultsDialog::itemExpanded( QTreeWidgetItem *item )
 {
   Q_UNUSED( item );
   expandColumnsToFit();
 }
 
-void QgsIdentifyResults::handleCurrentItemChanged( QTreeWidgetItem *current, QTreeWidgetItem *previous )
+void QgsIdentifyResultsDialog::handleCurrentItemChanged( QTreeWidgetItem *current, QTreeWidgetItem *previous )
 {
   Q_UNUSED( previous );
   if ( !current )
@@ -745,7 +745,7 @@ void QgsIdentifyResults::handleCurrentItemChanged( QTreeWidgetItem *current, QTr
   }
 }
 
-void QgsIdentifyResults::layerDestroyed()
+void QgsIdentifyResultsDialog::layerDestroyed()
 {
   QObject *theSender = sender();
 
@@ -771,7 +771,7 @@ void QgsIdentifyResults::layerDestroyed()
   }
 }
 
-void QgsIdentifyResults::disconnectLayer( QObject *layer )
+void QgsIdentifyResultsDialog::disconnectLayer( QObject *layer )
 {
   if ( !layer )
     return;
@@ -792,7 +792,7 @@ void QgsIdentifyResults::disconnectLayer( QObject *layer )
   }
 }
 
-void QgsIdentifyResults::featureDeleted( QgsFeatureId fid )
+void QgsIdentifyResultsDialog::featureDeleted( QgsFeatureId fid )
 {
   QTreeWidgetItem *layItem = layerItem( sender() );
 
@@ -822,7 +822,7 @@ void QgsIdentifyResults::featureDeleted( QgsFeatureId fid )
   }
 }
 
-void QgsIdentifyResults::attributeValueChanged( QgsFeatureId fid, int idx, const QVariant &val )
+void QgsIdentifyResultsDialog::attributeValueChanged( QgsFeatureId fid, int idx, const QVariant &val )
 {
   QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( sender() );
   QTreeWidgetItem *layItem = layerItem( sender() );
@@ -855,7 +855,7 @@ void QgsIdentifyResults::attributeValueChanged( QgsFeatureId fid, int idx, const
   }
 }
 
-void QgsIdentifyResults::highlightFeature( QTreeWidgetItem *item )
+void QgsIdentifyResultsDialog::highlightFeature( QTreeWidgetItem *item )
 {
   QgsVectorLayer *layer = vectorLayer( item );
   if ( !layer )
@@ -891,7 +891,7 @@ void QgsIdentifyResults::highlightFeature( QTreeWidgetItem *item )
   }
 }
 
-void QgsIdentifyResults::zoomToFeature()
+void QgsIdentifyResultsDialog::zoomToFeature()
 {
   QTreeWidgetItem *item = lstResults->currentItem();
 
@@ -929,7 +929,7 @@ void QgsIdentifyResults::zoomToFeature()
   mCanvas->refresh();
 }
 
-void QgsIdentifyResults::featureForm()
+void QgsIdentifyResultsDialog::featureForm()
 {
   QTreeWidgetItem *item = lstResults->currentItem();
 
@@ -962,7 +962,7 @@ void QgsIdentifyResults::featureForm()
   }
 }
 
-void QgsIdentifyResults::highlightAll()
+void QgsIdentifyResultsDialog::highlightAll()
 {
   for ( int i = 0; i < lstResults->topLevelItemCount(); i++ )
   {
@@ -975,12 +975,12 @@ void QgsIdentifyResults::highlightAll()
   }
 }
 
-void QgsIdentifyResults::highlightLayer()
+void QgsIdentifyResultsDialog::highlightLayer()
 {
   highlightLayer( lstResults->currentItem() );
 }
 
-void QgsIdentifyResults::highlightLayer( QTreeWidgetItem *item )
+void QgsIdentifyResultsDialog::highlightLayer( QTreeWidgetItem *item )
 {
   QTreeWidgetItem *layItem = layerItem( item );
   if ( !layItem )
@@ -994,12 +994,12 @@ void QgsIdentifyResults::highlightLayer( QTreeWidgetItem *item )
   }
 }
 
-void QgsIdentifyResults::layerProperties()
+void QgsIdentifyResultsDialog::layerProperties()
 {
   layerProperties( lstResults->currentItem() );
 }
 
-void QgsIdentifyResults::layerProperties( QTreeWidgetItem *item )
+void QgsIdentifyResultsDialog::layerProperties( QTreeWidgetItem *item )
 {
   QgsVectorLayer *vlayer = vectorLayer( item );
   if ( !vlayer )
@@ -1008,17 +1008,17 @@ void QgsIdentifyResults::layerProperties( QTreeWidgetItem *item )
   QgisApp::instance()->showLayerProperties( vlayer );
 }
 
-void QgsIdentifyResults::expandAll()
+void QgsIdentifyResultsDialog::expandAll()
 {
   lstResults->expandAll();
 }
 
-void QgsIdentifyResults::collapseAll()
+void QgsIdentifyResultsDialog::collapseAll()
 {
   lstResults->collapseAll();
 }
 
-void QgsIdentifyResults::copyAttributeValue()
+void QgsIdentifyResultsDialog::copyAttributeValue()
 {
   QClipboard *clipboard = QApplication::clipboard();
   QString text = lstResults->currentItem()->data( 1, Qt::DisplayRole ).toString();
@@ -1026,7 +1026,7 @@ void QgsIdentifyResults::copyAttributeValue()
   clipboard->setText( text );
 }
 
-void QgsIdentifyResults::copyFeatureAttributes()
+void QgsIdentifyResultsDialog::copyFeatureAttributes()
 {
   QClipboard *clipboard = QApplication::clipboard();
   QString text;
@@ -1054,7 +1054,7 @@ void QgsIdentifyResults::copyFeatureAttributes()
   clipboard->setText( text );
 }
 
-void QgsIdentifyResults::openUrl( const QUrl &url )
+void QgsIdentifyResultsDialog::openUrl( const QUrl &url )
 {
   if ( !QDesktopServices::openUrl( url ) )
   {
@@ -1062,7 +1062,7 @@ void QgsIdentifyResults::openUrl( const QUrl &url )
   }
 }
 
-void QgsIdentifyResults::printCurrentItem()
+void QgsIdentifyResultsDialog::printCurrentItem()
 {
   QTreeWidgetItem *item = lstResults->currentItem();
   if ( !item )
@@ -1078,7 +1078,7 @@ void QgsIdentifyResults::printCurrentItem()
     wv->print( &printer );
 }
 
-void QgsIdentifyResults:: on_mExpandNewToolButton_toggled( bool checked )
+void QgsIdentifyResultsDialog:: on_mExpandNewToolButton_toggled( bool checked )
 {
   QSettings settings;
   settings.setValue( "/Map/identifyExpand", checked );

--- a/src/app/qgsidentifyresultsdialog.h
+++ b/src/app/qgsidentifyresultsdialog.h
@@ -15,8 +15,8 @@
  *   (at your option) any later version.                                   *
  *                                                                         *
  ***************************************************************************/
-#ifndef QGSIDENTIFYRESULTS_H
-#define QGSIDENTIFYRESULTS_H
+#ifndef QGSIDENTIFYRESULTSDIALOG_H
+#define QGSIDENTIFYRESULTSDIALOG_H
 
 #include "ui_qgsidentifyresultsbase.h"
 #include "qgsattributeaction.h"
@@ -42,7 +42,7 @@ class QDockWidget;
  *@author Gary E.Sherman
  */
 
-class QgsIdentifyResults: public QDialog, private Ui::QgsIdentifyResultsBase
+class QgsIdentifyResultsDialog: public QDialog, private Ui::QgsIdentifyResultsBase
 {
     Q_OBJECT
 
@@ -50,9 +50,9 @@ class QgsIdentifyResults: public QDialog, private Ui::QgsIdentifyResultsBase
 
     //! Constructor - takes it own copy of the QgsAttributeAction so
     // that it is independent of whoever created it.
-    QgsIdentifyResults( QgsMapCanvas *canvas, QWidget *parent = 0, Qt::WFlags f = 0 );
+    QgsIdentifyResultsDialog( QgsMapCanvas *canvas, QWidget *parent = 0, Qt::WFlags f = 0 );
 
-    ~QgsIdentifyResults();
+    ~QgsIdentifyResultsDialog();
 
     /** Add add feature from vector layer */
     void addFeature( QgsVectorLayer *layer,

--- a/src/app/qgsmaptoolidentifyaction.cpp
+++ b/src/app/qgsmaptoolidentifyaction.cpp
@@ -1,0 +1,139 @@
+/***************************************************************************
+    qgsmaptoolidentify.cpp  -  map tool for identifying features
+    ---------------------
+    begin                : January 2006
+    copyright            : (C) 2006 by Martin Dobias
+    email                : wonder.sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgscursors.h"
+#include "qgsdistancearea.h"
+#include "qgsfeature.h"
+#include "qgsfield.h"
+#include "qgsgeometry.h"
+#include "qgslogger.h"
+#include "qgsidentifyresultsdialog.h"
+#include "qgsmapcanvas.h"
+#include "qgsmaptopixel.h"
+#include "qgsmessageviewer.h"
+#include "qgsmaptoolidentifyaction.h"
+#include "qgsrasterlayer.h"
+#include "qgscoordinatereferencesystem.h"
+#include "qgsvectordataprovider.h"
+#include "qgsvectorlayer.h"
+#include "qgsproject.h"
+#include "qgsmaplayerregistry.h"
+#include "qgisapp.h"
+#include "qgsrendererv2.h"
+
+#include <QSettings>
+#include <QMessageBox>
+#include <QMouseEvent>
+#include <QCursor>
+#include <QPixmap>
+#include <QStatusBar>
+#include <QVariant>
+
+QgsMapToolIdentifyAction::QgsMapToolIdentifyAction( QgsMapCanvas* canvas )
+    : QgsMapToolIdentify( canvas )
+{
+  // set cursor
+  QPixmap myIdentifyQPixmap = QPixmap(( const char ** ) identify_cursor );
+  mCursor = QCursor( myIdentifyQPixmap, 1, 1 );
+}
+
+QgsMapToolIdentifyAction::~QgsMapToolIdentifyAction()
+{
+  if ( mResultsDialog )
+  {
+    mResultsDialog->done( 0 );
+  }
+}
+
+QgsIdentifyResultsDialog *QgsMapToolIdentifyAction::resultsDialog()
+{
+  if ( !mResultsDialog )
+    mResultsDialog = new QgsIdentifyResultsDialog( mCanvas, mCanvas->window() );
+
+  return mResultsDialog;
+}
+
+void QgsMapToolIdentifyAction::canvasMoveEvent( QMouseEvent *e )
+{
+  Q_UNUSED( e );
+}
+
+void QgsMapToolIdentifyAction::canvasPressEvent( QMouseEvent *e )
+{
+  Q_UNUSED( e );
+}
+
+void QgsMapToolIdentifyAction::canvasReleaseEvent( QMouseEvent *e )
+{
+    if ( !mCanvas || mCanvas->isDrawing() )
+    {
+      return;
+    }
+
+    resultsDialog()->clear();
+
+    connect( this, SIGNAL( identifyProgress( int, int ) ), QgisApp::instance(), SLOT( showProgress( int, int ) ) );
+    connect( this, SIGNAL( identifyMessage( QString ) ), QgisApp::instance(), SLOT( showStatusMessage( QString ) ) );
+    bool res = QgsMapToolIdentify::identify(e->x(), e->y() );
+    disconnect( this, SIGNAL( identifyProgress( int, int ) ), QgisApp::instance(), SLOT( showProgress( int, int ) ) );
+    disconnect( this, SIGNAL( identifyMessage( QString ) ), QgisApp::instance(), SLOT( showStatusMessage( QString ) ) );
+
+
+    QList<VectorResult>::const_iterator vresult;
+    for ( vresult = results().mVectorResults.begin(); vresult != results().mVectorResults.end(); ++vresult)
+        resultsDialog()->addFeature( vresult->mLayer, vresult->mFeature, vresult->mDerivedAttributes);
+    QList<RasterResult>::const_iterator rresult;
+    for ( rresult = results().mRasterResults.begin(); rresult != results().mRasterResults.end(); ++rresult)
+        resultsDialog()->addFeature( rresult->mLayer, rresult->mLabel, rresult->mAttributes, rresult->mDerivedAttributes);
+
+  if ( res )
+  {
+    resultsDialog()->show();
+  }
+  else
+  {
+    QSettings mySettings;
+    bool myDockFlag = mySettings.value( "/qgis/dockIdentifyResults", false ).toBool();
+    if ( !myDockFlag )
+    {
+      resultsDialog()->hide();
+    }
+    else
+    {
+      resultsDialog()->clear();
+    }
+    QgisApp::instance()->statusBar()->showMessage( tr( "No features at this position found." ) );
+  }
+}
+
+void QgsMapToolIdentifyAction::activate()
+{
+  resultsDialog()->activate();
+  QgsMapTool::activate();
+}
+
+void QgsMapToolIdentifyAction::deactivate()
+{
+  resultsDialog()->deactivate();
+  QgsMapTool::deactivate();
+}
+
+QGis::UnitType QgsMapToolIdentifyAction::displayUnits()
+{
+    // Get the units for display
+    QSettings settings;
+    return QGis::fromLiteral( settings.value( "/qgis/measure/displayunits", QGis::toLiteral( QGis::Meters ) ).toString() );
+}
+

--- a/src/app/qgsmaptoolidentifyaction.h
+++ b/src/app/qgsmaptoolidentifyaction.h
@@ -13,11 +13,11 @@
  *                                                                         *
  ***************************************************************************/
 
-#ifndef QGSMAPTOOLIDENTIFY_H
-#define QGSMAPTOOLIDENTIFY_H
+#ifndef QGSMAPTOOLIDENTIFYACTION_H
+#define QGSMAPTOOLIDENTIFYACTION_H
 
 #include "qgis.h"
-#include "qgsmaptool.h"
+#include "qgsmaptoolidentify.h"
 #include "qgspoint.h"
 #include "qgsfeature.h"
 #include "qgsdistancearea.h"
@@ -25,28 +25,28 @@
 #include <QObject>
 #include <QPointer>
 
-class QgsIdentifyResults;
+class QgsIdentifyResultsDialog;
 class QgsMapLayer;
 class QgsRasterLayer;
 class QgsRubberBand;
 class QgsVectorLayer;
 
 /**
-  \brief Map tool for identifying features in current layer
+  \brief Map tool for identifying features layers and showing results
 
   after selecting a point shows dialog with identification results
   - for raster layers shows value of underlying pixel
   - for vector layers shows feature attributes within search radius
     (allows to edit values when vector layer is in editing mode)
 */
-class QgsMapToolIdentify : public QgsMapTool
+class QgsMapToolIdentifyAction : public QgsMapToolIdentify
 {
     Q_OBJECT
 
   public:
-    QgsMapToolIdentify( QgsMapCanvas* canvas );
+    QgsMapToolIdentifyAction( QgsMapCanvas* canvas );
 
-    ~QgsMapToolIdentify();
+    ~QgsMapToolIdentifyAction();
 
     //! Overridden mouse move event
     virtual void canvasMoveEvent( QMouseEvent * e );
@@ -71,17 +71,16 @@ class QgsMapToolIdentify : public QgsMapTool
     bool identifyVectorLayer( QgsVectorLayer *layer, int x, int y );
 
     //! Pointer to the identify results dialog for name/value pairs
-    QPointer<QgsIdentifyResults> mResults;
-
-    //! Private helper
-    void convertMeasurement( QgsDistanceArea &calc, double &measure, QGis::UnitType &u, bool isArea );
+    QPointer<QgsIdentifyResultsDialog> mResultsDialog;
 
     void addFeature( QgsMapLayer *layer, int fid,
                      QString displayField, QString displayValue,
                      const QMap< QString, QString > &attributes,
                      const QMap< QString, QString > &derivedAttributes );
 
-    QgsIdentifyResults *results();
+    QgsIdentifyResultsDialog *resultsDialog();
+
+    virtual QGis::UnitType displayUnits();
 };
 
 #endif

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -72,6 +72,7 @@ qgsmapoverviewcanvas.cpp
 qgsmaptip.cpp
 qgsmaptool.cpp
 qgsmaptoolemitpoint.cpp
+qgsmaptoolidentify.cpp
 qgsmaptoolpan.cpp
 qgsmaptoolzoom.cpp
 qgsmessagebar.cpp
@@ -169,6 +170,7 @@ qgsmanageconnectionsdialog.h
 qgsmapcanvas.h
 qgsmapoverviewcanvas.h
 qgsmaptoolemitpoint.h
+qgsmaptoolidentify.h
 qgsmessagebar.h
 qgsmessageviewer.h
 qgsmessagelogviewer.h
@@ -213,6 +215,7 @@ qgsmapcanvassnapper.h
 qgsmapoverviewcanvas.h
 qgsmaptool.h
 qgsmaptoolemitpoint.h
+qgsmaptoolidentify.h
 qgsmaptoolpan.h
 qgsmaptoolzoom.h
 qgsmessagebar.h

--- a/src/gui/qgsmaptoolidentify.cpp
+++ b/src/gui/qgsmaptoolidentify.cpp
@@ -19,18 +19,17 @@
 #include "qgsfield.h"
 #include "qgsgeometry.h"
 #include "qgslogger.h"
-#include "qgsidentifyresults.h"
 #include "qgsmapcanvas.h"
+#include "qgsmaptoolidentify.h"
 #include "qgsmaptopixel.h"
 #include "qgsmessageviewer.h"
-#include "qgsmaptoolidentify.h"
+#include "qgsmaplayer.h"
 #include "qgsrasterlayer.h"
 #include "qgscoordinatereferencesystem.h"
 #include "qgsvectordataprovider.h"
 #include "qgsvectorlayer.h"
 #include "qgsproject.h"
 #include "qgsmaplayerregistry.h"
-#include "qgisapp.h"
 #include "qgsrendererv2.h"
 
 #include <QSettings>
@@ -51,18 +50,6 @@ QgsMapToolIdentify::QgsMapToolIdentify( QgsMapCanvas* canvas )
 
 QgsMapToolIdentify::~QgsMapToolIdentify()
 {
-  if ( mResults )
-  {
-    mResults->done( 0 );
-  }
-}
-
-QgsIdentifyResults *QgsMapToolIdentify::results()
-{
-  if ( !mResults )
-    mResults = new QgsIdentifyResults( mCanvas, mCanvas->window() );
-
-  return mResults;
 }
 
 void QgsMapToolIdentify::canvasMoveEvent( QMouseEvent *e )
@@ -77,48 +64,72 @@ void QgsMapToolIdentify::canvasPressEvent( QMouseEvent *e )
 
 void QgsMapToolIdentify::canvasReleaseEvent( QMouseEvent *e )
 {
-  if ( !mCanvas || mCanvas->isDrawing() )
-  {
-    return;
-  }
+    Q_UNUSED( e );
+}
 
-  results()->clear();
+bool QgsMapToolIdentify::identify(int x, int y, QList<QgsMapLayer *> layerList, IdentifyMode mode)
+{
+    return identify(x, y, mode, layerList, AllLayers);
+}
 
-  QSettings settings;
-  int identifyMode = settings.value( "/Map/identifyMode", 0 ).toInt();
+bool QgsMapToolIdentify::identify(int x, int y, IdentifyMode mode, LayerType layerType)
+{
+    return identify(x, y, mode, QList<QgsMapLayer*>(), layerType);
+}
 
+bool QgsMapToolIdentify::identify(int x, int y, IdentifyMode mode, QList<QgsMapLayer*> layerList, LayerType layerType )
+{
   bool res = false;
 
-  if ( identifyMode == 0 )
+  if ( !mCanvas || mCanvas->isDrawing() )
+  {
+    return res;
+  }
+
+  mResultData.mVectorResults.clear();
+  mResultData.mRasterResults.clear();
+
+  if (mode == DefaultQgsSetting)
+  {
+    QSettings settings;
+    mode = static_cast<IdentifyMode>( settings.value( "/Map/identifyMode", 0 ).toInt() );
+  }
+
+  if ( mode == ActiveLayer && ~layerList.isEmpty())
   {
     QgsMapLayer *layer = mCanvas->currentLayer();
 
     if ( !layer )
     {
-      QMessageBox::warning( mCanvas,
-                            tr( "No active layer" ),
-                            tr( "To identify features, you must choose an active layer by clicking on its name in the legend" ) );
-      return;
+      emit identifyMessage( tr( "No active layer. To identify features, you must choose an active layer." ) );
+      return res;
     }
 
     QApplication::setOverrideCursor( Qt::WaitCursor );
 
-    res = identifyLayer( layer, e->x(), e->y() );
-
-    QApplication::restoreOverrideCursor();
+    res = identifyLayer( layer, x, y, layerType );
   }
   else
   {
-    connect( this, SIGNAL( identifyProgress( int, int ) ), QgisApp::instance(), SLOT( showProgress( int, int ) ) );
-    connect( this, SIGNAL( identifyMessage( QString ) ), QgisApp::instance(), SLOT( showStatusMessage( QString ) ) );
-
     QApplication::setOverrideCursor( Qt::WaitCursor );
 
     QStringList noIdentifyLayerIdList = QgsProject::instance()->readListEntry( "Identify", "/disabledLayers" );
 
-    for ( int i = 0; i < mCanvas->layerCount(); i++ )
+    int layerCount;
+    if (layerList.isEmpty())
+        layerCount = mCanvas->layerCount();
+    else
+        layerCount = layerList.count();
+
+
+    for ( int i = 0; i < layerCount; i++ )
     {
-      QgsMapLayer *layer = mCanvas->layer( i );
+
+      QgsMapLayer *layer ;
+      if (layerList.isEmpty())
+          layer = mCanvas->layer( i );
+      else
+          layer = layerList.value( i );
 
       emit identifyProgress( i, mCanvas->layerCount() );
       emit identifyMessage( tr( "Identifying on %1..." ).arg( layer->name() ) );
@@ -126,69 +137,47 @@ void QgsMapToolIdentify::canvasReleaseEvent( QMouseEvent *e )
       if ( noIdentifyLayerIdList.contains( layer->id() ) )
         continue;
 
-      if ( identifyLayer( layer, e->x(), e->y() ) )
+      if ( identifyLayer( layer, x, y, layerType ) )
       {
         res = true;
-        if ( identifyMode == 1 )
+        if ( mode == TopDownStopAtFirst )
           break;
       }
     }
 
     emit identifyProgress( mCanvas->layerCount(), mCanvas->layerCount() );
     emit identifyMessage( tr( "Identifying done." ) );
-
-    disconnect( this, SIGNAL( identifyProgress( int, int ) ), QgisApp::instance(), SLOT( showProgress( int, int ) ) );
-    disconnect( this, SIGNAL( identifyMessage( QString ) ), QgisApp::instance(), SLOT( showStatusMessage( QString ) ) );
-
-    QApplication::restoreOverrideCursor();
   }
 
-  if ( res )
-  {
-    results()->show();
-  }
-  else
-  {
-    QSettings mySettings;
-    bool myDockFlag = mySettings.value( "/qgis/dockIdentifyResults", false ).toBool();
-    if ( !myDockFlag )
-    {
-      results()->hide();
-    }
-    else
-    {
-      results()->clear();
-    }
-    QgisApp::instance()->statusBar()->showMessage( tr( "No features at this position found." ) );
-  }
+  QApplication::restoreOverrideCursor();
+
+  return res;
 }
 
 void QgsMapToolIdentify::activate()
 {
-  results()->activate();
   QgsMapTool::activate();
 }
 
 void QgsMapToolIdentify::deactivate()
 {
-  results()->deactivate();
   QgsMapTool::deactivate();
 }
 
-bool QgsMapToolIdentify::identifyLayer( QgsMapLayer *layer, int x, int y )
+bool QgsMapToolIdentify::identifyLayer( QgsMapLayer *layer, int x, int y, LayerType layerType )
 {
-  bool res = false;
-
-  if ( layer->type() == QgsMapLayer::RasterLayer )
+  if ( layer->type() == QgsMapLayer::RasterLayer && (layerType==AllLayers || layerType==RasterLayer))
   {
-    res = identifyRasterLayer( qobject_cast<QgsRasterLayer *>( layer ), x, y );
+    return identifyRasterLayer( qobject_cast<QgsRasterLayer *>( layer ), x, y );
+  }
+  else if ( layer->type() == QgsMapLayer::VectorLayer && (layerType==AllLayers || layerType==VectorLayer))
+  {
+    return identifyVectorLayer( qobject_cast<QgsVectorLayer *>( layer ), x, y );
   }
   else
   {
-    res = identifyVectorLayer( qobject_cast<QgsVectorLayer *>( layer ), x, y );
+    return false;
   }
-
-  return res;
 }
 
 
@@ -333,7 +322,7 @@ bool QgsMapToolIdentify::identifyVectorLayer( QgsVectorLayer *layer, int x, int 
 
     derivedAttributes.insert( tr( "feature id" ), fid < 0 ? tr( "new feature" ) : FID_TO_STRING( fid ) );
 
-    results()->addFeature( layer, *f_it, derivedAttributes );
+    mResultData.mVectorResults.append( VectorResult(layer, *f_it, derivedAttributes));
   }
 
   if ( renderer && renderer->capabilities() & QgsFeatureRendererV2::ScaleDependent )
@@ -415,12 +404,11 @@ bool QgsMapToolIdentify::identifyRasterLayer( QgsRasterLayer *layer, int x, int 
   if ( attributes.size() > 0 )
   {
     derivedAttributes.insert( tr( "(clicked coordinate)" ), idPoint.toString() );
-    results()->addFeature( layer, type, attributes, derivedAttributes );
+    mResultData.mRasterResults.append( RasterResult(layer, type, attributes, derivedAttributes));
   }
 
   return res;
 }
-
 
 void QgsMapToolIdentify::convertMeasurement( QgsDistanceArea &calc, double &measure, QGis::UnitType &u, bool isArea )
 {
@@ -430,10 +418,16 @@ void QgsMapToolIdentify::convertMeasurement( QgsDistanceArea &calc, double &meas
   // Get the canvas units
   QGis::UnitType myUnits = mCanvas->mapUnits();
 
-  // Get the units for display
-  QSettings settings;
-  QGis::UnitType displayUnits = QGis::fromLiteral( settings.value( "/qgis/measure/displayunits", QGis::toLiteral( QGis::Meters ) ).toString() );
-
-  calc.convertMeasurement( measure, myUnits, displayUnits, isArea );
+  calc.convertMeasurement( measure, myUnits, displayUnits(), isArea );
   u = myUnits;
+}
+
+QGis::UnitType QgsMapToolIdentify::displayUnits()
+{
+    return mCanvas->mapUnits();
+}
+
+QgsMapToolIdentify::IdentifyResults &QgsMapToolIdentify::results()
+{
+    return mResultData;
 }

--- a/src/gui/qgsmaptoolidentify.h
+++ b/src/gui/qgsmaptoolidentify.h
@@ -1,0 +1,161 @@
+/***************************************************************************
+    qgsmaptoolidentify.h  -  map tool for identifying features
+    ---------------------
+    begin                : January 2006
+    copyright            : (C) 2006 by Martin Dobias
+    email                : wonder.sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSMAPTOOLIDENTIFY_H
+#define QGSMAPTOOLIDENTIFY_H
+
+
+#include "qgsmaptool.h"
+#include "qgspoint.h"
+#include "qgsfeature.h"
+#include "qgsdistancearea.h"
+#include "qgsmaplayer.h"
+
+#include <QObject>
+#include <QPointer>
+
+class QgsRasterLayer;
+class QgsVectorLayer;
+class QgsMapCanvas;
+
+/**
+  \brief Map tool for identifying features in layers
+
+  after selecting a point, performs the identification:
+  - for raster layers shows value of underlying pixel
+  - for vector layers shows feature attributes within search radius
+    (allows to edit values when vector layer is in editing mode)
+*/
+class QgsMapToolIdentify : public QgsMapTool
+{
+    Q_OBJECT
+
+  public:
+
+    enum IdentifyMode
+    {
+        DefaultQgsSetting=-1,
+        ActiveLayer,
+        TopDownStopAtFirst,
+        TopDownAll
+    };
+
+    enum LayerType
+    {
+        AllLayers=-1,
+        VectorLayer,
+        RasterLayer
+    };
+
+    struct VectorResult
+    {
+        VectorResult(){}
+        VectorResult(QgsVectorLayer * layer, QgsFeature feature, QMap< QString, QString > derivedAttributes):
+            mLayer( layer ), mFeature( feature ), mDerivedAttributes( derivedAttributes )  {}
+        QgsVectorLayer* mLayer;
+        QgsFeature mFeature;
+        QMap< QString, QString > mDerivedAttributes;
+    };
+
+    struct RasterResult
+    {
+        RasterResult(){}
+        RasterResult( QgsRasterLayer * layer, QString label, QMap< QString, QString > attributes, QMap< QString, QString > derivedAttributes):
+            mLayer( layer ), mLabel( label ), mAttributes( attributes ), mDerivedAttributes( derivedAttributes )  {}
+        QgsRasterLayer* mLayer;
+        QString mLabel;
+        QMap< QString, QString > mAttributes;
+        QMap< QString, QString > mDerivedAttributes;
+    };
+
+    struct IdentifyResults
+    {
+        IdentifyResults(){}
+        IdentifyResults ( QList<VectorResult> vectorResults , QList<RasterResult> rasterResults) :
+            mVectorResults( vectorResults),
+            mRasterResults( rasterResults )
+        {}
+        QList<VectorResult> mVectorResults;
+        QList<RasterResult> mRasterResults;
+    };
+
+    //! constructor
+    QgsMapToolIdentify( QgsMapCanvas* canvas );
+
+    virtual ~QgsMapToolIdentify();
+
+    //! Overridden mouse move event
+    virtual void canvasMoveEvent( QMouseEvent * e );
+
+    //! Overridden mouse press event
+    virtual void canvasPressEvent( QMouseEvent * e );
+
+    //! Overridden mouse release event
+    virtual void canvasReleaseEvent( QMouseEvent * e );
+
+    virtual void activate();
+
+    virtual void deactivate();
+
+    /** Performs the identification.
+    @param x x coordinates of mouseEvent
+    @param y y coordinates of mouseEvent
+    @param layerList Performs the identification within the given list of layers. Default value is an empty list, i.e. uses all the layers.
+    @param mode Identification mode. Can use Qgis default settings or a defined mode. Default mode is DefaultQgsSetting.
+    @return true if identification succeeded and a feature has been found, false otherwise.*/
+    bool identify(int x, int y, QList<QgsMapLayer*> layerList = QList<QgsMapLayer*>(), IdentifyMode mode = DefaultQgsSetting);
+
+    /** Performs the identification.
+    To avoid beeing forced to specify IdentifyMode with a list of layers
+    this has been made private and two publics methods are offered
+    @param x x coordinates of mouseEvent
+    @param y y coordinates of mouseEvent
+    @param mode Identification mode. Can use Qgis default settings or a defined mode.
+    @param layerType Only performs identification in a certain type of layers (raster, vector). Default value is AllLayers.
+    @return true if identification succeeded and a feature has been found, false otherwise.*/
+    bool identify(int x, int y, IdentifyMode mode, LayerType layerType = AllLayers);
+
+    /** Access to results */
+    IdentifyResults &results();
+
+  signals:
+    void identifyProgress( int, int );
+    void identifyMessage( QString );
+
+  private:
+    /** Performs the identification.
+    To avoid beeing forced to specify IdentifyMode with a list of layers
+    this has been made private and two publics methods are offered
+    @param x x coordinates of mouseEvent
+    @param y y coordinates of mouseEvent
+    @param mode Identification mode. Can use Qgis default settings or a defined mode.
+    @param layerList Performs the identification within the given list of layers.
+    @param layerType Only performs identification in a certain type of layers (raster, vector).
+    @return true if identification succeeded and a feature has been found, false otherwise.*/
+    bool identify(int x, int y, IdentifyMode mode,  QList<QgsMapLayer*> layerList, LayerType layerType = AllLayers);
+    bool identifyLayer( QgsMapLayer *layer, int x, int y, LayerType layerType = AllLayers );
+    bool identifyRasterLayer( QgsRasterLayer *layer, int x, int y );
+    bool identifyVectorLayer( QgsVectorLayer *layer, int x, int y );
+
+    //! Private helper
+    virtual void convertMeasurement( QgsDistanceArea &calc, double &measure, QGis::UnitType &u, bool isArea );
+
+    /** Transforms the measurements of derived attributes in the desired units*/
+    virtual QGis::UnitType displayUnits();
+
+    IdentifyResults mResultData;
+};
+
+#endif


### PR DESCRIPTION
app/QgsMapToolIdentify class has been separated in two:

gui/QgsMapToolIdentify for the generic identification process
app/QgsMapToolIdentifyAction for app specific (shows the dialog)

app/QgsIdentifyResults rename to app/QgsIdentifyResultsDialog

sip files added for QgsMapToolIdentify

The identify method can be called with parameters:

Identify mode (default setting or active layer, or top-down, or stop at first)
List of layers
Type of layer
A great thanks to Matthias Kuhn for his great support and advice.
