### PR TITLE
[composer] Change to pos() for item position

### DIFF
--- a/src/app/composer/qgscomposeritemwidget.cpp
+++ b/src/app/composer/qgscomposeritemwidget.cpp
@@ -244,64 +244,64 @@ void QgsComposerItemWidget::setValuesForGuiPositionElements()
   if ( mItem->lastUsedPositionMode() == QgsComposerItem::UpperLeft )
   {
     mUpperLeftCheckBox->setChecked( true );
-    mXLineEdit->setText( QString::number( mItem->transform().dx() ) );
-    mYLineEdit->setText( QString::number( mItem->transform().dy() ) );
+    mXLineEdit->setText( QString::number( mItem->pos().x() ) );
+    mYLineEdit->setText( QString::number( mItem->pos().y() ) );
   }
 
   if ( mItem->lastUsedPositionMode() == QgsComposerItem::UpperMiddle )
   {
     mUpperMiddleCheckBox->setChecked( true );
-    mXLineEdit->setText( QString::number( mItem->transform().dx() + mItem->rect().width() / 2.0 ) );
-    mYLineEdit->setText( QString::number( mItem->transform().dy() ) );
+    mXLineEdit->setText( QString::number( mItem->pos().x() + mItem->rect().width() / 2.0 ) );
+    mYLineEdit->setText( QString::number( mItem->pos().y() ) );
   }
 
   if ( mItem->lastUsedPositionMode() == QgsComposerItem::UpperRight )
   {
     mUpperRightCheckBox->setChecked( true );
-    mXLineEdit->setText( QString::number( mItem->transform().dx() + mItem->rect().width() ) );
-    mYLineEdit->setText( QString::number( mItem->transform().dy() ) );
+    mXLineEdit->setText( QString::number( mItem->pos().x() + mItem->rect().width() ) );
+    mYLineEdit->setText( QString::number( mItem->pos().y() ) );
   }
 
   if ( mItem->lastUsedPositionMode() == QgsComposerItem::MiddleLeft )
   {
     mMiddleLeftCheckBox->setChecked( true );
-    mXLineEdit->setText( QString::number( mItem->transform().dx() ) );
-    mYLineEdit->setText( QString::number( mItem->transform().dy() + mItem->rect().height() / 2.0 ) );
+    mXLineEdit->setText( QString::number( mItem->pos().x() ) );
+    mYLineEdit->setText( QString::number( mItem->pos().y() + mItem->rect().height() / 2.0 ) );
   }
 
   if ( mItem->lastUsedPositionMode() == QgsComposerItem::Middle )
   {
     mMiddleCheckBox->setChecked( true );
-    mXLineEdit->setText( QString::number( mItem->transform().dx() + mItem->rect().width() / 2.0 ) );
-    mYLineEdit->setText( QString::number( mItem->transform().dy() + mItem->rect().height() / 2.0 ) );
+    mXLineEdit->setText( QString::number( mItem->pos().x() + mItem->rect().width() / 2.0 ) );
+    mYLineEdit->setText( QString::number( mItem->pos().y() + mItem->rect().height() / 2.0 ) );
   }
 
   if ( mItem->lastUsedPositionMode() == QgsComposerItem::MiddleRight )
   {
     mMiddleRightCheckBox->setChecked( true );
-    mXLineEdit->setText( QString::number( mItem->transform().dx() + mItem->rect().width() ) );
-    mYLineEdit->setText( QString::number( mItem->transform().dy() + mItem->rect().height() / 2.0 ) );
+    mXLineEdit->setText( QString::number( mItem->pos().x() + mItem->rect().width() ) );
+    mYLineEdit->setText( QString::number( mItem->pos().y() + mItem->rect().height() / 2.0 ) );
   }
 
   if ( mItem->lastUsedPositionMode() == QgsComposerItem::LowerLeft )
   {
     mLowerLeftCheckBox->setChecked( true );
-    mXLineEdit->setText( QString::number( mItem->transform().dx() ) );
-    mYLineEdit->setText( QString::number( mItem->transform().dy() + mItem->rect().height() ) );
+    mXLineEdit->setText( QString::number( mItem->pos().x() ) );
+    mYLineEdit->setText( QString::number( mItem->pos().y() + mItem->rect().height() ) );
   }
 
   if ( mItem->lastUsedPositionMode() == QgsComposerItem::LowerMiddle )
   {
     mLowerMiddleCheckBox->setChecked( true );
-    mXLineEdit->setText( QString::number( mItem->transform().dx() + mItem->rect().width() / 2.0 ) );
-    mYLineEdit->setText( QString::number( mItem->transform().dy() + mItem->rect().height() ) );
+    mXLineEdit->setText( QString::number( mItem->pos().x() + mItem->rect().width() / 2.0 ) );
+    mYLineEdit->setText( QString::number( mItem->pos().y() + mItem->rect().height() ) );
   }
 
   if ( mItem->lastUsedPositionMode() == QgsComposerItem::LowerRight )
   {
     mLowerRightCheckBox->setChecked( true );
-    mXLineEdit->setText( QString::number( mItem->transform().dx() + mItem->rect().width() ) );
-    mYLineEdit->setText( QString::number( mItem->transform().dy() + mItem->rect().height() ) );
+    mXLineEdit->setText( QString::number( mItem->pos().x() + mItem->rect().width() ) );
+    mYLineEdit->setText( QString::number( mItem->pos().y() + mItem->rect().height() ) );
   }
 
   mWidthLineEdit->setText( QString::number( mItem->rect().width() ) );
@@ -395,7 +395,7 @@ void QgsComposerItemWidget::on_mUpperLeftCheckBox_stateChanged( int state )
     return;
   if ( mItem )
   {
-    mItem->setItemPosition( mItem->transform().dx(), mItem->transform().dy(), QgsComposerItem::UpperLeft );
+    mItem->setItemPosition( mItem->pos().x(), mItem->pos().y(), QgsComposerItem::UpperLeft );
   }
   setValuesForGuiPositionElements();
 }
@@ -406,8 +406,8 @@ void QgsComposerItemWidget::on_mUpperMiddleCheckBox_stateChanged( int state )
     return;
   if ( mItem )
   {
-    mItem->setItemPosition( mItem->transform().dx() + mItem->rect().width() / 2.0,
-                            mItem->transform().dy(), QgsComposerItem::UpperMiddle );
+    mItem->setItemPosition( mItem->pos().x() + mItem->rect().width() / 2.0,
+                            mItem->pos().y(), QgsComposerItem::UpperMiddle );
   }
   setValuesForGuiPositionElements();
 }
@@ -418,8 +418,8 @@ void QgsComposerItemWidget::on_mUpperRightCheckBox_stateChanged( int state )
     return;
   if ( mItem )
   {
-    mItem->setItemPosition( mItem->transform().dx() + mItem->rect().width(),
-                            mItem->transform().dy(), QgsComposerItem::UpperRight );
+    mItem->setItemPosition( mItem->pos().x() + mItem->rect().width(),
+                            mItem->pos().y(), QgsComposerItem::UpperRight );
   }
   setValuesForGuiPositionElements();
 }
@@ -430,8 +430,8 @@ void QgsComposerItemWidget::on_mMiddleLeftCheckBox_stateChanged( int state )
     return;
   if ( mItem )
   {
-    mItem->setItemPosition( mItem->transform().dx(),
-                            mItem->transform().dy() + mItem->rect().height() / 2.0, QgsComposerItem::MiddleLeft );
+    mItem->setItemPosition( mItem->pos().x(),
+                            mItem->pos().y() + mItem->rect().height() / 2.0, QgsComposerItem::MiddleLeft );
   }
   setValuesForGuiPositionElements();
 }
@@ -442,8 +442,8 @@ void QgsComposerItemWidget::on_mMiddleCheckBox_stateChanged( int state )
     return;
   if ( mItem )
   {
-    mItem->setItemPosition( mItem->transform().dx() + mItem->rect().width() / 2.0,
-                            mItem->transform().dy() + mItem->rect().height() / 2.0, QgsComposerItem::Middle );
+    mItem->setItemPosition( mItem->pos().x() + mItem->rect().width() / 2.0,
+                            mItem->pos().y() + mItem->rect().height() / 2.0, QgsComposerItem::Middle );
   }
   setValuesForGuiPositionElements();
 }
@@ -454,8 +454,8 @@ void QgsComposerItemWidget::on_mMiddleRightCheckBox_stateChanged( int state )
     return;
   if ( mItem )
   {
-    mItem->setItemPosition( mItem->transform().dx() + mItem->rect().width(),
-                            mItem->transform().dy() + mItem->rect().height() / 2.0, QgsComposerItem::MiddleRight );
+    mItem->setItemPosition( mItem->pos().x() + mItem->rect().width(),
+                            mItem->pos().y() + mItem->rect().height() / 2.0, QgsComposerItem::MiddleRight );
   }
   setValuesForGuiPositionElements();
 }
@@ -466,8 +466,8 @@ void QgsComposerItemWidget::on_mLowerLeftCheckBox_stateChanged( int state )
     return;
   if ( mItem )
   {
-    mItem->setItemPosition( mItem->transform().dx(),
-                            mItem->transform().dy() + mItem->rect().height(), QgsComposerItem::LowerLeft );
+    mItem->setItemPosition( mItem->pos().x(),
+                            mItem->pos().y() + mItem->rect().height(), QgsComposerItem::LowerLeft );
   }
   setValuesForGuiPositionElements();
 }
@@ -478,8 +478,8 @@ void QgsComposerItemWidget::on_mLowerMiddleCheckBox_stateChanged( int state )
     return;
   if ( mItem )
   {
-    mItem->setItemPosition( mItem->transform().dx() + mItem->rect().width() / 2.0,
-                            mItem->transform().dy() + mItem->rect().height(), QgsComposerItem::LowerMiddle );
+    mItem->setItemPosition( mItem->pos().x() + mItem->rect().width() / 2.0,
+                            mItem->pos().y() + mItem->rect().height(), QgsComposerItem::LowerMiddle );
   }
   setValuesForGuiPositionElements();
 }
@@ -490,8 +490,8 @@ void QgsComposerItemWidget::on_mLowerRightCheckBox_stateChanged( int state )
     return;
   if ( mItem )
   {
-    mItem->setItemPosition( mItem->transform().dx() + mItem->rect().width(),
-                            mItem->transform().dy() + mItem->rect().height(), QgsComposerItem::LowerRight );
+    mItem->setItemPosition( mItem->pos().x() + mItem->rect().width(),
+                            mItem->pos().y() + mItem->rect().height(), QgsComposerItem::LowerRight );
   }
   setValuesForGuiPositionElements();
 }

--- a/src/core/composer/qgscomposerarrow.cpp
+++ b/src/core/composer/qgscomposerarrow.cpp
@@ -76,7 +76,7 @@ void QgsComposerArrow::paint( QPainter* painter, const QStyleOptionGraphicsItem 
   arrowPen.setColor( mArrowColor );
   painter->setPen( arrowPen );
   painter->setBrush( QBrush( mArrowColor ) );
-  painter->drawLine( QPointF( mStartPoint.x() - transform().dx(), mStartPoint.y() - transform().dy() ), QPointF( mStopPoint.x() - transform().dx(), mStopPoint.y() - transform().dy() ) );
+  painter->drawLine( QPointF( mStartPoint.x() - pos().x(), mStartPoint.y() - pos().y() ), QPointF( mStopPoint.x() - pos().x(), mStopPoint.y() - pos().y() ) );
 
   if ( mMarkerMode == DefaultMarker )
   {
@@ -98,10 +98,10 @@ void QgsComposerArrow::paint( QPainter* painter, const QStyleOptionGraphicsItem 
 void QgsComposerArrow::setSceneRect( const QRectF& rectangle )
 {
   //maintain the relative position of start and stop point in the rectangle
-  double startPointXPos = ( mStartPoint.x() - transform().dx() ) / rect().width();
-  double startPointYPos = ( mStartPoint.y() - transform().dy() ) / rect().height();
-  double stopPointXPos = ( mStopPoint.x() - transform().dx() ) / rect().width();
-  double stopPointYPos = ( mStopPoint.y() - transform().dy() ) / rect().height();
+  double startPointXPos = ( mStartPoint.x() - pos().x() ) / rect().width();
+  double startPointYPos = ( mStartPoint.y() - pos().y() ) / rect().height();
+  double stopPointXPos = ( mStopPoint.x() - pos().x() ) / rect().width();
+  double stopPointYPos = ( mStopPoint.y() - pos().y() ) / rect().height();
 
   mStartPoint.setX( rectangle.left() + startPointXPos * rectangle.width() );
   mStartPoint.setY( rectangle.top() + startPointYPos * rectangle.height() );
@@ -117,7 +117,7 @@ void QgsComposerArrow::drawHardcodedMarker( QPainter *p, MarkerType type )
   QBrush arrowBrush = p->brush();
   arrowBrush.setColor( mArrowColor );
   p->setBrush( arrowBrush );
-  drawArrowHead( p, mStopPoint.x() - transform().dx(), mStopPoint.y() - transform().dy(), angle( mStartPoint, mStopPoint ), mArrowHeadWidth );
+  drawArrowHead( p, mStopPoint.x() - pos().x(), mStopPoint.y() - pos().y(), angle( mStartPoint, mStopPoint ), mArrowHeadWidth );
 }
 
 void QgsComposerArrow::drawSVGMarker( QPainter* p, MarkerType type, const QString &markerPath )
@@ -156,12 +156,12 @@ void QgsComposerArrow::drawSVGMarker( QPainter* p, MarkerType type, const QStrin
   QPointF canvasPoint;
   if ( type == StartMarker )
   {
-    canvasPoint = QPointF( mStartPoint.x() - transform().dx(), mStartPoint.y() - transform().dy() );
+    canvasPoint = QPointF( mStartPoint.x() - pos().x(), mStartPoint.y() - pos().y() );
     imageFixPoint.setY( mStartArrowHeadHeight );
   }
   else //end marker
   {
-    canvasPoint = QPointF( mStopPoint.x() - transform().dx(), mStopPoint.y() - transform().dy() );
+    canvasPoint = QPointF( mStopPoint.x() - pos().x(), mStopPoint.y() - pos().y() );
     imageFixPoint.setY( 0 );
   }
 

--- a/src/core/composer/qgscomposeritem.cpp
+++ b/src/core/composer/qgscomposeritem.cpp
@@ -86,9 +86,7 @@ QgsComposerItem::QgsComposerItem( qreal x, qreal y, qreal width, qreal height, Q
     , mUuid( QUuid::createUuid().toString() )
 {
   init( manageZValue );
-  QTransform t;
-  t.translate( x, y );
-  setTransform( t );
+  setPos( x, y );
 }
 
 void QgsComposerItem::init( bool manageZValue )
@@ -165,8 +163,8 @@ bool QgsComposerItem::_writeXML( QDomElement& itemElem, QDomDocument& doc ) cons
   }
 
   //scene rect
-  composerItemElem.setAttribute( "x", QString::number( transform().dx() ) );
-  composerItemElem.setAttribute( "y", QString::number( transform().dy() ) );
+  composerItemElem.setAttribute( "x", QString::number( pos().x() ) );
+  composerItemElem.setAttribute( "y", QString::number( pos().y() ) );
   composerItemElem.setAttribute( "width", QString::number( rect().width() ) );
   composerItemElem.setAttribute( "height", QString::number( rect().height() ) );
   composerItemElem.setAttribute( "positionMode", QString::number(( int ) mLastUsedPositionMode ) );
@@ -416,8 +414,7 @@ void QgsComposerItem::setPositionLock( bool lock )
 
 void QgsComposerItem::move( double dx, double dy )
 {
-  QTransform t = transform();
-  QRectF newSceneRect( t.dx() + dx, t.dy() + dy, rect().width(), rect().height() );
+  QRectF newSceneRect( pos().x() + dx, pos().y() + dy, rect().width(), rect().height() );
   setSceneRect( newSceneRect );
 }
 
@@ -482,11 +479,7 @@ void QgsComposerItem::setSceneRect( const QRectF& rectangle )
 
   QRectF newRect( 0, 0, newWidth, newHeight );
   QGraphicsRectItem::setRect( newRect );
-
-  //set up transformation matrix for item coordinates
-  QTransform t;
-  t.translate( xTranslation, yTranslation );
-  setTransform( t );
+  setPos( xTranslation, yTranslation );
 
   emit sizeChanged();
 }

--- a/src/core/composer/qgscomposeritemgroup.cpp
+++ b/src/core/composer/qgscomposeritemgroup.cpp
@@ -60,8 +60,8 @@ void QgsComposerItemGroup::addItem( QgsComposerItem* item )
   item->setFlag( QGraphicsItem::ItemIsSelectable, false ); //item in groups cannot be selected
 
   //update extent (which is in scene coordinates)
-  double minXItem = item->transform().dx();
-  double minYItem = item->transform().dy();
+  double minXItem = item->pos().x();
+  double minYItem = item->pos().y();
   double maxXItem = minXItem + item->rect().width();
   double maxYItem = minYItem + item->rect().height();
 
@@ -126,9 +126,9 @@ void QgsComposerItemGroup::setSceneRect( const QRectF& rectangle )
 {
   //calculate values between 0 and 1 for boundaries of all contained items, depending on their positions in the item group rectangle.
   //then position the item boundaries in the new item group rect such that these values are the same
-  double xLeftCurrent = transform().dx();
+  double xLeftCurrent = pos().x();
   double xRightCurrent = xLeftCurrent + rect().width();
-  double yTopCurrent = transform().dy();
+  double yTopCurrent = pos().y();
   double yBottomCurrent = yTopCurrent + rect().height();
 
   double xItemLeft, xItemRight, yItemTop, yItemBottom;
@@ -139,9 +139,9 @@ void QgsComposerItemGroup::setSceneRect( const QRectF& rectangle )
   QSet<QgsComposerItem*>::iterator item_it = mItems.begin();
   for ( ; item_it != mItems.end(); ++item_it )
   {
-    xItemLeft = ( *item_it )->transform().dx();
+    xItemLeft = ( *item_it )->pos().x();
     xItemRight = xItemLeft + ( *item_it )->rect().width();
-    yItemTop = ( *item_it )->transform().dy();
+    yItemTop = ( *item_it )->pos().y();
     yItemBottom = yItemTop + ( *item_it )->rect().height();
 
     xParamLeft = ( xItemLeft - xLeftCurrent ) / ( xRightCurrent - xLeftCurrent );

--- a/src/core/composer/qgscomposerlabel.cpp
+++ b/src/core/composer/qgscomposerlabel.cpp
@@ -237,7 +237,7 @@ void QgsComposerLabel::adjustSizeToText()
   double yShift = 0;
   itemShiftAdjustSize( width, height, xShift, yShift );
 
-  QgsComposerItem::setSceneRect( QRectF( transform().dx() + xShift, transform().dy() + yShift, width, height ) );
+  QgsComposerItem::setSceneRect( QRectF( pos().x() + xShift, pos().y() + yShift, width, height ) );
 }
 
 QFont QgsComposerLabel::font() const
@@ -252,8 +252,8 @@ void QgsComposerLabel::setRotation( double r )
   QgsComposerItem::setRotation( r );
   sizeChangedByRotation( width, height );
 
-  double x = transform().dx() + rect().width() / 2.0 - width / 2.0;
-  double y = transform().dy() + rect().height() / 2.0 - height / 2.0;
+  double x = pos().x() + rect().width() / 2.0 - width / 2.0;
+  double y = pos().y() + rect().height() / 2.0 - height / 2.0;
   QgsComposerItem::setSceneRect( QRectF( x, y, width, height ) );
 }
 

--- a/src/core/composer/qgscomposerlegend.cpp
+++ b/src/core/composer/qgscomposerlegend.cpp
@@ -175,11 +175,11 @@ QSizeF QgsComposerLegend::paintAndDetermineSize( QPainter* painter )
   //adjust box if width or height is to small
   if ( painter && size.height() > rect().height() )
   {
-    setSceneRect( QRectF( transform().dx(), transform().dy(), rect().width(), size.height() ) );
+    setSceneRect( QRectF( pos().x(), pos().y(), rect().width(), size.height() ) );
   }
   if ( painter && size.width() > rect().width() )
   {
-    setSceneRect( QRectF( transform().dx(), transform().dy(), size.width(), rect().height() ) );
+    setSceneRect( QRectF( pos().x(), pos().y(), size.width(), rect().height() ) );
   }
 
   if ( painter )
@@ -294,7 +294,7 @@ void QgsComposerLegend::adjustBoxSize()
   QgsDebugMsg( QString( "width = %1 height = %2" ).arg( size.width() ).arg( size.height() ) );
   if ( size.isValid() )
   {
-    setSceneRect( QRectF( transform().dx(), transform().dy(), size.width(), size.height() ) );
+    setSceneRect( QRectF( pos().x(), pos().y(), size.width(), size.height() ) );
   }
 }
 

--- a/src/core/composer/qgscomposermap.cpp
+++ b/src/core/composer/qgscomposermap.cpp
@@ -470,7 +470,7 @@ void QgsComposerMap::resize( double dx, double dy )
 {
   //setRect
   QRectF currentRect = rect();
-  QRectF newSceneRect = QRectF( transform().dx(), transform().dy(), currentRect.width() + dx, currentRect.height() + dy );
+  QRectF newSceneRect = QRectF( pos().x(), pos().y(), currentRect.width() + dx, currentRect.height() + dy );
   setSceneRect( newSceneRect );
   updateItem();
 }
@@ -591,7 +591,7 @@ void QgsComposerMap::setNewExtent( const QgsRectangle& extent )
 
   double newHeight = currentRect.width() * extent.height() / extent.width();
 
-  setSceneRect( QRectF( transform().dx(), transform().dy(), currentRect.width(), newHeight ) );
+  setSceneRect( QRectF( pos().x(), pos().y(), currentRect.width(), newHeight ) );
   updateItem();
 }
 

--- a/src/core/composer/qgscomposermousehandles.cpp
+++ b/src/core/composer/qgscomposermousehandles.cpp
@@ -1026,12 +1026,12 @@ void QgsComposerMouseHandles::collectAlignCoordinates( QMap< double, const QgsCo
       {
         continue;
       }
-      alignCoordsX.insert( currentItem->transform().dx(), currentItem );
-      alignCoordsX.insert( currentItem->transform().dx() + currentItem->rect().width(), currentItem );
-      alignCoordsX.insert( currentItem->transform().dx() + currentItem->rect().center().x(), currentItem );
-      alignCoordsY.insert( currentItem->transform().dy() + currentItem->rect().top(), currentItem );
-      alignCoordsY.insert( currentItem->transform().dy() + currentItem->rect().center().y(), currentItem );
-      alignCoordsY.insert( currentItem->transform().dy() + currentItem->rect().bottom(), currentItem );
+      alignCoordsX.insert( currentItem->pos().x(), currentItem );
+      alignCoordsX.insert( currentItem->pos().x() + currentItem->rect().width(), currentItem );
+      alignCoordsX.insert( currentItem->pos().x() + currentItem->rect().center().x(), currentItem );
+      alignCoordsY.insert( currentItem->pos().y() + currentItem->rect().top(), currentItem );
+      alignCoordsY.insert( currentItem->pos().y() + currentItem->rect().center().y(), currentItem );
+      alignCoordsY.insert( currentItem->pos().y() + currentItem->rect().bottom(), currentItem );
     }
   }
 

--- a/src/core/composer/qgscomposermultiframe.cpp
+++ b/src/core/composer/qgscomposermultiframe.cpp
@@ -95,7 +95,7 @@ void QgsComposerMultiFrame::recalculateFrameSizes()
     while (( mResizeMode == RepeatOnEveryPage ) || currentY < totalHeight )
     {
       //find out on which page the lower left point of the last frame is
-      int page = currentItem->transform().dy() / ( mComposition->paperHeight() + mComposition->spaceBetweenPages() );
+      int page = currentItem->pos().y() / ( mComposition->paperHeight() + mComposition->spaceBetweenPages() );
       if ( mResizeMode == RepeatOnEveryPage )
       {
         if ( page > mComposition->numPages() - 2 )
@@ -124,9 +124,9 @@ void QgsComposerMultiFrame::recalculateFrameSizes()
       double newFrameY = ( page + 1 ) * ( mComposition->paperHeight() + mComposition->spaceBetweenPages() );
       if ( mResizeMode == RepeatUntilFinished || mResizeMode == RepeatOnEveryPage )
       {
-        newFrameY += currentItem->transform().dy() - page * ( mComposition->paperHeight() + mComposition->spaceBetweenPages() );
+        newFrameY += currentItem->pos().y() - page * ( mComposition->paperHeight() + mComposition->spaceBetweenPages() );
       }
-      QgsComposerFrame* newFrame = new QgsComposerFrame( mComposition, this, currentItem->transform().dx(),
+      QgsComposerFrame* newFrame = new QgsComposerFrame( mComposition, this, currentItem->pos().x(),
           newFrameY,
           currentItem->rect().width(), frameHeight );
       if ( mResizeMode == RepeatOnEveryPage )
@@ -179,7 +179,7 @@ void QgsComposerMultiFrame::handlePageChange()
   for ( int i = mFrameItems.size() - 1; i >= 0; --i )
   {
     QgsComposerFrame* frame = mFrameItems[i];
-    int page = frame->transform().dy() / ( mComposition->paperHeight() + mComposition->spaceBetweenPages() );
+    int page = frame->pos().y() / ( mComposition->paperHeight() + mComposition->spaceBetweenPages() );
     if ( page > ( mComposition->numPages() - 1 ) )
     {
       removeFrame( i );
@@ -188,13 +188,13 @@ void QgsComposerMultiFrame::handlePageChange()
 
   //page number of the last item
   QgsComposerFrame* lastFrame = mFrameItems.last();
-  int lastItemPage = lastFrame->transform().dy() / ( mComposition->paperHeight() + mComposition->spaceBetweenPages() );
+  int lastItemPage = lastFrame->pos().y() / ( mComposition->paperHeight() + mComposition->spaceBetweenPages() );
 
   for ( int i = lastItemPage + 1; i < mComposition->numPages(); ++i )
   {
     //copy last frame to current page
-    QgsComposerFrame* newFrame = new QgsComposerFrame( mComposition, this, lastFrame->transform().dx(),
-        lastFrame->transform().dy() + mComposition->paperHeight() + mComposition->spaceBetweenPages(),
+    QgsComposerFrame* newFrame = new QgsComposerFrame( mComposition, this, lastFrame->pos().x(),
+        lastFrame->pos().y() + mComposition->paperHeight() + mComposition->spaceBetweenPages(),
         lastFrame->rect().width(), lastFrame->rect().height() );
     addFrame( newFrame, false );
     lastFrame = newFrame;

--- a/src/core/composer/qgscomposerpicture.cpp
+++ b/src/core/composer/qgscomposerpicture.cpp
@@ -141,7 +141,7 @@ void QgsComposerPicture::setPictureFile( const QString& path )
 
   if ( mMode != Unknown ) //make sure we start with a new QImage
   {
-    setSceneRect( QRectF( transform().dx(), transform().dy(), rect().width(), rect().height() ) );
+    setSceneRect( QRectF( pos().x(), pos().y(), rect().width(), rect().height() ) );
   }
   emit itemChanged();
 }
@@ -221,8 +221,8 @@ void QgsComposerPicture::setRotation( double r )
   sizeChangedByRotation( width, height );
 
   //adapt scene rect to have the same center and the new width / height
-  double x = transform().dx() + rect().width() / 2.0 - width / 2.0;
-  double y = transform().dy() + rect().height() / 2.0 - height / 2.0;
+  double x = pos().x() + rect().width() / 2.0 - width / 2.0;
+  double y = pos().y() + rect().height() / 2.0 - height / 2.0;
   QgsComposerItem::setSceneRect( QRectF( x, y, width, height ) );
 
   QgsComposerItem::setRotation( r );

--- a/src/core/composer/qgscomposershape.cpp
+++ b/src/core/composer/qgscomposershape.cpp
@@ -150,8 +150,8 @@ void QgsComposerShape::setRotation( double r )
   sizeChangedByRotation( width, height );
 
   //adapt scene rect to have the same center and the new width / height
-  double x = transform().dx() + rect().width() / 2.0 - width / 2.0;
-  double y = transform().dy() + rect().height() / 2.0 - height / 2.0;
+  double x = pos().x() + rect().width() / 2.0 - width / 2.0;
+  double y = pos().y() + rect().height() / 2.0 - height / 2.0;
   QgsComposerItem::setSceneRect( QRectF( x, y, width, height ) );
 
   QgsComposerItem::setRotation( r );

--- a/src/core/composer/qgscomposertable.cpp
+++ b/src/core/composer/qgscomposertable.cpp
@@ -225,8 +225,8 @@ void QgsComposerTable::adaptItemFrame( const QMap<int, double>& maxWidthMap, con
   }
   totalWidth += ( 2 * maxWidthMap.size() * mLineTextDistance );
   totalWidth += ( maxWidthMap.size() + 1 ) * mGridStrokeWidth;
-  QTransform t = transform();
-  QgsComposerItem::setSceneRect( QRectF( t.dx(), t.dy(), totalWidth, totalHeight ) );
+
+  QgsComposerItem::setSceneRect( QRectF( pos().x(), pos().y(), totalWidth, totalHeight ) );
 }
 
 void QgsComposerTable::drawHorizontalGridLines( QPainter* p, int nAttributes )

--- a/src/core/composer/qgscomposition.cpp
+++ b/src/core/composer/qgscomposition.cpp
@@ -274,7 +274,7 @@ int QgsComposition::pageNumberAt( const QPointF& position ) const
 
 int QgsComposition::itemPageNumber( const QgsComposerItem* item ) const
 {
-  return pageNumberAt( QPointF( item->transform().dx(), item->transform().dy() ) );
+  return pageNumberAt( QPointF( item->pos().x(), item->pos().y() ) );
 }
 
 QList<QgsComposerItem*> QgsComposition::selectedComposerItems()
@@ -713,7 +713,7 @@ void QgsComposition::addItemsFromXML( const QDomElement& elem, const QDomDocumen
     {
       if ( pasteInPlacePt )
       {
-        newLabel->setItemPosition( newLabel->transform().dx(), fmod( newLabel->transform().dy(), ( paperHeight() + spaceBetweenPages() ) ) );
+        newLabel->setItemPosition( newLabel->pos().x(), fmod( newLabel->pos().y(), ( paperHeight() + spaceBetweenPages() ) ) );
         newLabel->move( pasteInPlacePt->x(), pasteInPlacePt->y() );
       }
       else
@@ -747,7 +747,7 @@ void QgsComposition::addItemsFromXML( const QDomElement& elem, const QDomDocumen
     {
       if ( pasteInPlace )
       {
-        newMap->setItemPosition( newMap->transform().dx(), fmod( newMap->transform().dy(), ( paperHeight() + spaceBetweenPages() ) ) );
+        newMap->setItemPosition( newMap->pos().x(), fmod( newMap->pos().y(), ( paperHeight() + spaceBetweenPages() ) ) );
         newMap->move( pasteInPlacePt->x(), pasteInPlacePt->y() );
       }
       else
@@ -772,7 +772,7 @@ void QgsComposition::addItemsFromXML( const QDomElement& elem, const QDomDocumen
     {
       if ( pasteInPlace )
       {
-        newArrow->setItemPosition( newArrow->transform().dx(), fmod( newArrow->transform().dy(), ( paperHeight() + spaceBetweenPages() ) ) );
+        newArrow->setItemPosition( newArrow->pos().x(), fmod( newArrow->pos().y(), ( paperHeight() + spaceBetweenPages() ) ) );
         newArrow->move( pasteInPlacePt->x(), pasteInPlacePt->y() );
       }
       else
@@ -797,7 +797,7 @@ void QgsComposition::addItemsFromXML( const QDomElement& elem, const QDomDocumen
     {
       if ( pasteInPlace )
       {
-        newScaleBar->setItemPosition( newScaleBar->transform().dx(), fmod( newScaleBar->transform().dy(), ( paperHeight() + spaceBetweenPages() ) ) );
+        newScaleBar->setItemPosition( newScaleBar->pos().x(), fmod( newScaleBar->pos().y(), ( paperHeight() + spaceBetweenPages() ) ) );
         newScaleBar->move( pasteInPlacePt->x(), pasteInPlacePt->y() );
       }
       else
@@ -822,7 +822,7 @@ void QgsComposition::addItemsFromXML( const QDomElement& elem, const QDomDocumen
     {
       if ( pasteInPlace )
       {
-        newShape->setItemPosition( newShape->transform().dx(), fmod( newShape->transform().dy(), ( paperHeight() + spaceBetweenPages() ) ) );
+        newShape->setItemPosition( newShape->pos().x(), fmod( newShape->pos().y(), ( paperHeight() + spaceBetweenPages() ) ) );
         newShape->move( pasteInPlacePt->x(), pasteInPlacePt->y() );
       }
       else
@@ -847,7 +847,7 @@ void QgsComposition::addItemsFromXML( const QDomElement& elem, const QDomDocumen
     {
       if ( pasteInPlace )
       {
-        newPicture->setItemPosition( newPicture->transform().dx(), fmod( newPicture->transform().dy(), ( paperHeight() + spaceBetweenPages() ) ) );
+        newPicture->setItemPosition( newPicture->pos().x(), fmod( newPicture->pos().y(), ( paperHeight() + spaceBetweenPages() ) ) );
         newPicture->move( pasteInPlacePt->x(), pasteInPlacePt->y() );
       }
       else
@@ -872,7 +872,7 @@ void QgsComposition::addItemsFromXML( const QDomElement& elem, const QDomDocumen
     {
       if ( pasteInPlace )
       {
-        newLegend->setItemPosition( newLegend->transform().dx(), fmod( newLegend->transform().dy(), ( paperHeight() + spaceBetweenPages() ) ) );
+        newLegend->setItemPosition( newLegend->pos().x(), fmod( newLegend->pos().y(), ( paperHeight() + spaceBetweenPages() ) ) );
         newLegend->move( pasteInPlacePt->x(), pasteInPlacePt->y() );
       }
       else
@@ -897,7 +897,7 @@ void QgsComposition::addItemsFromXML( const QDomElement& elem, const QDomDocumen
     {
       if ( pasteInPlace )
       {
-        newTable->setItemPosition( newTable->transform().dx(), fmod( newTable->transform().dy(), ( paperHeight() + spaceBetweenPages() ) ) );
+        newTable->setItemPosition( newTable->pos().x(), fmod( newTable->pos().y(), ( paperHeight() + spaceBetweenPages() ) ) );
         newTable->move( pasteInPlacePt->x(), pasteInPlacePt->y() );
       }
       else
@@ -1155,9 +1155,7 @@ void QgsComposition::alignSelectedItemsLeft()
   {
     QgsComposerItemCommand* subcommand = new QgsComposerItemCommand( *align_it, "", parentCommand );
     subcommand->savePreviousState();
-    QTransform itemTransform = ( *align_it )->transform();
-    itemTransform.translate( minXCoordinate - itemTransform.dx(), 0 );
-    ( *align_it )->setTransform( itemTransform );
+    ( *align_it )->setPos( minXCoordinate, ( *align_it )->pos().y() );
     subcommand->saveAfterState();
   }
   mUndoStack.push( parentCommand );
@@ -1186,9 +1184,7 @@ void QgsComposition::alignSelectedItemsHCenter()
   {
     QgsComposerItemCommand* subcommand = new QgsComposerItemCommand( *align_it, "", parentCommand );
     subcommand->savePreviousState();
-    QTransform itemTransform = ( *align_it )->transform();
-    itemTransform.translate( averageXCoord - itemTransform.dx() - ( *align_it )->rect().width() / 2.0, 0 );
-    ( *align_it )->setTransform( itemTransform );
+    ( *align_it )->setPos( averageXCoord - ( *align_it )->rect().width() / 2.0, ( *align_it )->pos().y() );
     subcommand->saveAfterState();
   }
   mUndoStack.push( parentCommand );
@@ -1217,9 +1213,7 @@ void QgsComposition::alignSelectedItemsRight()
   {
     QgsComposerItemCommand* subcommand = new QgsComposerItemCommand( *align_it, "", parentCommand );
     subcommand->savePreviousState();
-    QTransform itemTransform = ( *align_it )->transform();
-    itemTransform.translate( maxXCoordinate - itemTransform.dx() - ( *align_it )->rect().width(), 0 );
-    ( *align_it )->setTransform( itemTransform );
+    ( *align_it )->setPos( maxXCoordinate - ( *align_it )->rect().width(), ( *align_it )->pos().y() );
     subcommand->saveAfterState();
   }
   mUndoStack.push( parentCommand );
@@ -1247,9 +1241,7 @@ void QgsComposition::alignSelectedItemsTop()
   {
     QgsComposerItemCommand* subcommand = new QgsComposerItemCommand( *align_it, "", parentCommand );
     subcommand->savePreviousState();
-    QTransform itemTransform = ( *align_it )->transform();
-    itemTransform.translate( 0, minYCoordinate - itemTransform.dy() );
-    ( *align_it )->setTransform( itemTransform );
+    ( *align_it )->setPos(( *align_it )->pos().x(), minYCoordinate );
     subcommand->saveAfterState();
   }
   mUndoStack.push( parentCommand );
@@ -1276,9 +1268,7 @@ void QgsComposition::alignSelectedItemsVCenter()
   {
     QgsComposerItemCommand* subcommand = new QgsComposerItemCommand( *align_it, "", parentCommand );
     subcommand->savePreviousState();
-    QTransform itemTransform = ( *align_it )->transform();
-    itemTransform.translate( 0, averageYCoord - itemTransform.dy() - ( *align_it )->rect().height() / 2 );
-    ( *align_it )->setTransform( itemTransform );
+    ( *align_it )->setPos(( *align_it )->pos().x(), averageYCoord - ( *align_it )->rect().height() / 2 );
     subcommand->saveAfterState();
   }
   mUndoStack.push( parentCommand );
@@ -1305,9 +1295,7 @@ void QgsComposition::alignSelectedItemsBottom()
   {
     QgsComposerItemCommand* subcommand = new QgsComposerItemCommand( *align_it, "", parentCommand );
     subcommand->savePreviousState();
-    QTransform itemTransform = ( *align_it )->transform();
-    itemTransform.translate( 0, maxYCoord - itemTransform.dy() - ( *align_it )->rect().height() );
-    ( *align_it )->setTransform( itemTransform );
+    ( *align_it )->setPos(( *align_it )->pos().x(), maxYCoord - ( *align_it )->rect().height() );
     subcommand->saveAfterState();
   }
   mUndoStack.push( parentCommand );
@@ -1544,30 +1532,30 @@ QGraphicsLineItem* QgsComposition::nearestSnapLine( bool horizontal, double x, d
 
       if ( horizontal )
       {
-        if ( qgsDoubleNear( currentYCoord, currentItem->transform().dy() + currentItem->rect().top(), itemTolerance ) )
+        if ( qgsDoubleNear( currentYCoord, currentItem->pos().y() + currentItem->rect().top(), itemTolerance ) )
         {
           snappedItems.append( qMakePair( currentItem, QgsComposerItem::UpperMiddle ) );
         }
-        else if ( qgsDoubleNear( currentYCoord, currentItem->transform().dy() + currentItem->rect().center().y(), itemTolerance ) )
+        else if ( qgsDoubleNear( currentYCoord, currentItem->pos().y() + currentItem->rect().center().y(), itemTolerance ) )
         {
           snappedItems.append( qMakePair( currentItem, QgsComposerItem::Middle ) );
         }
-        else if ( qgsDoubleNear( currentYCoord, currentItem->transform().dy() + currentItem->rect().bottom(), itemTolerance ) )
+        else if ( qgsDoubleNear( currentYCoord, currentItem->pos().y() + currentItem->rect().bottom(), itemTolerance ) )
         {
           snappedItems.append( qMakePair( currentItem, QgsComposerItem::LowerMiddle ) );
         }
       }
       else
       {
-        if ( qgsDoubleNear( currentXCoord, currentItem->transform().dx(), itemTolerance ) )
+        if ( qgsDoubleNear( currentXCoord, currentItem->pos().x(), itemTolerance ) )
         {
           snappedItems.append( qMakePair( currentItem, QgsComposerItem::MiddleLeft ) );
         }
-        else if ( qgsDoubleNear( currentXCoord, currentItem->transform().dx() + currentItem->rect().center().x(), itemTolerance ) )
+        else if ( qgsDoubleNear( currentXCoord, currentItem->pos().x() + currentItem->rect().center().x(), itemTolerance ) )
         {
           snappedItems.append( qMakePair( currentItem, QgsComposerItem::Middle ) );
         }
-        else if ( qgsDoubleNear( currentXCoord, currentItem->transform().dx() + currentItem->rect().width(), itemTolerance ) )
+        else if ( qgsDoubleNear( currentXCoord, currentItem->pos().x() + currentItem->rect().width(), itemTolerance ) )
         {
           snappedItems.append( qMakePair( currentItem, QgsComposerItem::MiddleRight ) );
         }
@@ -1588,8 +1576,8 @@ int QgsComposition::boundingRectOfSelectedItems( QRectF& bRect )
 
   //set the box to the first item
   QgsComposerItem* currentItem = selectedItems.at( 0 );
-  double minX = currentItem->transform().dx();
-  double minY = currentItem->transform().dy();
+  double minX = currentItem->pos().x();
+  double minY = currentItem->pos().y();
   double maxX = minX + currentItem->rect().width();
   double maxY = minY + currentItem->rect().height();
 
@@ -1598,8 +1586,8 @@ int QgsComposition::boundingRectOfSelectedItems( QRectF& bRect )
   for ( int i = 1; i < selectedItems.size(); ++i )
   {
     currentItem = selectedItems.at( i );
-    currentMinX = currentItem->transform().dx();
-    currentMinY = currentItem->transform().dy();
+    currentMinX = currentItem->pos().x();
+    currentMinY = currentItem->pos().y();
     currentMaxX = currentMinX + currentItem->rect().width();
     currentMaxY = currentMinY + currentItem->rect().height();
 
@@ -2200,7 +2188,7 @@ void QgsComposition::renderPage( QPainter* p, int page )
     return;
   }
 
-  QRectF paperRect = QRectF( paperItem->transform().dx(), paperItem->transform().dy(), paperItem->rect().width(), paperItem->rect().height() );
+  QRectF paperRect = QRectF( paperItem->pos().x(), paperItem->pos().y(), paperItem->rect().width(), paperItem->rect().height() );
 
   QgsComposition::PlotStyle savedPlotStyle = mPlotStyle;
   mPlotStyle = QgsComposition::Print;
@@ -2245,8 +2233,8 @@ void QgsComposition::computeWorldFileParameters( double& a, double& b, double& c
   double YC = extent.center().y();
 
   // get the extent for the page
-  double xmin = extent.xMinimum() - mWorldFileMap->transform().dx() * xr;
-  double ymax = extent.yMaximum() + mWorldFileMap->transform().dy() * yr;
+  double xmin = extent.xMinimum() - mWorldFileMap->pos().x() * xr;
+  double ymax = extent.yMaximum() + mWorldFileMap->pos().y() * yr;
   QgsRectangle paperExtent( xmin, ymax - paperHeight() * yr, xmin + paperWidth() * xr, ymax );
 
   double X0 = paperExtent.xMinimum();

--- a/src/core/composer/qgsnumericscalebarstyle.cpp
+++ b/src/core/composer/qgsnumericscalebarstyle.cpp
@@ -94,7 +94,7 @@ QRectF QgsNumericScaleBarStyle::calculateBoxSize() const
   double textWidth = mScaleBar->textWidthMillimeters( mScaleBar->font(), scaleText() );
   double textHeight = mScaleBar->fontAscentMillimeters( mScaleBar->font() );
 
-  rect = QRectF( mScaleBar->transform().dx(), mScaleBar->transform().dy(), 2 * mScaleBar->boxContentSpace()
+  rect = QRectF( mScaleBar->pos().x(), mScaleBar->pos().y(), 2 * mScaleBar->boxContentSpace()
                  + 2 * mScaleBar->pen().width() + textWidth,
                  textHeight + 2 * mScaleBar->boxContentSpace() );
 

--- a/src/core/composer/qgspaperitem.cpp
+++ b/src/core/composer/qgspaperitem.cpp
@@ -174,7 +174,7 @@ void QgsPaperItem::setSceneRect( const QRectF& rectangle )
   QgsComposerItem::setSceneRect( rectangle );
   //update size and position of attached QgsPaperGrid to reflect new page size and position
   mPageGrid->setRect( 0, 0, rect().width(), rect().height() );
-  mPageGrid->setPos( transform().dx(), transform().dy() );
+  mPageGrid->setPos( pos().x(), pos().y() );
 }
 
 void QgsPaperItem::initialize()
@@ -184,6 +184,6 @@ void QgsPaperItem::initialize()
   setZValue( 0 );
 
   //create a new QgsPaperGrid for this page, and add it to the composition
-  mPageGrid = new QgsPaperGrid( transform().dx(), transform().dy(), rect().width(), rect().height(), mComposition );
+  mPageGrid = new QgsPaperGrid( pos().x(), pos().y(), rect().width(), rect().height(), mComposition );
   mComposition->addItem( mPageGrid );
 }

--- a/src/core/composer/qgsscalebarstyle.cpp
+++ b/src/core/composer/qgsscalebarstyle.cpp
@@ -130,5 +130,5 @@ QRectF QgsScaleBarStyle::calculateBoxSize() const
   double width =  firstLabelLeft + totalBarLength + 2 * mScaleBar->pen().widthF() + largestLabelWidth + 2 * mScaleBar->boxContentSpace();
   double height = mScaleBar->height() + mScaleBar->labelBarSpace() + 2 * mScaleBar->boxContentSpace() + mScaleBar->fontAscentMillimeters( mScaleBar->font() );
 
-  return QRectF( mScaleBar->transform().dx(), mScaleBar->transform().dy(), width, height );
+  return QRectF( mScaleBar->pos().x(), mScaleBar->pos().y(), width, height );
 }

--- a/src/gui/qgscomposerruler.cpp
+++ b/src/gui/qgscomposerruler.cpp
@@ -229,30 +229,30 @@ void QgsComposerRuler::setSnapLinePosition( const QPointF& pos )
     {
       if ( itemIt->second == QgsComposerItem::MiddleLeft )
       {
-        itemIt->first->setItemPosition( transformedPt.x(), itemIt->first->transform().dy(), QgsComposerItem::UpperLeft );
+        itemIt->first->setItemPosition( transformedPt.x(), itemIt->first->pos().y(), QgsComposerItem::UpperLeft );
       }
       else if ( itemIt->second == QgsComposerItem::Middle )
       {
-        itemIt->first->setItemPosition( transformedPt.x(), itemIt->first->transform().dy(), QgsComposerItem::UpperMiddle );
+        itemIt->first->setItemPosition( transformedPt.x(), itemIt->first->pos().y(), QgsComposerItem::UpperMiddle );
       }
       else
       {
-        itemIt->first->setItemPosition( transformedPt.x(), itemIt->first->transform().dy(), QgsComposerItem::UpperRight );
+        itemIt->first->setItemPosition( transformedPt.x(), itemIt->first->pos().y(), QgsComposerItem::UpperRight );
       }
     }
     else
     {
       if ( itemIt->second == QgsComposerItem::UpperMiddle )
       {
-        itemIt->first->setItemPosition( itemIt->first->transform().dx(), transformedPt.y(), QgsComposerItem::UpperLeft );
+        itemIt->first->setItemPosition( itemIt->first->pos().x(), transformedPt.y(), QgsComposerItem::UpperLeft );
       }
       else if ( itemIt->second == QgsComposerItem::Middle )
       {
-        itemIt->first->setItemPosition( itemIt->first->transform().dx(), transformedPt.y(), QgsComposerItem::MiddleLeft );
+        itemIt->first->setItemPosition( itemIt->first->pos().x(), transformedPt.y(), QgsComposerItem::MiddleLeft );
       }
       else
       {
-        itemIt->first->setItemPosition( itemIt->first->transform().dx(), transformedPt.y(), QgsComposerItem::LowerLeft );
+        itemIt->first->setItemPosition( itemIt->first->pos().x(), transformedPt.y(), QgsComposerItem::LowerLeft );
       }
     }
   }

--- a/src/plugins/georeferencer/qgsgeorefplugingui.cpp
+++ b/src/plugins/georeferencer/qgsgeorefplugingui.cpp
@@ -1604,7 +1604,7 @@ bool QgsGeorefPluginGui::writePDFReportFile( const QString& fileName, const QgsG
     mapWidthMM = 70 / canvasExtent.height() * canvasExtent.width();
   }
 
-  QgsComposerMap* composerMap = new QgsComposerMap( composition, leftMargin, titleLabel->rect().bottom() + titleLabel->transform().dy(), mapWidthMM, mapHeightMM );
+  QgsComposerMap* composerMap = new QgsComposerMap( composition, leftMargin, titleLabel->rect().bottom() + titleLabel->pos().y(), mapWidthMM, mapHeightMM );
   composerMap->setLayerSet( canvasRenderer->layerSet() );
   composerMap->setNewExtent( mCanvas->extent() );
   composerMap->setMapCanvas( mCanvas );
@@ -1638,7 +1638,7 @@ bool QgsGeorefPluginGui::writePDFReportFile( const QString& fileName, const QgsG
     parameterLabel->setText( parameterTitle );
     parameterLabel->adjustSizeToText();
     composition->addItem( parameterLabel );
-    parameterLabel->setSceneRect( QRectF( leftMargin, composerMap->rect().bottom() + composerMap->transform().dy() + 5, contentWidth, 8 ) );
+    parameterLabel->setSceneRect( QRectF( leftMargin, composerMap->rect().bottom() + composerMap->pos().y() + 5, contentWidth, 8 ) );
     parameterLabel->setFrameEnabled( false );
 
     //calculate mean error
@@ -1655,7 +1655,7 @@ bool QgsGeorefPluginGui::writePDFReportFile( const QString& fileName, const QgsG
     row << QString::number( origin.x(), 'f', 3 ) << QString::number( origin.y(), 'f', 3 ) << QString::number( scaleX ) << QString::number( scaleY ) << QString::number( rotation * 180 / M_PI ) << QString::number( meanError );
     parameterTable->addRow( row );
     composition->addItem( parameterTable );
-    parameterTable->setSceneRect( QRectF( leftMargin, parameterLabel->rect().bottom() + parameterLabel->transform().dy() + 5, contentWidth, 20 ) );
+    parameterTable->setSceneRect( QRectF( leftMargin, parameterLabel->rect().bottom() + parameterLabel->pos().y() + 5, contentWidth, 20 ) );
     parameterTable->setGridStrokeWidth( 0.1 );
     parameterTable->adjustFrameToSize();
   }
@@ -1670,13 +1670,13 @@ bool QgsGeorefPluginGui::writePDFReportFile( const QString& fileName, const QgsG
   residualLabel->setFont( titleFont );
   residualLabel->setText( tr( "Residuals" ) );
   composition->addItem( residualLabel );
-  residualLabel->setSceneRect( QRectF( leftMargin, previousItem->rect().bottom() + previousItem->transform().dy() + 5, contentWidth, 6 ) );
+  residualLabel->setSceneRect( QRectF( leftMargin, previousItem->rect().bottom() + previousItem->pos().y() + 5, contentWidth, 6 ) );
   residualLabel->setFrameEnabled( false );
 
   //residual plot
   QgsResidualPlotItem* resPlotItem = new QgsResidualPlotItem( composition );
   composition->addItem( resPlotItem );
-  resPlotItem->setSceneRect( QRectF( leftMargin, residualLabel->rect().bottom() + residualLabel->transform().dy() + 5, contentWidth, composerMap->rect().height() ) );
+  resPlotItem->setSceneRect( QRectF( leftMargin, residualLabel->rect().bottom() + residualLabel->pos().y() + 5, contentWidth, composerMap->rect().height() ) );
   resPlotItem->setExtent( composerMap->extent() );
   resPlotItem->setGCPList( mPoints );
 
@@ -1713,7 +1713,7 @@ bool QgsGeorefPluginGui::writePDFReportFile( const QString& fileName, const QgsG
 
   composition->addItem( gcpTable );
 
-  gcpTable->setSceneRect( QRectF( leftMargin,  resPlotItem->rect().bottom() + resPlotItem->transform().dy() + 5, contentWidth, 100 ) );
+  gcpTable->setSceneRect( QRectF( leftMargin,  resPlotItem->rect().bottom() + resPlotItem->pos().y() + 5, contentWidth, 100 ) );
   gcpTable->setGridStrokeWidth( 0.1 );
 
   printer.setResolution( composition->printResolution() );


### PR DESCRIPTION
Currently QGIS uses QGraphicsItem::transform to position composer items in the scene. This is a little strange since the position can be set directly using QGraphicsItem::pos() / QGraphicsItem::setPos() (possibly these weren't available when the item positioning code was originally written?).  I'm needing to use QGraphicsItem::transform for its proper use - setting item transformations, so this pull request makes sure we use the proper QGraphicsItem pos/setPos methods for positioning composer items. There's no regressions that I've encountered and it also has the benefit of making the code more readable.
