### PR TITLE
Fix bug #9655: some polygons not labelled when layer's simplification is on

### DIFF
--- a/src/core/qgsmaptopixelgeometrysimplifier.cpp
+++ b/src/core/qgsmaptopixelgeometrysimplifier.cpp
@@ -147,6 +147,11 @@ bool QgsMapToPixelSimplifier::simplifyWkbGeometry( int simplifyFlags, QGis::WkbT
   bool hasZValue = QGis::wkbDimensions( wkbType ) == 3;
   bool result = false;
 
+  // Save initial WKB settings to use when the simplification creates invalid geometries
+  unsigned char* sourcePrevWkb = sourceWkb;
+  unsigned char* targetPrevWkb = targetWkb;
+  size_t targetWkbPrevSize = targetWkbSize;
+
   // Can replace the geometry by its BBOX ?
   if (( simplifyFlags & QgsMapToPixelSimplifier::SimplifyEnvelope ) && ( envelope.xMaximum() - envelope.xMinimum() ) < map2pixelTol && ( envelope.yMaximum() - envelope.yMinimum() ) < map2pixelTol )
   {
@@ -181,6 +186,11 @@ bool QgsMapToPixelSimplifier::simplifyWkbGeometry( int simplifyFlags, QGis::WkbT
   {
     double x, y, lastX = 0, lastY = 0;
 
+    double xmin =  std::numeric_limits<double>::max();
+    double ymin =  std::numeric_limits<double>::max();
+    double xmax = -std::numeric_limits<double>::max();
+    double ymax = -std::numeric_limits<double>::max();
+
     int sizeOfDoubleX = sizeof( double );
     int sizeOfDoubleY = QGis::wkbDimensions( wkbType ) == 3 /*hasZValue*/ ? 2 * sizeof( double ) : sizeof( double );
 
@@ -209,10 +219,21 @@ bool QgsMapToPixelSimplifier::simplifyWkbGeometry( int simplifyFlags, QGis::WkbT
         memcpy( ptr, &y, sizeof( double ) ); lastY = y; ptr++;
         numTargetPoints++;
       }
+      if ( xmin > x ) xmin = x;
+      if ( ymin > y ) ymin = y;
+      if ( xmax < x ) xmax = x;
+      if ( ymax < y ) ymax = y;
     }
     targetWkb = wkb2 + 4;
 
     // Fix the topology of the geometry
+    if ( numTargetPoints <= ( isaLinearRing ? 2 : 1 ) )
+    {
+      sourceWkb = sourcePrevWkb;
+      targetWkb = targetPrevWkb;
+      targetWkbSize = targetWkbPrevSize;
+      return generalizeWkbGeometry( wkbType, sourceWkb, sourceWkbSize, targetWkb, targetWkbSize, QgsRectangle( xmin, ymin, xmax, ymax ), writeHeader );
+    }
     if ( isaLinearRing )
     {
       memcpy( &x, targetWkb + 0, sizeof( double ) );

--- a/src/core/qgspallabeling.cpp
+++ b/src/core/qgspallabeling.cpp
@@ -1841,7 +1841,7 @@ void QgsPalLayerSettings::registerFeature( QgsFeature& f, const QgsRenderContext
   }
 
   // fix invalid polygons
-  if ( QGis::singleType( QGis::flatType( geom->wkbType() ) ) == QGis::WKBPolygon && !geom->isGeosValid() )
+  if ( geom->type() == QGis::Polygon && !geom->isGeosValid() )
   {
     geom->fromGeos( GEOSBuffer( geom->asGeos(), 0, 0 ) );
   }

--- a/src/core/qgspallabeling.cpp
+++ b/src/core/qgspallabeling.cpp
@@ -1840,6 +1840,12 @@ void QgsPalLayerSettings::registerFeature( QgsFeature& f, const QgsRenderContext
     }
   }
 
+  // fix invalid polygons
+  if ( QGis::singleType( QGis::flatType( geom->wkbType() ) ) == QGis::WKBPolygon && !geom->isGeosValid() )
+  {
+    geom->fromGeos( GEOSBuffer( geom->asGeos(), 0, 0 ) );
+  }
+
   // CLIP the geometry if it is bigger than the extent
   // don't clip if centroid is requested for whole feature
   bool do_clip = false;


### PR DESCRIPTION
This pull request fixes the bug http://hub.qgis.org/issues/9655

Changes:
- fix a bug in the simplification of multipolygon geometries
- fix invalid polygons using buffer_0
