### PR TITLE
[FEATURE] Pan composer with middle mouse button

### DIFF
--- a/src/core/composer/qgscomposeritem.cpp
+++ b/src/core/composer/qgscomposeritem.cpp
@@ -919,6 +919,13 @@ void QgsComposerItem::setEffectsEnabled( bool effectsEnabled )
 
 void QgsComposerItem::hoverMoveEvent( QGraphicsSceneHoverEvent * event )
 {
+  if ( QgsApplication::mouseButtons() == Qt::MidButton )
+  {
+    //middle mouse button panning, make sure we use the closed hand cursor
+    setCursor( Qt::ClosedHandCursor );
+    return;
+  }
+
   if ( isSelected() )
   {
     setCursor( cursorForPosition( event->pos() ) );

--- a/src/gui/qgscomposerview.cpp
+++ b/src/gui/qgscomposerview.cpp
@@ -47,6 +47,7 @@ QgsComposerView::QgsComposerView( QWidget* parent, const char* name, Qt::WFlags 
     , mPaintingEnabled( true )
     , mHorizontalRuler( 0 )
     , mVerticalRuler( 0 )
+    , mPanning( false )
 {
   Q_UNUSED( f );
   Q_UNUSED( name );
@@ -80,6 +81,15 @@ void QgsComposerView::mousePressEvent( QMouseEvent* e )
       QPointF itemPoint = selectedItem->mapFromScene( scenePoint );
       selectedItem->updateCursor( itemPoint );
     }
+    return;
+  }
+  else if ( e->button() == Qt::MidButton )
+  {
+    //pan composer with middle button
+    mPanning = true;
+    mMouseLastXY = e->pos();
+    setCursor( Qt::ClosedHandCursor );
+    e->accept();
     return;
   }
 
@@ -264,6 +274,15 @@ void QgsComposerView::mouseReleaseEvent( QMouseEvent* e )
 
   QPointF scenePoint = mapToScene( e->pos() );
 
+  if ( mPanning )
+  {
+    //panning with middle button
+    mPanning = false;
+    setCursor( Qt::ArrowCursor );
+    e->accept();
+    return;
+  }
+
   switch ( mCurrentTool )
   {
     case Select:
@@ -383,6 +402,15 @@ void QgsComposerView::mouseMoveEvent( QMouseEvent* e )
     {
       QGraphicsView::mouseMoveEvent( e );
     }
+  }
+  else if ( mPanning )
+  {
+    //panning with middle mouse button, scroll view
+    horizontalScrollBar()->setValue( horizontalScrollBar()->value() - ( e->x() - mMouseLastXY.x() ) );
+    verticalScrollBar()->setValue( verticalScrollBar()->value() - ( e->y() - mMouseLastXY.y() ) );
+    mMouseLastXY = e->pos();
+    e->accept();
+    return;
   }
   else
   {
@@ -604,16 +632,47 @@ void QgsComposerView::wheelEvent( QWheelEvent* event )
 {
   QPointF scenePoint = mapToScene( event->pos() );
 
-  //select topmost item at position of event
-  QgsComposerItem* theItem = composition()->composerItemAt( scenePoint );
-  if ( theItem )
+  if ( currentTool() == MoveItemContent )
   {
-    if ( theItem->isSelected() )
+    //move item content tool, so scroll events get handled by the composer item
+
+    //select topmost item at position of event
+    QgsComposerItem* theItem = composition()->composerItemAt( scenePoint );
+    if ( theItem )
     {
-      QPointF itemPoint = theItem->mapFromScene( scenePoint );
-      theItem->beginCommand( tr( "Zoom item content" ) );
-      theItem->zoomContent( event->delta(), itemPoint.x(), itemPoint.y() );
-      theItem->endCommand();
+      if ( theItem->isSelected() )
+      {
+        QPointF itemPoint = theItem->mapFromScene( scenePoint );
+        theItem->beginCommand( tr( "Zoom item content" ) );
+        theItem->zoomContent( event->delta(), itemPoint.x(), itemPoint.y() );
+        theItem->endCommand();
+      }
+    }
+  }
+  else
+  {
+    //zoom whole composition
+    if ( event->delta() > 0 )
+    {
+      scale( 2, 2 );
+    }
+    else
+    {
+      scale( 0.5, 0.5 );
+    }
+
+    updateRulers();
+    update();
+    //redraw cached map items
+    QList<QGraphicsItem *> itemList = composition()->items();
+    QList<QGraphicsItem *>::iterator itemIt = itemList.begin();
+    for ( ; itemIt != itemList.end(); ++itemIt )
+    {
+      QgsComposerMap* mypItem = dynamic_cast<QgsComposerMap *>( *itemIt );
+      if (( mypItem ) && ( mypItem->previewMode() == QgsComposerMap::Render ) )
+      {
+        mypItem->updateCachedImage();
+      }
     }
   }
 }

--- a/src/gui/qgscomposerview.h
+++ b/src/gui/qgscomposerview.h
@@ -136,6 +136,9 @@ class GUI_EXPORT QgsComposerView: public QGraphicsView
     /** Draw a shape on the canvas */
     void addShape( Tool currentTool );
 
+    bool mPanning;
+    QPoint mMouseLastXY;
+
     //void connectAddRemoveCommandSignals( QgsAddRemoveItemCommand* c );
 
   signals:


### PR DESCRIPTION
... and allow zoom in and out on composer using mouse scroll wheel. Map item zooming now only applies if the move item content tool is used and the map is selected, to prevent accidental change of scale when mouse wheel is used.
