### PR TITLE
Fix for issue 3975, labeling svg as text

### DIFF
--- a/python/core/qgsmapsettings.sip
+++ b/python/core/qgsmapsettings.sip
@@ -72,6 +72,11 @@ class QgsMapSettings
     Flags flags() const;
     bool testFlag( Flag flag ) const;
 
+    //! sets format of internal QImage
+    void setOutputImageFormat( QImage::Format format );
+    //! format of internal QImage, default QImage::Format_ARGB32_Premultiplied
+    QImage::Format outputImageFormat() const;
+
     bool hasValidSettings() const;
     QgsRectangle visibleExtent() const;
     double mapUnitsPerPixel() const;

--- a/python/core/qgspallabeling.sip
+++ b/python/core/qgspallabeling.sip
@@ -666,6 +666,10 @@ class QgsPalLabeling : QgsLabelingEngineInterface
     bool isShowingPartialsLabels() const;
     void setShowingPartialsLabels( bool showing );
 
+    //! @note added in 2.4
+    bool isDrawingOutlineLabels() const;
+    void setDrawingOutlineLabels( bool outline );
+
     // implemented methods from labeling engine interface
 
     //! called when we're going to start with rendering

--- a/src/app/qgslabelengineconfigdialog.cpp
+++ b/src/app/qgslabelengineconfigdialog.cpp
@@ -46,6 +46,7 @@ QgsLabelEngineConfigDialog::QgsLabelEngineConfigDialog( QWidget* parent )
   mShadowDebugRectChkBox->setChecked( lbl.isShowingShadowRectangles() );
 
   chkShowPartialsLabels->setChecked( lbl.isShowingPartialsLabels() );
+  mDrawOutlinesChkBox->setChecked( lbl.isDrawingOutlineLabels() );
 }
 
 
@@ -64,6 +65,7 @@ void QgsLabelEngineConfigDialog::onOK()
   lbl.setShowingShadowRectangles( mShadowDebugRectChkBox->isChecked() );
   lbl.setShowingAllLabels( chkShowAllLabels->isChecked() );
   lbl.setShowingPartialsLabels( chkShowPartialsLabels->isChecked() );
+  lbl.setDrawingOutlineLabels( mDrawOutlinesChkBox->isChecked() );
 
   lbl.saveEngineSettings();
 
@@ -81,4 +83,5 @@ void QgsLabelEngineConfigDialog::setDefaults()
   chkShowAllLabels->setChecked( false );
   mShadowDebugRectChkBox->setChecked( false );
   chkShowPartialsLabels->setChecked( p.getShowPartial() );
+  mDrawOutlinesChkBox->setChecked( true );
 }

--- a/src/core/composer/qgscomposermap.cpp
+++ b/src/core/composer/qgscomposermap.cpp
@@ -186,6 +186,7 @@ void QgsComposerMap::draw( QPainter *painter, const QgsRectangle& extent, const 
   jobMapSettings.setMapUnits( ms.mapUnits() );
   jobMapSettings.setBackgroundColor( Qt::transparent );
   jobMapSettings.setShowSelection( false );
+  jobMapSettings.setOutputImageFormat( ms.outputImageFormat() );
 
   //set layers to render
   QStringList theLayerSet = layersToRender();

--- a/src/core/composer/qgscomposition.cpp
+++ b/src/core/composer/qgscomposition.cpp
@@ -2428,9 +2428,19 @@ void QgsComposition::deleteAndRemoveMultiFrames()
 
 void QgsComposition::beginPrintAsPDF( QPrinter& printer, const QString& file )
 {
-  printer.setOutputFormat( QPrinter::PdfFormat );
   printer.setOutputFileName( file );
+  // setOutputFormat should come after setOutputFileName, which auto-sets format to QPrinter::PdfFormat.
+  // [LS] This should be QPrinter::NativeFormat for Mac, otherwise fonts are not embed-able
+  // and text is not searchable; however, there are several bugs with <= Qt 4.8.5, 5.1.1, 5.2.0:
+  // https://bugreports.qt-project.org/browse/QTBUG-10094 - PDF font embedding fails
+  // https://bugreports.qt-project.org/browse/QTBUG-33583 - PDF output converts text to outline
+  // Also an issue with PDF paper size using QPrinter::NativeFormat on Mac (always outputs portrait letter-size)
+  printer.setOutputFormat( QPrinter::PdfFormat );
   printer.setPaperSize( QSizeF( paperWidth(), paperHeight() ), QPrinter::Millimeter );
+
+  // TODO: add option for this in Composer
+  // May not work on Windows or non-X11 Linux. Works fine on Mac using QPrinter::NativeFormat
+  //printer.setFontEmbeddingEnabled( true );
 
   QgsPaintEngineHack::fixEngineFlags( printer.paintEngine() );
 }

--- a/src/core/qgsmaprendererjob.cpp
+++ b/src/core/qgsmaprendererjob.cpp
@@ -50,7 +50,7 @@ QgsMapRendererSequentialJob::QgsMapRendererSequentialJob( const QgsMapSettings& 
 {
   QgsDebugMsg( "SEQUENTIAL construct" );
 
-  mImage = QImage( mSettings.outputSize(), QImage::Format_ARGB32_Premultiplied );
+  mImage = QImage( mSettings.outputSize(), mSettings.outputImageFormat() );
 }
 
 QgsMapRendererSequentialJob::~QgsMapRendererSequentialJob()
@@ -639,7 +639,8 @@ LayerRenderJobs QgsMapRendererJob::prepareJobs( QPainter* painter, QgsPalLabelin
       // Flattened image for drawing when a blending mode is set
       QImage * mypFlattenedImage = 0;
       mypFlattenedImage = new QImage( mSettings.outputSize().width(),
-                                      mSettings.outputSize().height(), QImage::Format_ARGB32_Premultiplied );
+                                      mSettings.outputSize().height(),
+                                      mSettings.outputImageFormat() );
       if ( mypFlattenedImage->isNull() )
       {
         mErrors.append( Error( layerId, "Insufficient memory for image " + QString::number( mSettings.outputSize().width() ) + "x" + QString::number( mSettings.outputSize().height() ) ) );
@@ -915,7 +916,7 @@ void QgsMapRendererParallelJob::renderLabelsStatic( QgsMapRendererParallelJob* s
 
 QImage QgsMapRendererJob::composeImage( const QgsMapSettings& settings, const LayerRenderJobs& jobs )
 {
-  QImage image( settings.outputSize(), QImage::Format_ARGB32_Premultiplied );
+  QImage image( settings.outputSize(), settings.outputImageFormat() );
   image.fill( settings.backgroundColor().rgb() );
 
   QPainter painter( &image );

--- a/src/core/qgsmapsettings.cpp
+++ b/src/core/qgsmapsettings.cpp
@@ -27,6 +27,7 @@ QgsMapSettings::QgsMapSettings()
     , mSelectionColor( Qt::yellow )
     , mShowSelection( true )
     , mFlags( Antialiasing | UseAdvancedEffects | DrawLabeling )
+    , mImageFormat( QImage::Format_ARGB32_Premultiplied )
 {
   updateDerived();
 

--- a/src/core/qgsmapsettings.h
+++ b/src/core/qgsmapsettings.h
@@ -2,6 +2,7 @@
 #define QGSMAPSETTINGS_H
 
 #include <QColor>
+#include <QImage>
 #include <QSize>
 #include <QStringList>
 
@@ -87,6 +88,11 @@ class CORE_EXPORT QgsMapSettings
     void setFlag( Flag flag, bool on = true );
     Flags flags() const;
     bool testFlag( Flag flag ) const;
+
+    //! sets format of internal QImage
+    void setOutputImageFormat( QImage::Format format ) { mImageFormat = format; }
+    //! format of internal QImage, default QImage::Format_ARGB32_Premultiplied
+    QImage::Format outputImageFormat() const { return mImageFormat; }
 
     bool hasValidSettings() const;
     QgsRectangle visibleExtent() const;
@@ -177,6 +183,8 @@ class CORE_EXPORT QgsMapSettings
     bool mShowSelection;
 
     Flags mFlags;
+
+    QImage::Format mImageFormat;
 
     // derived properties
     bool mValid; //!< whether the actual settings are valid (set in updateDerived())

--- a/src/core/qgspallabeling.h
+++ b/src/core/qgspallabeling.h
@@ -740,6 +740,10 @@ class CORE_EXPORT QgsPalLabeling : public QgsLabelingEngineInterface
     bool isShowingPartialsLabels() const { return mShowingPartialsLabels; }
     void setShowingPartialsLabels( bool showing ) { mShowingPartialsLabels = showing; }
 
+    //! @note added in 2.4
+    bool isDrawingOutlineLabels() const { return mDrawOutlineLabels; }
+    void setDrawingOutlineLabels( bool outline ) { mDrawOutlineLabels = outline; }
+
     // implemented methods from labeling engine interface
 
     //! called when we're going to start with rendering
@@ -856,6 +860,7 @@ class CORE_EXPORT QgsPalLabeling : public QgsLabelingEngineInterface
     bool mShowingAllLabels; // whether to avoid collisions or not
     bool mShowingShadowRects; // whether to show debugging rectangles for drop shadows
     bool mShowingPartialsLabels; // whether to avoid partials labels or not
+    bool mDrawOutlineLabels; // whether to draw labels as text or outlines
 
     QgsLabelingResults* mResults;
 };

--- a/src/ui/qgsengineconfigdialog.ui
+++ b/src/ui/qgsengineconfigdialog.ui
@@ -215,7 +215,67 @@
      <property name="verticalSpacing">
       <number>6</number>
      </property>
-     <item row="2" column="0">
+     <item row="1" column="0" colspan="3">
+      <widget class="QCheckBox" name="chkShowPartialsLabels">
+       <property name="text">
+        <string>Show partials labels</string>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="0" colspan="3">
+      <widget class="QCheckBox" name="mShadowDebugRectChkBox">
+       <property name="text">
+        <string>Show shadow rectangles (for debugging)</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="2">
+      <spacer name="horizontalSpacer_4">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>0</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item row="4" column="0" colspan="3">
+      <widget class="QCheckBox" name="chkShowCandidates">
+       <property name="text">
+        <string>Show candidates (for debugging)</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QLabel" name="label_6">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>(i.e. including colliding objects)</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0" colspan="3">
+      <widget class="QCheckBox" name="chkShowAllLabels">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="text">
+        <string>Show all labels and features for all layers</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
       <spacer name="horizontalSpacer_3">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -231,63 +291,10 @@
        </property>
       </spacer>
      </item>
-     <item row="1" column="0" colspan="3">
-      <widget class="QCheckBox" name="chkShowAllLabels">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>Show all labels and features for all layers</string>
-       </property>
-      </widget>
-     </item>
-     <item row="3" column="0" colspan="3">
-      <widget class="QCheckBox" name="chkShowCandidates">
-       <property name="text">
-        <string>Show candidates (for debugging)</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="1">
-      <widget class="QLabel" name="label_6">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="text">
-        <string>(i.e. including colliding objects)</string>
-       </property>
-      </widget>
-     </item>
-     <item row="2" column="2">
-      <spacer name="horizontalSpacer_4">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>0</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item row="4" column="0" colspan="3">
-      <widget class="QCheckBox" name="mShadowDebugRectChkBox">
-       <property name="text">
-        <string>Show shadow rectangles (for debugging)</string>
-       </property>
-      </widget>
-     </item>
      <item row="0" column="0" colspan="3">
-      <widget class="QCheckBox" name="chkShowPartialsLabels">
+      <widget class="QCheckBox" name="mDrawOutlinesChkBox">
        <property name="text">
-        <string>Show partials labels</string>
+        <string>Draw text as outlines (recommended)</string>
        </property>
       </widget>
      </item>

--- a/tests/src/python/qgis_local_server.py
+++ b/tests/src/python/qgis_local_server.py
@@ -430,7 +430,7 @@ class QgisLocalServer(object):
             openInBrowserTab(url)
             return False, ''
 
-        success = ('perhaps you left off the .qgs extension' in xml or
+        success = ('error reading the project file' in xml or
                    'WMS_Capabilities' in xml)
         return success, xml
 
@@ -525,7 +525,7 @@ class QgisLocalServer(object):
                 'No valid PNG output'
             )
 
-        return success, filepath
+        return success, filepath, url
 
     def process_params(self, params):
         # set all keys to uppercase
@@ -821,7 +821,7 @@ if __name__ == '__main__':
     try:
         local_srv.check_server_capabilities()
         # open resultant png with system
-        result, png = local_srv.get_map(req_params)
+        result, png, url = local_srv.get_map(req_params)
     finally:
         local_srv.shutdown()
 

--- a/tests/src/python/test_qgis_local_server.py
+++ b/tests/src/python/test_qgis_local_server.py
@@ -116,7 +116,7 @@ class TestQgisLocalServer(TestCase):
     # @unittest.skip('')
     def test_getmap(self):
         test_name = 'qgis_local_server'
-        success, img_path = MAPSERV.get_map(self.getmap_params())
+        success, img_path, url = MAPSERV.get_map(self.getmap_params())
         msg = '\nLocal server get_map failed'
         assert success, msg
 

--- a/tests/src/python/test_qgspallabeling_base.py
+++ b/tests/src/python/test_qgspallabeling_base.py
@@ -233,6 +233,7 @@ class TestQgsPalLabeling(TestCase):
         ms.setCrsTransformEnabled(oms.hasCrsTransformEnabled())
         ms.setMapUnits(oms.mapUnits())
         ms.setExtent(oms.extent())
+        ms.setOutputImageFormat(oms.outputImageFormat())
 
         ms.setLayers(oms.layers())
         return ms

--- a/tests/src/python/test_qgspallabeling_canvas.py
+++ b/tests/src/python/test_qgspallabeling_canvas.py
@@ -27,6 +27,9 @@ from qgis.core import *
 from utilities import (
     unittest,
     expectedFailure,
+    getTempfilePath,
+    renderMapToImage,
+    mapSettingsString
 )
 
 from test_qgspallabeling_base import TestQgsPalLabeling, runSuite
@@ -55,6 +58,9 @@ class TestCanvasBase(TestQgsPalLabeling):
     def setUp(self):
         """Run before each test."""
         super(TestCanvasBase, self).setUp()
+        self._TestImage = ''
+        # ensure per test map settings stay encapsulated
+        self._TestMapSettings = self.cloneMapSettings(self._MapSettings)
         self._Mismatch = 0
         self._ColorTol = 0
         self._Mismatches.clear()
@@ -62,8 +68,37 @@ class TestCanvasBase(TestQgsPalLabeling):
 
     def checkTest(self, **kwargs):
         self.lyr.writeToLayer(self.layer)
-        self.saveControlImage()
-        self.assertTrue(*self.renderCheck())
+
+        ms = self._MapSettings  # class settings
+        settings_type = 'Class'
+        if self._TestMapSettings is not None:
+            ms = self._TestMapSettings  # per test settings
+            settings_type = 'Test'
+        if 'PAL_VERBOSE' in os.environ:
+            qDebug('MapSettings type: {0}'.format(settings_type))
+            qDebug(mapSettingsString(ms))
+
+        img = renderMapToImage(ms, parallel=False)
+        self._TestImage = getTempfilePath('png')
+        if not img.save(self._TestImage, 'png'):
+            os.unlink(self._TestImage)
+            raise OSError('Failed to save output from map render job')
+        self.saveControlImage(self._TestImage)
+
+        mismatch = 0
+        if 'PAL_NO_MISMATCH' not in os.environ:
+            # some mismatch expected
+            mismatch = self._Mismatch if self._Mismatch else 0
+            if self._TestGroup in self._Mismatches:
+                mismatch = self._Mismatches[self._TestGroup]
+        colortol = 0
+        if 'PAL_NO_COLORTOL' not in os.environ:
+            colortol = self._ColorTol if self._ColorTol else 0
+            if self._TestGroup in self._ColorTols:
+                colortol = self._ColorTols[self._TestGroup]
+        self.assertTrue(*self.renderCheck(mismatch=mismatch,
+                                          colortol=colortol,
+                                          imgpath=self._TestImage))
 
 
 class TestCanvasBasePoint(TestCanvasBase):

--- a/tests/src/python/test_qgspallabeling_composer.py
+++ b/tests/src/python/test_qgspallabeling_composer.py
@@ -29,6 +29,7 @@ from qgis.core import *
 from utilities import (
     getTempfilePath,
     getExecutablePath,
+    mapSettingsString
 )
 
 from test_qgspallabeling_base import TestQgsPalLabeling, runSuite
@@ -96,9 +97,6 @@ class TestComposerBase(TestQgsPalLabeling):
 
     def _set_up_composition(self, width, height, dpi):
         # set up composition and add map
-        self._TestMapSettings.setFlag(QgsMapSettings.Antialiasing, True)
-        self._TestMapSettings.setFlag(QgsMapSettings.UseAdvancedEffects, True)
-        self._TestMapSettings.setFlag(QgsMapSettings.ForceVectorOutput, True)
         self._c = QgsComposition(self._TestMapSettings)
         """:type: QgsComposition"""
         # self._c.setUseAdvancedEffects(False)
@@ -270,6 +268,16 @@ class TestComposerBase(TestQgsPalLabeling):
     # noinspection PyUnusedLocal
     def checkTest(self, **kwargs):
         self.lyr.writeToLayer(self.layer)
+
+        ms = self._MapSettings  # class settings
+        settings_type = 'Class'
+        if self._TestMapSettings is not None:
+            ms = self._TestMapSettings  # per test settings
+            settings_type = 'Test'
+        if 'PAL_VERBOSE' in os.environ:
+            qDebug('MapSettings type: {0}'.format(settings_type))
+            qDebug(mapSettingsString(ms))
+
         res_m, self._TestImage = self.get_composer_output(self._TestKind)
         self.assertTrue(res_m, 'Failed to retrieve/save output from composer')
         self.saveControlImage(self._TestImage)

--- a/tests/src/python/test_qgspallabeling_composer.py
+++ b/tests/src/python/test_qgspallabeling_composer.py
@@ -123,19 +123,22 @@ class TestComposerBase(TestQgsPalLabeling):
 
     # noinspection PyUnusedLocal
     def _get_composer_image(self, width, height, dpi):
-        # image = QImage(QSize(width, height), QImage.Format_ARGB32)
-        # image.fill(QColor(152, 219, 249).rgb())
-        # image.setDotsPerMeterX(dpi / 25.4 * 1000)
-        # image.setDotsPerMeterY(dpi / 25.4 * 1000)
-        #
-        # p = QPainter(image)
-        # p.setRenderHint(QPainter.Antialiasing, False)
-        # p.setRenderHint(QPainter.HighQualityAntialiasing, False)
-        # self._c.renderPage(p, 0)
-        # p.end()
+        image = QImage(QSize(width, height),
+                       self._TestMapSettings.outputImageFormat())
+        image.fill(QColor(152, 219, 249).rgb())
+        image.setDotsPerMeterX(dpi / 25.4 * 1000)
+        image.setDotsPerMeterY(dpi / 25.4 * 1000)
 
-        image = self._c.printPageAsRaster(0)
-        """:type: QImage"""
+        p = QPainter(image)
+        p.setRenderHint(
+            QPainter.Antialiasing,
+            self._TestMapSettings.testFlag(QgsMapSettings.Antialiasing)
+        )
+        self._c.renderPage(p, 0)
+        p.end()
+
+        # image = self._c.printPageAsRaster(0)
+        # """:type: QImage"""
 
         if image.isNull():
             return False, ''
@@ -169,13 +172,18 @@ class TestComposerBase(TestQgsPalLabeling):
         if temp_size == os.path.getsize(svgpath):
             return False, ''
 
-        image = QImage(width, height, QImage.Format_ARGB32)
+        image = QImage(width, height, self._TestMapSettings.outputImageFormat())
         image.fill(QColor(152, 219, 249).rgb())
         image.setDotsPerMeterX(dpi / 25.4 * 1000)
         image.setDotsPerMeterY(dpi / 25.4 * 1000)
 
         svgr = QSvgRenderer(svgpath)
         p = QPainter(image)
+        p.setRenderHint(
+            QPainter.Antialiasing,
+            self._TestMapSettings.testFlag(QgsMapSettings.Antialiasing)
+        )
+        p.setRenderHint(QPainter.TextAntialiasing)
         svgr.render(p)
         p.end()
 

--- a/tests/src/python/test_qgspallabeling_server.py
+++ b/tests/src/python/test_qgspallabeling_server.py
@@ -177,9 +177,10 @@ class TestServerBase(TestQgsPalLabeling):
             qDebug('MapSettings type: {0}'.format(settings_type))
             qDebug(mapSettingsString(ms))
 
-        res_m, self._TestImage = MAPSERV.get_map(
-            self.get_request_params(), False)
+        res_m, self._TestImage, url = MAPSERV.get_map(self.get_request_params(), False)
         # print self._TestImage.__repr__()
+        if 'PAL_VERBOSE' in os.environ:
+            qDebug('GetMap request:\n  {0}\n'.format(url))
         self.saveControlImage(self._TestImage)
         self.assertTrue(res_m, 'Failed to retrieve/save image from test server')
         mismatch = 0

--- a/tests/src/python/test_qgspallabeling_server.py
+++ b/tests/src/python/test_qgspallabeling_server.py
@@ -31,6 +31,7 @@ from qgis.core import *
 from utilities import (
     unittest,
     expectedFailure,
+    mapSettingsString
 )
 
 from qgis_local_server import (
@@ -117,7 +118,8 @@ class TestServerBase(TestQgsPalLabeling):
                           ignore_errors=True)
 
     # noinspection PyPep8Naming
-    def get_wms_params(self):
+    def get_request_params(self):
+        # TODO: support other types of servers, besides WMS
         ms = self._TestMapSettings
         osize = ms.outputSize()
         dpi = str(ms.outputDpi())
@@ -147,7 +149,17 @@ class TestServerBase(TestQgsPalLabeling):
         # print params
         return params
 
+    def sync_map_settings(self):
+        """
+        Sync custom test QgsMapSettings to Project file
+        """
+        pal = QgsPalLabeling()
+        pal.loadEngineSettings()
+        pal.init(self._TestMapSettings)
+        pal.saveEngineSettings()
+
     def checkTest(self, **kwargs):
+        self.sync_map_settings()
         self.lyr.writeToLayer(self.layer)
         # save project file
         self._TestProj.write()
@@ -155,7 +167,18 @@ class TestServerBase(TestQgsPalLabeling):
         # MAPSERV.fcgi_server_process().start()
         # get server results
         # print self.params.__repr__()
-        res_m, self._TestImage = MAPSERV.get_map(self.params, False)
+
+        ms = self._MapSettings  # class settings
+        settings_type = 'Class'
+        if self._TestMapSettings is not None:
+            ms = self._TestMapSettings  # per test settings
+            settings_type = 'Test'
+        if 'PAL_VERBOSE' in os.environ:
+            qDebug('MapSettings type: {0}'.format(settings_type))
+            qDebug(mapSettingsString(ms))
+
+        res_m, self._TestImage = MAPSERV.get_map(
+            self.get_request_params(), False)
         # print self._TestImage.__repr__()
         self.saveControlImage(self._TestImage)
         self.assertTrue(res_m, 'Failed to retrieve/save image from test server')
@@ -182,11 +205,6 @@ class TestServerBasePoint(TestServerBase):
     def setUpClass(cls):
         TestServerBase.setUpClass()
         cls.layer = TestQgsPalLabeling.loadFeatureLayer('point')
-
-    def setUp(self):
-        super(TestServerBasePoint, self).setUp()
-        # self._TestMapSettings defines the params
-        self.params = self.get_wms_params()
 
 
 class TestServerPoint(TestServerBasePoint, TestPointBase):

--- a/tests/src/python/test_qgspallabeling_tests.py
+++ b/tests/src/python/test_qgspallabeling_tests.py
@@ -36,7 +36,6 @@ class TestPointBase(object):
         """:type: QgsPalLayerSettings"""
         # noinspection PyArgumentList
         self._TestFont = QFont()  # will become a standard test font
-        self.params = dict()
         self._Pal = None
         """:type: QgsPalLabeling"""
         self._Canvas = None

--- a/tests/src/python/utilities.py
+++ b/tests/src/python/utilities.py
@@ -17,10 +17,16 @@ import platform
 import tempfile
 import qgis
 from PyQt4 import QtGui, QtCore
-from qgis.core import (QgsApplication,
-                       QgsCoordinateReferenceSystem,
-                       QgsVectorFileWriter,
-                       QgsFontUtils)
+from qgis.core import (
+    QgsApplication,
+    QgsCoordinateReferenceSystem,
+    QgsVectorFileWriter,
+    QgsMapLayerRegistry,
+    QgsMapSettings,
+    QgsMapRendererParallelJob,
+    QgsMapRendererSequentialJob,
+    QgsFontUtils
+)
 from qgis.gui import QgsMapCanvas
 from qgis_interface import QgisInterface
 import hashlib
@@ -234,6 +240,69 @@ def getTempfilePath(sufx='png'):
     filepath = tmp.name
     tmp.close()
     return filepath
+
+
+def renderMapToImage(mapsettings, parallel=False):
+    """
+    Render current map to an image, via multi-threaded renderer
+    :param QgsMapSettings mapsettings:
+    :param bool parallel: Do parallel or sequential render job
+    :rtype: QImage
+    """
+    if parallel:
+        job = QgsMapRendererParallelJob(mapsettings)
+    else:
+        job = QgsMapRendererSequentialJob(mapsettings)
+    job.start()
+    job.waitForFinished()
+
+    return job.renderedImage()
+
+
+def mapSettingsString(ms):
+    """
+    :param QgsMapSettings mapsettings:
+    :rtype: str
+    """
+    # fullExtent() causes extra call in middle of output flow; get first
+    full_ext = ms.visibleExtent().toString()
+
+    s = 'MapSettings...\n'
+    s += '  layers(): {0}\n'.format(
+        [unicode(QgsMapLayerRegistry.instance().mapLayer(i).name())
+         for i in ms.layers()])
+    s += '  backgroundColor(): rgba {0},{1},{2},{3}\n'.format(
+        ms.backgroundColor().red(), ms.backgroundColor().green(),
+        ms.backgroundColor().blue(), ms.backgroundColor().alpha())
+    s += '  selectionColor(): rgba {0},{1},{2},{3}\n'.format(
+        ms.selectionColor().red(), ms.selectionColor().green(),
+        ms.selectionColor().blue(), ms.selectionColor().alpha())
+    s += '  outputSize(): {0} x {1}\n'.format(
+        ms.outputSize().width(), ms.outputSize().height())
+    s += '  outputDpi(): {0}\n'.format(ms.outputDpi())
+    s += '  mapUnits(): {0}\n'.format(ms.mapUnits())
+    s += '  scale(): {0}\n'.format(ms.scale())
+    s += '  mapUnitsPerPixel(): {0}\n'.format(ms.mapUnitsPerPixel())
+    s += '  extent():\n    {0}\n'.format(
+        ms.extent().toString().replace(' : ', '\n    '))
+    s += '  visibleExtent():\n    {0}\n'.format(
+        ms.visibleExtent().toString().replace(' : ', '\n    '))
+    s += '  fullExtent():\n    {0}\n'.format(full_ext.replace(' : ', '\n    '))
+    s += '  hasCrsTransformEnabled(): {0}\n'.format(
+        ms.hasCrsTransformEnabled())
+    s += '  destinationCrs(): {0}\n'.format(
+        ms.destinationCrs().authid())
+    s += '  flag.Antialiasing: {0}\n'.format(
+        ms.testFlag(QgsMapSettings.Antialiasing))
+    s += '  flag.UseAdvancedEffects: {0}\n'.format(
+        ms.testFlag(QgsMapSettings.UseAdvancedEffects))
+    s += '  flag.ForceVectorOutput: {0}\n'.format(
+        ms.testFlag(QgsMapSettings.ForceVectorOutput))
+    s += '  flag.DrawLabeling: {0}\n'.format(
+        ms.testFlag(QgsMapSettings.DrawLabeling))
+    s += '  flag.DrawEditingInfo: {0}\n'.format(
+        ms.testFlag(QgsMapSettings.DrawEditingInfo))
+    return s
 
 
 def getExecutablePath(exe):

--- a/tests/src/python/utilities.py
+++ b/tests/src/python/utilities.py
@@ -302,6 +302,7 @@ def mapSettingsString(ms):
         ms.testFlag(QgsMapSettings.DrawLabeling))
     s += '  flag.DrawEditingInfo: {0}\n'.format(
         ms.testFlag(QgsMapSettings.DrawEditingInfo))
+    s += '  outputImageFormat(): {0}\n'.format(ms.outputImageFormat())
     return s
 
 


### PR DESCRIPTION
Reinstates output of text-as-text for use in SVG, PDF and PS exports.

**Implements the following:**
- Labeling engine (per project) setting.
- Labeling engine option overrides as `QgsMapSettings` properties. Allows all map rendering options to be encapsulated in `QgsMapSettings` and programmatically set without having to edit user's project settings. For example: `QgsMapRendererSequentialJob(mapsettings)`, where the instantiation of `QgsPalLabeling` is embedded in the class and not publicly accessible. 
- Text-as-outlines (vectorized) remains the default, with text-as-text optional. 
- `QImage::Format` can now be defined for render jobs' backend `QImage`, via `QgsMapSettings` property.
- Does _not_ implement any optional choosing of text output mode during SVG or PDF export. These should be added.

**Preliminary (non-unit) testing results:**
- Since the label buffer is already drawn as text-as-outline, the use of text-as-text over the buffer resulted in poor registration. Text-as-text does not include any allowance for stroke width, which leads to some styling features, e.g. underline, to be offset from the buffer with no easy means of fixing it (Qt glyph and style rendering).  
- When outputting text-as-text, as a default, initial unit tests had greatly varied results. I was found that using `QImage::Format_ARGB32_Premultiplied` had a detrimental effect on the quality of text rendering. Hence the need to set `QImage::Format` for a render job.
- Outputting text-as-text in SVG has scaling issues. Text is slightly smaller scale than buffer background. Correctly aligned in PDF/PS output, however.

Unit tests to follow, once changes in `QgsMapSettings` are discussed.

Supersedes PR #1096
