### PR TITLE
Description: Fix qreal VS double issues.

### DIFF
--- a/python/core/composer/qgsatlascomposition.sip
+++ b/python/core/composer/qgsatlascomposition.sip
@@ -155,7 +155,7 @@ public:
      * @see setPredefinedScales
      * @see QgsComposerMap::atlasScalingMode
     */
-    const QVector<double>& predefinedScales() const;
+    const QVector<qreal>& predefinedScales() const;
 
     /**Sets the list of predefined scales for the atlas. This is used
      * for maps which are set to the predefined atlas scaling mode.
@@ -163,7 +163,7 @@ public:
      * @see predefinedScales
      * @see QgsComposerMap::atlasScalingMode
      */
-    void setPredefinedScales( const QVector<double>& scales );
+    void setPredefinedScales( const QVector<qreal>& scales );
 
     /** Begins the rendering. Returns true if successful, false if no matching atlas
       features found.*/

--- a/src/app/composer/qgscomposer.cpp
+++ b/src/app/composer/qgscomposer.cpp
@@ -3629,7 +3629,7 @@ void QgsComposer::loadAtlasPredefinedScalesFromProject()
     return;
   }
   QgsAtlasComposition& atlasMap = mComposition->atlasComposition();
-  QVector<double> pScales;
+  QVector<qreal> pScales;
   // first look at project's scales
   QStringList scales( QgsProject::instance()->readListEntry( "Scales", "/ScalesList" ) );
   bool hasProjectScales( QgsProject::instance()->readBoolEntry( "Scales", "/useProjectScales" ) );

--- a/src/core/composer/qgsatlascomposition.cpp
+++ b/src/core/composer/qgsatlascomposition.cpp
@@ -506,7 +506,7 @@ void QgsAtlasComposition::prepareMap( QgsComposerMap* map )
       // choose one of the predefined scales
       double newWidth = mOrigExtent.width();
       double newHeight = mOrigExtent.height();
-      const QVector<double>& scales = mPredefinedScales;
+      const QVector<qreal>& scales = mPredefinedScales;
       for ( int i = 0; i < scales.size(); i++ )
       {
         double ratio = scales[i] / originalScale;
@@ -768,7 +768,7 @@ bool QgsAtlasComposition::evalFeatureFilename()
   return true;
 }
 
-void QgsAtlasComposition::setPredefinedScales( const QVector<double>& scales )
+void QgsAtlasComposition::setPredefinedScales( const QVector<qreal>& scales )
 {
   mPredefinedScales = scales;
   // make sure the list is sorted

--- a/src/core/composer/qgsatlascomposition.h
+++ b/src/core/composer/qgsatlascomposition.h
@@ -183,7 +183,7 @@ class CORE_EXPORT QgsAtlasComposition : public QObject
      * @see setPredefinedScales
      * @see QgsComposerMap::atlasScalingMode
     */
-    const QVector<double>& predefinedScales() const { return mPredefinedScales; }
+    const QVector<qreal>& predefinedScales() const { return mPredefinedScales; }
 
     /**Sets the list of predefined scales for the atlas. This is used
      * for maps which are set to the predefined atlas scaling mode.
@@ -191,7 +191,7 @@ class CORE_EXPORT QgsAtlasComposition : public QObject
      * @see predefinedScales
      * @see QgsComposerMap::atlasScalingMode
      */
-    void setPredefinedScales( const QVector<double>& scales );
+    void setPredefinedScales( const QVector<qreal>& scales );
 
     /** Begins the rendering. Returns true if successful, false if no matching atlas
       features found.*/
@@ -336,7 +336,7 @@ class CORE_EXPORT QgsAtlasComposition : public QObject
     void computeExtent( QgsComposerMap *map );
 
     //list of predefined scales
-    QVector<double> mPredefinedScales;
+    QVector<qreal> mPredefinedScales;
 };
 
 #endif

--- a/src/gui/qgscomposerview.cpp
+++ b/src/gui/qgscomposerview.cpp
@@ -865,7 +865,7 @@ void QgsComposerView::mouseReleaseEvent( QMouseEvent* e )
       else
       {
         QgsComposerAttributeTable* newTable = new QgsComposerAttributeTable( composition() );
-        newTable->setSceneRect( QRectF( mRubberBandItem->transform().dx(), mRubberBandItem->transform().dy(), mRubberBandItem->rect().width(), qMax( mRubberBandItem->rect().height(), 15.0 ) ) );
+        newTable->setSceneRect( QRectF( mRubberBandItem->transform().dx(), mRubberBandItem->transform().dy(), mRubberBandItem->rect().width(), qMax( mRubberBandItem->rect().height(), (qreal)15.0 ) ) );
         QList<const QgsComposerMap*> mapItemList = composition()->composerMapItems();
         if ( mapItemList.size() > 0 )
         {


### PR DESCRIPTION
 This patch tries to fix qreal VS double issues for ARM

 There are two seperate issues, the first is trivial just a typecast on
 a const.

 The second is however less-trivial and needs to be checked
 before merging. sip doesn't seem to like the type
 QVector<double> on platforms where qreal is float but changing
 the type to qreal may have knock-on impacts on the native code.

 QGIS Issue: http://hub.qgis.org/issues/11148
 Debian Bug: https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=760535

Author: Peter Michael Green plugwash@debian.org
