### PR TITLE
dialog base: separator and dialog title as argument to init/restore

### DIFF
--- a/src/app/pluginmanager/qgspluginmanager.cpp
+++ b/src/app/pluginmanager/qgspluginmanager.cpp
@@ -1346,17 +1346,22 @@ bool QgsPluginManager::hasInvalidPlugins( )
 
 void QgsPluginManager::updateWindowTitle( )
 {
-  QString newTitle = QString( "%1 - %2" ).arg( tr( "Plugins" ) ).arg( mOptionsListWidget->currentItem()->text() );
-  if ( mOptionsListWidget->currentRow() < mOptionsListWidget->count() - 1 )
+  QListWidgetItem *curitem = mOptListWidget->currentItem();
+  if ( curitem )
   {
-    // if it's not the Settings tab, add the plugin count
-    newTitle += QString( " (%3)" ).arg( mModelProxy->countWithCurrentStatus() );
+    QString title = QString( "%1 | %2" ).arg( tr( "Plugins" ) ).arg( curitem->text() );
+    if ( mOptionsListWidget->currentRow() < mOptionsListWidget->count() - 1 )
+    {
+      // if it's not the Settings tab, add the plugin count
+      title += QString( " (%3)" ).arg( mModelProxy->countWithCurrentStatus() );
+      setWindowTitle( title );
+    }
   }
-  setWindowTitle( newTitle );
-  return;
+  else
+  {
+    setWindowTitle( mDialogTitle );
+  }
 }
-
-
 
 void QgsPluginManager::showEvent( QShowEvent* e )
 {

--- a/src/app/qgsabout.cpp
+++ b/src/app/qgsabout.cpp
@@ -38,7 +38,8 @@ QgsAbout::QgsAbout( QWidget *parent )
 #endif
 {
   setupUi( this );
-  initOptionsBase();
+  QString title = QString( "%1 - %2 Bit" ).arg( windowTitle() ).arg( QSysInfo::WordSize );
+  initOptionsBase( true, title );
   init();
 }
 
@@ -49,8 +50,6 @@ QgsAbout::~QgsAbout()
 void QgsAbout::init()
 {
   setPluginInfo();
-
-  setWindowTitle( QString( "%1 - %2 Bit" ).arg( windowTitle() ).arg( QSysInfo::WordSize ) );
 
   // set the 60x60 icon pixmap
   QPixmap icon( QgsApplication::iconsPath() + "qgis-icon-60x60.png" );

--- a/src/app/qgsrasterlayerproperties.cpp
+++ b/src/app/qgsrasterlayerproperties.cpp
@@ -225,8 +225,6 @@ QgsRasterLayerProperties::QgsRasterLayerProperties( QgsMapLayer* lyr, QgsMapCanv
                                  .arg( pyramidSentence2 ).arg( pyramidSentence3 )
                                  .arg( pyramidSentence4 ).arg( pyramidSentence5 ) );
 
-  setWindowTitle( tr( "Layer Properties - %1" ).arg( lyr->name() ) );
-
   tableTransparency->horizontalHeader()->setResizeMode( 0, QHeaderView::Stretch );
   tableTransparency->horizontalHeader()->setResizeMode( 1, QHeaderView::Stretch );
 
@@ -402,7 +400,8 @@ QgsRasterLayerProperties::QgsRasterLayerProperties( QgsMapLayer* lyr, QgsMapCanv
 
   mResetColorRenderingBtn->setIcon( QgsApplication::getThemeIcon( "/mActionUndo.png" ) );
 
-  restoreOptionsBaseUi();
+  QString title = QString( tr( "Layer Properties - %1" ) ).arg( lyr->name() );
+  restoreOptionsBaseUi( title );
 } // QgsRasterLayerProperties ctor
 
 

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -250,8 +250,6 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
     );
   }
 
-  setWindowTitle( tr( "Layer Properties - %1" ).arg( layer->name() ) );
-
   QSettings settings;
   // if dialog hasn't been opened/closed yet, default to Styles tab, which is used most often
   // this will be read by restoreOptionsBaseUi()
@@ -261,7 +259,8 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
                        mOptStackedWidget->indexOf( mOptsPage_Style ) );
   }
 
-  restoreOptionsBaseUi();
+  QString title = QString( tr( "Layer Properties - %1" ) ).arg( layer->name() );
+  restoreOptionsBaseUi( title );
 } // QgsVectorLayerProperties ctor
 
 

--- a/src/gui/qgsoptionsdialogbase.cpp
+++ b/src/gui/qgsoptionsdialogbase.cpp
@@ -47,11 +47,14 @@ QgsOptionsDialogBase::~QgsOptionsDialogBase()
   }
 }
 
-void QgsOptionsDialogBase::initOptionsBase( bool restoreUi )
+void QgsOptionsDialogBase::initOptionsBase( bool restoreUi, QString title )
 {
-  // save original dialog title so it can be used to be concatenated
+  // save dialog title so it can be used to be concatenated
   // with category title in icon-only mode
-  mDialogTitle = windowTitle();
+  if ( title.isEmpty() )
+    mDialogTitle = windowTitle();
+  else
+    mDialogTitle = title;
 
   // don't add to dialog margins
   // redefine now, or those in inherited .ui file will be added
@@ -109,14 +112,20 @@ void QgsOptionsDialogBase::initOptionsBase( bool restoreUi )
   mInit = true;
 
   if ( restoreUi )
-    restoreOptionsBaseUi();
+    restoreOptionsBaseUi( mDialogTitle );
 }
 
-void QgsOptionsDialogBase::restoreOptionsBaseUi()
+void QgsOptionsDialogBase::restoreOptionsBaseUi( QString title )
 {
   if ( !mInit )
   {
     return;
+  }
+
+  if ( !title.isEmpty() )
+  {
+    mDialogTitle = title;
+    updateWindowTitle();
   }
 
   // re-save original dialog title in case it was changed after dialog initialization
@@ -179,6 +188,19 @@ void QgsOptionsDialogBase::paintEvent( QPaintEvent* e )
   QDialog::paintEvent( e );
 }
 
+void QgsOptionsDialogBase::updateWindowTitle()
+{
+  QListWidgetItem *curitem = mOptListWidget->currentItem();
+  if ( curitem )
+  {
+    setWindowTitle( QString( "%1 | %2" ).arg( mDialogTitle ).arg( curitem->text() ) );
+  }
+  else
+  {
+    setWindowTitle( mDialogTitle );
+  }
+}
+
 void QgsOptionsDialogBase::updateOptionsListVerticalTabs()
 {
   if ( !mInit )
@@ -221,15 +243,7 @@ void QgsOptionsDialogBase::optionsStackedWidget_CurrentChanged( int indx )
   mOptListWidget->setCurrentRow( indx );
   mOptListWidget->blockSignals( false );
 
-  QListWidgetItem *curitem = mOptListWidget->currentItem();
-  if ( curitem )
-  {
-    setWindowTitle( QString( "%1 - %2" ).arg( mDialogTitle ).arg( curitem->text() ) );
-  }
-  else
-  {
-    setWindowTitle( mDialogTitle );
-  }
+  updateWindowTitle();
 }
 
 void QgsOptionsDialogBase::optionsStackedWidget_WidgetRemoved( int indx )

--- a/src/gui/qgsoptionsdialogbase.h
+++ b/src/gui/qgsoptionsdialogbase.h
@@ -59,14 +59,15 @@ class GUI_EXPORT QgsOptionsDialogBase : public QDialog
 
     /** Set up the base ui connections for vertical tabs.
      * @param restoreUi Whether to restore the base ui at this time.
+     * @param title the window title
      */
-    void initOptionsBase( bool restoreUi = true );
+    void initOptionsBase( bool restoreUi = true, QString title = QString() );
 
     /** Restore the base ui.
      * Sometimes useful to do at end of subclass's constructor.
-     * e.g. if setWindowTitle is used after initOptionsBase.
+     * @param title the window title (it does not need to be defined if previously given to initOptionsBase();
      */
-    void restoreOptionsBaseUi();
+    void restoreOptionsBaseUi( QString title = QString() );
 
     /** determine if the options list is in icon only mode
      */
@@ -81,6 +82,8 @@ class GUI_EXPORT QgsOptionsDialogBase : public QDialog
   protected:
     void showEvent( QShowEvent* e );
     void paintEvent( QPaintEvent* e );
+
+    virtual void updateWindowTitle();
 
     QString mOptsKey;
     bool mInit;


### PR DESCRIPTION
following #1082
- adds title option to init and restore methods
- adds a virtual updateWindowTitle to QgsOptionsDialogBase
- updated the classes using QgsOptionsDialogBase
