### PR TITLE
Use improved rounding function (taken from LibreOffice) in QgsExpression

### DIFF
--- a/src/app/qgsfieldcalculator.cpp
+++ b/src/app/qgsfieldcalculator.cpp
@@ -208,6 +208,13 @@ void QgsFieldCalculator::accept()
     }
     else
     {
+
+      const QgsField& field = feature.fields()->field(mAttributeId);
+      if(field.type() == QVariant::Double && field.precision() > 0) {
+        double scaler = pow( 10.0, field.precision() );
+        value = QVariant( qRound( value.toDouble() * scaler ) / scaler );
+      }
+
       mVectorLayer->changeAttributeValue( feature.id(), mAttributeId, value, newField ? emptyAttribute : feature.attributes().value( mAttributeId ) );
     }
 


### PR DESCRIPTION
The round function used in QgsExpression suffers from floating point precision issues when rounding.  I.e. when rounding 0.005, 0.015, 0.025 to two decimals, it inconsistently rounds up and down (`0.005 -> 0.01`, `0.015 -> 0.01`, `0.025 -> 0.03`).

This patch adds replaces the rounding function with an adapted version of the LibreOffice rounding function, which does not exhibit this behavior.

Funded by Sourcepole QGIS Enterprise.
