### PR TITLE
Fix bounding box calculation for features with NULL geometry (fixes #8192, #8194)

### DIFF
--- a/src/core/qgsgeometry.cpp
+++ b/src/core/qgsgeometry.cpp
@@ -3607,7 +3607,10 @@ QgsRectangle QgsGeometry::boundingBox()
   if ( !mGeometry )
   {
     QgsDebugMsg( "WKB geometry not available!" );
-    return QgsRectangle( 0, 0, 0, 0 );
+    // Return minimal QgsRectangle
+    QgsRectangle invalidRect;
+    invalidRect.setMinimal();
+    return invalidRect;
   }
 
   // consider endian when fetching feature type

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -1161,7 +1161,7 @@ QgsRectangle QgsVectorLayer::extent()
     QgsFeature fet;
     while ( fit.nextFeature( fet ) )
     {
-      if ( fet.geometry() )
+      if ( fet.geometry() && fet.geometry()->type() != QGis::UnknownGeometry )
       {
         QgsRectangle bb = fet.geometry()->boundingBox();
         rect.combineExtentWith( &bb );


### PR DESCRIPTION
For features with NULL geometry, 
qgsvectorlayer.cpp:1166:
 fet.geometry->boundingBox() 

is returning QgsRectangle(0,0,0,0). Combining this extent causes the bounding box min x and y to be set incorrectly to 0. 

Instead, features with no geometry should not be considered when calculating the layer extent. I'm not sure that fet.geometry()->type() != QGis::UnknownGeometry is the best way to test for NULL geometry - please let me know if there's a better way and I'll update the request.

I've also changed the behaviour of QgsGeometry::boundingBox() to return a minimal QgsRectangle when no geometry is available, since it's possible that a valid point feature at 0,0 would have a bounding box of (0,0,0,0).
