### PR TITLE
Fix label vertical alignment, ignoring no value

### DIFF
--- a/src/app/qgslabelpropertydialog.cpp
+++ b/src/app/qgslabelpropertydialog.cpp
@@ -368,6 +368,7 @@ void QgsLabelPropertyDialog::fillValiComboBox()
 {
   mValiComboBox->addItem( "Bottom" );
   mValiComboBox->addItem( "Base" );
+  mValiComboBox->addItem( "Cap" );
   mValiComboBox->addItem( "Half" );
   mValiComboBox->addItem( "Top" );
 }

--- a/src/app/qgsmaptoollabel.cpp
+++ b/src/app/qgsmaptoollabel.cpp
@@ -397,14 +397,19 @@ bool QgsMapToolLabel::rotationPoint( QgsPoint& pos, bool ignoreUpsideDown, bool 
   }
   else
   {
-    double descentRatio = 1 / labelFontMetrics.ascent() / labelFontMetrics.height();
+    double descentRatio = labelFontMetrics.descent() / labelFontMetrics.height();
+    double capHeightRatio = ( labelFontMetrics.boundingRect( 'H' ).height() + 1 + labelFontMetrics.descent() ) / labelFontMetrics.height();
     if ( valiString.compare( "Base", Qt::CaseInsensitive ) == 0 )
     {
       ydiff = labelSizeY * descentRatio;
     }
+    else if ( valiString.compare( "Cap", Qt::CaseInsensitive ) == 0 )
+    {
+      ydiff = labelSizeY * capHeightRatio;
+    }
     else if ( valiString.compare( "Half", Qt::CaseInsensitive ) == 0 )
     {
-      ydiff = labelSizeY * 0.5 * ( 1 - descentRatio );
+      ydiff = labelSizeY / 2.0;
     }
   }
 

--- a/src/core/qgspallabeling.cpp
+++ b/src/core/qgspallabeling.cpp
@@ -2082,18 +2082,18 @@ void QgsPalLayerSettings::registerFeature( QgsFeature& f, const QgsRenderContext
             else
             {
               double descentRatio = labelFontMetrics->descent() / labelFontMetrics->height();
+              double capHeightRatio = ( labelFontMetrics->boundingRect( 'H' ).height() + 1 + labelFontMetrics->descent() ) / labelFontMetrics->height();
               if ( valiString.compare( "Base", Qt::CaseInsensitive ) == 0 )
               {
                 ydiff -= labelY * descentRatio;
               }
-              else //'Cap' or 'Half'
+              else if ( valiString.compare( "Cap", Qt::CaseInsensitive ) == 0 )
               {
-                double capHeightRatio = ( labelFontMetrics->boundingRect( 'H' ).height() + 1 + labelFontMetrics->descent() ) / labelFontMetrics->height();
                 ydiff -= labelY * capHeightRatio;
-                if ( valiString.compare( "Half", Qt::CaseInsensitive ) == 0 )
-                {
-                  ydiff += labelY * ( capHeightRatio - descentRatio ) / 2.0;
-                }
+              }
+              else if ( valiString.compare( "Half", Qt::CaseInsensitive ) == 0 )
+              {
+                ydiff -= labelY / 2.0;
               }
             }
           }


### PR DESCRIPTION
- Set Half to always half of label height (works again for multiline labels)
- Add Cap alignment choice to Change Label properties dialog

Fixed when Hali and Vali data defined mappings were set, but no value was returned, which caused Base to be applied by default.
