### PR TITLE
[processing] Spaces need to be escaped when passing parameters in GRASS

### DIFF
--- a/python/plugins/processing/grass/GrassAlgorithm.py
+++ b/python/plugins/processing/grass/GrassAlgorithm.py
@@ -335,7 +335,7 @@ class GrassAlgorithm(GeoAlgorithm):
             elif isinstance(param, ParameterString):
                 command += ' ' + param.name + '="' + str(param.value) + '"'
             else:
-                command += ' ' + param.name + '=' + str(param.value)
+                command += ' ' + param.name + '="' + str(param.value) + '"'
 
         uniqueSufix = str(uuid.uuid4()).replace('-', '')
         for out in self.outputs:

--- a/python/plugins/processing/grass/description/r.horizon.height.txt
+++ b/python/plugins/processing/grass/description/r.horizon.height.txt
@@ -1,9 +1,9 @@
 r.horizon
-r.horizon - Horizon angle computation from a digital elevation model.
+r.horizon.height - Horizon angle computation from a digital elevation model.
 Raster (r.*)
 ParameterRaster|elevin|Elevation layer [meters]|False
-ParameterNumber|direction|Direction in which you want to know the horizon height|0|360|0.0
+ParameterString|coord|Coordinate for which you want to calculate the horizon|0,0
+ParameterNumber|horizonstep|Angle step size for multidirectional horizon [degrees]|0|360|0.0
 ParameterNumber|maxdistance|The maximum distance to consider when finding the horizon height|0|None|10000
 ParameterString|dist|Sampling distance step coefficient (0.5-1.5)|1.0
 ParameterBoolean|-d|Write output in degrees (default is radians)|False
-OutputRaster|horizon|Horizon angle computation


### PR DESCRIPTION
Otherwise the module will fail (ex: r.reclass)
