### PR TITLE
Populate transparency table when loading qml style for raster layer

### DIFF
--- a/src/app/qgsrasterlayerproperties.cpp
+++ b/src/app/qgsrasterlayerproperties.cpp
@@ -1604,6 +1604,7 @@ void QgsRasterLayerProperties::on_pbnLoadDefaultStyle_clicked()
       setRendererWidget( renderer->type() );
     }
     mRasterLayer->triggerRepaint();
+    populateTransparencyTable( mRasterLayer->renderer() );
   }
   else
   {
@@ -1661,6 +1662,7 @@ void QgsRasterLayerProperties::on_pbnLoadStyle_clicked()
       setRendererWidget( renderer->type() );
     }
     mRasterLayer->triggerRepaint();
+    populateTransparencyTable( mRasterLayer->renderer() );
   }
   else
   {
@@ -1737,4 +1739,5 @@ bool QgsRasterLayerProperties::rasterIsMultiBandColor()
 {
   return mRasterLayer && dynamic_cast<QgsMultiBandColorRenderer*>( mRasterLayer->renderer() ) != 0;
 }
+
 


### PR DESCRIPTION
When loading a raster layer style which contains entries for pixel transparencies, these do not appear in the Layer Properties -> Transparency -> Transparent pixel list.

This patch adds missing calls to `populateTransparencyTable`.

Funded by Sourcepole QGIS Enterprise.
