### PR TITLE
[Feature] add HTML capabilities to composer labels

### DIFF
--- a/src/app/composer/qgscomposerlabelwidget.cpp
+++ b/src/app/composer/qgscomposerlabelwidget.cpp
@@ -32,10 +32,50 @@ QgsComposerLabelWidget::QgsComposerLabelWidget( QgsComposerLabel* label ): QWidg
   QgsComposerItemWidget* itemPropertiesWidget = new QgsComposerItemWidget( this, label );
   toolBox->addItem( itemPropertiesWidget, tr( "General options" ) );
 
+
   if ( mComposerLabel )
   {
     setGuiElementValues();
     connect( mComposerLabel, SIGNAL( itemChanged() ), this, SLOT( setGuiElementValues() ) );
+  }
+}
+
+void QgsComposerLabelWidget::on_mHtmlCheckBox_stateChanged( int state )
+{
+  if ( mComposerLabel )
+  {
+    if (state)
+    {
+      mFontButton->setEnabled( false );
+      mFontColorButton->setEnabled( false );
+      mHorizontalAlignementGroup->setEnabled( false );
+      mVerticalAlignementGroup->setEnabled( false );
+      mMarginDoubleSpinBox->setEnabled( false );
+      mRotationSpinBox->setEnabled( false );
+      mComposerLabel->beginCommand( tr( "Label text HTML state changed" ), QgsComposerMergeCommand::ComposerLabelSetText );
+      mComposerLabel->blockSignals( true );
+      //mComposerLabel->setHtml(state);
+      mComposerLabel->setText( mTextEdit->toPlainText() );
+      mComposerLabel->update();
+      mComposerLabel->blockSignals( false );
+      mComposerLabel->endCommand();
+    }
+    else
+    {
+      mFontButton->setEnabled( true );
+      mFontColorButton->setEnabled( true );
+      mHorizontalAlignementGroup->setEnabled( true );
+      mVerticalAlignementGroup->setEnabled( true );
+      mMarginDoubleSpinBox->setEnabled( true );
+      mRotationSpinBox->setEnabled( true );
+      mComposerLabel->beginCommand( tr( "Label text HTML state changed" ), QgsComposerMergeCommand::ComposerLabelSetText );
+      mComposerLabel->blockSignals( true );
+      //mComposerLabel->setHtml(state);
+      mComposerLabel->setText( mTextEdit->toPlainText() );
+      mComposerLabel->update();
+      mComposerLabel->blockSignals( false );
+      mComposerLabel->endCommand();
+    }
   }
 }
 

--- a/src/app/composer/qgscomposerlabelwidget.cpp
+++ b/src/app/composer/qgscomposerlabelwidget.cpp
@@ -50,15 +50,6 @@ void QgsComposerLabelWidget::on_mHtmlCheckBox_stateChanged( int state )
       mFontColorButton->setEnabled( false );
       mHorizontalAlignementGroup->setEnabled( false );
       mVerticalAlignementGroup->setEnabled( false );
-      mMarginDoubleSpinBox->setEnabled( false );
-      mRotationSpinBox->setEnabled( false );
-      mComposerLabel->beginCommand( tr( "Label text HTML state changed" ), QgsComposerMergeCommand::ComposerLabelSetText );
-      mComposerLabel->blockSignals( true );
-      //mComposerLabel->setHtml(state);
-      mComposerLabel->setText( mTextEdit->toPlainText() );
-      mComposerLabel->update();
-      mComposerLabel->blockSignals( false );
-      mComposerLabel->endCommand();
     }
     else
     {
@@ -66,16 +57,15 @@ void QgsComposerLabelWidget::on_mHtmlCheckBox_stateChanged( int state )
       mFontColorButton->setEnabled( true );
       mHorizontalAlignementGroup->setEnabled( true );
       mVerticalAlignementGroup->setEnabled( true );
-      mMarginDoubleSpinBox->setEnabled( true );
-      mRotationSpinBox->setEnabled( true );
-      mComposerLabel->beginCommand( tr( "Label text HTML state changed" ), QgsComposerMergeCommand::ComposerLabelSetText );
-      mComposerLabel->blockSignals( true );
-      //mComposerLabel->setHtml(state);
-      mComposerLabel->setText( mTextEdit->toPlainText() );
-      mComposerLabel->update();
-      mComposerLabel->blockSignals( false );
-      mComposerLabel->endCommand();
     }
+
+    mComposerLabel->beginCommand( tr( "Label text HTML state changed" ), QgsComposerMergeCommand::ComposerLabelSetText );
+    mComposerLabel->blockSignals( true );
+    mComposerLabel->setHtmlSate(state);
+    mComposerLabel->setText( mTextEdit->toPlainText() );
+    mComposerLabel->update();
+    mComposerLabel->blockSignals( false );
+    mComposerLabel->endCommand();
   }
 }
 
@@ -263,9 +253,10 @@ void QgsComposerLabelWidget::on_mRotationSpinBox_valueChanged( double v )
 void QgsComposerLabelWidget::setGuiElementValues()
 {
   blockAllSignals( true );
-  mTextEdit->setText( mComposerLabel->text() );
+  mTextEdit->setPlainText( mComposerLabel->text() );
   mTextEdit->moveCursor( QTextCursor::End, QTextCursor::MoveAnchor );
   mMarginDoubleSpinBox->setValue( mComposerLabel->margin() );
+  mHtmlCheckBox->setChecked( mComposerLabel->htmlSate() );
   mTopRadioButton->setChecked( mComposerLabel->vAlign() == Qt::AlignTop );
   mMiddleRadioButton->setChecked( mComposerLabel->vAlign() == Qt::AlignVCenter );
   mBottomRadioButton->setChecked( mComposerLabel->vAlign() == Qt::AlignBottom );
@@ -279,6 +270,7 @@ void QgsComposerLabelWidget::setGuiElementValues()
 void QgsComposerLabelWidget::blockAllSignals( bool block )
 {
   mTextEdit->blockSignals( block );
+  mHtmlCheckBox->blockSignals( block );
   mMarginDoubleSpinBox->blockSignals( block );
   mTopRadioButton->blockSignals( block );
   mMiddleRadioButton->blockSignals( block );

--- a/src/app/composer/qgscomposerlabelwidget.h
+++ b/src/app/composer/qgscomposerlabelwidget.h
@@ -32,6 +32,7 @@ class QgsComposerLabelWidget: public QWidget, private Ui::QgsComposerLabelWidget
     QgsComposerLabelWidget( QgsComposerLabel* label );
 
   public slots:
+    void on_mHtmlCheckBox_stateChanged( int i );
     void on_mTextEdit_textChanged();
     void on_mFontButton_clicked();
     void on_mInsertExpressionButton_clicked();

--- a/src/core/composer/qgscomposerhtml.cpp
+++ b/src/core/composer/qgscomposerhtml.cpp
@@ -103,7 +103,7 @@ double QgsComposerHtml::htmlUnitsToMM()
     return 1.0;
   }
 
-  return ( mComposition->printResolution() / 96.0 ); //webkit seems to assume a standard dpi of 96
+  return ( mComposition->printResolution() / 72.0 ); //webkit seems to assume a standard dpi of 96
 }
 
 void QgsComposerHtml::addFrame( QgsComposerFrame* frame, bool recalcFrameSizes )

--- a/src/core/composer/qgscomposerlabel.cpp
+++ b/src/core/composer/qgscomposerlabel.cpp
@@ -61,6 +61,13 @@ void QgsComposerLabel::paint( QPainter* painter, const QStyleOptionGraphicsItem*
     painter->scale( 1.0 / mHtmlUnitsToMM, 1.0 / mHtmlUnitsToMM );
 
     QWebPage* webPage = new QWebPage();
+
+    //This makes the background transparent. Found on http://blog.qt.digia.com/blog/2009/06/30/transparent-qwebview-or-qwebpage/
+    QPalette palette = webPage->palette();
+    palette.setBrush(QPalette::Base, Qt::transparent);
+    webPage->setPalette(palette);
+    //webPage->setAttribute(Qt::WA_OpaquePaintEvent, false); //this does not compile, why ?
+
     webPage->setViewportSize( QSize(painterRect.width() * mHtmlUnitsToMM, painterRect.height() * mHtmlUnitsToMM) );
     webPage->mainFrame()->setScrollBarPolicy( Qt::Horizontal, Qt::ScrollBarAlwaysOff );
     webPage->mainFrame()->setScrollBarPolicy( Qt::Vertical, Qt::ScrollBarAlwaysOff );

--- a/src/core/composer/qgscomposerlabel.cpp
+++ b/src/core/composer/qgscomposerlabel.cpp
@@ -58,7 +58,7 @@ void QgsComposerLabel::paint( QPainter* painter, const QStyleOptionGraphicsItem*
 
   if( mHtmlState )
   {
-    painter->scale( 1.0 / mHtmlUnitsToMM, 1.0 / mHtmlUnitsToMM );
+    painter->scale( 1.0 / mHtmlUnitsToMM / 10.0, 1.0 / mHtmlUnitsToMM / 10.0 );
 
     QWebPage* webPage = new QWebPage();
 
@@ -68,7 +68,8 @@ void QgsComposerLabel::paint( QPainter* painter, const QStyleOptionGraphicsItem*
     webPage->setPalette(palette);
     //webPage->setAttribute(Qt::WA_OpaquePaintEvent, false); //this does not compile, why ?
 
-    webPage->setViewportSize( QSize(painterRect.width() * mHtmlUnitsToMM, painterRect.height() * mHtmlUnitsToMM) );
+    webPage->setViewportSize( QSize(painterRect.width() * mHtmlUnitsToMM * 10.0, painterRect.height() * mHtmlUnitsToMM * 10.0) );
+    webPage->mainFrame()->setZoomFactor( 10.0 );
     webPage->mainFrame()->setScrollBarPolicy( Qt::Horizontal, Qt::ScrollBarAlwaysOff );
     webPage->mainFrame()->setScrollBarPolicy( Qt::Vertical, Qt::ScrollBarAlwaysOff );
     webPage->mainFrame()->setHtml( displayText() );

--- a/src/core/composer/qgscomposerlabel.cpp
+++ b/src/core/composer/qgscomposerlabel.cpp
@@ -107,7 +107,7 @@ double QgsComposerLabel::htmlUnitsToMM()
   }
 
   //TODO : fix this more precisely so that the label's default text size is the same with or without "display as html"
-  return ( mComposition->printResolution() / 96.0 ); //webkit seems to assume a standard dpi of 96
+  return ( mComposition->printResolution() / 72.0 ); //webkit seems to assume a standard dpi of 72
 }
 
 void QgsComposerLabel::setText( const QString& text )

--- a/src/core/composer/qgscomposerlabel.cpp
+++ b/src/core/composer/qgscomposerlabel.cpp
@@ -59,24 +59,17 @@ void QgsComposerLabel::paint( QPainter* painter, const QStyleOptionGraphicsItem*
   if( mHtmlState )
   {
     painter->scale( 1.0 / mHtmlUnitsToMM, 1.0 / mHtmlUnitsToMM );
-    //painter->translate( 0.0, -renderExtent.top() * mHtmlUnitsToMM );
+
     QWebPage* webPage = new QWebPage();
-    /*
-    TODO : http://blog.qt.digia.com/blog/2009/06/30/transparent-qwebview-or-qwebpage/
-    is it possible ?
-    */
     webPage->setViewportSize( QSize(painterRect.width() * mHtmlUnitsToMM, painterRect.height() * mHtmlUnitsToMM) );
     webPage->mainFrame()->setScrollBarPolicy( Qt::Horizontal, Qt::ScrollBarAlwaysOff );
     webPage->mainFrame()->setScrollBarPolicy( Qt::Vertical, Qt::ScrollBarAlwaysOff );
     webPage->mainFrame()->setHtml( displayText() );
-    webPage->mainFrame()->render( painter );
-    //webPage->mainFrame()->render( painter, QRegion( painterRect.left(), painterRect.top() * mHtmlUnitsToMM, painterRect.width(), painterRect.height() ) );
-    //webPage->mainFrame()->render( painter, QRegion( painterRect.left(), painterRect.top() * mHtmlUnitsToMM, painterRect.width() * mHtmlUnitsToMM, painterRect.height() * mHtmlUnitsToMM ) );
-    //DELETE WEBPAGE ?
+    webPage->mainFrame()->render( painter );//DELETE WEBPAGE ?
   }
   else
   {
-    painter->setPen( QPen( QColor( mFontColor ) ) ); //draw all text black
+    painter->setPen( QPen( QColor( mFontColor ) ) );
     painter->setFont( mFont );
 
     QFontMetricsF fontSize( mFont );
@@ -106,6 +99,7 @@ double QgsComposerLabel::htmlUnitsToMM()
     return 1.0;
   }
 
+  //TODO : fix this more precisely so that the label's default text size is the same with or without "display as html"
   return ( mComposition->printResolution() / 96.0 ); //webkit seems to assume a standard dpi of 96
 }
 

--- a/src/core/composer/qgscomposerlabel.h
+++ b/src/core/composer/qgscomposerlabel.h
@@ -44,6 +44,9 @@ class CORE_EXPORT QgsComposerLabel: public QgsComposerItem
     QString text() { return mText; }
     void setText( const QString& text );
 
+    int htmlSate() { return mHtmlState; }
+    void setHtmlSate( int state ) {mHtmlState = state;}
+
     /**Returns the text as it appears on screen (with replaced data field)
       @note this function was added in version 1.2*/
     QString displayText() const;
@@ -103,6 +106,11 @@ class CORE_EXPORT QgsComposerLabel: public QgsComposerItem
   private:
     // Text
     QString mText;
+
+    // Html state
+    int mHtmlState;
+    double mHtmlUnitsToMM;
+    double htmlUnitsToMM(); //calculate scale factor
 
     // Font
     QFont mFont;

--- a/src/ui/qgscomposerhtmlwidgetbase.ui
+++ b/src/ui/qgscomposerhtmlwidgetbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>243</width>
-    <height>116</height>
+    <height>153</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -24,30 +24,46 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>225</width>
-        <height>72</height>
+        <width>221</width>
+        <height>100</height>
        </rect>
       </property>
       <attribute name="label">
        <string>HTML</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout">
-       <item row="1" column="2">
+       <item row="2" column="2">
         <widget class="QToolButton" name="mFileToolButton">
          <property name="text">
           <string>...</string>
          </property>
         </widget>
        </item>
-       <item row="1" column="1">
+       <item row="2" column="1">
         <widget class="QLineEdit" name="mUrlLineEdit"/>
        </item>
-       <item row="1" column="0">
+       <item row="2" column="0">
         <widget class="QLabel" name="mUrlLabel">
          <property name="text">
           <string>URL</string>
          </property>
         </widget>
+       </item>
+       <item row="0" column="1" colspan="2">
+        <widget class="QComboBox" name="mResizeModeComboBox"/>
+       </item>
+       <item row="3" column="1">
+        <spacer name="verticalSpacer">
+         <property name="orientation">
+          <enum>Qt::Vertical</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>20</width>
+           <height>40</height>
+          </size>
+         </property>
+        </spacer>
        </item>
        <item row="0" column="0">
         <widget class="QLabel" name="mResizeModeLabel">
@@ -55,9 +71,6 @@
           <string>Resize mode</string>
          </property>
         </widget>
-       </item>
-       <item row="0" column="1" colspan="2">
-        <widget class="QComboBox" name="mResizeModeComboBox"/>
        </item>
       </layout>
      </widget>

--- a/src/ui/qgscomposerlabelwidgetbase.ui
+++ b/src/ui/qgscomposerlabelwidgetbase.ui
@@ -234,7 +234,11 @@
         </widget>
        </item>
        <item row="0" column="0" colspan="2">
-        <widget class="QPlainTextEdit" name="mTextEdit"/>
+        <widget class="QPlainTextEdit" name="mTextEdit">
+         <property name="tabStopWidth">
+          <number>10</number>
+         </property>
+        </widget>
        </item>
       </layout>
      </widget>

--- a/src/ui/qgscomposerlabelwidgetbase.ui
+++ b/src/ui/qgscomposerlabelwidgetbase.ui
@@ -38,20 +38,6 @@
        <string>Label</string>
       </attribute>
       <layout class="QGridLayout" name="gridLayout">
-       <item row="0" column="0" colspan="2">
-        <widget class="QTextEdit" name="mTextEdit">
-         <property name="lineWrapMode">
-          <enum>QTextEdit::WidgetWidth</enum>
-         </property>
-         <property name="html">
-          <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
-&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
-p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:7.8pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:8pt;&quot;&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
-         </property>
-        </widget>
-       </item>
        <item row="7" column="1">
         <widget class="QDoubleSpinBox" name="mMarginDoubleSpinBox">
          <property name="prefix">
@@ -247,6 +233,9 @@ p, li { white-space: pre-wrap; }
          </property>
         </widget>
        </item>
+       <item row="0" column="0" colspan="2">
+        <widget class="QPlainTextEdit" name="mTextEdit"/>
+       </item>
       </layout>
      </widget>
     </widget>
@@ -255,7 +244,6 @@ p, li { white-space: pre-wrap; }
  </widget>
  <layoutdefault spacing="6" margin="11"/>
  <tabstops>
-  <tabstop>mTextEdit</tabstop>
   <tabstop>mFontButton</tabstop>
   <tabstop>mMarginDoubleSpinBox</tabstop>
  </tabstops>

--- a/src/ui/qgscomposerlabelwidgetbase.ui
+++ b/src/ui/qgscomposerlabelwidgetbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>307</width>
-    <height>525</height>
+    <width>443</width>
+    <height>550</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -30,7 +30,7 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>276</width>
+        <width>400</width>
         <height>503</height>
        </rect>
       </property>
@@ -43,47 +43,83 @@
          <property name="lineWrapMode">
           <enum>QTextEdit::WidgetWidth</enum>
          </property>
+         <property name="html">
+          <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
+&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+p, li { white-space: pre-wrap; }
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'MS Shell Dlg 2'; font-size:7.8pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot;-qt-paragraph-type:empty; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:8pt;&quot;&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         </property>
         </widget>
        </item>
-       <item row="3" column="0" colspan="2">
-        <widget class="QPushButton" name="mFontColorButton">
+       <item row="7" column="1">
+        <widget class="QDoubleSpinBox" name="mMarginDoubleSpinBox">
+         <property name="prefix">
+          <string/>
+         </property>
+         <property name="suffix">
+          <string> mm</string>
+         </property>
+        </widget>
+       </item>
+       <item row="8" column="0">
+        <widget class="QLabel" name="mRotationLabel">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="text">
-          <string>Font color...</string>
+          <string>Rotation</string>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
+         <property name="buddy">
+          <cstring>mRotationSpinBox</cstring>
          </property>
         </widget>
        </item>
-       <item row="4" column="0" colspan="2">
-        <widget class="QGroupBox" name="buttonGroup1">
-         <property name="title">
-          <string>Horizontal Alignment:</string>
+       <item row="8" column="1">
+        <widget class="QDoubleSpinBox" name="mRotationSpinBox">
+         <property name="suffix">
+          <string> °</string>
          </property>
-         <layout class="QHBoxLayout" name="horizontalLayout">
-          <property name="sizeConstraint">
-           <enum>QLayout::SetMinimumSize</enum>
-          </property>
+         <property name="maximum">
+          <double>360.000000000000000</double>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0" colspan="2">
+        <widget class="QPushButton" name="mInsertExpressionButton">
+         <property name="text">
+          <string>Insert an expression</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0" colspan="2">
+        <widget class="QCheckBox" name="mHtmlCheckBox">
+         <property name="text">
+          <string>Render as HTML</string>
+         </property>
+        </widget>
+       </item>
+       <item row="7" column="0">
+        <widget class="QLabel" name="mMarginLabel">
+         <property name="text">
+          <string>Margin</string>
+         </property>
+        </widget>
+       </item>
+       <item row="6" column="0" colspan="2">
+        <widget class="QGroupBox" name="mVerticalAlignementGroup">
+         <property name="title">
+          <string>Vertical Alignment:</string>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout_2">
           <item>
-           <widget class="QRadioButton" name="mLeftRadioButton">
-            <property name="text">
-             <string>Left</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QRadioButton" name="mCenterRadioButton">
-            <property name="text">
-             <string>Center</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <widget class="QRadioButton" name="mRightRadioButton">
-            <property name="text">
-             <string>Right</string>
-            </property>
-           </widget>
-          </item>
-          <item>
-           <spacer name="horizontalSpacer">
+           <spacer name="horizontalSpacer_3">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
             </property>
@@ -95,15 +131,6 @@
             </property>
            </spacer>
           </item>
-         </layout>
-        </widget>
-       </item>
-       <item row="5" column="0" colspan="2">
-        <widget class="QGroupBox" name="buttonGroup2">
-         <property name="title">
-          <string>Vertical Alignment:</string>
-         </property>
-         <layout class="QHBoxLayout" name="horizontalLayout_2">
           <item>
            <widget class="QRadioButton" name="mTopRadioButton">
             <property name="text">
@@ -126,6 +153,65 @@
            </widget>
           </item>
           <item>
+           <spacer name="horizontalSpacer_4">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item row="5" column="0" colspan="2">
+        <widget class="QGroupBox" name="mHorizontalAlignementGroup">
+         <property name="title">
+          <string>Horizontal Alignment:</string>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout">
+          <property name="sizeConstraint">
+           <enum>QLayout::SetMinimumSize</enum>
+          </property>
+          <item>
+           <spacer name="horizontalSpacer">
+            <property name="orientation">
+             <enum>Qt::Horizontal</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>40</width>
+              <height>20</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="mLeftRadioButton">
+            <property name="text">
+             <string>Left</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="mCenterRadioButton">
+            <property name="text">
+             <string>Center</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QRadioButton" name="mRightRadioButton">
+            <property name="text">
+             <string>Right</string>
+            </property>
+           </widget>
+          </item>
+          <item>
            <spacer name="horizontalSpacer_2">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
@@ -141,43 +227,14 @@
          </layout>
         </widget>
        </item>
-       <item row="6" column="0" colspan="2">
-        <widget class="QDoubleSpinBox" name="mMarginDoubleSpinBox">
-         <property name="prefix">
-          <string>Margin </string>
-         </property>
-         <property name="suffix">
-          <string>mm</string>
-         </property>
-        </widget>
-       </item>
-       <item row="7" column="0">
-        <widget class="QLabel" name="mRotationLabel">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
+       <item row="3" column="1">
+        <widget class="QPushButton" name="mFontColorButton">
          <property name="text">
-          <string>Rotation</string>
-         </property>
-         <property name="wordWrap">
-          <bool>true</bool>
-         </property>
-         <property name="buddy">
-          <cstring>mRotationSpinBox</cstring>
+          <string>Font color...</string>
          </property>
         </widget>
        </item>
-       <item row="7" column="1">
-        <widget class="QDoubleSpinBox" name="mRotationSpinBox">
-         <property name="maximum">
-          <double>360.000000000000000</double>
-         </property>
-        </widget>
-       </item>
-       <item row="2" column="0" colspan="2">
+       <item row="3" column="0">
         <widget class="QPushButton" name="mFontButton">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
@@ -187,13 +244,6 @@
          </property>
          <property name="text">
           <string>Font</string>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="0" colspan="2">
-        <widget class="QPushButton" name="mInsertExpressionButton">
-         <property name="text">
-          <string>Insert an expression</string>
          </property>
         </widget>
        </item>
@@ -207,7 +257,6 @@
  <tabstops>
   <tabstop>mTextEdit</tabstop>
   <tabstop>mFontButton</tabstop>
-  <tabstop>mFontColorButton</tabstop>
   <tabstop>mMarginDoubleSpinBox</tabstop>
  </tabstops>
  <resources/>


### PR DESCRIPTION
Hi !

This adds a "render as html" checkbox to composer labels.

I think this features is a little bit overlapping with the html composer item, but :
1) unifying the HTML tool in the normal label seems logical: it still is a label, only a formatted one;
2) it is different in that you can use expressions;
3) it would be possible to implement html composer's item features (display an external page) in the new label tool.

This allows to make some advanced composition. For instance, you could display comma separated values as a table by replacing the comma by &lt;/td>&lt;td>.

![htmlFeature](https://f.cloud.github.com/assets/1894106/107835/d9229348-6a39-11e2-9291-d3f237a3ee97.png)
