### PR TITLE
Fix Blocker Issue #7871 : SVG Marker fill and outlin colors are restored

### DIFF
--- a/src/gui/symbology-ng/qgssymbollayerv2widget.cpp
+++ b/src/gui/symbology-ng/qgssymbollayerv2widget.cpp
@@ -905,9 +905,27 @@ void QgsSvgMarkerSymbolLayerV2Widget::setGuiForSvg( const QgsSvgMarkerSymbolLaye
   mBorderWidthSpinBox->setEnabled( hasOutlineWidthParam );
 
   if ( hasFillParam )
-    mChangeColorButton->setColor( defaultFill );
+  {
+    if ( layer->fillColor().isValid() )
+    {
+      mChangeColorButton->setColor( layer->fillColor() );
+    }
+    else
+    {
+      mChangeColorButton->setColor( defaultFill );
+    }
+  }
   if ( hasOutlineParam )
-    mChangeBorderColorButton->setColor( defaultOutline );
+  {
+    if ( layer->outlineColor().isValid() )
+    {
+      mChangeBorderColorButton->setColor( layer->outlineColor() );
+    }
+    else
+    {
+      mChangeBorderColorButton->setColor( defaultOutline );
+    }
+  }
 
   mFileLineEdit->blockSignals( true );
   mFileLineEdit->setText( layer->path() );


### PR DESCRIPTION
when changing widget or reopening style window
