### PR TITLE
fix qgis_rendererstest (nearly)

### DIFF
--- a/tests/testdata/lines_uniquevalue_symbol.qml
+++ b/tests/testdata/lines_uniquevalue_symbol.qml
@@ -1,75 +1,198 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis version="0.9.2-Ganymede" minimumScale="1" maximumScale="1e+08" hasScaleBasedVisibilityFlag="0" geometry="Line" type="vector" >
-    <id>lines20080110101725388</id>
-    <datasource>/Users/timlinux/dev/cpp/qgis_qml/tests/testdata/lines.shp</datasource>
-    <layername>lines</layername>
-    <srs>
-      <spatialrefsys>
-        <proj4>+proj=longlat +ellps=WGS84 +no_defs</proj4>
-        <srsid>1449</srsid>
-        <srid>4031</srid>
-        <epsg>4031</epsg>
-        <description>Unknown datum based upon the GEM 10C ellipsoid</description>
-        <projectionacronym>longlat</projectionacronym>
-        <ellipsoidacronym>WGS84</ellipsoidacronym>
-        <geographicflag>true</geographicflag>
-      </spatialrefsys>
-    </srs>
-    <transparencyLevelInt>255</transparencyLevelInt>
-    <provider>ogr</provider>
-    <encoding>System</encoding>
-    <classificationattribute>Name</classificationattribute>
-    <displayfield>Name</displayfield>
-    <label>0</label>
-    <attributeactions/>
-    <uniquevalue>
-      <classificationfield>Name</classificationfield>
-      <symbol>
-        <lowervalue>Arterial</lowervalue>
-        <uppervalue></uppervalue>
-        <label></label>
-        <pointsymbol>hard:circle</pointsymbol>
-        <pointsize>11</pointsize>
-        <rotationclassificationfield>-1</rotationclassificationfield>
-        <scaleclassificationfield>-1</scaleclassificationfield>
-        <outlinecolor red="165" blue="74" green="36" />
-        <outlinestyle>DashLine</outlinestyle>
-        <outlinewidth>2</outlinewidth>
-        <fillcolor red="0" blue="0" green="0" />
-        <fillpattern>NoBrush</fillpattern>
-        <texturepath></texturepath>
+<qgis version="2.1.0-Master" minimumScale="1" maximumScale="1e+08" simplifyDrawingHints="3" minLabelScale="1" maxLabelScale="1e+08" simplifyDrawingTol="1" hasScaleBasedVisibilityFlag="0" scaleBasedLabelVisibilityFlag="0">
+  <renderer-v2 attr="Name" symbollevels="0" type="categorizedSymbol">
+    <categories>
+      <category symbol="0" value="Arterial" label="Arterial"/>
+      <category symbol="1" value="Highway" label="Highway"/>
+    </categories>
+    <symbols>
+      <symbol alpha="1" type="line" name="0">
+        <layer pass="0" class="SimpleLine" locked="0">
+          <prop k="capstyle" v="square"/>
+          <prop k="color" v="165,36,74,255"/>
+          <prop k="customdash" v="5;2"/>
+          <prop k="customdash_unit" v="MM"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="offset" v="0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="penstyle" v="dash"/>
+          <prop k="use_custom_dash" v="0"/>
+          <prop k="width" v="2"/>
+          <prop k="width_unit" v="MM"/>
+        </layer>
       </symbol>
-      <symbol>
-        <lowervalue>Highway</lowervalue>
-        <uppervalue></uppervalue>
-        <label></label>
-        <pointsymbol>hard:circle</pointsymbol>
-        <pointsize>11</pointsize>
-        <rotationclassificationfield>-1</rotationclassificationfield>
-        <scaleclassificationfield>-1</scaleclassificationfield>
-        <outlinecolor red="12" blue="96" green="151" />
-        <outlinestyle>SolidLine</outlinestyle>
-        <outlinewidth>2.8</outlinewidth>
-        <fillcolor red="0" blue="0" green="0" />
-        <fillpattern>NoBrush</fillpattern>
-        <texturepath></texturepath>
+      <symbol alpha="1" type="line" name="1">
+        <layer pass="0" class="SimpleLine" locked="0">
+          <prop k="capstyle" v="square"/>
+          <prop k="color" v="12,151,96,255"/>
+          <prop k="customdash" v="5;2"/>
+          <prop k="customdash_unit" v="MM"/>
+          <prop k="joinstyle" v="bevel"/>
+          <prop k="offset" v="0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="penstyle" v="solid"/>
+          <prop k="use_custom_dash" v="0"/>
+          <prop k="width" v="2.8"/>
+          <prop k="width_unit" v="MM"/>
+        </layer>
       </symbol>
-    </uniquevalue>
-    <labelattributes>
-      <label field="" text="Label" />
-      <family field="" name="Lucida Grande" />
-      <size field="" units="pt" value="12" />
-      <bold field="" on="0" />
-      <italic field="" on="0" />
-      <underline field="" on="0" />
-      <color field="" red="0" blue="0" green="0" />
-      <x field="" />
-      <y field="" />
-      <offset x="0" y="0" yfield="-1" xfield="-1" units="pt" />
-      <angle field="" value="0" />
-      <alignment field="-1" value="center" />
-      <buffercolor field="" red="255" blue="255" green="255" />
-      <buffersize field="" units="pt" value="1" />
-      <bufferenabled field="" on="" />
-    </labelattributes>
+    </symbols>
+    <rotation field=""/>
+    <sizescale field="" scalemethod="area"/>
+  </renderer-v2>
+  <customproperties>
+    <property key="labeling" value="pal"/>
+    <property key="labeling/addDirectionSymbol" value="false"/>
+    <property key="labeling/angleOffset" value="0"/>
+    <property key="labeling/blendMode" value="0"/>
+    <property key="labeling/bufferBlendMode" value="0"/>
+    <property key="labeling/bufferColorA" value="255"/>
+    <property key="labeling/bufferColorB" value="255"/>
+    <property key="labeling/bufferColorG" value="255"/>
+    <property key="labeling/bufferColorR" value="255"/>
+    <property key="labeling/bufferDraw" value="false"/>
+    <property key="labeling/bufferJoinStyle" value="64"/>
+    <property key="labeling/bufferNoFill" value="false"/>
+    <property key="labeling/bufferSize" value="1"/>
+    <property key="labeling/bufferSizeInMapUnits" value="false"/>
+    <property key="labeling/bufferTransp" value="0"/>
+    <property key="labeling/centroidWhole" value="false"/>
+    <property key="labeling/decimals" value="3"/>
+    <property key="labeling/displayAll" value="false"/>
+    <property key="labeling/dist" value="0"/>
+    <property key="labeling/distInMapUnits" value="false"/>
+    <property key="labeling/enabled" value="false"/>
+    <property key="labeling/fieldName" value=""/>
+    <property key="labeling/fontBold" value="false"/>
+    <property key="labeling/fontCapitals" value="0"/>
+    <property key="labeling/fontFamily" value="Sans"/>
+    <property key="labeling/fontItalic" value="false"/>
+    <property key="labeling/fontLetterSpacing" value="0"/>
+    <property key="labeling/fontLimitPixelSize" value="false"/>
+    <property key="labeling/fontMaxPixelSize" value="10000"/>
+    <property key="labeling/fontMinPixelSize" value="3"/>
+    <property key="labeling/fontSize" value="11"/>
+    <property key="labeling/fontSizeInMapUnits" value="false"/>
+    <property key="labeling/fontStrikeout" value="false"/>
+    <property key="labeling/fontUnderline" value="false"/>
+    <property key="labeling/fontWeight" value="50"/>
+    <property key="labeling/fontWordSpacing" value="0"/>
+    <property key="labeling/formatNumbers" value="false"/>
+    <property key="labeling/isExpression" value="false"/>
+    <property key="labeling/labelOffsetInMapUnits" value="true"/>
+    <property key="labeling/labelPerPart" value="false"/>
+    <property key="labeling/leftDirectionSymbol" value="&lt;"/>
+    <property key="labeling/limitNumLabels" value="false"/>
+    <property key="labeling/maxCurvedCharAngleIn" value="20"/>
+    <property key="labeling/maxCurvedCharAngleOut" value="-20"/>
+    <property key="labeling/maxNumLabels" value="2000"/>
+    <property key="labeling/mergeLines" value="false"/>
+    <property key="labeling/minFeatureSize" value="0"/>
+    <property key="labeling/multilineAlign" value="0"/>
+    <property key="labeling/multilineHeight" value="1"/>
+    <property key="labeling/namedStyle" value=""/>
+    <property key="labeling/obstacle" value="true"/>
+    <property key="labeling/placeDirectionSymbol" value="0"/>
+    <property key="labeling/placement" value="2"/>
+    <property key="labeling/placementFlags" value="10"/>
+    <property key="labeling/plussign" value="false"/>
+    <property key="labeling/preserveRotation" value="true"/>
+    <property key="labeling/previewBkgrdColor" value="#ffffff"/>
+    <property key="labeling/priority" value="5"/>
+    <property key="labeling/quadOffset" value="4"/>
+    <property key="labeling/reverseDirectionSymbol" value="false"/>
+    <property key="labeling/rightDirectionSymbol" value=">"/>
+    <property key="labeling/scaleMax" value="10000000"/>
+    <property key="labeling/scaleMin" value="1"/>
+    <property key="labeling/scaleVisibility" value="false"/>
+    <property key="labeling/shadowBlendMode" value="6"/>
+    <property key="labeling/shadowColorB" value="0"/>
+    <property key="labeling/shadowColorG" value="0"/>
+    <property key="labeling/shadowColorR" value="0"/>
+    <property key="labeling/shadowDraw" value="false"/>
+    <property key="labeling/shadowOffsetAngle" value="135"/>
+    <property key="labeling/shadowOffsetDist" value="1"/>
+    <property key="labeling/shadowOffsetGlobal" value="true"/>
+    <property key="labeling/shadowOffsetUnits" value="1"/>
+    <property key="labeling/shadowRadius" value="1.5"/>
+    <property key="labeling/shadowRadiusAlphaOnly" value="false"/>
+    <property key="labeling/shadowRadiusUnits" value="1"/>
+    <property key="labeling/shadowScale" value="100"/>
+    <property key="labeling/shadowTransparency" value="30"/>
+    <property key="labeling/shadowUnder" value="0"/>
+    <property key="labeling/shapeBlendMode" value="0"/>
+    <property key="labeling/shapeBorderColorA" value="255"/>
+    <property key="labeling/shapeBorderColorB" value="128"/>
+    <property key="labeling/shapeBorderColorG" value="128"/>
+    <property key="labeling/shapeBorderColorR" value="128"/>
+    <property key="labeling/shapeBorderWidth" value="0"/>
+    <property key="labeling/shapeBorderWidthUnits" value="1"/>
+    <property key="labeling/shapeDraw" value="false"/>
+    <property key="labeling/shapeFillColorA" value="255"/>
+    <property key="labeling/shapeFillColorB" value="255"/>
+    <property key="labeling/shapeFillColorG" value="255"/>
+    <property key="labeling/shapeFillColorR" value="255"/>
+    <property key="labeling/shapeJoinStyle" value="64"/>
+    <property key="labeling/shapeOffsetUnits" value="1"/>
+    <property key="labeling/shapeOffsetX" value="0"/>
+    <property key="labeling/shapeOffsetY" value="0"/>
+    <property key="labeling/shapeRadiiUnits" value="1"/>
+    <property key="labeling/shapeRadiiX" value="0"/>
+    <property key="labeling/shapeRadiiY" value="0"/>
+    <property key="labeling/shapeRotation" value="0"/>
+    <property key="labeling/shapeRotationType" value="0"/>
+    <property key="labeling/shapeSVGFile" value=""/>
+    <property key="labeling/shapeSizeType" value="0"/>
+    <property key="labeling/shapeSizeUnits" value="1"/>
+    <property key="labeling/shapeSizeX" value="0"/>
+    <property key="labeling/shapeSizeY" value="0"/>
+    <property key="labeling/shapeTransparency" value="0"/>
+    <property key="labeling/shapeType" value="0"/>
+    <property key="labeling/textColorA" value="255"/>
+    <property key="labeling/textColorB" value="0"/>
+    <property key="labeling/textColorG" value="0"/>
+    <property key="labeling/textColorR" value="0"/>
+    <property key="labeling/textTransp" value="0"/>
+    <property key="labeling/upsidedownLabels" value="0"/>
+    <property key="labeling/wrapChar" value=""/>
+    <property key="labeling/xOffset" value="0"/>
+    <property key="labeling/yOffset" value="0"/>
+  </customproperties>
+  <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <layerTransparency>0</layerTransparency>
+  <displayfield>Name</displayfield>
+  <label>0</label>
+  <labelattributes>
+    <label fieldname="" text="Label"/>
+    <family fieldname="" name="Lucida Grande"/>
+    <size fieldname="" units="pt" value="12"/>
+    <bold fieldname="" on="0"/>
+    <italic fieldname="" on="0"/>
+    <underline fieldname="" on="0"/>
+    <strikeout fieldname="" on="0"/>
+    <color fieldname="" red="0" blue="0" green="0"/>
+    <x fieldname=""/>
+    <y fieldname=""/>
+    <offset x="0" y="0" units="pt" yfieldname="" xfieldname=""/>
+    <angle fieldname="" value="0" auto="0"/>
+    <alignment fieldname="" value="center"/>
+    <buffercolor fieldname="" red="255" blue="255" green="255"/>
+    <buffersize fieldname="" units="pt" value="1"/>
+    <bufferenabled fieldname="" on=""/>
+    <multilineenabled fieldname="" on=""/>
+    <selectedonly on=""/>
+  </labelattributes>
+  <edittypes>
+    <edittype labelontop="0" editable="1" type="0" name="Name"/>
+    <edittype labelontop="0" editable="1" type="0" name="Value"/>
+  </edittypes>
+  <editform></editform>
+  <editforminit></editforminit>
+  <featformsuppress>0</featformsuppress>
+  <annotationform></annotationform>
+  <editorlayout>generatedlayout</editorlayout>
+  <excludeAttributesWMS/>
+  <excludeAttributesWFS/>
+  <attributeactions/>
 </qgis>

--- a/tests/testdata/points_graduated_symbol.qml
+++ b/tests/testdata/points_graduated_symbol.qml
@@ -1,91 +1,228 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis version="0.9.2-Ganymede" minimumScale="1" maximumScale="1e+08" hasScaleBasedVisibilityFlag="0" geometry="Point" type="vector" >
-    <id>points20080103150949100</id>
-    <datasource>/Users/tim/dev/cpp/qgis/tests/testdata/points.shp</datasource>
-    <layername>points</layername>
-    <srs>
-      <spatialrefsys>
-        <proj4>+proj=longlat +ellps=WGS84 +no_defs</proj4>
-        <srsid>1449</srsid>
-        <srid>4031</srid>
-        <epsg>4031</epsg>
-        <description>Unknown datum based upon the GEM 10C ellipsoid</description>
-        <projectionacronym>longlat</projectionacronym>
-        <ellipsoidacronym>WGS84</ellipsoidacronym>
-        <geographicflag>true</geographicflag>
-      </spatialrefsys>
-    </srs>
-    <transparencyLevelInt>255</transparencyLevelInt>
-    <provider>ogr</provider>
-    <encoding>System</encoding>
-    <classificationattribute>Heading</classificationattribute>
-    <classificationattribute>Importance</classificationattribute>
-    <displayfield>Class</displayfield>
-    <label>0</label>
-    <attributeactions/>
-    <graduatedsymbol>
-      <classificationfield>Importance</classificationfield>
-      <symbol>
-        <lowervalue>0.999</lowervalue>
-        <uppervalue>7.333</uppervalue>
-        <label></label>
-        <pointsymbol>hard:circle</pointsymbol>
-        <pointsize>4</pointsize>
-        <rotationclassificationfield>1</rotationclassificationfield>
-        <scaleclassificationfield>2</scaleclassificationfield>
-        <outlinecolor red="0" blue="0" green="0" />
-        <outlinestyle>SolidLine</outlinestyle>
-        <outlinewidth>0.4</outlinewidth>
-        <fillcolor red="0" blue="0" green="255" />
-        <fillpattern>SolidPattern</fillpattern>
-        <texturepath></texturepath>
+<qgis version="2.1.0-Master" minimumScale="1" maximumScale="1e+08" simplifyDrawingHints="3" minLabelScale="1" maxLabelScale="1e+08" simplifyDrawingTol="1" hasScaleBasedVisibilityFlag="0" scaleBasedLabelVisibilityFlag="0">
+  <renderer-v2 attr="Importance" symbollevels="0" type="graduatedSymbol">
+    <ranges>
+      <range symbol="0" lower="0.999000" upper="7.333000" label="0.999 - 7.333"/>
+      <range symbol="1" lower="7.333000" upper="13.667000" label="7.333 - 13.667"/>
+      <range symbol="2" lower="13.667000" upper="20.001000" label="13.667 - 20.001"/>
+    </ranges>
+    <symbols>
+      <symbol alpha="1" type="marker" name="0">
+        <layer pass="0" class="SimpleMarker" locked="0">
+          <prop k="angle" v="0"/>
+          <prop k="color" v="0,255,0,255"/>
+          <prop k="color_border" v="0,0,0,255"/>
+          <prop k="horizontal_anchor_point" v="1"/>
+          <prop k="name" v="circle"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v=".4"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="scale_method" v="area"/>
+          <prop k="size" v="60"/>
+          <prop k="size_unit" v="MM"/>
+          <prop k="vertical_anchor_point" v="1"/>
+        </layer>
       </symbol>
-      <symbol>
-        <lowervalue>7.333</lowervalue>
-        <uppervalue>13.667</uppervalue>
-        <label></label>
-        <pointsymbol>hard:rectangle</pointsymbol>
-        <pointsize>7</pointsize>
-        <rotationclassificationfield>1</rotationclassificationfield>
-        <scaleclassificationfield>2</scaleclassificationfield>
-        <outlinecolor red="0" blue="0" green="0" />
-        <outlinestyle>SolidLine</outlinestyle>
-        <outlinewidth>0.4</outlinewidth>
-        <fillcolor red="169" blue="108" green="102" />
-        <fillpattern>SolidPattern</fillpattern>
-        <texturepath></texturepath>
+      <symbol alpha="1" type="marker" name="1">
+        <layer pass="0" class="SimpleMarker" locked="0">
+          <prop k="angle" v="0"/>
+          <prop k="color" v="169,102,108,255"/>
+          <prop k="color_border" v="0,0,0,255"/>
+          <prop k="horizontal_anchor_point" v="1"/>
+          <prop k="name" v="rectangle"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v=".4"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="scale_method" v="area"/>
+          <prop k="size" v="185"/>
+          <prop k="size_unit" v="MM"/>
+          <prop k="vertical_anchor_point" v="1"/>
+        </layer>
       </symbol>
-      <symbol>
-        <lowervalue>13.667</lowervalue>
-        <uppervalue>20.001</uppervalue>
-        <label></label>
-        <pointsymbol>hard:star</pointsymbol>
-        <pointsize>9</pointsize>
-        <rotationclassificationfield>1</rotationclassificationfield>
-        <scaleclassificationfield>2</scaleclassificationfield>
-        <outlinecolor red="0" blue="0" green="0" />
-        <outlinestyle>SolidLine</outlinestyle>
-        <outlinewidth>0.4</outlinewidth>
-        <fillcolor red="0" blue="171" green="84" />
-        <fillpattern>SolidPattern</fillpattern>
-        <texturepath></texturepath>
+      <symbol alpha="1" type="marker" name="2">
+        <layer pass="0" class="SimpleMarker" locked="0">
+          <prop k="angle" v="0"/>
+          <prop k="color" v="0,84,171,255"/>
+          <prop k="color_border" v="0,0,0,255"/>
+          <prop k="horizontal_anchor_point" v="1"/>
+          <prop k="name" v="star"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v=".4"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="scale_method" v="area"/>
+          <prop k="size" v="300"/>
+          <prop k="size_unit" v="MM"/>
+          <prop k="vertical_anchor_point" v="1"/>
+        </layer>
       </symbol>
-    </graduatedsymbol>
-    <labelattributes>
-      <label field="" text="Label" />
-      <family field="" name="Lucida Grande" />
-      <size field="" units="pt" value="12" />
-      <bold field="" on="0" />
-      <italic field="" on="0" />
-      <underline field="" on="0" />
-      <color field="" red="0" blue="0" green="0" />
-      <x field="" />
-      <y field="" />
-      <offset x="0" y="0" yfield="-1" xfield="-1" units="pt" />
-      <angle field="" value="0" />
-      <alignment field="-1" value="center" />
-      <buffercolor field="" red="255" blue="255" green="255" />
-      <buffersize field="" units="pt" value="1" />
-      <bufferenabled field="" on="" />
-    </labelattributes>
+    </symbols>
+    <mode name="equal"/>
+    <rotation field="Heading"/>
+    <sizescale field="Importance" scalemethod="area"/>
+  </renderer-v2>
+  <customproperties>
+    <property key="labeling" value="pal"/>
+    <property key="labeling/addDirectionSymbol" value="false"/>
+    <property key="labeling/angleOffset" value="0"/>
+    <property key="labeling/blendMode" value="0"/>
+    <property key="labeling/bufferBlendMode" value="0"/>
+    <property key="labeling/bufferColorA" value="255"/>
+    <property key="labeling/bufferColorB" value="255"/>
+    <property key="labeling/bufferColorG" value="255"/>
+    <property key="labeling/bufferColorR" value="255"/>
+    <property key="labeling/bufferDraw" value="false"/>
+    <property key="labeling/bufferJoinStyle" value="64"/>
+    <property key="labeling/bufferNoFill" value="false"/>
+    <property key="labeling/bufferSize" value="1"/>
+    <property key="labeling/bufferSizeInMapUnits" value="false"/>
+    <property key="labeling/bufferTransp" value="0"/>
+    <property key="labeling/centroidWhole" value="false"/>
+    <property key="labeling/decimals" value="3"/>
+    <property key="labeling/displayAll" value="false"/>
+    <property key="labeling/dist" value="0"/>
+    <property key="labeling/distInMapUnits" value="false"/>
+    <property key="labeling/enabled" value="false"/>
+    <property key="labeling/fieldName" value=""/>
+    <property key="labeling/fontBold" value="false"/>
+    <property key="labeling/fontCapitals" value="0"/>
+    <property key="labeling/fontFamily" value="Sans"/>
+    <property key="labeling/fontItalic" value="false"/>
+    <property key="labeling/fontLetterSpacing" value="0"/>
+    <property key="labeling/fontLimitPixelSize" value="false"/>
+    <property key="labeling/fontMaxPixelSize" value="10000"/>
+    <property key="labeling/fontMinPixelSize" value="3"/>
+    <property key="labeling/fontSize" value="11"/>
+    <property key="labeling/fontSizeInMapUnits" value="false"/>
+    <property key="labeling/fontStrikeout" value="false"/>
+    <property key="labeling/fontUnderline" value="false"/>
+    <property key="labeling/fontWeight" value="50"/>
+    <property key="labeling/fontWordSpacing" value="0"/>
+    <property key="labeling/formatNumbers" value="false"/>
+    <property key="labeling/isExpression" value="false"/>
+    <property key="labeling/labelOffsetInMapUnits" value="true"/>
+    <property key="labeling/labelPerPart" value="false"/>
+    <property key="labeling/leftDirectionSymbol" value="&lt;"/>
+    <property key="labeling/limitNumLabels" value="false"/>
+    <property key="labeling/maxCurvedCharAngleIn" value="20"/>
+    <property key="labeling/maxCurvedCharAngleOut" value="-20"/>
+    <property key="labeling/maxNumLabels" value="2000"/>
+    <property key="labeling/mergeLines" value="false"/>
+    <property key="labeling/minFeatureSize" value="0"/>
+    <property key="labeling/multilineAlign" value="0"/>
+    <property key="labeling/multilineHeight" value="1"/>
+    <property key="labeling/namedStyle" value=""/>
+    <property key="labeling/obstacle" value="true"/>
+    <property key="labeling/placeDirectionSymbol" value="0"/>
+    <property key="labeling/placement" value="0"/>
+    <property key="labeling/placementFlags" value="0"/>
+    <property key="labeling/plussign" value="false"/>
+    <property key="labeling/preserveRotation" value="true"/>
+    <property key="labeling/previewBkgrdColor" value="#ffffff"/>
+    <property key="labeling/priority" value="5"/>
+    <property key="labeling/quadOffset" value="4"/>
+    <property key="labeling/reverseDirectionSymbol" value="false"/>
+    <property key="labeling/rightDirectionSymbol" value=">"/>
+    <property key="labeling/scaleMax" value="10000000"/>
+    <property key="labeling/scaleMin" value="1"/>
+    <property key="labeling/scaleVisibility" value="false"/>
+    <property key="labeling/shadowBlendMode" value="6"/>
+    <property key="labeling/shadowColorB" value="0"/>
+    <property key="labeling/shadowColorG" value="0"/>
+    <property key="labeling/shadowColorR" value="0"/>
+    <property key="labeling/shadowDraw" value="false"/>
+    <property key="labeling/shadowOffsetAngle" value="135"/>
+    <property key="labeling/shadowOffsetDist" value="1"/>
+    <property key="labeling/shadowOffsetGlobal" value="true"/>
+    <property key="labeling/shadowOffsetUnits" value="1"/>
+    <property key="labeling/shadowRadius" value="1.5"/>
+    <property key="labeling/shadowRadiusAlphaOnly" value="false"/>
+    <property key="labeling/shadowRadiusUnits" value="1"/>
+    <property key="labeling/shadowScale" value="100"/>
+    <property key="labeling/shadowTransparency" value="30"/>
+    <property key="labeling/shadowUnder" value="0"/>
+    <property key="labeling/shapeBlendMode" value="0"/>
+    <property key="labeling/shapeBorderColorA" value="255"/>
+    <property key="labeling/shapeBorderColorB" value="128"/>
+    <property key="labeling/shapeBorderColorG" value="128"/>
+    <property key="labeling/shapeBorderColorR" value="128"/>
+    <property key="labeling/shapeBorderWidth" value="0"/>
+    <property key="labeling/shapeBorderWidthUnits" value="1"/>
+    <property key="labeling/shapeDraw" value="false"/>
+    <property key="labeling/shapeFillColorA" value="255"/>
+    <property key="labeling/shapeFillColorB" value="255"/>
+    <property key="labeling/shapeFillColorG" value="255"/>
+    <property key="labeling/shapeFillColorR" value="255"/>
+    <property key="labeling/shapeJoinStyle" value="64"/>
+    <property key="labeling/shapeOffsetUnits" value="1"/>
+    <property key="labeling/shapeOffsetX" value="0"/>
+    <property key="labeling/shapeOffsetY" value="0"/>
+    <property key="labeling/shapeRadiiUnits" value="1"/>
+    <property key="labeling/shapeRadiiX" value="0"/>
+    <property key="labeling/shapeRadiiY" value="0"/>
+    <property key="labeling/shapeRotation" value="0"/>
+    <property key="labeling/shapeRotationType" value="0"/>
+    <property key="labeling/shapeSVGFile" value=""/>
+    <property key="labeling/shapeSizeType" value="0"/>
+    <property key="labeling/shapeSizeUnits" value="1"/>
+    <property key="labeling/shapeSizeX" value="0"/>
+    <property key="labeling/shapeSizeY" value="0"/>
+    <property key="labeling/shapeTransparency" value="0"/>
+    <property key="labeling/shapeType" value="0"/>
+    <property key="labeling/textColorA" value="255"/>
+    <property key="labeling/textColorB" value="0"/>
+    <property key="labeling/textColorG" value="0"/>
+    <property key="labeling/textColorR" value="0"/>
+    <property key="labeling/textTransp" value="0"/>
+    <property key="labeling/upsidedownLabels" value="0"/>
+    <property key="labeling/wrapChar" value=""/>
+    <property key="labeling/xOffset" value="0"/>
+    <property key="labeling/yOffset" value="0"/>
+  </customproperties>
+  <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <layerTransparency>0</layerTransparency>
+  <displayfield>Class</displayfield>
+  <label>0</label>
+  <labelattributes>
+    <label fieldname="" text="Label"/>
+    <family fieldname="" name="Lucida Grande"/>
+    <size fieldname="" units="pt" value="12"/>
+    <bold fieldname="" on="0"/>
+    <italic fieldname="" on="0"/>
+    <underline fieldname="" on="0"/>
+    <strikeout fieldname="" on="0"/>
+    <color fieldname="" red="0" blue="0" green="0"/>
+    <x fieldname=""/>
+    <y fieldname=""/>
+    <offset x="0" y="0" units="pt" yfieldname="" xfieldname=""/>
+    <angle fieldname="" value="0" auto="0"/>
+    <alignment fieldname="" value="center"/>
+    <buffercolor fieldname="" red="255" blue="255" green="255"/>
+    <buffersize fieldname="" units="pt" value="1"/>
+    <bufferenabled fieldname="" on=""/>
+    <multilineenabled fieldname="" on=""/>
+    <selectedonly on=""/>
+  </labelattributes>
+  <edittypes>
+    <edittype labelontop="0" editable="1" type="0" name="Cabin Crew"/>
+    <edittype labelontop="0" editable="1" type="0" name="Class"/>
+    <edittype labelontop="0" editable="1" type="0" name="Heading"/>
+    <edittype labelontop="0" editable="1" type="0" name="Importance"/>
+    <edittype labelontop="0" editable="1" type="0" name="Pilots"/>
+    <edittype labelontop="0" editable="1" type="0" name="Staff"/>
+  </edittypes>
+  <editform></editform>
+  <editforminit></editforminit>
+  <featformsuppress>0</featformsuppress>
+  <annotationform></annotationform>
+  <editorlayout>generatedlayout</editorlayout>
+  <excludeAttributesWMS/>
+  <excludeAttributesWFS/>
+  <attributeactions/>
 </qgis>

--- a/tests/testdata/points_single_symbol.qml
+++ b/tests/testdata/points_single_symbol.qml
@@ -1,60 +1,186 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis version="0.9.2-Ganymede" minimumScale="1" maximumScale="1e+08" hasScaleBasedVisibilityFlag="0" geometry="Point" type="vector" >
-    <id>points20080103150949100</id>
-    <datasource>/Users/tim/dev/cpp/qgis/tests/testdata/points.shp</datasource>
-    <layername>points</layername>
-    <srs>
-      <spatialrefsys>
-        <proj4>+proj=longlat +ellps=WGS84 +no_defs</proj4>
-        <srsid>1449</srsid>
-        <srid>4031</srid>
-        <epsg>4031</epsg>
-        <description>Unknown datum based upon the GEM 10C ellipsoid</description>
-        <projectionacronym>longlat</projectionacronym>
-        <ellipsoidacronym>WGS84</ellipsoidacronym>
-        <geographicflag>true</geographicflag>
-      </spatialrefsys>
-    </srs>
-    <transparencyLevelInt>255</transparencyLevelInt>
-    <provider>ogr</provider>
-    <encoding>System</encoding>
-    <classificationattribute>Heading</classificationattribute>
-    <classificationattribute>Importance</classificationattribute>
-    <displayfield>Class</displayfield>
-    <label>0</label>
-    <attributeactions/>
-    <singlesymbol>
-      <symbol>
-        <lowervalue></lowervalue>
-        <uppervalue></uppervalue>
-        <label></label>
-        <pointsymbol>hard:triangle</pointsymbol>
-        <pointsize>5</pointsize>
-        <rotationclassificationfield>1</rotationclassificationfield>
-        <scaleclassificationfield>2</scaleclassificationfield>
-        <outlinecolor red="140" blue="60" green="82" />
-        <outlinestyle>SolidLine</outlinestyle>
-        <outlinewidth>0.4</outlinewidth>
-        <fillcolor red="193" blue="122" green="145" />
-        <fillpattern>SolidPattern</fillpattern>
-        <texturepath></texturepath>
+<qgis version="2.1.0-Master" minimumScale="1" maximumScale="1e+08" simplifyDrawingHints="3" minLabelScale="1" maxLabelScale="1e+08" simplifyDrawingTol="1" hasScaleBasedVisibilityFlag="0" scaleBasedLabelVisibilityFlag="0">
+  <renderer-v2 symbollevels="0" type="singleSymbol">
+    <symbols>
+      <symbol alpha="1" type="marker" name="0">
+        <layer pass="0" class="SimpleMarker" locked="0">
+          <prop k="angle" v="0"/>
+          <prop k="color" v="193,145,122,255"/>
+          <prop k="color_border" v="140,82,60,255"/>
+          <prop k="horizontal_anchor_point" v="1"/>
+          <prop k="name" v="triangle"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline_style" v="solid"/>
+          <prop k="outline_width" v="0.4"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="scale_method" v="diameter"/>
+          <prop k="size" v="95"/>
+          <prop k="size_unit" v="MM"/>
+          <prop k="vertical_anchor_point" v="1"/>
+        </layer>
       </symbol>
-    </singlesymbol>
-    <labelattributes>
-      <label field="" text="Label" />
-      <family field="" name="Lucida Grande" />
-      <size field="" units="pt" value="12" />
-      <bold field="" on="0" />
-      <italic field="" on="0" />
-      <underline field="" on="0" />
-      <color field="" red="0" blue="0" green="0" />
-      <x field="" />
-      <y field="" />
-      <offset x="0" y="0" yfield="-1" xfield="-1" units="pt" />
-      <angle field="" value="0" />
-      <alignment field="-1" value="center" />
-      <buffercolor field="" red="255" blue="255" green="255" />
-      <buffersize field="" units="pt" value="1" />
-      <bufferenabled field="" on="" />
-    </labelattributes>
+    </symbols>
+    <rotation field="Heading"/>
+    <sizescale field="Importance" scalemethod="area"/>
+  </renderer-v2>
+  <customproperties>
+    <property key="labeling" value="pal"/>
+    <property key="labeling/addDirectionSymbol" value="false"/>
+    <property key="labeling/angleOffset" value="0"/>
+    <property key="labeling/blendMode" value="0"/>
+    <property key="labeling/bufferBlendMode" value="0"/>
+    <property key="labeling/bufferColorA" value="255"/>
+    <property key="labeling/bufferColorB" value="255"/>
+    <property key="labeling/bufferColorG" value="255"/>
+    <property key="labeling/bufferColorR" value="255"/>
+    <property key="labeling/bufferDraw" value="false"/>
+    <property key="labeling/bufferJoinStyle" value="64"/>
+    <property key="labeling/bufferNoFill" value="false"/>
+    <property key="labeling/bufferSize" value="1"/>
+    <property key="labeling/bufferSizeInMapUnits" value="false"/>
+    <property key="labeling/bufferTransp" value="0"/>
+    <property key="labeling/centroidWhole" value="false"/>
+    <property key="labeling/decimals" value="3"/>
+    <property key="labeling/displayAll" value="false"/>
+    <property key="labeling/dist" value="0"/>
+    <property key="labeling/distInMapUnits" value="false"/>
+    <property key="labeling/enabled" value="false"/>
+    <property key="labeling/fieldName" value=""/>
+    <property key="labeling/fontBold" value="false"/>
+    <property key="labeling/fontCapitals" value="0"/>
+    <property key="labeling/fontFamily" value="Sans"/>
+    <property key="labeling/fontItalic" value="false"/>
+    <property key="labeling/fontLetterSpacing" value="0"/>
+    <property key="labeling/fontLimitPixelSize" value="false"/>
+    <property key="labeling/fontMaxPixelSize" value="10000"/>
+    <property key="labeling/fontMinPixelSize" value="3"/>
+    <property key="labeling/fontSize" value="11"/>
+    <property key="labeling/fontSizeInMapUnits" value="false"/>
+    <property key="labeling/fontStrikeout" value="false"/>
+    <property key="labeling/fontUnderline" value="false"/>
+    <property key="labeling/fontWeight" value="50"/>
+    <property key="labeling/fontWordSpacing" value="0"/>
+    <property key="labeling/formatNumbers" value="false"/>
+    <property key="labeling/isExpression" value="false"/>
+    <property key="labeling/labelOffsetInMapUnits" value="true"/>
+    <property key="labeling/labelPerPart" value="false"/>
+    <property key="labeling/leftDirectionSymbol" value="&lt;"/>
+    <property key="labeling/limitNumLabels" value="false"/>
+    <property key="labeling/maxCurvedCharAngleIn" value="20"/>
+    <property key="labeling/maxCurvedCharAngleOut" value="-20"/>
+    <property key="labeling/maxNumLabels" value="2000"/>
+    <property key="labeling/mergeLines" value="false"/>
+    <property key="labeling/minFeatureSize" value="0"/>
+    <property key="labeling/multilineAlign" value="0"/>
+    <property key="labeling/multilineHeight" value="1"/>
+    <property key="labeling/namedStyle" value=""/>
+    <property key="labeling/obstacle" value="true"/>
+    <property key="labeling/placeDirectionSymbol" value="0"/>
+    <property key="labeling/placement" value="0"/>
+    <property key="labeling/placementFlags" value="0"/>
+    <property key="labeling/plussign" value="false"/>
+    <property key="labeling/preserveRotation" value="true"/>
+    <property key="labeling/previewBkgrdColor" value="#ffffff"/>
+    <property key="labeling/priority" value="5"/>
+    <property key="labeling/quadOffset" value="4"/>
+    <property key="labeling/reverseDirectionSymbol" value="false"/>
+    <property key="labeling/rightDirectionSymbol" value=">"/>
+    <property key="labeling/scaleMax" value="10000000"/>
+    <property key="labeling/scaleMin" value="1"/>
+    <property key="labeling/scaleVisibility" value="false"/>
+    <property key="labeling/shadowBlendMode" value="6"/>
+    <property key="labeling/shadowColorB" value="0"/>
+    <property key="labeling/shadowColorG" value="0"/>
+    <property key="labeling/shadowColorR" value="0"/>
+    <property key="labeling/shadowDraw" value="false"/>
+    <property key="labeling/shadowOffsetAngle" value="135"/>
+    <property key="labeling/shadowOffsetDist" value="1"/>
+    <property key="labeling/shadowOffsetGlobal" value="true"/>
+    <property key="labeling/shadowOffsetUnits" value="1"/>
+    <property key="labeling/shadowRadius" value="1.5"/>
+    <property key="labeling/shadowRadiusAlphaOnly" value="false"/>
+    <property key="labeling/shadowRadiusUnits" value="1"/>
+    <property key="labeling/shadowScale" value="100"/>
+    <property key="labeling/shadowTransparency" value="30"/>
+    <property key="labeling/shadowUnder" value="0"/>
+    <property key="labeling/shapeBlendMode" value="0"/>
+    <property key="labeling/shapeBorderColorA" value="255"/>
+    <property key="labeling/shapeBorderColorB" value="128"/>
+    <property key="labeling/shapeBorderColorG" value="128"/>
+    <property key="labeling/shapeBorderColorR" value="128"/>
+    <property key="labeling/shapeBorderWidth" value="0"/>
+    <property key="labeling/shapeBorderWidthUnits" value="1"/>
+    <property key="labeling/shapeDraw" value="false"/>
+    <property key="labeling/shapeFillColorA" value="255"/>
+    <property key="labeling/shapeFillColorB" value="255"/>
+    <property key="labeling/shapeFillColorG" value="255"/>
+    <property key="labeling/shapeFillColorR" value="255"/>
+    <property key="labeling/shapeJoinStyle" value="64"/>
+    <property key="labeling/shapeOffsetUnits" value="1"/>
+    <property key="labeling/shapeOffsetX" value="0"/>
+    <property key="labeling/shapeOffsetY" value="0"/>
+    <property key="labeling/shapeRadiiUnits" value="1"/>
+    <property key="labeling/shapeRadiiX" value="0"/>
+    <property key="labeling/shapeRadiiY" value="0"/>
+    <property key="labeling/shapeRotation" value="0"/>
+    <property key="labeling/shapeRotationType" value="0"/>
+    <property key="labeling/shapeSVGFile" value=""/>
+    <property key="labeling/shapeSizeType" value="0"/>
+    <property key="labeling/shapeSizeUnits" value="1"/>
+    <property key="labeling/shapeSizeX" value="0"/>
+    <property key="labeling/shapeSizeY" value="0"/>
+    <property key="labeling/shapeTransparency" value="0"/>
+    <property key="labeling/shapeType" value="0"/>
+    <property key="labeling/textColorA" value="255"/>
+    <property key="labeling/textColorB" value="0"/>
+    <property key="labeling/textColorG" value="0"/>
+    <property key="labeling/textColorR" value="0"/>
+    <property key="labeling/textTransp" value="0"/>
+    <property key="labeling/upsidedownLabels" value="0"/>
+    <property key="labeling/wrapChar" value=""/>
+    <property key="labeling/xOffset" value="0"/>
+    <property key="labeling/yOffset" value="0"/>
+  </customproperties>
+  <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <layerTransparency>0</layerTransparency>
+  <displayfield>Class</displayfield>
+  <label>0</label>
+  <labelattributes>
+    <label fieldname="" text="Label"/>
+    <family fieldname="" name="Lucida Grande"/>
+    <size fieldname="" units="pt" value="12"/>
+    <bold fieldname="" on="0"/>
+    <italic fieldname="" on="0"/>
+    <underline fieldname="" on="0"/>
+    <strikeout fieldname="" on="0"/>
+    <color fieldname="" red="0" blue="0" green="0"/>
+    <x fieldname=""/>
+    <y fieldname=""/>
+    <offset x="0" y="0" units="pt" yfieldname="" xfieldname=""/>
+    <angle fieldname="" value="0" auto="0"/>
+    <alignment fieldname="" value="center"/>
+    <buffercolor fieldname="" red="255" blue="255" green="255"/>
+    <buffersize fieldname="" units="pt" value="1"/>
+    <bufferenabled fieldname="" on=""/>
+    <multilineenabled fieldname="" on=""/>
+    <selectedonly on=""/>
+  </labelattributes>
+  <edittypes>
+    <edittype labelontop="0" editable="1" type="0" name="Cabin Crew"/>
+    <edittype labelontop="0" editable="1" type="0" name="Class"/>
+    <edittype labelontop="0" editable="1" type="0" name="Heading"/>
+    <edittype labelontop="0" editable="1" type="0" name="Importance"/>
+    <edittype labelontop="0" editable="1" type="0" name="Pilots"/>
+    <edittype labelontop="0" editable="1" type="0" name="Staff"/>
+  </edittypes>
+  <editform></editform>
+  <editforminit></editforminit>
+  <featformsuppress>0</featformsuppress>
+  <annotationform></annotationform>
+  <editorlayout>generatedlayout</editorlayout>
+  <excludeAttributesWMS/>
+  <excludeAttributesWFS/>
+  <attributeactions/>
 </qgis>

--- a/tests/testdata/points_uniquevalue_symbol.qml
+++ b/tests/testdata/points_uniquevalue_symbol.qml
@@ -1,92 +1,221 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis version="0.9.2-Ganymede" minimumScale="1" maximumScale="1e+08" hasScaleBasedVisibilityFlag="0" geometry="Point" type="vector" >
-    <id>points20080103150949100</id>
-    <datasource>/Users/tim/dev/cpp/qgis/tests/testdata/points.shp</datasource>
-    <layername>points</layername>
-    <srs>
-      <spatialrefsys>
-        <proj4>+proj=longlat +ellps=WGS84 +no_defs</proj4>
-        <srsid>1449</srsid>
-        <srid>4031</srid>
-        <epsg>4031</epsg>
-        <description>Unknown datum based upon the GEM 10C ellipsoid</description>
-        <projectionacronym>longlat</projectionacronym>
-        <ellipsoidacronym>WGS84</ellipsoidacronym>
-        <geographicflag>false</geographicflag>
-      </spatialrefsys>
-    </srs>
-    <transparencyLevelInt>255</transparencyLevelInt>
-    <provider>ogr</provider>
-    <encoding>System</encoding>
-    <classificationattribute>Heading</classificationattribute>
-    <classificationattribute>Importance</classificationattribute>
-    <classificationattribute>Class</classificationattribute>
-    <displayfield>Class</displayfield>
-    <label>0</label>
-    <attributeactions/>
-    <uniquevalue>
-      <classificationfield>Class</classificationfield>
-      <symbol>
-        <lowervalue>B52</lowervalue>
-        <uppervalue></uppervalue>
-        <label></label>
-        <pointsymbol>svg:/gpsicons/plane.svg</pointsymbol>
-        <pointsize>6</pointsize>
-        <rotationclassificationfield>1</rotationclassificationfield>
-        <scaleclassificationfield>2</scaleclassificationfield>
-        <outlinecolor red="0" blue="0" green="0" />
-        <outlinestyle>SolidLine</outlinestyle>
-        <outlinewidth>0.4</outlinewidth>
-        <fillcolor red="231" blue="132" green="129" />
-        <fillpattern>SolidPattern</fillpattern>
-        <texturepath></texturepath>
+<qgis version="2.1.0-Master" minimumScale="1" maximumScale="1e+08" simplifyDrawingHints="3" minLabelScale="1" maxLabelScale="1e+08" simplifyDrawingTol="1" hasScaleBasedVisibilityFlag="0" scaleBasedLabelVisibilityFlag="0">
+  <renderer-v2 attr="Class" symbollevels="0" type="categorizedSymbol">
+    <categories>
+      <category symbol="0" value="B52" label="B52"/>
+      <category symbol="1" value="Biplane" label="Biplane"/>
+      <category symbol="2" value="Jet" label="Jet"/>
+    </categories>
+    <symbols>
+      <symbol alpha="1" type="marker" name="0">
+        <layer pass="0" class="SvgMarker" locked="0">
+          <prop k="angle" v="0"/>
+          <prop k="fill" v="#000000"/>
+          <prop k="horizontal_anchor_point" v="1"/>
+          <prop k="name" v="/gpsicons/plane.svg"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline" v="#000000"/>
+          <prop k="outline-width" v="1"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="size" v="90"/>
+          <prop k="size_unit" v="MM"/>
+          <prop k="vertical_anchor_point" v="1"/>
+        </layer>
       </symbol>
-      <symbol>
-        <lowervalue>Biplane</lowervalue>
-        <uppervalue></uppervalue>
-        <label></label>
-        <pointsymbol>svg:/gpsicons/plane_orange.svg</pointsymbol>
-        <pointsize>5</pointsize>
-        <rotationclassificationfield>1</rotationclassificationfield>
-        <scaleclassificationfield>2</scaleclassificationfield>
-        <outlinecolor red="0" blue="0" green="0" />
-        <outlinestyle>SolidLine</outlinestyle>
-        <outlinewidth>0.4</outlinewidth>
-        <fillcolor red="82" blue="126" green="252" />
-        <fillpattern>SolidPattern</fillpattern>
-        <texturepath></texturepath>
+      <symbol alpha="1" type="marker" name="1">
+        <layer pass="0" class="SvgMarker" locked="0">
+          <prop k="angle" v="0"/>
+          <prop k="fill" v="#000000"/>
+          <prop k="horizontal_anchor_point" v="1"/>
+          <prop k="name" v="/gpsicons/plane_orange.svg"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline" v="#000000"/>
+          <prop k="outline-width" v="1"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="size" v="90"/>
+          <prop k="size_unit" v="MM"/>
+          <prop k="vertical_anchor_point" v="1"/>
+        </layer>
       </symbol>
-      <symbol>
-        <lowervalue>Jet</lowervalue>
-        <uppervalue></uppervalue>
-        <label></label>
-        <pointsymbol>svg:/gpsicons/plane.svg</pointsymbol>
-        <pointsize>5</pointsize>
-        <rotationclassificationfield>1</rotationclassificationfield>
-        <scaleclassificationfield>2</scaleclassificationfield>
-        <outlinecolor red="0" blue="0" green="0" />
-        <outlinestyle>SolidLine</outlinestyle>
-        <outlinewidth>0.4</outlinewidth>
-        <fillcolor red="68" blue="242" green="24" />
-        <fillpattern>SolidPattern</fillpattern>
-        <texturepath></texturepath>
+      <symbol alpha="1" type="marker" name="2">
+        <layer pass="0" class="SvgMarker" locked="0">
+          <prop k="angle" v="0"/>
+          <prop k="fill" v="#000000"/>
+          <prop k="horizontal_anchor_point" v="1"/>
+          <prop k="name" v="/gpsicons/plane.svg"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="outline" v="#000000"/>
+          <prop k="outline-width" v="1"/>
+          <prop k="outline_width_unit" v="MM"/>
+          <prop k="size" v="90"/>
+          <prop k="size_unit" v="MM"/>
+          <prop k="vertical_anchor_point" v="1"/>
+        </layer>
       </symbol>
-    </uniquevalue>
-    <labelattributes>
-      <label field="" text="Label" />
-      <family field="" name="Lucida Grande" />
-      <size field="" units="pt" value="12" />
-      <bold field="" on="0" />
-      <italic field="" on="0" />
-      <underline field="" on="0" />
-      <color field="" red="0" blue="0" green="0" />
-      <x field="" />
-      <y field="" />
-      <offset x="0" y="0" yfield="-1" xfield="-1" units="pt" />
-      <angle field="" value="0" />
-      <alignment field="-1" value="center" />
-      <buffercolor field="" red="255" blue="255" green="255" />
-      <buffersize field="" units="pt" value="1" />
-      <bufferenabled field="" on="" />
-    </labelattributes>
+    </symbols>
+    <rotation field="Heading"/>
+    <sizescale field="Importance" scalemethod="area"/>
+  </renderer-v2>
+  <customproperties>
+    <property key="labeling" value="pal"/>
+    <property key="labeling/addDirectionSymbol" value="false"/>
+    <property key="labeling/angleOffset" value="0"/>
+    <property key="labeling/blendMode" value="0"/>
+    <property key="labeling/bufferBlendMode" value="0"/>
+    <property key="labeling/bufferColorA" value="255"/>
+    <property key="labeling/bufferColorB" value="255"/>
+    <property key="labeling/bufferColorG" value="255"/>
+    <property key="labeling/bufferColorR" value="255"/>
+    <property key="labeling/bufferDraw" value="false"/>
+    <property key="labeling/bufferJoinStyle" value="64"/>
+    <property key="labeling/bufferNoFill" value="false"/>
+    <property key="labeling/bufferSize" value="1"/>
+    <property key="labeling/bufferSizeInMapUnits" value="false"/>
+    <property key="labeling/bufferTransp" value="0"/>
+    <property key="labeling/centroidWhole" value="false"/>
+    <property key="labeling/decimals" value="3"/>
+    <property key="labeling/displayAll" value="false"/>
+    <property key="labeling/dist" value="0"/>
+    <property key="labeling/distInMapUnits" value="false"/>
+    <property key="labeling/enabled" value="false"/>
+    <property key="labeling/fieldName" value=""/>
+    <property key="labeling/fontBold" value="false"/>
+    <property key="labeling/fontCapitals" value="0"/>
+    <property key="labeling/fontFamily" value="Sans"/>
+    <property key="labeling/fontItalic" value="false"/>
+    <property key="labeling/fontLetterSpacing" value="0"/>
+    <property key="labeling/fontLimitPixelSize" value="false"/>
+    <property key="labeling/fontMaxPixelSize" value="10000"/>
+    <property key="labeling/fontMinPixelSize" value="3"/>
+    <property key="labeling/fontSize" value="11"/>
+    <property key="labeling/fontSizeInMapUnits" value="false"/>
+    <property key="labeling/fontStrikeout" value="false"/>
+    <property key="labeling/fontUnderline" value="false"/>
+    <property key="labeling/fontWeight" value="50"/>
+    <property key="labeling/fontWordSpacing" value="0"/>
+    <property key="labeling/formatNumbers" value="false"/>
+    <property key="labeling/isExpression" value="false"/>
+    <property key="labeling/labelOffsetInMapUnits" value="true"/>
+    <property key="labeling/labelPerPart" value="false"/>
+    <property key="labeling/leftDirectionSymbol" value="&lt;"/>
+    <property key="labeling/limitNumLabels" value="false"/>
+    <property key="labeling/maxCurvedCharAngleIn" value="20"/>
+    <property key="labeling/maxCurvedCharAngleOut" value="-20"/>
+    <property key="labeling/maxNumLabels" value="2000"/>
+    <property key="labeling/mergeLines" value="false"/>
+    <property key="labeling/minFeatureSize" value="0"/>
+    <property key="labeling/multilineAlign" value="0"/>
+    <property key="labeling/multilineHeight" value="1"/>
+    <property key="labeling/namedStyle" value=""/>
+    <property key="labeling/obstacle" value="true"/>
+    <property key="labeling/placeDirectionSymbol" value="0"/>
+    <property key="labeling/placement" value="0"/>
+    <property key="labeling/placementFlags" value="0"/>
+    <property key="labeling/plussign" value="false"/>
+    <property key="labeling/preserveRotation" value="true"/>
+    <property key="labeling/previewBkgrdColor" value="#ffffff"/>
+    <property key="labeling/priority" value="5"/>
+    <property key="labeling/quadOffset" value="4"/>
+    <property key="labeling/reverseDirectionSymbol" value="false"/>
+    <property key="labeling/rightDirectionSymbol" value=">"/>
+    <property key="labeling/scaleMax" value="10000000"/>
+    <property key="labeling/scaleMin" value="1"/>
+    <property key="labeling/scaleVisibility" value="false"/>
+    <property key="labeling/shadowBlendMode" value="6"/>
+    <property key="labeling/shadowColorB" value="0"/>
+    <property key="labeling/shadowColorG" value="0"/>
+    <property key="labeling/shadowColorR" value="0"/>
+    <property key="labeling/shadowDraw" value="false"/>
+    <property key="labeling/shadowOffsetAngle" value="135"/>
+    <property key="labeling/shadowOffsetDist" value="1"/>
+    <property key="labeling/shadowOffsetGlobal" value="true"/>
+    <property key="labeling/shadowOffsetUnits" value="1"/>
+    <property key="labeling/shadowRadius" value="1.5"/>
+    <property key="labeling/shadowRadiusAlphaOnly" value="false"/>
+    <property key="labeling/shadowRadiusUnits" value="1"/>
+    <property key="labeling/shadowScale" value="100"/>
+    <property key="labeling/shadowTransparency" value="30"/>
+    <property key="labeling/shadowUnder" value="0"/>
+    <property key="labeling/shapeBlendMode" value="0"/>
+    <property key="labeling/shapeBorderColorA" value="255"/>
+    <property key="labeling/shapeBorderColorB" value="128"/>
+    <property key="labeling/shapeBorderColorG" value="128"/>
+    <property key="labeling/shapeBorderColorR" value="128"/>
+    <property key="labeling/shapeBorderWidth" value="0"/>
+    <property key="labeling/shapeBorderWidthUnits" value="1"/>
+    <property key="labeling/shapeDraw" value="false"/>
+    <property key="labeling/shapeFillColorA" value="255"/>
+    <property key="labeling/shapeFillColorB" value="255"/>
+    <property key="labeling/shapeFillColorG" value="255"/>
+    <property key="labeling/shapeFillColorR" value="255"/>
+    <property key="labeling/shapeJoinStyle" value="64"/>
+    <property key="labeling/shapeOffsetUnits" value="1"/>
+    <property key="labeling/shapeOffsetX" value="0"/>
+    <property key="labeling/shapeOffsetY" value="0"/>
+    <property key="labeling/shapeRadiiUnits" value="1"/>
+    <property key="labeling/shapeRadiiX" value="0"/>
+    <property key="labeling/shapeRadiiY" value="0"/>
+    <property key="labeling/shapeRotation" value="0"/>
+    <property key="labeling/shapeRotationType" value="0"/>
+    <property key="labeling/shapeSVGFile" value=""/>
+    <property key="labeling/shapeSizeType" value="0"/>
+    <property key="labeling/shapeSizeUnits" value="1"/>
+    <property key="labeling/shapeSizeX" value="0"/>
+    <property key="labeling/shapeSizeY" value="0"/>
+    <property key="labeling/shapeTransparency" value="0"/>
+    <property key="labeling/shapeType" value="0"/>
+    <property key="labeling/textColorA" value="255"/>
+    <property key="labeling/textColorB" value="0"/>
+    <property key="labeling/textColorG" value="0"/>
+    <property key="labeling/textColorR" value="0"/>
+    <property key="labeling/textTransp" value="0"/>
+    <property key="labeling/upsidedownLabels" value="0"/>
+    <property key="labeling/wrapChar" value=""/>
+    <property key="labeling/xOffset" value="0"/>
+    <property key="labeling/yOffset" value="0"/>
+  </customproperties>
+  <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <layerTransparency>0</layerTransparency>
+  <displayfield>Class</displayfield>
+  <label>0</label>
+  <labelattributes>
+    <label fieldname="" text="Label"/>
+    <family fieldname="" name="Lucida Grande"/>
+    <size fieldname="" units="pt" value="12"/>
+    <bold fieldname="" on="0"/>
+    <italic fieldname="" on="0"/>
+    <underline fieldname="" on="0"/>
+    <strikeout fieldname="" on="0"/>
+    <color fieldname="" red="0" blue="0" green="0"/>
+    <x fieldname=""/>
+    <y fieldname=""/>
+    <offset x="0" y="0" units="pt" yfieldname="" xfieldname=""/>
+    <angle fieldname="" value="0" auto="0"/>
+    <alignment fieldname="" value="center"/>
+    <buffercolor fieldname="" red="255" blue="255" green="255"/>
+    <buffersize fieldname="" units="pt" value="1"/>
+    <bufferenabled fieldname="" on=""/>
+    <multilineenabled fieldname="" on=""/>
+    <selectedonly on=""/>
+  </labelattributes>
+  <edittypes>
+    <edittype labelontop="0" editable="1" type="0" name="Cabin Crew"/>
+    <edittype labelontop="0" editable="1" type="0" name="Class"/>
+    <edittype labelontop="0" editable="1" type="0" name="Heading"/>
+    <edittype labelontop="0" editable="1" type="0" name="Importance"/>
+    <edittype labelontop="0" editable="1" type="0" name="Pilots"/>
+    <edittype labelontop="0" editable="1" type="0" name="Staff"/>
+  </edittypes>
+  <editform></editform>
+  <editforminit></editforminit>
+  <featformsuppress>0</featformsuppress>
+  <annotationform></annotationform>
+  <editorlayout>generatedlayout</editorlayout>
+  <excludeAttributesWMS/>
+  <excludeAttributesWFS/>
+  <attributeactions/>
 </qgis>

--- a/tests/testdata/polys_uniquevalue_symbol.qml
+++ b/tests/testdata/polys_uniquevalue_symbol.qml
@@ -1,45 +1,160 @@
 <!DOCTYPE qgis PUBLIC 'http://mrcc.com/qgis.dtd' 'SYSTEM'>
-<qgis version="1.9.90-Alpha" minimumScale="1" maximumScale="1e+08" minLabelScale="1" maxLabelScale="1e+08" hasScaleBasedVisibilityFlag="0" scaleBasedLabelVisibilityFlag="0">
-  <transparencyLevelInt>227</transparencyLevelInt>
-  <classificationattribute>Name</classificationattribute>
-  <uniquevalue>
-    <classificationfield>Name</classificationfield>
-    <symbol>
-      <lowervalue>Dam</lowervalue>
-      <uppervalue></uppervalue>
-      <label>Dam</label>
-      <pointsymbol>hard:circle</pointsymbol>
-      <pointsize>11</pointsize>
-      <pointsizeunits>pixels</pointsizeunits>
-      <rotationclassificationfieldname></rotationclassificationfieldname>
-      <scaleclassificationfieldname></scaleclassificationfieldname>
-      <symbolfieldname></symbolfieldname>
-      <outlinecolor red="159" blue="159" green="159"/>
-      <outlinestyle>SolidLine</outlinestyle>
-      <outlinewidth>2</outlinewidth>
-      <fillcolor red="27" blue="212" green="54"/>
-      <fillpattern>Dense4Pattern</fillpattern>
-      <texturepath></texturepath>
-    </symbol>
-    <symbol>
-      <lowervalue>Lake</lowervalue>
-      <uppervalue></uppervalue>
-      <label>Lake</label>
-      <pointsymbol>hard:circle</pointsymbol>
-      <pointsize>11</pointsize>
-      <pointsizeunits>pixels</pointsizeunits>
-      <rotationclassificationfieldname></rotationclassificationfieldname>
-      <scaleclassificationfieldname></scaleclassificationfieldname>
-      <symbolfieldname></symbolfieldname>
-      <outlinecolor red="144" blue="144" green="144"/>
-      <outlinestyle>SolidLine</outlinestyle>
-      <outlinewidth>1</outlinewidth>
-      <fillcolor red="110" blue="217" green="194"/>
-      <fillpattern>SolidPattern</fillpattern>
-      <texturepath></texturepath>
-    </symbol>
-  </uniquevalue>
-  <customproperties/>
+<qgis version="2.1.0-Master" minimumScale="1" maximumScale="1e+08" simplifyDrawingHints="3" minLabelScale="1" maxLabelScale="1e+08" simplifyDrawingTol="1" hasScaleBasedVisibilityFlag="0" scaleBasedLabelVisibilityFlag="0">
+  <renderer-v2 attr="Name" symbollevels="0" type="categorizedSymbol">
+    <categories>
+      <category symbol="0" value="Dam" label="Dam"/>
+      <category symbol="1" value="Lake" label="Lake"/>
+    </categories>
+    <symbols>
+      <symbol alpha="0.847059" type="fill" name="0">
+        <layer pass="0" class="SimpleFill" locked="0">
+          <prop k="border_width_unit" v="MM"/>
+          <prop k="color" v="27,54,212,255"/>
+          <prop k="color_border" v="159,159,159,255"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="style" v="dense4"/>
+          <prop k="style_border" v="solid"/>
+          <prop k="width_border" v="2"/>
+        </layer>
+      </symbol>
+      <symbol alpha="1" type="fill" name="1">
+        <layer pass="0" class="SimpleFill" locked="0">
+          <prop k="border_width_unit" v="MM"/>
+          <prop k="color" v="115,197,220,255"/>
+          <prop k="color_border" v="144,144,144,255"/>
+          <prop k="offset" v="0,0"/>
+          <prop k="offset_unit" v="MM"/>
+          <prop k="style" v="solid"/>
+          <prop k="style_border" v="solid"/>
+          <prop k="width_border" v="1"/>
+        </layer>
+      </symbol>
+    </symbols>
+    <rotation field=""/>
+    <sizescale field="" scalemethod="area"/>
+  </renderer-v2>
+  <customproperties>
+    <property key="labeling" value="pal"/>
+    <property key="labeling/addDirectionSymbol" value="false"/>
+    <property key="labeling/angleOffset" value="0"/>
+    <property key="labeling/blendMode" value="0"/>
+    <property key="labeling/bufferBlendMode" value="0"/>
+    <property key="labeling/bufferColorA" value="255"/>
+    <property key="labeling/bufferColorB" value="255"/>
+    <property key="labeling/bufferColorG" value="255"/>
+    <property key="labeling/bufferColorR" value="255"/>
+    <property key="labeling/bufferDraw" value="false"/>
+    <property key="labeling/bufferJoinStyle" value="64"/>
+    <property key="labeling/bufferNoFill" value="false"/>
+    <property key="labeling/bufferSize" value="1"/>
+    <property key="labeling/bufferSizeInMapUnits" value="false"/>
+    <property key="labeling/bufferTransp" value="0"/>
+    <property key="labeling/centroidWhole" value="false"/>
+    <property key="labeling/decimals" value="3"/>
+    <property key="labeling/displayAll" value="false"/>
+    <property key="labeling/dist" value="0"/>
+    <property key="labeling/distInMapUnits" value="false"/>
+    <property key="labeling/enabled" value="false"/>
+    <property key="labeling/fieldName" value=""/>
+    <property key="labeling/fontBold" value="false"/>
+    <property key="labeling/fontCapitals" value="0"/>
+    <property key="labeling/fontFamily" value="Sans"/>
+    <property key="labeling/fontItalic" value="false"/>
+    <property key="labeling/fontLetterSpacing" value="0"/>
+    <property key="labeling/fontLimitPixelSize" value="false"/>
+    <property key="labeling/fontMaxPixelSize" value="10000"/>
+    <property key="labeling/fontMinPixelSize" value="3"/>
+    <property key="labeling/fontSize" value="11"/>
+    <property key="labeling/fontSizeInMapUnits" value="false"/>
+    <property key="labeling/fontStrikeout" value="false"/>
+    <property key="labeling/fontUnderline" value="false"/>
+    <property key="labeling/fontWeight" value="50"/>
+    <property key="labeling/fontWordSpacing" value="0"/>
+    <property key="labeling/formatNumbers" value="false"/>
+    <property key="labeling/isExpression" value="false"/>
+    <property key="labeling/labelOffsetInMapUnits" value="true"/>
+    <property key="labeling/labelPerPart" value="false"/>
+    <property key="labeling/leftDirectionSymbol" value="&lt;"/>
+    <property key="labeling/limitNumLabels" value="false"/>
+    <property key="labeling/maxCurvedCharAngleIn" value="20"/>
+    <property key="labeling/maxCurvedCharAngleOut" value="-20"/>
+    <property key="labeling/maxNumLabels" value="2000"/>
+    <property key="labeling/mergeLines" value="false"/>
+    <property key="labeling/minFeatureSize" value="0"/>
+    <property key="labeling/multilineAlign" value="0"/>
+    <property key="labeling/multilineHeight" value="1"/>
+    <property key="labeling/namedStyle" value=""/>
+    <property key="labeling/obstacle" value="true"/>
+    <property key="labeling/placeDirectionSymbol" value="0"/>
+    <property key="labeling/placement" value="0"/>
+    <property key="labeling/placementFlags" value="0"/>
+    <property key="labeling/plussign" value="false"/>
+    <property key="labeling/preserveRotation" value="true"/>
+    <property key="labeling/previewBkgrdColor" value="#ffffff"/>
+    <property key="labeling/priority" value="5"/>
+    <property key="labeling/quadOffset" value="4"/>
+    <property key="labeling/reverseDirectionSymbol" value="false"/>
+    <property key="labeling/rightDirectionSymbol" value=">"/>
+    <property key="labeling/scaleMax" value="10000000"/>
+    <property key="labeling/scaleMin" value="1"/>
+    <property key="labeling/scaleVisibility" value="false"/>
+    <property key="labeling/shadowBlendMode" value="6"/>
+    <property key="labeling/shadowColorB" value="0"/>
+    <property key="labeling/shadowColorG" value="0"/>
+    <property key="labeling/shadowColorR" value="0"/>
+    <property key="labeling/shadowDraw" value="false"/>
+    <property key="labeling/shadowOffsetAngle" value="135"/>
+    <property key="labeling/shadowOffsetDist" value="1"/>
+    <property key="labeling/shadowOffsetGlobal" value="true"/>
+    <property key="labeling/shadowOffsetUnits" value="1"/>
+    <property key="labeling/shadowRadius" value="1.5"/>
+    <property key="labeling/shadowRadiusAlphaOnly" value="false"/>
+    <property key="labeling/shadowRadiusUnits" value="1"/>
+    <property key="labeling/shadowScale" value="100"/>
+    <property key="labeling/shadowTransparency" value="30"/>
+    <property key="labeling/shadowUnder" value="0"/>
+    <property key="labeling/shapeBlendMode" value="0"/>
+    <property key="labeling/shapeBorderColorA" value="255"/>
+    <property key="labeling/shapeBorderColorB" value="128"/>
+    <property key="labeling/shapeBorderColorG" value="128"/>
+    <property key="labeling/shapeBorderColorR" value="128"/>
+    <property key="labeling/shapeBorderWidth" value="0"/>
+    <property key="labeling/shapeBorderWidthUnits" value="1"/>
+    <property key="labeling/shapeDraw" value="false"/>
+    <property key="labeling/shapeFillColorA" value="255"/>
+    <property key="labeling/shapeFillColorB" value="255"/>
+    <property key="labeling/shapeFillColorG" value="255"/>
+    <property key="labeling/shapeFillColorR" value="255"/>
+    <property key="labeling/shapeJoinStyle" value="64"/>
+    <property key="labeling/shapeOffsetUnits" value="1"/>
+    <property key="labeling/shapeOffsetX" value="0"/>
+    <property key="labeling/shapeOffsetY" value="0"/>
+    <property key="labeling/shapeRadiiUnits" value="1"/>
+    <property key="labeling/shapeRadiiX" value="0"/>
+    <property key="labeling/shapeRadiiY" value="0"/>
+    <property key="labeling/shapeRotation" value="0"/>
+    <property key="labeling/shapeRotationType" value="0"/>
+    <property key="labeling/shapeSVGFile" value=""/>
+    <property key="labeling/shapeSizeType" value="0"/>
+    <property key="labeling/shapeSizeUnits" value="1"/>
+    <property key="labeling/shapeSizeX" value="0"/>
+    <property key="labeling/shapeSizeY" value="0"/>
+    <property key="labeling/shapeTransparency" value="0"/>
+    <property key="labeling/shapeType" value="0"/>
+    <property key="labeling/textColorA" value="255"/>
+    <property key="labeling/textColorB" value="0"/>
+    <property key="labeling/textColorG" value="0"/>
+    <property key="labeling/textColorR" value="0"/>
+    <property key="labeling/textTransp" value="0"/>
+    <property key="labeling/upsidedownLabels" value="0"/>
+    <property key="labeling/wrapChar" value=""/>
+    <property key="labeling/xOffset" value="0"/>
+    <property key="labeling/yOffset" value="0"/>
+  </customproperties>
+  <blendMode>0</blendMode>
+  <featureBlendMode>0</featureBlendMode>
+  <layerTransparency>0</layerTransparency>
   <displayfield>Name</displayfield>
   <label>0</label>
   <labelattributes>
@@ -63,11 +178,15 @@
     <selectedonly on=""/>
   </labelattributes>
   <edittypes>
-    <edittype type="0" name="Name"/>
-    <edittype type="0" name="Value"/>
+    <edittype labelontop="0" editable="1" type="0" name="Name"/>
+    <edittype labelontop="0" editable="1" type="0" name="Value"/>
   </edittypes>
   <editform></editform>
   <editforminit></editforminit>
+  <featformsuppress>0</featformsuppress>
   <annotationform></annotationform>
+  <editorlayout>generatedlayout</editorlayout>
+  <excludeAttributesWMS/>
+  <excludeAttributesWFS/>
   <attributeactions/>
 </qgis>


### PR DESCRIPTION
generated style files that try to match the old reference

The test won't pass yet because I did not change the reference images.

The match is not perfect and the Continuous symbol style seems to be removed from qgis.

If the match is good enough, We can change the ref images

We can also change the old .qml files for new ones in a more systematic way.
