### PR TITLE
[processing] fixes ticket #8814

### DIFF
--- a/python/plugins/processing/grass/GrassAlgorithm.py
+++ b/python/plugins/processing/grass/GrassAlgorithm.py
@@ -381,7 +381,7 @@ class GrassAlgorithm(GeoAlgorithm):
 
             if isinstance(out, OutputVector):
                 filename = out.value
-                command = 'v.out.ogr -c -e -z input=' + out.name + uniqueSufix
+                command = 'v.out.ogr -s -c -e -z input=' + out.name + uniqueSufix
                 command += ' dsn="' + os.path.dirname(out.value) + '"'
                 command += ' format=ESRI_Shapefile'
                 command += ' olayer=' + os.path.basename(out.value)[:-4]

--- a/python/plugins/processing/grass/description/v.delaunay.txt
+++ b/python/plugins/processing/grass/description/v.delaunay.txt
@@ -3,6 +3,5 @@ v.delaunay - Creates a Delaunay triangulation from an input vector map containin
 Vector (v.*)
 ParameterVector|input|Input vector layer|0|False
 ParameterBoolean|-r|Use only points in current region|True
-ParameterBoolean|-l|Output triangulation as a graph (lines), not areas|True
 OutputVector|output|Delaunay triangulation
 


### PR DESCRIPTION
The option to create the v.delaunay output as line must be removed because of the "-c" switch in processing v.out.ogr.
