### PR TITLE
lighter UI for atlas composer

### DIFF
--- a/src/app/composer/qgsatlascompositionwidget.cpp
+++ b/src/app/composer/qgsatlascompositionwidget.cpp
@@ -70,18 +70,12 @@ void QgsAtlasCompositionWidget::on_mUseAtlasCheckBox_stateChanged( int state )
   {
     atlasMap->setEnabled( true );
     mConfigurationGroup->setEnabled( true );
-    mVisibilityGroup->setEnabled( true );
-    mSortingGroup->setEnabled( true );
-    mFilteringGroup->setEnabled( true );
     mOutputGroup->setEnabled( true );
   }
   else
   {
     atlasMap->setEnabled( false );
     mConfigurationGroup->setEnabled( false );
-    mVisibilityGroup->setEnabled( false );
-    mSortingGroup->setEnabled( false );
-    mFilteringGroup->setEnabled( false );
     mOutputGroup->setEnabled( false );
   }
 }
@@ -400,8 +394,5 @@ void QgsAtlasCompositionWidget::blockAllSignals( bool b )
 {
   mUseAtlasCheckBox->blockSignals( b );
   mConfigurationGroup->blockSignals( b );
-  mVisibilityGroup->blockSignals( b );
-  mSortingGroup->blockSignals( b );
-  mFilteringGroup->blockSignals( b );
   mOutputGroup->blockSignals( b );
 }

--- a/src/ui/qgsatlascompositionwidgetbase.ui
+++ b/src/ui/qgsatlascompositionwidgetbase.ui
@@ -23,16 +23,7 @@
    <property name="spacing">
     <number>0</number>
    </property>
-   <property name="leftMargin">
-    <number>0</number>
-   </property>
-   <property name="topMargin">
-    <number>0</number>
-   </property>
-   <property name="rightMargin">
-    <number>0</number>
-   </property>
-   <property name="bottomMargin">
+   <property name="margin">
     <number>0</number>
    </property>
    <item>
@@ -41,23 +32,14 @@
       <enum>QFrame::StyledPanel</enum>
      </property>
      <layout class="QGridLayout" name="gridLayout">
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
-       <number>0</number>
-      </property>
       <property name="horizontalSpacing">
        <number>0</number>
       </property>
       <property name="verticalSpacing">
        <number>3</number>
+      </property>
+      <property name="margin">
+       <number>0</number>
       </property>
       <item row="0" column="1">
        <widget class="QCheckBox" name="mUseAtlasCheckBox">
@@ -133,153 +115,67 @@
             <property name="collapsed" stdset="0">
              <bool>false</bool>
             </property>
-            <layout class="QFormLayout" name="formLayout_4">
-             <property name="fieldGrowthPolicy">
-              <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-             </property>
-             <property name="labelAlignment">
-              <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-             </property>
+            <layout class="QGridLayout" name="gridLayout_2">
              <item row="0" column="0">
               <widget class="QLabel" name="mHorizontalAlignementLabel">
                <property name="text">
-                <string>Coverage layer</string>
+                <string>Coverage layer </string>
+               </property>
+              </widget>
+             </item>
+             <item row="2" column="0">
+              <widget class="QCheckBox" name="mAtlasFeatureFilterCheckBox">
+               <property name="text">
+                <string>Filter with</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="2">
+              <widget class="QComboBox" name="mAtlasCoverageLayerComboBox">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
                </property>
               </widget>
              </item>
              <item row="0" column="1">
-              <layout class="QHBoxLayout" name="horizontalLayout_5">
-               <item>
-                <widget class="QComboBox" name="mAtlasCoverageLayerComboBox"/>
-               </item>
-              </layout>
+              <spacer name="horizontalSpacer_3">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeType">
+                <enum>QSizePolicy::Preferred</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>20</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
              </item>
-            </layout>
-           </widget>
-          </item>
-          <item>
-           <widget class="QgsCollapsibleGroupBoxBasic" name="mVisibilityGroup">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-            <property name="title">
-             <string>Visibility</string>
-            </property>
-            <property name="checkable">
-             <bool>false</bool>
-            </property>
-            <property name="syncGroup" stdset="0">
-             <string notr="true">composeritem</string>
-            </property>
-            <property name="collapsed" stdset="0">
-             <bool>false</bool>
-            </property>
-            <layout class="QVBoxLayout" name="verticalLayout_2">
-             <item>
+             <item row="2" column="2">
+              <widget class="QLineEdit" name="mAtlasFeatureFilterEdit"/>
+             </item>
+             <item row="2" column="3">
+              <widget class="QToolButton" name="mAtlasFeatureFilterButton">
+               <property name="text">
+                <string>...</string>
+               </property>
+               <property name="icon">
+                <iconset resource="../../images/images.qrc">
+                 <normaloff>:/images/themes/default/mIconExpression.svg</normaloff>:/images/themes/default/mIconExpression.svg</iconset>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0" colspan="4">
               <widget class="QCheckBox" name="mAtlasHideCoverageCheckBox">
                <property name="text">
                 <string>Hidden coverage layer</string>
                </property>
               </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item>
-           <widget class="QgsCollapsibleGroupBoxBasic" name="mSortingGroup">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-            <property name="title">
-             <string>Feature sorting</string>
-            </property>
-            <property name="checkable">
-             <bool>false</bool>
-            </property>
-            <property name="syncGroup" stdset="0">
-             <string notr="true">composeritem</string>
-            </property>
-            <property name="collapsed" stdset="0">
-             <bool>true</bool>
-            </property>
-            <layout class="QVBoxLayout" name="verticalLayout_3">
-             <item>
-              <layout class="QHBoxLayout" name="horizontalLayout">
-               <item>
-                <widget class="QCheckBox" name="mAtlasSortFeatureCheckBox">
-                 <property name="sizePolicy">
-                  <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                   <horstretch>0</horstretch>
-                   <verstretch>0</verstretch>
-                  </sizepolicy>
-                 </property>
-                 <property name="text">
-                  <string>Sort by</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QComboBox" name="mAtlasSortFeatureKeyComboBox"/>
-               </item>
-               <item>
-                <widget class="QToolButton" name="mAtlasSortFeatureDirectionButton">
-                 <property name="toolTip">
-                  <string>Sort direction</string>
-                 </property>
-                 <property name="text">
-                  <string>...</string>
-                 </property>
-                 <property name="arrowType">
-                  <enum>Qt::UpArrow</enum>
-                 </property>
-                </widget>
-               </item>
-              </layout>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item>
-           <widget class="QgsCollapsibleGroupBoxBasic" name="mFilteringGroup">
-            <property name="enabled">
-             <bool>false</bool>
-            </property>
-            <property name="title">
-             <string>Feature filtering</string>
-            </property>
-            <property name="checkable">
-             <bool>false</bool>
-            </property>
-            <property name="syncGroup" stdset="0">
-             <string notr="true">composeritem</string>
-            </property>
-            <property name="collapsed" stdset="0">
-             <bool>true</bool>
-            </property>
-            <layout class="QFormLayout" name="formLayout_2">
-             <property name="fieldGrowthPolicy">
-              <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
-             </property>
-             <item row="0" column="0" colspan="2">
-              <layout class="QHBoxLayout" name="horizontalLayout_2">
-               <item>
-                <widget class="QCheckBox" name="mAtlasFeatureFilterCheckBox">
-                 <property name="text">
-                  <string>Filter with</string>
-                 </property>
-                </widget>
-               </item>
-               <item>
-                <widget class="QLineEdit" name="mAtlasFeatureFilterEdit"/>
-               </item>
-               <item>
-                <widget class="QToolButton" name="mAtlasFeatureFilterButton">
-                 <property name="text">
-                  <string>...</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
              </item>
             </layout>
            </widget>
@@ -302,13 +198,6 @@
              <bool>false</bool>
             </property>
             <layout class="QGridLayout" name="gridLayout_3">
-             <item row="2" column="0" colspan="2">
-              <widget class="QCheckBox" name="mAtlasSingleFileCheckBox">
-               <property name="text">
-                <string>Single file export when possible</string>
-               </property>
-              </widget>
-             </item>
              <item row="0" column="0" colspan="2">
               <widget class="QLabel" name="label_4">
                <property name="text">
@@ -316,22 +205,55 @@
                </property>
               </widget>
              </item>
-             <item row="1" column="0" colspan="2">
-              <layout class="QHBoxLayout" name="horizontalLayout_3">
-               <property name="leftMargin">
-                <number>12</number>
+             <item row="3" column="1">
+              <widget class="QComboBox" name="mAtlasSortFeatureKeyComboBox"/>
+             </item>
+             <item row="3" column="0">
+              <widget class="QCheckBox" name="mAtlasSortFeatureCheckBox">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
                </property>
-               <item>
-                <widget class="QLineEdit" name="mAtlasFilenamePatternEdit"/>
-               </item>
-               <item>
-                <widget class="QToolButton" name="mAtlasFilenameExpressionButton">
-                 <property name="text">
-                  <string>...</string>
-                 </property>
-                </widget>
-               </item>
-              </layout>
+               <property name="text">
+                <string>Sort by</string>
+               </property>
+              </widget>
+             </item>
+             <item row="3" column="2">
+              <widget class="QToolButton" name="mAtlasSortFeatureDirectionButton">
+               <property name="toolTip">
+                <string>Sort direction</string>
+               </property>
+               <property name="text">
+                <string>...</string>
+               </property>
+               <property name="arrowType">
+                <enum>Qt::UpArrow</enum>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="2">
+              <widget class="QToolButton" name="mAtlasFilenameExpressionButton">
+               <property name="text">
+                <string>...</string>
+               </property>
+               <property name="icon">
+                <iconset resource="../../images/images.qrc">
+                 <normaloff>:/images/themes/default/mIconExpression.svg</normaloff>:/images/themes/default/mIconExpression.svg</iconset>
+               </property>
+              </widget>
+             </item>
+             <item row="1" column="0" colspan="2">
+              <widget class="QLineEdit" name="mAtlasFilenamePatternEdit"/>
+             </item>
+             <item row="2" column="0" colspan="3">
+              <widget class="QCheckBox" name="mAtlasSingleFileCheckBox">
+               <property name="text">
+                <string>Single file export when possible</string>
+               </property>
+              </widget>
              </item>
             </layout>
            </widget>
@@ -366,6 +288,8 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
- <resources/>
+ <resources>
+  <include location="../../images/images.qrc"/>
+ </resources>
  <connections/>
 </ui>


### PR DESCRIPTION
I just grouped some widgets in two main categories to respect HIG

"Avoid using group boxes with only a single widget / item inside"

![image](https://f.cloud.github.com/assets/127259/1918451/23fa6e7a-7dbe-11e3-890f-1b630ff7f9c0.png)
