### PR TITLE
Georeferencer: a fix to support non-ASCII path

### DIFF
--- a/src/plugins/georeferencer/qgsgeorefplugingui.cpp
+++ b/src/plugins/georeferencer/qgsgeorefplugingui.cpp
@@ -358,7 +358,7 @@ void QgsGeorefPluginGui::generateGDALScript()
       {
         gdalwarpCommand = generateGDALwarpCommand( resamplingStr, mCompressionMethod, mUseZeroForTrans, order,
                           mUserResX, mUserResY );
-        showGDALScript( 2, translateCommand.toAscii().data(), gdalwarpCommand.toAscii().data() );
+        showGDALScript( QStringList() << translateCommand << gdalwarpCommand );
         break;
       }
     }
@@ -1761,17 +1761,9 @@ void QgsGeorefPluginGui::updateTransformParamLabel()
 }
 
 // Gdal script
-void QgsGeorefPluginGui::showGDALScript( int argNum... )
+void QgsGeorefPluginGui::showGDALScript( const QStringList& commands )
 {
-  QString script;
-  va_list vl;
-  va_start( vl, argNum );
-  while ( argNum-- )
-  {
-    script.append( va_arg( vl, char * ) );
-    script.append( "\n" );
-  }
-  va_end( vl );
+  QString script = commands.join( "\n" ) + "\n";
 
   // create window to show gdal script
   QDialogButtonBox *bbxGdalScript = new QDialogButtonBox( QDialogButtonBox::Cancel, Qt::Horizontal, this );

--- a/src/plugins/georeferencer/qgsgeorefplugingui.h
+++ b/src/plugins/georeferencer/qgsgeorefplugingui.h
@@ -161,7 +161,7 @@ class QgsGeorefPluginGui : public QMainWindow, private Ui::QgsGeorefPluginGuiBas
     void updateTransformParamLabel();
 
     // gdal script
-    void showGDALScript( int argNum... );
+    void showGDALScript( const QStringList& commands );
     QString generateGDALtranslateCommand( bool generateTFW = true );
     /* Generate command-line for gdalwarp based on current GCPs and given parameters.
      * For values in the range 1 to 3, the parameter "order" prescribes the degree of the interpolating polynomials to use,

--- a/src/plugins/georeferencer/qgsimagewarper.cpp
+++ b/src/plugins/georeferencer/qgsimagewarper.cpp
@@ -86,7 +86,7 @@ bool QgsImageWarper::createDestinationDataset(
   char **papszOptions = NULL;
   papszOptions = CSLSetNameValue( papszOptions, "COMPRESS", compression.toAscii() );
   hDstDS = GDALCreate( driver,
-                       QFile::encodeName( outputName ).constData(), resX, resY,
+                       TO8F( outputName ), resX, resY,
                        GDALGetRasterCount( hSrcDS ),
                        GDALGetRasterDataType( GDALGetRasterBand( hSrcDS, 1 ) ),
                        papszOptions );


### PR DESCRIPTION
This fixes the second issue reported to the mailing list (http://lists.osgeo.org/pipermail/qgis-developer/2013-February/024347.html).
