### PR TITLE
Automatic update of label and neighboring ranges boundaries in graduated renderer

### DIFF
--- a/src/gui/symbology-ng/qgsgraduatedsymbolrendererv2widget.h
+++ b/src/gui/symbology-ng/qgsgraduatedsymbolrendererv2widget.h
@@ -94,6 +94,8 @@ class GUI_EXPORT QgsGraduatedSymbolRendererV2Widget : public QgsRendererV2Widget
     void deleteClasses();
     /**Removes all classes from the classification*/
     void deleteAllClasses();
+    /**Toggle the link between classes boundaries */
+    void toggleBoundariesLink( bool linked );
 
     void rotationFieldChanged( QString fldName );
     void sizeScaleFieldChanged( QString fldName );
@@ -114,6 +116,8 @@ class GUI_EXPORT QgsGraduatedSymbolRendererV2Widget : public QgsRendererV2Widget
 
     void changeRangeSymbol( int rangeIdx );
     void changeRange( int rangeIdx );
+
+    QString createLabel( double lowerValue, double upperValue );
 
     void changeSelectedSymbols();
 

--- a/src/ui/qgsgraduatedsymbolrendererv2widget.ui
+++ b/src/ui/qgsgraduatedsymbolrendererv2widget.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>505</width>
+    <width>615</width>
     <height>339</height>
    </rect>
   </property>
@@ -237,6 +237,16 @@
       <widget class="QPushButton" name="btnDeleteAllClasses">
        <property name="text">
         <string>Delete all</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QCheckBox" name="cbxLinkBoundaries">
+       <property name="text">
+        <string>Link classes boundaries</string>
+       </property>
+       <property name="checked">
+        <bool>true</bool>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
Currently, when the bounds of a graduated renderer are manually edited, the labels have to be manually modified as well. This is quite time consuming and has been the cause of several complaints, for example: 
- http://hub.qgis.org/issues/9312
- http://hub.qgis.org/issues/9900 
- http://hub.qgis.org/issues/10203

This pull request allows to automatically update the label to follow the range, but the label will be updated only if it has not been manually modified.

I also added a checkbox allowing to link ranges boundaries. Editing the boundary of a range will automatically update the corresponding boundary of the other corresponding range (above for lower bound, below for upper bound). This is what is wanted most of the time, but it is also possible to uncheck the checkbox and freely edit as it is now.

What do you think?
