### PR TITLE
Replace manual square by creation of a ICON_FULL_BOX icon type for rubber band

### DIFF
--- a/src/app/nodetool/qgsmaptoolnodetool.cpp
+++ b/src/app/nodetool/qgsmaptoolnodetool.cpp
@@ -724,23 +724,14 @@ void QgsMapToolNodeTool::keyReleaseEvent( QKeyEvent* e )
 
 QgsRubberBand* QgsMapToolNodeTool::createRubberBandMarker( QgsPoint center, QgsVectorLayer* vlayer )
 {
+
   // create rubberband marker for moving points
-  QgsRubberBand* marker = new QgsRubberBand( mCanvas, QGis::Polygon );
+  QgsRubberBand* marker = new QgsRubberBand( mCanvas, QGis::Point );
   marker->setColor( Qt::red );
   marker->setWidth( 2 );
-  double movement = 4;
-  double s = QgsTolerance::toleranceInMapUnits( movement, vlayer, mCanvas->mapRenderer(), QgsTolerance::Pixels );
+  marker->setIcon( QgsRubberBand::ICON_FULL_BOX );
+  marker->setIconSize( 8 );
   QgsPoint pom = toMapCoordinates( vlayer, center );
-  pom.setX( pom.x() - s );
-  pom.setY( pom.y() - s );
-  marker->addPoint( pom );
-  pom.setX( pom.x() + 2*s );
-  marker->addPoint( pom );
-  pom.setY( pom.y() + 2*s );
-  marker->addPoint( pom );
-  pom.setX( pom.x() - 2*s );
-  marker->addPoint( pom );
-  pom.setY( pom.y() - 2*s );
   marker->addPoint( pom );
   return marker;
 }

--- a/src/gui/qgsrubberband.cpp
+++ b/src/gui/qgsrubberband.cpp
@@ -473,6 +473,10 @@ void QgsRubberBand::paint( QPainter* p )
                 p->drawLine( QLineF( x - s, y + s, x - s, y - s ) );
                 break;
 
+              case ICON_FULL_BOX:
+                p->drawRect( x - s, y - s, mIconSize, mIconSize );
+                break;
+
               case ICON_CIRCLE:
                 p->drawEllipse( x - s, y - s, mIconSize, mIconSize );
                 break;

--- a/src/gui/qgsrubberband.h
+++ b/src/gui/qgsrubberband.h
@@ -54,6 +54,10 @@ class GUI_EXPORT QgsRubberBand: public QgsMapCanvasItem
        */
       ICON_BOX,
       /**
+       * A full box is used to highlight points (■)
+       */
+      ICON_FULL_BOX,
+      /**
        * A circle is used to highlight points (○)
        */
       ICON_CIRCLE


### PR DESCRIPTION
I encountered a bug where the rubber band marker created by QgsMapToolNodeTool::createRubberBandMarker does not deal correctly with the project CRS. When the project CRS is geographic while the layer CRS is projected (and OTF enabled), the marker seems to confuse the size and the whole screen is drawn red because it is covered by a gigantic marker.

While trying to fix this bug, I realized the marker is drawn manually inside the function, while it could easily use the QgsRubberBand. To do that, I added a ICON_FULL_BOX icon type, which drawns a full square of the specified size and color. The end result should be identical to the current situation, without the bug and with a slightly cleaner code.
