### PR TITLE
Fix for  "a class-key must be used when declaring a friend" on make using Oracle Spatial

### DIFF
--- a/src/providers/oracle/qgsoracleprovider.h
+++ b/src/providers/oracle/qgsoracleprovider.h
@@ -391,7 +391,7 @@ class QgsOracleProvider : public QgsVectorDataProvider
     QString mSpatialIndex;                   //! name of spatial index of geometry column
     bool mHasSpatial;                        //! Oracle Spatial is installed
 
-    friend QgsOracleFeatureIterator;
+    friend class QgsOracleFeatureIterator;
 };
 
 #endif


### PR DESCRIPTION
fixes "a class-key must be used when declaring a friend" error on make
