### PR TITLE
Fix malloc-ed memory freed by delete[]

### DIFF
--- a/src/core/qgsmaptopixelgeometrysimplifier.cpp
+++ b/src/core/qgsmaptopixelgeometrysimplifier.cpp
@@ -392,7 +392,7 @@ bool QgsMapToPixelSimplifier::simplifyGeometry( QgsGeometry* geometry, int simpl
   // Simplify the geometry rewriting temporally its WKB-stream for saving calloc's.
   if ( simplifyWkbGeometry( simplifyFlags, wkbType, wkb, wkbSize, wkb, targetWkbSize, envelope, tolerance ) )
   {
-    unsigned char* targetWkb = ( unsigned char* )malloc( targetWkbSize );
+    unsigned char* targetWkb = new unsigned char[targetWkbSize];
     memcpy( targetWkb, wkb, targetWkbSize );
     geometry->fromWkb( targetWkb, targetWkbSize );
     return true;


### PR DESCRIPTION
Some memory which later is deleted via `delete[]` is allocated via `malloc`, whereas it should be allocated via `new[]`. This patch fixes this. Found via gcc address sanitizer:
# 

```
==8350==ERROR: AddressSanitizer: alloc-dealloc-mismatch (malloc vs operator delete []) on 0x617000e65180
    #0 0x7ffff6f55b5f in operator delete[](void*) (/lib64/libasan.so.1+0x58b5f)
    #1 0x7ffff2da6d45 in QgsGeometry::~QgsGeometry() (/home/sandro/Documents/Devel/QGIS/qgis-master/build/output/lib/libqgis_core.so.2.3.0+0x4c3d45)
    #2 0x7ffff2d9b78b in QgsFeature::setGeometry(QgsGeometry*) (/home/sandro/Documents/Devel/QGIS/qgis-master/build/output/lib/libqgis_core.so.2.3.0+0x4b878b)
[...]

0x617000e65180 is located 0 bytes inside of 653-byte region [0x617000e65180,0x617000e6540d)
allocated by thread T3 (Thread (pooled)) here:
    #0 0x7ffff6f54b97 in malloc (/lib64/libasan.so.1+0x57b97)
    #1 0x7ffff2e391c6 in QgsMapToPixelSimplifier::simplifyGeometry(QgsGeometry*, int, double) (/home/sandro/Documents/Devel/QGIS/qgis-master/build/output/lib/libqgis_core.so.2.3.0+0x5561c6)
    #2 0x7ffff2e39444 in QgsMapToPixelSimplifier::simplifyGeometry(QgsGeometry*) const (/home/sandro/Documents/Devel/QGIS/qgis-master/build/output/lib/libqgis_core.so.2.3.0+0x556444)
[....]

SUMMARY: AddressSanitizer: alloc-dealloc-mismatch ??:0 operator delete[](void*)
==8350==HINT: if you don't care about these warnings you may set ASAN_OPTIONS=alloc_dealloc_mismatch=0
==8350==ABORTING
```
