### PR TITLE
[processing] fixes SAGA raster import/export

### DIFF
--- a/python/plugins/processing/grass/GrassAlgorithm.py
+++ b/python/plugins/processing/grass/GrassAlgorithm.py
@@ -335,7 +335,7 @@ class GrassAlgorithm(GeoAlgorithm):
             elif isinstance(param, ParameterString):
                 command += ' ' + param.name + '="' + str(param.value) + '"'
             else:
-                command += ' ' + param.name + '=' + str(param.value)
+                command += ' ' + param.name + '="' + str(param.value) + '"'
 
         uniqueSufix = str(uuid.uuid4()).replace('-', '')
         for out in self.outputs:

--- a/python/plugins/processing/grass/description/r.horizon.height.txt
+++ b/python/plugins/processing/grass/description/r.horizon.height.txt
@@ -1,9 +1,9 @@
 r.horizon
-r.horizon - Horizon angle computation from a digital elevation model.
+r.horizon.height - Horizon angle computation from a digital elevation model.
 Raster (r.*)
 ParameterRaster|elevin|Elevation layer [meters]|False
-ParameterNumber|direction|Direction in which you want to know the horizon height|0|360|0.0
+ParameterString|coord|Coordinate for which you want to calculate the horizon|0,0
+ParameterNumber|horizonstep|Angle step size for multidirectional horizon [degrees]|0|360|0.0
 ParameterNumber|maxdistance|The maximum distance to consider when finding the horizon height|0|None|10000
 ParameterString|dist|Sampling distance step coefficient (0.5-1.5)|1.0
 ParameterBoolean|-d|Write output in degrees (default is radians)|False
-OutputRaster|horizon|Horizon angle computation

--- a/python/plugins/processing/grass/description/r.kappa.txt
+++ b/python/plugins/processing/grass/description/r.kappa.txt
@@ -3,7 +3,7 @@ r.kappa - Calculate error matrix and kappa parameter for accuracy assessment of 
 Raster (r.*)
 ParameterRaster|classification|Raster layer containing classification result|False
 ParameterRaster|reference|Raster layer containing reference classes|False
-ParameterString|title|Title for error matrix and kappa|"ACCURACY ASSESSMENT"
+ParameterString|title|Title for error matrix and kappa|ACCURACY ASSESSMENT
 ParameterBoolean|-h|No header in the report|False
 ParameterBoolean|-w|Wide report (132 columns)|False
 OutputFile|output|Output file containing error matrix and kappa

--- a/python/plugins/processing/saga/SagaAlgorithm.py
+++ b/python/plugins/processing/saga/SagaAlgorithm.py
@@ -359,16 +359,24 @@ class SagaAlgorithm(GeoAlgorithm):
                     if dontExport:
                         continue
 
-                transform = ('' if saga208 else '-TRANSFORM')
-                if isWindows() or isMac() or not saga208:
-                    commands.append('io_gdal 1 -GRIDS "' + filename2
-                                    + '" -FORMAT ' + str(formatIndex)
-                                    + ' -TYPE 0 -FILE "' + filename + '"'
-                                    + transform)
+                if self.cmdname == 'RGB Composite':
+	                if isWindows() or isMac() or not saga208:
+   	        		commands.append('io_grid_image 0 -IS_RGB -GRID:"' + filename2
+                                	+ '" -FILE:"' + filename
+                                	+ '"')
+                	else:
+   	        		commands.append('libio_grid_image 0 -IS_RGB -GRID:"' + filename2
+                                	+ '" -FILE:"' + filename
+                                	+ '"')
                 else:
-                    commands.append('libio_gdal 1 -GRIDS "' + filename2
-                                    + '" -FORMAT 1 -TYPE 0 -FILE "' + filename
-                                    + '"' + transform)
+	                if isWindows() or isMac() or not saga208:
+	                    commands.append('io_gdal 1 -GRIDS "' + filename2
+	                                    + '" -FORMAT ' + str(formatIndex)
+	                                    + ' -TYPE 0 -FILE "' + filename + '"')
+	                else:
+	                    commands.append('libio_gdal 1 -GRIDS "' + filename2
+	                                    + '" -FORMAT 1 -TYPE 0 -FILE "' + filename
+	                                    + '"')
 
         # 4: Run SAGA
         commands = self.editCommands(commands)
@@ -463,7 +471,7 @@ class SagaAlgorithm(GeoAlgorithm):
         sessionExportedLayers[source] = destFilename
         saga208 = ProcessingConfig.getSetting(SagaUtils.SAGA_208)
         if isWindows() or isMac() or not saga208:
-            return 'io_gdal 0 -GRIDS "' + destFilename + '" -FILES "' + source \
+            return 'io_gdal 0 -TRANSFORM -INTERPOL 0 -GRIDS "' + destFilename + '" -FILES "' + source \
                 + '"'
         else:
             return 'libio_gdal 0 -GRIDS "' + destFilename + '" -FILES "' \


### PR DESCRIPTION
The parameter "-TRANSFORM" that was added in 1d754d9 (because now is mandatory in SAGA 2.10) was added in the command that exports the SAGA grid into a TIFF, but actually had to be added in the SAGA command that imports a tiff into a SAGA grid. It was anyway missing a space and the process was failing (with the missing space it would have failed too, because the parameter would not have been recognized). In the commit I also propose to use the "-INTERPOL 0" parameter, to import the rasters into SAGA grids using a NN interpolation instead of the B-Spline used by default by SAGA 2.10.

SAGA raster export was also modified in order to allow the "RGB composite" module create the right output.
