### PR TITLE
added error handling for too big rasters

### DIFF
--- a/python/plugins/processing/script/scripts/Extract_raster_values_to_shapefile.py
+++ b/python/plugins/processing/script/scripts/Extract_raster_values_to_shapefile.py
@@ -95,7 +95,11 @@ for i in xrange(bandCount):
     progress.setPercentage(int(current * total))
 
     rasterBand = raster.GetRasterBand(i + 1)
-    data = rasterBand.ReadAsArray()
+    try:
+        data = rasterBand.ReadAsArray()
+    except:
+        raise GeoAlgorithmExecutionException(
+                'Error reading raster data. File might be too big.')
     layer.ResetReading()
     feature = layer.GetNextFeature()
     while feature is not None:


### PR DESCRIPTION
I ran into memory problems with big rasters. Now the error message points the user to this potential error source.
