### PR TITLE
Fix bug #10195: Offset line symbology added to polygon layer leads to crash

### DIFF
--- a/src/core/symbology-ng/qgslinesymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgslinesymbollayerv2.cpp
@@ -273,7 +273,7 @@ void QgsSimpleLineSymbolLayerV2::renderPolyline( const QPolygonF& points, QgsSym
   else
   {
     double scaledOffset = offset * QgsSymbolLayerV2Utils::lineWidthScaleFactor( context.renderContext(), mOffsetUnit, mOffsetMapUnitScale );
-    QList<QPolygonF> mline = ::offsetLine( points, scaledOffset );
+    QList<QPolygonF> mline = ::offsetLine( points, scaledOffset, context.feature() ? context.feature()->geometry()->type() : QGis::Line );
     for ( int part = 0; part < mline.count(); ++part )
       p->drawPolyline( mline[ part ] );
   }
@@ -765,7 +765,7 @@ void QgsMarkerLineSymbolLayerV2::renderPolyline( const QPolygonF& points, QgsSym
   }
   else
   {
-    QList<QPolygonF> mline = ::offsetLine( points, offset * QgsSymbolLayerV2Utils::lineWidthScaleFactor( context.renderContext(), mOffsetUnit, mOffsetMapUnitScale ) );
+    QList<QPolygonF> mline = ::offsetLine( points, offset * QgsSymbolLayerV2Utils::lineWidthScaleFactor( context.renderContext(), mOffsetUnit, mOffsetMapUnitScale ), context.feature() ? context.feature()->geometry()->type() : QGis::Line );
 
     for ( int part = 0; part < mline.count(); ++part )
     {

--- a/src/core/symbology-ng/qgssymbollayerv2utils.h
+++ b/src/core/symbology-ng/qgssymbollayerv2utils.h
@@ -312,9 +312,10 @@ class CORE_EXPORT QgsSymbolLayerV2Utils
 
 class QPolygonF;
 
-//! calculate line shifted by a specified distance
+//! @deprecated since 2.4 - calculate line shifted by a specified distance
 QList<QPolygonF> offsetLine( QPolygonF polyline, double dist );
-
+//! calculate geometry shifted by a specified distance
+QList<QPolygonF> offsetLine( QPolygonF polyline, double dist, QGis::GeometryType geometryType );
 
 #endif
 


### PR DESCRIPTION
This PR attemps to fix the bug 10195 ( http://hub.qgis.org/issues/10195 ) using GEOSBuffer in offsetline when the geometry is a polygon.
