### PR TITLE
Add QGIS_PROJECT_FILE environement option

### DIFF
--- a/src/mapserver/qgis_map_serv.cpp
+++ b/src/mapserver/qgis_map_serv.cpp
@@ -297,14 +297,22 @@ int main( int argc, char * argv[] )
     //set admin config file to wms server object
     QString configFilePath( defaultConfigFilePath );
 
-    paramIt = parameterMap.find( "MAP" );
-    if ( paramIt == parameterMap.constEnd() )
+    QString projectFile = getenv( "QGIS_PROJECT_FILE" );
+    if ( !projectFile.isEmpty() )
     {
-      QgsDebugMsg( QString( "Using default configuration file path: %1" ).arg( defaultConfigFilePath ) );
+      configFilePath = projectFile;
     }
     else
     {
-      configFilePath = paramIt.value();
+      paramIt = parameterMap.find( "MAP" );
+      if ( paramIt == parameterMap.constEnd() )
+      {
+        QgsDebugMsg( QString( "Using default configuration file path: %1" ).arg( defaultConfigFilePath ) );
+      }
+      else
+      {
+        configFilePath = paramIt.value();
+      }
     }
 
     QgsConfigParser* adminConfigParser = QgsConfigCache::instance()->searchConfiguration( configFilePath );


### PR DESCRIPTION
To be able to configure the project file in apache configuration
like:
SetEnv QGIS_PROJECT_FILE  <path to project file>.qgs
