### PR TITLE
Fix for issue #8407 - Allow selecting between file or directory when using a File Parameter in the modeler

### DIFF
--- a/python/plugins/sextante/modeler/ModelerParameterDefinitionDialog.py
+++ b/python/plugins/sextante/modeler/ModelerParameterDefinitionDialog.py
@@ -204,9 +204,10 @@ class ModelerParameterDefinitionDialog(QtGui.QDialog):
             self.fileFolderCombo = QtGui.QComboBox()
             self.fileFolderCombo.addItem("File")
             self.fileFolderCombo.addItem("Folder")
-            self.horizontalLayout2.addWidget(self.fileFolderCombo)
             if self.param is not None:
                 self.fileFolderCombo.setCurrentIndex(1 if self.param.isFolder else 0)
+            self.horizontalLayout2.addWidget(self.fileFolderCombo)
+            self.verticalLayout.addLayout(self.horizontalLayout2)
 
         self.buttonBox = QtGui.QDialogButtonBox(self)
         self.buttonBox.setOrientation(QtCore.Qt.Horizontal)
@@ -268,7 +269,8 @@ class ModelerParameterDefinitionDialog(QtGui.QDialog):
         elif self.paramType == ModelerParameterDefinitionDialog.PARAMETER_EXTENT or isinstance(self.param, ParameterExtent):
             self.param = ParameterExtent(name, description)
         elif self.paramType == ModelerParameterDefinitionDialog.PARAMETER_FILE or isinstance(self.param, ParameterFile):
-            self.param = ParameterFile(name, description)
+            isFolder = self.fileFolderCombo.currentIndex() == 1
+            self.param = ParameterFile(name, description, isFolder=isFolder)
         self.close()
 
     def cancelPressed(self):


### PR DESCRIPTION
This pull request adds the possibility to use File Parameters in Sextante modeler with either file or folder behaviours.
The code was already half done, I've just finished it in a similar way as the other parameters.
