### PR TITLE
Copy On Write for EditBuffer in QgsVectorLayerFeatureIterator

### DIFF
--- a/python/core/qgsclipper.sip
+++ b/python/core/qgsclipper.sip
@@ -48,5 +48,5 @@ class QgsClipper
       @param wkb pointer to the start of the line wkb
       @param clipExtent clipping bounds
       @param line out: clipped line coordinates*/
-    static unsigned char* clippedLineWKB( unsigned char* wkb, const QgsRectangle& clipExtent, QPolygonF& line );
+    static const unsigned char* clippedLineWKB( const unsigned char* wkb, const QgsRectangle& clipExtent, QPolygonF& line );
 };

--- a/python/core/symbology-ng/qgsrendererv2.sip
+++ b/python/core/symbology-ng/qgsrendererv2.sip
@@ -164,7 +164,7 @@ class QgsFeatureRendererV2
     //! render editing vertex marker for a polygon
     void renderVertexMarkerPolygon( QPolygonF& pts, QList<QPolygonF>* rings, QgsRenderContext& context );
 
-    static unsigned char* _getPoint( QPointF& pt, QgsRenderContext& context, unsigned char* wkb );
-    static unsigned char* _getLineString( QPolygonF& pts, QgsRenderContext& context, unsigned char* wkb );
-    static unsigned char* _getPolygon( QPolygonF& pts, QList<QPolygonF>& holes, QgsRenderContext& context, unsigned char* wkb );
+    static const unsigned char* _getPoint( QPointF& pt, QgsRenderContext& context, const unsigned char* wkb );
+    static const unsigned char* _getLineString( QPolygonF& pts, QgsRenderContext& context, const unsigned char* wkb );
+    static const unsigned char* _getPolygon( QPolygonF& pts, QList<QPolygonF>& holes, QgsRenderContext& context, const unsigned char* wkb );
 };

--- a/src/analysis/interpolation/qgsinterpolator.cpp
+++ b/src/analysis/interpolation/qgsinterpolator.cpp
@@ -108,7 +108,7 @@ int QgsInterpolator::addVerticesToCache( QgsGeometry* geom, bool zCoord, double 
   }
 
   bool hasZValue = false;
-  unsigned char* currentWkbPtr = geom->asWkb();
+  const unsigned char* currentWkbPtr = geom->asWkb();
   vertexData theVertex; //the current vertex
 
   QGis::WkbType wkbType = geom->wkbType();

--- a/src/analysis/interpolation/qgstininterpolator.cpp
+++ b/src/analysis/interpolation/qgstininterpolator.cpp
@@ -200,7 +200,7 @@ int QgsTINInterpolator::insertData( QgsFeature* f, bool zCoord, int attr, InputT
   //parse WKB. It is ugly, but we cannot use the methods with QgsPoint because they don't contain z-values for 25D types
   bool hasZValue = false;
   double x, y, z;
-  unsigned char* currentWkbPtr = g->asWkb();
+  const unsigned char* currentWkbPtr = g->asWkb();
   //maybe a structure or break line
   Line3D* line = 0;
 

--- a/src/analysis/vector/qgsgeometryanalyzer.cpp
+++ b/src/analysis/vector/qgsgeometryanalyzer.cpp
@@ -1186,9 +1186,9 @@ QgsGeometry* QgsGeometryAnalyzer::locateBetweenMeasures( double fromMeasure, dou
   QgsMultiPolyline resultGeom;
 
   //need to go with WKB and z coordinate until QgsGeometry supports M values
-  unsigned char* lineWkb = lineGeom->asWkb();
+  const unsigned char* lineWkb = lineGeom->asWkb();
 
-  unsigned char* ptr = lineWkb + 1;
+  const unsigned char* ptr = lineWkb + 1;
   QGis::WkbType wkbType;
   memcpy( &wkbType, ptr, sizeof( wkbType ) );
   ptr += sizeof( wkbType );
@@ -1230,9 +1230,9 @@ QgsGeometry* QgsGeometryAnalyzer::locateAlongMeasure( double measure, QgsGeometr
   QgsMultiPoint resultGeom;
 
   //need to go with WKB and z coordinate until QgsGeometry supports M values
-  unsigned char* lineWkb = lineGeom->asWkb();
+  const unsigned char* lineWkb = lineGeom->asWkb();
 
-  unsigned char* ptr = lineWkb + 1;
+  const unsigned char* ptr = lineWkb + 1;
   QGis::WkbType wkbType;
   memcpy( &wkbType, ptr, sizeof( wkbType ) );
   ptr += sizeof( wkbType );
@@ -1264,7 +1264,7 @@ QgsGeometry* QgsGeometryAnalyzer::locateAlongMeasure( double measure, QgsGeometr
   return QgsGeometry::fromMultiPoint( resultGeom );
 }
 
-unsigned char* QgsGeometryAnalyzer::locateBetweenWkbString( unsigned char* ptr, QgsMultiPolyline& result, double fromMeasure, double toMeasure )
+const unsigned char* QgsGeometryAnalyzer::locateBetweenWkbString( const unsigned char* ptr, QgsMultiPolyline& result, double fromMeasure, double toMeasure )
 {
   int* nPoints = ( int* ) ptr;
   ptr += sizeof( int );
@@ -1316,7 +1316,7 @@ unsigned char* QgsGeometryAnalyzer::locateBetweenWkbString( unsigned char* ptr, 
   return ptr;
 }
 
-unsigned char* QgsGeometryAnalyzer::locateAlongWkbString( unsigned char* ptr, QgsMultiPoint& result, double measure )
+const unsigned char* QgsGeometryAnalyzer::locateAlongWkbString( const unsigned char* ptr, QgsMultiPoint& result, double measure )
 {
   int* nPoints = ( int* ) ptr;
   ptr += sizeof( int );

--- a/src/analysis/vector/qgsgeometryanalyzer.h
+++ b/src/analysis/vector/qgsgeometryanalyzer.h
@@ -152,8 +152,8 @@ class ANALYSIS_EXPORT QgsGeometryAnalyzer
         @param offset the offset value in layer unit. Negative values mean offset towards left, positive values offset to the right side*/
     void createOffsetGeometry( QgsGeometry* geom, QgsGeometry* lineGeom, double offset );
     QgsPoint createPointOffset( double x, double y, double dist, QgsGeometry* lineGeom ) const;
-    unsigned char* locateBetweenWkbString( unsigned char* ptr, QgsMultiPolyline& result, double fromMeasure, double toMeasure );
-    unsigned char* locateAlongWkbString( unsigned char* ptr, QgsMultiPoint& result, double measure );
+    const unsigned char* locateBetweenWkbString( const unsigned char* ptr, QgsMultiPolyline& result, double fromMeasure, double toMeasure );
+    const unsigned char* locateAlongWkbString( const unsigned char* ptr, QgsMultiPoint& result, double measure );
     static bool clipSegmentByRange( double x1, double y1, double m1, double x2, double y2, double m2, double range1, double range2, QgsPoint& pt1, QgsPoint& pt2, bool& secondPointClipped );
     static void locateAlongSegment( double x1, double y1, double m1, double x2, double y2, double m2, double measure, bool& pt1Ok, QgsPoint& pt1, bool& pt2Ok, QgsPoint& pt2 );
 };

--- a/src/analysis/vector/qgszonalstatistics.cpp
+++ b/src/analysis/vector/qgszonalstatistics.cpp
@@ -270,7 +270,7 @@ void QgsZonalStatistics::statisticsFromMiddlePointTest( void* band, QgsGeometry*
   count = 0;
   sum = 0;
 
-  GEOSGeometry* polyGeos = poly->asGeos();
+  const GEOSGeometry* polyGeos = poly->asGeos();
   if ( !polyGeos )
   {
     return;

--- a/src/app/qgsmaptooloffsetcurve.cpp
+++ b/src/app/qgsmaptooloffsetcurve.cpp
@@ -352,7 +352,7 @@ void QgsMapToolOffsetCurve::setOffsetForRubberBand( double offset, bool leftSide
   }
 
   QgsGeometry geomCopy( *mOriginalGeometry );
-  GEOSGeometry* geosGeom = geomCopy.asGeos();
+  const GEOSGeometry* geosGeom = geomCopy.asGeos();
   if ( geosGeom )
   {
     QSettings s;

--- a/src/core/pal/layer.cpp
+++ b/src/core/pal/layer.cpp
@@ -244,7 +244,7 @@ namespace pal
     }
 
     // Split MULTI GEOM and Collection in simple geometries
-    GEOSGeometry *the_geom = userGeom->getGeosGeometry();
+    const GEOSGeometry *the_geom = userGeom->getGeosGeometry();
 
     Feature* f = new Feature( this, geom_id, userGeom, label_x, label_y );
     if ( fixedPos )

--- a/src/core/pal/palgeometry.h
+++ b/src/core/pal/palgeometry.h
@@ -49,14 +49,14 @@ namespace pal
        *
        * @return GEOSGeometry * a pointer the geos geom
        */
-      virtual GEOSGeometry* getGeosGeometry() = 0;
+      virtual const GEOSGeometry* getGeosGeometry() = 0;
 
 
       /**
        * \brief Called by Pal when it doesn't need the coordinates anymore
        * @param the_geom is the geoms geom  from PalGeometry::getfeomGeometry()
        */
-      virtual void releaseGeosGeometry( GEOSGeometry *the_geom ) = 0;
+      virtual void releaseGeosGeometry( const GEOSGeometry *the_geom ) = 0;
 
 
       virtual ~PalGeometry() {}

--- a/src/core/pal/util.cpp
+++ b/src/core/pal/util.cpp
@@ -193,7 +193,7 @@ namespace pal
   }
 
 //LinkedList<const geos::geom::Geometry*> * unmulti (geos::geom::Geometry *the_geom){
-  LinkedList<const GEOSGeometry*> * unmulti( GEOSGeometry *the_geom )
+  LinkedList<const GEOSGeometry*> * unmulti( const GEOSGeometry *the_geom )
   {
 
     //LinkedList<const geos::geom::Geometry*> *queue = new  LinkedList<const geos::geom::Geometry*>(ptrGeomEq);

--- a/src/core/pal/util.h
+++ b/src/core/pal/util.h
@@ -51,7 +51,7 @@ namespace pal
   class Layer;
   class FeaturePart;
 
-  LinkedList<const GEOSGeometry*> * unmulti( GEOSGeometry *the_geom );
+  LinkedList<const GEOSGeometry*> * unmulti( const GEOSGeometry* the_geom );
 
   /**
    * \brief For usage in problem solving algorithm

--- a/src/core/qgsclipper.cpp
+++ b/src/core/qgsclipper.cpp
@@ -35,7 +35,7 @@ const double QgsClipper::MIN_Y = -16000;
 
 const double QgsClipper::SMALL_NUM = 1e-12;
 
-unsigned char* QgsClipper::clippedLineWKB( unsigned char* wkb, const QgsRectangle& clipExtent, QPolygonF& line )
+const unsigned char* QgsClipper::clippedLineWKB( const unsigned char* wkb, const QgsRectangle& clipExtent, QPolygonF& line )
 {
   wkb++; // jump over endian info
   unsigned int wkbType = *(( int* ) wkb );

--- a/src/core/qgsclipper.h
+++ b/src/core/qgsclipper.h
@@ -82,7 +82,7 @@ class CORE_EXPORT QgsClipper
       @param wkb pointer to the start of the line wkb
       @param clipExtent clipping bounds
       @param line out: clipped line coordinates*/
-    static unsigned char* clippedLineWKB( unsigned char* wkb, const QgsRectangle& clipExtent, QPolygonF& line );
+    static const unsigned char* clippedLineWKB( const unsigned char* wkb, const QgsRectangle& clipExtent, QPolygonF& line );
 
   private:
 

--- a/src/core/qgsdistancearea.cpp
+++ b/src/core/qgsdistancearea.cpp
@@ -257,11 +257,11 @@ double QgsDistanceArea::measure( QgsGeometry* geometry )
   if ( !geometry )
     return 0.0;
 
-  unsigned char* wkb = geometry->asWkb();
+  const unsigned char* wkb = geometry->asWkb();
   if ( !wkb )
     return 0.0;
 
-  unsigned char* ptr;
+  const unsigned char* ptr;
   unsigned int wkbType;
   double res, resTotal = 0;
   int count, i;
@@ -324,11 +324,11 @@ double QgsDistanceArea::measurePerimeter( QgsGeometry* geometry )
   if ( !geometry )
     return 0.0;
 
-  unsigned char* wkb = geometry->asWkb();
+  const unsigned char* wkb = geometry->asWkb();
   if ( !wkb )
     return 0.0;
 
-  unsigned char* ptr;
+  const unsigned char* ptr;
   unsigned int wkbType;
   double res, resTotal = 0;
   int count, i;
@@ -373,9 +373,9 @@ double QgsDistanceArea::measurePerimeter( QgsGeometry* geometry )
 }
 
 
-unsigned char* QgsDistanceArea::measureLine( unsigned char* feature, double* area, bool hasZptr )
+const unsigned char* QgsDistanceArea::measureLine( const unsigned char* feature, double* area, bool hasZptr )
 {
-  unsigned char *ptr = feature + 5;
+  const unsigned char *ptr = feature + 5;
   unsigned int nPoints = *(( int* )ptr );
   ptr = feature + 9;
 
@@ -481,7 +481,7 @@ double QgsDistanceArea::measureLine( const QgsPoint& p1, const QgsPoint& p2 )
 }
 
 
-unsigned char* QgsDistanceArea::measurePolygon( unsigned char* feature, double* area, double* perimeter, bool hasZptr )
+const unsigned char* QgsDistanceArea::measurePolygon( const unsigned char* feature, double* area, double* perimeter, bool hasZptr )
 {
   // get number of rings in the polygon
   unsigned int numRings = *(( int* )( feature + 1 + sizeof( int ) ) );
@@ -490,7 +490,7 @@ unsigned char* QgsDistanceArea::measurePolygon( unsigned char* feature, double* 
     return 0;
 
   // Set pointer to the first ring
-  unsigned char* ptr = feature + 1 + 2 * sizeof( int );
+  const unsigned char* ptr = feature + 1 + 2 * sizeof( int );
 
   QList<QgsPoint> points;
   QgsPoint pnt;

--- a/src/core/qgsdistancearea.h
+++ b/src/core/qgsdistancearea.h
@@ -105,9 +105,9 @@ class CORE_EXPORT QgsDistanceArea
 
   protected:
     //! measures line distance, line points are extracted from WKB
-    unsigned char* measureLine( unsigned char* feature, double* area, bool hasZptr = false );
+    const unsigned char* measureLine( const unsigned char* feature, double* area, bool hasZptr = false );
     //! measures polygon area and perimeter, vertices are extracted from WKB
-    unsigned char* measurePolygon( unsigned char* feature, double* area, double* perimeter, bool hasZptr = false );
+    const unsigned char* measurePolygon( const unsigned char* feature, double* area, double* perimeter, bool hasZptr = false );
 
     /**
       calculates distance from two points on ellipsoid

--- a/src/core/qgsgeometry.cpp
+++ b/src/core/qgsgeometry.cpp
@@ -605,7 +605,7 @@ void QgsGeometry::fromWkb( unsigned char * wkb, size_t length )
   mDirtyGeos  = true;
 }
 
-unsigned char * QgsGeometry::asWkb()
+unsigned char * QgsGeometry::asWkb() const
 {
   if ( mDirtyWkb )
   {
@@ -616,7 +616,7 @@ unsigned char * QgsGeometry::asWkb()
   return mGeometry;
 }
 
-size_t QgsGeometry::wkbSize()
+size_t QgsGeometry::wkbSize() const
 {
   if ( mDirtyWkb )
   {
@@ -626,7 +626,7 @@ size_t QgsGeometry::wkbSize()
   return mGeometrySize;
 }
 
-GEOSGeometry* QgsGeometry::asGeos()
+GEOSGeometry* QgsGeometry::asGeos() const
 {
   if ( mDirtyGeos )
   {
@@ -639,7 +639,7 @@ GEOSGeometry* QgsGeometry::asGeos()
 }
 
 
-QGis::WkbType QgsGeometry::wkbType()
+QGis::WkbType QgsGeometry::wkbType() const
 {
   unsigned char *geom = asWkb(); // ensure that wkb representation exists
   if ( geom && wkbSize() >= 5 )
@@ -3858,7 +3858,7 @@ QgsRectangle QgsGeometry::boundingBox()
   return QgsRectangle( xmin, ymin, xmax, ymax );
 }
 
-bool QgsGeometry::intersects( const QgsRectangle& r )
+bool QgsGeometry::intersects( const QgsRectangle& r ) const
 {
   QgsGeometry* g = fromRect( r );
   bool res = intersects( g );
@@ -3866,7 +3866,7 @@ bool QgsGeometry::intersects( const QgsRectangle& r )
   return res;
 }
 
-bool QgsGeometry::intersects( QgsGeometry* geometry )
+bool QgsGeometry::intersects( const QgsGeometry* geometry ) const
 {
   try // geos might throw exception on error
   {
@@ -3886,7 +3886,7 @@ bool QgsGeometry::intersects( QgsGeometry* geometry )
 }
 
 
-bool QgsGeometry::contains( QgsPoint* p )
+bool QgsGeometry::contains( const QgsPoint* p ) const
 {
   exportWkbToGeos();
 
@@ -3919,8 +3919,8 @@ bool QgsGeometry::contains( QgsPoint* p )
 
 bool QgsGeometry::geosRelOp(
   char( *op )( const GEOSGeometry*, const GEOSGeometry * ),
-  QgsGeometry *a,
-  QgsGeometry *b )
+  const QgsGeometry *a,
+  const QgsGeometry *b )
 {
   try // geos might throw exception on error
   {
@@ -3938,42 +3938,42 @@ bool QgsGeometry::geosRelOp(
   CATCH_GEOS( false )
 }
 
-bool QgsGeometry::contains( QgsGeometry* geometry )
+bool QgsGeometry::contains( const QgsGeometry* geometry ) const
 {
   return geosRelOp( GEOSContains, this, geometry );
 }
 
-bool QgsGeometry::disjoint( QgsGeometry* geometry )
+bool QgsGeometry::disjoint( const QgsGeometry* geometry ) const
 {
   return geosRelOp( GEOSDisjoint, this, geometry );
 }
 
-bool QgsGeometry::equals( QgsGeometry* geometry )
+bool QgsGeometry::equals( const QgsGeometry* geometry ) const
 {
   return geosRelOp( GEOSEquals, this, geometry );
 }
 
-bool QgsGeometry::touches( QgsGeometry* geometry )
+bool QgsGeometry::touches( const QgsGeometry* geometry ) const
 {
   return geosRelOp( GEOSTouches, this, geometry );
 }
 
-bool QgsGeometry::overlaps( QgsGeometry* geometry )
+bool QgsGeometry::overlaps( const QgsGeometry* geometry ) const
 {
   return geosRelOp( GEOSOverlaps, this, geometry );
 }
 
-bool QgsGeometry::within( QgsGeometry* geometry )
+bool QgsGeometry::within( const QgsGeometry* geometry ) const
 {
   return geosRelOp( GEOSWithin, this, geometry );
 }
 
-bool QgsGeometry::crosses( QgsGeometry* geometry )
+bool QgsGeometry::crosses( const QgsGeometry* geometry ) const
 {
   return geosRelOp( GEOSCrosses, this, geometry );
 }
 
-QString QgsGeometry::exportToWkt()
+QString QgsGeometry::exportToWkt() const
 {
   QgsDebugMsg( "entered." );
 
@@ -4253,7 +4253,7 @@ QString QgsGeometry::exportToWkt()
   }
 }
 
-QString QgsGeometry::exportToGeoJSON()
+QString QgsGeometry::exportToGeoJSON() const
 {
   QgsDebugMsg( "entered." );
 
@@ -4544,7 +4544,7 @@ QString QgsGeometry::exportToGeoJSON()
 }
 
 
-bool QgsGeometry::exportWkbToGeos()
+bool QgsGeometry::exportWkbToGeos() const
 {
   QgsDebugMsgLevel( "entered.", 3 );
 
@@ -4794,7 +4794,7 @@ bool QgsGeometry::exportWkbToGeos()
   return true;
 }
 
-bool QgsGeometry::exportGeosToWkb()
+bool QgsGeometry::exportGeosToWkb() const
 {
   //QgsDebugMsg("entered.");
   if ( !mDirtyWkb )
@@ -6170,7 +6170,7 @@ int QgsGeometry::mergeGeometriesMultiTypeSplit( QVector<GEOSGeometry*>& splitRes
   return 0;
 }
 
-QgsPoint QgsGeometry::asPoint( unsigned char*& ptr, bool hasZValue )
+QgsPoint QgsGeometry::asPoint( unsigned char*& ptr, bool hasZValue ) const
 {
   ptr += 5;
   double* x = ( double * )( ptr );
@@ -6184,7 +6184,7 @@ QgsPoint QgsGeometry::asPoint( unsigned char*& ptr, bool hasZValue )
 }
 
 
-QgsPolyline QgsGeometry::asPolyline( unsigned char*& ptr, bool hasZValue )
+QgsPolyline QgsGeometry::asPolyline( unsigned char*& ptr, bool hasZValue ) const
 {
   double x, y;
   ptr += 5;
@@ -6211,7 +6211,7 @@ QgsPolyline QgsGeometry::asPolyline( unsigned char*& ptr, bool hasZValue )
 }
 
 
-QgsPolygon QgsGeometry::asPolygon( unsigned char*& ptr, bool hasZValue )
+QgsPolygon QgsGeometry::asPolygon( unsigned char*& ptr, bool hasZValue ) const
 {
   double x, y;
 
@@ -6253,7 +6253,7 @@ QgsPolygon QgsGeometry::asPolygon( unsigned char*& ptr, bool hasZValue )
 }
 
 
-QgsPoint QgsGeometry::asPoint()
+QgsPoint QgsGeometry::asPoint() const
 {
   QGis::WkbType type = wkbType();
   if ( type != QGis::WKBPoint && type != QGis::WKBPoint25D )
@@ -6263,7 +6263,7 @@ QgsPoint QgsGeometry::asPoint()
   return asPoint( ptr, type == QGis::WKBPoint25D );
 }
 
-QgsPolyline QgsGeometry::asPolyline()
+QgsPolyline QgsGeometry::asPolyline() const
 {
   QGis::WkbType type = wkbType();
   if ( type != QGis::WKBLineString && type != QGis::WKBLineString25D )
@@ -6273,7 +6273,7 @@ QgsPolyline QgsGeometry::asPolyline()
   return asPolyline( ptr, type == QGis::WKBLineString25D );
 }
 
-QgsPolygon QgsGeometry::asPolygon()
+QgsPolygon QgsGeometry::asPolygon() const
 {
   QGis::WkbType type = wkbType();
   if ( type != QGis::WKBPolygon && type != QGis::WKBPolygon25D )
@@ -6283,7 +6283,7 @@ QgsPolygon QgsGeometry::asPolygon()
   return asPolygon( ptr, type == QGis::WKBPolygon25D );
 }
 
-QgsMultiPoint QgsGeometry::asMultiPoint()
+QgsMultiPoint QgsGeometry::asMultiPoint() const
 {
   QGis::WkbType type = wkbType();
   if ( type != QGis::WKBMultiPoint && type != QGis::WKBMultiPoint25D )
@@ -6304,7 +6304,7 @@ QgsMultiPoint QgsGeometry::asMultiPoint()
   return points;
 }
 
-QgsMultiPolyline QgsGeometry::asMultiPolyline()
+QgsMultiPolyline QgsGeometry::asMultiPolyline() const
 {
   QGis::WkbType type = wkbType();
   if ( type != QGis::WKBMultiLineString && type != QGis::WKBMultiLineString25D )
@@ -6326,7 +6326,7 @@ QgsMultiPolyline QgsGeometry::asMultiPolyline()
   return lines;
 }
 
-QgsMultiPolygon QgsGeometry::asMultiPolygon()
+QgsMultiPolygon QgsGeometry::asMultiPolygon() const
 {
   QGis::WkbType type = wkbType();
   if ( type != QGis::WKBMultiPolygon && type != QGis::WKBMultiPolygon25D )
@@ -6635,7 +6635,7 @@ QgsGeometry* QgsGeometry::symDifference( QgsGeometry* geometry )
   CATCH_GEOS( 0 )
 }
 
-QList<QgsGeometry*> QgsGeometry::asGeometryCollection()
+QList<QgsGeometry*> QgsGeometry::asGeometryCollection() const
 {
   if ( mDirtyGeos )
   {

--- a/src/core/qgsgeometry.cpp
+++ b/src/core/qgsgeometry.cpp
@@ -605,7 +605,7 @@ void QgsGeometry::fromWkb( unsigned char * wkb, size_t length )
   mDirtyGeos  = true;
 }
 
-unsigned char * QgsGeometry::asWkb() const
+const unsigned char * QgsGeometry::asWkb() const
 {
   if ( mDirtyWkb )
   {
@@ -626,7 +626,7 @@ size_t QgsGeometry::wkbSize() const
   return mGeometrySize;
 }
 
-GEOSGeometry* QgsGeometry::asGeos() const
+const GEOSGeometry* QgsGeometry::asGeos() const
 {
   if ( mDirtyGeos )
   {
@@ -641,7 +641,7 @@ GEOSGeometry* QgsGeometry::asGeos() const
 
 QGis::WkbType QgsGeometry::wkbType() const
 {
-  unsigned char *geom = asWkb(); // ensure that wkb representation exists
+  const unsigned char *geom = asWkb(); // ensure that wkb representation exists
   if ( geom && wkbSize() >= 5 )
   {
     unsigned int wkbType;
@@ -6848,7 +6848,7 @@ bool QgsGeometry::isGeosValid()
 {
   try
   {
-    GEOSGeometry *g = asGeos();
+    const GEOSGeometry *g = asGeos();
 
     if ( !g )
       return false;
@@ -6871,7 +6871,7 @@ bool QgsGeometry::isGeosEmpty()
 {
   try
   {
-    GEOSGeometry *g = asGeos();
+    const GEOSGeometry *g = asGeos();
 
     if ( !g )
       return false;

--- a/src/core/qgsgeometry.h
+++ b/src/core/qgsgeometry.h
@@ -119,7 +119,7 @@ class CORE_EXPORT QgsGeometry
        Returns the buffer containing this geometry in WKB format.
        You may wish to use in conjunction with wkbSize().
     */
-    unsigned char * asWkb() const;
+    const unsigned char* asWkb() const;
 
     /**
      * Returns the size of the WKB in asWkb().
@@ -130,7 +130,7 @@ class CORE_EXPORT QgsGeometry
         @note this method was added in version 1.1
         @note not available in python bindings
       */
-    GEOSGeometry* asGeos() const;
+    const GEOSGeometry* asGeos() const;
 
     /** Returns type of wkb (point / linestring / polygon etc.) */
     QGis::WkbType wkbType() const;

--- a/src/core/qgsgeometry.h
+++ b/src/core/qgsgeometry.h
@@ -119,21 +119,21 @@ class CORE_EXPORT QgsGeometry
        Returns the buffer containing this geometry in WKB format.
        You may wish to use in conjunction with wkbSize().
     */
-    unsigned char * asWkb();
+    unsigned char * asWkb() const;
 
     /**
      * Returns the size of the WKB in asWkb().
      */
-    size_t wkbSize();
+    size_t wkbSize() const;
 
     /**Returns a geos geomtry. QgsGeometry keeps ownership, don't delete the returned object!
         @note this method was added in version 1.1
         @note not available in python bindings
       */
-    GEOSGeometry* asGeos();
+    GEOSGeometry* asGeos() const;
 
     /** Returns type of wkb (point / linestring / polygon etc.) */
-    QGis::WkbType wkbType();
+    QGis::WkbType wkbType() const;
 
     /** Returns type of the vector */
     QGis::GeometryType type();
@@ -301,41 +301,41 @@ class CORE_EXPORT QgsGeometry
     QgsRectangle boundingBox();
 
     /** Test for intersection with a rectangle (uses GEOS) */
-    bool intersects( const QgsRectangle& r );
+    bool intersects( const QgsRectangle& r ) const;
 
     /** Test for intersection with a geometry (uses GEOS) */
-    bool intersects( QgsGeometry* geometry );
+    bool intersects( const QgsGeometry* geometry ) const;
 
     /** Test for containment of a point (uses GEOS) */
-    bool contains( QgsPoint* p );
+    bool contains( const QgsPoint* p ) const;
 
     /** Test for if geometry is contained in an other (uses GEOS)
      *  @note added in 1.5 */
-    bool contains( QgsGeometry* geometry );
+    bool contains( const QgsGeometry* geometry ) const;
 
     /** Test for if geometry is disjoint of an other (uses GEOS)
      *  @note added in 1.5 */
-    bool disjoint( QgsGeometry* geometry );
+    bool disjoint( const QgsGeometry* geometry ) const;
 
     /** Test for if geometry equals an other (uses GEOS)
      *  @note added in 1.5 */
-    bool equals( QgsGeometry* geometry );
+    bool equals( const QgsGeometry* geometry ) const;
 
     /** Test for if geometry touch an other (uses GEOS)
      *  @note added in 1.5 */
-    bool touches( QgsGeometry* geometry );
+    bool touches( const QgsGeometry* geometry ) const;
 
     /** Test for if geometry overlaps an other (uses GEOS)
      *  @note added in 1.5 */
-    bool overlaps( QgsGeometry* geometry );
+    bool overlaps( const QgsGeometry* geometry ) const;
 
     /** Test for if geometry is within an other (uses GEOS)
      *  @note added in 1.5 */
-    bool within( QgsGeometry* geometry );
+    bool within( const QgsGeometry* geometry ) const;
 
     /** Test for if geometry crosses an other (uses GEOS)
      *  @note added in 1.5 */
-    bool crosses( QgsGeometry* geometry );
+    bool crosses( const QgsGeometry* geometry ) const;
 
     /** Returns a buffer region around this geometry having the given width and with a specified number
         of segments used to approximate curves */
@@ -374,44 +374,44 @@ class CORE_EXPORT QgsGeometry
     /** Exports the geometry to mWkt
      *  @return true in case of success and false else
      */
-    QString exportToWkt();
+    QString exportToWkt() const;
 
     /** Exports the geometry to mGeoJSON
      *  @return true in case of success and false else
      *  @note added in 1.8
      *  @note python binding added in 1.9
      */
-    QString exportToGeoJSON();
+    QString exportToGeoJSON() const;
 
     /* Accessor functions for getting geometry data */
 
     /** return contents of the geometry as a point
         if wkbType is WKBPoint, otherwise returns [0,0] */
-    QgsPoint asPoint();
+    QgsPoint asPoint() const;
 
     /** return contents of the geometry as a polyline
         if wkbType is WKBLineString, otherwise an empty list */
-    QgsPolyline asPolyline();
+    QgsPolyline asPolyline() const;
 
     /** return contents of the geometry as a polygon
         if wkbType is WKBPolygon, otherwise an empty list */
-    QgsPolygon asPolygon();
+    QgsPolygon asPolygon() const;
 
     /** return contents of the geometry as a multi point
         if wkbType is WKBMultiPoint, otherwise an empty list */
-    QgsMultiPoint asMultiPoint();
+    QgsMultiPoint asMultiPoint() const;
 
     /** return contents of the geometry as a multi linestring
         if wkbType is WKBMultiLineString, otherwise an empty list */
-    QgsMultiPolyline asMultiPolyline();
+    QgsMultiPolyline asMultiPolyline() const;
 
     /** return contents of the geometry as a multi polygon
         if wkbType is WKBMultiPolygon, otherwise an empty list */
-    QgsMultiPolygon asMultiPolygon();
+    QgsMultiPolygon asMultiPolygon() const;
 
     /** return contents of the geometry as a list of geometries
      @note added in version 1.1 */
-    QList<QgsGeometry*> asGeometryCollection();
+    QList<QgsGeometry*> asGeometryCollection() const;
 
     /** delete a ring in polygon or multipolygon.
       Ring 0 is outer ring and can't be deleted.
@@ -471,19 +471,19 @@ class CORE_EXPORT QgsGeometry
     /** pointer to geometry in binary WKB format
         This is the class' native implementation
      */
-    unsigned char * mGeometry;
+    mutable unsigned char * mGeometry;
 
     /** size of geometry */
-    size_t mGeometrySize;
+    mutable size_t mGeometrySize;
 
     /** cached GEOS version of this geometry */
-    GEOSGeometry* mGeos;
+    mutable GEOSGeometry* mGeos;
 
     /** If the geometry has been set since the last conversion to WKB **/
-    bool mDirtyWkb;
+    mutable bool mDirtyWkb;
 
     /** If the geometry has been set  since the last conversion to GEOS **/
-    bool mDirtyGeos;
+    mutable bool mDirtyGeos;
 
 
     // Private functions
@@ -491,12 +491,12 @@ class CORE_EXPORT QgsGeometry
     /** Converts from the WKB geometry to the GEOS geometry.
         @return   true in case of success and false else
      */
-    bool exportWkbToGeos();
+    bool exportWkbToGeos() const;
 
     /** Converts from the GEOS geometry to the WKB geometry.
         @return   true in case of success and false else
      */
-    bool exportGeosToWkb();
+    bool exportGeosToWkb() const;
 
     /** Insert a new vertex before the given vertex index (first number is index 0)
      *  in the given GEOS Coordinate Sequence.
@@ -580,16 +580,16 @@ class CORE_EXPORT QgsGeometry
     int mergeGeometriesMultiTypeSplit( QVector<GEOSGeometry*>& splitResult );
 
     /** return point from wkb */
-    QgsPoint asPoint( unsigned char*& ptr, bool hasZValue );
+    QgsPoint asPoint( unsigned char*& ptr, bool hasZValue ) const;
 
     /** return polyline from wkb */
-    QgsPolyline asPolyline( unsigned char*& ptr, bool hasZValue );
+    QgsPolyline asPolyline( unsigned char*& ptr, bool hasZValue ) const;
 
     /** return polygon from wkb */
-    QgsPolygon asPolygon( unsigned char*& ptr, bool hasZValue );
+    QgsPolygon asPolygon( unsigned char*& ptr, bool hasZValue ) const;
 
     static bool geosRelOp( char( *op )( const GEOSGeometry*, const GEOSGeometry * ),
-                           QgsGeometry *a, QgsGeometry *b );
+                           const QgsGeometry* a, const QgsGeometry* b );
 
     /**Returns < 0 if point(x/y) is left of the line x1,y1 -> x1,y2*/
     double leftOf( double x, double y, double& x1, double& y1, double& x2, double& y2 );

--- a/src/core/qgsgeometryvalidator.cpp
+++ b/src/core/qgsgeometryvalidator.cpp
@@ -200,7 +200,7 @@ void QgsGeometryValidator::run()
   if ( settings.value( "/qgis/digitizing/validate_geometries", 1 ).toInt() == 2 )
   {
     char *r = 0;
-    GEOSGeometry *g0 = mG.asGeos();
+    const GEOSGeometry *g0 = mG.asGeos();
     if ( !g0 )
     {
       emit errorFound( QgsGeometry::Error( QObject::tr( "GEOS error:could not produce geometry for GEOS (check log window)" ) ) );

--- a/src/core/qgslabel.cpp
+++ b/src/core/qgslabel.cpp
@@ -519,7 +519,7 @@ QgsLabelAttributes *QgsLabel::labelAttributes( void )
 void QgsLabel::labelPoint( std::vector<labelpoint>& points, QgsFeature & feature )
 {
   QgsGeometry *geometry = feature.geometry();
-  unsigned char *geom = geometry->asWkb();
+  const unsigned char *geom = geometry->asWkb();
   size_t geomlen = geometry->wkbSize();
   QGis::WkbType wkbType = geometry->wkbType();
   labelpoint point;
@@ -551,7 +551,7 @@ void QgsLabel::labelPoint( std::vector<labelpoint>& points, QgsFeature & feature
       int nFeatures = *( unsigned int * )geom;
       geom += sizeof( int );
 
-      unsigned char *feature = geom;
+      const unsigned char *feature = geom;
       for ( int i = 0; i < nFeatures && feature; ++i )
       {
         feature = labelPoint( point, feature, geom + geomlen - feature );
@@ -564,7 +564,7 @@ void QgsLabel::labelPoint( std::vector<labelpoint>& points, QgsFeature & feature
   }
 }
 
-unsigned char* QgsLabel::labelPoint( labelpoint& point, unsigned char *geom, size_t geomlen )
+const unsigned char* QgsLabel::labelPoint( labelpoint& point, const unsigned char *geom, size_t geomlen )
 {
   // verify that local types match sizes as WKB spec
   Q_ASSERT( sizeof( int ) == 4 );
@@ -579,7 +579,7 @@ unsigned char* QgsLabel::labelPoint( labelpoint& point, unsigned char *geom, siz
 
   QGis::WkbType wkbType;
 #ifndef QT_NO_DEBUG
-  unsigned char *geomend = geom + geomlen;
+  const unsigned char *geomend = geom + geomlen;
 #else
   Q_UNUSED( geomlen );
 #endif

--- a/src/core/qgslabel.h
+++ b/src/core/qgslabel.h
@@ -165,7 +165,7 @@ class CORE_EXPORT QgsLabel
     void labelPoint( std::vector<labelpoint>&, QgsFeature &feature );
 
     /** Get label point for the given feature in wkb format. */
-    unsigned char* labelPoint( labelpoint& point, unsigned char* wkb, size_t wkblen );
+    const unsigned char* labelPoint( labelpoint& point, const unsigned char* wkb, size_t wkblen );
 
     /** Color to draw selected features */
     QColor mSelectionColor;

--- a/src/core/qgsogcutils.cpp
+++ b/src/core/qgsogcutils.cpp
@@ -1062,7 +1062,7 @@ QDomElement QgsOgcUtils::geometryToGML( QgsGeometry* geometry, QDomDocument& doc
 
   bool hasZValue = false;
   double *x, *y;
-  unsigned char* wkb = geometry->asWkb();
+  const unsigned char* wkb = geometry->asWkb();
 
   if ( format == "GML3" )
   {
@@ -1110,7 +1110,7 @@ QDomElement QgsOgcUtils::geometryToGML( QgsGeometry* geometry, QDomDocument& doc
       hasZValue = true;
     case QGis::WKBMultiPoint:
     {
-      unsigned char *ptr;
+      const unsigned char *ptr;
       int idx;
       int *nPoints;
 
@@ -1148,7 +1148,7 @@ QDomElement QgsOgcUtils::geometryToGML( QgsGeometry* geometry, QDomDocument& doc
       hasZValue = true;
     case QGis::WKBLineString:
     {
-      unsigned char *ptr;
+      const unsigned char *ptr;
       int *nPoints;
       int idx;
 
@@ -1186,7 +1186,7 @@ QDomElement QgsOgcUtils::geometryToGML( QgsGeometry* geometry, QDomDocument& doc
       hasZValue = true;
     case QGis::WKBMultiLineString:
     {
-      unsigned char *ptr;
+      const unsigned char *ptr;
       int idx, jdx, numLineStrings;
       int *nPoints;
 
@@ -1232,7 +1232,7 @@ QDomElement QgsOgcUtils::geometryToGML( QgsGeometry* geometry, QDomDocument& doc
       hasZValue = true;
     case QGis::WKBPolygon:
     {
-      unsigned char *ptr;
+      const unsigned char *ptr;
       int idx, jdx;
       int *numRings, *nPoints;
 
@@ -1295,7 +1295,7 @@ QDomElement QgsOgcUtils::geometryToGML( QgsGeometry* geometry, QDomDocument& doc
       hasZValue = true;
     case QGis::WKBMultiPolygon:
     {
-      unsigned char *ptr;
+      const unsigned char *ptr;
       int idx, jdx, kdx;
       int *numPolygons, *numRings, *nPoints;
 

--- a/src/core/qgspalgeometry.cpp
+++ b/src/core/qgspalgeometry.cpp
@@ -32,7 +32,7 @@ QgsPALGeometry::~QgsPALGeometry()
 {
 }
 
-GEOSGeometry* QgsPALGeometry::getGeosGeometry()
+const GEOSGeometry* QgsPALGeometry::getGeosGeometry()
 {
   if ( mOverlayObjectPtr )
   {

--- a/src/core/qgspalgeometry.h
+++ b/src/core/qgspalgeometry.h
@@ -35,9 +35,9 @@ class CORE_EXPORT QgsPALGeometry: public pal::PalGeometry
 
     //methods inherited from PalGeometry
     // @note available in python bindings
-    GEOSGeometry* getGeosGeometry();
+    const GEOSGeometry* getGeosGeometry();
     // @note available in python bindings
-    void releaseGeosGeometry( GEOSGeometry *the_geom ) { Q_UNUSED( the_geom ); }
+    void releaseGeosGeometry( const GEOSGeometry *the_geom ) { Q_UNUSED( the_geom ); }
 
     /**Returns pointer to the overlay object this geometry referrs to. Don't delete the returned object!*/
     QgsOverlayObject* overlayObjectPtr() const { return mOverlayObjectPtr; }

--- a/src/core/qgspallabeling.cpp
+++ b/src/core/qgspallabeling.cpp
@@ -90,11 +90,11 @@ class QgsPalGeometry : public PalGeometry
 
     // getGeosGeometry + releaseGeosGeometry is called twice: once when adding, second time when labeling
 
-    GEOSGeometry* getGeosGeometry()
+    const GEOSGeometry* getGeosGeometry()
     {
       return mG;
     }
-    void releaseGeosGeometry( GEOSGeometry* /*geom*/ )
+    void releaseGeosGeometry( const GEOSGeometry* /*geom*/ )
     {
       // nothing here - we'll delete the geometry in destructor
     }
@@ -1819,7 +1819,7 @@ void QgsPalLayerSettings::registerFeature( QgsVectorLayer* layer,  QgsFeature& f
     }
   }
 
-  GEOSGeometry* geos_geom = geom->asGeos();
+  const GEOSGeometry* geos_geom = geom->asGeos();
 
   if ( geos_geom == NULL )
     return; // invalid geometry
@@ -3321,7 +3321,7 @@ void QgsPalLabeling::registerDiagramFeature( QgsVectorLayer* layer, QgsFeature& 
     geom->transform( *( layerIt.value().ct ) );
   }
 
-  GEOSGeometry* geos_geom = geom->asGeos();
+  const GEOSGeometry* geos_geom = geom->asGeos();
   if ( geos_geom == 0 )
   {
     return; // invalid geometry

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -623,7 +623,7 @@ OGRFeatureH QgsVectorFileWriter::createFeature( QgsFeature& feature )
         return 0;
       }
 
-      OGRErr err = OGR_G_ImportFromWkb( mGeom2, geom->asWkb(), geom->wkbSize() );
+      OGRErr err = OGR_G_ImportFromWkb( mGeom2, const_cast<unsigned char *>( geom->asWkb() ), geom->wkbSize() );
       if ( err != OGRERR_NONE )
       {
         mErrorMessage = QObject::tr( "Feature geometry not imported (OGR error: %1)" )
@@ -639,7 +639,7 @@ OGRFeatureH QgsVectorFileWriter::createFeature( QgsFeature& feature )
     }
     else if ( geom )
     {
-      OGRErr err = OGR_G_ImportFromWkb( mGeom, geom->asWkb(), geom->wkbSize() );
+      OGRErr err = OGR_G_ImportFromWkb( mGeom, const_cast<unsigned char *>( geom->asWkb() ), geom->wkbSize() );
       if ( err != OGRERR_NONE )
       {
         mErrorMessage = QObject::tr( "Feature geometry not imported (OGR error: %1)" )

--- a/src/core/qgsvectorlayereditbuffer.h
+++ b/src/core/qgsvectorlayereditbuffer.h
@@ -106,6 +106,7 @@ class CORE_EXPORT QgsVectorLayerEditBuffer : public QObject
     /** Changed geometries which are not commited. */
     inline const QgsGeometryMap& changedGeometries() { return mChangedGeometries; }
 
+    inline const QgsFeatureIds deletedFeatureIds() { return mDeletedFeatureIds; }
     //QString dumpEditBuffer();
 
 
@@ -157,7 +158,6 @@ class CORE_EXPORT QgsVectorLayerEditBuffer : public QObject
   protected:
     QgsVectorLayer* L;
     friend class QgsVectorLayer;
-    friend class QgsVectorLayerFeatureIterator;
 
     friend class QgsVectorLayerUndoCommand;
     friend class QgsVectorLayerUndoCommandAddFeature;

--- a/src/core/qgsvectorlayerfeatureiterator.h
+++ b/src/core/qgsvectorlayerfeatureiterator.h
@@ -22,6 +22,7 @@
 typedef QMap<QgsFeatureId, QgsFeature> QgsFeatureMap;
 
 class QgsVectorLayer;
+class QgsVectorLayerEditBuffer;
 struct QgsVectorJoinInfo;
 
 class CORE_EXPORT QgsVectorLayerFeatureIterator : public QgsAbstractFeatureIterator
@@ -46,17 +47,19 @@ class CORE_EXPORT QgsVectorLayerFeatureIterator : public QgsAbstractFeatureItera
     QgsFeatureRequest mProviderRequest;
     QgsFeatureIterator mProviderIterator;
 
+#if 0
     // general stuff
-    //bool mFetching;
-    //QgsRectangle mFetchRect;
-    //QgsAttributeList mFetchAttributes;
-    //QgsAttributeList mFetchProvAttributes;
-    //bool mFetchGeometry;
+    bool mFetching;
+    QgsRectangle mFetchRect;
+    QgsAttributeList mFetchAttributes;
+    QgsAttributeList mFetchProvAttributes;
+    bool mFetchGeometry;
+#endif
 
     // only related to editing
     QSet<QgsFeatureId> mFetchConsidered;
-    QgsGeometryMap::iterator mFetchChangedGeomIt;
-    QgsFeatureMap::iterator mFetchAddedFeaturesIt;
+    QgsGeometryMap::ConstIterator mFetchChangedGeomIt;
+    QgsFeatureMap::ConstIterator mFetchAddedFeaturesIt;
 
     bool mFetchedFid; // when iterating by FID: indicator whether it has been fetched yet or not
 
@@ -68,6 +71,12 @@ class CORE_EXPORT QgsVectorLayerFeatureIterator : public QgsAbstractFeatureItera
     void useChangedAttributeFeature( QgsFeatureId fid, const QgsGeometry& geom, QgsFeature& f );
     bool nextFeatureFid( QgsFeature& f );
     void addJoinedAttributes( QgsFeature &f );
+
+    /** Update feature with uncommited attribute updates */
+    void updateChangedAttributes( QgsFeature& f );
+
+    /** Update feature with uncommited geometry updates */
+    void updateFeatureGeometry( QgsFeature& f );
 
     /** Join information prepared for fast attribute id mapping in QgsVectorLayerJoinBuffer::updateFeatureAttributes().
       Created in the select() method of QgsVectorLayerJoinBuffer for the joins that contain fetched attributes
@@ -86,10 +95,16 @@ class CORE_EXPORT QgsVectorLayerFeatureIterator : public QgsAbstractFeatureItera
     };
 
 
+    QgsFeatureMap mAddedFeatures;
+    QgsGeometryMap mChangedGeometries;
+    QgsFeatureIds mDeletedFeatureIds;
+    QList<QgsField> mAddedAttributes;
+    QgsChangedAttributesMap mChangedAttributeValues;
+    QgsAttributeList mDeletedAttributeIds;
+
     /** Informations about joins used in the current select() statement.
       Allows faster mapping of attribute ids compared to mVectorJoins */
     QMap<QgsVectorLayer*, FetchJoinInfo> mFetchJoinInfo;
-
 };
 
 #endif // QGSVECTORLAYERFEATUREITERATOR_H

--- a/src/core/symbology-ng/qgsrendererv2.cpp
+++ b/src/core/symbology-ng/qgsrendererv2.cpp
@@ -34,7 +34,7 @@
 
 
 
-unsigned char* QgsFeatureRendererV2::_getPoint( QPointF& pt, QgsRenderContext& context, unsigned char* wkb )
+const unsigned char* QgsFeatureRendererV2::_getPoint( QPointF& pt, QgsRenderContext& context, const unsigned char* wkb )
 {
   wkb++; // jump over endian info
   unsigned int wkbType = *(( int* ) wkb );
@@ -58,7 +58,7 @@ unsigned char* QgsFeatureRendererV2::_getPoint( QPointF& pt, QgsRenderContext& c
   return wkb;
 }
 
-unsigned char* QgsFeatureRendererV2::_getLineString( QPolygonF& pts, QgsRenderContext& context, unsigned char* wkb )
+const unsigned char* QgsFeatureRendererV2::_getLineString( QPolygonF& pts, QgsRenderContext& context, const unsigned char* wkb )
 {
   wkb++; // jump over endian info
   unsigned int wkbType = *(( int* ) wkb );
@@ -114,7 +114,7 @@ unsigned char* QgsFeatureRendererV2::_getLineString( QPolygonF& pts, QgsRenderCo
   return wkb;
 }
 
-unsigned char* QgsFeatureRendererV2::_getPolygon( QPolygonF& pts, QList<QPolygonF>& holes, QgsRenderContext& context, unsigned char* wkb )
+const unsigned char* QgsFeatureRendererV2::_getPolygon( QPolygonF& pts, QList<QPolygonF>& holes, QgsRenderContext& context, const unsigned char* wkb )
 {
   wkb++; // jump over endian info
   unsigned int wkbType = *(( int* ) wkb );
@@ -290,9 +290,9 @@ void QgsFeatureRendererV2::renderFeatureWithSymbol( QgsFeature& feature, QgsSymb
         break;
       }
 
-      unsigned char* wkb = geom->asWkb();
+      const unsigned char* wkb = geom->asWkb();
       unsigned int num = *(( int* )( wkb + 5 ) );
-      unsigned char* ptr = wkb + 9;
+      const unsigned char* ptr = wkb + 9;
       QPointF pt;
 
       for ( unsigned int i = 0; i < num; ++i )
@@ -315,9 +315,9 @@ void QgsFeatureRendererV2::renderFeatureWithSymbol( QgsFeature& feature, QgsSymb
         break;
       }
 
-      unsigned char* wkb = geom->asWkb();
+      const unsigned char* wkb = geom->asWkb();
       unsigned int num = *(( int* )( wkb + 5 ) );
-      unsigned char* ptr = wkb + 9;
+      const unsigned char* ptr = wkb + 9;
       QPolygonF pts;
 
       for ( unsigned int i = 0; i < num; ++i )
@@ -340,9 +340,9 @@ void QgsFeatureRendererV2::renderFeatureWithSymbol( QgsFeature& feature, QgsSymb
         break;
       }
 
-      unsigned char* wkb = geom->asWkb();
+      const unsigned char* wkb = geom->asWkb();
       unsigned int num = *(( int* )( wkb + 5 ) );
-      unsigned char* ptr = wkb + 9;
+      const unsigned char* ptr = wkb + 9;
       QPolygonF pts;
       QList<QPolygonF> holes;
 

--- a/src/core/symbology-ng/qgsrendererv2.h
+++ b/src/core/symbology-ng/qgsrendererv2.h
@@ -190,9 +190,9 @@ class CORE_EXPORT QgsFeatureRendererV2
     //! render editing vertex marker for a polygon
     void renderVertexMarkerPolygon( QPolygonF& pts, QList<QPolygonF>* rings, QgsRenderContext& context );
 
-    static unsigned char* _getPoint( QPointF& pt, QgsRenderContext& context, unsigned char* wkb );
-    static unsigned char* _getLineString( QPolygonF& pts, QgsRenderContext& context, unsigned char* wkb );
-    static unsigned char* _getPolygon( QPolygonF& pts, QList<QPolygonF>& holes, QgsRenderContext& context, unsigned char* wkb );
+    static const unsigned char* _getPoint( QPointF& pt, QgsRenderContext& context, const unsigned char* wkb );
+    static const unsigned char* _getLineString( QPolygonF& pts, QgsRenderContext& context, const unsigned char* wkb );
+    static const unsigned char* _getPolygon( QPolygonF& pts, QList<QPolygonF>& holes, QgsRenderContext& context, const unsigned char* wkb );
 
     void setScaleMethodToSymbol( QgsSymbolV2* symbol, int scaleMethod );
 

--- a/src/plugins/spatialquery/qgsspatialquery.cpp
+++ b/src/plugins/spatialquery/qgsspatialquery.cpp
@@ -214,7 +214,7 @@ void QgsSpatialQuery::setSpatialIndexReference( QgsFeatureIds &qsetIndexInvalidR
 
 void QgsSpatialQuery::execQuery( QgsFeatureIds &qsetIndexResult, QgsFeatureIds &qsetIndexInvalidTarget, int relation )
 {
-  bool ( QgsGeometry::* operation )( QgsGeometry * );
+  bool ( QgsGeometry::* operation )( const QgsGeometry * ) const;
   switch ( relation )
   {
     case Disjoint:
@@ -251,7 +251,7 @@ void QgsSpatialQuery::execQuery( QgsFeatureIds &qsetIndexResult, QgsFeatureIds &
   coordinateTransform->setCoordinateTransform( mLayerTarget, mLayerReference );
 
   // Set function for populate result
-  void ( QgsSpatialQuery::* funcPopulateIndexResult )( QgsFeatureIds&, QgsFeatureId, QgsGeometry *, bool ( QgsGeometry::* )( QgsGeometry * ) );
+  void ( QgsSpatialQuery::* funcPopulateIndexResult )( QgsFeatureIds&, QgsFeatureId, QgsGeometry *, bool ( QgsGeometry::* )( const QgsGeometry * ) const );
   funcPopulateIndexResult = ( relation == Disjoint )
                             ? &QgsSpatialQuery::populateIndexResultDisjoint
                             : &QgsSpatialQuery::populateIndexResult;
@@ -280,7 +280,7 @@ void QgsSpatialQuery::execQuery( QgsFeatureIds &qsetIndexResult, QgsFeatureIds &
 
 void QgsSpatialQuery::populateIndexResult(
   QgsFeatureIds &qsetIndexResult, QgsFeatureId idTarget, QgsGeometry * geomTarget,
-  bool ( QgsGeometry::* op )( QgsGeometry * ) )
+  bool ( QgsGeometry::* op )( const QgsGeometry * ) const )
 {
   QList<QgsFeatureId> listIdReference;
   listIdReference = mIndexReference.intersects( geomTarget->boundingBox() );
@@ -306,7 +306,7 @@ void QgsSpatialQuery::populateIndexResult(
 
 void QgsSpatialQuery::populateIndexResultDisjoint(
   QgsFeatureIds &qsetIndexResult, QgsFeatureId idTarget, QgsGeometry * geomTarget,
-  bool ( QgsGeometry::* op )( QgsGeometry * ) )
+  bool ( QgsGeometry::* op )( const QgsGeometry * ) const )
 {
   QList<QgsFeatureId> listIdReference;
   listIdReference = mIndexReference.intersects( geomTarget->boundingBox() );

--- a/src/plugins/spatialquery/qgsspatialquery.h
+++ b/src/plugins/spatialquery/qgsspatialquery.h
@@ -137,7 +137,7 @@ class QgsSpatialQuery
     */
     void populateIndexResult(
       QgsFeatureIds &qsetIndexResult, QgsFeatureId idTarget, QgsGeometry *geomTarget,
-      bool ( QgsGeometry::* operation )( QgsGeometry * ) );
+      bool ( QgsGeometry::* operation )( const QgsGeometry * ) const );
     /**
     * \brief Populate index Result Disjoint
     * \param qsetIndexResult    Reference to QSet contains the result query
@@ -147,7 +147,7 @@ class QgsSpatialQuery
     */
     void populateIndexResultDisjoint(
       QgsFeatureIds &qsetIndexResult, QgsFeatureId idTarget, QgsGeometry *geomTarget,
-      bool ( QgsGeometry::* operation )( QgsGeometry * ) );
+      bool ( QgsGeometry::* operation )( const QgsGeometry * ) const );
 
     MngProgressBar *mPb;
     bool mUseReferenceSelection;

--- a/src/providers/gpx/qgsgpxprovider.cpp
+++ b/src/providers/gpx/qgsgpxprovider.cpp
@@ -217,7 +217,7 @@ bool QgsGPXProvider::addFeatures( QgsFeatureList & flist )
 
 bool QgsGPXProvider::addFeature( QgsFeature& f )
 {
-  unsigned char* geo = f.geometry()->asWkb();
+  const unsigned char* geo = f.geometry()->asWkb();
   QGis::WkbType wkbType = f.geometry()->wkbType();
   bool success = false;
   QgsGPSObject* obj = NULL;

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -855,12 +855,12 @@ bool QgsOgrProvider::addFeature( QgsFeature& f )
 
   if ( f.geometry() && f.geometry()->wkbSize() > 0 )
   {
-    unsigned char* wkb = f.geometry()->asWkb();
+    const unsigned char* wkb = f.geometry()->asWkb();
     OGRGeometryH geom = NULL;
 
     if ( wkb )
     {
-      if ( OGR_G_CreateFromWkb( wkb, NULL, &geom, f.geometry()->wkbSize() ) != OGRERR_NONE )
+      if ( OGR_G_CreateFromWkb( const_cast<unsigned char *>( wkb ), NULL, &geom, f.geometry()->wkbSize() ) != OGRERR_NONE )
       {
         pushError( tr( "OGR error creating wkb for feature %1: %2" ).arg( f.id() ).arg( CPLGetLastErrorMsg() ) );
         return false;
@@ -1163,7 +1163,7 @@ bool QgsOgrProvider::changeGeometryValues( QgsGeometryMap & geometry_map )
     }
 
     //create an OGRGeometry
-    if ( OGR_G_CreateFromWkb( it->asWkb(),
+    if ( OGR_G_CreateFromWkb( const_cast<unsigned char*>( it->asWkb() ),
                               OGR_L_GetSpatialRef( ogrLayer ),
                               &theNewGeometry,
                               it->wkbSize() ) != OGRERR_NONE )

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -2072,7 +2072,7 @@ void QgsPostgresProvider::appendGeomParam( QgsGeometry *geom, QStringList &param
   }
 
   QString param;
-  unsigned char *buf = geom->asWkb();
+  const unsigned char *buf = geom->asWkb();
   for ( uint i = 0; i < geom->wkbSize(); ++i )
   {
     if ( mConnectionRW->useWkbHex() )

--- a/src/providers/wfs/qgswfsprovider.cpp
+++ b/src/providers/wfs/qgswfsprovider.cpp
@@ -164,7 +164,7 @@ void QgsWFSProvider::copyFeature( QgsFeature* f, QgsFeature& feature, bool fetch
   QgsGeometry* geometry = f->geometry();
   if ( geometry && fetchGeometry )
   {
-    unsigned char *geom = geometry->asWkb();
+    const unsigned char *geom = geometry->asWkb();
     int geomSize = geometry->wkbSize();
     unsigned char* copiedGeom = new unsigned char[geomSize];
     memcpy( copiedGeom, geom, geomSize );


### PR DESCRIPTION
This introduces quite a bit of ~~SmartPointer and~~ constness magic, so I would be very happy to have some of the experienced devs in here ( @jef @wonder-sk  @mhugent and of course anybody else feeling qualified) to have a look at it if you find time

Problem:
The VectorLayerFeatureIterator works with the edit buffer, which can change, disappear or appear while the iterator is active.
For an iterator which does 
a) not fail unexpectedly due to concurrent changes and 
b) still works on the same dataset that was active when constructed and
c) does not copy all the edit buffer
I introduced Copy On Write (COW) here.

Qt does COW on their collections (QMap et al) when using a ConstIterator. 
Nice: We don't have to care! 
Downside: QgsGeometry has no const-ness and it's not that easy to achieve, because it caches the geometry in WKB and GEOS format and only transforms when necessary. Therefore I made both of them mutable, so they are allowed to change in const-methods as well. I think this is valid because if you want to change the "true" geometry of the object you will have to call a non-const method still.

As the QgsEditBuffer also can disappear anytime, (layer editing stopped) a shared copy of its contents are made in the vectorlayerfeatureiterator
~~I introduced a smart pointer (QSharedPointer) which deletes it only after the last reference has been deleted. But as smart pointers are not yet widely used in QGIS and opinions of these are different, please let me know if you disagree with this approach.~~

IMHO it works quite fine, but YMMV.
