### PR TITLE
Fix color buttons disappearing in windows when alpha is set (fix #10187)

### DIFF
--- a/src/gui/qgscolorbutton.cpp
+++ b/src/gui/qgscolorbutton.cpp
@@ -26,6 +26,25 @@
 #include <QMenu>
 #include <QClipboard>
 
+#ifdef Q_OS_WIN
+#include <windows.h>
+QString QgsColorButton::fullPath( const QString &path )
+{
+  TCHAR buf[MAX_PATH];
+  int len = GetLongPathName( path.toUtf8().constData(), buf, MAX_PATH );
+
+  if ( len == 0 || len > MAX_PATH )
+  {
+    QgsDebugMsg( QString( "GetLongPathName('%1') failed with %2: %3" )
+                 .arg( path ).arg( len ).arg( GetLastError() ) );
+    return path;
+  }
+
+  QString res = QString::fromUtf8( buf );
+  return res;
+}
+#endif
+
 /*!
   \class QgsColorButton
 
@@ -386,10 +405,14 @@ void QgsColorButton::setButtonBackground()
         mTempPNG.close();
       }
 
-      bkgrd = QString( " background-image: url(%1);" ).arg( mTempPNG.fileName() );
+      QString bgFileName = mTempPNG.fileName();
+#ifdef Q_OS_WIN
+      //on windows, mTempPNG will use a shortened path for the temporary folder name
+      //this does not work with stylesheets, resulting in the whole button disappearing (#10187)
+      bgFileName = fullPath( bgFileName );
+#endif
+      bkgrd = QString( " background-image: url(%1);" ).arg( bgFileName );
     }
-
-    //QgsDebugMsg( QString( "%1" ).arg( bkgrd ) );
 
     // TODO: get OS-style focus color and switch border to that color when button in focus
     setStyleSheet( QString( "QgsColorButton{"

--- a/src/gui/qgscolorbutton.h
+++ b/src/gui/qgscolorbutton.h
@@ -191,6 +191,16 @@ class GUI_EXPORT QgsColorButton: public QPushButton
      */
     bool colorFromMimeData( const QMimeData *mimeData, QColor &resultColor );
 
+#ifdef Q_OS_WIN
+    /**
+     * Expands a shortened Windows path to its full path name.
+     * @returns full path name.
+     * @param path a (possibly) shortened Windows path
+     * @note added in 2.3
+     */
+    QString fullPath( const QString &path );
+#endif
+
   private slots:
     void onButtonClicked();
 


### PR DESCRIPTION
Here's a fix for 10187, where colour buttons disappear completely when the colour has an alpha set on Windows. This bug is cause by user's temporary folder path being returned in short file name format by QTemporaryFile (and also by all QDir::tempPath and similar functions). Most qt functions handle short filename paths without issue, but trying to include short filename paths in stylesheets results in qt rejecting the stylesheet and not rendering the button at all. This patch uses the windows api GetLongPathName function to expand out the temporary file's path to a full long pathname, which means the stylesheet is parsed correctly and the button drawn.
