### PR TITLE
#8725 (Fast rendering) and #8733 (Better formating scales) and fix #8776

### DIFF
--- a/python/core/symbology-ng/qgssymbollayerv2.sip
+++ b/python/core/symbology-ng/qgssymbollayerv2.sip
@@ -202,5 +202,5 @@ class QgsFillSymbolLayerV2 : QgsSymbolLayerV2
   protected:
     QgsFillSymbolLayerV2( bool locked = false );
     /**Default method to render polygon*/
-    void _renderPolygon( QPainter* p, const QPolygonF& points, const QList<QPolygonF>* rings );
+    void _renderPolygon( QPainter* p, const QPolygonF& points, const QList<QPolygonF>* rings, QgsSymbolV2RenderContext& context );
 };

--- a/python/core/symbology-ng/qgssymbolv2.sip
+++ b/python/core/symbology-ng/qgssymbolv2.sip
@@ -214,7 +214,7 @@ class QgsLineSymbolV2 : QgsSymbolV2
     void setWidth( double width );
     double width();
 
-    void renderPolyline( const QPolygonF& points, const QgsFeature* f, QgsRenderContext& context, int layer = -1, bool selected = false );
+    void renderPolyline( const QPolygonF& points, const QgsFeature* f, QgsRenderContext& context, int layer = -1, bool selected = false, bool generalizedByBoundingBox = false );
 
     virtual QgsSymbolV2* clone() const /Factory/;
 };
@@ -237,7 +237,7 @@ class QgsFillSymbolV2 : QgsSymbolV2
     QgsFillSymbolV2( QgsSymbolLayerV2List layers /Transfer/ = QgsSymbolLayerV2List() );
 
     void setAngle( double angle );
-    void renderPolygon( const QPolygonF& points, QList<QPolygonF>* rings, const QgsFeature* f, QgsRenderContext& context, int layer = -1, bool selected = false );
+    void renderPolygon( const QPolygonF& points, QList<QPolygonF>* rings, const QgsFeature* f, QgsRenderContext& context, int layer = -1, bool selected = false, bool generalizedByBoundingBox = false );
 
     virtual QgsSymbolV2* clone() const /Factory/;
 };

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -591,6 +591,7 @@ void QgsProjectProperties::apply()
   QgsProject::instance()->writeEntry( "Gui", "/CanvasColorRedPart", myColor.red() );
   QgsProject::instance()->writeEntry( "Gui", "/CanvasColorGreenPart", myColor.green() );
   QgsProject::instance()->writeEntry( "Gui", "/CanvasColorBluePart", myColor.blue() );
+  mMapCanvas->setCanvasColor( myColor );
 
   //save project scales
   QStringList myScales;
@@ -794,7 +795,6 @@ void QgsProjectProperties::apply()
   }
   QgsProject::instance()->writeEntry( "Macros", "/pythonCode", pythonMacros );
 
-  //todo XXX set canvas color
   emit refresh();
 }
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -23,6 +23,7 @@ SET(QGIS_CORE_SRCS
   symbology-ng/qgslinesymbollayerv2.cpp
   symbology-ng/qgsmarkersymbollayerv2.cpp
   symbology-ng/qgsfillsymbollayerv2.cpp
+  symbology-ng/qgsrendererv2geometrysimplifier.cpp
   symbology-ng/qgsrendererv2.cpp
   symbology-ng/qgsrendererv2registry.cpp
   symbology-ng/qgssinglesymbolrendererv2.cpp
@@ -106,6 +107,7 @@ SET(QGIS_CORE_SRCS
   qgsprovidermetadata.cpp
   qgsproviderregistry.cpp
   qgspythonrunner.cpp
+  qgsrenderstats.cpp
   qgsrendercontext.cpp
   qgsrenderchecker.cpp
   qgsrectangle.cpp

--- a/src/core/qgsmaprenderer.cpp
+++ b/src/core/qgsmaprenderer.cpp
@@ -269,11 +269,16 @@ void QgsMapRenderer::render( QPainter* painter, double* forceWidthScale )
   renderTime.start();
 #endif
 
+  #ifdef QGISDEBUG_STATS
+  mRenderContext.stats.start(); // Starts the statistics of the rendering operation.
+  #endif
+
   if ( mOverview )
     mRenderContext.setDrawEditingInformation( !mOverview );
 
   mRenderContext.setPainter( painter );
   mRenderContext.setCoordinateTransform( 0 );
+  mRenderContext.setDestinationCrs( 0 );
   //this flag is only for stopping during the current rendering progress,
   //so must be false at every new render operation
   mRenderContext.setRenderingStopped( false );
@@ -428,6 +433,9 @@ void QgsMapRenderer::render( QPainter* painter, double* forceWidthScale )
 
       mRenderContext.setCoordinateTransform( ct );
 
+	  // Sets the destination spatial reference system of the projection.
+	  mRenderContext.setDestinationCrs( mDestCRS );
+
       //decide if we have to scale the raster
       //this is necessary in case QGraphicsScene is used
       bool scaleRaster = false;
@@ -558,6 +566,10 @@ void QgsMapRenderer::render( QPainter* painter, double* forceWidthScale )
         QgsDebugMsg( "Layer rendered without issues" );
       }
 
+	  #ifdef QGISDEBUG_STATS
+	  mRenderContext.stats.LayerCount++; // Update counters of the rendering operation.
+	  #endif
+
       if ( split )
       {
         mRenderContext.setExtent( r2 );
@@ -665,6 +677,9 @@ void QgsMapRenderer::render( QPainter* painter, double* forceWidthScale )
 
           mRenderContext.setCoordinateTransform( ct );
 
+		  // Sets the destination spatial reference system of the projection.
+		  mRenderContext.setDestinationCrs( mDestCRS );
+
           ml->drawLabels( mRenderContext );
           if ( split )
           {
@@ -684,12 +699,17 @@ void QgsMapRenderer::render( QPainter* painter, double* forceWidthScale )
     // set correct extent
     mRenderContext.setExtent( mExtent );
     mRenderContext.setCoordinateTransform( NULL );
+	mRenderContext.setDestinationCrs( NULL );
 
     mLabelingEngine->drawLabeling( mRenderContext );
     mLabelingEngine->exit();
   }
 
   QgsDebugMsg( "Rendering completed in (seconds): " + QString( "%1" ).arg( renderTime.elapsed() / 1000.0 ) );
+
+  #ifdef QGISDEBUG_STATS
+  mRenderContext.stats.stopAndFlush("C:/temp/test_data_qgis_master_RenderingStatsQGIS.log"); // Stop and flush the statistics of the rendering operation.
+  #endif
 
   mDrawing = false;
 }

--- a/src/core/qgsrendercontext.cpp
+++ b/src/core/qgsrendercontext.cpp
@@ -21,6 +21,7 @@
 QgsRenderContext::QgsRenderContext()
     : mPainter( 0 ),
     mCoordTransform( 0 ),
+	mDestCRS( 0 ),
     mDrawEditingInformation( true ),
     mForceVectorOutput( false ),
     mUseAdvancedEffects( true ),

--- a/src/core/qgsrendercontext.h
+++ b/src/core/qgsrendercontext.h
@@ -24,6 +24,9 @@
 #include "qgsmaptopixel.h"
 #include "qgsrectangle.h"
 
+// Provides statistical information about of a rendering operation.
+#include "qgsrenderstats.h"
+
 class QPainter;
 
 class QgsLabelingEngineInterface;
@@ -95,6 +98,13 @@ class CORE_EXPORT QgsRenderContext
     //! Added in QGIS v2.0
     void setSelectionColor( const QColor& color ) { mSelectionColor = color; }
 
+	void setDestinationCrs( const QgsCoordinateReferenceSystem* crs ) { mDestCRS = crs; }
+	const QgsCoordinateReferenceSystem* destinationCrs() const { return mDestCRS; }
+
+	#ifdef QGISDEBUG_STATS
+	QgsRenderStats stats; // Provides statistical information about of a rendering operation.
+	#endif
+
   private:
 
     /**Painter for rendering operations*/
@@ -102,6 +112,9 @@ class CORE_EXPORT QgsRenderContext
 
     /**For transformation between coordinate systems. Can be 0 if on-the-fly reprojection is not used*/
     const QgsCoordinateTransform* mCoordTransform;
+
+	/**Destination spatial reference system of the projection*/
+    const QgsCoordinateReferenceSystem* mDestCRS;
 
     /**True if vertex markers for editing should be drawn*/
     bool mDrawEditingInformation;

--- a/src/core/qgsrenderstats.cpp
+++ b/src/core/qgsrenderstats.cpp
@@ -1,0 +1,65 @@
+/***************************************************************************
+    qgsrenderstats.cpp
+    ---------------------
+    begin                : October 2013
+    copyright            : (C) 2013 by Alvaro Huarte
+    email                : http://wiki.osgeo.org/wiki/Alvaro_Huarte
+
+***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsrenderstats.h"
+
+QgsRenderStats::QgsRenderStats() 
+	: LayerCount(0), GeneralizedFeatureCount(0), FeatureCount(0), GeneralizedPointCount(0), PointCount(0)
+{
+}
+
+/** Starts the statistics of the rendering operation */
+bool QgsRenderStats::start()
+{
+	LayerCount = 0;
+	GeneralizedFeatureCount = 0;
+	FeatureCount = 0;
+	GeneralizedPointCount = 0;
+	PointCount = 0;		
+
+	mRenderTime.start();
+	return true;
+}
+
+/** Stops and flush the statistics of the rendering operation */
+bool QgsRenderStats::stopAndFlush(const char* logFileName)
+{
+	int elapsedTime = mRenderTime.elapsed();
+
+	if (logFileName && strlen(logFileName))
+	{
+		FILE* fp = fopen(logFileName, "a");
+
+		char  messageText[255];
+		float featFactor = FeatureCount==0 ? 0 : (float)(100.0*(GeneralizedFeatureCount/(double)FeatureCount));
+		float geomFactor = PointCount==0   ? 0 : (float)(100.0*(GeneralizedPointCount  /(double)PointCount  ));
+
+		sprintf(messageText, "Rendering stats:\r\n");
+		fputs  (messageText, fp);
+		sprintf(messageText, "LayerCount=%li FeatureCount=[%li gn=(%li)] PointCount=[%I64d gn=(%I64d)]\r\n", LayerCount, FeatureCount, GeneralizedFeatureCount, PointCount, GeneralizedPointCount);
+		fputs  (messageText, fp);
+		sprintf(messageText, "GeneralizedFT=%.2f%s GeneralizedPT=%.2f%s\r\n", featFactor, "%", geomFactor, "%");
+		fputs  (messageText, fp);
+		sprintf(messageText, "Rendering completed in (seconds): %li\r\n\r\n\r\n", (int)(elapsedTime/1000.0));
+		fputs  (messageText, fp);
+
+		fclose(fp);
+		fp = NULL;
+
+		return true;
+	}
+	return false;
+}

--- a/src/core/qgsrenderstats.h
+++ b/src/core/qgsrenderstats.h
@@ -1,0 +1,63 @@
+/***************************************************************************
+    qgsrenderstats.h
+    ---------------------
+    begin                : October 2013
+    copyright            : (C) 2013 by Alvaro Huarte
+    email                : http://wiki.osgeo.org/wiki/Alvaro_Huarte
+
+***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSRENDERSTATS_H
+#define QGSRENDERSTATS_H
+
+#include <QtCore/qdatetime.h>
+
+//#ifdef QGISDEBUG
+//#define QGISDEBUG_STATS 1
+//#endif
+
+#ifdef QGISDEBUG_STATS
+
+/** \ingroup core
+ * Contains statistical information about of a rendering operation.
+ **/
+class QgsRenderStats
+{
+public:
+    QgsRenderStats();
+
+private:
+	QTime mRenderTime;
+
+public:
+    /** Number of layers drawed in the rendering operation */
+	int LayerCount;
+
+	/** Number of generalized features drawed in the rendering operation */
+	int GeneralizedFeatureCount;
+	/** Number of features drawed in the rendering operation */
+	int FeatureCount;
+
+	/** Number of generalized points drawed in the rendering operation */
+	__int64 GeneralizedPointCount;
+	/** Number of points drawed in the rendering operation */
+	__int64 PointCount;
+
+public:
+
+	/** Starts the statistics of the rendering operation */
+	bool start();
+
+	/** Stops and flush the statistics of the rendering operation */
+	bool stopAndFlush(const char* logFileName);
+};
+#endif
+
+#endif

--- a/src/core/symbology-ng/qgsfillsymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgsfillsymbollayerv2.cpp
@@ -182,7 +182,7 @@ void QgsSimpleFillSymbolLayerV2::renderPolygon( const QPolygonF& points, QList<Q
     p->translate( offset );
   }
 
-  _renderPolygon( p, points, rings );
+  _renderPolygon( p, points, rings, context );
 
   if ( !mOffset.isNull() )
   {
@@ -313,7 +313,7 @@ void QgsImageFillSymbolLayer::renderPolygon( const QPolygonF& points, QList<QPol
     //if ( ! selectionIsOpaque )
     //  selColor.setAlphaF( context.alpha() );
     p->setBrush( QBrush( selColor ) );
-    _renderPolygon( p, points, rings );
+    _renderPolygon( p, points, rings, context );
   }
 
   if ( qgsDoubleNear( mNextAngle, 0.0 ) )
@@ -328,7 +328,7 @@ void QgsImageFillSymbolLayer::renderPolygon( const QPolygonF& points, QList<QPol
     rotatedBrush.setTransform( t );
     p->setBrush( rotatedBrush );
   }
-  _renderPolygon( p, points, rings );
+  _renderPolygon( p, points, rings, context );
   if ( mOutline )
   {
     mOutline->renderPolyline( points, context.feature(), context.renderContext(), -1, selectFillBorder && context.selected() );

--- a/src/core/symbology-ng/qgslinesymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgslinesymbollayerv2.cpp
@@ -175,6 +175,15 @@ void QgsSimpleLineSymbolLayerV2::renderPolyline( const QPolygonF& points, QgsSym
     return;
   }
 
+  // Disable 'Antialiasing' if the geometry was generalized in the current RenderContext.
+  if ( context.generalizedByBoundingBox() && p->renderHints() & QPainter::Antialiasing )
+  {
+	p->setRenderHint(QPainter::Antialiasing, false);
+	p->drawPolyline( points );
+	p->setRenderHint(QPainter::Antialiasing);
+	return;
+  }
+
   double offset = 0.0;
   applyDataDefinedSymbology( context, mPen, mSelPen, offset );
 

--- a/src/core/symbology-ng/qgsrendererv2.h
+++ b/src/core/symbology-ng/qgsrendererv2.h
@@ -194,6 +194,9 @@ class CORE_EXPORT QgsFeatureRendererV2
     static const unsigned char* _getLineString( QPolygonF& pts, QgsRenderContext& context, const unsigned char* wkb );
     static const unsigned char* _getPolygon( QPolygonF& pts, QList<QPolygonF>& holes, QgsRenderContext& context, const unsigned char* wkb );
 
+    static const unsigned char* _getLineString( QPolygonF& pts, QgsRenderContext& context, const unsigned char* wkb, bool& generalizedByBoundingBox );
+    static const unsigned char* _getPolygon( QPolygonF& pts, QList<QPolygonF>& holes, QgsRenderContext& context, const unsigned char* wkb, bool& generalizedByBoundingBox );
+
     void setScaleMethodToSymbol( QgsSymbolV2* symbol, int scaleMethod );
 
     QString mType;

--- a/src/core/symbology-ng/qgsrendererv2geometrysimplifier.cpp
+++ b/src/core/symbology-ng/qgsrendererv2geometrysimplifier.cpp
@@ -1,0 +1,220 @@
+/***************************************************************************
+    qgsrendererv2geometrysimplifier.cpp
+    ---------------------
+    begin                : October 2013
+    copyright            : (C) 2013 by Alvaro Huarte
+    email                : http://wiki.osgeo.org/wiki/Alvaro_Huarte
+
+***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsrendererv2geometrysimplifier.h"
+#include "QtCore/qrect.h"
+
+/** Threshold of the map2pixel value in the current RenderContext */
+#define MAP2PIXEL_THRESHOLD_FACTOR 1.3
+
+
+/** Returns the squared 2D-distance of the vector defined by the two points specified */
+float QgsFeatureRendererSimplifier::LengthGeneralizedSquared2D(double x1, double y1, double x2, double y2)
+{
+	float vx = (float)(x2-x1);
+	float vy = (float)(y2-y1);
+
+	return vx*vx + vy*vy;
+}
+
+/** Returns the MapTolerance of the current View for transforms between map coordinates and device coordinates */
+float QgsFeatureRendererSimplifier::CalculateViewPixelTolerance(QgsRenderContext& context, QRectF& boundingRect)
+{
+	const QgsMapToPixel& mtp = context.mapToPixel();
+	const QgsCoordinateTransform* ct = context.coordinateTransform();
+
+	double mapUnitsPerPixel = mtp.mapUnitsPerPixel();
+	double mapUnitsFactor = 1;
+
+	// Calculate one aprox factor of the size of the BBOX from the source CoordinateSystem to the target CoordinateSystem.
+	if (ct && !((QgsCoordinateTransform*)ct)->isShortCircuited())
+	{
+		QgsRectangle sourceRect(boundingRect.left(), boundingRect.bottom(), boundingRect.right(), boundingRect.top());
+		QgsRectangle targetRect = ct->transform(sourceRect);
+
+		QgsPoint minimumSrcPoint( sourceRect.xMinimum(), sourceRect.yMinimum() );
+		QgsPoint maximumSrcPoint( sourceRect.xMaximum(), sourceRect.yMaximum() );
+		QgsPoint minimumDstPoint( targetRect.xMinimum(), targetRect.yMinimum() );
+		QgsPoint maximumDstPoint( targetRect.xMaximum(), targetRect.yMaximum() );
+
+		double sourceHypothenuse = sqrt( LengthGeneralizedSquared2D( minimumSrcPoint.x(), minimumSrcPoint.y(), maximumSrcPoint.x(), maximumSrcPoint.y() ) );
+		double targetHypothenuse = sqrt( LengthGeneralizedSquared2D( minimumDstPoint.x(), minimumDstPoint.y(), maximumDstPoint.x(), maximumDstPoint.y() ) );
+
+		if (targetHypothenuse!=0) 
+		mapUnitsFactor = sourceHypothenuse/targetHypothenuse;
+	}
+	return (float)( MAP2PIXEL_THRESHOLD_FACTOR * mapUnitsPerPixel * mapUnitsFactor );
+}
+
+/** Returns the view-valid number of points of the specified geometry */
+unsigned int QgsFeatureRendererSimplifier::CalculateGeneralizedPointCount(QgsRenderContext& context, QGis::WkbType wkbType, const unsigned char* wkb, unsigned int numPoints, QRectF& boundingRect, bool& generalizedByBoundingBox)
+{
+	const unsigned char* wkb2 = wkb;
+
+	double xmin = DBL_MAX, ymin = DBL_MAX, xmax = -DBL_MAX, ymax = -DBL_MAX;
+	double x,y, lastX=0,lastY=0;
+
+	int sizeOfDoubleX = sizeof(double);
+	int sizeOfDoubleY = QGis::wkbDimensions(wkbType)==3 /*hasZValue*/ ? 2*sizeof(double) : sizeof(double);
+
+	// Calculate the full BoundingBox of the current point stream.
+	for ( unsigned int jdx = 0; jdx < numPoints; ++jdx )
+	{
+		x = *(( double * ) wkb ); wkb += sizeOfDoubleX;
+		y = *(( double * ) wkb ); wkb += sizeOfDoubleY;
+
+		if (xmin>x) xmin = x;
+		if (ymin>y) ymin = y;
+		if (xmax<x) xmax = x;
+		if (ymax<y) ymax = y;
+	}
+	boundingRect.setCoords(xmin,ymin,xmax,ymax);
+	wkb = wkb2;
+
+	// MapTolerance of the current View for transforms between map coordinates and device coordinates.
+	float mappixelTol = QgsFeatureRendererSimplifier::CalculateViewPixelTolerance( context, boundingRect );
+
+	// Can simplify the geometry using the full BBOX ¿?
+	if ((generalizedByBoundingBox = ((xmax-xmin)<=mappixelTol && (ymax-ymin)<=mappixelTol)))
+	{
+		return QGis::flatType(wkbType)==QGis::WKBLineString ? 2 : 5;
+	}
+
+	unsigned int simplifiedPointCount = 0;
+	mappixelTol *= mappixelTol; //-> Use mappixelTol for 'LengthSquare' calculations.
+
+	// Force equal the first and last point of the closed geometry.
+	if (QGis::flatType(wkbType)==QGis::WKBPolygon)
+	{
+		simplifiedPointCount++;
+		numPoints--;
+	}
+
+	// Calculate the view-valid number of points of the specified geometry.
+	for ( unsigned int jdx = 0; jdx < numPoints; ++jdx )
+	{
+		x = *(( double * ) wkb ); wkb += sizeOfDoubleX;
+		y = *(( double * ) wkb ); wkb += sizeOfDoubleY;
+
+		if (jdx==0 || LengthGeneralizedSquared2D(lastX,lastY,x,y)>mappixelTol)
+		{
+			simplifiedPointCount++;
+			lastX = x;
+			lastY = y;
+		}
+	}
+	wkb = wkb2;
+
+	// Returns the view-valid PointCount.
+	if (QGis::flatType(wkbType)==QGis::WKBLineString && simplifiedPointCount<=1)
+	{
+		generalizedByBoundingBox = true;
+		simplifiedPointCount = 2;
+	}
+	else
+	if (QGis::flatType(wkbType)==QGis::WKBPolygon && simplifiedPointCount<=3)
+	{
+		generalizedByBoundingBox = true;
+		simplifiedPointCount = 5;
+	}
+	return simplifiedPointCount;
+}
+
+/** Fill the view-valid simplified points to the specified geometry */
+unsigned int QgsFeatureRendererSimplifier::SimplifyGeometry(QgsRenderContext& context, QGis::WkbType wkbType, const unsigned char* wkb, unsigned int numPoints, QVector<QPointF>& outputPoints, bool& generalizedByBoundingBox)
+{
+	QGis::WkbType flatType = QGis::flatType(wkbType);
+
+	int sizeOfDoubleX = sizeof(double);
+	int sizeOfDoubleY = QGis::wkbDimensions(wkbType)==3 /*hasZValue*/ ? 2*sizeof(double) : sizeof(double);
+
+	generalizedByBoundingBox = false;
+	double x,y;
+
+	// Fill if possible, the view-valid simplified points to the specified geometry.
+	if (numPoints>2 && flatType!=QGis::WKBPoint && flatType!=QGis::WKBMultiPoint)
+	{
+		double lastX=0,lastY=0;
+
+		// Calculate the view-valid number of points of the geometry.
+		QRectF boundingRect;
+		unsigned int simplifiedPointCount = CalculateGeneralizedPointCount(context, wkbType, wkb, numPoints, boundingRect, generalizedByBoundingBox);
+
+		outputPoints.resize(simplifiedPointCount);
+		QPointF* ptr = outputPoints.data();
+
+		// Can simplify the geometry using the full BBOX ¿?
+		if (generalizedByBoundingBox)
+		{
+			if (flatType==QGis::WKBLineString)
+			{
+			   *ptr = boundingRect.topLeft(); ptr++;
+			   *ptr = boundingRect.bottomRight();
+			}
+			else
+			if (flatType==QGis::WKBPolygon)
+			{
+			   *ptr = boundingRect.topLeft(); ptr++;
+			   *ptr = boundingRect.topRight(); ptr++;
+			   *ptr = boundingRect.bottomRight(); ptr++;
+			   *ptr = boundingRect.bottomLeft(); ptr++;
+			   *ptr = boundingRect.topLeft();
+			}
+			return simplifiedPointCount;
+		}
+
+		// MapTolerance of the current View for transforms between map coordinates and device coordinates.
+		float mappixelTol = QgsFeatureRendererSimplifier::CalculateViewPixelTolerance( context, boundingRect );
+		mappixelTol *= mappixelTol; //-> Use mappixelTol for 'LengthSquare' calculations.
+
+		// Force equal the first and last point of the closed geometry.
+		bool isaPolygon = QGis::flatType(wkbType)==QGis::WKBPolygon;
+		if (isaPolygon) numPoints--;
+		
+		// Fill the view-valid points of the specified geometry.
+		for ( unsigned int jdx = 0; jdx < numPoints; ++jdx)
+		{
+			x = *(( double * ) wkb ); wkb += sizeOfDoubleX;
+			y = *(( double * ) wkb ); wkb += sizeOfDoubleY;
+
+			if (jdx==0 || LengthGeneralizedSquared2D(lastX,lastY,x,y)>mappixelTol)
+			{
+			   *ptr = QPointF(x, y); ++ptr;
+				lastX = x; 
+				lastY = y;
+			}
+		}
+		if (isaPolygon)
+		{
+			*ptr = *outputPoints.data();
+		}
+		return simplifiedPointCount;
+	}
+	else
+	{
+		outputPoints.resize(numPoints);
+		QPointF* ptr = outputPoints.data();
+
+		for ( unsigned int jdx = 0; jdx < numPoints; ++jdx, ++ptr )
+		{
+			x = *(( double * ) wkb ); wkb += sizeOfDoubleX;
+			y = *(( double * ) wkb ); wkb += sizeOfDoubleY;
+
+			*ptr = QPointF( x, y );
+		}
+		return numPoints;
+	}
+}

--- a/src/core/symbology-ng/qgsrendererv2geometrysimplifier.h
+++ b/src/core/symbology-ng/qgsrendererv2geometrysimplifier.h
@@ -1,0 +1,49 @@
+/***************************************************************************
+    qgsrendererv2geometrysimplifier.h
+    ---------------------
+    begin                : October 2013
+    copyright            : (C) 2013 by Alvaro Huarte
+    email                : http://wiki.osgeo.org/wiki/Alvaro_Huarte
+
+***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSRENDER_GEOMETRY_SIMPLIFIER_H
+#define QGSRENDER_GEOMETRY_SIMPLIFIER_H
+
+#include "qgsrendercontext.h"
+#include "qgsgeometry.h"
+#include "qgsfeature.h"
+
+/** \ingroup core
+ * Provides geometry simplification methods for optimize the drawing of features.
+ * This helper class calculate a simplified/generalized geometry from one source 
+ * feature using a tolerance of the current map2pixel value of the RenderContext.
+ * Output geometry is drawed with undetectable visual changes.
+ **/
+class CORE_EXPORT QgsFeatureRendererSimplifier
+{
+private:
+
+	/** Returns the squared 2D-distance of the vector defined by the two points specified */
+	static float LengthGeneralizedSquared2D(double x1, double y1, double x2, double y2);
+
+	/** Returns the MapTolerance of the current View for transforms between map coordinates and device coordinates */
+	static float CalculateViewPixelTolerance(QgsRenderContext& context, QRectF& boundingRect);
+
+	/** Returns the view-valid number of points of the specified geometry */
+	static unsigned int CalculateGeneralizedPointCount(QgsRenderContext& context, QGis::WkbType wkbType, const unsigned char* wkb, unsigned int numPoints, QRectF& boundingRect, bool& generalizedByBoundingBox);
+
+public:
+
+	/** Fill the view-valid simplified points to the specified geometry */
+	static unsigned int SimplifyGeometry(QgsRenderContext& context, QGis::WkbType wkbType, const unsigned char* wkb, unsigned int numPoints, QVector<QPointF>& outputPoints, bool& generalizedByBoundingBox);
+};
+
+#endif

--- a/src/core/symbology-ng/qgssymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgssymbollayerv2.cpp
@@ -324,11 +324,20 @@ void QgsFillSymbolLayerV2::drawPreviewIcon( QgsSymbolV2RenderContext& context, Q
   stopRender( context );
 }
 
-void QgsFillSymbolLayerV2::_renderPolygon( QPainter* p, const QPolygonF& points, const QList<QPolygonF>* rings )
+void QgsFillSymbolLayerV2::_renderPolygon( QPainter* p, const QPolygonF& points, const QList<QPolygonF>* rings, QgsSymbolV2RenderContext& context )
 {
   if ( !p )
   {
     return;
+  }
+
+  // Disable 'Antialiasing' if the geometry was generalized in the current RenderContext.
+  if ( context.generalizedByBoundingBox() && p->renderHints() & QPainter::Antialiasing )
+  {
+	p->setRenderHint(QPainter::Antialiasing, false);
+	p->drawPolygon( points );
+	p->setRenderHint(QPainter::Antialiasing);
+	return;
   }
 
   if ( rings == NULL )

--- a/src/core/symbology-ng/qgssymbollayerv2.h
+++ b/src/core/symbology-ng/qgssymbollayerv2.h
@@ -231,7 +231,7 @@ class CORE_EXPORT QgsFillSymbolLayerV2 : public QgsSymbolLayerV2
   protected:
     QgsFillSymbolLayerV2( bool locked = false );
     /**Default method to render polygon*/
-    void _renderPolygon( QPainter* p, const QPolygonF& points, const QList<QPolygonF>* rings );
+    void _renderPolygon( QPainter* p, const QPolygonF& points, const QList<QPolygonF>* rings, QgsSymbolV2RenderContext& context );
 
     double mAngle;
 };

--- a/src/core/symbology-ng/qgssymbolv2.cpp
+++ b/src/core/symbology-ng/qgssymbolv2.cpp
@@ -378,7 +378,15 @@ QSet<QString> QgsSymbolV2::usedAttributes() const
 QgsSymbolV2RenderContext::QgsSymbolV2RenderContext( QgsRenderContext& c, QgsSymbolV2::OutputUnit u, qreal alpha, bool selected, int renderHints, const QgsFeature* f )
     : mRenderContext( c ), mOutputUnit( u ), mAlpha( alpha ), mSelected( selected ), mRenderHints( renderHints ), mFeature( f ), mLayer( 0 )
 {
+	// Indicates that the feature was generalized in the current rendering context.
+	mGeneralizedByBoundingBox = false;
+}
 
+QgsSymbolV2RenderContext::QgsSymbolV2RenderContext( QgsRenderContext& c, QgsSymbolV2::OutputUnit u, qreal alpha, bool selected, bool generalizedByBoundingBox, int renderHints, const QgsFeature* f )
+    : mRenderContext( c ), mOutputUnit( u ), mAlpha( alpha ), mSelected( selected ), mRenderHints( renderHints ), mFeature( f ), mLayer( 0 )
+{
+	// Indicates that the feature was generalized in the current rendering context.
+	mGeneralizedByBoundingBox = generalizedByBoundingBox;
 }
 
 QgsSymbolV2RenderContext::~QgsSymbolV2RenderContext()
@@ -597,9 +605,9 @@ double QgsLineSymbolV2::width()
   return maxWidth;
 }
 
-void QgsLineSymbolV2::renderPolyline( const QPolygonF& points, const QgsFeature* f, QgsRenderContext& context, int layer, bool selected )
+void QgsLineSymbolV2::renderPolyline( const QPolygonF& points, const QgsFeature* f, QgsRenderContext& context, int layer, bool selected, bool generalizedByBoundingBox )
 {
-  QgsSymbolV2RenderContext symbolContext( context, outputUnit(), mAlpha, selected, mRenderHints, f );
+  QgsSymbolV2RenderContext symbolContext( context, outputUnit(), mAlpha, selected, generalizedByBoundingBox, mRenderHints, f );
   if ( layer != -1 )
   {
     if ( layer >= 0 && layer < mLayers.count() )
@@ -632,9 +640,9 @@ QgsFillSymbolV2::QgsFillSymbolV2( QgsSymbolLayerV2List layers )
     mLayers.append( new QgsSimpleFillSymbolLayerV2() );
 }
 
-void QgsFillSymbolV2::renderPolygon( const QPolygonF& points, QList<QPolygonF>* rings, const QgsFeature* f, QgsRenderContext& context, int layer, bool selected )
+void QgsFillSymbolV2::renderPolygon( const QPolygonF& points, QList<QPolygonF>* rings, const QgsFeature* f, QgsRenderContext& context, int layer, bool selected, bool generalizedByBoundingBox )
 {
-  QgsSymbolV2RenderContext symbolContext( context, outputUnit(), mAlpha, selected, mRenderHints, f );
+  QgsSymbolV2RenderContext symbolContext( context, outputUnit(), mAlpha, selected, generalizedByBoundingBox, mRenderHints, f );
   if ( layer != -1 )
   {
     if ( layer >= 0 && layer < mLayers.count() )

--- a/src/core/symbology-ng/qgssymbolv2.h
+++ b/src/core/symbology-ng/qgssymbolv2.h
@@ -153,6 +153,7 @@ class CORE_EXPORT QgsSymbolV2RenderContext
 {
   public:
     QgsSymbolV2RenderContext( QgsRenderContext& c, QgsSymbolV2::OutputUnit u , qreal alpha = 1.0, bool selected = false, int renderHints = 0, const QgsFeature* f = 0 );
+    QgsSymbolV2RenderContext( QgsRenderContext& c, QgsSymbolV2::OutputUnit u , qreal alpha, bool selected, bool generalizedByBoundingBox, int renderHints, const QgsFeature* f );
     ~QgsSymbolV2RenderContext();
 
     QgsRenderContext& renderContext() { return mRenderContext; }
@@ -169,6 +170,9 @@ class CORE_EXPORT QgsSymbolV2RenderContext
 
     bool selected() const { return mSelected; }
     void setSelected( bool selected ) { mSelected = selected; }
+
+    bool generalizedByBoundingBox() const { return mGeneralizedByBoundingBox; }
+    void setGeneralizedByBoundingBox( bool generalizedByBoundingBox ) { mGeneralizedByBoundingBox = generalizedByBoundingBox; }
 
     //! @note added in 1.5
     int renderHints() const { return mRenderHints; }
@@ -192,6 +196,7 @@ class CORE_EXPORT QgsSymbolV2RenderContext
     QgsSymbolV2::OutputUnit mOutputUnit;
     qreal mAlpha;
     bool mSelected;
+	bool mGeneralizedByBoundingBox; 
     int mRenderHints;
     const QgsFeature* mFeature; //current feature
     const QgsVectorLayer* mLayer; //current vectorlayer
@@ -244,7 +249,7 @@ class CORE_EXPORT QgsLineSymbolV2 : public QgsSymbolV2
     void setWidth( double width );
     double width();
 
-    void renderPolyline( const QPolygonF& points, const QgsFeature* f, QgsRenderContext& context, int layer = -1, bool selected = false );
+    void renderPolyline( const QPolygonF& points, const QgsFeature* f, QgsRenderContext& context, int layer = -1, bool selected = false, bool generalizedByBoundingBox = false );
 
     virtual QgsSymbolV2* clone() const;
 };
@@ -262,7 +267,7 @@ class CORE_EXPORT QgsFillSymbolV2 : public QgsSymbolV2
 
     QgsFillSymbolV2( QgsSymbolLayerV2List layers = QgsSymbolLayerV2List() );
     void setAngle( double angle );
-    void renderPolygon( const QPolygonF& points, QList<QPolygonF>* rings, const QgsFeature* f, QgsRenderContext& context, int layer = -1, bool selected = false );
+    void renderPolygon( const QPolygonF& points, QList<QPolygonF>* rings, const QgsFeature* f, QgsRenderContext& context, int layer = -1, bool selected = false, bool generalizedByBoundingBox = false );
 
     virtual QgsSymbolV2* clone() const;
 };

--- a/src/gui/qgsscalecombobox.cpp
+++ b/src/gui/qgsscalecombobox.cpp
@@ -63,6 +63,18 @@ void QgsScaleComboBox::updateScales( const QStringList &scales )
     }
   }
 
+  // Feature #8733: Better formatting for scales as "1.000.000" instead of "1000000"
+  QString locale = QLocale::system().toString( 1000 );
+  bool ok;
+  for ( int i = 0; i < myScalesList.size(); i++ )
+  {
+	  QStringList parts = myScalesList[i].split( ':' );
+	  QString tempTx = parts.at( 1 ); tempTx = tempTx.replace( locale[1], "" );
+
+	  double scale = QLocale::system().toDouble( tempTx, &ok );
+	  if (ok) myScalesList[i] = toString(1.0 / scale);
+  }
+
   blockSignals( true );
   clear();
   addItems( myScalesList );
@@ -82,12 +94,20 @@ void QgsScaleComboBox::showPopup()
   bool ok;
   int idx = 0;
   int min = 999999;
-  long currScale = parts.at( 1 ).toLong( &ok );
+
+  QString locale = QLocale::system().toString( 1000 );
+  QString tempTx = parts.at( 1 ); tempTx = tempTx.replace( locale[1], "" );
+  long currScale = tempTx.toLong( &ok );
   long nextScale, delta;
+
   for ( int i = 0; i < count(); i++ )
   {
     parts = itemText( i ).split( ':' );
-    nextScale = parts.at( 1 ).toLong( &ok );
+
+	tempTx = parts.at( 1 );
+	tempTx = tempTx.replace( locale[1], "" );
+	nextScale = tempTx.toLong( &ok );
+
     delta = qAbs( currScale - nextScale );
     if ( delta < min )
     {
@@ -180,11 +200,11 @@ QString QgsScaleComboBox::toString( double scale )
 {
   if ( scale > 1 )
   {
-    return QString( "%1:1" ).arg( qRound( scale ) );
+    return QString( "%1:1" ).arg( QLocale::system().toString( qRound( scale ) ));
   }
   else
   {
-    return QString( "1:%1" ).arg( qRound( 1.0 / scale ) );
+    return QString( "1:%1" ).arg( QLocale::system().toString( qRound( 1.0 / scale ) ));
   }
 }
 

--- a/src/providers/ogr/qgsogrfeatureiterator.cpp
+++ b/src/providers/ogr/qgsogrfeatureiterator.cpp
@@ -70,7 +70,13 @@ QgsOgrFeatureIterator::QgsOgrFeatureIterator( QgsOgrProvider* p, const QgsFeatur
 
     OGR_G_CreateFromWkt(( char ** )&wktText, NULL, &filter );
     QgsDebugMsg( "Setting spatial filter using " + wktExtent );
-    OGR_L_SetSpatialFilter( ogrLayer, filter );
+
+	// Checks whether is really needed filter by rect. 
+	OGREnvelope extent;
+	OGR_L_GetExtent(ogrLayer, &extent, true);
+	QgsRectangle layerRect(extent.MinX, extent.MinY, extent.MaxX, extent.MaxY);
+	if (!mRequest.filterRect().contains(layerRect)) OGR_L_SetSpatialFilter( ogrLayer, filter );
+
     OGR_G_DestroyGeometry( filter );
   }
   else


### PR DESCRIPTION
#8725: Fast rendering of LineStrings and Polygons pre-applying a view threshold filter to the geometries to render in qgis. View Table of test results in 'http://hub.qgis.org/issues/8725'
#8733: Better formating scales
#8776: Set the canvas color in 'qgsprojectproperties::apply()' before refresh
