### PR TITLE
Update stage-installed plugins CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -83,7 +83,7 @@ IF (WITH_BINDINGS)
   # as otherwise user has to use PYTHONPATH environemnt variable to add
   # QGIS bindings to package search path
   SET (BINDINGS_GLOBAL_INSTALL FALSE CACHE BOOL "Install bindings to global python directory? (might need root)")
-  SET (WITH_STAGED_PLUGINS TRUE CACHE BOOL "Stage-install core Python plugins to run from build directory? (utilities, console and installer are always staged)")
+  SET (WITH_STAGED_PLUGINS TRUE CACHE BOOL "Stage-install core Python plugins to run from build directory? (utilities and console are always staged)")
   SET (WITH_PY_COMPILE FALSE CACHE BOOL "Determines whether Python modules in staged or installed locations are byte-compiled")
   # concatenate QScintilla2 API files
   SET (WITH_QSCIAPI TRUE CACHE BOOL "Determines whether the QScintilla2 API files will be updated and concatenated")

--- a/python/plugins/CMakeLists.txt
+++ b/python/plugins/CMakeLists.txt
@@ -1,29 +1,75 @@
-IF(WITH_PY_COMPILE)
-  ADD_CUSTOM_TARGET(pycompile_staged ALL
-    COMMAND ${PYTHON_EXECUTABLE} -m compileall -q "${PYTHON_OUTPUT_DIRECTORY}/plugins"
-    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
-    COMMENT "Byte-compiling staged Python plugins..."
-  )
-ENDIF(WITH_PY_COMPILE)
+# Python plugins can be staged to PYTHON_OUTPUT_DIRECTORY so plugins
+# will function when app is run from build directory
+
+# When staging all plugins, use the following make targets:
+#   staged_plugins - stage plugins (usually after repo pull/build and project make)
+#   staged_plugins_pyc - stage and byte-compile all Python scripts
+#   clean_staged_plugins - removes the plugins directory and all contents
+#
+# When developing on a plugin, use the following make targets:
+#   staged_[plugin_dir_name] - stage specific plugin, regenerating any changed resources
+#   clean_staged_[plugin_dir_name] - removes the plugin directory and its contents
+#
+# NOTE: regular project 'make install' is unaffected
+
+ADD_CUSTOM_TARGET(staged_plugins)
+
+ADD_CUSTOM_TARGET(staged_plugins_pyc DEPENDS staged_plugins
+  COMMAND ${PYTHON_EXECUTABLE} -m compileall -q "${PYTHON_OUTPUT_DIRECTORY}/plugins"
+  WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+  COMMENT "Byte-compiling staged Python plugins..."
+)
+
+# plugins can also be staged with CMake option at build time
+IF(WITH_STAGED_PLUGINS)
+  IF(WITH_PY_COMPILE)
+    ADD_CUSTOM_TARGET(staged_plugins_on_build ALL DEPENDS staged_plugins_pyc)
+  ELSE(WITH_PY_COMPILE)
+    ADD_CUSTOM_TARGET(staged_plugins_on_build ALL DEPENDS staged_plugins)
+  ENDIF(WITH_PY_COMPILE)
+ENDIF(WITH_STAGED_PLUGINS)
+
+ADD_CUSTOM_TARGET(clean_staged_plugins
+  COMMAND ${CMAKE_COMMAND} -E remove_directory ${PYTHON_OUTPUT_DIRECTORY}/plugins
+)
 
 MACRO (PLUGIN_INSTALL plugin subdir )
+
+  # regular project build's install command and target
   INSTALL(FILES ${ARGN} DESTINATION ${QGIS_DATA_DIR}/python/plugins/${plugin}/${subdir})
   STRING(REPLACE "/" "_" subdir_sane "${subdir}")
-  ADD_CUSTOM_TARGET(${plugin}_${subdir_sane}_stageinstall ALL DEPENDS ${ARGN})
-  IF(WITH_STAGED_PLUGINS OR "${plugin}" STREQUAL "plugin_installer")
-    IF(WITH_PY_COMPILE)
-      ADD_DEPENDENCIES(pycompile_staged ${plugin}_${subdir_sane}_stageinstall)
-    ENDIF(WITH_PY_COMPILE)
-    FOREACH(file ${ARGN})
-      ADD_CUSTOM_COMMAND(TARGET ${plugin}_${subdir_sane}_stageinstall
-        POST_BUILD
-        COMMAND ${CMAKE_COMMAND} -E make_directory ${PYTHON_OUTPUT_DIRECTORY}/plugins/${plugin}/${subdir}
-        COMMAND ${CMAKE_COMMAND} -E copy \"${file}\" ${PYTHON_OUTPUT_DIRECTORY}/plugins/${plugin}/${subdir}
-        WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
-        #COMMENT "copying ${file} to ${PYTHON_OUTPUT_DIRECTORY}/plugins/${plugin}/${subdir}"
-      )
-    ENDFOREACH(file)
-  ENDIF()
+  IF(WITH_STAGED_PLUGINS)
+    ADD_CUSTOM_TARGET(${plugin}_${subdir_sane} DEPENDS ${ARGN})
+  ELSE(WITH_STAGED_PLUGINS)
+    ADD_CUSTOM_TARGET(${plugin}_${subdir_sane} ALL DEPENDS ${ARGN})
+  ENDIF(WITH_STAGED_PLUGINS)
+
+  # for staged plugin install (to run from build directory)
+  ADD_CUSTOM_TARGET(${plugin}_${subdir_sane}_stageinstall DEPENDS ${ARGN})
+  ADD_CUSTOM_COMMAND(TARGET ${plugin}_${subdir_sane}_stageinstall
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E make_directory ${PYTHON_OUTPUT_DIRECTORY}/plugins/${plugin}/${subdir}
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+  )
+  FOREACH(file ${ARGN})
+    ADD_CUSTOM_COMMAND(TARGET ${plugin}_${subdir_sane}_stageinstall
+      POST_BUILD
+      COMMAND ${CMAKE_COMMAND} -E copy_if_different \"${file}\" ${PYTHON_OUTPUT_DIRECTORY}/plugins/${plugin}/${subdir}
+      WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+      #COMMENT "copying ${file} to ${PYTHON_OUTPUT_DIRECTORY}/plugins/${plugin}/${subdir}"
+    )
+  ENDFOREACH(file)
+  ADD_DEPENDENCIES(staged_plugins ${plugin}_${subdir_sane}_stageinstall)
+
+  IF(TARGET staged_${plugin})
+    ADD_DEPENDENCIES(staged_${plugin} ${plugin}_${subdir_sane}_stageinstall)
+  ELSE(TARGET staged_${plugin})
+    ADD_CUSTOM_TARGET(staged_${plugin} DEPENDS ${plugin}_${subdir_sane}_stageinstall)
+    ADD_CUSTOM_TARGET(clean_staged_${plugin}
+      COMMAND ${CMAKE_COMMAND} -E remove_directory ${PYTHON_OUTPUT_DIRECTORY}/plugins/${plugin}
+    )
+  ENDIF(TARGET staged_${plugin})
+
 ENDMACRO (PLUGIN_INSTALL)
 
 


### PR DESCRIPTION
Changes how staged plugins are built (resources generated and copied to [build dir]/output/python/plugins).

When _staging_ all plugins, use the following _make targets_:
-  **staged_plugins** - stage plugins (usually after repo pull/build and project make)
-  **staged_plugins_pyc** - stage and byte-compile all Python scripts
-  **clean_staged_plugins** - removes the plugins directory and all contents

When _developing_ on a plugin, use the following _make targets_:
-  **staged_[plugin_dir_name]** - stage specific plugin, regenerating any changed resources
-  **clean_staged_[plugin_dir_name]** - removes the plugin directory and its contents

CMake options WITH_STAGED_PLUGINS and WITH_PY_COMPILE are still valid and just run _staged_plugins_ and _staged_plugins_pyc_ respectively as part of a regular project build.

In the newly available workflow for running app from build directory, leaving WITH_STAGED_PLUGINS=FALSE (should be as default now?), all above targets are still generated, but not built as part of ALL target. This allows a developer to set up their IDE with custom build process steps like so:
- make
- make staged_plugins (_optional_)
- make install (_optional_)

with _make staged_plugins_ capable of being built anytime after project build, making those project builds as fast as possible, as done here with QtCreator project setup:

![make_staged_plugins](https://f.cloud.github.com/assets/1295919/122081/4cf36540-6e2c-11e2-98c8-1afa7141e75b.png)
