### PR TITLE
[FEATURE] Marquee select for composer items

### DIFF
--- a/src/gui/qgscomposerview.h
+++ b/src/gui/qgscomposerview.h
@@ -159,6 +159,9 @@ class GUI_EXPORT QgsComposerView: public QGraphicsView
     /**Start of rubber band creation*/
     QPointF mRubberBandStartPos;
 
+    /**True if user is currently selecting by marquee*/
+    bool mMarqueeSelect;
+
     bool mPaintingEnabled;
 
     QgsComposerRuler* mHorizontalRuler;
@@ -166,6 +169,16 @@ class GUI_EXPORT QgsComposerView: public QGraphicsView
 
     /** Draw a shape on the canvas */
     void addShape( Tool currentTool );
+
+    /**Redraws the rubber band*/
+    void updateRubberBand( QPointF & pos );
+    /**Removes the rubber band and cleans up*/
+    void removeRubberBand();
+
+    /**Starts a marquee selection*/
+    void startMarqueeSelect( QPointF & scenePoint );
+    /**Finalises a marquee selection*/
+    void endMarqueeSelect( QMouseEvent* e );
 
     //void connectAddRemoveCommandSignals( QgsAddRemoveItemCommand* c );
 


### PR DESCRIPTION
Allows for marquee selection of composer items using the mouse

Holding shift adds to a selection, control subtracts from a selection, and holding alt can be used to switch to "contains" rather then "intersects" selection mode.
