### PR TITLE
QGIS Server: Exclude composers in OWS tab does not work

### DIFF
--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -316,7 +316,7 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas* mapCanvas, QWidget *pa
   grpWMSList->setChecked( mWMSList->count() > 0 );
 
   //composer restriction for WMS
-  values = QgsProject::instance()->readListEntry( "WMSComposerList", "/", QStringList(), &ok );
+  values = QgsProject::instance()->readListEntry( "WMSRestrictedComposers", "/", QStringList(), &ok );
   mWMSComposerGroupBox->setChecked( ok );
   if ( ok )
   {
@@ -699,11 +699,11 @@ void QgsProjectProperties::apply()
     {
       composerTitles << mComposerListWidget->item( i )->text();
     }
-    QgsProject::instance()->writeEntry( "WMSComposerList", "/", composerTitles );
+    QgsProject::instance()->writeEntry( "WMSRestrictedComposers", "/", composerTitles );
   }
   else
   {
-    QgsProject::instance()->removeEntry( "WMSComposerList", "/" );
+    QgsProject::instance()->removeEntry( "WMSRestrictedComposers", "/" );
   }
 
   //WMS layer restrictions

--- a/src/mapserver/qgsprojectparser.cpp
+++ b/src/mapserver/qgsprojectparser.cpp
@@ -2407,8 +2407,8 @@ QList<QDomElement> QgsProjectParser::publishedComposerElements() const
   QDomNodeList composerNodeList = mXMLDoc->elementsByTagName( "Composer" );
 
   QDomElement propertiesElem = mXMLDoc->documentElement().firstChildElement( "properties" );
-  QDomElement wmsComposerListElem = propertiesElem.firstChildElement( "WMSComposerList" );
-  if ( wmsComposerListElem.isNull() )
+  QDomElement wmsRestrictedComposersElem = propertiesElem.firstChildElement( "WMSRestrictedComposers" );
+  if ( wmsRestrictedComposersElem.isNull() )
   {
     for ( unsigned int i = 0; i < composerNodeList.length(); ++i )
     {
@@ -2417,11 +2417,11 @@ QList<QDomElement> QgsProjectParser::publishedComposerElements() const
     return composerElemList;
   }
 
-  QSet<QString> publishedComposerNames;
-  QDomNodeList valueList = wmsComposerListElem.elementsByTagName( "value" );
+  QSet<QString> restrictedComposerNames;
+  QDomNodeList valueList = wmsRestrictedComposersElem.elementsByTagName( "value" );
   for ( int i = 0; i < valueList.size(); ++i )
   {
-    publishedComposerNames.insert( valueList.at( i ).toElement().text() );
+    restrictedComposerNames.insert( valueList.at( i ).toElement().text() );
   }
 
   //remove unpublished composers from list
@@ -2431,7 +2431,7 @@ QList<QDomElement> QgsProjectParser::publishedComposerElements() const
   {
     currentElem = composerNodeList.at( i ).toElement();
     currentComposerName = currentElem.attribute( "title" );
-    if ( publishedComposerNames.contains( currentComposerName ) )
+    if ( !restrictedComposerNames.contains( currentComposerName ) )
     {
       composerElemList.push_back( currentElem );
     }


### PR DESCRIPTION
In the current QGIS server, if one uses a list of "Exclude composers" in the OWS tab, QGIS server lists only the excluded composers and not the composers the map author actually wants. So it acts as a white list and not as a black list.
