### PR TITLE
Make QgsComposerManager non-modal

### DIFF
--- a/src/app/composer/qgscomposer.cpp
+++ b/src/app/composer/qgscomposer.cpp
@@ -3184,3 +3184,4 @@ void QgsComposer::updateAtlasMapLayerAction( bool atlasEnabled )
     connect( mAtlasFeatureAction, SIGNAL( triggeredForFeature( QgsMapLayer*, QgsFeature* ) ), this, SLOT( setAtlasFeature( QgsMapLayer*, QgsFeature* ) ) );
   }
 }
+

--- a/src/app/composer/qgscomposermanager.cpp
+++ b/src/app/composer/qgscomposermanager.cpp
@@ -204,7 +204,7 @@ void QgsComposerManager::on_mAddButton_clicked()
     }
   }
 
-  if ( newComposer && !loadedOK )
+  if ( !loadedOK )
   {
     newComposer->close();
     QgisApp::instance()->deleteComposer( newComposer );

--- a/src/app/composer/qgscomposermanager.cpp
+++ b/src/app/composer/qgscomposermanager.cpp
@@ -101,6 +101,8 @@ QgsComposerManager::~QgsComposerManager()
 
 void QgsComposerManager::refreshComposers()
 {
+  QString selName = mComposerListWidget->currentItem() ? mComposerListWidget->currentItem()->text() : "";
+
   mItemComposerMap.clear();
   mComposerListWidget->clear();
 
@@ -113,6 +115,16 @@ void QgsComposerManager::refreshComposers()
     mItemComposerMap.insert( item, *it );
   }
   mComposerListWidget->sortItems();
+
+  // Restore selection
+  if ( !selName.isEmpty() )
+  {
+    QList<QListWidgetItem*> items = mComposerListWidget->findItems( selName, Qt::MatchExactly );
+    if ( !items.isEmpty() )
+    {
+      mComposerListWidget->setCurrentItem( items.first() );
+    }
+  }
 }
 
 QMap<QString, QString> QgsComposerManager::defaultTemplates( bool fromUser ) const
@@ -299,7 +311,6 @@ void QgsComposerManager::show_clicked()
       {
         // extra activation steps for Windows
         bool shown = c->isVisible();
-        hide();
 
         c->activate();
 
@@ -344,7 +355,6 @@ void QgsComposerManager::show_clicked()
     c->activate();
   }
 #endif //0
-  close();
 }
 
 void QgsComposerManager::duplicate_clicked()
@@ -388,11 +398,7 @@ void QgsComposerManager::duplicate_clicked()
   if ( newComposer )
   {
     // extra activation steps for Windows
-    hide();
     newComposer->activate();
-
-    // no need to add new composer to list widget, if just closing this->exec();
-    close();
   }
   else
   {

--- a/src/app/composer/qgscomposermanager.cpp
+++ b/src/app/composer/qgscomposermanager.cpp
@@ -61,6 +61,12 @@ QgsComposerManager::QgsComposerManager( QWidget * parent, Qt::WindowFlags f ): Q
   mButtonBox->addButton( pb, QDialogButtonBox::ActionRole );
   connect( pb, SIGNAL( clicked() ), this, SLOT( rename_clicked() ) );
 
+#ifdef Q_WS_MAC
+  // Create action to select this window
+  mWindowAction = new QAction( windowTitle(), this );
+  connect( mWindowAction, SIGNAL( triggered() ), this, SLOT( activate() ) );
+#endif
+
   mTemplate->addItem( tr( "Empty composer" ) );
   mTemplate->addItem( tr( "Specific" ) );
 
@@ -269,6 +275,32 @@ void QgsComposerManager::openLocalDirectory( const QString& localDirPath )
   }
   QDesktopServices::openUrl( QUrl::fromLocalFile( localDirPath ) );
 }
+
+#ifdef Q_WS_MAC
+void QgsComposerManager::showEvent(QShowEvent* event)
+{
+  if(!event->spontaneous()) {
+    QgisApp::instance()->addWindow( mWindowAction );
+  }
+}
+
+void QgsComposerManager::changeEvent( QEvent* event )
+{
+  QDialog::changeEvent( event );
+  switch ( event->type() )
+  {
+    case QEvent::ActivationChange:
+      if ( QApplication::activeWindow() == this )
+      {
+        mWindowAction->setChecked( true );
+      }
+      break;
+
+    default:
+      break;
+  }
+}
+#endif
 
 void QgsComposerManager::remove_clicked()
 {

--- a/src/app/composer/qgscomposermanager.cpp
+++ b/src/app/composer/qgscomposermanager.cpp
@@ -133,6 +133,13 @@ void QgsComposerManager::refreshComposers()
   }
 }
 
+void QgsComposerManager::activate()
+{
+  raise();
+  setWindowState( windowState() & ~Qt::WindowMinimized );
+  activateWindow();
+}
+
 QMap<QString, QString> QgsComposerManager::defaultTemplates( bool fromUser ) const
 {
   QMap<QString, QString> templateMap;

--- a/src/app/composer/qgscomposermanager.h
+++ b/src/app/composer/qgscomposermanager.h
@@ -31,6 +31,10 @@ class QgsComposerManager: public QDialog, private Ui::QgsComposerManagerBase
     QgsComposerManager( QWidget * parent = 0, Qt::WindowFlags f = 0 );
     ~QgsComposerManager();
 
+  public slots:
+    /** Raise, unminimize and activate this window */
+    void activate();
+
   private:
     /**Stores the relation between items and composer pointers. A 0 pointer for the composer means that
       this composer needs to be created from a default template*/

--- a/src/app/composer/qgscomposermanager.h
+++ b/src/app/composer/qgscomposermanager.h
@@ -31,14 +31,10 @@ class QgsComposerManager: public QDialog, private Ui::QgsComposerManagerBase
     QgsComposerManager( QWidget * parent = 0, Qt::WindowFlags f = 0 );
     ~QgsComposerManager();
 
-
   private:
     /**Stores the relation between items and composer pointers. A 0 pointer for the composer means that
       this composer needs to be created from a default template*/
     QMap<QListWidgetItem*, QgsComposer*> mItemComposerMap;
-
-    /**Enters the composer instances and created the item-composer map*/
-    void initialize();
 
     /** Returns the default templates (key: template name, value: absolute path to template file)
      * @param fromUser whether to return user templates from ~/.qgis/composer_templates (added in 1.9)
@@ -71,6 +67,9 @@ class QgsComposerManager: public QDialog, private Ui::QgsComposerManagerBase
      * @note added in QGIS 1.9
      */
     void on_mTemplatesUserDirBtn_pressed();
+
+    /** Refreshes the list of composers */
+    void refreshComposers();
 
     void remove_clicked();
     void show_clicked();

--- a/src/app/composer/qgscomposermanager.h
+++ b/src/app/composer/qgscomposermanager.h
@@ -49,6 +49,13 @@ class QgsComposerManager: public QDialog, private Ui::QgsComposerManagerBase
     QString mDefaultTemplatesDir;
     QString mUserTemplatesDir;
 
+#ifdef Q_WS_MAC
+    void showEvent(QShowEvent *event);
+    void changeEvent(QEvent *);
+
+    QAction* mWindowAction;
+#endif
+
   private slots:
     void on_mAddButton_clicked();
     /** Slot to track combobox to use specific template path

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -452,6 +452,7 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, QWidget * parent, 
 #ifdef Q_OS_WIN
     , mSkipNextContextMenuEvent( 0 )
 #endif
+    , mComposerManager( 0 )
     , mpGpsWidget( 0 )
 {
   if ( smInstance )
@@ -776,6 +777,7 @@ QgisApp::QgisApp( )
     , mInternalClipboard( 0 )
     , mpMaptip( 0 )
     , mPythonUtils( 0 )
+    , mComposerManager( 0 )
     , mpGpsWidget( 0 )
 {
   smInstance = this;
@@ -844,6 +846,8 @@ QgisApp::~QgisApp()
   delete mpGpsWidget;
 
   delete mOverviewMapCursor;
+
+  delete mComposerManager;
 
   deletePrintComposers();
   removeAnnotationItems();
@@ -3919,11 +3923,20 @@ void QgisApp::newPrintComposer()
 
 void QgisApp::showComposerManager()
 {
-  QgsComposerManager* m = new QgsComposerManager( this, Qt::Window );
-  connect( m, SIGNAL( finished( int ) ), m, SLOT( deleteLater() ) );
-  m->show();
-  m->raise();
-  m->activateWindow();
+  if ( !mComposerManager )
+  {
+    mComposerManager = new QgsComposerManager( this, Qt::Window );
+    connect( mComposerManager, SIGNAL( finished( int ) ), this, SLOT( deleteComposerManager() ) );
+  }
+  mComposerManager->show();
+  mComposerManager->raise();
+  mComposerManager->activateWindow();
+}
+
+void QgisApp::deleteComposerManager()
+{
+  delete mComposerManager;
+  mComposerManager = 0;
 }
 
 void QgisApp::saveMapAsImage()

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -3929,8 +3929,7 @@ void QgisApp::showComposerManager()
     connect( mComposerManager, SIGNAL( finished( int ) ), this, SLOT( deleteComposerManager() ) );
   }
   mComposerManager->show();
-  mComposerManager->raise();
-  mComposerManager->activateWindow();
+  mComposerManager->activate();
 }
 
 void QgisApp::deleteComposerManager()

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -3935,7 +3935,7 @@ void QgisApp::showComposerManager()
 
 void QgisApp::deleteComposerManager()
 {
-  delete mComposerManager;
+  mComposerManager->deleteLater();
   mComposerManager = 0;
 }
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -3919,8 +3919,11 @@ void QgisApp::newPrintComposer()
 
 void QgisApp::showComposerManager()
 {
-  QgsComposerManager m( this );
-  m.exec();
+  QgsComposerManager* m = new QgsComposerManager( this, Qt::Window );
+  connect( m, SIGNAL( finished( int ) ), m, SLOT( deleteLater() ) );
+  m->show();
+  m->raise();
+  m->activateWindow();
 }
 
 void QgisApp::saveMapAsImage()
@@ -5004,6 +5007,7 @@ void QgisApp::deleteComposer( QgsComposer* c )
   mPrintComposers.remove( c );
   mPrintComposersMenu->removeAction( c->windowAction() );
   markDirty();
+  emit composerRemoved( c->view() );
   delete c;
 }
 

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -42,6 +42,7 @@ class QgsAnnotationItem;
 class QgsClipboard;
 class QgsComposer;
 class QgsComposerView;
+class QgsComposerManager;
 class QgsContrastEnhancement;
 class QgsGeometry;
 class QgsFeature;
@@ -1172,6 +1173,9 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     //! catch MapCanvas keyPress event so we can check if selected feature collection must be deleted
     void mapCanvas_keyPressed( QKeyEvent *e );
 
+    //! Deletes the active QgsComposerManager instance
+    void deleteComposerManager();
+
   signals:
     /** emitted when a key is pressed and we want non widget sublasses to be able
       to pick up on this (e.g. maplayer) */
@@ -1512,6 +1516,8 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     QgsSnappingDialog* mSnappingDialog;
 
     QgsPluginManager* mPluginManager;
+
+    QgsComposerManager* mComposerManager;
 
     //! Persistent tile scale slider
     QgsTileScaleWidget * mpTileScaleWidget;

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1208,6 +1208,10 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
       @note added in version 1.4*/
     void composerWillBeRemoved( QgsComposerView* v );
 
+    /**This signal is emitted when a composer instance has been removed
+       @note added in version 2.3*/
+    void composerRemoved( QgsComposerView* v );
+
     /**This signal is emitted when QGIS' initialization is complete
      @note added in version 1.6*/
     void initializationCompleted();


### PR DESCRIPTION
New approach for #1298: When opening the Composer Manager and adding a new Print Composer, the Print Composer Window appears behind the Composer Manager dialog, and does not accept any inputs until the Composer Manager dialog is closed.

This approach makes the Composer Manager non-modal, and ensures the list of composers in the Composer Manager stays up-to-date by connecting to the QgisApp signals emitted when composers are added and removed.

Funded by Sourcepole QGIS Enterprise.
