### PR TITLE
Status bar for composer

### DIFF
--- a/src/app/composer/qgscomposer.cpp
+++ b/src/app/composer/qgscomposer.cpp
@@ -98,7 +98,6 @@ QgsComposer::QgsComposer( QgisApp *qgis, const QString& title )
   setupUi( this );
   setWindowTitle( mTitle );
   setupTheme();
-  connect( mButtonBox, SIGNAL( rejected() ), this, SLOT( close() ) );
 
   QSettings settings;
   setStyleSheet( mQgis->styleSheet() );

--- a/src/app/composer/qgscomposer.h
+++ b/src/app/composer/qgscomposer.h
@@ -338,8 +338,6 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
     //! Raise, unminimize and activate this window
     void activate();
 
-    void on_mButtonBox_helpRequested() { QgsContextHelp::run( metaObject()->className() ); }
-
   private:
 
     /**Establishes the signal slot connection for the class*/

--- a/src/app/composer/qgscomposer.h
+++ b/src/app/composer/qgscomposer.h
@@ -338,6 +338,12 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
     //! Raise, unminimize and activate this window
     void activate();
 
+    //! Updates cursor position in status bar
+    void updateStatusCursorPos( QPointF position );
+
+    //! Updates status bar composition message
+    void updateStatusCompositionMsg( QString message );
+
   private:
 
     /**Establishes the signal slot connection for the class*/
@@ -376,6 +382,13 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
 
     /**Composer title*/
     QString mTitle;
+
+    /**Labels in status bar which shows current mouse position*/
+    QLabel* mStatusCursorXLabel;
+    QLabel* mStatusCursorYLabel;
+    QLabel* mStatusCursorPageLabel;
+    /**Label in status bar which shows messages from the composition*/
+    QLabel* mStatusCompositionLabel;
 
     //! Pointer to composer view
     QgsComposerView *mView;
@@ -464,3 +477,4 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
 };
 
 #endif
+

--- a/src/core/composer/qgscomposermousehandles.cpp
+++ b/src/core/composer/qgscomposermousehandles.cpp
@@ -192,6 +192,7 @@ void QgsComposerMouseHandles::selectionChanged()
     }
   }
 
+  resetStatusBar();
   updateHandles();
 }
 
@@ -515,6 +516,29 @@ void QgsComposerMouseHandles::mouseReleaseEvent( QGraphicsSceneMouseEvent* event
   //redraw handles
   resetTransform();
   updateHandles();
+  //reset status bar message
+  resetStatusBar();
+}
+
+void QgsComposerMouseHandles::resetStatusBar()
+{
+  QList<QgsComposerItem*> selectedItems = mComposition->selectedComposerItems();
+  int selectedCount = selectedItems.size();
+  if ( selectedCount > 1 )
+  {
+    //set status bar message to count of selected items
+    mComposition->setStatusMessage( QString( tr( "%1 items selected" ) ).arg( selectedCount ) );
+  }
+  else if ( selectedCount == 1 )
+  {
+    //set status bar message to count of selected items
+    mComposition->setStatusMessage( tr( "1 item selected" ) );
+  }
+  else
+  {
+    //clear status bar message
+    mComposition->setStatusMessage( QString( "" ) );
+  }
 }
 
 void QgsComposerMouseHandles::mousePressEvent( QGraphicsSceneMouseEvent* event )
@@ -594,6 +618,8 @@ void QgsComposerMouseHandles::dragMouseMove( const QPointF& currentPosition, boo
   QTransform moveTransform;
   moveTransform.translate( moveRectX, moveRectY );
   setTransform( moveTransform );
+  //show current displacement of selection in status bar
+  mComposition->setStatusMessage( QString( tr( "dx: %1 mm dy: %2 mm" ) ).arg( moveRectX ).arg( moveRectY ) );
 }
 
 void QgsComposerMouseHandles::resizeMouseMove( const QPointF& currentPosition, bool lockRatio, bool fromCenter )
@@ -770,6 +796,9 @@ void QgsComposerMouseHandles::resizeMouseMove( const QPointF& currentPosition, b
   setTransform( itemTransform );
   mResizeRect = QRectF( mBeginHandlePos.x() + mx, mBeginHandlePos.y() + my, mBeginHandleWidth + rx, mBeginHandleHeight + ry );
   setRect( 0, 0, fabs( mBeginHandleWidth + rx ), fabs( mBeginHandleHeight + ry ) );
+
+  //show current size of selection in status bar
+  mComposition->setStatusMessage( QString( tr( "width: %1 mm height: %2 mm" ) ).arg( rect().width() ).arg( rect().height() ) );
 }
 
 void QgsComposerMouseHandles::relativeResizeRect( QRectF& rectToResize, const QRectF& boundsBefore, const QRectF& boundsAfter )

--- a/src/core/composer/qgscomposermousehandles.h
+++ b/src/core/composer/qgscomposermousehandles.h
@@ -179,6 +179,9 @@ class CORE_EXPORT QgsComposerMouseHandles: public QObject, public QGraphicsRectI
 
     //sets the mouse cursor for the QGraphicsView attached to the composition (workaround qt bug #3732)
     void setViewportCursor( Qt::CursorShape cursor );
+
+    //resets the composer window status bar to the default message
+    void resetStatusBar();
 };
 
 #endif // QGSCOMPOSERMOUSEHANDLES_H

--- a/src/core/composer/qgscomposition.cpp
+++ b/src/core/composer/qgscomposition.cpp
@@ -181,6 +181,36 @@ int QgsComposition::numPages() const
   return mPages.size();
 }
 
+QPointF QgsComposition::positionOnPage( const QPointF & position ) const
+{
+  double y;
+  if ( position.y() > ( mPages.size() - 1 ) * ( paperHeight() + spaceBetweenPages() ) )
+  {
+    //y coordinate is greater then the end of the last page, so return distance between
+    //top of last page and y coordinate
+    y = position.y() - ( mPages.size() - 1 ) * ( paperHeight() + spaceBetweenPages() );
+  }
+  else
+  {
+    //y coordinate is less then the end of the last page
+    y = fmod( position.y(), ( paperHeight() + spaceBetweenPages() ) );
+  }
+  return QPointF( position.x(), y );
+}
+
+int QgsComposition::pageNumberForPoint( const QPointF & position ) const
+{
+  int pageNumber = qFloor( position.y() / ( paperHeight() + spaceBetweenPages() ) ) + 1;
+  pageNumber = pageNumber < 1 ? 1 : pageNumber;
+  pageNumber = pageNumber > mPages.size() ? mPages.size() : pageNumber;
+  return pageNumber;
+}
+
+void QgsComposition::setStatusMessage( const QString & message )
+{
+  emit statusMsgChanged( message );
+}
+
 QgsComposerItem* QgsComposition::composerItemAt( const QPointF & position )
 {
   return composerItemAt( position, 0 );

--- a/src/core/composer/qgscomposition.h
+++ b/src/core/composer/qgscomposition.h
@@ -108,6 +108,21 @@ class CORE_EXPORT QgsComposition : public QGraphicsScene
     /**Note: added in version 1.9*/
     int numPages() const;
 
+    /**Returns the position within a page of a point in the composition
+      @note Added in QGIS 2.1
+    */
+    QPointF positionOnPage( const QPointF & position ) const;
+
+    /**Returns the page number corresponding to a point in the composition
+      @note Added in QGIS 2.1
+    */
+    int pageNumberForPoint( const QPointF & position ) const;
+
+    /**Sets the status bar message for the composer window
+      @note Added in QGIS 2.1
+    */
+    void setStatusMessage( const QString & message );
+
     void setSnapToGridEnabled( bool b );
     bool snapToGridEnabled() const {return mSnapToGrid;}
 
@@ -498,6 +513,9 @@ class CORE_EXPORT QgsComposition : public QGraphicsScene
     void composerTableAdded( QgsComposerAttributeTable* table );
     /**Is emitted when a composer item has been removed from the scene*/
     void itemRemoved( QgsComposerItem* );
+
+    /**Is emitted when the composition has an updated status bar message for the composer window*/
+    void statusMsgChanged( QString message );
 };
 
 template<class T> void QgsComposition::composerItems( QList<T*>& itemList )

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -212,6 +212,7 @@ qgsbusyindicatordialog.h
 qgscharacterselectdialog.h
 qgscollapsiblegroupbox.h
 qgscolordialog.h
+qgscomposerruler.h
 qgscomposerview.h
 qgscredentialdialog.h
 qgsdatadefinedbutton.h

--- a/src/gui/qgscomposerruler.cpp
+++ b/src/gui/qgscomposerruler.cpp
@@ -132,6 +132,20 @@ void QgsComposerRuler::mouseMoveEvent( QMouseEvent* event )
   //qWarning( "QgsComposerRuler::mouseMoveEvent" );
   updateMarker( event->posF() );
   setSnapLinePosition( event->posF() );
+
+  //update cursor position in status bar
+  QPointF displayPos = mTransform.inverted().map( event->posF() );
+  if ( mDirection == Horizontal )
+  {
+    //mouse is over a horizontal ruler, so don't show a y coordinate
+    displayPos.setY( 0 );
+  }
+  else
+  {
+    //mouse is over a vertical ruler, so don't show an x coordinate
+    displayPos.setX( 0 );
+  }
+  emit cursorPosChanged( displayPos );
 }
 
 void QgsComposerRuler::mouseReleaseEvent( QMouseEvent* event )

--- a/src/gui/qgscomposerruler.h
+++ b/src/gui/qgscomposerruler.h
@@ -9,6 +9,8 @@ class QGraphicsLineItem;
 /**A class to show paper scale and the current cursor position*/
 class GUI_EXPORT QgsComposerRuler: public QWidget
 {
+    Q_OBJECT
+
   public:
     enum Direction
     {
@@ -43,6 +45,11 @@ class GUI_EXPORT QgsComposerRuler: public QWidget
     QList< QPair< QgsComposerItem*, QgsComposerItem::ItemPositionMode > > mSnappedItems;
 
     void setSnapLinePosition( const QPointF& pos );
+
+  signals:
+    /**Is emitted when mouse cursor coordinates change*/
+    void cursorPosChanged( QPointF );
+
 };
 
 #endif // QGSCOMPOSERRULER_H

--- a/src/gui/qgscomposerview.cpp
+++ b/src/gui/qgscomposerview.cpp
@@ -603,6 +603,8 @@ void QgsComposerView::mouseMoveEvent( QMouseEvent* e )
   }
 
   mMouseCurrentXY = e->pos();
+  //update cursor position in composer status bar
+  emit cursorPosChanged( mapToScene( e->pos() ) );
 
   updateRulers();
   if ( mHorizontalRuler )

--- a/src/gui/qgscomposerview.h
+++ b/src/gui/qgscomposerview.h
@@ -198,6 +198,8 @@ class GUI_EXPORT QgsComposerView: public QGraphicsView
     /**Current action (e.g. adding composer map) has been finished. The purpose of this signal is that
      QgsComposer may set the selection tool again*/
     void actionFinished();
+    /**Is emitted when mouse cursor coordinates change*/
+    void cursorPosChanged( QPointF );
 
     /**Emitted before composerview is shown*/
     void composerViewShow( QgsComposerView* );

--- a/src/ui/qgscomposerbase.ui
+++ b/src/ui/qgscomposerbase.ui
@@ -39,6 +39,7 @@
     </item>
    </layout>
   </widget>
+  <widget class="QStatusBar" name="mStatusBar"/>  
   <widget class="QToolBar" name="mComposerToolbar">
    <property name="windowTitle">
     <string>Composer</string>

--- a/src/ui/qgscomposerbase.ui
+++ b/src/ui/qgscomposerbase.ui
@@ -37,13 +37,6 @@
       </property>
      </widget>
     </item>
-    <item row="1" column="0">
-     <widget class="QDialogButtonBox" name="mButtonBox">
-      <property name="standardButtons">
-       <set>QDialogButtonBox::Close|QDialogButtonBox::Help</set>
-      </property>
-     </widget>
-    </item>
    </layout>
   </widget>
   <widget class="QToolBar" name="mComposerToolbar">
@@ -688,7 +681,7 @@
    <property name="shortcut">
     <string>Ctrl+Alt+]</string>
    </property>
-  </action>  
+  </action>
   <action name="mActionPan">
    <property name="icon">
     <iconset resource="../../images/images.qrc">
@@ -697,7 +690,7 @@
    <property name="text">
     <string>Pan Composer</string>
    </property>
-  </action>     
+  </action>
  </widget>
  <resources>
   <include location="../../images/images.qrc"/>


### PR DESCRIPTION
This request replaces the current button bar at the bottom of the composer window with a status bar. The status bar shows the current cursor position and details of item movement/resizing. It also also shows the precise position of guides, allowing for accurate placement of them.
