### PR TITLE
Untranslatable strings and formatting of the raster min/max label

### DIFF
--- a/src/core/raster/qgsrasterrenderer.cpp
+++ b/src/core/raster/qgsrasterrenderer.cpp
@@ -191,45 +191,48 @@ QString QgsRasterRenderer::minMaxOriginLabel( int theOrigin )
     return tr( "User defined" );
   }
 
-  QString name;
+  QString label;
+  QString est_exact;
+  QString values;
+  QString extent;
+  
   if ( theOrigin & MinMaxEstimated )
   {
-    name += tr( "Estimated" );
+    est_exact = tr( "Estimated" );
   }
   else if ( theOrigin & MinMaxExact )
   {
-    name += tr( "Exact" );
+    est_exact = tr( "Exact" );
   }
-
-  name += " ";
 
   if ( theOrigin & MinMaxMinMax )
   {
-    name += tr( "min / max" );
+    values = tr( "min / max" );
   }
   else if ( theOrigin & MinMaxCumulativeCut )
   {
-    name += "cumulative cut";
+    values = tr( "cumulative cut" );
   }
   else if ( theOrigin & MinMaxStdDev )
   {
-    name += "standard deviation";
+    values = tr( "standard deviation" );
   }
-
-  name += " " + tr( " of " ) + " ";
 
   if ( theOrigin & MinMaxFullExtent )
   {
-    name += "full extent";
+    extent = tr( "full extent" );
   }
   else if ( theOrigin & MinMaxSubExtent )
   {
-    name += "sub extent";
+    extent = tr( "sub extent" );
   }
 
-  name += ".";
-
-  return name;
+  label = tr( "%1 %2 of %3.",
+    "min/max origin label in raster properties, where %1 - estimated/exact, %2 - values (min/max, stddev, etc.), %3 - extent" )
+    .arg(est_exact)
+    .arg(values)
+    .arg(extent);
+  return label;
 }
 
 int QgsRasterRenderer::minMaxOriginFromName( QString theName )


### PR DESCRIPTION
Pull request https://github.com/qgis/Quantum-GIS/pull/782 was never reviewed and was lost after I reset my master branch, so I'm reopening it from a dedicated branch.
