### PR TITLE
Some blending fixes and code cleanup

### DIFF
--- a/src/app/composer/qgscomposeritemwidget.cpp
+++ b/src/app/composer/qgscomposeritemwidget.cpp
@@ -392,7 +392,7 @@ void QgsComposerItemWidget::on_mBlendModeCombo_currentIndexChanged( int index )
   Q_UNUSED( index );
   if ( mItem )
   {
-    mItem->setBlendMode(( QgsMapRenderer::BlendMode ) mBlendModeCombo->blendMode() );
+    mItem->setBlendMode( mBlendModeCombo->blendMode() );
   }
 }
 

--- a/src/app/qgslabelinggui.cpp
+++ b/src/app/qgslabelinggui.cpp
@@ -254,7 +254,7 @@ QgsLabelingGui::QgsLabelingGui( QgsPalLabeling* lbl, QgsVectorLayer* layer, QgsM
     mBufferTranspSpinBox->setValue( lyr.bufferTransp );
     mBufferJoinStyleComboBox->setPenJoinStyle( lyr.bufferJoinStyle );
     mBufferTranspFillChbx->setChecked( !lyr.bufferNoFill );
-    comboBufferBlendMode->setBlendMode( QgsMapRenderer::getBlendModeEnum( lyr.bufferBlendMode ) );
+    comboBufferBlendMode->setBlendMode( lyr.bufferBlendMode );
   }
   else
   {
@@ -295,7 +295,7 @@ QgsLabelingGui::QgsLabelingGui( QgsPalLabeling* lbl, QgsVectorLayer* layer, QgsM
   mFontSizeSpinBox->setValue( lyr.textFont.pointSizeF() );
   btnTextColor->setColor( lyr.textColor );
   mFontTranspSpinBox->setValue( lyr.textTransp );
-  comboBlendMode->setBlendMode( QgsMapRenderer::getBlendModeEnum( lyr.blendMode ) );
+  comboBlendMode->setBlendMode( lyr.blendMode );
 
   mFontWordSpacingSpinBox->setValue( lyr.textFont.wordSpacing() );
   mFontLetterSpacingSpinBox->setValue( lyr.textFont.letterSpacing() );
@@ -336,7 +336,7 @@ QgsLabelingGui::QgsLabelingGui( QgsPalLabeling* lbl, QgsVectorLayer* layer, QgsM
   connect( mShapeTranspSlider, SIGNAL( valueChanged( int ) ), mShapeTranspSpinBox, SLOT( setValue( int ) ) );
   connect( mShapeTranspSpinBox, SIGNAL( valueChanged( int ) ), mShapeTranspSlider, SLOT( setValue( int ) ) );
   mShapeTranspSpinBox->setValue( lyr.shapeTransparency );
-  mShapeBlendCmbBx->setBlendMode( QgsMapRenderer::getBlendModeEnum( lyr.shapeBlendMode ) );
+  mShapeBlendCmbBx->setBlendMode( lyr.shapeBlendMode );
 
   mLoadSvgParams = false;
   on_mShapeTypeCmbBx_currentIndexChanged( lyr.shapeType ); // force update of shape background gui
@@ -498,7 +498,7 @@ QgsPalLayerSettings QgsLabelingGui::layerSettings()
   lyr.textFont = mRefFont;
   lyr.textNamedStyle = mFontStyleComboBox->currentText();
   lyr.textTransp = mFontTranspSpinBox->value();
-  lyr.blendMode = QgsMapRenderer::getCompositionMode(( QgsMapRenderer::BlendMode )comboBlendMode->blendMode() );
+  lyr.blendMode = comboBlendMode->blendMode();
   lyr.previewBkgrdColor = mPreviewBackgroundBtn->color();
   lyr.enabled = chkEnableLabeling->isChecked();
   lyr.priority = sliderPriority->value();
@@ -523,7 +523,7 @@ QgsPalLayerSettings QgsLabelingGui::layerSettings()
     lyr.bufferSizeInMapUnits = ( mBufferUnitComboBox->currentIndex() == 1 );
     lyr.bufferJoinStyle = mBufferJoinStyleComboBox->penJoinStyle();
     lyr.bufferNoFill = !mBufferTranspFillChbx->isChecked();
-    lyr.bufferBlendMode = QgsMapRenderer::getCompositionMode(( QgsMapRenderer::BlendMode )comboBufferBlendMode->blendMode() );
+    lyr.bufferBlendMode = comboBufferBlendMode->blendMode();
   }
   else
   {
@@ -551,7 +551,7 @@ QgsPalLayerSettings QgsLabelingGui::layerSettings()
   lyr.shapeBorderWidthUnits = ( QgsPalLayerSettings::SizeUnit )( mShapeBorderWidthUnitsCmbBx->currentIndex() + 1 );
   lyr.shapeJoinStyle = mShapePenStyleCmbBx->penJoinStyle();
   lyr.shapeTransparency = mShapeTranspSpinBox->value();
-  lyr.shapeBlendMode = QgsMapRenderer::getCompositionMode(( QgsMapRenderer::BlendMode )mShapeBlendCmbBx->blendMode() );
+  lyr.shapeBlendMode = mShapeBlendCmbBx->blendMode();
 
 
   if ( chkFormattedNumbers->isChecked() )

--- a/src/app/qgsrasterlayerproperties.cpp
+++ b/src/app/qgsrasterlayerproperties.cpp
@@ -871,7 +871,7 @@ void QgsRasterLayerProperties::apply()
   }
 
   //set the blend mode for the layer
-  mRasterLayer->setBlendMode(( QgsMapRenderer::BlendMode ) mBlendModeComboBox->blendMode() );
+  mRasterLayer->setBlendMode( mBlendModeComboBox->blendMode() );
 
   //get the thumbnail for the layer
   pixmapThumbnail->setPixmap( mRasterLayer->previewAsPixmap( pixmapThumbnail->size() ) );

--- a/src/core/composer/qgscomposeritem.cpp
+++ b/src/core/composer/qgscomposeritem.cpp
@@ -54,7 +54,7 @@ QgsComposerItem::QgsComposerItem( QgsComposition* composition, bool manageZValue
     , mItemPositionLocked( false )
     , mLastValidViewScaleFactor( -1 )
     , mRotation( 0 )
-    , mBlendMode( QgsMapRenderer::BlendNormal )
+    , mBlendMode( QPainter::CompositionMode_SourceOver )
     , mTransparency( 0 )
     , mLastUsedPositionMode( UpperLeft )
     , mId( "" )
@@ -75,7 +75,7 @@ QgsComposerItem::QgsComposerItem( qreal x, qreal y, qreal width, qreal height, Q
     , mItemPositionLocked( false )
     , mLastValidViewScaleFactor( -1 )
     , mRotation( 0 )
-    , mBlendMode( QgsMapRenderer::BlendNormal )
+    , mBlendMode( QPainter::CompositionMode_SourceOver )
     , mTransparency( 0 )
     , mLastUsedPositionMode( UpperLeft )
     , mId( "" )
@@ -205,7 +205,7 @@ bool QgsComposerItem::_writeXML( QDomElement& itemElem, QDomDocument& doc ) cons
   composerItemElem.appendChild( bgColorElem );
 
   //blend mode
-  composerItemElem.setAttribute( "blendMode", QString::number( mBlendMode ) );
+  composerItemElem.setAttribute( "blendMode", QgsMapRenderer::getBlendModeEnum( mBlendMode ) );
 
   //transparency
   composerItemElem.setAttribute( "transparency", QString::number( mTransparency ) );
@@ -331,7 +331,7 @@ bool QgsComposerItem::_readXML( const QDomElement& itemElem, const QDomDocument&
   }
 
   //blend mode
-  setBlendMode(( QgsMapRenderer::BlendMode ) itemElem.attribute( "blendMode" , "0" ).toInt() );
+  setBlendMode( QgsMapRenderer::getCompositionMode(( QgsMapRenderer::BlendMode ) itemElem.attribute( "blendMode", "0" ).toUInt() ) );
 
   //transparency
   setTransparency( itemElem.attribute( "transparency" , "0" ).toInt() );
@@ -884,11 +884,11 @@ void QgsComposerItem::drawBackground( QPainter* p )
   }
 }
 
-void QgsComposerItem::setBlendMode( QgsMapRenderer::BlendMode blendMode )
+void QgsComposerItem::setBlendMode( QPainter::CompositionMode blendMode )
 {
   mBlendMode = blendMode;
   // Update the composer effect to use the new blend mode
-  mEffect->setCompositionMode( QgsMapRenderer::getCompositionMode( mBlendMode ) );
+  mEffect->setCompositionMode( mBlendMode );
 }
 
 void QgsComposerItem::setTransparency( int transparency )

--- a/src/core/composer/qgscomposeritem.h
+++ b/src/core/composer/qgscomposeritem.h
@@ -198,10 +198,10 @@ class CORE_EXPORT QgsComposerItem: public QObject, public QGraphicsRectItem
     void setBackgroundEnabled( bool drawBackground ) {mBackground = drawBackground;}
 
     /** Returns the item's composition blending mode */
-    QgsMapRenderer::BlendMode blendMode() const {return mBlendMode;}
+    QPainter::CompositionMode blendMode() const {return mBlendMode;}
 
     /** Sets the item's composition blending mode*/
-    void setBlendMode( QgsMapRenderer::BlendMode blendMode );
+    void setBlendMode( QPainter::CompositionMode blendMode );
 
     /** Returns the item's transparency */
     int transparency() const {return mTransparency;}
@@ -321,7 +321,7 @@ class CORE_EXPORT QgsComposerItem: public QObject, public QGraphicsRectItem
     double mRotation;
 
     /**Composition blend mode for item*/
-    QgsMapRenderer::BlendMode mBlendMode;
+    QPainter::CompositionMode mBlendMode;
 
     QgsComposerEffect *mEffect;
 

--- a/src/core/composer/qgscomposerlabel.cpp
+++ b/src/core/composer/qgscomposerlabel.cpp
@@ -124,6 +124,8 @@ void QgsComposerLabel::setExpressionContext( QgsFeature* feature, QgsVectorLayer
   mExpressionFeature = feature;
   mExpressionLayer = layer;
   mSubstitutions = substitutions;
+  // Force label to redraw -- fixes label printing for labels with blend modes when used with atlas
+  update();
 }
 
 QString QgsComposerLabel::displayText() const

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -49,7 +49,7 @@ QgsMapLayer::QgsMapLayer( QgsMapLayer::LayerType type,
     mLayerOrigName( lyrname ), // store the original name
     mID( "" ),
     mLayerType( type ),
-    mBlendMode( QgsMapRenderer::BlendNormal ) // Default to normal blending
+    mBlendMode( QPainter::CompositionMode_SourceOver ) // Default to normal blending
 {
   mCRS = new QgsCoordinateReferenceSystem();
 
@@ -134,13 +134,13 @@ QgsRectangle QgsMapLayer::extent()
 }
 
 /** Write blend mode for layer */
-void QgsMapLayer::setBlendMode( const QgsMapRenderer::BlendMode blendMode )
+void QgsMapLayer::setBlendMode( const QPainter::CompositionMode blendMode )
 {
   mBlendMode = blendMode;
 }
 
 /** Read blend mode for layer */
-QgsMapRenderer::BlendMode QgsMapLayer::blendMode() const
+QPainter::CompositionMode QgsMapLayer::blendMode() const
 {
   return mBlendMode;
 }

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -97,9 +97,9 @@ class CORE_EXPORT QgsMapLayer : public QObject
     const QString& abstract() const { return mAbstract; }
 
     /* Set the blending mode used for rendering a layer */
-    void setBlendMode( const QgsMapRenderer::BlendMode blendMode );
+    void setBlendMode( const QPainter::CompositionMode blendMode );
     /* Returns the current blending mode for a layer */
-    QgsMapRenderer::BlendMode blendMode() const;
+    QPainter::CompositionMode blendMode() const;
 
     /**Synchronises with changes in the datasource
         @note added in version 1.6*/
@@ -479,7 +479,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
     QgsMapLayer::LayerType mLayerType;
 
     /** Blend mode for the layer */
-    QgsMapRenderer::BlendMode mBlendMode;
+    QPainter::CompositionMode mBlendMode;
 
     /** Tag for embedding additional information */
     QString mTag;

--- a/src/core/qgsmaprenderer.cpp
+++ b/src/core/qgsmaprenderer.cpp
@@ -388,7 +388,7 @@ void QgsMapRenderer::render( QPainter* painter, double* forceWidthScale )
 
     // Set the QPainter composition mode so that this layer is rendered using
     // the desired blending mode
-    mypContextPainter->setCompositionMode( getCompositionMode( ml->blendMode() ) );
+    mypContextPainter->setCompositionMode( ml->blendMode() );
 
     if ( !ml->hasScaleBasedVisibility() || ( ml->minimumScale() <= mScale && mScale < ml->maximumScale() ) || mOverview )
     {

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -1721,7 +1721,7 @@ bool QgsVectorLayer::readSymbology( const QDomNode& node, QString& errorMessage 
     if ( !blendModeNode.isNull() )
     {
       QDomElement e = blendModeNode.toElement();
-      setBlendMode(( QgsMapRenderer::BlendMode ) e.text().toInt() );
+      setBlendMode( QgsMapRenderer::getCompositionMode(( QgsMapRenderer::BlendMode ) e.text().toInt() ) );
     }
 
     // use scale dependent visibility flag
@@ -2045,7 +2045,7 @@ bool QgsVectorLayer::writeSymbology( QDomNode& node, QDomDocument& doc, QString&
 
     // add the blend mode field
     QDomElement blendModeElem  = doc.createElement( "blendMode" );
-    QDomText blendModeText = doc.createTextNode( QString::number( blendMode() ) );
+    QDomText blendModeText = doc.createTextNode( QString::number( QgsMapRenderer::getBlendModeEnum( blendMode() ) ) );
     blendModeElem.appendChild( blendModeText );
     node.appendChild( blendModeElem );
 

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -2332,7 +2332,7 @@ bool QgsRasterLayer::readSymbology( const QDomNode& layer_node, QString& errorMe
   if ( !blendModeNode.isNull() )
   {
     QDomElement e = blendModeNode.toElement();
-    setBlendMode(( QgsMapRenderer::BlendMode ) e.text().toInt() );
+    setBlendMode( QgsMapRenderer::getCompositionMode(( QgsMapRenderer::BlendMode ) e.text().toInt() ) );
   }
 
   return true;
@@ -2531,7 +2531,7 @@ bool QgsRasterLayer::writeSymbology( QDomNode & layer_node, QDomDocument & docum
 
   // add blend mode node
   QDomElement blendModeElement  = document.createElement( "blendMode" );
-  QDomText blendModeText = document.createTextNode( QString::number( blendMode() ) );
+  QDomText blendModeText = document.createTextNode( QString::number( QgsMapRenderer::getBlendModeEnum( blendMode() ) ) );
   blendModeElement.appendChild( blendModeText );
   layer_node.appendChild( blendModeElement );
 

--- a/src/gui/qgsblendmodecombobox.cpp
+++ b/src/gui/qgsblendmodecombobox.cpp
@@ -98,15 +98,15 @@ void QgsBlendModeComboBox::updateModes()
   blockSignals( false );
 }
 
-//! Function to read the selected blend mode as int
-int QgsBlendModeComboBox::blendMode()
+//! Function to read the selected blend mode
+QPainter::CompositionMode QgsBlendModeComboBox::blendMode()
 {
-  return mListIndexToBlendMode[ currentIndex()];
+  return QgsMapRenderer::getCompositionMode(( QgsMapRenderer::BlendMode ) mListIndexToBlendMode[ currentIndex()] );
 }
 
-//! Function to set the selected blend mode from int
-void QgsBlendModeComboBox::setBlendMode( int blendMode )
+//! Function to set the selected blend mode
+void QgsBlendModeComboBox::setBlendMode( QPainter::CompositionMode blendMode )
 {
-  setCurrentIndex( mBlendModeToListIndex[ blendMode ] );
+  setCurrentIndex( mBlendModeToListIndex[( int ) QgsMapRenderer::getBlendModeEnum( blendMode )] );
 }
 

--- a/src/gui/qgsblendmodecombobox.h
+++ b/src/gui/qgsblendmodecombobox.h
@@ -19,6 +19,8 @@
 #define QGSBLENDMODECOMBOBOX_H
 
 #include <QComboBox>
+#include <QPainter> // For QPainter::CompositionMode enum
+#include "qgsmaprenderer.h" //for getCompositionMode
 
 /** \ingroup gui
  * A combobox which lets the user select blend modes from a predefined list
@@ -30,10 +32,10 @@ class GUI_EXPORT QgsBlendModeComboBox : public QComboBox
     QgsBlendModeComboBox( QWidget* parent = 0 );
     virtual ~QgsBlendModeComboBox();
 
-    //! Function to read the selected blend mode as integer
-    int blendMode();
-    //! Function to set the selected blend mode from integer
-    void setBlendMode( int blendMode );
+    //! Function to read the selected blend mode as QPainter::CompositionMode
+    QPainter::CompositionMode blendMode();
+    //! Function to set the selected blend mode from QPainter::CompositionMode
+    void setBlendMode( QPainter::CompositionMode blendMode );
   private:
     //! Returns a list of grouped blend modes (with seperators)
     QStringList blendModesList() const;

--- a/src/gui/symbology-ng/qgsrendererv2propertiesdialog.cpp
+++ b/src/gui/symbology-ng/qgsrendererv2propertiesdialog.cpp
@@ -174,7 +174,7 @@ void QgsRendererV2PropertiesDialog::apply()
   }
 
   // set the blend mode for the layer
-  mLayer->setBlendMode(( QgsMapRenderer::BlendMode ) mBlendModeComboBox->blendMode() );
+  mLayer->setBlendMode( mBlendModeComboBox->blendMode() );
 }
 
 void QgsRendererV2PropertiesDialog::onOK()


### PR DESCRIPTION
1. As discussed on #qgis, the first commit is for QPainter::CompositionMode to be used in all internal blending variables and functions. This cleans up the code significantly and brings it into line with how label blend modes currently work.
2. Fixes a small bug causing labels in atlas prints to behave erratically when a blending mode was applied.
