### PR TITLE
[core-plugin] fix capture coordinate plugin

### DIFF
--- a/src/plugins/coordinate_capture/coordinatecapture.cpp
+++ b/src/plugins/coordinate_capture/coordinatecapture.cpp
@@ -94,10 +94,11 @@ void CoordinateCapture::initGui()
 
   // Create the action for tool
   mQActionPointer = new QAction( QIcon(), tr( "Coordinate Capture" ), this );
+  mQActionPointer->setCheckable( true ); 
   // Set the what's this text
   mQActionPointer->setWhatsThis( tr( "Click on the map to view coordinates and capture to clipboard." ) );
   // Connect the action to the run
-  connect( mQActionPointer, SIGNAL( triggered() ), this, SLOT( run() ) );
+  connect( mQActionPointer, SIGNAL( triggered() ), this, SLOT( showOrHide() ) );
   mQGisIface->addPluginToVectorMenu( tr( "&Coordinate Capture" ), mQActionPointer );
 
   // create our map tool
@@ -164,6 +165,7 @@ void CoordinateCapture::initGui()
 
   // now add our custom widget to the dock - ownership of the widget is passed to the dock
   mpDockWidget->setWidget( mypWidget );
+  connect( mpDockWidget, SIGNAL( visibilityChanged( bool ) ), mQActionPointer, SLOT( setChecked( bool ) ) );
 
 }
 
@@ -243,11 +245,22 @@ void CoordinateCapture::run()
   //myPluginGui->show();
 }
 
+void CoordinateCapture::showOrHide()
+{
+  if ( !mpDockWidget )
+    run();
+  else
+    if ( mQActionPointer->isChecked() )
+      mpDockWidget->show();
+    else
+      mpDockWidget->hide();
+}
+
 // Unload the plugin by cleaning up the GUI
 void CoordinateCapture::unload()
 {
   // remove the GUI
-  mQGisIface->removePluginMenu( "&Coordinate Capture", mQActionPointer );
+  mQGisIface->removePluginVectorMenu( "&Coordinate Capture", mQActionPointer );
   //mQGisIface->removeToolBarIcon( mQActionPointer );
   mpMapTool->deactivate();
   delete mpMapTool;

--- a/src/plugins/coordinate_capture/coordinatecapture.h
+++ b/src/plugins/coordinate_capture/coordinatecapture.h
@@ -90,6 +90,8 @@ class CoordinateCapture: public QObject, public QgisPlugin
     void run();
     //! unload the plugin
     void unload();
+    //! Show/hide the dockwidget
+    void showOrHide();
     //! show the help document
     void help();
     //! Set the Coordinate Reference System used for displaying non canvas CRS coord


### PR DESCRIPTION
The plugin is not deleted from the vector menu when you unload it from plugin manager and the button
seems not to work properly. This patch should fix.
