### PR TITLE
Rename setAcceptsHoverEvents

### DIFF
--- a/src/core/composer/qgscomposermousehandles.cpp
+++ b/src/core/composer/qgscomposermousehandles.cpp
@@ -45,7 +45,7 @@ QgsComposerMouseHandles::QgsComposerMouseHandles( QgsComposition *composition ) 
   QObject::connect( mComposition, SIGNAL( selectionChanged() ), this, SLOT( selectionChanged() ) );
 
   //accept hover events, required for changing cursor to resize cursors
-  setAcceptsHoverEvents( true );
+  setAcceptHoverEvents( true );
 }
 
 QgsComposerMouseHandles::~QgsComposerMouseHandles()


### PR DESCRIPTION
setAcceptsHoverEvents was obsoleted in place of setAcceptHoverEvent in
Qt 4.4. They behave the same.
