### PR TITLE
Keep CRS for db layers with type GEOMETRY + more flexible type selection

### DIFF
--- a/src/providers/postgres/qgspgsourceselect.cpp
+++ b/src/providers/postgres/qgspgsourceselect.cpp
@@ -467,7 +467,6 @@ void QgsPgSourceSelect::on_btnConnect_clicked()
 
             addSearchGeometryColumn( layer );
             type = "";
-            srid = "";
           }
         }
         QgsDebugMsg( QString( "adding table %1.%2" ).arg( layer.schemaName ).arg( layer.tableName ) );

--- a/src/providers/postgres/qgspgtablemodel.cpp
+++ b/src/providers/postgres/qgspgtablemodel.cpp
@@ -208,7 +208,7 @@ void QgsPgTableModel::setGeometryTypesForTable( QgsPostgresLayerProperty layerPr
 {
   QStringList typeList = layerProperty.type.split( ",", QString::SkipEmptyParts );
   QStringList sridList = layerProperty.srid.split( ",", QString::SkipEmptyParts );
-  Q_ASSERT( typeList.size() == sridList.size() );
+  Q_ASSERT( typeList.size() == sridList.size() || ( typeList.size() == 0 && sridList.size() == 1 ) );
 
   //find schema item and table item
   QStandardItem* schemaItem;
@@ -241,42 +241,29 @@ void QgsPgTableModel::setGeometryTypesForTable( QgsPostgresLayerProperty layerPr
     {
       row[ dbtmSrid ]->setText( layerProperty.srid );
 
-      if ( typeList.isEmpty() )
-      {
-        row[ dbtmType ]->setText( tr( "Select..." ) );
-        row[ dbtmType ]->setFlags( row[ dbtmType ]->flags() | Qt::ItemIsEditable );
+      row[ dbtmType ]->setText( tr( "Select..." ) );
+      row[ dbtmType ]->setFlags( row[ dbtmType ]->flags() | Qt::ItemIsEditable );
 
+      if ( sridList.isEmpty() )
+      {
         row[ dbtmSrid ]->setText( tr( "Enter..." ) );
         row[ dbtmSrid ]->setFlags( row[ dbtmSrid ]->flags() | Qt::ItemIsEditable );
-
-        foreach ( QStandardItem *item, row )
-        {
-          item->setFlags( item->flags() | Qt::ItemIsEnabled );
-        }
       }
       else
       {
-        // update existing row
-        QGis::WkbType wkbType = QgsPostgresConn::wkbTypeFromPostgis( typeList.at( 0 ) );
-
-        row[ dbtmType ]->setIcon( iconForWkbType( wkbType ) );
-        row[ dbtmType ]->setText( QgsPostgresConn::displayStringForWkbType( wkbType ) );
-        row[ dbtmType ]->setData( false, Qt::UserRole + 1 );
-        row[ dbtmType ]->setData( wkbType, Qt::UserRole + 2 );
-
         row[ dbtmSrid ]->setText( sridList.at( 0 ) );
+      }
 
-        foreach ( QStandardItem *item, row )
-        {
-          item->setFlags( item->flags() | Qt::ItemIsSelectable | Qt::ItemIsEnabled );
-        }
+      foreach ( QStandardItem *item, row )
+      {
+        item->setFlags( item->flags() | Qt::ItemIsEnabled );
+      }
 
-        for ( int j = 1; j < typeList.size(); j++ )
-        {
-          layerProperty.type = typeList[j];
-          layerProperty.srid = sridList[j];
-          addTableEntry( layerProperty );
-        }
+      for ( int j = 0; j < typeList.size(); j++ )
+      {
+        layerProperty.type = typeList[j];
+        layerProperty.srid = sridList[j];
+        addTableEntry( layerProperty );
       }
     }
   }

--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -1137,7 +1137,8 @@ void QgsPostgresConn::retrieveLayerTypes( QgsPostgresLayerProperty &layerPropert
     QStringList types;
     QStringList srids;
 
-    for ( int i = 0; i < gresult.PQntuples(); i++ )
+    int nTuples = gresult.PQntuples();
+    for ( int i = 0; i < nTuples; i++ )
     {
       QString type = gresult.PQgetvalue( i, 0 );
       QString srid = gresult.PQgetvalue( i, 1 );
@@ -1149,7 +1150,14 @@ void QgsPostgresConn::retrieveLayerTypes( QgsPostgresLayerProperty &layerPropert
     }
 
     type = types.join( "," );
-    srid = srids.join( "," );
+    if ( nTuples > 0 )
+    {
+      srid = srids.join( "," );
+    }
+    else
+    {
+      srid = layerProperty.srid;
+    }
   }
 
   QgsDebugMsg( QString( "type:%1 srid:%2" ).arg( type ).arg( srid ) );


### PR DESCRIPTION
Currently, if a db layer is of type GEOMETRY (or not contained in geometry_columns) and the search thread does not find an entry, it is always needed to enter the srid number. However, the table usually has already an srid. This patch keeps the srid if it is present.

Additionally, if the search thread has detected geometry objects, those types are added to the dialog. But if the user wants to open the layer with a new type (e.g. needs polygons even if currently there is no polygon in the table), it is not possible now. The patch always adds an extra line to select the type.

Please review.
