### PR TITLE
Composer grid fixes

### DIFF
--- a/src/app/composer/qgscompositionwidget.cpp
+++ b/src/app/composer/qgscompositionwidget.cpp
@@ -108,6 +108,7 @@ QgsCompositionWidget::QgsCompositionWidget( QWidget* parent, QgsComposition* c )
     }
 
     mSelectionToleranceSpinBox->setValue( mComposition->selectionTolerance() );
+    mGridToleranceSpinBox->setValue( mComposition->snapGridTolerance() );
   }
   blockSignals( false );
 }
@@ -561,6 +562,14 @@ void QgsCompositionWidget::on_mGridStyleComboBox_currentIndexChanged( const QStr
   }
 }
 
+void QgsCompositionWidget::on_mGridToleranceSpinBox_valueChanged( double d )
+{
+  if ( mComposition )
+  {
+    mComposition->setSnapGridTolerance( d );
+  }
+}
+
 void QgsCompositionWidget::on_mSelectionToleranceSpinBox_valueChanged( double d )
 {
   if ( mComposition )
@@ -601,6 +610,7 @@ void QgsCompositionWidget::blockSignals( bool block )
   mOffsetYSpinBox->blockSignals( block );
   mGridColorButton->blockSignals( block );
   mGridStyleComboBox->blockSignals( block );
+  mGridToleranceSpinBox->blockSignals( block );
   mSelectionToleranceSpinBox->blockSignals( block );
   mAlignmentSnapGroupCheckBox->blockSignals( block );
   mAlignmentToleranceSpinBox->blockSignals( block );

--- a/src/app/composer/qgscompositionwidget.cpp
+++ b/src/app/composer/qgscompositionwidget.cpp
@@ -84,9 +84,6 @@ QgsCompositionWidget::QgsCompositionWidget( QWidget* parent, QgsComposition* c )
     mOffsetYSpinBox->setValue( mComposition->snapGridOffsetY() );
 
 
-    //grid pen width
-    mPenWidthSpinBox->setValue( mComposition->gridPen().widthF() );
-
     //grid pen color
     mGridColorButton->setColor( mComposition->gridPen().color() );
     mGridColorButton->setColorDialogTitle( tr( "Select grid color" ) );
@@ -564,16 +561,6 @@ void QgsCompositionWidget::on_mGridStyleComboBox_currentIndexChanged( const QStr
   }
 }
 
-void QgsCompositionWidget::on_mPenWidthSpinBox_valueChanged( double d )
-{
-  if ( mComposition )
-  {
-    QPen pen = mComposition->gridPen();
-    pen.setWidthF( d );
-    mComposition->setGridPen( pen );
-  }
-}
-
 void QgsCompositionWidget::on_mSelectionToleranceSpinBox_valueChanged( double d )
 {
   if ( mComposition )
@@ -612,7 +599,6 @@ void QgsCompositionWidget::blockSignals( bool block )
   mGridResolutionSpinBox->blockSignals( block );
   mOffsetXSpinBox->blockSignals( block );
   mOffsetYSpinBox->blockSignals( block );
-  mPenWidthSpinBox->blockSignals( block );
   mGridColorButton->blockSignals( block );
   mGridStyleComboBox->blockSignals( block );
   mSelectionToleranceSpinBox->blockSignals( block );

--- a/src/app/composer/qgscompositionwidget.h
+++ b/src/app/composer/qgscompositionwidget.h
@@ -59,6 +59,7 @@ class QgsCompositionWidget: public QWidget, private Ui::QgsCompositionWidgetBase
     void on_mOffsetYSpinBox_valueChanged( double d );
     void on_mGridColorButton_colorChanged( const QColor &newColor );
     void on_mGridStyleComboBox_currentIndexChanged( const QString& text );
+    void on_mGridToleranceSpinBox_valueChanged( double d );
     void on_mSelectionToleranceSpinBox_valueChanged( double d );
     void on_mAlignmentSnapGroupCheckBox_toggled( bool state );
     void on_mAlignmentToleranceSpinBox_valueChanged( double d );

--- a/src/app/composer/qgscompositionwidget.h
+++ b/src/app/composer/qgscompositionwidget.h
@@ -59,7 +59,6 @@ class QgsCompositionWidget: public QWidget, private Ui::QgsCompositionWidgetBase
     void on_mOffsetYSpinBox_valueChanged( double d );
     void on_mGridColorButton_colorChanged( const QColor &newColor );
     void on_mGridStyleComboBox_currentIndexChanged( const QString& text );
-    void on_mPenWidthSpinBox_valueChanged( double d );
     void on_mSelectionToleranceSpinBox_valueChanged( double d );
     void on_mAlignmentSnapGroupCheckBox_toggled( bool state );
     void on_mAlignmentToleranceSpinBox_valueChanged( double d );

--- a/src/core/composer/qgscomposition.cpp
+++ b/src/core/composer/qgscomposition.cpp
@@ -1491,6 +1491,8 @@ void QgsComposition::setSnapGridOffsetY( double offset )
 void QgsComposition::setGridPen( const QPen& p )
 {
   mGridPen = p;
+  //make sure grid is drawn using a zero-width cosmetic pen
+  mGridPen.setWidthF( 0 );
   updatePaperItems();
   saveSettings();
 }
@@ -1515,16 +1517,14 @@ void QgsComposition::loadSettings()
 
   QString gridStyleString;
   int red, green, blue;
-  double penWidth;
 
   gridStyleString = s.value( "/qgis/composerGridStyle", "Dots" ).toString();
-  penWidth = s.value( "/qgis/composerGridWidth", 0.5 ).toDouble();
   red = s.value( "/qgis/composerGridRed", 0 ).toInt();
   green = s.value( "/qgis/composerGridGreen", 0 ).toInt();
   blue = s.value( "/qgis/composerGridBlue", 0 ).toInt();
 
   mGridPen.setColor( QColor( red, green, blue ) );
-  mGridPen.setWidthF( penWidth );
+  mGridPen.setWidthF( 0 );
 
   if ( gridStyleString == "Dots" )
   {
@@ -1546,7 +1546,6 @@ void QgsComposition::saveSettings()
 {
   //store grid appearance settings
   QSettings s;
-  s.setValue( "/qgis/composerGridWidth", mGridPen.widthF() );
   s.setValue( "/qgis/composerGridRed", mGridPen.color().red() );
   s.setValue( "/qgis/composerGridGreen", mGridPen.color().green() );
   s.setValue( "/qgis/composerGridBlue", mGridPen.color().blue() );

--- a/src/core/composer/qgscomposition.h
+++ b/src/core/composer/qgscomposition.h
@@ -107,6 +107,9 @@ class CORE_EXPORT QgsComposition : public QGraphicsScene
     void setSnapGridResolution( double r );
     double snapGridResolution() const {return mSnapGridResolution;}
 
+    void setSnapGridTolerance( double tolerance );
+    double snapGridTolerance() const {return mSnapGridTolerance;}
+
     void setSnapGridOffsetX( double offset );
     double snapGridOffsetX() const {return mSnapGridOffsetX;}
 
@@ -407,6 +410,7 @@ class CORE_EXPORT QgsComposition : public QGraphicsScene
     /**Parameters for snap to grid function*/
     bool mSnapToGrid;
     double mSnapGridResolution;
+    double mSnapGridTolerance;
     double mSnapGridOffsetX;
     double mSnapGridOffsetY;
     QPen mGridPen;

--- a/src/ui/qgscompositionwidgetbase.ui
+++ b/src/ui/qgscompositionwidgetbase.ui
@@ -23,7 +23,16 @@
    <property name="spacing">
     <number>0</number>
    </property>
-   <property name="margin">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
     <number>0</number>
    </property>
    <item>
@@ -361,26 +370,6 @@
            </layout>
           </item>
           <item row="2" column="0">
-           <widget class="QLabel" name="label_5">
-            <property name="text">
-             <string>Pen width</string>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QDoubleSpinBox" name="mPenWidthSpinBox">
-            <property name="prefix">
-             <string/>
-            </property>
-            <property name="suffix">
-             <string> mm</string>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="0">
            <widget class="QLabel" name="mGridStyleLabel">
             <property name="text">
              <string>Grid style</string>
@@ -393,10 +382,17 @@
             </property>
            </widget>
           </item>
-          <item row="3" column="1">
+          <item row="2" column="1">
            <widget class="QComboBox" name="mGridStyleComboBox"/>
           </item>
-          <item row="5" column="0">
+          <item row="3" column="1">
+           <widget class="QgsColorButton" name="mGridColorButton">
+            <property name="text">
+             <string>Color...</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
            <widget class="QLabel" name="label_4">
             <property name="text">
              <string>Selection tolerance</string>
@@ -406,20 +402,13 @@
             </property>
            </widget>
           </item>
-          <item row="5" column="1">
+          <item row="4" column="1">
            <widget class="QDoubleSpinBox" name="mSelectionToleranceSpinBox">
             <property name="prefix">
              <string/>
             </property>
             <property name="suffix">
              <string> mm</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="1">
-           <widget class="QgsColorButton" name="mGridColorButton">
-            <property name="text">
-             <string>Color...</string>
             </property>
            </widget>
           </item>

--- a/src/ui/qgscompositionwidgetbase.ui
+++ b/src/ui/qgscompositionwidgetbase.ui
@@ -286,6 +286,38 @@
         </widget>
        </item>
        <item>
+        <widget class="QgsCollapsibleGroupBoxBasic" name="generalSettingsGroupBox">
+         <property name="title">
+          <string>General settings</string>
+         </property>
+         <property name="collapsed" stdset="0">
+          <bool>false</bool>
+         </property>
+         <layout class="QFormLayout" name="formLayout_2">
+          <property name="fieldGrowthPolicy">
+           <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+          </property>
+          <property name="labelAlignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+          </property>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_5">
+            <property name="text">
+             <string>Selection tolerance</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QDoubleSpinBox" name="mSelectionToleranceSpinBox">
+            <property name="suffix">
+             <string> mm</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
         <widget class="QgsCollapsibleGroupBoxBasic" name="mSnapToGridGroupCheckBox">
          <property name="title">
           <string>Snap to grid</string>
@@ -395,7 +427,7 @@
           <item row="4" column="0">
            <widget class="QLabel" name="label_4">
             <property name="text">
-             <string>Selection tolerance</string>
+             <string>Tolerance</string>
             </property>
             <property name="wordWrap">
              <bool>true</bool>
@@ -403,12 +435,15 @@
            </widget>
           </item>
           <item row="4" column="1">
-           <widget class="QDoubleSpinBox" name="mSelectionToleranceSpinBox">
+           <widget class="QDoubleSpinBox" name="mGridToleranceSpinBox">
             <property name="prefix">
              <string/>
             </property>
             <property name="suffix">
              <string> mm</string>
+            </property>
+            <property name="value">
+             <double>2.000000000000000</double>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
Improve visual appearance of composer snap grid by making sure it is always drawn using a 1 pixel width cosmetic pen
Remove options for composer pen width
Add new option for grid snap tolerance and move selection tolerance spin box out of grid options to clarify that it's not related to grid snapping (fixes 8214)
