### PR TITLE
Composer rotation fixes and improvements

### DIFF
--- a/python/core/composer/qgscomposeritem.sip
+++ b/python/core/composer/qgscomposeritem.sip
@@ -332,6 +332,14 @@ class QgsComposerItem: QObject, QGraphicsRectItem
     @note this method was added in version 1.2*/
     bool positionLock() const;
 
+    /**Returns the rotation for the composer item
+    @note this method was added in version 2.1*/
+    double itemRotation() const;
+
+    /**Returns the rotation for the composer item
+     * @deprecated Use itemRotation()
+     *             instead
+     */    
     double rotation() const;
 
     /**Updates item, with the possibility to do custom update for subclasses*/
@@ -351,7 +359,15 @@ class QgsComposerItem: QObject, QGraphicsRectItem
     QString uuid() const;
 
   public slots:
+    /**Sets the item rotation
+     * @deprecated Use setItemRotation( double rotation ) instead
+     */   
     virtual void setRotation( double r );
+
+    /**Sets the item rotation
+      @note this method was added in version 2.1
+    */
+    virtual void setItemRotation( double r );
     void repaint();
 
   protected:
@@ -394,11 +410,27 @@ class QgsComposerItem: QObject, QGraphicsRectItem
     //some utility functions
 
     /**Calculates width and hight of the picture (in mm) such that it fits into the item frame with the given rotation*/
+    bool imageSizeConsideringRotation( double& width, double& height, double rotation ) const;
+    /**Calculates width and hight of the picture (in mm) such that it fits into the item frame with the given rotation
+     * @deprecated Use bool imageSizeConsideringRotation( double& width, double& height, double rotation )
+     * instead
+     */
     bool imageSizeConsideringRotation( double& width, double& height ) const;
+    
     /**Calculates corner point after rotation and scaling*/
+    bool cornerPointOnRotatedAndScaledRect( double& x, double& y, double width, double height, double rotation ) const;
+    /**Calculates corner point after rotation and scaling
+     * @deprecated Use bool cornerPointOnRotatedAndScaledRect( double& x, double& y, double width, double height, double rotation )
+     * instead
+     */    
     bool cornerPointOnRotatedAndScaledRect( double& x, double& y, double width, double height ) const;
 
-    /**Calculates width / height of the bounding box of a rotated rectangle (mRotation)*/
+    /**Calculates width / height of the bounding box of a rotated rectangle*/
+    void sizeChangedByRotation( double& width, double& height, double rotation );
+     /**Calculates width / height of the bounding box of a rotated rectangle
+     * @deprecated Use void sizeChangedByRotation( double& width, double& height, double rotation )
+     * instead
+     */      
     void sizeChangedByRotation( double& width, double& height );
     /**Rotates a point / vector
         @param angle rotation angle in degrees, counterclockwise
@@ -416,7 +448,7 @@ class QgsComposerItem: QObject, QGraphicsRectItem
 
   signals:
     /**Is emitted on rotation change to notify north arrow pictures*/
-    void rotationChanged( double newRotation );
+    void itemRotationChanged( double newRotation );
     /**Used e.g. by the item widgets to update the gui elements*/
     void itemChanged();
     /**Emitted if the rectangle changes*/

--- a/python/core/composer/qgscomposeritemcommand.sip
+++ b/python/core/composer/qgscomposeritemcommand.sip
@@ -46,7 +46,6 @@ class QgsComposerMergeCommand : QgsComposerItemCommand
       //composer label
       ComposerLabelSetText,
       ComposerLabelSetId,
-      ComposerLabelRotation,
       //composer map
       ComposerMapRotation,
       ComposerMapAnnotationDistance,
@@ -57,6 +56,8 @@ class QgsComposerMergeCommand : QgsComposerItemCommand
       LegendEqualColumnWidth,
       LegendSymbolWidth,
       LegendSymbolHeight,
+      LegendWmsLegendWidth,
+      LegendWmsLegendHeight,
       LegendTitleSpaceBottom,
       LegendGroupSpace,
       LegendLayerSpace,
@@ -81,14 +82,15 @@ class QgsComposerMergeCommand : QgsComposerItemCommand
       TableMargin,
       TableGridStrokeWidth,
       //composer shape
-      ShapeRotation,
+      ShapeCornerRadius,
       ShapeOutlineWidth,
       //composer arrow
       ArrowOutlineWidth,
       ArrowHeadWidth,
       //item
       ItemOutlineWidth,
-      ItemMove
+      ItemMove,
+      ItemRotation
     };
 
     QgsComposerMergeCommand( Context c, QgsComposerItem* item, const QString& text );

--- a/python/core/composer/qgscomposerlabel.sip
+++ b/python/core/composer/qgscomposerlabel.sip
@@ -79,5 +79,11 @@ class QgsComposerLabel : QgsComposerItem
     bool readXML( const QDomElement& itemElem, const QDomDocument& doc );
 
   public slots:
+    /* Sets rotation for the label
+     * @deprecated Use setItemRotation( double rotation ) instead
+     */
     virtual void setRotation( double r );
+  
+    /* Sets rotation for the label */
+    virtual void setItemRotation( double r );
 };

--- a/python/core/composer/qgscomposermap.sip
+++ b/python/core/composer/qgscomposermap.sip
@@ -267,7 +267,22 @@ class QgsComposerMap : QgsComposerItem
     void setCrossLength( double l );
     double crossLength();
 
+    /**Sets rotation for the map - this does not affect the composer item shape, only the
+      way the map is drawn within the item
+     * @deprecated Use setMapRotation( double rotation ) instead
+     */
+    void setRotation( double r );
+    /**Returns the rotation used for drawing the map within the composer item    
+     * @deprecated Use mapRotation() instead
+     */
+    double rotation() const;
+
+    /**Sets rotation for the map - this does not affect the composer item shape, only the
+      way the map is drawn within the item
+      @note this function was added in version 2.1*/
     void setMapRotation( double r );
+    /**Returns the rotation used for drawing the map within the composer item*/
+    double mapRotation() const;
 
     void updateItem();
 
@@ -310,9 +325,28 @@ class QgsComposerMap : QgsComposerItem
     /**Sets mId to a number not yet used in the composition. mId is kept if it is not in use.
         Usually, this function is called before adding the composer map to the composition*/
     void assignFreeId();
+    
+    /**Calculates width and hight of the picture (in mm) such that it fits into the item frame with the given rotation
+     * @deprecated Use bool QgsComposerItem::imageSizeConsideringRotation( double& width, double& height, double rotation )
+     * instead
+     */
+    bool imageSizeConsideringRotation( double& width, double& height ) const;
+    /**Calculates corner point after rotation and scaling
+     * @deprecated Use QgsComposerItem::cornerPointOnRotatedAndScaledRect( double& x, double& y, double width, double height, double rotation )
+     * instead
+     */
+    bool cornerPointOnRotatedAndScaledRect( double& x, double& y, double width, double height ) const;
+    /**Calculates width / height of the bounding box of a rotated rectangle
+    * @deprecated Use QgsComposerItem::sizeChangedByRotation( double& width, double& height, double rotation )
+    * instead
+    */
+    void sizeChangedByRotation( double& width, double& height );    
 
   signals:
     void extentChanged();
+    
+    /**Is emitted on rotation change to notify north arrow pictures*/
+    void mapRotationChanged( double newRotation );    
 
   public slots:
 

--- a/python/core/composer/qgscomposerpicture.sip
+++ b/python/core/composer/qgscomposerpicture.sip
@@ -38,6 +38,15 @@ class QgsComposerPicture: QgsComposerItem
       */
     bool readXML( const QDomElement& itemElem, const QDomDocument& doc );
 
+    /**Returns the rotation used for drawing the picture within the composer item    
+     * @deprecated Use pictureRotation() instead
+     */
+    double rotation() const;
+
+    /**Returns the rotation used for drawing the picture within the item
+      @note this function was added in version 2.1*/
+    double pictureRotation() const;
+
     /**Sets the map object for rotation (by id). A value of -1 disables the map rotation*/
     void setRotationMap( int composerMapId );
     /**Returns the id of the rotation map*/
@@ -45,7 +54,35 @@ class QgsComposerPicture: QgsComposerItem
     /**True if the rotation is taken from a map item*/
     bool useRotationMap() const;
 
+    /**Calculates width and hight of the picture (in mm) such that it fits into the item frame with the given rotation
+     * @deprecated Use bool QgsComposerItem::imageSizeConsideringRotation( double& width, double& height, double rotation )
+     * instead
+     */
+    bool imageSizeConsideringRotation( double& width, double& height ) const;
+    /**Calculates corner point after rotation and scaling
+     * @deprecated Use QgsComposerItem::cornerPointOnRotatedAndScaledRect( double& x, double& y, double width, double height, double rotation )
+     * instead
+     */
+    bool cornerPointOnRotatedAndScaledRect( double& x, double& y, double width, double height ) const;
+    /**Calculates width / height of the bounding box of a rotated rectangle
+    * @deprecated Use QgsComposerItem::sizeChangedByRotation( double& width, double& height, double rotation )
+    * instead
+    */
+    void sizeChangedByRotation( double& width, double& height );
+    
   public slots:
-    /**Sets the rotation and adapts the item rect*/
+    /**Sets the picture rotation within the item bounds. This does not affect the item rectangle,
+      only the way the picture is drawn within the item.
+     * @deprecated Use setPictureRotation( double rotation ) instead
+     */
     virtual void setRotation( double r );
+
+    /**Sets the picture rotation within the item bounds. This does not affect the item rectangle,
+      only the way the picture is drawn within the item.
+      @note this function was added in version 2.1*/
+    virtual void setPictureRotation( double r );
+    
+  signals:
+    /**Is emitted on picture rotation change*/
+    void pictureRotationChanged( double newRotation );    
 };

--- a/python/core/composer/qgscomposershape.sip
+++ b/python/core/composer/qgscomposershape.sip
@@ -50,7 +50,7 @@ class QgsComposerShape: QgsComposerItem
 
   public slots:
     /**Sets item rotation and resizes item bounds such that the shape always has the same size*/
-    virtual void setRotation( double r );
+    virtual void setItemRotation( double r );
 
   protected:
     /* reimplement drawFrame, since it's not a rect, but a custom shape */

--- a/src/app/composer/qgscomposeritemwidget.cpp
+++ b/src/app/composer/qgscomposeritemwidget.cpp
@@ -333,6 +333,7 @@ void QgsComposerItemWidget::setValuesForGuiElements()
   mTransparencySpnBx->blockSignals( true );
   mFrameColorButton->blockSignals( true );
   mBackgroundColorButton->blockSignals( true );
+  mItemRotationSpinBox->blockSignals( true );
 
   mBackgroundColorButton->setColor( mItem->brush().color() );
   mBackgroundColorButton->setColorDialogTitle( tr( "Select background color" ) );
@@ -348,6 +349,7 @@ void QgsComposerItemWidget::setValuesForGuiElements()
   mBlendModeCombo->setBlendMode( mItem->blendMode() );
   mTransparencySlider->setValue( mItem->transparency() );
   mTransparencySpnBx->setValue( mItem->transparency() );
+  mItemRotationSpinBox->setValue( mItem->itemRotation() );
 
   mBackgroundColorButton->blockSignals( false );
   mFrameColorButton->blockSignals( false );
@@ -359,6 +361,7 @@ void QgsComposerItemWidget::setValuesForGuiElements()
   mBlendModeCombo->blockSignals( false );
   mTransparencySlider->blockSignals( false );
   mTransparencySpnBx->blockSignals( false );
+  mItemRotationSpinBox->blockSignals( false );
 }
 
 void QgsComposerItemWidget::on_mBlendModeCombo_currentIndexChanged( int index )
@@ -494,4 +497,15 @@ void QgsComposerItemWidget::on_mLowerRightCheckBox_stateChanged( int state )
                             mItem->pos().y() + mItem->rect().height(), QgsComposerItem::LowerRight );
   }
   setValuesForGuiPositionElements();
+}
+
+void QgsComposerItemWidget::on_mItemRotationSpinBox_valueChanged( double val )
+{
+  if ( mItem )
+  {
+    mItem->beginCommand( tr( "Item rotation changed" ), QgsComposerMergeCommand::ItemRotation );
+    mItem->setItemRotation( val );
+    mItem->update();
+    mItem->endCommand();
+  }
 }

--- a/src/app/composer/qgscomposeritemwidget.cpp
+++ b/src/app/composer/qgscomposeritemwidget.cpp
@@ -504,7 +504,7 @@ void QgsComposerItemWidget::on_mItemRotationSpinBox_valueChanged( double val )
   if ( mItem )
   {
     mItem->beginCommand( tr( "Item rotation changed" ), QgsComposerMergeCommand::ItemRotation );
-    mItem->setItemRotation( val );
+    mItem->setItemRotation( val, true );
     mItem->update();
     mItem->endCommand();
   }

--- a/src/app/composer/qgscomposeritemwidget.h
+++ b/src/app/composer/qgscomposeritemwidget.h
@@ -73,6 +73,8 @@ class QgsComposerItemWidget: public QWidget, private Ui::QgsComposerItemWidgetBa
     void on_mBlendModeCombo_currentIndexChanged( int index );
     void on_mTransparencySlider_valueChanged( int value );
 
+    void on_mItemRotationSpinBox_valueChanged( double val );
+
     void setValuesForGuiElements();
     void setValuesForGuiPositionElements();
 

--- a/src/app/composer/qgscomposerlabelwidget.cpp
+++ b/src/app/composer/qgscomposerlabelwidget.cpp
@@ -228,17 +228,6 @@ void QgsComposerLabelWidget::on_mMiddleRadioButton_clicked()
   }
 }
 
-void QgsComposerLabelWidget::on_mRotationSpinBox_valueChanged( double v )
-{
-  if ( mComposerLabel )
-  {
-    mComposerLabel->beginCommand( tr( "Label rotation changed" ), QgsComposerMergeCommand::ItemRotation );
-    mComposerLabel->setItemRotation( v );
-    mComposerLabel->update();
-    mComposerLabel->endCommand();
-  }
-}
-
 void QgsComposerLabelWidget::setGuiElementValues()
 {
   blockAllSignals( true );
@@ -252,7 +241,6 @@ void QgsComposerLabelWidget::setGuiElementValues()
   mLeftRadioButton->setChecked( mComposerLabel->hAlign() == Qt::AlignLeft );
   mCenterRadioButton->setChecked( mComposerLabel->hAlign() == Qt::AlignHCenter );
   mRightRadioButton->setChecked( mComposerLabel->hAlign() == Qt::AlignRight );
-  mRotationSpinBox->setValue( mComposerLabel->itemRotation() );
   blockAllSignals( false );
 }
 
@@ -267,5 +255,4 @@ void QgsComposerLabelWidget::blockAllSignals( bool block )
   mLeftRadioButton->blockSignals( block );
   mCenterRadioButton->blockSignals( block );
   mRightRadioButton->blockSignals( block );
-  mRotationSpinBox->blockSignals( block );
 }

--- a/src/app/composer/qgscomposerlabelwidget.cpp
+++ b/src/app/composer/qgscomposerlabelwidget.cpp
@@ -232,8 +232,8 @@ void QgsComposerLabelWidget::on_mRotationSpinBox_valueChanged( double v )
 {
   if ( mComposerLabel )
   {
-    mComposerLabel->beginCommand( tr( "Label rotation changed" ), QgsComposerMergeCommand::ComposerLabelRotation );
-    mComposerLabel->setRotation( v );
+    mComposerLabel->beginCommand( tr( "Label rotation changed" ), QgsComposerMergeCommand::ItemRotation );
+    mComposerLabel->setItemRotation( v );
     mComposerLabel->update();
     mComposerLabel->endCommand();
   }
@@ -252,7 +252,7 @@ void QgsComposerLabelWidget::setGuiElementValues()
   mLeftRadioButton->setChecked( mComposerLabel->hAlign() == Qt::AlignLeft );
   mCenterRadioButton->setChecked( mComposerLabel->hAlign() == Qt::AlignHCenter );
   mRightRadioButton->setChecked( mComposerLabel->hAlign() == Qt::AlignRight );
-  mRotationSpinBox->setValue( mComposerLabel->rotation() );
+  mRotationSpinBox->setValue( mComposerLabel->itemRotation() );
   blockAllSignals( false );
 }
 

--- a/src/app/composer/qgscomposerlabelwidget.h
+++ b/src/app/composer/qgscomposerlabelwidget.h
@@ -44,7 +44,6 @@ class QgsComposerLabelWidget: public QWidget, private Ui::QgsComposerLabelWidget
     void on_mTopRadioButton_clicked();
     void on_mBottomRadioButton_clicked();
     void on_mMiddleRadioButton_clicked();
-    void on_mRotationSpinBox_valueChanged( double v );
 
   private slots:
     void setGuiElementValues();

--- a/src/app/composer/qgscomposermapwidget.cpp
+++ b/src/app/composer/qgscomposermapwidget.cpp
@@ -148,7 +148,7 @@ void QgsComposerMapWidget::on_mScaleLineEdit_editingFinished()
   mComposerMap->endCommand();
 }
 
-void QgsComposerMapWidget::on_mRotationSpinBox_valueChanged( double value )
+void QgsComposerMapWidget::on_mMapRotationSpinBox_valueChanged( double value )
 {
   if ( !mComposerMap )
   {
@@ -278,7 +278,7 @@ void QgsComposerMapWidget::updateGuiElements()
     mYMinLineEdit->setText( QString::number( composerMapExtent.yMinimum(), 'f', 3 ) );
     mYMaxLineEdit->setText( QString::number( composerMapExtent.yMaximum(), 'f', 3 ) );
 
-    mRotationSpinBox->setValue( mComposerMap->rotation() );
+    mMapRotationSpinBox->setValue( mComposerMap->mapRotation() );
 
     //keep layer list check box
     if ( mComposerMap->keepLayerSet() )

--- a/src/app/composer/qgscomposermapwidget.h
+++ b/src/app/composer/qgscomposermapwidget.h
@@ -37,7 +37,7 @@ class QgsComposerMapWidget: public QWidget, private Ui::QgsComposerMapWidgetBase
   public slots:
     void on_mPreviewModeComboBox_activated( int i );
     void on_mScaleLineEdit_editingFinished();
-    void on_mRotationSpinBox_valueChanged( double value );
+    void on_mMapRotationSpinBox_valueChanged( double value );
     void on_mSetToMapCanvasExtentButton_clicked();
     void on_mUpdatePreviewButton_clicked();
     void on_mKeepLayerListCheckBox_stateChanged( int state );

--- a/src/app/composer/qgscomposerpicturewidget.cpp
+++ b/src/app/composer/qgscomposerpicturewidget.cpp
@@ -50,7 +50,7 @@ QgsComposerPictureWidget::QgsComposerPictureWidget( QgsComposerPicture* picture 
   connect( mSearchDirectoriesGroupBox, SIGNAL( collapsedStateChanged( bool ) ), this, SLOT( loadPicturePreviews( bool ) ) );
 
   connect( mPicture, SIGNAL( itemChanged() ), this, SLOT( setGuiElementValues() ) );
-  connect( mPicture, SIGNAL( rotationChanged( double ) ), this, SLOT( setGuiElementValues() ) );
+  connect( mPicture, SIGNAL( pictureRotationChanged( double ) ), this, SLOT( setPicRotationSpinValue( double ) ) );
 }
 
 QgsComposerPictureWidget::~QgsComposerPictureWidget()
@@ -121,13 +121,12 @@ void QgsComposerPictureWidget::on_mPictureLineEdit_editingFinished()
 }
 
 
-void QgsComposerPictureWidget::on_mRotationSpinBox_valueChanged( double d )
+void QgsComposerPictureWidget::on_mPictureRotationSpinBox_valueChanged( double d )
 {
   if ( mPicture )
   {
     mPicture->beginCommand( tr( "Picture rotation changed" ), QgsComposerMergeCommand::ComposerPictureRotation );
-    mPicture->setRotation( d );
-    mPicture->update();
+    mPicture->setPictureRotation( d );
     mPicture->endCommand();
   }
 }
@@ -210,8 +209,9 @@ void QgsComposerPictureWidget::on_mRotationFromComposerMapCheckBox_stateChanged(
   if ( state == Qt::Unchecked )
   {
     mPicture->setRotationMap( -1 );
-    mRotationSpinBox->setEnabled( true );
+    mPictureRotationSpinBox->setEnabled( true );
     mComposerMapComboBox->setEnabled( false );
+    mPicture->setPictureRotation( mPictureRotationSpinBox->value() );
   }
   else
   {
@@ -223,7 +223,7 @@ void QgsComposerPictureWidget::on_mRotationFromComposerMapCheckBox_stateChanged(
     int composerId = mComposerMapComboBox->itemData( currentItemIndex, Qt::UserRole ).toInt();
 
     mPicture->setRotationMap( composerId );
-    mRotationSpinBox->setEnabled( false );
+    mPictureRotationSpinBox->setEnabled( false );
     mComposerMapComboBox->setEnabled( true );
   }
   mPicture->endCommand();
@@ -310,26 +310,33 @@ void QgsComposerPictureWidget::refreshMapComboBox()
   mComposerMapComboBox->blockSignals( false );
 }
 
+void QgsComposerPictureWidget::setPicRotationSpinValue( double r )
+{
+  mPictureRotationSpinBox->blockSignals( true );
+  mPictureRotationSpinBox->setValue( r );
+  mPictureRotationSpinBox->blockSignals( false );
+}
+
 void QgsComposerPictureWidget::setGuiElementValues()
 {
   //set initial gui values
   if ( mPicture )
   {
-    mRotationSpinBox->blockSignals( true );
+    mPictureRotationSpinBox->blockSignals( true );
     mPictureLineEdit->blockSignals( true );
     mComposerMapComboBox->blockSignals( true );
     mRotationFromComposerMapCheckBox->blockSignals( true );
 
     mPictureLineEdit->setText( mPicture->pictureFile() );
 //    QRectF pictureRect = mPicture->rect();
-    mRotationSpinBox->setValue( mPicture->rotation() );
+    mPictureRotationSpinBox->setValue( mPicture->pictureRotation() );
 
     refreshMapComboBox();
 
     if ( mPicture->useRotationMap() )
     {
       mRotationFromComposerMapCheckBox->setCheckState( Qt::Checked );
-      mRotationSpinBox->setEnabled( false );
+      mPictureRotationSpinBox->setEnabled( false );
       mComposerMapComboBox->setEnabled( true );
       QString mapText = tr( "Map %1" ).arg( mPicture->rotationMap() );
       int itemId = mComposerMapComboBox->findText( mapText );
@@ -341,13 +348,13 @@ void QgsComposerPictureWidget::setGuiElementValues()
     else
     {
       mRotationFromComposerMapCheckBox->setCheckState( Qt::Unchecked );
-      mRotationSpinBox->setEnabled( true );
+      mPictureRotationSpinBox->setEnabled( true );
       mComposerMapComboBox->setEnabled( false );
     }
 
 
     mRotationFromComposerMapCheckBox->blockSignals( false );
-    mRotationSpinBox->blockSignals( false );
+    mPictureRotationSpinBox->blockSignals( false );
     mPictureLineEdit->blockSignals( false );
     mComposerMapComboBox->blockSignals( false );
   }

--- a/src/app/composer/qgscomposerpicturewidget.h
+++ b/src/app/composer/qgscomposerpicturewidget.h
@@ -39,7 +39,7 @@ class QgsComposerPictureWidget: public QWidget, private Ui::QgsComposerPictureWi
   public slots:
     void on_mPictureBrowseButton_clicked();
     void on_mPictureLineEdit_editingFinished();
-    void on_mRotationSpinBox_valueChanged( double d );
+    void on_mPictureRotationSpinBox_valueChanged( double d );
     void on_mPreviewListWidget_currentItemChanged( QListWidgetItem* current, QListWidgetItem* previous );
     void on_mAddDirectoryButton_clicked();
     void on_mRemoveDirectoryButton_clicked();
@@ -53,6 +53,10 @@ class QgsComposerPictureWidget: public QWidget, private Ui::QgsComposerPictureWi
   private slots:
     /**Sets the GUI elements to the values of mPicture*/
     void setGuiElementValues();
+
+    /**Sets the picture rotation GUI control value*/
+    void setPicRotationSpinValue( double r );
+
     /** Load SVG and pixel-based image previews
      * @param collapsed Whether the parent group box is collapsed
      * @note added in 1.9

--- a/src/app/composer/qgscomposershapewidget.cpp
+++ b/src/app/composer/qgscomposershapewidget.cpp
@@ -66,7 +66,7 @@ void QgsComposerShapeWidget::setGuiElementValues()
 
   blockAllSignals( true );
 
-  mRotationSpinBox->setValue( mComposerShape->rotation() );
+  mRotationSpinBox->setValue( mComposerShape->itemRotation() );
   mCornerRadiusSpinBox->setValue( mComposerShape->cornerRadius() );
   if ( mComposerShape->shapeType() == QgsComposerShape::Ellipse )
   {
@@ -91,8 +91,8 @@ void QgsComposerShapeWidget::on_mRotationSpinBox_valueChanged( int val )
 {
   if ( mComposerShape )
   {
-    mComposerShape->beginCommand( tr( "Shape rotation changed" ), QgsComposerMergeCommand::ShapeRotation );
-    mComposerShape->setRotation( val );
+    mComposerShape->beginCommand( tr( "Shape rotation changed" ), QgsComposerMergeCommand::ItemRotation );
+    mComposerShape->setItemRotation( val );
     mComposerShape->update();
     mComposerShape->endCommand();
   }
@@ -102,7 +102,7 @@ void QgsComposerShapeWidget::on_mCornerRadiusSpinBox_valueChanged( double val )
 {
   if ( mComposerShape )
   {
-    mComposerShape->beginCommand( tr( "Shape radius changed" ), QgsComposerMergeCommand::ShapeRotation );
+    mComposerShape->beginCommand( tr( "Shape radius changed" ), QgsComposerMergeCommand::ShapeCornerRadius );
     mComposerShape->setCornerRadius( val );
     mComposerShape->update();
     mComposerShape->endCommand();

--- a/src/app/composer/qgscomposershapewidget.cpp
+++ b/src/app/composer/qgscomposershapewidget.cpp
@@ -53,7 +53,6 @@ QgsComposerShapeWidget::~QgsComposerShapeWidget()
 void QgsComposerShapeWidget::blockAllSignals( bool block )
 {
   mShapeComboBox->blockSignals( block );
-  mRotationSpinBox->blockSignals( block );
   mCornerRadiusSpinBox->blockSignals( block );
 }
 
@@ -66,7 +65,6 @@ void QgsComposerShapeWidget::setGuiElementValues()
 
   blockAllSignals( true );
 
-  mRotationSpinBox->setValue( mComposerShape->itemRotation() );
   mCornerRadiusSpinBox->setValue( mComposerShape->cornerRadius() );
   if ( mComposerShape->shapeType() == QgsComposerShape::Ellipse )
   {
@@ -85,17 +83,6 @@ void QgsComposerShapeWidget::setGuiElementValues()
   }
 
   blockAllSignals( false );
-}
-
-void QgsComposerShapeWidget::on_mRotationSpinBox_valueChanged( int val )
-{
-  if ( mComposerShape )
-  {
-    mComposerShape->beginCommand( tr( "Shape rotation changed" ), QgsComposerMergeCommand::ItemRotation );
-    mComposerShape->setItemRotation( val );
-    mComposerShape->update();
-    mComposerShape->endCommand();
-  }
 }
 
 void QgsComposerShapeWidget::on_mCornerRadiusSpinBox_valueChanged( double val )

--- a/src/app/composer/qgscomposershapewidget.h
+++ b/src/app/composer/qgscomposershapewidget.h
@@ -38,7 +38,6 @@ class QgsComposerShapeWidget: public QWidget, private Ui::QgsComposerShapeWidget
 
   private slots:
     void on_mShapeComboBox_currentIndexChanged( const QString& text );
-    void on_mRotationSpinBox_valueChanged( int val );
     void on_mCornerRadiusSpinBox_valueChanged( double val );
 
     /**Sets the GUI elements to the currentValues of mComposerShape*/

--- a/src/core/composer/qgscomposeritem.cpp
+++ b/src/core/composer/qgscomposeritem.cpp
@@ -226,7 +226,7 @@ bool QgsComposerItem::_readXML( const QDomElement& itemElem, const QDomDocument&
   //rotation
   if ( itemElem.attribute( "itemRotation", "0" ).toDouble() != 0 )
   {
-    mItemRotation = itemElem.attribute( "itemRotation", "0" ).toDouble();
+    setItemRotation( itemElem.attribute( "itemRotation", "0" ).toDouble() );
   }
 
   //uuid
@@ -482,6 +482,8 @@ void QgsComposerItem::setSceneRect( const QRectF& rectangle )
 
   QRectF newRect( 0, 0, newWidth, newHeight );
   QGraphicsRectItem::setRect( newRect );
+  //rotate item around its centre point
+  setTransformOriginPoint( QPointF( rect().width() / 2.0, rect().height() / 2.0 ) );
   setPos( xTranslation, yTranslation );
 
   emit sizeChanged();
@@ -716,6 +718,11 @@ void QgsComposerItem::setItemRotation( double r )
   {
     mItemRotation = r;
   }
+
+  //rotate item around its centre point
+  setTransformOriginPoint( QPointF( rect().width() / 2.0, rect().height() / 2.0 ) );
+  QGraphicsItem::setRotation( mItemRotation );
+
   emit itemRotationChanged( r );
   update();
 }

--- a/src/core/composer/qgscomposeritem.h
+++ b/src/core/composer/qgscomposeritem.h
@@ -320,9 +320,12 @@ class CORE_EXPORT QgsComposerItem: public QObject, public QGraphicsRectItem
     virtual void setRotation( double r );
 
     /**Sets the item rotation
+      @param r item rotation in degrees
+      @param adjustPosition set to true if item should be shifted so that rotation occurs
+       around item center. If false, rotation occurs around item origin
       @note this method was added in version 2.1
     */
-    virtual void setItemRotation( double r );
+    virtual void setItemRotation( double r, bool adjustPosition = false );
 
     void repaint();
 

--- a/src/core/composer/qgscomposeritem.h
+++ b/src/core/composer/qgscomposeritem.h
@@ -287,7 +287,15 @@ class CORE_EXPORT QgsComposerItem: public QObject, public QGraphicsRectItem
     @note this method was added in version 1.2*/
     bool positionLock() const {return mItemPositionLocked;}
 
-    double rotation() const {return mRotation;}
+    /**Returns the rotation for the composer item
+    @note this method was added in version 2.1*/
+    double itemRotation() const {return mItemRotation;}
+
+    /**Returns the rotation for the composer item
+     * @deprecated Use itemRotation()
+     *             instead
+     */
+    double rotation() const {return mItemRotation;}
 
     /**Updates item, with the possibility to do custom update for subclasses*/
     virtual void updateItem() { QGraphicsRectItem::update(); }
@@ -306,7 +314,16 @@ class CORE_EXPORT QgsComposerItem: public QObject, public QGraphicsRectItem
     QString uuid() const { return mUuid; }
 
   public slots:
+    /**Sets the item rotation
+     * @deprecated Use setItemRotation( double rotation ) instead
+     */
     virtual void setRotation( double r );
+
+    /**Sets the item rotation
+      @note this method was added in version 2.1
+    */
+    virtual void setItemRotation( double r );
+
     void repaint();
 
   protected:
@@ -339,7 +356,7 @@ class CORE_EXPORT QgsComposerItem: public QObject, public QGraphicsRectItem
     mutable double mLastValidViewScaleFactor;
 
     /**Item rotation in degrees, clockwise*/
-    double mRotation;
+    double mItemRotation;
 
     /**Composition blend mode for item*/
     QPainter::CompositionMode mBlendMode;
@@ -384,12 +401,29 @@ class CORE_EXPORT QgsComposerItem: public QObject, public QGraphicsRectItem
     //some utility functions
 
     /**Calculates width and hight of the picture (in mm) such that it fits into the item frame with the given rotation*/
+    bool imageSizeConsideringRotation( double& width, double& height, double rotation ) const;
+    /**Calculates width and hight of the picture (in mm) such that it fits into the item frame with the given rotation
+     * @deprecated Use bool imageSizeConsideringRotation( double& width, double& height, double rotation )
+     * instead
+     */
     bool imageSizeConsideringRotation( double& width, double& height ) const;
+
     /**Calculates corner point after rotation and scaling*/
+    bool cornerPointOnRotatedAndScaledRect( double& x, double& y, double width, double height, double rotation ) const;
+    /**Calculates corner point after rotation and scaling
+     * @deprecated Use bool cornerPointOnRotatedAndScaledRect( double& x, double& y, double width, double height, double rotation )
+     * instead
+     */
     bool cornerPointOnRotatedAndScaledRect( double& x, double& y, double width, double height ) const;
 
-    /**Calculates width / height of the bounding box of a rotated rectangle (mRotation)*/
+    /**Calculates width / height of the bounding box of a rotated rectangle*/
+    void sizeChangedByRotation( double& width, double& height, double rotation );
+    /**Calculates width / height of the bounding box of a rotated rectangle
+    * @deprecated Use void sizeChangedByRotation( double& width, double& height, double rotation )
+    * instead
+    */
     void sizeChangedByRotation( double& width, double& height );
+
     /**Rotates a point / vector
         @param angle rotation angle in degrees, counterclockwise
         @param x in/out: x coordinate before / after the rotation
@@ -405,8 +439,8 @@ class CORE_EXPORT QgsComposerItem: public QObject, public QGraphicsRectItem
     void deleteAlignItems();
 
   signals:
-    /**Is emitted on rotation change to notify north arrow pictures*/
-    void rotationChanged( double newRotation );
+    /**Is emitted on item rotation change*/
+    void itemRotationChanged( double newRotation );
     /**Used e.g. by the item widgets to update the gui elements*/
     void itemChanged();
     /**Emitted if the rectangle changes*/

--- a/src/core/composer/qgscomposeritemcommand.h
+++ b/src/core/composer/qgscomposeritemcommand.h
@@ -74,7 +74,6 @@ class CORE_EXPORT QgsComposerMergeCommand: public QgsComposerItemCommand
       //composer label
       ComposerLabelSetText,
       ComposerLabelSetId,
-      ComposerLabelRotation,
       //composer map
       ComposerMapRotation,
       ComposerMapAnnotationDistance,
@@ -111,14 +110,15 @@ class CORE_EXPORT QgsComposerMergeCommand: public QgsComposerItemCommand
       TableMargin,
       TableGridStrokeWidth,
       //composer shape
-      ShapeRotation,
+      ShapeCornerRadius,
       ShapeOutlineWidth,
       //composer arrow
       ArrowOutlineWidth,
       ArrowHeadWidth,
       //item
       ItemOutlineWidth,
-      ItemMove
+      ItemMove,
+      ItemRotation
     };
 
     QgsComposerMergeCommand( Context c, QgsComposerItem* item, const QString& text );

--- a/src/core/composer/qgscomposeritemgroup.cpp
+++ b/src/core/composer/qgscomposeritemgroup.cpp
@@ -17,6 +17,7 @@
 
 #include "qgscomposeritemgroup.h"
 #include "qgscomposition.h"
+#include "qgslogger.h"
 
 #include <QPen>
 #include <QPainter>
@@ -59,40 +60,39 @@ void QgsComposerItemGroup::addItem( QgsComposerItem* item )
   item->setSelected( false );
   item->setFlag( QGraphicsItem::ItemIsSelectable, false ); //item in groups cannot be selected
 
-  //update extent (which is in scene coordinates)
-  double minXItem = item->pos().x();
-  double minYItem = item->pos().y();
-  double maxXItem = minXItem + item->rect().width();
-  double maxYItem = minYItem + item->rect().height();
-
-  if ( mSceneBoundingRectangle.isEmpty() ) //we add the first item
+  //update extent
+  if ( mBoundingRectangle.isEmpty() ) //we add the first item
   {
-    mSceneBoundingRectangle.setLeft( minXItem );
-    mSceneBoundingRectangle.setTop( minYItem );
-    mSceneBoundingRectangle.setRight( maxXItem );
-    mSceneBoundingRectangle.setBottom( maxYItem );
+    mBoundingRectangle = QRectF( 0, 0, item->rect().width(), item->rect().height() );
+    //call method of superclass to avoid repositioning of items
+    QgsComposerItem::setSceneRect( QRectF( item->pos().x(), item->pos().y(), item->rect().width(), item->rect().height() ) );
+
+    if ( item->itemRotation() != 0 )
+    {
+      setItemRotation( item->itemRotation() );
+    }
   }
   else
   {
-    if ( minXItem < mSceneBoundingRectangle.left() )
+    if ( item->itemRotation() != itemRotation() )
     {
-      mSceneBoundingRectangle.setLeft( minXItem );
+      //items have mixed rotation, so reset rotation of group
+      mBoundingRectangle = mapRectToScene( mBoundingRectangle );
+      setItemRotation( 0 );
+      mBoundingRectangle = mBoundingRectangle.united( item->mapRectToScene( item->rect() ) );
+      //call method of superclass to avoid repositioning of items
+      QgsComposerItem::setSceneRect( mBoundingRectangle );
     }
-    if ( minYItem < mSceneBoundingRectangle.top() )
+    else
     {
-      mSceneBoundingRectangle.setTop( minYItem );
-    }
-    if ( maxXItem > mSceneBoundingRectangle.right() )
-    {
-      mSceneBoundingRectangle.setRight( maxXItem );
-    }
-    if ( maxYItem > mSceneBoundingRectangle.bottom() )
-    {
-      mSceneBoundingRectangle.setBottom( maxYItem );
+      //items have same rotation, so keep rotation of group
+      mBoundingRectangle = mBoundingRectangle.united( mapRectFromItem( item, item->rect() ) );
+      QPointF newPos = mapToScene( mBoundingRectangle.topLeft().x(), mBoundingRectangle.topLeft().y() );
+      mBoundingRectangle = QRectF( 0, 0, mBoundingRectangle.width(), mBoundingRectangle.height() );
+      QgsComposerItem::setSceneRect( QRectF( newPos.x(), newPos.y(), mBoundingRectangle.width(), mBoundingRectangle.height() ) );
     }
   }
 
-  QgsComposerItem::setSceneRect( mSceneBoundingRectangle ); //call method of superclass to avoid repositioning of items
 }
 
 void QgsComposerItemGroup::removeItems()
@@ -124,38 +124,22 @@ void QgsComposerItemGroup::paint( QPainter * painter, const QStyleOptionGraphics
 
 void QgsComposerItemGroup::setSceneRect( const QRectF& rectangle )
 {
-  //calculate values between 0 and 1 for boundaries of all contained items, depending on their positions in the item group rectangle.
-  //then position the item boundaries in the new item group rect such that these values are the same
-  double xLeftCurrent = pos().x();
-  double xRightCurrent = xLeftCurrent + rect().width();
-  double yTopCurrent = pos().y();
-  double yBottomCurrent = yTopCurrent + rect().height();
-
-  double xItemLeft, xItemRight, yItemTop, yItemBottom;
-  double xItemLeftNew, xItemRightNew, yItemTopNew, yItemBottomNew;
-  double xParamLeft, xParamRight, yParamTop, yParamBottom;
-
+  //resize all items in this group
+  //first calculate new group rectangle in current group coordsys
+  QPointF newOrigin = mapFromScene( rectangle.topLeft() );
+  QRectF newRect = QRectF( newOrigin.x(), newOrigin.y(), rectangle.width(), rectangle.height() );
 
   QSet<QgsComposerItem*>::iterator item_it = mItems.begin();
   for ( ; item_it != mItems.end(); ++item_it )
   {
-    xItemLeft = ( *item_it )->pos().x();
-    xItemRight = xItemLeft + ( *item_it )->rect().width();
-    yItemTop = ( *item_it )->pos().y();
-    yItemBottom = yItemTop + ( *item_it )->rect().height();
+    //each item needs to be scaled relatively to the final size of the group
+    QRectF itemRect = mapRectFromItem(( *item_it ), ( *item_it )->rect() );
+    QgsComposition::relativeResizeRect( itemRect, rect(), newRect );
 
-    xParamLeft = ( xItemLeft - xLeftCurrent ) / ( xRightCurrent - xLeftCurrent );
-    xParamRight = ( xItemRight - xLeftCurrent ) / ( xRightCurrent - xLeftCurrent );
-    yParamTop = ( yItemTop - yTopCurrent ) / ( yBottomCurrent - yTopCurrent );
-    yParamBottom = ( yItemBottom - yTopCurrent ) / ( yBottomCurrent - yTopCurrent );
-
-    xItemLeftNew = xParamLeft * rectangle.right()  + ( 1 - xParamLeft ) * rectangle.left();
-    xItemRightNew = xParamRight * rectangle.right() + ( 1 - xParamRight ) * rectangle.left();
-    yItemTopNew = yParamTop * rectangle.bottom() + ( 1 - yParamTop ) * rectangle.top();
-    yItemBottomNew = yParamBottom * rectangle.bottom() + ( 1 - yParamBottom ) * rectangle.top();
-
-    ( *item_it )->setSceneRect( QRectF( xItemLeftNew, yItemTopNew, xItemRightNew - xItemLeftNew, yItemBottomNew - yItemTopNew ) );
+    QPointF newPos = mapToScene( itemRect.topLeft() );
+    ( *item_it )->setSceneRect( QRectF( newPos.x(), newPos.y(), itemRect.width(), itemRect.height() ) );
   }
+  //lastly, set new rect for group
   QgsComposerItem::setSceneRect( rectangle );
 }
 

--- a/src/core/composer/qgscomposeritemgroup.h
+++ b/src/core/composer/qgscomposeritemgroup.h
@@ -67,5 +67,5 @@ class CORE_EXPORT QgsComposerItemGroup: public QgsComposerItem
 
   private:
     QSet<QgsComposerItem*> mItems;
-    QRectF mSceneBoundingRectangle;
+    QRectF mBoundingRectangle;
 };

--- a/src/core/composer/qgscomposerlabel.cpp
+++ b/src/core/composer/qgscomposerlabel.cpp
@@ -66,7 +66,7 @@ void QgsComposerLabel::paint( QPainter* painter, const QStyleOptionGraphicsItem*
   double penWidth = pen().widthF();
   QRectF painterRect( penWidth + mMargin, penWidth + mMargin, mTextBoxWidth - 2 * penWidth - 2 * mMargin, mTextBoxHeight - 2 * penWidth - 2 * mMargin );
   painter->translate( rect().width() / 2.0, rect().height() / 2.0 );
-  painter->rotate( mRotation );
+  painter->rotate( mItemRotation );
   painter->translate( -mTextBoxWidth / 2.0, -mTextBoxHeight / 2.0 );
 
   if ( mHtmlState )
@@ -247,9 +247,15 @@ QFont QgsComposerLabel::font() const
 
 void QgsComposerLabel::setRotation( double r )
 {
+  //kept for api compatibility with QGIS 2.0
+  setItemRotation( r );
+}
+
+void QgsComposerLabel::setItemRotation( double r )
+{
   double width = mTextBoxWidth;
   double height = mTextBoxHeight;
-  QgsComposerItem::setRotation( r );
+  QgsComposerItem::setItemRotation( r );
   sizeChangedByRotation( width, height );
 
   double x = pos().x() + rect().width() / 2.0 - width / 2.0;
@@ -359,6 +365,14 @@ bool QgsComposerLabel::readXML( const QDomElement& itemElem, const QDomDocument&
   if ( composerItemList.size() > 0 )
   {
     QDomElement composerItemElem = composerItemList.at( 0 ).toElement();
+
+    //rotation
+    if ( composerItemElem.attribute( "rotation", "0" ).toDouble() != 0 )
+    {
+      //check for old (pre 2.1) rotation attribute
+      mItemRotation = composerItemElem.attribute( "rotation", "0" ).toDouble();
+    }
+
     _readXML( composerItemElem, doc );
   }
   emit itemChanged();
@@ -373,7 +387,7 @@ void QgsComposerLabel::itemShiftAdjustSize( double newWidth, double newHeight, d
   xShift = 0;
   yShift = 0;
 
-  if ( mRotation >= 0 && mRotation < 90 )
+  if ( mItemRotation >= 0 && mItemRotation < 90 )
   {
     if ( mHAlignment == Qt::AlignHCenter )
     {
@@ -392,7 +406,7 @@ void QgsComposerLabel::itemShiftAdjustSize( double newWidth, double newHeight, d
       yShift = - ( newHeight - currentHeight );
     }
   }
-  if ( mRotation >= 90 && mRotation < 180 )
+  if ( mItemRotation >= 90 && mItemRotation < 180 )
   {
     if ( mHAlignment == Qt::AlignHCenter )
     {
@@ -411,7 +425,7 @@ void QgsComposerLabel::itemShiftAdjustSize( double newWidth, double newHeight, d
       xShift = -( newWidth - currentWidth / 2.0 );
     }
   }
-  else if ( mRotation >= 180 && mRotation < 270 )
+  else if ( mItemRotation >= 180 && mItemRotation < 270 )
   {
     if ( mHAlignment == Qt::AlignHCenter )
     {
@@ -430,7 +444,7 @@ void QgsComposerLabel::itemShiftAdjustSize( double newWidth, double newHeight, d
       yShift = ( newHeight - currentHeight );
     }
   }
-  else if ( mRotation >= 270 && mRotation < 360 )
+  else if ( mItemRotation >= 270 && mItemRotation < 360 )
   {
     if ( mHAlignment == Qt::AlignHCenter )
     {

--- a/src/core/composer/qgscomposerlabel.cpp
+++ b/src/core/composer/qgscomposerlabel.cpp
@@ -64,7 +64,7 @@ void QgsComposerLabel::paint( QPainter* painter, const QStyleOptionGraphicsItem*
   painter->save();
 
   double penWidth = pen().widthF();
-  QRectF painterRect( penWidth + mMargin, penWidth + mMargin, mTextBoxWidth - 2 * penWidth - 2 * mMargin, mTextBoxHeight - 2 * penWidth - 2 * mMargin );
+  QRectF painterRect( penWidth + mMargin, penWidth + mMargin, rect().width() - 2 * penWidth - 2 * mMargin, rect().height() - 2 * penWidth - 2 * mMargin );
 
   if ( mHtmlState )
   {
@@ -221,20 +221,15 @@ void QgsComposerLabel::adjustSizeToText()
   double textWidth = textWidthMillimeters( mFont, displayText() );
   double fontAscent = fontAscentMillimeters( mFont );
 
-  mTextBoxWidth = textWidth + 2 * mMargin + 2 * pen().widthF() + 1;
-  mTextBoxHeight = fontAscent + 2 * mMargin + 2 * pen().widthF() + 1;
-
-  double width = mTextBoxWidth;
-  double height = mTextBoxHeight;
-
-  sizeChangedByRotation( width, height );
+  double width = textWidth + 2 * mMargin + 2 * pen().widthF() + 1;
+  double height = fontAscent + 2 * mMargin + 2 * pen().widthF() + 1;
 
   //keep alignment point constant
   double xShift = 0;
   double yShift = 0;
   itemShiftAdjustSize( width, height, xShift, yShift );
 
-  QgsComposerItem::setSceneRect( QRectF( pos().x() + xShift, pos().y() + yShift, width, height ) );
+  setSceneRect( QRectF( pos().x() + xShift, pos().y() + yShift, width, height ) );
 }
 
 QFont QgsComposerLabel::font() const

--- a/src/core/composer/qgscomposerlabel.cpp
+++ b/src/core/composer/qgscomposerlabel.cpp
@@ -65,9 +65,6 @@ void QgsComposerLabel::paint( QPainter* painter, const QStyleOptionGraphicsItem*
 
   double penWidth = pen().widthF();
   QRectF painterRect( penWidth + mMargin, penWidth + mMargin, mTextBoxWidth - 2 * penWidth - 2 * mMargin, mTextBoxHeight - 2 * penWidth - 2 * mMargin );
-  painter->translate( rect().width() / 2.0, rect().height() / 2.0 );
-  painter->rotate( mItemRotation );
-  painter->translate( -mTextBoxWidth / 2.0, -mTextBoxHeight / 2.0 );
 
   if ( mHtmlState )
   {
@@ -245,37 +242,6 @@ QFont QgsComposerLabel::font() const
   return mFont;
 }
 
-void QgsComposerLabel::setRotation( double r )
-{
-  //kept for api compatibility with QGIS 2.0
-  setItemRotation( r );
-}
-
-void QgsComposerLabel::setItemRotation( double r )
-{
-  double width = mTextBoxWidth;
-  double height = mTextBoxHeight;
-  QgsComposerItem::setItemRotation( r );
-  sizeChangedByRotation( width, height );
-
-  double x = pos().x() + rect().width() / 2.0 - width / 2.0;
-  double y = pos().y() + rect().height() / 2.0 - height / 2.0;
-  QgsComposerItem::setSceneRect( QRectF( x, y, width, height ) );
-}
-
-void QgsComposerLabel::setSceneRect( const QRectF& rectangle )
-{
-  if ( rectangle.width() != rect().width() || rectangle.height() != rect().height() )
-  {
-    double textBoxWidth = rectangle.width();
-    double textBoxHeight = rectangle.height();
-    imageSizeConsideringRotation( textBoxWidth, textBoxHeight );
-    mTextBoxWidth = textBoxWidth;
-    mTextBoxHeight = textBoxHeight;
-  }
-  QgsComposerItem::setSceneRect( rectangle );
-}
-
 bool QgsComposerLabel::writeXML( QDomElement& elem, QDomDocument & doc ) const
 {
   QString alignment;
@@ -370,7 +336,7 @@ bool QgsComposerLabel::readXML( const QDomElement& itemElem, const QDomDocument&
     if ( composerItemElem.attribute( "rotation", "0" ).toDouble() != 0 )
     {
       //check for old (pre 2.1) rotation attribute
-      mItemRotation = composerItemElem.attribute( "rotation", "0" ).toDouble();
+      setItemRotation( composerItemElem.attribute( "rotation", "0" ).toDouble() );
     }
 
     _readXML( composerItemElem, doc );

--- a/src/core/composer/qgscomposerlabel.h
+++ b/src/core/composer/qgscomposerlabel.h
@@ -133,11 +133,6 @@ class CORE_EXPORT QgsComposerLabel: public QgsComposerItem
     /**Replaces replace '$CURRENT_DATE<(FORMAT)>' with the current date (e.g. $CURRENT_DATE(d 'June' yyyy)*/
     void replaceDateText( QString& text ) const;
 
-    /**Width of the text box. This is different to rectangle().width() in case there is rotation*/
-    double mTextBoxWidth;
-    /**Height of the text box. This is different to rectangle().height() in case there is rotation*/
-    double mTextBoxHeight;
-
     QgsFeature* mExpressionFeature;
     QgsVectorLayer* mExpressionLayer;
     QMap<QString, QVariant> mSubstitutions;

--- a/src/core/composer/qgscomposerlabel.h
+++ b/src/core/composer/qgscomposerlabel.h
@@ -87,8 +87,6 @@ class CORE_EXPORT QgsComposerLabel: public QgsComposerItem
         @note: this function was added in version 1.4*/
     QColor fontColor() const {return mFontColor;}
 
-    void setSceneRect( const QRectF& rectangle );
-
     /** stores state in Dom element
        * @param elem is Dom element corresponding to 'Composer' tag
        * @param doc document
@@ -100,15 +98,6 @@ class CORE_EXPORT QgsComposerLabel: public QgsComposerItem
        * @param doc document
        */
     bool readXML( const QDomElement& itemElem, const QDomDocument& doc );
-
-  public slots:
-    /* Sets rotation for the label
-     * @deprecated Use setItemRotation( double rotation ) instead
-     */
-    virtual void setRotation( double r );
-
-    /* Sets rotation for the label */
-    virtual void setItemRotation( double r );
 
   private slots:
     void loadingHtmlFinished( bool );

--- a/src/core/composer/qgscomposerlabel.h
+++ b/src/core/composer/qgscomposerlabel.h
@@ -102,7 +102,13 @@ class CORE_EXPORT QgsComposerLabel: public QgsComposerItem
     bool readXML( const QDomElement& itemElem, const QDomDocument& doc );
 
   public slots:
+    /* Sets rotation for the label
+     * @deprecated Use setItemRotation( double rotation ) instead
+     */
     virtual void setRotation( double r );
+
+    /* Sets rotation for the label */
+    virtual void setItemRotation( double r );
 
   private slots:
     void loadingHtmlFinished( bool );

--- a/src/core/composer/qgscomposermap.cpp
+++ b/src/core/composer/qgscomposermap.cpp
@@ -40,7 +40,7 @@
 #include <cmath>
 
 QgsComposerMap::QgsComposerMap( QgsComposition *composition, int x, int y, int width, int height )
-    : QgsComposerItem( x, y, width, height, composition ), mKeepLayerSet( false ),
+    : QgsComposerItem( x, y, width, height, composition ), mMapRotation( 0 ), mKeepLayerSet( false ),
     mOverviewFrameMapId( -1 ), mOverviewBlendMode( QPainter::CompositionMode_SourceOver ), mOverviewInverted( false ), mOverviewCentered( false ),
     mGridEnabled( false ), mGridStyle( Solid ),
     mGridIntervalX( 0.0 ), mGridIntervalY( 0.0 ), mGridOffsetX( 0.0 ), mGridOffsetY( 0.0 ), mGridAnnotationFontColor( QColor( 0, 0, 0 ) ),
@@ -94,7 +94,7 @@ QgsComposerMap::QgsComposerMap( QgsComposition *composition, int x, int y, int w
 }
 
 QgsComposerMap::QgsComposerMap( QgsComposition *composition )
-    : QgsComposerItem( 0, 0, 10, 10, composition ), mKeepLayerSet( false ), mOverviewFrameMapId( -1 ),
+    : QgsComposerItem( 0, 0, 10, 10, composition ), mMapRotation( 0 ), mKeepLayerSet( false ), mOverviewFrameMapId( -1 ),
     mOverviewBlendMode( QPainter::CompositionMode_SourceOver ), mOverviewInverted( false ), mOverviewCentered( false ),
     mGridEnabled( false ), mGridStyle( Solid ),
     mGridIntervalX( 0.0 ), mGridIntervalY( 0.0 ), mGridOffsetX( 0.0 ), mGridOffsetY( 0.0 ), mGridAnnotationFontColor( QColor( 0, 0, 0 ) ),
@@ -355,7 +355,7 @@ void QgsComposerMap::paint( QPainter* painter, const QStyleOptionGraphicsItem* i
 
     painter->translate( mXOffset, mYOffset );
     painter->translate( xTopLeftShift, yTopLeftShift );
-    painter->rotate( mRotation );
+    painter->rotate( mMapRotation );
     painter->translate( xShiftMM, -yShiftMM );
     painter->scale( scale, scale );
     painter->drawImage( 0, 0, mCacheImage );
@@ -404,7 +404,7 @@ void QgsComposerMap::paint( QPainter* painter, const QStyleOptionGraphicsItem* i
     painter->save();
     painter->translate( mXOffset, mYOffset );
     painter->translate( xTopLeftShift, yTopLeftShift );
-    painter->rotate( mRotation );
+    painter->rotate( mMapRotation );
     painter->translate( xShiftMM, -yShiftMM );
     draw( painter, requestRectangle, theSize, 25.4 ); //scene coordinates seem to be in mm
 
@@ -625,11 +625,18 @@ void QgsComposerMap::setOffset( double xOffset, double yOffset )
   mYOffset = yOffset;
 }
 
+void QgsComposerMap::setRotation( double r )
+{
+  //kept for api compatibility with QGIS 2.0
+  setMapRotation( r );
+}
+
 void QgsComposerMap::setMapRotation( double r )
 {
-  setRotation( r );
-  emit rotationChanged( r );
+  mMapRotation = r;
+  emit mapRotationChanged( r );
   emit itemChanged();
+  update();
 }
 
 void QgsComposerMap::updateItem()
@@ -813,6 +820,9 @@ bool QgsComposerMap::writeXML( QDomElement& elem, QDomDocument & doc ) const
   extentElem.setAttribute( "ymax", qgsDoubleToString( mExtent.yMaximum() ) );
   composerMapElem.appendChild( extentElem );
 
+  //map rotation
+  composerMapElem.setAttribute( "mapRotation",  QString::number( mMapRotation ) );
+
   //layer set
   QDomElement layerSetElem = doc.createElement( "LayerSet" );
   QStringList::const_iterator layerIt = mLayerSet.constBegin();
@@ -948,6 +958,12 @@ bool QgsComposerMap::readXML( const QDomElement& itemElem, const QDomDocument& d
     mExtent = QgsRectangle( xmin, ymin, xmax, ymax );
   }
 
+  //map rotation
+  if ( itemElem.attribute( "mapRotation", "0" ).toDouble() != 0 )
+  {
+    mMapRotation = itemElem.attribute( "mapRotation", "0" ).toDouble();
+  }
+
   //mKeepLayerSet flag
   QString keepLayerSetFlag = itemElem.attribute( "keepLayerSet" );
   if ( keepLayerSetFlag.compare( "true", Qt::CaseInsensitive ) == 0 )
@@ -1060,6 +1076,13 @@ bool QgsComposerMap::readXML( const QDomElement& itemElem, const QDomDocument& d
   if ( composerItemList.size() > 0 )
   {
     QDomElement composerItemElem = composerItemList.at( 0 ).toElement();
+
+    if ( composerItemElem.attribute( "rotation", "0" ).toDouble() != 0 )
+    {
+      //in versions prior to 2.1 map rotation was stored in the rotation attribute
+      mMapRotation = composerItemElem.attribute( "rotation", "0" ).toDouble();
+    }
+
     _readXML( composerItemElem, doc );
   }
 
@@ -1531,7 +1554,7 @@ int QgsComposerMap::xGridLines( QList< QPair< double, QLineF > >& lines ) const
   double roundCorrection = mapBoundingRect.top() > 0 ? 1.0 : 0.0;
   double currentLevel = ( int )(( mapBoundingRect.top() - mGridOffsetY ) / mGridIntervalY + roundCorrection ) * mGridIntervalY + mGridOffsetY;
 
-  if ( qgsDoubleNear( mRotation, 0.0 ) )
+  if ( qgsDoubleNear( mMapRotation, 0.0 ) )
   {
     //no rotation. Do it 'the easy way'
 
@@ -1599,7 +1622,7 @@ int QgsComposerMap::yGridLines( QList< QPair< double, QLineF > >& lines ) const
   double roundCorrection = mapBoundingRect.left() > 0 ? 1.0 : 0.0;
   double currentLevel = ( int )(( mapBoundingRect.left() - mGridOffsetX ) / mGridIntervalX + roundCorrection ) * mGridIntervalX + mGridOffsetX;
 
-  if ( qgsDoubleNear( mRotation, 0.0 ) )
+  if ( qgsDoubleNear( mMapRotation, 0.0 ) )
   {
     //no rotation. Do it 'the easy way'
     double xCanvasCoord;
@@ -1782,7 +1805,7 @@ double QgsComposerMap::maxExtension() const
 void QgsComposerMap::mapPolygon( const QgsRectangle& extent, QPolygonF& poly ) const
 {
   poly.clear();
-  if ( mRotation == 0 )
+  if ( mMapRotation == 0 )
   {
     poly << QPointF( extent.xMinimum(), extent.yMaximum() );
     poly << QPointF( extent.xMaximum(), extent.yMaximum() );
@@ -1798,25 +1821,25 @@ void QgsComposerMap::mapPolygon( const QgsRectangle& extent, QPolygonF& poly ) c
   //top left point
   dx = rotationPoint.x() - extent.xMinimum();
   dy = rotationPoint.y() - extent.yMaximum();
-  rotate( mRotation, dx, dy );
+  rotate( mMapRotation, dx, dy );
   poly << QPointF( rotationPoint.x() + dx, rotationPoint.y() + dy );
 
   //top right point
   dx = rotationPoint.x() - extent.xMaximum();
   dy = rotationPoint.y() - extent.yMaximum();
-  rotate( mRotation, dx, dy );
+  rotate( mMapRotation, dx, dy );
   poly << QPointF( rotationPoint.x() + dx, rotationPoint.y() + dy );
 
   //bottom right point
   dx = rotationPoint.x() - extent.xMaximum();
   dy = rotationPoint.y() - extent.yMinimum();
-  rotate( mRotation, dx, dy );
+  rotate( mMapRotation, dx, dy );
   poly << QPointF( rotationPoint.x() + dx, rotationPoint.y() + dy );
 
   //bottom left point
   dx = rotationPoint.x() - extent.xMinimum();
   dy = rotationPoint.y() - extent.yMinimum();
-  rotate( mRotation, dx, dy );
+  rotate( mMapRotation, dx, dy );
   poly << QPointF( rotationPoint.x() + dx, rotationPoint.y() + dy );
 }
 
@@ -1829,7 +1852,7 @@ void QgsComposerMap::requestedExtent( QgsRectangle& extent ) const
 {
   QgsRectangle newExtent;
   extentCenteredOnOverview( newExtent );
-  if ( mRotation == 0 )
+  if ( mMapRotation == 0 )
   {
     extent = newExtent;
   }
@@ -1913,7 +1936,7 @@ void QgsComposerMap::transformShift( double& xShift, double& yShift ) const
   double dxScaled = xShift * mmToMapUnits;
   double dyScaled = - yShift * mmToMapUnits;
 
-  rotate( mRotation, dxScaled, dyScaled );
+  rotate( mMapRotation, dxScaled, dyScaled );
 
   xShift = dxScaled;
   yShift = dyScaled;
@@ -1931,7 +1954,7 @@ QPointF QgsComposerMap::mapToItemCoords( const QPointF& mapCoords ) const
   QgsPoint rotationPoint(( tExtent.xMaximum() + tExtent.xMinimum() ) / 2.0, ( tExtent.yMaximum() + tExtent.yMinimum() ) / 2.0 );
   double dx = mapCoords.x() - rotationPoint.x();
   double dy = mapCoords.y() - rotationPoint.y();
-  rotate( -mRotation, dx, dy );
+  rotate( -mMapRotation, dx, dy );
   QgsPoint backRotatedCoords( rotationPoint.x() + dx, rotationPoint.y() + dy );
 
   QgsRectangle unrotatedExtent = transformedExtent();
@@ -2312,4 +2335,22 @@ void QgsComposerMap::assignFreeId()
     }
   }
   mId = maxId + 1;
+}
+
+bool QgsComposerMap::imageSizeConsideringRotation( double& width, double& height ) const
+{
+  //kept for api compatibility with QGIS 2.0 - use mMapRotation
+  return QgsComposerItem::imageSizeConsideringRotation( width, height, mMapRotation );
+}
+
+bool QgsComposerMap::cornerPointOnRotatedAndScaledRect( double& x, double& y, double width, double height ) const
+{
+  //kept for api compatibility with QGIS 2.0 - use mMapRotation
+  return QgsComposerItem::cornerPointOnRotatedAndScaledRect( x, y, width, height, mMapRotation );
+}
+
+void QgsComposerMap::sizeChangedByRotation( double& width, double& height )
+{
+  //kept for api compatibility with QGIS 2.0 - use mMapRotation
+  return QgsComposerItem::sizeChangedByRotation( width, height, mMapRotation );
 }

--- a/src/core/composer/qgscomposermap.h
+++ b/src/core/composer/qgscomposermap.h
@@ -299,7 +299,22 @@ class CORE_EXPORT QgsComposerMap : public QgsComposerItem
     void setCrossLength( double l ) {mCrossLength = l;}
     double crossLength() {return mCrossLength;}
 
+    /**Sets rotation for the map - this does not affect the composer item shape, only the
+      way the map is drawn within the item
+     * @deprecated Use setMapRotation( double rotation ) instead
+     */
+    void setRotation( double r );
+    /**Returns the rotation used for drawing the map within the composer item
+     * @deprecated Use mapRotation() instead
+     */
+    double rotation() const { return mMapRotation;};
+
+    /**Sets rotation for the map - this does not affect the composer item shape, only the
+      way the map is drawn within the item
+      @note this function was added in version 2.1*/
     void setMapRotation( double r );
+    /**Returns the rotation used for drawing the map within the composer item*/
+    double mapRotation() const { return mMapRotation;};
 
     void updateItem();
 
@@ -349,8 +364,27 @@ class CORE_EXPORT QgsComposerMap : public QgsComposerItem
         Usually, this function is called before adding the composer map to the composition*/
     void assignFreeId();
 
+    /**Calculates width and hight of the picture (in mm) such that it fits into the item frame with the given rotation
+     * @deprecated Use bool QgsComposerItem::imageSizeConsideringRotation( double& width, double& height, double rotation )
+     * instead
+     */
+    bool imageSizeConsideringRotation( double& width, double& height ) const;
+    /**Calculates corner point after rotation and scaling
+     * @deprecated Use QgsComposerItem::cornerPointOnRotatedAndScaledRect( double& x, double& y, double width, double height, double rotation )
+     * instead
+     */
+    bool cornerPointOnRotatedAndScaledRect( double& x, double& y, double width, double height ) const;
+    /**Calculates width / height of the bounding box of a rotated rectangle
+    * @deprecated Use QgsComposerItem::sizeChangedByRotation( double& width, double& height, double rotation )
+    * instead
+    */
+    void sizeChangedByRotation( double& width, double& height );
+
   signals:
     void extentChanged();
+
+    /**Is emitted on rotation change to notify north arrow pictures*/
+    void mapRotationChanged( double newRotation );
 
   public slots:
 
@@ -398,6 +432,9 @@ class CORE_EXPORT QgsComposerMap : public QgsComposerItem
     double mXOffset;
     /**Offset in y direction for showing map cache image*/
     double mYOffset;
+
+    /**Map rotation*/
+    double mMapRotation;
 
     /**Flag if layers to be displayed should be read from qgis canvas (true) or from stored list in mLayerSet (false)*/
     bool mKeepLayerSet;

--- a/src/core/composer/qgscomposermousehandles.cpp
+++ b/src/core/composer/qgscomposermousehandles.cpp
@@ -31,6 +31,8 @@ QgsComposerMouseHandles::QgsComposerMouseHandles( QgsComposition *composition ) 
     mGraphicsView( 0 ),
     mBeginHandleWidth( 0 ),
     mBeginHandleHeight( 0 ),
+    mResizeMoveX( 0 ),
+    mResizeMoveY( 0 ),
     mIsDragging( false ),
     mIsResizing( false ),
     mHAlignSnapItem( 0 ),
@@ -144,29 +146,42 @@ void QgsComposerMouseHandles::drawSelectedItemBounds( QPainter* painter )
   QList<QgsComposerItem*>::iterator itemIter = selectedItems.begin();
   for ( ; itemIter != selectedItems.end(); ++itemIter )
   {
-    //scene bounds of selected item
-    QRectF itemSceneBounds = ( *itemIter )->sceneBoundingRect();
-    //convert scene bounds to handle item bounds
-    QRectF itemBounds;
+    //get bounds of selected item
+    QPolygonF itemBounds;
     if ( mIsDragging && !( *itemIter )->positionLock() )
     {
       //if currently dragging, draw selected item bounds relative to current mouse position
-      itemBounds = mapRectFromScene( itemSceneBounds );
-      itemBounds.translate( transform().dx(), transform().dy() );
+      //first, get bounds of current item in scene coordinates
+      QPolygonF itemSceneBounds = ( *itemIter )->mapToScene(( *itemIter )->rect() );
+      //now, translate it by the current movement amount
+      //IMPORTANT - this is done in scene coordinates, since we don't want any rotation/non-translation transforms to affect the movement
+      itemSceneBounds.translate( transform().dx(), transform().dy() );
+      //finally, remap it to the mouse handle item's coordinate system so it's ready for drawing
+      itemBounds = mapFromScene( itemSceneBounds );
     }
     else if ( mIsResizing && !( *itemIter )->positionLock() )
     {
       //if currently resizing, calculate relative resize of this item
-      itemBounds = itemSceneBounds;
-      relativeResizeRect( itemBounds, QRectF( mBeginHandlePos.x(), mBeginHandlePos.y(), mBeginHandleWidth, mBeginHandleHeight ), mResizeRect );
-      itemBounds = mapRectFromScene( itemBounds );
+      if ( selectedItems.size() > 1 )
+      {
+        //get item bounds in mouse handle item's coordinate system
+        QRectF itemRect = mapRectFromItem(( *itemIter ), ( *itemIter )->rect() );
+        //now, resize it relative to the current resized dimensions of the mouse handles
+        relativeResizeRect( itemRect, QRectF( -mResizeMoveX, -mResizeMoveY, mBeginHandleWidth, mBeginHandleHeight ), mResizeRect );
+        itemBounds = QPolygonF( itemRect );
+      }
+      else
+      {
+        //single item selected
+        itemBounds = rect();
+      }
     }
     else
     {
       //not resizing or moving, so just map from scene bounds
-      itemBounds = mapRectFromScene( itemSceneBounds );
+      itemBounds = mapRectFromItem(( *itemIter ), ( *itemIter )->rect() );
     }
-    painter->drawRect( itemBounds );
+    painter->drawPolygon( itemBounds );
   }
   painter->restore();
 }
@@ -184,6 +199,7 @@ void QgsComposerMouseHandles::selectionChanged()
       if ( item->selected() )
       {
         QObject::connect( item, SIGNAL( sizeChanged() ), this, SLOT( selectedItemSizeChanged() ) );
+        QObject::connect( item, SIGNAL( itemRotationChanged( double ) ), this, SLOT( selectedItemRotationChanged() ) );
       }
       else
       {
@@ -205,6 +221,15 @@ void QgsComposerMouseHandles::selectedItemSizeChanged()
   }
 }
 
+void QgsComposerMouseHandles::selectedItemRotationChanged()
+{
+  if ( !mIsDragging && !mIsResizing )
+  {
+    //only required for non-mouse initiated rotation changes
+    updateHandles();
+  }
+}
+
 void QgsComposerMouseHandles::updateHandles()
 {
   //recalculate size and position of handle item
@@ -214,10 +239,27 @@ void QgsComposerMouseHandles::updateHandles()
   if ( selectedItems.size() > 0 )
   {
     //one or more items are selected, get bounds of all selected items
+
+    //update rotation of handle object
+    double rotation;
+    if ( selectionRotation( rotation ) )
+    {
+      //all items share a common rotation value, so we rotate the mouse handles to match
+      setRotation( rotation );
+    }
+    else
+    {
+      //items have varying rotation values - we can't rotate the mouse handles to match
+      setRotation( 0 );
+    }
+
+    //get bounds of all selected items
     QRectF newHandleBounds = selectionBounds();
+
     //update size and position of handle object
     setRect( 0, 0, newHandleBounds.width(), newHandleBounds.height() );
-    setPos( newHandleBounds.topLeft() );
+    setPos( mapToScene( newHandleBounds.topLeft() ) );
+
     show();
   }
   else
@@ -231,20 +273,44 @@ void QgsComposerMouseHandles::updateHandles()
 
 QRectF QgsComposerMouseHandles::selectionBounds() const
 {
-  //calculate scene bounds of all currently selected items
+  //calculate bounds of all currently selected items in mouse handle coordinate system
   QList<QgsComposerItem*> selectedItems = mComposition->selectedComposerItems();
   QList<QgsComposerItem*>::iterator itemIter = selectedItems.begin();
 
-  //start with scene bounds of first selected item
-  QRectF bounds = ( *itemIter )->sceneBoundingRect();
+  //start with handle bounds of first selected item
+  QRectF bounds = mapFromItem(( *itemIter ), ( *itemIter )->rect() ).boundingRect();
 
   //iterate through remaining items, expanding the bounds as required
   for ( ++itemIter; itemIter != selectedItems.end(); ++itemIter )
   {
-    bounds = bounds.united(( *itemIter )->sceneBoundingRect() );
+    bounds = bounds.united( mapFromItem(( *itemIter ), ( *itemIter )->rect() ).boundingRect() );
   }
 
   return bounds;
+}
+
+bool QgsComposerMouseHandles::selectionRotation( double & rotation ) const
+{
+  //check if all selected items have same rotation
+  QList<QgsComposerItem*> selectedItems = mComposition->selectedComposerItems();
+  QList<QgsComposerItem*>::iterator itemIter = selectedItems.begin();
+
+  //start with rotation of first selected item
+  double firstItemRotation = ( *itemIter )->itemRotation();
+
+  //iterate through remaining items, checking if they have same rotation
+  for ( ++itemIter; itemIter != selectedItems.end(); ++itemIter )
+  {
+    if (( *itemIter )->itemRotation() != firstItemRotation )
+    {
+      //item has a different rotation, so return false
+      return false;
+    }
+  }
+
+  //all items have the same rotation, so set the rotation variable and return true
+  rotation = firstItemRotation;
+  return true;
 }
 
 double QgsComposerMouseHandles::rectHandlerBorderTolerance()
@@ -279,16 +345,81 @@ Qt::CursorShape QgsComposerMouseHandles::cursorForPosition( const QPointF& itemC
       return Qt::SizeAllCursor;
     case ResizeUp:
     case ResizeDown:
-      return Qt::SizeVerCursor;
+      //account for rotation
+      if (( rotation() <= 22.5 || rotation() >= 337.5 ) || ( rotation() >= 157.5 && rotation() <= 202.5 ) )
+      {
+        return Qt::SizeVerCursor;
+      }
+      else if (( rotation() >= 22.5 && rotation() <= 67.5 ) || ( rotation() >= 202.5 && rotation() <= 247.5 ) )
+      {
+        return Qt::SizeBDiagCursor;
+      }
+      else if (( rotation() >= 67.5 && rotation() <= 112.5 ) || ( rotation() >= 247.5 && rotation() <= 292.5 ) )
+      {
+        return Qt::SizeHorCursor;
+      }
+      else
+      {
+        return Qt::SizeFDiagCursor;
+      }
     case ResizeLeft:
     case ResizeRight:
-      return Qt::SizeHorCursor;
+      //account for rotation
+      if (( rotation() <= 22.5 || rotation() >= 337.5 ) || ( rotation() >= 157.5 && rotation() <= 202.5 ) )
+      {
+        return Qt::SizeHorCursor;
+      }
+      else if (( rotation() >= 22.5 && rotation() <= 67.5 ) || ( rotation() >= 202.5 && rotation() <= 247.5 ) )
+      {
+        return Qt::SizeFDiagCursor;
+      }
+      else if (( rotation() >= 67.5 && rotation() <= 112.5 ) || ( rotation() >= 247.5 && rotation() <= 292.5 ) )
+      {
+        return Qt::SizeVerCursor;
+      }
+      else
+      {
+        return Qt::SizeBDiagCursor;
+      }
+
     case ResizeLeftUp:
     case ResizeRightDown:
-      return Qt::SizeFDiagCursor;
+      //account for rotation
+      if (( rotation() <= 22.5 || rotation() >= 337.5 ) || ( rotation() >= 157.5 && rotation() <= 202.5 ) )
+      {
+        return Qt::SizeFDiagCursor;
+      }
+      else if (( rotation() >= 22.5 && rotation() <= 67.5 ) || ( rotation() >= 202.5 && rotation() <= 247.5 ) )
+      {
+        return Qt::SizeVerCursor;
+      }
+      else if (( rotation() >= 67.5 && rotation() <= 112.5 ) || ( rotation() >= 247.5 && rotation() <= 292.5 ) )
+      {
+        return Qt::SizeBDiagCursor;
+      }
+      else
+      {
+        return Qt::SizeHorCursor;
+      }
     case ResizeRightUp:
     case ResizeLeftDown:
-      return Qt::SizeBDiagCursor;
+      //account for rotation
+      if (( rotation() <= 22.5 || rotation() >= 337.5 ) || ( rotation() >= 157.5 && rotation() <= 202.5 ) )
+      {
+        return Qt::SizeBDiagCursor;
+      }
+      else if (( rotation() >= 22.5 && rotation() <= 67.5 ) || ( rotation() >= 202.5 && rotation() <= 247.5 ) )
+      {
+        return Qt::SizeHorCursor;
+      }
+      else if (( rotation() >= 67.5 && rotation() <= 112.5 ) || ( rotation() >= 247.5 && rotation() <= 292.5 ) )
+      {
+        return Qt::SizeFDiagCursor;
+      }
+      else
+      {
+        return Qt::SizeVerCursor;
+      }
     case SelectItem:
     default:
       return Qt::ArrowCursor;
@@ -491,9 +622,24 @@ void QgsComposerMouseHandles::mouseReleaseEvent( QGraphicsSceneMouseEvent* event
       }
       QgsComposerItemCommand* subcommand = new QgsComposerItemCommand( *itemIter, "", parentCommand );
       subcommand->savePreviousState();
-      QRectF itemBounds = ( *itemIter )->sceneBoundingRect();
-      relativeResizeRect( itemBounds, QRectF( mBeginHandlePos.x(), mBeginHandlePos.y(), mBeginHandleWidth, mBeginHandleHeight ), mResizeRect );
-      ( *itemIter )->setSceneRect( itemBounds );
+
+      QRectF itemRect;
+      if ( selectedItems.size() == 1 )
+      {
+        //only a single item is selected, so set it's size to the final resized mouse handle size
+        itemRect = mResizeRect;
+      }
+      else
+      {
+        //multiple items selected, so each needs to be scaled relatively to the final size of the mouse handles
+        itemRect = mapRectFromItem(( *itemIter ), ( *itemIter )->rect() );
+        relativeResizeRect( itemRect, QRectF( -mResizeMoveX, -mResizeMoveY, mBeginHandleWidth, mBeginHandleHeight ), mResizeRect );
+      }
+
+      itemRect = itemRect.normalized();
+      QPointF newPos = mapToScene( itemRect.topLeft() );
+      ( *itemIter )->setItemPosition( newPos.x(), newPos.y(), itemRect.width(), itemRect.height() );
+
       subcommand->saveAfterState();
     }
     mComposition->undoStack()->push( parentCommand );
@@ -564,7 +710,9 @@ void QgsComposerMouseHandles::mousePressEvent( QGraphicsSceneMouseEvent* event )
             mCurrentMouseMoveAction != QgsComposerMouseHandles::NoAction )
   {
     mIsResizing = true;
-    mResizeRect = QRectF( mBeginHandlePos.x(), mBeginHandlePos.y(), mBeginHandleWidth, mBeginHandleHeight );
+    mResizeRect = QRectF( 0, 0, mBeginHandleWidth, mBeginHandleHeight );
+    mResizeMoveX = 0;
+    mResizeMoveY = 0;
   }
 
 }
@@ -630,11 +778,18 @@ void QgsComposerMouseHandles::resizeMouseMove( const QPointF& currentPosition, b
     return;
   }
 
+  QPointF beginMousePos = mapFromScene( mBeginMouseEventPos );
+
   double mx = 0.0, my = 0.0, rx = 0.0, ry = 0.0;
   QPointF snappedPosition = snapPoint( currentPosition, QgsComposerMouseHandles::Point );
 
+  //QPointF currentPosHandle = mapFromScene( currentPosition );
+  snappedPosition = mapFromScene( snappedPosition );
   double diffX = 0;
   double diffY = 0;
+
+  diffX = snappedPosition.x() - beginMousePos.x();
+  diffY = snappedPosition.y() - beginMousePos.y();
 
   double ratio = 0;
   if ( lockRatio && mBeginHandleHeight != 0 )
@@ -646,7 +801,7 @@ void QgsComposerMouseHandles::resizeMouseMove( const QPointF& currentPosition, b
   {
       //vertical resize
     case QgsComposerMouseHandles::ResizeUp:
-      diffY = snappedPosition.y() - mBeginHandlePos.y();
+      //diffY = snappedPosition.y() - beginMousePos.y();
       if ( ratio )
       {
         diffX = (( mBeginHandleHeight - diffY ) * ratio ) - mBeginHandleWidth;
@@ -659,7 +814,7 @@ void QgsComposerMouseHandles::resizeMouseMove( const QPointF& currentPosition, b
       break;
 
     case QgsComposerMouseHandles::ResizeDown:
-      diffY = snappedPosition.y() - ( mBeginHandlePos.y() + mBeginHandleHeight );
+      //diffY = snappedPosition.y() - beginMousePos.y();
       if ( ratio )
       {
         diffX = (( mBeginHandleHeight + diffY ) * ratio ) - mBeginHandleWidth;
@@ -673,7 +828,7 @@ void QgsComposerMouseHandles::resizeMouseMove( const QPointF& currentPosition, b
 
       //horizontal resize
     case QgsComposerMouseHandles::ResizeLeft:
-      diffX = snappedPosition.x() - mBeginHandlePos.x();
+      //diffX = snappedPosition.x() - beginMousePos.x();
       if ( ratio )
       {
         diffY = (( mBeginHandleWidth - diffX ) / ratio ) - mBeginHandleHeight;
@@ -686,7 +841,7 @@ void QgsComposerMouseHandles::resizeMouseMove( const QPointF& currentPosition, b
       break;
 
     case QgsComposerMouseHandles::ResizeRight:
-      diffX = snappedPosition.x() - ( mBeginHandlePos.x() + mBeginHandleWidth );
+      //diffX = snappedPosition.x() - ( beginMousePos.x() + mBeginHandleWidth );
       if ( ratio )
       {
         diffY = (( mBeginHandleWidth + diffX ) / ratio ) - mBeginHandleHeight;
@@ -700,8 +855,8 @@ void QgsComposerMouseHandles::resizeMouseMove( const QPointF& currentPosition, b
 
       //diagonal resize
     case QgsComposerMouseHandles::ResizeLeftUp:
-      diffX = snappedPosition.x() - mBeginHandlePos.x();
-      diffY = snappedPosition.y() - mBeginHandlePos.y();
+      //diffX = snappedPosition.x() - beginMousePos.x();
+      diffY = snappedPosition.y() - beginMousePos.y();
       if ( ratio )
       {
         //ratio locked resize
@@ -718,8 +873,8 @@ void QgsComposerMouseHandles::resizeMouseMove( const QPointF& currentPosition, b
       break;
 
     case QgsComposerMouseHandles::ResizeRightDown:
-      diffX = snappedPosition.x() - ( mBeginHandlePos.x() + mBeginHandleWidth );
-      diffY = snappedPosition.y() - ( mBeginHandlePos.y() + mBeginHandleHeight );
+      //diffX = snappedPosition.x() - ( beginMousePos.x() + mBeginHandleWidth );
+      //diffY = snappedPosition.y() - ( beginMousePos.y() + mBeginHandleHeight );
       if ( ratio )
       {
         //ratio locked resize
@@ -736,8 +891,8 @@ void QgsComposerMouseHandles::resizeMouseMove( const QPointF& currentPosition, b
       break;
 
     case QgsComposerMouseHandles::ResizeRightUp:
-      diffX = snappedPosition.x() - ( mBeginHandlePos.x() + mBeginHandleWidth );
-      diffY = snappedPosition.y() - mBeginHandlePos.y();
+      //diffX = snappedPosition.x() - ( beginMousePos.x() + mBeginHandleWidth );
+      //diffY = snappedPosition.y() - beginMousePos.y();
       if ( ratio )
       {
         //ratio locked resize
@@ -754,8 +909,8 @@ void QgsComposerMouseHandles::resizeMouseMove( const QPointF& currentPosition, b
       break;
 
     case QgsComposerMouseHandles::ResizeLeftDown:
-      diffX = snappedPosition.x() - mBeginHandlePos.x();
-      diffY = snappedPosition.y() - ( mBeginHandlePos.y() + mBeginHandleHeight );
+      //diffX = snappedPosition.x() - beginMousePos.x();
+      //diffY = snappedPosition.y() - ( beginMousePos.y() + mBeginHandleHeight );
       if ( ratio )
       {
         //ratio locked resize
@@ -787,14 +942,39 @@ void QgsComposerMouseHandles::resizeMouseMove( const QPointF& currentPosition, b
   }
 
   //update selection handle rectangle
-  QTransform itemTransform;
-  //make sure selection handle size rectangle is normalized (ie, left coord < right coord)
-  double translateX = mBeginHandleWidth + rx > 0 ? mx : mx + mBeginHandleWidth + rx;
-  double translateY = mBeginHandleHeight + ry > 0 ? my : my + mBeginHandleHeight + ry;
-  itemTransform.translate( translateX, translateY );
 
+  //make sure selection handle size rectangle is normalized (ie, left coord < right coord)
+  mResizeMoveX = mBeginHandleWidth + rx > 0 ? mx : mx + mBeginHandleWidth + rx;
+  mResizeMoveY = mBeginHandleHeight + ry > 0 ? my : my + mBeginHandleHeight + ry;
+
+  //calculate movement in scene coordinates
+  QLineF translateLine = QLineF( 0, 0, mResizeMoveX, mResizeMoveY );
+  translateLine.setAngle( translateLine.angle() - rotation() );
+  QPointF sceneTranslate = translateLine.p2();
+
+  //move selection handles
+  QTransform itemTransform;
+  itemTransform.translate( sceneTranslate.x(), sceneTranslate.y() );
   setTransform( itemTransform );
-  mResizeRect = QRectF( mBeginHandlePos.x() + mx, mBeginHandlePos.y() + my, mBeginHandleWidth + rx, mBeginHandleHeight + ry );
+
+  //handle non-normalised resizes - eg, dragging the left handle so far to the right that it's past the right handle
+  if ( mBeginHandleWidth + rx >= 0 && mBeginHandleHeight + ry >= 0 )
+  {
+    mResizeRect = QRectF( 0, 0,  mBeginHandleWidth + rx, mBeginHandleHeight + ry );
+  }
+  else if ( mBeginHandleHeight + ry >= 0 )
+  {
+    mResizeRect = QRectF( QPointF( -( mBeginHandleWidth + rx ), 0 ),  QPointF( 0, mBeginHandleHeight + ry ) );
+  }
+  else if ( mBeginHandleWidth + rx >= 0 )
+  {
+    mResizeRect = QRectF( QPointF( 0, -( mBeginHandleHeight + ry ) ),  QPointF( mBeginHandleWidth + rx, 0 ) );
+  }
+  else
+  {
+    mResizeRect = QRectF( QPointF( -( mBeginHandleWidth + rx ), -( mBeginHandleHeight + ry ) ),  QPointF( 0, 0 ) );
+  }
+
   setRect( 0, 0, fabs( mBeginHandleWidth + rx ), fabs( mBeginHandleHeight + ry ) );
 
   //show current size of selection in status bar
@@ -1026,12 +1206,13 @@ void QgsComposerMouseHandles::collectAlignCoordinates( QMap< double, const QgsCo
       {
         continue;
       }
-      alignCoordsX.insert( currentItem->pos().x(), currentItem );
-      alignCoordsX.insert( currentItem->pos().x() + currentItem->rect().width(), currentItem );
-      alignCoordsX.insert( currentItem->pos().x() + currentItem->rect().center().x(), currentItem );
-      alignCoordsY.insert( currentItem->pos().y() + currentItem->rect().top(), currentItem );
-      alignCoordsY.insert( currentItem->pos().y() + currentItem->rect().center().y(), currentItem );
-      alignCoordsY.insert( currentItem->pos().y() + currentItem->rect().bottom(), currentItem );
+      QRectF itemRect = currentItem->sceneBoundingRect();
+      alignCoordsX.insert( itemRect.left(), currentItem );
+      alignCoordsX.insert( itemRect.right(), currentItem );
+      alignCoordsX.insert( itemRect.center().x(), currentItem );
+      alignCoordsY.insert( itemRect.top(), currentItem );
+      alignCoordsY.insert( itemRect.center().y(), currentItem );
+      alignCoordsY.insert( itemRect.bottom(), currentItem );
     }
   }
 

--- a/src/core/composer/qgscomposermousehandles.h
+++ b/src/core/composer/qgscomposermousehandles.h
@@ -95,6 +95,9 @@ class CORE_EXPORT QgsComposerMouseHandles: public QObject, public QGraphicsRectI
     /**Redraws handles when selected item size changes*/
     void selectedItemSizeChanged();
 
+    /**Redraws handles when selected item rotation changes*/
+    void selectedItemRotationChanged();
+    
   private:
 
     QgsComposition* mComposition; //reference to composition
@@ -114,6 +117,8 @@ class CORE_EXPORT QgsComposerMouseHandles: public QObject, public QGraphicsRectI
     double mBeginHandleHeight;
 
     QRectF mResizeRect;
+    double mResizeMoveX;
+    double mResizeMoveY;
 
     /**True if user is currently dragging items*/
     bool mIsDragging;
@@ -124,8 +129,11 @@ class CORE_EXPORT QgsComposerMouseHandles: public QObject, public QGraphicsRectI
     QGraphicsLineItem* mHAlignSnapItem;
     QGraphicsLineItem* mVAlignSnapItem;
 
-    /**Returns the scene bounds of current selection*/
+    /**Returns the mouse handle bounds of current selection*/
     QRectF selectionBounds() const;
+    
+    /**Returns true if all selected items have same rotation, and if so, updates passed rotation variable*/    
+    bool selectionRotation( double & rotation ) const;
 
     /**Redraws or hides the handles based on the current selection*/
     void updateHandles();

--- a/src/core/composer/qgscomposermousehandles.h
+++ b/src/core/composer/qgscomposermousehandles.h
@@ -157,11 +157,6 @@ class CORE_EXPORT QgsComposerMouseHandles: public QObject, public QGraphicsRectI
     /**Handles resizing of items during mouse move*/
     void resizeMouseMove( const QPointF& currentPosition, bool lockAspect, bool fromCenter );
 
-    /**Resizes a QRectF relative to the change from boundsBefore to boundsAfter*/
-    void relativeResizeRect( QRectF& rectToResize, const QRectF& boundsBefore, const QRectF& boundsAfter );
-    /**Returns a scaled position given a before and after range*/
-    double relativePosition( double position, double beforeMin, double beforeMax, double afterMin, double afterMax );
-
     /**Return horizontal align snap item. Creates a new graphics line if 0*/
     QGraphicsLineItem* hAlignSnapItem();
     void deleteHAlignSnapItem();

--- a/src/core/composer/qgscomposerpicture.h
+++ b/src/core/composer/qgscomposerpicture.h
@@ -60,6 +60,15 @@ class CORE_EXPORT QgsComposerPicture: public QgsComposerItem
       */
     bool readXML( const QDomElement& itemElem, const QDomDocument& doc );
 
+    /**Returns the rotation used for drawing the picture within the composer item
+     * @deprecated Use pictureRotation() instead
+     */
+    double rotation() const { return mPictureRotation;};
+
+    /**Returns the rotation used for drawing the picture within the item
+      @note this function was added in version 2.1*/
+    double pictureRotation() const { return mPictureRotation;};
+
     /**Sets the map object for rotation (by id). A value of -1 disables the map rotation*/
     void setRotationMap( int composerMapId );
     /**Returns the id of the rotation map*/
@@ -67,9 +76,37 @@ class CORE_EXPORT QgsComposerPicture: public QgsComposerItem
     /**True if the rotation is taken from a map item*/
     bool useRotationMap() const {return mRotationMap;}
 
+    /**Calculates width and hight of the picture (in mm) such that it fits into the item frame with the given rotation
+     * @deprecated Use bool QgsComposerItem::imageSizeConsideringRotation( double& width, double& height, double rotation )
+     * instead
+     */
+    bool imageSizeConsideringRotation( double& width, double& height ) const;
+    /**Calculates corner point after rotation and scaling
+     * @deprecated Use QgsComposerItem::cornerPointOnRotatedAndScaledRect( double& x, double& y, double width, double height, double rotation )
+     * instead
+     */
+    bool cornerPointOnRotatedAndScaledRect( double& x, double& y, double width, double height ) const;
+    /**Calculates width / height of the bounding box of a rotated rectangle
+    * @deprecated Use QgsComposerItem::sizeChangedByRotation( double& width, double& height, double rotation )
+    * instead
+    */
+    void sizeChangedByRotation( double& width, double& height );
+
   public slots:
-    /**Sets the rotation and adapts the item rect*/
+    /**Sets the picture rotation within the item bounds. This does not affect the item rectangle,
+      only the way the picture is drawn within the item.
+     * @deprecated Use setPictureRotation( double rotation ) instead
+     */
     virtual void setRotation( double r );
+
+    /**Sets the picture rotation within the item bounds. This does not affect the item rectangle,
+      only the way the picture is drawn within the item.
+      @note this function was added in version 2.1*/
+    virtual void setPictureRotation( double r );
+
+  signals:
+    /**Is emitted on picture rotation change*/
+    void pictureRotationChanged( double newRotation );
 
   private:
 
@@ -94,6 +131,9 @@ class CORE_EXPORT QgsComposerPicture: public QgsComposerItem
     Mode mMode;
 
     QSize mDefaultSvgSize;
+
+    /**Image rotation*/
+    double mPictureRotation;
     /**Map that sets the rotation (or 0 if this picture uses map independent rotation)*/
     const QgsComposerMap* mRotationMap;
     /**Width of the picture (in mm)*/

--- a/src/core/composer/qgscomposershape.cpp
+++ b/src/core/composer/qgscomposershape.cpp
@@ -60,10 +60,6 @@ void QgsComposerShape::drawShape( QPainter* p )
   p->save();
   p->setRenderHint( QPainter::Antialiasing );
 
-  p->translate( rect().width() / 2.0, rect().height() / 2.0 );
-  p->rotate( mItemRotation );
-  p->translate( -rect().width() / 2.0, -rect().height() / 2.0 );
-
   switch ( mShape )
   {
     case Ellipse:
@@ -140,7 +136,7 @@ bool QgsComposerShape::readXML( const QDomElement& itemElem, const QDomDocument&
     if ( composerItemElem.attribute( "rotation", "0" ).toDouble() != 0 )
     {
       //check for old (pre 2.1) rotation attribute
-      mItemRotation = composerItemElem.attribute( "rotation", "0" ).toDouble();
+      setItemRotation( composerItemElem.attribute( "rotation", "0" ).toDouble() );
     }
 
     _readXML( composerItemElem, doc );
@@ -149,36 +145,7 @@ bool QgsComposerShape::readXML( const QDomElement& itemElem, const QDomDocument&
   return true;
 }
 
-
-void QgsComposerShape::setItemRotation( double r )
-{
-  //adapt rectangle size
-  double width = rect().width();
-  double height = rect().height();
-  sizeChangedByRotation( width, height );
-
-  //adapt scene rect to have the same center and the new width / height
-  double x = pos().x() + rect().width() / 2.0 - width / 2.0;
-  double y = pos().y() + rect().height() / 2.0 - height / 2.0;
-  QgsComposerItem::setSceneRect( QRectF( x, y, width, height ) );
-
-  QgsComposerItem::setItemRotation( r );
-}
-
 void QgsComposerShape::setCornerRadius( double radius )
 {
   mCornerRadius = radius;
-}
-
-void QgsComposerShape::setSceneRect( const QRectF& rectangle )
-{
-  //consider to change size of the shape if the rectangle changes width and/or height
-  if ( rectangle.width() != rect().width() || rectangle.height() != rect().height() )
-  {
-    double newShapeWidth = rectangle.width();
-    double newShapeHeight = rectangle.height();
-    imageSizeConsideringRotation( newShapeWidth, newShapeHeight );
-  }
-
-  QgsComposerItem::setSceneRect( rectangle );
 }

--- a/src/core/composer/qgscomposershape.cpp
+++ b/src/core/composer/qgscomposershape.cpp
@@ -61,7 +61,7 @@ void QgsComposerShape::drawShape( QPainter* p )
   p->setRenderHint( QPainter::Antialiasing );
 
   p->translate( rect().width() / 2.0, rect().height() / 2.0 );
-  p->rotate( mRotation );
+  p->rotate( mItemRotation );
   p->translate( -rect().width() / 2.0, -rect().height() / 2.0 );
 
   switch ( mShape )
@@ -135,6 +135,14 @@ bool QgsComposerShape::readXML( const QDomElement& itemElem, const QDomDocument&
   if ( composerItemList.size() > 0 )
   {
     QDomElement composerItemElem = composerItemList.at( 0 ).toElement();
+
+    //rotation
+    if ( composerItemElem.attribute( "rotation", "0" ).toDouble() != 0 )
+    {
+      //check for old (pre 2.1) rotation attribute
+      mItemRotation = composerItemElem.attribute( "rotation", "0" ).toDouble();
+    }
+
     _readXML( composerItemElem, doc );
   }
   emit itemChanged();
@@ -142,7 +150,7 @@ bool QgsComposerShape::readXML( const QDomElement& itemElem, const QDomDocument&
 }
 
 
-void QgsComposerShape::setRotation( double r )
+void QgsComposerShape::setItemRotation( double r )
 {
   //adapt rectangle size
   double width = rect().width();
@@ -154,7 +162,7 @@ void QgsComposerShape::setRotation( double r )
   double y = pos().y() + rect().height() / 2.0 - height / 2.0;
   QgsComposerItem::setSceneRect( QRectF( x, y, width, height ) );
 
-  QgsComposerItem::setRotation( r );
+  QgsComposerItem::setItemRotation( r );
 }
 
 void QgsComposerShape::setCornerRadius( double radius )

--- a/src/core/composer/qgscomposershape.h
+++ b/src/core/composer/qgscomposershape.h
@@ -61,18 +61,10 @@ class CORE_EXPORT QgsComposerShape: public QgsComposerItem
     QgsComposerShape::Shape shapeType() const {return mShape;}
     void setShapeType( QgsComposerShape::Shape s ) {mShape = s;}
 
-    /**Sets this items bound in scene coordinates such that 1 item size units
-     corresponds to 1 scene size unit. Also, the shape is scaled*/
-    void setSceneRect( const QRectF& rectangle );
-
     /**Sets radius for rounded rectangle corners. Added in v2.1 */
     void setCornerRadius( double radius );
     /**Returns the radius for rounded rectangle corners*/
     double cornerRadius() const { return mCornerRadius; };
-
-  public slots:
-    /**Sets item rotation and resizes item bounds such that the shape always has the same size*/
-    virtual void setItemRotation( double r );
 
   protected:
     /* reimplement drawFrame, since it's not a rect, but a custom shape */

--- a/src/core/composer/qgscomposershape.h
+++ b/src/core/composer/qgscomposershape.h
@@ -72,7 +72,7 @@ class CORE_EXPORT QgsComposerShape: public QgsComposerItem
 
   public slots:
     /**Sets item rotation and resizes item bounds such that the shape always has the same size*/
-    virtual void setRotation( double r );
+    virtual void setItemRotation( double r );
 
   protected:
     /* reimplement drawFrame, since it's not a rect, but a custom shape */

--- a/src/core/composer/qgscomposition.cpp
+++ b/src/core/composer/qgscomposition.cpp
@@ -2272,3 +2272,24 @@ void QgsComposition::computeWorldFileParameters( double& a, double& b, double& c
   e = r[3] * s[1] + r[4] * s[4];
   f = r[3] * s[2] + r[4] * s[5] + r[5];
 }
+
+void QgsComposition::relativeResizeRect( QRectF& rectToResize, const QRectF& boundsBefore, const QRectF& boundsAfter )
+{
+  //linearly scale rectToResize relative to the scaling from boundsBefore to boundsAfter
+  double left = relativePosition( rectToResize.left(), boundsBefore.left(), boundsBefore.right(), boundsAfter.left(), boundsAfter.right() );
+  double right = relativePosition( rectToResize.right(), boundsBefore.left(), boundsBefore.right(), boundsAfter.left(), boundsAfter.right() );
+  double top = relativePosition( rectToResize.top(), boundsBefore.top(), boundsBefore.bottom(), boundsAfter.top(), boundsAfter.bottom() );
+  double bottom = relativePosition( rectToResize.bottom(), boundsBefore.top(), boundsBefore.bottom(), boundsAfter.top(), boundsAfter.bottom() );
+
+  rectToResize.setRect( left, top, right - left, bottom - top );
+}
+
+double QgsComposition::relativePosition( double position, double beforeMin, double beforeMax, double afterMin, double afterMax )
+{
+  //calculate parameters for linear scale between before and after ranges
+  double m = ( afterMax - afterMin ) / ( beforeMax - beforeMin );
+  double c = afterMin - ( beforeMin * m );
+
+  //return linearly scaled position
+  return m * position + c;
+}

--- a/src/core/composer/qgscomposition.h
+++ b/src/core/composer/qgscomposition.h
@@ -412,7 +412,12 @@ class CORE_EXPORT QgsComposition : public QGraphicsScene
     /** Compute world file parameters */
     void computeWorldFileParameters( double& a, double& b, double& c, double& d, double& e, double& f ) const;
 
-    QgsAtlasComposition& atlasComposition() { return mAtlasComposition; }
+    QgsAtlasComposition& atlasComposition() { return mAtlasComposition; };
+    
+    /**Resizes a QRectF relative to the change from boundsBefore to boundsAfter*/
+    static void relativeResizeRect( QRectF& rectToResize, const QRectF& boundsBefore, const QRectF& boundsAfter );
+    /**Returns a scaled position given a before and after range*/
+    static double relativePosition( double position, double beforeMin, double beforeMax, double afterMin, double afterMax );    
 
   public slots:
     /**Casts object to the proper subclass type and calls corresponding itemAdded signal*/

--- a/src/ui/qgscomposeritemwidgetbase.ui
+++ b/src/ui/qgscomposeritemwidgetbase.ui
@@ -218,6 +218,38 @@
     </widget>
    </item>
    <item>
+    <widget class="QgsCollapsibleGroupBoxBasic" name="mTransformsGroupBox">
+     <property name="title">
+      <string>Rotation</string>
+     </property>
+     <property name="syncGroup" stdset="0">
+      <string notr="true">composeritem</string>
+     </property>
+     <property name="collapsed" stdset="0">
+      <bool>true</bool>
+     </property>
+     <layout class="QFormLayout" name="formLayout">
+      <item row="0" column="0">
+       <widget class="QLabel" name="label">
+        <property name="text">
+         <string>Rotation</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QDoubleSpinBox" name="mItemRotationSpinBox">
+        <property name="suffix">
+         <string> °</string>
+        </property>
+        <property name="maximum">
+         <double>360.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item>
     <widget class="QgsCollapsibleGroupBoxBasic" name="mFrameGroupBox">
      <property name="title">
       <string>Frame</string>

--- a/src/ui/qgscomposerlabelwidgetbase.ui
+++ b/src/ui/qgscomposerlabelwidgetbase.ui
@@ -299,35 +299,6 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="mRotationLabel">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="text">
-             <string>Rotation</string>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-            <property name="buddy">
-             <cstring>mRotationSpinBox</cstring>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
-           <widget class="QDoubleSpinBox" name="mRotationSpinBox">
-            <property name="suffix">
-             <string> °</string>
-            </property>
-            <property name="maximum">
-             <double>360.000000000000000</double>
-            </property>
-           </widget>
-          </item>
          </layout>
         </widget>
        </item>

--- a/src/ui/qgscomposermapwidgetbase.ui
+++ b/src/ui/qgscomposermapwidgetbase.ui
@@ -123,16 +123,16 @@
            </widget>
           </item>
           <item row="2" column="0">
-           <widget class="QLabel" name="mRotationLabel">
+           <widget class="QLabel" name="mMapRotationLabel">
             <property name="text">
-             <string>Rotation</string>
+             <string>Map Rotation</string>
             </property>
            </widget>
           </item>
           <item row="2" column="1">
-           <widget class="QDoubleSpinBox" name="mRotationSpinBox">
+           <widget class="QDoubleSpinBox" name="mMapRotationSpinBox">
             <property name="suffix">
-             <string> degrees</string>
+             <string> °</string>
             </property>
             <property name="maximum">
              <double>360.000000000000000</double>

--- a/src/ui/qgscomposerpicturewidgetbase.ui
+++ b/src/ui/qgscomposerpicturewidgetbase.ui
@@ -213,7 +213,7 @@
        <item>
         <widget class="QgsCollapsibleGroupBoxBasic" name="groupBox">
          <property name="title">
-          <string>Rotation</string>
+          <string>Image Rotation</string>
          </property>
          <property name="syncGroup" stdset="0">
           <string notr="true">composeritem</string>
@@ -239,7 +239,7 @@
            <widget class="QComboBox" name="mComposerMapComboBox"/>
           </item>
           <item row="0" column="0" colspan="2">
-           <widget class="QDoubleSpinBox" name="mRotationSpinBox">
+           <widget class="QDoubleSpinBox" name="mPictureRotationSpinBox">
             <property name="suffix">
              <string> °</string>
             </property>

--- a/src/ui/qgscomposershapewidgetbase.ui
+++ b/src/ui/qgscomposershapewidgetbase.ui
@@ -72,33 +72,13 @@
           <item row="2" column="0" colspan="2">
            <layout class="QGridLayout" name="gridLayout">
             <item row="1" column="0">
-             <widget class="QLabel" name="label">
-              <property name="text">
-               <string>Rotation</string>
-              </property>
-             </widget>
-            </item>
-            <item row="1" column="1">
-             <widget class="QSpinBox" name="mRotationSpinBox">
-              <property name="suffix">
-               <string> °</string>
-              </property>
-              <property name="prefix">
-               <string comment="Rotation" extracomment="Rotation"/>
-              </property>
-              <property name="maximum">
-               <number>359</number>
-              </property>
-             </widget>
-            </item>
-            <item row="2" column="0">
              <widget class="QLabel" name="label_3">
               <property name="text">
                <string>Corner radius</string>
               </property>
              </widget>
             </item>
-            <item row="2" column="1">
+            <item row="1" column="1">
              <widget class="QDoubleSpinBox" name="mCornerRadiusSpinBox">
               <property name="suffix">
                <string> mm</string>

--- a/tests/src/core/testqgscomposermap.cpp
+++ b/tests/src/core/testqgscomposermap.cpp
@@ -239,7 +239,7 @@ void TestQgsComposerMap::overviewMapCenter()
 void TestQgsComposerMap::worldFileGeneration()
 {
   mComposerMap->setNewExtent( QgsRectangle( 781662.375, 3339523.125, 793062.375, 3345223.125 ) );
-  mComposerMap->setRotation( 30.0 );
+  mComposerMap->setMapRotation( 30.0 );
 
   mComposition->setGenerateWorldFile( true );
   mComposition->setWorldFileMap( mComposerMap );

--- a/tests/src/python/test_qgscomposermap.py
+++ b/tests/src/python/test_qgscomposermap.py
@@ -252,7 +252,7 @@ class TestQgsComposerMap(TestCase):
     def testWorldFileGeneration( self ):
         myRectangle = QgsRectangle(781662.375, 3339523.125, 793062.375, 3345223.125)
         self.mComposerMap.setNewExtent( myRectangle )
-        self.mComposerMap.setRotation( 30.0 )
+        self.mComposerMap.setMapRotation( 30.0 )
 
         self.mComposition.setGenerateWorldFile( True )
         self.mComposition.setWorldFileMap( self.mComposerMap )


### PR DESCRIPTION
This branch goes a long way toward fixing rotation of composer items. I've made it possible to rotate all types of composer items (fixes #4884) and improved how QGIS handles rotated items (fixes #7933). Now, resizing of single rotated items or selections/groups of items with the same rotation are done using the same axis as the rotated items. This mostly fixes  #8466 and #8125, at least for the most common use cases. (Still remaining to do is fixing resizing of selections consisting of items with differing rotation, but this depends on shear/perspective transforms, which is still a wip and is a much rarer use case). Additionally, using new methods available in qt 4.6 helped clean up and simplify the old rotation code.
Still to come is rotation rescaling which depends on shear/perspective transforms, and a comprehensive test suite. In the meantime it should be safe to get this merged for further testing and feedback.
