### PR TITLE
Adding alternative file path for postgres 9.2 to cmake

### DIFF
--- a/cmake/FindPostgres.cmake
+++ b/cmake/FindPostgres.cmake
@@ -45,6 +45,7 @@ ELSE(WIN32)
     SET(POSTGRES_CONFIG_PREFER_PATH "$ENV{POSTGRES_HOME}/bin" CACHE STRING "preferred path to PG (pg_config)")
     FIND_PROGRAM(POSTGRES_CONFIG pg_config
       ${POSTGRES_CONFIG_PREFER_PATH}
+      /usr/pgsql-9.2/bin/
       /usr/local/pgsql/bin/
       /usr/local/bin/
       /usr/bin/


### PR DESCRIPTION
For current versions of postgresql in Fedora, postgres has its own repository: http://yum.postgresql.org/

Installation of the files goes into /usr/pgsql-[0-9.]+/bin what is not covered. Would love to do this with a regex, but this seems not to be supported by cmake FIND_PROGRAM. The workaround is adding known path's incrementally... That's what this patch does for version 9.2.
