### PR TITLE
Fix #8507

### DIFF
--- a/src/core/qgsmaplayerregistry.h
+++ b/src/core/qgsmaplayerregistry.h
@@ -239,6 +239,11 @@ class CORE_EXPORT QgsMapLayerRegistry : public QObject
     //! protected constructor
     QgsMapLayerRegistry( QObject * parent = 0 );
 
+    /** debugging member
+        invoked when a connect() is made to this object
+    */
+    void connectNotify( const char * signal );
+
   private:
 
     static QgsMapLayerRegistry* mInstance;
@@ -246,10 +251,6 @@ class CORE_EXPORT QgsMapLayerRegistry : public QObject
     QMap<QString, QgsMapLayer*> mMapLayers;
     QSet<QgsMapLayer*> mOwnedLayers;
 
-    /** debugging member
-        invoked when a connect() is made to this object
-    */
-    void connectNotify( const char * signal );
 
 
 }; // class QgsMapLayerRegistry

--- a/src/gui/qgsattributedialog.h
+++ b/src/gui/qgsattributedialog.h
@@ -59,9 +59,10 @@ class GUI_EXPORT QgsAttributeDialog : public QObject
 
     void dialogDestroyed();
 
-  private:
+  protected:
     bool eventFilter( QObject *obj, QEvent *event );
 
+  private:
     QDialog *mDialog;
     QString mSettingsPath;
     // Used to sync multiple widgets for the same field

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -410,6 +410,11 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     /// Handle pattern for implementation object
     std::auto_ptr<CanvasProperties> mCanvasProperties;
 
+    /**debugging member
+       invoked when a connect() is made to this object
+    */
+    void connectNotify( const char * signal );
+
   private slots:
     void crsTransformEnabled( bool );
 
@@ -458,11 +463,6 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
        rendering may put their sizes into this list. The canvas then picks up
        the last entry in case a lot of resize events arrive in short time*/
     QList< QPair<int, int> > mResizeQueue;
-
-    /**debugging member
-       invoked when a connect() is made to this object
-    */
-    void connectNotify( const char * signal );
 
     //! current layer in legend
     QgsMapLayer* mCurrentLayer;

--- a/src/gui/qgsmessagelogviewer.h
+++ b/src/gui/qgsmessagelogviewer.h
@@ -42,10 +42,11 @@ class GUI_EXPORT QgsMessageLogViewer: public QDialog, private Ui::QgsMessageLogV
   public slots:
     void logMessage( QString message, QString tag, QgsMessageLog::MessageLevel level );
 
-  private:
+  protected:
     void showEvent( QShowEvent * );
     void hideEvent( QHideEvent * );
 
+  private:
     QToolButton *mButton;
     int mCount;
 


### PR DESCRIPTION
As described in http://hub.qgis.org/issues/8507 master doesn't compile with sip 4.15. (I'm using OSX 10.8 and sip 4.15.1.)

The quick fix was moving methods from private to protected solved the compiling error.
