### PR TITLE
Fixed build on OS X. QXmlStream* renamed to QCoreXmlStream*.

### DIFF
--- a/src/analysis/openstreetmap/qgsosmimport.h
+++ b/src/analysis/openstreetmap/qgsosmimport.h
@@ -21,6 +21,20 @@
 
 #include "qgsosmbase.h"
 
+/**
+ * QXmlStream* was moved from QtXml to QtCore in Qt 4.4.0.
+ * Apple Mac OS X and IBM AIX executables do not support symbol renaming or
+ * duplication, so we have to move things about here.
+ * See original comments in corelib/xml/qxmlstream.h
+ */
+#if QT_VERSION >= 0x040400
+# if defined(Q_OS_MAC32) || defined(Q_OS_AIX)
+#  if !defined QT_BUILD_XML_LIB
+#   define QXmlStreamReader QCoreXmlStreamReader
+#  endif
+# endif
+#endif
+
 class QXmlStreamReader;
 
 /**


### PR DESCRIPTION
This commit fixes a problem with building QGIS on OS X.

Without this patch I get the following errors building on OS X 10.6.8 (Core Duo, 32-bit):

```
[ 15%] Building CXX object src/analysis/CMakeFiles/qgis_analysis.dir/openstreetmap/qgsosmimport.cpp.o
/Users/snorf/Desktop/Quantum-GIS/src/analysis/openstreetmap/qgsosmimport.cpp: In member function ‘bool QgsOSMXmlImport::import()’:
/Users/snorf/Desktop/Quantum-GIS/src/analysis/openstreetmap/qgsosmimport.cpp:88: error: no matching function for call to ‘QgsOSMXmlImport::readRoot(QCoreXmlStreamReader&)’
/Users/snorf/Desktop/Quantum-GIS/src/analysis/openstreetmap/qgsosmimport.h:67: note: candidates are: void QgsOSMXmlImport::readRoot(QXmlStreamReader&)
/Users/snorf/Desktop/Quantum-GIS/src/analysis/openstreetmap/qgsosmimport.cpp: At global scope:
/Users/snorf/Desktop/Quantum-GIS/src/analysis/openstreetmap/qgsosmimport.cpp:230: error: prototype for ‘void QgsOSMXmlImport::readRoot(QCoreXmlStreamReader&)’ does not match any in class ‘QgsOSMXmlImport’
/Users/snorf/Desktop/Quantum-GIS/src/analysis/openstreetmap/qgsosmimport.h:67: error: candidate is: void QgsOSMXmlImport::readRoot(QXmlStreamReader&)
/Users/snorf/Desktop/Quantum-GIS/src/analysis/openstreetmap/qgsosmimport.cpp: In member function ‘void QgsOSMXmlImport::readRoot(QCoreXmlStreamReader&)’:
/Users/snorf/Desktop/Quantum-GIS/src/analysis/openstreetmap/qgsosmimport.cpp:256: error: no matching function for call to ‘QgsOSMXmlImport::readNode(QCoreXmlStreamReader&)’
/Users/snorf/Desktop/Quantum-GIS/src/analysis/openstreetmap/qgsosmimport.h:68: note: candidates are: void QgsOSMXmlImport::readNode(QXmlStreamReader&)
/Users/snorf/Desktop/Quantum-GIS/src/analysis/openstreetmap/qgsosmimport.cpp:258: error: no matching function for call to ‘QgsOSMXmlImport::readWay(QCoreXmlStreamReader&)’
/Users/snorf/Desktop/Quantum-GIS/src/analysis/openstreetmap/qgsosmimport.h:69: note: candidates are: void QgsOSMXmlImport::readWay(QXmlStreamReader&)
/Users/snorf/Desktop/Quantum-GIS/src/analysis/openstreetmap/qgsosmimport.cpp: At global scope:
/Users/snorf/Desktop/Quantum-GIS/src/analysis/openstreetmap/qgsosmimport.cpp:266: error: prototype for ‘void QgsOSMXmlImport::readNode(QCoreXmlStreamReader&)’ does not match any in class ‘QgsOSMXmlImport’
/Users/snorf/Desktop/Quantum-GIS/src/analysis/openstreetmap/qgsosmimport.h:68: error: candidate is: void QgsOSMXmlImport::readNode(QXmlStreamReader&)
/Users/snorf/Desktop/Quantum-GIS/src/analysis/openstreetmap/qgsosmimport.cpp: In member function ‘void QgsOSMXmlImport::readNode(QCoreXmlStreamReader&)’:
/Users/snorf/Desktop/Quantum-GIS/src/analysis/openstreetmap/qgsosmimport.cpp:296: error: no matching function for call to ‘QgsOSMXmlImport::readTag(bool, QgsOSMId&, QCoreXmlStreamReader&)’
/Users/snorf/Desktop/Quantum-GIS/src/analysis/openstreetmap/qgsosmimport.h:70: note: candidates are: void QgsOSMXmlImport::readTag(bool, QgsOSMId, QXmlStreamReader&)
/Users/snorf/Desktop/Quantum-GIS/src/analysis/openstreetmap/qgsosmimport.cpp: At global scope:
/Users/snorf/Desktop/Quantum-GIS/src/analysis/openstreetmap/qgsosmimport.cpp:303: error: prototype for ‘void QgsOSMXmlImport::readTag(bool, QgsOSMId, QCoreXmlStreamReader&)’ does not match any in class ‘QgsOSMXmlImport’
/Users/snorf/Desktop/Quantum-GIS/src/analysis/openstreetmap/qgsosmimport.h:70: error: candidate is: void QgsOSMXmlImport::readTag(bool, QgsOSMId, QXmlStreamReader&)
/Users/snorf/Desktop/Quantum-GIS/src/analysis/openstreetmap/qgsosmimport.cpp:325: error: prototype for ‘void QgsOSMXmlImport::readWay(QCoreXmlStreamReader&)’ does not match any in class ‘QgsOSMXmlImport’
/Users/snorf/Desktop/Quantum-GIS/src/analysis/openstreetmap/qgsosmimport.h:69: error: candidate is: void QgsOSMXmlImport::readWay(QXmlStreamReader&)
make[2]: *** [src/analysis/CMakeFiles/qgis_analysis.dir/openstreetmap/qgsosmimport.cpp.o] Error 1
make[1]: *** [src/analysis/CMakeFiles/qgis_analysis.dir/all] Error 2
make: *** [all] Error 2
```

`QXmlStreamReader` is pulled from `qxmlstream.cpp/.h`:

From `qxmlstream.h`:

```
// QXmlStream* was originally in the QtXml module
// since we've moved it to QtCore in Qt 4.4.0, we need to
// keep binary compatibility
//
// The list of supported platforms is in:
//   http://qt.nokia.com/doc/supported_platforms.html
//
// These platforms do not support symbol moving nor duplication
// (because duplicate symbols cause warnings when linking):
//   Apple MacOS X (Mach-O executable format)
//       special case: 64-bit on Mac wasn't supported before 4.5.0
//   IBM AIX (XCOFF executable format)

// ... [omitted for brevity]

#if defined Q_XMLSTREAM_RENAME_SYMBOLS
// don't worry, we'll undef and change to typedef at the bottom of the file
# define QXmlStreamAttribute QCoreXmlStreamAttribute
# define QXmlStreamAttributes QCoreXmlStreamAttributes
# define QXmlStreamEntityDeclaration QCoreXmlStreamEntityDeclaration
# define QXmlStreamEntityDeclarations QCoreXmlStreamEntityDeclarations
# define QXmlStreamEntityResolver QCoreXmlStreamEntityResolver
# define QXmlStreamNamespaceDeclaration QCoreXmlStreamNamespaceDeclaration
# define QXmlStreamNamespaceDeclarations QCoreXmlStreamNamespaceDeclarations
# define QXmlStreamNotationDeclaration QCoreXmlStreamNotationDeclaration
# define QXmlStreamNotationDeclarations QCoreXmlStreamNotationDeclarations
# define QXmlStreamReader QCoreXmlStreamReader
# define QXmlStreamStringRef QCoreXmlStreamStringRef
# define QXmlStreamWriter QCoreXmlStreamWriter
#endif
```

I have not tested this on any machine other than my own. I believe I am in a fairly niche group, running QGIS on OS X on a 32-bit Intel processor (most are 64-bit).

This is the first time I've submitted a pull request... please be gentle.
