### PR TITLE
Feature #8725R: support for maximum scale at which the layer should be simplified

### DIFF
--- a/python/core/qgsvectorlayer.sip
+++ b/python/core/qgsvectorlayer.sip
@@ -1013,7 +1013,7 @@ class QgsVectorLayer : QgsMapLayer
     const QgsVectorSimplifyMethod& simplifyMethod() const;
 
     /** Returns whether the VectorLayer can apply the specified simplification hint */
-    bool simplifyDrawingCanbeApplied( int simplifyHint ) const;
+    bool simplifyDrawingCanbeApplied( const QgsRenderContext& renderContext, int simplifyHint ) const;
 
   public slots:
     /**

--- a/python/core/qgsvectorsimplifymethod.sip
+++ b/python/core/qgsvectorsimplifymethod.sip
@@ -26,4 +26,9 @@ class QgsVectorSimplifyMethod
     void setForceLocalOptimization( bool localOptimization );
     /** Gets where the simplification executes, after fetch the geometries from provider, or when supported, in provider before fetch the geometries */
     bool forceLocalOptimization();
+
+    /** Sets the maximum scale at which the layer should be simplified */
+    void setMaximumScale( float maximumScale );
+    /** Gets the maximum scale at which the layer should be simplified */
+    float maximumScale() const;
 };

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -570,6 +570,11 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WFlags fl ) :
   mSimplifyDrawingSpinBox->setValue( settings.value( "/qgis/simplifyDrawingTol", QGis::DEFAULT_MAPTOPIXEL_THRESHOLD ).toFloat() );
   mSimplifyDrawingAtProvider->setChecked( !settings.value( "/qgis/simplifyLocal", true ).toBool() );
 
+  QStringList myScalesList = PROJECT_SCALES.split( "," );
+  myScalesList.append( "1:1" );
+  mSimplifyMaximumScaleComboBox->updateScales( myScalesList );
+  mSimplifyMaximumScaleComboBox->setScale( 1.0 / settings.value( "/qgis/simplifyMaxScale", 1 ).toFloat() );
+
   // Slightly awkard here at the settings value is true to use QImage,
   // but the checkbox is true to use QPixmap
   chkUseQPixmap->setChecked( !( settings.value( "/qgis/use_qimage_to_render", true ).toBool() ) );
@@ -1111,6 +1116,7 @@ void QgsOptions::saveOptions()
   settings.setValue( "/qgis/simplifyDrawingHints", simplifyHints );
   settings.setValue( "/qgis/simplifyDrawingTol", mSimplifyDrawingSpinBox->value() );
   settings.setValue( "/qgis/simplifyLocal", !mSimplifyDrawingAtProvider->isChecked() );
+  settings.setValue( "/qgis/simplifyMaxScale", 1.0 / mSimplifyMaximumScaleComboBox->scale() );
 
   // project
   settings.setValue( "/qgis/projOpenAtLaunch", mProjectOnLaunchCmbBx->currentIndex() );

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -409,6 +409,11 @@ void QgsVectorLayerProperties::syncToLayer( void )
     mSimplifyDrawingAtProvider->setEnabled( mSimplifyDrawingGroupBox->isChecked() );
   }
 
+  QStringList myScalesList = PROJECT_SCALES.split( "," );
+  myScalesList.append( "1:1" );
+  mSimplifyMaximumScaleComboBox->updateScales( myScalesList );
+  mSimplifyMaximumScaleComboBox->setScale( 1.0 / simplifyMethod.maximumScale() );
+
   // load appropriate symbology page (V1 or V2)
   updateSymbologyPage();
 
@@ -557,6 +562,7 @@ void QgsVectorLayerProperties::apply()
   simplifyMethod.setSimplifyHints( simplifyHints );
   simplifyMethod.setThreshold( mSimplifyDrawingSpinBox->value() );
   simplifyMethod.setForceLocalOptimization( !mSimplifyDrawingAtProvider->isChecked() );
+  simplifyMethod.setMaximumScale( 1.0 / mSimplifyMaximumScaleComboBox->scale() );
   layer->setSimplifyMethod( simplifyMethod );
 
   // update symbology

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -702,8 +702,7 @@ bool QgsVectorLayer::draw( QgsRenderContext& rendererContext )
                                       .setSubsetOfAttributes( attributes );
 
   // enable the simplification of the geometries (Using the current map2pixel context) before send it to renderer engine.
-  mCurrentRendererContext = &rendererContext;
-  if ( simplifyDrawingCanbeApplied( QgsVectorLayer::GeometrySimplification ) )
+  if ( simplifyDrawingCanbeApplied( rendererContext, QgsVectorLayer::GeometrySimplification ) )
   {
     QPainter* p = rendererContext.painter();
     double dpi = ( p->device()->logicalDpiX() + p->device()->logicalDpiY() ) / 2;
@@ -749,7 +748,6 @@ bool QgsVectorLayer::draw( QgsRenderContext& rendererContext )
   else
     drawRendererV2( fit, rendererContext, labeling );
 
-  mCurrentRendererContext = NULL;
   return true;
 }
 
@@ -1259,14 +1257,14 @@ bool QgsVectorLayer::setSubsetString( QString subset )
   return res;
 }
 
-bool QgsVectorLayer::simplifyDrawingCanbeApplied( int simplifyHint ) const
+bool QgsVectorLayer::simplifyDrawingCanbeApplied( const QgsRenderContext& renderContext, int simplifyHint ) const
 {
-  if ( mDataProvider && !mEditBuffer && ( hasGeometryType() && geometryType() != QGis::Point ) && ( mSimplifyMethod.simplifyHints() & simplifyHint ) && ( !mCurrentRendererContext || mCurrentRendererContext->useRenderingOptimization() ) )
+  if ( mDataProvider && !mEditBuffer && ( hasGeometryType() && geometryType() != QGis::Point ) && ( mSimplifyMethod.simplifyHints() & simplifyHint ) && renderContext.useRenderingOptimization() )
   {
     double maximumSimplificationScale = mSimplifyMethod.maximumScale();
 
     // check maximum scale at which generalisation should be carried out
-    if ( mCurrentRendererContext && maximumSimplificationScale > 1 && mCurrentRendererContext->rendererScale() <= maximumSimplificationScale )
+    if ( maximumSimplificationScale > 1 && renderContext.rendererScale() <= maximumSimplificationScale )
       return false;
 
     return true;

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -1387,7 +1387,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
     inline const QgsVectorSimplifyMethod& simplifyMethod() const { return mSimplifyMethod; }
 
     /** Returns whether the VectorLayer can apply the specified simplification hint */
-    bool simplifyDrawingCanbeApplied( int simplifyHint ) const;
+    bool simplifyDrawingCanbeApplied( const QgsRenderContext& renderContext, int simplifyHint ) const;
 
   public slots:
     /**

--- a/src/core/qgsvectorsimplifymethod.cpp
+++ b/src/core/qgsvectorsimplifymethod.cpp
@@ -21,6 +21,7 @@ QgsVectorSimplifyMethod::QgsVectorSimplifyMethod()
     : mSimplifyHints( QGis::DEFAULT_MAPTOPIXEL_THRESHOLD > 1 ? QgsVectorLayer::FullSimplification : QgsVectorLayer::GeometrySimplification )
     , mThreshold( QGis::DEFAULT_MAPTOPIXEL_THRESHOLD )
     , mLocalOptimization( true )
+    , mMaximumScale( 1 )
 {
 }
 
@@ -34,5 +35,6 @@ QgsVectorSimplifyMethod& QgsVectorSimplifyMethod::operator=( const QgsVectorSimp
   mSimplifyHints = rh.mSimplifyHints;
   mThreshold = rh.mThreshold;
   mLocalOptimization = rh.mLocalOptimization;
+  mMaximumScale = rh.mMaximumScale;
   return *this;
 }

--- a/src/core/qgsvectorsimplifymethod.h
+++ b/src/core/qgsvectorsimplifymethod.h
@@ -42,6 +42,11 @@ class CORE_EXPORT QgsVectorSimplifyMethod
     /** Gets where the simplification executes, after fetch the geometries from provider, or when supported, in provider before fetch the geometries */
     inline bool forceLocalOptimization() const { return mLocalOptimization; }
 
+    /** Sets the maximum scale at which the layer should be simplified */
+    void setMaximumScale( float maximumScale ) { mMaximumScale = maximumScale; }
+    /** Gets the maximum scale at which the layer should be simplified */
+    inline float maximumScale() const { return mMaximumScale; }
+
   private:
     /** Simplification hints for fast rendering of features of the vector layer managed */
     int mSimplifyHints;
@@ -49,6 +54,8 @@ class CORE_EXPORT QgsVectorSimplifyMethod
     float mThreshold;
     /** Simplification executes after fetch the geometries from provider, otherwise it executes, when supported, in provider before fetch the geometries */
     bool mLocalOptimization;
+    /** Maximum scale at which the layer should be simplified (Maximum scale at which generalisation should be carried out) */
+    float mMaximumScale;
 };
 
 #endif // QGSVECTORSIMPLIFYMETHOD_H

--- a/src/core/symbology-ng/qgslinesymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgslinesymbollayerv2.cpp
@@ -183,7 +183,7 @@ void QgsSimpleLineSymbolLayerV2::renderPolyline( const QPolygonF& points, QgsSym
   p->setPen( context.selected() ? mSelPen : mPen );
 
   // Disable 'Antialiasing' if the geometry was generalized in the current RenderContext (We known that it must have least #2 points).
-  if ( points.size() <= 2 && context.layer() && context.layer()->simplifyDrawingCanbeApplied( QgsVectorLayer::AntialiasingSimplification ) && QgsAbstractGeometrySimplifier::canbeGeneralizedByDeviceBoundingBox( points, context.layer()->simplifyMethod().threshold() ) && ( p->renderHints() & QPainter::Antialiasing ) )
+  if ( points.size() <= 2 && context.layer() && context.layer()->simplifyDrawingCanbeApplied( context.renderContext(), QgsVectorLayer::AntialiasingSimplification ) && QgsAbstractGeometrySimplifier::canbeGeneralizedByDeviceBoundingBox( points, context.layer()->simplifyMethod().threshold() ) && ( p->renderHints() & QPainter::Antialiasing ) )
   {
     p->setRenderHint( QPainter::Antialiasing, false );
     p->drawPolyline( points );

--- a/src/core/symbology-ng/qgssymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgssymbollayerv2.cpp
@@ -388,7 +388,7 @@ void QgsFillSymbolLayerV2::_renderPolygon( QPainter* p, const QPolygonF& points,
   }
 
   // Disable 'Antialiasing' if the geometry was generalized in the current RenderContext (We known that it must have least #5 points).
-  if ( points.size() <= 5 && context.layer() && context.layer()->simplifyDrawingCanbeApplied( QgsVectorLayer::AntialiasingSimplification ) && QgsAbstractGeometrySimplifier::canbeGeneralizedByDeviceBoundingBox( points, context.layer()->simplifyMethod().threshold() ) && ( p->renderHints() & QPainter::Antialiasing ) )
+  if ( points.size() <= 5 && context.layer() && context.layer()->simplifyDrawingCanbeApplied( context.renderContext(), QgsVectorLayer::AntialiasingSimplification ) && QgsAbstractGeometrySimplifier::canbeGeneralizedByDeviceBoundingBox( points, context.layer()->simplifyMethod().threshold() ) && ( p->renderHints() & QPainter::Antialiasing ) )
   {
     p->setRenderHint( QPainter::Antialiasing, false );
     p->drawRect( points.boundingRect() );

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -1710,6 +1710,26 @@
                        </property>
                       </widget>
                      </item>
+                     <item row="3" column="1">
+                      <widget class="QLabel" name="mSimplifyMaxScaleLabel">
+                       <property name="text">
+                        <string>Maximum scale at which the layer should be simplified (1:1 always simplifies): </string>
+                       </property>
+                       <property name="margin">
+                        <number>2</number>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="3" column="2">
+                      <widget class="QgsScaleComboBox" name="mSimplifyMaximumScaleComboBox">
+                       <property name="sizePolicy">
+                        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                         <horstretch>0</horstretch>
+                         <verstretch>0</verstretch>
+                        </sizepolicy>
+                       </property>
+                      </widget>
+                     </item>                      
                     </layout>
                    </widget>
                   </item>

--- a/src/ui/qgsvectorlayerpropertiesbase.ui
+++ b/src/ui/qgsvectorlayerpropertiesbase.ui
@@ -958,6 +958,26 @@
                     </property>
                    </widget>
                   </item>
+                  <item row="3" column="1">
+                   <widget class="QLabel" name="mSimplifyMaxScaleLabel">
+                    <property name="text">
+                     <string>Maximum scale at which the layer should be simplified (1:1 always simplifies): </string>
+                    </property>
+                    <property name="margin">
+                     <number>2</number>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="2">
+                   <widget class="QgsScaleComboBox" name="mSimplifyMaximumScaleComboBox">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
+                    </property>
+                   </widget>
+                  </item>
                  </layout>
                 </widget>
                </item>


### PR DESCRIPTION
This patch adds a new setting for the simplification of vector layers:

The simplification uses a maximum scale at which generalisation should be carried out to the layer rendering options.

So e.g. if I choose 1:50000, no simplification should be carried out in scales [1:1, 1:50000].
