### PR TITLE
[FEATURE] Add preview modes for composer - needs feedback!

### DIFF
--- a/python/gui/qgscomposerview.sip
+++ b/python/gui/qgscomposerview.sip
@@ -109,6 +109,20 @@ class QgsComposerView : QGraphicsView
     /**Set zoom level, where a zoom level of 1.0 corresponds to 100%*/
     void setZoomLevel( double zoomLevel );
 
+    /**Sets whether a preview effect should be used to alter the view's appearance
+     * @param enabled Set to true to enable the preview effect on the view
+     * @note added in 2.3
+     * @see setPreviewMode
+    */
+    void setPreviewModeEnabled( bool enabled );
+    /**Sets the preview mode which should be used to modify the view's appearance. Preview modes are only used
+     * if setPreviewMode is set to true.
+     * @param mode PreviewMode to be used to draw the view
+     * @note added in 2.3
+     * @see setPreviewModeEnabled
+    */
+    void setPreviewMode( QgsPreviewEffect::PreviewMode mode );
+
   protected:
     void mousePressEvent( QMouseEvent* );
     void mouseReleaseEvent( QMouseEvent* );

--- a/python/gui/qgsgraphicseffect.sip
+++ b/python/gui/qgsgraphicseffect.sip
@@ -1,0 +1,39 @@
+/** \ingroup gui
+ * A graphics effect which can be applied to a widget to simulate various printing and
+ * color blindness modes.
+ */
+class QgsPreviewEffect : QGraphicsEffect
+{
+%TypeHeaderCode
+#include "qgsgraphicseffect.h"
+%End
+
+  public:
+    enum PreviewMode
+    {
+      PreviewGrayscale,
+      PreviewMono,
+      PreviewProtanope,
+      PreviewDeuteranope
+    };
+
+    QgsPreviewEffect( QObject* parent );
+    ~QgsPreviewEffect();
+
+    /**Sets the mode for the preview effect, which controls how the effect modifies a widgets appearance.
+     * @param mode PreviewMode to use to draw the widget
+     * @note added in 2.3
+     * @see mode
+    */
+    void setMode( PreviewMode mode );
+
+    /**Returns the mode used for the preview effect.
+     * @returns PreviewMode currently used by the effect
+     * @note added in 2.3
+     * @see setMode
+    */
+    PreviewMode mode() const;
+
+  protected:
+    virtual void draw( QPainter *painter );
+};

--- a/src/app/composer/qgscomposer.cpp
+++ b/src/app/composer/qgscomposer.cpp
@@ -57,6 +57,7 @@
 #include "qgsgeometry.h"
 #include "qgspaperitem.h"
 #include "qgsmaplayerregistry.h"
+#include "qgsprevieweffect.h"
 #include "ui_qgssvgexportoptions.h"
 
 #include <QCloseEvent>
@@ -260,10 +261,49 @@ QgsComposer::QgsComposer( QgisApp *qgis, const QString& title )
   editMenu->addAction( mActionSelectNextBelow );
   editMenu->addAction( mActionSelectNextAbove );
 
+  mActionPreviewModeOff = new QAction( tr( "Normal" ), this );
+  mActionPreviewModeOff->setStatusTip( tr( "Normal" ) );
+  mActionPreviewModeOff->setCheckable( true );
+  mActionPreviewModeOff->setChecked( true );
+  connect( mActionPreviewModeOff, SIGNAL( triggered() ), this, SLOT( disablePreviewMode() ) );
+  mActionPreviewModeGrayscale = new QAction( tr( "Simulate photocopy (grayscale)" ), this );
+  mActionPreviewModeGrayscale->setStatusTip( tr( "Simulate photocopy (grayscale)" ) );
+  mActionPreviewModeGrayscale->setCheckable( true );
+  connect( mActionPreviewModeGrayscale, SIGNAL( triggered() ), this, SLOT( activateGrayscalePreview() ) );
+  mActionPreviewModeMono = new QAction( tr( "Simulate fax (mono)" ), this );
+  mActionPreviewModeMono->setStatusTip( tr( "Simulate fax (mono)" ) );
+  mActionPreviewModeMono->setCheckable( true );
+  connect( mActionPreviewModeMono, SIGNAL( triggered() ), this, SLOT( activateMonoPreview() ) );
+  mActionPreviewProtanope = new QAction( tr( "Simulate color blindness (Protanope)" ), this );
+  mActionPreviewProtanope->setStatusTip( tr( "Simulate color blindness (Protanope)" ) );
+  mActionPreviewProtanope->setCheckable( true );
+  connect( mActionPreviewProtanope, SIGNAL( triggered() ), this, SLOT( activateProtanopePreview() ) );
+  mActionPreviewDeuteranope = new QAction( tr( "Simulate color blindness (Deuteranope)" ), this );
+  mActionPreviewDeuteranope->setStatusTip( tr( "Simulate color blindness (Deuteranope)" ) );
+  mActionPreviewDeuteranope->setCheckable( true );
+  connect( mActionPreviewDeuteranope, SIGNAL( triggered() ), this, SLOT( activateDeuteranopePreview() ) );
+
+  QActionGroup* mPreviewGroup = new QActionGroup( this );
+  mPreviewGroup->setExclusive( true );
+  mActionPreviewModeOff->setActionGroup( mPreviewGroup );
+  mActionPreviewModeGrayscale->setActionGroup( mPreviewGroup );
+  mActionPreviewModeMono->setActionGroup( mPreviewGroup );
+  mActionPreviewProtanope->setActionGroup( mPreviewGroup );
+  mActionPreviewDeuteranope->setActionGroup( mPreviewGroup );
+
   QMenu *viewMenu = menuBar()->addMenu( tr( "View" ) );
   //Ctrl+= should also trigger zoom in
   QShortcut* ctrlEquals = new QShortcut( QKeySequence( "Ctrl+=" ), this );
   connect( ctrlEquals, SIGNAL( activated() ), mActionZoomIn, SLOT( trigger() ) );
+
+  QMenu *previewMenu = viewMenu->addMenu( "Preview" );
+  previewMenu->addAction( mActionPreviewModeOff );
+  previewMenu->addAction( mActionPreviewModeGrayscale );
+  previewMenu->addAction( mActionPreviewModeMono );
+  previewMenu->addAction( mActionPreviewProtanope );
+  previewMenu->addAction( mActionPreviewDeuteranope );
+
+  viewMenu->addSeparator();
   viewMenu->addAction( mActionZoomIn );
   viewMenu->addAction( mActionZoomOut );
   viewMenu->addAction( mActionZoomAll );
@@ -1099,6 +1139,60 @@ void QgsComposer::on_mActionAtlasSettings_triggered()
   }
 
   mAtlasDock->raise();
+}
+
+void QgsComposer::disablePreviewMode()
+{
+  if ( !mView )
+  {
+    return;
+  }
+
+  mView->setPreviewModeEnabled( false );
+}
+
+void QgsComposer::activateGrayscalePreview()
+{
+  if ( !mView )
+  {
+    return;
+  }
+
+  mView->setPreviewMode( QgsPreviewEffect::PreviewGrayscale );
+  mView->setPreviewModeEnabled( true );
+}
+
+void QgsComposer::activateMonoPreview()
+{
+  if ( !mView )
+  {
+    return;
+  }
+
+  mView->setPreviewMode( QgsPreviewEffect::PreviewMono );
+  mView->setPreviewModeEnabled( true );
+}
+
+void QgsComposer::activateProtanopePreview()
+{
+  if ( !mView )
+  {
+    return;
+  }
+
+  mView->setPreviewMode( QgsPreviewEffect::PreviewProtanope );
+  mView->setPreviewModeEnabled( true );
+}
+
+void QgsComposer::activateDeuteranopePreview()
+{
+  if ( !mView )
+  {
+    return;
+  }
+
+  mView->setPreviewMode( QgsPreviewEffect::PreviewDeuteranope );
+  mView->setPreviewModeEnabled( true );
 }
 
 void QgsComposer::on_mActionExportAtlasAsPDF_triggered()

--- a/src/app/composer/qgscomposer.h
+++ b/src/app/composer/qgscomposer.h
@@ -537,6 +537,13 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
 
     QUndoView* mUndoView;
 
+    //! Preview mode actions
+    QAction *mActionPreviewModeOff;
+    QAction *mActionPreviewModeGrayscale;
+    QAction *mActionPreviewModeMono;
+    QAction *mActionPreviewProtanope;
+    QAction *mActionPreviewDeuteranope;
+
     //! We load composer map content from project xml only on demand. Therefore we need to store the real preview mode type
     QMap< QgsComposerMap*, int > mMapsToRestore;
 
@@ -601,6 +608,12 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
 
     //! Sets the printer page orientation when the page orientation changes
     void setPrinterPageOrientation( QString orientation );
+
+    void disablePreviewMode();
+    void activateGrayscalePreview();
+    void activateMonoPreview();
+    void activateProtanopePreview();
+    void activateDeuteranopePreview();
 
 };
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -72,6 +72,7 @@ qgscolorbutton.cpp
 qgscolordialog.cpp
 qgscomposerruler.cpp
 qgscomposerview.cpp
+qgsprevieweffect.cpp
 qgscredentialdialog.cpp
 qgscursors.cpp
 qgsdatadefinedbutton.cpp
@@ -220,6 +221,7 @@ qgsbusyindicatordialog.h
 qgscharacterselectdialog.h
 qgscollapsiblegroupbox.h
 qgscolordialog.h
+qgsprevieweffect.h
 qgscomposerruler.h
 qgscomposerview.h
 qgscredentialdialog.h

--- a/src/gui/qgscomposerview.cpp
+++ b/src/gui/qgscomposerview.cpp
@@ -61,6 +61,7 @@ QgsComposerView::QgsComposerView( QWidget* parent, const char* name, Qt::WindowF
     , mMousePanning( false )
     , mKeyPanning( false )
     , mMovingItemContent( false )
+    , mPreviewEffect( 0 )
 {
   Q_UNUSED( f );
   Q_UNUSED( name );
@@ -69,6 +70,9 @@ QgsComposerView::QgsComposerView( QWidget* parent, const char* name, Qt::WindowF
   setMouseTracking( true );
   viewport()->setMouseTracking( true );
   setFrameShape( QFrame::NoFrame );
+
+  mPreviewEffect = new QgsPreviewEffect( this );
+  viewport()->setGraphicsEffect( mPreviewEffect );
 }
 
 void QgsComposerView::setCurrentTool( QgsComposerView::Tool t )
@@ -1499,6 +1503,26 @@ void QgsComposerView::setZoomLevel( double zoomLevel )
   updateRulers();
   update();
   emit zoomLevelChanged();
+}
+
+void QgsComposerView::setPreviewModeEnabled( bool enabled )
+{
+  if ( !mPreviewEffect )
+  {
+    return;
+  }
+
+  mPreviewEffect->setEnabled( enabled );
+}
+
+void QgsComposerView::setPreviewMode( QgsPreviewEffect::PreviewMode mode )
+{
+  if ( !mPreviewEffect )
+  {
+    return;
+  }
+
+  mPreviewEffect->setMode( mode );
 }
 
 void QgsComposerView::paintEvent( QPaintEvent* event )

--- a/src/gui/qgscomposerview.h
+++ b/src/gui/qgscomposerview.h
@@ -19,6 +19,7 @@
 
 #include <QGraphicsView>
 #include "qgsaddremoveitemcommand.h"
+#include "qgsprevieweffect.h" // for QgsPreviewEffect::PreviewMode
 
 class QDomDocument;
 class QDomElement;
@@ -139,6 +140,20 @@ class GUI_EXPORT QgsComposerView: public QGraphicsView
     /**Set zoom level, where a zoom level of 1.0 corresponds to 100%*/
     void setZoomLevel( double zoomLevel );
 
+    /**Sets whether a preview effect should be used to alter the view's appearance
+     * @param enabled Set to true to enable the preview effect on the view
+     * @note added in 2.3
+     * @see setPreviewMode
+    */
+    void setPreviewModeEnabled( bool enabled );
+    /**Sets the preview mode which should be used to modify the view's appearance. Preview modes are only used
+     * if setPreviewMode is set to true.
+     * @param mode PreviewMode to be used to draw the view
+     * @note added in 2.3
+     * @see setPreviewModeEnabled
+    */
+    void setPreviewMode( QgsPreviewEffect::PreviewMode mode );
+
   protected:
     void mousePressEvent( QMouseEvent* );
     void mouseReleaseEvent( QMouseEvent* );
@@ -203,6 +218,8 @@ class GUI_EXPORT QgsComposerView: public QGraphicsView
     QPoint mMouseLastXY;
     QPoint mMouseCurrentXY;
     QPoint mMousePressStartPos;
+
+    QgsPreviewEffect* mPreviewEffect;
 
     /**Returns the default mouse cursor for a tool*/
     QCursor defaultCursorForTool( Tool currentTool );

--- a/src/gui/qgsprevieweffect.cpp
+++ b/src/gui/qgsprevieweffect.cpp
@@ -1,0 +1,157 @@
+/***************************************************************************
+                         qgsprevieweffect.cpp
+                             -------------------
+    begin                : March 2014
+    copyright            : (C) 2014 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <QPainter>
+#include "qgsprevieweffect.h"
+
+
+QgsPreviewEffect::QgsPreviewEffect( QObject* parent ) :
+    QGraphicsEffect( parent ),
+    mMode( PreviewGrayscale )
+{
+  //effect is disabled by default
+  setEnabled( false );
+}
+
+QgsPreviewEffect::~QgsPreviewEffect()
+{
+
+}
+
+void QgsPreviewEffect::setMode( QgsPreviewEffect::PreviewMode mode )
+{
+  mMode = mode;
+  update();
+}
+
+void QgsPreviewEffect::draw( QPainter* painter )
+{
+  QPoint offset;
+  QPixmap pixmap;
+
+  if ( sourceIsPixmap() )
+  {
+    // No point in drawing in device coordinates (pixmap will be scaled anyways).
+    pixmap = sourcePixmap( Qt::LogicalCoordinates, &offset );
+  }
+  else
+  {
+    // Draw pixmap in device coordinates to avoid pixmap scaling;
+    pixmap = sourcePixmap( Qt::DeviceCoordinates, &offset );
+    painter->setWorldTransform( QTransform() );
+  }
+
+  QImage image = pixmap.toImage();
+
+  switch ( mMode )
+  {
+    case QgsPreviewEffect::PreviewGrayscale:
+    {
+      QRgb * line;
+
+      for ( int y = 0; y < image.height(); y++ )
+      {
+        line = ( QRgb * )image.scanLine( y );
+        for ( int x = 0; x < image.width(); x++ )
+        {
+          int gray = 0.21 * qRed( line[x] ) + 0.72 * qGreen( line[x] ) + 0.07 * qBlue( line[x] );
+          line[x] = qRgb( gray, gray, gray );
+        }
+      }
+
+      painter->drawImage( offset, image );
+      break;
+    }
+    case QgsPreviewEffect::PreviewMono:
+    {
+      QImage bwImage = image.convertToFormat( QImage::Format_Mono );
+      painter->drawImage( offset, bwImage );
+      break;
+    }
+    case QgsPreviewEffect::PreviewProtanope:
+    case QgsPreviewEffect::PreviewDeuteranope:
+    {
+      QRgb * line;
+
+      for ( int y = 0; y < image.height(); y++ )
+      {
+        line = ( QRgb * )image.scanLine( y );
+        for ( int x = 0; x < image.width(); x++ )
+        {
+          line[x] = simulateColorBlindness( line[x], mMode );
+        }
+      }
+
+      painter->drawImage( offset, image );
+      break;
+    }
+  }
+
+}
+
+QRgb QgsPreviewEffect::simulateColorBlindness( QRgb& originalColor, QgsPreviewEffect::PreviewMode mode )
+{
+  int red = qRed( originalColor );
+  int green = qGreen( originalColor );
+  int blue = qBlue( originalColor );
+
+  //convert RGB to LMS color space
+  // (http://vision.psychol.cam.ac.uk/jdmollon/papers/colourmaps.pdf p245, equation 4)
+  double L = ( 17.8824 * red ) + ( 43.5161 * green ) + ( 4.11935 * blue );
+  double M = ( 3.45565 * red ) + ( 27.1554 * green ) + ( 3.86714 * blue );
+  double S = ( 0.0299566 * red ) + ( 0.184309 * green ) + ( 1.46709 * blue );
+
+  //simulate color blindness
+  switch ( mode )
+  {
+    case PreviewProtanope:
+      simulateProtanopeLMS( L, M, S );
+      break;
+    case PreviewDeuteranope:
+      simulateDeuteranopeLMS( L, M, S );
+      break;
+    default:
+      break;
+  }
+
+  //convert LMS back to RGB color space
+  //(http://vision.psychol.cam.ac.uk/jdmollon/papers/colourmaps.pdf p248, equation 6)
+  red = ( 0.080944 * L ) + ( -0.130504 * M ) + ( 0.116721 * S );
+  green = ( -0.0102485 * L ) + ( 0.0540194 * M ) + ( -0.113615 * S );
+  blue = ( -0.000365294 * L ) + ( -0.00412163 * M ) + ( 0.693513 * S );
+
+  //restrict values to 0-255
+  red = qMax( qMin( 255, red ), 0 );
+  green = qMax( qMin( 255, green ), 0 );
+  blue = qMax( qMin( 255, blue ), 0 );
+
+  return qRgb( red, green, blue );
+}
+
+void QgsPreviewEffect::simulateProtanopeLMS( double& L, double &M, double &S )
+{
+  //adjust L component to simulate vision of Protanope
+  //(http://vision.psychol.cam.ac.uk/jdmollon/papers/colourmaps.pdf p248, equation 5)
+  L = ( 2.02344 * M ) + ( -2.52581 * S );
+}
+
+void QgsPreviewEffect::simulateDeuteranopeLMS( double& L, double &M, double &S )
+{
+  //adjust M component to simulate vision of Deuteranope
+  //(http://vision.psychol.cam.ac.uk/jdmollon/papers/colourmaps.pdf p248, equation 5)
+  M = ( 0.494207 * L ) + ( 1.24827 * S );
+}

--- a/src/gui/qgsprevieweffect.h
+++ b/src/gui/qgsprevieweffect.h
@@ -1,0 +1,69 @@
+/***************************************************************************
+                         qgsprevieweffect.h
+                             -------------------
+    begin                : March 2014
+    copyright            : (C) 2014 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSPREVIEWEFFECT_H
+#define QGSPREVIEWEFFECT_H
+
+#include <QGraphicsEffect>
+
+/** \ingroup gui
+ * A graphics effect which can be applied to a widget to simulate various printing and
+ * color blindness modes.
+ */
+
+class GUI_EXPORT QgsPreviewEffect: public QGraphicsEffect
+{
+    Q_OBJECT
+
+  public:
+    enum PreviewMode
+    {
+      PreviewGrayscale,
+      PreviewMono,
+      PreviewProtanope,
+      PreviewDeuteranope
+    };
+
+    QgsPreviewEffect( QObject* parent );
+    ~QgsPreviewEffect();
+
+    /**Sets the mode for the preview effect, which controls how the effect modifies a widgets appearance.
+     * @param mode PreviewMode to use to draw the widget
+     * @note added in 2.3
+     * @see mode
+    */
+    void setMode( PreviewMode mode );
+    /**Returns the mode used for the preview effect.
+     * @returns PreviewMode currently used by the effect
+     * @note added in 2.3
+     * @see setMode
+    */
+    PreviewMode mode() const { return mMode; }
+
+  protected:
+    virtual void draw( QPainter *painter );
+
+  private:
+
+    PreviewMode mMode;
+
+    QRgb simulateColorBlindness( QRgb &originalColor, PreviewMode type );
+    void simulateProtanopeLMS( double &L, double &M, double &S );
+    void simulateDeuteranopeLMS( double &L, double &M, double &S );
+};
+
+#endif // QGSPREVIEWEFFECT_H


### PR DESCRIPTION
This pull request adds a new QGraphicsEffect to QGIS for simulating grayscale, monochrome and color blindness (see http://hub.qgis.org/issues/9886 for the original inspiration). I've added it to the composer, so that interactive previews in any of these modes are possible. It should also be possible to add this effect to the map canvas so that map layer symbology can be tweaked with immediate feedback.

HOWEVER - there's an issue somewhere in the code which I can't track down (or replicate). In Nathan's testing switching on any of the preview modes stops the composer view widget from repainting (effectively freezing the control) until the effect is disabled. I've tested on a range of windows and linux environments but can't reproduce this or figure out what is happening. So, any advice on what is going wrong here would be appreciated
