### PR TITLE
Make QgsComposer window WindowModal

### DIFF
--- a/src/app/composer/qgscomposer.cpp
+++ b/src/app/composer/qgscomposer.cpp
@@ -100,6 +100,7 @@ QgsComposer::QgsComposer( QgisApp *qgis, const QString& title )
 {
   setupUi( this );
   setWindowTitle( mTitle );
+  setWindowModality( Qt::WindowModal );
   setupTheme();
 
   QSettings settings;
@@ -3184,3 +3185,4 @@ void QgsComposer::updateAtlasMapLayerAction( bool atlasEnabled )
     connect( mAtlasFeatureAction, SIGNAL( triggeredForFeature( QgsMapLayer*, QgsFeature* ) ), this, SLOT( setAtlasFeature( QgsMapLayer*, QgsFeature* ) ) );
   }
 }
+


### PR DESCRIPTION
When opening the Composer Manager and adding a new Print Composer, the Print Composer Window appears behind the Composer Manager dialog, and does not accept any inputs until the Composer Manager dialog is closed. This patch fixes this.

Funded by Sourcepole QGIS Enterprise.
