### PR TITLE
Custom crs api

### DIFF
--- a/python/core/qgscoordinatereferencesystem.sip
+++ b/python/core/qgscoordinatereferencesystem.sip
@@ -304,4 +304,9 @@ class QgsCoordinateReferenceSystem
      * @note added in 1.8
      */
     static int syncDb();
+
+    /*! Save the proj4-string as a custom CRS
+     * @returns bool true if success else false
+     */
+    bool saveAsUserCRS( QString name );
 };

--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -641,46 +641,6 @@ bool QgsCoordinateReferenceSystem::createFromProj4( const QString theProj4String
   {
     QgsDebugMsg( "Projection is not found in databases." );
     setProj4String( myProj4String );
-
-    // Is the SRS is valid now, we know it's a decent +proj string that can be entered into the srs.db
-    if ( mIsValidFlag )
-    {
-      // but the proj.4 parsed string might already be in our database
-      myRecord = getRecord( "select * from tbl_srs where parameters=" + quotedValue( toProj4() ) + " order by deprecated" );
-      if ( myRecord.empty() )
-      {
-        // It's not, so try to add it
-        QgsDebugMsg( "Projection appears to be valid. Save to database!" );
-        mIsValidFlag = saveAsUserCRS();
-
-        if ( mIsValidFlag )
-        {
-          // but validate that it's there afterwards
-          myRecord = getRecord( "select * from tbl_srs where parameters=" + quotedValue( toProj4() ) + " order by deprecated" );
-        }
-      }
-
-      if ( !myRecord.empty() )
-      {
-        // take the srid from the record
-        mySrsId = myRecord["srs_id"].toLong();
-        QgsDebugMsg( "proj4string match search for srsid returned srsid: " + QString::number( mySrsId ) );
-        if ( mySrsId > 0 )
-        {
-          createFromSrsId( mySrsId );
-        }
-        else
-        {
-          QgsDebugMsg( QString( "invalid srid %1 found" ).arg( mySrsId ) );
-          mIsValidFlag = false;
-        }
-      }
-      else
-      {
-        QgsDebugMsg( "Couldn't find newly added proj string?" );
-        mIsValidFlag = false;
-      }
-    }
   }
 
   return mIsValidFlag;
@@ -1426,7 +1386,7 @@ QString QgsCoordinateReferenceSystem::validationHint()
 /// Copied from QgsCustomProjectionDialog ///
 /// Please refactor into SQL handler !!!  ///
 
-bool QgsCoordinateReferenceSystem::saveAsUserCRS()
+bool QgsCoordinateReferenceSystem::saveAsUserCRS(QString name)
 {
   if ( ! mIsValidFlag )
   {
@@ -1435,9 +1395,6 @@ bool QgsCoordinateReferenceSystem::saveAsUserCRS()
   }
 
   QString mySql;
-  QString myName = QString( " * %1 (%2)" )
-                   .arg( QObject::tr( "Generated CRS", "A CRS automatically generated from layer info get this prefix for description" ) )
-                   .arg( toProj4() );
 
   //if this is the first record we need to ensure that its srs_id is 10000. For
   //any rec after that sqlite3 will take care of the autonumering
@@ -1447,7 +1404,7 @@ bool QgsCoordinateReferenceSystem::saveAsUserCRS()
   {
     mySql = "insert into tbl_srs (srs_id,description,projection_acronym,ellipsoid_acronym,parameters,is_geo) values ("
             + QString::number( USER_CRS_START_ID )
-            + "," + quotedValue( myName )
+            + "," + quotedValue( name )
             + "," + quotedValue( projectionAcronym() )
             + "," + quotedValue( ellipsoidAcronym() )
             + "," + quotedValue( toProj4() )
@@ -1456,7 +1413,7 @@ bool QgsCoordinateReferenceSystem::saveAsUserCRS()
   else
   {
     mySql = "insert into tbl_srs (description,projection_acronym,ellipsoid_acronym,parameters,is_geo) values ("
-            + quotedValue( myName )
+            + quotedValue( name )
             + "," + quotedValue( projectionAcronym() )
             + "," + quotedValue( ellipsoidAcronym() )
             + "," + quotedValue( toProj4() )

--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -134,6 +134,17 @@ bool QgsCoordinateReferenceSystem::createFromString( const QString theDefinition
       if ( reCrsStr.cap( 1 ).toLower() == "proj4" )
       {
         result = createFromProj4( reCrsStr.cap( 2 ) );
+        //TODO: createFromProj4 used to save to the user database any new CRS 
+        // this behavior was changed in order to separate creation and saving.
+        // Not sure if it necessary to save it here, should be checked by someone 
+        // familiar with the code (should also give a more descriptive name to the generated CRS)
+        if( srsid() == 0 )
+        {
+          QString myName = QString( " * %1 (%2)" )
+              .arg( QObject::tr( "Generated CRS", "A CRS automatically generated from layer info get this prefix for description" ) )
+              .arg( toProj4() );
+          saveAsUserCRS(myName);
+        }
       }
       else
       {
@@ -459,6 +470,17 @@ bool QgsCoordinateReferenceSystem::createFromWkt( QString theWkt )
     OSRExportToProj4( mCRS, &proj4src );
 
     createFromProj4( proj4src );
+  }
+  //TODO: createFromProj4 used to save to the user database any new CRS 
+  // this behavior was changed in order to separate creation and saving.
+  // Not sure if it necessary to save it here, should be checked by someone 
+  // familiar with the code (should also give a more descriptive name to the generated CRS)
+  if( mSrsId == 0 )
+  {
+    QString myName = QString( " * %1 (%2)" )
+        .arg( QObject::tr( "Generated CRS", "A CRS automatically generated from layer info get this prefix for description" ) )
+        .arg( toProj4() );
+    saveAsUserCRS(myName);
   }
 
   CPLFree( proj4src );
@@ -1190,6 +1212,18 @@ bool QgsCoordinateReferenceSystem::readXML( QDomNode & theNode )
         //@TODO this srs needs to be validated!!!
         mIsValidFlag = true; //shamelessly hard coded for now
       }
+      //TODO: createFromProj4 used to save to the user database any new CRS 
+      // this behavior was changed in order to separate creation and saving.
+      // Not sure if it necessary to save it here, should be checked by someone 
+      // familiar with the code (should also give a more descriptive name to the generated CRS)
+      if( mSrsId == 0 )
+      {
+        QString myName = QString( " * %1 (%2)" )
+            .arg( QObject::tr( "Generated CRS", "A CRS automatically generated from layer info get this prefix for description" ) )
+            .arg( toProj4() );
+        saveAsUserCRS(myName);
+      }
+
     }
   }
   else

--- a/src/core/qgscoordinatereferencesystem.h
+++ b/src/core/qgscoordinatereferencesystem.h
@@ -151,9 +151,6 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      *   check for a match in entities that have the same ellps and proj entries so
      *   that it doesn't munch yer cpu so much.
      *
-     * @note If the srs was not matched, we will create a new entry on the users tbl_srs
-     *    for this srs.
-     *
      * @param theProjString A proj4 format string
      * @return bool TRUE if success else false
      */
@@ -350,6 +347,12 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      * @note added in 1.8
      */
     static int syncDb();
+    
+    
+    /*! Save the proj4-string as a custom CRS
+     * @returns bool true if success else false
+     */
+    bool saveAsUserCRS( QString name );
 
     // Mutators -----------------------------------
     // We don't want to expose these to the public api since they wont create
@@ -446,9 +449,6 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
 
     //! Work out the projection units and set the appropriate local variable
     void setMapUnits();
-
-    //! Save the proj4-string as a custom CRS
-    bool saveAsUserCRS();
 
     //! Helper for getting number of user CRS already in db
     long getRecordCount();

--- a/src/core/qgsdistancearea.cpp
+++ b/src/core/qgsdistancearea.cpp
@@ -212,6 +212,18 @@ bool QgsDistanceArea::setEllipsoid( const QString& ellipsoid )
   QString proj4 = "+proj=longlat +ellps=" + ellipsoid + " +no_defs";
   QgsCoordinateReferenceSystem destCRS;
   destCRS.createFromProj4( proj4 );
+  //TODO: createFromProj4 used to save to the user database any new CRS 
+  // this behavior was changed in order to separate creation and saving.
+  // Not sure if it necessary to save it here, should be checked by someone 
+  // familiar with the code (should also give a more descriptive name to the generated CRS)
+  if( destCRS.srsid() == 0 )
+  {
+    QString myName = QString( " * %1 (%2)" )
+        .arg( QObject::tr( "Generated CRS", "A CRS automatically generated from layer info get this prefix for description" ) )
+        .arg( destCRS.toProj4() );
+    destCRS.saveAsUserCRS(myName);
+  }
+  //
 
   // set transformation from project CRS to ellipsoid coordinates
   mCoordTransform->setDestCRS( destCRS );

--- a/src/gui/qgsprojectionselector.cpp
+++ b/src/gui/qgsprojectionselector.cpp
@@ -81,6 +81,20 @@ QgsProjectionSelector::QgsProjectionSelector( QWidget* parent, const char *name,
           // No? Skip this entry
           continue;
         }
+        else
+        {
+          //TODO: createFromProj4 used to save to the user database any new CRS 
+          // this behavior was changed in order to separate creation and saving.
+          // Not sure if it necessary to save it here, should be checked by someone 
+          // familiar with the code (should also give a more descriptive name to the generated CRS)
+          if( crs.srsid() == 0 )
+          {
+            QString myName = QString( " * %1 (%2)" )
+                .arg( QObject::tr( "Generated CRS", "A CRS automatically generated from layer info get this prefix for description" ) )
+                .arg( crs.toProj4() );
+            crs.saveAsUserCRS(myName);
+          }
+        }
       }
       mRecentProjections << QString::number( crs.srsid() );
     }

--- a/src/mapserver/qgssldparser.cpp
+++ b/src/mapserver/qgssldparser.cpp
@@ -1524,6 +1524,18 @@ void QgsSLDParser::setCrsForLayer( const QDomElement& layerElem, QgsMapLayer* ml
     {
       QgsCoordinateReferenceSystem srs;
       srs.createFromProj4( projString );
+      //TODO: createFromProj4 used to save to the user database any new CRS 
+      // this behavior was changed in order to separate creation and saving.
+      // Not sure if it necessary to save it here, should be checked by someone 
+      // familiar with the code (should also give a more descriptive name to the generated CRS)
+      if( srs.srsid() == 0 )
+      {
+        QString myName = QString( " * %1 (%2)" )
+            .arg( QObject::tr( "Generated CRS", "A CRS automatically generated from layer info get this prefix for description" ) )
+            .arg( srs.toProj4() );
+        srs.saveAsUserCRS(myName);
+      }
+
       ml->setCrs( srs );
     }
   }

--- a/src/providers/grass/qgsgrassgislib.cpp
+++ b/src/providers/grass/qgsgrassgislib.cpp
@@ -221,6 +221,17 @@ int GRASS_LIB_EXPORT QgsGrassGisLib::G__gisinit( const char * version, const cha
     {
       fatal( "Cannot create CRS from QGIS_GRASS_CRS: " + crsStr );
     }
+    //TODO: createFromProj4 used to save to the user database any new CRS 
+    // this behavior was changed in order to separate creation and saving.
+    // Not sure if it necessary to save it here, should be checked by someone 
+    // familiar with the code (should also give a more descriptive name to the generated CRS)
+    if( mCrs.srsid() == 0 )
+    {
+      QString myName = QString( " * %1 (%2)" )
+          .arg( QObject::tr( "Generated CRS", "A CRS automatically generated from layer info get this prefix for description" ) )
+          .arg( mCrs.toProj4() );
+      mCrs.saveAsUserCRS(myName);
+    }
   }
   mDistanceArea.setSourceCrs( mCrs.srsid() );
 

--- a/src/providers/spatialite/qgsspatialiteprovider.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovider.cpp
@@ -3200,6 +3200,18 @@ QgsCoordinateReferenceSystem QgsSpatiaLiteProvider::crs()
   if ( !srs.isValid() )
   {
     srs.createFromProj4( mProj4text );
+    //TODO: createFromProj4 used to save to the user database any new CRS 
+    // this behavior was changed in order to separate creation and saving.
+    // Not sure if it necessary to save it here, should be checked by someone 
+    // familiar with the code (should also give a more descriptive name to the generated CRS)
+    if( srs.srsid() == 0 )
+    {
+      QString myName = QString( " * %1 (%2)" )
+          .arg( QObject::tr( "Generated CRS", "A CRS automatically generated from layer info get this prefix for description" ) )
+          .arg( srs.toProj4() );
+      srs.saveAsUserCRS(myName);
+    }
+
   }
   return srs;
 }

--- a/src/providers/sqlanywhere/qgssqlanywhereprovider.cpp
+++ b/src/providers/sqlanywhere/qgssqlanywhereprovider.cpp
@@ -1886,6 +1886,17 @@ QgsSqlAnywhereProvider::checkSrs()
     SaDebugMsg( "Failed to create CRS from Proj4 description. Trying WKT." );
     mCrs.createFromWkt( srsWkt );
   }
+  //TODO: createFromProj4 used to save to the user database any new CRS 
+  // this behavior was changed in order to separate creation and saving.
+  // Not sure if it necessary to save it here, should be checked by someone 
+  // familiar with the code (should also give a more descriptive name to the generated CRS)
+  if( mCrs.srsid() == 0 )
+  {
+    QString myName = QString( " * %1 (%2)" )
+        .arg( QObject::tr( "Generated CRS", "A CRS automatically generated from layer info get this prefix for description" ) )
+        .arg( mCrs.toProj4() );
+    mCrs.saveAsUserCRS(myName);
+  }
 
   return true;
 } // QgsSqlAnywhereProvider::checkSrs()


### PR DESCRIPTION
Following the discussion with mhugent here: https://github.com/qgis/Quantum-GIS/pull/315 , I provide a minimal patch for a small API change concerning custom CRS.

Currently, any call to a function to create a custom CRS will search the user database and automatically save the CRS if it is not found. This prevents reusing the QgsCoordinateReferenceSystem class in some situation (most notably the custom CRS creation dialog).

This patch makes saveAsUserCRS public and adds a new argument, the name of the user CRS. It also removes the call to saveAsUserCRS in the custom CRS creation functions, meaning any user of these functions now has to check manually if the CRS exists in the database.

The first patch is the API change, the second patch updates all the call to createFromProj4 in the code.
