### PR TITLE
Fix tab order in WMS dialog, change layer control to extended selection mode for usability

### DIFF
--- a/src/providers/wms/qgswmssourceselect.cpp
+++ b/src/providers/wms/qgswmssourceselect.cpp
@@ -109,6 +109,7 @@ QgsWMSSourceSelect::QgsWMSSourceSelect( QWidget * parent, Qt::WFlags fl, bool ma
 
     layout->addStretch();
     btnGrpImageEncoding->setLayout( layout );
+    setTabOrder( lstLayers, mImageFormatGroup->button( 0 ) );
 
     //set the current project CRS if available
     long currentCRS = QgsProject::instance()->readNumEntry( "SpatialRefSys", "/ProjectCRSID", -1 );

--- a/src/ui/qgswmssourceselectbase.ui
+++ b/src/ui/qgswmssourceselectbase.ui
@@ -135,7 +135,7 @@
           </sizepolicy>
          </property>
          <property name="selectionMode">
-          <enum>QAbstractItemView::MultiSelection</enum>
+          <enum>QAbstractItemView::ExtendedSelection</enum>
          </property>
          <property name="allColumnsShowFocus">
           <bool>true</bool>
@@ -461,9 +461,14 @@
   <tabstop>btnNew</tabstop>
   <tabstop>btnEdit</tabstop>
   <tabstop>btnDelete</tabstop>
+  <tabstop>btnLoad</tabstop>
+  <tabstop>btnSave</tabstop>
   <tabstop>btnAddDefault</tabstop>
   <tabstop>lstLayers</tabstop>
   <tabstop>leLayerName</tabstop>
+  <tabstop>mTileWidth</tabstop>
+  <tabstop>mTileHeight</tabstop>
+  <tabstop>mFeatureCount</tabstop>
   <tabstop>btnChangeSpatialRefSys</tabstop>
   <tabstop>mLayerUpButton</tabstop>
   <tabstop>mLayerDownButton</tabstop>


### PR DESCRIPTION
In current master the tab order is haphazard for this dialog. In addition, the current Multi Selection mode for the layer control should be changed to Extended Selection, since the majority of time users will only be adding a single layer from this dialog.
