### PR TITLE
Fix crash in QgsVectorFileWriter::addFeature()

### DIFF
--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -1548,6 +1548,8 @@ bool QgsVectorFileWriter::addFeature( QgsFeature& feature, QgsFeatureRendererV2*
 {
   // create the feature
   OGRFeatureH poFeature = createFeature( feature );
+  if( !poFeature )
+      return false;
 
   //add OGR feature style type
   if ( mSymbologyExport != NoSymbology && renderer )


### PR DESCRIPTION
createFeature() might return a NULL pointer that OGR_L_CreateFeature()
will crash upon when GDAL is compiled in debug mode (where null
pointer assertions are turned on)

(Issue found when computing a Union on a layer that had one polygon already written, and another one created but not saved)
