### PR TITLE
Add GML format in GetFeatureInfo requests

### DIFF
--- a/src/mapserver/qgshttprequesthandler.cpp
+++ b/src/mapserver/qgshttprequesthandler.cpp
@@ -162,7 +162,7 @@ void QgsHttpRequestHandler::sendGetFeatureInfoResponse( const QDomDocument& info
   QByteArray ba;
   QgsDebugMsg( "Info format is:" + infoFormat );
 
-  if ( infoFormat == "text/xml" )
+  if ( infoFormat == "text/xml" || infoFormat.startsWith("application/vnd.ogc.gml") )
   {
     ba = infoDoc.toByteArray();
   }

--- a/src/mapserver/qgswmsserver.h
+++ b/src/mapserver/qgswmsserver.h
@@ -205,6 +205,12 @@ class QgsWMSServer
     QMap<QString, QString> mParameterMap;
     QgsConfigParser* mConfigParser;
     QgsMapRenderer* mMapRenderer;
+
+    /* get from qgswfsserver.h */
+    //methods to write GML2
+    QDomElement createFeatureGML2( QgsFeature* feat, QDomDocument& doc, QgsCoordinateReferenceSystem& crs ) /*const*/;
+    //methods to write GML3
+    QDomElement createFeatureGML3( QgsFeature* feat, QDomDocument& doc, QgsCoordinateReferenceSystem& crs ) /*const*/;
 };
 
 #endif

--- a/src/mapserver/qgswmsserver.h
+++ b/src/mapserver/qgswmsserver.h
@@ -29,6 +29,7 @@ class QgsComposerLayerItem;
 class QgsComposerLegendItem;
 class QgsComposition;
 class QgsConfigParser;
+class QgsFeature;
 class QgsFeatureRendererV2;
 class QgsMapLayer;
 class QgsMapRenderer;
@@ -122,10 +123,23 @@ class QgsWMSServer
     /**Appends feature info xml for the layer to the layer element of the feature info dom document
     @param featureBBox the bounding box of the selected features in output CRS
     @return 0 in case of success*/
-    int featureInfoFromVectorLayer( QgsVectorLayer* layer, const QgsPoint* infoPoint, int nFeatures, QDomDocument& infoDocument, QDomElement& layerElement, QgsMapRenderer* mapRender,
-                                    QgsRenderContext& renderContext, QString version, QgsRectangle* featureBBox = 0 ) const;
+    int featureInfoFromVectorLayer( QgsVectorLayer* layer,
+        const QgsPoint* infoPoint,
+        int nFeatures,
+        QDomDocument& infoDocument,
+        QDomElement& layerElement,
+        QgsMapRenderer* mapRender,
+        QgsRenderContext& renderContext,
+        QString version,
+        QString infoFormat,
+        QgsRectangle* featureBBox = 0 ) const;
     /**Appends feature info xml for the layer to the layer element of the dom document*/
-    int featureInfoFromRasterLayer( QgsRasterLayer* layer, const QgsPoint* infoPoint, QDomDocument& infoDocument, QDomElement& layerElement, QString version ) const;
+    int featureInfoFromRasterLayer( QgsRasterLayer* layer,
+        const QgsPoint* infoPoint,
+        QDomDocument& infoDocument,
+        QDomElement& layerElement,
+        QString version,
+        QString infoFormat ) const;
 
     /**Creates a layer set and returns a stringlist with layer ids that can be passed to a QgsMapRenderer. Usually used in conjunction with readLayersAndStyles
        @param scaleDenominator Filter out layer if scale based visibility does not match (or use -1 if no scale restriction)*/
@@ -206,11 +220,13 @@ class QgsWMSServer
     QgsConfigParser* mConfigParser;
     QgsMapRenderer* mMapRenderer;
 
-    /* get from qgswfsserver.h */
-    //methods to write GML2
-    QDomElement createFeatureGML2( QgsFeature* feat, QDomDocument& doc, QgsCoordinateReferenceSystem& crs ) /*const*/;
-    //methods to write GML3
-    QDomElement createFeatureGML3( QgsFeature* feat, QDomDocument& doc, QgsCoordinateReferenceSystem& crs ) /*const*/;
+    QDomElement createFeatureGML(
+      QgsFeature* feat,
+      QDomDocument& doc,
+      QgsCoordinateReferenceSystem& crs,
+      QString typeName,
+      bool withGeom,
+      int version) const;
 };
 
 #endif


### PR DESCRIPTION
To fix http://hub.qgis.org/issues/7719

As we can see in the issue it's a bit confusing that the feature are partially formated in the `qgswmsserver.cpp` for the XML part, and in the `qgshttprequesthandler.cpp` for the txt/html part.

I see that's needed for the `qgssoaprequesthandler.cpp`, actually I don't have any problem with this but if we want to have a geojson output it will be difficult to do it properly.

In my first commit I copy things from the `qgswfsserver.cpp` but finally I change some things on it and the important part in in `qgsogcutils` than I think that ok like it.

I don't know if you have some coding style than it will probably have an issue with it.  
