### PR TITLE
Bug #10974 QGIS WFS Server provides too much precision

### DIFF
--- a/python/core/qgsgeometry.sip
+++ b/python/core/qgsgeometry.sip
@@ -369,12 +369,13 @@ class QgsGeometry
      */
     QString exportToWkt() const;
 
-    /** Exports the geometry to mGeoJSON
-     *  @return true in case of success and false else
+    /** Exports the geometry to GeoJSON
+     *  @return a QString representing the geometry as GeoJSON
      *  @note added in 1.8
      *  @note python binding added in 1.9
+     *  @note precision parameter added in 2.4
      */
-    QString exportToGeoJSON() const;
+    QString exportToGeoJSON( const int &precision = 17 ) const;
 
     /** try to convert the geometry to the requested type
      * @param destType the geometry type to be converted to

--- a/python/core/qgsgeometry.sip
+++ b/python/core/qgsgeometry.sip
@@ -364,10 +364,11 @@ class QgsGeometry
     /** Returns a Geometry representing the points making up this Geometry that do not make up other. */
     QgsGeometry* symDifference( QgsGeometry* geometry ) /Factory/;
 
-    /** Exports the geometry to mWkt
+    /** Exports the geometry to WKT
+     *  @note precision parameter added in 2.4
      *  @return true in case of success and false else
      */
-    QString exportToWkt() const;
+    QString exportToWkt( const int &precision = 17 ) const;
 
     /** Exports the geometry to GeoJSON
      *  @return a QString representing the geometry as GeoJSON

--- a/python/core/qgsogcutils.sip
+++ b/python/core/qgsogcutils.sip
@@ -28,22 +28,22 @@ class QgsOgcUtils
     /** Exports the geometry to GML2 or GML3
         @return QDomElement
      */
-    static QDomElement geometryToGML( QgsGeometry* geometry, QDomDocument& doc, QString format );
+    static QDomElement geometryToGML( QgsGeometry* geometry, QDomDocument& doc, QString format, const int &precision = 17 );
 
     /** Exports the geometry to GML2
         @return QDomElement
      */
-    static QDomElement geometryToGML( QgsGeometry* geometry, QDomDocument& doc );
+    static QDomElement geometryToGML( QgsGeometry* geometry, QDomDocument& doc, const int &precision = 17 );
 
     /** Exports the rectangle to GML2 Box
         @return QDomElement
      */
-    static QDomElement rectangleToGMLBox( QgsRectangle* box, QDomDocument& doc );
+    static QDomElement rectangleToGMLBox( QgsRectangle* box, QDomDocument& doc, const int &precision = 17 );
 
     /** Exports the rectangle to GML2 Envelope
         @return QDomElement
      */
-    static QDomElement rectangleToGMLEnvelope( QgsRectangle* env, QDomDocument& doc );
+    static QDomElement rectangleToGMLEnvelope( QgsRectangle* env, QDomDocument& doc, const int &precision = 17 );
 
 
     /** Parse XML with OGC fill into QColor */

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -272,6 +272,13 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas* mapCanvas, QWidget *pa
   mWMSAccessConstraints->setText( QgsProject::instance()->readEntry( "WMSAccessConstraints", "/", "" ) );
   mWMSKeywordList->setText( QgsProject::instance()->readListEntry( "WMSKeywordList", "/" ).join( "," ) );
 
+  // WMS GetFeatureInfo precision
+  int WMSprecision = QgsProject::instance()->readNumEntry( "WMSPrecision", "/", -1 );
+  if ( WMSprecision != -1 )
+  {
+    mWMSPrecisionSpinBox->setValue( WMSprecision );
+  }
+
   bool ok;
   QStringList values;
 
@@ -742,6 +749,9 @@ void QgsProjectProperties::apply()
   {
     QgsProject::instance()->removeEntry( "WMSKeywordList", "/" );
   }
+
+  // WMS GetFeatureInfo geometry precision (decimal places)
+  QgsProject::instance()->writeEntry( "WMSPrecision", "/", mWMSPrecisionSpinBox->text());
 
   if ( grpWMSExt->isChecked() )
   {

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -313,9 +313,9 @@ inline void ( *cast_to_fptr( void *p ) )()
 //
 // return a string representation of a double
 //
-inline QString qgsDoubleToString( const double &a )
+inline QString qgsDoubleToString( const double &a, const int &precision = 17 )
 {
-  return QString::number( a, 'f', 17 ).remove( QRegExp( "\\.?0+$" ) );
+  return QString::number( a, 'f', precision ).remove( QRegExp( "\\.?0+$" ) );
 }
 
 //

--- a/src/core/qgsgeometry.cpp
+++ b/src/core/qgsgeometry.cpp
@@ -3536,7 +3536,7 @@ bool QgsGeometry::crosses( const QgsGeometry* geometry ) const
   return geosRelOp( GEOSCrosses, this, geometry );
 }
 
-QString QgsGeometry::exportToWkt() const
+QString QgsGeometry::exportToWkt( const int &precision ) const
 {
   QgsDebugMsg( "entered." );
 
@@ -3566,7 +3566,7 @@ QString QgsGeometry::exportToWkt() const
     {
       double x, y;
       wkbPtr >> x >> y;
-      wkt += "POINT(" + qgsDoubleToString( x ) + " " + qgsDoubleToString( y ) + ")";
+      wkt += "POINT(" + qgsDoubleToString( x, precision ) + " " + qgsDoubleToString( y, precision ) + ")";
       return wkt;
     }
 
@@ -3589,7 +3589,7 @@ QString QgsGeometry::exportToWkt() const
         if ( idx != 0 )
           wkt += ", ";
 
-        wkt += qgsDoubleToString( x ) + " " + qgsDoubleToString( y );
+        wkt += qgsDoubleToString( x, precision ) + " " + qgsDoubleToString( y, precision );
       }
       wkt += ")";
       return wkt;
@@ -3626,7 +3626,7 @@ QString QgsGeometry::exportToWkt() const
           if ( hasZValue )
             wkbPtr += sizeof( double );
 
-          wkt += qgsDoubleToString( x ) + " " + qgsDoubleToString( y );
+          wkt += qgsDoubleToString( x, precision ) + " " + qgsDoubleToString( y, precision );
         }
         wkt += ")";
       }
@@ -3653,7 +3653,7 @@ QString QgsGeometry::exportToWkt() const
         if ( hasZValue )
           wkbPtr += sizeof( double );
 
-        wkt += qgsDoubleToString( x ) + " " + qgsDoubleToString( y );
+        wkt += qgsDoubleToString( x, precision ) + " " + qgsDoubleToString( y, precision );
       }
       wkt += ")";
       return wkt;
@@ -3686,7 +3686,7 @@ QString QgsGeometry::exportToWkt() const
           if ( hasZValue )
             wkbPtr += sizeof( double );
 
-          wkt += qgsDoubleToString( x ) + " " + qgsDoubleToString( y );
+          wkt += qgsDoubleToString( x, precision ) + " " + qgsDoubleToString( y, precision );
         }
         wkt += ")";
       }
@@ -3729,7 +3729,7 @@ QString QgsGeometry::exportToWkt() const
             if ( hasZValue )
               wkbPtr += sizeof( double );
 
-            wkt += qgsDoubleToString( x ) + " " + qgsDoubleToString( y );
+            wkt += qgsDoubleToString( x, precision ) + " " + qgsDoubleToString( y, precision );
           }
           wkt += ")";
         }

--- a/src/core/qgsgeometry.cpp
+++ b/src/core/qgsgeometry.cpp
@@ -3745,7 +3745,7 @@ QString QgsGeometry::exportToWkt() const
   }
 }
 
-QString QgsGeometry::exportToGeoJSON() const
+QString QgsGeometry::exportToGeoJSON( const int &precision ) const
 {
   QgsDebugMsg( "entered." );
 
@@ -3776,8 +3776,8 @@ QString QgsGeometry::exportToGeoJSON() const
       wkbPtr >> x >> y;
 
       wkt += "{ \"type\": \"Point\", \"coordinates\": ["
-             + qgsDoubleToString( x ) + ", "
-             + qgsDoubleToString( y )
+             + qgsDoubleToString( x, precision ) + ", "
+             + qgsDoubleToString( y, precision )
              + "] }";
       return wkt;
     }
@@ -3801,7 +3801,7 @@ QString QgsGeometry::exportToGeoJSON() const
         if ( hasZValue )
           wkbPtr += sizeof( double );
 
-        wkt += "[" + qgsDoubleToString( x ) + ", " + qgsDoubleToString( y ) + "]";
+        wkt += "[" + qgsDoubleToString( x, precision ) + ", " + qgsDoubleToString( y, precision ) + "]";
       }
       wkt += " ] }";
       return wkt;
@@ -3839,7 +3839,7 @@ QString QgsGeometry::exportToGeoJSON() const
           if ( hasZValue )
             wkbPtr += sizeof( double );
 
-          wkt += "[" + qgsDoubleToString( x ) + ", " + qgsDoubleToString( y ) + "]";
+          wkt += "[" + qgsDoubleToString( x, precision ) + ", " + qgsDoubleToString( y, precision ) + "]";
         }
         wkt += " ]";
       }
@@ -3865,7 +3865,7 @@ QString QgsGeometry::exportToGeoJSON() const
         if ( hasZValue )
           wkbPtr += sizeof( double );
 
-        wkt += "[" + qgsDoubleToString( x ) + ", " + qgsDoubleToString( y ) + "]";
+        wkt += "[" + qgsDoubleToString( x, precision ) + ", " + qgsDoubleToString( y, precision ) + "]";
       }
       wkt += " ] }";
       return wkt;
@@ -3899,7 +3899,7 @@ QString QgsGeometry::exportToGeoJSON() const
           if ( hasZValue )
             wkbPtr += sizeof( double );
 
-          wkt += "[" + qgsDoubleToString( x ) + ", " + qgsDoubleToString( y ) + "]";
+          wkt += "[" + qgsDoubleToString( x, precision ) + ", " + qgsDoubleToString( y, precision ) + "]";
         }
         wkt += " ]";
       }
@@ -3946,7 +3946,7 @@ QString QgsGeometry::exportToGeoJSON() const
             if ( hasZValue )
               wkbPtr += sizeof( double );
 
-            wkt += "[" + qgsDoubleToString( x ) + ", " + qgsDoubleToString( y ) + "]";
+            wkt += "[" + qgsDoubleToString( x, precision ) + ", " + qgsDoubleToString( y, precision ) + "]";
           }
           wkt += " ]";
         }

--- a/src/core/qgsgeometry.h
+++ b/src/core/qgsgeometry.h
@@ -406,10 +406,11 @@ class CORE_EXPORT QgsGeometry
     /** Returns a Geometry representing the points making up this Geometry that do not make up other. */
     QgsGeometry* symDifference( QgsGeometry* geometry );
 
-    /** Exports the geometry to mWkt
+    /** Exports the geometry to WKT
+     *  @note precision parameter added in 2.4
      *  @return true in case of success and false else
      */
-    QString exportToWkt() const;
+    QString exportToWkt( const int &precision = 17 ) const;
 
     /** Exports the geometry to GeoJSON
      *  @return a QString representing the geometry as GeoJSON

--- a/src/core/qgsgeometry.h
+++ b/src/core/qgsgeometry.h
@@ -411,12 +411,13 @@ class CORE_EXPORT QgsGeometry
      */
     QString exportToWkt() const;
 
-    /** Exports the geometry to mGeoJSON
-     *  @return true in case of success and false else
+    /** Exports the geometry to GeoJSON
+     *  @return a QString representing the geometry as GeoJSON
      *  @note added in 1.8
      *  @note python binding added in 1.9
+     *  @note precision parameter added in 2.4
      */
-    QString exportToGeoJSON() const;
+    QString exportToGeoJSON( const int &precision = 17 ) const;
 
     /** try to convert the geometry to the requested type
      * @param destType the geometry type to be converted to

--- a/src/core/qgsogcutils.cpp
+++ b/src/core/qgsogcutils.cpp
@@ -993,7 +993,7 @@ QgsRectangle QgsOgcUtils::rectangleFromGMLEnvelope( const QDomNode& envelopeNode
   return rect;
 }
 
-QDomElement QgsOgcUtils::rectangleToGMLBox( QgsRectangle* box, QDomDocument& doc )
+QDomElement QgsOgcUtils::rectangleToGMLBox( QgsRectangle* box, QDomDocument& doc, const int &precision )
 {
   if ( !box )
   {
@@ -1006,13 +1006,13 @@ QDomElement QgsOgcUtils::rectangleToGMLBox( QgsRectangle* box, QDomDocument& doc
   coordElem.setAttribute( "ts", " " );
 
   QString coordString;
-  coordString += qgsDoubleToString( box->xMinimum() );
+  coordString += qgsDoubleToString( box->xMinimum(), precision );
   coordString += ",";
-  coordString += qgsDoubleToString( box->yMinimum() );
+  coordString += qgsDoubleToString( box->yMinimum(), precision );
   coordString += " ";
-  coordString += qgsDoubleToString( box->xMaximum() );
+  coordString += qgsDoubleToString( box->xMaximum(), precision );
   coordString += ",";
-  coordString += qgsDoubleToString( box->yMaximum() );
+  coordString += qgsDoubleToString( box->yMaximum(), precision );
 
   QDomText coordText = doc.createTextNode( coordString );
   coordElem.appendChild( coordText );
@@ -1021,7 +1021,7 @@ QDomElement QgsOgcUtils::rectangleToGMLBox( QgsRectangle* box, QDomDocument& doc
   return boxElem;
 }
 
-QDomElement QgsOgcUtils::rectangleToGMLEnvelope( QgsRectangle* env, QDomDocument& doc )
+QDomElement QgsOgcUtils::rectangleToGMLEnvelope( QgsRectangle* env, QDomDocument& doc, const int &precision )
 {
   if ( !env )
   {
@@ -1032,17 +1032,17 @@ QDomElement QgsOgcUtils::rectangleToGMLEnvelope( QgsRectangle* env, QDomDocument
   QString posList;
 
   QDomElement lowerCornerElem = doc.createElement( "gml:lowerCorner" );
-  posList = qgsDoubleToString( env->xMinimum() );
+  posList = qgsDoubleToString( env->xMinimum(), precision );
   posList += " ";
-  posList += qgsDoubleToString( env->yMinimum() );
+  posList += qgsDoubleToString( env->yMinimum(), precision );
   QDomText lowerCornerText = doc.createTextNode( posList );
   lowerCornerElem.appendChild( lowerCornerText );
   envElem.appendChild( lowerCornerElem );
 
   QDomElement upperCornerElem = doc.createElement( "gml:upperCorner" );
-  posList = qgsDoubleToString( env->xMaximum() );
+  posList = qgsDoubleToString( env->xMaximum(), precision );
   posList += " ";
-  posList += qgsDoubleToString( env->yMaximum() );
+  posList += qgsDoubleToString( env->yMaximum(), precision );
   QDomText upperCornerText = doc.createTextNode( posList );
   upperCornerElem.appendChild( upperCornerText );
   envElem.appendChild( upperCornerElem );
@@ -1050,7 +1050,7 @@ QDomElement QgsOgcUtils::rectangleToGMLEnvelope( QgsRectangle* env, QDomDocument
   return envElem;
 }
 
-QDomElement QgsOgcUtils::geometryToGML( QgsGeometry* geometry, QDomDocument& doc, QString format )
+QDomElement QgsOgcUtils::geometryToGML( QgsGeometry* geometry, QDomDocument& doc, QString format, const int &precision )
 {
   if ( !geometry || !geometry->asWkb() )
     return QDomElement();
@@ -1100,7 +1100,7 @@ QDomElement QgsOgcUtils::geometryToGML( QgsGeometry* geometry, QDomDocument& doc
 
       double x, y;
       wkbPtr >> x >> y;
-      QDomText coordText = doc.createTextNode( qgsDoubleToString( x ) + cs + qgsDoubleToString( y ) );
+      QDomText coordText = doc.createTextNode( qgsDoubleToString( x, precision ) + cs + qgsDoubleToString( y, precision ) );
 
       coordElem.appendChild( coordText );
       pointElem.appendChild( coordElem );
@@ -1124,7 +1124,7 @@ QDomElement QgsOgcUtils::geometryToGML( QgsGeometry* geometry, QDomDocument& doc
 
         double x, y;
         wkbPtr >> x >> y;
-        QDomText coordText = doc.createTextNode( qgsDoubleToString( x ) + cs + qgsDoubleToString( y ) );
+        QDomText coordText = doc.createTextNode( qgsDoubleToString( x, precision ) + cs + qgsDoubleToString( y, precision ) );
 
         coordElem.appendChild( coordText );
         pointElem.appendChild( coordElem );
@@ -1159,7 +1159,7 @@ QDomElement QgsOgcUtils::geometryToGML( QgsGeometry* geometry, QDomDocument& doc
 
         double x, y;
         wkbPtr >> x >> y;
-        coordString += qgsDoubleToString( x ) + cs + qgsDoubleToString( y );
+        coordString += qgsDoubleToString( x, precision ) + cs + qgsDoubleToString( y, precision );
 
         if ( hasZValue )
         {
@@ -1201,7 +1201,7 @@ QDomElement QgsOgcUtils::geometryToGML( QgsGeometry* geometry, QDomDocument& doc
           double x, y;
           wkbPtr >> x >> y;
 
-          coordString += qgsDoubleToString( x ) + cs + qgsDoubleToString( y );
+          coordString += qgsDoubleToString( x, precision ) + cs + qgsDoubleToString( y, precision );
 
           if ( hasZValue )
           {
@@ -1257,7 +1257,7 @@ QDomElement QgsOgcUtils::geometryToGML( QgsGeometry* geometry, QDomDocument& doc
           double x, y;
           wkbPtr >> x >> y;
 
-          coordString += qgsDoubleToString( x ) + cs + qgsDoubleToString( y );
+          coordString += qgsDoubleToString( x, precision ) + cs + qgsDoubleToString( y, precision );
           if ( hasZValue )
           {
             wkbPtr += sizeof( double );
@@ -1316,7 +1316,7 @@ QDomElement QgsOgcUtils::geometryToGML( QgsGeometry* geometry, QDomDocument& doc
             double x, y;
             wkbPtr >> x >> y;
 
-            coordString += qgsDoubleToString( x ) + cs + qgsDoubleToString( y );
+            coordString += qgsDoubleToString( x, precision ) + cs + qgsDoubleToString( y, precision );
 
             if ( hasZValue )
             {
@@ -1339,9 +1339,9 @@ QDomElement QgsOgcUtils::geometryToGML( QgsGeometry* geometry, QDomDocument& doc
   }
 }
 
-QDomElement QgsOgcUtils::geometryToGML( QgsGeometry *geometry, QDomDocument &doc )
+QDomElement QgsOgcUtils::geometryToGML( QgsGeometry *geometry, QDomDocument &doc, const int &precision )
 {
-  return geometryToGML( geometry, doc, "GML2" );
+  return geometryToGML( geometry, doc, "GML2", precision );
 }
 
 QDomElement QgsOgcUtils::createGMLCoordinates( const QgsPolyline &points, QDomDocument &doc )

--- a/src/core/qgsogcutils.h
+++ b/src/core/qgsogcutils.h
@@ -51,22 +51,22 @@ class CORE_EXPORT QgsOgcUtils
     /** Exports the geometry to GML2 or GML3
         @return QDomElement
      */
-    static QDomElement geometryToGML( QgsGeometry* geometry, QDomDocument& doc, QString format );
+    static QDomElement geometryToGML( QgsGeometry* geometry, QDomDocument& doc, QString format, const int &precision = 17 );
 
     /** Exports the geometry to GML2
         @return QDomElement
      */
-    static QDomElement geometryToGML( QgsGeometry* geometry, QDomDocument& doc );
+    static QDomElement geometryToGML( QgsGeometry* geometry, QDomDocument& doc, const int &precision = 17 );
 
     /** Exports the rectangle to GML2 Box
         @return QDomElement
      */
-    static QDomElement rectangleToGMLBox( QgsRectangle* box, QDomDocument& doc );
+    static QDomElement rectangleToGMLBox( QgsRectangle* box, QDomDocument& doc, const int &precision = 17 );
 
     /** Exports the rectangle to GML2 Envelope
         @return QDomElement
      */
-    static QDomElement rectangleToGMLEnvelope( QgsRectangle* env, QDomDocument& doc );
+    static QDomElement rectangleToGMLEnvelope( QgsRectangle* env, QDomDocument& doc, const int &precision = 17 );
 
 
     /** Parse XML with OGC fill into QColor */

--- a/src/mapserver/qgssldconfigparser.cpp
+++ b/src/mapserver/qgssldconfigparser.cpp
@@ -678,6 +678,15 @@ double QgsSLDConfigParser::imageQuality() const
   return -1;
 }
 
+int QgsSLDConfigParser::WMSPrecision() const
+{
+  if ( mFallbackParser )
+  {
+    return mFallbackParser->WMSPrecision();
+  }
+  return -1;
+}
+
 QgsComposition* QgsSLDConfigParser::createPrintComposition( const QString& composerTemplate, QgsMapRenderer* mapRenderer, const QMap< QString, QString >& parameterMap ) const
 {
   if ( mFallbackParser )

--- a/src/mapserver/qgssldconfigparser.h
+++ b/src/mapserver/qgssldconfigparser.h
@@ -99,6 +99,7 @@ class QgsSLDConfigParser : public QgsWMSConfigParser
     double maxWidth() const;
     double maxHeight() const;
     double imageQuality() const;
+    int WMSPrecision() const;
 
     //printing
 

--- a/src/mapserver/qgswfsserver.cpp
+++ b/src/mapserver/qgswfsserver.cpp
@@ -1074,7 +1074,7 @@ void QgsWFSServer::startGetFeature( QgsRequestHandler& request, const QString& f
   if ( format == "GeoJSON" )
   {
     fcString = "{\"type\": \"FeatureCollection\",\n";
-    fcString += " \"bbox\": [ " + QString::number( rect->xMinimum(), 'f', 8 ).remove( QRegExp( "[0]{1,7}$" ) ) + ", " + QString::number( rect->yMinimum(), 'f', 8 ).remove( QRegExp( "[0]{1,7}$" ) ) + ", " + QString::number( rect->xMaximum(), 'f', 8 ).remove( QRegExp( "[0]{1,7}$" ) ) + ", " + QString::number( rect->yMaximum(), 'f', 8 ).remove( QRegExp( "[0]{1,7}$" ) ) + "],\n";
+    fcString += " \"bbox\": [ " + qgsDoubleToString( rect->xMinimum(), 8 ) + ", " + qgsDoubleToString( rect->yMinimum(), 8 ) + ", " + qgsDoubleToString( rect->xMaximum(), 8 ) + ", " + qgsDoubleToString( rect->yMaximum(), 8 ) + "],\n";
     fcString += " \"features\": [\n";
     result = fcString.toUtf8();
     request.startGetFeatureResponse( &result, format );
@@ -1167,7 +1167,7 @@ void QgsWFSServer::startGetFeature( QgsRequestHandler& request, const QString& f
     QDomElement bbElem = doc.createElement( "gml:boundedBy" );
     if ( format == "GML3" )
     {
-      QDomElement envElem = QgsOgcUtils::rectangleToGMLEnvelope( rect, doc );
+      QDomElement envElem = QgsOgcUtils::rectangleToGMLEnvelope( rect, doc, 8 );
       if ( !envElem.isNull() )
       {
         if ( crs.isValid() )
@@ -1180,7 +1180,7 @@ void QgsWFSServer::startGetFeature( QgsRequestHandler& request, const QString& f
     }
     else
     {
-      QDomElement boxElem = QgsOgcUtils::rectangleToGMLBox( rect, doc );
+      QDomElement boxElem = QgsOgcUtils::rectangleToGMLBox( rect, doc, 8 );
       if ( !boxElem.isNull() )
       {
         if ( crs.isValid() )
@@ -1691,10 +1691,10 @@ QString QgsWFSServer::createFeatureGeoJSON( QgsFeature* feat, QgsCoordinateRefer
   {
     QgsRectangle box = geom->boundingBox();
 
-    fStr += " \"bbox\": [ " + QString::number( box.xMinimum(), 'f', 8 ).remove( QRegExp( "[0]{1,7}$" ) ) + ", " + QString::number( box.yMinimum(), 'f', 8 ).remove( QRegExp( "[0]{1,7}$" ) ) + ", " + QString::number( box.xMaximum(), 'f', 8 ).remove( QRegExp( "[0]{1,7}$" ) ) + ", " + QString::number( box.yMaximum(), 'f', 8 ).remove( QRegExp( "[0]{1,7}$" ) ) + "],\n";
+    fStr += " \"bbox\": [ " + qgsDoubleToString( box.xMinimum(), 8 ) + ", " + qgsDoubleToString( box.yMinimum(), 8 ) + ", " + qgsDoubleToString( box.xMaximum(), 8 ) + ", " + qgsDoubleToString( box.yMaximum(), 8 ) + "],\n";
 
     fStr += "  \"geometry\": ";
-    fStr += geom->exportToGeoJSON();
+    fStr += geom->exportToGeoJSON( 8 );
     fStr += ",\n";
   }
 
@@ -1757,12 +1757,12 @@ QDomElement QgsWFSServer::createFeatureGML2( QgsFeature* feat, QDomDocument& doc
     QgsGeometry* geom = feat->geometry();
 
     QDomElement geomElem = doc.createElement( "qgs:geometry" );
-    QDomElement gmlElem = QgsOgcUtils::geometryToGML( geom, doc );
+    QDomElement gmlElem = QgsOgcUtils::geometryToGML( geom, doc, 8 );
     if ( !gmlElem.isNull() )
     {
       QgsRectangle box = geom->boundingBox();
       QDomElement bbElem = doc.createElement( "gml:boundedBy" );
-      QDomElement boxElem = QgsOgcUtils::rectangleToGMLBox( &box, doc );
+      QDomElement boxElem = QgsOgcUtils::rectangleToGMLBox( &box, doc, 8 );
 
       if ( crs.isValid() )
       {
@@ -1816,12 +1816,12 @@ QDomElement QgsWFSServer::createFeatureGML3( QgsFeature* feat, QDomDocument& doc
     QgsGeometry* geom = feat->geometry();
 
     QDomElement geomElem = doc.createElement( "qgs:geometry" );
-    QDomElement gmlElem = QgsOgcUtils::geometryToGML( geom, doc, "GML3" );
+    QDomElement gmlElem = QgsOgcUtils::geometryToGML( geom, doc, "GML3", 8 );
     if ( !gmlElem.isNull() )
     {
       QgsRectangle box = geom->boundingBox();
       QDomElement bbElem = doc.createElement( "gml:boundedBy" );
-      QDomElement boxElem = QgsOgcUtils::rectangleToGMLEnvelope( &box, doc );
+      QDomElement boxElem = QgsOgcUtils::rectangleToGMLEnvelope( &box, doc, 8 );
 
       if ( crs.isValid() )
       {

--- a/src/mapserver/qgswmsconfigparser.h
+++ b/src/mapserver/qgswmsconfigparser.h
@@ -98,6 +98,9 @@ class QgsWMSConfigParser
     virtual double maxHeight() const = 0;
     virtual double imageQuality() const = 0;
 
+    // WMS GetFeatureInfo precision (decimal places)
+    virtual int WMSPrecision() const = 0;
+
     //printing
 
     /**Creates a print composition, usually for a GetPrint request. Replaces map and label parameters*/

--- a/src/mapserver/qgswmsprojectparser.cpp
+++ b/src/mapserver/qgswmsprojectparser.cpp
@@ -353,6 +353,21 @@ double QgsWMSProjectParser::imageQuality() const
   return imageQuality;
 }
 
+int QgsWMSProjectParser::WMSPrecision() const
+{
+  int WMSPrecision = -1;
+  QDomElement propertiesElem = mProjectParser.propertiesElem();
+  if ( !propertiesElem.isNull() )
+  {
+    QDomElement WMSPrecisionElem = propertiesElem.firstChildElement( "WMSPrecision" );
+    if ( !WMSPrecisionElem.isNull() )
+    {
+      WMSPrecision = WMSPrecisionElem.text().toInt();
+    }
+  }
+  return WMSPrecision;
+}
+
 QgsComposition* QgsWMSProjectParser::initComposition( const QString& composerTemplate, QgsMapRenderer* mapRenderer, QList< QgsComposerMap*>& mapList, QList< QgsComposerLabel* >& labelList, QList<const QgsComposerHtml *>& htmlList ) const
 {
   //Create composition from xml

--- a/src/mapserver/qgswmsprojectparser.h
+++ b/src/mapserver/qgswmsprojectparser.h
@@ -56,6 +56,7 @@ class QgsWMSProjectParser : public QgsWMSConfigParser
     double maxWidth() const;
     double maxHeight() const;
     double imageQuality() const;
+    int WMSPrecision() const;
 
     //printing
     QgsComposition* initComposition( const QString& composerTemplate, QgsMapRenderer* mapRenderer, QList< QgsComposerMap*>& mapList, QList< QgsComposerLabel* >& labelList, QList<const QgsComposerHtml *>& htmlFrameList ) const;

--- a/src/mapserver/qgswmsserver.cpp
+++ b/src/mapserver/qgswmsserver.cpp
@@ -1286,11 +1286,11 @@ int QgsWMSServer::getFeatureInfo( QDomDocument& result, QString version )
       int gmlVersion = infoFormat.startsWith( "application/vnd.ogc.gml/3" ) ? 3 : 2;
       if ( gmlVersion < 3 )
       {
-        boxElem = QgsOgcUtils::rectangleToGMLBox( featuresRect, result );
+        boxElem = QgsOgcUtils::rectangleToGMLBox( featuresRect, result, 8 );
       }
       else
       {
-        boxElem = QgsOgcUtils::rectangleToGMLEnvelope( featuresRect, result );
+        boxElem = QgsOgcUtils::rectangleToGMLEnvelope( featuresRect, result, 8 );
       }
 
       QgsCoordinateReferenceSystem crs = mMapRenderer->destinationCrs();
@@ -1305,10 +1305,10 @@ int QgsWMSServer::getFeatureInfo( QDomDocument& result, QString version )
     {
       QDomElement bBoxElem = result.createElement( "BoundingBox" );
       bBoxElem.setAttribute( "CRS", mMapRenderer->destinationCrs().authid() );
-      bBoxElem.setAttribute( "minx", QString::number( featuresRect->xMinimum() ) );
-      bBoxElem.setAttribute( "maxx", QString::number( featuresRect->xMaximum() ) );
-      bBoxElem.setAttribute( "miny", QString::number( featuresRect->yMinimum() ) );
-      bBoxElem.setAttribute( "maxy", QString::number( featuresRect->yMaximum() ) );
+      bBoxElem.setAttribute( "minx", qgsDoubleToString( featuresRect->xMinimum(), 8 ) );
+      bBoxElem.setAttribute( "maxx", qgsDoubleToString( featuresRect->xMaximum(), 8 ) );
+      bBoxElem.setAttribute( "miny", qgsDoubleToString( featuresRect->yMinimum(), 8 ) );
+      bBoxElem.setAttribute( "maxy", qgsDoubleToString( featuresRect->yMaximum(), 8 ) );
       getFeatureInfoElement.insertBefore( bBoxElem, QDomNode() ); //insert as first child
     }
   }
@@ -1830,10 +1830,10 @@ int QgsWMSServer::featureInfoFromVectorLayer( QgsVectorLayer* layer,
       {
         QDomElement bBoxElem = infoDocument.createElement( "BoundingBox" );
         bBoxElem.setAttribute( version == "1.1.1" ? "SRS" : "CRS", outputCrs.authid() );
-        bBoxElem.setAttribute( "minx", QString::number( box.xMinimum() ) );
-        bBoxElem.setAttribute( "maxx", QString::number( box.xMaximum() ) );
-        bBoxElem.setAttribute( "miny", QString::number( box.yMinimum() ) );
-        bBoxElem.setAttribute( "maxy", QString::number( box.yMaximum() ) );
+        bBoxElem.setAttribute( "minx", qgsDoubleToString( box.xMinimum(), 8 ) );
+        bBoxElem.setAttribute( "maxx", qgsDoubleToString( box.xMaximum(), 8 ) );
+        bBoxElem.setAttribute( "miny", qgsDoubleToString( box.yMinimum(), 8 ) );
+        bBoxElem.setAttribute( "maxy", qgsDoubleToString( box.yMaximum(), 8 ) );
         featureElement.appendChild( bBoxElem );
       }
 
@@ -1851,7 +1851,7 @@ int QgsWMSServer::featureInfoFromVectorLayer( QgsVectorLayer* layer,
         }
         QDomElement geometryElement = infoDocument.createElement( "Attribute" );
         geometryElement.setAttribute( "name", "geometry" );
-        geometryElement.setAttribute( "value", geom->exportToWkt() );
+        geometryElement.setAttribute( "value", geom->exportToWkt( 8 ) );
         geometryElement.setAttribute( "type", "derived" );
         featureElement.appendChild( geometryElement );
       }
@@ -2836,11 +2836,11 @@ QDomElement QgsWMSServer::createFeatureGML(
     QDomElement boxElem;
     if ( version < 3 )
     {
-      boxElem = QgsOgcUtils::rectangleToGMLBox( &box, doc );
+      boxElem = QgsOgcUtils::rectangleToGMLBox( &box, doc, 8 );
     }
     else
     {
-      boxElem = QgsOgcUtils::rectangleToGMLEnvelope( &box, doc );
+      boxElem = QgsOgcUtils::rectangleToGMLEnvelope( &box, doc, 8 );
     }
 
     if ( crs.isValid() )
@@ -2864,11 +2864,11 @@ QDomElement QgsWMSServer::createFeatureGML(
     QDomElement gmlElem;
     if ( version < 3 )
     {
-      gmlElem = QgsOgcUtils::geometryToGML( geom, doc );
+      gmlElem = QgsOgcUtils::geometryToGML( geom, doc, 8 );
     }
     else
     {
-      gmlElem = QgsOgcUtils::geometryToGML( geom, doc, "GML3" );
+      gmlElem = QgsOgcUtils::geometryToGML( geom, doc, "GML3", 8 );
     }
 
     if ( !gmlElem.isNull() )

--- a/src/mapserver/qgswmsserver.cpp
+++ b/src/mapserver/qgswmsserver.cpp
@@ -1830,10 +1830,10 @@ int QgsWMSServer::featureInfoFromVectorLayer( QgsVectorLayer* layer,
       {
         QDomElement bBoxElem = infoDocument.createElement( "BoundingBox" );
         bBoxElem.setAttribute( version == "1.1.1" ? "SRS" : "CRS", outputCrs.authid() );
-        bBoxElem.setAttribute( "minx", qgsDoubleToString( box.xMinimum(), 8 ) );
-        bBoxElem.setAttribute( "maxx", qgsDoubleToString( box.xMaximum(), 8 ) );
-        bBoxElem.setAttribute( "miny", qgsDoubleToString( box.yMinimum(), 8 ) );
-        bBoxElem.setAttribute( "maxy", qgsDoubleToString( box.yMaximum(), 8 ) );
+        bBoxElem.setAttribute( "minx", qgsDoubleToString( box.xMinimum(), getWMSPrecision( 8 ) ) );
+        bBoxElem.setAttribute( "maxx", qgsDoubleToString( box.xMaximum(), getWMSPrecision( 8 ) ) );
+        bBoxElem.setAttribute( "miny", qgsDoubleToString( box.yMinimum(), getWMSPrecision( 8 ) ) );
+        bBoxElem.setAttribute( "maxy", qgsDoubleToString( box.yMaximum(), getWMSPrecision( 8 ) ) );
         featureElement.appendChild( bBoxElem );
       }
 
@@ -1851,7 +1851,7 @@ int QgsWMSServer::featureInfoFromVectorLayer( QgsVectorLayer* layer,
         }
         QDomElement geometryElement = infoDocument.createElement( "Attribute" );
         geometryElement.setAttribute( "name", "geometry" );
-        geometryElement.setAttribute( "value", geom->exportToWkt( 8 ) );
+        geometryElement.setAttribute( "value", geom->exportToWkt( getWMSPrecision( 8 ) ) );
         geometryElement.setAttribute( "type", "derived" );
         featureElement.appendChild( geometryElement );
       }
@@ -3019,4 +3019,26 @@ int QgsWMSServer::getImageQuality( ) const
     }
   }
   return imageQuality;
+}
+
+int QgsWMSServer::getWMSPrecision( int defaultValue = 8) const
+{
+  // First taken from QGIS project
+  int WMSPrecision = mConfigParser->WMSPrecision();
+
+  // Then checks if a parameter is given, if so use it instead
+  if ( mParameters.contains( "WMS_PRECISION" ) )
+  {
+    bool conversionSuccess;
+    int WMSPrecisionParameter;
+    WMSPrecisionParameter = mParameters[ "WMS_PRECISION" ].toInt( &conversionSuccess );
+    if ( conversionSuccess )
+    {
+      WMSPrecision = WMSPrecisionParameter;
+    }
+  }
+  if ( WMSPrecision == -1 ){
+    WMSPrecision = defaultValue;
+  }
+  return WMSPrecision;
 }

--- a/src/mapserver/qgswmsserver.h
+++ b/src/mapserver/qgswmsserver.h
@@ -258,6 +258,9 @@ class QgsWMSServer: public QgsOWSServer
 
     /** Return the image quality to use for getMap request */
     int getImageQuality() const;
+
+    /** Return precision to use for GetFeatureInfo request */
+    int getWMSPrecision(int defaultValue ) const;
 };
 
 #endif

--- a/src/ui/qgsprojectpropertiesbase.ui
+++ b/src/ui/qgsprojectpropertiesbase.ui
@@ -42,7 +42,16 @@
        <enum>QFrame::Raised</enum>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_2">
-       <property name="margin">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
         <number>0</number>
        </property>
        <item>
@@ -179,7 +188,16 @@
        <enum>QFrame::Raised</enum>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_3">
-       <property name="margin">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
         <number>0</number>
        </property>
        <item>
@@ -191,11 +209,20 @@
           </sizepolicy>
          </property>
          <property name="currentIndex">
-          <number>1</number>
+          <number>4</number>
          </property>
          <widget class="QWidget" name="mProjOpts_01">
           <layout class="QVBoxLayout" name="verticalLayout_6">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -211,8 +238,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>683</width>
-                <height>779</height>
+                <width>637</width>
+                <height>696</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_8">
@@ -609,7 +636,16 @@
                      <enum>QFrame::Raised</enum>
                     </property>
                     <layout class="QHBoxLayout" name="horizontalLayout_4">
-                     <property name="margin">
+                     <property name="leftMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="topMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="rightMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="bottomMargin">
                       <number>0</number>
                      </property>
                      <item>
@@ -782,7 +818,16 @@
          </widget>
          <widget class="QWidget" name="mProjOpts_02">
           <layout class="QVBoxLayout" name="verticalLayout_5">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -798,8 +843,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>683</width>
-                <height>779</height>
+                <width>328</width>
+                <height>54</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_7">
@@ -832,7 +877,16 @@
          </widget>
          <widget class="QWidget" name="mProjOpts_03">
           <layout class="QVBoxLayout" name="verticalLayout_9">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -848,8 +902,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>683</width>
-                <height>779</height>
+                <width>141</width>
+                <height>100</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_10">
@@ -904,7 +958,16 @@
          </widget>
          <widget class="QWidget" name="mProjOpts_04">
           <layout class="QVBoxLayout" name="verticalLayout_11">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -920,8 +983,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>683</width>
-                <height>779</height>
+                <width>379</width>
+                <height>570</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_12">
@@ -1320,7 +1383,16 @@
          </widget>
          <widget class="QWidget" name="mProjOpts_05">
           <layout class="QVBoxLayout" name="verticalLayout_14">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -1335,9 +1407,9 @@
               <property name="geometry">
                <rect>
                 <x>0</x>
-                <y>0</y>
-                <width>667</width>
-                <height>1570</height>
+                <y>-330</y>
+                <width>671</width>
+                <height>1624</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_13">
@@ -1368,15 +1440,11 @@
                   <string notr="true">projowsserver</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_6">
-                  <item row="3" column="0">
-                   <widget class="QLabel" name="label_9">
-                    <property name="text">
-                     <string>Person</string>
-                    </property>
-                    <property name="buddy">
-                     <cstring>mWMSContactPerson</cstring>
-                    </property>
-                   </widget>
+                  <item row="7" column="1">
+                   <widget class="QLineEdit" name="mWMSFees"/>
+                  </item>
+                  <item row="8" column="1">
+                   <widget class="QLineEdit" name="mWMSAccessConstraints"/>
                   </item>
                   <item row="0" column="0">
                    <widget class="QLabel" name="label_10">
@@ -1388,21 +1456,8 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="0" column="1">
-                   <widget class="QLineEdit" name="mWMSTitle"/>
-                  </item>
-                  <item row="1" column="0">
-                   <widget class="QLabel" name="label_11">
-                    <property name="text">
-                     <string>Organization</string>
-                    </property>
-                    <property name="buddy">
-                     <cstring>mWMSContactOrganization</cstring>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="1">
-                   <widget class="QLineEdit" name="mWMSContactOrganization"/>
+                  <item row="2" column="1">
+                   <widget class="QLineEdit" name="mWMSOnlineResourceLineEdit"/>
                   </item>
                   <item row="2" column="0">
                    <widget class="QLabel" name="mWMSOnlineResourceLabel">
@@ -1411,8 +1466,18 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="2" column="1">
-                   <widget class="QLineEdit" name="mWMSOnlineResourceLineEdit"/>
+                  <item row="3" column="0">
+                   <widget class="QLabel" name="label_9">
+                    <property name="text">
+                     <string>Person</string>
+                    </property>
+                    <property name="buddy">
+                     <cstring>mWMSContactPerson</cstring>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="4" column="1">
+                   <widget class="QLineEdit" name="mWMSContactMail"/>
                   </item>
                   <item row="3" column="1">
                    <widget class="QLineEdit" name="mWMSContactPerson"/>
@@ -1424,8 +1489,8 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="4" column="1">
-                   <widget class="QLineEdit" name="mWMSContactMail"/>
+                  <item row="1" column="1">
+                   <widget class="QLineEdit" name="mWMSContactOrganization"/>
                   </item>
                   <item row="5" column="0">
                    <widget class="QLabel" name="label_12">
@@ -1437,8 +1502,8 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="5" column="1">
-                   <widget class="QLineEdit" name="mWMSContactPhone"/>
+                  <item row="0" column="1">
+                   <widget class="QLineEdit" name="mWMSTitle"/>
                   </item>
                   <item row="6" column="0">
                    <widget class="QLabel" name="label_15">
@@ -1450,21 +1515,31 @@
                     </property>
                    </widget>
                   </item>
+                  <item row="5" column="1">
+                   <widget class="QLineEdit" name="mWMSContactPhone"/>
+                  </item>
                   <item row="6" column="1">
                    <widget class="QTextEdit" name="mWMSAbstract"/>
                   </item>
-                  <item row="7" column="1">
-                   <widget class="QLineEdit" name="mWMSFees"/>
-                  </item>
-                  <item row="7" column="0">
-                   <widget class="QLabel" name="mWMSFeesLabel">
+                  <item row="9" column="0">
+                   <widget class="QLabel" name="mWMSKeywordListLabel">
                     <property name="text">
-                     <string>Fees</string>
+                     <string>Keyword list</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="8" column="1">
-                   <widget class="QLineEdit" name="mWMSAccessConstraints"/>
+                  <item row="9" column="1">
+                   <widget class="QLineEdit" name="mWMSKeywordList"/>
+                  </item>
+                  <item row="1" column="0">
+                   <widget class="QLabel" name="label_11">
+                    <property name="text">
+                     <string>Organization</string>
+                    </property>
+                    <property name="buddy">
+                     <cstring>mWMSContactOrganization</cstring>
+                    </property>
+                   </widget>
                   </item>
                   <item row="8" column="0">
                    <widget class="QLabel" name="mWMSAccessConstraintsLabel">
@@ -1473,13 +1548,10 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="9" column="1">
-                   <widget class="QLineEdit" name="mWMSKeywordList"/>
-                  </item>
-                  <item row="9" column="0">
-                   <widget class="QLabel" name="mWMSKeywordListLabel">
+                  <item row="7" column="0">
+                   <widget class="QLabel" name="mWMSFeesLabel">
                     <property name="text">
-                     <string>Keyword list</string>
+                     <string>Fees</string>
                     </property>
                    </widget>
                   </item>
@@ -1494,55 +1566,8 @@
                  <property name="syncGroup" stdset="0">
                   <string notr="true">projowsserver</string>
                  </property>
-                 <layout class="QGridLayout" name="gridLayout_14">
-                  <item row="0" column="1" colspan="2">
-                   <widget class="QgsCollapsibleGroupBox" name="grpWMSList">
-                    <property name="title">
-                     <string>CRS restrictions</string>
-                    </property>
-                    <property name="checkable">
-                     <bool>true</bool>
-                    </property>
-                    <property name="checked">
-                     <bool>false</bool>
-                    </property>
-                    <property name="collapsed" stdset="0">
-                     <bool>false</bool>
-                    </property>
-                    <property name="saveCollapsedState" stdset="0">
-                     <bool>true</bool>
-                    </property>
-                    <layout class="QGridLayout" name="gridLayout_5">
-                     <item row="1" column="0">
-                      <widget class="QToolButton" name="pbnWMSAddSRS">
-                       <property name="icon">
-                        <iconset resource="../../images/images.qrc">
-                         <normaloff>:/images/themes/default/mActionSignPlus.png</normaloff>:/images/themes/default/mActionSignPlus.png</iconset>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="0" column="0" colspan="4">
-                      <widget class="QListWidget" name="mWMSList"/>
-                     </item>
-                     <item row="1" column="2">
-                      <widget class="QPushButton" name="pbnWMSSetUsedSRS">
-                       <property name="text">
-                        <string>Used</string>
-                       </property>
-                      </widget>
-                     </item>
-                     <item row="1" column="1">
-                      <widget class="QToolButton" name="pbnWMSRemoveSRS">
-                       <property name="icon">
-                        <iconset resource="../../images/images.qrc">
-                         <normaloff>:/images/themes/default/symbologyRemove.png</normaloff>:/images/themes/default/symbologyRemove.png</iconset>
-                       </property>
-                      </widget>
-                     </item>
-                    </layout>
-                   </widget>
-                  </item>
-                  <item row="1" column="0">
+                 <layout class="QGridLayout" name="gridLayout_12">
+                  <item row="2" column="0">
                    <widget class="QgsCollapsibleGroupBox" name="mWMSComposerGroupBox">
                     <property name="title">
                      <string>Exclude composers</string>
@@ -1601,7 +1626,7 @@
                     </layout>
                    </widget>
                   </item>
-                  <item row="1" column="1" colspan="2">
+                  <item row="2" column="1">
                    <widget class="QgsCollapsibleGroupBox" name="mLayerRestrictionsGroupBox">
                     <property name="title">
                      <string>Exclude layers</string>
@@ -1660,68 +1685,7 @@
                     </layout>
                    </widget>
                   </item>
-                  <item row="4" column="0" colspan="3">
-                   <layout class="QHBoxLayout" name="horizontalLayout_2">
-                    <item>
-                     <widget class="QLabel" name="mWMSUrlLabel">
-                      <property name="text">
-                       <string>Advertised URL</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QLineEdit" name="mWMSUrlLineEdit"/>
-                    </item>
-                   </layout>
-                  </item>
-                  <item row="5" column="0" colspan="3">
-                   <layout class="QGridLayout" name="gridLayout_3">
-                    <item row="1" column="1">
-                     <widget class="QLabel" name="mMaxWidthLabel">
-                      <property name="text">
-                       <string>Width</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="1" column="0">
-                     <spacer name="horizontalSpacer_6">
-                      <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
-                      </property>
-                      <property name="sizeType">
-                       <enum>QSizePolicy::Fixed</enum>
-                      </property>
-                      <property name="sizeHint" stdset="0">
-                       <size>
-                        <width>6</width>
-                        <height>20</height>
-                       </size>
-                      </property>
-                     </spacer>
-                    </item>
-                    <item row="1" column="4">
-                     <widget class="QLineEdit" name="mMaxHeightLineEdit"/>
-                    </item>
-                    <item row="1" column="2">
-                     <widget class="QLineEdit" name="mMaxWidthLineEdit"/>
-                    </item>
-                    <item row="1" column="3">
-                     <widget class="QLabel" name="mMaxHeightLabel">
-                      <property name="text">
-                       <string>Height</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="0" column="0" colspan="5">
-                     <widget class="QLabel" name="label_21">
-                      <property name="text">
-                       <string>Maximums for GetMap request</string>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </item>
-                  <item row="0" column="0">
+                  <item row="1" column="0">
                    <widget class="QgsCollapsibleGroupBox" name="grpWMSExt">
                     <property name="title">
                      <string>Advertised extent</string>
@@ -1830,7 +1794,61 @@
                     </layout>
                    </widget>
                   </item>
-                  <item row="6" column="0" colspan="3">
+                  <item row="1" column="1">
+                   <widget class="QgsCollapsibleGroupBox" name="grpWMSList">
+                    <property name="title">
+                     <string>CRS restrictions</string>
+                    </property>
+                    <property name="checkable">
+                     <bool>true</bool>
+                    </property>
+                    <property name="checked">
+                     <bool>false</bool>
+                    </property>
+                    <property name="collapsed" stdset="0">
+                     <bool>false</bool>
+                    </property>
+                    <property name="saveCollapsedState" stdset="0">
+                     <bool>true</bool>
+                    </property>
+                    <layout class="QGridLayout" name="gridLayout_5">
+                     <item row="1" column="0">
+                      <widget class="QToolButton" name="pbnWMSAddSRS">
+                       <property name="icon">
+                        <iconset resource="../../images/images.qrc">
+                         <normaloff>:/images/themes/default/mActionSignPlus.png</normaloff>:/images/themes/default/mActionSignPlus.png</iconset>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="0" column="0" colspan="4">
+                      <widget class="QListWidget" name="mWMSList"/>
+                     </item>
+                     <item row="1" column="2">
+                      <widget class="QPushButton" name="pbnWMSSetUsedSRS">
+                       <property name="text">
+                        <string>Used</string>
+                       </property>
+                      </widget>
+                     </item>
+                     <item row="1" column="1">
+                      <widget class="QToolButton" name="pbnWMSRemoveSRS">
+                       <property name="icon">
+                        <iconset resource="../../images/images.qrc">
+                         <normaloff>:/images/themes/default/symbologyRemove.png</normaloff>:/images/themes/default/symbologyRemove.png</iconset>
+                       </property>
+                      </widget>
+                     </item>
+                    </layout>
+                   </widget>
+                  </item>
+                  <item row="3" column="0">
+                   <widget class="QCheckBox" name="mWmsUseLayerIDs">
+                    <property name="text">
+                     <string>Use layer ids as names</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="8" column="0" colspan="2">
                    <layout class="QHBoxLayout" name="horizontalLayout_10">
                     <item>
                      <widget class="QLabel" name="mWMSImageQualityLabel">
@@ -1857,19 +1875,97 @@
                     </item>
                    </layout>
                   </item>
-                  <item row="2" column="0">
+                  <item row="4" column="0">
                    <widget class="QCheckBox" name="mAddWktGeometryCheckBox">
                     <property name="text">
                      <string>Add geometry to feature response</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="2" column="1" colspan="2">
-                   <widget class="QCheckBox" name="mWmsUseLayerIDs">
-                    <property name="text">
-                     <string>Use layer ids as names</string>
-                    </property>
-                   </widget>
+                  <item row="7" column="0" colspan="2">
+                   <layout class="QGridLayout" name="gridLayout_3">
+                    <item row="1" column="1">
+                     <widget class="QLabel" name="mMaxWidthLabel">
+                      <property name="text">
+                       <string>Width</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="1" column="0">
+                     <spacer name="horizontalSpacer_6">
+                      <property name="orientation">
+                       <enum>Qt::Horizontal</enum>
+                      </property>
+                      <property name="sizeType">
+                       <enum>QSizePolicy::Fixed</enum>
+                      </property>
+                      <property name="sizeHint" stdset="0">
+                       <size>
+                        <width>6</width>
+                        <height>20</height>
+                       </size>
+                      </property>
+                     </spacer>
+                    </item>
+                    <item row="1" column="4">
+                     <widget class="QLineEdit" name="mMaxHeightLineEdit"/>
+                    </item>
+                    <item row="1" column="2">
+                     <widget class="QLineEdit" name="mMaxWidthLineEdit"/>
+                    </item>
+                    <item row="1" column="3">
+                     <widget class="QLabel" name="mMaxHeightLabel">
+                      <property name="text">
+                       <string>Height</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item row="0" column="0" colspan="5">
+                     <widget class="QLabel" name="label_21">
+                      <property name="text">
+                       <string>Maximums for GetMap request</string>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                  <item row="5" column="0" colspan="2">
+                   <layout class="QHBoxLayout" name="grpWMSPrecision">
+                    <item>
+                     <widget class="QLabel" name="label_5">
+                      <property name="text">
+                       <string>GetFeatureInfo geometry precision (decimal places)</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QSpinBox" name="mWMSPrecisionSpinBox">
+                      <property name="minimum">
+                       <number>1</number>
+                      </property>
+                      <property name="maximum">
+                       <number>17</number>
+                      </property>
+                      <property name="value">
+                       <number>8</number>
+                      </property>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                  <item row="6" column="0" colspan="2">
+                   <layout class="QHBoxLayout" name="horizontalLayout_2">
+                    <item>
+                     <widget class="QLabel" name="mWMSUrlLabel">
+                      <property name="text">
+                       <string>Advertised URL</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QLineEdit" name="mWMSUrlLineEdit"/>
+                    </item>
+                   </layout>
                   </item>
                  </layout>
                 </widget>
@@ -2042,7 +2138,16 @@
          </widget>
          <widget class="QWidget" name="mProjOpts_06">
           <layout class="QVBoxLayout" name="verticalLayout_15">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -2058,8 +2163,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>683</width>
-                <height>779</height>
+                <width>170</width>
+                <height>54</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_17">
@@ -2095,7 +2200,16 @@
          </widget>
          <widget class="QWidget" name="mTabRelations">
           <layout class="QGridLayout" name="gridLayout_16">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
           </layout>
@@ -2121,7 +2235,16 @@
       <enum>QFrame::Raised</enum>
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout">
-      <property name="margin">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
        <number>0</number>
       </property>
       <item>
@@ -2221,7 +2344,6 @@
   <tabstop>mButtonImportColors</tabstop>
   <tabstop>mButtonExportColors</tabstop>
   <tabstop>scrollArea_5</tabstop>
-  <tabstop>mWmsUseLayerIDs</tabstop>
   <tabstop>buttonBox</tabstop>
   <tabstop>mWMSAccessConstraints</tabstop>
   <tabstop>mWMSKeywordList</tabstop>
@@ -2229,8 +2351,6 @@
   <tabstop>mComposerListWidget</tabstop>
   <tabstop>mAddWMSComposerButton</tabstop>
   <tabstop>mRemoveWMSComposerButton</tabstop>
-  <tabstop>mAddWktGeometryCheckBox</tabstop>
-  <tabstop>mLayerRestrictionsGroupBox</tabstop>
   <tabstop>mLayerRestrictionsListWidget</tabstop>
   <tabstop>mAddLayerRestrictionButton</tabstop>
   <tabstop>mRemoveLayerRestrictionButton</tabstop>


### PR DESCRIPTION
In the GetFeature request QGIS WFS Server uses the static method: QgsDoubleToString. This method returns double with a precision fixed to 17.

We do not need that much precision for coordinates. Firstly because we are not able to measure a position on earth with a lower micron precision. Secondly because it unnecessarily overload response.

I propose to add the ability to specify the precision in the QgsDoubleToString method.

http://hub.qgis.org/issues/10974
