### PR TITLE
Join cache refresh and MapUnit autoscale

### DIFF
--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -1209,10 +1209,12 @@ bool QgsVectorLayer::setSubsetString( QString subset )
 
   if ( res )
   {
-    // update the cached joins to this layer
+    // update the cached joins pointing to this layer
     const QMap< QString, QgsMapLayer * > & layerList=QgsMapLayerRegistry::instance()->mapLayers();
     QMap<QString, QgsMapLayer*>::const_iterator it=layerList.constBegin();
-    bool updated=false;
+
+    // track the updates we make
+    bool some_updates=false;
 
     for ( ; it != layerList.constEnd(); ++it )
     {
@@ -1221,18 +1223,18 @@ bool QgsVectorLayer::setSubsetString( QString subset )
       QgsVectorLayer* currentVectorLayer = dynamic_cast<QgsVectorLayer*>( currentLayer );
       if ( ! currentVectorLayer || currentVectorLayer == this ) { continue; }
       if( currentVectorLayer->updateJoinCache(id()) ) {
-        updated=true;
+        some_updates=true;
         currentVectorLayer->updateFields();
       }
     }
 
-    if(updated)
+    setCacheImage( 0 );
+
+    if(some_updates)
     {
-        // refresh
+        // call for refresh
         emit repaintRequested();
     }
-
-    setCacheImage( 0 );
   }
 
   return res;

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -1204,6 +1204,9 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
       @note added in 1.7 */
     void createJoinCaches();
 
+    /** update the cache of a join pointing to a given (or any) layer*/
+    bool updateJoinCache(QString joinDestLayer="");
+
     /**Returns unique values for column
       @param index column index for attribute
       @param uniqueValues out: result list

--- a/src/core/qgsvectorlayerjoinbuffer.cpp
+++ b/src/core/qgsvectorlayerjoinbuffer.cpp
@@ -121,6 +121,21 @@ void QgsVectorLayerJoinBuffer::createJoinCaches()
   }
 }
 
+bool QgsVectorLayerJoinBuffer::updateJoinCache(QString joinDestLayer)
+{
+  bool updated=false;
+  QList< QgsVectorJoinInfo >::iterator joinIt = mVectorJoins.begin();
+  for ( ; joinIt != mVectorJoins.end(); ++joinIt )
+  {
+    if ( joinDestLayer == "" || joinDestLayer == joinIt->joinLayerId )
+    {
+      joinIt->cachedAttributes.clear();
+      cacheJoinLayer( *joinIt );
+      updated=true;
+    }
+  }
+  return updated;
+}
 
 void QgsVectorLayerJoinBuffer::writeXml( QDomNode& layer_node, QDomDocument& document ) const
 {

--- a/src/core/qgsvectorlayerjoinbuffer.h
+++ b/src/core/qgsvectorlayerjoinbuffer.h
@@ -49,6 +49,9 @@ class CORE_EXPORT QgsVectorLayerJoinBuffer
     /**Calls cacheJoinLayer() for all vector joins*/
     void createJoinCaches();
 
+    /**Updates the cache of a join pointing to a given (or any) layer*/
+    bool updateJoinCache(QString joinDestLayer="");
+
     /**Saves mVectorJoins to xml under the layer node*/
     void writeXml( QDomNode& layer_node, QDomDocument& document ) const;
 

--- a/src/core/symbology-ng/qgssymbollayerv2utils.cpp
+++ b/src/core/symbology-ng/qgssymbollayerv2utils.cpp
@@ -2557,6 +2557,39 @@ double QgsSymbolLayerV2Utils::lineWidthScaleFactor( const QgsRenderContext& c, Q
   else //QgsSymbol::MapUnit
   {
     double mup = c.mapToPixel().mapUnitsPerPixel();
+
+    // adjust the scale factor considering the native-to-target projection transform
+    // For layers in degrees, the translation uses 1 arcminute of latitude = 1 nautical mile = 1852m
+
+    const QgsCoordinateTransform * transform=c.coordinateTransform();
+    if(transform) {
+      switch(transform->sourceCrs().mapUnits())
+      {
+        case QGis::UnknownUnit: //assume degrees
+        case QGis::DecimalDegrees:
+          mup/=111120.;
+          break;
+        case QGis::Feet:
+          mup/=0.3048;
+          break;
+        case QGis::Meters:
+        default:;
+      }
+
+      switch(transform->destCRS().mapUnits())
+      {
+        case QGis::UnknownUnit: //assume degrees
+        case QGis::DecimalDegrees:
+          mup*=111120.;
+          break;
+        case QGis::Feet:
+          mup*=0.3048;
+          break;
+        case QGis::Meters:
+        default:;
+      }
+    }
+
     if ( mup > 0 )
     {
       return 1.0 / mup;


### PR DESCRIPTION
1/ Added join cache automatic update when joined table is filtered/altered: 
A filter applied on the join destination (usually a DB table or a csv) now imposes a refresh of the join cache in the source layer(s) such that all join caches are always kept up to date and syncro with the joined database filter.

2/ Corrected MapUnit behaviour accross projections: The sizes set with the option 'MapUnit' now adapt to the canvas projections according to the 'native' unit setting implied by the layer (in units of the layer CRS) and the unit of the rendering canvas CRS (which can be different when on-the-fly CRS transform are used). For instance, a line width set to 1 (degree) in a QGS84 layer will automatically translate to 60*1852m (60 nautical miles equivalent of one degree of latitude) when displayed on a polar stereo canvas. This becomes quite handy to always render identically regardless of the canvas projection.

Could you please review and eventually merge this code into the master?
(PS: i was a newbie to qgis a fortnight ago, so please beware of these first proposals, although intensively tested and (i suppose) in line with the project approach. btw, my compliments to the qgis team for this really nice and powerful product)
