### PR TITLE
Fix crash caused by attempting to run a QgsMapLayerAction

### DIFF
--- a/src/app/qgsidentifyresultsdialog.h
+++ b/src/app/qgsidentifyresultsdialog.h
@@ -191,6 +191,8 @@ class APP_EXPORT QgsIdentifyResultsDialog: public QDialog, private Ui::QgsIdenti
 
     void printCurrentItem();
 
+    void mapLayerActionRemoved( QgsMapLayerAction *action );
+
   private:
     enum ItemDataRole
     {
@@ -226,6 +228,8 @@ class APP_EXPORT QgsIdentifyResultsDialog: public QDialog, private Ui::QgsIdenti
     void doMapLayerAction( QTreeWidgetItem *item, QgsMapLayerAction* action );
 
     QDockWidget *mDock;
+
+    void removeMapLayerActionItems( QTreeWidgetItem *item, QgsMapLayerAction *action );
 };
 
 class QgsIdentifyResultsDialogMapLayerAction : public QAction

--- a/src/gui/qgsmaplayeractionregistry.cpp
+++ b/src/gui/qgsmaplayeractionregistry.cpp
@@ -13,13 +13,15 @@
  *                                                                         *
  ***************************************************************************/
 
+#include <QUuid>
 #include "qgsmaplayeractionregistry.h"
 
 
 QgsMapLayerAction::QgsMapLayerAction( QString name, QObject* parent ) : QAction( name, parent ),
     mSingleLayer( false ),
     mActionLayer( 0 ),
-    mSpecificLayerType( false )
+    mSpecificLayerType( false ),
+    mUuid( QUuid::createUuid().toString() )
 {
 
 }
@@ -28,7 +30,8 @@ QgsMapLayerAction::QgsMapLayerAction( QString name, QObject* parent ) : QAction(
 QgsMapLayerAction::QgsMapLayerAction( QString name, QObject* parent, QgsMapLayer* layer ) : QAction( name, parent ),
     mSingleLayer( true ),
     mActionLayer( layer ),
-    mSpecificLayerType( false )
+    mSpecificLayerType( false ),
+    mUuid( QUuid::createUuid().toString() )
 {
 
 }
@@ -38,7 +41,8 @@ QgsMapLayerAction::QgsMapLayerAction( QString name, QObject* parent, QgsMapLayer
     mSingleLayer( false ),
     mActionLayer( 0 ),
     mSpecificLayerType( true ),
-    mLayerType( layerType )
+    mLayerType( layerType ),
+    mUuid( QUuid::createUuid().toString() )
 {
 
 }
@@ -138,6 +142,8 @@ bool QgsMapLayerActionRegistry::removeMapLayerAction( QgsMapLayerAction* action 
 {
   if ( mMapLayerActionList.indexOf( action ) != -1 )
   {
+    emit actionRemoved( action );
+
     mMapLayerActionList.removeAll( action );
 
     //also remove this action from the default layer action map

--- a/src/gui/qgsmaplayeractionregistry.h
+++ b/src/gui/qgsmaplayeractionregistry.h
@@ -52,6 +52,9 @@ class GUI_EXPORT QgsMapLayerAction : public QAction
     /** Triggers the action with the specified layer. This also emits the triggered() slot. */
     void triggerForLayer( QgsMapLayer* layer );
 
+    /** Returns a unique id for the map layer action */
+    QString id() { return mUuid; };
+
   signals:
     /** Triggered when action has been run for a specific feature */
     void triggeredForFeature( QgsMapLayer* layer, QgsFeature* feature );
@@ -71,6 +74,8 @@ class GUI_EXPORT QgsMapLayerAction : public QAction
     //layer type if action is only valid for a specific layer type
     QgsMapLayer::LayerType mLayerType;
 
+    //unique id for map layer action
+    QString mUuid;
 
 };
 
@@ -108,6 +113,9 @@ class GUI_EXPORT QgsMapLayerActionRegistry : public QObject
   signals:
     /** Triggered when an action is added or removed from the registry */
     void changed();
+
+    /** Triggered when an action is removed from the registry */
+    void actionRemoved( QgsMapLayerAction* action );
 
   private:
 


### PR DESCRIPTION
... from the idenitify results dialog after the action has been removed. This commit fixes a potential crash which can caused by:
- enabling an atlas for a vector layer
- running the identify tool on that layer, so that the results dialog is shown
- while the dialog is shown, disable the atlas for that layer. The QgsMapLayerAction is removed, but the action isn't removed from the display identify results dialog
- Clicking on the invalid action in the identify results dialog crashes QGIS

This commit makes sure the QgsMapLayerAction is removed from the identify results dialog when it is destroyed.
