### PR TITLE
[FEATURE] Preview mode for Atlas prints - sponsored by SIGE

### DIFF
--- a/src/app/composer/qgsatlascompositionwidget.cpp
+++ b/src/app/composer/qgsatlascompositionwidget.cpp
@@ -136,6 +136,7 @@ void QgsAtlasCompositionWidget::onLayerAdded( QgsMapLayer* map )
     if ( mAtlasCoverageLayerComboBox->count() == 1 )
     {
       atlasMap->setCoverageLayer( vectorLayer );
+      atlasMap->updateFeatures();
       checkLayerType( vectorLayer );
     }
   }
@@ -191,6 +192,7 @@ void QgsAtlasCompositionWidget::on_mAtlasCoverageLayerComboBox_currentIndexChang
     {
       checkLayerType( layer );
       atlasMap->setCoverageLayer( layer );
+      atlasMap->updateFeatures();
     }
 
     // update sorting columns
@@ -333,6 +335,7 @@ void QgsAtlasCompositionWidget::on_mAtlasSortFeatureCheckBox_stateChanged( int s
     mAtlasSortFeatureKeyComboBox->setEnabled( false );
   }
   atlasMap->setSortFeatures( state == Qt::Checked );
+  atlasMap->updateFeatures();
 }
 
 void QgsAtlasCompositionWidget::on_mAtlasSortFeatureKeyComboBox_currentIndexChanged( int index )
@@ -347,6 +350,7 @@ void QgsAtlasCompositionWidget::on_mAtlasSortFeatureKeyComboBox_currentIndexChan
   {
     atlasMap->setSortKeyAttributeIndex( index );
   }
+  atlasMap->updateFeatures();
 }
 
 void QgsAtlasCompositionWidget::on_mAtlasFeatureFilterCheckBox_stateChanged( int state )
@@ -368,6 +372,7 @@ void QgsAtlasCompositionWidget::on_mAtlasFeatureFilterCheckBox_stateChanged( int
     mAtlasFeatureFilterButton->setEnabled( false );
   }
   atlasMap->setFilterFeatures( state == Qt::Checked );
+  atlasMap->updateFeatures();
 }
 
 void QgsAtlasCompositionWidget::on_mAtlasFeatureFilterEdit_textChanged( const QString& text )
@@ -379,6 +384,7 @@ void QgsAtlasCompositionWidget::on_mAtlasFeatureFilterEdit_textChanged( const QS
   }
 
   atlasMap->setFeatureFilter( text );
+  atlasMap->updateFeatures();
 }
 
 void QgsAtlasCompositionWidget::on_mAtlasFeatureFilterButton_clicked()
@@ -415,6 +421,7 @@ void QgsAtlasCompositionWidget::on_mAtlasSortFeatureDirectionButton_clicked()
   }
 
   atlasMap->setSortAscending( at == Qt::UpArrow );
+  atlasMap->updateFeatures();
 }
 
 void QgsAtlasCompositionWidget::fillSortColumns()

--- a/src/app/composer/qgsatlascompositionwidget.cpp
+++ b/src/app/composer/qgsatlascompositionwidget.cpp
@@ -136,7 +136,7 @@ void QgsAtlasCompositionWidget::onLayerAdded( QgsMapLayer* map )
     if ( mAtlasCoverageLayerComboBox->count() == 1 )
     {
       atlasMap->setCoverageLayer( vectorLayer );
-      atlasMap->updateFeatures();
+      updateAtlasFeatures();
       checkLayerType( vectorLayer );
     }
   }
@@ -192,7 +192,7 @@ void QgsAtlasCompositionWidget::on_mAtlasCoverageLayerComboBox_currentIndexChang
     {
       checkLayerType( layer );
       atlasMap->setCoverageLayer( layer );
-      atlasMap->updateFeatures();
+      updateAtlasFeatures();
     }
 
     // update sorting columns
@@ -335,7 +335,36 @@ void QgsAtlasCompositionWidget::on_mAtlasSortFeatureCheckBox_stateChanged( int s
     mAtlasSortFeatureKeyComboBox->setEnabled( false );
   }
   atlasMap->setSortFeatures( state == Qt::Checked );
-  atlasMap->updateFeatures();
+  updateAtlasFeatures();
+}
+
+void QgsAtlasCompositionWidget::updateAtlasFeatures()
+{
+  //only do this if composer mode is preview
+  if ( !mComposition->atlasPreviewEnabled() )
+  {
+    return;
+  }
+
+  //update atlas features
+  QgsAtlasComposition* atlasMap = &mComposition->atlasComposition();
+  if ( !atlasMap )
+  {
+    return;
+  }
+
+  bool updated = atlasMap->updateFeatures();
+  if ( !updated )
+  {
+    QMessageBox::warning( 0, tr( "Atlas preview" ),
+                          tr( "No matching atlas features found!" ),
+                          QMessageBox::Ok,
+                          QMessageBox::Ok );
+
+    //Perhaps atlas preview should be disabled now? If so, it may get annoying if user is editing
+    //the filter expression and it keeps disabling itself.
+    return;
+  }
 }
 
 void QgsAtlasCompositionWidget::on_mAtlasSortFeatureKeyComboBox_currentIndexChanged( int index )
@@ -350,7 +379,7 @@ void QgsAtlasCompositionWidget::on_mAtlasSortFeatureKeyComboBox_currentIndexChan
   {
     atlasMap->setSortKeyAttributeIndex( index );
   }
-  atlasMap->updateFeatures();
+  updateAtlasFeatures();
 }
 
 void QgsAtlasCompositionWidget::on_mAtlasFeatureFilterCheckBox_stateChanged( int state )
@@ -372,7 +401,7 @@ void QgsAtlasCompositionWidget::on_mAtlasFeatureFilterCheckBox_stateChanged( int
     mAtlasFeatureFilterButton->setEnabled( false );
   }
   atlasMap->setFilterFeatures( state == Qt::Checked );
-  atlasMap->updateFeatures();
+  updateAtlasFeatures();
 }
 
 void QgsAtlasCompositionWidget::on_mAtlasFeatureFilterEdit_textChanged( const QString& text )
@@ -384,7 +413,7 @@ void QgsAtlasCompositionWidget::on_mAtlasFeatureFilterEdit_textChanged( const QS
   }
 
   atlasMap->setFeatureFilter( text );
-  atlasMap->updateFeatures();
+  updateAtlasFeatures();
 }
 
 void QgsAtlasCompositionWidget::on_mAtlasFeatureFilterButton_clicked()
@@ -421,7 +450,7 @@ void QgsAtlasCompositionWidget::on_mAtlasSortFeatureDirectionButton_clicked()
   }
 
   atlasMap->setSortAscending( at == Qt::UpArrow );
-  atlasMap->updateFeatures();
+  updateAtlasFeatures();
 }
 
 void QgsAtlasCompositionWidget::fillSortColumns()

--- a/src/app/composer/qgsatlascompositionwidget.h
+++ b/src/app/composer/qgsatlascompositionwidget.h
@@ -62,6 +62,8 @@ class QgsAtlasCompositionWidget:
 
     void updateGuiElements();
 
+    void updateAtlasFeatures();
+
   private:
     QgsComposition* mComposition;
 

--- a/src/app/composer/qgscomposer.cpp
+++ b/src/app/composer/qgscomposer.cpp
@@ -316,6 +316,8 @@ QgsComposer::QgsComposer( QgisApp *qgis, const QString& title )
   atlasMenu->addAction( mActionExportAtlasAsImage );
   atlasMenu->addAction( mActionExportAtlasAsSVG );
   atlasMenu->addAction( mActionExportAtlasAsPDF );
+  atlasMenu->addSeparator();
+  atlasMenu->addAction( mActionAtlasSettings );
 
   QToolButton* atlasExportToolButton = new QToolButton( mAtlasToolbar );
   atlasExportToolButton->setPopupMode( QToolButton::InstantPopup );
@@ -325,7 +327,7 @@ QgsComposer::QgsComposer( QgisApp *qgis, const QString& title )
   atlasExportToolButton->addAction( mActionExportAtlasAsSVG );
   atlasExportToolButton->addAction( mActionExportAtlasAsPDF );
   atlasExportToolButton->setDefaultAction( mActionExportAtlasAsImage );
-  mAtlasToolbar->addWidget( atlasExportToolButton );
+  mAtlasToolbar->insertWidget( mActionAtlasSettings, atlasExportToolButton );
 
   QMenu *settingsMenu = menuBar()->addMenu( tr( "Settings" ) );
   settingsMenu->addAction( mActionOptions );
@@ -954,6 +956,16 @@ void QgsComposer::on_mActionClearGuides_triggered()
   {
     mComposition->clearSnapLines();
   }
+}
+
+void QgsComposer::on_mActionAtlasSettings_triggered()
+{
+  if ( !mAtlasDock->isVisible() )
+  {
+    mAtlasDock->show();
+  }
+
+  mAtlasDock->raise();
 }
 
 void QgsComposer::on_mActionExportAtlasAsPDF_triggered()

--- a/src/app/composer/qgscomposer.cpp
+++ b/src/app/composer/qgscomposer.cpp
@@ -341,10 +341,14 @@ QgsComposer::QgsComposer( QgisApp *qgis, const QString& title )
   mStatusCursorPageLabel = new QLabel( mStatusBar );
   mStatusCursorPageLabel->setMinimumWidth( 100 );
   mStatusCompositionLabel = new QLabel( mStatusBar );
+  mStatusCompositionLabel->setMinimumWidth( 350 );
+  mStatusAtlasLabel = new QLabel( mStatusBar );
+
   mStatusBar->addWidget( mStatusCursorXLabel );
   mStatusBar->addWidget( mStatusCursorYLabel );
   mStatusBar->addWidget( mStatusCursorPageLabel );
   mStatusBar->addWidget( mStatusCompositionLabel );
+  mStatusBar->addWidget( mStatusAtlasLabel );
 
   //create composer view and layout with rulers
   mView = 0;
@@ -559,6 +563,9 @@ void QgsComposer::connectSlots()
   connect( mVerticalRuler, SIGNAL( cursorPosChanged( QPointF ) ), this, SLOT( updateStatusCursorPos( QPointF ) ) );
   //listen out to status bar updates from the composition
   connect( mComposition, SIGNAL( statusMsgChanged( QString ) ), this, SLOT( updateStatusCompositionMsg( QString ) ) );
+  //listen out to status bar updates from the atlas
+  QgsAtlasComposition* atlasMap = &mComposition->atlasComposition();
+  connect( atlasMap, SIGNAL( statusMsgChanged( QString ) ), this, SLOT( updateStatusAtlasMsg( QString ) ) );
 }
 
 void QgsComposer::open( void )
@@ -646,6 +653,11 @@ void QgsComposer::updateStatusCompositionMsg( QString message )
   mStatusCompositionLabel->setText( message );
 }
 
+void QgsComposer::updateStatusAtlasMsg( QString message )
+{
+  mStatusAtlasLabel->setText( message );
+}
+
 void QgsComposer::showItemOptions( QgsComposerItem* item )
 {
   QWidget* currentWidget = mItemDock->widget();
@@ -699,6 +711,7 @@ void QgsComposer::on_mActionAtlasPreview_triggered( bool checked )
     mActionAtlasPreview->blockSignals( true );
     mActionAtlasPreview->setChecked( false );
     mActionAtlasPreview->blockSignals( false );
+    mStatusAtlasLabel->setText( QString() );
     return;
   }
 
@@ -712,6 +725,10 @@ void QgsComposer::on_mActionAtlasPreview_triggered( bool checked )
   if ( checked )
   {
     atlasMap->firstFeature();
+  }
+  else
+  {
+    mStatusAtlasLabel->setText( QString() );
   }
 
 }

--- a/src/app/composer/qgscomposer.cpp
+++ b/src/app/composer/qgscomposer.cpp
@@ -305,6 +305,13 @@ QgsComposer::QgsComposer( QgisApp *qgis, const QString& title )
   layoutMenu->addAction( mActionLockItems );
   layoutMenu->addAction( mActionUnlockAll );
 
+  QMenu *atlasMenu = menuBar()->addMenu( tr( "Atlas" ) );
+  atlasMenu->addAction( mActionAtlasPreview );
+  atlasMenu->addAction( mActionAtlasFirst );
+  atlasMenu->addAction( mActionAtlasPrev );
+  atlasMenu->addAction( mActionAtlasNext );
+  atlasMenu->addAction( mActionAtlasLast );
+
   QMenu *settingsMenu = menuBar()->addMenu( tr( "Settings" ) );
   settingsMenu->addAction( mActionOptions );
 

--- a/src/app/composer/qgscomposer.cpp
+++ b/src/app/composer/qgscomposer.cpp
@@ -471,6 +471,8 @@ QgsComposer::QgsComposer( QgisApp *qgis, const QString& title )
   mActionExportAtlasAsImage->setEnabled( false );
   mActionExportAtlasAsSVG->setEnabled( false );
   mActionExportAtlasAsPDF->setEnabled( false );
+  QgsAtlasComposition* atlasMap = &mComposition->atlasComposition();
+  connect( atlasMap, SIGNAL( toggled( bool ) ), this, SLOT( toggleAtlasControls( bool ) ) );
 
   // Create size grip (needed by Mac OS X for QMainWindow if QStatusBar is not visible)
   //should not be needed now that composer has a status bar?
@@ -771,6 +773,7 @@ void QgsComposer::on_mActionAtlasPreview_triggered( bool checked )
   if ( checked )
   {
     atlasMap->firstFeature();
+    emit( atlasPreviewFeatureChanged() );
   }
   else
   {
@@ -789,7 +792,7 @@ void QgsComposer::on_mActionAtlasNext_triggered()
   }
 
   atlasMap->nextFeature();
-
+  emit( atlasPreviewFeatureChanged() );
 }
 
 void QgsComposer::on_mActionAtlasPrev_triggered()
@@ -801,7 +804,7 @@ void QgsComposer::on_mActionAtlasPrev_triggered()
   }
 
   atlasMap->prevFeature();
-
+  emit( atlasPreviewFeatureChanged() );
 }
 
 void QgsComposer::on_mActionAtlasFirst_triggered()
@@ -813,6 +816,7 @@ void QgsComposer::on_mActionAtlasFirst_triggered()
   }
 
   atlasMap->firstFeature();
+  emit( atlasPreviewFeatureChanged() );
 }
 
 void QgsComposer::on_mActionAtlasLast_triggered()
@@ -824,6 +828,7 @@ void QgsComposer::on_mActionAtlasLast_triggered()
   }
 
   atlasMap->lastFeature();
+  emit( atlasPreviewFeatureChanged() );
 }
 
 QgsMapCanvas *QgsComposer::mapCanvas( void )

--- a/src/app/composer/qgscomposer.cpp
+++ b/src/app/composer/qgscomposer.cpp
@@ -721,7 +721,21 @@ void QgsComposer::on_mActionAtlasPreview_triggered( bool checked )
   mActionAtlasNext->setEnabled( checked );
   mActionAtlasPrev->setEnabled( checked );
 
-  mComposition->setAtlasPreviewEnabled( checked );
+  bool previewEnabled = mComposition->setAtlasPreviewEnabled( checked );
+  if ( !previewEnabled )
+  {
+    //something went wrong, eg, no matching features
+    QMessageBox::warning( 0, tr( "Enable atlas preview" ),
+                          tr( "No matching atlas features found!" ),
+                          QMessageBox::Ok,
+                          QMessageBox::Ok );
+    mActionAtlasPreview->blockSignals( true );
+    mActionAtlasPreview->setChecked( false );
+    mActionAtlasPreview->blockSignals( false );
+    mStatusAtlasLabel->setText( QString() );
+    return;
+  }
+
   if ( checked )
   {
     atlasMap->firstFeature();

--- a/src/app/composer/qgscomposer.h
+++ b/src/app/composer/qgscomposer.h
@@ -383,6 +383,9 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
     //! Updates status bar composition message
     void updateStatusCompositionMsg( QString message );
 
+    //! Updates status bar atlas message
+    void updateStatusAtlasMsg( QString message );
+
   private:
 
     /**Establishes the signal slot connection for the class*/
@@ -431,6 +434,8 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
     QLabel* mStatusCursorPageLabel;
     /**Label in status bar which shows messages from the composition*/
     QLabel* mStatusCompositionLabel;
+    /**Label in status bar which shows atlas details*/
+    QLabel* mStatusAtlasLabel;
 
     //! Pointer to composer view
     QgsComposerView *mView;

--- a/src/app/composer/qgscomposer.h
+++ b/src/app/composer/qgscomposer.h
@@ -123,6 +123,9 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
     //!Composer deletes the old composerview when loading a template
     void composerWillBeRemoved( QgsComposerView* v );
 
+    //! Is emitted when the atlas preview feature changes
+    void atlasPreviewFeatureChanged();
+
   public slots:
     //! Zoom to full extent of the paper
     void on_mActionZoomAll_triggered();

--- a/src/app/composer/qgscomposer.h
+++ b/src/app/composer/qgscomposer.h
@@ -56,6 +56,13 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
     Q_OBJECT
 
   public:
+
+    enum OutputMode
+    {
+      Single = 0,
+      Atlas
+    };
+
     QgsComposer( QgisApp *qgis, const QString& title );
     ~QgsComposer();
 
@@ -324,6 +331,18 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
     //!Last atlas feature
     void on_mActionAtlasLast_triggered();
 
+    //! Print the atlas
+    void on_mActionPrintAtlas_triggered();
+
+    //! Print atlas as image
+    void on_mActionExportAtlasAsImage_triggered();
+
+    //! Print atlas as SVG
+    void on_mActionExportAtlasAsSVG_triggered();
+
+    //! Print atlas as PDF
+    void on_mActionExportAtlasAsPDF_triggered();
+
     //! Save window state
     void saveWindowState();
 
@@ -424,6 +443,18 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
 
     //! Updates the grid/guide action status based on compositions grid/guide settings
     void restoreGridSettings();
+
+    //! Prints either the whole atlas or just the current feature, depending on mode
+    void printComposition( QgsComposer::OutputMode mode );
+
+    //! Exports either either the whole atlas or just the current feature as an image, depending on mode
+    void exportCompositionAsImage( QgsComposer::OutputMode mode );
+
+    //! Exports either either the whole atlas or just the current feature as an SVG, depending on mode
+    void exportCompositionAsSVG( QgsComposer::OutputMode mode );
+
+    //! Exports either either the whole atlas or just the current feature as a PDF, depending on mode
+    void exportCompositionAsPDF( QgsComposer::OutputMode mode );
 
     /**Composer title*/
     QString mTitle;

--- a/src/app/composer/qgscomposer.h
+++ b/src/app/composer/qgscomposer.h
@@ -343,6 +343,9 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
     //! Print atlas as PDF
     void on_mActionExportAtlasAsPDF_triggered();
 
+    //! Atlas settings
+    void on_mActionAtlasSettings_triggered();
+
     //! Save window state
     void saveWindowState();
 

--- a/src/app/composer/qgscomposer.h
+++ b/src/app/composer/qgscomposer.h
@@ -309,6 +309,21 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
     //!Show options dialog
     void on_mActionOptions_triggered();
 
+    //!Toggle atlas preview
+    void on_mActionAtlasPreview_triggered( bool checked );
+
+    //!Next atlas feature
+    void on_mActionAtlasNext_triggered();
+
+    //!Previous atlas feature
+    void on_mActionAtlasPrev_triggered();
+
+    //!First atlas feature
+    void on_mActionAtlasFirst_triggered();
+
+    //!Last atlas feature
+    void on_mActionAtlasLast_triggered();
+
     //! Save window state
     void saveWindowState();
 
@@ -501,6 +516,10 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
     //! Create a duplicate of a menu (for Mac)
     //! @note added in 1.9
     QMenu* mirrorOtherMenu( QMenu* otherMenu );
+
+    //! Toggles the state of the atlas preview and navigation controls
+    //! @note added in 2.1
+    void toggleAtlasControls( bool atlasEnabled );
 };
 
 #endif

--- a/src/app/composer/qgscomposermapwidget.cpp
+++ b/src/app/composer/qgscomposermapwidget.cpp
@@ -173,7 +173,7 @@ void QgsComposerMapWidget::on_mSetToMapCanvasExtentButton_clicked()
 
       //Make sure the width/height ratio is the same as in current composer map extent.
       //This is to keep the map item frame and the page layout fixed
-      QgsRectangle currentMapExtent = mComposerMap->extent();
+      QgsRectangle currentMapExtent = *( mComposerMap->currentMapExtent() );
       double currentWidthHeightRatio = currentMapExtent.width() / currentMapExtent.height();
       double newWidthHeightRatio = newExtent.width() / newExtent.height();
 
@@ -272,7 +272,7 @@ void QgsComposerMapWidget::updateGuiElements()
     }
 
     //composer map extent
-    QgsRectangle composerMapExtent = mComposerMap->extent();
+    QgsRectangle composerMapExtent = *( mComposerMap->currentMapExtent() );
     mXMinLineEdit->setText( QString::number( composerMapExtent.xMinimum(), 'f', 3 ) );
     mXMaxLineEdit->setText( QString::number( composerMapExtent.xMaximum(), 'f', 3 ) );
     mYMinLineEdit->setText( QString::number( composerMapExtent.yMinimum(), 'f', 3 ) );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5025,6 +5025,7 @@ QgsComposer* QgisApp::createNewComposer( QString title )
   emit composerAdded( newComposerObject->view() );
   connect( newComposerObject, SIGNAL( composerAdded( QgsComposerView* ) ), this, SIGNAL( composerAdded( QgsComposerView* ) ) );
   connect( newComposerObject, SIGNAL( composerWillBeRemoved( QgsComposerView* ) ), this, SIGNAL( composerWillBeRemoved( QgsComposerView* ) ) );
+  connect( newComposerObject, SIGNAL( atlasPreviewFeatureChanged() ), this, SLOT( refreshMapCanvas() ) );
   markDirty();
   return newComposerObject;
 }
@@ -5114,6 +5115,7 @@ bool QgisApp::loadComposersFromProject( const QDomDocument& doc )
     emit composerAdded( composer->view() );
     connect( composer, SIGNAL( composerAdded( QgsComposerView* ) ), this, SIGNAL( composerAdded( QgsComposerView* ) ) );
     connect( composer, SIGNAL( composerWillBeRemoved( QgsComposerView* ) ), this, SIGNAL( composerWillBeRemoved( QgsComposerView* ) ) );
+    connect( composer, SIGNAL( atlasPreviewFeatureChanged() ), this, SLOT( refreshMapCanvas() ) );
   }
   return true;
 }

--- a/src/core/composer/qgsatlascomposition.cpp
+++ b/src/core/composer/qgsatlascomposition.cpp
@@ -297,17 +297,8 @@ void QgsAtlasComposition::prepareForFeature( int featureI )
   QgsExpression::setSpecialColumn( "$atlasfeatureid", mCurrentFeature.id() );
   QgsExpression::setSpecialColumn( "$atlasgeometry", QVariant::fromValue( *mCurrentFeature.geometry() ) );
 
-  if ( !mSingleFile && mFilenamePattern.size() > 0 )
-  {
-    QgsExpression::setSpecialColumn( "$feature", QVariant(( int )featureI + 1 ) );
-    QVariant filenameRes = mFilenameExpr->evaluate( &mCurrentFeature, mCoverageLayer->pendingFields() );
-    if ( mFilenameExpr->hasEvalError() )
-    {
-      throw std::runtime_error( tr( "Filename eval error: %1" ).arg( mFilenameExpr->evalErrorString() ).toLocal8Bit().data() );
-    }
-
-    mCurrentFilename = filenameRes.toString();
-  }
+  // generate filename for current feature
+  evalFeatureFilename();
 
   //
   // compute the new extent
@@ -547,6 +538,28 @@ void QgsAtlasComposition::updateFilenameExpression()
 
     // prepare the filename expression
     mFilenameExpr->prepare( fields );
+  }
+
+  //if atlas preview is currently enabled, regenerate filename for current feature
+  if ( mComposition->atlasPreviewEnabled() )
+  {
+    evalFeatureFilename();
+  }
+
+}
+
+void QgsAtlasComposition::evalFeatureFilename()
+{
+  //generate filename for current atlas feature
+  if ( !mSingleFile && mFilenamePattern.size() > 0 )
+  {
+    QVariant filenameRes = mFilenameExpr->evaluate( &mCurrentFeature, mCoverageLayer->pendingFields() );
+    if ( mFilenameExpr->hasEvalError() )
+    {
+      throw std::runtime_error( tr( "Filename eval error: %1" ).arg( mFilenameExpr->evalErrorString() ).toLocal8Bit().data() );
+    }
+
+    mCurrentFilename = filenameRes.toString();
   }
 }
 

--- a/src/core/composer/qgsatlascomposition.cpp
+++ b/src/core/composer/qgsatlascomposition.cpp
@@ -296,6 +296,7 @@ void QgsAtlasComposition::prepareForFeature( int featureI )
 
   QgsExpression::setSpecialColumn( "$atlasfeatureid", mCurrentFeature.id() );
   QgsExpression::setSpecialColumn( "$atlasgeometry", QVariant::fromValue( *mCurrentFeature.geometry() ) );
+  QgsExpression::setSpecialColumn( "$feature", QVariant(( int )featureI + 1 ) );
 
   // generate filename for current feature
   evalFeatureFilename();
@@ -367,7 +368,6 @@ void QgsAtlasComposition::prepareForFeature( int featureI )
   // evaluate label expressions
   QList<QgsComposerLabel*> labels;
   mComposition->composerItems( labels );
-  QgsExpression::setSpecialColumn( "$feature", QVariant(( int )featureI + 1 ) );
 
   for ( QList<QgsComposerLabel*>::iterator lit = labels.begin(); lit != labels.end(); ++lit )
   {

--- a/src/core/composer/qgsatlascomposition.cpp
+++ b/src/core/composer/qgsatlascomposition.cpp
@@ -181,7 +181,7 @@ void QgsAtlasComposition::updateFeatures()
   }
 
   QgsExpression::setSpecialColumn( "$numfeatures", QVariant(( int )mFeatureIds.size() ) );
-  
+
   //jump to first feature if currently using an atlas preview
   //need to do this in case filtering/layer change has altered matching features
   if ( mComposition->atlasPreviewEnabled() )
@@ -290,6 +290,12 @@ void QgsAtlasComposition::prepareForFeature( int featureI )
     return;
   }
 
+  if ( mFeatureIds.size() == 0 )
+  {
+    emit statusMsgChanged( tr( "No matching atlas features" ) );
+    return;
+  }
+
   // retrieve the next feature, based on its id
   mCoverageLayer->getFeatures( QgsFeatureRequest().setFilterFid( mFeatureIds[ featureI ] ) ).nextFeature( mCurrentFeature );
 
@@ -384,6 +390,8 @@ void QgsAtlasComposition::prepareForFeature( int featureI )
 
   // set the new extent (and render)
   mComposerMap->setNewAtlasFeatureExtent( new_extent );
+
+  emit statusMsgChanged( QString( tr( "Atlas feature %1 of %2" ) ).arg( featureI + 1 ).arg( mFeatureIds.size() ) );
 }
 
 const QString& QgsAtlasComposition::currentFilename() const

--- a/src/core/composer/qgsatlascomposition.cpp
+++ b/src/core/composer/qgsatlascomposition.cpp
@@ -115,21 +115,7 @@ int QgsAtlasComposition::updateFeatures()
   mTransform.setSourceCrs( coverage_crs );
   mTransform.setDestCRS( destination_crs );
 
-  const QgsFields& fields = mCoverageLayer->pendingFields();
-
-  if ( !mSingleFile && mFilenamePattern.size() > 0 )
-  {
-    mFilenameExpr = std::auto_ptr<QgsExpression>( new QgsExpression( mFilenamePattern ) );
-    // expression used to evaluate each filename
-    // test for evaluation errors
-    if ( mFilenameExpr->hasParserError() )
-    {
-      throw std::runtime_error( tr( "Filename parsing error: %1" ).arg( mFilenameExpr->parserErrorString() ).toLocal8Bit().data() );
-    }
-
-    // prepare the filename expression
-    mFilenameExpr->prepare( fields );
-  }
+  updateFilenameExpression();
 
   // select all features with all attributes
   QgsFeatureIterator fit = mCoverageLayer->getFeatures();
@@ -537,6 +523,31 @@ void QgsAtlasComposition::setHideCoverage( bool hide )
     mComposition->update();
   }
 
+}
+
+void QgsAtlasComposition::setFilenamePattern( const QString& pattern )
+{
+  mFilenamePattern = pattern;
+  updateFilenameExpression();
+}
+
+void QgsAtlasComposition::updateFilenameExpression()
+{
+  const QgsFields& fields = mCoverageLayer->pendingFields();
+
+  if ( !mSingleFile && mFilenamePattern.size() > 0 )
+  {
+    mFilenameExpr = std::auto_ptr<QgsExpression>( new QgsExpression( mFilenamePattern ) );
+    // expression used to evaluate each filename
+    // test for evaluation errors
+    if ( mFilenameExpr->hasParserError() )
+    {
+      throw std::runtime_error( tr( "Filename parsing error: %1" ).arg( mFilenameExpr->parserErrorString() ).toLocal8Bit().data() );
+    }
+
+    // prepare the filename expression
+    mFilenameExpr->prepare( fields );
+  }
 }
 
 

--- a/src/core/composer/qgsatlascomposition.h
+++ b/src/core/composer/qgsatlascomposition.h
@@ -81,8 +81,9 @@ class CORE_EXPORT QgsAtlasComposition : public QObject
     int sortKeyAttributeIndex() const { return mSortKeyAttributeIdx; }
     void setSortKeyAttributeIndex( int idx ) { mSortKeyAttributeIdx = idx; }
 
-    /** Begins the rendering. */
-    void beginRender();
+    /** Begins the rendering. Returns true if successful, false if no matching atlas
+      features found.*/
+    bool beginRender();
     /** Ends the rendering. Restores original extent */
     void endRender();
 
@@ -100,7 +101,9 @@ class CORE_EXPORT QgsAtlasComposition : public QObject
 
     QgsComposition* composition() { return mComposition; }
 
-    void updateFeatures();
+    /** Requeries the current atlas coverage layer and applies filtering and sorting. Returns
+      number of matching features. Must be called after prepareForFeature( i ) */
+    int updateFeatures();
 
     void nextFeature();
     void prevFeature();

--- a/src/core/composer/qgsatlascomposition.h
+++ b/src/core/composer/qgsatlascomposition.h
@@ -114,6 +114,9 @@ class CORE_EXPORT QgsAtlasComposition : public QObject
     /** emitted when atlas is enabled or disabled */
     void toggled( bool );
 
+    /**Is emitted when the atlas has an updated status bar message for the composer window*/
+    void statusMsgChanged( QString message );
+
   private:
     QgsComposition* mComposition;
 

--- a/src/core/composer/qgsatlascomposition.h
+++ b/src/core/composer/qgsatlascomposition.h
@@ -124,6 +124,9 @@ class CORE_EXPORT QgsAtlasComposition : public QObject
     /**Updates the filename expression*/
     void updateFilenameExpression();
 
+    /**Evaluates filename for current feature*/
+    void evalFeatureFilename();
+
     QgsComposition* mComposition;
 
     bool mEnabled;

--- a/src/core/composer/qgsatlascomposition.h
+++ b/src/core/composer/qgsatlascomposition.h
@@ -58,7 +58,7 @@ class CORE_EXPORT QgsAtlasComposition : public QObject
     void setMargin( float margin ) { mMargin = margin; }
 
     QString filenamePattern() const { return mFilenamePattern; }
-    void setFilenamePattern( const QString& pattern ) { mFilenamePattern = pattern; }
+    void setFilenamePattern( const QString& pattern );
 
     QgsVectorLayer* coverageLayer() const { return mCoverageLayer; }
     void setCoverageLayer( QgsVectorLayer* lmap );
@@ -121,6 +121,9 @@ class CORE_EXPORT QgsAtlasComposition : public QObject
     void statusMsgChanged( QString message );
 
   private:
+    /**Updates the filename expression*/
+    void updateFilenameExpression();
+
     QgsComposition* mComposition;
 
     bool mEnabled;

--- a/src/core/composer/qgsatlascomposition.h
+++ b/src/core/composer/qgsatlascomposition.h
@@ -43,13 +43,13 @@ class CORE_EXPORT QgsAtlasComposition : public QObject
 
     /** Is the atlas generation enabled ? */
     bool enabled() const { return mEnabled; }
-    void setEnabled( bool e ) { mEnabled = e; }
+    void setEnabled( bool e );
 
     QgsComposerMap* composerMap() const { return mComposerMap; }
     void setComposerMap( QgsComposerMap* map ) { mComposerMap = map; }
 
     bool hideCoverage() const { return mHideCoverage; }
-    void setHideCoverage( bool hide ) { mHideCoverage = hide; }
+    void setHideCoverage( bool hide );
 
     bool fixedScale() const { return mFixedScale; }
     void setFixedScale( bool fixed ) { mFixedScale = fixed; }
@@ -100,9 +100,19 @@ class CORE_EXPORT QgsAtlasComposition : public QObject
 
     QgsComposition* composition() { return mComposition; }
 
+    void updateFeatures();
+
+    void nextFeature();
+    void prevFeature();
+    void lastFeature();
+    void firstFeature();
+
   signals:
     /** emitted when one of the parameters changes */
     void parameterChanged();
+
+    /** emitted when atlas is enabled or disabled */
+    void toggled( bool );
 
   private:
     QgsComposition* mComposition;
@@ -122,6 +132,10 @@ class CORE_EXPORT QgsAtlasComposition : public QObject
     bool mSortFeatures;
     // sort direction
     bool mSortAscending;
+
+    // current atlas feature number
+    int mCurrentFeatureNo;
+
   public:
     typedef QMap< QgsFeatureId, QVariant > SorterKeys;
   private:
@@ -139,7 +153,6 @@ class CORE_EXPORT QgsAtlasComposition : public QObject
     QVector<QgsFeatureId> mFeatureIds;
 
     QgsFeature mCurrentFeature;
-    QgsRectangle mOrigExtent;
     bool mRestoreLayer;
     std::auto_ptr<QgsExpression> mFilenameExpr;
 };

--- a/src/core/composer/qgscomposerlabel.cpp
+++ b/src/core/composer/qgscomposerlabel.cpp
@@ -69,6 +69,18 @@ void QgsComposerLabel::paint( QPainter* painter, const QStyleOptionGraphicsItem*
   painter->rotate( mRotation );
   painter->translate( -mTextBoxWidth / 2.0, -mTextBoxHeight / 2.0 );
 
+  QString textToDraw;
+  if ( mComposition->plotStyle() != QgsComposition::Preview || mComposition->atlasPreviewEnabled() )
+  {
+    //render text with expressions evaluated
+    textToDraw = displayText();
+  }
+  else
+  {
+    //not outputing or using an atlas preview, so render text without expressions evaluated
+    textToDraw = mText;
+  }
+
   if ( mHtmlState )
   {
     painter->scale( 1.0 / mHtmlUnitsToMM / 10.0, 1.0 / mHtmlUnitsToMM / 10.0 );
@@ -110,7 +122,7 @@ void QgsComposerLabel::paint( QPainter* painter, const QStyleOptionGraphicsItem*
     mHtmlLoaded = false;
     connect( webPage, SIGNAL( loadFinished( bool ) ), SLOT( loadingHtmlFinished( bool ) ) );
 
-    webPage->mainFrame()->setHtml( displayText() );
+    webPage->mainFrame()->setHtml( textToDraw );
 
     //For very basic html labels with no external assets, the html load will already be
     //complete before we even get a chance to start the QEventLoop. Make sure we check
@@ -135,7 +147,7 @@ void QgsComposerLabel::paint( QPainter* painter, const QStyleOptionGraphicsItem*
     //debug
     //painter->setPen( QColor( Qt::red ) );
     //painter->drawRect( painterRect );
-    drawText( painter, painterRect, displayText(), mFont, mHAlignment, mVAlignment );
+    drawText( painter, painterRect, textToDraw, mFont, mHAlignment, mVAlignment );
   }
 
   painter->restore();

--- a/src/core/composer/qgscomposermap.cpp
+++ b/src/core/composer/qgscomposermap.cpp
@@ -608,6 +608,15 @@ void QgsComposerMap::setNewAtlasFeatureExtent( const QgsRectangle& extent )
   emit extentChanged();
 }
 
+void QgsComposerMap::toggleAtlasPreview()
+{
+  //atlas preview has been toggled, so update item and extents
+  mCacheUpdated = false;
+  updateItem();
+  emit itemChanged();
+  emit extentChanged();
+}
+
 QgsRectangle* QgsComposerMap::currentMapExtent()
 {
   QgsAtlasComposition* atlasMap = &mComposition->atlasComposition();

--- a/src/core/composer/qgscomposermap.cpp
+++ b/src/core/composer/qgscomposermap.cpp
@@ -126,28 +126,6 @@ QgsComposerMap::QgsComposerMap( QgsComposition *composition )
   initGridAnnotationFormatFromProject();
 }
 
-void QgsComposerMap::extentCenteredOnOverview( QgsRectangle& extent ) const
-{
-  extent = mExtent;
-  if ( ! mOverviewCentered )
-  {
-    return;
-  }
-
-  if ( mOverviewFrameMapId != -1 )
-  {
-    const QgsComposerMap* overviewFrameMap = mComposition->getComposerMapById( mOverviewFrameMapId );
-    QgsRectangle otherExtent = overviewFrameMap->extent();
-
-    QgsPoint center = otherExtent.center();
-    QgsRectangle movedExtent( center.x() - mExtent.width() / 2,
-                              center.y() - mExtent.height() / 2,
-                              center.x() - mExtent.width() / 2 + mExtent.width(),
-                              center.y() - mExtent.height() / 2 + mExtent.height() );
-    extent = movedExtent;
-  }
-}
-
 QgsComposerMap::~QgsComposerMap()
 {
   delete mOverviewFrameMapSymbol;
@@ -282,7 +260,7 @@ void QgsComposerMap::cache( void )
     mCacheImage.fill( QColor( 255, 255, 255, 0 ).rgba() );
   }
 
-  double mapUnitsPerPixel = mExtent.width() / w;
+  double mapUnitsPerPixel = currentMapExtent()->width() / w;
 
   // WARNING: ymax in QgsMapToPixel is device height!!!
   QgsMapToPixel transform( mapUnitsPerPixel, h, requestExtent.yMinimum(), requestExtent.xMinimum() );
@@ -330,8 +308,7 @@ void QgsComposerMap::paint( QPainter* painter, const QStyleOptionGraphicsItem* i
     QgsRectangle requestRectangle;
     requestedExtent( requestRectangle );
 
-    QgsRectangle cExtent;
-    extentCenteredOnOverview( cExtent );
+    QgsRectangle cExtent = *currentMapExtent();
 
     double horizontalVScaleFactor = horizontalViewScaleFactor();
     if ( horizontalVScaleFactor < 0 )
@@ -339,7 +316,7 @@ void QgsComposerMap::paint( QPainter* painter, const QStyleOptionGraphicsItem* i
       horizontalVScaleFactor = mLastValidViewScaleFactor;
     }
 
-    double imagePixelWidth = mExtent.width() / requestRectangle.width() * mCacheImage.width() ; //how many pixels of the image are for the map extent?
+    double imagePixelWidth = cExtent.width() / requestRectangle.width() * mCacheImage.width() ; //how many pixels of the image are for the map extent?
     double scale = rect().width() / imagePixelWidth;
     QgsPoint rotationPoint = QgsPoint(( cExtent.xMaximum() + cExtent.xMinimum() ) / 2.0, ( cExtent.yMaximum() + cExtent.yMinimum() ) / 2.0 );
 
@@ -387,8 +364,7 @@ void QgsComposerMap::paint( QPainter* painter, const QStyleOptionGraphicsItem* i
     QgsRectangle requestRectangle;
     requestedExtent( requestRectangle );
 
-    QgsRectangle cExtent;
-    extentCenteredOnOverview( cExtent );
+    QgsRectangle cExtent = *currentMapExtent();
 
     QSizeF theSize( requestRectangle.width() * mapUnitsToMM(), requestRectangle.height() * mapUnitsToMM() );
 
@@ -462,7 +438,7 @@ double QgsComposerMap::scale() const
   QgsScaleCalculator calculator;
   calculator.setMapUnits( mMapRenderer->mapUnits() );
   calculator.setDpi( 25.4 );  //QGraphicsView units are mm
-  return calculator.calculate( mExtent, rect().width() );
+  return calculator.calculate( *currentMapExtent(), rect().width() );
 }
 
 void QgsComposerMap::resize( double dx, double dy )
@@ -479,10 +455,10 @@ void QgsComposerMap::moveContent( double dx, double dy )
   if ( !mDrawing )
   {
     transformShift( dx, dy );
-    mExtent.setXMinimum( mExtent.xMinimum() + dx );
-    mExtent.setXMaximum( mExtent.xMaximum() + dx );
-    mExtent.setYMinimum( mExtent.yMinimum() + dy );
-    mExtent.setYMaximum( mExtent.yMaximum() + dy );
+    currentMapExtent()->setXMinimum( currentMapExtent()->xMinimum() + dx );
+    currentMapExtent()->setXMaximum( currentMapExtent()->xMaximum() + dx );
+    currentMapExtent()->setYMinimum( currentMapExtent()->yMinimum() + dy );
+    currentMapExtent()->setYMaximum( currentMapExtent()->yMaximum() + dy );
     cache();
     update();
     emit itemChanged();
@@ -510,14 +486,14 @@ void QgsComposerMap::zoomContent( int delta, double x, double y )
   double zoomFactor = settings.value( "/qgis/zoom_factor", 2.0 ).toDouble();
 
   //find out new center point
-  double centerX = ( mExtent.xMaximum() + mExtent.xMinimum() ) / 2;
-  double centerY = ( mExtent.yMaximum() + mExtent.yMinimum() ) / 2;
+  double centerX = ( currentMapExtent()->xMaximum() + currentMapExtent()->xMinimum() ) / 2;
+  double centerY = ( currentMapExtent()->yMaximum() + currentMapExtent()->yMinimum() ) / 2;
 
   if ( zoomMode != 0 )
   {
     //find out map coordinates of mouse position
-    double mapMouseX = mExtent.xMinimum() + ( x / rect().width() ) * ( mExtent.xMaximum() - mExtent.xMinimum() );
-    double mapMouseY = mExtent.yMinimum() + ( 1 - ( y / rect().height() ) ) * ( mExtent.yMaximum() - mExtent.yMinimum() );
+    double mapMouseX = currentMapExtent()->xMinimum() + ( x / rect().width() ) * ( currentMapExtent()->xMaximum() - currentMapExtent()->xMinimum() );
+    double mapMouseY = currentMapExtent()->yMinimum() + ( 1 - ( y / rect().height() ) ) * ( currentMapExtent()->yMaximum() - currentMapExtent()->yMinimum() );
     if ( zoomMode == 1 ) //zoom and recenter
     {
       centerX = mapMouseX;
@@ -534,23 +510,23 @@ void QgsComposerMap::zoomContent( int delta, double x, double y )
 
   if ( delta > 0 )
   {
-    newIntervalX = ( mExtent.xMaximum() - mExtent.xMinimum() ) / zoomFactor;
-    newIntervalY = ( mExtent.yMaximum() - mExtent.yMinimum() ) / zoomFactor;
+    newIntervalX = ( currentMapExtent()->xMaximum() - currentMapExtent()->xMinimum() ) / zoomFactor;
+    newIntervalY = ( currentMapExtent()->yMaximum() - currentMapExtent()->yMinimum() ) / zoomFactor;
   }
   else if ( delta < 0 )
   {
-    newIntervalX = ( mExtent.xMaximum() - mExtent.xMinimum() ) * zoomFactor;
-    newIntervalY = ( mExtent.yMaximum() - mExtent.yMinimum() ) * zoomFactor;
+    newIntervalX = ( currentMapExtent()->xMaximum() - currentMapExtent()->xMinimum() ) * zoomFactor;
+    newIntervalY = ( currentMapExtent()->yMaximum() - currentMapExtent()->yMinimum() ) * zoomFactor;
   }
   else //no need to zoom
   {
     return;
   }
 
-  mExtent.setXMaximum( centerX + newIntervalX / 2 );
-  mExtent.setXMinimum( centerX - newIntervalX / 2 );
-  mExtent.setYMaximum( centerY + newIntervalY / 2 );
-  mExtent.setYMinimum( centerY - newIntervalY / 2 );
+  currentMapExtent()->setXMaximum( centerX + newIntervalX / 2 );
+  currentMapExtent()->setXMinimum( centerX - newIntervalX / 2 );
+  currentMapExtent()->setYMaximum( centerY + newIntervalY / 2 );
+  currentMapExtent()->setYMinimum( centerY - newIntervalY / 2 );
 
   cache();
   update();
@@ -594,6 +570,80 @@ void QgsComposerMap::setNewExtent( const QgsRectangle& extent )
   updateItem();
 }
 
+void QgsComposerMap::setNewAtlasFeatureExtent( const QgsRectangle& extent )
+{
+  if ( mAtlasFeatureExtent == extent )
+  {
+    return;
+  }
+
+  //don't adjust size of item, instead adjust size of bounds to fit
+  QgsRectangle newExtent = extent;
+
+  //Make sure the width/height ratio is the same as the map item size
+  double currentWidthHeightRatio = rect().width() / rect().height();
+  double newWidthHeightRatio = newExtent.width() / newExtent.height();
+
+  if ( currentWidthHeightRatio < newWidthHeightRatio )
+  {
+    //enlarge height of new extent, ensuring the map center stays the same
+    double newHeight = newExtent.width() / currentWidthHeightRatio;
+    double deltaHeight = newHeight - newExtent.height();
+    newExtent.setYMinimum( extent.yMinimum() - deltaHeight / 2 );
+    newExtent.setYMaximum( extent.yMaximum() + deltaHeight / 2 );
+  }
+  else if ( currentWidthHeightRatio > newWidthHeightRatio )
+  {
+    //enlarge width of new extent, ensuring the map center stays the same
+    double newWidth = currentWidthHeightRatio * newExtent.height();
+    double deltaWidth = newWidth - newExtent.width();
+    newExtent.setXMinimum( extent.xMinimum() - deltaWidth / 2 );
+    newExtent.setXMaximum( extent.xMaximum() + deltaWidth / 2 );
+  }
+
+  mAtlasFeatureExtent = newExtent;
+  mCacheUpdated = false;
+  updateItem();
+  emit itemChanged();
+  emit extentChanged();
+}
+
+QgsRectangle* QgsComposerMap::currentMapExtent()
+{
+  QgsAtlasComposition* atlasMap = &mComposition->atlasComposition();
+
+
+  if ( atlasMap->enabled() && atlasMap->composerMap() == this &&
+       ( mComposition->atlasPreviewEnabled() || mComposition->plotStyle() != QgsComposition::Preview ) )
+  {
+    //if atlas is enabled, and we are either exporting the composition or previewing the atlas, then
+    //return the current temporary atlas feature extent
+    return &mAtlasFeatureExtent;
+  }
+  else
+  {
+    //otherwise return permenant user set extent
+    return &mExtent;
+  }
+}
+
+const QgsRectangle* QgsComposerMap::currentMapExtent() const
+{
+  QgsAtlasComposition* atlasMap = &mComposition->atlasComposition();
+  if ( atlasMap->enabled() && atlasMap->composerMap() == this &&
+       ( mComposition->atlasPreviewEnabled() || mComposition->plotStyle() != QgsComposition::Preview ) )
+  {
+    //if atlas is enabled, and we are either exporting the composition or previewing the atlas, then
+    //return the current temporary atlas feature extent
+    return &mAtlasFeatureExtent;
+  }
+  else
+  {
+    //otherwise return permenant user set extent
+    return &mExtent;
+  }
+}
+
 void QgsComposerMap::setNewScale( double scaleDenominator )
 {
   double currentScaleDenominator = scale();
@@ -604,7 +654,7 @@ void QgsComposerMap::setNewScale( double scaleDenominator )
   }
 
   double scaleRatio = scaleDenominator / currentScaleDenominator;
-  mExtent.scale( scaleRatio );
+  currentMapExtent()->scale( scaleRatio );
   mCacheUpdated = false;
   cache();
   update();
@@ -1714,7 +1764,7 @@ QgsRectangle QgsComposerMap::transformedExtent() const
   double dx = mXOffset;
   double dy = mYOffset;
   transformShift( dx, dy );
-  return QgsRectangle( mExtent.xMinimum() - dx, mExtent.yMinimum() - dy, mExtent.xMaximum() - dx, mExtent.yMaximum() - dy );
+  return QgsRectangle( currentMapExtent()->xMinimum() - dx, currentMapExtent()->yMinimum() - dy, currentMapExtent()->xMaximum() - dx, currentMapExtent()->yMaximum() - dy );
 }
 
 QPolygonF QgsComposerMap::transformedMapPolygon() const
@@ -1821,13 +1871,12 @@ void QgsComposerMap::mapPolygon( const QgsRectangle& extent, QPolygonF& poly ) c
 
 void QgsComposerMap::mapPolygon( QPolygonF& poly ) const
 {
-  return mapPolygon( mExtent, poly );
+  return mapPolygon( *currentMapExtent(), poly );
 }
 
 void QgsComposerMap::requestedExtent( QgsRectangle& extent ) const
 {
-  QgsRectangle newExtent;
-  extentCenteredOnOverview( newExtent );
+  QgsRectangle newExtent = *currentMapExtent();
   if ( mRotation == 0 )
   {
     extent = newExtent;
@@ -1846,7 +1895,7 @@ void QgsComposerMap::requestedExtent( QgsRectangle& extent ) const
 
 double QgsComposerMap::mapUnitsToMM() const
 {
-  double extentWidth = mExtent.width();
+  double extentWidth = currentMapExtent()->width();
   if ( extentWidth <= 0 )
   {
     return 1;
@@ -1861,7 +1910,7 @@ void QgsComposerMap::setOverviewFrameMap( int mapId )
     const QgsComposerMap* map = mComposition->getComposerMapById( mapId );
     if ( map )
     {
-      QObject::disconnect( map, SIGNAL( extentChanged() ), this, SLOT( repaint() ) );
+      QObject::disconnect( map, SIGNAL( extentChanged() ), this, SLOT( overviewExtentChanged() ) );
     }
   }
   mOverviewFrameMapId = mapId;
@@ -1870,11 +1919,38 @@ void QgsComposerMap::setOverviewFrameMap( int mapId )
     const QgsComposerMap* map = mComposition->getComposerMapById( mapId );
     if ( map )
     {
-      QObject::connect( map, SIGNAL( extentChanged() ), this, SLOT( repaint() ) );
+      QObject::connect( map, SIGNAL( extentChanged() ), this, SLOT( overviewExtentChanged() ) );
     }
   }
   update();
 }
+
+void QgsComposerMap::overviewExtentChanged()
+{
+  //if using overview centering, update the map's extent
+  if ( mOverviewCentered && mOverviewFrameMapId != -1 )
+  {
+    QgsRectangle extent = *currentMapExtent();
+
+    const QgsComposerMap* overviewFrameMap = mComposition->getComposerMapById( mOverviewFrameMapId );
+    QgsRectangle otherExtent = *overviewFrameMap->currentMapExtent();
+
+    QgsPoint center = otherExtent.center();
+    QgsRectangle movedExtent( center.x() - currentMapExtent()->width() / 2,
+                              center.y() - currentMapExtent()->height() / 2,
+                              center.x() - currentMapExtent()->width() / 2 + currentMapExtent()->width(),
+                              center.y() - currentMapExtent()->height() / 2 + currentMapExtent()->height() );
+    *currentMapExtent() = movedExtent;
+
+    emit itemChanged();
+    emit extentChanged();
+  }
+
+  //redraw so that overview gets updated
+  cache();
+  update();
+}
+
 
 void QgsComposerMap::setOverviewFrameMapSymbol( QgsFillSymbolV2* symbol )
 {
@@ -1995,7 +2071,7 @@ void QgsComposerMap::drawCanvasItem( QGraphicsItem* item, QPainter* painter, con
   painter->save();
 
   QgsRectangle rendererExtent = mMapRenderer->extent();
-  QgsRectangle composerMapExtent = mExtent;
+  QgsRectangle composerMapExtent = *currentMapExtent();
 
   //determine scale factor according to graphics view dpi
   double scaleFactor = 1.0 / mMapCanvas->logicalDpiX() * 25.4;
@@ -2037,7 +2113,7 @@ QPointF QgsComposerMap::composerMapPosForItem( const QGraphicsItem* item ) const
     return QPointF( 0, 0 );
   }
 
-  if ( mExtent.height() <= 0 || mExtent.width() <= 0 || mMapCanvas->width() <= 0 || mMapCanvas->height() <= 0 )
+  if ( currentMapExtent()->height() <= 0 || currentMapExtent()->width() <= 0 || mMapCanvas->width() <= 0 || mMapCanvas->height() <= 0 )
   {
     return QPointF( 0, 0 );
   }
@@ -2198,9 +2274,8 @@ void QgsComposerMap::drawOverviewMapExtent( QPainter* p )
     return;
   }
 
-  QgsRectangle otherExtent = overviewFrameMap->extent();
-  QgsRectangle thisExtent;
-  extentCenteredOnOverview( thisExtent );
+  QgsRectangle otherExtent = *overviewFrameMap->currentMapExtent();
+  QgsRectangle thisExtent = *currentMapExtent();
   QgsRectangle intersectRect = thisExtent.intersect( &otherExtent );
 
   QgsRenderContext context;

--- a/src/core/composer/qgscomposermap.cpp
+++ b/src/core/composer/qgscomposermap.cpp
@@ -968,11 +968,11 @@ bool QgsComposerMap::readXML( const QDomElement& itemElem, const QDomDocument& d
 
     if ( overviewFrameElem.attribute( "overviewCentered" ).compare( "true", Qt::CaseInsensitive ) == 0 )
     {
-      setOverviewCentered( true );
+      mOverviewCentered = true;
     }
     else
     {
-      setOverviewCentered( false );
+      mOverviewCentered = false;
     }
 
     QDomElement overviewFrameSymbolElem = overviewFrameElem.firstChildElement( "symbol" );
@@ -1973,7 +1973,7 @@ void QgsComposerMap::setOverviewInverted( bool inverted )
 void QgsComposerMap::setOverviewCentered( bool centered )
 {
   mOverviewCentered = centered;
-  update();
+  overviewExtentChanged();
 }
 
 void QgsComposerMap::setGridLineSymbol( QgsLineSymbolV2* symbol )

--- a/src/core/composer/qgscomposermap.cpp
+++ b/src/core/composer/qgscomposermap.cpp
@@ -2285,6 +2285,7 @@ void QgsComposerMap::drawOverviewMapExtent( QPainter* p )
 
   p->save();
   p->setCompositionMode( mOverviewBlendMode );
+  p->translate( mXOffset, mYOffset );
   mOverviewFrameMapSymbol->startRender( context );
 
   //construct a polygon corresponding to the intersecting map extent

--- a/src/core/composer/qgscomposermap.h
+++ b/src/core/composer/qgscomposermap.h
@@ -156,6 +156,9 @@ class CORE_EXPORT QgsComposerMap : public QgsComposerItem
     */
     void setNewAtlasFeatureExtent( const QgsRectangle& extent );
 
+    /**Called when atlas preview is toggled, to force map item to update its extent and redraw*/
+    void toggleAtlasPreview();
+
     /**Returns a pointer to the current map extent, which is either the original user specified
       extent or the temporary atlas-driven feature extent depending on the current atlas state of the composition*/
     QgsRectangle* currentMapExtent();

--- a/src/core/composer/qgscomposermap.h
+++ b/src/core/composer/qgscomposermap.h
@@ -151,6 +151,16 @@ class CORE_EXPORT QgsComposerMap : public QgsComposerItem
     /**Sets new Extent and changes width, height (and implicitely also scale)*/
     void setNewExtent( const QgsRectangle& extent );
 
+    /**Sets new Extent for the current atlas preview and changes width, height (and implicitely also scale).
+      Atlas preview extents are only temporary, and are regenerated whenever the atlas feature changes
+    */
+    void setNewAtlasFeatureExtent( const QgsRectangle& extent );
+
+    /**Returns a pointer to the current map extent, which is either the original user specified
+      extent or the temporary atlas-driven feature extent depending on the current atlas state of the composition*/
+    QgsRectangle* currentMapExtent();
+    const QgsRectangle* currentMapExtent() const;
+
     PreviewMode previewMode() const {return mPreviewMode;}
     void setPreviewMode( PreviewMode m );
 
@@ -359,6 +369,8 @@ class CORE_EXPORT QgsComposerMap : public QgsComposerItem
     /**Call updateCachedImage if item is in render mode*/
     void renderModeUpdateCachedImage();
 
+    void overviewExtentChanged();
+
   private:
 
     enum AnnotationCoordinate
@@ -378,6 +390,11 @@ class CORE_EXPORT QgsComposerMap : public QgsComposerItem
     // It can be the same as mUserExtent, but it can be bigger in on dimension if mCalculate==Scale,
     // so that full rectangle in paper is used.
     QgsRectangle mExtent;
+
+    // Current temporary map region in map units. This is overwritten when atlas feature changes. It's also
+    // used when the user changes the map extent and an atlas preview is enabled. This allows the user
+    // to manually tweak each atlas preview page without affecting the actual original map extent.
+    QgsRectangle mAtlasFeatureExtent;
 
     // Cache used in composer preview
     QImage mCacheImage;
@@ -536,10 +553,6 @@ class CORE_EXPORT QgsComposerMap : public QgsComposerItem
     void createDefaultGridLineSymbol();
     void initGridAnnotationFormatFromProject();
 
-    /**
-     * Returns the extent, centered on the overview frame
-     */
-    void extentCenteredOnOverview( QgsRectangle& extent ) const;
 };
 
 #endif

--- a/src/core/composer/qgscomposerscalebar.cpp
+++ b/src/core/composer/qgscomposerscalebar.cpp
@@ -164,7 +164,7 @@ void QgsComposerScaleBar::refreshSegmentMillimeters()
   if ( mComposerMap )
   {
     //get extent of composer map
-    QgsRectangle composerMapRect = mComposerMap->extent();
+    QgsRectangle composerMapRect = *( mComposerMap->currentMapExtent() );
 
     //get mm dimension of composer map
     QRectF composerItemRect = mComposerMap->rect();
@@ -181,7 +181,7 @@ double QgsComposerScaleBar::mapWidth() const
     return 0.0;
   }
 
-  QgsRectangle composerMapRect = mComposerMap->extent();
+  QgsRectangle composerMapRect = *( mComposerMap->currentMapExtent() );
   if ( mUnits == MapUnits )
   {
     return composerMapRect.width();

--- a/src/core/composer/qgscomposition.cpp
+++ b/src/core/composer/qgscomposition.cpp
@@ -2290,7 +2290,7 @@ void QgsComposition::computeWorldFileParameters( double& a, double& b, double& c
   f = r[3] * s[2] + r[4] * s[5] + r[5];
 }
 
-void QgsComposition::setAtlasPreviewEnabled( bool e )
+bool QgsComposition::setAtlasPreviewEnabled( bool e )
 {
   mAtlasPreviewEnabled = e;
 
@@ -2300,8 +2300,14 @@ void QgsComposition::setAtlasPreviewEnabled( bool e )
   }
   else
   {
-    mAtlasComposition.beginRender();
+    bool atlasHasFeatures = mAtlasComposition.beginRender();
+    if ( ! atlasHasFeatures )
+    {
+      mAtlasPreviewEnabled = false;
+      return false;
+    }
   }
 
   update();
+  return true;
 }

--- a/src/core/composer/qgscomposition.cpp
+++ b/src/core/composer/qgscomposition.cpp
@@ -72,6 +72,7 @@ QgsComposition::QgsComposition( QgsMapRenderer* mapRenderer )
     , mActiveItemCommand( 0 )
     , mActiveMultiFrameCommand( 0 )
     , mAtlasComposition( this )
+    , mAtlasPreviewEnabled( false )
     , mPreventCursorChange( false )
 {
   setBackgroundBrush( Qt::gray );
@@ -115,6 +116,7 @@ QgsComposition::QgsComposition()
     mActiveItemCommand( 0 ),
     mActiveMultiFrameCommand( 0 ),
     mAtlasComposition( this ),
+    mAtlasPreviewEnabled( false ),
     mPreventCursorChange( false )
 {
   //load default composition settings
@@ -2271,4 +2273,20 @@ void QgsComposition::computeWorldFileParameters( double& a, double& b, double& c
   d = r[3] * s[0] + r[4] * s[3];
   e = r[3] * s[1] + r[4] * s[4];
   f = r[3] * s[2] + r[4] * s[5] + r[5];
+}
+
+void QgsComposition::setAtlasPreviewEnabled( bool e )
+{
+  mAtlasPreviewEnabled = e;
+
+  if ( !mAtlasPreviewEnabled )
+  {
+    mAtlasComposition.endRender();
+  }
+  else
+  {
+    mAtlasComposition.beginRender();
+  }
+
+  update();
 }

--- a/src/core/composer/qgscomposition.cpp
+++ b/src/core/composer/qgscomposition.cpp
@@ -2308,6 +2308,11 @@ bool QgsComposition::setAtlasPreviewEnabled( bool e )
     }
   }
 
+  if ( mAtlasComposition.composerMap() )
+  {
+    mAtlasComposition.composerMap()->toggleAtlasPreview();
+  }
+
   update();
   return true;
 }

--- a/src/core/composer/qgscomposition.cpp
+++ b/src/core/composer/qgscomposition.cpp
@@ -763,6 +763,21 @@ void QgsComposition::addItemsFromXML( const QDomElement& elem, const QDomDocumen
       pushAddRemoveCommand( newMap, tr( "Map added" ) );
     }
   }
+  //now that all map items have been created, re-connect overview map signals
+  QList<QgsComposerMap*> maps;
+  composerItems( maps );
+  for ( QList<QgsComposerMap*>::iterator mit = maps.begin(); mit != maps.end(); ++mit )
+  {
+    if (( *mit )->overviewFrameMapId() != -1 )
+    {
+      const QgsComposerMap* overviewMap = getComposerMapById(( *mit )->overviewFrameMapId() );
+      if ( overviewMap )
+      {
+        QObject::connect( overviewMap, SIGNAL( extentChanged() ), *mit, SLOT( overviewExtentChanged() ) );
+      }
+    }
+  }
+
   // arrow
   QDomNodeList composerArrowList = elem.elementsByTagName( "ComposerArrow" );
   for ( int i = 0; i < composerArrowList.size(); ++i )

--- a/src/core/composer/qgscomposition.h
+++ b/src/core/composer/qgscomposition.h
@@ -414,6 +414,11 @@ class CORE_EXPORT QgsComposition : public QGraphicsScene
 
     QgsAtlasComposition& atlasComposition() { return mAtlasComposition; }
 
+    /** Is the atlas preview enabled ? */
+    bool atlasPreviewEnabled() const { return mAtlasPreviewEnabled; }
+    void setAtlasPreviewEnabled( bool e );
+
+
   public slots:
     /**Casts object to the proper subclass type and calls corresponding itemAdded signal*/
     void sendItemAddedSignal( QgsComposerItem* item );
@@ -475,6 +480,8 @@ class CORE_EXPORT QgsComposition : public QGraphicsScene
 
     /** The atlas composition object. It is held by the QgsComposition */
     QgsAtlasComposition mAtlasComposition;
+
+    bool mAtlasPreviewEnabled;
 
     QgsComposition(); //default constructor is forbidden
 

--- a/src/core/composer/qgscomposition.h
+++ b/src/core/composer/qgscomposition.h
@@ -416,7 +416,8 @@ class CORE_EXPORT QgsComposition : public QGraphicsScene
 
     /** Is the atlas preview enabled ? */
     bool atlasPreviewEnabled() const { return mAtlasPreviewEnabled; }
-    void setAtlasPreviewEnabled( bool e );
+    /** Set atlas preview enabled. Returns false if atlas preview could not be enabled */
+    bool setAtlasPreviewEnabled( bool e );
 
 
   public slots:

--- a/src/ui/qgscomposerbase.ui
+++ b/src/ui/qgscomposerbase.ui
@@ -144,6 +144,7 @@
    <addaction name="mActionAtlasNext"/>
    <addaction name="mActionAtlasLast"/>
    <addaction name="mActionPrintAtlas"/>
+   <addaction name="mActionAtlasSettings"/>
   </widget>
   <action name="mActionPrint">
    <property name="checkable">
@@ -898,6 +899,15 @@
    </property>
    <property name="text">
     <string>Export Atlas As PDF...</string>
+   </property>
+  </action>
+  <action name="mActionAtlasSettings">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionSetProjection.svg</normaloff>:/images/themes/default/mActionSetProjection.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Atlas Settings</string>
    </property>
   </action>
  </widget>

--- a/src/ui/qgscomposerbase.ui
+++ b/src/ui/qgscomposerbase.ui
@@ -21,7 +21,16 @@
     <bool>true</bool>
    </property>
    <layout class="QGridLayout" name="gridLayout">
-    <property name="margin">
+    <property name="leftMargin">
+     <number>0</number>
+    </property>
+    <property name="topMargin">
+     <number>0</number>
+    </property>
+    <property name="rightMargin">
+     <number>0</number>
+    </property>
+    <property name="bottomMargin">
      <number>0</number>
     </property>
     <item row="0" column="0">
@@ -118,6 +127,22 @@
    <addaction name="mActionAddArrow"/>
    <addaction name="mActionAddTable"/>
    <addaction name="mActionAddHtml"/>
+  </widget>
+  <widget class="QToolBar" name="mAtlasToolbar">
+   <property name="windowTitle">
+    <string>Atlas</string>
+   </property>
+   <attribute name="toolBarArea">
+    <enum>TopToolBarArea</enum>
+   </attribute>
+   <attribute name="toolBarBreak">
+    <bool>true</bool>
+   </attribute>
+   <addaction name="mActionAtlasPreview"/>
+   <addaction name="mActionAtlasFirst"/>
+   <addaction name="mActionAtlasPrev"/>
+   <addaction name="mActionAtlasNext"/>
+   <addaction name="mActionAtlasLast"/>
   </widget>
   <action name="mActionPrint">
    <property name="checkable">
@@ -780,7 +805,7 @@
    <property name="text">
     <string>Pan Composer</string>
    </property>
-  </action> 
+  </action>
   <action name="mActionOptions">
    <property name="icon">
     <iconset resource="../../images/images.qrc">
@@ -792,7 +817,52 @@
    <property name="menuRole">
     <enum>QAction::PreferencesRole</enum>
    </property>
-  </action>      
+  </action>
+  <action name="mActionAtlasFirst">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionArrowUp.png</normaloff>:/images/themes/default/mActionArrowUp.png</iconset>
+   </property>
+   <property name="text">
+    <string>First Feature</string>
+   </property>
+  </action>
+  <action name="mActionAtlasPrev">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionArrowLeft.png</normaloff>:/images/themes/default/mActionArrowLeft.png</iconset>
+   </property>
+   <property name="text">
+    <string>Previous Feature</string>
+   </property>
+  </action>
+  <action name="mActionAtlasNext">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionArrowRight.png</normaloff>:/images/themes/default/mActionArrowRight.png</iconset>
+   </property>
+   <property name="text">
+    <string>Next Feature</string>
+   </property>
+  </action>
+  <action name="mActionAtlasLast">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionArrowDown.png</normaloff>:/images/themes/default/mActionArrowDown.png</iconset>
+   </property>
+   <property name="text">
+    <string>Last Feature</string>
+   </property>
+  </action>
+  <action name="mActionAtlasPreview">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mIconWmsLayer.png</normaloff>:/images/themes/default/mIconWmsLayer.png</iconset>
+   </property>
+   <property name="text">
+    <string>Preview Atlas</string>
+   </property>
+  </action>
  </widget>
  <resources>
   <include location="../../images/images.qrc"/>

--- a/src/ui/qgscomposerbase.ui
+++ b/src/ui/qgscomposerbase.ui
@@ -143,6 +143,7 @@
    <addaction name="mActionAtlasPrev"/>
    <addaction name="mActionAtlasNext"/>
    <addaction name="mActionAtlasLast"/>
+   <addaction name="mActionPrintAtlas"/>
   </widget>
   <action name="mActionPrint">
    <property name="checkable">
@@ -861,6 +862,42 @@
    </property>
    <property name="text">
     <string>Preview Atlas</string>
+   </property>
+  </action>
+  <action name="mActionPrintAtlas">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionFilePrint.png</normaloff>:/images/themes/default/mActionFilePrint.png</iconset>
+   </property>
+   <property name="text">
+    <string>Print Atlas...</string>
+   </property>
+  </action>
+  <action name="mActionExportAtlasAsImage">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionSaveMapAsImage.png</normaloff>:/images/themes/default/mActionSaveMapAsImage.png</iconset>
+   </property>
+   <property name="text">
+    <string>Export Atlas as Images...</string>
+   </property>
+  </action>
+  <action name="mActionExportAtlasAsSVG">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionSaveAsSVG.png</normaloff>:/images/themes/default/mActionSaveAsSVG.png</iconset>
+   </property>
+   <property name="text">
+    <string>Export Atlas as SVG...</string>
+   </property>
+  </action>
+  <action name="mActionExportAtlasAsPDF">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionSaveAsPDF.png</normaloff>:/images/themes/default/mActionSaveAsPDF.png</iconset>
+   </property>
+   <property name="text">
+    <string>Export Atlas As PDF...</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
This request adds new atlas functionality to the composer, which allows the atlas to be previewed and exported feature-by-feature.

Users can switch on an atlas preview mode and then navigate through the coverage layer using a new atlas toolbar. In preview mode any changes made to the extent or scale of the atlas map are only temporary and do not affect the original composition, thus allowing users to manually tweak each page in an atlas before exporting it.

Printing and exporting of complete atlases has been moved to their own controls, so that individual features from an atlas can be printed/exported one at a time.

This work is kindly sponsored by SIGE (www.sige.ch).

NOTE: The current, temporary toolbar icons will be replaced by new icons which Denis Rouzaud is currently working on.
