### PR TITLE
[FEATURE] New edit menu for composer

### DIFF
--- a/src/app/composer/qgscomposer.cpp
+++ b/src/app/composer/qgscomposer.cpp
@@ -234,6 +234,10 @@ QgsComposer::QgsComposer( QgisApp *qgis, const QString& title )
   editMenu->addAction( mActionPaste );
   //TODO : "Ctrl+Shift+V" is one way to paste in place, but on some platforms you can use Shift+Ins and F18
   editMenu->addAction( mActionPasteInPlace );
+  editMenu->addSeparator();
+  editMenu->addAction( mActionSelectAll );
+  editMenu->addAction( mActionDeselectAll );
+  editMenu->addAction( mActionInvertSelection );
 
   QMenu *viewMenu = menuBar()->addMenu( tr( "View" ) );
   viewMenu->addAction( mActionZoomIn );
@@ -1748,6 +1752,30 @@ void QgsComposer::on_mActionDeleteSelection_triggered()
   if ( mView )
   {
     mView->deleteSelectedItems();
+  }
+}
+
+void QgsComposer::on_mActionSelectAll_triggered()
+{
+  if ( mView )
+  {
+    mView->selectAll();
+  }
+}
+
+void QgsComposer::on_mActionDeselectAll_triggered()
+{
+  if ( mView )
+  {
+    mView->selectNone();
+  }
+}
+
+void QgsComposer::on_mActionInvertSelection_triggered()
+{
+  if ( mView )
+  {
+    mView->selectInvert();
   }
 }
 

--- a/src/app/composer/qgscomposer.h
+++ b/src/app/composer/qgscomposer.h
@@ -222,6 +222,15 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
     //! Delete selected item(s)
     void on_mActionDeleteSelection_triggered();
 
+    //! Select all items
+    void on_mActionSelectAll_triggered();
+
+    //! Deselect all items
+    void on_mActionDeselectAll_triggered();
+
+    //! Invert selection
+    void on_mActionInvertSelection_triggered();
+
     //! Ungroup selected item group
     void on_mActionUngroupItems_triggered();
 

--- a/src/app/composer/qgscomposer.h
+++ b/src/app/composer/qgscomposer.h
@@ -207,6 +207,21 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
     //! Group selected items
     void on_mActionGroupItems_triggered();
 
+    //! Cut item(s)
+    void actionCutTriggered();
+
+    //! Copy item(s)
+    void actionCopyTriggered();
+
+    //! Paste item(s)
+    void actionPasteTriggered();
+
+    //! Paste in place item(s)
+    void on_mActionPasteInPlace_triggered();
+
+    //! Delete selected item(s)
+    void on_mActionDeleteSelection_triggered();
+
     //! Ungroup selected item group
     void on_mActionUngroupItems_triggered();
 
@@ -372,6 +387,11 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
 
     //! Window menu action to select this window
     QAction *mWindowAction;
+
+    //! Copy/cut/paste actions
+    QAction *mActionCut;
+    QAction *mActionCopy;
+    QAction *mActionPaste;
 
     //! Page & Printer Setup
     QPrinter mPrinter;

--- a/src/gui/qgscomposerview.cpp
+++ b/src/gui/qgscomposerview.cpp
@@ -38,6 +38,7 @@
 #include "qgscomposerattributetable.h"
 #include "qgslogger.h"
 #include "qgsaddremovemultiframecommand.h"
+#include "qgspaperitem.h"
 
 QgsComposerView::QgsComposerView( QWidget* parent, const char* name, Qt::WFlags f )
     : QGraphicsView( parent )
@@ -591,6 +592,77 @@ void QgsComposerView::deleteSelectedItems()
     if ( composition() )
     {
       composition()->removeComposerItem( *itemIt );
+    }
+  }
+}
+
+void QgsComposerView::selectAll()
+{
+  if ( !composition() )
+  {
+    return;
+  }
+
+  //select all items in composer
+  QList<QGraphicsItem *> itemList = composition()->items();
+  QList<QGraphicsItem *>::iterator itemIt = itemList.begin();
+  for ( ; itemIt != itemList.end(); ++itemIt )
+  {
+    QgsComposerItem* mypItem = dynamic_cast<QgsComposerItem *>( *itemIt );
+    QgsPaperItem* paperItem = dynamic_cast<QgsPaperItem*>( *itemIt );
+    if ( mypItem && !paperItem )
+    {
+      if ( !mypItem->positionLock() )
+      {
+        mypItem->setSelected( true );
+      }
+      else
+      {
+        //deselect all locked items
+        mypItem->setSelected( false );
+      }
+      emit selectedItemChanged( mypItem );
+    }
+  }
+}
+
+void QgsComposerView::selectNone()
+{
+  if ( !composition() )
+  {
+    return;
+  }
+
+  composition()->clearSelection();
+}
+
+void QgsComposerView::selectInvert()
+{
+  if ( !composition() )
+  {
+    return;
+  }
+
+  //check all items in composer
+  QList<QGraphicsItem *> itemList = composition()->items();
+  QList<QGraphicsItem *>::iterator itemIt = itemList.begin();
+  for ( ; itemIt != itemList.end(); ++itemIt )
+  {
+    QgsComposerItem* mypItem = dynamic_cast<QgsComposerItem *>( *itemIt );
+    QgsPaperItem* paperItem = dynamic_cast<QgsPaperItem*>( *itemIt );
+    if ( mypItem && !paperItem )
+    {
+      //flip selected state for items (and deselect any locked items)
+      if ( mypItem->selected() || mypItem->positionLock() )
+      {
+
+        mypItem->setSelected( false );
+      }
+      else
+      {
+        mypItem->setSelected( true );
+        emit selectedItemChanged( mypItem );
+      }
     }
   }
 }

--- a/src/gui/qgscomposerview.cpp
+++ b/src/gui/qgscomposerview.cpp
@@ -487,10 +487,116 @@ void QgsComposerView::mouseDoubleClickEvent( QMouseEvent* e )
   e->ignore();
 }
 
+void QgsComposerView::copyItems( ClipboardMode mode )
+{
+  if ( !composition() )
+  {
+    return;
+  }
+
+  QList<QgsComposerItem*> composerItemList = composition()->selectedComposerItems();
+  QList<QgsComposerItem*>::iterator itemIt = composerItemList.begin();
+
+  QDomDocument doc;
+  QDomElement documentElement = doc.createElement( "ComposerItemClipboard" );
+  for ( ; itemIt != composerItemList.end(); ++itemIt )
+  {
+    // copy each item in a group
+    QgsComposerItemGroup* itemGroup = dynamic_cast<QgsComposerItemGroup*>( *itemIt );
+    if ( itemGroup && composition() )
+    {
+      QSet<QgsComposerItem*> groupedItems = itemGroup->items();
+      QSet<QgsComposerItem*>::iterator it = groupedItems.begin();
+      for ( ; it != groupedItems.end(); ++it )
+      {
+        ( *it )->writeXML( documentElement, doc );
+      }
+    }
+    ( *itemIt )->writeXML( documentElement, doc );
+    if ( mode == ClipboardModeCut )
+    {
+      composition()->removeComposerItem( *itemIt );
+    }
+  }
+  doc.appendChild( documentElement );
+
+  //if it's a copy, we have to remove the UUIDs since we don't want any duplicate UUID
+  if ( mode == ClipboardModeCopy )
+  {
+    // remove all uuid attributes
+    QDomNodeList composerItemsNodes = doc.elementsByTagName( "ComposerItem" );
+    for ( int i = 0; i < composerItemsNodes.count(); ++i )
+    {
+      QDomNode composerItemNode = composerItemsNodes.at( i );
+      if ( composerItemNode.isElement() )
+      {
+        composerItemNode.toElement().removeAttribute( "uuid" );
+      }
+    }
+  }
+
+  QMimeData *mimeData = new QMimeData;
+  mimeData->setData( "text/xml", doc.toByteArray() );
+  QClipboard *clipboard = QApplication::clipboard();
+  clipboard->setMimeData( mimeData );
+}
+
+void QgsComposerView::pasteItems( PasteMode mode )
+{
+  if ( !composition() )
+  {
+    return;
+  }
+
+  QDomDocument doc;
+  QClipboard *clipboard = QApplication::clipboard();
+  if ( doc.setContent( clipboard->mimeData()->data( "text/xml" ) ) )
+  {
+    QDomElement docElem = doc.documentElement();
+    if ( docElem.tagName() == "ComposerItemClipboard" )
+    {
+      if ( composition() )
+      {
+        QPointF pt;
+        if ( mode == PasteModeCursor )
+        {
+          // place items at cursor position
+          pt = mapToScene( mapFromGlobal( QCursor::pos() ) );
+        }
+        else
+        {
+          // place items in center of viewport
+          pt = mapToScene( viewport()->rect().center() );
+        }
+        bool pasteInPlace = ( mode == PasteModeInPlace );
+        composition()->addItemsFromXML( docElem, doc, 0, true, &pt, pasteInPlace );
+      }
+    }
+  }
+}
+
+void QgsComposerView::deleteSelectedItems()
+{
+  if ( !composition() )
+  {
+    return;
+  }
+
+  QList<QgsComposerItem*> composerItemList = composition()->selectedComposerItems();
+  QList<QgsComposerItem*>::iterator itemIt = composerItemList.begin();
+
+  //delete selected items
+  for ( ; itemIt != composerItemList.end(); ++itemIt )
+  {
+    if ( composition() )
+    {
+      composition()->removeComposerItem( *itemIt );
+    }
+  }
+}
+
 void QgsComposerView::keyPressEvent( QKeyEvent * e )
 {
-  //TODO : those should be actions (so we could also display menu items and/or toolbar items)
-
   if ( !composition() )
   {
     return;
@@ -507,85 +613,7 @@ void QgsComposerView::keyPressEvent( QKeyEvent * e )
     increment = 10.0;
   }
 
-  if ( e->matches( QKeySequence::Copy ) || e->matches( QKeySequence::Cut ) )
-  {
-    QDomDocument doc;
-    QDomElement documentElement = doc.createElement( "ComposerItemClipboard" );
-    for ( ; itemIt != composerItemList.end(); ++itemIt )
-    {
-      // copy each item in a group
-      QgsComposerItemGroup* itemGroup = dynamic_cast<QgsComposerItemGroup*>( *itemIt );
-      if ( itemGroup && composition() )
-      {
-        QSet<QgsComposerItem*> groupedItems = itemGroup->items();
-        QSet<QgsComposerItem*>::iterator it = groupedItems.begin();
-        for ( ; it != groupedItems.end(); ++it )
-        {
-          ( *it )->writeXML( documentElement, doc );
-        }
-      }
-      ( *itemIt )->writeXML( documentElement, doc );
-      if ( e->matches( QKeySequence::Cut ) )
-      {
-        composition()->removeComposerItem( *itemIt );
-      }
-    }
-    doc.appendChild( documentElement );
-
-    //if it's a copy, we have to remove the UUIDs since we don't want any duplicate UUID
-    if ( e->matches( QKeySequence::Copy ) )
-    {
-      // remove all uuid attributes
-      QDomNodeList composerItemsNodes = doc.elementsByTagName( "ComposerItem" );
-      for ( int i = 0; i < composerItemsNodes.count(); ++i )
-      {
-        QDomNode composerItemNode = composerItemsNodes.at( i );
-        if ( composerItemNode.isElement() )
-        {
-          composerItemNode.toElement().removeAttribute( "uuid" );
-        }
-      }
-    }
-
-    QMimeData *mimeData = new QMimeData;
-    mimeData->setData( "text/xml", doc.toByteArray() );
-    QClipboard *clipboard = QApplication::clipboard();
-    clipboard->setMimeData( mimeData );
-  }
-
-  //TODO : "Ctrl+Shift+V" is one way to paste, but on some platefoms you can use Shift+Ins and F18
-  if ( e->matches( QKeySequence::Paste ) || ( e->key() == Qt::Key_V && e->modifiers() & Qt::ControlModifier && e->modifiers() & Qt::ShiftModifier ) )
-  {
-    QDomDocument doc;
-    QClipboard *clipboard = QApplication::clipboard();
-    if ( doc.setContent( clipboard->mimeData()->data( "text/xml" ) ) )
-    {
-      QDomElement docElem = doc.documentElement();
-      if ( docElem.tagName() == "ComposerItemClipboard" )
-      {
-        if ( composition() )
-        {
-          QPointF pt = mapToScene( mapFromGlobal( QCursor::pos() ) );
-          bool pasteInPlace = ( e->modifiers() & Qt::ShiftModifier );
-          composition()->addItemsFromXML( docElem, doc, 0, true, &pt, pasteInPlace );
-        }
-      }
-    }
-  }
-
-  //delete selected items
-  if ( e->key() == Qt::Key_Delete || e->key() == Qt::Key_Backspace )
-  {
-    for ( ; itemIt != composerItemList.end(); ++itemIt )
-    {
-      if ( composition() )
-      {
-        composition()->removeComposerItem( *itemIt );
-      }
-    }
-  }
-
-  else if ( e->key() == Qt::Key_Left )
+  if ( e->key() == Qt::Key_Left )
   {
     for ( ; itemIt != composerItemList.end(); ++itemIt )
     {

--- a/src/gui/qgscomposerview.h
+++ b/src/gui/qgscomposerview.h
@@ -68,6 +68,19 @@ class GUI_EXPORT QgsComposerView: public QGraphicsView
       MoveItemContent //move content of item (e.g. content of map)
     };
 
+    enum ClipboardMode
+    {
+      ClipboardModeCut,
+      ClipboardModeCopy
+    };
+
+    enum PasteMode
+    {
+      PasteModeCursor,
+      PasteModeCenter,
+      PasteModeInPlace
+    };
+
     QgsComposerView( QWidget* parent = 0, const char* name = 0, Qt::WFlags f = 0 );
 
     /**Add an item group containing the selected items*/
@@ -81,6 +94,15 @@ class GUI_EXPORT QgsComposerView: public QGraphicsView
 
     /**Unlock all items*/
     void unlockAllItems();
+
+    /**Cuts or copies the selected items*/
+    void copyItems( ClipboardMode mode );
+
+    /**Pastes items from clipboard*/
+    void pasteItems( PasteMode mode );
+
+    /**Deletes selected items*/
+    void deleteSelectedItems();
 
     QgsComposerView::Tool currentTool() const {return mCurrentTool;}
     void setCurrentTool( QgsComposerView::Tool t ) {mCurrentTool = t;}

--- a/src/gui/qgscomposerview.h
+++ b/src/gui/qgscomposerview.h
@@ -104,6 +104,15 @@ class GUI_EXPORT QgsComposerView: public QGraphicsView
     /**Deletes selected items*/
     void deleteSelectedItems();
 
+    /**Selects all items*/
+    void selectAll();
+
+    /**Deselects all items*/
+    void selectNone();
+
+    /**Inverts current selection*/
+    void selectInvert();
+
     QgsComposerView::Tool currentTool() const {return mCurrentTool;}
     void setCurrentTool( QgsComposerView::Tool t ) {mCurrentTool = t;}
 

--- a/src/ui/qgscomposerbase.ui
+++ b/src/ui/qgscomposerbase.ui
@@ -593,6 +593,28 @@
     <string>Unlock All Items</string>
    </property>
   </action>
+  <action name="mActionPasteInPlace">
+   <property name="text">
+    <string>Pa&amp;ste in Place</string>
+   </property>
+   <property name="toolTip">
+    <string>Paste in place</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+V</string>
+   </property>
+  </action>
+  <action name="mActionDeleteSelection">
+   <property name="text">
+    <string>&amp;Delete</string>
+   </property>
+   <property name="toolTip">
+    <string>Delete selected items</string>
+   </property>
+   <property name="shortcut">
+    <string>Del</string>
+   </property>
+  </action>  
  </widget>
  <resources>
   <include location="../../images/images.qrc"/>

--- a/src/ui/qgscomposerbase.ui
+++ b/src/ui/qgscomposerbase.ui
@@ -458,7 +458,7 @@
     </iconset>
    </property>
    <property name="text">
-    <string>Undo</string>
+    <string>&amp;Undo</string>
    </property>
    <property name="toolTip">
     <string>Revert last change</string>
@@ -473,7 +473,7 @@
      <normaloff>:/images/themes/default/mActionRedo.png</normaloff>:/images/themes/default/mActionRedo.png</iconset>
    </property>
    <property name="text">
-    <string>Redo</string>
+    <string>&amp;Redo</string>
    </property>
    <property name="toolTip">
     <string>Restore last change</string>
@@ -614,7 +614,37 @@
    <property name="shortcut">
     <string>Del</string>
    </property>
-  </action>  
+  </action>
+  <action name="mActionDeselectAll">
+   <property name="text">
+    <string>De&amp;select All</string>
+   </property>
+   <property name="toolTip">
+    <string>Deselect all</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+A</string>
+   </property>
+  </action>
+  <action name="mActionSelectAll">
+   <property name="text">
+    <string>Select &amp;All</string>
+   </property>
+   <property name="toolTip">
+    <string>Select all items</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+A</string>
+   </property>
+  </action>
+  <action name="mActionInvertSelection">
+   <property name="text">
+    <string>&amp;Invert Selection</string>
+   </property>
+   <property name="toolTip">
+    <string>Invert selection</string>
+   </property>
+  </action>
  </widget>
  <resources>
   <include location="../../images/images.qrc"/>


### PR DESCRIPTION
With cut/copy/paste actions, select all/none/invert selection actions, and also moves delete, undo and redo actions to the edit menu.

This request supersedes #877 and adds the select all/none/invert selection commands.
