### PR TITLE
Add composer settings to QGIS options

### DIFF
--- a/src/app/composer/qgscomposer.cpp
+++ b/src/app/composer/qgscomposer.cpp
@@ -303,6 +303,9 @@ QgsComposer::QgsComposer( QgisApp *qgis, const QString& title )
   layoutMenu->addAction( mActionLockItems );
   layoutMenu->addAction( mActionUnlockAll );
 
+  QMenu *settingsMenu = menuBar()->addMenu( tr( "Settings" ) );
+  settingsMenu->addAction( mActionOptions );
+
 #ifdef Q_WS_MAC
   // this doesn't work on Mac anymore: menuBar()->addMenu( mQgis->windowMenu() );
   // QgsComposer::populateWithOtherMenu should work recursively with submenus and regardless of Qt version
@@ -657,6 +660,11 @@ void QgsComposer::showItemOptions( QgsComposerItem* item )
   }
 
   mItemDock->setWidget( newWidget );
+}
+
+void QgsComposer::on_mActionOptions_triggered()
+{
+  mQgis->showOptionsDialog( this, QString("mOptionsPageComposer") );
 }
 
 QgsMapCanvas *QgsComposer::mapCanvas( void )

--- a/src/app/composer/qgscomposer.h
+++ b/src/app/composer/qgscomposer.h
@@ -306,6 +306,9 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
     //!Clear guides
     void on_mActionClearGuides_triggered();
 
+    //!Show options dialog
+    void on_mActionOptions_triggered();
+
     //! Save window state
     void saveWindowState();
 

--- a/src/app/composer/qgscompositionwidget.cpp
+++ b/src/app/composer/qgscompositionwidget.cpp
@@ -80,30 +80,6 @@ QgsCompositionWidget::QgsCompositionWidget( QWidget* parent, QgsComposition* c )
     mOffsetXSpinBox->setValue( mComposition->snapGridOffsetX() );
     mOffsetYSpinBox->setValue( mComposition->snapGridOffsetY() );
 
-
-    //grid pen color
-    mGridColorButton->setColor( mComposition->gridPen().color() );
-    mGridColorButton->setColorDialogTitle( tr( "Select grid color" ) );
-    mGridColorButton->setColorDialogOptions( QColorDialog::ShowAlphaChannel );
-
-    mGridStyleComboBox->insertItem( 0, tr( "Solid" ) );
-    mGridStyleComboBox->insertItem( 1, tr( "Dots" ) );
-    mGridStyleComboBox->insertItem( 2, tr( "Crosses" ) );
-
-    QgsComposition::GridStyle snapGridStyle = mComposition->gridStyle();
-    if ( snapGridStyle == QgsComposition::Solid )
-    {
-      mGridStyleComboBox->setCurrentIndex( 0 );
-    }
-    else if ( snapGridStyle == QgsComposition::Dots )
-    {
-      mGridStyleComboBox->setCurrentIndex( 1 );
-    }
-    else
-    {
-      mGridStyleComboBox->setCurrentIndex( 2 );
-    }
-
     mGridToleranceSpinBox->setValue( mComposition->snapGridTolerance() );
   }
   blockSignals( false );
@@ -520,37 +496,6 @@ void QgsCompositionWidget::on_mOffsetYSpinBox_valueChanged( double d )
   }
 }
 
-void QgsCompositionWidget::on_mGridColorButton_colorChanged( const QColor &newColor )
-{
-  if ( mComposition )
-  {
-    QPen pen = mComposition->gridPen();
-    pen.setColor( newColor );
-    mComposition->setGridPen( pen );
-  }
-}
-
-void QgsCompositionWidget::on_mGridStyleComboBox_currentIndexChanged( const QString& text )
-{
-  Q_UNUSED( text );
-
-  if ( mComposition )
-  {
-    if ( mGridStyleComboBox->currentText() == tr( "Solid" ) )
-    {
-      mComposition->setGridStyle( QgsComposition::Solid );
-    }
-    else if ( mGridStyleComboBox->currentText() == tr( "Dots" ) )
-    {
-      mComposition->setGridStyle( QgsComposition::Dots );
-    }
-    else if ( mGridStyleComboBox->currentText() == tr( "Crosses" ) )
-    {
-      mComposition->setGridStyle( QgsComposition::Crosses );
-    }
-  }
-}
-
 void QgsCompositionWidget::on_mGridToleranceSpinBox_valueChanged( double d )
 {
   if ( mComposition )
@@ -580,8 +525,6 @@ void QgsCompositionWidget::blockSignals( bool block )
   mGridResolutionSpinBox->blockSignals( block );
   mOffsetXSpinBox->blockSignals( block );
   mOffsetYSpinBox->blockSignals( block );
-  mGridColorButton->blockSignals( block );
-  mGridStyleComboBox->blockSignals( block );
   mGridToleranceSpinBox->blockSignals( block );
   mAlignmentToleranceSpinBox->blockSignals( block );
 }

--- a/src/app/composer/qgscompositionwidget.h
+++ b/src/app/composer/qgscompositionwidget.h
@@ -56,8 +56,6 @@ class QgsCompositionWidget: public QWidget, private Ui::QgsCompositionWidgetBase
     void on_mGridResolutionSpinBox_valueChanged( double d );
     void on_mOffsetXSpinBox_valueChanged( double d );
     void on_mOffsetYSpinBox_valueChanged( double d );
-    void on_mGridColorButton_colorChanged( const QColor &newColor );
-    void on_mGridStyleComboBox_currentIndexChanged( const QString& text );
     void on_mGridToleranceSpinBox_valueChanged( double d );
     void on_mAlignmentToleranceSpinBox_valueChanged( double d );
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -6839,8 +6839,12 @@ void QgisApp::customize()
   QgsCustomization::instance()->openDialog( this );
 }
 
-
 void QgisApp::options()
+{
+  showOptionsDialog( this );
+}
+
+void QgisApp::showOptionsDialog( QWidget *parent, QString currentPage )
 {
   if ( mMapCanvas && mMapCanvas->isDrawing() )
   {
@@ -6850,7 +6854,12 @@ void QgisApp::options()
   QSettings mySettings;
   QString oldScales = mySettings.value( "Map/scales", PROJECT_SCALES ).toString();
 
-  QgsOptions *optionsDialog = new QgsOptions( this );
+  QgsOptions *optionsDialog = new QgsOptions( parent );
+  if ( !currentPage.isEmpty() )
+  {
+    optionsDialog->setCurrentPage( currentPage );
+  }
+
   if ( optionsDialog->exec() )
   {
     // set the theme if it changed

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -6863,6 +6863,17 @@ void QgisApp::options()
     double zoomFactor = mySettings.value( "/qgis/zoom_factor", 2 ).toDouble();
     mMapCanvas->setWheelAction(( QgsMapCanvas::WheelAction ) action, zoomFactor );
 
+    //update any open compositions so they reflect new composer settings
+    //we have to push the changes to the compositions here, because compositions
+    //have no access to qgisapp and accordingly can't listen in to changes
+    QSet<QgsComposer*> composers = instance()->printComposers();
+    QSet<QgsComposer*>::iterator composer_it = composers.begin();
+    for ( ; composer_it != composers.end(); ++composer_it )
+    {
+      QgsComposition* composition = ( *composer_it )->composition();
+      composition->updateSettings();
+    }
+
     //do we need this? TS
     mMapCanvas->refresh();
 

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -618,6 +618,9 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     //! Update project menu with the project templates
     void updateProjectFromTemplates();
 
+    //! Opens the options dialog
+    void showOptionsDialog( QWidget *parent = 0, QString currentPage = QString() );
+
   protected:
 
     //! Handle state changes (WindowTitleChange)

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -684,7 +684,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WFlags fl ) :
   //
   // Composer settings
   //
-  
+
   //default composer font
   mComposerFontComboBox->blockSignals( true );
 
@@ -730,7 +730,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WFlags fl ) :
     //default grid is dots
     mGridStyleComboBox->setCurrentIndex( 1 );
   }
-  
+
   //
   // Locale settings
   //
@@ -844,6 +844,21 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WFlags fl ) :
 //! Destructor
 QgsOptions::~QgsOptions()
 {
+}
+
+void QgsOptions::setCurrentPage( QString pageWidgetName )
+{
+  //find the page with a matching widget name
+  for ( int idx = 0; idx < mOptionsStackedWidget->count(); ++idx )
+  {
+    QWidget * currentPage = mOptionsStackedWidget->widget( idx );
+    if ( currentPage->objectName() == pageWidgetName )
+    {
+      //found the page, set it as current
+      mOptionsStackedWidget->setCurrentIndex( idx );
+      return;
+    }
+  }
 }
 
 void QgsOptions::on_cbxProjectDefaultNew_toggled( bool checked )
@@ -1264,7 +1279,7 @@ void QgsOptions::saveOptions()
   //
   // Composer settings
   //
-  
+
   //default font
   QString composerFont = mComposerFontComboBox->currentFont().family();
   settings.setValue( "/Composer/defaultFont", composerFont );
@@ -1288,7 +1303,7 @@ void QgsOptions::saveOptions()
   {
     settings.setValue( "/Composer/gridStyle", "Crosses" );
   }
-  
+
   //
   // Locale settings
   //
@@ -1676,7 +1691,7 @@ void QgsOptions::on_mOptionsStackedWidget_currentChanged( int theIndx )
 {
   Q_UNUSED( theIndx );
   // load gdal driver list when gdal tab is first opened
-  if ( mOptionsStackedWidget->currentWidget()->objectName() == QString( "mOptionsPage_02" )
+  if ( mOptionsStackedWidget->currentWidget()->objectName() == QString( "mOptionsPageGDAL" )
        && ! mLoadedGdalDriverList )
   {
     loadGdalDriverList();

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -684,6 +684,8 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WFlags fl ) :
   //
   // Composer settings
   //
+  
+  //default composer font
   mComposerFontComboBox->blockSignals( true );
 
   QString composerFontFamily = settings.value( "/Composer/defaultFont" ).toString();
@@ -698,6 +700,37 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WFlags fl ) :
 
   mComposerFontComboBox->blockSignals( false );
 
+  //default composer grid color
+  int gridRed, gridGreen, gridBlue, gridAlpha;
+  gridRed = settings.value( "/Composer/gridRed", 190 ).toInt();
+  gridGreen = settings.value( "/Composer/gridGreen", 190 ).toInt();
+  gridBlue = settings.value( "/Composer/gridBlue", 190 ).toInt();
+  gridAlpha = settings.value( "/Composer/gridAlpha", 100 ).toInt();
+  QColor gridColor = QColor( gridRed, gridGreen, gridBlue, gridAlpha );
+  mGridColorButton->setColor( gridColor );
+  mGridColorButton->setColorDialogTitle( tr( "Select grid color" ) );
+  mGridColorButton->setColorDialogOptions( QColorDialog::ShowAlphaChannel );
+
+  //default composer grid style
+  QString gridStyleString;
+  gridStyleString = settings.value( "/Composer/gridStyle", "Dots" ).toString();
+  mGridStyleComboBox->insertItem( 0, tr( "Solid" ) );
+  mGridStyleComboBox->insertItem( 1, tr( "Dots" ) );
+  mGridStyleComboBox->insertItem( 2, tr( "Crosses" ) );
+  if ( gridStyleString == "Solid" )
+  {
+    mGridStyleComboBox->setCurrentIndex( 0 );
+  }
+  else if ( gridStyleString == "Crosses" )
+  {
+    mGridStyleComboBox->setCurrentIndex( 2 );
+  }
+  else
+  {
+    //default grid is dots
+    mGridStyleComboBox->setCurrentIndex( 1 );
+  }
+  
   //
   // Locale settings
   //
@@ -1231,9 +1264,31 @@ void QgsOptions::saveOptions()
   //
   // Composer settings
   //
+  
+  //default font
   QString composerFont = mComposerFontComboBox->currentFont().family();
   settings.setValue( "/Composer/defaultFont", composerFont );
 
+  //grid color
+  settings.setValue( "/Composer/gridRed", mGridColorButton->color().red() );
+  settings.setValue( "/Composer/gridGreen", mGridColorButton->color().green() );
+  settings.setValue( "/Composer/gridBlue", mGridColorButton->color().blue() );
+  settings.setValue( "/Composer/gridAlpha", mGridColorButton->color().alpha() );
+
+  //grid style
+  if ( mGridStyleComboBox->currentText() == tr( "Solid" ) )
+  {
+    settings.setValue( "/Composer/gridStyle", "Solid" );
+  }
+  else if ( mGridStyleComboBox->currentText() == tr( "Dots" ) )
+  {
+    settings.setValue( "/Composer/gridStyle", "Dots" );
+  }
+  else if ( mGridStyleComboBox->currentText() == tr( "Crosses" ) )
+  {
+    settings.setValue( "/Composer/gridStyle", "Crosses" );
+  }
+  
   //
   // Locale settings
   //

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -731,6 +731,15 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WFlags fl ) :
     mGridStyleComboBox->setCurrentIndex( 1 );
   }
 
+  //grid defaults
+  mGridResolutionSpinBox->setValue( settings.value( "/Composer/defaultSnapGridResolution", 10.0 ).toDouble() );
+  mGridToleranceSpinBox->setValue( settings.value( "/Composer/defaultSnapGridTolerance", 2 ).toDouble() );
+  mOffsetXSpinBox->setValue( settings.value( "/Composer/defaultSnapGridOffsetX", 0 ).toDouble() );
+  mOffsetYSpinBox->setValue( settings.value( "/Composer/defaultSnapGridOffsetY", 0 ).toDouble() );
+
+  //guide defaults
+  mGuideToleranceSpinBox->setValue( settings.value( "/Composer/defaultSnapGuideTolerance", 2 ).toDouble() );
+
   //
   // Locale settings
   //
@@ -1303,6 +1312,15 @@ void QgsOptions::saveOptions()
   {
     settings.setValue( "/Composer/gridStyle", "Crosses" );
   }
+
+  //grid defaults
+  settings.setValue( "/Composer/defaultSnapGridResolution", mGridResolutionSpinBox->value() );
+  settings.setValue( "/Composer/defaultSnapGridTolerance", mGridToleranceSpinBox->value() );
+  settings.setValue( "/Composer/defaultSnapGridOffsetX", mOffsetXSpinBox->value() );
+  settings.setValue( "/Composer/defaultSnapGridOffsetY", mOffsetYSpinBox->value() );
+
+  //guide defaults
+  settings.setValue( "/Composer/defaultSnapGuideTolerance", mGuideToleranceSpinBox->value() );
 
   //
   // Locale settings

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -682,6 +682,23 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WFlags fl ) :
   }
 
   //
+  // Composer settings
+  //
+  mComposerFontComboBox->blockSignals( true );
+
+  QString composerFontFamily = settings.value( "/Composer/defaultFont" ).toString();
+
+  QFont *tempComposerFont = new QFont( composerFontFamily );
+  // is exact family match returned from system?
+  if ( tempComposerFont->family() == composerFontFamily )
+  {
+    mComposerFontComboBox->setCurrentFont( *tempComposerFont );
+  }
+  delete tempComposerFont;
+
+  mComposerFontComboBox->blockSignals( false );
+
+  //
   // Locale settings
   //
   QString mySystemLocale = QLocale::system().name();
@@ -1210,6 +1227,12 @@ void QgsOptions::saveOptions()
     myPaths += mListGlobalScales->item( i )->text();
   }
   settings.setValue( "Map/scales", myPaths );
+
+  //
+  // Composer settings
+  //
+  QString composerFont = mComposerFontComboBox->currentFont().family();
+  settings.setValue( "/Composer/defaultFont", composerFont );
 
   //
   // Locale settings

--- a/src/app/qgsoptions.h
+++ b/src/app/qgsoptions.h
@@ -52,6 +52,11 @@ class APP_EXPORT QgsOptions : public QgsOptionsDialogBase, private Ui::QgsOption
      */
     QString theme();
 
+    /** Sets the page with the specified widget name as the current page
+     * @note added in QGIS 2.1
+     */
+    void setCurrentPage( QString pageWidgetName );
+
   public slots:
     void on_cbxProjectDefaultNew_toggled( bool checked );
     void on_pbnProjectDefaultSetCurrent_clicked();

--- a/src/core/composer/qgscomposerlabel.cpp
+++ b/src/core/composer/qgscomposerlabel.cpp
@@ -33,8 +33,18 @@ QgsComposerLabel::QgsComposerLabel( QgsComposition *composition ):
     mExpressionFeature( 0 ), mExpressionLayer( 0 )
 {
   mHtmlUnitsToMM = htmlUnitsToMM();
-  //default font size is 10 point
+
+  //get default composer font from settings
+  QSettings settings;
+  QString defaultFontString = settings.value( "/Composer/defaultFont" ).toString();
+  if ( !defaultFontString.isEmpty() )
+  {
+    mFont.setFamily( defaultFontString );
+  }
+
+  //default to a 10 point font size
   mFont.setPointSizeF( 10 );
+
 }
 
 QgsComposerLabel::~QgsComposerLabel()

--- a/src/core/composer/qgscomposerlegendstyle.cpp
+++ b/src/core/composer/qgscomposerlegendstyle.cpp
@@ -16,6 +16,7 @@
  ***************************************************************************/
 
 #include "qgscomposerlegendstyle.h"
+#include "qgscomposition.h"
 #include <QFont>
 #include <QMap>
 #include <QString>
@@ -25,6 +26,13 @@
 
 QgsComposerLegendStyle::QgsComposerLegendStyle()
 {
+  //get default composer font from settings
+  QSettings settings;
+  QString defaultFontString = settings.value( "/Composer/defaultFont" ).toString();
+  if ( !defaultFontString.isEmpty() )
+  {
+    mFont.setFamily( defaultFontString );
+  }
 }
 
 QgsComposerLegendStyle::~QgsComposerLegendStyle()

--- a/src/core/composer/qgscomposermap.cpp
+++ b/src/core/composer/qgscomposermap.cpp
@@ -72,6 +72,14 @@ QgsComposerMap::QgsComposerMap( QgsComposition *composition, int x, int y, int w
   mXOffset = 0.0;
   mYOffset = 0.0;
 
+  //get default composer font from settings
+  QSettings settings;
+  QString defaultFontString = settings.value( "/Composer/defaultFont" ).toString();
+  if ( !defaultFontString.isEmpty() )
+  {
+    mGridAnnotationFont.setFamily( defaultFontString );
+  }
+
   connectUpdateSlot();
 
   //calculate mExtent based on width/height ratio and map canvas extent

--- a/src/core/composer/qgscomposerscalebar.cpp
+++ b/src/core/composer/qgscomposerscalebar.cpp
@@ -235,6 +235,13 @@ void QgsComposerScaleBar::applyDefaultSettings()
   mBrush.setColor( QColor( 0, 0, 0 ) );
   mBrush.setStyle( Qt::SolidPattern );
 
+  //get default composer font from settings
+  QSettings settings;
+  QString defaultFontString = settings.value( "/Composer/defaultFont" ).toString();
+  if ( !defaultFontString.isEmpty() )
+  {
+    mFont.setFamily( defaultFontString );
+  }
   mFont.setPointSizeF( 12.0 );
   mFontColor = QColor( 0, 0, 0 );
 

--- a/src/core/composer/qgscomposertable.cpp
+++ b/src/core/composer/qgscomposertable.cpp
@@ -26,6 +26,14 @@ QgsComposerTable::QgsComposerTable( QgsComposition* composition )
     , mGridStrokeWidth( 0.5 )
     , mGridColor( QColor( 0, 0, 0 ) )
 {
+  //get default composer font from settings
+  QSettings settings;
+  QString defaultFontString = settings.value( "/Composer/defaultFont" ).toString();
+  if ( !defaultFontString.isEmpty() )
+  {
+    mHeaderFont.setFamily( defaultFontString );
+    mContentFont.setFamily( defaultFontString );
+  }
 }
 
 QgsComposerTable::~QgsComposerTable()

--- a/src/core/composer/qgscomposition.cpp
+++ b/src/core/composer/qgscomposition.cpp
@@ -1608,41 +1608,35 @@ void QgsComposition::setSnapToGridEnabled( bool b )
 {
   mSnapToGrid = b;
   updatePaperItems();
-  saveSettings();
 }
 
 void QgsComposition::setGridVisible( bool b )
 {
   mGridVisible = b;
   updatePaperItems();
-  saveSettings();
 }
 
 void QgsComposition::setSnapGridResolution( double r )
 {
   mSnapGridResolution = r;
   updatePaperItems();
-  saveSettings();
 }
 
 void QgsComposition::setSnapGridTolerance( double tolerance )
 {
   mSnapGridTolerance = tolerance;
-  saveSettings();
 }
 
 void QgsComposition::setSnapGridOffsetX( double offset )
 {
   mSnapGridOffsetX = offset;
   updatePaperItems();
-  saveSettings();
 }
 
 void QgsComposition::setSnapGridOffsetY( double offset )
 {
   mSnapGridOffsetY = offset;
   updatePaperItems();
-  saveSettings();
 }
 
 void QgsComposition::setGridPen( const QPen& p )
@@ -1651,14 +1645,20 @@ void QgsComposition::setGridPen( const QPen& p )
   //make sure grid is drawn using a zero-width cosmetic pen
   mGridPen.setWidthF( 0 );
   updatePaperItems();
-  saveSettings();
 }
 
 void QgsComposition::setGridStyle( GridStyle s )
 {
   mGridStyle = s;
   updatePaperItems();
-  saveSettings();
+}
+
+void QgsComposition::updateSettings()
+{
+  //load new composer setting values
+  loadSettings();
+  //update any paper items to reflect new settings
+  updatePaperItems();
 }
 
 void QgsComposition::loadSettings()
@@ -1667,14 +1667,16 @@ void QgsComposition::loadSettings()
   QSettings s;
 
   QString gridStyleString;
-  int red, green, blue;
+  gridStyleString = s.value( "/Composer/gridStyle", "Dots" ).toString();
 
-  gridStyleString = s.value( "/qgis/composerGridStyle", "Dots" ).toString();
-  red = s.value( "/qgis/composerGridRed", 0 ).toInt();
-  green = s.value( "/qgis/composerGridGreen", 0 ).toInt();
-  blue = s.value( "/qgis/composerGridBlue", 0 ).toInt();
+  int gridRed, gridGreen, gridBlue, gridAlpha;
+  gridRed = s.value( "/Composer/gridRed", 190 ).toInt();
+  gridGreen = s.value( "/Composer/gridGreen", 190 ).toInt();
+  gridBlue = s.value( "/Composer/gridBlue", 190 ).toInt();
+  gridAlpha = s.value( "/Composer/gridAlpha", 100 ).toInt();
+  QColor gridColor = QColor( gridRed, gridGreen, gridBlue, gridAlpha );
 
-  mGridPen.setColor( QColor( red, green, blue ) );
+  mGridPen.setColor( gridColor );
   mGridPen.setWidthF( 0 );
 
   if ( gridStyleString == "Dots" )
@@ -1688,28 +1690,6 @@ void QgsComposition::loadSettings()
   else
   {
     mGridStyle = Solid;
-  }
-}
-
-void QgsComposition::saveSettings()
-{
-  //store grid appearance settings
-  QSettings s;
-  s.setValue( "/qgis/composerGridRed", mGridPen.color().red() );
-  s.setValue( "/qgis/composerGridGreen", mGridPen.color().green() );
-  s.setValue( "/qgis/composerGridBlue", mGridPen.color().blue() );
-
-  if ( mGridStyle == Solid )
-  {
-    s.setValue( "/qgis/composerGridStyle", "Solid" );
-  }
-  else if ( mGridStyle == Dots )
-  {
-    s.setValue( "/qgis/composerGridStyle", "Dots" );
-  }
-  else if ( mGridStyle == Crosses )
-  {
-    s.setValue( "/qgis/composerGridStyle", "Crosses" );
   }
 }
 

--- a/src/core/composer/qgscomposition.cpp
+++ b/src/core/composer/qgscomposition.cpp
@@ -60,14 +60,14 @@ QgsComposition::QgsComposition( QgsMapRenderer* mapRenderer )
     , mUseAdvancedEffects( true )
     , mSnapToGrid( false )
     , mGridVisible( false )
-    , mSnapGridResolution( 10.0 )
-    , mSnapGridTolerance( 2 )
-    , mSnapGridOffsetX( 0.0 )
-    , mSnapGridOffsetY( 0.0 )
+    , mSnapGridResolution( 0 )
+    , mSnapGridTolerance( 0 )
+    , mSnapGridOffsetX( 0 )
+    , mSnapGridOffsetY( 0 )
     , mAlignmentSnap( true )
     , mGuidesVisible( true )
     , mSmartGuides( true )
-    , mAlignmentSnapTolerance( 2 )
+    , mAlignmentSnapTolerance( 0 )
     , mSelectionHandles( 0 )
     , mActiveItemCommand( 0 )
     , mActiveMultiFrameCommand( 0 )
@@ -84,6 +84,9 @@ QgsComposition::QgsComposition( QgsMapRenderer* mapRenderer )
   mSelectionHandles->setZValue( 500 );
 
   mPrintResolution = 300; //hardcoded default
+
+  //load default composition settings
+  loadDefaults();
   loadSettings();
 }
 
@@ -100,22 +103,23 @@ QgsComposition::QgsComposition()
     mUseAdvancedEffects( true ),
     mSnapToGrid( false ),
     mGridVisible( false ),
-    mSnapGridResolution( 10.0 ),
-    mSnapGridTolerance( 2 ),
-    mSnapGridOffsetX( 0.0 ),
-    mSnapGridOffsetY( 0.0 ),
+    mSnapGridResolution( 0 ),
+    mSnapGridTolerance( 0 ),
+    mSnapGridOffsetX( 0 ),
+    mSnapGridOffsetY( 0 ),
     mAlignmentSnap( true ),
     mGuidesVisible( true ),
     mSmartGuides( true ),
-    mAlignmentSnapTolerance( 2 ),
+    mAlignmentSnapTolerance( 0 ),
     mSelectionHandles( 0 ),
     mActiveItemCommand( 0 ),
     mActiveMultiFrameCommand( 0 ),
     mAtlasComposition( this ),
     mPreventCursorChange( false )
 {
+  //load default composition settings
+  loadDefaults();
   loadSettings();
-
 }
 
 QgsComposition::~QgsComposition()
@@ -129,6 +133,16 @@ QgsComposition::~QgsComposition()
   clear();
   delete mActiveItemCommand;
   delete mActiveMultiFrameCommand;
+}
+
+void QgsComposition::loadDefaults()
+{
+  QSettings settings;
+  mSnapGridResolution = settings.value( "/Composer/defaultSnapGridResolution", 10.0 ).toDouble();
+  mSnapGridTolerance = settings.value( "/Composer/defaultSnapGridTolerance", 2 ).toDouble();
+  mSnapGridOffsetX = settings.value( "/Composer/defaultSnapGridOffsetX", 0 ).toDouble();
+  mSnapGridOffsetY = settings.value( "/Composer/defaultSnapGridOffsetY", 0 ).toDouble();
+  mAlignmentSnapTolerance = settings.value( "/Composer/defaultSnapGuideTolerance", 2 ).toDouble();
 }
 
 void QgsComposition::setPaperSize( double width, double height )

--- a/src/core/composer/qgscomposition.h
+++ b/src/core/composer/qgscomposition.h
@@ -485,6 +485,10 @@ class CORE_EXPORT QgsComposition : public QGraphicsScene
      @return 0 in case of success*/
     int boundingRectOfSelectedItems( QRectF& bRect );
 
+    /**Loads default composer settings*/
+    void loadDefaults();
+
+    /**Loads composer settings which may change, eg grid color*/
     void loadSettings();
 
     void connectAddRemoveCommandSignals( QgsAddRemoveItemCommand* c );

--- a/src/core/composer/qgscomposition.h
+++ b/src/core/composer/qgscomposition.h
@@ -123,6 +123,10 @@ class CORE_EXPORT QgsComposition : public QGraphicsScene
     */
     void setStatusMessage( const QString & message );
 
+    /**Refreshes the composition when composer related options change
+     *Note: added in version 2.1*/
+    void updateSettings();
+
     void setSnapToGridEnabled( bool b );
     bool snapToGridEnabled() const {return mSnapToGrid;}
 
@@ -482,7 +486,6 @@ class CORE_EXPORT QgsComposition : public QGraphicsScene
     int boundingRectOfSelectedItems( QRectF& bRect );
 
     void loadSettings();
-    void saveSettings();
 
     void connectAddRemoveCommandSignals( QgsAddRemoveItemCommand* c );
 

--- a/src/ui/qgscomposerbase.ui
+++ b/src/ui/qgscomposerbase.ui
@@ -780,7 +780,19 @@
    <property name="text">
     <string>Pan Composer</string>
    </property>
-  </action>
+  </action> 
+  <action name="mActionOptions">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionOptions.svg</normaloff>:/images/themes/default/mActionOptions.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Composer Options...</string>
+   </property>
+   <property name="menuRole">
+    <enum>QAction::PreferencesRole</enum>
+   </property>
+  </action>      
  </widget>
  <resources>
   <include location="../../images/images.qrc"/>

--- a/src/ui/qgscompositionwidgetbase.ui
+++ b/src/ui/qgscompositionwidgetbase.ui
@@ -361,29 +361,6 @@
            </layout>
           </item>
           <item row="2" column="0">
-           <widget class="QLabel" name="mGridStyleLabel">
-            <property name="text">
-             <string>Grid style</string>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-            <property name="buddy">
-             <cstring>mGridStyleComboBox</cstring>
-            </property>
-           </widget>
-          </item>
-          <item row="2" column="1">
-           <widget class="QComboBox" name="mGridStyleComboBox"/>
-          </item>
-          <item row="3" column="1">
-           <widget class="QgsColorButton" name="mGridColorButton">
-            <property name="text">
-             <string>Color...</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0">
            <widget class="QLabel" name="label_4">
             <property name="text">
              <string>Tolerance</string>
@@ -393,7 +370,7 @@
             </property>
            </widget>
           </item>
-          <item row="4" column="1">
+          <item row="2" column="1">
            <widget class="QDoubleSpinBox" name="mGridToleranceSpinBox">
             <property name="prefix">
              <string/>
@@ -471,11 +448,6 @@
  </widget>
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
-  <customwidget>
-   <class>QgsColorButton</class>
-   <extends>QPushButton</extends>
-   <header>qgscolorbutton.h</header>
-  </customwidget>
   <customwidget>
    <class>QgsCollapsibleGroupBoxBasic</class>
    <extends>QGroupBox</extends>

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -2878,10 +2878,10 @@
                   <string>Composition defaults</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_8">
-                  <item row="0" column="0">
+                  <item row="1" column="0">
                    <layout class="QHBoxLayout" name="horizontalLayout_4">
                     <item>
-                     <widget class="QLabel" name="label_58">
+                     <widget class="QLabel" name="label_60">
                       <property name="text">
                        <string>Default font</string>
                       </property>
@@ -2893,21 +2893,51 @@
                     </item>
                    </layout>
                   </item>
-                  <item row="7" column="0">
-                   <spacer name="verticalSpacer_10">
-                    <property name="orientation">
-                     <enum>Qt::Vertical</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>20</width>
-                      <height>40</height>
-                     </size>
-                    </property>
-                   </spacer>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="groupBox_23">
+                 <property name="title">
+                  <string>Grid appearance</string>
+                 </property>
+                 <layout class="QGridLayout" name="gridLayout_9">
+                  <item row="0" column="0">
+                   <layout class="QHBoxLayout" name="horizontalLayout_32">
+                    <item>
+                     <widget class="QLabel" name="label_59">
+                      <property name="text">
+                       <string>Grid style</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QComboBox" name="mGridStyleComboBox"/>
+                    </item>
+                    <item>
+                     <widget class="QgsColorButton" name="mGridColorButton">
+                      <property name="text">
+                       <string>Color...</string>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
                   </item>
                  </layout>
                 </widget>
+               </item>
+               <item>
+                <spacer name="verticalSpacer_10">
+                 <property name="orientation">
+                  <enum>Qt::Vertical</enum>
+                 </property>
+                 <property name="sizeHint" stdset="0">
+                  <size>
+                   <width>20</width>
+                   <height>40</height>
+                  </size>
+                 </property>
+                </spacer>
                </item>
               </layout>
              </widget>
@@ -4021,7 +4051,7 @@
                    </layout>
                   </item>
                   <item>
-                   <layout class="QHBoxLayout" name="horizontalLayout_34">
+                   <layout class="QHBoxLayout" name="horizontalLayout_35">
                     <item>
                      <widget class="QLabel" name="lblUserAgent">
                       <property name="text">

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -250,7 +250,7 @@
          <property name="currentIndex">
           <number>0</number>
          </property>
-         <widget class="QWidget" name="mOptionsPage_01">
+         <widget class="QWidget" name="mOptionsPageGeneral">
           <layout class="QVBoxLayout" name="verticalLayout_3">
            <property name="margin">
             <number>0</number>
@@ -896,7 +896,7 @@
            </item>
           </layout>
          </widget>
-         <widget class="QWidget" name="mOptionsPage_03">
+         <widget class="QWidget" name="mOptionsPageSystem">
           <layout class="QVBoxLayout" name="verticalLayout_7">
            <property name="margin">
             <number>0</number>
@@ -1232,7 +1232,7 @@
            </item>
           </layout>
          </widget>
-         <widget class="QWidget" name="mOptionsPage_11">
+         <widget class="QWidget" name="mOptionsPageDataSources">
           <layout class="QVBoxLayout" name="verticalLayout_26">
            <property name="margin">
             <number>0</number>
@@ -1561,7 +1561,7 @@
            </item>
           </layout>
          </widget>
-         <widget class="QWidget" name="mOptionsPage_04">
+         <widget class="QWidget" name="mOptionsPageRendering">
           <layout class="QVBoxLayout" name="verticalLayout_12">
            <property name="margin">
             <number>0</number>
@@ -2076,7 +2076,7 @@
            </item>
           </layout>
          </widget>
-         <widget class="QWidget" name="mOptionsPage_06">
+         <widget class="QWidget" name="mOptionsPageMapCanvas">
           <layout class="QVBoxLayout" name="verticalLayout_16">
            <property name="margin">
             <number>0</number>
@@ -2422,7 +2422,7 @@
            </item>
           </layout>
          </widget>
-         <widget class="QWidget" name="mOptionsPage_05">
+         <widget class="QWidget" name="mOptionsPageMapTools">
           <layout class="QVBoxLayout" name="verticalLayout_14">
            <property name="margin">
             <number>0</number>
@@ -2836,7 +2836,7 @@
            </item>
           </layout>
          </widget>
-         <widget class="QWidget" name="mOptionsPage_12">
+         <widget class="QWidget" name="mOptionsPageComposer">
           <layout class="QVBoxLayout" name="verticalLayout_9">
            <property name="margin">
             <number>0</number>
@@ -2945,7 +2945,7 @@
            </item>
           </layout>
          </widget>
-         <widget class="QWidget" name="mOptionsPage_07">
+         <widget class="QWidget" name="mOptionsPageDigitizing">
           <layout class="QVBoxLayout" name="verticalLayout_17">
            <property name="margin">
             <number>0</number>
@@ -3446,7 +3446,7 @@
            </item>
           </layout>
          </widget>
-         <widget class="QWidget" name="mOptionsPage_02">
+         <widget class="QWidget" name="mOptionsPageGDAL">
           <layout class="QVBoxLayout" name="verticalLayout_4">
            <property name="margin">
             <number>0</number>
@@ -3586,7 +3586,7 @@
            </item>
           </layout>
          </widget>
-         <widget class="QWidget" name="mOptionsPage_08">
+         <widget class="QWidget" name="mOptionsPageCRS">
           <layout class="QVBoxLayout" name="verticalLayout_18">
            <property name="margin">
             <number>0</number>
@@ -3843,7 +3843,7 @@
            </item>
           </layout>
          </widget>
-         <widget class="QWidget" name="mOptionsPage_09">
+         <widget class="QWidget" name="mOptionsPageLocale">
           <layout class="QVBoxLayout" name="verticalLayout_19">
            <property name="margin">
             <number>0</number>
@@ -3943,7 +3943,7 @@
            </item>
           </layout>
          </widget>
-         <widget class="QWidget" name="mOptionsPage_10">
+         <widget class="QWidget" name="mOptionsPageNetwork">
           <layout class="QVBoxLayout" name="verticalLayout_20">
            <property name="margin">
             <number>0</number>

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -154,6 +154,18 @@
          </item>
          <item>
           <property name="text">
+           <string>Composer</string>
+          </property>
+          <property name="toolTip">
+           <string>Composer</string>
+          </property>
+          <property name="icon">
+           <iconset resource="../../images/images.qrc">
+            <normaloff>:/images/themes/default/mActionNewComposer.svg</normaloff>:/images/themes/default/mActionNewComposer.svg</iconset>
+          </property>
+         </item>
+         <item>
+          <property name="text">
            <string>Digitizing</string>
           </property>
           <property name="toolTip">
@@ -2817,6 +2829,85 @@
                   </size>
                  </property>
                 </spacer>
+               </item>
+              </layout>
+             </widget>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="mOptionsPage_12">
+          <layout class="QVBoxLayout" name="verticalLayout_9">
+           <property name="margin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="label_56">
+             <property name="styleSheet">
+              <string notr="true">font-weight:bold;</string>
+             </property>
+             <property name="text">
+              <string>Composer</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QScrollArea" name="mOptionsScrollArea_12">
+             <property name="frameShape">
+              <enum>QFrame::NoFrame</enum>
+             </property>
+             <property name="widgetResizable">
+              <bool>true</bool>
+             </property>
+             <widget class="QWidget" name="mOptionsScrollAreaContents_12">
+              <property name="geometry">
+               <rect>
+                <x>0</x>
+                <y>0</y>
+                <width>674</width>
+                <height>505</height>
+               </rect>
+              </property>
+              <layout class="QVBoxLayout" name="verticalLayout_39">
+               <property name="topMargin">
+                <number>0</number>
+               </property>
+               <item>
+                <widget class="QGroupBox" name="groupBox_3">
+                 <property name="title">
+                  <string>Composition defaults</string>
+                 </property>
+                 <layout class="QGridLayout" name="gridLayout_8">
+                  <item row="0" column="0">
+                   <layout class="QHBoxLayout" name="horizontalLayout_4">
+                    <item>
+                     <widget class="QLabel" name="label_58">
+                      <property name="text">
+                       <string>Default font</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QFontComboBox" name="mComposerFontComboBox">
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                  <item row="7" column="0">
+                   <spacer name="verticalSpacer_10">
+                    <property name="orientation">
+                     <enum>Qt::Vertical</enum>
+                    </property>
+                    <property name="sizeHint" stdset="0">
+                     <size>
+                      <width>20</width>
+                      <height>40</height>
+                     </size>
+                    </property>
+                   </spacer>
+                  </item>
+                 </layout>
+                </widget>
                </item>
               </layout>
              </widget>

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -2888,8 +2888,7 @@
                      </widget>
                     </item>
                     <item>
-                     <widget class="QFontComboBox" name="mComposerFontComboBox">
-                     </widget>
+                     <widget class="QFontComboBox" name="mComposerFontComboBox"/>
                     </item>
                    </layout>
                   </item>
@@ -2918,6 +2917,119 @@
                      <widget class="QgsColorButton" name="mGridColorButton">
                       <property name="text">
                        <string>Color...</string>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="groupBox_24">
+                 <property name="title">
+                  <string>Grid defaults</string>
+                 </property>
+                 <layout class="QGridLayout" name="gridLayout_11">
+                  <item row="0" column="0">
+                   <widget class="QLabel" name="label_61">
+                    <property name="text">
+                     <string>Spacing</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="1">
+                   <widget class="QDoubleSpinBox" name="mGridResolutionSpinBox">
+                    <property name="suffix">
+                     <string> mm</string>
+                    </property>
+                    <property name="minimum">
+                     <double>0.500000000000000</double>
+                    </property>
+                    <property name="maximum">
+                     <double>9999.000000000000000</double>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="2">
+                   <widget class="QLabel" name="label_63">
+                    <property name="text">
+                     <string>Grid offset</string>
+                    </property>
+                    <property name="wordWrap">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="3">
+                   <layout class="QHBoxLayout" name="horizontalLayout_36">
+                    <item>
+                     <widget class="QDoubleSpinBox" name="mOffsetXSpinBox">
+                      <property name="prefix">
+                       <string>x: </string>
+                      </property>
+                      <property name="maximum">
+                       <double>9999.000000000000000</double>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QDoubleSpinBox" name="mOffsetYSpinBox">
+                      <property name="prefix">
+                       <string>y: </string>
+                      </property>
+                      <property name="suffix">
+                       <string/>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                  <item row="1" column="0">
+                   <widget class="QLabel" name="label_62">
+                    <property name="text">
+                     <string>Snap tolerance</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="1">
+                   <widget class="QDoubleSpinBox" name="mGridToleranceSpinBox">
+                    <property name="prefix">
+                     <string/>
+                    </property>
+                    <property name="suffix">
+                     <string> mm</string>
+                    </property>
+                    <property name="value">
+                     <double>2.000000000000000</double>
+                    </property>
+                   </widget>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QGroupBox" name="groupBox_25">
+                 <property name="title">
+                  <string>Guide defaults</string>
+                 </property>
+                 <layout class="QGridLayout" name="gridLayout_12">
+                  <item row="0" column="0">
+                   <layout class="QHBoxLayout" name="horizontalLayout_37">
+                    <item>
+                     <widget class="QLabel" name="label_64">
+                      <property name="text">
+                       <string>Snap tolerance</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QDoubleSpinBox" name="mGuideToleranceSpinBox">
+                      <property name="prefix">
+                       <string/>
+                      </property>
+                      <property name="suffix">
+                       <string> mm</string>
                       </property>
                      </widget>
                     </item>


### PR DESCRIPTION
This request moves a bunch of composer related settings which apply globally (ie, not just to the current composition) to a new "Composer" page in the qgis options window. These include the grid color and style, and also new options for the default font for composer items and the default grid and guide parameters. This helps users distinguish between settings which only apply to the current composer and settings which apply to all compositions, and makes room for a lot more composer default options (I'm thinking default page size and orientation for a start, and default composer units in the future).

I've also added a method for opening the options window at a specific page, and there's a shortcut to go straight the the composer preferences from composer windows.

One important thing to note is that I've moved the location of the grid settings, so previous settings for grid colour and style are ignored. There's two reasons I've done this:
1. To keep the QGIS settings organised and group all composer related settings together
2. The old QGIS default grid colour was solid black, no transparency. This is very visually heavy. I've set a new lighter, semi-transparent default color for the grid. Moving the grid settings to a new location means that all QGIS users will get this improved grid colouring by default.
