### PR TITLE
Trivial: Stretch last column in bad layers dialog

### DIFF
--- a/src/ui/qgshandlebadlayersbase.ui
+++ b/src/ui/qgshandlebadlayersbase.ui
@@ -15,7 +15,11 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QTableWidget" name="mLayerList"/>
+    <widget class="QTableWidget" name="mLayerList">
+     <attribute name="horizontalHeaderStretchLastSection">
+      <bool>true</bool>
+     </attribute>
+    </widget>
    </item>
    <item>
     <widget class="QDialogButtonBox" name="buttonBox">


### PR DESCRIPTION
Make the last column of the bad layers dialog fill up the remaining space.
