### PR TITLE
Avoid memcpy on overlapping memory

### DIFF
--- a/src/core/qgsmaptopixelgeometrysimplifier.cpp
+++ b/src/core/qgsmaptopixelgeometrysimplifier.cpp
@@ -163,7 +163,7 @@ bool QgsMapToPixelSimplifier::simplifyWkbGeometry( int simplifyFlags, QGis::WkbT
   // Write the main header of the geometry
   if ( writeHeader )
   {
-    memcpy( targetWkb, sourceWkb, 1 ); // byteOrder
+    targetWkb[0] = sourceWkb[0]; // byteOrder
     sourceWkb += 1;
     targetWkb += 1;
 


### PR DESCRIPTION
At `qgsmaptopixelgeometrysimplifier.cpp:393`, `QgsMapToPixelSimplifier::simplifyWkbGeometry` is called with the same pointer for `sourceWkb` and `targetWkb`, resulting in a memcpy on overlapping memory. This patch replaces the memcpy of one byte with a simple assignment.

Found by valgrind:

```
==25755== Thread 4 Thread (pooled):
==25755== Source and destination overlap in memcpy(0x1ffb0430, 0x1ffb0430, 1)
==25755==    at 0x4C3013D: memcpy@@GLIBC_2.14 (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==25755==    by 0x8AFB49A: QgsMapToPixelSimplifier::simplifyWkbGeometry(int, QGis::WkbType, unsigned char*, unsigned long, unsigned char*, unsigned long&, QgsRectangle const&, double, bool, bool) (qgsmaptopixelgeometrysimplifier.cpp:166)
==25755==    by 0x8AFC1CA: QgsMapToPixelSimplifier::simplifyGeometry(QgsGeometry*, int, double) (qgsmaptopixelgeometrysimplifier.cpp:393)
==25755==    by 0x8AFC283: QgsMapToPixelSimplifier::simplifyGeometry(QgsGeometry*) const (qgsmaptopixelgeometrysimplifier.cpp:406)
==25755==    by 0x8A8FE99: QgsAbstractFeatureIterator::simplify(QgsFeature&) (qgsfeatureiterator.cpp:136)
==25755==    by 0x8A8FB03: QgsAbstractFeatureIterator::nextFeature(QgsFeature&) (qgsfeatureiterator.cpp:59)
==25755==    by 0x5FF0A5: QgsFeatureIterator::nextFeature(QgsFeature&) (qgsfeatureiterator.h:196)
==25755==    by 0x8BEB4E7: QgsVectorLayerFeatureIterator::fetchFeature(QgsFeature&) (qgsvectorlayerfeatureiterator.cpp:199)
==25755==    by 0x8A8FAB5: QgsAbstractFeatureIterator::nextFeature(QgsFeature&) (qgsfeatureiterator.cpp:51)
==25755==    by 0x5FF0A5: QgsFeatureIterator::nextFeature(QgsFeature&) (qgsfeatureiterator.h:196)
==25755==    by 0x8941A72: QgsVectorLayerRenderer::drawRendererV2(QgsFeatureIterator&) (qgsvectorlayerrenderer.cpp:214)
==25755==    by 0x89412BF: QgsVectorLayerRenderer::render() (qgsvectorlayerrenderer.cpp:181)
==25755== 
```
