### PR TITLE
fix split vector layer tool (QPyNullVariant again!)

### DIFF
--- a/python/plugins/fTools/tools/doVectorSplit.py
+++ b/python/plugins/fTools/tools/doVectorSplit.py
@@ -172,6 +172,8 @@ class SplitThread(QThread):
 
 
         for i in unique:
+            if type(i) == QPyNullVariant:
+                i = u'NULL'
             check = QFile(baseName + "_" + unicode(i).strip() + ".shp")
             fName = check.fileName()
             if check.exists():
@@ -184,7 +186,7 @@ class SplitThread(QThread):
             fit = provider.getFeatures()
             while fit.nextFeature(inFeat):
                 atMap = inFeat.attributes()
-                if atMap[index] == i:
+                if atMap[index] == i or (not atMap[index] and i == u'NULL'):
                     writer.addFeature(inFeat)
             del writer
 


### PR DESCRIPTION
I am seeing something strange with `QPyNullVariant` by using some fTools tool. if there is a `NULL` value in attribute table `QgsFeature::attributeMap()` returns `None`  so some tool may not work as expected, while in 1.8 it returns an empty `QString` and the tool works properly also with `NULL` value.

This patch allows to write a feature even when some attribute value is `NULL` (or `QPyNullVariant`).

I am no sure if it is correct, but I had to insert a check on `atMap[index]`, which returns `None` if the value is `NULL`, to add the feature to `QgsVectorFileWriter`

Maybe I am wrong, but we have to find a way to fix this in core, is it possible ?
