### PR TITLE
Allow the definition of public interfaces for plugins

### DIFF
--- a/python/core/core.sip
+++ b/python/core/core.sip
@@ -63,6 +63,7 @@
 %Include qgsowsconnection.sip
 %Include qgspaintenginehack.sip
 %Include qgspallabeling.sip
+%Include qgsplugininterface.sip
 %Include qgspluginlayer.sip
 %Include qgspluginlayerregistry.sip
 %Include qgspoint.sip

--- a/python/core/qgsplugininterface.sip
+++ b/python/core/qgsplugininterface.sip
@@ -1,0 +1,25 @@
+/***************************************************************************
+    qgsplugininterface.sip
+     --------------------------------------
+    Date                 : 21.8.2013
+    Copyright            : (C) 2013 Matthias Kuhn
+    Email                : matthias dot kuhn at gmx dot ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+class QgsPluginInterface : QObject
+{
+%TypeHeaderCode
+#include "qgsplugininterface.h"
+%End
+
+  // Should only be instantiated from subclasses
+  private:
+    QgsPluginInterface();
+};

--- a/python/gui/qgisinterface.sip
+++ b/python/gui/qgisinterface.sip
@@ -32,9 +32,7 @@ class QgisInterface : QObject
 
     virtual QgsPluginManagerInterface* pluginManagerInterface() = 0;
 
-  public slots: // TODO: do these functions really need to be slots?
-
-    /* Exposed functions */
+    virtual QgsPluginInterface* pluginInterface( const QString& pluginName ) = 0;
 
     //! Zoom to full extent of map layers
     virtual void zoomFull() = 0;

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2158,6 +2158,16 @@ QgsPluginManager *QgisApp::pluginManager()
   return mPluginManager;
 }
 
+QgsPluginInterface* QgisApp::pluginInterface( const QString& pluginName )
+{
+  QgisPlugin* plugin = QgsPluginRegistry::instance()->plugin( pluginName );
+  if ( plugin )
+  {
+    return plugin->pluginInterface();
+  }
+  return NULL;
+}
+
 QgsMapCanvas *QgisApp::mapCanvas()
 {
   Q_ASSERT( mMapCanvas );

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -56,6 +56,7 @@ class QgsMapTool;
 class QgsPoint;
 class QgsProviderRegistry;
 class QgsPythonUtils;
+class QgsPluginInterface;
 class QgsRectangle;
 class QgsUndoWidget;
 class QgsVectorLayer;
@@ -435,6 +436,8 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     //! returns pointer to plugin manager
     QgsPluginManager *pluginManager();
+
+    QgsPluginInterface* pluginInterface( const QString& pluginName );
 
     /** Return vector layers in edit mode
      * @param modified whether to return only layers that have been modified

--- a/src/app/qgisappinterface.cpp
+++ b/src/app/qgisappinterface.cpp
@@ -640,3 +640,9 @@ int QgisAppInterface::messageTimeout()
 {
   return qgis->messageTimeout();
 }
+
+QgsPluginInterface* QgisAppInterface::pluginInterface( const QString& pluginName )
+{
+  return qgis->pluginInterface( pluginName );
+}
+

--- a/src/app/qgisappinterface.h
+++ b/src/app/qgisappinterface.h
@@ -48,6 +48,8 @@ class APP_EXPORT QgisAppInterface : public QgisInterface
 
     QgsPluginManagerInterface* pluginManagerInterface();
 
+    QgsPluginInterface* pluginInterface( const QString& pluginName );
+
     /* Exposed functions */
 
     //! Zoom map to full extent

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -334,6 +334,7 @@ SET(QGIS_CORE_MOC_HDRS
   qgscredentials.h
   qgspluginlayer.h
   qgsproject.h
+  qgsplugininterface.h
   qgsrunprocess.h
   qgsrelationmanager.h
   qgsvectorlayer.h
@@ -456,6 +457,7 @@ SET(QGIS_CORE_HDRS
   qgspluginlayerregistry.h
   qgspoint.h
   qgsproject.h
+  qgsplugininterface.h
   qgsprojectfiletransform.h
   qgsprojectproperty.h
   qgsprojectversion.h

--- a/src/core/qgsplugininterface.h
+++ b/src/core/qgsplugininterface.h
@@ -1,0 +1,29 @@
+/***************************************************************************
+    qgsplugininterface.h
+     --------------------------------------
+    Date                 : 21.8.2013
+    Copyright            : (C) 2013 Matthias Kuhn
+    Email                : matthias dot kuhn at gmx dot ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSPLUGININTERFACE_H
+#define QGSPLUGININTERFACE_H
+
+#include <QObject>
+
+class QgsPluginInterface : public QObject
+{
+    Q_OBJECT
+
+  public:
+    QgsPluginInterface() : QObject() {}
+};
+
+#endif // QGSPLUGININTERFACE_H

--- a/src/gui/qgisinterface.h
+++ b/src/gui/qgisinterface.h
@@ -19,21 +19,23 @@
 #define QGISINTERFACE_H
 
 class QAction;
-class QMenu;
-class QToolBar;
 class QDockWidget;
 class QMainWindow;
+class QMenu;
+class QToolBar;
 class QWidget;
 
 class QgsComposerView;
-class QgsMapLayer;
+class QgsFeature;
+class QgsLegendInterface;
 class QgsMapCanvas;
+class QgsMapLayer;
+class QgsMapLayerPropertiesFactory;
+class QgsMessageBar;
+class QgsPluginInterface;
+class QgsPluginManagerInterface;
 class QgsRasterLayer;
 class QgsVectorLayer;
-class QgsLegendInterface;
-class QgsPluginManagerInterface;
-class QgsFeature;
-class QgsMessageBar;
 class QgsVectorLayerTools;
 
 #include <QObject>
@@ -75,7 +77,7 @@ class GUI_EXPORT QgisInterface : public QObject
 
     virtual QgsPluginManagerInterface* pluginManagerInterface() = 0;
 
-  public slots: // TODO: do these functions really need to be slots?
+    virtual QgsPluginInterface* pluginInterface( const QString& pluginName ) = 0;
 
     /* Exposed functions */
 

--- a/src/plugins/globe/CMakeLists.txt
+++ b/src/plugins/globe/CMakeLists.txt
@@ -20,6 +20,7 @@ SET (globe_plugin_SRCS
      globe_plugin.cpp
      qgsosgearthtilesource.cpp
      globe_plugin_dialog.cpp
+     qgsglobeinterface.cpp
 )
 IF (NOT HAVE_OSGEARTHQT)
     SET(globe_plugin_SRCS
@@ -36,12 +37,36 @@ SET (globe_plugin_UIS
 SET (globe_plugin_MOC_HDRS
      globe_plugin.h
      globe_plugin_dialog.h
+     qgsglobeinterface.h
 )
 
 SET (globe_plugin_RCCS  globe_plugin.qrc)
 
+SET (GLOBE_PLUGIN_HDRS
+     qgsosgearthtilesource.h
+     qgsosgearthfeaturesource.h
+     qgsosgearthfeatureoptions.h
+
+     qgsglobefeatureutils.h
+     qgsglobeinterface.h
+     qgsglobestyleutils.h
+     qgsglobelayerpropertiesfactory.h
+     qgsglobevectorlayerpropertiespage.h
+     qgsglobevectorlayerconfig.h
+)
+
+SET (GLOBE_PLUGIN_RCCS  globe_plugin.qrc)
+
 ########################################################
 # Build
+
+ADD_DEFINITIONS("-DGLOBE_EXPORT=")
+
+IF(WIN32)
+  IF(MSVC)
+    ADD_DEFINITIONS("-DGLOBE_EXPORT=${DLLEXPORT}")
+  ENDIF(MSVC)
+ENDIF(WIN32)
 
 QT4_WRAP_UI (globe_plugin_UIS_H  ${globe_plugin_UIS})
 
@@ -49,13 +74,14 @@ QT4_WRAP_CPP (globe_plugin_MOC_SRCS  ${globe_plugin_MOC_HDRS})
 
 QT4_ADD_RESOURCES(globe_plugin_RCC_SRCS ${globe_plugin_RCCS})
 
-ADD_LIBRARY (globeplugin MODULE ${globe_plugin_SRCS} ${globe_plugin_MOC_SRCS} ${globe_plugin_RCC_SRCS} ${globe_plugin_UIS_H})
+ADD_LIBRARY (globeplugin SHARED ${globe_plugin_SRCS} ${globe_plugin_MOC_SRCS} ${globe_plugin_RCC_SRCS} ${globe_plugin_UIS_H})
 
 INCLUDE_DIRECTORIES(
      ${CMAKE_CURRENT_BINARY_DIR}
      ${OSGEARTH_INCLUDE_DIR}
      ${OSG_INCLUDE_DIR}
      ${GEOS_INCLUDE_DIR}
+     ${SIP_INCLUDE_DIR}
      ../../core ../../core/raster
      ../../gui
      ..
@@ -86,6 +112,7 @@ TARGET_LINK_LIBRARIES(globeplugin
   ${OPENTHREADS_LIBRARY}
 )
 
+ADD_SUBDIRECTORY(python)
 
 ########################################################
 # Install

--- a/src/plugins/globe/globe_plugin.cpp
+++ b/src/plugins/globe/globe_plugin.cpp
@@ -128,6 +128,7 @@ GlobePlugin::GlobePlugin( QgisInterface* theQgisInterface )
     , mTileSource( 0 )
     , mElevationManager( 0 )
     , mObjectPlacer( 0 )
+    , mGlobeInterface( this )
 {
   mIsGlobeRunning = false;
   //needed to be "seen" by other plugins by doing
@@ -161,6 +162,11 @@ GlobePlugin::GlobePlugin( QgisInterface* theQgisInterface )
 //destructor
 GlobePlugin::~GlobePlugin()
 {
+}
+
+QgsPluginInterface* GlobePlugin::pluginInterface()
+{
+  return &mGlobeInterface;
 }
 
 struct PanControlHandler : public NavigationControlHandler

--- a/src/plugins/globe/globe_plugin.h
+++ b/src/plugins/globe/globe_plugin.h
@@ -19,11 +19,14 @@
 #ifndef QGS_GLOBE_PLUGIN_H
 #define QGS_GLOBE_PLUGIN_H
 
-#include "qgsconfig.h"
-#include "qgisplugin.h"
-#include "qgsosgearthtilesource.h"
 #include "globe_plugin_dialog.h"
+#include "qgisplugin.h"
+#include "qgsconfig.h"
+#include "qgsglobeinterface.h"
+#include "qgsosgearthtilesource.h"
+
 #include <QObject>
+
 #include <osgViewer/Viewer>
 #include <osgEarth/MapNode>
 #include <osgEarth/ImageLayer>
@@ -65,6 +68,10 @@ class GlobePlugin : public QObject, public QgisPlugin
   public:
     GlobePlugin( QgisInterface* theQgisInterface );
     virtual ~GlobePlugin();
+
+    public:
+    //! offer an interface for python plugins
+    virtual QgsPluginInterface* pluginInterface();
 
   public slots:
     //! init the gui
@@ -171,6 +178,8 @@ class GlobePlugin : public QObject, public QgisPlugin
     osgEarth::ElevationQuery* mElevationManager;
     //! Object placer
     osgEarth::Util::ObjectLocator* mObjectPlacer;
+    //! The public interface for this plugin
+    QgsGlobeInterface mGlobeInterface;
 #else
     //! Elevation manager
     osgEarth::Util::ElevationManager* mElevationManager;

--- a/src/plugins/globe/python/CMakeLists.txt
+++ b/src/plugins/globe/python/CMakeLists.txt
@@ -1,0 +1,114 @@
+SET (PYTHON_OUTPUT_DIRECTORY ${QGIS_OUTPUT_DIRECTORY}/python)
+
+SET (QGIS_GLOBE_PYTHON_OUTPUT_DIRECTORY ${PYTHON_OUTPUT_DIRECTORY}/qgis)
+SET (OSG_PYTHON_OUTPUT_DIRECTORY ${PYTHON_OUTPUT_DIRECTORY}/osg)
+SET (OSGEARTH_PYTHON_OUTPUT_DIRECTORY ${PYTHON_OUTPUT_DIRECTORY}/osgEarth)
+
+SET (QGIS_GLOBE_PYTHON_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR})
+SET (QGIS_GLOBE_INCLUDE_DIRECTORY {CMAKE_CURRENT_SOURCE_DIR}/..)
+
+SET(OSG_PYTHON_DIR ${PYTHON_SITE_PACKAGES_DIR}/osg)
+SET(OSGEARTH_PYTHON_DIR ${PYTHON_SITE_PACKAGES_DIR}/osgearth)
+
+INCLUDE_DIRECTORIES(
+  ${PYTHON_INCLUDE_PATH}
+  ${SIP_INCLUDE_DIR}
+  ..
+  ../../../core
+)
+
+IF(WIN32)
+  IF(MSVC)
+    ADD_DEFINITIONS("-DGLOBE_EXPORT=${DLLIMPORT}")
+  ENDIF(MSVC)
+ENDIF(WIN32)
+
+
+SET(SIP_INCLUDES ${SIP_INCLUDES} ${QGIS_GLOBE_PYTHON_DIRECTORY})
+
+SET(SIP_DISABLE_FEATURES ${SIP_DISABLE_FEATURES} QSETINT_CONVERSION)
+SET(SIP_DISABLE_FEATURES ${SIP_DISABLE_FEATURES} QSETTYPE_CONVERSION)
+
+##########################
+# osg modules
+##########################
+#SET (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${OSG_PYTHON_OUTPUT_DIRECTORY})
+#SET (CMAKE_LIBRARY_OUTPUT_DIRECTORY ${OSG_PYTHON_OUTPUT_DIRECTORY})
+#FILE(GLOB sip_files_osg osg/osg/*.sip)
+#SET(SIP_EXTRA_FILES_DEPEND ${sip_files_osg})
+#SET(SIP_EXTRA_OPTIONS ${PYQT4_SIP_FLAGS} -o -a ${CMAKE_BINARY_DIR}/python/osg.api)
+#ADD_SIP_PYTHON_MODULE(osg.osg osg/osg/osg.sip ${OSG_LIBRARY})
+
+#FILE(GLOB sip_files_osgViewer osgViewer/*.sip)
+#SET(SIP_EXTRA_FILES_DEPEND ${sip_files_osgViewer})
+#SET(SIP_EXTRA_OPTIONS ${PYQT4_SIP_FLAGS} -o -a ${CMAKE_BINARY_DIR}/python/osgViewer.api)
+#ADD_SIP_PYTHON_MODULE(osg.osgViewer osg/osgViewer/osgViewer.sip ${OSG_LIBRARY} ${OSGVIEWER_LIBRARY})
+
+#FILE(GLOB sip_files_osgGA osg/osgGA/*.sip)
+#SET(SIP_EXTRA_FILES_DEPEND ${sip_files_osgGA})
+#SET(SIP_EXTRA_OPTIONS ${PYQT4_SIP_FLAGS} -o -a ${CMAKE_BINARY_DIR}/python/osgGA.api)
+#ADD_SIP_PYTHON_MODULE(osg.osgGA osg/osgGA/osgGA.sip ${OSG_LIBRARY} ${OSGGA_LIBRARY})
+
+##########################
+# osgearth modules
+##########################
+#SET (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${OSGEARTH_PYTHON_OUTPUT_DIRECTORY})
+#SET (CMAKE_LIBRARY_OUTPUT_DIRECTORY ${OSGEARTH_PYTHON_OUTPUT_DIRECTORY})
+#FILE(GLOB_RECURSE sip_files_osgearth osgEarth/*.sip)
+#SET(SIP_EXTRA_FILES_DEPEND ${sip_files_osgearth})
+#SET(SIP_EXTRA_OPTIONS ${PYQT4_SIP_FLAGS} -o -a ${CMAKE_BINARY_DIR}/python/osgEarth.api)
+#ADD_SIP_PYTHON_MODULE(osgEarth.osgEarth osgEarth/osgEarth.sip ${OSGEARTH_LIBS} ${OSG_LIBRARY} ${OSGDB_LIBRARY})
+
+#FILE(GLOB_RECURSE sip_files_osgearth_features osgEarth/Features/*.sip)
+#SET(SIP_EXTRA_FILES_DEPEND ${sip_files_osgearth_features} ${sip_files_osgearth})
+#SET(SIP_EXTRA_OPTIONS ${PYQT4_SIP_FLAGS} -o -a ${CMAKE_BINARY_DIR}/python/osgEarth.Features.api)
+#ADD_SIP_PYTHON_MODULE(osgEarth.Features osgEarth/Features/Features.sip ${OSGEARTH_LIBS} ${OSG_LIBRARY})
+
+#FILE(GLOB_RECURSE sip_files_osgearth_symbology osgEarth/Symbology/*.sip)
+#SET(SIP_EXTRA_FILES_DEPEND ${sip_files_osgearth_symbology} ${sip_files_osgearth})
+#SET(SIP_EXTRA_OPTIONS ${PYQT4_SIP_FLAGS} -o -a ${CMAKE_BINARY_DIR}/python/osgEarth.Symbology.api)
+#ADD_SIP_PYTHON_MODULE(osgEarth.Symbology osgEarth/Symbology/Symbology.sip ${OSGEARTH_LIBS} ${OSG_LIBRARY})
+
+#FILE(GLOB_RECURSE sip_files_osgearth_util osgearth/Util/*.sip)
+#SET(SIP_EXTRA_FILES_DEPEND ${sip_files_osgearth_util} ${sip_files_osgearth})
+#SET(SIP_EXTRA_OPTIONS ${PYQT4_SIP_FLAGS} -o -a ${CMAKE_BINARY_DIR}/python/osgEarth.Util.api)
+#ADD_SIP_PYTHON_MODULE(osgEarth.Util osgEarth/Util/Util.sip ${OSGEARTH_LIBS} ${OSG_LIBRARY} ${OSGGA_LIBRARY})
+
+# globe module
+SET (CMAKE_RUNTIME_OUTPUT_DIRECTORY ${QGIS_GLOBE_PYTHON_OUTPUT_DIRECTORY})
+SET (CMAKE_LIBRARY_OUTPUT_DIRECTORY ${QGIS_GLOBE_PYTHON_OUTPUT_DIRECTORY})
+FILE(GLOB_RECURSE sip_files_globe *.sip)
+SET(SIP_EXTRA_FILES_DEPEND ${sip_files_globe})
+SET(SIP_EXTRA_OPTIONS ${PYQT4_SIP_FLAGS} -o -a ${CMAKE_BINARY_DIR}/python/qgis.globe.api)
+ADD_SIP_PYTHON_MODULE(qgis.globe globe.sip globeplugin)
+
+# Plugin utilities files to copy to staging or install
+SET(PY_FILES
+  __init__.py
+)
+
+#ADD_CUSTOM_TARGET(osgpyutils ALL)
+#INSTALL(FILES ${PY_FILES} DESTINATION "${OSG_PYTHON_DIR}")
+#INSTALL(FILES ${PY_FILES} DESTINATION "${OSGEARTH_PYTHON_DIR}")
+
+# stage to output to make available when QGIS is run from build directory
+FOREACH(pyfile ${PY_FILES})
+  ADD_CUSTOM_COMMAND(TARGET osgpyutils
+    POST_BUILD
+    COMMAND ${CMAKE_COMMAND} -E copy ${pyfile} "${OSG_PYTHON_OUTPUT_DIRECTORY}"
+    COMMAND ${CMAKE_COMMAND} -E copy ${pyfile} "${OSGEARTH_PYTHON_OUTPUT_DIRECTORY}"
+    WORKING_DIRECTORY ${CMAKE_CURRENT_SOURCE_DIR}
+    DEPENDS ${pyfile}
+  )
+ENDFOREACH(pyfile)
+
+# Byte-compile staged PyQGIS utilities
+IF(WITH_PY_COMPILE)
+  ADD_CUSTOM_TARGET(pycompile-pyutils ALL
+    COMMAND ${PYTHON_EXECUTABLE} -m compileall -q "${OSG_PYTHON_OUTPUT_DIRECTORY}"
+    COMMAND ${PYTHON_EXECUTABLE} -m compileall -q "${OSGEARTH_PYTHON_OUTPUT_DIRECTORY}"
+    WORKING_DIRECTORY "${CMAKE_BINARY_DIR}"
+    COMMENT "Byte-compiling staged PyQGIS utility modules..."
+    DEPENDS osgpyutils
+  )
+ENDIF(WITH_PY_COMPILE)

--- a/src/plugins/globe/python/globe.sip
+++ b/src/plugins/globe/python/globe.sip
@@ -1,0 +1,10 @@
+%Module(name=qgis.globe,
+        version=0,
+        keyword_arguments="Optional")
+
+%Import QtCore/QtCoremod.sip
+%Import QtGui/QtGuimod.sip
+
+%Import core/core.sip
+
+%Include qgsglobeinterface.sip

--- a/src/plugins/globe/python/qgsglobeinterface.sip
+++ b/src/plugins/globe/python/qgsglobeinterface.sip
@@ -1,0 +1,40 @@
+/***************************************************************************
+    qgsglobeinterface.sip
+     --------------------------------------
+    Date                 : 22.8.2013
+    Copyright            : (C) 2013 Matthias Kuhn
+    Email                : matthias dot kuhn at gmx dot ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+class QgsGlobeInterface : QgsPluginInterface
+{
+%TypeHeaderCode
+    #include "qgsglobeinterface.h"
+%End
+
+// Provide converter code
+// Attention: qgis.globe has to be imported before this interface
+// is requested the first time. In case this is not done,
+// the converter code will not be executed and this will be treated as
+// a (useless) QgsPluginInterface object instead.
+%ConvertToSubClassCode
+  if ( sipCpp->inherits( sipName_QgsGlobeInterface ) )
+    sipType = sipType_QgsGlobeInterface;
+  else
+    sipType = NULL;
+%End
+
+  public:
+    void syncExtent();
+
+  private:
+    // Instances will only be created from the globe plugin itself
+    QgsGlobeInterface();
+};

--- a/src/plugins/globe/qgsglobeinterface.cpp
+++ b/src/plugins/globe/qgsglobeinterface.cpp
@@ -1,0 +1,36 @@
+/***************************************************************************
+    qgsglobeinterface.cpp
+     --------------------------------------
+    Date                 : 22.8.2013
+    Copyright            : (C) 2013 Matthias Kuhn
+    Email                : matthias dot kuhn at gmx dot ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsglobeinterface.h"
+
+// Qt Includes
+
+// QGIS Includes
+#include "qgslogger.h"
+
+// Globe Includes
+#include "globe_plugin.h"
+
+QgsGlobeInterface::QgsGlobeInterface( GlobePlugin* const globe )
+    : QgsPluginInterface()
+    , mGlobe( globe )
+{
+}
+
+void QgsGlobeInterface::syncExtent()
+{
+  mGlobe->syncExtent();
+}
+

--- a/src/plugins/globe/qgsglobeinterface.h
+++ b/src/plugins/globe/qgsglobeinterface.h
@@ -1,0 +1,37 @@
+/***************************************************************************
+    qgsglobeinterface.h
+     --------------------------------------
+    Date                 : 22.8.2013
+    Copyright            : (C) 2013 Matthias Kuhn
+    Email                : matthias dot kuhn at gmx dot ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSGLOBEINTERFACE_H
+#define QGSGLOBEINTERFACE_H
+
+#include "qgsplugininterface.h"
+
+
+class GlobePlugin;
+
+class QgsGlobeInterface : public QgsPluginInterface
+{
+    Q_OBJECT
+
+  public:
+    QgsGlobeInterface( GlobePlugin* const globe );
+    
+    void syncExtent();
+
+  private:
+    GlobePlugin* mGlobe;
+};
+
+#endif // QGSGLOBEINTERFACE_H

--- a/src/plugins/qgisplugin.h
+++ b/src/plugins/qgisplugin.h
@@ -38,6 +38,7 @@
 #include <QString>
 
 class QgisInterface;
+class QgsPluginInterface;
 
 //#include "qgisplugingui.h"
 
@@ -149,6 +150,16 @@ class QgisPlugin
 
     //! Unload the plugin and cleanup the GUI
     virtual void unload() = 0;
+
+    /**
+     * This method should return a pointer to a valid QgsPluginInterface
+     * if this plugin offers python bindings.
+     * Defaults to return NULL
+     *
+     * @return pointer to an object containing python bindings
+     */
+
+    virtual QgsPluginInterface* pluginInterface() { return NULL; }
 
   private:
 


### PR DESCRIPTION
As an example, the method `syncExtent()` from the globe plugin can be called from python.

```
# Needs to be done before calling pluginInterface()
from qgis import globe

glb = iface.pluginInterface( 'libglobeplugin' ) # On windows it's just 'globeplugin'
glb.syncExtent()
```

Question: should a "lib" prefix be stripped away for platform independence?
