### PR TITLE
model/view for layer/field selectors

### DIFF
--- a/python/core/composer/qgsatlascomposition.sip
+++ b/python/core/composer/qgsatlascomposition.sip
@@ -68,8 +68,11 @@ public:
     QString featureFilter() const;
     void setFeatureFilter( const QString& expression );
 
-    int sortKeyAttributeIndex() const;
-    void setSortKeyAttributeIndex( int idx );
+    QString sortKeyAttributeName() const;
+    void setSortKeyAttributeName( QString fieldName );
+    
+    int sortKeyAttributeIndex() const /Deprecated/;
+    void setSortKeyAttributeIndex( int idx ) /Deprecated/;
 
     /** Begins the rendering. Returns true if successful, false if no matching atlas
       features found.*/

--- a/python/gui/gui.sip
+++ b/python/gui/gui.sip
@@ -28,6 +28,8 @@
 %Include qgsexpressionbuilderdialog.sip
 %Include qgsexpressionbuilderwidget.sip
 %Include qgsexpressionhighlighter.sip
+%Include qgsfieldcombobox.sip
+%Include qgsfieldmodel.sip
 %Include qgsfieldvalidator.sip
 %Include qgsfiledropedit.sip
 %Include qgsfilterlineedit.sip
@@ -44,6 +46,9 @@
 %Include qgsmapcanvasmap.sip
 %Include qgsmapcanvassnapper.sip
 %Include qgsmaplayeractionregistry.sip
+%Include qgsmaplayercombobox.sip
+%Include qgsmaplayermodel.sip
+%Include qgsmaplayerproxymodel.sip
 %Include qgsmapoverviewcanvas.sip
 %Include qgsmaptip.sip
 %Include qgsmaptool.sip

--- a/python/gui/qgsfieldcombobox.sip
+++ b/python/gui/qgsfieldcombobox.sip
@@ -1,0 +1,40 @@
+/**
+ * @brief The QgsFieldComboBox is a combo box which displays the list of fields of a given layer.
+ * @note added in 2.3
+ */
+class QgsFieldComboBox : QComboBox
+{
+
+%TypeHeaderCode
+#include "qgsfieldcombobox.h"
+%End
+
+  public:
+    /**
+     * @brief QgsFieldComboBox creates a combo box to display the fields of a layer.
+     * The layer can be either manually given or dynamically set by connecting the signal QgsMapLayerComboBox::layerChanged to the slot setLayer.
+     */
+    explicit QgsFieldComboBox( QWidget *parent /TransferThis/ = 0 );
+
+    /**
+     * @brief currentField returns the currently selected field
+     */
+    QString currentField();
+
+  signals:
+    /**
+     * @brief fieldChanged the signal is emitted when the currently selected field changes
+     */
+    void fieldChanged( QString fieldName );
+
+  public slots:
+    /**
+     * @brief setLayer sets the layer of which the fields are listed
+     */
+    void setLayer( QgsMapLayer* layer );
+    /**
+     * @brief setField sets the currently selected field
+     */
+    void setField( QString fieldName );
+
+};

--- a/python/gui/qgsfieldmodel.sip
+++ b/python/gui/qgsfieldmodel.sip
@@ -1,0 +1,42 @@
+
+/**
+ * @brief The QgsFieldModel class is a model to display the list of fields of a layer in widgets.
+ * It can be associated with a QgsMapLayerModel to dynamically display a layer and its fields.
+ * @note added in 2.3
+ */
+
+class QgsFieldModel : QAbstractItemModel
+{
+%TypeHeaderCode
+#include "qgsfieldmodel.h"
+%End
+
+  public:
+    static const int FieldNameRole;
+    static const int FieldIndexRole;
+
+    /**
+     * @brief QgsFieldModel creates a model to display the fields of a given layer
+     */
+    explicit QgsFieldModel( QObject *parent /TransferThis/ = 0 );
+
+    /**
+     * @brief indexFromName returns the index corresponding to a given fieldName
+     */
+    QModelIndex indexFromName( QString fieldName );
+
+  public slots:
+    /**
+     * @brief setLayer sets the layer of whch fields are displayed
+     */
+    void setLayer( QgsMapLayer *layer );
+
+    // QAbstractItemModel interface
+  public:
+    QModelIndex index( int row, int column, const QModelIndex &parent = QModelIndex() ) const;
+    QModelIndex parent( const QModelIndex &child ) const;
+    int rowCount( const QModelIndex &parent ) const;
+    int columnCount( const QModelIndex &parent ) const;
+    QVariant data( const QModelIndex &index, int role ) const;
+
+};

--- a/python/gui/qgsmaplayercombobox.sip
+++ b/python/gui/qgsmaplayercombobox.sip
@@ -1,0 +1,40 @@
+/**
+ * @brief The QgsMapLayerComboBox class is a combo box which displays the list of layers
+ * @note added in 2.3
+ */
+class QgsMapLayerComboBox : QComboBox
+{
+
+%TypeHeaderCode
+#include "qgsmaplayercombobox.h"
+%End
+
+  public:
+    /**
+     * @brief QgsMapLayerComboBox creates a combo box to dislpay the list of layers (currently in the registry).
+     * The layers can be filtered and/or ordered.
+     */
+    explicit QgsMapLayerComboBox( QWidget *parent /TransferThis/ = 0 );
+
+    /**
+     * @brief setFilters allows fitering according to layer type and/or geometry type.
+     */
+    void setFilters( QgsMapLayerProxyModel::Filters filters );
+
+    /**
+     * @brief currentLayer returns the current layer selected in the combo box
+     */
+    QgsMapLayer* currentLayer();
+
+  public slots:
+    /**
+     * @brief setLayer set the current layer selected in the combo
+     */
+    void setLayer( QgsMapLayer* layer );
+
+  signals:
+    /**
+     * @brief layerChanged this signal is emitted whenever the currently selected layer changes
+     */
+    void layerChanged( QgsMapLayer* layer );
+};

--- a/python/gui/qgsmaplayermodel.sip
+++ b/python/gui/qgsmaplayermodel.sip
@@ -1,0 +1,58 @@
+
+/**
+ * @brief The QgsMapLayerModel class is a model to display layers in widgets.
+ * @see QgsMapLayerProxyModel to sort and/filter the layers
+ * @see QgsFieldModel to combine in with a field selector.
+ * @note added in 2.3
+ */
+class QgsMapLayerModel : QAbstractItemModel
+{
+
+%TypeHeaderCode
+#include "qgsmaplayermodel.h"
+%End
+    
+  public:
+    static const int LayerIdRole;
+
+    /**
+     * @brief QgsMapLayerModel creates a model to display layers in widgets.
+     */
+    explicit QgsMapLayerModel( QObject *parent /TransferThis/ = 0 );
+    /**
+     * @brief QgsMapLayerModel creates a model to display a specific list of layers in a widget.
+     */
+    explicit QgsMapLayerModel( QList<QgsMapLayer*> layers, QObject *parent /TransferThis/ = 0 );
+
+    /**
+     * @brief setItemsCheckable defines if layers should be selectable in the widget
+     */
+    void setItemsCheckable( bool checkable );
+    /**
+     * @brief checkAll changes the checkstate for all the layers
+     */
+    void checkAll( Qt::CheckState checkState );
+    /**
+     * @brief layersChecked returns the list of layers which are checked (or unchecked)
+     */
+    QList<QgsMapLayer*> layersChecked( Qt::CheckState checkState = Qt::Checked );
+    //! returns if the items can be checked or not
+    bool itemsCheckable() ;
+
+    /**
+     * @brief indexFromLayer returns the model index for a given layer
+     */
+    QModelIndex indexFromLayer( QgsMapLayer* layer );
+
+    // QAbstractItemModel interface
+  public:
+    QModelIndex index( int row, int column, const QModelIndex &parent = QModelIndex() ) const;
+    QModelIndex parent( const QModelIndex &child ) const;
+    int rowCount( const QModelIndex &parent ) const;
+    int columnCount( const QModelIndex &parent ) const;
+    QVariant data( const QModelIndex &index, int role ) const;
+    bool setData( const QModelIndex &index, const QVariant &value, int role );
+    Qt::ItemFlags flags( const QModelIndex &index ) const;
+};
+
+

--- a/python/gui/qgsmaplayerproxymodel.sip
+++ b/python/gui/qgsmaplayerproxymodel.sip
@@ -1,0 +1,50 @@
+/**
+ * @brief The QgsMapLayerProxModel class provides an easy to use model to display the list of layers in widgets.
+ * @note added in 2.3
+ */
+class QgsMapLayerProxyModel : QSortFilterProxyModel
+{
+
+%TypeHeaderCode
+#include "qgsmaplayerproxymodel.h"
+%End
+
+  public:
+    enum Filter
+    {
+      NoFilter = 1,
+      RasterLayer = 2,
+      NoGeometry = 4,
+      PointLayer = 8,
+      LineLayer = 16,
+      PolygonLayer = 32,
+      HasGeometry = 56,
+      VectorLayer = 60
+    };
+    typedef QFlags<QgsMapLayerProxyModel::Filter> Filters;
+
+    /**
+     * @brief QgsMapLayerProxModel creates a proxy model with a QgsMapLayerModel as source model.
+     * It can be used to filter the layers list in a widget.
+     */
+    explicit QgsMapLayerProxyModel( QObject *parent /TransferThis/ = 0 );
+
+    /**
+     * @brief layerModel returns the QgsMapLayerModel used in this QSortFilterProxyModel
+     */
+    QgsMapLayerModel* sourceLayerModel() ;
+
+    /**
+     * @brief setFilters set flags that affect how layers are filtered
+     * @param filters are Filter flags
+     * @note added in 2.3
+     */
+    QgsMapLayerProxyModel* setFilters( Filters filters );
+    const Filters& filters() const ;
+
+    // QSortFilterProxyModel interface
+  public:
+    bool filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const;
+    bool lessThan( const QModelIndex &left, const QModelIndex &right ) const;
+};
+

--- a/src/app/composer/qgsatlascompositionwidget.cpp
+++ b/src/app/composer/qgsatlascompositionwidget.cpp
@@ -19,7 +19,9 @@
 #include "qgsatlascompositionwidget.h"
 #include "qgsatlascomposition.h"
 #include "qgscomposition.h"
+#include "qgsfieldmodel.h"
 #include "qgsmaplayerregistry.h"
+#include "qgsmaplayerproxymodel.h"
 #include "qgsexpressionbuilderdialog.h"
 #include "qgscomposermap.h"
 
@@ -28,28 +30,11 @@ QgsAtlasCompositionWidget::QgsAtlasCompositionWidget( QWidget* parent, QgsCompos
 {
   setupUi( this );
 
-  // populate the layer list
-  mAtlasCoverageLayerComboBox->clear();
-  const QMap< QString, QgsMapLayer * >& layers = QgsMapLayerRegistry::instance()->mapLayers();
-  int idx = 0;
-  for ( QMap<QString, QgsMapLayer*>::const_iterator it = layers.begin(); it != layers.end(); ++it )
-  {
-    // Only consider vector layers
-    if ( dynamic_cast<QgsVectorLayer*>( it.value() ) )
-    {
-      mAtlasCoverageLayerComboBox->insertItem( idx++, it.value()->name(), /* userdata */ qVariantFromValue(( void* )it.value() ) );
-    }
-  }
-  // update sort columns
-  fillSortColumns();
-
-  // Connect to addition / removal of layers
-  QgsMapLayerRegistry* layerRegistry = QgsMapLayerRegistry::instance();
-  if ( layerRegistry )
-  {
-    connect( layerRegistry, SIGNAL( layerWillBeRemoved( QString ) ), this, SLOT( onLayerRemoved( QString ) ) );
-    connect( layerRegistry, SIGNAL( layerWasAdded( QgsMapLayer* ) ), this, SLOT( onLayerAdded( QgsMapLayer* ) ) );
-  }
+  mAtlasCoverageLayerComboBox->setFilters( QgsMapLayerProxyModel::HasGeometry );
+  mAtlasSortFeatureKeyComboBox->setLayer( mAtlasCoverageLayerComboBox->currentLayer() );
+  connect( mAtlasCoverageLayerComboBox, SIGNAL( layerChanged( QgsMapLayer* ) ), mAtlasSortFeatureKeyComboBox, SLOT( setLayer( QgsMapLayer* ) ) );
+  connect( mAtlasCoverageLayerComboBox, SIGNAL( layerChanged( QgsMapLayer* ) ), this, SLOT( changeCoverageLayer( QgsMapLayer* ) ) );
+  connect( mAtlasSortFeatureKeyComboBox, SIGNAL( fieldChanged( QString ) ), this, SLOT( changesSortFeatureField( QString ) ) );
 
   // Sort direction
   mAtlasSortFeatureDirectionButton->setEnabled( false );
@@ -82,68 +67,24 @@ void QgsAtlasCompositionWidget::on_mUseAtlasCheckBox_stateChanged( int state )
   }
 }
 
-void QgsAtlasCompositionWidget::onLayerRemoved( QString layerName )
-{
-  QgsAtlasComposition* atlasMap = &mComposition->atlasComposition();
-  // update the atlas coverage layer combo box
-  for ( int i = 0; i < mAtlasCoverageLayerComboBox->count(); ++i )
-  {
-    const QgsMapLayer* layer = reinterpret_cast<const QgsMapLayer*>( mAtlasCoverageLayerComboBox->itemData( i ).value<void*>() );
-    if ( layer->id() == layerName )
-    {
-      mAtlasCoverageLayerComboBox->removeItem( i );
-      break;
-    }
-  }
-  if ( mAtlasCoverageLayerComboBox->count() == 0 )
-  {
-    atlasMap->setCoverageLayer( 0 );
-  }
-}
-
-void QgsAtlasCompositionWidget::onLayerAdded( QgsMapLayer* map )
-{
-  QgsAtlasComposition* atlasMap = &mComposition->atlasComposition();
-  // update the atlas coverage layer combo box
-  QgsVectorLayer* vectorLayer = dynamic_cast<QgsVectorLayer*>( map );
-  if ( vectorLayer )
-  {
-    mAtlasCoverageLayerComboBox->addItem( map->name(), qVariantFromValue(( void* )map ) );
-
-    if ( mAtlasCoverageLayerComboBox->count() == 1 )
-    {
-      atlasMap->setCoverageLayer( vectorLayer );
-      updateAtlasFeatures();
-    }
-  }
-}
-
-void QgsAtlasCompositionWidget::on_mAtlasCoverageLayerComboBox_currentIndexChanged( int index )
+void QgsAtlasCompositionWidget::changeCoverageLayer( QgsMapLayer *layer )
 {
   QgsAtlasComposition* atlasMap = &mComposition->atlasComposition();
   if ( !atlasMap )
   {
     return;
   }
-  if ( index == -1 )
+
+  QgsVectorLayer* vl = dynamic_cast<QgsVectorLayer*>( layer );
+
+  if ( !vl )
   {
     atlasMap->setCoverageLayer( 0 );
-
-    // clean up the sorting columns
-    mAtlasSortFeatureKeyComboBox->clear();
   }
   else
   {
-    QgsVectorLayer* layer = reinterpret_cast<QgsVectorLayer*>( mAtlasCoverageLayerComboBox->itemData( index ).value<void*>() );
-
-    if ( layer )
-    {
-      atlasMap->setCoverageLayer( layer );
-      updateAtlasFeatures();
-    }
-
-    // update sorting columns
-    fillSortColumns();
+    atlasMap->setCoverageLayer( vl );
+    updateAtlasFeatures();
   }
 }
 
@@ -260,18 +201,14 @@ void QgsAtlasCompositionWidget::updateAtlasFeatures()
   }
 }
 
-void QgsAtlasCompositionWidget::on_mAtlasSortFeatureKeyComboBox_currentIndexChanged( int index )
+void QgsAtlasCompositionWidget::changesSortFeatureField( QString fieldName )
 {
   QgsAtlasComposition* atlasMap = &mComposition->atlasComposition();
   if ( !atlasMap )
   {
     return;
   }
-
-  if ( index != -1 )
-  {
-    atlasMap->setSortKeyAttributeIndex( index );
-  }
+  atlasMap->setSortKeyAttributeName( fieldName );
   updateAtlasFeatures();
 }
 
@@ -347,23 +284,6 @@ void QgsAtlasCompositionWidget::on_mAtlasSortFeatureDirectionButton_clicked()
   updateAtlasFeatures();
 }
 
-void QgsAtlasCompositionWidget::fillSortColumns()
-{
-  QgsAtlasComposition* atlasMap = &mComposition->atlasComposition();
-  if ( !atlasMap || !atlasMap->coverageLayer() )
-  {
-    return;
-  }
-
-  mAtlasSortFeatureKeyComboBox->clear();
-  // Get fields of the selected coverage layer
-  const QgsFields& fields = atlasMap->coverageLayer()->pendingFields();
-  for ( int i = 0; i < fields.count(); ++i )
-  {
-    mAtlasSortFeatureKeyComboBox->insertItem( i, fields.at( i ).name() );
-  }
-}
-
 void QgsAtlasCompositionWidget::updateGuiElements()
 {
   QgsAtlasComposition* atlasMap = &mComposition->atlasComposition();
@@ -376,17 +296,12 @@ void QgsAtlasCompositionWidget::updateGuiElements()
     mUseAtlasCheckBox->setCheckState( Qt::Unchecked );
   }
 
-  int idx = mAtlasCoverageLayerComboBox->findData( qVariantFromValue(( void* )atlasMap->coverageLayer() ) );
-  if ( idx != -1 )
-  {
-    mAtlasCoverageLayerComboBox->setCurrentIndex( idx );
-  }
-
+  mAtlasCoverageLayerComboBox->setLayer( atlasMap->coverageLayer() );
+  mAtlasSortFeatureKeyComboBox->setField( atlasMap->sortKeyAttributeName() );
   mAtlasFilenamePatternEdit->setText( atlasMap->filenamePattern() );
   mAtlasHideCoverageCheckBox->setCheckState( atlasMap->hideCoverage() ? Qt::Checked : Qt::Unchecked );
   mAtlasSingleFileCheckBox->setCheckState( atlasMap->singleFile() ? Qt::Checked : Qt::Unchecked );
   mAtlasSortFeatureCheckBox->setCheckState( atlasMap->sortFeatures() ? Qt::Checked : Qt::Unchecked );
-  mAtlasSortFeatureKeyComboBox->setCurrentIndex( atlasMap->sortKeyAttributeIndex() );
   mAtlasSortFeatureDirectionButton->setArrowType( atlasMap->sortAscending() ? Qt::UpArrow : Qt::DownArrow );
   mAtlasFeatureFilterEdit->setText( atlasMap->featureFilter() );
   mAtlasFeatureFilterCheckBox->setCheckState( atlasMap->filterFeatures() ? Qt::Checked : Qt::Unchecked );

--- a/src/app/composer/qgsatlascompositionwidget.h
+++ b/src/app/composer/qgsatlascompositionwidget.h
@@ -36,25 +36,20 @@ class QgsAtlasCompositionWidget:
 
   public slots:
     void on_mUseAtlasCheckBox_stateChanged( int state );
-    void on_mAtlasCoverageLayerComboBox_currentIndexChanged( int index );
+    void changeCoverageLayer( QgsMapLayer* layer );
     void on_mAtlasFilenamePatternEdit_textChanged( const QString& text );
     void on_mAtlasFilenameExpressionButton_clicked();
     void on_mAtlasHideCoverageCheckBox_stateChanged( int state );
     void on_mAtlasSingleFileCheckBox_stateChanged( int state );
 
     void on_mAtlasSortFeatureCheckBox_stateChanged( int state );
-    void on_mAtlasSortFeatureKeyComboBox_currentIndexChanged( int index );
+    void changesSortFeatureField( QString fieldName );
     void on_mAtlasSortFeatureDirectionButton_clicked();
     void on_mAtlasFeatureFilterEdit_editingFinished();
     void on_mAtlasFeatureFilterButton_clicked();
     void on_mAtlasFeatureFilterCheckBox_stateChanged( int state );
 
-    // extract fields from the current coverage layer and populate the corresponding combo box
-    void fillSortColumns();
   private slots:
-    void onLayerRemoved( QString );
-    void onLayerAdded( QgsMapLayer* );
-
     void updateGuiElements();
 
     void updateAtlasFeatures();

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -3758,29 +3758,11 @@ void QgisApp::fileSaveAs()
 
 void QgisApp::dxfExport()
 {
-  QgsLegend* mapLegend = legend();
-  if ( !mapLegend )
-  {
-    return;
-  }
-
-  QgsDxfExportDialog d( mapLegend->layers() );
+  QgsDxfExportDialog d;
   if ( d.exec() == QDialog::Accepted )
   {
     QgsDxfExport dxfExport;
-
-    QList<QgsMapLayer*> layerList;
-    QList<QString> layerIdList = d.layers();
-    QList<QString>::const_iterator layerIt = layerIdList.constBegin();
-    for ( ; layerIt != layerIdList.constEnd(); ++layerIt )
-    {
-      QgsMapLayer* l = QgsMapLayerRegistry::instance()->mapLayer( *layerIt );
-      if ( l )
-      {
-        layerList.append( l );
-      }
-    }
-
+    QList<QgsMapLayer*> layerList = d.layers();
     dxfExport.addLayers( layerList );
     dxfExport.setSymbologyScaleDenominator( d.symbologyScale() );
     dxfExport.setSymbologyExport( d.symbologyMode() );

--- a/src/app/qgsdxfexportdialog.h
+++ b/src/app/qgsdxfexportdialog.h
@@ -20,15 +20,16 @@
 
 #include "ui_qgsdxfexportdialogbase.h"
 #include "qgsdxfexport.h"
+#include "qgsmaplayerproxymodel.h"
 
 class QgsDxfExportDialog: public QDialog, private Ui::QgsDxfExportDialogBase
 {
     Q_OBJECT
   public:
-    QgsDxfExportDialog( const QList<QgsMapLayer*>& layerKeys, QWidget * parent = 0, Qt::WindowFlags f = 0 );
+    QgsDxfExportDialog( QWidget * parent = 0, Qt::WindowFlags f = 0 );
     ~QgsDxfExportDialog();
 
-    QList<QString> layers() const;
+    QList<QgsMapLayer *> layers() const;
     double symbologyScale() const;
     QgsDxfExport::SymbologyExport symbologyMode() const;
     QString saveFile() const;
@@ -43,6 +44,9 @@ class QgsDxfExportDialog: public QDialog, private Ui::QgsDxfExportDialogBase
     void on_mFileSelectionButton_clicked();
     void setOkEnabled();
     void saveSettings();
+
+  private:
+    QgsMapLayerProxyModel* mModel;
 };
 
 #endif // QGSDXFEXPORTDIALOG_H

--- a/src/core/composer/qgsatlascomposition.h
+++ b/src/core/composer/qgsatlascomposition.h
@@ -96,8 +96,11 @@ class CORE_EXPORT QgsAtlasComposition : public QObject
     QString featureFilter() const { return mFeatureFilter; }
     void setFeatureFilter( const QString& expression ) { mFeatureFilter = expression; }
 
-    int sortKeyAttributeIndex() const { return mSortKeyAttributeIdx; }
-    void setSortKeyAttributeIndex( int idx ) { mSortKeyAttributeIdx = idx; }
+    QString sortKeyAttributeName() const { return mSortKeyAttributeName; }
+    void setSortKeyAttributeName( QString fieldName ) { mSortKeyAttributeName = fieldName; }
+
+    Q_DECL_DEPRECATED int sortKeyAttributeIndex() const;
+    Q_DECL_DEPRECATED void setSortKeyAttributeIndex( int idx );
 
     /** Begins the rendering. Returns true if successful, false if no matching atlas
       features found.*/
@@ -188,7 +191,7 @@ class CORE_EXPORT QgsAtlasComposition : public QObject
     // value of field that is used for ordering of features
     SorterKeys mFeatureKeys;
     // key (attribute index) used for ordering
-    int mSortKeyAttributeIdx;
+    QString mSortKeyAttributeName;
 
     // feature filtering
     bool mFilterFeatures;

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -88,6 +88,8 @@ qgsexpressionhighlighter.cpp
 qgsexpressionselectiondialog.cpp
 qgsextentgroupbox.cpp
 qgsfeatureselectiondlg.cpp
+qgsfieldcombobox.cpp
+qgsfieldmodel.cpp
 qgsfieldvalidator.cpp
 qgsfiledropedit.cpp
 qgsfilterlineedit.cpp
@@ -103,6 +105,9 @@ qgsmapcanvasitem.cpp
 qgsmapcanvasmap.cpp
 qgsmapcanvassnapper.cpp
 qgsmaplayeractionregistry.cpp
+qgsmaplayercombobox.cpp
+qgsmaplayermodel.cpp
+qgsmaplayerproxymodel.cpp
 qgsmapoverviewcanvas.cpp
 qgsmaptip.cpp
 qgsmaptool.cpp
@@ -227,6 +232,8 @@ qgsexpressionhighlighter.h
 qgsexpressionselectiondialog.h
 qgsextentgroupbox.h
 qgsfeatureselectiondlg.h
+qgsfieldcombobox.h
+qgsfieldmodel.h
 qgsfieldvalidator.h
 qgsfilterlineedit.h
 qgsformannotationitem.h
@@ -238,6 +245,9 @@ qgsludialog.h
 qgsmanageconnectionsdialog.h
 qgsmapcanvas.h
 qgsmaplayeractionregistry.h
+qgsmaplayercombobox.h
+qgsmaplayermodel.h
+qgsmaplayerproxymodel.h
 qgsmapoverviewcanvas.h
 qgsmaptool.h
 qgsmaptoolemitpoint.h
@@ -292,6 +302,8 @@ qgsexpressionbuilderwidget.h
 qgsexpressionhighlighter.h
 qgsexpressionselectiondialog.h
 qgsfeatureselectiondlg.h
+qgsfieldcombobox.h
+qgsfieldmodel.h
 qgsfieldvalidator.h
 qgsfiledropedit.h
 qgsfilterlineedit.h
@@ -301,6 +313,9 @@ qgsmapcanvas.h
 qgsmapcanvasitem.h
 qgsmapcanvasmap.h
 qgsmapcanvassnapper.h
+qgsmaplayercombobox.h
+qgsmaplayermodel.h
+qgsmaplayerproxymodel.h
 qgsmapoverviewcanvas.h
 qgsmaptip.h
 qgsmaptool.h

--- a/src/gui/qgsfieldcombobox.cpp
+++ b/src/gui/qgsfieldcombobox.cpp
@@ -1,0 +1,66 @@
+/***************************************************************************
+   qgsfieldcombobox.cpp
+    --------------------------------------
+   Date                 : 01.04.2014
+   Copyright            : (C) 2014 Denis Rouzaud
+   Email                : denis.rouzaud@gmail.com
+***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************/
+
+#include "qgsfieldcombobox.h"
+#include "qgsfieldmodel.h"
+#include "qgsmaplayer.h"
+
+QgsFieldComboBox::QgsFieldComboBox( QWidget *parent ) :
+    QComboBox( parent )
+{
+  mFieldModel = new QgsFieldModel( this );
+  setModel( mFieldModel );
+
+  connect( this, SIGNAL( currentIndexChanged( int ) ), this, SLOT( indexChanged( int ) ) );
+}
+
+void QgsFieldComboBox::setLayer( QgsMapLayer *layer )
+{
+  mFieldModel->setLayer( layer );
+}
+
+void QgsFieldComboBox::setField( QString fieldName )
+{
+  QModelIndex idx = mFieldModel->indexFromName( fieldName );
+  if ( idx.isValid() )
+  {
+    setCurrentIndex( idx.row() );
+  }
+  else
+  {
+    setCurrentIndex( -1 );
+  }
+}
+
+QString QgsFieldComboBox::currentField()
+{
+  int i = currentIndex();
+
+  const QModelIndex index = mFieldModel->index( i, 0 );
+  if ( !index.isValid() )
+  {
+    return "";
+  }
+
+  QString name = mFieldModel->data( index, QgsFieldModel::FieldNameRole ).toString();
+  return name;
+}
+
+void QgsFieldComboBox::indexChanged( int i )
+{
+  Q_UNUSED( i );
+  QString name = currentField();
+  emit fieldChanged( name );
+}

--- a/src/gui/qgsfieldcombobox.h
+++ b/src/gui/qgsfieldcombobox.h
@@ -1,0 +1,67 @@
+/***************************************************************************
+   qgsfieldcombobox.h
+    --------------------------------------
+   Date                 : 01.04.2014
+   Copyright            : (C) 2014 Denis Rouzaud
+   Email                : denis.rouzaud@gmail.com
+***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************/
+
+#ifndef QGSFIELDCOMBOBOX_H
+#define QGSFIELDCOMBOBOX_H
+
+#include <QComboBox>
+
+class QgsFieldModel;
+class QgsMapLayer;
+
+/**
+ * @brief The QgsFieldComboBox is a combo box which displays the list of fields of a given layer.
+ * @note added in 2.3
+ */
+class GUI_EXPORT QgsFieldComboBox : public QComboBox
+{
+    Q_OBJECT
+  public:
+    /**
+     * @brief QgsFieldComboBox creates a combo box to display the fields of a layer.
+     * The layer can be either manually given or dynamically set by connecting the signal QgsMapLayerComboBox::layerChanged to the slot setLayer.
+     */
+    explicit QgsFieldComboBox( QWidget *parent = 0 );
+
+    /**
+     * @brief currentField returns the currently selected field
+     */
+    QString currentField();
+
+  signals:
+    /**
+     * @brief fieldChanged the signal is emitted when the currently selected field changes
+     */
+    void fieldChanged( QString fieldName );
+
+  public slots:
+    /**
+     * @brief setLayer sets the layer of which the fields are listed
+     */
+    void setLayer( QgsMapLayer* layer );
+    /**
+     * @brief setField sets the currently selected field
+     */
+    void setField( QString fieldName );
+
+  protected slots:
+    void indexChanged( int i );
+
+  private:
+    QgsFieldModel* mFieldModel;
+
+};
+
+#endif // QGSFIELDCOMBOBOX_H

--- a/src/gui/qgsfieldmodel.cpp
+++ b/src/gui/qgsfieldmodel.cpp
@@ -1,0 +1,126 @@
+/***************************************************************************
+   qgsfieldmodel.cpp
+    --------------------------------------
+   Date                 : 01.04.2014
+   Copyright            : (C) 2014 Denis Rouzaud
+   Email                : denis.rouzaud@gmail.com
+***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************/
+
+#include "qgsfieldmodel.h"
+#include "qgsmaplayermodel.h"
+#include "qgsmaplayerproxymodel.h"
+#include "qgslogger.h"
+
+
+const int QgsFieldModel::FieldIndexRole = Qt::UserRole + 1;
+const int QgsFieldModel::FieldNameRole = Qt::UserRole + 2;
+
+QgsFieldModel::QgsFieldModel( QObject *parent )
+    : QAbstractItemModel( parent )
+    , mLayer( NULL )
+{
+}
+
+QModelIndex QgsFieldModel::indexFromName( QString fieldName )
+{
+  int r = mFields.indexFromName( fieldName );
+  return index( r, 0 );
+}
+
+
+void QgsFieldModel::setLayer( QgsMapLayer *layer )
+{
+  if ( mLayer )
+  {
+    disconnect( mLayer, SIGNAL( updatedFields() ), this, SLOT( updateFields() ) );
+    disconnect( mLayer, SIGNAL( layerDeleted() ), this, SLOT( layerDeleted() ) );
+  }
+  QgsVectorLayer* vl = dynamic_cast<QgsVectorLayer*>( layer );
+  if ( vl )
+  {
+    mLayer = vl;
+    connect( mLayer, SIGNAL( updatedFields() ), this, SLOT( updateFields() ) );
+    connect( mLayer, SIGNAL( layerDeleted() ), this, SLOT( layerDeleted() ) );
+  }
+  else
+  {
+    mLayer = 0;
+  }
+  updateFields();
+}
+
+void QgsFieldModel::layerDeleted()
+{
+  mLayer = 0;
+  updateFields();
+}
+
+void QgsFieldModel::updateFields()
+{
+  beginResetModel();
+  if ( mLayer )
+    mFields = mLayer->pendingFields();
+  else
+    mFields = QgsFields();
+  endResetModel();
+}
+
+QModelIndex QgsFieldModel::index( int row, int column, const QModelIndex &parent ) const
+{
+  Q_UNUSED( parent );
+  if ( row < 0 || row >= mFields.count() )
+    return QModelIndex();
+
+  return createIndex( row, column, row );
+}
+
+QModelIndex QgsFieldModel::parent( const QModelIndex &child ) const
+{
+  Q_UNUSED( child );
+  return QModelIndex();
+}
+
+int QgsFieldModel::rowCount( const QModelIndex &parent ) const
+{
+  Q_UNUSED( parent );
+  return mFields.count();
+}
+
+int QgsFieldModel::columnCount( const QModelIndex &parent ) const
+{
+  Q_UNUSED( parent );
+  return 1;
+}
+
+QVariant QgsFieldModel::data( const QModelIndex &index, int role ) const
+{
+  if ( !index.isValid() )
+    return QVariant();
+
+  if ( !mLayer )
+    return QVariant();
+
+  if ( role == Qt::DisplayRole )
+  {
+    QgsField field = mFields[index.internalId()];
+    const QMap< QString, QString > aliases = mLayer->attributeAliases();
+    QString alias = aliases.value( field.name(), field.name() );
+    return alias;
+  }
+
+  if ( role == Qt::UserRole )
+  {
+    QgsField field = mFields[index.internalId()];
+    return field.name();
+  }
+
+  return QVariant();
+}
+

--- a/src/gui/qgsfieldmodel.cpp
+++ b/src/gui/qgsfieldmodel.cpp
@@ -107,6 +107,17 @@ QVariant QgsFieldModel::data( const QModelIndex &index, int role ) const
   if ( !mLayer )
     return QVariant();
 
+  if ( role == FieldNameRole )
+  {
+    QgsField field = mFields[index.internalId()];
+    return field.name();
+  }
+
+  if ( role == FieldIndexRole )
+  {
+    return index.row();
+  }
+
   if ( role == Qt::DisplayRole )
   {
     QgsField field = mFields[index.internalId()];

--- a/src/gui/qgsfieldmodel.h
+++ b/src/gui/qgsfieldmodel.h
@@ -1,0 +1,72 @@
+/***************************************************************************
+   qgsfieldmodel.h
+    --------------------------------------
+   Date                 : 01.04.2014
+   Copyright            : (C) 2014 Denis Rouzaud
+   Email                : denis.rouzaud@gmail.com
+***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************/
+
+#ifndef QGSFIELDMODEL_H
+#define QGSFIELDMODEL_H
+
+#include <QAbstractItemModel>
+#include <QItemSelectionModel>
+#include <QComboBox>
+
+#include "qgsvectorlayer.h"
+
+/**
+ * @brief The QgsFieldModel class is a model to display the list of fields of a layer in widgets.
+ * It can be associated with a QgsMapLayerModel to dynamically display a layer and its fields.
+ * @note added in 2.3
+ */
+
+class GUI_EXPORT QgsFieldModel : public QAbstractItemModel
+{
+    Q_OBJECT
+  public:
+    static const int FieldNameRole, FieldIndexRole;
+
+    /**
+     * @brief QgsFieldModel creates a model to display the fields of a given layer
+     */
+    explicit QgsFieldModel( QObject *parent = 0 );
+
+    /**
+     * @brief indexFromName returns the index corresponding to a given fieldName
+     */
+    QModelIndex indexFromName( QString fieldName );
+
+  public slots:
+    /**
+     * @brief setLayer sets the layer of whch fields are displayed
+     */
+    void setLayer( QgsMapLayer *layer );
+
+  protected slots:
+    void updateFields();
+    void layerDeleted();
+
+  protected:
+    QgsFields mFields;
+    QgsVectorLayer* mLayer;
+
+    // QAbstractItemModel interface
+  public:
+    QModelIndex index( int row, int column, const QModelIndex &parent = QModelIndex() ) const;
+    QModelIndex parent( const QModelIndex &child ) const;
+    int rowCount( const QModelIndex &parent ) const;
+    int columnCount( const QModelIndex &parent ) const;
+    QVariant data( const QModelIndex &index, int role ) const;
+
+
+};
+
+#endif // QGSFIELDMODEL_H

--- a/src/gui/qgsmaplayercombobox.cpp
+++ b/src/gui/qgsmaplayercombobox.cpp
@@ -1,0 +1,79 @@
+/***************************************************************************
+   qgsmaplayercombobox.cpp
+    --------------------------------------
+   Date                 : 01.04.2014
+   Copyright            : (C) 2014 Denis Rouzaud
+   Email                : denis.rouzaud@gmail.com
+***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************/
+
+#include "qgsmaplayercombobox.h"
+#include "qgsmaplayermodel.h"
+
+QgsMapLayerComboBox::QgsMapLayerComboBox( QWidget *parent ) :
+    QComboBox( parent )
+{
+  mProxyModel = new QgsMapLayerProxyModel( this );
+  setModel( mProxyModel );
+
+  connect( this, SIGNAL( currentIndexChanged( int ) ), this, SLOT( indexChanged( int ) ) );
+}
+
+void QgsMapLayerComboBox::setFilters( QgsMapLayerProxyModel::Filters filters )
+{
+  mProxyModel->setFilters( filters );
+}
+
+void QgsMapLayerComboBox::setLayer( QgsMapLayer *layer )
+{
+  QModelIndex idx = mProxyModel->sourceLayerModel()->indexFromLayer( layer );
+  if ( idx.isValid() )
+  {
+    QModelIndex proxyIdx = mProxyModel->mapFromSource( idx );
+    if ( proxyIdx.isValid() )
+    {
+      setCurrentIndex( proxyIdx.row() );
+      return;
+    }
+  }
+  setCurrentIndex( -1 );
+}
+
+QgsMapLayer* QgsMapLayerComboBox::currentLayer()
+{
+  int i = currentIndex();
+
+  const QModelIndex proxyIndex = mProxyModel->index( i, 0 );
+  if ( !proxyIndex.isValid() )
+  {
+    return 0;
+  }
+
+  const QModelIndex index = mProxyModel->mapToSource( proxyIndex );
+  if ( !index.isValid() )
+  {
+    return 0;
+  }
+
+  QgsMapLayer* layer = static_cast<QgsMapLayer*>( index.internalPointer() );
+  if ( layer )
+  {
+    return layer;
+  }
+  return 0;
+}
+
+void QgsMapLayerComboBox::indexChanged( int i )
+{
+  Q_UNUSED( i );
+  QgsMapLayer* layer = currentLayer();
+  emit layerChanged( layer );
+}
+
+

--- a/src/gui/qgsmaplayercombobox.h
+++ b/src/gui/qgsmaplayercombobox.h
@@ -1,0 +1,70 @@
+/***************************************************************************
+   qgsmaplayercombobox.h
+    --------------------------------------
+   Date                 : 01.04.2014
+   Copyright            : (C) 2014 Denis Rouzaud
+   Email                : denis.rouzaud@gmail.com
+***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************/
+
+#ifndef QGSMAPLAYERCOMBOBOX_H
+#define QGSMAPLAYERCOMBOBOX_H
+
+#include <QComboBox>
+
+#include "qgsmaplayerproxymodel.h"
+
+class QgsMapLayer;
+class QgsVectorLayer;
+
+/**
+ * @brief The QgsMapLayerComboBox class is a combo box which displays the list of layers
+ * @note added in 2.3
+ */
+class GUI_EXPORT QgsMapLayerComboBox : public QComboBox
+{
+    Q_OBJECT
+  public:
+    /**
+     * @brief QgsMapLayerComboBox creates a combo box to dislpay the list of layers (currently in the registry).
+     * The layers can be filtered and/or ordered.
+     */
+    explicit QgsMapLayerComboBox( QWidget *parent = 0 );
+
+    /**
+     * @brief setFilters allows fitering according to layer type and/or geometry type.
+     */
+    void setFilters( QgsMapLayerProxyModel::Filters filters );
+
+    /**
+     * @brief currentLayer returns the current layer selected in the combo box
+     */
+    QgsMapLayer* currentLayer();
+
+  public slots:
+    /**
+     * @brief setLayer set the current layer selected in the combo
+     */
+    void setLayer( QgsMapLayer* layer );
+
+  signals:
+    /**
+     * @brief layerChanged this signal is emitted whenever the currently selected layer changes
+     */
+    void layerChanged( QgsMapLayer* layer );
+
+  protected slots:
+    void indexChanged( int i );
+
+  private:
+    QgsMapLayerProxyModel* mProxyModel;
+
+};
+
+#endif // QGSMAPLAYERCOMBOBOX_H

--- a/src/gui/qgsmaplayermodel.cpp
+++ b/src/gui/qgsmaplayermodel.cpp
@@ -1,0 +1,238 @@
+/***************************************************************************
+   qgsmaplayermodel.cpp
+    --------------------------------------
+   Date                 : 01.04.2014
+   Copyright            : (C) 2014 Denis Rouzaud
+   Email                : denis.rouzaud@gmail.com
+***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************/
+
+#include <QIcon>
+
+#include "qgsmaplayermodel.h"
+#include "qgsmaplayerregistry.h"
+#include "qgsapplication.h"
+#include "qgsvectorlayer.h"
+
+
+const int QgsMapLayerModel::LayerIdRole = Qt::UserRole + 1;
+
+QgsMapLayerModel::QgsMapLayerModel( QList<QgsMapLayer *> layers, QObject *parent )
+    : QAbstractItemModel( parent )
+    , mLayersChecked( QMap<QString, Qt::CheckState>() )
+    , mItemCheckable( false )
+{
+  connect( QgsMapLayerRegistry::instance(), SIGNAL( removeLayers( QStringList ) ), this, SLOT( removeLayers( QStringList ) ) );
+  addLayers( layers );
+}
+
+QgsMapLayerModel::QgsMapLayerModel( QObject *parent )
+    : QAbstractItemModel( parent )
+    , mLayersChecked( QMap<QString, Qt::CheckState>() )
+    , mItemCheckable( false )
+{
+  connect( QgsMapLayerRegistry::instance(), SIGNAL( layersAdded( QList<QgsMapLayer*> ) ), this, SLOT( addLayers( QList<QgsMapLayer*> ) ) );
+  connect( QgsMapLayerRegistry::instance(), SIGNAL( layersRemoved( QStringList ) ), this, SLOT( removeLayers( QStringList ) ) );
+  addLayers( QgsMapLayerRegistry::instance()->mapLayers().values() );
+}
+
+void QgsMapLayerModel::setItemsCheckable( bool checkable )
+{
+  mItemCheckable = checkable;
+}
+
+void QgsMapLayerModel::checkAll( Qt::CheckState checkState )
+{
+  foreach ( const QString key, mLayersChecked.keys() )
+  {
+    mLayersChecked[key] = checkState;
+  }
+  emit dataChanged( index( 0, 0 ), index( mLayers.length() - 1, 0 ) );
+}
+
+QList<QgsMapLayer *> QgsMapLayerModel::layersChecked( Qt::CheckState checkState )
+{
+  QList<QgsMapLayer *> layers;
+  foreach ( QgsMapLayer* layer, mLayers )
+  {
+    if ( mLayersChecked[layer->id()] == checkState )
+    {
+      layers.append( layer );
+    }
+  }
+  return layers;
+}
+
+QModelIndex QgsMapLayerModel::indexFromLayer( QgsMapLayer *layer )
+{
+  int r = mLayers.indexOf( layer );
+  return index( r, 0 );
+}
+
+void QgsMapLayerModel::removeLayers( const QStringList layerIds )
+{
+  foreach ( const QString layerId, layerIds )
+  {
+    QModelIndex startIndex = index( 0, 0 );
+    QModelIndexList list = match( startIndex, LayerIdRole, layerId, 1 );
+    if ( list.count() )
+    {
+      QModelIndex index = list[0];
+      beginRemoveRows( QModelIndex(), index.row(), index.row() );
+      mLayersChecked.remove( layerId );
+      mLayers.removeAt( index.row() );
+      endRemoveRows();
+    }
+  }
+}
+
+void QgsMapLayerModel::addLayers( QList<QgsMapLayer *> layers )
+{
+  beginInsertRows( QModelIndex(), mLayers.count(), mLayers.count() + layers.count() - 1 );
+  foreach ( QgsMapLayer* layer, layers )
+  {
+    mLayers.append( layer );
+    mLayersChecked.insert( layer->id(), Qt::Unchecked );
+  }
+  endInsertRows();
+}
+
+QModelIndex QgsMapLayerModel::index( int row, int column, const QModelIndex &parent ) const
+{
+  Q_UNUSED( parent );
+  if ( row < 0 || row >= mLayers.length() )
+    return QModelIndex();
+
+  return createIndex( row, column, mLayers[row] );
+}
+
+QModelIndex QgsMapLayerModel::parent( const QModelIndex &child ) const
+{
+  Q_UNUSED( child );
+  return QModelIndex();
+}
+
+int QgsMapLayerModel::rowCount( const QModelIndex &parent ) const
+{
+  Q_UNUSED( parent );
+
+  return mLayers.length();
+}
+
+int QgsMapLayerModel::columnCount( const QModelIndex &parent ) const
+{
+  Q_UNUSED( parent );
+  return 1;
+}
+
+QVariant QgsMapLayerModel::data( const QModelIndex &index, int role ) const
+{
+  if ( !index.isValid() || !index.internalPointer() )
+    return QVariant();
+
+  if ( role == Qt::DisplayRole )
+  {
+    QgsMapLayer* layer = static_cast<QgsMapLayer*>( index.internalPointer() );
+    return layer->name();
+  }
+
+  if ( role == LayerIdRole )
+  {
+    QgsMapLayer* layer = static_cast<QgsMapLayer*>( index.internalPointer() );
+    return layer->id();
+  }
+
+  if ( role == Qt::CheckStateRole )
+  {
+    QgsMapLayer* layer = static_cast<QgsMapLayer*>( index.internalPointer() );
+    return mLayersChecked[layer->id()];
+  }
+
+  if ( role == Qt::DecorationRole )
+  {
+    QgsMapLayer* layer = static_cast<QgsMapLayer*>( index.internalPointer() );
+    QgsMapLayer::LayerType type = layer->type();
+    if ( role == Qt::DecorationRole )
+    {
+      switch ( type )
+      {
+        case QgsMapLayer::RasterLayer:
+        {
+          return QgsApplication::getThemeIcon( "/mIconRasterLayer.svg" );
+        }
+
+        case QgsMapLayer::VectorLayer:
+        {
+          QgsVectorLayer* vl = dynamic_cast<QgsVectorLayer*>( layer );
+          if ( !vl )
+          {
+            return QIcon();
+          }
+          QGis::GeometryType geomType = vl->geometryType();
+          switch ( geomType )
+          {
+            case QGis::Point:
+            {
+              return QgsApplication::getThemeIcon( "/mIconPointLayer.svg" );
+            }
+            case QGis::Polygon :
+            {
+              return QgsApplication::getThemeIcon( "/mIconPolygonLayer.svg" );
+            }
+            case QGis::Line :
+            {
+              return QgsApplication::getThemeIcon( "/mIconLineLayer.svg" );
+            }
+            case QGis::NoGeometry :
+            {
+              return QgsApplication::getThemeIcon( "/mIconTableLayer.png" );
+            }
+            default:
+            {
+              return QIcon();
+            }
+          }
+        }
+        default:
+        {
+          return QIcon();
+        }
+      }
+    }
+  }
+
+  return QVariant();
+}
+
+
+Qt::ItemFlags QgsMapLayerModel::flags( const QModelIndex &index ) const
+{
+  Q_UNUSED( index );
+
+  Qt::ItemFlags flags = Qt::ItemIsEnabled | Qt::ItemIsSelectable;
+  if ( mItemCheckable )
+  {
+    flags |= Qt::ItemIsUserCheckable;
+  }
+  return flags;
+}
+
+
+bool QgsMapLayerModel::setData( const QModelIndex &index, const QVariant &value, int role )
+{
+  if ( role == Qt::CheckStateRole )
+  {
+    QgsMapLayer* layer = static_cast<QgsMapLayer*>( index.internalPointer() );
+    mLayersChecked[layer->id()] = ( Qt::CheckState )value.toInt();
+    emit dataChanged( index, index );
+    return true;
+  }
+
+  return false;
+}

--- a/src/gui/qgsmaplayermodel.cpp
+++ b/src/gui/qgsmaplayermodel.cpp
@@ -148,7 +148,7 @@ QVariant QgsMapLayerModel::data( const QModelIndex &index, int role ) const
     return layer->id();
   }
 
-  if ( role == Qt::CheckStateRole )
+  if ( role == Qt::CheckStateRole && mItemCheckable )
   {
     QgsMapLayer* layer = static_cast<QgsMapLayer*>( index.internalPointer() );
     return mLayersChecked[layer->id()];

--- a/src/gui/qgsmaplayermodel.h
+++ b/src/gui/qgsmaplayermodel.h
@@ -1,0 +1,88 @@
+/***************************************************************************
+   qgsmaplayermodel.h
+    --------------------------------------
+   Date                 : 01.04.2014
+   Copyright            : (C) 2014 Denis Rouzaud
+   Email                : denis.rouzaud@gmail.com
+***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************/
+
+#ifndef QGSMAPLAYERMODEL_H
+#define QGSMAPLAYERMODEL_H
+
+#include <QAbstractItemModel>
+#include <QSortFilterProxyModel>
+#include <QStringList>
+
+class QgsMapLayer;
+
+
+/**
+ * @brief The QgsMapLayerModel class is a model to display layers in widgets.
+ * @see QgsMapLayerProxyModel to sort and/filter the layers
+ * @see QgsFieldModel to combine in with a field selector.
+ * @note added in 2.3
+ */
+class GUI_EXPORT QgsMapLayerModel : public QAbstractItemModel
+{
+    Q_OBJECT
+  public:
+    static const int LayerIdRole;
+
+    /**
+     * @brief QgsMapLayerModel creates a model to display layers in widgets.
+     */
+    explicit QgsMapLayerModel( QObject *parent = 0 );
+    /**
+     * @brief QgsMapLayerModel creates a model to display a specific list of layers in a widget.
+     */
+    explicit QgsMapLayerModel( QList<QgsMapLayer*> layers, QObject *parent = 0 );
+
+    /**
+     * @brief setItemsCheckable defines if layers should be selectable in the widget
+     */
+    void setItemsCheckable( bool checkable );
+    /**
+     * @brief checkAll changes the checkstate for all the layers
+     */
+    void checkAll( Qt::CheckState checkState );
+    /**
+     * @brief layersChecked returns the list of layers which are checked (or unchecked)
+     */
+    QList<QgsMapLayer*> layersChecked( Qt::CheckState checkState = Qt::Checked );
+    //! returns if the items can be checked or not
+    bool itemsCheckable() {return mItemCheckable;}
+
+    /**
+     * @brief indexFromLayer returns the model index for a given layer
+     */
+    QModelIndex indexFromLayer( QgsMapLayer* layer );
+
+
+  protected slots:
+    void removeLayers( const QStringList layerIds );
+    void addLayers( QList<QgsMapLayer*> layers );
+
+  protected:
+    QList<QgsMapLayer*> mLayers;
+    QMap<QString, Qt::CheckState> mLayersChecked;
+    bool mItemCheckable;
+
+    // QAbstractItemModel interface
+  public:
+    QModelIndex index( int row, int column, const QModelIndex &parent = QModelIndex() ) const;
+    QModelIndex parent( const QModelIndex &child ) const;
+    int rowCount( const QModelIndex &parent ) const;
+    int columnCount( const QModelIndex &parent ) const;
+    QVariant data( const QModelIndex &index, int role ) const;
+    bool setData( const QModelIndex &index, const QVariant &value, int role );
+    Qt::ItemFlags flags( const QModelIndex &index ) const;
+};
+
+#endif // QGSMAPLAYERMODEL_H

--- a/src/gui/qgsmaplayerproxymodel.cpp
+++ b/src/gui/qgsmaplayerproxymodel.cpp
@@ -1,0 +1,83 @@
+/***************************************************************************
+   qgsmaplayerproxymodel.cpp
+    --------------------------------------
+   Date                 : 01.04.2014
+   Copyright            : (C) 2014 Denis Rouzaud
+   Email                : denis.rouzaud@gmail.com
+***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************/
+
+#include "qgsmaplayerproxymodel.h"
+#include "qgsmaplayermodel.h"
+#include "qgsmaplayer.h"
+#include "qgsvectorlayer.h"
+
+QgsMapLayerProxyModel::QgsMapLayerProxyModel( QObject *parent )
+    : QSortFilterProxyModel( parent )
+    , mFilters( NoFilter )
+    , mModel( new QgsMapLayerModel( this ) )
+{
+  setSourceModel( mModel );
+}
+
+QgsMapLayerProxyModel *QgsMapLayerProxyModel::setFilters( Filters filters )
+{
+  mFilters = filters;
+  return this;
+}
+
+bool QgsMapLayerProxyModel::filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const
+{
+  if ( mFilters.testFlag( NoFilter ) )
+    return true;
+
+  QModelIndex index = sourceModel()->index( source_row, 0, source_parent );
+  QgsMapLayer* layer = static_cast<QgsMapLayer*>( index.internalPointer() );
+  if ( !layer )
+    return false;
+
+  // layer type
+  if (( mFilters.testFlag( RasterLayer ) && layer->type() == QgsMapLayer::RasterLayer ) ||
+      ( mFilters.testFlag( VectorLayer ) && layer->type() == QgsMapLayer::VectorLayer ) )
+    return true;
+
+  // geometry type
+  bool detectGeometry = mFilters.testFlag( NoGeometry ) ||
+                        mFilters.testFlag( PointLayer ) ||
+                        mFilters.testFlag( LineLayer ) ||
+                        mFilters.testFlag( PolygonLayer ) ||
+                        mFilters.testFlag( HasGeometry );
+  if ( detectGeometry && layer->type() == QgsMapLayer::VectorLayer )
+  {
+    QgsVectorLayer* vl = dynamic_cast<QgsVectorLayer*>( layer );
+    if ( vl )
+    {
+      if ( mFilters.testFlag( HasGeometry ) && vl->hasGeometryType() )
+        return true;
+      if ( mFilters.testFlag( NoGeometry ) && vl->geometryType() == QGis::NoGeometry )
+        return true;
+      if ( mFilters.testFlag( PointLayer ) && vl->geometryType() == QGis::Point )
+        return true;
+      if ( mFilters.testFlag( LineLayer ) && vl->geometryType() == QGis::Line )
+        return true;
+      if ( mFilters.testFlag( PolygonLayer ) && vl->geometryType() == QGis::Polygon )
+        return true;
+    }
+  }
+
+  return false;
+}
+
+bool QgsMapLayerProxyModel::lessThan( const QModelIndex &left, const QModelIndex &right ) const
+{
+  // default mode is alphabetical order
+  QString leftId = sourceModel()->data( left ).toString();
+  QString rightId = sourceModel()->data( right ).toString();
+  return QString::localeAwareCompare( leftId, rightId ) < 0;
+}

--- a/src/gui/qgsmaplayerproxymodel.h
+++ b/src/gui/qgsmaplayerproxymodel.h
@@ -1,0 +1,75 @@
+/***************************************************************************
+   qgsmaplayerproxymodel.h
+    --------------------------------------
+   Date                 : 01.04.2014
+   Copyright            : (C) 2014 Denis Rouzaud
+   Email                : denis.rouzaud@gmail.com
+***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************/
+
+#ifndef QGSMAPLAYERPROXYMODEL_H
+#define QGSMAPLAYERPROXYMODEL_H
+
+#include <QSortFilterProxyModel>
+
+class QgsMapLayerModel;
+
+/**
+ * @brief The QgsMapLayerProxModel class provides an easy to use model to display the list of layers in widgets.
+ * @note added in 2.3
+ */
+class GUI_EXPORT QgsMapLayerProxyModel : public QSortFilterProxyModel
+{
+    Q_OBJECT
+  public:
+    enum Filter
+    {
+      NoFilter = 1,
+      RasterLayer = 2,
+      NoGeometry = 4,
+      PointLayer = 8,
+      LineLayer = 16,
+      PolygonLayer = 32,
+      HasGeometry = PointLayer | LineLayer | PolygonLayer,
+      VectorLayer = NoGeometry | HasGeometry
+    };
+    Q_DECLARE_FLAGS( Filters, Filter )
+
+    /**
+     * @brief QgsMapLayerProxModel creates a proxy model with a QgsMapLayerModel as source model.
+     * It can be used to filter the layers list in a widget.
+     */
+    explicit QgsMapLayerProxyModel( QObject *parent = 0 );
+
+    /**
+     * @brief layerModel returns the QgsMapLayerModel used in this QSortFilterProxyModel
+     */
+    QgsMapLayerModel* sourceLayerModel() {return mModel;}
+
+    /**
+     * @brief setFilters set flags that affect how layers are filtered
+     * @param filters are Filter flags
+     * @note added in 2.3
+     */
+    QgsMapLayerProxyModel* setFilters( Filters filters );
+    const Filters& filters() const { return mFilters; }
+
+  private:
+    Filters mFilters;
+    QgsMapLayerModel* mModel;
+
+    // QSortFilterProxyModel interface
+  public:
+    bool filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const;
+    bool lessThan( const QModelIndex &left, const QModelIndex &right ) const;
+};
+
+Q_DECLARE_OPERATORS_FOR_FLAGS( QgsMapLayerProxyModel::Filters )
+
+#endif // QGSMAPLAYERPROXYMODEL_H

--- a/src/ui/qgsatlascompositionwidgetbase.ui
+++ b/src/ui/qgsatlascompositionwidgetbase.ui
@@ -131,7 +131,7 @@
               </widget>
              </item>
              <item row="0" column="2">
-              <widget class="QComboBox" name="mAtlasCoverageLayerComboBox">
+              <widget class="QgsMapLayerComboBox" name="mAtlasCoverageLayerComboBox">
                <property name="sizePolicy">
                 <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
                  <horstretch>0</horstretch>
@@ -206,7 +206,7 @@
               </widget>
              </item>
              <item row="3" column="1">
-              <widget class="QComboBox" name="mAtlasSortFeatureKeyComboBox"/>
+              <widget class="QgsFieldComboBox" name="mAtlasSortFeatureKeyComboBox"/>
              </item>
              <item row="3" column="0">
               <widget class="QCheckBox" name="mAtlasSortFeatureCheckBox">
@@ -284,8 +284,18 @@
   <customwidget>
    <class>QgsCollapsibleGroupBoxBasic</class>
    <extends>QGroupBox</extends>
-   <header location="global">qgscollapsiblegroupbox.h</header>
+   <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsMapLayerComboBox</class>
+   <extends>QComboBox</extends>
+   <header location="global">qgsmaplayercombobox.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsFieldComboBox</class>
+   <extends>QComboBox</extends>
+   <header location="global">qgsfieldcombobox.h</header>
   </customwidget>
  </customwidgets>
  <resources>

--- a/src/ui/qgsdxfexportdialogbase.ui
+++ b/src/ui/qgsdxfexportdialogbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>377</width>
-    <height>292</height>
+    <width>406</width>
+    <height>293</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -80,7 +80,11 @@
       <widget class="QLineEdit" name="mSymbologyScaleLineEdit"/>
      </item>
      <item row="3" column="0" colspan="3">
-      <widget class="QListWidget" name="mLayersListWidget"/>
+      <widget class="QListView" name="mLayersListView">
+       <property name="selectionMode">
+        <enum>QAbstractItemView::NoSelection</enum>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>

--- a/tests/src/core/testqgsatlascomposition.cpp
+++ b/tests/src/core/testqgsatlascomposition.cpp
@@ -330,7 +330,7 @@ void TestQgsAtlasComposition::sorting_render()
   mAtlas->setHideCoverage( false );
 
   mAtlas->setSortFeatures( true );
-  mAtlas->setSortKeyAttributeIndex( 4 ); // departement name
+  mAtlas->setSortKeyAttributeName( "NAME_1" ); // departement name
   mAtlas->setSortAscending( false );
 
   mAtlas->beginRender();


### PR DESCRIPTION
This implements a model/view for selecting layers and eventually their corresponding fields.

The models can be used directly on top of widgets.
Anyway, I implement sub-classes of QComboBox since the connection between layer and fields models can only be made by the selection model. And, having the field model changed by a change in selection in the layer combo is not a good idea (it must be changed on currentItemChanged and not selection changed).

For testing, I implemented these model in two places:
- DXF export: a checkable list of layers
- Atlas: a layer combo related to a field combo

Also, my intention is to extend the field model and combo to handle expressions (since it is used in many places).

Thanks a lot to @NathanW2 for his initial python model: https://gist.github.com/NathanW2/d2bf29d9043c5658dab2
and to @wonder-sk for his advices.
