### PR TITLE
Offline Editing Plugin - Windows Fix

### DIFF
--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -73,7 +73,7 @@ bool QgsOfflineEditing::convertToOfflineProject( const QString& offlineDataPath,
   {
     spatialite_init( 0 );
     sqlite3* db;
-    int rc = sqlite3_open( dbPath.toStdString().c_str(), &db );
+    int rc = sqlite3_open( dbPath.toUtf8().constData(), &db );
     if ( rc != SQLITE_OK )
     {
       showWarning( tr( "Could not open the spatialite database" ) );
@@ -794,7 +794,7 @@ sqlite3* QgsOfflineEditing::openLoggingDb()
   QString dbPath = QgsProject::instance()->readEntry( PROJECT_ENTRY_SCOPE_OFFLINE, PROJECT_ENTRY_KEY_OFFLINE_DB_PATH );
   if ( !dbPath.isEmpty() )
   {
-    int rc = sqlite3_open( dbPath.toStdString().c_str(), &db );
+    int rc = sqlite3_open( dbPath.toUtf8().constData(), &db );
     if ( rc != SQLITE_OK )
     {
       showWarning( tr( "Could not open the spatialite logging database" ) );


### PR DESCRIPTION
Fix for http://hub.qgis.org/issues/6146

With an earlier merged pull request(https://github.com/qgis/Quantum-GIS/pull/586), the issue was resolved in linux systems but was not functional in windows. After converting the database path to UTF-8, it is working in windows. Tested in Windows XP.
