### PR TITLE
Correct topology rubber band bug for first and last vertexes

### DIFF
--- a/src/app/nodetool/qgsmaptoolnodetool.cpp
+++ b/src/app/nodetool/qgsmaptoolnodetool.cpp
@@ -311,7 +311,7 @@ void QgsMapToolNodeTool::canvasMoveEvent( QMouseEvent * e )
       offset = posMapCoord - mPosMapCoordBackup;
       for ( int i = 0; i < mTopologyRubberBand.size(); i++ )
       {
-        for ( int pointIndex = 0; pointIndex < mTopologyRubberBand[i]->numberOfVertices() - 1; pointIndex++ )
+        for ( int pointIndex = 0; pointIndex < mTopologyRubberBand[i]->numberOfVertices(); pointIndex++ )
         {
           if ( mTopologyRubberBandVertexes[i]->contains( pointIndex ) )
           {
@@ -321,10 +321,6 @@ void QgsMapToolNodeTool::canvasMoveEvent( QMouseEvent * e )
               break;
             }
             mTopologyRubberBand[i]->movePoint( pointIndex, *point + offset );
-            if ( pointIndex == 0 )
-            {
-              mTopologyRubberBand[i]->movePoint( pointIndex, *point + offset );
-            }
           }
         }
       }


### PR DESCRIPTION
This is a clean version of the pull request https://github.com/qgis/QGIS/pull/649 . I copy the original explanation text below: 

I have been playing with topological editing recently. There are two bugs when dealing with the first and last point of a line, with the rubber band not drawn correctly.

When the first point of a line is moved due to topological editing, the rubberband is shown as moving twice the real distance (but once validated, the movement is correct): 
![first point topological rubber band](https://f.cloud.github.com/assets/537624/632631/147376ea-d1e8-11e2-8cf6-1b81c13d35b5.png)

When it is the last point, the rubberband is not moved at all (but the point is moved after): 
![last point topological rubber band](https://f.cloud.github.com/assets/537624/632626/08ea94d4-d1e8-11e2-92d8-7d3a0be808c0.png)

I had a look at the code and it is due to two special cases concerning these two points. As they seem to be specifically added, could someone more familiar with the code explain the reasoning behind? Otherwise, I propose this simple patch which just treats all points the same and solves the issue from what I have seen. I did some simple testings, but maybe there are additional cases I did not see?
