### PR TITLE
Remove include of QtGui in favor of individual includes

### DIFF
--- a/src/app/composer/qgsatlascompositionwidget.cpp
+++ b/src/app/composer/qgsatlascompositionwidget.cpp
@@ -14,6 +14,8 @@
  *                                                                         *
  ***************************************************************************/
 
+#include <QMessageBox>
+
 #include "qgsatlascompositionwidget.h"
 #include "qgsatlascomposition.h"
 #include "qgscomposition.h"

--- a/src/app/composer/qgscomposer.cpp
+++ b/src/app/composer/qgscomposer.cpp
@@ -82,6 +82,7 @@
 #include <QPaintEngine>
 #include <QProgressBar>
 #include <QProgressDialog>
+#include <QShortcut>
 
 
 // sort function for QList<QAction*>, e.g. menu listings

--- a/src/app/composer/qgscomposer.h
+++ b/src/app/composer/qgscomposer.h
@@ -48,6 +48,8 @@ class QResizeEvent;
 class QFile;
 class QSizeGrip;
 class QUndoView;
+class QComboBox;
+class QLabel;
 
 /** \ingroup MapComposer
  * \brief A gui for composing a printable map.

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -14,7 +14,8 @@
  *                                                                         *
  ***************************************************************************/
 
-#include <QtGui>
+#include <QDockWidget>
+#include <QMessageBox>
 
 #include "qgsattributetabledialog.h"
 #include "qgsattributetablemodel.h"

--- a/src/app/qgsundowidget.h
+++ b/src/app/qgsundowidget.h
@@ -15,15 +15,15 @@
 #ifndef QGSUNDOWIDGET_H
 #define QGSUNDOWIDGET_H
 
-#include <QtCore/QVariant>
-#include <QtGui/QAction>
-#include <QtGui/QApplication>
-#include <QtGui/QButtonGroup>
-#include <QtGui/QDockWidget>
-#include <QtGui/QGridLayout>
-#include <QtGui/QPushButton>
-#include <QtGui/QSpacerItem>
-#include <QtGui/QWidget>
+#include <QVariant>
+#include <QAction>
+#include <QApplication>
+#include <QButtonGroup>
+#include <QDockWidget>
+#include <QGridLayout>
+#include <QPushButton>
+#include <QSpacerItem>
+#include <QWidget>
 #include <QUndoView>
 #include <QUndoStack>
 

--- a/src/core/composer/qgscomposereffect.h
+++ b/src/core/composer/qgscomposereffect.h
@@ -18,8 +18,8 @@
 #ifndef QGSCOMPOSEREFFECT_H
 #define QGSCOMPOSEREFFECT_H
 
-#include <QtGui>
 #include <QGraphicsEffect>
+#include <QPainter>
 
 class CORE_EXPORT QgsComposerEffect : public QGraphicsEffect
 {

--- a/src/core/composer/qgscomposerlabel.cpp
+++ b/src/core/composer/qgscomposerlabel.cpp
@@ -22,6 +22,8 @@
 #include <QDate>
 #include <QDomElement>
 #include <QPainter>
+#include <QSettings>
+#include <QTimer>
 #include <QWebFrame>
 #include <QWebPage>
 #include <QEventLoop>

--- a/src/core/composer/qgscomposerlegendstyle.cpp
+++ b/src/core/composer/qgscomposerlegendstyle.cpp
@@ -19,6 +19,7 @@
 #include "qgscomposition.h"
 #include <QFont>
 #include <QMap>
+#include <QSettings>
 #include <QString>
 #include <QDomElement>
 #include <QDomDocument>

--- a/src/core/composer/qgscomposermousehandles.cpp
+++ b/src/core/composer/qgscomposermousehandles.cpp
@@ -14,6 +14,8 @@
  *   (at your option) any later version.                                   *
  *                                                                         *
  ***************************************************************************/
+#include <QGraphicsView>
+#include <QGraphicsSceneHoverEvent>
 #include <QPainter>
 #include <QWidget>
 

--- a/src/core/composer/qgscomposertable.cpp
+++ b/src/core/composer/qgscomposertable.cpp
@@ -18,6 +18,7 @@
 #include "qgscomposertable.h"
 #include "qgslogger.h"
 #include <QPainter>
+#include <QSettings>
 
 QgsComposerTable::QgsComposerTable( QgsComposition* composition )
     : QgsComposerItem( composition )

--- a/src/core/composer/qgspaperitem.cpp
+++ b/src/core/composer/qgspaperitem.cpp
@@ -20,6 +20,7 @@
 #include "qgsstylev2.h"
 #include "qgslogger.h"
 #include <QGraphicsRectItem>
+#include <QGraphicsView>
 #include <QPainter>
 
 //QgsPaperGrid

--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -27,7 +27,6 @@
 #include "qgsexpression.h"
 #include "qgsmaplayeractionregistry.h"
 
-#include <QtGui>
 #include <QVariant>
 
 #include <limits>

--- a/src/gui/qgscomposerview.cpp
+++ b/src/gui/qgscomposerview.cpp
@@ -22,6 +22,8 @@
 #include <QClipboard>
 #include <QMimeData>
 #include <QGridLayout>
+#include <QScrollBar>
+#include <QDesktopWidget>
 
 #include "qgsapplication.h"
 #include "qgscomposerview.h"

--- a/src/gui/symbology-ng/characterwidget.cpp
+++ b/src/gui/symbology-ng/characterwidget.cpp
@@ -43,7 +43,13 @@
 **
 ****************************************************************************/
 
-#include <QtGui>
+#include <QFontDatabase>
+#include <QMouseEvent>
+#include <QPaintEvent>
+#include <QPainter>
+#include <QPen>
+#include <QPoint>
+#include <QToolTip>
 
 #include "characterwidget.h"
 


### PR DESCRIPTION
The reason for removing instances of "#include <QtGui>" is twofold:

1) Including it will probably include more than is actually needed. Plus,
   it hide what is actually needed, especially if in a header

2) Qt 5 splits Gui into Gui and Widgets, so being explict about what is
   needed gets around this problem
