### PR TITLE
Fix Scales in qgis server

### DIFF
--- a/src/mapserver/qgsprojectparser.cpp
+++ b/src/mapserver/qgsprojectparser.cpp
@@ -772,22 +772,25 @@ void QgsProjectParser::addLayers( QDomDocument &doc,
       //min/max scale denominatormScaleBasedVisibility
       if ( currentLayer->hasScaleBasedVisibility() )
       {
-        QString minScaleString = QString::number( currentLayer->minimumScale() );
-        QString maxScaleString = QString::number( currentLayer->maximumScale() );
-
         if ( version == "1.1.1" )
         {
+          double OGC_PX_M = 0.00028; // OGC referance pixel size in meter, also used by qgis
+          double SCALE_TO_SCALEHINT = OGC_PX_M * sqrt( 2 );
+
           QDomElement scaleHintElem = doc.createElement( "ScaleHint" );
-          scaleHintElem.setAttribute( "min", minScaleString );
-          scaleHintElem.setAttribute( "max", maxScaleString );
+          scaleHintElem.setAttribute( "min", QString::number( currentLayer->minimumScale() * SCALE_TO_SCALEHINT ) );
+          scaleHintElem.setAttribute( "max", QString::number( currentLayer->maximumScale() * SCALE_TO_SCALEHINT ) );
           layerElem.appendChild( scaleHintElem );
         }
         else
         {
+          QString minScaleString = QString::number( currentLayer->minimumScale() );
           QDomElement minScaleElem = doc.createElement( "MinScaleDenominator" );
           QDomText minScaleText = doc.createTextNode( minScaleString );
           minScaleElem.appendChild( minScaleText );
           layerElem.appendChild( minScaleElem );
+
+          QString maxScaleString = QString::number( currentLayer->maximumScale() );
           QDomElement maxScaleElem = doc.createElement( "MaxScaleDenominator" );
           QDomText maxScaleText = doc.createTextNode( maxScaleString );
           maxScaleElem.appendChild( maxScaleText );

--- a/src/mapserver/qgswmsserver.cpp
+++ b/src/mapserver/qgswmsserver.cpp
@@ -1109,16 +1109,18 @@ QImage* QgsWMSServer::createImage( int width, int height ) const
 
   //apply DPI parameter if present. This is an extension of QGIS mapserver compared to WMS 1.3.
   //Because of backwards compatibility, this parameter is optional
+  double OGC_PX_M = 0.00028; // OGC referance pixel size in meter, also used by qgis
+  int dpm = 1 / OGC_PX_M;
   if ( mParameterMap.contains( "DPI" ) )
   {
     int dpi = mParameterMap[ "DPI" ].toInt( &conversionSuccess );
     if ( conversionSuccess )
     {
-      int dpm = dpi / 0.0254;
-      theImage->setDotsPerMeterX( dpm );
-      theImage->setDotsPerMeterY( dpm );
+      dpm = dpi / 0.0254;
     }
   }
+  theImage->setDotsPerMeterX( dpm );
+  theImage->setDotsPerMeterY( dpm );
   return theImage;
 }
 


### PR DESCRIPTION
Actually we have in the capabilities the scales directly from QGis but it don't respect the OGC specifications.

The second commit is to fix the scale used to display the feature, actually the default DPI used for the symbols size is 72 and the default DPI for the visibility is 96 ... with my commit booth are 72.
