### PR TITLE
create a relationsChanged signal for relation manager

### DIFF
--- a/python/core/qgsrelationmanager.sip
+++ b/python/core/qgsrelationmanager.sip
@@ -12,7 +12,7 @@ class QgsRelationManager : QObject
     void setRelations( const QList<QgsRelation>& relations );
     const QMap<QString, QgsRelation>& relations() const;
     void addRelation( const QgsRelation& relation );
-    void removeRelation( const QString& name );
+    void removeRelation( const QString& id );
     void removeRelation( const QgsRelation& relation );
     QgsRelation relation( const QString& id ) const;
     void clear();
@@ -21,5 +21,9 @@ class QgsRelationManager : QObject
     QList<QgsRelation> referencedRelations( QgsVectorLayer *layer = 0 ) const;
 
   signals:
+    /** this signal is emitted when the relations were loaded after reading a project */
     void relationsLoaded();
+
+    /** this signal is emitted whenever the relations in the project changed */
+    void relationsChanged();
 };

--- a/src/core/qgsrelationmanager.cpp
+++ b/src/core/qgsrelationmanager.cpp
@@ -52,16 +52,20 @@ void QgsRelationManager::addRelation( const QgsRelation& relation )
   mRelations.insert( relation.id(), relation );
 
   mProject->dirty( true );
+
+  emit relationsChanged();
 }
 
-void QgsRelationManager::removeRelation( const QString& name )
+void QgsRelationManager::removeRelation( const QString& id )
 {
-  mRelations.remove( name );
+  mRelations.remove( id );
+  emit relationsChanged();
 }
 
 void QgsRelationManager::removeRelation( const QgsRelation& relation )
 {
   mRelations.remove( relation.id() );
+  emit relationsChanged();
 }
 
 QgsRelation QgsRelationManager::relation( const QString& id ) const
@@ -72,6 +76,7 @@ QgsRelation QgsRelationManager::relation( const QString& id ) const
 void QgsRelationManager::clear()
 {
   mRelations.clear();
+  emit relationsChanged();
 }
 
 QList<QgsRelation> QgsRelationManager::referencingRelations( QgsVectorLayer* layer, int fieldIdx ) const
@@ -152,6 +157,7 @@ void QgsRelationManager::readProject( const QDomDocument & doc )
   }
 
   emit( relationsLoaded() );
+  emit( relationsChanged() );
 }
 
 void QgsRelationManager::writeProject( QDomDocument & doc )

--- a/src/core/qgsrelationmanager.h
+++ b/src/core/qgsrelationmanager.h
@@ -105,7 +105,11 @@ class CORE_EXPORT QgsRelationManager : public QObject
     QList<QgsRelation> referencedRelations( QgsVectorLayer *layer = 0 ) const;
 
   signals:
+    /** this signal is emitted when the relations were loaded after reading a project */
     void relationsLoaded();
+
+    /** this signal is emitted whenever the relations in the project changed */
+    void relationsChanged();
 
   private slots:
     void readProject( const QDomDocument &doc );


### PR DESCRIPTION
I had the problem of being able to when the relations change within a project.
I am not sure it is the best place to do it though.
What do you think?

(I also renamed the argument of QgsRelationManager::removeRelation fron name to id, since it's removed by id)
