### PR TITLE
diable copy for qgsrendererv2 and derived

### DIFF
--- a/python/core/symbology-ng/qgscategorizedsymbolrendererv2.sip
+++ b/python/core/symbology-ng/qgscategorizedsymbolrendererv2.sip
@@ -123,5 +123,9 @@ class QgsCategorizedSymbolRendererV2 : QgsFeatureRendererV2
     void rebuildHash();
 
     QgsSymbolV2* symbolForValue( QVariant value );
+
+  private:
+    QgsCategorizedSymbolRendererV2( const QgsCategorizedSymbolRendererV2 & );
+    QgsCategorizedSymbolRendererV2 & operator=( const QgsCategorizedSymbolRendererV2 & );
 };
 

--- a/python/core/symbology-ng/qgsgraduatedsymbolrendererv2.sip
+++ b/python/core/symbology-ng/qgsgraduatedsymbolrendererv2.sip
@@ -147,4 +147,8 @@ class QgsGraduatedSymbolRendererV2 : QgsFeatureRendererV2
 
   protected:
     QgsSymbolV2* symbolForValue( double value );
+
+  private:
+    QgsGraduatedSymbolRendererV2( const QgsGraduatedSymbolRendererV2 & );
+    QgsGraduatedSymbolRendererV2 & operator=( const QgsGraduatedSymbolRendererV2 & );
 };

--- a/python/core/symbology-ng/qgspointdisplacementrenderer.sip
+++ b/python/core/symbology-ng/qgspointdisplacementrenderer.sip
@@ -65,4 +65,8 @@ class QgsPointDisplacementRenderer : QgsFeatureRendererV2
 
     void setTolerance( double t );
     double tolerance() const;
+
+  private:
+    QgsPointDisplacementRenderer( const QgsPointDisplacementRenderer & );
+    QgsPointDisplacementRenderer & operator=( const QgsPointDisplacementRenderer & );
 };

--- a/python/core/symbology-ng/qgsrendererv2.sip
+++ b/python/core/symbology-ng/qgsrendererv2.sip
@@ -170,4 +170,8 @@ class QgsFeatureRendererV2
     static const unsigned char* _getPolygon( QPolygonF& pts, QList<QPolygonF>& holes, QgsRenderContext& context, const unsigned char* wkb );
 
     void setScaleMethodToSymbol( QgsSymbolV2* symbol, int scaleMethod );
+  private:
+    QgsFeatureRendererV2( const QgsFeatureRendererV2 & );
+    QgsFeatureRendererV2 & operator=( const QgsFeatureRendererV2 & );
+    
 };

--- a/python/core/symbology-ng/qgsrulebasedrendererv2.sip
+++ b/python/core/symbology-ng/qgsrulebasedrendererv2.sip
@@ -201,4 +201,8 @@ class QgsRuleBasedRendererV2 : QgsFeatureRendererV2
     static void refineRuleRanges( QgsRuleBasedRendererV2::Rule* initialRule, QgsGraduatedSymbolRendererV2* r );
     //! take a rule and create a list of new rules with intervals of scales given by the passed scale denominators
     static void refineRuleScales( QgsRuleBasedRendererV2::Rule* initialRule, QList<int> scales );
+
+  private:
+    QgsRuleBasedRendererV2( const QgsRuleBasedRendererV2 & );
+    QgsRuleBasedRendererV2 & operator=( const QgsRuleBasedRendererV2 & );
 };

--- a/python/core/symbology-ng/qgssinglesymbolrendererv2.sip
+++ b/python/core/symbology-ng/qgssinglesymbolrendererv2.sip
@@ -60,4 +60,8 @@ class QgsSingleSymbolRendererV2 : QgsFeatureRendererV2
     //! return a list of item text / symbol
     //! @note: this method was added in version 1.5
     // virtual QgsLegendSymbolList legendSymbolItems();
+
+  private:
+    QgsSingleSymbolRendererV2( const QgsSingleSymbolRendererV2 & );
+    QgsSingleSymbolRendererV2 & operator=( const QgsSingleSymbolRendererV2 & );
 };

--- a/src/core/symbology-ng/qgsrendererv2.h
+++ b/src/core/symbology-ng/qgsrendererv2.h
@@ -204,6 +204,9 @@ class CORE_EXPORT QgsFeatureRendererV2
     int mCurrentVertexMarkerType;
     /** The current size of editing marker */
     int mCurrentVertexMarkerSize;
+
+  private:
+    Q_DISABLE_COPY( QgsFeatureRendererV2 )
 };
 
 class QgsRendererV2Widget;  // why does SIP fail, when this isn't here


### PR DESCRIPTION
it was buggy (crash) an certainly not used (because of crash)

The bugs all have the same pattern:

class A
{
public:
  A()
    : mPtrToResource(new Resource)
  {}
  ~A()
  {
    delete mPtrToResource;
  }
private:
  Resource \* mPtrToResource;
};

If you happen to make a copy of A, intensionnally or otherwize (c++ is eager to make copies), you have a double delete on the resource.
