### PR TITLE
[fix #8395] Add a second rubber band in map tool capture 

### DIFF
--- a/src/app/qgsmaptooladdfeature.cpp
+++ b/src/app/qgsmaptooladdfeature.cpp
@@ -141,6 +141,8 @@ void QgsMapToolAddFeature::canvasReleaseEvent( QMouseEvent * e )
       mCanvas->refresh();
     }
   }
+
+  // LINE AND POLYGON CAPTURING
   else if ( mode() == CaptureLine || mode() == CapturePolygon )
   {
     //check we only use the line tool for line/multiline layers
@@ -181,8 +183,7 @@ void QgsMapToolAddFeature::canvasReleaseEvent( QMouseEvent * e )
     else if ( e->button() == Qt::RightButton )
     {
       // End of string
-
-      resetLastVertex();
+      deleteTempRubberBand();
 
       //lines: bail out if there are not at least two vertices
       if ( mode() == CaptureLine && size() < 2 )

--- a/src/app/qgsmaptooladdpart.cpp
+++ b/src/app/qgsmaptooladdpart.cpp
@@ -112,7 +112,7 @@ void QgsMapToolAddPart::canvasReleaseEvent( QMouseEvent * e )
       }
       else if ( e->button() != Qt::RightButton )
       {
-        resetLastVertex();
+        deleteTempRubberBand();
 
         return;
       }

--- a/src/app/qgsmaptooladdring.cpp
+++ b/src/app/qgsmaptooladdring.cpp
@@ -69,7 +69,7 @@ void QgsMapToolAddRing::canvasReleaseEvent( QMouseEvent * e )
   }
   else if ( e->button() == Qt::RightButton )
   {
-    resetLastVertex();
+    deleteTempRubberBand();
 
     closePolygon();
 

--- a/src/app/qgsmaptoolcapture.cpp
+++ b/src/app/qgsmaptoolcapture.cpp
@@ -36,6 +36,7 @@ QgsMapToolCapture::QgsMapToolCapture( QgsMapCanvas* canvas, enum CaptureMode too
     : QgsMapToolEdit( canvas )
     , mCaptureMode( tool )
     , mRubberBand( 0 )
+    , mTempRubberBand( 0 )
     , mValidator( 0 )
 {
   mCaptureModeFromLayer = tool == CaptureNone;
@@ -100,7 +101,6 @@ void QgsMapToolCapture::currentLayerChanged( QgsMapLayer *layer )
   }
 }
 
-
 void QgsMapToolCapture::canvasMoveEvent( QMouseEvent * e )
 {
   QgsPoint mapPoint;
@@ -120,10 +120,10 @@ void QgsMapToolCapture::canvasMoveEvent( QMouseEvent * e )
       mSnappingMarkers << m;
     }
 
-    if ( mCaptureMode != CapturePoint && mRubberBand && mCapturing )
+    if ( mCaptureMode != CapturePoint && mTempRubberBand && mCapturing )
     {
       mapPoint = snapPointFromResults( snapResults, e->pos() );
-      mRubberBand->movePoint( mapPoint );
+      mTempRubberBand->movePoint( mapPoint );
     }
   }
 } // mouseMoveEvent
@@ -180,7 +180,6 @@ int QgsMapToolCapture::nextPoint( const QPoint &p, QgsPoint &layerPoint, QgsPoin
   return 0;
 }
 
-
 int QgsMapToolCapture::addVertex( const QPoint &p )
 {
   QgsPoint layerPoint;
@@ -203,9 +202,27 @@ int QgsMapToolCapture::addVertex( const QPoint &p )
   {
     mRubberBand = createRubberBand( mCaptureMode == CapturePolygon ? QGis::Polygon : QGis::Line );
   }
-
   mRubberBand->addPoint( mapPoint );
   mCaptureList.append( layerPoint );
+
+  if ( !mTempRubberBand )
+  {
+    mTempRubberBand = createRubberBand( mCaptureMode == CapturePolygon ? QGis::Polygon : QGis::Line , true );
+  }
+  else{
+    mTempRubberBand->reset(CapturePolygon ? true : false);
+  }
+  if ( mCaptureMode == CaptureLine )
+  {
+    mTempRubberBand->addPoint( mapPoint );
+  }
+  else if ( mCaptureMode == CapturePolygon )
+  {
+    const QgsPoint *firstPoint = mRubberBand->getPoint( 0 , 0 );
+    mTempRubberBand->addPoint( *firstPoint );
+    mTempRubberBand->movePoint( mapPoint );
+    mTempRubberBand->addPoint( mapPoint );
+  }
 
   validateGeometry();
 
@@ -231,20 +248,6 @@ void QgsMapToolCapture::undo()
   }
 }
 
-void QgsMapToolCapture::resetLastVertex()
-{
-  if ( mRubberBand )
-  {
-    int rubberBandSize = mRubberBand->numberOfVertices();
-    if ( rubberBandSize < 2 )
-    {
-      return;
-    }
-    const QgsPoint *lastPoint = mRubberBand->getPoint(0, rubberBandSize-2);
-    mRubberBand->movePoint( *lastPoint );
-  }
-}
-
 void QgsMapToolCapture::keyPressEvent( QKeyEvent* e )
 {
   if ( e->key() == Qt::Key_Backspace || e->key() == Qt::Key_Delete )
@@ -266,6 +269,12 @@ void QgsMapToolCapture::stopCapturing()
     mRubberBand = 0;
   }
 
+  if ( mTempRubberBand )
+  {
+    delete mTempRubberBand;
+    mTempRubberBand = 0;
+  }
+
   while ( !mGeomErrorMarkers.isEmpty() )
   {
     delete mGeomErrorMarkers.takeFirst();
@@ -281,6 +290,15 @@ void QgsMapToolCapture::stopCapturing()
   mCapturing = false;
   mCaptureList.clear();
   mCanvas->refresh();
+}
+
+void QgsMapToolCapture::deleteTempRubberBand()
+{
+  if ( mTempRubberBand )
+  {
+    delete mTempRubberBand;
+    mTempRubberBand = 0;
+  }
 }
 
 void QgsMapToolCapture::closePolygon()

--- a/src/app/qgsmaptoolcapture.h
+++ b/src/app/qgsmaptoolcapture.h
@@ -82,11 +82,9 @@ class QgsMapToolCapture : public QgsMapToolEdit
     /**Removes the last vertex from mRubberBand and mCaptureList*/
     void undo();
 
-    /**Reset the last vertex from RubberBand to the previous one position*/
-    void resetLastVertex();
-
     void startCapturing();
     void stopCapturing();
+    void deleteTempRubberBand();
 
     CaptureMode mode() { return mCaptureMode; }
 
@@ -106,6 +104,9 @@ class QgsMapToolCapture : public QgsMapToolEdit
 
     /** rubber band for polylines and polygons */
     QgsRubberBand* mRubberBand;
+
+    /** temporary rubber band for polylines and polygons. this connects the last added point to the mouse cursor position */
+    QgsRubberBand* mTempRubberBand;
 
     /** List to store the points of digitised lines and polygons (in layer coordinates)*/
     QList<QgsPoint> mCaptureList;

--- a/src/app/qgsmaptooledit.cpp
+++ b/src/app/qgsmaptooledit.cpp
@@ -68,15 +68,26 @@ QgsPoint QgsMapToolEdit::snapPointFromResults( const QList<QgsSnappingResult>& s
   }
 }
 
-QgsRubberBand* QgsMapToolEdit::createRubberBand( QGis::GeometryType geometryType )
+QgsRubberBand* QgsMapToolEdit::createRubberBand( QGis::GeometryType geometryType, bool alternativeBand )
 {
   QSettings settings;
   QgsRubberBand* rb = new QgsRubberBand( mCanvas, geometryType );
+  rb->setWidth( settings.value( "/qgis/digitizing/line_width", 1 ).toInt() );
   QColor color( settings.value( "/qgis/digitizing/line_color_red", 255 ).toInt(),
                 settings.value( "/qgis/digitizing/line_color_green", 0 ).toInt(),
-                settings.value( "/qgis/digitizing/line_color_blue", 0 ).toInt() );
+                settings.value( "/qgis/digitizing/line_color_blue", 0 ).toInt());
+  double myAlpha = settings.value( "/qgis/digitizing/line_color_alpha", 200 ).toInt() / 255.0 ;
+  if ( alternativeBand )
+  {
+    myAlpha = myAlpha * settings.value( "/qgis/digitizing/line_color_alpha_scale" , 0.75 ).toDouble();
+    rb->setLineStyle( Qt::DotLine );
+  }
+  if ( geometryType == QGis::Polygon )
+  {
+    color.setAlphaF ( myAlpha );
+  }
+  color.setAlphaF ( myAlpha );
   rb->setColor( color );
-  rb->setWidth( settings.value( "/qgis/digitizing/line_width", 1 ).toInt() );
   rb->show();
   return rb;
 }

--- a/src/app/qgsmaptooledit.h
+++ b/src/app/qgsmaptooledit.h
@@ -50,10 +50,13 @@ class QgsMapToolEdit: public QgsMapTool
        @return the snapped point in map coordinates*/
     QgsPoint snapPointFromResults( const QList<QgsSnappingResult>& snapResults, const QPoint& screenCoords );
 
-    /**Creates a rubber band with the color/line width from
-     the QGIS settings. The caller takes ownership of the
-    returned object*/
-    QgsRubberBand* createRubberBand( QGis::GeometryType geometryType = QGis::Line );
+    /** Creates a rubber band with the color/line width from
+    *   the QGIS settings. The caller takes ownership of the
+    *   returned object
+    *   @param geometryType
+    *   @param alternativeBand if true, rubber band will be set with more transparency and a dash pattern. defaut is false.
+    */
+    QgsRubberBand* createRubberBand(QGis::GeometryType geometryType = QGis::Line , bool alternativeBand = false );
 
     /**Returns the current vector layer of the map canvas or 0*/
     QgsVectorLayer* currentVectorLayer();

--- a/src/app/qgsmaptoolreshape.cpp
+++ b/src/app/qgsmaptoolreshape.cpp
@@ -68,7 +68,7 @@ void QgsMapToolReshape::canvasReleaseEvent( QMouseEvent * e )
   }
   else if ( e->button() == Qt::RightButton )
   {
-    resetLastVertex();
+    deleteTempRubberBand();
 
     //find out bounding box of mCaptureList
     if ( size() < 1 )

--- a/src/app/qgsmaptoolsplitfeatures.cpp
+++ b/src/app/qgsmaptoolsplitfeatures.cpp
@@ -68,7 +68,7 @@ void QgsMapToolSplitFeatures::canvasReleaseEvent( QMouseEvent * e )
   }
   else if ( e->button() == Qt::RightButton )
   {
-    resetLastVertex();
+    deleteTempRubberBand();
 
     //bring up dialog if a split was not possible (polygon) or only done once (line)
     int topologicalEditing = QgsProject::instance()->readNumEntry( "Digitizing", "/TopologicalEditing", 0 );

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -638,7 +638,9 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WFlags fl ) :
   myRed = settings.value( "/qgis/digitizing/line_color_red", 255 ).toInt();
   myGreen = settings.value( "/qgis/digitizing/line_color_green", 0 ).toInt();
   myBlue = settings.value( "/qgis/digitizing/line_color_blue", 0 ).toInt();
-  mLineColorToolButton->setColor( QColor( myRed, myGreen, myBlue ) );
+  myAlpha = settings.value( "/qgis/digitizing/line_color_alpha", 200 ).toInt();
+  mLineColorToolButton->setColor( QColor( myRed, myGreen, myBlue, myAlpha ) );
+  mLineColorToolButton->setColorDialogOptions(QColorDialog::ShowAlphaChannel);
 
   //default snap mode
   mDefaultSnapModeComboBox->insertItem( 0, tr( "To vertex" ), "to vertex" );
@@ -1083,6 +1085,7 @@ void QgsOptions::saveOptions()
   settings.setValue( "/qgis/digitizing/line_color_red", digitizingColor.red() );
   settings.setValue( "/qgis/digitizing/line_color_green", digitizingColor.green() );
   settings.setValue( "/qgis/digitizing/line_color_blue", digitizingColor.blue() );
+  settings.setValue( "/qgis/digitizing/line_color_alpha", digitizingColor.alpha() );
 
   //default snap mode
   QString defaultSnapModeString = mDefaultSnapModeComboBox->itemData( mDefaultSnapModeComboBox->currentIndex() ).toString();

--- a/src/gui/qgsrubberband.cpp
+++ b/src/gui/qgsrubberband.cpp
@@ -29,7 +29,6 @@
 */
 QgsRubberBand::QgsRubberBand( QgsMapCanvas* mapCanvas, QGis::GeometryType geometryType )
     : QgsMapCanvasItem( mapCanvas )
-    , mWidth( 1 )
     , mIconSize( 5 )
     , mIconType( ICON_CIRCLE )
     , mGeometryType( geometryType )
@@ -37,23 +36,28 @@ QgsRubberBand::QgsRubberBand( QgsMapCanvas* mapCanvas, QGis::GeometryType geomet
     , mTranslationOffsetY( 0.0 )
 {
   reset( geometryType );
-  QColor color(Qt::lightGray);
-  color.setAlpha(63);
+  QColor color( Qt::lightGray );
+  color.setAlpha( 63 );
   setColor( color );
+  setWidth( 1 );
+  setLineStyle( Qt::SolidLine );
+  setBrushStyle( Qt::SolidPattern );
 }
 
 QgsRubberBand::QgsRubberBand( QgsMapCanvas* mapCanvas, bool isPolygon )
     : QgsMapCanvasItem( mapCanvas )
-    , mWidth( 1 )
     , mIconSize( 5 )
     , mIconType( ICON_CIRCLE )
     , mTranslationOffsetX( 0.0 )
     , mTranslationOffsetY( 0.0 )
 {
   reset( isPolygon ? QGis::Polygon : QGis::Line );
-  QColor color(Qt::lightGray);
-  color.setAlpha(63);
+  QColor color( Qt::lightGray );
+  color.setAlpha( 63 );
   setColor( color );
+  setWidth( 1 );
+  setLineStyle( Qt::SolidLine );
+  setBrushStyle( Qt::SolidPattern );
 }
 
 QgsRubberBand::QgsRubberBand(): QgsMapCanvasItem( 0 )
@@ -72,7 +76,6 @@ void QgsRubberBand::setColor( const QColor & color )
   mPen.setColor( color );
   QColor fillColor( color.red(), color.green(), color.blue(), color.alpha() );
   mBrush.setColor( fillColor );
-  mBrush.setStyle( Qt::SolidPattern );
 }
 
 /*!
@@ -80,7 +83,7 @@ void QgsRubberBand::setColor( const QColor & color )
   */
 void QgsRubberBand::setWidth( int width )
 {
-  mWidth = width;
+  mPen.setWidth( width );
 }
 
 void QgsRubberBand::setIcon( IconType icon )
@@ -91,6 +94,16 @@ void QgsRubberBand::setIcon( IconType icon )
 void QgsRubberBand::setIconSize( int iconSize )
 {
   mIconSize = iconSize;
+}
+
+void QgsRubberBand::setLineStyle( Qt::PenStyle penStyle )
+{
+  mPen.setStyle( penStyle );
+}
+
+void QgsRubberBand::setBrushStyle( Qt::BrushStyle brushStyle )
+{
+  mBrush.setStyle( brushStyle );
 }
 
 /*!
@@ -406,7 +419,6 @@ void QgsRubberBand::paint( QPainter* p )
   if ( mPoints.size() > 0 )
   {
     p->setBrush( mBrush );
-    mPen.setWidth( mWidth );
     p->setPen( mPen );
 
     Q_FOREACH( const QList<QgsPoint>& line, mPoints )
@@ -488,7 +500,7 @@ void QgsRubberBand::updateRect()
       return;
     }
     qreal s = ( mIconSize - 1 ) / 2;
-    qreal p = mWidth;
+    qreal p = mPen.width();
 
     QgsRectangle r( it->x() + mTranslationOffsetX - s - p, it->y() + mTranslationOffsetY - s - p,
                     it->x() + mTranslationOffsetX + s + p, it->y() + mTranslationOffsetY + s + p );

--- a/src/gui/qgsrubberband.h
+++ b/src/gui/qgsrubberband.h
@@ -101,6 +101,18 @@ class GUI_EXPORT QgsRubberBand: public QgsMapCanvasItem
     void setIconSize( int iconSize );
 
     /**
+    * Set the style of the line
+    *  @note Added in 1.9
+    */
+    void setLineStyle( Qt::PenStyle penStyle );
+
+    /**
+    * Set the style of the brush
+    *  @note Added in 1.9
+    */
+    void setBrushStyle( Qt::BrushStyle brushStyle );
+
+    /**
      * Clears all the geometries in this rubberband.
      * Sets the representation type according to geometryType.
      *  @param geometryType Defines how the data should be drawn onto the screen. (Use QGis::Line, QGis::Polygon or QGis::Point)
@@ -226,16 +238,13 @@ class GUI_EXPORT QgsRubberBand: public QgsMapCanvasItem
     QBrush mBrush;
     QPen mPen;
 
-    /** The width of any line within the rubberband. */
-    int mWidth;
-
     /** The size of the icon for points.
       * @note Added in 1.9 */
     int mIconSize;
 
     /** Icon to be shown.
      *  @note Added in 1.9 */
-    IconType mIconType ;
+    IconType mIconType;
 
     /**
      * Nested lists used for multitypes


### PR DESCRIPTION
- add method to set dash pattern for rubber bands:
  - setDashPattern
  - setSolid
- allow alpha channel for digitization color
- add second temporary rubber band to distinguish drawn vertices from next possible point

http://hub.qgis.org/issues/8395
