### PR TITLE
[Feature][Processing] Headless

### DIFF
--- a/python/plugins/processing/core/Processing.py
+++ b/python/plugins/processing/core/Processing.py
@@ -34,6 +34,7 @@ from processing import interface
 from processing.core.ProcessingConfig import ProcessingConfig
 from processing.core.GeoAlgorithm import GeoAlgorithm
 from processing.core.ProcessingLog import ProcessingLog
+from processing.core.SilentProgress import SilentProgress
 from processing.gui.AlgorithmClassification import AlgorithmDecorator
 from processing.gui.MessageBarProgress import MessageBarProgress
 from processing.gui.RenderingStyles import RenderingStyles
@@ -347,7 +348,9 @@ class Processing:
         elif cursor.shape() != Qt.WaitCursor:
             QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
 
-        progress = MessageBarProgress()
+        progress = SilentProgress()
+        if not interface.iface == None :
+          progress = MessageBarProgress()
         ret = UnthreadedAlgorithmExecutor.runalg(alg, progress)
         if onFinish is not None and ret:
             onFinish(alg, progress)

--- a/python/plugins/processing/core/SilentProgress.py
+++ b/python/plugins/processing/core/SilentProgress.py
@@ -48,3 +48,6 @@ class SilentProgress:
 
     def setConsoleInfo(self, _):
         pass
+
+    def close(self):
+        pass

--- a/python/plugins/processing/tools/dataobjects.py
+++ b/python/plugins/processing/tools/dataobjects.py
@@ -65,7 +65,7 @@ def getSupportedOutputTableExtensions():
 
 
 def getRasterLayers():
-    layers = interface.iface.legendInterface().layers()
+    layers = QgsMapLayerRegistry.instance().mapLayers().values()
     raster = list()
 
     for layer in layers:
@@ -76,7 +76,7 @@ def getRasterLayers():
 
 
 def getVectorLayers(shapetype=[-1]):
-    layers = interface.iface.legendInterface().layers()
+    layers = QgsMapLayerRegistry.instance().mapLayers().values()
     vector = []
     for layer in layers:
         if layer.type() == layer.VectorLayer:
@@ -96,7 +96,7 @@ def getAllLayers():
 
 
 def getTables():
-    layers = interface.iface.legendInterface().layers()
+    layers = QgsMapLayerRegistry.instance().mapLayers().values()
     tables = list()
     for layer in layers:
         if layer.type() == layer.VectorLayer:


### PR DESCRIPTION
To use QGIS Processing in python scripts out of QGIS.
The changes made concern the dependence to legendInterface. In cases
where the interface.iface is null (None) QGIS Processing uses the
QgsMapLayerRegistry instance.
