### PR TITLE
Fix uses of deprecated Qt methods

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -516,7 +516,7 @@ int main( int argc, char *argv[] )
       }
       else if ( i + 1 < argc && ( arg == "--snapshot" || arg == "-s" ) )
       {
-        mySnapshotFileName = QDir::convertSeparators( QFileInfo( args[++i] ).absoluteFilePath() );
+        mySnapshotFileName = QDir::toNativeSeparators( QFileInfo( args[++i] ).absoluteFilePath() );
       }
       else if ( i + 1 < argc && ( arg == "--width" || arg == "-w" ) )
       {
@@ -532,7 +532,7 @@ int main( int argc, char *argv[] )
       }
       else if ( i + 1 < argc && ( arg == "--project" || arg == "-p" ) )
       {
-        myProjectFileName = QDir::convertSeparators( QFileInfo( args[++i] ).absoluteFilePath() );
+        myProjectFileName = QDir::toNativeSeparators( QFileInfo( args[++i] ).absoluteFilePath() );
       }
       else if ( i + 1 < argc && ( arg == "--extent" || arg == "-e" ) )
       {
@@ -540,23 +540,23 @@ int main( int argc, char *argv[] )
       }
       else if ( i + 1 < argc && ( arg == "--optionspath" || arg == "-o" ) )
       {
-        optionpath = QDir::convertSeparators( QDir( args[++i] ).absolutePath() );
+        optionpath = QDir::toNativeSeparators( QDir( args[++i] ).absolutePath() );
       }
       else if ( i + 1 < argc && ( arg == "--configpath" || arg == "-c" ) )
       {
-        configpath = QDir::convertSeparators( QDir( args[++i] ).absolutePath() );
+        configpath = QDir::toNativeSeparators( QDir( args[++i] ).absolutePath() );
       }
       else if ( i + 1 < argc && ( arg == "--code" || arg == "-f" ) )
       {
-        pythonfile = QDir::convertSeparators( QFileInfo( args[++i] ).absoluteFilePath() );
+        pythonfile = QDir::toNativeSeparators( QFileInfo( args[++i] ).absoluteFilePath() );
       }
       else if ( i + 1 < argc && ( arg == "--customizationfile" || arg == "-z" ) )
       {
-        customizationfile = QDir::convertSeparators( QFileInfo( args[++i] ).absoluteFilePath() );
+        customizationfile = QDir::toNativeSeparators( QFileInfo( args[++i] ).absoluteFilePath() );
       }
       else
       {
-        myFileList.append( QDir::convertSeparators( QFileInfo( args[i] ).absoluteFilePath() ) );
+        myFileList.append( QDir::toNativeSeparators( QFileInfo( args[i] ).absoluteFilePath() ) );
       }
     }
   }
@@ -572,7 +572,7 @@ int main( int argc, char *argv[] )
     // check for a .qgs
     for ( int i = 0; i < args.size(); i++ )
     {
-      QString arg = QDir::convertSeparators( QFileInfo( args[i] ).absoluteFilePath() );
+      QString arg = QDir::toNativeSeparators( QFileInfo( args[i] ).absoluteFilePath() );
       if ( arg.contains( ".qgs" ) )
       {
         myProjectFileName = arg;

--- a/src/app/qgsattributetypedialog.cpp
+++ b/src/app/qgsattributetypedialog.cpp
@@ -287,12 +287,12 @@ void QgsAttributeTypeDialog::loadFromCSVButtonPushed()
     QString l = s.readLine().trimmed();
 
     QString key, val;
-    if ( re0.indexIn( l ) >= 0 && re0.numCaptures() == 2 )
+    if ( re0.indexIn( l ) >= 0 && re0.captureCount() == 2 )
     {
       key = re0.cap( 1 ).trimmed();
       val = re0.cap( 2 ).trimmed();
     }
-    else if ( re1.indexIn( l ) >= 0 && re1.numCaptures() == 2 )
+    else if ( re1.indexIn( l ) >= 0 && re1.captureCount() == 2 )
     {
       key = re1.cap( 1 ).trimmed();
       val = re1.cap( 2 ).trimmed();

--- a/src/core/qgscredentials.cpp
+++ b/src/core/qgscredentials.cpp
@@ -16,8 +16,7 @@
 #include "qgscredentials.h"
 #include "qgslogger.h"
 
-#include <QTextIStream>
-#include <QTextOStream>
+#include <QTextStream>
 
 QgsCredentials *QgsCredentials::smInstance = 0;
 

--- a/src/gui/qgisgui.cpp
+++ b/src/gui/qgisgui.cpp
@@ -49,7 +49,7 @@ namespace QgisGui
 
       if ( !lastUsedFilter.isEmpty() )
       {
-        openFileDialog->selectFilter( lastUsedFilter );
+        openFileDialog->selectNameFilter( lastUsedFilter );
       }
       openFileDialog->addCancelAll();
       if ( openFileDialog->exec() == QDialog::Accepted )
@@ -146,7 +146,7 @@ namespace QgisGui
 
     if ( !lastUsedFilter.isEmpty() )     // set the filter to the last one used
     {
-      fileDialog->selectFilter( lastUsedFilter );
+      fileDialog->selectNameFilter( lastUsedFilter );
     }
 
     //prompt the user for a fileName

--- a/src/gui/qgsdetaileditemdelegate.cpp
+++ b/src/gui/qgsdetaileditemdelegate.cpp
@@ -49,10 +49,10 @@ void QgsDetailedItemDelegate::paint( QPainter * thepPainter,
 {
   // After painting we need to restore the painter to its original state
   thepPainter->save();
-  if ( qVariantCanConvert<QgsDetailedItemData>( theIndex.data( Qt::UserRole ) ) )
+  if ( theIndex.data( Qt::UserRole ).canConvert<QgsDetailedItemData>() )
   {
     QgsDetailedItemData myData =
-      qVariantValue<QgsDetailedItemData>( theIndex.data( Qt::UserRole ) );
+      theIndex.data( Qt::UserRole ).value<QgsDetailedItemData>();
     if ( myData.isRenderedAsWidget() )
     {
       paintAsWidget( thepPainter, theOption, myData );
@@ -71,10 +71,10 @@ QSize QgsDetailedItemDelegate::sizeHint(
   const QStyleOptionViewItem & theOption,
   const QModelIndex & theIndex ) const
 {
-  if ( qVariantCanConvert<QgsDetailedItemData>( theIndex.data( Qt::UserRole ) ) )
+  if ( theIndex.data( Qt::UserRole ).canConvert<QgsDetailedItemData>() )
   {
     QgsDetailedItemData myData =
-      qVariantValue<QgsDetailedItemData>( theIndex.data( Qt::UserRole ) );
+      theIndex.data( Qt::UserRole ).value<QgsDetailedItemData>();
     if ( myData.isRenderedAsWidget() )
     {
       return QSize( 378, mpWidget->height() );

--- a/src/gui/qgsencodingfiledialog.cpp
+++ b/src/gui/qgsencodingfiledialog.cpp
@@ -61,7 +61,7 @@ QgsEncodingFileDialog::QgsEncodingFileDialog( QWidget * parent,
   // need to force selection of the first filter since that corresponds to
   // the file name we're looking for; even if we're not here from
   // findFiles_(), it won't hurt to force selection of the first file filter
-  selectFilter( filters().at( 0 ) );
+  selectNameFilter( nameFilters().at( 0 ) );
 
   // Connect our slot to get a signal when the user is done with the file dialog
   connect( this, SIGNAL( accepted() ), this, SLOT( saveUsedEncoding() ) );

--- a/tests/bench/main.cpp
+++ b/tests/bench/main.cpp
@@ -209,11 +209,11 @@ int main( int argc, char *argv[] )
         break;
 
       case 's':
-        mySnapshotFileName = QDir::convertSeparators( QFileInfo( QFile::decodeName( optarg ) ).absoluteFilePath() );
+        mySnapshotFileName = QDir::toNativeSeparators( QFileInfo( QFile::decodeName( optarg ) ).absoluteFilePath() );
         break;
 
       case 'l':
-        myLogFileName = QDir::convertSeparators( QFileInfo( QFile::decodeName( optarg ) ).absoluteFilePath() );
+        myLogFileName = QDir::toNativeSeparators( QFileInfo( QFile::decodeName( optarg ) ).absoluteFilePath() );
         break;
 
       case 'w':
@@ -225,7 +225,7 @@ int main( int argc, char *argv[] )
         break;
 
       case 'p':
-        myProjectFileName = QDir::convertSeparators( QFileInfo( QFile::decodeName( optarg ) ).absoluteFilePath() );
+        myProjectFileName = QDir::toNativeSeparators( QFileInfo( QFile::decodeName( optarg ) ).absoluteFilePath() );
         break;
 
       case 'e':
@@ -278,7 +278,7 @@ int main( int argc, char *argv[] )
       int idx = optind;
       QgsDebugMsg( QString( "%1: %2" ).arg( idx ).arg( argv[idx] ) );
 #endif
-      myFileList.append( QDir::convertSeparators( QFileInfo( QFile::decodeName( argv[optind++] ) ).absoluteFilePath() ) );
+      myFileList.append( QDir::toNativeSeparators( QFileInfo( QFile::decodeName( argv[optind++] ) ).absoluteFilePath() ) );
     }
   }
 #else
@@ -297,11 +297,11 @@ int main( int argc, char *argv[] )
     }
     else if ( i + 1 < argc && ( arg == "--snapshot" || arg == "-s" ) )
     {
-      mySnapshotFileName = QDir::convertSeparators( QFileInfo( QFile::decodeName( argv[++i] ) ).absoluteFilePath() );
+      mySnapshotFileName = QDir::toNativeSeparators( QFileInfo( QFile::decodeName( argv[++i] ) ).absoluteFilePath() );
     }
     else if ( i + 1 < argc && ( arg == "--log" || arg == "-l" ) )
     {
-      myLogFileName = QDir::convertSeparators( QFileInfo( QFile::decodeName( argv[++i] ) ).absoluteFilePath() );
+      myLogFileName = QDir::toNativeSeparators( QFileInfo( QFile::decodeName( argv[++i] ) ).absoluteFilePath() );
     }
     else if ( i + 1 < argc && ( arg == "--width" || arg == "-w" ) )
     {
@@ -313,7 +313,7 @@ int main( int argc, char *argv[] )
     }
     else if ( i + 1 < argc && ( arg == "--project" || arg == "-p" ) )
     {
-      myProjectFileName = QDir::convertSeparators( QFileInfo( QFile::decodeName( argv[++i] ) ).absoluteFilePath() );
+      myProjectFileName = QDir::toNativeSeparators( QFileInfo( QFile::decodeName( argv[++i] ) ).absoluteFilePath() );
     }
     else if ( i + 1 < argc && ( arg == "--extent" || arg == "-e" ) )
     {
@@ -346,7 +346,7 @@ int main( int argc, char *argv[] )
     }
     else
     {
-      myFileList.append( QDir::convertSeparators( QFileInfo( QFile::decodeName( argv[i] ) ).absoluteFilePath() ) );
+      myFileList.append( QDir::toNativeSeparators( QFileInfo( QFile::decodeName( argv[i] ) ).absoluteFilePath() ) );
     }
   }
 #endif //WIN32
@@ -457,7 +457,7 @@ int main( int argc, char *argv[] )
     // check for a .qgs
     for ( int i = 0; i < argc; i++ )
     {
-      QString arg = QDir::convertSeparators( QFileInfo( QFile::decodeName( argv[i] ) ).absoluteFilePath() );
+      QString arg = QDir::toNativeSeparators( QFileInfo( QFile::decodeName( argv[i] ) ).absoluteFilePath() );
       if ( arg.contains( ".qgs" ) )
       {
         myProjectFileName = arg;

--- a/tests/src/providers/testqgswcspublicservers.cpp
+++ b/tests/src/providers/testqgswcspublicservers.cpp
@@ -982,7 +982,7 @@ int main( int argc, char *argv[] )
     return 1;
   }
 
-  QString myCacheDirPath = QDir::convertSeparators( QFileInfo( QFile::decodeName( argv[optind] ) ).absoluteFilePath() ) ;
+  QString myCacheDirPath = QDir::toNativeSeparators( QFileInfo( QFile::decodeName( argv[optind] ) ).absoluteFilePath() ) ;
 
   QgsDebugMsg( "myCacheDirPath = " + myCacheDirPath );
 


### PR DESCRIPTION
There are still a few leftovers from the Qt 3 to Qt 4 migration that can
be found by defining QT_NO_DEPRECATED. Here is a summary of the changes:
- QDir::convertSeparators was changed to QDir::toNativeSeparators with Qt 4
- QRexExp::numCaptures was changed to captureCount with Qt 4
- QTextIStream/QTextOStream was merged into QTextStream with Qt 4
- QFileDialog::selectFilter/filters was changed to
  selectNameFilter/nameFilters with Qt 4.4
- qVariantCanConvert/qVariantValue was changed to canConvert/value with Qt
  4

Note that if a conversion to Qt 5 will happen someday, this will have to
be done since Qt 5 removes these deprecations.
