### PR TITLE
[tests] Make app startup test work on Mac

### DIFF
--- a/tests/testdata/test_plugin_path/qgis.org/QGIS2.ini
+++ b/tests/testdata/test_plugin_path/qgis.org/QGIS2.ini
@@ -1,0 +1,2 @@
+[PythonPlugins]
+PluginPathTest=true


### PR DESCRIPTION
- Handle bundled app path on Mac
- Move test writes to temporary, instead of source, directory
- Add Mac code for options.ini parent directory
- Add Mac options.ini file for plugin path test
- Clean up imports
