### PR TITLE
better message display in map edit tools (fix #8873)

### DIFF
--- a/python/gui/qgsmapcanvas.sip
+++ b/python/gui/qgsmapcanvas.sip
@@ -354,6 +354,10 @@ class QgsMapCanvas : QGraphicsView
 
     //! Emit map tool changed event
     void mapToolSet( QgsMapTool *tool );
+    
+    //! Emit map tool changed with the old tool
+    //! @note added in 2.3
+    void mapToolSet( QgsMapTool *newTool, QgsMapTool* oldTool );
 
     // ### QGIS 3: remove the signal
     //! Emitted when selection in any layer gets changed

--- a/python/gui/qgsmaptool.sip
+++ b/python/gui/qgsmaptool.sip
@@ -105,6 +105,11 @@ class QgsMapTool : QObject
 
     //! returns pointer to the tool's map canvas
     QgsMapCanvas* canvas();
+    
+    /** return the tool name
+    * @note added in 2.3
+    */
+    QString toolName();
 
   protected:
 

--- a/src/app/nodetool/qgsmaptoolnodetool.cpp
+++ b/src/app/nodetool/qgsmaptoolnodetool.cpp
@@ -362,9 +362,12 @@ void QgsMapToolNodeTool::canvasPressEvent( QMouseEvent * e )
 
     if ( snapResults.size() < 1 )
     {
-      displaySnapToleranceWarning();
+      emit displayMessage( tr( "could not snap to a segment on the current layer." ) );
       return;
     }
+
+    // remove previous warning
+    emit removeMessage();
 
     mSelectedFeature = new QgsSelectedFeature( snapResults[0].snappedAtGeometry, vlayer, mCanvas );
     connect( QgisApp::instance()->legend(), SIGNAL( currentLayerChanged( QgsMapLayer* ) ), this, SLOT( currentLayerChanged( QgsMapLayer* ) ) );
@@ -374,6 +377,9 @@ void QgsMapToolNodeTool::canvasPressEvent( QMouseEvent * e )
   }
   else
   {
+    // remove previous warning
+    emit removeMessage();
+
     QgsVectorLayer *vlayer = mSelectedFeature->vlayer();
     Q_ASSERT( vlayer );
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -579,6 +579,8 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, QWidget * parent, 
   mpGpsDock->setWidget( mpGpsWidget );
   mpGpsDock->hide();
 
+  mLastMapToolMessage = 0;
+
   mLogViewer = new QgsMessageLogViewer( statusBar(), this );
 
   mLogDock = new QDockWidget( tr( "Log Messages" ), this );
@@ -1890,8 +1892,8 @@ void QgisApp::setupConnections()
            this, SLOT( showScale( double ) ) );
   connect( mMapCanvas, SIGNAL( scaleChanged( double ) ),
            this, SLOT( updateMouseCoordinatePrecision() ) );
-  connect( mMapCanvas, SIGNAL( mapToolSet( QgsMapTool * ) ),
-           this, SLOT( mapToolChanged( QgsMapTool * ) ) );
+  connect( mMapCanvas, SIGNAL( mapToolSet( QgsMapTool *, QgsMapTool * ) ),
+           this, SLOT( mapToolChanged( QgsMapTool *, QgsMapTool * ) ) );
   connect( mMapCanvas, SIGNAL( selectionChanged( QgsMapLayer * ) ),
            this, SLOT( selectionChanged( QgsMapLayer * ) ) );
   connect( mMapCanvas, SIGNAL( extentsChanged() ),
@@ -2006,9 +2008,9 @@ void QgisApp::createCanvasTools()
   mMapTools.mMoveFeature->setAction( mActionMoveFeature );
   mMapTools.mRotateFeature = new QgsMapToolRotateFeature( mMapCanvas );
   mMapTools.mRotateFeature->setAction( mActionRotateFeature );
-  //need at least geos 3.3 for OffsetCurve tool
+//need at least geos 3.3 for OffsetCurve tool
 #if defined(GEOS_VERSION_MAJOR) && defined(GEOS_VERSION_MINOR) && \
-  ((GEOS_VERSION_MAJOR>3) || ((GEOS_VERSION_MAJOR==3) && (GEOS_VERSION_MINOR>=3)))
+((GEOS_VERSION_MAJOR>3) || ((GEOS_VERSION_MAJOR==3) && (GEOS_VERSION_MINOR>=3)))
   mMapTools.mOffsetCurve = new QgsMapToolOffsetCurve( mMapCanvas );
   mMapTools.mOffsetCurve->setAction( mActionOffsetCurve );
 #else
@@ -2059,7 +2061,7 @@ void QgisApp::createCanvasTools()
   mMapTools.mRotateLabel->setAction( mActionRotateLabel );
   mMapTools.mChangeLabelProperties = new QgsMapToolChangeLabelProperties( mMapCanvas );
   mMapTools.mChangeLabelProperties->setAction( mActionChangeLabelProperties );
-  //ensure that non edit tool is initialised or we will get crashes in some situations
+//ensure that non edit tool is initialised or we will get crashes in some situations
   mNonEditMapTool = mMapTools.mPan;
 }
 
@@ -8020,11 +8022,25 @@ void QgisApp::showProgress( int theProgress, int theTotalSteps )
   }
 }
 
-void QgisApp::mapToolChanged( QgsMapTool *tool )
+void QgisApp::mapToolChanged( QgsMapTool *newTool, QgsMapTool *oldTool )
 {
-  if ( tool && !tool->isEditTool() )
+  if ( oldTool )
   {
-    mNonEditMapTool = tool;
+    disconnect( oldTool, SIGNAL( displayMessage( QString ) ), this, SLOT( displayMapToolMessage( QString ) ) );
+    disconnect( oldTool, SIGNAL( displayMessage( QString, QgsMessageBar::MessageLevel ) ), this, SLOT( displayMapToolMessage( QString, QgsMessageBar::MessageLevel ) ) );
+    disconnect( oldTool, SIGNAL( removeMessage() ), this, SLOT( removeMapToolMessage() ) );
+  }
+
+  if ( newTool )
+  {
+    if ( !newTool->isEditTool() )
+    {
+      mNonEditMapTool = newTool;
+    }
+
+    connect( newTool, SIGNAL( displayMessage( QString ) ), this, SLOT( displayMapToolMessage( QString ) ) );
+    connect( newTool, SIGNAL( displayMessage( QString, QgsMessageBar::MessageLevel ) ), this, SLOT( displayMapToolMessage( QString, QgsMessageBar::MessageLevel ) ) );
+    connect( newTool, SIGNAL( removeMessage() ), this, SLOT( removeMapToolMessage() ) );
   }
 }
 
@@ -8150,6 +8166,27 @@ void QgisApp::showStatusMessage( QString theMessage )
 {
   statusBar()->showMessage( theMessage );
 }
+
+void QgisApp::displayMapToolMessage( QString message, QgsMessageBar::MessageLevel level )
+{
+  // remove previous message
+  messageBar()->popWidget( mLastMapToolMessage );
+
+  QgsMapTool* tool = mapCanvas()->mapTool();
+
+  if ( tool )
+  {
+    mLastMapToolMessage = new QgsMessageBarItem( tool->toolName(), message, level, messageTimeout() );
+    QgisApp::instance()->messageBar()->pushItem( mLastMapToolMessage );
+  }
+}
+
+void QgisApp::removeMapToolMessage()
+{
+  // remove previous message
+  messageBar()->popWidget( mLastMapToolMessage );
+}
+
 
 // Show the maptip using tooltip
 void QgisApp::showMapTip()

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -8177,7 +8177,7 @@ void QgisApp::displayMapToolMessage( QString message, QgsMessageBar::MessageLeve
   if ( tool )
   {
     mLastMapToolMessage = new QgsMessageBarItem( tool->toolName(), message, level, messageTimeout() );
-    QgisApp::instance()->messageBar()->pushItem( mLastMapToolMessage );
+    messageBar()->pushItem( mLastMapToolMessage );
   }
 }
 

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -92,6 +92,7 @@ class QgsTileScaleWidget;
 #include "qgsrasterlayer.h"
 #include "qgssnappingdialog.h"
 #include "qgspluginmanager.h"
+#include "qgsmessagebar.h"
 
 #include "ui_qgisapp.h"
 
@@ -999,7 +1000,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     void layerSubsetString();
 
     //! map tool changed
-    void mapToolChanged( QgsMapTool *tool );
+    void mapToolChanged( QgsMapTool *newTool , QgsMapTool* oldTool );
 
     /** Called when some layer's editing mode was toggled on/off
      * @note added in 1.9 */
@@ -1015,6 +1016,8 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     void extentsViewToggled( bool theFlag );
     void showExtents();
     void showStatusMessage( QString theMessage );
+    void displayMapToolMessage( QString message, QgsMessageBar::MessageLevel level = QgsMessageBar::INFO );
+    void removeMapToolMessage();
     void updateMouseCoordinatePrecision();
     void hasCrsTransformEnabled( bool theFlag );
     void destinationCrsChanged();
@@ -1522,6 +1525,8 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     //! Persistent GPS toolbox
     QgsGPSInformationWidget * mpGpsWidget;
 
+    QgsMessageBarItem* mLastMapToolMessage;
+
     QgsMessageLogViewer *mLogViewer;
 
     //! project changed
@@ -1541,7 +1546,6 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     bool gestureEvent( QGestureEvent *event );
     void tapAndHoldTriggered( QTapAndHoldGesture *gesture );
 #endif
-
 };
 
 #ifdef ANDROID

--- a/src/app/qgsmaptooladdpart.cpp
+++ b/src/app/qgsmaptooladdpart.cpp
@@ -62,7 +62,7 @@ void QgsMapToolAddPart::canvasReleaseEvent( QMouseEvent * e )
 
   if ( !selectionErrorMsg.isEmpty() )
   {
-    QMessageBox::critical( 0, tr( "Error. Could not add part." ), selectionErrorMsg );
+    emit displayMessage( tr( "Could not add part. %1" ).arg( selectionErrorMsg ) , QgsMessageBar::WARNING );
     stopCapturing();
     return;
   }
@@ -101,9 +101,7 @@ void QgsMapToolAddPart::canvasReleaseEvent( QMouseEvent * e )
         else if ( error == 2 )
         {
           //problem with coordinate transformation
-          QMessageBox::information( 0,
-                                    tr( "Coordinate transform error" ),
-                                    tr( "Cannot transform the point to the layers coordinate system" ) );
+          emit displayMessage( tr( "Coordinate transform error. Cannot transform the point to the layers coordinate system" ) , QgsMessageBar::WARNING );
           return;
         }
 
@@ -156,6 +154,9 @@ void QgsMapToolAddPart::canvasReleaseEvent( QMouseEvent * e )
   {
     case 0:
     {
+      // remove previous message
+      emit removeMessage();
+
       //add points to other features to keep topology up-to-date
       int topologicalEditing = QgsProject::instance()->readNumEntry( "Digitizing", "/TopologicalEditing", 0 );
       if ( topologicalEditing )
@@ -194,6 +195,6 @@ void QgsMapToolAddPart::canvasReleaseEvent( QMouseEvent * e )
       break;
   }
 
-  QMessageBox::critical( 0, tr( "Error, could not add part" ), errorMessage );
+  emit displayMessage( errorMessage , QgsMessageBar::WARNING );
   vlayer->destroyEditCommand();
 }

--- a/src/app/qgsmaptooldeletepart.cpp
+++ b/src/app/qgsmaptooldeletepart.cpp
@@ -52,6 +52,9 @@ void QgsMapToolDeletePart::canvasPressEvent( QMouseEvent *e )
 
   if ( mRecentSnappingResults.size() > 0 )
   {
+    // remove previous warning
+    emit removeMessage();
+
     QgsPoint markerPoint = mRecentSnappingResults.begin()->snappedVertex;
 
     //show vertex marker
@@ -61,7 +64,7 @@ void QgsMapToolDeletePart::canvasPressEvent( QMouseEvent *e )
   }
   else
   {
-    displaySnapToleranceWarning();
+    emit displayMessage( tr( "could not snap to a part on the current layer." ) );
   }
 }
 

--- a/src/app/qgsmaptooldeletering.cpp
+++ b/src/app/qgsmaptooldeletering.cpp
@@ -23,8 +23,10 @@
 #include <QMessageBox>
 
 QgsMapToolDeleteRing::QgsMapToolDeleteRing( QgsMapCanvas* canvas )
-    : QgsMapToolVertexEdit( canvas ), mCross( 0 )
+    : QgsMapToolVertexEdit( canvas )
+    , mCross( 0 )
 {
+  mToolName = tr( "Delete ring" );
 }
 
 QgsMapToolDeleteRing::~QgsMapToolDeleteRing()
@@ -52,6 +54,9 @@ void QgsMapToolDeleteRing::canvasPressEvent( QMouseEvent *e )
 
   if ( mRecentSnappingResults.size() > 0 )
   {
+    // remove previous warning
+    emit removeMessage();
+
     QgsPoint markerPoint = mRecentSnappingResults.begin()->snappedVertex;
 
     //show vertex marker
@@ -61,7 +66,7 @@ void QgsMapToolDeleteRing::canvasPressEvent( QMouseEvent *e )
   }
   else
   {
-    displaySnapToleranceWarning();
+    emit displayMessage( tr( "could not snap to a ring on the current layer." ) );
   }
 }
 

--- a/src/app/qgsmaptooledit.cpp
+++ b/src/app/qgsmaptooledit.cpp
@@ -14,12 +14,12 @@
  ***************************************************************************/
 
 #include "qgsmaptooledit.h"
-#include "qgisapp.h"
 #include "qgsmessagebar.h"
 #include "qgsproject.h"
 #include "qgsmapcanvas.h"
 #include "qgsrubberband.h"
 #include "qgsvectorlayer.h"
+
 #include <QKeyEvent>
 #include <QSettings>
 
@@ -134,18 +134,10 @@ int QgsMapToolEdit::addTopologicalPoints( const QList<QgsPoint>& geom )
 
 void QgsMapToolEdit::notifyNotVectorLayer()
 {
-  QgisApp::instance()->messageBar()->pushMessage(
-    tr( "No active vector layer" ),
-    tr( "Choose a vector layer in the legend" ),
-    QgsMessageBar::INFO,
-    QgisApp::instance()->messageTimeout() );
+  emit displayMessage( tr( "No active vector layer" ) );
 }
 
 void QgsMapToolEdit::notifyNotEditableLayer()
 {
-  QgisApp::instance()->messageBar()->pushMessage(
-    tr( "Layer not editable" ),
-    tr( "Use 'Toggle Editing' to make it editable" ),
-    QgsMessageBar::INFO,
-    QgisApp::instance()->messageTimeout() );
+  emit displayMessage( tr( "Layer not editable" ) );
 }

--- a/src/app/qgsmaptooledit.cpp
+++ b/src/app/qgsmaptooledit.cpp
@@ -14,7 +14,6 @@
  ***************************************************************************/
 
 #include "qgsmaptooledit.h"
-#include "qgsmessagebar.h"
 #include "qgsproject.h"
 #include "qgsmapcanvas.h"
 #include "qgsrubberband.h"

--- a/src/app/qgsmaptooledit.h
+++ b/src/app/qgsmaptooledit.h
@@ -36,6 +36,9 @@ class APP_EXPORT QgsMapToolEdit: public QgsMapTool
      and applies it to the map canvas*/
     QgsMapCanvasSnapper mSnapper;
 
+    /**keeps trace of last displayed message*/
+    QgsMessageBarItem* mMessageItem;
+
     /**Inserts vertices to the snapped segments of the editing layer.
      This is useful for topological editing if snap to segment is enabled.
      @param snapResults results collected from the snapping operation
@@ -72,7 +75,6 @@ class APP_EXPORT QgsMapToolEdit: public QgsMapTool
     /**Display a timed message bar noting the active vector layer is not editable.
        @note added in QGIS 1.9*/
     void notifyNotEditableLayer();
-
 };
 
 #endif

--- a/src/app/qgsmaptooledit.h
+++ b/src/app/qgsmaptooledit.h
@@ -36,9 +36,6 @@ class APP_EXPORT QgsMapToolEdit: public QgsMapTool
      and applies it to the map canvas*/
     QgsMapCanvasSnapper mSnapper;
 
-    /**keeps trace of last displayed message*/
-    QgsMessageBarItem* mMessageItem;
-
     /**Inserts vertices to the snapped segments of the editing layer.
      This is useful for topological editing if snap to segment is enabled.
      @param snapResults results collected from the snapping operation

--- a/src/app/qgsmaptoolvertexedit.cpp
+++ b/src/app/qgsmaptoolvertexedit.cpp
@@ -39,12 +39,3 @@ QgsMapToolVertexEdit::~QgsMapToolVertexEdit()
 {
 
 }
-
-void QgsMapToolVertexEdit::displaySnapToleranceWarning()
-{
-  QgisApp::instance()->messageBar()->pushMessage(
-    tr( "Snap tolerance" ),
-    tr( "Could not snap segment. Have you set the tolerance in Settings > Snapping Options?" ),
-    QgsMessageBar::INFO,
-    QgisApp::instance()->messageTimeout() );
-}

--- a/src/app/qgsmaptoolvertexedit.h
+++ b/src/app/qgsmaptoolvertexedit.h
@@ -38,9 +38,6 @@ class APP_EXPORT QgsMapToolVertexEdit: public QgsMapToolEdit
     /**Snapping results that are collected during the mouse press event
      (search for vertices/segments to manipulate)*/
     QList<QgsSnappingResult> mRecentSnappingResults;
-
-    //! Displays a warning about the snap tolerance settings
-    void displaySnapToleranceWarning();
 };
 
 #endif

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -239,6 +239,7 @@ qgsmanageconnectionsdialog.h
 qgsmapcanvas.h
 qgsmaplayeractionregistry.h
 qgsmapoverviewcanvas.h
+qgsmaptool.h
 qgsmaptoolemitpoint.h
 qgsmaptoolidentify.h
 qgsmessagebaritem.h

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -1429,6 +1429,8 @@ void QgsMapCanvas::setMapTool( QgsMapTool* tool )
     mLastNonZoomMapTool = NULL;
   }
 
+  QgsMapTool* oldTool = mMapTool;
+
   // set new map tool and activate it
   mMapTool = tool;
   if ( mMapTool )
@@ -1438,6 +1440,7 @@ void QgsMapCanvas::setMapTool( QgsMapTool* tool )
   }
 
   emit mapToolSet( mMapTool );
+  emit mapToolSet( mMapTool, oldTool );
 } // setMapTool
 
 void QgsMapCanvas::unsetMapTool( QgsMapTool* tool )
@@ -1447,6 +1450,7 @@ void QgsMapCanvas::unsetMapTool( QgsMapTool* tool )
     mMapTool->deactivate();
     mMapTool = NULL;
     emit mapToolSet( NULL );
+    emit mapToolSet( NULL, mMapTool );
     setCursor( Qt::ArrowCursor );
   }
 

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -435,6 +435,11 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     //! Emit map tool changed event
     void mapToolSet( QgsMapTool *tool );
 
+    /** Emit map tool changed with the old tool
+     * @note added in 2.3
+     */
+    void mapToolSet( QgsMapTool *newTool, QgsMapTool* oldTool );
+
     // ### QGIS 3: remove the signal
     //! Emitted when selection in any layer gets changed
     void selectionChanged( QgsMapLayer * layer );

--- a/src/gui/qgsmaptool.cpp
+++ b/src/gui/qgsmaptool.cpp
@@ -22,7 +22,12 @@
 #include <QAbstractButton>
 
 QgsMapTool::QgsMapTool( QgsMapCanvas* canvas )
-    : QObject( canvas ), mCanvas( canvas ), mCursor( Qt::CrossCursor ), mAction( NULL ), mButton( NULL )
+    : QObject( canvas )
+    , mCanvas( canvas )
+    , mCursor( Qt::CrossCursor )
+    , mAction( NULL )
+    , mButton( NULL )
+    , mToolName( QString() )
 {
 }
 

--- a/src/gui/qgsmaptool.h
+++ b/src/gui/qgsmaptool.h
@@ -17,6 +17,7 @@
 #define QGSMAPTOOL_H
 
 #include "qgsconfig.h"
+#include "qgsmessagebar.h"
 
 #include <QCursor>
 #include <QString>
@@ -45,6 +46,9 @@ class QAbstractButton;
  */
 class GUI_EXPORT QgsMapTool : public QObject
 {
+
+    Q_OBJECT
+
   public:
 
     //! virtual destructor
@@ -121,6 +125,18 @@ class GUI_EXPORT QgsMapTool : public QObject
     //! returns pointer to the tool's map canvas
     QgsMapCanvas* canvas();
 
+    //! Emit map tool changed with the old tool
+    //! @note added in 2.3
+    QString toolName() { return mToolName; }
+
+  signals:
+    //! emit a message
+    void displayMessage( QString message );
+    void displayMessage( QString message, QgsMessageBar::MessageLevel );
+
+    //! emit signal to clear previous message
+    void removeMessage();
+
   protected:
 
     //! constructor takes map canvas as a parameter
@@ -158,6 +174,8 @@ class GUI_EXPORT QgsMapTool : public QObject
     //! which will be used to set that action as active
     QAbstractButton* mButton;
 
+    //! translated name of the map tool
+    QString mToolName;
 };
 
 #endif

--- a/src/gui/qgsmessagebaritem.cpp
+++ b/src/gui/qgsmessagebaritem.cpp
@@ -149,9 +149,9 @@ void QgsMessageBarItem::writeContent()
     {
       // add ':' to end of title
       QString t = mTitle.trimmed();
-      if ( !t.endsWith( ":" ) && !content.isEmpty() )
+      if ( !content.isEmpty() && !t.endsWith( ":" ) && !t.endsWith( ": " ) )
         t += ": ";
-      content.prepend( QString( "<b>" ) + t + "</b>" );
+      content.prepend( QString( "<b>" ) + t + " </b>" );
     }
     mTextEdit->setText( content );
   }


### PR DESCRIPTION
See http://hub.qgis.org/issues/8873

The idea is to keep traces of the displayed message in the map tool edit class, and to display only one (avoid having many messages displayed).
