### PR TITLE
Join cache refresh

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -6500,17 +6500,21 @@ void QgisApp::layerSubsetString()
     return;
 
   // launch the query builder
-  QgsQueryBuilder *qb = new QgsQueryBuilder( vlayer, this );
   QString subsetBefore = vlayer->subsetString();
+  QgsQueryBuilder *qb = new QgsQueryBuilder( vlayer, this );
 
   // Set the sql in the query builder to the same in the prop dialog
   // (in case the user has already changed it)
-  qb->setSql( vlayer->subsetString() );
+  qb->setSql( subsetBefore );
   // Open the query builder
   if ( qb->exec() )
   {
     if ( subsetBefore != qb->sql() )
     {
+
+      // refresh the join cache of depending layers
+      vlayer->refreshJointLayersCache();
+
       mMapCanvas->refresh();
       if ( mLayerTreeView )
       {

--- a/src/core/qgsmaplayerregistry.cpp
+++ b/src/core/qgsmaplayerregistry.cpp
@@ -18,6 +18,7 @@
 #include "qgsmaplayerregistry.h"
 #include "qgsmaplayer.h"
 #include "qgslogger.h"
+#include "qgsvectorlayer.h"
 
 //
 // Static calls to enforce singleton behaviour
@@ -153,6 +154,15 @@ void QgsMapLayerRegistry::removeAllMapLayers()
 
 void QgsMapLayerRegistry::clearAllLayerCaches()
 {
+  QMap<QString, QgsMapLayer *>::iterator it;
+  for ( it = mMapLayers.begin(); it != mMapLayers.end() ; ++it )
+  {
+    // clear the join caches
+    if ( it.value()->type() == QgsMapLayer::VectorLayer ) {
+      QgsVectorLayer* currentVectorLayer = dynamic_cast<QgsVectorLayer*>( it.value() );
+      currentVectorLayer->updateJoinCache();
+    }
+  }
 }
 
 void QgsMapLayerRegistry::reloadAllLayers()

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -2766,6 +2766,42 @@ void QgsVectorLayer::createJoinCaches()
   }
 }
 
+bool QgsVectorLayer::updateJoinCache(QString joinDestLayer)
+{
+  if ( ! mJoinBuffer ) { return false; }
+  return mJoinBuffer->updateJoinCache(joinDestLayer);
+}
+
+bool QgsVectorLayer::refreshJointLayersCache()
+{
+    // refresh the cache of the joins pointing to this layer
+
+    // track if we will update some
+    bool some_updated=false;
+
+    // loop on all other vector layers
+    const QMap< QString, QgsMapLayer * > & layerList=QgsMapLayerRegistry::instance()->mapLayers();
+    QMap<QString, QgsMapLayer*>::const_iterator it=layerList.constBegin();
+
+    for ( ; it != layerList.constEnd(); ++it )
+    {
+      QgsMapLayer* currentLayer = it.value();
+      if ( currentLayer->type() != QgsMapLayer::VectorLayer ) { continue; }
+      QgsVectorLayer* currentVectorLayer = dynamic_cast<QgsVectorLayer*>( currentLayer );
+      if ( ! currentVectorLayer || currentVectorLayer == this ) { continue; }
+
+      if ( currentVectorLayer->updateJoinCache(id()) )
+      {
+        some_updated=true;
+        // update it and recurse 
+        currentVectorLayer->updateFields();
+        currentVectorLayer->refreshJointLayersCache();
+      }
+    }
+
+    return some_updated;
+}
+
 void QgsVectorLayer::uniqueValues( int index, QList<QVariant> &uniqueValues, int limit )
 {
   uniqueValues.clear();

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -1397,6 +1397,12 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
       @note added in 1.7 */
     void createJoinCaches();
 
+    /** update the cache of a join pointing to a given (or any) layer*/
+    bool updateJoinCache(QString joinDestLayer="");
+
+    /** refresh the cache of the joins pointing to this layer*/
+    bool refreshJointLayersCache();
+
     /**Returns unique values for column
       @param index column index for attribute
       @param uniqueValues out: result list

--- a/src/core/qgsvectorlayerjoinbuffer.cpp
+++ b/src/core/qgsvectorlayerjoinbuffer.cpp
@@ -121,6 +121,22 @@ void QgsVectorLayerJoinBuffer::createJoinCaches()
   }
 }
 
+bool QgsVectorLayerJoinBuffer::updateJoinCache(QString joinDestLayer)
+{
+  bool updated=false;
+  QList< QgsVectorJoinInfo >::iterator joinIt = mVectorJoins.begin();
+
+  for ( ; joinIt != mVectorJoins.end(); ++joinIt )
+  {
+    if ( joinDestLayer == "" || joinDestLayer == joinIt->joinLayerId )
+    {
+      joinIt->cachedAttributes.clear();
+      cacheJoinLayer( *joinIt );
+      updated=true;
+    }
+  }
+  return updated;
+}
 
 void QgsVectorLayerJoinBuffer::writeXml( QDomNode& layer_node, QDomDocument& document ) const
 {

--- a/src/core/qgsvectorlayerjoinbuffer.h
+++ b/src/core/qgsvectorlayerjoinbuffer.h
@@ -49,6 +49,9 @@ class CORE_EXPORT QgsVectorLayerJoinBuffer
     /**Calls cacheJoinLayer() for all vector joins*/
     void createJoinCaches();
 
+     /**Updates the cache of a join pointing to a given (or any) layer*/
+    bool updateJoinCache(QString joinDestLayer="");
+
     /**Saves mVectorJoins to xml under the layer node*/
     void writeXml( QDomNode& layer_node, QDomDocument& document ) const;
 

--- a/src/gui/qgsquerybuilder.cpp
+++ b/src/gui/qgsquerybuilder.cpp
@@ -72,11 +72,15 @@ void QgsQueryBuilder::populateFields()
   const QgsFields& fields = mLayer->pendingFields();
   for ( int idx = 0; idx < fields.count(); ++idx )
   {
+    // skip if the field cannot be queried upon
+    if(! mLayer->setSubsetString(QString("%1 is NULL").arg(fields[idx].name()))) { continue; }
+
     QStandardItem *myItem = new QStandardItem( fields[idx].name() );
     myItem->setData( idx );
     myItem->setEditable( false );
     mModelFields->insertRow( mModelFields->rowCount(), myItem );
   }
+  mLayer->setSubsetString( mOrigSubsetString );
 
   // All fields get ... setup
   setupLstFieldsModel();


### PR DESCRIPTION
Added join cache automatic update when the joined table is filtered/altered: A filter applied on the join destination (usually a DB table or a csv) now refreshes the join cache in the source layer(s) so that all join caches are systematically kept up to date and syncro with the joined database(s).
A global refresh action (e.g. triggered from the view menu) also triggers a refresh of all Join caches.

thanks for reviewing for merge into master
