### PR TITLE
give the option to turn QgsMessageLog loggin on and off

### DIFF
--- a/python/core/qgsmessagelog.sip
+++ b/python/core/qgsmessagelog.sip
@@ -13,6 +13,12 @@ class QgsMessageLog : QObject
       WARNING,
       CRITICAL,
     };
+    
+    static void activate();
+
+    static void deactivate();
+
+    static bool isActivated();
 
     //! add a message to the instance (and create it if necessary)
     static void logMessage( QString message, QString tag = QString::null, MessageLevel level = WARNING );

--- a/src/core/qgsmessagelog.cpp
+++ b/src/core/qgsmessagelog.cpp
@@ -22,6 +22,7 @@
 class QgsMessageLogConsole;
 
 QgsMessageLog *QgsMessageLog::sInstance = 0;
+bool QgsMessageLog::activated = true;
 
 QgsMessageLog::QgsMessageLog()
     : QObject()
@@ -40,11 +41,25 @@ QgsMessageLog *QgsMessageLog::instance()
   return sInstance;
 }
 
+void QgsMessageLog::activate(){
+  QgsMessageLog::activated = true;
+}
+
+void QgsMessageLog::deactivate(){
+  QgsMessageLog::activated = false;
+}
+
+bool QgsMessageLog::isActivated(){
+  return QgsMessageLog::activated;
+}
+
 void QgsMessageLog::logMessage( QString message, QString tag, QgsMessageLog::MessageLevel level )
 {
-  QgsDebugMsg( QString( "%1 %2[%3] %4" ).arg( QDateTime::currentDateTime().toString( Qt::ISODate ) ).arg( tag ).arg( level ).arg( message ) );
+  if (QgsMessageLog::activated){
+    QgsDebugMsg( QString( "%1 %2[%3] %4" ).arg( QDateTime::currentDateTime().toString( Qt::ISODate ) ).arg( tag ).arg( level ).arg( message ) );
 
-  QgsMessageLog::instance()->emitMessage( message, tag, level );
+    QgsMessageLog::instance()->emitMessage( message, tag, level );
+  }
 }
 
 void QgsMessageLog::emitMessage( QString message, QString tag, QgsMessageLog::MessageLevel level )
@@ -68,4 +83,3 @@ void QgsMessageLogConsole::logMessage( QString message, QString tag, QgsMessageL
       : "CRITICAL" )
     << "]: " << message.toLocal8Bit().data() << std::endl;
 }
-

--- a/src/core/qgsmessagelog.h
+++ b/src/core/qgsmessagelog.h
@@ -44,6 +44,12 @@ class CORE_EXPORT QgsMessageLog : public QObject
       CRITICAL = 2
     };
 
+    static void activate();
+
+    static void deactivate();
+
+    static bool isActivated();
+
     //! add a message to the instance (and create it if necessary)
     static void logMessage( QString message, QString tag = QString::null, MessageLevel level = WARNING );
 
@@ -54,6 +60,8 @@ class CORE_EXPORT QgsMessageLog : public QObject
     QgsMessageLog();
 
     void emitMessage( QString message, QString tag, QgsMessageLog::MessageLevel level );
+
+    static bool activated;
 
     static QgsMessageLog *sInstance;
 };


### PR DESCRIPTION
Being a singleton instance I'm not sure if it's ok to make it turnable on/off globally, because it could happen that a plugin turns it off and forget to turni it on again. The other parts of QGIS should query it with isActivated.
Should we make it available only from the GUI? Mmm....
