### PR TITLE
Bug #9280: fix "Add postgis layer" creates a connection that is not removed until qgis is terminated

### DIFF
--- a/src/providers/postgres/qgscolumntypethread.cpp
+++ b/src/providers/postgres/qgscolumntypethread.cpp
@@ -43,7 +43,7 @@ void QgsGeomColumnTypeThread::stop()
 void QgsGeomColumnTypeThread::run()
 {
   QgsDataSourceURI uri = QgsPostgresConn::connUri( mName );
-  mConn = QgsPostgresConn::connectDb( uri.connectionInfo(), true );
+  mConn = new QgsPostgresConn( uri.connectionInfo(), true );
   if ( !mConn )
   {
     QgsDebugMsg( "Connection failed - " + uri.connectionInfo() );
@@ -63,6 +63,7 @@ void QgsGeomColumnTypeThread::run()
        layerProperties.isEmpty() )
   {
     mConn->disconnect();
+    delete mConn;
     mConn = 0;
     return;
   }
@@ -109,5 +110,6 @@ void QgsGeomColumnTypeThread::run()
   emit progressMessage( tr( "Table retrieval finished." ) );
 
   mConn->disconnect();
+  delete mConn;
   mConn = 0;
 }

--- a/src/providers/postgres/qgspostgresconn.h
+++ b/src/providers/postgres/qgspostgresconn.h
@@ -257,10 +257,10 @@ class QgsPostgresConn : public QObject
     static bool allowGeometrylessTables( QString theConnName );
     static void deleteConnection( QString theConnName );
 
-  private:
+  public:
     QgsPostgresConn( QString conninfo, bool readOnly );
     ~QgsPostgresConn();
-
+  private:
     int mRef;
     int mOpenCursors;
     PGconn *mConn;

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -3360,6 +3360,7 @@ QGISEXTERN bool saveStyle( const QString& uri, const QString& qmlStyle, const QS
                                 QMessageBox::Yes | QMessageBox::No ) == QMessageBox::No )
     {
       errCause = QObject::tr( "Operation aborted. No changes were made in the database" );
+      conn->disconnect();
       return false;
     }
 
@@ -3439,7 +3440,9 @@ QGISEXTERN QString loadStyle( const QString& uri, QString& errCause )
 
   QgsPostgresResult result = conn->PQexec( selectQmlQuery, false );
 
-  return result.PQntuples() == 1 ? result.PQgetvalue( 0, 0 ) : "";
+  QString style = result.PQntuples() == 1 ? result.PQgetvalue( 0, 0 ) : "";
+  conn->disconnect();
+  return style;
 }
 
 QGISEXTERN int listStyles( const QString &uri, QStringList &ids, QStringList &names,
@@ -3470,6 +3473,7 @@ QGISEXTERN int listStyles( const QString &uri, QStringList &ids, QStringList &na
   {
     QgsMessageLog::logMessage( QObject::tr( "Error executing query: %1" ).arg( selectRelatedQuery ) );
     errCause = QObject::tr( "Error executing the select query for related styles. The query was logged" );
+    conn->disconnect();
     return -1;
   }
 
@@ -3495,6 +3499,7 @@ QGISEXTERN int listStyles( const QString &uri, QStringList &ids, QStringList &na
   {
     QgsMessageLog::logMessage( QObject::tr( "Error executing query: %1" ).arg( selectOthersQuery ) );
     errCause = QObject::tr( "Error executing the select query for unrelated styles. The query was logged" );
+    conn->disconnect();
     return -1;
   }
   for ( int i = 0; i < result.PQntuples(); i++ )
@@ -3503,6 +3508,7 @@ QGISEXTERN int listStyles( const QString &uri, QStringList &ids, QStringList &na
     names.append( result.PQgetvalue( i, 1 ) );
     descriptions.append( result.PQgetvalue( i, 2 ) );
   }
+  conn->disconnect();
 
   return numberOfRelatedStyles;
 }
@@ -3524,16 +3530,20 @@ QGISEXTERN QString getStyleById( const QString& uri, QString styleId, QString& e
   {
     QgsMessageLog::logMessage( QObject::tr( "Error executing query: %1" ).arg( selectQmlQuery ) );
     errCause = QObject::tr( "Error executing the select query. The query was logged" );
+    conn->disconnect();
     return "";
   }
 
   if ( result.PQntuples() == 1 )
   {
-    return result.PQgetvalue( 0, 0 );
+    QString style = result.PQgetvalue( 0, 0 );
+    conn->disconnect();
+    return style;
   }
   else
   {
     errCause = QObject::tr( "Consistency error in table '%1'. Style id should be unique" ).arg( "layer_styles" );
+    conn->disconnect();
     return "";
   }
 }


### PR DESCRIPTION
Changes:
- Disconnect postgres connections created.
- Fix deleteLayer not called in thread without event loop. 
  From Qt documentation: void QObject::deleteLater() [slot]  ...the object will be deleted once the event loop is started. If deleteLater() is called after the main event loop has stopped, the object will not be deleted. Since Qt 4.8, if deleteLater() is called on an object that lives in a thread with no running event loop, the object will be destroyed when the thread finishes.

Fix:
http://hub.qgis.org/issues/9280
