### PR TITLE
restore "stretch using current extent" functionality in layer context menu

### DIFF
--- a/src/app/legend/qgslegend.cpp
+++ b/src/app/legend/qgslegend.cpp
@@ -2773,7 +2773,10 @@ void QgsLegend::legendLayerStretchUsingCurrentExtent()
       layer->setContrastEnhancementAlgorithm( "StretchToMinimumMaximum" );
     }
 
-    layer->setMinimumMaximumUsingLastExtent();
+    QgsRectangle myRectangle;
+    myRectangle = mMapCanvas->mapRenderer()->outputExtentToLayerExtent( layer, mMapCanvas->extent() );
+    layer->setContrastEnhancementAlgorithm( layer->contrastEnhancementAlgorithm(), QgsRasterLayer::ContrastEnhancementMinMax, myRectangle );
+
     layer->setCacheImage( NULL );
     refreshLayerSymbology( layer->id() );
     mMapCanvas->refresh();


### PR DESCRIPTION
Fix  for #7070 (http://hub.qgis.org/issues/7070)
