### PR TITLE
Add zoom scales to composer and zoom to 100% action

### DIFF
--- a/src/app/composer/qgscomposer.h
+++ b/src/app/composer/qgscomposer.h
@@ -126,6 +126,9 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
     //! Zoom out
     void on_mActionZoomOut_triggered();
 
+    //! Zoom actual
+    void on_mActionZoomActual_triggered();
+
     //! Refresh view
     void on_mActionRefreshView_triggered();
 
@@ -365,6 +368,13 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
     //! Updates cursor position in status bar
     void updateStatusCursorPos( QPointF position );
 
+    //! Updates zoom level in status bar
+    void updateStatusZoom();
+
+    void on_mStatusZoomCombo_currentIndexChanged( int index );
+
+    void on_mStatusZoomCombo_zoomEntered();
+
     //! Updates status bar composition message
     void updateStatusCompositionMsg( QString message );
 
@@ -414,6 +424,9 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
     QLabel* mStatusCursorXLabel;
     QLabel* mStatusCursorYLabel;
     QLabel* mStatusCursorPageLabel;
+    /**Combobox in status bar which shows/adjusts current zoom level*/
+    QComboBox* mStatusZoomCombo;
+    QList<double> mStatusZoomLevelsList;
     /**Label in status bar which shows messages from the composition*/
     QLabel* mStatusCompositionLabel;
 

--- a/src/gui/qgscomposerview.cpp
+++ b/src/gui/qgscomposerview.cpp
@@ -23,6 +23,7 @@
 #include <QMimeData>
 #include <QGridLayout>
 
+#include "qgsapplication.h"
 #include "qgscomposerview.h"
 #include "qgscomposerarrow.h"
 #include "qgscomposerframe.h"
@@ -1313,6 +1314,7 @@ void QgsComposerView::wheelZoom( QWheelEvent * event )
   }
 
   //update composition for new zoom
+  emit zoomLevelChanged();
   updateRulers();
   update();
   //redraw cached map items
@@ -1326,6 +1328,22 @@ void QgsComposerView::wheelZoom( QWheelEvent * event )
       mypItem->updateCachedImage();
     }
   }
+}
+
+void QgsComposerView::setZoomLevel( double zoomLevel )
+{
+  double dpi = QgsApplication::desktop()->logicalDpiX();
+  //monitor dpi is not always correct - so make sure the value is sane
+  if (( dpi < 60 ) || ( dpi > 250 ) )
+    dpi = 72;
+
+  //desired pixel width for 1mm on screen
+  double scale = zoomLevel * dpi / 25.4;
+  setTransform( QTransform::fromScale( scale , scale ) );
+
+  updateRulers();
+  update();
+  emit zoomLevelChanged();
 }
 
 void QgsComposerView::paintEvent( QPaintEvent* event )
@@ -1356,6 +1374,7 @@ void QgsComposerView::showEvent( QShowEvent* e )
 void QgsComposerView::resizeEvent( QResizeEvent* event )
 {
   QGraphicsView::resizeEvent( event );
+  emit zoomLevelChanged();
   updateRulers();
 }
 

--- a/src/gui/qgscomposerview.h
+++ b/src/gui/qgscomposerview.h
@@ -136,6 +136,9 @@ class GUI_EXPORT QgsComposerView: public QGraphicsView
     void setHorizontalRuler( QgsComposerRuler* r ) { mHorizontalRuler = r; }
     void setVerticalRuler( QgsComposerRuler* r ) { mVerticalRuler = r; }
 
+    /**Set zoom level, where a zoom level of 1.0 corresponds to 100%*/
+    void setZoomLevel( double zoomLevel );
+
   protected:
     void mousePressEvent( QMouseEvent* );
     void mouseReleaseEvent( QMouseEvent* );
@@ -220,6 +223,8 @@ class GUI_EXPORT QgsComposerView: public QGraphicsView
     void actionFinished();
     /**Is emitted when mouse cursor coordinates change*/
     void cursorPosChanged( QPointF );
+    /**Is emitted when the view zoom changes*/
+    void zoomLevelChanged();
 
     /**Emitted before composerview is shown*/
     void composerViewShow( QgsComposerView* );

--- a/src/ui/qgscomposerbase.ui
+++ b/src/ui/qgscomposerbase.ui
@@ -76,6 +76,7 @@
     <bool>true</bool>
    </attribute>
    <addaction name="mActionZoomAll"/>
+   <addaction name="mActionZoomActual"/>
    <addaction name="mActionZoomIn"/>
    <addaction name="mActionZoomOut"/>
    <addaction name="mActionRefreshView"/>
@@ -177,6 +178,21 @@
    </property>
    <property name="shortcut">
     <string>Ctrl+-</string>
+   </property>
+  </action>
+  <action name="mActionZoomActual">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionZoomActual.svg</normaloff>:/images/themes/default/mActionZoomActual.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Zoom to 100%</string>
+   </property>
+   <property name="toolTip">
+    <string>Zoom to 100%</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+1</string>
    </property>
   </action>
   <action name="mActionMouseZoom">


### PR DESCRIPTION
This adds a new "100% zoom" action, for quickly zooming a composition to actual size. It also adds a new control to the status bar which shows the current zoom level, and allows for entering an exact zoom scale or choosing from predefined scales via a combo box.

Also includes a small enhancement which makes sure that wheel zoom actions result in a predictable zoom step, so that zooming in then out always returns to the exact original zoom level. 
