### PR TITLE
removed limitation to accept an empty QgsGeometry() in changeGeometryValues

### DIFF
--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -2180,7 +2180,6 @@ bool QgsPostgresProvider::changeGeometryValues( QgsGeometryMap & geometry_map )
       if ( !iter->asWkb() )
       {
         QgsDebugMsg( "empty geometry" );
-        continue;
       }
 
       QgsDebugMsg( "iterating over feature id " + FID_TO_STRING( iter.key() ) );

--- a/src/providers/spatialite/qgsspatialiteprovider.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovider.cpp
@@ -3982,7 +3982,8 @@ bool QgsSpatiaLiteProvider::changeGeometryValues( QgsGeometryMap & geometry_map 
   for ( QgsGeometryMap::iterator iter = geometry_map.begin(); iter != geometry_map.end(); ++iter )
   {
     // looping on each feature to change
-    if ( iter->asWkb() )
+    // empty QgsGeometry has asWkb == NULL. It's not a Geos Empty Geometry
+    if ( iter->asWkb() or iter->asWkb() == NULL )
     {
 
       // resetting Prepared Statement and bindings

--- a/src/providers/spatialite/qgsspatialiteprovider.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovider.cpp
@@ -3983,7 +3983,7 @@ bool QgsSpatiaLiteProvider::changeGeometryValues( QgsGeometryMap & geometry_map 
   {
     // looping on each feature to change
     // empty QgsGeometry has asWkb == NULL. It's not a Geos Empty Geometry
-    if ( iter->asWkb() or iter->asWkb() == NULL )
+    if ( iter->asWkb() || iter->asWkb() == NULL )
     {
 
       // resetting Prepared Statement and bindings


### PR DESCRIPTION
due to bug:
https://hub.qgis.org/issues/10216
changed Spatialite and Postgres provider to avoid skipping empty QgsGeometry() geometries.

Tested and works as expected setting Geometry to NULL
