### PR TITLE
restore addLegendLayerAction and related functions after legend redesign

### DIFF
--- a/src/app/legend/qgsapplegendinterface.cpp
+++ b/src/app/legend/qgsapplegendinterface.cpp
@@ -20,6 +20,8 @@
 #include "qgslayertreemodel.h"
 #include "qgslayertreeview.h"
 #include "qgsmaplayer.h"
+#include "qgsproject.h"
+#include "qgslayertreeregistrybridge.h"
 
 
 QgsAppLegendInterface::QgsAppLegendInterface( QgsLayerTreeView * layerTreeView )
@@ -299,18 +301,17 @@ void QgsAppLegendInterface::onRemovedChildren()
 void QgsAppLegendInterface::addLegendLayerAction( QAction* action,
     QString menu, QString id, QgsMapLayer::LayerType type, bool allLayers )
 {
-  // TODO[MD] mLegend->addLegendLayerAction( action, menu, id, type, allLayers );
+  QgsProject::instance()->layerTreeRegistryBridge()->addLegendLayerAction( action, menu, id, type, allLayers );
 }
 
 void QgsAppLegendInterface::addLegendLayerActionForLayer( QAction* action, QgsMapLayer* layer )
 {
-  // TODO[MD] mLegend->addLegendLayerActionForLayer( action, layer );
+  QgsProject::instance()->layerTreeRegistryBridge()->addLegendLayerActionForLayer( action, layer );
 }
 
 bool QgsAppLegendInterface::removeLegendLayerAction( QAction* action )
 {
-  // TODO[MD] return mLegend->removeLegendLayerAction( action );
-  return false;
+  return QgsProject::instance()->layerTreeRegistryBridge()->removeLegendLayerAction( action );
 }
 
 QgsMapLayer* QgsAppLegendInterface::currentLayer()

--- a/src/core/layertree/qgslayertreeregistrybridge.cpp
+++ b/src/core/layertree/qgslayertreeregistrybridge.cpp
@@ -20,6 +20,8 @@
 #include "qgslayertree.h"
 
 #include "qgsproject.h"
+#include "qgslogger.h"
+#include <QAction>
 
 QgsLayerTreeRegistryBridge::QgsLayerTreeRegistryBridge( QgsLayerTreeGroup *root, QObject *parent )
     : QObject( parent )
@@ -63,11 +65,17 @@ void QgsLayerTreeRegistryBridge::layersAdded( QList<QgsMapLayer*> layers )
 
 void QgsLayerTreeRegistryBridge::layersWillBeRemoved( QStringList layerIds )
 {
+  QgsDebugMsg( QString( "%1 layers will be removed, enabled:%2" ).arg( layerIds.count() ).arg( mEnabled ) );
+
   if ( !mEnabled )
     return;
 
   foreach ( QString layerId, layerIds )
   {
+	QgsMapLayer* mapLayer = QgsMapLayerRegistry::instance()->mapLayer( layerId );
+	if ( mapLayer )
+	  removeLegendLayerActionsForLayer( mapLayer );
+
     QgsLayerTreeLayer* nodeLayer = mRoot->findLayer( layerId );
     if ( nodeLayer )
       qobject_cast<QgsLayerTreeGroup*>( nodeLayer->parent() )->removeChildNode( nodeLayer );
@@ -111,5 +119,79 @@ void QgsLayerTreeRegistryBridge::groupRemovedChildren()
       toRemove << layerId;
   mLayerIdsForRemoval.clear();
 
+  QgsDebugMsg( QString( "%1 layers will be removed" ).arg( toRemove.count() ) );
+
   QgsMapLayerRegistry::instance()->removeMapLayers( toRemove );
+}
+
+void QgsLayerTreeRegistryBridge::addLegendLayerAction( QAction* action, QString menu, QString id,
+                                      QgsMapLayer::LayerType type, bool allLayers )
+{
+  mLegendLayerActionMap[type].append( LegendLayerAction( action, menu, id, allLayers ) );
+}
+
+bool QgsLayerTreeRegistryBridge::removeLegendLayerAction( QAction* action )
+{
+  QMap< QgsMapLayer::LayerType, QList< LegendLayerAction > >::iterator it;
+  for ( it = mLegendLayerActionMap.begin();
+        it != mLegendLayerActionMap.end(); ++it )
+  {
+    for ( int i = 0; i < it->count(); i++ )
+    {
+      if (( *it )[i].action == action )
+      {
+        ( *it ).removeAt( i );
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+void QgsLayerTreeRegistryBridge::addLegendLayerActionForLayer( QAction* action, QgsMapLayer* layer )
+{
+  legendLayerActions( layer->type() );
+  if ( !action || !layer || ! mLegendLayerActionMap.contains( layer->type() ) )
+   	return;
+
+  QMap< QgsMapLayer::LayerType, QList< LegendLayerAction > >::iterator it
+	= mLegendLayerActionMap.find( layer->type() );
+  for ( int i = 0; i < it->count(); i++ )
+  {
+	if ( ( *it )[i].action == action )
+	{
+	  ( *it )[i].layers.append( layer );
+	  return;
+	}
+  }
+}
+
+void QgsLayerTreeRegistryBridge::removeLegendLayerActionsForLayer( QgsMapLayer* layer )
+{
+  if ( ! layer || ! mLegendLayerActionMap.contains( layer->type() ) )
+   	return;
+
+  QMap< QgsMapLayer::LayerType, QList< LegendLayerAction > >::iterator it 
+	= mLegendLayerActionMap.find( layer->type() );
+  for ( int i = 0; i < it->count(); i++ )
+  {
+	( *it )[i].layers.removeAll( layer );
+  }
+}
+
+QList< LegendLayerAction > QgsLayerTreeRegistryBridge::legendLayerActions( QgsMapLayer::LayerType type ) const
+{
+#ifdef QGISDEBUG
+  if ( mLegendLayerActionMap.contains( type ) )
+  {
+	QgsDebugMsg( QString("legendLayerActions for layers of type %1:").arg( type ) );
+	
+	foreach ( LegendLayerAction lyrAction, mLegendLayerActionMap[ type ] )
+	{
+	  QgsDebugMsg( QString("%1/%2 - %3 layers").arg( lyrAction.menu ).arg( lyrAction.action->text() ).arg( lyrAction.layers.count()) );
+	}
+  }
+#endif
+
+  return mLegendLayerActionMap.contains( type ) ? mLegendLayerActionMap.value( type ) : QList< LegendLayerAction >() ;
 }

--- a/src/core/layertree/qgslayertreeregistrybridge.h
+++ b/src/core/layertree/qgslayertreeregistrybridge.h
@@ -19,10 +19,23 @@
 #include <QObject>
 #include <QStringList>
 
+class QAction;
+
 class QgsLayerTreeGroup;
 class QgsLayerTreeNode;
 
-class QgsMapLayer;
+#include "qgsmaplayer.h"
+
+struct LegendLayerAction
+{
+  LegendLayerAction( QAction* a, QString m, QString i, bool all )
+      : action( a ), menu( m ), id( i ), allLayers( all ) {}
+  QAction* action;
+  QString menu;
+  QString id;
+  bool allLayers;
+  QList<QgsMapLayer*> layers;
+};
 
 /**
  * Listens to the updates in map layer registry and does changes in layer tree.
@@ -49,6 +62,14 @@ class CORE_EXPORT QgsLayerTreeRegistryBridge : public QObject
     //! By default it is root group with zero index.
     void setLayerInsertionPoint( QgsLayerTreeGroup* parentGroup, int index );
 
+	void addLegendLayerAction( QAction* action, QString menu, QString id,
+                               QgsMapLayer::LayerType type, bool allLayers );
+    bool removeLegendLayerAction( QAction* action );
+    void addLegendLayerActionForLayer( QAction* action, QgsMapLayer* layer );
+    void removeLegendLayerActionsForLayer( QgsMapLayer* layer );
+    QList< LegendLayerAction > legendLayerActions( QgsMapLayer::LayerType type ) const;
+
+
   signals:
 
   protected slots:
@@ -59,14 +80,14 @@ class CORE_EXPORT QgsLayerTreeRegistryBridge : public QObject
     void groupRemovedChildren();
 
   protected:
-
-  protected:
     QgsLayerTreeGroup* mRoot;
     QStringList mLayerIdsForRemoval;
     bool mEnabled;
 
     QgsLayerTreeGroup* mInsertionPointGroup;
-    int mInsertionPointIndex;
+    int mInsertionPointIndex;    
+
+    QMap< QgsMapLayer::LayerType, QList< LegendLayerAction > > mLegendLayerActionMap;
 };
 
 #endif // QGSLAYERTREEREGISTRYBRIDGE_H


### PR DESCRIPTION
the member names are not compatible with the new legend classes, but I didn't want to break the api
