### PR TITLE
Fix bug #9861: self crossing lines stop rendering if offset is set

### DIFF
--- a/src/core/symbology-ng/qgslinesymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgslinesymbollayerv2.cpp
@@ -250,7 +250,8 @@ void QgsSimpleLineSymbolLayerV2::renderPolyline( const QPolygonF& points, QgsSym
   else
   {
     double scaledOffset = offset * QgsSymbolLayerV2Utils::lineWidthScaleFactor( context.renderContext(), mOffsetUnit );
-    p->drawPolyline( ::offsetLine( points, scaledOffset ) );
+    QList<QPolygonF> mline = ::offsetLine( points, scaledOffset );
+    for ( int part = 0; part < mline.count(); ++part ) p->drawPolyline( mline[ part ] );
   }
 }
 
@@ -721,13 +722,19 @@ void QgsMarkerLineSymbolLayerV2::renderPolyline( const QPolygonF& points, QgsSym
   }
   else
   {
-    QPolygonF points2 = ::offsetLine( points, offset * QgsSymbolLayerV2Utils::lineWidthScaleFactor( context.renderContext(), mOffsetUnit ) );
-    if ( placement == Interval )
-      renderPolylineInterval( points2, context );
-    else if ( placement == CentralPoint )
-      renderPolylineCentral( points2, context );
-    else
-      renderPolylineVertex( points2, context, placement );
+    QList<QPolygonF> mline = ::offsetLine( points, offset * QgsSymbolLayerV2Utils::lineWidthScaleFactor( context.renderContext(), mOffsetUnit ) );
+
+    for ( int part = 0; part < mline.count(); ++part )
+    {
+      QPolygonF points2 = mline[ part ];
+
+      if ( placement == Interval )
+        renderPolylineInterval( points2, context );
+      else if ( placement == CentralPoint )
+        renderPolylineCentral( points2, context );
+      else
+        renderPolylineVertex( points2, context, placement );
+    }
   }
 }
 

--- a/src/core/symbology-ng/qgssymbollayerv2utils.cpp
+++ b/src/core/symbology-ng/qgssymbollayerv2utils.cpp
@@ -649,10 +649,15 @@ static QPointF linesIntersection( QPointF p1, double t1, QPointF p2, double t2 )
 #endif
 
 
-QPolygonF offsetLine( QPolygonF polyline, double dist )
+QList<QPolygonF> offsetLine( QPolygonF polyline, double dist )
 {
+  QList<QPolygonF> resultLine;
+
   if ( polyline.count() < 2 )
-    return polyline;
+  {
+    resultLine.append( polyline );
+    return resultLine;
+  }
 
   QPolygonF newLine;
 
@@ -675,22 +680,49 @@ QPolygonF offsetLine( QPolygonF polyline, double dist )
     if ( offsetGeom )
     {
       tempGeometry->fromGeos( offsetGeom );
-      tempPolyline = tempGeometry->asPolyline();
 
-      pointCount = tempPolyline.count();
-      newLine.resize( pointCount );
+      if ( QGis::flatType( tempGeometry->wkbType() ) == QGis::WKBLineString )
+      {
+        tempPolyline = tempGeometry->asPolyline();
 
-      QgsPoint* tempPtr2 = tempPolyline.data();
-      for ( i = 0; i < pointCount; ++i, tempPtr2++ ) newLine[i] = QPointF( tempPtr2->x(), tempPtr2->y() );
+        pointCount = tempPolyline.count();
+        newLine.resize( pointCount );
 
-      delete tempGeometry;
-      return newLine;
+        QgsPoint* tempPtr2 = tempPolyline.data();
+        for ( i = 0; i < pointCount; ++i, tempPtr2++ ) newLine[i] = QPointF( tempPtr2->x(), tempPtr2->y() );
+        resultLine.append( newLine );
+
+        delete tempGeometry;
+        return resultLine;
+      }
+      else
+      if ( QGis::flatType( tempGeometry->wkbType() ) == QGis::WKBMultiLineString )
+      {
+        QgsMultiPolyline tempMPolyline = tempGeometry->asMultiPolyline();
+
+        for ( int part = 0; part < tempMPolyline.count(); ++part )
+        {
+          tempPolyline = tempMPolyline[ part ];
+
+          pointCount = tempPolyline.count();
+          newLine.resize( pointCount );
+
+          QgsPoint* tempPtr2 = tempPolyline.data();
+          for ( i = 0; i < pointCount; ++i, tempPtr2++ ) newLine[i] = QPointF( tempPtr2->x(), tempPtr2->y() );
+          resultLine.append( newLine );
+
+          newLine = QPolygonF();
+        }
+        delete tempGeometry;
+        return resultLine;
+      }
     }
     delete tempGeometry;
   }
 
   // returns original polyline when 'GEOSOffsetCurve' fails!
-  return polyline;
+  resultLine.append( polyline );
+  return resultLine;
 
 #else
 
@@ -728,7 +760,9 @@ QPolygonF offsetLine( QPolygonF polyline, double dist )
   // last line segment:
   pt_new = offsetPoint( p2, angle + M_PI / 2, dist );
   newLine.append( pt_new );
-  return newLine;
+
+  resultLine.append( newLine );
+  return resultLine;
 
 #endif
 }

--- a/src/core/symbology-ng/qgssymbollayerv2utils.h
+++ b/src/core/symbology-ng/qgssymbollayerv2utils.h
@@ -287,7 +287,7 @@ class CORE_EXPORT QgsSymbolLayerV2Utils
 class QPolygonF;
 
 //! calculate line shifted by a specified distance
-QPolygonF offsetLine( QPolygonF polyline, double dist );
+QList<QPolygonF> offsetLine( QPolygonF polyline, double dist );
 
 
 #endif


### PR DESCRIPTION
This pull fixes the bug 9861 (http://hub.qgis.org/issues/9861).

It modifies the ::offsetline declaration to support multi geometries when a self-crossing geometry is offseted.
