### PR TITLE
Indentation error in the Dissolve.py fTools Processing script

### DIFF
--- a/python/plugins/processing/algs/ftools/Dissolve.py
+++ b/python/plugins/processing/algs/ftools/Dissolve.py
@@ -85,8 +85,8 @@ class Dissolve(GeoAlgorithm):
                     except:
                         raise GeoAlgorithmExecutionException(
                                 'Geometry exception while dissolving')
-                    outFeat.setAttributes(attrs)
-                    writer.addFeature(outFeat)
+            outFeat.setAttributes(attrs)
+            writer.addFeature(outFeat)
         else:
             unique = vector.getUniqueValues(vlayerA, int(field))
             nFeat = nFeat * len(unique)
@@ -125,7 +125,8 @@ class Dissolve(GeoAlgorithm):
         self.name = 'Dissolve'
         self.group = 'Vector geometry tools'
         self.addParameter(ParameterVector(Dissolve.INPUT, 'Input layer',
-                          [ParameterVector.VECTOR_TYPE_POLYGON]))
+                          [ParameterVector.VECTOR_TYPE_POLYGON,
+                          ParameterVector.VECTOR_TYPE_LINE]))
         self.addParameter(ParameterBoolean(Dissolve.DISSOLVE_ALL,
                           'Dissolve all (do not use field)', True))
         self.addParameter(ParameterTableField(Dissolve.FIELD, 'Unique ID field'


### PR DESCRIPTION
This results in the intermediate object being written on every merge with an input feature rather than just once at the end of the processing.

I have also edited the defineCharacteristics function to allow the tool input to accept polyline features as well as polygons, in line with the fTools UI.
