### PR TITLE
UI: dialog base: add current category to dialog title if in icon only mode

### DIFF
--- a/src/gui/qgsoptionsdialogbase.h
+++ b/src/gui/qgsoptionsdialogbase.h
@@ -64,8 +64,13 @@ class GUI_EXPORT QgsOptionsDialogBase : public QDialog
 
     /** Restore the base ui.
      * Sometimes useful to do at end of subclass's constructor.
+     * e.g. if setWindowTitle is used after initOptionsBase.
      */
     void restoreOptionsBaseUi();
+
+    /** determine if the options list is in icon only mode
+     */
+    bool iconOnly() {return mIconOnly;}
 
   protected slots:
     void updateOptionsListVerticalTabs();
@@ -83,6 +88,8 @@ class GUI_EXPORT QgsOptionsDialogBase : public QDialog
     QStackedWidget* mOptStackedWidget;
     QSplitter* mOptSplitter;
     QDialogButtonBox* mOptButtonBox;
+    QString mDialogTitle;
+    bool mIconOnly;
 };
 
 #endif // QGSOPTIONSDIALOGBASE_H


### PR DESCRIPTION
- the icon only mode status is saved in a private var (mIconOnly) so slots are not triggered if no changes are needed
- I reduced the width of the list widget in icon mode because text was visible on Ubuntu. Can someone chack this on Win and/or OSX?
