### PR TITLE
Update v.distance.txt

### DIFF
--- a/python/plugins/processing/grass/description/v.distance.txt
+++ b/python/plugins/processing/grass/description/v.distance.txt
@@ -4,7 +4,7 @@ Vector (v.*)
 ParameterVector|from|"from" input layer|0|False
 ParameterVector|to|"to" input layer|-1|False
 ParameterSelection|upload|Values describing the relation between two nearest features|cat;dist;to_x;to_y;to_along;to_angle
-ParameterTableField|column|Column where values specified by 'upload' option will be uploaded|to|-1|False
+ParameterTableField|column|Column where values specified by 'upload' option will be uploaded|from|-1|False
 ParameterBoolean|-a|Calculate distances to all features within the threshold|False
 OutputVector|output|Output layer
 


### PR DESCRIPTION
Changed the ParameterTableField layer to "from".  This is correct for the "dist" relation option, and probably for all the other relation options.
According to the GRASS documentation, it seems that all attribute updates is done to the first (from) layer:

```
DESCRIPTION
v.distance finds the nearest element in vector map (to) for elements in vector map (from).
Various information about the vectors' relationships (distance, category, etc.) may be
uploaded to the attribute table attached to the first vector map, or printed to 'stdout'.
A new vector map may be created where lines connecting nearest points on features are
written. dmin and/or dmax can be used to limit the search radius.
```

The GRASS documentation is a bit confusing, since it refers to the "first vector map" (and not the "from" vector map), and the "to" vector map is mentioned before the "from" vector map.
