### PR TITLE
Fix bug #8725R: no check simplification topology for point geometries in postgis provider

### DIFF
--- a/src/providers/postgres/qgspostgresfeatureiterator.cpp
+++ b/src/providers/postgres/qgspostgresfeatureiterator.cpp
@@ -605,7 +605,7 @@ bool QgsPostgresFeatureIterator::getFeature( QgsPostgresResult &queryResult, int
 
     // fix collapsed geometries by ST_Simplify() using the BBOX fetched from the current query
     const QgsSimplifyMethod& simplifyMethod = mRequest.simplifyMethod();
-    if ( mFetchGeometry && !simplifyMethod.forceLocalOptimization() && simplifyMethod.methodType() == QgsSimplifyMethod::OptimizeForRendering )
+    if ( mFetchGeometry && !simplifyMethod.forceLocalOptimization() && simplifyMethod.methodType() == QgsSimplifyMethod::OptimizeForRendering && QGis::flatType( QGis::singleType( P->geometryType() ) ) != QGis::WKBPoint )
     {
       QgsGeometry* geometry = feature.geometry();
 


### PR DESCRIPTION
It fixes one serious error, avoid check topology state for point geometries!
