### PR TITLE
Fix subset for ODBC ogr layers

### DIFF
--- a/src/providers/ogr/qgsogrfeatureiterator.cpp
+++ b/src/providers/ogr/qgsogrfeatureiterator.cpp
@@ -54,21 +54,7 @@ QgsOgrFeatureIterator::QgsOgrFeatureIterator( QgsOgrProvider* p, const QgsFeatur
 
   if ( !P->subsetString().isEmpty() )
   {
-    QByteArray layerName = OGR_FD_GetName( OGR_L_GetLayerDefn( ogrLayer ) );
-    if ( P->ogrDriverName == "ODBC" ) //the odbc driver does not like schema names for subset
-    {
-      QString layerNameString = P->mEncoding->toUnicode( layerName );
-      int dotIndex = layerNameString.indexOf( "." );
-      if ( dotIndex > 1 )
-      {
-        QString modifiedLayerName = layerNameString.right( layerNameString.size() - dotIndex - 1 );
-        layerName = P->mEncoding->fromUnicode( modifiedLayerName );
-      }
-    }
-    QByteArray sql = "SELECT * FROM " + P->quotedIdentifier( layerName );
-    sql += " WHERE " + P->textEncoding()->fromUnicode( P->subsetString() );
-    QgsDebugMsg( QString( "SQL: %1" ).arg( P->textEncoding()->toUnicode( sql ) ) );
-    ogrLayer = OGR_DS_ExecuteSQL( ogrDataSource, sql.constData(), NULL, NULL );
+    ogrLayer = P->setSubsetString( ogrLayer, ogrDataSource );
     mSubsetStringSet = true;
   }
 

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -398,23 +398,8 @@ bool QgsOgrProvider::setSubsetString( QString theSQL, bool updateFeatureCount )
 
   if ( !mSubsetString.isEmpty() )
   {
-    QByteArray layerName = OGR_FD_GetName( OGR_L_GetLayerDefn( ogrOrigLayer ) );
-    if ( ogrDriverName == "ODBC" ) //the odbc driver does not like schema names for subset
-    {
-      QString layerNameString = mEncoding->toUnicode( layerName );
-      int dotIndex = layerNameString.indexOf( "." );
-      if ( dotIndex > 1 )
-      {
-        QString modifiedLayerName = layerNameString.right( layerNameString.size() - dotIndex - 1 );
-        layerName = mEncoding->fromUnicode( modifiedLayerName );
-      }
-    }
-    QByteArray sql = "SELECT * FROM " + quotedIdentifier( layerName );
-    sql += " WHERE " + mEncoding->fromUnicode( mSubsetString );
 
-    QgsDebugMsg( QString( "SQL: %1" ).arg( mEncoding->toUnicode( sql ) ) );
-    ogrLayer = OGR_DS_ExecuteSQL( ogrDataSource, sql.constData(), NULL, NULL );
-
+    ogrLayer = setSubsetString( ogrOrigLayer, ogrDataSource );
     if ( !ogrLayer )
     {
       pushError( tr( "OGR[%1] error %2: %3" ).arg( CPLGetLastErrorType() ).arg( CPLGetLastErrorNo() ).arg( CPLGetLastErrorMsg() ) );
@@ -2417,6 +2402,26 @@ OGRwkbGeometryType QgsOgrProvider::ogrWkbSingleFlatten( OGRwkbGeometryType type 
     case wkbMultiPolygon: return wkbPolygon;
     default: return type;
   }
+}
+
+OGRLayerH QgsOgrProvider::setSubsetString( OGRLayerH layer, OGRDataSourceH ds )
+{
+  QByteArray layerName = OGR_FD_GetName( OGR_L_GetLayerDefn( layer ) );
+  if ( ogrDriverName == "ODBC" ) //the odbc driver does not like schema names for subset
+  {
+    QString layerNameString = mEncoding->toUnicode( layerName );
+    int dotIndex = layerNameString.indexOf( "." );
+    if ( dotIndex > 1 )
+    {
+      QString modifiedLayerName = layerNameString.right( layerNameString.size() - dotIndex - 1 );
+      layerName = mEncoding->fromUnicode( modifiedLayerName );
+    }
+  }
+  QByteArray sql = "SELECT * FROM " + quotedIdentifier( layerName );
+  sql += " WHERE " + mEncoding->fromUnicode( mSubsetString );
+
+  QgsDebugMsg( QString( "SQL: %1" ).arg( mEncoding->toUnicode( sql ) ) );
+  return OGR_DS_ExecuteSQL( ds, sql.constData(), NULL, NULL );
 }
 
 // ---------------------------------------------------------------------------

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -398,7 +398,18 @@ bool QgsOgrProvider::setSubsetString( QString theSQL, bool updateFeatureCount )
 
   if ( !mSubsetString.isEmpty() )
   {
-    QByteArray sql = "SELECT * FROM " + quotedIdentifier( OGR_FD_GetName( OGR_L_GetLayerDefn( ogrOrigLayer ) ) );
+    QByteArray layerName = OGR_FD_GetName( OGR_L_GetLayerDefn( ogrOrigLayer ) );
+    if ( ogrDriverName == "ODBC" ) //the odbc driver does not like schema names for subset
+    {
+      QString layerNameString = mEncoding->toUnicode( layerName );
+      int dotIndex = layerNameString.indexOf( "." );
+      if ( dotIndex > 1 )
+      {
+        QString modifiedLayerName = layerNameString.right( layerNameString.size() - dotIndex - 1 );
+        layerName = mEncoding->fromUnicode( modifiedLayerName );
+      }
+    }
+    QByteArray sql = "SELECT * FROM " + quotedIdentifier( layerName );
     sql += " WHERE " + mEncoding->fromUnicode( mSubsetString );
 
     QgsDebugMsg( QString( "SQL: %1" ).arg( mEncoding->toUnicode( sql ) ) );

--- a/src/providers/ogr/qgsogrprovider.h
+++ b/src/providers/ogr/qgsogrprovider.h
@@ -341,6 +341,8 @@ class QgsOgrProvider : public QgsVectorDataProvider
     /**Calls OGR_L_SyncToDisk and recreates the spatial index if present*/
     bool syncToDisc();
 
+    OGRLayerH setSubsetString( OGRLayerH layer, OGRDataSourceH ds );
+
     friend class QgsOgrFeatureIterator;
     QSet< QgsOgrFeatureIterator* > mActiveIterators;
 };


### PR DESCRIPTION
Creating subsets for ODBC ogr layers does currently not work because the odbc ogr driver does not accept a schema name in the ogr SQL string. This patch fixes that by removing the schema from the layer name. 

Please review.
