### PR TITLE
Correctly update symbol UI (units, transparency) when selecting a style

### DIFF
--- a/src/gui/symbology-ng/qgssymbolslistwidget.cpp
+++ b/src/gui/symbology-ng/qgssymbolslistwidget.cpp
@@ -84,16 +84,7 @@ QgsSymbolsListWidget::QgsSymbolsListWidget( QgsSymbolV2* symbol, QgsStyleV2* sty
 
   if ( mSymbol )
   {
-    // output unit
-    mSymbolUnitComboBox->blockSignals( true );
-    mSymbolUnitComboBox->setCurrentIndex( mSymbol->outputUnit() );
-    mSymbolUnitComboBox->blockSignals( false );
-
-    mTransparencySlider->blockSignals( true );
-    double transparency = 1 - symbol->alpha();
-    mTransparencySlider->setValue( transparency * 255 );
-    displayTransparency( symbol->alpha() );
-    mTransparencySlider->blockSignals( false );
+    updateSymbolInfo();
   }
 
   // select correct page in stacked widget
@@ -107,8 +98,6 @@ QgsSymbolsListWidget::QgsSymbolsListWidget( QgsSymbolV2* symbol, QgsStyleV2* sty
   // Live color updates are not undoable to child symbol layers
   btnColor->setAcceptLiveUpdates( false );
   btnColor->setColorDialogOptions( QColorDialog::ShowAlphaChannel );
-
-  updateSymbolInfo();
 }
 
 void QgsSymbolsListWidget::populateGroups( QString parent, QString prepend )
@@ -297,6 +286,16 @@ void QgsSymbolsListWidget::updateSymbolInfo()
     QgsLineSymbolV2* lineSymbol = static_cast<QgsLineSymbolV2*>( mSymbol );
     spinWidth->setValue( lineSymbol->width() );
   }
+
+  mSymbolUnitComboBox->blockSignals( true );
+  mSymbolUnitComboBox->setCurrentIndex( mSymbol->outputUnit() );
+  mSymbolUnitComboBox->blockSignals( false );
+
+  mTransparencySlider->blockSignals( true );
+  double transparency = 1 - mSymbol->alpha();
+  mTransparencySlider->setValue( transparency * 255 );
+  displayTransparency( mSymbol->alpha() );
+  mTransparencySlider->blockSignals( false );
 }
 
 void QgsSymbolsListWidget::setSymbolFromStyle( const QModelIndex & index )
@@ -314,6 +313,8 @@ void QgsSymbolsListWidget::setSymbolFromStyle( const QModelIndex & index )
     QgsSymbolLayerV2* sl = s->takeSymbolLayer( 0 );
     mSymbol->appendSymbolLayer( sl );
   }
+  mSymbol->setAlpha( s->alpha() );
+  mSymbol->setOutputUnit( s->outputUnit() );
   // delete the temporary symbol
   delete s;
 
@@ -352,3 +353,4 @@ void QgsSymbolsListWidget::on_groupsCombo_editTextChanged( const QString &text )
   QStringList symbols = mStyle->findSymbols( QgsStyleV2::SymbolEntity, text );
   populateSymbols( symbols );
 }
+


### PR DESCRIPTION
When selecting a style from the Saved styles list (Layer Properties -> Style), the UI is not correctly updated. For instance, if one saves a style with a certain transparency value, that slider is not set accordingly when selecting that style from the list.

Another separate but related issue is that the `clone()` function of a handful of symbol layers is incomplete, consequently when loading a saved symbol, the loaded symbol state won't always match 100% with the saved symbol state. I'll send a separate pull request for this.

Funded by Sourcepole QGIS Enterprise.
