### PR TITLE
option: right click ends digitizing with or without adding a vertex

### DIFF
--- a/src/app/qgsmaptooladdfeature.cpp
+++ b/src/app/qgsmaptooladdfeature.cpp
@@ -22,7 +22,6 @@
 #include "qgsmapcanvas.h"
 #include "qgsmaplayerregistry.h"
 #include "qgsproject.h"
-#include "qgsrubberband.h"
 #include "qgsvectordataprovider.h"
 #include "qgsvectorlayer.h"
 #include "qgslogger.h"
@@ -161,27 +160,29 @@ void QgsMapToolAddFeature::canvasReleaseEvent( QMouseEvent * e )
     }
 
     //add point to list and to rubber band
-    int error = addVertex( e->pos() );
-    if ( error == 1 )
-    {
-      //current layer is not a vector layer
-      return;
-    }
-    else if ( error == 2 )
-    {
-      //problem with coordinate transformation
-      QMessageBox::information( 0, tr( "Coordinate transform error" ),
-                                tr( "Cannot transform the point to the layers coordinate system" ) );
-      return;
-    }
-
     if ( e->button() == Qt::LeftButton )
     {
+      int error = addVertex( e->pos() );
+      if ( error == 1 )
+      {
+        //current layer is not a vector layer
+        return;
+      }
+      else if ( error == 2 )
+      {
+        //problem with coordinate transformation
+        QMessageBox::information( 0, tr( "Coordinate transform error" ),
+                                     tr( "Cannot transform the point to the layers coordinate system" ) );
+        return;
+      }
+
       startCapturing();
     }
     else if ( e->button() == Qt::RightButton )
     {
       // End of string
+
+      resetLastVertex();
 
       //lines: bail out if there are not at least two vertices
       if ( mode() == CaptureLine && size() < 2 )

--- a/src/app/qgsmaptooladdpart.cpp
+++ b/src/app/qgsmaptooladdpart.cpp
@@ -17,7 +17,6 @@
 #include "qgsgeometry.h"
 #include "qgsmapcanvas.h"
 #include "qgsproject.h"
-#include "qgsrubberband.h"
 #include "qgsvectorlayer.h"
 #include "qgslogger.h"
 
@@ -91,28 +90,30 @@ void QgsMapToolAddPart::canvasReleaseEvent( QMouseEvent * e )
     case CapturePolygon:
     {
       //add point to list and to rubber band
-      int error = addVertex( e->pos() );
-      if ( error == 1 )
-      {
-        QgsDebugMsg( "current layer is not a vector layer" );
-        return;
-      }
-      else if ( error == 2 )
-      {
-        //problem with coordinate transformation
-        QMessageBox::information( 0,
-                                  tr( "Coordinate transform error" ),
-                                  tr( "Cannot transform the point to the layers coordinate system" ) );
-        return;
-      }
-
       if ( e->button() == Qt::LeftButton )
       {
+       int error = addVertex( e->pos() );
+        if ( error == 1 )
+        {
+          QgsDebugMsg( "current layer is not a vector layer" );
+          return;
+        }
+        else if ( error == 2 )
+        {
+          //problem with coordinate transformation
+          QMessageBox::information( 0,
+                                    tr( "Coordinate transform error" ),
+                                    tr( "Cannot transform the point to the layers coordinate system" ) );
+          return;
+        }
+
         startCapturing();
         return;
       }
       else if ( e->button() != Qt::RightButton )
       {
+        resetLastVertex();
+
         return;
       }
 

--- a/src/app/qgsmaptooladdring.cpp
+++ b/src/app/qgsmaptooladdring.cpp
@@ -17,7 +17,6 @@
 #include "qgsgeometry.h"
 #include "qgsmapcanvas.h"
 #include "qgsproject.h"
-#include "qgsrubberband.h"
 #include "qgsvectorlayer.h"
 #include <QMessageBox>
 #include <QMouseEvent>
@@ -50,26 +49,28 @@ void QgsMapToolAddRing::canvasReleaseEvent( QMouseEvent * e )
   }
 
   //add point to list and to rubber band
-  int error = addVertex( e->pos() );
-  if ( error == 1 )
-  {
-    //current layer is not a vector layer
-    return;
-  }
-  else if ( error == 2 )
-  {
-    //problem with coordinate transformation
-    QMessageBox::information( 0, tr( "Coordinate transform error" ),
-                              tr( "Cannot transform the point to the layers coordinate system" ) );
-    return;
-  }
-
   if ( e->button() == Qt::LeftButton )
   {
+    int error = addVertex( e->pos() );
+    if ( error == 1 )
+    {
+      //current layer is not a vector layer
+      return;
+    }
+    else if ( error == 2 )
+    {
+      //problem with coordinate transformation
+      QMessageBox::information( 0, tr( "Coordinate transform error" ),
+                                   tr( "Cannot transform the point to the layers coordinate system" ) );
+     return;
+    }
+
     startCapturing();
   }
   else if ( e->button() == Qt::RightButton )
   {
+    resetLastVertex();
+
     closePolygon();
 
     vlayer->beginEditCommand( tr( "Ring added" ) );

--- a/src/app/qgsmaptoolcapture.cpp
+++ b/src/app/qgsmaptoolcapture.cpp
@@ -231,6 +231,20 @@ void QgsMapToolCapture::undo()
   }
 }
 
+void QgsMapToolCapture::resetLastVertex()
+{
+  if ( mRubberBand )
+  {
+    int rubberBandSize = mRubberBand->numberOfVertices();
+    if ( rubberBandSize < 2 )
+    {
+      return;
+    }
+    const QgsPoint *lastPoint = mRubberBand->getPoint(0, rubberBandSize-2);
+    mRubberBand->movePoint( *lastPoint );
+  }
+}
+
 void QgsMapToolCapture::keyPressEvent( QKeyEvent* e )
 {
   if ( e->key() == Qt::Key_Backspace || e->key() == Qt::Key_Delete )

--- a/src/app/qgsmaptoolcapture.h
+++ b/src/app/qgsmaptoolcapture.h
@@ -82,6 +82,9 @@ class QgsMapToolCapture : public QgsMapToolEdit
     /**Removes the last vertex from mRubberBand and mCaptureList*/
     void undo();
 
+    /**Reset the last vertex from RubberBand to the previous one position*/
+    void resetLastVertex();
+
     void startCapturing();
     void stopCapturing();
 

--- a/src/app/qgsmaptoolreshape.cpp
+++ b/src/app/qgsmaptoolreshape.cpp
@@ -16,7 +16,6 @@
 #include "qgsmaptoolreshape.h"
 #include "qgsgeometry.h"
 #include "qgsmapcanvas.h"
-#include "qgsrubberband.h"
 #include "qgsvectorlayer.h"
 #include <QMessageBox>
 #include <QMouseEvent>
@@ -49,26 +48,28 @@ void QgsMapToolReshape::canvasReleaseEvent( QMouseEvent * e )
   }
 
   //add point to list and to rubber band
-  int error = addVertex( e->pos() );
-  if ( error == 1 )
-  {
-    //current layer is not a vector layer
-    return;
-  }
-  else if ( error == 2 )
-  {
-    //problem with coordinate transformation
-    QMessageBox::information( 0, tr( "Coordinate transform error" ),
-                              tr( "Cannot transform the point to the layers coordinate system" ) );
-    return;
-  }
-
   if ( e->button() == Qt::LeftButton )
   {
+    int error = addVertex( e->pos() );
+    if ( error == 1 )
+    {
+      //current layer is not a vector layer
+      return;
+    }
+    else if ( error == 2 )
+    {
+      //problem with coordinate transformation
+      QMessageBox::information( 0, tr( "Coordinate transform error" ),
+                                   tr( "Cannot transform the point to the layers coordinate system" ) );
+      return;
+    }
+
     startCapturing();
   }
   else if ( e->button() == Qt::RightButton )
   {
+    resetLastVertex();
+
     //find out bounding box of mCaptureList
     if ( size() < 1 )
     {

--- a/src/app/qgsmaptoolsplitfeatures.cpp
+++ b/src/app/qgsmaptoolsplitfeatures.cpp
@@ -16,7 +16,6 @@
 #include "qgsmaptoolsplitfeatures.h"
 #include "qgsmapcanvas.h"
 #include "qgsproject.h"
-#include "qgsrubberband.h"
 #include "qgsvectorlayer.h"
 #include <QMessageBox>
 #include <QMouseEvent>
@@ -49,26 +48,28 @@ void QgsMapToolSplitFeatures::canvasReleaseEvent( QMouseEvent * e )
   }
 
   //add point to list and to rubber band
-  int error = addVertex( e->pos() );
-  if ( error == 1 )
-  {
-    //current layer is not a vector layer
-    return;
-  }
-  else if ( error == 2 )
-  {
-    //problem with coordinate transformation
-    QMessageBox::information( 0, tr( "Coordinate transform error" ),
-                              tr( "Cannot transform the point to the layers coordinate system" ) );
-    return;
-  }
-
   if ( e->button() == Qt::LeftButton )
   {
+    int error = addVertex( e->pos() );
+    if ( error == 1 )
+    {
+      //current layer is not a vector layer
+      return;
+    }
+    else if ( error == 2 )
+    {
+      //problem with coordinate transformation
+      QMessageBox::information( 0, tr( "Coordinate transform error" ),
+                                   tr( "Cannot transform the point to the layers coordinate system" ) );
+      return;
+    }
+
     startCapturing();
   }
   else if ( e->button() == Qt::RightButton )
   {
+    resetLastVertex();
+
     //bring up dialog if a split was not possible (polygon) or only done once (line)
     int topologicalEditing = QgsProject::instance()->readNumEntry( "Digitizing", "/TopologicalEditing", 0 );
     vlayer->beginEditCommand( tr( "Features split" ) );


### PR DESCRIPTION
I propose to add an option to determine right-click behevior in digitalization: it adds or not a vertex.
This adds a new option in the digitizing category in main option:

![aaa](https://f.cloud.github.com/assets/127259/854722/5c013928-f50d-11e2-90a6-cdeab82c2104.png)
