### PR TITLE
New identify menu

### DIFF
--- a/python/gui/qgsmaptoolidentify.sip
+++ b/python/gui/qgsmaptoolidentify.sip
@@ -80,7 +80,6 @@ class QgsMapToolIdentify : QgsMapTool
 
   public slots:
     void formatChanged( QgsRasterLayer *layer );
-    void layerDestroyed();
 
   signals:
     void identifyProgress( int, int );
@@ -88,8 +87,6 @@ class QgsMapToolIdentify : QgsMapTool
     void changedRasterResults( QList<QgsMapToolIdentify::IdentifyResult>& );
 
   protected:
-    //! rubber bands for layer select mode
-    void deleteRubberBands();
 
     /** Performs the identification.
     To avoid beeing forced to specify IdentifyMode with a list of layers

--- a/src/app/qgsattributeactiondialog.h
+++ b/src/app/qgsattributeactiondialog.h
@@ -58,10 +58,11 @@ class APP_EXPORT QgsAttributeActionDialog: public QWidget, private Ui::QgsAttrib
 
   private slots:
     void updateButtons();
+    void chooseIcon();
 
   private:
 
-    void insertRow( int row, QgsAction::ActionType type, const QString &name, const QString &action, bool capture );
+    void insertRow(int row, QgsAction::ActionType type, const QString &name, const QString &action, const QString& iconPath, bool capture );
     void swapRows( int row1, int row2 );
 
     void insert( int pos );

--- a/src/app/qgsidentifyresultsdialog.h
+++ b/src/app/qgsidentifyresultsdialog.h
@@ -51,7 +51,7 @@ class QwtPlotCurve;
 
 class APP_EXPORT QgsIdentifyResultsWebView : public QWebView
 {
-    Q_OBJECT;
+    Q_OBJECT
   public:
     QgsIdentifyResultsWebView( QWidget *parent = 0 );
     QSize sizeHint() const;

--- a/src/app/qgsmaptoolidentifyaction.cpp
+++ b/src/app/qgsmaptoolidentifyaction.cpp
@@ -55,8 +55,9 @@ QgsMapToolIdentifyAction::QgsMapToolIdentifyAction( QgsMapCanvas * canvas )
 
   mIdentifyMenu->setAllowMultipleReturn( true );
 
-  QgsMapLayerAction* attrTableAction = new QgsMapLayerAction( tr( "Show attribute table" ), this, QgsMapLayer::VectorLayer, QgsMapLayerAction::MultipleFeatures );
   connect( attrTableAction, SIGNAL( triggeredForFeatures( QgsMapLayer*, QList<const QgsFeature*> ) ), this, SLOT( showAttributeTable( QgsMapLayer*, QList<const QgsFeature*> ) ) );
+
+  QgsMapLayerAction* attrTableAction = new QgsMapLayerAction( tr( "Show attribute table" ), mIdentifyMenu, QgsMapLayer::VectorLayer, QgsMapLayerAction::MultipleFeatures );
   identifyMenu()->addCustomAction( attrTableAction );
 }
 

--- a/src/app/qgsmaptoolidentifyaction.h
+++ b/src/app/qgsmaptoolidentifyaction.h
@@ -71,6 +71,8 @@ class APP_EXPORT QgsMapToolIdentifyAction : public QgsMapToolIdentify
     void identifyMessage( QString );
     void copyToClipboard( QgsFeatureStore & );
 
+  private slots:
+    void showAttributeTable( QgsMapLayer* layer, QList<const QgsFeature*> featureList );
   private:
     //! Pointer to the identify results dialog for name/value pairs
     QPointer<QgsIdentifyResultsDialog> mResultsDialog;
@@ -78,6 +80,9 @@ class APP_EXPORT QgsMapToolIdentifyAction : public QgsMapToolIdentify
     QgsIdentifyResultsDialog *resultsDialog();
 
     virtual QGis::UnitType displayUnits();
+
+    // pointers to the custom actions for identify menu
+    QAction* mAttributeTableAction;
 };
 
 #endif

--- a/src/core/qgsattributeaction.cpp
+++ b/src/core/qgsattributeaction.cpp
@@ -45,6 +45,11 @@ void QgsAttributeAction::addAction( QgsAction::ActionType type, QString name, QS
   mActions << QgsAction( type, name, action, capture );
 }
 
+void QgsAttributeAction::addAction(QgsAction::ActionType type, QString name, QString action, const QString& icon, bool capture)
+{
+  mActions << QgsAction( type, name, action, icon, capture );
+}
+
 void QgsAttributeAction::removeAction( int index )
 {
   if ( index >= 0 && index < mActions.size() )
@@ -236,6 +241,7 @@ bool QgsAttributeAction::writeXML( QDomNode& layer_node, QDomDocument& doc ) con
     QDomElement actionSetting = doc.createElement( "actionsetting" );
     actionSetting.setAttribute( "type", mActions[i].type() );
     actionSetting.setAttribute( "name", mActions[i].name() );
+    actionSetting.setAttribute( "icon", mActions[i].iconPath() );
     actionSetting.setAttribute( "action", mActions[i].action() );
     actionSetting.setAttribute( "capture", mActions[i].capture() );
     aActions.appendChild( actionSetting );
@@ -260,6 +266,7 @@ bool QgsAttributeAction::readXML( const QDomNode& layer_node )
       addAction(( QgsAction::ActionType ) setting.attributeNode( "type" ).value().toInt(),
                 setting.attributeNode( "name" ).value(),
                 setting.attributeNode( "action" ).value(),
+                setting.attributeNode( "icon" ).value(),
                 setting.attributeNode( "capture" ).value().toInt() != 0 );
     }
   }

--- a/src/core/qgsattributeaction.h
+++ b/src/core/qgsattributeaction.h
@@ -25,7 +25,7 @@
 #define QGSATTRIBUTEACTION_H
 
 #include <QString>
-#include <QObject>
+#include <QIcon>
 
 #include <qgsfeature.h>
 
@@ -53,8 +53,17 @@ class CORE_EXPORT QgsAction
     QgsAction( ActionType type, QString name, QString action, bool capture ) :
         mType( type ), mName( name ), mAction( action ), mCaptureOutput( capture ) {}
 
+    QgsAction( ActionType type, QString name, QString action, const QString& icon, bool capture ) :
+        mType( type ), mName( name ), mIcon( icon ), mAction( action ), mCaptureOutput( capture ) {}
+
     //! The name of the action
     QString name() const { return mName; }
+
+    //! The path to the icon
+    const QString iconPath() const { return mIcon; }
+
+    //! The icon
+    const QIcon icon() const { return QIcon( mIcon ); }
 
     //! The action
     QString action() const { return mAction; }
@@ -84,6 +93,7 @@ class CORE_EXPORT QgsAction
   private:
     ActionType mType;
     QString mName;
+    QString mIcon;
     QString mAction;
     bool mCaptureOutput;
 };
@@ -102,12 +112,21 @@ class  CORE_EXPORT QgsAttributeAction
     //! Destructor
     virtual ~QgsAttributeAction() {}
 
-    //! Add an action with the given name and action details.
-    // Will happily have duplicate names and actions. If
-    // capture is true, when running the action using doAction(),
-    // any stdout from the process will be captured and displayed in a
-    // dialog box.
+    /** Add an action with the given name and action details.
+     * Will happily have duplicate names and actions. If
+     * capture is true, when running the action using doAction(),
+     * any stdout from the process will be captured and displayed in a
+     * dialog box.
+     */
     void addAction( QgsAction::ActionType type, QString name, QString action, bool capture = false );
+
+    /** Add an action with the given name and action details.
+     * Will happily have duplicate names and actions. If
+     * capture is true, when running the action using doAction(),
+     * any stdout from the process will be captured and displayed in a
+     * dialog box.
+     */
+    void addAction(QgsAction::ActionType type, QString name, QString action, const QString& icon, bool capture = false );
 
     //! Remove an action at given index
     void removeAction( int index );

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -167,6 +167,7 @@ qgsfilterlineedit.cpp
 qgsformannotationitem.cpp
 qgsgenericprojectionselector.cpp
 qgshighlight.cpp
+qgsidentifymenu.cpp
 qgshtmlannotationitem.cpp
 qgslegendinterface.cpp
 qgsludialog.cpp
@@ -366,6 +367,7 @@ qgsfilterlineedit.h
 qgsformannotationitem.h
 qgsgenericprojectionselector.h
 qgshtmlannotationitem.h
+qgsidentifymenu.h
 qgslegendinterface.h
 qgslonglongvalidator.h
 qgsludialog.h
@@ -452,6 +454,7 @@ qgsfiledropedit.h
 qgsfilterlineedit.h
 qgsgenericprojectionselector.h
 qgshighlight.h
+qgsidentifymenu.h
 qgsmapcanvas.h
 qgsmapcanvasitem.h
 qgsmapcanvasmap.h

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -114,6 +114,7 @@ layertree/qgslayertreeviewdefaultactions.cpp
 qgisgui.cpp
 qgisinterface.cpp
 qgsannotationitem.cpp
+qgsactionmenu.cpp
 qgsattributedialog.cpp
 qgsattributeeditor.cpp
 qgsattributeeditorcontext.cpp
@@ -323,6 +324,7 @@ layertree/qgslayertreeview.h
 layertree/qgslayertreeviewdefaultactions.h
 
 qgisinterface.h
+qgsactionmenu.h
 qgsattributedialog.h
 qgsattributeeditor.h
 qgsattributeform.h
@@ -418,6 +420,7 @@ ENDIF(MSVC)
 SET(QGIS_GUI_HDRS
 qgisgui.h
 qgisinterface.h
+qgsactionmenu.h
 qgsattributeeditor.h
 qgsattributedialog.h
 qgsattributeeditorcontext.h

--- a/src/gui/attributetable/qgsattributetableview.cpp
+++ b/src/gui/attributetable/qgsattributetableview.cpp
@@ -59,10 +59,7 @@ QgsAttributeTableView::QgsAttributeTableView( QWidget *parent )
 
 QgsAttributeTableView::~QgsAttributeTableView()
 {
-  if ( mActionPopup )
-  {
-    delete mActionPopup;
-  }
+  delete mActionPopup;
 }
 #if 0
 void QgsAttributeTableView::setCanvasAndLayerCache( QgsMapCanvas *canvas, QgsVectorLayerCache *layerCache )
@@ -222,11 +219,8 @@ void QgsAttributeTableView::selectAll()
 
 void QgsAttributeTableView::contextMenuEvent( QContextMenuEvent* event )
 {
-  if ( mActionPopup )
-  {
-    delete mActionPopup;
-    mActionPopup = 0;
-  }
+  delete mActionPopup;
+  mActionPopup = 0;
 
   QModelIndex idx = indexAt( event->pos() );
   if ( !idx.isValid() )

--- a/src/gui/attributetable/qgsfeaturelistmodel.cpp
+++ b/src/gui/attributetable/qgsfeaturelistmodel.cpp
@@ -64,7 +64,7 @@ QVariant QgsFeatureListModel::data( const QModelIndex &index, int role ) const
     return mExpression->evaluate( &feat, fields );
   }
 
-  if ( role == Qt::UserRole )
+  if ( role == FeatureInfoRole )
   {
     FeatureInfo featInfo;
 
@@ -90,6 +90,14 @@ QVariant QgsFeatureListModel::data( const QModelIndex &index, int role ) const
     }
 
     return QVariant::fromValue( featInfo );
+  }
+  else if ( role == FeatureRole )
+  {
+    QgsFeature feat;
+
+    mFilterModel->layerCache()->featureAtId( idxToFid( index ), feat );
+
+    return QVariant::fromValue( feat );
   }
 
   return sourceModel()->data( mapToSource( index ), role );

--- a/src/gui/attributetable/qgsfeaturelistmodel.h
+++ b/src/gui/attributetable/qgsfeaturelistmodel.h
@@ -31,6 +31,12 @@ class GUI_EXPORT QgsFeatureListModel : public QAbstractProxyModel, public QgsFea
       bool isEdited;
     };
 
+    enum Role
+    {
+      FeatureInfoRole = Qt::UserRole,
+      FeatureRole
+    };
+
   public:
     explicit QgsFeatureListModel( QgsAttributeTableFilterModel *sourceModel, QObject* parent = NULL );
     virtual ~QgsFeatureListModel();

--- a/src/gui/attributetable/qgsfeaturelistview.cpp
+++ b/src/gui/attributetable/qgsfeaturelistview.cpp
@@ -19,6 +19,7 @@
 #include <QSet>
 #include <QSettings>
 
+#include "qgsactionmenu.h"
 #include "qgsattributetabledelegate.h"
 #include "qgsattributetablefiltermodel.h"
 #include "qgsattributetablemodel.h"
@@ -287,6 +288,19 @@ void QgsFeatureListView::keyPressEvent( QKeyEvent *event )
   else
   {
     QListView::keyPressEvent( event );
+  }
+}
+
+void QgsFeatureListView::contextMenuEvent( QContextMenuEvent *event )
+{
+  QModelIndex index = indexAt( event->pos() );
+
+  if ( index.isValid() )
+  {
+    QgsFeature feature = mModel->data( index, QgsFeatureListModel::FeatureRole ).value<QgsFeature>();
+
+    QgsActionMenu menu( mModel->layerCache()->layer(), &feature, this );
+    menu.exec( event->globalPos() );
   }
 }
 

--- a/src/gui/attributetable/qgsfeaturelistview.h
+++ b/src/gui/attributetable/qgsfeaturelistview.h
@@ -119,6 +119,7 @@ class GUI_EXPORT QgsFeatureListView : public QListView
     virtual void mousePressEvent( QMouseEvent *event );
     virtual void mouseReleaseEvent( QMouseEvent *event );
     virtual void keyPressEvent( QKeyEvent *event );
+    virtual void contextMenuEvent( QContextMenuEvent *event );
 
   signals:
     /**

--- a/src/gui/qgsactionmenu.cpp
+++ b/src/gui/qgsactionmenu.cpp
@@ -126,7 +126,7 @@ void QgsActionMenu::reloadActions()
   {
     const QgsAction& qaction( mActions->at( idx ) );
 
-    QAction* action = new QAction( qaction.name(), this );
+    QAction* action = new QAction( qaction.icon(), qaction.name(), this );
 
     // Only enable items on supported platforms
     if ( !qaction.runable() )

--- a/src/gui/qgsactionmenu.cpp
+++ b/src/gui/qgsactionmenu.cpp
@@ -25,6 +25,7 @@ QgsActionMenu::QgsActionMenu( QgsVectorLayer* layer, const QgsFeature* feature, 
     , mMapLayerActionSignalMapper( 0 )
     , mActions( 0 )
     , mFeature( feature )
+    , mFeatureId( feature->id() )
     , mOwnsFeature( false )
 {
   init();
@@ -127,6 +128,7 @@ void QgsActionMenu::reloadActions()
     const QgsAction& qaction( mActions->at( idx ) );
 
     QAction* action = new QAction( qaction.icon(), qaction.name(), this );
+    action->setData( QVariant::fromValue<ActionData>( ActionData( idx, mFeatureId, mLayer ) ) );
 
     // Only enable items on supported platforms
     if ( !qaction.runable() )
@@ -157,6 +159,7 @@ void QgsActionMenu::reloadActions()
     {
       QgsMapLayerAction* qaction = mapLayerActions.at( i );
       QAction* action = new QAction( qaction->text(), this );
+      action->setData( QVariant::fromValue<ActionData>( ActionData( MapLayerAction, mFeatureId, mLayer ) ) );
       mMapLayerActionSignalMapper->setMapping( action, i );
       addAction( action );
       connect( action, SIGNAL(triggered()), mMapLayerActionSignalMapper, SLOT(map()) );

--- a/src/gui/qgsactionmenu.cpp
+++ b/src/gui/qgsactionmenu.cpp
@@ -1,0 +1,168 @@
+/***************************************************************************
+    qgsactionmenu.cpp
+     --------------------------------------
+    Date                 : 11.8.2014
+    Copyright            : (C) 2014 Matthias Kuhn
+    Email                : matthias dot kuhn at gmx dot ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsactionmenu.h"
+#include "qgsvectorlayer.h"
+
+#include <QMenuItem>
+
+QgsActionMenu::QgsActionMenu( QgsVectorLayer* layer, const QgsFeature* feature, QWidget*  parent )
+    : QMenu( parent )
+    , mLayer( layer )
+    , mAttributeActionSignalMapper( 0 )
+    , mMapLayerActionSignalMapper( 0 )
+    , mActions( 0 )
+    , mFeature( feature )
+    , mOwnsFeature( false )
+{
+  init();
+}
+
+QgsActionMenu::QgsActionMenu( QgsVectorLayer* layer, const QgsFeatureId fid, QWidget*  parent )
+  : QMenu( parent )
+  , mLayer( layer )
+  , mAttributeActionSignalMapper( 0 )
+  , mMapLayerActionSignalMapper( 0 )
+  , mActions( 0 )
+  , mFeature( 0 )
+  , mFeatureId( fid )
+  , mOwnsFeature( false )
+{
+  init();
+}
+
+void QgsActionMenu::init()
+{
+  setTitle( tr( "&Actions" ) );
+
+  connect( QgsMapLayerActionRegistry::instance(), SIGNAL(changed()), this, SLOT(reloadActions()) );
+
+  reloadActions();
+}
+
+const QgsFeature* QgsActionMenu::feature()
+{
+  if ( !mFeature )
+  {
+    QgsFeature* feat = new QgsFeature();
+    if ( mActions->layer()->getFeatures( QgsFeatureRequest( mFeatureId ) ).nextFeature( *feat ) )
+    {
+      mFeature = feat;
+      mOwnsFeature = true;
+    }
+    else
+    {
+      delete feat;
+    }
+  }
+
+  return mFeature;
+}
+
+QgsActionMenu::~QgsActionMenu()
+{
+  delete mActions;
+
+  if ( mOwnsFeature )
+    delete mFeature;
+}
+
+void QgsActionMenu::setFeature( QgsFeature* feature )
+{
+  if ( mOwnsFeature )
+    delete mFeature;
+  mOwnsFeature = false;
+  mFeature = feature;
+}
+
+void QgsActionMenu::triggerAttributeAction( int index )
+{
+  if ( feature() )
+  {
+    mActions->doAction( index, *feature() );
+  }
+  else
+  {
+    QgsDebugMsg( QString( "Trying to run an action on a non-existing feature with fid %1" ).arg( mFeatureId ) );
+  }
+}
+
+void QgsActionMenu::triggerMapLayerAction( int index )
+{
+  if ( feature() )
+  {
+    QgsMapLayerAction* action = QgsMapLayerActionRegistry::instance()->mapLayerActions( mLayer ).at( index );
+
+    action->triggerForFeature( mLayer, feature() );
+  }
+}
+
+void QgsActionMenu::reloadActions()
+{
+  delete mAttributeActionSignalMapper;
+  mAttributeActionSignalMapper = new QSignalMapper( this );
+  delete mMapLayerActionSignalMapper;
+  mMapLayerActionSignalMapper = new QSignalMapper( this );
+
+  connect( mAttributeActionSignalMapper, SIGNAL(mapped(int)), this, SLOT(triggerAttributeAction(int)) );
+  connect( mMapLayerActionSignalMapper, SIGNAL(mapped(int)), this, SLOT(triggerMapLayerAction(int)) );
+
+  delete mActions;
+  mActions = new QgsAttributeAction( *mLayer->actions() );
+
+  for( int idx = 0; idx < mActions->size(); ++idx )
+  {
+    const QgsAction& qaction( mActions->at( idx ) );
+
+    QAction* action = new QAction( qaction.name(), this );
+
+    // Only enable items on supported platforms
+    if ( !qaction.runable() )
+    {
+      action->setEnabled( false );
+      action->setToolTip( tr( "Not supported on your platform" ) );
+    }
+    else
+    {
+      action->setToolTip( qaction.action() );
+    }
+
+    mAttributeActionSignalMapper->setMapping( action, idx );
+
+    connect( action, SIGNAL(triggered()), mAttributeActionSignalMapper, SLOT(map()) );
+
+    addAction( action );
+  }
+
+  QList<QgsMapLayerAction*> mapLayerActions = QgsMapLayerActionRegistry::instance()->mapLayerActions( mLayer );
+
+  if ( mapLayerActions.size() > 0 )
+  {
+    //add a separator between user defined and standard actions
+    addSeparator();
+
+    for ( int i = 0; i < mapLayerActions.size(); ++i )
+    {
+      QgsMapLayerAction* qaction = mapLayerActions.at( i );
+      QAction* action = new QAction( qaction->text(), this );
+      mMapLayerActionSignalMapper->setMapping( action, i );
+      addAction( action );
+      connect( action, SIGNAL(triggered()), mMapLayerActionSignalMapper, SLOT(map()) );
+    }
+  }
+
+  emit reinit();
+}
+

--- a/src/gui/qgsactionmenu.cpp
+++ b/src/gui/qgsactionmenu.cpp
@@ -104,7 +104,7 @@ void QgsActionMenu::triggerMapLayerAction( int index )
 {
   if ( feature() )
   {
-    QgsMapLayerAction* action = QgsMapLayerActionRegistry::instance()->mapLayerActions( mLayer ).at( index );
+    QgsMapLayerAction* action = QgsMapLayerActionRegistry::instance()->mapLayerActions( mLayer, QgsMapLayerAction::Feature ).at( index );
 
     action->triggerForFeature( mLayer, feature() );
   }
@@ -148,7 +148,7 @@ void QgsActionMenu::reloadActions()
     addAction( action );
   }
 
-  QList<QgsMapLayerAction*> mapLayerActions = QgsMapLayerActionRegistry::instance()->mapLayerActions( mLayer );
+  QList<QgsMapLayerAction*> mapLayerActions = QgsMapLayerActionRegistry::instance()->mapLayerActions( mLayer, QgsMapLayerAction::SingleFeature );
 
   if ( mapLayerActions.size() > 0 )
   {

--- a/src/gui/qgsactionmenu.cpp
+++ b/src/gui/qgsactionmenu.cpp
@@ -51,7 +51,7 @@ void QgsActionMenu::init()
 
 const QgsFeature* QgsActionMenu::feature()
 {
-  if ( !mFeature )
+  if ( !mFeature || !mFeature->isValid() )
   {
     QgsFeature* feat = new QgsFeature();
     if ( mActions->layer()->getFeatures( QgsFeatureRequest( mFeatureId ) ).nextFeature( *feat ) )

--- a/src/gui/qgsactionmenu.h
+++ b/src/gui/qgsactionmenu.h
@@ -1,0 +1,93 @@
+/***************************************************************************
+    qgsactionmenu.h
+     --------------------------------------
+    Date                 : 11.8.2014
+    Copyright            : (C) 2014 Matthias Kuhn
+    Email                : matthias dot kuhn at gmx dot ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSACTIONMENU_H
+#define QGSACTIONMENU_H
+
+#include <QMenu>
+#include <QSignalMapper>
+
+#include "qgsattributeaction.h"
+#include "qgsmaplayeractionregistry.h"
+
+/**
+ * This class is a menu that is populated automatically with the actions defined for a given layer.
+ */
+
+class QgsActionMenu : public QMenu
+{
+    Q_OBJECT
+  public:
+    /**
+     * Constructs a new QgsActionMenu
+     *
+     * @param layer    The layer that this action will be run upon.
+     * @param feature  The feature that this action will be run upon. Make sure that this feature is available
+     *                 for the lifetime of this object.
+     * @param parent   The usual QWidget parent.
+     */
+    explicit QgsActionMenu( QgsVectorLayer* layer, const QgsFeature* feature, QWidget*  parent = 0 );
+
+    /**
+     * Constructs a new QgsActionMenu
+     *
+     * @param layer    The layer that this action will be run upon.
+     * @param fid      The feature id of the feature for which this action will be run.
+     * @param parent   The usual QWidget parent.
+     */
+    explicit QgsActionMenu( QgsVectorLayer* layer, const QgsFeatureId fid, QWidget*  parent = 0 );
+
+    /**
+     * Destructor
+     */
+    ~QgsActionMenu();
+
+    /**
+     * Change the feature on which actions are performed
+     *
+     * @param feature  A feature. Will not take ownership. It's the callers responsibility to keep the feature
+     *                 as long as the menu is displayed and the action is running.
+     */
+    void setFeature( QgsFeature* feature );
+
+    /**
+     * @brief setFeature
+     * @param feature
+     */
+    void setFeature( QgsFeatureId feature );
+
+  private slots:
+    void triggerAttributeAction( int index );
+    void triggerMapLayerAction( int index );
+    void reloadActions();
+
+  signals:
+    void reinit();
+
+  private:
+    void init();
+    const QgsFeature* feature();
+
+    QgsVectorLayer* mLayer;
+    QSignalMapper* mAttributeActionSignalMapper;
+    QSignalMapper* mMapLayerActionSignalMapper;
+    QgsAttributeAction* mActions;
+    const QgsFeature* mFeature;
+    QgsFeatureId mFeatureId;
+    bool mOwnsFeature;
+};
+
+
+#endif // QGSACTIONMENU_H

--- a/src/gui/qgsactionmenu.h
+++ b/src/gui/qgsactionmenu.h
@@ -29,6 +29,51 @@
 class QgsActionMenu : public QMenu
 {
     Q_OBJECT
+
+  public:
+    enum ActionType
+    {
+      Invalid,        //!< Invalid
+      MapLayerAction, //!< Standard actions (defined by core or plugins)
+      AttributeAction //!< Custom actions (manually defined in layer properties)
+    };
+
+    struct ActionData
+    {
+        ActionData()
+          : actionType( Invalid )
+          , actionId( 0 )
+        {}
+
+        ActionData( int actionId, QgsFeatureId featureId, QgsMapLayer* mapLayer )
+          : actionType( AttributeAction )
+          , actionId( actionId )
+          , featureId( featureId )
+          , mapLayer( mapLayer )
+        {}
+
+        ActionData( QgsMapLayerAction* action, QgsFeatureId featureId, QgsMapLayer* mapLayer )
+          : actionType( AttributeAction )
+          , actionId( action )
+          , featureId( featureId )
+          , mapLayer( mapLayer )
+        {}
+
+        ActionType actionType;
+
+        union aid
+        {
+          aid( int i ) : id( i ) {}
+          aid( QgsMapLayerAction* a ) : action( a ) {}
+          int id;
+          QgsMapLayerAction* action;
+        } actionId;
+
+        QgsFeatureId featureId;
+        QgsMapLayer* mapLayer;
+    };
+
+
   public:
     /**
      * Constructs a new QgsActionMenu
@@ -89,5 +134,6 @@ class QgsActionMenu : public QMenu
     bool mOwnsFeature;
 };
 
+Q_DECLARE_METATYPE( QgsActionMenu::ActionData )
 
 #endif // QGSACTIONMENU_H

--- a/src/gui/qgsactionmenu.h
+++ b/src/gui/qgsactionmenu.h
@@ -22,6 +22,7 @@
 #include "qgsattributeaction.h"
 #include "qgsmaplayeractionregistry.h"
 
+
 /**
  * This class is a menu that is populated automatically with the actions defined for a given layer.
  */
@@ -40,37 +41,37 @@ class QgsActionMenu : public QMenu
 
     struct ActionData
     {
-        ActionData()
+      ActionData()
           : actionType( Invalid )
           , actionId( 0 )
-        {}
+      {}
 
-        ActionData( int actionId, QgsFeatureId featureId, QgsMapLayer* mapLayer )
+      ActionData( int actionId, QgsFeatureId featureId, QgsMapLayer* mapLayer )
           : actionType( AttributeAction )
           , actionId( actionId )
           , featureId( featureId )
           , mapLayer( mapLayer )
-        {}
+      {}
 
-        ActionData( QgsMapLayerAction* action, QgsFeatureId featureId, QgsMapLayer* mapLayer )
-          : actionType( AttributeAction )
+      ActionData( QgsMapLayerAction* action, QgsFeatureId featureId, QgsMapLayer* mapLayer )
+          : actionType( MapLayerAction )
           , actionId( action )
           , featureId( featureId )
           , mapLayer( mapLayer )
-        {}
+      {}
 
-        ActionType actionType;
+      ActionType actionType;
 
-        union aid
-        {
-          aid( int i ) : id( i ) {}
-          aid( QgsMapLayerAction* a ) : action( a ) {}
-          int id;
-          QgsMapLayerAction* action;
-        } actionId;
+      union aid
+      {
+        aid( int i ) : id( i ) {}
+        aid( QgsMapLayerAction* a ) : action( a ) {}
+        int id;
+        QgsMapLayerAction* action;
+      } actionId;
 
-        QgsFeatureId featureId;
-        QgsMapLayer* mapLayer;
+      QgsFeatureId featureId;
+      QgsMapLayer* mapLayer;
     };
 
 
@@ -114,8 +115,7 @@ class QgsActionMenu : public QMenu
     void setFeature( QgsFeatureId feature );
 
   private slots:
-    void triggerAttributeAction( int index );
-    void triggerMapLayerAction( int index );
+    void triggerAction();
     void reloadActions();
 
   signals:
@@ -126,8 +126,6 @@ class QgsActionMenu : public QMenu
     const QgsFeature* feature();
 
     QgsVectorLayer* mLayer;
-    QSignalMapper* mAttributeActionSignalMapper;
-    QSignalMapper* mMapLayerActionSignalMapper;
     QgsAttributeAction* mActions;
     const QgsFeature* mFeature;
     QgsFeatureId mFeatureId;

--- a/src/gui/qgsattributedialog.cpp
+++ b/src/gui/qgsattributedialog.cpp
@@ -19,9 +19,9 @@
 
 #include "qgsattributeform.h"
 #include "qgshighlight.h"
+#include "qgsactionmenu.h"
 
 #include <QSettings>
-#include <QGridLayout>
 
 
 QgsAttributeDialog::QgsAttributeDialog( QgsVectorLayer* vl, QgsFeature* thepFeature, bool featureOwner, QgsDistanceArea myDa, QWidget* parent, bool showDialogButtons )
@@ -107,6 +107,12 @@ void QgsAttributeDialog::init( QgsVectorLayer* layer, QgsFeature* feature, QgsAt
   QDialogButtonBox* buttonBox = mAttributeForm->findChild<QDialogButtonBox*>();
   connect( buttonBox, SIGNAL( rejected() ), this, SLOT( reject() ) );
   connect( buttonBox, SIGNAL( accepted() ), this, SLOT( accept() ) );
+
+  mMenuBar = new QMenuBar( this );
+  QgsActionMenu* menu = new QgsActionMenu( layer, feature, this );
+  mMenuBar->addMenu( menu );
+  layout()->setMenuBar( mMenuBar );
+
   restoreGeometry();
   focusNextChild();
 }

--- a/src/gui/qgsattributedialog.h
+++ b/src/gui/qgsattributedialog.h
@@ -22,8 +22,8 @@
 #include "qgsattributeform.h"
 
 #include <QDialog>
-
-class QLayout;
+#include <QMenuBar>
+#include <QGridLayout>
 
 class QgsDistanceArea;
 class QgsFeature;
@@ -135,6 +135,7 @@ class GUI_EXPORT QgsAttributeDialog : public QDialog
     bool mShowDialogButtons;
     QString mReturnvarname;
     QgsAttributeForm* mAttributeForm;
+    QMenuBar* mMenuBar;
 
     // true if this dialog is editable
     bool mEditable;

--- a/src/gui/qgsidentifymenu.cpp
+++ b/src/gui/qgsidentifymenu.cpp
@@ -84,7 +84,7 @@ QList<QgsMapToolIdentify::IdentifyResult> QgsIdentifyMenu::exec( const QList<Qgs
   }
 
   // sort results by layer
-  Q_FOREACH( const QgsMapToolIdentify::IdentifyResult result, idResults )
+  Q_FOREACH ( const QgsMapToolIdentify::IdentifyResult result, idResults )
   {
     QgsMapLayer *layer = result.mLayer;
     if ( mLayerIdResults.contains( layer ) )
@@ -190,7 +190,7 @@ void QgsIdentifyMenu::addRasterLayer( QgsMapLayer* layer )
   layerMenu->addAction( identifyFeatureAction );
 
   // add custom/layer actions
-  Q_FOREACH( QgsMapLayerAction* mapLayerAction, layerActions )
+  Q_FOREACH ( QgsMapLayerAction* mapLayerAction, layerActions )
   {
     QAction* action = new QAction( mapLayerAction->icon(), mapLayerAction->text(), layerMenu );
     action->setData( QVariant::fromValue<ActionData>( ActionData( layer, true ) ) );
@@ -281,7 +281,7 @@ void QgsIdentifyMenu::addVectorLayer( QgsVectorLayer* layer, const QList<QgsMapT
 
   // add results to the menu
   int count = 0;
-  Q_FOREACH( const QgsMapToolIdentify::IdentifyResult result, results )
+  Q_FOREACH ( const QgsMapToolIdentify::IdentifyResult result, results )
   {
     if ( mMaxFeatureDisplay != 0 && count > mMaxFeatureDisplay )
       break;
@@ -342,7 +342,7 @@ void QgsIdentifyMenu::addVectorLayer( QgsVectorLayer* layer, const QList<QgsMapT
     featureMenu->addSeparator();
 
     // custom action at feature level
-    Q_FOREACH( QgsMapLayerAction* mapLayerAction, customFeatureActions )
+    Q_FOREACH ( QgsMapLayerAction* mapLayerAction, customFeatureActions )
     {
       QAction* action = new QAction( mapLayerAction->icon(), mapLayerAction->text(), featureMenu );
       action->setData( QVariant::fromValue<ActionData>( ActionData( layer, result.mFeature.id(), mapLayerAction ) ) );
@@ -353,7 +353,7 @@ void QgsIdentifyMenu::addVectorLayer( QgsVectorLayer* layer, const QList<QgsMapT
     // use QgsActionMenu for feature actions
     if ( featureActionMenu )
     {
-      Q_FOREACH( QAction* action, featureActionMenu->actions() )
+      Q_FOREACH ( QAction* action, featureActionMenu->actions() )
       {
         connect( action, SIGNAL( hovered() ), this, SLOT( handleMenuHover() ) );
         featureMenu->addAction( action );
@@ -374,7 +374,7 @@ void QgsIdentifyMenu::addVectorLayer( QgsVectorLayer* layer, const QList<QgsMapT
   }
 
   // add custom/layer actions
-  Q_FOREACH( QgsMapLayerAction* mapLayerAction, layerActions )
+  Q_FOREACH ( QgsMapLayerAction* mapLayerAction, layerActions )
   {
     QString title = mapLayerAction->text();
     if ( mapLayerAction->targets().testFlag( QgsMapLayerAction::MultipleFeatures ) )
@@ -414,7 +414,7 @@ void QgsIdentifyMenu::triggerMapLayerAction()
     if ( actData.mMapLayerAction->targets().testFlag( QgsMapLayerAction::MultipleFeatures ) )
     {
       QList<const QgsFeature*> featureList;
-      Q_FOREACH( QgsMapToolIdentify::IdentifyResult result, mLayerIdResults[actData.mLayer] )
+      Q_FOREACH ( QgsMapToolIdentify::IdentifyResult result, mLayerIdResults[actData.mLayer] )
       {
         featureList << new QgsFeature( result.mFeature );
       }
@@ -424,7 +424,7 @@ void QgsIdentifyMenu::triggerMapLayerAction()
     // single feature
     if ( actData.mMapLayerAction->targets().testFlag( QgsMapLayerAction::SingleFeature ) )
     {
-      Q_FOREACH( QgsMapToolIdentify::IdentifyResult result, mLayerIdResults[actData.mLayer] )
+      Q_FOREACH ( QgsMapToolIdentify::IdentifyResult result, mLayerIdResults[actData.mLayer] )
       {
         if ( result.mFeature.id() == actData.mFeatureId )
         {
@@ -510,7 +510,7 @@ QList<QgsMapToolIdentify::IdentifyResult> QgsIdentifyMenu::results( QAction* act
 
   if ( actData.mLevel == FeatureLevel )
   {
-    Q_FOREACH( QgsMapToolIdentify::IdentifyResult res, mLayerIdResults[actData.mLayer] )
+    Q_FOREACH ( QgsMapToolIdentify::IdentifyResult res, mLayerIdResults[actData.mLayer] )
     {
       if ( res.mFeature.id() == actData.mFeatureId )
       {
@@ -538,7 +538,7 @@ void QgsIdentifyMenu::handleMenuHover()
   bool externalAction;
   QList<QgsMapToolIdentify::IdentifyResult> idResults = results( senderAction, externalAction );
 
-  Q_FOREACH( const QgsMapToolIdentify::IdentifyResult result, idResults )
+  Q_FOREACH ( const QgsMapToolIdentify::IdentifyResult result, idResults )
   {
     QgsVectorLayer* vl = qobject_cast<QgsVectorLayer*>( result.mLayer );
     if ( !vl )
@@ -576,5 +576,8 @@ void QgsIdentifyMenu::layerDestroyed()
   }
 }
 
+void QgsIdentifyMenu::removeCustomActions()
+{
+  mCustomActionRegistry.clear();
 
-
+}

--- a/src/gui/qgsidentifymenu.cpp
+++ b/src/gui/qgsidentifymenu.cpp
@@ -1,0 +1,580 @@
+/***************************************************************************
+    qgsidentifymenu.cpp  -  menu to be used in identify map tool
+    ---------------------
+    begin                : August 2014
+    copyright            : (C) 2014 by Denis Rouzaud
+    email                : denis.rouzaud@gmail.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <QMouseEvent>
+
+#include "qgsidentifymenu.h"
+
+#include "qgsapplication.h"
+#include "qgsattributeaction.h"
+#include "qgshighlight.h"
+
+QgsIdentifyMenu::CustomActionRegistry::CustomActionRegistry( QObject* parent )
+    : QgsMapLayerActionRegistry( parent )
+{
+}
+
+
+QgsIdentifyMenu::QgsIdentifyMenu( QgsMapCanvas* canvas )
+    : QMenu( canvas )
+    , mCanvas( canvas )
+    , mAllowMultipleReturn( true )
+    , mExecWithSingleResult( false )
+    , mResultsIfExternalAction( false )
+    , mMaxLayerDisplay( 10 )
+    , mMaxFeatureDisplay( 10 )
+    , mDefaultActionName( tr( "Identify" ) )
+    , mCustomActionRegistry( CustomActionRegistry::instance() )
+{
+}
+
+QgsIdentifyMenu::~QgsIdentifyMenu()
+{
+  deleteRubberBands();
+}
+
+
+void QgsIdentifyMenu::setMaxLayerDisplay( int maxLayerDisplay )
+{
+  if ( maxLayerDisplay < 0 )
+  {
+    QgsDebugMsg( "invalid value for number of layers displayed." );
+  }
+  mMaxLayerDisplay = maxLayerDisplay;
+}
+
+
+void QgsIdentifyMenu::setMaxFeatureDisplay( int maxFeatureDisplay )
+{
+  if ( maxFeatureDisplay < 0 )
+  {
+    QgsDebugMsg( "invalid value for number of layers displayed." );
+  }
+  mMaxFeatureDisplay = maxFeatureDisplay;
+}
+
+
+QList<QgsMapToolIdentify::IdentifyResult> QgsIdentifyMenu::exec( const QList<QgsMapToolIdentify::IdentifyResult> idResults, QPoint pos )
+{
+  clear();
+  mLayerIdResults.clear();
+
+  QList<QgsMapToolIdentify::IdentifyResult> returnResults = QList<QgsMapToolIdentify::IdentifyResult>();
+
+  if ( idResults.count() == 0 )
+  {
+    return returnResults;
+  }
+  if ( idResults.count() == 1 && !mExecWithSingleResult )
+  {
+    returnResults << idResults[0];
+    return returnResults;
+  }
+
+  // sort results by layer
+  Q_FOREACH( const QgsMapToolIdentify::IdentifyResult result, idResults )
+  {
+    QgsMapLayer *layer = result.mLayer;
+    if ( mLayerIdResults.contains( layer ) )
+    {
+      mLayerIdResults[layer].append( result );
+    }
+    else
+    {
+      mLayerIdResults.insert( layer, QList<QgsMapToolIdentify::IdentifyResult>() << result );
+    }
+  }
+
+  // add results to the menu
+  int count = 0;
+  QMapIterator< QgsMapLayer*, QList<QgsMapToolIdentify::IdentifyResult> > it( mLayerIdResults ) ;
+  while ( it.hasNext() )
+  {
+    if ( mMaxLayerDisplay != 0 && count > mMaxLayerDisplay )
+      break;
+    ++count;
+    it.next();
+    QgsMapLayer* layer = it.key();
+    if ( layer->type() == QgsMapLayer::RasterLayer )
+    {
+      addRasterLayer( layer );
+    }
+    else if ( layer->type() == QgsMapLayer::VectorLayer )
+    {
+      QgsVectorLayer* vl = qobject_cast<QgsVectorLayer*>( layer );
+      if ( !vl )
+        continue;
+      addVectorLayer( vl, it.value() );
+    }
+  }
+
+  // add an "identify all" action on the top level
+  if ( mAllowMultipleReturn && idResults.count() > 1 )
+  {
+    addSeparator();
+    QAction* allAction = new QAction( tr( "%1 for all (%2)" ).arg( mDefaultActionName ).arg( idResults.count() ), this );
+    allAction->setData( QVariant::fromValue<ActionData>( ActionData( 0 ) ) );
+    connect( allAction, SIGNAL( hovered() ), this, SLOT( handleMenuHover() ) );
+    addAction( allAction );
+  }
+
+  // exec
+  QAction* selectedAction = QMenu::exec( pos );
+  bool externalAction;
+  returnResults = results( selectedAction, externalAction );
+
+  if ( externalAction && !mResultsIfExternalAction )
+    return QList<QgsMapToolIdentify::IdentifyResult>();
+
+  return returnResults;
+}
+
+void QgsIdentifyMenu::addRasterLayer( QgsMapLayer* layer )
+{
+  QAction* layerAction;
+  QMenu* layerMenu = 0;
+
+  QList<QgsMapLayerAction*> separators = QList<QgsMapLayerAction*>();
+  QList<QgsMapLayerAction*> layerActions = mCustomActionRegistry.mapLayerActions( layer, QgsMapLayerAction::Layer );
+  int nCustomActions = layerActions.count();
+  if ( nCustomActions )
+  {
+    separators.append( layerActions[0] );
+  }
+  if ( mShowFeatureActions )
+  {
+    layerActions.append( QgsMapLayerActionRegistry::instance()->mapLayerActions( layer, QgsMapLayerAction::Layer ) );
+    if ( layerActions.count() > nCustomActions )
+    {
+      separators.append( layerActions[nCustomActions] );
+    }
+  }
+
+  // use a menu only if actions will be listed
+  if ( !layerActions.count() )
+  {
+    layerAction = new QAction( layer->name(), this );
+  }
+  else
+  {
+    layerMenu = new QMenu( layer->name(), this );
+    layerAction = layerMenu->menuAction();
+  }
+
+  // add layer action to the top menu
+  layerAction->setIcon( QgsApplication::getThemeIcon( "/mIconRasterLayer.png" ) );
+  layerAction->setData( QVariant::fromValue<ActionData>( ActionData( layer ) ) );
+  connect( layerAction, SIGNAL( hovered() ), this, SLOT( handleMenuHover() ) );
+  addAction( layerAction );
+
+  // no need to go further if there is no menu
+  if ( !layerMenu )
+    return;
+
+  // add default identify action
+  QAction* identifyFeatureAction = new QAction( mDefaultActionName, layerMenu );
+  connect( identifyFeatureAction, SIGNAL( hovered() ), this, SLOT( handleMenuHover() ) );
+  identifyFeatureAction->setData( QVariant::fromValue<ActionData>( ActionData( layer ) ) );
+  layerMenu->addAction( identifyFeatureAction );
+
+  // add custom/layer actions
+  Q_FOREACH( QgsMapLayerAction* mapLayerAction, layerActions )
+  {
+    QAction* action = new QAction( mapLayerAction->icon(), mapLayerAction->text(), layerMenu );
+    action->setData( QVariant::fromValue<ActionData>( ActionData( layer, true ) ) );
+    connect( action, SIGNAL( hovered() ), this, SLOT( handleMenuHover() ) );
+    connect( action, SIGNAL( triggered() ), this, SLOT( triggerMapLayerAction() ) );
+    layerMenu->addAction( action );
+    if ( separators.contains( mapLayerAction ) )
+    {
+      layerMenu->insertSeparator( action );
+    }
+  }
+}
+
+void QgsIdentifyMenu::addVectorLayer( QgsVectorLayer* layer, const QList<QgsMapToolIdentify::IdentifyResult> results )
+{
+  QAction* layerAction;
+  QMenu* layerMenu = 0;
+
+  // do not add actions for multiple results if only 1
+  QgsMapLayerAction::Targets targets = results.count() > 1 ? QgsMapLayerAction::Layer | QgsMapLayerAction::MultipleFeatures : QgsMapLayerAction::Layer;
+
+  QList<QgsMapLayerAction*> separators = QList<QgsMapLayerAction*>();
+  QList<QgsMapLayerAction*> layerActions = mCustomActionRegistry.mapLayerActions( layer, targets );
+  int nCustomActions = layerActions.count();
+  if ( nCustomActions )
+  {
+    separators << layerActions[0];
+  }
+  if ( mShowFeatureActions )
+  {
+    layerActions << QgsMapLayerActionRegistry::instance()->mapLayerActions( layer, targets ) ;
+
+    if ( layerActions.count() > nCustomActions )
+    {
+      separators << layerActions[nCustomActions];
+    }
+  }
+  bool createMenu = results.count() > 1 || layerActions.count() > 0;
+
+  // still create a menu for layer, if there is a sub-level for features
+  // i.e custom actions or map layer actions at feature level
+  if ( !createMenu )
+  {
+    createMenu = mCustomActionRegistry.mapLayerActions( layer, QgsMapLayerAction::SingleFeature ).count() > 0;
+    if ( !createMenu && mShowFeatureActions )
+    {
+      QgsActionMenu* featureActionMenu = new QgsActionMenu( layer, &( results[0].mFeature ), this );
+      createMenu  = featureActionMenu->actions().count() > 0 ;
+      delete featureActionMenu;
+    }
+  }
+
+  // use a menu only if actions will be listed
+  if ( !createMenu )
+  {
+    layerAction = new QAction( layer->name(), this );
+  }
+  else
+  {
+    layerMenu = new QMenu( layer->name(), this );
+    layerAction = layerMenu->menuAction();
+  }
+
+  // icons
+  switch ( layer->geometryType() )
+  {
+    case QGis::Point:
+      layerAction->setIcon( QgsApplication::getThemeIcon( "/mIconPointLayer.png" ) );
+      break;
+    case QGis::Line:
+      layerAction->setIcon( QgsApplication::getThemeIcon( "/mIconLineLayer.png" ) );
+      break;
+    case QGis::Polygon:
+      layerAction->setIcon( QgsApplication::getThemeIcon( "/mIconPolygonLayer.png" ) );
+      break;
+    default:
+      break;
+  }
+
+  // add layer action to the top menu
+  layerAction->setData( QVariant::fromValue<ActionData>( ActionData( layer ) ) );
+  connect( layerAction, SIGNAL( hovered() ), this, SLOT( handleMenuHover() ) );
+  addAction( layerAction );
+
+  // no need to go further if there is no menu
+  if ( !layerMenu )
+    return;
+
+  // add results to the menu
+  int count = 0;
+  Q_FOREACH( const QgsMapToolIdentify::IdentifyResult result, results )
+  {
+    if ( mMaxFeatureDisplay != 0 && count > mMaxFeatureDisplay )
+      break;
+    ++count;
+
+    QAction* featureAction = 0;
+    QMenu* featureMenu = 0;
+    QgsActionMenu* featureActionMenu = 0;
+
+    QList<QgsMapLayerAction*> customFeatureActions = mCustomActionRegistry.mapLayerActions( layer, QgsMapLayerAction::SingleFeature );
+    if ( mShowFeatureActions )
+    {
+      featureActionMenu = new QgsActionMenu( layer, &( result.mFeature ), this );
+    }
+
+    // feature title
+    QString featureTitle = result.mFeature.attribute( layer->displayField() ).toString();
+    if ( featureTitle.isEmpty() )
+      featureTitle = result.mFeature.id();
+
+    if ( !customFeatureActions.count() && ( !featureActionMenu || !featureActionMenu->actions().count() ) )
+    {
+      featureAction = new QAction( featureTitle, layerMenu );
+      // add the feature action (or menu) to the layer menu
+      featureAction->setData( QVariant::fromValue<ActionData>( ActionData( layer, result.mFeature.id() ) ) );
+      connect( featureAction, SIGNAL( hovered() ), this, SLOT( handleMenuHover() ) );
+      layerMenu->addAction( featureAction );
+    }
+    else if ( results.count() == 1 )
+    {
+      // if we are here with only one results, this means there is a sub-feature level (for actions)
+      // => skip the feature level since there would be only a single entry
+      // => give the layer menu as pointer instead of a new feature menu
+      featureAction = layerAction;
+      featureMenu = layerMenu;
+    }
+    else
+    {
+      featureMenu = new QMenu( featureTitle, layerMenu );
+
+      // get the action from the menu
+      featureAction = featureMenu->menuAction();
+      // add the feature action (or menu) to the layer menu
+      featureAction->setData( QVariant::fromValue<ActionData>( ActionData( layer, result.mFeature.id() ) ) );
+      connect( featureAction, SIGNAL( hovered() ), this, SLOT( handleMenuHover() ) );
+      layerMenu->addAction( featureAction );
+    }
+
+    // if no feature menu, no need to go further
+    if ( !featureMenu )
+      continue;
+
+    // add default identify action
+    QAction* identifyFeatureAction = new QAction( mDefaultActionName, featureMenu );
+    connect( identifyFeatureAction, SIGNAL( hovered() ), this, SLOT( handleMenuHover() ) );
+    identifyFeatureAction->setData( QVariant::fromValue<ActionData>( ActionData( layer, result.mFeature.id() ) ) );
+    featureMenu->addAction( identifyFeatureAction );
+    featureMenu->addSeparator();
+
+    // custom action at feature level
+    Q_FOREACH( QgsMapLayerAction* mapLayerAction, customFeatureActions )
+    {
+      QAction* action = new QAction( mapLayerAction->icon(), mapLayerAction->text(), featureMenu );
+      action->setData( QVariant::fromValue<ActionData>( ActionData( layer, result.mFeature.id(), mapLayerAction ) ) );
+      connect( action, SIGNAL( hovered() ), this, SLOT( handleMenuHover() ) );
+      connect( action, SIGNAL( triggered() ), this, SLOT( triggerMapLayerAction() ) );
+      featureMenu->addAction( action );
+    }
+    // use QgsActionMenu for feature actions
+    if ( featureActionMenu )
+    {
+      Q_FOREACH( QAction* action, featureActionMenu->actions() )
+      {
+        connect( action, SIGNAL( hovered() ), this, SLOT( handleMenuHover() ) );
+        featureMenu->addAction( action );
+      }
+    }
+  }
+
+  // back to layer level
+
+  // identify all action
+  if ( mAllowMultipleReturn && results.count() > 1 )
+  {
+    layerMenu->addSeparator();
+    QAction* allAction = new QAction( tr( "%1 for all (%2)" ).arg( mDefaultActionName ).arg( results.count() ), layerMenu );
+    allAction->setData( QVariant::fromValue<ActionData>( ActionData( layer ) ) );
+    connect( allAction, SIGNAL( hovered() ), this, SLOT( handleMenuHover() ) );
+    layerMenu->addAction( allAction );
+  }
+
+  // add custom/layer actions
+  Q_FOREACH( QgsMapLayerAction* mapLayerAction, layerActions )
+  {
+    QString title = mapLayerAction->text();
+    if ( mapLayerAction->targets().testFlag( QgsMapLayerAction::MultipleFeatures ) )
+      title.append( QString( " (%1)" ).arg( results.count() ) );
+    QAction* action = new QAction( mapLayerAction->icon(), title, layerMenu );
+    action->setData( QVariant::fromValue<ActionData>( ActionData( layer, mapLayerAction ) ) );
+    connect( action, SIGNAL( hovered() ), this, SLOT( handleMenuHover() ) );
+    connect( action, SIGNAL( triggered() ), this, SLOT( triggerMapLayerAction() ) );
+    layerMenu->addAction( action );
+    if ( separators.contains( mapLayerAction ) )
+    {
+      layerMenu->insertSeparator( action );
+    }
+  }
+}
+
+void QgsIdentifyMenu::triggerMapLayerAction()
+{
+  QAction* action = qobject_cast<QAction*>( sender() );
+  if ( !action )
+    return;
+  QVariant varData = action->data();
+  if ( !varData.isValid() || !varData.canConvert<ActionData>() )
+    return;
+
+  ActionData actData = action->data().value<ActionData>();
+
+  if ( actData.mIsValid && actData.mMapLayerAction )
+  {
+    // layer
+    if ( actData.mMapLayerAction->targets().testFlag( QgsMapLayerAction::Layer ) )
+    {
+      actData.mMapLayerAction->triggerForLayer( actData.mLayer );
+    }
+
+    // multiples features
+    if ( actData.mMapLayerAction->targets().testFlag( QgsMapLayerAction::MultipleFeatures ) )
+    {
+      QList<const QgsFeature*> featureList;
+      Q_FOREACH( QgsMapToolIdentify::IdentifyResult result, mLayerIdResults[actData.mLayer] )
+      {
+        featureList << new QgsFeature( result.mFeature );
+      }
+      actData.mMapLayerAction->triggerForFeatures( actData.mLayer, featureList );
+    }
+
+    // single feature
+    if ( actData.mMapLayerAction->targets().testFlag( QgsMapLayerAction::SingleFeature ) )
+    {
+      Q_FOREACH( QgsMapToolIdentify::IdentifyResult result, mLayerIdResults[actData.mLayer] )
+      {
+        if ( result.mFeature.id() == actData.mFeatureId )
+        {
+          actData.mMapLayerAction->triggerForFeature( actData.mLayer, new QgsFeature( result.mFeature ) );
+          return;
+        }
+      }
+      QgsDebugMsg( QString( "Identify menu: could not retrieve feature for action %1" ).arg( action->text() ) );
+    }
+  }
+}
+
+
+QList<QgsMapToolIdentify::IdentifyResult> QgsIdentifyMenu::results( QAction* action, bool &externalAction )
+{
+  QList<QgsMapToolIdentify::IdentifyResult> idResults = QList<QgsMapToolIdentify::IdentifyResult>();
+
+  externalAction = false;
+
+  ActionData actData;
+  bool hasData = false;
+
+  if ( !action )
+    return idResults;
+
+  QVariant varData = action->data();
+  if ( !varData.isValid() )
+  {
+    QgsDebugMsg( "Identify menu: could not retrieve results from menu entry (invalid data)" );
+    return idResults;
+  }
+
+  if ( varData.canConvert<ActionData>() )
+  {
+    actData = action->data().value<ActionData>();
+    if ( actData.mIsValid )
+    {
+      externalAction = actData.mIsExternalAction;
+      hasData = true;
+    }
+  }
+
+  if ( !hasData && varData.canConvert<QgsActionMenu::ActionData>() )
+  {
+    QgsActionMenu::ActionData dataSrc = action->data().value<QgsActionMenu::ActionData>();
+    if ( dataSrc.actionType != QgsActionMenu::Invalid )
+    {
+      externalAction = true;
+      actData = ActionData( dataSrc.mapLayer, dataSrc.featureId );
+      hasData = true;
+    }
+  }
+
+  if ( !hasData )
+  {
+    QgsDebugMsg( "Identify menu: could not retrieve results from menu entry (no data found)" );
+    return idResults;
+  }
+
+  // return all results
+  if ( actData.mAllResults )
+  {
+    // this means "All" action was triggered
+    QMapIterator< QgsMapLayer*, QList<QgsMapToolIdentify::IdentifyResult> > it( mLayerIdResults ) ;
+    while ( it.hasNext() )
+    {
+      it.next();
+      idResults << it.value();
+    }
+    return idResults;
+  }
+
+  if ( !mLayerIdResults.contains( actData.mLayer ) )
+  {
+    QgsDebugMsg( "Identify menu: could not retrieve results from menu entry (layer not found)" );
+    return idResults;
+  }
+
+  if ( actData.mLevel == LayerLevel )
+  {
+    return mLayerIdResults[actData.mLayer];
+  }
+
+  if ( actData.mLevel == FeatureLevel )
+  {
+    Q_FOREACH( QgsMapToolIdentify::IdentifyResult res, mLayerIdResults[actData.mLayer] )
+    {
+      if ( res.mFeature.id() == actData.mFeatureId )
+      {
+        idResults << res;
+        return idResults;
+      }
+    }
+  }
+
+  QgsDebugMsg( "Identify menu: could not retrieve results from menu entry (don't know what happened')" );
+  return idResults;
+}
+
+void QgsIdentifyMenu::handleMenuHover()
+{
+  if ( !mCanvas )
+    return;
+
+  deleteRubberBands();
+
+  QAction* senderAction = qobject_cast<QAction*>( sender() );
+  if ( !senderAction )
+    return;
+
+  bool externalAction;
+  QList<QgsMapToolIdentify::IdentifyResult> idResults = results( senderAction, externalAction );
+
+  Q_FOREACH( const QgsMapToolIdentify::IdentifyResult result, idResults )
+  {
+    QgsVectorLayer* vl = qobject_cast<QgsVectorLayer*>( result.mLayer );
+    if ( !vl )
+      continue;
+    QgsHighlight *hl = new QgsHighlight( mCanvas, result.mFeature.geometry(), vl );
+    hl->setColor( QColor( 255, 0, 0 ) );
+    hl->setWidth( 2 );
+    mRubberBands.append( hl );
+    connect( vl, SIGNAL( destroyed() ), this, SLOT( layerDestroyed() ) );
+  }
+}
+
+void QgsIdentifyMenu::deleteRubberBands()
+{
+  QList<QgsHighlight*>::const_iterator it = mRubberBands.constBegin();
+  for ( ; it != mRubberBands.constEnd(); ++it )
+    delete *it;
+  mRubberBands.clear();
+}
+
+void QgsIdentifyMenu::layerDestroyed()
+{
+  QList<QgsHighlight*>::iterator it = mRubberBands.begin();
+  while ( it != mRubberBands.end() )
+  {
+    if (( *it )->layer() == sender() )
+    {
+      delete *it;
+      it = mRubberBands.erase( it );
+    }
+    else
+    {
+      ++it;
+    }
+  }
+}
+
+
+

--- a/src/gui/qgsidentifymenu.h
+++ b/src/gui/qgsidentifymenu.h
@@ -1,0 +1,178 @@
+/***************************************************************************
+    qgsidentifymenu.h  -  menu to be used in identify map tool
+    ---------------------
+    begin                : August 2014
+    copyright            : (C) 2014 by Denis Rouzaud
+    email                : denis.rouzaud@gmail.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSIDENTIFYMENU_H
+#define QGSIDENTIFYMENU_H
+
+#include <QMenu>
+
+#include "qgsactionmenu.h"
+#include "qgsmapcanvas.h"
+#include "qgsmaptoolidentify.h"
+#include "qgsvectorlayer.h"
+
+/**
+ * @brief The QgsIdentifyMenu class builds a menu to be used with identify results (@see QgsMapToolIdentify).
+ * It is customizable and can display attribute actions (@see QgsAttributeAction) as well as map layer actions (@see QgsMapLayerAction).
+ * It can also embed custom map layer actions, defined for this menu exclusively.
+ * If used in a QgsMapToolIdentify, it is accessible via QgsMapToolIdentify::identifyMenu() and can be customized in the map tool sub-class.
+ */
+class GUI_EXPORT QgsIdentifyMenu : public QMenu
+{
+
+    Q_OBJECT
+
+  public:
+    enum MenuLevel
+    {
+      LayerLevel,
+      FeatureLevel
+    };
+
+    struct ActionData
+    {
+      ActionData()
+          : mIsValid( false )
+      {}
+
+      ActionData( QgsMapLayer* layer, QgsMapLayerAction* mapLayerAction = 0 )
+          : mIsValid( true )
+          , mAllResults( layer == 0 )
+          , mIsExternalAction( mapLayerAction != 0 )
+          , mLayer( layer )
+          , mLevel( LayerLevel )
+          , mMapLayerAction( mapLayerAction )
+      {}
+
+      ActionData( QgsMapLayer* layer, QgsFeatureId fid, QgsMapLayerAction* mapLayerAction = 0 )
+          : mIsValid( true )
+          , mAllResults( false )
+          , mIsExternalAction( mapLayerAction != 0 )
+          , mLayer( layer )
+          , mFeatureId( fid )
+          , mLevel( FeatureLevel )
+          , mMapLayerAction( mapLayerAction )
+      {}
+
+      bool mIsValid;
+      bool mAllResults;
+      bool mIsExternalAction;
+      QgsMapLayer* mLayer;
+      QgsFeatureId mFeatureId;
+      MenuLevel mLevel;
+      QgsMapLayerAction* mMapLayerAction;
+    };
+
+    /**
+     * @brief QgsIdentifyMenu is a menu to be used to choose within a list of QgsMapTool::IdentifyReults
+     */
+    explicit QgsIdentifyMenu( QgsMapCanvas* canvas );
+
+    ~QgsIdentifyMenu();
+
+    //! define if the menu executed can return multiple results (e.g. all results or all identified features of a vector layer)
+    void setAllowMultipleReturn( bool multipleReturn ) { mAllowMultipleReturn = multipleReturn;}
+    bool allowMultipleReturn() { return mAllowMultipleReturn;}
+
+    //! define if the menu will be shown with a single idetify result
+    void setExecWithSingleResult( bool execWithSingleResult ) { mExecWithSingleResult = execWithSingleResult;}
+    bool execWithSingleResult() { return mExecWithSingleResult;}
+
+    /**
+     * @brief define if attribute actions(1) and map layer actions(2) can be listed and run from the menu
+     * @note custom actions will be shown in any case if they exist.
+     * @note (1) attribute actions are defined by the user in the layer properties @see QgsAttributeAction
+     * @note (2) map layer actions are built-in c++ actions or actions which are defined by a python plugin @see QgsMapLayerActionRegistry
+     */
+    void setShowFeatureActions( bool showFeatureActions ) { mShowFeatureActions = showFeatureActions; }
+    bool showFeatureActions() { return mShowFeatureActions;}
+
+    /**
+     * @brief setResultsIfExternalAction if set to false (default) the menu will not return any results if an external action has been triggered
+     * @note external action can be either custom actions or feature / map layer actions (@see setShowFeatureActions)
+     */
+    void setResultsIfExternalAction( bool resultsIfExternalAction ) {mResultsIfExternalAction = resultsIfExternalAction;}
+    bool resultsIfExternalAction() {return mResultsIfExternalAction;}
+
+    //! Defines the maximimum number of layers displayed in the menu (default is 10).
+    //! @note 0 is unlimited.
+    void setMaxLayerDisplay( int maxLayerDisplay );
+    int maxLayerDisplay() {return mMaxLayerDisplay;}
+
+    //! Defines the maximimum number of features displayed in the menu for vector layers (default is 10).
+    //! @note 0 is unlimited.
+    void setMaxFeatureDisplay( int maxFeatureDisplay );
+    int maxFeatureDisplay() {return mMaxFeatureDisplay;}
+
+    //! adds a new custom action to the menu
+    void addCustomAction( QgsMapLayerAction* action ) {mCustomActionRegistry.addMapLayerAction( action );}
+
+    //! remove all custom actions from the menu to be built
+    void removeCustomActions() {mCustomActionRegistry.clear();}
+
+    /**
+     * @brief exec
+     * @param idResults the list of identify results to choose within
+     * @param pos the position where the menu will be executed
+     * @param selectedAction if specified, this will allow to know which action has been triggered
+     */
+    QList<QgsMapToolIdentify::IdentifyResult> exec( const QList<QgsMapToolIdentify::IdentifyResult> idResults, QPoint pos );
+
+  private slots:
+    void handleMenuHover();
+    void deleteRubberBands();
+    void layerDestroyed();
+    void triggerMapLayerAction();
+
+  private:
+    class CustomActionRegistry : public QgsMapLayerActionRegistry
+    {
+      public:
+        explicit CustomActionRegistry( QObject *parent );
+        // remove all actions
+        void clear() {mMapLayerActionList.clear();}
+    };
+
+    //! adds a raster layer in the menu being built
+    void addRasterLayer( QgsMapLayer* layer );
+
+    //! adds a vector layer and its results in the menu being built
+    void addVectorLayer( QgsVectorLayer* layer, const QList<QgsMapToolIdentify::IdentifyResult> results );
+
+    //! get the lists of results corresponding to an action in the menu
+    QList<QgsMapToolIdentify::IdentifyResult> results( QAction* action, bool& externalAction );
+
+    QgsMapCanvas* mCanvas;
+    QList<QgsHighlight*> mRubberBands;
+    bool mAllowMultipleReturn;
+    bool mExecWithSingleResult;
+    bool mShowFeatureActions;
+    bool mResultsIfExternalAction;
+    int mMaxLayerDisplay;
+    int mMaxFeatureDisplay;
+
+    // name of the action to be displayed for feature default action, if other actions are shown
+    QString mDefaultActionName;
+
+    // custom menu actions regirstry
+    CustomActionRegistry mCustomActionRegistry;
+
+    // map layers with their results, this is the odering of the menu
+    QMap <QgsMapLayer*, QList<QgsMapToolIdentify::IdentifyResult> > mLayerIdResults;
+};
+
+Q_DECLARE_METATYPE( QgsIdentifyMenu::ActionData )
+
+#endif // QGSIDENTIFYMENU_H

--- a/src/gui/qgsidentifymenu.h
+++ b/src/gui/qgsidentifymenu.h
@@ -120,7 +120,7 @@ class GUI_EXPORT QgsIdentifyMenu : public QMenu
     void addCustomAction( QgsMapLayerAction* action ) {mCustomActionRegistry.addMapLayerAction( action );}
 
     //! remove all custom actions from the menu to be built
-    void removeCustomActions() {mCustomActionRegistry.clear();}
+    void removeCustomActions();
 
     /**
      * @brief exec

--- a/src/gui/qgsmaplayeractionregistry.h
+++ b/src/gui/qgsmaplayeractionregistry.h
@@ -131,6 +131,8 @@ class GUI_EXPORT QgsMapLayerActionRegistry : public QObject
     //! protected constructor
     QgsMapLayerActionRegistry( QObject * parent = 0 );
 
+    QList< QgsMapLayerAction* > mMapLayerActionList;
+
   signals:
     /** Triggered when an action is added or removed from the registry */
     void changed();
@@ -138,8 +140,6 @@ class GUI_EXPORT QgsMapLayerActionRegistry : public QObject
   private:
 
     static QgsMapLayerActionRegistry *mInstance;
-
-    QList< QgsMapLayerAction* > mMapLayerActionList;
 
     QMap< QgsMapLayer*, QgsMapLayerAction* > mDefaultLayerActionMap;
 

--- a/src/gui/qgsmaptoolidentify.cpp
+++ b/src/gui/qgsmaptoolidentify.cpp
@@ -56,6 +56,7 @@ QgsMapToolIdentify::QgsMapToolIdentify( QgsMapCanvas* canvas )
 
 QgsMapToolIdentify::~QgsMapToolIdentify()
 {
+  delete mIdentifyMenu;
 }
 
 void QgsMapToolIdentify::canvasMoveEvent( QMouseEvent * e )
@@ -168,6 +169,7 @@ void QgsMapToolIdentify::activate()
 
 void QgsMapToolIdentify::deactivate()
 {
+
   QgsMapTool::deactivate();
 }
 

--- a/src/ui/qgsattributeactiondialogbase.ui
+++ b/src/ui/qgsattributeactiondialogbase.ui
@@ -291,6 +291,13 @@
        </widget>
       </item>
       <item row="2" column="0">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Icon</string>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="0">
        <widget class="QLabel" name="textLabel2">
         <property name="whatsThis">
          <string>Enter the action here. This can be any program, script or command that is available on your system. When the action is invoked any set of characters that start with a % and then have the name of a field will be replaced by the value of that field. The special characters %% will be replaced by the value of the field that was selected. Double quote marks group text into single arguments to the program, script or command. Double quotes will be ignored if prefixed with a backslash</string>
@@ -303,7 +310,7 @@
         </property>
        </widget>
       </item>
-      <item row="2" column="1">
+      <item row="3" column="1">
        <layout class="QGridLayout" name="gridLayout_4">
         <item row="0" column="1">
          <widget class="QToolButton" name="browseButton">
@@ -356,7 +363,7 @@
         </item>
        </layout>
       </item>
-      <item row="3" column="1">
+      <item row="4" column="1">
        <layout class="QHBoxLayout" name="horizontalLayout_2">
         <item>
          <widget class="QPushButton" name="insertExpressionButton">
@@ -415,7 +422,7 @@
         </item>
        </layout>
       </item>
-      <item row="4" column="0" colspan="2">
+      <item row="5" column="0" colspan="2">
        <layout class="QHBoxLayout" name="horizontalLayout_3">
         <item>
          <spacer name="horizontalSpacer">
@@ -450,6 +457,39 @@
           </property>
           <property name="text">
            <string>Update selected action</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
+      </item>
+      <item row="2" column="1">
+       <layout class="QHBoxLayout" name="horizontalLayout_5">
+        <item>
+         <widget class="QLabel" name="iconPreview">
+          <property name="sizePolicy">
+           <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+            <horstretch>24</horstretch>
+            <verstretch>24</verstretch>
+           </sizepolicy>
+          </property>
+          <property name="minimumSize">
+           <size>
+            <width>24</width>
+            <height>24</height>
+           </size>
+          </property>
+          <property name="text">
+           <string/>
+          </property>
+         </widget>
+        </item>
+        <item>
+         <widget class="QLineEdit" name="actionIcon"/>
+        </item>
+        <item>
+         <widget class="QToolButton" name="chooseIconButton">
+          <property name="text">
+           <string>...</string>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
This improves a bit the menu displayed in identify map tool with the "Layer Selection" mode.

Now, the menu allows choosing between features if several features are found for the same layer.
Also, you can open the attribute table for the features of the same layer.

If launched with right-click, the menu will also display attribute and map layer actions (such as "set atlas feature").

The menu has the following hierarchy:
- At top level:
  - layer names
  - identify all
- At layer level:
  - list all features
  - map layer actions for layer or multiple features (such as show attribute table)
- At feature level:
  - standard identify action
  - attribute action
  - map layer action for single feature

Generally, the menu is "mouse-move-saving": you won't have a level displayed if it's not necessary. For example:
- if a single feature is found for a layer and attribute/map layer actions are not displayed (left click), you will be able to click on the top level. This is basically as it is done now.
- if left click, the feature level will not be shown, so you will click on the feature at the layer level.
- if attribute/map layer actions are shown and found (right-click) and a single feature is identified for the layer, the layer level will be skipped and the feature level will be shown directly under the top level.

The new QgsIdentifyMenu is (highly) customizable. It should be easy to reuse it in plugins by subclassing QgsMapToolIdentify, set the LayerSelection mode and access it with identifyMenu().
Custom actions (as QgsMapLayerAction) can be easily added. (This is done in app/QgsMapToolIdentifyAction to add the "Show attribute table action").

This PR also adds a QgsActionMenu which creates a menu for a combination of layer/feature and lists attribute and map layer actions.

I have troubles at running actions at feature level (such as "set atlas feature"), I expect this to be solved soon. 

Anyway, the menu is displayed properly, so you can easily test the menu to see if it's working as you expect. 
