### PR TITLE
Add QgsVectorLayer::updateFields() signal, so adding of joined fields is communicated

### DIFF
--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -3114,6 +3114,8 @@ void QgsVectorLayer::updateFields()
   // joined fields
   if ( mJoinBuffer && mJoinBuffer->containsJoins() )
     mJoinBuffer->updateFields( mUpdatedFields );
+
+  emit updatedFields();
 }
 
 

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -993,6 +993,11 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
     void attributeDeleted( int idx );
     void featureAdded( QgsFeatureId fid );  // added in 1.7
     void featureDeleted( QgsFeatureId fid );
+    /**
+     * Is emitted, whenever the fields available from this layer have been changed.
+     * This can be due to manually adding attributes or a layer join.
+     */
+    void updatedFields();
     void layerDeleted();
 
     void attributeValueChanged( QgsFeatureId fid, int idx, const QVariant & );

--- a/src/core/qgsvectorlayercache.cpp
+++ b/src/core/qgsvectorlayercache.cpp
@@ -34,6 +34,7 @@ QgsVectorLayerCache::QgsVectorLayerCache( QgsVectorLayer* layer, int cacheSize, 
   setCacheAddedAttributes( true );
 
   connect( mLayer, SIGNAL( attributeDeleted( int ) ), SLOT( attributeDeleted( int ) ) );
+  connect( mLayer, SIGNAL( updatedFields() ), SLOT( updatedFields() ) );
   connect( mLayer, SIGNAL( attributeValueChanged( QgsFeatureId, int, const QVariant& ) ), SLOT( attributeValueChanged( QgsFeatureId, int, const QVariant& ) ) );
 }
 
@@ -234,6 +235,11 @@ void QgsVectorLayerCache::layerDeleted()
   emit( cachedLayerDeleted() );
 
   mLayer = NULL;
+}
+
+void QgsVectorLayerCache::updatedFields()
+{
+  mCache.clear();
 }
 
 QgsFeatureIterator QgsVectorLayerCache::getFeatures( const QgsFeatureRequest &featureRequest )

--- a/src/core/qgsvectorlayercache.h
+++ b/src/core/qgsvectorlayercache.h
@@ -216,7 +216,7 @@ class CORE_EXPORT QgsVectorLayerCache : public QObject
      */
     void cachedLayerDeleted();
 
-  public slots:
+  private slots:
     void attributeValueChanged( QgsFeatureId fid, int field, const QVariant& value );
     void featureDeleted( QgsFeatureId fid );
     void featureAdded( QgsFeatureId fid );
@@ -224,6 +224,7 @@ class CORE_EXPORT QgsVectorLayerCache : public QObject
     void attributeDeleted( int field );
     void geometryChanged( QgsFeatureId fid, QgsGeometry& geom );
     void layerDeleted();
+    void updatedFields();
 
   private:
 

--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -51,8 +51,7 @@ QgsAttributeTableModel::QgsAttributeTableModel( QgsVectorLayerCache *layerCache,
   connect( layer(), SIGNAL( attributeValueChanged( QgsFeatureId, int, const QVariant& ) ), this, SLOT( attributeValueChanged( QgsFeatureId, int, const QVariant& ) ) );
   connect( layer(), SIGNAL( featureAdded( QgsFeatureId ) ), this, SLOT( featureAdded( QgsFeatureId ) ) );
   connect( layer(), SIGNAL( featureDeleted( QgsFeatureId ) ), this, SLOT( featureDeleted( QgsFeatureId ) ) );
-  connect( layer(), SIGNAL( attributeAdded( int ) ), this, SLOT( attributeAdded( int ) ) );
-  connect( layer(), SIGNAL( attributeDeleted( int ) ), this, SLOT( attributeDeleted( int ) ) );
+  connect( layer(), SIGNAL( updatedFields() ), this, SLOT( updatedFields() ) );
   connect( mLayerCache, SIGNAL( cachedLayerDeleted() ), this, SLOT( layerDeleted() ) );
 }
 
@@ -151,18 +150,8 @@ void QgsAttributeTableModel::featureAdded( QgsFeatureId fid, bool newOperation )
   reload( index( rowCount() - 1, 0 ), index( rowCount() - 1, columnCount() ) );
 }
 
-void QgsAttributeTableModel::attributeAdded( int idx )
+void QgsAttributeTableModel::updatedFields()
 {
-  Q_UNUSED( idx );
-  QgsDebugMsg( "entered." );
-  loadAttributes();
-  loadLayer();
-  emit modelChanged();
-}
-
-void QgsAttributeTableModel::attributeDeleted( int idx )
-{
-  Q_UNUSED( idx );
   QgsDebugMsg( "entered." );
   loadAttributes();
   emit modelChanged();

--- a/src/gui/attributetable/qgsattributetablemodel.h
+++ b/src/gui/attributetable/qgsattributetablemodel.h
@@ -188,15 +188,9 @@ class GUI_EXPORT QgsAttributeTableModel: public QAbstractTableModel
 
   private slots:
     /**
-     * Launched when attribute has been added
-     * @param idx attribute index
+     * Launched whenever the number of fields has changed
      */
-    virtual void attributeAdded( int idx );
-    /**
-     * Launched when attribute has been deleted
-     * @param idx attribute index
-     */
-    virtual void attributeDeleted( int idx );
+    virtual void updatedFields();
 
   protected slots:
     /**


### PR DESCRIPTION
Currently there is no way of executing code, once fields are joined or removed. This makes it impossible for the attributetable to update accordingly and can lead to a crash in the worst case.

Unfortunately this method does not contain detailed information as in the attributeAdded / attributeDeleted signals. I would even prefer to send a simple attributeAdded and attributeDeleted signal for joined fields as well, as in most cases they are treated equal from other points in the code.

As far as I can see, if fields are joined and new attributes get added, the joined field indexes are shifted, so in this case a fieldIndexChanged signal should probably be emitted.

So therefore, this patch does only offer a quickfix which will enable dev's to react properly to changes, but will lead in most cases to a brute-force reload of attached data (as in vector layer cache -> clear() )

Martin: Any thoughts? Should this be merged like that?
