### PR TITLE
Try to use the project CRS when adding a layer from the browser

### DIFF
--- a/python/core/qgsdataitem.sip
+++ b/python/core/qgsdataitem.sip
@@ -141,6 +141,15 @@ class QgsLayerItem : QgsDataItem
     // Returns provider key
     QString providerKey();
 
+    /** Returns the supported CRS
+     *  @note Added in 2.8
+     */
+    QStringList supportedCRS();
+
+    /** Returns the supported formats
+     *  @note Added in 2.8
+     */
+    QStringList supportedFormats();
   public:
     static const QIcon &iconPoint();
     static const QIcon &iconLine();

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -150,6 +150,11 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
       */
     QgsRasterLayer *addRasterLayer( const QString &rasterFile, const QString &baseName, bool guiWarning = true );
 
+    /** Returns and adjusted uri for the layer based on current and available CRS as well as the last selected image format
+     * @note added in 2.4
+     */
+    QString crsAndFormatAdjustedLayerUri(const QString& uri, const QStringList& supportedCrs, const QStringList& supportedFormats) const;
+
     /** Add a 'pre-made' map layer to the project */
     void addMapLayer( QgsMapLayer *theMapLayer );
 

--- a/src/app/qgsbrowserdockwidget.cpp
+++ b/src/app/qgsbrowserdockwidget.cpp
@@ -480,7 +480,7 @@ void QgsBrowserDockWidget::addLayer( QgsLayerItem *layerItem )
   if ( layerItem == NULL )
     return;
 
-  QString uri = layerItem->uri();
+  QString uri = QgisApp::instance()->crsAndFormatAdjustedLayerUri( layerItem->uri(), layerItem->supportedCRS(), layerItem->supportedFormats() );
   if ( uri.isEmpty() )
     return;
 

--- a/src/core/qgsdataitem.h
+++ b/src/core/qgsdataitem.h
@@ -277,11 +277,23 @@ class CORE_EXPORT QgsLayerItem : public QgsDataItem
     // Returns provider key
     QString providerKey() { return mProviderKey; }
 
+    /** Returns the supported CRS
+     *  @note Added in 2.8
+     */
+    QStringList supportedCRS() { return mSupportedCRS; }
+
+    /** Returns the supported formats
+     *  @note Added in 2.8
+     */
+    QStringList supportedFormats() { return mSupportFormats; }
+
   protected:
 
     QString mProviderKey;
     QString mUri;
     LayerType mLayerType;
+    QStringList mSupportedCRS;
+    QStringList mSupportFormats;
 
   public:
     static const QIcon &iconPoint();
@@ -441,4 +453,5 @@ class CORE_EXPORT QgsZipItem : public QgsDataCollectionItem
 };
 
 #endif // QGSDATAITEM_H
+
 

--- a/src/core/qgsmimedatautils.h
+++ b/src/core/qgsmimedatautils.h
@@ -16,6 +16,7 @@
 #define QGSMIMEDATAUTILS_H
 
 #include <QMimeData>
+#include <QStringList>
 
 class QgsLayerItem;
 
@@ -34,6 +35,8 @@ class CORE_EXPORT QgsMimeDataUtils
       QString providerKey;
       QString name;
       QString uri;
+      QStringList supportedCrs;
+      QStringList supportedFormats;
     };
     typedef QList<Uri> UriList;
 
@@ -43,6 +46,11 @@ class CORE_EXPORT QgsMimeDataUtils
 
     static UriList decodeUriList( const QMimeData* data );
 
+  private:
+    static QString encode( const QStringList& items );
+    static QStringList decode( const QString& encoded );
+
 };
 
 #endif // QGSMIMEDATAUTILS_H
+

--- a/src/providers/wcs/qgswcsdataitems.cpp
+++ b/src/providers/wcs/qgswcsdataitems.cpp
@@ -125,6 +125,7 @@ QgsWCSLayerItem::QgsWCSLayerItem( QgsDataItem* parent, QString name, QString pat
     mDataSourceUri( dataSourceUri ),
     mCoverageSummary( coverageSummary )
 {
+  mSupportedCRS = mCoverageSummary.supportedCrs;
   QgsDebugMsg( "uri = " + mDataSourceUri.encodedUri() );
   mUri = createUri();
   // Populate everything, it costs nothing, all info about layers is collected
@@ -312,3 +313,4 @@ QGISEXTERN QgsWCSSourceSelect * selectWidget( QWidget * parent, Qt::WindowFlags 
 {
   return new QgsWCSSourceSelect( parent, fl );
 }
+

--- a/src/providers/wms/qgswmsdataitems.cpp
+++ b/src/providers/wms/qgswmsdataitems.cpp
@@ -244,6 +244,8 @@ QgsWMSLayerItem::QgsWMSLayerItem( QgsDataItem* parent, QString name, QString pat
     , mDataSourceUri( dataSourceUri )
     , mLayerProperty( layerProperty )
 {
+  mSupportedCRS = mLayerProperty.crs;
+  mSupportFormats = mCapabilitiesProperty.capability.request.getMap.format;
   QgsDebugMsg( "uri = " + mDataSourceUri.encodedUri() );
 
   mUri = createUri();
@@ -454,3 +456,4 @@ QGISEXTERN QgsDataItem * dataItem( QString thePath, QgsDataItem* parentItem )
 
   return 0;
 }
+


### PR DESCRIPTION
Currently, when a layer is added from the browser, the first valid CRS is used. With this patch, the project CRS is used if possible. Also, the last selected image format is used if possible.

At the same time, proper escaping and unescaping routines are introduced, removing the need for the `if ( parts[3] == "PG" )` workaround.

Funded by Sourcepole QGIS Enterprise.
