### PR TITLE
[processing] Small fixes 2

### DIFF
--- a/python/plugins/processing/algs/gdal/GdalUtils.py
+++ b/python/plugins/processing/algs/gdal/GdalUtils.py
@@ -138,7 +138,7 @@ class GdalUtils:
     def escapeAndJoin(strList):
         joined = ''
         for s in strList:
-            if ' ' in s:
+            if s[0]!='-' and ' ' in s:
                 escaped = '"' + s.replace('\\', '\\\\').replace('"', '\\"') \
                     + '"'
             else:

--- a/python/plugins/processing/core/GeoAlgorithm.py
+++ b/python/plugins/processing/core/GeoAlgorithm.py
@@ -361,17 +361,10 @@ class GeoAlgorithm:
                             if layer.source() == inputlayer:
                                 self.crs = layer.crs()
                                 return
-                        if isinstance(param, ParameterRaster) \
-                                or isinstance(param, ParameterMultipleInput) \
-                                and param.datatype \
-                                == ParameterMultipleInput.TYPE_RASTER:
-                            p = QgsProviderRegistry.instance().provider('gdal',
-                                    inputlayer)
-                        else:
-                            p = QgsProviderRegistry.instance().provider('ogr',
-                                    inputlayer)
+                        p = dataobjects.getObjectFromUri(inputlayer)
                         if p is not None:
                             self.crs = p.crs()
+                            p = None
                             return
         try:
             from qgis.utils import iface

--- a/python/plugins/processing/gui/InputLayerSelectorPanel.py
+++ b/python/plugins/processing/gui/InputLayerSelectorPanel.py
@@ -63,7 +63,7 @@ class InputLayerSelectorPanel(QtGui.QWidget):
             path = ''
 
         filename = QtGui.QFileDialog.getOpenFileName(self, self.param.description, path,
-                self.param.getFileFilter())
+                'All files(*.*);;' + self.param.getFileFilter())
         if filename:
             self.text.addItem(filename, filename)
             self.text.setCurrentIndex(self.text.count() - 1)

--- a/python/plugins/processing/gui/ProcessingToolbox.py
+++ b/python/plugins/processing/gui/ProcessingToolbox.py
@@ -123,6 +123,10 @@ class ProcessingToolbox(QDockWidget, Ui_ProcessingToolbox):
             if isinstance(child, TreeProviderItem):
                 if child.providerName == providerName:
                     child.refresh()
+                    # sort categories and items in categories
+                    child.sortChildren(0, Qt.AscendingOrder)
+                    for i in xrange(child.childCount()):
+                        child.child(i).sortChildren(0, Qt.AscendingOrder)
                     break
 
     def showPopupMenu(self, point):


### PR DESCRIPTION
The first commit allows scripts to pass parameter values to processing algorithms in a dict instead of a list. This makes the scripts more robust since the names of algorithm parameters are less likely to change than their order or number (when, for example, a new optional parameter is added). It also improves the readability of the scripts.

The second commit also concerns scripts. Previously, if a script passed a file to a processing algorithm it was not possible to delete this file in the same scripts, since QGIS would keep the file handle open. This commit avoids the problem and also simplifies the code a bit.

The third commit prevents quotation marks from being put around extra parameters (starting with -, e.g. -b 1) passed to GDAL algorithms. This caused problems in the "Additional creation parameters" field in translate and warp algorithms. 
