### PR TITLE
Show warning when printing or pdfing a composition when blend modes are present

### DIFF
--- a/src/app/composer/qgscomposer.cpp
+++ b/src/app/composer/qgscomposer.cpp
@@ -2079,7 +2079,7 @@ void QgsComposer::showBlendModePrintingWarning()
 {
   if ( ! mComposition->printAsRaster() )
   {
-    QgsMessageViewer* m = new QgsMessageViewer( this );
+    QgsMessageViewer* m = new QgsMessageViewer( this, QgisGui::ModalDialogFlags, false );
     m->setWindowTitle( tr( "Project contains blend modes" ) );
     m->setMessage( tr( "Blend modes are enabled in this project, which cannot be printed as vectors. Printing as a raster is recommended." ), QgsMessageOutput::MessageText );
     m->setCheckBoxText( tr( "Print as raster" ) );
@@ -2087,7 +2087,6 @@ void QgsComposer::showBlendModePrintingWarning()
     m->setCheckBoxVisible( true );
     m->showMessage( true );
 
-    // TODO - fix this - checkBoxState is never true
     // also need to make sure composer print as raster checkbox is updated
     if ( m->checkBoxState() == Qt::Checked )
     {
@@ -2095,8 +2094,10 @@ void QgsComposer::showBlendModePrintingWarning()
     }
     else
     {
-      mComposition->setPrintAsRaster( true );
+      mComposition->setPrintAsRaster( false );
     }
+
+    delete m;
   }
 }
 

--- a/src/app/composer/qgscomposer.cpp
+++ b/src/app/composer/qgscomposer.cpp
@@ -330,6 +330,7 @@ QgsComposer::QgsComposer( QgisApp *qgis, const QString& title )
 
   QgsCompositionWidget* compositionWidget = new QgsCompositionWidget( mGeneralDock, mComposition );
   connect( mComposition, SIGNAL( paperSizeChanged() ), compositionWidget, SLOT( displayCompositionWidthHeight() ) );
+  connect( this, SIGNAL( printAsRasterChanged( bool ) ), compositionWidget, SLOT( setPrintAsRasterCheckBox( bool ) ) );
   mGeneralDock->setWidget( compositionWidget );
 
   //undo widget
@@ -1818,6 +1819,7 @@ void QgsComposer::readXML( const QDomElement& composerElem, const QDomDocument& 
   //create compositionwidget
   QgsCompositionWidget* compositionWidget = new QgsCompositionWidget( mGeneralDock, mComposition );
   QObject::connect( mComposition, SIGNAL( paperSizeChanged() ), compositionWidget, SLOT( displayCompositionWidthHeight() ) );
+  QObject::connect( this, SIGNAL( printAsRasterChanged( bool ) ), compositionWidget, SLOT( setPrintAsRasterCheckBox( bool ) ) );
   mGeneralDock->setWidget( compositionWidget );
 
   //read and restore all the items
@@ -2087,14 +2089,16 @@ void QgsComposer::showBlendModePrintingWarning()
     m->setCheckBoxVisible( true );
     m->showMessage( true );
 
-    // also need to make sure composer print as raster checkbox is updated
     if ( m->checkBoxState() == Qt::Checked )
     {
       mComposition->setPrintAsRaster( true );
+      //make sure print as raster checkbox is updated
+      emit printAsRasterChanged( true );
     }
     else
     {
       mComposition->setPrintAsRaster( false );
+      emit printAsRasterChanged( false );
     }
 
     delete m;

--- a/src/app/composer/qgscomposer.h
+++ b/src/app/composer/qgscomposer.h
@@ -397,6 +397,9 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
     //! @note added in 1.9
     QMenu* mHelpMenu;
 
+  signals:
+    void printAsRasterChanged( bool state );
+
   private slots:
 
     //! Populate Print Composers menu from main app's

--- a/src/app/composer/qgscomposer.h
+++ b/src/app/composer/qgscomposer.h
@@ -309,8 +309,14 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
     //! True if a composer map contains a WMS layer
     bool containsWMSLayer() const;
 
+    //! True if a composer contains blend modes
+    bool containsBlendModes() const;
+
     //! Displays a warning because of possible min/max size in WMS
     void showWMSPrintingWarning();
+
+    //! Displays a warning because of incompatibility between blend modes and QPrinter
+    void showBlendModePrintingWarning();
 
     //! Changes elements that are not suitable for this project
     void cleanupAfterTemplateRead();

--- a/src/app/composer/qgscompositionwidget.cpp
+++ b/src/app/composer/qgscompositionwidget.cpp
@@ -377,6 +377,13 @@ void QgsCompositionWidget::displayCompositionWidthHeight()
   }
 }
 
+void QgsCompositionWidget::setPrintAsRasterCheckBox( bool state )
+{
+  mPrintAsRasterGroupCheckBox->blockSignals( true );
+  mPrintAsRasterGroupCheckBox->setChecked( state );
+  mPrintAsRasterGroupCheckBox->blockSignals( false );
+}
+
 void QgsCompositionWidget::displaySnapingSettings()
 {
   if ( !mComposition )

--- a/src/app/composer/qgscompositionwidget.h
+++ b/src/app/composer/qgscompositionwidget.h
@@ -62,6 +62,8 @@ class QgsCompositionWidget: public QWidget, private Ui::QgsCompositionWidgetBase
 
     /**Sets GUI elements to width/height from composition*/
     void displayCompositionWidthHeight();
+    /**Sets Print as raster checkbox value*/
+    void setPrintAsRasterCheckBox( bool state );
 
   private:
     QgsComposition* mComposition;

--- a/src/core/composer/qgscomposermap.h
+++ b/src/core/composer/qgscomposermap.h
@@ -183,6 +183,9 @@ class CORE_EXPORT QgsComposerMap : public QgsComposerItem
     /**True if composer map renders a WMS layer*/
     bool containsWMSLayer() const;
 
+    /**True if composer map contains layers with blend modes*/
+    bool containsBlendModes() const;
+
     /** stores state in Dom node
      * @param elem is Dom element corresponding to 'Composer' tag
      * @param doc Dom document

--- a/src/gui/qgsmessageviewer.cpp
+++ b/src/gui/qgsmessageviewer.cpp
@@ -18,12 +18,14 @@
 #include "qgsmessageviewer.h"
 #include <QSettings>
 
-QgsMessageViewer::QgsMessageViewer( QWidget *parent, Qt::WFlags fl )
+QgsMessageViewer::QgsMessageViewer( QWidget *parent, Qt::WFlags fl, bool deleteOnClose )
     : QDialog( parent, fl )
 {
   setupUi( this );
-  setAttribute( Qt::WA_DeleteOnClose );
-
+  if ( deleteOnClose )
+  {
+    setAttribute( Qt::WA_DeleteOnClose );
+  }
   // Default state for the checkbox
   setCheckBoxVisible( false );
   setCheckBoxState( Qt::Unchecked );

--- a/src/gui/qgsmessageviewer.h
+++ b/src/gui/qgsmessageviewer.h
@@ -31,7 +31,7 @@ class GUI_EXPORT QgsMessageViewer: public QDialog, public QgsMessageOutput, priv
 {
     Q_OBJECT
   public:
-    QgsMessageViewer( QWidget *parent = 0, Qt::WFlags fl = QgisGui::ModalDialogFlags );
+    QgsMessageViewer( QWidget *parent = 0, Qt::WFlags fl = QgisGui::ModalDialogFlags, bool deleteOnClose = true );
     ~QgsMessageViewer();
 
     virtual void setMessage( const QString& message, MessageType msgType );


### PR DESCRIPTION
Since QPainter doesn't support composition modes, this adds a warning message to tell the user to "print as raster" when a composition contains blending and they are attempting to print or pdf it.

(Discussed on qgis-dev here
http://lists.osgeo.org/pipermail/qgis-developer/2013-May/026001.html)
