### PR TITLE
[FIX #7533] Field calculator is slow

### DIFF
--- a/src/app/qgsfieldcalculator.cpp
+++ b/src/app/qgsfieldcalculator.cpp
@@ -94,6 +94,7 @@ void QgsFieldCalculator::accept()
 
   QString calcString = builder->expressionText();
   QgsExpression exp( calcString );
+  exp.setGeomCalculator( myDa );
 
   if ( !mVectorLayer || !mVectorLayer->isEditable() )
     return;
@@ -173,8 +174,6 @@ void QgsFieldCalculator::accept()
     }
 
     exp.setCurrentRowNumber( rownum );
-    exp.setGeomCalculator( myDa );
-
     QVariant value = exp.evaluate( &feature );
     if ( exp.hasEvalError() )
     {


### PR DESCRIPTION
Set the QgsDistanceArea only once and not for every loop cycle.
QgsCoordinateReferenceSystem::loadFromDb takes very long.

Please review, if it is necessary to set the field calculator within every iteration.

Note:
Caching of CRS could be an improvement of which various parts of qgis could benefit. There are probably a handful of CRS (if not only 1) which are needed within a qgis session and loading them only once instead of dozens of times could help to save CPU cycles and I/O.
