### PR TITLE
replace list of snapping markers with a single marker

### DIFF
--- a/src/app/qgsmaptoolcapture.cpp
+++ b/src/app/qgsmaptoolcapture.cpp
@@ -51,8 +51,7 @@ QgsMapToolCapture::QgsMapToolCapture( QgsMapCanvas* canvas, enum CaptureMode too
 
 QgsMapToolCapture::~QgsMapToolCapture()
 {
-  while ( !mSnappingMarkers.isEmpty() )
-    delete mSnappingMarkers.takeFirst();
+  delete mSnappingMarker;
 
   stopCapturing();
 
@@ -65,8 +64,7 @@ QgsMapToolCapture::~QgsMapToolCapture()
 
 void QgsMapToolCapture::deactivate()
 {
-  while ( !mSnappingMarkers.isEmpty() )
-    delete mSnappingMarkers.takeFirst();
+  delete mSnappingMarker;
 
   QgsMapToolEdit::deactivate();
 }
@@ -107,18 +105,14 @@ void QgsMapToolCapture::canvasMoveEvent( QMouseEvent * e )
   QList<QgsSnappingResult> snapResults;
   if ( mSnapper.snapToBackgroundLayers( e->pos(), snapResults ) == 0 )
   {
-    while ( !mSnappingMarkers.isEmpty() )
-      delete mSnappingMarkers.takeFirst();
+    delete mSnappingMarker;
 
-    foreach ( const QgsSnappingResult &r, snapResults )
-    {
-      QgsVertexMarker *m = new QgsVertexMarker( mCanvas );
-      m->setIconType( QgsVertexMarker::ICON_CROSS );
-      m->setColor( Qt::magenta );
-      m->setPenWidth( 3 );
-      m->setCenter( r.snappedVertex );
-      mSnappingMarkers << m;
-    }
+    mSnappingMarker = new QgsVertexMarker( mCanvas );
+    mSnappingMarker->setIconType( QgsVertexMarker::ICON_CROSS );
+    mSnappingMarker->setColor( Qt::magenta );
+    mSnappingMarker->setPenWidth( 3 );
+    mSnappingMarker->setCenter( snapPointFromResults(snapResults,e->pos()) );
+
 
     if ( mCaptureMode != CapturePoint && mTempRubberBand && mCapturing )
     {

--- a/src/app/qgsmaptoolcapture.h
+++ b/src/app/qgsmaptoolcapture.h
@@ -119,7 +119,7 @@ class APP_EXPORT QgsMapToolCapture : public QgsMapToolEdit
 
     bool mCaptureModeFromLayer;
 
-    QList<QgsVertexMarker *> mSnappingMarkers;
+    QgsVertexMarker* mSnappingMarker;
 };
 
 #endif


### PR DESCRIPTION
In some cases during digitizing, there are several snapping markers drawn: to reproduce, activate snapping with a rather large tolerance, enable snapping on intersection then add a new feature near an area where several features already are. The result is something like this: 
![2014-02-14 18_54_19-qgis 57dd877 - project](https://f.cloud.github.com/assets/537624/2170167/6d15b2de-9567-11e3-90dd-b6c382c7c03c.png)

This seems like a bug to me, very confusing to the user, but the code was written explicitely to support this (by @jef-n in b8642a93faac8cb30b5dd43200ef1c5797175bfd), so I wonder if there is a use case I didn't think about?

This patch replaces the list of markers by a single marker.
