### PR TITLE
Fix empty expression when reading from OGC filter

### DIFF
--- a/src/core/qgsogcutils.cpp
+++ b/src/core/qgsogcutils.cpp
@@ -1444,6 +1444,9 @@ QgsExpression* QgsOgcUtils::expressionFromOgcFilter( const QDomElement& element 
     childElem = childElem.nextSiblingElement();
   }
 
+  // update expression string
+  expr->mExp = expr->dump();
+
   return expr;
 }
 


### PR DESCRIPTION
This fixes empty filter expressions in a layer style, e.g. when loading a SLD containing ogc:Filter nodes.
