### PR TITLE
[composer] fix vertical spacing of hidden layer title in legend items (fix #9498)

### DIFF
--- a/src/core/composer/qgscomposerlegend.cpp
+++ b/src/core/composer/qgscomposerlegend.cpp
@@ -265,7 +265,7 @@ QSizeF QgsComposerLegend::drawLayerItemTitle( QgsComposerLayerItem* layerItem, Q
   if ( !layerItem ) return size;
 
   //Let the user omit the layer title item by having an empty layer title string
-  if ( layerItem->text().isEmpty() ) return size;
+  if ( layerItem->text().isEmpty() || layerItem->style() == QgsComposerLegendStyle::Hidden ) return size;
 
   double y = point.y();
 
@@ -805,15 +805,12 @@ QList<QgsComposerLegend::Atom> QgsComposerLegend::createAtomList( QStandardItem*
     {
       Atom atom;
 
-      if ( currentLegendItem->style() != QgsComposerLegendStyle::Hidden )
-      {
-        Nucleon nucleon;
-        nucleon.item = currentLegendItem;
-        nucleon.size = drawLayerItemTitle( dynamic_cast<QgsComposerLayerItem*>( currentLegendItem ) );
-        atom.nucleons.append( nucleon );
-        atom.size.rwidth() = nucleon.size.width();
-        atom.size.rheight() = nucleon.size.height();
-      }
+      Nucleon nucleon;
+      nucleon.item = currentLegendItem;
+      nucleon.size = drawLayerItemTitle( dynamic_cast<QgsComposerLayerItem*>( currentLegendItem ) );
+      atom.nucleons.append( nucleon );
+      atom.size.rwidth() = nucleon.size.width();
+      atom.size.rheight() = nucleon.size.height();
 
       QList<Atom> layerAtoms;
 


### PR DESCRIPTION
(See http://hub.qgis.org/issues/9498 for background and screenshot of problem)

This pull request changes how the legend item treats hidden layer title to apply the same logic as empty text layer title. It initializes a layer item atom to size(0,0) and over here fixes the unwanted gap in legend items when two hidden layer title items follow one another.

I tested this out with various legend item configurations (single column, multi column, etc.) and all appear fine. Hope it can make it before 2.2.
