### PR TITLE
Set composer item positions relative to page origin

### DIFF
--- a/python/core/composer/qgscomposeritem.sip
+++ b/python/core/composer/qgscomposeritem.sip
@@ -179,6 +179,15 @@ class QgsComposerItem : QObject, QGraphicsRectItem
       @param y y-position of mouse cursor (in item coordinates)*/
     virtual void zoomContent( int delta, double x, double y );
 
+    /** gets the page the item is currently on */
+    int page() const;
+
+    /** Returns the position relative to the current page */
+    QPointF pagePos() const;
+
+    /** Updates the page relative position for the new paper size */
+    void updatePagePos( int newwidth, int newheight );
+
     /**Moves the item to a new position (in canvas coordinates)*/
     void setItemPosition( double x, double y, ItemPositionMode itemPoint = UpperLeft );
 

--- a/python/core/composer/qgscomposeritem.sip
+++ b/python/core/composer/qgscomposeritem.sip
@@ -186,7 +186,7 @@ class QgsComposerItem : QObject, QGraphicsRectItem
     QPointF pagePos() const;
 
     /** Updates the page relative position for the new paper size */
-    void updatePagePos( int newwidth, int newheight );
+    void updatePagePos( double newPageWidth, double newPageHeight );
 
     /**Moves the item to a new position (in canvas coordinates)*/
     void setItemPosition( double x, double y, ItemPositionMode itemPoint = UpperLeft );

--- a/src/app/composer/qgscomposeritemwidget.cpp
+++ b/src/app/composer/qgscomposeritemwidget.cpp
@@ -423,7 +423,13 @@ void QgsComposerItemWidget::setValuesForGuiElements()
 
 void QgsComposerItemWidget::setPages()
 {
-  mPageSpinBox->setMaximum( mItem->composition()->numPages() );
+  int maxPages = mItem->composition()->numPages();
+  if ( maxPages < mPageSpinBox->value() )
+  {
+    double h = ( mItem->composition()->paperHeight() + mItem->composition()->spaceBetweenPages() );
+    mYLineEdit->setText( QString::number( mYLineEdit->text().toDouble( ) + ( mPageSpinBox->value() - maxPages ) * h ) );
+  }
+  mPageSpinBox->setMaximum( maxPages );
 }
 
 void QgsComposerItemWidget::on_mBlendModeCombo_currentIndexChanged( int index )

--- a/src/app/composer/qgscomposeritemwidget.cpp
+++ b/src/app/composer/qgscomposeritemwidget.cpp
@@ -18,6 +18,7 @@
 #include "qgscomposeritemwidget.h"
 #include "qgscomposeritem.h"
 #include "qgscomposermap.h"
+#include "qgscomposition.h"
 #include "qgspoint.h"
 #include <QColorDialog>
 #include <QPen>
@@ -46,6 +47,8 @@ QgsComposerItemWidget::QgsComposerItemWidget( QWidget* parent, QgsComposerItem* 
   mHeightLineEdit->setValidator( new QDoubleValidator( 0 ) );
 
   setValuesForGuiElements();
+  connect( mItem->composition(), SIGNAL( nPagesChanged() ), this, SLOT( setPages() ) );
+  connect( mItem->composition(), SIGNAL( paperSizeChanged() ), this, SLOT( setValuesForGuiPositionElements() ) );
   connect( mItem, SIGNAL( sizeChanged() ), this, SLOT( setValuesForGuiPositionElements() ) );
   connect( mItem, SIGNAL( itemChanged() ), this, SLOT( setValuesForGuiNonPositionElements() ) );
 
@@ -142,7 +145,7 @@ void QgsComposerItemWidget::changeItemPosition()
     return;
   }
 
-  mItem->setItemPosition( x, y, width, height, positionMode() );
+  mItem->setItemPosition( x, y, width, height, positionMode(), false, mPageSpinBox->value() );
 
   mItem->update();
   mItem->endCommand();
@@ -270,73 +273,76 @@ void QgsComposerItemWidget::setValuesForGuiPositionElements()
   mLowerLeftCheckBox->blockSignals( true );
   mLowerMiddleCheckBox->blockSignals( true );
   mLowerRightCheckBox->blockSignals( true );
+  mPageSpinBox->blockSignals( true );
 
+  QPointF pos = mItem->pagePos();
 
   if ( mItem->lastUsedPositionMode() == QgsComposerItem::UpperLeft )
   {
     mUpperLeftCheckBox->setChecked( true );
-    mXLineEdit->setText( QString::number( mItem->pos().x() ) );
-    mYLineEdit->setText( QString::number( mItem->pos().y() ) );
+    mXLineEdit->setText( QString::number( pos.x() ) );
+    mYLineEdit->setText( QString::number( pos.y() ) );
   }
 
   if ( mItem->lastUsedPositionMode() == QgsComposerItem::UpperMiddle )
   {
     mUpperMiddleCheckBox->setChecked( true );
-    mXLineEdit->setText( QString::number( mItem->pos().x() + mItem->rect().width() / 2.0 ) );
-    mYLineEdit->setText( QString::number( mItem->pos().y() ) );
+    mXLineEdit->setText( QString::number( pos.x() + mItem->rect().width() / 2.0 ) );
+    mYLineEdit->setText( QString::number( pos.y() ) );
   }
 
   if ( mItem->lastUsedPositionMode() == QgsComposerItem::UpperRight )
   {
     mUpperRightCheckBox->setChecked( true );
-    mXLineEdit->setText( QString::number( mItem->pos().x() + mItem->rect().width() ) );
-    mYLineEdit->setText( QString::number( mItem->pos().y() ) );
+    mXLineEdit->setText( QString::number( pos.x() + mItem->rect().width() ) );
+    mYLineEdit->setText( QString::number( pos.y() ) );
   }
 
   if ( mItem->lastUsedPositionMode() == QgsComposerItem::MiddleLeft )
   {
     mMiddleLeftCheckBox->setChecked( true );
-    mXLineEdit->setText( QString::number( mItem->pos().x() ) );
-    mYLineEdit->setText( QString::number( mItem->pos().y() + mItem->rect().height() / 2.0 ) );
+    mXLineEdit->setText( QString::number( pos.x() ) );
+    mYLineEdit->setText( QString::number( pos.y() + mItem->rect().height() / 2.0 ) );
   }
 
   if ( mItem->lastUsedPositionMode() == QgsComposerItem::Middle )
   {
     mMiddleCheckBox->setChecked( true );
-    mXLineEdit->setText( QString::number( mItem->pos().x() + mItem->rect().width() / 2.0 ) );
-    mYLineEdit->setText( QString::number( mItem->pos().y() + mItem->rect().height() / 2.0 ) );
+    mXLineEdit->setText( QString::number( pos.x() + mItem->rect().width() / 2.0 ) );
+    mYLineEdit->setText( QString::number( pos.y() + mItem->rect().height() / 2.0 ) );
   }
 
   if ( mItem->lastUsedPositionMode() == QgsComposerItem::MiddleRight )
   {
     mMiddleRightCheckBox->setChecked( true );
-    mXLineEdit->setText( QString::number( mItem->pos().x() + mItem->rect().width() ) );
-    mYLineEdit->setText( QString::number( mItem->pos().y() + mItem->rect().height() / 2.0 ) );
+    mXLineEdit->setText( QString::number( pos.x() + mItem->rect().width() ) );
+    mYLineEdit->setText( QString::number( pos.y() + mItem->rect().height() / 2.0 ) );
   }
 
   if ( mItem->lastUsedPositionMode() == QgsComposerItem::LowerLeft )
   {
     mLowerLeftCheckBox->setChecked( true );
-    mXLineEdit->setText( QString::number( mItem->pos().x() ) );
-    mYLineEdit->setText( QString::number( mItem->pos().y() + mItem->rect().height() ) );
+    mXLineEdit->setText( QString::number( pos.x() ) );
+    mYLineEdit->setText( QString::number( pos.y() + mItem->rect().height() ) );
   }
 
   if ( mItem->lastUsedPositionMode() == QgsComposerItem::LowerMiddle )
   {
     mLowerMiddleCheckBox->setChecked( true );
-    mXLineEdit->setText( QString::number( mItem->pos().x() + mItem->rect().width() / 2.0 ) );
-    mYLineEdit->setText( QString::number( mItem->pos().y() + mItem->rect().height() ) );
+    mXLineEdit->setText( QString::number( pos.x() + mItem->rect().width() / 2.0 ) );
+    mYLineEdit->setText( QString::number( pos.y() + mItem->rect().height() ) );
   }
 
   if ( mItem->lastUsedPositionMode() == QgsComposerItem::LowerRight )
   {
     mLowerRightCheckBox->setChecked( true );
-    mXLineEdit->setText( QString::number( mItem->pos().x() + mItem->rect().width() ) );
-    mYLineEdit->setText( QString::number( mItem->pos().y() + mItem->rect().height() ) );
+    mXLineEdit->setText( QString::number( pos.x() + mItem->rect().width() ) );
+    mYLineEdit->setText( QString::number( pos.y() + mItem->rect().height() ) );
   }
 
   mWidthLineEdit->setText( QString::number( mItem->rect().width() ) );
   mHeightLineEdit->setText( QString::number( mItem->rect().height() ) );
+  mPageSpinBox->setValue( mItem->page() );
 
 
   mXLineEdit->blockSignals( false );
@@ -352,6 +358,7 @@ void QgsComposerItemWidget::setValuesForGuiPositionElements()
   mLowerLeftCheckBox->blockSignals( false );
   mLowerMiddleCheckBox->blockSignals( false );
   mLowerRightCheckBox->blockSignals( false );
+  mPageSpinBox->blockSignals( false );
 }
 
 void QgsComposerItemWidget::setValuesForGuiNonPositionElements()
@@ -412,6 +419,11 @@ void QgsComposerItemWidget::setValuesForGuiElements()
 
   setValuesForGuiPositionElements();
   setValuesForGuiNonPositionElements();
+}
+
+void QgsComposerItemWidget::setPages()
+{
+  mPageSpinBox->setMaximum( mItem->composition()->numPages() );
 }
 
 void QgsComposerItemWidget::on_mBlendModeCombo_currentIndexChanged( int index )

--- a/src/app/composer/qgscomposeritemwidget.h
+++ b/src/app/composer/qgscomposeritemwidget.h
@@ -60,6 +60,7 @@ class QgsComposerItemWidget: public QWidget, private Ui::QgsComposerItemWidgetBa
     void on_mItemIdLineEdit_editingFinished();
 
     //adjust coordinates in line edits
+    void on_mPageSpinBox_valueChanged(int) { changeItemPosition(); }
     void on_mXLineEdit_editingFinished() { changeItemPosition(); }
     void on_mYLineEdit_editingFinished() { changeItemPosition(); }
     void on_mWidthLineEdit_editingFinished() { changeItemPosition(); }
@@ -85,6 +86,10 @@ class QgsComposerItemWidget: public QWidget, private Ui::QgsComposerItemWidgetBa
     void setValuesForGuiPositionElements();
     //sets the values for all non-position related elements
     void setValuesForGuiNonPositionElements();
+
+private slots:
+    // sets the number of pages in the page number spinbox
+    void setPages();
 
   private:
     QgsComposerItemWidget();

--- a/src/core/composer/qgscomposeritem.cpp
+++ b/src/core/composer/qgscomposeritem.cpp
@@ -172,8 +172,12 @@ bool QgsComposerItem::_writeXML( QDomElement& itemElem, QDomDocument& doc ) cons
   }
 
   //scene rect
+  QPointF pagepos = pagePos();
   composerItemElem.setAttribute( "x", QString::number( pos().x() ) );
   composerItemElem.setAttribute( "y", QString::number( pos().y() ) );
+  composerItemElem.setAttribute( "page", page() );
+  composerItemElem.setAttribute( "pagex", QString::number( pagepos.x() ) );
+  composerItemElem.setAttribute( "pagey", QString::number( pagepos.y() ) );
   composerItemElem.setAttribute( "width", QString::number( rect().width() ) );
   composerItemElem.setAttribute( "height", QString::number( rect().height() ) );
   composerItemElem.setAttribute( "positionMode", QString::number(( int ) mLastUsedPositionMode ) );
@@ -280,17 +284,28 @@ bool QgsComposerItem::_readXML( const QDomElement& itemElem, const QDomDocument&
   }
 
   //position
-  double x, y, width, height;
-  bool xOk, yOk, widthOk, heightOk, positionModeOK;
+  int page;
+  double x, y, pagex, pagey, width, height;
+  bool xOk, yOk, pageOk, pagexOk, pageyOk, widthOk, heightOk, positionModeOK;
 
   x = itemElem.attribute( "x" ).toDouble( &xOk );
   y = itemElem.attribute( "y" ).toDouble( &yOk );
+  page = itemElem.attribute( "page" ).toInt( &pageOk );
+  pagex = itemElem.attribute( "pagex" ).toDouble( &pagexOk );
+  pagey = itemElem.attribute( "pagey" ).toDouble( &pageyOk );
   width = itemElem.attribute( "width" ).toDouble( &widthOk );
   height = itemElem.attribute( "height" ).toDouble( &heightOk );
   mLastUsedPositionMode = ( ItemPositionMode )itemElem.attribute( "positionMode" ).toInt( &positionModeOK );
   if ( !positionModeOK )
   {
     mLastUsedPositionMode = UpperLeft;
+  }
+  if ( pageOk && pagexOk && pageyOk )
+  {
+    xOk = true;
+    yOk = true;
+    x = pagex;
+    y = ( page - 1 ) * ( mComposition->paperHeight() + composition()->spaceBetweenPages() ) + pagey;
   }
 
   if ( !xOk || !yOk || !widthOk || !heightOk )

--- a/src/core/composer/qgscomposeritem.cpp
+++ b/src/core/composer/qgscomposeritem.cpp
@@ -502,11 +502,12 @@ QPointF QgsComposerItem::pagePos() const
   return p;
 }
 
-void QgsComposerItem::updatePagePos( int /*newwidth*/, int newheight )
+void QgsComposerItem::updatePagePos( double newPageWidth, double newPageHeight )
 {
+  Q_UNUSED( newPageWidth )
   QPointF curPagePos = pagePos();
   int curPage = page() - 1;
-  setY( curPage * ( newheight + composition()->spaceBetweenPages() ) + curPagePos.y() );
+  setY( curPage * ( newPageHeight + composition()->spaceBetweenPages() ) + curPagePos.y() );
   emit sizeChanged();
 }
 

--- a/src/core/composer/qgscomposeritem.cpp
+++ b/src/core/composer/qgscomposeritem.cpp
@@ -481,17 +481,52 @@ void QgsComposerItem::move( double dx, double dy )
   setSceneRect( newSceneRect );
 }
 
-void QgsComposerItem::setItemPosition( double x, double y, ItemPositionMode itemPoint )
+int QgsComposerItem::page() const
+{
+  double y = pos().y();
+  double h = composition()->paperHeight() + composition()->spaceBetweenPages();
+  int page = 1;
+  while ( y - h >= 0. )
+  {
+    y -= h;
+    ++page;
+  }
+  return page;
+}
+
+QPointF QgsComposerItem::pagePos() const
+{
+  QPointF p = pos();
+  double h = composition()->paperHeight() + composition()->spaceBetweenPages();
+  p.ry() -= ( page() - 1 ) * h;
+  return p;
+}
+
+void QgsComposerItem::updatePagePos( int /*newwidth*/, int newheight )
+{
+  QPointF curPagePos = pagePos();
+  int curPage = page() - 1;
+  setY( curPage * ( newheight + composition()->spaceBetweenPages() ) + curPagePos.y() );
+  emit sizeChanged();
+}
+
+void QgsComposerItem::setItemPosition( double x, double y, ItemPositionMode itemPoint, int page )
 {
   double width = rect().width();
   double height = rect().height();
-  setItemPosition( x, y, width, height, itemPoint );
+  setItemPosition( x, y, width, height, itemPoint, page );
 }
 
-void QgsComposerItem::setItemPosition( double x, double y, double width, double height, ItemPositionMode itemPoint, bool posIncludesFrame )
+void QgsComposerItem::setItemPosition( double x, double y, double width, double height, ItemPositionMode itemPoint, bool posIncludesFrame, int page )
 {
   double upperLeftX = x;
   double upperLeftY = y;
+
+  if ( page > 0 )
+  {
+    double h = composition()->paperHeight() + composition()->spaceBetweenPages();
+    upperLeftY += ( page - 1 ) * h;
+  }
 
   //store the item position mode
   mLastUsedPositionMode = itemPoint;

--- a/src/core/composer/qgscomposeritem.h
+++ b/src/core/composer/qgscomposeritem.h
@@ -133,8 +133,17 @@ class CORE_EXPORT QgsComposerItem: public QObject, public QGraphicsRectItem
       @param y y-position of mouse cursor (in item coordinates)*/
     virtual void zoomContent( int delta, double x, double y ) { Q_UNUSED( delta ); Q_UNUSED( x ); Q_UNUSED( y ); }
 
+    /** gets the page the item is currently on */
+    int page() const;
+
+    /** Returns the position relative to the current page */
+    QPointF pagePos() const;
+
+    /** Updates the page relative position for the new paper size */
+    void updatePagePos( int newwidth, int newheight );
+
     /**Moves the item to a new position (in canvas coordinates)*/
-    void setItemPosition( double x, double y, ItemPositionMode itemPoint = UpperLeft );
+    void setItemPosition( double x, double y, ItemPositionMode itemPoint = UpperLeft, int page = -1 );
 
     /**Sets item position and width / height in one go
       @param x item position x
@@ -143,9 +152,9 @@ class CORE_EXPORT QgsComposerItem: public QObject, public QGraphicsRectItem
       @param height item height
       @param itemPoint item position mode
       @param posIncludesFrame set to true if the position and size arguments include the item's frame border
-
+      @param page if page > 0, y is interpreted as relative to the origin of the specified page, if page <= 0, y is in absolute canvas coordinates
       @note: this method was added in version 1.6*/
-    void setItemPosition( double x, double y, double width, double height, ItemPositionMode itemPoint = UpperLeft, bool posIncludesFrame = false );
+    void setItemPosition( double x, double y, double width, double height, ItemPositionMode itemPoint = UpperLeft, bool posIncludesFrame = false, int page = -1 );
 
     /**Returns item's last used position mode.
       @note: This property has no effect on actual's item position, which is always the top-left corner.

--- a/src/core/composer/qgscomposeritem.h
+++ b/src/core/composer/qgscomposeritem.h
@@ -140,7 +140,7 @@ class CORE_EXPORT QgsComposerItem: public QObject, public QGraphicsRectItem
     QPointF pagePos() const;
 
     /** Updates the page relative position for the new paper size */
-    void updatePagePos( int newwidth, int newheight );
+    void updatePagePos( double newPageWidth, double newPageHeight );
 
     /**Moves the item to a new position (in canvas coordinates)*/
     void setItemPosition( double x, double y, ItemPositionMode itemPoint = UpperLeft, int page = -1 );

--- a/src/core/composer/qgscomposition.cpp
+++ b/src/core/composer/qgscomposition.cpp
@@ -220,6 +220,17 @@ QRectF QgsComposition::compositionBounds() const
 
 void QgsComposition::setPaperSize( double width, double height )
 {
+  QList<QGraphicsItem *> itemList = items();
+  QList<QGraphicsItem *>::iterator itemIt = itemList.begin();
+  for ( ; itemIt != itemList.end(); ++itemIt )
+  {
+    QgsComposerItem* composerItem = dynamic_cast<QgsComposerItem *>( *itemIt );
+    if ( composerItem )
+    {
+      composerItem->updatePagePos( width, height );
+    }
+  }
+
   mPageWidth = width;
   mPageHeight = height;
   double currentY = 0;

--- a/src/ui/qgscomposeritemwidgetbase.ui
+++ b/src/ui/qgscomposeritemwidgetbase.ui
@@ -179,45 +179,59 @@
         </item>
         <item row="0" column="0" rowspan="2">
          <layout class="QGridLayout" name="gridLayout_3">
-          <item row="0" column="0">
-           <widget class="QLabel" name="mXLabel">
-            <property name="text">
-             <string>X</string>
-            </property>
-           </widget>
+          <item row="4" column="1">
+           <widget class="QLineEdit" name="mHeightLineEdit"/>
           </item>
-          <item row="0" column="1">
+          <item row="1" column="1">
            <widget class="QLineEdit" name="mXLineEdit"/>
           </item>
-          <item row="1" column="0">
+          <item row="3" column="1">
+           <widget class="QLineEdit" name="mWidthLineEdit"/>
+          </item>
+          <item row="2" column="0">
            <widget class="QLabel" name="mYLabel">
             <property name="text">
              <string>Y</string>
             </property>
            </widget>
           </item>
-          <item row="1" column="1">
-           <widget class="QLineEdit" name="mYLineEdit"/>
-          </item>
-          <item row="2" column="0">
+          <item row="3" column="0">
            <widget class="QLabel" name="mWidthLabel">
             <property name="text">
              <string>Width</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
-           <widget class="QLineEdit" name="mWidthLineEdit"/>
+          <item row="1" column="0">
+           <widget class="QLabel" name="mXLabel">
+            <property name="text">
+             <string>X</string>
+            </property>
+           </widget>
           </item>
-          <item row="3" column="0">
+          <item row="4" column="0">
            <widget class="QLabel" name="mHeightLabel">
             <property name="text">
              <string>Height</string>
             </property>
            </widget>
           </item>
-          <item row="3" column="1">
-           <widget class="QLineEdit" name="mHeightLineEdit"/>
+          <item row="2" column="1">
+           <widget class="QLineEdit" name="mYLineEdit"/>
+          </item>
+          <item row="0" column="0">
+           <widget class="QLabel" name="mPageLabel">
+            <property name="text">
+             <string>Page</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="1">
+           <widget class="QSpinBox" name="mPageSpinBox">
+            <property name="minimum">
+             <number>1</number>
+            </property>
+           </widget>
           </item>
          </layout>
         </item>


### PR DESCRIPTION
With this commit, composer item positions are shown relative to the page origin in the UI, and new spinbox also allows the user to select which page the item is placed on. Internally, the positions are still stored with respect to the absolute origin, so this will not break existing compositions.

Funded by Sourcepole QGIS Enterprise
