### PR TITLE
fix project saving and reading of vsizip paths (fixes #6369)

### DIFF
--- a/src/core/qgis.cpp
+++ b/src/core/qgis.cpp
@@ -176,3 +176,19 @@ bool qgsVariantGreaterThan( const QVariant& lhs, const QVariant& rhs )
   return ! qgsVariantLessThan( lhs, rhs );
 }
 
+QString qgsVsiPrefix( QString path )
+{
+  if ( path.startsWith( "/vsizip/", Qt::CaseInsensitive ) ||
+       path.endsWith( ".zip", Qt::CaseInsensitive ) )
+    return "/vsizip/";
+  else if ( path.startsWith( "/vsitar/", Qt::CaseInsensitive ) ||
+            path.endsWith( ".tar", Qt::CaseInsensitive ) ||
+            path.endsWith( ".tar.gz", Qt::CaseInsensitive ) ||
+            path.endsWith( ".tgz", Qt::CaseInsensitive ) )
+    return "/vsitar/";
+  else if ( path.startsWith( "/vsigzip/", Qt::CaseInsensitive ) ||
+            path.endsWith( ".gz", Qt::CaseInsensitive ) )
+    return "/vsigzip/";
+  else
+    return "";
+}

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -324,6 +324,8 @@ bool qgsVariantLessThan( const QVariant& lhs, const QVariant& rhs );
 
 bool qgsVariantGreaterThan( const QVariant& lhs, const QVariant& rhs );
 
+QString qgsVsiPrefix( QString path );
+
 /** Allocates size bytes and returns a pointer to the allocated  memory.
     Works like C malloc() but prints debug message by QgsLogger if allocation fails.
     @param size size in bytes

--- a/src/core/qgsdataitem.cpp
+++ b/src/core/qgsdataitem.cpp
@@ -954,23 +954,6 @@ QVector<QgsDataItem*> QgsZipItem::createChildren()
   return children;
 }
 
-QString QgsZipItem::vsiPrefix( QString path )
-{
-  if ( path.startsWith( "/vsizip/", Qt::CaseInsensitive ) ||
-       path.endsWith( ".zip", Qt::CaseInsensitive ) )
-    return "/vsizip/";
-  else if ( path.startsWith( "/vsitar/", Qt::CaseInsensitive ) ||
-            path.endsWith( ".tar", Qt::CaseInsensitive ) ||
-            path.endsWith( ".tar.gz", Qt::CaseInsensitive ) ||
-            path.endsWith( ".tgz", Qt::CaseInsensitive ) )
-    return "/vsitar/";
-  else if ( path.startsWith( "/vsigzip/", Qt::CaseInsensitive ) ||
-            path.endsWith( ".gz", Qt::CaseInsensitive ) )
-    return "/vsigzip/";
-  else
-    return "";
-}
-
 QgsDataItem* QgsZipItem::itemFromPath( QgsDataItem* parent, QString path, QString name )
 {
   QSettings settings;

--- a/src/core/qgsdataitem.h
+++ b/src/core/qgsdataitem.h
@@ -316,7 +316,7 @@ class CORE_EXPORT QgsZipItem : public QgsDataCollectionItem
     static QVector<dataItem_t *> mDataItemPtr;
     static QStringList mProviderNames;
 
-    static QString vsiPrefix( QString uri );
+    static QString vsiPrefix( QString uri ) { return qgsVsiPrefix( uri ); }
 
     static QgsDataItem* itemFromPath( QgsDataItem* parent, QString path, QString name );
 

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -1366,6 +1366,13 @@ QString QgsProject::readPath( QString src ) const
     return src;
   }
 
+  // if this is a VSIFILE, remove the VSI prefix and append to final result
+  QString vsiPrefix = qgsVsiPrefix( src );
+  if ( ! vsiPrefix.isEmpty() )
+  {
+    src.remove(0, vsiPrefix.size());  
+  }
+
   // relative path should always start with ./ or ../
   if ( !src.startsWith( "./" ) && !src.startsWith( "../" ) )
   {
@@ -1375,13 +1382,13 @@ QString QgsProject::readPath( QString src ) const
          ( src[0].isLetter() && src[1] == ':' ) )
     {
       // UNC or absolute path
-      return src;
+      return vsiPrefix + src;
     }
 #else
     if ( src[0] == '/' )
     {
       // absolute path
-      return src;
+      return vsiPrefix + src;
     }
 #endif
 
@@ -1391,17 +1398,17 @@ QString QgsProject::readPath( QString src ) const
     // from the filename.
     QString home = homePath();
     if ( home.isNull() )
-      return src;
+      return vsiPrefix + src;
 
     QFileInfo fi( home + "/" + src );
 
     if ( !fi.exists() )
     {
-      return src;
+      return vsiPrefix + src;
     }
     else
     {
-      return fi.canonicalFilePath();
+      return vsiPrefix + fi.canonicalFilePath();
     }
   }
 
@@ -1410,7 +1417,7 @@ QString QgsProject::readPath( QString src ) const
 
   if ( projPath.isEmpty() )
   {
-    return src;
+    return vsiPrefix + src;
   }
 
 #if defined(Q_OS_WIN)
@@ -1452,13 +1459,13 @@ QString QgsProject::readPath( QString src ) const
   projElems.prepend( "" );
 #endif
 
-  return projElems.join( "/" );
+  return vsiPrefix + projElems.join( "/" );
 }
 
 // return the absolute or relative path to write it to the project file
 QString QgsProject::writePath( QString src ) const
 {
-  if ( readBoolEntry( "Paths", "/Absolute", false ) || src.isEmpty() )
+   if ( readBoolEntry( "Paths", "/Absolute", false ) || src.isEmpty() )
   {
     return src;
   }
@@ -1467,8 +1474,15 @@ QString QgsProject::writePath( QString src ) const
   QString projPath = fileName();
 
   if ( projPath.isEmpty() )
-  {
+  {  
     return src;
+  }
+
+  // if this is a VSIFILE, remove the VSI prefix and append to final result
+  QString vsiPrefix = qgsVsiPrefix( src );
+  if ( ! vsiPrefix.isEmpty() )
+  {
+    srcPath.remove(0, vsiPrefix.size());  
   }
 
 #if defined( Q_OS_WIN )
@@ -1533,7 +1547,7 @@ QString QgsProject::writePath( QString src ) const
     srcElems.insert( 0, "." );
   }
 
-  return srcElems.join( "/" );
+  return vsiPrefix + srcElems.join( "/" );
 }
 
 void QgsProject::setError( QString errorMessage )


### PR DESCRIPTION
I am submitting this as a pull request for review because it can potentially break layer reading/writing in projects. 

But it should not, as it simply removes the vsiprefix from a path (e.g. /vsizip/) before prepending it to final result, in QgsProject::readPath writePath

QgsZipItem::vsiPrefix was moved to Qgis.h so that any code that uses it does not depend on qgsdataitem.h
