### PR TITLE
Don't treat null values as zero for graduated symbology

### DIFF
--- a/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.cpp
+++ b/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.cpp
@@ -193,7 +193,7 @@ QgsSymbolV2* QgsGraduatedSymbolRendererV2::symbolForFeature( QgsFeature& feature
   }
 
   // Null values should not be categorized
-  if ( attrs[mAttrNum] == "")
+  if ( attrs[mAttrNum].toString().isEmpty() )
     return NULL;
     
   // find the right category    
@@ -809,7 +809,7 @@ QgsGraduatedSymbolRendererV2* QgsGraduatedSymbolRendererV2::createRenderer(
     
     // create list of non-null attribute values
     while ( fit.nextFeature( f ) )
-      if ( f.attribute( attrNum ) != "" )
+      if ( !f.attribute( attrNum ).toString().isEmpty() )
         values.append( f.attribute( attrNum ).toDouble() );
 
     // calculate the breaks

--- a/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.cpp
+++ b/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.cpp
@@ -193,7 +193,7 @@ QgsSymbolV2* QgsGraduatedSymbolRendererV2::symbolForFeature( QgsFeature& feature
   }
 
   // Null values should not be categorized
-  if ( attrs[mAttrNum].toString().isEmpty() )
+  if ( attrs[mAttrNum].isNull() )
     return NULL;
     
   // find the right category    
@@ -809,7 +809,7 @@ QgsGraduatedSymbolRendererV2* QgsGraduatedSymbolRendererV2::createRenderer(
     
     // create list of non-null attribute values
     while ( fit.nextFeature( f ) )
-      if ( !f.attribute( attrNum ).toString().isEmpty() )
+      if ( !f.attribute( attrNum ).isNull() )
         values.append( f.attribute( attrNum ).toDouble() );
 
     // calculate the breaks

--- a/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.cpp
+++ b/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.cpp
@@ -192,7 +192,11 @@ QgsSymbolV2* QgsGraduatedSymbolRendererV2::symbolForFeature( QgsFeature& feature
     return NULL;
   }
 
-  // find the right category
+  // Null values should not be categorized
+  if ( attrs[mAttrNum] == "")
+    return NULL;
+    
+  // find the right category    
   QgsSymbolV2* symbol = symbolForValue( attrs[mAttrNum].toDouble() );
   if ( symbol == NULL )
     return NULL;
@@ -802,8 +806,12 @@ QgsGraduatedSymbolRendererV2* QgsGraduatedSymbolRendererV2::createRenderer(
     lst.append( attrNum );
 
     QgsFeatureIterator fit = vlayer->getFeatures( QgsFeatureRequest().setFlags( QgsFeatureRequest::NoGeometry ).setSubsetOfAttributes( lst ) );
+    
+    // create list of non-null attribute values
     while ( fit.nextFeature( f ) )
-      values.append( f.attribute( attrNum ).toDouble() );
+      if ( f.attribute( attrNum ) != "" )
+        values.append( f.attribute( attrNum ).toDouble() );
+
     // calculate the breaks
     if ( mode == Quantile )
     {


### PR DESCRIPTION
This fixes a regression in master where NULL values in a vector layer are treated as 0 by the quantile, jenks and standard deviation classifiers.

By my testing this should also fix #6096. 
