### PR TITLE
Solve map canvas flickering on X11 (linux) systems

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -704,6 +704,13 @@ int main( int argc, char *argv[] )
     QgsCustomization::instance()->setEnabled( false );
   }
 
+  // Temporary fix, until the rendering is not done in the main thread any more:
+  // switch graphics system to "X11" (instead of Qt's "raster") to avoid flickering
+  // see http://hub.qgis.org/issues/4011#note-31
+#ifdef Q_WS_X11
+  QgsApplication::setGraphicsSystem( QLatin1String( "X11" ) );
+#endif
+
   QgsApplication myApp( argc, argv, myUseGuiFlag, configpath );
 
 // (if Windows/Mac, use icon from resource)

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -93,10 +93,6 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WFlags fl ) :
   connect( cmbIconSize, SIGNAL( highlighted( const QString& ) ), this, SLOT( iconSizeChanged( const QString& ) ) );
   connect( cmbIconSize, SIGNAL( textChanged( const QString& ) ), this, SLOT( iconSizeChanged( const QString& ) ) );
 
-#ifdef Q_WS_X11
-  connect( chkEnableBackbuffer, SIGNAL( stateChanged( int ) ), this, SLOT( toggleEnableBackbuffer( int ) ) );
-#endif
-
   connect( this, SIGNAL( accepted() ), this, SLOT( saveOptions() ) );
   connect( this, SIGNAL( rejected() ), this, SLOT( rejectOptions() ) );
 
@@ -344,19 +340,9 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WFlags fl ) :
   if ( index == -1 ) index = 1;
   cmbScanZipInBrowser->setCurrentIndex( index );
 
-  // Set the enable backbuffer state for X11 (linux) systems only
-  // TODO: remove this when threading is implemented
-#ifdef Q_WS_X11
-  chkEnableBackbuffer->setChecked( settings.value( "/Map/enableBackbuffer", 1 ).toBool() );
-  toggleEnableBackbuffer( chkEnableBackbuffer->checkState() );
-#elif defined(Q_WS_MAC)
-  chkEnableBackbuffer->setChecked( true );
-  chkEnableBackbuffer->setEnabled( false );
+#ifdef Q_WS_MAC
   labelUpdateThreshold->setEnabled( false );
   spinBoxUpdateThreshold->setEnabled( false );
-#else // Q_WS_WIN32
-  chkEnableBackbuffer->setChecked( true );
-  chkEnableBackbuffer->setEnabled( false );
 #endif
 
   // set the display update threshold
@@ -812,24 +798,6 @@ void QgsOptions::on_mProjectOnLaunchPushBtn_pressed()
   }
 }
 
-void QgsOptions::toggleEnableBackbuffer( int state )
-{
-#ifdef Q_WS_X11
-  if ( Qt::Checked == state )
-  {
-    labelUpdateThreshold->setEnabled( false );
-    spinBoxUpdateThreshold->setEnabled( false );
-  }
-  else
-  {
-    labelUpdateThreshold->setEnabled( true );
-    spinBoxUpdateThreshold->setEnabled( true );
-  }
-#else
-  Q_UNUSED( state );
-#endif
-}
-
 QString QgsOptions::theme()
 {
   // returns the current theme (as selected in the cmbTheme combo box)
@@ -1002,7 +970,6 @@ void QgsOptions::saveOptions()
   settings.setValue( "/Raster/cumulativeCutLower", mRasterCumulativeCutLowerDoubleSpinBox->value() / 100.0 );
   settings.setValue( "/Raster/cumulativeCutUpper", mRasterCumulativeCutUpperDoubleSpinBox->value() / 100.0 );
 
-  settings.setValue( "/Map/enableBackbuffer", chkEnableBackbuffer->isChecked() );
   int threshold = spinBoxUpdateThreshold->value();
   settings.setValue( "/Map/updateThreshold", threshold < 1000 ? 0 : threshold );
 

--- a/src/app/qgsoptions.h
+++ b/src/app/qgsoptions.h
@@ -88,10 +88,6 @@ class QgsOptions : public QgsOptionsDialogBase, private Ui::QgsOptionsBase
      */
     void on_mProjectOnLaunchPushBtn_pressed();
 
-    //! Slot to change backbuffering. This is handled when the user changes
-    // the value of the checkbox
-    void toggleEnableBackbuffer( int );
-
     /**
      * Return the desired state of newly added layers. If a layer
      * is to be drawn when added to the map, this function returns

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -412,24 +412,17 @@ void QgsVectorLayer::drawRendererV2( QgsFeatureIterator &fit, QgsRenderContext& 
         continue; // skip features without geometry
 
 #ifndef Q_WS_MAC //MH: disable this on Mac for now to avoid problems with resizing
-#ifdef Q_WS_X11
-      if ( !mEnableBackbuffer ) // do not handle events, as we're already inside a paint event
+      if ( mUpdateThreshold > 0 && 0 == featureCount % mUpdateThreshold )
       {
-#endif // Q_WS_X11
-        if ( mUpdateThreshold > 0 && 0 == featureCount % mUpdateThreshold )
-        {
-          emit screenUpdateRequested();
-          // emit drawingProgress( featureCount, totalFeatures );
-          qApp->processEvents();
-        }
-        else if ( featureCount % 1000 == 0 )
-        {
-          // emit drawingProgress( featureCount, totalFeatures );
-          qApp->processEvents();
-        }
-#ifdef Q_WS_X11
+        emit screenUpdateRequested();
+        // emit drawingProgress( featureCount, totalFeatures );
+        qApp->processEvents();
       }
-#endif // Q_WS_X11
+      else if ( featureCount % 1000 == 0 )
+      {
+        // emit drawingProgress( featureCount, totalFeatures );
+        qApp->processEvents();
+      }
 #endif // Q_WS_MAC
 
       if ( rendererContext.renderingStopped() )
@@ -652,10 +645,6 @@ bool QgsVectorLayer::draw( QgsRenderContext& rendererContext )
   {
     mUpdateThreshold = 1000;
   }
-
-#ifdef Q_WS_X11
-  mEnableBackbuffer = settings.value( "/Map/enableBackbuffer", 1 ).toBool();
-#endif
 
   if ( !mRendererV2 )
     return false;

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -1444,12 +1444,6 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
      */
     int mUpdateThreshold;
 
-    /** Enables backbuffering for the map window. This improves graphics performance,
-     *  but the possibility to cancel rendering and incremental feature drawing will be lost.
-     *
-     */
-    bool mEnableBackbuffer;
-
     /** Pointer to data provider derived from the abastract base class QgsDataProvider */
     QgsVectorDataProvider *mDataProvider;
 

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -96,7 +96,6 @@ QgsMapCanvas::QgsMapCanvas( QWidget * parent, const char *name )
   mMapTool = NULL;
   mLastNonZoomMapTool = NULL;
 
-  mBackbufferEnabled = true;
   mDrawing = false;
   mFrozen = false;
   mDirty = true;
@@ -385,27 +384,11 @@ void QgsMapCanvas::refresh()
   }
 
 #ifdef Q_WS_X11
-  bool enableBackbufferSetting = settings.value( "/Map/enableBackbuffer", 1 ).toBool();
-#endif
-
-#ifdef Q_WS_X11
 #ifndef ANDROID
   // disable the update that leads to the resize crash on X11 systems
   if ( viewport() )
   {
-    if ( enableBackbufferSetting != mBackbufferEnabled )
-    {
-      qDebug() << "Enable back buffering: " << enableBackbufferSetting;
-      if ( enableBackbufferSetting )
-      {
-        viewport()->setAttribute( Qt::WA_PaintOnScreen, false );
-      }
-      else
-      {
-        viewport()->setAttribute( Qt::WA_PaintOnScreen, true );
-      }
-      mBackbufferEnabled = enableBackbufferSetting;
-    }
+    viewport()->setAttribute( Qt::WA_PaintOnScreen, true );
   }
 #endif // ANDROID
 #endif // Q_WS_X11

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -432,8 +432,6 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     //! map overview widget - it's controlled by QgsMapCanvas
     QgsMapOverviewCanvas* mMapOverview;
 
-    //! If backbuffering is currently enabled
-    bool mBackbufferEnabled;
     //! Flag indicating a map refresh is in progress
     bool mDrawing;
 

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -266,8 +266,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>687</width>
-                <height>523</height>
+                <width>661</width>
+                <height>674</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_28">
@@ -912,8 +912,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>670</width>
-                <height>750</height>
+                <width>661</width>
+                <height>803</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_22">
@@ -1248,8 +1248,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>687</width>
-                <height>523</height>
+                <width>674</width>
+                <height>496</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_27">
@@ -1577,8 +1577,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>670</width>
-                <height>611</height>
+                <width>661</width>
+                <height>725</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_29">
@@ -1588,16 +1588,6 @@
                   <string>Rendering behavior</string>
                  </property>
                  <layout class="QGridLayout" name="_4">
-                  <item row="1" column="0">
-                   <widget class="QCheckBox" name="chkEnableBackbuffer">
-                    <property name="toolTip">
-                     <string>Better graphics performance at the cost of loosing the possibility to cancel rendering and incremental feature drawing</string>
-                    </property>
-                    <property name="text">
-                     <string>Enable back buffer</string>
-                    </property>
-                   </widget>
-                  </item>
                   <item row="0" column="0">
                    <widget class="QCheckBox" name="chkAddedVisibility">
                     <property name="text">
@@ -1605,14 +1595,14 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="4" column="0" colspan="2">
+                  <item row="3" column="0" colspan="2">
                    <widget class="QCheckBox" name="chkUseRenderCaching">
                     <property name="text">
                      <string>Use render caching where possible to speed up redraws</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="2" column="0">
+                  <item row="1" column="0">
                    <layout class="QHBoxLayout" name="horizontalLayout_26">
                     <item>
                      <widget class="QLabel" name="labelUpdateThreshold">
@@ -1642,7 +1632,7 @@
                     </item>
                    </layout>
                   </item>
-                  <item row="3" column="0" colspan="2">
+                  <item row="2" column="0" colspan="2">
                    <widget class="QLabel" name="textLabel3">
                     <property name="text">
                      <string>&lt;b&gt;Note:&lt;/b&gt; Set below 1000 to prevent display updates until all features have been rendered</string>
@@ -2092,8 +2082,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>687</width>
-                <height>523</height>
+                <width>482</width>
+                <height>353</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_25">
@@ -2395,8 +2385,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>670</width>
-                <height>619</height>
+                <width>532</width>
+                <height>770</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_30">
@@ -2802,8 +2792,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>670</width>
-                <height>551</height>
+                <width>497</width>
+                <height>691</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_31">
@@ -3303,8 +3293,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>687</width>
-                <height>523</height>
+                <width>464</width>
+                <height>386</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -3443,8 +3433,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>687</width>
-                <height>523</height>
+                <width>639</width>
+                <height>422</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_15">
@@ -3624,8 +3614,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>687</width>
-                <height>523</height>
+                <width>298</width>
+                <height>240</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_32">
@@ -3724,8 +3714,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>670</width>
-                <height>528</height>
+                <width>534</width>
+                <height>672</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_33">


### PR DESCRIPTION
With this fix, the flickering disappears but you are still able to
- enable incremental rendering
- cancel the rendering process
- not having artifacts
