### PR TITLE
Fix bug #9429: no validate featureIds using all feature collection

### DIFF
--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -2787,20 +2787,6 @@ void QgsVectorLayer::setSelectedFeatures( const QgsFeatureIds& ids )
 
   mSelectedFeatureIds = ids;
 
-  QgsFeatureIds allIds = allFeatureIds();
-  QgsFeatureIds::iterator id = mSelectedFeatureIds.begin();
-  while ( id != mSelectedFeatureIds.end() )
-  {
-    if ( !allIds.contains( *id ) )
-    {
-      id = mSelectedFeatureIds.erase( id );
-    }
-    else
-    {
-      ++id;
-    }
-  }
-
   // invalidate cache
   setCacheImage( 0 );
 


### PR DESCRIPTION
This patch fixes bug http://hub.qgis.org/issues/9429

Any selection of features in QGIS calls to 'QgsVectorLayer::setSelectedFeatures' and from this commit (https://github.com/qgis/QGIS/commit/39fab67e602aaa8be7e561a50b40ab7c38914258) it loads all featureIds even when none features were selected.

When the layer has many features, it is a big bottleneck!

I think that this verification is unneccesary in most of situations because of selections become from a 'QgsFeatureIterator fit = getFeatures(...)' calls.
