### PR TITLE
Snapping priority to vertex in QgsSnapper

### DIFF
--- a/src/core/qgssnapper.cpp
+++ b/src/core/qgssnapper.cpp
@@ -59,6 +59,7 @@ int QgsSnapper::snapPoint( const QPoint& startPoint, QList<QgsSnappingResult>& s
     if ( !snapLayerIt->mLayer->hasGeometryType() )
       continue;
 
+    currentResultList.clear();
     //transform point from map coordinates to layer coordinates
     layerCoordPoint = mMapSettings.mapToLayerCoordinates( snapLayerIt->mLayer, mapCoordPoint );
 
@@ -93,31 +94,44 @@ int QgsSnapper::snapPoint( const QPoint& startPoint, QList<QgsSnappingResult>& s
     return 0;
   }
 
+
+  //Gives a priority to vertex snapping over segment snapping
+  QgsSnappingResult returnResult = evalIt.value();
+  for ( evalIt = snappingResultList.begin(); evalIt != snappingResultList.end(); ++evalIt )
+  {
+    if( evalIt.value().snappedVertexNr != -1 )
+    {
+      returnResult = evalIt.value();
+      snappingResultList.erase( evalIt );
+      break;
+    }
+  }
+
+  //We return the preferred result
+  snappingResult.push_back( returnResult );
+
   if ( mSnapMode == QgsSnapper::SnapWithOneResult )
   {
-    //return only closest result
-    snappingResult.push_back( evalIt.value() );
+    //return only a single  result, nothing more to do
   }
   else if ( mSnapMode == QgsSnapper::SnapWithResultsForSamePosition )
   {
-    //take all snapping Results within a certain tolerance because rounding differences may occur
+    //take all snapping results within a certain tolerance because rounding differences may occur
     double tolerance = 0.000001;
-    double minDistance = evalIt.key();
 
     for ( evalIt = snappingResultList.begin(); evalIt != snappingResultList.end(); ++evalIt )
     {
-      if ( evalIt.key() > ( minDistance + tolerance ) )
+      if ( returnResult.snappedVertex.sqrDist( evalIt.value().snappedVertex ) < tolerance*tolerance )
       {
-        break;
+        snappingResult.push_back( evalIt.value() );
       }
-      snappingResult.push_back( evalIt.value() );
     }
 
   }
 
   else //take all results
   {
-    for ( ; evalIt != snappingResultList.end(); ++evalIt )
+    for ( evalIt = snappingResultList.begin(); evalIt != snappingResultList.end(); ++evalIt )
     {
       snappingResult.push_back( evalIt.value() );
     }


### PR DESCRIPTION
Following the discussion in #1257, I modify QgsSnapper to give priority to vertex snapping above segment snapping. Instead of taking the closest snapping result, it tries first to take the closest vertex snapped. Only if no vertex has been snapped a segment can be chosen. This aims to solve http://hub.qgis.org/issues/7058 .
