### PR TITLE
Fix crash with empty attribute list

### DIFF
--- a/src/gui/qgsattributedialog.cpp
+++ b/src/gui/qgsattributedialog.cpp
@@ -285,9 +285,9 @@ void QgsAttributeDialog::init()
     // Set focus to first widget in list, to help entering data without moving the mouse.
     if ( mypInnerLayout->rowCount() > 0 )
     {
-      QWidget* widget = mypInnerLayout->itemAtPosition( 0, 1 )->widget();
-      if ( widget )
-        widget->setFocus( Qt::OtherFocusReason );
+      QLayoutItem* item = mypInnerLayout->itemAtPosition( 0, 1 );
+      if ( item && item->widget() )
+        item->widget()->setFocus( Qt::OtherFocusReason );
     }
 
     QSpacerItem *mypSpacer = new QSpacerItem( 0, 0, QSizePolicy::Fixed, QSizePolicy::MinimumExpanding );

--- a/src/gui/qgsattributedialog.cpp
+++ b/src/gui/qgsattributedialog.cpp
@@ -283,12 +283,9 @@ void QgsAttributeDialog::init()
     }
 
     // Set focus to first widget in list, to help entering data without moving the mouse.
-    if ( mypInnerLayout->rowCount() > 0 )
-    {
-      QLayoutItem* item = mypInnerLayout->itemAtPosition( 0, 1 );
-      if ( item && item->widget() )
-        item->widget()->setFocus( Qt::OtherFocusReason );
-    }
+    QLayoutItem* item = mypInnerLayout->itemAtPosition( 0, 1 );
+    if ( item && item->widget() )
+      item->widget()->setFocus( Qt::OtherFocusReason );
 
     QSpacerItem *mypSpacer = new QSpacerItem( 0, 0, QSizePolicy::Fixed, QSizePolicy::MinimumExpanding );
     mypInnerLayout->addItem( mypSpacer, mypInnerLayout->rowCount() + 1, 0 );


### PR DESCRIPTION
When opening the attribute dialog of a feature with no attributes, QGIS crashes (since `mypInnerLayout->itemAtPosition( 0, 1 )` is `null`). This patch correctly handles this case.

Funded by Sourcepole QGIS Enterprise.
