### PR TITLE
Fix crash when authentication fails. Fix #7913

### DIFF
--- a/src/gui/qgscredentialdialog.cpp
+++ b/src/gui/qgscredentialdialog.cpp
@@ -64,7 +64,7 @@ void QgsCredentialDialog::requestCredentials( QString realm, QString *username, 
 
   QgsDebugMsg( "exec()" );
   *ok = exec() == QDialog::Accepted;
-  QgsDebugMsg( QString( "exec(): %1" ).arg( ok ? "true" : "false" ) );
+  QgsDebugMsg( QString( "exec(): %1" ).arg( *ok ? "true" : "false" ) );
 
   QApplication::restoreOverrideCursor();
 

--- a/src/providers/wfs/qgswfssourceselect.cpp
+++ b/src/providers/wfs/qgswfssourceselect.cpp
@@ -207,8 +207,6 @@ void QgsWFSSourceSelect::capabilitiesReplyFinished()
     }
     // handle errors
     QMessageBox::critical( 0, title, mCapabilities->errorMessage() );
-
-    btnAdd->setEnabled( false );
     return;
   }
 


### PR DESCRIPTION
- Fix pointer dereferencing
- Remove call to uninitialized button.
  As stated by Valgrind:

==13851== Use of uninitialised value of size 8
==13851==    at 0x9961780: QWidget::setEnabled(bool) (in /usr/lib/x86_64-linux-gnu/libQtGui.so.4.8.2)
==13851==    by 0x27600FB1: QgsWFSSourceSelect::capabilitiesReplyFinished() (qgswfssourceselect.cpp:211)
==13851==    by 0x2760B78F: QgsWFSSourceSelect::qt_static_metacall(QObject_, QMetaObject::Call, int, void__) (moc_qgswfssourceselect.cxx:156)
==13851==    by 0x93F554E: QMetaObject::activate(QObject_, QMetaObject const_, int, void__) (in /usr/lib/x86_64-linux-gnu/libQtCore.so.4.8.2)
==13851==    by 0x2760A458: QgsWFSCapabilities::gotCapabilities() (moc_qgswfscapabilities.cxx:103)
==13851==    by 0x275F88CD: QgsWFSCapabilities::capabilitiesReplyFinished() (qgswfscapabilities.cpp:156)
==13851==    by 0x2760A331: QgsWFSCapabilities::qt_static_metacall(QObject_, QMetaObject::Call, int, void**) (moc_qgswfscapabilities.cxx:54)
==13851==    by 0x93F554E: QMetaObject::activate(QObject_, QMetaObject const_, int, void**) (in /usr/lib/x86_64-linux-gnu/libQtCore.so.4.8.2)
==13851==    by 0xA46E824: ??? (in /usr/lib/x86_64-linux-gnu/libQtNetwork.so.4.8.2)
==13851==    by 0xA4DC904: ??? (in /usr/lib/x86_64-linux-gnu/libQtNetwork.so.4.8.2)
==13851==    by 0x93F4A2D: QObject::event(QEvent_) (in /usr/lib/x86_64-linux-gnu/libQtCore.so.4.8.2)
==13851==    by 0x991470B: QApplicationPrivate::notify_helper(QObject_, QEvent*) (in /usr/lib/x86_64-linux-gnu/libQtGui.so.4.8.2)
==13851==
