### PR TITLE
Fix #10518, PAL engine settings no longer honored by qgis_mapserv

### DIFF
--- a/src/mapserver/qgis_map_serv.cpp
+++ b/src/mapserver/qgis_map_serv.cpp
@@ -389,7 +389,6 @@ int main( int argc, char * argv[] )
         theRequestHandler->sendServiceException( QgsMapServiceException( "WMS configuration error", "There was an error reading the project file or the SLD configuration" ) );
         continue;
       }
-      //adminConfigParser->loadLabelSettings( theMapRenderer->labelingEngine() );
       QgsWMSServer wmsServer( configFilePath, parameterMap, p, theRequestHandler.take(), theMapRenderer.data(), &capabilitiesCache );
       wmsServer.executeRequest();
     }

--- a/src/mapserver/qgssldconfigparser.cpp
+++ b/src/mapserver/qgssldconfigparser.cpp
@@ -533,8 +533,9 @@ void QgsSLDConfigParser::drawOverlays( QPainter *, int , int, int ) const
   //todo: fixme
 }
 
-void QgsSLDConfigParser::loadLabelSettings( QgsLabelingEngineInterface * )
+void QgsSLDConfigParser::loadLabelSettings( QgsLabelingEngineInterface * lbl ) const
 {
+  Q_UNUSED ( lbl );
   //needs to be here?
 }
 

--- a/src/mapserver/qgssldconfigparser.h
+++ b/src/mapserver/qgssldconfigparser.h
@@ -76,8 +76,8 @@ class QgsSLDConfigParser: public QgsWMSConfigParser
     /**Draw text annotation items from the QGIS projectfile*/
     void drawOverlays( QPainter* p, int dpi, int width, int height ) const;
 
-    //todo: fixme
-    void loadLabelSettings( QgsLabelingEngineInterface* lbl );
+    /**Load PAL engine settings from projectfile*/
+    void loadLabelSettings( QgsLabelingEngineInterface* lbl ) const;
 
     QString serviceUrl() const;
 

--- a/src/mapserver/qgswmsconfigparser.h
+++ b/src/mapserver/qgswmsconfigparser.h
@@ -74,8 +74,8 @@ class QgsWMSConfigParser
     /**Draw text annotation items from the QGIS projectfile*/
     virtual void drawOverlays( QPainter* p, int dpi, int width, int height ) const = 0;
 
-    //todo: fixme
-    virtual void loadLabelSettings( QgsLabelingEngineInterface* lbl ) { Q_UNUSED( lbl ); } //= 0;
+    /**Load PAL engine settings from the QGIS projectfile*/
+    virtual void loadLabelSettings( QgsLabelingEngineInterface* lbl ) const = 0;
 
     virtual QString serviceUrl() const = 0;
 

--- a/src/mapserver/qgswmsprojectparser.cpp
+++ b/src/mapserver/qgswmsprojectparser.cpp
@@ -21,6 +21,7 @@
 #include "qgslogger.h"
 #include "qgsmaplayer.h"
 #include "qgsmapserviceexception.h"
+#include "qgspallabeling.h"
 #include "qgsvectorlayer.h"
 
 #include "qgscomposition.h"
@@ -1748,6 +1749,77 @@ void QgsWMSProjectParser::drawOverlays( QPainter* p, int dpi, int width, int hei
       svgIt->first->render( p, QRectF( xPos, yPos, renderWidth,
                                        renderHeight ) );
     }
+  }
+}
+
+void QgsWMSProjectParser::loadLabelSettings( QgsLabelingEngineInterface* lbl ) const
+{
+  QgsPalLabeling* pal = dynamic_cast<QgsPalLabeling*>( lbl );
+  if ( pal )
+  {
+    QDomElement propertiesElem = mProjectParser.propertiesElem();
+    if ( propertiesElem.isNull() )
+    {
+      return;
+    }
+
+    QDomElement palElem = propertiesElem.firstChildElement( "PAL" );
+    if ( palElem.isNull() )
+    {
+      return;
+    }
+
+    //pal::Pal default positions for candidates;
+    int candPoint, candLine, candPoly;
+    pal->numCandidatePositions( candPoint, candLine, candPoly );
+
+    //mCandPoint
+    QDomElement candPointElem = palElem.firstChildElement( "CandidatesPoint" );
+    if ( !candPointElem.isNull() )
+    {
+      candPoint = candPointElem.text().toInt();
+    }
+
+    //mCandLine
+    QDomElement candLineElem = palElem.firstChildElement( "CandidatesLine" );
+    if ( !candLineElem.isNull() )
+    {
+      candLine = candLineElem.text().toInt();
+    }
+
+    //mCandPolygon
+    QDomElement candPolyElem = palElem.firstChildElement( "CandidatesPolygon" );
+    if ( !candPolyElem.isNull() )
+    {
+      candPoly = candPolyElem.text().toInt();
+    }
+
+    pal->setNumCandidatePositions( candPoint, candLine, candPoly );
+
+    //mShowingCandidates
+    QDomElement showCandElem = palElem.firstChildElement( "ShowingCandidates" );
+    if ( !showCandElem.isNull() )
+    {
+      pal->setShowingCandidates( showCandElem.text().compare( "true", Qt::CaseInsensitive ) == 0 );
+    }
+
+    //mShowingAllLabels
+    QDomElement showAllLabelsElem = palElem.firstChildElement( "ShowingAllLabels" );
+    if ( !showAllLabelsElem.isNull() )
+    {
+      pal->setShowingAllLabels( showAllLabelsElem.text().compare( "true", Qt::CaseInsensitive ) == 0 );
+    }
+
+    //mShowingPartialsLabels
+    QDomElement showPartialsLabelsElem = palElem.firstChildElement( "ShowingPartialsLabels" );
+    if ( !showPartialsLabelsElem.isNull() )
+    {
+      pal->setShowingPartialsLabels( showPartialsLabelsElem.text().compare( "true", Qt::CaseInsensitive ) == 0 );
+    }
+
+    //mDrawOutlineLabels
+    // TODO: This should probably always be true (already default) for WMS, regardless of any project setting.
+    //       Not much sense to output text-as-text, when text-as-outlines gives better results.
   }
 }
 

--- a/src/mapserver/qgswmsprojectparser.h
+++ b/src/mapserver/qgswmsprojectparser.h
@@ -98,6 +98,9 @@ class QgsWMSProjectParser: public QgsWMSConfigParser
     /**Draw text annotation items from the QGIS projectfile*/
     void drawOverlays( QPainter* p, int dpi, int width, int height ) const;
 
+    /**Load PAL engine settings from projectfile*/
+    void loadLabelSettings( QgsLabelingEngineInterface* lbl ) const;
+
     int nLayers() const;
 
     void serviceCapabilities( QDomElement& parentElement, QDomDocument& doc ) const;

--- a/src/mapserver/qgswmsserver.cpp
+++ b/src/mapserver/qgswmsserver.cpp
@@ -999,6 +999,11 @@ QImage* QgsWMSServer::getMap()
 
   applyOpacities( layersList, bkVectorRenderers, bkRasterRenderers, labelTransparencies, labelBufferTransparencies );
 
+  if ( mConfigParser )
+  {
+    mConfigParser->loadLabelSettings( mMapRenderer->labelingEngine() );
+  }
+
   mMapRenderer->render( &thePainter );
   if ( mConfigParser )
   {


### PR DESCRIPTION
This attempts to fix the issue. Works fine here.

Do the `drawOverlays` and `loadLabelSettings` functions need to be virtual in the base `QgsWMSConfigParser` class? Or, should they only extend in `QgsWMSProjectParser`, since a project is required?

The `mDrawOutlineLabels` extra setting comment, with no code, refers to the setting added by PR #1286.
