### PR TITLE
fix a iteration

### DIFF
--- a/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.cpp
+++ b/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.cpp
@@ -976,7 +976,7 @@ QDomElement QgsGraduatedSymbolRendererV2::save( QDomDocument& doc )
   QgsSymbolV2Map symbols;
   QDomElement rangesElem = doc.createElement( "ranges" );
   QgsRangeList::const_iterator it = mRanges.constBegin();
-  for ( ; it != mRanges.end(); it++ )
+  for ( ; it != mRanges.constEnd(); it++ )
   {
     const QgsRendererRangeV2& range = *it;
     QString symbolName = QString::number( i );


### PR DESCRIPTION
This patch fixes a bug which was reported to Japanese ML (http://osgeo-org.1560.x6.nabble.com/QGIS-td5015613.html). Crash occurs when graduated style of a hidden layer is saved to a QGIS Layer Style File.
