### PR TITLE
Add support for specifying legend title horizontal alignment in composer

### DIFF
--- a/python/core/composer/qgscomposerlegend.sip
+++ b/python/core/composer/qgscomposerlegend.sip
@@ -31,6 +31,11 @@ class QgsComposerLegend : QgsComposerItem
     void setTitle( const QString& t );
     QString title() const;
 
+    /** Returns the alignment of the legend title*/
+    Qt::AlignmentFlag titleAlignment() const;
+    /** Sets the alignment of the legend title*/
+    void setTitleAlignment( Qt::AlignmentFlag alignment );
+
     /** Returns reference to modifiable style */
     QgsComposerLegendStyle & rstyle( QgsComposerLegendStyle::Style s );
     /** Returns style */

--- a/src/app/composer/qgscomposerlegendwidget.cpp
+++ b/src/app/composer/qgscomposerlegendwidget.cpp
@@ -161,8 +161,11 @@ void QgsComposerLegendWidget::setGuiElements()
     return;
   }
 
+  int alignment = mLegend->titleAlignment() == Qt::AlignLeft ? 0 : mLegend->titleAlignment() == Qt::AlignHCenter ? 1 : 2;
+
   blockAllSignals( true );
   mTitleLineEdit->setText( mLegend->title() );
+  mTitleAlignCombo->setCurrentIndex( alignment );
   mColumnCountSpinBox->setValue( mLegend->columnCount() );
   mSplitLayerCheckBox->setChecked( mLegend->splitLayer() );
   mEqualColumnWidthCheckBox->setChecked( mLegend->equalColumnWidth() );
@@ -215,6 +218,18 @@ void QgsComposerLegendWidget::on_mTitleLineEdit_textChanged( const QString& text
     mLegend->beginCommand( tr( "Legend title changed" ), QgsComposerMergeCommand::ComposerLegendText );
     mLegend->setTitle( text );
     mLegend->adjustBoxSize();
+    mLegend->update();
+    mLegend->endCommand();
+  }
+}
+
+void QgsComposerLegendWidget::on_mTitleAlignCombo_currentIndexChanged( int index )
+{
+  if ( mLegend )
+  {
+    Qt::AlignmentFlag alignment = index == 0 ? Qt::AlignLeft : index == 1 ? Qt::AlignHCenter : Qt::AlignRight;
+    mLegend->beginCommand( tr( "Legend title alignment changed" ) );
+    mLegend->setTitleAlignment( alignment );
     mLegend->update();
     mLegend->endCommand();
   }
@@ -916,6 +931,7 @@ void QgsComposerLegendWidget::updateLegend()
 void QgsComposerLegendWidget::blockAllSignals( bool b )
 {
   mTitleLineEdit->blockSignals( b );
+  mTitleAlignCombo->blockSignals( b );
   mItemTreeView->blockSignals( b );
   mCheckBoxAutoUpdate->blockSignals( b );
   mMapComboBox->blockSignals( b );
@@ -997,3 +1013,4 @@ void QgsComposerLegendWidget::selectedChanged( const QModelIndex & current, cons
   mCountToolButton->setChecked( layerItem->showFeatureCount() );
   mCountToolButton->setEnabled( true );
 }
+

--- a/src/app/composer/qgscomposerlegendwidget.h
+++ b/src/app/composer/qgscomposerlegendwidget.h
@@ -54,6 +54,7 @@ class QgsComposerLegendWidget: public QWidget, private Ui::QgsComposerLegendWidg
 
     void on_mWrapCharLineEdit_textChanged( const QString& text );
     void on_mTitleLineEdit_textChanged( const QString& text );
+    void on_mTitleAlignCombo_currentIndexChanged( int index );
     void on_mColumnCountSpinBox_valueChanged( int c );
     void on_mSplitLayerCheckBox_toggled( bool checked );
     void on_mEqualColumnWidthCheckBox_toggled( bool checked );
@@ -106,3 +107,4 @@ class QgsComposerLegendWidget: public QWidget, private Ui::QgsComposerLegendWidg
 };
 
 #endif
+

--- a/src/core/composer/qgscomposerlegend.cpp
+++ b/src/core/composer/qgscomposerlegend.cpp
@@ -154,7 +154,7 @@ QSizeF QgsComposerLegend::paintAndDetermineSize( QPainter* painter )
   // Now we know total width and can draw the title centered
   if ( !mTitle.isEmpty() )
   {
-    size.rwidth() = qMax( titleSize.width() + 2 * mBoxSpace, size.width() );
+    size.rwidth() = qMax( titleSize.width(), size.width() );
     if ( mTitleAlignment == Qt::AlignLeft )
     {
       point.rx() = mBoxSpace;
@@ -165,7 +165,7 @@ QSizeF QgsComposerLegend::paintAndDetermineSize( QPainter* painter )
     }
     else
     {
-      point.rx() = mBoxSpace + size.rwidth();
+      point.rx() = mBoxSpace + size.rwidth() - mBoxSpace;
     }
     point.ry() = mBoxSpace;
     drawTitle( painter, point, mTitleAlignment );
@@ -210,18 +210,16 @@ QSizeF QgsComposerLegend::drawTitle( QPainter* painter, QPointF point, Qt::Align
   for ( QStringList::Iterator titlePart = lines.begin(); titlePart != lines.end(); ++titlePart )
   {
     // it does not draw the last world if rectangle width is exactly text width
-    qreal width = textWidthMillimeters( styleFont( QgsComposerLegendStyle::Title ), *titlePart ) + 1;
     qreal height = fontAscentMillimeters( styleFont( QgsComposerLegendStyle::Title ) ) + fontDescentMillimeters( styleFont( QgsComposerLegendStyle::Title ) );
 
     double left = halignment == Qt::AlignLeft ?    point.x() :
-                  halignment == Qt::AlignHCenter ? point.x() - width / 2 :
-                  point.x() - width - mBoxSpace;
+                  halignment == Qt::AlignHCenter ? point.x() - rect().width() / 2. :
+                  point.x() - rect().width();
+    QRectF r( left, y, rect().width(), height );
 
-    QRectF rect( left, y, width, height );
+    if ( painter ) drawText( painter, r, *titlePart, styleFont( QgsComposerLegendStyle::Title ), halignment, Qt::AlignVCenter );
 
-    if ( painter ) drawText( painter, rect, *titlePart, styleFont( QgsComposerLegendStyle::Title ), halignment, Qt::AlignVCenter );
-
-    size.rwidth() = qMax( width, size.width() );
+    size.rwidth() = qMax( rect().width(), size.width() );
 
     y += height;
     if ( titlePart != lines.end() )

--- a/src/core/composer/qgscomposerlegend.cpp
+++ b/src/core/composer/qgscomposerlegend.cpp
@@ -36,6 +36,7 @@ QgsComposerLegend::QgsComposerLegend( QgsComposition* composition )
     , mFontColor( QColor( 0, 0, 0 ) )
     , mBoxSpace( 2 )
     , mColumnSpace( 2 )
+    , mTitleAlignment( Qt::AlignLeft )
     , mColumnCount( 1 )
     , mComposerMap( 0 )
     , mSplitLayer( false )
@@ -153,23 +154,21 @@ QSizeF QgsComposerLegend::paintAndDetermineSize( QPainter* painter )
   // Now we know total width and can draw the title centered
   if ( !mTitle.isEmpty() )
   {
-    // For multicolumn center if we stay in totalWidth, otherwise allign to left
-    // and expand total width. With single column keep alligned to left be cause
-    // it looks better alligned with items bellow instead of centered
-    Qt::AlignmentFlag halignment;
-    if ( mColumnCount > 1 && titleSize.width() + 2 * mBoxSpace < size.width() )
+    size.rwidth() = qMax( titleSize.width() + 2 * mBoxSpace, size.width() );
+    if ( mTitleAlignment == Qt::AlignLeft )
     {
-      halignment = Qt::AlignHCenter;
+      point.rx() = mBoxSpace;
+    }
+    else if ( mTitleAlignment == Qt::AlignHCenter )
+    {
       point.rx() = mBoxSpace + size.rwidth() / 2;
     }
     else
     {
-      halignment = Qt::AlignLeft;
-      point.rx() = mBoxSpace;
-      size.rwidth() = qMax( titleSize.width() + 2 * mBoxSpace, size.width() );
+      point.rx() = mBoxSpace + size.rwidth();
     }
     point.ry() = mBoxSpace;
-    drawTitle( painter, point, halignment );
+    drawTitle( painter, point, mTitleAlignment );
   }
 
   //adjust box if width or height is to small
@@ -214,7 +213,9 @@ QSizeF QgsComposerLegend::drawTitle( QPainter* painter, QPointF point, Qt::Align
     qreal width = textWidthMillimeters( styleFont( QgsComposerLegendStyle::Title ), *titlePart ) + 1;
     qreal height = fontAscentMillimeters( styleFont( QgsComposerLegendStyle::Title ) ) + fontDescentMillimeters( styleFont( QgsComposerLegendStyle::Title ) );
 
-    double left = halignment == Qt::AlignLeft ?  point.x() : point.x() - width / 2;
+    double left = halignment == Qt::AlignLeft ?    point.x() :
+                  halignment == Qt::AlignHCenter ? point.x() - width / 2 :
+                  point.x() - width - mBoxSpace;
 
     QRectF rect( left, y, width, height );
 
@@ -1038,4 +1039,5 @@ void QgsComposerLegend::setColumns( QList<Atom>& atomList )
     }
   }
 }
+
 

--- a/src/core/composer/qgscomposerlegend.h
+++ b/src/core/composer/qgscomposerlegend.h
@@ -58,6 +58,9 @@ class CORE_EXPORT QgsComposerLegend : public QgsComposerItem
     void setTitle( const QString& t ) {mTitle = t;}
     QString title() const {return mTitle;}
 
+    Qt::AlignmentFlag titleAlignment() const { return mTitleAlignment; }
+    void setTitleAlignment( Qt::AlignmentFlag alignment ) { mTitleAlignment = alignment; }
+
     /** Returns reference to modifiable style */
     QgsComposerLegendStyle & rstyle( QgsComposerLegendStyle::Style s ) { return mStyleMap[s]; }
     /** Returns style */
@@ -153,6 +156,9 @@ class CORE_EXPORT QgsComposerLegend : public QgsComposerItem
     /** Spacing between lines when wrapped */
     double mlineSpacing;
 
+    /** Title alignment, one of Qt::AlignLeft, Qt::AlignHCenter, Qt::AlignRight) */
+    Qt::AlignmentFlag mTitleAlignment;
+
     /** Number of legend columns */
     int mColumnCount;
 
@@ -247,3 +253,4 @@ class CORE_EXPORT QgsComposerLegend : public QgsComposerItem
 };
 
 #endif
+

--- a/src/core/composer/qgscomposerlegend.h
+++ b/src/core/composer/qgscomposerlegend.h
@@ -58,7 +58,9 @@ class CORE_EXPORT QgsComposerLegend : public QgsComposerItem
     void setTitle( const QString& t ) {mTitle = t;}
     QString title() const {return mTitle;}
 
+    /** Returns the alignment of the legend title*/
     Qt::AlignmentFlag titleAlignment() const { return mTitleAlignment; }
+    /** Sets the alignment of the legend title*/
     void setTitleAlignment( Qt::AlignmentFlag alignment ) { mTitleAlignment = alignment; }
 
     /** Returns reference to modifiable style */

--- a/src/ui/qgscomposerlegendwidgetbase.ui
+++ b/src/ui/qgscomposerlegendwidgetbase.ui
@@ -23,7 +23,16 @@
    <property name="spacing">
     <number>0</number>
    </property>
-   <property name="margin">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
     <number>0</number>
    </property>
    <item>
@@ -55,8 +64,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>375</width>
-        <height>1287</height>
+        <width>377</width>
+        <height>1251</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="mainLayout">
@@ -94,7 +103,7 @@
           <item row="0" column="1">
            <widget class="QLineEdit" name="mTitleLineEdit"/>
           </item>
-          <item row="1" column="0">
+          <item row="2" column="0">
            <widget class="QLabel" name="mMapLabel">
             <property name="text">
              <string>Map</string>
@@ -104,10 +113,10 @@
             </property>
            </widget>
           </item>
-          <item row="1" column="1">
+          <item row="2" column="1">
            <widget class="QComboBox" name="mMapComboBox"/>
           </item>
-          <item row="2" column="0">
+          <item row="3" column="0">
            <widget class="QLabel" name="label">
             <property name="text">
              <string>Wrap text on</string>
@@ -117,11 +126,37 @@
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
+          <item row="3" column="1">
            <widget class="QLineEdit" name="mWrapCharLineEdit">
             <property name="frame">
              <bool>true</bool>
             </property>
+           </widget>
+          </item>
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_15">
+            <property name="text">
+             <string>Title alignment:</string>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QComboBox" name="mTitleAlignCombo">
+            <item>
+             <property name="text">
+              <string>Left</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Center</string>
+             </property>
+            </item>
+            <item>
+             <property name="text">
+              <string>Right</string>
+             </property>
+            </item>
            </widget>
           </item>
          </layout>


### PR DESCRIPTION
This patch allows users to specify the horizontal alignment of the legend title in the print composer.

Funded by Sourcepole QGIS Enterprise.
