### PR TITLE
Fix bug #9454: MapNodeTool unnecessarily refresh the map

### DIFF
--- a/src/app/nodetool/qgsmaptoolnodetool.cpp
+++ b/src/app/nodetool/qgsmaptoolnodetool.cpp
@@ -741,7 +741,6 @@ void QgsMapToolNodeTool::keyPressEvent( QKeyEvent* e )
 
     mSelectedFeature->deselectAllVertexes();
     safeSelectVertex( firstSelectedIndex - 1 );
-    mCanvas->refresh();
   }
   else if ( mSelectedFeature && ( e->key() == Qt::Key_Greater || e->key() == Qt::Key_Period ) )
   {
@@ -751,7 +750,6 @@ void QgsMapToolNodeTool::keyPressEvent( QKeyEvent* e )
 
     mSelectedFeature->deselectAllVertexes();
     safeSelectVertex( firstSelectedIndex + 1 );
-    mCanvas->refresh();
   }
 }
 


### PR DESCRIPTION
This pull fixes the bug #9454 ( http://hub.qgis.org/issues/9454 ):

When MapNodeTool is active and user changes the selected nodes, it unnecessarily refresh the map
