### PR TITLE
Labeling performance

### DIFF
--- a/src/core/pal/costcalculator.h
+++ b/src/core/pal/costcalculator.h
@@ -47,13 +47,9 @@ namespace pal
   {
       LabelPosition *lp;
       double px, py;
-      double dist[8];
-      double rpx[8];
-      double rpy[8];
-      bool ok[8];
+      double dist;
+      bool ok;
 
-      void updatePoint( PointSet *pset );
-      double updateLinePoly( PointSet *pset );
     public:
       PolygonCostCalculator( LabelPosition *lp );
 

--- a/src/core/pal/feature.cpp
+++ b/src/core/pal/feature.cpp
@@ -1103,7 +1103,10 @@ namespace pal
         j++;
       }
 
-      dx = dy = min( yrm, xrm ) / 2;
+      //dx = dy = min( yrm, xrm ) / 2;
+      dx = xrm / 2.0;
+      dy = yrm / 2.0;
+
 
       int num_try = 0;
       int max_try = 10;


### PR DESCRIPTION
Horizontal and free placement for labels in polygons is currently very slow. This pull request simplifies the candidate cost calculation to improve performance. Originally, to calculate the cost of a candidate position, the position to the closest polygon boundary or obstable was evaluated in eight direction and additionally to the closest boundary/obstacle. This pull request uses only the distance to the closest boundary / obstacle, therefore saving the eight ray / segment instersections.
Please review.
