### PR TITLE
add checkbox to invert color ramps in graduated and categorized symbology

### DIFF
--- a/src/core/symbology-ng/qgscategorizedsymbolrendererv2.cpp
+++ b/src/core/symbology-ng/qgscategorizedsymbolrendererv2.cpp
@@ -140,6 +140,7 @@ QgsCategorizedSymbolRendererV2::QgsCategorizedSymbolRendererV2( QString attrName
     mCategories( categories ),
     mSourceSymbol( NULL ),
     mSourceColorRamp( NULL ),
+    mInvertedColorRamp( false ),
     mScaleMethod( DEFAULT_SCALE_METHOD ),
     mRotationFieldIdx( -1 ),
     mSizeScaleFieldIdx( -1 )
@@ -450,7 +451,10 @@ QgsFeatureRendererV2* QgsCategorizedSymbolRendererV2::clone()
   if ( mSourceSymbol )
     r->setSourceSymbol( mSourceSymbol->clone() );
   if ( mSourceColorRamp )
+  {
     r->setSourceColorRamp( mSourceColorRamp->clone() );
+    r->setInvertedColorRamp( mInvertedColorRamp );
+  }
   r->setUsingSymbolLevels( usingSymbolLevels() );
   r->setRotationField( rotationField() );
   r->setSizeScaleField( sizeScaleField() );
@@ -537,6 +541,9 @@ QgsFeatureRendererV2* QgsCategorizedSymbolRendererV2::create( QDomElement& eleme
   if ( !sourceColorRampElem.isNull() && sourceColorRampElem.attribute( "name" ) == "[source]" )
   {
     r->setSourceColorRamp( QgsSymbolLayerV2Utils::loadColorRamp( sourceColorRampElem ) );
+    QDomElement invertedColorRampElem = element.firstChildElement( "invertedcolorramp" );
+    if ( !invertedColorRampElem.isNull() )
+      r->setInvertedColorRamp( invertedColorRampElem.attribute( "value" ) == "1" );
   }
 
   QDomElement rotationElem = element.firstChildElement( "rotation" );
@@ -600,6 +607,9 @@ QDomElement QgsCategorizedSymbolRendererV2::save( QDomDocument& doc )
   {
     QDomElement colorRampElem = QgsSymbolLayerV2Utils::saveColorRamp( "[source]", mSourceColorRamp, doc );
     rendererElem.appendChild( colorRampElem );
+    QDomElement invertedElem = doc.createElement( "invertedcolorramp" );
+    invertedElem.setAttribute( "value", mInvertedColorRamp );
+    rendererElem.appendChild( invertedElem );
   }
 
   QDomElement rotationElem = doc.createElement( "rotation" );

--- a/src/core/symbology-ng/qgscategorizedsymbolrendererv2.h
+++ b/src/core/symbology-ng/qgscategorizedsymbolrendererv2.h
@@ -132,6 +132,9 @@ class CORE_EXPORT QgsCategorizedSymbolRendererV2 : public QgsFeatureRendererV2
 
     QgsVectorColorRampV2* sourceColorRamp();
     void setSourceColorRamp( QgsVectorColorRampV2* ramp );
+    //! @note added in 2.1
+    bool invertedColorRamp() { return mInvertedColorRamp; }
+    void setInvertedColorRamp( bool inverted ) { mInvertedColorRamp = inverted; }
 
     //! @note added in 1.6
     void setRotationField( QString fieldName ) { mRotationField = fieldName; }
@@ -153,6 +156,7 @@ class CORE_EXPORT QgsCategorizedSymbolRendererV2 : public QgsFeatureRendererV2
     QgsCategoryList mCategories;
     QgsSymbolV2* mSourceSymbol;
     QgsVectorColorRampV2* mSourceColorRamp;
+    bool mInvertedColorRamp;
     QString mRotationField;
     QString mSizeScaleField;
     QgsSymbolV2::ScaleMethod mScaleMethod;

--- a/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.h
+++ b/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.h
@@ -124,7 +124,8 @@ class CORE_EXPORT QgsGraduatedSymbolRendererV2 : public QgsFeatureRendererV2
       int classes,
       Mode mode,
       QgsSymbolV2* symbol,
-      QgsVectorColorRampV2* ramp );
+      QgsVectorColorRampV2* ramp,
+      bool inverted = false );
 
     //! create renderer from XML element
     static QgsFeatureRendererV2* create( QDomElement& element );
@@ -145,11 +146,14 @@ class CORE_EXPORT QgsGraduatedSymbolRendererV2 : public QgsFeatureRendererV2
 
     QgsVectorColorRampV2* sourceColorRamp();
     void setSourceColorRamp( QgsVectorColorRampV2* ramp );
+    //! @note added in 2.1
+    bool invertedColorRamp() { return mInvertedColorRamp; }
+    void setInvertedColorRamp( bool inverted ) { mInvertedColorRamp = inverted; }
 
     /** Update the color ramp used. Also updates all symbols colors.
       * Doesn't alter current breaks.
       */
-    void updateColorRamp( QgsVectorColorRampV2* ramp );
+    void updateColorRamp( QgsVectorColorRampV2* ramp, bool inverted = false );
 
     /** Update the all symbols but leave breaks and colors. */
     void updateSymbols( QgsSymbolV2* sym );
@@ -176,6 +180,7 @@ class CORE_EXPORT QgsGraduatedSymbolRendererV2 : public QgsFeatureRendererV2
     Mode mMode;
     QgsSymbolV2* mSourceSymbol;
     QgsVectorColorRampV2* mSourceColorRamp;
+    bool mInvertedColorRamp;
     QString mRotationField;
     QString mSizeScaleField;
     QgsSymbolV2::ScaleMethod mScaleMethod;

--- a/src/gui/symbology-ng/qgscategorizedsymbolrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgscategorizedsymbolrendererv2widget.cpp
@@ -464,6 +464,7 @@ void QgsCategorizedSymbolRendererV2Widget::updateUiFromRenderer()
   if ( mRenderer->sourceColorRamp() )
   {
     cboCategorizedColorRamp->setSourceColorRamp( mRenderer->sourceColorRamp() );
+    cbxInvertedColorRamp->setChecked( mRenderer->invertedColorRamp() );
   }
 
 }
@@ -582,7 +583,7 @@ void QgsCategorizedSymbolRendererV2Widget::changeCategorySymbol()
   mRenderer->updateCategorySymbol( catIdx, symbol );
 }
 
-static void _createCategories( QgsCategoryList& cats, QList<QVariant>& values, QgsSymbolV2* symbol, QgsVectorColorRampV2* ramp )
+static void _createCategories( QgsCategoryList& cats, QList<QVariant>& values, QgsSymbolV2* symbol, QgsVectorColorRampV2* ramp, bool invert )
 {
   // sort the categories first
   QgsSymbolLayerV2Utils::sortVariantList( values, Qt::AscendingOrder );
@@ -598,7 +599,7 @@ static void _createCategories( QgsCategoryList& cats, QList<QVariant>& values, Q
     {
       hasNull = true;
     }
-    double x = i / ( double ) num;
+    double x = ( invert ? num - i : i )  / ( double ) num;
     QgsSymbolV2* newSymbol = symbol->clone();
     newSymbol->setColor( ramp->color( x ) );
 
@@ -609,7 +610,7 @@ static void _createCategories( QgsCategoryList& cats, QList<QVariant>& values, Q
   if ( !hasNull )
   {
     QgsSymbolV2* newSymbol = symbol->clone();
-    newSymbol->setColor( ramp->color( 1 ) );
+    newSymbol->setColor( ramp->color( invert ? 0 : 1 ) );
     cats.append( QgsRendererCategoryV2( QVariant( "" ), newSymbol, QString() ) );
   }
 }
@@ -670,7 +671,7 @@ void QgsCategorizedSymbolRendererV2Widget::addCategories()
   }
 
   QgsCategoryList cats;
-  _createCategories( cats, unique_vals, mCategorizedSymbol, ramp );
+  _createCategories( cats, unique_vals, mCategorizedSymbol, ramp, cbxInvertedColorRamp->isChecked() );
 
   bool deleteExisting = false;
 
@@ -737,6 +738,7 @@ void QgsCategorizedSymbolRendererV2Widget::addCategories()
   r->setScaleMethod( mRenderer->scaleMethod() );
   r->setSizeScaleField( mRenderer->sizeScaleField() );
   r->setRotationField( mRenderer->rotationField() );
+  r->setInvertedColorRamp( cbxInvertedColorRamp->isChecked() );
 
   if ( mModel )
   {

--- a/src/gui/symbology-ng/qgsgraduatedsymbolrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgsgraduatedsymbolrendererv2widget.cpp
@@ -462,6 +462,7 @@ void QgsGraduatedSymbolRendererV2Widget::updateUiFromRenderer()
   if ( mRenderer->sourceColorRamp() )
   {
     cboGraduatedColorRamp->setSourceColorRamp( mRenderer->sourceColorRamp() );
+    cbxInvertedColorRamp->setChecked( mRenderer->invertedColorRamp() );
   }
 }
 
@@ -540,7 +541,7 @@ void QgsGraduatedSymbolRendererV2Widget::classifyGraduated()
   // create and set new renderer
   QApplication::setOverrideCursor( Qt::WaitCursor );
   QgsGraduatedSymbolRendererV2* r = QgsGraduatedSymbolRendererV2::createRenderer(
-                                      mLayer, attrName, classes, mode, mGraduatedSymbol, ramp );
+                                      mLayer, attrName, classes, mode, mGraduatedSymbol, ramp, cbxInvertedColorRamp->isChecked() );
   QApplication::restoreOverrideCursor();
   if ( !r )
   {
@@ -566,7 +567,7 @@ void QgsGraduatedSymbolRendererV2Widget::reapplyColorRamp()
   if ( ramp == NULL )
     return;
 
-  mRenderer->updateColorRamp( ramp );
+  mRenderer->updateColorRamp( ramp, cbxInvertedColorRamp->isChecked() );
   refreshSymbolView();
 }
 

--- a/src/ui/qgscategorizedsymbolrendererv2widget.ui
+++ b/src/ui/qgscategorizedsymbolrendererv2widget.ui
@@ -116,6 +116,13 @@
        </property>
       </widget>
      </item>
+     <item>
+      <widget class="QCheckBox" name="cbxInvertedColorRamp">
+       <property name="text">
+        <string>Invert</string>
+       </property>
+      </widget>
+     </item>
     </layout>
    </item>
    <item>
@@ -227,6 +234,7 @@
   <tabstop>cboCategorizedColumn</tabstop>
   <tabstop>btnChangeCategorizedSymbol</tabstop>
   <tabstop>cboCategorizedColorRamp</tabstop>
+  <tabstop>cbxInvertedColorRamp</tabstop>
   <tabstop>viewCategories</tabstop>
   <tabstop>btnAddCategories</tabstop>
   <tabstop>btnDeleteCategories</tabstop>

--- a/src/ui/qgsgraduatedsymbolrendererv2widget.ui
+++ b/src/ui/qgsgraduatedsymbolrendererv2widget.ui
@@ -39,9 +39,6 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="1">
-      <widget class="QgsColorRampComboBox" name="cboGraduatedColorRamp"/>
-     </item>
      <item row="5" column="3">
       <widget class="QComboBox" name="cboGraduatedMode">
        <item>
@@ -192,6 +189,20 @@
        </item>
       </layout>
      </item>
+     <item row="5" column="1">
+      <layout class="QHBoxLayout" name="horizontalLayout_2">
+       <item>
+        <widget class="QgsColorRampComboBox" name="cboGraduatedColorRamp"/>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="cbxInvertedColorRamp">
+         <property name="text">
+          <string>Invert</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
     </layout>
    </item>
    <item>
@@ -283,6 +294,7 @@
  <tabstops>
   <tabstop>btnChangeGraduatedSymbol</tabstop>
   <tabstop>cboGraduatedColorRamp</tabstop>
+  <tabstop>cbxInvertedColorRamp</tabstop>
   <tabstop>spinGraduatedClasses</tabstop>
   <tabstop>cboGraduatedMode</tabstop>
   <tabstop>viewGraduated</tabstop>


### PR DESCRIPTION
see http://hub.qgis.org/issues/9303

this is simpler than changing all the color ramps widgets, similar to the raster properties
