### PR TITLE
Save blendmode/composition mode in project file

### DIFF
--- a/python/core/qgsmaprenderer.sip
+++ b/python/core/qgsmaprenderer.sip
@@ -124,7 +124,18 @@ class QgsMapRenderer : QObject
       BlendSoftLight,
       BlendHardLight,
       BlendDifference,
-      BlendSubtract
+      BlendSubtract,
+      BlendSource,
+      BlendDestinationOver,
+      BlendClear,
+      BlendDestination,
+      BlendSourceIn,
+      BlendDestinationIn,
+      BlendSourceOut,
+      BlendDestinationOut,
+      BlendSourceAtop,
+      BlendDestinationAtop,
+      BlendXor,
     };
 
     //! constructor

--- a/src/core/qgsmaprenderer.cpp
+++ b/src/core/qgsmaprenderer.cpp
@@ -1136,7 +1136,30 @@ QPainter::CompositionMode QgsMapRenderer::getCompositionMode( const QgsMapRender
       return QPainter::CompositionMode_Difference;
     case QgsMapRenderer::BlendSubtract:
       return QPainter::CompositionMode_Exclusion;
+    case QgsMapRenderer::BlendSource:
+      return QPainter::CompositionMode_Source;
+    case QgsMapRenderer::BlendDestinationOver:
+      return QPainter::CompositionMode_DestinationOver;
+    case QgsMapRenderer::BlendClear:
+      return QPainter::CompositionMode_Clear;
+    case QgsMapRenderer::BlendDestination:
+      return QPainter::CompositionMode_Destination;
+    case QgsMapRenderer::BlendSourceIn:
+      return QPainter::CompositionMode_SourceIn;
+    case QgsMapRenderer::BlendDestinationIn:
+      return QPainter::CompositionMode_DestinationIn;
+    case QgsMapRenderer::BlendSourceOut:
+      return QPainter::CompositionMode_SourceOut;
+    case QgsMapRenderer::BlendDestinationOut:
+      return QPainter::CompositionMode_DestinationOut;
+    case QgsMapRenderer::BlendSourceAtop:
+      return QPainter::CompositionMode_SourceAtop;
+    case QgsMapRenderer::BlendDestinationAtop:
+      return QPainter::CompositionMode_DestinationAtop;
+    case QgsMapRenderer::BlendXor:
+      return QPainter::CompositionMode_Xor;
     default:
+      QgsDebugMsg( QString( "Blend mode %1 mapped to SourceOver" ).arg( blendMode ) );
       return QPainter::CompositionMode_SourceOver;
   }
 }
@@ -1172,7 +1195,30 @@ QgsMapRenderer::BlendMode QgsMapRenderer::getBlendModeEnum( const QPainter::Comp
       return QgsMapRenderer::BlendDifference;
     case QPainter::CompositionMode_Exclusion:
       return QgsMapRenderer::BlendSubtract;
+    case QPainter::CompositionMode_Source:
+      return QgsMapRenderer::BlendSource;
+    case QPainter::CompositionMode_DestinationOver:
+      return QgsMapRenderer::BlendDestinationOver;
+    case QPainter::CompositionMode_Clear:
+      return QgsMapRenderer::BlendClear;
+    case QPainter::CompositionMode_Destination:
+      return QgsMapRenderer::BlendDestination;
+    case QPainter::CompositionMode_SourceIn:
+      return QgsMapRenderer::BlendSourceIn;
+    case QPainter::CompositionMode_DestinationIn:
+      return QgsMapRenderer::BlendDestinationIn;
+    case QPainter::CompositionMode_SourceOut:
+      return QgsMapRenderer::BlendSourceOut;
+    case QPainter::CompositionMode_DestinationOut:
+      return QgsMapRenderer::BlendDestinationOut;
+    case QPainter::CompositionMode_SourceAtop:
+      return QgsMapRenderer::BlendSourceAtop;
+    case QPainter::CompositionMode_DestinationAtop:
+      return QgsMapRenderer::BlendDestinationAtop;
+    case QPainter::CompositionMode_Xor:
+      return QgsMapRenderer::BlendXor;
     default:
+      QgsDebugMsg( QString( "Composition mode %1 mapped to Normal" ).arg( blendMode ) );
       return QgsMapRenderer::BlendNormal;
   }
 }

--- a/src/core/qgsmaprenderer.h
+++ b/src/core/qgsmaprenderer.h
@@ -161,7 +161,18 @@ class CORE_EXPORT QgsMapRenderer : public QObject
       BlendSoftLight,
       BlendHardLight,
       BlendDifference,
-      BlendSubtract
+      BlendSubtract,
+      BlendSource,
+      BlendDestinationOver,
+      BlendClear,
+      BlendDestination,
+      BlendSourceIn,
+      BlendDestinationIn,
+      BlendSourceOut,
+      BlendDestinationOut,
+      BlendSourceAtop,
+      BlendDestinationAtop,
+      BlendXor,
     };
 
     //! constructor


### PR DESCRIPTION
I'm using `QgsVectorLayer.setFeatureBlendMode( QPainter.CompositionMode_Source )` in a plugin.  That setting is not properly stored and restored from the project file.  Any objections to push this?
