### PR TITLE
Fix crash when opening entity form from layer without attribute

### DIFF
--- a/src/gui/attributetable/qgsfeaturelistview.cpp
+++ b/src/gui/attributetable/qgsfeaturelistview.cpp
@@ -144,10 +144,14 @@ void QgsFeatureListView::editSelectionChanged( QItemSelection deselected, QItemS
   QItemSelection currentSelection = mCurrentEditSelectionModel->selection();
   if ( currentSelection.size() == 1 )
   {
-    QgsFeature feat;
-    mModel->featureByIndex( mModel->mapFromMaster( currentSelection.indexes().first() ), feat );
+    QModelIndexList indexList = currentSelection.indexes();
+    if ( !indexList.isEmpty() )
+    {
+      QgsFeature feat;
+      mModel->featureByIndex( mModel->mapFromMaster( indexList.first() ), feat );
 
-    emit currentEditSelectionChanged( feat );
+      emit currentEditSelectionChanged( feat );
+    }
   }
 }
 


### PR DESCRIPTION
When right-clicking in the attribute table of a layer that has
no attribute, no feature is selected. If selecting the 'Edit form'
entry, we got a crash.

==28289== Invalid read of size 8
==28289==    at 0x602E28: QList<QModelIndex>::Node::t() (qlist.h:114)
==28289==    by 0x60C428: QList<QModelIndex>::iterator::operator_() const (qlist.h:193)
==28289==    by 0x9676995: QList<QModelIndex>::first() (qlist.h:282)
==28289==    by 0x96DC767: QgsFeatureListView::editSelectionChanged(QItemSelection, QItemSelection) (qgsfeaturelistview.cpp:148)
==28289==    by 0x981B557: QgsFeatureListView::qt_static_metacall(QObject_, QMetaObject::Call, int, void**) (moc_qgsfeaturelistview.cxx:76)
==28289==    by 0xA49ADDE: QMetaObject::activate(QObject_, QMetaObject const_, int, void**) (in /home/even/install-qt-4.8.5/lib/libQtCore.so.4.8.5)
==28289==    by 0xAF477F6: QItemSelectionModel::selectionChanged(QItemSelection const&, QItemSelection const&) (in /home/even/install-qt-4.8.5/lib/libQtGui.so.4.8.5)
==28289==    by 0xAF4C492: QItemSelectionModel::emitSelectionChanged(QItemSelection const&, QItemSelection const&) (in /home/even/install-qt-4.8.5/lib/libQtGui.so.4.8.5)
==28289==    by 0xAF4D65B: QItemSelectionModel::select(QItemSelection const&, QFlagsQItemSelectionModel::SelectionFlag) (in /home/even/install-qt-4.8.5/lib/libQtGui.so.4.8.5)
==28289==    by 0x96DCD25: QgsFeatureListView::setEditSelection(QSet<long long> const&) (qgsfeaturelistview.cpp:175)
==28289==    by 0x96D60DF: QgsDualView::setCurrentEditSelection(QSet<long long> const&) (qgsdualview.cpp:262)
==28289==    by 0x96D744A: QgsAttributeTableAction::featureForm() (qgsdualview.cpp:431)
==28289==  Address 0x2a0155e8 is 0 bytes after a block of size 24 alloc'd
==28289==    at 0x4C28DBC: malloc (vg_replace_malloc.c:270)
==28289==    by 0xA3A6CBA: QListData::detach(int) (in /home/even/install-qt-4.8.5/lib/libQtCore.so.4.8.5)
==28289==    by 0x603212: QList<QModelIndex>::detach_helper(int) (qlist.h:709)
==28289==    by 0x602FDF: QList<QModelIndex>::detach_helper() (qlist.h:725)
==28289==    by 0x60C4DD: QList<QModelIndex>::detach() (in /home/even/qgis-git/Quantum-GIS/build/output/bin/qgis)
==28289==    by 0x60C3A9: QList<QModelIndex>::begin() (qlist.h:267)
==28289==    by 0x9676989: QList<QModelIndex>::first() (qlist.h:282)
==28289==    by 0x96DC767: QgsFeatureListView::editSelectionChanged(QItemSelection, QItemSelection) (qgsfeaturelistview.cpp:148)
==28289==    by 0x981B557: QgsFeatureListView::qt_static_metacall(QObject_, QMetaObject::Call, int, void__) (moc_qgsfeaturelistview.cxx:76)
==28289==    by 0xA49ADDE: QMetaObject::activate(QObject_, QMetaObject const_, int, void__) (in /home/even/install-qt-4.8.5/lib/libQtCore.so.4.8.5)
==28289==    by 0xAF477F6: QItemSelectionModel::selectionChanged(QItemSelection const&, QItemSelection const&) (in /home/even/install-qt-4.8.5/lib/libQtGui.so.4.8.5)
==28289==    by 0xAF4C492: QItemSelectionModel::emitSelectionChanged(QItemSelection const&, QItemSelection const&) (in /home/even/install-qt-4.8.5/lib/libQtGui.so.4.8.5)
==28289== 
==28289== Invalid read of size 4
==28289==    at 0x5A8CFC: QModelIndex::isValid() const (in /home/even/qgis-git/Quantum-GIS/build/output/bin/qgis)
==28289==    by 0x96DB2E8: QgsFeatureListModel::mapFromMaster(QModelIndex const&) const (qgsfeaturelistmodel.cpp:181)
==28289==    by 0x96DC781: QgsFeatureListView::editSelectionChanged(QItemSelection, QItemSelection) (qgsfeaturelistview.cpp:148)
==28289==    by 0x981B557: QgsFeatureListView::qt_static_metacall(QObject_, QMetaObject::Call, int, void**) (moc_qgsfeaturelistview.cxx:76)
==28289==    by 0xA49ADDE: QMetaObject::activate(QObject_, QMetaObject const_, int, void**) (in /home/even/install-qt-4.8.5/lib/libQtCore.so.4.8.5)
==28289==    by 0xAF477F6: QItemSelectionModel::selectionChanged(QItemSelection const&, QItemSelection const&) (in /home/even/install-qt-4.8.5/lib/libQtGui.so.4.8.5)
==28289==    by 0xAF4C492: QItemSelectionModel::emitSelectionChanged(QItemSelection const&, QItemSelection const&) (in /home/even/install-qt-4.8.5/lib/libQtGui.so.4.8.5)
==28289==    by 0xAF4D65B: QItemSelectionModel::select(QItemSelection const&, QFlagsQItemSelectionModel::SelectionFlag) (in /home/even/install-qt-4.8.5/lib/libQtGui.so.4.8.5)
==28289==    by 0x96DCD25: QgsFeatureListView::setEditSelection(QSet<long long> const&) (qgsfeaturelistview.cpp:175)
==28289==    by 0x96D60DF: QgsDualView::setCurrentEditSelection(QSet<long long> const&) (qgsdualview.cpp:262)
==28289==    by 0x96D744A: QgsAttributeTableAction::featureForm() (qgsdualview.cpp:431)
==28289==    by 0x981AC56: QgsAttributeTableAction::qt_static_metacall(QObject_, QMetaObject::Call, int, void_*) (moc_qgsdualview.cxx:176)
==28289==  Address 0x38002e00330000 is not stack'd, malloc'd or (recently) free'd
