### PR TITLE
[Fix #7618,Fix #4761] - Distance Matrix entries are only calculated for the first feature

### DIFF
--- a/python/plugins/fTools/tools/doPointDistance.py
+++ b/python/plugins/fTools/tools/doPointDistance.py
@@ -153,7 +153,13 @@ class Dialog(QDialog, Ui_Dialog):
 
     def compute(self, line1, line2, field1, field2, outPath, matType, nearest, progressBar):
         layer1 = ftools_utils.getVectorLayerByName(line1)
-        layer2 = ftools_utils.getVectorLayerByName(line2)
+        layer2 = ftools_utils.getVectorLayerByName(line2)        
+        # if finding nearest n geometries from same layer,
+        # increment by 1 to compensate for self check that results in 0 distance
+        if layer1.id() == layer2.id():
+            if nearest > 0:
+                nearest = nearest + 1		
+
         provider1 = layer1.dataProvider()
         provider2 = layer2.dataProvider()
         sindex = QgsSpatialIndex()
@@ -190,10 +196,16 @@ class Dialog(QDialog, Ui_Dialog):
         first = True
         start = 15.00
         add = 85.00 / provider1.featureCount()
-	fit1 = provider1.getFeatures()
+        fit1 = provider1.getFeatures()
+        # store features in lists to prevent ogriterator closing
+        geomIdList = []
         while fit1.nextFeature(inFeat):
-            inGeom = inFeat.geometry()
-            inID = inFeat.attributes()[index1].toString()
+            geomIdList.append(inFeat)
+            inFeat = QgsFeature()
+        for feat in geomIdList:		
+            inID = feat.attributes()[index1].toString()
+            inGeom = feat.geometry()
+            
             if first:
                 featList = sindex.nearestNeighbor(inGeom.asPoint(), nearest)
                 first = False
@@ -207,7 +219,7 @@ class Dialog(QDialog, Ui_Dialog):
                 provider2.getFeatures( QgsFeatureRequest().setFilterFid( int(j) ) ).nextFeature( outFeat )
                 outGeom = outFeat.geometry()
                 dist = distArea.measureLine(inGeom.asPoint(), outGeom.asPoint())
-                data.append(str(float(dist)))
+                data.append(unicode(float(dist)))
             writer.writerow(data)
             start = start + add
             progressBar.setValue(start)
@@ -221,9 +233,14 @@ class Dialog(QDialog, Ui_Dialog):
         start = 15.00
         add = 85.00 / provider1.featureCount()
         fit1 = provider1.getFeatures()
+        # store features in lists to prevent ogriterator closing
+        geomIdList = []
         while fit1.nextFeature(inFeat):
-            inGeom = inFeat.geometry()
-            inID = inFeat.attributes()[index1].toString()
+            geomIdList.append(inFeat)
+            inFeat = QgsFeature()
+        for feat in geomIdList:
+            inID = feat.attributes()[index1].toString()
+            inGeom = feat.geometry()            
             featList = sindex.nearestNeighbor(inGeom.asPoint(), nearest)
             distList = []
             vari = 0.00

--- a/python/plugins/fTools/tools/doPointDistance.py
+++ b/python/plugins/fTools/tools/doPointDistance.py
@@ -198,11 +198,11 @@ class Dialog(QDialog, Ui_Dialog):
         add = 85.00 / provider1.featureCount()
         fit1 = provider1.getFeatures()
         # store features in lists to prevent ogriterator closing
-        geomIdList = []
+        featList = []
         while fit1.nextFeature(inFeat):
-            geomIdList.append(inFeat)
+            featList.append(inFeat)
             inFeat = QgsFeature()
-        for feat in geomIdList:		
+        for feat in featList:		
             inID = feat.attributes()[index1].toString()
             inGeom = feat.geometry()
             
@@ -234,11 +234,11 @@ class Dialog(QDialog, Ui_Dialog):
         add = 85.00 / provider1.featureCount()
         fit1 = provider1.getFeatures()
         # store features in lists to prevent ogriterator closing
-        geomIdList = []
+        featList = []
         while fit1.nextFeature(inFeat):
-            geomIdList.append(inFeat)
+            featList.append(inFeat)
             inFeat = QgsFeature()
-        for feat in geomIdList:
+        for feat in featList:
             inID = feat.attributes()[index1].toString()
             inGeom = feat.geometry()            
             featList = sindex.nearestNeighbor(inGeom.asPoint(), nearest)


### PR DESCRIPTION
I believe this issue was due to the existence of two iterators pointing to the same layer was causing OgrIterator to close. Please review and comment if this is the right method to fix this issue. Also fixes  http://hub.qgis.org/issues/4761 which existed from QGIS 1.8. Unfortunately, I did both fixes in a single commit. I can try to separate them if required.
