### PR TITLE
Maptoolidentify: return results and IdentifyResult

### DIFF
--- a/python/gui/qgsmaptoolidentify.sip
+++ b/python/gui/qgsmaptoolidentify.sip
@@ -74,7 +74,7 @@ class QgsMapToolIdentify : QgsMapTool
     @param layerList Performs the identification within the given list of layers. Default value is an empty list, i.e. uses all the layers.
     @param mode Identification mode. Can use Qgis default settings or a defined mode. Default mode is DefaultQgsSetting.
     @return true if identification succeeded and a feature has been found, false otherwise.*/
-    bool identify(int x, int y, QList<QgsMapLayer*> layerList = QList<QgsMapLayer*>(), IdentifyMode mode = DefaultQgsSetting);
+    IdentifyResults identify(int x, int y, QList<QgsMapLayer*> layerList = QList<QgsMapLayer*>(), IdentifyMode mode = DefaultQgsSetting);
 
     /** Performs the identification.
     To avoid beeing forced to specify IdentifyMode with a list of layers
@@ -84,10 +84,7 @@ class QgsMapToolIdentify : QgsMapTool
     @param mode Identification mode. Can use Qgis default settings or a defined mode.
     @param layerType Only performs identification in a certain type of layers (raster, vector). Default value is AllLayers.
     @return true if identification succeeded and a feature has been found, false otherwise.*/
-    bool identify(int x, int y, IdentifyMode mode, LayerType layerType = AllLayers);
-
-    /** Access to results */
-    IdentifyResults &results();
+    IdentifyResults identify(int x, int y, IdentifyMode mode, LayerType layerType = AllLayers);
 
   signals:
     void identifyProgress( int, int );

--- a/python/gui/qgsmaptoolidentify.sip
+++ b/python/gui/qgsmaptoolidentify.sip
@@ -20,34 +20,24 @@ class QgsMapToolIdentify : QgsMapTool
         VectorLayer,
         RasterLayer,
     };
-
-    struct VectorResult
-    {
-        VectorResult();
-        VectorResult(QgsVectorLayer* layer, QgsFeature feature, QMap< QString, QString > derivedAttributes);
-        QgsVectorLayer* mLayer;
-        QgsFeature mFeature;
-        QMap< QString, QString > mDerivedAttributes;
-    };
     
-    struct RasterResult
+
+    struct IdentifyResult
     {
-      RasterResult();
-      RasterResult( QgsRasterLayer * layer, QString label, QgsFields fields, QgsFeature feature, QMap< QString, QString > derivedAttributes );
-      QgsRasterLayer* mLayer;
+      IdentifyResult();
+
+      IdentifyResult( QgsMapLayer * layer, QgsFeature feature, QMap< QString, QString > derivedAttributes );
+
+      IdentifyResult( QgsMapLayer * layer, QString label, QMap< QString, QString > attributes, QMap< QString, QString > derivedAttributes );
+
+      IdentifyResult( QgsMapLayer * layer, QString label, QgsFields fields, QgsFeature feature, QMap< QString, QString > derivedAttributes );
+
+     QgsMapLayer* mLayer;
       QString mLabel;
       QgsFields mFields;
       QgsFeature mFeature;
       QMap< QString, QString > mAttributes;
       QMap< QString, QString > mDerivedAttributes;
-    };
-
-    struct IdentifyResults
-    {
-        IdentifyResults();
-        IdentifyResults ( QList<QgsMapToolIdentify::VectorResult> vectorResults , QList<QgsMapToolIdentify::RasterResult> rasterResults); 
-        QList<QgsMapToolIdentify::VectorResult> mVectorResults;
-        QList<QgsMapToolIdentify::RasterResult> mRasterResults;
     };
 
 	//! constructor
@@ -73,8 +63,8 @@ class QgsMapToolIdentify : QgsMapTool
     @param y y coordinates of mouseEvent
     @param layerList Performs the identification within the given list of layers. Default value is an empty list, i.e. uses all the layers.
     @param mode Identification mode. Can use Qgis default settings or a defined mode. Default mode is DefaultQgsSetting.
-    @return true if identification succeeded and a feature has been found, false otherwise.*/
-    IdentifyResults identify(int x, int y, QList<QgsMapLayer*> layerList = QList<QgsMapLayer*>(), IdentifyMode mode = DefaultQgsSetting);
+    @return a list of IdentifyResult*/
+    QList<QgsMapToolIdentify::IdentifyResult> identify(int x, int y, QList<QgsMapLayer*> layerList = QList<QgsMapLayer*>(), IdentifyMode mode = DefaultQgsSetting);
 
     /** Performs the identification.
     To avoid beeing forced to specify IdentifyMode with a list of layers
@@ -83,8 +73,8 @@ class QgsMapToolIdentify : QgsMapTool
     @param y y coordinates of mouseEvent
     @param mode Identification mode. Can use Qgis default settings or a defined mode.
     @param layerType Only performs identification in a certain type of layers (raster, vector). Default value is AllLayers.
-    @return true if identification succeeded and a feature has been found, false otherwise.*/
-    IdentifyResults identify(int x, int y, IdentifyMode mode, LayerType layerType = AllLayers);
+    @return a list of IdentifyResult*/
+    QList<QgsMapToolIdentify::IdentifyResult> identify(int x, int y, IdentifyMode mode, LayerType layerType = AllLayers);
 
   signals:
     void identifyProgress( int, int );

--- a/src/app/qgsfeatureaction.h
+++ b/src/app/qgsfeatureaction.h
@@ -23,7 +23,7 @@
 #include <QPair>
 #include <QAction>
 
-class QgsIdentifyResults;
+class QgsIdentifyResultsDialog;
 class QgsVectorLayer;
 class QgsHighlight;
 class QgsAttributeDialog;

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -292,9 +292,19 @@ QTreeWidgetItem *QgsIdentifyResultsDialog::layerItem( QObject *layer )
   return 0;
 }
 
-void QgsIdentifyResultsDialog::addFeature( QgsVectorLayer *vlayer,
-    const QgsFeature &f,
-    const QMap<QString, QString> &derivedAttributes )
+void QgsIdentifyResultsDialog::addFeature( QgsMapToolIdentify::IdentifyResult result )
+{
+  if ( result.mLayer->type() == QgsMapLayer::VectorLayer )
+  {
+    addFeature( qobject_cast<QgsVectorLayer *>( result.mLayer ), result.mFeature, result.mDerivedAttributes );
+  }
+  else if ( result.mLayer->type() == QgsMapLayer::RasterLayer )
+  {
+    addFeature( qobject_cast<QgsRasterLayer *>( result.mLayer ), result.mLabel, result.mAttributes, result.mDerivedAttributes, result.mFields,  result.mFeature );
+  }
+}
+
+void QgsIdentifyResultsDialog::addFeature( QgsVectorLayer *vlayer, const QgsFeature &f, const QMap<QString, QString> &derivedAttributes )
 {
   QTreeWidgetItem *layItem = layerItem( vlayer );
 

--- a/src/app/qgsidentifyresultsdialog.h
+++ b/src/app/qgsidentifyresultsdialog.h
@@ -24,6 +24,7 @@
 #include "qgsfeature.h"
 #include "qgsfeaturestore.h"
 #include "qgsfield.h"
+#include "qgsmaptoolidentify.h"
 #include "qgscoordinatereferencesystem.h"
 
 #include <QWidget>
@@ -101,17 +102,20 @@ class QgsIdentifyResultsDialog: public QDialog, private Ui::QgsIdentifyResultsBa
     ~QgsIdentifyResultsDialog();
 
     /** Add add feature from vector layer */
-    void addFeature( QgsVectorLayer *layer,
+    void addFeature( QgsVectorLayer * layer,
                      const QgsFeature &f,
                      const QMap< QString, QString > &derivedAttributes );
 
     /** Add add feature from other layer */
-    void addFeature( QgsRasterLayer *layer,
+    void addFeature( QgsRasterLayer * layer,
                      QString label,
                      const QMap< QString, QString > &attributes,
                      const QMap< QString, QString > &derivedAttributes,
                      const QgsFields &fields = QgsFields(),
                      const QgsFeature &feature = QgsFeature() );
+
+    /** Add feature from identify results */
+    void addFeature( QgsMapToolIdentify::IdentifyResult result );
 
     /** map tool was deactivated */
     void deactivate();

--- a/src/app/qgsmaptoolidentifyaction.cpp
+++ b/src/app/qgsmaptoolidentifyaction.cpp
@@ -48,7 +48,7 @@ QgsMapToolIdentifyAction::QgsMapToolIdentifyAction( QgsMapCanvas * canvas )
   QPixmap myIdentifyQPixmap = QPixmap(( const char ** ) identify_cursor );
   mCursor = QCursor( myIdentifyQPixmap, 1, 1 );
 
-  connect( this, SIGNAL( changedRasterResults( QList<IdentifyResult>& ) ), this, SLOT( handleChangedRasterResults( QList<RasterResult>& ) ) );
+  connect( this, SIGNAL( changedRasterResults( QList<IdentifyResult>& ) ), this, SLOT( handleChangedRasterResults( QList<IdentifyResult>& ) ) );
 }
 
 QgsMapToolIdentifyAction::~QgsMapToolIdentifyAction()

--- a/src/app/qgsmaptoolidentifyaction.cpp
+++ b/src/app/qgsmaptoolidentifyaction.cpp
@@ -93,23 +93,23 @@ void QgsMapToolIdentifyAction::canvasReleaseEvent( QMouseEvent *e )
 
   connect( this, SIGNAL( identifyProgress( int, int ) ), QgisApp::instance(), SLOT( showProgress( int, int ) ) );
   connect( this, SIGNAL( identifyMessage( QString ) ), QgisApp::instance(), SLOT( showStatusMessage( QString ) ) );
-  bool res = QgsMapToolIdentify::identify( e->x(), e->y() );
+  IdentifyResults results = QgsMapToolIdentify::identify( e->x(), e->y() );
   disconnect( this, SIGNAL( identifyProgress( int, int ) ), QgisApp::instance(), SLOT( showProgress( int, int ) ) );
   disconnect( this, SIGNAL( identifyMessage( QString ) ), QgisApp::instance(), SLOT( showStatusMessage( QString ) ) );
 
 
   QList<VectorResult>::const_iterator vresult;
-  for ( vresult = results().mVectorResults.begin(); vresult != results().mVectorResults.end(); ++vresult )
+  for ( vresult = results.mVectorResults.begin(); vresult != results.mVectorResults.end(); ++vresult )
   {
     resultsDialog()->addFeature( vresult->mLayer, vresult->mFeature, vresult->mDerivedAttributes );
   }
   QList<RasterResult>::const_iterator rresult;
-  for ( rresult = results().mRasterResults.begin(); rresult != results().mRasterResults.end(); ++rresult )
+  for ( rresult = results.mRasterResults.begin(); rresult != results.mRasterResults.end(); ++rresult )
   {
     resultsDialog()->addFeature( rresult->mLayer, rresult->mLabel, rresult->mAttributes, rresult->mDerivedAttributes, rresult->mFields,  rresult->mFeature );
   }
 
-  if ( res )
+  if ( !results.mRasterResults.isEmpty() || !results.mVectorResults.isEmpty() )
   {
     resultsDialog()->show();
   }

--- a/src/app/qgsmaptoolidentifyaction.h
+++ b/src/app/qgsmaptoolidentifyaction.h
@@ -46,7 +46,7 @@ class QgsMapToolIdentifyAction : public QgsMapToolIdentify
     Q_OBJECT
 
   public:
-    QgsMapToolIdentifyAction( QgsMapCanvas* canvas );
+    QgsMapToolIdentifyAction( QgsMapCanvas * canvas );
 
     ~QgsMapToolIdentifyAction();
 
@@ -65,7 +65,7 @@ class QgsMapToolIdentifyAction : public QgsMapToolIdentify
 
   public slots:
     void handleCopyToClipboard( QgsFeatureStore & );
-    void handleChangedRasterResults( QList<RasterResult>& rasterResults );
+    void handleChangedRasterResults( QList<IdentifyResult>& results );
 
   signals:
     void identifyProgress( int, int );

--- a/src/gui/qgsmaptoolidentify.cpp
+++ b/src/gui/qgsmaptoolidentify.cpp
@@ -68,34 +68,28 @@ void QgsMapToolIdentify::canvasReleaseEvent( QMouseEvent *e )
   Q_UNUSED( e );
 }
 
-bool QgsMapToolIdentify::identify( int x, int y, QList<QgsMapLayer *> layerList, IdentifyMode mode )
+QgsMapToolIdentify::IdentifyResults QgsMapToolIdentify::identify ( int x, int y, QList<QgsMapLayer *> layerList, IdentifyMode mode )
 {
   return identify( x, y, mode, layerList, AllLayers );
 }
 
-bool QgsMapToolIdentify::identify( int x, int y, IdentifyMode mode, LayerType layerType )
+QgsMapToolIdentify::IdentifyResults QgsMapToolIdentify::identify( int x, int y, IdentifyMode mode, LayerType layerType )
 {
   return identify( x, y, mode, QList<QgsMapLayer*>(), layerType );
 }
 
-bool QgsMapToolIdentify::identify( int x, int y, IdentifyMode mode, QList<QgsMapLayer*> layerList, LayerType layerType )
+QgsMapToolIdentify::IdentifyResults QgsMapToolIdentify::identify( int x, int y, IdentifyMode mode, QList<QgsMapLayer*> layerList, LayerType layerType )
 {
+  IdentifyResults results;
+
   mLastPoint = mCanvas->getCoordinateTransform()->toMapCoordinates( x, y );
   mLastExtent = mCanvas->extent();
   mLastMapUnitsPerPixel = mCanvas->mapUnitsPerPixel();
-  return identify( mLastPoint, mLastExtent, mLastMapUnitsPerPixel, mode, layerList, layerType );
-}
 
-bool QgsMapToolIdentify::identify( QgsPoint point, QgsRectangle viewExtent, double mapUnitsPerPixel, IdentifyMode mode,  QList<QgsMapLayer*> layerList, LayerType layerType )
-{
-  bool res = false;
   if ( !mCanvas || mCanvas->isDrawing() )
   {
-    return res;
+    return results;
   }
-
-  mResultData.mVectorResults.clear();
-  mResultData.mRasterResults.clear();
 
   if ( mode == DefaultQgsSetting )
   {
@@ -110,12 +104,12 @@ bool QgsMapToolIdentify::identify( QgsPoint point, QgsRectangle viewExtent, doub
     if ( !layer )
     {
       emit identifyMessage( tr( "No active layer. To identify features, you must choose an active layer." ) );
-      return res;
+      return results;
     }
 
     QApplication::setOverrideCursor( Qt::WaitCursor );
 
-    res = identifyLayer( layer, point, viewExtent, mapUnitsPerPixel, layerType );
+    identifyLayer( &results, layer, mLastPoint, mLastExtent, mLastMapUnitsPerPixel, layerType );
   }
   else
   {
@@ -145,9 +139,8 @@ bool QgsMapToolIdentify::identify( QgsPoint point, QgsRectangle viewExtent, doub
       if ( noIdentifyLayerIdList.contains( layer->id() ) )
         continue;
 
-      if ( identifyLayer( layer, point, viewExtent, mapUnitsPerPixel, layerType ) )
+      if ( identifyLayer( &results, layer,  mLastPoint, mLastExtent, mLastMapUnitsPerPixel, layerType ) )
       {
-        res = true;
         if ( mode == TopDownStopAtFirst )
           break;
       }
@@ -159,7 +152,7 @@ bool QgsMapToolIdentify::identify( QgsPoint point, QgsRectangle viewExtent, doub
 
   QApplication::restoreOverrideCursor();
 
-  return res;
+  return results;
 }
 
 void QgsMapToolIdentify::activate()
@@ -172,15 +165,15 @@ void QgsMapToolIdentify::deactivate()
   QgsMapTool::deactivate();
 }
 
-bool QgsMapToolIdentify::identifyLayer( QgsMapLayer *layer, QgsPoint point, QgsRectangle viewExtent, double mapUnitsPerPixel, LayerType layerType )
+bool QgsMapToolIdentify::identifyLayer( IdentifyResults *results, QgsMapLayer *layer, QgsPoint point, QgsRectangle viewExtent, double mapUnitsPerPixel, LayerType layerType )
 {
   if ( layer->type() == QgsMapLayer::RasterLayer && ( layerType == AllLayers || layerType == RasterLayer ) )
   {
-    return identifyRasterLayer( qobject_cast<QgsRasterLayer *>( layer ), point, viewExtent, mapUnitsPerPixel, mResultData.mRasterResults );
+    return identifyRasterLayer( results, qobject_cast<QgsRasterLayer *>( layer ), point, viewExtent, mapUnitsPerPixel );
   }
   else if ( layer->type() == QgsMapLayer::VectorLayer && ( layerType == AllLayers || layerType == VectorLayer ) )
   {
-    return identifyVectorLayer( qobject_cast<QgsVectorLayer *>( layer ), point );
+    return identifyVectorLayer( results, qobject_cast<QgsVectorLayer *>( layer ), point );
   }
   else
   {
@@ -188,9 +181,8 @@ bool QgsMapToolIdentify::identifyLayer( QgsMapLayer *layer, QgsPoint point, QgsR
   }
 }
 
-bool QgsMapToolIdentify::identifyVectorLayer( QgsVectorLayer *layer, QgsPoint point )
+bool QgsMapToolIdentify::identifyVectorLayer( IdentifyResults *results, QgsVectorLayer *layer, QgsPoint point )
 {
-  QgsDebugMsg( "point = " + point.toString() );
   if ( !layer )
     return false;
 
@@ -209,7 +201,6 @@ bool QgsMapToolIdentify::identifyVectorLayer( QgsVectorLayer *layer, QgsPoint po
   // load identify radius from settings
   QSettings settings;
   double identifyValue = settings.value( "/Map/identifyRadius", QGis::DEFAULT_IDENTIFY_RADIUS ).toDouble();
-
 
   if ( identifyValue <= 0.0 )
     identifyValue = QGis::DEFAULT_IDENTIFY_RADIUS;
@@ -271,7 +262,7 @@ bool QgsMapToolIdentify::identifyVectorLayer( QgsVectorLayer *layer, QgsPoint po
 
     derivedAttributes.insert( tr( "feature id" ), fid < 0 ? tr( "new feature" ) : FID_TO_STRING( fid ) );
 
-    mResultData.mVectorResults.append( VectorResult( layer, *f_it, derivedAttributes ) );
+    results->mVectorResults.append( VectorResult( layer, *f_it, derivedAttributes ) );
   }
 
   if ( renderer && renderer->capabilities() & QgsFeatureRendererV2::ScaleDependent )
@@ -348,7 +339,7 @@ QMap< QString, QString > QgsMapToolIdentify::featureDerivedAttributes( QgsFeatur
   return derivedAttributes;
 }
 
-bool QgsMapToolIdentify::identifyRasterLayer( QgsRasterLayer *layer, QgsPoint point, QgsRectangle viewExtent, double mapUnitsPerPixel, QList<RasterResult>& rasterResults )
+bool QgsMapToolIdentify::identifyRasterLayer( IdentifyResults *results, QgsRasterLayer *layer, QgsPoint point, QgsRectangle viewExtent, double mapUnitsPerPixel )
 {
   QgsDebugMsg( "point = " + point.toString() );
   if ( !layer ) return false;
@@ -442,7 +433,7 @@ bool QgsMapToolIdentify::identifyRasterLayer( QgsRasterLayer *layer, QgsPoint po
       attributes.insert( dprovider->generateBandName( bandNo ), valueString );
     }
     QString label = layer->name();
-    rasterResults.append( RasterResult( layer, label, attributes, derivedAttributes ) );
+    results->mRasterResults.append( RasterResult( layer, label, attributes, derivedAttributes ) );
   }
   else if ( format == QgsRasterDataProvider::IdentifyFormatFeature )
   {
@@ -476,7 +467,7 @@ bool QgsMapToolIdentify::identifyRasterLayer( QgsRasterLayer *layer, QgsPoint po
           QMap< QString, QString > derAttributes = derivedAttributes;
           derAttributes.unite( featureDerivedAttributes( &feature, layer ) );
 
-          rasterResults.append( RasterResult( layer, labels.join( " / " ), featureStore.fields(), feature, derAttributes ) );
+          results->mRasterResults.append( RasterResult( layer, labels.join( " / " ), featureStore.fields(), feature, derAttributes ) );
         }
       }
     }
@@ -491,7 +482,7 @@ bool QgsMapToolIdentify::identifyRasterLayer( QgsRasterLayer *layer, QgsPoint po
       attributes.insert( "", value );
 
       QString label = layer->subLayers().value( bandNo );
-      rasterResults.append( RasterResult( layer, label, attributes, derivedAttributes ) );
+      results->mRasterResults.append( RasterResult( layer, label, attributes, derivedAttributes ) );
     }
   }
 
@@ -515,16 +506,13 @@ QGis::UnitType QgsMapToolIdentify::displayUnits()
   return mCanvas->mapUnits();
 }
 
-QgsMapToolIdentify::IdentifyResults &QgsMapToolIdentify::results()
-{
-  return mResultData;
-}
-
 void QgsMapToolIdentify::formatChanged( QgsRasterLayer *layer )
 {
   QgsDebugMsg( "Entered" );
-  QList<RasterResult> rasterResults;
-  identifyRasterLayer( layer, mLastPoint, mLastExtent, mLastMapUnitsPerPixel, rasterResults );
-  emit changedRasterResults( rasterResults );
+  IdentifyResults results;
+  if ( identifyRasterLayer( &results, layer, mLastPoint, mLastExtent, mLastMapUnitsPerPixel ) )
+  {
+      emit changedRasterResults( results.mRasterResults );
+  }
 }
 

--- a/src/gui/qgsmaptoolidentify.h
+++ b/src/gui/qgsmaptoolidentify.h
@@ -29,6 +29,7 @@
 
 class QgsRasterLayer;
 class QgsVectorLayer;
+class QgsMapLayer;
 class QgsMapCanvas;
 
 /**
@@ -60,25 +61,20 @@ class GUI_EXPORT QgsMapToolIdentify : public QgsMapTool
       RasterLayer
     };
 
-    struct VectorResult
+    struct IdentifyResult
     {
-      VectorResult() {}
-      VectorResult( QgsVectorLayer * layer, QgsFeature feature, QMap< QString, QString > derivedAttributes ):
-          mLayer( layer ), mFeature( feature ), mDerivedAttributes( derivedAttributes )  {}
-      QgsVectorLayer* mLayer;
-      QgsFeature mFeature;
-      QMap< QString, QString > mDerivedAttributes;
-    };
+      IdentifyResult() {}
 
-    struct RasterResult
-    {
-      RasterResult() {}
-      RasterResult( QgsRasterLayer * layer, QString label, QMap< QString, QString > attributes, QMap< QString, QString > derivedAttributes ):
+      IdentifyResult( QgsMapLayer * layer, QgsFeature feature, QMap< QString, QString > derivedAttributes ):
+          mLayer( layer ), mFeature( feature ), mDerivedAttributes( derivedAttributes )  {}
+
+      IdentifyResult( QgsMapLayer * layer, QString label, QMap< QString, QString > attributes, QMap< QString, QString > derivedAttributes ):
           mLayer( layer ), mLabel( label ), mAttributes( attributes ), mDerivedAttributes( derivedAttributes )  {}
 
-      RasterResult( QgsRasterLayer * layer, QString label, QgsFields fields, QgsFeature feature, QMap< QString, QString > derivedAttributes ):
+      IdentifyResult( QgsMapLayer * layer, QString label, QgsFields fields, QgsFeature feature, QMap< QString, QString > derivedAttributes ):
           mLayer( layer ), mLabel( label ), mFields( fields ), mFeature( feature ), mDerivedAttributes( derivedAttributes )  {}
-      QgsRasterLayer* mLayer;
+
+      QgsMapLayer* mLayer;
       QString mLabel;
       QgsFields mFields;
       QgsFeature mFeature;
@@ -86,19 +82,8 @@ class GUI_EXPORT QgsMapToolIdentify : public QgsMapTool
       QMap< QString, QString > mDerivedAttributes;
     };
 
-    struct IdentifyResults
-    {
-      IdentifyResults() {}
-      IdentifyResults( QList<VectorResult> vectorResults , QList<RasterResult> rasterResults ) :
-          mVectorResults( vectorResults ),
-          mRasterResults( rasterResults )
-      {}
-      QList<VectorResult> mVectorResults;
-      QList<RasterResult> mRasterResults;
-    };
-
     //! constructor
-    QgsMapToolIdentify( QgsMapCanvas* canvas );
+    QgsMapToolIdentify( QgsMapCanvas * canvas );
 
     virtual ~QgsMapToolIdentify();
 
@@ -120,8 +105,8 @@ class GUI_EXPORT QgsMapToolIdentify : public QgsMapTool
     @param y y coordinates of mouseEvent
     @param layerList Performs the identification within the given list of layers. Default value is an empty list, i.e. uses all the layers.
     @param mode Identification mode. Can use Qgis default settings or a defined mode. Default mode is DefaultQgsSetting.
-    @return true if identification succeeded and a feature has been found, false otherwise.*/
-    IdentifyResults identify( int x, int y, QList<QgsMapLayer*> layerList = QList<QgsMapLayer*>(), IdentifyMode mode = DefaultQgsSetting );
+    @return a list of IdentifyResult*/
+    QList<IdentifyResult> identify( int x, int y, QList<QgsMapLayer*> layerList = QList<QgsMapLayer*>(), IdentifyMode mode = DefaultQgsSetting );
 
     /** Performs the identification.
     To avoid beeing forced to specify IdentifyMode with a list of layers
@@ -130,8 +115,8 @@ class GUI_EXPORT QgsMapToolIdentify : public QgsMapTool
     @param y y coordinates of mouseEvent
     @param mode Identification mode. Can use Qgis default settings or a defined mode.
     @param layerType Only performs identification in a certain type of layers (raster, vector). Default value is AllLayers.
-    @return true if identification succeeded and a feature has been found, false otherwise.*/
-    IdentifyResults identify( int x, int y, IdentifyMode mode, LayerType layerType = AllLayers );
+    @return a list of IdentifyResult*/
+    QList<IdentifyResult> identify( int x, int y, IdentifyMode mode, LayerType layerType = AllLayers );
 
   public slots:
     void formatChanged( QgsRasterLayer *layer );
@@ -139,7 +124,7 @@ class GUI_EXPORT QgsMapToolIdentify : public QgsMapTool
   signals:
     void identifyProgress( int, int );
     void identifyMessage( QString );
-    void changedRasterResults( QList<RasterResult>& );
+    void changedRasterResults( QList<IdentifyResult>& );
 
   private:
     /** Performs the identification.
@@ -151,13 +136,13 @@ class GUI_EXPORT QgsMapToolIdentify : public QgsMapTool
     @param layerList Performs the identification within the given list of layers.
     @param layerType Only performs identification in a certain type of layers (raster, vector).
     @return true if identification succeeded and a feature has been found, false otherwise.*/
-    IdentifyResults identify( int x, int y, IdentifyMode mode,  QList<QgsMapLayer*> layerList, LayerType layerType = AllLayers );
+    QList<IdentifyResult> identify( int x, int y, IdentifyMode mode,  QList<QgsMapLayer*> layerList, LayerType layerType = AllLayers );
 
     /** call the right method depending on layer type */
-    bool identifyLayer( IdentifyResults *results, QgsMapLayer *layer, QgsPoint point, QgsRectangle viewExtent, double mapUnitsPerPixel, LayerType layerType = AllLayers );
+    bool identifyLayer( QList<IdentifyResult> *results, QgsMapLayer *layer, QgsPoint point, QgsRectangle viewExtent, double mapUnitsPerPixel, LayerType layerType = AllLayers );
 
-    bool identifyRasterLayer( IdentifyResults *results, QgsRasterLayer *layer, QgsPoint point, QgsRectangle viewExtent, double mapUnitsPerPixel );
-    bool identifyVectorLayer( IdentifyResults *results, QgsVectorLayer *layer, QgsPoint point );
+    bool identifyRasterLayer( QList<IdentifyResult> *results, QgsRasterLayer *layer, QgsPoint point, QgsRectangle viewExtent, double mapUnitsPerPixel );
+    bool identifyVectorLayer( QList<IdentifyResult> *results, QgsVectorLayer *layer, QgsPoint point );
 
     //! Private helper
     virtual void convertMeasurement( QgsDistanceArea &calc, double &measure, QGis::UnitType &u, bool isArea );

--- a/src/gui/qgsmaptoolidentify.h
+++ b/src/gui/qgsmaptoolidentify.h
@@ -121,7 +121,7 @@ class GUI_EXPORT QgsMapToolIdentify : public QgsMapTool
     @param layerList Performs the identification within the given list of layers. Default value is an empty list, i.e. uses all the layers.
     @param mode Identification mode. Can use Qgis default settings or a defined mode. Default mode is DefaultQgsSetting.
     @return true if identification succeeded and a feature has been found, false otherwise.*/
-    bool identify( int x, int y, QList<QgsMapLayer*> layerList = QList<QgsMapLayer*>(), IdentifyMode mode = DefaultQgsSetting );
+    IdentifyResults identify( int x, int y, QList<QgsMapLayer*> layerList = QList<QgsMapLayer*>(), IdentifyMode mode = DefaultQgsSetting );
 
     /** Performs the identification.
     To avoid beeing forced to specify IdentifyMode with a list of layers
@@ -131,10 +131,7 @@ class GUI_EXPORT QgsMapToolIdentify : public QgsMapTool
     @param mode Identification mode. Can use Qgis default settings or a defined mode.
     @param layerType Only performs identification in a certain type of layers (raster, vector). Default value is AllLayers.
     @return true if identification succeeded and a feature has been found, false otherwise.*/
-    bool identify( int x, int y, IdentifyMode mode, LayerType layerType = AllLayers );
-
-    /** Access to results */
-    IdentifyResults &results();
+    IdentifyResults identify( int x, int y, IdentifyMode mode, LayerType layerType = AllLayers );
 
   public slots:
     void formatChanged( QgsRasterLayer *layer );
@@ -154,13 +151,13 @@ class GUI_EXPORT QgsMapToolIdentify : public QgsMapTool
     @param layerList Performs the identification within the given list of layers.
     @param layerType Only performs identification in a certain type of layers (raster, vector).
     @return true if identification succeeded and a feature has been found, false otherwise.*/
-    bool identify( int x, int y, IdentifyMode mode,  QList<QgsMapLayer*> layerList, LayerType layerType = AllLayers );
+    IdentifyResults identify( int x, int y, IdentifyMode mode,  QList<QgsMapLayer*> layerList, LayerType layerType = AllLayers );
 
-    bool identify( QgsPoint point, QgsRectangle viewExtent, double mapUnitsPerPixel, IdentifyMode mode,  QList<QgsMapLayer*> layerList, LayerType layerType = AllLayers );
+    /** call the right method depending on layer type */
+    bool identifyLayer( IdentifyResults *results, QgsMapLayer *layer, QgsPoint point, QgsRectangle viewExtent, double mapUnitsPerPixel, LayerType layerType = AllLayers );
 
-    bool identifyLayer( QgsMapLayer *layer, QgsPoint point, QgsRectangle viewExtent, double mapUnitsPerPixel, LayerType layerType = AllLayers );
-    bool identifyRasterLayer( QgsRasterLayer *layer, QgsPoint point, QgsRectangle viewExtent, double mapUnitsPerPixel, QList<RasterResult>& rasterResults );
-    bool identifyVectorLayer( QgsVectorLayer *layer, QgsPoint point );
+    bool identifyRasterLayer( IdentifyResults *results, QgsRasterLayer *layer, QgsPoint point, QgsRectangle viewExtent, double mapUnitsPerPixel );
+    bool identifyVectorLayer( IdentifyResults *results, QgsVectorLayer *layer, QgsPoint point );
 
     //! Private helper
     virtual void convertMeasurement( QgsDistanceArea &calc, double &measure, QGis::UnitType &u, bool isArea );
@@ -169,8 +166,6 @@ class GUI_EXPORT QgsMapToolIdentify : public QgsMapTool
     virtual QGis::UnitType displayUnits();
 
     QMap< QString, QString > featureDerivedAttributes( QgsFeature *feature, QgsMapLayer *layer );
-
-    IdentifyResults mResultData;
 
     // Last point in canvas CRS
     QgsPoint mLastPoint;


### PR DESCRIPTION
The identify method now returns directly the IdentifyResults instead of using a private attribute.

Also, IdentifyResult is now a single struct (no RasterResult and VectorResult)
