### PR TITLE
Updates in src/core/CMakeLists.txt, missing raster headers in installation of core library

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -486,6 +486,12 @@ SET(QGIS_CORE_HDRS
   raster/qgsrastershader.h
   raster/qgsrastershaderfunction.h
   raster/qgsrasterviewport.h
+  raster/qgsbrightnesscontrastfilter.h
+  raster/qgshuesaturationfilter.h
+  raster/qgsrasternuller.h
+  raster/qgsrasterrenderer.h
+
+  
 
   symbology-ng/qgscategorizedsymbolrendererv2.h
   symbology-ng/qgscolorbrewerpalette.h


### PR DESCRIPTION
When working in a external application and doing make install in qgis it misses some raster headers.
