### PR TITLE
Visual candy for the "Save as" GUI 

### DIFF
--- a/src/app/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/app/ogr/qgsvectorlayersaveasdialog.cpp
@@ -139,14 +139,20 @@ QList<QPair<QLabel*, QWidget*> > QgsVectorLayerSaveAsDialog::createControls( con
         control = le;
         break;
       }
+
+      case QgsVectorFileWriter::Hidden:
+        control = 0;
+        break;
     }
 
-    // Pack the tooltip in some html element, so it gets linebreaks.
-    label->setToolTip( QString( "<p>%1</p>" ).arg( option->docString ) );
-    control->setToolTip( QString( "<p>%1</p>" ).arg( option->docString ) );
+    if ( control )
+    {
+      // Pack the tooltip in some html element, so it gets linebreaks.
+      label->setToolTip( QString( "<p>%1</p>" ).arg( option->docString ) );
+      control->setToolTip( QString( "<p>%1</p>" ).arg( option->docString ) );
 
-    controls << QPair<QLabel*, QWidget*>( label, control );
-
+      controls << QPair<QLabel*, QWidget*>( label, control );
+    }
   }
 
   return controls;
@@ -353,6 +359,14 @@ QStringList QgsVectorLayerSaveAsDialog::datasourceOptions() const
             options << QString( "%1=%2" ).arg( it.key() ).arg( le->text() );
           break;
         }
+
+        case QgsVectorFileWriter::Hidden:
+        {
+          QgsVectorFileWriter::HiddenOption* opt
+              = dynamic_cast<QgsVectorFileWriter::HiddenOption*>( it.value() );
+          options << QString( "%1=%2" ).arg( it.key() ).arg( opt->mValue );
+          break;
+        }
       }
     }
   }
@@ -392,6 +406,14 @@ QStringList QgsVectorLayerSaveAsDialog::layerOptions() const
         {
           QLineEdit* le = mLayerOptionsGroupBox->findChild<QLineEdit*>( it.key() );
           options << QString( "%1=%2" ).arg( it.key() ).arg( le->text() );
+          break;
+        }
+
+        case QgsVectorFileWriter::Hidden:
+        {
+          QgsVectorFileWriter::HiddenOption* opt
+              = dynamic_cast<QgsVectorFileWriter::HiddenOption*>( it.value() );
+          options << QString( "%1=%2" ).arg( it.key() ).arg( opt->mValue );
           break;
         }
       }

--- a/src/app/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/app/ogr/qgsvectorlayersaveasdialog.cpp
@@ -19,7 +19,6 @@
 #include "qgsvectorlayersaveasdialog.h"
 #include "qgsgenericprojectionselector.h"
 #include "qgsvectordataprovider.h"
-#include "qgsvectorfilewriter.h"
 #include "qgscoordinatereferencesystem.h"
 
 #include <QSettings>
@@ -90,6 +89,68 @@ void QgsVectorLayerSaveAsDialog::setup()
   on_mSymbologyExportComboBox_currentIndexChanged( mSymbologyExportComboBox->currentText() );
 }
 
+QList<QPair<QLabel*, QWidget*> > QgsVectorLayerSaveAsDialog::createControls( const QMap<QString, QgsVectorFileWriter::Option*>& options )
+{
+  QList<QPair<QLabel*, QWidget*> > controls;
+  QMap<QString, QgsVectorFileWriter::Option*>::ConstIterator it;
+
+  for ( it = options.constBegin(); it != options.constEnd(); ++it )
+  {
+    QgsVectorFileWriter::Option* option = it.value();
+    QLabel* label = new QLabel( it.key() );
+    QWidget* control;
+    switch ( option->type )
+    {
+      case QgsVectorFileWriter::Int:
+      {
+        QgsVectorFileWriter::IntOption* opt = dynamic_cast<QgsVectorFileWriter::IntOption*>( option );
+        QSpinBox* sb = new QSpinBox();
+        sb->setObjectName( it.key() );
+        sb->setValue( opt->defaultValue );
+        control = sb;
+        break;
+      }
+
+      case QgsVectorFileWriter::Set:
+      {
+        QgsVectorFileWriter::SetOption* opt = dynamic_cast<QgsVectorFileWriter::SetOption*>( option );
+        QComboBox* cb = new QComboBox();
+        cb->setObjectName( it.key() );
+        Q_FOREACH( const QString& val, opt->values )
+        {
+          cb->addItem( val, val );
+        }
+        if ( opt->allowNone )
+          cb->addItem( tr( "<Default>" ), QVariant( QVariant::String ) );
+        int idx = cb->findText( opt->defaultValue );
+        if ( idx == -1 )
+          idx = cb->findData( QVariant( QVariant::String ) );
+        cb->setCurrentIndex( idx );
+        control = cb;
+        break;
+      }
+
+      case QgsVectorFileWriter::String:
+      {
+        QgsVectorFileWriter::StringOption* opt = dynamic_cast<QgsVectorFileWriter::StringOption*>( option );
+        QLineEdit* le = new QLineEdit( opt->defaultValue );
+        le->setObjectName( it.key() );
+        control = le;
+        break;
+      }
+    }
+
+    // Pack the tooltip in some html element, so it gets linebreaks.
+    label->setToolTip( QString( "<p>%1</p>" ).arg( option->docString ) );
+    control->setToolTip( QString( "<p>%1</p>" ).arg( option->docString ) );
+
+    controls << QPair<QLabel*, QWidget*>( label, control );
+
+  }
+
+  return controls;
+}
+
 QgsVectorLayerSaveAsDialog::~QgsVectorLayerSaveAsDialog()
 {
   QSettings settings;
@@ -132,6 +193,62 @@ void QgsVectorLayerSaveAsDialog::on_mFormatComboBox_currentIndexChanged( int idx
   {
     mEncodingComboBox->setEnabled( true );
     mSkipAttributeCreation->setEnabled( true );
+  }
+
+  QgsVectorFileWriter::MetaData driverMetaData;
+
+  while ( mDatasourceOptionsGroupBox->layout()->count() )
+  {
+    QLayoutItem* item = mDatasourceOptionsGroupBox->layout()->takeAt( 0 );
+    delete item->widget();
+    delete item;
+  }
+
+  while ( mLayerOptionsGroupBox->layout()->count() )
+  {
+    QLayoutItem* item = mLayerOptionsGroupBox->layout()->takeAt( 0 );
+    delete item->widget();
+    delete item;
+  }
+
+  // workaround so the Q_FOREACH macro does not get confused by the ','
+  typedef QPair<QLabel*, QWidget*> LabelControlPair;
+
+  if ( QgsVectorFileWriter::driverMetadata( format(), driverMetaData ) )
+  {
+    if ( driverMetaData.driverOptions.size() != 0 )
+    {
+      mDatasourceOptionsGroupBox->setVisible( true );
+      QList<QPair<QLabel*, QWidget*> > controls = createControls( driverMetaData.driverOptions );
+
+      QFormLayout* datasourceLayout = dynamic_cast<QFormLayout*>( mDatasourceOptionsGroupBox->layout() );
+
+      Q_FOREACH( const LabelControlPair& control, controls )
+      {
+        datasourceLayout->addRow( control.first, control.second );
+      }
+    }
+    else
+    {
+      mDatasourceOptionsGroupBox->setVisible( false );
+    }
+
+    if ( driverMetaData.layerOptions.size() != 0 )
+    {
+      mLayerOptionsGroupBox->setVisible( true );
+      QList<QPair<QLabel*, QWidget*> > controls = createControls( driverMetaData.layerOptions );
+
+      QFormLayout* layerOptionsLayout = dynamic_cast<QFormLayout*>( mLayerOptionsGroupBox->layout() );
+
+      Q_FOREACH( const LabelControlPair& control, controls )
+      {
+        layerOptionsLayout->addRow( control.first, control.second );
+      }
+    }
+    else
+    {
+      mLayerOptionsGroupBox->setVisible( false );
+    }
   }
 }
 
@@ -199,12 +316,87 @@ long QgsVectorLayerSaveAsDialog::crs() const
 
 QStringList QgsVectorLayerSaveAsDialog::datasourceOptions() const
 {
-  return mOgrDatasourceOptions->toPlainText().split( "\n" );
+  QStringList options;
+
+  QgsVectorFileWriter::MetaData driverMetaData;
+
+  if ( QgsVectorFileWriter::driverMetadata( format(), driverMetaData ) )
+  {
+    QMap<QString, QgsVectorFileWriter::Option*>::ConstIterator it;
+
+    for ( it = driverMetaData.driverOptions.constBegin(); it != driverMetaData.driverOptions.constEnd(); ++it )
+    {
+      switch ( it.value()->type )
+      {
+        case QgsVectorFileWriter::Int:
+        {
+          QSpinBox* sb = mDatasourceOptionsGroupBox->findChild<QSpinBox*>( it.key() );
+          if ( sb )
+            options << QString( "%1=%2" ).arg( it.key() ).arg( sb->value() );
+          break;
+        }
+
+        case QgsVectorFileWriter::Set:
+        {
+          QComboBox* cb = mDatasourceOptionsGroupBox->findChild<QComboBox*>( it.key() );
+          if ( cb && !cb->itemData( cb->currentIndex() ).isNull() )
+            options << QString( "%1=%2" ).arg( it.key() ).arg( cb->currentText() );
+          break;
+        }
+
+        case QgsVectorFileWriter::String:
+        {
+          QLineEdit* le = mDatasourceOptionsGroupBox->findChild<QLineEdit*>( it.key() );
+          if ( le )
+            options << QString( "%1=%2" ).arg( it.key() ).arg( le->text() );
+          break;
+        }
+      }
+    }
+  }
+
+  return options + mOgrDatasourceOptions->toPlainText().split( "\n" );
 }
 
 QStringList QgsVectorLayerSaveAsDialog::layerOptions() const
 {
-  return mOgrLayerOptions->toPlainText().split( "\n" );
+  QStringList options;
+
+  QgsVectorFileWriter::MetaData driverMetaData;
+
+  if ( QgsVectorFileWriter::driverMetadata( format(), driverMetaData ) )
+  {
+    QMap<QString, QgsVectorFileWriter::Option*>::ConstIterator it;
+
+    for ( it = driverMetaData.layerOptions.constBegin(); it != driverMetaData.layerOptions.constEnd(); ++it )
+    {
+      switch ( it.value()->type )
+      {
+        case QgsVectorFileWriter::Int:
+        {
+          QSpinBox* sb = mLayerOptionsGroupBox->findChild<QSpinBox*>( it.key() );
+          options << QString( "%1=%2" ).arg( it.key() ).arg( sb->value() );
+          break;
+        }
+
+        case QgsVectorFileWriter::Set:
+        {
+          QComboBox* cb = mLayerOptionsGroupBox->findChild<QComboBox*>( it.key() );
+          options << QString( "%1=%2" ).arg( it.key() ).arg( cb->currentText() );
+          break;
+        }
+
+        case QgsVectorFileWriter::String:
+        {
+          QLineEdit* le = mLayerOptionsGroupBox->findChild<QLineEdit*>( it.key() );
+          options << QString( "%1=%2" ).arg( it.key() ).arg( le->text() );
+          break;
+        }
+      }
+    }
+  }
+
+  return options + mOgrLayerOptions->toPlainText().split( "\n" );
 }
 
 bool QgsVectorLayerSaveAsDialog::skipAttributeCreation() const

--- a/src/app/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/app/ogr/qgsvectorlayersaveasdialog.cpp
@@ -87,6 +87,7 @@ void QgsVectorLayerSaveAsDialog::setup()
   mSymbologyExportComboBox->addItem( tr( "Feature symbology" ), QgsVectorFileWriter::FeatureSymbology );
   mSymbologyExportComboBox->addItem( tr( "Symbol layer symbology" ), QgsVectorFileWriter::SymbolLayerSymbology );
   on_mSymbologyExportComboBox_currentIndexChanged( mSymbologyExportComboBox->currentText() );
+  mOptionsButton->setChecked( settings.value( "/UI/vectorLayerSaveAsOptionsVisible" ).toBool() );
 }
 
 QList<QPair<QLabel*, QWidget*> > QgsVectorLayerSaveAsDialog::createControls( const QMap<QString, QgsVectorFileWriter::Option*>& options )
@@ -163,6 +164,7 @@ void QgsVectorLayerSaveAsDialog::accept()
   settings.setValue( "/UI/lastVectorFileFilterDir", QFileInfo( filename() ).absolutePath() );
   settings.setValue( "/UI/lastVectorFormat", format() );
   settings.setValue( "/UI/encoding", encoding() );
+  settings.setValue( "/UI/vectorLayerSaveAsOptionsVisible", mOptionsButton->isChecked() );
   QDialog::accept();
 }
 
@@ -428,4 +430,9 @@ void QgsVectorLayerSaveAsDialog::on_mSymbologyExportComboBox_currentIndexChanged
   }
   mScaleSpinBox->setEnabled( scaleEnabled );
   mScaleLabel->setEnabled( scaleEnabled );
+}
+
+void QgsVectorLayerSaveAsDialog::on_mOptionsButton_toggled( bool checked )
+{
+  mOptionsGroupBox->setVisible( checked );
 }

--- a/src/app/ogr/qgsvectorlayersaveasdialog.h
+++ b/src/app/ogr/qgsvectorlayersaveasdialog.h
@@ -64,6 +64,7 @@ class QgsVectorLayerSaveAsDialog : public QDialog, private Ui::QgsVectorLayerSav
     void on_browseCRS_clicked();
     void on_buttonBox_helpRequested() { QgsContextHelp::run( metaObject()->className() ); }
     void on_mSymbologyExportComboBox_currentIndexChanged( const QString& text );
+    void on_mOptionsButton_toggled( bool checked );
     void accept();
 
   private:

--- a/src/app/ogr/qgsvectorlayersaveasdialog.h
+++ b/src/app/ogr/qgsvectorlayersaveasdialog.h
@@ -21,6 +21,7 @@
 #include <ui_qgsvectorlayersaveasdialogbase.h>
 #include <QDialog>
 #include "qgscontexthelp.h"
+#include "qgsvectorfilewriter.h"
 
 /**
  *  Class to select destination file, type and CRS for ogr layrs
@@ -67,6 +68,7 @@ class QgsVectorLayerSaveAsDialog : public QDialog, private Ui::QgsVectorLayerSav
 
   private:
     void setup();
+    QList< QPair< QLabel*, QWidget* > > createControls( const QMap<QString, QgsVectorFileWriter::Option*>& options );
 
     long mCRS;
 };

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -1271,6 +1271,7 @@ QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
                        );
 
   // SQLite
+  // SQLite
   datasetOptions.clear();
   layerOptions.clear();
 
@@ -1281,15 +1282,77 @@ QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
                             , true  // Default value
                             ) );
 
-  // Will be handled with the SpatiaLite driver alias
-#if 0
-  datasetOptions.insert( "SPATIALITE", new BoolOption(
-                            QObject::tr( "Create the SpatiaLite flavour of the metadata tables, which are a bit "
-                                         "differ from the metadata used by this OGR driver and from OGC "
-                                         "specifications. Implies METADATA=yes" )
+  // Will handle the spatialite alias
+  datasetOptions.insert( "SPATIALITE", new HiddenOption(
+                           "NO"
+                            ) );
+
+
+  datasetOptions.insert( "INIT_WITH_EPSG", new HiddenOption(
+                           "NO"
+                            ) );
+
+  layerOptions.insert( "FORMAT", new HiddenOption(
+                         "WKT"
+                         ) );
+
+  layerOptions.insert( "LAUNDER", new BoolOption(
+                            QObject::tr( "Controls whether layer and field names will be laundered for easier use "
+                                         "in SQLite. Laundered names will be convered to lower case and some special "
+                                         "characters(' - #) will be changed to underscores." )
                             , true  // Default value
                             ) );
-#endif
+
+  layerOptions.insert( "SPATIAL_INDEX", new HiddenOption(
+                         "NO"
+                            ) );
+
+  layerOptions.insert( "COMPRESS_GEOM", new HiddenOption(
+                         "NO"
+                            ) );
+
+  layerOptions.insert( "SRID", new HiddenOption(
+                          ""
+                          ) );
+
+  layerOptions.insert( "COMPRESS_COLUMNS", new StringOption(
+                           QObject::tr( "column_name1[,column_name2, ...] A list of (String) columns that "
+                                        "must be compressed with ZLib DEFLATE algorithm. This might be beneficial "
+                                        "for databases that have big string blobs. However, use with care, since "
+                                        "the value of such columns will be seen as compressed binary content with "
+                                        "other SQLite utilities (or previous OGR versions). With OGR, when inserting, "
+                                        "modifying or queryings compressed columns, compression/decompression is "
+                                        "done transparently. However, such columns cannot be (easily) queried with "
+                                        "an attribute filter or WHERE clause. Note: in table definition, such columns "
+                                        "have the 'VARCHAR_deflate' declaration type." )
+                          , ""  // Default value
+                          ) );
+
+  driverMetadata.insert( "SQLite",
+                         MetaData(
+                           "SQLite",
+                           QObject::tr( "SQLite" ),
+                           "*.sqlite",
+                           "sqlite",
+                           datasetOptions,
+                           layerOptions
+                         )
+                       );
+  // SpatiaLite
+
+  datasetOptions.clear();
+  layerOptions.clear();
+
+  datasetOptions.insert( "METADATA", new BoolOption(
+                            QObject::tr( "Can be used to avoid creating the geometry_columns and spatial_ref_sys "
+                                         "tables in a new database. By default these metadata tables are created "
+                                         "when a new database is created." )
+                            , true  // Default value
+                            ) );
+
+  datasetOptions.insert( "SPATIALITE", new HiddenOption(
+                           "YES"
+                            ) );
 
   datasetOptions.insert( "INIT_WITH_EPSG", new BoolOption(
                             QObject::tr( "Insert the content of the EPSG CSV files into the spatial_ref_sys table. "
@@ -1355,17 +1418,6 @@ QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
                                         "have the 'VARCHAR_deflate' declaration type." )
                           , ""  // Default value
                           ) );
-
-  driverMetadata.insert( "SQLite",
-                         MetaData(
-                           "SQLite",
-                           QObject::tr( "SQLite" ),
-                           "*.sqlite",
-                           "sqlite",
-                           datasetOptions,
-                           layerOptions
-                         )
-                       );
 
   driverMetadata.insert( "SpatiaLite",
                          MetaData(

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -1292,9 +1292,15 @@ QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
                            "NO"
                             ) );
 
-  layerOptions.insert( "FORMAT", new HiddenOption(
-                         "WKT"
-                         ) );
+  layerOptions.insert( "FORMAT", new SetOption(
+                            QObject::tr( "Controls the format used for the geometry column. Defaults to WKB."
+                                         "This is generally more space and processing efficient, but harder "
+                                         "to inspect or use in simple applications than WKT (Well Known Text)."),
+                            QStringList()
+                            << "WKB"
+                            << "WKT"
+                            , "WKB" // Default value
+                             ) );
 
   layerOptions.insert( "LAUNDER", new BoolOption(
                             QObject::tr( "Controls whether layer and field names will be laundered for easier use "
@@ -1360,19 +1366,9 @@ QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
                             , true  // Default value
                             ) );
 
-  layerOptions.insert( "FORMAT", new SetOption(
-                            QObject::tr( "Controls the format used for the geometry column. By default we assume "
-                                         "that an SpatiaLite database will be created. SpatiaLite extension uses "
-                                         "its own binary format to store geometries. Set to WKB (Well Known Binary) "
-                                         "if you only want to export a SQlite database. This is generally more space "
-                                         "and processing efficient, but harder to inspect or use in simple applications "
-                                         "than WKT (Well Known Text)."),
-                            QStringList()
-                            << "WKB"
-                            << "WKT"
-                            << "SPATIALITE"
-                            , "SPATIALITE" // Default value
-                             ) );
+  layerOptions.insert( "FORMAT", new HiddenOption(
+                         "SPATIALITE"
+                         ) );
 
   layerOptions.insert( "LAUNDER", new BoolOption(
                             QObject::tr( "Controls whether layer and field names will be laundered for easier use "

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -511,7 +511,9 @@ QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
   layerOptions.clear();
 
   datasetOptions.insert( "LINEFORMAT", new SetOption(
-                            QObject::tr( "By default when creating new .BNA files they are created with the line termination conventions of the local platform (CR/LF on win32 or LF on all other systems). This may be overridden through use of the LINEFORMAT option." ),
+                            QObject::tr( "New BNA files are created by the "
+                                         "systems default line termination conventions. "
+                                         "This may be overridden here." ),
                             QStringList()
                             << "CRLF"
                             << "LF"
@@ -520,12 +522,17 @@ QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
                             ) );
 
   datasetOptions.insert( "MULTILINE", new BoolOption(
-                            QObject::tr( "By default, BNA files are created in the multi-line format (for each record, the first line contains the identifiers and the type/number of coordinates to follow. The following lines contains a pair of coordinates)." )
+                            QObject::tr( "By default, BNA files are created in multi-line format. "
+                                         "For each record, the first line contains the identifiers and the "
+                                         "type/number of coordinates to follow. The following lines contains "
+                                         "a pair of coordinates)." )
                             , true  // Default value
                             ) );
 
   datasetOptions.insert( "NB_IDS", new SetOption(
-                            QObject::tr( "BNA records may contain from 2 to 4 identifiers per record. Some software packages only support a precise number of identifiers. You can override the default value (2) by a precise value" ),
+                            QObject::tr( "BNA records may contain from 2 to 4 identifiers per record. "
+                                         "Some software packages only support a precise number of identifiers. "
+                                         "You can override the default value (2) by a precise value" ),
                             QStringList()
                             << "2"
                             << "3"
@@ -535,17 +542,21 @@ QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
                             ) );
 
   datasetOptions.insert( "ELLIPSES_AS_ELLIPSES", new BoolOption(
-                            QObject::tr( "The BNA writer will try to recognize ellipses and circles when writing a polygon. <br/>This will only work if the feature has previously been read from a BNA file.<br/> As some software packages do not support ellipses/circles in BNA data file, it may be useful to tell the writer by specifying <strong>ELLIPSES_AS_ELLIPSES=NO</strong> not to export them as such, but keep them as polygons." )
+                            QObject::tr( "The BNA writer will try to recognize ellipses and circles when writing a polygon. "
+                                         "This will only work if the feature has previously been read from a BNA file. "
+                                         "As some software packages do not support ellipses/circles in BNA data file, "
+                                         "it may be useful to tell the writer by specifying ELLIPSES_AS_ELLIPSES=NO not "
+                                         "to export them as such, but keep them as polygons." )
                             , true  // Default value
                             ) );
 
   datasetOptions.insert( "NB_PAIRS_PER_LINE", new IntOption(
-                          QObject::tr( "This option may be used to limit the number of coordinate pairs per line in multiline format." )
+                          QObject::tr( "Limit the number of coordinate pairs per line in multiline format." )
                           , 2 // Default value
                           ) );
 
   datasetOptions.insert( "COORDINATE_PRECISION", new IntOption(
-                          QObject::tr( "This option may be used to set the number of decimal for coordinates. Default value is 10." )
+                          QObject::tr( "Set the number of decimal for coordinates. Default value is 10." )
                           , 10 // Default value
                           ) );
 
@@ -565,27 +576,35 @@ QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
   layerOptions.clear();
 
   layerOptions.insert( "LINEFORMAT", new SetOption(
-                            QObject::tr( "By default when creating new .BNA files they are created with the line termination conventions of the local platform (CR/LF on win32 or LF on all other systems). This may be overridden through use of the LINEFORMAT option." ),
+                            QObject::tr( "By default when creating new .csv files they "
+                                         "are created with the line termination conventions "
+                                         "of the local platform (CR/LF on win32 or LF on all other systems). "
+                                         "This may be overridden through use of the LINEFORMAT option." ),
                             QStringList()
                             << "AS_WKT"
                             << "LF"
                             , "" // Default value
-                         , true // Allow None
+                            , true // Allow None
                             ) );
 
   layerOptions.insert( "GEOMETRY", new SetOption(
-                            QObject::tr( "By default, the geometry of a feature written to a .csv file is discarded. It is possible to export the geometry in its WKT representation by specifying GEOMETRY=AS_WKT. It is also possible to export point geometries into their X,Y,Z components (different columns in the csv file) by specifying GEOMETRY=AS_XYZ, GEOMETRY=AS_XY or GEOMETRY=AS_YX. The geometry column(s) will be prepended to the columns with the attributes values." ),
+                            QObject::tr( "By default, the geometry of a feature written to a .csv file is discarded. "
+                                         "It is possible to export the geometry in its WKT representation by "
+                                         "specifying GEOMETRY=AS_WKT. It is also possible to export point geometries "
+                                         "into their X,Y,Z components by specifying GEOMETRY=AS_XYZ, GEOMETRY=AS_XY "
+                                         "or GEOMETRY=AS_YX." ),
                             QStringList()
                             << "CRLF"
                             << "AS_XYZ"
                             << "AS_XY"
                             << "AS_YX"
-                            , "" // Default value
-                         , true // Allow None
+                            , "AS_XY" // Default value
+                            , true // Allow None
                             ) );
 
   layerOptions.insert( "CREATE_CSVT", new BoolOption(
-                            QObject::tr( "Create the associated .csvt file (see above paragraph) to describe the type of each column of the layer and its optional width and precision. Default value : NO" )
+                            QObject::tr( "Create the associated .csvt file to describe the type of each "
+                                         "column of the layer and its optional width and precision.")
                             , false  // Default value
                             ) );
 
@@ -599,7 +618,7 @@ QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
                             ) );
 
   layerOptions.insert( "WRITE_BOM", new BoolOption(
-                            QObject::tr( "Write a UTF-8 Byte Order Mark (BOM) at the start of the file. Default value : NO" )
+                            QObject::tr( "Write a UTF-8 Byte Order Mark (BOM) at the start of the file." )
                             , false  // Default value
                             ) );
 
@@ -619,7 +638,11 @@ QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
   layerOptions.clear();
 
   layerOptions.insert( "SHPT", new SetOption(
-                            QObject::tr( "Override the type of shapefile created. Can be one of NULL for a simple .dbf file with no .shp file, POINT, ARC, POLYGON or MULTIPOINT for 2D, or POINTZ, ARCZ, POLYGONZ or MULTIPOINTZ for 3D. Shapefiles with measure values are not supported, nor are MULTIPATCH files." ),
+                            QObject::tr( "Override the type of shapefile created. "
+                                         "Can be one of NULL for a simple .dbf file with no .shp file, POINT, "
+                                         "ARC, POLYGON or MULTIPOINT for 2D, or POINTZ, ARCZ, POLYGONZ or "
+                                         "MULTIPOINTZ for 3D. Shapefiles with measure values are not supported, "
+                                         "nor are MULTIPATCH files." ),
                             QStringList()
                             << "NULL"
                             << "POINT"
@@ -634,7 +657,9 @@ QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
                             ) );
 
   layerOptions.insert( "ENCODING", new SetOption(
-                            QObject::tr( "set the encoding value in the DBF file. The default value is LDID/87. It is not clear what other values may be appropriate." ),
+                            QObject::tr( "set the encoding value in the DBF file. "
+                                         "The default value is LDID/87. It is not clear "
+                                         "what other values may be appropriate." ),
                             QStringList()
                             << "LDID/87"
                             , "LDID/87" // Default value
@@ -691,12 +716,14 @@ QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
   layerOptions.clear();
 
   layerOptions.insert( "WRITE_BBOX", new BoolOption(
-                            QObject::tr( "Set to YES to write a bbox property with the bounding box of the geometries at the feature and feature collection level. Defaults to NO." )
+                            QObject::tr( "Set to YES to write a bbox property with the bounding box "
+                                         "of the geometries at the feature and feature collection level." )
                             , false  // Default value
                             ) );
 
   layerOptions.insert( "COORDINATE_PRECISION", new IntOption(
-                          QObject::tr( "Maximum number of figures after decimal separator to write in coordinates. Default to 15. Truncation will occur to remove trailing zeros." )
+                          QObject::tr( "Maximum number of figures after decimal separator to write in coordinates. "
+                                       "Default to 15. Truncation will occur to remove trailing zeros." )
                           , 15 // Default value
                           ) );
 
@@ -716,7 +743,8 @@ QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
   layerOptions.clear();
 
   datasetOptions.insert( "FORMAT", new SetOption(
-                            QObject::tr( "whether the document must be in RSS 2.0 or Atom 1.0 format. Default value : RSS" ),
+                            QObject::tr( "whether the document must be in RSS 2.0 or Atom 1.0 format. "
+                                         "Default value : RSS" ),
                             QStringList()
                             << "RSS"
                             << "ATOM"
@@ -724,7 +752,9 @@ QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
                             ) );
 
   datasetOptions.insert( "GEOM_DIALECT", new SetOption(
-                            QObject::tr( "the encoding of location information. Default value : SIMPLE W3C_GEO only supports point geometries. SIMPLE or W3C_GEO only support geometries in geographic WGS84 coordinates." ),
+                            QObject::tr( "The encoding of location information. Default value : SIMPLE. "
+                                         "W3C_GEO only supports point geometries. "
+                                         "SIMPLE or W3C_GEO only support geometries in geographic WGS84 coordinates." ),
                             QStringList()
                             << "SIMPLE"
                             << "GML"
@@ -733,47 +763,61 @@ QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
                             ) );
 
   datasetOptions.insert( "USE_EXTENSIONS", new BoolOption(
-                            QObject::tr( "If defined to YES, extension fields (that is to say fields not in the base schema of RSS or Atom documents) will be written. If the field name not found in the base schema matches the foo_bar pattern, foo will be considered as the namespace of the element, and a <foo:bar> element will be written. Otherwise, elements will be written in the <ogr:> namespace." )
-                            , false  // Default value
+                            QObject::tr( "If defined to YES, extension fields  will be written. "
+                                         "If the field name not found in the base schema matches "
+                                         "the foo_bar pattern, foo will be considered as the namespace "
+                                         "of the element, and a <foo:bar> element will be written. "
+                                         "Otherwise, elements will be written in the <ogr:> namespace." )
+                            , true  // Default value
                             ) );
 
   datasetOptions.insert( "WRITE_HEADER_AND_FOOTER", new BoolOption(
-                            QObject::tr( "If defined to NO, only <entry> or <item> elements will be written. The user will have to provide the appropriate header and footer of the document." )
+                            QObject::tr( "If defined to NO, only <entry> or <item> elements will be written. "
+                                         "The user will have to provide the appropriate header and footer of the document." )
                             , true  // Default value
                             ) );
 
   datasetOptions.insert( "HEADER", new StringOption(
-                          QObject::tr( "XML content that will be put between the <channel> element and the first <item> element for a RSS document, or between the xml tag and the first <entry> element for an Atom document. If it is specified, it will overload the following options." )
+                          QObject::tr( "XML content that will be put between the <channel> element and the "
+                                       "first <item> element for a RSS document, or between the xml tag and "
+                                       "the first <entry> element for an Atom document. ")
                           , ""  // Default value
                           ) );
 
   datasetOptions.insert( "TITLE", new StringOption(
-                          QObject::tr( "value put inside the <title> element in the header. If not provided, a dummy value will be used as that element is compulsory." )
+                          QObject::tr( "Value put inside the <title> element in the header. "
+                                       "If not provided, a dummy value will be used as that element is compulsory." )
                           , ""  // Default value
                           ) );
 
   datasetOptions.insert( "DESCRIPTION", new StringOption(
-                          QObject::tr( "value put inside the <description> element in the header. If not provided, a dummy value will be used as that element is compulsory." )
+                          QObject::tr( "Value put inside the <description> element in the header. "
+                                       "If not provided, a dummy value will be used as that element is compulsory." )
                           , ""  // Default value
                           ) );
 
   datasetOptions.insert( "LINK", new StringOption(
-                          QObject::tr( "value put inside the <link> element in the header. If not provided, a dummy value will be used as that element is compulsory." )
+                          QObject::tr( "Value put inside the <link> element in the header. "
+                                       "If not provided, a dummy value will be used as that element is compulsory." )
                           , ""  // Default value
                           ) );
 
   datasetOptions.insert( "UPDATED", new StringOption(
-                          QObject::tr( "value put inside the <updated> element in the header. Should be formatted as a XML datetime. If not provided, a dummy value will be used as that element is compulsory." )
+                          QObject::tr( "Value put inside the <updated> element in the header. "
+                                       "Should be formatted as a XML datetime. "
+                                       "If not provided, a dummy value will be used as that element is compulsory." )
                           , ""  // Default value
                           ) );
 
   datasetOptions.insert( "AUTHOR_NAME", new StringOption(
-                          QObject::tr( "value put inside the <author><name> element in the header. If not provided, a dummy value will be used as that element is compulsory." )
+                          QObject::tr( "Value put inside the <author><name> element in the header. "
+                                       "If not provided, a dummy value will be used as that element is compulsory." )
                           , ""  // Default value
                           ) );
 
   datasetOptions.insert( "ID", new StringOption(
-                          QObject::tr( "value put inside the <id> element in the header. If not provided, a dummy value will be used as that element is compulsory." )
+                          QObject::tr( "Value put inside the <id> element in the header. "
+                                       "If not provided, a dummy value will be used as that element is compulsory." )
                           , ""  // Default value
                           ) );
 
@@ -793,12 +837,19 @@ QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
   layerOptions.clear();
 
   datasetOptions.insert( "XSISCHEMAURI", new StringOption(
-                          QObject::tr( "If provided, this URI will be inserted as the schema location. Note that the schema file isn't actually accessed by OGR, so it is up to the user to ensure it will match the schema of the OGR produced GML data file." )
+                          QObject::tr( "If provided, this URI will be inserted as the schema location. "
+                                       "Note that the schema file isn't actually accessed by OGR, so it "
+                                       "is up to the user to ensure it will match the schema of the OGR "
+                                       "produced GML data file." )
                           , ""  // Default value
                           ) );
 
   datasetOptions.insert( "XSISCHEMA", new SetOption(
-                            QObject::tr( "This writes a GML application schema file to a corresponding .xsd file (with the same basename). If INTERNAL is used the schema is written within the GML file, but this is experimental and almost certainly not valid XML. OFF disables schema generation (and is implicit if XSISCHEMAURI is used)." ),
+                            QObject::tr( "This writes a GML application schema file to a corresponding "
+                                         ".xsd file (with the same basename). If INTERNAL is used the "
+                                         "schema is written within the GML file, but this is experimental "
+                                         "and almost certainly not valid XML. "
+                                         "OFF disables schema generation (and is implicit if XSISCHEMAURI is used)." ),
                             QStringList()
                             << "EXTERNAL"
                             << "INTERNAL"
@@ -807,17 +858,19 @@ QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
                             ) );
 
   datasetOptions.insert( "PREFIX", new StringOption(
-                          QObject::tr( "Defaults to 'ogr'. This is the prefix for the application target namespace." )
+                          QObject::tr( "This is the prefix for the application target namespace." )
                           , "ogr"  // Default value
                           ) );
 
   datasetOptions.insert( "STRIP_PREFIX", new BoolOption(
-                            QObject::tr( "Defaults to FALSE. Can be set to TRUE to avoid writing the prefix of the application target namespace in the GML file." )
+                            QObject::tr( "Can be set to TRUE to avoid writing the prefix of the "
+                                         "application target namespace in the GML file." )
                             , false  // Default value
                             ) );
 
   datasetOptions.insert( "TARGET_NAMESPACE", new StringOption(
-                          QObject::tr( "Defaults to 'http://ogr.maptools.org/'. This is the application target namespace." )
+                          QObject::tr( "Defaults to 'http://ogr.maptools.org/'. "
+                                       "This is the application target namespace." )
                           , "http://ogr.maptools.org/"  // Default value
                           ) );
 
@@ -832,17 +885,27 @@ QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
                             ) );
 
   datasetOptions.insert( "GML3_LONGSRS", new BoolOption(
-                             QObject::tr( "only valid when FORMAT=GML3/GML3Degree/GML3.2) Default to YES. If YES, SRS with EPSG authority will be written with the 'urn:ogc:def:crs:EPSG::' prefix. In the case, if the SRS is a geographic SRS without explicit AXIS order, but that the same SRS authority code imported with ImportFromEPSGA() should be treated as lat/long, then the function will take care of coordinate order swapping. If set to NO, SRS with EPSG authority will be written with the 'EPSG:' prefix, even if they are in lat/long order." )
+                             QObject::tr( "only valid when FORMAT=GML3/GML3Degree/GML3.2) Default to YES. "
+                                          "If YES, SRS with EPSG authority will be written with the "
+                                          "'urn:ogc:def:crs:EPSG::' prefix. In the case, if the SRS is a "
+                                          "geographic SRS without explicit AXIS order, but that the same "
+                                          "SRS authority code imported with ImportFromEPSGA() should be "
+                                          "treated as lat/long, then the function will take care of coordinate "
+                                          "order swapping. If set to NO, SRS with EPSG authority will be "
+                                          "written with the 'EPSG:' prefix, even if they are in lat/long order." )
                             , true  // Default value
                             ) );
 
   datasetOptions.insert( "WRITE_FEATURE_BOUNDED_BY", new BoolOption(
-                             QObject::tr( "only valid when FORMAT=GML3/GML3Degree/GML3.2) Default to YES. If set to NO, the <gml:boundedBy> element will not be written for each feature." )
+                             QObject::tr( "only valid when FORMAT=GML3/GML3Degree/GML3.2) Default to YES. "
+                                          "If set to NO, the <gml:boundedBy> element will not be written for "
+                                          "each feature." )
                             , true  // Default value
                             ) );
 
   datasetOptions.insert( "SPACE_INDENTATION", new BoolOption(
-                             QObject::tr( "Default to YES. If YES, the output will be indented with spaces for more readability, but at the expense of file size." )
+                             QObject::tr( "Default to YES. If YES, the output will be indented with spaces "
+                                          "for more readability, but at the expense of file size." )
                             , true  // Default value
                             ) );
 
@@ -878,32 +941,46 @@ QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
   layerOptions.clear();
 
   layerOptions.insert( "FORCE_GPX_TRACK", new BoolOption(
-                             QObject::tr( "By default when writting a layer whose features are of type wkbLineString, the GPX driver chooses to write them as routes. If FORCE_GPX_TRACK=YES is specified, they will be written as tracks." )
+                             QObject::tr( "By default when writing a layer whose features are of "
+                                          "type wkbLineString, the GPX driver chooses to write "
+                                          "them as routes. If FORCE_GPX_TRACK=YES is specified, "
+                                          "they will be written as tracks." )
                             , false  // Default value
                             ) );
 
   layerOptions.insert( "FORCE_GPX_ROUTE", new BoolOption(
-                             QObject::tr( "By default when writting a layer whose features are of type wkbMultiLineString, the GPX driver chooses to write them as tracks. If FORCE_GPX_ROUTE=YES is specified, they will be written as routes, provided that the multilines are composed of only one single line." )
+                             QObject::tr( "By default when writing a layer whose features are of "
+                                          "type wkbMultiLineString, the GPX driver chooses to write "
+                                          "them as tracks. If FORCE_GPX_ROUTE=YES is specified, "
+                                          "they will be written as routes, provided that the multilines "
+                                          "are composed of only one single line." )
                             , false  // Default value
                             ) );
 
   datasetOptions.insert( "GPX_USE_EXTENSIONS", new BoolOption(
-                             QObject::tr( "By default, the GPX driver will discard attribute fields that do not match the GPX XML definition (name, cmt, etc...). If GPX_USE_EXTENSIONS=YES is specified, extra fields will be written inside the<extensions> tag." )
-                            , false  // Default value
+                             QObject::tr( "If GPX_USE_EXTENSIONS=YES is specified, "
+                                          "extra fields will be written inside the <extensions> tag." )
+                            , true  // Default value
                             ) );
 
   datasetOptions.insert( "GPX_EXTENSIONS_NS", new StringOption(
-                             QObject::tr( "Only used if GPX_USE_EXTENSIONS=YES and GPX_EXTENSIONS_NS_URL is set. The namespace value used for extension tags. By default, 'ogr'." )
+                             QObject::tr( "Only used if GPX_USE_EXTENSIONS=YES and GPX_EXTENSIONS_NS_URL "
+                                          "is set. The namespace value used for extension tags. By default, 'ogr'." )
                           , "ogr"  // Default value
                           ) );
 
   datasetOptions.insert( "GPX_EXTENSIONS_NS_URL", new StringOption(
-                             QObject::tr( "Only used if GPX_USE_EXTENSIONS=YES and GPX_EXTENSIONS_NS is set. The namespace URI. By default, 'http://osgeo.org/gdal'." )
+                             QObject::tr( "Only used if GPX_USE_EXTENSIONS=YES and GPX_EXTENSIONS_NS "
+                                          "is set. The namespace URI. By default, 'http://osgeo.org/gdal'." )
                           , "http://osgeo.org/gdal"  // Default value
                           ) );
 
   datasetOptions.insert( "LINEFORMAT", new SetOption(
-                            QObject::tr( "By default files are created with the line termination conventions of the local platform (CR/LF on win32 or LF on all other systems). This may be overridden through use of the LINEFORMAT layer creation option which may have a value of CRLF (DOS format) or LF (Unix format)." ),
+                            QObject::tr( "By default files are created with the line termination "
+                                         "conventions of the local platform (CR/LF on win32 or LF "
+                                         "on all other systems). This may be overridden through use "
+                                         "of the LINEFORMAT layer creation option which may have a value "
+                                         "of CRLF (DOS format) or LF (Unix format)." ),
                             QStringList()
                             << "CRLF"
                             << "LF"
@@ -957,17 +1034,18 @@ QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
   layerOptions.clear();
 
   datasetOptions.insert( "NameField", new StringOption(
-                             QObject::tr( "Allows you to specify the field to use for the KML <name> element. Default value : 'Name'" )
+                             QObject::tr( "Allows you to specify the field to use for the KML <name> element. ")
                           , "Name"  // Default value
                           ) );
 
   datasetOptions.insert( "DescriptionField", new StringOption(
-                             QObject::tr( "Allows you to specify the field to use for the KML <description> element. Default value : 'Description'" )
+                             QObject::tr( "Allows you to specify the field to use for the KML <description> element.")
                           , "Description"  // Default value
                           ) );
 
   datasetOptions.insert( "AltitudeMode", new SetOption(
-                            QObject::tr( "Allows you to specify the AltitudeMode to use for KML geometries. This will only affect 3D geometries and must be one of the valid KML options." ),
+                            QObject::tr( "Allows you to specify the AltitudeMode to use for KML geometries. "
+                                         "This will only affect 3D geometries and must be one of the valid KML options." ),
                             QStringList()
                             << "relativeToGround"
                             << "clampToGround"
@@ -991,7 +1069,7 @@ QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
   layerOptions.clear();
 
   datasetOptions.insert( "FORMAT", new SetOption(
-                            QObject::tr( "To create MIF/MID instead of TAB files (TAB is the default)." ),
+                            QObject::tr( "To create MIF/MID instead of TAB files." ),
                             QStringList()
                             << "MIF/MID"
                             << "TAB"
@@ -999,10 +1077,11 @@ QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
                              ) );
 
   layerOptions.insert( "SPATIAL_INDEX_MODE", new SetOption(
-                            QObject::tr( "Use this to turn on 'quick spatial index mode'. The default behavior of MITAB since GDAL v1.5.0 is to generate an optimized spatial index, but this results in slower write speed than what we used to get with GDAL 1.4.x and older. Applications that want faster write speed and do not care about the performance of spatial queries on the resulting file can use this option to require the creation of a non-optimal spatial index (actually emulating the type of spatial index produced by OGR's TAB driver before GDAL 1.5.0). In this mode writing files can be about 5 times faster, but spatial queries can be up to 30 times slower." ),
+                            QObject::tr( "Use this to turn on 'quick spatial index mode'. "
+                                         "In this mode writing files can be about 5 times faster, "
+                                         "but spatial queries can be up to 30 times slower." ),
                             QStringList()
                             << "QUICK"
-                            << ""
                             , "" // Default value
                          , true // Allow None
                              ) );
@@ -1023,7 +1102,8 @@ QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
   layerOptions.clear();
 
   datasetOptions.insert( "3D", new BoolOption(
-                            QObject::tr( "Determine whether 2D (seed_2d.dgn) or 3D (seed_3d.dgn) seed file should be used. This option is ignored if the SEED option is provided." )
+                            QObject::tr( "Determine whether 2D (seed_2d.dgn) or 3D (seed_3d.dgn) "
+                                         "seed file should be used. This option is ignored if the SEED option is provided." )
                             , false  // Default value
                             ) );
 
@@ -1033,37 +1113,43 @@ QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
                           ) );
 
   datasetOptions.insert( "COPY_WHOLE_SEED_FILE", new BoolOption(
-                            QObject::tr( "Indicate whether the whole seed file should be copied. If not, only the first three elements (and potentially the color table) will be copied. Default is NO." )
+                            QObject::tr( "Indicate whether the whole seed file should be copied. "
+                                         "If not, only the first three elements will be copied.")
                             , false  // Default value
                             ) );
 
   datasetOptions.insert( "COPY_SEED_FILE_COLOR_TABLEE", new BoolOption(
-                            QObject::tr( "Indicates whether the color table should be copied from the seed file. By default this is NO." )
+                            QObject::tr( "Indicates whether the color table should be copied from the seed file.")
                             , false  // Default value
                             ) );
 
   datasetOptions.insert( "MASTER_UNIT_NAME", new StringOption(
-                             QObject::tr( "Override the master unit name from the seed file with the provided one or two character unit name." )
+                             QObject::tr( "Override the master unit name from the seed file with "
+                                          "the provided one or two character unit name." )
                           , ""  // Default value
                           ) );
 
   datasetOptions.insert( "SUB_UNIT_NAME", new StringOption(
-                             QObject::tr( "Override the sub unit name from the seed file with the provided one or two character unit name." )
+                             QObject::tr( "Override the sub unit name from the seed file with the provided "
+                                          "one or two character unit name." )
                           , ""  // Default value
                           ) );
 
   datasetOptions.insert( "SUB_UNITS_PER_MASTER_UNIT", new IntOption(
-                          QObject::tr( "Override the number of subunits per master unit. By default the seed file value is used." )
+                          QObject::tr( "Override the number of subunits per master unit. "
+                                       "By default the seed file value is used." )
                           , 0 // Default value
                           ) );
 
   datasetOptions.insert( "UOR_PER_SUB_UNIT", new IntOption(
-                          QObject::tr( "Override the number of UORs (Units of Resolution) per sub unit. By default the seed file value is used." )
+                          QObject::tr( "Override the number of UORs (Units of Resolution) "
+                                       "per sub unit. By default the seed file value is used." )
                           , 0 // Default value
                           ) );
 
   datasetOptions.insert( "ORIGIN", new StringOption(
-                             QObject::tr( "ORIGIN=x,y,z: Override the origin of the design plane. By default the origin from the seed file is used." )
+                             QObject::tr( "ORIGIN=x,y,z: Override the origin of the design plane. "
+                                          "By default the origin from the seed file is used." )
                           , ""  // Default value
                           ) );
 
@@ -1106,37 +1192,49 @@ QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
                              ) );
 
   datasetOptions.insert( "SPLIT_MULTIPOINT", new BoolOption(
-                            QObject::tr( "Should multipoint soundings be split into many single point sounding features. Multipoint geometries are not well handle by many formats, so it can be convenient to split single sounding features with many points into many single point features. Default is OFF." )
+                            QObject::tr( "Should multipoint soundings be split into many single point sounding features. "
+                                         "Multipoint geometries are not well handle by many formats, "
+                                         "so it can be convenient to split single sounding features with many points "
+                                         "into many single point features." )
                             , false  // Default value
                             ) );
 
   datasetOptions.insert( "ADD_SOUNDG_DEPTH", new BoolOption(
-                            QObject::tr( "Should a DEPTH attribute be added on SOUNDG features and assign the depth of the sounding. This should only be enabled with SPLIT_MULTIPOINT is also enabled. Default is OFF." )
+                            QObject::tr( "Should a DEPTH attribute be added on SOUNDG features and assign the depth "
+                                         "of the sounding. This should only be enabled with SPLIT_MULTIPOINT is "
+                                         "also enabled." )
                             , false  // Default value
                             ) );
 
   datasetOptions.insert( "RETURN_PRIMITIVES", new BoolOption(
-                            QObject::tr( "Should all the low level geometry primitives be returned as special IsolatedNode, ConnectedNode, Edge and Face layers. Default is OFF." )
-                            , false  // Default value
+                            QObject::tr( "Should all the low level geometry primitives be returned as special "
+                                         "IsolatedNode, ConnectedNode, Edge and Face layers." )
+                            , true  // Default value
                             ) );
 
   datasetOptions.insert( "PRESERVE_EMPTY_NUMBERS", new BoolOption(
-                            QObject::tr( "If enabled, numeric attributes assigned an empty string as a value will be preserved as a special numeric value. This option should not generally be needed, but may be useful when translated S-57 to S-57 losslessly. Default is OFF." )
+                            QObject::tr( "If enabled, numeric attributes assigned an empty string as a value will "
+                                         "be preserved as a special numeric value. This option should not generally "
+                                         "be needed, but may be useful when translated S-57 to S-57 losslessly." )
                             , false  // Default value
                             ) );
 
   datasetOptions.insert( "LNAM_REFS", new BoolOption(
-                            QObject::tr( "Should LNAM and LNAM_REFS fields be attached to features capturing the feature to feature relationships in the FFPT group of the S-57 file. Default is OFF." )
-                            , false  // Default value
+                            QObject::tr( "Should LNAM and LNAM_REFS fields be attached to features capturing "
+                                         "the feature to feature relationships in the FFPT group of the S-57 file." )
+                            , true  // Default value
                             ) );
 
   datasetOptions.insert( "RETURN_LINKAGES", new BoolOption(
-                            QObject::tr( "Should additional attributes relating features to their underlying geometric primtives be attached. These are the values of the FSPT group, and are primarily needed when doing S-57 to S-57 translations. Default is OFF." )
-                            , false  // Default value
+                            QObject::tr( "Should additional attributes relating features to their underlying "
+                                         "geometric primitives be attached. These are the values of the FSPT group, "
+                                         "and are primarily needed when doing S-57 to S-57 translations." )
+                            , true  // Default value
                             ) );
 
   datasetOptions.insert( "RECODE_BY_DSSI", new BoolOption(
-                            QObject::tr( "Should attribute values be recoded to UTF-8 from the character encoding specified in the S57 DSSI record. Default is OFF." )
+                            QObject::tr( "Should attribute values be recoded to UTF-8 from the character encoding "
+                                         "specified in the S57 DSSI record." )
                             , false  // Default value
                             ) );
 
@@ -1173,51 +1271,81 @@ QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
   layerOptions.clear();
 
   datasetOptions.insert( "METADATA", new BoolOption(
-                            QObject::tr( "This can be used to avoid creating the geometry_columns and spatial_ref_sys tables in a new database. By default these metadata tables are created when a new database is created." )
+                            QObject::tr( "Can be used to avoid creating the geometry_columns and spatial_ref_sys "
+                                         "tables in a new database. By default these metadata tables are created "
+                                         "when a new database is created." )
                             , true  // Default value
                             ) );
 
   datasetOptions.insert( "SPATIALITE", new BoolOption(
-                            QObject::tr( "Create the SpatiaLite flavour of the metadata tables, which are a bit differ from the metadata used by this OGR driver and from OGC specifications. Implies METADATA=yes" )
+                            QObject::tr( "Create the SpatiaLite flavour of the metadata tables, which are a bit "
+                                         "differ from the metadata used by this OGR driver and from OGC "
+                                         "specifications. Implies METADATA=yes" )
                             , true  // Default value
                             ) );
 
   datasetOptions.insert( "INIT_WITH_EPSG", new BoolOption(
-                            QObject::tr( "Insert the content of the EPSG CSV files into the spatial_ref_sys table. Defaults to NO for regular SQLite databases." )
-                            , false  // Default value
+                            QObject::tr( "Insert the content of the EPSG CSV files into the spatial_ref_sys table. "
+                                         "Set to NO for regular SQLite databases." )
+                            , true  // Default value
                             ) );
 
   layerOptions.insert( "FORMAT", new SetOption(
-                            QObject::tr( "Controls the format used for the geometry column. By default WKB (Well Known Binary) is used. This is generally more space and processing efficient, but harder to inspect or use in simple applications than WKT (Well Known Text). SpatiaLite extension uses its own binary format to store geometries and you can choose it as well. It will be selected automatically when SpatiaLite database is opened or created with SPATIALITE=yes option" ),
+                            QObject::tr( "Controls the format used for the geometry column. By default we assume "
+                                         "that an SpatiaLite database will be created. SpatiaLite extension uses "
+                                         "its own binary format to store geometries. Set to WKB (Well Known Binary) "
+                                         "if you only want to export a SQlite database. This is generally more space "
+                                         "and processing efficient, but harder to inspect or use in simple applications "
+                                         "than WKT (Well Known Text)."),
                             QStringList()
                             << "WKB"
                             << "WKT"
                             << "SPATIALITE"
-                            , "WKB" // Default value
+                            , "SPATIALITE" // Default value
                              ) );
 
   layerOptions.insert( "LAUNDER", new BoolOption(
-                            QObject::tr( "Controls whether layer and field names will be laundered for easier use in SQLite. Laundered names will be convered to lower case and some special characters(' - #) will be changed to underscores. Default to yes." )
+                            QObject::tr( "Controls whether layer and field names will be laundered for easier use "
+                                         "in SQLite. Laundered names will be convered to lower case and some special "
+                                         "characters(' - #) will be changed to underscores." )
                             , true  // Default value
                             ) );
 
   layerOptions.insert( "SPATIAL_INDEX", new BoolOption(
-                            QObject::tr( "If the database is of the SpatiaLite flavour, and if OGR is linked against libspatialite, this option can be used to control if a spatial index must be created. Default to yes" )
+                            QObject::tr( "If the database is of the SpatiaLite flavour, and if OGR is linked "
+                                         "against libspatialite, this option can be used to control if a spatial "
+                                         "index must be created." )
                             , true  // Default value
                             ) );
 
   layerOptions.insert( "COMPRESS_GEOM", new BoolOption(
-                            QObject::tr( "If the format of the geometry BLOB is of the SpatiaLite flavour, this option can be used to control if the compressed format for geometries (LINESTRINGs, POLYGONs) must be used" )
+                            QObject::tr( "If the format of the geometry BLOB is of the SpatiaLite flavour, "
+                                         "this option can be used to control if the compressed format for "
+                                         "geometries (LINESTRINGs, POLYGONs) must be used" )
                             , false  // Default value
                             ) );
 
   layerOptions.insert( "SRID", new StringOption(
-                          QObject::tr( "Used to force the SRID number of the SRS associated with the layer. <br/>When this option isn't specified and that a SRS is associated with the layer, a search is made in the spatial_ref_sys to find a match for the SRS, and, if there is no match, a new entry is inserted for the SRS in the spatial_ref_sys table. When the SRID option is specified, this search (and the eventual insertion of a new entry) will not be done : the specified SRID is used as such." )
+                          QObject::tr( "Used to force the SRID number of the SRS associated with the layer. "
+                                       "When this option isn't specified and that a SRS is associated with the "
+                                       "layer, a search is made in the spatial_ref_sys to find a match for the "
+                                       "SRS, and, if there is no match, a new entry is inserted for the SRS in "
+                                       "the spatial_ref_sys table. When the SRID option is specified, this "
+                                       "search (and the eventual insertion of a new entry) will not be done: "
+                                       "the specified SRID is used as such." )
                           , ""  // Default value
                           ) );
 
   layerOptions.insert( "COMPRESS_COLUMNS", new StringOption(
-                           QObject::tr( "column_name1[,column_name2, ...] <br/>A list of (String) columns that must be compressed with ZLib DEFLATE algorithm. <br/>This might be beneficial for databases that have big string blobs. However, use with care, since the value of such columns will be seen as compressed binary content with other SQLite utilities (or previous OGR versions). </br>With OGR, when inserting, modifying or queryings compressed columns, compression/decompression is done transparently. <br/>However, such columns cannot be (easily) queried with an attribute filter or WHERE clause. <br/>Note: in table definition, such columns have the 'VARCHAR_deflate' declaration type." )
+                           QObject::tr( "column_name1[,column_name2, ...] A list of (String) columns that "
+                                        "must be compressed with ZLib DEFLATE algorithm. This might be beneficial "
+                                        "for databases that have big string blobs. However, use with care, since "
+                                        "the value of such columns will be seen as compressed binary content with "
+                                        "other SQLite utilities (or previous OGR versions). With OGR, when inserting, "
+                                        "modifying or queryings compressed columns, compression/decompression is "
+                                        "done transparently. However, such columns cannot be (easily) queried with "
+                                        "an attribute filter or WHERE clause. Note: in table definition, such columns "
+                                        "have the 'VARCHAR_deflate' declaration type." )
                           , ""  // Default value
                           ) );
 
@@ -1236,15 +1364,15 @@ QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
   datasetOptions.clear();
   layerOptions.clear();
 
-  datasetOptions.insert( "HEADER", new StringOption(
-                          QObject::tr( "Override the header file used - in place of header.dxf." )
-                          , ""  // Default value
-                          ) );
+//  datasetOptions.insert( "HEADER", new StringOption(
+//                          QObject::tr( "Override the header file used - in place of header.dxf." )
+//                          , ""  // Default value
+//                          ) );
 
-  datasetOptions.insert( "TRAILER", new StringOption(
-                          QObject::tr( "Override the trailer file used - in place of trailer.dxf." )
-                          , ""  // Default value
-                          ) );
+//  datasetOptions.insert( "TRAILER", new StringOption(
+//                          QObject::tr( "Override the trailer file used - in place of trailer.dxf." )
+//                          , ""  // Default value
+//                          ) );
 
   driverMetadata.insert( "DXF",
                          MetaData(
@@ -1262,17 +1390,20 @@ QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
   layerOptions.clear();
 
   datasetOptions.insert( "EXTENSION", new SetOption(
-                            QObject::tr( "indicates the GeoConcept export file extension. TXT was used by earlier releases of GeoConcept. GXT is currently used." ),
+                            QObject::tr( "Indicates the GeoConcept export file extension. "
+                                         "TXT was used by earlier releases of GeoConcept. GXT is currently used." ),
                             QStringList()
                             << "GXT"
                             << "TXT"
                             , "GXT" // Default value
                              ) );
 
-  datasetOptions.insert( "CONFIG", new StringOption(
-                          QObject::tr( "path to the GCT : the GCT file describe the GeoConcept types definitions : In this file, every line must start with //# followed by a keyword. Lines starting with // are comments." )
-                          , ""  // Default value
-                          ) );
+//  datasetOptions.insert( "CONFIG", new StringOption(
+//                            QObject::tr( "path to the GCT : the GCT file describe the GeoConcept types definitions: "
+//                                         "In this file, every line must start with //# followed by a keyword. "
+//                                         "Lines starting with // are comments." )
+//                          , ""  // Default value
+//                          ) );
 
   driverMetadata.insert( "Geoconcept",
                          MetaData(
@@ -1290,7 +1421,8 @@ QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
   layerOptions.clear();
 
   layerOptions.insert( "FEATURE_DATASET", new StringOption(
-                          QObject::tr( "When this option is set, the new layer will be created inside the named FeatureDataset folder. If the folder does not already exist, it will be created." )
+                          QObject::tr( "When this option is set, the new layer will be created inside the named "
+                                       "FeatureDataset folder. If the folder does not already exist, it will be created." )
                           , ""  // Default value
                           ) );
 

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -484,6 +484,857 @@ OGRGeometryH QgsVectorFileWriter::createEmptyGeometry( QGis::WkbType wkbType )
   return OGR_G_CreateGeometry(( OGRwkbGeometryType ) wkbType );
 }
 
+QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
+{
+  QMap<QString, MetaData> driverMetadata;
+
+  QMap<QString, Option*> datasetOptions;
+  QMap<QString, Option*> layerOptions;
+
+  // Arc/Info ASCII Coverage
+  datasetOptions.clear();
+  layerOptions.clear();
+
+  driverMetadata.insert( "AVCE00",
+                         MetaData(
+                           "Arc/Info ASCII Coverage",
+                           QObject::tr( "Arc/Info ASCII Coverage" ),
+                           "*.e00",
+                           "e00",
+                           datasetOptions,
+                           layerOptions
+                         )
+                       );
+
+  // Atlas BNA
+  datasetOptions.clear();
+  layerOptions.clear();
+
+  datasetOptions.insert( "LINEFORMAT", new SetOption(
+                            QObject::tr( "By default when creating new .BNA files they are created with the line termination conventions of the local platform (CR/LF on win32 or LF on all other systems). This may be overridden through use of the LINEFORMAT option." ),
+                            QStringList()
+                            << "CRLF"
+                            << "LF"
+                            , "" // Default value
+                            , true // Allow None
+                            ) );
+
+  datasetOptions.insert( "MULTILINE", new BoolOption(
+                            QObject::tr( "By default, BNA files are created in the multi-line format (for each record, the first line contains the identifiers and the type/number of coordinates to follow. The following lines contains a pair of coordinates)." )
+                            , true  // Default value
+                            ) );
+
+  datasetOptions.insert( "NB_IDS", new SetOption(
+                            QObject::tr( "BNA records may contain from 2 to 4 identifiers per record. Some software packages only support a precise number of identifiers. You can override the default value (2) by a precise value" ),
+                            QStringList()
+                            << "2"
+                            << "3"
+                            << "4"
+                            << "NB_SOURCE_FIELDS"
+                            , "2" // Default value
+                            ) );
+
+  datasetOptions.insert( "ELLIPSES_AS_ELLIPSES", new BoolOption(
+                            QObject::tr( "The BNA writer will try to recognize ellipses and circles when writing a polygon. <br/>This will only work if the feature has previously been read from a BNA file.<br/> As some software packages do not support ellipses/circles in BNA data file, it may be useful to tell the writer by specifying <strong>ELLIPSES_AS_ELLIPSES=NO</strong> not to export them as such, but keep them as polygons." )
+                            , true  // Default value
+                            ) );
+
+  datasetOptions.insert( "NB_PAIRS_PER_LINE", new IntOption(
+                          QObject::tr( "This option may be used to limit the number of coordinate pairs per line in multiline format." )
+                          , 2 // Default value
+                          ) );
+
+  datasetOptions.insert( "COORDINATE_PRECISION", new IntOption(
+                          QObject::tr( "This option may be used to set the number of decimal for coordinates. Default value is 10." )
+                          , 10 // Default value
+                          ) );
+
+  driverMetadata.insert( "BNA",
+                         MetaData(
+                           "Atlas BNA",
+                           QObject::tr( "Atlas BNA" ),
+                           "*.bna",
+                           "bna",
+                           datasetOptions,
+                           layerOptions
+                         )
+                       );
+
+  // Comma Separated Value
+  datasetOptions.clear();
+  layerOptions.clear();
+
+  layerOptions.insert( "LINEFORMAT", new SetOption(
+                            QObject::tr( "By default when creating new .BNA files they are created with the line termination conventions of the local platform (CR/LF on win32 or LF on all other systems). This may be overridden through use of the LINEFORMAT option." ),
+                            QStringList()
+                            << "AS_WKT"
+                            << "LF"
+                            , "" // Default value
+                         , true // Allow None
+                            ) );
+
+  layerOptions.insert( "GEOMETRY", new SetOption(
+                            QObject::tr( "By default, the geometry of a feature written to a .csv file is discarded. It is possible to export the geometry in its WKT representation by specifying GEOMETRY=AS_WKT. It is also possible to export point geometries into their X,Y,Z components (different columns in the csv file) by specifying GEOMETRY=AS_XYZ, GEOMETRY=AS_XY or GEOMETRY=AS_YX. The geometry column(s) will be prepended to the columns with the attributes values." ),
+                            QStringList()
+                            << "CRLF"
+                            << "AS_XYZ"
+                            << "AS_XY"
+                            << "AS_YX"
+                            , "" // Default value
+                         , true // Allow None
+                            ) );
+
+  layerOptions.insert( "CREATE_CSVT", new BoolOption(
+                            QObject::tr( "Create the associated .csvt file (see above paragraph) to describe the type of each column of the layer and its optional width and precision. Default value : NO" )
+                            , false  // Default value
+                            ) );
+
+  layerOptions.insert( "SEPARATOR", new SetOption(
+                            QObject::tr( "Field separator character. Default value : COMMA" ),
+                            QStringList()
+                            << "COMMA"
+                            << "SEMICOLON"
+                            << "TAB"
+                            , "COMMA" // Default value
+                            ) );
+
+  layerOptions.insert( "WRITE_BOM", new BoolOption(
+                            QObject::tr( "Write a UTF-8 Byte Order Mark (BOM) at the start of the file. Default value : NO" )
+                            , false  // Default value
+                            ) );
+
+  driverMetadata.insert( "CSV",
+                         MetaData(
+                           "Comma Separated Value",
+                           QObject::tr( "Comma Separated Value" ),
+                           "*.csv",
+                           "csv",
+                           datasetOptions,
+                           layerOptions
+                         )
+                       );
+
+  // ESRI Shapefile
+  datasetOptions.clear();
+  layerOptions.clear();
+
+  layerOptions.insert( "SHPT", new SetOption(
+                            QObject::tr( "Override the type of shapefile created. Can be one of NULL for a simple .dbf file with no .shp file, POINT, ARC, POLYGON or MULTIPOINT for 2D, or POINTZ, ARCZ, POLYGONZ or MULTIPOINTZ for 3D. Shapefiles with measure values are not supported, nor are MULTIPATCH files." ),
+                            QStringList()
+                            << "NULL"
+                            << "POINT"
+                            << "ARC"
+                            << "POLYGON"
+                            << "MULTIPOINT"
+                            << "POINTZ"
+                            << "ARCZ"
+                            << "POLYGONZ"
+                            << "MULTIPOINTZ"
+                            , "NULL" // Default value
+                            ) );
+
+  layerOptions.insert( "ENCODING", new SetOption(
+                            QObject::tr( "set the encoding value in the DBF file. The default value is LDID/87. It is not clear what other values may be appropriate." ),
+                            QStringList()
+                            << "LDID/87"
+                            , "LDID/87" // Default value
+                            ) );
+
+  layerOptions.insert( "RESIZE", new BoolOption(
+                            QObject::tr( "Set to YES to resize fields to their optimal size." )
+                            , false  // Default value
+                            ) );
+
+  driverMetadata.insert( "ESRI",
+                         MetaData(
+                           "ESRI Shapefile",
+                           QObject::tr( "ESRI Shapefile" ),
+                           "*.shp",
+                           "shp",
+                           datasetOptions,
+                           layerOptions
+                         )
+                       );
+
+  // DBF File
+  datasetOptions.clear();
+  layerOptions.clear();
+
+  driverMetadata.insert( "DBF File",
+                         MetaData(
+                           "DBF File",
+                           QObject::tr( "DBF File" ),
+                           "*.dbf",
+                           "dbf",
+                           datasetOptions,
+                           layerOptions
+                         )
+                       );
+
+  // FMEObjects Gateway
+  datasetOptions.clear();
+  layerOptions.clear();
+
+  driverMetadata.insert( "FMEObjects Gateway",
+                         MetaData(
+                           "FMEObjects Gateway",
+                           QObject::tr( "FMEObjects Gateway" ),
+                           "*.fdd",
+                           "fdd",
+                           datasetOptions,
+                           layerOptions
+                         )
+                       );
+
+  // GeoJSON
+  datasetOptions.clear();
+  layerOptions.clear();
+
+  layerOptions.insert( "WRITE_BBOX", new BoolOption(
+                            QObject::tr( "Set to YES to write a bbox property with the bounding box of the geometries at the feature and feature collection level. Defaults to NO." )
+                            , false  // Default value
+                            ) );
+
+  layerOptions.insert( "COORDINATE_PRECISION", new IntOption(
+                          QObject::tr( "Maximum number of figures after decimal separator to write in coordinates. Default to 15. Truncation will occur to remove trailing zeros." )
+                          , 15 // Default value
+                          ) );
+
+  driverMetadata.insert( "GeoJSON",
+                         MetaData(
+                           "GeoJSON",
+                           QObject::tr( "GeoJSON" ),
+                           "*.geojson",
+                           "geojson",
+                           datasetOptions,
+                           layerOptions
+                         )
+                       );
+
+  // GeoRSS
+  datasetOptions.clear();
+  layerOptions.clear();
+
+  datasetOptions.insert( "FORMAT", new SetOption(
+                            QObject::tr( "whether the document must be in RSS 2.0 or Atom 1.0 format. Default value : RSS" ),
+                            QStringList()
+                            << "RSS"
+                            << "ATOM"
+                            , "RSS" // Default value
+                            ) );
+
+  datasetOptions.insert( "GEOM_DIALECT", new SetOption(
+                            QObject::tr( "the encoding of location information. Default value : SIMPLE W3C_GEO only supports point geometries. SIMPLE or W3C_GEO only support geometries in geographic WGS84 coordinates." ),
+                            QStringList()
+                            << "SIMPLE"
+                            << "GML"
+                            << "W3C_GEO"
+                            , "SIMPLE" // Default value
+                            ) );
+
+  datasetOptions.insert( "USE_EXTENSIONS", new BoolOption(
+                            QObject::tr( "If defined to YES, extension fields (that is to say fields not in the base schema of RSS or Atom documents) will be written. If the field name not found in the base schema matches the foo_bar pattern, foo will be considered as the namespace of the element, and a <foo:bar> element will be written. Otherwise, elements will be written in the <ogr:> namespace." )
+                            , false  // Default value
+                            ) );
+
+  datasetOptions.insert( "WRITE_HEADER_AND_FOOTER", new BoolOption(
+                            QObject::tr( "If defined to NO, only <entry> or <item> elements will be written. The user will have to provide the appropriate header and footer of the document." )
+                            , true  // Default value
+                            ) );
+
+  datasetOptions.insert( "HEADER", new StringOption(
+                          QObject::tr( "XML content that will be put between the <channel> element and the first <item> element for a RSS document, or between the xml tag and the first <entry> element for an Atom document. If it is specified, it will overload the following options." )
+                          , ""  // Default value
+                          ) );
+
+  datasetOptions.insert( "TITLE", new StringOption(
+                          QObject::tr( "value put inside the <title> element in the header. If not provided, a dummy value will be used as that element is compulsory." )
+                          , ""  // Default value
+                          ) );
+
+  datasetOptions.insert( "DESCRIPTION", new StringOption(
+                          QObject::tr( "value put inside the <description> element in the header. If not provided, a dummy value will be used as that element is compulsory." )
+                          , ""  // Default value
+                          ) );
+
+  datasetOptions.insert( "LINK", new StringOption(
+                          QObject::tr( "value put inside the <link> element in the header. If not provided, a dummy value will be used as that element is compulsory." )
+                          , ""  // Default value
+                          ) );
+
+  datasetOptions.insert( "UPDATED", new StringOption(
+                          QObject::tr( "value put inside the <updated> element in the header. Should be formatted as a XML datetime. If not provided, a dummy value will be used as that element is compulsory." )
+                          , ""  // Default value
+                          ) );
+
+  datasetOptions.insert( "AUTHOR_NAME", new StringOption(
+                          QObject::tr( "value put inside the <author><name> element in the header. If not provided, a dummy value will be used as that element is compulsory." )
+                          , ""  // Default value
+                          ) );
+
+  datasetOptions.insert( "ID", new StringOption(
+                          QObject::tr( "value put inside the <id> element in the header. If not provided, a dummy value will be used as that element is compulsory." )
+                          , ""  // Default value
+                          ) );
+
+  driverMetadata.insert( "GeoRSS",
+                         MetaData(
+                           "GeoRSS",
+                           QObject::tr( "GeoRSS" ),
+                           "*.xml",
+                           "xml",
+                           datasetOptions,
+                           layerOptions
+                         )
+                       );
+
+  // Geography Markup Language [GML]
+  datasetOptions.clear();
+  layerOptions.clear();
+
+  datasetOptions.insert( "XSISCHEMAURI", new StringOption(
+                          QObject::tr( "If provided, this URI will be inserted as the schema location. Note that the schema file isn't actually accessed by OGR, so it is up to the user to ensure it will match the schema of the OGR produced GML data file." )
+                          , ""  // Default value
+                          ) );
+
+  datasetOptions.insert( "XSISCHEMA", new SetOption(
+                            QObject::tr( "This writes a GML application schema file to a corresponding .xsd file (with the same basename). If INTERNAL is used the schema is written within the GML file, but this is experimental and almost certainly not valid XML. OFF disables schema generation (and is implicit if XSISCHEMAURI is used)." ),
+                            QStringList()
+                            << "EXTERNAL"
+                            << "INTERNAL"
+                            << "OFF"
+                            , "EXTERNAL" // Default value
+                            ) );
+
+  datasetOptions.insert( "PREFIX", new StringOption(
+                          QObject::tr( "Defaults to 'ogr'. This is the prefix for the application target namespace." )
+                          , "ogr"  // Default value
+                          ) );
+
+  datasetOptions.insert( "STRIP_PREFIX", new BoolOption(
+                            QObject::tr( "Defaults to FALSE. Can be set to TRUE to avoid writing the prefix of the application target namespace in the GML file." )
+                            , false  // Default value
+                            ) );
+
+  datasetOptions.insert( "TARGET_NAMESPACE", new StringOption(
+                          QObject::tr( "Defaults to 'http://ogr.maptools.org/'. This is the application target namespace." )
+                          , "http://ogr.maptools.org/"  // Default value
+                          ) );
+
+  datasetOptions.insert( "FORMAT", new SetOption(
+                            QObject::tr( "If not specified, GML2 will be used." ),
+                            QStringList()
+                            << "GML3"
+                            << "GML3Deegree"
+                            << "GML3.2"
+                            , "" // Default value
+                           , true // Allow None
+                            ) );
+
+  datasetOptions.insert( "GML3_LONGSRS", new BoolOption(
+                             QObject::tr( "only valid when FORMAT=GML3/GML3Degree/GML3.2) Default to YES. If YES, SRS with EPSG authority will be written with the 'urn:ogc:def:crs:EPSG::' prefix. In the case, if the SRS is a geographic SRS without explicit AXIS order, but that the same SRS authority code imported with ImportFromEPSGA() should be treated as lat/long, then the function will take care of coordinate order swapping. If set to NO, SRS with EPSG authority will be written with the 'EPSG:' prefix, even if they are in lat/long order." )
+                            , true  // Default value
+                            ) );
+
+  datasetOptions.insert( "WRITE_FEATURE_BOUNDED_BY", new BoolOption(
+                             QObject::tr( "only valid when FORMAT=GML3/GML3Degree/GML3.2) Default to YES. If set to NO, the <gml:boundedBy> element will not be written for each feature." )
+                            , true  // Default value
+                            ) );
+
+  datasetOptions.insert( "SPACE_INDENTATION", new BoolOption(
+                             QObject::tr( "Default to YES. If YES, the output will be indented with spaces for more readability, but at the expense of file size." )
+                            , true  // Default value
+                            ) );
+
+
+  driverMetadata.insert( "GML",
+                         MetaData(
+                           "Geography Markup Language [GML]",
+                           QObject::tr( "Geography Markup Language [GML]" ),
+                           "*.gml",
+                           "gml",
+                           datasetOptions,
+                           layerOptions
+                         )
+                       );
+
+  // Generic Mapping Tools [GMT]
+  datasetOptions.clear();
+  layerOptions.clear();
+
+  driverMetadata.insert( "GMT",
+                         MetaData(
+                           "Generic Mapping Tools [GMT]",
+                           QObject::tr( "Generic Mapping Tools [GMT]" ),
+                           "*.gmt",
+                           "gmt",
+                           datasetOptions,
+                           layerOptions
+                         )
+                       );
+
+  // GPS eXchange Format [GPX]
+  datasetOptions.clear();
+  layerOptions.clear();
+
+  layerOptions.insert( "FORCE_GPX_TRACK", new BoolOption(
+                             QObject::tr( "By default when writting a layer whose features are of type wkbLineString, the GPX driver chooses to write them as routes. If FORCE_GPX_TRACK=YES is specified, they will be written as tracks." )
+                            , false  // Default value
+                            ) );
+
+  layerOptions.insert( "FORCE_GPX_ROUTE", new BoolOption(
+                             QObject::tr( "By default when writting a layer whose features are of type wkbMultiLineString, the GPX driver chooses to write them as tracks. If FORCE_GPX_ROUTE=YES is specified, they will be written as routes, provided that the multilines are composed of only one single line." )
+                            , false  // Default value
+                            ) );
+
+  datasetOptions.insert( "GPX_USE_EXTENSIONS", new BoolOption(
+                             QObject::tr( "By default, the GPX driver will discard attribute fields that do not match the GPX XML definition (name, cmt, etc...). If GPX_USE_EXTENSIONS=YES is specified, extra fields will be written inside the<extensions> tag." )
+                            , false  // Default value
+                            ) );
+
+  datasetOptions.insert( "GPX_EXTENSIONS_NS", new StringOption(
+                             QObject::tr( "Only used if GPX_USE_EXTENSIONS=YES and GPX_EXTENSIONS_NS_URL is set. The namespace value used for extension tags. By default, 'ogr'." )
+                          , "ogr"  // Default value
+                          ) );
+
+  datasetOptions.insert( "GPX_EXTENSIONS_NS_URL", new StringOption(
+                             QObject::tr( "Only used if GPX_USE_EXTENSIONS=YES and GPX_EXTENSIONS_NS is set. The namespace URI. By default, 'http://osgeo.org/gdal'." )
+                          , "http://osgeo.org/gdal"  // Default value
+                          ) );
+
+  datasetOptions.insert( "LINEFORMAT", new SetOption(
+                            QObject::tr( "By default files are created with the line termination conventions of the local platform (CR/LF on win32 or LF on all other systems). This may be overridden through use of the LINEFORMAT layer creation option which may have a value of CRLF (DOS format) or LF (Unix format)." ),
+                            QStringList()
+                            << "CRLF"
+                            << "LF"
+                            , "" // Default value
+                           , true // Allow None
+                            ) );
+
+  driverMetadata.insert( "GPX",
+                         MetaData(
+                           "GPS eXchange Format [GPX]",
+                           QObject::tr( "GPS eXchange Format [GPX]" ),
+                           "*.gpx",
+                           "gpx",
+                           datasetOptions,
+                           layerOptions
+                         )
+                       );
+
+  // INTERLIS 1
+  datasetOptions.clear();
+  layerOptions.clear();
+
+  driverMetadata.insert( "Interlis 1",
+                         MetaData(
+                           "INTERLIS 1",
+                           QObject::tr( "INTERLIS 1" ),
+                           "*.itf *.xml *.ili",
+                           "ili",
+                           datasetOptions,
+                           layerOptions
+                         )
+                       );
+
+  // INTERLIS 2
+  datasetOptions.clear();
+  layerOptions.clear();
+
+  driverMetadata.insert( "Interlis 2",
+                         MetaData(
+                           "INTERLIS 2",
+                           QObject::tr( "INTERLIS 2" ),
+                           "*.itf *.xml *.ili",
+                           "ili",
+                           datasetOptions,
+                           layerOptions
+                         )
+                       );
+
+  // Keyhole Markup Language [KML]
+  datasetOptions.clear();
+  layerOptions.clear();
+
+  datasetOptions.insert( "NameField", new StringOption(
+                             QObject::tr( "Allows you to specify the field to use for the KML <name> element. Default value : 'Name'" )
+                          , "Name"  // Default value
+                          ) );
+
+  datasetOptions.insert( "DescriptionField", new StringOption(
+                             QObject::tr( "Allows you to specify the field to use for the KML <description> element. Default value : 'Description'" )
+                          , "Description"  // Default value
+                          ) );
+
+  datasetOptions.insert( "AltitudeMode", new SetOption(
+                            QObject::tr( "Allows you to specify the AltitudeMode to use for KML geometries. This will only affect 3D geometries and must be one of the valid KML options." ),
+                            QStringList()
+                            << "relativeToGround"
+                            << "clampToGround"
+                            << "absolute"
+                            , "relativeToGround" // Default value
+                             ) );
+
+  driverMetadata.insert( "KML",
+                         MetaData(
+                           "Keyhole Markup Language [KML]",
+                           QObject::tr( "Keyhole Markup Language [KML]" ),
+                           "*.kml",
+                           "kml",
+                           datasetOptions,
+                           layerOptions
+                         )
+                       );
+
+  // Mapinfo
+  datasetOptions.clear();
+  layerOptions.clear();
+
+  datasetOptions.insert( "FORMAT", new SetOption(
+                            QObject::tr( "To create MIF/MID instead of TAB files (TAB is the default)." ),
+                            QStringList()
+                            << "MIF/MID"
+                            << "TAB"
+                            , "TAB" // Default value
+                             ) );
+
+  layerOptions.insert( "SPATIAL_INDEX_MODE", new SetOption(
+                            QObject::tr( "Use this to turn on 'quick spatial index mode'. The default behavior of MITAB since GDAL v1.5.0 is to generate an optimized spatial index, but this results in slower write speed than what we used to get with GDAL 1.4.x and older. Applications that want faster write speed and do not care about the performance of spatial queries on the resulting file can use this option to require the creation of a non-optimal spatial index (actually emulating the type of spatial index produced by OGR's TAB driver before GDAL 1.5.0). In this mode writing files can be about 5 times faster, but spatial queries can be up to 30 times slower." ),
+                            QStringList()
+                            << "QUICK"
+                            << ""
+                            , "" // Default value
+                         , true // Allow None
+                             ) );
+
+  driverMetadata.insert( "MapInfo File",
+                         MetaData(
+                           "Mapinfo",
+                           QObject::tr( "Mapinfo" ),
+                           "*.tab *.mif",
+                           "tab",
+                           datasetOptions,
+                           layerOptions
+                         )
+                       );
+
+  // Microstation DGN
+  datasetOptions.clear();
+  layerOptions.clear();
+
+  datasetOptions.insert( "3D", new BoolOption(
+                            QObject::tr( "Determine whether 2D (seed_2d.dgn) or 3D (seed_3d.dgn) seed file should be used. This option is ignored if the SEED option is provided." )
+                            , false  // Default value
+                            ) );
+
+  datasetOptions.insert( "SEED", new StringOption(
+                             QObject::tr( "Override the seed file to use." )
+                          , ""  // Default value
+                          ) );
+
+  datasetOptions.insert( "COPY_WHOLE_SEED_FILE", new BoolOption(
+                            QObject::tr( "Indicate whether the whole seed file should be copied. If not, only the first three elements (and potentially the color table) will be copied. Default is NO." )
+                            , false  // Default value
+                            ) );
+
+  datasetOptions.insert( "COPY_SEED_FILE_COLOR_TABLEE", new BoolOption(
+                            QObject::tr( "Indicates whether the color table should be copied from the seed file. By default this is NO." )
+                            , false  // Default value
+                            ) );
+
+  datasetOptions.insert( "MASTER_UNIT_NAME", new StringOption(
+                             QObject::tr( "Override the master unit name from the seed file with the provided one or two character unit name." )
+                          , ""  // Default value
+                          ) );
+
+  datasetOptions.insert( "SUB_UNIT_NAME", new StringOption(
+                             QObject::tr( "Override the sub unit name from the seed file with the provided one or two character unit name." )
+                          , ""  // Default value
+                          ) );
+
+  datasetOptions.insert( "SUB_UNITS_PER_MASTER_UNIT", new IntOption(
+                          QObject::tr( "Override the number of subunits per master unit. By default the seed file value is used." )
+                          , 0 // Default value
+                          ) );
+
+  datasetOptions.insert( "UOR_PER_SUB_UNIT", new IntOption(
+                          QObject::tr( "Override the number of UORs (Units of Resolution) per sub unit. By default the seed file value is used." )
+                          , 0 // Default value
+                          ) );
+
+  datasetOptions.insert( "ORIGIN", new StringOption(
+                             QObject::tr( "ORIGIN=x,y,z: Override the origin of the design plane. By default the origin from the seed file is used." )
+                          , ""  // Default value
+                          ) );
+
+  driverMetadata.insert( "DGN",
+                         MetaData(
+                           "Microstation DGN",
+                           QObject::tr( "Microstation DGN" ),
+                           "*.dgn",
+                           "dgn",
+                           datasetOptions,
+                           layerOptions
+                         )
+                       );
+
+  // Microstation DGN
+  datasetOptions.clear();
+  layerOptions.clear();
+
+  driverMetadata.insert( "DGN",
+                         MetaData(
+                           "Microstation DGN",
+                           QObject::tr( "Microstation DGN" ),
+                           "*.dgn",
+                           "dgn",
+                           datasetOptions,
+                           layerOptions
+                         )
+                       );
+
+  // S-57 Base file
+  datasetOptions.clear();
+  layerOptions.clear();
+
+  datasetOptions.insert( "UPDATES", new SetOption(
+                            QObject::tr( "Should update files be incorporated into the base data on the fly. " ),
+                            QStringList()
+                            << "APPLY"
+                            << "IGNORE"
+                            , "APPLY" // Default value
+                             ) );
+
+  datasetOptions.insert( "SPLIT_MULTIPOINT", new BoolOption(
+                            QObject::tr( "Should multipoint soundings be split into many single point sounding features. Multipoint geometries are not well handle by many formats, so it can be convenient to split single sounding features with many points into many single point features. Default is OFF." )
+                            , false  // Default value
+                            ) );
+
+  datasetOptions.insert( "ADD_SOUNDG_DEPTH", new BoolOption(
+                            QObject::tr( "Should a DEPTH attribute be added on SOUNDG features and assign the depth of the sounding. This should only be enabled with SPLIT_MULTIPOINT is also enabled. Default is OFF." )
+                            , false  // Default value
+                            ) );
+
+  datasetOptions.insert( "RETURN_PRIMITIVES", new BoolOption(
+                            QObject::tr( "Should all the low level geometry primitives be returned as special IsolatedNode, ConnectedNode, Edge and Face layers. Default is OFF." )
+                            , false  // Default value
+                            ) );
+
+  datasetOptions.insert( "PRESERVE_EMPTY_NUMBERS", new BoolOption(
+                            QObject::tr( "If enabled, numeric attributes assigned an empty string as a value will be preserved as a special numeric value. This option should not generally be needed, but may be useful when translated S-57 to S-57 losslessly. Default is OFF." )
+                            , false  // Default value
+                            ) );
+
+  datasetOptions.insert( "LNAM_REFS", new BoolOption(
+                            QObject::tr( "Should LNAM and LNAM_REFS fields be attached to features capturing the feature to feature relationships in the FFPT group of the S-57 file. Default is OFF." )
+                            , false  // Default value
+                            ) );
+
+  datasetOptions.insert( "RETURN_LINKAGES", new BoolOption(
+                            QObject::tr( "Should additional attributes relating features to their underlying geometric primtives be attached. These are the values of the FSPT group, and are primarily needed when doing S-57 to S-57 translations. Default is OFF." )
+                            , false  // Default value
+                            ) );
+
+  datasetOptions.insert( "RECODE_BY_DSSI", new BoolOption(
+                            QObject::tr( "Should attribute values be recoded to UTF-8 from the character encoding specified in the S57 DSSI record. Default is OFF." )
+                            , false  // Default value
+                            ) );
+
+  // set OGR_S57_OPTIONS = "RETURN_PRIMITIVES=ON,RETURN_LINKAGES=ON,LNAM_REFS=ON"
+
+  driverMetadata.insert( "S57",
+                         MetaData(
+                           "S-57 Base file",
+                           QObject::tr( "S-57 Base file" ),
+                           "*.000",
+                           "000",
+                           datasetOptions,
+                           layerOptions
+                         )
+                       );
+
+  // Spatial Data Transfer Standard [SDTS]
+  datasetOptions.clear();
+  layerOptions.clear();
+
+  driverMetadata.insert( "SDTS",
+                         MetaData(
+                           "Spatial Data Transfer Standard [SDTS]",
+                           QObject::tr( "Spatial Data Transfer Standard [SDTS]" ),
+                           "*catd.ddf",
+                           "ddf",
+                           datasetOptions,
+                           layerOptions
+                         )
+                       );
+
+  // SQLite
+  datasetOptions.clear();
+  layerOptions.clear();
+
+  datasetOptions.insert( "METADATA", new BoolOption(
+                            QObject::tr( "This can be used to avoid creating the geometry_columns and spatial_ref_sys tables in a new database. By default these metadata tables are created when a new database is created." )
+                            , true  // Default value
+                            ) );
+
+  datasetOptions.insert( "SPATIALITE", new BoolOption(
+                            QObject::tr( "Create the SpatiaLite flavour of the metadata tables, which are a bit differ from the metadata used by this OGR driver and from OGC specifications. Implies METADATA=yes" )
+                            , true  // Default value
+                            ) );
+
+  datasetOptions.insert( "INIT_WITH_EPSG", new BoolOption(
+                            QObject::tr( "Insert the content of the EPSG CSV files into the spatial_ref_sys table. Defaults to NO for regular SQLite databases." )
+                            , false  // Default value
+                            ) );
+
+  layerOptions.insert( "FORMAT", new SetOption(
+                            QObject::tr( "Controls the format used for the geometry column. By default WKB (Well Known Binary) is used. This is generally more space and processing efficient, but harder to inspect or use in simple applications than WKT (Well Known Text). SpatiaLite extension uses its own binary format to store geometries and you can choose it as well. It will be selected automatically when SpatiaLite database is opened or created with SPATIALITE=yes option" ),
+                            QStringList()
+                            << "WKB"
+                            << "WKT"
+                            << "SPATIALITE"
+                            , "WKB" // Default value
+                             ) );
+
+  layerOptions.insert( "LAUNDER", new BoolOption(
+                            QObject::tr( "Controls whether layer and field names will be laundered for easier use in SQLite. Laundered names will be convered to lower case and some special characters(' - #) will be changed to underscores. Default to yes." )
+                            , true  // Default value
+                            ) );
+
+  layerOptions.insert( "SPATIAL_INDEX", new BoolOption(
+                            QObject::tr( "If the database is of the SpatiaLite flavour, and if OGR is linked against libspatialite, this option can be used to control if a spatial index must be created. Default to yes" )
+                            , true  // Default value
+                            ) );
+
+  layerOptions.insert( "COMPRESS_GEOM", new BoolOption(
+                            QObject::tr( "If the format of the geometry BLOB is of the SpatiaLite flavour, this option can be used to control if the compressed format for geometries (LINESTRINGs, POLYGONs) must be used" )
+                            , false  // Default value
+                            ) );
+
+  layerOptions.insert( "SRID", new StringOption(
+                          QObject::tr( "Used to force the SRID number of the SRS associated with the layer. <br/>When this option isn't specified and that a SRS is associated with the layer, a search is made in the spatial_ref_sys to find a match for the SRS, and, if there is no match, a new entry is inserted for the SRS in the spatial_ref_sys table. When the SRID option is specified, this search (and the eventual insertion of a new entry) will not be done : the specified SRID is used as such." )
+                          , ""  // Default value
+                          ) );
+
+  layerOptions.insert( "COMPRESS_COLUMNS", new StringOption(
+                           QObject::tr( "column_name1[,column_name2, ...] <br/>A list of (String) columns that must be compressed with ZLib DEFLATE algorithm. <br/>This might be beneficial for databases that have big string blobs. However, use with care, since the value of such columns will be seen as compressed binary content with other SQLite utilities (or previous OGR versions). </br>With OGR, when inserting, modifying or queryings compressed columns, compression/decompression is done transparently. <br/>However, such columns cannot be (easily) queried with an attribute filter or WHERE clause. <br/>Note: in table definition, such columns have the 'VARCHAR_deflate' declaration type." )
+                          , ""  // Default value
+                          ) );
+
+  driverMetadata.insert( "SQLite",
+                         MetaData(
+                           "SQLite/SpatiaLite",
+                           QObject::tr( "SQLite/SpatiaLite" ),
+                           "*.sqlite",
+                           "sqlite",
+                           datasetOptions,
+                           layerOptions
+                         )
+                       );
+
+  // AutoCAD DXF
+  datasetOptions.clear();
+  layerOptions.clear();
+
+  datasetOptions.insert( "HEADER", new StringOption(
+                          QObject::tr( "Override the header file used - in place of header.dxf." )
+                          , ""  // Default value
+                          ) );
+
+  datasetOptions.insert( "TRAILER", new StringOption(
+                          QObject::tr( "Override the trailer file used - in place of trailer.dxf." )
+                          , ""  // Default value
+                          ) );
+
+  driverMetadata.insert( "DXF",
+                         MetaData(
+                           "AutoCAD DXF",
+                           QObject::tr( "AutoCAD DXF" ),
+                           "*.dxf",
+                           "dxf",
+                           datasetOptions,
+                           layerOptions
+                         )
+                       );
+
+  // Geoconcept
+  datasetOptions.clear();
+  layerOptions.clear();
+
+  datasetOptions.insert( "EXTENSION", new SetOption(
+                            QObject::tr( "indicates the GeoConcept export file extension. TXT was used by earlier releases of GeoConcept. GXT is currently used." ),
+                            QStringList()
+                            << "GXT"
+                            << "TXT"
+                            , "GXT" // Default value
+                             ) );
+
+  datasetOptions.insert( "CONFIG", new StringOption(
+                          QObject::tr( "path to the GCT : the GCT file describe the GeoConcept types definitions : In this file, every line must start with //# followed by a keyword. Lines starting with // are comments." )
+                          , ""  // Default value
+                          ) );
+
+  driverMetadata.insert( "Geoconcept",
+                         MetaData(
+                           "Geoconcept",
+                           QObject::tr( "Geoconcept" ),
+                           "*.gxt *.txt",
+                           "gxt",
+                           datasetOptions,
+                           layerOptions
+                         )
+                       );
+
+  // ESRI FileGDB
+  datasetOptions.clear();
+  layerOptions.clear();
+
+  layerOptions.insert( "FEATURE_DATASET", new StringOption(
+                          QObject::tr( "When this option is set, the new layer will be created inside the named FeatureDataset folder. If the folder does not already exist, it will be created." )
+                          , ""  // Default value
+                          ) );
+
+  layerOptions.insert( "GEOMETRY_NAME", new StringOption(
+                          QObject::tr( "Set name of geometry column in new layer. Defaults to 'SHAPE'." )
+                          , "SHAPE"  // Default value
+                          ) );
+
+  layerOptions.insert( "OID_NAME", new StringOption(
+                          QObject::tr( "Name of the OID column to create. Defaults to 'OBJECTID'." )
+                          , "OBJECTID"  // Default value
+                          ) );
+
+  driverMetadata.insert( "FileGDB",
+                         MetaData(
+                           "ESRI FileGDB",
+                           QObject::tr( "ESRI FileGDB" ),
+                           "*.gdb",
+                           "gdb",
+                           datasetOptions,
+                           layerOptions
+                         )
+                       );
+  return driverMetadata;
+}
+
+bool QgsVectorFileWriter::driverMetadata( const QString& driverName, QgsVectorFileWriter::MetaData& driverMetadata )
+{
+  static const QMap<QString, MetaData> sDriverMetadata = initMetaData();
+
+  QMap<QString, MetaData>::ConstIterator it = sDriverMetadata.constBegin();
+
+  for ( ; it != sDriverMetadata.constEnd(); ++it )
+  {
+    if ( it.key().startsWith( driverName ) )
+    {
+      driverMetadata = it.value();
+      return true;
+    }
+  }
+
+  return false;
+}
+
 
 QgsVectorFileWriter::WriterError QgsVectorFileWriter::hasError()
 {

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -1068,14 +1068,6 @@ QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
   datasetOptions.clear();
   layerOptions.clear();
 
-  datasetOptions.insert( "FORMAT", new SetOption(
-                            QObject::tr( "To create MIF/MID instead of TAB files." ),
-                            QStringList()
-                            << "MIF/MID"
-                            << "TAB"
-                            , "TAB" // Default value
-                             ) );
-
   layerOptions.insert( "SPATIAL_INDEX_MODE", new SetOption(
                             QObject::tr( "Use this to turn on 'quick spatial index mode'. "
                                          "In this mode writing files can be about 5 times faster, "
@@ -1083,15 +1075,27 @@ QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
                             QStringList()
                             << "QUICK"
                             , "" // Default value
-                         , true // Allow None
+                            , true // Allow None
                              ) );
 
   driverMetadata.insert( "MapInfo File",
                          MetaData(
                            "Mapinfo",
-                           QObject::tr( "Mapinfo" ),
-                           "*.tab *.mif",
+                           QObject::tr( "Mapinfo TAB" ),
+                           "*.tab",
                            "tab",
+                           datasetOptions,
+                           layerOptions
+                         )
+                       );
+
+  // QGIS internal alias for MIF files
+  driverMetadata.insert( "MapInfo MIF",
+                         MetaData(
+                           "Mapinfo",
+                           QObject::tr( "Mapinfo MIF" ),
+                           "*.mif",
+                           "mif",
                            datasetOptions,
                            layerOptions
                          )
@@ -1277,12 +1281,15 @@ QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
                             , true  // Default value
                             ) );
 
+  // Will be handled with the SpatiaLite driver alias
+#if 0
   datasetOptions.insert( "SPATIALITE", new BoolOption(
                             QObject::tr( "Create the SpatiaLite flavour of the metadata tables, which are a bit "
                                          "differ from the metadata used by this OGR driver and from OGC "
                                          "specifications. Implies METADATA=yes" )
                             , true  // Default value
                             ) );
+#endif
 
   datasetOptions.insert( "INIT_WITH_EPSG", new BoolOption(
                             QObject::tr( "Insert the content of the EPSG CSV files into the spatial_ref_sys table. "
@@ -1351,8 +1358,8 @@ QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
 
   driverMetadata.insert( "SQLite",
                          MetaData(
-                           "SQLite/SpatiaLite",
-                           QObject::tr( "SQLite/SpatiaLite" ),
+                           "SQLite",
+                           QObject::tr( "SQLite" ),
                            "*.sqlite",
                            "sqlite",
                            datasetOptions,
@@ -1360,6 +1367,16 @@ QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
                          )
                        );
 
+  driverMetadata.insert( "SpatiaLite",
+                         MetaData(
+                           "SpatiaLite",
+                           QObject::tr( "SpatiaLite" ),
+                           "*.sqlite",
+                           "sqlite",
+                           datasetOptions,
+                           layerOptions
+                         )
+                       );
   // AutoCAD DXF
   datasetOptions.clear();
   layerOptions.clear();

--- a/src/core/qgsvectorfilewriter.h
+++ b/src/core/qgsvectorfilewriter.h
@@ -46,7 +46,8 @@ class CORE_EXPORT QgsVectorFileWriter
     {
       Set,
       String,
-      Int
+      Int,
+      Hidden
     };
 
     class Option
@@ -108,6 +109,16 @@ class CORE_EXPORT QgsVectorFileWriter
       {}
     };
 
+    class HiddenOption: public Option
+    {
+      public:
+        HiddenOption( const QString& value )
+          : Option( "", Hidden )
+          , mValue( value )
+        {}
+
+        QString mValue;
+    };
 
     struct MetaData
     {

--- a/src/core/qgsvectorfilewriter.h
+++ b/src/core/qgsvectorfilewriter.h
@@ -42,6 +42,94 @@ class QTextCodec;
 class CORE_EXPORT QgsVectorFileWriter
 {
   public:
+    enum OptionType
+    {
+      Set,
+      String,
+      Int
+    };
+
+    class Option
+    {
+    public:
+      Option( const QString& docString, OptionType type )
+          : docString( docString )
+          , type( type )
+      {}
+
+      virtual ~Option() {}
+
+      QString docString;
+      OptionType type;
+    };
+
+    class SetOption : public Option
+    {
+      public:
+      SetOption( const QString& docString, QStringList values, const QString& defaultValue, bool allowNone = false )
+          : Option( docString, Set )
+          , values( values.toSet() )
+          , defaultValue( defaultValue )
+          , allowNone( allowNone )
+      {}
+
+      QSet<QString> values;
+      QString defaultValue;
+      bool allowNone;
+    };
+
+    class StringOption: public Option
+    {
+      public:
+      StringOption( const QString& docString, const QString& defaultValue = QString() )
+          : Option( docString, String )
+          , defaultValue( defaultValue )
+      {}
+
+      QString defaultValue;
+    };
+
+    class IntOption: public Option
+    {
+      public:
+      IntOption( const QString& docString, int defaultValue )
+          : Option( docString, Int )
+          , defaultValue( defaultValue )
+      {}
+
+      int defaultValue;
+    };
+
+    class BoolOption : public SetOption
+    {
+      public:
+      BoolOption( const QString& docString, bool defaultValue )
+          : SetOption( docString, QStringList() << "YES" << "NO", defaultValue ? "YES" : "NO" )
+      {}
+    };
+
+
+    struct MetaData
+    {
+      MetaData()
+      {}
+
+      MetaData( QString longName, QString trLongName, QString glob, QString ext, QMap<QString, Option*> driverOptions, QMap<QString, Option*> layerOptions )
+          : longName( longName )
+          , trLongName( trLongName )
+          , glob( glob )
+          , ext( ext )
+          , driverOptions( driverOptions )
+          , layerOptions( layerOptions )
+      {}
+
+      QString longName;
+      QString trLongName;
+      QString glob;
+      QString ext;
+      QMap<QString, Option*> driverOptions;
+      QMap<QString, Option*> layerOptions;
+    };
 
     enum WriterError
     {
@@ -170,6 +258,8 @@ class CORE_EXPORT QgsVectorFileWriter
     double symbologyScaleDenominator() const { return mSymbologyScaleDenominator; }
     void setSymbologyScaleDenominator( double d ) { mSymbologyScaleDenominator = d; }
 
+    static bool driverMetadata( const QString& driverName, MetaData& driverMetadata );
+
   protected:
     //! @note not available in python bindings
     OGRGeometryH createEmptyGeometry( QGis::WkbType wkbType );
@@ -202,6 +292,10 @@ class CORE_EXPORT QgsVectorFileWriter
     double mSymbologyScaleDenominator;
 
   private:
+    static QMap<QString, MetaData> initMetaData();
+    /**
+     * @deprecated
+     */
     static bool driverMetadata( QString driverName, QString &longName, QString &trLongName, QString &glob, QString &ext );
     void createSymbolLayerTable( QgsVectorLayer* vl,  const QgsCoordinateTransform* ct, OGRDataSourceH ds );
     OGRFeatureH createFeature( QgsFeature& feature );
@@ -217,7 +311,7 @@ class CORE_EXPORT QgsVectorFileWriter
     QgsFeatureRendererV2* symbologyRenderer( QgsVectorLayer* vl ) const;
     /**Adds attributes needed for classification*/
     void addRendererAttributes( QgsVectorLayer* vl, QgsAttributeList& attList );
-
+    static QMap<QString, MetaData> sDriverMetadata;
 };
 
 #endif

--- a/src/ui/qgsvectorlayersaveasdialogbase.ui
+++ b/src/ui/qgsvectorlayersaveasdialogbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>383</width>
-    <height>444</height>
+    <width>574</width>
+    <height>652</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -23,43 +23,6 @@
    <property name="sizeConstraint">
     <enum>QLayout::SetMinAndMaxSize</enum>
    </property>
-   <item row="1" column="1">
-    <widget class="QLineEdit" name="leFilename">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="2">
-    <widget class="QPushButton" name="browseCRS">
-     <property name="text">
-      <string>Browse</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="label_4">
-     <property name="text">
-      <string>Encoding</string>
-     </property>
-     <property name="buddy">
-      <cstring>mEncodingComboBox</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0" rowspan="2">
-    <widget class="QLabel" name="label_3">
-     <property name="text">
-      <string>CRS</string>
-     </property>
-     <property name="buddy">
-      <cstring>leCRS</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="1" colspan="2">
-    <widget class="QComboBox" name="mEncodingComboBox"/>
-   </item>
    <item row="7" column="0">
     <widget class="QLabel" name="mSymbologyExportLabel">
      <property name="text">
@@ -67,41 +30,15 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Save as</string>
-     </property>
-     <property name="buddy">
-      <cstring>leFilename</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="7" column="1" colspan="2">
-    <widget class="QComboBox" name="mSymbologyExportComboBox"/>
-   </item>
-   <item row="1" column="2">
-    <widget class="QPushButton" name="browseFilename">
-     <property name="enabled">
-      <bool>false</bool>
+   <item row="12" column="0">
+    <widget class="QCheckBox" name="mSkipAttributeCreation">
+     <property name="toolTip">
+      <string>This allows one to surpress attribute creation as some OGR drivers (eg. DGN, DXF) don't support it.</string>
      </property>
      <property name="text">
-      <string>Browse</string>
+      <string>Skip attribute creation</string>
      </property>
     </widget>
-   </item>
-   <item row="6" column="1">
-    <widget class="QLineEdit" name="leCRS">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="readOnly">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="1" colspan="2">
-    <widget class="QComboBox" name="mCRSSelection"/>
    </item>
    <item row="0" column="0">
     <widget class="QLabel" name="label_2">
@@ -113,49 +50,32 @@
      </property>
     </widget>
    </item>
-   <item row="12" column="0" colspan="3">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+   <item row="1" column="2">
+    <widget class="QPushButton" name="browseFilename">
+     <property name="enabled">
+      <bool>false</bool>
      </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
+     <property name="text">
+      <string>Browse</string>
      </property>
     </widget>
    </item>
-   <item row="0" column="1" colspan="2">
-    <widget class="QComboBox" name="mFormatComboBox"/>
-   </item>
-   <item row="9" column="0" colspan="3">
-    <widget class="QgsCollapsibleGroupBox" name="mOgrOptionsGroupBox" native="true">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+   <item row="11" column="0" colspan="3">
+    <widget class="QgsCollapsibleGroupBox" name="mOgrOptionsGroupBox">
+     <property name="title">
+      <string>Custom Options</string>
      </property>
-     <property name="minimumSize">
-      <size>
-       <width>0</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="maximumSize">
-      <size>
-       <width>16777215</width>
-       <height>16777215</height>
-      </size>
-     </property>
-     <property name="baseSize">
-      <size>
-       <width>0</width>
-       <height>0</height>
-      </size>
-     </property>
-     <property name="title" stdset="0">
-      <string>OGR creation options</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_2">
+     <layout class="QGridLayout" name="gridLayout_3">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label_5">
+        <property name="text">
+         <string>Data source</string>
+        </property>
+        <property name="buddy">
+         <cstring>mOgrDatasourceOptions</cstring>
+        </property>
+       </widget>
+      </item>
       <item row="0" column="1">
        <widget class="QTextEdit" name="mOgrDatasourceOptions">
         <property name="sizePolicy">
@@ -181,6 +101,16 @@
           <width>0</width>
           <height>0</height>
          </size>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_6">
+        <property name="text">
+         <string>Layer</string>
+        </property>
+        <property name="buddy">
+         <cstring>mOgrLayerOptions</cstring>
         </property>
        </widget>
       </item>
@@ -212,27 +142,81 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_5">
-        <property name="text">
-         <string>Data source</string>
-        </property>
-        <property name="buddy">
-         <cstring>mOgrDatasourceOptions</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_6">
-        <property name="text">
-         <string>Layer</string>
-        </property>
-        <property name="buddy">
-         <cstring>mOgrLayerOptions</cstring>
-        </property>
-       </widget>
-      </item>
      </layout>
+     <zorder>label_6</zorder>
+     <zorder>label_5</zorder>
+     <zorder>mOgrDatasourceOptions</zorder>
+     <zorder>mOgrLayerOptions</zorder>
+    </widget>
+   </item>
+   <item row="13" column="0">
+    <widget class="QCheckBox" name="mAddToCanvas">
+     <property name="text">
+      <string>Add saved file to map</string>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="1">
+    <widget class="QLineEdit" name="leCRS">
+     <property name="enabled">
+      <bool>false</bool>
+     </property>
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="5" column="0" rowspan="2">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>CRS</string>
+     </property>
+     <property name="buddy">
+      <cstring>leCRS</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Save as</string>
+     </property>
+     <property name="buddy">
+      <cstring>leFilename</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="14" column="0" colspan="3">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Help|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="1" colspan="2">
+    <widget class="QComboBox" name="mEncodingComboBox"/>
+   </item>
+   <item row="8" column="0">
+    <widget class="QLabel" name="mScaleLabel">
+     <property name="text">
+      <string>Scale</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1" colspan="2">
+    <widget class="QComboBox" name="mFormatComboBox"/>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Encoding</string>
+     </property>
+     <property name="buddy">
+      <cstring>mEncodingComboBox</cstring>
+     </property>
     </widget>
    </item>
    <item row="8" column="1" colspan="2">
@@ -248,37 +232,79 @@
      </property>
     </widget>
    </item>
-   <item row="8" column="0">
-    <widget class="QLabel" name="mScaleLabel">
-     <property name="text">
-      <string>Scale</string>
+   <item row="1" column="1">
+    <widget class="QLineEdit" name="leFilename">
+     <property name="enabled">
+      <bool>false</bool>
      </property>
     </widget>
    </item>
-   <item row="11" column="0">
-    <widget class="QCheckBox" name="mAddToCanvas">
+   <item row="10" column="0" colspan="3">
+    <widget class="QgsCollapsibleGroupBox" name="mLayerOptionsGroupBox">
+     <property name="title">
+      <string>Layer Options</string>
+     </property>
+     <layout class="QFormLayout" name="formLayout_2">
+      <property name="fieldGrowthPolicy">
+       <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+      </property>
+     </layout>
+    </widget>
+   </item>
+   <item row="6" column="2">
+    <widget class="QPushButton" name="browseCRS">
      <property name="text">
-      <string>Add saved file to map</string>
+      <string>Browse</string>
      </property>
     </widget>
    </item>
-   <item row="10" column="0">
-    <widget class="QCheckBox" name="mSkipAttributeCreation">
-     <property name="toolTip">
-      <string>This allows one to surpress attribute creation as some OGR drivers (eg. DGN, DXF) don't support it.</string>
+   <item row="5" column="1" colspan="2">
+    <widget class="QComboBox" name="mCRSSelection"/>
+   </item>
+   <item row="7" column="1" colspan="2">
+    <widget class="QComboBox" name="mSymbologyExportComboBox"/>
+   </item>
+   <item row="9" column="0" colspan="3">
+    <widget class="QgsCollapsibleGroupBox" name="mDatasourceOptionsGroupBox">
+     <property name="title">
+      <string>Datasource Options</string>
      </property>
-     <property name="text">
-      <string>Skip attribute creation</string>
-     </property>
+     <layout class="QFormLayout" name="formLayout">
+      <property name="fieldGrowthPolicy">
+       <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+      </property>
+     </layout>
     </widget>
    </item>
   </layout>
+  <zorder>mDatasourceOptionsGroupBox</zorder>
+  <zorder>mLayerOptionsGroupBox</zorder>
+  <zorder>mFormatComboBox</zorder>
+  <zorder>mScaleSpinBox</zorder>
+  <zorder>mScaleLabel</zorder>
+  <zorder>mAddToCanvas</zorder>
+  <zorder>mSkipAttributeCreation</zorder>
+  <zorder>leFilename</zorder>
+  <zorder>browseCRS</zorder>
+  <zorder>label_4</zorder>
+  <zorder>label_3</zorder>
+  <zorder>mEncodingComboBox</zorder>
+  <zorder>mSymbologyExportLabel</zorder>
+  <zorder>label</zorder>
+  <zorder>mSymbologyExportComboBox</zorder>
+  <zorder>browseFilename</zorder>
+  <zorder>leCRS</zorder>
+  <zorder>mCRSSelection</zorder>
+  <zorder>label_2</zorder>
+  <zorder>buttonBox</zorder>
+  <zorder>mOgrOptionsGroupBox</zorder>
  </widget>
  <customwidgets>
   <customwidget>
    <class>QgsCollapsibleGroupBox</class>
-   <extends>QWidget</extends>
+   <extends>QGroupBox</extends>
    <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/qgsvectorlayersaveasdialogbase.ui
+++ b/src/ui/qgsvectorlayersaveasdialogbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>653</width>
-    <height>467</height>
+    <width>592</width>
+    <height>394</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -46,10 +46,93 @@
         </property>
         <widget class="QWidget" name="widget" native="true">
          <layout class="QGridLayout" name="gridLayout_4">
-          <item row="2" column="1" colspan="2">
+          <item row="1" column="0">
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>Save as</string>
+            </property>
+            <property name="buddy">
+             <cstring>leFilename</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QLabel" name="label_3">
+            <property name="text">
+             <string>CRS</string>
+            </property>
+            <property name="buddy">
+             <cstring>leCRS</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="2">
+           <widget class="QComboBox" name="mSymbologyExportComboBox"/>
+          </item>
+          <item row="5" column="0" colspan="2">
+           <widget class="QLineEdit" name="leCRS">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="readOnly">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1" colspan="2">
+           <widget class="QComboBox" name="mCRSSelection"/>
+          </item>
+          <item row="2" column="0" colspan="2">
+           <widget class="QLineEdit" name="leFilename">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1" colspan="2">
            <widget class="QComboBox" name="mEncodingComboBox"/>
           </item>
-          <item row="6" column="1" colspan="2">
+          <item row="7" column="0">
+           <widget class="QLabel" name="mScaleLabel">
+            <property name="text">
+             <string>Scale</string>
+            </property>
+           </widget>
+          </item>
+          <item row="10" column="0" colspan="2">
+           <widget class="QCheckBox" name="mAddToCanvas">
+            <property name="text">
+             <string>Add saved file to map</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1" colspan="2">
+           <widget class="QComboBox" name="mFormatComboBox"/>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_2">
+            <property name="text">
+             <string>Format</string>
+            </property>
+            <property name="buddy">
+             <cstring>mFormatComboBox</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="1">
+           <spacer name="verticalSpacer_3">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+          <item row="7" column="1" colspan="2">
            <widget class="QSpinBox" name="mScaleSpinBox">
             <property name="prefix">
              <string>1:</string>
@@ -63,96 +146,13 @@
            </widget>
           </item>
           <item row="6" column="0">
-           <widget class="QLabel" name="mScaleLabel">
+           <widget class="QLabel" name="mSymbologyExportLabel">
             <property name="text">
-             <string>Scale</string>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="label">
-            <property name="text">
-             <string>Save as</string>
-            </property>
-            <property name="buddy">
-             <cstring>leFilename</cstring>
-            </property>
-           </widget>
-          </item>
-          <item row="0" column="1" colspan="2">
-           <widget class="QComboBox" name="mFormatComboBox"/>
-          </item>
-          <item row="4" column="2">
-           <widget class="QPushButton" name="browseCRS">
-            <property name="text">
-             <string>Browse</string>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="1">
-           <widget class="QLineEdit" name="leCRS">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-            <property name="readOnly">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="3" column="1" colspan="2">
-           <widget class="QComboBox" name="mCRSSelection"/>
-          </item>
-          <item row="10" column="2">
-           <widget class="QToolButton" name="mOptionsButton">
-            <property name="text">
-             <string>Options &gt;&gt;</string>
-            </property>
-            <property name="checkable">
-             <bool>true</bool>
-            </property>
-            <property name="checked">
-             <bool>true</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QLineEdit" name="leFilename">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="2">
-           <widget class="QPushButton" name="browseFilename">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-            <property name="text">
-             <string>Browse</string>
+             <string>Symbology export</string>
             </property>
            </widget>
           </item>
           <item row="3" column="0">
-           <widget class="QLabel" name="label_3">
-            <property name="text">
-             <string>CRS</string>
-            </property>
-            <property name="buddy">
-             <cstring>leCRS</cstring>
-            </property>
-           </widget>
-          </item>
-          <item row="8" column="0" colspan="2">
-           <widget class="QCheckBox" name="mAddToCanvas">
-            <property name="text">
-             <string>Add saved file to map</string>
-            </property>
-           </widget>
-          </item>
-          <item row="5" column="1" colspan="2">
-           <widget class="QComboBox" name="mSymbologyExportComboBox"/>
-          </item>
-          <item row="2" column="0">
            <widget class="QLabel" name="label_4">
             <property name="text">
              <string>Encoding</string>
@@ -162,35 +162,54 @@
             </property>
            </widget>
           </item>
-          <item row="0" column="0">
-           <widget class="QLabel" name="label_2">
+          <item row="5" column="2">
+           <widget class="QPushButton" name="browseCRS">
             <property name="text">
-             <string>Format</string>
-            </property>
-            <property name="buddy">
-             <cstring>mFormatComboBox</cstring>
+             <string>Browse</string>
             </property>
            </widget>
           </item>
-          <item row="5" column="0">
-           <widget class="QLabel" name="mSymbologyExportLabel">
+          <item row="9" column="0" colspan="2">
+           <widget class="QCheckBox" name="mSkipAttributeCreation">
+            <property name="toolTip">
+             <string>This allows one to surpress attribute creation as some OGR drivers (eg. DGN, DXF) don't support it.</string>
+            </property>
             <property name="text">
-             <string>Symbology export</string>
+             <string>Skip attribute creation</string>
             </property>
            </widget>
           </item>
-          <item row="9" column="0" colspan="3">
-           <spacer name="verticalSpacer">
-            <property name="orientation">
-             <enum>Qt::Vertical</enum>
+          <item row="2" column="2">
+           <widget class="QPushButton" name="browseFilename">
+            <property name="enabled">
+             <bool>false</bool>
             </property>
-            <property name="sizeHint" stdset="0">
-             <size>
-              <width>20</width>
-              <height>40</height>
-             </size>
+            <property name="text">
+             <string>Browse</string>
             </property>
-           </spacer>
+           </widget>
+          </item>
+          <item row="11" column="0" colspan="3">
+           <widget class="QToolButton" name="mOptionsButton">
+            <property name="enabled">
+             <bool>true</bool>
+            </property>
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>More Options &gt;&gt;</string>
+            </property>
+            <property name="checkable">
+             <bool>true</bool>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
           </item>
          </layout>
         </widget>
@@ -313,16 +332,6 @@
             <zorder>label_5</zorder>
             <zorder>mOgrDatasourceOptions</zorder>
             <zorder>mOgrLayerOptions</zorder>
-           </widget>
-          </item>
-          <item row="4" column="0">
-           <widget class="QCheckBox" name="mSkipAttributeCreation">
-            <property name="toolTip">
-             <string>This allows one to surpress attribute creation as some OGR drivers (eg. DGN, DXF) don't support it.</string>
-            </property>
-            <property name="text">
-             <string>Skip attribute creation</string>
-            </property>
            </widget>
           </item>
           <item row="1" column="0">

--- a/src/ui/qgsvectorlayersaveasdialogbase.ui
+++ b/src/ui/qgsvectorlayersaveasdialogbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>366</width>
-    <height>589</height>
+    <width>653</width>
+    <height>467</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -23,170 +23,7 @@
    <property name="sizeConstraint">
     <enum>QLayout::SetMinAndMaxSize</enum>
    </property>
-   <item row="7" column="0">
-    <widget class="QLabel" name="mSymbologyExportLabel">
-     <property name="text">
-      <string>Symbology export</string>
-     </property>
-    </widget>
-   </item>
-   <item row="12" column="0">
-    <widget class="QCheckBox" name="mSkipAttributeCreation">
-     <property name="toolTip">
-      <string>This allows one to surpress attribute creation as some OGR drivers (eg. DGN, DXF) don't support it.</string>
-     </property>
-     <property name="text">
-      <string>Skip attribute creation</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>Format</string>
-     </property>
-     <property name="buddy">
-      <cstring>mFormatComboBox</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="2">
-    <widget class="QPushButton" name="browseFilename">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="text">
-      <string>Browse</string>
-     </property>
-    </widget>
-   </item>
-   <item row="11" column="0" colspan="3">
-    <widget class="QgsCollapsibleGroupBox" name="mOgrOptionsGroupBox">
-     <property name="title">
-      <string>Custom Options</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_3">
-      <item row="0" column="0">
-       <widget class="QLabel" name="label_5">
-        <property name="text">
-         <string>Data source</string>
-        </property>
-        <property name="buddy">
-         <cstring>mOgrDatasourceOptions</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QTextEdit" name="mOgrDatasourceOptions">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>16777215</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="baseSize">
-         <size>
-          <width>0</width>
-          <height>0</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QLabel" name="label_6">
-        <property name="text">
-         <string>Layer</string>
-        </property>
-        <property name="buddy">
-         <cstring>mOgrLayerOptions</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QTextEdit" name="mOgrLayerOptions">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="maximumSize">
-         <size>
-          <width>16777215</width>
-          <height>16777215</height>
-         </size>
-        </property>
-        <property name="baseSize">
-         <size>
-          <width>0</width>
-          <height>0</height>
-         </size>
-        </property>
-       </widget>
-      </item>
-     </layout>
-     <zorder>label_6</zorder>
-     <zorder>label_5</zorder>
-     <zorder>mOgrDatasourceOptions</zorder>
-     <zorder>mOgrLayerOptions</zorder>
-    </widget>
-   </item>
-   <item row="13" column="0">
-    <widget class="QCheckBox" name="mAddToCanvas">
-     <property name="text">
-      <string>Add saved file to map</string>
-     </property>
-    </widget>
-   </item>
-   <item row="6" column="1">
-    <widget class="QLineEdit" name="leCRS">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-     <property name="readOnly">
-      <bool>true</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0" rowspan="2">
-    <widget class="QLabel" name="label_3">
-     <property name="text">
-      <string>CRS</string>
-     </property>
-     <property name="buddy">
-      <cstring>leCRS</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Save as</string>
-     </property>
-     <property name="buddy">
-      <cstring>leFilename</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="14" column="0" colspan="3">
+   <item row="4" column="0" colspan="2">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -196,108 +33,331 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="1" colspan="2">
-    <widget class="QComboBox" name="mEncodingComboBox"/>
-   </item>
-   <item row="8" column="0">
-    <widget class="QLabel" name="mScaleLabel">
-     <property name="text">
-      <string>Scale</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1" colspan="2">
-    <widget class="QComboBox" name="mFormatComboBox"/>
-   </item>
-   <item row="4" column="0">
-    <widget class="QLabel" name="label_4">
-     <property name="text">
-      <string>Encoding</string>
-     </property>
-     <property name="buddy">
-      <cstring>mEncodingComboBox</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="8" column="1" colspan="2">
-    <widget class="QSpinBox" name="mScaleSpinBox">
-     <property name="prefix">
-      <string>1:</string>
-     </property>
-     <property name="maximum">
-      <number>999999999</number>
-     </property>
-     <property name="value">
-      <number>50000</number>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QLineEdit" name="leFilename">
-     <property name="enabled">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="10" column="0" colspan="3">
-    <widget class="QgsCollapsibleGroupBox" name="mLayerOptionsGroupBox">
-     <property name="title">
-      <string>Layer Options</string>
-     </property>
-     <layout class="QFormLayout" name="formLayout_2">
-      <property name="fieldGrowthPolicy">
-       <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+   <item row="0" column="0" colspan="2">
+    <widget class="QWidget" name="widget_3" native="true">
+     <layout class="QGridLayout" name="gridLayout_5">
+      <property name="margin">
+       <number>0</number>
       </property>
-     </layout>
-    </widget>
-   </item>
-   <item row="6" column="2">
-    <widget class="QPushButton" name="browseCRS">
-     <property name="text">
-      <string>Browse</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="1" colspan="2">
-    <widget class="QComboBox" name="mCRSSelection"/>
-   </item>
-   <item row="7" column="1" colspan="2">
-    <widget class="QComboBox" name="mSymbologyExportComboBox"/>
-   </item>
-   <item row="9" column="0" colspan="3">
-    <widget class="QgsCollapsibleGroupBox" name="mDatasourceOptionsGroupBox">
-     <property name="title">
-      <string>Datasource Options</string>
-     </property>
-     <layout class="QFormLayout" name="formLayout">
-      <property name="fieldGrowthPolicy">
-       <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-      </property>
+      <item row="0" column="0">
+       <widget class="QSplitter" name="splitter">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <widget class="QWidget" name="widget" native="true">
+         <layout class="QGridLayout" name="gridLayout_4">
+          <item row="2" column="1" colspan="2">
+           <widget class="QComboBox" name="mEncodingComboBox"/>
+          </item>
+          <item row="6" column="1" colspan="2">
+           <widget class="QSpinBox" name="mScaleSpinBox">
+            <property name="prefix">
+             <string>1:</string>
+            </property>
+            <property name="maximum">
+             <number>999999999</number>
+            </property>
+            <property name="value">
+             <number>50000</number>
+            </property>
+           </widget>
+          </item>
+          <item row="6" column="0">
+           <widget class="QLabel" name="mScaleLabel">
+            <property name="text">
+             <string>Scale</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label">
+            <property name="text">
+             <string>Save as</string>
+            </property>
+            <property name="buddy">
+             <cstring>leFilename</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1" colspan="2">
+           <widget class="QComboBox" name="mFormatComboBox"/>
+          </item>
+          <item row="4" column="2">
+           <widget class="QPushButton" name="browseCRS">
+            <property name="text">
+             <string>Browse</string>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="1">
+           <widget class="QLineEdit" name="leCRS">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="readOnly">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1" colspan="2">
+           <widget class="QComboBox" name="mCRSSelection"/>
+          </item>
+          <item row="10" column="2">
+           <widget class="QToolButton" name="mOptionsButton">
+            <property name="text">
+             <string>Options &gt;&gt;</string>
+            </property>
+            <property name="checkable">
+             <bool>true</bool>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLineEdit" name="leFilename">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="2">
+           <widget class="QPushButton" name="browseFilename">
+            <property name="enabled">
+             <bool>false</bool>
+            </property>
+            <property name="text">
+             <string>Browse</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_3">
+            <property name="text">
+             <string>CRS</string>
+            </property>
+            <property name="buddy">
+             <cstring>leCRS</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="8" column="0" colspan="2">
+           <widget class="QCheckBox" name="mAddToCanvas">
+            <property name="text">
+             <string>Add saved file to map</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="1" colspan="2">
+           <widget class="QComboBox" name="mSymbologyExportComboBox"/>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_4">
+            <property name="text">
+             <string>Encoding</string>
+            </property>
+            <property name="buddy">
+             <cstring>mEncodingComboBox</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="label_2">
+            <property name="text">
+             <string>Format</string>
+            </property>
+            <property name="buddy">
+             <cstring>mFormatComboBox</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0">
+           <widget class="QLabel" name="mSymbologyExportLabel">
+            <property name="text">
+             <string>Symbology export</string>
+            </property>
+           </widget>
+          </item>
+          <item row="9" column="0" colspan="3">
+           <spacer name="verticalSpacer">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+        <widget class="QWidget" name="mOptionsGroupBox" native="true">
+         <layout class="QGridLayout" name="gridLayout_2">
+          <property name="topMargin">
+           <number>0</number>
+          </property>
+          <property name="rightMargin">
+           <number>0</number>
+          </property>
+          <property name="bottomMargin">
+           <number>0</number>
+          </property>
+          <item row="0" column="0">
+           <widget class="QgsCollapsibleGroupBox" name="mDatasourceOptionsGroupBox">
+            <property name="title">
+             <string>Datasource Options</string>
+            </property>
+            <layout class="QFormLayout" name="formLayout">
+             <property name="fieldGrowthPolicy">
+              <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+             </property>
+            </layout>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QgsCollapsibleGroupBox" name="mOgrOptionsGroupBox">
+            <property name="title">
+             <string>Custom Options</string>
+            </property>
+            <property name="collapsed" stdset="0">
+             <bool>true</bool>
+            </property>
+            <layout class="QGridLayout" name="gridLayout_3">
+             <item row="0" column="0">
+              <widget class="QLabel" name="label_5">
+               <property name="text">
+                <string>Data source</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+               </property>
+               <property name="buddy">
+                <cstring>mOgrDatasourceOptions</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="1">
+              <widget class="QTextEdit" name="mOgrDatasourceOptions">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>0</width>
+                 <height>0</height>
+                </size>
+               </property>
+               <property name="maximumSize">
+                <size>
+                 <width>16777215</width>
+                 <height>16777215</height>
+                </size>
+               </property>
+               <property name="baseSize">
+                <size>
+                 <width>0</width>
+                 <height>0</height>
+                </size>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0">
+              <widget class="QLabel" name="label_6">
+               <property name="text">
+                <string>Layer</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignTop</set>
+               </property>
+               <property name="buddy">
+                <cstring>mOgrLayerOptions</cstring>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="1">
+              <widget class="QTextEdit" name="mOgrLayerOptions">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="minimumSize">
+                <size>
+                 <width>0</width>
+                 <height>0</height>
+                </size>
+               </property>
+               <property name="maximumSize">
+                <size>
+                 <width>16777215</width>
+                 <height>16777215</height>
+                </size>
+               </property>
+               <property name="baseSize">
+                <size>
+                 <width>0</width>
+                 <height>0</height>
+                </size>
+               </property>
+              </widget>
+             </item>
+            </layout>
+            <zorder>label_6</zorder>
+            <zorder>label_5</zorder>
+            <zorder>mOgrDatasourceOptions</zorder>
+            <zorder>mOgrLayerOptions</zorder>
+           </widget>
+          </item>
+          <item row="4" column="0">
+           <widget class="QCheckBox" name="mSkipAttributeCreation">
+            <property name="toolTip">
+             <string>This allows one to surpress attribute creation as some OGR drivers (eg. DGN, DXF) don't support it.</string>
+            </property>
+            <property name="text">
+             <string>Skip attribute creation</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QgsCollapsibleGroupBox" name="mLayerOptionsGroupBox">
+            <property name="title">
+             <string>Layer Options</string>
+            </property>
+            <layout class="QFormLayout" name="formLayout_2">
+             <property name="fieldGrowthPolicy">
+              <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+             </property>
+            </layout>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <spacer name="verticalSpacer_2">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>20</width>
+              <height>40</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>
   </layout>
-  <zorder>mDatasourceOptionsGroupBox</zorder>
-  <zorder>mLayerOptionsGroupBox</zorder>
-  <zorder>mFormatComboBox</zorder>
-  <zorder>mScaleSpinBox</zorder>
-  <zorder>mScaleLabel</zorder>
-  <zorder>mAddToCanvas</zorder>
-  <zorder>mSkipAttributeCreation</zorder>
-  <zorder>leFilename</zorder>
-  <zorder>browseCRS</zorder>
-  <zorder>label_4</zorder>
-  <zorder>label_3</zorder>
-  <zorder>mEncodingComboBox</zorder>
-  <zorder>mSymbologyExportLabel</zorder>
-  <zorder>label</zorder>
-  <zorder>mSymbologyExportComboBox</zorder>
-  <zorder>browseFilename</zorder>
-  <zorder>leCRS</zorder>
-  <zorder>mCRSSelection</zorder>
-  <zorder>label_2</zorder>
-  <zorder>buttonBox</zorder>
-  <zorder>mOgrOptionsGroupBox</zorder>
  </widget>
  <customwidgets>
   <customwidget>
@@ -307,15 +367,6 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
- <tabstops>
-  <tabstop>mFormatComboBox</tabstop>
-  <tabstop>leFilename</tabstop>
-  <tabstop>browseFilename</tabstop>
-  <tabstop>mEncodingComboBox</tabstop>
-  <tabstop>leCRS</tabstop>
-  <tabstop>browseCRS</tabstop>
-  <tabstop>buttonBox</tabstop>
- </tabstops>
  <resources/>
  <connections>
   <connection>

--- a/src/ui/qgsvectorlayersaveasdialogbase.ui
+++ b/src/ui/qgsvectorlayersaveasdialogbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>574</width>
-    <height>652</height>
+    <width>366</width>
+    <height>589</height>
    </rect>
   </property>
   <property name="sizePolicy">


### PR DESCRIPTION
Introduces various widgets for controlling the output file.

The options currently available are based on the documentation for GDAL 1.10 and will need to be adjusted if changes are made on GDAL side.
![screenshot from 2013-11-21 13 49 59](https://f.cloud.github.com/assets/588407/1591705/7afa426a-52ab-11e3-83a1-8319b5d75b98.png)
