### PR TITLE
Skip attribute dialog when adding features on layers w/o attributes

### DIFF
--- a/src/app/qgsfeatureaction.cpp
+++ b/src/app/qgsfeatureaction.cpp
@@ -194,7 +194,7 @@ bool QgsFeatureAction::addFeature( const QgsAttributeMap& defaultAttributes )
     case QgsVectorLayer::SuppressDefault:
       break;
   }
-  if ( isDisabledAttributeValuesDlg )
+  if ( isDisabledAttributeValuesDlg || mLayer->pendingFields().count() == 0 )
   {
     mLayer->beginEditCommand( text() );
     res = mLayer->addFeature( mFeature );


### PR DESCRIPTION
The idea was brought up here:
http://hub.qgis.org/issues/10351
