### PR TITLE
properly write NULL values in postgres provider

### DIFF
--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -1674,6 +1674,10 @@ bool QgsPostgresProvider::addFeatures( QgsFeatureList &flist )
                     .arg( delim )
                     .arg( quotedValue( v.toString() ) );
         }
+        else if ( v.isNull() )
+        {
+          values += QString( "%1NULL" ).arg( delim );
+        }
         else
         {
           values += delim + quotedValue( v.toString() );


### PR DESCRIPTION
If you have an integer field, toString will return 0 hence having a '0' in the INSERT.
