### PR TITLE
OgrProvider: initial encoding setting check (fix #8167)

### DIFF
--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -335,6 +335,9 @@ QgsOgrProvider::QgsOgrProvider( QString const & uri )
     ogrLayer = ogrOrigLayer;
     if ( ogrLayer )
     {
+      // check that the initial encoding setting is fit for this layer
+      setEncoding( encoding() );
+
       valid = setSubsetString( mSubsetString );
       QgsDebugMsg( "Data source is valid" );
     }


### PR DESCRIPTION
This fixes http://hub.qgis.org/issues/8167
