### PR TITLE
[ftools] fix random points tool not recognizing memory layer integer column (fix #9695)

### DIFF
--- a/python/plugins/fTools/tools/doRandPoints.py
+++ b/python/plugins/fTools/tools/doRandPoints.py
@@ -67,7 +67,7 @@ class Dialog(QDialog, Ui_Dialog):
             changedLayer = ftools_utils.getVectorLayerByName(inputLayer)
             changedFields = ftools_utils.getFieldList(changedLayer)
             for f in changedFields:
-              if f.typeName() == "Integer":
+              if f.typeName().lower() == "integer":
                 self.cmbField.addItem(unicode(f.name()))
         else:
             self.rdoUnstratified.setChecked(True)


### PR DESCRIPTION
ftools' random points does a case sensitive search for integer column. While shapefile integer column returns "Integer", a memory layer's newly created column returns "integer".

This patch simply makes a case insensitive comparison.
