### PR TITLE
Fix SAGA GetShapeExtents

### DIFF
--- a/python/plugins/processing/algs/saga/description/2.0.8_GetShapesExtents.txt
+++ b/python/plugins/processing/algs/saga/description/2.0.8_GetShapesExtents.txt
@@ -1,0 +1,5 @@
+Get Shapes Extents
+shapes_tools
+ParameterVector|SHAPES|Shapes|-1|False
+ParameterBoolean|PARTS        |Parts|True
+OutputVector|EXTENTS|Extents

--- a/python/plugins/processing/algs/saga/description/2.1_GetShapesExtents.txt
+++ b/python/plugins/processing/algs/saga/description/2.1_GetShapesExtents.txt
@@ -1,5 +1,5 @@
 Get Shapes Extents
 shapes_tools
 ParameterVector|SHAPES|Shapes|-1|False
-ParameterBoolean|PARTS        |Parts|True
+ParameterSelection|OUTPUT|Get Extent for|[0] all shapes;[1] each shape;[2] each shape's part
 OutputVector|EXTENTS|Extents


### PR DESCRIPTION
The module changed in SAGA 2.10
