### PR TITLE
[Feature #6562] add editable option for all edit types

### DIFF
--- a/src/app/qgsattributedialog.cpp
+++ b/src/app/qgsattributedialog.cpp
@@ -177,7 +177,6 @@ QgsAttributeDialog::QgsAttributeDialog( QgsVectorLayer *vl, QgsFeature *thepFeat
       //show attribute alias if available
       QString myFieldName = vl->attributeDisplayName( fldIdx );
       int myFieldType = theFields[fldIdx].type();
-      bool isEditable = vl->fieldEditable( fldIdx );
 
       QWidget *myWidget = QgsAttributeEditor::createAttributeEditor( 0, 0, vl, fldIdx, myAttributes[fldIdx], mProxyWidgets );
       if ( !myWidget )
@@ -205,7 +204,7 @@ QgsAttributeDialog::QgsAttributeDialog( QgsVectorLayer *vl, QgsFeature *thepFeat
 
       if ( vl->editType( fldIdx ) != QgsVectorLayer::Immutable )
       {
-        myWidget->setEnabled( vl->isEditable() && isEditable );
+        myWidget->setEnabled( vl->isEditable() && vl->fieldEditable(fldIdx) );
       }
 
       mypInnerLayout->addWidget( myWidget, index, 1 );
@@ -234,15 +233,13 @@ QgsAttributeDialog::QgsAttributeDialog( QgsVectorLayer *vl, QgsFeature *thepFeat
       if ( !myWidgets.size() )
         continue;
 
-      bool isEditable = vl->fieldEditable( fldIdx );
-
       for ( QList<QWidget *>::const_iterator itw = myWidgets.begin(); itw != myWidgets.end(); ++itw )
       {
         QgsAttributeEditor::createAttributeEditor( mDialog, *itw, vl, fldIdx, myAttributes[fldIdx], mProxyWidgets );
 
         if ( vl->editType( fldIdx ) != QgsVectorLayer::Immutable )
         {
-          ( *itw )->setEnabled(( *itw )->isEnabled() && vl->isEditable() && isEditable );
+          ( *itw )->setEnabled( (*itw)->isEnabled() && vl->isEditable() && vl->fieldEditable( fldIdx ) );
         }
       }
     }

--- a/src/app/qgsattributedialog.cpp
+++ b/src/app/qgsattributedialog.cpp
@@ -177,6 +177,7 @@ QgsAttributeDialog::QgsAttributeDialog( QgsVectorLayer *vl, QgsFeature *thepFeat
       //show attribute alias if available
       QString myFieldName = vl->attributeDisplayName( fldIdx );
       int myFieldType = theFields[fldIdx].type();
+      bool isEditable = vl->fieldEditable( fldIdx );
 
       QWidget *myWidget = QgsAttributeEditor::createAttributeEditor( 0, 0, vl, fldIdx, myAttributes[fldIdx], mProxyWidgets );
       if ( !myWidget )
@@ -204,7 +205,7 @@ QgsAttributeDialog::QgsAttributeDialog( QgsVectorLayer *vl, QgsFeature *thepFeat
 
       if ( vl->editType( fldIdx ) != QgsVectorLayer::Immutable )
       {
-        myWidget->setEnabled( vl->isEditable() );
+        myWidget->setEnabled( vl->isEditable() && isEditable );
       }
 
       mypInnerLayout->addWidget( myWidget, index, 1 );
@@ -233,13 +234,15 @@ QgsAttributeDialog::QgsAttributeDialog( QgsVectorLayer *vl, QgsFeature *thepFeat
       if ( !myWidgets.size() )
         continue;
 
+      bool isEditable = vl->fieldEditable( fldIdx );
+
       for ( QList<QWidget *>::const_iterator itw = myWidgets.begin(); itw != myWidgets.end(); ++itw )
       {
         QgsAttributeEditor::createAttributeEditor( mDialog, *itw, vl, fldIdx, myAttributes[fldIdx], mProxyWidgets );
 
         if ( vl->editType( fldIdx ) != QgsVectorLayer::Immutable )
         {
-          ( *itw )->setEnabled(( *itw )->isEnabled() && vl->isEditable() );
+          ( *itw )->setEnabled(( *itw )->isEnabled() && vl->isEditable() && isEditable );
         }
       }
     }

--- a/src/app/qgsattributetypedialog.cpp
+++ b/src/app/qgsattributetypedialog.cpp
@@ -84,6 +84,16 @@ QMap<QString, QVariant> &QgsAttributeTypeDialog::valueMap()
   return mValueMap;
 }
 
+bool QgsAttributeTypeDialog::fieldEditable()
+{
+  return isFieldEditableCheckBox->isChecked();
+}
+
+void QgsAttributeTypeDialog::setFieldEditable(bool editable)
+{
+  isFieldEditableCheckBox->setChecked( editable );
+}
+
 QPair<QString, QString> QgsAttributeTypeDialog::checkedState()
 {
   return QPair<QString, QString>( leCheckedState->text(), leUncheckedState->text() );
@@ -538,6 +548,8 @@ void QgsAttributeTypeDialog::setStackPage( int index )
 void QgsAttributeTypeDialog::accept()
 {
   //store data to output variables
+  mFieldEditable = isFieldEditableCheckBox->isChecked();
+
   switch ( selectionListWidget->currentRow() )
   {
     default:

--- a/src/app/qgsattributetypedialog.h
+++ b/src/app/qgsattributetypedialog.h
@@ -83,6 +83,12 @@ class QgsAttributeTypeDialog: public QDialog, private Ui::QgsAttributeTypeDialog
     void setValueRelation( QgsVectorLayer::ValueRelationData valueRelationData );
 
     /**
+     * Setter for checkbox for editable state of field
+     * @param bool editable
+     */
+    void setFieldEditable( bool editable );
+
+    /**
      * Getter for checked state after editing
      * @return string representing the checked
      */
@@ -104,6 +110,11 @@ class QgsAttributeTypeDialog: public QDialog, private Ui::QgsAttributeTypeDialog
      * Getter for value relation data
      */
     QgsVectorLayer::ValueRelationData valueRelationData();
+
+    /**
+     * Getter for checkbox for editable state of field
+     */
+    bool fieldEditable();
 
   private slots:
     /**
@@ -160,6 +171,7 @@ class QgsAttributeTypeDialog: public QDialog, private Ui::QgsAttributeTypeDialog
      */
     void updateMap( const QMap<QString, QVariant> &map );
 
+    bool mFieldEditable;
 
     QMap<QString, QVariant> mValueMap;
 

--- a/src/app/qgsfieldsproperties.cpp
+++ b/src/app/qgsfieldsproperties.cpp
@@ -489,12 +489,16 @@ void QgsFieldsProperties::attributeTypeDialog()
 
   attributeTypeDialog.setIndex( index, mEditTypeMap.value( index, mLayer->editType( index ) ) );
 
+  attributeTypeDialog.setFieldEditable( mLayer->fieldEditable( index ) );
+
   if ( !attributeTypeDialog.exec() )
     return;
 
   QgsVectorLayer::EditType editType = attributeTypeDialog.editType();
-
   mEditTypeMap.insert( index, editType );
+
+  bool isFieldEditable = attributeTypeDialog.fieldEditable();
+  mFieldEditables.insert( index, isFieldEditable );
 
   QString buttonText;
   switch ( editType )
@@ -815,6 +819,8 @@ void QgsFieldsProperties::apply()
 
     QgsVectorLayer::EditType editType = editTypeFromButtonText( pb->text() );
     mLayer->setEditType( idx, editType );
+
+    mLayer->setFieldEditable( idx, mFieldEditables.value( idx, true ));
 
     switch ( editType )
     {

--- a/src/app/qgsfieldsproperties.h
+++ b/src/app/qgsfieldsproperties.h
@@ -123,6 +123,7 @@ class QgsFieldsProperties : public QWidget, private Ui_QgsFieldsPropertiesBase
     QgsAttributesTree* mAttributesTree;
     QgsAttributesList* mAttributesList;
 
+    QMap<int, bool> mFieldEditables;
     QMap<int, QgsVectorLayer::ValueRelationData> mValueRelationData;
     QMap<int, QMap<QString, QVariant> > mValueMaps;
     QMap<int, QgsVectorLayer::RangeData> mRanges;

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -2618,6 +2618,9 @@ bool QgsVectorLayer::readSymbology( const QDomNode& node, QString& errorMessage 
       EditType editType = ( EditType ) editTypeElement.attribute( "type" ).toInt();
       mEditTypes.insert( name, editType );
 
+      int editable = editTypeElement.attribute( "editable" , "1" ).toInt();
+      mFieldEditables.insert( name, editable == 1);
+
       switch ( editType )
       {
         case ValueMap:
@@ -2933,6 +2936,7 @@ bool QgsVectorLayer::writeSymbology( QDomNode& node, QDomDocument& doc, QString&
       QDomElement editTypeElement = doc.createElement( "edittype" );
       editTypeElement.setAttribute( "name", it.key() );
       editTypeElement.setAttribute( "type", it.value() );
+      editTypeElement.setAttribute( "editable", mFieldEditables[ it.key()]?1:0 );
 
       switch (( EditType ) it.value() )
       {
@@ -3893,6 +3897,22 @@ QgsVectorLayer::RangeData &QgsVectorLayer::range( int idx )
     mRanges[fieldName] = RangeData();
 
   return mRanges[fieldName];
+}
+
+bool QgsVectorLayer::fieldEditable( int idx )
+{
+  const QgsFields &fields = pendingFields();
+  if ( idx >= 0 && idx < fields.count() && mEditTypes.contains( fields[idx].name() ) )
+    return mFieldEditables[ fields[idx].name() ];
+  else
+    return false;
+}
+
+void QgsVectorLayer::setFieldEditable( int idx, bool editable )
+{
+  const QgsFields &fields = pendingFields();
+  if ( idx >= 0 && idx < fields.count() && mEditTypes.contains( fields[idx].name() ) )
+    mFieldEditables[ fields[idx].name() ] = editable;
 }
 
 void QgsVectorLayer::addOverlay( QgsVectorOverlay* overlay )

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -767,6 +767,17 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
      **/
     ValueRelationData &valueRelation( int idx );
 
+    /**is edit widget editable
+     * @note added in 1.9
+     **/
+    bool fieldEditable( int idx );
+
+    /**set edit widget editable
+     * @note added in 1.9
+     **/
+    void setFieldEditable( int idx, bool editable );
+
+
     /**Adds a new overlay to this class. QgsVectorLayer takes ownership of the object
      @note this method was added in version 1.1
      */
@@ -1058,6 +1069,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
     QStringList mCommitErrors;
 
     QMap< QString, EditType > mEditTypes;
+    QMap< QString, bool> mFieldEditables;
     QMap< QString, QMap<QString, QVariant> > mValueMaps;
     QMap< QString, RangeData > mRanges;
     QMap< QString, QPair<QString, QString> > mCheckedStates;

--- a/src/ui/qgsattributetypeedit.ui
+++ b/src/ui/qgsattributetypeedit.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>615</width>
-    <height>421</height>
+    <width>620</width>
+    <height>418</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -23,7 +23,7 @@
       </sizepolicy>
      </property>
      <property name="currentIndex">
-      <number>12</number>
+      <number>0</number>
      </property>
      <widget class="QWidget" name="lineEditPage">
       <layout class="QVBoxLayout" name="verticalLayout_1">
@@ -751,6 +751,16 @@
        <string>UUID generator</string>
       </property>
      </item>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QCheckBox" name="isFieldEditableCheckBox">
+     <property name="text">
+      <string>Editable</string>
+     </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
     </widget>
    </item>
   </layout>


### PR DESCRIPTION
I have added an option to define if a field is editable or not by the user.

I know there was the immutable edit type but, this property is more a field property than a proper edit type. Indeed, value relations, ranges or checkboxes could not be disabled before.

I have not removed the immutable type since the edit types are saved as numbers (and not text) in the project.
I would propose to change this. But for compatibility, we would have to create some translation methods (int->string, string->int) to traduce the enum type to the name of the edit type.
Discussion's open!
