### PR TITLE
[feature] Action to set a feature as the current atlas feature - sponsored by SIGE Edit - version 2

### DIFF
--- a/src/app/composer/qgscomposer.h
+++ b/src/app/composer/qgscomposer.h
@@ -38,6 +38,7 @@ class QgsComposerView;
 class QgsComposition;
 class QgsMapCanvas;
 class QgsAtlasComposition;
+class QgsMapLayerAction;
 
 class QGridLayout;
 class QDomNode;
@@ -475,6 +476,9 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
     //! Exports either either the whole atlas or just the current feature as a PDF, depending on mode
     void exportCompositionAsPDF( QgsComposer::OutputMode mode );
 
+    //! Updates the "set as atlas feature" map layer action, removing it if atlas is disabled
+    void updateAtlasMapLayerAction( bool atlasEnabled );
+
     /**Composer title*/
     QString mTitle;
 
@@ -551,6 +555,8 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
     //! @note added in 1.9
     QMenu* mHelpMenu;
 
+    QgsMapLayerAction* mAtlasFeatureAction;
+
   signals:
     void printAsRasterChanged( bool state );
 
@@ -579,6 +585,13 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
     //! Toggles the state of the atlas preview and navigation controls
     //! @note added in 2.1
     void toggleAtlasControls( bool atlasEnabled );
+
+    //! Sets the specified feature as the current atlas feature
+    //! @note added in 2.1
+    void setAtlasFeature( QgsMapLayer* layer, QgsFeature * feat );
+
+    //! Updates the "set as atlas feature" map layer action when atlas coverage layer changes
+    void updateAtlasMapLayerAction( QgsVectorLayer* coverageLayer );
 };
 
 #endif

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -622,6 +622,10 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     //! Opens the options dialog
     void showOptionsDialog( QWidget *parent = 0, QString currentPage = QString() );
 
+    /** Refreshes the state of the layer actions toolbar action
+      * @note added in 2.1 */
+    void refreshActionFeatureAction();
+
   protected:
 
     //! Handle state changes (WindowTitleChange)

--- a/src/app/qgsidentifyresultsdialog.h
+++ b/src/app/qgsidentifyresultsdialog.h
@@ -26,6 +26,7 @@
 #include "qgsfield.h"
 #include "qgsmaptoolidentify.h"
 #include "qgscoordinatereferencesystem.h"
+#include "qgsmaplayeractionregistry.h"
 
 #include <QWidget>
 #include <QList>
@@ -199,6 +200,8 @@ class APP_EXPORT QgsIdentifyResultsDialog: public QDialog, private Ui::QgsIdenti
     QgsMapCanvas *mCanvas;
     QList<QgsFeature> mFeatures;
 
+    QList< QgsMapLayerAction* > mMapLayerActions;
+
     QgsMapLayer *layer( QTreeWidgetItem *item );
     QgsVectorLayer *vectorLayer( QTreeWidgetItem *item );
     QgsRasterLayer *rasterLayer( QTreeWidgetItem *item );
@@ -218,7 +221,27 @@ class APP_EXPORT QgsIdentifyResultsDialog: public QDialog, private Ui::QgsIdenti
 
     void doAction( QTreeWidgetItem *item, int action );
 
+    void doMapLayerAction( QTreeWidgetItem *item, QgsMapLayerAction* action );
+
     QDockWidget *mDock;
+};
+
+class QgsIdentifyResultsDialogMapLayerAction : public QAction
+{
+    Q_OBJECT
+
+  public:
+    QgsIdentifyResultsDialogMapLayerAction( const QString &name, QObject *parent, QgsMapLayerAction* action, QgsMapLayer* layer, QgsFeature * f ) :
+        QAction( name, parent ), mAction( action ), mFeature( f ), mLayer( layer )
+    {}
+
+  public slots:
+    void execute();
+
+  private:
+    QgsMapLayerAction* mAction;
+    QgsFeature* mFeature;
+    QgsMapLayer* mLayer;
 };
 
 #endif

--- a/src/core/composer/qgsatlascomposition.cpp
+++ b/src/core/composer/qgsatlascomposition.cpp
@@ -372,6 +372,12 @@ void QgsAtlasComposition::lastFeature()
   prepareForFeature( mCurrentFeatureNo );
 }
 
+void QgsAtlasComposition::prepareForFeature( QgsFeature * feat )
+{
+  int featureI = mFeatureIds.indexOf( feat->id() );
+  prepareForFeature( featureI );
+}
+
 void QgsAtlasComposition::prepareForFeature( int featureI )
 {
   if ( !mCoverageLayer )

--- a/src/core/composer/qgsatlascomposition.h
+++ b/src/core/composer/qgsatlascomposition.h
@@ -110,6 +110,7 @@ class CORE_EXPORT QgsAtlasComposition : public QObject
 
     /** Prepare the atlas map for the given feature. Sets the extent and context variables */
     void prepareForFeature( int i );
+    void prepareForFeature( QgsFeature * feat );
 
     /** Returns the current filename. Must be called after prepareForFeature( i ) */
     const QString& currentFilename() const;
@@ -174,6 +175,7 @@ class CORE_EXPORT QgsAtlasComposition : public QObject
 
   public:
     typedef QMap< QgsFeatureId, QVariant > SorterKeys;
+
   private:
     // value of field that is used for ordering of features
     SorterKeys mFeatureKeys;

--- a/src/core/qgsattributeaction.h
+++ b/src/core/qgsattributeaction.h
@@ -97,7 +97,7 @@ class  CORE_EXPORT QgsAttributeAction
 {
   public:
     //! Constructor
-    QgsAttributeAction( QgsVectorLayer *layer ) : mLayer( layer ) {}
+    QgsAttributeAction( QgsVectorLayer *layer ) : mLayer( layer ), mDefaultAction( -1 ) {}
 
     //! Destructor
     virtual ~QgsAttributeAction() {}
@@ -175,7 +175,7 @@ class  CORE_EXPORT QgsAttributeAction
     static void setPythonExecute( void ( * )( const QString & ) );
 
     //! Whether the action is the default action
-    int defaultAction() const { return mDefaultAction < 0 || mDefaultAction >= size() ? 0 : mDefaultAction; }
+    int defaultAction() const { return mDefaultAction < 0 || mDefaultAction >= size() ? -1 : mDefaultAction; }
     void setDefaultAction( int actionNumber ) { mDefaultAction = actionNumber ; }
 
   private:

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -101,6 +101,7 @@ qgsmapcanvas.cpp
 qgsmapcanvasitem.cpp
 qgsmapcanvasmap.cpp
 qgsmapcanvassnapper.cpp
+qgsmaplayeractionregistry.cpp
 qgsmapoverviewcanvas.cpp
 qgsmaptip.cpp
 qgsmaptool.cpp
@@ -236,6 +237,7 @@ qgslonglongvalidator.h
 qgsludialog.h
 qgsmanageconnectionsdialog.h
 qgsmapcanvas.h
+qgsmaplayeractionregistry.h
 qgsmapoverviewcanvas.h
 qgsmaptoolemitpoint.h
 qgsmaptoolidentify.h

--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -25,6 +25,7 @@
 #include "qgsrendererv2.h"
 #include "qgsmaplayerregistry.h"
 #include "qgsexpression.h"
+#include "qgsmaplayeractionregistry.h"
 
 #include <QtGui>
 #include <QVariant>
@@ -627,6 +628,12 @@ void QgsAttributeTableModel::executeAction( int action, const QModelIndex &idx )
 {
   QgsFeature f = feature( idx );
   layer()->actions()->doAction( action, f, fieldIdx( idx.column() ) );
+}
+
+void QgsAttributeTableModel::executeMapLayerAction( QgsMapLayerAction* action, const QModelIndex &idx ) const
+{
+  QgsFeature f = feature( idx );
+  action->triggerForFeature( layer(), &f );
 }
 
 QgsFeature QgsAttributeTableModel::feature( const QModelIndex &idx ) const

--- a/src/gui/attributetable/qgsattributetablemodel.h
+++ b/src/gui/attributetable/qgsattributetablemodel.h
@@ -28,6 +28,7 @@
 #include "qgsvectorlayercache.h"
 
 class QgsMapCanvas;
+class QgsMapLayerAction;
 
 /**
  * A model backed by a {@link QgsVectorLayerCache} which is able to provide
@@ -172,6 +173,11 @@ class GUI_EXPORT QgsAttributeTableModel: public QAbstractTableModel
      * Execute an action
      */
     void executeAction( int action, const QModelIndex &idx ) const;
+
+    /**
+     * Execute an QgsMapLayerAction
+     */
+    void executeMapLayerAction( QgsMapLayerAction* action, const QModelIndex &idx ) const;
 
     /**
      * Return the feature attributes at given model index

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -26,6 +26,7 @@
 #include "qgsmapcanvas.h"
 #include "qgsvectordataprovider.h"
 #include "qgsvectorlayercache.h"
+#include "qgsmaplayeractionregistry.h"
 
 #include <QDialog>
 #include <QMenu>
@@ -418,10 +419,11 @@ void QgsDualView::viewWillShowContextMenu( QMenu* menu, QModelIndex atIndex )
 {
   QModelIndex sourceIndex = mFilterModel->mapToSource( atIndex );
 
+  //add user-defined actions to context menu
   if ( mLayerCache->layer()->actions()->size() != 0 )
   {
 
-    QAction *a = menu->addAction( tr( "Run action" ) );
+    QAction *a = menu->addAction( tr( "Run layer action" ) );
     a->setEnabled( false );
 
     for ( int i = 0; i < mLayerCache->layer()->actions()->size(); i++ )
@@ -436,6 +438,22 @@ void QgsDualView::viewWillShowContextMenu( QMenu* menu, QModelIndex atIndex )
     }
   }
 
+  //add actions from QgsMapLayerActionRegistry to context menu
+  QList<QgsMapLayerAction *> registeredActions = QgsMapLayerActionRegistry::instance()->mapLayerActions( mLayerCache->layer() );
+  if ( registeredActions.size() > 0 )
+  {
+    //add a seperator between user defined and standard actions
+    menu->addSeparator();
+
+    QList<QgsMapLayerAction*>::iterator actionIt;
+    for ( actionIt = registeredActions.begin(); actionIt != registeredActions.end(); ++actionIt )
+    {
+      QgsAttributeTableMapLayerAction *a = new QgsAttributeTableMapLayerAction(( *actionIt )->text(), this, ( *actionIt ), sourceIndex );
+      menu->addAction(( *actionIt )->text(), a, SLOT( execute() ) );
+    }
+  }
+
+  menu->addSeparator();
   QgsAttributeTableAction *a = new QgsAttributeTableAction( tr( "Open form" ), this, -1, sourceIndex );
   menu->addAction( tr( "Open form" ), a, SLOT( featureForm() ) );
 }
@@ -611,4 +629,13 @@ void QgsAttributeTableAction::featureForm()
   editedIds << mDualView->masterModel()->rowToId( mFieldIdx.row() );
   mDualView->setCurrentEditSelection( editedIds );
   mDualView->setView( QgsDualView::AttributeEditor );
+}
+
+/*
+ * QgsAttributeTableMapLayerAction
+ */
+
+void QgsAttributeTableMapLayerAction::execute()
+{
+  mDualView->masterModel()->executeMapLayerAction( mAction, mFieldIdx );
 }

--- a/src/gui/attributetable/qgsdualview.h
+++ b/src/gui/attributetable/qgsdualview.h
@@ -277,4 +277,22 @@ class GUI_EXPORT QgsAttributeTableAction : public QAction
     QModelIndex mFieldIdx;
 };
 
+class GUI_EXPORT QgsAttributeTableMapLayerAction : public QAction
+{
+    Q_OBJECT
+
+  public:
+    QgsAttributeTableMapLayerAction( const QString &name, QgsDualView *dualView, QgsMapLayerAction* action, const QModelIndex &fieldIdx ) :
+        QAction( name, dualView ), mDualView( dualView ), mAction( action ), mFieldIdx( fieldIdx )
+    {}
+
+  public slots:
+    void execute();
+
+  private:
+    QgsDualView* mDualView;
+    QgsMapLayerAction* mAction;
+    QModelIndex mFieldIdx;
+};
+
 #endif // QGSFEATURELIST_H

--- a/src/gui/qgsmaplayeractionregistry.cpp
+++ b/src/gui/qgsmaplayeractionregistry.cpp
@@ -1,0 +1,175 @@
+/***************************************************************************
+    qgsmaplayeractionregistry.cpp
+    -----------------------------
+    begin                : January 2014
+    copyright            : (C) 2014 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsmaplayeractionregistry.h"
+
+
+QgsMapLayerAction::QgsMapLayerAction( QString name, QObject* parent ) : QAction( name, parent ),
+    mActionName( name ),
+    mSingleLayer( false ),
+    mActionLayer( 0 ),
+    mSpecificLayerType( false )
+{
+
+}
+
+/**Creates a map layer action which can run only on a specific layer*/
+QgsMapLayerAction::QgsMapLayerAction( QString name, QObject* parent, QgsMapLayer* layer ) : QAction( name, parent ),
+    mActionName( name ),
+    mSingleLayer( true ),
+    mActionLayer( layer ),
+    mSpecificLayerType( false )
+{
+
+
+}
+
+/**Creates a map layer action which can run on a specific type of layer*/
+QgsMapLayerAction::QgsMapLayerAction( QString name, QObject* parent, QgsMapLayer::LayerType layerType ) : QAction( name, parent ),
+    mActionName( name ),
+    mSingleLayer( false ),
+    mActionLayer( 0 ),
+    mSpecificLayerType( true ),
+    mLayerType( layerType )
+{
+
+}
+
+QgsMapLayerAction::~QgsMapLayerAction()
+{
+  QgsMapLayerActionRegistry::instance()->removeMapLayerAction( this );
+}
+
+bool QgsMapLayerAction::canRunUsingLayer( QgsMapLayer* layer ) const
+{
+  //check layer details
+  if ( !mSingleLayer && !mSpecificLayerType )
+  {
+    //action is not a single layer of specific layer type action,
+    //so return true
+    return true;
+  }
+  if ( mSingleLayer && layer == mActionLayer )
+  {
+    //action is a single layer type and layer matches
+    return true;
+  }
+  else if ( mSpecificLayerType && layer->type() == mLayerType )
+  {
+    //action is for a layer type and layer type matches
+    return true;
+  }
+
+  return false;
+}
+
+void QgsMapLayerAction::triggerForFeature( QgsMapLayer* layer, QgsFeature* feature )
+{
+  emit triggeredForFeature( layer, feature );
+  //also trigger this action for the specified layer
+  triggerForLayer( layer );
+}
+
+void QgsMapLayerAction::triggerForLayer( QgsMapLayer* layer )
+{
+  emit triggeredForLayer( layer );
+  //also emit triggered signal
+  emit triggered();
+}
+
+//
+// Static calls to enforce singleton behaviour
+//
+QgsMapLayerActionRegistry *QgsMapLayerActionRegistry::mInstance = 0;
+QgsMapLayerActionRegistry *QgsMapLayerActionRegistry::instance()
+{
+  if ( mInstance == 0 )
+  {
+    mInstance = new QgsMapLayerActionRegistry();
+  }
+  return mInstance;
+}
+
+//
+// Main class begins now...
+//
+
+QgsMapLayerActionRegistry::QgsMapLayerActionRegistry( QObject *parent ) : QObject( parent )
+{
+  // constructor does nothing
+}
+
+QgsMapLayerActionRegistry::~QgsMapLayerActionRegistry()
+{
+  //removeAllMapLayers();
+}
+
+void QgsMapLayerActionRegistry::addMapLayerAction( QgsMapLayerAction * action )
+{
+  mMapLayerActionList.append( action );
+  emit changed();
+}
+
+QList< QgsMapLayerAction* > QgsMapLayerActionRegistry::mapLayerActions( QgsMapLayer* layer )
+{
+  QList< QgsMapLayerAction* > validActions;
+  QList<QgsMapLayerAction*>::iterator actionIt;
+  for ( actionIt = mMapLayerActionList.begin(); actionIt != mMapLayerActionList.end(); ++actionIt )
+  {
+    if (( *actionIt )->canRunUsingLayer( layer ) )
+    {
+      validActions.append(( *actionIt ) );
+    }
+  }
+  return validActions;
+}
+
+
+bool QgsMapLayerActionRegistry::removeMapLayerAction( QgsMapLayerAction* action )
+{
+  if ( mMapLayerActionList.indexOf( action ) != -1 )
+  {
+    mMapLayerActionList.removeAll( action );
+
+    //also remove this action from the default layer action map
+    QMap<QgsMapLayer*, QgsMapLayerAction*>::iterator defaultIt;
+    for ( defaultIt = mDefaultLayerActionMap.begin(); defaultIt != mDefaultLayerActionMap.end(); ++defaultIt )
+    {
+      if ( defaultIt.value() == action )
+      {
+        defaultIt.value() = 0;
+      }
+    }
+    emit changed();
+    return true;
+  }
+  //not found
+  return false;
+}
+
+void QgsMapLayerActionRegistry::setDefaultActionForLayer( QgsMapLayer* layer, QgsMapLayerAction* action )
+{
+  mDefaultLayerActionMap[ layer ] = action;
+}
+
+QgsMapLayerAction * QgsMapLayerActionRegistry::defaultActionForLayer( QgsMapLayer* layer )
+{
+  if ( !mDefaultLayerActionMap.contains( layer ) )
+  {
+    return 0;
+  }
+
+  return mDefaultLayerActionMap[ layer ];
+}

--- a/src/gui/qgsmaplayeractionregistry.h
+++ b/src/gui/qgsmaplayeractionregistry.h
@@ -1,0 +1,128 @@
+/***************************************************************************
+    qgsmaplayeractionregistry.h
+    ---------------------------
+    begin                : January 2014
+    copyright            : (C) 2014 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSMAPLAYERACTIONREGISTRY_H
+#define QGSMAPLAYERACTIONREGISTRY_H
+
+#include <QObject>
+#include <QList>
+#include <QMap>
+#include <QAction>
+
+#include "qgsmaplayer.h"
+
+class QgsFeature;
+
+
+/**
+* An action which can run on map layers
+*/
+class QgsMapLayerAction : public QAction
+{
+    Q_OBJECT
+
+  public:
+    /**Creates a map layer action which can run on any layer*/
+    QgsMapLayerAction( QString name, QObject *parent );
+    /**Creates a map layer action which can run only on a specific layer*/
+    QgsMapLayerAction( QString name, QObject *parent, QgsMapLayer* layer );
+    /**Creates a map layer action which can run on a specific type of layer*/
+    QgsMapLayerAction( QString name, QObject *parent, QgsMapLayer::LayerType layerType );
+
+    ~QgsMapLayerAction();
+
+    /** Returns action name */
+    QString actionName() { return mActionName; }
+
+    /** True if action can run using the specified layer */
+    bool canRunUsingLayer( QgsMapLayer* layer ) const;
+
+    /** Triggers the action with the specified layer and feature. This also emits the triggeredForLayer( QgsMapLayer *)
+     * and triggered() slots */
+    void triggerForFeature( QgsMapLayer* layer, QgsFeature* feature );
+
+    /** Triggers the action with the specified layer. This also emits the triggered() slot. */
+    void triggerForLayer( QgsMapLayer* layer );
+
+  signals:
+    /** Triggered when action has been run for a specific feature */
+    void triggeredForFeature( QgsMapLayer* layer, QgsFeature* feature );
+
+    /** Triggered when action has been run for a specific layer */
+    void triggeredForLayer( QgsMapLayer* layer );
+
+  private:
+
+    QString mActionName;
+
+    //true if action is only valid for a single layer
+    bool mSingleLayer;
+    //layer if action is only valid for a single layer
+    QgsMapLayer* mActionLayer;
+
+    //true if action is only valid for a specific layer type
+    bool mSpecificLayerType;
+    //layer type if action is only valid for a specific layer type
+    QgsMapLayer::LayerType mLayerType;
+
+
+};
+
+/**
+* This class tracks map layer actions
+*/
+class QgsMapLayerActionRegistry : public QObject
+{
+    Q_OBJECT
+
+  public:
+    //! Returns the instance pointer, creating the object on the first call
+    static QgsMapLayerActionRegistry * instance();
+
+    ~QgsMapLayerActionRegistry();
+
+    /**Adds a map layer action to the registry*/
+    void addMapLayerAction( QgsMapLayerAction * action );
+
+    /**Returns the map layer actions which can run on the specified layer*/
+    QList<QgsMapLayerAction *> mapLayerActions( QgsMapLayer* layer );
+
+    /**Removes a map layer action from the registry*/
+    bool removeMapLayerAction( QgsMapLayerAction *action );
+
+    /**Sets the default action for a layer*/
+    void setDefaultActionForLayer( QgsMapLayer* layer, QgsMapLayerAction* action );
+    /**Returns the default action for a layer*/
+    QgsMapLayerAction * defaultActionForLayer( QgsMapLayer* layer );
+
+  protected:
+    //! protected constructor
+    QgsMapLayerActionRegistry( QObject * parent = 0 );
+
+  signals:
+    /** Triggered when an action is added or removed from the registry */
+    void changed();
+
+  private:
+
+    static QgsMapLayerActionRegistry *mInstance;
+
+    QList< QgsMapLayerAction* > mMapLayerActionList;
+
+    QMap< QgsMapLayer*, QgsMapLayerAction* > mDefaultLayerActionMap;
+
+};
+
+#endif // QGSMAPLAYERACTIONREGISTRY_H


### PR DESCRIPTION
This request supercedes https://github.com/qgis/QGIS/pull/1061 . I've now created a QgsMapLayerAction and QgsMapLayerActionRegistry as suggested by @wonder-sk. This means there's now no changes to QgsVectorLayer. There's a few small cleanups I still need to do with the new "Set as atlas feature" action (namely, make the action text show the composition it applies to), but I'd like to get these major changes reviewed and committed first.
