### PR TITLE
[feature] Action to set a feature as the current atlas feature - sponsored by SIGE

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -8220,7 +8220,7 @@ void QgisApp::setAtlasFeature( QgsVectorLayer* layer, QgsFeature &feat )
     }
 
     //check if composition has preview enabled
-    if ( ! composition->atlasPreviewEnabled() )
+    if ( ! composition->atlasMode() == QgsComposition::PreviewAtlas )
     {
       //Composition is not in atlas preview mode
       //so skip it. Possibly it would be better here to

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1164,6 +1164,9 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     //! catch MapCanvas keyPress event so we can check if selected feature collection must be deleted
     void mapCanvas_keyPressed( QKeyEvent *e );
 
+    //! sets a feature as the current atlas feature
+    void setAtlasFeature( QgsVectorLayer* layer, QgsFeature &feat );
+
   signals:
     /** emitted when a key is pressed and we want non widget sublasses to be able
       to pick up on this (e.g. maplayer) */

--- a/src/app/qgsfeatureaction.h
+++ b/src/app/qgsfeatureaction.h
@@ -17,6 +17,7 @@
 #ifndef QGSFEATUREACTION_H
 #define QGSFEATUREACTION_H
 
+#include "qgsattributeaction.h"
 #include "qgsfeature.h"
 #include "qgsvectorlayertools.h"
 
@@ -34,7 +35,9 @@ class APP_EXPORT QgsFeatureAction : public QAction
     Q_OBJECT
 
   public:
-    QgsFeatureAction( const QString &name, QgsFeature &f, QgsVectorLayer *vl, int action = -1, int defaultAttr = -1, QObject *parent = NULL );
+
+    QgsFeatureAction( const QString &name, QgsFeature &f, QgsVectorLayer *vl, int action = -1, int defaultAttr = -1,
+                      QObject *parent = NULL, QgsAction::ActionClass actionClass = QgsAction::UserDefinedAction );
 
   public slots:
     void execute();
@@ -59,6 +62,8 @@ class APP_EXPORT QgsFeatureAction : public QAction
     QgsFeature &mFeature;
     int mAction;
     int mIdx;
+
+    QgsAction::ActionClass mClass;
 
     static QMap<QgsVectorLayer *, QgsAttributeMap> mLastUsedValues;
 };

--- a/src/app/qgsidentifyresultsdialog.h
+++ b/src/app/qgsidentifyresultsdialog.h
@@ -216,7 +216,7 @@ class APP_EXPORT QgsIdentifyResultsDialog: public QDialog, private Ui::QgsIdenti
 
     void highlightFeature( QTreeWidgetItem *item );
 
-    void doAction( QTreeWidgetItem *item, int action );
+    void doAction( QTreeWidgetItem *item, int action, QgsAction::ActionClass actionClass );
 
     QDockWidget *mDock;
 };

--- a/src/app/qgsmaptoolfeatureaction.cpp
+++ b/src/app/qgsmaptoolfeatureaction.cpp
@@ -78,7 +78,7 @@ void QgsMapToolFeatureAction::canvasReleaseEvent( QMouseEvent *e )
   }
 
   QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( layer );
-  if ( vlayer->actions()->size() == 0 )
+  if ( vlayer->actions()->size() == 0 && vlayer->standardActions()->size() == 0 )
   {
     QMessageBox::warning( mCanvas,
                           tr( "No actions available" ),
@@ -149,7 +149,16 @@ bool QgsMapToolFeatureAction::doAction( QgsVectorLayer *layer, int x, int y )
 
   foreach ( QgsFeature feat, featList )
   {
-    int actionIdx = layer->actions()->defaultAction();
+    int actionIdx;
+
+    if ( layer->actions()->defaultAction() >= 0 )
+    {
+      actionIdx = layer->actions()->defaultAction();
+    }
+    else if ( layer->standardActions()->defaultAction() >= 0 )
+    {
+      actionIdx = layer->standardActions()->defaultAction();
+    }
 
     // define custom substitutions: layer id and clicked coords
     QMap<QString, QVariant> substitutionMap;
@@ -158,7 +167,15 @@ bool QgsMapToolFeatureAction::doAction( QgsVectorLayer *layer, int x, int y )
     substitutionMap.insert( "$clickx", point.x() );
     substitutionMap.insert( "$clicky", point.y() );
 
-    layer->actions()->doAction( actionIdx, feat, &substitutionMap );
+    if ( layer->actions()->defaultAction() >= 0 )
+    {
+      layer->actions()->doAction( actionIdx, feat, &substitutionMap );
+    }
+    else if ( layer->standardActions()->defaultAction() >= 0 )
+    {
+      layer->standardActions()->doAction( actionIdx, feat, &substitutionMap );
+    }
+
   }
 
   return true;

--- a/src/core/composer/qgsatlascomposition.cpp
+++ b/src/core/composer/qgsatlascomposition.cpp
@@ -279,6 +279,12 @@ void QgsAtlasComposition::lastFeature()
   prepareForFeature( mCurrentFeatureNo );
 }
 
+void QgsAtlasComposition::prepareForFeature( QgsFeature * feat )
+{
+  int featureI = mFeatureIds.indexOf( feat->id() );
+  prepareForFeature( featureI );
+}
+
 void QgsAtlasComposition::prepareForFeature( int featureI )
 {
   if ( !mComposerMap || !mCoverageLayer )

--- a/src/core/composer/qgsatlascomposition.h
+++ b/src/core/composer/qgsatlascomposition.h
@@ -92,6 +92,7 @@ class CORE_EXPORT QgsAtlasComposition : public QObject
 
     /** Prepare the atlas map for the given feature. Sets the extent and context variables */
     void prepareForFeature( int i );
+    void prepareForFeature( QgsFeature * feat );
 
     /** Returns the current filename. Must be called after prepareForFeature( i ) */
     const QString& currentFilename() const;

--- a/src/core/qgsattributeaction.cpp
+++ b/src/core/qgsattributeaction.cpp
@@ -45,6 +45,10 @@ bool QgsAction::runable() const
   if ( mType == QgsAction::Atlas )
   {
     //atlas dependant logic here
+    //possibly could set this action as runable only if a composition has this layer as the atlas layer
+    //but alternatively it may be more flexible to always allow this action (eg, for previewing
+    //atlas based symbology before a composition has been created)
+    //for now, always show this action
     return true;
   }
 

--- a/src/core/qgsattributeaction.cpp
+++ b/src/core/qgsattributeaction.cpp
@@ -23,6 +23,7 @@
  ***************************************************************************/
 
 #include "qgsattributeaction.h"
+#include "qgsgeometry.h"
 #include "qgspythonrunner.h"
 #include "qgsrunprocess.h"
 #include "qgsvectorlayer.h"
@@ -39,6 +40,26 @@
 #include <QDir>
 #include <QFileInfo>
 
+bool QgsAction::runable() const
+{
+  if ( mType == QgsAction::Atlas )
+  {
+    //atlas dependant logic here
+    return true;
+  }
+
+  return mType == QgsAction::Generic ||
+         mType == QgsAction::GenericPython ||
+         mType == QgsAction::OpenUrl ||
+#if defined(Q_OS_WIN)
+         mType == QgsAction::Windows
+#elif defined(Q_OS_MAC)
+         mType == QgsAction::Mac
+#else
+         mType == QgsAction::Unix
+#endif
+         ;
+}
 
 void QgsAttributeAction::addAction( QgsAction::ActionType type, QString name, QString action, bool capture )
 {
@@ -75,6 +96,13 @@ void QgsAttributeAction::doAction( int index, QgsFeature &feat,
   const QgsAction &action = at( index );
   if ( !action.runable() )
     return;
+
+  if ( action.type() == QgsAction::Atlas )
+  {
+    //special type of action - does not require expanding, etc
+    mLayer->setAtlasFeature( feat );
+    return;
+  }
 
   // search for expressions while expanding actions
   QString expandedAction = QgsExpression::replaceExpressionText( action.action(), &feat, mLayer , substitutionMap );

--- a/src/core/qgsattributeaction.h
+++ b/src/core/qgsattributeaction.h
@@ -51,6 +51,12 @@ class CORE_EXPORT QgsAction
       Atlas
     };
 
+    enum ActionClass
+    {
+      UserDefinedAction,
+      StandardAction
+    };
+
     QgsAction( ActionType type, QString name, QString action, bool capture ) :
         mType( type ), mName( name ), mAction( action ), mCaptureOutput( capture ) {}
 

--- a/src/core/qgsattributeaction.h
+++ b/src/core/qgsattributeaction.h
@@ -91,7 +91,7 @@ class  CORE_EXPORT QgsAttributeAction
 {
   public:
     //! Constructor
-    QgsAttributeAction( QgsVectorLayer *layer ) : mLayer( layer ) {}
+    QgsAttributeAction( QgsVectorLayer *layer ) : mLayer( layer ), mDefaultAction( -1 ) {}
 
     //! Destructor
     virtual ~QgsAttributeAction() {}
@@ -169,7 +169,7 @@ class  CORE_EXPORT QgsAttributeAction
     static void setPythonExecute( void ( * )( const QString & ) );
 
     //! Whether the action is the default action
-    int defaultAction() const { return mDefaultAction < 0 || mDefaultAction >= size() ? 0 : mDefaultAction; }
+    int defaultAction() const { return mDefaultAction < 0 || mDefaultAction >= size() ? -1 : mDefaultAction; }
     void setDefaultAction( int actionNumber ) { mDefaultAction = actionNumber ; }
 
   private:

--- a/src/core/qgsattributeaction.h
+++ b/src/core/qgsattributeaction.h
@@ -48,6 +48,7 @@ class CORE_EXPORT QgsAction
       Windows,
       Unix,
       OpenUrl,
+      Atlas
     };
 
     QgsAction( ActionType type, QString name, QString action, bool capture ) :
@@ -66,20 +67,7 @@ class CORE_EXPORT QgsAction
     bool capture() const { return mCaptureOutput; }
 
     //! Whether the action is runable on the current platform
-    bool runable() const
-    {
-      return mType == Generic ||
-             mType == GenericPython ||
-             mType == OpenUrl ||
-#if defined(Q_OS_WIN)
-             mType == Windows
-#elif defined(Q_OS_MAC)
-             mType == Mac
-#else
-             mType == Unix
-#endif
-             ;
-    }
+    bool runable() const;
 
   private:
     ActionType mType;

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -3562,8 +3562,7 @@ void QgsVectorLayer::stopRendererV2( QgsRenderContext& rendererContext, QgsSingl
 
 void QgsVectorLayer::setAtlasFeature( QgsFeature &feat )
 {
-  QgsExpression::setSpecialColumn( "$atlasfeatureid", feat.id() );
-  QgsExpression::setSpecialColumn( "$atlasgeometry", QVariant::fromValue( *feat.geometry() ) );
+  emit actionAtlasFeatureCalled( this, feat );
 }
 
 void QgsVectorLayer::prepareLabelingAndDiagrams( QgsRenderContext& rendererContext, QgsAttributeList& attributes, bool& labeling )

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -141,6 +141,8 @@ QgsVectorLayer::QgsVectorLayer( QString vectorLayerPath,
 
 {
   mActions = new QgsAttributeAction( this );
+  mStandardActions = new QgsAttributeAction( this );
+  addStandardActions();
 
   // if we're given a provider type, try to create and bind one to this layer
   if ( ! mProviderKey.isEmpty() )
@@ -208,6 +210,7 @@ QgsVectorLayer::~QgsVectorLayer()
   delete mDiagramLayerSettings;
 
   delete mActions;
+  delete mStandardActions;
 
   delete mRendererV2;
 }
@@ -1915,12 +1918,6 @@ bool QgsVectorLayer::readSymbology( const QDomNode& node, QString& errorMessage 
 
   // process the attribute actions
   mActions->readXML( node );
-
-  // add atlas action
-  mActions->addAction( QgsAction::Atlas,
-                       "Set as atlas feature",
-                       "",
-                       false );
 
   mEditTypes.clear();
   QDomNode editTypesNode = node.namedItem( "edittypes" );
@@ -4160,6 +4157,15 @@ bool QgsVectorLayer::applyNamedStyle( QString namedStyle, QString errorMsg )
 #endif
 
   return readSymbology( myRoot, errorMsg );
+}
+
+void QgsVectorLayer::addStandardActions()
+{
+  // add atlas action
+  mStandardActions->addAction( QgsAction::Atlas,
+                               "Set as atlas feature",
+                               "",
+                               false );
 }
 
 

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -1916,6 +1916,12 @@ bool QgsVectorLayer::readSymbology( const QDomNode& node, QString& errorMessage 
   // process the attribute actions
   mActions->readXML( node );
 
+  // add atlas action
+  mActions->addAction( QgsAction::Atlas,
+                       "Set as atlas feature",
+                       "",
+                       false );
+
   mEditTypes.clear();
   QDomNode editTypesNode = node.namedItem( "edittypes" );
   if ( !editTypesNode.isNull() )
@@ -3555,6 +3561,12 @@ void QgsVectorLayer::stopRendererV2( QgsRenderContext& rendererContext, QgsSingl
     selRenderer->stopRender( rendererContext );
     delete selRenderer;
   }
+}
+
+void QgsVectorLayer::setAtlasFeature( QgsFeature &feat )
+{
+  QgsExpression::setSpecialColumn( "$atlasfeatureid", feat.id() );
+  QgsExpression::setSpecialColumn( "$atlasgeometry", QVariant::fromValue( *feat.geometry() ) );
 }
 
 void QgsVectorLayer::prepareLabelingAndDiagrams( QgsRenderContext& rendererContext, QgsAttributeList& attributes, bool& labeling )

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -1550,6 +1550,11 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
     /** Signal emitted when setLayerTransparency() is called */
     void layerTransparencyChanged( int layerTransparency );
 
+    /** Emitted when a feature from this layer is set as the current atlas feature via the layer action
+     * @note added in 2.1
+     */
+    void actionAtlasFeatureCalled( QgsVectorLayer* layer, QgsFeature &feat );
+
   private slots:
     void onRelationsLoaded();
 

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -1395,6 +1395,9 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
     /** Returns whether the VectorLayer can apply the specified simplification hint */
     bool simplifyDrawingCanbeApplied( int simplifyHint ) const;
 
+    /**Sets the feature with matching id as the current atlas feature */
+    void setAtlasFeature( QgsFeature &feat );
+
   public slots:
     /**
      * Select feature by its ID

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -633,6 +633,8 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
     const QgsLabel *label() const;
 
     QgsAttributeAction *actions() { return mActions; }
+    QgsAttributeAction *standardActions() { return mStandardActions; }
+
 
     /**
      * The number of features that are selected in this layer
@@ -1605,6 +1607,9 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
       @param labeling out: true if there will be labeling (ng) for this layer*/
     void prepareLabelingAndDiagrams( QgsRenderContext& rendererContext, QgsAttributeList& attributes, bool& labeling );
 
+    /** Adds standard layer actions which are available for all vector layers */
+    void addStandardActions();
+
   private:                       // Private attributes
 
     /** Update threshold for drawing features as they are read. A value of zero indicates
@@ -1634,6 +1639,9 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
 
     /** The user-defined actions that are accessed from the Identify Results dialog box */
     QgsAttributeAction* mActions;
+
+    /** Standard layer actions that are available for all layers */
+    QgsAttributeAction* mStandardActions;
 
     /** Flag indicating whether the layer is in read-only mode (editing disabled) or not */
     bool mReadOnly;

--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -637,11 +637,8 @@ void QgsAttributeTableModel::executeAction( int action, const QModelIndex &idx )
     //action is a standard action
     //so need to subtract size of user-defined actions
     int actionId = action - layer()->actions()->size();
-    if ( layer()->actions()->size() > 0 )
-    {
-      // also need to subtract 1 for the seperator item
-      actionId--;
-    }
+    // also need to subtract 1 for the seperator item
+    actionId--;
     layer()->standardActions()->doAction( actionId, f, fieldIdx( idx.column() ) );
   }
 

--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -626,7 +626,25 @@ void QgsAttributeTableModel::resetModel()
 void QgsAttributeTableModel::executeAction( int action, const QModelIndex &idx ) const
 {
   QgsFeature f = feature( idx );
-  layer()->actions()->doAction( action, f, fieldIdx( idx.column() ) );
+
+  if ( action < layer()->actions()->size() )
+  {
+    //action is a user-defined action
+    layer()->actions()->doAction( action, f, fieldIdx( idx.column() ) );
+  }
+  else
+  {
+    //action is a standard action
+    //so need to subtract size of user-defined actions
+    int actionId = action - layer()->actions()->size();
+    if ( layer()->actions()->size() > 0 )
+    {
+      // also need to subtract 1 for the seperator item
+      actionId--;
+    }
+    layer()->standardActions()->doAction( actionId, f, fieldIdx( idx.column() ) );
+  }
+
 }
 
 QgsFeature QgsAttributeTableModel::feature( const QModelIndex &idx ) const

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -418,10 +418,11 @@ void QgsDualView::viewWillShowContextMenu( QMenu* menu, QModelIndex atIndex )
 {
   QModelIndex sourceIndex = mFilterModel->mapToSource( atIndex );
 
+  //add user-defined actions to context menu
   if ( mLayerCache->layer()->actions()->size() != 0 )
   {
 
-    QAction *a = menu->addAction( tr( "Run action" ) );
+    QAction *a = menu->addAction( tr( "Run layer action" ) );
     a->setEnabled( false );
 
     for ( int i = 0; i < mLayerCache->layer()->actions()->size(); i++ )
@@ -436,6 +437,26 @@ void QgsDualView::viewWillShowContextMenu( QMenu* menu, QModelIndex atIndex )
     }
   }
 
+  //add standard vector layer actions to context menu
+  if ( mLayerCache->layer()->standardActions()->size() != 0 )
+  {
+    //add a seperator between user defined and standard actions
+    menu->addSeparator();
+    int actionIdOffset = mLayerCache->layer()->actions()->size() + 1;
+
+    for ( int i = 0; i < mLayerCache->layer()->standardActions()->size(); i++ )
+    {
+      const QgsAction &action = mLayerCache->layer()->standardActions()->at( i );
+
+      if ( !action.runable() )
+        continue;
+
+      QgsAttributeTableAction *a = new QgsAttributeTableAction( action.name(), this, i + actionIdOffset, sourceIndex );
+      menu->addAction( action.name(), a, SLOT( execute() ) );
+    }
+  }
+
+  menu->addSeparator();
   QgsAttributeTableAction *a = new QgsAttributeTableAction( tr( "Open form" ), this, -1, sourceIndex );
   menu->addAction( tr( "Open form" ), a, SLOT( featureForm() ) );
 }


### PR DESCRIPTION
This work is kindly sponsored by SIGE (www.sige.ch). This request adds the concept of "standard actions" for a vector layer, which are predefined actions that are available for all vector layers. They are kept separate from the normal, user-defined actions to maintain the distinction from actions which are created and configurable by the user. 
This was done to allow for an action for setting a feature as the current atlas feature, which is useful for both previewing atlas based styling and for navigating to a specific feature in the new atlas preview mode.
