### PR TITLE
GdalTools: fix decoding standard output/error

### DIFF
--- a/python/plugins/GdalTools/tools/GdalTools_utils.py
+++ b/python/plugins/GdalTools/tools/GdalTools_utils.py
@@ -112,6 +112,10 @@ def setLastUsedEncoding(encoding):
     settings = QSettings()
     settings.setValue( "/UI/encoding", encoding)
 
+# Decodes standard output/error
+def decodeLocal8Bit( byteArray ):
+  return QTextCodec.codecForLocale().toUnicode( byteArray )
+
 def getRasterExtensions():
   formats = FileFilter.allRastersFilter().split( ";;" )
   extensions = []
@@ -291,7 +295,7 @@ def getRasterSRS( parent, fileName ):
     processSRS.start( "gdalinfo", [fileName], QIODevice.ReadOnly )
     arr = ''
     if processSRS.waitForFinished():
-      arr = str(processSRS.readAllStandardOutput())
+      arr = decodeLocal8Bit( processSRS.readAllStandardOutput() )
       processSRS.close()
 
     if arr == '':
@@ -313,7 +317,7 @@ def getRasterExtent(parent, fileName):
     processSRS.start( "gdalinfo", [fileName], QIODevice.ReadOnly )
     arr = ''
     if processSRS.waitForFinished():
-      arr = str(processSRS.readAllStandardOutput())
+      arr = decodeLocal8Bit( processSRS.readAllStandardOutput() )
       processSRS.close()
 
     if arr == '':

--- a/python/plugins/GdalTools/tools/dialogBase.py
+++ b/python/plugins/GdalTools/tools/dialogBase.py
@@ -205,9 +205,9 @@ class GdalToolsBaseDialog(QDialog, Ui_Dialog):
         return
 
       # show the error message if there's one, otherwise show the process output message
-      msg = str(self.process.readAllStandardError())
+      msg = Utils.decodeLocal8Bit( self.process.readAllStandardError() )
       if msg == '':
-        outMessages = str(self.process.readAllStandardOutput()).splitlines()
+        outMessages = Utils.decodeLocal8Bit( self.process.readAllStandardOutput() ).splitlines()
 
         # make sure to not show the help
         for m in outMessages:

--- a/python/plugins/GdalTools/tools/doInfo.py
+++ b/python/plugins/GdalTools/tools/doInfo.py
@@ -99,7 +99,7 @@ class GdalToolsDialog( QWidget, Ui_Widget, BasePluginWidget ):
 
   def finished( self ):
       self.rasterInfoList.clear()
-      arr = str(self.base.process.readAllStandardOutput()).strip()
+      arr = Utils.decodeLocal8Bit( self.base.process.readAllStandardOutput() ).strip()
       if platform.system() == "Windows":
         #info = QString.fromLocal8Bit( arr ).strip().split( "\r\n" )
         # TODO test

--- a/python/plugins/GdalTools/tools/doOverview.py
+++ b/python/plugins/GdalTools/tools/doOverview.py
@@ -186,7 +186,7 @@ class GdalToolsDialog( QWidget, Ui_Widget, BaseBatchWidget ):
         BasePluginWidget.onFinished(self, exitCode, status)
         return
 
-      msg = str( self.base.process.readAllStandardError() )
+      msg = Utils.decodeLocal8Bit( self.base.process.readAllStandardError() )
       if msg != '':
         self.errors.append( ">> " + self.inFiles[self.batchIndex] + "<br>" + msg.replace( "\n", "<br>" ) )
 

--- a/python/plugins/GdalTools/tools/widgetBatchBase.py
+++ b/python/plugins/GdalTools/tools/widgetBatchBase.py
@@ -112,7 +112,7 @@ class GdalToolsBaseBatchWidget(BasePluginWidget):
         BasePluginWidget.onFinished(self, exitCode, status)
         return
 
-      msg = bytes.decode( bytes( self.base.process.readAllStandardError() ) )
+      msg = Utils.decodeLocal8Bit( self.base.process.readAllStandardError() )
       if msg != '':
         self.errors.append( ">> " + self.inFiles[self.batchIndex] + "<br>" + msg.replace( "\n", "<br>" ) )
 


### PR DESCRIPTION
This patch fixes decoding standard output / error from gdal utilities.
