### PR TITLE
Interface elements for specifying raster resolution in GDAL Rasterize plugin

### DIFF
--- a/python/plugins/GdalTools/tools/widgetRasterize.ui
+++ b/python/plugins/GdalTools/tools/widgetRasterize.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>509</width>
-    <height>532</height>
+    <height>261</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -236,19 +236,6 @@
       </item>
      </layout>
     </widget>
-   </item>
-   <item>
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
    </item>
   </layout>
  </widget>

--- a/python/plugins/GdalTools/tools/widgetRasterize.ui
+++ b/python/plugins/GdalTools/tools/widgetRasterize.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>509</width>
-    <height>165</height>
+    <height>532</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -71,19 +71,42 @@
     </layout>
    </item>
    <item>
-    <widget class="QGroupBox" name="resizeGroupBox">
-     <property name="title">
-      <string>New size (required if output file doens't exist)</string>
+    <widget class="QRadioButton" name="radioKeepSize">
+     <property name="text">
+      <string>Keep existing raster size and resolution</string>
      </property>
-     <property name="checkable">
+     <property name="checked">
       <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QRadioButton" name="radioSetSize">
+     <property name="text">
+      <string>Raster size in pixels</string>
      </property>
      <property name="checked">
       <bool>false</bool>
      </property>
-     <layout class="QGridLayout" name="gridLayout_7">
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_11">
+    </widget>
+   </item>
+   <item>
+    <widget class="QWidget" name="widgetSize" native="true">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <property name="leftMargin">
+       <number>30</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="labelWidth">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
           <horstretch>0</horstretch>
@@ -95,15 +118,15 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="1">
+      <item>
        <widget class="QSpinBox" name="widthSpin">
         <property name="maximum">
          <number>999999</number>
         </property>
        </widget>
       </item>
-      <item row="0" column="2">
-       <widget class="QLabel" name="label_12">
+      <item>
+       <widget class="QLabel" name="labelHeight">
         <property name="sizePolicy">
          <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
           <horstretch>0</horstretch>
@@ -118,7 +141,7 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="3">
+      <item>
        <widget class="QSpinBox" name="heightSpin">
         <property name="maximum">
          <number>999999</number>
@@ -127,6 +150,105 @@
       </item>
      </layout>
     </widget>
+   </item>
+   <item>
+    <widget class="QRadioButton" name="radioSetResolution">
+     <property name="text">
+      <string>Raster resolution in map units per pixel</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QWidget" name="widgetResolution" native="true">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_2">
+      <property name="leftMargin">
+       <number>30</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="labelHorizontal">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Horizontal</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QDoubleSpinBox" name="horizresSpin">
+        <property name="decimals">
+         <number>8</number>
+        </property>
+        <property name="maximum">
+         <double>999999999.990000009536743</double>
+        </property>
+        <property name="value">
+         <double>1.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="labelVertical">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Fixed" vsizetype="Preferred">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="text">
+         <string>Vertical</string>
+        </property>
+        <property name="indent">
+         <number>40</number>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QDoubleSpinBox" name="vertresSpin">
+        <property name="inputMethodHints">
+         <set>Qt::ImhNone</set>
+        </property>
+        <property name="decimals">
+         <number>8</number>
+        </property>
+        <property name="maximum">
+         <double>999999999.990000009536743</double>
+        </property>
+        <property name="singleStep">
+         <double>1.000000000000000</double>
+        </property>
+        <property name="value">
+         <double>2.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
    </item>
   </layout>
  </widget>
@@ -139,5 +261,38 @@
   </customwidget>
  </customwidgets>
  <resources/>
- <connections/>
+ <connections>
+  <connection>
+   <sender>radioSetSize</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>widgetSize</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>254</x>
+     <y>128</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>254</x>
+     <y>163</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>radioSetResolution</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>widgetResolution</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>254</x>
+     <y>198</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>254</x>
+     <y>233</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
 </ui>


### PR DESCRIPTION
I've added interface elements for specifying the raster resolution when converting vector to raster data using the GDAL Rasterize plugin. So far, it has only been possible to specify the raster size.
![Screenshot of GDAL Rasterize plugin with option to specify resolution](https://f.cloud.github.com/assets/2399255/270964/89d07c8c-8fd8-11e2-99a8-64e72e356f69.png)
