### PR TITLE
[FIX] Show attribute table for layers without geometry

### DIFF
--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -36,6 +36,11 @@ QgsAttributeTableModel::QgsAttributeTableModel( QgsVectorLayerCache *layerCache,
 {
   QgsDebugMsg( "entered." );
 
+  if ( layerCache->layer()->geometryType() == QGis::NoGeometry )
+  {
+    mFeatureRequest.setFlags( QgsFeatureRequest::NoGeometry );
+  }
+
   mFeat.setFeatureId( std::numeric_limits<int>::min() );
 
   loadAttributes();
@@ -302,7 +307,7 @@ void QgsAttributeTableModel::loadLayer()
   removeRows( 0, rowCount() );
   endRemoveRows();
 
-  QgsFeatureIterator features = layer()->getFeatures( mFeatureRequest );
+  QgsFeatureIterator features = mLayerCache->getFeatures( mFeatureRequest );
 
   int i = 0;
 

--- a/src/providers/postgres/qgspostgresfeatureiterator.cpp
+++ b/src/providers/postgres/qgspostgresfeatureiterator.cpp
@@ -296,6 +296,7 @@ bool QgsPostgresFeatureIterator::declareCursor( const QString& whereClause )
   bool fetchGeometry = !( mRequest.flags() & QgsFeatureRequest::NoGeometry );
   if ( fetchGeometry && P->mGeometryColumn.isNull() )
   {
+    QgsMessageLog::logMessage( QObject::tr( "Trying to fetch geometry on a layer without geometry." ), QObject::tr( "PostgreSQL" ) );
     return false;
   }
 


### PR DESCRIPTION
And add a message to the message log when an iterator is closed due to missing geometry
