### PR TITLE
Vector layer: add a feature title property

### DIFF
--- a/src/app/qgslabelinggui.h
+++ b/src/app/qgslabelinggui.h
@@ -27,6 +27,7 @@ class QgsMapCanvas;
 class QgsCharacterSelectorDialog;
 
 #include "qgspallabeling.h"
+#include "qgsexpressionguihelper.h"
 
 class APP_EXPORT QgsLabelingGui : public QWidget, private Ui::QgsLabelingGuiBase
 {
@@ -45,7 +46,6 @@ class APP_EXPORT QgsLabelingGui : public QWidget, private Ui::QgsLabelingGuiBase
     void apply();
     void changeTextColor( const QColor &color );
     void showEngineConfigDialog();
-    void showExpressionDialog();
     void changeBufferColor( const QColor &color );
 
     void updateUi();
@@ -89,7 +89,6 @@ class APP_EXPORT QgsLabelingGui : public QWidget, private Ui::QgsLabelingGuiBase
     void populateFontCapitalsComboBox();
     void populateFontStyleComboBox();
     void populatePlacementMethods();
-    void populateFieldNames();
     void populateDataDefinedButtons( QgsPalLayerSettings& s );
     /**Sets data defined property attribute to map */
     void setDataDefinedProperty( const QgsDataDefinedButton* ddBtn, QgsPalLayerSettings::DataDefinedProperties p, QgsPalLayerSettings& lyr );
@@ -108,6 +107,8 @@ class APP_EXPORT QgsLabelingGui : public QWidget, private Ui::QgsLabelingGuiBase
     QButtonGroup* mPlacePointBtnGrp;
     QButtonGroup* mPlaceLineBtnGrp;
     QButtonGroup* mPlacePolygonBtnGrp;
+
+    QgsExpressionGuiHelper* mExpressionGuiHelper;
 
     // background reference font
     QFont mRefFont;

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -64,6 +64,7 @@
 #include "qgsrendererv2propertiesdialog.h"
 #include "qgsstylev2.h"
 #include "qgssymbologyv2conversion.h"
+#include "qgsexpressionguihelper.h"
 
 QgsVectorLayerProperties::QgsVectorLayerProperties(
   QgsVectorLayer *lyr,
@@ -91,6 +92,11 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
 
   connect( insertFieldButton, SIGNAL( clicked() ), this, SLOT( insertField() ) );
   connect( insertExpressionButton, SIGNAL( clicked() ), this, SLOT( insertExpression() ) );
+
+  // feature title
+  connect( mFeatureTitleExprRadio, SIGNAL( toggled( bool ) ), mFeatureTitleComboBox, SLOT( setEnabled( bool ) ) );
+  connect( mFeatureTitleExprRadio, SIGNAL( toggled( bool ) ), mFeatureTitleButton, SLOT( setEnabled( bool ) ) );
+  mFeatureTitleHelper = new QgsExpressionGuiHelper( layer, mFeatureTitleComboBox, mFeatureTitleButton, tr( "Expression based feature title" ), this );
 
   // connections for Map Tip display
   connect( htmlRadio, SIGNAL( toggled( bool ) ), htmlMapTip, SLOT( setEnabled( bool ) ) );
@@ -205,6 +211,10 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
       mDataSourceEncodingFrame->hide();
     }
   }
+
+  // feature title
+  mFeatureTitleExprRadio->setChecked( layer->featureTitleUseExpression() );
+  mFeatureTitleHelper->setExpression( layer->featureTitleExpression() );
 
   leSpatialRefSys->setText( layer->crs().authid() + " - " + layer->crs().description() );
   leSpatialRefSys->setCursorPosition( 0 );
@@ -498,6 +508,10 @@ void QgsVectorLayerProperties::apply()
   layer->toggleScaleBasedVisibility( chkUseScaleDependentRendering->isChecked() );
   layer->setMinimumScale( 1.0 / cbMinimumScale->scale() );
   layer->setMaximumScale( 1.0 / cbMaximumScale->scale() );
+
+  // feature title
+  layer->setFeatureTitleUseExpression( mFeatureTitleExprRadio->isChecked() );
+  layer->setFeatureTitleExpression( mFeatureTitleComboBox->currentText() );
 
   // provider-specific options
   if ( layer->dataProvider() )

--- a/src/app/qgsvectorlayerproperties.h
+++ b/src/app/qgsvectorlayerproperties.h
@@ -30,6 +30,7 @@
 #include "qgsmapcanvas.h"
 #include "qgscontexthelp.h"
 #include "qgsexpressionbuilderdialog.h"
+#include "qgsexpressionguihelper.h"
 
 class QgsMapLayer;
 
@@ -176,6 +177,9 @@ class APP_EXPORT QgsVectorLayerProperties : public QgsOptionsDialogBase, private
 
     /**Adds a new join to mJoinTreeWidget*/
     void addJoinToTreeWidget( const QgsVectorJoinInfo& join );
+
+    QgsExpressionGuiHelper* mFeatureTitleHelper;
+
 };
 
 inline QString QgsVectorLayerProperties::displayName()

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -1145,6 +1145,38 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
 
     const QMap< QString, QString >& attributeAliases() const { return mAttributeAliasMap; }
 
+    /**
+     * @brief featureTitle returns the title of the given feature
+     * @note added in 2.3
+     */
+    QVariant featureTitle( const QgsFeature &f );
+
+    /**
+     * @brief featureTitleUseExpression determines if the feature titles uses the feature id or an expression
+     * @note added in 2.3
+     */
+    bool featureTitleUseExpression() {return mFeatureTitleUseExpression;}
+
+    /**
+     * @brief setFeatureTitleUseExpression set if the feature titles uses the feature id or an expression
+     * @note added in 2.3
+     */
+    void setFeatureTitleUseExpression( bool useExpression );
+
+    /**
+     * @brief featureTitleExpression returns the QgsExpression defined for the layer
+     * @note added in 2.3
+     */
+    QString featureTitleExpression() {return mFeatureTitleExpression;}
+
+    /**
+     * @brief setFeatureTitle sets a QgsExpression to be used as feature title
+     * @note added in 2.3
+     */
+    void setFeatureTitleExpression( QString expression );
+
+
+
     const QSet<QString>& excludeAttributesWMS() const { return mExcludeAttributesWMS; }
     void setExcludeAttributesWMS( const QSet<QString>& att ) { mExcludeAttributesWMS = att; }
 
@@ -1686,6 +1718,9 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
 
     QMap<int, QString> mEditorWidgetV2Types;
     QMap<int, QMap<QString, QVariant> > mEditorWidgetV2Configs;
+
+    bool mFeatureTitleUseExpression;
+    QString mFeatureTitleExpression;
 
     /** Defines the default layout to use for the attribute editor (Drag and drop, UI File, Generated) */
     EditorLayout mEditorLayout;

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -84,6 +84,7 @@ qgsencodingfiledialog.cpp
 qgserrordialog.cpp
 qgsexpressionbuilderdialog.cpp
 qgsexpressionbuilderwidget.cpp
+qgsexpressionguihelper.cpp
 qgsexpressionhighlighter.cpp
 qgsexpressionselectiondialog.cpp
 qgsextentgroupbox.cpp
@@ -223,6 +224,7 @@ qgsdialog.h
 qgsencodingfiledialog.h
 qgserrordialog.h
 qgsexpressionbuilderwidget.h
+qgsexpressionguihelper.h
 qgsexpressionhighlighter.h
 qgsexpressionselectiondialog.h
 qgsextentgroupbox.h
@@ -288,6 +290,7 @@ qgsdatadefinedbutton.h
 qgsencodingfiledialog.h
 qgsexpressionbuilderdialog.h
 qgsexpressionbuilderwidget.h
+qgsexpressionguihelper.h
 qgsexpressionhighlighter.h
 qgsexpressionselectiondialog.h
 qgsfeatureselectiondlg.h

--- a/src/gui/qgsattributedialog.cpp
+++ b/src/gui/qgsattributedialog.cpp
@@ -426,7 +426,7 @@ void QgsAttributeDialog::init()
       mDialog->setObjectName( "QgsAttributeDialogBase" );
 
     if ( mDialog->windowTitle().isEmpty() )
-      mDialog->setWindowTitle( tr( "Attributes - %1" ).arg( mLayer->name() ) );
+      mDialog->setWindowTitle( tr( "Attributes - %1 - %2" ).arg( mLayer->name() ).arg( mLayer->featureTitle( *mFeature ).toString() ) );
   }
 
   if ( mShowDialogButtons )

--- a/src/gui/qgsexpressionguihelper.cpp
+++ b/src/gui/qgsexpressionguihelper.cpp
@@ -1,0 +1,118 @@
+
+#include "qgsexpressionguihelper.h"
+
+#include "qgsexpressionbuilderdialog.h"
+
+QgsExpressionGuiHelper::QgsExpressionGuiHelper( QgsVectorLayer* layer, QComboBox* fieldCombo, QAbstractButton* expressionButton, QString title, QWidget *parent )
+    : QObject( parent )
+    , mLayer( 0 )
+    , mFieldcombo( fieldCombo )
+    , mExpressionButton( expressionButton )
+    , mTitle( title )
+    , mParent( parent )
+{
+  connect( mExpressionButton, SIGNAL( clicked() ), this, SLOT( showExpressionDialog() ) );
+
+  changeLayer( layer );
+}
+
+void QgsExpressionGuiHelper::setExpression( const QString str )
+{
+  if ( str.isEmpty() )
+  {
+    return;
+  }
+  int idx = mFieldcombo->findText( str );
+  if ( idx == -1 )
+  {
+    mFieldcombo->addItem( str );
+    mFieldcombo->setCurrentIndex( mFieldcombo->count() - 1 );
+  }
+  else
+  {
+    mFieldcombo->setCurrentIndex( idx );
+  }
+}
+
+void QgsExpressionGuiHelper::changeLayer( QgsVectorLayer* layer )
+{
+  // disconnect previous layer (0 at init)
+  if ( mLayer )
+  {
+    disconnect( mLayer, SIGNAL( attributeAdded( int ) ), this, SLOT( addAttribute( int ) ) );
+    disconnect( mLayer, SIGNAL( attributeDeleted( int ) ), this, SLOT( removeAttribute( int ) ) );
+    disconnect( mLayer, SIGNAL( layerDeleted() ), this, SLOT( changeLayer() ) );
+  }
+  mLayer = layer;
+  mExpressions.empty();
+  if ( !layer )
+    return;
+
+  connect( mLayer, SIGNAL( attributeAdded( int ) ), this, SLOT( attributeAdded( int ) ) );
+  connect( mLayer, SIGNAL( attributeDeleted( int ) ), this, SLOT( attributeDeleted( int ) ) );
+  connect( mLayer, SIGNAL( layerDeleted() ), this, SLOT( changeLayer() ) );
+
+  mFieldcombo->clear();
+  populateFieldCombo();
+}
+
+void QgsExpressionGuiHelper::setGeomCalculator( const QgsDistanceArea &da )
+{
+  mDa = da;
+}
+
+void QgsExpressionGuiHelper::showExpressionDialog()
+{
+  if ( !mLayer )
+  {
+    return;
+  }
+
+  QgsExpressionBuilderDialog dlg( mLayer, mFieldcombo->currentText() , mParent );
+  dlg.setWindowTitle( mTitle );
+
+  if ( dlg.exec() == QDialog::Accepted )
+  {
+    QString expression =  dlg.expressionText();
+    //Only add the expression if the user has entered some text.
+    if ( !expression.isEmpty() )
+    {
+      mFieldcombo->addItem( expression );
+      mFieldcombo->setCurrentIndex( mFieldcombo->count() - 1 );
+      mExpressions << expression;
+    }
+  }
+  if ( mParent )
+  {
+    mParent->activateWindow();
+  }
+}
+
+void QgsExpressionGuiHelper::populateFieldCombo()
+{
+  if ( !mLayer )
+  {
+    return;
+  }
+  const QgsFields& fields = mLayer->pendingFields();
+  for ( int idx = 0; idx < fields.count(); ++idx )
+  {
+    mFieldcombo->addItem( fields[idx].name() );
+  }
+  foreach ( const QString expr, mExpressions )
+  {
+    mFieldcombo->addItem( expr );
+  }
+}
+
+void QgsExpressionGuiHelper::attributeAdded( int idx )
+{
+  const QgsFields& fields = mLayer->pendingFields();
+  mFieldcombo->insertItem( idx, fields[idx].name() );
+}
+
+void QgsExpressionGuiHelper::attributeDeleted( int idx )
+{
+  mFieldcombo->removeItem( idx );
+}
+

--- a/src/gui/qgsexpressionguihelper.cpp
+++ b/src/gui/qgsexpressionguihelper.cpp
@@ -70,6 +70,8 @@ void QgsExpressionGuiHelper::showExpressionDialog()
 
   QgsExpressionBuilderDialog dlg( mLayer, mFieldcombo->currentText() , mParent );
   dlg.setWindowTitle( mTitle );
+  dlg.setGeomCalculator( mDa );
+
 
   if ( dlg.exec() == QDialog::Accepted )
   {

--- a/src/gui/qgsexpressionguihelper.h
+++ b/src/gui/qgsexpressionguihelper.h
@@ -1,0 +1,57 @@
+#ifndef QGSEXPRESSIONGUIHELPER_H
+#define QGSEXPRESSIONGUIHELPER_H
+
+#include <QObject>
+#include <QAbstractButton>
+#include <QComboBox>
+#include <QStringList>
+
+#include "qgsvectorlayer.h"
+
+class GUI_EXPORT QgsExpressionGuiHelper : public QObject
+{
+    Q_OBJECT
+  public:
+    /**
+     * @brief QgsExpressionGuiHelper is a helper class to populate a combo with the field of a layer and allows to add expressions by clicking on a button
+     * @param layer the layer used for fields and expressions
+     * @param fieldCombo the QCombobox to be populated
+     * @param expressionButton the button which triggers the expression builder dialg
+     * @param title the title to be shown in the dialog
+     * @param parent
+     */
+    QgsExpressionGuiHelper( QgsVectorLayer* layer, QComboBox *fieldCombo, QAbstractButton *expressionButton, QString title, QWidget *parent = 0 );
+
+    /**
+     * @brief setExpression sets the str expression as current item in combobox. If str was not in current items, it is automatically added
+     */
+    void setExpression( const QString str );
+
+
+  public slots:
+    void showExpressionDialog();
+    /**
+     * @brief changeLayer changes the layer will repopulate the fields
+     * @param layer if layer=0, this will empty the field combobox
+     */
+    void changeLayer( QgsVectorLayer *layer = 0 );
+
+    void setGeomCalculator( const QgsDistanceArea &da );
+
+  private:
+    QgsVectorLayer* mLayer;
+    QComboBox* mFieldcombo;
+    QAbstractButton* mExpressionButton;
+    QString mTitle;
+    QWidget* mParent;
+    QStringList mExpressions;
+    QgsDistanceArea mDa;
+
+    void populateFieldCombo();
+
+  private slots:
+    void attributeAdded( int idx );
+    void attributeDeleted( int idx );
+};
+
+#endif // QGSEXPRESSIONGUIHELPER_H

--- a/src/ui/qgsvectorlayerpropertiesbase.ui
+++ b/src/ui/qgsvectorlayerpropertiesbase.ui
@@ -246,7 +246,7 @@
           </sizepolicy>
          </property>
          <property name="currentIndex">
-          <number>7</number>
+          <number>0</number>
          </property>
          <widget class="QWidget" name="mOptsPage_General">
           <layout class="QVBoxLayout" name="verticalLayout_14">
@@ -267,7 +267,7 @@
                 <x>0</x>
                 <y>0</y>
                 <width>739</width>
-                <height>525</height>
+                <height>560</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_13">
@@ -283,14 +283,38 @@
                   <string notr="true">vectorgeneral</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout">
-                  <item row="1" column="0">
+                  <item row="0" column="0">
                    <widget class="QLabel" name="textLabel3">
                     <property name="text">
                      <string>Layer name</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="5" column="0">
+                  <item row="0" column="1">
+                   <widget class="QLineEdit" name="mLayerOrigNameLineEdit"/>
+                  </item>
+                  <item row="0" column="2">
+                   <widget class="QLabel" name="label_2">
+                    <property name="text">
+                     <string>displayed as</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="3">
+                   <widget class="QLineEdit" name="txtDisplayName">
+                    <property name="readOnly">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="1" column="0">
+                   <widget class="QLabel" name="lblLayerSource">
+                    <property name="text">
+                     <string>Layer source</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="4" column="0">
                    <widget class="QFrame" name="mDataSourceEncodingFrame">
                     <layout class="QHBoxLayout" name="horizontalLayout_4">
                      <property name="margin">
@@ -299,41 +323,7 @@
                     </layout>
                    </widget>
                   </item>
-                  <item row="1" column="1">
-                   <widget class="QLineEdit" name="mLayerOrigNameLineEdit"/>
-                  </item>
-                  <item row="1" column="3">
-                   <widget class="QLineEdit" name="txtDisplayName">
-                    <property name="readOnly">
-                     <bool>true</bool>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="2">
-                   <widget class="QLabel" name="label_2">
-                    <property name="text">
-                     <string>displayed as</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="2" column="0">
-                   <widget class="QLabel" name="lblLayerSource">
-                    <property name="text">
-                     <string>Layer source</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="2" column="1" colspan="3">
-                   <widget class="QLineEdit" name="txtLayerSource">
-                    <property name="enabled">
-                     <bool>true</bool>
-                    </property>
-                    <property name="readOnly">
-                     <bool>true</bool>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="4" column="0" colspan="4">
+                  <item row="2" column="0" colspan="4">
                    <layout class="QHBoxLayout" name="horizontalLayout_6">
                     <item>
                      <widget class="QLabel" name="label_3">
@@ -359,6 +349,90 @@
                       <property name="sizeHint" stdset="0">
                        <size>
                         <width>0</width>
+                        <height>20</height>
+                       </size>
+                      </property>
+                     </spacer>
+                    </item>
+                   </layout>
+                  </item>
+                  <item row="1" column="1" colspan="3">
+                   <widget class="QLineEdit" name="txtLayerSource">
+                    <property name="enabled">
+                     <bool>true</bool>
+                    </property>
+                    <property name="readOnly">
+                     <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="3" column="0" colspan="4">
+                   <layout class="QHBoxLayout" name="horizontalLayout_10">
+                    <item>
+                     <widget class="QLabel" name="label">
+                      <property name="text">
+                       <string>Feature title</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QRadioButton" name="mFeatureTitleIdRadio">
+                      <property name="text">
+                       <string>id</string>
+                      </property>
+                      <property name="checked">
+                       <bool>true</bool>
+                      </property>
+                      <attribute name="buttonGroup">
+                       <string notr="true">buttonGroup</string>
+                      </attribute>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QRadioButton" name="mFeatureTitleExprRadio">
+                      <property name="text">
+                       <string>expression</string>
+                      </property>
+                      <attribute name="buttonGroup">
+                       <string notr="true">buttonGroup</string>
+                      </attribute>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QComboBox" name="mFeatureTitleComboBox">
+                      <property name="enabled">
+                       <bool>false</bool>
+                      </property>
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QToolButton" name="mFeatureTitleButton">
+                      <property name="enabled">
+                       <bool>false</bool>
+                      </property>
+                      <property name="text">
+                       <string>...</string>
+                      </property>
+                      <property name="icon">
+                       <iconset resource="../../images/images.qrc">
+                        <normaloff>:/images/themes/default/mIconExpressionEditorOpen.svg</normaloff>:/images/themes/default/mIconExpressionEditorOpen.svg</iconset>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <spacer name="horizontalSpacer_6">
+                      <property name="orientation">
+                       <enum>Qt::Horizontal</enum>
+                      </property>
+                      <property name="sizeHint" stdset="0">
+                       <size>
+                        <width>40</width>
                         <height>20</height>
                        </size>
                       </property>
@@ -696,7 +770,7 @@
                 <x>0</x>
                 <y>0</y>
                 <width>755</width>
-                <height>452</height>
+                <height>487</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_18">
@@ -770,7 +844,7 @@
                 <x>0</x>
                 <y>0</y>
                 <width>755</width>
-                <height>452</height>
+                <height>487</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_28">
@@ -834,7 +908,7 @@
                 <x>0</x>
                 <y>0</y>
                 <width>755</width>
-                <height>452</height>
+                <height>487</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_20">
@@ -876,7 +950,7 @@
                 <x>0</x>
                 <y>0</y>
                 <width>755</width>
-                <height>452</height>
+                <height>487</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_32">
@@ -1019,7 +1093,7 @@
                 <x>0</x>
                 <y>0</y>
                 <width>755</width>
-                <height>452</height>
+                <height>487</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_26">
@@ -1321,7 +1395,7 @@
                 <x>0</x>
                 <y>0</y>
                 <width>755</width>
-                <height>452</height>
+                <height>487</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_24">
@@ -1740,4 +1814,7 @@
    </hints>
   </connection>
  </connections>
+ <buttongroups>
+  <buttongroup name="buttonGroup"/>
+ </buttongroups>
 </ui>


### PR DESCRIPTION
This PR adds a new property to the vector layer: a feature title.
This is defined as a field or an expression and can be changed in the vector layer properties:
![image](https://f.cloud.github.com/assets/127259/2371310/4a6cb06a-a823-11e3-9f52-dd90bdf0f443.png)

I already added this to feature form dialog title:
![image](https://f.cloud.github.com/assets/127259/2371318/80d2dbe8-a823-11e3-8292-d604198aaf36.png)

if accepted, my intention is to use it also in the dual view to be the default expression used. To be clear, in here:
![image](https://f.cloud.github.com/assets/127259/2371324/ba26f118-a823-11e3-87ad-9f3a872f479f.png)

The python bindings are not created yet, I wait for approval of the whole idea.

Also, in this PR I added a new class in gui: QgsExpressionGuiHelper. This class creates the connection mechanism between a field combobox and an expression button: it automatically populates the fields in the combo and update the combo with a new expression. This code as been rewritten in many places, and I thought it would be easier with this class helper, and even more for plugin writers. Although, I am not sure about the name of the class. I changed qgslabellinggui.cpp to use this helper.
