### PR TITLE
Allow long/bigint columns to be used for graduated symbology (#4593)

### DIFF
--- a/src/gui/symbology-ng/qgsgraduatedsymbolrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgsgraduatedsymbolrendererv2widget.cpp
@@ -441,7 +441,7 @@ void QgsGraduatedSymbolRendererV2Widget::populateColumns()
   const QgsFields& flds = mLayer->pendingFields();
   for ( int idx = 0; idx < flds.count(); ++idx )
   {
-    if ( flds[idx].type() == QVariant::Double || flds[idx].type() == QVariant::Int )
+    if ( flds[idx].type() == QVariant::Double || flds[idx].type() == QVariant::Int || flds[idx].type() == QVariant::LongLong)
       cboGraduatedColumn->addItem( flds[idx].name() );
   }
 }


### PR DESCRIPTION
By my testing this fixes #4593 - "Graduated fill style doesn't work with bigint"
