### PR TITLE
Fix bug #9060: Area is wrong in QGIS master (again)

### DIFF
--- a/src/app/qgsprojectproperties.h
+++ b/src/app/qgsprojectproperties.h
@@ -142,9 +142,9 @@ class APP_EXPORT QgsProjectProperties : public QgsOptionsDialogBase, private Ui:
     void cbxWCSPubliedStateChanged( int aIdx );
 
     /*!
-      * If user changes the CRS, set the corresponding map units
-      */
-    void setMapUnitsToCurrentProjection();
+     * If user changes the CRS, set the corresponding map units and ellipsoid
+     */
+    void updateMapUnitsAndEllipsoidUI();
 
     /* Update ComboBox accorindg to the selected new index
      * Also sets the new selected Ellipsoid. */
@@ -156,6 +156,8 @@ class APP_EXPORT QgsProjectProperties : public QgsOptionsDialogBase, private Ui:
     void on_mButtonAddColor_clicked();
     void on_mButtonImportColors_clicked();
     void on_mButtonExportColors_clicked();
+
+    void hideTooltipText();
 
   signals:
     //! Signal used to inform listeners that the mouse display precision may have changed
@@ -206,6 +208,11 @@ class APP_EXPORT QgsProjectProperties : public QgsOptionsDialogBase, private Ui:
 
     //! Populates list with ellipsoids from Sqlite3 db
     void populateEllipsoidList();
+
+    //! Gets the currently selected map units from related UI
+    QGis::UnitType selectedMapUnits() const;
+    //! Sets the selected map units to related UI
+    void setSelectedMapUnits( QGis::UnitType unit );
 
     static const char * GEO_NONE_DESC;
 


### PR DESCRIPTION
This PR try fix bug #9060 (http://hub.qgis.org/issues/9060) and weird behabior detected in issue #7441 (http://hub.qgis.org/issues/7441#note-4) :

"... To add to the confusion there's 2 "WGS84" ellipsoids listed - one is "WGS84" and one is "WGS 84". Choosing "WGS84" actually results in "Clarke 1986" being saved for the project! ..."

Changes:
- Fix bad selection of ellipsoid from active CRS in QgsProjectProperties dialog
- Notify with a tooltip the new mapunits and ellipsoid automatically selected when the CRS is changed
- Disable map units selection when OTF is ON
- Preserve the units and ellipsoid from current project settings when the project properties dialog (QgsProjectProperties) is loaded
