### PR TITLE
Update to new style side bar style for dialogs.

### DIFF
--- a/src/app/qgsabout.cpp
+++ b/src/app/qgsabout.cpp
@@ -31,13 +31,14 @@ std::map<QString, QPixmap> mugs;
 */
 #ifdef Q_OS_MACX
 QgsAbout::QgsAbout( QWidget *parent )
-    : QDialog( parent, Qt::WindowSystemMenuHint )  // Modeless dialog with close button only
+    : QgsOptionsDialogBase( parent, Qt::WindowSystemMenuHint )  // Modeless dialog with close button only
 #else
 QgsAbout::QgsAbout( QWidget *parent )
-    : QDialog( parent )  // Normal dialog in non Mac-OS
+    : QgsOptionsDialogBase( "about", parent )  // Normal dialog in non Mac-OS
 #endif
 {
   setupUi( this );
+  initOptionsBase();
   init();
 }
 

--- a/src/app/qgsabout.h
+++ b/src/app/qgsabout.h
@@ -18,8 +18,9 @@
 #define QGSABOUT_H
 
 #include "ui_qgsabout.h"
+#include "qgsoptionsdialogbase.h"
 
-class APP_EXPORT QgsAbout : public QDialog, private Ui::QgsAbout
+class APP_EXPORT QgsAbout : public QgsOptionsDialogBase , private Ui::QgsAbout
 {
     Q_OBJECT
   public:

--- a/src/gui/qgsoptionsdialogbase.cpp
+++ b/src/gui/qgsoptionsdialogbase.cpp
@@ -49,17 +49,51 @@ void QgsOptionsDialogBase::initOptionsBase( bool restoreUi )
   // don't add to dialog margins
   // redefine now, or those in inherited .ui file will be added
   if ( layout() )
-    layout()->setContentsMargins( 12, 12, 12, 12 ); // Qt default spacing
+  {
+    layout()->setContentsMargins( 0, 0, 0, 0 ); // Qt default spacing
+  }
 
   // start with copy of qgsoptionsdialog_template.ui to ensure existence of these objects
   mOptListWidget = findChild<QListWidget*>( "mOptionsListWidget" );
+  QFrame* optionsFrame = findChild<QFrame*>("mOptionsFrame");
   mOptStackedWidget = findChild<QStackedWidget*>( "mOptionsStackedWidget" );
   mOptSplitter = findChild<QSplitter*>( "mOptionsSplitter" );
   mOptButtonBox = findChild<QDialogButtonBox*>( "buttonBox" );
+  QFrame* buttonBoxFrame = findChild<QFrame*>("mButtonBoxFrame");
 
-  if ( !mOptListWidget || !mOptStackedWidget || !mOptSplitter )
+  if ( !mOptListWidget || !mOptStackedWidget || !mOptSplitter || !optionsFrame )
   {
     return;
+  }
+
+  QString style = "QListWidget {"
+     "background-color: rgb(162, 170, 179);"
+      "}"
+      "QListWidget::item {"
+      "    color: white;"
+      "    padding: 3px;"
+      "}"
+      "QListWidget::item::selected {"
+      "    color: white;"
+      "    background-color: rgb(145, 158, 179);"
+      "}";
+
+  mOptListWidget->setStyleSheet(style);
+  QSettings settings;
+  int size = settings.value( "/IconSize", 24 ).toInt();
+  mOptListWidget->setIconSize( QSize(size, size) );
+
+  optionsFrame->layout()->setContentsMargins(0,3,3,3);
+  QVBoxLayout* layout = static_cast<QVBoxLayout*>(optionsFrame->layout());
+
+  if ( buttonBoxFrame )
+  {
+      buttonBoxFrame->layout()->setContentsMargins(0,0,0,0);
+      layout->insertWidget(layout->count() + 1, buttonBoxFrame );
+  }
+  else
+  {
+      layout->insertWidget( layout->count() + 1, mOptButtonBox );
   }
 
   if ( mOptButtonBox )

--- a/src/ui/qgsabout.ui
+++ b/src/ui/qgsabout.ui
@@ -6,278 +6,583 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>753</width>
-    <height>416</height>
+    <width>903</width>
+    <height>444</height>
    </rect>
   </property>
+  <property name="minimumSize">
+   <size>
+    <width>700</width>
+    <height>0</height>
+   </size>
+  </property>
   <property name="windowTitle">
-   <string>About QGIS</string>
+   <string>Options Dialog Template</string>
   </property>
-  <property name="sizeGripEnabled">
-   <bool>true</bool>
-  </property>
-  <layout class="QGridLayout">
-   <item row="1" column="0">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Ok</set>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QSplitter" name="mOptionsSplitter">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
      </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QTabWidget" name="tabWidget">
-     <property name="currentIndex">
-      <number>0</number>
+     <property name="childrenCollapsible">
+      <bool>false</bool>
      </property>
-     <widget class="QWidget" name="Widget2">
-      <attribute name="title">
-       <string>About</string>
-      </attribute>
-      <layout class="QGridLayout">
-       <item row="0" column="0">
-        <layout class="QHBoxLayout">
+     <widget class="QFrame" name="mOptionsListFrame">
+      <property name="minimumSize">
+       <size>
+        <width>0</width>
+        <height>0</height>
+       </size>
+      </property>
+      <property name="frameShape">
+       <enum>QFrame::NoFrame</enum>
+      </property>
+      <property name="frameShadow">
+       <enum>QFrame::Raised</enum>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <property name="margin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QListWidget" name="mOptionsListWidget">
+         <property name="minimumSize">
+          <size>
+           <width>58</width>
+           <height>0</height>
+          </size>
+         </property>
+         <property name="maximumSize">
+          <size>
+           <width>150</width>
+           <height>16777215</height>
+          </size>
+         </property>
+         <property name="horizontalScrollBarPolicy">
+          <enum>Qt::ScrollBarAlwaysOff</enum>
+         </property>
+         <property name="editTriggers">
+          <set>QAbstractItemView::NoEditTriggers</set>
+         </property>
+         <property name="iconSize">
+          <size>
+           <width>32</width>
+           <height>32</height>
+          </size>
+         </property>
+         <property name="textElideMode">
+          <enum>Qt::ElideNone</enum>
+         </property>
+         <property name="resizeMode">
+          <enum>QListView::Adjust</enum>
+         </property>
+         <property name="wordWrap">
+          <bool>true</bool>
+         </property>
          <item>
-          <widget class="QLabel" name="qgisIcon">
-           <property name="maximumSize">
-            <size>
-             <width>60</width>
-             <height>60</height>
-            </size>
-           </property>
-           <property name="pixmap">
-            <pixmap resource="../../images/images.qrc">:/images/icons/qgis-icon-60x60.png</pixmap>
-           </property>
-           <property name="scaledContents">
-            <bool>false</bool>
-           </property>
-          </widget>
+          <property name="text">
+           <string>About</string>
+          </property>
          </item>
          <item>
-          <widget class="QLabel" name="TextLabel4">
-           <property name="text">
-            <string>&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
+          <property name="text">
+           <string>What's New</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Providers</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Developers</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Contributors</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Translators</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>Donors</string>
+          </property>
+         </item>
+         <item>
+          <property name="text">
+           <string>License</string>
+          </property>
+         </item>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QFrame" name="mOptionsFrame">
+      <property name="sizePolicy">
+       <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+        <horstretch>1</horstretch>
+        <verstretch>0</verstretch>
+       </sizepolicy>
+      </property>
+      <property name="frameShape">
+       <enum>QFrame::NoFrame</enum>
+      </property>
+      <property name="frameShadow">
+       <enum>QFrame::Raised</enum>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <property name="margin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QStackedWidget" name="mOptionsStackedWidget">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="currentIndex">
+          <number>8</number>
+         </property>
+         <widget class="QWidget" name="mOptsPage_01">
+          <layout class="QVBoxLayout" name="verticalLayout_4">
+           <property name="margin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="label">
+             <property name="styleSheet">
+              <string notr="true">font-weight:bold;</string>
+             </property>
+             <property name="text">
+              <string>About</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <layout class="QHBoxLayout">
+             <item>
+              <widget class="QLabel" name="qgisIcon">
+               <property name="maximumSize">
+                <size>
+                 <width>60</width>
+                 <height>60</height>
+                </size>
+               </property>
+               <property name="pixmap">
+                <pixmap resource="../../images/images.qrc">:/images/icons/qgis-icon-60x60.png</pixmap>
+               </property>
+               <property name="scaledContents">
+                <bool>false</bool>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QLabel" name="TextLabel4">
+               <property name="text">
+                <string>&lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
 &lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Lucida Grande'; font-size:13pt; font-weight:400; font-style:normal;&quot;&gt;
 &lt;p style=&quot; margin-top:16px; margin-bottom:12px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px; font-size:x-large; font-weight:600;&quot;&gt;&lt;span style=&quot; font-size:x-large;&quot;&gt;QGIS&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+               </property>
+               <property name="alignment">
+                <set>Qt::AlignCenter</set>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item>
+            <widget class="QWebView" name="txtVersion">
+             <property name="url">
+              <url>
+               <string>about:blank</string>
+              </url>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="spacer_2">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>21</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <widget class="QLabel" name="label_3">
+             <property name="text">
+              <string>QGIS is licensed under the GNU General Public License</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QLabel" name="label_2">
+             <property name="text">
+              <string>http://www.gnu.org/licenses</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <spacer name="spacer">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>20</width>
+               <height>40</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
+           <item>
+            <layout class="QHBoxLayout" name="_2">
+             <item>
+              <widget class="QPushButton" name="btnQgisHome">
+               <property name="text">
+                <string>QGIS Home Page</string>
+               </property>
+               <property name="flat">
+                <bool>false</bool>
+               </property>
+              </widget>
+             </item>
+             <item>
+              <widget class="QPushButton" name="btnQgisUser">
+               <property name="text">
+                <string>Join our user mailing list</string>
+               </property>
+               <property name="flat">
+                <bool>false</bool>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="page">
+          <layout class="QVBoxLayout" name="verticalLayout_5">
+           <property name="margin">
+            <number>0</number>
            </property>
-           <property name="alignment">
-            <set>Qt::AlignCenter</set>
+           <item>
+            <widget class="QLabel" name="label_4">
+             <property name="styleSheet">
+              <string notr="true">font-weight:bold;</string>
+             </property>
+             <property name="text">
+              <string>What's New</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QTextBrowser" name="txtWhatsNew"/>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="page_2">
+          <layout class="QVBoxLayout" name="verticalLayout_6">
+           <property name="margin">
+            <number>0</number>
            </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item row="2" column="0">
-        <spacer>
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>21</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="3" column="0">
-        <widget class="QLabel" name="label">
-         <property name="text">
-          <string>QGIS is licensed under the GNU General Public License</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="4" column="0">
-        <widget class="QLabel" name="label_2">
-         <property name="text">
-          <string>http://www.gnu.org/licenses</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="5" column="0">
-        <spacer>
-         <property name="orientation">
-          <enum>Qt::Vertical</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>20</width>
-           <height>40</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-       <item row="6" column="0">
-        <layout class="QHBoxLayout">
-         <item>
-          <widget class="QPushButton" name="btnQgisHome">
-           <property name="text">
-            <string>QGIS Home Page</string>
+           <item>
+            <widget class="QLabel" name="label_5">
+             <property name="styleSheet">
+              <string notr="true">font-weight:bold;</string>
+             </property>
+             <property name="text">
+              <string>Providers</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QTextBrowser" name="txtProviders"/>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="page_3">
+          <layout class="QGridLayout" name="gridLayout">
+           <property name="margin">
+            <number>0</number>
            </property>
-           <property name="flat">
-            <bool>false</bool>
+           <item row="0" column="0" colspan="2">
+            <widget class="QLabel" name="label_6">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="styleSheet">
+              <string notr="true">font-weight:bold;</string>
+             </property>
+             <property name="text">
+              <string>Developers</string>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="0" rowspan="2">
+            <widget class="QListWidget" name="lstDevelopers">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="alternatingRowColors">
+              <bool>true</bool>
+             </property>
+             <property name="isWrapping" stdset="0">
+              <bool>false</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="1" column="1">
+            <widget class="QLabel" name="label_7">
+             <property name="text">
+              <string/>
+             </property>
+             <property name="pixmap">
+              <pixmap resource="../../images/images.qrc">:/images/last-hackfest.jpg</pixmap>
+             </property>
+             <property name="scaledContents">
+              <bool>false</bool>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignCenter</set>
+             </property>
+            </widget>
+           </item>
+           <item row="2" column="1">
+            <widget class="QLabel" name="label_8">
+             <property name="font">
+              <font>
+               <pointsize>17</pointsize>
+              </font>
+             </property>
+             <property name="text">
+              <string>Essen (Germany), Developer meeting 2012</string>
+             </property>
+             <property name="alignment">
+              <set>Qt::AlignCenter</set>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="page_4">
+          <layout class="QVBoxLayout" name="verticalLayout_7">
+           <property name="margin">
+            <number>0</number>
            </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QPushButton" name="btnQgisUser">
-           <property name="text">
-            <string>Join our user mailing list</string>
+           <item>
+            <widget class="QLabel" name="label_9">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="styleSheet">
+              <string notr="true">font-weight:bold;</string>
+             </property>
+             <property name="text">
+              <string>Contributors</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QListWidget" name="lstContributors">
+             <property name="alternatingRowColors">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="page_5">
+          <layout class="QVBoxLayout" name="verticalLayout_8">
+           <property name="margin">
+            <number>0</number>
            </property>
-           <property name="flat">
-            <bool>false</bool>
+           <item>
+            <widget class="QLabel" name="label_10">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="styleSheet">
+              <string notr="true">font-weight:bold;</string>
+             </property>
+             <property name="text">
+              <string>Contributors</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QWebView" name="txtTranslators">
+             <property name="url">
+              <url>
+               <string>about:blank</string>
+              </url>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="page_6">
+          <layout class="QVBoxLayout" name="verticalLayout_9">
+           <property name="margin">
+            <number>0</number>
            </property>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item row="1" column="0">
-        <widget class="QWebView" name="txtVersion">
-         <property name="url">
-          <url>
-           <string>about:blank</string>
-          </url>
-         </property>
+           <item>
+            <widget class="QLabel" name="label_11">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="styleSheet">
+              <string notr="true">font-weight:bold;</string>
+             </property>
+             <property name="text">
+              <string>Translators</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QWebView" name="txtTranslators_2">
+             <property name="url">
+              <url>
+               <string>about:blank</string>
+              </url>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="page_7">
+          <layout class="QVBoxLayout" name="verticalLayout_10">
+           <property name="margin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="label_12">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="styleSheet">
+              <string notr="true">font-weight:bold;</string>
+             </property>
+             <property name="text">
+              <string>Translators</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QTextBrowser" name="txtDonors">
+             <property name="openExternalLinks">
+              <bool>true</bool>
+             </property>
+             <property name="openLinks">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QWidget" name="page_8">
+          <layout class="QVBoxLayout" name="verticalLayout_11">
+           <property name="margin">
+            <number>0</number>
+           </property>
+           <item>
+            <widget class="QLabel" name="label_13">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="styleSheet">
+              <string notr="true">font-weight:bold;</string>
+             </property>
+             <property name="text">
+              <string>Translators</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QTextBrowser" name="txtLicense"/>
+           </item>
+          </layout>
+         </widget>
         </widget>
        </item>
       </layout>
      </widget>
-     <widget class="QWidget" name="Widget3">
-      <attribute name="title">
-       <string>What's New</string>
-      </attribute>
-      <layout class="QGridLayout">
-       <item row="0" column="0">
-        <widget class="QTextBrowser" name="txtWhatsNew"/>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="TabPage">
-      <attribute name="title">
-       <string>Providers</string>
-      </attribute>
-      <layout class="QGridLayout">
-       <item row="0" column="0">
-        <widget class="QTextBrowser" name="txtProviders"/>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="tab">
-      <attribute name="title">
-       <string>Developers</string>
-      </attribute>
-      <layout class="QGridLayout" name="gridLayout_2">
-       <item row="0" column="0" rowspan="2">
-        <widget class="QListWidget" name="lstDevelopers">
-         <property name="alternatingRowColors">
-          <bool>true</bool>
-         </property>
-         <property name="isWrapping" stdset="0">
-          <bool>false</bool>
-         </property>
-        </widget>
-       </item>
-       <item row="0" column="1">
-        <widget class="QLabel" name="label_3">
-         <property name="text">
-          <string/>
-         </property>
-         <property name="pixmap">
-          <pixmap resource="../../images/images.qrc">:/images/last-hackfest.jpg</pixmap>
-         </property>
-         <property name="scaledContents">
-          <bool>false</bool>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-       <item row="1" column="1">
-        <widget class="QLabel" name="label_4">
-         <property name="font">
-          <font>
-           <pointsize>17</pointsize>
-          </font>
-         </property>
-         <property name="text">
-          <string>Essen (Germany), Developer meeting 2012</string>
-         </property>
-         <property name="alignment">
-          <set>Qt::AlignCenter</set>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="tab_5">
-      <attribute name="title">
-       <string>Contributors</string>
-      </attribute>
-      <layout class="QGridLayout" name="gridLayout_1">
-       <item row="0" column="0">
-        <widget class="QListWidget" name="lstContributors">
-         <property name="alternatingRowColors">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="tab_3">
-      <attribute name="title">
-       <string>Translators</string>
-      </attribute>
-      <layout class="QGridLayout">
-       <item row="0" column="0">
-        <widget class="QWebView" name="txtTranslators">
-         <property name="url">
-          <url>
-           <string>about:blank</string>
-          </url>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="tab_4">
-      <attribute name="title">
-       <string>Donors</string>
-      </attribute>
-      <layout class="QGridLayout">
-       <item row="0" column="0">
-        <widget class="QTextBrowser" name="txtDonors">
-         <property name="openExternalLinks">
-          <bool>true</bool>
-         </property>
-         <property name="openLinks">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QWidget" name="tab_2">
-      <attribute name="title">
-       <string>License </string>
-      </attribute>
-      <layout class="QGridLayout" name="gridLayout_3">
-       <item row="0" column="0">
-        <widget class="QTextBrowser" name="txtLicense"/>
-       </item>
-      </layout>
-     </widget>
+    </widget>
+   </item>
+   <item>
+    <widget class="QFrame" name="mButtonBoxFrame">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="frameShadow">
+      <enum>QFrame::Raised</enum>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout">
+      <property name="margin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QDialogButtonBox" name="buttonBox">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="standardButtons">
+         <set>QDialogButtonBox::Close</set>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
   </layout>
  </widget>
- <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
    <class>QWebView</class>
@@ -285,33 +590,25 @@ p, li { white-space: pre-wrap; }
    <header>QtWebKit/QWebView</header>
   </customwidget>
  </customwidgets>
- <tabstops>
-  <tabstop>tabWidget</tabstop>
-  <tabstop>btnQgisHome</tabstop>
-  <tabstop>btnQgisUser</tabstop>
-  <tabstop>txtProviders</tabstop>
-  <tabstop>lstDevelopers</tabstop>
-  <tabstop>buttonBox</tabstop>
-  <tabstop>txtDonors</tabstop>
-  <tabstop>lstContributors</tabstop>
- </tabstops>
  <resources>
+  <include location="../../../../Users/NATHAN~1.WOO/images/images.qrc"/>
   <include location="../../images/images.qrc"/>
+  <include location="C:/images/images.qrc"/>
  </resources>
  <connections>
   <connection>
-   <sender>buttonBox</sender>
-   <signal>clicked(QAbstractButton*)</signal>
-   <receiver>QgsAbout</receiver>
-   <slot>accept()</slot>
+   <sender>mOptionsListWidget</sender>
+   <signal>currentRowChanged(int)</signal>
+   <receiver>mOptionsStackedWidget</receiver>
+   <slot>setCurrentIndex(int)</slot>
    <hints>
     <hint type="sourcelabel">
-     <x>719</x>
-     <y>386</y>
+     <x>86</x>
+     <y>325</y>
     </hint>
     <hint type="destinationlabel">
-     <x>674</x>
-     <y>414</y>
+     <x>794</x>
+     <y>14</y>
     </hint>
    </hints>
   </connection>

--- a/src/ui/qgspluginmanagerbase.ui
+++ b/src/ui/qgspluginmanagerbase.ui
@@ -207,7 +207,7 @@
        </item>
       </layout>
      </widget>
-     <widget class="QFrame" name="mPluginsFrame">
+     <widget class="QFrame" name="mOptionsFrame">
       <property name="sizePolicy">
        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
         <horstretch>2</horstretch>
@@ -223,14 +223,14 @@
       <property name="lineWidth">
        <number>0</number>
       </property>
-      <layout class="QGridLayout" name="gridLayout_2">
+      <layout class="QVBoxLayout" name="verticalLayout_12">
+       <property name="spacing">
+        <number>6</number>
+       </property>
        <property name="margin">
         <number>0</number>
        </property>
-       <property name="spacing">
-        <number>-1</number>
-       </property>
-       <item row="0" column="0">
+       <item>
         <widget class="QStackedWidget" name="mOptionsStackedWidget">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
@@ -524,8 +524,8 @@
                   <rect>
                    <x>0</x>
                    <y>0</y>
-                   <width>352</width>
-                   <height>758</height>
+                   <width>360</width>
+                   <height>731</height>
                   </rect>
                  </property>
                  <layout class="QVBoxLayout" name="verticalLayout_10">

--- a/src/ui/qgsvectorlayerpropertiesbase.ui
+++ b/src/ui/qgsvectorlayerpropertiesbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>966</width>
-    <height>879</height>
+    <width>929</width>
+    <height>573</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -276,8 +276,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>793</width>
-                <height>784</height>
+                <width>756</width>
+                <height>476</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_13">
@@ -715,8 +715,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>793</width>
-                <height>784</height>
+                <width>765</width>
+                <height>545</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_18">
@@ -809,8 +809,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>793</width>
-                <height>784</height>
+                <width>83</width>
+                <height>33</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_28">
@@ -883,8 +883,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>793</width>
-                <height>784</height>
+                <width>83</width>
+                <height>16</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_20">
@@ -935,8 +935,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>794</width>
-                <height>780</height>
+                <width>374</width>
+                <height>255</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_32">
@@ -1164,8 +1164,8 @@ p, li { white-space: pre-wrap; }
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>793</width>
-                <height>784</height>
+                <width>385</width>
+                <height>161</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_26">
@@ -1335,8 +1335,8 @@ p, li { white-space: pre-wrap; }
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>793</width>
-                <height>784</height>
+                <width>765</width>
+                <height>545</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_21">
@@ -1393,8 +1393,8 @@ p, li { white-space: pre-wrap; }
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>793</width>
-                <height>784</height>
+                <width>91</width>
+                <height>123</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_23">
@@ -1505,8 +1505,8 @@ p, li { white-space: pre-wrap; }
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>793</width>
-                <height>784</height>
+                <width>83</width>
+                <height>16</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_24">
@@ -1557,8 +1557,8 @@ p, li { white-space: pre-wrap; }
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>793</width>
-                <height>784</height>
+                <width>279</width>
+                <height>451</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_8">
@@ -1724,7 +1724,7 @@ p, li { white-space: pre-wrap; }
                      <widget class="QComboBox" name="mLayerMetadataUrlTypeComboBox">
                       <item>
                        <property name="text">
-                        <string notr="true"></string>
+                        <string notr="true"/>
                        </property>
                       </item>
                       <item>
@@ -1750,7 +1750,7 @@ p, li { white-space: pre-wrap; }
                      <widget class="QComboBox" name="mLayerMetadataUrlFormatComboBox">
                       <item>
                        <property name="text">
-                        <string notr="true"></string>
+                        <string notr="true"/>
                        </property>
                       </item>
                       <item>
@@ -1832,6 +1832,38 @@ p, li { white-space: pre-wrap; }
          </widget>
         </widget>
        </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout_9">
+         <item>
+          <widget class="QPushButton" name="pbnLoadStyle">
+           <property name="text">
+            <string>Load Style ...</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="pbnSaveDefaultStyle">
+           <property name="text">
+            <string>Save As Default</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="pbnLoadDefaultStyle">
+           <property name="text">
+            <string>Restore Default Style</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="pbnSaveStyleAs">
+           <property name="text">
+            <string>Save Style ...</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
       </layout>
      </widget>
     </widget>
@@ -1854,35 +1886,7 @@ p, li { white-space: pre-wrap; }
       <property name="margin">
        <number>0</number>
       </property>
-      <item row="0" column="2">
-       <widget class="QPushButton" name="pbnSaveDefaultStyle">
-        <property name="text">
-         <string>Save As Default</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="3">
-       <widget class="QPushButton" name="pbnLoadStyle">
-        <property name="text">
-         <string>Load Style ...</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QPushButton" name="pbnLoadDefaultStyle">
-        <property name="text">
-         <string>Restore Default Style</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="4">
-       <widget class="QPushButton" name="pbnSaveStyleAs">
-        <property name="text">
-         <string>Save Style ...</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1" colspan="4">
+      <item row="2" column="1" colspan="4">
        <widget class="QDialogButtonBox" name="buttonBox">
         <property name="orientation">
          <enum>Qt::Horizontal</enum>
@@ -1911,6 +1915,7 @@ p, li { white-space: pre-wrap; }
   </customwidget>
  </customwidgets>
  <resources>
+  <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>
  </resources>
  <connections>

--- a/src/ui/templates/qgsoptionsdialog_template.ui
+++ b/src/ui/templates/qgsoptionsdialog_template.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>827</width>
-    <height>759</height>
+    <width>723</width>
+    <height>444</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -140,8 +140,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>646</width>
-                <height>669</height>
+                <width>550</width>
+                <height>378</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_13">


### PR DESCRIPTION
This pull request adds a new stylized side bar to any dialog that inherits from QgsOptionsDialogBase.  The main changes are: 
- New blue-grey with white text style dialog
- Side panel runs top to bottom
- Icon size is read from settings

The main reasons for changing this are 
- make the dialogs look a bit more stylish rather then just a bunch of widgets thrown on a dialog. 
- separates the page selector to page itself.  Pages on left, and options on right.
- IMO this makes it easier to focus on the real options on the right
- Running top to bottom with no border is done in order to make feel different to the rest of the options on the right so the user can focus on them rather then the pages widget.

**Vector layer dialog**
![image](https://f.cloud.github.com/assets/381660/1844709/48a0cc9a-754b-11e3-8855-6c8b52af1717.png)

**Plugin Manager**
![image](https://f.cloud.github.com/assets/381660/1844713/92284b72-754b-11e3-8011-0c0c48369e1f.png)

**Options**
![image](https://f.cloud.github.com/assets/381660/1844715/aa58cce4-754b-11e3-8c62-c494f89caece.png)

**Raster**
![image](https://f.cloud.github.com/assets/381660/1844716/bbf7c356-754b-11e3-820f-44693d7b8498.png)

**Compare**
![image](https://f.cloud.github.com/assets/381660/1844709/48a0cc9a-754b-11e3-8855-6c8b52af1717.png)
![image](https://f.cloud.github.com/assets/381660/1844717/f243ea84-754b-11e3-8795-10abbfb7943e.png)

General feel from people so far is that most like it.

I will leave this pull request open for a few days for comments then merge if there are no strong objections.
