### PR TITLE
db manager: fix connection holding - idle in transaction (QGIS bug #7162...

### DIFF
--- a/python/plugins/db_manager/db_plugins/postgis/connector.py
+++ b/python/plugins/db_manager/db_plugins/postgis/connector.py
@@ -53,6 +53,7 @@ class PostGisDBConnector(DBConnector):
 
 		try:
 			self.connection = psycopg2.connect( self._connectionInfo().encode('utf-8') )
+			self.connection.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
 		except self.connection_error_types(), e:
 			raise ConnectionError(e)
 
@@ -751,13 +752,9 @@ class PostGisDBConnector(DBConnector):
 
 	def runVacuumAnalyze(self, table):
 		""" run vacuum analyze on a table """
-		# vacuum analyze must be run outside transaction block - we have to change isolation level
-		self.connection.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_AUTOCOMMIT)
 		sql = u"VACUUM ANALYZE %s" % self.quoteId(table)
 		c = self._execute(None, sql)
 		self._commit()
-		self.connection.set_isolation_level(psycopg2.extensions.ISOLATION_LEVEL_READ_COMMITTED)
-
 
 	def addTableColumn(self, table, field_def):
 		""" add a column to table """

--- a/python/plugins/db_manager/db_plugins/postgis/data_model.py
+++ b/python/plugins/db_manager/db_plugins/postgis/data_model.py
@@ -43,8 +43,7 @@ class PGTableDataModel(TableDataModel):
 		fields_txt = u", ".join(self.fields)
 		table_txt = self.db.quoteId( (self.table.schemaName(), self.table.name) )
 
-		# create named cursor and run query
-		self.cursor = self.db._get_cursor(self.table.name)
+		self.cursor = self.db._get_cursor()
 		sql = u"SELECT %s FROM %s" % (fields_txt, table_txt)
 		self.db._execute(self.cursor, sql)
 


### PR DESCRIPTION
Fix to ticket #7679 .

Here is a working patch which will fix connection holding issue by setting DB Manager connection to AUTOCOMMIT isolation level (which is better practice). I have removed named cursor usage in PGTableDataModel._createCursor to fix problems when running with AUTOCOMMIT.
