### PR TITLE
Fix bug #9456-#9485: Line Offset in symbology generates artifacts

### DIFF
--- a/src/core/symbology-ng/qgssymbollayerv2utils.cpp
+++ b/src/core/symbology-ng/qgssymbollayerv2utils.cpp
@@ -653,6 +653,43 @@ QPolygonF offsetLine( QPolygonF polyline, double dist )
   if ( polyline.count() < 2 )
     return newLine;
 
+  // need at least geos 3.3 for OffsetCurve tool
+#if defined(GEOS_VERSION_MAJOR) && defined(GEOS_VERSION_MINOR) && \
+    ((GEOS_VERSION_MAJOR>3) || ((GEOS_VERSION_MAJOR==3) && (GEOS_VERSION_MINOR>=3)))
+
+  if ( polyline.count() > 2 )
+  {
+    unsigned int i, pointCount = polyline.count();
+
+    QgsPolyline tempPolyline( pointCount );
+    QPointF* tempPtr = polyline.data();
+    for ( i = 0; i < pointCount; ++i, tempPtr++ ) tempPolyline[i] = QgsPoint( tempPtr->rx(), tempPtr->ry() );
+
+    QgsGeometry* tempGeometry = QgsGeometry::fromPolyline( tempPolyline );
+    if ( tempGeometry )
+    {
+      const GEOSGeometry* geosGeom = tempGeometry->asGeos();
+      GEOSGeometry* offsetGeom = GEOSOffsetCurve( geosGeom, dist, 8 /*quadSegments*/, 0 /*joinStyle*/, 5.0 /*mitreLimit*/ );
+
+      if ( offsetGeom )
+      {
+        tempGeometry->fromGeos( offsetGeom );
+        tempPolyline = tempGeometry->asPolyline();
+
+        pointCount = tempPolyline.count();
+        newLine.resize( pointCount );
+
+        QgsPoint* tempPtr2 = tempPolyline.data();
+        for ( i = 0; i < pointCount; ++i, tempPtr2++ ) newLine[i] = QPointF( tempPtr2->x(), tempPtr2->y() );
+
+        delete tempGeometry;
+        return newLine;
+      }
+      delete tempGeometry;
+    }
+  }
+#endif
+
   double angle = 0.0, t_new, t_old = 0;
   QPointF pt_old, pt_new;
   QPointF p1 = polyline[0], p2;
@@ -687,6 +724,7 @@ QPolygonF offsetLine( QPolygonF polyline, double dist )
   // last line segment:
   pt_new = offsetPoint( p2, angle + M_PI / 2, dist );
   newLine.append( pt_new );
+
   return newLine;
 }
 

--- a/src/core/symbology-ng/qgssymbollayerv2utils.cpp
+++ b/src/core/symbology-ng/qgssymbollayerv2utils.cpp
@@ -648,47 +648,48 @@ static QPointF linesIntersection( QPointF p1, double t1, QPointF p2, double t2 )
 
 QPolygonF offsetLine( QPolygonF polyline, double dist )
 {
-  QPolygonF newLine;
-
   if ( polyline.count() < 2 )
-    return newLine;
+    return polyline;
+
+  QPolygonF newLine;
 
   // need at least geos 3.3 for OffsetCurve tool
 #if defined(GEOS_VERSION_MAJOR) && defined(GEOS_VERSION_MINOR) && \
     ((GEOS_VERSION_MAJOR>3) || ((GEOS_VERSION_MAJOR==3) && (GEOS_VERSION_MINOR>=3)))
 
-  if ( polyline.count() > 2 )
+  unsigned int i, pointCount = polyline.count();
+
+  QgsPolyline tempPolyline( pointCount );
+  QPointF* tempPtr = polyline.data();
+  for ( i = 0; i < pointCount; ++i, tempPtr++ ) tempPolyline[i] = QgsPoint( tempPtr->rx(), tempPtr->ry() );
+
+  QgsGeometry* tempGeometry = QgsGeometry::fromPolyline( tempPolyline );
+  if ( tempGeometry )
   {
-    unsigned int i, pointCount = polyline.count();
+    const GEOSGeometry* geosGeom = tempGeometry->asGeos();
+    GEOSGeometry* offsetGeom = GEOSOffsetCurve( geosGeom, dist, 8 /*quadSegments*/, 0 /*joinStyle*/, 5.0 /*mitreLimit*/ );
 
-    QgsPolyline tempPolyline( pointCount );
-    QPointF* tempPtr = polyline.data();
-    for ( i = 0; i < pointCount; ++i, tempPtr++ ) tempPolyline[i] = QgsPoint( tempPtr->rx(), tempPtr->ry() );
-
-    QgsGeometry* tempGeometry = QgsGeometry::fromPolyline( tempPolyline );
-    if ( tempGeometry )
+    if ( offsetGeom )
     {
-      const GEOSGeometry* geosGeom = tempGeometry->asGeos();
-      GEOSGeometry* offsetGeom = GEOSOffsetCurve( geosGeom, dist, 8 /*quadSegments*/, 0 /*joinStyle*/, 5.0 /*mitreLimit*/ );
+      tempGeometry->fromGeos( offsetGeom );
+      tempPolyline = tempGeometry->asPolyline();
 
-      if ( offsetGeom )
-      {
-        tempGeometry->fromGeos( offsetGeom );
-        tempPolyline = tempGeometry->asPolyline();
+      pointCount = tempPolyline.count();
+      newLine.resize( pointCount );
 
-        pointCount = tempPolyline.count();
-        newLine.resize( pointCount );
+      QgsPoint* tempPtr2 = tempPolyline.data();
+      for ( i = 0; i < pointCount; ++i, tempPtr2++ ) newLine[i] = QPointF( tempPtr2->x(), tempPtr2->y() );
 
-        QgsPoint* tempPtr2 = tempPolyline.data();
-        for ( i = 0; i < pointCount; ++i, tempPtr2++ ) newLine[i] = QPointF( tempPtr2->x(), tempPtr2->y() );
-
-        delete tempGeometry;
-        return newLine;
-      }
       delete tempGeometry;
+      return newLine;
     }
+    delete tempGeometry;
   }
-#endif
+
+  // returns original polyline when 'GEOSOffsetCurve' fails!
+  return polyline;
+
+#else
 
   double angle = 0.0, t_new, t_old = 0;
   QPointF pt_old, pt_new;
@@ -724,8 +725,9 @@ QPolygonF offsetLine( QPolygonF polyline, double dist )
   // last line segment:
   pt_new = offsetPoint( p2, angle + M_PI / 2, dist );
   newLine.append( pt_new );
-
   return newLine;
+
+#endif
 }
 
 /////


### PR DESCRIPTION
This patch improves the offset of lines using GEOSOffsetCurve if GEOS 3.3 is available.

Bugs related:
http://hub.qgis.org/issues/9456
http://hub.qgis.org/issues/9485

Results:
![issue_9485-results](https://f.cloud.github.com/assets/5576272/2224697/34e941da-9a82-11e3-8523-d933c783668e.JPG)
