### PR TITLE
Feature #8725R: hide simplification rendering tab for point layers

### DIFF
--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -408,6 +408,13 @@ void QgsVectorLayerProperties::syncToLayer( void )
     mSimplifyDrawingAtProvider->setChecked( !simplifyMethod.forceLocalOptimization() );
     mSimplifyDrawingAtProvider->setEnabled( mSimplifyDrawingGroupBox->isChecked() );
   }
+  
+  // disable simplification for point layers, now it is not implemented
+  if ( layer->geometryType() == QGis::Point )
+  {
+    mOptionsStackedWidget->removeWidget( mOptsPage_Rendering );
+    mSimplifyDrawingGroupBox->setChecked( false );
+  }
 
   // load appropriate symbology page (V1 or V2)
   updateSymbologyPage();


### PR DESCRIPTION
This patch hides the simplification rendering tab for point layers, now it is not supported
