### PR TITLE
[composer] Clean up item rotation api

### DIFF
--- a/python/core/composer/qgscomposeritem.sip
+++ b/python/core/composer/qgscomposeritem.sip
@@ -332,6 +332,14 @@ class QgsComposerItem: QObject, QGraphicsRectItem
     @note this method was added in version 1.2*/
     bool positionLock() const;
 
+    /**Returns the rotation for the composer item
+    @note this method was added in version 2.1*/
+    double itemRotation() const;
+
+    /**Returns the rotation for the composer item
+     * @deprecated Use itemRotation()
+     *             instead
+     */    
     double rotation() const;
 
     /**Updates item, with the possibility to do custom update for subclasses*/
@@ -351,7 +359,15 @@ class QgsComposerItem: QObject, QGraphicsRectItem
     QString uuid() const;
 
   public slots:
+    /**Sets the item rotation
+     * @deprecated Use setItemRotation( double rotation ) instead
+     */   
     virtual void setRotation( double r );
+
+    /**Sets the item rotation
+      @note this method was added in version 2.1
+    */
+    virtual void setItemRotation( double r );
     void repaint();
 
   protected:
@@ -394,11 +410,27 @@ class QgsComposerItem: QObject, QGraphicsRectItem
     //some utility functions
 
     /**Calculates width and hight of the picture (in mm) such that it fits into the item frame with the given rotation*/
+    bool imageSizeConsideringRotation( double& width, double& height, double rotation ) const;
+    /**Calculates width and hight of the picture (in mm) such that it fits into the item frame with the given rotation
+     * @deprecated Use bool imageSizeConsideringRotation( double& width, double& height, double rotation )
+     * instead
+     */
     bool imageSizeConsideringRotation( double& width, double& height ) const;
+    
     /**Calculates corner point after rotation and scaling*/
+    bool cornerPointOnRotatedAndScaledRect( double& x, double& y, double width, double height, double rotation ) const;
+    /**Calculates corner point after rotation and scaling
+     * @deprecated Use bool cornerPointOnRotatedAndScaledRect( double& x, double& y, double width, double height, double rotation )
+     * instead
+     */    
     bool cornerPointOnRotatedAndScaledRect( double& x, double& y, double width, double height ) const;
 
-    /**Calculates width / height of the bounding box of a rotated rectangle (mRotation)*/
+    /**Calculates width / height of the bounding box of a rotated rectangle*/
+    void sizeChangedByRotation( double& width, double& height, double rotation );
+     /**Calculates width / height of the bounding box of a rotated rectangle
+     * @deprecated Use void sizeChangedByRotation( double& width, double& height, double rotation )
+     * instead
+     */      
     void sizeChangedByRotation( double& width, double& height );
     /**Rotates a point / vector
         @param angle rotation angle in degrees, counterclockwise
@@ -416,7 +448,7 @@ class QgsComposerItem: QObject, QGraphicsRectItem
 
   signals:
     /**Is emitted on rotation change to notify north arrow pictures*/
-    void rotationChanged( double newRotation );
+    void itemRotationChanged( double newRotation );
     /**Used e.g. by the item widgets to update the gui elements*/
     void itemChanged();
     /**Emitted if the rectangle changes*/

--- a/python/core/composer/qgscomposeritemcommand.sip
+++ b/python/core/composer/qgscomposeritemcommand.sip
@@ -46,7 +46,6 @@ class QgsComposerMergeCommand : QgsComposerItemCommand
       //composer label
       ComposerLabelSetText,
       ComposerLabelSetId,
-      ComposerLabelRotation,
       //composer map
       ComposerMapRotation,
       ComposerMapAnnotationDistance,
@@ -57,6 +56,8 @@ class QgsComposerMergeCommand : QgsComposerItemCommand
       LegendEqualColumnWidth,
       LegendSymbolWidth,
       LegendSymbolHeight,
+      LegendWmsLegendWidth,
+      LegendWmsLegendHeight,
       LegendTitleSpaceBottom,
       LegendGroupSpace,
       LegendLayerSpace,
@@ -81,14 +82,15 @@ class QgsComposerMergeCommand : QgsComposerItemCommand
       TableMargin,
       TableGridStrokeWidth,
       //composer shape
-      ShapeRotation,
+      ShapeCornerRadius,
       ShapeOutlineWidth,
       //composer arrow
       ArrowOutlineWidth,
       ArrowHeadWidth,
       //item
       ItemOutlineWidth,
-      ItemMove
+      ItemMove,
+      ItemRotation
     };
 
     QgsComposerMergeCommand( Context c, QgsComposerItem* item, const QString& text );

--- a/python/core/composer/qgscomposerlabel.sip
+++ b/python/core/composer/qgscomposerlabel.sip
@@ -79,5 +79,11 @@ class QgsComposerLabel : QgsComposerItem
     bool readXML( const QDomElement& itemElem, const QDomDocument& doc );
 
   public slots:
+    /* Sets rotation for the label
+     * @deprecated Use setItemRotation( double rotation ) instead
+     */
     virtual void setRotation( double r );
+  
+    /* Sets rotation for the label */
+    virtual void setItemRotation( double r );
 };

--- a/python/core/composer/qgscomposermap.sip
+++ b/python/core/composer/qgscomposermap.sip
@@ -267,7 +267,22 @@ class QgsComposerMap : QgsComposerItem
     void setCrossLength( double l );
     double crossLength();
 
+    /**Sets rotation for the map - this does not affect the composer item shape, only the
+      way the map is drawn within the item
+     * @deprecated Use setMapRotation( double rotation ) instead
+     */
+    void setRotation( double r );
+    /**Returns the rotation used for drawing the map within the composer item    
+     * @deprecated Use mapRotation() instead
+     */
+    double rotation() const;
+
+    /**Sets rotation for the map - this does not affect the composer item shape, only the
+      way the map is drawn within the item
+      @note this function was added in version 2.1*/
     void setMapRotation( double r );
+    /**Returns the rotation used for drawing the map within the composer item*/
+    double mapRotation() const;
 
     void updateItem();
 
@@ -310,9 +325,28 @@ class QgsComposerMap : QgsComposerItem
     /**Sets mId to a number not yet used in the composition. mId is kept if it is not in use.
         Usually, this function is called before adding the composer map to the composition*/
     void assignFreeId();
+    
+    /**Calculates width and hight of the picture (in mm) such that it fits into the item frame with the given rotation
+     * @deprecated Use bool QgsComposerItem::imageSizeConsideringRotation( double& width, double& height, double rotation )
+     * instead
+     */
+    bool imageSizeConsideringRotation( double& width, double& height ) const;
+    /**Calculates corner point after rotation and scaling
+     * @deprecated Use QgsComposerItem::cornerPointOnRotatedAndScaledRect( double& x, double& y, double width, double height, double rotation )
+     * instead
+     */
+    bool cornerPointOnRotatedAndScaledRect( double& x, double& y, double width, double height ) const;
+    /**Calculates width / height of the bounding box of a rotated rectangle
+    * @deprecated Use QgsComposerItem::sizeChangedByRotation( double& width, double& height, double rotation )
+    * instead
+    */
+    void sizeChangedByRotation( double& width, double& height );    
 
   signals:
     void extentChanged();
+    
+    /**Is emitted on rotation change to notify north arrow pictures*/
+    void mapRotationChanged( double newRotation );    
 
   public slots:
 

--- a/python/core/composer/qgscomposerpicture.sip
+++ b/python/core/composer/qgscomposerpicture.sip
@@ -38,6 +38,15 @@ class QgsComposerPicture: QgsComposerItem
       */
     bool readXML( const QDomElement& itemElem, const QDomDocument& doc );
 
+    /**Returns the rotation used for drawing the picture within the composer item    
+     * @deprecated Use pictureRotation() instead
+     */
+    double rotation() const;
+
+    /**Returns the rotation used for drawing the picture within the item
+      @note this function was added in version 2.1*/
+    double pictureRotation() const;
+
     /**Sets the map object for rotation (by id). A value of -1 disables the map rotation*/
     void setRotationMap( int composerMapId );
     /**Returns the id of the rotation map*/
@@ -45,7 +54,35 @@ class QgsComposerPicture: QgsComposerItem
     /**True if the rotation is taken from a map item*/
     bool useRotationMap() const;
 
+    /**Calculates width and hight of the picture (in mm) such that it fits into the item frame with the given rotation
+     * @deprecated Use bool QgsComposerItem::imageSizeConsideringRotation( double& width, double& height, double rotation )
+     * instead
+     */
+    bool imageSizeConsideringRotation( double& width, double& height ) const;
+    /**Calculates corner point after rotation and scaling
+     * @deprecated Use QgsComposerItem::cornerPointOnRotatedAndScaledRect( double& x, double& y, double width, double height, double rotation )
+     * instead
+     */
+    bool cornerPointOnRotatedAndScaledRect( double& x, double& y, double width, double height ) const;
+    /**Calculates width / height of the bounding box of a rotated rectangle
+    * @deprecated Use QgsComposerItem::sizeChangedByRotation( double& width, double& height, double rotation )
+    * instead
+    */
+    void sizeChangedByRotation( double& width, double& height );
+    
   public slots:
-    /**Sets the rotation and adapts the item rect*/
+    /**Sets the picture rotation within the item bounds. This does not affect the item rectangle,
+      only the way the picture is drawn within the item.
+     * @deprecated Use setPictureRotation( double rotation ) instead
+     */
     virtual void setRotation( double r );
+
+    /**Sets the picture rotation within the item bounds. This does not affect the item rectangle,
+      only the way the picture is drawn within the item.
+      @note this function was added in version 2.1*/
+    virtual void setPictureRotation( double r );
+    
+  signals:
+    /**Is emitted on picture rotation change*/
+    void pictureRotationChanged( double newRotation );    
 };

--- a/python/core/composer/qgscomposershape.sip
+++ b/python/core/composer/qgscomposershape.sip
@@ -50,7 +50,7 @@ class QgsComposerShape: QgsComposerItem
 
   public slots:
     /**Sets item rotation and resizes item bounds such that the shape always has the same size*/
-    virtual void setRotation( double r );
+    virtual void setItemRotation( double r );
 
   protected:
     /* reimplement drawFrame, since it's not a rect, but a custom shape */

--- a/src/app/composer/qgscomposerlabelwidget.cpp
+++ b/src/app/composer/qgscomposerlabelwidget.cpp
@@ -232,8 +232,8 @@ void QgsComposerLabelWidget::on_mRotationSpinBox_valueChanged( double v )
 {
   if ( mComposerLabel )
   {
-    mComposerLabel->beginCommand( tr( "Label rotation changed" ), QgsComposerMergeCommand::ComposerLabelRotation );
-    mComposerLabel->setRotation( v );
+    mComposerLabel->beginCommand( tr( "Label rotation changed" ), QgsComposerMergeCommand::ItemRotation );
+    mComposerLabel->setItemRotation( v );
     mComposerLabel->update();
     mComposerLabel->endCommand();
   }
@@ -252,7 +252,7 @@ void QgsComposerLabelWidget::setGuiElementValues()
   mLeftRadioButton->setChecked( mComposerLabel->hAlign() == Qt::AlignLeft );
   mCenterRadioButton->setChecked( mComposerLabel->hAlign() == Qt::AlignHCenter );
   mRightRadioButton->setChecked( mComposerLabel->hAlign() == Qt::AlignRight );
-  mRotationSpinBox->setValue( mComposerLabel->rotation() );
+  mRotationSpinBox->setValue( mComposerLabel->itemRotation() );
   blockAllSignals( false );
 }
 

--- a/src/app/composer/qgscomposermapwidget.cpp
+++ b/src/app/composer/qgscomposermapwidget.cpp
@@ -148,7 +148,7 @@ void QgsComposerMapWidget::on_mScaleLineEdit_editingFinished()
   mComposerMap->endCommand();
 }
 
-void QgsComposerMapWidget::on_mRotationSpinBox_valueChanged( double value )
+void QgsComposerMapWidget::on_mMapRotationSpinBox_valueChanged( double value )
 {
   if ( !mComposerMap )
   {
@@ -278,7 +278,7 @@ void QgsComposerMapWidget::updateGuiElements()
     mYMinLineEdit->setText( QString::number( composerMapExtent.yMinimum(), 'f', 3 ) );
     mYMaxLineEdit->setText( QString::number( composerMapExtent.yMaximum(), 'f', 3 ) );
 
-    mRotationSpinBox->setValue( mComposerMap->rotation() );
+    mMapRotationSpinBox->setValue( mComposerMap->mapRotation() );
 
     //keep layer list check box
     if ( mComposerMap->keepLayerSet() )

--- a/src/app/composer/qgscomposermapwidget.h
+++ b/src/app/composer/qgscomposermapwidget.h
@@ -37,7 +37,7 @@ class QgsComposerMapWidget: public QWidget, private Ui::QgsComposerMapWidgetBase
   public slots:
     void on_mPreviewModeComboBox_activated( int i );
     void on_mScaleLineEdit_editingFinished();
-    void on_mRotationSpinBox_valueChanged( double value );
+    void on_mMapRotationSpinBox_valueChanged( double value );
     void on_mSetToMapCanvasExtentButton_clicked();
     void on_mUpdatePreviewButton_clicked();
     void on_mKeepLayerListCheckBox_stateChanged( int state );

--- a/src/app/composer/qgscomposerpicturewidget.cpp
+++ b/src/app/composer/qgscomposerpicturewidget.cpp
@@ -50,7 +50,7 @@ QgsComposerPictureWidget::QgsComposerPictureWidget( QgsComposerPicture* picture 
   connect( mSearchDirectoriesGroupBox, SIGNAL( collapsedStateChanged( bool ) ), this, SLOT( loadPicturePreviews( bool ) ) );
 
   connect( mPicture, SIGNAL( itemChanged() ), this, SLOT( setGuiElementValues() ) );
-  connect( mPicture, SIGNAL( rotationChanged( double ) ), this, SLOT( setGuiElementValues() ) );
+  connect( mPicture, SIGNAL( pictureRotationChanged( double ) ), this, SLOT( setPicRotationSpinValue( double ) ) );
 }
 
 QgsComposerPictureWidget::~QgsComposerPictureWidget()
@@ -121,13 +121,12 @@ void QgsComposerPictureWidget::on_mPictureLineEdit_editingFinished()
 }
 
 
-void QgsComposerPictureWidget::on_mRotationSpinBox_valueChanged( double d )
+void QgsComposerPictureWidget::on_mPictureRotationSpinBox_valueChanged( double d )
 {
   if ( mPicture )
   {
     mPicture->beginCommand( tr( "Picture rotation changed" ), QgsComposerMergeCommand::ComposerPictureRotation );
-    mPicture->setRotation( d );
-    mPicture->update();
+    mPicture->setPictureRotation( d );
     mPicture->endCommand();
   }
 }
@@ -210,8 +209,9 @@ void QgsComposerPictureWidget::on_mRotationFromComposerMapCheckBox_stateChanged(
   if ( state == Qt::Unchecked )
   {
     mPicture->setRotationMap( -1 );
-    mRotationSpinBox->setEnabled( true );
+    mPictureRotationSpinBox->setEnabled( true );
     mComposerMapComboBox->setEnabled( false );
+    mPicture->setPictureRotation( mPictureRotationSpinBox->value() );
   }
   else
   {
@@ -223,7 +223,7 @@ void QgsComposerPictureWidget::on_mRotationFromComposerMapCheckBox_stateChanged(
     int composerId = mComposerMapComboBox->itemData( currentItemIndex, Qt::UserRole ).toInt();
 
     mPicture->setRotationMap( composerId );
-    mRotationSpinBox->setEnabled( false );
+    mPictureRotationSpinBox->setEnabled( false );
     mComposerMapComboBox->setEnabled( true );
   }
   mPicture->endCommand();
@@ -310,26 +310,33 @@ void QgsComposerPictureWidget::refreshMapComboBox()
   mComposerMapComboBox->blockSignals( false );
 }
 
+void QgsComposerPictureWidget::setPicRotationSpinValue( double r )
+{
+  mPictureRotationSpinBox->blockSignals( true );
+  mPictureRotationSpinBox->setValue( r );
+  mPictureRotationSpinBox->blockSignals( false );
+}
+
 void QgsComposerPictureWidget::setGuiElementValues()
 {
   //set initial gui values
   if ( mPicture )
   {
-    mRotationSpinBox->blockSignals( true );
+    mPictureRotationSpinBox->blockSignals( true );
     mPictureLineEdit->blockSignals( true );
     mComposerMapComboBox->blockSignals( true );
     mRotationFromComposerMapCheckBox->blockSignals( true );
 
     mPictureLineEdit->setText( mPicture->pictureFile() );
 //    QRectF pictureRect = mPicture->rect();
-    mRotationSpinBox->setValue( mPicture->rotation() );
+    mPictureRotationSpinBox->setValue( mPicture->pictureRotation() );
 
     refreshMapComboBox();
 
     if ( mPicture->useRotationMap() )
     {
       mRotationFromComposerMapCheckBox->setCheckState( Qt::Checked );
-      mRotationSpinBox->setEnabled( false );
+      mPictureRotationSpinBox->setEnabled( false );
       mComposerMapComboBox->setEnabled( true );
       QString mapText = tr( "Map %1" ).arg( mPicture->rotationMap() );
       int itemId = mComposerMapComboBox->findText( mapText );
@@ -341,13 +348,13 @@ void QgsComposerPictureWidget::setGuiElementValues()
     else
     {
       mRotationFromComposerMapCheckBox->setCheckState( Qt::Unchecked );
-      mRotationSpinBox->setEnabled( true );
+      mPictureRotationSpinBox->setEnabled( true );
       mComposerMapComboBox->setEnabled( false );
     }
 
 
     mRotationFromComposerMapCheckBox->blockSignals( false );
-    mRotationSpinBox->blockSignals( false );
+    mPictureRotationSpinBox->blockSignals( false );
     mPictureLineEdit->blockSignals( false );
     mComposerMapComboBox->blockSignals( false );
   }

--- a/src/app/composer/qgscomposerpicturewidget.h
+++ b/src/app/composer/qgscomposerpicturewidget.h
@@ -39,7 +39,7 @@ class QgsComposerPictureWidget: public QWidget, private Ui::QgsComposerPictureWi
   public slots:
     void on_mPictureBrowseButton_clicked();
     void on_mPictureLineEdit_editingFinished();
-    void on_mRotationSpinBox_valueChanged( double d );
+    void on_mPictureRotationSpinBox_valueChanged( double d );
     void on_mPreviewListWidget_currentItemChanged( QListWidgetItem* current, QListWidgetItem* previous );
     void on_mAddDirectoryButton_clicked();
     void on_mRemoveDirectoryButton_clicked();
@@ -53,6 +53,10 @@ class QgsComposerPictureWidget: public QWidget, private Ui::QgsComposerPictureWi
   private slots:
     /**Sets the GUI elements to the values of mPicture*/
     void setGuiElementValues();
+
+    /**Sets the picture rotation GUI control value*/
+    void setPicRotationSpinValue( double r );
+
     /** Load SVG and pixel-based image previews
      * @param collapsed Whether the parent group box is collapsed
      * @note added in 1.9

--- a/src/app/composer/qgscomposershapewidget.cpp
+++ b/src/app/composer/qgscomposershapewidget.cpp
@@ -66,7 +66,7 @@ void QgsComposerShapeWidget::setGuiElementValues()
 
   blockAllSignals( true );
 
-  mRotationSpinBox->setValue( mComposerShape->rotation() );
+  mRotationSpinBox->setValue( mComposerShape->itemRotation() );
   mCornerRadiusSpinBox->setValue( mComposerShape->cornerRadius() );
   if ( mComposerShape->shapeType() == QgsComposerShape::Ellipse )
   {
@@ -91,8 +91,8 @@ void QgsComposerShapeWidget::on_mRotationSpinBox_valueChanged( int val )
 {
   if ( mComposerShape )
   {
-    mComposerShape->beginCommand( tr( "Shape rotation changed" ), QgsComposerMergeCommand::ShapeRotation );
-    mComposerShape->setRotation( val );
+    mComposerShape->beginCommand( tr( "Shape rotation changed" ), QgsComposerMergeCommand::ItemRotation );
+    mComposerShape->setItemRotation( val );
     mComposerShape->update();
     mComposerShape->endCommand();
   }
@@ -102,7 +102,7 @@ void QgsComposerShapeWidget::on_mCornerRadiusSpinBox_valueChanged( double val )
 {
   if ( mComposerShape )
   {
-    mComposerShape->beginCommand( tr( "Shape radius changed" ), QgsComposerMergeCommand::ShapeRotation );
+    mComposerShape->beginCommand( tr( "Shape radius changed" ), QgsComposerMergeCommand::ShapeCornerRadius );
     mComposerShape->setCornerRadius( val );
     mComposerShape->update();
     mComposerShape->endCommand();

--- a/src/core/composer/qgscomposeritem.h
+++ b/src/core/composer/qgscomposeritem.h
@@ -287,7 +287,15 @@ class CORE_EXPORT QgsComposerItem: public QObject, public QGraphicsRectItem
     @note this method was added in version 1.2*/
     bool positionLock() const {return mItemPositionLocked;}
 
-    double rotation() const {return mRotation;}
+    /**Returns the rotation for the composer item
+    @note this method was added in version 2.1*/
+    double itemRotation() const {return mItemRotation;}
+
+    /**Returns the rotation for the composer item
+     * @deprecated Use itemRotation()
+     *             instead
+     */
+    double rotation() const {return mItemRotation;}
 
     /**Updates item, with the possibility to do custom update for subclasses*/
     virtual void updateItem() { QGraphicsRectItem::update(); }
@@ -306,7 +314,16 @@ class CORE_EXPORT QgsComposerItem: public QObject, public QGraphicsRectItem
     QString uuid() const { return mUuid; }
 
   public slots:
+    /**Sets the item rotation
+     * @deprecated Use setItemRotation( double rotation ) instead
+     */
     virtual void setRotation( double r );
+
+    /**Sets the item rotation
+      @note this method was added in version 2.1
+    */
+    virtual void setItemRotation( double r );
+
     void repaint();
 
   protected:
@@ -339,7 +356,7 @@ class CORE_EXPORT QgsComposerItem: public QObject, public QGraphicsRectItem
     mutable double mLastValidViewScaleFactor;
 
     /**Item rotation in degrees, clockwise*/
-    double mRotation;
+    double mItemRotation;
 
     /**Composition blend mode for item*/
     QPainter::CompositionMode mBlendMode;
@@ -384,12 +401,29 @@ class CORE_EXPORT QgsComposerItem: public QObject, public QGraphicsRectItem
     //some utility functions
 
     /**Calculates width and hight of the picture (in mm) such that it fits into the item frame with the given rotation*/
+    bool imageSizeConsideringRotation( double& width, double& height, double rotation ) const;
+    /**Calculates width and hight of the picture (in mm) such that it fits into the item frame with the given rotation
+     * @deprecated Use bool imageSizeConsideringRotation( double& width, double& height, double rotation )
+     * instead
+     */
     bool imageSizeConsideringRotation( double& width, double& height ) const;
+
     /**Calculates corner point after rotation and scaling*/
+    bool cornerPointOnRotatedAndScaledRect( double& x, double& y, double width, double height, double rotation ) const;
+    /**Calculates corner point after rotation and scaling
+     * @deprecated Use bool cornerPointOnRotatedAndScaledRect( double& x, double& y, double width, double height, double rotation )
+     * instead
+     */
     bool cornerPointOnRotatedAndScaledRect( double& x, double& y, double width, double height ) const;
 
-    /**Calculates width / height of the bounding box of a rotated rectangle (mRotation)*/
+    /**Calculates width / height of the bounding box of a rotated rectangle*/
+    void sizeChangedByRotation( double& width, double& height, double rotation );
+    /**Calculates width / height of the bounding box of a rotated rectangle
+    * @deprecated Use void sizeChangedByRotation( double& width, double& height, double rotation )
+    * instead
+    */
     void sizeChangedByRotation( double& width, double& height );
+
     /**Rotates a point / vector
         @param angle rotation angle in degrees, counterclockwise
         @param x in/out: x coordinate before / after the rotation
@@ -405,8 +439,8 @@ class CORE_EXPORT QgsComposerItem: public QObject, public QGraphicsRectItem
     void deleteAlignItems();
 
   signals:
-    /**Is emitted on rotation change to notify north arrow pictures*/
-    void rotationChanged( double newRotation );
+    /**Is emitted on item rotation change*/
+    void itemRotationChanged( double newRotation );
     /**Used e.g. by the item widgets to update the gui elements*/
     void itemChanged();
     /**Emitted if the rectangle changes*/

--- a/src/core/composer/qgscomposeritemcommand.h
+++ b/src/core/composer/qgscomposeritemcommand.h
@@ -74,7 +74,6 @@ class CORE_EXPORT QgsComposerMergeCommand: public QgsComposerItemCommand
       //composer label
       ComposerLabelSetText,
       ComposerLabelSetId,
-      ComposerLabelRotation,
       //composer map
       ComposerMapRotation,
       ComposerMapAnnotationDistance,
@@ -111,14 +110,15 @@ class CORE_EXPORT QgsComposerMergeCommand: public QgsComposerItemCommand
       TableMargin,
       TableGridStrokeWidth,
       //composer shape
-      ShapeRotation,
+      ShapeCornerRadius,
       ShapeOutlineWidth,
       //composer arrow
       ArrowOutlineWidth,
       ArrowHeadWidth,
       //item
       ItemOutlineWidth,
-      ItemMove
+      ItemMove,
+      ItemRotation
     };
 
     QgsComposerMergeCommand( Context c, QgsComposerItem* item, const QString& text );

--- a/src/core/composer/qgscomposerlabel.cpp
+++ b/src/core/composer/qgscomposerlabel.cpp
@@ -66,7 +66,7 @@ void QgsComposerLabel::paint( QPainter* painter, const QStyleOptionGraphicsItem*
   double penWidth = pen().widthF();
   QRectF painterRect( penWidth + mMargin, penWidth + mMargin, mTextBoxWidth - 2 * penWidth - 2 * mMargin, mTextBoxHeight - 2 * penWidth - 2 * mMargin );
   painter->translate( rect().width() / 2.0, rect().height() / 2.0 );
-  painter->rotate( mRotation );
+  painter->rotate( mItemRotation );
   painter->translate( -mTextBoxWidth / 2.0, -mTextBoxHeight / 2.0 );
 
   if ( mHtmlState )
@@ -247,9 +247,15 @@ QFont QgsComposerLabel::font() const
 
 void QgsComposerLabel::setRotation( double r )
 {
+  //kept for api compatibility with QGIS 2.0
+  setItemRotation( r );
+}
+
+void QgsComposerLabel::setItemRotation( double r )
+{
   double width = mTextBoxWidth;
   double height = mTextBoxHeight;
-  QgsComposerItem::setRotation( r );
+  QgsComposerItem::setItemRotation( r );
   sizeChangedByRotation( width, height );
 
   double x = pos().x() + rect().width() / 2.0 - width / 2.0;
@@ -359,6 +365,14 @@ bool QgsComposerLabel::readXML( const QDomElement& itemElem, const QDomDocument&
   if ( composerItemList.size() > 0 )
   {
     QDomElement composerItemElem = composerItemList.at( 0 ).toElement();
+
+    //rotation
+    if ( composerItemElem.attribute( "rotation", "0" ).toDouble() != 0 )
+    {
+      //check for old (pre 2.1) rotation attribute
+      mItemRotation = composerItemElem.attribute( "rotation", "0" ).toDouble();
+    }
+
     _readXML( composerItemElem, doc );
   }
   emit itemChanged();
@@ -373,7 +387,7 @@ void QgsComposerLabel::itemShiftAdjustSize( double newWidth, double newHeight, d
   xShift = 0;
   yShift = 0;
 
-  if ( mRotation >= 0 && mRotation < 90 )
+  if ( mItemRotation >= 0 && mItemRotation < 90 )
   {
     if ( mHAlignment == Qt::AlignHCenter )
     {
@@ -392,7 +406,7 @@ void QgsComposerLabel::itemShiftAdjustSize( double newWidth, double newHeight, d
       yShift = - ( newHeight - currentHeight );
     }
   }
-  if ( mRotation >= 90 && mRotation < 180 )
+  if ( mItemRotation >= 90 && mItemRotation < 180 )
   {
     if ( mHAlignment == Qt::AlignHCenter )
     {
@@ -411,7 +425,7 @@ void QgsComposerLabel::itemShiftAdjustSize( double newWidth, double newHeight, d
       xShift = -( newWidth - currentWidth / 2.0 );
     }
   }
-  else if ( mRotation >= 180 && mRotation < 270 )
+  else if ( mItemRotation >= 180 && mItemRotation < 270 )
   {
     if ( mHAlignment == Qt::AlignHCenter )
     {
@@ -430,7 +444,7 @@ void QgsComposerLabel::itemShiftAdjustSize( double newWidth, double newHeight, d
       yShift = ( newHeight - currentHeight );
     }
   }
-  else if ( mRotation >= 270 && mRotation < 360 )
+  else if ( mItemRotation >= 270 && mItemRotation < 360 )
   {
     if ( mHAlignment == Qt::AlignHCenter )
     {

--- a/src/core/composer/qgscomposerlabel.h
+++ b/src/core/composer/qgscomposerlabel.h
@@ -102,7 +102,13 @@ class CORE_EXPORT QgsComposerLabel: public QgsComposerItem
     bool readXML( const QDomElement& itemElem, const QDomDocument& doc );
 
   public slots:
+    /* Sets rotation for the label
+     * @deprecated Use setItemRotation( double rotation ) instead
+     */
     virtual void setRotation( double r );
+
+    /* Sets rotation for the label */
+    virtual void setItemRotation( double r );
 
   private slots:
     void loadingHtmlFinished( bool );

--- a/src/core/composer/qgscomposermap.cpp
+++ b/src/core/composer/qgscomposermap.cpp
@@ -40,7 +40,7 @@
 #include <cmath>
 
 QgsComposerMap::QgsComposerMap( QgsComposition *composition, int x, int y, int width, int height )
-    : QgsComposerItem( x, y, width, height, composition ), mKeepLayerSet( false ),
+    : QgsComposerItem( x, y, width, height, composition ), mMapRotation( 0 ), mKeepLayerSet( false ),
     mOverviewFrameMapId( -1 ), mOverviewBlendMode( QPainter::CompositionMode_SourceOver ), mOverviewInverted( false ), mOverviewCentered( false ),
     mGridEnabled( false ), mGridStyle( Solid ),
     mGridIntervalX( 0.0 ), mGridIntervalY( 0.0 ), mGridOffsetX( 0.0 ), mGridOffsetY( 0.0 ), mGridAnnotationFontColor( QColor( 0, 0, 0 ) ),
@@ -94,7 +94,7 @@ QgsComposerMap::QgsComposerMap( QgsComposition *composition, int x, int y, int w
 }
 
 QgsComposerMap::QgsComposerMap( QgsComposition *composition )
-    : QgsComposerItem( 0, 0, 10, 10, composition ), mKeepLayerSet( false ), mOverviewFrameMapId( -1 ),
+    : QgsComposerItem( 0, 0, 10, 10, composition ), mMapRotation( 0 ), mKeepLayerSet( false ), mOverviewFrameMapId( -1 ),
     mOverviewBlendMode( QPainter::CompositionMode_SourceOver ), mOverviewInverted( false ), mOverviewCentered( false ),
     mGridEnabled( false ), mGridStyle( Solid ),
     mGridIntervalX( 0.0 ), mGridIntervalY( 0.0 ), mGridOffsetX( 0.0 ), mGridOffsetY( 0.0 ), mGridAnnotationFontColor( QColor( 0, 0, 0 ) ),
@@ -355,7 +355,7 @@ void QgsComposerMap::paint( QPainter* painter, const QStyleOptionGraphicsItem* i
 
     painter->translate( mXOffset, mYOffset );
     painter->translate( xTopLeftShift, yTopLeftShift );
-    painter->rotate( mRotation );
+    painter->rotate( mMapRotation );
     painter->translate( xShiftMM, -yShiftMM );
     painter->scale( scale, scale );
     painter->drawImage( 0, 0, mCacheImage );
@@ -404,7 +404,7 @@ void QgsComposerMap::paint( QPainter* painter, const QStyleOptionGraphicsItem* i
     painter->save();
     painter->translate( mXOffset, mYOffset );
     painter->translate( xTopLeftShift, yTopLeftShift );
-    painter->rotate( mRotation );
+    painter->rotate( mMapRotation );
     painter->translate( xShiftMM, -yShiftMM );
     draw( painter, requestRectangle, theSize, 25.4 ); //scene coordinates seem to be in mm
 
@@ -625,11 +625,18 @@ void QgsComposerMap::setOffset( double xOffset, double yOffset )
   mYOffset = yOffset;
 }
 
+void QgsComposerMap::setRotation( double r )
+{
+  //kept for api compatibility with QGIS 2.0
+  setMapRotation( r );
+}
+
 void QgsComposerMap::setMapRotation( double r )
 {
-  setRotation( r );
-  emit rotationChanged( r );
+  mMapRotation = r;
+  emit mapRotationChanged( r );
   emit itemChanged();
+  update();
 }
 
 void QgsComposerMap::updateItem()
@@ -813,6 +820,9 @@ bool QgsComposerMap::writeXML( QDomElement& elem, QDomDocument & doc ) const
   extentElem.setAttribute( "ymax", qgsDoubleToString( mExtent.yMaximum() ) );
   composerMapElem.appendChild( extentElem );
 
+  //map rotation
+  composerMapElem.setAttribute( "mapRotation",  QString::number( mMapRotation ) );
+
   //layer set
   QDomElement layerSetElem = doc.createElement( "LayerSet" );
   QStringList::const_iterator layerIt = mLayerSet.constBegin();
@@ -948,6 +958,12 @@ bool QgsComposerMap::readXML( const QDomElement& itemElem, const QDomDocument& d
     mExtent = QgsRectangle( xmin, ymin, xmax, ymax );
   }
 
+  //map rotation
+  if ( itemElem.attribute( "mapRotation", "0" ).toDouble() != 0 )
+  {
+    mMapRotation = itemElem.attribute( "mapRotation", "0" ).toDouble();
+  }
+
   //mKeepLayerSet flag
   QString keepLayerSetFlag = itemElem.attribute( "keepLayerSet" );
   if ( keepLayerSetFlag.compare( "true", Qt::CaseInsensitive ) == 0 )
@@ -1060,6 +1076,13 @@ bool QgsComposerMap::readXML( const QDomElement& itemElem, const QDomDocument& d
   if ( composerItemList.size() > 0 )
   {
     QDomElement composerItemElem = composerItemList.at( 0 ).toElement();
+
+    if ( composerItemElem.attribute( "rotation", "0" ).toDouble() != 0 )
+    {
+      //in versions prior to 2.1 map rotation was stored in the rotation attribute
+      mMapRotation = composerItemElem.attribute( "rotation", "0" ).toDouble();
+    }
+
     _readXML( composerItemElem, doc );
   }
 
@@ -1531,7 +1554,7 @@ int QgsComposerMap::xGridLines( QList< QPair< double, QLineF > >& lines ) const
   double roundCorrection = mapBoundingRect.top() > 0 ? 1.0 : 0.0;
   double currentLevel = ( int )(( mapBoundingRect.top() - mGridOffsetY ) / mGridIntervalY + roundCorrection ) * mGridIntervalY + mGridOffsetY;
 
-  if ( qgsDoubleNear( mRotation, 0.0 ) )
+  if ( qgsDoubleNear( mMapRotation, 0.0 ) )
   {
     //no rotation. Do it 'the easy way'
 
@@ -1599,7 +1622,7 @@ int QgsComposerMap::yGridLines( QList< QPair< double, QLineF > >& lines ) const
   double roundCorrection = mapBoundingRect.left() > 0 ? 1.0 : 0.0;
   double currentLevel = ( int )(( mapBoundingRect.left() - mGridOffsetX ) / mGridIntervalX + roundCorrection ) * mGridIntervalX + mGridOffsetX;
 
-  if ( qgsDoubleNear( mRotation, 0.0 ) )
+  if ( qgsDoubleNear( mMapRotation, 0.0 ) )
   {
     //no rotation. Do it 'the easy way'
     double xCanvasCoord;
@@ -1782,7 +1805,7 @@ double QgsComposerMap::maxExtension() const
 void QgsComposerMap::mapPolygon( const QgsRectangle& extent, QPolygonF& poly ) const
 {
   poly.clear();
-  if ( mRotation == 0 )
+  if ( mMapRotation == 0 )
   {
     poly << QPointF( extent.xMinimum(), extent.yMaximum() );
     poly << QPointF( extent.xMaximum(), extent.yMaximum() );
@@ -1798,25 +1821,25 @@ void QgsComposerMap::mapPolygon( const QgsRectangle& extent, QPolygonF& poly ) c
   //top left point
   dx = rotationPoint.x() - extent.xMinimum();
   dy = rotationPoint.y() - extent.yMaximum();
-  rotate( mRotation, dx, dy );
+  rotate( mMapRotation, dx, dy );
   poly << QPointF( rotationPoint.x() + dx, rotationPoint.y() + dy );
 
   //top right point
   dx = rotationPoint.x() - extent.xMaximum();
   dy = rotationPoint.y() - extent.yMaximum();
-  rotate( mRotation, dx, dy );
+  rotate( mMapRotation, dx, dy );
   poly << QPointF( rotationPoint.x() + dx, rotationPoint.y() + dy );
 
   //bottom right point
   dx = rotationPoint.x() - extent.xMaximum();
   dy = rotationPoint.y() - extent.yMinimum();
-  rotate( mRotation, dx, dy );
+  rotate( mMapRotation, dx, dy );
   poly << QPointF( rotationPoint.x() + dx, rotationPoint.y() + dy );
 
   //bottom left point
   dx = rotationPoint.x() - extent.xMinimum();
   dy = rotationPoint.y() - extent.yMinimum();
-  rotate( mRotation, dx, dy );
+  rotate( mMapRotation, dx, dy );
   poly << QPointF( rotationPoint.x() + dx, rotationPoint.y() + dy );
 }
 
@@ -1829,7 +1852,7 @@ void QgsComposerMap::requestedExtent( QgsRectangle& extent ) const
 {
   QgsRectangle newExtent;
   extentCenteredOnOverview( newExtent );
-  if ( mRotation == 0 )
+  if ( mMapRotation == 0 )
   {
     extent = newExtent;
   }
@@ -1913,7 +1936,7 @@ void QgsComposerMap::transformShift( double& xShift, double& yShift ) const
   double dxScaled = xShift * mmToMapUnits;
   double dyScaled = - yShift * mmToMapUnits;
 
-  rotate( mRotation, dxScaled, dyScaled );
+  rotate( mMapRotation, dxScaled, dyScaled );
 
   xShift = dxScaled;
   yShift = dyScaled;
@@ -1931,7 +1954,7 @@ QPointF QgsComposerMap::mapToItemCoords( const QPointF& mapCoords ) const
   QgsPoint rotationPoint(( tExtent.xMaximum() + tExtent.xMinimum() ) / 2.0, ( tExtent.yMaximum() + tExtent.yMinimum() ) / 2.0 );
   double dx = mapCoords.x() - rotationPoint.x();
   double dy = mapCoords.y() - rotationPoint.y();
-  rotate( -mRotation, dx, dy );
+  rotate( -mMapRotation, dx, dy );
   QgsPoint backRotatedCoords( rotationPoint.x() + dx, rotationPoint.y() + dy );
 
   QgsRectangle unrotatedExtent = transformedExtent();
@@ -2349,4 +2372,22 @@ void QgsComposerMap::assignFreeId()
     }
   }
   mId = maxId + 1;
+}
+
+bool QgsComposerMap::imageSizeConsideringRotation( double& width, double& height ) const
+{
+  //kept for api compatibility with QGIS 2.0 - use mMapRotation
+  return QgsComposerItem::imageSizeConsideringRotation( width, height, mMapRotation );
+}
+
+bool QgsComposerMap::cornerPointOnRotatedAndScaledRect( double& x, double& y, double width, double height ) const
+{
+  //kept for api compatibility with QGIS 2.0 - use mMapRotation
+  return QgsComposerItem::cornerPointOnRotatedAndScaledRect( x, y, width, height, mMapRotation );
+}
+
+void QgsComposerMap::sizeChangedByRotation( double& width, double& height )
+{
+  //kept for api compatibility with QGIS 2.0 - use mMapRotation
+  return QgsComposerItem::sizeChangedByRotation( width, height, mMapRotation );
 }

--- a/src/core/composer/qgscomposermap.h
+++ b/src/core/composer/qgscomposermap.h
@@ -299,7 +299,22 @@ class CORE_EXPORT QgsComposerMap : public QgsComposerItem
     void setCrossLength( double l ) {mCrossLength = l;}
     double crossLength() {return mCrossLength;}
 
+    /**Sets rotation for the map - this does not affect the composer item shape, only the
+      way the map is drawn within the item
+     * @deprecated Use setMapRotation( double rotation ) instead
+     */
+    void setRotation( double r );
+    /**Returns the rotation used for drawing the map within the composer item
+     * @deprecated Use mapRotation() instead
+     */
+    double rotation() const { return mMapRotation;};
+
+    /**Sets rotation for the map - this does not affect the composer item shape, only the
+      way the map is drawn within the item
+      @note this function was added in version 2.1*/
     void setMapRotation( double r );
+    /**Returns the rotation used for drawing the map within the composer item*/
+    double mapRotation() const { return mMapRotation;};
 
     void updateItem();
 
@@ -349,8 +364,27 @@ class CORE_EXPORT QgsComposerMap : public QgsComposerItem
         Usually, this function is called before adding the composer map to the composition*/
     void assignFreeId();
 
+    /**Calculates width and hight of the picture (in mm) such that it fits into the item frame with the given rotation
+     * @deprecated Use bool QgsComposerItem::imageSizeConsideringRotation( double& width, double& height, double rotation )
+     * instead
+     */
+    bool imageSizeConsideringRotation( double& width, double& height ) const;
+    /**Calculates corner point after rotation and scaling
+     * @deprecated Use QgsComposerItem::cornerPointOnRotatedAndScaledRect( double& x, double& y, double width, double height, double rotation )
+     * instead
+     */
+    bool cornerPointOnRotatedAndScaledRect( double& x, double& y, double width, double height ) const;
+    /**Calculates width / height of the bounding box of a rotated rectangle
+    * @deprecated Use QgsComposerItem::sizeChangedByRotation( double& width, double& height, double rotation )
+    * instead
+    */
+    void sizeChangedByRotation( double& width, double& height );
+
   signals:
     void extentChanged();
+
+    /**Is emitted on rotation change to notify north arrow pictures*/
+    void mapRotationChanged( double newRotation );
 
   public slots:
 
@@ -398,6 +432,9 @@ class CORE_EXPORT QgsComposerMap : public QgsComposerItem
     double mXOffset;
     /**Offset in y direction for showing map cache image*/
     double mYOffset;
+
+    /**Map rotation*/
+    double mMapRotation;
 
     /**Flag if layers to be displayed should be read from qgis canvas (true) or from stored list in mLayerSet (false)*/
     bool mKeepLayerSet;

--- a/src/core/composer/qgscomposerpicture.h
+++ b/src/core/composer/qgscomposerpicture.h
@@ -60,6 +60,15 @@ class CORE_EXPORT QgsComposerPicture: public QgsComposerItem
       */
     bool readXML( const QDomElement& itemElem, const QDomDocument& doc );
 
+    /**Returns the rotation used for drawing the picture within the composer item
+     * @deprecated Use pictureRotation() instead
+     */
+    double rotation() const { return mPictureRotation;};
+
+    /**Returns the rotation used for drawing the picture within the item
+      @note this function was added in version 2.1*/
+    double pictureRotation() const { return mPictureRotation;};
+
     /**Sets the map object for rotation (by id). A value of -1 disables the map rotation*/
     void setRotationMap( int composerMapId );
     /**Returns the id of the rotation map*/
@@ -67,9 +76,37 @@ class CORE_EXPORT QgsComposerPicture: public QgsComposerItem
     /**True if the rotation is taken from a map item*/
     bool useRotationMap() const {return mRotationMap;}
 
+    /**Calculates width and hight of the picture (in mm) such that it fits into the item frame with the given rotation
+     * @deprecated Use bool QgsComposerItem::imageSizeConsideringRotation( double& width, double& height, double rotation )
+     * instead
+     */
+    bool imageSizeConsideringRotation( double& width, double& height ) const;
+    /**Calculates corner point after rotation and scaling
+     * @deprecated Use QgsComposerItem::cornerPointOnRotatedAndScaledRect( double& x, double& y, double width, double height, double rotation )
+     * instead
+     */
+    bool cornerPointOnRotatedAndScaledRect( double& x, double& y, double width, double height ) const;
+    /**Calculates width / height of the bounding box of a rotated rectangle
+    * @deprecated Use QgsComposerItem::sizeChangedByRotation( double& width, double& height, double rotation )
+    * instead
+    */
+    void sizeChangedByRotation( double& width, double& height );
+
   public slots:
-    /**Sets the rotation and adapts the item rect*/
+    /**Sets the picture rotation within the item bounds. This does not affect the item rectangle,
+      only the way the picture is drawn within the item.
+     * @deprecated Use setPictureRotation( double rotation ) instead
+     */
     virtual void setRotation( double r );
+
+    /**Sets the picture rotation within the item bounds. This does not affect the item rectangle,
+      only the way the picture is drawn within the item.
+      @note this function was added in version 2.1*/
+    virtual void setPictureRotation( double r );
+
+  signals:
+    /**Is emitted on picture rotation change*/
+    void pictureRotationChanged( double newRotation );
 
   private:
 
@@ -94,6 +131,9 @@ class CORE_EXPORT QgsComposerPicture: public QgsComposerItem
     Mode mMode;
 
     QSize mDefaultSvgSize;
+
+    /**Image rotation*/
+    double mPictureRotation;
     /**Map that sets the rotation (or 0 if this picture uses map independent rotation)*/
     const QgsComposerMap* mRotationMap;
     /**Width of the picture (in mm)*/

--- a/src/core/composer/qgscomposershape.cpp
+++ b/src/core/composer/qgscomposershape.cpp
@@ -61,7 +61,7 @@ void QgsComposerShape::drawShape( QPainter* p )
   p->setRenderHint( QPainter::Antialiasing );
 
   p->translate( rect().width() / 2.0, rect().height() / 2.0 );
-  p->rotate( mRotation );
+  p->rotate( mItemRotation );
   p->translate( -rect().width() / 2.0, -rect().height() / 2.0 );
 
   switch ( mShape )
@@ -135,6 +135,14 @@ bool QgsComposerShape::readXML( const QDomElement& itemElem, const QDomDocument&
   if ( composerItemList.size() > 0 )
   {
     QDomElement composerItemElem = composerItemList.at( 0 ).toElement();
+
+    //rotation
+    if ( composerItemElem.attribute( "rotation", "0" ).toDouble() != 0 )
+    {
+      //check for old (pre 2.1) rotation attribute
+      mItemRotation = composerItemElem.attribute( "rotation", "0" ).toDouble();
+    }
+
     _readXML( composerItemElem, doc );
   }
   emit itemChanged();
@@ -142,7 +150,7 @@ bool QgsComposerShape::readXML( const QDomElement& itemElem, const QDomDocument&
 }
 
 
-void QgsComposerShape::setRotation( double r )
+void QgsComposerShape::setItemRotation( double r )
 {
   //adapt rectangle size
   double width = rect().width();
@@ -154,7 +162,7 @@ void QgsComposerShape::setRotation( double r )
   double y = pos().y() + rect().height() / 2.0 - height / 2.0;
   QgsComposerItem::setSceneRect( QRectF( x, y, width, height ) );
 
-  QgsComposerItem::setRotation( r );
+  QgsComposerItem::setItemRotation( r );
 }
 
 void QgsComposerShape::setCornerRadius( double radius )

--- a/src/core/composer/qgscomposershape.h
+++ b/src/core/composer/qgscomposershape.h
@@ -72,7 +72,7 @@ class CORE_EXPORT QgsComposerShape: public QgsComposerItem
 
   public slots:
     /**Sets item rotation and resizes item bounds such that the shape always has the same size*/
-    virtual void setRotation( double r );
+    virtual void setItemRotation( double r );
 
   protected:
     /* reimplement drawFrame, since it's not a rect, but a custom shape */

--- a/src/ui/qgscomposermapwidgetbase.ui
+++ b/src/ui/qgscomposermapwidgetbase.ui
@@ -123,16 +123,16 @@
            </widget>
           </item>
           <item row="2" column="0">
-           <widget class="QLabel" name="mRotationLabel">
+           <widget class="QLabel" name="mMapRotationLabel">
             <property name="text">
-             <string>Rotation</string>
+             <string>Map Rotation</string>
             </property>
            </widget>
           </item>
           <item row="2" column="1">
-           <widget class="QDoubleSpinBox" name="mRotationSpinBox">
+           <widget class="QDoubleSpinBox" name="mMapRotationSpinBox">
             <property name="suffix">
-             <string> degrees</string>
+             <string> °</string>
             </property>
             <property name="maximum">
              <double>360.000000000000000</double>

--- a/src/ui/qgscomposerpicturewidgetbase.ui
+++ b/src/ui/qgscomposerpicturewidgetbase.ui
@@ -213,7 +213,7 @@
        <item>
         <widget class="QgsCollapsibleGroupBoxBasic" name="groupBox">
          <property name="title">
-          <string>Rotation</string>
+          <string>Image Rotation</string>
          </property>
          <property name="syncGroup" stdset="0">
           <string notr="true">composeritem</string>
@@ -239,7 +239,7 @@
            <widget class="QComboBox" name="mComposerMapComboBox"/>
           </item>
           <item row="0" column="0" colspan="2">
-           <widget class="QDoubleSpinBox" name="mRotationSpinBox">
+           <widget class="QDoubleSpinBox" name="mPictureRotationSpinBox">
             <property name="suffix">
              <string> °</string>
             </property>

--- a/tests/src/core/testqgscomposermap.cpp
+++ b/tests/src/core/testqgscomposermap.cpp
@@ -239,7 +239,7 @@ void TestQgsComposerMap::overviewMapCenter()
 void TestQgsComposerMap::worldFileGeneration()
 {
   mComposerMap->setNewExtent( QgsRectangle( 781662.375, 3339523.125, 793062.375, 3345223.125 ) );
-  mComposerMap->setRotation( 30.0 );
+  mComposerMap->setMapRotation( 30.0 );
 
   mComposition->setGenerateWorldFile( true );
   mComposition->setWorldFileMap( mComposerMap );

--- a/tests/src/python/test_qgscomposermap.py
+++ b/tests/src/python/test_qgscomposermap.py
@@ -252,7 +252,7 @@ class TestQgsComposerMap(TestCase):
     def testWorldFileGeneration( self ):
         myRectangle = QgsRectangle(781662.375, 3339523.125, 793062.375, 3345223.125)
         self.mComposerMap.setNewExtent( myRectangle )
-        self.mComposerMap.setRotation( 30.0 )
+        self.mComposerMap.setMapRotation( 30.0 )
 
         self.mComposition.setGenerateWorldFile( True )
         self.mComposition.setWorldFileMap( self.mComposerMap )


### PR DESCRIPTION
This request cleans up the composer item api, since it currently has two different uses - one is setting the actual composer item rotation (for shapes, labels), and the other is setting the rotation for the item content (maps, pictures). This commit clarifies the rotation api, while maintaining compatibility with 2.0 api. It's a prerequisite to being able to rotation all types of composer items.
