### PR TITLE
Use begin/endResetModel instead of reset

### DIFF
--- a/src/core/qgsbrowsermodel.cpp
+++ b/src/core/qgsbrowsermodel.cpp
@@ -308,9 +308,10 @@ QModelIndex QgsBrowserModel::findPath( QString path )
 
 void QgsBrowserModel::reload()
 {
+  beginResetModel();
   removeRootItems();
   addRootItems();
-  reset(); // Qt4.6 brings better methods beginResetModel + endResetModel
+  endResetModel();
 }
 
 /* Refresh dir path */

--- a/src/core/symbology-ng/qgscptcityarchive.cpp
+++ b/src/core/symbology-ng/qgscptcityarchive.cpp
@@ -1583,9 +1583,10 @@ QModelIndex QgsCptCityBrowserModel::findPath( QString path )
 
 void QgsCptCityBrowserModel::reload()
 {
+  beginResetModel();
   removeRootItems();
   addRootItems();
-  reset(); // Qt4.6 brings better methods beginResetModel + endResetModel
+  endResetModel();
 }
 
 /* Refresh dir path */

--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -660,7 +660,8 @@ void QgsAttributeTableModel::reload( const QModelIndex &index1, const QModelInde
 
 void QgsAttributeTableModel::resetModel()
 {
-  reset();
+  beginResetModel();
+  endResetModel();
 }
 
 void QgsAttributeTableModel::executeAction( int action, const QModelIndex &idx ) const

--- a/src/plugins/topology/dockModel.cpp
+++ b/src/plugins/topology/dockModel.cpp
@@ -121,7 +121,8 @@ Qt::ItemFlags DockModel::flags( const QModelIndex &index ) const
 
 void DockModel::resetModel()
 {
-  reset();
+  beginResetModel();
+  endResetModel();
 }
 
 void DockModel::reload( const QModelIndex &index1, const QModelIndex &index2 )


### PR DESCRIPTION
Qt 4.6 introduced a better way of resetting models with beginResetModel()/
endResetModel(). Call beginResetModel() before resetting internal data
structures, and then endResetModel() when finished. beginResetModel()
followed by endResetModel() is the same as calling reset().

Note: reset() is deprecated and is removed in Qt 5.
