### PR TITLE
[qgis server] Add RULE parameter support in GetLegendGraphic

### DIFF
--- a/src/core/composer/qgscomposerlegenditem.cpp
+++ b/src/core/composer/qgscomposerlegenditem.cpp
@@ -286,7 +286,7 @@ void QgsComposerLayerItem::readXML( const QDomElement& itemElem, bool xServerAva
   }
 }
 
-void QgsComposerLayerItem::setDefaultStyle( double scaleDenominator )
+void QgsComposerLayerItem::setDefaultStyle( double scaleDenominator, QString rule )
 {
   // set default style according to number of symbols
   QgsVectorLayer* vLayer = qobject_cast<QgsVectorLayer*>( QgsMapLayerRegistry::instance()->mapLayer( layerID() ) );
@@ -295,8 +295,8 @@ void QgsComposerLayerItem::setDefaultStyle( double scaleDenominator )
     QgsFeatureRendererV2* renderer = vLayer->rendererV2();
     if ( renderer )
     {
-      QPair<QString, QgsSymbolV2*> symbolItem = renderer->legendSymbolItems( scaleDenominator ).value( 0 );
-      if ( renderer->legendSymbolItems().size() > 1 || !symbolItem.first.isEmpty() )
+      QPair<QString, QgsSymbolV2*> symbolItem = renderer->legendSymbolItems( scaleDenominator, rule ).value( 0 );
+      if ( renderer->legendSymbolItems( scaleDenominator, rule ).size() > 1 || !symbolItem.first.isEmpty() )
       {
         setStyle( QgsComposerLegendStyle::Subgroup );
       }

--- a/src/core/composer/qgscomposerlegenditem.h
+++ b/src/core/composer/qgscomposerlegenditem.h
@@ -138,7 +138,7 @@ class CORE_EXPORT QgsComposerLayerItem : public QgsComposerLegendItem
     void setShowFeatureCount( bool show ) { mShowFeatureCount = show; }
     bool showFeatureCount() const { return mShowFeatureCount; }
 
-    void setDefaultStyle( double scaleDenominator = -1 );
+    void setDefaultStyle( double scaleDenominator = -1, QString rule = "" );
 
   private:
     QString mLayerID;

--- a/src/core/composer/qgslegendmodel.cpp
+++ b/src/core/composer/qgslegendmodel.cpp
@@ -191,7 +191,10 @@ int QgsLegendModel::addVectorLayerItemsV2( QStandardItem* layerItem, QgsVectorLa
     else
     {
       QgsComposerSymbolV2Item* currentSymbolItem = new QgsComposerSymbolV2Item( "" );
-      currentSymbolItem->setIcon( QgsSymbolLayerV2Utils::symbolPreviewIcon( symbolIt->second, QSize( 30, 30 ) ) );
+      if ( mHasTopLevelWindow ) //only use QIcon / QPixmap if we have a running x-server
+      {
+        currentSymbolItem->setIcon( QgsSymbolLayerV2Utils::symbolPreviewIcon( symbolIt->second, QSize( 30, 30 ) ) );
+      }
       currentSymbolItem->setSymbolV2( symbolIt->second );
       layerItem->setChild( row, 0, currentSymbolItem );
       currentSymbolItem->setText( symbolIt->first );

--- a/src/core/composer/qgslegendmodel.cpp
+++ b/src/core/composer/qgslegendmodel.cpp
@@ -98,7 +98,7 @@ void QgsLegendModel::setLayerSetAndGroups( const QStringList& layerIds, const QL
   }
 }
 
-void QgsLegendModel::setLayerSet( const QStringList& layerIds, double scaleDenominator )
+void QgsLegendModel::setLayerSet( const QStringList& layerIds, double scaleDenominator, QString rule )
 {
   mLayerIds = layerIds;
 
@@ -111,7 +111,7 @@ void QgsLegendModel::setLayerSet( const QStringList& layerIds, double scaleDenom
   for ( ; idIter != mLayerIds.constEnd(); ++idIter )
   {
     currentLayer = QgsMapLayerRegistry::instance()->mapLayer( *idIter );
-    addLayer( currentLayer, scaleDenominator );
+    addLayer( currentLayer, scaleDenominator, rule );
   }
 }
 
@@ -135,7 +135,7 @@ QStandardItem* QgsLegendModel::addGroup( QString text, int position )
   return groupItem;
 }
 
-int QgsLegendModel::addVectorLayerItemsV2( QStandardItem* layerItem, QgsVectorLayer* vlayer, double scaleDenominator )
+int QgsLegendModel::addVectorLayerItemsV2( QStandardItem* layerItem, QgsVectorLayer* vlayer, double scaleDenominator, QString rule )
 {
   QgsComposerLayerItem* lItem = dynamic_cast<QgsComposerLayerItem*>( layerItem );
 
@@ -158,12 +158,12 @@ int QgsLegendModel::addVectorLayerItemsV2( QStandardItem* layerItem, QgsVectorLa
     }
   }
 
-  QgsLegendSymbolList lst = renderer->legendSymbolItems( scaleDenominator );
+  QgsLegendSymbolList lst = renderer->legendSymbolItems( scaleDenominator, rule );
   QgsLegendSymbolList::const_iterator symbolIt = lst.constBegin();
   int row = 0;
   for ( ; symbolIt != lst.constEnd(); ++symbolIt )
   {
-    if ( scaleDenominator == -1 )
+    if ( scaleDenominator == -1 && rule.isEmpty() )
     {
       QgsComposerSymbolV2Item* currentSymbolItem = new QgsComposerSymbolV2Item( "" );
 
@@ -200,7 +200,8 @@ int QgsLegendModel::addVectorLayerItemsV2( QStandardItem* layerItem, QgsVectorLa
     }
   }
 
-  if ( scaleDenominator == -1 )
+  // Don't remove row on getLegendGraphic (read only with filter)
+  if ( scaleDenominator == -1 && rule.isEmpty() )
   {
     // Delete following old items (if current number of items decreased)
     for ( int i = layerItem->rowCount() - 1; i >= row; --i )
@@ -467,7 +468,7 @@ void QgsLegendModel::removeLayer( const QString& layerId )
   }
 }
 
-void QgsLegendModel::addLayer( QgsMapLayer* theMapLayer, double scaleDenominator )
+void QgsLegendModel::addLayer( QgsMapLayer* theMapLayer, double scaleDenominator, QString rule )
 {
   if ( !theMapLayer )
   {
@@ -481,7 +482,7 @@ void QgsLegendModel::addLayer( QgsMapLayer* theMapLayer, double scaleDenominator
     layerItem->setUserText( theMapLayer->title() );
   }
   layerItem->setLayerID( theMapLayer->id() );
-  layerItem->setDefaultStyle( scaleDenominator );
+  layerItem->setDefaultStyle( scaleDenominator, rule );
   layerItem->setFlags( Qt::ItemIsEnabled | Qt::ItemIsSelectable );
 
   QList<QStandardItem *> itemsList;
@@ -495,7 +496,7 @@ void QgsLegendModel::addLayer( QgsMapLayer* theMapLayer, double scaleDenominator
       QgsVectorLayer* vl = dynamic_cast<QgsVectorLayer*>( theMapLayer );
       if ( vl )
       {
-        addVectorLayerItemsV2( layerItem, vl, scaleDenominator );
+        addVectorLayerItemsV2( layerItem, vl, scaleDenominator, rule );
       }
       break;
     }

--- a/src/core/composer/qgslegendmodel.cpp
+++ b/src/core/composer/qgslegendmodel.cpp
@@ -187,17 +187,17 @@ int QgsLegendModel::addVectorLayerItemsV2( QStandardItem* layerItem, QgsVectorLa
 
       // updateSymbolV2ItemText needs layer set
       updateSymbolV2ItemText( currentSymbolItem );
-
-      row++;
     }
     else
     {
       QgsComposerSymbolV2Item* currentSymbolItem = new QgsComposerSymbolV2Item( "" );
       currentSymbolItem->setIcon( QgsSymbolLayerV2Utils::symbolPreviewIcon( symbolIt->second, QSize( 30, 30 ) ) );
       currentSymbolItem->setSymbolV2( symbolIt->second );
-      layerItem->setChild( 0, 0, currentSymbolItem );
+      layerItem->setChild( row, 0, currentSymbolItem );
       currentSymbolItem->setText( symbolIt->first );
     }
+
+    row++;
   }
 
   // Don't remove row on getLegendGraphic (read only with filter)

--- a/src/core/composer/qgslegendmodel.h
+++ b/src/core/composer/qgslegendmodel.h
@@ -54,7 +54,7 @@ class CORE_EXPORT QgsLegendModel: public QStandardItemModel
 
     /**Sets layer set and groups*/
     void setLayerSetAndGroups( const QStringList& layerIds, const QList< GroupLayerInfo >& groupInfo );
-    void setLayerSet( const QStringList& layerIds, double scaleDenominator = -1 );
+    void setLayerSet( const QStringList& layerIds, double scaleDenominator = -1, QString rule = "" );
     /**Adds a group
       @param text name of group (defaults to translation of "Group")
       @param position insertion position (toplevel position (or -1 if it should be placed at the end of the legend).
@@ -97,14 +97,14 @@ class CORE_EXPORT QgsLegendModel: public QStandardItemModel
 
   public slots:
     void removeLayer( const QString& layerId );
-    void addLayer( QgsMapLayer* theMapLayer, double scaleDenominator = -1 );
+    void addLayer( QgsMapLayer* theMapLayer, double scaleDenominator = -1, QString rule="" );
 
   signals:
     void layersChanged();
 
   private:
     /**Adds classification items of vector layers using new symbology*/
-    int addVectorLayerItemsV2( QStandardItem* layerItem, QgsVectorLayer* vlayer, double scaleDenominator = -1 );
+    int addVectorLayerItemsV2( QStandardItem* layerItem, QgsVectorLayer* vlayer, double scaleDenominator = -1, QString rule = "" );
 
     /**Adds item of raster layer
      @return 0 in case of success*/

--- a/src/core/symbology-ng/qgscategorizedsymbolrendererv2.cpp
+++ b/src/core/symbology-ng/qgscategorizedsymbolrendererv2.cpp
@@ -649,7 +649,10 @@ QgsLegendSymbolList QgsCategorizedSymbolRendererV2::legendSymbolItems( double sc
 
   foreach ( const QgsRendererCategoryV2& cat, mCategories )
   {
-    lst << qMakePair( cat.label(), cat.symbol() );
+    if ( rule.isEmpty() || cat.label() == rule )
+    {
+      lst << qMakePair( cat.label(), cat.symbol() );
+    }
   }
   return lst;
 }

--- a/src/core/symbology-ng/qgscategorizedsymbolrendererv2.cpp
+++ b/src/core/symbology-ng/qgscategorizedsymbolrendererv2.cpp
@@ -635,7 +635,7 @@ QgsLegendSymbologyList QgsCategorizedSymbolRendererV2::legendSymbologyItems( QSi
   return lst;
 }
 
-QgsLegendSymbolList QgsCategorizedSymbolRendererV2::legendSymbolItems( double scaleDenominator )
+QgsLegendSymbolList QgsCategorizedSymbolRendererV2::legendSymbolItems( double scaleDenominator, QString rule )
 {
   Q_UNUSED( scaleDenominator );
   QSettings settings;

--- a/src/core/symbology-ng/qgscategorizedsymbolrendererv2.h
+++ b/src/core/symbology-ng/qgscategorizedsymbolrendererv2.h
@@ -125,7 +125,7 @@ class CORE_EXPORT QgsCategorizedSymbolRendererV2 : public QgsFeatureRendererV2
     //! return a list of item text / symbol
     //! @note: this method was added in version 1.5
     //! @note not available in python bindings
-    virtual QgsLegendSymbolList legendSymbolItems( double scaleDenominator = -1 );
+    virtual QgsLegendSymbolList legendSymbolItems( double scaleDenominator = -1, QString rule = "" );
 
     QgsSymbolV2* sourceSymbol();
     void setSourceSymbol( QgsSymbolV2* sym );

--- a/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.cpp
+++ b/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.cpp
@@ -1095,7 +1095,7 @@ QgsLegendSymbologyList QgsGraduatedSymbolRendererV2::legendSymbologyItems( QSize
   return lst;
 }
 
-QgsLegendSymbolList QgsGraduatedSymbolRendererV2::legendSymbolItems( double scaleDenominator )
+QgsLegendSymbolList QgsGraduatedSymbolRendererV2::legendSymbolItems( double scaleDenominator, QString rule )
 {
   Q_UNUSED( scaleDenominator );
   QSettings settings;

--- a/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.cpp
+++ b/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.cpp
@@ -1109,16 +1109,19 @@ QgsLegendSymbolList QgsGraduatedSymbolRendererV2::legendSymbolItems( double scal
 
   foreach ( const QgsRendererRangeV2& range, mRanges )
   {
-    QgsSymbolV2* symbol;
-    if ( mRotationFieldIdx == -1 && mSizeScaleFieldIdx == -1 )
+    if ( rule.isEmpty() || range.label() == rule )
     {
-      symbol = range.symbol();
+      QgsSymbolV2* symbol;
+      if ( mRotationFieldIdx == -1 && mSizeScaleFieldIdx == -1 )
+      {
+        symbol = range.symbol();
+      }
+      else
+      {
+        symbol = mTempSymbols[range.symbol()];
+      }
+      lst << qMakePair( range.label(), symbol );
     }
-    else
-    {
-      symbol = mTempSymbols[range.symbol()];
-    }
-    lst << qMakePair( range.label(), symbol );
   }
   return lst;
 }

--- a/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.h
+++ b/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.h
@@ -137,7 +137,7 @@ class CORE_EXPORT QgsGraduatedSymbolRendererV2 : public QgsFeatureRendererV2
     //! return a list of item text / symbol
     //! @note: this method was added in version 1.5
     //! @note not available in python bindings
-    virtual QgsLegendSymbolList legendSymbolItems( double scaleDenominator = -1 );
+    virtual QgsLegendSymbolList legendSymbolItems( double scaleDenominator = -1, QString rule = "" );
 
     QgsSymbolV2* sourceSymbol();
     void setSourceSymbol( QgsSymbolV2* sym );

--- a/src/core/symbology-ng/qgspointdisplacementrenderer.cpp
+++ b/src/core/symbology-ng/qgspointdisplacementrenderer.cpp
@@ -330,11 +330,11 @@ QgsLegendSymbologyList QgsPointDisplacementRenderer::legendSymbologyItems( QSize
   return QgsLegendSymbologyList();
 }
 
-QgsLegendSymbolList QgsPointDisplacementRenderer::legendSymbolItems()
+QgsLegendSymbolList QgsPointDisplacementRenderer::legendSymbolItems( double scaleDenominator, QString rule )
 {
   if ( mRenderer )
   {
-    return mRenderer->legendSymbolItems();
+    return mRenderer->legendSymbolItems( scaleDenominator, rule );
   }
   return QgsLegendSymbolList();
 }

--- a/src/core/symbology-ng/qgspointdisplacementrenderer.h
+++ b/src/core/symbology-ng/qgspointdisplacementrenderer.h
@@ -57,7 +57,7 @@ class CORE_EXPORT QgsPointDisplacementRenderer: public QgsFeatureRendererV2
     QgsLegendSymbologyList legendSymbologyItems( QSize iconSize );
 
     //! @note not available in python bindings
-    QgsLegendSymbolList legendSymbolItems();
+    QgsLegendSymbolList legendSymbolItems( double scaleDenominator = -1, QString rule = "" );
 
     void setLabelAttributeName( const QString& name ) { mLabelAttributeName = name; }
     QString labelAttributeName() const { return mLabelAttributeName; }

--- a/src/core/symbology-ng/qgsrendererv2.cpp
+++ b/src/core/symbology-ng/qgsrendererv2.cpp
@@ -510,6 +510,7 @@ QgsLegendSymbologyList QgsFeatureRendererV2::legendSymbologyItems( QSize iconSiz
 QgsLegendSymbolList QgsFeatureRendererV2::legendSymbolItems( double scaleDenominator, QString rule )
 {
   Q_UNUSED( scaleDenominator );
+  Q_UNUSED( rule );
   return QgsLegendSymbolList();
 }
 

--- a/src/core/symbology-ng/qgsrendererv2.cpp
+++ b/src/core/symbology-ng/qgsrendererv2.cpp
@@ -507,7 +507,7 @@ QgsLegendSymbologyList QgsFeatureRendererV2::legendSymbologyItems( QSize iconSiz
   return QgsLegendSymbologyList();
 }
 
-QgsLegendSymbolList QgsFeatureRendererV2::legendSymbolItems( double scaleDenominator )
+QgsLegendSymbolList QgsFeatureRendererV2::legendSymbolItems( double scaleDenominator, QString rule )
 {
   Q_UNUSED( scaleDenominator );
   return QgsLegendSymbolList();

--- a/src/core/symbology-ng/qgsrendererv2.h
+++ b/src/core/symbology-ng/qgsrendererv2.h
@@ -149,7 +149,7 @@ class CORE_EXPORT QgsFeatureRendererV2
     //! return a list of item text / symbol
     //! @note: this method was added in version 1.5
     //! @note: not available in python bindings
-    virtual QgsLegendSymbolList legendSymbolItems( double scaleDenominator = -1 );
+    virtual QgsLegendSymbolList legendSymbolItems( double scaleDenominator = -1, QString rule = "" );
 
     //! set type and size of editing vertex markers for subsequent rendering
     void setVertexMarkerAppearance( int type, int size );

--- a/src/core/symbology-ng/qgsrulebasedrendererv2.cpp
+++ b/src/core/symbology-ng/qgsrulebasedrendererv2.cpp
@@ -184,10 +184,7 @@ QgsLegendSymbolList QgsRuleBasedRendererV2::Rule::legendSymbolItems( double scal
   for ( RuleList::iterator it = mChildren.begin(); it != mChildren.end(); ++it )
   {
     Rule* rule = *it;
-    if ( scaleDenominator == -1 || (
-           ( rule->mScaleMinDenom == -1 || rule->mScaleMinDenom < scaleDenominator ) &&
-           ( rule->mScaleMaxDenom == -1 || scaleDenominator < rule->mScaleMaxDenom ) ) )
-    {
+    if ( scaleDenominator == -1 || rule->isScaleOK(scaleDenominator) ) {
       lst << rule->legendSymbolItems( scaleDenominator, ruleFilter );
     }
   }

--- a/src/core/symbology-ng/qgsrulebasedrendererv2.cpp
+++ b/src/core/symbology-ng/qgsrulebasedrendererv2.cpp
@@ -175,10 +175,10 @@ void QgsRuleBasedRendererV2::Rule::setSymbol( QgsSymbolV2* sym )
   mSymbol = sym;
 }
 
-QgsLegendSymbolList QgsRuleBasedRendererV2::Rule::legendSymbolItems( double scaleDenominator )
+QgsLegendSymbolList QgsRuleBasedRendererV2::Rule::legendSymbolItems( double scaleDenominator, QString ruleFilter )
 {
   QgsLegendSymbolList lst;
-  if ( mSymbol )
+  if ( mSymbol && ( ruleFilter.isEmpty() || mLabel == ruleFilter ) )
     lst << qMakePair( mLabel, mSymbol );
 
   for ( RuleList::iterator it = mChildren.begin(); it != mChildren.end(); ++it )
@@ -188,7 +188,7 @@ QgsLegendSymbolList QgsRuleBasedRendererV2::Rule::legendSymbolItems( double scal
            ( rule->mScaleMinDenom == -1 || rule->mScaleMinDenom < scaleDenominator ) &&
            ( rule->mScaleMaxDenom == -1 || scaleDenominator < rule->mScaleMaxDenom ) ) )
     {
-      lst << rule->legendSymbolItems( scaleDenominator );
+      lst << rule->legendSymbolItems( scaleDenominator, ruleFilter );
     }
   }
   return lst;
@@ -849,9 +849,9 @@ QgsLegendSymbologyList QgsRuleBasedRendererV2::legendSymbologyItems( QSize iconS
   return lst;
 }
 
-QgsLegendSymbolList QgsRuleBasedRendererV2::legendSymbolItems( double scaleDenominator )
+QgsLegendSymbolList QgsRuleBasedRendererV2::legendSymbolItems( double scaleDenominator, QString rule )
 {
-  return mRootRule->legendSymbolItems( scaleDenominator );
+  return mRootRule->legendSymbolItems( scaleDenominator, rule );
 }
 
 

--- a/src/core/symbology-ng/qgsrulebasedrendererv2.h
+++ b/src/core/symbology-ng/qgsrulebasedrendererv2.h
@@ -93,7 +93,7 @@ class CORE_EXPORT QgsRuleBasedRendererV2 : public QgsFeatureRendererV2
         QSet<QString> usedAttributes();
         QgsSymbolV2List symbols();
         //! @note not available in python bindings
-        QgsLegendSymbolList legendSymbolItems( double scaleDenominator = -1 );
+        QgsLegendSymbolList legendSymbolItems( double scaleDenominator = -1, QString rule = "" );
         bool isFilterOK( QgsFeature& f ) const;
         bool isScaleOK( double scale ) const;
 
@@ -226,7 +226,7 @@ class CORE_EXPORT QgsRuleBasedRendererV2 : public QgsFeatureRendererV2
     //! return a list of item text / symbol
     //! @note: this method was added in version 1.5
     //! @note not available in python bindings
-    virtual QgsLegendSymbolList legendSymbolItems( double scaleDenominator = -1 );
+    virtual QgsLegendSymbolList legendSymbolItems( double scaleDenominator = -1, QString rule = "" );
 
     //! for debugging
     virtual QString dump() const;

--- a/src/core/symbology-ng/qgssinglesymbolrendererv2.cpp
+++ b/src/core/symbology-ng/qgssinglesymbolrendererv2.cpp
@@ -373,9 +373,10 @@ QgsLegendSymbologyList QgsSingleSymbolRendererV2::legendSymbologyItems( QSize ic
   return lst;
 }
 
-QgsLegendSymbolList QgsSingleSymbolRendererV2::legendSymbolItems( double scaleDenominator )
+QgsLegendSymbolList QgsSingleSymbolRendererV2::legendSymbolItems( double scaleDenominator, QString rule )
 {
   Q_UNUSED( scaleDenominator );
+  Q_UNUSED( rule );
   QgsLegendSymbolList lst;
   lst << qMakePair( QString(), mSymbol );
   return lst;

--- a/src/core/symbology-ng/qgssinglesymbolrendererv2.h
+++ b/src/core/symbology-ng/qgssinglesymbolrendererv2.h
@@ -78,7 +78,7 @@ class CORE_EXPORT QgsSingleSymbolRendererV2 : public QgsFeatureRendererV2
     //! return a list of item text / symbol
     //! @note: this method was added in version 1.5
     //! @note not available in python bindings
-    virtual QgsLegendSymbolList legendSymbolItems( double scaleDenominator = -1 );
+    virtual QgsLegendSymbolList legendSymbolItems( double scaleDenominator = -1, QString rule = "" );
 
   protected:
     QgsSymbolV2* mSymbol;

--- a/src/core/symbology-ng/qgssymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgssymbollayerv2.cpp
@@ -318,7 +318,7 @@ void QgsLineSymbolLayerV2::renderPolygonOutline( const QPolygonF& points, QList<
 
 void QgsFillSymbolLayerV2::drawPreviewIcon( QgsSymbolV2RenderContext& context, QSize size )
 {
-  QPolygonF poly = QRectF( QPointF( 0, 0 ), QPointF( size.width() - 1, size.height() - 1 ) );
+  QPolygonF poly = QRectF( QPointF( 0, 0 ), QPointF( size.width(), size.height() ) );
   startRender( context );
   renderPolygon( poly, NULL, context );
   stopRender( context );

--- a/src/mapserver/qgswmsserver.cpp
+++ b/src/mapserver/qgswmsserver.cpp
@@ -404,7 +404,7 @@ QImage* QgsWMSServer::getLegendGraphics()
       switch ( type )
       {
         case QgsComposerLegendItem::SymbologyV2Item:
-          drawLegendSymbolV2( currentComposerItem, &p, 0., 0., symbolWidth, symbolHeight, theImage->dotsPerMeterX() * 0.0254, 0. );
+          drawLegendSymbolV2( currentComposerItem, &p, 0., 0., symbolWidth, symbolHeight, 0. );
           break;
         case QgsComposerLegendItem::RasterSymbolItem:
           drawRasterSymbol( currentComposerItem, &p, 0., 0., symbolWidth, symbolHeight, 0. );
@@ -428,7 +428,7 @@ QImage* QgsWMSServer::getLegendGraphics()
 
   double currentY = drawLegendGraphics( 0, fontOversamplingFactor, rootItem, boxSpace, layerSpace, layerTitleSpace, symbolSpace,
                                         iconLabelSpace, symbolWidth, symbolHeight, layerFont, itemFont, layerFontColor, itemFontColor, maxTextWidth,
-                                        maxSymbolWidth, theImage->dotsPerMeterX() * 0.0254 );
+                                        maxSymbolWidth );
 
   //create second image with the right dimensions
   QImage* paintImage = createImage( maxTextWidth + maxSymbolWidth, ceil( currentY ) );
@@ -439,7 +439,7 @@ QImage* QgsWMSServer::getLegendGraphics()
 
   drawLegendGraphics( &p, fontOversamplingFactor, rootItem, boxSpace, layerSpace, layerTitleSpace, symbolSpace,
                       iconLabelSpace, symbolWidth, symbolHeight, layerFont, itemFont, layerFontColor, itemFontColor, maxTextWidth,
-                      maxSymbolWidth, theImage->dotsPerMeterX() * 0.0254 );
+                      maxSymbolWidth );
 
   QgsMapLayerRegistry::instance()->removeAllMapLayers();
   delete theImage;
@@ -449,7 +449,7 @@ QImage* QgsWMSServer::getLegendGraphics()
 double QgsWMSServer::drawLegendGraphics( QPainter* p, double fontOversamplingFactor, QStandardItem* rootItem, double boxSpace,
     double layerSpace, double layerTitleSpace, double symbolSpace, double iconLabelSpace,
     double symbolWidth, double symbolHeight, const QFont& layerFont, const QFont& itemFont,
-    const QColor& layerFontColor, const QColor& itemFontColor, double& maxTextWidth, double& maxSymbolWidth, double dpi )
+    const QColor& layerFontColor, const QColor& itemFontColor, double& maxTextWidth, double& maxSymbolWidth )
 {
   if ( !rootItem )
   {
@@ -473,8 +473,7 @@ double QgsWMSServer::drawLegendGraphics( QPainter* p, double fontOversamplingFac
         currentY += layerSpace;
       }
       drawLegendLayerItem( layerItem, p, maxTextWidth, maxSymbolWidth, currentY, layerFont, layerFontColor, itemFont, itemFontColor,
-                           boxSpace, layerSpace, layerTitleSpace, symbolSpace, iconLabelSpace, symbolWidth, symbolHeight, fontOversamplingFactor,
-                           dpi );
+                           boxSpace, layerSpace, layerTitleSpace, symbolSpace, iconLabelSpace, symbolWidth, symbolHeight, fontOversamplingFactor );
     }
   }
   currentY += boxSpace;
@@ -1681,8 +1680,7 @@ QStringList QgsWMSServer::layerSet( const QStringList &layersList,
 
 void QgsWMSServer::drawLegendLayerItem( QgsComposerLayerItem* item, QPainter* p, double& maxTextWidth, double& maxSymbolWidth, double& currentY, const QFont& layerFont,
                                         const QColor& layerFontColor, const QFont& itemFont, const QColor&  itemFontColor, double boxSpace, double layerSpace,
-                                        double layerTitleSpace, double symbolSpace, double iconLabelSpace, double symbolWidth, double symbolHeight, double fontOversamplingFactor,
-                                        double dpi ) const
+                                        double layerTitleSpace, double symbolSpace, double iconLabelSpace, double symbolWidth, double symbolHeight, double fontOversamplingFactor ) const
 {
   Q_UNUSED( layerSpace );
   if ( !item )
@@ -1743,7 +1741,7 @@ void QgsWMSServer::drawLegendLayerItem( QgsComposerLayerItem* item, QPainter* p,
     switch ( type )
     {
       case QgsComposerLegendItem::SymbologyV2Item:
-        drawLegendSymbolV2( currentComposerItem, p, boxSpace, currentY, currentSymbolWidth, currentSymbolHeight, dpi, symbolDownShift );
+        drawLegendSymbolV2( currentComposerItem, p, boxSpace, currentY, currentSymbolWidth, currentSymbolHeight, symbolDownShift );
         break;
       case QgsComposerLegendItem::RasterSymbolItem:
         drawRasterSymbol( currentComposerItem, p, boxSpace, currentY, currentSymbolWidth, currentSymbolHeight, symbolDownShift );
@@ -1796,7 +1794,7 @@ void QgsWMSServer::drawLegendLayerItem( QgsComposerLayerItem* item, QPainter* p,
 
 
 void QgsWMSServer::drawLegendSymbolV2( QgsComposerLegendItem* item, QPainter* p, double boxSpace, double currentY, double& symbolWidth,
-                                       double& symbolHeight, double dpi, double yDownShift ) const
+                                       double& symbolHeight, double yDownShift ) const
 {
   QgsComposerSymbolV2Item* symbolItem = dynamic_cast< QgsComposerSymbolV2Item* >( item );
   if ( !symbolItem )
@@ -1807,14 +1805,6 @@ void QgsWMSServer::drawLegendSymbolV2( QgsComposerLegendItem* item, QPainter* p,
   if ( !symbol )
   {
     return;
-  }
-
-  //markers might have a different size
-  QgsMarkerSymbolV2* markerSymbol = dynamic_cast< QgsMarkerSymbolV2* >( symbol );
-  if ( markerSymbol )
-  {
-    symbolWidth = markerSymbol->size() * dpi / 25.4;
-    symbolHeight = markerSymbol->size() * dpi / 25.4;
   }
 
   if ( p )

--- a/src/mapserver/qgswmsserver.h
+++ b/src/mapserver/qgswmsserver.h
@@ -149,7 +149,7 @@ class QgsWMSServer
     double drawLegendGraphics( QPainter* p, double fontOversamplingFactor, QStandardItem* rootItem, double boxSpace, double layerSpace, double layerTitleSpace,
                                double symbolSpace, double iconLabelSpace, double symbolWidth, double symbolHeight,
                                const QFont& layerFont, const QFont& itemFont, const QColor& layerFontColor, const QColor& itemFontColor,
-                               double& maxTextWidth, double& maxSymbolWidth, double dpi );
+                               double& maxTextWidth, double& maxSymbolWidth );
 
     //helper functions for GetLegendGraphics
     /**Draws layer item and subitems
@@ -159,9 +159,9 @@ class QgsWMSServer
       */
     void drawLegendLayerItem( QgsComposerLayerItem* item, QPainter* p, double& maxTextWidth, double& maxSymbolWidth, double& currentY, const QFont& layerFont,
                               const QColor& layerFontColor, const QFont& itemFont, const QColor&  itemFontColor, double boxSpace, double layerSpace,
-                              double layerTitleSpace, double symbolSpace, double iconLabelSpace, double symbolWidth, double symbolHeight, double fontOversamplingFactor, double dpi ) const;
+                              double layerTitleSpace, double symbolSpace, double iconLabelSpace, double symbolWidth, double symbolHeight, double fontOversamplingFactor ) const;
     /**Draws a symbol. Optionally, maxHeight is adapted (e.g. for large point markers) */
-    void drawLegendSymbolV2( QgsComposerLegendItem* item, QPainter* p, double boxSpace, double currentY, double& symbolWidth, double& symbolHeight, double dpi, double yDownShift ) const;
+    void drawLegendSymbolV2( QgsComposerLegendItem* item, QPainter* p, double boxSpace, double currentY, double& symbolWidth, double& symbolHeight, double yDownShift ) const;
     void drawRasterSymbol( QgsComposerLegendItem* item, QPainter* p, double boxSpace, double currentY, double symbolWidth, double symbolHeight, double yDownShift ) const;
 
     /**Read legend parameter from the request or from the first print composer in the project*/


### PR DESCRIPTION
Especially with the new RULE parameter I see that the icon is one pixel smaller than it should be 
Fix symbole size    bc5cf20

When I introduce the scaleDenominator and rule in the mane class method signature I miss to change all the children method signature
Fix method signature for non rule based symbol  996a5f3

Implement the rule filter in Categorized and Graduated
Gett the right rule in Categorized and Graduated    0b4db7f

Before this the marker symbol is not centred on the symbol place (on top left corner).
Don't needed anymore …    4545858

Fix GetLegendGraphic with scale on Categorized or Graduated symbol  cc193c8

Use the already exists method isScaleOK
Fix GetLegendGraphic with scale on non scale limited rule   5ac0ecd

Without this, the scaleFactor in MM becomes 0 in https://github.com/qgis/QGIS/blob/master/src/core/symbology-ng/qgssymbollayerv2utils.cpp#L2555.
Than we enter in a loop. For example on a GetLegendGraphic with a line style as Steps
Add missing test. 2de9426153b0e0beacc07e6ff7b0cd9cdc83d4da
