### PR TITLE
more complete QgsMessageBarItem

### DIFF
--- a/python/gui/gui.sip
+++ b/python/gui/gui.sip
@@ -51,6 +51,7 @@
 %Include qgsmaptooltouch.sip
 %Include qgsmaptoolzoom.sip
 %Include qgsmessagebar.sip
+%Include qgsmessagebaritem.sip
 %Include qgsmessagelogviewer.sip
 %Include qgsmessageviewer.sip
 %Include qgsnewhttpconnection.sip

--- a/python/gui/qgsmessagebar.sip
+++ b/python/gui/qgsmessagebar.sip
@@ -15,41 +15,49 @@ class QgsMessageBar: QFrame
     QgsMessageBar( QWidget *parent = 0 );
     ~QgsMessageBar();
 
-    /*! display a widget on the bar after hiding the currently visible one
-     *  and putting it in a stack
-     * @param widget widget to add
+
+    /*! display a message item on the bar after hiding the currently visible one
+     *  and putting it in a stack.
+     * @param item item to display
+     */
+    void pushItem( QgsMessageBarItem *item /Transfer/);
+
+    /*! display a widget as a message on the bar after hiding the currently visible one
+     *  and putting it in a stack.
+     * @param widget message widget to display
      * @param level is QgsMessageBar::INFO, WARNING or CRITICAL
      * @param duration timeout duration of message in seconds, 0 value indicates no timeout
      */
-    void pushWidget( QWidget *widget /Transfer/, MessageLevel level = INFO, int duration = 0 );
+    QgsMessageBarItem *pushWidget( QWidget *widget /Transfer/, MessageLevel level = INFO, int duration = 0 );
 
     /*! remove the passed widget from the bar (if previously added),
      *  then display the next one in the stack if any or hide the bar
      *  @param widget widget to remove
      *  @return true if the widget was removed, false otherwise
      */
-    bool popWidget( QWidget *widget );
+    bool popWidget( QgsMessageBarItem *item );
 
-    //! make out a widget containing a message to be displayed on the bar
-    static QWidget* createMessage( const QString &text, QWidget *parent = 0 ) /Factory/;
-    //! make out a widget containing icon and message to be displayed on the bar
-    static QWidget* createMessage( const QString &text, const QIcon &icon, QWidget *parent = 0 ) /Factory/;
+    //make out a widget containing a message to be displayed on the bar
+    static QgsMessageBarItem* createMessage( const QString &text, QWidget *parent = 0 ) /Factory/;
     //! make out a widget containing title and message to be displayed on the bar
-    static QWidget* createMessage( const QString &title, const QString &text, QWidget *parent = 0 )  /Factory/;
-    //! make out a widget containing icon, title and message to be displayed on the bar
-    static QWidget* createMessage( const QString &title, const QString &text, const QIcon &icon, QWidget *parent = 0 ) /Factory/;
-
+    static QgsMessageBarItem* createMessage( const QString &title, const QString &text, QWidget *parent = 0 )  /Factory/;
+     //! make out a widget containing title and message to be displayed on the bar
+    static QgsMessageBarItem* createMessage( QWidget *widget, QWidget *parent = 0 ) /Factory/;
+    
     //! convenience method for pushing a non-widget-based message to the bar
-    void pushMessage( const QString &text, MessageLevel level = INFO, int duration = 0 );
+    QString pushMessage( const QString &text, MessageLevel level = INFO, int duration = 0 );
     //! convenience method for pushing a non-widget-based message with title to the bar
-    void pushMessage( const QString &title, const QString &text, MessageLevel level = INFO, int duration = 0 );
+    QString pushMessage( const QString &title, const QString &text, MessageLevel level = INFO, int duration = 0 );
+
+    //! return the item for given uuid if the item still exists, 0 otherwise
+    QgsMessageBarItem* itemAtId( QString uuid );
 
   signals:
     //! emitted when a message widget is added to the bar
-    void widgetAdded( QWidget *widget );
+    void widgetAdded( QgsMessageBarItem *item );
 
     //! emitted when a widget was removed from the bar
-    void widgetRemoved( QWidget *widget );
+    void widgetRemoved( QgsMessageBarItem *item );
 
   public slots:
     /*! remove the currently displayed widget from the bar and

--- a/python/gui/qgsmessagebaritem.sip
+++ b/python/gui/qgsmessagebaritem.sip
@@ -1,0 +1,49 @@
+class QgsMessageBarItem: QWidget
+{
+%TypeHeaderCode
+#include <qgsmessagebaritem.h>
+#include <qgsmessagebar.h>
+%End
+
+  public:
+    //! make out a widget containing a message to be displayed on the bar
+    QgsMessageBarItem( const QString &text, QgsMessageBar::MessageLevel level = QgsMessageBar::INFO, int duration = 0, QWidget *parent = 0 );
+
+    //! make out a widget containing title and message to be displayed on the bar
+    QgsMessageBarItem( const QString &title, const QString &text, QgsMessageBar::MessageLevel level = QgsMessageBar::INFO, int duration = 0, QWidget *parent = 0 );
+
+    //! make out a widget containing title, message and widget to be displayed on the bar
+    QgsMessageBarItem( const QString &title, const QString &text, QWidget *widget, QgsMessageBar::MessageLevel level = QgsMessageBar::INFO, int duration = 0, QWidget *parent = 0 );
+
+    //! make out a widget containing a widget to be displayed on the bar
+    QgsMessageBarItem( QWidget *widget, QgsMessageBar::MessageLevel level = QgsMessageBar::INFO, int duration = 0, QWidget *parent = 0 );
+
+    QgsMessageBarItem *setText( QString text );
+
+    QgsMessageBarItem *setTitle( QString title );
+
+    QgsMessageBarItem *setLevel( QgsMessageBar::MessageLevel level );
+
+    QgsMessageBarItem *setWidget( QWidget *widget );
+
+    QgsMessageBarItem *setIcon( const QIcon &icon );
+
+    QgsMessageBarItem *setDuration( int duration );
+
+    //! returns the duration in second of the message
+    int duration();
+
+    //! get the uuid of this message
+    QString id();
+    
+    //! returns the level
+    QgsMessageBar::MessageLevel level();
+
+    //! returns the styleSheet
+    QString getStyleSheet();
+
+  signals:
+    //! emitted when the message level has changed
+    void styleChanged( QString styleSheet );
+};
+

--- a/src/app/qgsmaptooledit.cpp
+++ b/src/app/qgsmaptooledit.cpp
@@ -75,7 +75,7 @@ QgsRubberBand* QgsMapToolEdit::createRubberBand( QGis::GeometryType geometryType
   rb->setWidth( settings.value( "/qgis/digitizing/line_width", 1 ).toInt() );
   QColor color( settings.value( "/qgis/digitizing/line_color_red", 255 ).toInt(),
                 settings.value( "/qgis/digitizing/line_color_green", 0 ).toInt(),
-                settings.value( "/qgis/digitizing/line_color_blue", 0 ).toInt());
+                settings.value( "/qgis/digitizing/line_color_blue", 0 ).toInt() );
   double myAlpha = settings.value( "/qgis/digitizing/line_color_alpha", 200 ).toInt() / 255.0 ;
   if ( alternativeBand )
   {
@@ -84,9 +84,9 @@ QgsRubberBand* QgsMapToolEdit::createRubberBand( QGis::GeometryType geometryType
   }
   if ( geometryType == QGis::Polygon )
   {
-    color.setAlphaF ( myAlpha );
+    color.setAlphaF( myAlpha );
   }
-  color.setAlphaF ( myAlpha );
+  color.setAlphaF( myAlpha );
   rb->setColor( color );
   rb->show();
   return rb;

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -89,6 +89,7 @@ qgsmaptoolidentify.cpp
 qgsmaptoolpan.cpp
 qgsmaptoolzoom.cpp
 qgsmessagebar.cpp
+qgsmessagebaritem.cpp
 qgsmessageviewer.cpp
 qgsmessagelogviewer.cpp
 qgsnewhttpconnection.cpp
@@ -201,6 +202,7 @@ qgsmapcanvas.h
 qgsmapoverviewcanvas.h
 qgsmaptoolemitpoint.h
 qgsmaptoolidentify.h
+qgsmessagebaritem.h
 qgsmessagebar.h
 qgsmessageviewer.h
 qgsmessagelogviewer.h
@@ -253,6 +255,7 @@ qgsmaptoolemitpoint.h
 qgsmaptoolidentify.h
 qgsmaptoolpan.h
 qgsmaptoolzoom.h
+qgsmessagebaritem.h
 qgsmessagebar.h
 qgsmessageviewer.h
 qgsoptionsdialogbase.h

--- a/src/gui/qgsmessagebar.h
+++ b/src/gui/qgsmessagebar.h
@@ -34,6 +34,8 @@ class QLabel;
 class QAction;
 class QTimer;
 
+class QgsMessageBarItem;
+
 /** \ingroup gui
  * A bar for displaying non-blocking messages to the user.
  * \note added in 1.9
@@ -53,41 +55,48 @@ class GUI_EXPORT QgsMessageBar: public QFrame
     QgsMessageBar( QWidget *parent = 0 );
     ~QgsMessageBar();
 
-    /*! display a widget on the bar after hiding the currently visible one
-     *  and putting it in a stack
-     * @param widget widget to add
+    /*! display a message item on the bar after hiding the currently visible one
+     *  and putting it in a stack.
+     * @param item item to display
+     */
+    void pushItem( QgsMessageBarItem *item );
+
+    /*! display a widget as a message on the bar after hiding the currently visible one
+     *  and putting it in a stack.
+     * @param widget message widget to display
      * @param level is QgsMessageBar::INFO, WARNING or CRITICAL
      * @param duration timeout duration of message in seconds, 0 value indicates no timeout
      */
-    void pushWidget( QWidget *widget, MessageLevel level = INFO, int duration = 0 );
+    QgsMessageBarItem *pushWidget( QWidget *widget, MessageLevel level = INFO, int duration = 0 );
 
     /*! remove the passed widget from the bar (if previously added),
      *  then display the next one in the stack if any or hide the bar
-     *  @param widget widget to remove
+     *  @param item item to remove
      *  @return true if the widget was removed, false otherwise
      */
-    bool popWidget( QWidget *widget );
+    bool popWidget( QgsMessageBarItem *item );
 
     //! make out a widget containing a message to be displayed on the bar
-    static QWidget* createMessage( const QString &text, QWidget *parent = 0 ) { return createMessage( QString::null, text, QIcon(), parent ); }
-    //! make out a widget containing icon and message to be displayed on the bar
-    static QWidget* createMessage( const QString &text, const QIcon &icon, QWidget *parent = 0 ) { return createMessage( QString::null, text, icon, parent ); }
+    static QgsMessageBarItem* createMessage( const QString &text, QWidget *parent = 0 );
     //! make out a widget containing title and message to be displayed on the bar
-    static QWidget* createMessage( const QString &title, const QString &text, QWidget *parent = 0 ) { return createMessage( title, text, QIcon(), parent ); }
-    //! make out a widget containing icon, title and message to be displayed on the bar
-    static QWidget* createMessage( const QString &title, const QString &text, const QIcon &icon, QWidget *parent = 0 );
+    static QgsMessageBarItem* createMessage( const QString &title, const QString &text, QWidget *parent = 0 );
+    //! make out a widget containing title and message to be displayed on the bar
+    static QgsMessageBarItem* createMessage( QWidget *widget, QWidget *parent = 0 );
 
-    //! convenience method for pushing a non-widget-based message to the bar
-    void pushMessage( const QString &text, MessageLevel level = INFO, int duration = 0 ) { pushMessage( QString::null, text, level, duration ); }
-    //! convenience method for pushing a non-widget-based message with title to the bar
-    void pushMessage( const QString &title, const QString &text, MessageLevel level = INFO, int duration = 0 );
+    //! convenience method for pushing a message to the bar
+    QString pushMessage( const QString &text, MessageLevel level = INFO, int duration = 0 ) { return pushMessage( QString::null, text, level, duration ); }
+    //! convenience method for pushing a message with title to the bar
+    QString pushMessage( const QString &title, const QString &text, MessageLevel level = INFO, int duration = 0 );
+
+    //! return the item for given uuid if the item still exists, 0 otherwise
+    QgsMessageBarItem* itemAtId( QString uuid );
 
   signals:
     //! emitted when a message widget is added to the bar
-    void widgetAdded( QWidget *widget );
+    void widgetAdded( QgsMessageBarItem *item );
 
     //! emitted when a message widget was removed from the bar
-    void widgetRemoved( QWidget *widget );
+    void widgetRemoved( QgsMessageBarItem *item );
 
   public slots:
     /*! remove the currently displayed widget from the bar and
@@ -105,30 +114,10 @@ class GUI_EXPORT QgsMessageBar: public QFrame
     void mousePressEvent( QMouseEvent * e );
 
   private:
-    class QgsMessageBarItem
-    {
-      public:
-        QgsMessageBarItem( QWidget *widget, const QString &styleSheet, int duration = 0 ):
-            mWidget( widget ), mStyleSheet( styleSheet ), mDuration( duration ) {}
-        ~QgsMessageBarItem() {}
-
-        QWidget* widget() const { return mWidget; }
-        QString styleSheet() const { return mStyleSheet; }
-        int duration() const { return mDuration; }
-
-      private:
-        QWidget *mWidget;
-        QString mStyleSheet;
-        int mDuration; // 0 value indicates no timeout duration
-    };
-
-    void pushWidget( QWidget *widget, const QString &styleSheet, int duration = 0 );
-
     void popItem( QgsMessageBarItem *item );
-    void pushItem( QgsMessageBarItem *item );
-
+    void showItem( QgsMessageBarItem *item );
     QgsMessageBarItem *mCurrentItem;
-    QList<QgsMessageBarItem *> mList;
+    QList<QgsMessageBarItem *> mItems;
     QMenu *mCloseMenu;
     QToolButton *mCloseBtn;
     QGridLayout *mLayout;

--- a/src/gui/qgsmessagebaritem.cpp
+++ b/src/gui/qgsmessagebaritem.cpp
@@ -1,0 +1,249 @@
+/***************************************************************************
+                          qgsmessagebaritem.h  -  description
+                             -------------------
+    begin                : August 2013
+    copyright            : (C) 2013 by Denis Rouzaud
+    email                : denis.rouzaud@gmail.com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsapplication.h"
+#include "qgsmessagebaritem.h"
+#include "qgsmessagebar.h"
+
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QTextEdit>
+#include <QUuid>
+
+QgsMessageBarItem::QgsMessageBarItem( const QString &text, QgsMessageBar::MessageLevel level, int duration, QWidget *parent ) :
+    QWidget( parent )
+    , mUuid( QUuid::createUuid().toString() )
+    , mTitle( "" )
+    , mText( text )
+    , mLevel( level )
+    , mDuration( duration )
+    , mWidget( 0 )
+    , mUserIcon( QIcon() )
+    , mLayout( 0 )
+{
+  writeContent();
+}
+
+QgsMessageBarItem::QgsMessageBarItem(const QString &title, const QString &text, QgsMessageBar::MessageLevel level, int duration , QWidget *parent ) :
+    QWidget( parent )
+    , mUuid( QUuid::createUuid().toString() )
+    , mTitle( title )
+    , mText( text )
+    , mLevel( level )
+    , mDuration( duration )
+    , mWidget( 0 )
+    , mUserIcon( QIcon() )
+    , mLayout( 0 )
+{
+  writeContent();
+}
+
+QgsMessageBarItem::QgsMessageBarItem( const QString &title, const QString &text, QWidget *widget, QgsMessageBar::MessageLevel level, int duration, QWidget *parent ) :
+    QWidget( parent )
+    , mUuid( QUuid::createUuid().toString() )
+    , mTitle( title )
+    , mText( text )
+    , mLevel( level )
+    , mDuration( duration )
+    , mWidget( widget )
+    , mUserIcon( QIcon() )
+    , mLayout( 0 )
+{
+  writeContent();
+}
+
+QgsMessageBarItem::QgsMessageBarItem( QWidget *widget, QgsMessageBar::MessageLevel level, int duration, QWidget *parent ) :
+    QWidget( parent )
+    , mUuid( QUuid::createUuid().toString() )
+    , mTitle( "" )
+    , mText( "" )
+    , mLevel( level )
+    , mDuration( duration )
+    , mWidget( widget )
+    , mUserIcon( QIcon() )
+    , mLayout( 0 )
+{
+  writeContent();
+}
+
+QgsMessageBarItem::~QgsMessageBarItem()
+{
+}
+
+void QgsMessageBarItem::writeContent()
+{
+  if ( mLayout == 0 )
+  {
+    mLayout = new QHBoxLayout( this );
+    mLayout->setContentsMargins( 0, 0, 0, 0 );
+    mTextEdit = 0;
+    mLblIcon = 0;
+  }
+
+  // TITLE AND TEXT
+  if ( mTitle.isEmpty() && mText.isEmpty() )
+  {
+    if ( mTextEdit != 0 )
+    {
+      delete mTextEdit;
+      mTextEdit = 0;
+    }
+  }
+  else
+  {
+    if ( mTextEdit == 0 )
+    {
+      mTextEdit = new QTextEdit( this );
+      mTextEdit->setObjectName( "textEdit" );
+      mTextEdit->setSizePolicy( QSizePolicy::Expanding, QSizePolicy::Maximum );
+      mTextEdit->setReadOnly( true );
+      mTextEdit->setFrameShape( QFrame::NoFrame );
+      // stylesheet set here so Qt-style substitued scrollbar arrows can show within limited height
+      // adjusts to height of font set in app options
+      mTextEdit->setStyleSheet( "* { background-color: rgba(0,0,0,0); margin-top: 0.25em; max-height: 1.75em; min-height: 1.75em; } "
+                                "QScrollBar::add-page,QScrollBar::sub-page,QScrollBar::handle { background-color: rgba(0,0,0,0); color: rgba(0,0,0,0); }" );
+      mLayout->addWidget( mTextEdit );
+    }
+    QString content = mText;
+    if ( !mTitle.isEmpty() )
+    {
+      // add ':' to end of title
+      QString t = mTitle.trimmed();
+      if ( !t.endsWith( ":" ) && !content.isEmpty() )
+        t += ": ";
+      content.prepend( QString( "<b>" ) + t + "</b>" );
+    }
+    mTextEdit->setText( content );
+  }
+
+  // WIDGET
+  if ( mWidget != 0 )
+  {
+    int idx = 0;
+    if ( mTextEdit != 0 )
+      idx = 1;
+
+    QLayoutItem *item = mLayout->itemAt( idx );
+    if ( !item || item->widget() != mWidget )
+    {
+      mLayout->insertWidget( idx, mWidget );
+    }
+  }
+
+  // ICON
+  if ( mLblIcon == 0 )
+  {
+    mLblIcon = new QLabel( this );
+    mLayout->addWidget( mLblIcon );
+  }
+  QIcon icon;
+  if ( !mUserIcon.isNull() )
+  {
+    icon = mUserIcon;
+  }
+  else
+  {
+    QString msgIcon( "/mIconInfo.png" );
+    switch ( mLevel )
+    {
+      case QgsMessageBar::CRITICAL:
+        msgIcon = QString( "/mIconCritical.png" );
+        break;
+      case QgsMessageBar::WARNING:
+        msgIcon = QString( "/mIconWarn.png" );
+        break;
+      default:
+        break;
+    }
+    icon = QgsApplication::getThemeIcon( msgIcon );
+  }
+  mLblIcon->setPixmap( icon.pixmap( 24 ) );
+
+
+  // STYLESHEET
+  if ( mLevel >= QgsMessageBar::CRITICAL )
+  {
+    mStyleSheet = "QgsMessageBar { background-color: #d65253; border: 1px solid #9b3d3d; } "
+                  "QLabel,QTextEdit { color: white; } ";
+  }
+  else if ( mLevel == QgsMessageBar::WARNING )
+  {
+    mStyleSheet = "QgsMessageBar { background-color: #ffc800; border: 1px solid #e0aa00; } "
+                  "QLabel,QTextEdit { color: black; } ";
+  }
+  else if ( mLevel <= QgsMessageBar::INFO )
+  {
+    mStyleSheet = "QgsMessageBar { background-color: #e7f5fe; border: 1px solid #b9cfe4; } "
+                  "QLabel,QTextEdit { color: #2554a1; } ";
+  }
+  mStyleSheet += "QLabel#mItemCount { font-style: italic; }";
+}
+
+QgsMessageBarItem* QgsMessageBarItem::setText( QString text )
+{
+  mText = text;
+  writeContent();
+  return this;
+}
+
+QgsMessageBarItem *QgsMessageBarItem::setTitle( QString title )
+{
+  mTitle = title;
+  writeContent();
+  return this;
+}
+
+QgsMessageBarItem *QgsMessageBarItem::setLevel( QgsMessageBar::MessageLevel level )
+{
+  mLevel = level;
+  writeContent();
+  emit styleChanged( mStyleSheet );
+  return this;
+}
+
+QgsMessageBarItem *QgsMessageBarItem::setWidget( QWidget *widget )
+{
+  if ( mWidget != 0 )
+  {
+    QLayoutItem *item;
+    int idx = 0;
+    if ( mTextEdit != 0 )
+      idx = 1;
+    item = mLayout->itemAt( idx );
+    if ( item->widget() == mWidget )
+    {
+      delete item->widget();
+    }
+  }
+  mWidget = widget;
+  writeContent();
+  return this;
+}
+
+QgsMessageBarItem* QgsMessageBarItem::setIcon( const QIcon &icon )
+{
+  mUserIcon = icon;
+  return this;
+}
+
+
+QgsMessageBarItem* QgsMessageBarItem::setDuration( int duration )
+{
+  mDuration = duration;
+  return this;
+}
+

--- a/src/gui/qgsmessagebaritem.h
+++ b/src/gui/qgsmessagebaritem.h
@@ -1,0 +1,92 @@
+/***************************************************************************
+                          qgsmessagebaritem.h  -  description
+                             -------------------
+    begin                : August 2013
+    copyright            : (C) 2013 by Denis Rouzaud
+    email                : denis.rouzaud@gmail.com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef qgsmessagebaritem_H
+#define qgsmessagebaritem_H
+
+#include <qgsmessagebaritem.h>
+#include <qgsmessagebar.h>
+
+#include <QWidget>
+#include <QIcon>
+#include <QTextEdit>
+#include <QHBoxLayout>
+
+class GUI_EXPORT QgsMessageBarItem : public QWidget
+{
+    Q_OBJECT
+  public:
+    //! make out a widget containing a message to be displayed on the bar
+    QgsMessageBarItem( const QString &text, QgsMessageBar::MessageLevel level = QgsMessageBar::INFO, int duration = 0, QWidget *parent = 0 );
+
+    //! make out a widget containing title and message to be displayed on the bar
+    QgsMessageBarItem( const QString &title, const QString &text, QgsMessageBar::MessageLevel level = QgsMessageBar::INFO, int duration = 0, QWidget *parent = 0 );
+
+    //! make out a widget containing title, message and widget to be displayed on the bar
+    QgsMessageBarItem( const QString &title, const QString &text, QWidget *widget, QgsMessageBar::MessageLevel level = QgsMessageBar::INFO, int duration = 0, QWidget *parent = 0 );
+
+    //! make out a widget containing a widget to be displayed on the bar
+    QgsMessageBarItem( QWidget *widget, QgsMessageBar::MessageLevel level = QgsMessageBar::INFO, int duration = 0, QWidget *parent = 0 );
+
+    //! Destructor
+    ~QgsMessageBarItem();
+
+    QgsMessageBarItem *setText( QString text );
+
+    QgsMessageBarItem *setTitle( QString title );
+
+    QgsMessageBarItem *setLevel( QgsMessageBar::MessageLevel level );
+
+    QgsMessageBarItem *setWidget( QWidget *widget );
+
+    QgsMessageBarItem *setIcon( const QIcon &icon );
+
+    QgsMessageBarItem *setDuration( int duration );
+
+    //! returns the duration in second of the message
+    int duration() const { return mDuration; }
+
+    //! get the uuid of this message
+    QString id() { return mUuid; }
+
+    //! returns the level
+    QgsMessageBar::MessageLevel level() { return mLevel; }
+
+    //! returns the styleSheet
+    QString getStyleSheet() { return mStyleSheet; }
+
+  signals:
+    //! emitted when the message level has changed
+    void styleChanged( QString styleSheet );
+
+
+  private:
+    void writeContent();
+
+    QString mUuid;
+    QString mTitle;
+    QString mText;
+    QgsMessageBar::MessageLevel mLevel;
+    int mDuration;
+    QWidget *mWidget;
+    QIcon mUserIcon;
+    QHBoxLayout *mLayout;
+    QLabel *mLblIcon;
+    QString mStyleSheet;
+    QTextEdit *mTextEdit;
+};
+
+#endif // qgsmessagebaritem_H


### PR DESCRIPTION
inherits from QWidget to allow further editing.

The global idea is to have a better control on message once they are created and also while they are shown.

The structure of a message is kept coherent: it is made of a title, text and widget. All of these are optional.
It also contains the info of duration and level.

There are very minor API changes:
- QgsMessageBar::createMessage now returns a QgsMessageBarItem instead of a QWidget. This won't be a problem in python
- I removed 2 of 4 of the createMessage methods. I kept the only one used in plugins on the repo as of today

so now pushItem should be used instead of pushWidget. If pushWidget is used with an item, it will also works since it tries to cast widget to QgsMessageBarItem.
