### PR TITLE
FIX BUG #8473 Cannot rename layers in composer legend

### DIFF
--- a/src/core/composer/qgslegendmodel.cpp
+++ b/src/core/composer/qgslegendmodel.cpp
@@ -275,7 +275,22 @@ void QgsLegendModel::updateSymbolV2ItemText( QStandardItem* symbolItem )
 
   if ( renderer->type() == "singleSymbol" )
   {
-    label = vLayer->name();
+    if ( !sv2Item->userText().isEmpty() )
+    {
+      label = sv2Item->userText();
+    }
+    else if ( !lItem->userText().isEmpty() )
+    {
+      label = lItem->userText();
+    }
+    else if ( !vLayer->title().isEmpty() )
+    {
+      label = vLayer->title();
+    }
+    else
+    {
+      label = vLayer->name();
+    }
   }
 
   if ( lItem->showFeatureCount() )
@@ -380,10 +395,9 @@ void QgsLegendModel::updateLayer( QStandardItem* layerItem )
     QgsMapLayer* mapLayer = QgsMapLayerRegistry::instance()->mapLayer( lItem->layerID() );
     if ( mapLayer )
     {
-      QgsVectorLayer* vLayer = qobject_cast<QgsVectorLayer*>( mapLayer );
-
       updateLayerItemText( lItem );
 
+      QgsVectorLayer* vLayer = qobject_cast<QgsVectorLayer*>( mapLayer );
       if ( vLayer )
       {
         addVectorLayerItemsV2( lItem, vLayer );
@@ -406,14 +420,16 @@ void QgsLegendModel::updateLayerItemText( QStandardItem* layerItem )
   QgsMapLayer* mapLayer = QgsMapLayerRegistry::instance()->mapLayer( lItem->layerID() );
   if ( !mapLayer ) return;
 
-  QgsVectorLayer* vLayer = qobject_cast<QgsVectorLayer*>( mapLayer );
-  if ( !vLayer ) return;
-
   QString label = lItem->userText().isEmpty() ? mapLayer->name() : lItem->userText();
 
-  if ( vLayer && lItem->showFeatureCount() )
+  QgsVectorLayer* vLayer = qobject_cast<QgsVectorLayer*>( mapLayer );
+  if ( vLayer )
   {
-    label += QString( " [%1]" ).arg( vLayer->featureCount() );
+    addVectorLayerItemsV2( lItem, vLayer );
+    if ( lItem->showFeatureCount() )
+    {
+      label += QString( " [%1]" ).arg( vLayer->featureCount() );
+    }
   }
   lItem->setText( label );
 }


### PR DESCRIPTION
If the layer is a raster layer, the layer label is not updated with the
user defined text.
If the layer is a vector layer with simple symbol the symbol label
cannot be updated and be blocked at layer name. The label can be the
symbol user label, the layer user label, the layer title or the layer
name.
