### PR TITLE
Improved method for selecting random colors for categorised renderer

### DIFF
--- a/python/core/symbology-ng/qgsvectorcolorrampv2.sip
+++ b/python/core/symbology-ng/qgsvectorcolorrampv2.sip
@@ -14,6 +14,9 @@ class QgsVectorColorRampV2
 %End
 
   public:
+  
+    QgsVectorColorRampV2();
+  
     virtual ~QgsVectorColorRampV2();
 
     // Number of defined colors
@@ -23,6 +26,12 @@ class QgsVectorColorRampV2
     virtual double value( int index ) const = 0;
 
     virtual QColor color( double value ) const = 0;
+    
+    /*Sets the desired total number of unique colors for the resultant ramp
+     * @param colorCount number of unique colors
+     * @note added in QGIS 2.5
+     */
+    virtual void setTotalColorCount( const int colorCount );
 
     virtual QString type() const = 0;
 
@@ -139,6 +148,8 @@ class QgsRandomColorsV2 : QgsVectorColorRampV2
     double value( int index ) const;
 
     QColor color( double value ) const;
+    
+    void setTotalColorCount( const int colorCount );
 
     QString type() const;
 

--- a/src/core/symbology-ng/qgsvectorcolorrampv2.h
+++ b/src/core/symbology-ng/qgsvectorcolorrampv2.h
@@ -25,6 +25,9 @@
 class CORE_EXPORT QgsVectorColorRampV2
 {
   public:
+
+    QgsVectorColorRampV2();
+
     virtual ~QgsVectorColorRampV2() {}
 
     // Number of defined colors
@@ -35,12 +38,21 @@ class CORE_EXPORT QgsVectorColorRampV2
 
     virtual QColor color( double value ) const = 0;
 
+    /*Sets the desired total number of unique colors for the resultant ramp
+     * @param colorCount number of unique colors
+     * @note added in QGIS 2.5
+     */
+    virtual void setTotalColorCount( const int colorCount ) { mTotalColorCount = colorCount; }
+
     virtual QString type() const = 0;
 
     virtual QgsVectorColorRampV2* clone() const = 0;
 
     virtual QgsStringMap properties() const = 0;
 
+  protected:
+
+    int mTotalColorCount;
 };
 
 struct QgsGradientStop
@@ -173,11 +185,18 @@ class CORE_EXPORT QgsRandomColorsV2: public QgsVectorColorRampV2
 
     QColor color( double value ) const;
 
+    void setTotalColorCount( const int colorCount );
+
     QString type() const;
 
     QgsVectorColorRampV2* clone() const;
 
     QgsStringMap properties() const;
+
+  protected:
+
+    QList<QColor> mPrecalculatedColors;
+
 };
 
 

--- a/src/gui/symbology-ng/qgscategorizedsymbolrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgscategorizedsymbolrendererv2widget.cpp
@@ -594,6 +594,10 @@ static void _createCategories( QgsCategoryList& cats, QList<QVariant>& values, Q
 
   bool hasNull = false;
 
+  //assume we need an extra color for nulls
+  int totalColors = num + 1;
+  ramp->setTotalColorCount( totalColors );
+
   for ( int i = 0; i < num; i++ )
   {
     QVariant value = values[i];


### PR DESCRIPTION
At the moment, the colors chosen by the categorised renderer are totally random. This is suboptimal, and results in a kind of lottery where you may end up with a nice distinct color scheme or a scheme where classes are indistinguishable. For instance:..

![screenshot from 2014-09-14 14 14 01](https://cloud.githubusercontent.com/assets/1829991/4263849/b56c67fe-3c05-11e4-9e11-d8f263adb5de.png)

This pull request modifies QgsVectorColorRampV2 so that ramps can be notified of the total desired number of colors to be generated by the ramp. This lets us precalculate a nicer set of colors which have a much greater chance of being visual distinct from one another. 

It's not perfect, but works well for ~<10 colors and in any case is 100x better than the current behaviour. I'll keep investigating better methods for selecting visually distinct colors, but in the meantime I think this is worthwhile merging.
