### PR TITLE
db manager: fixed quoting of table name when schema is empty string

### DIFF
--- a/python/plugins/db_manager/db_plugins/connector.py
+++ b/python/plugins/db_manager/db_plugins/connector.py
@@ -183,7 +183,7 @@ class DBConnector:
 		if hasattr(identifier, '__iter__'):
 			ids = list()
 			for i in identifier:
-				if i == None:
+				if i == None or i == "":
 					continue
 				ids.append( self.quoteId(i) )
 			return u'.'.join( ids )


### PR DESCRIPTION
This pull request is fixing SQL command crashing when spatial index is created with no schema name in "Import vector layer" dialog.
