### PR TITLE
allow to use custom QSettings for managing QgsOptionsDialog parameters

### DIFF
--- a/python/gui/qgsoptionsdialogbase.sip
+++ b/python/gui/qgsoptionsdialogbase.sip
@@ -17,6 +17,9 @@ class QgsOptionsDialogBase : QDialog
      */
     void initOptionsBase( bool restoreUi = true );
 
+    // set custom QSettings pointer if dialog used outside QGIS (in plugin)
+    void setSettings( QSettings* settings );
+
     /** Restore the base ui.
      * Sometimes useful to do at end of subclass's constructor.
      */

--- a/src/gui/qgsoptionsdialogbase.cpp
+++ b/src/gui/qgsoptionsdialogbase.cpp
@@ -37,7 +37,6 @@ QgsOptionsDialogBase::~QgsOptionsDialogBase()
 {
   if ( mInit )
   {
-    QSettings settings;
     mSettings->setValue( QString( "/Windows/%1/geometry" ).arg( mOptsKey ), saveGeometry() );
     mSettings->setValue( QString( "/Windows/%1/splitState" ).arg( mOptsKey ), mOptSplitter->saveState() );
     mSettings->setValue( QString( "/Windows/%1/tab" ).arg( mOptsKey ), mOptStackedWidget->currentIndex() );

--- a/src/gui/qgsoptionsdialogbase.h
+++ b/src/gui/qgsoptionsdialogbase.h
@@ -20,6 +20,8 @@
 #include "qgisgui.h"
 
 #include <QDialog>
+#include <QPointer>
+#include <QSettings>
 
 class QDialogButtonBox;
 class QListWidget;
@@ -54,13 +56,16 @@ class GUI_EXPORT QgsOptionsDialogBase : public QDialog
      * @param parent parent object (owner)
      * @param fl widget flags
      */
-    QgsOptionsDialogBase( QString settingsKey, QWidget* parent = 0, Qt::WFlags fl = 0 );
+    QgsOptionsDialogBase( QString settingsKey, QWidget* parent = 0, Qt::WFlags fl = 0, QSettings* settings = 0 );
     ~QgsOptionsDialogBase();
 
     /** Set up the base ui connections for vertical tabs.
      * @param restoreUi Whether to restore the base ui at this time.
      */
     void initOptionsBase( bool restoreUi = true );
+
+    // set custom QSettings pointer if dialog used outside QGIS (in plugin)
+    void setSettings( QSettings* settings );
 
     /** Restore the base ui.
      * Sometimes useful to do at end of subclass's constructor.
@@ -76,6 +81,11 @@ class GUI_EXPORT QgsOptionsDialogBase : public QDialog
   protected:
     void showEvent( QShowEvent* e );
     void paintEvent( QPaintEvent* e );
+
+    // pointer to app or custom, external QSettings
+    // QPointer in case custom settings obj gets deleted while dialog is open
+    QPointer<QSettings> mSettings;
+    bool mDelSettings;
 
     QString mOptsKey;
     bool mInit;


### PR DESCRIPTION
Currently QgsOptionsDialog can save its state only into main QGIS setting. This is not good when dialog used in plugin and/or standalone application.

This patch adds method setSettings() that allow to specify custom QSettings instance for saving dialog state. We already have similar functionality in QgsCollapsibleGroupBox.
