### PR TITLE
Reword "Only look in the layer registries" option

### DIFF
--- a/src/ui/qgspgnewconnectionbase.ui
+++ b/src/ui/qgspgnewconnectionbase.ui
@@ -205,7 +205,7 @@
          <string>Restricts the displayed tables to those that are found in the layer registries (geometry_columns, geography_columns, topology.layer). This can speed up the initial display of spatial tables.</string>
         </property>
         <property name="text">
-         <string>Only look in the layer registries</string>
+         <string>Only show layers in the layer registries</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
The wording was confusing in that real table scans can still be
performed when the srid or type in the registries are found to
be unconstrained. The real effect of the option is to _hide_
layers which are not in the registries.

Fix #8730
