### PR TITLE
Checkbox for sub index was missing tooltip text

### DIFF
--- a/src/ui/qgsdelimitedtextsourceselectbase.ui
+++ b/src/ui/qgsdelimitedtextsourceselectbase.ui
@@ -594,13 +594,13 @@
        </item>
        <item>
         <widget class="QCheckBox" name="cbxSubsetIndex">
+         <property name="toolTip">
+          <string>Use an index to improve performance of subset filters (set in layer properties)</string>
+         </property>
          <property name="statusTip">
           <string>Use an index to improve performance of subset filters (set in layer properties)</string>
          </property>
          <property name="whatsThis">
-          <string>Use an index to improve performance of subset filters (set in layer properties)</string>
-         </property>
-         <property name="accessibleName">
           <string>Use an index to improve performance of subset filters (set in layer properties)</string>
          </property>
          <property name="text">


### PR DESCRIPTION
Added toolTip and removed accessibleName and reformatted order to match the rest of the file structure.
