### PR TITLE
OGR provider: deal with wkbUnknown25D (wkbUnknown | wkb25DBit)

### DIFF
--- a/src/providers/ogr/qgsogrfeatureiterator.cpp
+++ b/src/providers/ogr/qgsogrfeatureiterator.cpp
@@ -337,7 +337,7 @@ QgsOgrFeatureSource::QgsOgrFeatureSource( const QgsOgrProvider* p )
   mSubsetString = p->mSubsetString;
   mEncoding = p->mEncoding; // no copying - this is a borrowed pointer from Qt
   mFields = p->mAttributeFields;
-  mOgrGeometryTypeFilter = p->mOgrGeometryTypeFilter;
+  mOgrGeometryTypeFilter = wkbFlatten(p->mOgrGeometryTypeFilter);
 }
 
 QgsFeatureIterator QgsOgrFeatureSource::getFeatures( const QgsFeatureRequest& request )

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -447,7 +447,10 @@ QgsOgrProvider::~QgsOgrProvider()
 
   repack();
 
-  OGR_DS_Destroy( ogrDataSource );
+  if( ogrDataSource )
+  {
+    OGR_DS_Destroy( ogrDataSource );
+  }
   ogrDataSource = 0;
 
   if ( extent_ )
@@ -548,7 +551,7 @@ QString QgsOgrProvider::subsetString()
 QString QgsOgrProvider::ogrWkbGeometryTypeName( OGRwkbGeometryType type ) const
 {
   QString geom;
-  switch ( type )
+  switch ( (int)type )
   {
     case wkbUnknown:            geom = "Unknown"; break;
     case wkbPoint:              geom = "Point"; break;
@@ -559,12 +562,14 @@ QString QgsOgrProvider::ogrWkbGeometryTypeName( OGRwkbGeometryType type ) const
     case wkbMultiPolygon:       geom = "MultiPolygon"; break;
     case wkbGeometryCollection: geom = "GeometryCollection"; break;
     case wkbNone:               geom = "None"; break;
+    case wkbUnknown | wkb25DBit:geom = "Unknown25D"; break;
     case wkbPoint25D:           geom = "Point25D"; break;
     case wkbLineString25D:      geom = "LineString25D"; break;
     case wkbPolygon25D:         geom = "Polygon25D"; break;
     case wkbMultiPoint25D:      geom = "MultiPoint25D"; break;
     case wkbMultiLineString25D: geom = "MultiLineString25D"; break;
     case wkbMultiPolygon25D:    geom = "MultiPolygon25D"; break;
+    case wkbGeometryCollection25D: geom = "GeometryCollection25D"; break;
     default:                    geom = QString( "Unknown WKB: %1" ).arg( type );
   }
   return geom;
@@ -619,7 +624,7 @@ QStringList QgsOgrProvider::subLayers() const
 
     QgsDebugMsg( QString( "id = %1 name = %2 layerGeomType = %3" ).arg( i ).arg( theLayerName ).arg( layerGeomType ) );
 
-    if ( layerGeomType != wkbUnknown )
+    if ( wkbFlatten(layerGeomType) != wkbUnknown )
     {
       int theLayerFeatureCount = OGR_L_GetFeatureCount( layer, 0 );
 
@@ -655,9 +660,10 @@ QStringList QgsOgrProvider::subLayers() const
       {
         fCount[wkbUnknown] = 0;
       }
+      bool bIs25D = ( (layerGeomType & wkb25DBit) != 0 );
       foreach ( OGRwkbGeometryType gType, fCount.keys() )
       {
-        QString geom = ogrWkbGeometryTypeName( gType );
+        QString geom = ogrWkbGeometryTypeName( (bIs25D) ? (OGRwkbGeometryType) (gType | wkb25DBit) : gType );
 
         QString sl = QString( "%1:%2:%3:%4" ).arg( i ).arg( theLayerName ).arg( fCount.value( gType ) ).arg( geom );
         QgsDebugMsg( "sub layer: " + sl );


### PR DESCRIPTION
This geometry type doesn't exist admitedly in the OGRwkbGeometryType
enumeration but a few OGR drivers can expose layers of this type.
Those layers should be dealt exactly like wkbUnknown layers, i.e.
QGIS should analyze the content to see if there are points, lines,
polygons and create derived layers.

Also report the geometry type of wkbGeometryCollection25D layers in
the U.I.
