### PR TITLE
[Bugfix] Make rendering cache more stable

### DIFF
--- a/src/app/qgsfieldsproperties.cpp
+++ b/src/app/qgsfieldsproperties.cpp
@@ -103,6 +103,7 @@ void QgsAttributesTree::dragMoveEvent( QDragMoveEvent *event )
 
 bool QgsAttributesTree::dropMimeData( QTreeWidgetItem * parent, int index, const QMimeData * data, Qt::DropAction action )
 {
+  Q_UNUSED( index )
   bool bDropSuccessful = false;
 
   if ( action == Qt::IgnoreAction )

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -1249,6 +1249,7 @@ void QgsMapLayer::setCacheImage( QImage * thepImage )
 
   if ( mpCacheImage )
   {
+    onCacheImageDelete();
     delete mpCacheImage;
   }
   mpCacheImage = thepImage;

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -331,6 +331,12 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * @note This method was added in QGIS 1.4 **/
     void setCacheImage( QImage * thepImage );
 
+    /**
+     * @brief Is called when the cache image is being deleted. Overwrite and use to clean up.
+     * @note added in 2.0
+     */
+    virtual void onCacheImageDelete() {};
+
   public slots:
 
     /** Event handler for when a coordinate transform fails due to bad vertex error */

--- a/src/core/qgsmaprenderer.cpp
+++ b/src/core/qgsmaprenderer.cpp
@@ -544,7 +544,8 @@ void QgsMapRenderer::render( QPainter* painter, double* forceWidthScale )
           delete mRenderContext.painter();
           mRenderContext.setPainter( mypContextPainter );
           //draw from cached image that we created further up
-          mypContextPainter->drawImage( 0, 0, *( ml->cacheImage() ) );
+          if ( ml->cacheImage() )
+            mypContextPainter->drawImage( 0, 0, *( ml->cacheImage() ) );
         }
       }
       disconnect( ml, SIGNAL( drawingProgress( int, int ) ), this, SLOT( onDrawingProgress( int, int ) ) );

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -879,6 +879,12 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
 
     inline QgsGeometryCache* cache() { return mCache; }
 
+    /**
+     * @brief Is called when the cache image is being deleted. Overwrite and use to clean up.
+     * @note added in 2.0
+     */
+    virtual void onCacheImageDelete();
+
   signals:
 
     /** This signal is emited when selection was changed */
@@ -1107,6 +1113,8 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
 
     // Feature counts for each renderer symbol
     QMap<QgsSymbolV2*, long> mSymbolFeatureCountMap;
+
+    QgsRenderContext* mCurrentRendererContext;
 
     friend class QgsVectorLayerFeatureIterator;
 };


### PR DESCRIPTION
As soon as QgsMapLayer::setCacheImage is called while rendering is active, a crash occurs.
Due to the fact, that processEvents is called from the main rendering loop, such situations cannot always be foreseen.

Fix: Abort rendering, as soon as setCacheImage is called.
