### PR TITLE
WMS getLegendGraphic management in QgsLegend and QgsComposer - Developed with funding from Regione Toscana-SITA

### DIFF
--- a/src/app/composer/qgscomposerlegendwidget.cpp
+++ b/src/app/composer/qgscomposerlegendwidget.cpp
@@ -168,6 +168,8 @@ void QgsComposerLegendWidget::setGuiElements()
   mEqualColumnWidthCheckBox->setChecked( mLegend->equalColumnWidth() );
   mSymbolWidthSpinBox->setValue( mLegend->symbolWidth() );
   mSymbolHeightSpinBox->setValue( mLegend->symbolHeight() );
+  mWmsLegendWidthSpinBox->setValue( mLegend->wmsLegendWidth() );
+  mWmsLegendHeightSpinBox->setValue( mLegend->wmsLegendHeight() );
   mTitleSpaceBottomSpinBox->setValue( mLegend->style( QgsComposerLegendStyle::Title ).margin( QgsComposerLegendStyle::Bottom ) );
   mGroupSpaceSpinBox->setValue( mLegend->style( QgsComposerLegendStyle::Group ).margin( QgsComposerLegendStyle::Top ) );
   mLayerSpaceSpinBox->setValue( mLegend->style( QgsComposerLegendStyle::Subgroup ).margin( QgsComposerLegendStyle::Top ) );
@@ -274,6 +276,30 @@ void QgsComposerLegendWidget::on_mSymbolHeightSpinBox_valueChanged( double d )
   {
     mLegend->beginCommand( tr( "Legend symbol height" ), QgsComposerMergeCommand::LegendSymbolHeight );
     mLegend->setSymbolHeight( d );
+    mLegend->adjustBoxSize();
+    mLegend->update();
+    mLegend->endCommand();
+  }
+}
+
+void QgsComposerLegendWidget::on_mWmsLegendWidthSpinBox_valueChanged( double d )
+{
+  if ( mLegend )
+  {
+    mLegend->beginCommand( tr( "Wms Legend width" ), QgsComposerMergeCommand::LegendWmsLegendWidth );
+    mLegend->setWmsLegendWidth( d );
+    mLegend->adjustBoxSize();
+    mLegend->update();
+    mLegend->endCommand();
+  }
+}
+
+void QgsComposerLegendWidget::on_mWmsLegendHeightSpinBox_valueChanged( double d )
+{
+  if ( mLegend )
+  {
+    mLegend->beginCommand( tr( "Wms Legend height" ), QgsComposerMergeCommand::LegendWmsLegendHeight );
+    mLegend->setWmsLegendHeight( d );
     mLegend->adjustBoxSize();
     mLegend->update();
     mLegend->endCommand();

--- a/src/app/composer/qgscomposerlegendwidget.h
+++ b/src/app/composer/qgscomposerlegendwidget.h
@@ -59,6 +59,8 @@ class QgsComposerLegendWidget: public QWidget, private Ui::QgsComposerLegendWidg
     void on_mEqualColumnWidthCheckBox_toggled( bool checked );
     void on_mSymbolWidthSpinBox_valueChanged( double d );
     void on_mSymbolHeightSpinBox_valueChanged( double d );
+    void on_mWmsLegendWidthSpinBox_valueChanged( double d );
+    void on_mWmsLegendHeightSpinBox_valueChanged( double d );
     void on_mTitleSpaceBottomSpinBox_valueChanged( double d );
     void on_mGroupSpaceSpinBox_valueChanged( double d );
     void on_mLayerSpaceSpinBox_valueChanged( double d );

--- a/src/app/legend/qgslegend.cpp
+++ b/src/app/legend/qgslegend.cpp
@@ -113,6 +113,8 @@ QgsLegend::QgsLegend( QgsMapCanvas *canvas, QWidget * parent, const char *name )
 
   connect( mMapCanvas, SIGNAL( layersChanged() ),
            this, SLOT( refreshCheckStates() ) );
+  connect( mMapCanvas, SIGNAL( extentsChanged() ),
+           this, SLOT( updateLegendItemSymbologies() ) );
 
   // Initialise the line indicator widget.
   mInsertionLine = new QWidget( viewport() );
@@ -141,6 +143,7 @@ QgsLegend::QgsLegend( QgsMapCanvas *canvas, QWidget * parent, const char *name )
 QgsLegend::~QgsLegend()
 {
   delete mInsertionLine;
+  delete mGetLegendGraphicPopup;
 }
 
 #ifdef QGISDEBUG
@@ -395,6 +398,24 @@ void QgsLegend::mousePressEvent( QMouseEvent * e )
 {
   if ( e->button() == Qt::LeftButton )
   {
+    // show WMS legend in case itemAt( e->pos() ) is a wms legend
+    // if it's not a legend later it return a null pixmap
+    QImage legend = getWmsLegendPixmap( itemAt( e->pos() ) );
+    if ( !legend.isNull() )
+    {
+      mGetLegendGraphicPopup = new QFrame();
+      mGetLegendGraphicPopup->setFrameStyle(QFrame::Box | QFrame::Raised);
+      mGetLegendGraphicPopup->setLineWidth(2);
+      mGetLegendGraphicPopup->setAutoFillBackground(true);
+      QVBoxLayout *layout = new QVBoxLayout;
+      QLabel *label = new QLabel(mGetLegendGraphicPopup);
+      label->setPixmap( QPixmap::fromImage(legend) );
+      layout->addWidget(label);
+      mGetLegendGraphicPopup->setLayout(layout);
+      mGetLegendGraphicPopup->move(e->globalX(), e->globalY());
+      mGetLegendGraphicPopup->show();
+    }
+
     mMousePressedFlag = true;
     mDropTarget = itemAt( e->pos() );
     if ( !mDropTarget )
@@ -624,6 +645,11 @@ void QgsLegend::updateGroupCheckStates( QTreeWidgetItem *item )
 
 void QgsLegend::mouseReleaseEvent( QMouseEvent * e )
 {
+  if (mGetLegendGraphicPopup) {
+    delete mGetLegendGraphicPopup;
+    mGetLegendGraphicPopup = 0;
+  }
+  
   QStringList layersPriorToEvent = layerIDs();
   QTreeWidget::mouseReleaseEvent( e );
   mMousePressedFlag = false;
@@ -3208,3 +3234,43 @@ void QgsLegend::updateLegendItemSymbologies()
     ll->refreshSymbology( ll->layer()->id() );
   }
 }
+
+QImage QgsLegend::getWmsLegendPixmap( QTreeWidgetItem *item )
+{
+  if ( !item )
+  {
+    return QImage();
+  }
+
+  QTreeWidgetItem *parent = item->parent();
+  if ( !parent ) 
+  {
+    return QImage();
+  }
+
+  QgsLegendItem* li = dynamic_cast<QgsLegendItem *>( parent );
+  if ( !li )
+  {
+    return QImage();
+  }
+
+  if ( li->type() != QgsLegendItem::LEGEND_LAYER )
+  {
+    return QImage();
+  }
+
+  QgsLegendLayer *lyr = qobject_cast<QgsLegendLayer*>( li );
+  QgsRasterLayer *rasterLayer = dynamic_cast<QgsRasterLayer*>( lyr->layer() );
+  if ( !rasterLayer )
+  {
+    return QImage();
+  }
+
+  if ( rasterLayer->providerType() != "wms" )
+  {
+    return QImage();
+  }
+  
+  return rasterLayer->dataProvider()->getLegendGraphic( canvas()->scale() );
+}
+

--- a/src/app/legend/qgslegend.h
+++ b/src/app/legend/qgslegend.h
@@ -590,6 +590,16 @@ class QgsLegend : public QTreeWidget
 
     bool verifyDrawingOrder();
 
+    /*!
+     * Check if current LegendItem belogs to a WMS layer 
+     * @param item LegendItem to check if belongs to a WMS layer
+     * @return QImage A valid Legend image if belogs to WMS otherwise QImage()
+     */
+    QImage getWmsLegendPixmap( QTreeWidgetItem *item );
+
+    //! popup QFrame containing WMS getLegendGraphic pixmap
+    QFrame *mGetLegendGraphicPopup;
+
   signals:
     void itemAdded( QModelIndex index );
     void itemMoved( QModelIndex oldIndex, QModelIndex newIndex );

--- a/src/app/legend/qgslegendlayer.cpp
+++ b/src/app/legend/qgslegendlayer.cpp
@@ -224,7 +224,7 @@ void QgsLegendLayer::rasterLayerSymbology( QgsRasterLayer* layer )
 #if QT_VERSION >= 0x40700
       if ( rasterItemList.size() == 0) itemList.reserve( 1 );
 #endif
-      itemList.append( qMakePair( QString(""), legendGraphic ) );
+      itemList.append( qMakePair( QString(""), QPixmap::fromImage(legendGraphic) ) );
     }
   }
 

--- a/src/app/legend/qgslegendlayer.cpp
+++ b/src/app/legend/qgslegendlayer.cpp
@@ -208,6 +208,26 @@ void QgsLegendLayer::rasterLayerSymbology( QgsRasterLayer* layer )
 #if QT_VERSION >= 0x40700
   itemList.reserve( rasterItemList.size() );
 #endif
+
+  // GetLegendGraphics in case of WMS service... pixmap can return null if GetLegendGraphics 
+  // is not supported by server
+  QgsDebugMsg( QString( "layer providertype:: %1" ).arg( layer->providerType() ) );
+  if ( layer->providerType() == "wms" )
+  {
+    double currentScale = legend()->canvas()->scale();
+
+    QImage legendGraphic = layer->dataProvider()->getLegendGraphic( currentScale );
+    if ( !legendGraphic.isNull() )
+    {
+      QgsDebugMsg( QString( "downloaded legend with dimension Width:" )+QString::number(legendGraphic.width())+QString(" and Height:")+QString::number(legendGraphic.height()) );
+      
+#if QT_VERSION >= 0x40700
+      if ( rasterItemList.size() == 0) itemList.reserve( 1 );
+#endif
+      itemList.append( qMakePair( QString(""), legendGraphic ) );
+    }
+  }
+
   // Paletted raster may have many colors, for example UInt16 may have 65536 colors
   // and it is very slow, so we limit max count
   QSize iconSize = treeWidget()->iconSize();

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -541,6 +541,9 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WFlags fl ) :
 
   cmbLegendDoubleClickAction->setCurrentIndex( settings.value( "/qgis/legendDoubleClickAction", 0 ).toInt() );
 
+  // WMS getLegendGraphic setting
+  mLegendGraphicResolutionSpinBox->setValue( settings.value("/qgis/defaultLegendGraphicResolution", 0).toInt() );
+
   //
   // Raster properties
   //
@@ -961,6 +964,7 @@ void QgsOptions::saveOptions()
   settings.setValue( "/qgis/addPostgisDC", cbxAddPostgisDC->isChecked() );
   settings.setValue( "/qgis/addOracleDC", cbxAddOracleDC->isChecked() );
   settings.setValue( "/qgis/addNewLayersToCurrentGroup", cbxAddNewLayersToCurrentGroup->isChecked() );
+  settings.setValue( "/qgis/defaultLegendGraphicResolution", mLegendGraphicResolutionSpinBox->value() );
   bool createRasterLegendIcons = settings.value( "/qgis/createRasterLegendIcons", false ).toBool();
   settings.setValue( "/qgis/createRasterLegendIcons", cbxCreateRasterLegendIcons->isChecked() );
   settings.setValue( "/qgis/copyGeometryAsWKT", cbxCopyWKTGeomFromTable->isChecked() );

--- a/src/core/composer/qgscomposeritemcommand.h
+++ b/src/core/composer/qgscomposeritemcommand.h
@@ -85,6 +85,8 @@ class CORE_EXPORT QgsComposerMergeCommand: public QgsComposerItemCommand
       LegendEqualColumnWidth,
       LegendSymbolWidth,
       LegendSymbolHeight,
+      LegendWmsLegendWidth,
+      LegendWmsLegendHeight,
       LegendTitleSpaceBottom,
       LegendGroupSpace,
       LegendLayerSpace,

--- a/src/core/composer/qgscomposerlegend.cpp
+++ b/src/core/composer/qgscomposerlegend.cpp
@@ -54,6 +54,8 @@ QgsComposerLegend::QgsComposerLegend( QgsComposition* composition )
 
   mSymbolWidth = 7;
   mSymbolHeight = 4;
+  mWmsLegendWidth = 50;
+  mWmsLegendHeight = 25;
   mWrapChar = "";
   mlineSpacing = 1.5;
   adjustBoxSize();
@@ -347,13 +349,41 @@ QgsComposerLegend::Nucleon QgsComposerLegend::drawSymbolItem( QgsComposerLegendI
   }
   else if ( rasterItem )
   {
-    if ( painter )
+    // manage WMS lengendGraphic
+    // actual code recognise if it's a legend because it has an icon and it's text is empty => this is not good MV pattern implementation :(
+    QIcon symbolIcon = symbolItem->icon();
+    if ( !symbolIcon.isNull() && symbolItem->text().isEmpty() )
     {
-      painter->setBrush( rasterItem->color() );
-      painter->drawRect( QRectF( point.x(), point.y() + ( itemHeight - mSymbolHeight ) / 2, mSymbolWidth, mSymbolHeight ) );
+      // find max size
+      QList<QSize> sizes = symbolIcon.availableSizes();
+      double maxWidth = 0;
+      double maxHeight = 0;
+      foreach ( QSize size, sizes )
+      {
+        if ( maxWidth < size.width() ) maxWidth = size.width();
+        if ( maxHeight < size.height() ) maxHeight = size.height();
+      }
+      QSize maxSize(maxWidth, maxHeight);
+
+      // get and print legend
+      QImage legend = symbolIcon.pixmap(maxWidth, maxHeight).toImage();
+      if ( painter )
+      {
+        painter->drawImage( QRectF( point.x(), point.y(), mWmsLegendWidth, mWmsLegendHeight ), legend, QRectF( 0, 0, maxWidth, maxHeight ) );
+      }
+      symbolSize.rwidth() = mWmsLegendWidth;
+      symbolSize.rheight() = mWmsLegendHeight;
     }
-    symbolSize.rwidth() = mSymbolWidth;
-    symbolSize.rheight() = mSymbolHeight;
+    else
+    {
+      if ( painter )
+      {
+        painter->setBrush( rasterItem->color() );
+        painter->drawRect( QRectF( point.x(), point.y() + ( itemHeight - mSymbolHeight ) / 2, mSymbolWidth, mSymbolHeight ) );
+      }
+      symbolSize.rwidth() = mSymbolWidth;
+      symbolSize.rheight() = mSymbolHeight;
+    }
   }
   else //item with icon?
   {
@@ -555,6 +585,8 @@ bool QgsComposerLegend::writeXML( QDomElement& elem, QDomDocument & doc ) const
 
   composerLegendElem.setAttribute( "symbolWidth", QString::number( mSymbolWidth ) );
   composerLegendElem.setAttribute( "symbolHeight", QString::number( mSymbolHeight ) );
+  composerLegendElem.setAttribute( "wmsLegendWidth", QString::number( mWmsLegendWidth ) );
+  composerLegendElem.setAttribute( "wmsLegendHeight", QString::number( mWmsLegendHeight ) );
   composerLegendElem.setAttribute( "wrapChar", mWrapChar );
   composerLegendElem.setAttribute( "fontColor", mFontColor.name() );
 
@@ -622,6 +654,8 @@ bool QgsComposerLegend::readXML( const QDomElement& itemElem, const QDomDocument
 
   mSymbolWidth = itemElem.attribute( "symbolWidth", "7.0" ).toDouble();
   mSymbolHeight = itemElem.attribute( "symbolHeight", "14.0" ).toDouble();
+  mWmsLegendWidth = itemElem.attribute( "wmsLegendWidth", "50" ).toDouble();
+  mWmsLegendHeight = itemElem.attribute( "wmsLegendHeight", "25" ).toDouble();
 
   mWrapChar = itemElem.attribute( "wrapChar" );
 

--- a/src/core/composer/qgscomposerlegend.h
+++ b/src/core/composer/qgscomposerlegend.h
@@ -87,6 +87,12 @@ class CORE_EXPORT QgsComposerLegend : public QgsComposerItem
     double symbolHeight() const {return mSymbolHeight;}
     void setSymbolHeight( double h ) {mSymbolHeight = h;}
 
+    double wmsLegendWidth() const {return mWmsLegendWidth;}
+    void setWmsLegendWidth( double w ) {mWmsLegendWidth = w;}
+
+    double wmsLegendHeight() const {return mWmsLegendHeight;}
+    void setWmsLegendHeight( double h ) {mWmsLegendHeight = h;}
+
     void setWrapChar( const QString& t ) {mWrapChar = t;}
     QString wrapChar() const {return mWrapChar;}
 
@@ -138,6 +144,11 @@ class CORE_EXPORT QgsComposerLegend : public QgsComposerItem
     double mSymbolWidth;
     /**Height of symbol icon*/
     double mSymbolHeight;
+
+    /**Width of WMS legendGraphic pixmap*/
+    double mWmsLegendWidth;
+    /**Height of WMS legendGraphic pixmap*/
+    double mWmsLegendHeight;
 
     /** Spacing between lines when wrapped */
     double mlineSpacing;

--- a/src/core/composer/qgslegendmodel.cpp
+++ b/src/core/composer/qgslegendmodel.cpp
@@ -225,37 +225,69 @@ int QgsLegendModel::addRasterLayerItems( QStandardItem* layerItem, QgsMapLayer* 
     return 2;
   }
 
-  QList< QPair< QString, QColor > > rasterItemList = rasterLayer->legendSymbologyItems();
-  QList< QPair< QString, QColor > >::const_iterator itemIt = rasterItemList.constBegin();
-  int row = 0;
-  for ( ; itemIt != rasterItemList.constEnd(); ++itemIt )
+  QgsDebugMsg( QString( "layer providertype:: %1" ).arg( rasterLayer->providerType() ) );
+  if ( rasterLayer->providerType() == "wms" )
   {
-    QgsComposerRasterSymbolItem* currentSymbolItem = new QgsComposerRasterSymbolItem( itemIt->first );
-
-    QgsComposerRasterSymbolItem* oldSymbolItem = dynamic_cast<QgsComposerRasterSymbolItem*>( layerItem->child( row, 0 ) );
-    if ( oldSymbolItem )
+    QgsComposerRasterSymbolItem* currentSymbolItem = new QgsComposerRasterSymbolItem( "" );
+    // GetLegendGraphics in case of WMS service... image can return null if GetLegendGraphics 
+    // is not supported by server
+    // double currentScale = legend()->canvas()->scale();
+    // BEAWARE getLegendGraphic() COULD BE USED WITHOUT SCALE PARAMETER IF IT WAS ALREADY CALLED WITH 
+    // THIS PARAMER FROM A COMPONENT THAT CAN RECOVER CURRENT SCALE => LEGEND IN THE DESKTOP
+    // OTHERWISE IT RETURN A INVALID PIXMAP (QPixmap().isNull() == False)
+    QImage legendGraphic = rasterLayer->dataProvider()->getLegendGraphic();
+    if ( !legendGraphic.isNull() )
     {
-      currentSymbolItem->setUserText( oldSymbolItem->userText() );
-      currentSymbolItem->setText( currentSymbolItem->userText() );
+      QgsDebugMsg( QString( "downloaded legend with dimension Width:" )+QString::number(legendGraphic.width())+QString(" and Height:")+QString::number(legendGraphic.height()) );
+      if ( mHasTopLevelWindow )
+      {
+        currentSymbolItem->setIcon( QIcon( QPixmap::fromImage(legendGraphic) ) );
+      }
+    }
+    else
+    {
+      currentSymbolItem->setText(tr("No Legend Available"));
     }
 
-    if ( mHasTopLevelWindow )
-    {
-      QPixmap itemPixmap( 20, 20 );
-      itemPixmap.fill( itemIt->second );
-      currentSymbolItem->setIcon( QIcon( itemPixmap ) );
-    }
     currentSymbolItem->setLayerID( rasterLayer->id() );
-    currentSymbolItem->setColor( itemIt->second );
-    int currentRowCount = layerItem->rowCount();
-    layerItem->setChild( currentRowCount, 0, currentSymbolItem );
-    row++;
+    currentSymbolItem->setColor( QColor() );
+    layerItem->removeRows(0, layerItem->rowCount());
+    layerItem->setChild( layerItem->rowCount(), 0, currentSymbolItem );
   }
-
-  // Delete following old items (if current number of items decreased)
-  for ( int i = layerItem->rowCount() - 1; i >= row; --i )
+  else
   {
-    layerItem->removeRow( i );
+    QList< QPair< QString, QColor > > rasterItemList = rasterLayer->legendSymbologyItems();
+    QList< QPair< QString, QColor > >::const_iterator itemIt = rasterItemList.constBegin();
+    int row = 0;
+    for ( ; itemIt != rasterItemList.constEnd(); ++itemIt )
+    {
+      QgsComposerRasterSymbolItem* currentSymbolItem = new QgsComposerRasterSymbolItem( itemIt->first );
+
+      QgsComposerRasterSymbolItem* oldSymbolItem = dynamic_cast<QgsComposerRasterSymbolItem*>( layerItem->child( row, 0 ) );
+      if ( oldSymbolItem )
+      {
+        currentSymbolItem->setUserText( oldSymbolItem->userText() );
+        currentSymbolItem->setText( currentSymbolItem->userText() );
+      }
+
+      if ( mHasTopLevelWindow )
+      {
+        QPixmap itemPixmap( 20, 20 );
+        itemPixmap.fill( itemIt->second );
+        currentSymbolItem->setIcon( QIcon( itemPixmap ) );
+      }
+      currentSymbolItem->setLayerID( rasterLayer->id() );
+      currentSymbolItem->setColor( itemIt->second );
+      int currentRowCount = layerItem->rowCount();
+      layerItem->setChild( currentRowCount, 0, currentSymbolItem );
+      row++;
+    }
+
+    // Delete following old items (if current number of items decreased)
+    for ( int i = layerItem->rowCount() - 1; i >= row; --i )
+    {
+      layerItem->removeRow( i );
+    }
   }
 
   return 0;

--- a/src/core/raster/qgsrasterdataprovider.h
+++ b/src/core/raster/qgsrasterdataprovider.h
@@ -24,6 +24,7 @@
 
 #include <QDateTime>
 #include <QVariant>
+#include <QImage>
 
 #include "qgscolorrampshader.h"
 #include "qgscoordinatereferencesystem.h"
@@ -184,6 +185,15 @@ class CORE_EXPORT QgsRasterDataProvider : public QgsDataProvider, public QgsRast
     virtual QStringList subLayers() const
     {
       return QStringList();
+    }
+
+    /** \brief Returns the legend rendered as pixmap
+     *  useful for that layer that need to get legend layer remotly as WMS */
+    virtual QImage getLegendGraphic( double scale=0, bool forceRefresh = false )
+    {
+      Q_UNUSED( scale );
+      Q_UNUSED( forceRefresh );
+      return QImage();
     }
 
     /** \brief Create pyramid overviews */

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -4663,6 +4663,24 @@ QImage QgsWmsProvider::getLegendGraphic( double scale, bool forceRefresh )
     setQueryItem( url, "SCALE", QString::number( scale, 'f') );
     setQueryItem( url, "FORMAT", mImageMimeType );
 
+    // add config parameter related to resolution
+    QSettings s;
+    int defaultLegendGraphicResolution = s.value( "/qgis/defaultLegendGraphicResolution", 0 ).toInt();
+    QgsDebugMsg( QString( "defaultLegendGraphicResolution: %1" ).arg( defaultLegendGraphicResolution ) );
+    if ( defaultLegendGraphicResolution ) {
+      if (url.queryItemValue("map_resolution") != "")
+      {
+        setQueryItem( url, "map_resolution", QString::number(defaultLegendGraphicResolution) );
+      }
+      else if (url.queryItemValue("dpi") != "")
+      {
+        setQueryItem( url, "dpi", QString::number(defaultLegendGraphicResolution) );
+      }
+      else{
+        QgsLogger::warning(tr("getLegendGraphic: Can not determine resolution uri parameter [map_resolution | dpi]. No resolution parameter will be used"));
+      }
+    }
+
     mError = "";
 
     QNetworkRequest request( url );

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -59,7 +59,6 @@
 #include <QImage>
 #include <QImageReader>
 #include <QPainter>
-#include <QPixmap>
 #include <QSet>
 #include <QSettings>
 #include <QEventLoop>
@@ -84,6 +83,9 @@ QgsWmsProvider::QgsWmsProvider( QString const &uri )
     : QgsRasterDataProvider( uri )
     , mHttpUri( uri )
     , mHttpCapabilitiesResponse( 0 )
+    , mHttpGetLegendGraphicResponse( 0 )
+    , mGetLegendGraphicImage()
+    , mGetLegendGraphicScale( 0 )
     , mImageCrs( DEFAULT_LATLON_CRS )
     , mCachedImage( 0 )
     , mCacheReply( 0 )
@@ -4586,6 +4588,189 @@ void QgsWmsProvider::showMessageBox( const QString& title, const QString& text )
   message->setTitle( title );
   message->setMessage( text, QgsMessageOutput::MessageText );
   message->showMessage();
+}
+
+QImage QgsWmsProvider::getLegendGraphic( double scale, bool forceRefresh )
+{
+  // TODO manage return basing of getCapablity => avoid call if service is not available
+  // some services dowsn't expose getLegendGraphic in capabilities but adding LegendURL in
+  // the layer tags inside capabilities
+  QgsDebugMsg( "entering." );
+
+  if ( !scale && !mGetLegendGraphicScale)
+  {
+    QgsDebugMsg( QString( "No scale factor set" ) );
+    return QImage();
+  }
+
+  if ( scale && scale != mGetLegendGraphicScale )
+  {
+    forceRefresh = true;
+    QgsDebugMsg( QString( "Download again due to scale change from: %1 to: %2" ).arg( mGetLegendGraphicScale ).arg( scale ) );
+  }
+  
+  if ( forceRefresh )
+  {
+    if ( scale )
+    {
+      mGetLegendGraphicScale = scale;
+    }
+
+    // if style is not defined, set as "default"
+    QString currentStyle("default");
+    if ( mActiveSubStyles[0] != "" )
+    {
+      currentStyle = mActiveSubStyles[0];
+    }
+
+    // add WMS GetGraphicLegend request
+    // TODO set sld version using instance var something like mSldVersion
+    // TODO at this moment LSD version can be get from LegendURL in getCapability,but parsing of
+    // this tag is not complete. Below the code that should work if pasing whould correct
+    //     if ( mActiveSubLayers[0] == mCapabilities.capability.layer.name )
+    //     {
+    //       foreach( QgsWmsStyleProperty style,  mCapabilities.capability.layer.style )
+    //       {
+    //         if ( currentStyle == style.name )
+    //         {
+    //           url.setUrl( style.legendUrl[0].onlineResource.xlinkHref, QUrl::StrictMode );
+    //         }
+    //       }
+    //     } // is a sublayer
+    //     else if ( mActiveSubLayers[0].contains( mCapabilities.capability.layer.name ) )
+    //     {
+    //       foreach( QgsWmsLayerProperty layerProperty, mCapabilities.capability.layer.layer )
+    //       {
+    //         if ( mActiveSubLayers[0] == layerProperty.name )
+    //         {
+    //           foreach( QgsWmsStyleProperty style, layerProperty.style )
+    //           {
+    //             if ( currentStyle == style.name )
+    //             {
+    //               url.setUrl( style.legendUrl[0].onlineResource.xlinkHref, QUrl::StrictMode );
+    //             }
+    //           }
+    //         }
+    //       }
+    //     }
+    QUrl url( mIgnoreGetMapUrl ? mBaseUrl : getMapUrl(), QUrl::StrictMode );
+    setQueryItem( url, "SERVICE", "WMS" );
+    setQueryItem( url, "VERSION", mCapabilities.version );
+    setQueryItem( url, "SLD_VERSION", "1.1.0" ); // can not determine SLD_VERSION
+    setQueryItem( url, "REQUEST", "GetLegendGraphic" );
+    setQueryItem( url, "LAYER", mActiveSubLayers[0] );
+    setQueryItem( url, "STYLE", currentStyle );
+    setQueryItem( url, "SCALE", QString::number( scale, 'f') );
+    setQueryItem( url, "FORMAT", mImageMimeType );
+
+    mError = "";
+
+    QNetworkRequest request( url );
+    setAuthorization( request );
+    request.setAttribute( QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::PreferNetwork );
+    request.setAttribute( QNetworkRequest::CacheSaveControlAttribute, true );
+
+    QgsDebugMsg( QString( "getlegendgraphics: %1" ).arg( url.toString() ) );
+    mGetLegendGraphicReply = QgsNetworkAccessManager::instance()->get( request );
+
+    connect( mGetLegendGraphicReply, SIGNAL( finished() ), this, SLOT( getLegendGraphicReplyFinished() ) );
+    connect( mGetLegendGraphicReply, SIGNAL( downloadProgress( qint64, qint64 ) ), this, SLOT( getLegendGraphicReplyProgress( qint64, qint64 ) ) );
+
+    while ( mGetLegendGraphicReply )
+    {
+      QCoreApplication::processEvents( QEventLoop::ExcludeUserInputEvents, WMS_THRESHOLD );
+    }
+  }
+  else
+  {
+    QgsDebugMsg( "get cached pixmap." );
+  }
+
+  QgsDebugMsg( "exiting." );
+
+  return mGetLegendGraphicImage; 
+}
+
+void QgsWmsProvider::getLegendGraphicReplyFinished()
+{
+  QgsDebugMsg( "entering." );
+  if ( mGetLegendGraphicReply->error() == QNetworkReply::NoError )
+  {
+    QgsDebugMsg( "reply ok" );
+    QVariant redirect = mGetLegendGraphicReply->attribute( QNetworkRequest::RedirectionTargetAttribute );
+    if ( !redirect.isNull() )
+    {
+      emit statusChanged( tr( "GetLegendGraphic request redirected." ) );
+
+      const QUrl& toUrl = redirect.toUrl();
+      mGetLegendGraphicReply->request();
+      if ( toUrl == mGetLegendGraphicReply->url() )
+      {
+        mErrorFormat = "text/plain";
+        mError = tr( "Redirect loop detected: %1" ).arg( toUrl.toString() );
+        QgsMessageLog::logMessage( mError, tr( "WMS" ) );
+        mHttpGetLegendGraphicResponse.clear();
+      }
+      else
+      {
+        QNetworkRequest request( toUrl );
+        setAuthorization( request );
+        request.setAttribute( QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::PreferNetwork );
+        request.setAttribute( QNetworkRequest::CacheSaveControlAttribute, true );
+
+        mGetLegendGraphicReply->deleteLater();
+        QgsDebugMsg( QString( "redirected GetLegendGraphic: %1" ).arg( redirect.toString() ) );
+        mGetLegendGraphicReply = QgsNetworkAccessManager::instance()->get( request );
+
+        connect( mGetLegendGraphicReply, SIGNAL( finished() ), this, SLOT( getLegendGraphicReplyFinished() ) );
+        connect( mGetLegendGraphicReply, SIGNAL( downloadProgress( qint64, qint64 ) ), this, SLOT( getLegendGraphicReplyProgress( qint64, qint64 ) ) );
+        return;
+      }
+    }
+
+    QVariant status = mGetLegendGraphicReply->attribute( QNetworkRequest::HttpStatusCodeAttribute );
+    if ( !status.isNull() && status.toInt() >= 400 )
+    {
+      QVariant phrase = mGetLegendGraphicReply->attribute( QNetworkRequest::HttpReasonPhraseAttribute );
+      showMessageBox( tr( "GetLegendGraphic request error" ), tr( "Status: %1\nReason phrase: %2" ).arg( status.toInt() ).arg( phrase.toString() ) );
+    }
+    else
+    {
+      QImage myLocalImage = QImage::fromData( mGetLegendGraphicReply->readAll() ) ;
+      if ( myLocalImage.isNull() )
+      {
+        QgsMessageLog::logMessage( tr( "Returned legend image is flawed [URL: %2]" )
+                                    .arg( mGetLegendGraphicReply->url().toString() ), tr( "WMS" ) );
+      }
+      else
+      {
+        mGetLegendGraphicImage = myLocalImage;
+
+#ifdef QGISDEBUG
+        QString filename = QDir::tempPath() + "/GetLegendGraphic.png";
+        mGetLegendGraphicImage.save(filename);
+        QgsDebugMsg( "saved GetLegendGraphic result in debug ile: "+filename );
+#endif
+      }
+    }
+  }
+  else
+  {
+    mErrorFormat = "text/plain";
+    mError = tr( "Download of GetLegendGraphic failed: %1" ).arg( mGetLegendGraphicReply->errorString() );
+    QgsMessageLog::logMessage( mError, tr( "WMS" ) );
+    mHttpGetLegendGraphicResponse.clear();
+  }
+
+  mGetLegendGraphicReply->deleteLater();
+  mGetLegendGraphicReply = 0;
+}
+
+void QgsWmsProvider::getLegendGraphicReplyProgress( qint64 bytesReceived, qint64 bytesTotal )
+{
+  QString msg = tr( "%1 of %2 bytes of GetLegendGraphic downloaded." ).arg( bytesReceived ).arg( bytesTotal < 0 ? QString( "unknown number of" ) : QString::number( bytesTotal ) );
+  QgsDebugMsg( msg );
+  emit statusChanged( msg );
 }
 
 /**

--- a/src/providers/wms/qgswmsprovider.h
+++ b/src/providers/wms/qgswmsprovider.h
@@ -632,6 +632,19 @@ class QgsWmsProvider : public QgsRasterDataProvider
     QStringList subLayerStyles() const;
 
 
+    /**
+     * \brief Get GetLegendGraphic if service available otherwise QImage() 
+     * BEAWARE call it the first time specifying scale parameter otherwise it always return QImage()
+     * \todo some services dowsn't expose getLegendGraphic in capabilities but adding LegendURL in 
+     * the layer tags inside capabilities, but LegendURL parsing is still not developed => getLegendGraphic is
+     * always called assuming that error means service is not available. Other drowback is that SLD_VERSION
+     * is inside LegendURL, so at this moment it is fixed to 1.1.0 waiting a correct parsing of LegendURL
+     * in getCapability
+     * \param scale Optional parameter that is the Scale of the wms layer
+     * \param forceRefresh Optional bool parameter to force refresh getLegendGraphic call 
+     */
+    QImage getLegendGraphic( double scale = 0, bool forceRefresh = false );
+
     // TODO: Get the WMS connection
 
     // TODO: Get the table name associated with this provider instance
@@ -736,6 +749,8 @@ class QgsWmsProvider : public QgsRasterDataProvider
     void capabilitiesReplyProgress( qint64, qint64 );
     void identifyReplyFinished();
     void tileReplyFinished();
+    void getLegendGraphicReplyFinished();
+    void getLegendGraphicReplyProgress( qint64, qint64 );
 
   private:
     void showMessageBox( const QString& title, const QString& text );
@@ -914,6 +929,21 @@ class QgsWmsProvider : public QgsRasterDataProvider
     QDomDocument mCapabilitiesDom;
 
     /**
+     * GetLegendGraphic of the WMS (raw)
+     */
+    QByteArray mHttpGetLegendGraphicResponse;
+
+    /**
+     * GetLegendGraphic WMS Pixmap result
+     */
+    QImage mGetLegendGraphicImage;
+
+    /**
+     * GetLegendGraphic scale for the WMS Pixmap result
+     */
+    double mGetLegendGraphicScale;
+
+    /**
      * Last Service Exception Report from the WMS
      */
     QDomDocument mServiceExceptionReportDom;
@@ -1002,6 +1032,11 @@ class QgsWmsProvider : public QgsRasterDataProvider
      * The reply to the capabilities request
      */
     QNetworkReply *mCapabilitiesReply;
+
+    /**
+     * The reply to the GetLegendGraphic request
+     */
+    QNetworkReply *mGetLegendGraphicReply;
 
     /**
      * The reply to the capabilities request

--- a/src/ui/qgscomposerlegendwidgetbase.ui
+++ b/src/ui/qgscomposerlegendwidgetbase.ui
@@ -54,9 +54,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-141</y>
+        <y>-309</y>
         <width>373</width>
-        <height>1141</height>
+        <height>1387</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="mainLayout">
@@ -193,9 +193,6 @@
             <property name="headerHidden">
              <bool>false</bool>
             </property>
-            <attribute name="headerVisible">
-             <bool>true</bool>
-            </attribute>
             <attribute name="headerVisible">
              <bool>true</bool>
             </attribute>
@@ -534,6 +531,73 @@
             </property>
             <property name="suffix">
              <string> mm</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QgsCollapsibleGroupBoxBasic" name="mSymbolsColGroupBox_2">
+         <property name="title">
+          <string>WMS LegendGraphic</string>
+         </property>
+         <property name="syncGroup" stdset="0">
+          <string notr="true">composeritem</string>
+         </property>
+         <property name="collapsed" stdset="0">
+          <bool>true</bool>
+         </property>
+         <layout class="QFormLayout" name="formLayout_5">
+          <property name="fieldGrowthPolicy">
+           <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+          </property>
+          <property name="labelAlignment">
+           <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+          </property>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_13">
+            <property name="text">
+             <string>Legend width</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QDoubleSpinBox" name="mWmsLegendWidthSpinBox">
+            <property name="prefix">
+             <string/>
+            </property>
+            <property name="suffix">
+             <string> mm</string>
+            </property>
+            <property name="maximum">
+             <double>9999.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_14">
+            <property name="text">
+             <string>Legend height</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QDoubleSpinBox" name="mWmsLegendHeightSpinBox">
+            <property name="prefix">
+             <string/>
+            </property>
+            <property name="suffix">
+             <string> mm</string>
+            </property>
+            <property name="maximum">
+             <double>9999.000000000000000</double>
             </property>
            </widget>
           </item>

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -2345,6 +2345,49 @@
                     </property>
                    </widget>
                   </item>
+                  <item>
+                   <layout class="QHBoxLayout" name="horizontalLayout_34">
+                    <item>
+                     <widget class="QLabel" name="label_58">
+                      <property name="text">
+                       <string>WMS getLegendGraphic Resolution</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <spacer name="horizontalSpacer_39">
+                      <property name="orientation">
+                       <enum>Qt::Horizontal</enum>
+                      </property>
+                      <property name="sizeType">
+                       <enum>QSizePolicy::Preferred</enum>
+                      </property>
+                      <property name="sizeHint" stdset="0">
+                       <size>
+                        <width>30</width>
+                        <height>20</height>
+                       </size>
+                      </property>
+                     </spacer>
+                    </item>
+                    <item>
+                     <widget class="QSpinBox" name="mLegendGraphicResolutionSpinBox">
+                      <property name="toolTip">
+                       <string extracomment="MAP_RESOLUTION or DPI value overloading getMap default value (set 0 to use default)"/>
+                      </property>
+                      <property name="whatsThis">
+                       <string extracomment="MAP_RESOLUTION or DPI value overloading getMap default value (set 0 to use default)"/>
+                      </property>
+                      <property name="minimum">
+                       <number>0</number>
+                      </property>
+                      <property name="maximum">
+                       <number>1000000</number>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
                  </layout>
                 </widget>
                </item>


### PR DESCRIPTION
Four commits that sequentially add these features

d770843 - getLegendGrapic in data provider
48002db - add WMS legend in QgsLegend and add a popup to show it better
32da13b - add configuration option to set WMS legend resolution
f6a6a0c - add support in QgsComposer to show WMS legend

Developed with funding from Regione Toscana-SITA

previous push discussion on: https://github.com/qgis/QGIS/pull/964
