### PR TITLE
Add support for 1bit PNG format to QGIS Server WMS

### DIFF
--- a/src/mapserver/qgshttprequesthandler.cpp
+++ b/src/mapserver/qgshttprequesthandler.cpp
@@ -97,7 +97,8 @@ void QgsHttpRequestHandler::sendGetMapResponse( const QString& service, QImage* 
   if ( img )
   {
     bool png8Bit = ( mFormat.compare( "image/png; mode=8bit", Qt::CaseInsensitive ) == 0 );
-    if ( mFormat != "PNG" && mFormat != "JPG" && !png8Bit )
+    bool png1Bit = ( mFormat.compare( "image/png; mode=1bit", Qt::CaseInsensitive ) == 0 );
+    if ( mFormat != "PNG" && mFormat != "JPG" && !png8Bit && !png1Bit )
     {
       QgsDebugMsg( "service exception - incorrect image format requested..." );
       sendServiceException( QgsMapServiceException( "InvalidFormat", "Output format '" + mFormat + "' is not supported in the GetMap request" ) );
@@ -114,6 +115,12 @@ void QgsHttpRequestHandler::sendGetMapResponse( const QString& service, QImage* 
       QVector<QRgb> colorTable;
       medianCut( colorTable, 256, *img );
       QImage palettedImg = img->convertToFormat( QImage::Format_Indexed8, colorTable, Qt::ColorOnly | Qt::ThresholdDither |
+                           Qt::ThresholdAlphaDither | Qt::NoOpaqueDetection );
+      palettedImg.save( &buffer, "PNG", -1 );
+    }
+    else if ( png1Bit )
+    {
+      QImage palettedImg = img->convertToFormat( QImage::Format_Mono, Qt::MonoOnly | Qt::ThresholdDither |
                            Qt::ThresholdAlphaDither | Qt::NoOpaqueDetection );
       palettedImg.save( &buffer, "PNG", -1 );
     }

--- a/src/mapserver/qgswmsserver.cpp
+++ b/src/mapserver/qgswmsserver.cpp
@@ -172,7 +172,7 @@ QDomDocument QgsWMSServer::getCapabilities( QString version, bool fullProjectInf
 
   //wms:GetMap
   elem = doc.createElement( "GetMap"/*wms:GetMap*/ );
-  appendFormats( doc, elem, QStringList() << "image/jpeg" << "image/png" << "image/png; mode=8bit" );
+  appendFormats( doc, elem, QStringList() << "image/jpeg" << "image/png" << "image/png; mode=8bit" << "image/png; mode=1bit" );
   elem.appendChild( dcpTypeElement.cloneNode().toElement() ); //this is the same as for 'GetCapabilities'
   requestElement.appendChild( elem );
 


### PR DESCRIPTION
I've added support for 1bit PNG format (FORMAT=image/png; mode=1bit) to QGIS Server WMS. This enables the creation of non-antialiased black/white maps.
