### PR TITLE
Really consider antialiasing setting when printing

### DIFF
--- a/src/core/composer/qgscomposermap.cpp
+++ b/src/core/composer/qgscomposermap.cpp
@@ -193,10 +193,8 @@ void QgsComposerMap::draw( QPainter *painter, const QgsRectangle& extent, const 
   //set antialiasing if enabled in options
   QSettings settings;
   // Changed to enable anti aliased rendering by default as of QGIS 1.7
-  if ( settings.value( "/qgis/enable_anti_aliasing", true ).toBool() )
-  {
-    painter->setRenderHint( QPainter::Antialiasing );
-  }
+  bool bkAntiAliasing = settings.value( "/qgis/enable_anti_aliasing", true ).toBool();
+  painter->setRenderHint( QPainter::Antialiasing, bkAntiAliasing );
 
   QgsRenderContext* theRendererContext = theMapRenderer.rendererContext();
   if ( theRendererContext )


### PR DESCRIPTION
When printing QgsComposerMap::draw() is called with antialiasing enabled
already. Since the old code only set the Antialiasing hint, but didn't
remove it, the antialiasing setting was ignored in this scenario.
