### PR TITLE
[Feature] Paste in place in the composer using ctrl+alt+v.

### DIFF
--- a/src/core/composer/qgscomposition.cpp
+++ b/src/core/composer/qgscomposition.cpp
@@ -446,8 +446,13 @@ bool QgsComposition::loadFromTemplate( const QDomDocument& doc, QMap<QString, QS
 }
 
 void QgsComposition::addItemsFromXML( const QDomElement& elem, const QDomDocument& doc, QMap< QgsComposerMap*, int >* mapsToRestore,
-                                      bool addUndoCommands, QPointF* pos )
+                                      bool addUndoCommands, QPointF* pos, bool pasteInPlace )
 {
+  QPointF* pasteInPlacePt;
+  if( pasteInPlace )
+  {
+    pasteInPlacePt = new QPointF(0, pageNumberAt( *pos ) * (mPageHeight+mSpaceBetweenPages) );
+  }
   QDomNodeList composerLabelList = elem.elementsByTagName( "ComposerLabel" );
   for ( int i = 0; i < composerLabelList.size(); ++i )
   {
@@ -456,7 +461,15 @@ void QgsComposition::addItemsFromXML( const QDomElement& elem, const QDomDocumen
     newLabel->readXML( currentComposerLabelElem, doc );
     if ( pos )
     {
-      newLabel->setItemPosition( pos->x(), pos->y() );
+      if ( pasteInPlace )
+      {
+        newLabel->setItemPosition( newLabel->transform().dx(), fmod(newLabel->transform().dy(), (paperHeight()+spaceBetweenPages()) ) );
+        newLabel->move( pasteInPlacePt->x(),pasteInPlacePt->y() );
+      }
+      else
+      {
+        newLabel->setItemPosition( pos->x(), pos->y() );
+      }
     }
     addComposerLabel( newLabel );
     if ( addUndoCommands )
@@ -482,7 +495,15 @@ void QgsComposition::addItemsFromXML( const QDomElement& elem, const QDomDocumen
 
     if ( pos )
     {
-      newMap->setItemPosition( pos->x(), pos->y() );
+      if ( pasteInPlace )
+      {
+        newMap->setItemPosition( newMap->transform().dx(), fmod(newMap->transform().dy(), (paperHeight()+spaceBetweenPages()) ) );
+        newMap->move( pasteInPlacePt->x(),pasteInPlacePt->y() );
+      }
+      else
+      {
+        newMap->setItemPosition( pos->x(), pos->y() );
+      }
     }
 
     if ( addUndoCommands )
@@ -499,7 +520,15 @@ void QgsComposition::addItemsFromXML( const QDomElement& elem, const QDomDocumen
     newArrow->readXML( currentComposerArrowElem, doc );
     if ( pos )
     {
-      newArrow->setItemPosition( pos->x(), pos->y() );
+      if ( pasteInPlace )
+      {
+        newArrow->setItemPosition( newArrow->transform().dx(), fmod(newArrow->transform().dy(), (paperHeight()+spaceBetweenPages()) ) );
+        newArrow->move( pasteInPlacePt->x(),pasteInPlacePt->y() );
+      }
+      else
+      {
+        newArrow->setItemPosition( pos->x(), pos->y() );
+      }
     }
     addComposerArrow( newArrow );
     if ( addUndoCommands )
@@ -516,7 +545,15 @@ void QgsComposition::addItemsFromXML( const QDomElement& elem, const QDomDocumen
     newScaleBar->readXML( currentComposerScaleBarElem, doc );
     if ( pos )
     {
-      newScaleBar->setItemPosition( pos->x(), pos->y() );
+      if ( pasteInPlace )
+      {
+        newScaleBar->setItemPosition( newScaleBar->transform().dx(), fmod(newScaleBar->transform().dy(), (paperHeight()+spaceBetweenPages()) ) );
+        newScaleBar->move( pasteInPlacePt->x(),pasteInPlacePt->y() );
+      }
+      else
+      {
+        newScaleBar->setItemPosition( pos->x(), pos->y() );
+      }
     }
     addComposerScaleBar( newScaleBar );
     if ( addUndoCommands )
@@ -533,7 +570,15 @@ void QgsComposition::addItemsFromXML( const QDomElement& elem, const QDomDocumen
     newShape->readXML( currentComposerShapeElem, doc );
     if ( pos )
     {
-      newShape->setItemPosition( pos->x(), pos->y() );
+      if ( pasteInPlace )
+      {
+        newShape->setItemPosition( newShape->transform().dx(), fmod(newShape->transform().dy(), (paperHeight()+spaceBetweenPages()) ) );
+        newShape->move( pasteInPlacePt->x(),pasteInPlacePt->y() );
+      }
+      else
+      {
+        newShape->setItemPosition( pos->x(), pos->y() );
+      }
     }
     addComposerShape( newShape );
     if ( addUndoCommands )
@@ -550,7 +595,15 @@ void QgsComposition::addItemsFromXML( const QDomElement& elem, const QDomDocumen
     newPicture->readXML( currentComposerPictureElem, doc );
     if ( pos )
     {
-      newPicture->setItemPosition( pos->x(), pos->y() );
+      if ( pasteInPlace )
+      {
+        newPicture->setItemPosition( newPicture->transform().dx(), fmod(newPicture->transform().dy(), (paperHeight()+spaceBetweenPages()) ) );
+        newPicture->move( pasteInPlacePt->x(),pasteInPlacePt->y() );
+      }
+      else
+      {
+        newPicture->setItemPosition( pos->x(), pos->y() );
+      }
     }
     addComposerPicture( newPicture );
     if ( addUndoCommands )
@@ -567,7 +620,15 @@ void QgsComposition::addItemsFromXML( const QDomElement& elem, const QDomDocumen
     newLegend->readXML( currentComposerLegendElem, doc );
     if ( pos )
     {
-      newLegend->setItemPosition( pos->x(), pos->y() );
+      if ( pasteInPlace )
+      {
+        newLegend->setItemPosition( newLegend->transform().dx(), fmod(newLegend->transform().dy(), (paperHeight()+spaceBetweenPages()) ) );
+        newLegend->move( pasteInPlacePt->x(),pasteInPlacePt->y() );
+      }
+      else
+      {
+        newLegend->setItemPosition( pos->x(), pos->y() );
+      }
     }
     addComposerLegend( newLegend );
     if ( addUndoCommands )
@@ -584,7 +645,15 @@ void QgsComposition::addItemsFromXML( const QDomElement& elem, const QDomDocumen
     newTable->readXML( currentComposerTableElem, doc );
     if ( pos )
     {
-      newTable->setItemPosition( pos->x(), pos->y() );
+      if ( pasteInPlace )
+      {
+        newTable->setItemPosition( newTable->transform().dx(), fmod(newTable->transform().dy(), (paperHeight()+spaceBetweenPages()) ) );
+        newTable->move( pasteInPlacePt->x(),pasteInPlacePt->y() );
+      }
+      else
+      {
+        newTable->setItemPosition( pos->x(), pos->y() );
+      }
     }
     addComposerTable( newTable );
     if ( addUndoCommands )

--- a/src/core/composer/qgscomposition.h
+++ b/src/core/composer/qgscomposition.h
@@ -207,10 +207,11 @@ class CORE_EXPORT QgsComposition: public QGraphicsScene
       @param mapsToRestore for reading from project file: set preview move 'rectangle' to all maps and save the preview states to show composer maps on demand
       @param addUndoCommands insert AddItem commands if true (e.g. for copy/paste)
       @param pos item position. Optional, take position from xml if 0
+      @param pasteInPlace wheter the position should be kept but mapped to the page origin. (the page is the page under to the mouse cursor)
       @note not available in python bindings
      */
     void addItemsFromXML( const QDomElement& elem, const QDomDocument& doc, QMap< QgsComposerMap*, int >* mapsToRestore = 0,
-                          bool addUndoCommands = false, QPointF* pos = 0 );
+                          bool addUndoCommands = false, QPointF* pos = 0, bool pasteInPlace = false );
 
     /**Adds item to z list. Usually called from constructor of QgsComposerItem*/
     void addItemToZList( QgsComposerItem* item );

--- a/src/gui/qgscomposerview.cpp
+++ b/src/gui/qgscomposerview.cpp
@@ -448,6 +448,7 @@ void QgsComposerView::mouseDoubleClickEvent( QMouseEvent* e )
 
 void QgsComposerView::keyPressEvent( QKeyEvent * e )
 {
+  //TODO : those should be actions (so we could also display menu items and/or toolbar items)
   if ( e->key() == Qt::Key_Shift )
   {
     mShiftKeyPressed = true;
@@ -491,7 +492,8 @@ void QgsComposerView::keyPressEvent( QKeyEvent * e )
     clipboard->setMimeData( mimeData );
   }
 
-  if ( e->matches( QKeySequence::Paste ) )
+  //TODO : "Ctrl+Shift+V" is one way to paste, but on some platefoms you can use Shift+Ins and F18 
+  if ( e->matches( QKeySequence::Paste ) || (e->key() == Qt::Key_V && e->modifiers() & Qt::ControlModifier && e->modifiers() & Qt::AltModifier) )
   {
     QDomDocument doc;
     QClipboard *clipboard = QApplication::clipboard();
@@ -503,7 +505,8 @@ void QgsComposerView::keyPressEvent( QKeyEvent * e )
         if ( composition() )
         {
           QPointF pt = mapToScene( mapFromGlobal( QCursor::pos() ) );
-          composition()->addItemsFromXML( docElem, doc, 0, true, &pt );
+          bool pasteInPlace = (e->modifiers() & Qt::AltModifier);
+          composition()->addItemsFromXML( docElem, doc, 0, true, &pt, pasteInPlace );
         }
       }
     }

--- a/src/gui/qgscomposerview.cpp
+++ b/src/gui/qgscomposerview.cpp
@@ -493,7 +493,7 @@ void QgsComposerView::keyPressEvent( QKeyEvent * e )
   }
 
   //TODO : "Ctrl+Shift+V" is one way to paste, but on some platefoms you can use Shift+Ins and F18 
-  if ( e->matches( QKeySequence::Paste ) || (e->key() == Qt::Key_V && e->modifiers() & Qt::ControlModifier && e->modifiers() & Qt::AltModifier) )
+  if ( e->matches( QKeySequence::Paste ) || (e->key() == Qt::Key_V && e->modifiers() & Qt::ControlModifier && e->modifiers() & Qt::ShiftModifier) )
   {
     QDomDocument doc;
     QClipboard *clipboard = QApplication::clipboard();
@@ -505,7 +505,7 @@ void QgsComposerView::keyPressEvent( QKeyEvent * e )
         if ( composition() )
         {
           QPointF pt = mapToScene( mapFromGlobal( QCursor::pos() ) );
-          bool pasteInPlace = (e->modifiers() & Qt::AltModifier);
+          bool pasteInPlace = (e->modifiers() & Qt::ShiftModifier);
           composition()->addItemsFromXML( docElem, doc, 0, true, &pt, pasteInPlace );
         }
       }


### PR DESCRIPTION
By using "Paste in place" (ctrl+alt+v), instead of having the elements pasted at the mouse position, they will be pasted at the same page-relative position than they were originally on the page hovered by the mouse.

This is a great time saver when working on multiple compositions having a same layout.

Todo 1 :
IMO, it would be nice if this feature was actually visible to the user.
This would need to have an "edit" menu and/or toolbar with the usual copy/paste/delete actions (it would probably make sense to move that to QActions instead of being implemented in keyPressEvent).

Todo 2 :
For now, pasting on a composer that has a different page height causes inaccurate vertical positioning, since the relative-to-paper origin is computed at paste time upon the destination paper size.

Fixing those would need some deeper modification of the copy/paste system and to the GUI, so, as they aren't essential (especially the 2nd), I'd suggest to pull even without them.
