### PR TITLE
set SHAPE_ENCODING to "" when creating new shapefile

### DIFF
--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -1851,6 +1851,9 @@ QGISEXTERN bool createEmptyDataSource( const QString &uri,
   if ( driverName == "ESRI Shapefile" )
   {
     papszOptions = CSLSetNameValue( papszOptions, "ENCODING", encoding.toLocal8Bit().data() );
+    // OGR Shapefile fails to create fields if given encoding is not supported by its side
+    // so disable encoding conversion of OGR Shapefile layer
+    CPLSetConfigOption( "SHAPE_ENCODING", "" );
   }
 
   OGRLayerH layer;


### PR DESCRIPTION
Today, I noticed OGR Shapefile fails to create fields if given encoding is not supported by its side. This pull request contains additional fix with SHAPE_ENCODING="" (follows up 4fb9879).
