### PR TITLE
added saveStyle capability to Spatialite Provider - Developed for ARPA Piemonte (Dipartimento Tematico Geologia e Dissesto)

### DIFF
--- a/src/providers/spatialite/qgsspatialiteprovider.h
+++ b/src/providers/spatialite/qgsspatialiteprovider.h
@@ -154,6 +154,10 @@ class QgsSpatiaLiteProvider: public QgsVectorDataProvider
     */
     bool isValid();
 
+    /**Describes if provider has save and load style support
+       @return true in case saving style to db is supported by this provider*/
+    virtual bool isSaveAndLoadStyleToDBSupported() { return true; }
+
     /**Adds a list of features
       @return true in case of success and false in case of failure*/
     bool addFeatures( QgsFeatureList & flist );


### PR DESCRIPTION
Added support into Spatialite provider to save and load styles related to a spatialite layer.
This functionality was already available in PosgreSQl provider. 
This spatialite version it's a simplified version where styles are saved in text field as pure XML encoded UTF8. 
In this way this functionality can be available where Spatialite is available with older version.
