### PR TITLE
fix list unique value tool: skip QPyNullVariant

### DIFF
--- a/python/plugins/fTools/tools/doVisual.py
+++ b/python/plugins/fTools/tools/doVisual.py
@@ -245,8 +245,9 @@ class visualThread( QThread ):
     for item in unique:
       nElement += 1
       self.emit( SIGNAL( "runStatus(PyQt_PyObject)" ), nElement )
-      lstUnique.append(unicode(item).strip())
-    lstCount = len( unique )
+      if item:
+        lstUnique.append(unicode(item).strip())
+    lstCount = len( lstUnique )
     return ( lstUnique, lstCount )
 
   def basic_statistics( self, vlayer, myField ):


### PR DESCRIPTION
If you use 'List unique values' tool on a layer with some NULL attribute values you'll get:
![qpynullvariant](https://f.cloud.github.com/assets/1374682/903384/13fe5ef0-fbaa-11e2-8ea4-fdd95f4fe86c.png)
