### PR TITLE
Rename Quantile classifier to 'Quantile (Equal Count)'

### DIFF
--- a/src/ui/qgsgraduatedsymbolrendererv2widget.ui
+++ b/src/ui/qgsgraduatedsymbolrendererv2widget.ui
@@ -116,7 +116,7 @@
        </item>
        <item>
         <property name="text">
-         <string>Quantile</string>
+         <string>Quantile (Equal Count)</string>
         </property>
        </item>
        <item>


### PR DESCRIPTION
...to aid transitions from MapInfo to QGIS. 

MapInfo includes both an "Equal Count" and "Quantile" method for creating graduated ranges. MapInfo's Equal Count classifier behaves in a similar way to QGIS' Quantile method, and creates ranges with a roughly equal number of items in each range. In contrast, MapInfo's "Quantile" method is a confusing classifier which tries to create ranges where the sum of the value of items in a range is equal.

Since MapInfo's "Quantile" classifier is poorly understood and of use in limited circumstances it's not often used. Coming from a MapInfo background, I always assumed QGIS' "Quantile" method was the same as MapInfo's, and that QGIS had no equivalent of the  "Equal Count" classifier. 

This commit changes the name of the Quantile classifier to "Quantile (Equal Count)" to clarify the situation and make things easier for users familiar with MapInfo's terminology.
