### PR TITLE
[BUG] #8298 - CRS change with recently used CRS makes no effect in the f...

### DIFF
--- a/src/gui/qgsprojectionselector.cpp
+++ b/src/gui/qgsprojectionselector.cpp
@@ -257,6 +257,12 @@ void QgsProjectionSelector::applySelection( int column, QString value )
     mSearchValue.clear();
   }
 
+  if ( column == NONE && mRecentProjListDone && mRecentProjections.size() != 0 )
+  {
+    column = QGIS_CRS_ID_COLUMN;
+    value = QString::number( mRecentProjections.at( 0 ).toLong() );
+  }
+
   if ( column == NONE )
     return;
 


### PR DESCRIPTION
...irst choice

If the developer, doesn't selector a default CRS, the projection
selector selects the last recent selected CRS.

Issue http://hub.qgis.org/issues/8298
