### PR TITLE
have more coherent names for transformations methods in map renderer

### DIFF
--- a/python/core/qgsmaprenderer.sip
+++ b/python/core/qgsmaprenderer.sip
@@ -152,14 +152,11 @@ class QgsMapRenderer : QObject
     QSize outputSize();
     QSizeF outputSizeF();
 
-    //! transform extent in layer's CRS to extent in output CRS
-    QgsRectangle layerExtentToOutputExtent( QgsMapLayer* theLayer, QgsRectangle extent );
-
-    //! transform extent in output CRS to extent in layer's CRS
-    QgsRectangle outputExtentToLayerExtent( QgsMapLayer* theLayer, QgsRectangle extent );
-
     //! transform coordinates from layer's CRS to output CRS
     QgsPoint layerToMapCoordinates( QgsMapLayer* theLayer, QgsPoint point );
+
+    //! transform coordinates from layer's CRS to output CRS
+    QgsRectangle layerToMapCoordinates( QgsMapLayer* theLayer, QgsRectangle rect );
 
     //! transform coordinates from output CRS to layer's CRS
     QgsPoint mapToLayerCoordinates( QgsMapLayer* theLayer, QgsPoint point );

--- a/python/plugins/fTools/tools/doValidate.py
+++ b/python/plugins/fTools/tools/doValidate.py
@@ -185,7 +185,7 @@ class ValidateDialog( QDialog, Ui_Dialog ):
         if not ok or not self.vlayer.getFeatures( QgsFeatureRequest().setFilterFid( fid ) ).nextFeature( ft ):
           return
 
-        rect = mc.mapRenderer().layerExtentToOutputExtent( self.vlayer, ft.geometry().boundingBox() )
+        rect = mc.mapRenderer().layerToMapCoordinates( self.vlayer, ft.geometry().boundingBox() )
         rect.scale( 1.05 )
 
       # Set the extent to our new rectangle

--- a/src/app/legend/qgslegend.cpp
+++ b/src/app/legend/qgslegend.cpp
@@ -2656,7 +2656,7 @@ void QgsLegend::legendLayerZoom()
       QgsMapRenderer* renderer = mMapCanvas->mapRenderer();
       if ( renderer )
       {
-        extent = renderer->layerExtentToOutputExtent( theLayer, extent );
+        extent = renderer->layerToMapCoordinates( theLayer, extent );
       }
     }
   }
@@ -2678,7 +2678,7 @@ void QgsLegend::legendLayerZoom()
         QgsMapRenderer* renderer = mMapCanvas->mapRenderer();
         if ( renderer )
         {
-          layerExtent = renderer->layerExtentToOutputExtent( theLayer, layerExtent );
+          layerExtent = renderer->layerToMapCoordinates( theLayer, layerExtent );
         }
       }
 
@@ -2756,7 +2756,7 @@ void QgsLegend::legendLayerStretchUsingCurrentExtent()
     QgsContrastEnhancement::ContrastEnhancementAlgorithm contrastEnhancementAlgorithm = QgsContrastEnhancement::StretchToMinimumMaximum;
 
     QgsRectangle myRectangle;
-    myRectangle = mMapCanvas->mapRenderer()->outputExtentToLayerExtent( layer, mMapCanvas->extent() );
+    myRectangle = mMapCanvas->mapRenderer()->mapToLayerCoordinates( layer, mMapCanvas->extent() );
     layer->setContrastEnhancementAlgorithm( contrastEnhancementAlgorithm, QgsRaster::ContrastEnhancementMinMax, myRectangle );
 
     layer->setCacheImage( NULL );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -6486,7 +6486,7 @@ void QgisApp::histogramStretch( bool visibleAreaOnly, QgsRaster::ContrastEnhance
   }
 
   QgsRectangle myRectangle;
-  if ( visibleAreaOnly ) myRectangle = mMapCanvas->mapRenderer()->outputExtentToLayerExtent( myRasterLayer, mMapCanvas->extent() );
+  if ( visibleAreaOnly ) myRectangle = mMapCanvas->mapRenderer()->mapToLayerCoordinates( myRasterLayer, mMapCanvas->extent() );
 
   myRasterLayer->setContrastEnhancementAlgorithm( QgsContrastEnhancement::StretchToMinimumMaximum, theLimits, myRectangle );
 

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -1163,7 +1163,7 @@ void QgsIdentifyResultsDialog::zoomToFeature()
   }
 
   // TODO: verify CRS for raster WMS features
-  QgsRectangle rect = mCanvas->mapRenderer()->layerExtentToOutputExtent( layer, feat.geometry()->boundingBox() );
+  QgsRectangle rect = mCanvas->mapRenderer()->layerToMapCoordinates( layer, feat.geometry()->boundingBox() );
 
   if ( rect.isEmpty() )
   {

--- a/src/app/qgsrasterlayerproperties.cpp
+++ b/src/app/qgsrasterlayerproperties.cpp
@@ -519,7 +519,7 @@ void QgsRasterLayerProperties::setRendererWidget( const QString& rendererName )
     {
       QgsDebugMsg( "renderer has widgetCreateFunction" );
       // Current canvas extent (used to calc min/max) in layer CRS
-      QgsRectangle myExtent = mMapCanvas->mapRenderer()->outputExtentToLayerExtent( mRasterLayer, mMapCanvas->extent() );
+      QgsRectangle myExtent = mMapCanvas->mapRenderer()->mapToLayerCoordinates( mRasterLayer, mMapCanvas->extent() );
       mRendererWidget = ( *rendererEntry.widgetCreateFunction )( mRasterLayer, myExtent );
       mRendererStackedWidget->addWidget( mRendererWidget );
       if ( oldWidget )

--- a/src/core/qgsmaprenderer.h
+++ b/src/core/qgsmaprenderer.h
@@ -190,14 +190,11 @@ class CORE_EXPORT QgsMapRenderer : public QObject
     QSize outputSize();
     QSizeF outputSizeF();
 
-    //! transform extent in layer's CRS to extent in output CRS
-    QgsRectangle layerExtentToOutputExtent( QgsMapLayer* theLayer, QgsRectangle extent );
-
-    //! transform extent in output CRS to extent in layer's CRS
-    QgsRectangle outputExtentToLayerExtent( QgsMapLayer* theLayer, QgsRectangle extent );
-
     //! transform coordinates from layer's CRS to output CRS
     QgsPoint layerToMapCoordinates( QgsMapLayer* theLayer, QgsPoint point );
+
+    //! transform coordinates from layer's CRS to output CRS
+    QgsRectangle layerToMapCoordinates( QgsMapLayer* theLayer, QgsRectangle rect );
 
     //! transform coordinates from output CRS to layer's CRS
     QgsPoint mapToLayerCoordinates( QgsMapLayer* theLayer, QgsPoint point );

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -730,7 +730,7 @@ void QgsMapCanvas::zoomToSelected( QgsVectorLayer* layer )
     return;
   }
 
-  QgsRectangle rect = mMapRenderer->layerExtentToOutputExtent( layer, layer->boundingBoxOfSelected() );
+  QgsRectangle rect = mMapRenderer->layerToMapCoordinates( layer, layer->boundingBoxOfSelected() );
 
   // no selected features, only one selected point feature
   //or two point features with the same x- or y-coordinates
@@ -777,7 +777,7 @@ void QgsMapCanvas::panToSelected( QgsVectorLayer* layer )
     return;
   }
 
-  QgsRectangle rect = mMapRenderer->layerExtentToOutputExtent( layer, layer->boundingBoxOfSelected() );
+  QgsRectangle rect = mMapRenderer->layerToMapCoordinates( layer, layer->boundingBoxOfSelected() );
   setExtent( QgsRectangle( rect.center(), rect.center() ) );
   refresh();
 } // panToSelected

--- a/src/mapserver/qgswmsserver.cpp
+++ b/src/mapserver/qgswmsserver.cpp
@@ -1336,7 +1336,7 @@ int QgsWMSServer::featureInfoFromVectorLayer( QgsVectorLayer* layer,
     }
     if ( featureBBox && geom && mapRender ) //extend feature info bounding box if requested
     {
-      QgsRectangle box = mapRender->layerExtentToOutputExtent( layer, geom->boundingBox() );
+      QgsRectangle box = mapRender->layerToMapCoordinates( layer, geom->boundingBox() );
       if ( featureBBox->isEmpty() )
       {
         *featureBBox = box;

--- a/src/plugins/georeferencer/qgsgeorefplugingui.cpp
+++ b/src/plugins/georeferencer/qgsgeorefplugingui.cpp
@@ -639,7 +639,7 @@ void QgsGeorefPluginGui::fullHistogramStretch()
 
 void QgsGeorefPluginGui::localHistogramStretch()
 {
-  QgsRectangle rectangle = mIface->mapCanvas()->mapRenderer()->outputExtentToLayerExtent( mLayer, mIface->mapCanvas()->extent() );
+  QgsRectangle rectangle = mIface->mapCanvas()->mapRenderer()->mapToLayerCoordinates( mLayer, mIface->mapCanvas()->extent() );
 
   mLayer->setContrastEnhancementAlgorithm( QgsContrastEnhancement::StretchToMinimumMaximum, QgsRaster::ContrastEnhancementMinMax, rectangle );
   mLayer->setCacheImage( NULL );

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -4265,7 +4265,7 @@ QgsRasterIdentifyResult QgsWmsProvider::identify( const QgsPoint & thePoint, Qgs
         Q_UNUSED( ret );
 #endif
         // TODO: all features coming from this layer should probably have the same CRS
-        // the same as this layer, because layerExtentToOutputExtent() may be used
+        // the same as this layer, because layerToMapCoordinates() may be used
         // for results -> verify CRS and reprojects if necessary
         QMap<QgsFeatureId, QgsFeature* > features = gml.featuresMap();
         QgsDebugMsg( QString( "%1 features read" ).arg( features.size() ) );


### PR DESCRIPTION
I removed outputExtentToLayerExtent (redundant with mapToLayerCoordinates) and I renamed layerExtentToOutputExtent to layerToMapCoordinates.

Names are now more coherent, and there is no more redundancy in the methods.
