### PR TITLE
add the -r parameter to r.external (used now to create grass inputs for ...

### DIFF
--- a/python/plugins/processing/grass/GrassAlgorithm.py
+++ b/python/plugins/processing/grass/GrassAlgorithm.py
@@ -483,7 +483,7 @@ class GrassAlgorithm(GeoAlgorithm):
         command += ' input="' + layer + '"'
         command += ' band=1'
         command += ' output=' + destFilename
-        command += ' --overwrite -o'
+        command += ' --overwrite -o -r'
         return command
 
     def getTempFilename(self):

--- a/python/plugins/processing/grass/GrassAlgorithm.py
+++ b/python/plugins/processing/grass/GrassAlgorithm.py
@@ -381,7 +381,7 @@ class GrassAlgorithm(GeoAlgorithm):
 
             if isinstance(out, OutputVector):
                 filename = out.value
-                command = 'v.out.ogr -c -e input=' + out.name + uniqueSufix
+                command = 'v.out.ogr -c -e -z input=' + out.name + uniqueSufix
                 command += ' dsn="' + os.path.dirname(out.value) + '"'
                 command += ' format=ESRI_Shapefile'
                 command += ' olayer=' + os.path.basename(out.value)[:-4]

--- a/python/plugins/processing/grass/description/v.surf.bspline.lambda.txt
+++ b/python/plugins/processing/grass/description/v.surf.bspline.lambda.txt
@@ -1,11 +1,12 @@
 v.surf.bspline
-v.surf.bspline - Bicubic or bilinear spline interpolation with Tykhonov regularization.
+v.surf.bspline.lambda - Bicubic or bilinear spline interpolation with Tykhonov regularization.
 Vector (v.*)
 ParameterVector|input|Input points layer|-1|False
 ParameterNumber|sie|Length of each spline step in the east-west direction|None|None|4
 ParameterNumber|sin|Length of each spline step in the north-south direction|None|None|4
 ParameterSelection|method|Spline interpolation algorithm|bilinear;bicubic
-ParameterNumber|lambda_i|Tykhonov regularization parameter (affects smoothing)|None|None|0.01
 ParameterTableField|column|Attribute table column with values to interpolate|input|-1|False
+ParameterBoolean|-c|Find the best Tykhonov regularizing parameter using a "leave-one-out" cross validation method|True
+ParameterBoolean|-e|Estimate point density and distance|False
 ParameterSelection|layer|layer|1;0
-OutputRaster|raster|Output raster layer
+OutputHTML|html|Lambda or Point Density and Distance

--- a/python/plugins/processing/grass/description/v.surf.bspline.sparse.txt
+++ b/python/plugins/processing/grass/description/v.surf.bspline.sparse.txt
@@ -1,7 +1,8 @@
 v.surf.bspline
-v.surf.bspline - Bicubic or bilinear spline interpolation with Tykhonov regularization.
+v.surf.bspline.sparse - Bicubic or bilinear spline interpolation with Tykhonov regularization.
 Vector (v.*)
 ParameterVector|input|Input points layer|-1|False
+ParameterVector|sparse|Input layer of sparse points|-1|False
 ParameterNumber|sie|Length of each spline step in the east-west direction|None|None|4
 ParameterNumber|sin|Length of each spline step in the north-south direction|None|None|4
 ParameterSelection|method|Spline interpolation algorithm|bilinear;bicubic


### PR DESCRIPTION
...processing, replacing r.in.gdal) and so fixes grass modules like r.reclass.area and probably many others. New take on v.surf.bspline in processing toolbox, Fixes #5943.
