### PR TITLE
push a message bar informing user of crs applied to newly added layer missing a crs

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -421,15 +421,16 @@ void QgisApp::validateSrs( QgsCoordinateReferenceSystem &srs )
   {
     // XXX TODO: Change project to store selected CS as 'projectCRS' not 'selectedWkt'
     authid = QgisApp::instance()->mapCanvas()->mapSettings().destinationCrs().authid();
-    QgsDebugMsg( "Layer srs set from project: " + authid );
-    QgisApp::instance()->statusBar()->showMessage( tr( "CRS undefined - defaulting to project CRS" ) );
     srs.createFromOgcWmsCrs( authid );
+    QgsDebugMsg( "Layer srs set from project: " + authid );
+    messageBar()->pushMessage( tr( "Warning" ), tr( "CRS undefined - defaulting to project CRS" ), QgsMessageBar::WARNING, messageTimeout() );
   }
   else ///Projections/defaultBehaviour==useGlobal
   {
     authid = mySettings.value( "/Projections/layerDefaultCrs", GEO_EPSG_CRS_AUTHID ).toString();
     srs.createFromOgcWmsCrs( authid );
-    QgisApp::instance()->statusBar()->showMessage( tr( "CRS undefined - defaulting to default CRS: %1" ).arg( authid ) );
+    QgsDebugMsg( "Layer srs set from default: " + authid );
+    messageBar()->pushMessage( tr( "Warning" ), tr( "CRS undefined - defaulting to default CRS: %1" ).arg( authid ), QgsMessageBar::WARNING, messageTimeout() );
   }
 }
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -423,14 +423,14 @@ void QgisApp::validateSrs( QgsCoordinateReferenceSystem &srs )
     authid = QgisApp::instance()->mapCanvas()->mapSettings().destinationCrs().authid();
     srs.createFromOgcWmsCrs( authid );
     QgsDebugMsg( "Layer srs set from project: " + authid );
-    messageBar()->pushMessage( tr( "Warning" ), tr( "CRS undefined - defaulting to project CRS" ), QgsMessageBar::WARNING, messageTimeout() );
+    messageBar()->pushMessage( tr( "CRS was undefined" ), tr( "defaulting to project CRS %1 - %2" ).arg( authid ).arg( srs.description() ), QgsMessageBar::WARNING, messageTimeout() );
   }
   else ///Projections/defaultBehaviour==useGlobal
   {
     authid = mySettings.value( "/Projections/layerDefaultCrs", GEO_EPSG_CRS_AUTHID ).toString();
     srs.createFromOgcWmsCrs( authid );
     QgsDebugMsg( "Layer srs set from default: " + authid );
-    messageBar()->pushMessage( tr( "Warning" ), tr( "CRS undefined - defaulting to default CRS: %1" ).arg( authid ), QgsMessageBar::WARNING, messageTimeout() );
+    messageBar()->pushMessage( tr( "CRS was undefined" ), tr( "defaulting to CRS %1 - %2" ).arg( authid ).arg( srs.description() ), QgsMessageBar::WARNING, messageTimeout() );
   }
 }
 


### PR DESCRIPTION
Since automatically applying a CRS to a newly loaded layer missing a CRS is a pretty big deal, I propose QGIS should push a message bar instead of throwing a far less visible string in the status bar. 

That would fix issue #8050 (http://hub.qgis.org/issues/8050).
