### PR TITLE
Fix typo in QgsVectorFileWriter::fileFilterString

### DIFF
--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -2150,7 +2150,7 @@ QString QgsVectorFileWriter::fileFilterString()
   QMap< QString, QString>::const_iterator it = driverFormatMap.constBegin();
   for ( ; it != driverFormatMap.constEnd(); ++it )
   {
-    if ( filterString.isEmpty() )
+    if ( !filterString.isEmpty() )
       filterString += ";;";
 
     filterString += it.key();


### PR DESCRIPTION
This patch ensures that `;;` is correctly used as a delimiter between the filter strings.
