### PR TITLE
fix #10472 : Enlarge btnSaveSymbol so it shows fully its text in all languages

### DIFF
--- a/src/ui/qgssymbolv2selectordialogbase.ui
+++ b/src/ui/qgssymbolv2selectordialogbase.ui
@@ -137,7 +137,7 @@
          </property>
          <property name="sizeHint" stdset="0">
           <size>
-           <width>40</width>
+           <width>20</width>
            <height>20</height>
           </size>
          </property>
@@ -147,7 +147,7 @@
         <widget class="QPushButton" name="btnSaveSymbol">
          <property name="maximumSize">
           <size>
-           <width>50</width>
+           <width>70</width>
            <height>16777215</height>
           </size>
          </property>


### PR DESCRIPTION
The btnSaveSymbol has his width increased from 50 to 70 when the horizontalSpacer has its width decreased from 40 to 20. It seems to be ok for all the languages I checked on reverso dot net.
