### PR TITLE
Initially disable composition width and height spinboxes 

### DIFF
--- a/src/app/composer/qgscompositionwidget.cpp
+++ b/src/app/composer/qgscompositionwidget.cpp
@@ -140,6 +140,8 @@ void QgsCompositionWidget::createPaperEntries()
     mPaperMap.insert( it->mName, *it );
   }
   mPaperSizeComboBox->setCurrentIndex( 2 ); //A4
+  mPaperWidthDoubleSpinBox->setEnabled( false );
+  mPaperHeightDoubleSpinBox->setEnabled( false );
 }
 
 void QgsCompositionWidget::on_mPaperSizeComboBox_currentIndexChanged( const QString& text )
@@ -567,3 +569,4 @@ void QgsCompositionWidget::blockSignals( bool block )
   mGridToleranceSpinBox->blockSignals( block );
   mAlignmentToleranceSpinBox->blockSignals( block );
 }
+

--- a/src/app/composer/qgscompositionwidget.cpp
+++ b/src/app/composer/qgscompositionwidget.cpp
@@ -139,9 +139,6 @@ void QgsCompositionWidget::createPaperEntries()
     mPaperSizeComboBox->addItem( it->mName );
     mPaperMap.insert( it->mName, *it );
   }
-  mPaperSizeComboBox->setCurrentIndex( 2 ); //A4
-  mPaperWidthDoubleSpinBox->setEnabled( false );
-  mPaperHeightDoubleSpinBox->setEnabled( false );
 }
 
 void QgsCompositionWidget::on_mPaperSizeComboBox_currentIndexChanged( const QString& text )
@@ -381,6 +378,11 @@ void QgsCompositionWidget::displayCompositionWidthHeight()
   {
     //custom
     mPaperSizeComboBox->setCurrentIndex( 0 );
+  }
+  else
+  {
+    mPaperWidthDoubleSpinBox->setEnabled( false );
+    mPaperHeightDoubleSpinBox->setEnabled( false );
   }
 }
 

--- a/src/app/composer/qgscompositionwidget.cpp
+++ b/src/app/composer/qgscompositionwidget.cpp
@@ -383,6 +383,7 @@ void QgsCompositionWidget::displayCompositionWidthHeight()
   {
     mPaperWidthDoubleSpinBox->setEnabled( false );
     mPaperHeightDoubleSpinBox->setEnabled( false );
+    mPaperUnitsComboBox->setEnabled( false );
   }
 }
 


### PR DESCRIPTION
Since the initial paper size is A4, the width and height spinboxes should be disabled.

Funded by Sourcepole QGIS Enterprise.
