### PR TITLE
Line multi labeling improved

### DIFF
--- a/src/app/qgslabelinggui.cpp
+++ b/src/app/qgslabelinggui.cpp
@@ -1295,7 +1295,7 @@ void QgsLabelingGui::updatePlacementWidgets()
   mPlacementOffsetFrame->setVisible( showOffsetFrame );
   mPlacementDistanceFrame->setVisible( showDistanceFrame );
   mPlacementRotationFrame->setVisible( showRotationFrame );
-  mPlacementRepeatDistanceFrame->setVisible( curWdgt == pageLine );
+  mPlacementRepeatDistanceFrame->setVisible( curWdgt == pageLine || ( curWdgt == pagePolygon && radPolygonPerimeter->isChecked() ) );
   mPlacementMaxCharAngleFrame->setVisible( showMaxCharAngleFrame );
 
   mMultiLinesFrame->setEnabled( enableMultiLinesFrame );

--- a/src/app/qgslabelinggui.cpp
+++ b/src/app/qgslabelinggui.cpp
@@ -1290,12 +1290,12 @@ void QgsLabelingGui::updatePlacementWidgets()
   }
 
   mPlacementLineFrame->setVisible( showLineFrame );
-  mPlacmentCentroidFrame->setVisible( showCentroidFrame );
+  mPlacementCentroidFrame->setVisible( showCentroidFrame );
   mPlacementQuadrantFrame->setVisible( showQuadrantFrame );
   mPlacementOffsetFrame->setVisible( showOffsetFrame );
   mPlacementDistanceFrame->setVisible( showDistanceFrame );
   mPlacementRotationFrame->setVisible( showRotationFrame );
-  mPlacmentRepeatDistanceFrame->setVisible( curWdgt == pageLine );
+  mPlacementRepeatDistanceFrame->setVisible( curWdgt == pageLine );
   mPlacementMaxCharAngleFrame->setVisible( showMaxCharAngleFrame );
 
   mMultiLinesFrame->setEnabled( enableMultiLinesFrame );

--- a/src/core/pal/feature.h
+++ b/src/core/pal/feature.h
@@ -229,6 +229,18 @@ namespace pal
       //int getId();
 
       /**
+       * \brief return the feature
+       * \return the feature
+       */
+      Feature* getFeature() { return f; }
+
+      /**
+       * \brief return the geometry
+       * \return the geometry
+       */
+      const GEOSGeometry* getGeometry() const { return the_geom; }
+
+      /**
        * \brief return the layer that feature belongs to
        * \return the layer of the feature
        */

--- a/src/core/pal/layer.cpp
+++ b/src/core/pal/layer.cpp
@@ -229,7 +229,7 @@ namespace pal
 
   bool Layer::registerFeature( const char *geom_id, PalGeometry *userGeom, double label_x, double label_y, const char* labelText,
                                double labelPosX, double labelPosY, bool fixedPos, double angle, bool fixedAngle,
-                               int xQuadOffset, int yQuadOffset, double xOffset, double yOffset, bool alwaysShow, double repeatDistance )
+                               int xQuadOffset, int yQuadOffset, double xOffset, double yOffset, bool alwaysShow )
   {
     if ( !geom_id || label_x < 0 || label_y < 0 )
       return false;
@@ -285,86 +285,6 @@ namespace pal
       throw InternalException::UnknownGeometry();
     }
 
-    // if multiple labels are requested for lines, split the line in pieces of desired distance
-    if ( repeatDistance > 0 )
-    {
-      int nSimpleGeometries = simpleGeometries->size();
-      for ( int i = 0; i < nSimpleGeometries; ++i )
-      {
-        const GEOSGeometry* geom = simpleGeometries->pop_front();
-        if ( GEOSGeomTypeId( geom ) == GEOS_LINESTRING )
-        {
-          const GEOSCoordSequence *cs = GEOSGeom_getCoordSeq( geom );
-
-          // get number of points
-          unsigned int n;
-          GEOSCoordSeq_getSize( cs, &n );
-
-          // Read points
-          std::vector<Point> points( n );
-          for ( unsigned int i = 0; i < n; ++i )
-          {
-            GEOSCoordSeq_getX( cs, i, &points[i].x );
-            GEOSCoordSeq_getY( cs, i, &points[i].y );
-          }
-
-          // Cumulative length vector
-          std::vector<double> len( n, 0 );
-          for ( unsigned int i = 1; i < n; ++i )
-          {
-            double dx = points[i].x - points[i - 1].x;
-            double dy = points[i].y - points[i - 1].y;
-            len[i] = len[i - 1] + std::sqrt( dx * dx + dy * dy );
-          }
-
-          // Walk along line
-          unsigned int cur = 0;
-          double lambda = 0;
-          std::vector<Point> part;
-          for ( ;; )
-          {
-            lambda += repeatDistance;
-            for ( ; cur < n && lambda > len[cur]; ++cur )
-            {
-              part.push_back( points[cur] );
-            }
-            if ( cur >= n )
-            {
-              break;
-            }
-            double c = ( lambda - len[cur - 1] ) / ( len[cur] - len[cur - 1] );
-            Point p;
-            p.x = points[cur - 1].x + c * ( points[cur].x - points[cur - 1].x );
-            p.y = points[cur - 1].y + c * ( points[cur].y - points[cur - 1].y );
-            part.push_back( p );
-            GEOSCoordSequence* cooSeq = GEOSCoordSeq_create( part.size(), 2 );
-            for ( std::size_t i = 0; i < part.size(); ++i )
-            {
-              GEOSCoordSeq_setX( cooSeq, i, part[i].x );
-              GEOSCoordSeq_setY( cooSeq, i, part[i].y );
-            }
-
-            simpleGeometries->push_back( GEOSGeom_createLineString( cooSeq ) );
-            part.clear();
-            part.push_back( p );
-          }
-          // Create final part
-          part.push_back( points[n - 1] );
-          GEOSCoordSequence* cooSeq = GEOSCoordSeq_create( part.size(), 2 );
-          for ( std::size_t i = 0; i < part.size(); ++i )
-          {
-            GEOSCoordSeq_setX( cooSeq, i, part[i].x );
-            GEOSCoordSeq_setY( cooSeq, i, part[i].y );
-          }
-          simpleGeometries->push_back( GEOSGeom_createLineString( cooSeq ) );
-        }
-        else
-        {
-          simpleGeometries->push_back( geom );
-        }
-      }
-    }
-
     while ( simpleGeometries->size() > 0 )
     {
       const GEOSGeometry* geom = simpleGeometries->pop_front();
@@ -401,7 +321,7 @@ namespace pal
         continue;
       }
 
-      if ( mode == LabelPerFeature && repeatDistance == 0.0 && ( type == GEOS_POLYGON || type == GEOS_LINESTRING ) )
+      if ( mode == LabelPerFeature && ( type == GEOS_POLYGON || type == GEOS_LINESTRING ) )
       {
         if ( type == GEOS_LINESTRING )
           GEOSLength( geom, &geom_size );
@@ -430,7 +350,7 @@ namespace pal
     modMutex->unlock();
 
     // if using only biggest parts...
-    if ((( mode == LabelPerFeature && repeatDistance == 0.0 ) || f->fixedPosition() ) && biggest_part != NULL )
+    if (( mode == LabelPerFeature || f->fixedPosition() ) && biggest_part != NULL )
     {
       addFeaturePart( biggest_part, labelText );
       first_feat = false;
@@ -567,6 +487,102 @@ namespace pal
     connectedHashtable = NULL;
     delete connectedTexts;
     connectedTexts = NULL;
+  }
+
+  void Layer::chopFeatures( double chopInterval )
+  {
+    LinkedList<FeaturePart*> * newFeatureParts = new LinkedList<FeaturePart*>( ptrFeaturePartCompare );
+    while ( FeaturePart* fpart = featureParts->pop_front() )
+    {
+      const GEOSGeometry* geom = fpart->getGeometry();
+      if ( GEOSGeomTypeId( geom ) == GEOS_LINESTRING )
+      {
+
+        double bmin[2], bmax[2];
+        fpart->getBoundingBox( bmin, bmax );
+        rtree->Remove( bmin, bmax, fpart );
+
+        const GEOSCoordSequence *cs = GEOSGeom_getCoordSeq( geom );
+
+        // get number of points
+        unsigned int n;
+        GEOSCoordSeq_getSize( cs, &n );
+
+        // Read points
+        std::vector<Point> points( n );
+        for ( unsigned int i = 0; i < n; ++i )
+        {
+          GEOSCoordSeq_getX( cs, i, &points[i].x );
+          GEOSCoordSeq_getY( cs, i, &points[i].y );
+        }
+
+        // Cumulative length vector
+        std::vector<double> len( n, 0 );
+        for ( unsigned int i = 1; i < n; ++i )
+        {
+          double dx = points[i].x - points[i - 1].x;
+          double dy = points[i].y - points[i - 1].y;
+          len[i] = len[i - 1] + std::sqrt( dx * dx + dy * dy );
+        }
+
+        // Walk along line
+        unsigned int cur = 0;
+        double lambda = 0;
+        std::vector<Point> part;
+        for ( ;; )
+        {
+          lambda += chopInterval;
+          for ( ; cur < n && lambda > len[cur]; ++cur )
+          {
+            part.push_back( points[cur] );
+          }
+          if ( cur >= n )
+          {
+            break;
+          }
+          double c = ( lambda - len[cur - 1] ) / ( len[cur] - len[cur - 1] );
+          Point p;
+          p.x = points[cur - 1].x + c * ( points[cur].x - points[cur - 1].x );
+          p.y = points[cur - 1].y + c * ( points[cur].y - points[cur - 1].y );
+          part.push_back( p );
+          GEOSCoordSequence* cooSeq = GEOSCoordSeq_create( part.size(), 2 );
+          for ( std::size_t i = 0; i < part.size(); ++i )
+          {
+            GEOSCoordSeq_setX( cooSeq, i, part[i].x );
+            GEOSCoordSeq_setY( cooSeq, i, part[i].y );
+          }
+
+          GEOSGeometry* newgeom = GEOSGeom_createLineString( cooSeq );
+          FeaturePart* newfpart = new FeaturePart( fpart->getFeature(), newgeom );
+          newFeatureParts->push_back( newfpart );
+          newfpart->getBoundingBox( bmin, bmax );
+          rtree->Insert( bmin, bmax, newfpart );
+          part.clear();
+          part.push_back( p );
+        }
+        // Create final part
+        part.push_back( points[n - 1] );
+        GEOSCoordSequence* cooSeq = GEOSCoordSeq_create( part.size(), 2 );
+        for ( std::size_t i = 0; i < part.size(); ++i )
+        {
+          GEOSCoordSeq_setX( cooSeq, i, part[i].x );
+          GEOSCoordSeq_setY( cooSeq, i, part[i].y );
+        }
+
+        GEOSGeometry* newgeom = GEOSGeom_createLineString( cooSeq );
+        FeaturePart* newfpart = new FeaturePart( fpart->getFeature(), newgeom );
+        newFeatureParts->push_back( newfpart );
+        newfpart->getBoundingBox( bmin, bmax );
+        rtree->Insert( bmin, bmax, newfpart );
+      }
+      else
+      {
+        newFeatureParts->push_back( fpart );
+      }
+    }
+
+    delete featureParts;
+    featureParts = newFeatureParts;
   }
 
 

--- a/src/core/pal/layer.h
+++ b/src/core/pal/layer.h
@@ -113,6 +113,7 @@ namespace pal
       unsigned long arrangementFlags;
       LabelMode mode;
       bool mergeLines;
+      double repeatDistance;
 
       UpsideDownLabels upsidedownLabels;
 
@@ -289,6 +290,9 @@ namespace pal
       void setMergeConnectedLines( bool m ) { mergeLines = m; }
       bool getMergeConnectedLines() const { return mergeLines; }
 
+      void setRepeatDistance( double distance ) { repeatDistance = distance; }
+      double getRepeatDistance() const { return repeatDistance; }
+
       void setUpsidedownLabels( UpsideDownLabels ud ) { upsidedownLabels = ud; }
       UpsideDownLabels getUpsidedownLabels() const { return upsidedownLabels; }
 
@@ -321,13 +325,15 @@ namespace pal
                             const char* labelText = NULL, double labelPosX = 0.0, double labelPosY = 0.0,
                             bool fixedPos = false, double angle = 0.0, bool fixedAngle = false,
                             int xQuadOffset = 0, int yQuadOffset = 0, double xOffset = 0.0, double yOffset = 0.0,
-                            bool alwaysShow = false, double repeatDistance = 0.0 );
+                            bool alwaysShow = false );
 
       /** return pointer to feature or NULL if doesn't exist */
       Feature* getFeature( const char* geom_id );
 
       /** join connected features with the same label text */
       void joinConnectedFeatures();
+
+      void chopFeatures(double chopInterval );
 
   };
 

--- a/src/core/pal/pal.cpp
+++ b/src/core/pal/pal.cpp
@@ -429,6 +429,9 @@ namespace pal
             if ( layer->getMergeConnectedLines() )
               layer->joinConnectedFeatures();
 
+            if ( layer->getRepeatDistance() > 0 )
+              layer->chopFeatures( layer->getRepeatDistance() );
+
             context->layer = layer;
             context->priority = layersFactor[i];
             // lookup for feature (and generates candidates list)

--- a/src/core/qgspallabeling.cpp
+++ b/src/core/qgspallabeling.cpp
@@ -1985,7 +1985,15 @@ void QgsPalLayerSettings::registerFeature( QgsFeature& f, const QgsRenderContext
     }
   }
 
-  GEOSGeometry* geos_geom_clone = GEOSGeom_clone( geos_geom );
+  GEOSGeometry* geos_geom_clone;
+  if ( GEOSGeomTypeId( geos_geom ) == GEOS_POLYGON && repeatDistance > 0 && placement == Line )
+  {
+    geos_geom_clone = GEOSBoundary( geos_geom );
+  }
+  else
+  {
+    geos_geom_clone = GEOSGeom_clone( geos_geom );
+  }
 
   //data defined position / alignment / rotation?
   bool dataDefinedPosition = false;

--- a/src/ui/qgslabelingguibase.ui
+++ b/src/ui/qgslabelingguibase.ui
@@ -4313,6 +4313,9 @@ font-style: italic;</string>
                            <property name="decimals">
                             <number>4</number>
                            </property>
+                           <property name="maximum">
+                            <double>999999999.000000000000000</double>
+                           </property>
                           </widget>
                          </item>
                          <item row="0" column="2">

--- a/src/ui/qgslabelingguibase.ui
+++ b/src/ui/qgslabelingguibase.ui
@@ -3706,7 +3706,7 @@ font-style: italic;</string>
                        </widget>
                       </item>
                       <item>
-                       <widget class="QFrame" name="mPlacmentCentroidFrame">
+                       <widget class="QFrame" name="mPlacementCentroidFrame">
                         <property name="frameShape">
                          <enum>QFrame::NoFrame</enum>
                         </property>
@@ -4281,7 +4281,7 @@ font-style: italic;</string>
                        </widget>
                       </item>
                       <item>
-                       <widget class="QFrame" name="mPlacmentRepeatDistanceFrame">
+                       <widget class="QFrame" name="mPlacementRepeatDistanceFrame">
                         <property name="frameShape">
                          <enum>QFrame::NoFrame</enum>
                         </property>


### PR DESCRIPTION
Followup of PR #1338, adds support for multi-labeling polygon perimeters.

TBH b190546 is really one big hack, but after spending some time looking at the pal code, it looks like adding proper multi-labeling support there is not straight forward. So this seems the easiest solution. Comments welcome.

Referring to the "Merge connected lines to avoid duplicate labels" issue pointed out in #1338, is there an actual case where this is relevant when multi-labeling is enabled? Couldn't the merge connected lines setting just be ignored in this case?
