### PR TITLE
Makes SAGA supervised classification work also with SAGA 2.0.8, fixes #8715. Add schema selection to GUI of "Import into PostGIS" tool (fixes #8513). Fixes export of GRASS vectors (fix #8515)

### DIFF
--- a/python/plugins/processing/admintools/ImportIntoPostGIS.py
+++ b/python/plugins/processing/admintools/ImportIntoPostGIS.py
@@ -96,6 +96,7 @@ class ImportIntoPostGIS(GeoAlgorithm):
         self.group = "PostGIS management tools"
         self.addParameter(ParameterVector(self.INPUT, "Layer to import"))
         self.addParameter(ParameterString(self.DATABASE, "Database (connection name)"))
+        self.addParameter(ParameterString(self.SCHEMA, "Schema (schema name)"))
         self.addParameter(ParameterString(self.TABLENAME, "Table to import to"))
         self.addParameter(ParameterBoolean(self.OVERWRITE, "Overwrite", True))
         self.addParameter(ParameterBoolean(self.CREATEINDEX, "Create spatial index", True))

--- a/python/plugins/processing/grass/GrassAlgorithm.py
+++ b/python/plugins/processing/grass/GrassAlgorithm.py
@@ -336,7 +336,7 @@ class GrassAlgorithm(GeoAlgorithm):
 
             if isinstance(out, OutputVector):
                 filename = out.value
-                command = "v.out.ogr -e input=" + out.name + uniqueSufix
+                command = "v.out.ogr -c -e input=" + out.name + uniqueSufix
                 command += " dsn=\"" + os.path.dirname(out.value) + "\""
                 command += " format=ESRI_Shapefile"
                 command += " olayer=" + os.path.basename(out.value)[:-4]

--- a/python/plugins/processing/saga/ext/supervisedclassification.py
+++ b/python/plugins/processing/saga/ext/supervisedclassification.py
@@ -26,7 +26,9 @@ __revision__ = '$Format:%H$'
 from processing.tests.TestData import table
 
 def editCommands(commands):
-    commands[-3] = commands[-3] + " -STATS " + table()
-    return commands
-
-
+	saga208 = ProcessingConfig.getSetting(SagaUtils.SAGA_208)
+	if not saga208:
+		commands[-3] = commands[-3] + " -STATS " + table()
+		return commands
+	else:
+		return commands

--- a/python/plugins/processing/saga/ext/supervisedclassification.py
+++ b/python/plugins/processing/saga/ext/supervisedclassification.py
@@ -24,6 +24,8 @@ __copyright__ = '(C) 2013, Victor Olaya'
 __revision__ = '$Format:%H$'
 
 from processing.tests.TestData import table
+from processing.core.ProcessingConfig import ProcessingConfig
+from processing.saga.SagaUtils import SagaUtils
 
 def editCommands(commands):
 	saga208 = ProcessingConfig.getSetting(SagaUtils.SAGA_208)


### PR DESCRIPTION
Supervised classification patch contributed by Luca Congedo.
