### PR TITLE
Some grid and snap guide improvements

### DIFF
--- a/python/core/composer/qgscomposition.sip
+++ b/python/core/composer/qgscomposition.sip
@@ -52,6 +52,9 @@ class QgsComposition : QGraphicsScene
 
     void setGridVisible( bool b );
     bool gridVisible() const;
+    
+    /**Removes all snap lines*/
+    void clearSnapLines();    
 
     void setSnapGridResolution( double r );
     double snapGridResolution() const;

--- a/python/core/composer/qgscomposition.sip
+++ b/python/core/composer/qgscomposition.sip
@@ -50,6 +50,9 @@ class QgsComposition : QGraphicsScene
     void setSnapToGridEnabled( bool b );
     bool snapToGridEnabled() const;
 
+    void setGridVisible( bool b );
+    bool gridVisible() const;
+
     void setSnapGridResolution( double r );
     double snapGridResolution() const;
 

--- a/python/core/composer/qgscomposition.sip
+++ b/python/core/composer/qgscomposition.sip
@@ -52,6 +52,11 @@ class QgsComposition : QGraphicsScene
 
     void setGridVisible( bool b );
     bool gridVisible() const;
+
+    /**Toggles state of smart guides*/
+    void setSmartGuidesEnabled( bool b );
+    /**Returns true if smart guides are enabled*/
+    bool smartGuidesEnabled() const;   
     
     /**Removes all snap lines*/
     void clearSnapLines();    
@@ -229,6 +234,8 @@ class QgsComposition : QGraphicsScene
     // QGraphicsLineItem* nearestSnapLine( bool horizontal, double x, double y, double tolerance, QList< QPair< QgsComposerItem*, QgsComposerItem::ItemPositionMode > >& snappedItems );
     /**Hides / shows custom snap lines*/
     void setSnapLinesVisible( bool visible );
+    /**Returns visibility of custom snap lines*/    
+    bool snapLinesVisible() const;    
 
     /**Allocates new item command and saves initial state in it
       @param item target item

--- a/src/app/composer/qgscomposer.cpp
+++ b/src/app/composer/qgscomposer.cpp
@@ -170,6 +170,9 @@ QgsComposer::QgsComposer( QgisApp *qgis, const QString& title )
   mActionPan->setCheckable( true );
   mActionAddArrow->setCheckable( true );
 
+  mActionShowGrid->setCheckable( true );
+  mActionSnapGrid->setCheckable( true );
+
 #ifdef Q_WS_MAC
   mActionQuit->setText( tr( "Close" ) );
   mActionQuit->setShortcut( QKeySequence::Close );
@@ -252,6 +255,9 @@ QgsComposer::QgsComposer( QgisApp *qgis, const QString& title )
   viewMenu->addAction( mActionZoomAll );
   viewMenu->addSeparator();
   viewMenu->addAction( mActionRefreshView );
+  viewMenu->addSeparator();
+  viewMenu->addAction( mActionShowGrid );
+  viewMenu->addAction( mActionSnapGrid );
 
   // Panel and toolbar submenus
   mPanelMenu = new QMenu( tr( "Panels" ), this );
@@ -667,6 +673,24 @@ void QgsComposer::on_mActionRefreshView_triggered()
   }
 
   mComposition->update();
+}
+
+void QgsComposer::on_mActionShowGrid_triggered( bool checked )
+{
+  //enable or disable snap items to grid
+  if ( mComposition )
+  {
+    mComposition->setGridVisible( checked );
+  }
+}
+
+void QgsComposer::on_mActionSnapGrid_triggered( bool checked )
+{
+  //enable or disable snap items to grid
+  if ( mComposition )
+  {
+    mComposition->setSnapToGridEnabled( checked );
+  }
 }
 
 void QgsComposer::on_mActionExportAsPDF_triggered()
@@ -2076,6 +2100,10 @@ void QgsComposer::readXML( const QDomElement& composerElem, const QDomDocument& 
   {
     mComposition->addItemsFromXML( composerElem, doc, &mMapsToRestore );
   }
+
+  //restore grid settings
+  mActionSnapGrid->setChecked( mComposition->snapToGridEnabled() );
+  mActionShowGrid->setChecked( mComposition->gridVisible() );
 
   // look for world file composer map, if needed
   // Note: this must be done after maps have been added by addItemsFromXML

--- a/src/app/composer/qgscomposer.cpp
+++ b/src/app/composer/qgscomposer.cpp
@@ -265,6 +265,7 @@ QgsComposer::QgsComposer( QgisApp *qgis, const QString& title )
   viewMenu->addAction( mActionShowGuides );
   viewMenu->addAction( mActionSnapGuides );
   viewMenu->addAction( mActionSmartGuides );
+  viewMenu->addAction( mActionClearGuides );
 
   // Panel and toolbar submenus
   mPanelMenu = new QMenu( tr( "Panels" ), this );
@@ -724,6 +725,15 @@ void QgsComposer::on_mActionSmartGuides_triggered( bool checked )
   if ( mComposition )
   {
     mComposition->setSmartGuidesEnabled( checked );
+  }
+}
+
+void QgsComposer::on_mActionClearGuides_triggered()
+{
+  //clear guide lines
+  if ( mComposition )
+  {
+    mComposition->clearSnapLines();
   }
 }
 

--- a/src/app/composer/qgscomposer.cpp
+++ b/src/app/composer/qgscomposer.cpp
@@ -172,6 +172,9 @@ QgsComposer::QgsComposer( QgisApp *qgis, const QString& title )
 
   mActionShowGrid->setCheckable( true );
   mActionSnapGrid->setCheckable( true );
+  mActionShowGuides->setCheckable( true );
+  mActionSnapGuides->setCheckable( true );
+  mActionSmartGuides->setCheckable( true );
 
 #ifdef Q_WS_MAC
   mActionQuit->setText( tr( "Close" ) );
@@ -258,6 +261,10 @@ QgsComposer::QgsComposer( QgisApp *qgis, const QString& title )
   viewMenu->addSeparator();
   viewMenu->addAction( mActionShowGrid );
   viewMenu->addAction( mActionSnapGrid );
+  viewMenu->addSeparator();
+  viewMenu->addAction( mActionShowGuides );
+  viewMenu->addAction( mActionSnapGuides );
+  viewMenu->addAction( mActionSmartGuides );
 
   // Panel and toolbar submenus
   mPanelMenu = new QMenu( tr( "Panels" ), this );
@@ -348,8 +355,8 @@ QgsComposer::QgsComposer( QgisApp *qgis, const QString& title )
     connect( mComposition->undoStack(), SIGNAL( canRedoChanged( bool ) ), mActionRedo, SLOT( setEnabled( bool ) ) );
   }
 
+  restoreGridSettings();
   connectSlots();
-
 
   mComposition->setParent( mView );
   mView->setComposition( mComposition );
@@ -677,7 +684,7 @@ void QgsComposer::on_mActionRefreshView_triggered()
 
 void QgsComposer::on_mActionShowGrid_triggered( bool checked )
 {
-  //enable or disable snap items to grid
+  //show or hide grid
   if ( mComposition )
   {
     mComposition->setGridVisible( checked );
@@ -690,6 +697,33 @@ void QgsComposer::on_mActionSnapGrid_triggered( bool checked )
   if ( mComposition )
   {
     mComposition->setSnapToGridEnabled( checked );
+  }
+}
+
+void QgsComposer::on_mActionShowGuides_triggered( bool checked )
+{
+  //show or hide guide lines
+  if ( mComposition )
+  {
+    mComposition->setSnapLinesVisible( checked );
+  }
+}
+
+void QgsComposer::on_mActionSnapGuides_triggered( bool checked )
+{
+  //enable or disable snap items to guides
+  if ( mComposition )
+  {
+    mComposition->setAlignmentSnap( checked );
+  }
+}
+
+void QgsComposer::on_mActionSmartGuides_triggered( bool checked )
+{
+  //enable or disable smart snapping guides
+  if ( mComposition )
+  {
+    mComposition->setSmartGuidesEnabled( checked );
   }
 }
 
@@ -2102,8 +2136,7 @@ void QgsComposer::readXML( const QDomElement& composerElem, const QDomDocument& 
   }
 
   //restore grid settings
-  mActionSnapGrid->setChecked( mComposition->snapToGridEnabled() );
-  mActionShowGrid->setChecked( mComposition->gridVisible() );
+  restoreGridSettings();
 
   // look for world file composer map, if needed
   // Note: this must be done after maps have been added by addItemsFromXML
@@ -2150,6 +2183,17 @@ void QgsComposer::readXML( const QDomElement& composerElem, const QDomDocument& 
   mComposition->atlasComposition().readXML( atlasNodeList.at( 0 ).toElement(), doc );
 
   setSelectionTool();
+}
+
+void QgsComposer::restoreGridSettings()
+{
+  //restore grid settings
+  mActionSnapGrid->setChecked( mComposition->snapToGridEnabled() );
+  mActionShowGrid->setChecked( mComposition->gridVisible() );
+  //restore guide settings
+  mActionShowGuides->setChecked( mComposition->snapLinesVisible() );
+  mActionSnapGuides->setChecked( mComposition->alignmentSnap() );
+  mActionSmartGuides->setChecked( mComposition->smartGuidesEnabled() );
 }
 
 void QgsComposer::deleteItemWidgets()

--- a/src/app/composer/qgscomposer.h
+++ b/src/app/composer/qgscomposer.h
@@ -291,6 +291,15 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
     //!Enable or disable snap items to grid
     void on_mActionSnapGrid_triggered( bool checked );
 
+    //!Show/hide guides
+    void on_mActionShowGuides_triggered( bool checked );
+
+    //!Enable or disable snap items to guides
+    void on_mActionSnapGuides_triggered( bool checked );
+
+    //!Enable or disable smart guides
+    void on_mActionSmartGuides_triggered( bool checked );
+
     //! Save window state
     void saveWindowState();
 
@@ -381,6 +390,9 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
 
     //! Write a world file
     void writeWorldFile( QString fileName, double a, double b, double c, double d, double e, double f ) const;
+
+    //! Updates the grid/guide action status based on compositions grid/guide settings
+    void restoreGridSettings();
 
     /**Composer title*/
     QString mTitle;

--- a/src/app/composer/qgscomposer.h
+++ b/src/app/composer/qgscomposer.h
@@ -285,6 +285,12 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
     //!Redo last composer change
     void on_mActionRedo_triggered();
 
+    //!Show/hide grid
+    void on_mActionShowGrid_triggered( bool checked );
+
+    //!Enable or disable snap items to grid
+    void on_mActionSnapGrid_triggered( bool checked );
+
     //! Save window state
     void saveWindowState();
 

--- a/src/app/composer/qgscomposer.h
+++ b/src/app/composer/qgscomposer.h
@@ -300,6 +300,9 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
     //!Enable or disable smart guides
     void on_mActionSmartGuides_triggered( bool checked );
 
+    //!Clear guides
+    void on_mActionClearGuides_triggered();
+
     //! Save window state
     void saveWindowState();
 

--- a/src/app/composer/qgscompositionwidget.cpp
+++ b/src/app/composer/qgscompositionwidget.cpp
@@ -73,8 +73,6 @@ QgsCompositionWidget::QgsCompositionWidget( QWidget* parent, QgsComposition* c )
     connect( mComposition, SIGNAL( composerMapAdded( QgsComposerMap* ) ), this, SLOT( onComposerMapAdded( QgsComposerMap* ) ) );
     connect( mComposition, SIGNAL( itemRemoved( QgsComposerItem* ) ), this, SLOT( onItemRemoved( QgsComposerItem* ) ) );
 
-
-    mAlignmentSnapGroupCheckBox->setChecked( mComposition->alignmentSnap() );
     mAlignmentToleranceSpinBox->setValue( mComposition->alignmentSnapTolerance() );
 
     //snap grid
@@ -570,14 +568,6 @@ void QgsCompositionWidget::on_mSelectionToleranceSpinBox_valueChanged( double d 
   }
 }
 
-void QgsCompositionWidget::on_mAlignmentSnapGroupCheckBox_toggled( bool state )
-{
-  if ( mComposition )
-  {
-    mComposition->setAlignmentSnap( state );
-  }
-}
-
 void QgsCompositionWidget::on_mAlignmentToleranceSpinBox_valueChanged( double d )
 {
   if ( mComposition )
@@ -603,6 +593,5 @@ void QgsCompositionWidget::blockSignals( bool block )
   mGridStyleComboBox->blockSignals( block );
   mGridToleranceSpinBox->blockSignals( block );
   mSelectionToleranceSpinBox->blockSignals( block );
-  mAlignmentSnapGroupCheckBox->blockSignals( block );
   mAlignmentToleranceSpinBox->blockSignals( block );
 }

--- a/src/app/composer/qgscompositionwidget.cpp
+++ b/src/app/composer/qgscompositionwidget.cpp
@@ -78,7 +78,6 @@ QgsCompositionWidget::QgsCompositionWidget( QWidget* parent, QgsComposition* c )
     mAlignmentToleranceSpinBox->setValue( mComposition->alignmentSnapTolerance() );
 
     //snap grid
-    mSnapToGridGroupCheckBox->setChecked( mComposition->snapToGridEnabled() );
     mGridResolutionSpinBox->setValue( mComposition->snapGridResolution() );
     mOffsetXSpinBox->setValue( mComposition->snapGridOffsetX() );
     mOffsetYSpinBox->setValue( mComposition->snapGridOffsetY() );
@@ -416,7 +415,6 @@ void QgsCompositionWidget::displaySnapingSettings()
     return;
   }
 
-  mSnapToGridGroupCheckBox->setChecked( mComposition->snapToGridEnabled() );
   mGridResolutionSpinBox->setValue( mComposition->snapGridResolution() );
   mOffsetXSpinBox->setValue( mComposition->snapGridOffsetX() );
   mOffsetYSpinBox->setValue( mComposition->snapGridOffsetY() );
@@ -498,14 +496,6 @@ void QgsCompositionWidget::on_mWorldFileMapComboBox_currentIndexChanged( int ind
   {
     QgsComposerMap* map = reinterpret_cast<QgsComposerMap*>( mWorldFileMapComboBox->itemData( index ).value<void*>() );
     mComposition->setWorldFileMap( map );
-  }
-}
-
-void QgsCompositionWidget::on_mSnapToGridGroupCheckBox_toggled( bool state )
-{
-  if ( mComposition )
-  {
-    mComposition->setSnapToGridEnabled( state );
   }
 }
 
@@ -606,7 +596,6 @@ void QgsCompositionWidget::blockSignals( bool block )
   mPaperOrientationComboBox->blockSignals( block );
   mResolutionSpinBox->blockSignals( block );
   mPrintAsRasterCheckBox->blockSignals( block );
-  mSnapToGridGroupCheckBox->blockSignals( block );
   mGridResolutionSpinBox->blockSignals( block );
   mOffsetXSpinBox->blockSignals( block );
   mOffsetYSpinBox->blockSignals( block );

--- a/src/app/composer/qgscompositionwidget.h
+++ b/src/app/composer/qgscompositionwidget.h
@@ -60,7 +60,6 @@ class QgsCompositionWidget: public QWidget, private Ui::QgsCompositionWidgetBase
     void on_mGridStyleComboBox_currentIndexChanged( const QString& text );
     void on_mGridToleranceSpinBox_valueChanged( double d );
     void on_mSelectionToleranceSpinBox_valueChanged( double d );
-    void on_mAlignmentSnapGroupCheckBox_toggled( bool state );
     void on_mAlignmentToleranceSpinBox_valueChanged( double d );
 
     /**Sets GUI elements to width/height from composition*/

--- a/src/app/composer/qgscompositionwidget.h
+++ b/src/app/composer/qgscompositionwidget.h
@@ -53,7 +53,6 @@ class QgsCompositionWidget: public QWidget, private Ui::QgsCompositionWidgetBase
     void on_mGenerateWorldFileCheckBox_toggled( bool state );
     void on_mWorldFileMapComboBox_currentIndexChanged( int index );
 
-    void on_mSnapToGridGroupCheckBox_toggled( bool state );
     void on_mGridResolutionSpinBox_valueChanged( double d );
     void on_mOffsetXSpinBox_valueChanged( double d );
     void on_mOffsetYSpinBox_valueChanged( double d );

--- a/src/core/composer/qgscomposition.cpp
+++ b/src/core/composer/qgscomposition.cpp
@@ -1466,10 +1466,14 @@ QGraphicsLineItem* QgsComposition::nearestSnapLine( bool horizontal, double x, d
       currentYCoord = ( *it )->line().y1();
       currentSqrDist = ( y - currentYCoord ) * ( y - currentYCoord );
     }
-    else if ( !itemHorizontal )
+    else if ( !horizontal && !itemHorizontal )
     {
       currentXCoord = ( *it )->line().x1();
       currentSqrDist = ( x - currentXCoord ) * ( x - currentXCoord );
+    }
+    else
+    {
+      continue;
     }
 
     if ( currentSqrDist < minSqrDist && currentSqrDist < sqrTolerance )

--- a/src/core/composer/qgscomposition.cpp
+++ b/src/core/composer/qgscomposition.cpp
@@ -1428,6 +1428,17 @@ void QgsComposition::removeSnapLine( QGraphicsLineItem* line )
   delete line;
 }
 
+void QgsComposition::clearSnapLines()
+{
+  QList< QGraphicsLineItem* >::iterator it = mSnapLines.begin();
+  for ( ; it != mSnapLines.end(); ++it )
+  {
+    removeItem(( *it ) );
+    delete( *it );
+  }
+  mSnapLines.clear();
+}
+
 void QgsComposition::setSnapLinesVisible( bool visible )
 {
   mGuidesVisible = visible;

--- a/src/core/composer/qgscomposition.cpp
+++ b/src/core/composer/qgscomposition.cpp
@@ -60,6 +60,7 @@ QgsComposition::QgsComposition( QgsMapRenderer* mapRenderer )
     , mUseAdvancedEffects( true )
     , mSelectionTolerance( 0.0 )
     , mSnapToGrid( false )
+    , mGridVisible( false )
     , mSnapGridResolution( 10.0 )
     , mSnapGridTolerance( 2 )
     , mSnapGridOffsetX( 0.0 )
@@ -98,6 +99,7 @@ QgsComposition::QgsComposition()
     mUseAdvancedEffects( true ),
     mSelectionTolerance( 0.0 ),
     mSnapToGrid( false ),
+    mGridVisible( false ),
     mSnapGridResolution( 10.0 ),
     mSnapGridTolerance( 2 ),
     mSnapGridOffsetX( 0.0 ),
@@ -437,6 +439,14 @@ bool QgsComposition::writeXML( QDomElement& composerElem, QDomDocument& doc )
   {
     compositionElem.setAttribute( "snapping", "0" );
   }
+  if ( mGridVisible )
+  {
+    compositionElem.setAttribute( "gridVisible", "1" );
+  }
+  else
+  {
+    compositionElem.setAttribute( "gridVisible", "0" );
+  }
   compositionElem.setAttribute( "snapGridResolution", QString::number( mSnapGridResolution ) );
   compositionElem.setAttribute( "snapGridTolerance", QString::number( mSnapGridTolerance ) );
   compositionElem.setAttribute( "snapGridOffsetX", QString::number( mSnapGridOffsetX ) );
@@ -525,6 +535,14 @@ bool QgsComposition::readXML( const QDomElement& compositionElem, const QDomDocu
   else
   {
     mSnapToGrid = true;
+  }
+  if ( compositionElem.attribute( "gridVisible" ) == "0" )
+  {
+    mGridVisible = false;
+  }
+  else
+  {
+    mGridVisible = true;
   }
   mSnapGridResolution = compositionElem.attribute( "snapGridResolution" ).toDouble();
   mSnapGridTolerance = compositionElem.attribute( "snapGridTolerance", "2.0" ).toDouble();
@@ -1544,6 +1562,13 @@ int QgsComposition::boundingRectOfSelectedItems( QRectF& bRect )
 void QgsComposition::setSnapToGridEnabled( bool b )
 {
   mSnapToGrid = b;
+  updatePaperItems();
+  saveSettings();
+}
+
+void QgsComposition::setGridVisible( bool b )
+{
+  mGridVisible = b;
   updatePaperItems();
   saveSettings();
 }

--- a/src/core/composer/qgscomposition.cpp
+++ b/src/core/composer/qgscomposition.cpp
@@ -66,6 +66,8 @@ QgsComposition::QgsComposition( QgsMapRenderer* mapRenderer )
     , mSnapGridOffsetX( 0.0 )
     , mSnapGridOffsetY( 0.0 )
     , mAlignmentSnap( true )
+    , mGuidesVisible( true )
+    , mSmartGuides( true )
     , mAlignmentSnapTolerance( 2 )
     , mSelectionHandles( 0 )
     , mActiveItemCommand( 0 )
@@ -105,6 +107,8 @@ QgsComposition::QgsComposition()
     mSnapGridOffsetX( 0.0 ),
     mSnapGridOffsetY( 0.0 ),
     mAlignmentSnap( true ),
+    mGuidesVisible( true ),
+    mSmartGuides( true ),
     mAlignmentSnapTolerance( 2 ),
     mSelectionHandles( 0 ),
     mActiveItemCommand( 0 ),
@@ -475,6 +479,8 @@ bool QgsComposition::writeXML( QDomElement& composerElem, QDomDocument& doc )
   }
 
   compositionElem.setAttribute( "alignmentSnap", mAlignmentSnap ? 1 : 0 );
+  compositionElem.setAttribute( "guidesVisible", mGuidesVisible ? 1 : 0 );
+  compositionElem.setAttribute( "smartGuides", mSmartGuides ? 1 : 0 );
   compositionElem.setAttribute( "alignmentSnapTolerance", mAlignmentSnapTolerance );
 
   //save items except paper items and frame items (they are saved with the corresponding multiframe)
@@ -549,6 +555,11 @@ bool QgsComposition::readXML( const QDomElement& compositionElem, const QDomDocu
   mSnapGridOffsetX = compositionElem.attribute( "snapGridOffsetX" ).toDouble();
   mSnapGridOffsetY = compositionElem.attribute( "snapGridOffsetY" ).toDouble();
 
+  mAlignmentSnap = compositionElem.attribute( "alignmentSnap", "1" ).toInt() == 0 ? false : true;
+  mGuidesVisible = compositionElem.attribute( "guidesVisible", "1" ).toInt() == 0 ? false : true;
+  mSmartGuides = compositionElem.attribute( "smartGuides", "1" ).toInt() == 0 ? false : true;
+  mAlignmentSnapTolerance = compositionElem.attribute( "alignmentSnapTolerance", "2.0" ).toDouble();
+
   //custom snap lines
   QDomNodeList snapLineNodes = compositionElem.elementsByTagName( "SnapLine" );
   for ( int i = 0; i < snapLineNodes.size(); ++i )
@@ -561,9 +572,6 @@ bool QgsComposition::readXML( const QDomElement& compositionElem, const QDomDocu
     double y2 = snapLineElem.attribute( "y2" ).toDouble();
     snapItem->setLine( x1, y1, x2, y2 );
   }
-
-  mAlignmentSnap = compositionElem.attribute( "alignmentSnap", "1" ).toInt() == 0 ? false : true;
-  mAlignmentSnapTolerance = compositionElem.attribute( "alignmentSnapTolerance", "2.0" ).toDouble();
 
   mPrintAsRaster = compositionElem.attribute( "printAsRaster" ).toInt();
   mPrintResolution = compositionElem.attribute( "printResolution", "300" ).toInt();
@@ -1407,6 +1415,7 @@ QGraphicsLineItem* QgsComposition::addSnapLine()
   linePen.setWidthF( 0 );
   item->setPen( linePen );
   item->setZValue( 100 );
+  item->setVisible( mGuidesVisible );
   addItem( item );
   mSnapLines.push_back( item );
   return item;
@@ -1421,6 +1430,7 @@ void QgsComposition::removeSnapLine( QGraphicsLineItem* line )
 
 void QgsComposition::setSnapLinesVisible( bool visible )
 {
+  mGuidesVisible = visible;
   QList< QGraphicsLineItem* >::iterator it = mSnapLines.begin();
   for ( ; it != mSnapLines.end(); ++it )
   {

--- a/src/core/composer/qgscomposition.h
+++ b/src/core/composer/qgscomposition.h
@@ -124,6 +124,9 @@ class CORE_EXPORT QgsComposition : public QGraphicsScene
     void setSmartGuidesEnabled( bool b ) { mSmartGuides = b; };
     bool smartGuidesEnabled() const {return mSmartGuides;}
 
+    /**Removes all snap lines*/
+    void clearSnapLines();
+
     void setSnapGridResolution( double r );
     double snapGridResolution() const {return mSnapGridResolution;}
 

--- a/src/core/composer/qgscomposition.h
+++ b/src/core/composer/qgscomposition.h
@@ -114,6 +114,16 @@ class CORE_EXPORT QgsComposition : public QGraphicsScene
     void setGridVisible( bool b );
     bool gridVisible() const {return mGridVisible;}
 
+    /**Hides / shows custom snap lines*/
+    void setSnapLinesVisible( bool visible );
+    bool snapLinesVisible() const {return mGuidesVisible;}
+
+    void setAlignmentSnap( bool s ) { mAlignmentSnap = s; }
+    bool alignmentSnap() const { return mAlignmentSnap; }
+
+    void setSmartGuidesEnabled( bool b ) { mSmartGuides = b; };
+    bool smartGuidesEnabled() const {return mSmartGuides;}
+
     void setSnapGridResolution( double r );
     double snapGridResolution() const {return mSnapGridResolution;}
 
@@ -131,9 +141,6 @@ class CORE_EXPORT QgsComposition : public QGraphicsScene
 
     void setGridStyle( GridStyle s );
     GridStyle gridStyle() const {return mGridStyle;}
-
-    void setAlignmentSnap( bool s ) { mAlignmentSnap = s; }
-    bool alignmentSnap() const { return mAlignmentSnap; }
 
     void setAlignmentSnapTolerance( double t ) { mAlignmentSnapTolerance = t; }
     double alignmentSnapTolerance() const { return mAlignmentSnapTolerance; }
@@ -310,8 +317,6 @@ class CORE_EXPORT QgsComposition : public QGraphicsScene
      * @note not available in python bindings
      */
     QGraphicsLineItem* nearestSnapLine( bool horizontal, double x, double y, double tolerance, QList< QPair< QgsComposerItem*, QgsComposerItem::ItemPositionMode > >& snappedItems );
-    /**Hides / shows custom snap lines*/
-    void setSnapLinesVisible( bool visible );
 
     /**Allocates new item command and saves initial state in it
       @param item target item
@@ -438,6 +443,8 @@ class CORE_EXPORT QgsComposition : public QGraphicsScene
 
     /**Parameters for alignment snap*/
     bool mAlignmentSnap;
+    bool mGuidesVisible;
+    bool mSmartGuides;
     double mAlignmentSnapTolerance;
 
     /**Arbitraty snap lines (horizontal and vertical)*/

--- a/src/core/composer/qgscomposition.h
+++ b/src/core/composer/qgscomposition.h
@@ -111,6 +111,9 @@ class CORE_EXPORT QgsComposition : public QGraphicsScene
     void setSnapToGridEnabled( bool b );
     bool snapToGridEnabled() const {return mSnapToGrid;}
 
+    void setGridVisible( bool b );
+    bool gridVisible() const {return mGridVisible;}
+
     void setSnapGridResolution( double r );
     double snapGridResolution() const {return mSnapGridResolution;}
 
@@ -425,6 +428,7 @@ class CORE_EXPORT QgsComposition : public QGraphicsScene
 
     /**Parameters for snap to grid function*/
     bool mSnapToGrid;
+    bool mGridVisible;
     double mSnapGridResolution;
     double mSnapGridTolerance;
     double mSnapGridOffsetX;

--- a/src/core/composer/qgspaperitem.cpp
+++ b/src/core/composer/qgspaperitem.cpp
@@ -43,7 +43,7 @@ void QgsPaperGrid::paint( QPainter* painter, const QStyleOptionGraphicsItem* ite
   //draw grid
   if ( mComposition )
   {
-    if ( mComposition->snapToGridEnabled() && mComposition->plotStyle() ==  QgsComposition::Preview
+    if ( mComposition->gridVisible() && mComposition->plotStyle() ==  QgsComposition::Preview
          && mComposition->snapGridResolution() > 0 )
     {
       int gridMultiplyX = ( int )( mComposition->snapGridOffsetX() / mComposition->snapGridResolution() );

--- a/src/core/composer/qgspaperitem.h
+++ b/src/core/composer/qgspaperitem.h
@@ -19,9 +19,24 @@
 #define QGSPAPERITEM_H
 
 #include "qgscomposeritem.h"
+#include <QGraphicsRectItem>
 
-/**Item representing the paper. May draw the snapping grid lines if composition is in
- preview mode*/
+/**Item representing a grid. This is drawn seperately to the underlying paper item since the grid needs to be
+ * drawn above all other composer items, while the paper item is drawn below all others.*/
+class CORE_EXPORT QgsPaperGrid: public QGraphicsRectItem
+{
+  public:
+    QgsPaperGrid( double x, double y, double width, double height, QgsComposition* composition );
+    ~QgsPaperGrid();
+
+    /** \brief Reimplementation of QCanvasItem::paint*/
+    void paint( QPainter* painter, const QStyleOptionGraphicsItem* itemStyle, QWidget* pWidget );
+
+  private:
+    QgsComposition* mComposition;
+};
+
+/**Item representing the paper.*/
 class CORE_EXPORT QgsPaperItem: public QgsComposerItem
 {
   public:
@@ -47,10 +62,14 @@ class CORE_EXPORT QgsPaperItem: public QgsComposerItem
      */
     bool readXML( const QDomElement& itemElem, const QDomDocument& doc );
 
+    virtual void setSceneRect( const QRectF& rectangle );
+
   private:
     QgsPaperItem();
     /**Set flags and z-value*/
     void initialize();
+
+    QgsPaperGrid* mPageGrid;
 };
 
 #endif

--- a/src/ui/qgscomposerbase.ui
+++ b/src/ui/qgscomposerbase.ui
@@ -285,6 +285,28 @@
     <string>Refresh view</string>
    </property>
   </action>
+  <action name="mActionShowGrid">
+   <property name="text">
+    <string>Show Grid</string>
+   </property>
+   <property name="toolTip">
+    <string>Show grid</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+'</string>
+   </property>
+  </action>
+  <action name="mActionSnapGrid">
+   <property name="text">
+    <string>Snap to Grid</string>
+   </property>
+   <property name="toolTip">
+    <string>Snap to grid</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+&quot;</string>
+   </property>
+  </action>
   <action name="mActionAddImage">
    <property name="icon">
     <iconset resource="../../images/images.qrc">
@@ -688,7 +710,7 @@
    <property name="shortcut">
     <string>Ctrl+Alt+]</string>
    </property>
-  </action>  
+  </action>
   <action name="mActionPan">
    <property name="icon">
     <iconset resource="../../images/images.qrc">
@@ -697,7 +719,7 @@
    <property name="text">
     <string>Pan Composer</string>
    </property>
-  </action>     
+  </action>
  </widget>
  <resources>
   <include location="../../images/images.qrc"/>

--- a/src/ui/qgscomposerbase.ui
+++ b/src/ui/qgscomposerbase.ui
@@ -339,7 +339,15 @@
    <property name="shortcut">
     <string>Ctrl+Alt+;</string>
    </property>
-  </action>     
+  </action>
+  <action name="mActionClearGuides">
+   <property name="text">
+    <string>Clear Guides</string>
+   </property>
+   <property name="toolTip">
+    <string>Clear guides</string>
+   </property>
+  </action>       
   <action name="mActionAddImage">
    <property name="icon">
     <iconset resource="../../images/images.qrc">

--- a/src/ui/qgscomposerbase.ui
+++ b/src/ui/qgscomposerbase.ui
@@ -307,6 +307,39 @@
     <string>Ctrl+&quot;</string>
    </property>
   </action>
+  <action name="mActionShowGuides">
+   <property name="text">
+    <string>Show Guides</string>
+   </property>
+   <property name="toolTip">
+    <string>Show guides</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+;</string>
+   </property>
+  </action>
+  <action name="mActionSnapGuides">
+   <property name="text">
+    <string>Snap to Guides</string>
+   </property>
+   <property name="toolTip">
+    <string>Snap to guides</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+:</string>
+   </property>
+  </action>
+  <action name="mActionSmartGuides">
+   <property name="text">
+    <string>Smart Guides</string>
+   </property>
+   <property name="toolTip">
+    <string>Smart guides</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Alt+;</string>
+   </property>
+  </action>     
   <action name="mActionAddImage">
    <property name="icon">
     <iconset resource="../../images/images.qrc">

--- a/src/ui/qgscompositionwidgetbase.ui
+++ b/src/ui/qgscompositionwidgetbase.ui
@@ -447,7 +447,7 @@
           <string>Snap to alignments</string>
          </property>
          <property name="checkable">
-          <bool>true</bool>
+          <bool>false</bool>
          </property>
          <property name="syncGroup" stdset="0">
           <string notr="true">composeritem</string>

--- a/src/ui/qgscompositionwidgetbase.ui
+++ b/src/ui/qgscompositionwidgetbase.ui
@@ -23,16 +23,7 @@
    <property name="spacing">
     <number>0</number>
    </property>
-   <property name="leftMargin">
-    <number>0</number>
-   </property>
-   <property name="topMargin">
-    <number>0</number>
-   </property>
-   <property name="rightMargin">
-    <number>0</number>
-   </property>
-   <property name="bottomMargin">
+   <property name="margin">
     <number>0</number>
    </property>
    <item>
@@ -320,10 +311,10 @@
        <item>
         <widget class="QgsCollapsibleGroupBoxBasic" name="mSnapToGridGroupCheckBox">
          <property name="title">
-          <string>Snap to grid</string>
+          <string>Grid</string>
          </property>
          <property name="checkable">
-          <bool>true</bool>
+          <bool>false</bool>
          </property>
          <property name="checked">
           <bool>false</bool>


### PR DESCRIPTION
This request contains a number of improvements and fixes for Composer grids and guides:
- grids are drawn above all composer items
- controls for snapping to grids/guides are added separately from the option to show them
- action for clearing all guides added
- grid & guide toggles are moved to the view menu and shortcut keys assigned to them
- fixes a bug were snap guides can vanish when new guides are added
