### PR TITLE
Use field precision for range edit spin

### DIFF
--- a/src/gui/editorwidgets/qgsrangewidget.cpp
+++ b/src/gui/editorwidgets/qgsrangewidget.cpp
@@ -43,11 +43,12 @@ QWidget* QgsRangeWidget::createWidget( QWidget* parent )
     switch ( layer()->pendingFields()[fieldIdx()].type() )
     {
       case QVariant::Double:
+      {
         QDoubleSpinBox* spin  = new QDoubleSpinBox( parent );
         spin->setDecimals( layer()->pendingFields()[fieldIdx()].precision() );
         editor = spin;
         break;
-
+      }
       case QVariant::Int:
       case QVariant::LongLong:
       default:

--- a/src/gui/editorwidgets/qgsrangewidget.cpp
+++ b/src/gui/editorwidgets/qgsrangewidget.cpp
@@ -45,7 +45,11 @@ QWidget* QgsRangeWidget::createWidget( QWidget* parent )
       case QVariant::Double:
       {
         QDoubleSpinBox* spin  = new QDoubleSpinBox( parent );
-        spin->setDecimals( layer()->pendingFields()[fieldIdx()].precision() );
+        int precision = layer()->pendingFields()[fieldIdx()].precision();
+        if ( precision > 0 )
+        {
+          spin->setDecimals( layer()->pendingFields()[fieldIdx()].precision() );
+        }
         editor = spin;
         break;
       }

--- a/src/gui/editorwidgets/qgsrangewidget.cpp
+++ b/src/gui/editorwidgets/qgsrangewidget.cpp
@@ -43,7 +43,9 @@ QWidget* QgsRangeWidget::createWidget( QWidget* parent )
     switch ( layer()->pendingFields()[fieldIdx()].type() )
     {
       case QVariant::Double:
-        editor = new QDoubleSpinBox( parent );
+        QDoubleSpinBox* spin  = new QDoubleSpinBox( parent );
+        spin->setDecimals( layer()->pendingFields()[fieldIdx()].precision() );
+        editor = spin;
         break;
 
       case QVariant::Int:


### PR DESCRIPTION
This commit makes the double spinbox of the range widget honor the field precision.
