### PR TITLE
fix for http://hub.qgis.org/issues/7628 rubberband not working ok for undo

### DIFF
--- a/src/app/qgsmaptoolcapture.cpp
+++ b/src/app/qgsmaptoolcapture.cpp
@@ -227,7 +227,8 @@ void QgsMapToolCapture::undo()
       return;
     }
 
-    mRubberBand->removeLastPoint();
+    // remove te second last point (the last point is the mouse point)
+    mRubberBand->removePoint( rubberBandSize - 2 );
     mCaptureList.removeLast();
 
     validateGeometry();

--- a/src/gui/qgsrubberband.cpp
+++ b/src/gui/qgsrubberband.cpp
@@ -146,7 +146,7 @@ void QgsRubberBand::addPoint( const QgsPoint & p, bool doUpdate /* = true */, in
   }
 }
 
-void QgsRubberBand::removeLastPoint( int geometryIndex )
+void QgsRubberBand::removePoint( int index, bool doUpdate/* = true*/, int geometryIndex/* = 0*/ )
 {
   if ( mPoints.size() < geometryIndex + 1 )
   {
@@ -155,11 +155,19 @@ void QgsRubberBand::removeLastPoint( int geometryIndex )
 
   if ( mPoints[geometryIndex].size() > 0 )
   {
-    mPoints[geometryIndex].pop_back();
+    mPoints[geometryIndex].removeAt(index);
   }
 
-  updateRect();
-  update();
+  if ( doUpdate )
+  {
+    updateRect();
+    update();
+  }
+}
+
+void QgsRubberBand::removeLastPoint( int geometryIndex )
+{
+  removePoint(geometryIndex, true, mPoints[geometryIndex].size() - 1);
 }
 
 /*!

--- a/src/gui/qgsrubberband.h
+++ b/src/gui/qgsrubberband.h
@@ -127,6 +127,16 @@ class GUI_EXPORT QgsRubberBand: public QgsMapCanvasItem
     void addPoint( const QgsPoint & p, bool doUpdate = true, int geometryIndex = 0 );
 
     /**
+     * Remove a vertex from the rubberband and update canvas.
+     * The rendering of the vertex depends on the current GeometryType and icon.
+     * If removing more points consider using update=false for better performance
+     *  @param index      The index of the vertex/point to remove
+     *  @param doUpdate      Should the map canvas be updated immediately?
+     *  @param geometryIndex The index of the feature part (in case of multipart geometries)
+     */
+    void removePoint( int index = 0, bool doUpdate = true, int geometryIndex = 0 );
+
+    /**
      * Removes the last point. Most useful in connection with undo operations
      */
     void removeLastPoint( int geometryIndex = 0 );


### PR DESCRIPTION
removing the last point of a rubberband is actually not removing the last point
but the point before last. The last point is your moving mouse point.
Addition of a 'removePoint' function to make this possible
