### PR TITLE
Allow selecting items hiding behind other items

### DIFF
--- a/src/app/composer/qgscomposer.cpp
+++ b/src/app/composer/qgscomposer.cpp
@@ -238,6 +238,8 @@ QgsComposer::QgsComposer( QgisApp *qgis, const QString& title )
   editMenu->addAction( mActionSelectAll );
   editMenu->addAction( mActionDeselectAll );
   editMenu->addAction( mActionInvertSelection );
+  editMenu->addAction( mActionSelectNextBelow );
+  editMenu->addAction( mActionSelectNextAbove );
 
   QMenu *viewMenu = menuBar()->addMenu( tr( "View" ) );
   viewMenu->addAction( mActionZoomIn );
@@ -1776,6 +1778,22 @@ void QgsComposer::on_mActionInvertSelection_triggered()
   if ( mView )
   {
     mView->selectInvert();
+  }
+}
+
+void QgsComposer::on_mActionSelectNextAbove_triggered()
+{
+  if ( mComposition )
+  {
+    mComposition->selectNextByZOrder( QgsComposition::ZValueAbove );
+  }
+}
+
+void QgsComposer::on_mActionSelectNextBelow_triggered()
+{
+  if ( mComposition )
+  {
+    mComposition->selectNextByZOrder( QgsComposition::ZValueBelow );
   }
 }
 

--- a/src/app/composer/qgscomposer.h
+++ b/src/app/composer/qgscomposer.h
@@ -240,6 +240,12 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
     //! Unlock all items
     void on_mActionUnlockAll_triggered();
 
+    //! Select next item below
+    void on_mActionSelectNextAbove_triggered();
+    
+    //! Select next item above
+    void on_mActionSelectNextBelow_triggered();
+
     //! Move selected items one position up
     void on_mActionRaiseItems_triggered();
 

--- a/src/core/composer/qgscomposition.cpp
+++ b/src/core/composer/qgscomposition.cpp
@@ -907,6 +907,75 @@ void QgsComposition::raiseItem( QgsComposerItem* item )
   }
 }
 
+QgsComposerItem* QgsComposition::getComposerItemAbove( QgsComposerItem* item )
+{
+  //search item z list for selected item
+  QLinkedListIterator<QgsComposerItem*> it( mItemZList );
+  if ( it.findNext( item ) )
+  {
+    //return next item (list is sorted from lowest->highest items)
+    if ( it.hasNext() )
+    {
+      return it.next();
+    }
+  }
+  return 0;
+}
+
+QgsComposerItem* QgsComposition::getComposerItemBelow( QgsComposerItem* item )
+{
+  //search item z list for selected item
+  QLinkedListIterator<QgsComposerItem*> it( mItemZList );
+  if ( it.findNext( item ) )
+  {
+    //move position to before selected item
+    it.previous();
+    //now find previous item, since list is sorted from lowest->highest items
+    if ( it.hasPrevious() )
+    {
+      return it.previous();
+    }
+  }
+  return 0;
+}
+
+void QgsComposition::selectNextByZOrder( ZValueDirection direction )
+{
+  QgsComposerItem* previousSelectedItem = 0;
+  QList<QgsComposerItem*> selectedItems = selectedComposerItems();
+  if ( selectedItems.size() > 0 )
+  {
+    previousSelectedItem = selectedItems.at( 0 );
+  }
+
+  if ( !previousSelectedItem )
+  {
+    return;
+  }
+
+  //select item with target z value
+  QgsComposerItem* selectedItem;
+  switch ( direction )
+  {
+    case QgsComposition::ZValueBelow:
+      selectedItem = getComposerItemBelow( previousSelectedItem );
+      break;
+    case QgsComposition::ZValueAbove:
+      selectedItem = getComposerItemAbove( previousSelectedItem );
+      break;
+  }
+
+  if ( !selectedItem )
+  {
+    return;
+  }
+
+  //ok, found a good target item
+  clearSelection();
+  selectedItem->setSelected( true );
+  emit selectedItemChanged( selectedItem );
+}
+
 void QgsComposition::lowerSelectedItems()
 {
   QList<QgsComposerItem*> selectedItems = selectedComposerItems();

--- a/src/core/composer/qgscomposition.h
+++ b/src/core/composer/qgscomposition.h
@@ -131,6 +131,11 @@ class CORE_EXPORT QgsComposition : public QGraphicsScene
     /**Returns the topmost composer item. Ignores mPaperItem*/
     QgsComposerItem* composerItemAt( const QPointF & position );
 
+    /**Returns the highest composer item at a specified position which is below a specified item. Ignores mPaperItem
+      @note Added in QGIS 2.1
+    */
+    QgsComposerItem* composerItemAt( const QPointF & position, const QgsComposerItem* belowItem );
+
     /** Returns the page number (0-bsaed) given a coordinate */
     int pageNumberAt( const QPointF& position ) const;
 

--- a/src/core/composer/qgscomposition.h
+++ b/src/core/composer/qgscomposition.h
@@ -82,6 +82,12 @@ class CORE_EXPORT QgsComposition : public QGraphicsScene
       Crosses
     };
 
+    enum ZValueDirection
+    {
+      ZValueBelow,
+      ZValueAbove
+    };
+
     QgsComposition( QgsMapRenderer* mapRenderer );
     ~QgsComposition();
 
@@ -256,6 +262,11 @@ class CORE_EXPORT QgsComposition : public QGraphicsScene
     void moveItemToTop( QgsComposerItem* item );
     void moveSelectedItemsToBottom();
     void moveItemToBottom( QgsComposerItem* item );
+
+    //functions to find items by their position in the z list
+    void selectNextByZOrder( ZValueDirection direction );
+    QgsComposerItem* getComposerItemBelow( QgsComposerItem* item );
+    QgsComposerItem* getComposerItemAbove( QgsComposerItem* item );
 
     //functions to align selected items
     void alignSelectedItemsLeft();

--- a/src/gui/qgscomposerview.cpp
+++ b/src/gui/qgscomposerview.cpp
@@ -89,13 +89,43 @@ void QgsComposerView::mousePressEvent( QMouseEvent* e )
       //select/deselect items and pass mouse event further
     case Select:
     {
+      QgsComposerItem* selectedItem;
+      QgsComposerItem* previousSelectedItem = 0;
+
+      if ( e->modifiers() & Qt::ControlModifier )
+      {
+        //CTRL modifier, so we are trying to select the next item below the current one
+        //first, find currently selected item
+        QList<QgsComposerItem*> selectedItems = composition()->selectedComposerItems();
+        if ( selectedItems.size() > 0 )
+        {
+          previousSelectedItem = selectedItems.at( 0 );
+        }
+      }
+
       if ( !( e->modifiers() & Qt::ShiftModifier ) ) //keep selection if shift key pressed
       {
         composition()->clearSelection();
       }
 
-      //select topmost item at position of event
-      QgsComposerItem* selectedItem = composition()->composerItemAt( scenePoint );
+      if ( previousSelectedItem )
+      {
+        //select highest item just below previously selected item at position of event
+        selectedItem = composition()->composerItemAt( scenePoint, previousSelectedItem );
+
+        //if we didn't find a lower item we'll use the top-most as fall-back
+        //this duplicates mapinfo/illustrator/etc behaviour where ctrl-clicks are "cyclic"
+        if ( !selectedItem )
+        {
+          selectedItem = composition()->composerItemAt( scenePoint );
+        }
+      }
+      else
+      {
+        //select topmost item at position of event
+        selectedItem = composition()->composerItemAt( scenePoint );
+      }
+
       if ( !selectedItem )
       {
         break;

--- a/src/ui/qgscomposerbase.ui
+++ b/src/ui/qgscomposerbase.ui
@@ -645,6 +645,28 @@
     <string>Invert selection</string>
    </property>
   </action>
+  <action name="mActionSelectNextBelow">
+   <property name="text">
+    <string>Select Next Item &amp;Below</string>
+   </property>
+   <property name="toolTip">
+    <string>Select next item below</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Alt+[</string>
+   </property>
+  </action>
+  <action name="mActionSelectNextAbove">
+   <property name="text">
+    <string>Select Next Item &amp;Above</string>
+   </property>
+   <property name="toolTip">
+    <string>Select next item above</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Alt+]</string>
+   </property>
+  </action>  
  </widget>
  <resources>
   <include location="../../images/images.qrc"/>


### PR DESCRIPTION
This request implements two ways of selecting obscured items 
- Ctrl clicking on an item progressively selects the next item below (following the same behaviour as illustrator and mapinfo)
- Menu items for "select next item above" and "select next item below" (along with keyboard shortcuts which match illustrator's) also allow for progressively selecting items in z order
