### PR TITLE
Fix bug #9480: Labels for polygon centroids should always originate inside a polygon

### DIFF
--- a/python/core/qgsgeometry.sip
+++ b/python/core/qgsgeometry.sip
@@ -322,6 +322,9 @@ class QgsGeometry
     * and for point based geometries, the point itself is returned */
     QgsGeometry* centroid() /Factory/;
 
+    /** Returns a point within a geometry */
+    QgsGeometry* pointOnSurface();
+
     /** Returns the smallest convex polygon that contains all the points in the geometry. */
     QgsGeometry* convexHull() /Factory/;
 

--- a/python/core/qgsgeometry.sip
+++ b/python/core/qgsgeometry.sip
@@ -323,7 +323,7 @@ class QgsGeometry
     QgsGeometry* centroid() /Factory/;
 
     /** Returns a point within a geometry */
-    QgsGeometry* pointOnSurface();
+    QgsGeometry* pointOnSurface() /Factory/;
 
     /** Returns the smallest convex polygon that contains all the points in the geometry. */
     QgsGeometry* convexHull() /Factory/;

--- a/python/core/qgspallabeling.sip
+++ b/python/core/qgspallabeling.sip
@@ -386,6 +386,7 @@ class QgsPalLayerSettings
     unsigned int placementFlags;
 
     bool centroidWhole; // whether centroid calculated from whole or visible polygon
+    bool centroidInside; // whether centroid-point calculated must be inside polygon
     double dist; // distance from the feature (in mm)
     bool distInMapUnits; //true if distance is in map units (otherwise in mm)
 

--- a/src/app/qgslabelinggui.cpp
+++ b/src/app/qgslabelinggui.cpp
@@ -259,6 +259,7 @@ void QgsLabelingGui::init()
 
   // populate placement options
   mCentroidRadioWhole->setChecked( lyr.centroidWhole );
+  mCentroidInsideCheckBox->setChecked( lyr.centroidInside );
   switch ( lyr.placement )
   {
     case QgsPalLayerSettings::AroundPoint:
@@ -545,6 +546,7 @@ QgsPalLayerSettings QgsLabelingGui::layerSettings()
 
   QWidget* curPlacementWdgt = stackedPlacement->currentWidget();
   lyr.centroidWhole = mCentroidRadioWhole->isChecked();
+  lyr.centroidInside = mCentroidInsideCheckBox->isChecked();
   if (( curPlacementWdgt == pagePoint && radAroundPoint->isChecked() )
       || ( curPlacementWdgt == pagePolygon && radAroundCentroid->isChecked() ) )
   {

--- a/src/core/pal/feature.cpp
+++ b/src/core/pal/feature.cpp
@@ -1344,7 +1344,7 @@ namespace pal
             case P_POINT:
             case P_POINT_OVER:
               double cx, cy;
-              mapShape->getCentroid( cx, cy );
+              mapShape->getCentroid( cx, cy, f->layer->getCentroidInside() );
               if ( f->layer->getArrangement() == P_POINT_OVER )
                 nbp = setPositionOverPoint( cx, cy, scale, lPos, delta, angle );
               else

--- a/src/core/pal/layer.cpp
+++ b/src/core/pal/layer.cpp
@@ -61,7 +61,7 @@ namespace pal
 
   Layer::Layer( const char *lyrName, double min_scale, double max_scale, Arrangement arrangement, Units label_unit, double defaultPriority, bool obstacle, bool active, bool toLabel, Pal *pal, bool displayAll )
       :  pal( pal ), obstacle( obstacle ), active( active ),
-      toLabel( toLabel ), displayAll( displayAll ), label_unit( label_unit ),
+      toLabel( toLabel ), displayAll( displayAll ), centroidInside( false ), label_unit( label_unit ),
       min_scale( min_scale ), max_scale( max_scale ),
       arrangement( arrangement ), arrangementFlags( 0 ), mode( LabelPerFeature ), mergeLines( false )
   {

--- a/src/core/pal/layer.h
+++ b/src/core/pal/layer.h
@@ -101,6 +101,7 @@ namespace pal
       bool active;
       bool toLabel;
       bool displayAll;
+      bool centroidInside;
 
       Units label_unit;
 
@@ -290,6 +291,9 @@ namespace pal
 
       void setUpsidedownLabels( UpsideDownLabels ud ) { upsidedownLabels = ud; }
       UpsideDownLabels getUpsidedownLabels() const { return upsidedownLabels; }
+
+      void setCentroidInside( bool forceInside ) { centroidInside = forceInside; }
+      bool getCentroidInside() const { return centroidInside; }
 
       /**
        * \brief register a feature in the layer

--- a/src/core/pal/pointset.h
+++ b/src/core/pal/pointset.h
@@ -160,7 +160,7 @@ namespace pal
 
       //double getDistInside(double px, double py);
 
-      void getCentroid( double &px, double &py );
+      void getCentroid( double &px, double &py, bool forceInside = false );
 
 
       int getGeosType() const { return type; }

--- a/src/core/qgsgeometry.cpp
+++ b/src/core/qgsgeometry.cpp
@@ -145,6 +145,7 @@ static GEOSInit geosinit;
 #define GEOSArea(g, a) GEOSArea( (GEOSGeometry*) g, a )
 #define GEOSTopologyPreserveSimplify(g, t) GEOSTopologyPreserveSimplify( (GEOSGeometry*) g, t )
 #define GEOSGetCentroid(g) GEOSGetCentroid( (GEOSGeometry*) g )
+#define GEOSPointOnSurface(g) GEOSPointOnSurface( (GEOSGeometry*) g )
 
 #define GEOSCoordSeq_getSize(cs,n) GEOSCoordSeq_getSize( (GEOSCoordSequence *) cs, n )
 #define GEOSCoordSeq_getX(cs,i,x) GEOSCoordSeq_getX( (GEOSCoordSequence *)cs, i, x )
@@ -5619,6 +5620,21 @@ QgsGeometry* QgsGeometry::centroid()
   try
   {
     return fromGeosGeom( GEOSGetCentroid( mGeos ) );
+  }
+  CATCH_GEOS( 0 )
+}
+
+QgsGeometry* QgsGeometry::pointOnSurface()
+{
+  if ( mDirtyGeos )
+    exportWkbToGeos();
+
+  if ( !mGeos )
+    return 0;
+
+  try
+  {
+    return fromGeosGeom( GEOSPointOnSurface( mGeos ) );
   }
   CATCH_GEOS( 0 )
 }

--- a/src/core/qgsgeometry.h
+++ b/src/core/qgsgeometry.h
@@ -363,6 +363,9 @@ class CORE_EXPORT QgsGeometry
     * and for point based geometries, the point itself is returned */
     QgsGeometry* centroid();
 
+    /** Returns a point within a geometry */
+    QgsGeometry* pointOnSurface();
+
     /** Returns the smallest convex polygon that contains all the points in the geometry. */
     QgsGeometry* convexHull();
 

--- a/src/core/qgspallabeling.cpp
+++ b/src/core/qgspallabeling.cpp
@@ -311,6 +311,7 @@ QgsPalLayerSettings::QgsPalLayerSettings()
   placement = AroundPoint;
   placementFlags = 0;
   centroidWhole = false;
+  centroidInside = false;
   quadOffset = QuadrantOver;
   xOffset = 0;
   yOffset = 0;
@@ -502,6 +503,7 @@ QgsPalLayerSettings::QgsPalLayerSettings( const QgsPalLayerSettings& s )
   placement = s.placement;
   placementFlags = s.placementFlags;
   centroidWhole = s.centroidWhole;
+  centroidInside = s.centroidInside;
   quadOffset = s.quadOffset;
   xOffset = s.xOffset;
   yOffset = s.yOffset;
@@ -997,6 +999,7 @@ void QgsPalLayerSettings::readFromLayer( QgsVectorLayer* layer )
   placement = ( Placement )layer->customProperty( "labeling/placement" ).toInt();
   placementFlags = layer->customProperty( "labeling/placementFlags" ).toUInt();
   centroidWhole = layer->customProperty( "labeling/centroidWhole", QVariant( false ) ).toBool();
+  centroidInside = layer->customProperty( "labeling/centroidInside", QVariant( false ) ).toBool();
   dist = layer->customProperty( "labeling/dist" ).toDouble();
   distInMapUnits = layer->customProperty( "labeling/distInMapUnits" ).toBool();
   distMapUnitScale.minScale = layer->customProperty( "labeling/distMapUnitMinScale", 0.0 ).toDouble();
@@ -1167,6 +1170,7 @@ void QgsPalLayerSettings::writeToLayer( QgsVectorLayer* layer )
   layer->setCustomProperty( "labeling/placement", placement );
   layer->setCustomProperty( "labeling/placementFlags", ( unsigned int )placementFlags );
   layer->setCustomProperty( "labeling/centroidWhole", centroidWhole );
+  layer->setCustomProperty( "labeling/centroidInside", centroidInside );
   layer->setCustomProperty( "labeling/dist", dist );
   layer->setCustomProperty( "labeling/distInMapUnits", distInMapUnits );
   layer->setCustomProperty( "labeling/distMapUnitMinScale", distMapUnitScale.minScale );
@@ -3389,8 +3393,8 @@ int QgsPalLabeling::prepareLayer( QgsVectorLayer* layer, QStringList& attrNames,
   // set whether adjacent lines should be merged
   l->setMergeConnectedLines( lyr.mergeLines );
 
-  // force the location of the centroid inside of polygons
-  l->setCentroidInside( true );
+  // set whether location of centroid must be inside of polygons
+  l->setCentroidInside( lyr.centroidInside );
 
   // set how to show upside-down labels
   Layer::UpsideDownLabels upsdnlabels;

--- a/src/core/qgspallabeling.cpp
+++ b/src/core/qgspallabeling.cpp
@@ -3389,6 +3389,9 @@ int QgsPalLabeling::prepareLayer( QgsVectorLayer* layer, QStringList& attrNames,
   // set whether adjacent lines should be merged
   l->setMergeConnectedLines( lyr.mergeLines );
 
+  // force the location of the centroid inside of polygons
+  l->setCentroidInside( true );
+
   // set how to show upside-down labels
   Layer::UpsideDownLabels upsdnlabels;
   switch ( lyr.upsidedownLabels )

--- a/src/core/qgspallabeling.h
+++ b/src/core/qgspallabeling.h
@@ -375,6 +375,7 @@ class CORE_EXPORT QgsPalLayerSettings
     unsigned int placementFlags;
 
     bool centroidWhole; // whether centroid calculated from whole or visible polygon
+    bool centroidInside; // whether centroid-point calculated must be inside polygon 
     double dist; // distance from the feature (in mm)
     bool distInMapUnits; //true if distance is in map units (otherwise in mm)
     QgsMapUnitScale distMapUnitScale;

--- a/src/core/symbology-ng/qgsfillsymbollayerv2.h
+++ b/src/core/symbology-ng/qgsfillsymbollayerv2.h
@@ -904,8 +904,12 @@ class CORE_EXPORT QgsCentroidFillSymbolLayerV2 : public QgsFillSymbolLayerV2
 
     virtual QSet<QString> usedAttributes() const;
 
+    void setPointOnSurface( bool pointOnSurface ) { mPointOnSurface = pointOnSurface; }
+    bool pointOnSurface() const { return mPointOnSurface; }
+
   protected:
     QgsMarkerSymbolV2* mMarker;
+    bool mPointOnSurface;
 };
 
 #endif

--- a/src/core/symbology-ng/qgssymbollayerv2utils.h
+++ b/src/core/symbology-ng/qgssymbollayerv2utils.h
@@ -287,6 +287,12 @@ class CORE_EXPORT QgsSymbolLayerV2Utils
     //! Calculate the centroid point of a QPolygonF
     static QPointF polygonCentroid( const QPolygonF& points );
 
+    //! Calculate a point within of a QPolygonF
+    static QPointF polygonPointOnSurface( const QPolygonF& points );
+
+    //! Calculate whether a point is within of a QPolygonF
+    static bool pointInPolygon( const QPolygonF &points, const QPointF &point );
+
     /** Return a new valid expression instance for given field or expression string.
      * If the input is not a valid expression, it is assumed that it is a field name and gets properly quoted.
      * If the string is empty, returns null pointer.

--- a/src/gui/symbology-ng/qgssymbollayerv2widget.cpp
+++ b/src/gui/symbology-ng/qgssymbollayerv2widget.cpp
@@ -2794,6 +2794,11 @@ void QgsCentroidFillSymbolLayerV2Widget::setSymbolLayer( QgsSymbolLayerV2* layer
 
   // layer type is correct, we can do the cast
   mLayer = static_cast<QgsCentroidFillSymbolLayerV2*>( layer );
+
+  // set values
+  mDrawInsideCheckBox->blockSignals( true );
+  mDrawInsideCheckBox->setChecked( mLayer->pointOnSurface() );
+  mDrawInsideCheckBox->blockSignals( false );
 }
 
 QgsSymbolLayerV2* QgsCentroidFillSymbolLayerV2Widget::symbolLayer()
@@ -2801,5 +2806,8 @@ QgsSymbolLayerV2* QgsCentroidFillSymbolLayerV2Widget::symbolLayer()
   return mLayer;
 }
 
-
-
+void QgsCentroidFillSymbolLayerV2Widget::on_mDrawInsideCheckBox_stateChanged( int state )
+{
+  mLayer->setPointOnSurface( state == Qt::Checked );
+  emit changed();
+}

--- a/src/gui/symbology-ng/qgssymbollayerv2widget.h
+++ b/src/gui/symbology-ng/qgssymbollayerv2widget.h
@@ -482,6 +482,9 @@ class GUI_EXPORT QgsCentroidFillSymbolLayerV2Widget : public QgsSymbolLayerV2Wid
     virtual void setSymbolLayer( QgsSymbolLayerV2* layer );
     virtual QgsSymbolLayerV2* symbolLayer();
 
+  public slots:
+    void on_mDrawInsideCheckBox_stateChanged( int state );
+
   protected:
     QgsCentroidFillSymbolLayerV2* mLayer;
 };

--- a/src/ui/qgslabelingguibase.ui
+++ b/src/ui/qgslabelingguibase.ui
@@ -4101,6 +4101,13 @@ font-style: italic;</string>
                            </property>
                           </widget>
                          </item>
+                         <item row="1" column="1">
+                          <widget class="QCheckBox" name="mCentroidInsideCheckBox">
+                           <property name="text">
+                            <string>Force point inside polygon</string>
+                           </property>
+                          </widget>
+                         </item>
                         </layout>
                        </widget>
                       </item>

--- a/src/ui/symbollayer/widget_centroidfill.ui
+++ b/src/ui/symbollayer/widget_centroidfill.ui
@@ -17,6 +17,13 @@
    <item>
     <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
+      <widget class="QCheckBox" name="mDrawInsideCheckBox">
+       <property name="text">
+        <string>Force point inside polygon</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <spacer>
        <property name="orientation">
         <enum>Qt::Horizontal</enum>


### PR DESCRIPTION
This pull fixes the bug 9480 (http://hub.qgis.org/issues/9480).

Changes:
- New 'pointOnSurface' method for QgsGeometry using 'GEOSPointOnSurface'.
- New option for CentroidFillSymbolLayerV2 to force the location of centroid inside of polygons.
- Force label position inside of polygons in PAL labeling library.
