### PR TITLE
QgsFeatureRequest::NoGeometry is optional for non-geometry-layers

### DIFF
--- a/src/core/qgsfeaturerequest.h
+++ b/src/core/qgsfeaturerequest.h
@@ -59,7 +59,7 @@ class CORE_EXPORT QgsFeatureRequest
     enum Flag
     {
       NoFlags            = 0,
-      NoGeometry         = 1,  //!< Do not fetch geometry
+      NoGeometry         = 1,  //!< Geometry is not required. It may still be returned if e.g. required for a filter condition.
       SubsetOfAttributes = 2,  //!< Fetch only a subset of attributes (setSubsetOfAttributes sets this flag)
       ExactIntersect     = 4   //!< Use exact geometry intersection (slower) instead of bounding boxes
     };
@@ -68,7 +68,7 @@ class CORE_EXPORT QgsFeatureRequest
     enum FilterType
     {
       FilterNone,       //!< No filter is applied
-      FilterRect,       //!< Filter using a rectangle
+      FilterRect,       //!< Filter using a rectangle, no need to set NoGeometry
       FilterFid,        //!< Filter using feature ID
       FilterExpression, //!< Filter using expression
       FilterFids        //!< Filter using feature ID's
@@ -117,8 +117,8 @@ class CORE_EXPORT QgsFeatureRequest
 
     //! Set a subset of attributes by names that will be fetched
     QgsFeatureRequest& setSubsetOfAttributes( const QStringList& attrNames, const QgsFields& fields );
-    
-    /** 
+
+    /**
      * Check if a feature is accepted by this requests filter
      *
      * @param feature  The feature which will be tested

--- a/src/providers/mssql/qgsmssqlfeatureiterator.cpp
+++ b/src/providers/mssql/qgsmssqlfeatureiterator.cpp
@@ -122,7 +122,7 @@ void QgsMssqlFeatureIterator::BuildStatement( const QgsFeatureRequest& request )
     ++fieldCount;
   }
   // get geometry col
-  if ( request.flags() != QgsFeatureRequest::NoGeometry && !mProvider->mGeometryColName.isEmpty() )
+  if ( !( request.flags() & QgsFeatureRequest::NoGeometry ) && !mProvider->mGeometryColName.isEmpty() )
   {
     if ( fieldCount != 0 )
       mStatement += ",";

--- a/src/providers/ogr/qgsogrfeatureiterator.cpp
+++ b/src/providers/ogr/qgsogrfeatureiterator.cpp
@@ -89,9 +89,9 @@ QgsOgrFeatureIterator::~QgsOgrFeatureIterator()
 
 void QgsOgrFeatureIterator::ensureRelevantFields()
 {
-  bool needGeom = ( mRequest.filterType() == QgsFeatureRequest::FilterRect ) || !( mRequest.flags() & QgsFeatureRequest::NoGeometry );
+  mFetchGeometry = ( mRequest.filterType() == QgsFeatureRequest::FilterRect ) || !( mRequest.flags() & QgsFeatureRequest::NoGeometry );
   QgsAttributeList attrs = ( mRequest.flags() & QgsFeatureRequest::SubsetOfAttributes ) ? mRequest.subsetOfAttributes() : P->attributeIndexes();
-  P->setRelevantFields( needGeom, attrs );
+  P->setRelevantFields( mFetchGeometry, attrs );
   P->mRelevantFieldsForNextFeature = true;
 }
 
@@ -225,10 +225,9 @@ bool QgsOgrFeatureIterator::readFeature( OGRFeatureH fet, QgsFeature& feature )
   feature.initAttributes( P->fields().count() );
   feature.setFields( &P->mAttributeFields ); // allow name-based attribute lookups
 
-  bool fetchGeom    = !( mRequest.flags() & QgsFeatureRequest::NoGeometry );
   bool useIntersect = mRequest.flags() & QgsFeatureRequest::ExactIntersect;
   bool geometryTypeFilter = P->mOgrGeometryTypeFilter != wkbUnknown;
-  if ( fetchGeom || useIntersect || geometryTypeFilter )
+  if ( mFetchGeometry || useIntersect || geometryTypeFilter )
   {
     OGRGeometryH geom = OGR_F_GetGeometryRef( fet );
 
@@ -248,7 +247,7 @@ bool QgsOgrFeatureIterator::readFeature( OGRFeatureH fet, QgsFeature& feature )
     }
   }
 
-  if ( !fetchGeom )
+  if ( !mFetchGeometry )
   {
     feature.setGeometry( 0 );
   }

--- a/src/providers/ogr/qgsogrfeatureiterator.h
+++ b/src/providers/ogr/qgsogrfeatureiterator.h
@@ -53,6 +53,9 @@ class QgsOgrFeatureIterator : public QgsAbstractFeatureIterator
     OGRLayerH ogrLayer;
 
     bool mSubsetStringSet;
+
+    //! Set to true, if geometry is in the requested columns
+    bool mFetchGeometry;
 };
 
 

--- a/src/providers/postgres/qgspostgresfeatureiterator.h
+++ b/src/providers/postgres/qgspostgresfeatureiterator.h
@@ -58,8 +58,11 @@ class QgsPostgresFeatureIterator : public QgsAbstractFeatureIterator
     //! Maximal size of the feature queue
     int mFeatureQueueSize;
 
-    //!< Number of retrieved features
+    //! Number of retrieved features
     int mFetched;
+
+    //! Set to true, if geometry is in the requested columns
+    bool mFetchGeometry;
 
     static const int sFeatureQueueSize;
 

--- a/src/providers/spatialite/qgsspatialitefeatureiterator.h
+++ b/src/providers/spatialite/qgsspatialitefeatureiterator.h
@@ -63,6 +63,9 @@ class QgsSpatiaLiteFeatureIterator : public QgsAbstractFeatureIterator
     /** geometry column index used when fetching geometry */
     int mGeomColIdx;
 
+    //! Set to true, if geometry is in the requested columns
+    bool mFetchGeometry;
+
 };
 
 #endif // QGSSPATIALITEFEATUREITERATOR_H

--- a/src/providers/sqlanywhere/qgssqlanywherefeatureiterator.h
+++ b/src/providers/sqlanywhere/qgssqlanywherefeatureiterator.h
@@ -61,6 +61,9 @@ class QgsSqlAnywhereFeatureIterator : public QgsAbstractFeatureIterator
 
     QgsRectangle mStmtRect;
 
+    //! Set to true, if geometry is in the requested columns
+    bool mFetchGeometry;
+
 };
 
 #endif // QGSSQLANYWHEREFEATUREITERATOR_H


### PR DESCRIPTION
With this patch applied, a default constructed `QgsFeatureRequest` will return all features, regardless if the layer has geometry or not.
Up to now, a feature-iterator acquired with the default request would not return any features. The request had to include the `QgsFeatureRequest::NoGeometry` flag.

The explicit meaning of the `QgsFeatureRequest::NoGeometry` flag is now:
The geometry is not required to satisfy the request. It may still be returned if e.g. required for a filter condition.
