### PR TITLE
Correct labeling issue for field with non-alphabetic characters

### DIFF
--- a/src/app/qgslabelinggui.cpp
+++ b/src/app/qgslabelinggui.cpp
@@ -681,9 +681,17 @@ QgsPalLayerSettings QgsLabelingGui::layerSettings()
 void QgsLabelingGui::populateFieldNames()
 {
   const QgsFields& fields = mLayer->pendingFields();
+  QRegExp nonalpha( "[^a-zA-Z]" );
   for ( int idx = 0; idx < fields.count(); ++idx )
   {
-    cboFieldName->addItem( fields[idx].name() );
+    if ( fields[idx].name().contains( nonalpha ) )
+    {
+      cboFieldName->addItem( "\"" + fields[idx].name() + "\"" );
+    }
+    else
+    {
+      cboFieldName->addItem( fields[idx].name() );
+    }
   }
 }
 
@@ -1015,7 +1023,7 @@ void QgsLabelingGui::showEngineConfigDialog()
 
 void QgsLabelingGui::showExpressionDialog()
 {
-  QgsExpressionBuilderDialog dlg( mLayer, cboFieldName->currentText() , this );
+  QgsExpressionBuilderDialog dlg( mLayer, cboFieldName->currentText(), this );
   dlg.setWindowTitle( tr( "Expression based label" ) );
 
   QgsDistanceArea myDa;

--- a/src/app/qgslabelinggui.cpp
+++ b/src/app/qgslabelinggui.cpp
@@ -681,9 +681,13 @@ QgsPalLayerSettings QgsLabelingGui::layerSettings()
 void QgsLabelingGui::populateFieldNames()
 {
   const QgsFields& fields = mLayer->pendingFields();
+  QRegExp nonalpha("[^a-zA-Z]");
   for ( int idx = 0; idx < fields.count(); ++idx )
   {
-    cboFieldName->addItem( fields[idx].name() );
+    if (fields[idx].name().contains(nonalpha))
+      cboFieldName->addItem( "\"" + fields[idx].name() + "\"" );
+    else
+      cboFieldName->addItem( fields[idx].name() );
   }
 }
 
@@ -1015,7 +1019,7 @@ void QgsLabelingGui::showEngineConfigDialog()
 
 void QgsLabelingGui::showExpressionDialog()
 {
-  QgsExpressionBuilderDialog dlg( mLayer, cboFieldName->currentText() , this );
+  QgsExpressionBuilderDialog dlg( mLayer, cboFieldName->currentText(), this );
   dlg.setWindowTitle( tr( "Expression based label" ) );
 
   QgsDistanceArea myDa;


### PR DESCRIPTION
The field names containing spaces or other special characters can not be used from the labeling drop-down menu. They can be selected, but the labeling fails silently.

This small patch encloses the field name with quotes when it contains any other characters than [a-zA-Z], allowing to use any field name. It does not add quotes for the most common case where a field is simply composed of letter.
