### PR TITLE
Restart timeout timer when data is received in QgsNetworkAccessManager

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -9385,7 +9385,8 @@ void QgisApp::namSslErrors( QNetworkReply *reply, const QList<QSslError> &errors
 
 void QgisApp::namRequestTimedOut( QNetworkReply *reply )
 {
-  messageBar()->pushMessage( tr( "Network request timeout" ), tr( "The request '%1' timed out. Any data received is likely incomplete." ).arg( reply->url().toString() ), QgsMessageBar::WARNING, messageTimeout() );
+  QgsMessageLog::logMessage( tr( "The request '%1' timed out. Any data received is likely incomplete." ).arg( reply->url().toString() ), QString::null, QgsMessageLog::WARNING );
+  messageBar()->pushMessage( tr( "Network request timeout" ), tr( "A network request timed out, any data received is likely incomplete." ), QgsMessageBar::WARNING, messageTimeout() );
 }
 
 void QgisApp::namUpdate()

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -9385,7 +9385,7 @@ void QgisApp::namSslErrors( QNetworkReply *reply, const QList<QSslError> &errors
 
 void QgisApp::namRequestTimedOut( QNetworkReply *reply )
 {
-  QMessageBox::warning( this, tr( "Network request timed out" ), tr( "The following request timed out %1. If any data was received, it is likely incomplete." ).arg( reply->url().toString() ) );
+  messageBar()->pushMessage( tr( "Network request timeout" ), tr( "The request '%1' timed out. Any data received is likely incomplete." ).arg( reply->url().toString() ), QgsMessageBar::WARNING, messageTimeout() );
 }
 
 void QgisApp::namUpdate()

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -9296,6 +9296,8 @@ void QgisApp::namSetup()
   connect( nam, SIGNAL( proxyAuthenticationRequired( const QNetworkProxy &, QAuthenticator * ) ),
            this, SLOT( namProxyAuthenticationRequired( const QNetworkProxy &, QAuthenticator * ) ) );
 
+  connect( nam, SIGNAL( requestTimedOut( QNetworkReply* ) ), this, SLOT( namRequestTimedOut( QNetworkReply* ) ) );
+
 #ifndef QT_NO_OPENSSL
   connect( nam, SIGNAL( sslErrors( QNetworkReply *, const QList<QSslError> & ) ),
            this, SLOT( namSslErrors( QNetworkReply *, const QList<QSslError> & ) ) );
@@ -9380,6 +9382,11 @@ void QgisApp::namSslErrors( QNetworkReply *reply, const QList<QSslError> &errors
   }
 }
 #endif
+
+void QgisApp::namRequestTimedOut( QNetworkReply *reply )
+{
+  QMessageBox::warning( this, tr( "Network request timed out" ), tr( "The following request timed out %1. If any data was received, it is likely incomplete." ).arg( reply->url().toString() ) );
+}
 
 void QgisApp::namUpdate()
 {
@@ -9560,3 +9567,4 @@ LONG WINAPI QgisApp::qgisCrashDump( struct _EXCEPTION_POINTERS *ExceptionInfo )
   return EXCEPTION_EXECUTE_HANDLER;
 }
 #endif
+

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -594,6 +594,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 #ifndef QT_NO_OPENSSL
     void namSslErrors( QNetworkReply *reply, const QList<QSslError> &errors );
 #endif
+    void namRequestTimedOut( QNetworkReply *reply );
 
     //! update default action of toolbutton
     void toolButtonActionTriggered( QAction * );
@@ -1553,3 +1554,4 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 #endif
 
 #endif
+

--- a/src/core/qgsnetworkaccessmanager.cpp
+++ b/src/core/qgsnetworkaccessmanager.cpp
@@ -161,6 +161,8 @@ QNetworkReply *QgsNetworkAccessManager::createRequest( QNetworkAccessManager::Op
   timer->setSingleShot( true );
   timer->start( s.value( "/qgis/networkAndProxy/networkTimeout", "20000" ).toInt() );
 
+  connect( reply, SIGNAL( downloadProgress( qint64, qint64 ) ), timer, SLOT( start() ) );
+
   mActiveRequests.insert( reply, timer );
   return reply;
 }
@@ -194,6 +196,8 @@ void QgsNetworkAccessManager::abortRequest()
 
   if ( reply->isRunning() )
     reply->close();
+
+  emit requestTimedOut( reply );
 }
 
 QString QgsNetworkAccessManager::cacheLoadControlName( QNetworkRequest::CacheLoadControl theControl )
@@ -324,3 +328,4 @@ void QgsNetworkAccessManager::setupDefaultProxyAndCache()
   setProxy( proxy );
 #endif
 }
+

--- a/src/core/qgsnetworkaccessmanager.h
+++ b/src/core/qgsnetworkaccessmanager.h
@@ -87,6 +87,7 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
   signals:
     void requestAboutToBeCreated( QNetworkAccessManager::Operation, const QNetworkRequest &, QIODevice * );
     void requestCreated( QNetworkReply * );
+    void requestTimedOut( QNetworkReply * );
 
   private slots:
     void connectionProgress();
@@ -105,3 +106,4 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
 };
 
 #endif // QGSNETWORKACCESSMANAGER_H
+


### PR DESCRIPTION
When transferring large amounts of data via a slow connection, the transfer can time out even if data is still being transferred. This results in the client ending up with incomplete data.

This patch makes the timer restart as soon as any data is received (hence "timeout" is interpreted as the maximum time which can pass without any transfer activity). It also adds a warning message which is displayed to the user in case a transfer times out.

Funded by Sourcepole QGIS Enterprise.
