### PR TITLE
Recompute webpage viewport dimensions when resizing html frames

### DIFF
--- a/python/core/composer/qgscomposerhtml.sip
+++ b/python/core/composer/qgscomposerhtml.sip
@@ -192,6 +192,9 @@ class QgsComposerHtml: QgsComposerMultiFrame
      */
     void loadHtml();
 
+    /**Recalculates the frame sizes for the current viewport dimensions*/
+    void recalculateFrameSizes();
+
     void refreshExpressionContext();
 
     virtual void refreshDataDefinedProperty( const QgsComposerObject::DataDefinedProperty property = QgsComposerObject::AllProperties );

--- a/src/core/composer/qgscomposerhtml.cpp
+++ b/src/core/composer/qgscomposerhtml.cpp
@@ -45,6 +45,8 @@ QgsComposerHtml::QgsComposerHtml( QgsComposition* c, bool createUndoCommands ): 
 {
   mHtmlUnitsToMM = htmlUnitsToMM();
   mWebPage = new QWebPage();
+  mWebPage->mainFrame()->setScrollBarPolicy( Qt::Horizontal, Qt::ScrollBarAlwaysOff );
+  mWebPage->mainFrame()->setScrollBarPolicy( Qt::Vertical, Qt::ScrollBarAlwaysOff );
   mWebPage->setNetworkAccessManager( QgsNetworkAccessManager::instance() );
   QObject::connect( mWebPage, SIGNAL( loadFinished( bool ) ), this, SLOT( frameLoaded( bool ) ) );
   if ( mComposition )
@@ -181,6 +183,20 @@ void QgsComposerHtml::loadHtml()
     qApp->processEvents();
   }
 
+  renderCachedImage();
+  recalculateFrameSizes();
+  //trigger a repaint
+  emit contentsChanged();
+}
+
+void QgsComposerHtml::frameLoaded( bool ok )
+{
+  Q_UNUSED( ok );
+  mLoaded = true;
+}
+
+void QgsComposerHtml::recalculateFrameSizes()
+{
   if ( frameCount() < 1 )  return;
 
   QSize contentsSize = mWebPage->mainFrame()->contentsSize();
@@ -196,23 +212,10 @@ void QgsComposerHtml::loadHtml()
   contentsSize.setWidth( maxFrameWidth * mHtmlUnitsToMM );
 
   mWebPage->setViewportSize( contentsSize );
-  mWebPage->mainFrame()->setScrollBarPolicy( Qt::Horizontal, Qt::ScrollBarAlwaysOff );
-  mWebPage->mainFrame()->setScrollBarPolicy( Qt::Vertical, Qt::ScrollBarAlwaysOff );
   mSize.setWidth( contentsSize.width() / mHtmlUnitsToMM );
   mSize.setHeight( contentsSize.height() / mHtmlUnitsToMM );
-
-  renderCachedImage();
-
-  recalculateFrameSizes();
+  QgsComposerMultiFrame::recalculateFrameSizes();
   emit changed();
-  //trigger a repaint
-  emit contentsChanged();
-}
-
-void QgsComposerHtml::frameLoaded( bool ok )
-{
-  Q_UNUSED( ok );
-  mLoaded = true;
 }
 
 void QgsComposerHtml::renderCachedImage()

--- a/src/core/composer/qgscomposerhtml.cpp
+++ b/src/core/composer/qgscomposerhtml.cpp
@@ -183,7 +183,6 @@ void QgsComposerHtml::loadHtml()
     qApp->processEvents();
   }
 
-  renderCachedImage();
   recalculateFrameSizes();
   //trigger a repaint
   emit contentsChanged();
@@ -214,6 +213,7 @@ void QgsComposerHtml::recalculateFrameSizes()
   mWebPage->setViewportSize( contentsSize );
   mSize.setWidth( contentsSize.width() / mHtmlUnitsToMM );
   mSize.setHeight( contentsSize.height() / mHtmlUnitsToMM );
+  renderCachedImage();
   QgsComposerMultiFrame::recalculateFrameSizes();
   emit changed();
 }

--- a/src/core/composer/qgscomposerhtml.h
+++ b/src/core/composer/qgscomposerhtml.h
@@ -214,7 +214,7 @@ class CORE_EXPORT QgsComposerHtml: public QgsComposerMultiFrame
      * @see url
      */
     void loadHtml();
-
+    void recalculateFrameSizes();
     void refreshExpressionContext();
 
     virtual void refreshDataDefinedProperty( const QgsComposerObject::DataDefinedProperty property = QgsComposerObject::AllProperties );

--- a/src/core/composer/qgscomposerhtml.h
+++ b/src/core/composer/qgscomposerhtml.h
@@ -214,6 +214,8 @@ class CORE_EXPORT QgsComposerHtml: public QgsComposerMultiFrame
      * @see url
      */
     void loadHtml();
+
+    /**Recalculates the frame sizes for the current viewport dimensions*/
     void recalculateFrameSizes();
     void refreshExpressionContext();
 


### PR DESCRIPTION
This patch ensures the viewport dimensions of the composer html frame are recomputed every time the frame is resized, to ensure that the webbpage is always rendered according to the available space.

Funded by Sourcepole QGIS Enterprise.
