### PR TITLE
fix #9513

### DIFF
--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -2266,7 +2266,7 @@ bool QgsExpression::NodeColumnRef::prepare( QgsExpression* parent, const QgsFiel
 
 QString QgsExpression::NodeColumnRef::dump() const
 {
-  return mName;
+  return mName.count( " " ) ? "\"" + mName + "\"" : mName;
 }
 
 //
@@ -2315,14 +2315,14 @@ bool QgsExpression::NodeCondition::prepare( QgsExpression* parent, const QgsFiel
 
 QString QgsExpression::NodeCondition::dump() const
 {
-  QString msg = QString("CASE ");
+  QString msg = QString( "CASE " );
   foreach ( WhenThen* cond, mConditions )
   {
     msg += QString( "WHEN %1 THEN %2" ).arg( cond->mWhenExp->dump() ).arg( cond->mThenExp->dump() );
   }
   if ( mElseExp )
     msg += QString( "ELSE %1" ).arg( mElseExp->dump() );
-  msg += QString(" END");
+  msg += QString( " END" );
   return msg;
 }
 

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -839,6 +839,19 @@ class TestQgsExpression: public QObject
       QgsExpression::unsetSpecialColumn( "$var1" );
     }
 
+    void expression_from_expression()
+    {
+      {
+        QgsExpression e( "my_column" );
+        QCOMPARE( e.expression() , QgsExpression( e.expression() ).expression() );
+      }
+      {
+        QgsExpression e( "\"my column\"" );
+        QCOMPARE( e.expression() , QgsExpression( e.expression() ).expression() );
+      }
+    }
+
+
 };
 
 QTEST_MAIN( TestQgsExpression )


### PR DESCRIPTION
QgsExpression("\"my column\"").expression() returns my column without quotes

As a result one can not build an expression from another like it is done in QgsFeatureRequest::QgsFeatureRequest( const QgsExpression& expr ).
