### PR TITLE
If ignoreShapeEncoding is false, clear SHAPE_ENCODING after creating shapefile with SHAPE_ENCODING="" (fix #8440)

### DIFF
--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -125,8 +125,6 @@ QgsVectorFileWriter::QgsVectorFileWriter(
       layOptions.append( "ENCODING=" + convertCodecNameForEncodingOption( fileEncoding ) );
     }
 
-    CPLSetConfigOption( "SHAPE_ENCODING", "" );
-
     if ( driverName == "ESRI Shapefile" && !vectorFileName.endsWith( ".shp", Qt::CaseInsensitive ) )
     {
       vectorFileName += ".shp";
@@ -270,6 +268,9 @@ QgsVectorFileWriter::QgsVectorFileWriter(
     options[ layOptions.size()] = NULL;
   }
 
+  // disable encoding conversion of OGR Shapefile layer
+  CPLSetConfigOption( "SHAPE_ENCODING", "" );
+
   mLayer = OGR_DS_CreateLayer( mDS, TO8F( layerName ), ogrRef, wkbType, options );
 
   if ( options )
@@ -278,6 +279,12 @@ QgsVectorFileWriter::QgsVectorFileWriter(
       CPLFree( options[i] );
     delete [] options;
     options = NULL;
+  }
+
+  QSettings settings;
+  if ( !settings.value( "/qgis/ignoreShapeEncoding", true ).toBool() )
+  {
+    CPLSetConfigOption( "SHAPE_ENCODING", 0 );
   }
 
   if ( srs )

--- a/src/plugins/spit/qgsshapefile.cpp
+++ b/src/plugins/spit/qgsshapefile.cpp
@@ -25,6 +25,7 @@
 #include <QLabel>
 #include <QTextCodec>
 #include <QFileInfo>
+#include <QSettings>
 
 #include "qgsapplication.h"
 #include "cpl_error.h"
@@ -45,6 +46,10 @@ QgsShapeFile::QgsShapeFile( QString name, QString encoding )
   fileName = name;
   features = 0;
   QgsApplication::registerOgrDrivers();
+
+  QSettings settings;
+  CPLSetConfigOption( "SHAPE_ENCODING", settings.value( "/qgis/ignoreShapeEncoding", true ).toBool() ? "" : 0 );
+
   ogrDataSource = OGROpen( TO8F( fileName ), false, NULL );
   if ( ogrDataSource != NULL )
   {

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -2025,6 +2025,13 @@ QGISEXTERN bool createEmptyDataSource( const QString &uri,
   OGRLayerH layer;
   layer = OGR_DS_CreateLayer( dataSource, TO8F( QFileInfo( uri ).completeBaseName() ), reference, OGRvectortype, papszOptions );
   CSLDestroy( papszOptions );
+
+  QSettings settings;
+  if ( !settings.value( "/qgis/ignoreShapeEncoding", true ).toBool() )
+  {
+    CPLSetConfigOption( "SHAPE_ENCODING", 0 );
+  }
+
   if ( !layer )
   {
     QgsMessageLog::logMessage( QObject::tr( "Creation of OGR data source %1 failed: %2" ).arg( uri ).arg( QString::fromUtf8( CPLGetLastErrorMsg() ) ), QObject::tr( "OGR" ) );


### PR DESCRIPTION
This fixes http://hub.qgis.org/issues/8440 and also applies SHAPE_ENCODING to shape layer opening in the Spit plugin.
