### PR TITLE
Fix GetLegendGraphic jpeg/jpg FORMAT bug

### DIFF
--- a/src/mapserver/qgshttprequesthandler.cpp
+++ b/src/mapserver/qgshttprequesthandler.cpp
@@ -99,7 +99,7 @@ void QgsHttpRequestHandler::sendGetMapResponse( const QString& service, QImage* 
     bool png8Bit = ( mFormat.compare( "image/png; mode=8bit", Qt::CaseInsensitive ) == 0 );
     bool png1Bit = ( mFormat.compare( "image/png; mode=1bit", Qt::CaseInsensitive ) == 0 );
     bool isBase64 = mFormatString.endsWith( ";base64", Qt::CaseInsensitive );
-    if ( mFormat != "PNG" && mFormat != "JPG" && !png8Bit && !png1Bit )
+    if ( mFormat != "PNG" && mFormat != "JPG" && mFormat != "JPEG" && !png8Bit && !png1Bit )
     {
       QgsDebugMsg( "service exception - incorrect image format requested..." );
       sendServiceException( QgsMapServiceException( "InvalidFormat", "Output format '" + mFormat + "' is not supported in the GetMap request" ) );

--- a/src/mapserver/qgshttprequesthandler.cpp
+++ b/src/mapserver/qgshttprequesthandler.cpp
@@ -75,7 +75,7 @@ QString QgsHttpRequestHandler::formatToMimeType( const QString& format ) const
   {
     return "image/png";
   }
-  else if ( format.compare( "jpg", Qt::CaseInsensitive ) == 0 )
+  else if ( format.compare( "jpg", Qt::CaseInsensitive ) == 0 || format.compare( "jpeg", Qt::CaseInsensitive ) )
   {
     return "image/jpeg";
   }
@@ -430,8 +430,8 @@ void QgsHttpRequestHandler::requestStringToParameterMap( const QString& request,
       {
         formatString = "PNG";
       }
-      else if ( formatString.contains( "image/jpeg", Qt::CaseInsensitive ) || formatString.contains( "image/jpg", Qt::CaseInsensitive )
-                || formatString.compare( "jpg", Qt::CaseInsensitive ) == 0 )
+      else if ( formatString.contains( "image/jpeg", Qt::CaseInsensitive ) || formatString.contains( "image/jpg", Qt::CaseInsensitive ) || formatString.contains( "image/jpeg", Qt::CaseInsensitive )
+                || formatString.compare( "jpg", Qt::CaseInsensitive ) == 0 || formatString.compare( "jpeg", Qt::CaseInsensitive ) == 0 )
       {
         formatString = "JPG";
       }

--- a/src/mapserver/qgswmsserver.cpp
+++ b/src/mapserver/qgswmsserver.cpp
@@ -171,7 +171,7 @@ QDomDocument QgsWMSServer::getCapabilities( QString version, bool fullProjectInf
 
   //wms:GetMap
   elem = doc.createElement( "GetMap"/*wms:GetMap*/ );
-  appendFormats( doc, elem, QStringList() << "image/jpeg" << "image/png" << "image/png; mode=8bit" << "image/png; mode=1bit" );
+  appendFormats( doc, elem, QStringList() << "image/jpg" << "image/jpeg" << "image/png" << "image/png; mode=8bit" << "image/png; mode=1bit" );
   elem.appendChild( dcpTypeElement.cloneNode().toElement() ); //this is the same as for 'GetCapabilities'
   requestElement.appendChild( elem );
 

--- a/src/mapserver/qgswmsserver.cpp
+++ b/src/mapserver/qgswmsserver.cpp
@@ -183,7 +183,7 @@ QDomDocument QgsWMSServer::getCapabilities( QString version, bool fullProjectInf
 
   //wms:GetLegendGraphic
   elem = doc.createElement( "GetLegendGraphic"/*wms:GetLegendGraphic*/ );
-  appendFormats( doc, elem, QStringList() << "jpeg" << "image/jpeg" << "image/png" );
+  appendFormats( doc, elem, QStringList() << "jpg" << "jpeg" << "image/jpeg" << "image/png" );
   elem.appendChild( dcpTypeElement.cloneNode().toElement() ); // this is the same as for 'GetCapabilities'
   requestElement.appendChild( elem );
 
@@ -1004,6 +1004,7 @@ QImage* QgsWMSServer::createImage( int width, int height ) const
   QString format = mParameterMap.value( "FORMAT" );
   bool jpeg = format.compare( "jpg", Qt::CaseInsensitive ) == 0
               || format.compare( "jpeg", Qt::CaseInsensitive ) == 0
+              || format.compare( "image/jpg", Qt::CaseInsensitive ) == 0
               || format.compare( "image/jpeg", Qt::CaseInsensitive ) == 0;
 
   //transparent parameter

--- a/src/mapserver/qgswmsserver.cpp
+++ b/src/mapserver/qgswmsserver.cpp
@@ -171,7 +171,7 @@ QDomDocument QgsWMSServer::getCapabilities( QString version, bool fullProjectInf
 
   //wms:GetMap
   elem = doc.createElement( "GetMap"/*wms:GetMap*/ );
-  appendFormats( doc, elem, QStringList() << "image/jpg" << "image/jpeg" << "image/png" << "image/png; mode=8bit" << "image/png; mode=1bit" );
+  appendFormats( doc, elem, QStringList() << "jpg" << "jpeg" << "image/jpg" << "image/jpeg" << "image/png" << "image/png; mode=8bit" << "image/png; mode=1bit" );
   elem.appendChild( dcpTypeElement.cloneNode().toElement() ); //this is the same as for 'GetCapabilities'
   requestElement.appendChild( elem );
 


### PR DESCRIPTION
Even GetCapabilities of a QGIS mapserver WMS tells jpeg is a valid format for GetLegendGraphic request, trying this format results in an exception telling that GetMap does not support "jpeg" format but works with the not listed "jpg". This pull request adds jpg, jpeg, image/jpg and image/jpeg as valid formats to GetMap and GetLegendGraphic requests
