### PR TITLE
Make diagram renderer (python bindings) more stable

### DIFF
--- a/python/core/qgsdiagramrendererv2.sip
+++ b/python/core/qgsdiagramrendererv2.sip
@@ -128,7 +128,7 @@ class QgsDiagramRendererV2
 
     void renderDiagram( const QgsAttributes& att, QgsRenderContext& c, const QPointF& pos );
 
-    void setDiagram( QgsDiagram* d );
+    void setDiagram( QgsDiagram* d /Transfer/ );
     const QgsDiagram* diagram() const;
 
     /**Returns list with all diagram settings in the renderer*/


### PR DESCRIPTION
Fix possible crash.
See http://hub.qgis.org/issues/7250#change-39023. (Run script twice)
