### PR TITLE
[processing] JoinAttributes improvement

### DIFF
--- a/python/plugins/processing/algs/qgis/JoinAttributes.py
+++ b/python/plugins/processing/algs/qgis/JoinAttributes.py
@@ -30,6 +30,7 @@ from PyQt4.QtGui import *
 from qgis.core import *
 from processing.core.GeoAlgorithm import GeoAlgorithm
 from processing.parameters.ParameterVector import ParameterVector
+from processing.parameters.ParameterTable import ParameterTable
 from processing.parameters.ParameterTableField import ParameterTableField
 from processing.outputs.OutputVector import OutputVector
 from processing.tools import dataobjects, vector
@@ -48,8 +49,8 @@ class JoinAttributes(GeoAlgorithm):
         self.group = 'Vector general tools'
         self.addParameter(ParameterVector(self.INPUT_LAYER, 'Input layer',
                           [ParameterVector.VECTOR_TYPE_ANY], False))
-        self.addParameter(ParameterVector(self.INPUT_LAYER_2, 'Input layer 2',
-                          [ParameterVector.VECTOR_TYPE_ANY], False))
+        self.addParameter(ParameterTable(self.INPUT_LAYER_2, 'Input layer 2',
+                          False))
         self.addParameter(ParameterTableField(self.TABLE_FIELD, 'Table field',
                           self.INPUT_LAYER))
         self.addParameter(ParameterTableField(self.TABLE_FIELD_2,
@@ -84,22 +85,25 @@ class JoinAttributes(GeoAlgorithm):
         inFeat2 = QgsFeature()
         outFeat = QgsFeature()
 
+        # Cache attributes of Layer 2
+        cache = {}
+        features2 = vector.features(layer2)
+        for inFeat2 in features2:
+            attrs2 = inFeat2.attributes()
+            joinValue2 = unicode(attrs2[joinField2Index])
+            # Put the attributes into the dict if the join key is not contained in the keys of the dict.
+            # Note: This behavior is same as previous behavior of this function,
+            # but different from the attribute cache function of QGIS core.
+            if not joinValue2 in cache:
+                cache[joinValue2] = attrs2
+
         # Create output vector layer with additional attribute
         features = vector.features(layer)
         for inFeat in features:
-            inGeom = inFeat.geometry()
+            outFeat.setGeometry(inFeat.geometry())
             attrs = inFeat.attributes()
-            joinValue1 = attrs[joinField1Index]
-            features2 = vector.features(layer2)
-            for inFeat2 in features2:
-                # Maybe it should cache this entries...
-                attrs2 = inFeat2.attributes()
-                joinValue2 = attrs2[joinField2Index]
-                if joinValue1 == joinValue2:
-                    # Create the new feature
-                    outFeat.setGeometry(inGeom)
-                    attrs.extend(attrs2)
-                    break
+            joinValue1 = unicode(attrs[joinField1Index])
+            attrs.extend(cache.get(joinValue1, []))
             outFeat.setAttributes(attrs)
             writer.addFeature(outFeat)
         del writer

--- a/python/plugins/processing/parameters/ParameterTableField.py
+++ b/python/plugins/processing/parameters/ParameterTableField.py
@@ -43,7 +43,7 @@ class ParameterTableField(Parameter):
         self.optional = optional
 
     def getValueAsCommandLineParameter(self):
-        return '"' + str(self.value) + '"'
+        return '"' + unicode(self.value) + '"'
 
     def getAsScriptCode(self):
         return '##' + self.name + '=field ' + str(self.parent)
@@ -52,7 +52,7 @@ class ParameterTableField(Parameter):
         if value is None:
             return self.optional
         elif len(value) > 0:
-            self.value = str(value)
+            self.value = unicode(value)
         else:
             return self.optional
         return True

--- a/python/plugins/processing/tools/vector.py
+++ b/python/plugins/processing/tools/vector.py
@@ -260,10 +260,10 @@ def combineVectorFields(layerA, layerB):
     """Create single field map from two input field maps.
     """
     fields = []
-    fieldsA = layerA.dataProvider().fields()
+    fieldsA = layerA.pendingFields()
     fields.extend(fieldsA)
     namesA = [unicode(f.name()).lower() for f in fieldsA]
-    fieldsB = layerB.dataProvider().fields()
+    fieldsB = layerB.pendingFields()
     for field in fieldsB:
         name = unicode(field.name()).lower()
         if name in namesA:


### PR DESCRIPTION
This commit will improve the JoinAttributes algorithm.
- Allows join not only with vector attribute table but also with geometryless table. Provides a way to join table without field name prefix.
- Improves performance by caching the records of join table.
- Avoids join failures due to the data type difference by comparing keys as unicode string.
- Fixes UnicodeEncodeError that occurs if key field name includes non-ASCII characters.
