### PR TITLE
Identify2

### DIFF
--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -311,8 +311,6 @@ QgsIdentifyResultsDialog::QgsIdentifyResultsDialog( QgsMapCanvas *canvas, QWidge
   mPlot->setSizePolicy( sizePolicy );
   mPlot->updateGeometry();
 
-  connect( buttonBox, SIGNAL( rejected() ), this, SLOT( close() ) );
-
   connect( lstResults, SIGNAL( itemExpanded( QTreeWidgetItem* ) ),
            this, SLOT( itemExpanded( QTreeWidgetItem* ) ) );
 
@@ -653,6 +651,7 @@ QgsIdentifyPlotCurve::~QgsIdentifyPlotCurve()
     delete mPlotCurve;
   }
 }
+#endif
 
 void QgsIdentifyResultsDialog::addFeature( QgsRasterLayer *layer,
     QString label,
@@ -1030,7 +1029,6 @@ void QgsIdentifyResultsDialog::contextMenuEvent( QContextMenuEvent* event )
 void QgsIdentifyResultsDialog::saveWindowLocation()
 {
   QSettings settings;
-  settings.setValue( "/Windows/Identify/geometry", saveGeometry() );
   // first column width
   settings.setValue( "/Windows/Identify/columnWidth", lstResults->columnWidth( 0 ) );
   settings.setValue( "/Windows/Identify/columnWidthTable", tblResults->columnWidth( 0 ) );

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -305,7 +305,7 @@ QgsIdentifyResultsDialog::QgsIdentifyResultsDialog( QgsMapCanvas *canvas, QWidge
 #if defined(QWT_VERSION) && QWT_VERSION<0x060000
   mPlot->setAutoFillBackground( false );
   mPlot->setAutoDelete( true );
-  mPlot->insertLegend( new QwtLegend(), QwtPlot::RightLegend );
+  mPlot->insertLegend( new QwtLegend(), QwtPlot::TopLegend );
   QSizePolicy sizePolicy = QSizePolicy( QSizePolicy::Expanding, QSizePolicy::Expanding );
   sizePolicy.setHorizontalStretch( 0 );
   sizePolicy.setVerticalStretch( 0 );

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -57,6 +57,8 @@
 #include <qwt_plot.h>
 #include <qwt_plot_curve.h>
 #include <qwt_symbol.h>
+#include <qwt_legend.h>
+#include "qgsvectorcolorrampv2.h" // for random colors
 #endif
 
 QgsIdentifyResultsWebView::QgsIdentifyResultsWebView( QWidget *parent ) : QWebView( parent )
@@ -303,17 +305,13 @@ QgsIdentifyResultsDialog::QgsIdentifyResultsDialog( QgsMapCanvas *canvas, QWidge
 #if defined(QWT_VERSION) && QWT_VERSION<0x060000
   mPlot->setAutoFillBackground( false );
   mPlot->setAutoDelete( true );
+  mPlot->insertLegend( new QwtLegend(), QwtPlot::RightLegend );
   QSizePolicy sizePolicy = QSizePolicy( QSizePolicy::Expanding, QSizePolicy::Expanding );
   sizePolicy.setHorizontalStretch( 0 );
   sizePolicy.setVerticalStretch( 0 );
   sizePolicy.setHeightForWidth( mPlot->sizePolicy().hasHeightForWidth() );
   mPlot->setSizePolicy( sizePolicy );
   mPlot->updateGeometry();
-
-  mPlotCurve = new QwtPlotCurve( "" );
-  mPlotCurve->setSymbol( QwtSymbol( QwtSymbol::Ellipse, QBrush( Qt::white ),
-                                    QPen( Qt::red, 2 ), QSize( 9, 9 ) ) );
-  mPlotCurve->attach( mPlot );
 #else
   delete mPlot;
   mPlot = 0;
@@ -347,7 +345,9 @@ QgsIdentifyResultsDialog::~QgsIdentifyResultsDialog()
   if ( mActionPopup )
     delete mActionPopup;
 #if defined(QWT_VERSION) && QWT_VERSION<0x060000
-  delete mPlotCurve;
+  foreach ( QgsIdentifyPlotCurve *curve, mPlotCurves )
+    delete curve;
+  mPlotCurves.clear();
 #endif
 }
 
@@ -600,6 +600,48 @@ void QgsIdentifyResultsDialog::mapLayerActionDestroyed()
   }
 }
 
+#if defined(QWT_VERSION) && QWT_VERSION<0x060000
+QgsIdentifyPlotCurve::QgsIdentifyPlotCurve( const QMap<QString, QString> &attributes,
+    QwtPlot* plot, const QString &title, QColor color )
+{
+  mPlotCurve = new QwtPlotCurve( title );
+
+  if ( color == QColor() )
+  {
+    color = QgsVectorRandomColorRampV2::randomColors( 1 )[0];
+  }
+  mPlotCurve->setSymbol( QwtSymbol( QwtSymbol::Ellipse, QBrush( Qt::white ),
+                                    QPen( color, 2 ), QSize( 9, 9 ) ) );
+
+  int i = 1;
+  for ( QMap<QString, QString>::const_iterator it = attributes.begin();
+        it != attributes.end(); ++it )
+  {
+    mPlotCurveXData.append( double( i++ ) );
+    mPlotCurveYData.append( double( it.value().toDouble() ) );
+  }
+  mPlotCurve->setData( mPlotCurveXData, mPlotCurveYData );
+
+  mPlotCurve->attach( plot );
+
+  plot->setAxisMaxMinor( QwtPlot::xBottom, 0 );
+  //mPlot->setAxisScale( QwtPlot::xBottom, 1, mPlotCurve->dataSize());
+  //mPlot->setAxisScale( QwtPlot::yLeft, ymin, ymax );
+
+  plot->replot();
+  plot->setVisible( true );
+}
+
+QgsIdentifyPlotCurve::~QgsIdentifyPlotCurve()
+{
+  if ( mPlotCurve )
+  {
+    mPlotCurve->detach();
+    delete mPlotCurve;
+  }
+}
+#endif
+
 void QgsIdentifyResultsDialog::addFeature( QgsRasterLayer *layer,
     QString label,
     const QMap<QString, QString> &attributes,
@@ -741,20 +783,10 @@ void QgsIdentifyResultsDialog::addFeature( QgsRasterLayer *layer,
 
   // graph
 #if defined(QWT_VERSION) && QWT_VERSION<0x060000
-  i = mPlotCurveXData.count();
-  for ( QMap<QString, QString>::const_iterator it = attributes.begin(); it != attributes.end(); ++it )
+  if ( attributes.count() > 0 )
   {
-    mPlotCurveXData.append( double( ++i ) );
-    mPlotCurveYData.append( double( it.value().toDouble() ) );
+    mPlotCurves.append( new QgsIdentifyPlotCurve( attributes, mPlot, layer->name() ) );
   }
-  mPlotCurve->setData( mPlotCurveXData, mPlotCurveYData );
-
-  mPlot->setAxisMaxMinor( QwtPlot::xBottom, 0 );
-  //mPlot->setAxisScale( QwtPlot::xBottom, 1, mPlotCurve->dataSize());
-  //mPlot->setAxisScale( QwtPlot::yLeft, ymin, ymax );
-
-  mPlot->replot();
-  mPlot->setVisible( mPlotCurveXData.count() > 0 );
 #endif
 }
 
@@ -1031,8 +1063,9 @@ void QgsIdentifyResultsDialog::clear()
 
 #if defined(QWT_VERSION) && QWT_VERSION<0x060000
   mPlot->setVisible( false );
-  mPlotCurveXData.clear();
-  mPlotCurveYData.clear();
+  foreach ( QgsIdentifyPlotCurve *curve, mPlotCurves )
+    delete curve;
+  mPlotCurves.clear();
 #endif
 
   // keep it visible but disabled, it can switch from disabled/enabled

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -467,6 +467,65 @@ void QgsIdentifyResultsDialog::addFeature( QgsVectorLayer *vlayer, const QgsFeat
     }
   }
 
+  // table
+  int j = tblResults->rowCount();
+  for ( int i = 0; i < attrs.count(); ++i )
+  {
+    if ( i >= fields.count() )
+      continue;
+
+    QString value = fields[i].displayString( attrs[i] );
+    QString value2 = value;
+    switch ( vlayer->editType( i ) )
+    {
+      case QgsVectorLayer::Hidden:
+        // skip the item
+        continue;
+
+      case QgsVectorLayer::ValueMap:
+        value2 = vlayer->valueMap( i ).key( value, QString( "(%1)" ).arg( value ) );
+        break;
+
+      case QgsVectorLayer::Calendar:
+        if ( attrs[i].canConvert( QVariant::Date ) )
+          value2 = attrs[i].toDate().toString( vlayer->dateFormat( i ) );
+        break;
+
+      default:
+        break;
+    }
+
+    tblResults->setRowCount( j + 1 );
+
+    QgsDebugMsg( QString( "adding item #%1 / %2 / %3 / %4" ).arg( j ).arg( vlayer->name() ).arg( vlayer->attributeDisplayName( i ) ).arg( value2 ) );
+
+    QTableWidgetItem *item = new QTableWidgetItem( vlayer->name() );
+    item->setData( Qt::UserRole, QVariant::fromValue( qobject_cast<QObject *>( vlayer ) ) );
+    tblResults->setItem( j, 0, item );
+
+    item = new QTableWidgetItem( FID_TO_STRING( f.id() ) );
+    item->setData( Qt::UserRole, FID_TO_STRING( f.id() ) );
+    item->setData( Qt::UserRole + 1, mFeatures.size() );
+    tblResults->setItem( j, 1, item );
+
+    item = new QTableWidgetItem( QString::number( i ) );
+    if ( fields[i].name() == vlayer->displayField() )
+      item->setData( Qt::DisplayRole, vlayer->attributeDisplayName( i ) + " *" );
+    else
+      item->setData( Qt::DisplayRole, vlayer->attributeDisplayName( i ) );
+    item->setData( Qt::UserRole, fields[i].name() );
+    item->setData( Qt::UserRole + 1, i );
+    tblResults->setItem( j, 2, item );
+
+    item = new QTableWidgetItem( value );
+    item->setData( Qt::UserRole, value );
+    item->setData( Qt::DisplayRole, value2 );
+    tblResults->setItem( j, 3, item );
+
+    j++;
+  }
+  tblResults->resizeColumnToContents( 1 );
+
   highlightFeature( featItem );
 }
 
@@ -591,6 +650,24 @@ void QgsIdentifyResultsDialog::addFeature( QgsRasterLayer *layer,
       derivedItem->addChild( new QTreeWidgetItem( QStringList() << it.key() << it.value() ) );
     }
   }
+
+  // table
+  int j = tblResults->rowCount();
+  tblResults->setRowCount( j + attributes.count() );
+  int i = 1;
+  for ( QMap<QString, QString>::const_iterator it = attributes.begin(); it != attributes.end(); ++it )
+  {
+    QgsDebugMsg( QString( "adding item #%1 / %1 / %2 / %3" ).arg( j ).arg( layer->name() ).arg( it.key() ).arg( it.value() ) );
+    QTableWidgetItem *item = new QTableWidgetItem( layer->name() );
+    item->setData( Qt::UserRole, QVariant::fromValue( qobject_cast<QObject *>( layer ) ) );
+    tblResults->setItem( j, 0, item );
+    tblResults->setItem( j, 1, new QTableWidgetItem( QString::number( i ) ) );
+    tblResults->setItem( j, 2, new QTableWidgetItem( it.key() ) );
+    tblResults->setItem( j, 3, new QTableWidgetItem( it.value() ) );
+    j++; i++;
+  }
+  tblResults->resizeColumnToContents( 1 );
+
 }
 
 void QgsIdentifyResultsDialog::editingToggled()
@@ -850,6 +927,9 @@ void QgsIdentifyResultsDialog::clear()
 
   lstResults->clear();
   clearHighlights();
+
+  tblResults->clearContents();
+  tblResults->setRowCount( 0 );
 
   // keep it visible but disabled, it can switch from disabled/enabled
   // after raster format change
@@ -1112,6 +1192,23 @@ void QgsIdentifyResultsDialog::layerDestroyed()
 
   disconnectLayer( theSender );
   delete layerItem( theSender );
+
+  // remove items, starting from last
+  for ( int i = tblResults->rowCount() - 1; i >= 0; i-- )
+  {
+    QgsDebugMsg( QString( "item %1 / %2" ).arg( i ).arg( tblResults->rowCount() ) );
+    QTableWidgetItem *layItem = tblResults->item( i, 0 );
+    if ( layItem && layItem->data( Qt::UserRole ).value<QObject *>() == sender() )
+    {
+      QgsDebugMsg( QString( "removing row %1" ).arg( i ) );
+      tblResults->removeRow( i );
+    }
+  }
+
+  if ( lstResults->topLevelItemCount() == 0 )
+  {
+    close();
+  }
 }
 
 void QgsIdentifyResultsDialog::disconnectLayer( QObject *layer )
@@ -1157,6 +1254,24 @@ void QgsIdentifyResultsDialog::featureDeleted( QgsFeatureId fid )
   if ( layItem->childCount() == 0 )
   {
     delete layItem;
+  }
+
+  for ( int i = tblResults->rowCount() - 1; i >= 0; i-- )
+  {
+    QgsDebugMsg( QString( "item %1 / %2" ).arg( i ).arg( tblResults->rowCount() ) );
+    QTableWidgetItem *layItem = tblResults->item( i, 0 );
+    QTableWidgetItem *featItem = tblResults->item( i, 1 );
+    if ( layItem && layItem->data( Qt::UserRole ).value<QObject *>() == sender() &&
+         featItem && STRING_TO_FID( featItem->data( Qt::UserRole ) ) == fid )
+    {
+      QgsDebugMsg( QString( "removing row %1" ).arg( i ) );
+      tblResults->removeRow( i );
+    }
+  }
+
+  if ( lstResults->topLevelItemCount() == 0 )
+  {
+    close();
   }
 }
 

--- a/src/app/qgsidentifyresultsdialog.h
+++ b/src/app/qgsidentifyresultsdialog.h
@@ -94,7 +94,6 @@ class APP_EXPORT QgsIdentifyResultsWebViewItem: public QObject, public QTreeWidg
     QgsIdentifyResultsWebView *mWebView;
 };
 
-#if defined(QWT_VERSION) && QWT_VERSION<0x060000
 class APP_EXPORT QgsIdentifyPlotCurve
 {
   public:
@@ -106,9 +105,7 @@ class APP_EXPORT QgsIdentifyPlotCurve
 
   private:
     QwtPlotCurve* mPlotCurve;
-    QVector<double> mPlotCurveXData, mPlotCurveYData;
 };
-#endif
 
 class APP_EXPORT QgsIdentifyResultsDialog: public QDialog, private Ui::QgsIdentifyResultsBase
 {
@@ -245,11 +242,7 @@ class APP_EXPORT QgsIdentifyResultsDialog: public QDialog, private Ui::QgsIdenti
 
     QDockWidget *mDock;
 
-#if defined(QWT_VERSION) && QWT_VERSION<0x060000
-    /* QwtPlotCurve* mPlotCurve; */
-    /* QVector<double> mPlotCurveXData, mPlotCurveYData; */
     QVector<QgsIdentifyPlotCurve *> mPlotCurves;
-#endif
 };
 
 class QgsIdentifyResultsDialogMapLayerAction : public QAction

--- a/src/app/qgsidentifyresultsdialog.h
+++ b/src/app/qgsidentifyresultsdialog.h
@@ -43,6 +43,8 @@ class QgsHighlight;
 class QgsMapCanvas;
 class QDockWidget;
 
+class QwtPlotCurve;
+
 /**
  *@author Gary E.Sherman
  */
@@ -226,6 +228,11 @@ class APP_EXPORT QgsIdentifyResultsDialog: public QDialog, private Ui::QgsIdenti
     void doMapLayerAction( QTreeWidgetItem *item, QgsMapLayerAction* action );
 
     QDockWidget *mDock;
+
+#if defined(QWT_VERSION) && QWT_VERSION<0x060000
+    QwtPlotCurve* mPlotCurve;
+    QVector<double> mPlotCurveXData, mPlotCurveYData;
+#endif
 };
 
 class QgsIdentifyResultsDialogMapLayerAction : public QAction

--- a/src/app/qgsidentifyresultsdialog.h
+++ b/src/app/qgsidentifyresultsdialog.h
@@ -231,6 +231,8 @@ class APP_EXPORT QgsIdentifyResultsDialog: public QDialog, private Ui::QgsIdenti
     void layerProperties( QTreeWidgetItem *object );
     void disconnectLayer( QObject *object );
 
+    void saveWindowLocation();
+
     void setColumnText( int column, const QString & label );
     void expandColumnsToFit();
 

--- a/src/app/qgsidentifyresultsdialog.h
+++ b/src/app/qgsidentifyresultsdialog.h
@@ -94,6 +94,22 @@ class APP_EXPORT QgsIdentifyResultsWebViewItem: public QObject, public QTreeWidg
     QgsIdentifyResultsWebView *mWebView;
 };
 
+#if defined(QWT_VERSION) && QWT_VERSION<0x060000
+class APP_EXPORT QgsIdentifyPlotCurve
+{
+  public:
+
+    QgsIdentifyPlotCurve() { mPlotCurve = 0; }
+    QgsIdentifyPlotCurve( const QMap<QString, QString> &attributes,
+                          QwtPlot* plot, const QString &title = QString(), QColor color = QColor() ) ;
+    ~QgsIdentifyPlotCurve();
+
+  private:
+    QwtPlotCurve* mPlotCurve;
+    QVector<double> mPlotCurveXData, mPlotCurveYData;
+};
+#endif
+
 class APP_EXPORT QgsIdentifyResultsDialog: public QDialog, private Ui::QgsIdentifyResultsBase
 {
     Q_OBJECT
@@ -230,8 +246,9 @@ class APP_EXPORT QgsIdentifyResultsDialog: public QDialog, private Ui::QgsIdenti
     QDockWidget *mDock;
 
 #if defined(QWT_VERSION) && QWT_VERSION<0x060000
-    QwtPlotCurve* mPlotCurve;
-    QVector<double> mPlotCurveXData, mPlotCurveYData;
+    /* QwtPlotCurve* mPlotCurve; */
+    /* QVector<double> mPlotCurveXData, mPlotCurveYData; */
+    QVector<QgsIdentifyPlotCurve *> mPlotCurves;
 #endif
 };
 

--- a/src/core/symbology-ng/qgsvectorcolorrampv2.cpp
+++ b/src/core/symbology-ng/qgsvectorcolorrampv2.cpp
@@ -309,26 +309,33 @@ QgsStringMap QgsVectorRandomColorRampV2::properties() const
   return map;
 }
 
-void QgsVectorRandomColorRampV2::updateColors()
+QList<QColor> QgsVectorRandomColorRampV2::randomColors( int count,
+    int hueMax, int hueMin, int satMax, int satMin, int valMax, int valMin )
 {
   int h, s, v;
+  QList<QColor> colors;
 
-  mColors.clear();
   //start hue at random angle
   double currentHueAngle = 360.0 * ( double )rand() / RAND_MAX;
 
-  for ( int i = 0; i < mCount; i++ )
+  for ( int i = 0; i < count; i++ )
   {
     //increment hue by golden ratio (approx 137.507 degrees)
     //as this minimises hue nearness as count increases
     //see http://basecase.org/env/on-rainbows for more details
     currentHueAngle += 137.50776;
-    //scale hue to between mHueMax and mHueMin
-    h = ( fmod( currentHueAngle, 360.0 ) / 360.0 ) * ( mHueMax - mHueMin ) + mHueMin;
-    s = ( rand() % ( mSatMax - mSatMin + 1 ) ) + mSatMin;
-    v = ( rand() % ( mValMax - mValMin + 1 ) ) + mValMin;
-    mColors.append( QColor::fromHsv( h, s, v ) );
+    //scale hue to between hueMax and hueMin
+    h = ( fmod( currentHueAngle, 360.0 ) / 360.0 ) * ( hueMax - hueMin ) + hueMin;
+    s = ( rand() % ( satMax - satMin + 1 ) ) + satMin;
+    v = ( rand() % ( valMax - valMin + 1 ) ) + valMin;
+    colors.append( QColor::fromHsv( h, s, v ) );
   }
+  return colors;
+}
+
+void QgsVectorRandomColorRampV2::updateColors()
+{
+  mColors = QgsVectorRandomColorRampV2::randomColors( mCount, mHueMax, mHueMin, mSatMax, mSatMin, mValMax, mValMin );
 }
 
 /////////////

--- a/src/core/symbology-ng/qgsvectorcolorrampv2.h
+++ b/src/core/symbology-ng/qgsvectorcolorrampv2.h
@@ -131,6 +131,12 @@ class CORE_EXPORT QgsVectorRandomColorRampV2 : public QgsVectorColorRampV2
 
     virtual QgsStringMap properties() const;
 
+    /** get a list of random colors
+    * @note added in 2.4 */
+    static QList<QColor> randomColors( int count,
+                                       int hueMax = DEFAULT_RANDOM_HUE_MAX, int hueMin = DEFAULT_RANDOM_HUE_MIN,
+                                       int satMax = DEFAULT_RANDOM_SAT_MAX, int satMin = DEFAULT_RANDOM_SAT_MIN,
+                                       int valMax = DEFAULT_RANDOM_VAL_MAX, int valMin = DEFAULT_RANDOM_VAL_MIN );
     void updateColors();
 
     int count() const { return mCount; }

--- a/src/ui/qgsidentifyresultsbase.ui
+++ b/src/ui/qgsidentifyresultsbase.ui
@@ -18,21 +18,88 @@
     <number>2</number>
    </property>
    <item>
-    <widget class="QTreeWidget" name="lstResults">
-     <property name="lineWidth">
-      <number>2</number>
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex">
+      <number>0</number>
      </property>
-     <property name="alternatingRowColors">
-      <bool>true</bool>
-     </property>
-     <property name="sortingEnabled">
-      <bool>true</bool>
-     </property>
-     <column>
-      <property name="text">
-       <string notr="true">1</string>
-      </property>
-     </column>
+     <widget class="QWidget" name="tab">
+      <attribute name="title">
+       <string>Tree</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <property name="spacing">
+        <number>0</number>
+       </property>
+       <property name="margin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QTreeWidget" name="lstResults">
+         <property name="lineWidth">
+          <number>2</number>
+         </property>
+         <property name="alternatingRowColors">
+          <bool>true</bool>
+         </property>
+         <property name="sortingEnabled">
+          <bool>true</bool>
+         </property>
+         <column>
+          <property name="text">
+           <string notr="true">1</string>
+          </property>
+         </column>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tab_2">
+      <attribute name="title">
+       <string>Table</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <property name="spacing">
+        <number>0</number>
+       </property>
+       <property name="margin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QTableWidget" name="tblResults">
+         <column>
+          <property name="text">
+           <string>Layer</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>FID</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Attribute</string>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Value</string>
+          </property>
+         </column>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tab_3">
+      <attribute name="title">
+       <string>Graph</string>
+      </attribute>
+      <layout class="QVBoxLayout" name="verticalLayout_3">
+       <item>
+        <widget class="QwtPlot" name="mPlot"/>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
    <item>
@@ -212,6 +279,14 @@
   </layout>
  </widget>
  <layoutdefault spacing="6" margin="11"/>
+ <customwidgets>
+  <customwidget>
+   <class>QwtPlot</class>
+   <extends>QFrame</extends>
+   <header>qwt_plot.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
  <resources>
   <include location="../../images/images.qrc"/>
  </resources>


### PR DESCRIPTION
This adds most features of the Identify Tool plugin to the main Identify map tool

please add your comments/suggestions

a tab widget allows to see the data in one of 3 ways

Tree, as previously
Table, a table view of Vector and Raster layers (Layer, FID, Attribute, Value)
Graph which shows a plot of raster layers, very basic for now (virtually identical to the plugin) and only qwt5 for now

this replaces a previous pull request, which contains some screenshots and a short discussion with @3nids and @NathanW2

https://github.com/qgis/QGIS/pull/1293

https://cloud.githubusercontent.com/assets/1018556/2625666/16a1700e-bda4-11e3-8340-d757f37cb874.jpg
https://cloud.githubusercontent.com/assets/1018556/2625664/169fc2ae-bda4-11e3-9d79-6dc72eb37770.jpg
https://cloud.githubusercontent.com/assets/1018556/2626299/5748a202-bdc8-11e3-9867-e6aaeaac7575.jpg
