### PR TITLE
Use ST_Force2D for PostGIS 2.1+

### DIFF
--- a/src/providers/postgres/qgspostgresfeatureiterator.cpp
+++ b/src/providers/postgres/qgspostgresfeatureiterator.cpp
@@ -270,7 +270,9 @@ bool QgsPostgresFeatureIterator::declareCursor( const QString& whereClause )
     {
       query += QString( "%1(%2(%3%4),'%5')" )
                .arg( P->mConnectionRO->majorVersion() < 2 ? "asbinary" : "st_asbinary" )
-               .arg( P->mConnectionRO->majorVersion() < 2 ? "force_2d" : "st_force_2d" )
+               .arg( P->mConnectionRO->majorVersion() < 2 ? "force_2d"
+                   : P->mConnectionRO->majorVersion() > 2 || P->mConnectionRO->minorVersion() > 0 ? "ST_Force2D"
+                   : "st_force_2d" )
                .arg( P->quotedIdentifier( P->mGeometryColumn ) )
                .arg( P->mSpatialColType == sctGeography ? "::geometry" : "" )
                .arg( P->endianString() );


### PR DESCRIPTION
This is to avoid the WARNING about ST_Force_2D being deprecated when using PostGIS-2.1.0+.
