### PR TITLE
Fix bug #9360-revival: fix whole layer not rendered (when simplify geometry activated)

### DIFF
--- a/src/providers/ogr/qgsogrfeatureiterator.cpp
+++ b/src/providers/ogr/qgsogrfeatureiterator.cpp
@@ -111,7 +111,7 @@ bool QgsOgrFeatureIterator::prepareSimplification( const QgsSimplifyMethod& simp
     QgsSimplifyMethod::MethodType methodType = simplifyMethod.methodType();
     Q_UNUSED( methodType);
 
-#if defined(HAVE_OGR_GEOMETRY_CLASS)
+#if defined(GDAL_VERSION_NUM) && defined(GDAL_COMPUTE_VERSION) && GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(1,11,0)
     if ( methodType == QgsSimplifyMethod::OptimizeForRendering )
     {
       int simplifyFlags = QgsMapToPixelSimplifier::SimplifyGeometry | QgsMapToPixelSimplifier::SimplifyEnvelope;
@@ -134,7 +134,7 @@ bool QgsOgrFeatureIterator::prepareSimplification( const QgsSimplifyMethod& simp
 
 bool QgsOgrFeatureIterator::providerCanSimplify( QgsSimplifyMethod::MethodType methodType ) const
 {
-#if defined(HAVE_OGR_GEOMETRY_CLASS)
+#if defined(GDAL_VERSION_NUM) && defined(GDAL_COMPUTE_VERSION) && GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(1,11,0)
   if ( methodType == QgsSimplifyMethod::OptimizeForRendering )
   {
     return true;

--- a/src/providers/ogr/qgsogrgeometrysimplifier.cpp
+++ b/src/providers/ogr/qgsogrgeometrysimplifier.cpp
@@ -18,6 +18,8 @@
 #include "qgsogrprovider.h"
 #include "qgsapplication.h"
 
+#include <ogr_geometry.h>
+
 QgsOgrAbstractGeometrySimplifier::~QgsOgrAbstractGeometrySimplifier()
 {
 }

--- a/src/providers/ogr/qgsogrgeometrysimplifier.h
+++ b/src/providers/ogr/qgsogrgeometrysimplifier.h
@@ -19,6 +19,7 @@
 
 #include "qgsmaptopixelgeometrysimplifier.h"
 #include <ogr_api.h>
+#include <ogr_geometry.h>
 
 /**
  * Abstract base class for simplify OGR-geometries using a specific algorithm
@@ -63,10 +64,18 @@ class QgsOgrMapToPixelSimplifier : public QgsOgrAbstractGeometrySimplifier, QgsM
     virtual ~QgsOgrMapToPixelSimplifier();
 
   private:
+    //! Point memory buffer for optimize the simplification process
+    OGRRawPoint* mPointBufferPtr;
+    //! Current Point memory buffer size
+    int mPointBufferCount;
+
     //! Simplifies the OGR-geometry (Removing duplicated points) when is applied the specified map2pixel context
-    bool simplifyOgrGeometry( QGis::GeometryType geometryType, const QgsRectangle& envelope, double *xptr, double *yptr, int pointCount, int &pointSimplifiedCount );
+    bool simplifyOgrGeometry( QGis::GeometryType geometryType, double* xptr, int xStride, double* yptr, int yStride, int pointCount, int& pointSimplifiedCount );
     //! Simplifies the OGR-geometry (Removing duplicated points) when is applied the specified map2pixel context
-    bool simplifyOgrGeometry( OGRGeometryH geometry, bool isaLinearRing );
+    bool simplifyOgrGeometry( OGRGeometry* geometry, bool isaLinearRing );
+
+    //! Returns a point buffer of the specified size
+    OGRRawPoint* mallocPoints( int numPoints );
 
   public:
     //! Simplifies the specified geometry

--- a/src/providers/ogr/qgsogrgeometrysimplifier.h
+++ b/src/providers/ogr/qgsogrgeometrysimplifier.h
@@ -19,7 +19,9 @@
 
 #include "qgsmaptopixelgeometrysimplifier.h"
 #include <ogr_api.h>
-#include <ogr_geometry.h>
+
+class OGRRawPoint;
+class OGRGeometry;
 
 /**
  * Abstract base class for simplify OGR-geometries using a specific algorithm

--- a/src/providers/ogr/qgsogrgeometrysimplifier.h
+++ b/src/providers/ogr/qgsogrgeometrysimplifier.h
@@ -20,7 +20,12 @@
 #include "qgsmaptopixelgeometrysimplifier.h"
 #include <ogr_api.h>
 
-class OGRRawPoint;
+// Enable OGR-simplification on provider side when OGRGeometry class is available
+#if defined(__cplusplus)
+ #define HAVE_OGR_GEOMETRY_CLASS 1
+ class OGRGeometry;
+ class OGRRawPoint;
+#endif
 
 /**
  * Abstract base class for simplify OGR-geometries using a specific algorithm
@@ -52,6 +57,7 @@ class QgsOgrTopologyPreservingSimplifier : public QgsOgrAbstractGeometrySimplifi
 };
 #endif
 
+#if defined(HAVE_OGR_GEOMETRY_CLASS)
 /**
  * OGR implementation of GeometrySimplifier using the "MapToPixel" algorithm
  *
@@ -73,17 +79,15 @@ class QgsOgrMapToPixelSimplifier : public QgsOgrAbstractGeometrySimplifier, QgsM
     //! Simplifies the OGR-geometry (Removing duplicated points) when is applied the specified map2pixel context
     bool simplifyOgrGeometry( QGis::GeometryType geometryType, double* xptr, int xStride, double* yptr, int yStride, int pointCount, int& pointSimplifiedCount );
     //! Simplifies the OGR-geometry (Removing duplicated points) when is applied the specified map2pixel context
-    bool simplifyOgrGeometry( OGRGeometryH geometry, bool isaLinearRing );
+    bool simplifyOgrGeometry( OGRGeometry* geometry, bool isaLinearRing );
 
     //! Returns a point buffer of the specified size
     OGRRawPoint* mallocPoints( int numPoints );
-
-    //! Load a point array to the specified LineString geometry 
-    static void setGeometryPoints( OGRGeometryH geometry, OGRRawPoint* points, int numPoints, bool isaLinearRing );
 
   public:
     //! Simplifies the specified geometry
     virtual bool simplifyGeometry( OGRGeometryH geometry );
 };
+#endif
 
 #endif // QGSOGRGEOMETRYSIMPLIFIER_H

--- a/src/providers/ogr/qgsogrgeometrysimplifier.h
+++ b/src/providers/ogr/qgsogrgeometrysimplifier.h
@@ -21,7 +21,6 @@
 #include <ogr_api.h>
 
 class OGRRawPoint;
-class OGRGeometry;
 
 /**
  * Abstract base class for simplify OGR-geometries using a specific algorithm
@@ -74,10 +73,13 @@ class QgsOgrMapToPixelSimplifier : public QgsOgrAbstractGeometrySimplifier, QgsM
     //! Simplifies the OGR-geometry (Removing duplicated points) when is applied the specified map2pixel context
     bool simplifyOgrGeometry( QGis::GeometryType geometryType, double* xptr, int xStride, double* yptr, int yStride, int pointCount, int& pointSimplifiedCount );
     //! Simplifies the OGR-geometry (Removing duplicated points) when is applied the specified map2pixel context
-    bool simplifyOgrGeometry( OGRGeometry* geometry, bool isaLinearRing );
+    bool simplifyOgrGeometry( OGRGeometryH geometry, bool isaLinearRing );
 
     //! Returns a point buffer of the specified size
     OGRRawPoint* mallocPoints( int numPoints );
+
+    //! Load a point array to the specified LineString geometry 
+    static void setGeometryPoints( OGRGeometryH geometry, OGRRawPoint* points, int numPoints, bool isaLinearRing );
 
   public:
     //! Simplifies the specified geometry

--- a/src/providers/ogr/qgsogrgeometrysimplifier.h
+++ b/src/providers/ogr/qgsogrgeometrysimplifier.h
@@ -20,12 +20,27 @@
 #include "qgsmaptopixelgeometrysimplifier.h"
 #include <ogr_api.h>
 
-// Enable OGR-simplification on provider side when OGRGeometry class is available
+/* TODO:
+ * Disable OGR-simplification on provider side because of OGRGeometry class
+ * (GDAL C++ API) is not available in current QGIS builds.
+ * This simplification is ~5-10% faster than simplification on QGIS side
+ * (for very complex polygons up to ~20%).
+ *
+ * While GDAL C API has not published the needed method 'OGR_G_SetPoints()'
+ * to rewrite the geometry of a LineString/LinearRing in one single call,
+ * we can not enable the OGR-simplification to change the current disabled
+ * references of OGRGeometry* (GDAL C++ API) to OGRGeometryH (GDAL C API).
+ *
+ * Search in 'qgsogrgeometrysimplifier.cpp' : lineString->setPoints(...);
+ * We can not use 'OGR_G_SetPoint(...)' because of each call reallocs the
+ * point array of the geometry and it is very-very slow.
+ *
 #if defined(__cplusplus)
  #define HAVE_OGR_GEOMETRY_CLASS 1
  class OGRGeometry;
  class OGRRawPoint;
 #endif
+ */
 
 /**
  * Abstract base class for simplify OGR-geometries using a specific algorithm

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -45,6 +45,7 @@ email                : sherman at mrcc.com
 #include "qgsgeometry.h"
 #include "qgscoordinatereferencesystem.h"
 #include "qgsvectorlayerimport.h"
+#include "qgsogrgeometrysimplifier.h"
 
 static const QString TEXT_PROVIDER_KEY = "ogr";
 static const QString TEXT_PROVIDER_DESCRIPTION =
@@ -1495,7 +1496,12 @@ int QgsOgrProvider::capabilities() const
     }
 
     // supports geometry simplification on provider side
-    ability |= ( QgsVectorDataProvider::SimplifyGeometries | QgsVectorDataProvider::SimplifyGeometriesWithTopologicalValidation );
+#if defined(HAVE_OGR_GEOMETRY_CLASS)
+    ability |= QgsVectorDataProvider::SimplifyGeometries;
+#endif
+#if defined(GDAL_VERSION_NUM) && GDAL_VERSION_NUM >= 1900
+    ability |= QgsVectorDataProvider::SimplifyGeometriesWithTopologicalValidation;
+#endif
   }
 
   return ability;

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -45,7 +45,6 @@ email                : sherman at mrcc.com
 #include "qgsgeometry.h"
 #include "qgscoordinatereferencesystem.h"
 #include "qgsvectorlayerimport.h"
-#include "qgsogrgeometrysimplifier.h"
 
 static const QString TEXT_PROVIDER_KEY = "ogr";
 static const QString TEXT_PROVIDER_DESCRIPTION =
@@ -1496,7 +1495,7 @@ int QgsOgrProvider::capabilities() const
     }
 
     // supports geometry simplification on provider side
-#if defined(HAVE_OGR_GEOMETRY_CLASS)
+#if defined(GDAL_VERSION_NUM) && defined(GDAL_COMPUTE_VERSION) && GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(1,11,0)
     ability |= QgsVectorDataProvider::SimplifyGeometries;
 #endif
 #if defined(GDAL_VERSION_NUM) && GDAL_VERSION_NUM >= 1900


### PR DESCRIPTION
Ths patch fixes the bug #9360 when the code was translated from OGRGeometry\* to OGRGeometryH classes in commit (https://github.com/qgis/QGIS/commit/3305a6c77903f1ef9cce012f52ff49c8e35f269a)

Changes:
- Restore OGRGeometry\* management to resize the simplified geometry with 'lineString->setPoints(...)'
- Restore the shared point buffer to optimize the memory for simplification of large datasets
