### PR TITLE
Some medium-impact improvements to composer

### DIFF
--- a/src/app/composer/qgscomposer.cpp
+++ b/src/app/composer/qgscomposer.cpp
@@ -203,6 +203,28 @@ QgsComposer::QgsComposer( QgisApp *qgis, const QString& title )
   composerMenu->addAction( mActionQuit );
   QObject::connect( mActionQuit, SIGNAL( triggered() ), this, SLOT( close() ) );
 
+  //cut/copy/paste actions. Note these are not included in the ui file
+  //as ui files have no support for QKeySequence shortcuts
+  mActionCut = new QAction( tr( "Cu&t" ), this );
+  mActionCut->setShortcuts( QKeySequence::Cut );
+  mActionCut->setStatusTip( tr( "Cut" ) );
+  QObject::connect( mActionCut, SIGNAL( triggered() ), this, SLOT( actionCutTriggered() ) );
+  mActionCopy = new QAction( tr( "&Copy" ), this );
+  mActionCopy->setShortcuts( QKeySequence::Copy );
+  mActionCopy->setStatusTip( tr( "Copy" ) );
+  QObject::connect( mActionCopy, SIGNAL( triggered() ), this, SLOT( actionCopyTriggered() ) );
+  mActionPaste = new QAction( tr( "&Paste" ), this );
+  mActionPaste->setShortcuts( QKeySequence::Paste );
+  mActionPaste->setStatusTip( tr( "Paste" ) );
+  QObject::connect( mActionPaste, SIGNAL( triggered() ), this, SLOT( actionPasteTriggered() ) );
+
+  QMenu *editMenu = menuBar()->addMenu( tr( "Edit" ) );
+  editMenu->addAction( mActionCut );
+  editMenu->addAction( mActionCopy );
+  editMenu->addAction( mActionPaste );
+  //TODO : "Ctrl+Shift+V" is one way to paste in place, but on some platforms you can use Shift+Ins and F18
+  editMenu->addAction( mActionPasteInPlace );
+
   QMenu *viewMenu = menuBar()->addMenu( tr( "View" ) );
   viewMenu->addAction( mActionZoomIn );
   viewMenu->addAction( mActionZoomOut );
@@ -1599,6 +1621,50 @@ void QgsComposer::on_mActionUngroupItems_triggered()
   if ( mView )
   {
     mView->ungroupItems();
+  }
+}
+
+void QgsComposer::actionCutTriggered()
+{
+  if ( mView )
+  {
+    mView->copyItems( QgsComposerView::ClipboardModeCut );
+  }
+}
+
+void QgsComposer::actionCopyTriggered()
+{
+  if ( mView )
+  {
+    mView->copyItems( QgsComposerView::ClipboardModeCopy );
+  }
+}
+
+void QgsComposer::actionPasteTriggered()
+{
+  if ( mView )
+  {
+    QPointF pt = mView->mapToScene( mView->mapFromGlobal( QCursor::pos() ) );
+    //TODO - use a better way of determining whether paste was triggered by keystroke
+    //or menu item
+    if (( pt.x() < 0 ) || ( pt.y() < 0 ) )
+    {
+      //action likely triggered by menu, paste items in center of screen
+      mView->pasteItems( QgsComposerView::PasteModeCenter );
+    }
+    else
+    {
+      //action likely triggered by keystroke, paste items at cursor position
+      mView->pasteItems( QgsComposerView::PasteModeCursor );
+    }
+  }
+}
+
+void QgsComposer::on_mActionPasteInPlace_triggered()
+{
+  if ( mView )
+  {
+    mView->pasteItems( QgsComposerView::PasteModeInPlace );
   }
 }
 

--- a/src/app/composer/qgscomposer.cpp
+++ b/src/app/composer/qgscomposer.cpp
@@ -222,6 +222,13 @@ QgsComposer::QgsComposer( QgisApp *qgis, const QString& title )
   editMenu->addAction( mActionUndo );
   editMenu->addAction( mActionRedo );
   editMenu->addSeparator();
+
+  //Backspace should also trigger delete selection
+  QShortcut* backSpace = new QShortcut( QKeySequence( "Backspace" ), this );
+  connect( backSpace, SIGNAL( activated() ), mActionDeleteSelection, SLOT( trigger() ) );
+  editMenu->addAction( mActionDeleteSelection );
+  editMenu->addSeparator();
+
   editMenu->addAction( mActionCut );
   editMenu->addAction( mActionCopy );
   editMenu->addAction( mActionPaste );
@@ -1666,6 +1673,14 @@ void QgsComposer::on_mActionPasteInPlace_triggered()
   if ( mView )
   {
     mView->pasteItems( QgsComposerView::PasteModeInPlace );
+  }
+}
+
+void QgsComposer::on_mActionDeleteSelection_triggered()
+{
+  if ( mView )
+  {
+    mView->deleteSelectedItems();
   }
 }
 

--- a/src/app/composer/qgscomposer.cpp
+++ b/src/app/composer/qgscomposer.cpp
@@ -234,6 +234,10 @@ QgsComposer::QgsComposer( QgisApp *qgis, const QString& title )
   editMenu->addAction( mActionPaste );
   //TODO : "Ctrl+Shift+V" is one way to paste in place, but on some platforms you can use Shift+Ins and F18
   editMenu->addAction( mActionPasteInPlace );
+  editMenu->addSeparator();
+  editMenu->addAction( mActionSelectAll );
+  editMenu->addAction( mActionDeselectAll );
+  editMenu->addAction( mActionInvertSelection );
 
   QMenu *viewMenu = menuBar()->addMenu( tr( "View" ) );
   viewMenu->addAction( mActionZoomIn );
@@ -1681,6 +1685,30 @@ void QgsComposer::on_mActionDeleteSelection_triggered()
   if ( mView )
   {
     mView->deleteSelectedItems();
+  }
+}
+
+void QgsComposer::on_mActionSelectAll_triggered()
+{
+  if ( mView )
+  {
+    mView->selectAll();
+  }
+}
+
+void QgsComposer::on_mActionDeselectAll_triggered()
+{
+  if ( mView )
+  {
+    mView->selectNone();
+  }
+}
+
+void QgsComposer::on_mActionInvertSelection_triggered()
+{
+  if ( mView )
+  {
+    mView->selectInvert();
   }
 }
 

--- a/src/app/composer/qgscomposer.cpp
+++ b/src/app/composer/qgscomposer.cpp
@@ -219,6 +219,9 @@ QgsComposer::QgsComposer( QgisApp *qgis, const QString& title )
   QObject::connect( mActionPaste, SIGNAL( triggered() ), this, SLOT( actionPasteTriggered() ) );
 
   QMenu *editMenu = menuBar()->addMenu( tr( "Edit" ) );
+  editMenu->addAction( mActionUndo );
+  editMenu->addAction( mActionRedo );
+  editMenu->addSeparator();
   editMenu->addAction( mActionCut );
   editMenu->addAction( mActionCopy );
   editMenu->addAction( mActionPaste );
@@ -247,22 +250,20 @@ QgsComposer::QgsComposer( QgisApp *qgis, const QString& title )
   mToolbarMenu->addAction( mItemToolbar->toggleViewAction() );
 
   QMenu *layoutMenu = menuBar()->addMenu( tr( "Layout" ) );
-  layoutMenu->addAction( mActionUndo );
-  layoutMenu->addAction( mActionRedo );
-  layoutMenu->addSeparator();
   layoutMenu->addAction( mActionAddNewMap );
   layoutMenu->addAction( mActionAddNewLabel );
   layoutMenu->addAction( mActionAddNewScalebar );
   layoutMenu->addAction( mActionAddNewLegend );
   layoutMenu->addAction( mActionAddImage );
-  layoutMenu->addAction( mActionSelectMoveItem );
-  layoutMenu->addAction( mActionMoveItemContent );
-
   layoutMenu->addAction( mActionAddArrow );
   layoutMenu->addAction( mActionAddTable );
   layoutMenu->addSeparator();
+  layoutMenu->addAction( mActionSelectMoveItem );
+  layoutMenu->addAction( mActionMoveItemContent );
+  layoutMenu->addSeparator();
   layoutMenu->addAction( mActionGroupItems );
   layoutMenu->addAction( mActionUngroupItems );
+  layoutMenu->addSeparator();
   layoutMenu->addAction( mActionRaiseItems );
   layoutMenu->addAction( mActionLowerItems );
   layoutMenu->addAction( mActionMoveItemsToTop );

--- a/src/app/composer/qgscomposer.h
+++ b/src/app/composer/qgscomposer.h
@@ -222,6 +222,15 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
     //! Delete selected item(s)
     void on_mActionDeleteSelection_triggered();
 
+    //! Select all items
+    void on_mActionSelectAll_triggered();
+
+    //! Deselect all items
+    void on_mActionDeselectAll_triggered();
+
+    //! Invert selection
+    void on_mActionInvertSelection_triggered();
+
     //! Ungroup selected item group
     void on_mActionUngroupItems_triggered();
 

--- a/src/app/composer/qgscomposer.h
+++ b/src/app/composer/qgscomposer.h
@@ -207,6 +207,18 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
     //! Group selected items
     void on_mActionGroupItems_triggered();
 
+    //! Cut item(s)
+    void actionCutTriggered();
+
+    //! Copy item(s)
+    void actionCopyTriggered();
+
+    //! Paste item(s)
+    void actionPasteTriggered();
+
+    //! Paste in place item(s)
+    void on_mActionPasteInPlace_triggered();
+
     //! Ungroup selected item group
     void on_mActionUngroupItems_triggered();
 
@@ -367,6 +379,11 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
 
     //! Window menu action to select this window
     QAction *mWindowAction;
+
+    //! Copy/cut/paste actions
+    QAction *mActionCut;
+    QAction *mActionCopy;
+    QAction *mActionPaste;
 
     //! Page & Printer Setup
     QPrinter mPrinter;

--- a/src/app/composer/qgscomposer.h
+++ b/src/app/composer/qgscomposer.h
@@ -219,6 +219,9 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
     //! Paste in place item(s)
     void on_mActionPasteInPlace_triggered();
 
+    //! Delete selected item(s)
+    void on_mActionDeleteSelection_triggered();
+
     //! Ungroup selected item group
     void on_mActionUngroupItems_triggered();
 

--- a/src/gui/qgscomposerview.cpp
+++ b/src/gui/qgscomposerview.cpp
@@ -560,10 +560,8 @@ void QgsComposerView::pasteItems( PasteMode mode )
   }
 }
 
-void QgsComposerView::keyPressEvent( QKeyEvent * e )
+void QgsComposerView::deleteSelectedItems()
 {
-  //TODO : those should be actions (so we could also display menu items and/or toolbar items)
-
   if ( !composition() )
   {
     return;
@@ -573,18 +571,26 @@ void QgsComposerView::keyPressEvent( QKeyEvent * e )
   QList<QgsComposerItem*>::iterator itemIt = composerItemList.begin();
 
   //delete selected items
-  if ( e->key() == Qt::Key_Delete || e->key() == Qt::Key_Backspace )
+  for ( ; itemIt != composerItemList.end(); ++itemIt )
   {
-    for ( ; itemIt != composerItemList.end(); ++itemIt )
+    if ( composition() )
     {
-      if ( composition() )
-      {
-        composition()->removeComposerItem( *itemIt );
-      }
+      composition()->removeComposerItem( *itemIt );
     }
   }
+}
 
-  else if ( e->key() == Qt::Key_Left )
+void QgsComposerView::keyPressEvent( QKeyEvent * e )
+{
+  if ( !composition() )
+  {
+    return;
+  }
+
+  QList<QgsComposerItem*> composerItemList = composition()->selectedComposerItems();
+  QList<QgsComposerItem*>::iterator itemIt = composerItemList.begin();
+
+  if ( e->key() == Qt::Key_Left )
   {
     for ( ; itemIt != composerItemList.end(); ++itemIt )
     {

--- a/src/gui/qgscomposerview.cpp
+++ b/src/gui/qgscomposerview.cpp
@@ -38,6 +38,7 @@
 #include "qgscomposerattributetable.h"
 #include "qgslogger.h"
 #include "qgsaddremovemultiframecommand.h"
+#include "qgspaperitem.h"
 
 QgsComposerView::QgsComposerView( QWidget* parent, const char* name, Qt::WFlags f )
     : QGraphicsView( parent )
@@ -576,6 +577,68 @@ void QgsComposerView::deleteSelectedItems()
     if ( composition() )
     {
       composition()->removeComposerItem( *itemIt );
+    }
+  }
+}
+
+void QgsComposerView::selectAll()
+{
+  if ( !composition() )
+  {
+    return;
+  }
+
+  //select all items in composer
+  QList<QGraphicsItem *> itemList = composition()->items();
+  QList<QGraphicsItem *>::iterator itemIt = itemList.begin();
+  for ( ; itemIt != itemList.end(); ++itemIt )
+  {
+    QgsComposerItem* mypItem = dynamic_cast<QgsComposerItem *>( *itemIt );
+    QgsPaperItem* paperItem = dynamic_cast<QgsPaperItem*>( *itemIt );
+    if ( mypItem && !paperItem )
+    {
+      mypItem->setSelected( true );
+      emit selectedItemChanged( mypItem );
+    }
+  }
+}
+
+void QgsComposerView::selectNone()
+{
+  if ( !composition() )
+  {
+    return;
+  }
+
+  composition()->clearSelection();
+}
+
+void QgsComposerView::selectInvert()
+{
+  if ( !composition() )
+  {
+    return;
+  }
+
+  //check all items in composer
+  QList<QGraphicsItem *> itemList = composition()->items();
+  QList<QGraphicsItem *>::iterator itemIt = itemList.begin();
+  for ( ; itemIt != itemList.end(); ++itemIt )
+  {
+    QgsComposerItem* mypItem = dynamic_cast<QgsComposerItem *>( *itemIt );
+    QgsPaperItem* paperItem = dynamic_cast<QgsPaperItem*>( *itemIt );
+    if ( mypItem && !paperItem )
+    {
+      //flip selected state for items
+      if ( mypItem->selected() )
+      {
+        mypItem->setSelected( false );
+      }
+      else
+      {
+        mypItem->setSelected( true );
+        emit selectedItemChanged( mypItem );
+      }
     }
   }
 }

--- a/src/gui/qgscomposerview.h
+++ b/src/gui/qgscomposerview.h
@@ -68,6 +68,19 @@ class GUI_EXPORT QgsComposerView: public QGraphicsView
       MoveItemContent //move content of item (e.g. content of map)
     };
 
+    enum ClipboardMode
+    {
+      ClipboardModeCut,
+      ClipboardModeCopy
+    };
+
+    enum PasteMode
+    {
+      PasteModeCursor,
+      PasteModeCenter,
+      PasteModeInPlace
+    };
+
     QgsComposerView( QWidget* parent = 0, const char* name = 0, Qt::WFlags f = 0 );
 
     /**Add an item group containing the selected items*/
@@ -75,6 +88,12 @@ class GUI_EXPORT QgsComposerView: public QGraphicsView
 
     /**Ungroups the selected items*/
     void ungroupItems();
+
+    /**Cuts or copies the selected items*/
+    void copyItems( ClipboardMode mode );
+
+    /**Pastes items from clipboard*/
+    void pasteItems( PasteMode mode );
 
     QgsComposerView::Tool currentTool() const {return mCurrentTool;}
     void setCurrentTool( QgsComposerView::Tool t ) {mCurrentTool = t;}

--- a/src/gui/qgscomposerview.h
+++ b/src/gui/qgscomposerview.h
@@ -98,6 +98,15 @@ class GUI_EXPORT QgsComposerView: public QGraphicsView
     /**Deletes selected items*/
     void deleteSelectedItems();
 
+    /**Selects all items*/
+    void selectAll();
+
+    /**Deselects all items*/
+    void selectNone();
+
+    /**Inverts current selection*/
+    void selectInvert();
+
     QgsComposerView::Tool currentTool() const {return mCurrentTool;}
     void setCurrentTool( QgsComposerView::Tool t ) {mCurrentTool = t;}
 

--- a/src/gui/qgscomposerview.h
+++ b/src/gui/qgscomposerview.h
@@ -95,6 +95,9 @@ class GUI_EXPORT QgsComposerView: public QGraphicsView
     /**Pastes items from clipboard*/
     void pasteItems( PasteMode mode );
 
+    /**Deletes selected items*/
+    void deleteSelectedItems();
+
     QgsComposerView::Tool currentTool() const {return mCurrentTool;}
     void setCurrentTool( QgsComposerView::Tool t ) {mCurrentTool = t;}
 

--- a/src/ui/qgscomposerbase.ui
+++ b/src/ui/qgscomposerbase.ui
@@ -570,6 +570,17 @@
     <string>New from template</string>
    </property>
   </action>
+  <action name="mActionPasteInPlace">
+   <property name="text">
+    <string>Pa&amp;ste in Place</string>
+   </property>
+   <property name="toolTip">
+    <string>Paste in place</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+V</string>
+   </property>
+  </action>
  </widget>
  <resources>
   <include location="../../images/images.qrc"/>

--- a/src/ui/qgscomposerbase.ui
+++ b/src/ui/qgscomposerbase.ui
@@ -581,6 +581,17 @@
     <string>Ctrl+Shift+V</string>
    </property>
   </action>
+  <action name="mActionDeleteSelection">
+   <property name="text">
+    <string>&amp;Delete</string>
+   </property>
+   <property name="toolTip">
+    <string>Delete selected items</string>
+   </property>
+   <property name="shortcut">
+    <string>Del</string>
+   </property>
+  </action>  
  </widget>
  <resources>
   <include location="../../images/images.qrc"/>

--- a/src/ui/qgscomposerbase.ui
+++ b/src/ui/qgscomposerbase.ui
@@ -456,7 +456,7 @@
     </iconset>
    </property>
    <property name="text">
-    <string>Undo</string>
+    <string>&amp;Undo</string>
    </property>
    <property name="toolTip">
     <string>Revert last change</string>
@@ -471,7 +471,7 @@
      <normaloff>:/images/themes/default/mActionRedo.png</normaloff>:/images/themes/default/mActionRedo.png</iconset>
    </property>
    <property name="text">
-    <string>Redo</string>
+    <string>&amp;Redo</string>
    </property>
    <property name="toolTip">
     <string>Restore last change</string>
@@ -591,7 +591,37 @@
    <property name="shortcut">
     <string>Del</string>
    </property>
-  </action>  
+  </action>
+  <action name="mActionDeselectAll">
+   <property name="text">
+    <string>De&amp;select All</string>
+   </property>
+   <property name="toolTip">
+    <string>Deselect all</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+A</string>
+   </property>
+  </action>
+  <action name="mActionSelectAll">
+   <property name="text">
+    <string>Select &amp;All</string>
+   </property>
+   <property name="toolTip">
+    <string>Select all items</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+A</string>
+   </property>
+  </action>
+  <action name="mActionInvertSelection">
+   <property name="text">
+    <string>&amp;Invert Selection</string>
+   </property>
+   <property name="toolTip">
+    <string>Invert selection</string>
+   </property>
+  </action>
  </widget>
  <resources>
   <include location="../../images/images.qrc"/>


### PR DESCRIPTION
I've split my original pull request #599 into a number of separate requests. This second one consists of some medium-impact changes as it adds a new 'Edit' menu to the composer and contains some new strings. The changes themselves should be harmless (although the diff for 3eb0ac0 makes it look much more intrusive than it actually is).

This request adds:
- A new edit menu in composers with cut/copy/paste/paste in place/delete items
- Moves undo/redo to the edit menu
- Adds new actions for "Select All", "Select None" and "Invert Selection"

Again, not sure if these can be accepted into 2.0, if not I'll hold off till 2.1.
