### PR TITLE
Apply settings before saving style, otherwise unapplied settings are not written to qml file

### DIFF
--- a/src/app/qgsrasterlayerproperties.cpp
+++ b/src/app/qgsrasterlayerproperties.cpp
@@ -1622,6 +1622,9 @@ void QgsRasterLayerProperties::on_pbnLoadDefaultStyle_clicked()
 
 void QgsRasterLayerProperties::on_pbnSaveDefaultStyle_clicked()
 {
+
+  apply(); // make sure the style to save is uptodate
+
   // a flag passed by reference
   bool defaultSavedFlag = false;
   // after calling this the above flag will be set true for success
@@ -1690,6 +1693,8 @@ void QgsRasterLayerProperties::on_pbnSaveStyleAs_clicked()
   // ensure the user never omits the extension from the file name
   if ( !outputFileName.endsWith( ".qml", Qt::CaseInsensitive ) )
     outputFileName += ".qml";
+
+  apply(); // make sure the style to save is uptodate
 
   bool defaultLoadedFlag = false;
   QString message = mRasterLayer->saveNamedStyle( outputFileName, defaultLoadedFlag );


### PR DESCRIPTION
Currently, in the raster layer properties, when selecting "Save Style", unapplied settings are not written to the qml file. This can potentially confuse users, but even worse, it resets the transparent pixel list to the previously applied state (due to  `QgsRasterLayerProperties::on_pbnSaveStyleAs_clicked` which calls `QgsRasterLayerProperties::sync` which calls `QgsRasterLayerProperties::setupTransparencyTable` and `QgsRasterLayerProperties::populateTransparencyTable`), which means that the user is potentially losing the entered list.

This solution is somewhat ugly, since users might potentially want to save settings without applying them. However, it is also how the issue was solved in the vector layer properties.

Funded by Sourcepole QGIS Enterprise.
