### PR TITLE
change a deprecated Constant in spatialite Provider the new is compliant with SL 4.1.1 and new coming 4.2.0

### DIFF
--- a/src/providers/spatialite/qgsspatialiteconnection.cpp
+++ b/src/providers/spatialite/qgsspatialiteconnection.cpp
@@ -298,7 +298,7 @@ bool QgsSpatiaLiteConnection::getTableInfoAbstractInterface( sqlite3 * handle, b
   }
 
 // attempting to load the VectorLayersList
-  list = gaiaGetVectorLayersList( handle, NULL, NULL, GAIA_VECTORS_LIST_FAST );
+  list = gaiaGetVectorLayersList( handle, NULL, NULL, GAIA_VECTORS_LIST_OPTIMISTIC );
   if ( list != NULL )
   {
     gaiaVectorLayerPtr lyr = list->First;


### PR DESCRIPTION
change a constant deprecated in 4.1.1 and removed in SL 4.2.0 RC.
