### PR TITLE
Sextante - added the OutputDirectory output type

### DIFF
--- a/python/plugins/sextante/gui/OutputSelectionPanel.py
+++ b/python/plugins/sextante/gui/OutputSelectionPanel.py
@@ -28,6 +28,7 @@ from PyQt4.QtGui import *
 from qgis.gui import *
 from sextante.core.SextanteConfig import SextanteConfig
 from sextante.outputs.OutputVector import OutputVector
+from sextante.outputs.OutputDirectory import OutputDirectory
 
 class OutputSelectionPanel(QWidget):
 
@@ -42,8 +43,16 @@ class OutputSelectionPanel(QWidget):
         self.horizontalLayout.setSpacing(2)
         self.horizontalLayout.setMargin(0)
         self.text = QLineEdit()
-        if hasattr(self.text, 'setPlaceholderText'):
-            self.text.setPlaceholderText(OutputSelectionPanel.SAVE_TO_TEMP_FILE)
+        if isinstance(self.output, OutputDirectory):
+            settings = QSettings()
+            if settings.contains("/SextanteQGIS/LastOutputPath"):
+                currentPath = settings.value( "/SextanteQGIS/LastOutputPath")
+            else:
+                currentPath = SextanteConfig.getSetting(SextanteConfig.OUTPUT_FOLDER)
+            self.text.setText(currentPath)
+        else:
+            if hasattr(self.text, 'setPlaceholderText'):
+                self.text.setPlaceholderText(OutputSelectionPanel.SAVE_TO_TEMP_FILE)
         self.text.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
         self.horizontalLayout.addWidget(self.text)
         self.pushButton = QPushButton()
@@ -53,19 +62,22 @@ class OutputSelectionPanel(QWidget):
         self.setLayout(self.horizontalLayout)
 
     def buttonPushed(self):
-        popupmenu = QMenu()
-        saveToTemporaryFileAction = QAction("Save to a temporary file", self.pushButton)
-        saveToTemporaryFileAction.triggered.connect(self.saveToTemporaryFile)
-        popupmenu.addAction(saveToTemporaryFileAction )
-        if (isinstance(self.output, OutputVector) and self.alg.provider.supportsNonFileBasedOutput()):
-            saveToMemoryAction= QAction("Save to a memory layer", self.pushButton)
-            saveToMemoryAction.triggered.connect(self.saveToMemory)
-            popupmenu.addAction(saveToMemoryAction)
-        saveToFileAction = QAction("Save to file...", self.pushButton)
-        saveToFileAction.triggered.connect(self.saveToFile)
-        popupmenu.addAction(saveToFileAction)
+        if isinstance(self.output, OutputDirectory):
+            self.saveToDirectory()
+        else:
+            popupmenu = QMenu()
+            saveToTemporaryFileAction = QAction("Save to a temporary file", self.pushButton)
+            saveToTemporaryFileAction.triggered.connect(self.saveToTemporaryFile)
+            popupmenu.addAction(saveToTemporaryFileAction )
+            if (isinstance(self.output, OutputVector) and self.alg.provider.supportsNonFileBasedOutput()):
+                saveToMemoryAction= QAction("Save to a memory layer", self.pushButton)
+                saveToMemoryAction.triggered.connect(self.saveToMemory)
+                popupmenu.addAction(saveToMemoryAction)
+            saveToFileAction = QAction("Save to file...", self.pushButton)
+            saveToFileAction.triggered.connect(self.saveToFile)
+            popupmenu.addAction(saveToFileAction)
 
-        popupmenu.exec_(QCursor.pos())
+            popupmenu.exec_(QCursor.pos())
 
     def saveToTemporaryFile(self):
         self.text.setText("")
@@ -94,13 +106,38 @@ class OutputSelectionPanel(QWidget):
             settings.setValue("/SextanteQGIS/LastOutputPath", os.path.dirname(filename))
             settings.setValue("/SextanteQGIS/encoding", encoding)
 
-    def getValue(self):
-        filename = unicode(self.text.text())
-        if filename.strip() == "" or filename == OutputSelectionPanel.SAVE_TO_TEMP_FILE:
-            return None
-        if filename.startswith("memory:"):
-            return filename
+    def saveToDirectory(self):
+        '''
+        Show a dialog for choosing an output directory.
+        '''
+
+        settings = QSettings()
+        if settings.contains("/SextanteQGIS/LastOutputPath"):
+            currentPath = settings.value( "/SextanteQGIS/LastOutputPath")
         else:
-            if not os.path.isabs(filename):
-                filename = SextanteConfig.getSetting(SextanteConfig.OUTPUT_FOLDER) + os.sep + filename
-            return filename
+            currentPath = SextanteConfig.getSetting(SextanteConfig.OUTPUT_FOLDER)
+        lastEncoding = settings.value("/SextanteQGIS/encoding", "System")
+        dirDialog = QgsEncodingFileDialog(self, "Save Directory", currentPath,
+                                          "", lastEncoding)
+        dirDialog.setFileMode(QFileDialog.Directory)
+        dirDialog.setOption(QFileDialog.ShowDirsOnly)
+        if dirDialog.exec_() == QDialog.Accepted:
+            directories = dirDialog.selectedFiles()
+            encoding = unicode(dirDialog.encoding())
+            self.output.encoding = encoding
+            directory = unicode(directories[0])
+            self.text.setText(directory)
+            settings.setValue("/SextanteQGIS/LastOutputPath", directory)
+            settings.setValue("/SextanteQGIS/encoding", encoding)
+
+    def getValue(self):
+        filepath = unicode(self.text.text())
+        if filepath.strip() == "" or filepath == OutputSelectionPanel.SAVE_TO_TEMP_FILE:
+            value = None
+        elif filepath.startswith("memory:"):
+            value = filepath
+        elif not os.path.isabs(filepath):
+            value = SextanteConfig.getSetting(SextanteConfig.OUTPUT_FOLDER) + os.sep + filepath
+        else:
+            value = filepath
+        return value

--- a/python/plugins/sextante/modeler/ModelerParametersDialog.py
+++ b/python/plugins/sextante/modeler/ModelerParametersDialog.py
@@ -52,6 +52,7 @@ from sextante.outputs.OutputNumber import OutputNumber
 from sextante.outputs.OutputHTML import OutputHTML
 from sextante.parameters.ParameterFile import ParameterFile
 from sextante.outputs.OutputFile import OutputFile
+from sextante.outputs.OutputDirectory import OutputDirectory
 from sextante.core.WrongHelpFileException import WrongHelpFileException
 from sextante.parameters.ParameterExtent import ParameterExtent
 
@@ -121,7 +122,8 @@ class ModelerParametersDialog(QtGui.QDialog):
         for output in self.alg.outputs:
             if output.hidden:
                 continue
-            if isinstance(output, (OutputRaster, OutputVector, OutputTable, OutputHTML, OutputFile)):
+            if isinstance(output, (OutputRaster, OutputVector, OutputTable,
+                          OutputHTML, OutputFile, OutputDirectory)):
                 label = QtGui.QLabel(output.description + "<" + output.__module__.split(".")[-1] + ">")
                 item = QLineEdit()
                 if hasattr(item, 'setPlaceholderText'):

--- a/python/plugins/sextante/outputs/OutputDirectory.py
+++ b/python/plugins/sextante/outputs/OutputDirectory.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+
+"""
+***************************************************************************
+    OutputDirectory.py
+    ---------------------
+    Date                 : July 2013
+    Copyright            : (C) 2013 by Ricardo Garcia Silva
+    Email                : ricardo dot garcia dot silva at gmail dot com
+***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************
+"""
+
+__author__ = 'Ricardo Garcia Silva'
+__date__ = 'July 2013'
+__copyright__ = '(C) 2013, Ricardo Garcia Silva'
+# This will get replaced with a git SHA1 when you do a git archive
+__revision__ = '$Format:%H$'
+
+from sextante.outputs.Output import Output
+
+class OutputDirectory(Output):
+    '''
+    This type of output allows the user to select a directory to store results
+    '''
+
+    pass

--- a/python/plugins/sextante/outputs/OutputFactory.py
+++ b/python/plugins/sextante/outputs/OutputFactory.py
@@ -28,13 +28,15 @@ from sextante.outputs.OutputTable import OutputTable
 from sextante.outputs.OutputVector import OutputVector
 from sextante.outputs.OutputNumber import OutputNumber
 from sextante.outputs.OutputFile import OutputFile
+from sextante.outputs.OutputDirectory import OutputDirectory
 from sextante.outputs.OutputString import OutputString
 
 class OutputFactory():
 
     @staticmethod
     def getFromString(s):
-        classes = [OutputRaster, OutputVector, OutputTable, OutputHTML, OutputNumber, OutputFile, OutputString]
+        classes = [OutputRaster, OutputVector, OutputTable, OutputHTML,
+                   OutputNumber, OutputFile, OutputDirectory, OutputString]
         for clazz in classes:
             if s.startswith(clazz().outputTypeName()):
                 tokens = s[len(clazz().outputTypeName())+1:].split("|")


### PR DESCRIPTION
This pull request adds a new output type to Sextante: OutputDirectory. It enables using directories as outputs when building Sextante GeoAlgorithms.

It is marked as Feature #6055 in the issue tracker[1].

Example usage:

``` python
from sextante.outputs.OutputDirectory import OutputDirectory

class TestAlgorithm(GeoAlgorithm):

    def defineCharacteristics(self):
        self.addOutput(OutputDirectory('OUTPUT_DIR', 'Choose an output directory for saving files'))
```

[1] - http://hub.qgis.org/projects/sextante/issues
