### PR TITLE
Allow LIKE operator in QGIS mapserver's GetFeatureInfo FILTER parameter

### DIFF
--- a/src/mapserver/qgswmsserver.cpp
+++ b/src/mapserver/qgswmsserver.cpp
@@ -2000,6 +2000,7 @@ bool QgsWMSServer::testFilterStringSafety( const QString& filter ) const
          || tokenIt->compare( "AND", Qt::CaseInsensitive ) == 0
          || tokenIt->compare( "OR", Qt::CaseInsensitive ) == 0
          || tokenIt->compare( "IN", Qt::CaseInsensitive ) == 0
+         || tokenIt->compare( "LIKE", Qt::CaseInsensitive ) == 0
          || tokenIt->compare( "DMETAPHONE", Qt::CaseInsensitive ) == 0
          || tokenIt->compare( "SOUNDEX", Qt::CaseInsensitive ) == 0 )
     {


### PR DESCRIPTION
If it doesn't imply any security risk, it would be nice to allow LIKE operator because it greatly improves searching on text attributes with wms GetFeatureInfo request. I have already tested such GetFeatureInfo requests and it worked fine.
