### PR TITLE
fix8873: remove misleading message

### DIFF
--- a/src/app/qgsmaptoolvertexedit.cpp
+++ b/src/app/qgsmaptoolvertexedit.cpp
@@ -44,7 +44,7 @@ void QgsMapToolVertexEdit::displaySnapToleranceWarning()
 {
   QgisApp::instance()->messageBar()->pushMessage(
     tr( "Snap tolerance" ),
-    tr( "Could not snap segment. Have you set the tolerance in Settings > Snapping Options?" ),
+    tr( "Could not snap segment." ),
     QgsMessageBar::INFO,
     QgisApp::instance()->messageTimeout() );
 }


### PR DESCRIPTION
ok to change this message?
I think it is a bit confusing, see http://hub.qgis.org/issues/8873
