### PR TITLE
fix visual compile error from e8205c98

### DIFF
--- a/src/core/symbology-ng/qgscategorizedsymbolrendererv2.cpp
+++ b/src/core/symbology-ng/qgscategorizedsymbolrendererv2.cpp
@@ -56,7 +56,7 @@ QgsRendererCategoryV2& QgsRendererCategoryV2::operator=( QgsRendererCategoryV2 c
 void QgsRendererCategoryV2::swap( QgsRendererCategoryV2 & cat )
 {
   std::swap( mValue, cat.mValue );
-  std::swap( mSymbol, cat.mSymbol );
+  mSymbol.swap( cat.mSymbol );
   std::swap( mLabel, cat.mLabel );
 }
 

--- a/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.cpp
+++ b/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.cpp
@@ -62,7 +62,7 @@ void QgsRendererRangeV2::swap( QgsRendererRangeV2 & other )
 {
   std::swap( mLowerValue, other.mLowerValue );
   std::swap( mUpperValue, other.mUpperValue );
-  std::swap( mSymbol, other.mSymbol );
+  mSymbol.swap( other.mSymbol );
   std::swap( mLabel, other.mLabel );
 }
 

--- a/src/core/symbology-ng/qgssinglesymbolrendererv2.cpp
+++ b/src/core/symbology-ng/qgssinglesymbolrendererv2.cpp
@@ -35,35 +35,6 @@ QgsSingleSymbolRendererV2::QgsSingleSymbolRendererV2( QgsSymbolV2* symbol )
   Q_ASSERT( symbol );
 }
 
-// we need to clone symbol
-QgsSingleSymbolRendererV2::QgsSingleSymbolRendererV2( const QgsSingleSymbolRendererV2 & src )
-    : QgsFeatureRendererV2( "singleSymbol" )
-    , mSymbol( src.mSymbol.data() ? src.mSymbol->clone() : NULL )
-    , mRotation( src.mRotation.data() ? new QgsExpression( src.mRotation->expression() ) : NULL )
-    , mSizeScale( src.mSizeScale.data() ?  new QgsExpression( src.mSizeScale->expression() ) : NULL )
-    , mScaleMethod( src.mScaleMethod )
-    , mTempSymbol( src.mTempSymbol.data() ? src.mTempSymbol->clone() : NULL )
-{
-}
-
-// this is a copy + swap idiom implementation
-// the copy is done with the 'pass by value'
-QgsSingleSymbolRendererV2 & QgsSingleSymbolRendererV2::operator=( QgsSingleSymbolRendererV2 other )
-{
-  swap( other );
-  return *this;
-}
-
-void QgsSingleSymbolRendererV2::swap( QgsSingleSymbolRendererV2 & other )
-{
-  std::swap( mSymbol, other.mSymbol );
-  std::swap( mRotation, other.mRotation );
-  std::swap( mSizeScale, other.mSizeScale );
-  std::swap( mScaleMethod, other.mScaleMethod );
-  std::swap( mTempSymbol, other.mTempSymbol );
-  std::swap( mOrigSize, other.mOrigSize );
-}
-
 QgsSingleSymbolRendererV2::~QgsSingleSymbolRendererV2()
 {
 }

--- a/src/core/symbology-ng/qgssinglesymbolrendererv2.h
+++ b/src/core/symbology-ng/qgssinglesymbolrendererv2.h
@@ -26,9 +26,6 @@ class CORE_EXPORT QgsSingleSymbolRendererV2 : public QgsFeatureRendererV2
   public:
 
     QgsSingleSymbolRendererV2( QgsSymbolV2* symbol );
-    QgsSingleSymbolRendererV2( const QgsSingleSymbolRendererV2 & );
-    QgsSingleSymbolRendererV2 & operator=( QgsSingleSymbolRendererV2 other );
-
 
     virtual ~QgsSingleSymbolRendererV2();
 
@@ -102,9 +99,6 @@ class CORE_EXPORT QgsSingleSymbolRendererV2 : public QgsFeatureRendererV2
     // temporary stuff for rendering
     QScopedPointer<QgsSymbolV2> mTempSymbol;
     double mOrigSize;
-
-    // for copy and swap idiom for assignment operator
-    void swap( QgsSingleSymbolRendererV2 & other );
 };
 
 


### PR DESCRIPTION
Can someone please confirm that it fixes the visual compile error ?

I replaced the std::swap by QScopedPointer swap.

I also removed the cpy and assigment op from QgsSingleSymbolRendererV2 that are useless since th base class is non copyable.
