### PR TITLE
#10725 : Show ContextHelp in Vector layer Symbol levels dialog

### DIFF
--- a/python/gui/symbology-ng/qgssymbollevelsv2dialog.sip
+++ b/python/gui/symbology-ng/qgssymbollevelsv2dialog.sip
@@ -18,6 +18,8 @@ class QgsSymbolLevelsV2Dialog : QDialog
 
     void renderingPassChanged( int row, int column );
 
+    void on_buttonBox_helpRequested();
+
   protected:
     void populateTable();
     void setDefaultLevels();

--- a/src/gui/symbology-ng/qgssymbollevelsv2dialog.h
+++ b/src/gui/symbology-ng/qgssymbollevelsv2dialog.h
@@ -21,6 +21,7 @@
 #include "qgsrendererv2.h"
 
 #include "ui_qgssymbollevelsv2dialogbase.h"
+#include "qgscontexthelp.h"
 
 
 class GUI_EXPORT QgsSymbolLevelsV2Dialog : public QDialog, private Ui::QgsSymbolLevelsV2DialogBase
@@ -40,6 +41,8 @@ class GUI_EXPORT QgsSymbolLevelsV2Dialog : public QDialog, private Ui::QgsSymbol
 
     void renderingPassChanged( int row, int column );
 
+    void on_buttonBox_helpRequested() { QgsContextHelp::run( metaObject()->className() ); }
+ 
   protected:
     void populateTable();
     void setDefaultLevels();


### PR DESCRIPTION
Might fix #10725 about contextHelp showing in vector layer properties > Style > Advanced > Symbol levels
