### PR TITLE
Update qgsproject.cpp

### DIFF
--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -1469,8 +1469,10 @@ QString QgsProject::writePath( QString src ) const
     return src;
   }
 
-  QString srcPath = src;
-  QString projPath = fileName();
+  QDir dir0(src);
+  QDir dir1(fileName());
+  QString srcPath = dir0.canonicalPath();
+  QString projPath = dir1.canonicalPath();
 
   if ( projPath.isEmpty() )
   {


### PR DESCRIPTION
if projPath is like "D:/output/bin/release/../data/ykw/ykw.qgs"
(Please note the "../"),
and srcPath is like "D:/output/bin/data/ykw/ge.tif"
the relative path generated is wrong as "../../../../data/ykw/ge.tif"
so dir0.canonicalPath() will Returns the canonical path, i.e. a path without symbolic links or redundant "." or ".." elements.
