### PR TITLE
Add support for blending (composition) modes, eg Overlay, Mutiply, etc (#5248)

### DIFF
--- a/src/app/qgsrasterlayerproperties.cpp
+++ b/src/app/qgsrasterlayerproperties.cpp
@@ -243,6 +243,9 @@ QgsRasterLayerProperties::QgsRasterLayerProperties( QgsMapLayer* lyr, QgsMapCanv
     mMaximumOversamplingSpinBox->setValue( resampleFilter->maxOversampling() );
   }
 
+  //blend mode
+  mBlendModeComboBox->setBlendMode( mRasterLayer->blendMode() );
+
   //transparency band
   if ( provider )
   {
@@ -798,6 +801,8 @@ void QgsRasterLayerProperties::apply()
     resampleFilter->setMaxOversampling( mMaximumOversamplingSpinBox->value() );
   }
 
+  //set the blend mode for the layer
+  mRasterLayer->setBlendMode(( QgsMapLayer::BlendMode ) mBlendModeComboBox->blendMode() );
 
   //get the thumbnail for the layer
   pixmapThumbnail->setPixmap( mRasterLayer->previewAsPixmap( pixmapThumbnail->size() ) );

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -192,6 +192,9 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
     mLayerAbstractTextEdit->setPlainText( layer->abstract() );
   }
 
+  // Blend mode
+  mBlendModeComboBox->setBlendMode( layer->blendMode() );
+
   QSettings settings;
   restoreGeometry( settings.value( "/Windows/VectorLayerProperties/geometry" ).toByteArray() );
   int tabIndex = settings.value( "/Windows/VectorLayerProperties/row", 0 ).toInt();
@@ -527,6 +530,9 @@ void QgsVectorLayerProperties::apply()
   //layer title and abstract
   layer->setTitle( mLayerTitleLineEdit->text() );
   layer->setAbstract( mLayerAbstractTextEdit->toPlainText() );
+
+  // set the blend mode for the layer
+  layer->setBlendMode(( QgsMapLayer::BlendMode ) mBlendModeComboBox->blendMode() );
 
   // update symbology
   emit refreshLegend( layer->id(), QgsLegendItem::DontChange );

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -411,6 +411,15 @@ bool QgsMapLayer::readXML( const QDomNode& layer_node )
     setTransparency( myElement.text().toInt() );
   }
 
+  //read blend mode
+  QDomNode blendModeNode = layer_node.namedItem( "blendMode" );
+  if ( ! blendModeNode.isNull() )
+  {
+    // set blend mode if it's specified in project
+    QDomElement myElement = blendModeNode.toElement();
+    setBlendMode(( QgsMapLayer::BlendMode )myElement.text().toInt() );
+  }
+
   readCustomProperties( layer_node );
 
   return true;
@@ -526,6 +535,13 @@ bool QgsMapLayer::writeXML( QDomNode & layer_node, QDomDocument & document )
   QDomText    transparencyLevelIntText    = document.createTextNode( QString::number( getTransparency() ) );
   transparencyLevelIntElement.appendChild( transparencyLevelIntText );
   maplayer.appendChild( transparencyLevelIntElement );
+
+  // <blendMode>
+  QDomElement blendModeElement = document.createElement( "blendMode" );
+  QDomText blendModeText = document.createTextNode( QString::number( blendMode() ) );
+  blendModeElement.appendChild( blendModeText );
+  maplayer.appendChild( blendModeElement );
+
   // now append layer node to map layer node
 
   layer_node.appendChild( maplayer );

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -49,7 +49,8 @@ QgsMapLayer::QgsMapLayer( QgsMapLayer::LayerType type,
     mDataSource( source ),
     mLayerOrigName( lyrname ), // store the original name
     mID( "" ),
-    mLayerType( type )
+    mLayerType( type ),
+    mBlendMode( QgsMapLayer::BlendNormal ) // Default to normal blending
 {
   mCRS = new QgsCoordinateReferenceSystem();
 
@@ -132,6 +133,58 @@ QgsRectangle QgsMapLayer::extent()
 {
   return mExtent;
 }
+
+/** Write blend mode for layer */
+void QgsMapLayer::setBlendMode( const QgsMapLayer::BlendMode blendMode )
+{
+  mBlendMode = blendMode;
+}
+
+/** Read blend mode for layer */
+QgsMapLayer::BlendMode QgsMapLayer::blendMode() const
+{
+  return mBlendMode;
+}
+
+/** Returns a QPainter::CompositionMode corresponding to the current
+ * blend mode for this layer
+ */
+QPainter::CompositionMode QgsMapLayer::getCompositionMode()
+{
+  // Map QgsMapLayer::BlendNormal to QPainter::CompositionMode
+  switch ( mBlendMode )
+  {
+    case QgsMapLayer::BlendNormal:
+      return QPainter::CompositionMode_SourceOver;
+    case QgsMapLayer::BlendLighten:
+      return QPainter::CompositionMode_Lighten;
+    case QgsMapLayer::BlendScreen:
+      return QPainter::CompositionMode_Screen;
+    case QgsMapLayer::BlendDodge:
+      return QPainter::CompositionMode_ColorDodge;
+    case QgsMapLayer::BlendAddition:
+      return QPainter::CompositionMode_Plus;
+    case QgsMapLayer::BlendDarken:
+      return QPainter::CompositionMode_Darken;
+    case QgsMapLayer::BlendMultiply:
+      return QPainter::CompositionMode_Multiply;
+    case QgsMapLayer::BlendBurn:
+      return QPainter::CompositionMode_ColorBurn;
+    case QgsMapLayer::BlendOverlay:
+      return QPainter::CompositionMode_Overlay;
+    case QgsMapLayer::BlendSoftLight:
+      return QPainter::CompositionMode_SoftLight;
+    case QgsMapLayer::BlendHardLight:
+      return QPainter::CompositionMode_HardLight;
+    case QgsMapLayer::BlendDifference:
+      return QPainter::CompositionMode_Difference;
+    case QgsMapLayer::BlendSubtract:
+      return QPainter::CompositionMode_Exclusion;
+    default:
+      return QPainter::CompositionMode_SourceOver;
+  }
+}
+
 
 bool QgsMapLayer::draw( QgsRenderContext& rendererContext )
 {

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -24,6 +24,7 @@
 #include <QVariant>
 #include <QImage>
 #include <QDomNode>
+#include <QPainter>
 
 #include "qgis.h"
 #include "qgserror.h"
@@ -51,6 +52,26 @@ class CORE_EXPORT QgsMapLayer : public QObject
       VectorLayer,
       RasterLayer,
       PluginLayer // added in 1.5
+    };
+    
+    /** Blending modes enum defining the available composition modes that can
+     * be used when rendering a layer
+     */
+    enum BlendMode
+    {
+      BlendNormal,
+      BlendLighten,
+      BlendScreen,
+      BlendDodge,
+      BlendAddition,
+      BlendDarken,
+      BlendMultiply,
+      BlendBurn,
+      BlendOverlay,
+      BlendSoftLight,
+      BlendHardLight,
+      BlendDifference,
+      BlendSubtract
     };
 
     /** Constructor
@@ -93,6 +114,15 @@ class CORE_EXPORT QgsMapLayer : public QObject
 
     void setAbstract( const QString& abstract ) { mAbstract = abstract; }
     const QString& abstract() const { return mAbstract; }
+
+    /* Set the blending mode used for rendering a layer */
+    void setBlendMode( const QgsMapLayer::BlendMode blendMode );
+    /* Returns the current blending mode for a layer */
+    QgsMapLayer::BlendMode blendMode() const;
+    /** Returns a QPainter::CompositionMode corresponding to the
+     * current blending mode for the layer
+     */
+    QPainter::CompositionMode getCompositionMode();
 
     /**Synchronises with changes in the datasource
         @note added in version 1.6*/
@@ -462,6 +492,9 @@ class CORE_EXPORT QgsMapLayer : public QObject
 
     /** Type of the layer (eg. vector, raster) */
     QgsMapLayer::LayerType mLayerType;
+    
+    /** Blend mode for the layer */
+    QgsMapLayer::BlendMode mBlendMode;
 
     /** Tag for embedding additional information */
     QString mTag;

--- a/src/core/qgsmaprenderer.cpp
+++ b/src/core/qgsmaprenderer.cpp
@@ -377,13 +377,18 @@ void QgsMapRenderer::render( QPainter* painter, double* forceWidthScale )
       continue;
     }
 
-    QgsDebugMsg( QString( "layer %1:  minscale:%2  maxscale:%3  scaledepvis:%4  extent:%5" )
+    QgsDebugMsg( QString( "layer %1:  minscale:%2  maxscale:%3  scaledepvis:%4  extent:%5  blendmode:%6" )
                  .arg( ml->name() )
                  .arg( ml->minimumScale() )
                  .arg( ml->maximumScale() )
                  .arg( ml->hasScaleBasedVisibility() )
                  .arg( ml->extent().toString() )
+                 .arg( ml->blendMode() )
                );
+    
+    // Set the QPainter composition mode so that this layer is rendered using
+    // the desired blending mode
+    mypContextPainter->setCompositionMode(ml->getCompositionMode());
 
     if ( !ml->hasScaleBasedVisibility() || ( ml->minimumScale() <= mScale && mScale < ml->maximumScale() ) || mOverview )
     {

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -48,6 +48,7 @@ qgisinterface.cpp
 qgsannotationitem.cpp
 qgsattributeeditor.cpp
 qgslegendinterface.cpp
+qgsblendmodecombobox.cpp
 qgscharacterselectdialog.cpp
 qgscolorbutton.cpp
 qgscomposerview.cpp
@@ -153,6 +154,7 @@ attributetable/qgsattributetablememorymodel.h
 attributetable/qgsattributetabledelegate.h
 
 qgsattributeeditor.h
+qgsblendmodecombobox.h
 qgscharacterselectdialog.h
 qgscomposerview.h
 qgsdetaileditemdelegate.h
@@ -227,6 +229,7 @@ qgsrubberband.h
 qgsvertexmarker.h
 qgsmaptip.h
 qgsscalecombobox.h
+qgsblendmodecombobox.h
 qgssearchquerybuilder.h
 qgsattributeeditor.h
 qgsfieldvalidator.h

--- a/src/gui/qgsblendmodecombobox.cpp
+++ b/src/gui/qgsblendmodecombobox.cpp
@@ -1,0 +1,112 @@
+/***************************************************************************
+                              qgsblendmodecombobox.cpp
+                              ------------------------
+  begin                : March 21, 2013
+  copyright            : (C) 2013 by Nyall Dawson
+  email                : nyall.dawson@gmail.com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgis.h"
+#include "qgslogger.h"
+#include "qgsblendmodecombobox.h"
+
+#include <QAbstractItemView>
+#include <QLocale>
+#include <QSettings>
+#include <QLineEdit>
+
+QgsBlendModeComboBox::QgsBlendModeComboBox( QWidget* parent ) : QComboBox( parent )
+{
+  updateModes();
+}
+
+QgsBlendModeComboBox::~QgsBlendModeComboBox()
+{
+}
+
+/* Returns a QStringList of the translated blend modes
+* "-" is used to indicate the position of a seperator in the list
+* This list is designed to emulate GIMP's layer modes, where
+* blending modes are grouped by their effect (lightening, darkening, etc)
+*/
+QStringList QgsBlendModeComboBox::blendModesList() const
+{
+  return QStringList() << tr( "Normal" )
+         << "-"
+         << tr( "Lighten" )
+         << tr( "Screen" )
+         << tr( "Dodge" )
+         << tr( "Addition" )
+         << "-"
+         << tr( "Darken" )
+         << tr( "Multiply" )
+         << tr( "Burn" )
+         << "-"
+         << tr( "Overlay" )
+         << tr( "Soft light" )
+         << tr( "Hard light" )
+         << "-"
+         << tr( "Difference" )
+         << tr( "Subtract" );
+}
+
+/* Populates the blend mode combo box, and sets up mapping for
+* blend modes to combo box indexes
+*/
+void QgsBlendModeComboBox::updateModes()
+{
+  blockSignals( true );
+  clear();
+
+  QStringList myBlendModesList = blendModesList();
+  QStringList::const_iterator blendModeIt = myBlendModesList.constBegin();
+
+  mBlendModeToListIndex.resize( myBlendModesList.count() );
+  mListIndexToBlendMode.resize( myBlendModesList.count() );
+
+  // Loop through blend modes
+  int index = 0;
+  int blendModeIndex = 0;
+  for ( ; blendModeIt != myBlendModesList.constEnd(); ++blendModeIt )
+  {
+    if ( *blendModeIt == "-" )
+    {
+      // Add seperator
+      insertSeparator( index );
+    }
+    else
+    {
+      // Not a seperator, so store indexes for translation
+      // between blend modes and combo box item index
+      addItem( *blendModeIt );
+      mListIndexToBlendMode[ index ] = blendModeIndex;
+      mBlendModeToListIndex[ blendModeIndex ] = index;
+      blendModeIndex++;
+    }
+    index++;
+  }
+
+  blockSignals( false );
+}
+
+//! Function to read the selected blend mode as int
+int QgsBlendModeComboBox::blendMode()
+{
+  return mListIndexToBlendMode[ currentIndex()];
+}
+
+//! Function to set the selected blend mode from int
+void QgsBlendModeComboBox::setBlendMode( int blendMode )
+{
+  setCurrentIndex( mBlendModeToListIndex[ blendMode ] );
+}
+

--- a/src/gui/qgsblendmodecombobox.h
+++ b/src/gui/qgsblendmodecombobox.h
@@ -1,0 +1,51 @@
+/***************************************************************************
+                              qgsblendmodecombobox.h
+                              ------------------------
+  begin                : March 21, 2013
+  copyright            : (C) 2013 by Nyall Dawson
+  email                : nyall.dawson@gmail.com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSBLENDMODECOMBOBOX_H
+#define QGSBLENDMODECOMBOBOX_H
+
+#include <QComboBox>
+
+/** \ingroup gui
+ * A combobox which lets the user select blend modes from a predefined list
+ **/
+class GUI_EXPORT QgsBlendModeComboBox : public QComboBox
+{
+    Q_OBJECT
+  public:
+    QgsBlendModeComboBox( QWidget* parent = 0 );
+    virtual ~QgsBlendModeComboBox();
+
+    //! Function to read the selected blend mode as integer
+    int blendMode();
+    //! Function to set the selected blend mode from integer
+    void setBlendMode( int blendMode );
+  private:
+    //! Returns a list of grouped blend modes (with seperators)
+    QStringList blendModesList() const;
+
+    //! Used to map blend modes across to their corresponding
+    //  index within the combo box
+    std::vector<int> mBlendModeToListIndex;
+    std::vector<int> mListIndexToBlendMode;
+
+  public slots:
+    void updateModes();
+
+};
+
+#endif // QGSBLENDMODECOMBOBOX_H

--- a/src/ui/qgsrasterlayerpropertiesbase.ui
+++ b/src/ui/qgsrasterlayerpropertiesbase.ui
@@ -870,6 +870,52 @@ p, li { white-space: pre-wrap; }
         </widget>
        </item>
        <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_11">
+         <property name="leftMargin">
+          <number>0</number>
+         </property>
+         <property name="rightMargin">
+          <number>0</number>
+         </property>
+         <property name="bottomMargin">
+          <number>0</number>
+         </property>
+         <item>
+          <widget class="QLabel" name="mBlendTypeLabel">
+           <property name="text">
+            <string>Composition blending mode</string>
+           </property>
+           <property name="margin">
+            <number>0</number>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QgsBlendModeComboBox" name="mBlendModeComboBox" native="true">
+           <property name="minimumSize">
+            <size>
+             <width>0</width>
+             <height>0</height>
+            </size>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_6">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+       <item>
         <widget class="QGroupBox" name="grpSRS">
          <property name="title">
           <string>Coordinate reference system</string>
@@ -1277,6 +1323,11 @@ p, li { white-space: pre-wrap; }
    <extends>QGroupBox</extends>
    <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsBlendModeComboBox</class>
+   <extends>QWidget</extends>
+   <header>qgsblendmodecombobox.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/qgsvectorlayerpropertiesbase.ui
+++ b/src/ui/qgsvectorlayerpropertiesbase.ui
@@ -530,7 +530,7 @@ p, li { white-space: pre-wrap; }
              </layout>
             </widget>
            </item>
-           <item row="3" column="0">
+           <item row="4" column="0">
             <widget class="QGroupBox" name="grpSubset">
              <property name="title">
               <string>Subset</string>
@@ -578,7 +578,7 @@ p, li { white-space: pre-wrap; }
              </layout>
             </widget>
            </item>
-           <item row="2" column="0">
+           <item row="3" column="0">
             <widget class="QGroupBox" name="grpProviderOptions">
              <property name="title">
               <string>Provider-specific options</string>
@@ -599,6 +599,52 @@ p, li { white-space: pre-wrap; }
               </item>
              </layout>
             </widget>
+           </item>
+           <item row="2" column="0">
+            <layout class="QHBoxLayout" name="horizontalLayout_11">
+             <property name="leftMargin">
+              <number>9</number>
+             </property>
+             <property name="rightMargin">
+              <number>9</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QLabel" name="mBlendTypeLabel">
+               <property name="text">
+                <string>Composition blending mode</string>
+               </property>
+               <property name="margin">
+                <number>0</number>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QgsBlendModeComboBox" name="mBlendModeComboBox" native="true">
+               <property name="minimumSize">
+                <size>
+                 <width>0</width>
+                 <height>0</height>
+                </size>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <spacer name="horizontalSpacer_4">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+            </layout>
            </item>
           </layout>
          </widget>
@@ -1007,6 +1053,11 @@ p, li { white-space: pre-wrap; }
    <class>QgsScaleComboBox</class>
    <extends>QWidget</extends>
    <header>qgsscalecombobox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsBlendModeComboBox</class>
+   <extends>QWidget</extends>
+   <header>qgsblendmodecombobox.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>


### PR DESCRIPTION
Adds support for blending modes for vector and raster layers. Allows for some fancy cartographic effects (along the lines of http://mapbox.com/blog/tilemill-compositing-operations-preview/)!

Works for all vector and raster layers, exporting maps and composers as images, and for exporting composers as pdfs IF "print as raster" is checked. 

Todo: investigate if compositing is possible for standard pdf output.
