### PR TITLE
WFS client fixes

### DIFF
--- a/src/core/qgsgml.cpp
+++ b/src/core/qgsgml.cpp
@@ -128,8 +128,21 @@ int QgsGml::getFeatures( const QString& uri, QGis::WkbType* wkbType, QgsRectangl
     QCoreApplication::processEvents();
   }
 
+  QNetworkReply::NetworkError replyError = reply->error();
+  QString replyErrorString = reply->errorString();
+
   delete reply;
   delete progressDialog;
+
+  if ( replyError )
+  {
+    QgsMessageLog::logMessage(
+      tr( "GML Getfeature network request failed with error: %1" ).arg( replyErrorString ),
+      tr( "Network" ),
+      QgsMessageLog::CRITICAL
+    );
+    return 1;
+  }
 
   if ( *mWkbType != QGis::WKBNoGeometry )
   {

--- a/src/core/qgsgml.cpp
+++ b/src/core/qgsgml.cpp
@@ -85,7 +85,16 @@ int QgsGml::getFeatures( const QString& uri, QGis::WkbType* wkbType, QgsRectangl
 
   //find out if there is a QGIS main window. If yes, display a progress dialog
   QProgressDialog* progressDialog = 0;
-  QWidget* mainWindow = qApp->activeWindow();
+  QWidget* mainWindow = 0;
+  QWidgetList topLevelWidgets = qApp->topLevelWidgets();
+  for ( QWidgetList::iterator it = topLevelWidgets.begin(); it != topLevelWidgets.end(); ++it )
+  {
+    if (( *it )->objectName() == "QgisApp" )
+    {
+      mainWindow = *it;
+      break;
+    }
+  }
   if ( mainWindow )
   {
     progressDialog = new QProgressDialog( tr( "Loading GML data\n%1" ).arg( mTypeName ), tr( "Abort" ), 0, 0, mainWindow );

--- a/src/providers/wfs/qgswfsdataitems.cpp
+++ b/src/providers/wfs/qgswfsdataitems.cpp
@@ -24,10 +24,10 @@
 #include <QCoreApplication>
 
 
-QgsWFSLayerItem::QgsWFSLayerItem( QgsDataItem* parent, QString name, QgsDataSourceURI uri, QString featureType, QString title )
+QgsWFSLayerItem::QgsWFSLayerItem( QgsDataItem* parent, QString name, QgsDataSourceURI uri, QString featureType, QString title, QString crsString )
     : QgsLayerItem( parent, title, parent->path() + "/" + name, QString(), QgsLayerItem::Vector, "WFS" )
 {
-  mUri = QgsWFSCapabilities( uri.encodedUri() ).uriGetFeature( featureType );
+  mUri = QgsWFSCapabilities( uri.encodedUri() ).uriGetFeature( featureType, crsString );
   mPopulated = true;
   mIcon = QgsApplication::getThemeIcon( "mIconWfs.svg" );
 }
@@ -74,7 +74,7 @@ QVector<QgsDataItem*> QgsWFSConnectionItem::createChildren()
     foreach ( const QgsWFSCapabilities::FeatureType& featureType, caps.featureTypes )
     {
       //QgsWFSLayerItem* layer = new QgsWFSLayerItem( this, mName, featureType.name, featureType.title );
-      QgsWFSLayerItem* layer = new QgsWFSLayerItem( this, mName, uri, featureType.name, featureType.title );
+      QgsWFSLayerItem* layer = new QgsWFSLayerItem( this, mName, uri, featureType.name, featureType.title, featureType.crslist.first() );
       layers.append( layer );
     }
   }

--- a/src/providers/wfs/qgswfsdataitems.h
+++ b/src/providers/wfs/qgswfsdataitems.h
@@ -69,7 +69,7 @@ class QgsWFSConnectionItem : public QgsDataCollectionItem
 class QgsWFSLayerItem : public QgsLayerItem
 {
   public:
-    QgsWFSLayerItem( QgsDataItem* parent, QString name, QgsDataSourceURI uri, QString featureType, QString title );
+    QgsWFSLayerItem( QgsDataItem* parent, QString name, QgsDataSourceURI uri, QString featureType, QString title, QString crsString );
     ~QgsWFSLayerItem();
 
 };

--- a/src/providers/wfs/qgswfssourceselect.cpp
+++ b/src/providers/wfs/qgswfssourceselect.cpp
@@ -207,6 +207,8 @@ void QgsWFSSourceSelect::capabilitiesReplyFinished()
     }
     // handle errors
     QMessageBox::critical( 0, title, mCapabilities->errorMessage() );
+
+    mAddButton->setEnabled( false );
     return;
   }
 

--- a/src/providers/wfs/qgswfssourceselect.h
+++ b/src/providers/wfs/qgswfssourceselect.h
@@ -60,7 +60,6 @@ class QgsWFSSourceSelect: public QDialog, private Ui::QgsWFSSourceSelectBase
      The first string is the typename, the corresponding list
     stores the CRS for the typename in the form 'EPSG:XXXX'*/
     std::map<QString, std::list<QString> > mAvailableCRS;
-    QAbstractButton* btnAdd;
     QgsWFSCapabilities* mCapabilities;
     QString mUri;            // data source URI
     QgsWFSItemDelegate* mItemDelegate;


### PR DESCRIPTION
This fixes bugs in the WFS client provider to work better with http://wfs.data.linz.govt.nz. The following issues have been fixed:
- WFS layers added from the browser no longer prompt the user for the layer coordinates system
- Ensure progress dialogue shows for WFS GML requests - especially in the case that the geometry type is not determined from the server describe feature type request and we need to inspect the feature type first feature. e.g "http://demo.deegree.org/deegree-wfs/services using the "app:springs" featuretype
- If a network request error occurs while reading the streamed GML, then return a failure status from the getFeatures method
- Re-write MimeData Uri concat and split function to deal with layer names and urls that contain the ':' character. e.g "Airport/airfield points (Hydro, 1:4k - 1:22k)"
