### PR TITLE
Fixed bug in the processing toolbox qgis:intersection tool

### DIFF
--- a/python/plugins/processing/algs/ftools/Intersection.py
+++ b/python/plugins/processing/algs/ftools/Intersection.py
@@ -33,6 +33,14 @@ from processing.parameters.ParameterVector import ParameterVector
 from processing.outputs.OutputVector import OutputVector
 from processing.tools import dataobjects, vector
 
+wkbTypeGroups = {
+    'Point': (QGis.WKBPoint, QGis.WKBMultiPoint, QGis.WKBPoint25D, QGis.WKBMultiPoint25D,),
+    'LineString': (QGis.WKBLineString, QGis.WKBMultiLineString, QGis.WKBLineString25D, QGis.WKBMultiLineString25D,),
+    'Polygon': (QGis.WKBPolygon, QGis.WKBMultiPolygon, QGis.WKBPolygon25D, QGis.WKBMultiPolygon25D,),
+}
+for key, value in wkbTypeGroups.items():
+    for const in value:
+        wkbTypeGroups[const] = key
 
 class Intersection(GeoAlgorithm):
 
@@ -70,16 +78,17 @@ class Intersection(GeoAlgorithm):
                 if geom.intersects(tmpGeom):
                     atMapB = inFeatB.attributes()
                     int_geom = QgsGeometry(geom.intersection(tmpGeom))
-                    if int_geom.wkbType() == 7:
+                    if int_geom.wkbType() == QGis.WKBUnknown:
                         int_com = geom.combine(tmpGeom)
                         int_sym = geom.symDifference(tmpGeom)
                         int_geom = QgsGeometry(int_com.difference(int_sym))
-                    outFeat.setGeometry(int_geom)
-                    attrs = []
-                    attrs.extend(atMapA)
-                    attrs.extend(atMapB)
-                    outFeat.setAttributes(attrs)
-                    writer.addFeature(outFeat)
+                    if int_geom.wkbType() in wkbTypeGroups[wkbTypeGroups[int_geom.wkbType()]]:
+                        outFeat.setGeometry(int_geom)
+                        attrs = []
+                        attrs.extend(atMapA)
+                        attrs.extend(atMapB)
+                        outFeat.setAttributes(attrs)
+                        writer.addFeature(outFeat)
 
         del writer
 


### PR DESCRIPTION
The qgis:intersection tool doesn't entirely reproduce the algorithm used in the original fTools plugin; with some data the plugin will attempt to write null geometries or geometries of the wrong type to the output shapefile (e.g. LINESTRING to a POLYGON shapefile). This commit corrects the issue.

I've uploaded some sample data as a gist, which exhibits the problem.

https://gist.github.com/snorfalorpagus/8426244

myshape.geojson - the first layer
grid.geojson - the second layer
output_fail.geojson - the output using the existing intersection tool
output_pass.geojson - the output using the modified version in this request
