### PR TITLE
add help for bbox function

### DIFF
--- a/resources/function_help/bbox
+++ b/resources/function_help/bbox
@@ -1,0 +1,13 @@
+<h3>bbox function</h3>
+Returns 1 if the geometries spatially intersect the bounding box defined and 0 if they don't.
+
+<h4>Syntax</h4>
+<pre>bbox( a, b )</pre>
+
+<h4>Arguments</h4>
+a &rarr; geometry
+b &rarr; geometry
+
+<h4>Example</h4>
+<pre>bbox( geomFromWKT( 'POINT(4 5)' ) , geomFromWKT( 'LINESTRING(3 3 , 4 4 , 5 5)' )) &rarr; returns 1</pre>
+<pre>bbox( geomFromWKT( 'POINT(6 5)' ) , geomFromWKT( 'POLYGON((3 3 , 4 4 , 5 5, 3 3))' )) &rarr; returns 0</pre>


### PR DESCRIPTION
the bbox function help is the only to be missing in the geometry menu.
