### PR TITLE
Mapserver: fixed bounding box of points features collection returned in GetFeatureInfo request

### DIFF
--- a/src/mapserver/qgswmsserver.cpp
+++ b/src/mapserver/qgswmsserver.cpp
@@ -1731,6 +1731,7 @@ int QgsWMSServer::featureInfoFromVectorLayer( QgsVectorLayer* layer,
   }
   QgsFeatureIterator fit = layer->getFeatures( fReq );
 
+  bool featureBBoxInitialized = false;
   while ( fit.nextFeature( feature ) )
   {
     ++featureCounter;
@@ -1760,9 +1761,10 @@ int QgsWMSServer::featureInfoFromVectorLayer( QgsVectorLayer* layer,
       box = mapRender->layerExtentToOutputExtent( layer, feature.geometry()->boundingBox() );
       if ( featureBBox ) //extend feature info bounding box if requested
       {
-        if ( featureBBox->isEmpty() )
+        if ( !featureBBoxInitialized && featureBBox->isEmpty())
         {
           *featureBBox = box;
+          featureBBoxInitialized = true;
         }
         else
         {


### PR DESCRIPTION
There is a bug in computing bounding box of all matched features - points. The reason is that every point has an empty bounding box, which results in re-assigning feature's bounding box into final bounding box variable, instead of extending it.
