### PR TITLE
English typo in ui

### DIFF
--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -116,7 +116,7 @@ class ModelerDialog(QDialog, Ui_DlgModeler):
     def closeEvent(self, evt):
         if self.hasChanged:
             ret = QMessageBox.question(self, self.tr('Message'),
-                    self.tr('They are unchanged changes in model. Close '
+                    self.tr('There are unchanged changes in model. Close '
                             'modeler without saving?'),
                     QMessageBox.Yes | QMessageBox.No,
                     QMessageBox.No)

--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -116,7 +116,7 @@ class ModelerDialog(QDialog, Ui_DlgModeler):
     def closeEvent(self, evt):
         if self.hasChanged:
             ret = QMessageBox.question(self, self.tr('Message'),
-                    self.tr('The are unchanged changes in model. Close '
+                    self.tr('They are unchanged changes in model. Close '
                             'modeler without saving?'),
                     QMessageBox.Yes | QMessageBox.No,
                     QMessageBox.No)


### PR DESCRIPTION
@volaya: correct a typo in english. We need to correct this before translating the sentence in french.
