### PR TITLE
Fix for #8130 - WFS client: invalid columns after copy/paste.

### DIFF
--- a/src/providers/wfs/qgswfsprovider.cpp
+++ b/src/providers/wfs/qgswfsprovider.cpp
@@ -339,13 +339,6 @@ bool QgsWFSProvider::addFeatures( QgsFeatureList &flist )
 
     QDomElement featureElem = transactionDoc.createElementNS( mWfsNamespace, tname );
 
-    //add thematic attributes
-    const QgsFields* fields = featureIt->fields();
-    if ( !fields )
-    {
-      continue;
-    }
-
     QgsAttributes featureAttributes = featureIt->attributes();
     int nAttrs = featureAttributes.size();
     for ( int i = 0; i < nAttrs; ++i )
@@ -353,7 +346,7 @@ bool QgsWFSProvider::addFeatures( QgsFeatureList &flist )
       const QVariant& value = featureAttributes.at( i );
       if ( value.isValid() && !value.isNull() )
       {
-        QDomElement fieldElem = transactionDoc.createElementNS( mWfsNamespace, fields->field( i ).name() );
+        QDomElement fieldElem = transactionDoc.createElementNS( mWfsNamespace, mFields.at( i ).name() );
         QDomText fieldText = transactionDoc.createTextNode( value.toString() );
         fieldElem.appendChild( fieldText );
         featureElem.appendChild( fieldElem );


### PR DESCRIPTION
When copying features from a Postgis, Shapefile, GPX, ... layer to a WFS layer, attributes are set incorrectly. When saving the wfs layer, we can see that the name of the columns are those from the Postgis layer (although the column names are correct in the attribute table).
There is also "Access vialotion" exception raised when the number of fields in the source layer is less then in the destination WFS layer and you edit values in the "over-fields".
