### PR TITLE
Fix issue preventing opening of Python console

### DIFF
--- a/python/console/console_settings.ui
+++ b/python/console/console_settings.ui
@@ -183,6 +183,9 @@
               <property name="rowCount">
                <number>0</number>
               </property>
+              <property name="columnCount">
+               <number>2</number>
+              </property>
               <attribute name="horizontalHeaderVisible">
                <bool>true</bool>
               </attribute>


### PR DESCRIPTION
With PyQT 4.11 the generated code of ui_console_settings.py miss
self.tableWidget.setColumnCount(2) which cause item.setText(_translate("SettingsDialogPythonConsole", "APIs", None))
in retranslateUi() to fail because item is None
