### PR TITLE
Adds more tolerance to QGIS mapserver for not fully OGC compliant WxS clients

### DIFF
--- a/src/mapserver/qgis_map_serv.cpp
+++ b/src/mapserver/qgis_map_serv.cpp
@@ -109,6 +109,19 @@ void printRequestInfos()
   {
     QgsDebugMsg( "HTTP_USER_AGENT: " + QString( getenv( "HTTP_USER_AGENT" ) ) );
   }
+  if ( getenv( "HTTP_PROXY" ) != NULL )
+  {
+    QgsDebugMsg( "HTTP_PROXY: " + QString( getenv( "HTTP_PROXY" ) ) );
+  }
+  if ( getenv( "HTTPS_PROXY" ) != NULL )
+  {
+    QgsDebugMsg( "HTTPS_PROXY: " + QString( getenv( "HTTPS_PROXY" ) ) );
+  }
+  if ( getenv( "NO_PROXY" ) != NULL )
+  {
+    QgsDebugMsg( "NO_PROXY: " + QString( getenv( "NO_PROXY" ) ) );
+  }
+
 #endif //QGSMSDEBUG
 }
 

--- a/src/mapserver/qgis_map_serv.cpp
+++ b/src/mapserver/qgis_map_serv.cpp
@@ -316,7 +316,7 @@ int main( int argc, char * argv[] )
         continue;
       }
 
-      if ( request == "GetCapabilities" )
+      if ( request.toLower() == QString( "GetCapabilities" ).toLower() )
       {
         QDomDocument capabilitiesDocument;
         try
@@ -336,7 +336,7 @@ int main( int argc, char * argv[] )
         delete theServer;
         continue;
       }
-      else if ( request == "DescribeFeatureType" )
+      else if ( request.toLower() == QString( "DescribeFeatureType" ).toLower() )
       {
         QDomDocument describeDocument;
         try
@@ -356,7 +356,7 @@ int main( int argc, char * argv[] )
         delete theServer;
         continue;
       }
-      else if ( request == "GetFeature" )
+      else if ( request.toLower() == QString( "GetFeature" ).toLower() )
       {
         //output format for GetFeature
         QString outputFormat = parameterMap.value( "OUTPUTFORMAT" );
@@ -383,7 +383,7 @@ int main( int argc, char * argv[] )
           continue;
         }
       }
-      else if ( request == "Transaction" )
+      else if ( request.toLower() == QString( "Transaction" ).toLower() )
       {
         QDomDocument transactionDocument;
         try
@@ -433,13 +433,13 @@ int main( int argc, char * argv[] )
     }
 
     QString version = parameterMap.value( "VERSION", "1.3.0" );
-    bool getProjectSettings = ( request == "GetProjectSettings" );
+    bool getProjectSettings = ( request.toLower() == QString( "GetProjectSettings" ).toLower() );
     if ( getProjectSettings )
     {
       version = "1.3.0"; //getProjectSettings extends WMS 1.3.0 capabilities
     }
 
-    if ( request == "GetCapabilities" || getProjectSettings )
+    if ( request.toLower() == QString( "GetCapabilities" ).toLower() || getProjectSettings )
     {
       const QDomDocument* capabilitiesDocument = capabilitiesCache.searchCapabilitiesDocument( configFilePath, getProjectSettings ? "projectSettings" : version );
       if ( !capabilitiesDocument ) //capabilities xml not in cache. Create a new one
@@ -473,7 +473,7 @@ int main( int argc, char * argv[] )
       delete theServer;
       continue;
     }
-    else if ( request == "GetMap" )
+    else if ( request.toLower() == QString( "GetMap" ).toLower() )
     {
       QImage* result = 0;
       try
@@ -505,7 +505,7 @@ int main( int argc, char * argv[] )
       delete theServer;
       continue;
     }
-    else if ( request == "GetFeatureInfo" )
+    else if ( request.toLower() == QString( "GetFeatureInfo" ).toLower() )
     {
       QDomDocument featureInfoDoc;
       try
@@ -531,7 +531,7 @@ int main( int argc, char * argv[] )
       delete theServer;
       continue;
     }
-    else if ( request == "GetStyles" || request == "GetStyle" ) // GetStyle for compatibility with earlier QGIS versions
+    else if ( request.toLower() == QString( "GetStyles" ).toLower() || request.toLower() == QString( "GetStyle" ).toLower() ) // GetStyle for compatibility with earlier QGIS versions
     {
       try
       {
@@ -547,7 +547,7 @@ int main( int argc, char * argv[] )
       delete theServer;
       continue;
     }
-    else if ( request == "GetLegendGraphic" || request == "GetLegendGraphics" ) // GetLegendGraphics for compatibility with earlier QGIS versions
+    else if ( request.toLower() == QString( "GetLegendGraphic" ).toLower() || request.toLower() == QString( "GetLegendGraphics" ).toLower() ) // GetLegendGraphics for compatibility with earlier QGIS versions
     {
       QImage* result = 0;
       try
@@ -576,7 +576,7 @@ int main( int argc, char * argv[] )
       continue;
 
     }
-    else if ( request == "GetPrint" )
+    else if ( request.toLower() == QString( "GetPrint" ).toLower() )
     {
       QByteArray* printOutput = 0;
       try


### PR DESCRIPTION
At the moment QGIS mapserver is relatively strict in interpreting the REQUEST parameter. With this pull QGIS mapserver also accepts non compliant requests not using CamelCase e.g. REQUEST=getcapabilities. This pull does not brake the servers OGC compliance but makes it more tolerant for non-compliant clients. Even the OGC reference implementation (based on deegree ?) is relatively tolerant at this point.
