### PR TITLE
make filename encoding consistent (gdal/ogr)

### DIFF
--- a/src/analysis/raster/qgsninecellfilter.cpp
+++ b/src/analysis/raster/qgsninecellfilter.cpp
@@ -20,9 +20,9 @@
 #include <QProgressDialog>
 
 #if defined(GDAL_VERSION_NUM) && GDAL_VERSION_NUM >= 1800
-#define TO8(x) (x).toUtf8().constData()
+#define TO8F(x) (x).toUtf8().constData()
 #else
-#define TO8(x) (x).toLocal8Bit().constData()
+#define TO8F(x) QFile::encodeName( x ).constData()
 #endif
 
 QgsNineCellFilter::QgsNineCellFilter( const QString& inputFile, const QString& outputFile, const QString& outputFormat )
@@ -187,7 +187,7 @@ int QgsNineCellFilter::processRaster( QProgressDialog* p )
   if ( p && p->wasCanceled() )
   {
     //delete the dataset without closing (because it is faster)
-    GDALDeleteDataset( outputDriver, mOutputFile.toLocal8Bit().data() );
+    GDALDeleteDataset( outputDriver, TO8F( mOutputFile ) );
     return 7;
   }
   GDALClose( outputDataset );
@@ -197,7 +197,7 @@ int QgsNineCellFilter::processRaster( QProgressDialog* p )
 
 GDALDatasetH QgsNineCellFilter::openInputFile( int& nCellsX, int& nCellsY )
 {
-  GDALDatasetH inputDataset = GDALOpen( TO8( mInputFile ), GA_ReadOnly );
+  GDALDatasetH inputDataset = GDALOpen( TO8F( mInputFile ), GA_ReadOnly );
   if ( inputDataset != NULL )
   {
     nCellsX = GDALGetRasterXSize( inputDataset );
@@ -246,7 +246,7 @@ GDALDatasetH QgsNineCellFilter::openOutputFile( GDALDatasetH inputDataset, GDALD
 
   //open output file
   char **papszOptions = NULL;
-  GDALDatasetH outputDataset = GDALCreate( outputDriver, mOutputFile.toLocal8Bit().data(), xSize, ySize, 1, GDT_Float32, papszOptions );
+  GDALDatasetH outputDataset = GDALCreate( outputDriver, TO8F( mOutputFile ), xSize, ySize, 1, GDT_Float32, papszOptions );
   if ( outputDataset == NULL )
   {
     return outputDataset;

--- a/src/analysis/raster/qgsrastercalculator.cpp
+++ b/src/analysis/raster/qgsrastercalculator.cpp
@@ -26,9 +26,11 @@
 #include <ogr_srs_api.h>
 
 #if defined(GDAL_VERSION_NUM) && GDAL_VERSION_NUM >= 1800
-#define TO8(x) (x).toUtf8().constData()
+#define TO8(x)   (x).toUtf8().constData()
+#define TO8F(x)  (x).toUtf8().constData()
 #else
-#define TO8(x) (x).toLocal8Bit().constData()
+#define TO8(x)   (x).toLocal8Bit().constData()
+#define TO8F(x)  QFile::encodeName( x ).constData()
 #endif
 
 QgsRasterCalculator::QgsRasterCalculator( const QString& formulaString, const QString& outputFile, const QString& outputFormat,
@@ -66,7 +68,7 @@ int QgsRasterCalculator::processCalculation( QProgressDialog* p )
     {
       return 2;
     }
-    GDALDatasetH inputDataset = GDALOpen( TO8( it->raster->source() ), GA_ReadOnly );
+    GDALDatasetH inputDataset = GDALOpen( TO8F( it->raster->source() ), GA_ReadOnly );
     if ( inputDataset == NULL )
     {
       return 2;
@@ -237,7 +239,7 @@ int QgsRasterCalculator::processCalculation( QProgressDialog* p )
   if ( p && p->wasCanceled() )
   {
     //delete the dataset without closing (because it is faster)
-    GDALDeleteDataset( outputDriver, mOutputFile.toLocal8Bit().data() );
+    GDALDeleteDataset( outputDriver, TO8F( mOutputFile ) );
     return 3;
   }
   GDALClose( outputDataset );
@@ -274,7 +276,7 @@ GDALDatasetH QgsRasterCalculator::openOutputFile( GDALDriverH outputDriver )
 {
   //open output file
   char **papszOptions = NULL;
-  GDALDatasetH outputDataset = GDALCreate( outputDriver, mOutputFile.toLocal8Bit().data(), mNumOutputColumns, mNumOutputRows, 1, GDT_Float32, papszOptions );
+  GDALDatasetH outputDataset = GDALCreate( outputDriver, TO8F( mOutputFile ), mNumOutputColumns, mNumOutputRows, 1, GDT_Float32, papszOptions );
   if ( outputDataset == NULL )
   {
     return outputDataset;

--- a/src/analysis/raster/qgsrelief.cpp
+++ b/src/analysis/raster/qgsrelief.cpp
@@ -28,9 +28,9 @@
 #include <QTextStream>
 
 #if defined(GDAL_VERSION_NUM) && GDAL_VERSION_NUM >= 1800
-#define TO8(x) (x).toUtf8().constData()
+#define TO8F(x) (x).toUtf8().constData()
 #else
-#define TO8(x) (x).toLocal8Bit().constData()
+#define TO8F(x) QFile::encodeName( x ).constData()
 #endif
 
 QgsRelief::QgsRelief( const QString& inputFile, const QString& outputFile, const QString& outputFormat ): \
@@ -269,7 +269,7 @@ int QgsRelief::processRaster( QProgressDialog* p )
   if ( p && p->wasCanceled() )
   {
     //delete the dataset without closing (because it is faster)
-    GDALDeleteDataset( outputDriver, mOutputFile.toLocal8Bit().data() );
+    GDALDeleteDataset( outputDriver, TO8F( mOutputFile ) );
     return 7;
   }
   GDALClose( outputDataset );
@@ -390,7 +390,7 @@ bool QgsRelief::setElevationColor( double elevation, int* red, int* green, int* 
 //duplicated from QgsNineCellFilter. Todo: make common base class
 GDALDatasetH QgsRelief::openInputFile( int& nCellsX, int& nCellsY )
 {
-  GDALDatasetH inputDataset = GDALOpen( TO8( mInputFile ), GA_ReadOnly );
+  GDALDatasetH inputDataset = GDALOpen( TO8F( mInputFile ), GA_ReadOnly );
   if ( inputDataset != NULL )
   {
     nCellsX = GDALGetRasterXSize( inputDataset );
@@ -444,7 +444,7 @@ GDALDatasetH QgsRelief::openOutputFile( GDALDatasetH inputDataset, GDALDriverH o
   papszOptions = CSLSetNameValue( papszOptions, "COMPRESS", "PACKBITS" );
 
   //create three band raster (reg, green, blue)
-  GDALDatasetH outputDataset = GDALCreate( outputDriver, mOutputFile.toLocal8Bit().data(), xSize, ySize, 3, GDT_Byte, papszOptions );
+  GDALDatasetH outputDataset = GDALCreate( outputDriver, TO8F( mOutputFile ), xSize, ySize, 3, GDT_Byte, papszOptions );
   if ( outputDataset == NULL )
   {
     return outputDataset;

--- a/src/analysis/vector/qgszonalstatistics.cpp
+++ b/src/analysis/vector/qgszonalstatistics.cpp
@@ -24,9 +24,9 @@
 #include <QProgressDialog>
 
 #if defined(GDAL_VERSION_NUM) && GDAL_VERSION_NUM >= 1800
-#define TO8(x) (x).toUtf8().constData()
+#define TO8F(x) (x).toUtf8().constData()
 #else
-#define TO8(x) (x).toLocal8Bit().constData()
+#define TO8F(x) QFile::encodeName( x ).constData()
 #endif
 
 QgsZonalStatistics::QgsZonalStatistics( QgsVectorLayer* polygonLayer, const QString& rasterFile, const QString& attributePrefix, int rasterBand )
@@ -66,7 +66,7 @@ int QgsZonalStatistics::calculateStatistics( QProgressDialog* p )
 
   //open the raster layer and the raster band
   GDALAllRegister();
-  GDALDatasetH inputDataset = GDALOpen( TO8( mRasterFilePath ), GA_ReadOnly );
+  GDALDatasetH inputDataset = GDALOpen( TO8F( mRasterFilePath ), GA_ReadOnly );
   if ( inputDataset == NULL )
   {
     return 3;

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -198,7 +198,7 @@ QgsVectorFileWriter::QgsVectorFileWriter(
   }
 
   // create the data source
-  mDS = OGR_Dr_CreateDataSource( poDriver, TO8( vectorFileName ), options );
+  mDS = OGR_Dr_CreateDataSource( poDriver, TO8F( vectorFileName ), options );
 
   if ( options )
   {
@@ -1012,11 +1012,11 @@ QMap<QString, QString> QgsVectorFileWriter::ogrDriverList()
           poDriver = OGRGetDriverByName( drvName.toLocal8Bit().data() );
           if ( poDriver )
           {
-            OGRDataSourceH ds = OGR_Dr_CreateDataSource( poDriver, TO8( QString( "/vsimem/spatialitetest.sqlite" ) ), options );
+            OGRDataSourceH ds = OGR_Dr_CreateDataSource( poDriver, TO8F( QString( "/vsimem/spatialitetest.sqlite" ) ), options );
             if ( ds )
             {
               writableDrivers << "SpatiaLite";
-              OGR_Dr_DeleteDataSource( poDriver, TO8( QString( "/vsimem/spatialitetest.sqlite" ) ) );
+              OGR_Dr_DeleteDataSource( poDriver, TO8F( QString( "/vsimem/spatialitetest.sqlite" ) ) );
               OGR_DS_Destroy( ds );
             }
           }

--- a/src/plugins/heatmap/heatmap.cpp
+++ b/src/plugins/heatmap/heatmap.cpp
@@ -47,6 +47,12 @@
 #define M_PI 3.14159265358979323846
 #endif
 
+#if defined(GDAL_VERSION_NUM) && GDAL_VERSION_NUM >= 1800
+#define TO8F(x) (x).toUtf8().constData()
+#else
+#define TO8F(x) QFile::encodeName( x ).constData()
+#endif
+
 static const QString sName = QObject::tr( "Heatmap" );
 static const QString sDescription = QObject::tr( "Creates a Heatmap raster for the input point vector" );
 static const QString sCategory = QObject::tr( "Raster" );
@@ -157,7 +163,7 @@ void Heatmap::run()
 
     // open the raster in GA_Update mode
     GDALDataset *heatmapDS;
-    heatmapDS = ( GDALDataset * ) GDALOpen( d.outputFilename().toUtf8(), GA_Update );
+    heatmapDS = ( GDALDataset * ) GDALOpen( TO8F( d.outputFilename() ), GA_Update );
     if ( !heatmapDS )
     {
       QMessageBox::information( 0, tr( "Raster update error" ), tr( "Could not open the created raster for updating. The heatmap was not generated." ) );

--- a/src/plugins/oracle_raster/qgsselectgeoraster_ui.cpp
+++ b/src/plugins/oracle_raster/qgsselectgeoraster_ui.cpp
@@ -26,9 +26,9 @@
 #include "qgsvectorlayer.h"
 
 #if defined(GDAL_VERSION_NUM) && GDAL_VERSION_NUM >= 1800
-#define TO8(x) (x).toUtf8().constData()
+#define TO8F(x) (x).toUtf8().constData()
 #else
-#define TO8(x) (x).toLocal8Bit().constData()
+#define TO8F(x) QFile::encodeName( x ).constData()
 #endif
 
 QgsOracleSelectGeoraster::QgsOracleSelectGeoraster( QWidget* parent,
@@ -199,7 +199,7 @@ void QgsOracleSelectGeoraster::showSelection( const QString & line )
    *  Try to open georaster dataset
    */
 
-  hDS = GDALOpenShared( TO8( identification ), eAccess );
+  hDS = GDALOpenShared( TO8F( identification ), eAccess );
 
   buttonBox->button( QDialogButtonBox::Ok )->setEnabled( false );
   if ( hDS == NULL )

--- a/src/providers/gdal/qgsgdaldataitems.cpp
+++ b/src/providers/gdal/qgsgdaldataitems.cpp
@@ -240,7 +240,7 @@ QGISEXTERN QgsDataItem * dataItem( QString thePath, QgsDataItem* parentItem )
       // do not print errors, but write to debug
       CPLPushErrorHandler( CPLQuietErrorHandler );
       CPLErrorReset();
-      if ( ! GDALIdentifyDriver( thePath.toLocal8Bit().constData(), 0 ) )
+      if ( ! GDALIdentifyDriver( TO8F( thePath ), 0 ) )
       {
         QgsDebugMsgLevel( "Skipping VRT file because root is not a GDAL VRT", 2 );
         CPLPopErrorHandler();

--- a/src/providers/gdal/qgsgdalprovider.cpp
+++ b/src/providers/gdal/qgsgdalprovider.cpp
@@ -2505,7 +2505,7 @@ QGISEXTERN QgsGdalProvider * create(
   //create dataset
   CPLErrorReset();
   char **papszOptions = papszFromStringList( createOptions );
-  GDALDatasetH dataset = GDALCreate( driver, uri.toLocal8Bit().data(), width, height, nBands, ( GDALDataType )type, papszOptions );
+  GDALDatasetH dataset = GDALCreate( driver, TO8F( uri ), width, height, nBands, ( GDALDataType )type, papszOptions );
   CSLDestroy( papszOptions );
   if ( dataset == NULL )
   {


### PR DESCRIPTION
There are still some filename encoding problems. For example, with the Terrain Analysis plugin, a output filename is garbled if the filename includes non-ascii characters. This patch fixes the problems.
