### PR TITLE
fix for http://hub.qgis.org/issues/7628 rubberband not ok for undo

### DIFF
--- a/src/gui/qgsrubberband.cpp
+++ b/src/gui/qgsrubberband.cpp
@@ -153,9 +153,12 @@ void QgsRubberBand::removeLastPoint( int geometryIndex )
     return;
   }
 
-  if ( mPoints[geometryIndex].size() > 0 )
+  // removing the last point from a rubber band is actually not removing
+  // the last one, but the one before last
+  if ( mPoints[geometryIndex].size() > 1 )
   {
-    mPoints[geometryIndex].pop_back();
+    //mPoints[geometryIndex].pop_back(); // wrong
+    mPoints[geometryIndex].removeAt(mPoints[geometryIndex].size() - 2);
   }
 
   updateRect();


### PR DESCRIPTION
removing the last point of a rubberband is actually not removing the last point
but the point before last. The last point is your moving mouse point.

More info http://hub.qgis.org/issues/7628 
