### PR TITLE
When searching snap targets in composer view, pick the closest one

### DIFF
--- a/src/core/composer/qgscomposermousehandles.cpp
+++ b/src/core/composer/qgscomposermousehandles.cpp
@@ -1300,7 +1300,7 @@ void QgsComposerMouseHandles::checkNearestItem( double checkCoord, const QMap< d
   }
 
   double currentDiff = abs( checkCoord - currentCoord );
-  if ( currentDiff < mComposition->alignmentSnapTolerance() )
+  if ( currentDiff < mComposition->alignmentSnapTolerance() && currentDiff < smallestDiff )
   {
     itemCoord = currentCoord + itemCoordOffset;
     alignCoord = currentCoord;
@@ -1348,3 +1348,4 @@ bool QgsComposerMouseHandles::nearestItem( const QMap< double, const QgsComposer
     }
   }
 }
+


### PR DESCRIPTION
There are some cases where items moved in the composer view do not snap to the expected guide. For instance, it is impossible to move and align the label "Demo Print Composer" to the left of the label "QGIS Enterprise 13.03" in this example: http://smani.fedorapeople.org/druckvorlage.qpt

This patch ensures the closest snap guide is picked.

Funded by Sourcepole QGIS Enterprise.
