### PR TITLE
Allow unprepared execution of QgsExpression

### DIFF
--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -2243,7 +2243,10 @@ QVariant QgsExpression::NodeColumnRef::eval( QgsExpression* /*parent*/, QgsFeatu
 {
   if ( f )
   {
-    return f->attribute( mIndex );
+    if ( mIndex >= 0 )
+      return f->attribute( mIndex );
+    else
+      return f->attribute( mName );
   }
   return QVariant( "[" + mName + "]" );
 }


### PR DESCRIPTION
The documentation of QgsExpression states: 

> For better performance with many evaluations you may first call prepare(fields) function
> to find out indices of columns and then repeatedly call evaluate(feature).

Currently it is not optional (may) but mandatory to do this. Unprepared execution silently fails to evaluate properly.
This patch introduces unprepared execution.
