### PR TITLE
Fix #8776 - project background color does not take effect until you pan

### DIFF
--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -608,6 +608,7 @@ void QgsProjectProperties::apply()
   QgsProject::instance()->writeEntry( "Gui", "/CanvasColorRedPart", myColor.red() );
   QgsProject::instance()->writeEntry( "Gui", "/CanvasColorGreenPart", myColor.green() );
   QgsProject::instance()->writeEntry( "Gui", "/CanvasColorBluePart", myColor.blue() );
+  mMapCanvas->setCanvasColor( myColor );
 
   //save project scales
   QStringList myScales;
@@ -813,7 +814,6 @@ void QgsProjectProperties::apply()
 
   QgsProject::instance()->relationManager()->setRelations( mRelationManagerDlg->relations() );
 
-  //todo XXX set canvas color
   emit refresh();
 }
 


### PR DESCRIPTION
Set the canvas color in 'qgsprojectproperties::apply()' before refresh
