### PR TITLE
#9273: Fix shortcuts commented in issue #9273

### DIFF
--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -1345,6 +1345,9 @@
    <property name="text">
     <string>Query...</string>
    </property>
+   <property name="shortcut">
+    <string>Ctrl+F</string>
+   </property>
   </action>
   <action name="mActionAddToOverview">
    <property name="icon">
@@ -1411,7 +1414,7 @@
     <string>Toggle Full Screen Mode</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+F</string>
+    <string>F11</string>
    </property>
   </action>
   <action name="mActionProjectProperties">


### PR DESCRIPTION
Changes:
- CTRL+F -> find/query in current layer (Now AttributeTableDialog use this shorcut to define a filter).
- F11 -> Toggle Full Screen Mode

Fix issue:
http://hub.qgis.org/issues/9273
