### PR TITLE
Fix bug #8725R: fix collapsed geometries by ST_simplify function of postgis

### DIFF
--- a/python/core/qgssimplifymethod.sip
+++ b/python/core/qgssimplifymethod.sip
@@ -29,9 +29,6 @@ class QgsSimplifyMethod
     /** Gets the tolerance of simplification */
     double tolerance() const;
 
-    /** Returns the optimal tolerance for Douglas-Peucker simplification algorithms */
-    double toleranceForDouglasPeuckerAlgorithms() const;
-
     /** Sets whether the simplification executes after fetch the geometries from provider, otherwise it executes, when supported, in provider before fetch the geometries */
     void setForceLocalOptimization( bool localOptimization );
     /** Gets whether the simplification executes after fetch the geometries from provider, otherwise it executes, when supported, in provider before fetch the geometries */

--- a/src/core/qgsgeometry.cpp
+++ b/src/core/qgsgeometry.cpp
@@ -4697,7 +4697,10 @@ bool QgsGeometry::exportWkbToGeos() const
             }
             sequence << QgsPoint( *x, *y );
           }
-          lines << createGeosLineString( sequence );
+
+          // ignore invalid parts, it can come from ST_Simplify operations
+          if ( sequence.count() > 1 )
+            lines << createGeosLineString( sequence );
         }
         mGeos = createGeosCollection( GEOS_MULTILINESTRING, lines );
         mDirtyGeos = false;

--- a/src/core/qgsmaptopixelgeometrysimplifier.cpp
+++ b/src/core/qgsmaptopixelgeometrysimplifier.cpp
@@ -18,9 +18,9 @@
 #include "qgsmaptopixelgeometrysimplifier.h"
 #include "qgsapplication.h"
 
-QgsMapToPixelSimplifier::QgsMapToPixelSimplifier( int simplifyFlags, double map2pixelTol )
+QgsMapToPixelSimplifier::QgsMapToPixelSimplifier( int simplifyFlags, double tolerance )
     : mSimplifyFlags( simplifyFlags )
-    , mMapToPixelTol( map2pixelTol )
+    , mTolerance( tolerance )
 {
 }
 QgsMapToPixelSimplifier::~QgsMapToPixelSimplifier()
@@ -330,13 +330,13 @@ QgsGeometry* QgsMapToPixelSimplifier::simplify( QgsGeometry* geometry ) const
   unsigned char* wkb = ( unsigned char* )malloc( wkbSize );
   memcpy( wkb, geometry->asWkb(), wkbSize );
   g->fromWkb( wkb, wkbSize );
-  simplifyGeometry( g, mSimplifyFlags, mMapToPixelTol );
+  simplifyGeometry( g, mSimplifyFlags, mTolerance );
 
   return g;
 }
 
 //! Simplifies the geometry (Removing duplicated points) when is applied the specified map2pixel context
-bool QgsMapToPixelSimplifier::simplifyGeometry( QgsGeometry* geometry, int simplifyFlags, double map2pixelTol )
+bool QgsMapToPixelSimplifier::simplifyGeometry( QgsGeometry* geometry, int simplifyFlags, double tolerance )
 {
   size_t targetWkbSize = 0;
 
@@ -351,7 +351,7 @@ bool QgsMapToPixelSimplifier::simplifyGeometry( QgsGeometry* geometry, int simpl
   size_t wkbSize = geometry->wkbSize( );
 
   // Simplify the geometry rewriting temporally its WKB-stream for saving calloc's.
-  if ( simplifyWkbGeometry( simplifyFlags, wkbType, wkb, wkbSize, wkb, targetWkbSize, envelope, map2pixelTol ) )
+  if ( simplifyWkbGeometry( simplifyFlags, wkbType, wkb, wkbSize, wkb, targetWkbSize, envelope, tolerance ) )
   {
     unsigned char* targetWkb = ( unsigned char* )malloc( targetWkbSize );
     memcpy( targetWkb, wkb, targetWkbSize );
@@ -364,5 +364,5 @@ bool QgsMapToPixelSimplifier::simplifyGeometry( QgsGeometry* geometry, int simpl
 //! Simplifies the geometry (Removing duplicated points) when is applied the specified map2pixel context
 bool QgsMapToPixelSimplifier::simplifyGeometry( QgsGeometry* geometry ) const
 {
-  return simplifyGeometry( geometry, mSimplifyFlags, mMapToPixelTol );
+  return simplifyGeometry( geometry, mSimplifyFlags, mTolerance );
 }

--- a/src/core/qgsmaptopixelgeometrysimplifier.h
+++ b/src/core/qgsmaptopixelgeometrysimplifier.h
@@ -32,7 +32,7 @@
 class CORE_EXPORT QgsMapToPixelSimplifier : public QgsAbstractGeometrySimplifier
 {
   public:
-    QgsMapToPixelSimplifier( int simplifyFlags, double map2pixelTol );
+    QgsMapToPixelSimplifier( int simplifyFlags, double tolerance );
     virtual ~QgsMapToPixelSimplifier();
 
     //! Applicable simplification flags
@@ -51,8 +51,8 @@ class CORE_EXPORT QgsMapToPixelSimplifier : public QgsAbstractGeometrySimplifier
     //! Current simplification flags
     int mSimplifyFlags;
 
-    //! Map2Pixel tolerance for the simplification
-    double mMapToPixelTol;
+    //! Distance tolerance for the simplification
+    double mTolerance;
 
     //! Returns the squared 2D-distance of the vector defined by the two points specified
     static float calculateLengthSquared2D( double x1, double y1, double x2, double y2 );
@@ -73,10 +73,10 @@ class CORE_EXPORT QgsMapToPixelSimplifier : public QgsAbstractGeometrySimplifier
     static bool canbeGeneralizedByMapBoundingBox( const QgsRectangle& envelope, double map2pixelTol );
 
     //! Returns whether the envelope can be replaced by its BBOX when is applied the specified map2pixel context
-    inline bool canbeGeneralizedByMapBoundingBox( const QgsRectangle& envelope ) const { return canbeGeneralizedByMapBoundingBox( envelope, mMapToPixelTol ); }
+    inline bool canbeGeneralizedByMapBoundingBox( const QgsRectangle& envelope ) const { return canbeGeneralizedByMapBoundingBox( envelope, mTolerance ); }
 
     //! Simplifies the geometry when is applied the specified map2pixel context
-    static bool simplifyGeometry( QgsGeometry* geometry, int simplifyFlags, double map2pixelTol );
+    static bool simplifyGeometry( QgsGeometry* geometry, int simplifyFlags, double tolerance );
 
 };
 

--- a/src/core/qgssimplifymethod.cpp
+++ b/src/core/qgssimplifymethod.cpp
@@ -54,12 +54,6 @@ void QgsSimplifyMethod::setForceLocalOptimization( bool localOptimization )
   mForceLocalOptimization = localOptimization;
 }
 
-double QgsSimplifyMethod::toleranceForDouglasPeuckerAlgorithms() const
-{
-  //TODO: define more precise value, now, it is experimental but conservative
-  return mTolerance / 5.0;
-}
-
 QgsAbstractGeometrySimplifier* QgsSimplifyMethod::createGeometrySimplifier( const QgsSimplifyMethod& simplifyMethod )
 {
   QgsSimplifyMethod::MethodType methodType = simplifyMethod.methodType();

--- a/src/core/qgssimplifymethod.h
+++ b/src/core/qgssimplifymethod.h
@@ -48,9 +48,6 @@ class CORE_EXPORT QgsSimplifyMethod
     //! Gets the tolerance of simplification
     inline double tolerance() const { return mTolerance; }
 
-    //! Returns the optimal tolerance for Douglas-Peucker simplification algorithms
-    double toleranceForDouglasPeuckerAlgorithms() const;
-
     //! Sets whether the simplification executes after fetch the geometries from provider, otherwise it executes, when supported, in provider before fetch the geometries
     void setForceLocalOptimization( bool localOptimization );
     //! Gets whether the simplification executes after fetch the geometries from provider, otherwise it executes, when supported, in provider before fetch the geometries

--- a/src/providers/ogr/qgsogrgeometrysimplifier.cpp
+++ b/src/providers/ogr/qgsogrgeometrysimplifier.cpp
@@ -62,8 +62,8 @@ bool QgsOgrTopologyPreservingSimplifier::simplifyGeometry( OGRGeometryH geometry
 
 #if defined(GDAL_VERSION_NUM) && defined(GDAL_COMPUTE_VERSION) && GDAL_VERSION_NUM >= GDAL_COMPUTE_VERSION(1,11,0)
 
-QgsOgrMapToPixelSimplifier::QgsOgrMapToPixelSimplifier( int simplifyFlags, double map2pixelTol )
-    : QgsMapToPixelSimplifier( simplifyFlags, map2pixelTol )
+QgsOgrMapToPixelSimplifier::QgsOgrMapToPixelSimplifier( int simplifyFlags, double tolerance )
+    : QgsMapToPixelSimplifier( simplifyFlags, tolerance )
     , mPointBufferPtr( NULL )
     , mPointBufferCount( 0 )
 {
@@ -136,7 +136,7 @@ bool QgsOgrMapToPixelSimplifier::simplifyOgrGeometry( QGis::GeometryType geometr
   if ( geometryType == QGis::Point || geometryType == QGis::UnknownGeometry ) return false;
   pointSimplifiedCount = 0;
 
-  double map2pixelTol = mMapToPixelTol * mMapToPixelTol; //-> Use mappixelTol for 'LengthSquare' calculations.
+  double map2pixelTol = mTolerance * mTolerance; //-> Use mappixelTol for 'LengthSquare' calculations.
   double x, y, lastX = 0, lastY = 0;
 
   char* xsourcePtr = ( char* )xptr;

--- a/src/providers/ogr/qgsogrgeometrysimplifier.h
+++ b/src/providers/ogr/qgsogrgeometrysimplifier.h
@@ -62,7 +62,7 @@ class QgsOgrTopologyPreservingSimplifier : public QgsOgrAbstractGeometrySimplifi
 class QgsOgrMapToPixelSimplifier : public QgsOgrAbstractGeometrySimplifier, QgsMapToPixelSimplifier
 {
   public:
-    QgsOgrMapToPixelSimplifier( int simplifyFlags, double map2pixelTol );
+    QgsOgrMapToPixelSimplifier( int simplifyFlags, double tolerance );
     virtual ~QgsOgrMapToPixelSimplifier();
 
   private:

--- a/src/providers/postgres/qgspostgresfeatureiterator.cpp
+++ b/src/providers/postgres/qgspostgresfeatureiterator.cpp
@@ -14,6 +14,7 @@
  ***************************************************************************/
 #include "qgspostgresfeatureiterator.h"
 #include "qgspostgresprovider.h"
+#include "qgsgeometry.h"
 
 #include "qgslogger.h"
 #include "qgsmessagelog.h"
@@ -292,6 +293,7 @@ QString QgsPostgresFeatureIterator::whereClauseRect()
 bool QgsPostgresFeatureIterator::declareCursor( const QString& whereClause )
 {
   mFetchGeometry = !( mRequest.flags() & QgsFeatureRequest::NoGeometry ) && !P->mGeometryColumn.isNull();
+  bool simplifyGeometry = false;
 
   try
   {
@@ -305,7 +307,8 @@ bool QgsPostgresFeatureIterator::declareCursor( const QString& whereClause )
                                      ? ( P->mConnectionRO->majorVersion() < 2 ? "simplify" : "st_simplify" )
                                      : ( P->mConnectionRO->majorVersion() < 2 ? "simplifypreservetopology" : "st_simplifypreservetopology" );
 
-      double tolerance = simplifyMethod.tolerance();
+      double tolerance = simplifyMethod.tolerance() * 0.8; //-> Default factor for the maximum displacement distance for simplification, similar as GeoServer does
+      simplifyGeometry = simplifyMethod.methodType() == QgsSimplifyMethod::OptimizeForRendering;
 
       query += QString( "%1(%5(%2%3,%6),'%4')" )
                .arg( P->mConnectionRO->majorVersion() < 2 ? "asbinary" : "st_asbinary" )
@@ -364,6 +367,17 @@ bool QgsPostgresFeatureIterator::declareCursor( const QString& whereClause )
         continue;
 
       query += delim + P->mConnectionRO->fieldExpression( P->field( idx ) );
+    }
+
+    // query BBOX of geometries to redefine the geometries collapsed by ST_Simplify()
+    if ( simplifyGeometry && !( P->mConnectionRO->majorVersion() >= 2 && P->mConnectionRO->minorVersion() >= 1 ) && QGis::flatType( QGis::singleType( P->geometryType() ) ) == QGis::WKBPolygon )
+    {
+      query += QString( ",%1(%5(%2)%3,'%4')" )
+               .arg( P->mConnectionRO->majorVersion() < 2 ? "asbinary" : "st_asbinary" )
+               .arg( P->quotedIdentifier( P->mGeometryColumn ) )
+               .arg( P->mSpatialColType == sctGeography ? "::geometry" : "" )
+               .arg( P->endianString() )
+               .arg( P->mConnectionRO->majorVersion() < 2 ? "envelope" : "st_envelope" );
     }
 
     query += " FROM " + P->mQuery;
@@ -587,6 +601,29 @@ bool QgsPostgresFeatureIterator::getFeature( QgsPostgresResult &queryResult, int
     {
       for ( int idx = 0; idx < P->mAttributeFields.count(); ++idx )
         getFeatureAttribute( idx, queryResult, row, col, feature );
+    }
+
+    // fix collapsed geometries by ST_Simplify() using the BBOX fetched from the current query
+    const QgsSimplifyMethod& simplifyMethod = mRequest.simplifyMethod();
+    if ( mFetchGeometry && !simplifyMethod.forceLocalOptimization() && simplifyMethod.methodType() == QgsSimplifyMethod::OptimizeForRendering && QGis::flatType( QGis::singleType( P->geometryType() ) ) == QGis::WKBPolygon )
+    {
+      QgsGeometry* geometry = feature.geometry();
+
+      if ( !( P->mConnectionRO->majorVersion() >= 2 && P->mConnectionRO->minorVersion() >= 1 ) && ( !geometry || geometry->length() == 0 ) )
+      {
+        int returnedLength = ::PQgetlength( queryResult.result(), row, col );
+
+        if ( returnedLength > 0 )
+        {
+          unsigned char *featureGeom = new unsigned char[returnedLength + 1];
+          memcpy( featureGeom, PQgetvalue( queryResult.result(), row, col ), returnedLength );
+          memset( featureGeom + returnedLength, 0, 1 );
+
+          QgsGeometry *envelope = new QgsGeometry();
+          envelope->fromWkb( featureGeom, returnedLength + 1 );
+          feature.setGeometry( envelope );
+        }
+      }
     }
 
     return true;

--- a/src/providers/postgres/qgspostgresfeatureiterator.cpp
+++ b/src/providers/postgres/qgspostgresfeatureiterator.cpp
@@ -303,11 +303,9 @@ bool QgsPostgresFeatureIterator::declareCursor( const QString& whereClause )
     {
       QString simplifyFunctionName = simplifyMethod.methodType() == QgsSimplifyMethod::OptimizeForRendering
                                      ? ( P->mConnectionRO->majorVersion() < 2 ? "simplify" : "st_simplify" )
-                                         : ( P->mConnectionRO->majorVersion() < 2 ? "simplifypreservetopology" : "st_simplifypreservetopology" );
+                                     : ( P->mConnectionRO->majorVersion() < 2 ? "simplifypreservetopology" : "st_simplifypreservetopology" );
 
-      double tolerance = simplifyMethod.methodType() == QgsSimplifyMethod::OptimizeForRendering
-                         ? simplifyMethod.toleranceForDouglasPeuckerAlgorithms()
-                         : simplifyMethod.tolerance();
+      double tolerance = simplifyMethod.tolerance();
 
       query += QString( "%1(%5(%2%3,%6),'%4')" )
                .arg( P->mConnectionRO->majorVersion() < 2 ? "asbinary" : "st_asbinary" )


### PR DESCRIPTION
This patch fixes the bug of ST_simplify function for postgis that collapse geometries (polygons and linestrings) using big tolerances of simplification.

Changes:
- fixes the bug of ST_simplify function for postgis <= 2.1.0
- define better the tolerance of simplification on provider side, now the rendering is faster!
