### PR TITLE
Bugfix #7177

### DIFF
--- a/src/app/composer/qgscomposerlegendwidget.cpp
+++ b/src/app/composer/qgscomposerlegendwidget.cpp
@@ -888,15 +888,26 @@ void QgsComposerLegendWidget::updateLegend()
 
     //get layer id list
     QStringList layerIdList;
-    QgsMapCanvas* canvas = app->mapCanvas();
-    if ( canvas )
+    const QgsComposerMap* linkedMap = mLegend->composerMap();
+    if ( linkedMap && linkedMap->keepLayerSet() )
     {
-      QgsMapRenderer* renderer = canvas->mapRenderer();
-      if ( renderer )
+      //if there is a linked map, and if that linked map has a locked layer set, we take the layerIdList from that ComposerMap
+      layerIdList = linkedMap->layerSet();
+    }
+    else
+    {
+      //we take the layerIdList from the Canvas
+      QgsMapCanvas* canvas = app->mapCanvas();
+      if ( canvas )
       {
-        layerIdList = renderer->layerSet();
+        QgsMapRenderer* renderer = canvas->mapRenderer();
+        if ( renderer )
+        {
+          layerIdList = renderer->layerSet();
+        }
       }
     }
+
 
     //and also group info
     QgsAppLegendInterface legendIface( app->legend() );

--- a/src/core/composer/qgscomposition.cpp
+++ b/src/core/composer/qgscomposition.cpp
@@ -1862,12 +1862,6 @@ void QgsComposition::addComposerScaleBar( QgsComposerScaleBar* scaleBar )
 
 void QgsComposition::addComposerLegend( QgsComposerLegend* legend )
 {
-  //take first available map
-  QList<const QgsComposerMap*> mapItemList = composerMapItems();
-  if ( mapItemList.size() > 0 )
-  {
-    legend->setComposerMap( mapItemList.at( 0 ) );
-  }
   addItem( legend );
   emit composerLegendAdded( legend );
   clearSelection();


### PR DESCRIPTION
Fixes #7177 and by the way fixed "composer legends inappropriately connected to the first composer map item on creation from XML"
