### PR TITLE
Added default value argument for readEntryList

### DIFF
--- a/python/core/qgsproject.sip
+++ b/python/core/qgsproject.sip
@@ -197,7 +197,7 @@ class QgsProject : QObject
         @note The key string <em>must</em> include '/'s.  E.g., "/foo" not "foo".
     */
     //@{
-    QStringList readListEntry( const QString & scope, const QString & key, bool * ok = 0 ) const;
+    QStringList readListEntry( const QString & scope, const QString & key, bool * ok = 0, QStringList def = QStringList() ) const;
 
     QString readEntry( const QString & scope, const QString & key, const QString & def = QString::null, bool * ok = 0 ) const;
     int readNumEntry( const QString & scope, const QString & key, int def = 0, bool * ok = 0 ) const;

--- a/python/core/qgsproject.sip
+++ b/python/core/qgsproject.sip
@@ -197,7 +197,7 @@ class QgsProject : QObject
         @note The key string <em>must</em> include '/'s.  E.g., "/foo" not "foo".
     */
     //@{
-    QStringList readListEntry( const QString & scope, const QString & key, bool * ok = 0, QStringList def = QStringList() ) const;
+    QStringList readListEntry( const QString & scope, const QString & key, QStringList def = QStringList(), bool * ok = 0 ) const;
 
     QString readEntry( const QString & scope, const QString & key, const QString & def = QString::null, bool * ok = 0 ) const;
     int readNumEntry( const QString & scope, const QString & key, int def = 0, bool * ok = 0 ) const;

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -272,7 +272,7 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas* mapCanvas, QWidget *pa
   mWMSExtMaxX->setValidator( new QDoubleValidator( mWMSExtMaxX ) );
   mWMSExtMaxY->setValidator( new QDoubleValidator( mWMSExtMaxY ) );
 
-  values = QgsProject::instance()->readListEntry( "WMSExtent", "/", &ok );
+  values = QgsProject::instance()->readListEntry( "WMSExtent", "/", QStringList(), &ok );
   grpWMSExt->setChecked( ok && values.size() == 4 );
   if ( grpWMSExt->isChecked() )
   {
@@ -282,7 +282,7 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas* mapCanvas, QWidget *pa
     mWMSExtMaxY->setText( values[3] );
   }
 
-  values = QgsProject::instance()->readListEntry( "WMSCrsList", "/", &ok );
+  values = QgsProject::instance()->readListEntry( "WMSCrsList", "/", QStringList(), &ok );
   grpWMSList->setChecked( ok && values.size() > 0 );
   if ( grpWMSList->isChecked() )
   {
@@ -290,7 +290,7 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas* mapCanvas, QWidget *pa
   }
   else
   {
-    values = QgsProject::instance()->readListEntry( "WMSEpsgList", "/", &ok );
+    values = QgsProject::instance()->readListEntry( "WMSEpsgList", "/", QStringList(), &ok );
     grpWMSList->setChecked( ok && values.size() > 0 );
     if ( grpWMSList->isChecked() )
     {
@@ -307,7 +307,7 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas* mapCanvas, QWidget *pa
   grpWMSList->setChecked( mWMSList->count() > 0 );
 
   //composer restriction for WMS
-  values = QgsProject::instance()->readListEntry( "WMSComposerList", "/", &ok );
+  values = QgsProject::instance()->readListEntry( "WMSComposerList", "/", QStringList(), &ok );
   mWMSComposerGroupBox->setChecked( ok );
   if ( ok )
   {
@@ -315,7 +315,7 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas* mapCanvas, QWidget *pa
   }
 
   //layer restriction for WMS
-  values = QgsProject::instance()->readListEntry( "WMSRestrictedLayers", "/", &ok );
+  values = QgsProject::instance()->readListEntry( "WMSRestrictedLayers", "/", QStringList(), &ok );
   mLayerRestrictionsGroupBox->setChecked( ok );
   if ( ok )
   {

--- a/src/app/qgssnappingdialog.cpp
+++ b/src/app/qgssnappingdialog.cpp
@@ -238,12 +238,13 @@ void QgsSnappingDialog::addLayer( QgsMapLayer * theMapLayer )
   }
 
   bool layerIdListOk, enabledListOk, toleranceListOk, toleranceUnitListOk, snapToListOk, avoidIntersectionListOk;
-  QStringList layerIdList = QgsProject::instance()->readListEntry( "Digitizing", "/LayerSnappingList", &layerIdListOk );
-  QStringList enabledList = QgsProject::instance()->readListEntry( "Digitizing", "/LayerSnappingEnabledList", &enabledListOk );
-  QStringList toleranceList = QgsProject::instance()->readListEntry( "Digitizing", "/LayerSnappingToleranceList", & toleranceListOk );
-  QStringList toleranceUnitList = QgsProject::instance()->readListEntry( "Digitizing", "/LayerSnappingToleranceUnitList", & toleranceUnitListOk );
-  QStringList snapToList = QgsProject::instance()->readListEntry( "Digitizing", "/LayerSnapToList", &snapToListOk );
-  QStringList avoidIntersectionsList = QgsProject::instance()->readListEntry( "Digitizing", "/AvoidIntersectionsList", &avoidIntersectionListOk );
+  QStringList defList;
+  QStringList layerIdList = QgsProject::instance()->readListEntry( "Digitizing", "/LayerSnappingList", defList, &layerIdListOk );
+  QStringList enabledList = QgsProject::instance()->readListEntry( "Digitizing", "/LayerSnappingEnabledList", defList, &enabledListOk );
+  QStringList toleranceList = QgsProject::instance()->readListEntry( "Digitizing", "/LayerSnappingToleranceList", defList, & toleranceListOk );
+  QStringList toleranceUnitList = QgsProject::instance()->readListEntry( "Digitizing", "/LayerSnappingToleranceUnitList", defList, &toleranceUnitListOk );
+  QStringList snapToList = QgsProject::instance()->readListEntry( "Digitizing", "/LayerSnapToList", defList, &snapToListOk );
+  QStringList avoidIntersectionsList = QgsProject::instance()->readListEntry( "Digitizing", "/AvoidIntersectionsList", defList, &avoidIntersectionListOk );
 
   //snap to layer yes/no
   QTreeWidgetItem *item = new QTreeWidgetItem( mLayerTreeWidget );

--- a/src/core/qgsgeometry.cpp
+++ b/src/core/qgsgeometry.cpp
@@ -7714,7 +7714,7 @@ int QgsGeometry::avoidIntersections( QMap<QgsVectorLayer*, QSet< QgsFeatureId > 
 
   //read avoid intersections list from project properties
   bool listReadOk;
-  QStringList avoidIntersectionsList = QgsProject::instance()->readListEntry( "Digitizing", "/AvoidIntersectionsList", &listReadOk );
+  QStringList avoidIntersectionsList = QgsProject::instance()->readListEntry( "Digitizing", "/AvoidIntersectionsList", QStringList(), &listReadOk );
   if ( !listReadOk )
   {
     return true; //no intersections stored in project does not mean error

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -1134,7 +1134,8 @@ QgsProject::writeEntry( QString const &scope, const QString & key,
 QStringList
 QgsProject::readListEntry( QString const & scope,
                            const QString & key,
-                           bool * ok ) const
+                           bool * ok,
+                           QStringList def ) const
 {
   QgsProperty * property = findKey_( scope, key, imp_->properties_ );
 
@@ -1157,7 +1158,7 @@ QgsProject::readListEntry( QString const & scope,
     return value.toStringList();
   }
 
-  return QStringList();
+  return def;
 } // QgsProject::readListEntry
 
 

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -1134,8 +1134,8 @@ QgsProject::writeEntry( QString const &scope, const QString & key,
 QStringList
 QgsProject::readListEntry( QString const & scope,
                            const QString & key,
-                           bool * ok,
-                           QStringList def ) const
+                           QStringList def,
+                           bool * ok) const
 {
   QgsProperty * property = findKey_( scope, key, imp_->properties_ );
 

--- a/src/core/qgsproject.h
+++ b/src/core/qgsproject.h
@@ -231,7 +231,7 @@ class CORE_EXPORT QgsProject : public QObject
         @note The key string <em>must</em> include '/'s.  E.g., "/foo" not "foo".
     */
     //@{
-    QStringList readListEntry( const QString & scope, const QString & key, bool * ok = 0, QStringList def = QStringList() ) const;
+    QStringList readListEntry( const QString & scope, const QString & key, QStringList def = QStringList(), bool *ok = 0  ) const;
 
     QString readEntry( const QString & scope, const QString & key, const QString & def = QString::null, bool * ok = 0 ) const;
     int readNumEntry( const QString & scope, const QString & key, int def = 0, bool * ok = 0 ) const;

--- a/src/core/qgsproject.h
+++ b/src/core/qgsproject.h
@@ -231,7 +231,7 @@ class CORE_EXPORT QgsProject : public QObject
         @note The key string <em>must</em> include '/'s.  E.g., "/foo" not "foo".
     */
     //@{
-    QStringList readListEntry( const QString & scope, const QString & key, bool * ok = 0 ) const;
+    QStringList readListEntry( const QString & scope, const QString & key, bool * ok = 0, QStringList def = QStringList() ) const;
 
     QString readEntry( const QString & scope, const QString & key, const QString & def = QString::null, bool * ok = 0 ) const;
     int readNumEntry( const QString & scope, const QString & key, int def = 0, bool * ok = 0 ) const;

--- a/src/gui/qgsmapcanvassnapper.cpp
+++ b/src/gui/qgsmapcanvassnapper.cpp
@@ -165,15 +165,16 @@ int QgsMapCanvasSnapper::snapToBackgroundLayers( const QPoint& p, QList<QgsSnapp
     //read snapping settings from project
     bool ok; //todo: take the default snapping tolerance for all vector layers if snapping not defined in project
     bool snappingDefinedInProject = true;
-    QStringList layerIdList = QgsProject::instance()->readListEntry( "Digitizing", "/LayerSnappingList", &ok );
+    QStringList defList;
+    QStringList layerIdList = QgsProject::instance()->readListEntry( "Digitizing", "/LayerSnappingList", defList, &ok );
     if ( !ok )
     {
       snappingDefinedInProject = false;
     }
-    QStringList enabledList = QgsProject::instance()->readListEntry( "Digitizing", "/LayerSnappingEnabledList", &ok );
-    QStringList toleranceList = QgsProject::instance()->readListEntry( "Digitizing", "/LayerSnappingToleranceList", &ok );
-    QStringList toleranceUnitList = QgsProject::instance()->readListEntry( "Digitizing", "/LayerSnappingToleranceUnitList", &ok );
-    QStringList snapToList = QgsProject::instance()->readListEntry( "Digitizing", "/LayerSnapToList", &ok );
+    QStringList enabledList = QgsProject::instance()->readListEntry( "Digitizing", "/LayerSnappingEnabledList", defList, &ok );
+    QStringList toleranceList = QgsProject::instance()->readListEntry( "Digitizing", "/LayerSnappingToleranceList", defList, &ok );
+    QStringList toleranceUnitList = QgsProject::instance()->readListEntry( "Digitizing", "/LayerSnappingToleranceUnitList", defList, &ok );
+    QStringList snapToList = QgsProject::instance()->readListEntry( "Digitizing", "/LayerSnapToList", defList, &ok );
 
     if ( !( layerIdList.size() == enabledList.size() && layerIdList.size() == toleranceList.size() && layerIdList.size() == toleranceUnitList.size() && layerIdList.size() == snapToList.size() ) )
     {


### PR DESCRIPTION
This concerns reading list entries from the project.

The first commit just added the argument at the end of the method.

In order to me more consistent with the rest of the read entry methods, I switched the default and the ok value. This is the second commit.

One could choose either the first or both commit. Second changes the API (just a bit) but is more coherent.
