### PR TITLE
[composer] Allow render optimisations when in preview mode

### DIFF
--- a/src/core/composer/qgscomposermap.cpp
+++ b/src/core/composer/qgscomposermap.cpp
@@ -199,7 +199,13 @@ void QgsComposerMap::draw( QPainter *painter, const QgsRectangle& extent, const 
   {
     theRendererContext->setDrawEditingInformation( false );
     theRendererContext->setRenderingStopped( false );
-    theRendererContext->setRenderingPrintComposition( true );
+
+    if ( mComposition->plotStyle() == QgsComposition::Print ||
+         mComposition->plotStyle() == QgsComposition::Postscript )
+    {
+      //if outputing composer, disable optimisations like layer simplification
+      theRendererContext->setRenderingPrintComposition( true );
+    }
 
     // force vector output (no caching of marker images etc.)
     theRendererContext->setForceVectorOutput( true );


### PR DESCRIPTION
Only disable render optimisations by simplification when a composer is being outputed. Allows composer previews to benefit from layer simplification optimisations without affecting print quality.
