### PR TITLE
Remove all traces of deprecated QgsFieldMap.

### DIFF
--- a/src/core/qgsfeature.h
+++ b/src/core/qgsfeature.h
@@ -100,7 +100,6 @@ typedef QMap<int, QVariant> QgsAttributeMap;
 typedef QVector<QVariant> QgsAttributes;
 
 class QgsField;
-typedef QMap<int, QgsField> QgsFieldMap;
 
 #include "qgsfield.h"
 

--- a/src/core/qgsfield.h
+++ b/src/core/qgsfield.h
@@ -149,9 +149,6 @@ class CORE_EXPORT QgsField
 
 }; // class QgsField
 
-// key = field index, value=field data
-typedef QMap<int, QgsField> QgsFieldMap;
-
 
 /**
  \ingroup core

--- a/src/core/qgslabel.h
+++ b/src/core/qgslabel.h
@@ -41,7 +41,6 @@ class QgsLabelAttributes;
 
 typedef QList<int> QgsAttributeList;
 
-typedef QMap<int, QgsField> QgsFieldMap;
 class QgsFields;
 
 /** \ingroup core

--- a/src/core/qgsvectordataprovider.h
+++ b/src/core/qgsvectordataprovider.h
@@ -150,7 +150,7 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider
     /**
      * Return a map of indexes with field names for this layer
      * @return map of fields
-     * @see QgsFieldMap
+     * @see QgsFields
      */
     virtual const QgsFields &fields() const = 0;
 

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -3440,10 +3440,10 @@ QString QgsVectorLayer::metadata()
   myMetadata += "</th>";
 
   //get info for each field by looping through them
-  const QgsFieldMap& myFields = pendingFields();
-  for ( QgsFieldMap::const_iterator it = myFields.begin(); it != myFields.end(); ++it )
+  const QgsFields& myFields = pendingFields();
+  for ( int i = 0, n = myFields.size(); i < n; ++i )
   {
-    const QgsField& myField = *it;
+    const QgsField& myField = fields[i];
 
     myMetadata += "<tr><td>";
     myMetadata += myField.name();

--- a/src/gui/symbology-ng/qgsrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgsrendererv2widget.cpp
@@ -243,7 +243,6 @@ void QgsRendererV2DataDefinedMenus::populateMenu( QMenu* menu, QString fieldName
 
   bool hasField = false;
   const QgsFields & flds = mLayer->pendingFields();
-  //const QgsFieldMap& flds = mLayer->pendingFields();
   for ( int idx = 0; idx < flds.count(); ++idx )
   {
     const QgsField& fld = flds[idx];

--- a/src/plugins/grass/qgsgrassmodule.cpp
+++ b/src/plugins/grass/qgsgrassmodule.cpp
@@ -2897,7 +2897,7 @@ void QgsGrassModuleInput::updateQgisLayers()
       mMapLayers.push_back( vector );
       mVectorLayerNames.push_back( grassLayer );
 
-      // convert from QgsFieldMap to std::vector<QgsField>
+      // convert from QgsFields to std::vector<QgsField>
       mVectorFields.push_back( vector->dataProvider()->fields() );
     }
     else if ( mType == Raster && layer->type() == QgsMapLayer::RasterLayer )

--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -1491,7 +1491,7 @@ QGis::WkbType QgsMssqlProvider::getWkbType( QString geometryType, int dim )
 
 QgsVectorLayerImport::ImportError QgsMssqlProvider::createEmptyLayer(
   const QString& uri,
-  const QgsFieldMap &fields,
+  const QgsFields &fields,
   QGis::WkbType wkbType,
   const QgsCoordinateReferenceSystem *srs,
   bool overwrite,
@@ -1541,25 +1541,25 @@ QgsVectorLayerImport::ImportError QgsMssqlProvider::createEmptyLayer(
   {
     int index = 0;
     QString pk = primaryKey = "qgs_fid";
-    for ( QgsFieldMap::const_iterator fldIt = fields.begin(); fldIt != fields.end(); ++fldIt )
+    for ( int i = 0, n = fields.size(); i < n; ++i )
     {
-      if ( fldIt.value().name() == primaryKey )
+      if ( fields[i].name() == primaryKey )
       {
         // it already exists, try again with a new name
         primaryKey = QString( "%1_%2" ).arg( pk ).arg( index++ );
-        fldIt = fields.begin();
+        i = 0;
       }
     }
   }
   else
   {
     // search for the passed field
-    for ( QgsFieldMap::const_iterator fldIt = fields.begin(); fldIt != fields.end(); ++fldIt )
+    for ( int i = 0, n = fields.size(); i < n; ++i )
     {
-      if ( fldIt.value().name() == primaryKey )
+      if ( fields[i].name() == primaryKey )
       {
         // found, get the field type
-        QgsField fld = fldIt.value();
+        QgsField fld = fields[i];
         if ( convertField( fld ) )
         {
           primaryKeyType = fld.typeName();
@@ -1688,12 +1688,12 @@ QgsVectorLayerImport::ImportError QgsMssqlProvider::createEmptyLayer(
 
     // get the list of fields
     QList<QgsField> flist;
-    for ( QgsFieldMap::const_iterator fldIt = fields.begin(); fldIt != fields.end(); ++fldIt )
+    for ( int i = 0, n = fields.size(); i < n; ++i )
     {
-      QgsField fld = fldIt.value();
+      QgsField fld = fields[i];
       if ( fld.name() == primaryKey )
       {
-        oldToNewAttrIdxMap->insert( fldIt.key(), 0 );
+        oldToNewAttrIdxMap->insert( fields.indexFromName( fld.name() ), 0 );
         continue;
       }
 
@@ -1714,7 +1714,7 @@ QgsVectorLayerImport::ImportError QgsMssqlProvider::createEmptyLayer(
 
       flist.append( fld );
       if ( oldToNewAttrIdxMap )
-        oldToNewAttrIdxMap->insert( fldIt.key(), offset++ );
+        oldToNewAttrIdxMap->insert( fields.indexFromName( fld.name() ), offset++ );
     }
 
     if ( !provider->addAttributes( flist ) )
@@ -1782,7 +1782,7 @@ QGISEXTERN QgsDataItem *dataItem( QString thePath, QgsDataItem *parentItem )
 
 QGISEXTERN QgsVectorLayerImport::ImportError createEmptyLayer(
   const QString& uri,
-  const QgsFieldMap &fields,
+  const QgsFields &fields,
   QGis::WkbType wkbType,
   const QgsCoordinateReferenceSystem *srs,
   bool overwrite,

--- a/src/providers/mssql/qgsmssqlprovider.h
+++ b/src/providers/mssql/qgsmssqlprovider.h
@@ -231,7 +231,7 @@ class QgsMssqlProvider : public QgsVectorDataProvider
     /** Import a vector layer into the database */
     static QgsVectorLayerImport::ImportError createEmptyLayer(
       const QString& uri,
-      const QgsFieldMap &fields,
+      const QgsFields &fields,
       QGis::WkbType wkbType,
       const QgsCoordinateReferenceSystem *srs,
       bool overwrite,


### PR DESCRIPTION
Some parts of the code still used the old QgsFieldMap, in particular the MSSQL provider code. This caused a crash when importing a vector layer into an MSSQL DB, since

```
createEmptyLayer_t * pCreateEmpty = ( createEmptyLayer_t * ) cast_to_fptr( myLib->resolve( "createEmptyLayer" ) );
```

in `QgsVectorLayerImport::QgsVectorLayerImport` reinterpret-casts the `QgsMssqlProvider::createEmptyLayer` function pointer to a function pointer with incompatible signature, resulting in a `QgsFields` being used as a `QgsFieldMap`.

Funded by Sourcepole.
