### PR TITLE
Usability improvements for db manager

### DIFF
--- a/python/plugins/db_manager/db_manager_plugin.py
+++ b/python/plugins/db_manager/db_manager_plugin.py
@@ -65,10 +65,11 @@ class DBManagerPlugin:
 		# keep opened only one instance
 		if self.dlg == None:
 			from db_manager import DBManager
-			self.dlg = DBManager(self.iface, self.iface.mainWindow())
+			self.dlg = DBManager(self.iface)
 			QObject.connect(self.dlg, SIGNAL("destroyed(QObject *)"), self.onDestroyed)
 		self.dlg.show()
 		self.dlg.raise_()
+		self.dlg.setWindowState( self.dlg.windowState() & ~Qt.WindowMinimized )
 		self.dlg.activateWindow()
 
 	def onDestroyed(self, obj):

--- a/python/plugins/db_manager/dlg_sql_window.py
+++ b/python/plugins/db_manager/dlg_sql_window.py
@@ -244,11 +244,31 @@ class DlgSqlWindow(QDialog, Ui_Dialog):
       if c:
         c.close()
         del c
+        
+    # get sensible default columns. do this before sorting in case there's hints in the column order (eg, id is more likely to be first)
+    try:
+      defaultGeomCol = next(col for col in cols if col in ['geom','geometry','the_geom'])
+    except:
+      defaultGeomCol = None
+    try:
+      defaultUniqueCol = [col for col in cols if 'id' in col][0]
+    except:
+      defaultUniqueCol = None
 
     cols.sort()
     self.uniqueCombo.addItems( cols )
     self.geomCombo.addItems( cols )
 
+    # set sensible default columns
+    try:
+      self.geomCombo.setCurrentIndex( cols.index(defaultGeomCol) )  
+    except:
+      pass
+    try:
+      self.uniqueCombo.setCurrentIndex( cols.index(defaultUniqueCol) )  
+    except:
+      pass
+      
     QApplication.restoreOverrideCursor()
 
   def copySelectedResults(self):

--- a/python/plugins/db_manager/dlg_sql_window.py
+++ b/python/plugins/db_manager/dlg_sql_window.py
@@ -173,6 +173,10 @@ class DlgSqlWindow(QDialog, Ui_Dialog):
     query = self.editSql.text()
     if query == "":
       return
+      
+    # remove a trailing ';' from query if present
+    if query.strip().endswith(';'):
+       query = query.strip()[:-1]      
 
     QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
 
@@ -216,7 +220,11 @@ class DlgSqlWindow(QDialog, Ui_Dialog):
       if not escaped.search(query):
         break
       aliasIndex += 1
-
+    
+    # remove a trailing ';' from query if present
+    if query.strip().endswith(';'):
+       query = query.strip()[:-1]
+    
     # get all the columns
     cols = []
     connector = self.db.connector


### PR DESCRIPTION
Here's some fixes to a couple of small usability issues I've encountered with db manager:
- can't keep the db manager window open and minimised and continue to work on qgis with it in the background
- the sql window trips up if sql ends in a ";"
- the sql window now auto selects sensible default columns for the id and geometry column combo boxes
