### PR TITLE
Fix joinConnectedFeatures not keeping the featureParts list in sync

### DIFF
--- a/src/core/pal/layer.cpp
+++ b/src/core/pal/layer.cpp
@@ -462,6 +462,7 @@ namespace pal
           double bmin[2], bmax[2];
           partCheck->getBoundingBox( bmin, bmax );
           rtree->Remove( bmin, bmax, partCheck );
+          featureParts->remove( partCheck );
 
           otherPart->getBoundingBox( bmin, bmax );
 


### PR DESCRIPTION
The method `Layer::joinConnectedFeatures()`, when merging connected features, only removes the obsolete features (i.e. those whose geometry was merged with another one) from the `rtree`, but not from the `featureParts` list. This causes `Layer::chopFeatures` to misbehave, and results in randomish behaviour when labeling multi-part lines with merge connected features activated.

Funded by Sourcepole.
