### PR TITLE
add svg export with layers

### DIFF
--- a/python/core/composer/qgscomposeritem.sip
+++ b/python/core/composer/qgscomposeritem.sip
@@ -358,6 +358,16 @@ class QgsComposerItem: QObject, QGraphicsRectItem
       @note there is not setter since one can't manually set the id*/
     QString uuid() const;
 
+    /**Get the number of layers that this item exports
+      @returns 0 if this item is to be placed on the same layer as the previous item
+      @note this method was added in version 2.2 */
+    int numberExportLayers() const;
+
+    /**Set the layer to export
+     @param layerIdx can be set to -1 to export all layerr and must be less than numberExportLayers()
+     @note this method was added in version 2.2 */
+    void setCurrentExportLayer( int layerIdx = -1 );
+
   public slots:
     /**Sets the item rotation
      * @deprecated Use setItemRotation( double rotation ) instead

--- a/python/core/composer/qgscomposermap.sip
+++ b/python/core/composer/qgscomposermap.sip
@@ -383,9 +383,9 @@ class QgsComposerMap : QgsComposerItem
     /** Sets the margin size (percentage) used when the map is in atlas mode */
     void setAtlasMargin( double margin ); 
 
-    /**Set the layer to export
-     @param layerIdx can be set to -1 to export all layerr and must be less than numberExportLayers()
-     @note this method was added in version 2.2 */
+    /**Get the number of layers that this item exports
+      @returns 0 if this item is to be placed on the same layer as the previous item
+      @note this method was added in version 2.2 */
     int numberExportLayers() const;
 
   signals:

--- a/python/core/composer/qgscomposermap.sip
+++ b/python/core/composer/qgscomposermap.sip
@@ -383,6 +383,11 @@ class QgsComposerMap : QgsComposerItem
     /** Sets the margin size (percentage) used when the map is in atlas mode */
     void setAtlasMargin( double margin ); 
 
+    /**Set the layer to export
+     @param layerIdx can be set to -1 to export all layerr and must be less than numberExportLayers()
+     @note this method was added in version 2.2 */
+    int numberExportLayers() const;
+
   signals:
     void extentChanged();
     

--- a/python/core/composer/qgscomposition.sip
+++ b/python/core/composer/qgscomposition.sip
@@ -382,6 +382,11 @@ class QgsComposition : QGraphicsScene
     /** Sets the current atlas mode of the composition. Returns false if the mode could not be changed. */
     bool setAtlasMode( QgsComposition::AtlasMode mode );
 
+    /** Return pages in the correct order
+     @note composerItems(QList< QgsPaperItem* > &) may not return pages in the correct order
+     @note added in version 2.2*/
+    QList< QgsPaperItem* > pages();
+
   public slots:
     /**Casts object to the proper subclass type and calls corresponding itemAdded signal*/
     void sendItemAddedSignal( QgsComposerItem* item );

--- a/src/app/composer/qgscomposer.cpp
+++ b/src/app/composer/qgscomposer.cpp
@@ -58,6 +58,7 @@
 #include "qgsgeometry.h"
 #include "qgspaperitem.h"
 #include "qgsmaplayerregistry.h"
+#include "ui_qgssvgexportoptions.h"
 
 #include <QCloseEvent>
 #include <QCheckBox>
@@ -1836,26 +1837,24 @@ void QgsComposer::exportCompositionAsSVG( QgsComposer::OutputMode mode )
       outputFileName = file.path();
     }
 
-    // open file dialog with export options
-    {
-      QScopedPointer<QFileDialog> fileDialog( new QFileDialog(
-                                                this,
-                                                tr( "Choose a file name to save the map as" ),
-                                                outputFileName,
-                                                tr( "SVG Format" ) + " (*.svg *.SVG)" ) );
-      fileDialog->setAcceptMode( QFileDialog::AcceptSave );
-      QCheckBox * cb = new QCheckBox( "Group layers", fileDialog.data() );
-      cb->setChecked( false );
-      fileDialog->layout()->addWidget( cb );
-
-      if ( !fileDialog->exec() ) return;
-      outputFileName = fileDialog->selectedFiles().length() ? fileDialog->selectedFiles().first() : QString();
-      groupLayers = cb->isChecked();
-    }
-
+    // open file dialog
+    outputFileName = QFileDialog::getSaveFileName(
+                       this,
+                       tr( "Choose a file name to save the map as" ),
+                       outputFileName,
+                       tr( "SVG Format" ) + " (*.svg *.SVG)" );
 
     if ( outputFileName.isEmpty() )
       return;
+
+    // open otions dialog
+    {
+        QDialog dialog;
+        Ui::QgsSvgExportOptionsDialog options;
+        options.setupUi( &dialog );
+        dialog.exec();
+        groupLayers = options.chkMapLayersAsGroup->isChecked();
+    }
 
     if ( !outputFileName.endsWith( ".svg", Qt::CaseInsensitive ) )
     {
@@ -1883,22 +1882,12 @@ void QgsComposer::exportCompositionAsSVG( QgsComposer::OutputMode mode )
     QSettings myQSettings;
     QString lastUsedDir = myQSettings.value( "/UI/lastSaveAtlasAsSvgDir", "." ).toString();
 
-    // open file dialog with options
-    {
-      QScopedPointer<QFileDialog> fileDialog( new QFileDialog(
-                                                this,
-                                                tr( "Directory where to save SVG files" ),
-                                                lastUsedDir ) );
-      fileDialog->setFileMode( QFileDialog::Directory );
-      fileDialog->setOption( QFileDialog::ShowDirsOnly, true );
-      QCheckBox * cb = new QCheckBox( "Group layers", fileDialog.data() );
-      cb->setChecked( false );
-      fileDialog->layout()->addWidget( cb );
+    // open file dialog
+    outputDir = QFileDialog::getExistingDirectory( this,
+                tr( "Directory where to save SVG files" ),
+                lastUsedDir,
+                QFileDialog::ShowDirsOnly );
 
-      if ( !fileDialog->exec() ) return;
-      outputDir = fileDialog->selectedFiles().length() ? fileDialog->selectedFiles().first() : QString();
-      groupLayers = cb->isChecked();
-    }
     if ( outputDir.isEmpty() )
     {
       return;
@@ -1912,6 +1901,16 @@ void QgsComposer::exportCompositionAsSVG( QgsComposer::OutputMode mode )
                             QMessageBox::Ok );
       return;
     }
+
+    // open otions dialog
+    {
+        QDialog dialog;
+        Ui::QgsSvgExportOptionsDialog options;
+        options.setupUi( &dialog );
+        dialog.exec();
+        groupLayers = options.chkMapLayersAsGroup->isChecked();
+    }
+    
 
     myQSettings.setValue( "/UI/lastSaveAtlasAsSvgDir", outputDir );
   }

--- a/src/app/composer/qgscomposer.cpp
+++ b/src/app/composer/qgscomposer.cpp
@@ -2022,6 +2022,7 @@ void QgsComposer::exportCompositionAsSVG( QgsComposer::OutputMode mode )
         QStringList savedLayerSet;
         bool keepLayerSet;
         bool hasBackground;
+        bool hasFrame;
         QStringList layerStack;
         QList<QGraphicsItem *>::const_iterator it = items.begin();
         for ( unsigned svgLayerId = 1; it != items.end(); ++svgLayerId )
@@ -2040,18 +2041,30 @@ void QgsComposer::exportCompositionAsSVG( QgsComposer::OutputMode mode )
               savedLayerSet = mapItem->layerSet();
               layerStack = savedLayerSet;
               hasBackground = mapItem->hasBackground();
-              if ( hasBackground ) layerStack.append( "" ); // to render the background
+              hasFrame = mapItem->hasFrame();
+              if ( hasBackground ) layerStack.append( "svg background layer" );
+              if ( hasFrame ) layerStack.prepend( "svg frame layer" );
             }
             if ( !layerStack.isEmpty() ) // no layers... this can happen
             {
               const QString layerId( layerStack.takeLast() );
-              if ( layerId.isEmpty() ) // background
+              if ( layerId == "svg background layer" )
               {
+                mapItem->setFrameEnabled( false );
+                mapItem->setBackgroundEnabled( true );
                 layerName.append( " Background" );
+                mapItem->setLayerSet( QStringList() );
+              }
+              else if ( layerId == "svg frame layer" )
+              {
+                mapItem->setFrameEnabled( true );
+                mapItem->setBackgroundEnabled( false );
+                layerName.append( " Frame" );
                 mapItem->setLayerSet( QStringList() );
               }
               else
               {
+                mapItem->setFrameEnabled( false );
                 mapItem->setBackgroundEnabled( false );
                 const QgsMapLayer * ml = QgsMapLayerRegistry::instance()->mapLayer( layerId );
                 layerName.append( " " + ( ml ? ml->name() : "" ) );
@@ -2113,6 +2126,7 @@ void QgsComposer::exportCompositionAsSVG( QgsComposer::OutputMode mode )
             mapItem->setKeepLayerSet( keepLayerSet );
             mapItem->setLayerSet( savedLayerSet );
             mapItem->setBackgroundEnabled( hasBackground );
+            mapItem->setFrameEnabled( hasFrame );
             mapItem = NULL;
             ++it;
           }

--- a/src/app/composer/qgscomposer.cpp
+++ b/src/app/composer/qgscomposer.cpp
@@ -2040,8 +2040,14 @@ void QgsComposer::exportCompositionAsSVG( QgsComposer::OutputMode mode )
             for ( ; it != items.end(); ++it )
             {
               composerItem = dynamic_cast<QgsComposerMap*>( *it );
-              if (composerItem && composerItem->numberExportLayers()) break;
-              else ( *it )->show();
+              if ( composerItem && composerItem->numberExportLayers() )
+              {
+                break;
+              }
+              else
+              {
+                ( *it )->show();
+              }
             }
           }
 

--- a/src/app/composer/qgscomposer.cpp
+++ b/src/app/composer/qgscomposer.cpp
@@ -1849,11 +1849,11 @@ void QgsComposer::exportCompositionAsSVG( QgsComposer::OutputMode mode )
 
     // open otions dialog
     {
-        QDialog dialog;
-        Ui::QgsSvgExportOptionsDialog options;
-        options.setupUi( &dialog );
-        dialog.exec();
-        groupLayers = options.chkMapLayersAsGroup->isChecked();
+      QDialog dialog;
+      Ui::QgsSvgExportOptionsDialog options;
+      options.setupUi( &dialog );
+      dialog.exec();
+      groupLayers = options.chkMapLayersAsGroup->isChecked();
     }
 
     if ( !outputFileName.endsWith( ".svg", Qt::CaseInsensitive ) )
@@ -1904,13 +1904,13 @@ void QgsComposer::exportCompositionAsSVG( QgsComposer::OutputMode mode )
 
     // open otions dialog
     {
-        QDialog dialog;
-        Ui::QgsSvgExportOptionsDialog options;
-        options.setupUi( &dialog );
-        dialog.exec();
-        groupLayers = options.chkMapLayersAsGroup->isChecked();
+      QDialog dialog;
+      Ui::QgsSvgExportOptionsDialog options;
+      options.setupUi( &dialog );
+      dialog.exec();
+      groupLayers = options.chkMapLayersAsGroup->isChecked();
     }
-    
+
 
     myQSettings.setValue( "/UI/lastSaveAtlasAsSvgDir", outputDir );
   }
@@ -2021,6 +2021,7 @@ void QgsComposer::exportCompositionAsSVG( QgsComposer::OutputMode mode )
         QgsComposerMap* mapItem = NULL;
         QStringList savedLayerSet;
         bool keepLayerSet;
+        bool hasBackground;
         QStringList layerStack;
         QList<QGraphicsItem *>::const_iterator it = items.begin();
         for ( unsigned svgLayerId = 1; it != items.end(); ++svgLayerId )
@@ -2038,13 +2039,24 @@ void QgsComposer::exportCompositionAsSVG( QgsComposer::OutputMode mode )
               mapItem->setKeepLayerSet( true );
               savedLayerSet = mapItem->layerSet();
               layerStack = savedLayerSet;
+              hasBackground = mapItem->hasBackground();
+              if ( hasBackground ) layerStack.append( "" ); // to render the background
             }
             if ( !layerStack.isEmpty() ) // no layers... this can happen
             {
               const QString layerId( layerStack.takeLast() );
-              const QgsMapLayer * ml = QgsMapLayerRegistry::instance()->mapLayer( layerId );
-              layerName.append( " " + ( ml ? ml->name() : "" ) );
-              mapItem->setLayerSet( QStringList( layerId ) );
+              if ( layerId.isEmpty() ) // background
+              {
+                layerName.append( " Background" );
+                mapItem->setLayerSet( QStringList() );
+              }
+              else
+              {
+                mapItem->setBackgroundEnabled( false );
+                const QgsMapLayer * ml = QgsMapLayerRegistry::instance()->mapLayer( layerId );
+                layerName.append( " " + ( ml ? ml->name() : "" ) );
+                mapItem->setLayerSet( QStringList( layerId ) );
+              }
             }
           }
           else
@@ -2100,6 +2112,7 @@ void QgsComposer::exportCompositionAsSVG( QgsComposer::OutputMode mode )
           {
             mapItem->setKeepLayerSet( keepLayerSet );
             mapItem->setLayerSet( savedLayerSet );
+            mapItem->setBackgroundEnabled( hasBackground );
             mapItem = NULL;
             ++it;
           }

--- a/src/app/composer/qgscomposer.cpp
+++ b/src/app/composer/qgscomposer.cpp
@@ -2017,6 +2017,9 @@ void QgsComposer::exportCompositionAsSVG( QgsComposer::OutputMode mode )
         QList<QGraphicsItem *> items = mComposition->items( paperRect,
                                        Qt::IntersectsItemBoundingRect,
                                        Qt::AscendingOrder );
+        if ( ! items.isEmpty()
+             && dynamic_cast<QgsPaperGrid*>( items.last() )
+             && !mComposition->gridVisible() ) items.pop_back();
         QgsItemTempHider itemsHider( items );
         QgsComposerMap* mapItem = NULL;
         QStringList savedLayerSet;

--- a/src/core/composer/qgsatlascomposition.cpp
+++ b/src/core/composer/qgsatlascomposition.cpp
@@ -270,19 +270,6 @@ bool QgsAtlasComposition::beginRender()
     return false;
   }
 
-  mRestoreLayer = false;
-  QStringList& layerSet = mComposition->mapRenderer()->layerSet();
-  if ( mHideCoverage )
-  {
-    // look for the layer in the renderer's set
-    int removeAt = layerSet.indexOf( mCoverageLayer->id() );
-    if ( removeAt != -1 )
-    {
-      mRestoreLayer = true;
-      layerSet.removeAt( removeAt );
-    }
-  }
-
   // special columns for expressions
   QgsExpression::setSpecialColumn( "$numpages", QVariant( mComposition->numPages() ) );
   QgsExpression::setSpecialColumn( "$numfeatures", QVariant(( int )mFeatureIds.size() ) );
@@ -303,14 +290,6 @@ void QgsAtlasComposition::endRender()
   for ( QList<QgsComposerLabel*>::iterator lit = labels.begin(); lit != labels.end(); ++lit )
   {
     ( *lit )->setExpressionContext( 0, 0 );
-  }
-
-  // restore the coverage visibility
-  if ( mRestoreLayer )
-  {
-    QStringList& layerSet = mComposition->mapRenderer()->layerSet();
-
-    layerSet.push_back( mCoverageLayer->id() );
   }
 
   updateAtlasMaps();
@@ -657,25 +636,6 @@ void QgsAtlasComposition::setHideCoverage( bool hide )
   if ( mComposition->atlasMode() == QgsComposition::PreviewAtlas )
   {
     //an atlas preview is enabled, so reflect changes in coverage layer visibility immediately
-    QStringList& layerSet = mComposition->mapRenderer()->layerSet();
-    if ( hide )
-    {
-      // look for the layer in the renderer's set
-      int removeAt = layerSet.indexOf( mCoverageLayer->id() );
-      if ( removeAt != -1 )
-      {
-        mRestoreLayer = true;
-        layerSet.removeAt( removeAt );
-      }
-    }
-    else
-    {
-      if ( mRestoreLayer )
-      {
-        layerSet.push_back( mCoverageLayer->id() );
-        mRestoreLayer = false;
-      }
-    }
     updateAtlasMaps();
     mComposition->update();
   }

--- a/src/core/composer/qgsatlascomposition.h
+++ b/src/core/composer/qgsatlascomposition.h
@@ -193,7 +193,7 @@ class CORE_EXPORT QgsAtlasComposition : public QObject
     QVector<QgsFeatureId> mFeatureIds;
 
     QgsFeature mCurrentFeature;
-    bool mRestoreLayer;
+
     std::auto_ptr<QgsExpression> mFilenameExpr;
 
     // bounding box of the current feature transformed into map crs

--- a/src/core/composer/qgscomposeritem.cpp
+++ b/src/core/composer/qgscomposeritem.cpp
@@ -63,6 +63,7 @@ QgsComposerItem::QgsComposerItem( QgsComposition* composition, bool manageZValue
     , mEffectsEnabled( true )
     , mTransparency( 0 )
     , mLastUsedPositionMode( UpperLeft )
+    , mCurrentExportLayer( -1 )
     , mId( "" )
     , mUuid( QUuid::createUuid().toString() )
 {
@@ -86,6 +87,7 @@ QgsComposerItem::QgsComposerItem( qreal x, qreal y, qreal width, qreal height, Q
     , mEffectsEnabled( true )
     , mTransparency( 0 )
     , mLastUsedPositionMode( UpperLeft )
+    , mCurrentExportLayer( -1 )
     , mId( "" )
     , mUuid( QUuid::createUuid().toString() )
 {

--- a/src/core/composer/qgscomposeritem.h
+++ b/src/core/composer/qgscomposeritem.h
@@ -313,6 +313,16 @@ class CORE_EXPORT QgsComposerItem: public QObject, public QGraphicsRectItem
       @note there is not setter since one can't manually set the id*/
     QString uuid() const { return mUuid; }
 
+    /**Get the number of layers that this item exports
+      @returns 0 if this item is to be placed on the same layer as the previous item
+      @note this method was added in version 2.2 */
+    virtual int numberExportLayers() const { return 0; }
+
+    /**Set the layer to export
+     @param layerIdx can be set to -1 to export all layerr and must be less than numberExportLayers()
+     @note this method was added in version 2.2 */
+    virtual void setCurrentExportLayer( int layerIdx = -1 ) { mCurrentExportLayer = layerIdx; }
+
   public slots:
     /**Sets the item rotation
      * @deprecated Use setItemRotation( double rotation ) instead
@@ -372,6 +382,11 @@ class CORE_EXPORT QgsComposerItem: public QObject, public QGraphicsRectItem
     /**The item's position mode
     @note: this member was added in version 2.0*/
     ItemPositionMode mLastUsedPositionMode;
+
+    /**The layer that needs to be exported
+    @note: if -1, all layers are to be exported
+    @note: this member was added in version 2.2*/
+    int mCurrentExportLayer;
 
     /**Draw selection boxes around item*/
     virtual void drawSelectionBoxes( QPainter* p );

--- a/src/core/composer/qgscomposermap.cpp
+++ b/src/core/composer/qgscomposermap.cpp
@@ -178,22 +178,20 @@ void QgsComposerMap::draw( QPainter *painter, const QgsRectangle& extent, const 
   if ( mMapRenderer->labelingEngine() )
     theMapRenderer.setLabelingEngine( mMapRenderer->labelingEngine()->clone() );
 
+
   //use stored layer set or read current set from main canvas
-  if ( mKeepLayerSet )
+  const QStringList theLayerSet = mKeepLayerSet ? mLayerSet : mMapRenderer->layerSet() ;
+
+  if ( -1 == mCurrentExportLayer )
   {
-    theMapRenderer.setLayerSet( mLayerSet );
+    theMapRenderer.setLayerSet( theLayerSet );
   }
   else
   {
-    theMapRenderer.setLayerSet( mMapRenderer->layerSet() );
-  }
-
-  if ( -1 != mCurrentExportLayer )
-  {
     const int layerIdx = mCurrentExportLayer - ( hasBackground() ? 1 : 0 );
     theMapRenderer.setLayerSet(
-      ( layerIdx >= 0 && layerIdx < theMapRenderer.layerSet().length() )
-      ? QStringList( theMapRenderer.layerSet()[ theMapRenderer.layerSet().length() - layerIdx - 1 ] )
+      ( layerIdx >= 0 && layerIdx < theLayerSet.length() )
+      ? QStringList( theLayerSet[ theLayerSet.length() - layerIdx - 1 ] )
       : QStringList()
     );
   }

--- a/src/core/composer/qgscomposermap.h
+++ b/src/core/composer/qgscomposermap.h
@@ -598,6 +598,9 @@ class CORE_EXPORT QgsComposerMap : public QgsComposerItem
     /**Margin size for atlas driven extents (percentage of feature size)*/
     double mAtlasMargin;
 
+    /**Returns a list of the layers to render for this map item*/
+    QStringList layersToRender();
+
     /**Draws the map grid*/
     void drawGrid( QPainter* p );
     void drawGridFrame( QPainter* p, const QList< QPair< double, QLineF > >& hLines, const QList< QPair< double, QLineF > >& vLines );

--- a/src/core/composer/qgscomposermap.h
+++ b/src/core/composer/qgscomposermap.h
@@ -435,7 +435,11 @@ class CORE_EXPORT QgsComposerMap : public QgsComposerItem
     /** Sets the margin size (percentage) used when the map is in atlas mode */
     void setAtlasMargin( double margin ) { mAtlasMargin = margin; }
 
+    /**Set the layer to export
+     @param layerIdx can be set to -1 to export all layerr and must be less than numberExportLayers()
+     @note this method was added in version 2.2 */
     int numberExportLayers() const;
+
   signals:
     void extentChanged();
 

--- a/src/core/composer/qgscomposermap.h
+++ b/src/core/composer/qgscomposermap.h
@@ -435,6 +435,7 @@ class CORE_EXPORT QgsComposerMap : public QgsComposerItem
     /** Sets the margin size (percentage) used when the map is in atlas mode */
     void setAtlasMargin( double margin ) { mAtlasMargin = margin; }
 
+    int numberExportLayers() const;
   signals:
     void extentChanged();
 
@@ -650,6 +651,18 @@ class CORE_EXPORT QgsComposerMap : public QgsComposerItem
     void createDefaultGridLineSymbol();
     void initGridAnnotationFormatFromProject();
 
+    enum ItemType
+    {
+      Background,
+      Layer,
+      Grid,
+      OverviewMapExtent,
+      Frame,
+      SelectionBoxes
+    };
+
+    /**Test if this item needs to be exported considering mCurrentExportLayer*/
+    bool exportLayer( ItemType type ) const;
 };
 
 #endif

--- a/src/core/composer/qgscomposermap.h
+++ b/src/core/composer/qgscomposermap.h
@@ -435,9 +435,9 @@ class CORE_EXPORT QgsComposerMap : public QgsComposerItem
     /** Sets the margin size (percentage) used when the map is in atlas mode */
     void setAtlasMargin( double margin ) { mAtlasMargin = margin; }
 
-    /**Set the layer to export
-     @param layerIdx can be set to -1 to export all layerr and must be less than numberExportLayers()
-     @note this method was added in version 2.2 */
+    /**Get the number of layers that this item exports
+      @returns 0 if this item is to be placed on the same layer as the previous item
+      @note this method was added in version 2.2 */
     int numberExportLayers() const;
 
   signals:

--- a/src/core/composer/qgscomposition.h
+++ b/src/core/composer/qgscomposition.h
@@ -440,6 +440,10 @@ class CORE_EXPORT QgsComposition : public QGraphicsScene
     /** Sets the current atlas mode of the composition. Returns false if the mode could not be changed. */
     bool setAtlasMode( QgsComposition::AtlasMode mode );
 
+    // necessary because composerItems( QList< QgsPaperItem* > & pages )
+    // may not return pages in the correct order
+    QList< QgsPaperItem* > pages() { return mPages; }
+
   public slots:
     /**Casts object to the proper subclass type and calls corresponding itemAdded signal*/
     void sendItemAddedSignal( QgsComposerItem* item );

--- a/src/core/composer/qgscomposition.h
+++ b/src/core/composer/qgscomposition.h
@@ -440,8 +440,9 @@ class CORE_EXPORT QgsComposition : public QGraphicsScene
     /** Sets the current atlas mode of the composition. Returns false if the mode could not be changed. */
     bool setAtlasMode( QgsComposition::AtlasMode mode );
 
-    // necessary because composerItems( QList< QgsPaperItem* > & pages )
-    // may not return pages in the correct order
+    /** Return pages in the correct order
+     @note composerItems(QList< QgsPaperItem* > &) may not return pages in the correct order
+     @note added in version 2.2*/
     QList< QgsPaperItem* > pages() { return mPages; }
 
   public slots:

--- a/src/ui/qgssvgexportoptions.ui
+++ b/src/ui/qgssvgexportoptions.ui
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsSvgExportOptionsDialog</class>
+ <widget class="QDialog" name="QgsSvgExportOptionsDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>294</width>
+    <height>118</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>SVG export options</string>
+  </property>
+  <widget class="QWidget" name="layoutWidget">
+   <property name="geometry">
+    <rect>
+     <x>10</x>
+     <y>20</y>
+     <width>273</width>
+     <height>87</height>
+    </rect>
+   </property>
+   <layout class="QVBoxLayout" name="verticalLayout">
+    <item>
+     <widget class="QCheckBox" name="chkMapLayersAsGroup">
+      <property name="text">
+       <string>Export map layers as svg groups</string>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QCheckBox" name="chkTextAsOutline">
+      <property name="enabled">
+       <bool>false</bool>
+      </property>
+      <property name="text">
+       <string>Render text as outline</string>
+      </property>
+      <property name="checked">
+       <bool>true</bool>
+      </property>
+     </widget>
+    </item>
+    <item>
+     <widget class="QDialogButtonBox" name="buttonBox">
+      <property name="orientation">
+       <enum>Qt::Horizontal</enum>
+      </property>
+      <property name="standardButtons">
+       <set>QDialogButtonBox::Ok</set>
+      </property>
+     </widget>
+    </item>
+   </layout>
+  </widget>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>QgsSvgExportOptionsDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>QgsSvgExportOptionsDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>


### PR DESCRIPTION
This allows to save svg in an inkscape compatible format with layers. Since the inkscape layers are top level svg groups, those groups can be axtracted in illustrator (script below).

Consecutive (z-order) graphic items that are not maps are grouped in the same layer, each map layers have its own group.

A checkbox has been added to the file selection dialog to enable this option, old export is still the default.

__ Adobe Illustrator script  to extract layers from svg __

var idoc = app.activeDocument; // get active document
var ilayer = idoc.activeLayer; // get active layer

for (i=ilayer.groupItems.length-1; i>=0; i--){ // loop thru all groups backwards
    var igroup = ilayer.groupItems[i]; // get group
    var newLayer = idoc.layers.add(); // add new layer
    newLayer.name = igroup.name; // rename layer same as group
    igroup.move(newLayer,ElementPlacement.PLACEATEND); // move group to new layer
}
