### PR TITLE
[API] expose mouse wheel to map tools, use it for zoom only if no keyboard modifier pressed

### DIFF
--- a/python/gui/qgsmaptool.sip
+++ b/python/gui/qgsmaptool.sip
@@ -47,6 +47,10 @@ class QgsMapTool : QObject
     //! Mouse release event for overriding. Default implementation does nothing.
     virtual void canvasReleaseEvent( QMouseEvent * e );
 
+    //! Mouse wheel event for overriding. Default implementation does nothing.
+    //! Added in version 2.0
+    virtual void wheelEvent( QWheelEvent * e );
+
     //! Key event for overriding. Default implementation does nothing.
     virtual void keyPressEvent( QKeyEvent* e );
 

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -37,6 +37,7 @@ email                : sherman at mrcc.com
 #include <QWheelEvent>
 
 #include "qgis.h"
+#include "qgsapplication.h"
 #include "qgslogger.h"
 #include "qgsmapcanvas.h"
 #include "qgsmapcanvasmap.h"
@@ -1090,6 +1091,12 @@ void QgsMapCanvas::wheelEvent( QWheelEvent *e )
 
   if ( mDrawing )
   {
+    return;
+  }
+
+  if ( QgsApplication::keyboardModifiers() )
+  {
+    // leave the wheel for map tools if any modifier pressed
     return;
   }
 

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -1094,6 +1094,11 @@ void QgsMapCanvas::wheelEvent( QWheelEvent *e )
     return;
   }
 
+  if ( mMapTool )
+  {
+    mMapTool->wheelEvent( e );
+  }
+
   if ( QgsApplication::keyboardModifiers() )
   {
     // leave the wheel for map tools if any modifier pressed

--- a/src/gui/qgsmaptool.cpp
+++ b/src/gui/qgsmaptool.cpp
@@ -131,6 +131,11 @@ void QgsMapTool::canvasReleaseEvent( QMouseEvent *e )
   Q_UNUSED( e );
 }
 
+void QgsMapTool::wheelEvent( QWheelEvent *e )
+{
+  Q_UNUSED( e );
+}
+
 void QgsMapTool::keyPressEvent( QKeyEvent *e )
 {
   Q_UNUSED( e );

--- a/src/gui/qgsmaptool.h
+++ b/src/gui/qgsmaptool.h
@@ -30,6 +30,7 @@ class QgsMapLayer;
 class QgsMapCanvas;
 class QKeyEvent;
 class QMouseEvent;
+class QWheelEvent;
 class QgsPoint;
 class QgsRectangle;
 class QPoint;
@@ -60,6 +61,10 @@ class GUI_EXPORT QgsMapTool : public QObject
 
     //! Mouse release event for overriding. Default implementation does nothing.
     virtual void canvasReleaseEvent( QMouseEvent * e );
+
+    //! Mouse wheel event for overriding. Default implementation does nothing.
+    //! Added in version 2.0
+    virtual void wheelEvent ( QWheelEvent* e );
 
     //! Key event for overriding. Default implementation does nothing.
     virtual void keyPressEvent( QKeyEvent* e );


### PR DESCRIPTION
Sometimes in custom map tools I'd need to adjust some parameters with mouse wheel.

If nobody opposes, this patch detaches the wheel from zoom function if any keyboard modifier pressed to make it available for map tools.
