### PR TITLE
Composer zoom improvements v2

### DIFF
--- a/src/app/composer/qgscomposer.cpp
+++ b/src/app/composer/qgscomposer.cpp
@@ -145,6 +145,7 @@ QgsComposer::QgsComposer( QgisApp *qgis, const QString& title )
   QActionGroup* toggleActionGroup = new QActionGroup( this );
   toggleActionGroup->addAction( mActionMoveItemContent );
   toggleActionGroup->addAction( mActionPan );
+  toggleActionGroup->addAction( mActionMouseZoom );
   toggleActionGroup->addAction( mActionAddNewMap );
   toggleActionGroup->addAction( mActionAddNewLabel );
   toggleActionGroup->addAction( mActionAddNewLegend );
@@ -159,7 +160,6 @@ QgsComposer::QgsComposer( QgisApp *qgis, const QString& title )
   toggleActionGroup->addAction( mActionAddHtml );
   toggleActionGroup->setExclusive( true );
 
-
   mActionAddNewMap->setCheckable( true );
   mActionAddNewLabel->setCheckable( true );
   mActionAddNewLegend->setCheckable( true );
@@ -168,6 +168,7 @@ QgsComposer::QgsComposer( QgisApp *qgis, const QString& title )
   mActionAddImage->setCheckable( true );
   mActionMoveItemContent->setCheckable( true );
   mActionPan->setCheckable( true );
+  mActionMouseZoom->setCheckable( true );
   mActionAddArrow->setCheckable( true );
 
 #ifdef Q_WS_MAC
@@ -447,6 +448,7 @@ void QgsComposer::setupTheme()
   mActionZoomAll->setIcon( QgsApplication::getThemeIcon( "/mActionZoomFullExtent.svg" ) );
   mActionZoomIn->setIcon( QgsApplication::getThemeIcon( "/mActionZoomIn.svg" ) );
   mActionZoomOut->setIcon( QgsApplication::getThemeIcon( "/mActionZoomOut.svg" ) );
+  mActionMouseZoom->setIcon( QgsApplication::getThemeIcon( "/mActionZoomToSelected.svg" ) );
   mActionRefreshView->setIcon( QgsApplication::getThemeIcon( "/mActionDraw.svg" ) );
   mActionUndo->setIcon( QgsApplication::getThemeIcon( "/mActionUndo.png" ) );
   mActionRedo->setIcon( QgsApplication::getThemeIcon( "/mActionRedo.png" ) );
@@ -645,6 +647,14 @@ void QgsComposer::on_mActionZoomOut_triggered()
   mView->updateRulers();
   mView->update();
   emit zoomLevelChanged();
+}
+
+void QgsComposer::on_mActionMouseZoom_triggered()
+{
+  if ( mView )
+  {
+    mView->setCurrentTool( QgsComposerView::Zoom );
+  }
 }
 
 void QgsComposer::on_mActionRefreshView_triggered()

--- a/src/app/composer/qgscomposer.h
+++ b/src/app/composer/qgscomposer.h
@@ -207,6 +207,9 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
     //! Set tool to move item content
     void on_mActionPan_triggered();
 
+    //! Set tool to mouse zoom
+    void on_mActionMouseZoom_triggered();
+
     //! Group selected items
     void on_mActionGroupItems_triggered();
 

--- a/src/gui/qgscomposerview.cpp
+++ b/src/gui/qgscomposerview.cpp
@@ -41,6 +41,7 @@
 #include "qgsaddremovemultiframecommand.h"
 #include "qgspaperitem.h"
 #include "qgsmapcanvas.h" //for QgsMapCanvas::WheelAction
+#include "qgscursors.h"
 
 QgsComposerView::QgsComposerView( QWidget* parent, const char* name, Qt::WFlags f )
     : QGraphicsView( parent )
@@ -48,6 +49,7 @@ QgsComposerView::QgsComposerView( QWidget* parent, const char* name, Qt::WFlags 
     , mRubberBandLineItem( 0 )
     , mMoveContentItem( 0 )
     , mMarqueeSelect( false )
+    , mMarqueeZoom( false )
     , mPaintingEnabled( true )
     , mHorizontalRuler( 0 )
     , mVerticalRuler( 0 )
@@ -76,6 +78,15 @@ void QgsComposerView::setCurrentTool( QgsComposerView::Tool t )
     //lock cursor to prevent composer items changing it
     composition()->setPreventCursorChange( true );
     viewport()->setCursor( Qt::OpenHandCursor );
+  }
+  else if ( t == QgsComposerView::Zoom )
+  {
+    //lock cursor to prevent composer items changing it
+    composition()->setPreventCursorChange( true );
+    //set the cursor to zoom in
+    QPixmap myZoomQPixmap = QPixmap(( const char ** )( zoom_in ) );
+    QCursor zoomCursor = QCursor( myZoomQPixmap, 7, 7 );
+    viewport()->setCursor( zoomCursor );
   }
   else
   {
@@ -202,6 +213,33 @@ void QgsComposerView::mousePressEvent( QMouseEvent* e )
         selectedItem->setSelected( true );
         QGraphicsView::mousePressEvent( e );
         emit selectedItemChanged( selectedItem );
+      }
+      break;
+    }
+
+    case Zoom:
+    {
+      if ( !( e->modifiers() & Qt::ShiftModifier ) )
+      {
+        //zoom in action
+        startMarqueeZoom( scenePoint );
+      }
+      else
+      {
+        //zoom out action, so zoom out and recenter on clicked point
+        double scaleFactor = 2;
+        //get current visible part of scene
+        QRect viewportRect( 0, 0, viewport()->width(), viewport()->height() );
+        QgsRectangle visibleRect = QgsRectangle( mapToScene( viewportRect ).boundingRect() );
+
+        //transform the mouse pos to scene coordinates
+        QPointF scenePoint = mapToScene( e->pos() );
+
+        visibleRect.scale( scaleFactor, scenePoint.x(), scenePoint.y() );
+        QRectF boundsRect = visibleRect.toRectF();
+
+        //zoom view to fit desired bounds
+        fitInView( boundsRect, Qt::KeepAspectRatio );
       }
       break;
     }
@@ -473,6 +511,55 @@ void QgsComposerView::endMarqueeSelect( QMouseEvent* e )
   }
 }
 
+void QgsComposerView::startMarqueeZoom( QPointF & scenePoint )
+{
+  mMarqueeZoom = true;
+
+  QTransform t;
+  mRubberBandItem = new QGraphicsRectItem( 0, 0, 0, 0 );
+  mRubberBandItem->setBrush( QBrush( QColor( 70, 50, 255, 25 ) ) );
+  mRubberBandItem->setPen( QPen( QColor( 70, 50, 255, 100 ) ) );
+  mRubberBandStartPos = QPointF( scenePoint.x(), scenePoint.y() );
+  t.translate( scenePoint.x(), scenePoint.y() );
+  mRubberBandItem->setTransform( t );
+  mRubberBandItem->setZValue( 1000 );
+  scene()->addItem( mRubberBandItem );
+  scene()->update();
+}
+
+void QgsComposerView::endMarqueeZoom( QMouseEvent* e )
+{
+  mMarqueeZoom = false;
+
+  QRectF boundsRect;
+
+  if ( !mRubberBandItem || ( mRubberBandItem->rect().width() < 0.1 && mRubberBandItem->rect().height() < 0.1 ) )
+  {
+    //just a click, so zoom to clicked point and recenter
+    double scaleFactor = 0.5;
+    //get current visible part of scene
+    QRect viewportRect( 0, 0, viewport()->width(), viewport()->height() );
+    QgsRectangle visibleRect = QgsRectangle( mapToScene( viewportRect ).boundingRect() );
+
+    //transform the mouse pos to scene coordinates
+    QPointF scenePoint = mapToScene( e->pos() );
+
+    visibleRect.scale( scaleFactor, scenePoint.x(), scenePoint.y() );
+    boundsRect = visibleRect.toRectF();
+  }
+  else
+  {
+    //marquee zoom
+    //zoom bounds are size marquee object
+    boundsRect = QRectF( mRubberBandItem->transform().dx(), mRubberBandItem->transform().dy(),
+                         mRubberBandItem->rect().width(), mRubberBandItem->rect().height() );
+  }
+
+  removeRubberBand();
+  //zoom view to fit desired bounds
+  fitInView( boundsRect, Qt::KeepAspectRatio );
+}
+
 void QgsComposerView::mouseReleaseEvent( QMouseEvent* e )
 {
   if ( !composition() )
@@ -513,6 +600,15 @@ void QgsComposerView::mouseReleaseEvent( QMouseEvent* e )
     case Select:
     {
       QGraphicsView::mouseReleaseEvent( e );
+      break;
+    }
+
+    case Zoom:
+    {
+      if ( mMarqueeZoom )
+      {
+        endMarqueeZoom( e );
+      }
       break;
     }
 
@@ -633,7 +729,7 @@ void QgsComposerView::mouseMoveEvent( QMouseEvent* e )
   {
     QPointF scenePoint = mapToScene( e->pos() );
 
-    if ( mMarqueeSelect )
+    if ( mMarqueeSelect || mMarqueeZoom )
     {
       updateRubberBand( scenePoint );
       return;
@@ -934,6 +1030,17 @@ void QgsComposerView::keyPressEvent( QKeyEvent * e )
     return;
   }
 
+  if ( mCurrentTool == QgsComposerView::Zoom )
+  {
+    if ( ! e->isAutoRepeat() )
+    {
+      QPixmap myZoomQPixmap = QPixmap(( const char ** )( e->modifiers() & Qt::ShiftModifier ? zoom_out : zoom_in ) );
+      QCursor zoomCursor = QCursor( myZoomQPixmap, 7, 7 );
+      viewport()->setCursor( zoomCursor );
+    }
+    return;
+  }
+
   QList<QgsComposerItem*> composerItemList = composition()->selectedComposerItems();
   QList<QgsComposerItem*>::iterator itemIt = composerItemList.begin();
 
@@ -1003,6 +1110,17 @@ void QgsComposerView::keyReleaseEvent( QKeyEvent * e )
         composition()->setPreventCursorChange( false );
       }
       viewport()->setCursor( Qt::ArrowCursor );
+    }
+    return;
+  }
+
+  if ( mCurrentTool == QgsComposerView::Zoom )
+  {
+    if ( ! e->isAutoRepeat() )
+    {
+      QPixmap myZoomQPixmap = QPixmap(( const char ** )( e->modifiers() & Qt::ShiftModifier ? zoom_out : zoom_in ) );
+      QCursor zoomCursor = QCursor( myZoomQPixmap, 7, 7 );
+      viewport()->setCursor( zoomCursor );
     }
     return;
   }

--- a/src/gui/qgscomposerview.h
+++ b/src/gui/qgscomposerview.h
@@ -66,7 +66,8 @@ class GUI_EXPORT QgsComposerView: public QGraphicsView
       AddTriangle,
       AddTable, //add attribute table
       MoveItemContent, //move content of item (e.g. content of map)
-      Pan
+      Pan,
+      Zoom
     };
 
     enum ClipboardMode
@@ -163,6 +164,8 @@ class GUI_EXPORT QgsComposerView: public QGraphicsView
 
     /**True if user is currently selecting by marquee*/
     bool mMarqueeSelect;
+    /**True if user is currently zooming by marquee*/
+    bool mMarqueeZoom;
 
     bool mPaintingEnabled;
 
@@ -187,6 +190,10 @@ class GUI_EXPORT QgsComposerView: public QGraphicsView
     void startMarqueeSelect( QPointF & scenePoint );
     /**Finalises a marquee selection*/
     void endMarqueeSelect( QMouseEvent* e );
+    /**Starts a zoom in marquee*/
+    void startMarqueeZoom( QPointF & scenePoint );
+    /**Finalises a marquee zoom*/
+    void endMarqueeZoom( QMouseEvent* e );
 
     //void connectAddRemoveCommandSignals( QgsAddRemoveItemCommand* c );
 

--- a/src/gui/qgscomposerview.h
+++ b/src/gui/qgscomposerview.h
@@ -83,6 +83,13 @@ class GUI_EXPORT QgsComposerView: public QGraphicsView
       PasteModeInPlace
     };
 
+    enum ToolStatus
+    {
+      Inactive,
+      Active,
+      ActiveUntilMouseRelease
+    };
+
     QgsComposerView( QWidget* parent = 0, const char* name = 0, Qt::WFlags f = 0 );
 
     /**Add an item group containing the selected items*/
@@ -151,6 +158,9 @@ class GUI_EXPORT QgsComposerView: public QGraphicsView
   private:
     /**Current composer tool*/
     QgsComposerView::Tool mCurrentTool;
+    /**Previous composer tool*/
+    QgsComposerView::Tool mPreviousTool;
+
     /**Rubber band item*/
     QGraphicsRectItem* mRubberBandItem;
     /**Rubber band item for arrows*/
@@ -166,6 +176,8 @@ class GUI_EXPORT QgsComposerView: public QGraphicsView
     bool mMarqueeSelect;
     /**True if user is currently zooming by marquee*/
     bool mMarqueeZoom;
+    /**True if user is currently temporarily activating the zoom tool by holding control+space*/
+    QgsComposerView::ToolStatus mTemporaryZoomStatus;
 
     bool mPaintingEnabled;
 

--- a/src/ui/qgscomposerbase.ui
+++ b/src/ui/qgscomposerbase.ui
@@ -97,6 +97,7 @@
     <bool>true</bool>
    </attribute>
    <addaction name="mActionPan"/>
+   <addaction name="mActionMouseZoom"/>
    <addaction name="mActionSelectMoveItem"/>
    <addaction name="mActionMoveItemContent"/>
    <addaction name="mActionGroupItems"/>
@@ -181,6 +182,18 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+-</string>
+   </property>
+  </action>
+  <action name="mActionMouseZoom">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionZoomToSelected.svg</normaloff>:/images/themes/default/mActionZoomToSelected.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Zoom</string>
+   </property>
+   <property name="toolTip">
+    <string>Zoom</string>
    </property>
   </action>
   <action name="mActionAddNewMap">
@@ -688,7 +701,7 @@
    <property name="shortcut">
     <string>Ctrl+Alt+]</string>
    </property>
-  </action>  
+  </action>
   <action name="mActionPan">
    <property name="icon">
     <iconset resource="../../images/images.qrc">
@@ -697,7 +710,7 @@
    <property name="text">
     <string>Pan Composer</string>
    </property>
-  </action>     
+  </action>
  </widget>
  <resources>
   <include location="../../images/images.qrc"/>


### PR DESCRIPTION
(This is an improved version of an earlier request -- this version leaves the existing zoom in/out actions untouched, but adds a new "zoom" tool for compositions)

These two commits add a new mouse-based zoom tool to the composer. This tool allows you to to zoom in on a specific composer region via mouse click-and-drag, or zoom out on a specific point via shift-clicking.
The second commit makes it possible to switch to the mouse based zoom in/out at any time by holding ctrl+space (zoom in) or ctrl+shift+space (zoom out). 

This behaviour seems a good trade off between mimicking other standard dtp package functionality while respecting the same behaviour as the main QGIS window.
