### PR TITLE
Snapping priority

### DIFF
--- a/src/app/qgsmaptoolcapture.cpp
+++ b/src/app/qgsmaptoolcapture.cpp
@@ -110,15 +110,12 @@ void QgsMapToolCapture::canvasMoveEvent( QMouseEvent * e )
     while ( !mSnappingMarkers.isEmpty() )
       delete mSnappingMarkers.takeFirst();
 
-    foreach ( const QgsSnappingResult &r, snapResults )
-    {
-      QgsVertexMarker *m = new QgsVertexMarker( mCanvas );
-      m->setIconType( QgsVertexMarker::ICON_CROSS );
-      m->setColor( Qt::magenta );
-      m->setPenWidth( 3 );
-      m->setCenter( r.snappedVertex );
-      mSnappingMarkers << m;
-    }
+    QgsVertexMarker *m = new QgsVertexMarker( mCanvas );
+    m->setIconType( QgsVertexMarker::ICON_CROSS );
+    m->setColor( Qt::magenta );
+    m->setPenWidth( 3 );
+    m->setCenter( snapPointFromResults(snapResults,e->pos()) );
+    mSnappingMarkers << m;
 
     if ( mCaptureMode != CapturePoint && mTempRubberBand && mCapturing )
     {

--- a/src/app/qgsmaptoolcapture.cpp
+++ b/src/app/qgsmaptoolcapture.cpp
@@ -114,8 +114,6 @@ void QgsMapToolCapture::canvasMoveEvent( QMouseEvent * e )
     mSnappingMarker->setColor( Qt::magenta );
     mSnappingMarker->setPenWidth( 3 );
     mSnappingMarker->setCenter( snapPointFromResults(snapResults,e->pos()) );
-
-
     if ( mCaptureMode != CapturePoint && mTempRubberBand && mCapturing )
     {
       mapPoint = snapPointFromResults( snapResults, e->pos() );

--- a/src/app/qgsmaptooledit.cpp
+++ b/src/app/qgsmaptooledit.cpp
@@ -64,7 +64,19 @@ QgsPoint QgsMapToolEdit::snapPointFromResults( const QList<QgsSnappingResult>& s
   }
   else
   {
-    return snapResults.constBegin()->snappedVertex;
+    QList<QgsSnappingResult>::const_iterator it = snapResults.constBegin();
+    QgsPoint snapPoint = it->snappedVertex;
+    while ( it != snapResults.constEnd() )
+    {
+      if( it->layer->geometryType()==QGis::Point )
+      {
+        snapPoint = it->snappedVertex;
+        break;
+      }
+      it++;
+    }
+
+    return snapPoint;
   }
 }
 

--- a/src/app/qgsmaptooledit.cpp
+++ b/src/app/qgsmaptooledit.cpp
@@ -63,7 +63,19 @@ QgsPoint QgsMapToolEdit::snapPointFromResults( const QList<QgsSnappingResult>& s
   }
   else
   {
-    return snapResults.constBegin()->snappedVertex;
+    QList<QgsSnappingResult>::const_iterator it = snapResults.constBegin();
+    QgsPoint snapPoint = it->snappedVertex;
+    while ( it != snapResults.constEnd() )
+    {
+      if( it->layer->geometryType()==QGis::Point )
+      {
+        snapPoint = it->snappedVertex;
+        break;
+      }
+      it++;
+    }
+
+    return snapPoint;
   }
 }
 

--- a/src/app/qgsmaptooledit.h
+++ b/src/app/qgsmaptooledit.h
@@ -45,7 +45,8 @@ class APP_EXPORT QgsMapToolEdit: public QgsMapTool
 
     /**Extracts a single snapping point from a set of snapping results.
        This is useful for snapping operations that just require a position to snap to and not all the
-       snapping results. If the list is empty, the screen coordinates are transformed into map coordinates and returned
+       snapping results. If the list is empty, the screen coordinates are transformed into map coordinates and returned.
+       Point layers are chosen in priority over other layers, to allow to snap on a point located on a line or polygon boundary
        @param snapResults results collected from the snapping operation.
        @return the snapped point in map coordinates*/
     QgsPoint snapPointFromResults( const QList<QgsSnappingResult>& snapResults, const QPoint& screenCoords );

--- a/src/app/qgsmaptoolmeasureangle.cpp
+++ b/src/app/qgsmaptoolmeasureangle.cpp
@@ -21,6 +21,7 @@
 #include "qgsmaptopixel.h"
 #include "qgsproject.h"
 #include "qgsrubberband.h"
+#include "qgsvectorlayer.h"
 #include <QMouseEvent>
 #include <QSettings>
 #include <cmath>
@@ -145,7 +146,18 @@ QgsPoint QgsMapToolMeasureAngle::snapPoint( const QPoint& p )
   }
   else
   {
-    return snappingResults.constBegin()->snappedVertex;
+    QList<QgsSnappingResult>::const_iterator it = snappingResults.constBegin();
+    QgsPoint snapPoint = it->snappedVertex;
+    while ( it != snappingResults.constEnd() )
+    {
+      if( it->layer->geometryType() == QGis::Point )
+      {
+        snapPoint = it->snappedVertex;
+        break;
+      }
+      it++;
+    }
+    return snapPoint;
   }
 }
 

--- a/src/app/qgsmaptooloffsetcurve.cpp
+++ b/src/app/qgsmaptooloffsetcurve.cpp
@@ -201,32 +201,33 @@ void QgsMapToolOffsetCurve::canvasMoveEvent( QMouseEvent * e )
 
   //snap cursor to background layers
   QList<QgsSnappingResult> results;
-  QList<QgsPoint> snapExcludePoints;
   if ( mSnapper.snapToBackgroundLayers( e->pos(), results ) == 0 )
   {
     if ( results.size() > 0 )
     {
-      QgsSnappingResult snap = results.at( 0 );
-      if ( snap.layer && snap.layer->id() != mSourceLayerId && snap.snappedAtGeometry != mModifiedFeature )
+      for( int i = 0 ; i < results.size(); ++i )
       {
-        layerCoords = results.at( 0 ).snappedVertex;
-        mSnapVertexMarker = new QgsVertexMarker( mCanvas );
-        mSnapVertexMarker->setIconType( QgsVertexMarker::ICON_CROSS );
-        mSnapVertexMarker->setColor( Qt::green );
-        mSnapVertexMarker->setPenWidth( 1 );
-        mSnapVertexMarker->setCenter( layerCoords );
+        if ( results[i].snappedAtGeometry != mModifiedFeature )
+        {
+          layerCoords = results[i].snappedVertex;
+          if ( results[i].layer->geometryType() == QGis::Point )
+          {
+            break;
+          }
+        }
       }
+      mSnapVertexMarker = new QgsVertexMarker( mCanvas );
+      mSnapVertexMarker->setIconType( QgsVertexMarker::ICON_CROSS );
+      mSnapVertexMarker->setColor( Qt::green );
+      mSnapVertexMarker->setPenWidth( 1 );
+      mSnapVertexMarker->setCenter( layerCoords );
     }
   }
-
+  QgsDebugMsg(QString("%1,%2").arg(layerCoords.x()).arg(layerCoords.y()));
   QgsPoint minDistPoint;
   int beforeVertex;
   double leftOf;
   double offset = sqrt( mOriginalGeometry->closestSegmentWithContext( layerCoords, minDistPoint, beforeVertex, &leftOf ) );
-  if ( offset == 0.0 )
-  {
-    return;
-  }
 
   //create offset geometry using geos
   setOffsetForRubberBand( offset, leftOf < 0 );

--- a/src/app/qgsmeasuretool.cpp
+++ b/src/app/qgsmeasuretool.cpp
@@ -214,6 +214,17 @@ QgsPoint QgsMeasureTool::snapPoint( const QPoint& p )
   }
   else
   {
-    return snappingResults.constBegin()->snappedVertex;
+    QList<QgsSnappingResult>::const_iterator it = snappingResults.constBegin();
+    QgsPoint snapPoint = it->snappedVertex;
+    while ( it != snappingResults.constEnd() )
+    {
+      if( it->layer->geometryType() == QGis::Point )
+      {
+        snapPoint = it->snappedVertex;
+        break;
+      }
+      it++;
+    }
+    return snapPoint;
   }
 }

--- a/src/gui/qgsmapcanvassnapper.cpp
+++ b/src/gui/qgsmapcanvassnapper.cpp
@@ -127,21 +127,8 @@ int QgsMapCanvasSnapper::snapToBackgroundLayers( const QPoint& p, QList<QgsSnapp
   //snapping on intersection on?
   int intersectionSnapping = QgsProject::instance()->readNumEntry( "Digitizing", "/IntersectionSnapping", 0 );
 
-  if ( topologicalEditing == 0 )
-  {
-    if ( intersectionSnapping == 0 )
-      mSnapper->setSnapMode( QgsSnapper::SnapWithOneResult );
-    else
-      mSnapper->setSnapMode( QgsSnapper::SnapWithResultsWithinTolerances );
-  }
-  else if ( intersectionSnapping == 0 )
-  {
-    mSnapper->setSnapMode( QgsSnapper::SnapWithResultsForSamePosition );
-  }
-  else
-  {
-    mSnapper->setSnapMode( QgsSnapper::SnapWithResultsWithinTolerances );
-  }
+  mSnapper->setSnapMode( QgsSnapper::SnapWithResultsWithinTolerances );
+
 
   //read snapping settings from project
   bool snappingDefinedInProject, ok;

--- a/src/gui/qgsmapcanvassnapper.cpp
+++ b/src/gui/qgsmapcanvassnapper.cpp
@@ -131,21 +131,8 @@ int QgsMapCanvasSnapper::snapToBackgroundLayers( const QPoint& p, QList<QgsSnapp
   //snapping on intersection on?
   int intersectionSnapping = QgsProject::instance()->readNumEntry( "Digitizing", "/IntersectionSnapping", 0 );
 
-  if ( topologicalEditing == 0 )
-  {
-    if ( intersectionSnapping == 0 )
-      mSnapper->setSnapMode( QgsSnapper::SnapWithOneResult );
-    else
-      mSnapper->setSnapMode( QgsSnapper::SnapWithResultsWithinTolerances );
-  }
-  else if ( intersectionSnapping == 0 )
-  {
-    mSnapper->setSnapMode( QgsSnapper::SnapWithResultsForSamePosition );
-  }
-  else
-  {
-    mSnapper->setSnapMode( QgsSnapper::SnapWithResultsWithinTolerances );
-  }
+  mSnapper->setSnapMode( QgsSnapper::SnapWithResultsWithinTolerances );
+
 
   //read snapping settings from project
   bool snappingDefinedInProject, ok;

--- a/src/gui/qgsmapcanvassnapper.h
+++ b/src/gui/qgsmapcanvassnapper.h
@@ -54,8 +54,8 @@ class GUI_EXPORT QgsMapCanvasSnapper
     int snapToCurrentLayer( const QPoint& p, QList<QgsSnappingResult>& results, QgsSnapper::SnappingType snap_to, double snappingTol = -1, const QList<QgsPoint>& excludePoints = QList<QgsPoint>() );
     /**Snaps to the background layers. This method is useful to align the features of the
        edited layers to those of other layers (as described in the project properties).
-       Uses snap mode QgsSnapper::SnapWithOneResult. Therefore, only the
-       closest result is returned.
+       Uses snap mode QgsSnapper::SnapWithResultsWithinTolerances.
+       Therefore, all possible snapping results are returned.
        @param p start point of the snap (in pixel coordinates)
        @param results snapped points
        @param excludePoints a list with (map coordinate) points that should be excluded in the snapping result. Useful e.g. for vertex moves where a vertex should not be snapped to its original position


### PR DESCRIPTION
This pull request aims to solve http://hub.qgis.org/issues/7058 , which was also mentioned as a problem by Olivier Dalang for CADInput (at the end of https://github.com/olivierdalang/CadInput). The problem is that when a point is on a line, with snapping to segment and vertex, there is currently no way to snap exactly on the point as all the segment is potential snapping position. 

The idea is to have snapToBackgroundLayers always return all the potential candidates (I did not understand why the use of QgsSnapper::SnapWithResultsWithinTolerances depended on intersection snapping or topological editing, please tell me if I missed something vital !). Then snapPointFromResults prioritizes a point layer if there is one in the list of results, instead of simply returning the first result as previously.

I had to implement the same logic for the measurement tools, which cannot use snapPointFromResults as they do not inherit QgsMapToolEdit but its base classe QgsMapTool. I think it would make sense to move snapPointFromResults to QgsMapTool.

QgsMaptoolOffsetCurve is a special case as the initial feature should not be snapped, so it has to decide itself which snapping result is needed. I tried to use excludePoints to avoid the initial features, but segments could also be snapped and there is no way to exclude segments of the snapping.

Additionally, I managed to somewhat mess up my git history, I hope the pull request is OK anyway. Otherwise, I will make a clean one.
