### PR TITLE
Identify

### DIFF
--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -51,6 +51,13 @@
 #include <QComboBox>
 #include <QWebFrame>
 
+//graph
+#if defined(QWT_VERSION) && QWT_VERSION<0x060000
+#include <qwt_plot.h>
+#include <qwt_plot_curve.h>
+#include <qwt_symbol.h>
+#endif
+
 QgsIdentifyResultsWebView::QgsIdentifyResultsWebView( QWidget *parent ) : QWebView( parent )
 {
   setSizePolicy( QSizePolicy::MinimumExpanding, QSizePolicy::Minimum );
@@ -293,6 +300,28 @@ QgsIdentifyResultsDialog::QgsIdentifyResultsDialog( QgsMapCanvas *canvas, QWidge
     tblResults->setColumnWidth( 0, width );
   }
 
+  // graph
+  mPlot->setVisible( false );
+#if defined(QWT_VERSION) && QWT_VERSION<0x060000
+  mPlot->setAutoFillBackground( false );
+  mPlot->setAutoDelete( true );
+  QSizePolicy sizePolicy = QSizePolicy( QSizePolicy::Expanding, QSizePolicy::Expanding );
+  sizePolicy.setHorizontalStretch( 0 );
+  sizePolicy.setVerticalStretch( 0 );
+  sizePolicy.setHeightForWidth( mPlot->sizePolicy().hasHeightForWidth() );
+  mPlot->setSizePolicy( sizePolicy );
+  mPlot->updateGeometry();
+
+  mPlotCurve = new QwtPlotCurve( "" );
+  mPlotCurve->setSymbol( QwtSymbol( QwtSymbol::Ellipse, QBrush( Qt::white ),
+                                    QPen( Qt::red, 2 ), QSize( 9, 9 ) ) );
+  mPlotCurve->attach( mPlot );
+#else
+  delete mPlot;
+  mPlot = 0;
+  tabWidget->removeTab( 2 );
+#endif
+
   connect( buttonBox, SIGNAL( rejected() ), this, SLOT( close() ) );
 
   connect( lstResults, SIGNAL( itemExpanded( QTreeWidgetItem* ) ),
@@ -313,6 +342,9 @@ QgsIdentifyResultsDialog::~QgsIdentifyResultsDialog()
   clearHighlights();
   if ( mActionPopup )
     delete mActionPopup;
+#if defined(QWT_VERSION) && QWT_VERSION<0x060000
+  delete mPlotCurve;
+#endif
 }
 
 QTreeWidgetItem *QgsIdentifyResultsDialog::layerItem( QObject *object )
@@ -688,6 +720,23 @@ void QgsIdentifyResultsDialog::addFeature( QgsRasterLayer *layer,
   }
   tblResults->resizeColumnToContents( 1 );
 
+  // graph
+#if defined(QWT_VERSION) && QWT_VERSION<0x060000
+  i = mPlotCurveXData.count();
+  for ( QMap<QString, QString>::const_iterator it = attributes.begin(); it != attributes.end(); ++it )
+  {
+    mPlotCurveXData.append( double( ++i ) );
+    mPlotCurveYData.append( double( it.value().toDouble() ) );
+  }
+  mPlotCurve->setData( mPlotCurveXData, mPlotCurveYData );
+
+  mPlot->setAxisMaxMinor( QwtPlot::xBottom, 0 );
+  //mPlot->setAxisScale( QwtPlot::xBottom, 1, mPlotCurve->dataSize());
+  //mPlot->setAxisScale( QwtPlot::yLeft, ymin, ymax );
+
+  mPlot->replot();
+  mPlot->setVisible( mPlotCurveXData.count() > 0 );
+#endif
 }
 
 void QgsIdentifyResultsDialog::editingToggled()
@@ -985,6 +1034,12 @@ void QgsIdentifyResultsDialog::clear()
 
   tblResults->clearContents();
   tblResults->setRowCount( 0 );
+
+#if defined(QWT_VERSION) && QWT_VERSION<0x060000
+  mPlot->setVisible( false );
+  mPlotCurveXData.clear();
+  mPlotCurveYData.clear();
+#endif
 
   // keep it visible but disabled, it can switch from disabled/enabled
   // after raster format change

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -307,7 +307,7 @@ QgsIdentifyResultsDialog::QgsIdentifyResultsDialog( QgsMapCanvas *canvas, QWidge
 #if defined(QWT_VERSION) && QWT_VERSION<0x060000
   mPlot->setAutoFillBackground( false );
   mPlot->setAutoDelete( true );
-  mPlot->insertLegend( new QwtLegend(), QwtPlot::RightLegend );
+  mPlot->insertLegend( new QwtLegend(), QwtPlot::TopLegend );
   QSizePolicy sizePolicy = QSizePolicy( QSizePolicy::Expanding, QSizePolicy::Expanding );
   sizePolicy.setHorizontalStretch( 0 );
   sizePolicy.setVerticalStretch( 0 );

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -52,13 +52,12 @@
 #include <QWebFrame>
 
 //graph
-#if defined(QWT_VERSION) && QWT_VERSION<0x060000
 #include <qwt_plot.h>
 #include <qwt_plot_curve.h>
 #include <qwt_symbol.h>
 #include <qwt_legend.h>
 #include "qgsvectorcolorrampv2.h" // for random colors
-#endif
+
 
 QgsIdentifyResultsWebView::QgsIdentifyResultsWebView( QWidget *parent ) : QWebView( parent )
 {
@@ -304,7 +303,6 @@ QgsIdentifyResultsDialog::QgsIdentifyResultsDialog( QgsMapCanvas *canvas, QWidge
 
   // graph
   mPlot->setVisible( false );
-#if defined(QWT_VERSION) && QWT_VERSION<0x060000
   mPlot->setAutoFillBackground( false );
   mPlot->setAutoDelete( true );
   mPlot->insertLegend( new QwtLegend(), QwtPlot::TopLegend );
@@ -314,11 +312,6 @@ QgsIdentifyResultsDialog::QgsIdentifyResultsDialog( QgsMapCanvas *canvas, QWidge
   sizePolicy.setHeightForWidth( mPlot->sizePolicy().hasHeightForWidth() );
   mPlot->setSizePolicy( sizePolicy );
   mPlot->updateGeometry();
-#else
-  delete mPlot;
-  mPlot = 0;
-  tabWidget->removeTab( 2 );
-#endif
 
   connect( buttonBox, SIGNAL( rejected() ), this, SLOT( close() ) );
 
@@ -340,11 +333,9 @@ QgsIdentifyResultsDialog::~QgsIdentifyResultsDialog()
   clearHighlights();
   if ( mActionPopup )
     delete mActionPopup;
-#if defined(QWT_VERSION) && QWT_VERSION<0x060000
   foreach ( QgsIdentifyPlotCurve *curve, mPlotCurves )
     delete curve;
   mPlotCurves.clear();
-#endif
 }
 
 QTreeWidgetItem *QgsIdentifyResultsDialog::layerItem( QObject *object )
@@ -581,7 +572,6 @@ void QgsIdentifyResultsDialog::addFeature( QgsVectorLayer *vlayer, const QgsFeat
   highlightFeature( featItem );
 }
 
-#if defined(QWT_VERSION) && QWT_VERSION<0x060000
 QgsIdentifyPlotCurve::QgsIdentifyPlotCurve( const QMap<QString, QString> &attributes,
     QwtPlot* plot, const QString &title, QColor color )
 {
@@ -591,17 +581,39 @@ QgsIdentifyPlotCurve::QgsIdentifyPlotCurve( const QMap<QString, QString> &attrib
   {
     color = QgsVectorRandomColorRampV2::randomColors( 1 )[0];
   }
+#if defined(QWT_VERSION) && QWT_VERSION>=0x060000
+  mPlotCurve->setSymbol( new QwtSymbol( QwtSymbol::Ellipse, QBrush( Qt::white ),
+                                        QPen( color, 2 ), QSize( 9, 9 ) ) );
+  mPlotCurve->setPen( QPen( color, 2 ) ); // needed for legend
+#else
   mPlotCurve->setSymbol( QwtSymbol( QwtSymbol::Ellipse, QBrush( Qt::white ),
                                     QPen( color, 2 ), QSize( 9, 9 ) ) );
+  mPlotCurve->setPen( QPen( color, 2 ) );
+#endif
 
+#if defined(QWT_VERSION) && QWT_VERSION>=0x060000
+  QVector<QPointF> myData;
+#else
+  QVector<double> myX2Data;
+  QVector<double> myY2Data;
+#endif
   int i = 1;
+
   for ( QMap<QString, QString>::const_iterator it = attributes.begin();
         it != attributes.end(); ++it )
   {
-    mPlotCurveXData.append( double( i++ ) );
-    mPlotCurveYData.append( double( it.value().toDouble() ) );
+#if defined(QWT_VERSION) && QWT_VERSION>=0x060000
+    myData << QPointF( double( i++ ), it.value().toDouble() );
+#else
+    myX2Data.append( double( i++ ) );
+    myY2Data.append( it.value().toDouble() );
+#endif
   }
-  mPlotCurve->setData( mPlotCurveXData, mPlotCurveYData );
+#if defined(QWT_VERSION) && QWT_VERSION>=0x060000
+  mPlotCurve->setSamples( myData );
+#else
+  mPlotCurve->setData( myX2Data, myY2Data );
+#endif
 
   mPlotCurve->attach( plot );
 
@@ -621,7 +633,6 @@ QgsIdentifyPlotCurve::~QgsIdentifyPlotCurve()
     delete mPlotCurve;
   }
 }
-#endif
 
 void QgsIdentifyResultsDialog::addFeature( QgsRasterLayer *layer,
     QString label,
@@ -763,12 +774,10 @@ void QgsIdentifyResultsDialog::addFeature( QgsRasterLayer *layer,
   tblResults->resizeColumnToContents( 1 );
 
   // graph
-#if defined(QWT_VERSION) && QWT_VERSION<0x060000
   if ( attributes.count() > 0 )
   {
     mPlotCurves.append( new QgsIdentifyPlotCurve( attributes, mPlot, layer->name() ) );
   }
-#endif
 }
 
 void QgsIdentifyResultsDialog::editingToggled()
@@ -1067,12 +1076,10 @@ void QgsIdentifyResultsDialog::clear()
   tblResults->clearContents();
   tblResults->setRowCount( 0 );
 
-#if defined(QWT_VERSION) && QWT_VERSION<0x060000
   mPlot->setVisible( false );
   foreach ( QgsIdentifyPlotCurve *curve, mPlotCurves )
     delete curve;
   mPlotCurves.clear();
-#endif
 
   // keep it visible but disabled, it can switch from disabled/enabled
   // after raster format change

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -463,6 +463,65 @@ void QgsIdentifyResultsDialog::addFeature( QgsVectorLayer *vlayer, const QgsFeat
     }
   }
 
+  // table
+  int j = tblResults->rowCount();
+  for ( int i = 0; i < attrs.count(); ++i )
+  {
+    if ( i >= fields.count() )
+      continue;
+
+    QString value = fields[i].displayString( attrs[i] );
+    QString value2 = value;
+    switch ( vlayer->editType( i ) )
+    {
+      case QgsVectorLayer::Hidden:
+        // skip the item
+        continue;
+
+      case QgsVectorLayer::ValueMap:
+        value2 = vlayer->valueMap( i ).key( value, QString( "(%1)" ).arg( value ) );
+        break;
+
+      case QgsVectorLayer::Calendar:
+        if ( attrs[i].canConvert( QVariant::Date ) )
+          value2 = attrs[i].toDate().toString( vlayer->dateFormat( i ) );
+        break;
+
+      default:
+        break;
+    }
+
+    tblResults->setRowCount( j + 1 );
+
+    QgsDebugMsg( QString( "adding item #%1 / %2 / %3 / %4" ).arg( j ).arg( vlayer->name() ).arg( vlayer->attributeDisplayName( i ) ).arg( value2 ) );
+
+    QTableWidgetItem *item = new QTableWidgetItem( vlayer->name() );
+    item->setData( Qt::UserRole, QVariant::fromValue( qobject_cast<QObject *>( vlayer ) ) );
+    tblResults->setItem( j, 0, item );
+
+    item = new QTableWidgetItem( FID_TO_STRING( f.id() ) );
+    item->setData( Qt::UserRole, FID_TO_STRING( f.id() ) );
+    item->setData( Qt::UserRole + 1, mFeatures.size() );
+    tblResults->setItem( j, 1, item );
+
+    item = new QTableWidgetItem( QString::number( i ) );
+    if ( fields[i].name() == vlayer->displayField() )
+      item->setData( Qt::DisplayRole, vlayer->attributeDisplayName( i ) + " *" );
+    else
+      item->setData( Qt::DisplayRole, vlayer->attributeDisplayName( i ) );
+    item->setData( Qt::UserRole, fields[i].name() );
+    item->setData( Qt::UserRole + 1, i );
+    tblResults->setItem( j, 2, item );
+
+    item = new QTableWidgetItem( value );
+    item->setData( Qt::UserRole, value );
+    item->setData( Qt::DisplayRole, value2 );
+    tblResults->setItem( j, 3, item );
+
+    j++;
+  }
+  tblResults->resizeColumnToContents( 1 );
+
   highlightFeature( featItem );
 }
 
@@ -574,6 +633,24 @@ void QgsIdentifyResultsDialog::addFeature( QgsRasterLayer *layer,
       derivedItem->addChild( new QTreeWidgetItem( QStringList() << it.key() << it.value() ) );
     }
   }
+
+  // table
+  int j = tblResults->rowCount();
+  tblResults->setRowCount( j + attributes.count() );
+  int i = 1;
+  for ( QMap<QString, QString>::const_iterator it = attributes.begin(); it != attributes.end(); ++it )
+  {
+    QgsDebugMsg( QString( "adding item #%1 / %1 / %2 / %3" ).arg( j ).arg( layer->name() ).arg( it.key() ).arg( it.value() ) );
+    QTableWidgetItem *item = new QTableWidgetItem( layer->name() );
+    item->setData( Qt::UserRole, QVariant::fromValue( qobject_cast<QObject *>( layer ) ) );
+    tblResults->setItem( j, 0, item );
+    tblResults->setItem( j, 1, new QTableWidgetItem( QString::number( i ) ) );
+    tblResults->setItem( j, 2, new QTableWidgetItem( it.key() ) );
+    tblResults->setItem( j, 3, new QTableWidgetItem( it.value() ) );
+    j++; i++;
+  }
+  tblResults->resizeColumnToContents( 1 );
+
 }
 
 void QgsIdentifyResultsDialog::editingToggled()
@@ -868,6 +945,9 @@ void QgsIdentifyResultsDialog::clear()
   lstResults->clear();
   clearHighlights();
 
+  tblResults->clearContents();
+  tblResults->setRowCount( 0 );
+
   // keep it visible but disabled, it can switch from disabled/enabled
   // after raster format change
   mPrintToolButton->setDisabled( true );
@@ -1120,6 +1200,18 @@ void QgsIdentifyResultsDialog::layerDestroyed()
   disconnectLayer( theSender );
   delete layerItem( theSender );
 
+  // remove items, starting from last
+  for ( int i = tblResults->rowCount() - 1; i >= 0; i-- )
+  {
+    QgsDebugMsg( QString( "item %1 / %2" ).arg( i ).arg( tblResults->rowCount() ) );
+    QTableWidgetItem *layItem = tblResults->item( i, 0 );
+    if ( layItem && layItem->data( Qt::UserRole ).value<QObject *>() == sender() )
+    {
+      QgsDebugMsg( QString( "removing row %1" ).arg( i ) );
+      tblResults->removeRow( i );
+    }
+  }
+
   if ( lstResults->topLevelItemCount() == 0 )
   {
     close();
@@ -1169,6 +1261,19 @@ void QgsIdentifyResultsDialog::featureDeleted( QgsFeatureId fid )
   if ( layItem->childCount() == 0 )
   {
     delete layItem;
+  }
+
+  for ( int i = tblResults->rowCount() - 1; i >= 0; i-- )
+  {
+    QgsDebugMsg( QString( "item %1 / %2" ).arg( i ).arg( tblResults->rowCount() ) );
+    QTableWidgetItem *layItem = tblResults->item( i, 0 );
+    QTableWidgetItem *featItem = tblResults->item( i, 1 );
+    if ( layItem && layItem->data( Qt::UserRole ).value<QObject *>() == sender() &&
+         featItem && STRING_TO_FID( featItem->data( Qt::UserRole ) ) == fid )
+    {
+      QgsDebugMsg( QString( "removing row %1" ).arg( i ) );
+      tblResults->removeRow( i );
+    }
   }
 
   if ( lstResults->topLevelItemCount() == 0 )

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -287,6 +287,11 @@ QgsIdentifyResultsDialog::QgsIdentifyResultsDialog( QgsMapCanvas *canvas, QWidge
   {
     lstResults->setColumnWidth( 0, width );
   }
+  width = mySettings.value( "/Windows/Identify/columnWidthTable", "0" ).toInt();
+  if ( width > 0 )
+  {
+    tblResults->setColumnWidth( 0, width );
+  }
 
   connect( buttonBox, SIGNAL( rejected() ), this, SLOT( close() ) );
 
@@ -465,6 +470,15 @@ void QgsIdentifyResultsDialog::addFeature( QgsVectorLayer *vlayer, const QgsFeat
 
   // table
   int j = tblResults->rowCount();
+  // insert empty row to separate layers
+  if ( j > 0 && tblResults->item( j - 1, 0 ) &&
+       tblResults->item( j - 1, 0 )->data( Qt::UserRole + 1 ).toString() != vlayer->id() )
+  {
+    tblResults->setRowCount( j + 1 );
+    tblResults->setRowHeight( j, 2 );
+    j++;
+  }
+
   for ( int i = 0; i < attrs.count(); ++i )
   {
     if ( i >= fields.count() )
@@ -497,6 +511,7 @@ void QgsIdentifyResultsDialog::addFeature( QgsVectorLayer *vlayer, const QgsFeat
 
     QTableWidgetItem *item = new QTableWidgetItem( vlayer->name() );
     item->setData( Qt::UserRole, QVariant::fromValue( qobject_cast<QObject *>( vlayer ) ) );
+    item->setData( Qt::UserRole + 1, vlayer->id() );
     tblResults->setItem( j, 0, item );
 
     item = new QTableWidgetItem( FID_TO_STRING( f.id() ) );
@@ -518,6 +533,15 @@ void QgsIdentifyResultsDialog::addFeature( QgsVectorLayer *vlayer, const QgsFeat
     item->setData( Qt::DisplayRole, value2 );
     tblResults->setItem( j, 3, item );
 
+    // highlight first item
+    // if ( i==0 )
+    // {
+    //   QBrush b = tblResults->palette().brush( QPalette::AlternateBase );
+    //   for ( int k = 0; k <= 3; k++)
+    //  tblResults->item( j, k )->setBackground( b );
+    // }
+
+    tblResults->resizeRowToContents( j );
     j++;
   }
   tblResults->resizeColumnToContents( 1 );
@@ -635,18 +659,31 @@ void QgsIdentifyResultsDialog::addFeature( QgsRasterLayer *layer,
   }
 
   // table
+  int i = 0;
   int j = tblResults->rowCount();
+  // insert empty row to separate layers
+  if ( j > 0 && tblResults->item( j - 1, 0 ) &&
+       tblResults->item( j - 1, 0 )->data( Qt::UserRole + 1 ).toString() != layer->id() )
+  {
+    j++;
+    tblResults->setRowCount( j + 1 );
+    tblResults->setRowHeight( j - 1, 2 );
+  }
   tblResults->setRowCount( j + attributes.count() );
-  int i = 1;
+
   for ( QMap<QString, QString>::const_iterator it = attributes.begin(); it != attributes.end(); ++it )
   {
-    QgsDebugMsg( QString( "adding item #%1 / %1 / %2 / %3" ).arg( j ).arg( layer->name() ).arg( it.key() ).arg( it.value() ) );
+    QgsDebugMsg( QString( "adding item #%1 / %2 / %3 / %4" ).arg( j ).arg( layer->name() ).arg( it.key() ).arg( it.value() ) );
     QTableWidgetItem *item = new QTableWidgetItem( layer->name() );
     item->setData( Qt::UserRole, QVariant::fromValue( qobject_cast<QObject *>( layer ) ) );
+    item->setData( Qt::UserRole + 1, layer->id() );
     tblResults->setItem( j, 0, item );
-    tblResults->setItem( j, 1, new QTableWidgetItem( QString::number( i ) ) );
+    tblResults->setItem( j, 1, new QTableWidgetItem( QString::number( i + 1 ) ) );
     tblResults->setItem( j, 2, new QTableWidgetItem( it.key() ) );
     tblResults->setItem( j, 3, new QTableWidgetItem( it.value() ) );
+
+    tblResults->resizeRowToContents( j );
+
     j++; i++;
   }
   tblResults->resizeColumnToContents( 1 );
@@ -911,6 +948,7 @@ void QgsIdentifyResultsDialog::saveWindowLocation()
   settings.setValue( "/Windows/Identify/geometry", saveGeometry() );
   // first column width
   settings.setValue( "/Windows/Identify/columnWidth", lstResults->columnWidth( 0 ) );
+  settings.setValue( "/Windows/Identify/columnWidthTable", tblResults->columnWidth( 0 ) );
 }
 
 void QgsIdentifyResultsDialog::setColumnText( int column, const QString & label )

--- a/src/app/qgsidentifyresultsdialog.h
+++ b/src/app/qgsidentifyresultsdialog.h
@@ -94,7 +94,6 @@ class APP_EXPORT QgsIdentifyResultsWebViewItem: public QObject, public QTreeWidg
     QgsIdentifyResultsWebView *mWebView;
 };
 
-#if defined(QWT_VERSION) && QWT_VERSION<0x060000
 class APP_EXPORT QgsIdentifyPlotCurve
 {
   public:
@@ -106,9 +105,7 @@ class APP_EXPORT QgsIdentifyPlotCurve
 
   private:
     QwtPlotCurve* mPlotCurve;
-    QVector<double> mPlotCurveXData, mPlotCurveYData;
 };
-#endif
 
 class APP_EXPORT QgsIdentifyResultsDialog: public QDialog, private Ui::QgsIdentifyResultsBase
 {
@@ -245,11 +242,7 @@ class APP_EXPORT QgsIdentifyResultsDialog: public QDialog, private Ui::QgsIdenti
 
     QDockWidget *mDock;
 
-#if defined(QWT_VERSION) && QWT_VERSION<0x060000
-    /* QwtPlotCurve* mPlotCurve; */
-    /* QVector<double> mPlotCurveXData, mPlotCurveYData; */
     QVector<QgsIdentifyPlotCurve *> mPlotCurves;
-#endif
 };
 
 class QgsIdentifyResultsDialogMapLayerAction : public QAction

--- a/src/app/qgsidentifyresultsdialog.h
+++ b/src/app/qgsidentifyresultsdialog.h
@@ -43,6 +43,8 @@ class QgsHighlight;
 class QgsMapCanvas;
 class QDockWidget;
 
+class QwtPlotCurve;
+
 /**
  *@author Gary E.Sherman
  */
@@ -226,6 +228,11 @@ class APP_EXPORT QgsIdentifyResultsDialog: public QDialog, private Ui::QgsIdenti
     void doMapLayerAction( QTreeWidgetItem *item, QgsMapLayerAction* action );
 
     QDockWidget *mDock;
+
+#if defined(QWT_VERSION) && QWT_VERSION<0x060000
+    QwtPlotCurve* mPlotCurve;
+    QVector<double> mPlotCurveXData, mPlotCurveYData;
+#endif
 };
 
 class QgsIdentifyResultsDialogMapLayerAction : public QAction

--- a/src/app/qgsidentifyresultsdialog.h
+++ b/src/app/qgsidentifyresultsdialog.h
@@ -94,6 +94,22 @@ class APP_EXPORT QgsIdentifyResultsWebViewItem: public QObject, public QTreeWidg
     QgsIdentifyResultsWebView *mWebView;
 };
 
+#if defined(QWT_VERSION) && QWT_VERSION<0x060000
+class APP_EXPORT QgsIdentifyPlotCurve
+{
+  public:
+
+    QgsIdentifyPlotCurve() { mPlotCurve = 0; }
+    QgsIdentifyPlotCurve( const QMap<QString, QString> &attributes,
+                          QwtPlot* plot, const QString &title = QString(), QColor color = QColor() ) ;
+    ~QgsIdentifyPlotCurve();
+
+  private:
+    QwtPlotCurve* mPlotCurve;
+    QVector<double> mPlotCurveXData, mPlotCurveYData;
+};
+#endif
+
 class APP_EXPORT QgsIdentifyResultsDialog: public QDialog, private Ui::QgsIdentifyResultsBase
 {
     Q_OBJECT
@@ -230,8 +246,9 @@ class APP_EXPORT QgsIdentifyResultsDialog: public QDialog, private Ui::QgsIdenti
     QDockWidget *mDock;
 
 #if defined(QWT_VERSION) && QWT_VERSION<0x060000
-    QwtPlotCurve* mPlotCurve;
-    QVector<double> mPlotCurveXData, mPlotCurveYData;
+    /* QwtPlotCurve* mPlotCurve; */
+    /* QVector<double> mPlotCurveXData, mPlotCurveYData; */
+    QVector<QgsIdentifyPlotCurve *> mPlotCurves;
 #endif
 };
 

--- a/src/core/symbology-ng/qgsvectorcolorrampv2.cpp
+++ b/src/core/symbology-ng/qgsvectorcolorrampv2.cpp
@@ -309,26 +309,33 @@ QgsStringMap QgsVectorRandomColorRampV2::properties() const
   return map;
 }
 
-void QgsVectorRandomColorRampV2::updateColors()
+QList<QColor> QgsVectorRandomColorRampV2::randomColors( int count,
+    int hueMax, int hueMin, int satMax, int satMin, int valMax, int valMin )
 {
   int h, s, v;
+  QList<QColor> colors;
 
-  mColors.clear();
   //start hue at random angle
   double currentHueAngle = 360.0 * ( double )rand() / RAND_MAX;
 
-  for ( int i = 0; i < mCount; i++ )
+  for ( int i = 0; i < count; i++ )
   {
     //increment hue by golden ratio (approx 137.507 degrees)
     //as this minimises hue nearness as count increases
     //see http://basecase.org/env/on-rainbows for more details
     currentHueAngle += 137.50776;
-    //scale hue to between mHueMax and mHueMin
-    h = ( fmod( currentHueAngle, 360.0 ) / 360.0 ) * ( mHueMax - mHueMin ) + mHueMin;
-    s = ( rand() % ( mSatMax - mSatMin + 1 ) ) + mSatMin;
-    v = ( rand() % ( mValMax - mValMin + 1 ) ) + mValMin;
-    mColors.append( QColor::fromHsv( h, s, v ) );
+    //scale hue to between hueMax and hueMin
+    h = ( fmod( currentHueAngle, 360.0 ) / 360.0 ) * ( hueMax - hueMin ) + hueMin;
+    s = ( rand() % ( satMax - satMin + 1 ) ) + satMin;
+    v = ( rand() % ( valMax - valMin + 1 ) ) + valMin;
+    colors.append( QColor::fromHsv( h, s, v ) );
   }
+  return colors;
+}
+
+void QgsVectorRandomColorRampV2::updateColors()
+{
+  mColors = QgsVectorRandomColorRampV2::randomColors( mCount, mHueMax, mHueMin, mSatMax, mSatMin, mValMax, mValMin );
 }
 
 /////////////

--- a/src/core/symbology-ng/qgsvectorcolorrampv2.h
+++ b/src/core/symbology-ng/qgsvectorcolorrampv2.h
@@ -131,6 +131,12 @@ class CORE_EXPORT QgsVectorRandomColorRampV2 : public QgsVectorColorRampV2
 
     virtual QgsStringMap properties() const;
 
+    /** get a list of random colors
+    * @note added in 2.4 */
+    static QList<QColor> randomColors( int count,
+                                       int hueMax = DEFAULT_RANDOM_HUE_MAX, int hueMin = DEFAULT_RANDOM_HUE_MIN,
+                                       int satMax = DEFAULT_RANDOM_SAT_MAX, int satMin = DEFAULT_RANDOM_SAT_MIN,
+                                       int valMax = DEFAULT_RANDOM_VAL_MAX, int valMin = DEFAULT_RANDOM_VAL_MIN );
     void updateColors();
 
     int count() const { return mCount; }

--- a/src/ui/qgsidentifyresultsbase.ui
+++ b/src/ui/qgsidentifyresultsbase.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>304</width>
+    <width>328</width>
     <height>306</height>
    </rect>
   </property>
@@ -18,21 +18,78 @@
     <number>2</number>
    </property>
    <item>
-    <widget class="QTreeWidget" name="lstResults">
-     <property name="lineWidth">
-      <number>2</number>
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex">
+      <number>0</number>
      </property>
-     <property name="alternatingRowColors">
-      <bool>true</bool>
-     </property>
-     <property name="sortingEnabled">
-      <bool>true</bool>
-     </property>
-     <column>
-      <property name="text">
-       <string notr="true">1</string>
-      </property>
-     </column>
+     <widget class="QWidget" name="tab">
+      <attribute name="title">
+       <string>Tree</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <property name="spacing">
+        <number>0</number>
+       </property>
+       <property name="margin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QTreeWidget" name="lstResults">
+         <property name="lineWidth">
+          <number>2</number>
+         </property>
+         <property name="alternatingRowColors">
+          <bool>true</bool>
+         </property>
+         <property name="sortingEnabled">
+          <bool>true</bool>
+         </property>
+         <column>
+          <property name="text">
+           <string notr="true">1</string>
+          </property>
+         </column>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tab_2">
+      <attribute name="title">
+       <string>Table</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <property name="spacing">
+        <number>0</number>
+       </property>
+       <property name="margin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QTableWidget" name="tblResults">
+         <column>
+          <property name="text">
+           <string>Layer</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>FID</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Attribute</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Value</string>
+          </property>
+         </column>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
    <item>

--- a/src/ui/qgsidentifyresultsbase.ui
+++ b/src/ui/qgsidentifyresultsbase.ui
@@ -90,6 +90,16 @@
        </item>
       </layout>
      </widget>
+     <widget class="QWidget" name="tab_3">
+      <attribute name="title">
+       <string>Graph</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <item>
+        <widget class="QwtPlot" name="mPlot"/>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
    <item>
@@ -210,6 +220,14 @@
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
+ <customwidgets>
+  <customwidget>
+   <class>QwtPlot</class>
+   <extends>QFrame</extends>
+   <header>qwt_plot.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources>
   <include location="../../images/images.qrc"/>
  </resources>


### PR DESCRIPTION
This adds most features of the Identify Tool plugin to the main Identify map tool

please add your comments/suggestions

a tab widget allows to see the data in one of 3 ways
- Tree, as previously
- Table, a table view of Vector and Raster layers (Layer, FID, Attribute, Value)
- Graph which shows a plot of raster layers, very basic for now (virtually identical to the plugin) and only qwt5 for now
