### PR TITLE
fix issue4819

### DIFF
--- a/src/core/qgsdistancearea.cpp
+++ b/src/core/qgsdistancearea.cpp
@@ -463,20 +463,20 @@ double QgsDistanceArea::measureLine( const QgsPoint& p1, const QgsPoint& p2 )
   {
     QgsPoint pp1 = p1, pp2 = p2;
 
-    QgsDebugMsg( QString( "Measuring from %1 to %2" ).arg( p1.toString( 4 ) ).arg( p2.toString( 4 ) ) );
+    QgsDebugMsgLevel( QString( "Measuring from %1 to %2" ).arg( p1.toString( 4 ) ).arg( p2.toString( 4 ) ), 3 );
     if ( mEllipsoidalMode && ( mEllipsoid != GEO_NONE ) )
     {
-      QgsDebugMsg( QString( "Ellipsoidal calculations is enabled, using ellipsoid %1" ).arg( mEllipsoid ) );
-      QgsDebugMsg( QString( "From proj4 : %1" ).arg( mCoordTransform->sourceCrs().toProj4() ) );
-      QgsDebugMsg( QString( "To   proj4 : %1" ).arg( mCoordTransform->destCRS().toProj4() ) );
+      QgsDebugMsgLevel( QString( "Ellipsoidal calculations is enabled, using ellipsoid %1" ).arg( mEllipsoid ), 4 );
+      QgsDebugMsgLevel( QString( "From proj4 : %1" ).arg( mCoordTransform->sourceCrs().toProj4() ), 4 );
+      QgsDebugMsgLevel( QString( "To   proj4 : %1" ).arg( mCoordTransform->destCRS().toProj4() ), 4 );
       pp1 = mCoordTransform->transform( p1 );
       pp2 = mCoordTransform->transform( p2 );
-      QgsDebugMsg( QString( "New points are %1 and %2, calculating..." ).arg( pp1.toString( 4 ) ).arg( pp2.toString( 4 ) ) );
+      QgsDebugMsgLevel( QString( "New points are %1 and %2, calculating..." ).arg( pp1.toString( 4 ) ).arg( pp2.toString( 4 ) ), 4 );
       result = computeDistanceBearing( pp1, pp2 );
     }
     else
     {
-      QgsDebugMsg( "Cartesian calculation on canvas coordinates" );
+      QgsDebugMsgLevel( "Cartesian calculation on canvas coordinates", 4 );
       result = sqrt(( p2.x() - p1.x() ) * ( p2.x() - p1.x() ) + ( p2.y() - p1.y() ) * ( p2.y() - p1.y() ) );
     }
   }
@@ -486,7 +486,7 @@ double QgsDistanceArea::measureLine( const QgsPoint& p1, const QgsPoint& p2 )
     QgsMessageLog::logMessage( QObject::tr( "Caught a coordinate system exception while trying to transform a point. Unable to calculate line length." ) );
     result = 0.0;
   }
-  QgsDebugMsg( QString( "The result was %1" ).arg( result ) );
+  QgsDebugMsgLevel( QString( "The result was %1" ).arg( result ), 3 );
   return result;
 }
 

--- a/src/gui/qgshighlight.cpp
+++ b/src/gui/qgshighlight.cpp
@@ -100,14 +100,22 @@ void QgsHighlight::paintPolygon( QPainter *p, QgsPolygon polygon )
 
   for ( int i = 0; i < polygon.size(); i++ )
   {
-    QPolygonF ring( polygon[i].size() + 1 );
+    if ( polygon[i].empty() ) continue;
+
+    QPolygonF ring;
+    ring.reserve( polygon[i].size() + 1 );
 
     for ( int j = 0; j < polygon[i].size(); j++ )
     {
-      ring[ j ] = toCanvasCoordinates( polygon[i][j] ) - pos();
+      //adding point only if it is more than a pixel appart from the previous one
+      const QPointF cur = toCanvasCoordinates( polygon[i][j] ) - pos();
+      if ( 0 == j || std::abs( ring.back().x() - cur.x() ) > 1 || std::abs( ring.back().y() - cur.y() ) > 1 )
+      {
+        ring.push_back( cur );
+      }
     }
 
-    ring[ polygon[i].size()] = ring[ 0 ];
+    ring.push_back( ring[ 0 ] );
 
     path.addPolygon( ring );
   }

--- a/src/gui/qgsrubberband.cpp
+++ b/src/gui/qgsrubberband.cpp
@@ -412,7 +412,9 @@ void QgsRubberBand::paint( QPainter* p )
       QList<QgsPoint>::const_iterator it = mPoints.at( i ).constBegin();
       for ( ; it != mPoints.at( i ).constEnd(); ++it )
       {
-        pts.append( toCanvasCoordinates( QgsPoint( it->x() + mTranslationOffsetX, it->y() + mTranslationOffsetY ) ) - pos() );
+        const QPointF cur = toCanvasCoordinates( QgsPoint( it->x() + mTranslationOffsetX, it->y() + mTranslationOffsetY ) ) - pos();
+        if ( pts.empty() || std::abs( pts.back().x() - cur.x() ) > 1 ||  std::abs( pts.back().y() - cur.y() ) > 1 )
+          pts.append( cur );
       }
 
       switch ( mGeometryType )

--- a/src/gui/qgsrubberband.cpp
+++ b/src/gui/qgsrubberband.cpp
@@ -135,7 +135,18 @@ void QgsRubberBand::addPoint( const QgsPoint & p, bool doUpdate /* = true */, in
   }
   else
   {
-    mPoints[geometryIndex] << p;
+    // add point only if it is further than a pixel appart from the previous point
+    if ( mPoints[geometryIndex].empty() )
+    {
+      mPoints[geometryIndex] << p;
+    }
+    else
+    {
+      const QPointF curr = toCanvasCoordinates( p );
+      const QPointF prev = toCanvasCoordinates( mPoints[geometryIndex].last() );
+      if ( std::abs( prev.x() - curr.x() ) > 1 || std::abs( prev.y() - curr.y() ) > 1 )
+        mPoints[geometryIndex] << p;
+    }
   }
 
 

--- a/src/gui/qgsrubberband.cpp
+++ b/src/gui/qgsrubberband.cpp
@@ -135,18 +135,7 @@ void QgsRubberBand::addPoint( const QgsPoint & p, bool doUpdate /* = true */, in
   }
   else
   {
-    // add point only if it is further than a pixel appart from the previous point
-    if ( mPoints[geometryIndex].empty() )
-    {
-      mPoints[geometryIndex] << p;
-    }
-    else
-    {
-      const QPointF curr = toCanvasCoordinates( p );
-      const QPointF prev = toCanvasCoordinates( mPoints[geometryIndex].last() );
-      if ( std::abs( prev.x() - curr.x() ) > 1 || std::abs( prev.y() - curr.y() ) > 1 )
-        mPoints[geometryIndex] << p;
-    }
+    mPoints[geometryIndex] << p;
   }
 
 

--- a/tests/src/gui/testqgsrubberband.cpp
+++ b/tests/src/gui/testqgsrubberband.cpp
@@ -90,9 +90,10 @@ void TestQgsRubberband::testAddSingleMultiGeometries()
   QgsGeometry* geomSinglePart = QgsGeometry::fromWkt( "POLYGON((-0.00022418 -0.00000279,-0.0001039 0.00002395,-0.00008677 -0.00005313,-0.00020705 -0.00007987,-0.00022418 -0.00000279))" );
   QgsGeometry* geomMultiPart = QgsGeometry::fromWkt( "MULTIPOLYGON(((-0.00018203 0.00012178,-0.00009444 0.00014125,-0.00007861 0.00007001,-0.00016619 0.00005054,-0.00018203 0.00012178)),((-0.00030957 0.00009464,-0.00021849 0.00011489,-0.00020447 0.00005184,-0.00029555 0.00003158,-0.00030957 0.00009464)))" );
 
+  mCanvas->setExtent(QgsRectangle(-1e-3,-1e-3,1e-3,1e-3)); // otherwise point cannot be converted to canvas coord
+
   mRubberband->addGeometry( geomSinglePart, mPolygonLayer );
   mRubberband->addGeometry( geomMultiPart, mPolygonLayer );
-
   QVERIFY( mRubberband->numberOfVertices() == 15 );
 }
 

--- a/tests/src/gui/testqgsrubberband.cpp
+++ b/tests/src/gui/testqgsrubberband.cpp
@@ -90,10 +90,9 @@ void TestQgsRubberband::testAddSingleMultiGeometries()
   QgsGeometry* geomSinglePart = QgsGeometry::fromWkt( "POLYGON((-0.00022418 -0.00000279,-0.0001039 0.00002395,-0.00008677 -0.00005313,-0.00020705 -0.00007987,-0.00022418 -0.00000279))" );
   QgsGeometry* geomMultiPart = QgsGeometry::fromWkt( "MULTIPOLYGON(((-0.00018203 0.00012178,-0.00009444 0.00014125,-0.00007861 0.00007001,-0.00016619 0.00005054,-0.00018203 0.00012178)),((-0.00030957 0.00009464,-0.00021849 0.00011489,-0.00020447 0.00005184,-0.00029555 0.00003158,-0.00030957 0.00009464)))" );
 
-  mCanvas->setExtent(QgsRectangle(-1e-3,-1e-3,1e-3,1e-3)); // otherwise point cannot be converted to canvas coord
-
   mRubberband->addGeometry( geomSinglePart, mPolygonLayer );
   mRubberband->addGeometry( geomMultiPart, mPolygonLayer );
+
   QVERIFY( mRubberband->numberOfVertices() == 15 );
 }
 


### PR DESCRIPTION
- modify polygon render to exclude consectuvie points that are less than a pixel appart
- moved inner loop debug prints to level 3 and 4 since they where slowing down too much the code in debug

This allow to have good interactivity with highlighted polygons with over 75k vertices (http://www.faunalia.pt/downloads/test_slow_vector.zip).
