### PR TITLE
Composer zoom improvements

### DIFF
--- a/src/app/composer/qgscomposer.cpp
+++ b/src/app/composer/qgscomposer.cpp
@@ -242,6 +242,9 @@ QgsComposer::QgsComposer( QgisApp *qgis, const QString& title )
   editMenu->addAction( mActionSelectNextAbove );
 
   QMenu *viewMenu = menuBar()->addMenu( tr( "View" ) );
+  //Ctrl+= should also trigger zoom in
+  QShortcut* ctrlEquals = new QShortcut( QKeySequence( "Ctrl+=" ), this );
+  connect( ctrlEquals, SIGNAL( activated() ), mActionZoomIn, SLOT( trigger() ) );
   viewMenu->addAction( mActionZoomIn );
   viewMenu->addAction( mActionZoomOut );
   viewMenu->addAction( mActionZoomAll );

--- a/src/core/qgsrectangle.cpp
+++ b/src/core/qgsrectangle.cpp
@@ -109,6 +109,11 @@ void QgsRectangle::scale( double scaleFactor, const QgsPoint * cp )
     centerX = xmin + width() / 2;
     centerY = ymin + height() / 2;
   }
+  scale( scaleFactor, centerX, centerY );
+}
+
+void QgsRectangle::scale( double scaleFactor, double centerX, double centerY )
+{
   double newWidth = width() * scaleFactor;
   double newHeight = height() * scaleFactor;
   xmin = centerX - newWidth / 2.0;

--- a/src/core/qgsrectangle.h
+++ b/src/core/qgsrectangle.h
@@ -81,6 +81,7 @@ class CORE_EXPORT QgsRectangle
     QgsPoint center() const;
     //! Scale the rectangle around its center point
     void scale( double scaleFactor, const QgsPoint *c = 0 );
+    void scale( double scaleFactor, double centerX, double centerY );
     //! return the intersection with the given rectangle
     QgsRectangle intersect( const QgsRectangle *rect ) const;
     //! returns true when rectangle intersects with other rectangle

--- a/src/gui/qgscomposerview.h
+++ b/src/gui/qgscomposerview.h
@@ -167,6 +167,9 @@ class GUI_EXPORT QgsComposerView: public QGraphicsView
     /** Draw a shape on the canvas */
     void addShape( Tool currentTool );
 
+    /**Zoom composition from a mouse wheel event*/
+    void wheelZoom( QWheelEvent * event );
+
     //void connectAddRemoveCommandSignals( QgsAddRemoveItemCommand* c );
 
   signals:

--- a/src/ui/qgscomposerbase.ui
+++ b/src/ui/qgscomposerbase.ui
@@ -148,6 +148,9 @@
    <property name="toolTip">
     <string>Zoom full</string>
    </property>
+   <property name="shortcut">
+    <string>Ctrl+0</string>
+   </property>
   </action>
   <action name="mActionZoomIn">
    <property name="icon">
@@ -160,6 +163,9 @@
    <property name="toolTip">
     <string>Zoom in</string>
    </property>
+   <property name="shortcut">
+    <string>Ctrl++</string>
+   </property>
   </action>
   <action name="mActionZoomOut">
    <property name="icon">
@@ -171,6 +177,9 @@
    </property>
    <property name="toolTip">
     <string>Zoom out</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+-</string>
    </property>
   </action>
   <action name="mActionAddNewMap">
@@ -302,6 +311,9 @@
    <property name="toolTip">
     <string>Group items</string>
    </property>
+   <property name="shortcut">
+    <string>Ctrl+G</string>
+   </property>
   </action>
   <action name="mActionUngroupItems">
    <property name="text">
@@ -309,6 +321,9 @@
    </property>
    <property name="toolTip">
     <string>Ungroup items</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+G</string>
    </property>
   </action>
   <action name="mActionRaiseItems">
@@ -453,7 +468,7 @@
   </action>
   <action name="mActionUndo">
    <property name="icon">
-    <iconset resource="../../images/images.qrc">
+    <iconset>
      <normalon>:/images/themes/default/mActionUndo.png</normalon>
     </iconset>
    </property>
@@ -672,7 +687,7 @@
    <property name="shortcut">
     <string>Ctrl+Alt+]</string>
    </property>
-  </action>  
+  </action>
  </widget>
  <resources>
   <include location="../../images/images.qrc"/>


### PR DESCRIPTION
Here's a refined version for zooming compositions using the mouse wheel. This one respects the current mouse wheel zoom factor and method (zoom, zoom and recenter, etc). 

Also adds a keyboard shortcut for composer zoom in/out and group/ungroup.
