### PR TITLE
Bug #9191-#9190: fix enable/disable issues of buttons

### DIFF
--- a/src/gui/qgsmanageconnectionsdialog.cpp
+++ b/src/gui/qgsmanageconnectionsdialog.cpp
@@ -46,11 +46,13 @@ QgsManageConnectionsDialog::QgsManageConnectionsDialog( QWidget *parent, Mode mo
   {
     label->setText( tr( "Select connections to import" ) );
     buttonBox->button( QDialogButtonBox::Ok )->setText( tr( "Import" ) );
+    buttonBox->button( QDialogButtonBox::Ok )->setEnabled( false );
   }
   else
   {
     //label->setText( tr( "Select connections to export" ) );
     buttonBox->button( QDialogButtonBox::Ok )->setText( tr( "Export" ) );
+    buttonBox->button( QDialogButtonBox::Ok )->setEnabled( false );
   }
 
   if ( !populateConnections() )
@@ -61,6 +63,13 @@ QgsManageConnectionsDialog::QgsManageConnectionsDialog( QWidget *parent, Mode mo
   // use Ok button for starting import and export operations
   disconnect( buttonBox, SIGNAL( accepted() ), this, SLOT( accept() ) );
   connect( buttonBox, SIGNAL( accepted() ), this, SLOT( doExportImport() ) );
+
+  connect( listConnections, SIGNAL( itemSelectionChanged() ), this, SLOT( selectionChanged() ) );
+}
+
+void QgsManageConnectionsDialog::selectionChanged()
+{
+  buttonBox->button( QDialogButtonBox::Ok )->setEnabled( !listConnections->selectedItems().isEmpty() );
 }
 
 void QgsManageConnectionsDialog::doExportImport()
@@ -945,9 +954,11 @@ void QgsManageConnectionsDialog::loadOracleConnections( const QDomDocument &doc,
 void QgsManageConnectionsDialog::selectAll()
 {
   listConnections->selectAll();
+  buttonBox->button( QDialogButtonBox::Ok )->setEnabled( !listConnections->selectedItems().isEmpty() );
 }
 
 void QgsManageConnectionsDialog::clearSelection()
 {
   listConnections->clearSelection();
+  buttonBox->button( QDialogButtonBox::Ok )->setEnabled( false );
 }

--- a/src/gui/qgsmanageconnectionsdialog.h
+++ b/src/gui/qgsmanageconnectionsdialog.h
@@ -52,6 +52,7 @@ class GUI_EXPORT QgsManageConnectionsDialog : public QDialog, private Ui::QgsMan
     void doExportImport();
     void selectAll();
     void clearSelection();
+    void selectionChanged();
 
   private:
     bool populateConnections();

--- a/src/gui/qgsnewhttpconnection.cpp
+++ b/src/gui/qgsnewhttpconnection.cpp
@@ -141,7 +141,12 @@ QgsNewHttpConnection::~QgsNewHttpConnection()
 
 void QgsNewHttpConnection::on_txtName_textChanged( const QString &text )
 {
-  buttonBox->button( QDialogButtonBox::Ok )->setDisabled( text.isEmpty() );
+  buttonBox->button( QDialogButtonBox::Ok )->setDisabled( txtName->text().isEmpty() || txtUrl->text().isEmpty() );
+}
+
+void QgsNewHttpConnection::on_txtUrl_textChanged( const QString &text )
+{
+  buttonBox->button( QDialogButtonBox::Ok )->setDisabled( txtName->text().isEmpty() || txtUrl->text().isEmpty() );
 }
 
 void QgsNewHttpConnection::accept()

--- a/src/gui/qgsnewhttpconnection.h
+++ b/src/gui/qgsnewhttpconnection.h
@@ -38,6 +38,8 @@ class GUI_EXPORT QgsNewHttpConnection : public QDialog, private Ui::QgsNewHttpCo
 
     void on_txtName_textChanged( const QString & );
 
+    void on_txtUrl_textChanged( const QString & );
+
     void on_buttonBox_helpRequested() { QgsContextHelp::run( metaObject()->className() ); }
 
   private:

--- a/src/gui/qgsowssourceselect.cpp
+++ b/src/gui/qgsowssourceselect.cpp
@@ -239,21 +239,6 @@ void QgsOWSSourceSelect::populateConnectionList()
   mConnectionsComboBox->addItems( QgsOWSConnection::connectionList( mService ) );
 
   setConnectionListPosition();
-
-  if ( mConnectionsComboBox->count() == 0 )
-  {
-    // No connections - disable various buttons
-    mConnectButton->setEnabled( false );
-    mEditButton->setEnabled( false );
-    mDeleteButton->setEnabled( false );
-  }
-  else
-  {
-    // Connections - enable various buttons
-    mConnectButton->setEnabled( true );
-    mEditButton->setEnabled( true );
-    mDeleteButton->setEnabled( true );
-  }
 }
 void QgsOWSSourceSelect::on_mNewButton_clicked()
 {
@@ -546,6 +531,22 @@ void QgsOWSSourceSelect::setConnectionListPosition()
     else
       mConnectionsComboBox->setCurrentIndex( mConnectionsComboBox->count() - 1 );
   }
+
+  if ( mConnectionsComboBox->count() == 0 )
+  {
+    // No connections - disable various buttons
+    mConnectButton->setEnabled( false );
+    mEditButton->setEnabled( false );
+    mDeleteButton->setEnabled( false );
+  }
+  else
+  {
+    // Connections - enable various buttons
+    mConnectButton->setEnabled( true );
+    mEditButton->setEnabled( true );
+    mDeleteButton->setEnabled( true );
+  }
+
   QgsOWSConnection::setSelectedConnection( mService, mConnectionsComboBox->currentText() );
 }
 

--- a/src/gui/qgsowssourceselect.cpp
+++ b/src/gui/qgsowssourceselect.cpp
@@ -538,6 +538,7 @@ void QgsOWSSourceSelect::setConnectionListPosition()
     mConnectButton->setEnabled( false );
     mEditButton->setEnabled( false );
     mDeleteButton->setEnabled( false );
+    mSaveButton->setEnabled( false );
   }
   else
   {
@@ -545,6 +546,7 @@ void QgsOWSSourceSelect::setConnectionListPosition()
     mConnectButton->setEnabled( true );
     mEditButton->setEnabled( true );
     mDeleteButton->setEnabled( true );
+    mSaveButton->setEnabled( true );
   }
 
   QgsOWSConnection::setSelectedConnection( mService, mConnectionsComboBox->currentText() );

--- a/src/providers/wfs/qgswfssourceselect.cpp
+++ b/src/providers/wfs/qgswfssourceselect.cpp
@@ -132,14 +132,15 @@ void QgsWFSSourceSelect::populateConnectionList()
     btnConnect->setEnabled( true );
     btnEdit->setEnabled( true );
     btnDelete->setEnabled( true );
+    btnSave->setEnabled( true );
   }
-
   else
   {
     // No connections available - disable various buttons
     btnConnect->setEnabled( false );
     btnEdit->setEnabled( false );
     btnDelete->setEnabled( false );
+    btnSave->setEnabled( false );
   }
 
   //set last used connection
@@ -310,6 +311,7 @@ void QgsWFSSourceSelect::deleteEntryOfServerList()
       btnConnect->setEnabled( true );
       btnEdit->setEnabled( true );
       btnDelete->setEnabled( true );
+      btnSave->setEnabled( true );
     }
     else
     {
@@ -317,6 +319,7 @@ void QgsWFSSourceSelect::deleteEntryOfServerList()
       btnConnect->setEnabled( false );
       btnEdit->setEnabled( false );
       btnDelete->setEnabled( false );
+      btnSave->setEnabled( false );
     }
   }
 }

--- a/src/providers/wfs/qgswfssourceselect.cpp
+++ b/src/providers/wfs/qgswfssourceselect.cpp
@@ -303,6 +303,21 @@ void QgsWFSSourceSelect::deleteEntryOfServerList()
     QgsOWSConnection::deleteConnection( "WFS", cmbConnections->currentText() );
     cmbConnections->removeItem( cmbConnections->currentIndex() );
     emit connectionsChanged();
+
+    if ( cmbConnections->count() > 0 )
+    {
+      // Connections available - enable various buttons
+      btnConnect->setEnabled( true );
+      btnEdit->setEnabled( true );
+      btnDelete->setEnabled( true );
+    }
+    else
+    {
+      // No connections available - disable various buttons
+      btnConnect->setEnabled( false );
+      btnEdit->setEnabled( false );
+      btnDelete->setEnabled( false );
+    }
   }
 }
 

--- a/src/providers/wms/qgswmssourceselect.cpp
+++ b/src/providers/wms/qgswmssourceselect.cpp
@@ -1016,6 +1016,7 @@ void QgsWMSSourceSelect::setConnectionListPosition()
     btnConnect->setEnabled( false );
     btnEdit->setEnabled( false );
     btnDelete->setEnabled( false );
+    btnSave->setEnabled( false );
   }
   else
   {
@@ -1023,6 +1024,7 @@ void QgsWMSSourceSelect::setConnectionListPosition()
     btnConnect->setEnabled( true );
     btnEdit->setEnabled( true );
     btnDelete->setEnabled( true );
+    btnSave->setEnabled( true );
   }
 }
 

--- a/src/providers/wms/qgswmssourceselect.cpp
+++ b/src/providers/wms/qgswmssourceselect.cpp
@@ -164,21 +164,6 @@ void QgsWMSSourceSelect::populateConnectionList()
   cmbConnections->addItems( QgsWMSConnection::connectionList() );
 
   setConnectionListPosition();
-
-  if ( cmbConnections->count() == 0 )
-  {
-    // No connections - disable various buttons
-    btnConnect->setEnabled( false );
-    btnEdit->setEnabled( false );
-    btnDelete->setEnabled( false );
-  }
-  else
-  {
-    // Connections - enable various buttons
-    btnConnect->setEnabled( true );
-    btnEdit->setEnabled( true );
-    btnDelete->setEnabled( true );
-  }
 }
 void QgsWMSSourceSelect::on_btnNew_clicked()
 {
@@ -214,7 +199,7 @@ void QgsWMSSourceSelect::on_btnDelete_clicked()
   if ( result == QMessageBox::Ok )
   {
     QgsWMSConnection::deleteConnection( cmbConnections->currentText() );
-    cmbConnections->removeItem( cmbConnections->currentIndex() );  // populateConnectionList();
+    cmbConnections->removeItem( cmbConnections->currentIndex() );
     setConnectionListPosition();
     emit connectionsChanged();
   }
@@ -1023,6 +1008,21 @@ void QgsWMSSourceSelect::setConnectionListPosition()
       cmbConnections->setCurrentIndex( 0 );
     else
       cmbConnections->setCurrentIndex( cmbConnections->count() - 1 );
+  }
+
+  if ( cmbConnections->count() == 0 )
+  {
+    // No connections - disable various buttons
+    btnConnect->setEnabled( false );
+    btnEdit->setEnabled( false );
+    btnDelete->setEnabled( false );
+  }
+  else
+  {
+    // Connections - enable various buttons
+    btnConnect->setEnabled( true );
+    btnEdit->setEnabled( true );
+    btnDelete->setEnabled( true );
   }
 }
 


### PR DESCRIPTION
Changes:
In the http connection dialog, both 'Name' and 'Url' text boxes must be filled to enable 'ok' button.
Disable connect-edit-delete buttons when there is not any connection defined.
