### PR TITLE
Check snapping tolerance of both layers before validating intersection snapping

### DIFF
--- a/src/gui/qgsmapcanvassnapper.cpp
+++ b/src/gui/qgsmapcanvassnapper.cpp
@@ -304,8 +304,27 @@ int QgsMapCanvasSnapper::snapToBackgroundLayers( const QPoint& p, QList<QgsSnapp
       QgsGeometry* intersectionPoint = lineA->intersection( lineB );
       if ( intersectionPoint->type()  == QGis::Point )
       {
-        iSegIt->snappedVertex = intersectionPoint->asPoint();
-        myResults.append( *iSegIt );
+        //We have to check the intersection point is inside the tolerance distance for both layers
+        double toleranceA, toleranceB;
+        for ( int i = 0 ;i < snapLayers.size();++i )
+        {
+          if ( snapLayers[i].mLayer == oSegIt->layer )
+          {
+            toleranceA = QgsTolerance::toleranceInMapUnits( snapLayers[i].mTolerance, snapLayers[i].mLayer, mMapCanvas->mapSettings(), snapLayers[i].mUnitType );
+          }
+          if ( snapLayers[i].mLayer == iSegIt->layer )
+          {
+            toleranceB = QgsTolerance::toleranceInMapUnits( snapLayers[i].mTolerance, snapLayers[i].mLayer, mMapCanvas->mapSettings(), snapLayers[i].mUnitType );
+          }
+        }
+        QgsPoint point = mMapCanvas->getCoordinateTransform()->toMapCoordinates( p );
+        QgsGeometry* cursorPoint = QgsGeometry::fromPoint( point );
+        double distance = intersectionPoint->distance( *cursorPoint );
+        if ( distance < toleranceA && distance < toleranceB )
+        {
+          iSegIt->snappedVertex = intersectionPoint->asPoint();
+          myResults.append( *iSegIt );
+        }
       }
     }
   }


### PR DESCRIPTION
Currently, when searching for intersection snapping, there is no check on the distance. If the angle between the two segment is small, they can both be within the snapping tolerance but intersect very far from the mouse: 
![snapping_intersection](https://cloud.githubusercontent.com/assets/537624/2983303/730a9186-dc21-11e3-92ff-c6f00d912095.png)

When this intersection point is outside the screen, it can be very confusing for the user.

With this pull request, once the intersection point is found, it is checked according the snapping tolerance of the layer of both segments and only accepted if it is within both.
