### PR TITLE
Convert a symbology to rule based symbology

### DIFF
--- a/python/core/symbology-ng/qgscategorizedsymbolrendererv2.sip
+++ b/python/core/symbology-ng/qgscategorizedsymbolrendererv2.sip
@@ -147,6 +147,10 @@ class QgsCategorizedSymbolRendererV2 : QgsFeatureRendererV2
     // @note added in 2.5
     virtual void checkLegendSymbolItem( QString key, bool state = true );
 
+    //! convert the renderer to a rule based renderer with equivalent rules
+    //! @note added in 2.5
+    virtual QgsRuleBasedRendererV2* convertToRuleBasedRenderer();
+
   protected:
     void rebuildHash();
 

--- a/python/core/symbology-ng/qgscategorizedsymbolrendererv2.sip
+++ b/python/core/symbology-ng/qgscategorizedsymbolrendererv2.sip
@@ -55,7 +55,7 @@ class QgsCategorizedSymbolRendererV2 : QgsFeatureRendererV2
 
     virtual QString dump() const;
 
-    virtual QgsFeatureRendererV2* clone() /Factory/;
+    virtual QgsFeatureRendererV2* clone() const /Factory/;
 
     virtual void toSld( QDomDocument& doc, QDomElement &element ) const;
 
@@ -147,9 +147,10 @@ class QgsCategorizedSymbolRendererV2 : QgsFeatureRendererV2
     // @note added in 2.5
     virtual void checkLegendSymbolItem( QString key, bool state = true );
 
-    //! convert the renderer to a rule based renderer with equivalent rules
+    //! creates a QgsCategorizedSymbolRendererV2 from an existing renderer.
     //! @note added in 2.5
-    virtual QgsRuleBasedRendererV2* convertToRuleBasedRenderer() /Factory/;
+    //! @returns a new renderer if the conversion was possible, otherwise 0.
+    static QgsCategorizedSymbolRendererV2* convertFromRenderer( const QgsFeatureRendererV2 *renderer ) /Factory/;
 
   protected:
     void rebuildHash();

--- a/python/core/symbology-ng/qgscategorizedsymbolrendererv2.sip
+++ b/python/core/symbology-ng/qgscategorizedsymbolrendererv2.sip
@@ -149,7 +149,7 @@ class QgsCategorizedSymbolRendererV2 : QgsFeatureRendererV2
 
     //! convert the renderer to a rule based renderer with equivalent rules
     //! @note added in 2.5
-    virtual QgsRuleBasedRendererV2* convertToRuleBasedRenderer();
+    virtual QgsRuleBasedRendererV2* convertToRuleBasedRenderer() /Factory/;
 
   protected:
     void rebuildHash();

--- a/python/core/symbology-ng/qgsgraduatedsymbolrendererv2.sip
+++ b/python/core/symbology-ng/qgsgraduatedsymbolrendererv2.sip
@@ -175,7 +175,7 @@ class QgsGraduatedSymbolRendererV2 : QgsFeatureRendererV2
 
     //! convert the renderer to a rule based renderer with equivalent rules
     //! @note added in 2.5
-    virtual QgsRuleBasedRendererV2* convertToRuleBasedRenderer();
+    virtual QgsRuleBasedRendererV2* convertToRuleBasedRenderer() /Factory/;
 
 
 

--- a/python/core/symbology-ng/qgsgraduatedsymbolrendererv2.sip
+++ b/python/core/symbology-ng/qgsgraduatedsymbolrendererv2.sip
@@ -173,6 +173,10 @@ class QgsGraduatedSymbolRendererV2 : QgsFeatureRendererV2
     // @note added in 2.5
     virtual void checkLegendSymbolItem( QString key, bool state = true );
 
+    //! convert the renderer to a rule based renderer with equivalent rules
+    //! @note added in 2.5
+    virtual QgsRuleBasedRendererV2* convertToRuleBasedRenderer();
+
 
 
   protected:

--- a/python/core/symbology-ng/qgsgraduatedsymbolrendererv2.sip
+++ b/python/core/symbology-ng/qgsgraduatedsymbolrendererv2.sip
@@ -59,7 +59,7 @@ class QgsGraduatedSymbolRendererV2 : QgsFeatureRendererV2
 
     virtual QString dump() const;
 
-    virtual QgsFeatureRendererV2* clone() /Factory/;
+    virtual QgsFeatureRendererV2* clone() const /Factory/;
 
     virtual void toSld( QDomDocument& doc, QDomElement &element ) const;
 
@@ -173,11 +173,10 @@ class QgsGraduatedSymbolRendererV2 : QgsFeatureRendererV2
     // @note added in 2.5
     virtual void checkLegendSymbolItem( QString key, bool state = true );
 
-    //! convert the renderer to a rule based renderer with equivalent rules
+    //! creates a QgsGraduatedSymbolRendererV2 from an existing renderer.
     //! @note added in 2.5
-    virtual QgsRuleBasedRendererV2* convertToRuleBasedRenderer() /Factory/;
-
-
+    //! @returns a new renderer if the conversion was possible, otherwise 0.
+    static QgsGraduatedSymbolRendererV2* convertFromRenderer( const QgsFeatureRendererV2 *renderer ) /Factory/;
 
   protected:
     QgsSymbolV2* symbolForValue( double value );

--- a/python/core/symbology-ng/qgsinvertedpolygonrenderer.sip
+++ b/python/core/symbology-ng/qgsinvertedpolygonrenderer.sip
@@ -12,7 +12,7 @@ class QgsInvertedPolygonRenderer : QgsFeatureRendererV2
     virtual ~QgsInvertedPolygonRenderer();
 
     /** Used to clone this feature renderer.*/
-    virtual QgsFeatureRendererV2* clone() /Factory/;
+    virtual QgsFeatureRendererV2* clone() const /Factory/;
 
     virtual void startRender( QgsRenderContext& context, const QgsFields& fields );
 
@@ -81,4 +81,10 @@ class QgsInvertedPolygonRenderer : QgsFeatureRendererV2
         This will involve some CPU-demanding computations and is thus disabled by default.
     */
     void setPreprocessingEnabled( bool enabled );
+
+    /** creates a QgsInvertedPolygonRenderer by a conversion from an existing renderer.
+        @note added in 2.5
+        @returns a new renderer if the conversion was possible, otherwise 0.
+        */
+    static QgsInvertedPolygonRenderer* convertFromRenderer( const QgsFeatureRendererV2* renderer ) /Factory/;
 };

--- a/python/core/symbology-ng/qgspointdisplacementrenderer.sip
+++ b/python/core/symbology-ng/qgspointdisplacementrenderer.sip
@@ -7,7 +7,7 @@ class QgsPointDisplacementRenderer : QgsFeatureRendererV2
     QgsPointDisplacementRenderer( const QString& labelAttributeName = "" );
     ~QgsPointDisplacementRenderer();
 
-    QgsFeatureRendererV2* clone() /Factory/;
+    QgsFeatureRendererV2* clone() const /Factory/;
 
     virtual void toSld( QDomDocument& doc, QDomElement &element ) const;
 
@@ -68,6 +68,11 @@ class QgsPointDisplacementRenderer : QgsFeatureRendererV2
 
     void setTolerance( double t );
     double tolerance() const;
+
+    //! creates a QgsPointDisplacementRenderer from an existing renderer.
+    //! @note added in 2.5
+    //! @returns a new renderer if the conversion was possible, otherwise 0.
+    static QgsPointDisplacementRenderer* convertFromRenderer(const QgsFeatureRendererV2 *renderer ) /Factory/;
 
   private:
     QgsPointDisplacementRenderer( const QgsPointDisplacementRenderer & );

--- a/python/core/symbology-ng/qgsrendererv2.sip
+++ b/python/core/symbology-ng/qgsrendererv2.sip
@@ -71,7 +71,7 @@ class QgsFeatureRendererV2
 
     virtual ~QgsFeatureRendererV2();
 
-    virtual QgsFeatureRendererV2* clone() = 0 /Factory/;
+    virtual QgsFeatureRendererV2* clone() const = 0 /Factory/;
 
     virtual bool renderFeature( QgsFeature& feature, QgsRenderContext& context, int layer = -1, bool selected = false, bool drawVertexMarker = false );
 
@@ -174,10 +174,6 @@ class QgsFeatureRendererV2
     //! to use symbolForFeature()
     //! @note added in 1.9
     virtual QgsSymbolV2List symbolsForFeature( QgsFeature& feat );
-
-    //! convert the renderer to a rule based renderer with equivalent rules, if possible
-    //! @note added in 2.5
-    virtual QgsRuleBasedRendererV2* convertToRuleBasedRenderer() /Factory/;
 
   protected:
     QgsFeatureRendererV2( QString type );

--- a/python/core/symbology-ng/qgsrendererv2.sip
+++ b/python/core/symbology-ng/qgsrendererv2.sip
@@ -175,6 +175,10 @@ class QgsFeatureRendererV2
     //! @note added in 1.9
     virtual QgsSymbolV2List symbolsForFeature( QgsFeature& feat );
 
+    //! convert the renderer to a rule based renderer with equivalent rules, if possible
+    //! @note added in 2.5
+    virtual QgsRuleBasedRendererV2* convertToRuleBasedRenderer();
+
   protected:
     QgsFeatureRendererV2( QString type );
 

--- a/python/core/symbology-ng/qgsrendererv2.sip
+++ b/python/core/symbology-ng/qgsrendererv2.sip
@@ -177,7 +177,7 @@ class QgsFeatureRendererV2
 
     //! convert the renderer to a rule based renderer with equivalent rules, if possible
     //! @note added in 2.5
-    virtual QgsRuleBasedRendererV2* convertToRuleBasedRenderer();
+    virtual QgsRuleBasedRendererV2* convertToRuleBasedRenderer() /Factory/;
 
   protected:
     QgsFeatureRendererV2( QString type );

--- a/python/core/symbology-ng/qgsrulebasedrendererv2.sip
+++ b/python/core/symbology-ng/qgsrulebasedrendererv2.sip
@@ -233,7 +233,7 @@ class QgsRuleBasedRendererV2 : QgsFeatureRendererV2
 
     //! convert the renderer to a rule based renderer with equivalent rules, if possible
     //! @note added in 2.5
-    virtual QgsRuleBasedRendererV2* convertToRuleBasedRenderer();
+    virtual QgsRuleBasedRendererV2* convertToRuleBasedRenderer() /Factory/;
 
   private:
     QgsRuleBasedRendererV2( const QgsRuleBasedRendererV2 & );

--- a/python/core/symbology-ng/qgsrulebasedrendererv2.sip
+++ b/python/core/symbology-ng/qgsrulebasedrendererv2.sip
@@ -231,6 +231,10 @@ class QgsRuleBasedRendererV2 : QgsFeatureRendererV2
     //! take a rule and create a list of new rules with intervals of scales given by the passed scale denominators
     static void refineRuleScales( QgsRuleBasedRendererV2::Rule* initialRule, QList<int> scales );
 
+    //! convert the renderer to a rule based renderer with equivalent rules, if possible
+    //! @note added in 2.5
+    virtual QgsRuleBasedRendererV2* convertToRuleBasedRenderer();
+
   private:
     QgsRuleBasedRendererV2( const QgsRuleBasedRendererV2 & );
     QgsRuleBasedRendererV2 & operator=( const QgsRuleBasedRendererV2 & );

--- a/python/core/symbology-ng/qgsrulebasedrendererv2.sip
+++ b/python/core/symbology-ng/qgsrulebasedrendererv2.sip
@@ -164,7 +164,7 @@ class QgsRuleBasedRendererV2 : QgsFeatureRendererV2
 
     virtual QList<QString> usedAttributes();
 
-    virtual QgsFeatureRendererV2* clone() /Factory/;
+    virtual QgsFeatureRendererV2* clone() const /Factory/;
 
     virtual void toSld( QDomDocument& doc, QDomElement &element ) const;
 
@@ -231,9 +231,13 @@ class QgsRuleBasedRendererV2 : QgsFeatureRendererV2
     //! take a rule and create a list of new rules with intervals of scales given by the passed scale denominators
     static void refineRuleScales( QgsRuleBasedRendererV2::Rule* initialRule, QList<int> scales );
 
-    //! convert the renderer to a rule based renderer with equivalent rules, if possible
+    //! creates a QgsRuleBasedRendererV2 from an existing renderer.
     //! @note added in 2.5
-    virtual QgsRuleBasedRendererV2* convertToRuleBasedRenderer() /Factory/;
+    //! @returns a new renderer if the conversion was possible, otherwise 0.
+    static QgsRuleBasedRendererV2* convertFromRenderer( const QgsFeatureRendererV2 *renderer ) /Factory/;
+
+    //! helper function to convert the size scale and rotation fields present in some other renderers to data defined symbology
+    static void convertToDataDefinedSymbology( QgsSymbolV2* symbol, QString sizeScaleField, QString rotationField );
 
   private:
     QgsRuleBasedRendererV2( const QgsRuleBasedRendererV2 & );

--- a/python/core/symbology-ng/qgssinglesymbolrendererv2.sip
+++ b/python/core/symbology-ng/qgssinglesymbolrendererv2.sip
@@ -68,7 +68,7 @@ class QgsSingleSymbolRendererV2 : QgsFeatureRendererV2
 
     //! convert the renderer to a rule based renderer with equivalent rules
     //! @note added in 2.5
-    virtual QgsRuleBasedRendererV2* convertToRuleBasedRenderer();
+    virtual QgsRuleBasedRendererV2* convertToRuleBasedRenderer() /Factory/;
 
   private:
     QgsSingleSymbolRendererV2( const QgsSingleSymbolRendererV2 & );

--- a/python/core/symbology-ng/qgssinglesymbolrendererv2.sip
+++ b/python/core/symbology-ng/qgssinglesymbolrendererv2.sip
@@ -66,6 +66,10 @@ class QgsSingleSymbolRendererV2 : QgsFeatureRendererV2
     //! @note added in 2.6
     virtual QgsLegendSymbolListV2 legendSymbolItemsV2() const;
 
+    //! convert the renderer to a rule based renderer with equivalent rules
+    //! @note added in 2.5
+    virtual QgsRuleBasedRendererV2* convertToRuleBasedRenderer();
+
   private:
     QgsSingleSymbolRendererV2( const QgsSingleSymbolRendererV2 & );
     QgsSingleSymbolRendererV2 & operator=( const QgsSingleSymbolRendererV2 & );

--- a/python/core/symbology-ng/qgssinglesymbolrendererv2.sip
+++ b/python/core/symbology-ng/qgssinglesymbolrendererv2.sip
@@ -37,7 +37,7 @@ class QgsSingleSymbolRendererV2 : QgsFeatureRendererV2
 
     virtual QString dump() const;
 
-    virtual QgsFeatureRendererV2* clone() /Factory/;
+    virtual QgsFeatureRendererV2* clone() const /Factory/;
 
     virtual void toSld( QDomDocument& doc, QDomElement &element ) const;
     static QgsFeatureRendererV2* createFromSld( QDomElement& element, QGis::GeometryType geomType );
@@ -66,9 +66,10 @@ class QgsSingleSymbolRendererV2 : QgsFeatureRendererV2
     //! @note added in 2.6
     virtual QgsLegendSymbolListV2 legendSymbolItemsV2() const;
 
-    //! convert the renderer to a rule based renderer with equivalent rules
+    //! creates a QgsSingleSymbolRendererV2 from an existing renderer.
     //! @note added in 2.5
-    virtual QgsRuleBasedRendererV2* convertToRuleBasedRenderer() /Factory/;
+    //! @returns a new renderer if the conversion was possible, otherwise 0.
+    static QgsSingleSymbolRendererV2* convertFromRenderer( const QgsFeatureRendererV2 *renderer ) /Factory/;
 
   private:
     QgsSingleSymbolRendererV2( const QgsSingleSymbolRendererV2 & );

--- a/src/core/symbology-ng/qgscategorizedsymbolrendererv2.cpp
+++ b/src/core/symbology-ng/qgscategorizedsymbolrendererv2.cpp
@@ -19,6 +19,7 @@
 #include "qgssymbolv2.h"
 #include "qgssymbollayerv2utils.h"
 #include "qgsvectorcolorrampv2.h"
+#include "qgsrulebasedrendererv2.h"
 
 #include "qgsfeature.h"
 #include "qgsvectorlayer.h"
@@ -758,3 +759,94 @@ void QgsCategorizedSymbolRendererV2::checkLegendSymbolItem( QString key, bool st
 }
 
 QgsMarkerSymbolV2 QgsCategorizedSymbolRendererV2::sSkipRender;
+
+QgsRuleBasedRendererV2* QgsCategorizedSymbolRendererV2::convertToRuleBasedRenderer()
+{
+  QgsRuleBasedRendererV2::Rule* rootrule = new QgsRuleBasedRendererV2::Rule( NULL );
+
+  QString expression;
+  QString sizeExpression;
+  QString value;
+  for ( int i = 0; i < mCategories.size();++i )
+  {
+    QgsRuleBasedRendererV2::Rule* rule = new QgsRuleBasedRendererV2::Rule( NULL );
+
+    rule->setLabel( mCategories[i].label() );
+
+    //We first define the rule corresponding to the category
+    //If the value is a number, we can use it directly, otherwise we need to quote it in the rule
+    if ( QVariant( mCategories[i].value() ).convert( QVariant::Double ) )
+    {
+      value = mCategories[i].value().toString();
+    }
+    else
+    {
+      value = "'" + mCategories[i].value().toString() + "'";
+    }
+
+    //An empty category is equivalent to the ELSE keyword
+    if ( value == "''" )
+      expression = "ELSE";
+    else
+      expression = classAttribute() + " = " + value;
+    rule->setFilterExpression( expression );
+
+    //Then we construct an equivalent symbol.
+    //Ideally we could simply copy the symbol, but the categorized renderer allows a separate interface to specify
+    //data dependent area and rotation, so we need to convert these to obtain the same rendering
+
+    QgsSymbolV2* origSymbol = mCategories[i].symbol()->clone();
+
+    switch ( origSymbol->type() )
+    {
+      case QgsSymbolV2::Marker:
+        for ( int j = 0; j < origSymbol->symbolLayerCount();++j )
+        {
+          QgsMarkerSymbolLayerV2* msl = static_cast<QgsMarkerSymbolLayerV2*>( origSymbol->symbolLayer( j ) );
+          if ( mSizeScale.data() )
+          {
+            sizeExpression = QString( "%1*(%2)" ).arg( msl->size() ).arg( sizeScaleField() );
+            msl->setDataDefinedProperty( "size", sizeExpression );
+          }
+          if ( mRotation.data() )
+          {
+            msl->setDataDefinedProperty( "angle", rotationField() );
+          }
+        }
+        break;
+      case QgsSymbolV2::Line:
+        if ( mSizeScale.data() )
+        {
+          for ( int j = 0; j < origSymbol->symbolLayerCount();++j )
+          {
+            if ( origSymbol->symbolLayer( j )->layerType() == "SimpleLine" )
+            {
+              QgsLineSymbolLayerV2* lsl = static_cast<QgsLineSymbolLayerV2*>( origSymbol->symbolLayer( j ) );
+              sizeExpression = QString( "%1*(%2)" ).arg( lsl->width() ).arg( sizeScaleField() );
+              lsl->setDataDefinedProperty( "width", sizeExpression );
+            }
+            if ( origSymbol->symbolLayer( j )->layerType() == "MarkerLine" )
+            {
+              QgsSymbolV2* marker = origSymbol->symbolLayer( j )->subSymbol();
+              for ( int k = 0; k < marker->symbolLayerCount();++k )
+              {
+                QgsMarkerSymbolLayerV2* msl = static_cast<QgsMarkerSymbolLayerV2*>( marker->symbolLayer( k ) );
+                sizeExpression = QString( "%1*(%2)" ).arg( msl->size() ).arg( sizeScaleField() );
+                msl->setDataDefinedProperty( "size", sizeExpression );
+              }
+            }
+          }
+        }
+        break;
+      default:
+        break;
+    }
+
+    rule->setSymbol( origSymbol );
+
+    rootrule->appendChild( rule );
+  }
+
+  return new QgsRuleBasedRendererV2( rootrule );
+
+}

--- a/src/core/symbology-ng/qgscategorizedsymbolrendererv2.h
+++ b/src/core/symbology-ng/qgscategorizedsymbolrendererv2.h
@@ -24,7 +24,6 @@
 
 class QgsVectorColorRampV2;
 class QgsVectorLayer;
-class QgsRuleBasedRendererV2;
 
 /* \brief categorized renderer */
 class CORE_EXPORT QgsRendererCategoryV2
@@ -86,7 +85,7 @@ class CORE_EXPORT QgsCategorizedSymbolRendererV2 : public QgsFeatureRendererV2
 
     virtual QString dump() const;
 
-    virtual QgsFeatureRendererV2* clone();
+    virtual QgsFeatureRendererV2* clone() const;
 
     virtual void toSld( QDomDocument& doc, QDomElement &element ) const;
 
@@ -166,9 +165,8 @@ class CORE_EXPORT QgsCategorizedSymbolRendererV2 : public QgsFeatureRendererV2
     //! @note added in 2.0
     QgsSymbolV2::ScaleMethod scaleMethod() const { return mScaleMethod; }
 
-
     //! items of symbology items in legend should be checkable
-    // @note added in 2.5
+    //! @note added in 2.5
     virtual bool legendSymbolItemsCheckable() const;
 
     //! item in symbology was checked
@@ -183,9 +181,10 @@ class CORE_EXPORT QgsCategorizedSymbolRendererV2 : public QgsFeatureRendererV2
     //! @note added in 2.6
     virtual QString legendClassificationAttribute() const { return classAttribute(); }
 
-    //! convert the renderer to a rule based renderer with equivalent rules
+    //! creates a QgsCategorizedSymbolRendererV2 from an existing renderer.
     //! @note added in 2.5
-    virtual QgsRuleBasedRendererV2* convertToRuleBasedRenderer();
+    //! @returns a new renderer if the conversion was possible, otherwise 0.
+    static QgsCategorizedSymbolRendererV2* convertFromRenderer( const QgsFeatureRendererV2 *renderer );
 
   protected:
     QString mAttrName;

--- a/src/core/symbology-ng/qgscategorizedsymbolrendererv2.h
+++ b/src/core/symbology-ng/qgscategorizedsymbolrendererv2.h
@@ -24,6 +24,7 @@
 
 class QgsVectorColorRampV2;
 class QgsVectorLayer;
+class QgsRuleBasedRendererV2;
 
 /* \brief categorized renderer */
 class CORE_EXPORT QgsRendererCategoryV2
@@ -165,6 +166,7 @@ class CORE_EXPORT QgsCategorizedSymbolRendererV2 : public QgsFeatureRendererV2
     //! @note added in 2.0
     QgsSymbolV2::ScaleMethod scaleMethod() const { return mScaleMethod; }
 
+
     //! items of symbology items in legend should be checkable
     // @note added in 2.5
     virtual bool legendSymbolItemsCheckable() const;
@@ -180,6 +182,10 @@ class CORE_EXPORT QgsCategorizedSymbolRendererV2 : public QgsFeatureRendererV2
     //! If supported by the renderer, return classification attribute for the use in legend
     //! @note added in 2.6
     virtual QString legendClassificationAttribute() const { return classAttribute(); }
+
+    //! convert the renderer to a rule based renderer with equivalent rules
+    //! @note added in 2.5
+    virtual QgsRuleBasedRendererV2* convertToRuleBasedRenderer();
 
   protected:
     QString mAttrName;

--- a/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.cpp
+++ b/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.cpp
@@ -17,7 +17,8 @@
 #include "qgssymbolv2.h"
 #include "qgssymbollayerv2utils.h"
 #include "qgsvectorcolorrampv2.h"
-#include "qgsrulebasedrendererv2.h"
+#include "qgspointdisplacementrenderer.h"
+#include "qgsinvertedpolygonrenderer.h"
 
 #include "qgsfeature.h"
 #include "qgsvectorlayer.h"
@@ -358,7 +359,7 @@ QString QgsGraduatedSymbolRendererV2::dump() const
   return s;
 }
 
-QgsFeatureRendererV2* QgsGraduatedSymbolRendererV2::clone()
+QgsFeatureRendererV2* QgsGraduatedSymbolRendererV2::clone() const
 {
   QgsGraduatedSymbolRendererV2* r = new QgsGraduatedSymbolRendererV2( mAttrName, mRanges );
   r->setMode( mMode );
@@ -1312,85 +1313,21 @@ void QgsGraduatedSymbolRendererV2::sortByLabel( Qt::SortOrder order )
   }
 }
 
-QgsRuleBasedRendererV2* QgsGraduatedSymbolRendererV2::convertToRuleBasedRenderer()
+QgsGraduatedSymbolRendererV2* QgsGraduatedSymbolRendererV2::convertFromRenderer( const QgsFeatureRendererV2 *renderer )
 {
-  QgsRuleBasedRendererV2::Rule* rootrule = new QgsRuleBasedRendererV2::Rule( NULL );
-
-  QString sizeExpression;
-  QString expression;
-  for ( int i = 0; i < mRanges.size();++i )
+  if ( renderer->type() == "graduatedSymbol" )
   {
-    QgsRuleBasedRendererV2::Rule* rule = new QgsRuleBasedRendererV2::Rule( NULL );
-    rule->setSymbol( mRanges[i].symbol() );
-    rule->setLabel( mRanges[i].label() );
-    if ( i == 0 )//The lower boundary of the first range is included, while it is excluded for the others
-    {
-      expression = classAttribute() + " >= " + QString::number( mRanges[i].lowerValue(), 'f' ) + " AND " + \
-                   classAttribute() + " <= " + QString::number( mRanges[i].upperValue(), 'f' );
-    }
-    else
-    {
-      expression = classAttribute() + " > " + QString::number( mRanges[i].lowerValue(), 'f' ) + " AND " + \
-                   classAttribute() + " <= " + QString::number( mRanges[i].upperValue(), 'f' );
-    }
-    rule->setFilterExpression( expression );
-
-    //Then we construct an equivalent symbol.
-    //Ideally we could simply copy the symbol, but the graduated renderer allows a separate interface to specify
-    //data dependent area and rotation, so we need to convert these to obtain the same rendering
-
-    QgsSymbolV2* origSymbol = mRanges[i].symbol()->clone();
-
-    switch ( origSymbol->type() )
-    {
-      case QgsSymbolV2::Marker:
-        for ( int j = 0; j < origSymbol->symbolLayerCount();++j )
-        {
-          QgsMarkerSymbolLayerV2* msl = static_cast<QgsMarkerSymbolLayerV2*>( origSymbol->symbolLayer( j ) );
-          if ( mSizeScale.data() )
-          {
-            sizeExpression = QString( "%1*(%2)" ).arg( msl->size() ).arg( sizeScaleField() );
-            msl->setDataDefinedProperty( "size", sizeExpression );
-            if ( mRotation.data() )
-            {
-              msl->setDataDefinedProperty( "angle", rotationField() );
-            }
-          }
-        }
-        break;
-      case QgsSymbolV2::Line:
-        if ( mSizeScale.data() )
-        {
-          for ( int j = 0; j < origSymbol->symbolLayerCount();++j )
-          {
-            if ( origSymbol->symbolLayer( j )->layerType() == "SimpleLine" )
-            {
-              QgsLineSymbolLayerV2* lsl = static_cast<QgsLineSymbolLayerV2*>( origSymbol->symbolLayer( j ) );
-              sizeExpression = QString( "%1*(%2)" ).arg( lsl->width() ).arg( sizeScaleField() );
-              lsl->setDataDefinedProperty( "width", sizeExpression );
-            }
-            if ( origSymbol->symbolLayer( j )->layerType() == "MarkerLine" )
-            {
-              QgsSymbolV2* marker = origSymbol->symbolLayer( j )->subSymbol();
-              for ( int k = 0; k < marker->symbolLayerCount();++k )
-              {
-                QgsMarkerSymbolLayerV2* msl = static_cast<QgsMarkerSymbolLayerV2*>( marker->symbolLayer( k ) );
-                sizeExpression = QString( "%1*(%2)" ).arg( msl->size() ).arg( sizeScaleField() );
-                msl->setDataDefinedProperty( "size", sizeExpression );
-              }
-            }
-          }
-        }
-        break;
-      default:
-        break;
-    }
-
-    rule->setSymbol( origSymbol );
-
-    rootrule->appendChild( rule );
+    return dynamic_cast<QgsGraduatedSymbolRendererV2*>( renderer->clone() );
   }
-
-  return new QgsRuleBasedRendererV2( rootrule );
-
+  if ( renderer->type() == "pointDisplacement" )
+  {
+    const QgsPointDisplacementRenderer* pointDisplacementRenderer = dynamic_cast<const QgsPointDisplacementRenderer*>( renderer );
+    return convertFromRenderer( pointDisplacementRenderer->embeddedRenderer() );
+  }
+  if ( renderer->type() == "invertedPolygonRenderer" )
+  {
+    const QgsInvertedPolygonRenderer* invertedPolygonRenderer = dynamic_cast<const QgsInvertedPolygonRenderer*>( renderer );
+    return convertFromRenderer( invertedPolygonRenderer->embeddedRenderer() );
+  }
+  return 0;
 }

--- a/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.h
+++ b/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.h
@@ -64,6 +64,7 @@ typedef QList<QgsRendererRangeV2> QgsRangeList;
 
 class QgsVectorLayer;
 class QgsVectorColorRampV2;
+class QgsRuleBasedRenderedV2;
 
 class CORE_EXPORT QgsGraduatedSymbolRendererV2 : public QgsFeatureRendererV2
 {
@@ -201,6 +202,10 @@ class CORE_EXPORT QgsGraduatedSymbolRendererV2 : public QgsFeatureRendererV2
     //! If supported by the renderer, return classification attribute for the use in legend
     //! @note added in 2.6
     virtual QString legendClassificationAttribute() const { return classAttribute(); }
+
+    //! convert the renderer to a rule based renderer with equivalent rules
+    //! @note added in 2.5
+    virtual QgsRuleBasedRendererV2* convertToRuleBasedRenderer();
 
   protected:
     QString mAttrName;

--- a/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.h
+++ b/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.h
@@ -64,7 +64,6 @@ typedef QList<QgsRendererRangeV2> QgsRangeList;
 
 class QgsVectorLayer;
 class QgsVectorColorRampV2;
-class QgsRuleBasedRenderedV2;
 
 class CORE_EXPORT QgsGraduatedSymbolRendererV2 : public QgsFeatureRendererV2
 {
@@ -84,7 +83,7 @@ class CORE_EXPORT QgsGraduatedSymbolRendererV2 : public QgsFeatureRendererV2
 
     virtual QString dump() const;
 
-    virtual QgsFeatureRendererV2* clone();
+    virtual QgsFeatureRendererV2* clone() const;
 
     virtual void toSld( QDomDocument& doc, QDomElement &element ) const;
 
@@ -97,7 +96,7 @@ class CORE_EXPORT QgsGraduatedSymbolRendererV2 : public QgsFeatureRendererV2
     QString classAttribute() const { return mAttrName; }
     void setClassAttribute( QString attr ) { mAttrName = attr; }
 
-    const QgsRangeList& ranges() { return mRanges; }
+    const QgsRangeList& ranges() const { return mRanges; }
 
     bool updateRangeSymbol( int rangeIndex, QgsSymbolV2* symbol );
     bool updateRangeLabel( int rangeIndex, QString label );
@@ -169,7 +168,7 @@ class CORE_EXPORT QgsGraduatedSymbolRendererV2 : public QgsFeatureRendererV2
       */
     void updateColorRamp( QgsVectorColorRampV2* ramp, bool inverted = false );
 
-    /** Update the all symbols but leave breaks and colors. */
+    /** Update all the symbols but leave breaks and colors. */
     void updateSymbols( QgsSymbolV2* sym );
 
     //! @note added in 1.6
@@ -188,7 +187,7 @@ class CORE_EXPORT QgsGraduatedSymbolRendererV2 : public QgsFeatureRendererV2
     QgsSymbolV2::ScaleMethod scaleMethod() const { return mScaleMethod; }
 
     //! items of symbology items in legend should be checkable
-    // @note added in 2.5
+    //! @note added in 2.5
     virtual bool legendSymbolItemsCheckable() const;
 
     //! item in symbology was checked
@@ -203,9 +202,10 @@ class CORE_EXPORT QgsGraduatedSymbolRendererV2 : public QgsFeatureRendererV2
     //! @note added in 2.6
     virtual QString legendClassificationAttribute() const { return classAttribute(); }
 
-    //! convert the renderer to a rule based renderer with equivalent rules
+    //! creates a QgsGraduatedSymbolRendererV2 from an existing renderer.
     //! @note added in 2.5
-    virtual QgsRuleBasedRendererV2* convertToRuleBasedRenderer();
+    //! @returns a new renderer if the conversion was possible, otherwise 0.
+    static QgsGraduatedSymbolRendererV2* convertFromRenderer( const QgsFeatureRendererV2 *renderer );
 
   protected:
     QString mAttrName;

--- a/src/core/symbology-ng/qgsinvertedpolygonrenderer.cpp
+++ b/src/core/symbology-ng/qgsinvertedpolygonrenderer.cpp
@@ -325,7 +325,7 @@ QString QgsInvertedPolygonRenderer::dump() const
   return "INVERTED [" + mSubRenderer->dump() + "]";
 }
 
-QgsFeatureRendererV2* QgsInvertedPolygonRenderer::clone()
+QgsFeatureRendererV2* QgsInvertedPolygonRenderer::clone() const
 {
   QgsInvertedPolygonRenderer* newRenderer;
   if ( mSubRenderer.isNull() )
@@ -438,5 +438,22 @@ bool QgsInvertedPolygonRenderer::willRenderFeature( QgsFeature& feat )
     return false;
   }
   return mSubRenderer->willRenderFeature( feat );
+}
+
+QgsInvertedPolygonRenderer* QgsInvertedPolygonRenderer::convertFromRenderer( const QgsFeatureRendererV2 *renderer )
+{
+  if ( renderer->type() == "invertedPolygonRenderer" )
+  {
+    return dynamic_cast<QgsInvertedPolygonRenderer*>( renderer->clone() );
+  }
+
+  if ( renderer->type() == "singleSymbol" ||
+       renderer->type() == "categorizedSymbol" ||
+       renderer->type() == "graduatedSymbol" ||
+       renderer->type() == "ruleRenderer" )
+  {
+    return new QgsInvertedPolygonRenderer( renderer->clone() );
+  }
+  return 0;
 }
 

--- a/src/core/symbology-ng/qgsinvertedpolygonrenderer.h
+++ b/src/core/symbology-ng/qgsinvertedpolygonrenderer.h
@@ -48,7 +48,7 @@ class CORE_EXPORT QgsInvertedPolygonRenderer : public QgsFeatureRendererV2
     virtual ~QgsInvertedPolygonRenderer();
 
     /** Used to clone this feature renderer.*/
-    virtual QgsFeatureRendererV2* clone();
+    virtual QgsFeatureRendererV2* clone() const;
 
     virtual void startRender( QgsRenderContext& context, const QgsFields& fields );
 
@@ -117,6 +117,12 @@ class CORE_EXPORT QgsInvertedPolygonRenderer : public QgsFeatureRendererV2
         This will involve some CPU-demanding computations and is thus disabled by default.
     */
     void setPreprocessingEnabled( bool enabled ) { mPreprocessingEnabled = enabled; }
+
+    /** creates a QgsInvertedPolygonRenderer by a conversion from an existing renderer.
+        @note added in 2.5
+        @returns a new renderer if the conversion was possible, otherwise 0.
+        */
+    static QgsInvertedPolygonRenderer* convertFromRenderer( const QgsFeatureRendererV2* renderer );
 
   private:
     /** Private copy constructor. @see clone() */

--- a/src/core/symbology-ng/qgspointdisplacementrenderer.cpp
+++ b/src/core/symbology-ng/qgspointdisplacementrenderer.cpp
@@ -22,6 +22,7 @@
 #include "qgssymbolv2.h"
 #include "qgssymbollayerv2utils.h"
 #include "qgsvectorlayer.h"
+#include "qgssinglesymbolrendererv2.h"
 
 #include <QDomElement>
 #include <QPainter>
@@ -49,7 +50,7 @@ QgsPointDisplacementRenderer::~QgsPointDisplacementRenderer()
   delete mRenderer;
 }
 
-QgsFeatureRendererV2* QgsPointDisplacementRenderer::clone()
+QgsFeatureRendererV2* QgsPointDisplacementRenderer::clone() const
 {
   QgsPointDisplacementRenderer* r = new QgsPointDisplacementRenderer( mLabelAttributeName );
   r->setEmbeddedRenderer( mRenderer->clone() );
@@ -517,4 +518,21 @@ QgsSymbolV2* QgsPointDisplacementRenderer::firstSymbolForFeature( QgsFeatureRend
   return symbolList.at( 0 );
 }
 
+QgsPointDisplacementRenderer* QgsPointDisplacementRenderer::convertFromRenderer( const QgsFeatureRendererV2* renderer )
+{
+  if ( renderer->type() == "pointDisplacement" )
+  {
+    return dynamic_cast<QgsPointDisplacementRenderer*>( renderer->clone() );
+  }
 
+  if ( renderer->type() == "singleSymbol" ||
+       renderer->type() == "categorizedSymbol" ||
+       renderer->type() == "graduatedSymbol" ||
+       renderer->type() == "ruleRenderer" )
+  {
+    QgsPointDisplacementRenderer* pointRenderer = new QgsPointDisplacementRenderer();
+    pointRenderer->setEmbeddedRenderer( renderer->clone() );
+    return pointRenderer;
+  }
+  return 0;
+}

--- a/src/core/symbology-ng/qgspointdisplacementrenderer.h
+++ b/src/core/symbology-ng/qgspointdisplacementrenderer.h
@@ -34,7 +34,7 @@ class CORE_EXPORT QgsPointDisplacementRenderer: public QgsFeatureRendererV2
     QgsPointDisplacementRenderer( const QString& labelAttributeName = "" );
     ~QgsPointDisplacementRenderer();
 
-    QgsFeatureRendererV2* clone();
+    QgsFeatureRendererV2* clone() const;
 
     virtual void toSld( QDomDocument& doc, QDomElement &element ) const;
 
@@ -64,7 +64,7 @@ class CORE_EXPORT QgsPointDisplacementRenderer: public QgsFeatureRendererV2
 
     /**Sets embedded renderer (takes ownership)*/
     void setEmbeddedRenderer( QgsFeatureRendererV2* r );
-    QgsFeatureRendererV2* embeddedRenderer() { return mRenderer;}
+    QgsFeatureRendererV2* embeddedRenderer() const { return mRenderer;}
 
     //! not available in python bindings
     //! @deprecated since 2.4
@@ -95,6 +95,11 @@ class CORE_EXPORT QgsPointDisplacementRenderer: public QgsFeatureRendererV2
 
     void setTolerance( double t ) { mTolerance = t; }
     double tolerance() const { return mTolerance; }
+
+    //! creates a QgsPointDisplacementRenderer from an existing renderer.
+    //! @note added in 2.5
+    //! @returns a new renderer if the conversion was possible, otherwise 0.
+    static QgsPointDisplacementRenderer* convertFromRenderer(const QgsFeatureRendererV2 *renderer );
 
   private:
 

--- a/src/core/symbology-ng/qgsrendererv2.cpp
+++ b/src/core/symbology-ng/qgsrendererv2.cpp
@@ -467,7 +467,7 @@ QgsFeatureRendererV2* QgsFeatureRendererV2::loadSld( const QDomNode &node, QGis:
   QString rendererType;
   if ( needRuleRenderer )
   {
-    rendererType = "RuleRenderer";
+    rendererType = "ruleRenderer";
   }
   else
   {
@@ -585,9 +585,4 @@ QgsSymbolV2List QgsFeatureRendererV2::symbolsForFeature( QgsFeature& feat )
   QgsSymbolV2* s = symbolForFeature( feat );
   if ( s ) lst.append( s );
   return lst;
-}
-
-QgsRuleBasedRendererV2* QgsFeatureRendererV2::convertToRuleBasedRenderer()
-{
-  return 0;
 }

--- a/src/core/symbology-ng/qgsrendererv2.cpp
+++ b/src/core/symbology-ng/qgsrendererv2.cpp
@@ -16,6 +16,7 @@
 #include "qgsrendererv2.h"
 #include "qgssymbolv2.h"
 #include "qgssymbollayerv2utils.h"
+#include "qgsrulebasedrendererv2.h"
 
 #include "qgssinglesymbolrendererv2.h" // for default renderer
 
@@ -584,4 +585,9 @@ QgsSymbolV2List QgsFeatureRendererV2::symbolsForFeature( QgsFeature& feat )
   QgsSymbolV2* s = symbolForFeature( feat );
   if ( s ) lst.append( s );
   return lst;
+}
+
+QgsRuleBasedRendererV2* QgsFeatureRendererV2::convertToRuleBasedRenderer()
+{
+  return 0;
 }

--- a/src/core/symbology-ng/qgsrendererv2.h
+++ b/src/core/symbology-ng/qgsrendererv2.h
@@ -31,7 +31,6 @@ class QgsRenderContext;
 class QgsFeature;
 class QgsFields;
 class QgsVectorLayer;
-class QgsRuleBasedRendererV2;
 
 typedef QMap<QString, QString> QgsStringMap;
 
@@ -97,7 +96,7 @@ class CORE_EXPORT QgsFeatureRendererV2
 
     virtual ~QgsFeatureRendererV2() {}
 
-    virtual QgsFeatureRendererV2* clone() = 0;
+    virtual QgsFeatureRendererV2* clone() const = 0;
 
     virtual bool renderFeature( QgsFeature& feature, QgsRenderContext& context, int layer = -1, bool selected = false, bool drawVertexMarker = false );
 
@@ -201,10 +200,6 @@ class CORE_EXPORT QgsFeatureRendererV2
     //! to use symbolForFeature()
     //! @note added in 1.9
     virtual QgsSymbolV2List symbolsForFeature( QgsFeature& feat );
-
-    //! convert the renderer to a rule based renderer with equivalent rules, if possible
-    //! @note added in 2.5
-    virtual QgsRuleBasedRendererV2* convertToRuleBasedRenderer();
 
   protected:
     QgsFeatureRendererV2( QString type );

--- a/src/core/symbology-ng/qgsrendererv2.h
+++ b/src/core/symbology-ng/qgsrendererv2.h
@@ -31,6 +31,7 @@ class QgsRenderContext;
 class QgsFeature;
 class QgsFields;
 class QgsVectorLayer;
+class QgsRuleBasedRendererV2;
 
 typedef QMap<QString, QString> QgsStringMap;
 
@@ -200,6 +201,10 @@ class CORE_EXPORT QgsFeatureRendererV2
     //! to use symbolForFeature()
     //! @note added in 1.9
     virtual QgsSymbolV2List symbolsForFeature( QgsFeature& feat );
+
+    //! convert the renderer to a rule based renderer with equivalent rules, if possible
+    //! @note added in 2.5
+    virtual QgsRuleBasedRendererV2* convertToRuleBasedRenderer();
 
   protected:
     QgsFeatureRendererV2( QString type );

--- a/src/core/symbology-ng/qgsrendererv2registry.cpp
+++ b/src/core/symbology-ng/qgsrendererv2registry.cpp
@@ -33,11 +33,12 @@ QgsRendererV2Registry::QgsRendererV2Registry()
   addRenderer( new QgsRendererV2Metadata( "categorizedSymbol",
                                           QObject::tr( "Categorized" ),
                                           QgsCategorizedSymbolRendererV2::create ) );
+
   addRenderer( new QgsRendererV2Metadata( "graduatedSymbol",
                                           QObject::tr( "Graduated" ),
                                           QgsGraduatedSymbolRendererV2::create ) );
 
-  addRenderer( new QgsRendererV2Metadata( "RuleRenderer",
+  addRenderer( new QgsRendererV2Metadata( "ruleRenderer",
                                           QObject::tr( "Rule-based" ),
                                           QgsRuleBasedRendererV2::create,
                                           QgsRuleBasedRendererV2::createFromSld ) );

--- a/src/core/symbology-ng/qgsrulebasedrendererv2.cpp
+++ b/src/core/symbology-ng/qgsrulebasedrendererv2.cpp
@@ -1043,3 +1043,8 @@ QgsSymbolV2List QgsRuleBasedRendererV2::symbolsForFeature( QgsFeature& feat )
 {
   return mRootRule->symbolsForFeature( feat );
 }
+
+QgsRuleBasedRendererV2* QgsRuleBasedRendererV2::convertToRuleBasedRenderer()
+{
+  return this ;
+}

--- a/src/core/symbology-ng/qgsrulebasedrendererv2.cpp
+++ b/src/core/symbology-ng/qgsrulebasedrendererv2.cpp
@@ -1046,5 +1046,5 @@ QgsSymbolV2List QgsRuleBasedRendererV2::symbolsForFeature( QgsFeature& feat )
 
 QgsRuleBasedRendererV2* QgsRuleBasedRendererV2::convertToRuleBasedRenderer()
 {
-  return this ;
+  return dynamic_cast<QgsRuleBasedRendererV2*>( this->clone() ) ;
 }

--- a/src/core/symbology-ng/qgsrulebasedrendererv2.cpp
+++ b/src/core/symbology-ng/qgsrulebasedrendererv2.cpp
@@ -21,6 +21,9 @@
 #include "qgsvectorlayer.h"
 #include "qgslogger.h"
 #include "qgsogcutils.h"
+#include "qgssinglesymbolrendererv2.h"
+#include "qgspointdisplacementrenderer.h"
+#include "qgsinvertedpolygonrenderer.h"
 
 #include <QSet>
 
@@ -726,12 +729,12 @@ QgsRuleBasedRendererV2::Rule* QgsRuleBasedRendererV2::Rule::createFromSld( QDomE
 /////////////////////
 
 QgsRuleBasedRendererV2::QgsRuleBasedRendererV2( QgsRuleBasedRendererV2::Rule* root )
-    : QgsFeatureRendererV2( "RuleRenderer" ), mRootRule( root )
+    : QgsFeatureRendererV2( "ruleRenderer" ), mRootRule( root )
 {
 }
 
 QgsRuleBasedRendererV2::QgsRuleBasedRendererV2( QgsSymbolV2* defaultSymbol )
-    : QgsFeatureRendererV2( "RuleRenderer" )
+    : QgsFeatureRendererV2( "ruleRenderer" )
 {
   mRootRule = new Rule( NULL ); // root has no symbol, no filter etc - just a container
   mRootRule->appendChild( new Rule( defaultSymbol ) );
@@ -835,12 +838,11 @@ QList<QString> QgsRuleBasedRendererV2::usedAttributes()
   return attrs.values();
 }
 
-QgsFeatureRendererV2* QgsRuleBasedRendererV2::clone()
+QgsFeatureRendererV2* QgsRuleBasedRendererV2::clone() const
 {
   QgsRuleBasedRendererV2* r = new QgsRuleBasedRendererV2( mRootRule->clone() );
 
   r->setUsingSymbolLevels( usingSymbolLevels() );
-  setUsingSymbolLevels( usingSymbolLevels() );
   return r;
 }
 
@@ -1044,7 +1046,173 @@ QgsSymbolV2List QgsRuleBasedRendererV2::symbolsForFeature( QgsFeature& feat )
   return mRootRule->symbolsForFeature( feat );
 }
 
-QgsRuleBasedRendererV2* QgsRuleBasedRendererV2::convertToRuleBasedRenderer()
+QgsRuleBasedRendererV2* QgsRuleBasedRendererV2::convertFromRenderer( const QgsFeatureRendererV2* renderer )
 {
-  return dynamic_cast<QgsRuleBasedRendererV2*>( this->clone() ) ;
+  if ( renderer->type() == "ruleRenderer" )
+  {
+    return dynamic_cast<QgsRuleBasedRendererV2*>( renderer->clone() );
+  }
+
+  if ( renderer->type() == "singleSymbol" )
+  {
+    const QgsSingleSymbolRendererV2* singleSymbolRenderer = dynamic_cast<const QgsSingleSymbolRendererV2*>( renderer );
+    QgsSymbolV2* origSymbol = singleSymbolRenderer->symbol()->clone();
+    convertToDataDefinedSymbology( origSymbol, singleSymbolRenderer->sizeScaleField(), singleSymbolRenderer->rotationField() );
+    return new QgsRuleBasedRendererV2( origSymbol );
+  }
+
+  if ( renderer->type() == "categorizedSymbol" )
+  {
+    const QgsCategorizedSymbolRendererV2* categorizedRenderer = dynamic_cast<const QgsCategorizedSymbolRendererV2*>( renderer );
+    QgsRuleBasedRendererV2::Rule* rootrule = new QgsRuleBasedRendererV2::Rule( NULL );
+
+    QString expression;
+    QString value;
+    QgsRendererCategoryV2 category;
+    for ( int i = 0; i < categorizedRenderer->categories().size(); ++i )
+    {
+      category = categorizedRenderer->categories().value( i );
+      QgsRuleBasedRendererV2::Rule* rule = new QgsRuleBasedRendererV2::Rule( NULL );
+
+      rule->setLabel( category.label() );
+
+      //We first define the rule corresponding to the category
+      //If the value is a number, we can use it directly, otherwise we need to quote it in the rule
+      if ( QVariant( category.value() ).convert( QVariant::Double ) )
+      {
+        value = category.value().toString();
+      }
+      else
+      {
+        value = "'" + category.value().toString() + "'";
+      }
+
+      //An empty category is equivalent to the ELSE keyword
+      if ( value == "''" )
+      {
+        expression = "ELSE";
+      }
+      else
+      {
+        expression = categorizedRenderer->classAttribute() + " = " + value;
+      }
+      rule->setFilterExpression( expression );
+
+      //Then we construct an equivalent symbol.
+      //Ideally we could simply copy the symbol, but the categorized renderer allows a separate interface to specify
+      //data dependent area and rotation, so we need to convert these to obtain the same rendering
+
+      QgsSymbolV2* origSymbol = category.symbol()->clone();
+      convertToDataDefinedSymbology( origSymbol, categorizedRenderer->sizeScaleField(), categorizedRenderer->rotationField() );
+      rule->setSymbol( origSymbol );
+
+      rootrule->appendChild( rule );
+    }
+
+    return new QgsRuleBasedRendererV2( rootrule );
+  }
+
+  if ( renderer->type() == "graduatedSymbol" )
+  {
+
+    const QgsGraduatedSymbolRendererV2* graduatedRenderer = dynamic_cast<const QgsGraduatedSymbolRendererV2*>( renderer );
+
+    QgsRuleBasedRendererV2::Rule* rootrule = new QgsRuleBasedRendererV2::Rule( NULL );
+
+    QString expression;
+    QgsRendererRangeV2 range;
+    for ( int i = 0; i < graduatedRenderer->ranges().size();++i )
+    {
+      range = graduatedRenderer->ranges().value( i );
+      QgsRuleBasedRendererV2::Rule* rule = new QgsRuleBasedRendererV2::Rule( NULL );
+      rule->setSymbol( range.symbol() );
+      rule->setLabel( range.label() );
+      if ( i == 0 )//The lower boundary of the first range is included, while it is excluded for the others
+      {
+        expression = graduatedRenderer->classAttribute() + " >= " + QString::number( range.lowerValue(), 'f' ) + " AND " + \
+                     graduatedRenderer->classAttribute() + " <= " + QString::number( range.upperValue(), 'f' );
+      }
+      else
+      {
+        expression = graduatedRenderer->classAttribute() + " > " + QString::number( range.lowerValue(), 'f' ) + " AND " + \
+                     graduatedRenderer->classAttribute() + " <= " + QString::number( range.upperValue(), 'f' );
+      }
+      rule->setFilterExpression( expression );
+
+      //Then we construct an equivalent symbol.
+      //Ideally we could simply copy the symbol, but the graduated renderer allows a separate interface to specify
+      //data dependent area and rotation, so we need to convert these to obtain the same rendering
+
+      QgsSymbolV2* symbol = range.symbol()->clone();
+      convertToDataDefinedSymbology( symbol, graduatedRenderer->sizeScaleField(), graduatedRenderer->rotationField() );
+
+      rule->setSymbol( symbol );
+
+      rootrule->appendChild( rule );
+    }
+
+    return new QgsRuleBasedRendererV2( rootrule );
+  }
+
+  if ( renderer->type() == "pointDisplacement" )
+  {
+    const QgsPointDisplacementRenderer* pointDisplacementRenderer = dynamic_cast<const QgsPointDisplacementRenderer*>( renderer );
+    return convertFromRenderer( pointDisplacementRenderer->embeddedRenderer() );
+  }
+  if ( renderer->type() == "invertedPolygonRenderer" )
+  {
+    const QgsInvertedPolygonRenderer* invertedPolygonRenderer = dynamic_cast<const QgsInvertedPolygonRenderer*>( renderer );
+    return convertFromRenderer( invertedPolygonRenderer->embeddedRenderer() );
+  }
+
+  return NULL;
+}
+
+void QgsRuleBasedRendererV2::convertToDataDefinedSymbology( QgsSymbolV2* symbol, QString sizeScaleField, QString rotationField )
+{
+  QString sizeExpression;
+  switch ( symbol->type() )
+  {
+    case QgsSymbolV2::Marker:
+      for ( int j = 0; j < symbol->symbolLayerCount();++j )
+      {
+        QgsMarkerSymbolLayerV2* msl = static_cast<QgsMarkerSymbolLayerV2*>( symbol->symbolLayer( j ) );
+        if ( ! sizeScaleField.isNull() )
+        {
+          sizeExpression = QString( "%1*(%2)" ).arg( msl->size() ).arg( sizeScaleField );
+          msl->setDataDefinedProperty( "size", sizeExpression );
+        }
+        if ( ! rotationField.isNull() )
+        {
+          msl->setDataDefinedProperty( "angle", rotationField );
+        }
+      }
+      break;
+    case QgsSymbolV2::Line:
+      if ( ! sizeScaleField.isNull() )
+      {
+        for ( int j = 0; j < symbol->symbolLayerCount();++j )
+        {
+          if ( symbol->symbolLayer( j )->layerType() == "SimpleLine" )
+          {
+            QgsLineSymbolLayerV2* lsl = static_cast<QgsLineSymbolLayerV2*>( symbol->symbolLayer( j ) );
+            sizeExpression = QString( "%1*(%2)" ).arg( lsl->width() ).arg( sizeScaleField );
+            lsl->setDataDefinedProperty( "width", sizeExpression );
+          }
+          if ( symbol->symbolLayer( j )->layerType() == "MarkerLine" )
+          {
+            QgsSymbolV2* marker = symbol->symbolLayer( j )->subSymbol();
+            for ( int k = 0; k < marker->symbolLayerCount();++k )
+            {
+              QgsMarkerSymbolLayerV2* msl = static_cast<QgsMarkerSymbolLayerV2*>( marker->symbolLayer( k ) );
+              sizeExpression = QString( "%1*(%2)" ).arg( msl->size() ).arg( sizeScaleField );
+              msl->setDataDefinedProperty( "size", sizeExpression );
+            }
+          }
+        }
+      }
+      break;
+    default:
+      break;
+  }
 }

--- a/src/core/symbology-ng/qgsrulebasedrendererv2.cpp
+++ b/src/core/symbology-ng/qgsrulebasedrendererv2.cpp
@@ -1125,7 +1125,6 @@ QgsRuleBasedRendererV2* QgsRuleBasedRendererV2::convertFromRenderer( const QgsFe
     {
       range = graduatedRenderer->ranges().value( i );
       QgsRuleBasedRendererV2::Rule* rule = new QgsRuleBasedRendererV2::Rule( NULL );
-      rule->setSymbol( range.symbol() );
       rule->setLabel( range.label() );
       if ( i == 0 )//The lower boundary of the first range is included, while it is excluded for the others
       {

--- a/src/core/symbology-ng/qgsrulebasedrendererv2.h
+++ b/src/core/symbology-ng/qgsrulebasedrendererv2.h
@@ -226,7 +226,7 @@ class CORE_EXPORT QgsRuleBasedRendererV2 : public QgsFeatureRendererV2
 
     virtual QList<QString> usedAttributes();
 
-    virtual QgsFeatureRendererV2* clone();
+    virtual QgsFeatureRendererV2* clone() const;
 
     virtual void toSld( QDomDocument& doc, QDomElement &element ) const;
 
@@ -293,9 +293,13 @@ class CORE_EXPORT QgsRuleBasedRendererV2 : public QgsFeatureRendererV2
     //! take a rule and create a list of new rules with intervals of scales given by the passed scale denominators
     static void refineRuleScales( Rule* initialRule, QList<int> scales );
 
-    //! convert the renderer to a rule based renderer with equivalent rules, if possible
+    //! creates a QgsRuleBasedRendererV2 from an existing renderer.
     //! @note added in 2.5
-    virtual QgsRuleBasedRendererV2* convertToRuleBasedRenderer();
+    //! @returns a new renderer if the conversion was possible, otherwise 0.
+    static QgsRuleBasedRendererV2* convertFromRenderer( const QgsFeatureRendererV2 *renderer );
+
+    //! helper function to convert the size scale and rotation fields present in some other renderers to data defined symbology
+    static void convertToDataDefinedSymbology( QgsSymbolV2* symbol, QString sizeScaleField, QString rotationField );
 
   protected:
     //! the root node with hierarchical list of rules

--- a/src/core/symbology-ng/qgsrulebasedrendererv2.h
+++ b/src/core/symbology-ng/qgsrulebasedrendererv2.h
@@ -293,6 +293,10 @@ class CORE_EXPORT QgsRuleBasedRendererV2 : public QgsFeatureRendererV2
     //! take a rule and create a list of new rules with intervals of scales given by the passed scale denominators
     static void refineRuleScales( Rule* initialRule, QList<int> scales );
 
+    //! convert the renderer to a rule based renderer with equivalent rules, if possible
+    //! @note added in 2.5
+    virtual QgsRuleBasedRendererV2* convertToRuleBasedRenderer();
+
   protected:
     //! the root node with hierarchical list of rules
     Rule* mRootRule;

--- a/src/core/symbology-ng/qgssinglesymbolrendererv2.h
+++ b/src/core/symbology-ng/qgssinglesymbolrendererv2.h
@@ -21,8 +21,6 @@
 #include "qgsexpression.h"
 #include <QScopedPointer>
 
-class QgsRuleBasedRenderedV2;
-
 class CORE_EXPORT QgsSingleSymbolRendererV2 : public QgsFeatureRendererV2
 {
   public:
@@ -59,7 +57,7 @@ class CORE_EXPORT QgsSingleSymbolRendererV2 : public QgsFeatureRendererV2
 
     virtual QString dump() const;
 
-    virtual QgsFeatureRendererV2* clone();
+    virtual QgsFeatureRendererV2* clone() const ;
 
     virtual void toSld( QDomDocument& doc, QDomElement &element ) const;
     static QgsFeatureRendererV2* createFromSld( QDomElement& element, QGis::GeometryType geomType );
@@ -89,9 +87,10 @@ class CORE_EXPORT QgsSingleSymbolRendererV2 : public QgsFeatureRendererV2
     //! @note added in 2.6
     virtual QgsLegendSymbolListV2 legendSymbolItemsV2() const;
 
-    //! convert the renderer to a rule based renderer with equivalent rules
+    //! creates a QgsSingleSymbolRendererV2 from an existing renderer.
     //! @note added in 2.5
-    virtual QgsRuleBasedRendererV2* convertToRuleBasedRenderer();
+    //! @returns a new renderer if the conversion was possible, otherwise 0.
+    static QgsSingleSymbolRendererV2* convertFromRenderer( const QgsFeatureRendererV2 *renderer );
 
 
   protected:

--- a/src/core/symbology-ng/qgssinglesymbolrendererv2.h
+++ b/src/core/symbology-ng/qgssinglesymbolrendererv2.h
@@ -21,6 +21,8 @@
 #include "qgsexpression.h"
 #include <QScopedPointer>
 
+class QgsRuleBasedRenderedV2;
+
 class CORE_EXPORT QgsSingleSymbolRendererV2 : public QgsFeatureRendererV2
 {
   public:
@@ -82,9 +84,15 @@ class CORE_EXPORT QgsSingleSymbolRendererV2 : public QgsFeatureRendererV2
     //! @note not available in python bindings
     virtual QgsLegendSymbolList legendSymbolItems( double scaleDenominator = -1, QString rule = QString() );
 
+
     //! Return a list of symbology items for the legend. Better choice than legendSymbolItems().
     //! @note added in 2.6
     virtual QgsLegendSymbolListV2 legendSymbolItemsV2() const;
+
+    //! convert the renderer to a rule based renderer with equivalent rules
+    //! @note added in 2.5
+    virtual QgsRuleBasedRendererV2* convertToRuleBasedRenderer();
+
 
   protected:
     QScopedPointer<QgsSymbolV2> mSymbol;

--- a/src/gui/symbology-ng/qgscategorizedsymbolrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgscategorizedsymbolrendererv2widget.cpp
@@ -372,16 +372,13 @@ QgsCategorizedSymbolRendererV2Widget::QgsCategorizedSymbolRendererV2Widget( QgsV
 
   // try to recognize the previous renderer
   // (null renderer means "no previous renderer")
-  if ( !renderer || renderer->type() != "categorizedSymbol" )
+  if ( renderer )
   {
-    // we're not going to use it - so let's delete the renderer
-    delete renderer;
-
-    mRenderer = new QgsCategorizedSymbolRendererV2( "", QgsCategoryList() );
+    mRenderer = QgsCategorizedSymbolRendererV2::convertFromRenderer( renderer );
   }
-  else
+  if ( !mRenderer )
   {
-    mRenderer = static_cast<QgsCategorizedSymbolRendererV2*>( renderer );
+    mRenderer = new QgsCategorizedSymbolRendererV2( "", QgsCategoryList() );
   }
 
   QString attrName = mRenderer->classAttribute();

--- a/src/gui/symbology-ng/qgsgraduatedsymbolrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgsgraduatedsymbolrendererv2widget.cpp
@@ -365,16 +365,13 @@ QgsGraduatedSymbolRendererV2Widget::QgsGraduatedSymbolRendererV2Widget( QgsVecto
 
   // try to recognize the previous renderer
   // (null renderer means "no previous renderer")
-  if ( !renderer || renderer->type() != "graduatedSymbol" )
+  if ( renderer )
   {
-    // we're not going to use it - so let's delete the renderer
-    delete renderer;
-
-    mRenderer = new QgsGraduatedSymbolRendererV2( "", QgsRangeList() );
+    mRenderer = QgsGraduatedSymbolRendererV2::convertFromRenderer( renderer );
   }
-  else
+  if ( !mRenderer )
   {
-    mRenderer = static_cast<QgsGraduatedSymbolRendererV2*>( renderer );
+    mRenderer = new QgsGraduatedSymbolRendererV2( "", QgsRangeList() );
   }
 
   // setup user interface

--- a/src/gui/symbology-ng/qgsinvertedpolygonrendererwidget.cpp
+++ b/src/gui/symbology-ng/qgsinvertedpolygonrendererwidget.cpp
@@ -53,25 +53,18 @@ QgsInvertedPolygonRendererWidget::QgsInvertedPolygonRendererWidget( QgsVectorLay
 
   // try to recognize the previous renderer
   // (null renderer means "no previous renderer")
-  if ( !renderer )
+
+  if ( renderer )
   {
-    // a new renderer
+    mRenderer.reset( QgsInvertedPolygonRenderer::convertFromRenderer( renderer ) );
+  }
+  if ( ! mRenderer )
+  {
     mRenderer.reset( new QgsInvertedPolygonRenderer() );
   }
-  else if ( renderer && renderer->type() != "invertedPolygonRenderer" )
-  {
-    // an existing renderer, but not an inverted renderer
-    // create an inverted renderer, with the existing renderer embedded
-    mRenderer.reset( new QgsInvertedPolygonRenderer( renderer ) );
-  }
-  else
-  {
-    // an existing inverted renderer
-    mRenderer.reset( static_cast<QgsInvertedPolygonRenderer*>( renderer ) );
-    mMergePolygonsCheckBox->blockSignals( true );
-    mMergePolygonsCheckBox->setCheckState( mRenderer->preprocessingEnabled() ? Qt::Checked : Qt::Unchecked );
-    mMergePolygonsCheckBox->blockSignals( false );
-  }
+  mMergePolygonsCheckBox->blockSignals( true );
+  mMergePolygonsCheckBox->setCheckState( mRenderer->preprocessingEnabled() ? Qt::Checked : Qt::Unchecked );
+  mMergePolygonsCheckBox->blockSignals( false );
 
   int currentEmbeddedIdx = 0;
   //insert possible renderer types

--- a/src/gui/symbology-ng/qgspointdisplacementrendererwidget.cpp
+++ b/src/gui/symbology-ng/qgspointdisplacementrendererwidget.cpp
@@ -49,11 +49,12 @@ QgsPointDisplacementRendererWidget::QgsPointDisplacementRendererWidget( QgsVecto
   }
   setupUi( this );
 
-  if ( renderer && renderer->type() == "pointDisplacement" )
+
+  if ( renderer )
   {
-    mRenderer = dynamic_cast<QgsPointDisplacementRenderer*>( renderer->clone() );
+    mRenderer = QgsPointDisplacementRenderer::convertFromRenderer(renderer);
   }
-  else
+  if ( !mRenderer )
   {
     mRenderer = new QgsPointDisplacementRenderer();
   }

--- a/src/gui/symbology-ng/qgsrendererv2propertiesdialog.cpp
+++ b/src/gui/symbology-ng/qgsrendererv2propertiesdialog.cpp
@@ -65,7 +65,7 @@ static void _initRendererWidgetFunctions()
   _initRenderer( "singleSymbol", QgsSingleSymbolRendererV2Widget::create, "rendererSingleSymbol.png" );
   _initRenderer( "categorizedSymbol", QgsCategorizedSymbolRendererV2Widget::create, "rendererCategorizedSymbol.png" );
   _initRenderer( "graduatedSymbol", QgsGraduatedSymbolRendererV2Widget::create, "rendererGraduatedSymbol.png" );
-  _initRenderer( "RuleRenderer", QgsRuleBasedRendererV2Widget::create );
+  _initRenderer( "ruleRenderer", QgsRuleBasedRendererV2Widget::create );
   _initRenderer( "pointDisplacement", QgsPointDisplacementRendererWidget::create );
   _initRenderer( "invertedPolygonRenderer", QgsInvertedPolygonRendererWidget::create );
   initialized = true;
@@ -146,7 +146,7 @@ void QgsRendererV2PropertiesDialog::rendererChanged()
 
   //Retrieve the previous renderer: from the old active widget if possible, otherwise from the layer
   QgsFeatureRendererV2* oldRenderer;
-  if ( mActiveWidget )
+  if ( mActiveWidget  && mActiveWidget->renderer() )
   {
     oldRenderer = mActiveWidget->renderer()->clone();
   }

--- a/src/gui/symbology-ng/qgsrendererv2propertiesdialog.cpp
+++ b/src/gui/symbology-ng/qgsrendererv2propertiesdialog.cpp
@@ -144,6 +144,17 @@ void QgsRendererV2PropertiesDialog::rendererChanged()
 
   QString rendererName = cboRenderers->itemData( cboRenderers->currentIndex() ).toString();
 
+  //Retrieve the previous renderer: from the old active widget if possible, otherwise from the layer
+  QgsFeatureRendererV2* oldRenderer;
+  if ( mActiveWidget )
+  {
+    oldRenderer = mActiveWidget->renderer()->clone();
+  }
+  else
+  {
+    oldRenderer = mLayer->rendererV2()->clone();
+  }
+
   // get rid of old active widget (if any)
   if ( mActiveWidget )
   {
@@ -156,7 +167,7 @@ void QgsRendererV2PropertiesDialog::rendererChanged()
   QgsRendererV2Widget* w = NULL;
   QgsRendererV2AbstractMetadata* m = QgsRendererV2Registry::instance()->rendererMetadata( rendererName );
   if ( m != NULL )
-    w = m->createRendererWidget( mLayer, mStyle, mLayer->rendererV2()->clone() );
+    w = m->createRendererWidget( mLayer, mStyle, oldRenderer );
 
   if ( w != NULL )
   {

--- a/src/gui/symbology-ng/qgsrulebasedrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgsrulebasedrendererv2widget.cpp
@@ -43,22 +43,19 @@ QgsRendererV2Widget* QgsRuleBasedRendererV2Widget::create( QgsVectorLayer* layer
 QgsRuleBasedRendererV2Widget::QgsRuleBasedRendererV2Widget( QgsVectorLayer* layer, QgsStyleV2* style, QgsFeatureRendererV2* renderer )
     : QgsRendererV2Widget( layer, style )
 {
-
+  mRenderer = 0;
   // try to recognize the previous renderer
   // (null renderer means "no previous renderer")
-  if ( !renderer || renderer->type() != "RuleRenderer" )
+  if ( renderer )
   {
-    // we're not going to use it - so let's delete the renderer
-    delete renderer;
-
+    mRenderer = renderer->convertToRuleBasedRenderer();
+  }
+  if ( !mRenderer )
+  {
     // some default options
     QgsSymbolV2* symbol = QgsSymbolV2::defaultSymbol( mLayer->geometryType() );
 
     mRenderer = new QgsRuleBasedRendererV2( symbol );
-  }
-  else
-  {
-    mRenderer = static_cast<QgsRuleBasedRendererV2*>( renderer );
   }
 
   setupUi( this );

--- a/src/gui/symbology-ng/qgsrulebasedrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgsrulebasedrendererv2widget.cpp
@@ -24,6 +24,7 @@
 #include "qgssymbolv2selectordialog.h"
 #include "qgslogger.h"
 #include "qstring.h"
+#include "qgssinglesymbolrendererv2.h"
 
 #include <QKeyEvent>
 #include <QMenu>
@@ -46,9 +47,11 @@ QgsRuleBasedRendererV2Widget::QgsRuleBasedRendererV2Widget( QgsVectorLayer* laye
   mRenderer = 0;
   // try to recognize the previous renderer
   // (null renderer means "no previous renderer")
+
+
   if ( renderer )
   {
-    mRenderer = renderer->convertToRuleBasedRenderer();
+    mRenderer = QgsRuleBasedRendererV2::convertFromRenderer(renderer);
   }
   if ( !mRenderer )
   {

--- a/src/gui/symbology-ng/qgssinglesymbolrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgssinglesymbolrendererv2widget.cpp
@@ -34,19 +34,16 @@ QgsSingleSymbolRendererV2Widget::QgsSingleSymbolRendererV2Widget( QgsVectorLayer
 {
   // try to recognize the previous renderer
   // (null renderer means "no previous renderer")
-  if ( !renderer || renderer->type() != "singleSymbol" )
-  {
-    // we're not going to use it - so let's delete the renderer
-    delete renderer;
 
-    // some default options
+  if ( renderer )
+  {
+    mRenderer = QgsSingleSymbolRendererV2::convertFromRenderer( renderer );
+  }
+  if ( !mRenderer )
+  {
     QgsSymbolV2* symbol = QgsSymbolV2::defaultSymbol( mLayer->geometryType() );
 
     mRenderer = new QgsSingleSymbolRendererV2( symbol );
-  }
-  else
-  {
-    mRenderer = static_cast<QgsSingleSymbolRendererV2*>( renderer );
   }
 
   // load symbol from it


### PR DESCRIPTION
Hi devs,

Very often I start with a categorized or graduated symbology, but I realize later I have to refine it with a custom rule. Or I make a complex symbol with several layer, data defined attributes, etc., then realize I cannot use a single symbol representation for what I want to achieve and I have to work with rules. Sometimes I know from the beginning I will need rules, but it is very tedious to build as these rules are very close to a categorized symbology, so a lot of classes need to be created. In all these cases, I have to start from scratch again when switching to rule-based symbology.

I propose to improve this situation by allowing to automatically convert other renderers to a rule based renderer when we switch renderers in the properties. If the renderer supports it, it should implement convertToRuleBasedRenderer() and the existing rendering will be preserved when switching to a rule based renderer. If it can't, the previous behavior is kept and a new rule based renderer is created (for example inverted polygons or point displacement renderer).

This conversion supports rotation fields and size scale fields by converting them to data-defined symbology. I think these fields should be replaced by data-defined symbology anyway, now that it is so powerful.

The result is something like that:
![categorized](https://cloud.githubusercontent.com/assets/537624/4022281/0b23f228-2b28-11e4-882a-671e29765071.png)
![rule_based](https://cloud.githubusercontent.com/assets/537624/4022283/121d982c-2b28-11e4-89ab-101ae7256c63.png)
![graduated](https://cloud.githubusercontent.com/assets/537624/4022284/17b6b1c4-2b28-11e4-96c1-79d920d09fdd.png)
![rule_based_2](https://cloud.githubusercontent.com/assets/537624/4022286/2eae18ae-2b28-11e4-9f82-7e1b8a77a04f.png)
