### PR TITLE
Inverted polygons: fix memory leaks

### DIFF
--- a/src/core/qgsgeometry.cpp
+++ b/src/core/qgsgeometry.cpp
@@ -6402,16 +6402,12 @@ namespace QgsGeometryAlgorithms
 
 QgsGeometry* unaryUnion( const QList<QgsGeometry*>& geometryList )
 {
-  QVector<GEOSGeometry*> geoms;
+  QList<GEOSGeometry*> geoms;
   foreach( QgsGeometry* g, geometryList )
   {
     geoms.append( GEOSGeom_clone(g->asGeos()) );
   }
-
-  GEOSGeometry* geomCollection = 0;
-  geomCollection = createGeosCollection( GEOS_GEOMETRYCOLLECTION, geoms );
-  GEOSGeometry* geomUnion = GEOSUnaryUnion( geomCollection );
-  GEOSGeom_destroy( geomCollection );
+  GEOSGeometry *geomUnion = _makeUnion( geoms );
   QgsGeometry *ret = new QgsGeometry();
   ret->fromGeos( geomUnion );
   return ret;

--- a/src/core/qgsgeometry.cpp
+++ b/src/core/qgsgeometry.cpp
@@ -6402,16 +6402,18 @@ namespace QgsGeometryAlgorithms
 
 QgsGeometry* unaryUnion( const QList<QgsGeometry*>& geometryList )
 {
-  QList<GEOSGeometry*> geoms;
+  QVector<GEOSGeometry*> geoms;
   foreach( QgsGeometry* g, geometryList )
   {
-    // const cast: it is ok here, since the pointers will only be used to be stored
-    // in a list for a call to union
-    geoms.append( const_cast<GEOSGeometry*>(g->asGeos()) );
+    geoms.append( GEOSGeom_clone(g->asGeos()) );
   }
-  GEOSGeometry* unioned = _makeUnion( geoms );
+
+  GEOSGeometry* geomCollection = 0;
+  geomCollection = createGeosCollection( GEOS_GEOMETRYCOLLECTION, geoms );
+  GEOSGeometry* geomUnion = GEOSUnaryUnion( geomCollection );
+  GEOSGeom_destroy( geomCollection );
   QgsGeometry *ret = new QgsGeometry();
-  ret->fromGeos( unioned );
+  ret->fromGeos( geomUnion );
   return ret;
 }
 

--- a/src/core/symbology-ng/qgsinvertedpolygonrenderer.cpp
+++ b/src/core/symbology-ng/qgsinvertedpolygonrenderer.cpp
@@ -73,6 +73,7 @@ void QgsInvertedPolygonRenderer::startRender( QgsRenderContext& context, const Q
   mSubRenderer->startRender( context, fields );
 
   mFeaturesCategories.clear();
+  mSymbolCategories.clear();
   mFeatureDecorations.clear();
   mFields = fields;
 
@@ -278,6 +279,13 @@ void QgsInvertedPolygonRenderer::stopRender( QgsRenderContext& context )
       }
     }
     mSubRenderer->renderFeature( feat, mContext );
+  }
+  for ( FeatureCategoryVector::iterator cit = mFeaturesCategories.begin(); cit != mFeaturesCategories.end(); ++cit )
+  {
+    foreach( QgsGeometry* g, cit->geometries )
+    {
+      delete g;
+    }
   }
 
   // when no features are visible, we still have to draw the exterior rectangle

--- a/src/gui/symbology-ng/qgssinglesymbolrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgssinglesymbolrendererv2widget.cpp
@@ -80,6 +80,8 @@ QgsSingleSymbolRendererV2Widget::~QgsSingleSymbolRendererV2Widget()
   delete mRenderer;
 
   delete mSelector;
+
+  delete mDataDefinedMenus;
 }
 
 


### PR DESCRIPTION
Fix memory leaks in the inverted polygon symbology
It also fixes a small one in the GUI part (single symbol renderer widget).
Tested with google perftools heap leak checker (I should have done that in the first place :( )
