### PR TITLE
Remove deprecated labeling properties tab if not used by older project

### DIFF
--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -435,6 +435,10 @@ class QgisApp : public QMainWindow, private Ui::MainWindow
     QList<QgsDecorationItem*> decorationItems() { return mDecorationItems; }
     void addDecorationItem( QgsDecorationItem* item ) { mDecorationItems.append( item ); }
 
+    /** Whether the current project still uses deprecated labels (QGIS 2.0)
+     */
+    bool deprecatedLabelsInProject() { return mDeprecatedLabelsInProj; }
+
   public slots:
     //! Zoom to full extent
     void zoomFull();
@@ -1038,6 +1042,10 @@ class QgisApp : public QMainWindow, private Ui::MainWindow
     //! shows label settings dialog (for labeling-ng)
     void labeling();
 
+    /** Check if deprecated labels are used in project and enable/disable it for project's open session (QGIS 2.0)
+     */
+    void checkForDeprecatedLabelsInProject();
+
     //! save current vector layer
     void saveAsFile();
     void saveSelectionAsVectorFile();
@@ -1481,6 +1489,9 @@ class QgisApp : public QMainWindow, private Ui::MainWindow
     //! a bar to display warnings in a non-blocker manner
     QgsMessageBar *mInfoBar;
     QWidget *mMacrosWarn;
+
+    //! whether deprecated labels are used in current project (QGIS 2.0)
+    bool mDeprecatedLabelsInProj;
 
 #ifdef HAVE_TOUCH
     bool gestureEvent( QGestureEvent *event );

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -267,7 +267,7 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
 
 QgsVectorLayerProperties::~QgsVectorLayerProperties()
 {
-  if ( layer->hasGeometryType() )
+  if ( mOptsPage_LabelsOld && layer->hasGeometryType() )
   {
     disconnect( labelDialog, SIGNAL( labelSourceSet() ), this, SLOT( setLabelCheckBox() ) );
   }
@@ -412,6 +412,18 @@ void QgsVectorLayerProperties::syncToLayer( void )
   mFieldsPropertiesDialog->init();
 
   QObject::connect( labelCheckBox, SIGNAL( clicked( bool ) ), this, SLOT( enableLabelOptions( bool ) ) );
+
+  // delete deprecated labels tab if not already used by project
+  // NOTE: this is not ideal, but a quick fix for QGIS 2.0 release
+  if ( !QgisApp::instance()->deprecatedLabelsInProject() )
+  {
+    if ( mOptsPage_LabelsOld )
+    {
+      disconnect( labelDialog, SIGNAL( labelSourceSet() ), this, SLOT( setLabelCheckBox() ) );
+      delete mOptsPage_LabelsOld;
+      mOptsPage_LabelsOld = 0;
+    }
+  }
 } // reset()
 
 
@@ -462,10 +474,13 @@ void QgsVectorLayerProperties::apply()
 
   actionDialog->apply();
 
-  if ( labelDialog )
-    labelDialog->apply();
-  layer->enableLabels( labelCheckBox->isChecked() );
-  layer->setLayerName( mLayerOrigNameLineEdit->text() );
+  if ( mOptsPage_LabelsOld )
+  {
+    if ( labelDialog )
+      labelDialog->apply();
+    layer->enableLabels( labelCheckBox->isChecked() );
+    layer->setLayerName( mLayerOrigNameLineEdit->text() );
+  }
 
   // Apply fields settings
   mFieldsPropertiesDialog->apply();


### PR DESCRIPTION
Deprecated labels tab remains active for all layers in an older project, if any layer uses them, for the duration of project's open session

Caveat (feature?):
- If all layers no longer use deprecated labels on project close, when reopened, deprecated labels tab will no longer be available

I created another branch where the deprecated labels tab was only turned on for the layers that use deprecated labels (7eb4866ff38ee1d0e9c8b16dc6921b762e8ba056). However, this was fairly limiting (see commit message) and would probably annoy users.
