### PR TITLE
fix9430: correctly check the clipboard content

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -608,6 +608,7 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, QWidget * parent, 
   addWindow( mWindowAction );
 #endif
 
+  mMenuPasteAs->setEnabled( false );
   activateDeactivateLayerRelatedActions( NULL ); // after members were created
 
   connect( QgsMapLayerActionRegistry::instance(), SIGNAL( changed() ), this, SLOT( refreshActionFeatureAction() ) );
@@ -5707,6 +5708,8 @@ void QgisApp::editCopy( QgsMapLayer * layerContainingSelection )
 
 void QgisApp::clipboardChanged()
 {
+  mMenuPasteAs->setEnabled( clipboard() && !clipboard()->empty() );
+
   activateDeactivateLayerRelatedActions( activeLayer() );
 }
 
@@ -8447,10 +8450,6 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer* layer )
   mActionMoveLabel->setEnabled( enableMove );
   mActionRotateLabel->setEnabled( enableRotate );
   mActionChangeLabelProperties->setEnabled( enableChange );
-
-  mMenuPasteAs->setEnabled( clipboard() && !clipboard()->empty() );
-  mActionPasteAsNewVector->setEnabled( clipboard() && !clipboard()->empty() );
-  mActionPasteAsNewMemoryVector->setEnabled( clipboard() && !clipboard()->empty() );
 
   updateLayerModifiedActions();
 

--- a/src/app/qgsclipboard.cpp
+++ b/src/app/qgsclipboard.cpp
@@ -205,13 +205,8 @@ void QgsClipboard::insert( QgsFeature& feature )
 
 bool QgsClipboard::empty()
 {
-  QClipboard *cb = QApplication::clipboard();
-#ifndef Q_OS_WIN
-  QString text = cb->text( QClipboard::Selection );
-#else
-  QString text = cb->text( QClipboard::Clipboard );
-#endif
-  return text.isEmpty() && mFeatureClipboard.empty();
+  const QgsFields fields = QgsFields();
+  return copyOf( fields ).empty();
 }
 
 QgsFeatureList QgsClipboard::transformedCopyOf( QgsCoordinateReferenceSystem destCRS , const QgsFields &fields )


### PR DESCRIPTION
http://hub.qgis.org/issues/9430

sorry for the mess with the previous commits.

the paste menu gets enabled as soon as there is something in the clipboard (I mean any text).
Even if the text does not contain WKT strings, the menu is enabled.

To prevent this, the check of the clipboard content should be done every time it changes.

This will output GEOS every time there is a new copy which is not made of WKT strings.

Is this reasonable or shall the current behavior remain (and consider this issue as a non-issue)?
