### PR TITLE
Some postgresql provider and PostGIS-related processing improvements and fixes (v2)

### DIFF
--- a/python/plugins/processing/algs/admintools/ImportIntoPostGIS.py
+++ b/python/plugins/processing/algs/admintools/ImportIntoPostGIS.py
@@ -36,6 +36,7 @@ from processing.parameters.ParameterBoolean import ParameterBoolean
 from processing.parameters.ParameterVector import ParameterVector
 from processing.parameters.ParameterString import ParameterString
 from processing.parameters.ParameterSelection import ParameterSelection
+from processing.parameters.ParameterTableField import ParameterTableField
 from processing.tools import dataobjects
 import postgis_utils
 
@@ -51,6 +52,7 @@ class ImportIntoPostGIS(GeoAlgorithm):
     GEOMETRY_COLUMN = 'GEOMETRY_COLUMN'
     LOWERCASE_NAMES = 'LOWERCASE_NAMES'
     DROP_STRING_LENGTH = 'DROP_STRING_LENGTH'
+    PRIMARY_KEY = 'PRIMARY_KEY'
 
     def getIcon(self):
         return QIcon(os.path.dirname(__file__) + '/../../images/postgis.png')
@@ -62,6 +64,7 @@ class ImportIntoPostGIS(GeoAlgorithm):
         createIndex = self.getParameterValue(self.CREATEINDEX)
         convertLowerCase = self.getParameterValue(self.LOWERCASE_NAMES)
         dropStringLength = self.getParameterValue(self.DROP_STRING_LENGTH)
+        primaryKeyField = self.getParameterValue(self.PRIMARY_KEY)
         settings = QSettings()
         mySettings = '/PostgreSQL/connections/' + connection
         try:
@@ -91,7 +94,10 @@ class ImportIntoPostGIS(GeoAlgorithm):
 
         uri = QgsDataSourceURI()
         uri.setConnection(host, str(port), database, username, password)
-        uri.setDataSource(schema, table, geomColumn, '')
+        if primaryKeyField:
+            uri.setDataSource(schema, table, geomColumn, '', primaryKeyField)
+        else:
+            uri.setDataSource(schema, table, geomColumn, '')
 
         options = {}
         if overwrite:
@@ -137,6 +143,8 @@ class ImportIntoPostGIS(GeoAlgorithm):
         self.addParameter(ParameterString(self.SCHEMA, 'Schema (schema name)'))
         self.addParameter(ParameterString(self.TABLENAME, 'Table to import to'
                           ))
+        self.addParameter(ParameterTableField(self.PRIMARY_KEY, 'Primary key field',
+                          self.INPUT, optional=True))
         self.addParameter(ParameterString(self.GEOMETRY_COLUMN, 'Geometry column', 'the_geom'
                           ))
         self.addParameter(ParameterBoolean(self.OVERWRITE, 'Overwrite', True))

--- a/python/plugins/processing/algs/admintools/ImportIntoPostGIS.py
+++ b/python/plugins/processing/algs/admintools/ImportIntoPostGIS.py
@@ -50,6 +50,7 @@ class ImportIntoPostGIS(GeoAlgorithm):
     CREATEINDEX = 'CREATEINDEX'
     GEOMETRY_COLUMN = 'GEOMETRY_COLUMN'
     LOWERCASE_NAMES = 'LOWERCASE_NAMES'
+    DROP_STRING_LENGTH = 'DROP_STRING_LENGTH'
 
     def getIcon(self):
         return QIcon(os.path.dirname(__file__) + '/../../images/postgis.png')
@@ -60,6 +61,7 @@ class ImportIntoPostGIS(GeoAlgorithm):
         overwrite = self.getParameterValue(self.OVERWRITE)
         createIndex = self.getParameterValue(self.CREATEINDEX)
         convertLowerCase = self.getParameterValue(self.LOWERCASE_NAMES)
+        dropStringLength = self.getParameterValue(self.DROP_STRING_LENGTH)
         settings = QSettings()
         mySettings = '/PostgreSQL/connections/' + connection
         try:
@@ -96,6 +98,8 @@ class ImportIntoPostGIS(GeoAlgorithm):
             options['overwrite'] = True
         if convertLowerCase:
             options['lowercaseFieldNames'] = True
+        if dropStringLength:
+            options['dropStringConstraints'] = True
         layerUri = self.getParameterValue(self.INPUT)
         layer = dataobjects.getObjectFromUri(layerUri)
         (ret, errMsg) = QgsVectorLayerImport.importLayer(
@@ -140,3 +144,5 @@ class ImportIntoPostGIS(GeoAlgorithm):
                           'Create spatial index', True))
         self.addParameter(ParameterBoolean(self.LOWERCASE_NAMES,
                           'Convert field names to lowercase', False))
+        self.addParameter(ParameterBoolean(self.DROP_STRING_LENGTH,
+                          'Drop length constraints on character fields', False))

--- a/python/plugins/processing/algs/admintools/ImportIntoPostGIS.py
+++ b/python/plugins/processing/algs/admintools/ImportIntoPostGIS.py
@@ -92,20 +92,22 @@ class ImportIntoPostGIS(GeoAlgorithm):
         if not geomColumn:
             geomColumn = 'the_geom'
 
+        options = {}
+        if overwrite:
+            options['overwrite'] = True
+        if convertLowerCase:
+            options['lowercaseFieldNames'] = True
+            geomColumn = geomColumn.lower()
+        if dropStringLength:
+            options['dropStringConstraints'] = True
+            
         uri = QgsDataSourceURI()
         uri.setConnection(host, str(port), database, username, password)
         if primaryKeyField:
             uri.setDataSource(schema, table, geomColumn, '', primaryKeyField)
         else:
             uri.setDataSource(schema, table, geomColumn, '')
-
-        options = {}
-        if overwrite:
-            options['overwrite'] = True
-        if convertLowerCase:
-            options['lowercaseFieldNames'] = True
-        if dropStringLength:
-            options['dropStringConstraints'] = True
+            
         layerUri = self.getParameterValue(self.INPUT)
         layer = dataobjects.getObjectFromUri(layerUri)
         (ret, errMsg) = QgsVectorLayerImport.importLayer(

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -2767,9 +2767,17 @@ bool QgsPostgresProvider::getGeometryDetails()
   return mValid;
 }
 
-bool QgsPostgresProvider::convertField( QgsField &field )
+bool QgsPostgresProvider::convertField( QgsField &field , const QMap<QString, QVariant>* options )
 {
-  QString fieldType = "varchar"; //default to string
+  //determine field type to use for strings
+  QString stringFieldType = "varchar";
+  if ( options->contains( "dropStringConstraints" ) && options->value( "dropStringConstraints" ).toBool() )
+  {
+    //drop string length constraints by using PostgreSQL text type for strings
+    stringFieldType = "text";
+  }
+
+  QString fieldType = stringFieldType; //default to string
   int fieldSize = field.length();
   int fieldPrec = field.precision();
   switch ( field.type() )
@@ -2788,7 +2796,7 @@ bool QgsPostgresProvider::convertField( QgsField &field )
       break;
 
     case QVariant::String:
-      fieldType = "varchar";
+      fieldType = stringFieldType;
       fieldPrec = -1;
       break;
 
@@ -2900,7 +2908,7 @@ QgsVectorLayerImport::ImportError QgsPostgresProvider::createEmptyLayer(
       {
         // found, get the field type
         QgsField fld = fields[fldIdx];
-        if ( convertField( fld ) )
+        if ( convertField( fld, options ) )
         {
           primaryKeyType = fld.typeName();
         }
@@ -3050,7 +3058,7 @@ QgsVectorLayerImport::ImportError QgsPostgresProvider::createEmptyLayer(
         fld.setName( fld.name().toLower() );
       }
 
-      if ( !convertField( fld ) )
+      if ( !convertField( fld, options ) )
       {
         if ( errorMessage )
           *errorMessage = QObject::tr( "Unsupported type for field %1" ).arg( fld.name() );

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -47,7 +47,12 @@ class QgsPostgresProvider : public QgsVectorDataProvider
 
   public:
 
-    /** Import a vector layer into the database */
+    /** Import a vector layer into the database
+     * @param options options for provider, specified via a map of option name
+     * to value. Valid options are lowercaseFieldNames (set to true to convert
+     * field names to lowercase), dropStringConstraints (set to true to remove
+     * length constraints on character fields).
+    */
     static QgsVectorLayerImport::ImportError createEmptyLayer(
       const QString& uri,
       const QgsFields &fields,
@@ -324,7 +329,7 @@ class QgsPostgresProvider : public QgsVectorDataProvider
     bool loadFields();
 
     /** convert a QgsField to work with PG */
-    static bool convertField( QgsField &field );
+    static bool convertField( QgsField &field, const QMap<QString, QVariant> *options = 0 );
 
     /**Parses the enum_range of an attribute and inserts the possible values into a stringlist
     @param enumValues the stringlist where the values are appended


### PR DESCRIPTION
This is a reworked version of https://github.com/qgis/QGIS/pull/1311 . This version implements a postgresql provider option for dropping length constraints of character fields.
It also omits the fix for quoting upper-case geometry fields, as this requires further investigation (looks like _quote in postgis_utils.py should be using a refined regular expression, and also test for reserved keywords). I'll tackle that in a separate pull request.
