### PR TITLE
[FIX  #7483] Attribute table changed selection on layer twice subsequent...

### DIFF
--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -355,11 +355,6 @@ void QgsAttributeTableDialog::on_mSaveEditsButton_clicked()
   QgisApp::instance()->saveEdits( mLayer, true, true );
 }
 
-void QgsAttributeTableDialog::on_mTableView_selectionChangeFinished( const QgsFeatureIds &selectedFeatures )
-{
-  mLayer->setSelectedFeatures( selectedFeatures );
-}
-
 void QgsAttributeTableDialog::on_mAddFeature_clicked()
 {
   if ( !mLayer->isEditable() )

--- a/src/app/qgsattributetabledialog.h
+++ b/src/app/qgsattributetabledialog.h
@@ -81,7 +81,6 @@ class QgsAttributeTableDialog : public QDialog, private Ui::QgsAttributeTableDia
      */
     void on_mSaveEditsButton_clicked();
 
-    void on_mTableView_selectionChangeFinished( const QgsFeatureIds &selectedFeatures );
     /**
      * Inverts selection
      */


### PR DESCRIPTION
...ly

This led to a crash and was superfluent
