### PR TITLE
make QgsExpression non copyable (bug in cpy)

### DIFF
--- a/python/core/qgsexpression.sip
+++ b/python/core/qgsexpression.sip
@@ -394,4 +394,7 @@ class QgsExpression
 
   protected:
     void initGeomCalculator();
+
+  private:
+    Q_DISABLE_COPY( QgsExpression )
 };

--- a/src/core/qgsexpression.h
+++ b/src/core/qgsexpression.h
@@ -623,8 +623,7 @@ class CORE_EXPORT QgsExpression
 
   private:
     // default copy and assignment are buggy (they cause multiple delete)
-    QgsExpression( const QgsException & );
-    QgsExpression operator=( const QgsException & );
+    Q_DISABLE_COPY( QgsExpression )
 };
 
 Q_DECLARE_METATYPE( QgsExpression::Interval );

--- a/src/core/qgsexpression.h
+++ b/src/core/qgsexpression.h
@@ -620,6 +620,11 @@ class CORE_EXPORT QgsExpression
     static void initFunctionHelp();
     static QHash<QString, QString> gFunctionHelpTexts;
     static QHash<QString, QString> gGroups;
+
+  private:
+    // default copy and assignment are buggy (they cause multiple delete)
+    QgsExpression( const QgsException & );
+    QgsExpression operator=( const QgsException & );
 };
 
 Q_DECLARE_METATYPE( QgsExpression::Interval );

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -105,6 +105,27 @@ class TestQgsExpression: public QObject
       QCOMPARE( !exp.hasParserError(), valid );
     }
 
+//  QgsExpression has been made non copyable because of a bug
+//  that can be tested by this commented block
+//
+//  void assigning()
+//  {
+//    QgsExpression src("my_col");
+//    QgsExpression cpy("m_dummy_col_because_default_ctor_is_protected");
+//    cpy = src;
+//    qDebug() << "copy : " << cpy.expression() << " = " << src.expression();
+//    QCOMPARE( cpy.expression(), src.expression() );
+//  }
+//
+//  void copying()
+//  {
+//    QgsExpression src("my_col");
+//    QgsExpression cpy( src );
+//    qDebug() << "copy : " << cpy.expression() << " = " << src.expression();
+//    QCOMPARE( cpy.expression(), src.expression() );
+//  }
+//
+
     void parsing_with_locale()
     {
       // check that parsing of numbers works correctly even when using some other locale


### PR DESCRIPTION
a test has been added to show the bug if cpy is called
the test is commented out because of the fix (disable cpy)
