### PR TITLE
new identify method: feature selection

### DIFF
--- a/python/gui/qgsmaptoolidentify.sip
+++ b/python/gui/qgsmaptoolidentify.sip
@@ -12,7 +12,8 @@ class QgsMapToolIdentify : QgsMapTool
       ActiveLayer,
       TopDownStopAtFirst,
       TopDownAll,
-      LayerSelection
+      LayerSelection,
+      FeatureSelection
     };
 
     enum LayerType

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -297,6 +297,7 @@ QgsIdentifyResultsDialog::QgsIdentifyResultsDialog( QgsMapCanvas *canvas, QWidge
   cmbIdentifyMode->addItem( tr( "Top down, stop at first" ), 1 );
   cmbIdentifyMode->addItem( tr( "Top down" ), 2 );
   cmbIdentifyMode->addItem( tr( "Layer selection" ), 3 );
+  cmbIdentifyMode->addItem( tr( "Feature selection" ), 4 );
   cmbIdentifyMode->setCurrentIndex( cmbIdentifyMode->findData( identifyMode ) );
   cbxAutoFeatureForm->setChecked( mySettings.value( "/Map/identifyAutoFeatureForm", false ).toBool() );
 

--- a/src/gui/qgsmaptoolidentify.h
+++ b/src/gui/qgsmaptoolidentify.h
@@ -53,7 +53,8 @@ class GUI_EXPORT QgsMapToolIdentify : public QgsMapTool
       ActiveLayer,
       TopDownStopAtFirst,
       TopDownAll,
-      LayerSelection
+      LayerSelection,
+      FeatureSelection
     };
 
     enum LayerType


### PR DESCRIPTION
![image](https://cloud.githubusercontent.com/assets/127259/3798733/a3934f22-1be7-11e4-84b6-40cb478f40d1.png)

This adds a new identify method to be able to identify a single method and thus always open the desired feature form.

I did not find a nice way to combine _layer selection_ with _feature selection_ due to the fact that a menu item can not be clicked (only actions can). Otherwise, mixing the two might be a problems for some since it would need one more level to reach the old functionnality (open identify dock with all results of a single layer). This is why I added a new method.
Anyway, one might wants to remove the old behavior by this one?
