### PR TITLE
no html in the url anymore

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -7032,7 +7032,7 @@ void QgisApp::adjustBrightnessContrast( int delta, bool updateBrightness )
 void QgisApp::helpContents()
 {
   // We should really ship the HTML version of the docs local too.
-  openURL( QString( "http://docs.qgis.org/%1.%2/html/%3/docs/user_manual/" )
+  openURL( QString( "http://docs.qgis.org/%1.%2/%3/docs/user_manual/" )
            .arg( QGis::QGIS_VERSION_INT / 10000 )
            .arg( QGis::QGIS_VERSION_INT / 100 % 100 )
            .arg( tr( "en", "documentation language" ) ),


### PR DESCRIPTION
see http://hub.qgis.org/issues/9715

we do not have the 'html' in the url's anymore. 

For <=2.0 we did some apache rewriting in apache confs, but actually this (html-part) should be removed in 2.2 branch too.
