### PR TITLE
WMS GetLegendGrapics: with LAYERFONTSIZE and ITEMFONTSIZE equal to 0, the labels should not be drawn.

### DIFF
--- a/src/mapserver/qgswmsserver.h
+++ b/src/mapserver/qgswmsserver.h
@@ -153,6 +153,10 @@ class QgsWMSServer
                                const QFont& layerFont, const QFont& itemFont, const QColor& layerFontColor, const QColor& itemFontColor,
                                double& maxTextWidth, double& maxSymbolWidth );
 
+    // speficy if layer or item text should be drawn in the legend (for GetLegendGraphics request)
+    bool drawLayer;
+    bool drawItem;
+
     //helper functions for GetLegendGraphics
     /**Draws layer item and subitems
        @param p painter if the item should be drawn, if 0 the size parameters are calculated only


### PR DESCRIPTION
As subject, for the WMS request GetLegendGrapics:
 if I set LAYERFONTSIZE and ITEMFONTSIZE to 0, the labels should not be drawn.

Useful for Qgis Web Client, you can get the graphic of the symbol and put it in the layer tree (in the left panel) without labels, since there is already the layer name in the layer tree.
