### PR TITLE
[cmake] Discover PyQt4 built with its new build system

### DIFF
--- a/cmake/FindPyQt.py
+++ b/cmake/FindPyQt.py
@@ -27,19 +27,54 @@
 #
 # FindPyQt.py
 # Copyright (c) 2007, Simon Edwards <simon@simonzone.com>
+# Copyright (c) 2015, Alexei Ardyakov <ardjakov@rambler.ru>
 # Redistribution and use is allowed according to the terms of the BSD license.
 # For details see the accompanying COPYING-CMAKE-SCRIPTS file.
 
-import PyQt4.pyqtconfig
+import os
 
-pyqtcfg = PyQt4.pyqtconfig.Configuration()
-print("pyqt_version:%06.0x" % pyqtcfg.pyqt_version)
-print("pyqt_version_num:%d" % pyqtcfg.pyqt_version)
-print("pyqt_version_str:%s" % pyqtcfg.pyqt_version_str)
+def get_pyqt_sip_dir():
+    # Only works for a few popular locations of PyQt4 SIP directory.
+    import sipconfig
+    sipcfg = sipconfig.Configuration()
+    default_sip_dir = sipcfg.default_sip_dir
+    postfixes = ('Py2-PyQt4', 'PyQt4',)
+    for postfix in postfixes:
+        pyqt_sip_dir = os.path.join(default_sip_dir, postfix)
+        if os.path.exists(pyqt_sip_dir) and os.path.exists(
+                os.path.join(pyqt_sip_dir, 'QtCore')):
+            return pyqt_sip_dir
+    return default_sip_dir
+
+
+def get_pyqt_bin_dir():
+    import sipconfig
+    sipcfg = sipconfig.Configuration()
+    return sipcfg.default_bin_dir
+
+
+try:
+    import PyQt4.pyqtconfig
+    pyqtcfg = PyQt4.pyqtconfig.Configuration()
+    pyqt_version = pyqtcfg.pyqt_version
+    pyqt_version_str = pyqtcfg.pyqt_version_str
+    pyqt_mod_dir = pyqtcfg.pyqt_mod_dir
+    pyqt_sip_dir = pyqtcfg.pyqt_sip_dir
+    pyqt_sip_flags = pyqtcfg.pyqt_sip_flags
+    pyqt_bin_dir = pyqtcfg.pyqt_bin_dir
+except ImportError:
+    # PyQt4 built with configure-ng.py has no pyqtconfig module
+    import PyQt4.QtCore
+    pyqt_version = PyQt4.QtCore.PYQT_VERSION
+    pyqt_version_str = PyQt4.QtCore.PYQT_VERSION_STR
+    pyqt_mod_dir = os.path.dirname(os.path.dirname(PyQt4.QtCore.__file__))
+    pyqt_sip_dir = get_pyqt_sip_dir()
+    pyqt_sip_flags = PyQt4.QtCore.PYQT_CONFIGURATION["sip_flags"]
+    pyqt_bin_dir = get_pyqt_bin_dir()
 
 pyqt_version_tag = ""
 in_t = False
-for item in pyqtcfg.pyqt_sip_flags.split(' '):
+for item in pyqt_sip_flags.split(' '):
     if item=="-t":
         in_t = True
     elif in_t:
@@ -47,9 +82,15 @@ for item in pyqtcfg.pyqt_sip_flags.split(' '):
             pyqt_version_tag = item
     else:
         in_t = False
+        
 print("pyqt_version_tag:%s" % pyqt_version_tag)
+print("pyqt_version:%06.0x" % pyqt_version)
+print("pyqt_version_num:%d" % pyqt_version)
+print("pyqt_version_str:%s" % pyqt_version_str)
+print("pyqt_mod_dir:%s" % pyqt_mod_dir)
+print("pyqt_sip_dir:%s" % pyqt_sip_dir)
+print("pyqt_sip_flags:%s" % pyqt_sip_flags)
+print("pyqt_bin_dir:%s" % pyqt_bin_dir)
 
-print("pyqt_mod_dir:%s" % pyqtcfg.pyqt_mod_dir)
-print("pyqt_sip_dir:%s" % pyqtcfg.pyqt_sip_dir)
-print("pyqt_sip_flags:%s" % pyqtcfg.pyqt_sip_flags)
-print("pyqt_bin_dir:%s" % pyqtcfg.pyqt_bin_dir)
+
+

--- a/python/console/console.py
+++ b/python/console/console.py
@@ -21,7 +21,6 @@ Some portions of code were taken from https://code.google.com/p/pydee/
 
 from PyQt4.QtCore import Qt, QTimer, QSettings, QCoreApplication, QSize, QByteArray, QFileInfo, SIGNAL
 from PyQt4.QtGui import QDockWidget, QToolBar, QToolButton, QWidget, QSplitter, QTreeWidget, QAction, QFileDialog, QCheckBox, QSizePolicy, QMenu, QGridLayout, QApplication
-from PyQt4 import pyqtconfig
 from qgis.utils import iface
 from console_sci import ShellScintilla
 from console_output import ShellOutputScintilla
@@ -31,6 +30,12 @@ from qgis.core import QgsApplication, QgsContextHelp
 from qgis.gui import QgsFilterLineEdit
 
 import sys
+
+try:
+  from PyQt4.QtCore import QT_VERSION # works if PyQt4 was built with configure-ng.py
+except ImportError:
+  from PyQt4 import pyqtconfig # works if built with configure.py
+  QT_VERSION = pyqtconfig.Configuration().qt_version
 
 _console = None
 
@@ -464,7 +469,7 @@ class PythonConsoleWidget(QWidget):
         self.lineEditFind = QgsFilterLineEdit()
         placeHolderTxt = QCoreApplication.translate("PythonConsole", "Enter text to find...")
 
-        if pyqtconfig.Configuration().qt_version >= 0x40700:
+        if QT_VERSION >= 0x40700:
           self.lineEditFind.setPlaceholderText(placeHolderTxt)
         else:
           self.lineEditFind.setToolTip(placeHolderTxt)


### PR DESCRIPTION
Addresses bug reports [#10596](https://hub.qgis.org/issues/10596), [#8857](https://hub.qgis.org/issues/8857). The module pyqtconfig isn't available in PyQt4 built with configure-ng.py instead of configure.py, so changes were made in cmake/FindPyQt.py to support both.
Now can build without issues on Arch Linux x86_64.
Related links:
- [PyQt build system](http://pyqt.sourceforge.net/Docs/PyQt4/build_system.html)
- [SIP build system](http://pyqt.sourceforge.net/Docs/sip4/build_system.html)
