### PR TITLE
Allow removing last point while measuring

### DIFF
--- a/src/app/qgsmeasuredialog.h
+++ b/src/app/qgsmeasuredialog.h
@@ -47,6 +47,9 @@ class APP_EXPORT QgsMeasureDialog : public QDialog, private Ui::QgsMeasureBase
     //! Mose move
     void mouseMove( QgsPoint &point );
 
+    //! Remove last point
+    void removeLastPoint();
+
   public slots:
     //! Reject
     void on_buttonBox_rejected( void );
@@ -96,6 +99,8 @@ class APP_EXPORT QgsMeasureDialog : public QDialog, private Ui::QgsMeasureBase
 
     //! pointer to measure tool which owns this dialog
     QgsMeasureTool* mTool;
+
+    QgsPoint mLastMousePoint;
 };
 
 #endif

--- a/src/app/qgsmeasuretool.cpp
+++ b/src/app/qgsmeasuretool.cpp
@@ -167,10 +167,52 @@ void QgsMeasureTool::canvasReleaseEvent( QMouseEvent * e )
     mDone = false;
   }
 
-  // we allways add the clicked point to the measuring feature
+  // we always add the clicked point to the measuring feature
   addPoint( point );
   mDialog->show();
 
+}
+
+void QgsMeasureTool::undo()
+{
+  if ( mRubberBand )
+  {
+    if ( mPoints.size() < 1 )
+    {
+      return;
+    }
+
+    if ( mPoints.size() == 1 )
+    {
+      //removing first point, so restart everything
+      restart();
+      mDialog->restart();
+    }
+    else
+    {
+      //remove second last point from line band, and last point from points band
+      mRubberBand->removePoint( -2, true );
+      mRubberBandPoints->removePoint( -1, true );
+      mPoints.removeLast();
+
+      mDialog->removeLastPoint();
+    }
+
+  }
+}
+
+void QgsMeasureTool::keyPressEvent( QKeyEvent* e )
+{
+  if (( e->key() == Qt::Key_Backspace || e->key() == Qt::Key_Delete ) )
+  {
+    if ( !mDone )
+    {
+      undo();
+    }
+
+    // Override default shortcut management in MapCanvas
+    e->ignore();
+  }
 }
 
 

--- a/src/app/qgsmeasuretool.h
+++ b/src/app/qgsmeasuretool.h
@@ -70,6 +70,8 @@ class APP_EXPORT QgsMeasureTool : public QgsMapTool
     //! called when map tool is being deactivated
     virtual void deactivate();
 
+    virtual void keyPressEvent( QKeyEvent* e );
+
   public slots:
     //! updates the projections we're using
     void updateSettings();
@@ -102,6 +104,8 @@ class APP_EXPORT QgsMeasureTool : public QgsMapTool
     //@param p (pixel) coordinate
     QgsPoint snapPoint( const QPoint& p );
 
+    /**Removes the last vertex from mRubberBand*/
+    void undo();
 };
 
 #endif


### PR DESCRIPTION
This PR implements the delete/backspace "undo last point" behaviour for the measure tool (fixing #10176). I'm not sure who is responsible for this area of code - @3nids?
