### PR TITLE
Fix crash in core plugins

### DIFF
--- a/src/plugins/compass/qgscompassplugin.cpp
+++ b/src/plugins/compass/qgscompassplugin.cpp
@@ -145,15 +145,21 @@ void QgsCompassPlugin::unload()
   mQGisIface->removePluginMenu( sName, mActionAboutCompass );
 
   delete mActionRunCompass;
+  mActionRunCompass = 0;
   delete mActionAboutCompass;
+  mActionAboutCompass = 0;
   delete mDock;
+  mDock = 0;
 }
 
 //! Set icons to the current theme
 void QgsCompassPlugin::setCurrentTheme( QString )
 {
-  mActionRunCompass->setIcon( getThemeIcon( "/mCompassRun.png" ) );
-  mActionAboutCompass->setIcon( getThemeIcon( "/mActionAbout.png" ) );
+  if ( mActionRunCompass && mActionAboutCompass )
+  {
+    mActionRunCompass->setIcon( getThemeIcon( "/mCompassRun.png" ) );
+    mActionAboutCompass->setIcon( getThemeIcon( "/mActionAbout.png" ) );
+  }
 }
 
 QIcon QgsCompassPlugin::getThemeIcon( const QString &theName )

--- a/src/plugins/dxf2shp_converter/dxf2shpconverter.cpp
+++ b/src/plugins/dxf2shp_converter/dxf2shpconverter.cpp
@@ -115,6 +115,7 @@ void dxf2shpConverter::unload()
   mQGisIface->removePluginVectorMenu( tr( "&Dxf2Shp" ), mQActionPointer );
   mQGisIface->removeVectorToolBarIcon( mQActionPointer );
   delete mQActionPointer;
+  mQActionPointer = 0;
 }
 
 void dxf2shpConverter::addMyLayer( QString myfname, QString mytitle )
@@ -129,21 +130,24 @@ void dxf2shpConverter::setCurrentTheme( QString theThemeName )
   QString myCurThemePath = QgsApplication::activeThemePath() + "/plugins/dxf2shp_converter.png";
   QString myDefThemePath = QgsApplication::defaultThemePath() + "/plugins/dxf2shp_converter.png";
   QString myQrcPath = ":/dxf2shp_converter.png";
-  if ( QFile::exists( myCurThemePath ) )
+  if ( mQActionPointer )
   {
-    mQActionPointer->setIcon( QIcon( myCurThemePath ) );
-  }
-  else if ( QFile::exists( myDefThemePath ) )
-  {
-    mQActionPointer->setIcon( QIcon( myDefThemePath ) );
-  }
-  else if ( QFile::exists( myQrcPath ) )
-  {
-    mQActionPointer->setIcon( QIcon( myQrcPath ) );
-  }
-  else
-  {
-    mQActionPointer->setIcon( QIcon() );
+    if ( QFile::exists( myCurThemePath ) )
+    {
+      mQActionPointer->setIcon( QIcon( myCurThemePath ) );
+    }
+    else if ( QFile::exists( myDefThemePath ) )
+    {
+      mQActionPointer->setIcon( QIcon( myDefThemePath ) );
+    }
+    else if ( QFile::exists( myQrcPath ) )
+    {
+      mQActionPointer->setIcon( QIcon( myQrcPath ) );
+    }
+    else
+    {
+      mQActionPointer->setIcon( QIcon() );
+    }
   }
 }
 

--- a/src/plugins/georeferencer/qgsgeorefplugin.cpp
+++ b/src/plugins/georeferencer/qgsgeorefplugin.cpp
@@ -125,6 +125,7 @@ void QgsGeorefPlugin::unload()
   mQGisIface->removeRasterToolBarIcon( mActionRunGeoref );
 
   delete mActionRunGeoref;
+  mActionRunGeoref = 0;
 
   delete mPluginGui;
   mPluginGui = NULL;
@@ -133,7 +134,8 @@ void QgsGeorefPlugin::unload()
 //! Set icons to the current theme
 void QgsGeorefPlugin::setCurrentTheme( QString )
 {
-  mActionRunGeoref->setIcon( getThemeIcon( "/mGeorefRun.png" ) );
+  if ( mActionRunGeoref )
+    mActionRunGeoref->setIcon( getThemeIcon( "/mGeorefRun.png" ) );
 }
 
 QIcon QgsGeorefPlugin::getThemeIcon( const QString &theName )

--- a/src/plugins/gps_importer/qgsgpsplugin.cpp
+++ b/src/plugins/gps_importer/qgsgpsplugin.cpp
@@ -211,6 +211,7 @@ void QgsGPSPlugin::unload()
   mQGisInterface->removePluginVectorMenu( tr( "&GPS" ), mQActionPointer );
   mQGisInterface->removeVectorToolBarIcon( mQActionPointer );
   delete mQActionPointer;
+  mQActionPointer = 0;
 }
 
 void QgsGPSPlugin::loadGPXFile( QString fileName, bool loadWaypoints, bool loadRoutes,
@@ -665,25 +666,28 @@ void QgsGPSPlugin::setCurrentTheme( QString theThemeName )
   QString myCurThemePath = QgsApplication::activeThemePath() + "/plugins/gps_importer/";
   QString myDefThemePath = QgsApplication::defaultThemePath() + "/plugins/gps_importer/";
   QString myQrcPath = ":/";
-  if ( QFile::exists( myCurThemePath ) )
+  if ( mQActionPointer )
   {
-    mQActionPointer->setIcon( QIcon( myCurThemePath + "import_gpx.png" ) );
-    mCreateGPXAction->setIcon( QIcon( myCurThemePath + "create_gpx.png" ) );
-  }
-  else if ( QFile::exists( myDefThemePath ) )
-  {
-    mQActionPointer->setIcon( QIcon( myDefThemePath + "import_gpx.png" ) );
-    mCreateGPXAction->setIcon( QIcon( myDefThemePath + "create_gpx.png" ) );
-  }
-  else if ( QFile::exists( myQrcPath ) )
-  {
-    mQActionPointer->setIcon( QIcon( myQrcPath + "import_gpx.png" ) );
-    mCreateGPXAction->setIcon( QIcon( myQrcPath + "create_gpx.png" ) );
-  }
-  else
-  {
-    mQActionPointer->setIcon( QIcon() );
-    mCreateGPXAction->setIcon( QIcon() );
+    if ( QFile::exists( myCurThemePath ) )
+    {
+      mQActionPointer->setIcon( QIcon( myCurThemePath + "import_gpx.png" ) );
+      mCreateGPXAction->setIcon( QIcon( myCurThemePath + "create_gpx.png" ) );
+    }
+    else if ( QFile::exists( myDefThemePath ) )
+    {
+      mQActionPointer->setIcon( QIcon( myDefThemePath + "import_gpx.png" ) );
+      mCreateGPXAction->setIcon( QIcon( myDefThemePath + "create_gpx.png" ) );
+    }
+    else if ( QFile::exists( myQrcPath ) )
+    {
+      mQActionPointer->setIcon( QIcon( myQrcPath + "import_gpx.png" ) );
+      mCreateGPXAction->setIcon( QIcon( myQrcPath + "create_gpx.png" ) );
+    }
+    else
+    {
+      mQActionPointer->setIcon( QIcon() );
+      mCreateGPXAction->setIcon( QIcon() );
+    }
   }
 }
 

--- a/src/plugins/grass/qgsgrassplugin.cpp
+++ b/src/plugins/grass/qgsgrassplugin.cpp
@@ -848,7 +848,10 @@ void QgsGrassPlugin::unload()
   delete mNewVectorAction;
 
   if ( toolBarPointer )
+  {
     delete toolBarPointer;
+    toolBarPointer = 0;
+  }
 
   // disconnect slots of QgsGrassPlugin so they're not fired also after unload
   disconnect( mCanvas, SIGNAL( renderComplete( QPainter * ) ), this, SLOT( postRender( QPainter * ) ) );
@@ -864,20 +867,22 @@ void QgsGrassPlugin::unload()
 void QgsGrassPlugin::setCurrentTheme( QString theThemeName )
 {
   Q_UNUSED( theThemeName );
+  if ( toolBarPointer )
+  {
+    mOpenMapsetAction->setIcon( getThemeIcon( "grass_open_mapset.png" ) );
+    mNewMapsetAction->setIcon( getThemeIcon( "grass_new_mapset.png" ) );
+    mCloseMapsetAction->setIcon( getThemeIcon( "grass_close_mapset.png" ) );
 
-  mOpenMapsetAction->setIcon( getThemeIcon( "grass_open_mapset.png" ) );
-  mNewMapsetAction->setIcon( getThemeIcon( "grass_new_mapset.png" ) );
-  mCloseMapsetAction->setIcon( getThemeIcon( "grass_close_mapset.png" ) );
+    mAddVectorAction->setIcon( getThemeIcon( "grass_add_vector.png" ) );
+    mAddRasterAction->setIcon( getThemeIcon( "grass_add_raster.png" ) );
+    mOpenToolsAction->setIcon( getThemeIcon( "grass_tools.png" ) );
 
-  mAddVectorAction->setIcon( getThemeIcon( "grass_add_vector.png" ) );
-  mAddRasterAction->setIcon( getThemeIcon( "grass_add_raster.png" ) );
-  mOpenToolsAction->setIcon( getThemeIcon( "grass_tools.png" ) );
+    mRegionAction->setIcon( getThemeIcon( "grass_region.png" ) );
 
-  mRegionAction->setIcon( getThemeIcon( "grass_region.png" ) );
-
-  mEditRegionAction->setIcon( getThemeIcon( "grass_region_edit.png" ) );
-  mEditAction->setIcon( getThemeIcon( "grass_edit.png" ) );
-  mNewVectorAction->setIcon( getThemeIcon( "grass_new_vector_layer.png" ) );
+    mEditRegionAction->setIcon( getThemeIcon( "grass_region_edit.png" ) );
+    mEditAction->setIcon( getThemeIcon( "grass_edit.png" ) );
+    mNewVectorAction->setIcon( getThemeIcon( "grass_new_vector_layer.png" ) );
+  }
 }
 
 // Note this code is duplicated from qgisapp.cpp because

--- a/src/plugins/spatialquery/qgsspatialqueryplugin.cpp
+++ b/src/plugins/spatialquery/qgsspatialqueryplugin.cpp
@@ -99,7 +99,7 @@ void QgsSpatialQueryPlugin::unload()
   mIface->removePluginVectorMenu( tr( "&Spatial Query" ), mSpatialQueryAction );
 
   delete mSpatialQueryAction;
-
+  mSpatialQueryAction = 0;
   delete mDialog;
   mDialog = NULL;
 }
@@ -137,7 +137,8 @@ void QgsSpatialQueryPlugin::run()
 //! Set icons to the current theme
 void QgsSpatialQueryPlugin::setCurrentTheme( QString )
 {
-  mSpatialQueryAction->setIcon( getThemeIcon( "/spatialquery.png" ) );
+  if ( mSpatialQueryAction )
+    mSpatialQueryAction->setIcon( getThemeIcon( "/spatialquery.png" ) );
 }
 
 QIcon QgsSpatialQueryPlugin::getThemeIcon( const QString &theName )

--- a/src/plugins/spit/qgsspitplugin.cpp
+++ b/src/plugins/spit/qgsspitplugin.cpp
@@ -93,6 +93,7 @@ void QgsSpitPlugin::unload()
   qI->removeDatabaseToolBarIcon( spitAction );
   qI->removePluginDatabaseMenu( tr( "&Spit" ), spitAction );
   delete spitAction;
+  spitAction = 0;
 }
 
 //! Set icons to the current theme
@@ -102,21 +103,24 @@ void QgsSpitPlugin::setCurrentTheme( QString theThemeName )
   QString myCurThemePath = QgsApplication::activeThemePath() + "/plugins/spit.png";
   QString myDefThemePath = QgsApplication::defaultThemePath() + "/plugins/spit.png";
   QString myQrcPath = ":/spit.png";
-  if ( QFile::exists( myCurThemePath ) )
+  if ( spitAction )
   {
-    spitAction->setIcon( QIcon( myCurThemePath ) );
-  }
-  else if ( QFile::exists( myDefThemePath ) )
-  {
-    spitAction->setIcon( QIcon( myDefThemePath ) );
-  }
-  else if ( QFile::exists( myQrcPath ) )
-  {
-    spitAction->setIcon( QIcon( myQrcPath ) );
-  }
-  else
-  {
-    spitAction->setIcon( QIcon() );
+    if ( QFile::exists( myCurThemePath ) )
+    {
+      spitAction->setIcon( QIcon( myCurThemePath ) );
+    }
+    else if ( QFile::exists( myDefThemePath ) )
+    {
+      spitAction->setIcon( QIcon( myDefThemePath ) );
+    }
+    else if ( QFile::exists( myQrcPath ) )
+    {
+      spitAction->setIcon( QIcon( myQrcPath ) );
+    }
+    else
+    {
+      spitAction->setIcon( QIcon() );
+    }
   }
 }
 


### PR DESCRIPTION
Sorry if I haven't described this bug before, but I discussed about it last night on IRC channel together to @timlinux and @jef-n who has already fixed the coordinate capture plugin.

This issue occurs when you disabled a core plugin (spatialquery, georeferencer etc) and subsequently you try to change some setting in option dialog. It is happening because the `currentThemeChanged` signal is emitted (I am guessing also other signals), just simply hitting the OK button without changing anything,and it tries to change the current theme  for the plugin action button which is not unloaded properly. I had thought to comment out the line that connects at the `setCurrentTheme` slot, since we have only the default theme, but Jürgen has found a more elegant solution.

Also note that I was able to test grass and compass plugin which also are affected as they are using that signal.
Could anybody else fix grass and compass plugin ?

So if this patch is fine for you, please cherry pick it to release-2.0 branch.

Thanks!
