### PR TITLE
Ask whether to save existing project when creating a new project from a template

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -3284,6 +3284,11 @@ void QgisApp::fileNew( bool thePromptToSaveFlag, bool forceBlank )
 
 bool QgisApp::fileNewFromTemplate( QString fileName )
 {
+  if ( !saveDirty() )
+  {
+    return false; //cancel pressed
+  }
+
   QgsDebugMsg( QString( "loading project template: %1" ).arg( fileName ) );
   if ( addProject( fileName ) )
   {
@@ -9560,3 +9565,4 @@ LONG WINAPI QgisApp::qgisCrashDump( struct _EXCEPTION_POINTERS *ExceptionInfo )
   return EXCEPTION_EXECUTE_HANDLER;
 }
 #endif
+


### PR DESCRIPTION
When creating a new project from a template, the user would not get asked whether to save the currently open project.

Funded by Sourcepole QGIS Enterprise.
