### PR TITLE
Make PostGIS provider correctly create time and datetime formats

### DIFF
--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -2788,7 +2788,13 @@ bool QgsPostgresProvider::convertField( QgsField &field )
       break;
 
     case QVariant::DateTime:
+      fieldType = "timestamp without time zone";
+      break;
+
     case QVariant::Time:
+      fieldType = "time";
+      break;
+
     case QVariant::String:
       fieldType = "varchar";
       fieldPrec = -1;


### PR DESCRIPTION
At the moment the postgis provider converts time and datetime fields to varchar fields. I'm not sure what the rationale behind this is. This patch correctly maps the datetime and time types to postgis timestamp and time types.
