### PR TITLE
Panning controls and shortcuts for composer

### DIFF
--- a/src/app/composer/qgscomposer.cpp
+++ b/src/app/composer/qgscomposer.cpp
@@ -144,6 +144,7 @@ QgsComposer::QgsComposer( QgisApp *qgis, const QString& title )
 
   QActionGroup* toggleActionGroup = new QActionGroup( this );
   toggleActionGroup->addAction( mActionMoveItemContent );
+  toggleActionGroup->addAction( mActionPan );
   toggleActionGroup->addAction( mActionAddNewMap );
   toggleActionGroup->addAction( mActionAddNewLabel );
   toggleActionGroup->addAction( mActionAddNewLegend );
@@ -166,6 +167,7 @@ QgsComposer::QgsComposer( QgisApp *qgis, const QString& title )
   mActionAddNewScalebar->setCheckable( true );
   mActionAddImage->setCheckable( true );
   mActionMoveItemContent->setCheckable( true );
+  mActionPan->setCheckable( true );
   mActionAddArrow->setCheckable( true );
 
 #ifdef Q_WS_MAC
@@ -1670,6 +1672,14 @@ void QgsComposer::on_mActionMoveItemContent_triggered()
   if ( mView )
   {
     mView->setCurrentTool( QgsComposerView::MoveItemContent );
+  }
+}
+
+void QgsComposer::on_mActionPan_triggered()
+{
+  if ( mView )
+  {
+    mView->setCurrentTool( QgsComposerView::Pan );
   }
 }
 

--- a/src/app/composer/qgscomposer.h
+++ b/src/app/composer/qgscomposer.h
@@ -204,6 +204,9 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
     //! Set tool to move item content
     void on_mActionMoveItemContent_triggered();
 
+    //! Set tool to move item content
+    void on_mActionPan_triggered();
+
     //! Group selected items
     void on_mActionGroupItems_triggered();
 
@@ -242,7 +245,7 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
 
     //! Select next item below
     void on_mActionSelectNextAbove_triggered();
-    
+
     //! Select next item above
     void on_mActionSelectNextBelow_triggered();
 

--- a/src/core/composer/qgscomposermousehandles.h
+++ b/src/core/composer/qgscomposermousehandles.h
@@ -22,6 +22,7 @@
 
 class QgsComposition;
 class QgsComposerItem;
+class QGraphicsView;
 
 /** \ingroup MapComposer
  * Handles drawing of selection outlines and mouse handles. Responsible for mouse
@@ -84,6 +85,7 @@ class CORE_EXPORT QgsComposerMouseHandles: public QObject, public QGraphicsRectI
     void mouseReleaseEvent( QGraphicsSceneMouseEvent* event );
     void mousePressEvent( QGraphicsSceneMouseEvent* event );
     void hoverMoveEvent( QGraphicsSceneHoverEvent * event );
+    void hoverLeaveEvent( QGraphicsSceneHoverEvent * event );
 
   public slots:
 
@@ -96,6 +98,7 @@ class CORE_EXPORT QgsComposerMouseHandles: public QObject, public QGraphicsRectI
   private:
 
     QgsComposition* mComposition; //reference to composition
+    QGraphicsView* mGraphicsView; //reference to QGraphicsView
 
     QgsComposerMouseHandles::MouseAction mCurrentMouseMoveAction;
     /**Start point of the last mouse move action (in scene coordinates)*/
@@ -131,7 +134,7 @@ class CORE_EXPORT QgsComposerMouseHandles: public QObject, public QGraphicsRectI
 
     /**Returns the current (zoom level dependent) tolerance to decide if mouse position is close enough to the
     item border for resizing*/
-    double rectHandlerBorderTolerance() const;
+    double rectHandlerBorderTolerance();
 
     /**Finds out the appropriate cursor for the current mouse position in the widget (e.g. move in the middle, resize at border)*/
     Qt::CursorShape cursorForPosition( const QPointF& itemCoordPos );
@@ -169,6 +172,11 @@ class CORE_EXPORT QgsComposerMouseHandles: public QObject, public QGraphicsRectI
     bool nearestItem( const QMap< double, const QgsComposerItem* >& coords, double value, double& nearestValue ) const;
     void checkNearestItem( double checkCoord, const QMap< double, const QgsComposerItem* >& alignCoords, double& smallestDiff, double itemCoordOffset, double& itemCoord, double& alignCoord ) const;
 
+    //tries to return the current QGraphicsView attached to the composition
+    QGraphicsView* graphicsView();
+
+    //sets the mouse cursor for the QGraphicsView attached to the composition (workaround qt bug #3732)
+    void setViewportCursor( Qt::CursorShape cursor );
 };
 
 #endif // QGSCOMPOSERMOUSEHANDLES_H

--- a/src/core/composer/qgscomposition.cpp
+++ b/src/core/composer/qgscomposition.cpp
@@ -69,6 +69,7 @@ QgsComposition::QgsComposition( QgsMapRenderer* mapRenderer )
     , mActiveItemCommand( 0 )
     , mActiveMultiFrameCommand( 0 )
     , mAtlasComposition( this )
+    , mPreventCursorChange( false )
 {
   setBackgroundBrush( Qt::gray );
   addPaperItem();
@@ -104,7 +105,8 @@ QgsComposition::QgsComposition()
     mSelectionHandles( 0 ),
     mActiveItemCommand( 0 ),
     mActiveMultiFrameCommand( 0 ),
-    mAtlasComposition( this )
+    mAtlasComposition( this ),
+    mPreventCursorChange( false )
 {
   loadSettings();
 

--- a/src/core/composer/qgscomposition.h
+++ b/src/core/composer/qgscomposition.h
@@ -351,6 +351,10 @@ class CORE_EXPORT QgsComposition : public QGraphicsScene
     /**Convenience function to create a QgsAddRemoveItemCommand, connect its signals and push it to the undo stack*/
     void pushAddRemoveCommand( QgsComposerItem* item, const QString& text, QgsAddRemoveItemCommand::State state = QgsAddRemoveItemCommand::Added );
 
+    /**If true, prevents any mouse cursor changes by the composition or by any composer items
+      Used by QgsComposer and QgsComposerView to prevent unwanted cursor changes*/
+    void setPreventCursorChange( bool preventChange ) { mPreventCursorChange = preventChange; };
+    bool preventCursorChange() { return mPreventCursorChange; };
 
     //printing
 
@@ -461,6 +465,8 @@ class CORE_EXPORT QgsComposition : public QGraphicsScene
     void deleteAndRemoveMultiFrames();
 
     static QString encodeStringForXML( const QString& str );
+
+    bool mPreventCursorChange;
 
   signals:
     void paperSizeChanged();

--- a/src/gui/qgscomposerview.cpp
+++ b/src/gui/qgscomposerview.cpp
@@ -812,6 +812,26 @@ void QgsComposerView::keyPressEvent( QKeyEvent * e )
     return;
   }
 
+  if ( mPanning )
+    return;
+
+  if ( e->key() == Qt::Key_Space )
+  {
+    // Pan composer with space bar
+    if ( ! e->isAutoRepeat() )
+    {
+      mPanning = true;
+      mMouseLastXY = mMouseCurrentXY;
+      if ( composition() )
+      {
+        //prevent cursor changes while panning
+        composition()->setPreventCursorChange( true );
+      }
+      viewport()->setCursor( Qt::ClosedHandCursor );
+    }
+    return;
+  }
+
   QList<QgsComposerItem*> composerItemList = composition()->selectedComposerItems();
   QList<QgsComposerItem*>::iterator itemIt = composerItemList.begin();
 
@@ -858,6 +878,31 @@ void QgsComposerView::keyPressEvent( QKeyEvent * e )
       ( *itemIt )->move( 0.0, -1 * increment );
       ( *itemIt )->endCommand();
     }
+  }
+}
+
+void QgsComposerView::keyReleaseEvent( QKeyEvent * e )
+{
+  if ( e->key() == Qt::Key_Space && !e->isAutoRepeat() && mPanning )
+  {
+    //end of panning with space key
+    mPanning = false;
+
+    //reset cursor
+    if ( mCurrentTool == Pan )
+    {
+      viewport()->setCursor( Qt::OpenHandCursor );
+    }
+    else
+    {
+      if ( composition() )
+      {
+        //allow cursor changes again
+        composition()->setPreventCursorChange( false );
+      }
+      viewport()->setCursor( Qt::ArrowCursor );
+    }
+    return;
   }
 }
 

--- a/src/gui/qgscomposerview.cpp
+++ b/src/gui/qgscomposerview.cpp
@@ -105,6 +105,19 @@ void QgsComposerView::mousePressEvent( QMouseEvent* e )
     }
     return;
   }
+  else if ( e->button() == Qt::MidButton )
+  {
+    //pan composer with middle button
+    mPanning = true;
+    mMouseLastXY = e->pos();
+    if ( composition() )
+    {
+      //lock cursor to closed hand cursor
+      composition()->setPreventCursorChange( true );
+    }
+    viewport()->setCursor( Qt::ClosedHandCursor );
+    return;
+  }
 
   switch ( mCurrentTool )
   {

--- a/src/gui/qgscomposerview.h
+++ b/src/gui/qgscomposerview.h
@@ -135,6 +135,7 @@ class GUI_EXPORT QgsComposerView: public QGraphicsView
     void mouseDoubleClickEvent( QMouseEvent* e );
 
     void keyPressEvent( QKeyEvent * e );
+    void keyReleaseEvent( QKeyEvent * e );
 
     void wheelEvent( QWheelEvent* event );
 

--- a/src/gui/qgscomposerview.h
+++ b/src/gui/qgscomposerview.h
@@ -65,7 +65,8 @@ class GUI_EXPORT QgsComposerView: public QGraphicsView
       AddEllipse,
       AddTriangle,
       AddTable, //add attribute table
-      MoveItemContent //move content of item (e.g. content of map)
+      MoveItemContent, //move content of item (e.g. content of map)
+      Pan
     };
 
     enum ClipboardMode
@@ -108,7 +109,7 @@ class GUI_EXPORT QgsComposerView: public QGraphicsView
     void selectInvert();
 
     QgsComposerView::Tool currentTool() const {return mCurrentTool;}
-    void setCurrentTool( QgsComposerView::Tool t ) {mCurrentTool = t;}
+    void setCurrentTool( QgsComposerView::Tool t );
 
     /**Sets composition (derived from QGraphicsScene)*/
     void setComposition( QgsComposition* c );
@@ -166,6 +167,10 @@ class GUI_EXPORT QgsComposerView: public QGraphicsView
 
     /** Draw a shape on the canvas */
     void addShape( Tool currentTool );
+
+    bool mPanning;
+    QPoint mMouseLastXY;
+    QPoint mMouseCurrentXY;
 
     //void connectAddRemoveCommandSignals( QgsAddRemoveItemCommand* c );
 

--- a/src/ui/qgscomposerbase.ui
+++ b/src/ui/qgscomposerbase.ui
@@ -96,6 +96,7 @@
    <attribute name="toolBarBreak">
     <bool>true</bool>
    </attribute>
+   <addaction name="mActionPan"/>
    <addaction name="mActionSelectMoveItem"/>
    <addaction name="mActionMoveItemContent"/>
    <addaction name="mActionGroupItems"/>
@@ -673,6 +674,15 @@
     <string>Ctrl+Alt+]</string>
    </property>
   </action>  
+  <action name="mActionPan">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionPan.svg</normaloff>:/images/themes/default/mActionPan.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Pan Composer</string>
+   </property>
+  </action>     
  </widget>
  <resources>
   <include location="../../images/images.qrc"/>


### PR DESCRIPTION
This pull request improves navigation of compositions by:
- Adding a dedicated "pan" action for dragging around compositions
- Allowing panning compositions by holding and dragging with the middle mouse button
- Allow panning compositions by holding space key

This pull request replaces some earlier (inferior) versions. I'm happy with how this one works, although qt bug #3732 means the code isn't as tidy as it should be.

I'll send through the composer zoom in/out with mouse wheel, and a couple of other improvements to composition zooming as a seperate pull request.
