### PR TITLE
[FEATURE]  Module to generate prepared APIs file for call tips and auto-completion in Python Console

### DIFF
--- a/python/console/CMakeLists.txt
+++ b/python/console/CMakeLists.txt
@@ -7,6 +7,7 @@ SET(PY_CONSOLE_FILES
   console_settings.py
   console_output.py
   console_editor.py
+  console_compile_apis.py
   __init__.py
 )
 

--- a/python/console/console_compile_apis.py
+++ b/python/console/console_compile_apis.py
@@ -1,0 +1,95 @@
+# -*- coding:utf-8 -*-
+"""
+/***************************************************************************
+Module to generate prepared APIs for calltips and auto-completion.
+                             -------------------
+begin                : 2012-09-10
+copyright            : (C) 2012 Larry Shaffer
+email                : larrys (at) dakotacarto (dot) com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+Portions of this file contain code from Eric4 APIsManager module.
+"""
+
+import sys
+import os
+import shutil
+import fnmatch
+import glob
+
+from PyQt4.Qsci import *
+from PyQt4.QtGui import *
+from PyQt4.QtCore import *
+
+from ui_console_compile_apis import Ui_APIsDialogPythonConsole
+
+class PrepareAPIDialog(QDialog):
+    def __init__(self, api_lexer, api_files, pap_file, parent=None):
+        QDialog.__init__(self, parent)
+        self.ui = Ui_APIsDialogPythonConsole()
+        self.ui.setupUi(self)
+        self.setWindowTitle(QCoreApplication.translate("PythonConsole","Compile APIs"))
+        self.ui.plainTextEdit.setVisible(False)
+        self.ui.textEdit_Qsci.setVisible(False)
+        self.adjustSize()
+        self._api = None
+        self.ui.buttonBox.rejected.connect(self._stopPreparation)
+        self._api_files = api_files
+        self._api_lexer = api_lexer
+        self._pap_file = pap_file
+
+    def _clearLexer(self):
+#        self.ui.textEdit_Qsci.setLexer(0)
+        self.qlexer = None
+
+    def _stopPreparation(self):
+        if self._api is not None:
+            self._api.cancelPreparation()
+        self._api = None
+        self._clearLexer()
+        self.close()
+
+    def _preparationFinished(self):
+        self._clearLexer()
+        if os.path.exists(self._pap_file):
+            os.remove(self._pap_file)
+        self.ui.label.setText(QCoreApplication.translate("PythonConsole","Saving prepared file..."))
+        prepd = self._api.savePrepared(unicode(self._pap_file))
+        rslt = self.trUtf8("Error")
+        if prepd:
+            rslt = QCoreApplication.translate("PythonConsole","Saved")
+        self.ui.label.setText('{0} {1}'.format(self.ui.label.text(), rslt))
+        self._api = None
+        self.ui.progressBar.setVisible(False)
+        self.ui.buttonBox.button(QDialogButtonBox.Cancel).setText(
+            QCoreApplication.translate("PythonConsole","Done"))
+        self.adjustSize()
+
+    def prepareAPI(self):
+#        self.ui.textEdit_Qsci.setLexer(0)
+        exec 'self.qlexer = {0}(self.ui.textEdit_Qsci)'.format(self._api_lexer)
+#        self.ui.textEdit_Qsci.setLexer(self.qlexer)
+        self._api = QsciAPIs(self.qlexer)
+        self._api.apiPreparationFinished.connect(self._preparationFinished)
+        for api_file in self._api_files:
+            self._api.load(unicode(api_file))
+        try:
+            self._api.prepare()
+        except Exception, err:
+            self._api = None
+            self._clearLexer()
+            self.ui.label.setText(QCoreApplication.translate("PythonConsole","Error preparing file..."))
+            self.ui.progressBar.setVisible(False)
+            self.ui.plainTextEdit.setVisible(True)
+            self.ui.plainTextEdit.insertPlainText(err)
+            self.ui.buttonBox.button(QDialogButtonBox.Cancel).setText(
+                self.trUtf8("Done"))
+            self.adjustSize()

--- a/python/console/console_compile_apis.ui
+++ b/python/console/console_compile_apis.ui
@@ -1,0 +1,98 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>APIsDialogPythonConsole</class>
+ <widget class="QDialog" name="APIsDialogPythonConsole">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>320</width>
+    <height>280</height>
+   </rect>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>320</width>
+    <height>0</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string/>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QLabel" name="label">
+     <property name="minimumSize">
+      <size>
+       <width>320</width>
+       <height>0</height>
+      </size>
+     </property>
+     <property name="text">
+      <string>Generating prepared API file (please wait)...</string>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QProgressBar" name="progressBar">
+     <property name="enabled">
+      <bool>true</bool>
+     </property>
+     <property name="maximum">
+      <number>0</number>
+     </property>
+     <property name="value">
+      <number>-1</number>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QPlainTextEdit" name="plainTextEdit">
+     <property name="font">
+      <font>
+       <pointsize>12</pointsize>
+      </font>
+     </property>
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QsciScintilla" name="textEdit_Qsci">
+     <property name="toolTip">
+      <string/>
+     </property>
+     <property name="whatsThis">
+      <string/>
+     </property>
+     <property name="verticalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
+     </property>
+     <property name="horizontalScrollBarPolicy">
+      <enum>Qt::ScrollBarAlwaysOff</enum>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QsciScintilla</class>
+   <extends>QFrame</extends>
+   <header>Qsci/qsciscintilla.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>

--- a/python/console/console_editor.py
+++ b/python/console/console_editor.py
@@ -237,8 +237,11 @@ class Editor(QsciScintilla):
 
         self.api = QsciAPIs(self.lexer)
         chekBoxAPI = self.settings.value("pythonConsole/preloadAPI", True, type=bool)
+        chekBoxPreparedAPI = self.settings.value("pythonConsole/usePreparedAPIFile", False, type=bool)
         if chekBoxAPI:
-            self.api.loadPrepared( QgsApplication.pkgDataPath() + "/python/qsci_apis/pyqgis_master.pap" )
+            self.api.loadPrepared(QgsApplication.pkgDataPath() + "/python/qsci_apis/pyqgis_master.pap")
+        elif chekBoxPreparedAPI:
+            self.api.loadPrepared(self.settings.value("pythonConsole/preparedAPIFile"))
         else:
             apiPath = self.settings.value("pythonConsole/userAPI")
             for i in range(0, len(apiPath)):

--- a/python/console/console_sci.py
+++ b/python/console/console_sci.py
@@ -189,8 +189,11 @@ class ShellScintilla(QsciScintilla, code.InteractiveInterpreter):
 
         self.api = QsciAPIs(self.lexer)
         chekBoxAPI = self.settings.value("pythonConsole/preloadAPI", True, type=bool)
+        chekBoxPreparedAPI = self.settings.value("pythonConsole/usePreparedAPIFile", False, type=bool)
         if chekBoxAPI:
-            self.api.loadPrepared( QgsApplication.pkgDataPath() + "/python/qsci_apis/pyqgis_master.pap" )
+            self.api.loadPrepared(QgsApplication.pkgDataPath() + "/python/qsci_apis/pyqgis_master.pap")
+        elif chekBoxPreparedAPI:
+            self.api.loadPrepared(self.settings.value("pythonConsole/preparedAPIFile"))
         else:
             apiPath = self.settings.value("pythonConsole/userAPI")
             for i in range(0, len(apiPath)):

--- a/python/console/console_settings.ui
+++ b/python/console/console_settings.ui
@@ -9,8 +9,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>579</width>
-    <height>563</height>
+    <width>580</width>
+    <height>569</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -63,7 +63,7 @@
        </rect>
       </property>
       <layout class="QGridLayout" name="gridLayout_2">
-       <item row="2" column="0">
+       <item row="1" column="0">
         <widget class="QGroupBox" name="groupBox_3">
          <property name="title">
           <string>Editor</string>
@@ -73,6 +73,91 @@
            <widget class="QCheckBox" name="autoSaveScript">
             <property name="text">
              <string>Auto-save script before running</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QgsCollapsibleGroupBox" name="groupBoxAutoCompletionEditor">
+            <property name="title">
+             <string>Autocompletion</string>
+            </property>
+            <property name="checkable">
+             <bool>true</bool>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+            <property name="collapsed" stdset="0">
+             <bool>true</bool>
+            </property>
+            <property name="saveCheckedState" stdset="0">
+             <bool>true</bool>
+            </property>
+            <property name="saveCollapsedState" stdset="0">
+             <bool>true</bool>
+            </property>
+            <layout class="QGridLayout" name="gridLayout_4">
+             <item row="1" column="0" colspan="2">
+              <layout class="QGridLayout" name="layoutRadioButtonEditor">
+               <item row="0" column="0">
+                <widget class="QRadioButton" name="autoCompFromDocEditor">
+                 <property name="toolTip">
+                  <string>Get autocompletion from current document</string>
+                 </property>
+                 <property name="text">
+                  <string>from Document</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="2">
+                <widget class="QRadioButton" name="autoCompFromDocAPIEditor">
+                 <property name="toolTip">
+                  <string>Get autocompletion from current document and installed APIs</string>
+                 </property>
+                 <property name="text">
+                  <string>from Doc and APIs</string>
+                 </property>
+                </widget>
+               </item>
+               <item row="0" column="1">
+                <widget class="QRadioButton" name="autoCompFromAPIEditor">
+                 <property name="toolTip">
+                  <string>Get autocompletion from installed APIs</string>
+                 </property>
+                 <property name="text">
+                  <string>from APIs files</string>
+                 </property>
+                 <property name="checked">
+                  <bool>true</bool>
+                 </property>
+                </widget>
+               </item>
+              </layout>
+             </item>
+             <item row="0" column="0">
+              <widget class="QLabel" name="label_2">
+               <property name="text">
+                <string>Autocompletion threshold</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QSpinBox" name="autoCompThresholdEditor">
+               <property name="maximum">
+                <number>10</number>
+               </property>
+               <property name="value">
+                <number>2</number>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QCheckBox" name="autoCloseBracketEditor">
+            <property name="text">
+             <string>Automatic parentheses insertion</string>
             </property>
            </widget>
           </item>
@@ -132,81 +217,6 @@
             </item>
            </layout>
           </item>
-          <item row="4" column="0">
-           <widget class="QgsCollapsibleGroupBox" name="groupBoxAutoCompletionEditor">
-            <property name="title">
-             <string>Autocompletion</string>
-            </property>
-            <property name="checkable">
-             <bool>true</bool>
-            </property>
-            <property name="collapsed" stdset="0">
-             <bool>true</bool>
-            </property>
-            <property name="saveCheckedState" stdset="0">
-             <bool>true</bool>
-            </property>
-            <property name="saveCollapsedState" stdset="0">
-             <bool>true</bool>
-            </property>
-            <layout class="QGridLayout" name="gridLayout_4">
-             <item row="0" column="0">
-              <widget class="QLabel" name="label_2">
-               <property name="text">
-                <string>Autocompletion threshold</string>
-               </property>
-              </widget>
-             </item>
-             <item row="0" column="1">
-              <widget class="QSpinBox" name="autoCompThresholdEditor">
-               <property name="maximum">
-                <number>10</number>
-               </property>
-               <property name="value">
-                <number>2</number>
-               </property>
-              </widget>
-             </item>
-             <item row="1" column="0" colspan="2">
-              <layout class="QGridLayout" name="layoutRadioButtonEditor">
-               <item row="0" column="0">
-                <widget class="QRadioButton" name="autoCompFromDocEditor">
-                 <property name="toolTip">
-                  <string>Get autocompletion from current document</string>
-                 </property>
-                 <property name="text">
-                  <string>from Document</string>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="1">
-                <widget class="QRadioButton" name="autoCompFromAPIEditor">
-                 <property name="toolTip">
-                  <string>Get autocompletion from installed APIs</string>
-                 </property>
-                 <property name="text">
-                  <string>from APIs files</string>
-                 </property>
-                 <property name="checked">
-                  <bool>true</bool>
-                 </property>
-                </widget>
-               </item>
-               <item row="0" column="2">
-                <widget class="QRadioButton" name="autoCompFromDocAPIEditor">
-                 <property name="toolTip">
-                  <string>Get autocompletion from current document and installed APIs</string>
-                 </property>
-                 <property name="text">
-                  <string>from Doc and APIs</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </item>
-            </layout>
-           </widget>
-          </item>
           <item row="0" column="0">
            <widget class="QCheckBox" name="enableObjectInspector">
             <property name="text">
@@ -214,13 +224,6 @@
             </property>
             <property name="checked">
              <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="0">
-           <widget class="QCheckBox" name="autoCloseBracketEditor">
-            <property name="text">
-             <string>Automatic parentheses insertion</string>
             </property>
            </widget>
           </item>
@@ -304,6 +307,9 @@
             <property name="checkable">
              <bool>true</bool>
             </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
             <property name="collapsed" stdset="0">
              <bool>false</bool>
             </property>
@@ -374,12 +380,12 @@
          </layout>
         </widget>
        </item>
-       <item row="4" column="0">
+       <item row="2" column="0">
         <widget class="QGroupBox" name="groupBox_2">
          <property name="title">
           <string>APIs</string>
          </property>
-         <layout class="QGridLayout" name="gridLayout_3">
+         <layout class="QGridLayout" name="gridLayout_7">
           <item row="0" column="0">
            <widget class="QCheckBox" name="preloadAPI">
             <property name="text">
@@ -522,6 +528,47 @@
              </widget>
             </item>
            </layout>
+          </item>
+          <item row="2" column="0">
+           <widget class="QgsCollapsibleGroupBox" name="groupBoxPreparedAPI">
+            <property name="title">
+             <string>Using prepared APIs file</string>
+            </property>
+            <property name="checkable">
+             <bool>true</bool>
+            </property>
+            <property name="checked">
+             <bool>false</bool>
+            </property>
+            <property name="collapsed" stdset="0">
+             <bool>true</bool>
+            </property>
+            <property name="saveCollapsedState" stdset="0">
+             <bool>true</bool>
+            </property>
+            <property name="saveCheckedState" stdset="0">
+             <bool>true</bool>
+            </property>
+            <layout class="QGridLayout" name="gridLayout_3">
+             <item row="0" column="0">
+              <widget class="QPushButton" name="compileAPIs">
+               <property name="text">
+                <string>Compile APIs...</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QLineEdit" name="lineEdit">
+               <property name="minimumSize">
+                <size>
+                 <width>0</width>
+                 <height>27</height>
+                </size>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </widget>
           </item>
          </layout>
         </widget>


### PR DESCRIPTION
I would like add this new feature to the python console.

As discussed long ago with Larry, it would be useful to add the ability to python console to compile the APIs files to generate a prepared APIs file used by QScintilla. This brings the benefit of speeding up the code completion and calltips when you use many APIs files.

@dakcarto: I used your script (editors_api.py) to do this, so if you get a chance, could you test this feature please?
