### PR TITLE
Python snippets can be evaluated to return objects

### DIFF
--- a/python/core/qgspythonrunner.sip
+++ b/python/core/qgspythonrunner.sip
@@ -28,4 +28,6 @@ class QgsPythonRunner
     virtual bool runCommand( QString command, QString messageOnError = QString() ) = 0;
 
     virtual bool evalCommand( QString command, QString& result ) = 0;
+
+    virtual void* evalToObject( const QString& command, const QString& siptype ) = 0;
 };

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -7266,6 +7266,15 @@ class QgsPythonRunnerImpl : public QgsPythonRunner
       return false;
     }
 
+    virtual void* evalToObject( const QString &command, const QString &siptype )
+    {
+      if ( mPythonUtils && mPythonUtils->isEnabled() )
+      {
+        return mPythonUtils->evalToObject( command, siptype );
+      }
+      return 0;
+    }
+
   protected:
     QgsPythonUtils* mPythonUtils;
 };

--- a/src/core/qgspythonrunner.cpp
+++ b/src/core/qgspythonrunner.cpp
@@ -58,6 +58,19 @@ void QgsPythonRunner::setInstance( QgsPythonRunner* runner )
   mInstance = runner;
 }
 
+void* QgsPythonRunner::evalToObjectHelper( const QString& command, const QString& siptype )
+{
+  if ( mInstance )
+  {
+    return mInstance->evalToObject( command, siptype );
+  }
+  else
+  {
+    QgsDebugMsg( "Unable to run Python command: runner not available!" );
+    return 0;
+  }
+}
+
 ///////////////////////////
 // non-static methods
 

--- a/src/core/qgspythonrunner.h
+++ b/src/core/qgspythonrunner.h
@@ -16,12 +16,13 @@
 #define QGSPYTHONRUNNER_H
 
 #include <QString>
+#include <typeinfo>
 
 /**
   Utility class for running python commands from various parts of QGIS.
   There is no direct python support in the core library, so it is expected
   that application with python support creates a subclass that implements
-  pure virtual function(s) during the initialization. The static methods
+  pure virtual functions during the initialization. The static methods
   will then work as expected.
 
   Added in QGIS v?
@@ -40,12 +41,20 @@ class CORE_EXPORT QgsPythonRunner
     /** Eval a python statement */
     static bool eval( QString command, QString& result );
 
+    template <typename T>
+    static T evalToSipObject( const QString& command, const QString& siptype )
+    {
+      return static_cast<T>( evalToObjectHelper( command, siptype ) );
+    }
+
     /** assign an instance of python runner so that run() can be used.
       This method should be called during app initialization.
       Takes ownership of the object, deletes previous instance. */
     static void setInstance( QgsPythonRunner* runner );
 
   protected:
+    static void* evalToObjectHelper( const QString& command, const QString& siptype );
+
     /** protected constructor: can be instantiated only from children */
     QgsPythonRunner();
     virtual ~QgsPythonRunner();
@@ -53,6 +62,8 @@ class CORE_EXPORT QgsPythonRunner
     virtual bool runCommand( QString command, QString messageOnError = QString() ) = 0;
 
     virtual bool evalCommand( QString command, QString& result ) = 0;
+
+    virtual void* evalToObject( const QString& command, const QString& siptype ) = 0;
 
     static QgsPythonRunner* mInstance;
 };

--- a/src/python/qgspythonutils.h
+++ b/src/python/qgspythonutils.h
@@ -59,6 +59,8 @@ class PYTHON_EXPORT QgsPythonUtils
 
     virtual bool evalString( const QString& command, QString& result ) = 0;
 
+    virtual void* evalToObject( const QString& command, const QString& siptype ) = 0;
+
     //! get information about error to the supplied arguments
     //! @return false if there was no python error
     virtual bool getError( QString& errorClassName, QString& errorText ) = 0;

--- a/src/python/qgspythonutilsimpl.cpp
+++ b/src/python/qgspythonutilsimpl.cpp
@@ -33,6 +33,43 @@
 #include <QStringList>
 #include <QDir>
 
+
+#include <sip.h>
+
+
+const sipAPIDef* get_sip_api()
+{
+#if defined(SIP_USE_PYCAPSULE)
+  return ( const sipAPIDef * )PyCapsule_Import( "sip._C_API", 0 );
+#else
+  PyObject *sip_module;
+  PyObject *sip_module_dict;
+  PyObject *c_api;
+
+  /* Import the SIP module. */
+  sip_module = PyImport_ImportModule( "sip" );
+
+  if ( sip_module == NULL )
+    return NULL;
+
+  /* Get the module's dictionary. */
+  sip_module_dict = PyModule_GetDict( sip_module );
+
+  /* Get the "_C_API" attribute. */
+  c_api = PyDict_GetItemString( sip_module_dict, "_C_API" );
+
+  if ( c_api == NULL )
+    return NULL;
+
+  /* Sanity check that it is the right type. */
+  if ( !PyCObject_Check( c_api ) )
+    return NULL;
+
+  /* Get the actual pointer from the object. */
+  return ( const sipAPIDef * )PyCObject_AsVoidPtr( c_api );
+#endif
+}
+
 PyThreadState* _mainState;
 
 QgsPythonUtilsImpl::QgsPythonUtilsImpl()
@@ -480,6 +517,52 @@ bool QgsPythonUtilsImpl::evalString( const QString& command, QString& result )
   PyGILState_Release( gstate );
 
   return success;
+}
+
+void* QgsPythonUtilsImpl::evalToObject( const QString& command, const QString& siptype )
+{
+  void* result;
+
+  // acquire global interpreter lock to ensure we are in a consistent state
+  PyGILState_STATE gstate;
+  gstate = PyGILState_Ensure();
+
+  PyObject* pyObj = PyRun_String( command.toUtf8().data(), Py_eval_input, mMainDict, mMainDict );
+
+  if ( !pyObj )
+  {
+    // TODO: use python implementation
+
+    QString traceback = getTraceback();
+    QString path, version;
+    evalString( "str(sys.path)", path );
+    evalString( "sys.version", version );
+
+    QString str = "<font color=\"red\">Error</font><br><pre>\n" + traceback + "\n</pre>"
+                  + QObject::tr( "Python version:" ) + "<br>" + version + "<br><br>"
+                  + QObject::tr( "QGIS version:" ) + "<br>" + QString( "%1 '%2', %3" ).arg( QGis::QGIS_VERSION ).arg( QGis::QGIS_RELEASE_NAME ).arg( QGis::QGIS_DEV_VERSION ) + "<br><br>"
+                  + QObject::tr( "Python path:" ) + "<br>" + path;
+    str.replace( "\n", "<br>" ).replace( "  ", "&nbsp; " );
+
+    QgsMessageOutput* msg = QgsMessageOutput::createMessageOutput();
+    msg->setTitle( QObject::tr( "Python error" ) );
+    msg->setMessage( str, QgsMessageOutput::MessageHtml );
+    msg->showMessage();
+  }
+
+  const sipAPIDef* sipAPI_core = get_sip_api();
+  const sipTypeDef* td = sipAPI_core->api_find_type( siptype.toUtf8().data() );
+
+  Q_ASSERT( td );
+
+  int state = 0;
+  int iserr = 0;
+  result = sipAPI_core->api_convert_to_type( pyObj, td, 0, 0, &state, &iserr );
+
+  // we are done calling python API, release global interpreter lock
+  PyGILState_Release( gstate );
+
+  return result;
 }
 
 QString QgsPythonUtilsImpl::pythonPath()

--- a/src/python/qgspythonutilsimpl.h
+++ b/src/python/qgspythonutilsimpl.h
@@ -60,6 +60,8 @@ class QgsPythonUtilsImpl : public QgsPythonUtils
 
     bool evalString( const QString& command, QString& result );
 
+    void* evalToObject( const QString& command, const QString& siptype );
+
     //! @return object's type name as a string
     QString getTypeAsString( PyObject* obj );
 


### PR DESCRIPTION
This commit enables python snippets to return objects which can then be used in C++.

As an example, this can be useful to let the user implement an object that implements a virtual interface and use this from the main application. An example for this idea can be found here: http://nathanw.net/2011/09/05/qgis-tips-custom-feature-forms-with-python-logic/#comment-777590042

In particular, I plan to implement this for python form logic. Instead of disconnecting and reconnecting buttonbox signals and dialog slots, a method like `virtual bool acceptChanges()` can be implemented in a sip/python subclass.

The code proposed in this PR is highly experimental.
- Only very basic error checking is done
- Ownership is always transferred to C++
- API documentation comments are missing

However, any comment on the idea is appreciated.
