### PR TITLE
use QgsFieldExpressionWidget in data defined properties

### DIFF
--- a/src/gui/symbology-ng/qgsdatadefinedsymboldialog.cpp
+++ b/src/gui/symbology-ng/qgsdatadefinedsymboldialog.cpp
@@ -1,10 +1,11 @@
 #include "qgsdatadefinedsymboldialog.h"
 #include "qgsexpressionbuilderdialog.h"
+#include "qgsfieldexpressionwidget.h"
 #include "qgsvectorlayer.h"
 #include "qgslogger.h"
+
 #include <QCheckBox>
-#include <QComboBox>
-#include <QPushButton>
+
 
 QgsDataDefinedSymbolDialog::QgsDataDefinedSymbolDialog( const QList< DataDefinedSymbolEntry >& entries, const QgsVectorLayer* vl, QWidget * parent, Qt::WindowFlags f )
     : QDialog( parent, f )
@@ -18,56 +19,33 @@ QgsDataDefinedSymbolDialog::QgsDataDefinedSymbolDialog( const QList< DataDefined
     attributeFields = mVectorLayer->pendingFields();
   }
 
-  mTableWidget->setRowCount( entries.size() );
-
   int i = 0;
   QList< DataDefinedSymbolEntry >::const_iterator entryIt = entries.constBegin();
   for ( ; entryIt != entries.constEnd(); ++entryIt )
   {
+    QTreeWidgetItem* item = new QTreeWidgetItem( mTreeWidget );
+
     //check box
-    QCheckBox* cb = new QCheckBox( this );
+    QCheckBox* cb = new QCheckBox( entryIt->title, this );
     cb->setChecked( !entryIt->initialValue.isEmpty() );
-    mTableWidget->setCellWidget( i, 0, cb );
-    mTableWidget->setColumnWidth( 0, cb->width() );
+    item->setData( 0, Qt::UserRole, entryIt->property );
+    mTreeWidget->setItemWidget( item, 0, cb );
 
-
-    //property name
-    QTableWidgetItem* propertyItem = new QTableWidgetItem( entryIt->title );
-    propertyItem->setData( Qt::UserRole, entryIt->property );
-    mTableWidget->setItem( i, 1, propertyItem );
-
-    //attribute list
-    QString expressionString = entryIt->initialValue;
-    QComboBox* attributeComboBox = new QComboBox( this );
-    attributeComboBox->addItem( QString() );
-    for ( int j = 0; j < attributeFields.count(); ++j )
-    {
-      attributeComboBox->addItem( attributeFields.at( j ).name() );
-    }
-
-    int attrComboIndex = comboIndexForExpressionString( expressionString, attributeComboBox );
-    if ( attrComboIndex >= 0 )
-    {
-      attributeComboBox->setCurrentIndex( attrComboIndex );
-    }
-    else
-    {
-      attributeComboBox->setItemText( 0, expressionString );
-    }
-
-    mTableWidget->setCellWidget( i, 2, attributeComboBox );
-
-    //expression button
-    QPushButton* expressionButton = new QPushButton( "...", this );
-    QObject::connect( expressionButton, SIGNAL( clicked() ), this, SLOT( expressionButtonClicked() ) );
-    mTableWidget->setCellWidget( i, 3, expressionButton );
+    // expression
+    QgsFieldExpressionWidget* few = new QgsFieldExpressionWidget( this );
+    few->setLayer( const_cast<QgsVectorLayer*>( vl ) );
+    few->setField( entryIt->initialValue );
+    mTreeWidget->setItemWidget( item, 1, few );
 
     //help text
-    QTableWidgetItem* helpItem = new QTableWidgetItem( entryIt->helpText );
-    mTableWidget->setItem( i, 4, helpItem );
+    item->setText( 2, entryIt->helpText );
 
+    mTreeWidget->addTopLevelItem( item );
     ++i;
   }
+
+  for ( int c = 0; c != mTreeWidget->columnCount() - 1; c++ )
+    mTreeWidget->resizeColumnToContents( c );
 }
 
 QgsDataDefinedSymbolDialog::~QgsDataDefinedSymbolDialog()
@@ -78,14 +56,15 @@ QgsDataDefinedSymbolDialog::~QgsDataDefinedSymbolDialog()
 QMap< QString, QString > QgsDataDefinedSymbolDialog::dataDefinedProperties() const
 {
   QMap< QString, QString > propertyMap;
-  int rowCount = mTableWidget->rowCount();
+  int rowCount = mTreeWidget->topLevelItemCount();
   for ( int i = 0; i < rowCount; ++i )
   {
+    QTreeWidgetItem* item = mTreeWidget->topLevelItem( i );
     //property
-    QString propertyKey = mTableWidget->item( i, 1 )->data( Qt::UserRole ).toString();
+    QString propertyKey = item->data( 0, Qt::UserRole ).toString();
     //checked?
     bool checked = false;
-    QCheckBox* cb = qobject_cast<QCheckBox*>( mTableWidget->cellWidget( i, 0 ) );
+    QCheckBox* cb = qobject_cast<QCheckBox*>( mTreeWidget->itemWidget( item, 0 ) );
     if ( cb )
     {
       checked = cb->isChecked();
@@ -93,78 +72,12 @@ QMap< QString, QString > QgsDataDefinedSymbolDialog::dataDefinedProperties() con
     QString expressionString;
     if ( checked )
     {
-      QComboBox* comboBox = qobject_cast<QComboBox*>( mTableWidget->cellWidget( i, 2 ) );
-      expressionString = comboBox->currentText();
-      if ( comboBox->currentIndex() > 0 )
-      {
-        expressionString.prepend( "\"" ).append( "\"" );
-      }
+      QgsFieldExpressionWidget* few = qobject_cast<QgsFieldExpressionWidget*>( mTreeWidget->itemWidget( item, 1 ) );
+      expressionString = few->currentField();
     }
     propertyMap.insert( propertyKey, expressionString );
   }
   return propertyMap;
-}
-
-void QgsDataDefinedSymbolDialog::expressionButtonClicked()
-{
-  QgsDebugMsg( "Expression button clicked" );
-
-  //find out row
-  QObject* senderObj = sender();
-  int row = 0;
-  for ( ; row < mTableWidget->rowCount(); ++row )
-  {
-    if ( senderObj == mTableWidget->cellWidget( row, 3 ) )
-    {
-      break;
-    }
-  }
-
-  QComboBox* attributeCombo = qobject_cast<QComboBox*>( mTableWidget->cellWidget( row, 2 ) );
-  if ( !attributeCombo )
-  {
-    return;
-  }
-
-  QString previousText = attributeCombo->itemText( attributeCombo->currentIndex() );
-  if ( attributeCombo->currentIndex() > 0 )
-  {
-    previousText.prepend( "\"" ).append( "\"" );
-  }
-
-  QgsExpressionBuilderDialog d( const_cast<QgsVectorLayer*>( mVectorLayer ), previousText );
-  if ( d.exec() == QDialog::Accepted )
-  {
-    QString expressionString = d.expressionText();
-    int comboIndex = comboIndexForExpressionString( d.expressionText(), attributeCombo );
-
-    if ( comboIndex == -1 )
-    {
-      attributeCombo->setItemText( 0, d.expressionText() );
-      attributeCombo->setCurrentIndex( 0 );
-      Q_ASSERT( d.expressionText() == attributeCombo->currentText() );
-    }
-    else
-    {
-      if ( comboIndex != 0 )
-      {
-        attributeCombo->setItemText( 0, QString() );
-      }
-      attributeCombo->setCurrentIndex( comboIndex );
-    }
-  }
-}
-
-int QgsDataDefinedSymbolDialog::comboIndexForExpressionString( const QString& expr, const QComboBox* cb )
-{
-  QString attributeString = expr.trimmed();
-  int comboIndex = cb->findText( attributeString );
-  if ( comboIndex == -1 && attributeString.startsWith( '"' ) && attributeString.endsWith( '"' ) )
-  {
-    attributeString.remove( 0, 1 ).chop( 1 );
-    comboIndex = cb->findText( attributeString );
-  }
-  return comboIndex;
 }
 
 QString QgsDataDefinedSymbolDialog::doubleHelpText()

--- a/src/gui/symbology-ng/qgsdatadefinedsymboldialog.h
+++ b/src/gui/symbology-ng/qgsdatadefinedsymboldialog.h
@@ -40,15 +40,8 @@ class GUI_EXPORT QgsDataDefinedSymbolDialog: public QDialog, private Ui::QgsData
     static QString gradientSpreadHelpText();
     static QString boolHelpText();
 
-  private slots:
-    void expressionButtonClicked();
-
   private:
     const QgsVectorLayer* mVectorLayer;
-
-    /**Tries to fiend a combo box field for an expression string (considering whitespaces, brackets around attribute names)
-        @return index or -1 in case not found*/
-    int comboIndexForExpressionString( const QString& expr, const QComboBox* cb );
 };
 
 #endif // QGSDATADEFINEDSYMBOLLAYERDIALOG_H

--- a/src/gui/symbology-ng/qgssymbollayerv2widget.cpp
+++ b/src/gui/symbology-ng/qgssymbollayerv2widget.cpp
@@ -513,7 +513,7 @@ void QgsSimpleMarkerSymbolLayerV2Widget::on_mDataDefinedPropertiesButton_clicked
 
   QList< QgsDataDefinedSymbolDialog::DataDefinedSymbolEntry > dataDefinedProperties;
   dataDefinedProperties << QgsDataDefinedSymbolDialog::DataDefinedSymbolEntry( "name", tr( "Name" ), mLayer->dataDefinedPropertyString( "name" ),
-      "'square'|'rectangle'|'diamond'|'pentagon'\n|'triangle'|'equilateral_triangle'|'star'\n|'regular_star'|'arrow'|'filled_arrowhead'|'circle'\n|'cross'|'x'|'cross2'|'line'|'arrowhead'" );
+      "'square'|'rectangle'|'diamond'|'pentagon'|'triangle'|'equilateral_triangle'|'star'|'regular_star'|'arrow'|'filled_arrowhead'|'circle'|'cross'|'x'|'cross2'|'line'|'arrowhead'" );
   dataDefinedProperties << QgsDataDefinedSymbolDialog::DataDefinedSymbolEntry( "color", tr( "Fill color" ), mLayer->dataDefinedPropertyString( "color" ),
       QgsDataDefinedSymbolDialog::colorHelpText() );
   dataDefinedProperties << QgsDataDefinedSymbolDialog::DataDefinedSymbolEntry( "color_border", tr( "Border color" ), mLayer->dataDefinedPropertyString( "color_border" ),

--- a/src/ui/qgsdatadefinedsymboldialogbase.ui
+++ b/src/ui/qgsdatadefinedsymboldialogbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>409</width>
-    <height>299</height>
+    <width>439</width>
+    <height>320</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -37,59 +37,44 @@
     </widget>
    </item>
    <item row="0" column="0">
-    <widget class="QTableWidget" name="mTableWidget">
+    <widget class="QTreeWidget" name="mTreeWidget">
      <property name="frameShape">
       <enum>QFrame::NoFrame</enum>
+     </property>
+     <property name="alternatingRowColors">
+      <bool>true</bool>
      </property>
      <property name="selectionMode">
       <enum>QAbstractItemView::NoSelection</enum>
      </property>
-     <property name="showGrid">
-      <bool>false</bool>
-     </property>
-     <property name="gridStyle">
-      <enum>Qt::NoPen</enum>
-     </property>
-     <attribute name="horizontalHeaderVisible">
+     <property name="wordWrap">
       <bool>true</bool>
+     </property>
+     <attribute name="headerMinimumSectionSize">
+      <number>10</number>
      </attribute>
-     <attribute name="horizontalHeaderHighlightSections">
-      <bool>false</bool>
-     </attribute>
-     <attribute name="verticalHeaderVisible">
-      <bool>false</bool>
-     </attribute>
-     <attribute name="verticalHeaderHighlightSections">
-      <bool>false</bool>
-     </attribute>
-     <row>
-      <property name="text">
-       <string>New Row</string>
-      </property>
-     </row>
-     <column>
-      <property name="text">
-       <string/>
-      </property>
-     </column>
      <column>
       <property name="text">
        <string>Property</string>
       </property>
-     </column>
-     <column>
-      <property name="text">
-       <string>Field</string>
+      <property name="textAlignment">
+       <set>AlignHCenter|AlignVCenter|AlignCenter</set>
       </property>
      </column>
      <column>
       <property name="text">
        <string>Expression</string>
       </property>
+      <property name="textAlignment">
+       <set>AlignHCenter|AlignVCenter|AlignCenter</set>
+      </property>
      </column>
      <column>
       <property name="text">
        <string>Help</string>
+      </property>
+      <property name="textAlignment">
+       <set>AlignHCenter|AlignVCenter|AlignCenter</set>
       </property>
      </column>
     </widget>


### PR DESCRIPTION
This uses the new field expression widget in data defined properties for a better UI coherence.
I had to const_cast QgsVectorLayer because QgsDataDefinedSymbolDialog uses a const layer pointer.
BTW, this fixes the fact that the help for the name symbol was not fully readable (was multiline).

@mhugent since you designed, can you tell me if it's ok for you?

new dialog:
![image](https://cloud.githubusercontent.com/assets/127259/2981110/6fe0d5e6-dbff-11e3-838f-8ad7a7b701f0.png)

old dialog:
![image](https://cloud.githubusercontent.com/assets/127259/2981097/3b527d20-dbff-11e3-98a3-02287f154b64.png)
