### PR TITLE
enhance the GetFeatureInfo response with the option to configure it usin...

### DIFF
--- a/src/mapserver/qgis_getfeatureinfo_response.css
+++ b/src/mapserver/qgis_getfeatureinfo_response.css
@@ -1,0 +1,94 @@
+.container:before, .container:after {
+    display:table;
+    content:"";
+    zoom:1 /* ie fix */;
+}
+
+.container:after {
+    clear:both;
+}
+
+.container {
+    width:500px;
+    margin:0 auto;
+    border:1px solid #fff;
+    box-shadow:0px 2px 7px #292929;
+    -moz-box-shadow: 0px 2px 7px #292929;
+    -webkit-box-shadow: 0px 2px 7px #292929;
+    border-radius:10px;
+    -moz-border-radius:10px;
+    -webkit-border-radius:10px;
+    background-color:#ffffff;
+}
+
+.mainbody {
+    height:250px;
+    width:500px;
+    border: solid #eee;
+    border-width:1px 0;
+}
+
+.header:before {
+	content: url(http://www.url-to-logo/logo.gif);
+}
+
+.table_layer {
+	border: 0px solid black;
+	/*border-collapse: collapse;*/
+	/*border-color: red;*/
+}
+.table_layer_tr {
+	background-color: white;
+	color: black;
+}
+.table_layer_th {
+	text-align: left;
+	vertical-align:text-top;
+	border-color: lightgray;
+	padding-right: 15px;
+	padding-bottom: 15px;
+}
+.table_layer_td {
+	text-align: left;
+	vertical-align:text-top;
+	border-color: lightgray;
+}
+
+.table_feature {
+	border: 0px solid black;
+	border-collapse: collapse;
+}
+.table_feature_id {
+	border: solid;
+	border-width: 1px 0;
+}
+.table_feature_th_id {
+	text-align: left;
+}
+.table_feature_td_id {
+	text-align: left;
+}
+.table_feature_field {
+	border: solid;
+	border-width: 1px 0;
+	border-color: lightgray;
+}
+.table_feature_field:last-child {
+	border: solid;
+	border-width: 0px 0;
+}
+
+.table_feature_th_field {
+	text-align: left;
+	vertical-align:text-top;
+}
+.table_feature_td_field {
+	text-align: left;
+	vertical-align:text-top;
+}
+.break_between_features {
+	color: lightgray;
+	background-color: lightgray;
+	height: 6px;
+}
+

--- a/src/mapserver/qgshttprequesthandler.cpp
+++ b/src/mapserver/qgshttprequesthandler.cpp
@@ -186,10 +186,13 @@ void QgsHttpRequestHandler::sendGetFeatureInfoResponse( const QDomDocument& info
     else if ( infoFormat == "text/html" )
     {
       featureInfoString.append( "<HEAD>\n" );
+      featureInfoString.append( "<link href=\"../qgis_getfeatureinfo_response.css\" rel=\"stylesheet\" type=\"text/css\">\n" );
       featureInfoString.append( "<TITLE> GetFeatureInfo results </TITLE>\n" );
       featureInfoString.append( "<meta http-equiv=\"Content-Type\" content=\"text/html;charset=utf-8\">\n" );
       featureInfoString.append( "</HEAD>\n" );
       featureInfoString.append( "<BODY>\n" );
+      featureInfoString.append( "<div class=\"header\">\n" );
+      featureInfoString.append( "</div>\n" );
     }
 
     QDomNodeList layerList = infoDoc.elementsByTagName( "Layer" );
@@ -204,8 +207,8 @@ void QgsHttpRequestHandler::sendGetFeatureInfoResponse( const QDomDocument& info
       }
       else if ( infoFormat == "text/html" )
       {
-        featureInfoString.append( "<TABLE border=1 width=100%>\n" );
-        featureInfoString.append( "<TR><TH width=25%>Layer</TH><TD>" + layerElem.attribute( "name" ) + "</TD></TR>\n" );
+        featureInfoString.append( "<TABLE class=\"table_layer\">\n" );
+        featureInfoString.append( "<TR class=\"table_layer_tr\"><TH class=\"table_layer_th\">Layer</TH><TD class=\"table_layer_td\">" + layerElem.attribute( "name" ) + "</TD></TR>\n" );
         featureInfoString.append( "</BR>" );
       }
 
@@ -242,8 +245,8 @@ void QgsHttpRequestHandler::sendGetFeatureInfoResponse( const QDomDocument& info
           }
           else if ( infoFormat == "text/html" )
           {
-            featureInfoString.append( "<TABLE border=1 width=100%>\n" );
-            featureInfoString.append( "<TR><TH>Feature</TH><TD>" + featureElement.attribute( "id" ) + "</TD></TR>\n" );
+            featureInfoString.append( "<TABLE class=\"table_feature\">\n" );
+            featureInfoString.append( "<TR class=\"table_feature_tr_id\"><TH class=\"table_feature_th_id\">Feature</TH><TD class=\"table_feature_td_id\">" + featureElement.attribute( "id" ) + "</TD></TR>\n" );
           }
           //attribute loop
           QDomNodeList attributeNodeList = featureElement.elementsByTagName( "Attribute" );
@@ -257,13 +260,13 @@ void QgsHttpRequestHandler::sendGetFeatureInfoResponse( const QDomDocument& info
             }
             else if ( infoFormat == "text/html" )
             {
-              featureInfoString.append( "<TR><TH>" + attributeElement.attribute( "name" ) + "</TH><TD>" + attributeElement.attribute( "value" ) + "</TD></TR>\n" );
+              featureInfoString.append( "<TR class=\"table_feature_field\"><TH class=\"table_feature_th_field\">" + attributeElement.attribute( "name" ) + "</TH><TD class=\"table_feature_td_field\">" + attributeElement.attribute( "value" ) + "</TD></TR>\n" );
             }
           }
 
           if ( infoFormat == "text/html" )
           {
-            featureInfoString.append( "</TABLE>\n</BR>\n" );
+            featureInfoString.append( "</TABLE>\n<HR class=\"break_between_features\" />\n" );
           }
         }
       }


### PR DESCRIPTION
...g a css (see the qgis_getfeatureinfo_response.css) for add a logo or configure the rendering of tables.
![sample_response](https://cloud.githubusercontent.com/assets/2136684/3863030/e8e9d5ec-1f42-11e4-9522-ae2c0e89b029.gif)
