### PR TITLE
Improve print composer arrow bounding box logic

### DIFF
--- a/src/core/composer/qgscomposerarrow.h
+++ b/src/core/composer/qgscomposerarrow.h
@@ -63,7 +63,7 @@ class CORE_EXPORT QgsComposerArrow: public QgsComposerItem
     void setArrowColor( const QColor& c ) { mArrowColor = c; }
 
     MarkerMode markerMode() const { return mMarkerMode;}
-    void setMarkerMode( MarkerMode mode ) {mMarkerMode = mode;}
+    void setMarkerMode( MarkerMode mode );
 
     /** stores state in Dom element
     * @param elem is Dom element corresponding to 'Composer' tag
@@ -88,6 +88,12 @@ class CORE_EXPORT QgsComposerArrow: public QgsComposerItem
     QPointF mStartPoint;
     QPointF mStopPoint;
 
+    /**Considering the rectangle as spanning [x[0], x[1]] x [y[0], y[1]], these
+     * indices specify which index {0, 1} corresponds to the start point
+     * coordinate of the respective dimension*/
+    int mStartXIdx;
+    int mStartYIdx;
+
     QPen mPen;
     QBrush mBrush;
 
@@ -110,6 +116,8 @@ class CORE_EXPORT QgsComposerArrow: public QgsComposerItem
     /**Adapts the item scene rect to contain the start point, the stop point including the arrow marker and the outline.
         Needs to be called whenever the arrow width/height, the outline with or the endpoints are changed*/
     void adaptItemSceneRect();
+    /**Computes the margin around the line necessary to include the markers */
+    double computeMarkerMargin() const;
     /**Draws the default marker at the line end*/
     void drawHardcodedMarker( QPainter* p, MarkerType type );
     /**Draws a user-defined marker (must be an svg file)*/
@@ -119,3 +127,5 @@ class CORE_EXPORT QgsComposerArrow: public QgsComposerItem
 };
 
 #endif // QGSCOMPOSERARROW_H
+
+


### PR DESCRIPTION
Currently, `setSceneRect` does not directly set the bounding box, but first adjusts the arrow endpoints, and then adjusts the bounding box accordingly. A consequence of this is that when the user adapts the bounding box dimensions in the `Item properties`  -> `Position and size`  UI, the entered values will not be exactly equal to the resulting bounding box size (i.e. if the user enters 200 for width, the bounding box will end up being wide i.e. 199.738, depending on the previous size). The cause of this is that the marker size which do not scale proportionally to the bounding box size (whereas the code attempts to reposition the endpoints by keeping the relative position of the endpoints within the bounding box constant).

This patch reworks the bounding box logic. Now, the bounding box is resized first, and then the arrow endpoints are repositioned appropriately inside the bounding box. This also has the advantage that, when changing marker symbol, the bounding box does not change (except when the bounding box is too small to contain the marker symbol). This patch also ensures the bounding box is correctly updated when the marker symbol changes.

Funded by Sourcepole QGIS Enterprise.
