### PR TITLE
use checkable groupbox instead of separate checkboxes in console

### DIFF
--- a/python/console/console_editor.py
+++ b/python/console/console_editor.py
@@ -186,7 +186,6 @@ class Editor(QsciScintilla):
         threshold = self.settings.value("pythonConsole/autoCompThresholdEditor", 2).toInt()[0]
         radioButtonSource = self.settings.value("pythonConsole/autoCompleteSourceEditor", 'fromAPI').toString()
         autoCompEnabled = self.settings.value("pythonConsole/autoCompleteEnabledEditor", True).toBool()
-
         self.setAutoCompletionThreshold(threshold)
         if autoCompEnabled:
             if radioButtonSource == 'fromDoc':
@@ -958,11 +957,11 @@ class EditorTabWidget(QTabWidget):
             self._removeTab(i)
         self.newTabEditor(tabName='Untitled-0')
         self._removeTab(0)
-        
+
     def saveAs(self):
         idx = self.idx
         self.parent.saveAsScriptFile(idx)
-    
+
     def enableSaveIfModified(self, tab):
         tabWidget = self.widget(tab)
         if tabWidget:

--- a/python/console/console_sci.py
+++ b/python/console/console_sci.py
@@ -118,7 +118,6 @@ class ShellScintilla(QsciScintilla, code.InteractiveInterpreter):
         self.setAutoCompletionThreshold(threshold)
         radioButtonSource = self.settings.value("pythonConsole/autoCompleteSource", 'fromAPI').toString()
         autoCompEnabled = self.settings.value("pythonConsole/autoCompleteEnabled", True).toBool()
-        self.setAutoCompletionThreshold(threshold)
         if autoCompEnabled:
             if radioButtonSource == 'fromDoc':
                 self.setAutoCompletionSource(self.AcsDocument)

--- a/python/console/console_settings.py
+++ b/python/console/console_settings.py
@@ -35,7 +35,6 @@ class optionsDialog(QDialog, Ui_SettingsDialogPythonConsole):
 
         self.restoreSettings()
         self.initialCheck()
-        self.autoCompletionOptions()
 
         self.addAPIpath.setIcon(QIcon(":/images/themes/default/symbologyAdd.png"))
         self.addAPIpath.setToolTip(QCoreApplication.translate("PythonConsole", "Add API path"))
@@ -44,10 +43,6 @@ class optionsDialog(QDialog, Ui_SettingsDialogPythonConsole):
 
         self.connect( self.preloadAPI,
                       SIGNAL("stateChanged(int)"), self.initialCheck)
-        self.connect( self.autoCompleteEnabled,
-                      SIGNAL("stateChanged(int)"), self.autoCompletionOptions)
-        self.connect( self.autoCompleteEnabledEditor,
-                      SIGNAL("stateChanged(int)"), self.autoCompletionOptions)
         self.connect(self.addAPIpath,
                      SIGNAL("clicked()"), self.loadAPIFile)
         self.connect(self.removeAPIpath,
@@ -63,28 +58,6 @@ class optionsDialog(QDialog, Ui_SettingsDialogPythonConsole):
         self.tableWidget.setEnabled(value)
         self.addAPIpath.setEnabled(value)
         self.removeAPIpath.setEnabled(value)
-
-    def autoCompletionOptions(self):
-        if self.autoCompleteEnabled.isChecked():
-            self.enableDisableAutoCompleteOptions(True)
-        else:
-            self.enableDisableAutoCompleteOptions(False)
-        if self.autoCompleteEnabledEditor.isChecked():
-            self.enableDisableAutoCompleteOptions(True, editor='editor')
-        else:
-            self.enableDisableAutoCompleteOptions(False, editor='editor')
-
-    def enableDisableAutoCompleteOptions(self, value, editor=None):
-        if editor:
-            self.autoCompFromAPIEditor.setEnabled(value)
-            self.autoCompFromDocAPIEditor.setEnabled(value)
-            self.autoCompFromDocEditor.setEnabled(value)
-            self.autoCompThresholdEditor.setEnabled(value)
-        else:
-            self.autoCompFromAPI.setEnabled(value)
-            self.autoCompFromDocAPI.setEnabled(value)
-            self.autoCompFromDoc.setEnabled(value)
-            self.autoCompThreshold.setEnabled(value)
 
     def loadAPIFile(self):
         settings = QSettings()
@@ -146,6 +119,9 @@ class optionsDialog(QDialog, Ui_SettingsDialogPythonConsole):
         settings.setValue("pythonConsole/autoCompThreshold", QVariant(self.autoCompThreshold.value()))
         settings.setValue("pythonConsole/autoCompThresholdEditor", QVariant(self.autoCompThresholdEditor.value()))
 
+        settings.setValue("pythonConsole/autoCompleteEnabledEditor", QVariant(self.groupBoxAutoCompletionEditor.isChecked()))
+        settings.setValue("pythonConsole/autoCompleteEnabled", QVariant(self.groupBoxAutoCompletion.isChecked()))
+
         if self.autoCompFromAPIEditor.isChecked():
             settings.setValue("pythonConsole/autoCompleteSourceEditor", QVariant('fromAPI'))
         elif self.autoCompFromDocEditor.isChecked():
@@ -160,8 +136,6 @@ class optionsDialog(QDialog, Ui_SettingsDialogPythonConsole):
         elif self.autoCompFromDocAPI.isChecked():
             settings.setValue("pythonConsole/autoCompleteSource", QVariant('fromDocAPI'))
 
-        settings.setValue("pythonConsole/autoCompleteEnabledEditor", QVariant(self.autoCompleteEnabledEditor.isChecked()))
-        settings.setValue("pythonConsole/autoCompleteEnabled", QVariant(self.autoCompleteEnabled.isChecked()))
         settings.setValue("pythonConsole/enableObjectInsp", QVariant(self.enableObjectInspector.isChecked()))
         settings.setValue("pythonConsole/autoCloseBracket", QVariant(self.autoCloseBracket.isChecked()))
         settings.setValue("pythonConsole/autoCloseBracketEditor", QVariant(self.autoCloseBracketEditor.isChecked()))
@@ -188,8 +162,6 @@ class optionsDialog(QDialog, Ui_SettingsDialogPythonConsole):
         self.autoCompThreshold.setValue(settings.value("pythonConsole/autoCompThreshold", 2).toInt()[0])
         self.autoCompThresholdEditor.setValue(settings.value("pythonConsole/autoCompThresholdEditor", 2).toInt()[0])
 
-        self.autoCompleteEnabledEditor.setChecked(settings.value("pythonConsole/autoCompleteEnabledEditor", True).toBool())
-        self.autoCompleteEnabled.setChecked(settings.value("pythonConsole/autoCompleteEnabled", True).toBool())
         self.enableObjectInspector.setChecked(settings.value("pythonConsole/enableObjectInsp", False).toBool())
         self.autoCloseBracketEditor.setChecked(settings.value("pythonConsole/autoCloseBracketEditor", True).toBool())
         self.autoCloseBracket.setChecked(settings.value("pythonConsole/autoCloseBracket", True).toBool())

--- a/python/console/console_settings.ui
+++ b/python/console/console_settings.ui
@@ -58,8 +58,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>543</width>
-        <height>674</height>
+        <width>554</width>
+        <height>642</height>
        </rect>
       </property>
       <layout class="QGridLayout" name="gridLayout_2">
@@ -137,59 +137,37 @@
             <property name="title">
              <string>Autocompletion</string>
             </property>
+            <property name="checkable">
+             <bool>true</bool>
+            </property>
             <property name="collapsed" stdset="0">
              <bool>true</bool>
             </property>
-            <layout class="QGridLayout" name="gridLayout_7">
+            <property name="saveCheckedState" stdset="0">
+             <bool>true</bool>
+            </property>
+            <property name="saveCollapsedState" stdset="0">
+             <bool>true</bool>
+            </property>
+            <layout class="QGridLayout" name="gridLayout_4">
              <item row="0" column="0">
-              <layout class="QHBoxLayout" name="horizontalLayout_2">
-               <item>
-                <widget class="QCheckBox" name="autoCompleteEnabledEditor">
-                 <property name="text">
-                  <string>Autocompletion enabled</string>
-                 </property>
-                 <property name="checked">
-                  <bool>true</bool>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <spacer name="horizontalSpacer">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>40</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-               <item>
-                <layout class="QGridLayout" name="gridLayout_4">
-                 <item row="0" column="0">
-                  <widget class="QLabel" name="label_2">
-                   <property name="text">
-                    <string>Threshold</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="1">
-                  <widget class="QSpinBox" name="autoCompThresholdEditor">
-                   <property name="maximum">
-                    <number>10</number>
-                   </property>
-                   <property name="value">
-                    <number>2</number>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
-              </layout>
+              <widget class="QLabel" name="label_2">
+               <property name="text">
+                <string>Autocompletion threshold</string>
+               </property>
+              </widget>
              </item>
-             <item row="1" column="0">
+             <item row="0" column="1">
+              <widget class="QSpinBox" name="autoCompThresholdEditor">
+               <property name="maximum">
+                <number>10</number>
+               </property>
+               <property name="value">
+                <number>2</number>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0" colspan="2">
               <layout class="QGridLayout" name="layoutRadioButtonEditor">
                <item row="0" column="0">
                 <widget class="QRadioButton" name="autoCompFromDocEditor">
@@ -255,103 +233,6 @@
           <string>Console</string>
          </property>
          <layout class="QGridLayout" name="gridLayout_9">
-          <item row="3" column="0">
-           <widget class="QgsCollapsibleGroupBox" name="groupBoxAutoCompletion">
-            <property name="title">
-             <string>Autocompletion</string>
-            </property>
-            <property name="collapsed" stdset="0">
-             <bool>false</bool>
-            </property>
-            <layout class="QGridLayout" name="gridLayout_8">
-             <item row="0" column="0">
-              <layout class="QHBoxLayout" name="horizontalLayout_4">
-               <item>
-                <widget class="QCheckBox" name="autoCompleteEnabled">
-                 <property name="text">
-                  <string>Autocompletion enabled</string>
-                 </property>
-                 <property name="checked">
-                  <bool>true</bool>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <spacer name="horizontalSpacer_2">
-                 <property name="orientation">
-                  <enum>Qt::Horizontal</enum>
-                 </property>
-                 <property name="sizeHint" stdset="0">
-                  <size>
-                   <width>40</width>
-                   <height>20</height>
-                  </size>
-                 </property>
-                </spacer>
-               </item>
-               <item>
-                <layout class="QGridLayout" name="gridLayout_5">
-                 <item row="0" column="0">
-                  <widget class="QLabel" name="label_6">
-                   <property name="text">
-                    <string>Threshold</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="1">
-                  <widget class="QSpinBox" name="autoCompThreshold">
-                   <property name="maximum">
-                    <number>10</number>
-                   </property>
-                   <property name="value">
-                    <number>2</number>
-                   </property>
-                  </widget>
-                 </item>
-                </layout>
-               </item>
-              </layout>
-             </item>
-             <item row="1" column="0">
-              <layout class="QGridLayout" name="layoutRadioButton">
-               <item row="0" column="0">
-                <widget class="QRadioButton" name="autoCompFromDoc">
-                 <property name="toolTip">
-                  <string>Get autocompletion from current document</string>
-                 </property>
-                 <property name="text">
-                  <string>from Document</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="1">
-                <widget class="QRadioButton" name="autoCompFromAPI">
-                 <property name="toolTip">
-                  <string>Get autocompletion from installed APIs</string>
-                 </property>
-                 <property name="text">
-                  <string>from APIs files</string>
-                 </property>
-                 <property name="checked">
-                  <bool>true</bool>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="2">
-                <widget class="QRadioButton" name="autoCompFromDocAPI">
-                 <property name="toolTip">
-                  <string>Get autocompletion from current document and installed APIs</string>
-                 </property>
-                 <property name="text">
-                  <string>from Doc and APIs</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </item>
-            </layout>
-           </widget>
-          </item>
           <item row="1" column="0">
            <layout class="QHBoxLayout" name="horizontalLayout">
             <item>
@@ -408,11 +289,86 @@
             </item>
            </layout>
           </item>
-          <item row="4" column="0">
+          <item row="6" column="0">
            <widget class="QCheckBox" name="autoCloseBracket">
             <property name="text">
              <string>Automatic parentheses insertion</string>
             </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QgsCollapsibleGroupBox" name="groupBoxAutoCompletion">
+            <property name="title">
+             <string>Autocompletion</string>
+            </property>
+            <property name="checkable">
+             <bool>true</bool>
+            </property>
+            <property name="collapsed" stdset="0">
+             <bool>false</bool>
+            </property>
+            <property name="saveCheckedState" stdset="0">
+             <bool>true</bool>
+            </property>
+            <property name="saveCollapsedState" stdset="0">
+             <bool>true</bool>
+            </property>
+            <layout class="QGridLayout" name="gridLayout_5">
+             <item row="0" column="0">
+              <widget class="QLabel" name="label_6">
+               <property name="text">
+                <string>Autocompletion threshold</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QSpinBox" name="autoCompThreshold">
+               <property name="maximum">
+                <number>10</number>
+               </property>
+               <property name="value">
+                <number>2</number>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0" colspan="2">
+              <layout class="QGridLayout" name="layoutRadioButton">
+               <item row="0" column="2">
+                <widget class="QRadioButton" name="autoCompFromDocAPI">
+                 <property name="toolTip">
+                  <string>Get autocompletion from current document and installed APIs</string>
+                 </property>
+                 <property name="text">
+                  <string>from Doc and APIs</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <widget class="QRadioButton" name="autoCompFromAPI">
+                 <property name="toolTip">
+                  <string>Get autocompletion from installed APIs</string>
+                 </property>
+                 <property name="text">
+                  <string>from APIs files</string>
+                 </property>
+                 <property name="checked">
+                  <bool>false</bool>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="0">
+                <widget class="QRadioButton" name="autoCompFromDoc">
+                 <property name="toolTip">
+                  <string>Get autocompletion from current document</string>
+                 </property>
+                 <property name="text">
+                  <string>from Document</string>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+            </layout>
            </widget>
           </item>
          </layout>


### PR DESCRIPTION
Small cleanup in console settings dialog: use checkable groupboxes instead of separate checkboxes for autocompletion settings
