### PR TITLE
Update composer legend entry when layer symbology changes. 

### DIFF
--- a/src/core/composer/qgslegendmodel.h
+++ b/src/core/composer/qgslegendmodel.h
@@ -99,6 +99,9 @@ class CORE_EXPORT QgsLegendModel : public QStandardItemModel
     void removeLayer( const QString& layerId );
     void addLayer( QgsMapLayer* theMapLayer, double scaleDenominator = -1, QString rule = "" );
 
+  private slots:
+    void updateLayer();
+
   signals:
     void layersChanged();
 


### PR DESCRIPTION
This commit ensures that the composer legend item symbols are correctly update when the symbology of the respective layers change, if automatic updates to the composer legend are enabled.

There is one slightly ugly aspect, namely that the actual layer is retrieved via `QObject::sender()`. Another option would have been to add a `QgsMapLayer::rendererChanged(QString)` signal which is emitted like  `QgsMapLayer::rendererChanged()`, but also passes the layer id. However, it adds more code.

Funded by Sourcepole QGIS Enterprise.
