### PR TITLE
fix Gdal Merge nodata value and UI

### DIFF
--- a/python/plugins/GdalTools/tools/doMerge.py
+++ b/python/plugins/GdalTools/tools/doMerge.py
@@ -147,8 +147,9 @@ class GdalToolsDialog(QWidget, Ui_Widget, BasePluginWidget):
       if self.noDataCheck.isChecked():
         arguments.append("-n")
         arguments.append(str(self.noDataSpin.value()))
-        arguments.append("-a_nodata")
-        arguments.append(str(self.noDataSpin.value()))
+        if Utils.GdalConfig.versionNum() >= 1900:
+          arguments.append("-a_nodata")
+          arguments.append(str(self.noDataSpin.value()))
       if self.separateCheck.isChecked():
         arguments.append("-separate")
       if self.pctCheck.isChecked():

--- a/python/plugins/GdalTools/tools/doMerge.py
+++ b/python/plugins/GdalTools/tools/doMerge.py
@@ -147,6 +147,8 @@ class GdalToolsDialog(QWidget, Ui_Widget, BasePluginWidget):
       if self.noDataCheck.isChecked():
         arguments.append("-n")
         arguments.append(str(self.noDataSpin.value()))
+        arguments.append("-a_nodata")
+        arguments.append(str(self.noDataSpin.value()))
       if self.separateCheck.isChecked():
         arguments.append("-separate")
       if self.pctCheck.isChecked():

--- a/python/plugins/GdalTools/tools/widgetMerge.ui
+++ b/python/plugins/GdalTools/tools/widgetMerge.ui
@@ -106,7 +106,7 @@
     </widget>
    </item>
    <item>
-    <widget class="QGroupBox" name="creationOptionsGroupBox">
+    <widget class="QgsCollapsibleGroupBox" name="creationOptionsGroupBox">
      <property name="title">
       <string>&amp;Creation Options</string>
      </property>
@@ -116,9 +116,15 @@
      <property name="checked">
       <bool>false</bool>
      </property>
+     <property name="collapsed" stdset="0">
+      <bool>false</bool>
+     </property>
+     <property name="saveCollapsedState" stdset="0">
+      <bool>true</bool>
+     </property>
      <layout class="QVBoxLayout" name="verticalLayout_2">
       <property name="margin">
-       <number>0</number>
+       <number>9</number>
       </property>
       <item>
        <widget class="QgsRasterFormatSaveOptionsWidget" name="creationOptionsWidget" native="true"/>
@@ -138,6 +144,12 @@
   <customwidget>
    <class>QgsRasterFormatSaveOptionsWidget</class>
    <extends>QWidget</extends>
+   <header>qgis.gui</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
    <header>qgis.gui</header>
    <container>1</container>
   </customwidget>


### PR DESCRIPTION
this pull request has 2 commits
- fix nodata value of the GDalTools merge widget

This essentially adds the -a_nodata argument when nodata is set

Discussed in this thread
http://osgeo-org.1560.x6.nabble.com/No-data-value-in-Raster-Merge-not-working-td5091670.html
- put the creation options in a collapsible group box, as in other widgets
