### PR TITLE
 [FIX #7477] Topology Checker - Crash as soon a layer is choosen when defining a rule

### DIFF
--- a/src/plugins/topology/checkDock.cpp
+++ b/src/plugins/topology/checkDock.cpp
@@ -59,15 +59,13 @@ checkDock::checkDock( QgisInterface* qIface, QWidget* parent )
   mErrorTableView->verticalHeader()->setDefaultSectionSize( 20 );
 
   mLayerRegistry = QgsMapLayerRegistry::instance();
-  mConfigureDialog = new rulesDialog( mLayerRegistry->mapLayers().keys(), mTest->testMap(), qIface, parent );
-  mTestTable = mConfigureDialog->testTable();
+  mConfigureDialog = new rulesDialog( mTest->testMap(), qIface, parent );
+  mTestTable = mConfigureDialog->rulesTable();
 
   mValidateExtentButton->setIcon( QIcon( ":/topology/validateExtent.png" ) );
   mValidateAllButton->setIcon( QIcon( ":/topology/validateAll.png" ) );
   mConfigureButton->setIcon( QIcon( ":/topology/configureRules.png" ) );
 
-
-// mQgisApp = QgisApp::instance();
   QgsMapCanvas* canvas = qIface->mapCanvas();// mQgisApp->mapCanvas();
   mRBFeature1 = new QgsRubberBand( canvas );
   mRBFeature2 = new QgsRubberBand( canvas );
@@ -94,11 +92,12 @@ checkDock::checkDock( QgisInterface* qIface, QWidget* parent )
   connect( mFixButton, SIGNAL( clicked() ), this, SLOT( fix() ) );
   connect( mErrorTableView, SIGNAL( clicked( const QModelIndex & ) ), this, SLOT( errorListClicked( const QModelIndex & ) ) );
 
-  connect( mLayerRegistry, SIGNAL( layerWasAdded( QgsMapLayer* ) ), mConfigureDialog, SLOT( addLayer( QgsMapLayer* ) ) );
-  connect( mLayerRegistry, SIGNAL( layerWillBeRemoved( QString ) ), mConfigureDialog, SLOT( removeLayer( QString ) ) );
   connect( mLayerRegistry, SIGNAL( layerWillBeRemoved( QString ) ), this, SLOT( parseErrorListByLayer( QString ) ) );
 
   connect( this, SIGNAL( visibilityChanged( bool ) ), this, SLOT( updateRubberBands( bool ) ) );
+  connect( qgsInterface, SIGNAL( newProjectCreated() ), mConfigureDialog, SLOT( clearRules() ) );
+  connect( qgsInterface, SIGNAL( newProjectCreated() ), this, SLOT( deleteErrors() ) );
+
 }
 
 checkDock::~checkDock()
@@ -204,6 +203,7 @@ void checkDock::parseErrorListByFeature( int featureId )
 
 void checkDock::configure()
 {
+  mConfigureDialog->initGui();
   mConfigureDialog->show();
 }
 

--- a/src/plugins/topology/rulesDialog.h
+++ b/src/plugins/topology/rulesDialog.h
@@ -40,16 +40,21 @@ class rulesDialog : public QDialog, public Ui::rulesDialog
      * @param theQgisIface pointer to a QgisInterface instance
      * @param parent parent widget
      */
-    rulesDialog( QList<QString> layerList, QMap<QString, TopologyRule> testMap, QgisInterface* theQgisIface, QWidget *parent );
+    rulesDialog( QMap<QString, TopologyRule> testMap, QgisInterface* theQgisIface, QWidget *parent );
     ~rulesDialog();
     /*
      * Returns pointer to the test table
      */
-    QTableWidget* testTable() { return mTestTable; }
+    QTableWidget* rulesTable() { return mRulesTable; }
     /*
      * Returns pointer to the test combobox
      */
-    QComboBox* testBox() { return mTestBox; }
+    QComboBox* rulesBox() { return mRuleBox; }
+
+    /*
+     * Initialize Rules UI with layers and rules
+     */
+    void initGui();
 
   private:
     QMap<QString, TopologyRule> mTestConfMap;
@@ -67,6 +72,8 @@ class rulesDialog : public QDialog, public Ui::rulesDialog
      */
     void setHorizontalHeaderItems();
 
+
+
   private slots:
     /*
      * Shows or hides controls according to test settings
@@ -76,7 +83,7 @@ class rulesDialog : public QDialog, public Ui::rulesDialog
     /*
      * Adds test to the table
      */
-    void addTest();
+    void addRule();
     /*
      * Deletes test from the table
      */
@@ -86,22 +93,17 @@ class rulesDialog : public QDialog, public Ui::rulesDialog
      */
     void projectRead();
     /*
-     * Adds layer to layer comboboxes
-     * @param layer layer pointer
-     */
-    void addLayer( QgsMapLayer* layer );
-    /*
-     * Deletes layer to layer comboboxes
-     * @param layerId layer ID
-     */
-    void removeLayer( QString layerId );
-
-
-    /*
      * Updates Rule combobox to mach first layer
      * @param layerId layer ID
      */
     void updateRuleItems( const QString& layerName );
+
+    /*
+     * Deletes all rules from rules dialog
+     */
+    void clearRules();
+
+
 
 };
 

--- a/src/plugins/topology/rulesDialog.ui
+++ b/src/plugins/topology/rulesDialog.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Test settings</string>
+   <string>Topology Rule Settings</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
    <item row="0" column="0">

--- a/src/plugins/topology/rulesDialog.ui
+++ b/src/plugins/topology/rulesDialog.ui
@@ -24,7 +24,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QTableWidget" name="mTestTable">
+      <widget class="QTableWidget" name="mRulesTable">
        <column>
         <property name="text">
          <string>Rule</string>
@@ -72,7 +72,7 @@
         </widget>
        </item>
        <item>
-        <widget class="QComboBox" name="mTestBox">
+        <widget class="QComboBox" name="mRuleBox">
          <property name="sizeAdjustPolicy">
           <enum>QComboBox::AdjustToContents</enum>
          </property>


### PR DESCRIPTION
This also seem to fix #7475
