### PR TITLE
[processing] fixes SAGA import and export rasters

### DIFF
--- a/python/plugins/processing/saga/SagaAlgorithm.py
+++ b/python/plugins/processing/saga/SagaAlgorithm.py
@@ -470,12 +470,16 @@ class SagaAlgorithm(GeoAlgorithm):
         self.exportedLayers[source] = destFilename
         sessionExportedLayers[source] = destFilename
         saga208 = ProcessingConfig.getSetting(SagaUtils.SAGA_208)
-        if isWindows() or isMac() or not saga208:
+        if saga208:
+			if isWindows() or isMac():
+				return 'io_gdal 0 -GRIDS "' + destFilename + '" -FILES "' + source \
+					+ '"'
+			else:
+				return 'libio_gdal 0 -GRIDS "' + destFilename + '" -FILES "' \
+					+ source + '"'
+        else:
             return 'io_gdal 0 -TRANSFORM -INTERPOL 0 -GRIDS "' + destFilename + '" -FILES "' + source \
                 + '"'
-        else:
-            return 'libio_gdal 0 -GRIDS "' + destFilename + '" -FILES "' \
-                + source + '"'
 
     def checkBeforeOpeningParametersDialog(self):
         msg = SagaUtils.checkSagaIsInstalled()

--- a/python/plugins/processing/saga/SagaAlgorithm.py
+++ b/python/plugins/processing/saga/SagaAlgorithm.py
@@ -359,16 +359,24 @@ class SagaAlgorithm(GeoAlgorithm):
                     if dontExport:
                         continue
 
-                transform = ('' if saga208 else '-TRANSFORM')
-                if isWindows() or isMac() or not saga208:
-                    commands.append('io_gdal 1 -GRIDS "' + filename2
-                                    + '" -FORMAT ' + str(formatIndex)
-                                    + ' -TYPE 0 -FILE "' + filename + '"'
-                                    + transform)
+                if self.cmdname == 'RGB Composite':
+	                if isWindows() or isMac() or not saga208:
+   	        		commands.append('io_grid_image 0 -IS_RGB -GRID:"' + filename2
+                                	+ '" -FILE:"' + filename
+                                	+ '"')
+                	else:
+   	        		commands.append('libio_grid_image 0 -IS_RGB -GRID:"' + filename2
+                                	+ '" -FILE:"' + filename
+                                	+ '"')
                 else:
-                    commands.append('libio_gdal 1 -GRIDS "' + filename2
-                                    + '" -FORMAT 1 -TYPE 0 -FILE "' + filename
-                                    + '"' + transform)
+	                if isWindows() or isMac() or not saga208:
+	                    commands.append('io_gdal 1 -GRIDS "' + filename2
+	                                    + '" -FORMAT ' + str(formatIndex)
+	                                    + ' -TYPE 0 -FILE "' + filename + '"')
+	                else:
+	                    commands.append('libio_gdal 1 -GRIDS "' + filename2
+	                                    + '" -FORMAT 1 -TYPE 0 -FILE "' + filename
+	                                    + '"')
 
         # 4: Run SAGA
         commands = self.editCommands(commands)
@@ -463,7 +471,7 @@ class SagaAlgorithm(GeoAlgorithm):
         sessionExportedLayers[source] = destFilename
         saga208 = ProcessingConfig.getSetting(SagaUtils.SAGA_208)
         if isWindows() or isMac() or not saga208:
-            return 'io_gdal 0 -GRIDS "' + destFilename + '" -FILES "' + source \
+            return 'io_gdal 0 -TRANSFORM -INTERPOL 0 -GRIDS "' + destFilename + '" -FILES "' + source \
                 + '"'
         else:
             return 'libio_gdal 0 -GRIDS "' + destFilename + '" -FILES "' \


### PR DESCRIPTION
The parameter "-TRANSFORM" that was added in 1d754d9 (because now is mandatory in SAGA 2.10) was added in the command that exports the SAGA grid into a TIFF, but actually had to be added in the SAGA command that imports a tiff into a SAGA grid. It was anyway missing a space and the process was failing (with the missing space it would have failed too, because the parameter would not have been recognized). In the commit I also propose to use the "-INTERPOL 0" parameter, to import the rasters into SAGA grids using a NN interpolation instead of the B-Spline used by default by SAGA 2.10.
