### PR TITLE
fix for #7628

### DIFF
--- a/python/gui/qgsrubberband.sip
+++ b/python/gui/qgsrubberband.sip
@@ -42,6 +42,13 @@ class QgsRubberBand: QgsMapCanvasItem
     //! geometryIndex is the index of the feature part (in case of multipart geometries)
     void addPoint( const QgsPoint & p, bool update = true, int geometryIndex = 0 );
 
+    /**Remove a vertex from the rubberband and (optionally) update canvas.
+    @param index The index of the vertex/point to remove, negative indexes start at end
+    @param doUpdate Should the map canvas be updated immediately?
+    @param geometryIndex The index of the feature part (in case of multipart geometries)
+    */
+    void removePoint( int index = 0, bool doUpdate = true, int geometryIndex = 0 );
+
     //!Removes the last point. Most useful in connection with undo operations
     void removeLastPoint( int geometryIndex = 0 );
 

--- a/src/app/qgsmaptoolcapture.cpp
+++ b/src/app/qgsmaptoolcapture.cpp
@@ -227,7 +227,7 @@ void QgsMapToolCapture::undo()
       return;
     }
 
-    mRubberBand->removeLastPoint();
+    mRubberBand->removePoint(-2); // remove the one before the last one
     mCaptureList.removeLast();
 
     validateGeometry();

--- a/src/gui/qgsrubberband.cpp
+++ b/src/gui/qgsrubberband.cpp
@@ -146,20 +146,36 @@ void QgsRubberBand::addPoint( const QgsPoint & p, bool doUpdate /* = true */, in
   }
 }
 
-void QgsRubberBand::removeLastPoint( int geometryIndex )
+
+void QgsRubberBand::removePoint( int index, bool doUpdate/* = true*/, int geometryIndex/* = 0*/ )
 {
+
   if ( mPoints.size() < geometryIndex + 1 )
   {
     return;
   }
 
+
   if ( mPoints[geometryIndex].size() > 0 )
   {
-    mPoints[geometryIndex].pop_back();
+    // negative index removes from end, eg -1 removes last one
+    if ( index < 0 )
+    {
+      index = mPoints[geometryIndex].size() + index;
+    }
+    mPoints[geometryIndex].removeAt(index);
   }
 
-  updateRect();
-  update();
+  if ( doUpdate )
+  {
+    updateRect();
+    update();
+  }
+}
+
+void QgsRubberBand::removeLastPoint( int geometryIndex )
+{
+  removePoint(-1, true, geometryIndex);
 }
 
 /*!

--- a/src/gui/qgsrubberband.h
+++ b/src/gui/qgsrubberband.h
@@ -127,6 +127,14 @@ class GUI_EXPORT QgsRubberBand: public QgsMapCanvasItem
     void addPoint( const QgsPoint & p, bool doUpdate = true, int geometryIndex = 0 );
 
     /**
+    * Remove a vertex from the rubberband and (optionally) update canvas.
+    * @param index The index of the vertex/point to remove, negative indexes start at end
+    * @param doUpdate Should the map canvas be updated immediately?
+    * @param geometryIndex The index of the feature part (in case of multipart geometries)
+    */
+    void removePoint( int index = 0, bool doUpdate = true, int geometryIndex = 0 );
+
+    /**
      * Removes the last point. Most useful in connection with undo operations
      */
     void removeLastPoint( int geometryIndex = 0 );


### PR DESCRIPTION
adding a removePoint method, which can also take a negative index to start
removing vertices from the end.

actual fix for #7628 was to not remove the last node, but the one before that.

this pull request supersedes https://github.com/qgis/Quantum-GIS/pull/542 which was by accident done in my master branch 
