### PR TITLE
Fix #8298 ignored first selection in projection selector

### DIFF
--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -602,6 +602,12 @@ void QgsProjectProperties::apply()
       if ( srs.mapUnits() != QGis::UnknownUnit )
         mMapCanvas->setMapUnits( srs.mapUnits() );
     }
+
+    if ( cbxProjectionEnabled->isChecked() )
+    {
+      // mark selected projection for push to front
+      projectionSelector->pushProjectionToFront();
+    }
   }
 
   // Set the project title

--- a/src/gui/qgsprojectionselector.cpp
+++ b/src/gui/qgsprojectionselector.cpp
@@ -32,10 +32,16 @@ QgsProjectionSelector::QgsProjectionSelector( QWidget* parent, const char *name,
     , mUserProjListDone( false )
     , mRecentProjListDone( false )
     , mSearchColumn( NONE )
-    , mSkipFirstRecent( true )
+    , mPushProjectionToFront( false )
 {
   Q_UNUSED( name );
   setupUi( this );
+
+  if ( qobject_cast<QDialog*>( parent ) )
+  {
+    // mark selected projection for push to front if parent dialog is accepted
+    connect( parent, SIGNAL( accepted() ), this, SLOT( pushProjectionToFront() ) );
+  }
 
   // Get the full path name to the sqlite3 spatial reference database.
   mSrsDatabaseFileName = QgsApplication::srsDbFilePath();
@@ -94,6 +100,11 @@ QgsProjectionSelector::QgsProjectionSelector( QWidget* parent, const char *name,
 
 QgsProjectionSelector::~QgsProjectionSelector()
 {
+  if ( !mPushProjectionToFront )
+  {
+    return;
+  }
+
   // Push current projection to front, only if set
   long crsId = selectedCrsId();
   if ( crsId == 0 )
@@ -750,12 +761,6 @@ void QgsProjectionSelector::on_lstRecent_currentItemChanged( QTreeWidgetItem *cu
 {
   QgsDebugMsg( "Entered." );
 
-  if ( mSkipFirstRecent )
-  {
-    mSkipFirstRecent = false;
-    return;
-  }
-
   if ( !current )
   {
     QgsDebugMsg( "no current item" );
@@ -859,6 +864,13 @@ void QgsProjectionSelector::on_leSearch_textChanged( const QString & theFilterTx
     }
     ++it;
   }
+}
+
+
+void QgsProjectionSelector::pushProjectionToFront()
+{
+  // set flag to push selected projection to front in destructor
+  mPushProjectionToFront = true;
 }
 
 

--- a/src/gui/qgsprojectionselector.h
+++ b/src/gui/qgsprojectionselector.h
@@ -104,6 +104,9 @@ class GUI_EXPORT QgsProjectionSelector : public QWidget, private Ui::QgsProjecti
     void on_cbxHideDeprecated_stateChanged();
     void on_leSearch_textChanged( const QString & );
 
+    //! mark selected projection for push to front
+    void pushProjectionToFront();
+
   protected:
     /** Used to ensure the projection list view is actually populated */
     void showEvent( QShowEvent * theEvent );
@@ -181,7 +184,7 @@ class GUI_EXPORT QgsProjectionSelector : public QWidget, private Ui::QgsProjecti
     int mSearchColumn;
     QString mSearchValue;
 
-    bool mSkipFirstRecent;
+    bool mPushProjectionToFront;
 
     //! The set of OGC WMS CRSs that want to be applied to this widget
     QSet<QString> mCrsFilter;


### PR DESCRIPTION
The projection is now properly selected on the first selection in the recently used CRS list (see http://hub.qgis.org/issues/8298).
Also the selected projection will only be pushed to the front of the recently used CRS list if the parent dialog is accepted (see also http://hub.qgis.org/issues/5030).
