### PR TITLE
New functions

### DIFF
--- a/resources/function_help/abs-en_US
+++ b/resources/function_help/abs-en_US
@@ -1,0 +1,12 @@
+<h3>abs() function</h3>
+Returns the absolute value of a number.<br>
+
+
+<h4>Syntax</h4>
+abs(<i>value</i>)<br>
+
+<h4>Arguments</h4>
+<code>value</code> - a number.<br>
+
+<h4>Example</h4>
+<code>abs(-2) &rarr; 2</code><br>

--- a/resources/function_help/ceil-en_US
+++ b/resources/function_help/ceil-en_US
@@ -1,0 +1,14 @@
+<h3>Function ceil()</h3>
+Rounds a number upwards.
+
+<h4>Syntax</h4>
+<code>ceil(value)</code><br>
+
+<h4>Arguments</h4>
+<code>value</code> - a number.
+<br>
+
+<h4>Example</h4>
+<!-- Show example of function.-->
+<code>ceil(4.9) &rarr; 5</code><br>
+<code>ceil(-4.9) &rarr; -4</code><br>

--- a/resources/function_help/floor-en_US
+++ b/resources/function_help/floor-en_US
@@ -1,0 +1,14 @@
+<h3>Function floor()</h3>
+Rounds a number downwards.
+
+<h4>Syntax</h4>
+<code>floor(value)</code><br>
+
+<h4>Arguments</h4>
+<code>value</code> - a number.
+<br>
+
+<h4>Example</h4>
+<!-- Show example of function.-->
+<code>floor(4.9) &rarr; 4</code><br>
+<code>floor(-4.9) &rarr; -5</code><br>

--- a/resources/function_help/log-en_US
+++ b/resources/function_help/log-en_US
@@ -6,7 +6,7 @@ This function takes two arguments.
 <code>log(base, value)</code><br>
 
 <h4>Arguments</h4>
-<code>base</code> - any positive number.
+<code>base</code> - any positive number.<br>
 <code>value</code> - any positive number.
 <br>
 

--- a/resources/function_help/max-en_US
+++ b/resources/function_help/max-en_US
@@ -1,0 +1,13 @@
+<h3>max() function</h3>
+Returns the largest value in a set of values.
+
+<h4>Syntax</h4>
+     max(<i>value<i>[,<i>value</i>...])
+
+<h4>Arguments</h4>
+<!-- List args for functions here-->
+<i>  value</i> &rarr; a number.<br>
+
+<h4>Example</h4>
+<!-- Show example of function.-->
+     max(2,10.2,5.5) &rarr; 10.2

--- a/resources/function_help/min-en_US
+++ b/resources/function_help/min-en_US
@@ -1,0 +1,13 @@
+<h3>min() function</h3>
+Returns the smallest value in a set of values.
+
+<h4>Syntax</h4>
+     min(<i>value<i>[,<i>value</i>...])
+
+<h4>Arguments</h4>
+<!-- List args for functions here-->
+<i>  value</i> &rarr; a number.<br>
+
+<h4>Example</h4>
+<!-- Show example of function.-->
+     min(20.5,10,6.2) &rarr; 6.2

--- a/resources/function_help/rand-en_US
+++ b/resources/function_help/rand-en_US
@@ -1,0 +1,16 @@
+<h3>rand() function</h3>
+Returns a random integer within the range specified by the minimum and 
+maximum argument (inclusive).
+<br>
+This function takes two arguments.
+<h4>Syntax</h4>
+<code>rand(min, max)</code><br>
+
+<h4>Arguments</h4>
+<code>min</code> - an integer representing the smallest possible random number desired.<br>
+<code>max</code> - an integer representing the largest possible random number desired.
+<br>
+
+<h4>Example</h4>
+<!-- Show example of function.-->
+<code>rand(1, 10) &rarr; 8</code><br>

--- a/resources/function_help/randf-en_US
+++ b/resources/function_help/randf-en_US
@@ -1,0 +1,16 @@
+<h3>rand() function</h3>
+Returns a random float within the range specified by the minimum and 
+maximum argument (inclusive).
+<br>
+This function takes two arguments.
+<h4>Syntax</h4>
+<code>randf(min, max)</code><br>
+
+<h4>Arguments</h4>
+<code>min</code> - a float representing the smallest possible random number desired.<br>
+<code>max</code> - a float representing the largest possible random number desired.
+<br>
+
+<h4>Example</h4>
+<!-- Show example of function.-->
+<code>randf(1, 10) &rarr; 4.59258286403147</code><br>

--- a/resources/function_help/regexp_substr-en_US
+++ b/resources/function_help/regexp_substr-en_US
@@ -1,0 +1,14 @@
+<h3>regexp_substr() function</h3>
+Returns the portion of a string which matches a supplied regular expression.
+
+<p><h4>Syntax</h4>
+     regexp_substr(<i>string,regex</i>)</p>
+
+<p><h4>Arguments</h4>
+<!-- List args for functions here-->
+<i>  string</i> &rarr; is string.  The input string.<br>
+<i>  regex</i> &rarr; is string.  The regular expression to match against. Backslash characters must be double escaped (eg "\\s" to match a white space character).<br>
+
+<p><h4>Example</h4>
+<!-- Show example of function.-->
+     regexp_substr('abc123','(\\d+)') &rarr; '123'</p>

--- a/resources/function_help/right-en_US
+++ b/resources/function_help/right-en_US
@@ -7,7 +7,7 @@ Returns a substring that contains the <i>n</i> rightmost characters of the strin
 <h4>Arguments</h4>
 <code>string</code> - is string. The string.
 <br>
-<code>length</code> - is int. The numbder of characters from the right to return.
+<code>length</code> - is int. The number of characters from the right to return.
 
 <h4>Example</h4>
 <!-- Show example of function.-->

--- a/resources/function_help/scale_linear-en_US
+++ b/resources/function_help/scale_linear-en_US
@@ -1,0 +1,19 @@
+<h3>scale_linear() function</h3>
+Transforms a given value from an input domain to an output range using linear interpolation. 
+
+<p><h4>Syntax</h4>
+     scale_linear(<i>val</i>,<i>domain_min</i>,<i>domain_max</i>,<i>range_min</i>,<i>range_max</i>)</p>
+
+<p><h4>Arguments</h4>
+<!-- List args for functions here-->
+<i>  val</i> &rarr; is a value in the input domain. The function will return a corresponding scaled value in the output range.<br>
+<i>  domain_min, domain_max</i> &rarr; specify the input domain, the smallest and largest values the input <i>val</i> should take.<br>
+<i>  range_min, range_max</i> &rarr; sepcify the output range, the smallest and largest values which should be output by the function.<br>
+
+<h4>Example</h4>
+<!-- Show example of function.-->
+     scale_linear(5,0,10,0,100) &rarr; 50<br>
+     scale_linear(0.2,0,1,0,360) &rarr; 72 <i>(eg, scaling a value between 0 and 1 to an angle between 0 and 360)</i><br>
+     scale_linear(1500,1000,10000,9,20) &rarr; 10.22 <i>(eg, scaling a population which varies between 1000 and 10000 to a font size between 9 and 20)</i><br>
+     
+     

--- a/resources/function_help/trim-en_US
+++ b/resources/function_help/trim-en_US
@@ -1,0 +1,13 @@
+<h3>trim() function</h3>
+Removes all leading and trailing whitespace (spaces, tabs, etc) from a string.
+
+<p><h4>Syntax</h4>
+     trim(<i>string</i>)</p>
+
+<p><h4>Arguments</h4>
+<!-- List args for functions here-->
+<i>  string</i> &rarr; is string. The string to trim.</p>
+
+<p><h4>Example</h4>
+<!-- Show example of function.-->
+     trim('   hello world    ') &rarr; 'hello world'</p>

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -294,6 +294,9 @@ int main( int argc, char *argv[] )
   SetUnhandledExceptionFilter( qgisCrashDump );
 #endif
 
+  // initialize random number seed
+  srand( time( NULL ) );
+
   /////////////////////////////////////////////////////////////////
   // Command line options 'behaviour' flag setup
   ////////////////////////////////////////////////////////////////

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -347,6 +347,13 @@ static QVariant fcnSqrt( const QVariantList& values, QgsFeature* /*f*/, QgsExpre
   double x = getDoubleValue( values.at( 0 ), parent );
   return QVariant( sqrt( x ) );
 }
+
+static QVariant fcnAbs( const QVariantList& values, QgsFeature*, QgsExpression* parent )
+{
+  double val = getDoubleValue( values.at( 0 ), parent );
+  return QVariant( fabs( val ) );
+}
+
 static QVariant fcnSin( const QVariantList& values, QgsFeature* , QgsExpression* parent )
 {
   double x = getDoubleValue( values.at( 0 ), parent );
@@ -1299,7 +1306,7 @@ const QStringList &QgsExpression::BuiltinFunctions()
   if ( gmBuiltinFunctions.isEmpty() )
   {
     gmBuiltinFunctions
-    << "sqrt" << "cos" << "sin" << "tan"
+    << "abs" << "sqrt" << "cos" << "sin" << "tan"
     << "asin" << "acos" << "atan" << "atan2"
     << "exp" << "ln" << "log10" << "log"
     << "round" << "rand" << "randf" << "max" << "min"
@@ -1331,6 +1338,7 @@ const QList<QgsExpression::Function*> &QgsExpression::Functions()
   {
     gmFunctions
     << new StaticFunction( "sqrt", 1, fcnSqrt, QObject::tr( "Math" ) )
+    << new StaticFunction( "abs", 1, fcnAbs, QObject::tr( "Math" ) )
     << new StaticFunction( "cos", 1, fcnCos, QObject::tr( "Math" ) )
     << new StaticFunction( "sin", 1, fcnSin, QObject::tr( "Math" ) )
     << new StaticFunction( "tan", 1, fcnTan, QObject::tr( "Math" ) )

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -521,6 +521,31 @@ static QVariant fcnRegexpMatch( const QVariantList& values, QgsFeature* , QgsExp
   return QVariant( str.contains( re ) ? 1 : 0 );
 }
 
+static QVariant fcnRegexpSubstr( const QVariantList& values, QgsFeature* , QgsExpression* parent )
+{
+  QString str = getStringValue( values.at( 0 ), parent );
+  QString regexp = getStringValue( values.at( 1 ), parent );
+
+  QRegExp re( regexp );
+  if ( !re.isValid() )
+  {
+    parent->setEvalErrorString( QObject::tr( "Invalid regular expression '%1': %2" ).arg( regexp ).arg( re.errorString() ) );
+    return QVariant();
+  }
+
+  // extract substring
+  re.indexIn( str );
+  if ( re.captureCount() > 0 )
+  {
+    // return first capture
+    return QVariant( re.capturedTexts()[0] );
+  }
+  else
+  {
+    return QVariant( "" );
+  }
+}
+
 static QVariant fcnSubstr( const QVariantList& values, QgsFeature* , QgsExpression* parent )
 {
   QString str = getStringValue( values.at( 0 ), parent );
@@ -1233,7 +1258,7 @@ const QStringList &QgsExpression::BuiltinFunctions()
     << "coalesce" << "regexp_match" << "$now" << "age" << "year"
     << "month" << "week" << "day" << "hour"
     << "minute" << "second" << "lower" << "upper"
-    << "title" << "length" << "replace" << "regexp_replace"
+    << "title" << "length" << "replace" << "regexp_replace" << "regexp_substr"
     << "substr" << "concat" << "strpos" << "left"
     << "right" << "rpad" << "lpad"
     << "format_number" << "format_date"
@@ -1294,6 +1319,7 @@ const QList<QgsExpression::Function*> &QgsExpression::Functions()
     << new StaticFunction( "length", 1, fcnLength, QObject::tr( "String" ) )
     << new StaticFunction( "replace", 3, fcnReplace, QObject::tr( "String" ) )
     << new StaticFunction( "regexp_replace", 3, fcnRegexpReplace, QObject::tr( "String" ) )
+    << new StaticFunction( "regexp_substr", 2, fcnRegexpSubstr, QObject::tr( "String" ) )
     << new StaticFunction( "substr", 3, fcnSubstr, QObject::tr( "String" ) )
     << new StaticFunction( "concat", -1, fcnConcat, QObject::tr( "String" ) )
     << new StaticFunction( "strpos", 2, fcnStrpos, QObject::tr( "String" ) )

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -431,6 +431,43 @@ static QVariant fcnRnd( const QVariantList& values, QgsFeature* , QgsExpression*
   // Return a random integer in the range [min, max] (inclusive)
   return QVariant( min + ( rand() % ( int )( max - min + 1 ) ) );
 }
+
+static QVariant fcnMax( const QVariantList& values, QgsFeature* , QgsExpression *parent )
+{
+  //initially set max as first value
+  double maxVal = getDoubleValue( values.at( 0 ), parent );
+
+  //check against all other values
+  for ( int i = 1; i < values.length(); ++i )
+  {
+    double testVal = getDoubleValue( values[i], parent );
+    if ( testVal > maxVal )
+    {
+      maxVal = testVal;
+    }
+  }
+
+  return QVariant( maxVal );
+}
+
+static QVariant fcnMin( const QVariantList& values, QgsFeature* , QgsExpression *parent )
+{
+  //initially set min as first value
+  double minVal = getDoubleValue( values.at( 0 ), parent );
+
+  //check against all other values
+  for ( int i = 1; i < values.length(); ++i )
+  {
+    double testVal = getDoubleValue( values[i], parent );
+    if ( testVal < minVal )
+    {
+      minVal = testVal;
+    }
+  }
+
+  return QVariant( minVal );
+}
+
 static QVariant fcnToInt( const QVariantList& values, QgsFeature* , QgsExpression* parent )
 {
   return QVariant( getIntValue( values.at( 0 ), parent ) );
@@ -1253,7 +1290,8 @@ const QStringList &QgsExpression::BuiltinFunctions()
     << "sqrt" << "cos" << "sin" << "tan"
     << "asin" << "acos" << "atan" << "atan2"
     << "exp" << "ln" << "log10" << "log"
-    << "round" << "rand" << "randf" << "toint" << "toreal" << "tostring"
+    << "round" << "rand" << "randf" << "max" << "min"
+    << "toint" << "toreal" << "tostring"
     << "todatetime" << "todate" << "totime" << "tointerval"
     << "coalesce" << "regexp_match" << "$now" << "age" << "year"
     << "month" << "week" << "day" << "hour"
@@ -1294,6 +1332,8 @@ const QList<QgsExpression::Function*> &QgsExpression::Functions()
     << new StaticFunction( "round", -1, fcnRound, QObject::tr( "Math" ) )
     << new StaticFunction( "rand", 2, fcnRnd, QObject::tr( "Math" ) )
     << new StaticFunction( "randf", 2, fcnRndF, QObject::tr( "Math" ) )
+    << new StaticFunction( "max", -1, fcnMax, QObject::tr( "Math" ) )
+    << new StaticFunction( "min", -1, fcnMin, QObject::tr( "Math" ) )
     << new StaticFunction( "$pi", 0, fcnPi, QObject::tr( "Math" ) )
     << new StaticFunction( "toint", 1, fcnToInt, QObject::tr( "Conversions" ) )
     << new StaticFunction( "toreal", 1, fcnToReal, QObject::tr( "Conversions" ) )

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -468,6 +468,18 @@ static QVariant fcnMin( const QVariantList& values, QgsFeature* , QgsExpression 
   return QVariant( minVal );
 }
 
+static QVariant fcnFloor( const QVariantList& values, QgsFeature* , QgsExpression* parent )
+{
+  double x = getDoubleValue( values.at( 0 ), parent );
+  return QVariant( floor( x ) );
+}
+
+static QVariant fcnCeil( const QVariantList& values, QgsFeature* , QgsExpression* parent )
+{
+  double x = getDoubleValue( values.at( 0 ), parent );
+  return QVariant( ceil( x ) );
+}
+
 static QVariant fcnToInt( const QVariantList& values, QgsFeature* , QgsExpression* parent )
 {
   return QVariant( getIntValue( values.at( 0 ), parent ) );
@@ -1291,6 +1303,7 @@ const QStringList &QgsExpression::BuiltinFunctions()
     << "asin" << "acos" << "atan" << "atan2"
     << "exp" << "ln" << "log10" << "log"
     << "round" << "rand" << "randf" << "max" << "min"
+    << "floor" << "ceil"
     << "toint" << "toreal" << "tostring"
     << "todatetime" << "todate" << "totime" << "tointerval"
     << "coalesce" << "regexp_match" << "$now" << "age" << "year"
@@ -1334,6 +1347,8 @@ const QList<QgsExpression::Function*> &QgsExpression::Functions()
     << new StaticFunction( "randf", 2, fcnRndF, QObject::tr( "Math" ) )
     << new StaticFunction( "max", -1, fcnMax, QObject::tr( "Math" ) )
     << new StaticFunction( "min", -1, fcnMin, QObject::tr( "Math" ) )
+    << new StaticFunction( "floor", 1, fcnFloor, QObject::tr( "Math" ) )
+    << new StaticFunction( "ceil", 1, fcnCeil, QObject::tr( "Math" ) )
     << new StaticFunction( "$pi", 0, fcnPi, QObject::tr( "Math" ) )
     << new StaticFunction( "toint", 1, fcnToInt, QObject::tr( "Conversions" ) )
     << new StaticFunction( "toreal", 1, fcnToReal, QObject::tr( "Conversions" ) )

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -410,6 +410,27 @@ static QVariant fcnLog( const QVariantList& values, QgsFeature* , QgsExpression*
     return QVariant();
   return QVariant( log( x ) / log( b ) );
 }
+static QVariant fcnRndF( const QVariantList& values, QgsFeature* , QgsExpression* parent )
+{
+  double min = getDoubleValue( values.at( 0 ), parent );
+  double max = getDoubleValue( values.at( 1 ), parent );
+  if ( max < min )
+    return QVariant();
+
+  // Return a random double in the range [min, max] (inclusive)
+  double f = ( double )rand() / RAND_MAX;
+  return QVariant( min + f * ( max - min ) ) ;
+}
+static QVariant fcnRnd( const QVariantList& values, QgsFeature* , QgsExpression* parent )
+{
+  int min = getIntValue( values.at( 0 ), parent );
+  int max = getIntValue( values.at( 1 ), parent );
+  if ( max < min )
+    return QVariant();
+
+  // Return a random integer in the range [min, max] (inclusive)
+  return QVariant( min + ( rand() % ( int )( max - min + 1 ) ) );
+}
 static QVariant fcnToInt( const QVariantList& values, QgsFeature* , QgsExpression* parent )
 {
   return QVariant( getIntValue( values.at( 0 ), parent ) );
@@ -1207,7 +1228,7 @@ const QStringList &QgsExpression::BuiltinFunctions()
     << "sqrt" << "cos" << "sin" << "tan"
     << "asin" << "acos" << "atan" << "atan2"
     << "exp" << "ln" << "log10" << "log"
-    << "round" << "toint" << "toreal" << "tostring"
+    << "round" << "rand" << "randf" << "toint" << "toreal" << "tostring"
     << "todatetime" << "todate" << "totime" << "tointerval"
     << "coalesce" << "regexp_match" << "$now" << "age" << "year"
     << "month" << "week" << "day" << "hour"
@@ -1246,6 +1267,8 @@ const QList<QgsExpression::Function*> &QgsExpression::Functions()
     << new StaticFunction( "log10", 1, fcnLog10, QObject::tr( "Math" ) )
     << new StaticFunction( "log", 2, fcnLog, QObject::tr( "Math" ) )
     << new StaticFunction( "round", -1, fcnRound, QObject::tr( "Math" ) )
+    << new StaticFunction( "rand", 2, fcnRnd, QObject::tr( "Math" ) )
+    << new StaticFunction( "randf", 2, fcnRndF, QObject::tr( "Math" ) )
     << new StaticFunction( "$pi", 0, fcnPi, QObject::tr( "Math" ) )
     << new StaticFunction( "toint", 1, fcnToInt, QObject::tr( "Conversions" ) )
     << new StaticFunction( "toreal", 1, fcnToReal, QObject::tr( "Conversions" ) )

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -536,6 +536,13 @@ static QVariant fcnTitle( const QVariantList& values, QgsFeature* , QgsExpressio
   }
   return QVariant( elems.join( " " ) );
 }
+
+static QVariant fcnTrim( const QVariantList& values, QgsFeature* , QgsExpression* parent )
+{
+  QString str = getStringValue( values.at( 0 ), parent );
+  return QVariant( str.trimmed() );
+}
+
 static QVariant fcnLength( const QVariantList& values, QgsFeature* , QgsExpression* parent )
 {
   QString str = getStringValue( values.at( 0 ), parent );
@@ -1316,7 +1323,8 @@ const QStringList &QgsExpression::BuiltinFunctions()
     << "coalesce" << "regexp_match" << "$now" << "age" << "year"
     << "month" << "week" << "day" << "hour"
     << "minute" << "second" << "lower" << "upper"
-    << "title" << "length" << "replace" << "regexp_replace" << "regexp_substr"
+    << "title" << "length" << "replace" << "trim"
+    << "regexp_replace" << "regexp_substr"
     << "substr" << "concat" << "strpos" << "left"
     << "right" << "rpad" << "lpad"
     << "format_number" << "format_date"
@@ -1379,6 +1387,7 @@ const QList<QgsExpression::Function*> &QgsExpression::Functions()
     << new StaticFunction( "lower", 1, fcnLower, QObject::tr( "String" ) )
     << new StaticFunction( "upper", 1, fcnUpper, QObject::tr( "String" ) )
     << new StaticFunction( "title", 1, fcnTitle, QObject::tr( "String" ) )
+    << new StaticFunction( "trim", 1, fcnTrim, QObject::tr( "String" ) )
     << new StaticFunction( "length", 1, fcnLength, QObject::tr( "String" ) )
     << new StaticFunction( "replace", 3, fcnReplace, QObject::tr( "String" ) )
     << new StaticFunction( "regexp_replace", 3, fcnRegexpReplace, QObject::tr( "String" ) )

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -439,6 +439,32 @@ static QVariant fcnRnd( const QVariantList& values, QgsFeature* , QgsExpression*
   return QVariant( min + ( rand() % ( int )( max - min + 1 ) ) );
 }
 
+static QVariant fcnLinearScale( const QVariantList& values, QgsFeature* , QgsExpression* parent )
+{
+  double val = getDoubleValue( values.at( 0 ), parent );
+  double domain_min = getDoubleValue( values.at( 1 ), parent );
+  double domain_max = getDoubleValue( values.at( 2 ), parent );
+  double range_min = getDoubleValue( values.at( 3 ), parent );
+  double range_max = getDoubleValue( values.at( 4 ), parent );
+
+  // outside of domain?
+  if ( val >= domain_max )
+  {
+    return range_max;
+  }
+  else if ( val <= domain_min )
+  {
+    return range_min;
+  }
+
+  // calculate linear scale
+  double m = ( range_max - range_min ) / ( domain_max - domain_min );
+  double c = range_min - ( domain_min * m );
+
+  // Return linearly scaled value
+  return QVariant( m * val + c );
+}
+
 static QVariant fcnMax( const QVariantList& values, QgsFeature* , QgsExpression *parent )
 {
   //initially set max as first value
@@ -1317,7 +1343,7 @@ const QStringList &QgsExpression::BuiltinFunctions()
     << "asin" << "acos" << "atan" << "atan2"
     << "exp" << "ln" << "log10" << "log"
     << "round" << "rand" << "randf" << "max" << "min"
-    << "floor" << "ceil"
+    << "scale_linear" << "floor" << "ceil"
     << "toint" << "toreal" << "tostring"
     << "todatetime" << "todate" << "totime" << "tointerval"
     << "coalesce" << "regexp_match" << "$now" << "age" << "year"
@@ -1363,6 +1389,7 @@ const QList<QgsExpression::Function*> &QgsExpression::Functions()
     << new StaticFunction( "randf", 2, fcnRndF, QObject::tr( "Math" ) )
     << new StaticFunction( "max", -1, fcnMax, QObject::tr( "Math" ) )
     << new StaticFunction( "min", -1, fcnMin, QObject::tr( "Math" ) )
+    << new StaticFunction( "scale_linear", 5, fcnLinearScale, QObject::tr( "Math" ) )
     << new StaticFunction( "floor", 1, fcnFloor, QObject::tr( "Math" ) )
     << new StaticFunction( "ceil", 1, fcnCeil, QObject::tr( "Math" ) )
     << new StaticFunction( "$pi", 0, fcnPi, QObject::tr( "Math" ) )

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -296,6 +296,8 @@ class TestQgsExpression: public QObject
       QTest::newRow( "lpad" ) << "lpad('Hello', 10, 'x')" << false << QVariant( "Helloxxxxx" );
       QTest::newRow( "lpad truncate" ) << "rpad('Hello', 4, 'x')" << false << QVariant( "Hell" );
       QTest::newRow( "title" ) << "title(' HeLlO   WORLD ')" << false << QVariant( " Hello   World " );
+      QTest::newRow( "trim" ) << "trim('   Test String ')" << false << QVariant( "Test String" );
+      QTest::newRow( "trim empty string" ) << "trim('')" << false << QVariant( "" );
       QTest::newRow( "format" ) << "format('%1 %2 %3 %1', 'One', 'Two', 'Three')" << false << QVariant( "One Two Three One" );
 
       // implicit conversions

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -229,6 +229,9 @@ class TestQgsExpression: public QObject
 
       // math functions
       QTest::newRow( "sqrt" ) << "sqrt(16)" << false << QVariant( 4. );
+      QTest::newRow( "abs(0.1)" ) << "abs(0.1)" << false << QVariant( 0.1 );
+      QTest::newRow( "abs(0)" ) << "abs(0)" << false << QVariant( 0. );
+      QTest::newRow( "abs(-0.1)" ) << "abs(-0.1)" << false << QVariant( 0.1 );
       QTest::newRow( "invalid sqrt value" ) << "sqrt('a')" << true << QVariant();
       QTest::newRow( "sin 0" ) << "sin(0)" << false << QVariant( 0. );
       QTest::newRow( "cos 0" ) << "cos(0)" << false << QVariant( 1. );

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -257,6 +257,10 @@ class TestQgsExpression: public QObject
       QTest::newRow( "max(1,3.5,-2.1)" ) << "max(1,3.5,-2.1)" << false << QVariant( 3.5 );
       QTest::newRow( "min(-1.5)" ) << "min(-1.5)" << false << QVariant( -1.5 );
       QTest::newRow( "min(-16.6,3.5,-2.1)" ) << "min(-16.6,3.5,-2.1)" << false << QVariant( -16.6 );
+      QTest::newRow( "floor(4.9)" ) << "floor(4.9)" << false << QVariant( 4. );
+      QTest::newRow( "floor(-4.9)" ) << "floor(-4.9)" << false << QVariant( -5. );
+      QTest::newRow( "ceil(4.9)" ) << "ceil(4.9)" << false << QVariant( 5. );
+      QTest::newRow( "ceil(-4.9)" ) << "ceil(-4.9)" << false << QVariant( -4. );
 
       // cast functions
       QTest::newRow( "double to int" ) << "toint(3.2)" << false << QVariant( 3 );

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -264,6 +264,12 @@ class TestQgsExpression: public QObject
       QTest::newRow( "floor(-4.9)" ) << "floor(-4.9)" << false << QVariant( -5. );
       QTest::newRow( "ceil(4.9)" ) << "ceil(4.9)" << false << QVariant( 5. );
       QTest::newRow( "ceil(-4.9)" ) << "ceil(-4.9)" << false << QVariant( -4. );
+      QTest::newRow( "scale_linear(0.5,0,1,0,1)" ) << "scale_linear(0.5,0,1,0,1)" << false << QVariant( 0.5 );
+      QTest::newRow( "scale_linear(0,0,10,100,200)" ) << "scale_linear(0,0,10,100,200)" << false << QVariant( 100. );
+      QTest::newRow( "scale_linear(5,0,10,100,200)" ) << "scale_linear(5,0,10,100,200)" << false << QVariant( 150. );
+      QTest::newRow( "scale_linear(10,0,10,100,200)" ) << "scale_linear(10,0,10,100,200)" << false << QVariant( 200. );
+      QTest::newRow( "scale_linear(-1,0,10,100,200)" ) << "scale_linear(-1,0,10,100,200)" << false << QVariant( 100. );
+      QTest::newRow( "scale_linear(11,0,10,100,200)" ) << "scale_linear(11,0,10,100,200)" << false << QVariant( 200. );
 
       // cast functions
       QTest::newRow( "double to int" ) << "toint(3.2)" << false << QVariant( 3 );

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -274,6 +274,8 @@ class TestQgsExpression: public QObject
       QTest::newRow( "regexp_replace invalid" ) << "regexp_replace('HeLLo','[[[', '-')" << true << QVariant();
       QTest::newRow( "substr" ) << "substr('HeLLo', 3,2)" << false << QVariant( "LL" );
       QTest::newRow( "substr outside" ) << "substr('HeLLo', -5,2)" << false << QVariant( "" );
+      QTest::newRow( "regexp_substr" ) << "regexp_substr('abc123','(\\\\d+)')" << false << QVariant( "123" );
+      QTest::newRow( "regexp_substr invalid" ) << "regexp_substr('abc123','([[[')" << true << QVariant();
       QTest::newRow( "strpos" ) << "strpos('Hello World','World')" << false << QVariant( 6 );
       QTest::newRow( "strpos outside" ) << "strpos('Hello World','blah')" << false << QVariant( -1 );
       QTest::newRow( "left" ) << "left('Hello World',5)" << false << QVariant( "Hello" );

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -253,6 +253,10 @@ class TestQgsExpression: public QObject
       QTest::newRow( "round(1234.554,2) - round down" ) << "round(1234.554,2)" << false << QVariant( 1234.55 );
       QTest::newRow( "round(1234.6) - round up to int" ) << "round(1234.6)" << false << QVariant( 1235 );
       QTest::newRow( "round(1234.6) - round down to int" ) << "round(1234.4)" << false << QVariant( 1234 );
+      QTest::newRow( "max(1)" ) << "max(1)" << false << QVariant( 1. );
+      QTest::newRow( "max(1,3.5,-2.1)" ) << "max(1,3.5,-2.1)" << false << QVariant( 3.5 );
+      QTest::newRow( "min(-1.5)" ) << "min(-1.5)" << false << QVariant( -1.5 );
+      QTest::newRow( "min(-16.6,3.5,-2.1)" ) << "min(-16.6,3.5,-2.1)" << false << QVariant( -16.6 );
 
       // cast functions
       QTest::newRow( "double to int" ) << "toint(3.2)" << false << QVariant( 3 );

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -454,6 +454,40 @@ class TestQgsExpression: public QObject
       QCOMPARE( v.toInt(), 200 );
     }
 
+    void eval_rand()
+    {
+      QgsExpression exp1( "rand(1,10)" );
+      QVariant v1 = exp1.evaluate();
+      QCOMPARE( v1.toInt() <= 10, true );
+      QCOMPARE( v1.toInt() >= 1, true );
+
+      QgsExpression exp2( "rand(-5,-5)" );
+      QVariant v2 = exp2.evaluate();
+      QCOMPARE( v2.toInt(), -5 );
+
+      // Invalid expression since max<min
+      QgsExpression exp3( "rand(10,1)" );
+      QVariant v3 = exp3.evaluate();
+      QCOMPARE( v3.type(),  QVariant::Invalid );
+    }
+
+    void eval_randf()
+    {
+      QgsExpression exp1( "randf(1.5,9.5)" );
+      QVariant v1 = exp1.evaluate();
+      QCOMPARE( v1.toDouble() <= 9.5, true );
+      QCOMPARE( v1.toDouble() >= 1.5, true );
+
+      QgsExpression exp2( "randf(-0.0005,-0.0005)" );
+      QVariant v2 = exp2.evaluate();
+      QCOMPARE( v2.toDouble(), -0.0005 );
+
+      // Invalid expression since max<min
+      QgsExpression exp3( "randf(9.3333,1.784)" );
+      QVariant v3 = exp3.evaluate();
+      QCOMPARE( v3.type(),  QVariant::Invalid );
+    }
+
     void referenced_columns()
     {
       QSet<QString> expectedCols;


### PR DESCRIPTION
This commit adds a bunch of (imho) crucial functions to the expression engine:
- abs (returns absolute value)
- rand and randf, for generating random numbers
- max and min (return max or min value from a set of input values)
- trim (removes whitespace from start/end of string)
- floor and ceil (for rounding up/down a double)
- scale_linear (for linearly scaling an input value to an output range, great for data defined expressions where your field values may range from 1000-10000 and you need output values between say 10 and 20). Think d3's scale function.
- regexp_substr, for returning the matched part of a regular expression

I've added these functions because I think they're vital to make the expression engine flexible and powerful. All functions have help and test cases, so I'm hoping these can be merged for 2.0 despite being past the feature freeze.
