### PR TITLE
fix .cpg file contents

### DIFF
--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -113,7 +113,7 @@ QgsVectorFileWriter::QgsVectorFileWriter(
   {
     if ( layOptions.join( "" ).toUpper().indexOf( "ENCODING=" ) == -1 )
     {
-      layOptions.append( "ENCODING=" + fileEncoding );
+      layOptions.append( "ENCODING=" + convertCodecNameForEncodingOption( fileEncoding ) );
     }
 
     CPLSetConfigOption( "SHAPE_ENCODING", "" );
@@ -1021,6 +1021,23 @@ QString QgsVectorFileWriter::filterForDriver( const QString& driverName )
     return "";
 
   return trLongName + " [OGR] (" + glob.toLower() + " " + glob.toUpper() + ")";
+}
+
+QString QgsVectorFileWriter::convertCodecNameForEncodingOption( const QString &codecName )
+{
+  if ( codecName == "System" )
+    return QString( "LDID/0" );
+
+  QRegExp re = QRegExp( QString( "(CP|windows-|ISO[ -])(.+)" ), Qt::CaseInsensitive );
+  if ( re.exactMatch( codecName ) )
+  {
+    QString c = re.cap( 2 ).replace( "-" , "" );
+    bool isNumber;
+    c.toInt( &isNumber );
+    if ( isNumber )
+      return c;
+  }
+  return codecName;
 }
 
 bool QgsVectorFileWriter::driverMetadata( QString driverName, QString &longName, QString &trLongName, QString &glob, QString &ext )

--- a/src/core/qgsvectorfilewriter.h
+++ b/src/core/qgsvectorfilewriter.h
@@ -123,6 +123,9 @@ class CORE_EXPORT QgsVectorFileWriter
     /**Creates a filter for an OGR driver key*/
     static QString filterForDriver( const QString& driverName );
 
+    /**Converts codec name to string passed to ENCODING layer creation option of OGR Shapefile*/
+    static QString convertCodecNameForEncodingOption( const QString &codecName );
+
     /** checks whether there were any errors in constructor */
     WriterError hasError();
 

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -1850,7 +1850,7 @@ QGISEXTERN bool createEmptyDataSource( const QString &uri,
   char **papszOptions = NULL;
   if ( driverName == "ESRI Shapefile" )
   {
-    papszOptions = CSLSetNameValue( papszOptions, "ENCODING", encoding.toLocal8Bit().data() );
+    papszOptions = CSLSetNameValue( papszOptions, "ENCODING", QgsVectorFileWriter::convertCodecNameForEncodingOption( encoding ).toLocal8Bit().data() );
     // OGR Shapefile fails to create fields if given encoding is not supported by its side
     // so disable encoding conversion of OGR Shapefile layer
     CPLSetConfigOption( "SHAPE_ENCODING", "" );


### PR DESCRIPTION
I want QGIS to write proper cpg file as possible.

Links:
- .cpg file
  http://resources.arcgis.com/fr/content/kbase?fa=articleShow&d=21106
- cpg number interpretation of OGR Shapefile
  https://github.com/OSGeo/gdal/blob/trunk/gdal/ogr/ogrsf_frmts/shape/ogrshapelayer.cpp#L272
