### PR TITLE
field  expression widget (with expression capability added to QgsFieldModel)

### DIFF
--- a/python/gui/gui.sip
+++ b/python/gui/gui.sip
@@ -29,6 +29,7 @@
 %Include qgsexpressionbuilderwidget.sip
 %Include qgsexpressionhighlighter.sip
 %Include qgsfieldcombobox.sip
+%Include qgsfieldexpressionwidget.sip
 %Include qgsfieldmodel.sip
 %Include qgsfieldvalidator.sip
 %Include qgsfiledropedit.sip

--- a/python/gui/qgsfieldcombobox.sip
+++ b/python/gui/qgsfieldcombobox.sip
@@ -35,7 +35,4 @@ class QgsFieldComboBox : QComboBox
 
     //! setField sets the currently selected field
     void setField( QString fieldName );
-
-  protected slots:
-    void indexChanged( int i );
 };

--- a/python/gui/qgsfieldcombobox.sip
+++ b/python/gui/qgsfieldcombobox.sip
@@ -31,6 +31,9 @@ class QgsFieldComboBox : QComboBox
 
   public slots:
     //! set the layer of which the fields are listed
+    void setLayer( QgsVectorLayer* layer );
+    
+    //! convenience slot to connect QgsMapLayerComboBox layer signal
     void setLayer( QgsMapLayer* layer );
 
     //! setField sets the currently selected field

--- a/python/gui/qgsfieldcombobox.sip
+++ b/python/gui/qgsfieldcombobox.sip
@@ -1,9 +1,8 @@
 /**
  * @brief The QgsFieldComboBox is a combo box which displays the list of fields of a given layer.
- * If allowed, expression may also be added at the bottom of the list of fields.
- * It can be combined with a QgsExpressioButton to set the expression using the dedicated expression builder dialog.
- * It might also be combined with a QgsMapLayerComboBox and the fields will be automatically updated according to the chosen layer.
- * @see QgsExpressioButton, QgsMapLayerComboBox
+ * It might be combined with a QgsMapLayerComboBox to automatically update fields according to a chosen layer.
+ * If expression must be used, QgsFieldExpressionWidget shall be used instead.
+ * @see QgsMapLayerComboBox
  * @note added in 2.3
  */
 class QgsFieldComboBox : QComboBox
@@ -20,37 +19,23 @@ class QgsFieldComboBox : QComboBox
      */
     explicit QgsFieldComboBox( QWidget *parent /TransferThis/ = 0 );
 
-    /**
-     * @brief currentField returns the currently selected field or expression if allowed
-     * @param isExpression determines if the string returned is the name of a field or an expression
-     */
-    QString currentField( bool *isExpression = 0 );
-    
-    //!! setAllowExpression sets if expression can be added the combo box
-    void setAllowExpression( bool allowExpression );
-    //! returns if the widget allows expressions to be added or not
-    bool allowExpression();
-    
+    //! return the currently selected field
+    QString currentField();
+
     //! Returns the currently used layer
     QgsVectorLayer* layer();
 
   signals:
-    /**
-     * @brief setField sets the currently selected field
-     * if expressions are allowed in the widget,
-     * then it will either set it as selected
-     * if it already exists, or it will add it otherwise
-     */
+    //! the signal is emitted when the currently selected field changes
     void fieldChanged( QString fieldName );
 
   public slots:
-    /**
-     * @brief setLayer sets the layer of which the fields are listed
-     */
+    //! set the layer of which the fields are listed
     void setLayer( QgsMapLayer* layer );
-    /**
-     * @brief setField sets the currently selected field
-     */
+
+    //! setField sets the currently selected field
     void setField( QString fieldName );
 
+  protected slots:
+    void indexChanged( int i );
 };

--- a/python/gui/qgsfieldcombobox.sip
+++ b/python/gui/qgsfieldcombobox.sip
@@ -1,5 +1,9 @@
 /**
  * @brief The QgsFieldComboBox is a combo box which displays the list of fields of a given layer.
+ * If allowed, expression may also be added at the bottom of the list of fields.
+ * It can be combined with a QgsExpressioButton to set the expression using the dedicated expression builder dialog.
+ * It might also be combined with a QgsMapLayerComboBox and the fields will be automatically updated according to the chosen layer.
+ * @see QgsExpressioButton, QgsMapLayerComboBox
  * @note added in 2.3
  */
 class QgsFieldComboBox : QComboBox
@@ -17,13 +21,25 @@ class QgsFieldComboBox : QComboBox
     explicit QgsFieldComboBox( QWidget *parent /TransferThis/ = 0 );
 
     /**
-     * @brief currentField returns the currently selected field
+     * @brief currentField returns the currently selected field or expression if allowed
+     * @param isExpression determines if the string returned is the name of a field or an expression
      */
-    QString currentField();
+    QString currentField( bool *isExpression = 0 );
+    
+    //!! setAllowExpression sets if expression can be added the combo box
+    void setAllowExpression( bool allowExpression );
+    //! returns if the widget allows expressions to be added or not
+    bool allowExpression();
+    
+    //! Returns the currently used layer
+    QgsVectorLayer* layer();
 
   signals:
     /**
-     * @brief fieldChanged the signal is emitted when the currently selected field changes
+     * @brief setField sets the currently selected field
+     * if expressions are allowed in the widget,
+     * then it will either set it as selected
+     * if it already exists, or it will add it otherwise
      */
     void fieldChanged( QString fieldName );
 

--- a/python/gui/qgsfieldexpressionwidget.sip
+++ b/python/gui/qgsfieldexpressionwidget.sip
@@ -1,0 +1,44 @@
+
+class QgsFieldExpressionWidget : QWidget
+{
+%TypeHeaderCode
+#include "qgsfieldexpressionwidget.h"
+%End
+
+  public:
+    /**
+     * @brief QgsFieldExpressionWidget creates a widget with a combo box to display the fields and expression and a button to open the expression dialog
+     */
+    explicit QgsFieldExpressionWidget( QWidget *parent /TransferThis/ = 0 );
+
+    //! define the title used in the expression dialog
+    void setExpressionDialogTitle( QString title );
+
+    //! set the geometry calculator used in the expression dialog
+    void setGeomCalculator( const QgsDistanceArea &da );
+
+    //! return a pointer to the combo box in the widget
+    QgsFieldComboBox* fieldComboBox();
+
+    //! return a pointer to the tool button used in the widget
+    QToolButton* toolButton();
+
+    /**
+     * @brief currentField returns the currently selected field or expression if allowed
+     * @param isExpression determines if the string returned is the name of a field or an expression
+     */
+    QString currentField( bool *isExpression = 0 );
+
+    //! Returns the currently used layer
+    QgsVectorLayer* layer();
+
+  public slots:
+    //! set the layer used to display the fields and expression
+    void setLayer( QgsMapLayer* layer );
+
+    //! sets the current field or expression in the widget
+    void setField( QString fieldName );
+
+    //! open the expression dialog to edit the current or add a new expression
+    void editExpression();
+};

--- a/python/gui/qgsfieldexpressionwidget.sip
+++ b/python/gui/qgsfieldexpressionwidget.sip
@@ -36,13 +36,4 @@ class QgsFieldExpressionWidget : QWidget
 
     //! sets the current field or expression in the widget
     void setField( QString fieldName );
-
-  protected slots:
-    //! open the expression dialog to edit the current or add a new expression
-    void editExpression();
-
-    //! when expression is edited by the user in the line edit
-    void expressionEdited( QString expression );
-
-    void indexChanged( int i );
 };

--- a/python/gui/qgsfieldexpressionwidget.sip
+++ b/python/gui/qgsfieldexpressionwidget.sip
@@ -29,9 +29,15 @@ class QgsFieldExpressionWidget : QWidget
   signals:
      //! the signal is emitted when the currently selected field changes
      void fieldChanged( QString fieldName );
+    
+    //! fieldChanged signal with indication of the validity of the expression
+    void fieldChanged( QString fieldName, bool isValid );
 
   public slots:
     //! set the layer used to display the fields and expression
+    void setLayer( QgsVectorLayer* layer );
+    
+    //! convenience slot to connect QgsMapLayerComboBox layer signal
     void setLayer( QgsMapLayer* layer );
 
     //! sets the current field or expression in the widget

--- a/python/gui/qgsfieldexpressionwidget.sip
+++ b/python/gui/qgsfieldexpressionwidget.sip
@@ -17,12 +17,6 @@ class QgsFieldExpressionWidget : QWidget
     //! set the geometry calculator used in the expression dialog
     void setGeomCalculator( const QgsDistanceArea &da );
 
-    //! return a pointer to the combo box in the widget
-    QgsFieldComboBox* fieldComboBox();
-
-    //! return a pointer to the tool button used in the widget
-    QToolButton* toolButton();
-
     /**
      * @brief currentField returns the currently selected field or expression if allowed
      * @param isExpression determines if the string returned is the name of a field or an expression
@@ -32,6 +26,10 @@ class QgsFieldExpressionWidget : QWidget
     //! Returns the currently used layer
     QgsVectorLayer* layer();
 
+  signals:
+     //! the signal is emitted when the currently selected field changes
+     void fieldChanged( QString fieldName );
+
   public slots:
     //! set the layer used to display the fields and expression
     void setLayer( QgsMapLayer* layer );
@@ -39,6 +37,12 @@ class QgsFieldExpressionWidget : QWidget
     //! sets the current field or expression in the widget
     void setField( QString fieldName );
 
+  protected slots:
     //! open the expression dialog to edit the current or add a new expression
     void editExpression();
+
+    //! when expression is edited by the user in the line edit
+    void expressionEdited( QString expression );
+
+    void indexChanged( int i );
 };

--- a/python/gui/qgsfieldmodel.sip
+++ b/python/gui/qgsfieldmodel.sip
@@ -13,9 +13,12 @@ class QgsFieldModel : QAbstractItemModel
 
   public:
     enum FieldRoles {
-      FieldNameRole = 33, /* Qt::UserRole + 1, SIP does not accept any arithmetic" */
-      FieldIndexRole = 34,
-      ExpressionRole = 35
+      /* SIP does not accept any arithmetic" */
+      FieldNameRole = 33,  /* return field name if index corresponds to a field */
+      FieldIndexRole = 34, /* return field index if index corresponds to a field */
+      ExpressionRole = 35, /* return field name or expression */
+      IsExpressionRole = 36, /* return if index corresponds to an expression */
+      ExpressionValidityRole = 37 /* return if expression is valid or not */
     };
 
     /**
@@ -23,14 +26,10 @@ class QgsFieldModel : QAbstractItemModel
      */
     explicit QgsFieldModel( QObject *parent /TransferThis/ = 0 );
 
-    /**
-     * @brief indexFromName returns the index corresponding to a given fieldName
-     */
+    //! return the index corresponding to a given fieldName
     QModelIndex indexFromName( QString fieldName );
     
-    /**
-     * @brief setAllowExpression determines if expressions are allowed to be added to the model
-     */
+    //! returns the currently used layer
     void setAllowExpression( bool allowExpression );
     bool allowExpression();
 
@@ -39,19 +38,20 @@ class QgsFieldModel : QAbstractItemModel
      * @return the model index of the newly added expression
      */
     QModelIndex setExpression( QString expression );
+    
+    //! remove expressions from the model
+    void removeExpression();
 
-    /**
-     * @brief layer returns the currently used layer
-     */
+    //! returns the currently used layer
     QgsMapLayer* layer();
 
   public slots:
-    /**
-     * @brief setLayer sets the layer of whch fields are displayed
-     */
+    //! set the layer of whch fields are displayed
     void setLayer( QgsMapLayer *layer );
     
-
+  protected slots:
+    virtual void updateModel();
+    
     // QAbstractItemModel interface
   public:
     QModelIndex index( int row, int column, const QModelIndex &parent = QModelIndex() ) const;

--- a/python/gui/qgsfieldmodel.sip
+++ b/python/gui/qgsfieldmodel.sip
@@ -1,10 +1,10 @@
 
 /**
  * @brief The QgsFieldModel class is a model to display the list of fields of a layer in widgets.
+ * If allowed, expressions might be added to the end of the model.
  * It can be associated with a QgsMapLayerModel to dynamically display a layer and its fields.
  * @note added in 2.3
  */
-
 class QgsFieldModel : QAbstractItemModel
 {
 %TypeHeaderCode
@@ -12,8 +12,11 @@ class QgsFieldModel : QAbstractItemModel
 %End
 
   public:
-    static const int FieldNameRole;
-    static const int FieldIndexRole;
+    enum FieldRoles {
+      FieldNameRole = 33, /* Qt::UserRole + 1, SIP does not accept any arithmetic" */
+      FieldIndexRole = 34,
+      ExpressionRole = 35
+    };
 
     /**
      * @brief QgsFieldModel creates a model to display the fields of a given layer
@@ -24,12 +27,30 @@ class QgsFieldModel : QAbstractItemModel
      * @brief indexFromName returns the index corresponding to a given fieldName
      */
     QModelIndex indexFromName( QString fieldName );
+    
+    /**
+     * @brief setAllowExpression determines if expressions are allowed to be added to the model
+     */
+    void setAllowExpression( bool allowExpression );
+    bool allowExpression();
+
+    /**
+     * @brief setExpression sets a single expression to be added after the fields at the end of the model
+     * @return the model index of the newly added expression
+     */
+    QModelIndex setExpression( QString expression );
+
+    /**
+     * @brief layer returns the currently used layer
+     */
+    QgsMapLayer* layer();
 
   public slots:
     /**
      * @brief setLayer sets the layer of whch fields are displayed
      */
     void setLayer( QgsMapLayer *layer );
+    
 
     // QAbstractItemModel interface
   public:

--- a/python/gui/qgsfieldmodel.sip
+++ b/python/gui/qgsfieldmodel.sip
@@ -47,7 +47,7 @@ class QgsFieldModel : QAbstractItemModel
 
   public slots:
     //! set the layer of whch fields are displayed
-    void setLayer( QgsMapLayer *layer );
+    void setLayer( QgsVectorLayer *layer );
     
   protected slots:
     virtual void updateModel();
@@ -56,7 +56,7 @@ class QgsFieldModel : QAbstractItemModel
   public:
     QModelIndex index( int row, int column, const QModelIndex &parent = QModelIndex() ) const;
     QModelIndex parent( const QModelIndex &child ) const;
-    int rowCount( const QModelIndex &parent ) const;
+    int rowCount( const QModelIndex &parent = QModelIndex() ) const;
     int columnCount( const QModelIndex &parent ) const;
     QVariant data( const QModelIndex &index, int role ) const;
 

--- a/python/gui/qgsfieldmodel.sip
+++ b/python/gui/qgsfieldmodel.sip
@@ -43,7 +43,7 @@ class QgsFieldModel : QAbstractItemModel
     void removeExpression();
 
     //! returns the currently used layer
-    QgsMapLayer* layer();
+    QgsVectorLayer* layer();
 
   public slots:
     //! set the layer of whch fields are displayed

--- a/python/gui/symbology-ng/qgscategorizedsymbolrendererv2widget.sip
+++ b/python/gui/symbology-ng/qgscategorizedsymbolrendererv2widget.sip
@@ -14,13 +14,12 @@ class QgsCategorizedSymbolRendererV2Widget : QgsRendererV2Widget
 
   public slots:
     void changeCategorizedSymbol();
-    void categoryColumnChanged();
+    void categoryColumnChanged( QString field );
     void categoriesDoubleClicked( const QModelIndex & idx );
     void addCategory();
     void addCategories();
     void deleteCategories();
     void deleteAllCategories();
-    void setExpression();
 
     void rotationFieldChanged( QString fldName );
     void sizeScaleFieldChanged( QString fldName );
@@ -38,9 +37,6 @@ class QgsCategorizedSymbolRendererV2Widget : QgsRendererV2Widget
 
     // Called by virtual refreshSymbolView()
     void populateCategories();
-
-    //! populate column combo
-    void populateColumns();
 
     //! return row index for the currently selected category (-1 if on no selection)
     int currentCategoryRow();

--- a/python/gui/symbology-ng/qgsgraduatedsymbolrendererv2widget.sip
+++ b/python/gui/symbology-ng/qgsgraduatedsymbolrendererv2widget.sip
@@ -13,8 +13,7 @@ class QgsGraduatedSymbolRendererV2Widget : QgsRendererV2Widget
 
   public slots:
     void changeGraduatedSymbol();
-    void graduatedColumnChanged();
-    void setExpression();
+    void graduatedColumnChanged( QString field );
     void classifyGraduated();
     void reapplyColorRamp();
     void rangesDoubleClicked( const QModelIndex & idx );
@@ -44,9 +43,6 @@ class QgsGraduatedSymbolRendererV2Widget : QgsRendererV2Widget
     //! return a list of indexes for the classes under selection
     QList<int> selectedClasses();
     QgsRangeList selectedRanges();
-
-    //! populate column combos in categorized and graduated page
-    void populateColumns();
 
     void changeRangeSymbol( int rangeIdx );
     void changeRange( int rangeIdx );

--- a/src/app/qgslabelinggui.h
+++ b/src/app/qgslabelinggui.h
@@ -45,7 +45,6 @@ class APP_EXPORT QgsLabelingGui : public QWidget, private Ui::QgsLabelingGuiBase
     void apply();
     void changeTextColor( const QColor &color );
     void showEngineConfigDialog();
-    void showExpressionDialog();
     void changeBufferColor( const QColor &color );
 
     void updateUi();

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -89,6 +89,7 @@ qgsexpressionselectiondialog.cpp
 qgsextentgroupbox.cpp
 qgsfeatureselectiondlg.cpp
 qgsfieldcombobox.cpp
+qgsfieldexpressionwidget.cpp
 qgsfieldmodel.cpp
 qgsfieldvalidator.cpp
 qgsfiledropedit.cpp
@@ -233,6 +234,7 @@ qgsexpressionselectiondialog.h
 qgsextentgroupbox.h
 qgsfeatureselectiondlg.h
 qgsfieldcombobox.h
+qgsfieldexpressionwidget.h
 qgsfieldmodel.h
 qgsfieldvalidator.h
 qgsfilterlineedit.h
@@ -303,6 +305,7 @@ qgsexpressionhighlighter.h
 qgsexpressionselectiondialog.h
 qgsfeatureselectiondlg.h
 qgsfieldcombobox.h
+qgsfieldexpressionwidget.h
 qgsfieldmodel.h
 qgsfieldvalidator.h
 qgsfiledropedit.h

--- a/src/gui/qgsfieldcombobox.cpp
+++ b/src/gui/qgsfieldcombobox.cpp
@@ -33,12 +33,7 @@ void QgsFieldComboBox::setLayer( QgsMapLayer *layer )
 
 QgsVectorLayer *QgsFieldComboBox::layer()
 {
-  QgsMapLayer* layer = mFieldModel->layer();
-  QgsVectorLayer* vl = dynamic_cast<QgsVectorLayer*>( layer );
-  if ( vl )
-    return vl;
-  else
-    return 0;
+  return mFieldModel->layer();
 }
 
 void QgsFieldComboBox::setField( QString fieldName )

--- a/src/gui/qgsfieldcombobox.cpp
+++ b/src/gui/qgsfieldcombobox.cpp
@@ -47,25 +47,15 @@ void QgsFieldComboBox::setField( QString fieldName )
   if ( idx.isValid() )
   {
     setCurrentIndex( idx.row() );
-    return;
   }
-
-  if ( mAllowExpression )
+  else
   {
-    mFieldModel->setExpression( fieldName );
-    setCurrentIndex( findText( fieldName ) );
-    return;
+    setCurrentIndex( -1 );
   }
-  setCurrentIndex( -1 );
 }
 
-QString QgsFieldComboBox::currentField( bool *isExpression )
+QString QgsFieldComboBox::currentField()
 {
-  if ( isExpression )
-  {
-    *isExpression = false;
-  }
-
   int i = currentIndex();
 
   const QModelIndex index = mFieldModel->index( i, 0 );
@@ -74,31 +64,8 @@ QString QgsFieldComboBox::currentField( bool *isExpression )
     return "";
   }
 
-  QString fieldName = mFieldModel->data( index, QgsFieldModel::FieldNameRole ).toString();
-  if ( !fieldName.isEmpty() )
-  {
-    return fieldName;
-  }
-
-  if ( mAllowExpression )
-  {
-    QString expression = mFieldModel->data( index, QgsFieldModel::ExpressionRole ).toString();
-    if ( !expression.isEmpty() )
-    {
-      if ( isExpression )
-      {
-        *isExpression = true;
-      }
-      return expression;
-    }
-  }
-
-  return "";
-}
-
-void QgsFieldComboBox::setAllowExpression( bool allowExpression )
-{
-  mFieldModel->setAllowExpression( allowExpression );
+  QString name = mFieldModel->data( index, QgsFieldModel::FieldNameRole ).toString();
+  return name;
 }
 
 void QgsFieldComboBox::indexChanged( int i )

--- a/src/gui/qgsfieldcombobox.cpp
+++ b/src/gui/qgsfieldcombobox.cpp
@@ -28,6 +28,15 @@ QgsFieldComboBox::QgsFieldComboBox( QWidget *parent ) :
 
 void QgsFieldComboBox::setLayer( QgsMapLayer *layer )
 {
+  QgsVectorLayer* vl = dynamic_cast<QgsVectorLayer*>( layer );
+  if ( vl )
+  {
+    setLayer( vl );
+  }
+}
+
+void QgsFieldComboBox::setLayer( QgsVectorLayer *layer )
+{
   mFieldModel->setLayer( layer );
 }
 

--- a/src/gui/qgsfieldcombobox.h
+++ b/src/gui/qgsfieldcombobox.h
@@ -24,10 +24,9 @@ class QgsVectorLayer;
 
 /**
  * @brief The QgsFieldComboBox is a combo box which displays the list of fields of a given layer.
- * If allowed, expression may also be added at the bottom of the list of fields.
- * It can be combined with a QgsExpressioButton to set the expression using the dedicated expression builder dialog.
- * It might also be combined with a QgsMapLayerComboBox and the fields will be automatically updated according to the chosen layer.
- * @see QgsExpressioButton, QgsMapLayerComboBox
+ * It might be combined with a QgsMapLayerComboBox to automatically update fields according to a chosen layer.
+ * If expression must be used, QgsFieldExpressionWidget shall be used instead.
+ * @see QgsMapLayerComboBox
  * @note added in 2.3
  */
 class GUI_EXPORT QgsFieldComboBox : public QComboBox
@@ -40,38 +39,21 @@ class GUI_EXPORT QgsFieldComboBox : public QComboBox
      */
     explicit QgsFieldComboBox( QWidget *parent = 0 );
 
-    /**
-     * @brief currentField returns the currently selected field or expression if allowed
-     * @param isExpression determines if the string returned is the name of a field or an expression
-     */
-    QString currentField( bool *isExpression = 0 );
-
-    //!! setAllowExpression sets if expression can be added the combo box
-    void setAllowExpression( bool allowExpression );
-    //! returns if the widget allows expressions to be added or not
-    bool allowExpression() { return mAllowExpression; }
+    //! return the currently selected field
+    QString currentField();
 
     //! Returns the currently used layer
     QgsVectorLayer* layer();
 
   signals:
-    /**
-     * @brief fieldChanged the signal is emitted when the currently selected field changes
-     */
+    //! the signal is emitted when the currently selected field changes
     void fieldChanged( QString fieldName );
 
   public slots:
-    /**
-     * @brief setLayer sets the layer of which the fields are listed
-     */
+    //! set the layer of which the fields are listed
     void setLayer( QgsMapLayer* layer );
 
-    /**
-     * @brief setField sets the currently selected field
-     * if expressions are allowed in the widget,
-     * then it will either set it as selected
-     * if it already exists, or it will add it otherwise
-     */
+    //! setField sets the currently selected field
     void setField( QString fieldName );
 
   protected slots:
@@ -79,8 +61,6 @@ class GUI_EXPORT QgsFieldComboBox : public QComboBox
 
   private:
     QgsFieldModel* mFieldModel;
-    bool mAllowExpression;
-
 };
 
 #endif // QGSFIELDCOMBOBOX_H

--- a/src/gui/qgsfieldcombobox.h
+++ b/src/gui/qgsfieldcombobox.h
@@ -20,9 +20,14 @@
 
 class QgsFieldModel;
 class QgsMapLayer;
+class QgsVectorLayer;
 
 /**
  * @brief The QgsFieldComboBox is a combo box which displays the list of fields of a given layer.
+ * If allowed, expression may also be added at the bottom of the list of fields.
+ * It can be combined with a QgsExpressioButton to set the expression using the dedicated expression builder dialog.
+ * It might also be combined with a QgsMapLayerComboBox and the fields will be automatically updated according to the chosen layer.
+ * @see QgsExpressioButton, QgsMapLayerComboBox
  * @note added in 2.3
  */
 class GUI_EXPORT QgsFieldComboBox : public QComboBox
@@ -36,9 +41,18 @@ class GUI_EXPORT QgsFieldComboBox : public QComboBox
     explicit QgsFieldComboBox( QWidget *parent = 0 );
 
     /**
-     * @brief currentField returns the currently selected field
+     * @brief currentField returns the currently selected field or expression if allowed
+     * @param isExpression determines if the string returned is the name of a field or an expression
      */
-    QString currentField();
+    QString currentField( bool *isExpression = 0 );
+
+    //!! setAllowExpression sets if expression can be added the combo box
+    void setAllowExpression( bool allowExpression );
+    //! returns if the widget allows expressions to be added or not
+    bool allowExpression() { return mAllowExpression; }
+
+    //! Returns the currently used layer
+    QgsVectorLayer* layer();
 
   signals:
     /**
@@ -51,8 +65,12 @@ class GUI_EXPORT QgsFieldComboBox : public QComboBox
      * @brief setLayer sets the layer of which the fields are listed
      */
     void setLayer( QgsMapLayer* layer );
+
     /**
      * @brief setField sets the currently selected field
+     * if expressions are allowed in the widget,
+     * then it will either set it as selected
+     * if it already exists, or it will add it otherwise
      */
     void setField( QString fieldName );
 
@@ -61,6 +79,7 @@ class GUI_EXPORT QgsFieldComboBox : public QComboBox
 
   private:
     QgsFieldModel* mFieldModel;
+    bool mAllowExpression;
 
 };
 

--- a/src/gui/qgsfieldcombobox.h
+++ b/src/gui/qgsfieldcombobox.h
@@ -51,6 +51,9 @@ class GUI_EXPORT QgsFieldComboBox : public QComboBox
 
   public slots:
     //! set the layer of which the fields are listed
+    void setLayer( QgsVectorLayer* layer );
+
+    //! convenience slot to connect QgsMapLayerComboBox layer signal
     void setLayer( QgsMapLayer* layer );
 
     //! setField sets the currently selected field

--- a/src/gui/qgsfieldexpressionwidget.cpp
+++ b/src/gui/qgsfieldexpressionwidget.cpp
@@ -98,37 +98,16 @@ void QgsFieldExpressionWidget::setLayer( QgsVectorLayer *layer )
 
 void QgsFieldExpressionWidget::setField( QString fieldName )
 {
+  if ( fieldName.isEmpty() )
+    return;
+
   QModelIndex idx = mFieldModel->indexFromName( fieldName );
-  bool isExpression ;
-  if ( idx.isValid() )
-  {
-    isExpression = mFieldModel->data( idx, QgsFieldModel::IsExpressionRole ).toBool();
-  }
-  else
+  if ( !idx.isValid() )
   {
     // new expression
     idx = mFieldModel->setExpression( fieldName );
-    isExpression = true;
   }
   mCombo->setCurrentIndex( idx.row() );
-
-  QFont font;
-  font.setItalic( isExpression );
-  mCombo->lineEdit()->setFont( font );
-
-  QPalette palette;
-  palette.setColor( QPalette::Text, Qt::black );
-  if ( isExpression )
-  {
-    bool isValid = mFieldModel->data( idx, QgsFieldModel::ExpressionValidityRole ).toBool();
-    if ( !isValid )
-    {
-      palette.setColor( QPalette::Text, Qt::red );
-    }
-  }
-  mCombo->lineEdit()->setPalette( palette );
-
-  emit fieldChanged( currentField() );
 }
 
 void QgsFieldExpressionWidget::editExpression()
@@ -162,6 +141,28 @@ void QgsFieldExpressionWidget::expressionEdited( QString expression )
 void QgsFieldExpressionWidget::indexChanged( int i )
 {
   Q_UNUSED( i );
-  QString name = currentField();
-  emit fieldChanged( name );
+  bool isExpression;
+  QString fieldName = currentField( &isExpression );
+
+  QFont font = mCombo->lineEdit()->font();
+  font.setItalic( isExpression );
+  mCombo->lineEdit()->setFont( font );
+
+  QPalette palette;
+  palette.setColor( QPalette::Text, Qt::black );
+  if ( isExpression )
+  {
+    QModelIndex idx = mFieldModel->indexFromName( fieldName );
+    if ( idx.isValid() )
+    {
+      bool isValid = mFieldModel->data( idx, QgsFieldModel::ExpressionValidityRole ).toBool();
+      if ( !isValid )
+      {
+        palette.setColor( QPalette::Text, Qt::red );
+      }
+    }
+  }
+  mCombo->lineEdit()->setPalette( palette );
+
+  emit fieldChanged( fieldName );
 }

--- a/src/gui/qgsfieldexpressionwidget.cpp
+++ b/src/gui/qgsfieldexpressionwidget.cpp
@@ -1,0 +1,104 @@
+/***************************************************************************
+   qgsfieldexpressionwidget.cpp
+    --------------------------------------
+   Date                 : 01.04.2014
+   Copyright            : (C) 2014 Denis Rouzaud
+   Email                : denis.rouzaud@gmail.com
+***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************/
+
+#include <QHBoxLayout>
+
+#include "qgsapplication.h"
+#include "qgsfieldexpressionwidget.h"
+#include "qgsexpressionbuilderdialog.h"
+#include "qgsfieldcombobox.h"
+#include "qgsdistancearea.h"
+
+QgsFieldExpressionWidget::QgsFieldExpressionWidget( QWidget *parent )
+    : QWidget( parent )
+    , mExpressionDialogTitle( tr( "Expression dialog" ) )
+    , mDa( 0 )
+{
+  QHBoxLayout* layout = new QHBoxLayout( this );
+  layout->setContentsMargins( 0, 0, 0, 0 );
+  mCombo = new QgsFieldComboBox( this );
+  mCombo->setAllowExpression( true );
+  mCombo->setSizePolicy( QSizePolicy::MinimumExpanding, QSizePolicy::Minimum );
+  layout->addWidget( mCombo );
+  mButton = new QToolButton( this );
+  mButton->setSizePolicy( QSizePolicy::Minimum, QSizePolicy::MinimumExpanding );
+  mButton->setIcon( QgsApplication::getThemeIcon( "/mIconExpressionEditorOpen.svg" ) );
+  layout->addWidget( mButton );
+
+  connect( mButton, SIGNAL( clicked() ), this, SLOT( editExpression() ) );
+}
+
+void QgsFieldExpressionWidget::setExpressionDialogTitle( QString title )
+{
+  mExpressionDialogTitle = title;
+}
+
+void QgsFieldExpressionWidget::setGeomCalculator( const QgsDistanceArea &da )
+{
+  mDa = QSharedPointer<const QgsDistanceArea>( new QgsDistanceArea( da ) );
+}
+
+QgsFieldComboBox *QgsFieldExpressionWidget::fieldComboBox()
+{
+  return mCombo;
+}
+
+QToolButton *QgsFieldExpressionWidget::toolButton()
+{
+  return mButton;
+}
+
+QString QgsFieldExpressionWidget::currentField( bool *isExpression )
+{
+  return mCombo->currentField( isExpression );
+}
+
+QgsVectorLayer *QgsFieldExpressionWidget::layer()
+{
+  return mCombo->layer();
+}
+
+void QgsFieldExpressionWidget::setLayer( QgsMapLayer *layer )
+{
+  mCombo->setLayer( layer );
+}
+
+void QgsFieldExpressionWidget::setField( QString fieldName )
+{
+  mCombo->setField( fieldName );
+}
+
+void QgsFieldExpressionWidget::editExpression()
+{
+  QString currentExpression = mCombo->currentField();
+  QgsVectorLayer* layer = mCombo->layer();
+
+  if ( !layer )
+    return;
+
+  QgsExpressionBuilderDialog dlg( layer, currentExpression );
+  if ( !mDa.isNull() )
+  {
+    dlg.setGeomCalculator( *mDa );
+  }
+  dlg.setWindowTitle( mExpressionDialogTitle );
+
+  if ( dlg.exec() )
+  {
+    QString newExpression = dlg.expressionText();
+    mCombo->setField( newExpression );
+  }
+
+}

--- a/src/gui/qgsfieldexpressionwidget.cpp
+++ b/src/gui/qgsfieldexpressionwidget.cpp
@@ -147,6 +147,7 @@ void QgsFieldExpressionWidget::indexChanged( int i )
   Q_UNUSED( i );
   bool isExpression;
   QString fieldName = currentField( &isExpression );
+  bool isValid = true;
 
   QFont font = mCombo->lineEdit()->font();
   font.setItalic( isExpression );
@@ -159,7 +160,7 @@ void QgsFieldExpressionWidget::indexChanged( int i )
     QModelIndex idx = mFieldModel->indexFromName( fieldName );
     if ( idx.isValid() )
     {
-      bool isValid = mFieldModel->data( idx, QgsFieldModel::ExpressionValidityRole ).toBool();
+      isValid = mFieldModel->data( idx, QgsFieldModel::ExpressionValidityRole ).toBool();
       if ( !isValid )
       {
         palette.setColor( QPalette::Text, Qt::red );
@@ -169,4 +170,5 @@ void QgsFieldExpressionWidget::indexChanged( int i )
   mCombo->lineEdit()->setPalette( palette );
 
   emit fieldChanged( fieldName );
+  emit fieldChanged( fieldName, isValid );
 }

--- a/src/gui/qgsfieldexpressionwidget.cpp
+++ b/src/gui/qgsfieldexpressionwidget.cpp
@@ -83,12 +83,7 @@ QString QgsFieldExpressionWidget::currentField( bool *isExpression )
 
 QgsVectorLayer *QgsFieldExpressionWidget::layer()
 {
-  QgsMapLayer* layer = mFieldModel->layer();
-  QgsVectorLayer* vl = dynamic_cast<QgsVectorLayer*>( layer );
-  if ( vl )
-    return vl;
-  else
-    return 0;
+  return mFieldModel->layer();
 }
 
 void QgsFieldExpressionWidget::setLayer( QgsVectorLayer *layer )

--- a/src/gui/qgsfieldexpressionwidget.cpp
+++ b/src/gui/qgsfieldexpressionwidget.cpp
@@ -86,6 +86,15 @@ QgsVectorLayer *QgsFieldExpressionWidget::layer()
   return mFieldModel->layer();
 }
 
+void QgsFieldExpressionWidget::setLayer( QgsMapLayer *layer )
+{
+  QgsVectorLayer* vl = dynamic_cast<QgsVectorLayer*>( layer );
+  if ( vl )
+  {
+    setLayer( vl );
+  }
+}
+
 void QgsFieldExpressionWidget::setLayer( QgsVectorLayer *layer )
 {
   mFieldModel->setLayer( layer );

--- a/src/gui/qgsfieldexpressionwidget.h
+++ b/src/gui/qgsfieldexpressionwidget.h
@@ -61,6 +61,9 @@ class GUI_EXPORT QgsFieldExpressionWidget : public QWidget
     //! set the layer used to display the fields and expression
     void setLayer( QgsVectorLayer* layer );
 
+    //! convenience slot to connect QgsMapLayerComboBox layer signal
+    void setLayer( QgsMapLayer* layer );
+
     //! sets the current field or expression in the widget
     void setField( QString fieldName );
 

--- a/src/gui/qgsfieldexpressionwidget.h
+++ b/src/gui/qgsfieldexpressionwidget.h
@@ -1,0 +1,78 @@
+/***************************************************************************
+   qgsfieldexpressionwidget.h
+    --------------------------------------
+   Date                 : 01.04.2014
+   Copyright            : (C) 2014 Denis Rouzaud
+   Email                : denis.rouzaud@gmail.com
+***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************/
+
+#ifndef QGSFIELDEXPRESSIONWIDGET_H
+#define QGSFIELDEXPRESSIONWIDGET_H
+
+#include <QSharedPointer>
+#include <QWidget>
+#include <QToolButton>
+
+#include "qgsdistancearea.h"
+
+class QgsFieldComboBox;
+class QgsMapLayer;
+class QgsVectorLayer;
+
+
+class GUI_EXPORT QgsFieldExpressionWidget : public QWidget
+{
+    Q_OBJECT
+  public:
+    /**
+     * @brief QgsFieldExpressionWidget creates a widget with a combo box to display the fields and expression and a button to open the expression dialog
+     */
+    explicit QgsFieldExpressionWidget( QWidget *parent = 0 );
+
+    //! define the title used in the expression dialog
+    void setExpressionDialogTitle( QString title );
+
+    //! set the geometry calculator used in the expression dialog
+    void setGeomCalculator( const QgsDistanceArea &da );
+
+    //! return a pointer to the combo box in the widget
+    QgsFieldComboBox* fieldComboBox();
+
+    //! return a pointer to the tool button used in the widget
+    QToolButton* toolButton();
+
+    /**
+     * @brief currentField returns the currently selected field or expression if allowed
+     * @param isExpression determines if the string returned is the name of a field or an expression
+     */
+    QString currentField( bool *isExpression = 0 );
+
+    //! Returns the currently used layer
+    QgsVectorLayer* layer();
+
+  public slots:
+    //! set the layer used to display the fields and expression
+    void setLayer( QgsMapLayer* layer );
+
+    //! sets the current field or expression in the widget
+    void setField( QString fieldName );
+
+    //! open the expression dialog to edit the current or add a new expression
+    void editExpression();
+
+  private:
+    QgsFieldComboBox* mCombo;
+    QToolButton* mButton;
+    QString mExpressionDialogTitle;
+    QSharedPointer<const QgsDistanceArea> mDa;
+
+};
+
+#endif // QGSFIELDEXPRESSIONWIDGET_H

--- a/src/gui/qgsfieldexpressionwidget.h
+++ b/src/gui/qgsfieldexpressionwidget.h
@@ -57,6 +57,9 @@ class GUI_EXPORT QgsFieldExpressionWidget : public QWidget
     //! the signal is emitted when the currently selected field changes
     void fieldChanged( QString fieldName );
 
+    //! fieldChanged signal with indication of the validity of the expression
+    void fieldChanged( QString fieldName, bool isValid );
+
   public slots:
     //! set the layer used to display the fields and expression
     void setLayer( QgsVectorLayer* layer );

--- a/src/gui/qgsfieldexpressionwidget.h
+++ b/src/gui/qgsfieldexpressionwidget.h
@@ -19,12 +19,14 @@
 #include <QSharedPointer>
 #include <QWidget>
 #include <QToolButton>
+#include <QComboBox>
+#include <QColor>
 
 #include "qgsdistancearea.h"
 
-class QgsFieldComboBox;
 class QgsMapLayer;
 class QgsVectorLayer;
+class QgsFieldModel;
 
 
 class GUI_EXPORT QgsFieldExpressionWidget : public QWidget
@@ -42,12 +44,6 @@ class GUI_EXPORT QgsFieldExpressionWidget : public QWidget
     //! set the geometry calculator used in the expression dialog
     void setGeomCalculator( const QgsDistanceArea &da );
 
-    //! return a pointer to the combo box in the widget
-    QgsFieldComboBox* fieldComboBox();
-
-    //! return a pointer to the tool button used in the widget
-    QToolButton* toolButton();
-
     /**
      * @brief currentField returns the currently selected field or expression if allowed
      * @param isExpression determines if the string returned is the name of a field or an expression
@@ -57,22 +53,34 @@ class GUI_EXPORT QgsFieldExpressionWidget : public QWidget
     //! Returns the currently used layer
     QgsVectorLayer* layer();
 
+  signals:
+    //! the signal is emitted when the currently selected field changes
+    void fieldChanged( QString fieldName );
+
   public slots:
     //! set the layer used to display the fields and expression
-    void setLayer( QgsMapLayer* layer );
+    void setLayer( QgsVectorLayer* layer );
 
     //! sets the current field or expression in the widget
     void setField( QString fieldName );
 
+  protected slots:
     //! open the expression dialog to edit the current or add a new expression
     void editExpression();
 
+    //! when expression is edited by the user in the line edit
+    void expressionEdited( QString expression );
+
+    void indexChanged( int i );
+
   private:
-    QgsFieldComboBox* mCombo;
+    QComboBox* mCombo;
     QToolButton* mButton;
+    QgsFieldModel* mFieldModel;
     QString mExpressionDialogTitle;
     QSharedPointer<const QgsDistanceArea> mDa;
 
+    QString color2rgbaStr( QColor color );
 };
 
 #endif // QGSFIELDEXPRESSIONWIDGET_H

--- a/src/gui/qgsfieldmodel.cpp
+++ b/src/gui/qgsfieldmodel.cpp
@@ -49,7 +49,7 @@ QModelIndex QgsFieldModel::indexFromName( QString fieldName )
   return QModelIndex();
 }
 
-void QgsFieldModel::setLayer( QgsMapLayer *layer )
+void QgsFieldModel::setLayer( QgsVectorLayer *layer )
 {
   if ( mLayer )
   {
@@ -63,15 +63,8 @@ void QgsFieldModel::setLayer( QgsMapLayer *layer )
     updateModel();
     return;
   }
-  QgsVectorLayer* vl = dynamic_cast<QgsVectorLayer*>( layer );
-  if ( !vl )
-  {
-    mLayer = 0;
-    updateModel();
-    return;
-  }
 
-  mLayer = vl;
+  mLayer = layer;
   connect( mLayer, SIGNAL( updatedFields() ), this, SLOT( updateModel() ) );
   connect( mLayer, SIGNAL( layerDeleted() ), this, SLOT( layerDeleted() ) );
   updateModel();

--- a/src/gui/qgsfieldmodel.cpp
+++ b/src/gui/qgsfieldmodel.cpp
@@ -13,6 +13,8 @@
 *                                                                         *
 ***************************************************************************/
 
+#include <QFont>
+
 #include "qgsfieldmodel.h"
 #include "qgsmaplayermodel.h"
 #include "qgsmaplayerproxymodel.h"
@@ -51,7 +53,7 @@ void QgsFieldModel::setLayer( QgsMapLayer *layer )
 {
   if ( mLayer )
   {
-    disconnect( mLayer, SIGNAL( updatedFields() ), this, SLOT( updateFields() ) );
+    disconnect( mLayer, SIGNAL( updatedFields() ), this, SLOT( updateModel() ) );
     disconnect( mLayer, SIGNAL( layerDeleted() ), this, SLOT( layerDeleted() ) );
   }
 
@@ -70,7 +72,7 @@ void QgsFieldModel::setLayer( QgsMapLayer *layer )
   }
 
   mLayer = vl;
-  connect( mLayer, SIGNAL( updatedFields() ), this, SLOT( updateFields() ) );
+  connect( mLayer, SIGNAL( updatedFields() ), this, SLOT( updateModel() ) );
   connect( mLayer, SIGNAL( layerDeleted() ), this, SLOT( layerDeleted() ) );
   updateModel();
 }
@@ -241,7 +243,7 @@ QVariant QgsFieldModel::data( const QModelIndex &index, int role ) const
       return alias;
     }
 
-    case Qt::BackgroundRole:
+    case Qt::ForegroundRole:
     {
       if ( exprIdx >= 0 )
       {
@@ -253,7 +255,7 @@ QVariant QgsFieldModel::data( const QModelIndex &index, int role ) const
           exp.evaluate( &mFeature, mLayer->pendingFields() );
           if ( exp.hasEvalError() )
           {
-            return QBrush( QColor( 240, 60, 60, 180 ) );
+            return QBrush( QColor( Qt::red ) );
           }
         }
       }
@@ -265,7 +267,7 @@ QVariant QgsFieldModel::data( const QModelIndex &index, int role ) const
       if ( exprIdx >= 0 )
       {
         // if the line is an expression, set it as italic
-        QFont font;
+        QFont font = QFont();
         font.setItalic( true );
         return font;
       }

--- a/src/gui/qgsfieldmodel.h
+++ b/src/gui/qgsfieldmodel.h
@@ -22,6 +22,8 @@
 
 #include "qgsvectorlayer.h"
 
+class QgsFeature;
+
 /**
  * @brief The QgsFieldModel class is a model to display the list of fields of a layer in widgets.
  * If allowed, expressions might be added to the end of the model.
@@ -34,9 +36,11 @@ class GUI_EXPORT QgsFieldModel : public QAbstractItemModel
   public:
     enum  FieldRoles
     {
-      FieldNameRole = Qt::UserRole + 1,
-      FieldIndexRole = Qt::UserRole + 2,
-      ExpressionRole = Qt::UserRole + 3
+      FieldNameRole = Qt::UserRole + 1,  /* return field name if index corresponds to a field */
+      FieldIndexRole = Qt::UserRole + 2, /* return field index if index corresponds to a field */
+      ExpressionRole = Qt::UserRole + 3, /* return field name or expression */
+      IsExpressionRole = Qt::UserRole + 4, /* return if index corresponds to an expression */
+      ExpressionValidityRole = Qt::UserRole + 5 /* return if expression is valid or not */
     };
 
     /**
@@ -44,14 +48,10 @@ class GUI_EXPORT QgsFieldModel : public QAbstractItemModel
      */
     explicit QgsFieldModel( QObject *parent = 0 );
 
-    /**
-     * @brief indexFromName returns the index corresponding to a given fieldName
-     */
+    //! return the index corresponding to a given fieldName
     QModelIndex indexFromName( QString fieldName );
 
-    /**
-     * @brief setAllowExpression determines if expressions are allowed to be added to the model
-     */
+    //! returns the currently used layer
     void setAllowExpression( bool allowExpression );
     bool allowExpression() {return mAllowExpression;}
 
@@ -61,15 +61,14 @@ class GUI_EXPORT QgsFieldModel : public QAbstractItemModel
      */
     QModelIndex setExpression( QString expression );
 
-    /**
-     * @brief layer returns the currently used layer
-     */
+    //! remove expressions from the model
+    void removeExpression();
+
+    //! returns the currently used layer
     QgsMapLayer* layer() {return mLayer;}
 
   public slots:
-    /**
-     * @brief setLayer sets the layer of whch fields are displayed
-     */
+    //! set the layer of whch fields are displayed
     void setLayer( QgsMapLayer *layer );
 
   protected slots:
@@ -84,6 +83,11 @@ class GUI_EXPORT QgsFieldModel : public QAbstractItemModel
 
     QgsVectorLayer* mLayer;
     bool mAllowExpression;
+
+  private:
+    QgsFeature mFeature;
+
+    void fetchFeature();
 
     // QAbstractItemModel interface
   public:

--- a/src/gui/qgsfieldmodel.h
+++ b/src/gui/qgsfieldmodel.h
@@ -24,15 +24,20 @@
 
 /**
  * @brief The QgsFieldModel class is a model to display the list of fields of a layer in widgets.
+ * If allowed, expressions might be added to the end of the model.
  * It can be associated with a QgsMapLayerModel to dynamically display a layer and its fields.
  * @note added in 2.3
  */
-
 class GUI_EXPORT QgsFieldModel : public QAbstractItemModel
 {
     Q_OBJECT
   public:
-    enum { FieldNameRole = Qt::UserRole + 1, FieldIndexRole = Qt::UserRole + 2 };
+    enum  FieldRoles
+    {
+      FieldNameRole = Qt::UserRole + 1,
+      FieldIndexRole = Qt::UserRole + 2,
+      ExpressionRole = Qt::UserRole + 3
+    };
 
     /**
      * @brief QgsFieldModel creates a model to display the fields of a given layer
@@ -44,6 +49,23 @@ class GUI_EXPORT QgsFieldModel : public QAbstractItemModel
      */
     QModelIndex indexFromName( QString fieldName );
 
+    /**
+     * @brief setAllowExpression determines if expressions are allowed to be added to the model
+     */
+    void setAllowExpression( bool allowExpression );
+    bool allowExpression() {return mAllowExpression;}
+
+    /**
+     * @brief setExpression sets a single expression to be added after the fields at the end of the model
+     * @return the model index of the newly added expression
+     */
+    QModelIndex setExpression( QString expression );
+
+    /**
+     * @brief layer returns the currently used layer
+     */
+    QgsMapLayer* layer() {return mLayer;}
+
   public slots:
     /**
      * @brief setLayer sets the layer of whch fields are displayed
@@ -51,22 +73,25 @@ class GUI_EXPORT QgsFieldModel : public QAbstractItemModel
     void setLayer( QgsMapLayer *layer );
 
   protected slots:
-    void updateFields();
+    virtual void updateModel();
+
+  private slots:
     void layerDeleted();
 
   protected:
     QgsFields mFields;
+    QList<QString> mExpression;
+
     QgsVectorLayer* mLayer;
+    bool mAllowExpression;
 
     // QAbstractItemModel interface
   public:
     QModelIndex index( int row, int column, const QModelIndex &parent = QModelIndex() ) const;
     QModelIndex parent( const QModelIndex &child ) const;
-    int rowCount( const QModelIndex &parent ) const;
+    int rowCount( const QModelIndex &parent = QModelIndex() ) const;
     int columnCount( const QModelIndex &parent ) const;
     QVariant data( const QModelIndex &index, int role ) const;
-
-
 };
 
 #endif // QGSFIELDMODEL_H

--- a/src/gui/qgsfieldmodel.h
+++ b/src/gui/qgsfieldmodel.h
@@ -69,7 +69,7 @@ class GUI_EXPORT QgsFieldModel : public QAbstractItemModel
 
   public slots:
     //! set the layer of whch fields are displayed
-    void setLayer( QgsMapLayer *layer );
+    void setLayer( QgsVectorLayer *layer );
 
   protected slots:
     virtual void updateModel();

--- a/src/gui/qgsfieldmodel.h
+++ b/src/gui/qgsfieldmodel.h
@@ -65,7 +65,7 @@ class GUI_EXPORT QgsFieldModel : public QAbstractItemModel
     void removeExpression();
 
     //! returns the currently used layer
-    QgsMapLayer* layer() {return mLayer;}
+    QgsVectorLayer* layer() {return mLayer;}
 
   public slots:
     //! set the layer of whch fields are displayed

--- a/src/gui/symbology-ng/qgscategorizedsymbolrendererv2widget.h
+++ b/src/gui/symbology-ng/qgscategorizedsymbolrendererv2widget.h
@@ -81,13 +81,12 @@ class GUI_EXPORT QgsCategorizedSymbolRendererV2Widget : public QgsRendererV2Widg
 
   public slots:
     void changeCategorizedSymbol();
-    void categoryColumnChanged();
+    void categoryColumnChanged( QString field );
     void categoriesDoubleClicked( const QModelIndex & idx );
     void addCategory();
     void addCategories();
     void deleteCategories();
     void deleteAllCategories();
-    void setExpression();
 
     void rotationFieldChanged( QString fldName );
     void sizeScaleFieldChanged( QString fldName );
@@ -105,9 +104,6 @@ class GUI_EXPORT QgsCategorizedSymbolRendererV2Widget : public QgsRendererV2Widg
 
     // Called by virtual refreshSymbolView()
     void populateCategories();
-
-    //! populate column combo
-    void populateColumns();
 
     //! return row index for the currently selected category (-1 if on no selection)
     int currentCategoryRow();

--- a/src/gui/symbology-ng/qgsgraduatedsymbolrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgsgraduatedsymbolrendererv2widget.cpp
@@ -462,7 +462,6 @@ void QgsGraduatedSymbolRendererV2Widget::updateUiFromRenderer()
 void QgsGraduatedSymbolRendererV2Widget::graduatedColumnChanged( QString field )
 {
   mRenderer->setClassAttribute( field );
-  classifyGraduated();
 }
 
 void QgsGraduatedSymbolRendererV2Widget::classifyGraduated()

--- a/src/gui/symbology-ng/qgsgraduatedsymbolrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgsgraduatedsymbolrendererv2widget.cpp
@@ -358,7 +358,7 @@ QgsGraduatedSymbolRendererV2Widget::QgsGraduatedSymbolRendererV2Widget( QgsVecto
   // setup user interface
   setupUi( this );
 
-  populateColumns();
+  mExprressionWidget->setLayer( mLayer );
 
   cboGraduatedColorRamp->populate( mStyle );
 
@@ -382,8 +382,7 @@ QgsGraduatedSymbolRendererV2Widget::QgsGraduatedSymbolRendererV2Widget( QgsVecto
 
   mGraduatedSymbol = QgsSymbolV2::defaultSymbol( mLayer->geometryType() );
 
-  connect( cboGraduatedColumn, SIGNAL( currentIndexChanged( int ) ), this, SLOT( graduatedColumnChanged() ) );
-  connect( btnExpression, SIGNAL( clicked() ), this, SLOT( setExpression() ) );
+  connect( mExprressionWidget, SIGNAL( fieldChanged( QString ) ), this, SLOT( graduatedColumnChanged( QString ) ) );
   connect( viewGraduated, SIGNAL( doubleClicked( const QModelIndex & ) ), this, SLOT( rangesDoubleClicked( const QModelIndex & ) ) );
   connect( viewGraduated, SIGNAL( clicked( const QModelIndex & ) ), this, SLOT( rangesClicked( const QModelIndex & ) ) );
   connect( viewGraduated, SIGNAL( customContextMenuRequested( const QPoint& ) ),  this, SLOT( contextMenuViewCategories( const QPoint& ) ) );
@@ -439,16 +438,10 @@ void QgsGraduatedSymbolRendererV2Widget::updateUiFromRenderer()
     spinGraduatedClasses->setValue( mRenderer->ranges().count() );
 
   // set column
-  disconnect( cboGraduatedColumn, SIGNAL( currentIndexChanged( int ) ), this, SLOT( graduatedColumnChanged() ) );
+  disconnect( mExprressionWidget, SIGNAL( fieldChanged( QString ) ), this, SLOT( graduatedColumnChanged( QString ) ) );
   QString attrName = mRenderer->classAttribute();
-  int idx = cboGraduatedColumn->findText( attrName, Qt::MatchExactly );
-  if ( idx == -1 )
-  {
-    cboGraduatedColumn->addItem( attrName );
-    idx = cboGraduatedColumn->count() - 1;
-  }
-  cboGraduatedColumn->setCurrentIndex( idx );
-  connect( cboGraduatedColumn, SIGNAL( currentIndexChanged( int ) ), this, SLOT( graduatedColumnChanged() ) );
+  mExprressionWidget->setField( attrName );
+  connect( mExprressionWidget, SIGNAL( fieldChanged( QString ) ), this, SLOT( graduatedColumnChanged( QString ) ) );
 
   // set source symbol
   if ( mRenderer->sourceSymbol() )
@@ -466,43 +459,15 @@ void QgsGraduatedSymbolRendererV2Widget::updateUiFromRenderer()
   }
 }
 
-void QgsGraduatedSymbolRendererV2Widget::populateColumns()
+void QgsGraduatedSymbolRendererV2Widget::graduatedColumnChanged( QString field )
 {
-  cboGraduatedColumn->clear();
-  const QgsFields& flds = mLayer->pendingFields();
-  for ( int idx = 0; idx < flds.count(); ++idx )
-  {
-    if ( flds[idx].type() == QVariant::Double || flds[idx].type() == QVariant::Int || flds[idx].type() == QVariant::LongLong )
-      cboGraduatedColumn->addItem( flds[idx].name() );
-  }
-}
-
-void QgsGraduatedSymbolRendererV2Widget::graduatedColumnChanged()
-{
-  mRenderer->setClassAttribute( cboGraduatedColumn->currentText() );
+  mRenderer->setClassAttribute( field );
   classifyGraduated();
-}
-
-
-void QgsGraduatedSymbolRendererV2Widget::setExpression()
-{
-  QgsExpressionBuilderDialog dlg( mLayer, cboGraduatedColumn->currentText(), this );
-  dlg.setWindowTitle( "Set column expression" );
-  if ( dlg.exec() )
-  {
-    QString expression = dlg.expressionText();
-    if ( !expression.isEmpty() )
-    {
-      cboGraduatedColumn->addItem( expression );
-      cboGraduatedColumn->setCurrentIndex( cboGraduatedColumn->count() - 1 );
-    }
-  }
-
 }
 
 void QgsGraduatedSymbolRendererV2Widget::classifyGraduated()
 {
-  QString attrName = cboGraduatedColumn->currentText();
+  QString attrName = mExprressionWidget->currentField();
 
   int classes = spinGraduatedClasses->value();
 

--- a/src/gui/symbology-ng/qgsgraduatedsymbolrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgsgraduatedsymbolrendererv2widget.cpp
@@ -358,7 +358,7 @@ QgsGraduatedSymbolRendererV2Widget::QgsGraduatedSymbolRendererV2Widget( QgsVecto
   // setup user interface
   setupUi( this );
 
-  mExprressionWidget->setLayer( mLayer );
+  mExpressionWidget->setLayer( mLayer );
 
   cboGraduatedColorRamp->populate( mStyle );
 
@@ -382,7 +382,7 @@ QgsGraduatedSymbolRendererV2Widget::QgsGraduatedSymbolRendererV2Widget( QgsVecto
 
   mGraduatedSymbol = QgsSymbolV2::defaultSymbol( mLayer->geometryType() );
 
-  connect( mExprressionWidget, SIGNAL( fieldChanged( QString ) ), this, SLOT( graduatedColumnChanged( QString ) ) );
+  connect( mExpressionWidget, SIGNAL( fieldChanged( QString ) ), this, SLOT( graduatedColumnChanged( QString ) ) );
   connect( viewGraduated, SIGNAL( doubleClicked( const QModelIndex & ) ), this, SLOT( rangesDoubleClicked( const QModelIndex & ) ) );
   connect( viewGraduated, SIGNAL( clicked( const QModelIndex & ) ), this, SLOT( rangesClicked( const QModelIndex & ) ) );
   connect( viewGraduated, SIGNAL( customContextMenuRequested( const QPoint& ) ),  this, SLOT( contextMenuViewCategories( const QPoint& ) ) );
@@ -438,10 +438,10 @@ void QgsGraduatedSymbolRendererV2Widget::updateUiFromRenderer()
     spinGraduatedClasses->setValue( mRenderer->ranges().count() );
 
   // set column
-  disconnect( mExprressionWidget, SIGNAL( fieldChanged( QString ) ), this, SLOT( graduatedColumnChanged( QString ) ) );
+  disconnect( mExpressionWidget, SIGNAL( fieldChanged( QString ) ), this, SLOT( graduatedColumnChanged( QString ) ) );
   QString attrName = mRenderer->classAttribute();
-  mExprressionWidget->setField( attrName );
-  connect( mExprressionWidget, SIGNAL( fieldChanged( QString ) ), this, SLOT( graduatedColumnChanged( QString ) ) );
+  mExpressionWidget->setField( attrName );
+  connect( mExpressionWidget, SIGNAL( fieldChanged( QString ) ), this, SLOT( graduatedColumnChanged( QString ) ) );
 
   // set source symbol
   if ( mRenderer->sourceSymbol() )
@@ -467,7 +467,7 @@ void QgsGraduatedSymbolRendererV2Widget::graduatedColumnChanged( QString field )
 
 void QgsGraduatedSymbolRendererV2Widget::classifyGraduated()
 {
-  QString attrName = mExprressionWidget->currentField();
+  QString attrName = mExpressionWidget->currentField();
 
   int classes = spinGraduatedClasses->value();
 

--- a/src/gui/symbology-ng/qgsgraduatedsymbolrendererv2widget.h
+++ b/src/gui/symbology-ng/qgsgraduatedsymbolrendererv2widget.h
@@ -81,8 +81,7 @@ class GUI_EXPORT QgsGraduatedSymbolRendererV2Widget : public QgsRendererV2Widget
 
   public slots:
     void changeGraduatedSymbol();
-    void graduatedColumnChanged();
-    void setExpression();
+    void graduatedColumnChanged( QString field );
     void classifyGraduated();
     void reapplyColorRamp();
     void rangesDoubleClicked( const QModelIndex & idx );
@@ -112,9 +111,6 @@ class GUI_EXPORT QgsGraduatedSymbolRendererV2Widget : public QgsRendererV2Widget
     //! return a list of indexes for the classes under selection
     QList<int> selectedClasses();
     QgsRangeList selectedRanges();
-
-    //! populate column combos in categorized and graduated page
-    void populateColumns();
 
     void changeRangeSymbol( int rangeIdx );
     void changeRange( int rangeIdx );

--- a/src/ui/qgscategorizedsymbolrendererv2widget.ui
+++ b/src/ui/qgscategorizedsymbolrendererv2widget.ui
@@ -24,40 +24,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QComboBox" name="cboCategorizedColumn">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="maximumSize">
-        <size>
-         <width>300</width>
-         <height>16777215</height>
-        </size>
-       </property>
-       <property name="editable">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="btnExpression">
-       <property name="text">
-        <string/>
-       </property>
-       <property name="icon">
-        <iconset resource="../../images/images.qrc">
-         <normaloff>:/images/themes/default/mIconExpressionEditorOpen.svg</normaloff>:/images/themes/default/mIconExpressionEditorOpen.svg</iconset>
-       </property>
-       <property name="iconSize">
-        <size>
-         <width>24</width>
-         <height>16</height>
-        </size>
-       </property>
-      </widget>
+      <widget class="QgsFieldExpressionWidget" name="mExpressionWidget" native="true"/>
      </item>
      <item>
       <spacer name="horizontalSpacer">
@@ -229,9 +196,14 @@
    <extends>QComboBox</extends>
    <header>qgscolorrampcombobox.h</header>
   </customwidget>
+  <customwidget>
+   <class>QgsFieldExpressionWidget</class>
+   <extends>QWidget</extends>
+   <header location="global">qgsfieldexpressionwidget.h</header>
+   <container>1</container>
+  </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>cboCategorizedColumn</tabstop>
   <tabstop>btnChangeCategorizedSymbol</tabstop>
   <tabstop>cboCategorizedColorRamp</tabstop>
   <tabstop>cbxInvertedColorRamp</tabstop>
@@ -241,8 +213,6 @@
   <tabstop>btnDeleteAllCategories</tabstop>
   <tabstop>btnJoinCategories</tabstop>
  </tabstops>
- <resources>
-  <include location="../../images/images.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>

--- a/src/ui/qgsgraduatedsymbolrendererv2widget.ui
+++ b/src/ui/qgsgraduatedsymbolrendererv2widget.ui
@@ -128,66 +128,7 @@
        <property name="text">
         <string>Column</string>
        </property>
-       <property name="buddy">
-        <cstring>cboGraduatedColumn</cstring>
-       </property>
       </widget>
-     </item>
-     <item row="0" column="1" colspan="3">
-      <layout class="QHBoxLayout" name="horizontalLayout">
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <item>
-        <widget class="QComboBox" name="cboGraduatedColumn">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>300</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="editable">
-          <bool>true</bool>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="btnExpression">
-         <property name="text">
-          <string/>
-         </property>
-         <property name="icon">
-          <iconset resource="../../images/images.qrc">
-           <normaloff>:/images/themes/default/mIconExpressionEditorOpen.svg</normaloff>:/images/themes/default/mIconExpressionEditorOpen.svg</iconset>
-         </property>
-         <property name="iconSize">
-          <size>
-           <width>24</width>
-           <height>16</height>
-          </size>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <spacer name="horizontalSpacer">
-         <property name="orientation">
-          <enum>Qt::Horizontal</enum>
-         </property>
-         <property name="sizeHint" stdset="0">
-          <size>
-           <width>10</width>
-           <height>20</height>
-          </size>
-         </property>
-        </spacer>
-       </item>
-      </layout>
      </item>
      <item row="5" column="1">
       <layout class="QHBoxLayout" name="horizontalLayout_2">
@@ -200,6 +141,29 @@
           <string>Invert</string>
          </property>
         </widget>
+       </item>
+      </layout>
+     </item>
+     <item row="0" column="1" colspan="3">
+      <layout class="QHBoxLayout" name="horizontalLayout">
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QgsFieldExpressionWidget" name="mExprressionWidget" native="true"/>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>40</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
        </item>
       </layout>
      </item>
@@ -290,6 +254,12 @@
    <extends>QComboBox</extends>
    <header>qgscolorrampcombobox.h</header>
   </customwidget>
+  <customwidget>
+   <class>QgsFieldExpressionWidget</class>
+   <extends>QWidget</extends>
+   <header location="global">qgsfieldexpressionwidget.h</header>
+   <container>1</container>
+  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>btnChangeGraduatedSymbol</tabstop>
@@ -301,8 +271,6 @@
   <tabstop>btnGraduatedClassify</tabstop>
   <tabstop>btnGraduatedDelete</tabstop>
  </tabstops>
- <resources>
-  <include location="../../images/images.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>

--- a/src/ui/qgsgraduatedsymbolrendererv2widget.ui
+++ b/src/ui/qgsgraduatedsymbolrendererv2widget.ui
@@ -150,7 +150,7 @@
         <number>0</number>
        </property>
        <item>
-        <widget class="QgsFieldExpressionWidget" name="mExprressionWidget" native="true"/>
+        <widget class="QgsFieldExpressionWidget" name="mExpressionWidget" native="true"/>
        </item>
        <item>
         <spacer name="horizontalSpacer">

--- a/src/ui/qgslabelingguibase.ui
+++ b/src/ui/qgslabelingguibase.ui
@@ -14,10 +14,10 @@
    <string>Layer labeling settings</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_8">
-   <property name="verticalSpacing">
+   <property name="margin">
     <number>6</number>
    </property>
-   <property name="margin">
+   <property name="verticalSpacing">
     <number>6</number>
    </property>
    <item row="0" column="0">
@@ -34,23 +34,7 @@
        </widget>
       </item>
       <item>
-       <widget class="QComboBox" name="cboFieldName">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="minimumSize">
-         <size>
-          <width>75</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="editable">
-         <bool>false</bool>
-        </property>
-        <property name="sizeAdjustPolicy">
-         <enum>QComboBox::AdjustToContents</enum>
-        </property>
-       </widget>
+       <widget class="QgsFieldExpressionWidget" name="mFieldExpressionWidget" native="true"/>
       </item>
       <item>
        <spacer name="horizontalSpacer_7">
@@ -67,26 +51,6 @@
          </size>
         </property>
        </spacer>
-      </item>
-      <item>
-       <widget class="QPushButton" name="btnExpression">
-        <property name="enabled">
-         <bool>false</bool>
-        </property>
-        <property name="toolTip">
-         <string>Edit expression</string>
-        </property>
-        <property name="icon">
-         <iconset resource="../../images/images.qrc">
-          <normaloff>:/images/themes/default/mIconExpressionEditorOpen.svg</normaloff>:/images/themes/default/mIconExpressionEditorOpen.svg</iconset>
-        </property>
-        <property name="iconSize">
-         <size>
-          <width>24</width>
-          <height>16</height>
-         </size>
-        </property>
-       </widget>
       </item>
       <item>
        <spacer name="horizontalSpacer_5">
@@ -198,7 +162,7 @@
               <rect>
                <x>0</x>
                <y>0</y>
-               <width>605</width>
+               <width>602</width>
                <height>300</height>
               </rect>
              </property>
@@ -629,7 +593,7 @@
                        <x>0</x>
                        <y>0</y>
                        <width>566</width>
-                       <height>406</height>
+                       <height>392</height>
                       </rect>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -1350,8 +1314,8 @@ font-style: italic;</string>
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>640</width>
-                       <height>462</height>
+                       <width>383</width>
+                       <height>389</height>
                       </rect>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_14">
@@ -1534,11 +1498,11 @@ font-style: italic;</string>
                       <item>
                        <widget class="QFrame" name="mDirectSymbolsFrame">
                         <layout class="QGridLayout" name="gridLayout_33">
-                         <property name="verticalSpacing">
-                          <number>6</number>
-                         </property>
                          <property name="margin">
                           <number>0</number>
+                         </property>
+                         <property name="verticalSpacing">
+                          <number>6</number>
                          </property>
                          <item row="0" column="2">
                           <spacer name="horizontalSpacer_9">
@@ -1961,8 +1925,8 @@ font-style: italic;</string>
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>640</width>
-                       <height>462</height>
+                       <width>298</width>
+                       <height>261</height>
                       </rect>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_12">
@@ -2339,8 +2303,8 @@ font-style: italic;</string>
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>625</width>
-                       <height>753</height>
+                       <width>362</width>
+                       <height>711</height>
                       </rect>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_21">
@@ -3170,8 +3134,8 @@ font-style: italic;</string>
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>640</width>
-                       <height>462</height>
+                       <width>325</width>
+                       <height>430</height>
                       </rect>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_22">
@@ -3664,8 +3628,8 @@ font-style: italic;</string>
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>625</width>
-                       <height>814</height>
+                       <width>377</width>
+                       <height>737</height>
                       </rect>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_11">
@@ -4930,8 +4894,8 @@ font-style: italic;</string>
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>625</width>
-                       <height>639</height>
+                       <width>421</width>
+                       <height>622</height>
                       </rect>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_8">
@@ -5241,11 +5205,11 @@ font-style: italic;</string>
                             <enum>QFrame::Raised</enum>
                            </property>
                            <layout class="QGridLayout" name="gridLayout_5">
-                            <property name="verticalSpacing">
-                             <number>6</number>
-                            </property>
                             <property name="margin">
                              <number>0</number>
+                            </property>
+                            <property name="verticalSpacing">
+                             <number>6</number>
                             </property>
                             <item row="1" column="6">
                              <spacer name="horizontalSpacer_23">
@@ -5339,11 +5303,11 @@ font-style: italic;</string>
                          <item>
                           <widget class="QFrame" name="mUpsidedownFrame">
                            <layout class="QGridLayout" name="gridLayout">
-                            <property name="verticalSpacing">
-                             <number>6</number>
-                            </property>
                             <property name="margin">
                              <number>0</number>
+                            </property>
+                            <property name="verticalSpacing">
+                             <number>6</number>
                             </property>
                             <item row="1" column="3">
                              <widget class="QRadioButton" name="mUpsidedownRadioAll">
@@ -5442,11 +5406,11 @@ font-style: italic;</string>
                          <item>
                           <widget class="QFrame" name="mLimitLabelFrame">
                            <layout class="QGridLayout" name="gridLayout_20">
-                            <property name="verticalSpacing">
-                             <number>6</number>
-                            </property>
                             <property name="margin">
                              <number>0</number>
+                            </property>
+                            <property name="verticalSpacing">
+                             <number>6</number>
                             </property>
                             <item row="1" column="0">
                              <spacer name="verticalSpacer_8">
@@ -5496,11 +5460,11 @@ font-style: italic;</string>
                          <item>
                           <widget class="QFrame" name="mMinSizeFrame">
                            <layout class="QGridLayout" name="gridLayout_21">
-                            <property name="verticalSpacing">
-                             <number>6</number>
-                            </property>
                             <property name="margin">
                              <number>0</number>
+                            </property>
+                            <property name="verticalSpacing">
+                             <number>6</number>
                             </property>
                             <item row="1" column="0">
                              <spacer name="horizontalSpacer_20">
@@ -5614,6 +5578,12 @@ font-style: italic;</string>
    <class>QgsDataDefinedButton</class>
    <extends>QToolButton</extends>
    <header>qgsdatadefinedbutton.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsFieldExpressionWidget</class>
+   <extends>QWidget</extends>
+   <header location="global">qgsfieldexpressionwidget.h</header>
+   <container>1</container>
   </customwidget>
  </customwidgets>
  <resources>


### PR DESCRIPTION
This follows #1289

It allows adding expressions to the field model.

An expression button has been created (buttons can be promoted in Qt designer). It uses the expression dialog and adds directly the new expression to the model.

One thing, I don't get: in QgsFieldModel::data, it seems that for combo box (only thing I tested), the font role is never asked. I wanted the expressions to be in italic, but that doesn't work.
