### PR TITLE
WFS Layer Selection UI Improvements

### DIFF
--- a/src/providers/wfs/qgswfssourceselect.cpp
+++ b/src/providers/wfs/qgswfssourceselect.cpp
@@ -78,8 +78,9 @@ QgsWFSSourceSelect::QgsWFSSourceSelect( QWidget* parent, Qt::WFlags fl, bool emb
   treeView->setItemDelegate( mItemDelegate );
 
   QSettings settings;
-  QgsDebugMsg( "restoring geometry" );
+  QgsDebugMsg( "restoring settings" );
   restoreGeometry( settings.value( "/Windows/WFSSourceSelect/geometry" ).toByteArray() );
+  cbxUseTitleLayerName->setChecked( settings.value( "/Windows/WFSSourceSelect/UseTitleLayerName", false ).toBool() );
 
   mModel = new QStandardItemModel();
   mModel->setHorizontalHeaderItem( 0, new QStandardItem( "Title" ) );
@@ -100,8 +101,9 @@ QgsWFSSourceSelect::QgsWFSSourceSelect( QWidget* parent, Qt::WFlags fl, bool emb
 QgsWFSSourceSelect::~QgsWFSSourceSelect()
 {
   QSettings settings;
-  QgsDebugMsg( "saving geometry" );
+  QgsDebugMsg( "saving settings" );
   settings.setValue( "/Windows/WFSSourceSelect/geometry", saveGeometry() );
+  settings.setValue( "/Windows/WFSSourceSelect/UseTitleLayerName", cbxUseTitleLayerName->isChecked() );
 
   delete mItemDelegate;
   delete mProjectionSelector;
@@ -377,7 +379,13 @@ void QgsWFSSourceSelect::addLayer()
     }
     int row = idx.row();
     QString typeName = mModel->item( row,  1 )->text(); //WFS repository's name for layer
+    QString titleName = mModel->item( row,  0 )->text(); //WFS type name title for layer name (if option is set)
     QString filter = mModel->item( row,  4 )->text(); //optional filter specified by user
+    QString layerName = typeName;
+    if ( cbxUseTitleLayerName->isChecked() && !titleName.isEmpty() )
+    {
+        layerName = titleName;
+    }
     QgsDebugMsg( "Layer " + typeName + " Filter is " + filter );
     //is "cache features" checked?
     if ( mModel->item( row,  3 )->checkState() == Qt::Checked )
@@ -388,7 +396,7 @@ void QgsWFSSourceSelect::addLayer()
     { //no: include BBOX of current canvas extent in URI
       mUri = conn.uriGetFeature( typeName, pCrsString, filter, extent );
     }
-    emit addWfsLayer( mUri, typeName );
+    emit addWfsLayer( mUri, layerName );
   }
   accept();
 }

--- a/src/providers/wfs/qgswfssourceselect.cpp
+++ b/src/providers/wfs/qgswfssourceselect.cpp
@@ -35,6 +35,7 @@
 #include <QMessageBox>
 #include <QSettings>
 #include <QFileDialog>
+#include <QPainter>
 
 
 QgsWFSSourceSelect::QgsWFSSourceSelect( QWidget* parent, Qt::WFlags fl, bool embeddedMode )
@@ -43,30 +44,57 @@ QgsWFSSourceSelect::QgsWFSSourceSelect( QWidget* parent, Qt::WFlags fl, bool emb
 {
   setupUi( this );
 
-  btnAdd = buttonBox->button( QDialogButtonBox::Apply );
-  btnAdd->setEnabled( false );
-
   if ( embeddedMode )
   {
-    buttonBox->button( QDialogButtonBox::Apply )->hide();
     buttonBox->button( QDialogButtonBox::Close )->hide();
   }
 
-  connect( buttonBox->button( QDialogButtonBox::Apply ), SIGNAL( clicked() ), this, SLOT( addLayer() ) );
+  mAddButton = new QPushButton( tr( "&Add" ) );
+  mAddButton->setEnabled( false );
+
+  mBuildQueryButton = new QPushButton( tr( "&Build query" ) );
+  mBuildQueryButton->setToolTip( tr( "Build query" ) );
+  mBuildQueryButton->setDisabled( true );
+
+
+  buttonBox->addButton( mAddButton, QDialogButtonBox::ActionRole );
+  connect( mAddButton, SIGNAL( clicked() ), this, SLOT( addLayer() ) );
+
+  buttonBox->addButton( mBuildQueryButton, QDialogButtonBox::ActionRole );
+  connect( mBuildQueryButton, SIGNAL( clicked() ), this, SLOT( on_mBuildQueryButton_clicked() ) );
+
   connect( buttonBox, SIGNAL( rejected() ), this, SLOT( reject() ) );
   connect( btnNew, SIGNAL( clicked() ), this, SLOT( addEntryToServerList() ) );
   connect( btnEdit, SIGNAL( clicked() ), this, SLOT( modifyEntryOfServerList() ) );
   connect( btnDelete, SIGNAL( clicked() ), this, SLOT( deleteEntryOfServerList() ) );
   connect( btnConnect, SIGNAL( clicked() ), this, SLOT( connectToServer() ) );
   connect( btnChangeSpatialRefSys, SIGNAL( clicked() ), this, SLOT( changeCRS() ) );
-  connect( treeWidget, SIGNAL( currentItemChanged( QTreeWidgetItem*, QTreeWidgetItem* ) ), this, SLOT( changeCRSFilter() ) );
+  connect( lineFilter, SIGNAL( textChanged( QString ) ), this, SLOT( filterChanged( QString ) ) );
   populateConnectionList();
   mProjectionSelector = new QgsGenericProjectionSelector( this );
   mProjectionSelector->setMessage();
 
+  mItemDelegate = new QgsWFSItemDelegate( treeView );
+  treeView->setItemDelegate( mItemDelegate );
+
   QSettings settings;
   QgsDebugMsg( "restoring geometry" );
   restoreGeometry( settings.value( "/Windows/WFSSourceSelect/geometry" ).toByteArray() );
+
+  mModel = new QStandardItemModel();
+  mModel->setHorizontalHeaderItem( 0, new QStandardItem( "Title" ) );
+  mModel->setHorizontalHeaderItem( 1, new QStandardItem( "Name" ) );
+  mModel->setHorizontalHeaderItem( 2, new QStandardItem( "Abstract" ) );
+  mModel->setHorizontalHeaderItem( 3, new QStandardItem( "Cache Feature" ) );
+  mModel->setHorizontalHeaderItem( 4, new QStandardItem( "Filter" ) );
+
+  mModelProxy = new QSortFilterProxyModel( this );
+  mModelProxy->setSourceModel( mModel );
+  mModelProxy->setSortCaseSensitivity( Qt::CaseInsensitive );
+  treeView->setModel( mModelProxy );
+
+  connect( treeView, SIGNAL( doubleClicked(const QModelIndex&) ), this, SLOT( on_treeWidget_itemDoubleClicked(const QModelIndex&) ) );
+  connect( treeView->selectionModel(), SIGNAL( currentRowChanged ( QModelIndex, QModelIndex) ), this, SLOT( on_treeWidget_currentRowChanged(const QModelIndex&, const QModelIndex&) ) );
 }
 
 QgsWFSSourceSelect::~QgsWFSSourceSelect()
@@ -75,8 +103,13 @@ QgsWFSSourceSelect::~QgsWFSSourceSelect()
   QgsDebugMsg( "saving geometry" );
   settings.setValue( "/Windows/WFSSourceSelect/geometry", saveGeometry() );
 
+  delete mItemDelegate;
   delete mProjectionSelector;
   delete mCapabilities;
+  delete mModel;
+  delete mModelProxy;
+  delete mAddButton;
+  delete mBuildQueryButton;
 }
 
 void QgsWFSSourceSelect::populateConnectionList()
@@ -183,13 +216,18 @@ void QgsWFSSourceSelect::capabilitiesReplyFinished()
   foreach ( QgsWFSCapabilities::FeatureType featureType, caps.featureTypes )
   {
     // insert the typenames, titles and abstracts into the tree view
-    QTreeWidgetItem* newItem = new QTreeWidgetItem();
-    newItem->setText( 0, featureType.title );
-    newItem->setText( 1, featureType.name );
-    newItem->setText( 2, featureType.abstract );
-    newItem->setToolTip( 2, "<font color=black>" + featureType.abstract  + "</font>" );
-    newItem->setCheckState( 3, Qt::Checked );
-    treeWidget->addTopLevelItem( newItem );
+    QStandardItem* titleItem = new QStandardItem( featureType.title );
+    QStandardItem* nameItem = new QStandardItem( featureType.name );
+    QStandardItem* abstractItem = new QStandardItem( featureType.abstract );
+    abstractItem->setToolTip( "<font color=black>" + featureType.abstract  + "</font>" );
+    abstractItem->setTextAlignment( Qt::AlignLeft | Qt::AlignTop );
+    QStandardItem* cachedItem = new QStandardItem();
+    QStandardItem* filterItem = new QStandardItem();
+    cachedItem->setCheckable( true );
+    cachedItem->setCheckState( Qt::Checked );
+
+    typedef QList< QStandardItem* > StandardItemList;
+    mModel->appendRow( StandardItemList() << titleItem << nameItem << abstractItem << cachedItem << filterItem);
 
     // insert the available CRS into mAvailableCRS
     std::list<QString> currentCRSList;
@@ -202,14 +240,30 @@ void QgsWFSSourceSelect::capabilitiesReplyFinished()
 
   if ( caps.featureTypes.count() > 0 )
   {
-    btnAdd->setEnabled( true );
-    treeWidget->setCurrentItem( treeWidget->topLevelItem( 0 ) );
+    treeView->resizeColumnToContents( 0 );
+    treeView->resizeColumnToContents( 1 );
+    treeView->resizeColumnToContents( 2 );
+    treeView->resizeColumnToContents( 3 );
+    for  ( int i = 0; i < 2; i++ )
+    {
+        if ( treeView->columnWidth( i ) > 300 )
+        {
+            treeView->setColumnWidth( i, 300 );
+        }
+    }
+    if ( treeView->columnWidth( 2 ) > 150 )
+    {
+        treeView->setColumnWidth( 2, 150 );
+    }
     btnChangeSpatialRefSys->setEnabled( true );
+    treeView->selectionModel()->select( mModel->index( 0, 0 ), QItemSelectionModel::SelectCurrent | QItemSelectionModel::Rows );
+    treeView->setFocus();
   }
   else
   {
     QMessageBox::information( 0, tr( "No Layers" ), tr( "capabilities document contained no layers." ) );
-    btnAdd->setEnabled( false );
+    mAddButton->setEnabled( false );
+    mBuildQueryButton->setEnabled( false );
   }
 }
 
@@ -253,8 +307,10 @@ void QgsWFSSourceSelect::deleteEntryOfServerList()
 void QgsWFSSourceSelect::connectToServer()
 {
   btnConnect->setEnabled( false );
-  treeWidget->clear();
-
+  if ( mModel )
+  {
+      mModel->removeRows( 0, mModel->rowCount() );
+  }
   if ( mCapabilities )
   {
     mCapabilities->requestCapabilities();
@@ -264,15 +320,12 @@ void QgsWFSSourceSelect::connectToServer()
 
 void QgsWFSSourceSelect::addLayer()
 {
-  //get selected entry in lstWidget
-  QTreeWidgetItem* tItem = treeWidget->currentItem();
-  if ( !tItem )
+  //get selected entry in treeview
+  QModelIndex currentIndex = treeView->selectionModel()->currentIndex();
+  if ( !currentIndex.isValid() )
   {
     return;
   }
-
-  QList<QTreeWidgetItem*> selectedItems = treeWidget->selectedItems();
-  QList<QTreeWidgetItem*>::const_iterator sIt = selectedItems.constBegin();
 
   QgsOWSConnection connection( "WFS", cmbConnections->currentText() );
   QgsWFSCapabilities conn( connection.uri().encodedUri() );
@@ -312,13 +365,22 @@ void QgsWFSSourceSelect::addLayer()
       }
     }
   }
+
   //create layers that user selected from this WFS source
-  for ( ; sIt != selectedItems.constEnd(); ++sIt )
+  QModelIndexList list = treeView->selectionModel()->selectedRows();
+  for ( int i = 0; i < list.size(); i++ )
   { //add a wfs layer to the map
-    QString typeName = ( *sIt )->text( 1 );  //WFS repository's name for layer
-    QString filter = ( *sIt )->text( 4 );    //optional filter specified by user
+    QModelIndex idx = mModelProxy->mapToSource( list[i] );
+    if ( !idx.isValid() )
+    {
+      continue;
+    }
+    int row = idx.row();
+    QString typeName = mModel->item( row,  1 )->text(); //WFS repository's name for layer
+    QString filter = mModel->item( row,  4 )->text(); //optional filter specified by user
+    QgsDebugMsg( "Layer " + typeName + " Filter is " + filter );
     //is "cache features" checked?
-    if (( *sIt )->checkState( 3 ) == Qt::Checked )
+    if ( mModel->item( row,  3 )->checkState() == Qt::Checked )
     { //yes: entire WFS layer will be retrieved and cached
       mUri = conn.uriGetFeature( typeName, pCrsString, filter );
     }
@@ -329,6 +391,48 @@ void QgsWFSSourceSelect::addLayer()
     emit addWfsLayer( mUri, typeName );
   }
   accept();
+}
+
+void QgsWFSSourceSelect::buildQuery( const QModelIndex& index )
+{
+    if ( !index.isValid() )
+    {
+        return;
+    }
+    QModelIndex filterIndex = index.sibling( index.row(), 4 );
+    QString typeName = index.sibling( index.row(), 1 ).data().toString();
+
+    //get available fields for wfs layer
+    QgsWFSProvider p( "" );  //bypasses most provider instantiation logic
+    QgsOWSConnection connection( "WFS", cmbConnections->currentText() );
+    QgsWFSCapabilities conn( connection.uri().encodedUri() );
+    QString uri = conn.uriDescribeFeatureType( typeName );
+
+    QgsFields fields;
+    QString geometryAttribute;
+    QGis::WkbType geomType;
+    if ( p.describeFeatureType( uri, geometryAttribute, fields, geomType ) != 0 )
+    {
+      return;
+    }
+
+    //show expression builder
+    QgsExpressionBuilderDialog d( 0, filterIndex.data().toString() );
+
+    //add available attributes to expression builder
+    QgsExpressionBuilderWidget* w = d.expressionBuilder();
+    if ( !w )
+    {
+      return;
+    }
+
+    w->loadFieldNames( fields );
+
+    if ( d.exec() == QDialog::Accepted )
+    {
+      QgsDebugMsg( "Expression text = " + w->expressionText() );
+      mModelProxy->setData( filterIndex, QVariant( w->expressionText() ) );
+    }
 }
 
 void QgsWFSSourceSelect::changeCRS()
@@ -342,11 +446,12 @@ void QgsWFSSourceSelect::changeCRS()
 
 void QgsWFSSourceSelect::changeCRSFilter()
 {
+  QgsDebugMsg("changeCRSFilter called");
   //evaluate currently selected typename and set the CRS filter in mProjectionSelector
-  QTreeWidgetItem* currentTreeItem = treeWidget->currentItem();
-  if ( currentTreeItem )
+  QModelIndex currentIndex = treeView->selectionModel()->currentIndex();
+  if ( currentIndex.isValid() )
   {
-    QString currentTypename = currentTreeItem->text( 1 );
+    QString currentTypename = currentIndex.sibling( currentIndex.row(), 1 ).data().toString();
     QgsDebugMsg( QString( "the current typename is: %1" ).arg( currentTypename ) );
 
     std::map<QString, std::list<QString> >::const_iterator crsIterator = mAvailableCRS.find( currentTypename );
@@ -410,39 +515,47 @@ void QgsWFSSourceSelect::on_btnLoad_clicked()
   emit connectionsChanged();
 }
 
-void QgsWFSSourceSelect::on_treeWidget_itemDoubleClicked( QTreeWidgetItem* item, int column )
+void QgsWFSSourceSelect::on_treeWidget_itemDoubleClicked( const QModelIndex& index )
 {
-  if ( item && column == 4 )
-  {
-    //get available fields for wfs layer
-    QgsWFSProvider p( "" );  //bypasses most provider instantiation logic
-    QgsOWSConnection connection( "WFS", cmbConnections->currentText() );
-    QgsWFSCapabilities conn( connection.uri().encodedUri() );
-    QString uri = conn.uriDescribeFeatureType( item->text( 1 ) );
+  QgsDebugMsg( "double click called" );
+  buildQuery( index );
+}
 
-    QgsFields fields;
-    QString geometryAttribute;
-    QGis::WkbType geomType;
-    if ( p.describeFeatureType( uri, geometryAttribute, fields, geomType ) != 0 )
+void QgsWFSSourceSelect::on_treeWidget_currentRowChanged( const QModelIndex & current, const QModelIndex & previous)
+{
+  Q_UNUSED( previous )
+  QgsDebugMsg( "treeWidget_currentRowChanged called" );
+  changeCRSFilter();
+  mBuildQueryButton->setEnabled( current.isValid() );
+  mAddButton->setEnabled( current.isValid() );
+}
+
+void QgsWFSSourceSelect::on_mBuildQueryButton_clicked()
+{
+  QgsDebugMsg( "mBuildQueryButton click called" );
+  buildQuery( treeView->selectionModel()->currentIndex() );
+}
+
+void QgsWFSSourceSelect::filterChanged(QString text)
+{
+  QgsDebugMsg( "WFS FeatureType filter changed to :" + text );
+  QRegExp::PatternSyntax mySyntax = QRegExp::PatternSyntax( QRegExp::RegExp );
+  Qt::CaseSensitivity myCaseSensitivity = Qt::CaseInsensitive;
+  QRegExp myRegExp( text, myCaseSensitivity, mySyntax );
+  mModelProxy->setFilterRegExp( myRegExp );
+  mModelProxy->sort( mModelProxy->sortColumn(), mModelProxy->sortOrder() );
+}
+
+QSize QgsWFSItemDelegate::sizeHint ( const QStyleOptionViewItem & option, const QModelIndex & index ) const
+{
+    QVariant indexData;
+    indexData = index.data(Qt::DisplayRole);
+    if ( indexData.isNull() )
     {
-      return;
+        return QSize();
     }
-
-    //show expression builder
-    QgsExpressionBuilderDialog d( 0, item->text( 3 ) );
-
-    //add available attributes to expression builder
-    QgsExpressionBuilderWidget* w = d.expressionBuilder();
-    if ( !w )
-    {
-      return;
-    }
-
-    w->loadFieldNames( fields );
-
-    if ( d.exec() == QDialog::Accepted )
-    {
-      item->setText( 4, w->expressionText() );
-    }
-  }
+    QString data = indexData.toString();
+    QSize size = option.fontMetrics.boundingRect(data).size();
+    size.setHeight(size.height() + 2);
+    return size;
 }

--- a/src/providers/wfs/qgswfssourceselect.cpp
+++ b/src/providers/wfs/qgswfssourceselect.cpp
@@ -339,8 +339,6 @@ void QgsWFSSourceSelect::addLayer()
   QVariant extentVariant = property( "MapExtent" );
   if ( extentVariant.isValid() )
   {
-    QString crs;
-    QgsCoordinateTransform xform;
     QString extentString = extentVariant.toString();
     QStringList minMaxSplit = extentString.split( ":" );
     if ( minMaxSplit.size() > 1 )

--- a/src/providers/wfs/qgswfssourceselect.h
+++ b/src/providers/wfs/qgswfssourceselect.h
@@ -21,8 +21,24 @@
 #include "ui_qgswfssourceselectbase.h"
 #include "qgscontexthelp.h"
 
+#include <QItemDelegate>
+#include <QStandardItemModel>
+#include <QSortFilterProxyModel>
+
 class QgsGenericProjectionSelector;
 class QgsWFSCapabilities;
+
+class QgsWFSItemDelegate : public QItemDelegate
+{
+  Q_OBJECT
+
+  public:
+
+      QgsWFSItemDelegate(QObject *parent=0) : QItemDelegate(parent){ }
+
+      virtual QSize sizeHint(const QStyleOptionViewItem &option, const QModelIndex &index) const;
+
+};
 
 class QgsWFSSourceSelect: public QDialog, private Ui::QgsWFSSourceSelectBase
 {
@@ -47,6 +63,11 @@ class QgsWFSSourceSelect: public QDialog, private Ui::QgsWFSSourceSelectBase
     QAbstractButton* btnAdd;
     QgsWFSCapabilities* mCapabilities;
     QString mUri;            // data source URI
+    QgsWFSItemDelegate* mItemDelegate;
+    QStandardItemModel* mModel;
+    QSortFilterProxyModel* mModelProxy;
+    QPushButton *mBuildQueryButton;
+    QPushButton *mAddButton;
 
     void populateConnectionList();
 
@@ -63,16 +84,21 @@ class QgsWFSSourceSelect: public QDialog, private Ui::QgsWFSSourceSelectBase
     void deleteEntryOfServerList();
     void connectToServer();
     void addLayer();
+    void buildQuery( const QModelIndex& index );
     void changeCRS();
     void changeCRSFilter();
     void on_cmbConnections_activated( int index );
     void capabilitiesReplyFinished();
     void on_btnSave_clicked();
     void on_btnLoad_clicked();
-    void on_treeWidget_itemDoubleClicked( QTreeWidgetItem* item, int column );
+    void on_treeWidget_itemDoubleClicked( const QModelIndex & index );
+    void on_treeWidget_currentRowChanged( const QModelIndex & current, const QModelIndex & previous);
+    void on_mBuildQueryButton_clicked();
+    void filterChanged(QString text);
 
     void on_buttonBox_helpRequested() { QgsContextHelp::run( metaObject()->className() ); }
 
 };
+
 
 #endif

--- a/src/ui/qgswfssourceselectbase.ui
+++ b/src/ui/qgswfssourceselectbase.ui
@@ -14,7 +14,17 @@
    <string>Add WFS Layer from a Server</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="3" column="0">
+   <item row="5" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Close|QDialogButtonBox::Help</set>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
     <widget class="QGroupBox" name="gbCRS">
      <property name="title">
       <string>Coordinate reference system</string>
@@ -60,16 +70,6 @@
        </widget>
       </item>
      </layout>
-    </widget>
-   </item>
-   <item row="4" column="0">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Close|QDialogButtonBox::Help</set>
-     </property>
     </widget>
    </item>
    <item row="1" column="0">
@@ -208,6 +208,13 @@
      <attribute name="headerVisible">
       <bool>true</bool>
      </attribute>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QCheckBox" name="cbxUseTitleLayerName">
+     <property name="text">
+      <string>Use title for layer name</string>
+     </property>
     </widget>
    </item>
   </layout>

--- a/src/ui/qgswfssourceselectbase.ui
+++ b/src/ui/qgswfssourceselectbase.ui
@@ -14,6 +14,94 @@
    <string>Add WFS Layer from a Server</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
+   <item row="3" column="0">
+    <widget class="QGroupBox" name="gbCRS">
+     <property name="title">
+      <string>Coordinate reference system</string>
+     </property>
+     <layout class="QHBoxLayout">
+      <property name="spacing">
+       <number>6</number>
+      </property>
+      <property name="margin">
+       <number>9</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="labelCoordRefSys">
+        <property name="text">
+         <string/>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer>
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Expanding</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>441</width>
+          <height>23</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QPushButton" name="btnChangeSpatialRefSys">
+        <property name="enabled">
+         <bool>false</bool>
+        </property>
+        <property name="text">
+         <string>Change ...</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Close|QDialogButtonBox::Help</set>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayoutFilter">
+     <item>
+      <widget class="QLabel" name="labelFilter">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="text">
+        <string>Filter:</string>
+       </property>
+       <property name="buddy">
+        <cstring>lineFilter</cstring>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="lineFilter">
+       <property name="enabled">
+        <bool>true</bool>
+       </property>
+       <property name="toolTip">
+        <string>Display WFS FeatureTypes containing this word in the title, name or abstract</string>
+       </property>
+       <property name="whatsThis">
+        <string>Display WFS FeatureTypes containing this word in the title, name or abstract</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
    <item row="0" column="0">
     <widget class="QGroupBox" name="GroupBox1">
      <property name="title">
@@ -103,110 +191,23 @@
      </layout>
     </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="QTreeWidget" name="treeWidget">
+   <item row="2" column="0">
+    <widget class="QTreeView" name="treeView">
+     <property name="editTriggers">
+      <set>QAbstractItemView::NoEditTriggers</set>
+     </property>
+     <property name="alternatingRowColors">
+      <bool>true</bool>
+     </property>
      <property name="selectionMode">
-      <enum>QAbstractItemView::ExtendedSelection</enum>
+      <enum>QAbstractItemView::MultiSelection</enum>
      </property>
      <property name="sortingEnabled">
       <bool>true</bool>
      </property>
-     <property name="columnCount">
-      <number>5</number>
-     </property>
-     <attribute name="headerMinimumSectionSize">
-      <number>27</number>
+     <attribute name="headerVisible">
+      <bool>true</bool>
      </attribute>
-     <attribute name="headerMinimumSectionSize">
-      <number>27</number>
-     </attribute>
-     <column>
-      <property name="text">
-       <string>Title</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Name</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Abstract</string>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Cache
-Features</string>
-      </property>
-      <property name="textAlignment">
-       <set>AlignHCenter|AlignVCenter|AlignCenter</set>
-      </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Filter</string>
-      </property>
-     </column>
-    </widget>
-   </item>
-   <item row="2" column="0">
-    <widget class="QGroupBox" name="gbCRS">
-     <property name="title">
-      <string>Coordinate reference system</string>
-     </property>
-     <layout class="QHBoxLayout">
-      <property name="spacing">
-       <number>6</number>
-      </property>
-      <property name="margin">
-       <number>9</number>
-      </property>
-      <item>
-       <widget class="QLabel" name="labelCoordRefSys">
-        <property name="text">
-         <string/>
-        </property>
-       </widget>
-      </item>
-      <item>
-       <spacer>
-        <property name="orientation">
-         <enum>Qt::Horizontal</enum>
-        </property>
-        <property name="sizeType">
-         <enum>QSizePolicy::Expanding</enum>
-        </property>
-        <property name="sizeHint" stdset="0">
-         <size>
-          <width>441</width>
-          <height>23</height>
-         </size>
-        </property>
-       </spacer>
-      </item>
-      <item>
-       <widget class="QPushButton" name="btnChangeSpatialRefSys">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="text">
-         <string>Change ...</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Apply|QDialogButtonBox::Close|QDialogButtonBox::Help</set>
-     </property>
     </widget>
    </item>
   </layout>
@@ -217,7 +218,7 @@ Features</string>
   <tabstop>btnNew</tabstop>
   <tabstop>btnEdit</tabstop>
   <tabstop>btnDelete</tabstop>
-  <tabstop>treeWidget</tabstop>
+  <tabstop>treeView</tabstop>
   <tabstop>btnChangeSpatialRefSys</tabstop>
   <tabstop>buttonBox</tabstop>
  </tabstops>

--- a/src/ui/qgswfssourceselectbase.ui
+++ b/src/ui/qgswfssourceselectbase.ui
@@ -200,7 +200,7 @@
       <bool>true</bool>
      </property>
      <property name="selectionMode">
-      <enum>QAbstractItemView::MultiSelection</enum>
+      <enum>QAbstractItemView::ExtendedSelection</enum>
      </property>
      <property name="sortingEnabled">
       <bool>true</bool>


### PR DESCRIPTION
This pull request enhances the WFS layer selection UI to:
- Improves the row and column sizing for the item list
- Allow filtering type name by keywords
- Using the type name title for the layer name when add to the map

The main driver for this enhancement is usability of the LINZ Data Service (http://data.linz.govt.nz) which has over 800 layers in it's WFS service. Also to make typeName names unique the service uses ID identifiers, and "titles" for the actual layer name.

See attached screenshot for the proposed changes.

![wfs_ui_improvements](https://f.cloud.github.com/assets/580022/326695/8b68e60e-9b42-11e2-9869-0598d866ef68.png)
