### PR TITLE
Add support for 3D types in the PostGIS provider

### DIFF
--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -1237,7 +1237,7 @@ QString QgsPostgresConn::postgisTypeFilter( QString geomCol, QGis::WkbType geomT
     case QGis::WKBPolygon25D:
     case QGis::WKBMultiPolygon:
     case QGis::WKBMultiPolygon25D:
-      return QString( "upper(geometrytype(%1)) IN ('POLYGON','MULTIPOLYGON','POLYGONM','MULTIPOLYGONM')" ).arg( geomCol );
+      return QString( "upper(geometrytype(%1)) IN ('POLYGON','MULTIPOLYGON','POLYGONM','MULTIPOLYGONM', 'POLYHEDRALSURFACE', 'TIN')" ).arg( geomCol );
     case QGis::WKBNoGeometry:
       return QString( "geometrytype(%1) IS NULL" ).arg( geomCol );
     case QGis::WKBUnknown:

--- a/src/providers/postgres/qgspostgresfeatureiterator.cpp
+++ b/src/providers/postgres/qgspostgresfeatureiterator.cpp
@@ -268,9 +268,8 @@ bool QgsPostgresFeatureIterator::declareCursor( const QString& whereClause )
 
     if ( fetchGeometry )
     {
-      query += QString( "%1(%2(%3%4),'%5')" )
+      query += QString( "%1(%2%3,'%4')" )
                .arg( P->mConnectionRO->majorVersion() < 2 ? "asbinary" : "st_asbinary" )
-               .arg( P->mConnectionRO->majorVersion() < 2 ? "force_2d" : "st_force_2d" )
                .arg( P->quotedIdentifier( P->mGeometryColumn ) )
                .arg( P->mSpatialColType == sctGeography ? "::geometry" : "" )
                .arg( P->endianString() );


### PR DESCRIPTION
Allows PostGIS tables with the following geometry types to be displayed (in 2D):
- Triangle
- TIN
- PolyhedralSurface

They are converted to polygon or multipolygon
