### PR TITLE
Changes str.format() to (%s) % (str): fix for non-ascii chars

### DIFF
--- a/python/console/console.py
+++ b/python/console/console.py
@@ -641,8 +641,8 @@ class PythonConsoleWidget(QWidget):
         except (IOError, OSError), error:
             errTr = QCoreApplication.translate("PythonConsole", "Save Error")
             msgText = QCoreApplication.translate('PythonConsole',
-                                                 'The file <b>{0}</b> could not be saved. Error: {1}'.format(unicode(tabWidget.path),
-                                                                                                           error.strerror))
+                                                 'The file <b>%s</b> could not be saved. Error: %s') % (unicode(tabWidget.path),
+                                                                                                        error.strerror)
             self.callWidgetMessageBarEditor(msgText, 2, False)
 
     def saveAsScriptFile(self, index=-1):
@@ -668,8 +668,8 @@ class PythonConsoleWidget(QWidget):
             except (IOError, OSError), error:
                 errTr = QCoreApplication.translate("PythonConsole", "Save Error")
                 msgText = QCoreApplication.translate('PythonConsole',
-                                                     'The file <b>{0}</b> could not be saved. Error: {1}'.format(unicode(tabWidget.path),
-                                                                                                            error.strerror))
+                                                     'The file <b>%s</b> could not be saved. Error: %s') % (unicode(tabWidget.path),
+                                                                                                            error.strerror)
                 self.callWidgetMessageBarEditor(msgText, 2, False)
                 if fileNone:
                     tabWidget.path = None

--- a/python/console/console_compile_apis.py
+++ b/python/console/console_compile_apis.py
@@ -66,7 +66,7 @@ class PrepareAPIDialog(QDialog):
         rslt = self.trUtf8("Error")
         if prepd:
             rslt = QCoreApplication.translate("PythonConsole","Saved")
-        self.ui.label.setText('{0} {1}'.format(self.ui.label.text(), rslt))
+        self.ui.label.setText(u'{0} {1}'.format(self.ui.label.text(), rslt))
         self._api = None
         self.ui.progressBar.setVisible(False)
         self.ui.buttonBox.button(QDialogButtonBox.Cancel).setText(
@@ -75,7 +75,7 @@ class PrepareAPIDialog(QDialog):
 
     def prepareAPI(self):
 #        self.ui.textEdit_Qsci.setLexer(0)
-        exec 'self.qlexer = {0}(self.ui.textEdit_Qsci)'.format(self._api_lexer)
+        exec u'self.qlexer = {0}(self.ui.textEdit_Qsci)'.format(self._api_lexer)
 #        self.ui.textEdit_Qsci.setLexer(self.qlexer)
         self._api = QsciAPIs(self.qlexer)
         self._api.apiPreparationFinished.connect(self._preparationFinished)

--- a/python/console/console_editor.py
+++ b/python/console/console_editor.py
@@ -400,7 +400,7 @@ class Editor(QsciScintilla):
                 styleError = 'QLineEdit {background-color: #d65253; \
                                         color: #ffffff;}'
                 msgText = QCoreApplication.translate('PythonConsole',
-                                                     '<b>"{0}"</b> was not found.'.format(text))
+                                                     '<b>"%s"</b> was not found.') % (text)
                 self.parent.pc.callWidgetMessageBarEditor(msgText, 0, True)
             else:
                 styleError = ''
@@ -522,17 +522,17 @@ class Editor(QsciScintilla):
                         else:
                             raise e
             if tmp:
-                tmpFileTr = QCoreApplication.translate('PythonConsole', ' [Temporary file saved in {0}]'.format(dir))
+                tmpFileTr = QCoreApplication.translate('PythonConsole', ' [Temporary file saved in %s]') % (unicode(dir))
                 file = file + tmpFileTr
             if _traceback:
-                msgTraceTr = QCoreApplication.translate('PythonConsole', '## Script error: {0}'.format(file))
+                msgTraceTr = QCoreApplication.translate('PythonConsole', '## Script error: %s') % (unicode(file))
                 print "## %s" % datetime.datetime.now()
                 print unicode(msgTraceTr)
                 sys.stderr.write(_traceback)
                 p.stderr.close()
             else:
                 msgSuccessTr = QCoreApplication.translate('PythonConsole',
-                                                          '## Script executed successfully: {0}'.format(file))
+                                                          '## Script executed successfully: %s') % (unicode(file))
                 print "## %s" % datetime.datetime.now()
                 print unicode(msgSuccessTr)
                 sys.stdout.write(out)
@@ -542,7 +542,7 @@ class Editor(QsciScintilla):
                 os.remove(filename)
         except IOError, error:
             IOErrorTr = QCoreApplication.translate('PythonConsole',
-                                                   'Cannot execute file {0}. Error: {1}\n'.format(unicode(filename), error.strerror))
+                                                   'Cannot execute file %s. Error: %s\n') % (unicode(filename), error.strerror)
             print '## Error: ' + IOErrorTr
         except:
             s = traceback.format_exc()
@@ -575,7 +575,7 @@ class Editor(QsciScintilla):
                 tmpFile = self.createTempFile()
                 filename = tmpFile
 
-            self.parent.pc.shell.runCommand("execfile(r'{0}')".format(filename))
+            self.parent.pc.shell.runCommand("execfile(r'%s')") % (unicode(filename))
 
     def runSelectedCode(self):
         cmd = self.selectedText()
@@ -690,7 +690,7 @@ class Editor(QsciScintilla):
         if pathfile:
             if not QFileInfo(pathfile).exists():
                 msgText = QCoreApplication.translate('PythonConsole',
-                                                     'The file <b>"{0}"</b> has been deleted or is not accessible'.format(unicode(pathfile)))
+                                                     'The file <b>"%s"</b> has been deleted or is not accessible') % (unicode(pathfile))
                 self.parent.pc.callWidgetMessageBarEditor(msgText, 2, False)
                 return
         if pathfile and self.lastModified != QFileInfo(pathfile).lastModified():
@@ -711,14 +711,14 @@ class Editor(QsciScintilla):
             self.parent.tw.listObject(self.parent.tw.currentWidget())
             self.lastModified = QFileInfo(pathfile).lastModified()
             msgText = QCoreApplication.translate('PythonConsole',
-                                                 'The file <b>"{0}"</b> has been changed and reloaded'.format(unicode(pathfile)))
+                                                 'The file <b>"%s"</b> has been changed and reloaded') % (unicode(pathfile))
             self.parent.pc.callWidgetMessageBarEditor(msgText, 1, False)
         QsciScintilla.focusInEvent(self, e)
 
     def fileReadOnly(self):
         tabWidget = self.parent.tw.currentWidget()
         msgText = QCoreApplication.translate('PythonConsole',
-                                             'The file <b>"{0}"</b> is read only, please save to different file first.'.format(unicode(tabWidget.path)))
+                                             'The file <b>"%s"</b> is read only, please save to different file first.') % (unicode(tabWidget.path))
         self.parent.pc.callWidgetMessageBarEditor(msgText, 1, False)
 
 class EditorTab(QWidget):
@@ -1012,14 +1012,14 @@ class EditorTabWidget(QTabWidget):
                 fn.close()
             except IOError, error:
                 IOErrorTr = QCoreApplication.translate('PythonConsole',
-                                                       'The file {0} could not be opened. Error: {1}\n'.format(unicode(filename), error.strerror))
+                                                       'The file %s could not be opened. Error: %s\n') % (unicode(filename), error.strerror)
                 print '## Error: '
                 sys.stderr.write(IOErrorTr)
                 return
 
         nr = self.count()
         if not tabName:
-            tabName = QCoreApplication.translate('PythonConsole', 'Untitled-{0}'.format(nr))
+            tabName = QCoreApplication.translate('PythonConsole', 'Untitled-%s') % (nr)
         self.tab = EditorTab(self, self.parent, filename, readOnly)
         self.iconTab = QgsApplication.getThemeIcon('console/iconTabEditorConsole.png')
         self.addTab(self.tab, self.iconTab, tabName + ' (ro)' if readOnly else tabName)
@@ -1054,7 +1054,7 @@ class EditorTabWidget(QTabWidget):
             txtSaveOnRemove = QCoreApplication.translate("PythonConsole",
                                                          "Python Console: Save File")
             txtMsgSaveOnRemove = QCoreApplication.translate("PythonConsole",
-                                                            "The file <b>'{0}'</b> has been modified, save changes?".format(self.tabText(tab)))
+                                                            "The file <b>'%s'</b> has been modified, save changes?") % (unicode(self.tabText(tab)))
             res = QMessageBox.question( self, txtSaveOnRemove,
                                         txtMsgSaveOnRemove,
                                         QMessageBox.Save | QMessageBox.Discard | QMessageBox.Cancel )
@@ -1098,7 +1098,7 @@ class EditorTabWidget(QTabWidget):
                 self.newTabEditor(tabName, pathFile)
             else:
                 errOnRestore = QCoreApplication.translate("PythonConsole",
-                                                          "Unable to restore the file: \n{0}\n".format(unicode(pathFile)))
+                                                          "Unable to restore the file: \n%s\n") % unicode(pathFile)
                 print  '## Error: '
                 s = errOnRestore
                 sys.stderr.write(s)

--- a/python/console/console_output.py
+++ b/python/console/console_output.py
@@ -134,8 +134,8 @@ class ShellOutputScintilla(QsciScintilla):
 
     def insertInitText(self):
         txtInit = QCoreApplication.translate("PythonConsole",
-                                             "Python {0} on {1}\n"
-                                             "## Type help(iface) for more info and list of methods.\n".format(sys.version,  socket.gethostname()))
+                                             "Python %s on %s\n"
+                                             "## Type help(iface) for more info and list of methods.\n") % (sys.version,  socket.gethostname())
         initText = self.setText(txtInit)
 
     def refreshLexerProperties(self):


### PR DESCRIPTION
I am aware this going to break the translation files, but it is necessary to avoid the `UnicodeEncodeError` if non ascii chars are used in path file or directory.
Changing `str.format()` to `u'str'.format()` works but it seems not applicable to `QCoreApplication.translate()`.

So, if someone knows any solution to avoid to break the translation file please let me know it !

Thanks!
