### PR TITLE
CMake: Throw errors for SIP problems in subsequent builds also

### DIFF
--- a/cmake/SIPMacros.cmake
+++ b/cmake/SIPMacros.cmake
@@ -104,7 +104,7 @@ MACRO(ADD_SIP_PYTHON_MODULE MODULE_NAME MODULE_SIP)
     ADD_CUSTOM_COMMAND(
         OUTPUT ${_sip_output_files} 
         COMMAND ${CMAKE_COMMAND} -E echo ${message}
-        COMMAND ${CMAKE_COMMAND} -E touch ${_sip_output_files} 
+#        COMMAND ${CMAKE_COMMAND} -E touch ${_sip_output_files} 
         COMMAND ${SIP_BINARY_PATH} ${_sip_tags} -w -e ${_sip_x} ${SIP_EXTRA_OPTIONS} -j ${SIP_CONCAT_PARTS} -c ${CMAKE_CURRENT_BINARY_DIR}/${_module_path} ${_sip_includes} ${_abs_module_sip}
         DEPENDS ${_abs_module_sip} ${SIP_EXTRA_FILES_DEPEND}
     )


### PR DESCRIPTION
Old behavior was to only spit out errors on the first `make` run.
To reproduce the problem:

Edit a random sip file and introduce some parse error (e.g. append some garbage at the end of the file)
`make` (errors...)
`make` (again, no errors, start qgis: python errors indicating e.g. initgui not found)
To fix this you had to `touch python/gui/gui.sip`, `make` again and then solve the problem.

With this patch introduced, `make` will fail repeatedly untill you properly fixed the sip problem.
