### PR TITLE
[FEATURE]: Joins in QgsExpression

### DIFF
--- a/resources/function_help/JOIN AS ON
+++ b/resources/function_help/JOIN AS ON
@@ -1,0 +1,8 @@
+<h3>JOIN AS ON</h3>
+Does an equi-join with a second layer such that those attributes are also available in the expression
+
+<h4>Syntax</h4>
+<pre>JOIN 'layername' AS 'alias' ON 'attribute = "alias.attribute"'</pre>
+
+<h4>Example</h4>
+<pre> attribute + "alias.attr" JOIN 'joinlayer' AS 'alias' ON 'key_attribute = "alias.join_attribute"'</pre>

--- a/resources/function_help/JOIN ON
+++ b/resources/function_help/JOIN ON
@@ -1,0 +1,8 @@
+<h3>JOIN ON</h3>
+Does an equi-join with a second layer such that those attributes are also available in the expression
+
+<h4>Syntax</h4>
+<pre>JOIN 'layername' ON 'attribute = "layername.attribute"'</pre>
+
+<h4>Example</h4>
+<pre> attribute + "joinlayer.attr" JOIN 'joinlayer' ON 'key_attribute = "joinlayer.join_attribute"'</pre>

--- a/src/core/qgsexpressionlexer.ll
+++ b/src/core/qgsexpressionlexer.ll
@@ -149,6 +149,9 @@ string      "'"{str_char}*"'"
 "THEN" { return THEN; }
 "ELSE" { return ELSE; }
 "END"  { return END;  }
+"JOIN" { return JOIN; }
+"ON" { return ON; }
+"AS" { return AS; }
 
 [()]      { return yytext[0]; }
 

--- a/src/core/qgsexpressionparser.yy
+++ b/src/core/qgsexpressionparser.yy
@@ -92,6 +92,8 @@ QgsExpression::Node* gExpParserRootNode;
 
 %token Unknown_CHARACTER
 
+%token JOIN AS ON
+
 //
 // definition of non-terminal types
 //
@@ -111,6 +113,7 @@ QgsExpression::Node* gExpParserRootNode;
 // left associativity means that 1+2+3 translates to (1+2)+3
 // the order of operators here determines their precedence
 
+%left JOIN
 %left OR
 %left AND
 %right NOT
@@ -134,7 +137,9 @@ root: expression { gExpParserRootNode = $1; }
     ;
 
 expression:
-      expression AND expression       { $$ = BINOP($2, $1, $3); }
+        expression JOIN STRING ON STRING      { $$ = new QgsExpression::NodeJoin($1, $3, $5 ); }
+    | expression JOIN STRING AS STRING ON STRING    { $$ = new QgsExpression::NodeJoin($1, $3, $7, $5 ); }
+    |  expression AND expression       { $$ = BINOP($2, $1, $3); }
     | expression OR expression        { $$ = BINOP($2, $1, $3); }
     | expression EQ expression        { $$ = BINOP($2, $1, $3); }
     | expression NE expression        { $$ = BINOP($2, $1, $3); }

--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -84,6 +84,11 @@ QgsExpressionBuilderWidget::QgsExpressionBuilderWidget( QWidget *parent )
   registerItem( "Conditionals", "CASE", casestring );
   registerItem( "Conditionals", "CASE ELSE", caseelsestring );
 
+  QString joinstring = "JOIN 'layername' ON 'attribute = layername.attribute'";
+  QString joinasstring = "JOIN 'layername' AS 'alias' ON 'attribute = alias.attribute'";
+  registerItem( "Join", "JOIN ON", joinstring );
+  registerItem( "Join", "JOIN AS ON", joinasstring );
+
   // Load the functions from the QgsExpression class
   int count = QgsExpression::functionCount();
   for ( int i = 0; i < count; i++ )


### PR DESCRIPTION
This pull request adds joins in expressions. Using JOIN 'tablename' ON 'attributeX = "tablename.attributeY"', all the attributes of the join tables can be used in an expression. To improve performance (expressions are copied often), QgsExpression holds a join cache. If a joined table is too large (more than 10 million entries), there is a fallback to on-the-fly retrieval (with very low performance).

Some things to note:
- The join must be an equi-join and is provided as a string. It is not an expression to make it clear to people they cannot use more complex join conditions, like 'sqrt(attribute1) > ( table.attribute2 + table.attribute2)'.
- It is possible to join multiple tables by adding multiple JOIN-statements. But the joins cannot depend on each other (this limitation is the same as with the normal qgis vector layer join).
- The functions addJoinedAttributesFromCache() and addJoinedAttributesDirect() should probably unified with the join buffer code in future
