### PR TITLE
Composer item lock improvements

### DIFF
--- a/src/app/composer/qgscomposer.cpp
+++ b/src/app/composer/qgscomposer.cpp
@@ -1689,17 +1689,17 @@ void QgsComposer::on_mActionUngroupItems_triggered()
 
 void QgsComposer::on_mActionLockItems_triggered()
 {
-  if ( mView )
+  if ( mComposition )
   {
-    mView->lockItems();
+    mComposition->lockSelectedItems();
   }
 }
 
 void QgsComposer::on_mActionUnlockAll_triggered()
 {
-  if ( mView )
+  if ( mComposition )
   {
-    mView->unlockAllItems();
+    mComposition->unlockAllItems();
   }
 }
 

--- a/src/core/composer/qgscomposition.cpp
+++ b/src/core/composer/qgscomposition.cpp
@@ -1169,17 +1169,25 @@ void QgsComposition::lockSelectedItems()
 void QgsComposition::unlockAllItems()
 {
   //unlock all items in composer
+
   QUndoCommand* parentCommand = new QUndoCommand( tr( "Items unlocked" ) );
+
+  //first, clear the selection
+  clearSelection();
+
   QList<QGraphicsItem *> itemList = items();
   QList<QGraphicsItem *>::iterator itemIt = itemList.begin();
   for ( ; itemIt != itemList.end(); ++itemIt )
   {
     QgsComposerItem* mypItem = dynamic_cast<QgsComposerItem *>( *itemIt );
-    if ( mypItem )
+    if ( mypItem && mypItem->positionLock() )
     {
       QgsComposerItemCommand* subcommand = new QgsComposerItemCommand( mypItem, "", parentCommand );
       subcommand->savePreviousState();
       mypItem->setPositionLock( false );
+      //select unlocked items, same behaviour as illustrator
+      mypItem->setSelected( true );
+      emit selectedItemChanged( mypItem );
       subcommand->saveAfterState();
     }
   }

--- a/src/core/composer/qgscomposition.cpp
+++ b/src/core/composer/qgscomposition.cpp
@@ -1149,6 +1149,43 @@ void QgsComposition::alignSelectedItemsBottom()
   mUndoStack.push( parentCommand );
 }
 
+void QgsComposition::lockSelectedItems()
+{
+  QUndoCommand* parentCommand = new QUndoCommand( tr( "Items locked" ) );
+  QList<QgsComposerItem*> selectionList = selectedComposerItems();
+  QList<QgsComposerItem*>::iterator itemIter = selectionList.begin();
+  for ( ; itemIter != selectionList.end(); ++itemIter )
+  {
+    QgsComposerItemCommand* subcommand = new QgsComposerItemCommand( *itemIter, "", parentCommand );
+    subcommand->savePreviousState();
+    ( *itemIter )->setPositionLock( true );
+    subcommand->saveAfterState();
+  }
+
+  clearSelection();
+  mUndoStack.push( parentCommand );
+}
+
+void QgsComposition::unlockAllItems()
+{
+  //unlock all items in composer
+  QUndoCommand* parentCommand = new QUndoCommand( tr( "Items unlocked" ) );
+  QList<QGraphicsItem *> itemList = items();
+  QList<QGraphicsItem *>::iterator itemIt = itemList.begin();
+  for ( ; itemIt != itemList.end(); ++itemIt )
+  {
+    QgsComposerItem* mypItem = dynamic_cast<QgsComposerItem *>( *itemIt );
+    if ( mypItem )
+    {
+      QgsComposerItemCommand* subcommand = new QgsComposerItemCommand( mypItem, "", parentCommand );
+      subcommand->savePreviousState();
+      mypItem->setPositionLock( false );
+      subcommand->saveAfterState();
+    }
+  }
+  mUndoStack.push( parentCommand );
+}
+
 void QgsComposition::updateZValues()
 {
   int counter = 1;

--- a/src/core/composer/qgscomposition.h
+++ b/src/core/composer/qgscomposition.h
@@ -260,6 +260,12 @@ class CORE_EXPORT QgsComposition : public QGraphicsScene
     void alignSelectedItemsVCenter();
     void alignSelectedItemsBottom();
 
+    //functions to lock and unlock items
+    /**Lock the selected items*/
+    void lockSelectedItems();
+    /**Unlock all items*/
+    void unlockAllItems();
+
     /**Sorts the zList. The only time where this function needs to be called is from QgsComposer
      after reading all the items from xml file*/
     void sortZList();

--- a/src/gui/qgscomposerview.cpp
+++ b/src/gui/qgscomposerview.cpp
@@ -851,43 +851,6 @@ void QgsComposerView::ungroupItems()
   }
 }
 
-void QgsComposerView::lockItems()
-{
-  if ( !composition() )
-  {
-    return;
-  }
-
-  QList<QgsComposerItem*> selectionList = composition()->selectedComposerItems();
-  QList<QgsComposerItem*>::iterator itemIter = selectionList.begin();
-  for ( ; itemIter != selectionList.end(); ++itemIter )
-  {
-    ( *itemIter )->setPositionLock( true );
-  }
-
-  composition()->clearSelection();
-}
-
-void QgsComposerView::unlockAllItems()
-{
-  if ( !composition() )
-  {
-    return;
-  }
-
-  //unlock all items in composer
-  QList<QGraphicsItem *> itemList = composition()->items();
-  QList<QGraphicsItem *>::iterator itemIt = itemList.begin();
-  for ( ; itemIt != itemList.end(); ++itemIt )
-  {
-    QgsComposerItem* mypItem = dynamic_cast<QgsComposerItem *>( *itemIt );
-    if ( mypItem )
-    {
-      mypItem->setPositionLock( false );
-    }
-  }
-}
-
 QMainWindow* QgsComposerView::composerWindow()
 {
   QMainWindow* composerObject = 0;

--- a/src/gui/qgscomposerview.cpp
+++ b/src/gui/qgscomposerview.cpp
@@ -67,23 +67,6 @@ void QgsComposerView::mousePressEvent( QMouseEvent* e )
 
   QPointF scenePoint = mapToScene( e->pos() );
   QPointF snappedScenePoint = composition()->snapPointToGrid( scenePoint );
-
-  //lock/unlock position of item with right click
-  if ( e->button() == Qt::RightButton )
-  {
-    QgsComposerItem* selectedItem = composition()->composerItemAt( scenePoint );
-    if ( selectedItem )
-    {
-      bool lock = selectedItem->positionLock() ? false : true;
-      selectedItem->setPositionLock( lock );
-      selectedItem->update();
-      //make sure the new cursor is correct
-      QPointF itemPoint = selectedItem->mapFromScene( scenePoint );
-      selectedItem->updateCursor( itemPoint );
-    }
-    return;
-  }
-
   switch ( mCurrentTool )
   {
       //select/deselect items and pass mouse event further

--- a/src/gui/qgscomposerview.h
+++ b/src/gui/qgscomposerview.h
@@ -89,12 +89,6 @@ class GUI_EXPORT QgsComposerView: public QGraphicsView
     /**Ungroups the selected items*/
     void ungroupItems();
 
-    /**Lock the selected items*/
-    void lockItems();
-
-    /**Unlock all items*/
-    void unlockAllItems();
-
     /**Cuts or copies the selected items*/
     void copyItems( ClipboardMode mode );
 

--- a/src/ui/qgscomposerbase.ui
+++ b/src/ui/qgscomposerbase.ui
@@ -580,6 +580,9 @@
    <property name="text">
     <string>Lock Selected Items</string>
    </property>
+   <property name="shortcut">
+    <string>Ctrl+L</string>
+   </property>
   </action>
   <action name="mActionUnlockAll">
    <property name="icon">
@@ -591,6 +594,9 @@
    </property>
    <property name="toolTip">
     <string>Unlock All Items</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+L</string>
    </property>
   </action>
   <action name="mActionPasteInPlace">


### PR DESCRIPTION
Make composer history track lock/unlock state (works for lock/unlock actions only, but right click lock/unlock will be removed soon anyway)
Move unlock/lock functions from QgsComposerView to QgsComposition
Add keyboard shortcuts to lock item/unlock all
