### PR TITLE
Correctly update extent when restoring composer map state

### DIFF
--- a/python/core/composer/qgscomposermap.sip
+++ b/python/core/composer/qgscomposermap.sip
@@ -401,6 +401,12 @@ class QgsComposerMap : QgsComposerItem
     /** Sets the margin size (percentage) used when the map is in atlas mode */
     void setAtlasMargin( double margin );
 
+    /** Sets whether updates to the composer map are enabled. */
+    void setUpdatesEnabled( bool enabled );
+
+    /** Returns whether updates to the composer map are enabled. */
+    bool updatesEnabled() const;
+
   signals:
     void extentChanged();
 

--- a/src/core/composer/qgscomposermap.cpp
+++ b/src/core/composer/qgscomposermap.cpp
@@ -44,7 +44,7 @@
 QgsComposerMap::QgsComposerMap( QgsComposition *composition, int x, int y, int width, int height )
     : QgsComposerItem( x, y, width, height, composition ), mMapRotation( 0 ), mKeepLayerSet( false )
     , mOverviewFrameMapId( -1 ), mOverviewBlendMode( QPainter::CompositionMode_SourceOver ), mOverviewInverted( false ), mOverviewCentered( false )
-    , mGridEnabled( false ), mGridStyle( Solid )
+    , mUpdatesEnabled( true ), mGridEnabled( false ), mGridStyle( Solid )
     , mGridIntervalX( 0.0 ), mGridIntervalY( 0.0 ), mGridOffsetX( 0.0 ), mGridOffsetY( 0.0 ), mGridAnnotationFontColor( QColor( 0, 0, 0 ) )
     , mGridAnnotationPrecision( 3 ), mShowGridAnnotation( false ), mGridBlendMode( QPainter::CompositionMode_SourceOver )
     , mLeftGridAnnotationPosition( OutsideMapFrame ), mRightGridAnnotationPosition( OutsideMapFrame )
@@ -102,7 +102,7 @@ QgsComposerMap::QgsComposerMap( QgsComposition *composition, int x, int y, int w
 QgsComposerMap::QgsComposerMap( QgsComposition *composition )
     : QgsComposerItem( 0, 0, 10, 10, composition ), mMapRotation( 0 ), mKeepLayerSet( false ), mOverviewFrameMapId( -1 )
     , mOverviewBlendMode( QPainter::CompositionMode_SourceOver ), mOverviewInverted( false ), mOverviewCentered( false )
-    , mGridEnabled( false ), mGridStyle( Solid )
+    , mUpdatesEnabled( true ), mGridEnabled( false ), mGridStyle( Solid )
     , mGridIntervalX( 0.0 ), mGridIntervalY( 0.0 ), mGridOffsetX( 0.0 ), mGridOffsetY( 0.0 ), mGridAnnotationFontColor( QColor( 0, 0, 0 ) )
     , mGridAnnotationPrecision( 3 ), mShowGridAnnotation( false ), mGridBlendMode( QPainter::CompositionMode_SourceOver )
     , mLeftGridAnnotationPosition( OutsideMapFrame ), mRightGridAnnotationPosition( OutsideMapFrame )
@@ -734,6 +734,11 @@ void QgsComposerMap::setMapRotation( double r )
 
 void QgsComposerMap::updateItem()
 {
+  if ( !mUpdatesEnabled )
+  {
+    return;
+  }
+
   if ( mPreviewMode != QgsComposerMap::Rectangle &&  !mCacheUpdated )
   {
     cache();
@@ -1065,8 +1070,7 @@ bool QgsComposerMap::readXML( const QDomElement& itemElem, const QDomDocument& d
     xmax = extentElem.attribute( "xmax" ).toDouble();
     ymin = extentElem.attribute( "ymin" ).toDouble();
     ymax = extentElem.attribute( "ymax" ).toDouble();
-
-    mExtent = QgsRectangle( xmin, ymin, xmax, ymax );
+    setNewExtent( QgsRectangle( xmin, ymin, xmax, ymax ) );
   }
 
   //map rotation
@@ -2553,3 +2557,4 @@ void QgsComposerMap::sizeChangedByRotation( double& width, double& height )
   //kept for api compatibility with QGIS 2.0 - use mMapRotation
   return QgsComposerItem::sizeChangedByRotation( width, height, mMapRotation );
 }
+

--- a/src/core/composer/qgscomposermap.h
+++ b/src/core/composer/qgscomposermap.h
@@ -439,6 +439,9 @@ class CORE_EXPORT QgsComposerMap : public QgsComposerItem
     /** Sets the margin size (percentage) used when the map is in atlas mode */
     void setAtlasMargin( double margin ) { mAtlasMargin = margin; }
 
+    void setUpdatesEnabled( bool enabled ) { mUpdatesEnabled = enabled; }
+    bool updatesEnabled() const { return mUpdatesEnabled; }
+
   signals:
     void extentChanged();
 
@@ -517,6 +520,9 @@ class CORE_EXPORT QgsComposerMap : public QgsComposerItem
     bool mOverviewInverted;
     /** Centering mode for overview */
     bool mOverviewCentered;
+
+    /** Whether updates to the map are enabled */
+    bool mUpdatesEnabled;
 
     /**Establishes signal/slot connection for update in case of layer change*/
     void connectUpdateSlot();
@@ -659,3 +665,4 @@ class CORE_EXPORT QgsComposerMap : public QgsComposerItem
 };
 
 #endif
+

--- a/src/core/composer/qgscomposermap.h
+++ b/src/core/composer/qgscomposermap.h
@@ -439,7 +439,10 @@ class CORE_EXPORT QgsComposerMap : public QgsComposerItem
     /** Sets the margin size (percentage) used when the map is in atlas mode */
     void setAtlasMargin( double margin ) { mAtlasMargin = margin; }
 
+    /** Sets whether updates to the composer map are enabled. */
     void setUpdatesEnabled( bool enabled ) { mUpdatesEnabled = enabled; }
+
+    /** Returns whether updates to the composer map are enabled. */
     bool updatesEnabled() const { return mUpdatesEnabled; }
 
   signals:

--- a/src/core/composer/qgscomposition.cpp
+++ b/src/core/composer/qgscomposition.cpp
@@ -867,6 +867,12 @@ void QgsComposition::addItemsFromXML( const QDomElement& elem, const QDomDocumen
   {
     QDomElement currentComposerMapElem = composerMapList.at( i ).toElement();
     QgsComposerMap* newMap = new QgsComposerMap( this );
+
+    if ( mapsToRestore )
+    {
+      newMap->setUpdatesEnabled( false );
+    }
+
     newMap->readXML( currentComposerMapElem, doc );
     newMap->assignFreeId();
 
@@ -874,6 +880,7 @@ void QgsComposition::addItemsFromXML( const QDomElement& elem, const QDomDocumen
     {
       mapsToRestore->insert( newMap, ( int )( newMap->previewMode() ) );
       newMap->setPreviewMode( QgsComposerMap::Rectangle );
+      newMap->setUpdatesEnabled( true );
     }
     addComposerMap( newMap, false );
     newMap->setZValue( newMap->zValue() + zOrderOffset );
@@ -2578,3 +2585,4 @@ double QgsComposition::relativePosition( double position, double beforeMin, doub
   //return linearly scaled position
   return m * position + c;
 }
+


### PR DESCRIPTION
When changing the composer map scale from the UI, and then doing undo, the map is not redrawn with the old scale. This patch ensures that the extent of the composer map is correctly updated. When loading a composition, updates to the composer map are disabled to improve loading performance.

Funded by Sourcepole QGIS Enterprise.
