### PR TITLE
Replace QtGui include with individual includes

### DIFF
--- a/src/plugins/compass/compass.h
+++ b/src/plugins/compass/compass.h
@@ -20,8 +20,6 @@
 #ifndef _COMPASS_H__
 #define _COMPASS_H__
 
-#include <QtGui>
-#include <QtCore>
 #include <QtSensors/QCompass>
 #include <QObject>
 

--- a/src/plugins/topology/checkDock.cpp
+++ b/src/plugins/topology/checkDock.cpp
@@ -15,7 +15,8 @@
  *                                                                         *
  ***************************************************************************/
 
-#include <QtGui>
+#include <QMessageBox>
+#include <QProgressDialog>
 
 #include "checkDock.h"
 

--- a/src/plugins/topology/rulesDialog.cpp
+++ b/src/plugins/topology/rulesDialog.cpp
@@ -15,7 +15,9 @@
  *                                                                         *
  ***************************************************************************/
 
-#include <QtGui>
+#include <QDebug>
+#include <QTableWidgetItem>
+
 #include <qgsvectordataprovider.h>
 #include <qgsvectorlayer.h>
 #include <qgsmaplayer.h>


### PR DESCRIPTION
Qt 5 splits QtGui into Gui and Widgets components. Including the
individual includes will solve this problem.
