### PR TITLE
Use QRect::united instead of unite

### DIFF
--- a/src/core/composer/qgscomposerarrow.cpp
+++ b/src/core/composer/qgscomposerarrow.cpp
@@ -113,7 +113,7 @@ void QgsComposerArrow::setSceneRect( const QRectF& rectangle )
   double margin = computeMarkerMargin();
 
   // Ensure the rectangle is at least as large as needed to include the markers
-  QRectF rect = rectangle.unite( QRectF( rectangle.x(), rectangle.y(), 2. * margin, 2. * margin ) );
+  QRectF rect = rectangle.united( QRectF( rectangle.x(), rectangle.y(), 2. * margin, 2. * margin ) );
 
   // Compute new start and stop positions
   double x[2] = {rect.x(), rect.x() + rect.width()};


### PR DESCRIPTION
The unite() method has been deprecated in favor of united(). In Qt 4,
united() just calls unite(); in Qt 5, it is completely removed.
