### PR TITLE
[processing] Add crs selection panel to scripts

### DIFF
--- a/python/plugins/processing/gui/CrsSelectionPanel.py
+++ b/python/plugins/processing/gui/CrsSelectionPanel.py
@@ -27,13 +27,13 @@ __revision__ = '$Format:%H$'
 
 from PyQt4 import QtGui, QtCore
 from processing.gui.CrsSelectionDialog import CrsSelectionDialog
-
+from qgis.core import QgsCoordinateReferenceSystem
 
 class CrsSelectionPanel(QtGui.QWidget):
 
     def __init__(self, default):
         super(CrsSelectionPanel, self).__init__(None)
-        self.authid = default
+        self.authid = QgsCoordinateReferenceSystem(default).authid()
         self.horizontalLayout = QtGui.QHBoxLayout(self)
         self.horizontalLayout.setSpacing(2)
         self.horizontalLayout.setMargin(0)

--- a/python/plugins/processing/script/ScriptAlgorithm.py
+++ b/python/plugins/processing/script/ScriptAlgorithm.py
@@ -35,6 +35,7 @@ from processing.parameters.ParameterTable import ParameterTable
 from processing.parameters.ParameterVector import ParameterVector
 from processing.parameters.ParameterMultipleInput import ParameterMultipleInput
 from processing.parameters.ParameterString import ParameterString
+from processing.parameters.ParameterCrs import ParameterCrs
 from processing.parameters.ParameterNumber import ParameterNumber
 from processing.parameters.ParameterBoolean import ParameterBoolean
 from processing.parameters.ParameterSelection import ParameterSelection
@@ -128,7 +129,7 @@ class ScriptAlgorithm(GeoAlgorithm):
         if '|' in line:
             self.processDescriptionParameterLine(line)
             return
-        tokens = line.split('=')
+        tokens = line.split('=', 1)
         desc = self.createDescriptiveName(tokens[0])
         if tokens[1].lower().strip() == 'group':
             self.group = tokens[0]
@@ -178,6 +179,11 @@ class ScriptAlgorithm(GeoAlgorithm):
         elif tokens[1].lower().strip().startswith('string'):
             default = tokens[1].strip()[len('string') + 1:]
             param = ParameterString(tokens[0], desc, default)
+        elif tokens[1].lower().strip().startswith('crs'):
+            default = tokens[1].strip()[len('crs') + 1:]
+            if not default:
+                default = 'EPSG:4326'
+            param = ParameterCrs(tokens[0], desc, default)
         elif tokens[1].lower().strip().startswith('output raster'):
             out = OutputRaster()
         elif tokens[1].lower().strip().startswith('output vector'):


### PR DESCRIPTION
CRS selection panel can be added as widget from scripts:
![crs_panel](https://f.cloud.github.com/assets/1368688/1485485/c375e824-4715-11e3-9b4d-bfbc4de3a185.png)
Simple type 'crs' as parametr type:

``` python
##outCrs=crs
```

Default CRS is WGS84, but it can be changed by passing optional value which can be any of string definition supported by QgsCoordinateReferenceSystem.:

``` python
##outCrs=crs EPSG:2180
##outCrs=crs proj4:+proj=tmerc +lat_0=0 +lon_0=19 +k=0.9993 +x_0=500000 +y_0=-5300000 +ellps=GRS80 +towgs84=0,0,0,0,0,0,0 +units=m +no_defs
```
