### PR TITLE
MapUnit scale fix

### DIFF
--- a/src/core/symbology-ng/qgssymbollayerv2utils.cpp
+++ b/src/core/symbology-ng/qgssymbollayerv2utils.cpp
@@ -2557,6 +2557,39 @@ double QgsSymbolLayerV2Utils::lineWidthScaleFactor( const QgsRenderContext& c, Q
   else //QgsSymbol::MapUnit
   {
     double mup = c.mapToPixel().mapUnitsPerPixel();
+
+    // adjust the scale factor considering the native-to-target projection transform
+    // For layers in degrees, the translation uses 1 arcminute of latitude = 1 nautical mile = 1852m
+
+    const QgsCoordinateTransform * transform=c.coordinateTransform();
+    if(transform) {
+      switch(transform->sourceCrs().mapUnits())
+      {
+        case QGis::UnknownUnit: //assume degrees
+        case QGis::Degrees:
+          mup/=111120.;
+          break;
+        case QGis::Feet:
+          mup/=0.3048;
+          break;
+        case QGis::Meters:
+        default:;
+      }
+
+      switch(transform->destCRS().mapUnits())
+      {
+        case QGis::UnknownUnit: //assume degrees
+        case QGis::Degrees:
+          mup*=111120.;
+          break;
+        case QGis::Feet:
+          mup*=0.3048;
+          break;
+        case QGis::Meters:
+        default:;
+      }
+    }
+
     if ( mup > 0 )
     {
       return 1.0 / mup;


### PR DESCRIPTION
Corrected MapUnit behaviour accross projections: The sizes set with the
option 'MapUnit' now adapt to the canvas projections according to the
'native' unit setting implied by the layer (in units of the layer CRS)
and the unit of the rendering canvas CRS (which can be different when
on-the-fly CRS transform are used). For instance, a line width set to 1
(degree) in a QGS84 layer will automatically translate to 60*1852m (60
nautical miles equivalent of one degree of latitude) when displayed on
a polar stereo canvas. This becomes quite handy to always render
identically regardless of the canvas projection.

could you please review and merge into the master?
