### PR TITLE
[FEATURE] new edit type: date/time edit

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -265,6 +265,7 @@
 // Editor widgets
 #include "qgseditorwidgetregistry.h"
 #include "qgsrelationreferencefactory.h"
+#include "qgsdatetimeeditfactory.h"
 
 //
 // Conditional Includes
@@ -597,6 +598,7 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, QWidget * parent, 
   QgsAttributeEditorContext context;
   context.setVectorLayerTools( vectorLayerTools() );
   editorWidgetRegistry->registerWidget( "RelationReference", new QgsRelationReferenceFactory( context, tr( "Relation Reference" ) ) );
+  editorWidgetRegistry->registerWidget( "DateTimeEdit", new QgsDateTimeEditFactory( tr( "Date/Time" ) ) );
 
 
   mInternalClipboard = new QgsClipboard; // create clipboard

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -54,9 +54,14 @@ editorwidgets/core/qgseditorconfigwidget.cpp
 editorwidgets/core/qgseditorwidgetfactory.cpp
 editorwidgets/core/qgseditorwidgetregistry.cpp
 editorwidgets/core/qgseditorwidgetwrapper.cpp
+
+editorwidgets/qgsdatetimeeditfactory.cpp
+editorwidgets/qgsdatetimeeditconfig.cpp
+editorwidgets/qgsdatetimeeditwrapper.cpp
 editorwidgets/qgsrelationreferencewidget.cpp
 editorwidgets/qgsrelationreferencefactory.cpp
 editorwidgets/qgsrelreferenceconfigdlg.cpp
+
 
 qgisgui.cpp
 qgisinterface.cpp
@@ -201,6 +206,9 @@ attributetable/qgsvectorlayerselectionmanager.h
 editorwidgets/core/qgseditorconfigwidget.h
 editorwidgets/core/qgseditorwidgetregistry.h
 editorwidgets/core/qgseditorwidgetwrapper.h
+
+editorwidgets/qgsdatetimeeditconfig.h
+editorwidgets/qgsdatetimeeditwrapper.h
 editorwidgets/qgsrelationreferencewidget.h
 editorwidgets/qgsrelreferenceconfigdlg.h
 
@@ -346,6 +354,10 @@ editorwidgets/core/qgseditorconfigwidget.h
 editorwidgets/core/qgseditorwidgetfactory.h
 editorwidgets/core/qgseditorwidgetregistry.h
 editorwidgets/core/qgseditorwidgetwrapper.h
+
+editorwidgets/qgsdatetimeeditfactory.h
+editorwidgets/qgsdatetimeeditconfig.h
+editorwidgets/qgsdatetimeeditwrapper.h
 editorwidgets/qgsrelationreferencefactory.h
 editorwidgets/qgsrelationreferencewidget.h
 editorwidgets/qgsrelreferenceconfigdlg.h

--- a/src/gui/editorwidgets/qgsdatetimeeditconfig.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeeditconfig.cpp
@@ -1,0 +1,97 @@
+/***************************************************************************
+    qgsdatetimeeditconfig.cpp
+     --------------------------------------
+    Date                 : 03.2014
+    Copyright            : (C) 2014 Denis Rouzaud
+    Email                : denis.rouzaud@gmail.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsdatetimeeditconfig.h"
+#include "qgsdatetimeeditfactory.h"
+
+QgsDateTimeEditConfig::QgsDateTimeEditConfig( QgsVectorLayer* vl, int fieldIdx, QWidget* parent )
+    : QgsEditorConfigWidget( vl, fieldIdx, parent )
+{
+  setupUi( this );
+
+  mDemoDateTimeEdit->setDateTime( QDateTime::currentDateTime() );
+
+  connect( mDateTimeRadio, SIGNAL( toggled( bool ) ), this, SLOT( updateDemoWidget() ) );
+  connect( mDateRadio, SIGNAL( toggled( bool ) ), this, SLOT( updateDemoWidget() ) );
+  connect( mTimeRadio, SIGNAL( toggled( bool ) ), this, SLOT( updateDemoWidget() ) );
+  connect( mCustomRadio, SIGNAL( toggled( bool ) ), this, SLOT( updateDemoWidget() ) );
+  connect( mFormatEdit, SIGNAL( textChanged( QString ) ), this, SLOT( updateDemoWidget() ) );
+  connect( mCalendarPopupCheckBox, SIGNAL( toggled( bool ) ), this, SLOT( updateDemoWidget() ) );
+}
+
+void QgsDateTimeEditConfig::updateDemoWidget()
+{
+  if ( mDateTimeRadio->isChecked() )
+  {
+    mDemoDateTimeEdit->setDisplayFormat( "yyyy-MM-dd HH:mm:ss" );
+  }
+  else if ( mTimeRadio->isChecked() )
+  {
+    mDemoDateTimeEdit->setDisplayFormat( "HH:mm:ss" );
+  }
+  else if ( mDateRadio->isChecked() )
+  {
+    mDemoDateTimeEdit->setDisplayFormat( "yyyy-MM-dd" );
+  }
+  else if ( mCustomRadio->isChecked() )
+  {
+    mDemoDateTimeEdit->setDisplayFormat( mFormatEdit->text() );
+  }
+
+  mDemoDateTimeEdit->setCalendarPopup( mCalendarPopupCheckBox->isChecked() );
+}
+
+
+QgsEditorWidgetConfig QgsDateTimeEditConfig::config()
+{
+  QgsEditorWidgetConfig myConfig;
+
+  QString type = "datetime";
+  if ( mDateRadio->isChecked() )
+    type = "date";
+  else if ( mTimeRadio->isChecked() )
+    type = "time";
+  myConfig.insert( "type", type );
+
+  myConfig.insert( "format", mFormatEdit->text() );
+  myConfig.insert( "calendar_popup", mCalendarPopupCheckBox->isChecked() );
+
+  return myConfig;
+}
+
+void QgsDateTimeEditConfig::setConfig( const QgsEditorWidgetConfig &config )
+{
+  if ( config.contains( "type" ) )
+  {
+    QString type = config[ "type" ].toString();
+    if ( type == "datetime" )
+      mDateTimeRadio->setChecked( true );
+    else if ( type == "time" )
+      mTimeRadio->setChecked( true );
+    else if ( type == "date" )
+      mDateRadio->setChecked( true );
+  }
+
+  if ( config.contains( "format" ) )
+  {
+    mFormatEdit->setText( config[ "format" ].toString() );
+  }
+
+  if ( config.contains( "calendar_popup" ) )
+  {
+    mCalendarPopupCheckBox->setChecked( config[ "calendar_popup" ].toBool() );
+  }
+
+}

--- a/src/gui/editorwidgets/qgsdatetimeeditconfig.h
+++ b/src/gui/editorwidgets/qgsdatetimeeditconfig.h
@@ -1,0 +1,40 @@
+/***************************************************************************
+    qgsdatetimeeditconfig.h
+     --------------------------------------
+    Date                 : 03.2014
+    Copyright            : (C) 2014 Denis Rouzaud
+    Email                : denis.rouzaud@gmail.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSDATETIMEEDITCONFIG_H
+#define QGSDATETIMEEDITCONFIG_H
+
+#include "qgseditorconfigwidget.h"
+#include "ui_qgsdatetimeeditconfig.h"
+
+class GUI_EXPORT QgsDateTimeEditConfig : public QgsEditorConfigWidget, private Ui::QgsDateTimeEditConfig
+{
+    Q_OBJECT
+  public:
+    QgsDateTimeEditConfig( QgsVectorLayer* vl, int fieldIdx, QWidget* parent = 0 );
+
+  signals:
+
+  private slots:
+    void updateDemoWidget();
+
+
+    // QgsEditorConfigWidget interface
+  public:
+    QgsEditorWidgetConfig config();
+    void setConfig( const QgsEditorWidgetConfig &config );
+};
+
+#endif // QGSDATETIMEEDITCONFIG_H

--- a/src/gui/editorwidgets/qgsdatetimeeditfactory.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeeditfactory.cpp
@@ -1,0 +1,59 @@
+/***************************************************************************
+    qgsdatetimeeditfactory.cpp
+     --------------------------------------
+    Date                 : 03.2014
+    Copyright            : (C) 2014 Denis Rouzaud
+    Email                : denis.rouzaud@gmail.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsdatetimeeditfactory.h"
+#include "qgsdatetimeeditconfig.h"
+#include "qgsdatetimeeditwrapper.h"
+
+QgsDateTimeEditFactory::QgsDateTimeEditFactory( QString name ) :
+    QgsEditorWidgetFactory( name )
+{
+}
+
+
+QgsEditorWidgetWrapper *QgsDateTimeEditFactory::create( QgsVectorLayer *vl, int fieldIdx, QWidget *editor, QWidget *parent ) const
+{
+  return new QgsDateTimeEditWrapper( vl, fieldIdx, editor, parent );
+}
+
+QgsEditorConfigWidget *QgsDateTimeEditFactory::configWidget( QgsVectorLayer *vl, int fieldIdx, QWidget *parent ) const
+{
+  return new QgsDateTimeEditConfig( vl, fieldIdx, parent );
+}
+
+QgsEditorWidgetConfig QgsDateTimeEditFactory::readConfig( const QDomElement &configElement, QgsVectorLayer *layer, int fieldIdx )
+{
+  Q_UNUSED( layer );
+  Q_UNUSED( fieldIdx );
+  QMap<QString, QVariant> cfg;
+
+  cfg.insert( "type", configElement.attribute( "type" ) );
+  cfg.insert( "format", configElement.attribute( "format" ) );
+  cfg.insert( "calendar_popup", configElement.attribute( "calendar_popup" ) == "1" );
+
+  return cfg;
+}
+
+void QgsDateTimeEditFactory::writeConfig( const QgsEditorWidgetConfig &config, QDomElement &configElement, const QDomDocument &doc, const QgsVectorLayer *layer, int fieldIdx )
+{
+  Q_UNUSED( doc );
+  Q_UNUSED( layer );
+  Q_UNUSED( fieldIdx );
+
+  configElement.setAttribute( "type", config["type"].toString() );
+  configElement.setAttribute( "display_format", config["display_format"].toString() );
+  configElement.setAttribute( "format", config["format"].toString() );
+  configElement.setAttribute( "calendar_popup", config["calendar_popup"].toBool() );
+}

--- a/src/gui/editorwidgets/qgsdatetimeeditfactory.h
+++ b/src/gui/editorwidgets/qgsdatetimeeditfactory.h
@@ -1,0 +1,34 @@
+/***************************************************************************
+    qgsdatetimeeditfactory.h
+     --------------------------------------
+    Date                 : 03.2014
+    Copyright            : (C) 2014 Denis Rouzaud
+    Email                : denis.rouzaud@gmail.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSDATETIMEEDITFACTORY_H
+#define QGSDATETIMEEDITFACTORY_H
+
+#include "qgseditorwidgetfactory.h"
+
+class GUI_EXPORT QgsDateTimeEditFactory : public QgsEditorWidgetFactory
+{
+  public:
+    QgsDateTimeEditFactory( QString name );
+
+    // QgsEditorWidgetFactory interface
+  public:
+    QgsEditorWidgetWrapper *create( QgsVectorLayer *vl, int fieldIdx, QWidget *editor, QWidget *parent ) const;
+    QgsEditorConfigWidget *configWidget( QgsVectorLayer *vl, int fieldIdx, QWidget *parent ) const;
+    QgsEditorWidgetConfig readConfig( const QDomElement &configElement, QgsVectorLayer *layer, int fieldIdx );
+    void writeConfig( const QgsEditorWidgetConfig &config, QDomElement &configElement, const QDomDocument &doc, const QgsVectorLayer *layer, int fieldIdx );
+};
+
+#endif // QGSDATETIMEEDITFACTORY_H

--- a/src/gui/editorwidgets/qgsdatetimeeditwrapper.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeeditwrapper.cpp
@@ -1,0 +1,135 @@
+/***************************************************************************
+    qgsdatetimeeditwrapper.cpp
+     --------------------------------------
+    Date                 : 03.2014
+    Copyright            : (C) 2014 Denis Rouzaud
+    Email                : denis.rouzaud@gmail.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include <QDateTimeEdit>
+#include <QDateEdit>
+#include <QTimeEdit>
+
+#include "qgsdatetimeeditwrapper.h"
+#include "qgsdatetimeeditfactory.h"
+#include "qgsmessagelog.h"
+#include "qgslogger.h"
+
+
+QgsDateTimeEditWrapper::QgsDateTimeEditWrapper( QgsVectorLayer* vl, int fieldIdx, QWidget* editor, QWidget* parent )
+    : QgsEditorWidgetWrapper( vl, fieldIdx, editor, parent )
+    , mDateTimeWidget( NULL )
+    , mType( "date" )
+{
+}
+
+QWidget *QgsDateTimeEditWrapper::createWidget( QWidget *parent )
+{
+  return new QDateTimeEdit( parent );
+}
+
+void QgsDateTimeEditWrapper::initWidget( QWidget *editor )
+{
+  mType = config( "type", "datetime" ).toString();
+
+  QDateTimeEdit* w = dynamic_cast<QDateTimeEdit*>( editor );
+  if ( !w )
+  {
+    QgsDebugMsg( "Date/time edit widget could not be initialized because provided widget is not a QDateTimeEdit." );
+    QgsMessageLog::logMessage( "Date/time edit widget could not be initialized because provided widget is not a QDateTimeEdit." , "UI forms", QgsMessageLog::WARNING );
+    return;
+  }
+  mDateTimeWidget = w;
+
+  if ( mType ==  "datetime" )
+  {
+    mDateTimeWidget->setDisplayFormat( "yyyy-MM-dd HH:mm:ss" );
+  }
+  else if ( mType ==  "time" )
+  {
+    mDateTimeWidget->setDisplayFormat( "HH:mm:ss" );
+  }
+  else if ( mType ==  "date" )
+  {
+    mDateTimeWidget->setDisplayFormat( "yyyy-MM-dd" );
+  }
+  else if ( mType == "custom" )
+  {
+    QString format = config( "format", "yyyy-MM-dd HH:mm" ).toString();
+    mDateTimeWidget->setDisplayFormat( format );
+  }
+
+  if ( mType != "time" )
+  {
+    mDateTimeWidget->setCalendarPopup( config( "calendar_popup", "0" ) == 1 );
+  }
+}
+
+QVariant QgsDateTimeEditWrapper::value()
+{
+  if ( !mDateTimeWidget )
+    return QVariant();
+
+  if ( mType ==  "datetime" )
+  {
+    return mDateTimeWidget->dateTime().toString( "yyyy-MM-dd HH:mm:ss" );
+  }
+  else if ( mType ==  "time" )
+  {
+    return mDateTimeWidget->time().toString( "HH:mm:ss" );
+  }
+  else if ( mType ==  "date" )
+  {
+
+    return mDateTimeWidget->date().toString( "yyyy-MM-dd" );
+  }
+  else if ( mType == "custom" )
+  {
+    QString format = config( "format", "yyyy-MM-dd HH:mm:ss" ).toString();
+    return mDateTimeWidget->date().toString( format );
+  }
+}
+
+
+void QgsDateTimeEditWrapper::setValue( const QVariant &value )
+{
+  if ( !mDateTimeWidget )
+    return;
+
+  if ( mType == "datetime" )
+  {
+    mDateTimeWidget->setDateTime( QDateTime::fromString( value.toString(), "yyyy-MM-dd HH:mm:ss" ) );
+  }
+  else if ( mType ==  "time" )
+  {
+    mDateTimeWidget->setTime( value.toTime() );
+  }
+  else if ( mType == "date" )
+  {
+    mDateTimeWidget->setDate( value.toDate() );
+  }
+  else if ( mType == "custom" )
+  {
+    QString format = config( "format", "yyyy-MM-dd HH:mm" ).toString();
+    mDateTimeWidget->setDateTime( QDateTime::fromString( value.toString(), format ) );
+  }
+  else
+    return;
+
+}
+
+void QgsDateTimeEditWrapper::setEnabled( bool enabled )
+{
+  if ( !mDateTimeWidget )
+    return;
+
+  mDateTimeWidget->setEnabled( enabled );
+}

--- a/src/gui/editorwidgets/qgsdatetimeeditwrapper.h
+++ b/src/gui/editorwidgets/qgsdatetimeeditwrapper.h
@@ -1,0 +1,47 @@
+/***************************************************************************
+    qgsdatetimeeditwrapper.h
+     --------------------------------------
+    Date                 : 03.2014
+    Copyright            : (C) 2014 Denis Rouzaud
+    Email                : denis.rouzaud@gmail.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSDATETIMEEDITWRAPPER_H
+#define QGSDATETIMEEDITWRAPPER_H
+
+#include <QDateTimeEdit>
+
+#include "qgseditorwidgetwrapper.h"
+#include "qgsdatetimeeditfactory.h"
+
+
+class GUI_EXPORT QgsDateTimeEditWrapper : public QgsEditorWidgetWrapper
+{
+    Q_OBJECT
+  public:
+    explicit QgsDateTimeEditWrapper( QgsVectorLayer* vl, int fieldIdx, QWidget* editor, QWidget* parent = 0 );
+
+  private:
+    QDateTimeEdit* mDateTimeWidget;
+    QString mType;
+
+
+    // QgsEditorWidgetWrapper interface
+  public:
+    QVariant value();
+    QWidget *createWidget( QWidget *parent );
+    void initWidget( QWidget *editor );
+
+  public slots:
+    void setValue( const QVariant &value );
+    void setEnabled( bool enabled );
+};
+
+#endif // QGSDATETIMEEDITWRAPPER_H

--- a/src/ui/editorwidgets/qgsdatetimeeditconfig.ui
+++ b/src/ui/editorwidgets/qgsdatetimeeditconfig.ui
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsDateTimeEditConfig</class>
+ <widget class="QWidget" name="QgsDateTimeEditConfig">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>300</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="5" column="0">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="0" column="1">
+    <spacer name="horizontalSpacer">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>40</width>
+       <height>20</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="3" column="0">
+    <widget class="Line" name="line">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>preview</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDateTimeEdit" name="mDemoDateTimeEdit">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="2" column="0">
+    <widget class="QCheckBox" name="mCalendarPopupCheckBox">
+     <property name="layoutDirection">
+      <enum>Qt::LeftToRight</enum>
+     </property>
+     <property name="text">
+      <string>calendar popup</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QRadioButton" name="mDateRadio">
+       <property name="text">
+        <string>date</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
+       </property>
+       <attribute name="buttonGroup">
+        <string notr="true">buttonGroup</string>
+       </attribute>
+      </widget>
+     </item>
+     <item>
+      <widget class="QRadioButton" name="mTimeRadio">
+       <property name="text">
+        <string>time</string>
+       </property>
+       <attribute name="buttonGroup">
+        <string notr="true">buttonGroup</string>
+       </attribute>
+      </widget>
+     </item>
+     <item>
+      <widget class="QRadioButton" name="mDateTimeRadio">
+       <property name="text">
+        <string>date time</string>
+       </property>
+       <property name="checked">
+        <bool>false</bool>
+       </property>
+       <attribute name="buttonGroup">
+        <string notr="true">buttonGroup</string>
+       </attribute>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="1" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <item>
+      <widget class="QRadioButton" name="mCustomRadio">
+       <property name="text">
+        <string>custom format</string>
+       </property>
+       <attribute name="buttonGroup">
+        <string notr="true">buttonGroup</string>
+       </attribute>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="mFormatEdit">
+       <property name="enabled">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>mCustomRadio</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>mFormatEdit</receiver>
+   <slot>setEnabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>79</x>
+     <y>58</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>190</x>
+     <y>56</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+ <buttongroups>
+  <buttongroup name="buttonGroup"/>
+ </buttongroups>
+</ui>


### PR DESCRIPTION
This adds a new edit type for date and/or time editing.

For the sake of clarity, I did not implemented a different display format from the field format. Otherwise, configuration would have been a bit complex. But this prevent the user from being able to display the day of the week in the widget. What do you think?

Also, I suggest to modifiy QgsEditorWidgetWrapper::initWidget to retun a bool. If it returns false (i.e. the provided widget in the UI form has not the correct type), then we can emit a message in the log saying it was badly configured (which layer, which field, which type, what widget given). 
That would be very useful to the power user I believe.
