### PR TITLE
Composer items unique ids

### DIFF
--- a/python/core/composer/qgscomposeritem.sip
+++ b/python/core/composer/qgscomposeritem.sip
@@ -292,15 +292,18 @@ class QgsComposerItem: QObject, QGraphicsRectItem
     /**Updates item, with the possibility to do custom update for subclasses*/
     virtual void updateItem();
 
-    /**Get item identification name
+    /**Get item's id (which is not necessarly unique)
       @note this method was added in version 1.7*/
     QString id() const;
 
-    /**Set item identification name
-      @note this method was added in version 1.7
-                     This method was moved from qgscomposerlabel so that every object can have a
-                      id (NathanW)*/
+    /**Set item's id (which is not necessarly unique)
+      @note this method was added in version 1.7*/
     void setId( const QString& id );
+
+    /**Get item identification name
+      @note this method was added in version 2.0
+      @note there is not setter since one can't manually set the id*/
+    QString uuid() const;
 
   public slots:
     virtual void setRotation( double r );

--- a/python/core/composer/qgscomposition.sip
+++ b/python/core/composer/qgscomposition.sip
@@ -106,12 +106,24 @@ class QgsComposition : QGraphicsScene
     const QgsComposerHtml* getComposerHtmlByItem( QgsComposerItem *item ) const;
 
     /**Returns a composer item given its text identifier.
+      Ids are not necessarely unique, but this function returns only one element.
       @note added in 2.0
       @param theId - A QString representing the identifier of the item to
         retrieve.
       @return QgsComposerItem pointer or 0 pointer if no such item exists.
       **/
     const QgsComposerItem* getComposerItemById( QString theId ) const;
+
+
+    /**Returns a composer item given its unique identifier.
+      Warning : ids are not necessarely unique, but this function returns only one element.
+      @note added in 2.0
+      @param theId - A QString representing the UUID of the item to retrieve.
+      @param inAllComposers - Whether the search should be done in all composers of the project
+      @return QgsComposerItem pointer or 0 pointer if no such item exists.
+      **/
+    //const QgsComposerItem* getComposerItemByUuid( QString theUuid, bool inAllComposers = false ) const;
+    const QgsComposerItem* getComposerItemByUuid( QString theUuid ) const;
 
     int printResolution() const;
     void setPrintResolution( int dpi );

--- a/src/app/composer/qgscomposeritemwidget.cpp
+++ b/src/app/composer/qgscomposeritemwidget.cpp
@@ -352,12 +352,14 @@ void QgsComposerItemWidget::setValuesForGuiElements()
   mFrameGroupBox->blockSignals( true );
   mBackgroundGroupBox->blockSignals( true );
   mItemIdLineEdit->blockSignals( true );
+  mItemUuidLineEdit->blockSignals( true );
   mTransparencySpinBox->blockSignals( true );
 
   mTransparencySpinBox->setValue( 255 - mItem->brush().color().alpha() );
   mTransparencySlider->setValue( 255 - mItem->brush().color().alpha() );
   mOutlineWidthSpinBox->setValue( mItem->pen().widthF() );
   mItemIdLineEdit->setText( mItem->id() );
+  mItemUuidLineEdit->setText( mItem->uuid() );
   mFrameGroupBox->setChecked( mItem->hasFrame() );
   mBackgroundGroupBox->setChecked( mItem->hasBackground() );
 
@@ -366,15 +368,18 @@ void QgsComposerItemWidget::setValuesForGuiElements()
   mFrameGroupBox->blockSignals( false );
   mBackgroundGroupBox->blockSignals( false );
   mItemIdLineEdit->blockSignals( false );
+  mItemUuidLineEdit->blockSignals( false );
   mTransparencySpinBox->blockSignals( false );
 }
 
-void QgsComposerItemWidget::on_mItemIdLineEdit_textChanged( const QString &text )
+
+void QgsComposerItemWidget::on_mItemIdLineEdit_editingFinished()
 {
   if ( mItem )
   {
     mItem->beginCommand( tr( "Item id changed" ), QgsComposerMergeCommand::ComposerLabelSetId );
-    mItem->setId( text );
+    mItem->setId( mItemIdLineEdit->text() );
+    mItemIdLineEdit->setText( mItem->id() );
     mItem->endCommand();
   }
 }

--- a/src/app/composer/qgscomposeritemwidget.h
+++ b/src/app/composer/qgscomposeritemwidget.h
@@ -44,7 +44,7 @@ class QgsComposerItemWidget: public QWidget, private Ui::QgsComposerItemWidgetBa
     void on_mOutlineWidthSpinBox_valueChanged( double d );
     void on_mFrameGroupBox_toggled( bool state );
     void on_mBackgroundGroupBox_toggled( bool state );
-    void on_mItemIdLineEdit_textChanged( const QString& text );
+    void on_mItemIdLineEdit_editingFinished();
 
     //adjust coordinates in line edits
     void on_mXLineEdit_editingFinished() { changeItemPosition(); }

--- a/src/app/composer/qgscomposerlabelwidget.cpp
+++ b/src/app/composer/qgscomposerlabelwidget.cpp
@@ -227,16 +227,6 @@ void QgsComposerLabelWidget::on_mMiddleRadioButton_clicked()
   }
 }
 
-void QgsComposerLabelWidget::on_mLabelIdLineEdit_textChanged( const QString& text )
-{
-  if ( mComposerLabel )
-  {
-    mComposerLabel->beginCommand( tr( "Label id changed" ), QgsComposerMergeCommand::ComposerLabelSetId );
-    mComposerLabel->setId( text );
-    mComposerLabel->endCommand();
-  }
-}
-
 void QgsComposerLabelWidget::on_mRotationSpinBox_valueChanged( double v )
 {
   if ( mComposerLabel )

--- a/src/app/composer/qgscomposerlabelwidget.h
+++ b/src/app/composer/qgscomposerlabelwidget.h
@@ -44,7 +44,6 @@ class QgsComposerLabelWidget: public QWidget, private Ui::QgsComposerLabelWidget
     void on_mTopRadioButton_clicked();
     void on_mBottomRadioButton_clicked();
     void on_mMiddleRadioButton_clicked();
-    void on_mLabelIdLineEdit_textChanged( const QString& text );
     void on_mRotationSpinBox_valueChanged( double v );
 
   private slots:

--- a/src/core/composer/qgscomposeritem.cpp
+++ b/src/core/composer/qgscomposeritem.cpp
@@ -22,11 +22,13 @@
 #include <QGraphicsSceneMouseEvent>
 #include <QGraphicsView>
 #include <QPainter>
+#include <QUuid>
+
+#include "qgsproject.h"
 
 #include "qgscomposition.h"
 #include "qgscomposeritem.h"
 #include "qgscomposerframe.h"
-
 
 #include <limits>
 #include "qgsapplication.h"
@@ -51,6 +53,8 @@ QgsComposerItem::QgsComposerItem( QgsComposition* composition, bool manageZValue
     , mLastValidViewScaleFactor( -1 )
     , mRotation( 0 )
     , mLastUsedPositionMode( UpperLeft )
+    , mId( "" )
+    , mUuid( QUuid::createUuid().toString() )
 {
   init( manageZValue );
 }
@@ -68,6 +72,8 @@ QgsComposerItem::QgsComposerItem( qreal x, qreal y, qreal width, qreal height, Q
     , mLastValidViewScaleFactor( -1 )
     , mRotation( 0 )
     , mLastUsedPositionMode( UpperLeft )
+    , mId( "" )
+    , mUuid( QUuid::createUuid().toString() )
 {
   init( manageZValue );
   QTransform t;
@@ -153,6 +159,7 @@ bool QgsComposerItem::_writeXML( QDomElement& itemElem, QDomDocument& doc ) cons
   composerItemElem.setAttribute( "zValue", QString::number( zValue() ) );
   composerItemElem.setAttribute( "outlineWidth", QString::number( pen().widthF() ) );
   composerItemElem.setAttribute( "rotation",  QString::number( mRotation ) );
+  composerItemElem.setAttribute( "uuid", mUuid );
   composerItemElem.setAttribute( "id", mId );
   //position lock for mouse moves/resizes
   if ( mItemPositionLocked )
@@ -201,8 +208,12 @@ bool QgsComposerItem::_readXML( const QDomElement& itemElem, const QDomDocument&
   //rotation
   mRotation = itemElem.attribute( "rotation", "0" ).toDouble();
 
+  //uuid
+  mUuid = itemElem.attribute( "uuid", QUuid::createUuid().toString() );
+
   //id
-  mId = itemElem.attribute( "id", "" );
+  QString id = itemElem.attribute( "id", "" );
+  setId(id);
 
   //frame
   QString frame = itemElem.attribute( "frame" );
@@ -1254,4 +1265,10 @@ void QgsComposerItem::deleteAlignItems()
 void QgsComposerItem::repaint()
 {
   update();
+}
+
+void QgsComposerItem::setId( const QString& id )
+{ 
+  setToolTip( id );
+  mId = id;
 }

--- a/src/core/composer/qgscomposeritem.h
+++ b/src/core/composer/qgscomposeritem.h
@@ -261,15 +261,18 @@ class CORE_EXPORT QgsComposerItem: public QObject, public QGraphicsRectItem
     /**Updates item, with the possibility to do custom update for subclasses*/
     virtual void updateItem() { QGraphicsRectItem::update(); }
 
-    /**Get item identification name
+    /**Get item's id (which is not necessarly unique)
       @note this method was added in version 1.7*/
     QString id() const { return mId; }
 
-    /**Set item identification name
-      @note this method was added in version 1.7
-                     This method was moved from qgscomposerlabel so that every object can have a
-                      id (NathanW)*/
-    void setId( const QString& id ) { mId = id; }
+    /**Set item's id (which is not necessarly unique)
+      @note this method was added in version 1.7*/
+    virtual void setId( const QString& id );
+
+    /**Get item identification name
+      @note this method was added in version 2.0
+      @note there is not setter since one can't manually set the id*/
+    QString uuid() const { return mUuid; }
 
   public slots:
     virtual void setRotation( double r );
@@ -392,8 +395,10 @@ class CORE_EXPORT QgsComposerItem: public QObject, public QGraphicsRectItem
     /**Emitted if the rectangle changes*/
     void sizeChanged();
   private:
-    // Label id (unique within the same composition)
+    // id (not unique)
     QString mId;
+    // name (unique)
+    QString mUuid;
 
     void init( bool manageZValue );
 };

--- a/src/core/composer/qgscomposition.cpp
+++ b/src/core/composer/qgscomposition.cpp
@@ -261,6 +261,61 @@ const QgsComposerItem* QgsComposition::getComposerItemById( QString theId ) cons
   }
   return 0;
 }
+/*
+const QgsComposerItem* QgsComposition::getComposerItemByUuid( QString theUuid, bool inAllComposers ) const
+{
+  //This does not work since it seems impossible to get the QgisApp::instance() from here... Is there a workaround ?
+  QSet<QgsComposer*> composers = QSet<QgsComposer*>();
+
+  if( inAllComposers )
+  {
+    composers = QgisApp::instance()->printComposers();
+  }
+  else
+  {
+    composers.insert( this )
+  }
+
+  QSet<QgsComposer*>::const_iterator it = composers.constBegin();
+  for ( ; it != composers.constEnd(); ++it )
+  {
+    QList<QGraphicsItem *> itemList = ( *it )->items();
+    QList<QGraphicsItem *>::iterator itemIt = itemList.begin();
+    for ( ; itemIt != itemList.end(); ++itemIt )
+    {
+      const QgsComposerItem* mypItem = dynamic_cast<const QgsComposerItem *>( *itemIt );
+      if ( mypItem )
+      {
+        if ( mypItem->uuid() == theUuid )
+        {
+          return mypItem;
+        }
+      }
+    }
+  }
+  
+  return 0;
+}
+*/
+
+const QgsComposerItem* QgsComposition::getComposerItemByUuid( QString theUuid ) const
+{
+  QList<QGraphicsItem *> itemList = items();
+  QList<QGraphicsItem *>::iterator itemIt = itemList.begin();
+  for ( ; itemIt != itemList.end(); ++itemIt )
+  {
+    const QgsComposerItem* mypItem = dynamic_cast<const QgsComposerItem *>( *itemIt );
+    if ( mypItem )
+    {
+      if ( mypItem->uuid() == theUuid )
+      {
+        return mypItem;
+      }
+    }
+  }
+  
+  return 0;
+}
 
 int QgsComposition::pixelFontSize( double pointSize ) const
 {

--- a/src/core/composer/qgscomposition.cpp
+++ b/src/core/composer/qgscomposition.cpp
@@ -436,6 +436,17 @@ bool QgsComposition::loadFromTemplate( const QDomDocument& doc, QMap<QString, QS
     return false;
   }
 
+  // remove all uuid attributes since we don't want duplicates UUIDS 
+  QDomNodeList composerItemsNodes = importDoc.elementsByTagName("ComposerItem");
+  for (int i=0; i<composerItemsNodes.count(); ++i)
+  {
+    QDomNode composerItemNode = composerItemsNodes.at(i);
+    if( composerItemNode.isElement() )
+    {
+      composerItemNode.toElement().removeAttribute("uuid");
+    }
+  }
+
   //addItemsFromXML
   addItemsFromXML( importDoc.documentElement(), importDoc, 0, addUndoCommands, 0 );
 

--- a/src/core/composer/qgscomposition.h
+++ b/src/core/composer/qgscomposition.h
@@ -30,6 +30,7 @@
 #include "qgscomposeritemcommand.h"
 #include "qgsatlascomposition.h"
 
+class QgisApp;
 class QgsComposerFrame;
 class QgsComposerItem;
 class QgsComposerMap;
@@ -50,6 +51,7 @@ class QgsComposerAttributeTable;
 class QgsComposerMultiFrame;
 class QgsComposerMultiFrameCommand;
 class QgsVectorLayer;
+class QgsComposer;
 
 /** \ingroup MapComposer
  * Graphics scene for map printing. The class manages the paper item which always
@@ -158,12 +160,23 @@ class CORE_EXPORT QgsComposition: public QGraphicsScene
     const QgsComposerHtml* getComposerHtmlByItem( QgsComposerItem *item ) const;
 
     /**Returns a composer item given its text identifier.
+       Ids are not necessarely unique, but this function returns only one element.
       @note added in 2.0
       @param theId - A QString representing the identifier of the item to
         retrieve.
       @return QgsComposerItem pointer or 0 pointer if no such item exists.
       **/
     const QgsComposerItem* getComposerItemById( QString theId ) const;
+
+    /**Returns a composer item given its unique identifier.
+      @note added in 2.0
+      @param theId - A QString representing the UUID of the item to
+      @param inAllComposers - Whether the search should be done in all composers of the project
+        retrieve.
+      @return QgsComposerItem pointer or 0 pointer if no such item exists.
+      **/
+    //const QgsComposerItem* getComposerItemByUuid( QString theUuid, bool inAllComposers = false ) const;//does not work since it's impossible to get QGisApp::instance()
+    const QgsComposerItem* getComposerItemByUuid( QString theUuid ) const;
 
     int printResolution() const {return mPrintResolution;}
     void setPrintResolution( int dpi ) {mPrintResolution = dpi;}

--- a/src/gui/qgscomposerview.cpp
+++ b/src/gui/qgscomposerview.cpp
@@ -485,6 +485,22 @@ void QgsComposerView::keyPressEvent( QKeyEvent * e )
       }
     }
     doc.appendChild( documentElement );
+
+    //if it's a copy, we have to remove the UUIDs since we don't want any duplicate UUID
+    if ( e->matches( QKeySequence::Copy ) )
+    {
+      // remove all uuid attributes
+      QDomNodeList composerItemsNodes = doc.elementsByTagName("ComposerItem");
+      for (int i=0; i<composerItemsNodes.count(); ++i)
+      {
+        QDomNode composerItemNode = composerItemsNodes.at(i);
+        if( composerItemNode.isElement() )
+        {
+          composerItemNode.toElement().removeAttribute("uuid");
+        }
+      }
+    }
+
     QMimeData *mimeData = new QMimeData;
     mimeData->setData( "text/xml", doc.toByteArray() );
     QClipboard *clipboard = QApplication::clipboard();

--- a/src/ui/qgscomposeritemwidgetbase.ui
+++ b/src/ui/qgscomposeritemwidgetbase.ui
@@ -358,15 +358,29 @@
       <property name="labelAlignment">
        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
       </property>
-      <item row="0" column="0">
-       <widget class="QLabel" name="mIdLabel">
+      <item row="1" column="0">
+       <widget class="QLabel" name="mItemUuidLabel">
         <property name="text">
-         <string>Item ID</string>
+         <string>Uuid (read-only)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QLineEdit" name="mItemUuidLineEdit">
+        <property name="readOnly">
+         <bool>true</bool>
         </property>
        </widget>
       </item>
       <item row="0" column="1">
        <widget class="QLineEdit" name="mItemIdLineEdit"/>
+      </item>
+      <item row="0" column="0">
+       <widget class="QLabel" name="mItemIdLabel">
+        <property name="text">
+         <string>Id</string>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>


### PR DESCRIPTION
Hi !

Following that discussion : http://osgeo-org.1560.n6.nabble.com/Composer-item-s-IDs-td5034938.html

The idea is to implement Uuids for QgsComposerItems, allowing to store some composer-item specific settings (for plugins, collapsibleboxes states, etc...)

1) ID : this property is unaltered. It is still a user-defined QString 
which is not necessarily unique. Only thing changed : all 
QgsComposerItems now show the ID as a ToolTip. (same behaviour as 
current QgsComposerMap) 

2) UUID: this is a new property, which is not modifiable. It consists 
of a QUuid geneated QString (looking like 
{00000000-0000-0000-0000-000000000000} ). The Uuid is generated on 
creation. It is kept when cut/paste, but regenerated on copy/paste and 
on template loading. This way, the Uuid should always be unique. 

This induces no API changes.

Another pull request will follow to make QgsComposerMap use this uuid instead of 
int QgsComposerMap::id() (since this hides QString QgsComposerItem::id() ), but this induces some deeper changes and potential API change, so I prefer to do it separately.
