### PR TITLE
fTools/union: fix output attribute shift

### DIFF
--- a/python/plugins/fTools/tools/doGeoprocessing.py
+++ b/python/plugins/fTools/tools/doGeoprocessing.py
@@ -1196,13 +1196,14 @@ class geoprocessingThread( QThread ):
             FEATURE_EXCEPT = False
 
     length = len( vproviderA.fields() )
+    atMapA = [None] * length
 
     fitB = vproviderB.getFeatures()
     while fitB.nextFeature( inFeatB ):
       add = False
       geom = QgsGeometry( inFeatB.geometry() )
       diff_geom = QgsGeometry( geom )
-      atMap = inFeatB.attributes()
+      atMap = atMapA + inFeatB.attributes()
       intersects = indexB.intersects( geom.boundingBox() )
 
       if len(intersects) < 1:


### PR DESCRIPTION
This fixes a regression (due to the Vector API change). Attributes that come from "Union" layer should be located on right places.

![union_result](https://f.cloud.github.com/assets/2672095/1061744/b760f566-11fe-11e3-937c-628eea07e3a6.png)
Image: Attribute table of Daniel's result_two_layers.shp (two_layers.tar.gz on http://hub.qgis.org/issues/8456)
