### PR TITLE
Store tileWidth and tileHeight values in properties of wms provider

### DIFF
--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -404,6 +404,11 @@ bool QgsWmsProvider::setImageCrs( QString const & crs )
       {
         resolutions << key;
       }
+      if ( !mTileMatrixSet->tileMatrices.empty() )
+      {
+        setProperty( "tileWidth", mTileMatrixSet->tileMatrices.values().first().tileWidth );
+        setProperty( "tileHeight", mTileMatrixSet->tileMatrices.values().first().tileHeight );
+      }
     }
     else
     {


### PR DESCRIPTION
I haven't found any way how to get tile size of cached wms layers through API, so I wrote this patch that set this info into wms provider's properties - tileWidth and tileHeight, similar as the resolutions property is set. It assume that tile size is the same for all resolutions, so it doesn't complicate code and there will be hardly any exceptions to that case. 
