### PR TITLE
Feature #9085: Set refresh to F5 key in qbrowser

### DIFF
--- a/src/browser/qgsbrowserbase.ui
+++ b/src/browser/qgsbrowserbase.ui
@@ -205,7 +205,7 @@
     <string>Refresh</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+R</string>
+    <string>F5</string>
    </property>
   </action>
   <action name="mActionSetProjection">


### PR DESCRIPTION
Set refresh to F5 key in qbrowser equally to qapp

http://hub.qgis.org/projects/quantum-gis/repository/revisions/32b05836d50b36f443517ef6a76ac26d49b19b89
