### PR TITLE
Call QCoreApplication.processEvents() after writing to Python console. Fixes #8343.

### DIFF
--- a/python/console/console_output.py
+++ b/python/console/console_output.py
@@ -52,6 +52,7 @@ class writeOut:
             self.out.write(m)
 
         self.move_cursor_to_end()
+        QCoreApplication.processEvents()
 
     def move_cursor_to_end(self):
         """Move cursor to end of text"""


### PR DESCRIPTION
This enables incremental output from Python code run in the Python console - currently the user has to wait until the function terminates before seeing any output, so he or she can't see progress indications, etc.
