### PR TITLE
Fix bug #10433: Crash simplificating and labeling invalid or empty multipolygons

### DIFF
--- a/src/core/qgsmaptopixelgeometrysimplifier.cpp
+++ b/src/core/qgsmaptopixelgeometrysimplifier.cpp
@@ -247,10 +247,17 @@ bool QgsMapToPixelSimplifier::simplifyWkbGeometry( int simplifyFlags, QGis::WkbT
     // Fix the topology of the geometry
     if ( numTargetPoints <= ( isaLinearRing ? 2 : 1 ) )
     {
+      unsigned char* targetTempWkb = targetWkb;
+      int targetWkbTempSize = targetWkbSize;
+
       sourceWkb = sourcePrevWkb;
       targetWkb = targetPrevWkb;
       targetWkbSize = targetWkbPrevSize;
-      return generalizeWkbGeometry( wkbType, sourceWkb, sourceWkbSize, targetWkb, targetWkbSize, QgsRectangle( xmin, ymin, xmax, ymax ), writeHeader );
+      bool isok = generalizeWkbGeometry( wkbType, sourceWkb, sourceWkbSize, targetWkb, targetWkbSize, QgsRectangle( xmin, ymin, xmax, ymax ), writeHeader );
+      if ( isok ) return true;
+
+      targetWkb = targetTempWkb;
+      targetWkbSize = targetWkbTempSize;
     }
     if ( isaLinearRing )
     {

--- a/src/core/qgspallabeling.cpp
+++ b/src/core/qgspallabeling.cpp
@@ -1917,7 +1917,8 @@ void QgsPalLayerSettings::registerFeature( QgsFeature& f, const QgsRenderContext
   // fix invalid polygons
   if ( geom->type() == QGis::Polygon && !geom->isGeosValid() )
   {
-    geom->fromGeos( GEOSBuffer( geom->asGeos(), 0, 0 ) );
+    const GEOSGeometry* geos = geom->asGeos();
+    if ( geos ) geom->fromGeos( GEOSBuffer( geos, 0, 0 ) );
   }
 
   // CLIP the geometry if it is bigger than the extent


### PR DESCRIPTION
This PR fixes the bug ( http://hub.qgis.org/issues/10433 )
