### PR TITLE
Fixes for raster memory-leaks

### DIFF
--- a/cmake/FindGDAL.cmake
+++ b/cmake/FindGDAL.cmake
@@ -1,191 +1,94 @@
-# Find GDAL
-# ~~~~~~~~~
-# Copyright (c) 2007, Magnus Homann <magnus at homann dot se>
-# Redistribution and use is allowed according to the terms of the BSD license.
-# For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+# Locate gdal
+# This module defines
+# GDAL_LIBRARY
+# GDAL_FOUND, if false, do not try to link to gdal 
+# GDAL_INCLUDE_DIR, where to find the headers
 #
+# $GDALDIR is an environment variable that would
+# correspond to the ./configure --prefix=$GDAL_DIR
+# used in building gdal.
 #
-# Once run this will define: 
-# 
-# GDAL_FOUND       = system has GDAL lib
-#
-# GDAL_LIBRARY     = full path to the library
-#
-# GDAL_INCLUDE_DIR      = where to find headers 
+# Created by Eric Wing. I'm not a gdal user, but OpenSceneGraph uses it 
+# for osgTerrain so I whipped this module together for completeness.
+# I actually don't know the conventions or where files are typically
+# placed in distros.
+# Any real gdal users are encouraged to correct this (but please don't
+# break the OS X framework stuff when doing so which is what usually seems 
+# to happen).
+
+# This makes the presumption that you are include gdal.h like
+# #include "gdal.h"
+
+FIND_PATH(GDAL_INCLUDE_DIR gdal.h
+  PATHS
+  $ENV{GDAL_DIR}
+  NO_DEFAULT_PATH
+    PATH_SUFFIXES include
+)
+
+FIND_PATH(GDAL_INCLUDE_DIR gdal.h
+    PATHS ${CMAKE_PREFIX_PATH} # Unofficial: We are proposing this.
+    NO_DEFAULT_PATH
+    PATH_SUFFIXES include
+)
+
+FIND_PATH(GDAL_INCLUDE_DIR gdal.h
+  PATHS
+  ~/Library/Frameworks/gdal.framework/Headers
+  /Library/Frameworks/gdal.framework/Headers
+  /usr/local/include/gdal
+  /usr/local/include/GDAL
+  /usr/local/include
+  /usr/include/gdal
+  /usr/include/GDAL
+  /usr/include
+  /sw/include/gdal 
+  /sw/include/GDAL 
+  /sw/include # Fink
+  /opt/local/include/gdal
+  /opt/local/include/GDAL
+  /opt/local/include # DarwinPorts
+  /opt/csw/include/gdal
+  /opt/csw/include/GDAL
+  /opt/csw/include # Blastwave
+  /opt/include/gdal
+  /opt/include/GDAL
+  /opt/include
+)
+
+FIND_LIBRARY(GDAL_LIBRARY 
+  NAMES gdal gdal_i gdal1.8.0 gdal1.7.0 gdal1.6.0 gdal1.5.0 gdal1.4.0 gdal1.3.2 GDAL
+  PATHS
+  $ENV{GDAL_DIR}
+  NO_DEFAULT_PATH
+  PATH_SUFFIXES lib64 lib
+)
+FIND_LIBRARY(GDAL_LIBRARY 
+  NAMES gdal gdal_i gdal 1.8.0 gdal1.7.0 gdal1.6.0 gdal1.5.0 gdal1.4.0 gdal1.3.2 GDAL
+  PATHS ${CMAKE_PREFIX_PATH} # Unofficial: We are proposing this.
+    NO_DEFAULT_PATH
+    PATH_SUFFIXES lib64 lib
+)
+FIND_LIBRARY(GDAL_LIBRARY 
+  NAMES gdal gdal_i gdal1.8.0 gdal1.7.0 gdal1.6.0 gdal1.5.0 gdal1.4.0 gdal1.3.2 GDAL
+  PATHS
+    ~/Library/Frameworks
+    /Library/Frameworks
+    /usr/local
+    /usr
+    /sw
+    /opt/local
+    /opt/csw
+    /opt
+    /usr/freeware
+    [HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Session\ Manager\\Environment;GDAL_ROOT]/lib
+  PATH_SUFFIXES lib64 lib
+)
+
+SET(GDAL_FOUND "NO")
+IF(GDAL_LIBRARY AND GDAL_INCLUDE_DIR)
+  SET(GDAL_FOUND "YES")
+ENDIF(GDAL_LIBRARY AND GDAL_INCLUDE_DIR)
 
 
-INCLUDE (@CMAKE_SOURCE_DIR@/cmake/MacPlistMacros.cmake)
 
-IF(WIN32)
-
-  IF (MINGW)
-    FIND_PATH(GDAL_INCLUDE_DIR gdal.h /usr/local/include /usr/include c:/msys/local/include)
-    FIND_LIBRARY(GDAL_LIBRARY NAMES gdal PATHS /usr/local/lib /usr/lib c:/msys/local/lib)
-  ENDIF (MINGW)
-
-  IF (MSVC)
-    FIND_PATH(GDAL_INCLUDE_DIR gdal.h "$ENV{LIB_DIR}/include/gdal" $ENV{INCLUDE})
-    FIND_LIBRARY(GDAL_LIBRARY NAMES gdal gdal_i PATHS 
-	    "$ENV{LIB_DIR}/lib" $ENV{LIB} /usr/lib c:/msys/local/lib)
-    IF (GDAL_LIBRARY)
-      SET (
-         GDAL_LIBRARY;odbc32;odbccp32 
-         CACHE STRING INTERNAL)
-    ENDIF (GDAL_LIBRARY)
-  ENDIF (MSVC)
-  
-  
-ELSE(WIN32)
-  IF(UNIX) 
-
-    # try to use framework on mac
-    # want clean framework path, not unix compatibility path
-    IF (APPLE)
-      IF (CMAKE_FIND_FRAMEWORK MATCHES "FIRST"
-          OR CMAKE_FRAMEWORK_PATH MATCHES "ONLY"
-          OR NOT CMAKE_FIND_FRAMEWORK)
-        SET (CMAKE_FIND_FRAMEWORK_save ${CMAKE_FIND_FRAMEWORK} CACHE STRING "" FORCE)
-        SET (CMAKE_FIND_FRAMEWORK "ONLY" CACHE STRING "" FORCE)
-        FIND_LIBRARY(GDAL_LIBRARY GDAL)
-        IF (GDAL_LIBRARY)
-          # they're all the same in a framework
-          SET (GDAL_INCLUDE_DIR ${GDAL_LIBRARY}/Headers CACHE PATH "Path to a file.")
-          # set GDAL_CONFIG to make later test happy, not used here, may not exist
-          SET (GDAL_CONFIG ${GDAL_LIBRARY}/unix/bin/gdal-config CACHE FILEPATH "Path to a program.")
-          # version in info.plist
-          GET_VERSION_PLIST (${GDAL_LIBRARY}/Resources/Info.plist GDAL_VERSION)
-          IF (NOT GDAL_VERSION)
-            MESSAGE (FATAL_ERROR "Could not determine GDAL version from framework.")
-          ENDIF (NOT GDAL_VERSION)
-          STRING(REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+)" "\\1" GDAL_VERSION_MAJOR "${GDAL_VERSION}")
-          STRING(REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+)" "\\2" GDAL_VERSION_MINOR "${GDAL_VERSION}")
-          IF (GDAL_VERSION_MAJOR LESS 1 OR (GDAL_VERSION EQUAL 1 AND GDAL_VERSION_MINOR LESS 4))
-            MESSAGE (FATAL_ERROR "GDAL version is too old (${GDAL_VERSION}). Use 1.4.0 or higher.")
-          ENDIF (GDAL_VERSION_MAJOR LESS 1 OR (GDAL_VERSION EQUAL 1 AND GDAL_VERSION_MINOR LESS 4))
-        ENDIF (GDAL_LIBRARY)
-        SET (CMAKE_FIND_FRAMEWORK ${CMAKE_FIND_FRAMEWORK_save} CACHE STRING "" FORCE)
-      ENDIF ()
-    ENDIF (APPLE)
-
-    IF(CYGWIN)
-      FIND_LIBRARY(GDAL_LIBRARY NAMES gdal PATHS /usr/lib /usr/local/lib)
-    ENDIF(CYGWIN)
-
-    IF (NOT GDAL_INCLUDE_DIR OR NOT GDAL_LIBRARY OR NOT GDAL_CONFIG)
-      # didn't find OS X framework, and was not set by user
-      SET(GDAL_CONFIG_PREFER_PATH "$ENV{GDAL_HOME}/bin" CACHE STRING "preferred path to GDAL (gdal-config)")
-      SET(GDAL_CONFIG_PREFER_FWTOOLS_PATH "$ENV{FWTOOLS_HOME}/bin_safe" CACHE STRING "preferred path to GDAL (gdal-config) from FWTools")
-      FIND_PROGRAM(GDAL_CONFIG gdal-config
-          ${GDAL_CONFIG_PREFER_PATH}
-          ${GDAL_CONFIG_PREFER_FWTOOLS_PATH}
-          /usr/local/bin/
-          /usr/bin/
-          )
-      # MESSAGE("DBG GDAL_CONFIG ${GDAL_CONFIG}")
-    
-      IF (GDAL_CONFIG) 
-
-        ## extract gdal version 
-        EXEC_PROGRAM(${GDAL_CONFIG}
-            ARGS --version
-            OUTPUT_VARIABLE GDAL_VERSION )
-        STRING(REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+)" "\\1" GDAL_VERSION_MAJOR "${GDAL_VERSION}")
-        STRING(REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+)" "\\2" GDAL_VERSION_MINOR "${GDAL_VERSION}")
-  
-        # MESSAGE("DBG GDAL_VERSION ${GDAL_VERSION}")
-        # MESSAGE("DBG GDAL_VERSION_MAJOR ${GDAL_VERSION_MAJOR}")
-        # MESSAGE("DBG GDAL_VERSION_MINOR ${GDAL_VERSION_MINOR}")
-  
-        # check for gdal version
-        # version 1.2.5 is known NOT to be supported (missing CPL_STDCALL macro)
-        # According to INSTALL, 1.4.0+ is required
-        IF (GDAL_VERSION_MAJOR LESS 1 OR (GDAL_VERSION_MAJOR EQUAL 1 AND GDAL_VERSION_MINOR LESS 4))
-          MESSAGE (FATAL_ERROR "GDAL version is too old (${GDAL_VERSION}). Use 1.4.0 or higher.")
-        ENDIF (GDAL_VERSION_MAJOR LESS 1 OR (GDAL_VERSION_MAJOR EQUAL 1 AND GDAL_VERSION_MINOR LESS 4))
-
-        # set INCLUDE_DIR to prefix+include
-        EXEC_PROGRAM(${GDAL_CONFIG}
-            ARGS --prefix
-            OUTPUT_VARIABLE GDAL_PREFIX)
-        #SET(GDAL_INCLUDE_DIR ${GDAL_PREFIX}/include CACHE STRING INTERNAL)
-        FIND_PATH(GDAL_INCLUDE_DIR 
-            gdal.h 
-            ${GDAL_PREFIX}/include/gdal
-            ${GDAL_PREFIX}/include
-            /usr/local/include 
-            /usr/include 
-            )
-
-        ## extract link dirs for rpath  
-        EXEC_PROGRAM(${GDAL_CONFIG}
-            ARGS --libs
-            OUTPUT_VARIABLE GDAL_CONFIG_LIBS )
-
-        ## split off the link dirs (for rpath)
-        ## use regular expression to match wildcard equivalent "-L*<endchar>"
-        ## with <endchar> is a space or a semicolon
-        STRING(REGEX MATCHALL "[-][L]([^ ;])+" 
-            GDAL_LINK_DIRECTORIES_WITH_PREFIX 
-            "${GDAL_CONFIG_LIBS}" )
-        #      MESSAGE("DBG  GDAL_LINK_DIRECTORIES_WITH_PREFIX=${GDAL_LINK_DIRECTORIES_WITH_PREFIX}")
-
-        ## remove prefix -L because we need the pure directory for LINK_DIRECTORIES
-      
-        IF (GDAL_LINK_DIRECTORIES_WITH_PREFIX)
-          STRING(REGEX REPLACE "[-][L]" "" GDAL_LINK_DIRECTORIES ${GDAL_LINK_DIRECTORIES_WITH_PREFIX} )
-        ENDIF (GDAL_LINK_DIRECTORIES_WITH_PREFIX)
-
-        ## split off the name
-        ## use regular expression to match wildcard equivalent "-l*<endchar>"
-        ## with <endchar> is a space or a semicolon
-        STRING(REGEX MATCHALL "[-][l]([^ ;])+" 
-            GDAL_LIB_NAME_WITH_PREFIX 
-            "${GDAL_CONFIG_LIBS}" )
-        #      MESSAGE("DBG  GDAL_LIB_NAME_WITH_PREFIX=${GDAL_LIB_NAME_WITH_PREFIX}")
-
-
-        ## remove prefix -l because we need the pure name
-      
-        IF (GDAL_LIB_NAME_WITH_PREFIX)
-          STRING(REGEX REPLACE "[-][l]" "" GDAL_LIB_NAME ${GDAL_LIB_NAME_WITH_PREFIX} )
-        ENDIF (GDAL_LIB_NAME_WITH_PREFIX)
-
-        IF (APPLE)
-          IF (NOT GDAL_LIBRARY)
-            # work around empty GDAL_LIBRARY left by framework check
-            # while still preserving user setting if given
-            # ***FIXME*** need to improve framework check so below not needed
-            SET(GDAL_LIBRARY ${GDAL_LINK_DIRECTORIES}/lib${GDAL_LIB_NAME}.dylib CACHE STRING INTERNAL FORCE)
-          ENDIF (NOT GDAL_LIBRARY)
-        ELSE (APPLE)
-          SET(GDAL_LIBRARY ${GDAL_LINK_DIRECTORIES}/lib${GDAL_LIB_NAME}.so CACHE STRING INTERNAL)
-        ENDIF (APPLE)
-      
-      ELSE(GDAL_CONFIG)
-        MESSAGE("FindGDAL.cmake: gdal-config not found. Please set it manually. GDAL_CONFIG=${GDAL_CONFIG}")
-      ENDIF(GDAL_CONFIG)
-    ENDIF (NOT GDAL_INCLUDE_DIR OR NOT GDAL_LIBRARY OR NOT GDAL_CONFIG)
-  ENDIF(UNIX)
-ENDIF(WIN32)
-
-
-IF (GDAL_INCLUDE_DIR AND GDAL_LIBRARY)
-   SET(GDAL_FOUND TRUE)
-ENDIF (GDAL_INCLUDE_DIR AND GDAL_LIBRARY)
-
-IF (GDAL_FOUND)
-
-   IF (NOT GDAL_FIND_QUIETLY)
-      FILE(READ ${GDAL_INCLUDE_DIR}/gdal_version.h gdal_version)
-      STRING(REGEX REPLACE "^.*GDAL_RELEASE_NAME +\"([^\"]+)\".*$" "\\1" GDAL_RELEASE_NAME "${gdal_version}")
-
-      MESSAGE(STATUS "Found GDAL: ${GDAL_LIBRARY} (${GDAL_RELEASE_NAME})")
-   ENDIF (NOT GDAL_FIND_QUIETLY)
-
-ELSE (GDAL_FOUND)
-
-   MESSAGE(GDAL_INCLUDE_DIR=${GDAL_INCLUDE_DIR})
-   MESSAGE(GDAL_LIBRARY=${GDAL_LIBRARY})
-   MESSAGE(FATAL_ERROR "Could not find GDAL")
-
-ENDIF (GDAL_FOUND)

--- a/cmake/FindGDAL.cmake
+++ b/cmake/FindGDAL.cmake
@@ -1,191 +1,93 @@
-# Find GDAL
-# ~~~~~~~~~
-# Copyright (c) 2007, Magnus Homann <magnus at homann dot se>
-# Redistribution and use is allowed according to the terms of the BSD license.
-# For details see the accompanying COPYING-CMAKE-SCRIPTS file.
+# Locate gdal
+# This module defines
+# GDAL_LIBRARY
+# GDAL_FOUND, if false, do not try to link to gdal 
+# GDAL_INCLUDE_DIR, where to find the headers
 #
+# $GDALDIR is an environment variable that would
+# correspond to the ./configure --prefix=$GDAL_DIR
+# used in building gdal.
 #
-# Once run this will define: 
-# 
-# GDAL_FOUND       = system has GDAL lib
-#
-# GDAL_LIBRARY     = full path to the library
-#
-# GDAL_INCLUDE_DIR      = where to find headers 
+# Created by Eric Wing. I'm not a gdal user, but OpenSceneGraph uses it 
+# for osgTerrain so I whipped this module together for completeness.
+# I actually don't know the conventions or where files are typically
+# placed in distros.
+# Any real gdal users are encouraged to correct this (but please don't
+# break the OS X framework stuff when doing so which is what usually seems 
+# to happen).
+
+# This makes the presumption that you are include gdal.h like
+# #include "gdal.h"
+
+FIND_PATH(GDAL_INCLUDE_DIR gdal.h
+  PATHS
+  $ENV{GDAL_DIR}
+  NO_DEFAULT_PATH
+    PATH_SUFFIXES include
+)
+
+FIND_PATH(GDAL_INCLUDE_DIR gdal.h
+    PATHS ${CMAKE_PREFIX_PATH} # Unofficial: We are proposing this.
+    NO_DEFAULT_PATH
+    PATH_SUFFIXES include
+)
+
+FIND_PATH(GDAL_INCLUDE_DIR gdal.h
+  PATHS
+  ~/Library/Frameworks/gdal.framework/Headers
+  /Library/Frameworks/gdal.framework/Headers
+  /usr/local/include/gdal
+  /usr/local/include/GDAL
+  /usr/local/include
+  /usr/include/gdal
+  /usr/include/GDAL
+  /usr/include
+  /sw/include/gdal 
+  /sw/include/GDAL 
+  /sw/include # Fink
+  /opt/local/include/gdal
+  /opt/local/include/GDAL
+  /opt/local/include # DarwinPorts
+  /opt/csw/include/gdal
+  /opt/csw/include/GDAL
+  /opt/csw/include # Blastwave
+  /opt/include/gdal
+  /opt/include/GDAL
+  /opt/include
+)
+
+FIND_LIBRARY(GDAL_LIBRARY 
+  NAMES gdal gdal_i gdal1.8.1 gdal1.7.0 gdal1.6.0 gdal1.5.0 gdal1.4.0 GDAL
+  PATHS
+  $ENV{GDAL_DIR}
+  NO_DEFAULT_PATH
+  PATH_SUFFIXES lib64 lib
+)
+FIND_LIBRARY(GDAL_LIBRARY 
+  NAMES gdal gdal_i gdal1.8.1 gdal1.7.0 gdal1.6.0 gdal1.5.0 gdal1.4.0  GDAL
+  PATHS ${CMAKE_PREFIX_PATH} # Unofficial: We are proposing this.
+    NO_DEFAULT_PATH
+    PATH_SUFFIXES lib64 lib
+)
+FIND_LIBRARY(GDAL_LIBRARY 
+  NAMES gdal gdal_i gdal1.8.1 gdal1.7.0 gdal1.6.0 gdal1.5.0 gdal1.4.0 GDAL
+  PATHS
+    ~/Library/Frameworks
+    /Library/Frameworks
+    /usr/local
+    /usr
+    /sw
+    /opt/local
+    /opt/csw
+    /opt
+    /usr/freeware
+    [HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Session\ Manager\\Environment;GDAL_ROOT]/lib
+  PATH_SUFFIXES lib64 lib
+)
+
+SET(GDAL_FOUND "NO")
+IF(GDAL_LIBRARY AND GDAL_INCLUDE_DIR)
+  SET(GDAL_FOUND "YES")
+ENDIF(GDAL_LIBRARY AND GDAL_INCLUDE_DIR)
 
 
-INCLUDE (@CMAKE_SOURCE_DIR@/cmake/MacPlistMacros.cmake)
-
-IF(WIN32)
-
-  IF (MINGW)
-    FIND_PATH(GDAL_INCLUDE_DIR gdal.h /usr/local/include /usr/include c:/msys/local/include)
-    FIND_LIBRARY(GDAL_LIBRARY NAMES gdal PATHS /usr/local/lib /usr/lib c:/msys/local/lib)
-  ENDIF (MINGW)
-
-  IF (MSVC)
-    FIND_PATH(GDAL_INCLUDE_DIR gdal.h "$ENV{LIB_DIR}/include/gdal" $ENV{INCLUDE})
-    FIND_LIBRARY(GDAL_LIBRARY NAMES gdal gdal_i PATHS 
-	    "$ENV{LIB_DIR}/lib" $ENV{LIB} /usr/lib c:/msys/local/lib)
-    IF (GDAL_LIBRARY)
-      SET (
-         GDAL_LIBRARY;odbc32;odbccp32 
-         CACHE STRING INTERNAL)
-    ENDIF (GDAL_LIBRARY)
-  ENDIF (MSVC)
-  
-  
-ELSE(WIN32)
-  IF(UNIX) 
-
-    # try to use framework on mac
-    # want clean framework path, not unix compatibility path
-    IF (APPLE)
-      IF (CMAKE_FIND_FRAMEWORK MATCHES "FIRST"
-          OR CMAKE_FRAMEWORK_PATH MATCHES "ONLY"
-          OR NOT CMAKE_FIND_FRAMEWORK)
-        SET (CMAKE_FIND_FRAMEWORK_save ${CMAKE_FIND_FRAMEWORK} CACHE STRING "" FORCE)
-        SET (CMAKE_FIND_FRAMEWORK "ONLY" CACHE STRING "" FORCE)
-        FIND_LIBRARY(GDAL_LIBRARY GDAL)
-        IF (GDAL_LIBRARY)
-          # they're all the same in a framework
-          SET (GDAL_INCLUDE_DIR ${GDAL_LIBRARY}/Headers CACHE PATH "Path to a file.")
-          # set GDAL_CONFIG to make later test happy, not used here, may not exist
-          SET (GDAL_CONFIG ${GDAL_LIBRARY}/unix/bin/gdal-config CACHE FILEPATH "Path to a program.")
-          # version in info.plist
-          GET_VERSION_PLIST (${GDAL_LIBRARY}/Resources/Info.plist GDAL_VERSION)
-          IF (NOT GDAL_VERSION)
-            MESSAGE (FATAL_ERROR "Could not determine GDAL version from framework.")
-          ENDIF (NOT GDAL_VERSION)
-          STRING(REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+)" "\\1" GDAL_VERSION_MAJOR "${GDAL_VERSION}")
-          STRING(REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+)" "\\2" GDAL_VERSION_MINOR "${GDAL_VERSION}")
-          IF (GDAL_VERSION_MAJOR LESS 1 OR (GDAL_VERSION EQUAL 1 AND GDAL_VERSION_MINOR LESS 4))
-            MESSAGE (FATAL_ERROR "GDAL version is too old (${GDAL_VERSION}). Use 1.4.0 or higher.")
-          ENDIF (GDAL_VERSION_MAJOR LESS 1 OR (GDAL_VERSION EQUAL 1 AND GDAL_VERSION_MINOR LESS 4))
-        ENDIF (GDAL_LIBRARY)
-        SET (CMAKE_FIND_FRAMEWORK ${CMAKE_FIND_FRAMEWORK_save} CACHE STRING "" FORCE)
-      ENDIF ()
-    ENDIF (APPLE)
-
-    IF(CYGWIN)
-      FIND_LIBRARY(GDAL_LIBRARY NAMES gdal PATHS /usr/lib /usr/local/lib)
-    ENDIF(CYGWIN)
-
-    IF (NOT GDAL_INCLUDE_DIR OR NOT GDAL_LIBRARY OR NOT GDAL_CONFIG)
-      # didn't find OS X framework, and was not set by user
-      SET(GDAL_CONFIG_PREFER_PATH "$ENV{GDAL_HOME}/bin" CACHE STRING "preferred path to GDAL (gdal-config)")
-      SET(GDAL_CONFIG_PREFER_FWTOOLS_PATH "$ENV{FWTOOLS_HOME}/bin_safe" CACHE STRING "preferred path to GDAL (gdal-config) from FWTools")
-      FIND_PROGRAM(GDAL_CONFIG gdal-config
-          ${GDAL_CONFIG_PREFER_PATH}
-          ${GDAL_CONFIG_PREFER_FWTOOLS_PATH}
-          /usr/local/bin/
-          /usr/bin/
-          )
-      # MESSAGE("DBG GDAL_CONFIG ${GDAL_CONFIG}")
-    
-      IF (GDAL_CONFIG) 
-
-        ## extract gdal version 
-        EXEC_PROGRAM(${GDAL_CONFIG}
-            ARGS --version
-            OUTPUT_VARIABLE GDAL_VERSION )
-        STRING(REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+)" "\\1" GDAL_VERSION_MAJOR "${GDAL_VERSION}")
-        STRING(REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+)" "\\2" GDAL_VERSION_MINOR "${GDAL_VERSION}")
-  
-        # MESSAGE("DBG GDAL_VERSION ${GDAL_VERSION}")
-        # MESSAGE("DBG GDAL_VERSION_MAJOR ${GDAL_VERSION_MAJOR}")
-        # MESSAGE("DBG GDAL_VERSION_MINOR ${GDAL_VERSION_MINOR}")
-  
-        # check for gdal version
-        # version 1.2.5 is known NOT to be supported (missing CPL_STDCALL macro)
-        # According to INSTALL, 1.4.0+ is required
-        IF (GDAL_VERSION_MAJOR LESS 1 OR (GDAL_VERSION_MAJOR EQUAL 1 AND GDAL_VERSION_MINOR LESS 4))
-          MESSAGE (FATAL_ERROR "GDAL version is too old (${GDAL_VERSION}). Use 1.4.0 or higher.")
-        ENDIF (GDAL_VERSION_MAJOR LESS 1 OR (GDAL_VERSION_MAJOR EQUAL 1 AND GDAL_VERSION_MINOR LESS 4))
-
-        # set INCLUDE_DIR to prefix+include
-        EXEC_PROGRAM(${GDAL_CONFIG}
-            ARGS --prefix
-            OUTPUT_VARIABLE GDAL_PREFIX)
-        #SET(GDAL_INCLUDE_DIR ${GDAL_PREFIX}/include CACHE STRING INTERNAL)
-        FIND_PATH(GDAL_INCLUDE_DIR 
-            gdal.h 
-            ${GDAL_PREFIX}/include/gdal
-            ${GDAL_PREFIX}/include
-            /usr/local/include 
-            /usr/include 
-            )
-
-        ## extract link dirs for rpath  
-        EXEC_PROGRAM(${GDAL_CONFIG}
-            ARGS --libs
-            OUTPUT_VARIABLE GDAL_CONFIG_LIBS )
-
-        ## split off the link dirs (for rpath)
-        ## use regular expression to match wildcard equivalent "-L*<endchar>"
-        ## with <endchar> is a space or a semicolon
-        STRING(REGEX MATCHALL "[-][L]([^ ;])+" 
-            GDAL_LINK_DIRECTORIES_WITH_PREFIX 
-            "${GDAL_CONFIG_LIBS}" )
-        #      MESSAGE("DBG  GDAL_LINK_DIRECTORIES_WITH_PREFIX=${GDAL_LINK_DIRECTORIES_WITH_PREFIX}")
-
-        ## remove prefix -L because we need the pure directory for LINK_DIRECTORIES
-      
-        IF (GDAL_LINK_DIRECTORIES_WITH_PREFIX)
-          STRING(REGEX REPLACE "[-][L]" "" GDAL_LINK_DIRECTORIES ${GDAL_LINK_DIRECTORIES_WITH_PREFIX} )
-        ENDIF (GDAL_LINK_DIRECTORIES_WITH_PREFIX)
-
-        ## split off the name
-        ## use regular expression to match wildcard equivalent "-l*<endchar>"
-        ## with <endchar> is a space or a semicolon
-        STRING(REGEX MATCHALL "[-][l]([^ ;])+" 
-            GDAL_LIB_NAME_WITH_PREFIX 
-            "${GDAL_CONFIG_LIBS}" )
-        #      MESSAGE("DBG  GDAL_LIB_NAME_WITH_PREFIX=${GDAL_LIB_NAME_WITH_PREFIX}")
-
-
-        ## remove prefix -l because we need the pure name
-      
-        IF (GDAL_LIB_NAME_WITH_PREFIX)
-          STRING(REGEX REPLACE "[-][l]" "" GDAL_LIB_NAME ${GDAL_LIB_NAME_WITH_PREFIX} )
-        ENDIF (GDAL_LIB_NAME_WITH_PREFIX)
-
-        IF (APPLE)
-          IF (NOT GDAL_LIBRARY)
-            # work around empty GDAL_LIBRARY left by framework check
-            # while still preserving user setting if given
-            # ***FIXME*** need to improve framework check so below not needed
-            SET(GDAL_LIBRARY ${GDAL_LINK_DIRECTORIES}/lib${GDAL_LIB_NAME}.dylib CACHE STRING INTERNAL FORCE)
-          ENDIF (NOT GDAL_LIBRARY)
-        ELSE (APPLE)
-          SET(GDAL_LIBRARY ${GDAL_LINK_DIRECTORIES}/lib${GDAL_LIB_NAME}.so CACHE STRING INTERNAL)
-        ENDIF (APPLE)
-      
-      ELSE(GDAL_CONFIG)
-        MESSAGE("FindGDAL.cmake: gdal-config not found. Please set it manually. GDAL_CONFIG=${GDAL_CONFIG}")
-      ENDIF(GDAL_CONFIG)
-    ENDIF (NOT GDAL_INCLUDE_DIR OR NOT GDAL_LIBRARY OR NOT GDAL_CONFIG)
-  ENDIF(UNIX)
-ENDIF(WIN32)
-
-
-IF (GDAL_INCLUDE_DIR AND GDAL_LIBRARY)
-   SET(GDAL_FOUND TRUE)
-ENDIF (GDAL_INCLUDE_DIR AND GDAL_LIBRARY)
-
-IF (GDAL_FOUND)
-
-   IF (NOT GDAL_FIND_QUIETLY)
-      FILE(READ ${GDAL_INCLUDE_DIR}/gdal_version.h gdal_version)
-      STRING(REGEX REPLACE "^.*GDAL_RELEASE_NAME +\"([^\"]+)\".*$" "\\1" GDAL_RELEASE_NAME "${gdal_version}")
-
-      MESSAGE(STATUS "Found GDAL: ${GDAL_LIBRARY} (${GDAL_RELEASE_NAME})")
-   ENDIF (NOT GDAL_FIND_QUIETLY)
-
-ELSE (GDAL_FOUND)
-
-   MESSAGE(GDAL_INCLUDE_DIR=${GDAL_INCLUDE_DIR})
-   MESSAGE(GDAL_LIBRARY=${GDAL_LIBRARY})
-   MESSAGE(FATAL_ERROR "Could not find GDAL")
-
-ENDIF (GDAL_FOUND)

--- a/cmake/FindGDAL.cmake
+++ b/cmake/FindGDAL.cmake
@@ -1,93 +1,191 @@
-# Locate gdal
-# This module defines
-# GDAL_LIBRARY
-# GDAL_FOUND, if false, do not try to link to gdal 
-# GDAL_INCLUDE_DIR, where to find the headers
+# Find GDAL
+# ~~~~~~~~~
+# Copyright (c) 2007, Magnus Homann <magnus at homann dot se>
+# Redistribution and use is allowed according to the terms of the BSD license.
+# For details see the accompanying COPYING-CMAKE-SCRIPTS file.
 #
-# $GDALDIR is an environment variable that would
-# correspond to the ./configure --prefix=$GDAL_DIR
-# used in building gdal.
 #
-# Created by Eric Wing. I'm not a gdal user, but OpenSceneGraph uses it 
-# for osgTerrain so I whipped this module together for completeness.
-# I actually don't know the conventions or where files are typically
-# placed in distros.
-# Any real gdal users are encouraged to correct this (but please don't
-# break the OS X framework stuff when doing so which is what usually seems 
-# to happen).
-
-# This makes the presumption that you are include gdal.h like
-# #include "gdal.h"
-
-FIND_PATH(GDAL_INCLUDE_DIR gdal.h
-  PATHS
-  $ENV{GDAL_DIR}
-  NO_DEFAULT_PATH
-    PATH_SUFFIXES include
-)
-
-FIND_PATH(GDAL_INCLUDE_DIR gdal.h
-    PATHS ${CMAKE_PREFIX_PATH} # Unofficial: We are proposing this.
-    NO_DEFAULT_PATH
-    PATH_SUFFIXES include
-)
-
-FIND_PATH(GDAL_INCLUDE_DIR gdal.h
-  PATHS
-  ~/Library/Frameworks/gdal.framework/Headers
-  /Library/Frameworks/gdal.framework/Headers
-  /usr/local/include/gdal
-  /usr/local/include/GDAL
-  /usr/local/include
-  /usr/include/gdal
-  /usr/include/GDAL
-  /usr/include
-  /sw/include/gdal 
-  /sw/include/GDAL 
-  /sw/include # Fink
-  /opt/local/include/gdal
-  /opt/local/include/GDAL
-  /opt/local/include # DarwinPorts
-  /opt/csw/include/gdal
-  /opt/csw/include/GDAL
-  /opt/csw/include # Blastwave
-  /opt/include/gdal
-  /opt/include/GDAL
-  /opt/include
-)
-
-FIND_LIBRARY(GDAL_LIBRARY 
-  NAMES gdal gdal_i gdal1.8.1 gdal1.7.0 gdal1.6.0 gdal1.5.0 gdal1.4.0 GDAL
-  PATHS
-  $ENV{GDAL_DIR}
-  NO_DEFAULT_PATH
-  PATH_SUFFIXES lib64 lib
-)
-FIND_LIBRARY(GDAL_LIBRARY 
-  NAMES gdal gdal_i gdal1.8.1 gdal1.7.0 gdal1.6.0 gdal1.5.0 gdal1.4.0  GDAL
-  PATHS ${CMAKE_PREFIX_PATH} # Unofficial: We are proposing this.
-    NO_DEFAULT_PATH
-    PATH_SUFFIXES lib64 lib
-)
-FIND_LIBRARY(GDAL_LIBRARY 
-  NAMES gdal gdal_i gdal1.8.1 gdal1.7.0 gdal1.6.0 gdal1.5.0 gdal1.4.0 GDAL
-  PATHS
-    ~/Library/Frameworks
-    /Library/Frameworks
-    /usr/local
-    /usr
-    /sw
-    /opt/local
-    /opt/csw
-    /opt
-    /usr/freeware
-    [HKEY_LOCAL_MACHINE\\SYSTEM\\CurrentControlSet\\Control\\Session\ Manager\\Environment;GDAL_ROOT]/lib
-  PATH_SUFFIXES lib64 lib
-)
-
-SET(GDAL_FOUND "NO")
-IF(GDAL_LIBRARY AND GDAL_INCLUDE_DIR)
-  SET(GDAL_FOUND "YES")
-ENDIF(GDAL_LIBRARY AND GDAL_INCLUDE_DIR)
+# Once run this will define: 
+# 
+# GDAL_FOUND       = system has GDAL lib
+#
+# GDAL_LIBRARY     = full path to the library
+#
+# GDAL_INCLUDE_DIR      = where to find headers 
 
 
+INCLUDE (@CMAKE_SOURCE_DIR@/cmake/MacPlistMacros.cmake)
+
+IF(WIN32)
+
+  IF (MINGW)
+    FIND_PATH(GDAL_INCLUDE_DIR gdal.h /usr/local/include /usr/include c:/msys/local/include)
+    FIND_LIBRARY(GDAL_LIBRARY NAMES gdal PATHS /usr/local/lib /usr/lib c:/msys/local/lib)
+  ENDIF (MINGW)
+
+  IF (MSVC)
+    FIND_PATH(GDAL_INCLUDE_DIR gdal.h "$ENV{LIB_DIR}/include/gdal" $ENV{INCLUDE})
+    FIND_LIBRARY(GDAL_LIBRARY NAMES gdal gdal_i PATHS 
+	    "$ENV{LIB_DIR}/lib" $ENV{LIB} /usr/lib c:/msys/local/lib)
+    IF (GDAL_LIBRARY)
+      SET (
+         GDAL_LIBRARY;odbc32;odbccp32 
+         CACHE STRING INTERNAL)
+    ENDIF (GDAL_LIBRARY)
+  ENDIF (MSVC)
+  
+  
+ELSE(WIN32)
+  IF(UNIX) 
+
+    # try to use framework on mac
+    # want clean framework path, not unix compatibility path
+    IF (APPLE)
+      IF (CMAKE_FIND_FRAMEWORK MATCHES "FIRST"
+          OR CMAKE_FRAMEWORK_PATH MATCHES "ONLY"
+          OR NOT CMAKE_FIND_FRAMEWORK)
+        SET (CMAKE_FIND_FRAMEWORK_save ${CMAKE_FIND_FRAMEWORK} CACHE STRING "" FORCE)
+        SET (CMAKE_FIND_FRAMEWORK "ONLY" CACHE STRING "" FORCE)
+        FIND_LIBRARY(GDAL_LIBRARY GDAL)
+        IF (GDAL_LIBRARY)
+          # they're all the same in a framework
+          SET (GDAL_INCLUDE_DIR ${GDAL_LIBRARY}/Headers CACHE PATH "Path to a file.")
+          # set GDAL_CONFIG to make later test happy, not used here, may not exist
+          SET (GDAL_CONFIG ${GDAL_LIBRARY}/unix/bin/gdal-config CACHE FILEPATH "Path to a program.")
+          # version in info.plist
+          GET_VERSION_PLIST (${GDAL_LIBRARY}/Resources/Info.plist GDAL_VERSION)
+          IF (NOT GDAL_VERSION)
+            MESSAGE (FATAL_ERROR "Could not determine GDAL version from framework.")
+          ENDIF (NOT GDAL_VERSION)
+          STRING(REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+)" "\\1" GDAL_VERSION_MAJOR "${GDAL_VERSION}")
+          STRING(REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+)" "\\2" GDAL_VERSION_MINOR "${GDAL_VERSION}")
+          IF (GDAL_VERSION_MAJOR LESS 1 OR (GDAL_VERSION EQUAL 1 AND GDAL_VERSION_MINOR LESS 4))
+            MESSAGE (FATAL_ERROR "GDAL version is too old (${GDAL_VERSION}). Use 1.4.0 or higher.")
+          ENDIF (GDAL_VERSION_MAJOR LESS 1 OR (GDAL_VERSION EQUAL 1 AND GDAL_VERSION_MINOR LESS 4))
+        ENDIF (GDAL_LIBRARY)
+        SET (CMAKE_FIND_FRAMEWORK ${CMAKE_FIND_FRAMEWORK_save} CACHE STRING "" FORCE)
+      ENDIF ()
+    ENDIF (APPLE)
+
+    IF(CYGWIN)
+      FIND_LIBRARY(GDAL_LIBRARY NAMES gdal PATHS /usr/lib /usr/local/lib)
+    ENDIF(CYGWIN)
+
+    IF (NOT GDAL_INCLUDE_DIR OR NOT GDAL_LIBRARY OR NOT GDAL_CONFIG)
+      # didn't find OS X framework, and was not set by user
+      SET(GDAL_CONFIG_PREFER_PATH "$ENV{GDAL_HOME}/bin" CACHE STRING "preferred path to GDAL (gdal-config)")
+      SET(GDAL_CONFIG_PREFER_FWTOOLS_PATH "$ENV{FWTOOLS_HOME}/bin_safe" CACHE STRING "preferred path to GDAL (gdal-config) from FWTools")
+      FIND_PROGRAM(GDAL_CONFIG gdal-config
+          ${GDAL_CONFIG_PREFER_PATH}
+          ${GDAL_CONFIG_PREFER_FWTOOLS_PATH}
+          /usr/local/bin/
+          /usr/bin/
+          )
+      # MESSAGE("DBG GDAL_CONFIG ${GDAL_CONFIG}")
+    
+      IF (GDAL_CONFIG) 
+
+        ## extract gdal version 
+        EXEC_PROGRAM(${GDAL_CONFIG}
+            ARGS --version
+            OUTPUT_VARIABLE GDAL_VERSION )
+        STRING(REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+)" "\\1" GDAL_VERSION_MAJOR "${GDAL_VERSION}")
+        STRING(REGEX REPLACE "([0-9]+)\\.([0-9]+)\\.([0-9]+)" "\\2" GDAL_VERSION_MINOR "${GDAL_VERSION}")
+  
+        # MESSAGE("DBG GDAL_VERSION ${GDAL_VERSION}")
+        # MESSAGE("DBG GDAL_VERSION_MAJOR ${GDAL_VERSION_MAJOR}")
+        # MESSAGE("DBG GDAL_VERSION_MINOR ${GDAL_VERSION_MINOR}")
+  
+        # check for gdal version
+        # version 1.2.5 is known NOT to be supported (missing CPL_STDCALL macro)
+        # According to INSTALL, 1.4.0+ is required
+        IF (GDAL_VERSION_MAJOR LESS 1 OR (GDAL_VERSION_MAJOR EQUAL 1 AND GDAL_VERSION_MINOR LESS 4))
+          MESSAGE (FATAL_ERROR "GDAL version is too old (${GDAL_VERSION}). Use 1.4.0 or higher.")
+        ENDIF (GDAL_VERSION_MAJOR LESS 1 OR (GDAL_VERSION_MAJOR EQUAL 1 AND GDAL_VERSION_MINOR LESS 4))
+
+        # set INCLUDE_DIR to prefix+include
+        EXEC_PROGRAM(${GDAL_CONFIG}
+            ARGS --prefix
+            OUTPUT_VARIABLE GDAL_PREFIX)
+        #SET(GDAL_INCLUDE_DIR ${GDAL_PREFIX}/include CACHE STRING INTERNAL)
+        FIND_PATH(GDAL_INCLUDE_DIR 
+            gdal.h 
+            ${GDAL_PREFIX}/include/gdal
+            ${GDAL_PREFIX}/include
+            /usr/local/include 
+            /usr/include 
+            )
+
+        ## extract link dirs for rpath  
+        EXEC_PROGRAM(${GDAL_CONFIG}
+            ARGS --libs
+            OUTPUT_VARIABLE GDAL_CONFIG_LIBS )
+
+        ## split off the link dirs (for rpath)
+        ## use regular expression to match wildcard equivalent "-L*<endchar>"
+        ## with <endchar> is a space or a semicolon
+        STRING(REGEX MATCHALL "[-][L]([^ ;])+" 
+            GDAL_LINK_DIRECTORIES_WITH_PREFIX 
+            "${GDAL_CONFIG_LIBS}" )
+        #      MESSAGE("DBG  GDAL_LINK_DIRECTORIES_WITH_PREFIX=${GDAL_LINK_DIRECTORIES_WITH_PREFIX}")
+
+        ## remove prefix -L because we need the pure directory for LINK_DIRECTORIES
+      
+        IF (GDAL_LINK_DIRECTORIES_WITH_PREFIX)
+          STRING(REGEX REPLACE "[-][L]" "" GDAL_LINK_DIRECTORIES ${GDAL_LINK_DIRECTORIES_WITH_PREFIX} )
+        ENDIF (GDAL_LINK_DIRECTORIES_WITH_PREFIX)
+
+        ## split off the name
+        ## use regular expression to match wildcard equivalent "-l*<endchar>"
+        ## with <endchar> is a space or a semicolon
+        STRING(REGEX MATCHALL "[-][l]([^ ;])+" 
+            GDAL_LIB_NAME_WITH_PREFIX 
+            "${GDAL_CONFIG_LIBS}" )
+        #      MESSAGE("DBG  GDAL_LIB_NAME_WITH_PREFIX=${GDAL_LIB_NAME_WITH_PREFIX}")
+
+
+        ## remove prefix -l because we need the pure name
+      
+        IF (GDAL_LIB_NAME_WITH_PREFIX)
+          STRING(REGEX REPLACE "[-][l]" "" GDAL_LIB_NAME ${GDAL_LIB_NAME_WITH_PREFIX} )
+        ENDIF (GDAL_LIB_NAME_WITH_PREFIX)
+
+        IF (APPLE)
+          IF (NOT GDAL_LIBRARY)
+            # work around empty GDAL_LIBRARY left by framework check
+            # while still preserving user setting if given
+            # ***FIXME*** need to improve framework check so below not needed
+            SET(GDAL_LIBRARY ${GDAL_LINK_DIRECTORIES}/lib${GDAL_LIB_NAME}.dylib CACHE STRING INTERNAL FORCE)
+          ENDIF (NOT GDAL_LIBRARY)
+        ELSE (APPLE)
+          SET(GDAL_LIBRARY ${GDAL_LINK_DIRECTORIES}/lib${GDAL_LIB_NAME}.so CACHE STRING INTERNAL)
+        ENDIF (APPLE)
+      
+      ELSE(GDAL_CONFIG)
+        MESSAGE("FindGDAL.cmake: gdal-config not found. Please set it manually. GDAL_CONFIG=${GDAL_CONFIG}")
+      ENDIF(GDAL_CONFIG)
+    ENDIF (NOT GDAL_INCLUDE_DIR OR NOT GDAL_LIBRARY OR NOT GDAL_CONFIG)
+  ENDIF(UNIX)
+ENDIF(WIN32)
+
+
+IF (GDAL_INCLUDE_DIR AND GDAL_LIBRARY)
+   SET(GDAL_FOUND TRUE)
+ENDIF (GDAL_INCLUDE_DIR AND GDAL_LIBRARY)
+
+IF (GDAL_FOUND)
+
+   IF (NOT GDAL_FIND_QUIETLY)
+      FILE(READ ${GDAL_INCLUDE_DIR}/gdal_version.h gdal_version)
+      STRING(REGEX REPLACE "^.*GDAL_RELEASE_NAME +\"([^\"]+)\".*$" "\\1" GDAL_RELEASE_NAME "${gdal_version}")
+
+      MESSAGE(STATUS "Found GDAL: ${GDAL_LIBRARY} (${GDAL_RELEASE_NAME})")
+   ENDIF (NOT GDAL_FIND_QUIETLY)
+
+ELSE (GDAL_FOUND)
+
+   MESSAGE(GDAL_INCLUDE_DIR=${GDAL_INCLUDE_DIR})
+   MESSAGE(GDAL_LIBRARY=${GDAL_LIBRARY})
+   MESSAGE(FATAL_ERROR "Could not find GDAL")
+
+ENDIF (GDAL_FOUND)

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -486,6 +486,12 @@ SET(QGIS_CORE_HDRS
   raster/qgsrastershader.h
   raster/qgsrastershaderfunction.h
   raster/qgsrasterviewport.h
+  raster/qgsbrightnesscontrastfilter.h
+  raster/qgshuesaturationfilter.h
+  raster/qgsrasternuller.h
+  raster/qgsrasterrenderer.h
+
+  
 
   symbology-ng/qgscategorizedsymbolrendererv2.h
   symbology-ng/qgscolorbrewerpalette.h

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -456,7 +456,6 @@ SET(QGIS_CORE_HDRS
   diagram/qgstextdiagram.h
   diagram/qgshistogramdiagram.h
 
-
   composer/qgslegendmodel.h
   composer/qgscomposerlegenditem.h
 
@@ -490,8 +489,6 @@ SET(QGIS_CORE_HDRS
   raster/qgshuesaturationfilter.h
   raster/qgsrasternuller.h
   raster/qgsrasterrenderer.h
-
-  
 
   symbology-ng/qgscategorizedsymbolrendererv2.h
   symbology-ng/qgscolorbrewerpalette.h

--- a/src/core/qgsmaprenderer.cpp
+++ b/src/core/qgsmaprenderer.cpp
@@ -681,7 +681,7 @@ void QgsMapRenderer::render( QPainter* painter, double* forceWidthScale )
           }
 
           mRenderContext.setCoordinateTransform( ct );
-
+          delete ct;
           ml->drawLabels( mRenderContext );
           if ( split )
           {
@@ -721,7 +721,6 @@ void QgsMapRenderer::render( QPainter* painter, double* forceWidthScale )
   }
 
   QgsDebugMsg( "Rendering completed in (seconds): " + QString( "%1" ).arg( renderTime.elapsed() / 1000.0 ) );
-
   mDrawing = false;
 }
 

--- a/src/core/qgsrendercontext.cpp
+++ b/src/core/qgsrendercontext.cpp
@@ -35,6 +35,7 @@ QgsRenderContext::QgsRenderContext()
 
 QgsRenderContext::~QgsRenderContext()
 {
+    delete mCoordTransform;
 }
 
 void QgsRenderContext::setCoordinateTransform( const QgsCoordinateTransform* t )

--- a/src/core/raster/qgsmultibandcolorrenderer.cpp
+++ b/src/core/raster/qgsmultibandcolorrenderer.cpp
@@ -211,10 +211,7 @@ QgsRasterBlock* QgsMultiBandColorRenderer::block( int bandNo, QgsRectangle  cons
 
   if ( !outputBlock->reset( QGis::ARGB32_Premultiplied, width, height ) )
   {
-    for ( int i = 0; i < bandBlocks.size(); i++ )
-    {
-      delete bandBlocks.value( i );
-    }
+    qDeleteAll(bandBlocks);  
     return outputBlock;
   }
 
@@ -309,11 +306,7 @@ QgsRasterBlock* QgsMultiBandColorRenderer::block( int bandNo, QgsRectangle  cons
     }
   }
 
-  for ( int i = 0; i < bandBlocks.size(); i++ )
-  {
-    delete bandBlocks.value( i );
-  }
-
+  qDeleteAll(bandBlocks);
   return outputBlock;
 }
 

--- a/src/core/raster/qgsrasterresamplefilter.cpp
+++ b/src/core/raster/qgsrasterresamplefilter.cpp
@@ -167,6 +167,7 @@ QgsRasterBlock * QgsRasterResampleFilter::block( int bandNo, QgsRectangle  const
   if ((( oversampling < 1.0 || qgsDoubleNear( oversampling, 1.0 ) ) && !mZoomedInResampler ) || ( oversampling > 1.0 && !mZoomedOutResampler ) )
   {
     QgsDebugMsg( "No oversampling." );
+    delete outputBlock;
     return mInput->block( bandNumber, extent, width, height );
   }
 

--- a/src/core/symbology-ng/qgscategorizedsymbolrendererv2.cpp
+++ b/src/core/symbology-ng/qgscategorizedsymbolrendererv2.cpp
@@ -379,6 +379,7 @@ void QgsCategorizedSymbolRendererV2::startRender( QgsRenderContext& context, con
                                  ( mSizeScaleFieldIdx != -1 ? QgsSymbolV2::DataDefinedSizeScale : 0 ) );
       tempSymbol->startRender( context, vlayer );
       mTempSymbols[ it->value().toString()] = tempSymbol;
+      delete tempSymbol;
     }
   }
 
@@ -395,8 +396,9 @@ void QgsCategorizedSymbolRendererV2::stopRender( QgsRenderContext& context )
   for ( ; it2 != mTempSymbols.end(); ++it2 )
   {
     it2.value()->stopRender( context );
-    delete it2.value();
   }
+  
+  qDeleteAll(mTempSymbols);
   mTempSymbols.clear();
 }
 

--- a/src/core/symbology-ng/qgssymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgssymbollayerv2.cpp
@@ -68,11 +68,7 @@ void QgsSymbolLayerV2::removeDataDefinedProperty( const QString& property )
 
 void QgsSymbolLayerV2::removeDataDefinedProperties()
 {
-  QMap< QString, QgsExpression* >::iterator it = mDataDefinedProperties.begin();
-  for ( ; it != mDataDefinedProperties.constEnd(); ++it )
-  {
-    delete( it.value() );
-  }
+  qDeleteAll(mDataDefinedProperties);
   mDataDefinedProperties.clear();
 }
 

--- a/src/core/symbology-ng/qgssymbollayerv2utils.cpp
+++ b/src/core/symbology-ng/qgssymbollayerv2utils.cpp
@@ -2438,7 +2438,7 @@ QgsSymbolV2Map QgsSymbolLayerV2Utils::loadSymbols( QDomElement& element )
     if ( parts.count() < 3 )
     {
       QgsDebugMsg( "found subsymbol with invalid name: " + it.key() );
-      delete it.value(); // we must delete it
+      delete *it; // we must delete it
       continue; // some invalid syntax
     }
     QString symname = parts[1];
@@ -2447,7 +2447,7 @@ QgsSymbolV2Map QgsSymbolLayerV2Utils::loadSymbols( QDomElement& element )
     if ( !symbols.contains( symname ) )
     {
       QgsDebugMsg( "subsymbol references invalid symbol: " + symname );
-      delete it.value(); // we must delete it
+      delete *it; // we must delete it
       continue;
     }
 
@@ -2455,7 +2455,7 @@ QgsSymbolV2Map QgsSymbolLayerV2Utils::loadSymbols( QDomElement& element )
     if ( symlayer < 0 || symlayer >= sym->symbolLayerCount() )
     {
       QgsDebugMsg( "subsymbol references invalid symbol layer: " + QString::number( symlayer ) );
-      delete it.value(); // we must delete it
+      delete *it; // we must delete it
       continue;
     }
 
@@ -2492,10 +2492,7 @@ QDomElement QgsSymbolLayerV2Utils::saveSymbols( QgsSymbolV2Map& symbols, QString
 
 void QgsSymbolLayerV2Utils::clearSymbolMap( QgsSymbolV2Map& symbols )
 {
-  foreach ( QString name, symbols.keys() )
-  {
-    delete symbols.value( name );
-  }
+  qDeleteAll(symbols);
   symbols.clear();
 }
 
@@ -2577,7 +2574,7 @@ double QgsSymbolLayerV2Utils::pixelSizeScaleFactor( const QgsRenderContext& c, Q
   else //QgsSymbol::MapUnit
   {
     double mup = c.mapToPixel().mapUnitsPerPixel();
-    if ( mup > 0 )
+    if ( mup >= 1 )
     {
       return c.rasterScaleFactor() / c.mapToPixel().mapUnitsPerPixel();
     }

--- a/src/core/symbology-ng/qgssymbollayerv2utils.cpp
+++ b/src/core/symbology-ng/qgssymbollayerv2utils.cpp
@@ -2557,7 +2557,7 @@ double QgsSymbolLayerV2Utils::lineWidthScaleFactor( const QgsRenderContext& c, Q
   else //QgsSymbol::MapUnit
   {
     double mup = c.mapToPixel().mapUnitsPerPixel();
-    if ( mup > 0 )
+    if ( mup >= 1 )
     {
       return 1.0 / mup;
     }


### PR DESCRIPTION
Please, dismiss the changes to FindGDAL.cmake.

Two leaks fixed: 
1. Missing delete in qgsrasterresamplefilter.cpp
2. Using qDeleteAll() instead of a leaky method to destroy pointers in multibandcolorrenderer.cpp
