### PR TITLE
Atlas signals

### DIFF
--- a/python/core/composer/qgsatlascomposition.sip
+++ b/python/core/composer/qgsatlascomposition.sip
@@ -122,4 +122,9 @@ public:
     /**Is emitted when the coverage layer for an atlas changes*/
     void coverageLayerChanged( QgsVectorLayer* layer );
 
+    /**Is emitted when atlas rendering has begun*/
+    void renderBegun();
+
+    /**Is emitted when atlas rendering has ended*/
+    void renderEnded();
 };

--- a/python/core/composer/qgscomposermap.sip
+++ b/python/core/composer/qgscomposermap.sip
@@ -407,6 +407,9 @@ class QgsComposerMap : QgsComposerItem
     /**Is emitted on rotation change to notify north arrow pictures*/
     void mapRotationChanged( double newRotation );
 
+    /**Is emitted when the map has been prepared for atlas rendering, just before actual rendering*/
+    void preparedForAtlas();
+
   public slots:
 
     /**Called if map canvas has changed*/

--- a/src/core/composer/qgsatlascomposition.cpp
+++ b/src/core/composer/qgsatlascomposition.cpp
@@ -266,6 +266,8 @@ bool QgsAtlasComposition::beginRender()
     return false;
   }
 
+  emit renderBegun();
+
   bool featuresUpdated = updateFeatures();
   if ( !featuresUpdated )
   {
@@ -296,6 +298,8 @@ void QgsAtlasComposition::endRender()
   }
 
   updateAtlasMaps();
+
+  emit renderEnded();
 }
 
 void QgsAtlasComposition::updateAtlasMaps()

--- a/src/core/composer/qgsatlascomposition.h
+++ b/src/core/composer/qgsatlascomposition.h
@@ -150,6 +150,12 @@ class CORE_EXPORT QgsAtlasComposition : public QObject
     /**Is emitted when the coverage layer for an atlas changes*/
     void coverageLayerChanged( QgsVectorLayer* layer );
 
+    /**Is emitted when atlas rendering has begun*/
+    void renderBegun();
+
+    /**Is emitted when atlas rendering has ended*/
+    void renderEnded();
+
   private:
     /**Updates the filename expression*/
     void updateFilenameExpression();

--- a/src/core/composer/qgscomposermap.cpp
+++ b/src/core/composer/qgscomposermap.cpp
@@ -641,6 +641,7 @@ void QgsComposerMap::setNewAtlasFeatureExtent( const QgsRectangle& extent )
 
   mAtlasFeatureExtent = newExtent;
   mCacheUpdated = false;
+  emit preparedForAtlas();
   updateItem();
   emit itemChanged();
   emit extentChanged();

--- a/src/core/composer/qgscomposermap.h
+++ b/src/core/composer/qgscomposermap.h
@@ -445,6 +445,9 @@ class CORE_EXPORT QgsComposerMap : public QgsComposerItem
     /**Is emitted on rotation change to notify north arrow pictures*/
     void mapRotationChanged( double newRotation );
 
+    /**Is emitted when the map has been prepared for atlas rendering, just before actual rendering*/
+    void preparedForAtlas();
+
   public slots:
 
     /**Called if map canvas has changed*/

--- a/src/core/composer/qgscomposition.cpp
+++ b/src/core/composer/qgscomposition.cpp
@@ -2537,6 +2537,7 @@ bool QgsComposition::setAtlasMode( QgsComposition::AtlasMode mode )
     if ( ! atlasHasFeatures )
     {
       mAtlasMode = QgsComposition::AtlasOff;
+      mAtlasComposition.endRender();
       return false;
     }
   }


### PR DESCRIPTION
Adds signals emitted when atlas rendering starts / ends and when composer maps are prepared for atlas rendering.
Includes SIP binding and unit tests
