### PR TITLE
[FEATURE] Shift-clicking a selected composer item should deselect it

### DIFF
--- a/src/gui/qgscomposerview.cpp
+++ b/src/gui/qgscomposerview.cpp
@@ -100,9 +100,24 @@ void QgsComposerView::mousePressEvent( QMouseEvent* e )
         break;
       }
 
-      selectedItem->setSelected( true );
-      QGraphicsView::mousePressEvent( e );
-      emit selectedItemChanged( selectedItem );
+      if (( e->modifiers() & Qt::ShiftModifier ) && ( selectedItem->selected() ) )
+      {
+        //SHIFT-clicking a selected item deselects it
+        selectedItem->setSelected( false );
+
+        //Check if we have any remaining selected items, and if so, update the item panel
+        QList<QgsComposerItem*> selectedItems = composition()->selectedComposerItems();
+        if ( selectedItems.size() > 0 )
+        {
+          emit selectedItemChanged( selectedItems.at( 0 ) );
+        }
+      }
+      else
+      {
+        selectedItem->setSelected( true );
+        QGraphicsView::mousePressEvent( e );
+        emit selectedItemChanged( selectedItem );
+      }
       break;
     }
 


### PR DESCRIPTION
Shift clicking a selected item in a composer should remove it from the selection
