### PR TITLE
[FIX #7485]: Don't crash when expression fails to parse in dual view/preview column.

### DIFF
--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -27,6 +27,7 @@
 #include <QDialog>
 #include <QMenu>
 #include <QProgressDialog>
+#include <QMessageBox>
 
 QgsDualView::QgsDualView( QWidget* parent )
     : QStackedWidget( parent )
@@ -262,7 +263,16 @@ void QgsDualView::previewColumnChanged( QObject* action )
 
   if ( previewAction )
   {
-    mFeatureList->setDisplayExpression( previewAction->text() );
+    if ( !mFeatureList->setDisplayExpression( previewAction->text() ) )
+    {
+      QMessageBox::warning( this
+                            , tr( "Could not set preview column" )
+                            , tr( "Could not set column '%1' as preview column.\nParser error:\n%2" )
+                              .arg( previewAction->text() )
+                              .arg( mFeatureList->parserErrorString() )
+                          );
+    }
+
     mFeatureListPreviewButton->setDefaultAction( previewAction );
     mFeatureListPreviewButton->setPopupMode( QToolButton::InstantPopup );
   }

--- a/src/gui/attributetable/qgsfeaturelistmodel.cpp
+++ b/src/gui/attributetable/qgsfeaturelistmodel.cpp
@@ -107,7 +107,7 @@ QItemSelectionModel* QgsFeatureListModel::masterSelection()
   return mFilterModel->masterSelection();
 }
 
-void QgsFeatureListModel::setDisplayExpression( const QString expression )
+bool QgsFeatureListModel::setDisplayExpression( const QString expression )
 {
   const QgsFields fields = mFilterModel->layer()->dataProvider()->fields();
 
@@ -117,15 +117,21 @@ void QgsFeatureListModel::setDisplayExpression( const QString expression )
 
   if ( exp->hasParserError() )
   {
-    QString msg = exp->parserErrorString();
+    mParserErrorString = exp->parserErrorString();
     delete exp;
-    throw QgsException( msg );
+    return false;
   }
 
   delete mExpression;
   mExpression = exp;
 
   emit( dataChanged( index( 0, 0 ), index( rowCount() - 1, 0 ) ) );
+  return true;
+}
+
+QString QgsFeatureListModel::parserErrorString()
+{
+  return mParserErrorString;
 }
 
 const QString& QgsFeatureListModel::displayExpression() const

--- a/src/gui/attributetable/qgsfeaturelistmodel.h
+++ b/src/gui/attributetable/qgsfeaturelistmodel.h
@@ -53,10 +53,18 @@ class QgsFeatureListModel : public QAbstractProxyModel
     QItemSelectionModel* masterSelection();
 
     /**
-     * @throws QgsException in case the expression cannot be parsed
+     *  @param  expression   A {@link QgsExpression} compatible string.
+     *  @return true if the expression could be set, false if there was a parse error.
+     *          If it fails, the old expression will still be applied. Call {@link parserErrorString()}
+     *          for a meaningful error message.
      */
-    void setDisplayExpression( const QString expression );
+    bool setDisplayExpression( const QString expression );
 
+    /**
+     * @brief Returns a detailed message about errors while parsing a QgsExpression.
+     * @return A message containg information about the parser error.
+     */
+    QString parserErrorString();
 
     const QString& displayExpression() const;
     bool featureByIndex( const QModelIndex& index, QgsFeature& feat );
@@ -87,6 +95,7 @@ class QgsFeatureListModel : public QAbstractProxyModel
   private:
     QgsExpression* mExpression;
     QgsAttributeTableFilterModel* mFilterModel;
+    QString mParserErrorString;
 };
 
 Q_DECLARE_METATYPE( QgsFeatureListModel::FeatureInfo )

--- a/src/gui/attributetable/qgsfeaturelistview.cpp
+++ b/src/gui/attributetable/qgsfeaturelistview.cpp
@@ -71,14 +71,19 @@ void QgsFeatureListView::setModel( QgsFeatureListModel* featureListModel )
   connect( mCurrentEditSelectionModel, SIGNAL( selectionChanged( QItemSelection, QItemSelection ) ), SLOT( editSelectionChanged( QItemSelection, QItemSelection ) ) );
 }
 
-void QgsFeatureListView::setDisplayExpression( const QString expression )
+bool QgsFeatureListView::setDisplayExpression( const QString expression )
 {
-  mModel->setDisplayExpression( expression );
+  return mModel->setDisplayExpression( expression );
 }
 
 const QString& QgsFeatureListView::displayExpression() const
 {
   return mModel->displayExpression();
+}
+
+QString QgsFeatureListView::parserErrorString()
+{
+  return mModel->parserErrorString();
 }
 
 void QgsFeatureListView::mouseMoveEvent( QMouseEvent *event )

--- a/src/gui/attributetable/qgsfeaturelistview.h
+++ b/src/gui/attributetable/qgsfeaturelistview.h
@@ -80,7 +80,7 @@ class GUI_EXPORT QgsFeatureListView : public QListView
      *
      * @see QgsExpression
      */
-    void setDisplayExpression( const QString displayExpression );
+    bool setDisplayExpression( const QString displayExpression );
 
     /**
      * Returns the expression which is currently used to render the features.
@@ -91,6 +91,12 @@ class GUI_EXPORT QgsFeatureListView : public QListView
      */
     const QString& displayExpression() const;
 
+    /**
+     * Returns a detailed message about errors while parsing a QgsExpression.
+     *
+     * @return A message containg information about the parser error.
+     */
+    QString parserErrorString();
 
   protected:
     virtual void mouseMoveEvent( QMouseEvent *event );


### PR DESCRIPTION
Don't crash when QgsExpression parser fails to parse a preview column (e.g. column without name)

Also removed throwing exception as this has been discouraged.
