### PR TITLE
[Fix #7639] Values for new attributes not saved (Blocker)

### DIFF
--- a/src/core/qgsfield.cpp
+++ b/src/core/qgsfield.cpp
@@ -42,7 +42,7 @@ QgsField::~QgsField()
 
 bool QgsField::operator==( const QgsField& other ) const
 {
-  return (( mName == other.mName ) && ( mType == other.mType ) && ( mTypeName == other.mTypeName )
+  return (( mName == other.mName ) && ( mType == other.mType )
           && ( mLength == other.mLength ) && ( mPrecision == other.mPrecision ) );
 }
 


### PR DESCRIPTION
The typenames of created fields do not always match
(e.g. 
"Integer" vs. "integer"
"real" vs. "double"
)

Apparently
QgsVectorDataProvider::addAttributes() does not produce the same as
QgsVectorDataProvider::nativeTypes() returns

Maybe this should be fixed in a different way?
