### PR TITLE
Rendering speedup

### DIFF
--- a/src/core/qgsclipper.cpp
+++ b/src/core/qgsclipper.cpp
@@ -49,8 +49,8 @@ const unsigned char* QgsClipper::clippedLineWKB( const unsigned char* wkb, const
   double p1x_c, p1y_c; //clipped end coordinates
   double lastClipX = 0.0, lastClipY = 0.0; //last successfully clipped coords
 
-  line.reserve( nPoints + 1 );
   line.clear();
+  line.reserve( nPoints + 1 );
 
   for ( unsigned int i = 0; i < nPoints; ++i )
   {

--- a/src/core/qgsclipper.h
+++ b/src/core/qgsclipper.h
@@ -179,11 +179,11 @@ inline void QgsClipper::trimPolygon( QPolygonF& pts, const QgsRectangle& clipRec
   tmpPts.reserve( pts.size() );
 
   trimPolygonToBoundary( pts, tmpPts, clipRect, XMax, clipRect.xMaximum() );
-  pts.clear();
+  pts.resize( 0 );
   trimPolygonToBoundary( tmpPts, pts, clipRect, YMax, clipRect.yMaximum() );
-  tmpPts.clear();
+  tmpPts.resize( 0 );
   trimPolygonToBoundary( pts, tmpPts, clipRect, XMin, clipRect.xMinimum() );
-  pts.clear();
+  pts.resize( 0 );
   trimPolygonToBoundary( tmpPts, pts, clipRect, YMin, clipRect.yMinimum() );
 }
 

--- a/src/core/qgsclipper.h
+++ b/src/core/qgsclipper.h
@@ -175,6 +175,29 @@ inline void QgsClipper::trimFeature( QVector<double>& x,
 
 inline void QgsClipper::trimPolygon( QPolygonF& pts, const QgsRectangle& clipRect )
 {
+  int is_inside = 1;
+  double x, y, xmin, ymin, xmax, ymax;
+
+  xmin = clipRect.xMinimum();
+  xmax = clipRect.xMaximum();
+  ymin = clipRect.yMinimum();
+  ymax = clipRect.yMaximum();
+
+  int s = pts.size();
+  QPointF *data = pts.data();
+
+  for ( int i = 0; ( i < s ) && is_inside; i++, data++ ) {
+          x = data->x();
+          y = data->y();
+
+          if (( x > xmax ) || ( x < xmin ) ||
+              ( y < ymin ) || ( y > ymax ))
+                  is_inside = 0;
+  }
+
+  if (is_inside)
+          return;
+
   QPolygonF tmpPts;
   tmpPts.reserve( pts.size() );
 

--- a/src/core/qgscoordinatetransform.cpp
+++ b/src/core/qgscoordinatetransform.cpp
@@ -632,14 +632,12 @@ void QgsCoordinateTransform::transformCoords( const int& numPoints, double *x, d
   if ( direction == ReverseTransform )
   {
     projResult = pj_transform( mDestinationProjection, mSourceProjection, numPoints, 0, x, y, z );
-    dir = tr( "inverse transform" );
   }
   else
   {
     Q_ASSERT( mSourceProjection != 0 );
     Q_ASSERT( mDestinationProjection != 0 );
     projResult = pj_transform( mSourceProjection, mDestinationProjection, numPoints, 0, x, y, z );
-    dir = tr( "forward transform" );
   }
 
   if ( projResult != 0 )
@@ -658,6 +656,8 @@ void QgsCoordinateTransform::transformCoords( const int& numPoints, double *x, d
         points += QString( "(%1, %2)\n" ).arg( x[i] * RAD_TO_DEG, 0, 'f' ).arg( y[i] * RAD_TO_DEG, 0, 'f' );
       }
     }
+
+    dir = (direction == ForwardTransform) ? tr( "forward transform" ) : tr( "inverse transform" );
 
     QString msg = tr( "%1 of\n"
                       "%2"

--- a/src/core/symbology-ng/qgsmarkersymbollayerv2.h
+++ b/src/core/symbology-ng/qgsmarkersymbollayerv2.h
@@ -105,6 +105,10 @@ class CORE_EXPORT QgsSimpleMarkerSymbolLayerV2 : public QgsMarkerSymbolLayerV2
 
     //Maximum width/height of cache image
     static const int mMaximumCacheWidth = 3000;
+
+  private:
+    QgsExpression *mAngleExpression;
+    QgsExpression *mNameExpression;
 };
 
 //////////

--- a/src/core/symbology-ng/qgssymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgssymbollayerv2.cpp
@@ -173,6 +173,9 @@ QgsMarkerSymbolLayerV2::QgsMarkerSymbolLayerV2( bool locked )
     : QgsSymbolLayerV2( QgsSymbolV2::Marker, locked ), mSizeUnit( QgsSymbolV2::MM ),  mOffsetUnit( QgsSymbolV2::MM ),
     mHorizontalAnchorPoint( HCenter ), mVerticalAnchorPoint( VCenter )
 {
+    mOffsetExpression = NULL;
+    mHorizontalAnchorExpression = NULL;
+    mVerticalAnchorExpression = NULL;
 }
 
 QgsLineSymbolLayerV2::QgsLineSymbolLayerV2( bool locked )
@@ -183,6 +186,13 @@ QgsLineSymbolLayerV2::QgsLineSymbolLayerV2( bool locked )
 QgsFillSymbolLayerV2::QgsFillSymbolLayerV2( bool locked )
     : QgsSymbolLayerV2( QgsSymbolV2::Fill, locked ), mAngle( 0.0 )
 {
+}
+
+void QgsMarkerSymbolLayerV2::startRender( QgsSymbolV2RenderContext& context )
+{
+  mOffsetExpression = expression( "offset" );
+  mHorizontalAnchorExpression = expression( "horizontal_anchor_point" );
+  mVerticalAnchorExpression = expression( "vertical_anchor_point" );
 }
 
 void QgsMarkerSymbolLayerV2::drawPreviewIcon( QgsSymbolV2RenderContext& context, QSize size )
@@ -210,10 +220,9 @@ void QgsMarkerSymbolLayerV2::markerOffset( const QgsSymbolV2RenderContext& conte
   offsetX = mOffset.x();
   offsetY = mOffset.y();
 
-  QgsExpression* offsetExpression = expression( "offset" );
-  if ( offsetExpression )
+  if ( mOffsetExpression )
   {
-    QPointF offset = QgsSymbolLayerV2Utils::decodePoint( offsetExpression->evaluate( const_cast<QgsFeature*>( context.feature() ) ).toString() );
+    QPointF offset = QgsSymbolLayerV2Utils::decodePoint( mOffsetExpression->evaluate( const_cast<QgsFeature*>( context.feature() ) ).toString() );
     offsetX = offset.x();
     offsetY = offset.y();
   }
@@ -223,15 +232,13 @@ void QgsMarkerSymbolLayerV2::markerOffset( const QgsSymbolV2RenderContext& conte
 
   HorizontalAnchorPoint horizontalAnchorPoint = mHorizontalAnchorPoint;
   VerticalAnchorPoint verticalAnchorPoint = mVerticalAnchorPoint;
-  QgsExpression* horizontalAnchorExpression = expression( "horizontal_anchor_point" );
-  if ( horizontalAnchorExpression )
+  if ( mHorizontalAnchorExpression )
   {
-    horizontalAnchorPoint = decodeHorizontalAnchorPoint( horizontalAnchorExpression->evaluate( const_cast<QgsFeature*>( context.feature() ) ).toString() );
+    horizontalAnchorPoint = decodeHorizontalAnchorPoint( mHorizontalAnchorExpression->evaluate( const_cast<QgsFeature*>( context.feature() ) ).toString() );
   }
-  QgsExpression* verticalAnchorExpression = expression( "vertical_anchor_point" );
-  if ( verticalAnchorExpression )
+  if ( mVerticalAnchorExpression )
   {
-    verticalAnchorPoint = decodeVerticalAnchorPoint( verticalAnchorExpression->evaluate( const_cast<QgsFeature*>( context.feature() ) ).toString() );
+    verticalAnchorPoint = decodeVerticalAnchorPoint( mVerticalAnchorExpression->evaluate( const_cast<QgsFeature*>( context.feature() ) ).toString() );
   }
 
   //correct horizontal position according to anchor point

--- a/src/core/symbology-ng/qgssymbollayerv2.h
+++ b/src/core/symbology-ng/qgssymbollayerv2.h
@@ -146,6 +146,8 @@ class CORE_EXPORT QgsMarkerSymbolLayerV2 : public QgsSymbolLayerV2
       Bottom
     };
 
+    void startRender( QgsSymbolV2RenderContext& context );
+
     virtual void renderPoint( const QPointF& point, QgsSymbolV2RenderContext& context ) = 0;
 
     void drawPreviewIcon( QgsSymbolV2RenderContext& context, QSize size );
@@ -205,6 +207,10 @@ class CORE_EXPORT QgsMarkerSymbolLayerV2 : public QgsSymbolLayerV2
   private:
     static QgsMarkerSymbolLayerV2::HorizontalAnchorPoint decodeHorizontalAnchorPoint( const QString& str );
     static QgsMarkerSymbolLayerV2::VerticalAnchorPoint decodeVerticalAnchorPoint( const QString& str );
+
+    QgsExpression* mOffsetExpression;
+    QgsExpression* mHorizontalAnchorExpression;
+    QgsExpression* mVerticalAnchorExpression;
 };
 
 class CORE_EXPORT QgsLineSymbolLayerV2 : public QgsSymbolLayerV2


### PR DESCRIPTION
Reduce rendering time for polygons, lines and simple markers by eliminating overhead at coordinate transformation, polygons and lines clipping and simple marker rendering.

I get perfomance gain upto 19% for polygons and 15% for markers at big layers (Belarus dump of OSM).
