### PR TITLE
Mapserver: fixed inconsistencies int WMS GetFeatureInfo response

### DIFF
--- a/src/mapserver/qgsconfigparser.h
+++ b/src/mapserver/qgsconfigparser.h
@@ -144,6 +144,9 @@ class QgsConfigParser
     /**Adds print capabilities to xml document. ParentElem usually is the <Capabilities> element*/
     virtual void printCapabilities( QDomElement& parentElement, QDomDocument& doc ) const = 0;
 
+    /**Adds project settings to xml document. ParentElem usually is the <Capabilities> element*/
+    virtual void projectSettings( QDomElement& parentElement, QDomDocument& doc ) const = 0;
+
     /**Appends service metadata to the capabilities document*/
     virtual void serviceCapabilities( QDomElement& parentElement, QDomDocument& doc ) const;
 
@@ -154,6 +157,8 @@ class QgsConfigParser
 
     QColor selectionColor() const { return mSelectionColor; }
     void setSelectionColor( const QColor& c ) { mSelectionColor = c; }
+    QColor canvasColor() const { return mCanvasColor; }
+    void setCanvasColor( const QColor& c ) { mCanvasColor = c; }
 
     int maxWidth() const { return mMaxWidth; }
     int maxHeight() const { return mMaxHeight; }
@@ -221,6 +226,7 @@ class QgsConfigParser
     double mLegendSymbolHeight;
 
     QColor mSelectionColor;
+    QColor mCanvasColor;
 
     //maximum width/height for the GetMap request. Disabled by default (-1)
     int mMaxWidth;

--- a/src/mapserver/qgsprojectparser.h
+++ b/src/mapserver/qgsprojectparser.h
@@ -126,6 +126,9 @@ class QgsProjectParser: public QgsConfigParser
     /**Adds print capabilities to xml document. ParentElem usually is the <Capabilities> element*/
     void printCapabilities( QDomElement& parentElement, QDomDocument& doc ) const;
 
+    /**Adds project settings to xml document. ParentElem usually is the <Capabilities> element*/
+    void projectSettings( QDomElement& parentElement, QDomDocument& doc ) const;
+
     /**Reads service metadata from projectfile or falls back to parent class method if not there*/
     void serviceCapabilities( QDomElement& parentElement, QDomDocument& doc ) const;
 
@@ -244,6 +247,8 @@ class QgsProjectParser: public QgsConfigParser
 
     /**Reads selection color from project and sets it to QgsConfigParser::mSelectionColor*/
     void setSelectionColor();
+    /**Reads canvas color from project and sets it to QgsConfigParser::mCanvasColor*/
+    void setCanvasColor();
     /**Reads maxWidth / maxHeight from project and sets it to QgsConfigParser::mMaxWidth / mMaxHeight*/
     void setMaxWidthHeight();
     /**Reads layer drawing order from the legend section of the project file and appends it to the parent elemen (usually the <Capability> element)*/

--- a/src/mapserver/qgssldparser.cpp
+++ b/src/mapserver/qgssldparser.cpp
@@ -1568,6 +1568,14 @@ void QgsSLDParser::printCapabilities( QDomElement& parentElement, QDomDocument& 
   }
 }
 
+void QgsSLDParser::projectSettings( QDomElement& parentElement, QDomDocument& doc ) const
+{
+  if ( mFallbackParser )
+  {
+    mFallbackParser->projectSettings( parentElement, doc );
+  }
+}
+
 bool QgsSLDParser::featureInfoWithWktGeometry() const
 {
   if ( mFallbackParser )

--- a/src/mapserver/qgssldparser.h
+++ b/src/mapserver/qgssldparser.h
@@ -88,6 +88,9 @@ class QgsSLDParser: public QgsConfigParser
     /**Adds print capabilities to xml document. Delegated to fallback parser*/
     void printCapabilities( QDomElement& parentElement, QDomDocument& doc ) const;
 
+    /**Adds project settings to xml document. Delegated to fallback parser*/
+    void projectSettings( QDomElement& parentElement, QDomDocument& doc ) const;
+
     /**True if the feature info response should contain the wkt geometry for vector features*/
     virtual bool featureInfoWithWktGeometry() const;
 

--- a/src/mapserver/qgswmsserver.cpp
+++ b/src/mapserver/qgswmsserver.cpp
@@ -1662,10 +1662,16 @@ int QgsWMSServer::featureInfoFromRasterLayer( QgsRasterLayer* layer,
   if ( infoFormat == "application/vnd.ogc.gml" )
   {
     QgsFeature feature;
+    QgsFields fields;
+    feature.initAttributes( attributes.count() );
+
+    int index = 0;
     for ( QMap<int, QVariant>::const_iterator it = attributes.constBegin(); it != attributes.constEnd(); ++it )
     {
-      feature.setAttribute( layer->bandName( it.key() ), QString::number( it.value().toDouble() ) );
+      fields.append( QgsField( layer->bandName( it.key() ), QVariant::Double ) );
+      feature.setAttribute( index++, QString::number( it.value().toDouble() ) );
     }
+    feature.setFields( &fields );
 
     QgsCoordinateReferenceSystem layerCrs = layer->crs();
     int version = infoFormat.startsWith( "application/vnd.ogc.gml/3" ) ? 3 : 2;
@@ -2639,7 +2645,6 @@ QDomElement QgsWMSServer::createFeatureGML(
     }
   }
 
-  const QSet<QString>& excludedAttributes = layer->excludeAttributesWMS();
   //read all attribute values from the feature
   QgsAttributes featureAttributes = feat->attributes();
   const QgsFields* fields = feat->fields();
@@ -2647,7 +2652,7 @@ QDomElement QgsWMSServer::createFeatureGML(
   {
     QString attributeName = fields->at( i ).name();
     //skip attribute if it is explicitly excluded from WMS publication
-    if ( excludedAttributes.contains( attributeName ) )
+    if ( layer && layer->excludeAttributesWMS().contains( attributeName ) )
     {
       continue;
     }

--- a/src/mapserver/qgswmsserver.cpp
+++ b/src/mapserver/qgswmsserver.cpp
@@ -972,7 +972,8 @@ int QgsWMSServer::getFeatureInfo( QDomDocument& result, QString version )
       }
 
       //skip layer if not visible at current map scale
-      if ( currentLayer->hasScaleBasedVisibility() && ( currentLayer->minimumScale() > scaleDenominator || currentLayer->maximumScale() < scaleDenominator ) )
+      bool useScaleConstraint = ( scaleDenominator > 0 && currentLayer->hasScaleBasedVisibility() );
+      if ( useScaleConstraint && ( currentLayer->minimumScale() > scaleDenominator || currentLayer->maximumScale() < scaleDenominator ) )
       {
         continue;
       }
@@ -1480,6 +1481,10 @@ int QgsWMSServer::featureInfoFromVectorLayer( QgsVectorLayer* layer,
 
     searchRect.set( infoPoint->x() - searchRadius, infoPoint->y() - searchRadius,
                     infoPoint->x() + searchRadius, infoPoint->y() + searchRadius );
+  }
+  else
+  {
+    searchRect = layerRect;
   }
 
   //do a select with searchRect and go through all the features
@@ -1994,7 +1999,7 @@ QMap<QString, QString> QgsWMSServer::applyRequestedLayerFilters( const QStringLi
           continue;
         }
 
-        QgsRectangle layerExtent = mapLayer->extent();
+        QgsRectangle layerExtent = mMapRenderer->layerToMapCoordinates(mapLayer, mapLayer->extent());
         if ( filterExtent.isEmpty() )
         {
           filterExtent = layerExtent;

--- a/src/mapserver/qgswmsserver.cpp
+++ b/src/mapserver/qgswmsserver.cpp
@@ -1506,6 +1506,7 @@ int QgsWMSServer::featureInfoFromVectorLayer( QgsVectorLayer* layer,
   }
   QgsFeatureIterator fit = layer->getFeatures( fReq );
 
+  bool featureBBoxInitialized = false;
   while ( fit.nextFeature( feature ) )
   {
     ++featureCounter;
@@ -1536,9 +1537,10 @@ int QgsWMSServer::featureInfoFromVectorLayer( QgsVectorLayer* layer,
       box = mapRender->layerExtentToOutputExtent( layer, feature.geometry()->boundingBox() );
       if ( featureBBox ) //extend feature info bounding box if requested
       {
-        if ( featureBBox->isEmpty() )
+        if ( !featureBBoxInitialized && featureBBox->isEmpty())
         {
           *featureBBox = box;
+          featureBBoxInitialized = true;
         }
         else
         {

--- a/src/mapserver/qgswmsserver.cpp
+++ b/src/mapserver/qgswmsserver.cpp
@@ -1052,13 +1052,38 @@ int QgsWMSServer::getFeatureInfo( QDomDocument& result, QString version )
 
   if ( featuresRect )
   {
-    QDomElement bBoxElem = result.createElement( "BoundingBox" );
-    bBoxElem.setAttribute( "CRS", mMapRenderer->destinationCrs().authid() );
-    bBoxElem.setAttribute( "minx", QString::number( featuresRect->xMinimum() ) );
-    bBoxElem.setAttribute( "maxx", QString::number( featuresRect->xMaximum() ) );
-    bBoxElem.setAttribute( "miny", QString::number( featuresRect->yMinimum() ) );
-    bBoxElem.setAttribute( "maxy", QString::number( featuresRect->yMaximum() ) );
-    getFeatureInfoElement.insertBefore( bBoxElem, QDomNode() ); //insert as first child
+    if ( infoFormat.startsWith( "application/vnd.ogc.gml" ) )
+    {
+      QDomElement bBoxElem = result.createElement( "gml:boundedBy" );
+      QDomElement boxElem;
+      int gmlVersion = infoFormat.startsWith( "application/vnd.ogc.gml/3" ) ? 3 : 2;
+      if ( gmlVersion < 3 )
+      {
+        boxElem = QgsOgcUtils::rectangleToGMLBox( featuresRect, result );
+      }
+      else
+      {
+        boxElem = QgsOgcUtils::rectangleToGMLEnvelope( featuresRect, result );
+      }
+
+      QgsCoordinateReferenceSystem crs = mMapRenderer->destinationCrs();
+      if ( crs.isValid() )
+      {
+        boxElem.setAttribute( "srsName", crs.authid() );
+      }
+      bBoxElem.appendChild( boxElem );
+      getFeatureInfoElement.insertBefore( bBoxElem, QDomNode() ); //insert as first child
+    }
+    else
+    {
+      QDomElement bBoxElem = result.createElement( "BoundingBox" );
+      bBoxElem.setAttribute( "CRS", mMapRenderer->destinationCrs().authid() );
+      bBoxElem.setAttribute( "minx", QString::number( featuresRect->xMinimum() ) );
+      bBoxElem.setAttribute( "maxx", QString::number( featuresRect->xMaximum() ) );
+      bBoxElem.setAttribute( "miny", QString::number( featuresRect->yMinimum() ) );
+      bBoxElem.setAttribute( "maxy", QString::number( featuresRect->yMaximum() ) );
+      getFeatureInfoElement.insertBefore( bBoxElem, QDomNode() ); //insert as first child
+    }
   }
 
   if ( sia2045 && infoFormat.compare( "text/xml", Qt::CaseInsensitive ) == 0 )
@@ -1460,7 +1485,8 @@ int QgsWMSServer::featureInfoFromVectorLayer( QgsVectorLayer* layer,
   const QSet<QString>& excludedAttributes = layer->excludeAttributesWMS();
 
   QgsFeatureRequest fReq;
-  fReq.setFlags((( addWktGeometry || featureBBox ) ? QgsFeatureRequest::NoFlags : QgsFeatureRequest::NoGeometry ) | QgsFeatureRequest::ExactIntersect );
+  bool hasGeometry = addWktGeometry || featureBBox;
+  fReq.setFlags((( hasGeometry ) ? QgsFeatureRequest::NoFlags : QgsFeatureRequest::NoGeometry ) | QgsFeatureRequest::ExactIntersect );
   if ( !searchRect.isEmpty() )
   {
     fReq.setFilterRect( searchRect );
@@ -1491,12 +1517,35 @@ int QgsWMSServer::featureInfoFromVectorLayer( QgsVectorLayer* layer,
       continue;
     }
 
+    QgsRectangle box;
+    if ( hasGeometry )
+    {
+      box = mapRender->layerExtentToOutputExtent( layer, feature.geometry()->boundingBox() );
+      if ( featureBBox ) //extend feature info bounding box if requested
+      {
+        if ( featureBBox->isEmpty() )
+        {
+          *featureBBox = box;
+        }
+        else
+        {
+          featureBBox->combineExtentWith( &box );
+        }
+      }
+    }
+
+    QgsCoordinateReferenceSystem outputCrs = layer->crs();
+    if ( hasGeometry && layer->crs() != mapRender->destinationCrs() && mapRender->hasCrsTransformEnabled() )
+    {
+      outputCrs = mapRender->destinationCrs();
+    }
+
     if ( infoFormat == "application/vnd.ogc.gml" )
     {
-      QgsCoordinateReferenceSystem layerCrs = layer->crs();
-      bool withGeom = layer->wkbType() != QGis::WKBNoGeometry;
+      bool withGeom = layer->wkbType() != QGis::WKBNoGeometry && addWktGeometry;
       int version = infoFormat.startsWith( "application/vnd.ogc.gml/3" ) ? 3 : 2;
-      QDomElement elem = createFeatureGML( &feature, infoDocument, layerCrs, layer->name(), withGeom, version );
+
+      QDomElement elem = createFeatureGML( &feature, layer, infoDocument, outputCrs, layer->name(), withGeom, version );
       QDomElement featureMemberElem = infoDocument.createElement( "gml:featureMember"/*wfs:FeatureMember*/ );
       featureMemberElem.appendChild( elem );
       layerElement.appendChild( featureMemberElem );
@@ -1527,36 +1576,35 @@ int QgsWMSServer::featureInfoFromVectorLayer( QgsVectorLayer* layer,
         featureElement.appendChild( attributeElement );
       }
 
-      //also append the wkt geometry as an attribute
-      QgsGeometry* geom = feature.geometry();
-      if ( addWktGeometry && geom )
+      //append feature bounding box to feature info xml
+      if ( hasGeometry )
       {
-        QDomElement geometryElement = infoDocument.createElement( "Attribute" );
-        geometryElement.setAttribute( "name", "geometry" );
-        geometryElement.setAttribute( "value", geom->exportToWkt() );
-        geometryElement.setAttribute( "type", "derived" );
-        featureElement.appendChild( geometryElement );
-      }
-      if ( featureBBox && geom && mapRender ) //extend feature info bounding box if requested
-      {
-        QgsRectangle box = mapRender->layerExtentToOutputExtent( layer, geom->boundingBox() );
-        if ( featureBBox->isEmpty() )
-        {
-          *featureBBox = box;
-        }
-        else
-        {
-          featureBBox->combineExtentWith( &box );
-        }
-
-        //append feature bounding box to feature info xml
         QDomElement bBoxElem = infoDocument.createElement( "BoundingBox" );
-        bBoxElem.setAttribute( version == "1.1.1" ? "SRS" : "CRS", mapRender->destinationCrs().authid() );
+        bBoxElem.setAttribute( version == "1.1.1" ? "SRS" : "CRS", outputCrs.authid() );
         bBoxElem.setAttribute( "minx", QString::number( box.xMinimum() ) );
         bBoxElem.setAttribute( "maxx", QString::number( box.xMaximum() ) );
         bBoxElem.setAttribute( "miny", QString::number( box.yMinimum() ) );
         bBoxElem.setAttribute( "maxy", QString::number( box.yMaximum() ) );
         featureElement.appendChild( bBoxElem );
+      }
+
+      //also append the wkt geometry as an attribute
+      if ( addWktGeometry && hasGeometry )
+      {
+         QgsGeometry* geom = feature.geometry();
+        if ( layer->crs() != outputCrs )
+        {
+          const QgsCoordinateTransform *transform = mapRender->transformation( layer );
+          if ( transform )
+          {
+            geom->transform( *transform );
+          }
+        }
+        QDomElement geometryElement = infoDocument.createElement( "Attribute" );
+        geometryElement.setAttribute( "name", "geometry" );
+        geometryElement.setAttribute( "value", geom->exportToWkt() );
+        geometryElement.setAttribute( "type", "derived" );
+        featureElement.appendChild( geometryElement );
       }
     }
   }
@@ -1607,7 +1655,7 @@ int QgsWMSServer::featureInfoFromRasterLayer( QgsRasterLayer* layer,
 
     QgsCoordinateReferenceSystem layerCrs = layer->crs();
     int version = infoFormat.startsWith( "application/vnd.ogc.gml/3" ) ? 3 : 2;
-    QDomElement elem = createFeatureGML( &feature, infoDocument, layerCrs, layer->name(), false, version );
+    QDomElement elem = createFeatureGML( &feature, 0, infoDocument, layerCrs, layer->name(), false, version );
     layerElement.appendChild( elem );
   }
   else
@@ -2499,6 +2547,7 @@ void QgsWMSServer::convertFeatureInfoToSIA2045( QDomDocument& doc )
 
 QDomElement QgsWMSServer::createFeatureGML(
   QgsFeature* feat,
+  QgsVectorLayer* layer,
   QDomDocument& doc,
   QgsCoordinateReferenceSystem& crs,
   QString typeName,
@@ -2509,10 +2558,50 @@ QDomElement QgsWMSServer::createFeatureGML(
   QDomElement typeNameElement = doc.createElement( "qgs:" + typeName /*qgs:%TYPENAME%*/ );
   typeNameElement.setAttribute( "fid", typeName + "." + QString::number( feat->id() ) );
 
-  if ( withGeom )
+  const QgsCoordinateTransform* transform = 0;
+  if ( layer && layer->crs() != crs)
+  {
+    transform = mMapRenderer->transformation( layer );
+  }
+
+  QgsGeometry* geom = feat->geometry();
+
+  // always add bounding box info if feature contains geometry
+  if ( geom && geom->type() != QGis::UnknownGeometry &&  geom->type() != QGis::NoGeometry)
+  {
+     QgsRectangle box = feat->geometry()->boundingBox();
+     if ( transform )
+     {
+       box = transform->transformBoundingBox( box );
+     }
+
+     QDomElement bbElem = doc.createElement( "gml:boundedBy" );
+     QDomElement boxElem;
+     if ( version < 3 )
+     {
+       boxElem = QgsOgcUtils::rectangleToGMLBox( &box, doc );
+     }
+     else
+     {
+       boxElem = QgsOgcUtils::rectangleToGMLEnvelope( &box, doc );
+     }
+
+     if ( crs.isValid() )
+     {
+       boxElem.setAttribute( "srsName", crs.authid() );
+     }
+     bbElem.appendChild( boxElem );
+     typeNameElement.appendChild( bbElem );
+  }
+
+  if ( withGeom)
   {
     //add geometry column (as gml)
-    QgsGeometry* geom = feat->geometry();
+
+    if ( transform )
+    {
+      geom->transform( *transform );
+    }
 
     QDomElement geomElem = doc.createElement( "qgs:geometry" );
     QDomElement gmlElem;
@@ -2527,27 +2616,10 @@ QDomElement QgsWMSServer::createFeatureGML(
 
     if ( !gmlElem.isNull() )
     {
-      QgsRectangle box = geom->boundingBox();
-      QDomElement bbElem = doc.createElement( "gml:boundedBy" );
-      QDomElement boxElem;
-      if ( version < 3 )
-      {
-        boxElem = QgsOgcUtils::rectangleToGMLBox( &box, doc );
-      }
-      else
-      {
-        boxElem = QgsOgcUtils::rectangleToGMLEnvelope( &box, doc );
-      }
-
       if ( crs.isValid() )
       {
-        boxElem.setAttribute( "srsName", crs.authid() );
         gmlElem.setAttribute( "srsName", crs.authid() );
       }
-
-      bbElem.appendChild( boxElem );
-      typeNameElement.appendChild( bbElem );
-
       geomElem.appendChild( gmlElem );
       typeNameElement.appendChild( geomElem );
     }

--- a/src/mapserver/qgswmsserver.h
+++ b/src/mapserver/qgswmsserver.h
@@ -226,6 +226,7 @@ class QgsWMSServer
 
     QDomElement createFeatureGML(
       QgsFeature* feat,
+      QgsVectorLayer* layer,
       QDomDocument& doc,
       QgsCoordinateReferenceSystem& crs,
       QString typeName,

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -582,6 +582,11 @@ bool QgsWmsProvider::setImageCrs( QString const & crs )
       {
         resolutions << key;
       }
+      if ( !mTileMatrixSet->tileMatrices.empty() )
+      {
+        setProperty( "tileWidth", mTileMatrixSet->tileMatrices.values().first().tileWidth );
+        setProperty( "tileHeight", mTileMatrixSet->tileMatrices.values().first().tileHeight );
+      }
     }
     else
     {


### PR DESCRIPTION
Changes:
- fixed computing of global bounding box (for all matched features) in GML format and include it in correct XML element (gml:boundedBy)
- transforms features geometries and bounding boxes into requested CRS (for both text/xml and GML formats)
- doesn't include feature geometry in GML format when 'Add geometry to feature response' is not set

I will prepare pull request for master in a short time
