### PR TITLE
Replace WFlags with WindowFlags

### DIFF
--- a/src/app/ogr/qgsnewogrconnection.cpp
+++ b/src/app/ogr/qgsnewogrconnection.cpp
@@ -31,7 +31,7 @@
 #define TO8F(x) QFile::encodeName( x ).constData()
 #endif
 
-QgsNewOgrConnection::QgsNewOgrConnection( QWidget *parent, const QString& connType, const QString& connName, Qt::WFlags fl )
+QgsNewOgrConnection::QgsNewOgrConnection( QWidget *parent, const QString& connType, const QString& connName, Qt::WindowFlags fl )
     : QDialog( parent, fl ),
     mOriginalConnName( connName )
 {

--- a/src/app/ogr/qgsnewogrconnection.h
+++ b/src/app/ogr/qgsnewogrconnection.h
@@ -31,7 +31,7 @@ class QgsNewOgrConnection : public QDialog, private Ui::QgsNewOgrConnectionBase
 
   public:
     //! Constructor
-    QgsNewOgrConnection( QWidget *parent = 0, const QString& connType = QString::null, const QString& connName = QString::null, Qt::WFlags fl = QgisGui::ModalDialogFlags );
+    QgsNewOgrConnection( QWidget *parent = 0, const QString& connType = QString::null, const QString& connName = QString::null, Qt::WindowFlags fl = QgisGui::ModalDialogFlags );
     //! Destructor
     ~QgsNewOgrConnection();
     //! Tests the connection using the parameters supplied

--- a/src/app/ogr/qgsopenvectorlayerdialog.cpp
+++ b/src/app/ogr/qgsopenvectorlayerdialog.cpp
@@ -32,7 +32,7 @@
 #include "qgsogrhelperfunctions.h"
 #include "qgscontexthelp.h"
 
-QgsOpenVectorLayerDialog::QgsOpenVectorLayerDialog( QWidget* parent, Qt::WFlags fl )
+QgsOpenVectorLayerDialog::QgsOpenVectorLayerDialog( QWidget* parent, Qt::WindowFlags fl )
     : QDialog( parent, fl )
 {
   setupUi( this );

--- a/src/app/ogr/qgsopenvectorlayerdialog.h
+++ b/src/app/ogr/qgsopenvectorlayerdialog.h
@@ -32,7 +32,7 @@ class QgsOpenVectorLayerDialog : public QDialog, private Ui::QgsOpenVectorLayerD
     Q_OBJECT
 
   public:
-    QgsOpenVectorLayerDialog( QWidget* parent = 0,  Qt::WFlags fl = 0 );
+    QgsOpenVectorLayerDialog( QWidget* parent = 0,  Qt::WindowFlags fl = 0 );
     ~QgsOpenVectorLayerDialog();
     //! Opens a dialog to select a file datasource*/
     QStringList openFile();

--- a/src/app/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/app/ogr/qgsvectorlayersaveasdialog.cpp
@@ -25,14 +25,14 @@
 #include <QFileDialog>
 #include <QTextCodec>
 
-QgsVectorLayerSaveAsDialog::QgsVectorLayerSaveAsDialog( long srsid, QWidget* parent, Qt::WFlags fl )
+QgsVectorLayerSaveAsDialog::QgsVectorLayerSaveAsDialog( long srsid, QWidget* parent, Qt::WindowFlags fl )
     : QDialog( parent, fl )
     , mCRS( srsid )
 {
   setup();
 }
 
-QgsVectorLayerSaveAsDialog::QgsVectorLayerSaveAsDialog( long srsid, const QgsRectangle& layerExtent, bool layerHasSelectedFeatures, int options, QWidget* parent, Qt::WFlags fl )
+QgsVectorLayerSaveAsDialog::QgsVectorLayerSaveAsDialog( long srsid, const QgsRectangle& layerExtent, bool layerHasSelectedFeatures, int options, QWidget* parent, Qt::WindowFlags fl )
     : QDialog( parent, fl )
     , mCRS( srsid )
     , mLayerExtent( layerExtent )

--- a/src/app/ogr/qgsvectorlayersaveasdialog.h
+++ b/src/app/ogr/qgsvectorlayersaveasdialog.h
@@ -38,8 +38,8 @@ class QgsVectorLayerSaveAsDialog : public QDialog, private Ui::QgsVectorLayerSav
       AllOptions = ~0
     };
 
-    QgsVectorLayerSaveAsDialog( long srsid, QWidget* parent = 0,  Qt::WFlags fl = 0 );
-    QgsVectorLayerSaveAsDialog( long srsid, const QgsRectangle& layerExtent, bool layerHasSelectedFeatures, int options = AllOptions, QWidget* parent = 0,  Qt::WFlags fl = 0 );
+    QgsVectorLayerSaveAsDialog( long srsid, QWidget* parent = 0,  Qt::WindowFlags fl = 0 );
+    QgsVectorLayerSaveAsDialog( long srsid, const QgsRectangle& layerExtent, bool layerHasSelectedFeatures, int options = AllOptions, QWidget* parent = 0,  Qt::WindowFlags fl = 0 );
     ~QgsVectorLayerSaveAsDialog();
 
     QString format() const;

--- a/src/app/pluginmanager/qgspluginmanager.cpp
+++ b/src/app/pluginmanager/qgspluginmanager.cpp
@@ -54,7 +54,7 @@
 #endif
 
 
-QgsPluginManager::QgsPluginManager( QWidget * parent, bool pluginsAreEnabled, Qt::WFlags fl )
+QgsPluginManager::QgsPluginManager( QWidget * parent, bool pluginsAreEnabled, Qt::WindowFlags fl )
     : QgsOptionsDialogBase( "PluginManager", parent, fl )
 {
   // initialize pointer

--- a/src/app/pluginmanager/qgspluginmanager.h
+++ b/src/app/pluginmanager/qgspluginmanager.h
@@ -46,7 +46,7 @@ class QgsPluginManager : public QgsOptionsDialogBase, private Ui::QgsPluginManag
     Q_OBJECT
   public:
     //! Constructor; set pluginsAreEnabled to false in --noplugins mode
-    QgsPluginManager( QWidget *parent = 0, bool pluginsAreEnabled = true, Qt::WFlags fl = QgisGui::ModalDialogFlags );
+    QgsPluginManager( QWidget *parent = 0, bool pluginsAreEnabled = true, Qt::WindowFlags fl = QgisGui::ModalDialogFlags );
 
     //! Destructor
     ~QgsPluginManager();

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -443,7 +443,7 @@ static bool cmpByText_( QAction* a, QAction* b )
 QgisApp *QgisApp::smInstance = 0;
 
 // constructor starts here
-QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, QWidget * parent, Qt::WFlags fl )
+QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, QWidget * parent, Qt::WindowFlags fl )
     : QMainWindow( parent, fl )
     , mSplash( splash )
     , mMousePrecisionDecimalPlaces( 0 )

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -113,7 +113,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     Q_OBJECT
   public:
     //! Constructor
-    QgisApp( QSplashScreen *splash, bool restorePlugins = true, QWidget * parent = 0, Qt::WFlags fl = Qt::Window );
+    QgisApp( QSplashScreen *splash, bool restorePlugins = true, QWidget * parent = 0, Qt::WindowFlags fl = Qt::Window );
     //! Constructor for unit tests
     QgisApp( );
     //! Destructor

--- a/src/app/qgsaddattrdialog.cpp
+++ b/src/app/qgsaddattrdialog.cpp
@@ -22,7 +22,7 @@
 
 #include <QMessageBox>
 
-QgsAddAttrDialog::QgsAddAttrDialog( QgsVectorLayer *vlayer, QWidget *parent, Qt::WFlags fl )
+QgsAddAttrDialog::QgsAddAttrDialog( QgsVectorLayer *vlayer, QWidget *parent, Qt::WindowFlags fl )
     : QDialog( parent, fl )
     , mIsShapeFile( vlayer && vlayer->providerType() == "ogr" && vlayer->storageType() == "ESRI Shapefile" )
 {

--- a/src/app/qgsaddattrdialog.h
+++ b/src/app/qgsaddattrdialog.h
@@ -29,9 +29,9 @@ class APP_EXPORT QgsAddAttrDialog: public QDialog, private Ui::QgsAddAttrDialogB
     Q_OBJECT
   public:
     QgsAddAttrDialog( QgsVectorLayer *vlayer,
-                      QWidget *parent = 0, Qt::WFlags fl = QgisGui::ModalDialogFlags );
+                      QWidget *parent = 0, Qt::WindowFlags fl = QgisGui::ModalDialogFlags );
     QgsAddAttrDialog( const std::list<QString>& typelist,
-                      QWidget *parent = 0, Qt::WFlags fl = QgisGui::ModalDialogFlags );
+                      QWidget *parent = 0, Qt::WindowFlags fl = QgisGui::ModalDialogFlags );
 
     QgsField field() const;
 

--- a/src/app/qgsbookmarks.cpp
+++ b/src/app/qgsbookmarks.cpp
@@ -34,7 +34,7 @@
 
 QgsBookmarks *QgsBookmarks::sInstance = 0;
 
-QgsBookmarks::QgsBookmarks( QWidget *parent, Qt::WFlags fl )
+QgsBookmarks::QgsBookmarks( QWidget *parent, Qt::WindowFlags fl )
     : QDialog( parent, fl )
 {
   setupUi( this );

--- a/src/app/qgsbookmarks.h
+++ b/src/app/qgsbookmarks.h
@@ -38,7 +38,7 @@ class APP_EXPORT QgsBookmarks : public QDialog, private Ui::QgsBookmarksBase
     void on_buttonBox_helpRequested() { QgsContextHelp::run( metaObject()->className() ); }
 
   private:
-    QgsBookmarks( QWidget *parent = 0, Qt::WFlags fl = 0 );
+    QgsBookmarks( QWidget *parent = 0, Qt::WindowFlags fl = 0 );
     ~QgsBookmarks();
 
     void saveWindowLocation();

--- a/src/app/qgscustomprojectiondialog.cpp
+++ b/src/app/qgscustomprojectiondialog.cpp
@@ -43,7 +43,7 @@ extern "C"
 }
 
 
-QgsCustomProjectionDialog::QgsCustomProjectionDialog( QWidget *parent, Qt::WFlags fl )
+QgsCustomProjectionDialog::QgsCustomProjectionDialog( QWidget *parent, Qt::WindowFlags fl )
     : QDialog( parent, fl )
 {
   setupUi( this );

--- a/src/app/qgscustomprojectiondialog.h
+++ b/src/app/qgscustomprojectiondialog.h
@@ -33,7 +33,7 @@ class APP_EXPORT QgsCustomProjectionDialog : public QDialog, private Ui::QgsCust
 {
     Q_OBJECT
   public:
-    QgsCustomProjectionDialog( QWidget *parent = 0, Qt::WFlags fl = 0 );
+    QgsCustomProjectionDialog( QWidget *parent = 0, Qt::WindowFlags fl = 0 );
     ~QgsCustomProjectionDialog();
 
   public slots:

--- a/src/app/qgsdisplayangle.cpp
+++ b/src/app/qgsdisplayangle.cpp
@@ -20,7 +20,7 @@
 #include <QSettings>
 #include <cmath>
 
-QgsDisplayAngle::QgsDisplayAngle( QgsMapToolMeasureAngle * tool, Qt::WFlags f )
+QgsDisplayAngle::QgsDisplayAngle( QgsMapToolMeasureAngle * tool, Qt::WindowFlags f )
     : QDialog( tool->canvas()->topLevelWidget(), f ), mTool( tool )
 {
   setupUi( this );

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -252,7 +252,7 @@ void QgsIdentifyResultsWebViewItem::loadFinished( bool ok )
 //       action
 //     name value
 
-QgsIdentifyResultsDialog::QgsIdentifyResultsDialog( QgsMapCanvas *canvas, QWidget *parent, Qt::WFlags f )
+QgsIdentifyResultsDialog::QgsIdentifyResultsDialog( QgsMapCanvas *canvas, QWidget *parent, Qt::WindowFlags f )
     : QDialog( parent, f )
     , mActionPopup( 0 )
     , mCanvas( canvas )

--- a/src/app/qgsidentifyresultsdialog.h
+++ b/src/app/qgsidentifyresultsdialog.h
@@ -100,7 +100,7 @@ class APP_EXPORT QgsIdentifyResultsDialog: public QDialog, private Ui::QgsIdenti
 
     //! Constructor - takes it own copy of the QgsAttributeAction so
     // that it is independent of whoever created it.
-    QgsIdentifyResultsDialog( QgsMapCanvas *canvas, QWidget *parent = 0, Qt::WFlags f = 0 );
+    QgsIdentifyResultsDialog( QgsMapCanvas *canvas, QWidget *parent = 0, Qt::WindowFlags f = 0 );
 
     ~QgsIdentifyResultsDialog();
 

--- a/src/app/qgsmeasuredialog.cpp
+++ b/src/app/qgsmeasuredialog.cpp
@@ -31,7 +31,7 @@
 #include <QPushButton>
 
 
-QgsMeasureDialog::QgsMeasureDialog( QgsMeasureTool* tool, Qt::WFlags f )
+QgsMeasureDialog::QgsMeasureDialog( QgsMeasureTool* tool, Qt::WindowFlags f )
     : QDialog( tool->canvas()->topLevelWidget(), f ), mTool( tool )
 {
   setupUi( this );

--- a/src/app/qgsmeasuredialog.h
+++ b/src/app/qgsmeasuredialog.h
@@ -33,7 +33,7 @@ class APP_EXPORT QgsMeasureDialog : public QDialog, private Ui::QgsMeasureBase
   public:
 
     //! Constructor
-    QgsMeasureDialog( QgsMeasureTool* tool, Qt::WFlags f = 0 );
+    QgsMeasureDialog( QgsMeasureTool* tool, Qt::WindowFlags f = 0 );
 
     //! Save position
     void saveWindowLocation( void );

--- a/src/app/qgsnewspatialitelayerdialog.cpp
+++ b/src/app/qgsnewspatialitelayerdialog.cpp
@@ -40,7 +40,7 @@
 
 #include <spatialite.h>
 
-QgsNewSpatialiteLayerDialog::QgsNewSpatialiteLayerDialog( QWidget *parent, Qt::WFlags fl )
+QgsNewSpatialiteLayerDialog::QgsNewSpatialiteLayerDialog( QWidget *parent, Qt::WindowFlags fl )
     : QDialog( parent, fl )
 {
   setupUi( this );

--- a/src/app/qgsnewspatialitelayerdialog.h
+++ b/src/app/qgsnewspatialitelayerdialog.h
@@ -34,7 +34,7 @@ class APP_EXPORT QgsNewSpatialiteLayerDialog: public QDialog, private Ui::QgsNew
     Q_OBJECT
 
   public:
-    QgsNewSpatialiteLayerDialog( QWidget *parent = 0, Qt::WFlags fl = QgisGui::ModalDialogFlags );
+    QgsNewSpatialiteLayerDialog( QWidget *parent = 0, Qt::WindowFlags fl = QgisGui::ModalDialogFlags );
     ~QgsNewSpatialiteLayerDialog();
 
   protected slots:

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -66,7 +66,7 @@
  * \class QgsOptions - Set user options and preferences
  * Constructor
  */
-QgsOptions::QgsOptions( QWidget *parent, Qt::WFlags fl ) :
+QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl ) :
     QgsOptionsDialogBase( "Options", parent, fl )
 {
   setupUi( this );

--- a/src/app/qgsoptions.h
+++ b/src/app/qgsoptions.h
@@ -43,7 +43,7 @@ class APP_EXPORT QgsOptions : public QgsOptionsDialogBase, private Ui::QgsOption
      * @param name name for the widget
      * @param modal true for modal dialog
      */
-    QgsOptions( QWidget *parent = 0, Qt::WFlags fl = QgisGui::ModalDialogFlags );
+    QgsOptions( QWidget *parent = 0, Qt::WindowFlags fl = QgisGui::ModalDialogFlags );
     //! Destructor
     ~QgsOptions();
     /**

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -58,7 +58,7 @@ const char * QgsProjectProperties::GEO_NONE_DESC = QT_TRANSLATE_NOOP( "QgsOption
 
 //stdc++ includes
 
-QgsProjectProperties::QgsProjectProperties( QgsMapCanvas* mapCanvas, QWidget *parent, Qt::WFlags fl )
+QgsProjectProperties::QgsProjectProperties( QgsMapCanvas* mapCanvas, QWidget *parent, Qt::WindowFlags fl )
     : QgsOptionsDialogBase( "ProjectProperties", parent, fl )
     , mMapCanvas( mapCanvas )
     , mEllipsoidList()

--- a/src/app/qgsprojectproperties.h
+++ b/src/app/qgsprojectproperties.h
@@ -38,7 +38,7 @@ class APP_EXPORT QgsProjectProperties : public QgsOptionsDialogBase, private Ui:
 
   public:
     //! Constructor
-    QgsProjectProperties( QgsMapCanvas* mapCanvas, QWidget *parent = 0, Qt::WFlags fl = QgisGui::ModalDialogFlags );
+    QgsProjectProperties( QgsMapCanvas* mapCanvas, QWidget *parent = 0, Qt::WindowFlags fl = QgisGui::ModalDialogFlags );
 
     //! Destructor
     ~QgsProjectProperties();

--- a/src/app/qgsrasterlayerproperties.cpp
+++ b/src/app/qgsrasterlayerproperties.cpp
@@ -66,7 +66,7 @@
 #include <QMouseEvent>
 #include <QVector>
 
-QgsRasterLayerProperties::QgsRasterLayerProperties( QgsMapLayer* lyr, QgsMapCanvas* theCanvas, QWidget *parent, Qt::WFlags fl )
+QgsRasterLayerProperties::QgsRasterLayerProperties( QgsMapLayer* lyr, QgsMapCanvas* theCanvas, QWidget *parent, Qt::WindowFlags fl )
     : QgsOptionsDialogBase( "RasterLayerProperties", parent, fl ),
     // Constant that signals property not used.
     TRSTRING_NOT_SET( tr( "Not Set" ) ),

--- a/src/app/qgsrasterlayerproperties.h
+++ b/src/app/qgsrasterlayerproperties.h
@@ -46,7 +46,7 @@ class APP_EXPORT QgsRasterLayerProperties : public QgsOptionsDialogBase, private
     /** \brief Constructor
      * @param ml Map layer for which properties will be displayed
      */
-    QgsRasterLayerProperties( QgsMapLayer *lyr, QgsMapCanvas* theCanvas, QWidget *parent = 0, Qt::WFlags = QgisGui::ModalDialogFlags );
+    QgsRasterLayerProperties( QgsMapLayer *lyr, QgsMapCanvas* theCanvas, QWidget *parent = 0, Qt::WindowFlags = QgisGui::ModalDialogFlags );
     /** \brief Destructor */
     ~QgsRasterLayerProperties();
 

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -68,7 +68,7 @@
 QgsVectorLayerProperties::QgsVectorLayerProperties(
   QgsVectorLayer *lyr,
   QWidget * parent,
-  Qt::WFlags fl
+  Qt::WindowFlags fl
 )
     : QgsOptionsDialogBase( "VectorLayerProperties", parent, fl )
     , layer( lyr )

--- a/src/app/qgsvectorlayerproperties.h
+++ b/src/app/qgsvectorlayerproperties.h
@@ -53,7 +53,7 @@ class APP_EXPORT QgsVectorLayerProperties : public QgsOptionsDialogBase, private
       DB,
     };
 
-    QgsVectorLayerProperties( QgsVectorLayer *lyr = 0, QWidget *parent = 0, Qt::WFlags fl = QgisGui::ModalDialogFlags );
+    QgsVectorLayerProperties( QgsVectorLayer *lyr = 0, QWidget *parent = 0, Qt::WindowFlags fl = QgisGui::ModalDialogFlags );
     ~QgsVectorLayerProperties();
     /**Returns the display name entered in the dialog*/
     QString displayName();

--- a/src/browser/qgsbrowser.cpp
+++ b/src/browser/qgsbrowser.cpp
@@ -41,7 +41,7 @@
 #define QGIS_ICON_SIZE 24
 #endif
 
-QgsBrowser::QgsBrowser( QWidget *parent, Qt::WFlags flags )
+QgsBrowser::QgsBrowser( QWidget *parent, Qt::WindowFlags flags )
     : QMainWindow( parent, flags )
     , mDirtyMetadata( true )
     , mDirtyPreview( true )

--- a/src/browser/qgsbrowser.h
+++ b/src/browser/qgsbrowser.h
@@ -30,7 +30,7 @@ class QgsBrowser : public QMainWindow, private Ui::QgsBrowserBase
 {
     Q_OBJECT
   public:
-    QgsBrowser( QWidget *parent = 0, Qt::WFlags flags = 0 );
+    QgsBrowser( QWidget *parent = 0, Qt::WindowFlags flags = 0 );
     ~QgsBrowser();
 
     // Expand to given path

--- a/src/core/qgsproviderregistry.cpp
+++ b/src/core/qgsproviderregistry.cpp
@@ -372,10 +372,10 @@ QgsDataProvider *QgsProviderRegistry::provider( QString const & providerKey, QSt
 } // QgsProviderRegistry::setDataProvider
 
 // This should be QWidget, not QDialog
-typedef QWidget * selectFactoryFunction_t( QWidget * parent, Qt::WFlags fl );
+typedef QWidget * selectFactoryFunction_t( QWidget * parent, Qt::WindowFlags fl );
 
 QWidget* QgsProviderRegistry::selectWidget( const QString & providerKey,
-    QWidget * parent, Qt::WFlags fl )
+    QWidget * parent, Qt::WindowFlags fl )
 {
   selectFactoryFunction_t * selectFactory =
     ( selectFactoryFunction_t * ) cast_to_fptr( function( providerKey, "selectWidget" ) );

--- a/src/core/qgsproviderregistry.h
+++ b/src/core/qgsproviderregistry.h
@@ -69,7 +69,7 @@ class CORE_EXPORT QgsProviderRegistry
                                const QString & dataSource );
 
     QWidget *selectWidget( const QString & providerKey,
-                           QWidget * parent = 0, Qt::WFlags fl = 0 );
+                           QWidget * parent = 0, Qt::WindowFlags fl = 0 );
 
     /** Get pointer to provider function
         @param providerKey identificator of the provider

--- a/src/gui/qgisgui.h
+++ b/src/gui/qgisgui.h
@@ -44,7 +44,7 @@ namespace QgisGui
    * Qt::WindowMaximizeButtonHint is included but will be ignored if
    * the dialog is a fixed size and does not have a size grip.
    */
-  static const Qt::WFlags ModalDialogFlags = 0;
+  static const Qt::WindowFlags ModalDialogFlags = 0;
 
   /**
     Open files, preferring to have the default file selector be the

--- a/src/gui/qgsbusyindicatordialog.cpp
+++ b/src/gui/qgsbusyindicatordialog.cpp
@@ -22,7 +22,7 @@
 #include <QLabel>
 #include <QProgressBar>
 
-QgsBusyIndicatorDialog::QgsBusyIndicatorDialog( const QString& message, QWidget* parent, Qt::WFlags fl )
+QgsBusyIndicatorDialog::QgsBusyIndicatorDialog( const QString& message, QWidget* parent, Qt::WindowFlags fl )
     : QDialog( parent, fl ), mMessage( QString( message ) ), mMsgLabel( 0 )
 {
   setWindowTitle( tr( "QGIS" ) );

--- a/src/gui/qgsbusyindicatordialog.h
+++ b/src/gui/qgsbusyindicatordialog.h
@@ -39,7 +39,7 @@ class GUI_EXPORT QgsBusyIndicatorDialog : public QDialog
      * @param fl widget flags
      * @note added in 1.9
     */
-    QgsBusyIndicatorDialog( const QString& message = "", QWidget *parent = 0, Qt::WFlags fl = QgisGui::ModalDialogFlags );
+    QgsBusyIndicatorDialog( const QString& message = "", QWidget *parent = 0, Qt::WindowFlags fl = QgisGui::ModalDialogFlags );
     ~QgsBusyIndicatorDialog();
 
     QString message() const { return mMessage; }

--- a/src/gui/qgscharacterselectdialog.cpp
+++ b/src/gui/qgscharacterselectdialog.cpp
@@ -18,7 +18,7 @@
 #include "qgscharacterselectdialog.h"
 
 
-QgsCharacterSelectorDialog::QgsCharacterSelectorDialog( QWidget *parent, Qt::WFlags fl )
+QgsCharacterSelectorDialog::QgsCharacterSelectorDialog( QWidget *parent, Qt::WindowFlags fl )
     : QDialog( parent, fl ), mChar( QChar::Null )
 {
   setupUi( this );

--- a/src/gui/qgscharacterselectdialog.h
+++ b/src/gui/qgscharacterselectdialog.h
@@ -32,7 +32,7 @@ class GUI_EXPORT QgsCharacterSelectorDialog : public QDialog, private Ui::QgsCha
     Q_OBJECT
 
   public:
-    QgsCharacterSelectorDialog( QWidget* parent = 0, Qt::WFlags fl = QgisGui::ModalDialogFlags );
+    QgsCharacterSelectorDialog( QWidget* parent = 0, Qt::WindowFlags fl = QgisGui::ModalDialogFlags );
     ~QgsCharacterSelectorDialog();
 
   public slots:

--- a/src/gui/qgscomposerview.cpp
+++ b/src/gui/qgscomposerview.cpp
@@ -46,7 +46,7 @@
 #include "qgsmapcanvas.h" //for QgsMapCanvas::WheelAction
 #include "qgscursors.h"
 
-QgsComposerView::QgsComposerView( QWidget* parent, const char* name, Qt::WFlags f )
+QgsComposerView::QgsComposerView( QWidget* parent, const char* name, Qt::WindowFlags f )
     : QGraphicsView( parent )
     , mRubberBandItem( 0 )
     , mRubberBandLineItem( 0 )

--- a/src/gui/qgscomposerview.h
+++ b/src/gui/qgscomposerview.h
@@ -90,7 +90,7 @@ class GUI_EXPORT QgsComposerView: public QGraphicsView
       ActiveUntilMouseRelease
     };
 
-    QgsComposerView( QWidget* parent = 0, const char* name = 0, Qt::WFlags f = 0 );
+    QgsComposerView( QWidget* parent = 0, const char* name = 0, Qt::WindowFlags f = 0 );
 
     /**Add an item group containing the selected items*/
     void groupItems();

--- a/src/gui/qgscredentialdialog.cpp
+++ b/src/gui/qgscredentialdialog.cpp
@@ -21,7 +21,7 @@
 #include <QSettings>
 #include <QThread>
 
-QgsCredentialDialog::QgsCredentialDialog( QWidget *parent, Qt::WFlags fl )
+QgsCredentialDialog::QgsCredentialDialog( QWidget *parent, Qt::WindowFlags fl )
     : QDialog( parent, fl )
 {
   setupUi( this );

--- a/src/gui/qgscredentialdialog.h
+++ b/src/gui/qgscredentialdialog.h
@@ -31,7 +31,7 @@ class GUI_EXPORT QgsCredentialDialog : public QDialog, public QgsCredentials, pr
 {
     Q_OBJECT
   public:
-    QgsCredentialDialog( QWidget *parent = 0, Qt::WFlags fl = QgisGui::ModalDialogFlags );
+    QgsCredentialDialog( QWidget *parent = 0, Qt::WindowFlags fl = QgisGui::ModalDialogFlags );
     ~QgsCredentialDialog();
 
   signals:

--- a/src/gui/qgsdialog.cpp
+++ b/src/gui/qgsdialog.cpp
@@ -17,7 +17,7 @@
 
 #include "qgsdialog.h"
 
-QgsDialog::QgsDialog( QWidget *parent, Qt::WFlags fl,
+QgsDialog::QgsDialog( QWidget *parent, Qt::WindowFlags fl,
                       QDialogButtonBox::StandardButtons buttons,
                       Qt::Orientation orientation )
     : QDialog( parent, fl )

--- a/src/gui/qgsdialog.h
+++ b/src/gui/qgsdialog.h
@@ -31,7 +31,7 @@ class GUI_EXPORT QgsDialog : public QDialog
 {
     Q_OBJECT
   public:
-    QgsDialog( QWidget *parent = 0, Qt::WFlags fl = QgisGui::ModalDialogFlags,
+    QgsDialog( QWidget *parent = 0, Qt::WindowFlags fl = QgisGui::ModalDialogFlags,
                QDialogButtonBox::StandardButtons buttons = QDialogButtonBox::Close,
                Qt::Orientation orientation = Qt::Horizontal );
     ~QgsDialog();

--- a/src/gui/qgserrordialog.cpp
+++ b/src/gui/qgserrordialog.cpp
@@ -19,7 +19,7 @@
 #include <QMessageBox>
 #include <QSettings>
 
-QgsErrorDialog::QgsErrorDialog( const QgsError & theError, const QString & theTitle, QWidget *parent, Qt::WFlags fl )
+QgsErrorDialog::QgsErrorDialog( const QgsError & theError, const QString & theTitle, QWidget *parent, Qt::WindowFlags fl )
     : QDialog( parent, fl )
     , mError( theError )
 {
@@ -56,7 +56,7 @@ QgsErrorDialog::~QgsErrorDialog()
 {
 }
 
-void QgsErrorDialog::show( const QgsError & theError, const QString & theTitle, QWidget *parent, Qt::WFlags fl )
+void QgsErrorDialog::show( const QgsError & theError, const QString & theTitle, QWidget *parent, Qt::WindowFlags fl )
 {
   QgsErrorDialog d( theError, theTitle, parent, fl );
   d.exec();

--- a/src/gui/qgserrordialog.h
+++ b/src/gui/qgserrordialog.h
@@ -27,7 +27,7 @@ class GUI_EXPORT QgsErrorDialog: public QDialog, private Ui::QgsErrorDialogBase
 {
     Q_OBJECT
   public:
-    QgsErrorDialog( const QgsError & theError, const QString & theTitle, QWidget *parent = 0, Qt::WFlags fl = QgisGui::ModalDialogFlags );
+    QgsErrorDialog( const QgsError & theError, const QString & theTitle, QWidget *parent = 0, Qt::WindowFlags fl = QgisGui::ModalDialogFlags );
     ~QgsErrorDialog();
 
     /** Show dialog with error
@@ -36,7 +36,7 @@ class GUI_EXPORT QgsErrorDialog: public QDialog, private Ui::QgsErrorDialogBase
      * @param parent parent object
      * @param fl widget flags
      */
-    static void show( const QgsError & theError, const QString & theTitle, QWidget *parent = 0, Qt::WFlags fl = QgisGui::ModalDialogFlags );
+    static void show( const QgsError & theError, const QString & theTitle, QWidget *parent = 0, Qt::WindowFlags fl = QgisGui::ModalDialogFlags );
 
   public slots:
     void on_mDetailPushButton_clicked();

--- a/src/gui/qgsgenericprojectionselector.cpp
+++ b/src/gui/qgsgenericprojectionselector.cpp
@@ -26,7 +26,7 @@
  * \brief A generic dialog to prompt the user for a Coordinate Reference System
  */
 QgsGenericProjectionSelector::QgsGenericProjectionSelector( QWidget *parent,
-    Qt::WFlags fl )
+    Qt::WindowFlags fl )
     : QDialog( parent, fl )
 {
   setupUi( this );

--- a/src/gui/qgsgenericprojectionselector.h
+++ b/src/gui/qgsgenericprojectionselector.h
@@ -50,7 +50,7 @@ class GUI_EXPORT QgsGenericProjectionSelector : public QDialog, private Ui::QgsG
      * Constructor
      */
     QgsGenericProjectionSelector( QWidget *parent = 0,
-                                  Qt::WFlags fl = QgisGui::ModalDialogFlags );
+                                  Qt::WindowFlags fl = QgisGui::ModalDialogFlags );
 
     //! Destructor
     ~QgsGenericProjectionSelector();

--- a/src/gui/qgsludialog.cpp
+++ b/src/gui/qgsludialog.cpp
@@ -18,7 +18,7 @@
 #include "qgsludialog.h"
 
 
-QgsLUDialog::QgsLUDialog( QWidget *parent, Qt::WFlags fl )
+QgsLUDialog::QgsLUDialog( QWidget *parent, Qt::WindowFlags fl )
     : QDialog( parent, fl )
 {
   setupUi( this );

--- a/src/gui/qgsludialog.h
+++ b/src/gui/qgsludialog.h
@@ -26,7 +26,7 @@ class GUI_EXPORT QgsLUDialog: public QDialog, private Ui::QgsLUDialogBase
 {
     Q_OBJECT
   public:
-    QgsLUDialog( QWidget *parent = 0, Qt::WFlags fl = QgisGui::ModalDialogFlags );
+    QgsLUDialog( QWidget *parent = 0, Qt::WindowFlags fl = QgisGui::ModalDialogFlags );
     ~QgsLUDialog();
     QString lowerValue() const;
     void setLowerValue( QString val );

--- a/src/gui/qgsmessagelogviewer.cpp
+++ b/src/gui/qgsmessagelogviewer.cpp
@@ -39,7 +39,7 @@ static QIcon icon( QString icon )
   return QIcon( path );
 }
 
-QgsMessageLogViewer::QgsMessageLogViewer( QStatusBar *statusBar, QWidget *parent, Qt::WFlags fl )
+QgsMessageLogViewer::QgsMessageLogViewer( QStatusBar *statusBar, QWidget *parent, Qt::WindowFlags fl )
     : QDialog( parent, fl )
     , mButton( 0 )
     , mCount( 0 )

--- a/src/gui/qgsmessagelogviewer.h
+++ b/src/gui/qgsmessagelogviewer.h
@@ -36,7 +36,7 @@ class GUI_EXPORT QgsMessageLogViewer: public QDialog, private Ui::QgsMessageLogV
 {
     Q_OBJECT
   public:
-    QgsMessageLogViewer( QStatusBar *statusBar = 0, QWidget *parent = 0, Qt::WFlags fl = QgisGui::ModalDialogFlags );
+    QgsMessageLogViewer( QStatusBar *statusBar = 0, QWidget *parent = 0, Qt::WindowFlags fl = QgisGui::ModalDialogFlags );
     ~QgsMessageLogViewer();
 
   public slots:

--- a/src/gui/qgsmessageviewer.cpp
+++ b/src/gui/qgsmessageviewer.cpp
@@ -18,7 +18,7 @@
 #include "qgsmessageviewer.h"
 #include <QSettings>
 
-QgsMessageViewer::QgsMessageViewer( QWidget *parent, Qt::WFlags fl, bool deleteOnClose )
+QgsMessageViewer::QgsMessageViewer( QWidget *parent, Qt::WindowFlags fl, bool deleteOnClose )
     : QDialog( parent, fl )
 {
   setupUi( this );

--- a/src/gui/qgsmessageviewer.h
+++ b/src/gui/qgsmessageviewer.h
@@ -31,7 +31,7 @@ class GUI_EXPORT QgsMessageViewer: public QDialog, public QgsMessageOutput, priv
 {
     Q_OBJECT
   public:
-    QgsMessageViewer( QWidget *parent = 0, Qt::WFlags fl = QgisGui::ModalDialogFlags, bool deleteOnClose = true );
+    QgsMessageViewer( QWidget *parent = 0, Qt::WindowFlags fl = QgisGui::ModalDialogFlags, bool deleteOnClose = true );
     ~QgsMessageViewer();
 
     virtual void setMessage( const QString& message, MessageType msgType );

--- a/src/gui/qgsnewhttpconnection.cpp
+++ b/src/gui/qgsnewhttpconnection.cpp
@@ -23,7 +23,7 @@
 #include <QRegExpValidator>
 
 QgsNewHttpConnection::QgsNewHttpConnection(
-  QWidget *parent, const QString& baseKey, const QString& connName, Qt::WFlags fl ):
+  QWidget *parent, const QString& baseKey, const QString& connName, Qt::WindowFlags fl ):
     QDialog( parent, fl ),
     mBaseKey( baseKey ),
     mOriginalConnName( connName )

--- a/src/gui/qgsnewhttpconnection.h
+++ b/src/gui/qgsnewhttpconnection.h
@@ -29,7 +29,7 @@ class GUI_EXPORT QgsNewHttpConnection : public QDialog, private Ui::QgsNewHttpCo
 
   public:
     //! Constructor
-    QgsNewHttpConnection( QWidget *parent = 0, const QString& baseKey = "/Qgis/connections-wms/", const QString& connName = QString::null, Qt::WFlags fl = QgisGui::ModalDialogFlags );
+    QgsNewHttpConnection( QWidget *parent = 0, const QString& baseKey = "/Qgis/connections-wms/", const QString& connName = QString::null, Qt::WindowFlags fl = QgisGui::ModalDialogFlags );
     //! Destructor
     ~QgsNewHttpConnection();
   public slots:

--- a/src/gui/qgsnewvectorlayerdialog.cpp
+++ b/src/gui/qgsnewvectorlayerdialog.cpp
@@ -32,7 +32,7 @@
 #include <QFileDialog>
 
 
-QgsNewVectorLayerDialog::QgsNewVectorLayerDialog( QWidget *parent, Qt::WFlags fl )
+QgsNewVectorLayerDialog::QgsNewVectorLayerDialog( QWidget *parent, Qt::WindowFlags fl )
     : QDialog( parent, fl )
 {
   setupUi( this );

--- a/src/gui/qgsnewvectorlayerdialog.h
+++ b/src/gui/qgsnewvectorlayerdialog.h
@@ -32,7 +32,7 @@ class GUI_EXPORT QgsNewVectorLayerDialog: public QDialog, private Ui::QgsNewVect
     // run the dialog, create the layer. Return file name if the creation was successful
     static QString runAndCreateLayer( QWidget* parent = 0, QString* enc = 0 );
 
-    QgsNewVectorLayerDialog( QWidget *parent = 0, Qt::WFlags fl = QgisGui::ModalDialogFlags );
+    QgsNewVectorLayerDialog( QWidget *parent = 0, Qt::WindowFlags fl = QgisGui::ModalDialogFlags );
     ~QgsNewVectorLayerDialog();
     /**Returns the selected geometry type*/
     QGis::WkbType selectedType() const;

--- a/src/gui/qgsoptionsdialogbase.cpp
+++ b/src/gui/qgsoptionsdialogbase.cpp
@@ -27,7 +27,7 @@
 #include <QTimer>
 
 
-QgsOptionsDialogBase::QgsOptionsDialogBase( QString settingsKey, QWidget* parent, Qt::WFlags fl, QSettings* settings )
+QgsOptionsDialogBase::QgsOptionsDialogBase( QString settingsKey, QWidget* parent, Qt::WindowFlags fl, QSettings* settings )
     : QDialog( parent, fl )
     , mOptsKey( settingsKey )
     , mInit( false )

--- a/src/gui/qgsoptionsdialogbase.h
+++ b/src/gui/qgsoptionsdialogbase.h
@@ -57,7 +57,7 @@ class GUI_EXPORT QgsOptionsDialogBase : public QDialog
      * @param fl widget flags
      * @param settings custom QSettings pointer
      */
-    QgsOptionsDialogBase( QString settingsKey, QWidget* parent = 0, Qt::WFlags fl = 0, QSettings* settings = 0 );
+    QgsOptionsDialogBase( QString settingsKey, QWidget* parent = 0, Qt::WindowFlags fl = 0, QSettings* settings = 0 );
     ~QgsOptionsDialogBase();
 
     /** Set up the base ui connections for vertical tabs.

--- a/src/gui/qgsowssourceselect.cpp
+++ b/src/gui/qgsowssourceselect.cpp
@@ -54,7 +54,7 @@
 #include <QNetworkRequest>
 #include <QNetworkReply>
 
-QgsOWSSourceSelect::QgsOWSSourceSelect( QString service, QWidget * parent, Qt::WFlags fl, bool managerMode, bool embeddedMode )
+QgsOWSSourceSelect::QgsOWSSourceSelect( QString service, QWidget * parent, Qt::WindowFlags fl, bool managerMode, bool embeddedMode )
     : QDialog( parent, fl )
     , mService( service )
     , mManagerMode( managerMode )

--- a/src/gui/qgsowssourceselect.h
+++ b/src/gui/qgsowssourceselect.h
@@ -60,7 +60,7 @@ class GUI_EXPORT QgsOWSSourceSelect : public QDialog, public Ui::QgsOWSSourceSel
     };
 
     //! Constructor
-    QgsOWSSourceSelect( QString service, QWidget *parent = 0, Qt::WFlags fl = QgisGui::ModalDialogFlags, bool managerMode = false, bool embeddedMode = false );
+    QgsOWSSourceSelect( QString service, QWidget *parent = 0, Qt::WindowFlags fl = QgisGui::ModalDialogFlags, bool managerMode = false, bool embeddedMode = false );
     //! Destructor
     ~QgsOWSSourceSelect();
 

--- a/src/gui/qgsprojectionselector.cpp
+++ b/src/gui/qgsprojectionselector.cpp
@@ -26,7 +26,7 @@
 #include <QMessageBox>
 #include <QSettings>
 
-QgsProjectionSelector::QgsProjectionSelector( QWidget* parent, const char *name, Qt::WFlags fl )
+QgsProjectionSelector::QgsProjectionSelector( QWidget* parent, const char *name, Qt::WindowFlags fl )
     : QWidget( parent, fl )
     , mProjListDone( false )
     , mUserProjListDone( false )

--- a/src/gui/qgsprojectionselector.h
+++ b/src/gui/qgsprojectionselector.h
@@ -29,7 +29,7 @@ class GUI_EXPORT QgsProjectionSelector : public QWidget, private Ui::QgsProjecti
 {
     Q_OBJECT
   public:
-    QgsProjectionSelector( QWidget* parent, const char *name = "", Qt::WFlags fl = 0 );
+    QgsProjectionSelector( QWidget* parent, const char *name = "", Qt::WindowFlags fl = 0 );
 
     ~QgsProjectionSelector();
 

--- a/src/gui/qgsquerybuilder.cpp
+++ b/src/gui/qgsquerybuilder.cpp
@@ -25,7 +25,7 @@
 // constructor used when the query builder must make its own
 // connection to the database
 QgsQueryBuilder::QgsQueryBuilder( QgsVectorLayer *layer,
-                                  QWidget *parent, Qt::WFlags fl )
+                                  QWidget *parent, Qt::WindowFlags fl )
     : QDialog( parent, fl )
     , mPreviousFieldRow( -1 )
     , mLayer( layer )

--- a/src/gui/qgsquerybuilder.h
+++ b/src/gui/qgsquerybuilder.h
@@ -48,7 +48,7 @@ class GUI_EXPORT QgsQueryBuilder : public QDialog, private Ui::QgsQueryBuilderBa
      * @param fl dialog flags
      */
     QgsQueryBuilder( QgsVectorLayer *layer, QWidget *parent = 0,
-                     Qt::WFlags fl = QgisGui::ModalDialogFlags );
+                     Qt::WindowFlags fl = QgisGui::ModalDialogFlags );
 
     ~QgsQueryBuilder();
 

--- a/src/gui/qgssearchquerybuilder.cpp
+++ b/src/gui/qgssearchquerybuilder.cpp
@@ -31,7 +31,7 @@
 #include "qgslogger.h"
 
 QgsSearchQueryBuilder::QgsSearchQueryBuilder( QgsVectorLayer* layer,
-    QWidget *parent, Qt::WFlags fl )
+    QWidget *parent, Qt::WindowFlags fl )
     : QDialog( parent, fl ), mLayer( layer )
 {
   setupUi( this );

--- a/src/gui/qgssearchquerybuilder.h
+++ b/src/gui/qgssearchquerybuilder.h
@@ -40,7 +40,7 @@ class GUI_EXPORT QgsSearchQueryBuilder : public QDialog, private Ui::QgsQueryBui
   public:
     //! Constructor - takes pointer to vector layer as a parameter
     QgsSearchQueryBuilder( QgsVectorLayer* layer, QWidget *parent = 0,
-                           Qt::WFlags fl = QgisGui::ModalDialogFlags );
+                           Qt::WindowFlags fl = QgisGui::ModalDialogFlags );
 
     ~QgsSearchQueryBuilder();
 

--- a/src/gui/qgssublayersdialog.cpp
+++ b/src/gui/qgssublayersdialog.cpp
@@ -23,7 +23,7 @@
 
 
 QgsSublayersDialog::QgsSublayersDialog( ProviderType providerType, QString name,
-                                        QWidget* parent, Qt::WFlags fl )
+                                        QWidget* parent, Qt::WindowFlags fl )
     : QDialog( parent, fl ), mName( name )
 {
   setupUi( this );

--- a/src/gui/qgssublayersdialog.h
+++ b/src/gui/qgssublayersdialog.h
@@ -33,7 +33,7 @@ class GUI_EXPORT QgsSublayersDialog : public QDialog, private Ui::QgsSublayersDi
       Vsifile
     };
 
-    QgsSublayersDialog( ProviderType providerType, QString name, QWidget* parent = 0, Qt::WFlags fl = 0 );
+    QgsSublayersDialog( ProviderType providerType, QString name, QWidget* parent = 0, Qt::WindowFlags fl = 0 );
     ~QgsSublayersDialog();
 
     void populateLayerTable( QStringList theList, QString delim = ":" );

--- a/src/gui/symbology-ng/qgssvgselectorwidget.cpp
+++ b/src/gui/symbology-ng/qgssvgselectorwidget.cpp
@@ -309,7 +309,7 @@ void QgsSvgSelectorWidget::populateList()
 
 //-- QgsSvgSelectorDialog
 
-QgsSvgSelectorDialog::QgsSvgSelectorDialog( QWidget *parent, Qt::WFlags fl,
+QgsSvgSelectorDialog::QgsSvgSelectorDialog( QWidget *parent, Qt::WindowFlags fl,
     QDialogButtonBox::StandardButtons buttons,
     Qt::Orientation orientation )
     : QDialog( parent, fl )

--- a/src/gui/symbology-ng/qgssvgselectorwidget.h
+++ b/src/gui/symbology-ng/qgssvgselectorwidget.h
@@ -109,7 +109,7 @@ class GUI_EXPORT QgsSvgSelectorDialog : public QDialog
 {
     Q_OBJECT
   public:
-    QgsSvgSelectorDialog( QWidget* parent = 0, Qt::WFlags fl = QgisGui::ModalDialogFlags,
+    QgsSvgSelectorDialog( QWidget* parent = 0, Qt::WindowFlags fl = QgisGui::ModalDialogFlags,
                           QDialogButtonBox::StandardButtons buttons = QDialogButtonBox::Close | QDialogButtonBox::Ok,
                           Qt::Orientation orientation = Qt::Horizontal );
     ~QgsSvgSelectorDialog();

--- a/src/helpviewer/qgshelpviewer.cpp
+++ b/src/helpviewer/qgshelpviewer.cpp
@@ -50,7 +50,7 @@ void QgsReaderThread::run()
   }
 }
 
-QgsHelpViewer::QgsHelpViewer( QWidget *parent, Qt::WFlags fl )
+QgsHelpViewer::QgsHelpViewer( QWidget *parent, Qt::WindowFlags fl )
     : QDialog( parent, fl )
 {
   setupUi( this );

--- a/src/helpviewer/qgshelpviewer.h
+++ b/src/helpviewer/qgshelpviewer.h
@@ -44,7 +44,7 @@ class QgsHelpViewer : public QDialog, private Ui::QgsHelpViewerBase
 {
     Q_OBJECT
   public:
-    QgsHelpViewer( QWidget *parent = 0, Qt::WFlags = 0 );
+    QgsHelpViewer( QWidget *parent = 0, Qt::WindowFlags = 0 );
     ~QgsHelpViewer();
   public slots:
     void showHelp( QString );

--- a/src/plugins/compass/qgscompassplugingui.cpp
+++ b/src/plugins/compass/qgscompassplugingui.cpp
@@ -25,7 +25,7 @@
 #include "qgscompassplugingui.h"
 #include "compass.h"
 
-QgsCompassPluginGui::QgsCompassPluginGui( QWidget * parent, Qt::WFlags fl )
+QgsCompassPluginGui::QgsCompassPluginGui( QWidget * parent, Qt::WindowFlags fl )
     : QWidget( parent, fl )
 {
   setupUi( this );

--- a/src/plugins/compass/qgscompassplugingui.h
+++ b/src/plugins/compass/qgscompassplugingui.h
@@ -36,7 +36,7 @@ class QgsCompassPluginGui : public QWidget, private Ui::QgsCompassPluginGuiBase
     Q_OBJECT
 
   public:
-    QgsCompassPluginGui( QWidget* parent = 0, Qt::WFlags fl = 0 );
+    QgsCompassPluginGui( QWidget* parent = 0, Qt::WindowFlags fl = 0 );
     ~QgsCompassPluginGui();
 
   private:

--- a/src/plugins/coordinate_capture/coordinatecapturegui.cpp
+++ b/src/plugins/coordinate_capture/coordinatecapturegui.cpp
@@ -16,7 +16,7 @@
 
 //standard includes
 
-CoordinateCaptureGui::CoordinateCaptureGui( QWidget* parent, Qt::WFlags fl )
+CoordinateCaptureGui::CoordinateCaptureGui( QWidget* parent, Qt::WindowFlags fl )
     : QDialog( parent, fl )
 {
 }

--- a/src/plugins/coordinate_capture/coordinatecapturegui.h
+++ b/src/plugins/coordinate_capture/coordinatecapturegui.h
@@ -23,7 +23,7 @@ class CoordinateCaptureGui : public QDialog
     Q_OBJECT
 
   public:
-    CoordinateCaptureGui( QWidget* parent = 0, Qt::WFlags fl = 0 );
+    CoordinateCaptureGui( QWidget* parent = 0, Qt::WindowFlags fl = 0 );
     ~CoordinateCaptureGui();
 
   private slots:

--- a/src/plugins/dxf2shp_converter/dxf2shpconvertergui.cpp
+++ b/src/plugins/dxf2shp_converter/dxf2shpconvertergui.cpp
@@ -28,7 +28,7 @@
 
 #include "qgslogger.h"
 
-dxf2shpConverterGui::dxf2shpConverterGui( QWidget *parent, Qt::WFlags fl ):
+dxf2shpConverterGui::dxf2shpConverterGui( QWidget *parent, Qt::WindowFlags fl ):
     QDialog( parent, fl )
 {
   setupUi( this );

--- a/src/plugins/dxf2shp_converter/dxf2shpconvertergui.h
+++ b/src/plugins/dxf2shp_converter/dxf2shpconvertergui.h
@@ -26,7 +26,7 @@ class dxf2shpConverterGui: public QDialog, private Ui::dxf2shpConverterGui
     Q_OBJECT
 
   public:
-    dxf2shpConverterGui( QWidget *parent = 0, Qt::WFlags fl = 0 );
+    dxf2shpConverterGui( QWidget *parent = 0, Qt::WindowFlags fl = 0 );
     ~dxf2shpConverterGui();
 
   private:

--- a/src/plugins/evis/databaseconnection/evisdatabaseconnectiongui.cpp
+++ b/src/plugins/evis/databaseconnection/evisdatabaseconnectiongui.cpp
@@ -46,7 +46,7 @@
 * @param parent - Pointer the to parent QWidget for modality
 * @param fl - Windown flags
 */
-eVisDatabaseConnectionGui::eVisDatabaseConnectionGui( QList<QTemporaryFile*>* theTemoraryFileList, QWidget* parent, Qt::WFlags fl )
+eVisDatabaseConnectionGui::eVisDatabaseConnectionGui( QList<QTemporaryFile*>* theTemoraryFileList, QWidget* parent, Qt::WindowFlags fl )
     : QDialog( parent, fl )
 {
   setupUi( this );

--- a/src/plugins/evis/databaseconnection/evisdatabaseconnectiongui.h
+++ b/src/plugins/evis/databaseconnection/evisdatabaseconnectiongui.h
@@ -50,7 +50,7 @@ class eVisDatabaseConnectionGui : public QDialog, private Ui::eVisDatabaseConnec
 
   public:
     /** \brief Constructor */
-    eVisDatabaseConnectionGui( QList<QTemporaryFile*>*, QWidget* parent = 0, Qt::WFlags fl = 0 );
+    eVisDatabaseConnectionGui( QList<QTemporaryFile*>*, QWidget* parent = 0, Qt::WindowFlags fl = 0 );
 
     /** \brief Destructor */
     ~eVisDatabaseConnectionGui( );

--- a/src/plugins/evis/databaseconnection/evisdatabaselayerfieldselectiongui.cpp
+++ b/src/plugins/evis/databaseconnection/evisdatabaselayerfieldselectiongui.cpp
@@ -31,7 +31,7 @@
 * @param parent - Pointer the to parent QWidget for modality
 * @param fl - Windown flags
 */
-eVisDatabaseLayerFieldSelectionGui::eVisDatabaseLayerFieldSelectionGui( QWidget* parent, Qt::WFlags fl )
+eVisDatabaseLayerFieldSelectionGui::eVisDatabaseLayerFieldSelectionGui( QWidget* parent, Qt::WindowFlags fl )
     : QDialog( parent, fl )
 {
   setupUi( this );

--- a/src/plugins/evis/databaseconnection/evisdatabaselayerfieldselectiongui.h
+++ b/src/plugins/evis/databaseconnection/evisdatabaselayerfieldselectiongui.h
@@ -42,7 +42,7 @@ class eVisDatabaseLayerFieldSelectionGui : public QDialog, private Ui::eVisDatab
 
   public:
     /** \brief Constructor */
-    eVisDatabaseLayerFieldSelectionGui( QWidget* parent, Qt::WFlags fl );
+    eVisDatabaseLayerFieldSelectionGui( QWidget* parent, Qt::WindowFlags fl );
 
     /** \brief Public method that sets the contents of the combo boxes with the available field names */
     void setFieldList( QStringList* );

--- a/src/plugins/evis/eventbrowser/evisgenericeventbrowsergui.cpp
+++ b/src/plugins/evis/eventbrowser/evisgenericeventbrowsergui.cpp
@@ -50,7 +50,7 @@
 * @param interface - Pointer to the application interface
 * @param fl - Window flags
 */
-eVisGenericEventBrowserGui::eVisGenericEventBrowserGui( QWidget* parent, QgisInterface* interface, Qt::WFlags fl )
+eVisGenericEventBrowserGui::eVisGenericEventBrowserGui( QWidget* parent, QgisInterface* interface, Qt::WindowFlags fl )
     : QDialog( parent, fl )
 {
   setupUi( this );
@@ -83,7 +83,7 @@ eVisGenericEventBrowserGui::eVisGenericEventBrowserGui( QWidget* parent, QgisInt
 * @param canvas - Pointer to the map canvas
 * @param fl - Window flags
 */
-eVisGenericEventBrowserGui::eVisGenericEventBrowserGui( QWidget* parent, QgsMapCanvas* canvas, Qt::WFlags fl )
+eVisGenericEventBrowserGui::eVisGenericEventBrowserGui( QWidget* parent, QgsMapCanvas* canvas, Qt::WindowFlags fl )
     : QDialog( parent, fl )
 {
   setupUi( this );

--- a/src/plugins/evis/eventbrowser/evisgenericeventbrowsergui.h
+++ b/src/plugins/evis/eventbrowser/evisgenericeventbrowsergui.h
@@ -57,10 +57,10 @@ class eVisGenericEventBrowserGui : public QDialog, private Ui::eVisGenericEventB
 
   public:
     /** \brief Constructor called when button is pressed in the plugin toolbar */
-    eVisGenericEventBrowserGui( QWidget* parent, QgisInterface* interface, Qt::WFlags fl );
+    eVisGenericEventBrowserGui( QWidget* parent, QgisInterface* interface, Qt::WindowFlags fl );
 
     /** \brief Constructor called when new browser is requested by the eVisEventIdTool */
-    eVisGenericEventBrowserGui( QWidget* parent, QgsMapCanvas* canvas, Qt::WFlags fl );
+    eVisGenericEventBrowserGui( QWidget* parent, QgsMapCanvas* canvas, Qt::WindowFlags fl );
 
     /** \Brief Destructor */
     ~eVisGenericEventBrowserGui( );

--- a/src/plugins/evis/eventbrowser/evisimagedisplaywidget.cpp
+++ b/src/plugins/evis/eventbrowser/evisimagedisplaywidget.cpp
@@ -37,7 +37,7 @@
 * @param parent - Pointer the to parent QWidget for modality
 * @param fl - Windown flags
 */
-eVisImageDisplayWidget::eVisImageDisplayWidget( QWidget* parent, Qt::WFlags fl ) : QWidget( parent, fl )
+eVisImageDisplayWidget::eVisImageDisplayWidget( QWidget* parent, Qt::WindowFlags fl ) : QWidget( parent, fl )
 {
   //Setup zoom buttons
   pbtnZoomIn = new QPushButton( );

--- a/src/plugins/evis/eventbrowser/evisimagedisplaywidget.h
+++ b/src/plugins/evis/eventbrowser/evisimagedisplaywidget.h
@@ -49,7 +49,7 @@ class eVisImageDisplayWidget : public QWidget
 
   public:
     /** \brief Constructor */
-    eVisImageDisplayWidget( QWidget* parent = 0, Qt::WFlags fl = 0 );
+    eVisImageDisplayWidget( QWidget* parent = 0, Qt::WindowFlags fl = 0 );
 
     /** \brief Destructor */
     ~eVisImageDisplayWidget();

--- a/src/plugins/georeferencer/qgsgeorefplugingui.cpp
+++ b/src/plugins/georeferencer/qgsgeorefplugingui.cpp
@@ -71,7 +71,7 @@ QgsGeorefDockWidget::QgsGeorefDockWidget( const QString & title, QWidget * paren
   setObjectName( "GeorefDockWidget" ); // set object name so the position can be saved
 }
 
-QgsGeorefPluginGui::QgsGeorefPluginGui( QgisInterface* theQgisInterface, QWidget* parent, Qt::WFlags fl )
+QgsGeorefPluginGui::QgsGeorefPluginGui( QgisInterface* theQgisInterface, QWidget* parent, Qt::WindowFlags fl )
     : QMainWindow( parent, fl )
     , mMousePrecisionDecimalPlaces( 0 )
     , mTransformParam( QgsGeorefTransform::InvalidTransform )

--- a/src/plugins/georeferencer/qgsgeorefplugingui.h
+++ b/src/plugins/georeferencer/qgsgeorefplugingui.h
@@ -50,7 +50,7 @@ class QgsGeorefPluginGui : public QMainWindow, private Ui::QgsGeorefPluginGuiBas
     Q_OBJECT
 
   public:
-    QgsGeorefPluginGui( QgisInterface* theQgisInterface, QWidget* parent = 0, Qt::WFlags fl = 0 );
+    QgsGeorefPluginGui( QgisInterface* theQgisInterface, QWidget* parent = 0, Qt::WindowFlags fl = 0 );
     ~QgsGeorefPluginGui();
 
   protected:

--- a/src/plugins/globe/globe_plugin_dialog.cpp
+++ b/src/plugins/globe/globe_plugin_dialog.cpp
@@ -38,7 +38,7 @@
 #include <osg/DisplaySettings>
 
 //constructor
-QgsGlobePluginDialog::QgsGlobePluginDialog( QWidget* parent, GlobePlugin* globe, Qt::WFlags fl )
+QgsGlobePluginDialog::QgsGlobePluginDialog( QWidget* parent, GlobePlugin* globe, Qt::WindowFlags fl )
     : QDialog( parent, fl )
     , mGlobe( globe )
 {

--- a/src/plugins/globe/globe_plugin_dialog.h
+++ b/src/plugins/globe/globe_plugin_dialog.h
@@ -31,7 +31,7 @@ class QgsGlobePluginDialog: public QDialog, private Ui::QgsGlobePluginDialogGuiB
     Q_OBJECT
 
   public:
-    QgsGlobePluginDialog( QWidget * parent, GlobePlugin* globe, Qt::WFlags fl = 0 );
+    QgsGlobePluginDialog( QWidget * parent, GlobePlugin* globe, Qt::WindowFlags fl = 0 );
     ~QgsGlobePluginDialog();
     void resetElevationDatasources();
     void readElevationDatasources();

--- a/src/plugins/gps_importer/qgsgpsplugingui.cpp
+++ b/src/plugins/gps_importer/qgsgpsplugingui.cpp
@@ -28,7 +28,7 @@
 QgsGPSPluginGui::QgsGPSPluginGui( const BabelMap& importers,
                                   std::map<QString, QgsGPSDevice*>& devices,
                                   std::vector<QgsVectorLayer*> gpxMapLayers,
-                                  QWidget* parent, Qt::WFlags fl )
+                                  QWidget* parent, Qt::WindowFlags fl )
     : QDialog( parent, fl )
     , mGPXLayers( gpxMapLayers )
     , mImporters( importers )

--- a/src/plugins/gps_importer/qgsgpsplugingui.h
+++ b/src/plugins/gps_importer/qgsgpsplugingui.h
@@ -39,7 +39,7 @@ class QgsGPSPluginGui : public QDialog, private Ui::QgsGPSPluginGuiBase
     QgsGPSPluginGui( const BabelMap& importers,
                      std::map<QString, QgsGPSDevice*>& devices,
                      std::vector<QgsVectorLayer*> gpxMapLayers,
-                     QWidget* parent, Qt::WFlags );
+                     QWidget* parent, Qt::WindowFlags );
     ~QgsGPSPluginGui();
 
   public slots:

--- a/src/plugins/grass/qgsgrassattributes.cpp
+++ b/src/plugins/grass/qgsgrassattributes.cpp
@@ -53,7 +53,7 @@ bool QgsGrassAttributesKeyPress::eventFilter( QObject *o, QEvent *e )
 }
 
 QgsGrassAttributes::QgsGrassAttributes( QgsGrassEdit *edit, QgsGrassProvider *provider, int line,
-                                        QWidget * parent, const char * name, Qt::WFlags f )
+                                        QWidget * parent, const char * name, Qt::WindowFlags f )
     : QDialog( parent, f ), QgsGrassAttributesBase()
 {
   Q_UNUSED( name );

--- a/src/plugins/grass/qgsgrassattributes.h
+++ b/src/plugins/grass/qgsgrassattributes.h
@@ -55,8 +55,8 @@ class QgsGrassAttributes: public QDialog, private Ui::QgsGrassAttributesBase
     //! Constructor
     QgsGrassAttributes( QgsGrassEdit *edit, QgsGrassProvider *provider, int line,
                         QWidget * parent = 0, const char * name = 0,
-                        Qt::WFlags f = Qt::Window );
-    //Qt::WFlags f = Qt::WStyle_Customize | Qt::WStyle_DialogBorder | Qt::WStyle_Title | Qt::WType_Dialog | Qt::WStyle_Tool);
+                        Qt::WindowFlags f = Qt::Window );
+    //Qt::WindowFlags f = Qt::WStyle_Customize | Qt::WStyle_DialogBorder | Qt::WStyle_Title | Qt::WType_Dialog | Qt::WStyle_Tool);
 
     //! Destructor
     ~QgsGrassAttributes();

--- a/src/plugins/grass/qgsgrassbrowser.cpp
+++ b/src/plugins/grass/qgsgrassbrowser.cpp
@@ -39,7 +39,7 @@
 
 
 QgsGrassBrowser::QgsGrassBrowser( QgisInterface *iface,
-                                  QWidget * parent, Qt::WFlags f )
+                                  QWidget * parent, Qt::WindowFlags f )
     : QMainWindow( parent, Qt::Dialog ), mIface( iface ), mRunningMods( 0 )
 {
   Q_UNUSED( f );

--- a/src/plugins/grass/qgsgrassbrowser.h
+++ b/src/plugins/grass/qgsgrassbrowser.h
@@ -37,7 +37,7 @@ class QgsGrassBrowser: public QMainWindow
 
   public:
     //! Constructor
-    QgsGrassBrowser( QgisInterface *iface, QWidget * parent = 0, Qt::WFlags f = 0 );
+    QgsGrassBrowser( QgisInterface *iface, QWidget * parent = 0, Qt::WindowFlags f = 0 );
 
     //! Destructor
     ~QgsGrassBrowser();

--- a/src/plugins/grass/qgsgrassedit.cpp
+++ b/src/plugins/grass/qgsgrassedit.cpp
@@ -144,7 +144,7 @@ void QgsGrassEditAttributeTableItemDelegate::setModelData( QWidget *editor,
 bool QgsGrassEdit::mRunning = false;
 
 QgsGrassEdit::QgsGrassEdit( QgisInterface *iface, QgsMapLayer* layer, bool newMap,
-                            QWidget * parent, Qt::WFlags f )
+                            QWidget * parent, Qt::WindowFlags f )
     : QMainWindow( parent, f ), QgsGrassEditBase(), mInited( false ),
     mMapTool( 0 ), mCanvasEdit( 0 ), mRubberBandLine( 0 ), mRubberBandIcon( 0 )
 {

--- a/src/plugins/grass/qgsgrassedit.h
+++ b/src/plugins/grass/qgsgrassedit.h
@@ -120,7 +120,7 @@ class QgsGrassEdit: public QMainWindow, private Ui::QgsGrassEditBase
     //! Constructor
     QgsGrassEdit( QgisInterface *iface,
                   QgsMapLayer *layer, bool newMap,
-                  QWidget * parent = 0, Qt::WFlags f = 0 );
+                  QWidget * parent = 0, Qt::WindowFlags f = 0 );
 
     // Shared by constructors
     void init();

--- a/src/plugins/grass/qgsgrassmapcalc.cpp
+++ b/src/plugins/grass/qgsgrassmapcalc.cpp
@@ -39,7 +39,7 @@
 QgsGrassMapcalc::QgsGrassMapcalc(
   QgsGrassTools *tools, QgsGrassModule *module,
   QgisInterface *iface,
-  QWidget * parent, Qt::WFlags f )
+  QWidget * parent, Qt::WindowFlags f )
     : QMainWindow( iface->mainWindow(), Qt::Dialog )
     , QgsGrassMapcalcBase( )
     , QgsGrassModuleOptions( tools, module, iface, false )
@@ -2135,7 +2135,7 @@ QgsGrassMapcalcFunction::QgsGrassMapcalcFunction( int type, QString name,
 /******************** CANVAS VIEW ******************************/
 
 QgsGrassMapcalcView::QgsGrassMapcalcView( QgsGrassMapcalc * mapcalc,
-    QWidget * parent, Qt::WFlags f ) :
+    QWidget * parent, Qt::WindowFlags f ) :
     QGraphicsView( parent )
 {
   Q_UNUSED( f );

--- a/src/plugins/grass/qgsgrassmapcalc.h
+++ b/src/plugins/grass/qgsgrassmapcalc.h
@@ -40,7 +40,7 @@ class QgsGrassMapcalc: public QMainWindow, private Ui::QgsGrassMapcalcBase,
     QgsGrassMapcalc(
       QgsGrassTools *tools, QgsGrassModule *module,
       QgisInterface *iface,
-      QWidget * parent = 0, Qt::WFlags f = 0 );
+      QWidget * parent = 0, Qt::WindowFlags f = 0 );
 
     //! Destructor
     ~QgsGrassMapcalc();
@@ -525,7 +525,7 @@ class QgsGrassMapcalcView: public QGraphicsView
     Q_OBJECT
 
   public:
-    QgsGrassMapcalcView( QgsGrassMapcalc * mapcalc, QWidget * parent = 0, Qt::WFlags f = 0 );
+    QgsGrassMapcalcView( QgsGrassMapcalc * mapcalc, QWidget * parent = 0, Qt::WindowFlags f = 0 );
 
   protected:
     void mousePressEvent( QMouseEvent * e );

--- a/src/plugins/grass/qgsgrassmodule.cpp
+++ b/src/plugins/grass/qgsgrassmodule.cpp
@@ -149,7 +149,7 @@ QStringList QgsGrassModule::execArguments( QString module )
 }
 
 QgsGrassModule::QgsGrassModule( QgsGrassTools *tools, QString moduleName, QgisInterface *iface,
-                                QString path, bool direct, QWidget * parent, Qt::WFlags f )
+                                QString path, bool direct, QWidget * parent, Qt::WindowFlags f )
     : QgsGrassModuleBase( ), mSuccess( false ), mDirect( direct )
 {
   Q_UNUSED( f );
@@ -308,7 +308,7 @@ QgsGrassModuleStandardOptions::QgsGrassModuleStandardOptions(
   QgsGrassTools *tools, QgsGrassModule *module,
   QgisInterface *iface,
   QString xname, QDomElement qDocElem,
-  bool direct, QWidget * parent, Qt::WFlags f )
+  bool direct, QWidget * parent, Qt::WindowFlags f )
     : QWidget( parent, f ),
     QgsGrassModuleOptions( tools, module, iface, direct )
 {

--- a/src/plugins/grass/qgsgrassmodule.h
+++ b/src/plugins/grass/qgsgrassmodule.h
@@ -64,7 +64,7 @@ class QgsGrassModule: public QDialog, private  Ui::QgsGrassModuleBase
 
     //! Constructor
     QgsGrassModule( QgsGrassTools *tools, QString moduleName, QgisInterface *iface,
-                    QString path, bool direct, QWidget *parent, Qt::WFlags f = 0 );
+                    QString path, bool direct, QWidget *parent, Qt::WindowFlags f = 0 );
 
     //! Destructor
     ~QgsGrassModule();
@@ -299,7 +299,7 @@ class QgsGrassModuleStandardOptions: QWidget, public QgsGrassModuleOptions
       QgsGrassTools *tools, QgsGrassModule *module,
       QgisInterface *iface,
       QString xname, QDomElement docElem,
-      bool direct, QWidget * parent = 0, Qt::WFlags f = 0 );
+      bool direct, QWidget * parent = 0, Qt::WindowFlags f = 0 );
 
     //! Destructor
     ~QgsGrassModuleStandardOptions();

--- a/src/plugins/grass/qgsgrassnewmapset.cpp
+++ b/src/plugins/grass/qgsgrassnewmapset.cpp
@@ -55,7 +55,7 @@ bool QgsGrassNewMapset::mRunning = false;
 
 QgsGrassNewMapset::QgsGrassNewMapset( QgisInterface *iface,
                                       QgsGrassPlugin *plugin, QWidget * parent,
-                                      Qt::WFlags f ) :
+                                      Qt::WindowFlags f ) :
     QWizard( parent, f ),
     QgsGrassNewMapsetBase( )
 {

--- a/src/plugins/grass/qgsgrassnewmapset.h
+++ b/src/plugins/grass/qgsgrassnewmapset.h
@@ -53,7 +53,7 @@ class QgsGrassNewMapset : public QWizard, private Ui::QgsGrassNewMapsetBase
     //! Constructor
     QgsGrassNewMapset( QgisInterface *iface,
                        QgsGrassPlugin *plugin,
-                       QWidget * parent = 0, Qt::WFlags f = 0 );
+                       QWidget * parent = 0, Qt::WindowFlags f = 0 );
 
     //! Destructor
     ~QgsGrassNewMapset();

--- a/src/plugins/grass/qgsgrassregion.cpp
+++ b/src/plugins/grass/qgsgrassregion.cpp
@@ -192,7 +192,7 @@ void QgsGrassRegionEdit::setSrcRegion( const QgsRectangle &rect )
 }
 
 QgsGrassRegion::QgsGrassRegion( QgsGrassPlugin *plugin,  QgisInterface *iface,
-                                QWidget * parent, Qt::WFlags f )
+                                QWidget * parent, Qt::WindowFlags f )
     : QDialog( parent, f ), QgsGrassRegionBase( )
 {
   QgsDebugMsg( "QgsGrassRegion()" );

--- a/src/plugins/grass/qgsgrassregion.h
+++ b/src/plugins/grass/qgsgrassregion.h
@@ -48,7 +48,7 @@ class QgsGrassRegion: public QDialog, private Ui::QgsGrassRegionBase
   public:
     //! Constructor
     QgsGrassRegion( QgsGrassPlugin *plugin, QgisInterface *iface,
-                    QWidget * parent = 0, Qt::WFlags f = 0 );
+                    QWidget * parent = 0, Qt::WindowFlags f = 0 );
 
     //! Destructor
     ~QgsGrassRegion();

--- a/src/plugins/grass/qgsgrasstools.cpp
+++ b/src/plugins/grass/qgsgrasstools.cpp
@@ -45,7 +45,7 @@
 
 
 QgsGrassTools::QgsGrassTools( QgisInterface *iface,
-                              QWidget * parent, const char * name, Qt::WFlags f )
+                              QWidget * parent, const char * name, Qt::WindowFlags f )
     : QDialog( parent, f ), QgsGrassToolsBase()
     , mBrowser( 0 )
     , mModulesListModel( 0 ), mModelProxy( 0 ), mDirectModulesListModel( 0 ), mDirectModelProxy( 0 )

--- a/src/plugins/grass/qgsgrasstools.h
+++ b/src/plugins/grass/qgsgrasstools.h
@@ -43,7 +43,7 @@ class QgsGrassTools: public QDialog, private Ui::QgsGrassToolsBase
   public:
     //! Constructor
     QgsGrassTools( QgisInterface *iface,
-                   QWidget * parent = 0, const char * name = 0, Qt::WFlags f = 0 );
+                   QWidget * parent = 0, const char * name = 0, Qt::WindowFlags f = 0 );
 
     //! Destructor
     ~QgsGrassTools();

--- a/src/plugins/heatmap/heatmapgui.cpp
+++ b/src/plugins/heatmap/heatmapgui.cpp
@@ -36,7 +36,7 @@
 
 //standard includes
 
-HeatmapGui::HeatmapGui( QWidget* parent, Qt::WFlags fl, QMap<QString, QVariant>* temporarySettings )
+HeatmapGui::HeatmapGui( QWidget* parent, Qt::WindowFlags fl, QMap<QString, QVariant>* temporarySettings )
     : QDialog( parent, fl ),
     mRows( 500 )
 {

--- a/src/plugins/heatmap/heatmapgui.h
+++ b/src/plugins/heatmap/heatmapgui.h
@@ -25,7 +25,7 @@ class HeatmapGui : public QDialog, private Ui::HeatmapGuiBase
 {
     Q_OBJECT
   public:
-    HeatmapGui( QWidget* parent, Qt::WFlags fl, QMap<QString, QVariant>* temporarySettings );
+    HeatmapGui( QWidget* parent, Qt::WindowFlags fl, QMap<QString, QVariant>* temporarySettings );
     ~HeatmapGui();
 
     // Buffer unit type

--- a/src/plugins/offline_editing/offline_editing_plugin_gui.cpp
+++ b/src/plugins/offline_editing/offline_editing_plugin_gui.cpp
@@ -28,7 +28,7 @@
 #include <QMessageBox>
 #include <QSettings>
 
-QgsOfflineEditingPluginGui::QgsOfflineEditingPluginGui( QWidget* parent /*= 0*/, Qt::WFlags fl /*= 0*/ )
+QgsOfflineEditingPluginGui::QgsOfflineEditingPluginGui( QWidget* parent /*= 0*/, Qt::WindowFlags fl /*= 0*/ )
     : QDialog( parent, fl )
 {
   setupUi( this );

--- a/src/plugins/offline_editing/offline_editing_plugin_gui.h
+++ b/src/plugins/offline_editing/offline_editing_plugin_gui.h
@@ -27,7 +27,7 @@ class QgsOfflineEditingPluginGui : public QDialog, private Ui::QgsOfflineEditing
     Q_OBJECT
 
   public:
-    QgsOfflineEditingPluginGui( QWidget* parent = 0, Qt::WFlags fl = 0 );
+    QgsOfflineEditingPluginGui( QWidget* parent = 0, Qt::WindowFlags fl = 0 );
     virtual ~QgsOfflineEditingPluginGui();
 
     QString offlineDataPath();

--- a/src/plugins/offline_editing/offline_editing_progress_dialog.cpp
+++ b/src/plugins/offline_editing/offline_editing_progress_dialog.cpp
@@ -18,7 +18,7 @@
 
 #include "offline_editing_progress_dialog.h"
 
-QgsOfflineEditingProgressDialog::QgsOfflineEditingProgressDialog( QWidget* parent /*= 0*/, Qt::WFlags fl /*= 0*/ )
+QgsOfflineEditingProgressDialog::QgsOfflineEditingProgressDialog( QWidget* parent /*= 0*/, Qt::WindowFlags fl /*= 0*/ )
     : QDialog( parent, fl )
 {
   setupUi( this );

--- a/src/plugins/offline_editing/offline_editing_progress_dialog.h
+++ b/src/plugins/offline_editing/offline_editing_progress_dialog.h
@@ -27,7 +27,7 @@ class QgsOfflineEditingProgressDialog : public QDialog, private Ui::QgsOfflineEd
     Q_OBJECT
 
   public:
-    QgsOfflineEditingProgressDialog( QWidget* parent = 0, Qt::WFlags fl = 0 );
+    QgsOfflineEditingProgressDialog( QWidget* parent = 0, Qt::WindowFlags fl = 0 );
     virtual ~QgsOfflineEditingProgressDialog();
 
     void setTitle( const QString& title );

--- a/src/plugins/oracle_raster/qgsoracleconnect_ui.cpp
+++ b/src/plugins/oracle_raster/qgsoracleconnect_ui.cpp
@@ -21,7 +21,7 @@
 
 QgsOracleConnect::QgsOracleConnect( QWidget* parent,
                                     const QString& connName,
-                                    Qt::WFlags fl ) : QDialog( parent, fl )
+                                    Qt::WindowFlags fl ) : QDialog( parent, fl )
 {
   setupUi( this );
 

--- a/src/plugins/oracle_raster/qgsoracleconnect_ui.h
+++ b/src/plugins/oracle_raster/qgsoracleconnect_ui.h
@@ -29,7 +29,7 @@ class QgsOracleConnect : public QDialog, private Ui::OracleConnectGuiBase
   public:
     QgsOracleConnect( QWidget* parent = 0,
                       const QString& connName = QString::null,
-                      Qt::WFlags fl = QgisGui::ModalDialogFlags );
+                      Qt::WindowFlags fl = QgisGui::ModalDialogFlags );
     ~QgsOracleConnect();
 
   private:

--- a/src/plugins/oracle_raster/qgsselectgeoraster_ui.cpp
+++ b/src/plugins/oracle_raster/qgsselectgeoraster_ui.cpp
@@ -33,7 +33,7 @@
 
 QgsOracleSelectGeoraster::QgsOracleSelectGeoraster( QWidget* parent,
     QgisInterface* iface,
-    Qt::WFlags fl ) : QDialog( parent, fl ), mIface( iface )
+    Qt::WindowFlags fl ) : QDialog( parent, fl ), mIface( iface )
 {
   setupUi( this );
 

--- a/src/plugins/oracle_raster/qgsselectgeoraster_ui.h
+++ b/src/plugins/oracle_raster/qgsselectgeoraster_ui.h
@@ -34,7 +34,7 @@ class QgsOracleSelectGeoraster : public QDialog, private Ui::SelectGeoRasterBase
     Q_OBJECT
 
   public:
-    QgsOracleSelectGeoraster( QWidget* parent, QgisInterface* iface, Qt::WFlags fl = 0 );
+    QgsOracleSelectGeoraster( QWidget* parent, QgisInterface* iface, Qt::WindowFlags fl = 0 );
     ~QgsOracleSelectGeoraster();
 
   private:

--- a/src/plugins/plugin_template/plugingui.cpp
+++ b/src/plugins/plugin_template/plugingui.cpp
@@ -16,7 +16,7 @@
 
 //standard includes
 
-[pluginname]Gui::[pluginname]Gui( QWidget* parent, Qt::WFlags fl )
+[pluginname]Gui::[pluginname]Gui( QWidget* parent, Qt::WindowFlags fl )
     : QDialog( parent, fl )
 {
   setupUi( this );

--- a/src/plugins/plugin_template/plugingui.h
+++ b/src/plugins/plugin_template/plugingui.h
@@ -22,7 +22,7 @@ class [pluginname]Gui : public QDialog, private Ui::[pluginname]GuiBase
 {
     Q_OBJECT
   public:
-    [pluginname]Gui( QWidget* parent = 0, Qt::WFlags fl = 0 );
+    [pluginname]Gui( QWidget* parent = 0, Qt::WindowFlags fl = 0 );
     ~[pluginname]Gui();
 
   private:

--- a/src/plugins/roadgraph/exportdlg.cpp
+++ b/src/plugins/roadgraph/exportdlg.cpp
@@ -27,7 +27,7 @@
 
 //standard includes
 
-RgExportDlg::RgExportDlg( QWidget* parent, Qt::WFlags fl )
+RgExportDlg::RgExportDlg( QWidget* parent, Qt::WindowFlags fl )
     : QDialog( parent, fl )
 {
   // create base widgets;

--- a/src/plugins/roadgraph/exportdlg.h
+++ b/src/plugins/roadgraph/exportdlg.h
@@ -36,7 +36,7 @@ class RgExportDlg : public QDialog
 {
     Q_OBJECT
   public:
-    RgExportDlg( QWidget* parent = 0, Qt::WFlags fl = 0 );
+    RgExportDlg( QWidget* parent = 0, Qt::WindowFlags fl = 0 );
     ~RgExportDlg();
 
   public:

--- a/src/plugins/roadgraph/settingsdlg.cpp
+++ b/src/plugins/roadgraph/settingsdlg.cpp
@@ -25,7 +25,7 @@
 
 //standard includes
 
-RgSettingsDlg::RgSettingsDlg( RgSettings *settings, QWidget* parent, Qt::WFlags fl )
+RgSettingsDlg::RgSettingsDlg( RgSettings *settings, QWidget* parent, Qt::WindowFlags fl )
     : QDialog( parent, fl )
     , mSettings( settings )
 {

--- a/src/plugins/roadgraph/settingsdlg.h
+++ b/src/plugins/roadgraph/settingsdlg.h
@@ -37,7 +37,7 @@ class RgSettingsDlg : public QDialog
 {
     Q_OBJECT
   public:
-    RgSettingsDlg( RgSettings *settings, QWidget* parent = 0, Qt::WFlags fl = 0 );
+    RgSettingsDlg( RgSettings *settings, QWidget* parent = 0, Qt::WindowFlags fl = 0 );
     ~RgSettingsDlg();
 
     QString timeUnitName();

--- a/src/plugins/spit/qgsspit.cpp
+++ b/src/plugins/spit/qgsspit.cpp
@@ -39,7 +39,7 @@
 #include "qgslogger.h"
 
 
-QgsSpit::QgsSpit( QWidget *parent, Qt::WFlags fl ) : QDialog( parent, fl )
+QgsSpit::QgsSpit( QWidget *parent, Qt::WindowFlags fl ) : QDialog( parent, fl )
 {
   setupUi( this );
 

--- a/src/plugins/spit/qgsspit.h
+++ b/src/plugins/spit/qgsspit.h
@@ -38,7 +38,7 @@ class QgsSpit : public QDialog, private Ui::QgsSpitBase
 {
     Q_OBJECT
   public:
-    QgsSpit( QWidget *parent = 0, Qt::WFlags fl = 0 );
+    QgsSpit( QWidget *parent = 0, Qt::WindowFlags fl = 0 );
     ~QgsSpit();
     //! Populate the list of available database connections
     void populateConnectionList();

--- a/src/plugins/sqlanywhere/sanewconnection.cpp
+++ b/src/plugins/sqlanywhere/sanewconnection.cpp
@@ -28,7 +28,7 @@
 #include "qgslogger.h"
 #include "qgscredentialdialog.h"
 
-SaNewConnection::SaNewConnection( QWidget *parent, const QString& connName, Qt::WFlags fl )
+SaNewConnection::SaNewConnection( QWidget *parent, const QString& connName, Qt::WindowFlags fl )
     : QDialog( parent, fl ), mOriginalConnName( connName )
 {
   setupUi( this );

--- a/src/plugins/sqlanywhere/sanewconnection.h
+++ b/src/plugins/sqlanywhere/sanewconnection.h
@@ -31,7 +31,7 @@ class SaNewConnection : public QDialog, private Ui::SaNewConnectionBase
     Q_OBJECT
   public:
     //! Constructor
-    SaNewConnection( QWidget *parent = 0, const QString& connName = QString::null, Qt::WFlags fl = QgisGui::ModalDialogFlags );
+    SaNewConnection( QWidget *parent = 0, const QString& connName = QString::null, Qt::WindowFlags fl = QgisGui::ModalDialogFlags );
     //! Destructor
     ~SaNewConnection();
     //! Tests the connection using the parameters supplied

--- a/src/plugins/sqlanywhere/sasourceselect.cpp
+++ b/src/plugins/sqlanywhere/sasourceselect.cpp
@@ -52,7 +52,7 @@ quotedIdentifier( QString id )
 } // quotedIdentifier()
 
 
-SaSourceSelect::SaSourceSelect( QWidget *parent, Qt::WFlags fl )
+SaSourceSelect::SaSourceSelect( QWidget *parent, Qt::WindowFlags fl )
     : QDialog( parent, fl ), mColumnTypeThread( NULL )
 {
   setupUi( this );

--- a/src/plugins/sqlanywhere/sasourceselect.h
+++ b/src/plugins/sqlanywhere/sasourceselect.h
@@ -101,7 +101,7 @@ class SaSourceSelect : public QDialog, private Ui::SaSourceSelectBase
   public:
 
     //! Constructor
-    SaSourceSelect( QWidget *parent = 0, Qt::WFlags fl = QgisGui::ModalDialogFlags );
+    SaSourceSelect( QWidget *parent = 0, Qt::WindowFlags fl = QgisGui::ModalDialogFlags );
     //! Destructor
     ~SaSourceSelect();
     //! Populate the connection list combo box

--- a/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
@@ -1156,7 +1156,7 @@ QGISEXTERN bool isProvider()
   return true;
 }
 
-QGISEXTERN QgsDelimitedTextSourceSelect *selectWidget( QWidget *parent, Qt::WFlags fl )
+QGISEXTERN QgsDelimitedTextSourceSelect *selectWidget( QWidget *parent, Qt::WindowFlags fl )
 {
   return new QgsDelimitedTextSourceSelect( parent, fl );
 }

--- a/src/providers/delimitedtext/qgsdelimitedtextsourceselect.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextsourceselect.cpp
@@ -33,7 +33,7 @@
 
 const int MAX_SAMPLE_LENGTH = 200;
 
-QgsDelimitedTextSourceSelect::QgsDelimitedTextSourceSelect( QWidget * parent, Qt::WFlags fl, bool embedded ):
+QgsDelimitedTextSourceSelect::QgsDelimitedTextSourceSelect( QWidget * parent, Qt::WindowFlags fl, bool embedded ):
     QDialog( parent, fl ),
     mFile( new QgsDelimitedTextFile() ),
     mExampleRowCount( 20 ),

--- a/src/providers/delimitedtext/qgsdelimitedtextsourceselect.h
+++ b/src/providers/delimitedtext/qgsdelimitedtextsourceselect.h
@@ -31,7 +31,7 @@ class QgsDelimitedTextSourceSelect : public QDialog, private Ui::QgsDelimitedTex
     Q_OBJECT
 
   public:
-    QgsDelimitedTextSourceSelect( QWidget * parent, Qt::WFlags fl = QgisGui::ModalDialogFlags, bool embedded = false );
+    QgsDelimitedTextSourceSelect( QWidget * parent, Qt::WindowFlags fl = QgisGui::ModalDialogFlags, bool embedded = false );
     ~QgsDelimitedTextSourceSelect();
 
     QStringList splitLine( QString line );

--- a/src/providers/mssql/qgsmssqlnewconnection.cpp
+++ b/src/providers/mssql/qgsmssqlnewconnection.cpp
@@ -26,7 +26,7 @@
 #include "qgsmssqlprovider.h"
 #include "qgscontexthelp.h"
 
-QgsMssqlNewConnection::QgsMssqlNewConnection( QWidget *parent, const QString& connName, Qt::WFlags fl )
+QgsMssqlNewConnection::QgsMssqlNewConnection( QWidget *parent, const QString& connName, Qt::WindowFlags fl )
     : QDialog( parent, fl ), mOriginalConnName( connName )
 {
   setupUi( this );

--- a/src/providers/mssql/qgsmssqlnewconnection.h
+++ b/src/providers/mssql/qgsmssqlnewconnection.h
@@ -29,7 +29,7 @@ class QgsMssqlNewConnection : public QDialog, private Ui::QgsMssqlNewConnectionB
     Q_OBJECT
   public:
     //! Constructor
-    QgsMssqlNewConnection( QWidget *parent = 0, const QString& connName = QString::null, Qt::WFlags fl = QgisGui::ModalDialogFlags );
+    QgsMssqlNewConnection( QWidget *parent = 0, const QString& connName = QString::null, Qt::WindowFlags fl = QgisGui::ModalDialogFlags );
     //! Destructor
     ~QgsMssqlNewConnection();
     //! Tests the connection using the parameters supplied

--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -1803,7 +1803,7 @@ QGISEXTERN bool isProvider()
   return true;
 }
 
-QGISEXTERN void *selectWidget( QWidget *parent, Qt::WFlags fl )
+QGISEXTERN void *selectWidget( QWidget *parent, Qt::WindowFlags fl )
 {
   return new QgsMssqlSourceSelect( parent, fl );
 }

--- a/src/providers/mssql/qgsmssqlsourceselect.cpp
+++ b/src/providers/mssql/qgsmssqlsourceselect.cpp
@@ -117,7 +117,7 @@ void QgsMssqlSourceSelectDelegate::setModelData( QWidget *editor, QAbstractItemM
     model->setData( index, le->text() );
 }
 
-QgsMssqlSourceSelect::QgsMssqlSourceSelect( QWidget *parent, Qt::WFlags fl, bool managerMode, bool embeddedMode )
+QgsMssqlSourceSelect::QgsMssqlSourceSelect( QWidget *parent, Qt::WindowFlags fl, bool managerMode, bool embeddedMode )
     : QDialog( parent, fl )
     , mManagerMode( managerMode )
     , mEmbeddedMode( embeddedMode )

--- a/src/providers/mssql/qgsmssqlsourceselect.h
+++ b/src/providers/mssql/qgsmssqlsourceselect.h
@@ -95,7 +95,7 @@ class QgsMssqlSourceSelect : public QDialog, private Ui::QgsDbSourceSelectBase
     static void deleteConnection( QString key );
 
     //! Constructor
-    QgsMssqlSourceSelect( QWidget *parent = 0, Qt::WFlags fl = QgisGui::ModalDialogFlags, bool managerMode = false, bool embeddedMode = false );
+    QgsMssqlSourceSelect( QWidget *parent = 0, Qt::WindowFlags fl = QgisGui::ModalDialogFlags, bool managerMode = false, bool embeddedMode = false );
     //! Destructor
     ~QgsMssqlSourceSelect();
     //! Populate the connection list combo box

--- a/src/providers/oracle/qgsoraclenewconnection.cpp
+++ b/src/providers/oracle/qgsoraclenewconnection.cpp
@@ -24,7 +24,7 @@
 #include "qgsdatasourceuri.h"
 #include "qgsoracletablemodel.h"
 
-QgsOracleNewConnection::QgsOracleNewConnection( QWidget *parent, const QString& connName, Qt::WFlags fl )
+QgsOracleNewConnection::QgsOracleNewConnection( QWidget *parent, const QString& connName, Qt::WindowFlags fl )
     : QDialog( parent, fl ), mOriginalConnName( connName )
 {
   setupUi( this );

--- a/src/providers/oracle/qgsoraclenewconnection.h
+++ b/src/providers/oracle/qgsoraclenewconnection.h
@@ -29,7 +29,7 @@ class QgsOracleNewConnection : public QDialog, private Ui::QgsOracleNewConnectio
     Q_OBJECT
   public:
     //! Constructor
-    QgsOracleNewConnection( QWidget *parent = 0, const QString& connName = QString::null, Qt::WFlags fl = QgisGui::ModalDialogFlags );
+    QgsOracleNewConnection( QWidget *parent = 0, const QString& connName = QString::null, Qt::WindowFlags fl = QgisGui::ModalDialogFlags );
     //! Destructor
     ~QgsOracleNewConnection();
   public slots:

--- a/src/providers/oracle/qgsoracleprovider.cpp
+++ b/src/providers/oracle/qgsoracleprovider.cpp
@@ -2835,7 +2835,7 @@ QGISEXTERN bool isProvider()
   return true;
 }
 
-QGISEXTERN QgsOracleSourceSelect *selectWidget( QWidget *parent, Qt::WFlags fl )
+QGISEXTERN QgsOracleSourceSelect *selectWidget( QWidget *parent, Qt::WindowFlags fl )
 {
   return new QgsOracleSourceSelect( parent, fl );
 }

--- a/src/providers/oracle/qgsoraclesourceselect.cpp
+++ b/src/providers/oracle/qgsoraclesourceselect.cpp
@@ -164,7 +164,7 @@ void QgsOracleSourceSelectDelegate::setModelData( QWidget *editor, QAbstractItem
   }
 }
 
-QgsOracleSourceSelect::QgsOracleSourceSelect( QWidget *parent, Qt::WFlags fl, bool managerMode, bool embeddedMode )
+QgsOracleSourceSelect::QgsOracleSourceSelect( QWidget *parent, Qt::WindowFlags fl, bool managerMode, bool embeddedMode )
     : QDialog( parent, fl )
     , mManagerMode( managerMode )
     , mEmbeddedMode( embeddedMode )

--- a/src/providers/oracle/qgsoraclesourceselect.h
+++ b/src/providers/oracle/qgsoraclesourceselect.h
@@ -73,7 +73,7 @@ class QgsOracleSourceSelect : public QDialog, private Ui::QgsDbSourceSelectBase
 
   public:
     //! Constructor
-    QgsOracleSourceSelect( QWidget *parent = 0, Qt::WFlags fl = QgisGui::ModalDialogFlags, bool managerMode = false, bool embeddedMode = false );
+    QgsOracleSourceSelect( QWidget *parent = 0, Qt::WindowFlags fl = QgisGui::ModalDialogFlags, bool managerMode = false, bool embeddedMode = false );
     //! Destructor
     ~QgsOracleSourceSelect();
     //! Populate the connection list combo box

--- a/src/providers/ows/qgsowsdataitems.cpp
+++ b/src/providers/ows/qgsowsdataitems.cpp
@@ -250,8 +250,8 @@ QGISEXTERN QgsDataItem * dataItem( QString thePath, QgsDataItem* parentItem )
   return 0;
 }
 
-//QGISEXTERN QgsOWSSourceSelect * selectWidget( QWidget * parent, Qt::WFlags fl )
-QGISEXTERN QDialog * selectWidget( QWidget * parent, Qt::WFlags fl )
+//QGISEXTERN QgsOWSSourceSelect * selectWidget( QWidget * parent, Qt::WindowFlags fl )
+QGISEXTERN QDialog * selectWidget( QWidget * parent, Qt::WindowFlags fl )
 {
   Q_UNUSED( parent );
   Q_UNUSED( fl );

--- a/src/providers/postgres/qgspgnewconnection.cpp
+++ b/src/providers/postgres/qgspgnewconnection.cpp
@@ -24,7 +24,7 @@
 #include "qgsdatasourceuri.h"
 #include "qgspostgresconn.h"
 
-QgsPgNewConnection::QgsPgNewConnection( QWidget *parent, const QString& connName, Qt::WFlags fl )
+QgsPgNewConnection::QgsPgNewConnection( QWidget *parent, const QString& connName, Qt::WindowFlags fl )
     : QDialog( parent, fl ), mOriginalConnName( connName )
 {
   setupUi( this );

--- a/src/providers/postgres/qgspgnewconnection.h
+++ b/src/providers/postgres/qgspgnewconnection.h
@@ -29,7 +29,7 @@ class QgsPgNewConnection : public QDialog, private Ui::QgsPgNewConnectionBase
     Q_OBJECT
   public:
     //! Constructor
-    QgsPgNewConnection( QWidget *parent = 0, const QString& connName = QString::null, Qt::WFlags fl = QgisGui::ModalDialogFlags );
+    QgsPgNewConnection( QWidget *parent = 0, const QString& connName = QString::null, Qt::WindowFlags fl = QgisGui::ModalDialogFlags );
     //! Destructor
     ~QgsPgNewConnection();
     //! Tests the connection using the parameters supplied

--- a/src/providers/postgres/qgspgsourceselect.cpp
+++ b/src/providers/postgres/qgspgsourceselect.cpp
@@ -152,7 +152,7 @@ void QgsPgSourceSelectDelegate::setModelData( QWidget *editor, QAbstractItemMode
   }
 }
 
-QgsPgSourceSelect::QgsPgSourceSelect( QWidget *parent, Qt::WFlags fl, bool managerMode, bool embeddedMode )
+QgsPgSourceSelect::QgsPgSourceSelect( QWidget *parent, Qt::WindowFlags fl, bool managerMode, bool embeddedMode )
     : QDialog( parent, fl )
     , mManagerMode( managerMode )
     , mEmbeddedMode( embeddedMode )

--- a/src/providers/postgres/qgspgsourceselect.h
+++ b/src/providers/postgres/qgspgsourceselect.h
@@ -62,7 +62,7 @@ class QgsPgSourceSelect : public QDialog, private Ui::QgsDbSourceSelectBase
 
   public:
     //! Constructor
-    QgsPgSourceSelect( QWidget *parent = 0, Qt::WFlags fl = QgisGui::ModalDialogFlags, bool managerMode = false, bool embeddedMode = false );
+    QgsPgSourceSelect( QWidget *parent = 0, Qt::WindowFlags fl = QgisGui::ModalDialogFlags, bool managerMode = false, bool embeddedMode = false );
     //! Destructor
     ~QgsPgSourceSelect();
     //! Populate the connection list combo box

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -3173,7 +3173,7 @@ QGISEXTERN bool isProvider()
   return true;
 }
 
-QGISEXTERN QgsPgSourceSelect *selectWidget( QWidget *parent, Qt::WFlags fl )
+QGISEXTERN QgsPgSourceSelect *selectWidget( QWidget *parent, Qt::WindowFlags fl )
 {
   return new QgsPgSourceSelect( parent, fl );
 }

--- a/src/providers/spatialite/qgsspatialitedataitems.cpp
+++ b/src/providers/spatialite/qgsspatialitedataitems.cpp
@@ -335,7 +335,7 @@ void QgsSLRootItem::createDatabase()
 
 // ---------------------------------------------------------------------------
 
-QGISEXTERN QgsSpatiaLiteSourceSelect * selectWidget( QWidget * parent, Qt::WFlags fl )
+QGISEXTERN QgsSpatiaLiteSourceSelect * selectWidget( QWidget * parent, Qt::WindowFlags fl )
 {
   // TODO: this should be somewhere else
   return new QgsSpatiaLiteSourceSelect( parent, fl, false );

--- a/src/providers/spatialite/qgsspatialitesourceselect.cpp
+++ b/src/providers/spatialite/qgsspatialitesourceselect.cpp
@@ -39,7 +39,7 @@ email                : a.furieri@lqt.it
 #define strcasecmp(a,b) stricmp(a,b)
 #endif
 
-QgsSpatiaLiteSourceSelect::QgsSpatiaLiteSourceSelect( QWidget * parent, Qt::WFlags fl, bool embedded ):
+QgsSpatiaLiteSourceSelect::QgsSpatiaLiteSourceSelect( QWidget * parent, Qt::WindowFlags fl, bool embedded ):
     QDialog( parent, fl )
 {
   setupUi( this );

--- a/src/providers/spatialite/qgsspatialitesourceselect.h
+++ b/src/providers/spatialite/qgsspatialitesourceselect.h
@@ -54,7 +54,7 @@ class QgsSpatiaLiteSourceSelect: public QDialog, private Ui::QgsDbSourceSelectBa
     static bool newConnection( QWidget* parent );
 
     //! Constructor
-    QgsSpatiaLiteSourceSelect( QWidget * parent, Qt::WFlags fl = QgisGui::ModalDialogFlags, bool embedded = false );
+    QgsSpatiaLiteSourceSelect( QWidget * parent, Qt::WindowFlags fl = QgisGui::ModalDialogFlags, bool embedded = false );
     //! Destructor
     ~QgsSpatiaLiteSourceSelect();
     //! Populate the connection list combo box

--- a/src/providers/wcs/qgswcsdataitems.cpp
+++ b/src/providers/wcs/qgswcsdataitems.cpp
@@ -303,7 +303,7 @@ QGISEXTERN QgsDataItem * dataItem( QString thePath, QgsDataItem* parentItem )
   return new QgsWCSConnectionItem( parentItem, "WCS", thePath );
 }
 
-QGISEXTERN QgsWCSSourceSelect * selectWidget( QWidget * parent, Qt::WFlags fl )
+QGISEXTERN QgsWCSSourceSelect * selectWidget( QWidget * parent, Qt::WindowFlags fl )
 {
   return new QgsWCSSourceSelect( parent, fl );
 }

--- a/src/providers/wcs/qgswcssourceselect.cpp
+++ b/src/providers/wcs/qgswcssourceselect.cpp
@@ -27,7 +27,7 @@
 
 #include <QWidget>
 
-QgsWCSSourceSelect::QgsWCSSourceSelect( QWidget * parent, Qt::WFlags fl, bool managerMode, bool embeddedMode )
+QgsWCSSourceSelect::QgsWCSSourceSelect( QWidget * parent, Qt::WindowFlags fl, bool managerMode, bool embeddedMode )
     : QgsOWSSourceSelect( "WCS", parent, fl, managerMode, embeddedMode )
 {
   // Hide irrelevant widgets

--- a/src/providers/wcs/qgswcssourceselect.h
+++ b/src/providers/wcs/qgswcssourceselect.h
@@ -53,7 +53,7 @@ class QgsWCSSourceSelect : public QgsOWSSourceSelect
 
   public:
     //! Constructor
-    QgsWCSSourceSelect( QWidget *parent = 0, Qt::WFlags fl = QgisGui::ModalDialogFlags, bool managerMode = false, bool embeddedMode = false );
+    QgsWCSSourceSelect( QWidget *parent = 0, Qt::WindowFlags fl = QgisGui::ModalDialogFlags, bool managerMode = false, bool embeddedMode = false );
     //! Destructor
     ~QgsWCSSourceSelect();
 

--- a/src/providers/wfs/qgswfsdataitems.cpp
+++ b/src/providers/wfs/qgswfsdataitems.cpp
@@ -196,7 +196,7 @@ void QgsWFSRootItem::newConnection()
 
 // ---------------------------------------------------------------------------
 
-QGISEXTERN QgsWFSSourceSelect * selectWidget( QWidget * parent, Qt::WFlags fl )
+QGISEXTERN QgsWFSSourceSelect * selectWidget( QWidget * parent, Qt::WindowFlags fl )
 {
   return new QgsWFSSourceSelect( parent, fl );
 }

--- a/src/providers/wfs/qgswfssourceselect.cpp
+++ b/src/providers/wfs/qgswfssourceselect.cpp
@@ -38,7 +38,7 @@
 #include <QPainter>
 
 
-QgsWFSSourceSelect::QgsWFSSourceSelect( QWidget* parent, Qt::WFlags fl, bool embeddedMode )
+QgsWFSSourceSelect::QgsWFSSourceSelect( QWidget* parent, Qt::WindowFlags fl, bool embeddedMode )
     : QDialog( parent, fl )
     , mCapabilities( NULL )
 {

--- a/src/providers/wfs/qgswfssourceselect.h
+++ b/src/providers/wfs/qgswfssourceselect.h
@@ -46,7 +46,7 @@ class QgsWFSSourceSelect: public QDialog, private Ui::QgsWFSSourceSelectBase
 
   public:
 
-    QgsWFSSourceSelect( QWidget* parent, Qt::WFlags fl, bool embeddedMode = false );
+    QgsWFSSourceSelect( QWidget* parent, Qt::WindowFlags fl, bool embeddedMode = false );
     ~QgsWFSSourceSelect();
 
   signals:

--- a/src/providers/wms/qgswmsdataitems.cpp
+++ b/src/providers/wms/qgswmsdataitems.cpp
@@ -429,7 +429,7 @@ QGISEXTERN void registerGui( QMainWindow *mainWindow )
   QgsTileScaleWidget::showTileScale( mainWindow );
 }
 
-QGISEXTERN QgsWMSSourceSelect * selectWidget( QWidget * parent, Qt::WFlags fl )
+QGISEXTERN QgsWMSSourceSelect * selectWidget( QWidget * parent, Qt::WindowFlags fl )
 {
   return new QgsWMSSourceSelect( parent, fl );
 }

--- a/src/providers/wms/qgswmssourceselect.cpp
+++ b/src/providers/wms/qgswmssourceselect.cpp
@@ -55,7 +55,7 @@
 #include <QNetworkRequest>
 #include <QNetworkReply>
 
-QgsWMSSourceSelect::QgsWMSSourceSelect( QWidget * parent, Qt::WFlags fl, bool managerMode, bool embeddedMode )
+QgsWMSSourceSelect::QgsWMSSourceSelect( QWidget * parent, Qt::WindowFlags fl, bool managerMode, bool embeddedMode )
     : QDialog( parent, fl )
     , mManagerMode( managerMode )
     , mEmbeddedMode( embeddedMode )

--- a/src/providers/wms/qgswmssourceselect.h
+++ b/src/providers/wms/qgswmssourceselect.h
@@ -50,7 +50,7 @@ class QgsWMSSourceSelect : public QDialog, private Ui::QgsWMSSourceSelectBase
 
   public:
     //! Constructor
-    QgsWMSSourceSelect( QWidget *parent = 0, Qt::WFlags fl = QgisGui::ModalDialogFlags, bool managerMode = false, bool embeddedMode = false );
+    QgsWMSSourceSelect( QWidget *parent = 0, Qt::WindowFlags fl = QgisGui::ModalDialogFlags, bool managerMode = false, bool embeddedMode = false );
     //! Destructor
     ~QgsWMSSourceSelect();
 

--- a/src/providers/wms/qgswmtsdimensions.cpp
+++ b/src/providers/wms/qgswmtsdimensions.cpp
@@ -21,7 +21,7 @@
 #include <QSettings>
 #include <QComboBox>
 
-QgsWmtsDimensions::QgsWmtsDimensions( const QgsWmtsTileLayer &layer, QWidget *parent, Qt::WFlags fl )
+QgsWmtsDimensions::QgsWmtsDimensions( const QgsWmtsTileLayer &layer, QWidget *parent, Qt::WindowFlags fl )
     : QDialog( parent, fl )
 {
   setupUi( this );

--- a/src/providers/wms/qgswmtsdimensions.h
+++ b/src/providers/wms/qgswmtsdimensions.h
@@ -37,7 +37,7 @@ class QgsWmtsDimensions : public QDialog, private Ui::QgsWmtsDimensionsBase
 
   public:
     //! Constructor
-    QgsWmtsDimensions( const QgsWmtsTileLayer &layer, QWidget *parent = 0, Qt::WFlags fl = 0 );
+    QgsWmtsDimensions( const QgsWmtsTileLayer &layer, QWidget *parent = 0, Qt::WindowFlags fl = 0 );
     //! Destructor
     ~QgsWmtsDimensions();
 


### PR DESCRIPTION
It has long been in Qt 4 that the WFlags window flags argument has been
renamed to WindowFlags. In fact, WFlags is just a typedef to WindowFlags.
In Qt 5, this will go away, so we can change this now to make transition
easier in the future.

This should not have any affect on API or ABI, as the symbol names already
have WindowFlags in them anyway.

This change concentrates on the sources in the src directory. There are
a few more places in the python directory that can be done later.
