### PR TITLE
new edit widget for date/time capable of setting null dates

### DIFF
--- a/python/gui/gui.sip
+++ b/python/gui/gui.sip
@@ -39,6 +39,7 @@
 %Include qgscolorschemelist.sip
 %Include qgscomposerview.sip
 %Include qgscredentialdialog.sip
+%Include qgsdatetimeedit.sip
 %Include qgsdetaileditemdata.sip
 %Include qgsdetaileditemdelegate.sip
 %Include qgsdialog.sip

--- a/python/gui/qgsdatetimeedit.sip
+++ b/python/gui/qgsdatetimeedit.sip
@@ -1,0 +1,38 @@
+
+class QgsDateTimeEdit : QDateTimeEdit
+{
+
+%TypeHeaderCode
+#include "qgsdatetimeedit.h"
+%End
+
+
+  public:
+    explicit QgsDateTimeEdit( QWidget *parent /TransferThis/ = 0 );
+
+    //! determines if the widget allows setting null date/time.
+    void setAllowNull( bool allowNull );
+    bool allowNull() const;
+
+    /**
+     * @brief setDateTime set the date time in the widget and handles null date times.
+     * @note since QDateTimeEdit::setDateTime() is not virtual, setDateTime must be called for QgsDateTimeEdit.
+     */
+    void setDateTime( const QDateTime &dateTime );
+
+    /**
+     * @brief dateTime returns the date time which can eventually be a null date/time
+     * @note since QDateTimeEdit::dateTime() is not virtual, dateTime must be called for QgsDateTimeEdit.
+     */
+    QDateTime dateTime() const;
+
+    //! Set the current date as NULL
+    //! @note if the widget is not configured to accept NULL dates, this will have no effect
+    virtual void clear();
+
+
+  protected:
+    virtual void resizeEvent( QResizeEvent* event );
+
+    void mousePressEvent( QMouseEvent*event );
+};

--- a/src/customwidgets/CMakeLists.txt
+++ b/src/customwidgets/CMakeLists.txt
@@ -18,6 +18,7 @@ SET (QGIS_CUSTOMWIDGETS_SRCS
   qgscollapsiblegroupboxplugin.cpp
   qgscolorbuttonplugin.cpp
   qgscolorbuttonv2plugin.cpp
+  qgsdatetimeeditplugin.cpp
   qgsdatadefinedbuttonplugin.cpp
   qgsfieldcomboboxplugin.cpp
   qgsfieldexpressionwidgetplugin.cpp
@@ -32,6 +33,7 @@ SET (QGIS_CUSTOMWIDGETS_MOC_HDRS
   qgscollapsiblegroupboxplugin.h
   qgscolorbuttonplugin.h
   qgscolorbuttonv2plugin.h
+  qgsdatetimeeditplugin.h
   qgsdatadefinedbuttonplugin.h
   qgsfieldcomboboxplugin.h
   qgsfieldexpressionwidgetplugin.h
@@ -54,6 +56,7 @@ SET(QGIS_CUSTOMWIDGETS_HDRS
   qgscollapsiblegroupboxplugin.h
   qgscolorbuttonplugin.h
   qgscolorbuttonv2plugin.h
+  qgsdatetimeeditplugin.h
   qgsdatadefinedbuttonplugin.h
   qgsfieldcomboboxplugin.h
   qgsfieldexpressionwidgetplugin.h

--- a/src/customwidgets/CMakeLists.txt.user
+++ b/src/customwidgets/CMakeLists.txt.user
@@ -1,0 +1,63 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE QtCreatorProject>
+<!-- Written by QtCreator 3.0.1, 2014-09-01T10:16:06. -->
+<qtcreator>
+ <data>
+  <variable>ProjectExplorer.Project.ActiveTarget</variable>
+  <value type="int">-1</value>
+ </data>
+ <data>
+  <variable>ProjectExplorer.Project.EditorSettings</variable>
+  <valuemap type="QVariantMap">
+   <value type="bool" key="EditorConfiguration.AutoIndent">true</value>
+   <value type="bool" key="EditorConfiguration.AutoSpacesForTabs">false</value>
+   <value type="bool" key="EditorConfiguration.CamelCaseNavigation">true</value>
+   <valuemap type="QVariantMap" key="EditorConfiguration.CodeStyle.0">
+    <value type="QString" key="language">Cpp</value>
+    <valuemap type="QVariantMap" key="value">
+     <value type="QByteArray" key="CurrentPreferences">CppGlobal</value>
+    </valuemap>
+   </valuemap>
+   <valuemap type="QVariantMap" key="EditorConfiguration.CodeStyle.1">
+    <value type="QString" key="language">QmlJS</value>
+    <valuemap type="QVariantMap" key="value">
+     <value type="QByteArray" key="CurrentPreferences">QmlJSGlobal</value>
+    </valuemap>
+   </valuemap>
+   <value type="int" key="EditorConfiguration.CodeStyle.Count">2</value>
+   <value type="QByteArray" key="EditorConfiguration.Codec">UTF-8</value>
+   <value type="bool" key="EditorConfiguration.ConstrainTooltips">false</value>
+   <value type="int" key="EditorConfiguration.IndentSize">4</value>
+   <value type="bool" key="EditorConfiguration.KeyboardTooltips">false</value>
+   <value type="bool" key="EditorConfiguration.MouseNavigation">true</value>
+   <value type="int" key="EditorConfiguration.PaddingMode">1</value>
+   <value type="bool" key="EditorConfiguration.ScrollWheelZooming">true</value>
+   <value type="int" key="EditorConfiguration.SmartBackspaceBehavior">0</value>
+   <value type="bool" key="EditorConfiguration.SpacesForTabs">true</value>
+   <value type="int" key="EditorConfiguration.TabKeyBehavior">0</value>
+   <value type="int" key="EditorConfiguration.TabSize">8</value>
+   <value type="bool" key="EditorConfiguration.UseGlobal">true</value>
+   <value type="int" key="EditorConfiguration.Utf8BomBehavior">1</value>
+   <value type="bool" key="EditorConfiguration.addFinalNewLine">true</value>
+   <value type="bool" key="EditorConfiguration.cleanIndentation">true</value>
+   <value type="bool" key="EditorConfiguration.cleanWhitespace">true</value>
+   <value type="bool" key="EditorConfiguration.inEntireDocument">false</value>
+  </valuemap>
+ </data>
+ <data>
+  <variable>ProjectExplorer.Project.PluginSettings</variable>
+  <valuemap type="QVariantMap"/>
+ </data>
+ <data>
+  <variable>ProjectExplorer.Project.TargetCount</variable>
+  <value type="int">0</value>
+ </data>
+ <data>
+  <variable>ProjectExplorer.Project.Updater.EnvironmentId</variable>
+  <value type="QByteArray">{316279e7-c793-4c38-a9aa-b021b7d95d28}</value>
+ </data>
+ <data>
+  <variable>ProjectExplorer.Project.Updater.FileVersion</variable>
+  <value type="int">15</value>
+ </data>
+</qtcreator>

--- a/src/customwidgets/qgsdatetimeeditplugin.cpp
+++ b/src/customwidgets/qgsdatetimeeditplugin.cpp
@@ -1,0 +1,97 @@
+/***************************************************************************
+   qgsdatetimeeditplugin.cpp
+    --------------------------------------
+   Date                 : 01.09.2014
+   Copyright            : (C) 2014 Denis Rouzaud
+   Email                : denis.rouzaud@gmail.com
+***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************/
+
+#include "qgiscustomwidgets.h"
+#include "qgsdatetimeeditplugin.h"
+#include "qgsdatetimeedit.h"
+
+
+QgsDateTimeEditPlugin::QgsDateTimeEditPlugin( QObject *parent )
+    : QObject( parent )
+    , mInitialized( false )
+{
+}
+
+
+QString QgsDateTimeEditPlugin::name() const
+{
+  return "QgsDateTimeEdit";
+}
+
+QString QgsDateTimeEditPlugin::group() const
+{
+  return QgisCustomWidgets::groupName();
+}
+
+QString QgsDateTimeEditPlugin::includeFile() const
+{
+  return "qgsdatetimeedit.h";
+}
+
+QIcon QgsDateTimeEditPlugin::icon() const
+{
+  return QIcon();
+}
+
+bool QgsDateTimeEditPlugin::isContainer() const
+{
+  return false;
+}
+
+QWidget *QgsDateTimeEditPlugin::createWidget( QWidget *parent )
+{
+  return new QgsDateTimeEdit( parent );
+}
+
+bool QgsDateTimeEditPlugin::isInitialized() const
+{
+  return mInitialized;
+}
+
+void QgsDateTimeEditPlugin::initialize( QDesignerFormEditorInterface *core )
+{
+  Q_UNUSED( core );
+  if ( mInitialized )
+    return;
+  mInitialized = true;
+}
+
+
+QString QgsDateTimeEditPlugin::toolTip() const
+{
+  return tr( "Define date" );
+}
+
+QString QgsDateTimeEditPlugin::whatsThis() const
+{
+  return "";
+}
+
+QString QgsDateTimeEditPlugin::domXml() const
+{
+  return QString( "<ui language=\"c++\">\n"
+                  " <widget class=\"%1\" name=\"mDateTimeEdit\">\n"
+                  "  <property name=\"geometry\">\n"
+                  "   <rect>\n"
+                  "    <x>0</x>\n"
+                  "    <y>0</y>\n"
+                  "    <width>90</width>\n"
+                  "    <height>27</height>\n"
+                  "   </rect>\n"
+                  "  </property>\n"
+                  " </widget>\n"
+                  "</ui>\n" )
+         .arg( name() );
+}

--- a/src/customwidgets/qgsdatetimeeditplugin.h
+++ b/src/customwidgets/qgsdatetimeeditplugin.h
@@ -1,0 +1,48 @@
+/***************************************************************************
+   qgsdatetimeeditplugin.h
+    --------------------------------------
+   Date                 : 01.09.2014
+   Copyright            : (C) 2014 Denis Rouzaud
+   Email                : denis.rouzaud@gmail.com
+***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************/
+
+#ifndef QGSDATETIMEEDITPLUGIN_H
+#define QGSDATETIMEEDITPLUGIN_H
+
+#include <QDesignerExportWidget>
+#include <QDesignerCustomWidgetInterface>
+
+
+class CUSTOMWIDGETS_EXPORT QgsDateTimeEditPlugin : public QObject, public QDesignerCustomWidgetInterface
+{
+    Q_OBJECT
+    Q_INTERFACES( QDesignerCustomWidgetInterface )
+
+  public:
+    explicit QgsDateTimeEditPlugin( QObject *parent = 0 );
+
+  private:
+    bool mInitialized;
+
+    // QDesignerCustomWidgetInterface interface
+  public:
+    QString name() const;
+    QString group() const;
+    QString includeFile() const;
+    QIcon icon() const;
+    bool isContainer() const;
+    QWidget *createWidget( QWidget *parent );
+    bool isInitialized() const;
+    void initialize( QDesignerFormEditorInterface *core );
+    QString toolTip() const;
+    QString whatsThis() const;
+    QString domXml() const;
+};
+#endif // QGSDATETIMEEDITPLUGIN_H

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -64,6 +64,7 @@ editorwidgets/qgsclassificationwidgetwrapper.cpp
 editorwidgets/qgsclassificationwidgetwrapperfactory.cpp
 editorwidgets/qgscolorwidgetwrapper.cpp
 editorwidgets/qgscolorwidgetfactory.cpp
+editorwidgets/qgsdatetimeedit.cpp
 editorwidgets/qgsdatetimeeditfactory.cpp
 editorwidgets/qgsdatetimeeditconfig.cpp
 editorwidgets/qgsdatetimeeditwrapper.cpp
@@ -288,6 +289,7 @@ editorwidgets/qgscheckboxconfigdlg.h
 editorwidgets/qgscheckboxwidgetwrapper.h
 editorwidgets/qgsclassificationwidgetwrapper.h
 editorwidgets/qgscolorwidgetwrapper.h
+editorwidgets/qgsdatetimeedit.h
 editorwidgets/qgsdatetimeeditconfig.h
 editorwidgets/qgsdatetimeeditwrapper.h
 editorwidgets/qgsdummyconfigdlg.h
@@ -510,6 +512,7 @@ editorwidgets/qgsclassificationwidgetwrapper.h
 editorwidgets/qgsclassificationwidgetwrapperfactory.h
 editorwidgets/qgscolorwidgetwrapper.h
 editorwidgets/qgscolorwidgetfactory.h
+editorwidgets/qgsdatetimeedit.h
 editorwidgets/qgsdatetimeeditfactory.h
 editorwidgets/qgsdatetimeeditconfig.h
 editorwidgets/qgsdatetimeeditwrapper.h

--- a/src/gui/editorwidgets/qgsdatetimeedit.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeedit.cpp
@@ -1,0 +1,140 @@
+/***************************************************************************
+    qgsdatetimeedit.cpp
+     --------------------------------------
+    Date                 : 08.2014
+    Copyright            : (C) 2014 Denis Rouzaud
+    Email                : denis.rouzaud@gmail.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <QLineEdit>
+#include <QMouseEvent>
+#include <QSettings>
+#include <QStyle>
+#include <QToolButton>
+
+#include "qgsdatetimeedit.h"
+
+#include "qgsapplication.h"
+#include "qgslogger.h"
+
+QgsDateTimeEdit::QgsDateTimeEdit( QWidget *parent )
+    : QDateTimeEdit( parent )
+    , mAllowNull( true )
+{
+  mClearButton = new QToolButton( this );
+  mClearButton->setIcon( QgsApplication::getThemeIcon( "/mIconClear.svg" ) );
+  mClearButton->setCursor( Qt::ArrowCursor );
+  mClearButton->setStyleSheet( "position: absolute; border: none; padding: 0px;" );
+  mClearButton->hide();
+  connect( mClearButton, SIGNAL( clicked() ), this, SLOT( clear() ) );
+
+  mNullLabel = new QLineEdit( QSettings().value( "qgis/nullValue", "NULL" ).toString(), this );
+  mNullLabel->setReadOnly( true );
+  mNullLabel->setStyleSheet( "position: absolute; border: none; font-style: italic; color: grey;" );
+  mNullLabel->hide();
+
+  setStyleSheet( QString( "padding-right: %1px;" ).arg( mClearButton->sizeHint().width() + spinButtonWidth() + frameWidth() + 1 ) );
+
+  QSize msz = minimumSizeHint();
+  setMinimumSize( qMax( msz.width(), mClearButton->sizeHint().height() + frameWidth() * 2 + 2 ),
+                  qMax( msz.height(), mClearButton->sizeHint().height() + frameWidth() * 2 + 2 ) );
+
+  connect( this, SIGNAL( dateTimeChanged( QDateTime ) ), this, SLOT( changed( QDateTime ) ) );
+
+  // init with current time so mIsNull is properly initialized
+  QDateTimeEdit::setDateTime( QDateTime::currentDateTime() );
+}
+
+void QgsDateTimeEdit::setAllowNull( bool allowNull )
+{
+  mAllowNull = allowNull;
+
+  mNullLabel->setVisible( mAllowNull && mIsNull );
+  mClearButton->setVisible( mAllowNull && !mIsNull );
+  lineEdit()->setVisible( !mAllowNull || !mIsNull );
+}
+
+
+void QgsDateTimeEdit::clear()
+{
+  changed( QDateTime() );
+  emit dateTimeChanged( QDateTime() );
+}
+
+void QgsDateTimeEdit::mousePressEvent( QMouseEvent* event )
+{
+  QRect lerect = rect().adjusted( 0, 0, -spinButtonWidth(), 0 );
+  if ( mAllowNull && mIsNull && lerect.contains( event->pos() ) )
+    return;
+
+  QDateTimeEdit::mousePressEvent( event );
+}
+
+void QgsDateTimeEdit::changed( const QDateTime & dateTime )
+{
+  mIsNull = dateTime.isNull();
+  mNullLabel->setVisible( mAllowNull && mIsNull );
+  mClearButton->setVisible( mAllowNull && !mIsNull );
+  lineEdit()->setVisible( !mAllowNull || !mIsNull );
+}
+
+int QgsDateTimeEdit::spinButtonWidth() const
+{
+  return calendarPopup() ? 25 : 18;
+}
+
+int QgsDateTimeEdit::frameWidth() const
+{
+  return style()->pixelMetric( QStyle::PM_DefaultFrameWidth );
+}
+
+void QgsDateTimeEdit::setDateTime( const QDateTime& dateTime )
+{
+  // set an undefined date
+  if ( !dateTime.isValid() || dateTime.isNull() )
+  {
+    clear();
+  }
+  else
+  {
+    QDateTimeEdit::setDateTime( dateTime );
+  }
+}
+
+QDateTime QgsDateTimeEdit::dateTime() const
+{
+  if ( mAllowNull && mIsNull )
+  {
+    return QDateTime();
+  }
+  else
+  {
+    return QDateTimeEdit::dateTime();
+  }
+}
+
+void QgsDateTimeEdit::resizeEvent( QResizeEvent * event )
+{
+  QDateTimeEdit::resizeEvent( event );
+
+  QSize sz = mClearButton->sizeHint();
+
+
+  mClearButton->move( rect().right() - frameWidth() - spinButtonWidth() - sz.width() ,
+                      ( rect().bottom() + 1 - sz.height() ) / 2 );
+
+  mNullLabel->move( 0, 0 );
+  mNullLabel->setMinimumSize( rect().adjusted( 0, 0, -spinButtonWidth(), 0 ).size() );
+  mNullLabel->setMaximumSize( rect().adjusted( 0, 0, -spinButtonWidth(), 0 ).size() );
+}
+
+
+
+

--- a/src/gui/editorwidgets/qgsdatetimeedit.h
+++ b/src/gui/editorwidgets/qgsdatetimeedit.h
@@ -1,0 +1,78 @@
+/***************************************************************************
+    qgsdatetimeedit.h
+     --------------------------------------
+    Date                 : 08.2014
+    Copyright            : (C) 2014 Denis Rouzaud
+    Email                : denis.rouzaud@gmail.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSDATETIMEEDIT_H
+#define QGSDATETIMEEDIT_H
+
+#include <QDateTimeEdit>
+
+class QToolButton;
+class QLineEdit;
+
+/**
+ * @brief The QgsDateTimeEdit class is a QDateTimeEdit with the capability of setting/reading null date/times.
+ */
+class GUI_EXPORT QgsDateTimeEdit : public QDateTimeEdit
+{
+    Q_OBJECT
+    Q_PROPERTY( bool allowNull READ allowNull WRITE setAllowNull )
+
+  public:
+    explicit QgsDateTimeEdit( QWidget *parent = 0 );
+
+    //! determines if the widget allows setting null date/time.
+    void setAllowNull( bool allowNull );
+    bool allowNull() {return mAllowNull;}
+
+    /**
+     * @brief setDateTime set the date time in the widget and handles null date times.
+     * @note since QDateTimeEdit::setDateTime() is not virtual, setDateTime must be called for QgsDateTimeEdit.
+     */
+    void setDateTime( const QDateTime &dateTime );
+
+    /**
+     * @brief dateTime returns the date time which can eventually be a null date/time
+     * @note since QDateTimeEdit::dateTime() is not virtual, dateTime must be called for QgsDateTimeEdit.
+     */
+    QDateTime dateTime() const;
+
+    //! Set the current date as NULL
+    //! @note if the widget is not configured to accept NULL dates, this will have no effect
+    virtual void clear();
+
+
+  protected:
+    virtual void resizeEvent( QResizeEvent* event );
+
+    void mousePressEvent( QMouseEvent*event );
+
+
+  private slots:
+    void changed( const QDateTime & dateTime );
+
+
+  private:
+    int spinButtonWidth() const;
+    int frameWidth() const;
+
+    bool mAllowNull;
+    bool mIsNull;
+
+    QLineEdit* mNullLabel;
+    QToolButton* mClearButton;
+
+};
+
+#endif // QGSDATETIMEEDIT_H

--- a/src/gui/editorwidgets/qgsdatetimeedit.h
+++ b/src/gui/editorwidgets/qgsdatetimeedit.h
@@ -34,7 +34,7 @@ class GUI_EXPORT QgsDateTimeEdit : public QDateTimeEdit
 
     //! determines if the widget allows setting null date/time.
     void setAllowNull( bool allowNull );
-    bool allowNull() {return mAllowNull;}
+    bool allowNull() const {return mAllowNull;}
 
     /**
      * @brief setDateTime set the date time in the widget and handles null date times.

--- a/src/gui/editorwidgets/qgsdatetimeeditconfig.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeeditconfig.cpp
@@ -108,6 +108,7 @@ QgsEditorWidgetConfig QgsDateTimeEditConfig::config()
   myConfig.insert( "field_format", mFieldFormatEdit->text() );
   myConfig.insert( "display_format", mDisplayFormatEdit->text() );
   myConfig.insert( "calendar_popup", mCalendarPopupCheckBox->isChecked() );
+  myConfig.insert( "allow_null", mAllowNullCheckBox->isChecked() );
 
   return myConfig;
 }
@@ -147,6 +148,11 @@ void QgsDateTimeEditConfig::setConfig( const QgsEditorWidgetConfig &config )
   if ( config.contains( "calendar_popup" ) )
   {
     mCalendarPopupCheckBox->setChecked( config[ "calendar_popup" ].toBool() );
+  }
+
+  if ( config.contains( "allow_null" ) )
+  {
+    mAllowNullCheckBox->setChecked( config[ "allow_null" ].toBool() );
   }
 
 }

--- a/src/gui/editorwidgets/qgsdatetimeeditfactory.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeeditfactory.cpp
@@ -43,6 +43,7 @@ QgsEditorWidgetConfig QgsDateTimeEditFactory::readConfig( const QDomElement& con
   cfg.insert( "field_format", configElement.attribute( "field_format" ) );
   cfg.insert( "display_format", configElement.attribute( "display_format" ) );
   cfg.insert( "calendar_popup", configElement.attribute( "calendar_popup" ) == "1" );
+  cfg.insert( "allow_null", configElement.attribute( "allow_null" ) == "1" );
 
   return cfg;
 }
@@ -56,6 +57,7 @@ void QgsDateTimeEditFactory::writeConfig( const QgsEditorWidgetConfig& config, Q
   configElement.setAttribute( "field_format", config["field_format"].toString() );
   configElement.setAttribute( "display_format", config["display_format"].toString() );
   configElement.setAttribute( "calendar_popup", config["calendar_popup"].toBool() );
+  configElement.setAttribute( "allow_null", config["allow_null"].toBool() );
 }
 
 QString QgsDateTimeEditFactory::representValue( QgsVectorLayer* vl, int fieldIdx, const QgsEditorWidgetConfig& config, const QVariant& cache, const QVariant& value ) const

--- a/src/gui/editorwidgets/qgsdatetimeeditwrapper.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeeditwrapper.cpp
@@ -18,6 +18,7 @@
 #include <QDateEdit>
 #include <QTimeEdit>
 
+
 #include "qgsdatetimeeditwrapper.h"
 #include "qgsdatetimeeditfactory.h"
 #include "qgsmessagelog.h"
@@ -26,57 +27,115 @@
 
 QgsDateTimeEditWrapper::QgsDateTimeEditWrapper( QgsVectorLayer* vl, int fieldIdx, QWidget* editor, QWidget* parent )
     : QgsEditorWidgetWrapper( vl, fieldIdx, editor, parent )
-    , mDateTimeWidget( NULL )
+    , mQDateTimeEdit( NULL )
+    , mQgsDateTimeEdit( NULL )
 {
 }
 
 QWidget *QgsDateTimeEditWrapper::createWidget( QWidget *parent )
 {
-  QDateTimeEdit* widget = new QDateTimeEdit( parent );
+  QgsDateTimeEdit* widget = new QgsDateTimeEdit( parent );
   widget->setDateTime( QDateTime::currentDateTime() );
   return widget;
 }
 
 void QgsDateTimeEditWrapper::initWidget( QWidget *editor )
 {
-  QDateTimeEdit* w = dynamic_cast<QDateTimeEdit*>( editor );
-  if ( !w )
+  QgsDateTimeEdit* qgsEditor = dynamic_cast<QgsDateTimeEdit*>( editor );
+  if ( qgsEditor )
+  {
+    mQgsDateTimeEdit = qgsEditor;
+  }
+  // assign the Qt editor also if the QGIS editor has been previously assigned
+  // this avoids testing each time which widget to use
+  // the QGIS editor must be used for non-virtual methods (dateTime, setDateTime)
+  QDateTimeEdit* qtEditor = dynamic_cast<QDateTimeEdit*>( editor );
+  if ( qtEditor )
+  {
+    mQDateTimeEdit = qtEditor;
+  }
+
+  if ( !mQDateTimeEdit )
   {
     QgsDebugMsg( "Date/time edit widget could not be initialized because provided widget is not a QDateTimeEdit." );
     QgsMessageLog::logMessage( "Date/time edit widget could not be initialized because provided widget is not a QDateTimeEdit." , "UI forms", QgsMessageLog::WARNING );
     return;
   }
-  mDateTimeWidget = w;
 
   const QString displayFormat = config( "display_format", QGSDATETIMEEDIT_DATEFORMAT ).toString();
-  mDateTimeWidget->setDisplayFormat( displayFormat );
+  mQDateTimeEdit->setDisplayFormat( displayFormat );
 
   const bool calendar = config( "calendar_popup", false ).toBool();
-  mDateTimeWidget->setCalendarPopup( calendar );
+  mQDateTimeEdit->setCalendarPopup( calendar );
+
+  const bool allowNull = config( "allow_null", true ).toBool();
+  if ( mQgsDateTimeEdit )
+  {
+    mQgsDateTimeEdit->setAllowNull( allowNull );
+  }
+  else
+  {
+    QgsMessageLog::instance()->logMessage( tr( "The date/time widget cannot be configured to allow NULL values. "
+                                           "The widget is a QDateTimeEdit while a QgsDateTimeEdit is requested for null values. "
+                                           "QgsDateTimeEdit is defined QGIS custom widgets." ),
+                                           "field widgets" );
+  }
+
+  if ( mQgsDateTimeEdit )
+  {
+    connect( mQgsDateTimeEdit, SIGNAL( dateTimeChanged( QVariant ) ), this, SLOT( dateTimeChanged( QDateTime ) ) );
+  }
+  else
+  {
+    connect( mQDateTimeEdit, SIGNAL( dateTimeChanged( QDateTime ) ), this,  SLOT( dateTimeChanged( QDateTime ) ) );
+  }
+}
+
+void QgsDateTimeEditWrapper::dateTimeChanged( const QDateTime& dateTime )
+{
+  const QString fieldFormat = config( "field_format", QGSDATETIMEEDIT_DATEFORMAT ).toString();
+  emit valueChanged( dateTime.toString( fieldFormat ) );
 }
 
 QVariant QgsDateTimeEditWrapper::value()
 {
-  if ( !mDateTimeWidget )
-    return QVariant();
+  if ( !mQDateTimeEdit )
+    return QVariant( field().type() );
 
   const QString fieldFormat = config( "field_format", QGSDATETIMEEDIT_DATEFORMAT ).toString();
-  return mDateTimeWidget->dateTime().toString( fieldFormat );
+
+  if ( mQgsDateTimeEdit )
+  {
+    return mQgsDateTimeEdit->dateTime().toString( fieldFormat );
+  }
+  else
+  {
+    return mQDateTimeEdit->dateTime().toString( fieldFormat );
+  }
 }
 
 void QgsDateTimeEditWrapper::setValue( const QVariant &value )
 {
-  if ( !mDateTimeWidget )
+  if ( !mQDateTimeEdit )
     return;
 
   const QString fieldFormat = config( "field_format", QGSDATETIMEEDIT_DATEFORMAT ).toString();
-  mDateTimeWidget->setDateTime( QDateTime::fromString( value.toString(), fieldFormat ) );
+  const QDateTime date = QDateTime::fromString( value.toString(), fieldFormat );
+
+  if ( mQgsDateTimeEdit )
+  {
+    mQgsDateTimeEdit->setDateTime( date );
+  }
+  else
+  {
+    mQDateTimeEdit->setDateTime( date );
+  }
 }
 
 void QgsDateTimeEditWrapper::setEnabled( bool enabled )
 {
-  if ( !mDateTimeWidget )
+  if ( !mQDateTimeEdit )
     return;
 
-  mDateTimeWidget->setEnabled( enabled );
+  mQDateTimeEdit->setEnabled( enabled );
 }

--- a/src/gui/editorwidgets/qgsdatetimeeditwrapper.h
+++ b/src/gui/editorwidgets/qgsdatetimeeditwrapper.h
@@ -19,6 +19,7 @@
 #include <QDateTimeEdit>
 
 #include "qgseditorwidgetwrapper.h"
+#include "qgsdatetimeedit.h"
 #include "qgsdatetimeeditfactory.h"
 
 
@@ -28,8 +29,12 @@ class GUI_EXPORT QgsDateTimeEditWrapper : public QgsEditorWidgetWrapper
   public:
     explicit QgsDateTimeEditWrapper( QgsVectorLayer* vl, int fieldIdx, QWidget* editor, QWidget* parent = 0 );
 
+  private slots:
+    void dateTimeChanged( const QDateTime &dateTime );
+
   private:
-    QDateTimeEdit* mDateTimeWidget;
+    QDateTimeEdit* mQDateTimeEdit;
+    QgsDateTimeEdit* mQgsDateTimeEdit;
 
 
     // QgsEditorWidgetWrapper interface

--- a/src/ui/editorwidgets/qgsdatetimeeditconfig.ui
+++ b/src/ui/editorwidgets/qgsdatetimeeditconfig.ui
@@ -168,16 +168,6 @@
         </property>
        </widget>
       </item>
-      <item row="1" column="0">
-       <widget class="QCheckBox" name="mCalendarPopupCheckBox">
-        <property name="layoutDirection">
-         <enum>Qt::LeftToRight</enum>
-        </property>
-        <property name="text">
-         <string>calendar popup</string>
-        </property>
-       </widget>
-      </item>
       <item row="0" column="0">
        <widget class="QComboBox" name="mDisplayFormatComboBox">
         <property name="minimumSize">
@@ -215,6 +205,23 @@
         </property>
         <property name="checked">
          <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0" colspan="2">
+       <widget class="QCheckBox" name="mCalendarPopupCheckBox">
+        <property name="layoutDirection">
+         <enum>Qt::LeftToRight</enum>
+        </property>
+        <property name="text">
+         <string>calendar popup</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0" colspan="2">
+       <widget class="QCheckBox" name="mAllowNullCheckBox">
+        <property name="text">
+         <string>allow NULL values</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
This adds a new QgsDateTimeEdit which inherits from QDateTimeEdit.
It handles and can set NULL dates.
The idea is the same than with QLineEdit: you have a "clear" icon on the right which will set it to NULL.

Here is how it looks "normally":
![image](https://cloud.githubusercontent.com/assets/127259/4091682/170e9ec8-2f8b-11e4-90ba-712b3c45f3ca.png)

when the date is NULL:
![image](https://cloud.githubusercontent.com/assets/127259/4091678/0467a77e-2f8b-11e4-8dfd-97d8802533ee.png)

There is an option in the config of the field to determine if it accepts NULL values or not.

If you design your own forms, this will be only accessible for those using the custom widgets (it will be included as soon as this PR goes through).

I hope you like it!
