### PR TITLE
Replace deprecated provides() with hasFormat()

### DIFF
--- a/src/app/qgsbrowserdockwidget.cpp
+++ b/src/app/qgsbrowserdockwidget.cpp
@@ -76,7 +76,7 @@ class QgsBrowserTreeView : public QTreeView
 
       QTreeView::dragMoveEvent( e );
 
-      if ( !e->provides( "application/x-vnd.qgis.qgis.uri" ) )
+      if ( !e->mimeData()->hasFormat( "application/x-vnd.qgis.qgis.uri" ) )
       {
         e->ignore();
         return;


### PR DESCRIPTION
QDropEvent::provides() has been deprecated from the move from Qt 3 to Qt 4.
Replace this instance with the hasFormat() method on the mimeData instance.
