### PR TITLE
set layer scale visibility for several layers

### DIFF
--- a/python/gui/gui.sip
+++ b/python/gui/gui.sip
@@ -76,6 +76,7 @@
 %Include qgsrubberband.sip
 %Include qgsscalecombobox.sip
 %Include qgsscalerangewidget.sip
+%Include qgsscalevisbilitydialog.sip
 %Include qgssearchquerybuilder.sip
 %Include qgstextannotationitem.sip
 %Include qgsvertexmarker.sip

--- a/python/gui/qgsattributedialog.sip
+++ b/python/gui/qgsattributedialog.sip
@@ -1,65 +1,30 @@
-class QgsAttributeDialog : QObject
+class QgsScaleVisibilityDialog : QObject
 {
 %TypeHeaderCode
-#include <qgsattributedialog.h>
+#include <qgsscalevisibilitydialog.h>
 %End
 
   public:
-    /**
-     * Create an attribute dialog for a given layer and feature
-     *
-     * @param vl                The layer for which the dialog will be generated
-     * @param thepFeature       A feature for which the dialog will be generated
-     * @param featureOwner      Set to true, if the dialog should take ownership of the feature
-     * @param myDa              A QgsDistanceArea which will be used for expressions
-     * @param parent            A parent widget for the dialog
-     * @param showDialogButtons True: Show the dialog buttons accept/cancel
-     *
-     * @deprecated
-     */
-    QgsAttributeDialog( QgsVectorLayer *vl, QgsFeature *thepFeature, bool featureOwner, QgsDistanceArea myDa, QWidget* parent = 0, bool showDialogButtons = true ) /Deprecated/;
+    explicit QgsScaleVisibilityDialog( QWidget *parent = 0, QString title = QString(), QgsMapCanvas* mapCanvas = 0 );
 
-    /**
-     * Create an attribute dialog for a given layer and feature
-     *
-     * @param vl                The layer for which the dialog will be generated
-     * @param thepFeature       A feature for which the dialog will be generated
-     * @param featureOwner      Set to true, if the dialog should take ownership of the feature
-     * @param parent            A parent widget for the dialog
-     * @param showDialogButtons True: Show the dialog buttons accept/cancel
-     * @param context           The context in which this dialog is created
-     *
-     */
-    QgsAttributeDialog( QgsVectorLayer *vl, QgsFeature *thepFeature, bool featureOwner, QWidget* parent = 0, bool showDialogButtons = true, QgsAttributeEditorContext context = QgsAttributeEditorContext() );
+    //! return if scale visibilty is enabled
+    bool hasScaleVisibility();
 
-    /** Saves the size and position for the next time
-     *  this dialog box will be used.
-     */
-    void saveGeometry();
+    //! return minimum scale (true scale, not scale denominator)
+    double minimumScale();
 
-    /** Restores the size and position from the last time
-     *  this dialog box was used.
-     */
-    void restoreGeometry();
+    //! return maximum scale (true scale, not scale denominator)
+    double maximumScale();
 
-    void setHighlight( QgsHighlight *h );
-
-    QDialog *dialog();
-
-    const QgsFeature* feature();
-
-    /**
-     * Is this dialog editable?
-     *
-     * @return returns true, if this dialog was created in an editable manner.
-     */
-    bool editable();
 
   public slots:
-    void accept();
+    //! set if scale visibility is enabled
+    void setScaleVisiblity( bool hasScaleVisibility );
 
-    int exec();
-    void show();
+    //! set minimum scale (true scale, not scale denominator)
+    void setMinimumScale( double minScale );
 
-    void dialogDestroyed();
+    //! set maximum scale (true scale, not scale denominator)
+    void setMaximumScale( double maxScale );
+
 };

--- a/src/app/legend/qgslegend.cpp
+++ b/src/app/legend/qgslegend.cpp
@@ -3012,6 +3012,42 @@ void QgsLegend::removeSelectedLayers()
   mMapCanvas->freeze( false );
 }
 
+void QgsLegend::setScaleVisibilityForSelectedLayers( bool hasScaleVisibility, double minScale, double maxScale )
+{
+  // Turn off rendering to improve speed.
+  mMapCanvas->freeze();
+
+  foreach ( QTreeWidgetItem * item, selectedItems() )
+  {
+    QgsLegendGroup* lg = dynamic_cast<QgsLegendGroup *>( item );
+    if ( lg )
+    {
+      foreach ( QgsLegendLayer *ll, lg->legendLayers() )
+      {
+        if ( ll && ll->layer() )
+        {
+          ll->layer()->toggleScaleBasedVisibility( hasScaleVisibility );
+          ll->layer()->setMinimumScale( 1.0 / maxScale );
+          ll->layer()->setMaximumScale( 1.0 / minScale );
+        }
+      }
+      continue;
+    }
+
+    QgsLegendLayer *ll = dynamic_cast<QgsLegendLayer *>( item );
+    if ( ll && ll->layer() )
+    {
+      ll->layer()->toggleScaleBasedVisibility( hasScaleVisibility );
+      ll->layer()->setMinimumScale( 1.0 / maxScale );
+      ll->layer()->setMaximumScale( 1.0 / minScale );
+      continue;
+    }
+  }
+
+  // Turn on rendering (if it was on previously)
+  mMapCanvas->freeze( false );
+}
+
 void QgsLegend::setCRSForSelectedLayers( const QgsCoordinateReferenceSystem &crs )
 {
   // Turn off rendering to improve speed.

--- a/src/app/legend/qgslegend.h
+++ b/src/app/legend/qgslegend.h
@@ -353,6 +353,9 @@ class QgsLegend : public QTreeWidget
     /** Remove selected layers */
     void removeSelectedLayers();
 
+    /** Set scale visiblity for selected layers */
+    void setScaleVisibilityForSelectedLayers( bool hasScaleVisibility, double minScale, double maxScale );
+
     /** Set CRS for selected layers */
     void setCRSForSelectedLayers( const QgsCoordinateReferenceSystem &crs );
 

--- a/src/app/legend/qgslegendlayer.cpp
+++ b/src/app/legend/qgslegendlayer.cpp
@@ -391,6 +391,9 @@ void QgsLegendLayer::addToPopupMenu( QMenu& theMenu )
   // duplicate layer
   QAction* duplicateLayersAction = theMenu.addAction( QgsApplication::getThemeIcon( "/mActionDuplicateLayer.svg" ), tr( "&Duplicate" ), QgisApp::instance(), SLOT( duplicateLayers() ) );
 
+  // set layer scale visibility
+  theMenu.addAction( tr( "&Set Layer Scale Visbility" ), QgisApp::instance(), SLOT( setLayerScaleVisibility() ) );
+
   // set layer crs
   theMenu.addAction( QgsApplication::getThemeIcon( "/mActionSetCRS.png" ), tr( "&Set Layer CRS" ), QgisApp::instance(), SLOT( setLayerCRS() ) );
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -177,6 +177,7 @@
 #include "qgsrasterlayersaveasdialog.h"
 #include "qgsrectangle.h"
 #include "qgsscalecombobox.h"
+#include "qgsscalevisibilitydialog.h"
 #include "qgsshortcutsmanager.h"
 #include "qgssinglebandgrayrenderer.h"
 #include "qgssnappingdialog.h"
@@ -1081,6 +1082,7 @@ void QgisApp::createActions()
   connect( mActionSaveLayerDefinition, SIGNAL( triggered() ), this, SLOT( saveAsLayerDefinition() ) );
   connect( mActionRemoveLayer, SIGNAL( triggered() ), this, SLOT( removeLayer() ) );
   connect( mActionDuplicateLayer, SIGNAL( triggered() ), this, SLOT( duplicateLayers() ) );
+  connect( mActionSetLayerScaleVisibility, SIGNAL( triggered() ), this, SLOT( setLayerScaleVisibility() ) );
   connect( mActionSetLayerCRS, SIGNAL( triggered() ), this, SLOT( setLayerCRS() ) );
   connect( mActionSetProjectCRSFromLayer, SIGNAL( triggered() ), this, SLOT( setProjectCRSFromLayer() ) );
   connect( mActionLayerProperties, SIGNAL( triggered() ), this, SLOT( layerProperties() ) );
@@ -6656,6 +6658,28 @@ void QgisApp::duplicateLayers( QList<QgsMapLayer *> lyrList )
   }
 }
 
+void QgisApp::setLayerScaleVisibility()
+{
+  if ( !( mMapLegend && mMapLegend->currentLayer() ) )
+  {
+    return;
+  }
+
+  QgsScaleVisibilityDialog* dlg = new QgsScaleVisibilityDialog( this, tr( "Set scale visibility for selected layers" ), mMapCanvas );
+  QgsMapLayer* layer = mMapLegend->currentLayer();
+  if ( layer )
+  {
+    dlg->setScaleVisiblity( layer->hasScaleBasedVisibility() );
+    dlg->setMinimumScale( 1.0 / layer->maximumScale() );
+    dlg->setMaximumScale( 1.0 / layer->minimumScale() );
+  }
+  if ( dlg->exec() )
+  {
+    mMapLegend->setScaleVisibilityForSelectedLayers( dlg->hasScaleVisibility(), dlg->minimumScale(), dlg->maximumScale() );
+  }
+  delete dlg;
+}
+
 void QgisApp::setLayerCRS()
 {
   if ( !( mMapLegend && mMapLegend->currentLayer() ) )
@@ -8319,6 +8343,7 @@ void QgisApp::legendLayerSelectionChanged( void )
 {
   mActionRemoveLayer->setEnabled( mMapLegend && mMapLegend->selectedLayers().size() > 0 );
   mActionDuplicateLayer->setEnabled( mMapLegend && mMapLegend->selectedLayers().size() > 0 );
+  mActionSetLayerScaleVisibility->setEnabled( mMapLegend && mMapLegend->selectedLayers().size() > 0 );
   mActionSetLayerCRS->setEnabled( mMapLegend && mMapLegend->selectedLayers().size() > 0 );
   mActionSetProjectCRSFromLayer->setEnabled( mMapLegend && mMapLegend->selectedLayers().size() == 1 );
 

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -707,7 +707,9 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     /** Duplicate map layer(s) in legend
      * @note added in 1.9 */
     void duplicateLayers( const QList<QgsMapLayer *> lyrList = QList<QgsMapLayer *>() );
-    //! Set CRS of a layer
+    //! Set scale visibility of layer(s)
+    void setLayerScaleVisibility();
+    //! Set CRS of layer(s)
     void setLayerCRS();
     //! Assign layer CRS to project
     void setProjectCRSFromLayer();

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -140,6 +140,7 @@ qgsrelationmanagerdialog.cpp
 qgsrubberband.cpp
 qgsscalecombobox.cpp
 qgsscalerangewidget.cpp
+qgsscalevisibilitydialog.cpp
 qgssearchquerybuilder.cpp
 qgssublayersdialog.cpp
 qgssvgannotationitem.cpp
@@ -280,6 +281,7 @@ qgsrelationeditor.h
 qgsrelationmanagerdialog.h
 qgsscalecombobox.h
 qgsscalerangewidget.h
+qgsscalevisibilitydialog.h
 qgssearchquerybuilder.h
 qgssublayersdialog.h
 qgsunitselectionwidget.h
@@ -347,6 +349,7 @@ qgsrelationeditor.h
 qgsrubberband.h
 qgsscalecombobox.h
 qgsscalerangewidget.h
+qgsscalevisibilitydialog.h
 qgssearchquerybuilder.h
 qgssublayersdialog.h
 qgsvectorlayertools.h

--- a/src/gui/qgsscalevisibilitydialog.cpp
+++ b/src/gui/qgsscalevisibilitydialog.cpp
@@ -1,0 +1,86 @@
+/***************************************************************************
+   qgsscalevisibilitydialog.cpp
+    --------------------------------------
+   Date                 : 20.05.2014
+   Copyright            : (C) 2014 Denis Rouzaud
+   Email                : denis.rouzaud@gmail.com
+***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************/
+
+#include <QGridLayout>
+#include <QDialogButtonBox>
+
+
+#include "qgsscalevisibilitydialog.h"
+
+
+
+QgsScaleVisibilityDialog::QgsScaleVisibilityDialog( QWidget *parent, QString title, QgsMapCanvas* mapCanvas ) :
+    QDialog( parent )
+{
+  if ( !title.isEmpty() )
+  {
+    setWindowTitle( title );
+  }
+
+  QGridLayout* dlgLayout = new QGridLayout( this );
+  //dlgLayout->setContentsMargins( 0, 0, 0, 0 );
+
+  mGroupBox = new QGroupBox( this );
+  mGroupBox->setCheckable( true );
+  mGroupBox->setTitle( tr( "Scale visibility " ) );
+
+  QGridLayout* gbLayout = new QGridLayout( this );
+  //gbLayout->setContentsMargins( 0, 0, 0, 0 );
+
+  mScaleWidget = new QgsScaleRangeWidget( this );
+  if ( mapCanvas )
+  {
+    mScaleWidget->setMapCanvas( mapCanvas );
+  }
+  gbLayout->addWidget( mScaleWidget, 0, 0 );
+  mGroupBox->setLayout( gbLayout );
+
+  QDialogButtonBox* buttonBox = new QDialogButtonBox( QDialogButtonBox::Cancel | QDialogButtonBox::Ok, Qt::Horizontal, this );
+  connect( buttonBox, SIGNAL( accepted() ), this, SLOT( accept() ) );
+  connect( buttonBox, SIGNAL( rejected() ), this, SLOT( reject() ) );
+
+  dlgLayout->addWidget( mGroupBox, 0, 0 );
+  dlgLayout->addWidget( buttonBox, 1, 0 );
+}
+
+void QgsScaleVisibilityDialog::setScaleVisiblity( bool hasScaleVisibility )
+{
+  mGroupBox->setChecked( hasScaleVisibility );
+}
+
+bool QgsScaleVisibilityDialog::hasScaleVisibility()
+{
+  return mGroupBox->isChecked();
+}
+
+void QgsScaleVisibilityDialog::setMinimumScale( double minScale )
+{
+  mScaleWidget->setMinimumScale( minScale );
+}
+
+double QgsScaleVisibilityDialog::minimumScale()
+{
+  return mScaleWidget->minimumScale();
+}
+
+void QgsScaleVisibilityDialog::setMaximumScale( double maxScale )
+{
+  mScaleWidget->setMaximumScale( maxScale );
+}
+
+double QgsScaleVisibilityDialog::maximumScale()
+{
+  return mScaleWidget->maximumScale();
+}

--- a/src/gui/qgsscalevisibilitydialog.h
+++ b/src/gui/qgsscalevisibilitydialog.h
@@ -1,0 +1,58 @@
+/***************************************************************************
+   qgsscalevisibilitydialog.cpp
+    --------------------------------------
+   Date                 : 20.05.2014
+   Copyright            : (C) 2014 Denis Rouzaud
+   Email                : denis.rouzaud@gmail.com
+***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************/
+
+#ifndef QGSSCALEVISIBILITYDIALOG_H
+#define QGSSCALEVISIBILITYDIALOG_H
+
+#include <QDialog>
+#include <QGroupBox>
+
+#include "qgsscalerangewidget.h"
+
+class GUI_EXPORT QgsScaleVisibilityDialog : public QDialog
+{
+    Q_OBJECT
+
+  public:
+    explicit QgsScaleVisibilityDialog( QWidget *parent = 0, QString title = QString(), QgsMapCanvas* mapCanvas = 0 );
+
+    //! return if scale visibilty is enabled
+    bool hasScaleVisibility();
+
+    //! return minimum scale (true scale, not scale denominator)
+    double minimumScale();
+
+    //! return maximum scale (true scale, not scale denominator)
+    double maximumScale();
+
+
+  public slots:
+    //! set if scale visibility is enabled
+    void setScaleVisiblity( bool hasScaleVisibility );
+
+    //! set minimum scale (true scale, not scale denominator)
+    void setMinimumScale( double minScale );
+
+    //! set maximum scale (true scale, not scale denominator)
+    void setMaximumScale( double maxScale );
+
+
+  private:
+    QGroupBox* mGroupBox;
+    QgsScaleRangeWidget* mScaleWidget;
+
+};
+
+#endif // QGSSCALEVISIBILITYDIALOG_H

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -17,7 +17,7 @@
      <x>0</x>
      <y>0</y>
      <width>1050</width>
-     <height>21</height>
+     <height>25</height>
     </rect>
    </property>
    <widget class="QMenu" name="mProjectMenu">
@@ -148,6 +148,7 @@
     <addaction name="mActionSaveLayerDefinition"/>
     <addaction name="mActionRemoveLayer"/>
     <addaction name="mActionDuplicateLayer"/>
+    <addaction name="mActionSetLayerScaleVisibility"/>
     <addaction name="mActionSetLayerCRS"/>
     <addaction name="mActionSetProjectCRSFromLayer"/>
     <addaction name="mActionLayerProperties"/>
@@ -2166,6 +2167,11 @@ Acts on currently active editable layer</string>
   <action name="mActionSaveLayerDefinition">
    <property name="text">
     <string>Save As Layer Definition File...</string>
+   </property>
+  </action>
+  <action name="mActionSetLayerScaleVisibility">
+   <property name="text">
+    <string>Set Scale Visibility of Layer(s)</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
This allows setting the scale visibility of several layers at once.
This is done similarly to "set CRS of layers": it adds a layer menu entry and a context menu entry.

If no objection is raised by feature freeze, I will merge this.

@wonder-sk: will this be a problem for the legend refactoring merge? 
I implemented `void QgsLegend::setScaleVisibilityForSelectedLayers( bool hasScaleVisibility, double minScale, double maxScale )` similarly to `QgsLegend::setCRSForSelectedLayers`. If you have a working branch, I can rebase on top of it to avoid any extra work.
