### PR TITLE
Fix bug #9429: enable validation ids with optional parameter

### DIFF
--- a/python/core/qgsvectorlayer.sip
+++ b/python/core/qgsvectorlayer.sip
@@ -356,7 +356,7 @@ class QgsVectorLayer : QgsMapLayer
      *
      * @param ids   The ids which will be the new selection
      */
-    void setSelectedFeatures( const QgsFeatureIds &ids );
+    void setSelectedFeatures( const QgsFeatureIds &ids, bool validateIds = false );
 
     /** Returns the bounding box of the selected features. If there is no selection, QgsRectangle(0,0,0,0) is returned */
     QgsRectangle boundingBoxOfSelected();

--- a/python/gui/attributetable/qgsifeatureselectionmanager.sip
+++ b/python/gui/attributetable/qgsifeatureselectionmanager.sip
@@ -55,7 +55,7 @@ class QgsIFeatureSelectionManager : QObject
      *
      * @param ids   The ids which will be the new selection
      */
-    virtual void setSelectedFeatures( const QgsFeatureIds& ids ) = 0;
+    virtual void setSelectedFeatures( const QgsFeatureIds& ids, bool validateIds = false ) = 0;
 
     /**
      * Return reference to identifiers of selected features

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -2787,20 +2787,13 @@ void QgsVectorLayer::setSelectedFeatures( const QgsFeatureIds& ids, bool validat
 
   mSelectedFeatureIds = ids;
 
-  if ( validateIds )
+  if ( validateIds && !mSelectedFeatureIds.empty() )
   {
-    QgsFeatureIds allIds;
-    bool selectAllIds = true;
+    QgsFeatureIds allIds = allFeatureIds();
 
     QgsFeatureIds::iterator id = mSelectedFeatureIds.begin();
     while ( id != mSelectedFeatureIds.end() )
     {
-      if ( selectAllIds )
-      {
-        allIds = allFeatureIds();
-        selectAllIds = false;
-      }
-
       if ( !allIds.contains( *id ) )
       {
         id = mSelectedFeatureIds.erase( id );

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -2781,11 +2781,36 @@ bool QgsVectorLayer::rollBack( bool deleteBuffer )
   return true;
 }
 
-void QgsVectorLayer::setSelectedFeatures( const QgsFeatureIds& ids )
+void QgsVectorLayer::setSelectedFeatures( const QgsFeatureIds& ids, bool validateIds )
 {
   QgsFeatureIds deselectedFeatures = mSelectedFeatureIds - ids;
 
   mSelectedFeatureIds = ids;
+
+  if ( validateIds )
+  {
+    QgsFeatureIds allIds;
+    bool selectAllIds = true;
+
+    QgsFeatureIds::iterator id = mSelectedFeatureIds.begin();
+    while ( id != mSelectedFeatureIds.end() )
+    {
+      if ( selectAllIds )
+      {
+        allIds = allFeatureIds();
+        selectAllIds = false;
+      }
+
+      if ( !allIds.contains( *id ) )
+      {
+        id = mSelectedFeatureIds.erase( id );
+      }
+      else
+      {
+        ++id;
+      }
+    }
+  }
 
   // invalidate cache
   setCacheImage( 0 );

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -707,7 +707,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
      *
      * @param ids   The ids which will be the new selection
      */
-    void setSelectedFeatures( const QgsFeatureIds &ids );
+    void setSelectedFeatures( const QgsFeatureIds &ids, bool validateIds = false );
 
     /** Returns the bounding box of the selected features. If there is no selection, QgsRectangle(0,0,0,0) is returned */
     QgsRectangle boundingBoxOfSelected();

--- a/src/gui/attributetable/qgsgenericfeatureselectionmanager.cpp
+++ b/src/gui/attributetable/qgsgenericfeatureselectionmanager.cpp
@@ -43,8 +43,10 @@ void QgsGenericFeatureSelectionManager::deselect( const QgsFeatureIds& ids )
   emit selectionChanged( QgsFeatureIds(), ids, false );
 }
 
-void QgsGenericFeatureSelectionManager::setSelectedFeatures( const QgsFeatureIds& ids )
+void QgsGenericFeatureSelectionManager::setSelectedFeatures( const QgsFeatureIds& ids, bool validateIds )
 {
+  Q_UNUSED( validateIds );
+
   QgsFeatureIds selected = mSelectedFeatures - ids;
   QgsFeatureIds deselected = ids - mSelectedFeatures;
 

--- a/src/gui/attributetable/qgsgenericfeatureselectionmanager.h
+++ b/src/gui/attributetable/qgsgenericfeatureselectionmanager.h
@@ -36,7 +36,7 @@ class GUI_EXPORT QgsGenericFeatureSelectionManager : public QgsIFeatureSelection
     virtual int selectedFeatureCount();
     virtual void select( const QgsFeatureIds& ids );
     virtual void deselect( const QgsFeatureIds& ids );
-    virtual void setSelectedFeatures( const QgsFeatureIds& ids );
+    virtual void setSelectedFeatures( const QgsFeatureIds& ids, bool validateIds = false );
     virtual const QgsFeatureIds& selectedFeaturesIds() const;
 
   private:

--- a/src/gui/attributetable/qgsifeatureselectionmanager.h
+++ b/src/gui/attributetable/qgsifeatureselectionmanager.h
@@ -62,7 +62,7 @@ class GUI_EXPORT QgsIFeatureSelectionManager : public QObject
      *
      * @param ids   The ids which will be the new selection
      */
-    virtual void setSelectedFeatures( const QgsFeatureIds& ids ) = 0;
+    virtual void setSelectedFeatures( const QgsFeatureIds& ids, bool validateIds = false ) = 0;
 
     /**
      * Return reference to identifiers of selected features

--- a/src/gui/attributetable/qgsvectorlayerselectionmanager.cpp
+++ b/src/gui/attributetable/qgsvectorlayerselectionmanager.cpp
@@ -39,9 +39,9 @@ void QgsVectorLayerSelectionManager::deselect( const QgsFeatureIds& ids )
   mLayer->deselect( ids );
 }
 
-void QgsVectorLayerSelectionManager::setSelectedFeatures( const QgsFeatureIds& ids )
+void QgsVectorLayerSelectionManager::setSelectedFeatures( const QgsFeatureIds& ids, bool validateIds )
 {
-  mLayer->setSelectedFeatures( ids );
+  mLayer->setSelectedFeatures( ids, validateIds );
 }
 
 const QgsFeatureIds& QgsVectorLayerSelectionManager::selectedFeaturesIds() const

--- a/src/gui/attributetable/qgsvectorlayerselectionmanager.h
+++ b/src/gui/attributetable/qgsvectorlayerselectionmanager.h
@@ -54,7 +54,7 @@ class GUI_EXPORT QgsVectorLayerSelectionManager : public QgsIFeatureSelectionMan
      *
      * @param ids   The ids which will be the new selection
      */
-    virtual void setSelectedFeatures( const QgsFeatureIds& ids );
+    virtual void setSelectedFeatures( const QgsFeatureIds& ids, bool validateIds = false );
 
     /**
      * Return reference to identifiers of selected features


### PR DESCRIPTION
This patch is related with bug 9429, it enables validation of new selected ids

It is related with ....
https://github.com/qgis/QGIS/pull/1114
