### PR TITLE
QgsDistanceArea::sourceCrs returns uninitialized value

### DIFF
--- a/src/core/qgsdistancearea.cpp
+++ b/src/core/qgsdistancearea.cpp
@@ -82,7 +82,6 @@ void QgsDistanceArea::_copy( const QgsDistanceArea & origDA )
   // Some calculations and trig. Should not be TOO time consuming.
   // Alternatively we could copy the temp vars?
   computeAreaInit();
-  mSourceRefSys = origDA.mSourceRefSys;
   mCoordTransform = new QgsCoordinateTransform( origDA.mCoordTransform->sourceCrs(), origDA.mCoordTransform->destCRS() );
 }
 
@@ -1008,3 +1007,4 @@ void QgsDistanceArea::convertMeasurement( double &measure, QGis::UnitType &measu
   QgsDebugMsg( QString( "to %1 %2" ).arg( QString::number( measure ), QGis::toLiteral( displayUnits ) ) );
   measureUnits = displayUnits;
 }
+

--- a/src/core/qgsdistancearea.h
+++ b/src/core/qgsdistancearea.h
@@ -65,7 +65,7 @@ class CORE_EXPORT QgsDistanceArea
     void setSourceAuthId( QString authid );
 
     //! returns source spatial reference system
-    long sourceCrs() const { return mSourceRefSys; }
+    long sourceCrs() const { return mCoordTransform->sourceCrs().srsid(); }
     //! What sort of coordinate system is being used?
     bool geographic() const { return mCoordTransform->sourceCrs().geographicFlag(); }
 
@@ -154,9 +154,6 @@ class CORE_EXPORT QgsDistanceArea
     //! indicates whether we will transform coordinates
     bool mEllipsoidalMode;
 
-    //! id of the source spatial reference system
-    long mSourceRefSys;
-
     //! ellipsoid acronym (from table tbl_ellipsoids)
     QString mEllipsoid;
 
@@ -180,3 +177,4 @@ class CORE_EXPORT QgsDistanceArea
 };
 
 #endif
+

--- a/src/gui/qgsattributedialog.cpp
+++ b/src/gui/qgsattributedialog.cpp
@@ -285,9 +285,9 @@ void QgsAttributeDialog::init()
     // Set focus to first widget in list, to help entering data without moving the mouse.
     if ( mypInnerLayout->rowCount() > 0 )
     {
-      QWidget* widget = mypInnerLayout->itemAtPosition( 0, 1 )->widget();
-      if ( widget )
-        widget->setFocus( Qt::OtherFocusReason );
+      QLayoutItem* item = mypInnerLayout->itemAtPosition( 0, 1 );
+      if ( item && item->widget() )
+        item->widget()->setFocus( Qt::OtherFocusReason );
     }
 
     QSpacerItem *mypSpacer = new QSpacerItem( 0, 0, QSizePolicy::Fixed, QSizePolicy::MinimumExpanding );


### PR DESCRIPTION
The member variable `mSourceRefSys` returned by `QgsDistanceArea::sourceCrs()` is never initialized. This patch removes that member variable and makes `sourceCrs()` get the srsid directly from `mCoordTransform->sourceCrs()`.

Funded by Sourcepole QGIS Enterprise.
