### PR TITLE
Fixed Legacy date widget default format

### DIFF
--- a/src/core/qgslegacyhelpers.cpp
+++ b/src/core/qgslegacyhelpers.cpp
@@ -104,7 +104,7 @@ const QString QgsLegacyHelpers::convertEditType( QgsVectorLayer::EditType editTy
     {
       widgetType = "DateTime";
       cfg.insert( "display_format", editTypeElement.attribute( "dateFormat" ) );
-      cfg.insert( "field_format", "yyyy-mm-dd" );
+      cfg.insert( "field_format", "yyyy-MM-dd" );
       break;
     }
 


### PR DESCRIPTION
I believe this will fix a papercut bug caused that happens when a older project with the date widget, is opened in 2.4 or Master. Since the default format used for old projects is yyyy-mm-dd (notice that "mm" is actually minutes) the target fields will show wrong values, and errors might occur when trying to save.

https://hub.qgis.org/issues/10988
