### PR TITLE
allow snapping to vertex and segment to remove part/ring

### DIFF
--- a/src/app/qgsmaptooldeletepart.cpp
+++ b/src/app/qgsmaptooldeletepart.cpp
@@ -45,7 +45,7 @@ void QgsMapToolDeletePart::canvasPressEvent( QMouseEvent *e )
 
   mRecentSnappingResults.clear();
   //do snap -> new recent snapping results
-  if ( mSnapper.snapToCurrentLayer( e->pos(), mRecentSnappingResults, QgsSnapper::SnapToVertex ) != 0 )
+  if ( mSnapper.snapToCurrentLayer( e->pos(), mRecentSnappingResults, QgsSnapper::SnapToVertexAndSegment ) != 0 )
   {
     //error
   }
@@ -84,7 +84,12 @@ void QgsMapToolDeletePart::canvasReleaseEvent( QMouseEvent *e )
     QList<QgsSnappingResult>::iterator sr_it = mRecentSnappingResults.begin();
     for ( ; sr_it != mRecentSnappingResults.end(); ++sr_it )
     {
-      deletePart( sr_it->snappedAtGeometry, sr_it->snappedVertexNr, vlayer );
+      if ( sr_it->snappedVertexNr != -1 )
+        deletePart( sr_it->snappedAtGeometry, sr_it->snappedVertexNr, vlayer );
+      else if ( sr_it->beforeVertexNr != -1 )
+        deletePart( sr_it->snappedAtGeometry, sr_it->beforeVertexNr, vlayer );
+      else if ( sr_it->afterVertexNr != -1 )
+        deletePart( sr_it->snappedAtGeometry, sr_it->afterVertexNr, vlayer );
     }
   }
 

--- a/src/app/qgsmaptooldeletering.cpp
+++ b/src/app/qgsmaptooldeletering.cpp
@@ -45,7 +45,7 @@ void QgsMapToolDeleteRing::canvasPressEvent( QMouseEvent *e )
 
   mRecentSnappingResults.clear();
   //do snap -> new recent snapping results
-  if ( mSnapper.snapToCurrentLayer( e->pos(), mRecentSnappingResults, QgsSnapper::SnapToVertex ) != 0 )
+  if ( mSnapper.snapToCurrentLayer( e->pos(), mRecentSnappingResults, QgsSnapper::SnapToVertexAndSegment ) != 0 )
   {
     //error
   }
@@ -85,11 +85,15 @@ void QgsMapToolDeleteRing::canvasReleaseEvent( QMouseEvent *e )
     QList<QgsSnappingResult>::iterator sr_it = mRecentSnappingResults.begin();
     for ( ; sr_it != mRecentSnappingResults.end(); ++sr_it )
     {
-      deleteRing( sr_it->snappedAtGeometry, sr_it->snappedVertexNr, vlayer );
+      if ( sr_it->snappedVertexNr != -1 )
+        deleteRing( sr_it->snappedAtGeometry, sr_it->snappedVertexNr, vlayer );
+      else if ( sr_it->beforeVertexNr != -1 )
+        deleteRing( sr_it->snappedAtGeometry, sr_it->beforeVertexNr, vlayer );
+      else if ( sr_it->afterVertexNr != -1 )
+        deleteRing( sr_it->snappedAtGeometry, sr_it->afterVertexNr, vlayer );
     }
   }
 }
-
 
 void QgsMapToolDeleteRing::deleteRing( QgsFeatureId fId, int beforeVertexNr, QgsVectorLayer* vlayer )
 {


### PR DESCRIPTION
I think it is more intuitive to remove parts and rings by clicking on vertex and segments rather than just vertices.
What do you think?
