### PR TITLE
[cmake] Fix warnings.

### DIFF
--- a/cmake/UsePythonTest.cmake
+++ b/cmake/UsePythonTest.cmake
@@ -57,10 +57,10 @@ EXECUTE_PROCESS(
 )
 # Pass the output back to ctest
 IF(import_output)
-  MESSAGE("\${import_output}")
+  MESSAGE(" \${import_output} ")
 ENDIF(import_output)
 IF(import_res)
-  MESSAGE(SEND_ERROR "\${import_res}")
+  MESSAGE(SEND_ERROR " \${import_res} ")
 ENDIF(import_res)
 "
 )


### PR DESCRIPTION
cmake spits the following warning on newer versions. Details can be found here http://www.cmake.org/Bug/view.php?id=14441

---

```
CMake Warning (dev) at tests/src/python/CMakeLists.txt:1 (INCLUDE):
  Syntax Warning in cmake code at

    /home/kk/dev/cpp/qgis/QGIS/cmake/UsePythonTest.cmake:60:12

  Argument not separated from preceding token by whitespace.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at tests/src/python/CMakeLists.txt:1 (INCLUDE):
  Syntax Warning in cmake code at

    /home/kk/dev/cpp/qgis/QGIS/cmake/UsePythonTest.cmake:60:29

  Argument not separated from preceding token by whitespace.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at tests/src/python/CMakeLists.txt:1 (INCLUDE):
  Syntax Warning in cmake code at

    /home/kk/dev/cpp/qgis/QGIS/cmake/UsePythonTest.cmake:63:23

  Argument not separated from preceding token by whitespace.
This warning is for project developers.  Use -Wno-dev to suppress it.

CMake Warning (dev) at tests/src/python/CMakeLists.txt:1 (INCLUDE):
  Syntax Warning in cmake code at

    /home/kk/dev/cpp/qgis/QGIS/cmake/UsePythonTest.cmake:63:37

  Argument not separated from preceding token by whitespace.
This warning is for project developers.  Use -Wno-dev to suppress it.
```
