### PR TITLE
Changed the link to commercial support page default to EN.

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -7091,7 +7091,7 @@ void QgisApp::apiDocumentation()
 
 void QgisApp::supportProviders()
 {
-  openURL( tr( "http://qgis.org/de/site/forusers/commercial_support.html" ), false );
+  openURL( tr( "http://qgis.org/en/site/forusers/commercial_support.html" ), false );
 }
 
 void QgisApp::helpQgisHomePage()


### PR DESCRIPTION
The default commercial support page is in DE. Changed to EN.
http://qgis.org/en/site/forusers/commercial_support.html

Ideally should set to match the locale.
