### PR TITLE
add LegendURL to Layers style section. substitutes pull request 767!

### DIFF
--- a/src/mapserver/qgsprojectparser.cpp
+++ b/src/mapserver/qgsprojectparser.cpp
@@ -756,7 +756,6 @@ void QgsProjectParser::addLayers( QDomDocument &doc,
       //Ex_GeographicBoundingBox
       appendLayerBoundingBoxes( layerElem, doc, currentLayer->extent(), currentLayer->crs() );
 
-
       //only one default style in project file mode
       QDomElement styleElem = doc.createElement( "Style" );
       QDomElement styleNameElem = doc.createElement( "Name" );

--- a/src/mapserver/qgsprojectparser.cpp
+++ b/src/mapserver/qgsprojectparser.cpp
@@ -813,7 +813,7 @@ void QgsProjectParser::addLayers( QDomDocument &doc,
           mapUrl.addQueryItem( "STYLE", styleNameText.data() );
           if ( version == "1.3.0" )
           {
-        	  mapUrl.addQueryItem( "SLD_VERSION", "1.1.1" );
+        	  mapUrl.addQueryItem( "SLD_VERSION", "1.1.0" );
           }
           hrefString = mapUrl.toString();
           QDomElement getLayerLegendGraphicORElem = doc.createElement( "OnlineResource" );


### PR DESCRIPTION
this commit substitutes pull request 767 (https://github.com/qgis/Quantum-GIS/pull/767) and adds a to each layer in STYLE to make QGIS mapserver work with clients reading GetLegend URLs directly from each LAYER. E.g. http://geoportal.bayern.de/bayernatlas
This format can also be seen on p. 42 of OGC 05-078r4 (http://www.opengeospatial.org/standards/sld SLD Version 1.1.0)

A great additional feature could be to make the URL alternatively configurable in QGIS project settings to link to a custom made URL (graphic).
