### PR TITLE
fix compile error

### DIFF
--- a/src/providers/grass/qgsgrassfeatureiterator.cpp
+++ b/src/providers/grass/qgsgrassfeatureiterator.cpp
@@ -17,6 +17,7 @@
 
 #include "qgsapplication.h"
 #include "qgslogger.h"
+#include "qgsmessagelog.h"
 
 extern "C"
 {
@@ -38,7 +39,7 @@ QgsGrassFeatureIterator::QgsGrassFeatureIterator( QgsGrassProvider* p, const Qgs
   // make sure that only one iterator is active
   if ( P->mActiveIterator )
   {
-    QgsMessageLog::logMessage( tr( "Already active iterator on this provider was closed." ), tr( "GRASS" ) );
+    QgsMessageLog::logMessage( QObject::tr( "Already active iterator on this provider was closed." ), QObject::tr( "GRASS" ) );
     P->mActiveIterator->close();
   }
   P->mActiveIterator = this;


### PR DESCRIPTION
Compile run throwed an error on compiling with being tr not declared.
Adding #include "qgsmessagelog.h" and QObject:tr fixed it to compile again
