### PR TITLE
Remove unused include

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -42,7 +42,6 @@
 #include <QLibrary>
 #include <QMenu>
 #include <QMenuBar>
-#include <QMenuItem>
 #include <QMessageBox>
 #include <QPainter>
 #include <QPictureIO>


### PR DESCRIPTION
This "QMenuItem" include is not used, and it's also a Qt 3 leftover.
Remove it.
