### PR TITLE
[processing] adds v.select

### DIFF
--- a/python/plugins/processing/grass/description/v.select.txt
+++ b/python/plugins/processing/grass/description/v.select.txt
@@ -1,0 +1,10 @@
+v.select
+v.select - Selects features from vector map (A) by features from other vector map (B).
+Vector (v.*)
+ParameterVector|ainput|Input layer (A)|-1|False
+ParameterSelection|atype|Input layer (A) Type|area;line;point
+ParameterVector|binput|Input layer (B)|-1|False
+ParameterSelection|btype|Input layer (B) Type|area;line;point
+ParameterSelection|operator|Operator to use|overlap;equals;disjoint;intersect;touches;crosses;within;contains;relate
+ParameterBoolean|-r|Reverse selection|False
+OutputVector|output|Name for output vector map


### PR DESCRIPTION
Because under Linux (debian) GRASS seems that is not compiled with GEOS, the only working operator will be "overlap", but under Windows all the operators will work.

See http://osgeo-org.1560.x6.nabble.com/v-select-query-and-GEOS-error-td5036311.html
