### PR TITLE
Sextante - Replace ParameterBoolean GUI widget with a QCheckBox instead of QComboBox

### DIFF
--- a/python/plugins/sextante/gui/AlgorithmExecutionDialog.py
+++ b/python/plugins/sextante/gui/AlgorithmExecutionDialog.py
@@ -163,7 +163,7 @@ class AlgorithmExecutionDialog(QtGui.QDialog):
             except:
                 return param.setValue(widget.getValue())
         elif isinstance(param, ParameterBoolean):
-            return param.setValue(widget.currentIndex() == 0)
+            return param.setValue(widget.isChecked())
         elif isinstance(param, ParameterSelection):
             return param.setValue(widget.currentIndex())
         elif isinstance(param, ParameterFixedTable):

--- a/python/plugins/sextante/gui/ParametersPanel.py
+++ b/python/plugins/sextante/gui/ParametersPanel.py
@@ -115,8 +115,6 @@ class ParametersPanel(QtGui.QWidget):
                 desc = param.description
                 if isinstance(param, ParameterExtent):
                     desc += "(xmin, xmax, ymin, ymax)"
-                label = QtGui.QLabel(desc)
-                self.labels[param.name] = label
                 widget = self.getWidgetFromParameter(param)
                 self.valueItems[param.name] = widget
                 if isinstance(param, ParameterVector) and not self.alg.allowOnlyOpenedLayers:
@@ -140,13 +138,21 @@ class ParametersPanel(QtGui.QWidget):
                     tooltip = tooltips[param.name]
                 else:
                     tooltip = param.description
-                label.setToolTip(tooltip)
                 widget.setToolTip(tooltip)
-                if param.isAdvanced:
-                    label.setVisible(self.showAdvanced)
-                    widget.setVisible(self.showAdvanced)
-                    self.widgets[param.name] = widget
-                self.verticalLayout.addWidget(label)
+                if isinstance(param, ParameterBoolean):
+                    widget.setText(desc)
+                    if param.isAdvanced:
+                        widget.setVisible(self.showAdvanced)
+                        self.widgets[param.name] = widget
+                else:
+                    label = QtGui.QLabel(desc)
+                    self.labels[param.name] = label
+                    label.setToolTip(tooltip)
+                    if param.isAdvanced:
+                        label.setVisible(self.showAdvanced)
+                        widget.setVisible(self.showAdvanced)
+                        self.widgets[param.name] = widget
+                    self.verticalLayout.addWidget(label)
                 self.verticalLayout.addWidget(widget)
 
             for output in self.alg.outputs:
@@ -238,13 +244,11 @@ class ParametersPanel(QtGui.QWidget):
                     items.append((layer.name(), layer))
                 item = InputLayerSelectorPanel(items)
         elif isinstance(param, ParameterBoolean):
-            item = QtGui.QComboBox()
-            item.addItem("Yes")
-            item.addItem("No")
+            item = QtGui.QCheckBox()
             if param.default:
-                item.setCurrentIndex(0)
+                item.setChecked(True)
             else:
-                item.setCurrentIndex(1)
+                item.setChecked(False)
         elif isinstance(param, ParameterTableField):
             item = QtGui.QComboBox()
             if param.parent in self.dependentItems:


### PR DESCRIPTION
This pull request changes the widget used in ParameterBoolean for GeoAlgorithms. The widget is now a QCheckBox instead of the previously used QComboBox.

_Current ParameterBoolean  widget example (widget for 'dissolve result' parameter)_
![qcombobox_boolean](https://f.cloud.github.com/assets/732010/906907/3688d432-fcf4-11e2-8208-a2cc655a150c.png)

_New ParameterBoolean widget example (widget for 'dissolve result' parameter)_
![qcheckbox_boolean](https://f.cloud.github.com/assets/732010/906908/3686462c-fcf4-11e2-9557-33c4e3a9e69e.png)

In my opinion, this widget presents the following advantages over the previous one:
- It is better suited to the range of values (0, 1) available in the boolean type
- The GUI becomes less cluttered
- The user only needs one click in order to toggle the values, as opposed to two clicks using the QComboBox widget

Please note that this change does not affect the building of models. When creating a model it would not be possible to use a QCheckBox, because there is the possibility to add a ParameterBoolean to the model itself and then connect it to the algorithm. In this case the QComboBox is still used, as there may be several choices available. 
