### PR TITLE
Fix bug #10181: Graduated styles show also non numeric columns

### DIFF
--- a/src/gui/qgsfieldexpressionwidget.cpp
+++ b/src/gui/qgsfieldexpressionwidget.cpp
@@ -108,6 +108,11 @@ void QgsFieldExpressionWidget::setLayer( QgsVectorLayer *layer )
   mFieldModel->setLayer( layer );
 }
 
+QgsFieldModel* QgsFieldExpressionWidget::fieldModel()
+{
+  return mFieldModel;
+}
+
 void QgsFieldExpressionWidget::setField( const QString fieldName )
 {
   if ( fieldName.isEmpty() )

--- a/src/gui/qgsfieldexpressionwidget.h
+++ b/src/gui/qgsfieldexpressionwidget.h
@@ -67,6 +67,9 @@ class GUI_EXPORT QgsFieldExpressionWidget : public QWidget
     //! Returns the currently used layer
     QgsVectorLayer* layer();
 
+    //! Returns the currently used field model
+    QgsFieldModel* fieldModel();
+
   signals:
     //! the signal is emitted when the currently selected field changes
     void fieldChanged( QString fieldName );

--- a/src/gui/qgsfieldmodel.h
+++ b/src/gui/qgsfieldmodel.h
@@ -22,6 +22,9 @@
 
 #include "qgsvectorlayer.h"
 
+// Defines a custom field validation proc
+typedef bool ( *customFieldValidationProc )( const QgsField& );
+
 /**
  * @brief The QgsFieldModel class is a model to display the list of fields of a layer in widgets.
  * If allowed, expressions might be added to the end of the model.
@@ -65,6 +68,18 @@ class GUI_EXPORT QgsFieldModel : public QAbstractItemModel
     //! returns the currently used layer
     QgsVectorLayer* layer() {return mLayer;}
 
+    //! sets the custom field validation
+    void setCustomFieldValidation(customFieldValidationProc func);
+    //! gets the custom field validation
+    customFieldValidationProc customFieldValidation() const { return mCustomFieldValidation; }
+
+    //! sets the custom field validation passing only the numeric fields
+    void setNumericFieldValidation();
+    //! sets the custom field validation passing only the integer fields
+    void setIntegerFieldValidation();
+    //! sets the custom field validation passing only the string fields
+    void setStringFieldValidation();
+
   public slots:
     //! set the layer of whch fields are displayed
     void setLayer( QgsVectorLayer *layer );
@@ -81,6 +96,7 @@ class GUI_EXPORT QgsFieldModel : public QAbstractItemModel
 
     QgsVectorLayer* mLayer;
     bool mAllowExpression;
+    customFieldValidationProc mCustomFieldValidation;
 
   private:
     void fetchFeature();

--- a/src/gui/symbology-ng/qgscategorizedsymbolrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgscategorizedsymbolrendererv2widget.cpp
@@ -29,7 +29,6 @@
 
 #include "qgsproject.h"
 #include "qgsexpression.h"
-#include "qgsfieldmodel.h"
 
 #include <QKeyEvent>
 #include <QMenu>
@@ -370,7 +369,6 @@ QgsCategorizedSymbolRendererV2Widget::QgsCategorizedSymbolRendererV2Widget( QgsV
   setupUi( this );
 
   mExpressionWidget->setLayer( mLayer );
-  mExpressionWidget->fieldModel()->setNumericFieldValidation();
 
   cboCategorizedColorRamp->populate( mStyle );
   int randomIndex = cboCategorizedColorRamp->findText( tr( "Random colors" ) );

--- a/src/gui/symbology-ng/qgscategorizedsymbolrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgscategorizedsymbolrendererv2widget.cpp
@@ -29,6 +29,7 @@
 
 #include "qgsproject.h"
 #include "qgsexpression.h"
+#include "qgsfieldmodel.h"
 
 #include <QKeyEvent>
 #include <QMenu>
@@ -369,6 +370,7 @@ QgsCategorizedSymbolRendererV2Widget::QgsCategorizedSymbolRendererV2Widget( QgsV
   setupUi( this );
 
   mExpressionWidget->setLayer( mLayer );
+  mExpressionWidget->fieldModel()->setNumericFieldValidation();
 
   cboCategorizedColorRamp->populate( mStyle );
   int randomIndex = cboCategorizedColorRamp->findText( tr( "Random colors" ) );

--- a/src/gui/symbology-ng/qgsgraduatedsymbolrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgsgraduatedsymbolrendererv2widget.cpp
@@ -27,6 +27,7 @@
 #include "qgsludialog.h"
 
 #include "qgsproject.h"
+#include "qgsfieldmodel.h"
 
 #include <QKeyEvent>
 #include <QMenu>
@@ -359,6 +360,7 @@ QgsGraduatedSymbolRendererV2Widget::QgsGraduatedSymbolRendererV2Widget( QgsVecto
   setupUi( this );
 
   mExpressionWidget->setLayer( mLayer );
+  mExpressionWidget->fieldModel()->setNumericFieldValidation();
 
   cboGraduatedColorRamp->populate( mStyle );
 


### PR DESCRIPTION
This pull fixes the bug (https://hub.qgis.org/issues/10181).

It implements a custom field validation function in the QgsFieldModel class to filter the fields to load in the related CombBox. 

In this case, the Categorized and Graduated widgets filter the fields to show passing only the numeric columns.
