### PR TITLE
Re-write the snapping settings when removing a layer

### DIFF
--- a/src/app/qgssnappingdialog.cpp
+++ b/src/app/qgssnappingdialog.cpp
@@ -365,6 +365,7 @@ void QgsSnappingDialog::layersWillBeRemoved( QStringList thelayers )
     if ( item )
       delete item;
   }
+  apply();
 }
 
 void QgsSnappingDialog::setTopologicalEditingState()
@@ -384,3 +385,4 @@ void QgsSnappingDialog::setIntersectionSnappingState()
   cbxEnableIntersectionSnappingCheckBox->setChecked( intersectionSnapping );
   cbxEnableIntersectionSnappingCheckBox->blockSignals( false );
 }
+


### PR DESCRIPTION
When removing a layer from the project, the project file would still include a reference to the layer in the `LayerSnappingList`. Rewriting the snapping settings when removing layers fixes this.

Funded by Sourcepole QGIS Enterprise.
