### PR TITLE
Split line feature with a single point when snapped to a line

### DIFF
--- a/src/app/qgsmaptoolsplitfeatures.cpp
+++ b/src/app/qgsmaptoolsplitfeatures.cpp
@@ -58,10 +58,10 @@ void QgsMapToolSplitFeatures::canvasReleaseEvent( QMouseEvent * e )
   {
     QList<QgsSnappingResult> snapResults;
 
-    //If we snap the first point on a line layer, we directly split the feature at this point
+    //If we snap the first point on a vertex of a line layer, we directly split the feature at this point
     if ( vlayer->geometryType() == QGis::Line && points().isEmpty() )
     {
-      if ( mSnapper.snapToBackgroundLayers( e->pos(), snapResults ) == 0 )
+      if ( mSnapper.snapToCurrentLayer( e->pos(), snapResults, QgsSnapper::SnapToVertex ) == 0 )
       {
         if ( snapResults.size() > 0 )
         {

--- a/src/app/qgsmaptoolsplitfeatures.cpp
+++ b/src/app/qgsmaptoolsplitfeatures.cpp
@@ -50,9 +50,26 @@ void QgsMapToolSplitFeatures::canvasReleaseEvent( QMouseEvent * e )
     return;
   }
 
+  bool split = false;
+
+
   //add point to list and to rubber band
   if ( e->button() == Qt::LeftButton )
   {
+    QList<QgsSnappingResult> snapResults;
+
+    //If we snap the first point on a line layer, we directly split the feature at this point
+    if ( vlayer->geometryType() == QGis::Line && points().isEmpty() )
+    {
+      if ( mSnapper.snapToBackgroundLayers( e->pos(), snapResults ) == 0 )
+      {
+        if ( snapResults.size() > 0 )
+        {
+          split = true;
+        }
+      }
+    }
+
     int error = addVertex( e->pos() );
     if ( error == 1 )
     {
@@ -73,6 +90,11 @@ void QgsMapToolSplitFeatures::canvasReleaseEvent( QMouseEvent * e )
     startCapturing();
   }
   else if ( e->button() == Qt::RightButton )
+  {
+    split = true;
+  }
+
+  if ( split )
   {
     deleteTempRubberBand();
 

--- a/src/app/qgsmaptoolsplitparts.cpp
+++ b/src/app/qgsmaptoolsplitparts.cpp
@@ -56,10 +56,10 @@ void QgsMapToolSplitParts::canvasReleaseEvent( QMouseEvent * e )
   {
     QList<QgsSnappingResult> snapResults;
 
-    //If we snap the first point on a line layer, we directly split the feature at this point
+    //If we snap the first point on a vertex of a line layer, we directly split the feature at this point
     if ( vlayer->geometryType() == QGis::Line && points().isEmpty() )
     {
-      if ( mSnapper.snapToBackgroundLayers( e->pos(), snapResults ) == 0 )
+      if ( mSnapper.snapToCurrentLayer( e->pos(), snapResults, QgsSnapper::SnapToVertex ) == 0 )
       {
         if ( snapResults.size() > 0 )
         {

--- a/src/app/qgsmaptoolsplitparts.cpp
+++ b/src/app/qgsmaptoolsplitparts.cpp
@@ -49,9 +49,25 @@ void QgsMapToolSplitParts::canvasReleaseEvent( QMouseEvent * e )
     return;
   }
 
+  bool split = false;
+
   //add point to list and to rubber band
   if ( e->button() == Qt::LeftButton )
   {
+    QList<QgsSnappingResult> snapResults;
+
+    //If we snap the first point on a line layer, we directly split the feature at this point
+    if ( vlayer->geometryType() == QGis::Line && points().isEmpty() )
+    {
+      if ( mSnapper.snapToBackgroundLayers( e->pos(), snapResults ) == 0 )
+      {
+        if ( snapResults.size() > 0 )
+        {
+          split = true;
+        }
+      }
+    }
+
     int error = addVertex( e->pos() );
     if ( error == 1 )
     {
@@ -72,6 +88,10 @@ void QgsMapToolSplitParts::canvasReleaseEvent( QMouseEvent * e )
     startCapturing();
   }
   else if ( e->button() == Qt::RightButton )
+  {
+    split = true;
+  }
+  if ( split )
   {
     deleteTempRubberBand();
 

--- a/src/core/qgsgeometry.cpp
+++ b/src/core/qgsgeometry.cpp
@@ -4596,67 +4596,15 @@ GEOSGeometry* QgsGeometry::linePointDifference( GEOSGeometry* GEOSsplitPoint )
     line = multiLine[i];
     //For each segment
     newline = QgsPolyline();
-    for ( int j = 1; j < line.size() ; ++j )
+    newline.append(line[0]);
+    for ( int j = 1; j < line.size()-1 ; ++j )
     {
-      p1 = line[j-1];
-      p2 = line[j];
-      g = QgsGeometry::fromPolyline( QgsPolyline() << p1 << p2 );
-      QgsDebugMsg( g->exportToWkt() );
-      QgsDebugMsg( splitPoint.toString() );
-
-      newline.append( p1 );
-
-      double x1 = p1.x();
-      double y1 = p1.y();
-      double x2 = p2.x();
-      double y2 = p2.y();
-      double xt = splitPoint.x();
-      double yt = splitPoint.y();
-      double k;
-      double diff;
-      if ( x2 == x1 )
+      newline.append( line[j] );
+      if ( line[j] == splitPoint )
       {
-        if ( y2 == y1 )
-        {
-          k = -1;
-          diff = 1e50;
-        }
-        else
-        {
-          k = ( yt - y1 ) / ( y2 - y1 );
-          diff = k * ( x2 - x1 ) - ( xt - x1 );
-        }
-      }
-      else
-      {
-        k = ( xt - x1 ) / ( x2 - x1 );
-        diff = k * ( y2 - y1 ) - ( yt - y1 );
-      }
-      if ( abs( diff ) < 1e-7 )
-      {
-        if ( k == 0 )
-        {
-          lines.append( newline );
-          newline = QgsPolyline();
-          newline.append( p1 );
-        }
-        if ( k == 1 )
-        {
-          newline.append( p2 );
-          lines.append( newline );
-          newline = QgsPolyline();
-        }
-        if ( k > 0 && k < 1 )
-        {
-          newline.append( splitPoint );
-          lines.append( newline );
-          newline = QgsPolyline();
-          newline.append( splitPoint );
-        }
-        if ( k < 0 || k > 1 )
-        {
-          //Nothing happens, we are on the line but not the segment
-        }
+        lines.append( newline );
+        newline = QgsPolyline();
+        newline.append( line[j] );
       }
     }
     newline.append( line.last() );

--- a/src/core/qgsgeometry.h
+++ b/src/core/qgsgeometry.h
@@ -562,6 +562,9 @@ class CORE_EXPORT QgsGeometry
     /**Splits polygon/multipolygon geometries
        @return 0 in case of success, 1 if geometry has not been split, error else*/
     int splitPolygonGeometry( GEOSGeometry *splitLine, QList<QgsGeometry*>& newGeometries );
+    /**Splits line/multiline geometries following a single point*/
+    GEOSGeometry* linePointDifference( GEOSGeometry* GEOSsplitPoint );
+
     /**Finds out the points that need to be tested for topological correctnes if this geometry will be split
      @return 0 in case of success*/
     int topologicalTestPointsSplit( const GEOSGeometry* splitLine, QList<QgsPoint>& testPoints ) const;

--- a/src/core/qgsvectorlayereditutils.cpp
+++ b/src/core/qgsvectorlayereditutils.cpp
@@ -232,7 +232,11 @@ int QgsVectorLayerEditUtils::splitFeatures( const QList<QgsPoint>& splitLine, bo
       }
       else
       {
-        return 2;
+        //If we have a single point, we still create a non-null box
+        bBox.setXMinimum( bBox.xMinimum() - 1 );
+        bBox.setXMaximum( bBox.xMaximum() + 1 );
+        bBox.setYMinimum( bBox.yMinimum() - 1 );
+        bBox.setYMaximum( bBox.yMaximum() + 1 );
       }
     }
 
@@ -362,7 +366,11 @@ int QgsVectorLayerEditUtils::splitParts( const QList<QgsPoint>& splitLine, bool 
       }
       else
       {
-        return 2;
+        //If we have a single point, we still create a non-null box
+        bBox.setXMinimum( bBox.xMinimum() - 1 );
+        bBox.setXMaximum( bBox.xMaximum() + 1 );
+        bBox.setYMinimum( bBox.yMinimum() - 1 );
+        bBox.setYMaximum( bBox.yMaximum() + 1 );
       }
     }
 

--- a/src/core/qgsvectorlayereditutils.cpp
+++ b/src/core/qgsvectorlayereditutils.cpp
@@ -233,10 +233,13 @@ int QgsVectorLayerEditUtils::splitFeatures( const QList<QgsPoint>& splitLine, bo
       else
       {
         //If we have a single point, we still create a non-null box
-        bBox.setXMinimum( bBox.xMinimum() - 1 );
-        bBox.setXMaximum( bBox.xMaximum() + 1 );
-        bBox.setYMinimum( bBox.yMinimum() - 1 );
-        bBox.setYMaximum( bBox.yMaximum() + 1 );
+        double bufferDistance = 0.000001;
+        if ( L->crs().geographicFlag() )
+          bufferDistance = 0.00000001;
+        bBox.setXMinimum( bBox.xMinimum() - bufferDistance );
+        bBox.setXMaximum( bBox.xMaximum() + bufferDistance );
+        bBox.setYMinimum( bBox.yMinimum() - bufferDistance );
+        bBox.setYMaximum( bBox.yMaximum() + bufferDistance );
       }
     }
 
@@ -367,10 +370,13 @@ int QgsVectorLayerEditUtils::splitParts( const QList<QgsPoint>& splitLine, bool 
       else
       {
         //If we have a single point, we still create a non-null box
-        bBox.setXMinimum( bBox.xMinimum() - 1 );
-        bBox.setXMaximum( bBox.xMaximum() + 1 );
-        bBox.setYMinimum( bBox.yMinimum() - 1 );
-        bBox.setYMaximum( bBox.yMaximum() + 1 );
+        double bufferDistance = 0.000001;
+        if ( L->crs().geographicFlag() )
+          bufferDistance = 0.00000001;
+        bBox.setXMinimum( bBox.xMinimum() - bufferDistance );
+        bBox.setXMaximum( bBox.xMaximum() + bufferDistance );
+        bBox.setYMinimum( bBox.yMinimum() - bufferDistance );
+        bBox.setYMaximum( bBox.yMaximum() + bufferDistance );
       }
     }
 


### PR DESCRIPTION
Hi,

When splitting a feature (either with split parts or split features), it is currently necessary to draw a line crossing the line feature, which takes three clicks. In addition, one very common use case is to want to split the line at a precise point (maybe marked by an intersection, by a node in another layer, etc.). In that case, another click is necessary, which is very heavy when this operation has to be done repeatedly : 
- Start the line
- Snap to the point
- Add another node
- Right click to finish the line

I would like to be able to split a line at a given point by just clicking on it. This pull request does just that, but uses a few quick hacks that have to be improved:
- GEOSDifference does not work with a point and a line, so I wrote a linePointDifference function to do just that, but it is very "manual" and can surely be improved. Any better existing function or algorithm to implement ?
- A bounding box is currently used to find the relevant features in qgsvectorlayereditutils.cpp, but a single point will not give a bounding box. I gave the box an arbitrary size, but I am sure there are a few case where this is a poor solution.

Do you think such a line splitting at snapped point would be useful? If so, how could I solve these two issues? Any other problem I didn't think about?
