### PR TITLE
respect the disabled option defined in the UI file

### DIFF
--- a/src/gui/qgsattributeeditor.cpp
+++ b/src/gui/qgsattributeeditor.cpp
@@ -532,7 +532,8 @@ QWidget *QgsAttributeEditor::createAttributeEditor( QWidget *parent, QWidget *ed
 
       if ( myWidget )
       {
-        myWidget->setDisabled( editType == QgsVectorLayer::Immutable );
+        if (editType == QgsVectorLayer::Immutable)
+          myWidget->setDisabled( true );
 
         QgsStringRelay* relay = NULL;
 


### PR DESCRIPTION
This is somehow related to pull request 455, but it's independent.

Right now, if you disable a widget in Qt Designer, QGIS will however enable it. This is fixing this.
