### PR TITLE
Consistent management of project CRS properties in project file

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -8086,11 +8086,6 @@ void QgisApp::updateCRSStatusBar()
 
 void QgisApp::destinationSrsChanged()
 {
-  // save this information to project
-  long srsid = mMapCanvas->mapRenderer()->destinationCrs().srsid();
-  QString srs = mMapCanvas->mapRenderer()->destinationCrs().authid();
-  QgsProject::instance()->writeEntry( "SpatialRefSys", "/ProjectCRSID", ( int )srsid );
-  QgsProject::instance()->writeEntry( "SpatialRefSys", "/ProjectCrs", srs );
   updateCRSStatusBar();
 }
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -3299,7 +3299,9 @@ void QgisApp::fileNew( bool thePromptToSaveFlag, bool forceBlank )
   srs.createFromOgcWmsCrs( defCrs );
   myRenderer->setDestinationCrs( srs );
   // write the projections _proj string_ to project settings
-  prj->writeEntry( "SpatialRefSys", "/ProjectCrs", defCrs );
+  prj->writeEntry( "SpatialRefSys", "/ProjectCRSProj4String", srs.toProj4() );
+  prj->writeEntry( "SpatialRefSys", "/ProjectCrs", srs.authid() );
+  prj->writeEntry( "SpatialRefSys", "/ProjectCRSID", (int) srs.srsid() );
   prj->dirty( false );
   if ( srs.mapUnits() != QGis::UnknownUnit )
   {

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -8088,7 +8088,9 @@ void QgisApp::destinationSrsChanged()
 {
   // save this information to project
   long srsid = mMapCanvas->mapRenderer()->destinationCrs().srsid();
+  QString srs = mMapCanvas->mapRenderer()->destinationCrs().authid();
   QgsProject::instance()->writeEntry( "SpatialRefSys", "/ProjectCRSID", ( int )srsid );
+  QgsProject::instance()->writeEntry( "SpatialRefSys", "/ProjectCrs", srs );
   updateCRSStatusBar();
 }
 

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -589,6 +589,8 @@ void QgsProjectProperties::apply()
     // write the currently selected projections _proj string_ to project settings
     QgsDebugMsg( QString( "SpatialRefSys/ProjectCRSProj4String: %1" ).arg( projectionSelector->selectedProj4String() ) );
     QgsProject::instance()->writeEntry( "SpatialRefSys", "/ProjectCRSProj4String", projectionSelector->selectedProj4String() );
+    QgsProject::instance()->writeEntry( "SpatialRefSys", "/ProjectCRSID", (int) projectionSelector->selectedCrsId() );
+    QgsProject::instance()->writeEntry( "SpatialRefSys", "/ProjectCrs", projectionSelector->selectedAuthId() );
 
     // Set the map units to the projected coordinates if we are projecting
     if ( isProjected() )


### PR DESCRIPTION
Following bug 9397 http://hub.qgis.org/issues/9397, I made project CRS properties storing more consistant. 

Previously, only "ProjectCrs" was created at the project creation. "ProjectCRSID" and "ProjectCRSProj4String" were only created when a different CRS is chosen, but saved in two different places. Also, "ProjectCrs" was not updated once a different CRS was chosen.

With this patch, all three properties are created as soon as a project is saved, then all three are updated in the same function when a new CRS is chosen.
