### PR TITLE
Do not wait for feature form closing for non-editable layers

### DIFF
--- a/src/app/qgisappinterface.cpp
+++ b/src/app/qgisappinterface.cpp
@@ -530,7 +530,14 @@ bool QgisAppInterface::openFeatureForm( QgsVectorLayer *vlayer, QgsFeature &f, b
     return false;
 
   QgsFeatureAction action( tr( "Attributes changed" ), f, vlayer, -1, -1, QgisApp::instance() );
-  return action.editFeature();
+  if (vlayer->isEditable())
+  {
+    return action.editFeature();
+  }
+  else
+  {
+      return action.viewFeatureForm();
+  }
 }
 
 QList<QgsMapLayer *> QgisAppInterface::editableLayers( bool modified ) const


### PR DESCRIPTION
use viewFeatureForm instead of editFeature if layer is non editable
