### PR TITLE
Update qgsgpsinformationwidget.h

### DIFF
--- a/src/app/gps/qgsgpsinformationwidget.h
+++ b/src/app/gps/qgsgpsinformationwidget.h
@@ -67,6 +67,7 @@ class QgsGPSInformationWidget: public QWidget, private Ui::QgsGPSInformationWidg
 
     void connected( QgsGPSConnection * );
     void timedout();
+    void updateOldLayer( QStringList lst );
 
   private:
     enum FixStatus  //GPS status


### PR DESCRIPTION
BUG FIX: mpLastLayer should get updated, or set to NULL when selected layer is removed.
