### PR TITLE
Cache attributes for composer table

### DIFF
--- a/python/core/composer/qgscomposerattributetable.sip
+++ b/python/core/composer/qgscomposerattributetable.sip
@@ -35,16 +35,74 @@ class QgsComposerAttributeTable : QgsComposerTable
     bool writeXML( QDomElement& elem, QDomDocument & doc ) const;
     bool readXML( const QDomElement& itemElem, const QDomDocument& doc );
 
-    void setVectorLayer( QgsVectorLayer* vl );
+    /**Sets the vector layer from which to display feature attributes
+     * @param layer Vector layer for attribute table
+     * @note added in 2.3
+     * @see vectorLayer
+    */
+    void setVectorLayer( QgsVectorLayer* layer );
+    
+    /*Returns the vector layer the attribute table is currently using
+     * @returns attribute table's current vector layer
+     * @note added in 2.3
+     * @see setVectorLayer
+    */  
     QgsVectorLayer* vectorLayer() const;
 
+    /**Sets the composer map to use to limit the extent of features shown in the
+     * attribute table. This setting only has an effect if setDisplayOnlyVisibleFeatures is
+     * set to true. Changing the composer map forces the table to refetch features from its
+     * vector layer, and may result in the table changing size to accomodate the new displayed
+     * feature attributes.
+     * @param map QgsComposerMap which drives the extents of the table's features
+     * @note added in 2.3
+     * @see composerMap
+     * @see setDisplayOnlyVisibleFeatures
+    */
     void setComposerMap( const QgsComposerMap* map /TransferThis/ );
+    
+    /*Returns the composer map whose extents are controlling the features shown in the
+     * table. The extents of the map are only used if displayOnlyVisibleFeatures() is true.
+     * @returns composer map controlling the attribute table
+     * @note added in 2.3
+     * @see setComposerMap
+     * @see displayOnlyVisibleFeatures
+    */  
     const QgsComposerMap* composerMap() const;
 
-    void setMaximumNumberOfFeatures( int nr );
+    /**Sets the maximum number of features shown by the table. Changing this setting may result
+     * in the attribute table changing its size to accomodate the new number of rows, and requires
+     * the table to refetch features from its vector layer.
+     * @param features maximum number of features to show in the table
+     * @note added in 2.3
+     * @see maximumNumberOfFeatures
+    */
+    void setMaximumNumberOfFeatures( int features );
+    
+    /*Returns the maximum number of features to be shown by the table.
+     * @returns maximum number of features
+     * @note added in 2.3
+     * @see setMaximumNumberOfFeatures
+    */    
     int maximumNumberOfFeatures() const;
 
+    /**Sets attribute table to only show features which are visible in a composer map item. Changing
+     * this setting forces the table to refetch features from its vector layer, and may result in
+     * the table changing size to accomodate the new displayed feature attributes.
+     * @param visibleOnly set to true to show only visible features
+     * @note added in 2.3
+     * @see displayOnlyVisibleFeatures
+     * @see setComposerMap
+    */
     void setDisplayOnlyVisibleFeatures( bool b );
+    
+    /*Returns true if the table is set to show only features visible on a corresponding
+     * composer map item.
+     * @returns true if table only shows visible features
+     * @note added in 2.3
+     * @see composerMap
+     * @see setDisplayOnlyVisibleFeatures
+    */   
     bool displayOnlyVisibleFeatures() const;
     
     /*Returns true if a feature filter is active on the attribute table
@@ -54,7 +112,10 @@ class QgsComposerAttributeTable : QgsComposerTable
      * @see featureFilter
     */
     bool filterFeatures() const;
-    /**Sets whether the feature filter is active for the attribute table
+    
+    /**Sets whether the feature filter is active for the attribute table. Changing
+     * this setting forces the table to refetch features from its vector layer, and may result in
+     * the table changing size to accomodate the new displayed feature attributes.
      * @param filter Set to true to enable the feature filter
      * @note added in 2.3
      * @see filterFeatures
@@ -70,8 +131,11 @@ class QgsComposerAttributeTable : QgsComposerTable
      * @see filterFeatures
     */
     QString featureFilter() const;
+    
     /**Sets the expression used for filtering features in the table. The filter is only
-     * active if filterFeatures() is set to true.
+     * active if filterFeatures() is set to true. Changing this setting forces the table
+     * to refetch features from its vector layer, and may result in
+     * the table changing size to accomodate the new displayed feature attributes.
      * @param expression filter to use for selecting which features to display in the table
      * @note added in 2.3
      * @see featureFilter
@@ -79,13 +143,45 @@ class QgsComposerAttributeTable : QgsComposerTable
     */
     void setFeatureFilter( const QString& expression );
 
+    /*Returns the attributes fields which are shown by the table.
+     * @returns a QSet of integers refering to the attributes in the vector layer
+     * @see setDisplayAttributes
+    */
     QSet<int> displayAttributes() const;
+    
+    /**Sets the attributes to display in the table.
+     * @param attr QSet of integer values refering to the attributes from the vector layer to show
+     * @param refresh set to true to force the table to refetch features from its vector layer
+     * and immediately update the display of the table. This may result in the table changing size
+     * to accomodate the new displayed feature attributes.
+     * @see displayAttributes
+    */    
     void setDisplayAttributes( const QSet<int>& attr );
 
+    /*Returns the attribute field aliases, which control how fields are named in the table's
+     * header row.
+     * @returns a QMap of integers to strings, where the string is the field's alias.
+     * @see setFieldAliasMap
+    */
     QMap<int, QString> fieldAliasMap() const;
+    
+    /**Sets the attribute field aliases, which control how fields are named in the table's
+     * header row.
+     * @param map QMap of integers to strings, where the string is the alias to use for the
+     * corresponding field.
+     * @param refresh set to true to force the table to refetch features from its vector layer
+     * and immediately update the display of the table. This may result in the table changing size
+     * to accomodate the new displayed feature attributes and field aliases.
+     * @see fieldAliasMap
+    */    
     void setFieldAliasMap( const QMap<int, QString>& map );
 
-    /**Adapts mMaximumNumberOfFeatures depending on the rectangle height*/
+    /**Adapts mMaximumNumberOfFeatures depending on the rectangle height. Calling this forces
+     * the table to refetch features from its vector layer and immediately updates the display
+     * of the table.
+     * @see maximumNumberOfFeatures
+     * @see setMaximumNumberOfFeatures
+    */
     void setSceneRect( const QRectF& rectangle );
 
     // @note not available in python bindings

--- a/python/core/composer/qgscomposertable.sip
+++ b/python/core/composer/qgscomposertable.sip
@@ -35,10 +35,25 @@ class QgsComposerTable: QgsComposerItem
 
     void setGridColor( const QColor& c );
     QColor gridColor() const;
+    
+  public slots:
 
-    /**Adapts the size of the frame to match the content. This is normally done in the paint method, but sometimes
-    it needs to be done before the first render*/
-    void adjustFrameToSize();
+    /**Refreshes the attributes shown in the table by querying the vector layer for new data.
+     * This also causes the column widths and size of the table to change to accomodate the
+     * new data.
+     * @note added in 2.3
+     * @see adjustFrameToSize
+    */
+    virtual void refreshAttributes();
+
+    /**Adapts the size of the frame to match the content. First, the optimal width of the columns
+     * is recalculated by checking the maximum width of attributes shown in the table. Then, the
+     * table is resized to fit its contents. This slot utilises the table's attribute cache so
+     * that a re-query of the vector layer is not required.
+     * @note added in 2.3
+     * @see refreshAttributes
+    */
+    virtual void adjustFrameToSize();   
 
   protected:
     /**Retrieves feature attributes*/

--- a/src/app/composer/qgscomposertablewidget.cpp
+++ b/src/app/composer/qgscomposertablewidget.cpp
@@ -94,6 +94,16 @@ void QgsComposerTableWidget::refreshMapComboBox()
   }
 }
 
+void QgsComposerTableWidget::on_mRefreshPushButton_clicked()
+{
+  if ( !mComposerTable )
+  {
+    return;
+  }
+
+  mComposerTable->refreshAttributes();
+}
+
 void QgsComposerTableWidget::on_mAttributesPushButton_clicked()
 {
   if ( !mComposerTable )

--- a/src/app/composer/qgscomposertablewidget.cpp
+++ b/src/app/composer/qgscomposertablewidget.cpp
@@ -106,9 +106,14 @@ void QgsComposerTableWidget::on_mAttributesPushButton_clicked()
   {
     //change displayAttributes and aliases
     mComposerTable->beginCommand( tr( "Table attribute settings" ) );
-    mComposerTable->setDisplayAttributes( d.enabledAttributes() );
-    mComposerTable->setFieldAliasMap( d.aliasMap() );
-    mComposerTable->setSortAttributes( d.attributeSorting() );
+
+    //call these methods with update=false to prevent multiple refreshing of table attributes
+    mComposerTable->setDisplayAttributes( d.enabledAttributes(), false );
+    mComposerTable->setFieldAliasMap( d.aliasMap(), false );
+    mComposerTable->setSortAttributes( d.attributeSorting(), false );
+    //finally, force a single refresh of the attributes
+    mComposerTable->refreshAttributes();
+
     mComposerTable->update();
     mComposerTable->endCommand();
   }

--- a/src/app/composer/qgscomposertablewidget.h
+++ b/src/app/composer/qgscomposertablewidget.h
@@ -40,6 +40,7 @@ class QgsComposerTableWidget: public QWidget, private Ui::QgsComposerTableWidget
     void refreshMapComboBox();
 
   private slots:
+    void on_mRefreshPushButton_clicked();
     void on_mAttributesPushButton_clicked();
     void on_mComposerMapComboBox_activated( int index );
     void on_mMaximumColumnsSpinBox_valueChanged( int i );

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -351,6 +351,7 @@ SET(QGIS_CORE_MOC_HDRS
   composer/qgscomposerlabel.h
   composer/qgscomposershape.h
   composer/qgscomposerattributetable.h
+  composer/qgscomposertable.h  
   composer/qgscomposerhtml.h
   composer/qgscomposermultiframe.h
   composer/qgscomposereffect.h

--- a/src/core/composer/qgscomposerattributetable.h
+++ b/src/core/composer/qgscomposerattributetable.h
@@ -53,16 +53,70 @@ class CORE_EXPORT QgsComposerAttributeTable: public QgsComposerTable
     bool writeXML( QDomElement& elem, QDomDocument & doc ) const;
     bool readXML( const QDomElement& itemElem, const QDomDocument& doc );
 
-    void setVectorLayer( QgsVectorLayer* vl );
+    /**Sets the vector layer from which to display feature attributes
+     * @param layer Vector layer for attribute table
+     * @note added in 2.3
+     * @see vectorLayer
+    */
+    void setVectorLayer( QgsVectorLayer* layer );
+    /*Returns the vector layer the attribute table is currently using
+     * @returns attribute table's current vector layer
+     * @note added in 2.3
+     * @see setVectorLayer
+    */
     QgsVectorLayer* vectorLayer() const { return mVectorLayer; }
 
+    /**Sets the composer map to use to limit the extent of features shown in the
+     * attribute table. This setting only has an effect if setDisplayOnlyVisibleFeatures is
+     * set to true. Changing the composer map forces the table to refetch features from its
+     * vector layer, and may result in the table changing size to accomodate the new displayed
+     * feature attributes.
+     * @param map QgsComposerMap which drives the extents of the table's features
+     * @note added in 2.3
+     * @see composerMap
+     * @see setDisplayOnlyVisibleFeatures
+    */
     void setComposerMap( const QgsComposerMap* map );
+    /*Returns the composer map whose extents are controlling the features shown in the
+     * table. The extents of the map are only used if displayOnlyVisibleFeatures() is true.
+     * @returns composer map controlling the attribute table
+     * @note added in 2.3
+     * @see setComposerMap
+     * @see displayOnlyVisibleFeatures
+    */
     const QgsComposerMap* composerMap() const { return mComposerMap; }
 
-    void setMaximumNumberOfFeatures( int nr ) { mMaximumNumberOfFeatures = nr; }
+    /**Sets the maximum number of features shown by the table. Changing this setting may result
+     * in the attribute table changing its size to accomodate the new number of rows, and requires
+     * the table to refetch features from its vector layer.
+     * @param features maximum number of features to show in the table
+     * @note added in 2.3
+     * @see maximumNumberOfFeatures
+    */
+    void setMaximumNumberOfFeatures( int features );
+    /*Returns the maximum number of features to be shown by the table.
+     * @returns maximum number of features
+     * @note added in 2.3
+     * @see setMaximumNumberOfFeatures
+    */
     int maximumNumberOfFeatures() const { return mMaximumNumberOfFeatures; }
 
-    void setDisplayOnlyVisibleFeatures( bool b ) { mShowOnlyVisibleFeatures = b; }
+    /**Sets attribute table to only show features which are visible in a composer map item. Changing
+     * this setting forces the table to refetch features from its vector layer, and may result in
+     * the table changing size to accomodate the new displayed feature attributes.
+     * @param visibleOnly set to true to show only visible features
+     * @note added in 2.3
+     * @see displayOnlyVisibleFeatures
+     * @see setComposerMap
+    */
+    void setDisplayOnlyVisibleFeatures( bool visibleOnly );
+    /*Returns true if the table is set to show only features visible on a corresponding
+     * composer map item.
+     * @returns true if table only shows visible features
+     * @note added in 2.3
+     * @see composerMap
+     * @see setDisplayOnlyVisibleFeatures
+    */
     bool displayOnlyVisibleFeatures() const { return mShowOnlyVisibleFeatures; }
 
     /*Returns true if a feature filter is active on the attribute table
@@ -72,13 +126,15 @@ class CORE_EXPORT QgsComposerAttributeTable: public QgsComposerTable
      * @see featureFilter
     */
     bool filterFeatures() const { return mFilterFeatures; }
-    /**Sets whether the feature filter is active for the attribute table
+    /**Sets whether the feature filter is active for the attribute table. Changing
+     * this setting forces the table to refetch features from its vector layer, and may result in
+     * the table changing size to accomodate the new displayed feature attributes.
      * @param filter Set to true to enable the feature filter
      * @note added in 2.3
      * @see filterFeatures
      * @see setFeatureFilter
     */
-    void setFilterFeatures( bool filter ) { mFilterFeatures = filter; }
+    void setFilterFeatures( bool filter );
 
     /*Returns the current expression used to filter features for the table. The filter is only
      * active if filterFeatures() is true.
@@ -89,27 +145,77 @@ class CORE_EXPORT QgsComposerAttributeTable: public QgsComposerTable
     */
     QString featureFilter() const { return mFeatureFilter; }
     /**Sets the expression used for filtering features in the table. The filter is only
-     * active if filterFeatures() is set to true.
+     * active if filterFeatures() is set to true. Changing this setting forces the table
+     * to refetch features from its vector layer, and may result in
+     * the table changing size to accomodate the new displayed feature attributes.
      * @param expression filter to use for selecting which features to display in the table
      * @note added in 2.3
      * @see featureFilter
      * @see setFilterFeatures
     */
-    void setFeatureFilter( const QString& expression ) { mFeatureFilter = expression; }
+    void setFeatureFilter( const QString& expression );
 
+    /*Returns the attributes fields which are shown by the table.
+     * @returns a QSet of integers refering to the attributes in the vector layer
+     * @see setDisplayAttributes
+    */
     QSet<int> displayAttributes() const { return mDisplayAttributes; }
-    void setDisplayAttributes( const QSet<int>& attr ) { mDisplayAttributes = attr; }
+    /**Sets the attributes to display in the table.
+     * @param attr QSet of integer values refering to the attributes from the vector layer to show
+     * @param refresh set to true to force the table to refetch features from its vector layer
+     * and immediately update the display of the table. This may result in the table changing size
+     * to accomodate the new displayed feature attributes.
+     * @see displayAttributes
+    */
+    void setDisplayAttributes( const QSet<int>& attr, bool refresh = true );
 
+    /*Returns the attribute field aliases, which control how fields are named in the table's
+     * header row.
+     * @returns a QMap of integers to strings, where the string is the field's alias.
+     * @see setFieldAliasMap
+    */
     QMap<int, QString> fieldAliasMap() const { return mFieldAliasMap; }
-    void setFieldAliasMap( const QMap<int, QString>& map ) { mFieldAliasMap = map; }
 
-    /**Adapts mMaximumNumberOfFeatures depending on the rectangle height*/
+    /**Sets the attribute field aliases, which control how fields are named in the table's
+     * header row.
+     * @param map QMap of integers to strings, where the string is the alias to use for the
+     * corresponding field.
+     * @param refresh set to true to force the table to refetch features from its vector layer
+     * and immediately update the display of the table. This may result in the table changing size
+     * to accomodate the new displayed feature attributes and field aliases.
+     * @see fieldAliasMap
+    */
+    void setFieldAliasMap( const QMap<int, QString>& map, bool refresh = true );
+
+    /**Adapts mMaximumNumberOfFeatures depending on the rectangle height. Calling this forces
+     * the table to refetch features from its vector layer and immediately updates the display
+     * of the table.
+     * @see maximumNumberOfFeatures
+     * @see setMaximumNumberOfFeatures
+    */
     void setSceneRect( const QRectF& rectangle );
 
-    // @note not available in python bindings
-    void setSortAttributes( const QList<QPair<int, bool> > att ) { mSortInformation = att; }
+    /**Sets the attributes to use to sort the table's features.
+     * @param att QList integers/bool pairs, where the integer refers to the attribute index and
+     * the bool sets the sort order for the attribute. If true the attribute is sorted ascending,
+     * if false, the attribute is sorted in descending order. Note that features are sorted
+     * after the maximum number of displayed features have been fetched from the vector layer's
+     * provider.
+     * @param refresh set to true to force the table to refetch features from its vector layer
+     * and immediately update the display of the table. This may result in the table changing size
+     * to accomodate the new displayed feature attributes and field aliases.l
+     * @see sortAttributes
+     * @note not available in python bindings
+    */
+    void setSortAttributes( const QList<QPair<int, bool> > att, bool refresh = true );
 
-    // @note not available in python bindings
+    /*Returns the attributes used to sort the table's features.
+     * @returns a QList of integer/bool pairs, where the integer refers to the attribute index and
+     * the bool to the sort order for the attribute. If true the attribute is sorted ascending,
+     * if false, the attribute is sorted in descending order.
+     * @see setSortAttributes
+     * @note not available in python bindings
+    */
     QList<QPair<int, bool> > sortAttributes() const { return mSortInformation; }
 
   protected:
@@ -147,7 +253,14 @@ class CORE_EXPORT QgsComposerAttributeTable: public QgsComposerTable
 
     /**Inserts aliases from vector layer as starting configuration to the alias map*/
     void initializeAliasMap();
-    /**Returns the attribute name to display in the item (attribute name or an alias if present)*/
+
+    /**Returns the attribute name to display in the table's header row for a specified attribute.
+     * @param attributeIndex attribute index
+     * @param name default name to use for the attribute
+     * @returns the aliases for the attribute if set. If an alias is not set then the
+     * default name will be returned.
+     * @see setFieldAliasMap
+     */
     QString attributeDisplayName( int attributeIndex, const QString& name ) const;
 
   private slots:

--- a/src/core/composer/qgscomposertable.cpp
+++ b/src/core/composer/qgscomposertable.cpp
@@ -42,6 +42,23 @@ QgsComposerTable::~QgsComposerTable()
 
 }
 
+void QgsComposerTable::refreshAttributes()
+{
+
+  mMaxColumnWidthMap.clear();
+  mAttributeMaps.clear();
+
+  //getFeatureAttributes
+  if ( !getFeatureAttributes( mAttributeMaps ) )
+  {
+    return;
+  }
+
+  //since attributes have changed, we also need to recalculate the column widths
+  //and size of table
+  adjustFrameToSize();
+}
+
 void QgsComposerTable::paint( QPainter* painter, const QStyleOptionGraphicsItem* itemStyle, QWidget* pWidget )
 {
   Q_UNUSED( itemStyle );
@@ -51,18 +68,13 @@ void QgsComposerTable::paint( QPainter* painter, const QStyleOptionGraphicsItem*
     return;
   }
 
-  //getFeatureAttributes
-  QList<QgsAttributeMap> attributeMaps;
-  if ( !getFeatureAttributes( attributeMaps ) )
+  if ( mComposition->plotStyle() == QgsComposition::Print ||
+       mComposition->plotStyle() == QgsComposition::Postscript )
   {
-    return;
+    //exporting composition, so force an attribute refresh
+    //we do this in case vector layer has changed via an external source (eg, another database user)
+    refreshAttributes();
   }
-
-  QMap<int, double> maxColumnWidthMap;
-  //check how much space each column needs
-  calculateMaxColumnWidths( maxColumnWidthMap, attributeMaps );
-  //adapt item frame to max width / height
-  adaptItemFrame( maxColumnWidthMap, attributeMaps );
 
   drawBackground( painter );
   painter->setPen( Qt::SolidLine );
@@ -86,8 +98,8 @@ void QgsComposerTable::paint( QPainter* painter, const QStyleOptionGraphicsItem*
     currentY += mGridStrokeWidth;
 
     //draw the attribute values
-    QList<QgsAttributeMap>::const_iterator attIt = attributeMaps.begin();
-    for ( ; attIt != attributeMaps.end(); ++attIt )
+    QList<QgsAttributeMap>::const_iterator attIt = mAttributeMaps.begin();
+    for ( ; attIt != mAttributeMaps.end(); ++attIt )
     {
       currentY += fontAscentMillimeters( mContentFont );
       currentY += mLineTextDistance;
@@ -99,7 +111,7 @@ void QgsComposerTable::paint( QPainter* painter, const QStyleOptionGraphicsItem*
       currentY += mGridStrokeWidth;
     }
 
-    currentX += maxColumnWidthMap[columnIt.key()];
+    currentX += mMaxColumnWidthMap[columnIt.key()];
     currentX += mLineTextDistance;
     currentX += mGridStrokeWidth;
   }
@@ -112,8 +124,8 @@ void QgsComposerTable::paint( QPainter* painter, const QStyleOptionGraphicsItem*
     gridPen.setColor( mGridColor );
     gridPen.setJoinStyle( Qt::MiterJoin );
     painter->setPen( gridPen );
-    drawHorizontalGridLines( painter, attributeMaps.size() );
-    drawVerticalGridLines( painter, maxColumnWidthMap );
+    drawHorizontalGridLines( painter, mAttributeMaps.size() );
+    drawVerticalGridLines( painter, mMaxColumnWidthMap );
   }
 
   //draw frame and selection boxes if necessary
@@ -124,17 +136,31 @@ void QgsComposerTable::paint( QPainter* painter, const QStyleOptionGraphicsItem*
   }
 }
 
+void QgsComposerTable::setHeaderFont( const QFont& f )
+{
+  mHeaderFont = f;
+  //since font attributes have changed, we need to recalculate the table size
+  adjustFrameToSize();
+}
+
+void QgsComposerTable::setContentFont( const QFont& f )
+{
+  mContentFont = f;
+  //since font attributes have changed, we need to recalculate the table size
+  adjustFrameToSize();
+}
+
 void QgsComposerTable::adjustFrameToSize()
 {
-  QList<QgsAttributeMap> attributes;
-  if ( !getFeatureAttributes( attributes ) )
+  //check how much space each column needs
+  if ( !calculateMaxColumnWidths( mMaxColumnWidthMap, mAttributeMaps ) )
+  {
     return;
+  }
+  //adapt item frame to max width / height
+  adaptItemFrame( mMaxColumnWidthMap, mAttributeMaps );
 
-  QMap<int, double> maxWidthMap;
-  if ( !calculateMaxColumnWidths( maxWidthMap, attributes ) )
-    return;
-
-  adaptItemFrame( maxWidthMap, attributes );
+  repaint();
 }
 
 bool QgsComposerTable::tableWriteXML( QDomElement& elem, QDomDocument & doc ) const

--- a/src/core/composer/qgscomposertable.h
+++ b/src/core/composer/qgscomposertable.h
@@ -28,6 +28,8 @@
 /**A class to display feature attributes in the print composer*/
 class CORE_EXPORT QgsComposerTable: public QgsComposerItem
 {
+    Q_OBJECT
+
   public:
     QgsComposerTable( QgsComposition* composition );
     virtual ~QgsComposerTable();
@@ -44,10 +46,10 @@ class CORE_EXPORT QgsComposerTable: public QgsComposerItem
     void setLineTextDistance( double d ) { mLineTextDistance = d; }
     double lineTextDistance() const { return mLineTextDistance; }
 
-    void setHeaderFont( const QFont& f ) { mHeaderFont = f;}
+    void setHeaderFont( const QFont& f );
     QFont headerFont() const { return mHeaderFont; }
 
-    void setContentFont( const QFont& f ) { mContentFont = f; }
+    void setContentFont( const QFont& f );
     QFont contentFont() const { return mContentFont; }
 
     void setShowGrid( bool show ) { mShowGrid = show;}
@@ -59,9 +61,24 @@ class CORE_EXPORT QgsComposerTable: public QgsComposerItem
     void setGridColor( const QColor& c ) { mGridColor = c; }
     QColor gridColor() const { return mGridColor; }
 
-    /**Adapts the size of the frame to match the content. This is normally done in the paint method, but sometimes
-    it needs to be done before the first render*/
-    void adjustFrameToSize();
+  public slots:
+
+    /**Refreshes the attributes shown in the table by querying the vector layer for new data.
+     * This also causes the column widths and size of the table to change to accomodate the
+     * new data.
+     * @note added in 2.3
+     * @see adjustFrameToSize
+    */
+    virtual void refreshAttributes();
+
+    /**Adapts the size of the frame to match the content. First, the optimal width of the columns
+     * is recalculated by checking the maximum width of attributes shown in the table. Then, the
+     * table is resized to fit its contents. This slot utilises the table's attribute cache so
+     * that a re-query of the vector layer is not required.
+     * @note added in 2.3
+     * @see refreshAttributes
+    */
+    virtual void adjustFrameToSize();
 
   protected:
     /**Distance between table lines and text*/
@@ -73,6 +90,9 @@ class CORE_EXPORT QgsComposerTable: public QgsComposerItem
     bool mShowGrid;
     double mGridStrokeWidth;
     QColor mGridColor;
+
+    QList<QgsAttributeMap> mAttributeMaps;
+    QMap<int, double> mMaxColumnWidthMap;
 
     /**Retrieves feature attributes*/
     //! @note not available in python bindings

--- a/src/ui/qgscomposertablewidgetbase.ui
+++ b/src/ui/qgscomposertablewidgetbase.ui
@@ -63,7 +63,10 @@
           <bool>false</bool>
          </property>
          <layout class="QFormLayout" name="formLayout">
-          <item row="0" column="0">
+          <property name="fieldGrowthPolicy">
+           <enum>QFormLayout::AllNonFixedFieldsGrow</enum>
+          </property>
+          <item row="1" column="0">
            <widget class="QLabel" name="mLayerLabel">
             <property name="text">
              <string>Layer</string>
@@ -73,14 +76,38 @@
             </property>
            </widget>
           </item>
-          <item row="8" column="0" colspan="2">
+          <item row="1" column="1">
+           <widget class="QgsMapLayerComboBox" name="mLayerComboBox">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+           </widget>
+          </item>
+          <item row="4" column="0" colspan="2">
+           <widget class="QPushButton" name="mRefreshPushButton">
+            <property name="text">
+             <string>Refresh table data</string>
+            </property>
+           </widget>
+          </item>
+          <item row="5" column="0" colspan="2">
+           <widget class="QPushButton" name="mAttributesPushButton">
+            <property name="text">
+             <string>Attributes...</string>
+            </property>
+           </widget>
+          </item>
+          <item row="9" column="0" colspan="2">
            <widget class="QCheckBox" name="mShowOnlyVisibleFeaturesCheckBox">
             <property name="text">
              <string>Show only visible features</string>
             </property>
            </widget>
           </item>
-          <item row="10" column="0">
+          <item row="11" column="0">
            <widget class="QLabel" name="mComposerMapLabel">
             <property name="text">
              <string>Composer map</string>
@@ -93,17 +120,17 @@
             </property>
            </widget>
           </item>
-          <item row="10" column="1">
+          <item row="11" column="1">
            <widget class="QComboBox" name="mComposerMapComboBox"/>
           </item>
-          <item row="12" column="0">
+          <item row="13" column="0">
            <widget class="QCheckBox" name="mFeatureFilterCheckBox">
             <property name="text">
              <string>Filter with</string>
             </property>
            </widget>
           </item>
-          <item row="12" column="1">
+          <item row="13" column="1">
            <layout class="QHBoxLayout" name="horizontalLayout">
             <item>
              <widget class="QLineEdit" name="mFeatureFilterEdit"/>
@@ -121,7 +148,7 @@
             </item>
            </layout>
           </item>
-          <item row="14" column="0">
+          <item row="15" column="0">
            <widget class="QLabel" name="mMaxNumFeaturesLabel">
             <property name="text">
              <string>Maximum rows</string>
@@ -134,10 +161,10 @@
             </property>
            </widget>
           </item>
-          <item row="14" column="1">
+          <item row="15" column="1">
            <widget class="QSpinBox" name="mMaximumColumnsSpinBox"/>
           </item>
-          <item row="16" column="0">
+          <item row="17" column="0">
            <widget class="QLabel" name="mMarginLabel">
             <property name="text">
              <string>Margin</string>
@@ -150,25 +177,8 @@
             </property>
            </widget>
           </item>
-          <item row="16" column="1">
+          <item row="17" column="1">
            <widget class="QDoubleSpinBox" name="mMarginSpinBox"/>
-          </item>
-          <item row="0" column="1">
-           <widget class="QgsMapLayerComboBox" name="mLayerComboBox">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-           </widget>
-          </item>
-          <item row="4" column="0" colspan="2">
-           <widget class="QPushButton" name="mAttributesPushButton">
-            <property name="text">
-             <string>Attributes...</string>
-            </property>
-           </widget>
           </item>
          </layout>
         </widget>


### PR DESCRIPTION
Currently, the composer attribute table is very heavy with the cpu, as it refetches the attributes from the layer's provider with every paint. This is both expensive and potentially results in many duplicated calls to a database backend. This pull request implements an attribute cache for the table, so that the attributes are only refetched when required. End result is that using composer tables no longer results in heavy cpu use and continual provider queries.

I'm reluctant to merge this myself as I don't know the history behind the composer table, and why it was originally created to requery on every paint operation. Perhaps there's a valid reason for this which I may be missing?
