### PR TITLE
Consider also font descent and baseline in QgsComposerLabel::adjustSizeToText

### DIFF
--- a/src/core/composer/qgscomposeritem.cpp
+++ b/src/core/composer/qgscomposeritem.cpp
@@ -749,6 +749,13 @@ double QgsComposerItem::fontDescentMillimeters( const QFont& font ) const
   return ( fontMetrics.descent() / FONT_WORKAROUND_SCALE );
 }
 
+double QgsComposerItem::fontHeightMillimeters( const QFont& font ) const
+{
+  QFont metricsFont = scaledFontPixelSize( font );
+  QFontMetricsF fontMetrics( metricsFont );
+  return ( fontMetrics.height() / FONT_WORKAROUND_SCALE );
+}
+
 double QgsComposerItem::pixelFontSize( double pointSize ) const
 {
   return ( pointSize * 0.3527 );

--- a/src/core/composer/qgscomposeritem.h
+++ b/src/core/composer/qgscomposeritem.h
@@ -363,6 +363,8 @@ class CORE_EXPORT QgsComposerItem: public QObject, public QGraphicsRectItem
     /**Returns the font ascent in Millimeters (considers upscaling and downscaling with FONT_WORKAROUND_SCALE*/
     double fontDescentMillimeters( const QFont& font ) const;
 
+    double fontHeightMillimeters( const QFont& font ) const;
+
     /**Calculates font to from point size to pixel size*/
     double pixelFontSize( double pointSize ) const;
 

--- a/src/core/composer/qgscomposerlabel.cpp
+++ b/src/core/composer/qgscomposerlabel.cpp
@@ -254,10 +254,10 @@ void QgsComposerLabel::setFont( const QFont& f )
 void QgsComposerLabel::adjustSizeToText()
 {
   double textWidth = textWidthMillimeters( mFont, displayText() );
-  double fontAscent = fontAscentMillimeters( mFont );
+  double fontHeight = fontHeightMillimeters( mFont );
 
   double width = textWidth + 2 * mMargin + 2 * pen().widthF() + 1;
-  double height = fontAscent + 2 * mMargin + 2 * pen().widthF() + 1;
+  double height = fontHeight + 2 * mMargin + 2 * pen().widthF();
 
   //keep alignment point constant
   double xShift = 0;


### PR DESCRIPTION
Consider also font descent and baseline in QgsComposerLabel::adjustSizeToText.

Funded by Sourcepole QGIS Enterprise.
