### PR TITLE
[QGIS server] add legendUrl to layers delivered by getCapa Doc. substitutes pull request 767 and 774!

### DIFF
--- a/src/app/qgsrasterlayerproperties.cpp
+++ b/src/app/qgsrasterlayerproperties.cpp
@@ -738,7 +738,7 @@ void QgsRasterLayerProperties::sync()
       mRasterLayer->dataUrlFormat()
     )
   );
-  //layer attribution and metadataUrl
+  //layer attribution metadataUrl and legendUrl
   mLayerAttributionLineEdit->setText( mRasterLayer->attribution() );
   mLayerAttributionUrlLineEdit->setText( mRasterLayer->attributionUrl() );
   mLayerMetadataUrlLineEdit->setText( mRasterLayer->metadataUrl() );
@@ -750,6 +750,12 @@ void QgsRasterLayerProperties::sync()
   mLayerMetadataUrlFormatComboBox->setCurrentIndex(
     mLayerMetadataUrlFormatComboBox->findText(
       mRasterLayer->metadataUrlFormat()
+    )
+  );
+  mLayerLegendUrlLineEdit->setText( mRasterLayer->legendUrl() );
+  mLayerLegendUrlFormatComboBox->setCurrentIndex(
+    mLayerLegendUrlFormatComboBox->findText(
+      mRasterLayer->legendUrlFormat()
     )
   );
 
@@ -920,12 +926,15 @@ void QgsRasterLayerProperties::apply()
   mRasterLayer->setKeywordList( mLayerKeywordListLineEdit->text() );
   mRasterLayer->setDataUrl( mLayerDataUrlLineEdit->text() );
   mRasterLayer->setDataUrlFormat( mLayerDataUrlFormatComboBox->currentText() );
-  //layer attribution and metadataUrl
+  //layer attribution metadataUrl and legendUrl
   mRasterLayer->setAttribution( mLayerAttributionLineEdit->text() );
   mRasterLayer->setAttributionUrl( mLayerAttributionUrlLineEdit->text() );
   mRasterLayer->setMetadataUrl( mLayerMetadataUrlLineEdit->text() );
   mRasterLayer->setMetadataUrlType( mLayerMetadataUrlTypeComboBox->currentText() );
   mRasterLayer->setMetadataUrlFormat( mLayerMetadataUrlFormatComboBox->currentText() );
+  mRasterLayer->setLegendUrl( mLayerLegendUrlLineEdit->text() );
+  mRasterLayer->setLegendUrlFormat( mLayerLegendUrlFormatComboBox->currentText() );
+
 
   // update symbology
   emit refreshLegend( mRasterLayer->id(), false );

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -248,7 +248,13 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
         layer->metadataUrlFormat()
       )
     );
-  }
+    mLayerLegendUrlLineEdit->setText( layer->legendUrl() );
+    mLayerLegendUrlFormatComboBox->setCurrentIndex(
+      mLayerLegendUrlFormatComboBox->findText(
+        layer->legendUrlFormat()
+      )
+    );
+}
 
   setWindowTitle( tr( "Layer Properties - %1" ).arg( layer->name() ) );
 
@@ -485,12 +491,14 @@ void QgsVectorLayerProperties::apply()
   layer->setKeywordList( mLayerKeywordListLineEdit->text() );
   layer->setDataUrl( mLayerDataUrlLineEdit->text() );
   layer->setDataUrlFormat( mLayerDataUrlFormatComboBox->currentText() );
-  //layer attribution and metadataUrl
+  //layer attribution metadataUrl and legendUrl
   layer->setAttribution( mLayerAttributionLineEdit->text() );
   layer->setAttributionUrl( mLayerAttributionUrlLineEdit->text() );
   layer->setMetadataUrl( mLayerMetadataUrlLineEdit->text() );
   layer->setMetadataUrlType( mLayerMetadataUrlTypeComboBox->currentText() );
   layer->setMetadataUrlFormat( mLayerMetadataUrlFormatComboBox->currentText() );
+  layer->setLegendUrl( mLayerLegendUrlLineEdit->text() );
+  layer->setLegendUrlFormat( mLayerLegendUrlFormatComboBox->currentText() );
 
   // update symbology
   emit refreshLegend( layer->id(), QgsLegendItem::DontChange );

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -395,6 +395,15 @@ bool QgsMapLayer::readLayerXML( const QDomElement& layerElement )
     mMetadataUrlFormat = metaUrlElem.attribute( "format", "" );
   }
 
+  //legendUrl
+  QDomElement legendUrlElem = layerElement.firstChildElement( "legendUrl" );
+  if ( !legendUrlElem.isNull() )
+  {
+    mLegendUrl = legendUrlElem.text();
+    mLegendUrlFormat = legendUrlElem.attribute( "format", "" );
+  }
+
+
 #if 0
   //read transparency level
   QDomNode transparencyNode = layer_node.namedItem( "transparencyLevelInt" );
@@ -542,6 +551,18 @@ bool QgsMapLayer::writeLayerXML( QDomElement& layerElement, QDomDocument& docume
     layerMetadataUrl.setAttribute( "format", metadataUrlFormat() );
     layerElement.appendChild( layerMetadataUrl );
   }
+
+  // layer legendUrl
+  QString aLegendUrl = legendUrl();
+  if ( !aLegendUrl.isEmpty() )
+  {
+    QDomElement layerLegendUrl = document.createElement( "legendUrl" ) ;
+    QDomText layerLegendUrlText = document.createTextNode( aLegendUrl );
+    layerLegendUrl.appendChild( layerLegendUrlText );
+    layerLegendUrl.setAttribute( "format", legendUrlFormat() );
+    layerElement.appendChild( layerLegendUrl );
+  }
+
 
   // timestamp if supported
   if ( timestamp() > QDateTime() )
@@ -1376,6 +1397,11 @@ void QgsMapLayer::clearCacheImage()
 }
 
 QString QgsMapLayer::metadata()
+{
+  return QString();
+}
+
+QString QgsMapLayer::legend()
 {
   return QString();
 }

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -119,6 +119,12 @@ class CORE_EXPORT QgsMapLayer : public QObject
     void setMetadataUrlFormat( const QString& metaUrlFormat ) { mMetadataUrlFormat = metaUrlFormat; }
     const QString& metadataUrlFormat() const { return mMetadataUrlFormat; }
 
+    /* Layer legendUrl information */
+    void setLegendUrl( const QString& legendUrl ) { mLegendUrl = legendUrl; }
+    const QString& legendUrl() const { return mLegendUrl; }
+    void setLegendUrlFormat( const QString& legendUrlFormat ) { mLegendUrlFormat = legendUrlFormat; }
+    const QString& legendUrlFormat() const { return mLegendUrlFormat; }
+
     /* Set the blending mode used for rendering a layer */
     void setBlendMode( const QPainter::CompositionMode blendMode );
     /* Returns the current blending mode for a layer */
@@ -397,6 +403,9 @@ class CORE_EXPORT QgsMapLayer : public QObject
     /** \brief Obtain Metadata for this layer */
     virtual QString metadata();
 
+    /** \brief Obtain Legend for this layer */
+    virtual QString legend();
+
     /** Time stamp of data source in the moment when data/metadata were loaded by provider */
     virtual QDateTime timestamp() const { return QDateTime() ; }
 
@@ -505,6 +514,10 @@ class CORE_EXPORT QgsMapLayer : public QObject
     QString mMetadataUrl;
     QString mMetadataUrlType;
     QString mMetadataUrlFormat;
+
+    /**MetadataUrl of the layer*/
+    QString mLegendUrl;
+    QString mLegendUrlFormat;
 
     /** \brief Error */
     QgsError mError;

--- a/src/mapserver/qgsprojectparser.cpp
+++ b/src/mapserver/qgsprojectparser.cpp
@@ -766,6 +766,70 @@ void QgsProjectParser::addLayers( QDomDocument &doc,
       styleTitleElem.appendChild( styleTitleText );
       styleElem.appendChild( styleNameElem );
       styleElem.appendChild( styleTitleElem );
+
+
+      // QString LegendURL for explicit layerbased GetLegendGraphic request
+      QDomElement getLayerLegendGraphicElem = doc.createElement( "LegendURL" );
+
+      // TODO: make configurable from GUI. Not yet implemented.
+      QString hrefString = currentLayer->legendUrl();
+      bool customHrefString;
+      if ( !hrefString.isEmpty() )
+      {
+        customHrefString = true;
+      }
+      else
+      {
+    	customHrefString = false;
+    	hrefString = serviceUrl();
+      }
+      if ( hrefString.isEmpty() )
+      {
+        hrefString = getCapaServiceUrl( doc );
+      }
+      if ( !hrefString.isEmpty() )
+      {
+        QStringList getLayerLegendGraphicFormats;
+        if ( customHrefString == false )
+        {
+          getLayerLegendGraphicFormats << "image/png"; // << "jpeg" << "image/jpeg"
+        }
+        else
+        {
+          getLayerLegendGraphicFormats << currentLayer->legendUrlFormat();
+        }
+        for ( int i = 0; i < getLayerLegendGraphicFormats.size(); ++i )
+        {
+          QDomElement getLayerLegendGraphicFormatElem = doc.createElement( "Format" );
+          QString getLayerLegendGraphicFormat = getLayerLegendGraphicFormats[i];
+          QDomText getLayerLegendGraphicFormatText = doc.createTextNode( getLayerLegendGraphicFormat );
+          getLayerLegendGraphicFormatElem.appendChild( getLayerLegendGraphicFormatText );
+          getLayerLegendGraphicElem.appendChild( getLayerLegendGraphicFormatElem );
+        }
+        // no parameters on custom hrefUrl, because should link directly to graphic
+        if ( customHrefString == false )
+        {
+          QUrl mapUrl( hrefString );
+          mapUrl.addQueryItem( "SERVICE", "WMS" );
+          mapUrl.addQueryItem( "VERSION", version );
+          mapUrl.addQueryItem( "REQUEST", "GetLegendGraphic" );
+          mapUrl.addQueryItem( "LAYER", currentLayer->name() );
+          mapUrl.addQueryItem( "FORMAT", "image/png" );
+          mapUrl.addQueryItem( "STYLE", styleNameText.data() );
+          if ( version == "1.3.0" )
+          {
+            mapUrl.addQueryItem( "SLD_VERSION", "1.1.0" );
+          }
+          hrefString = mapUrl.toString();
+        }
+        QDomElement getLayerLegendGraphicORElem = doc.createElement( "OnlineResource" );
+        getLayerLegendGraphicORElem.setAttribute( "xmlns:xlink", "http://www.w3.org/1999/xlink" );
+        getLayerLegendGraphicORElem.setAttribute( "xlink:type", "simple" );
+        getLayerLegendGraphicORElem.setAttribute( "xlink:href", hrefString );
+        getLayerLegendGraphicElem.appendChild( getLayerLegendGraphicORElem );
+        styleElem.appendChild( getLayerLegendGraphicElem );
+      }
+
       layerElem.appendChild( styleElem );
 
       //min/max scale denominatormScaleBasedVisibility
@@ -891,16 +955,7 @@ void QgsProjectParser::addLayers( QDomDocument &doc,
         }
         if ( hrefString.isEmpty() )
         {
-          QDomNodeList getCapNodeList = doc.elementsByTagName( "GetCapabilities" );
-          if ( getCapNodeList.count() > 0 )
-          {
-            QDomElement getCapElem = getCapNodeList.at( 0 ).toElement();
-            QDomNodeList getCapORNodeList = getCapElem.elementsByTagName( "OnlineResource" );
-            if ( getCapORNodeList.count() > 0 )
-            {
-              hrefString = getCapORNodeList.at( 0 ).toElement().attribute( "xlink:href", "" );
-            }
-          }
+          hrefString = getCapaServiceUrl( doc );
         }
         if ( !hrefString.isEmpty() )
         {
@@ -2748,6 +2803,23 @@ QString QgsProjectParser::serviceUrl() const
     }
   }
   return url;
+}
+
+QString QgsProjectParser::getCapaServiceUrl( QDomDocument &doc ) const
+{
+    QString url;
+    QDomNodeList getCapNodeList = doc.elementsByTagName( "GetCapabilities" );
+
+    if ( getCapNodeList.count() > 0 )
+    {
+    QDomElement getCapElem = getCapNodeList.at( 0 ).toElement();
+    QDomNodeList getCapORNodeList = getCapElem.elementsByTagName( "OnlineResource" );
+        if ( getCapORNodeList.count() > 0 )
+        {
+            url = getCapORNodeList.at( 0 ).toElement().attribute( "xlink:href", "" );
+        }
+    }
+    return url;
 }
 
 QString QgsProjectParser::wfsServiceUrl() const

--- a/src/mapserver/qgsprojectparser.h
+++ b/src/mapserver/qgsprojectparser.h
@@ -118,6 +118,8 @@ class QgsProjectParser: public QgsConfigParser
 
     QString serviceUrl() const;
 
+    QString getCapaServiceUrl( QDomDocument& doc ) const;
+
     QString wfsServiceUrl() const;
 
     /**Returns the names of the published wfs layers (not the ids as in wfsLayers() )*/

--- a/src/ui/qgsrasterlayerpropertiesbase.ui
+++ b/src/ui/qgsrasterlayerpropertiesbase.ui
@@ -182,7 +182,7 @@
           </sizepolicy>
          </property>
          <property name="currentIndex">
-          <number>0</number>
+          <number>5</number>
          </property>
          <widget class="QWidget" name="mOptsPage_General">
           <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -212,8 +212,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>693</width>
-                <height>646</height>
+                <width>700</width>
+                <height>663</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_7">
@@ -379,11 +379,11 @@
                   <string notr="true">rastergeneral</string>
                  </property>
                  <layout class="QGridLayout" name="_5">
-                  <property name="verticalSpacing">
-                   <number>6</number>
-                  </property>
                   <property name="margin">
                    <number>11</number>
+                  </property>
+                  <property name="verticalSpacing">
+                   <number>6</number>
                   </property>
                   <item row="0" column="4">
                    <widget class="QLabel" name="textLabel1_2_2_2">
@@ -683,8 +683,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>610</width>
-                <height>360</height>
+                <width>700</width>
+                <height>663</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_13">
@@ -1198,8 +1198,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>472</width>
-                <height>439</height>
+                <width>700</width>
+                <height>663</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_5">
@@ -1615,8 +1615,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>632</width>
-                <height>199</height>
+                <width>700</width>
+                <height>663</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_12">
@@ -1679,8 +1679,8 @@
                        <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Lucida Grande'; font-size:13pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Cantarell'; font-size:11pt;&quot;&gt;&lt;br /&gt;&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Cantarell';&quot;&gt;&lt;br /&gt;&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                       </property>
                      </widget>
                     </item>
@@ -1786,8 +1786,8 @@ p, li { white-space: pre-wrap; }
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>98</width>
-                <height>31</height>
+                <width>700</width>
+                <height>663</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_16">
@@ -1846,8 +1846,8 @@ p, li { white-space: pre-wrap; }
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>195</width>
-                <height>267</height>
+                <width>700</width>
+                <height>663</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_10">
@@ -1954,52 +1954,52 @@ p, li { white-space: pre-wrap; }
                   <string notr="true">vectormeta</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_7">
-                 <item row="0" column="0">
-                  <widget class="QLabel" name="mLayerAttributionLabel">
-                   <property name="text">
-                    <string>Title</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="1">
-                  <widget class="QLineEdit" name="mLayerAttributionLineEdit"/>
-                 </item>
-                 <item row="2" column="0">
-                  <widget class="QLabel" name="mLayerAttributionUrlLabel">
-                   <property name="text">
-                    <string>Url</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="2" column="1">
-                  <widget class="QLineEdit" name="mLayerAttributionUrlLineEdit"/>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-              <item>
-               <widget class="QgsCollapsibleGroupBox" name="mMetaMetaUrlGrpBx">
-                <property name="title">
-                 <string>MetadataUrl</string>
-                </property>
-                <property name="syncGroup" stdset="0">
-                 <string notr="true">vectormeta</string>
-                </property>
-                <layout class="QGridLayout" name="gridLayout_9">
-                 <item row="0" column="0">
-                  <widget class="QLabel" name="mLayerMetadataUrlLabel">
-                   <property name="text">
-                    <string>Url</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="1">
-                  <widget class="QLineEdit" name="mLayerMetadataUrlLineEdit"/>
-                 </item>
-                 <item row="1" column="1">
-                  <layout class="QHBoxLayout" name="horizontalLayout_8">
-                   <item>
-                    <widget class="QLabel" name="mLayerMetadataUrlTypeLabel">
+                  <item row="0" column="0">
+                   <widget class="QLabel" name="mLayerAttributionLabel">
+                    <property name="text">
+                     <string>Title</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="1">
+                   <widget class="QLineEdit" name="mLayerAttributionLineEdit"/>
+                  </item>
+                  <item row="2" column="0">
+                   <widget class="QLabel" name="mLayerAttributionUrlLabel">
+                    <property name="text">
+                     <string>Url</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="1">
+                   <widget class="QLineEdit" name="mLayerAttributionUrlLineEdit"/>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QgsCollapsibleGroupBox" name="mMetaMetaUrlGrpBx">
+                 <property name="title">
+                  <string>MetadataUrl</string>
+                 </property>
+                 <property name="syncGroup" stdset="0">
+                  <string notr="true">vectormeta</string>
+                 </property>
+                 <layout class="QGridLayout" name="gridLayout_9">
+                  <item row="0" column="0">
+                   <widget class="QLabel" name="mLayerMetadataUrlLabel">
+                    <property name="text">
+                     <string>Url</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="1">
+                   <widget class="QLineEdit" name="mLayerMetadataUrlLineEdit"/>
+                  </item>
+                  <item row="1" column="1">
+                   <layout class="QHBoxLayout" name="horizontalLayout_8">
+                    <item>
+                     <widget class="QLabel" name="mLayerMetadataUrlTypeLabel">
                       <property name="text">
                        <string>Type</string>
                       </property>
@@ -2009,7 +2009,7 @@ p, li { white-space: pre-wrap; }
                      <widget class="QComboBox" name="mLayerMetadataUrlTypeComboBox">
                       <item>
                        <property name="text">
-                        <string notr="true"></string>
+                        <string notr="true"/>
                        </property>
                       </item>
                       <item>
@@ -2035,7 +2035,7 @@ p, li { white-space: pre-wrap; }
                      <widget class="QComboBox" name="mLayerMetadataUrlFormatComboBox">
                       <item>
                        <property name="text">
-                        <string notr="true"></string>
+                        <string notr="true"/>
                        </property>
                       </item>
                       <item>
@@ -2062,6 +2062,64 @@ p, li { white-space: pre-wrap; }
                        </size>
                       </property>
                      </spacer>
+                    </item>
+                   </layout>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QgsCollapsibleGroupBox" name="mMetaLegendGrpBx">
+                 <property name="title">
+                  <string>LegendUrl</string>
+                 </property>
+                 <layout class="QGridLayout" name="gridLayout_2">
+                  <item row="0" column="0">
+                   <layout class="QHBoxLayout" name="horizontalLayout_11">
+                    <item>
+                     <widget class="QLabel" name="mLayerLegendUrlLabel">
+                      <property name="text">
+                       <string>Url</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QLineEdit" name="mLayerLegendUrlLineEdit"/>
+                    </item>
+                    <item>
+                     <widget class="QLabel" name="mLayerLegendUrlFormatLabel">
+                      <property name="text">
+                       <string>Format</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QComboBox" name="mLayerLegendUrlFormatComboBox">
+                      <property name="minimumSize">
+                       <size>
+                        <width>137</width>
+                        <height>0</height>
+                       </size>
+                      </property>
+                      <property name="currentIndex">
+                       <number>0</number>
+                      </property>
+                      <item>
+                       <property name="text">
+                        <string>image/png</string>
+                       </property>
+                      </item>
+                      <item>
+                       <property name="text">
+                        <string>image/jpeg</string>
+                       </property>
+                      </item>
+                      <item>
+                       <property name="text">
+                        <string>image/jpg</string>
+                       </property>
+                      </item>
+                     </widget>
                     </item>
                    </layout>
                   </item>

--- a/src/ui/qgsvectorlayerpropertiesbase.ui
+++ b/src/ui/qgsvectorlayerpropertiesbase.ui
@@ -234,7 +234,7 @@
           </sizepolicy>
          </property>
          <property name="currentIndex">
-          <number>0</number>
+          <number>9</number>
          </property>
          <widget class="QWidget" name="mOptsPage_General">
           <layout class="QVBoxLayout" name="verticalLayout_14">
@@ -264,8 +264,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>793</width>
-                <height>784</height>
+                <width>401</width>
+                <height>525</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_13">
@@ -703,8 +703,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>793</width>
-                <height>784</height>
+                <width>100</width>
+                <height>30</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_18">
@@ -797,8 +797,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>793</width>
-                <height>784</height>
+                <width>121</width>
+                <height>38</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_28">
@@ -871,8 +871,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>793</width>
-                <height>784</height>
+                <width>100</width>
+                <height>30</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_20">
@@ -923,8 +923,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>793</width>
-                <height>784</height>
+                <width>476</width>
+                <height>182</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_26">
@@ -1094,8 +1094,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>793</width>
-                <height>784</height>
+                <width>100</width>
+                <height>30</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_21">
@@ -1152,8 +1152,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>793</width>
-                <height>784</height>
+                <width>116</width>
+                <height>149</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_23">
@@ -1264,8 +1264,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>793</width>
-                <height>784</height>
+                <width>100</width>
+                <height>30</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_24">
@@ -1316,8 +1316,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>793</width>
-                <height>784</height>
+                <width>792</width>
+                <height>772</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_8">
@@ -1397,6 +1397,12 @@
                     </item>
                     <item>
                      <widget class="QComboBox" name="mLayerDataUrlFormatComboBox">
+                      <property name="minimumSize">
+                       <size>
+                        <width>137</width>
+                        <height>0</height>
+                       </size>
+                      </property>
                       <item>
                        <property name="text">
                         <string notr="true">text/html</string>
@@ -1483,7 +1489,7 @@
                      <widget class="QComboBox" name="mLayerMetadataUrlTypeComboBox">
                       <item>
                        <property name="text">
-                        <string notr="true"></string>
+                        <string notr="true"/>
                        </property>
                       </item>
                       <item>
@@ -1509,7 +1515,7 @@
                      <widget class="QComboBox" name="mLayerMetadataUrlFormatComboBox">
                       <item>
                        <property name="text">
-                        <string notr="true"></string>
+                        <string notr="true"/>
                        </property>
                       </item>
                       <item>
@@ -1543,6 +1549,64 @@
                 </widget>
                </item>
                <item>
+                <widget class="QgsCollapsibleGroupBox" name="mMetaLegendGrpBx">
+                 <property name="title">
+                  <string>LegendUrl</string>
+                 </property>
+                 <layout class="QGridLayout" name="gridLayout_2">
+                  <item row="0" column="0">
+                   <layout class="QHBoxLayout" name="horizontalLayout_2">
+                    <item>
+                     <widget class="QLabel" name="mLayerLegendUrlLabel">
+                      <property name="text">
+                       <string>Url</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QLineEdit" name="mLayerLegendUrlLineEdit"/>
+                    </item>
+                    <item>
+                     <widget class="QLabel" name="mLayerLegendUrlFormatLabel">
+                      <property name="text">
+                       <string>Format</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QComboBox" name="mLayerLegendUrlFormatComboBox">
+                      <property name="minimumSize">
+                       <size>
+                        <width>137</width>
+                        <height>0</height>
+                       </size>
+                      </property>
+                      <property name="currentIndex">
+                       <number>0</number>
+                      </property>
+                      <item>
+                       <property name="text">
+                        <string>image/png</string>
+                       </property>
+                      </item>
+                      <item>
+                       <property name="text">
+                        <string>image/jpeg</string>
+                       </property>
+                      </item>
+                      <item>
+                       <property name="text">
+                        <string>image/jpg</string>
+                       </property>
+                      </item>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
                 <widget class="QgsCollapsibleGroupBox" name="mMetaPropertiesGrpBx">
                  <property name="sizePolicy">
                   <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -1559,6 +1623,12 @@
                  <layout class="QVBoxLayout" name="verticalLayout_9">
                   <item>
                    <widget class="QTextEdit" name="teMetadata">
+                    <property name="minimumSize">
+                     <size>
+                      <width>0</width>
+                      <height>250</height>
+                     </size>
+                    </property>
                     <property name="lineWidth">
                      <number>2</number>
                     </property>


### PR DESCRIPTION
this commit adds legendUrl tags to the style section of a layer in the getCapa document.
It extends the layers metadata GUI in QGIs to make legendUrl customizable (linking to a
image url) providing the legend. If this is not set the Url is build from serviceUrl or main GetLegend
section of the getCapa doc.

this commit substitutes pull request 767 (#767) and adds a to each layer in STYLE to make QGIS mapserver work with clients reading GetLegend URLs directly from each LAYER. E.g. http://geoportal.bayern.de/bayernatlas
This format can also be seen on p. 42 of OGC 05-078r4 (http://www.opengeospatial.org/standards/sld SLD Version 1.1.0)
