### PR TITLE
#9094-R: Use ',' and '.' keys similar to '<' and '>' keys in QgsMapToolNodeTool

### DIFF
--- a/src/app/nodetool/qgsmaptoolnodetool.cpp
+++ b/src/app/nodetool/qgsmaptoolnodetool.cpp
@@ -733,15 +733,25 @@ void QgsMapToolNodeTool::keyPressEvent( QKeyEvent* e )
     e->ignore();
   }
   else
-    if ( mSelectedFeature && ( e->key() == Qt::Key_Less || e->key() == Qt::Key_Greater ) )
-    {
-      int firstSelectedIndex = firstSelectedVertex();
-      if ( firstSelectedIndex == -1 ) return;
+  if ( mSelectedFeature && ( e->key() == Qt::Key_Less || e->key() == Qt::Key_Comma ) )
+  {
+    int firstSelectedIndex = firstSelectedVertex();
+    if ( firstSelectedIndex == -1) return;
 
-      mSelectedFeature->deselectAllVertexes();
-      safeSelectVertex( firstSelectedIndex + (( e->key() == Qt::Key_Less ) ? -1 : + 1 ) );
-      mCanvas->refresh();
-    }
+    mSelectedFeature->deselectAllVertexes();
+    safeSelectVertex( firstSelectedIndex - 1 );
+    mCanvas->refresh();
+  }
+  else
+  if ( mSelectedFeature && ( e->key() == Qt::Key_Greater || e->key() == Qt::Key_Period ) )
+  {
+    int firstSelectedIndex = firstSelectedVertex();
+    if ( firstSelectedIndex == -1) return;
+
+    mSelectedFeature->deselectAllVertexes();
+    safeSelectVertex( firstSelectedIndex + 1 );
+    mCanvas->refresh();
+  }
 }
 
 void QgsMapToolNodeTool::keyReleaseEvent( QKeyEvent* e )


### PR DESCRIPTION
Source:
https://github.com/qgis/QGIS/pull/1010#issuecomment-31385714
