### PR TITLE
[FEATURE] Add right click menu to color buttons

### DIFF
--- a/python/core/symbology-ng/qgssymbollayerv2utils.sip
+++ b/python/core/symbology-ng/qgssymbollayerv2utils.sip
@@ -189,8 +189,24 @@ class QgsSymbolLayerV2Utils
     static QgsVectorColorRampV2* loadColorRamp( QDomElement& element ) /Factory/;
     static QDomElement saveColorRamp( QString name, QgsVectorColorRampV2* ramp, QDomDocument& doc );
 
-    /**  parse color definition with format "rgb(0,0,0)" or "0,0,0" */
+    /**
+     * Attempts to parse a string as a color using a variety of common formats, including hex
+     * codes, rgb and rgba strings.
+     * @param colorStr string representing the color
+     * @returns parsed color
+     * @note added in 2.3
+     */
     static QColor parseColor( QString colorStr );
+
+    /**
+     * Attempts to parse a string as a color using a variety of common formats, including hex
+     * codes, rgb and rgba strings.
+     * @param colorStr string representing the color
+     * @param containsAlpha if colorStr contains an explicit alpha value then containsAlpha will be set to true
+     * @returns parsed color
+     * @note added in 2.3
+     */
+    static QColor parseColorWithAlpha( const QString colorStr, bool &containsAlpha );
 
     /**Returns the line width scale factor depending on the unit and the paint device*/
     static double lineWidthScaleFactor( const QgsRenderContext& c, QgsSymbolV2::OutputUnit u, const QgsMapUnitScale& scale = QgsMapUnitScale() );

--- a/python/gui/qgscolorbutton.sip
+++ b/python/gui/qgscolorbutton.sip
@@ -111,4 +111,9 @@ class QgsColorButton: QPushButton
     void changeEvent( QEvent* e );
     void showEvent( QShowEvent* e );
     static const QPixmap& transpBkgrd();
+    
+    /**
+     * Reimplemented to detect right mouse button clicks on the color button.
+     */
+    void mousePressEvent( QMouseEvent* e );
 };

--- a/src/core/symbology-ng/qgssymbollayerv2utils.h
+++ b/src/core/symbology-ng/qgssymbollayerv2utils.h
@@ -225,8 +225,24 @@ class CORE_EXPORT QgsSymbolLayerV2Utils
     static QgsVectorColorRampV2* loadColorRamp( QDomElement& element );
     static QDomElement saveColorRamp( QString name, QgsVectorColorRampV2* ramp, QDomDocument& doc );
 
-    /**  parse color definition with format "rgb(0,0,0)" or "0,0,0" */
+    /**
+     * Attempts to parse a string as a color using a variety of common formats, including hex
+     * codes, rgb and rgba strings.
+     * @param colorStr string representing the color
+     * @returns parsed color
+     * @note added in 2.3
+     */
     static QColor parseColor( QString colorStr );
+
+    /**
+     * Attempts to parse a string as a color using a variety of common formats, including hex
+     * codes, rgb and rgba strings.
+     * @param colorStr string representing the color
+     * @param containsAlpha if colorStr contains an explicit alpha value then containsAlpha will be set to true
+     * @returns parsed color
+     * @note added in 2.3
+     */
+    static QColor parseColorWithAlpha( const QString colorStr, bool &containsAlpha );
 
     /**Returns the line width scale factor depending on the unit and the paint device*/
     static double lineWidthScaleFactor( const QgsRenderContext& c, QgsSymbolV2::OutputUnit u, const QgsMapUnitScale& scale = QgsMapUnitScale() );

--- a/src/gui/qgscolorbutton.h
+++ b/src/gui/qgscolorbutton.h
@@ -134,6 +134,11 @@ class GUI_EXPORT QgsColorButton: public QPushButton
     void showEvent( QShowEvent* e );
     static const QPixmap& transpBkgrd();
 
+    /**
+     * Reimplemented to detect right mouse button clicks on the color button.
+     */
+    void mousePressEvent( QMouseEvent* e );
+
   private:
     QString mColorDialogTitle;
     QColor mColor;
@@ -141,6 +146,11 @@ class GUI_EXPORT QgsColorButton: public QPushButton
     bool mAcceptLiveUpdates;
     QTemporaryFile mTempPNG;
     bool mColorSet; // added in QGIS 2.1
+
+    /**
+     * Shows the color button context menu and handles copying and pasting color values.
+     */
+    void showContextMenu( QMouseEvent* event );
 
   private slots:
     void onButtonClicked();

--- a/tests/src/core/testqgsstylev2.cpp
+++ b/tests/src/core/testqgsstylev2.cpp
@@ -54,6 +54,7 @@ class TestStyleV2: public QObject
     void testCreateColorRamps();
     void testLoadColorRamps();
     void testSaveLoad();
+    void testParseColor();
 };
 
 
@@ -211,6 +212,76 @@ void TestStyleV2::testSaveLoad()
   }
   // test content again
   testLoadColorRamps();
+}
+
+void TestStyleV2::testParseColor()
+{
+  // values for color tests
+  QMap< QString, QPair< QColor, bool> > colorTests;
+  colorTests.insert( "bad color", qMakePair( QColor( ), false ) );
+  colorTests.insert( "red", qMakePair( QColor( 255, 0, 0 ), false ) );
+  colorTests.insert( "#ff00ff", qMakePair( QColor( 255, 0, 255 ), false ) );
+  colorTests.insert( "#99AA00", qMakePair( QColor( 153, 170, 0 ), false ) );
+  colorTests.insert( "#GG0000", qMakePair( QColor(), false ) );
+  colorTests.insert( "000000", qMakePair( QColor( 0, 0, 0 ), false ) );
+  colorTests.insert( "00ff00", qMakePair( QColor( 0, 255, 0 ), false ) );
+  colorTests.insert( "00gg00", qMakePair( QColor( ), false ) );
+  colorTests.insert( "00ff000", qMakePair( QColor(), false ) );
+  colorTests.insert( "fff", qMakePair( QColor( 255, 255, 255 ), false ) );
+  colorTests.insert( "fff0", qMakePair( QColor(), false ) );
+  colorTests.insert( "0,0,0", qMakePair( QColor( 0, 0, 0 ), false ) );
+  colorTests.insert( "127,60,0", qMakePair( QColor( 127, 60, 0 ), false ) );
+  colorTests.insert( "255,255,255", qMakePair( QColor( 255, 255, 255 ), false ) );
+  colorTests.insert( "256,60,0", qMakePair( QColor(), false ) );
+  colorTests.insert( "rgb(127,60,0)", qMakePair( QColor( 127, 60, 0 ), false ) );
+  colorTests.insert( "rgb(255,255,255)", qMakePair( QColor( 255, 255, 255 ), false ) );
+  colorTests.insert( "rgb(256,60,0)", qMakePair( QColor(), false ) );
+  colorTests.insert( " rgb(  127, 60 ,  0 ) ", qMakePair( QColor( 127, 60, 0 ), false ) );
+  colorTests.insert( "rgb(127,60,0);", qMakePair( QColor( 127, 60, 0 ), false ) );
+  colorTests.insert( "(127,60,0);", qMakePair( QColor( 127, 60, 0 ), false ) );
+  colorTests.insert( "(127,60,0)", qMakePair( QColor( 127, 60, 0 ), false ) );
+  colorTests.insert( "127,060,000", qMakePair( QColor( 127, 60, 0 ), false ) );
+  colorTests.insert( "0,0,0,0", qMakePair( QColor( 0, 0, 0, 0 ), true ) );
+  colorTests.insert( "127,60,0,0.5", qMakePair( QColor( 127, 60, 0, 128 ), true ) );
+  colorTests.insert( "255,255,255,0.1", qMakePair( QColor( 255, 255, 255, 26 ), true ) );
+  colorTests.insert( "rgba(127,60,0,1.0)", qMakePair( QColor( 127, 60, 0, 255 ), true ) );
+  colorTests.insert( "rgba(255,255,255,0.0)", qMakePair( QColor( 255, 255, 255, 0 ), true ) );
+  colorTests.insert( " rgba(  127, 60 ,  0  , 0.2 ) ", qMakePair( QColor( 127, 60, 0, 51 ), true ) );
+  colorTests.insert( "rgba(127,60,0,0.1);", qMakePair( QColor( 127, 60, 0, 26 ), true ) );
+  colorTests.insert( "(127,60,0,1);", qMakePair( QColor( 127, 60, 0, 255 ), true ) );
+  colorTests.insert( "(127,60,0,1.0)", qMakePair( QColor( 127, 60, 0, 255 ), true ) );
+  colorTests.insert( "127,060,000,1", qMakePair( QColor( 127, 60, 0, 255 ), true ) );
+  colorTests.insert( "0%,0%,0%", qMakePair( QColor( 0, 0, 0 ), false ) );
+  colorTests.insert( "50 %,60 %,0 %", qMakePair( QColor( 127, 153, 0 ), false ) );
+  colorTests.insert( "100%, 100%, 100%", qMakePair( QColor( 255, 255, 255 ), false ) );
+  colorTests.insert( "rgb(50%,60%,0%)", qMakePair( QColor( 127, 153, 0 ), false ) );
+  colorTests.insert( "rgb(100%, 100%, 100%)", qMakePair( QColor( 255, 255, 255 ), false ) );
+  colorTests.insert( " rgb(  50 % , 60 % ,  0  % ) ", qMakePair( QColor( 127, 153, 0 ), false ) );
+  colorTests.insert( "rgb(50%,60%,0%);", qMakePair( QColor( 127, 153, 0 ), false ) );
+  colorTests.insert( "(50%,60%,0%);", qMakePair( QColor( 127, 153, 0 ), false ) );
+  colorTests.insert( "(50%,60%,0%)", qMakePair( QColor( 127, 153, 0 ), false ) );
+  colorTests.insert( "050%,060%,000%", qMakePair( QColor( 127, 153, 0 ), false ) );
+  colorTests.insert( "0%,0%,0%,0", qMakePair( QColor( 0, 0, 0, 0 ), true ) );
+  colorTests.insert( "50 %,60 %,0 %,0.5", qMakePair( QColor( 127, 153, 0, 128 ), true ) );
+  colorTests.insert( "100%, 100%, 100%, 1.0", qMakePair( QColor( 255, 255, 255, 255 ), true ) );
+  colorTests.insert( "rgba(50%,60%,0%, 1.0)", qMakePair( QColor( 127, 153, 0, 255 ), true ) );
+  colorTests.insert( "rgba(100%, 100%, 100%, 0.0)", qMakePair( QColor( 255, 255, 255, 0 ), true ) );
+  colorTests.insert( " rgba(  50 % , 60 % ,  0  %, 0.5 ) ", qMakePair( QColor( 127, 153, 0, 128 ), true ) );
+  colorTests.insert( "rgba(50%,60%,0%,0);", qMakePair( QColor( 127, 153, 0, 0 ), true ) );
+  colorTests.insert( "(50%,60%,0%,1);", qMakePair( QColor( 127, 153, 0, 255 ), true ) );
+  colorTests.insert( "(50%,60%,0%,1.0)", qMakePair( QColor( 127, 153, 0, 255 ), true ) );
+  colorTests.insert( "050%,060%,000%,0", qMakePair( QColor( 127, 153, 0, 0 ), true ) );
+
+  QMap<QString, QPair< QColor, bool> >::const_iterator i = colorTests.constBegin();
+  while ( i != colorTests.constEnd() )
+  {
+    QgsDebugMsg( "color string: " +  i.key() );
+    bool hasAlpha = false;
+    QColor result = QgsSymbolLayerV2Utils::parseColorWithAlpha( i.key(), hasAlpha );
+    QVERIFY( result == i.value().first );
+    QVERIFY( hasAlpha == i.value().second );
+    ++i;
+  }
 }
 
 


### PR DESCRIPTION
Allows copying and pasting colors. Pasting colors accepts clipboard text in a variety of common formats, including named colors, hex values, and css style rgb and rgba strings.
