### PR TITLE
Added disclaimer to WMS TileRetry feature - Development funded from Regione Toscana - SITA

### DIFF
--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -251,6 +251,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WFlags fl ) :
   // WMS/WMS-C tile expiry time
   mDefaultTileExpirySpinBox->setValue( settings.value( "/qgis/defaultTileExpiry", "24" ).toInt() );
 
+  // Feature funded by Regione Toscana - SITA
   // WMS/WMS-C default max retry in case of tile request errors
   mDefaultTileMaxRetrySpinBox->setValue( settings.value( "/qgis/defaultTileMaxRetry", "3" ).toInt() );
 
@@ -902,6 +903,7 @@ void QgsOptions::saveOptions()
   // WMS/WMS-C tile expiry time
   settings.setValue( "/qgis/defaultTileExpiry", mDefaultTileExpirySpinBox->value() );
 
+  // Feature funded by Regione Toscana - SITA
   // WMS/WMS-C default max retry in case of tile request errors
   settings.setValue( "/qgis/defaultTileMaxRetry", mDefaultTileMaxRetrySpinBox->value() );
 

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -843,7 +843,6 @@ QImage *QgsWmsProvider::draw( QgsRectangle  const &viewExtent, int pixelWidth, i
         }
 
         int i = 0;
-        int retry = 0;
         for ( int row = row0; row <= row1; row++ )
         {
           for ( int col = col0; col <= col1; col++ )
@@ -865,6 +864,7 @@ QImage *QgsWmsProvider::draw( QgsRectangle  const &viewExtent, int pixelWidth, i
             request.setAttribute( static_cast<QNetworkRequest::Attribute>( QNetworkRequest::User + 1 ), i );
             request.setAttribute( static_cast<QNetworkRequest::Attribute>( QNetworkRequest::User + 2 ),
                                   QRectF( tm->topLeft.x() + col * twMap, tm->topLeft.y() - ( row + 1 ) * thMap, twMap, thMap ) );
+            int retry = 0; // just for readability
             request.setAttribute( static_cast<QNetworkRequest::Attribute>( QNetworkRequest::User + 3 ), retry );
 
             QgsDebugMsg( QString( "gettile: %1" ).arg( turl ) );
@@ -902,7 +902,6 @@ QImage *QgsWmsProvider::draw( QgsRectangle  const &viewExtent, int pixelWidth, i
           url.removeQueryItem( "TILECOL" );
 
           int i = 0;
-          int retry = 0;
           for ( int row = row0; row <= row1; row++ )
           {
             for ( int col = col0; col <= col1; col++ )
@@ -920,6 +919,7 @@ QImage *QgsWmsProvider::draw( QgsRectangle  const &viewExtent, int pixelWidth, i
               request.setAttribute( static_cast<QNetworkRequest::Attribute>( QNetworkRequest::User + 1 ), i );
               request.setAttribute( static_cast<QNetworkRequest::Attribute>( QNetworkRequest::User + 2 ),
                                     QRectF( tm->topLeft.x() + col * twMap, tm->topLeft.y() - ( row + 1 ) * thMap, twMap, thMap ) );
+              int retry = 0; // just for readability
               request.setAttribute( static_cast<QNetworkRequest::Attribute>( QNetworkRequest::User + 3 ), retry );
 
               QgsDebugMsg( QString( "gettile: %1" ).arg( turl ) );
@@ -944,7 +944,6 @@ QImage *QgsWmsProvider::draw( QgsRectangle  const &viewExtent, int pixelWidth, i
           }
 
           int i = 0;
-          int retry = 0;
           for ( int row = row0; row <= row1; row++ )
           {
             for ( int col = col0; col <= col1; col++ )
@@ -962,6 +961,7 @@ QImage *QgsWmsProvider::draw( QgsRectangle  const &viewExtent, int pixelWidth, i
               request.setAttribute( static_cast<QNetworkRequest::Attribute>( QNetworkRequest::User + 1 ), i );
               request.setAttribute( static_cast<QNetworkRequest::Attribute>( QNetworkRequest::User + 2 ),
                                     QRectF( tm->topLeft.x() + col * twMap, tm->topLeft.y() - ( row + 1 ) * thMap, twMap, thMap ) );
+              int retry = 0; // just for readability
               request.setAttribute( static_cast<QNetworkRequest::Attribute>( QNetworkRequest::User + 3 ), retry );
 
               QgsDebugMsg( QString( "gettile: %1" ).arg( turl ) );
@@ -1039,6 +1039,7 @@ void QgsWmsProvider::readBlock( int bandNo, QgsRectangle  const & viewExtent, in
   //delete image;
 }
 
+// tile retry management developed with funding from Regione Toscana-SITA
 void QgsWmsProvider::repeatTileRequest( QNetworkRequest const &oldRequest )
 {
   if ( mErrors == 100 )

--- a/src/providers/wms/qgswmsprovider.h
+++ b/src/providers/wms/qgswmsprovider.h
@@ -746,6 +746,8 @@ class QgsWmsProvider : public QgsRasterDataProvider
     /**
      * \brief Relaunch tile request cloning previous request parameters and managing max repeat
      *
+     * \note Development funded by Regione Toscana - SITA
+     *
      * \param oldRequest request to clone to generate new tile request
      *
      * request is not launched if max retry is reached. Message is logged.


### PR DESCRIPTION
as requested by Jürgen Fisher:

add discaliming with comments,
commented use of retry variable that could be avoided but leaved there to better readability 

main code merged with commits:
a563f2a650b13db9a1d7d58983ac2a2f5b87f1bb
3e278110f298bdf9363a936dd296b75b84858e6c
