### PR TITLE
Fix bug #9777: Simplification of polygons may return invalid polygons -> ST_MakeValid

### DIFF
--- a/python/core/qgsgeometry.sip
+++ b/python/core/qgsgeometry.sip
@@ -518,5 +518,16 @@ class QgsGeometry
     */
     static bool compare( const QgsMultiPolygon& p1, const QgsMultiPolygon& p2, double epsilon = 4 * DBL_EPSILON );
 
+    /** Indicates whether the geometry must be automatically validated and fixed after last conversion to GEOS 
+     * @note added in 2.4
+     **/
+    void setAutomaticGeosValidation( bool automaticValidation );
+    bool hasAutomaticGeosValidation() const;
+
+    /** Attempts to create a valid representation of a given invalid geometry without loosing any of the input vertices.
+     * @note added in 2.4
+     **/
+    QgsGeometry* makeValid() const;
+
 }; // class QgsGeometry
 

--- a/python/core/qgsgeometry.sip
+++ b/python/core/qgsgeometry.sip
@@ -518,6 +518,11 @@ class QgsGeometry
     */
     static bool compare( const QgsMultiPolygon& p1, const QgsMultiPolygon& p2, double epsilon = 4 * DBL_EPSILON );
 
+    /** Attempts to repair the geometry if it is invalid.
+     * @note added in 2.4
+     **/
+    bool repairGeometry();
+
     /** Indicates whether the geometry must be automatically validated and fixed after last conversion to GEOS 
      * @note added in 2.4
      **/

--- a/python/core/qgsgeometryvalidator.sip
+++ b/python/core/qgsgeometryvalidator.sip
@@ -15,6 +15,11 @@ class QgsGeometryValidator : QThread
     /** Validate geometry and produce a list of geometry errors */
     static void validateGeometry( const QgsGeometry *g, QList<QgsGeometry::Error> &errors );
 
+    /** Attempts to create a valid representation of a given invalid geometry without loosing any of the input vertices.
+     * @note added in 2.4
+     **/
+    static QgsGeometry *makeValidGeometry( const QgsGeometry *g );
+
   signals:
     void errorFound( QgsGeometry::Error );
 

--- a/python/core/qgsvectorlayer.sip
+++ b/python/core/qgsvectorlayer.sip
@@ -1180,6 +1180,15 @@ class QgsVectorLayer : QgsMapLayer
      */
     bool simplifyDrawingCanbeApplied( const QgsRenderContext& renderContext, QgsVectorSimplifyMethod::SimplifyHint simplifyHint ) const;
 
+    /** Set whether the fetched geometries must be automatically validated and fixed when needed 
+     *  @note added in 2.4
+     **/
+    void setAutomaticGeometryValidation( bool automaticValidation );
+    /** Returns whether the fetched geometries must be automatically validated and fixed when needed 
+     *  @note added in 2.4
+     **/
+    bool automaticGeometryValidation() const;
+
   public slots:
     /**
      * Select feature by its ID

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -580,6 +580,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl ) :
   cbxSnappingOptionsDocked->setChecked( settings.value( "/qgis/dockSnapping", false ).toBool() );
   cbxAddPostgisDC->setChecked( settings.value( "/qgis/addPostgisDC", false ).toBool() );
   cbxAddOracleDC->setChecked( settings.value( "/qgis/addOracleDC", false ).toBool() );
+  cbxAutomaticValidation->setChecked( settings.value( "/qgis/automaticGeometryValidation", false ).toBool() );
   cbxCreateRasterLegendIcons->setChecked( settings.value( "/qgis/createRasterLegendIcons", false ).toBool() );
   cbxCopyWKTGeomFromTable->setChecked( settings.value( "/qgis/copyGeometryAsWKT", true ).toBool() );
   leNullValue->setText( settings.value( "qgis/nullValue", "NULL" ).toString() );
@@ -1095,6 +1096,7 @@ void QgsOptions::saveOptions()
   settings.setValue( "/qgis/dockSnapping", cbxSnappingOptionsDocked->isChecked() );
   settings.setValue( "/qgis/addPostgisDC", cbxAddPostgisDC->isChecked() );
   settings.setValue( "/qgis/addOracleDC", cbxAddOracleDC->isChecked() );
+  settings.setValue( "/qgis/automaticGeometryValidation", cbxAutomaticValidation->isChecked() );
   settings.setValue( "/qgis/defaultLegendGraphicResolution", mLegendGraphicResolutionSpinBox->value() );
   bool createRasterLegendIcons = settings.value( "/qgis/createRasterLegendIcons", false ).toBool();
   settings.setValue( "/qgis/createRasterLegendIcons", cbxCreateRasterLegendIcons->isChecked() );

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -420,6 +420,18 @@ void QgsVectorLayerProperties::syncToLayer( void )
   mSimplifyDrawingGroupBox->setChecked( simplifyMethod.simplifyHints() != QgsVectorSimplifyMethod::NoSimplification );
   mSimplifyDrawingSpinBox->setValue( simplifyMethod.threshold() );
 
+  // get geometry validation configuration, only for no-point layers
+  if ( layer->geometryType() == QGis::Point )
+  {
+    cbxAutomaticValidation->setEnabled( false );
+    cbxAutomaticValidation->setChecked( false );
+  }
+  else
+  {
+    cbxAutomaticValidation->setEnabled( true );
+    cbxAutomaticValidation->setChecked( layer->automaticGeometryValidation() );
+  }
+
   if ( !( layer->dataProvider()->capabilities() & QgsVectorDataProvider::SimplifyGeometries ) )
   {
     mSimplifyDrawingAtProvider->setChecked( false );
@@ -601,6 +613,9 @@ void QgsVectorLayerProperties::apply()
   simplifyMethod.setForceLocalOptimization( !mSimplifyDrawingAtProvider->isChecked() );
   simplifyMethod.setMaximumScale( 1.0 / mSimplifyMaximumScaleComboBox->scale() );
   layer->setSimplifyMethod( simplifyMethod );
+
+  // set geometry validation configuration
+  layer->setAutomaticGeometryValidation( cbxAutomaticValidation->isChecked() );
 
   mOldJoins = layer->vectorJoins();
 

--- a/src/core/qgsgeometry.h
+++ b/src/core/qgsgeometry.h
@@ -563,6 +563,21 @@ class CORE_EXPORT QgsGeometry
     */
     static bool compare( const QgsMultiPolygon& p1, const QgsMultiPolygon& p2, double epsilon = 4 * DBL_EPSILON );
 
+	/** Indicates whether the geometry must be automatically validated and fixed after last conversion to GEOS 
+     * @note added in 2.4
+     **/
+    void setAutomaticGeosValidation( bool automaticValidation );
+    bool hasAutomaticGeosValidation() const { return mAutovalidateGeos; }
+
+    /** Attempts to create a valid representation of a given invalid geometry without loosing any of the input vertices.
+     * Already-valid geometries are returned w/out further intervention.
+     * In case of full or partial dimensional collapses, the output geometry may be a collection of 
+     * lower-to-equal dimension geometries or a geometry of lower dimension.
+     * Single polygons may become multi-geometries in case of self-intersections.
+     * @note added in 2.4
+     */
+    QgsGeometry* makeValid() const;
+
   private:
     // Private variables
 
@@ -585,9 +600,11 @@ class CORE_EXPORT QgsGeometry
     /** If the geometry has been set since the last conversion to WKB **/
     mutable bool mDirtyWkb;
 
-    /** If the geometry has been set  since the last conversion to GEOS **/
+    /** If the geometry has been set since the last conversion to GEOS **/
     mutable bool mDirtyGeos;
 
+    /** If the geometry must be automatically validated and fixed after last conversion to GEOS **/
+    mutable bool mAutovalidateGeos;
 
     // Private functions
 
@@ -600,6 +617,9 @@ class CORE_EXPORT QgsGeometry
         @return   true in case of success and false else
      */
     bool exportGeosToWkb() const;
+
+    /** Execute the GEOS geometry validation and fix topology when needed **/
+    bool executeGeosValidation() const;
 
     /** Insert a new vertex before the given vertex index (first number is index 0)
      *  in the given GEOS Coordinate Sequence.

--- a/src/core/qgsgeometry.h
+++ b/src/core/qgsgeometry.h
@@ -563,7 +563,12 @@ class CORE_EXPORT QgsGeometry
     */
     static bool compare( const QgsMultiPolygon& p1, const QgsMultiPolygon& p2, double epsilon = 4 * DBL_EPSILON );
 
-	/** Indicates whether the geometry must be automatically validated and fixed after last conversion to GEOS 
+    /** Attempts to repair the geometry if it is invalid.
+     * @note added in 2.4
+     **/
+    bool repairGeometry();
+
+    /** Indicates whether the geometry must be automatically validated and fixed after last conversion to GEOS 
      * @note added in 2.4
      **/
     void setAutomaticGeosValidation( bool automaticValidation );

--- a/src/core/qgsgeometryvalidator.h
+++ b/src/core/qgsgeometryvalidator.h
@@ -34,6 +34,24 @@ class CORE_EXPORT QgsGeometryValidator : public QThread
     /** Validate geometry and produce a list of geometry errors */
     static void validateGeometry( const QgsGeometry *g, QList<QgsGeometry::Error> &errors );
 
+    /** Attempts to create a valid representation of a given invalid geometry without loosing any of the input vertices.
+     * Already-valid geometries are returned w/out further intervention.
+     * In case of full or partial dimensional collapses, the output geometry may be a collection of 
+     * lower-to-equal dimension geometries or a geometry of lower dimension.
+     * Single polygons may become multi-geometries in case of self-intersections.
+     * @note added in 2.4
+     **/
+    static GEOSGeometry *makeValidGeometry( const GEOSGeometry *g );
+
+    /** Attempts to create a valid representation of a given invalid geometry without loosing any of the input vertices.
+     * Already-valid geometries are returned w/out further intervention.
+     * In case of full or partial dimensional collapses, the output geometry may be a collection of 
+     * lower-to-equal dimension geometries or a geometry of lower dimension.
+     * Single polygons may become multi-geometries in case of self-intersections.
+     * @note added in 2.4
+     **/
+    static QgsGeometry *makeValidGeometry( const QgsGeometry *g );
+
   signals:
     void errorFound( QgsGeometry::Error );
 

--- a/src/core/qgspallabeling.cpp
+++ b/src/core/qgspallabeling.cpp
@@ -1754,6 +1754,20 @@ void QgsPalLayerSettings::registerFeature( QgsFeature& f, const QgsRenderContext
                          || placement == QgsPalLayerSettings::OverPoint )
                        && geom->type() == QGis::Polygon );
 
+  if ( !geom->asGeos() )
+    return;  // there is something really wrong with the geometry
+
+  // Rotate the geometry if needed, before clipping
+  const QgsMapToPixel& m2p = context.mapToPixel();
+  if ( m2p.mapRotation() )
+  {
+    if ( geom->rotate( m2p.mapRotation(), context.extent().center() ) )
+    {
+      QgsDebugMsg( QString( "Error rotating geometry" ).arg( geom->exportToWkt() ) );
+      return; // really ?
+    }
+  }
+
   // CLIP the geometry if it is bigger than the extent
   // don't clip if centroid is requested for whole feature
   bool doClip = false;

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -190,7 +190,7 @@ QgsVectorLayer::QgsVectorLayer( QString vectorLayerPath,
   mSimplifyMethod.setMaximumScale( settings.value( "/qgis/simplifyMaxScale", mSimplifyMethod.maximumScale() ).toFloat() );
 
   // Default geometry validation settings
-  mAutomaticGeometryValidation = settings.value( "/qgis/automaticGeometryValidation", false ).toBool();
+  mAutomaticGeometryValidation = settings.value( "/qgis/automaticGeometryValidation", false ).toBool() && hasGeometryType() && geometryType() != QGis::Point;
 
 } // QgsVectorLayer ctor
 

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -188,6 +188,10 @@ QgsVectorLayer::QgsVectorLayer( QString vectorLayerPath,
   mSimplifyMethod.setThreshold( settings.value( "/qgis/simplifyDrawingTol", mSimplifyMethod.threshold() ).toFloat() );
   mSimplifyMethod.setForceLocalOptimization( settings.value( "/qgis/simplifyLocal", mSimplifyMethod.forceLocalOptimization() ).toBool() );
   mSimplifyMethod.setMaximumScale( settings.value( "/qgis/simplifyMaxScale", mSimplifyMethod.maximumScale() ).toFloat() );
+
+  // Default geometry validation settings
+  mAutomaticGeometryValidation = settings.value( "/qgis/automaticGeometryValidation", false ).toBool();
+
 } // QgsVectorLayer ctor
 
 
@@ -1602,6 +1606,9 @@ bool QgsVectorLayer::readSymbology( const QDomNode& node, QString& errorMessage 
     mSimplifyMethod.setForceLocalOptimization( e.attribute( "simplifyLocal", "1" ).toInt() );
     mSimplifyMethod.setMaximumScale( e.attribute( "simplifyMaxScale", "1" ).toFloat() );
 
+    // get the geometry validation settings
+    mAutomaticGeometryValidation = e.attribute( "automaticGeometryValidationFlag", "0" ) == "1";
+
     //also restore custom properties (for labeling-ng)
     readCustomProperties( node, "labeling" );
 
@@ -1838,6 +1845,9 @@ bool QgsVectorLayer::writeSymbology( QDomNode& node, QDomDocument& doc, QString&
     mapLayerNode.setAttribute( "simplifyDrawingTol", QString::number( mSimplifyMethod.threshold() ) );
     mapLayerNode.setAttribute( "simplifyLocal", mSimplifyMethod.forceLocalOptimization() ? 1 : 0 );
     mapLayerNode.setAttribute( "simplifyMaxScale", QString::number( mSimplifyMethod.maximumScale() ) );
+
+    // save the geometry validation settings
+    mapLayerNode.setAttribute( "automaticGeometryValidationFlag", mAutomaticGeometryValidation ? 1 : 0 );
 
     //save customproperties (for labeling ng)
     writeCustomProperties( node, doc );

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -1542,6 +1542,15 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
      */
     bool simplifyDrawingCanbeApplied( const QgsRenderContext& renderContext, QgsVectorSimplifyMethod::SimplifyHint simplifyHint ) const;
 
+    /** Set whether the fetched geometries must be automatically validated and fixed when needed 
+     *  @note added in 2.4
+     **/
+    void setAutomaticGeometryValidation( bool automaticValidation ) { mAutomaticGeometryValidation = automaticValidation; }
+    /** Returns whether the fetched geometries must be automatically validated and fixed when needed 
+     *  @note added in 2.4
+     **/
+    inline bool automaticGeometryValidation() const { return mAutomaticGeometryValidation; }
+
   public slots:
     /**
      * Select feature by its ID
@@ -1818,6 +1827,11 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
 
     /** Simplification object which holds the information about how to simplify the features for fast rendering */
     QgsVectorSimplifyMethod mSimplifyMethod;
+
+    /** Flag indicating whether the fetched geometries must be automatically validated and fixed when needed
+     * @note added in 2.4
+     **/
+    bool mAutomaticGeometryValidation;
 
     /** Label */
     QgsLabel *mLabel;

--- a/src/core/qgsvectorlayerrenderer.cpp
+++ b/src/core/qgsvectorlayerrenderer.cpp
@@ -62,6 +62,8 @@ QgsVectorLayerRenderer::QgsVectorLayerRenderer( QgsVectorLayer* layer, QgsRender
   mSimplifyMethod = layer->simplifyMethod();
   mSimplifyGeometry = layer->simplifyDrawingCanbeApplied( mContext, QgsVectorSimplifyMethod::GeometrySimplification );
 
+  mValidateGeometry = layer->automaticGeometryValidation();
+
   QSettings settings;
   mVertexMarkerOnlyForSelection = settings.value( "/qgis/digitizing/marker_only_for_selected", false ).toBool();
 
@@ -276,6 +278,13 @@ void QgsVectorLayerRenderer::drawRendererV2( QgsFeatureIterator& fit )
       bool sel = mContext.showSelection() && mSelectedFeatureIds.contains( fet.id() );
       bool drawMarker = ( mDrawVertexMarkers && mContext.drawEditingInformation() && ( !mVertexMarkerOnlyForSelection || sel ) );
 
+      // make valid the geometry when needed
+      if ( mValidateGeometry )
+      {
+        QgsGeometry* g = fet.geometry();
+        g->setAutomaticGeosValidation( true );
+      }
+
       // render feature
       bool rendered = mRendererV2->renderFeature( fet, mContext, -1, sel, drawMarker );
 
@@ -335,6 +344,13 @@ void QgsVectorLayerRenderer::drawRendererV2Levels( QgsFeatureIterator& fit )
       qDebug( "rendering stop!" );
       stopRendererV2( selRenderer );
       return;
+    }
+
+    // make valid the geometry when needed
+    if ( mValidateGeometry )
+    {
+      QgsGeometry* g = fet.geometry();
+      g->setAutomaticGeosValidation( true );
     }
 
     QgsSymbolV2* sym = mRendererV2->symbolForFeature( fet );

--- a/src/core/qgsvectorlayerrenderer.h
+++ b/src/core/qgsvectorlayerrenderer.h
@@ -110,6 +110,8 @@ class QgsVectorLayerRenderer : public QgsMapLayerRenderer
 
     QgsVectorSimplifyMethod mSimplifyMethod;
     bool mSimplifyGeometry;
+
+    bool mValidateGeometry;
 };
 
 

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -1603,6 +1603,13 @@
                     </property>
                    </widget>
                   </item>
+                  <item>
+                   <widget class="QCheckBox" name="cbxAutomaticValidation">
+                     <property name="text">
+                       <string>Enable automatic repair of invalid geometries for newly added layers</string>
+                     </property>
+                   </widget>
+                  </item>
                  </layout>
                 </widget>
                </item>

--- a/src/ui/qgsvectorlayerpropertiesbase.ui
+++ b/src/ui/qgsvectorlayerpropertiesbase.ui
@@ -546,6 +546,22 @@
                 </widget>
                </item>
                <item>
+                 <widget class="QgsCollapsibleGroupBox" name="groupBox_19">
+                   <property name="title">
+                     <string>Data source handling</string>
+                   </property>
+                   <layout class="QVBoxLayout" name="verticalLayout_35">
+                     <item>
+                       <widget class="QCheckBox" name="cbxAutomaticValidation">
+                         <property name="text">
+                           <string>Enable automatic repair of invalid geometries for this layer</string>
+                         </property>
+                       </widget>
+                     </item>
+                   </layout>
+                 </widget>
+               </item>
+               <item>
                 <spacer name="verticalSpacer">
                  <property name="orientation">
                   <enum>Qt::Vertical</enum>


### PR DESCRIPTION
This pull fixes the bug 9777 (http://hub.qgis.org/issues/9777) or others errors when GEOS uses an invalid geometry (labeling, centroid calculations, spatial operations, ...):
- http://hub.qgis.org/issues/2949
- http://hub.qgis.org/issues/3517
- http://hub.qgis.org/issues/4079

It implements the -ST_MakeValid- function for QgsGeometry class. The code is a fork from the original code in postgis implementation with slight changes:

https://github.com/postgis/postgis/blob/svn-trunk/liblwgeom/lwgeom_geos_clean.c

Also, the user can configure automatic validation of the fetched geometries of a layer and convert them to valid when needed.

The validation code is only executed when needed, drawing labels of a simplified geometry, or any code requires the GEOS geometry and this flag is enabled. If a simplified geometry is drawed without internally call to 'exportWkbToGeos()', as usual, then the validation is not executed and there is no penalty in the performance.
