### PR TITLE
Fallback to external httplib2 when internal is not available

### DIFF
--- a/python/plugins/processing/algs/admintools/geoserver/catalog.py
+++ b/python/plugins/processing/algs/admintools/geoserver/catalog.py
@@ -41,7 +41,11 @@ from layergroup import LayerGroup, \
     UnsavedLayerGroup
 from workspace import workspace_from_index, \
     Workspace
-from processing.algs.admintools import httplib2
+try:
+    from processing.algs.admintools import httplib2
+except ImportError:
+    # If compiled without internal httplib2: Load external
+    import httplib2
 
 
 logger = logging.getLogger('gsconfig.catalog')


### PR DESCRIPTION
Currently QGIS will fail to load processing plugin when compiled with WITH_INTERNAL_HTTPLIB=False
