### PR TITLE
Composer zoom improvements

### DIFF
--- a/src/app/composer/qgscomposer.cpp
+++ b/src/app/composer/qgscomposer.cpp
@@ -145,6 +145,8 @@ QgsComposer::QgsComposer( QgisApp *qgis, const QString& title )
   QActionGroup* toggleActionGroup = new QActionGroup( this );
   toggleActionGroup->addAction( mActionMoveItemContent );
   toggleActionGroup->addAction( mActionPan );
+  toggleActionGroup->addAction( mActionMouseZoomIn );
+  toggleActionGroup->addAction( mActionMouseZoomOut );
   toggleActionGroup->addAction( mActionAddNewMap );
   toggleActionGroup->addAction( mActionAddNewLabel );
   toggleActionGroup->addAction( mActionAddNewLegend );
@@ -159,7 +161,6 @@ QgsComposer::QgsComposer( QgisApp *qgis, const QString& title )
   toggleActionGroup->addAction( mActionAddHtml );
   toggleActionGroup->setExclusive( true );
 
-
   mActionAddNewMap->setCheckable( true );
   mActionAddNewLabel->setCheckable( true );
   mActionAddNewLegend->setCheckable( true );
@@ -169,6 +170,8 @@ QgsComposer::QgsComposer( QgisApp *qgis, const QString& title )
   mActionMoveItemContent->setCheckable( true );
   mActionPan->setCheckable( true );
   mActionAddArrow->setCheckable( true );
+  mActionMouseZoomIn->setCheckable( true );
+  mActionMouseZoomOut->setCheckable( true );
 
 #ifdef Q_WS_MAC
   mActionQuit->setText( tr( "Close" ) );
@@ -446,7 +449,9 @@ void QgsComposer::setupTheme()
   mActionPrint->setIcon( QgsApplication::getThemeIcon( "/mActionFilePrint.png" ) );
   mActionZoomAll->setIcon( QgsApplication::getThemeIcon( "/mActionZoomFullExtent.svg" ) );
   mActionZoomIn->setIcon( QgsApplication::getThemeIcon( "/mActionZoomIn.svg" ) );
+  mActionMouseZoomIn->setIcon( QgsApplication::getThemeIcon( "/mActionZoomIn.svg" ) );
   mActionZoomOut->setIcon( QgsApplication::getThemeIcon( "/mActionZoomOut.svg" ) );
+  mActionMouseZoomOut->setIcon( QgsApplication::getThemeIcon( "/mActionZoomOut.svg" ) );
   mActionRefreshView->setIcon( QgsApplication::getThemeIcon( "/mActionDraw.svg" ) );
   mActionUndo->setIcon( QgsApplication::getThemeIcon( "/mActionUndo.png" ) );
   mActionRedo->setIcon( QgsApplication::getThemeIcon( "/mActionRedo.png" ) );
@@ -631,12 +636,28 @@ void QgsComposer::on_mActionZoomAll_triggered()
   emit zoomLevelChanged();
 }
 
+void QgsComposer::on_mActionMouseZoomIn_triggered()
+{
+  if ( mView )
+  {
+    mView->setCurrentTool( QgsComposerView::ZoomIn );
+  }
+}
+
 void QgsComposer::on_mActionZoomIn_triggered()
 {
   mView->scale( 2, 2 );
   mView->updateRulers();
   mView->update();
   emit zoomLevelChanged();
+}
+
+void QgsComposer::on_mActionMouseZoomOut_triggered()
+{
+  if ( mView )
+  {
+    mView->setCurrentTool( QgsComposerView::ZoomOut );
+  }
 }
 
 void QgsComposer::on_mActionZoomOut_triggered()

--- a/src/app/composer/qgscomposer.h
+++ b/src/app/composer/qgscomposer.h
@@ -122,9 +122,11 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
 
     //! Zoom in
     void on_mActionZoomIn_triggered();
+    void on_mActionMouseZoomIn_triggered();
 
     //! Zoom out
     void on_mActionZoomOut_triggered();
+    void on_mActionMouseZoomOut_triggered();
 
     //! Refresh view
     void on_mActionRefreshView_triggered();

--- a/src/gui/qgscomposerview.h
+++ b/src/gui/qgscomposerview.h
@@ -66,7 +66,9 @@ class GUI_EXPORT QgsComposerView: public QGraphicsView
       AddTriangle,
       AddTable, //add attribute table
       MoveItemContent, //move content of item (e.g. content of map)
-      Pan
+      Pan,
+      ZoomIn,
+      ZoomOut
     };
 
     enum ClipboardMode
@@ -163,6 +165,8 @@ class GUI_EXPORT QgsComposerView: public QGraphicsView
 
     /**True if user is currently selecting by marquee*/
     bool mMarqueeSelect;
+    /**True if user is currently zooming by marquee*/
+    bool mMarqueeZoom;
 
     bool mPaintingEnabled;
 
@@ -187,6 +191,10 @@ class GUI_EXPORT QgsComposerView: public QGraphicsView
     void startMarqueeSelect( QPointF & scenePoint );
     /**Finalises a marquee selection*/
     void endMarqueeSelect( QMouseEvent* e );
+    /**Starts a zoom in marquee*/
+    void startMarqueeZoom( QPointF & scenePoint );
+    /**Finalises a marquee zoom*/
+    void endMarqueeZoom( QMouseEvent* e );
 
     //void connectAddRemoveCommandSignals( QgsAddRemoveItemCommand* c );
 

--- a/src/gui/qgscomposerview.h
+++ b/src/gui/qgscomposerview.h
@@ -84,6 +84,13 @@ class GUI_EXPORT QgsComposerView: public QGraphicsView
       PasteModeInPlace
     };
 
+    enum ToolStatus
+    {
+      Inactive,
+      Active,
+      ActiveUntilMouseRelease
+    };
+
     QgsComposerView( QWidget* parent = 0, const char* name = 0, Qt::WFlags f = 0 );
 
     /**Add an item group containing the selected items*/
@@ -152,6 +159,9 @@ class GUI_EXPORT QgsComposerView: public QGraphicsView
   private:
     /**Current composer tool*/
     QgsComposerView::Tool mCurrentTool;
+    /**Previous composer tool*/
+    QgsComposerView::Tool mPreviousTool;
+
     /**Rubber band item*/
     QGraphicsRectItem* mRubberBandItem;
     /**Rubber band item for arrows*/
@@ -167,6 +177,8 @@ class GUI_EXPORT QgsComposerView: public QGraphicsView
     bool mMarqueeSelect;
     /**True if user is currently zooming by marquee*/
     bool mMarqueeZoom;
+    /**True if user is currently temporarily activating the zoom tool by holding control+space*/
+    QgsComposerView::ToolStatus mTemporaryZoomStatus;
 
     bool mPaintingEnabled;
 

--- a/src/ui/qgscomposerbase.ui
+++ b/src/ui/qgscomposerbase.ui
@@ -82,8 +82,8 @@
     <bool>true</bool>
    </attribute>
    <addaction name="mActionZoomAll"/>
-   <addaction name="mActionZoomIn"/>
-   <addaction name="mActionZoomOut"/>
+   <addaction name="mActionMouseZoomIn"/>
+   <addaction name="mActionMouseZoomOut"/>
    <addaction name="mActionRefreshView"/>
   </widget>
   <widget class="QToolBar" name="mItemActionToolbar">
@@ -166,8 +166,20 @@
    </property>
    <property name="shortcut">
     <string>Ctrl++</string>
-   </property>
+   </property>   
   </action>
+  <action name="mActionMouseZoomIn">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionZoomIn.svg</normaloff>:/images/themes/default/mActionZoomIn.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Zoom In</string>
+   </property>
+   <property name="toolTip">
+    <string>Zoom in</string>
+   </property>
+  </action>  
   <action name="mActionZoomOut">
    <property name="icon">
     <iconset resource="../../images/images.qrc">
@@ -183,6 +195,18 @@
     <string>Ctrl+-</string>
    </property>
   </action>
+  <action name="mActionMouseZoomOut">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionZoomOut.svg</normaloff>:/images/themes/default/mActionZoomOut.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Zoom Out</string>
+   </property>
+   <property name="toolTip">
+    <string>Zoom out</string>
+   </property>
+  </action>  
   <action name="mActionAddNewMap">
    <property name="icon">
     <iconset resource="../../images/images.qrc">


### PR DESCRIPTION
These two commits switch the behaviour of some composer zoom functions from an immediate action (zoom in/out on centre of view) to a mouse-based action (zoom in/out via mouse click, or zoom in on a specific composer region via mouse click-and-drag). The Ctrl+/Ctrl- and menu items for zoom in/out use the immediate action, while the toolbar zoom controls use the mouse based action. The second commit makes it possible to switch to the mouse based zoom in/out at any time by holding ctrl+space (zoom in) or ctrl+alt+space (zoom out). To me, this behaviour is a good balance of matching how other DTP packages operate while also mostly respecting how the qgis map canvas handles zoom operations.
