### PR TITLE
fTools: remove lines that cause error with non-ascii path

### DIFF
--- a/python/plugins/fTools/tools/doDefineProj.py
+++ b/python/plugins/fTools/tools/doDefineProj.py
@@ -118,12 +118,10 @@ class Dialog(QDialog, Ui_Dialog):
                 inPath = provider.dataSourceUri()
                 p = re.compile("\|.*")
                 inPath = p.sub("", inPath)
-                print "PATH", inPath
                 self.progressBar.setValue(40)
                 if inPath.endswith(".shp"):
                     inPath = inPath[:-4]
                 self.progressBar.setValue(55)
-                print "PATH2", inPath
                 if not srsDefine.isValid():
                     QMessageBox.information(self, self.tr("Define current projection"), self.tr("Output spatial reference system is not valid"))
                 else:
@@ -147,7 +145,6 @@ class Dialog(QDialog, Ui_Dialog):
                     self.progressBar.setValue(95)
                     vLayer.setCrs(srsDefine)
                     self.progressBar.setValue(100)
-                    print "PATH3", inPath
                     QMessageBox.information(self, self.tr("Define current projection"),
                                             self.tr("Defined Projection For:\n%s.shp") % (inPath) )
         self.progressBar.setValue(0)


### PR DESCRIPTION
When I used "Define Current Projection" tool with shapefiles that include non-ascii characters in their paths, I got the following error message. In 1.8, this tool works even if the file path includes non-ascii characters.

<pre>
Traceback (most recent call last):
  File "C:\OSGeo4W\apps\qgis-dev\python\plugins\fTools\tools\doDefineProj.py", line 121, in accept
    print "PATH", inPath
UnicodeEncodeError: 'ascii' codec can't encode characters in position 51-53: ordinal not in range(128)

Python version:
2.7.4 (default, Apr  6 2013, 19:54:46) [MSC v.1500 32 bit (Intel)]

QGIS version:
1.9.0-Master Master, 3f9890f
</pre>
