### PR TITLE
Feature  #8725: Fast rendering of geometries

### DIFF
--- a/python/core/symbology-ng/qgssymbollayerv2.sip
+++ b/python/core/symbology-ng/qgssymbollayerv2.sip
@@ -202,5 +202,5 @@ class QgsFillSymbolLayerV2 : QgsSymbolLayerV2
   protected:
     QgsFillSymbolLayerV2( bool locked = false );
     /**Default method to render polygon*/
-    void _renderPolygon( QPainter* p, const QPolygonF& points, const QList<QPolygonF>* rings );
+    void _renderPolygon( QPainter* p, const QPolygonF& points, const QList<QPolygonF>* rings, QgsSymbolV2RenderContext& context );
 };

--- a/python/core/symbology-ng/qgssymbolv2.sip
+++ b/python/core/symbology-ng/qgssymbolv2.sip
@@ -214,7 +214,7 @@ class QgsLineSymbolV2 : QgsSymbolV2
     void setWidth( double width );
     double width();
 
-    void renderPolyline( const QPolygonF& points, const QgsFeature* f, QgsRenderContext& context, int layer = -1, bool selected = false );
+    void renderPolyline( const QPolygonF& points, const QgsFeature* f, QgsRenderContext& context, int layer = -1, bool selected = false, bool generalizedByBoundingBox = false );
 
     virtual QgsSymbolV2* clone() const /Factory/;
 };
@@ -237,7 +237,7 @@ class QgsFillSymbolV2 : QgsSymbolV2
     QgsFillSymbolV2( QgsSymbolLayerV2List layers /Transfer/ = QgsSymbolLayerV2List() );
 
     void setAngle( double angle );
-    void renderPolygon( const QPolygonF& points, QList<QPolygonF>* rings, const QgsFeature* f, QgsRenderContext& context, int layer = -1, bool selected = false );
+    void renderPolygon( const QPolygonF& points, QList<QPolygonF>* rings, const QgsFeature* f, QgsRenderContext& context, int layer = -1, bool selected = false, bool generalizedByBoundingBox = false );
 
     virtual QgsSymbolV2* clone() const /Factory/;
 };

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -23,6 +23,7 @@ SET(QGIS_CORE_SRCS
   symbology-ng/qgslinesymbollayerv2.cpp
   symbology-ng/qgsmarkersymbollayerv2.cpp
   symbology-ng/qgsfillsymbollayerv2.cpp
+  symbology-ng/qgsrendererv2geometrysimplifier.cpp
   symbology-ng/qgsrendererv2.cpp
   symbology-ng/qgsrendererv2registry.cpp
   symbology-ng/qgssinglesymbolrendererv2.cpp

--- a/src/core/qgsclipper.cpp
+++ b/src/core/qgsclipper.cpp
@@ -120,8 +120,8 @@ void QgsClipper::clippedLine( const QVector<QPointF>& points, const QgsRectangle
   {
     if ( i == 0 )
     {
-	  p1x = points[i].x();
-	  p1y = points[i].y();
+      p1x = points[i].x();
+      p1y = points[i].y();
 
       continue;
     }

--- a/src/core/qgsclipper.cpp
+++ b/src/core/qgsclipper.cpp
@@ -130,8 +130,8 @@ void QgsClipper::clippedLine( const QVector<QPointF>& points, const QgsRectangle
       p0x = p1x;
       p0y = p1y;
 
-	  p1x = points[i].x();
-	  p1y = points[i].y();
+      p1x = points[i].x();
+      p1y = points[i].y();
 
       p1x_c = p1x; p1y_c = p1y;
       if ( clipLineSegment( clipExtent.xMinimum(), clipExtent.xMaximum(), clipExtent.yMinimum(), clipExtent.yMaximum(),

--- a/src/core/qgsclipper.h
+++ b/src/core/qgsclipper.h
@@ -84,6 +84,12 @@ class CORE_EXPORT QgsClipper
       @param line out: clipped line coordinates*/
     static const unsigned char* clippedLineWKB( const unsigned char* wkb, const QgsRectangle& clipExtent, QPolygonF& line );
 
+    /**Clips a polyline to clipExtent
+      @param points of the input line
+      @param clipExtent clipping bounds
+      @param line out: clipped line coordinates*/
+    static void clippedLine( const QVector<QPointF>& points, const QgsRectangle& clipExtent, QPolygonF& line );
+
   private:
 
     // Used when testing for equivalance to 0.0

--- a/src/core/symbology-ng/qgsfillsymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgsfillsymbollayerv2.cpp
@@ -182,7 +182,7 @@ void QgsSimpleFillSymbolLayerV2::renderPolygon( const QPolygonF& points, QList<Q
     p->translate( offset );
   }
 
-  _renderPolygon( p, points, rings );
+  _renderPolygon( p, points, rings, context );
 
   if ( !mOffset.isNull() )
   {
@@ -313,7 +313,7 @@ void QgsImageFillSymbolLayer::renderPolygon( const QPolygonF& points, QList<QPol
     //if ( ! selectionIsOpaque )
     //  selColor.setAlphaF( context.alpha() );
     p->setBrush( QBrush( selColor ) );
-    _renderPolygon( p, points, rings );
+    _renderPolygon( p, points, rings, context );
   }
 
   if ( qgsDoubleNear( mNextAngle, 0.0 ) )
@@ -328,7 +328,7 @@ void QgsImageFillSymbolLayer::renderPolygon( const QPolygonF& points, QList<QPol
     rotatedBrush.setTransform( t );
     p->setBrush( rotatedBrush );
   }
-  _renderPolygon( p, points, rings );
+  _renderPolygon( p, points, rings, context );
   if ( mOutline )
   {
     mOutline->renderPolyline( points, context.feature(), context.renderContext(), -1, selectFillBorder && context.selected() );

--- a/src/core/symbology-ng/qgslinesymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgslinesymbollayerv2.cpp
@@ -178,10 +178,10 @@ void QgsSimpleLineSymbolLayerV2::renderPolyline( const QPolygonF& points, QgsSym
   // Disable 'Antialiasing' if the geometry was generalized in the current RenderContext.
   if ( context.generalizedByBoundingBox() && p->renderHints() & QPainter::Antialiasing )
   {
-	p->setRenderHint( QPainter::Antialiasing, false );
-	p->drawPolyline( points );
-	p->setRenderHint( QPainter::Antialiasing, true );
-	return;
+    p->setRenderHint( QPainter::Antialiasing, false );
+    p->drawPolyline( points );
+    p->setRenderHint( QPainter::Antialiasing, true );
+    return;
   }
 
   double offset = 0.0;

--- a/src/core/symbology-ng/qgslinesymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgslinesymbollayerv2.cpp
@@ -175,6 +175,15 @@ void QgsSimpleLineSymbolLayerV2::renderPolyline( const QPolygonF& points, QgsSym
     return;
   }
 
+  // Disable 'Antialiasing' if the geometry was generalized in the current RenderContext.
+  if ( context.generalizedByBoundingBox() && p->renderHints() & QPainter::Antialiasing )
+  {
+	p->setRenderHint(QPainter::Antialiasing, false);
+	p->drawPolyline( points );
+	p->setRenderHint(QPainter::Antialiasing);
+	return;
+  }
+
   double offset = 0.0;
   applyDataDefinedSymbology( context, mPen, mSelPen, offset );
 

--- a/src/core/symbology-ng/qgslinesymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgslinesymbollayerv2.cpp
@@ -178,9 +178,9 @@ void QgsSimpleLineSymbolLayerV2::renderPolyline( const QPolygonF& points, QgsSym
   // Disable 'Antialiasing' if the geometry was generalized in the current RenderContext.
   if ( context.generalizedByBoundingBox() && p->renderHints() & QPainter::Antialiasing )
   {
-	p->setRenderHint(QPainter::Antialiasing, false);
+	p->setRenderHint( QPainter::Antialiasing, false );
 	p->drawPolyline( points );
-	p->setRenderHint(QPainter::Antialiasing);
+	p->setRenderHint( QPainter::Antialiasing, true );
 	return;
   }
 

--- a/src/core/symbology-ng/qgsrendererv2.cpp
+++ b/src/core/symbology-ng/qgsrendererv2.cpp
@@ -150,17 +150,17 @@ const unsigned char* QgsFeatureRendererV2::_getPolygon( QPolygonF& pts, QList<QP
     unsigned int nPoints = *(( int* )wkb );
     wkb += sizeof( unsigned int );
 
-	// Extract the points from the WKB and store in a pair of vectors, validating view precision. 
+    // Extract the points from the WKB and store in a pair of vectors, validating view precision. 
     QPolygonF poly;
     QgsFeatureRendererSimplifier::simplifyGeometry(context, map2pixelTol, (QGis::WkbType)wkbType, wkb, nPoints, poly, generalizedByBoundingBox);
     wkb += hasZValue ? 3*nPoints*sizeof(double) : 2*nPoints*sizeof(double);
     QPointF* ptr = poly.data();
     nPoints = poly.size();
 	
-	if ( nPoints < 1 )
+    if ( nPoints < 1 )
       continue;
 
-	// Clip close to view extent validating if needed.
+    // Clip close to view extent validating if needed.
     QRectF ptsRect = poly.boundingRect();
     if (!context.extent().contains( ptsRect )) QgsClipper::trimPolygon( poly, clipRect );
 

--- a/src/core/symbology-ng/qgsrendererv2.cpp
+++ b/src/core/symbology-ng/qgsrendererv2.cpp
@@ -123,7 +123,7 @@ const unsigned char* QgsFeatureRendererV2::_getPolygon( QPolygonF& pts, QList<QP
 const unsigned char* QgsFeatureRendererV2::_getPolygon( QPolygonF& pts, QList<QPolygonF>& holes, QgsRenderContext& context, const unsigned char* wkb, bool& generalizedByBoundingBox )
 {
   // Indicates whether the geometry can be generalized.
-  generalizedByBoundingBox = false;
+  generalizedByBoundingBox = true;
   // Threshold of the map2pixel value in the current RenderContext. //TODO: Find optimum value
   float map2pixelTol = 1.0f;
 
@@ -147,15 +147,18 @@ const unsigned char* QgsFeatureRendererV2::_getPolygon( QPolygonF& pts, QList<QP
 
   for ( unsigned int idx = 0; idx < numRings; idx++ )
   {
+    bool ringGeneralizedByBoundingBox = false;
+
     unsigned int nPoints = *(( int* )wkb );
     wkb += sizeof( unsigned int );
 
     // Extract the points from the WKB and store in a pair of vectors, validating view precision. 
     QPolygonF poly;
-    QgsFeatureRendererSimplifier::simplifyGeometry(context, map2pixelTol, (QGis::WkbType)wkbType, wkb, nPoints, poly, generalizedByBoundingBox);
+    QgsFeatureRendererSimplifier::simplifyGeometry(context, map2pixelTol, (QGis::WkbType)wkbType, wkb, nPoints, poly, ringGeneralizedByBoundingBox);
     wkb += hasZValue ? 3*nPoints*sizeof(double) : 2*nPoints*sizeof(double);
     QPointF* ptr = poly.data();
     nPoints = poly.size();
+    if (!ringGeneralizedByBoundingBox) generalizedByBoundingBox = false;
 	
     if ( nPoints < 1 )
       continue;

--- a/src/core/symbology-ng/qgsrendererv2.cpp
+++ b/src/core/symbology-ng/qgsrendererv2.cpp
@@ -27,6 +27,7 @@
 #include "qgsfeature.h"
 #include "qgslogger.h"
 #include "qgsvectorlayer.h"
+#include "qgsrendererv2geometrysimplifier.h" // Provides geometry simplification methods for optimize the drawing of features.
 
 #include <QDomElement>
 #include <QDomDocument>
@@ -60,6 +61,14 @@ const unsigned char* QgsFeatureRendererV2::_getPoint( QPointF& pt, QgsRenderCont
 
 const unsigned char* QgsFeatureRendererV2::_getLineString( QPolygonF& pts, QgsRenderContext& context, const unsigned char* wkb )
 {
+	bool generalizedByBoundingBox = false;
+	return _getLineString( pts, context, wkb, generalizedByBoundingBox );
+}
+const unsigned char* QgsFeatureRendererV2::_getLineString( QPolygonF& pts, QgsRenderContext& context, const unsigned char* wkb, bool& generalizedByBoundingBox )
+{
+  // Indicates whether the geometry can be generalized.
+  generalizedByBoundingBox = false;
+
   wkb++; // jump over endian info
   unsigned int wkbType = *(( int* ) wkb );
   wkb += sizeof( unsigned int );
@@ -67,36 +76,14 @@ const unsigned char* QgsFeatureRendererV2::_getLineString( QPolygonF& pts, QgsRe
   wkb += sizeof( unsigned int );
 
   bool hasZValue = ( wkbType == QGis::WKBLineString25D );
-  double x, y;
+
   const QgsCoordinateTransform* ct = context.coordinateTransform();
   const QgsMapToPixel& mtp = context.mapToPixel();
 
-  //apply clipping for large lines to achieve a better rendering performance
-  if ( nPoints > 1 )
-  {
-    const QgsRectangle& e = context.extent();
-    double cw = e.width() / 10; double ch = e.height() / 10;
-    QgsRectangle clipRect( e.xMinimum() - cw, e.yMinimum() - ch, e.xMaximum() + cw, e.yMaximum() + ch );
-    wkb = QgsClipper::clippedLineWKB( wkb - ( 2 * sizeof( unsigned int ) + 1 ), clipRect, pts );
-  }
-  else
-  {
-    pts.resize( nPoints );
-
-    QPointF* ptr = pts.data();
-    for ( unsigned int i = 0; i < nPoints; ++i, ++ptr )
-    {
-      x = *(( double * ) wkb );
-      wkb += sizeof( double );
-      y = *(( double * ) wkb );
-      wkb += sizeof( double );
-
-      if ( hasZValue ) // ignore Z value
-        wkb += sizeof( double );
-
-      *ptr = QPointF( x, y );
-    }
-  }
+  // Feature #8725: Speed improvement in the render of geometries, extract the points from the WKB validating view precision. 
+  QgsFeatureRendererSimplifier::SimplifyGeometry(context, (QGis::WkbType)wkbType, wkb, nPoints, pts, generalizedByBoundingBox);
+  wkb += hasZValue ? 3*nPoints*sizeof(double) : 2*nPoints*sizeof(double);
+  nPoints = pts.size();
 
   //transform the QPolygonF to screen coordinates
   if ( ct )
@@ -116,6 +103,14 @@ const unsigned char* QgsFeatureRendererV2::_getLineString( QPolygonF& pts, QgsRe
 
 const unsigned char* QgsFeatureRendererV2::_getPolygon( QPolygonF& pts, QList<QPolygonF>& holes, QgsRenderContext& context, const unsigned char* wkb )
 {
+	bool generalizedByBoundingBox = false;
+	return _getPolygon( pts, holes, context, wkb, generalizedByBoundingBox );
+}
+const unsigned char* QgsFeatureRendererV2::_getPolygon( QPolygonF& pts, QList<QPolygonF>& holes, QgsRenderContext& context, const unsigned char* wkb, bool& generalizedByBoundingBox )
+{
+  // Indicates whether the geometry can be generalized.
+  generalizedByBoundingBox = false;
+
   wkb++; // jump over endian info
   unsigned int wkbType = *(( int* ) wkb );
   wkb += sizeof( unsigned int ); // jump over wkb type
@@ -126,7 +121,6 @@ const unsigned char* QgsFeatureRendererV2::_getPolygon( QPolygonF& pts, QList<QP
     return wkb;
 
   bool hasZValue = ( wkbType == QGis::WKBPolygon25D );
-  double x, y;
   holes.clear();
 
   const QgsCoordinateTransform* ct = context.coordinateTransform();
@@ -140,26 +134,19 @@ const unsigned char* QgsFeatureRendererV2::_getPolygon( QPolygonF& pts, QList<QP
     unsigned int nPoints = *(( int* )wkb );
     wkb += sizeof( unsigned int );
 
-    QPolygonF poly( nPoints );
-
-    // Extract the points from the WKB and store in a pair of vectors.
-    QPointF* ptr = poly.data();
-    for ( unsigned int jdx = 0; jdx < nPoints; ++jdx, ++ptr )
-    {
-      x = *(( double * ) wkb ); wkb += sizeof( double );
-      y = *(( double * ) wkb ); wkb += sizeof( double );
-
-      *ptr = QPointF( x, y );
-
-      if ( hasZValue )
-        wkb += sizeof( double );
-    }
-
-    if ( nPoints < 1 )
+	// Extract the points from the WKB and store in a pair of vectors, validating view precision. 
+	QPolygonF poly;
+	QgsFeatureRendererSimplifier::SimplifyGeometry(context, (QGis::WkbType)wkbType, wkb, nPoints, poly, generalizedByBoundingBox);
+	wkb += hasZValue ? 3*nPoints*sizeof(double) : 2*nPoints*sizeof(double);
+	QPointF* ptr = poly.data();
+	nPoints = poly.size();
+	
+	if ( nPoints < 1 )
       continue;
 
-    //clip close to view extent
-    QgsClipper::trimPolygon( poly, clipRect );
+	// Clip close to view extent validating if needed.
+	QRectF ptsRect = poly.boundingRect();
+	if (!clipRect.contains(ptsRect)) QgsClipper::trimPolygon( poly, clipRect );
 
     //transform the QPolygonF to screen coordinates
     if ( ct )
@@ -226,6 +213,9 @@ void QgsFeatureRendererV2::renderFeatureWithSymbol( QgsFeature& feature, QgsSymb
 {
   QgsSymbolV2::SymbolType symbolType = symbol->type();
 
+  // Indicates whether the geometry can be generalized.
+  bool generalizedByBoundingBox = false;
+
   QgsGeometry* geom = feature.geometry();
   switch ( geom->wkbType() )
   {
@@ -255,8 +245,8 @@ void QgsFeatureRendererV2::renderFeatureWithSymbol( QgsFeature& feature, QgsSymb
         break;
       }
       QPolygonF pts;
-      _getLineString( pts, context, geom->asWkb() );
-      (( QgsLineSymbolV2* )symbol )->renderPolyline( pts, &feature, context, layer, selected );
+      _getLineString( pts, context, geom->asWkb(), generalizedByBoundingBox );
+      (( QgsLineSymbolV2* )symbol )->renderPolyline( pts, &feature, context, layer, selected, generalizedByBoundingBox );
 
       if ( drawVertexMarker )
         renderVertexMarkerPolyline( pts, context );
@@ -273,8 +263,8 @@ void QgsFeatureRendererV2::renderFeatureWithSymbol( QgsFeature& feature, QgsSymb
       }
       QPolygonF pts;
       QList<QPolygonF> holes;
-      _getPolygon( pts, holes, context, geom->asWkb() );
-      (( QgsFillSymbolV2* )symbol )->renderPolygon( pts, ( holes.count() ? &holes : NULL ), &feature, context, layer, selected );
+      _getPolygon( pts, holes, context, geom->asWkb(), generalizedByBoundingBox );
+      (( QgsFillSymbolV2* )symbol )->renderPolygon( pts, ( holes.count() ? &holes : NULL ), &feature, context, layer, selected, generalizedByBoundingBox );
 
       if ( drawVertexMarker )
         renderVertexMarkerPolygon( pts, ( holes.count() ? &holes : NULL ), context );
@@ -322,8 +312,8 @@ void QgsFeatureRendererV2::renderFeatureWithSymbol( QgsFeature& feature, QgsSymb
 
       for ( unsigned int i = 0; i < num; ++i )
       {
-        ptr = _getLineString( pts, context, ptr );
-        (( QgsLineSymbolV2* )symbol )->renderPolyline( pts, &feature, context, layer, selected );
+        ptr = _getLineString( pts, context, ptr, generalizedByBoundingBox );
+        (( QgsLineSymbolV2* )symbol )->renderPolyline( pts, &feature, context, layer, selected, generalizedByBoundingBox );
 
         if ( drawVertexMarker )
           renderVertexMarkerPolyline( pts, context );
@@ -348,8 +338,8 @@ void QgsFeatureRendererV2::renderFeatureWithSymbol( QgsFeature& feature, QgsSymb
 
       for ( unsigned int i = 0; i < num; ++i )
       {
-        ptr = _getPolygon( pts, holes, context, ptr );
-        (( QgsFillSymbolV2* )symbol )->renderPolygon( pts, ( holes.count() ? &holes : NULL ), &feature, context, layer, selected );
+        ptr = _getPolygon( pts, holes, context, ptr, generalizedByBoundingBox );
+        (( QgsFillSymbolV2* )symbol )->renderPolygon( pts, ( holes.count() ? &holes : NULL ), &feature, context, layer, selected, generalizedByBoundingBox );
 
         if ( drawVertexMarker )
           renderVertexMarkerPolygon( pts, ( holes.count() ? &holes : NULL ), context );

--- a/src/core/symbology-ng/qgsrendererv2.cpp
+++ b/src/core/symbology-ng/qgsrendererv2.cpp
@@ -91,12 +91,12 @@ const unsigned char* QgsFeatureRendererV2::_getLineString( QPolygonF& pts, QgsRe
   nPoints = pts.size();
 
   //apply clipping for large lines to achieve a better rendering performance
-  if ( nPoints > 1 && !generalizedByBoundingBox && !clipRect.contains( pts.boundingRect() ))
+  if ( nPoints > 1 && !generalizedByBoundingBox && !context.extent().contains( pts.boundingRect() ))
   {
-	QPolygonF line;
+    QPolygonF line;
     QgsClipper::clippedLine( pts, clipRect, line );
-	pts = line;
-	nPoints = pts.size();
+    pts = line;
+    nPoints = pts.size();
   }
 
   //transform the QPolygonF to screen coordinates
@@ -151,18 +151,18 @@ const unsigned char* QgsFeatureRendererV2::_getPolygon( QPolygonF& pts, QList<QP
     wkb += sizeof( unsigned int );
 
 	// Extract the points from the WKB and store in a pair of vectors, validating view precision. 
-	QPolygonF poly;
-	QgsFeatureRendererSimplifier::simplifyGeometry(context, map2pixelTol, (QGis::WkbType)wkbType, wkb, nPoints, poly, generalizedByBoundingBox);
-	wkb += hasZValue ? 3*nPoints*sizeof(double) : 2*nPoints*sizeof(double);
-	QPointF* ptr = poly.data();
-	nPoints = poly.size();
+    QPolygonF poly;
+    QgsFeatureRendererSimplifier::simplifyGeometry(context, map2pixelTol, (QGis::WkbType)wkbType, wkb, nPoints, poly, generalizedByBoundingBox);
+    wkb += hasZValue ? 3*nPoints*sizeof(double) : 2*nPoints*sizeof(double);
+    QPointF* ptr = poly.data();
+    nPoints = poly.size();
 	
 	if ( nPoints < 1 )
       continue;
 
 	// Clip close to view extent validating if needed.
-	QRectF ptsRect = poly.boundingRect();
-	if (!clipRect.contains( ptsRect )) QgsClipper::trimPolygon( poly, clipRect );
+    QRectF ptsRect = poly.boundingRect();
+    if (!context.extent().contains( ptsRect )) QgsClipper::trimPolygon( poly, clipRect );
 
     //transform the QPolygonF to screen coordinates
     if ( ct )

--- a/src/core/symbology-ng/qgsrendererv2.h
+++ b/src/core/symbology-ng/qgsrendererv2.h
@@ -194,6 +194,9 @@ class CORE_EXPORT QgsFeatureRendererV2
     static const unsigned char* _getLineString( QPolygonF& pts, QgsRenderContext& context, const unsigned char* wkb );
     static const unsigned char* _getPolygon( QPolygonF& pts, QList<QPolygonF>& holes, QgsRenderContext& context, const unsigned char* wkb );
 
+    static const unsigned char* _getLineString( QPolygonF& pts, QgsRenderContext& context, const unsigned char* wkb, bool& generalizedByBoundingBox );
+    static const unsigned char* _getPolygon( QPolygonF& pts, QList<QPolygonF>& holes, QgsRenderContext& context, const unsigned char* wkb, bool& generalizedByBoundingBox );
+
     void setScaleMethodToSymbol( QgsSymbolV2* symbol, int scaleMethod );
 
     QString mType;

--- a/src/core/symbology-ng/qgsrendererv2geometrysimplifier.cpp
+++ b/src/core/symbology-ng/qgsrendererv2geometrysimplifier.cpp
@@ -1,0 +1,220 @@
+/***************************************************************************
+    qgsrendererv2geometrysimplifier.cpp
+    ---------------------
+    begin                : October 2013
+    copyright            : (C) 2013 by Alvaro Huarte
+    email                : http://wiki.osgeo.org/wiki/Alvaro_Huarte
+
+***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsrendererv2geometrysimplifier.h"
+#include "QtCore/qrect.h"
+
+/** Threshold of the map2pixel value in the current RenderContext */
+#define MAP2PIXEL_THRESHOLD_FACTOR 1.3
+
+
+/** Returns the squared 2D-distance of the vector defined by the two points specified */
+float QgsFeatureRendererSimplifier::LengthGeneralizedSquared2D(double x1, double y1, double x2, double y2)
+{
+	float vx = (float)(x2-x1);
+	float vy = (float)(y2-y1);
+
+	return vx*vx + vy*vy;
+}
+
+/** Returns the MapTolerance of the current View for transforms between map coordinates and device coordinates */
+float QgsFeatureRendererSimplifier::CalculateViewPixelTolerance(QgsRenderContext& context, QRectF& boundingRect)
+{
+	const QgsMapToPixel& mtp = context.mapToPixel();
+	const QgsCoordinateTransform* ct = context.coordinateTransform();
+
+	double mapUnitsPerPixel = mtp.mapUnitsPerPixel();
+	double mapUnitsFactor = 1;
+
+	// Calculate one aprox factor of the size of the BBOX from the source CoordinateSystem to the target CoordinateSystem.
+	if (ct && !((QgsCoordinateTransform*)ct)->isShortCircuited())
+	{
+		QgsRectangle sourceRect(boundingRect.left(), boundingRect.bottom(), boundingRect.right(), boundingRect.top());
+		QgsRectangle targetRect = ct->transform(sourceRect);
+
+		QgsPoint minimumSrcPoint( sourceRect.xMinimum(), sourceRect.yMinimum() );
+		QgsPoint maximumSrcPoint( sourceRect.xMaximum(), sourceRect.yMaximum() );
+		QgsPoint minimumDstPoint( targetRect.xMinimum(), targetRect.yMinimum() );
+		QgsPoint maximumDstPoint( targetRect.xMaximum(), targetRect.yMaximum() );
+
+		double sourceHypothenuse = sqrt( LengthGeneralizedSquared2D( minimumSrcPoint.x(), minimumSrcPoint.y(), maximumSrcPoint.x(), maximumSrcPoint.y() ) );
+		double targetHypothenuse = sqrt( LengthGeneralizedSquared2D( minimumDstPoint.x(), minimumDstPoint.y(), maximumDstPoint.x(), maximumDstPoint.y() ) );
+
+		if (targetHypothenuse!=0) 
+		mapUnitsFactor = sourceHypothenuse/targetHypothenuse;
+	}
+	return (float)( MAP2PIXEL_THRESHOLD_FACTOR * mapUnitsPerPixel * mapUnitsFactor );
+}
+
+/** Returns the view-valid number of points of the specified geometry */
+unsigned int QgsFeatureRendererSimplifier::CalculateGeneralizedPointCount(QgsRenderContext& context, QGis::WkbType wkbType, const unsigned char* wkb, unsigned int numPoints, QRectF& boundingRect, bool& generalizedByBoundingBox)
+{
+	const unsigned char* wkb2 = wkb;
+
+	double xmin = DBL_MAX, ymin = DBL_MAX, xmax = -DBL_MAX, ymax = -DBL_MAX;
+	double x,y, lastX=0,lastY=0;
+
+	int sizeOfDoubleX = sizeof(double);
+	int sizeOfDoubleY = QGis::wkbDimensions(wkbType)==3 /*hasZValue*/ ? 2*sizeof(double) : sizeof(double);
+
+	// Calculate the full BoundingBox of the current point stream.
+	for ( unsigned int jdx = 0; jdx < numPoints; ++jdx )
+	{
+		x = *(( double * ) wkb ); wkb += sizeOfDoubleX;
+		y = *(( double * ) wkb ); wkb += sizeOfDoubleY;
+
+		if (xmin>x) xmin = x;
+		if (ymin>y) ymin = y;
+		if (xmax<x) xmax = x;
+		if (ymax<y) ymax = y;
+	}
+	boundingRect.setCoords(xmin,ymin,xmax,ymax);
+	wkb = wkb2;
+
+	// MapTolerance of the current View for transforms between map coordinates and device coordinates.
+	float mappixelTol = QgsFeatureRendererSimplifier::CalculateViewPixelTolerance( context, boundingRect );
+
+	// Can simplify the geometry using the full BBOX ¿?
+	if ((generalizedByBoundingBox = ((xmax-xmin)<=mappixelTol && (ymax-ymin)<=mappixelTol)))
+	{
+		return QGis::flatType(wkbType)==QGis::WKBLineString ? 2 : 5;
+	}
+
+	unsigned int simplifiedPointCount = 0;
+	mappixelTol *= mappixelTol; //-> Use mappixelTol for 'LengthSquare' calculations.
+
+	// Force equal the first and last point of the closed geometry.
+	if (QGis::flatType(wkbType)==QGis::WKBPolygon)
+	{
+		simplifiedPointCount++;
+		numPoints--;
+	}
+
+	// Calculate the view-valid number of points of the specified geometry.
+	for ( unsigned int jdx = 0; jdx < numPoints; ++jdx )
+	{
+		x = *(( double * ) wkb ); wkb += sizeOfDoubleX;
+		y = *(( double * ) wkb ); wkb += sizeOfDoubleY;
+
+		if (jdx==0 || LengthGeneralizedSquared2D(lastX,lastY,x,y)>mappixelTol)
+		{
+			simplifiedPointCount++;
+			lastX = x;
+			lastY = y;
+		}
+	}
+	wkb = wkb2;
+
+	// Returns the view-valid PointCount.
+	if (QGis::flatType(wkbType)==QGis::WKBLineString && simplifiedPointCount<=1)
+	{
+		generalizedByBoundingBox = true;
+		simplifiedPointCount = 2;
+	}
+	else
+	if (QGis::flatType(wkbType)==QGis::WKBPolygon && simplifiedPointCount<=3)
+	{
+		generalizedByBoundingBox = true;
+		simplifiedPointCount = 5;
+	}
+	return simplifiedPointCount;
+}
+
+/** Fill the view-valid simplified points to the specified geometry */
+unsigned int QgsFeatureRendererSimplifier::SimplifyGeometry(QgsRenderContext& context, QGis::WkbType wkbType, const unsigned char* wkb, unsigned int numPoints, QVector<QPointF>& outputPoints, bool& generalizedByBoundingBox)
+{
+	QGis::WkbType flatType = QGis::flatType(wkbType);
+
+	int sizeOfDoubleX = sizeof(double);
+	int sizeOfDoubleY = QGis::wkbDimensions(wkbType)==3 /*hasZValue*/ ? 2*sizeof(double) : sizeof(double);
+
+	generalizedByBoundingBox = false;
+	double x,y;
+
+	// Fill if possible, the view-valid simplified points to the specified geometry.
+	if (numPoints>2 && flatType!=QGis::WKBPoint && flatType!=QGis::WKBMultiPoint)
+	{
+		double lastX=0,lastY=0;
+
+		// Calculate the view-valid number of points of the geometry.
+		QRectF boundingRect;
+		unsigned int simplifiedPointCount = CalculateGeneralizedPointCount(context, wkbType, wkb, numPoints, boundingRect, generalizedByBoundingBox);
+
+		outputPoints.resize(simplifiedPointCount);
+		QPointF* ptr = outputPoints.data();
+
+		// Can simplify the geometry using the full BBOX ¿?
+		if (generalizedByBoundingBox)
+		{
+			if (flatType==QGis::WKBLineString)
+			{
+			   *ptr = boundingRect.topLeft(); ptr++;
+			   *ptr = boundingRect.bottomRight();
+			}
+			else
+			if (flatType==QGis::WKBPolygon)
+			{
+			   *ptr = boundingRect.topLeft(); ptr++;
+			   *ptr = boundingRect.topRight(); ptr++;
+			   *ptr = boundingRect.bottomRight(); ptr++;
+			   *ptr = boundingRect.bottomLeft(); ptr++;
+			   *ptr = boundingRect.topLeft();
+			}
+			return simplifiedPointCount;
+		}
+
+		// MapTolerance of the current View for transforms between map coordinates and device coordinates.
+		float mappixelTol = QgsFeatureRendererSimplifier::CalculateViewPixelTolerance( context, boundingRect );
+		mappixelTol *= mappixelTol; //-> Use mappixelTol for 'LengthSquare' calculations.
+
+		// Force equal the first and last point of the closed geometry.
+		bool isaPolygon = QGis::flatType(wkbType)==QGis::WKBPolygon;
+		if (isaPolygon) numPoints--;
+		
+		// Fill the view-valid points of the specified geometry.
+		for ( unsigned int jdx = 0; jdx < numPoints; ++jdx)
+		{
+			x = *(( double * ) wkb ); wkb += sizeOfDoubleX;
+			y = *(( double * ) wkb ); wkb += sizeOfDoubleY;
+
+			if (jdx==0 || LengthGeneralizedSquared2D(lastX,lastY,x,y)>mappixelTol)
+			{
+			   *ptr = QPointF(x, y); ++ptr;
+				lastX = x; 
+				lastY = y;
+			}
+		}
+		if (isaPolygon)
+		{
+			*ptr = *outputPoints.data();
+		}
+		return simplifiedPointCount;
+	}
+	else
+	{
+		outputPoints.resize(numPoints);
+		QPointF* ptr = outputPoints.data();
+
+		for ( unsigned int jdx = 0; jdx < numPoints; ++jdx, ++ptr )
+		{
+			x = *(( double * ) wkb ); wkb += sizeOfDoubleX;
+			y = *(( double * ) wkb ); wkb += sizeOfDoubleY;
+
+			*ptr = QPointF( x, y );
+		}
+		return numPoints;
+	}
+}

--- a/src/core/symbology-ng/qgsrendererv2geometrysimplifier.cpp
+++ b/src/core/symbology-ng/qgsrendererv2geometrysimplifier.cpp
@@ -14,7 +14,7 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "limits.h"
+#include <limits.h>
 #include "qgsrendererv2geometrysimplifier.h"
 #include "QtCore/qrect.h"
 

--- a/src/core/symbology-ng/qgsrendererv2geometrysimplifier.cpp
+++ b/src/core/symbology-ng/qgsrendererv2geometrysimplifier.cpp
@@ -14,9 +14,9 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "limits.h"
 #include "qgsrendererv2geometrysimplifier.h"
 #include "QtCore/qrect.h"
-
 
 /** Returns the squared 2D-distance of the vector defined by the two points specified */
 float QgsFeatureRendererSimplifier::lengthGeneralizedSquared2D(double x1, double y1, double x2, double y2)

--- a/src/core/symbology-ng/qgsrendererv2geometrysimplifier.h
+++ b/src/core/symbology-ng/qgsrendererv2geometrysimplifier.h
@@ -19,7 +19,6 @@
 
 #include "qgsrendercontext.h"
 #include "qgsgeometry.h"
-#include "qgsfeature.h"
 
 /** \ingroup core
  * Provides geometry simplification methods for optimize the drawing of features.
@@ -31,19 +30,20 @@ class CORE_EXPORT QgsFeatureRendererSimplifier
 {
 private:
 
-	/** Returns the squared 2D-distance of the vector defined by the two points specified */
-	static float LengthGeneralizedSquared2D(double x1, double y1, double x2, double y2);
+  /** Returns the squared 2D-distance of the vector defined by the two points specified */
+  static float lengthGeneralizedSquared2D(double x1, double y1, double x2, double y2);
 
-	/** Returns the MapTolerance of the current View for transforms between map coordinates and device coordinates */
-	static float CalculateViewPixelTolerance(QgsRenderContext& context, QRectF& boundingRect);
+  /** Returns the MapTolerance of the current View for transforms between map coordinates and device coordinates */
+  static float calculateViewPixelTolerance(QgsRenderContext& context, QRectF& boundingRect);
 
-	/** Returns the view-valid number of points of the specified geometry */
-	static unsigned int CalculateGeneralizedPointCount(QgsRenderContext& context, QGis::WkbType wkbType, const unsigned char* wkb, unsigned int numPoints, QRectF& boundingRect, bool& generalizedByBoundingBox);
+  /** Returns the view-valid number of points of the specified geometry */
+  static unsigned int calculateGeneralizedPointCount(QgsRenderContext& context, float map2pixelTol, QGis::WkbType wkbType, const unsigned char* wkb, unsigned int numPoints, QRectF& boundingRect, bool& generalizedByBoundingBox);
 
 public:
 
-	/** Fill the view-valid simplified points to the specified geometry */
-	static unsigned int SimplifyGeometry(QgsRenderContext& context, QGis::WkbType wkbType, const unsigned char* wkb, unsigned int numPoints, QVector<QPointF>& outputPoints, bool& generalizedByBoundingBox);
+  /** Fill the view-valid simplified points to the specified geometry */
+  static unsigned int simplifyGeometry(QgsRenderContext& context, float map2pixelTol, QGis::WkbType wkbType, const unsigned char* wkb, unsigned int numPoints, QVector<QPointF>& outputPoints, bool& generalizedByBoundingBox);
+
 };
 
 #endif

--- a/src/core/symbology-ng/qgsrendererv2geometrysimplifier.h
+++ b/src/core/symbology-ng/qgsrendererv2geometrysimplifier.h
@@ -1,0 +1,49 @@
+/***************************************************************************
+    qgsrendererv2geometrysimplifier.h
+    ---------------------
+    begin                : October 2013
+    copyright            : (C) 2013 by Alvaro Huarte
+    email                : http://wiki.osgeo.org/wiki/Alvaro_Huarte
+
+***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSRENDER_GEOMETRY_SIMPLIFIER_H
+#define QGSRENDER_GEOMETRY_SIMPLIFIER_H
+
+#include "qgsrendercontext.h"
+#include "qgsgeometry.h"
+#include "qgsfeature.h"
+
+/** \ingroup core
+ * Provides geometry simplification methods for optimize the drawing of features.
+ * This helper class calculate a simplified/generalized geometry from one source 
+ * feature using a tolerance of the current map2pixel value of the RenderContext.
+ * Output geometry is drawed with undetectable visual changes.
+ **/
+class CORE_EXPORT QgsFeatureRendererSimplifier
+{
+private:
+
+	/** Returns the squared 2D-distance of the vector defined by the two points specified */
+	static float LengthGeneralizedSquared2D(double x1, double y1, double x2, double y2);
+
+	/** Returns the MapTolerance of the current View for transforms between map coordinates and device coordinates */
+	static float CalculateViewPixelTolerance(QgsRenderContext& context, QRectF& boundingRect);
+
+	/** Returns the view-valid number of points of the specified geometry */
+	static unsigned int CalculateGeneralizedPointCount(QgsRenderContext& context, QGis::WkbType wkbType, const unsigned char* wkb, unsigned int numPoints, QRectF& boundingRect, bool& generalizedByBoundingBox);
+
+public:
+
+	/** Fill the view-valid simplified points to the specified geometry */
+	static unsigned int SimplifyGeometry(QgsRenderContext& context, QGis::WkbType wkbType, const unsigned char* wkb, unsigned int numPoints, QVector<QPointF>& outputPoints, bool& generalizedByBoundingBox);
+};
+
+#endif

--- a/src/core/symbology-ng/qgssymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgssymbollayerv2.cpp
@@ -334,10 +334,10 @@ void QgsFillSymbolLayerV2::_renderPolygon( QPainter* p, const QPolygonF& points,
   // Disable 'Antialiasing' if the geometry was generalized in the current RenderContext.
   if ( context.generalizedByBoundingBox() && p->renderHints() & QPainter::Antialiasing )
   {
-	p->setRenderHint( QPainter::Antialiasing, false );
-	p->drawPolygon( points );
-	p->setRenderHint( QPainter::Antialiasing, true );
-	return;
+    p->setRenderHint( QPainter::Antialiasing, false );
+    p->drawPolygon( points );
+    p->setRenderHint( QPainter::Antialiasing, true );
+    return;
   }
 
   if ( rings == NULL )

--- a/src/core/symbology-ng/qgssymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgssymbollayerv2.cpp
@@ -334,9 +334,9 @@ void QgsFillSymbolLayerV2::_renderPolygon( QPainter* p, const QPolygonF& points,
   // Disable 'Antialiasing' if the geometry was generalized in the current RenderContext.
   if ( context.generalizedByBoundingBox() && p->renderHints() & QPainter::Antialiasing )
   {
-	p->setRenderHint(QPainter::Antialiasing, false);
+	p->setRenderHint( QPainter::Antialiasing, false );
 	p->drawPolygon( points );
-	p->setRenderHint(QPainter::Antialiasing);
+	p->setRenderHint( QPainter::Antialiasing, true );
 	return;
   }
 

--- a/src/core/symbology-ng/qgssymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgssymbollayerv2.cpp
@@ -324,11 +324,20 @@ void QgsFillSymbolLayerV2::drawPreviewIcon( QgsSymbolV2RenderContext& context, Q
   stopRender( context );
 }
 
-void QgsFillSymbolLayerV2::_renderPolygon( QPainter* p, const QPolygonF& points, const QList<QPolygonF>* rings )
+void QgsFillSymbolLayerV2::_renderPolygon( QPainter* p, const QPolygonF& points, const QList<QPolygonF>* rings, QgsSymbolV2RenderContext& context )
 {
   if ( !p )
   {
     return;
+  }
+
+  // Disable 'Antialiasing' if the geometry was generalized in the current RenderContext.
+  if ( context.generalizedByBoundingBox() && p->renderHints() & QPainter::Antialiasing )
+  {
+	p->setRenderHint(QPainter::Antialiasing, false);
+	p->drawPolygon( points );
+	p->setRenderHint(QPainter::Antialiasing);
+	return;
   }
 
   if ( rings == NULL )

--- a/src/core/symbology-ng/qgssymbollayerv2.h
+++ b/src/core/symbology-ng/qgssymbollayerv2.h
@@ -231,7 +231,7 @@ class CORE_EXPORT QgsFillSymbolLayerV2 : public QgsSymbolLayerV2
   protected:
     QgsFillSymbolLayerV2( bool locked = false );
     /**Default method to render polygon*/
-    void _renderPolygon( QPainter* p, const QPolygonF& points, const QList<QPolygonF>* rings );
+    void _renderPolygon( QPainter* p, const QPolygonF& points, const QList<QPolygonF>* rings, QgsSymbolV2RenderContext& context );
 
     double mAngle;
 };

--- a/src/core/symbology-ng/qgssymbolv2.cpp
+++ b/src/core/symbology-ng/qgssymbolv2.cpp
@@ -378,7 +378,15 @@ QSet<QString> QgsSymbolV2::usedAttributes() const
 QgsSymbolV2RenderContext::QgsSymbolV2RenderContext( QgsRenderContext& c, QgsSymbolV2::OutputUnit u, qreal alpha, bool selected, int renderHints, const QgsFeature* f )
     : mRenderContext( c ), mOutputUnit( u ), mAlpha( alpha ), mSelected( selected ), mRenderHints( renderHints ), mFeature( f ), mLayer( 0 )
 {
+	// Indicates that the feature was generalized in the current rendering context.
+	mGeneralizedByBoundingBox = false;
+}
 
+QgsSymbolV2RenderContext::QgsSymbolV2RenderContext( QgsRenderContext& c, QgsSymbolV2::OutputUnit u, qreal alpha, bool selected, bool generalizedByBoundingBox, int renderHints, const QgsFeature* f )
+    : mRenderContext( c ), mOutputUnit( u ), mAlpha( alpha ), mSelected( selected ), mRenderHints( renderHints ), mFeature( f ), mLayer( 0 )
+{
+	// Indicates that the feature was generalized in the current rendering context.
+	mGeneralizedByBoundingBox = generalizedByBoundingBox;
 }
 
 QgsSymbolV2RenderContext::~QgsSymbolV2RenderContext()
@@ -597,9 +605,9 @@ double QgsLineSymbolV2::width()
   return maxWidth;
 }
 
-void QgsLineSymbolV2::renderPolyline( const QPolygonF& points, const QgsFeature* f, QgsRenderContext& context, int layer, bool selected )
+void QgsLineSymbolV2::renderPolyline( const QPolygonF& points, const QgsFeature* f, QgsRenderContext& context, int layer, bool selected, bool generalizedByBoundingBox )
 {
-  QgsSymbolV2RenderContext symbolContext( context, outputUnit(), mAlpha, selected, mRenderHints, f );
+  QgsSymbolV2RenderContext symbolContext( context, outputUnit(), mAlpha, selected, generalizedByBoundingBox, mRenderHints, f );
   if ( layer != -1 )
   {
     if ( layer >= 0 && layer < mLayers.count() )
@@ -632,9 +640,9 @@ QgsFillSymbolV2::QgsFillSymbolV2( QgsSymbolLayerV2List layers )
     mLayers.append( new QgsSimpleFillSymbolLayerV2() );
 }
 
-void QgsFillSymbolV2::renderPolygon( const QPolygonF& points, QList<QPolygonF>* rings, const QgsFeature* f, QgsRenderContext& context, int layer, bool selected )
+void QgsFillSymbolV2::renderPolygon( const QPolygonF& points, QList<QPolygonF>* rings, const QgsFeature* f, QgsRenderContext& context, int layer, bool selected, bool generalizedByBoundingBox )
 {
-  QgsSymbolV2RenderContext symbolContext( context, outputUnit(), mAlpha, selected, mRenderHints, f );
+  QgsSymbolV2RenderContext symbolContext( context, outputUnit(), mAlpha, selected, generalizedByBoundingBox, mRenderHints, f );
   if ( layer != -1 )
   {
     if ( layer >= 0 && layer < mLayers.count() )

--- a/src/core/symbology-ng/qgssymbolv2.h
+++ b/src/core/symbology-ng/qgssymbolv2.h
@@ -153,6 +153,7 @@ class CORE_EXPORT QgsSymbolV2RenderContext
 {
   public:
     QgsSymbolV2RenderContext( QgsRenderContext& c, QgsSymbolV2::OutputUnit u , qreal alpha = 1.0, bool selected = false, int renderHints = 0, const QgsFeature* f = 0 );
+    QgsSymbolV2RenderContext( QgsRenderContext& c, QgsSymbolV2::OutputUnit u , qreal alpha, bool selected, bool generalizedByBoundingBox, int renderHints, const QgsFeature* f );
     ~QgsSymbolV2RenderContext();
 
     QgsRenderContext& renderContext() { return mRenderContext; }
@@ -169,6 +170,9 @@ class CORE_EXPORT QgsSymbolV2RenderContext
 
     bool selected() const { return mSelected; }
     void setSelected( bool selected ) { mSelected = selected; }
+
+    bool generalizedByBoundingBox() const { return mGeneralizedByBoundingBox; }
+    void setGeneralizedByBoundingBox( bool generalizedByBoundingBox ) { mGeneralizedByBoundingBox = generalizedByBoundingBox; }
 
     //! @note added in 1.5
     int renderHints() const { return mRenderHints; }
@@ -192,6 +196,7 @@ class CORE_EXPORT QgsSymbolV2RenderContext
     QgsSymbolV2::OutputUnit mOutputUnit;
     qreal mAlpha;
     bool mSelected;
+	bool mGeneralizedByBoundingBox; 
     int mRenderHints;
     const QgsFeature* mFeature; //current feature
     const QgsVectorLayer* mLayer; //current vectorlayer
@@ -244,7 +249,7 @@ class CORE_EXPORT QgsLineSymbolV2 : public QgsSymbolV2
     void setWidth( double width );
     double width();
 
-    void renderPolyline( const QPolygonF& points, const QgsFeature* f, QgsRenderContext& context, int layer = -1, bool selected = false );
+    void renderPolyline( const QPolygonF& points, const QgsFeature* f, QgsRenderContext& context, int layer = -1, bool selected = false, bool generalizedByBoundingBox = false );
 
     virtual QgsSymbolV2* clone() const;
 };
@@ -262,7 +267,7 @@ class CORE_EXPORT QgsFillSymbolV2 : public QgsSymbolV2
 
     QgsFillSymbolV2( QgsSymbolLayerV2List layers = QgsSymbolLayerV2List() );
     void setAngle( double angle );
-    void renderPolygon( const QPolygonF& points, QList<QPolygonF>* rings, const QgsFeature* f, QgsRenderContext& context, int layer = -1, bool selected = false );
+    void renderPolygon( const QPolygonF& points, QList<QPolygonF>* rings, const QgsFeature* f, QgsRenderContext& context, int layer = -1, bool selected = false, bool generalizedByBoundingBox = false );
 
     virtual QgsSymbolV2* clone() const;
 };

--- a/src/core/symbology-ng/qgssymbolv2.h
+++ b/src/core/symbology-ng/qgssymbolv2.h
@@ -196,7 +196,7 @@ class CORE_EXPORT QgsSymbolV2RenderContext
     QgsSymbolV2::OutputUnit mOutputUnit;
     qreal mAlpha;
     bool mSelected;
-	bool mGeneralizedByBoundingBox; 
+    bool mGeneralizedByBoundingBox; 
     int mRenderHints;
     const QgsFeature* mFeature; //current feature
     const QgsVectorLayer* mLayer; //current vectorlayer

--- a/src/providers/ogr/qgsogrfeatureiterator.cpp
+++ b/src/providers/ogr/qgsogrfeatureiterator.cpp
@@ -70,12 +70,7 @@ QgsOgrFeatureIterator::QgsOgrFeatureIterator( QgsOgrProvider* p, const QgsFeatur
 
     OGR_G_CreateFromWkt(( char ** )&wktText, NULL, &filter );
     QgsDebugMsg( "Setting spatial filter using " + wktExtent );
-
-	// Checks whether is really needed filter by rect. 
-	OGREnvelope extent;
-	OGR_L_GetExtent(ogrLayer, &extent, true);
-	QgsRectangle layerRect(extent.MinX, extent.MinY, extent.MaxX, extent.MaxY);
-	if (!mRequest.filterRect().contains(layerRect)) OGR_L_SetSpatialFilter( ogrLayer, filter );
+    OGR_L_SetSpatialFilter( ogrLayer, filter );
     OGR_G_DestroyGeometry( filter );
   }
   else

--- a/src/providers/ogr/qgsogrfeatureiterator.cpp
+++ b/src/providers/ogr/qgsogrfeatureiterator.cpp
@@ -70,7 +70,12 @@ QgsOgrFeatureIterator::QgsOgrFeatureIterator( QgsOgrProvider* p, const QgsFeatur
 
     OGR_G_CreateFromWkt(( char ** )&wktText, NULL, &filter );
     QgsDebugMsg( "Setting spatial filter using " + wktExtent );
-    OGR_L_SetSpatialFilter( ogrLayer, filter );
+
+	// Checks whether is really needed filter by rect. 
+	OGREnvelope extent;
+	OGR_L_GetExtent(ogrLayer, &extent, true);
+	QgsRectangle layerRect(extent.MinX, extent.MinY, extent.MaxX, extent.MaxY);
+	if (!mRequest.filterRect().contains(layerRect)) OGR_L_SetSpatialFilter( ogrLayer, filter );
     OGR_G_DestroyGeometry( filter );
   }
   else


### PR DESCRIPTION
Implements fast rendering of LineStrings and Polygons pre-applying a view threshold filter to the geometries to render in qgis. 

Also disable 'Antialiasing' when it is possible.

View Table of test results in 'http://hub.qgis.org/issues/8725'
