### PR TITLE
UI: remove top labels, use collapsible groupboxes, and other small improvements

### DIFF
--- a/src/app/pluginmanager/qgspluginmanager.cpp
+++ b/src/app/pluginmanager/qgspluginmanager.cpp
@@ -538,8 +538,6 @@ void QgsPluginManager::reloadModelData()
     if ( hasAvailablePlugins() ) mModelPlugins->appendRow( createSpacerItem( tr( "Installable", "category: plugins that are available for installation" ), "not installedZ" ) );
   }
 
-  updateTabTitle();
-
   buttonUpgradeAll->setEnabled( hasUpgradeablePlugins() );
 
   // Disable tabs that are empty because of no suitable plugins in the model.
@@ -990,8 +988,6 @@ void QgsPluginManager::setCurrentTab( int idx )
     }
     mModelProxy->setAcceptedStatuses( acceptedStatuses );
 
-    updateTabTitle();
-
     // load tab description HTML to the detail browser
     QString tabInfoHTML = "";
     QMap<QString, QString>::iterator it = mTabDescriptions.find( tabTitle );
@@ -1340,13 +1336,3 @@ bool QgsPluginManager::hasInvalidPlugins( )
 
   return false;
 }
-
-
-
-void QgsPluginManager::updateTabTitle()
-{
-  lbStatusFilter->setText( QString( " %1 > %2 (%3)" ).arg( tr( "Plugins" ) )
-                           .arg( mOptionsListWidget->currentItem()->text() )
-                           .arg( mModelProxy->countWithCurrentStatus() ) );
-}
-

--- a/src/app/pluginmanager/qgspluginmanager.h
+++ b/src/app/pluginmanager/qgspluginmanager.h
@@ -100,9 +100,6 @@ class QgsPluginManager : public QgsOptionsDialogBase, private Ui::QgsPluginManag
     //! Set tab of the stacked widget (called from the vertical list item)
     void setCurrentTab( int idx );
 
-    //! Update title of the current tab according to current filters
-    void updateTabTitle();
-
     //! Handle plugin selection
     void currentPluginChanged( const QModelIndex & theIndex );
 

--- a/src/ui/qgsabout.ui
+++ b/src/ui/qgsabout.ui
@@ -150,23 +150,13 @@
           </sizepolicy>
          </property>
          <property name="currentIndex">
-          <number>5</number>
+          <number>0</number>
          </property>
          <widget class="QWidget" name="mOptsPage_01">
           <layout class="QVBoxLayout" name="verticalLayout_4">
            <property name="margin">
             <number>0</number>
            </property>
-           <item>
-            <widget class="QLabel" name="label">
-             <property name="styleSheet">
-              <string notr="true">font-weight:bold;</string>
-             </property>
-             <property name="text">
-              <string>About</string>
-             </property>
-            </widget>
-           </item>
            <item>
             <layout class="QHBoxLayout">
              <item>
@@ -201,8 +191,8 @@ p, li { white-space: pre-wrap; }
             </layout>
            </item>
            <item>
-            <widget class="QWebView" name="txtVersion">
-             <property name="url">
+            <widget class="QWebView" name="txtVersion" native="true">
+             <property name="url" stdset="0">
               <url>
                <string>about:blank</string>
               </url>
@@ -287,16 +277,6 @@ p, li { white-space: pre-wrap; }
             <number>0</number>
            </property>
            <item>
-            <widget class="QLabel" name="label_4">
-             <property name="styleSheet">
-              <string notr="true">font-weight:bold;</string>
-             </property>
-             <property name="text">
-              <string>What's New</string>
-             </property>
-            </widget>
-           </item>
-           <item>
             <widget class="QTextBrowser" name="txtWhatsNew"/>
            </item>
           </layout>
@@ -307,16 +287,6 @@ p, li { white-space: pre-wrap; }
             <number>0</number>
            </property>
            <item>
-            <widget class="QLabel" name="label_5">
-             <property name="styleSheet">
-              <string notr="true">font-weight:bold;</string>
-             </property>
-             <property name="text">
-              <string>Providers</string>
-             </property>
-            </widget>
-           </item>
-           <item>
             <widget class="QTextBrowser" name="txtProviders"/>
            </item>
           </layout>
@@ -326,23 +296,7 @@ p, li { white-space: pre-wrap; }
            <property name="margin">
             <number>0</number>
            </property>
-           <item row="0" column="0" colspan="2">
-            <widget class="QLabel" name="label_6">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="styleSheet">
-              <string notr="true">font-weight:bold;</string>
-             </property>
-             <property name="text">
-              <string>Developers</string>
-             </property>
-            </widget>
-           </item>
-           <item row="1" column="0" rowspan="2">
+           <item row="0" column="0" rowspan="2">
             <widget class="QListWidget" name="lstDevelopers">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -358,7 +312,7 @@ p, li { white-space: pre-wrap; }
              </property>
             </widget>
            </item>
-           <item row="1" column="1">
+           <item row="0" column="1">
             <widget class="QLabel" name="label_7">
              <property name="text">
               <string/>
@@ -374,7 +328,7 @@ p, li { white-space: pre-wrap; }
              </property>
             </widget>
            </item>
-           <item row="2" column="1">
+           <item row="1" column="1">
             <widget class="QLabel" name="label_8">
              <property name="font">
               <font>
@@ -397,22 +351,6 @@ p, li { white-space: pre-wrap; }
             <number>0</number>
            </property>
            <item>
-            <widget class="QLabel" name="label_9">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="styleSheet">
-              <string notr="true">font-weight:bold;</string>
-             </property>
-             <property name="text">
-              <string>Contributors</string>
-             </property>
-            </widget>
-           </item>
-           <item>
             <widget class="QListWidget" name="lstContributors">
              <property name="alternatingRowColors">
               <bool>true</bool>
@@ -427,24 +365,8 @@ p, li { white-space: pre-wrap; }
             <number>0</number>
            </property>
            <item>
-            <widget class="QLabel" name="label_10">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="styleSheet">
-              <string notr="true">font-weight:bold;</string>
-             </property>
-             <property name="text">
-              <string>Translators</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QWebView" name="txtTranslators">
-             <property name="url">
+            <widget class="QWebView" name="txtTranslators" native="true">
+             <property name="url" stdset="0">
               <url>
                <string>about:blank</string>
               </url>
@@ -458,22 +380,6 @@ p, li { white-space: pre-wrap; }
            <property name="margin">
             <number>0</number>
            </property>
-           <item>
-            <widget class="QLabel" name="label_12">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="styleSheet">
-              <string notr="true">font-weight:bold;</string>
-             </property>
-             <property name="text">
-              <string>Donors</string>
-             </property>
-            </widget>
-           </item>
            <item>
             <widget class="QTextBrowser" name="txtDonors">
              <property name="openExternalLinks">
@@ -491,22 +397,6 @@ p, li { white-space: pre-wrap; }
            <property name="margin">
             <number>0</number>
            </property>
-           <item>
-            <widget class="QLabel" name="label_13">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="styleSheet">
-              <string notr="true">font-weight:bold;</string>
-             </property>
-             <property name="text">
-              <string>License</string>
-             </property>
-            </widget>
-           </item>
            <item>
             <widget class="QTextBrowser" name="txtLicense"/>
            </item>

--- a/src/ui/qgsfieldspropertiesbase.ui
+++ b/src/ui/qgsfieldspropertiesbase.ui
@@ -11,80 +11,109 @@
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout_6">
-   <item row="0" column="4">
-    <spacer>
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>100</width>
-       <height>19</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="0" column="5">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>Attribute editor layout:</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0">
-    <widget class="QToolButton" name="mAddAttributeButton">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="toolTip">
-      <string>New column</string>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-     <property name="icon">
-      <iconset>
-       <normaloff>.designer/xpm/new_attribute.png</normaloff>.designer/xpm/new_attribute.png</iconset>
-     </property>
-     <property name="shortcut">
-      <string>Ctrl+N</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="3">
-    <widget class="QToolButton" name="mCalculateFieldButton">
-     <property name="toolTip">
-      <string>Field calculator</string>
-     </property>
-     <property name="whatsThis">
-      <string>Click to toggle table editing</string>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-     <property name="checkable">
-      <bool>false</bool>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="2">
-    <widget class="QToolButton" name="mToggleEditingButton">
-     <property name="toolTip">
-      <string>Toggle editing mode</string>
-     </property>
-     <property name="whatsThis">
-      <string>Click to toggle table editing</string>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-     <property name="checkable">
-      <bool>true</bool>
-     </property>
-    </widget>
+   <item row="1" column="0" colspan="7">
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item>
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Attribute editor layout:</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="mEditorLayoutComboBox">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <item>
+        <property name="text">
+         <string>Autogenerate</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Drag and drop designer</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Provide ui-file</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeType">
+        <enum>QSizePolicy::Minimum</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>25</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QLabel" name="label_3">
+       <property name="toolTip">
+        <string>QGIS forms can have a Python function that is called when the form is opened.  
+Use this function to add extra logic to your forms.
+
+An example is (in module MyForms.py):
+
+          def open(dialog, layer, feature):
+	geom = feature.geometry()
+	control = dialog.findChild(QWidget,&quot;MyLineEdit&quot;)
+
+Reference in Python Init Function like so: MyForms.open
+
+MyForms.py must live on PYTHONPATH, .qgis/python, or inside the project folder.</string>
+       </property>
+       <property name="text">
+        <string>Python Init function</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="leEditFormInit">
+       <property name="toolTip">
+        <string>QGIS forms can have a Python function that is called when the form is opened.  
+Use this function to add extra logic to your forms.
+
+An example is (in module MyForms.py):
+
+          def open(dialog, layer, feature):
+	geom = feature.geometry()
+	control = dialog.findChild(QWidget,&quot;MyLineEdit&quot;)
+
+Reference in Python Init Function like so: MyForms.open
+
+MyForms.py must live on PYTHONPATH, .qgis/python, or inside the project folder.</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer_3">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
    </item>
    <item row="2" column="0" colspan="7">
     <widget class="QSplitter" name="mSplitter">
@@ -107,11 +136,104 @@
          <property name="orientation">
           <enum>Qt::Vertical</enum>
          </property>
-         <widget class="QgsCollapsibleGroupBox" name="mAttributesListFrame">
+         <widget class="QgsCollapsibleGroupBox" name="mFieldsGroupBox">
           <property name="title">
            <string>Fields</string>
           </property>
-          <layout class="QGridLayout" name="mAttributesListLayout"/>
+          <layout class="QGridLayout" name="mAttributesListLayout">
+           <item row="0" column="0">
+            <layout class="QGridLayout" name="gridLayout_3">
+             <item row="0" column="1">
+              <widget class="QToolButton" name="mDeleteAttributeButton">
+               <property name="toolTip">
+                <string>Delete column</string>
+               </property>
+               <property name="text">
+                <string/>
+               </property>
+               <property name="icon">
+                <iconset>
+                 <normaloff>.designer/xpm/delete_attribute.png</normaloff>.designer/xpm/delete_attribute.png</iconset>
+               </property>
+               <property name="shortcut">
+                <string>Ctrl+X</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="3">
+              <widget class="QToolButton" name="mCalculateFieldButton">
+               <property name="toolTip">
+                <string>Field calculator</string>
+               </property>
+               <property name="whatsThis">
+                <string>Click to toggle table editing</string>
+               </property>
+               <property name="text">
+                <string/>
+               </property>
+               <property name="checkable">
+                <bool>false</bool>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="2">
+              <widget class="QToolButton" name="mToggleEditingButton">
+               <property name="toolTip">
+                <string>Toggle editing mode</string>
+               </property>
+               <property name="whatsThis">
+                <string>Click to toggle table editing</string>
+               </property>
+               <property name="text">
+                <string/>
+               </property>
+               <property name="checkable">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="0">
+              <widget class="QToolButton" name="mAddAttributeButton">
+               <property name="sizePolicy">
+                <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                 <horstretch>0</horstretch>
+                 <verstretch>0</verstretch>
+                </sizepolicy>
+               </property>
+               <property name="toolTip">
+                <string>New column</string>
+               </property>
+               <property name="text">
+                <string/>
+               </property>
+               <property name="icon">
+                <iconset>
+                 <normaloff>.designer/xpm/new_attribute.png</normaloff>.designer/xpm/new_attribute.png</iconset>
+               </property>
+               <property name="shortcut">
+                <string>Ctrl+N</string>
+               </property>
+              </widget>
+             </item>
+             <item row="0" column="4">
+              <spacer name="horizontalSpacer_2">
+               <property name="orientation">
+                <enum>Qt::Horizontal</enum>
+               </property>
+               <property name="sizeHint" stdset="0">
+                <size>
+                 <width>40</width>
+                 <height>20</height>
+                </size>
+               </property>
+              </spacer>
+             </item>
+             <item row="1" column="0" colspan="5">
+              <widget class="QWidget" name="mAttributesListFrame" native="true"/>
+             </item>
+            </layout>
+           </item>
+          </layout>
          </widget>
          <widget class="QgsCollapsibleGroupBox" name="mRelationsFrame">
           <property name="title">
@@ -304,69 +426,6 @@
      </widget>
     </widget>
    </item>
-   <item row="0" column="6">
-    <widget class="QComboBox" name="mEditorLayoutComboBox">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <item>
-      <property name="text">
-       <string>Autogenerate</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Drag and drop designer</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Provide ui-file</string>
-      </property>
-     </item>
-    </widget>
-   </item>
-   <item row="1" column="5">
-    <widget class="QLabel" name="label_3">
-     <property name="toolTip">
-      <string>QGIS forms can have a Python function that is called when the form is opened.  
-Use this function to add extra logic to your forms.
-
-An example is (in module MyForms.py):
-
-          def open(dialog, layer, feature):
-	geom = feature.geometry()
-	control = dialog.findChild(QWidget,&quot;MyLineEdit&quot;)
-
-Reference in Python Init Function like so: MyForms.open
-
-MyForms.py must live on PYTHONPATH, .qgis/python, or inside the project folder.</string>
-     </property>
-     <property name="text">
-      <string>Python Init function</string>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="1">
-    <widget class="QToolButton" name="mDeleteAttributeButton">
-     <property name="toolTip">
-      <string>Delete column</string>
-     </property>
-     <property name="text">
-      <string/>
-     </property>
-     <property name="icon">
-      <iconset>
-       <normaloff>.designer/xpm/delete_attribute.png</normaloff>.designer/xpm/delete_attribute.png</iconset>
-     </property>
-     <property name="shortcut">
-      <string>Ctrl+X</string>
-     </property>
-    </widget>
-   </item>
    <item row="3" column="0" colspan="7">
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
@@ -420,24 +479,6 @@ MyForms.py must live on PYTHONPATH, .qgis/python, or inside the project folder.<
       </widget>
      </item>
     </layout>
-   </item>
-   <item row="1" column="6">
-    <widget class="QLineEdit" name="leEditFormInit">
-     <property name="toolTip">
-      <string>QGIS forms can have a Python function that is called when the form is opened.  
-Use this function to add extra logic to your forms.
-
-An example is (in module MyForms.py):
-
-          def open(dialog, layer, feature):
-	geom = feature.geometry()
-	control = dialog.findChild(QWidget,&quot;MyLineEdit&quot;)
-
-Reference in Python Init Function like so: MyForms.open
-
-MyForms.py must live on PYTHONPATH, .qgis/python, or inside the project folder.</string>
-     </property>
-    </widget>
    </item>
   </layout>
  </widget>

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>848</width>
-    <height>705</height>
+    <width>801</width>
+    <height>636</height>
    </rect>
   </property>
   <property name="minimumSize">
@@ -248,23 +248,13 @@
        <item>
         <widget class="QStackedWidget" name="mOptionsStackedWidget">
          <property name="currentIndex">
-          <number>0</number>
+          <number>2</number>
          </property>
          <widget class="QWidget" name="mOptionsPageGeneral">
           <layout class="QVBoxLayout" name="verticalLayout_3">
            <property name="margin">
             <number>0</number>
            </property>
-           <item>
-            <widget class="QLabel" name="label_49">
-             <property name="styleSheet">
-              <string notr="true">font-weight:bold;</string>
-             </property>
-             <property name="text">
-              <string>General</string>
-             </property>
-            </widget>
-           </item>
            <item>
             <widget class="QScrollArea" name="mOptionsScrollArea_01">
              <property name="frameShape">
@@ -278,13 +268,13 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>675</width>
-                <height>639</height>
+                <width>632</width>
+                <height>612</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_28">
                <item>
-                <widget class="QGroupBox" name="groupBox">
+                <widget class="QgsCollapsibleGroupBox" name="groupBox">
                  <property name="title">
                   <string>Application</string>
                  </property>
@@ -641,7 +631,7 @@
                 </widget>
                </item>
                <item>
-                <widget class="QGroupBox" name="groupBox_11">
+                <widget class="QgsCollapsibleGroupBox" name="groupBox_11">
                  <property name="title">
                   <string>Project files</string>
                  </property>
@@ -922,16 +912,6 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QLabel" name="label_50">
-             <property name="styleSheet">
-              <string notr="true">font-weight:bold;</string>
-             </property>
-             <property name="text">
-              <string>System</string>
-             </property>
-            </widget>
-           </item>
-           <item>
             <widget class="QScrollArea" name="mOptionsScrollArea_03">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
@@ -943,14 +923,14 @@
               <property name="geometry">
                <rect>
                 <x>0</x>
-                <y>0</y>
-                <width>515</width>
-                <height>758</height>
+                <y>-133</y>
+                <width>655</width>
+                <height>787</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_22">
                <item>
-                <widget class="QGroupBox" name="groupBox_2">
+                <widget class="QgsCollapsibleGroupBox" name="groupBox_2">
                  <property name="title">
                   <string>SVG paths</string>
                  </property>
@@ -1003,7 +983,7 @@
                 </widget>
                </item>
                <item>
-                <widget class="QGroupBox" name="groupBox_4">
+                <widget class="QgsCollapsibleGroupBox" name="groupBox_4">
                  <property name="title">
                   <string>Plugin paths</string>
                  </property>
@@ -1056,7 +1036,7 @@
                 </widget>
                </item>
                <item>
-                <widget class="QGroupBox" name="mEnvironmentGrpBx">
+                <widget class="QgsCollapsibleGroupBox" name="mEnvironmentGrpBx">
                  <property name="minimumSize">
                   <size>
                    <width>0</width>
@@ -1258,16 +1238,6 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QLabel" name="label_52">
-             <property name="styleSheet">
-              <string notr="true">font-weight:bold;</string>
-             </property>
-             <property name="text">
-              <string>Data sources</string>
-             </property>
-            </widget>
-           </item>
-           <item>
             <widget class="QScrollArea" name="mOptionsScrollArea_11">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
@@ -1280,19 +1250,13 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>407</width>
-                <height>387</height>
+                <width>627</width>
+                <height>585</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_27">
                <item>
-                <widget class="QGroupBox" name="groupBox_18">
-                 <property name="minimumSize">
-                  <size>
-                   <width>0</width>
-                   <height>0</height>
-                  </size>
-                 </property>
+                <widget class="QgsCollapsibleGroupBox" name="groupBox_18">
                  <property name="title">
                   <string>Feature attributes and table</string>
                  </property>
@@ -1427,13 +1391,7 @@
                 </widget>
                </item>
                <item>
-                <widget class="QGroupBox" name="groupBox_19">
-                 <property name="minimumSize">
-                  <size>
-                   <width>0</width>
-                   <height>200</height>
-                  </size>
-                 </property>
+                <widget class="QgsCollapsibleGroupBox" name="groupBox_19">
                  <property name="title">
                   <string>Data source handling</string>
                  </property>
@@ -1567,10 +1525,13 @@
                  <property name="orientation">
                   <enum>Qt::Vertical</enum>
                  </property>
+                 <property name="sizeType">
+                  <enum>QSizePolicy::Expanding</enum>
+                 </property>
                  <property name="sizeHint" stdset="0">
                   <size>
                    <width>20</width>
-                   <height>458</height>
+                   <height>40</height>
                   </size>
                  </property>
                 </spacer>
@@ -1587,16 +1548,6 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QLabel" name="label_46">
-             <property name="styleSheet">
-              <string notr="true">font-weight:bold;</string>
-             </property>
-             <property name="text">
-              <string>Rendering</string>
-             </property>
-            </widget>
-           </item>
-           <item>
             <widget class="QScrollArea" name="mOptionsScrollArea_04">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
@@ -1608,14 +1559,14 @@
               <property name="geometry">
                <rect>
                 <x>0</x>
-                <y>0</y>
-                <width>457</width>
-                <height>811</height>
+                <y>-175</y>
+                <width>704</width>
+                <height>813</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_29">
                <item>
-                <widget class="QGroupBox" name="groupBox_5">
+                <widget class="QgsCollapsibleGroupBox" name="groupBox_5">
                  <property name="title">
                   <string>Rendering behavior</string>
                  </property>
@@ -1682,7 +1633,7 @@
                    </widget>
                   </item>
                   <item row="5" column="0" colspan="2">
-                   <widget class="QGroupBox" name="mSimplifyDrawingGroupBox">
+                   <widget class="QgsCollapsibleGroupBox" name="mSimplifyDrawingGroupBox">
                     <property name="title">
                      <string>Enable feature simplication by default for newly added layers</string>
                     </property>
@@ -1709,23 +1660,23 @@
                      </item>
                      <item row="1" column="2">
                       <widget class="QDoubleSpinBox" name="mSimplifyDrawingSpinBox">
+                       <property name="toolTip">
+                        <string>Higher values result in more simplification</string>
+                       </property>
                        <property name="decimals">
                         <number>2</number>
                        </property>
                        <property name="minimum">
-                        <number>1</number>
+                        <double>1.000000000000000</double>
                        </property>
                        <property name="maximum">
-                        <number>5</number>
+                        <double>5.000000000000000</double>
                        </property>
                        <property name="singleStep">
-                        <double>0.20</double>
+                        <double>0.200000000000000</double>
                        </property>
                        <property name="value">
-                         <double>1.0</double>
-                       </property>
-                       <property name="toolTip">
-                        <string>Higher values result in more simplification</string>
+                        <double>1.000000000000000</double>
                        </property>
                       </widget>
                      </item>
@@ -1751,7 +1702,7 @@
                         </size>
                        </property>
                       </spacer>
-                     </item>                         
+                     </item>
                      <item row="2" column="1" colspan="4">
                       <widget class="QCheckBox" name="mSimplifyDrawingAtProvider">
                        <property name="text">
@@ -1761,12 +1712,12 @@
                      </item>
                     </layout>
                    </widget>
-                  </item> 
+                  </item>
                  </layout>
                 </widget>
                </item>
                <item>
-                <widget class="QGroupBox" name="groupBox_8">
+                <widget class="QgsCollapsibleGroupBox" name="groupBox_8">
                  <property name="title">
                   <string>Rendering quality</string>
                  </property>
@@ -1792,7 +1743,7 @@
                 </widget>
                </item>
                <item>
-                <widget class="QGroupBox" name="groupBox_14">
+                <widget class="QgsCollapsibleGroupBox" name="groupBox_14">
                  <property name="title">
                   <string>Rasters</string>
                  </property>
@@ -2116,7 +2067,7 @@
                 </widget>
                </item>
                <item>
-                <widget class="QGroupBox" name="groupBox_22">
+                <widget class="QgsCollapsibleGroupBox" name="groupBox_22">
                  <property name="title">
                   <string>Debugging</string>
                  </property>
@@ -2183,16 +2134,6 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QLabel" name="label_44">
-             <property name="styleSheet">
-              <string notr="true">font-weight:bold;</string>
-             </property>
-             <property name="text">
-              <string>Map canvas &amp; legend</string>
-             </property>
-            </widget>
-           </item>
-           <item>
             <widget class="QScrollArea" name="mOptionsScrollArea_06">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
@@ -2205,13 +2146,13 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>413</width>
-                <height>305</height>
+                <width>674</width>
+                <height>654</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_25">
                <item>
-                <widget class="QGroupBox" name="groupBox_9">
+                <widget class="QgsCollapsibleGroupBox" name="groupBox_9">
                  <property name="title">
                   <string>Default map appearance (overridden by project properties)</string>
                  </property>
@@ -2309,7 +2250,7 @@
                 </widget>
                </item>
                <item>
-                <widget class="QGroupBox" name="mLegendGrpBx">
+                <widget class="QgsCollapsibleGroupBox" name="mLegendGrpBx">
                  <property name="minimumSize">
                   <size>
                    <width>0</width>
@@ -2529,16 +2470,6 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QLabel" name="label_45">
-             <property name="styleSheet">
-              <string notr="true">font-weight:bold;</string>
-             </property>
-             <property name="text">
-              <string>Map tools</string>
-             </property>
-            </widget>
-           </item>
-           <item>
             <widget class="QScrollArea" name="mOptionsScrollArea_05">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
@@ -2550,14 +2481,14 @@
               <property name="geometry">
                <rect>
                 <x>0</x>
-                <y>0</y>
-                <width>455</width>
-                <height>591</height>
+                <y>-30</y>
+                <width>658</width>
+                <height>684</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_30">
                <item>
-                <widget class="QGroupBox" name="groupBox_7">
+                <widget class="QgsCollapsibleGroupBox" name="groupBox_7">
                  <property name="title">
                   <string>Identify</string>
                  </property>
@@ -2623,7 +2554,7 @@
                 </widget>
                </item>
                <item>
-                <widget class="QGroupBox" name="groupBox_6">
+                <widget class="QgsCollapsibleGroupBox" name="groupBox_6">
                  <property name="title">
                   <string>Measure tool</string>
                  </property>
@@ -2757,7 +2688,7 @@
                 </widget>
                </item>
                <item>
-                <widget class="QGroupBox" name="groupBox_10">
+                <widget class="QgsCollapsibleGroupBox" name="groupBox_10">
                  <property name="title">
                   <string>Panning and zooming</string>
                  </property>
@@ -2820,7 +2751,7 @@
                 </widget>
                </item>
                <item>
-                <widget class="QGroupBox" name="groupBox_15">
+                <widget class="QgsCollapsibleGroupBox" name="groupBox_15">
                  <property name="title">
                   <string>Predefined scales</string>
                  </property>
@@ -2943,16 +2874,6 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QLabel" name="label_65">
-             <property name="styleSheet">
-              <string notr="true">font-weight:bold;</string>
-             </property>
-             <property name="text">
-              <string>Composer</string>
-             </property>
-            </widget>
-           </item>
-           <item>
             <widget class="QScrollArea" name="mOptionsScrollArea_12">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
@@ -2965,8 +2886,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>381</width>
-                <height>326</height>
+                <width>674</width>
+                <height>654</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_39">
@@ -2974,7 +2895,7 @@
                 <number>0</number>
                </property>
                <item>
-                <widget class="QGroupBox" name="groupBox_3">
+                <widget class="QgsCollapsibleGroupBox" name="groupBox_3">
                  <property name="title">
                   <string>Composition defaults</string>
                  </property>
@@ -2997,7 +2918,7 @@
                 </widget>
                </item>
                <item>
-                <widget class="QGroupBox" name="groupBox_23">
+                <widget class="QgsCollapsibleGroupBox" name="groupBox_23">
                  <property name="title">
                   <string>Grid appearance</string>
                  </property>
@@ -3027,7 +2948,7 @@
                 </widget>
                </item>
                <item>
-                <widget class="QGroupBox" name="groupBox_24">
+                <widget class="QgsCollapsibleGroupBox" name="groupBox_24">
                  <property name="title">
                   <string>Grid defaults</string>
                  </property>
@@ -3110,7 +3031,7 @@
                 </widget>
                </item>
                <item>
-                <widget class="QGroupBox" name="groupBox_25">
+                <widget class="QgsCollapsibleGroupBox" name="groupBox_25">
                  <property name="title">
                   <string>Guide defaults</string>
                  </property>
@@ -3164,16 +3085,6 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QLabel" name="label_41">
-             <property name="styleSheet">
-              <string notr="true">font-weight:bold;</string>
-             </property>
-             <property name="text">
-              <string>Digitizing</string>
-             </property>
-            </widget>
-           </item>
-           <item>
             <widget class="QScrollArea" name="mOptionsScrollArea_07">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
@@ -3186,8 +3097,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>374</width>
-                <height>529</height>
+                <width>674</width>
+                <height>654</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_31">
@@ -3195,7 +3106,7 @@
                 <number>0</number>
                </property>
                <item>
-                <widget class="QGroupBox" name="mEnterAttributeValuesGroupBox">
+                <widget class="QgsCollapsibleGroupBox" name="mEnterAttributeValuesGroupBox">
                  <property name="title">
                   <string>Feature creation</string>
                  </property>
@@ -3254,7 +3165,7 @@
                 </widget>
                </item>
                <item>
-                <widget class="QGroupBox" name="mRubberBandGroupBox">
+                <widget class="QgsCollapsibleGroupBox" name="mRubberBandGroupBox">
                  <property name="title">
                   <string>Rubberband</string>
                  </property>
@@ -3337,7 +3248,7 @@
                 </widget>
                </item>
                <item>
-                <widget class="QGroupBox" name="mSnappingGroupBox">
+                <widget class="QgsCollapsibleGroupBox" name="mSnappingGroupBox">
                  <property name="title">
                   <string>Snapping</string>
                  </property>
@@ -3477,7 +3388,7 @@
                 </widget>
                </item>
                <item>
-                <widget class="QGroupBox" name="mVertexMarkerGroupBox">
+                <widget class="QgsCollapsibleGroupBox" name="mVertexMarkerGroupBox">
                  <property name="title">
                   <string>Vertex markers</string>
                  </property>
@@ -3556,7 +3467,7 @@
                 </widget>
                </item>
                <item>
-                <widget class="QGroupBox" name="groupBox_21">
+                <widget class="QgsCollapsibleGroupBox" name="groupBox_21">
                  <property name="title">
                   <string>Curve offset tool</string>
                  </property>
@@ -3665,16 +3576,6 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QLabel" name="label_51">
-             <property name="styleSheet">
-              <string notr="true">font-weight:bold;</string>
-             </property>
-             <property name="text">
-              <string>GDAL</string>
-             </property>
-            </widget>
-           </item>
-           <item>
             <widget class="QScrollArea" name="mOptionsScrollArea_02">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
@@ -3687,8 +3588,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>345</width>
-                <height>350</height>
+                <width>627</width>
+                <height>585</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -3805,16 +3706,6 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QLabel" name="label_42">
-             <property name="styleSheet">
-              <string notr="true">font-weight:bold;</string>
-             </property>
-             <property name="text">
-              <string>Coordinate Reference System (CRS)</string>
-             </property>
-            </widget>
-           </item>
-           <item>
             <widget class="QScrollArea" name="mOptionsScrollArea_08">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
@@ -3827,8 +3718,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>491</width>
-                <height>624</height>
+                <width>650</width>
+                <height>679</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_15">
@@ -3846,7 +3737,7 @@
                 </spacer>
                </item>
                <item row="2" column="0">
-                <widget class="QGroupBox" name="grpProjectionBehaviour">
+                <widget class="QgsCollapsibleGroupBox" name="grpProjectionBehaviour">
                  <property name="title">
                   <string>CRS for new layers</string>
                  </property>
@@ -3922,7 +3813,7 @@
                 </widget>
                </item>
                <item row="1" column="0">
-                <widget class="QGroupBox" name="grpOtfTransform">
+                <widget class="QgsCollapsibleGroupBox" name="grpOtfTransform">
                  <property name="title">
                   <string>Default CRS for new projects</string>
                  </property>
@@ -3979,7 +3870,7 @@
                 </widget>
                </item>
                <item row="3" column="0">
-                <widget class="QGroupBox" name="mDefaultDatumTransformGroupBox">
+                <widget class="QgsCollapsibleGroupBox" name="mDefaultDatumTransformGroupBox">
                  <property name="title">
                   <string>Default datum transformations</string>
                  </property>
@@ -4023,31 +3914,31 @@
                     </item>
                    </layout>
                   </item>
+                  <item row="1" column="0">
+                   <widget class="QTreeWidget" name="mDefaultDatumTransformTreeWidget">
+                    <column>
+                     <property name="text">
+                      <string>Source CRS</string>
+                     </property>
+                    </column>
+                    <column>
+                     <property name="text">
+                      <string>Destination CRS</string>
+                     </property>
+                    </column>
+                    <column>
+                     <property name="text">
+                      <string>Source datum transform</string>
+                     </property>
+                    </column>
+                    <column>
+                     <property name="text">
+                      <string>Destination datum transform</string>
+                     </property>
+                    </column>
+                   </widget>
+                  </item>
                  </layout>
-                </widget>
-               </item>
-               <item row="4" column="0">
-                <widget class="QTreeWidget" name="mDefaultDatumTransformTreeWidget">
-                 <column>
-                  <property name="text">
-                   <string>Source CRS</string>
-                  </property>
-                 </column>
-                 <column>
-                  <property name="text">
-                   <string>Destination CRS</string>
-                  </property>
-                 </column>
-                 <column>
-                  <property name="text">
-                   <string>Source datum transform</string>
-                  </property>
-                 </column>
-                 <column>
-                  <property name="text">
-                   <string>Destination datum transform</string>
-                  </property>
-                 </column>
                 </widget>
                </item>
               </layout>
@@ -4062,16 +3953,6 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QLabel" name="label_47">
-             <property name="styleSheet">
-              <string notr="true">font-weight:bold;</string>
-             </property>
-             <property name="text">
-              <string>Locale</string>
-             </property>
-            </widget>
-           </item>
-           <item>
             <widget class="QScrollArea" name="mOptionsScrollArea_09">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
@@ -4084,8 +3965,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>225</width>
-                <height>201</height>
+                <width>627</width>
+                <height>585</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_32">
@@ -4162,16 +4043,6 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QLabel" name="label_48">
-             <property name="styleSheet">
-              <string notr="true">font-weight:bold;</string>
-             </property>
-             <property name="text">
-              <string>Network</string>
-             </property>
-            </widget>
-           </item>
-           <item>
             <widget class="QScrollArea" name="mOptionsScrollArea_10">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
@@ -4184,8 +4055,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>389</width>
-                <height>586</height>
+                <width>611</width>
+                <height>685</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_33">
@@ -4536,19 +4407,18 @@
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
-   <class>QgsColorButton</class>
-   <extends>QPushButton</extends>
-   <header>qgscolorbutton.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsCollapsibleGroupBox</class>
    <extends>QGroupBox</extends>
    <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>QgsColorButton</class>
+   <extends>QPushButton</extends>
+   <header>qgscolorbutton.h</header>
+  </customwidget>
  </customwidgets>
  <resources>
-  <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>
  </resources>
  <connections>

--- a/src/ui/qgspluginmanagerbase.ui
+++ b/src/ui/qgspluginmanagerbase.ui
@@ -242,7 +242,7 @@
           <number>0</number>
          </property>
          <property name="currentIndex">
-          <number>0</number>
+          <number>1</number>
          </property>
          <widget class="QWidget" name="pagePlugins">
           <layout class="QVBoxLayout" name="verticalLayout_8">
@@ -258,25 +258,6 @@
            <property name="bottomMargin">
             <number>0</number>
            </property>
-           <item>
-            <widget class="QLabel" name="lbStatusFilter">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="font">
-              <font>
-               <weight>75</weight>
-               <bold>true</bold>
-              </font>
-             </property>
-             <property name="text">
-              <string>Plugins</string>
-             </property>
-            </widget>
-           </item>
            <item>
             <layout class="QHBoxLayout" name="horizontalLayout_4">
              <item>
@@ -487,19 +468,6 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QLabel" name="lblSettingsTab">
-             <property name="font">
-              <font>
-               <weight>75</weight>
-               <bold>true</bold>
-              </font>
-             </property>
-             <property name="text">
-              <string>Settings</string>
-             </property>
-            </widget>
-           </item>
-           <item>
             <widget class="QFrame" name="frameSettings">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -524,15 +492,15 @@
                   <rect>
                    <x>0</x>
                    <y>0</y>
-                   <width>360</width>
-                   <height>731</height>
+                   <width>573</width>
+                   <height>734</height>
                   </rect>
                  </property>
                  <layout class="QVBoxLayout" name="verticalLayout_10">
                   <item>
                    <widget class="QLabel" name="labelNoPython">
                     <property name="sizePolicy">
-                     <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
+                     <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
                       <horstretch>0</horstretch>
                       <verstretch>0</verstretch>
                      </sizepolicy>
@@ -971,15 +939,15 @@ p, li { white-space: pre-wrap; }
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
-   <class>QgsFilterLineEdit</class>
-   <extends>QLineEdit</extends>
-   <header>qgsfilterlineedit.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsCollapsibleGroupBox</class>
    <extends>QGroupBox</extends>
    <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsFilterLineEdit</class>
+   <extends>QLineEdit</extends>
+   <header>qgsfilterlineedit.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/qgsprojectpropertiesbase.ui
+++ b/src/ui/qgsprojectpropertiesbase.ui
@@ -199,22 +199,6 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QLabel" name="label_4">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="styleSheet">
-              <string notr="true">font-weight:bold;</string>
-             </property>
-             <property name="text">
-              <string>General</string>
-             </property>
-            </widget>
-           </item>
-           <item>
             <widget class="QScrollArea" name="scrollArea_2">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
@@ -227,8 +211,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>640</width>
-                <height>712</height>
+                <width>653</width>
+                <height>708</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_8">
@@ -770,22 +754,6 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QLabel" name="label_5">
-             <property name="sizePolicy">
-              <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-               <horstretch>0</horstretch>
-               <verstretch>0</verstretch>
-              </sizepolicy>
-             </property>
-             <property name="styleSheet">
-              <string notr="true">font-weight:bold;</string>
-             </property>
-             <property name="text">
-              <string>Coordinate Reference System (CRS)</string>
-             </property>
-            </widget>
-           </item>
-           <item>
             <widget class="QScrollArea" name="scrollArea">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
@@ -798,8 +766,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>323</width>
-                <height>46</height>
+                <width>653</width>
+                <height>708</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_7">
@@ -836,16 +804,6 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QLabel" name="label_6">
-             <property name="styleSheet">
-              <string notr="true">font-weight:bold;</string>
-             </property>
-             <property name="text">
-              <string>Identifiable layers</string>
-             </property>
-            </widget>
-           </item>
-           <item>
             <widget class="QScrollArea" name="scrollArea_3">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
@@ -858,8 +816,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>133</width>
-                <height>100</height>
+                <width>653</width>
+                <height>708</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_10">
@@ -918,16 +876,6 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QLabel" name="label_7">
-             <property name="styleSheet">
-              <string notr="true">font-weight:bold;</string>
-             </property>
-             <property name="text">
-              <string>Default styles</string>
-             </property>
-            </widget>
-           </item>
-           <item>
             <widget class="QScrollArea" name="scrollArea_4">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
@@ -940,8 +888,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>371</width>
-                <height>336</height>
+                <width>653</width>
+                <height>708</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_12">
@@ -1296,16 +1244,6 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QLabel" name="label_8">
-             <property name="styleSheet">
-              <string notr="true">font-weight:bold;</string>
-             </property>
-             <property name="text">
-              <string>OWS server</string>
-             </property>
-            </widget>
-           </item>
-           <item>
             <widget class="QScrollArea" name="scrollArea_5">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
@@ -1318,8 +1256,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>491</width>
-                <height>1347</height>
+                <width>637</width>
+                <height>1535</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_13">
@@ -1994,16 +1932,6 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QLabel" name="label_20">
-             <property name="styleSheet">
-              <string notr="true">font-weight:bold;</string>
-             </property>
-             <property name="text">
-              <string>Macros</string>
-             </property>
-            </widget>
-           </item>
-           <item>
             <widget class="QScrollArea" name="scrollArea_6">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
@@ -2016,8 +1944,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>163</width>
-                <height>111</height>
+                <width>653</width>
+                <height>708</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_17">
@@ -2106,15 +2034,15 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsColorButton</class>
-   <extends>QPushButton</extends>
-   <header>qgscolorbutton.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsCollapsibleGroupBox</class>
    <extends>QGroupBox</extends>
    <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsColorButton</class>
+   <extends>QPushButton</extends>
+   <header>qgscolorbutton.h</header>
   </customwidget>
   <customwidget>
    <class>QgsProjectionSelector</class>

--- a/src/ui/qgsrasterlayerpropertiesbase.ui
+++ b/src/ui/qgsrasterlayerpropertiesbase.ui
@@ -190,16 +190,6 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QLabel" name="label_7">
-             <property name="styleSheet">
-              <string notr="true">font-weight:bold;</string>
-             </property>
-             <property name="text">
-              <string>General</string>
-             </property>
-            </widget>
-           </item>
-           <item>
             <widget class="QScrollArea" name="scrollArea_3">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
@@ -212,8 +202,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>693</width>
-                <height>646</height>
+                <width>700</width>
+                <height>686</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_7">
@@ -379,11 +369,11 @@
                   <string notr="true">rastergeneral</string>
                  </property>
                  <layout class="QGridLayout" name="_5">
-                  <property name="verticalSpacing">
-                   <number>6</number>
-                  </property>
                   <property name="margin">
                    <number>11</number>
+                  </property>
+                  <property name="verticalSpacing">
+                   <number>6</number>
                   </property>
                   <item row="0" column="4">
                    <widget class="QLabel" name="textLabel1_2_2_2">
@@ -661,16 +651,6 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QLabel" name="label">
-             <property name="styleSheet">
-              <string notr="true">font-weight:bold;</string>
-             </property>
-             <property name="text">
-              <string>Style</string>
-             </property>
-            </widget>
-           </item>
-           <item>
             <widget class="QScrollArea" name="scrollArea">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
@@ -683,8 +663,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>610</width>
-                <height>360</height>
+                <width>700</width>
+                <height>686</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_13">
@@ -1176,16 +1156,6 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QLabel" name="label_4">
-             <property name="styleSheet">
-              <string notr="true">font-weight:bold;</string>
-             </property>
-             <property name="text">
-              <string>Transparency</string>
-             </property>
-            </widget>
-           </item>
-           <item>
             <widget class="QScrollArea" name="scrollArea_2">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
@@ -1198,8 +1168,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>472</width>
-                <height>439</height>
+                <width>700</width>
+                <height>686</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_5">
@@ -1593,16 +1563,6 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QLabel" name="label_10">
-             <property name="styleSheet">
-              <string notr="true">font-weight:bold;</string>
-             </property>
-             <property name="text">
-              <string>Pyramids</string>
-             </property>
-            </widget>
-           </item>
-           <item>
             <widget class="QScrollArea" name="scrollArea_5">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
@@ -1615,8 +1575,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>632</width>
-                <height>199</height>
+                <width>700</width>
+                <height>686</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_12">
@@ -1679,8 +1639,8 @@
                        <string>&lt;!DOCTYPE HTML PUBLIC &quot;-//W3C//DTD HTML 4.0//EN&quot; &quot;http://www.w3.org/TR/REC-html40/strict.dtd&quot;&gt;
 &lt;html&gt;&lt;head&gt;&lt;meta name=&quot;qrichtext&quot; content=&quot;1&quot; /&gt;&lt;style type=&quot;text/css&quot;&gt;
 p, li { white-space: pre-wrap; }
-&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Lucida Grande'; font-size:13pt; font-weight:400; font-style:normal;&quot;&gt;
-&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Cantarell'; font-size:11pt;&quot;&gt;&lt;br /&gt;&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+&lt;/style&gt;&lt;/head&gt;&lt;body style=&quot; font-family:'Ubuntu'; font-size:11pt; font-weight:400; font-style:normal;&quot;&gt;
+&lt;p style=&quot; margin-top:0px; margin-bottom:0px; margin-left:0px; margin-right:0px; -qt-block-indent:0; text-indent:0px;&quot;&gt;&lt;span style=&quot; font-family:'Cantarell';&quot;&gt;&lt;br /&gt;&lt;/span&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
                       </property>
                      </widget>
                     </item>
@@ -1764,16 +1724,6 @@ p, li { white-space: pre-wrap; }
             <number>0</number>
            </property>
            <item>
-            <widget class="QLabel" name="label_13">
-             <property name="styleSheet">
-              <string notr="true">font-weight:bold;</string>
-             </property>
-             <property name="text">
-              <string>Histogram</string>
-             </property>
-            </widget>
-           </item>
-           <item>
             <widget class="QScrollArea" name="scrollArea_6">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
@@ -1786,8 +1736,8 @@ p, li { white-space: pre-wrap; }
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>98</width>
-                <height>31</height>
+                <width>700</width>
+                <height>686</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_16">
@@ -1824,16 +1774,6 @@ p, li { white-space: pre-wrap; }
             <number>0</number>
            </property>
            <item>
-            <widget class="QLabel" name="label_9">
-             <property name="styleSheet">
-              <string notr="true">font-weight:bold;</string>
-             </property>
-             <property name="text">
-              <string>Metadata</string>
-             </property>
-            </widget>
-           </item>
-           <item>
             <widget class="QScrollArea" name="scrollArea_4">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
@@ -1846,8 +1786,8 @@ p, li { white-space: pre-wrap; }
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>195</width>
-                <height>267</height>
+                <width>700</width>
+                <height>686</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_10">
@@ -1954,52 +1894,52 @@ p, li { white-space: pre-wrap; }
                   <string notr="true">vectormeta</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_7">
-                 <item row="0" column="0">
-                  <widget class="QLabel" name="mLayerAttributionLabel">
-                   <property name="text">
-                    <string>Title</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="1">
-                  <widget class="QLineEdit" name="mLayerAttributionLineEdit"/>
-                 </item>
-                 <item row="2" column="0">
-                  <widget class="QLabel" name="mLayerAttributionUrlLabel">
-                   <property name="text">
-                    <string>Url</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="2" column="1">
-                  <widget class="QLineEdit" name="mLayerAttributionUrlLineEdit"/>
-                 </item>
-                </layout>
-               </widget>
-              </item>
-              <item>
-               <widget class="QgsCollapsibleGroupBox" name="mMetaMetaUrlGrpBx">
-                <property name="title">
-                 <string>MetadataUrl</string>
-                </property>
-                <property name="syncGroup" stdset="0">
-                 <string notr="true">vectormeta</string>
-                </property>
-                <layout class="QGridLayout" name="gridLayout_9">
-                 <item row="0" column="0">
-                  <widget class="QLabel" name="mLayerMetadataUrlLabel">
-                   <property name="text">
-                    <string>Url</string>
-                   </property>
-                  </widget>
-                 </item>
-                 <item row="0" column="1">
-                  <widget class="QLineEdit" name="mLayerMetadataUrlLineEdit"/>
-                 </item>
-                 <item row="1" column="1">
-                  <layout class="QHBoxLayout" name="horizontalLayout_8">
-                   <item>
-                    <widget class="QLabel" name="mLayerMetadataUrlTypeLabel">
+                  <item row="0" column="0">
+                   <widget class="QLabel" name="mLayerAttributionLabel">
+                    <property name="text">
+                     <string>Title</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="1">
+                   <widget class="QLineEdit" name="mLayerAttributionLineEdit"/>
+                  </item>
+                  <item row="2" column="0">
+                   <widget class="QLabel" name="mLayerAttributionUrlLabel">
+                    <property name="text">
+                     <string>Url</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="2" column="1">
+                   <widget class="QLineEdit" name="mLayerAttributionUrlLineEdit"/>
+                  </item>
+                 </layout>
+                </widget>
+               </item>
+               <item>
+                <widget class="QgsCollapsibleGroupBox" name="mMetaMetaUrlGrpBx">
+                 <property name="title">
+                  <string>MetadataUrl</string>
+                 </property>
+                 <property name="syncGroup" stdset="0">
+                  <string notr="true">vectormeta</string>
+                 </property>
+                 <layout class="QGridLayout" name="gridLayout_9">
+                  <item row="0" column="0">
+                   <widget class="QLabel" name="mLayerMetadataUrlLabel">
+                    <property name="text">
+                     <string>Url</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="1">
+                   <widget class="QLineEdit" name="mLayerMetadataUrlLineEdit"/>
+                  </item>
+                  <item row="1" column="1">
+                   <layout class="QHBoxLayout" name="horizontalLayout_8">
+                    <item>
+                     <widget class="QLabel" name="mLayerMetadataUrlTypeLabel">
                       <property name="text">
                        <string>Type</string>
                       </property>
@@ -2009,7 +1949,7 @@ p, li { white-space: pre-wrap; }
                      <widget class="QComboBox" name="mLayerMetadataUrlTypeComboBox">
                       <item>
                        <property name="text">
-                        <string notr="true"></string>
+                        <string notr="true"/>
                        </property>
                       </item>
                       <item>
@@ -2035,7 +1975,7 @@ p, li { white-space: pre-wrap; }
                      <widget class="QComboBox" name="mLayerMetadataUrlFormatComboBox">
                       <item>
                        <property name="text">
-                        <string notr="true"></string>
+                        <string notr="true"/>
                        </property>
                       </item>
                       <item>
@@ -2177,15 +2117,15 @@ p, li { white-space: pre-wrap; }
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsScaleComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qgsscalecombobox.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsCollapsibleGroupBox</class>
    <extends>QGroupBox</extends>
    <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsBlendModeComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgsblendmodecombobox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsColorButton</class>
@@ -2193,9 +2133,9 @@ p, li { white-space: pre-wrap; }
    <header>qgscolorbutton.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsBlendModeComboBox</class>
+   <class>QgsScaleComboBox</class>
    <extends>QComboBox</extends>
-   <header>qgsblendmodecombobox.h</header>
+   <header>qgsscalecombobox.h</header>
   </customwidget>
  </customwidgets>
  <resources>

--- a/src/ui/qgsvectorlayerpropertiesbase.ui
+++ b/src/ui/qgsvectorlayerpropertiesbase.ui
@@ -246,23 +246,13 @@
           </sizepolicy>
          </property>
          <property name="currentIndex">
-          <number>0</number>
+          <number>7</number>
          </property>
          <widget class="QWidget" name="mOptsPage_General">
           <layout class="QVBoxLayout" name="verticalLayout_14">
            <property name="margin">
             <number>0</number>
            </property>
-           <item>
-            <widget class="QLabel" name="label">
-             <property name="styleSheet">
-              <string notr="true">font-weight:bold;</string>
-             </property>
-             <property name="text">
-              <string>General</string>
-             </property>
-            </widget>
-           </item>
            <item>
             <widget class="QScrollArea" name="scrollArea">
              <property name="frameShape">
@@ -276,8 +266,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>756</width>
-                <height>476</height>
+                <width>739</width>
+                <height>525</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_13">
@@ -693,16 +683,6 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QLabel" name="label_5">
-             <property name="styleSheet">
-              <string notr="true">font-weight:bold;</string>
-             </property>
-             <property name="text">
-              <string>Style</string>
-             </property>
-            </widget>
-           </item>
-           <item>
             <widget class="QScrollArea" name="scrollArea_3">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
@@ -715,8 +695,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>765</width>
-                <height>545</height>
+                <width>755</width>
+                <height>452</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_18">
@@ -754,16 +734,6 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QLabel" name="label_6">
-             <property name="styleSheet">
-              <string notr="true">font-weight:bold;</string>
-             </property>
-             <property name="text">
-              <string>Labels</string>
-             </property>
-            </widget>
-           </item>
-           <item>
             <widget class="QFrame" name="labelingFrame">
              <property name="sizePolicy">
               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -787,16 +757,6 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QLabel" name="label_11">
-             <property name="styleSheet">
-              <string notr="true">font-weight:bold;</string>
-             </property>
-             <property name="text">
-              <string>Labels (deprecated)</string>
-             </property>
-            </widget>
-           </item>
-           <item>
             <widget class="QScrollArea" name="scrollArea_9">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
@@ -809,8 +769,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>83</width>
-                <height>33</height>
+                <width>755</width>
+                <height>452</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_28">
@@ -861,16 +821,6 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QLabel" name="label_7">
-             <property name="styleSheet">
-              <string notr="true">font-weight:bold;</string>
-             </property>
-             <property name="text">
-              <string>Fields</string>
-             </property>
-            </widget>
-           </item>
-           <item>
             <widget class="QScrollArea" name="scrollArea_5">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
@@ -883,8 +833,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>83</width>
-                <height>16</height>
+                <width>755</width>
+                <height>452</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_20">
@@ -913,16 +863,6 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QLabel" name="label_15">
-             <property name="styleSheet">
-              <string notr="true">font-weight:bold;</string>
-             </property>
-             <property name="text">
-              <string>Rendering</string>
-             </property>
-            </widget>
-           </item>
-           <item>
             <widget class="QScrollArea" name="scrollArea_19">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
@@ -935,8 +875,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>374</width>
-                <height>255</height>
+                <width>755</width>
+                <height>452</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_32">
@@ -968,23 +908,23 @@
                   </item>
                   <item row="1" column="2">
                    <widget class="QDoubleSpinBox" name="mSimplifyDrawingSpinBox">
+                    <property name="toolTip">
+                     <string>Higher values result in more simplification</string>
+                    </property>
                     <property name="decimals">
                      <number>2</number>
                     </property>
                     <property name="minimum">
-                     <number>1</number>
+                     <double>1.000000000000000</double>
                     </property>
                     <property name="maximum">
-                     <number>5</number>
+                     <double>5.000000000000000</double>
                     </property>
                     <property name="singleStep">
-                     <double>0.20</double>
+                     <double>0.200000000000000</double>
                     </property>
                     <property name="value">
-                      <double>1.0</double>
-                    </property>
-                    <property name="toolTip">
-                     <string>Higher values result in more simplification</string>
+                     <double>1.000000000000000</double>
                     </property>
                    </widget>
                   </item>
@@ -1010,7 +950,7 @@
                      </size>
                     </property>
                    </spacer>
-                  </item>                         
+                  </item>
                   <item row="2" column="1" colspan="4">
                    <widget class="QCheckBox" name="mSimplifyDrawingAtProvider">
                     <property name="text">
@@ -1046,16 +986,6 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QLabel" name="label_12">
-             <property name="styleSheet">
-              <string notr="true">font-weight:bold;</string>
-             </property>
-             <property name="text">
-              <string>Display</string>
-             </property>
-            </widget>
-           </item>
-           <item>
             <widget class="QScrollArea" name="scrollArea_10">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
@@ -1068,8 +998,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>385</width>
-                <height>161</height>
+                <width>755</width>
+                <height>452</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_26">
@@ -1217,16 +1147,6 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QLabel" name="label_8">
-             <property name="styleSheet">
-              <string notr="true">font-weight:bold;</string>
-             </property>
-             <property name="text">
-              <string>Actions</string>
-             </property>
-            </widget>
-           </item>
-           <item>
             <widget class="QScrollArea" name="scrollArea_6">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
@@ -1239,8 +1159,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>765</width>
-                <height>545</height>
+                <width>755</width>
+                <height>487</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_21">
@@ -1275,16 +1195,6 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QLabel" name="label_9">
-             <property name="styleSheet">
-              <string notr="true">font-weight:bold;</string>
-             </property>
-             <property name="text">
-              <string>Joins</string>
-             </property>
-            </widget>
-           </item>
-           <item>
             <widget class="QScrollArea" name="scrollArea_7">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
@@ -1297,8 +1207,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>91</width>
-                <height>123</height>
+                <width>755</width>
+                <height>487</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_23">
@@ -1306,74 +1216,65 @@
                 <number>0</number>
                </property>
                <item>
-                <widget class="QGroupBox" name="mJoinsGrpBx">
-                 <property name="title">
-                  <string/>
+                <widget class="QTreeWidget" name="mJoinTreeWidget">
+                 <property name="columnCount">
+                  <number>3</number>
                  </property>
-                 <layout class="QVBoxLayout" name="verticalLayout_22">
-                  <item>
-                   <widget class="QTreeWidget" name="mJoinTreeWidget">
-                    <property name="columnCount">
-                     <number>3</number>
-                    </property>
-                    <column>
-                     <property name="text">
-                      <string>Join layer</string>
-                     </property>
-                    </column>
-                    <column>
-                     <property name="text">
-                      <string>Join field</string>
-                     </property>
-                    </column>
-                    <column>
-                     <property name="text">
-                      <string>Target field</string>
-                     </property>
-                    </column>
-                   </widget>
-                  </item>
-                  <item>
-                   <layout class="QHBoxLayout" name="horizontalLayout">
-                    <item>
-                     <widget class="QPushButton" name="mButtonAddJoin">
-                      <property name="text">
-                       <string/>
-                      </property>
-                      <property name="icon">
-                       <iconset resource="../../images/images.qrc">
-                        <normaloff>:/images/themes/default/symbologyAdd.png</normaloff>:/images/themes/default/symbologyAdd.png</iconset>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QPushButton" name="mButtonRemoveJoin">
-                      <property name="text">
-                       <string/>
-                      </property>
-                      <property name="icon">
-                       <iconset resource="../../images/images.qrc">
-                        <normaloff>:/images/themes/default/symbologyRemove.png</normaloff>:/images/themes/default/symbologyRemove.png</iconset>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <spacer name="horizontalSpacer">
-                      <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
-                      </property>
-                      <property name="sizeHint" stdset="0">
-                       <size>
-                        <width>0</width>
-                        <height>23</height>
-                       </size>
-                      </property>
-                     </spacer>
-                    </item>
-                   </layout>
-                  </item>
-                 </layout>
+                 <column>
+                  <property name="text">
+                   <string>Join layer</string>
+                  </property>
+                 </column>
+                 <column>
+                  <property name="text">
+                   <string>Join field</string>
+                  </property>
+                 </column>
+                 <column>
+                  <property name="text">
+                   <string>Target field</string>
+                  </property>
+                 </column>
                 </widget>
+               </item>
+               <item>
+                <layout class="QHBoxLayout" name="horizontalLayout">
+                 <item>
+                  <widget class="QPushButton" name="mButtonAddJoin">
+                   <property name="text">
+                    <string/>
+                   </property>
+                   <property name="icon">
+                    <iconset resource="../../images/images.qrc">
+                     <normaloff>:/images/themes/default/symbologyAdd.png</normaloff>:/images/themes/default/symbologyAdd.png</iconset>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QPushButton" name="mButtonRemoveJoin">
+                   <property name="text">
+                    <string/>
+                   </property>
+                   <property name="icon">
+                    <iconset resource="../../images/images.qrc">
+                     <normaloff>:/images/themes/default/symbologyRemove.png</normaloff>:/images/themes/default/symbologyRemove.png</iconset>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <spacer name="horizontalSpacer">
+                   <property name="orientation">
+                    <enum>Qt::Horizontal</enum>
+                   </property>
+                   <property name="sizeHint" stdset="0">
+                    <size>
+                     <width>0</width>
+                     <height>23</height>
+                    </size>
+                   </property>
+                  </spacer>
+                 </item>
+                </layout>
                </item>
               </layout>
              </widget>
@@ -1387,16 +1288,6 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QLabel" name="label_10">
-             <property name="styleSheet">
-              <string notr="true">font-weight:bold;</string>
-             </property>
-             <property name="text">
-              <string>Diagrams</string>
-             </property>
-            </widget>
-           </item>
-           <item>
             <widget class="QScrollArea" name="scrollArea_8">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
@@ -1409,8 +1300,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>83</width>
-                <height>16</height>
+                <width>755</width>
+                <height>452</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_24">
@@ -1439,16 +1330,6 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QLabel" name="label_4">
-             <property name="styleSheet">
-              <string notr="true">font-weight:bold;</string>
-             </property>
-             <property name="text">
-              <string>Metadata</string>
-             </property>
-            </widget>
-           </item>
-           <item>
             <widget class="QScrollArea" name="scrollArea_2">
              <property name="frameShape">
               <enum>QFrame::NoFrame</enum>
@@ -1461,8 +1342,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>279</width>
-                <height>451</height>
+                <width>739</width>
+                <height>519</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_8">
@@ -1807,19 +1688,18 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsScaleComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qgsscalecombobox.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsCollapsibleGroupBox</class>
    <extends>QGroupBox</extends>
    <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>QgsScaleComboBox</class>
+   <extends>QComboBox</extends>
+   <header>qgsscalecombobox.h</header>
+  </customwidget>
  </customwidgets>
  <resources>
-  <include location="../../images/images.qrc"/>
   <include location="../../images/images.qrc"/>
  </resources>
  <connections>


### PR DESCRIPTION
I update these 3 dialogs: main options, raster properties and vector properties doing mainly two things:
- since the page titles are already written on the left panel, the labels on top were redundant, so I removed them
- I made the group boxes collapsible so you can collapse some settings you don't change quite often

Main options:
![image](https://f.cloud.github.com/assets/127259/1920584/75d62a58-7dec-11e3-9bda-661b3ecef247.png)

Raster layers:
![image](https://f.cloud.github.com/assets/127259/1921050/2bf92e14-7df4-11e3-87d7-982b506ff4ad.png)

Vector layers:
![image](https://f.cloud.github.com/assets/127259/1921027/e80f33ba-7df3-11e3-9a4b-9172b3fd0f3e.png)

For vector layers, I also (see previous image):
- moved the field buttons into their corresponding group box
- put the "attribute editor layout" and "python init function" on the same line to gain some room
