### PR TITLE
Bug #9360: fix bug whole layer not rendered (when simplify geometry activated)

### DIFF
--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -728,8 +728,8 @@ bool QgsVectorLayer::draw( QgsRenderContext& rendererContext )
       double sourceHypothenuse = sqrt( minimumSrcPoint.sqrDist( maximumSrcPoint ) );
       double targetHypothenuse = sqrt( minimumDstPoint.sqrDist( maximumDstPoint ) );
 
-      if ( sourceHypothenuse != 0 )
-        map2pixelTol *= targetHypothenuse / sourceHypothenuse;
+      if ( targetHypothenuse != 0 )
+        map2pixelTol *= ( sourceHypothenuse / targetHypothenuse );
     }
 
     QgsSimplifyMethod simplifyMethod;
@@ -1258,7 +1258,7 @@ bool QgsVectorLayer::setSubsetString( QString subset )
 
 bool QgsVectorLayer::simplifyDrawingCanbeApplied( int simplifyHint ) const
 {
-  return mDataProvider && !mEditBuffer && ( mSimplifyMethod.simplifyHints() & simplifyHint ) && ( !mCurrentRendererContext || mCurrentRendererContext->useRenderingOptimization() );
+  return mDataProvider && !mEditBuffer && ( hasGeometryType() && geometryType() != QGis::Point ) && ( mSimplifyMethod.simplifyHints() & simplifyHint ) && ( !mCurrentRendererContext || mCurrentRendererContext->useRenderingOptimization() );
 }
 
 QgsFeatureIterator QgsVectorLayer::getFeatures( const QgsFeatureRequest& request )

--- a/src/core/qgsvectorlayerfeatureiterator.cpp
+++ b/src/core/qgsvectorlayerfeatureiterator.cpp
@@ -455,7 +455,7 @@ bool QgsVectorLayerFeatureIterator::prepareSimplification( const QgsSimplifyMeth
   mEditGeometrySimplifier = NULL;
 
   // setup simplification for edited geometries to fetch
-  if ( !( mRequest.flags() & QgsFeatureRequest::NoGeometry ) && simplifyMethod.methodType() != QgsSimplifyMethod::NoSimplification )
+  if ( !( mRequest.flags() & QgsFeatureRequest::NoGeometry ) && simplifyMethod.methodType() != QgsSimplifyMethod::NoSimplification && L->hasGeometryType() && L->geometryType() != QGis::Point )
   {
     mEditGeometrySimplifier = QgsSimplifyMethod::createGeometrySimplifier( simplifyMethod );
     return mEditGeometrySimplifier != NULL;


### PR DESCRIPTION
This patch fixes bug #9360, it appears when a layer must be simplified and transformed.

http://hub.qgis.org/issues/9360
