### PR TITLE
[FEATURE] SSL PKI integration for OWS connections

### DIFF
--- a/python/core/core.sip
+++ b/python/core/core.sip
@@ -95,6 +95,7 @@
 %Include qgssimplifymethod.sip
 %Include qgssnapper.sip
 %Include qgsspatialindex.sip
+%Include qgssslutils.sip
 %Include qgstolerance.sip
 %Include qgsvectordataprovider.sip
 %Include qgsvectorfilewriter.sip

--- a/python/core/qgscredentials.sip
+++ b/python/core/qgscredentials.sip
@@ -11,6 +11,9 @@ class QgsCredentials
     bool get( QString realm, QString &username /In,Out/, QString &password /In,Out/, QString message = QString::null );
     void put( QString realm, QString username, QString password );
 
+    bool getSsl( QString keyhash, QString &password /In,Out/, QString accessurl, QString message = QString::null );
+    void putSsl( QString keyhash, QString password );
+
     bool getSslNoCache( QString &password /In,Out/, QString accessurl, QString message = QString::null );
 
     //! retrieves instance

--- a/python/core/qgscredentials.sip
+++ b/python/core/qgscredentials.sip
@@ -11,6 +11,8 @@ class QgsCredentials
     bool get( QString realm, QString &username /In,Out/, QString &password /In,Out/, QString message = QString::null );
     void put( QString realm, QString username, QString password );
 
+    bool getSslNoCache( QString &password /In,Out/, QString accessurl, QString message = QString::null );
+
     //! retrieves instance
     static QgsCredentials *instance();
 
@@ -39,6 +41,9 @@ class QgsCredentials
 
     //! request a password
     virtual bool request( QString realm, QString &username /In,Out/, QString &password /In,Out/, QString message = QString::null ) = 0;
+
+    //! request a password for an SSL key
+    virtual bool requestSsl( QString &password /In,Out/, QString resource = QString::null, QString message = QString::null ) = 0;
 
     //! register instance
     void setInstance( QgsCredentials *theInstance );
@@ -70,4 +75,6 @@ class QgsCredentialsConsole : QObject, QgsCredentials
 
   protected:
     virtual bool request( QString realm, QString &username /In,Out/, QString &password /In,Out/, QString message = QString::null );
+
+    virtual bool requestSsl( QString &password /In,Out/, QString resource = QString::null, QString message = QString::null );
 };

--- a/python/core/qgscredentials.sip
+++ b/python/core/qgscredentials.sip
@@ -11,11 +11,6 @@ class QgsCredentials
     bool get( QString realm, QString &username /In,Out/, QString &password /In,Out/, QString message = QString::null );
     void put( QString realm, QString username, QString password );
 
-    bool getSsl( QString keyhash, QString &password /In,Out/, QString accessurl, QString message = QString::null );
-    void putSsl( QString keyhash, QString password );
-
-    bool getSslNoCache( QString &password /In,Out/, QString accessurl, QString message = QString::null );
-
     //! retrieves instance
     static QgsCredentials *instance();
 
@@ -45,8 +40,9 @@ class QgsCredentials
     //! request a password
     virtual bool request( QString realm, QString &username /In,Out/, QString &password /In,Out/, QString message = QString::null ) = 0;
 
-    //! request a password for an SSL key
-    virtual bool requestSsl( QString &password /In,Out/, QString resource = QString::null, QString message = QString::null ) = 0;
+    //! request a password for an SSL key, and optionally its filepath
+    virtual bool requestSslKey( QString &password /In,Out/, QString &keypath /In,Out/, bool needskeypath,
+                                QString resource, QString message = QString::null ) = 0;
 
     //! register instance
     void setInstance( QgsCredentials *theInstance );
@@ -79,5 +75,6 @@ class QgsCredentialsConsole : QObject, QgsCredentials
   protected:
     virtual bool request( QString realm, QString &username /In,Out/, QString &password /In,Out/, QString message = QString::null );
 
-    virtual bool requestSsl( QString &password /In,Out/, QString resource = QString::null, QString message = QString::null );
+    virtual bool requestSslKey( QString &password /In,Out/, QString &keypath /In,Out/, bool needskeypath,
+                                QString resource, QString message = QString::null );
 };

--- a/python/core/qgsnetworkaccessmanager.sip
+++ b/python/core/qgsnetworkaccessmanager.sip
@@ -62,6 +62,8 @@ class QgsNetworkAccessManager : QNetworkAccessManager
 
     bool useSystemProxy();
 
+    //! DO NOT ADD BINDING for access/set functions to the cache for hash/passphrases for private keys of PKI certificates
+
   signals:
     void requestAboutToBeCreated( QNetworkAccessManager::Operation, const QNetworkRequest &, QIODevice * );
     void requestCreated( QNetworkReply * );

--- a/python/core/qgssslutils.sip
+++ b/python/core/qgssslutils.sip
@@ -1,11 +1,11 @@
 /**
- * @class QgsSslCertSettings
+ * @class QgsSslPkiSettings
  * @ingroup core
  * @brief Settings for working with a SSL certificate, key and optional certificate issuer
  * @since since 2.5
  */
 
-class QgsSslCertSettings
+class QgsSslPkiSettings
 {
   public:
 
@@ -14,21 +14,21 @@ class QgsSslCertSettings
       QGISStore = 0
     };
 
-    QgsSslCertSettings();
+    QgsSslPkiSettings();
 
-    QSslCertificate clientCert() const;
+    QByteArray clientCertData() const;
 
-    QSslKey clientCertKey() const;
+    QByteArray clientKeyData() const;
 
-    QSslCertificate issuerCert() const;
+    QByteArray issuerCertData() const;
 
     // TODO: add protocol option, e.g. QSsl::TlsV1SslV3, etc.?
 
     bool certIsReady() const;
     void setCertReady( bool ready );
 
-    QgsSslCertSettings::SslStoreType storeType() const;
-    void setStoreType( QgsSslCertSettings::SslStoreType storetype );
+    QgsSslPkiSettings::SslStoreType storeType() const;
+    void setStoreType( QgsSslPkiSettings::SslStoreType storetype );
 
     QString certId() const;
     void setCertId( const QString& txtid );
@@ -36,8 +36,11 @@ class QgsSslCertSettings
     QString keyId() const;
     void setKeyId( const QString& txtid );
 
-    bool hasKeyPassphrase() const;
-    void setHasKeyPassphrase( bool has );
+    bool needsKeyPath() const;
+    void setNeedsKeyPath( bool needs );
+
+    bool needsKeyPassphrase() const;
+    void setNeedsKeyPassphrase( bool has );
 
     QString keyPassphrase() const;
     void setKeyPassphrase( const QString& passphrase );
@@ -53,25 +56,61 @@ class QgsSslCertSettings
 };
 
 /**
-  \class QgsSslUtils
+ * @class QgsSslPkiGroup
+ * @ingroup core
+ * @brief Storage set for constructed SSL certificate, key and optional certificate issuer
+ * @since 2.6
+ */
+
+class QgsSslPkiGroup
+{
+%TypeHeaderCode
+#include <qgssslutils.h>
+%End
+  public:
+    QgsSslPkiGroup( const QSslCertificate& cert = QSslCertificate(), const QSslKey& certkey = QSslKey(),
+                    const QSslCertificate& issuer = QSslCertificate(), bool issuerselfsigned = false );
+    ~QgsSslPkiGroup();
+
+    bool isNull();
+
+    QSslCertificate clientCert();
+    void setClientCert( const QSslCertificate& cert );
+
+    QSslKey clientCertKey();
+    void setClientCertKey( const QSslKey& certkey );
+
+    QSslCertificate issuerCert();
+    void setIssuerCert( const QSslCertificate& issuer );
+
+    bool issuerSelfSigned();
+    void setIssuerSelfSigned( bool selfsigned );
+};
+
+/**
+  \class QgsSslPkiUtility
   \ingroup core
   \brief Utilites functions for working with SSL certificates, keys and connections
   \since 2.5
 */
 
-class QgsSslUtils
+class QgsSslPkiUtility
 {
 %TypeHeaderCode
 #include <qgssslutils.h>
 %End
   public:
 
-    /** Path to user-local QGIS directory for certs, keys and issuers
-     */
+    static QgsSslPkiUtility *instance();
+
+    static bool urlToResource( const QString& accessurl, QString *resource );
+
+    QgsSslPkiGroup * getSslPkiGroup( const QgsSslPkiSettings& pki );
+    void putSslPkiGroup( const QgsSslPkiSettings& pki, QgsSslPkiGroup * pkigroup );
+    void removeSslPkiGroup( const QgsSslPkiSettings& pki );
+
     static const QString qgisCertStoreDirPath();
 
-    /** Create user-local QGIS directory for certs, keys and issuers
-     */
     static bool createQgisCertStoreDir();
 
     static const QString qgisCertsDirPath();
@@ -85,30 +124,14 @@ class QgsSslUtils
     static const QString qgisKeyPath( const QString& file );
     static const QString qgisIssuerPath( const QString& file );
 
-    static const QStringList storeCerts( QgsSslCertSettings::SslStoreType store );
-    static const QStringList storeKeys( QgsSslCertSettings::SslStoreType store );
-    static const QStringList storeIssuers( QgsSslCertSettings::SslStoreType store );
+    static const QStringList storeCerts( QgsSslPkiSettings::SslStoreType store );
+    static const QStringList storeKeys( QgsSslPkiSettings::SslStoreType store );
+    static const QStringList storeIssuers( QgsSslPkiSettings::SslStoreType store );
 
     static QSslCertificate certFromPath( const QString& path, QSsl::EncodingFormat format = QSsl::Pem );
 
     static QSsl::KeyAlgorithm keyAlgorithm( const QByteArray& keydata );
 
-    static QSslKey keyFromData( const QByteArray& keydata,
-                                QSsl::EncodingFormat format = QSsl::Pem,
-                                QSsl::KeyType type = QSsl::PrivateKey,
-                                bool hasKeyPhrase = false,
-                                const QString& passphrase = QString(),
-                                const QString& accessurl = QString() );
-    static QSslKey keyFromPath( const QString& path,
-                                QSsl::EncodingFormat format = QSsl::Pem,
-                                QSsl::KeyType type = QSsl::PrivateKey,
-                                bool hasKeyPhrase = false,
-                                const QString& passphrase = QString(),
-                                const QString& accessurl = QString() );
-
-    static const QString keyHashFromData( const QByteArray & data );
-    static const QString keyHashFromPath( const QString& path );
-
-    static void updateRequestSslConfiguration( QNetworkRequest &request /In,Out/, const QgsSslCertSettings& pki );
-    static void updateReplyExpectedSslErrors( QNetworkReply *reply, const QgsSslCertSettings& pki );
+    void updateRequestSslConfiguration( QNetworkRequest &request /In,Out/, const QgsSslPkiSettings& pki );
+    void updateReplyExpectedSslErrors( QNetworkReply *reply, const QgsSslPkiSettings& pki );
 };

--- a/python/core/qgssslutils.sip
+++ b/python/core/qgssslutils.sip
@@ -1,0 +1,114 @@
+/**
+ * @class QgsSslCertSettings
+ * @ingroup core
+ * @brief Settings for working with a SSL certificate, key and optional certificate issuer
+ * @since since 2.5
+ */
+
+class QgsSslCertSettings
+{
+  public:
+
+    enum SslStoreType
+    {
+      QGISStore = 0
+    };
+
+    QgsSslCertSettings();
+
+    QSslCertificate clientCert() const;
+
+    QSslKey clientCertKey() const;
+
+    QSslCertificate issuerCert() const;
+
+    // TODO: add protocol option, e.g. QSsl::TlsV1SslV3, etc.?
+
+    bool certIsReady() const;
+    void setCertReady( bool ready );
+
+    QgsSslCertSettings::SslStoreType storeType() const;
+    void setStoreType( QgsSslCertSettings::SslStoreType storetype );
+
+    QString certId() const;
+    void setCertId( const QString& txtid );
+
+    QString keyId() const;
+    void setKeyId( const QString& txtid );
+
+    bool hasKeyPassphrase() const;
+    void setHasKeyPassphrase( bool has );
+
+    QString keyPassphrase() const;
+    void setKeyPassphrase( const QString& passphrase );
+
+    QString issuerId() const;
+    void setIssuerId( const QString& txtid );
+
+    bool issuerSelfSigned() const;
+    void setIssuerSelfSigned( bool seflsigned );
+
+    QString accessUrl() const;
+    void setAccessUrl( const QString& url );
+};
+
+/**
+  \class QgsSslUtils
+  \ingroup core
+  \brief Utilites functions for working with SSL certificates, keys and connections
+  \since 2.5
+*/
+
+class QgsSslUtils
+{
+%TypeHeaderCode
+#include <qgssslutils.h>
+%End
+  public:
+
+    /** Path to user-local QGIS directory for certs, keys and issuers
+     */
+    static const QString qgisCertStoreDirPath();
+
+    /** Create user-local QGIS directory for certs, keys and issuers
+     */
+    static bool createQgisCertStoreDir();
+
+    static const QString qgisCertsDirPath();
+    static const QString qgisKeysDirPath();
+    static const QString qgisIssuersDirPath();
+
+    /**
+     * @return NULL QString if file does not exist
+     */
+    static const QString qgisCertPath( const QString& file );
+    static const QString qgisKeyPath( const QString& file );
+    static const QString qgisIssuerPath( const QString& file );
+
+    static const QStringList storeCerts( QgsSslCertSettings::SslStoreType store );
+    static const QStringList storeKeys( QgsSslCertSettings::SslStoreType store );
+    static const QStringList storeIssuers( QgsSslCertSettings::SslStoreType store );
+
+    static QSslCertificate certFromPath( const QString& path, QSsl::EncodingFormat format = QSsl::Pem );
+
+    static QSsl::KeyAlgorithm keyAlgorithm( const QByteArray& keydata );
+
+    static QSslKey keyFromData( const QByteArray& keydata,
+                                QSsl::EncodingFormat format = QSsl::Pem,
+                                QSsl::KeyType type = QSsl::PrivateKey,
+                                bool hasKeyPhrase = false,
+                                const QString& passphrase = QString(),
+                                const QString& accessurl = QString() );
+    static QSslKey keyFromPath( const QString& path,
+                                QSsl::EncodingFormat format = QSsl::Pem,
+                                QSsl::KeyType type = QSsl::PrivateKey,
+                                bool hasKeyPhrase = false,
+                                const QString& passphrase = QString(),
+                                const QString& accessurl = QString() );
+
+    static const QString keyHashFromData( const QByteArray & data );
+    static const QString keyHashFromPath( const QString& path );
+
+    static void updateRequestSslConfiguration( QNetworkRequest &request /In,Out/, const QgsSslCertSettings& pki );
+    static void updateReplyExpectedSslErrors( QNetworkReply *reply, const QgsSslCertSettings& pki );
+};

--- a/python/gui/gui.sip
+++ b/python/gui/gui.sip
@@ -100,6 +100,7 @@
 %Include qgsscalerangewidget.sip
 %Include qgsscalevisibilitydialog.sip
 %Include qgssearchquerybuilder.sip
+%Include qgssslcertificatewidget.sip
 %Include qgstextannotationitem.sip
 %Include qgsvertexmarker.sip
 %Include qgsvectorlayertools.sip

--- a/python/gui/qgscredentialdialog.sip
+++ b/python/gui/qgscredentialdialog.sip
@@ -14,5 +14,6 @@ class QgsCredentialDialog : QDialog, QgsCredentials
   protected:
     virtual bool request( QString realm, QString &username /In,Out/, QString &password /In,Out/, QString message = QString::null );
 
-    virtual bool requestSsl( QString &password /In,Out/, QString resource = QString::null, QString message = QString::null );
+    virtual bool requestSslKey( QString &password /In,Out/, QString &keypath /In,Out/, bool needskeypath,
+                                QString resource = QString::null, QString message = QString::null );
 };

--- a/python/gui/qgscredentialdialog.sip
+++ b/python/gui/qgscredentialdialog.sip
@@ -13,4 +13,6 @@ class QgsCredentialDialog : QDialog, QgsCredentials
 
   protected:
     virtual bool request( QString realm, QString &username /In,Out/, QString &password /In,Out/, QString message = QString::null );
+
+    virtual bool requestSsl( QString &password /In,Out/, QString resource = QString::null, QString message = QString::null );
 };

--- a/python/gui/qgssslcertificatewidget.sip
+++ b/python/gui/qgssslcertificatewidget.sip
@@ -1,0 +1,52 @@
+
+class QgsSslCertificateWidget : QWidget
+{
+%TypeHeaderCode
+#include "qgssslcertificatewidget.h"
+%End
+
+  public:
+    enum Validity
+    {
+      Valid,
+      Invalid,
+      Unknown
+    };
+
+    /** Widget for choosing/inspecting SSL certificate, using different store methods, and testing validity
+     */
+    explicit QgsSslCertificateWidget( QWidget *parent /TransferThis/ = 0, const QString& accessUrl = QString( "" ) );
+    ~QgsSslCertificateWidget();
+
+    void loadSettings( QgsSslCertSettings::SslStoreType storeType = QgsSslCertSettings::QGISStore,
+                       const QString& certId = "",
+                       const QString& keyId = "",
+                       bool keyPassphrase = false,
+                       const QString& issuerId = "",
+                       bool issuerSelf = false );
+
+    void loadSslCertSettings( const QgsSslCertSettings& pki );
+
+    QgsSslCertSettings toSslCertSettings();
+
+    bool certIsValid();
+
+    QgsSslCertSettings::SslStoreType ssLStoreType();
+    QString certId() const;
+    QString keyId() const;
+    bool keyHasPassPhrase();
+    QString issuerId() const;
+    bool issuerSelfSigned();
+    QString accessUrl() const;
+
+  public slots:
+    void setSslStoreType( QgsSslCertSettings::SslStoreType storeType );
+    void setCertId( const QString& id );
+    void setKeyId( const QString& id );
+    void setKeyHasPassPhrase( bool hasPass );
+    void setIssuerId( const QString& id );
+    void setIssuerSelfSigned( bool selfSigned );
+    void setAccessUrl( const QString& url );
+
+    void validateCert();
+};

--- a/python/gui/qgssslcertificatewidget.sip
+++ b/python/gui/qgssslcertificatewidget.sip
@@ -18,32 +18,35 @@ class QgsSslCertificateWidget : QWidget
     explicit QgsSslCertificateWidget( QWidget *parent /TransferThis/ = 0, const QString& accessUrl = QString( "" ) );
     ~QgsSslCertificateWidget();
 
-    void loadSettings( QgsSslCertSettings::SslStoreType storeType = QgsSslCertSettings::QGISStore,
+    void loadSettings( QgsSslPkiSettings::SslStoreType storeType = QgsSslPkiSettings::QGISStore,
                        const QString& certId = "",
                        const QString& keyId = "",
-                       bool keyPassphrase = false,
+                       bool needsKeyPath = false,
+                       bool needsKeyPhrase = false,
                        const QString& issuerId = "",
                        bool issuerSelf = false );
 
-    void loadSslCertSettings( const QgsSslCertSettings& pki );
+    void loadSslCertSettings( const QgsSslPkiSettings& pki );
 
-    QgsSslCertSettings toSslCertSettings();
+    QgsSslPkiSettings toSslCertSettings();
 
     bool certIsValid();
 
-    QgsSslCertSettings::SslStoreType ssLStoreType();
+    QgsSslPkiSettings::SslStoreType ssLStoreType();
     QString certId() const;
     QString keyId() const;
-    bool keyHasPassPhrase();
+    bool needsKeyPath();
+    bool needsKeyPassphrase();
     QString issuerId() const;
     bool issuerSelfSigned();
     QString accessUrl() const;
 
   public slots:
-    void setSslStoreType( QgsSslCertSettings::SslStoreType storeType );
+    void setSslStoreType( QgsSslPkiSettings::SslStoreType storeType );
     void setCertId( const QString& id );
     void setKeyId( const QString& id );
-    void setKeyHasPassPhrase( bool hasPass );
+    void setNeedsKeyPath( bool needsPath );
+    void setNeedsKeyPassphrase( bool needsPass );
     void setIssuerId( const QString& id );
     void setIssuerSelfSigned( bool selfSigned );
     void setAccessUrl( const QString& url );

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -852,7 +852,7 @@ int main( int argc, char *argv[] )
 
 #ifndef QT_NO_OPENSSL
   //set up user-local SSL cert store
-  bool storeSetup = QgsSslUtils::createQgisCertStoreDir();
+  bool storeSetup = QgsSslPkiUtility::createQgisCertStoreDir();
   QgsDebugMsg( QString( "Setting up QGIS local cert store: %1" ).arg( storeSetup ? "succeeded" : "failed" ) );
 #endif
 

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -39,6 +39,7 @@
 #include "qgspluginregistry.h"
 #include "qgsmessagelog.h"
 #include "qgspythonrunner.h"
+#include "qgssslutils.h"
 
 #include <cstdio>
 #include <stdio.h>
@@ -847,6 +848,12 @@ int main( int argc, char *argv[] )
   QgsDebugMsg( QString( "Adding Mac QGIS and Qt plugins dirs to search path: %1" ).arg( myPath ) );
   QCoreApplication::addLibraryPath( QgsApplication::pluginPath() );
   QCoreApplication::addLibraryPath( myPath );
+#endif
+
+#ifndef QT_NO_OPENSSL
+  //set up user-local SSL cert store
+  bool storeSetup = QgsSslUtils::createQgisCertStoreDir();
+  QgsDebugMsg( QString( "Setting up QGIS local cert store: %1" ).arg( storeSetup ? "succeeded" : "failed" ) );
 #endif
 
   //set up splash screen

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -148,6 +148,7 @@ SET(QGIS_CORE_SRCS
   qgssimplifymethod.cpp
   qgssnapper.cpp
   qgsspatialindex.cpp
+  qgssslutils.cpp
   qgstolerance.cpp
   qgsvectordataprovider.cpp
   qgsvectorfilewriter.cpp
@@ -542,6 +543,7 @@ SET(QGIS_CORE_HDRS
   qgssimplifymethod.h
   qgssnapper.h
   qgsspatialindex.h
+  qgssslutils.h
   qgstolerance.h
   qgsvectordataprovider.h
   qgsvectorlayercache.h

--- a/src/core/qgscredentials.cpp
+++ b/src/core/qgscredentials.cpp
@@ -78,7 +78,7 @@ void QgsCredentials::put( QString realm, QString username, QString password )
   mCredentialCache.insert( realm, QPair<QString, QString>( username, password ) );
 }
 
-bool QgsCredentials::getSslKeyInfo( QString &password, QString& keypath, bool needskeypath,
+bool QgsCredentials::getSslKeyInfo( QString &password, QString &keypath, bool needskeypath,
                                     QString accessurl, QString message )
 {
   // shorten url of resource to keep any dialog from being too wide

--- a/src/core/qgscredentials.h
+++ b/src/core/qgscredentials.h
@@ -43,6 +43,10 @@ class CORE_EXPORT QgsCredentials
     bool get( QString realm, QString &username, QString &password, QString message = QString::null );
     void put( QString realm, QString username, QString password );
 
+    // FIXME: Why doesn't this cache work here, but it does in QNetworkManager?
+    bool getSsl( QString keyhash, QString &password, QString accessurl, QString message = QString::null );
+    void putSsl( QString keyhash, QString password );
+
     /**
      * @brief Get a passphrase for a private key for a client certificate to be used in an SSL PKI handshake.
      * @param The passphrase for the key.
@@ -92,6 +96,9 @@ class CORE_EXPORT QgsCredentials
 
     //! cache for already requested credentials in this session
     QMap< QString, QPair<QString, QString> > mCredentialCache;
+
+    //! cache for already requested SSL hash of key and its password in this session
+    QMap< QString, QString > mCredentialSslCache;
 
     //! Pointer to the credential instance
     static QgsCredentials *smInstance;

--- a/src/core/qgscredentials.h
+++ b/src/core/qgscredentials.h
@@ -43,10 +43,6 @@ class CORE_EXPORT QgsCredentials
     bool get( QString realm, QString &username, QString &password, QString message = QString::null );
     void put( QString realm, QString username, QString password );
 
-    // FIXME: Why doesn't this cache work here, but it does in QNetworkManager?
-    bool getSsl( QString keyhash, QString &password, QString accessurl, QString message = QString::null );
-    void putSsl( QString keyhash, QString password );
-
     /**
      * @brief Get a passphrase for a private key for a client certificate to be used in an SSL PKI handshake.
      * @param The passphrase for the key.
@@ -54,7 +50,8 @@ class CORE_EXPORT QgsCredentials
      * @param Optional short message to go below password field.
      * @return
      */
-    bool getSslNoCache( QString &password, QString accessurl, QString message = QString::null );
+    bool getSslKeyInfo( QString &password, QString &keypath, bool needskeypath,
+                        QString accessurl, QString message = QString::null );
 
     //! retrieves instance
     static QgsCredentials *instance();
@@ -85,8 +82,9 @@ class CORE_EXPORT QgsCredentials
     //! request a password
     virtual bool request( QString realm, QString &username, QString &password, QString message = QString::null ) = 0;
 
-    //! request a password for an SSL key
-    virtual bool requestSsl( QString &password, QString resource = QString::null, QString message = QString::null ) = 0;
+    //! request a password for an SSL key, and optionally its filepath
+    virtual bool requestSslKey( QString &password, QString &keypath, bool needskeypath,
+                                QString resource, QString message = QString::null ) = 0;
 
     //! register instance
     void setInstance( QgsCredentials *theInstance );
@@ -96,9 +94,6 @@ class CORE_EXPORT QgsCredentials
 
     //! cache for already requested credentials in this session
     QMap< QString, QPair<QString, QString> > mCredentialCache;
-
-    //! cache for already requested SSL hash of key and its password in this session
-    QMap< QString, QString > mCredentialSslCache;
 
     //! Pointer to the credential instance
     static QgsCredentials *smInstance;
@@ -128,7 +123,8 @@ class CORE_EXPORT QgsCredentialsConsole : public QObject, public QgsCredentials
   protected:
     virtual bool request( QString realm, QString &username, QString &password, QString message = QString::null );
 
-    virtual bool requestSsl( QString &password, QString resource = QString::null, QString message = QString::null );
+    virtual bool requestSslKey( QString &password, QString &keypath, bool needskeypath,
+                                QString resource, QString message = QString::null );
 };
 
 #endif

--- a/src/core/qgscredentials.h
+++ b/src/core/qgscredentials.h
@@ -43,6 +43,15 @@ class CORE_EXPORT QgsCredentials
     bool get( QString realm, QString &username, QString &password, QString message = QString::null );
     void put( QString realm, QString username, QString password );
 
+    /**
+     * @brief Get a passphrase for a private key for a client certificate to be used in an SSL PKI handshake.
+     * @param The passphrase for the key.
+     * @param URL shown in the private key's password input dialog, so user remembers what scheme://domain.tld:port the key was meant for.
+     * @param Optional short message to go below password field.
+     * @return
+     */
+    bool getSslNoCache( QString &password, QString accessurl, QString message = QString::null );
+
     //! retrieves instance
     static QgsCredentials *instance();
 
@@ -71,6 +80,9 @@ class CORE_EXPORT QgsCredentials
 
     //! request a password
     virtual bool request( QString realm, QString &username, QString &password, QString message = QString::null ) = 0;
+
+    //! request a password for an SSL key
+    virtual bool requestSsl( QString &password, QString resource = QString::null, QString message = QString::null ) = 0;
 
     //! register instance
     void setInstance( QgsCredentials *theInstance );
@@ -108,6 +120,8 @@ class CORE_EXPORT QgsCredentialsConsole : public QObject, public QgsCredentials
 
   protected:
     virtual bool request( QString realm, QString &username, QString &password, QString message = QString::null );
+
+    virtual bool requestSsl( QString &password, QString resource = QString::null, QString message = QString::null );
 };
 
 #endif

--- a/src/core/qgsdatasourceuri.cpp
+++ b/src/core/qgsdatasourceuri.cpp
@@ -277,6 +277,11 @@ QString QgsDataSourceURI::removePassword( const QString& aUri )
     QStringList strlist = aUri.split( "," );
     safeName = strlist[0] + "," + strlist[1] + "," + strlist[2] + "," + strlist[3];
   }
+  else if ( aUri.contains( ",keypass=" ) )
+  {
+    regexp.setPattern( ",keypass=.*," );
+    safeName.replace( regexp, "," );
+  }
   return safeName;
 }
 

--- a/src/core/qgsnetworkaccessmanager.h
+++ b/src/core/qgsnetworkaccessmanager.h
@@ -84,6 +84,41 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
 
     bool useSystemProxy() { return mUseSystemProxy; }
 
+    // NOTE: The following PKI hash/passphrase cache is in this singleton,
+    //       since it doesn't seem to function in QgsCredentials.
+
+    /**
+     * @brief Cache a hash/passphrase for private key of PKI certificate
+     * @param Cryptographic hash representing the checksum of the private key's data
+     * @param The passphrase
+     * @note Do NOT expose to Python
+     */
+    void setKeyPass( const QString& keyhash, const QString& keypass ) { mKeyPasses.insert( keyhash, keypass ); }
+    /**
+     * @brief Whether cache has a hash/passphrase for private key of PKI certificate
+     * @param Cryptographic hash representing the checksum of the private key's data
+     * @note Do NOT expose to Python
+     */
+    bool hasKeyPass( const QString& keyhash ) { return mKeyPasses.contains( keyhash ); }
+    /**
+     * @brief Get passphrase for private key of PKI certificate
+     * @param Cryptographic hash representing the checksum of the private key's data
+     *
+     * @note ################## Do NOT expose to Python ######################
+     */
+    const QString keyPass( const QString& keyhash ) { return mKeyPasses.value( keyhash ); }
+    /**
+     * @brief Remove cache entry for a hash/passphrase for private key of PKI certificate
+     * @param Cryptographic hash representing the checksum of the private key's data
+     * @note Do NOT expose to Python
+     */
+    bool removeKeyPass( const QString& keyhash ) { return ( bool ) mKeyPasses.remove( keyhash ); }
+    /**
+     * @brief Clear cache of hash/passphrases for private keys of PKI certificates
+     * @note Do NOT expose to Python
+     */
+    void clearKeyPasses() { mKeyPasses.clear(); }
+
   signals:
     void requestAboutToBeCreated( QNetworkAccessManager::Operation, const QNetworkRequest &, QIODevice * );
     void requestCreated( QNetworkReply * );
@@ -100,6 +135,7 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
     QNetworkProxy mFallbackProxy;
     QStringList mExcludedURLs;
     bool mUseSystemProxy;
+    QHash< QString, QString > mKeyPasses;
 };
 
 #endif // QGSNETWORKACCESSMANAGER_H

--- a/src/core/qgsowsconnection.cpp
+++ b/src/core/qgsowsconnection.cpp
@@ -26,6 +26,10 @@
 #include "qgsproviderregistry.h"
 #include "qgsowsconnection.h"
 
+#ifndef QT_NO_OPENSSL
+#include "qgssslutils.h"
+#endif
+
 #include <QInputDialog>
 #include <QMessageBox>
 #include <QPicture>
@@ -65,6 +69,11 @@ QgsOWSConnection::QgsOWSConnection( const QString & theService, const QString & 
     mUri.setParam( "username", username );
     mUri.setParam( "password", password );
   }
+
+#ifndef QT_NO_OPENSSL
+  QgsDataSourceURI * owsuri = &mUri;
+  QgsSslPkiSettings::updateOwsConnection( settings, credentialsKey, owsuri, &mConnectionInfo );
+#endif
 
   bool ignoreGetMap = settings.value( key + "/ignoreGetMapURI", false ).toBool();
   bool ignoreGetFeatureInfo = settings.value( key + "/ignoreGetFeatureInfoURI", false ).toBool();

--- a/src/core/qgsowsconnection.cpp
+++ b/src/core/qgsowsconnection.cpp
@@ -71,8 +71,7 @@ QgsOWSConnection::QgsOWSConnection( const QString & theService, const QString & 
   }
 
 #ifndef QT_NO_OPENSSL
-  QgsDataSourceURI * owsuri = &mUri;
-  QgsSslPkiSettings::updateOwsConnection( settings, credentialsKey, owsuri, &mConnectionInfo );
+  QgsSslPkiSettings::updateOwsConnection( settings, credentialsKey, mUri, mConnectionInfo );
 #endif
 
   bool ignoreGetMap = settings.value( key + "/ignoreGetMapURI", false ).toBool();

--- a/src/core/qgssslutils.cpp
+++ b/src/core/qgssslutils.cpp
@@ -139,6 +139,93 @@ QByteArray QgsSslPkiSettings::issuerCertData() const
   return data;
 }
 
+void QgsSslPkiSettings::updateOwsConnection( const QSettings& settings,
+    const QString& credentialsKey,
+    QgsDataSourceURI *uri,
+    QString *connectioninfo )
+{
+  bool validcert = settings.value( credentialsKey + "/ssl/validcert", false ).toBool();
+  if ( validcert )
+  {
+    QString storetype = settings.value( credentialsKey + "/ssl/store" ).toString(); // int(enum) -> string
+    QString certid = settings.value( credentialsKey + "/ssl/certid" ).toString();
+    QString keyid = settings.value( credentialsKey + "/ssl/keyid" ).toString();
+    bool needskeypath = settings.value( credentialsKey + "/ssl/needskeypath", true ).toBool();
+    bool needskeypass = settings.value( credentialsKey + "/ssl/needskeypass", false ).toBool();
+    QString issuerid = settings.value( credentialsKey + "/ssl/issuerid" ).toString();
+    bool issuerself = settings.value( credentialsKey + "/ssl/issuerself", false ).toBool();
+
+    QString sslinfo;
+
+    // store/cert/key should always be non-empty for cert to have validated
+    sslinfo.append( ",storetype=" + storetype + ",certid=" + certid + ",keyid=" + keyid );
+    uri->setParam( "storetype", storetype );
+    uri->setParam( "certid", certid );
+    uri->setParam( "keyid", keyid );
+    if ( needskeypath )
+    {
+      sslinfo.append( ",needskeypath=1" );
+      uri->setParam( "needskeypath", "1" );
+    }
+    if ( needskeypass )
+    {
+      sslinfo.append( ",needskeypass=1" );
+      uri->setParam( "needskeypass", "1" );
+    }
+    if ( !issuerid.isEmpty() )
+    {
+      sslinfo.append( ",issuerid=" + issuerid );
+      uri->setParam( "issuerid", issuerid );
+    }
+    if ( issuerself )
+    {
+      sslinfo.append( ",issuerself=1" );
+      uri->setParam( "issuerself", "1" );
+    }
+    *connectioninfo = *connectioninfo + sslinfo;
+  }
+}
+
+void QgsSslPkiSettings::updateOwsCapabilities( QgsSslPkiSettings *pki,
+    const QgsDataSourceURI& uri,
+    const QString& accessurl )
+{
+  if ( uri.hasParam( "certid" ) )
+  {
+    QgsDebugMsg( "ssl cert exists" );
+    pki->setStoreType(( QgsSslPkiSettings::SslStoreType ) uri.param( "storetype" ).toInt() );
+    QgsDebugMsg( QString( "ssl cert storetype (enum): %1" ).arg( pki->storeType() ) );
+    pki->setCertId( uri.param( "certid" ) );
+    QgsDebugMsg( "ssl cert certid: " + pki->certId() );
+    pki->setKeyId( uri.param( "keyid" ) );
+    QgsDebugMsg( "ssl cert keyid: " + pki->keyId() );
+    if ( uri.hasParam( "needskeypath" ) )
+    {
+      pki->setNeedsKeyPath( true );
+      QgsDebugMsg( "ssl cert key needs path defined" );
+    }
+    if ( uri.hasParam( "needskeypass" ) )
+    {
+      pki->setNeedsKeyPassphrase( true );
+      QgsDebugMsg( "ssl cert key needs password" );
+    }
+    if ( uri.hasParam( "keypass" ) )
+    {
+      pki->setNeedsKeyPassphrase( true ); // may not have been in URL
+      pki->setKeyPassphrase( uri.param( "keypass" ) );
+      QgsDebugMsg( "ssl cert password passed-in" );
+    }
+    pki->setIssuerId( uri.param( "issuerid" ) );
+    QgsDebugMsg( "ssl cert issuerid: " + pki->issuerId() );
+    if ( uri.hasParam( "issuerself" ) )
+    {
+      pki->setIssuerSelfSigned( true );
+      QgsDebugMsg( "ssl cert self-signed" );
+    }
+    pki->setAccessUrl( accessurl );
+  }
+}
+
 //////////////////////////////////////////////////////
 // QgsSslPkiGroup
 //////////////////////////////////////////////////////

--- a/src/core/qgssslutils.cpp
+++ b/src/core/qgssslutils.cpp
@@ -141,8 +141,8 @@ QByteArray QgsSslPkiSettings::issuerCertData() const
 
 void QgsSslPkiSettings::updateOwsConnection( const QSettings& settings,
     const QString& credentialsKey,
-    QgsDataSourceURI *uri,
-    QString *connectioninfo )
+    QgsDataSourceURI &uri,
+    QString &connectioninfo )
 {
   bool validcert = settings.value( credentialsKey + "/ssl/validcert", false ).toBool();
   if ( validcert )
@@ -159,70 +159,70 @@ void QgsSslPkiSettings::updateOwsConnection( const QSettings& settings,
 
     // store/cert/key should always be non-empty for cert to have validated
     sslinfo.append( ",storetype=" + storetype + ",certid=" + certid + ",keyid=" + keyid );
-    uri->setParam( "storetype", storetype );
-    uri->setParam( "certid", certid );
-    uri->setParam( "keyid", keyid );
+    uri.setParam( "storetype", storetype );
+    uri.setParam( "certid", certid );
+    uri.setParam( "keyid", keyid );
     if ( needskeypath )
     {
       sslinfo.append( ",needskeypath=1" );
-      uri->setParam( "needskeypath", "1" );
+      uri.setParam( "needskeypath", "1" );
     }
     if ( needskeypass )
     {
       sslinfo.append( ",needskeypass=1" );
-      uri->setParam( "needskeypass", "1" );
+      uri.setParam( "needskeypass", "1" );
     }
     if ( !issuerid.isEmpty() )
     {
       sslinfo.append( ",issuerid=" + issuerid );
-      uri->setParam( "issuerid", issuerid );
+      uri.setParam( "issuerid", issuerid );
     }
     if ( issuerself )
     {
       sslinfo.append( ",issuerself=1" );
-      uri->setParam( "issuerself", "1" );
+      uri.setParam( "issuerself", "1" );
     }
-    *connectioninfo = *connectioninfo + sslinfo;
+    connectioninfo.append( sslinfo );
   }
 }
 
-void QgsSslPkiSettings::updateOwsCapabilities( QgsSslPkiSettings *pki,
+void QgsSslPkiSettings::updateOwsCapabilities( QgsSslPkiSettings &pki,
     const QgsDataSourceURI& uri,
     const QString& accessurl )
 {
   if ( uri.hasParam( "certid" ) )
   {
     QgsDebugMsg( "ssl cert exists" );
-    pki->setStoreType(( QgsSslPkiSettings::SslStoreType ) uri.param( "storetype" ).toInt() );
-    QgsDebugMsg( QString( "ssl cert storetype (enum): %1" ).arg( pki->storeType() ) );
-    pki->setCertId( uri.param( "certid" ) );
-    QgsDebugMsg( "ssl cert certid: " + pki->certId() );
-    pki->setKeyId( uri.param( "keyid" ) );
-    QgsDebugMsg( "ssl cert keyid: " + pki->keyId() );
+    pki.setStoreType(( QgsSslPkiSettings::SslStoreType ) uri.param( "storetype" ).toInt() );
+    QgsDebugMsg( QString( "ssl cert storetype (enum): %1" ).arg( pki.storeType() ) );
+    pki.setCertId( uri.param( "certid" ) );
+    QgsDebugMsg( "ssl cert certid: " + pki.certId() );
+    pki.setKeyId( uri.param( "keyid" ) );
+    QgsDebugMsg( "ssl cert keyid: " + pki.keyId() );
     if ( uri.hasParam( "needskeypath" ) )
     {
-      pki->setNeedsKeyPath( true );
+      pki.setNeedsKeyPath( true );
       QgsDebugMsg( "ssl cert key needs path defined" );
     }
     if ( uri.hasParam( "needskeypass" ) )
     {
-      pki->setNeedsKeyPassphrase( true );
+      pki.setNeedsKeyPassphrase( true );
       QgsDebugMsg( "ssl cert key needs password" );
     }
     if ( uri.hasParam( "keypass" ) )
     {
-      pki->setNeedsKeyPassphrase( true ); // may not have been in URL
-      pki->setKeyPassphrase( uri.param( "keypass" ) );
+      pki.setNeedsKeyPassphrase( true ); // may not have been in URL
+      pki.setKeyPassphrase( uri.param( "keypass" ) );
       QgsDebugMsg( "ssl cert password passed-in" );
     }
-    pki->setIssuerId( uri.param( "issuerid" ) );
-    QgsDebugMsg( "ssl cert issuerid: " + pki->issuerId() );
+    pki.setIssuerId( uri.param( "issuerid" ) );
+    QgsDebugMsg( "ssl cert issuerid: " + pki.issuerId() );
     if ( uri.hasParam( "issuerself" ) )
     {
-      pki->setIssuerSelfSigned( true );
+      pki.setIssuerSelfSigned( true );
       QgsDebugMsg( "ssl cert self-signed" );
     }
-    pki->setAccessUrl( accessurl );
+    pki.setAccessUrl( accessurl );
   }
 }
 

--- a/src/core/qgssslutils.cpp
+++ b/src/core/qgssslutils.cpp
@@ -1,0 +1,431 @@
+/***************************************************************************
+    qgssslutils.cpp
+    ---------------------
+    begin                : 2014/09/12
+    copyright            : (C) 2014 by Boundless Spatial, Inc.
+    web                  : http://boundlessgeo.com
+    author               : Larry Shaffer
+    email                : larrys at dakotacarto dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgssslutils.h"
+
+#include <QDir>
+#include <QFile>
+#include <QInputDialog>
+#include <QSslConfiguration>
+#include <QSslError>
+
+#include "qgsapplication.h"
+#include "qgscredentials.h"
+#include "qgslogger.h"
+#include "qgsnetworkaccessmanager.h"
+
+
+QgsSslCertSettings::QgsSslCertSettings()
+    : mCertReady( false )
+    , mStoreType( QgsSslCertSettings::QGISStore )
+    , mCertId( "" )
+    , mKeyId( "" )
+    , mHasKeyPass( false )
+    , mKeyPass( "" )
+    , mIssuerCertId( "" )
+    , mIssuerSelf( false )
+    , mAccessUrl( "" )
+{
+}
+
+bool QgsSslCertSettings::certIsReady() const
+{
+  bool ready = true;
+
+  if ( mCertId.isEmpty() )
+  {
+    ready = ready && false;
+    QgsDebugMsg( "SSL cert not ready: client cert is empty" );
+  }
+
+  if ( mKeyId.isEmpty() )
+  {
+    ready = ready && false;
+    QgsDebugMsg( "SSL cert not ready: client key is empty" );
+  }
+
+  if ( !clientCert().isValid() )
+  {
+    ready = ready && false;
+    QgsDebugMsg( "SSL cert not ready: client cert is invalid" );
+  }
+
+  return ready;
+}
+
+QSslCertificate QgsSslCertSettings::clientCert() const
+{
+  if ( mCertId.isEmpty() )
+  {
+    return QSslCertificate();
+  }
+  if ( mStoreType == QgsSslCertSettings::QGISStore )
+  {
+    QString path = QgsSslUtils::qgisCertPath( mCertId );
+    if ( !path.isEmpty() )
+    {
+      return QgsSslUtils::certFromPath( path );
+    }
+  }
+  return QSslCertificate();
+}
+
+QSslKey QgsSslCertSettings::clientCertKey() const
+{
+  if ( mKeyId.isEmpty() )
+  {
+    return QSslKey();
+  }
+  if ( mStoreType == QgsSslCertSettings::QGISStore )
+  {
+    QString path = QgsSslUtils::qgisKeyPath( mKeyId );
+    if ( path.isEmpty() )
+    {
+      return QSslKey();
+    }
+
+    if ( !mKeyPass.isEmpty() || mHasKeyPass )
+    {
+      QString passphrase = ( !mKeyPass.isEmpty() ? mKeyPass : "" );
+      return QgsSslUtils::keyFromPath( path, QSsl::Pem, QSsl::PrivateKey, mHasKeyPass, passphrase, mAccessUrl );
+    }
+    else
+    {
+      return QgsSslUtils::keyFromPath( path );
+    }
+
+  }
+  return QSslKey();
+}
+
+QSslCertificate QgsSslCertSettings::issuerCert() const
+{
+  if ( mIssuerCertId.isEmpty() )
+  {
+    return QSslCertificate();
+  }
+
+  if ( mStoreType == QgsSslCertSettings::QGISStore )
+  {
+    QString path = QgsSslUtils::qgisIssuerPath( mIssuerCertId );
+    if ( !path.isEmpty() )
+    {
+      return QgsSslUtils::certFromPath( path );
+    }
+  }
+  return QSslCertificate();
+}
+
+//////////////////////////////////////////////////////
+// QgsSslUtils
+//////////////////////////////////////////////////////
+
+static QDir::Filters dirFilters = QDir::Files | QDir::NoDotAndDotDot | QDir::NoSymLinks | QDir::Readable;
+static QFile::Permissions dirPerms = QFile::ReadUser | QFile::WriteUser | QFile::ExeUser;
+
+const QString QgsSslUtils::qgisCertStoreDirPath()
+{
+  QDir certsDir( QgsApplication::qgisSettingsDirPath() + "cert_store" );
+  return certsDir.absolutePath();
+}
+
+const QString QgsSslUtils::qgisCertsDirPath() { return QgsSslUtils::qgisCertStoreDirPath() + QDir::separator() + "certs"; }
+const QString QgsSslUtils::qgisKeysDirPath() { return QgsSslUtils::qgisCertStoreDirPath() + QDir::separator() + "private"; }
+const QString QgsSslUtils::qgisIssuersDirPath() { return QgsSslUtils::qgisCertStoreDirPath() + QDir::separator() + "issuers"; }
+
+bool QgsSslUtils::createQgisCertStoreDir()
+{
+  QStringList paths;
+  paths << QgsSslUtils::qgisCertStoreDirPath()
+  << QgsSslUtils::qgisCertsDirPath()
+  << QgsSslUtils::qgisKeysDirPath()
+  << QgsSslUtils::qgisIssuersDirPath();
+
+  QDir cwd;
+  foreach ( const QString& path, paths )
+  {
+    if ( !cwd.mkpath( path ) )
+      return false;
+    if ( !QFile::setPermissions( path, dirPerms ) )
+      return false;
+  }
+  return true;
+}
+
+static QString existingFilePath_( const QString& dir, const QString& file )
+{
+  QString path = dir + QDir::separator() + file;
+  bool exists = false;
+  if ( !file.isNull() && !file.isEmpty() )
+  {
+    exists = QFile::exists( path );
+  }
+  return ( exists ? path : QString() );
+}
+
+const QString QgsSslUtils::qgisCertPath( const QString& file )
+{
+  return existingFilePath_( QgsSslUtils::qgisCertsDirPath(), file );
+}
+
+const QString QgsSslUtils::qgisKeyPath( const QString& file )
+{
+  return existingFilePath_( QgsSslUtils::qgisKeysDirPath(), file );
+}
+
+const QString QgsSslUtils::qgisIssuerPath( const QString& file )
+{
+  return existingFilePath_( QgsSslUtils::qgisIssuersDirPath(), file );
+}
+
+static QStringList dirListing_( const QString& dirPath, const QStringList& nameFilter )
+{
+  QDir dir( dirPath );
+  return dir.entryList( nameFilter, dirFilters );
+}
+
+const QStringList QgsSslUtils::storeCerts( QgsSslCertSettings::SslStoreType store )
+{
+  QStringList certs;
+  if ( store == QgsSslCertSettings::QGISStore )
+  {
+    certs = dirListing_( QgsSslUtils::qgisCertsDirPath(), QStringList() << "*.pem" );
+  }
+  return certs;
+}
+
+const QStringList QgsSslUtils::storeKeys( QgsSslCertSettings::SslStoreType store )
+{
+  QStringList keys;
+  if ( store == QgsSslCertSettings::QGISStore )
+  {
+    keys = dirListing_( QgsSslUtils::qgisKeysDirPath(), QStringList() << "*.pem" << "*.key" );
+  }
+  return keys;
+}
+
+const QStringList QgsSslUtils::storeIssuers( QgsSslCertSettings::SslStoreType store )
+{
+  QStringList iss;
+  if ( store == QgsSslCertSettings::QGISStore )
+  {
+    iss = dirListing_( QgsSslUtils::qgisIssuersDirPath(), QStringList() << "*.pem" );
+  }
+  return iss;
+}
+
+QSslCertificate QgsSslUtils::certFromPath( const QString &path, QSsl::EncodingFormat format )
+{
+  QSslCertificate cert;
+  QFile file( path );
+  if ( file.exists() )
+  {
+    bool ret = file.open( QIODevice::ReadOnly | QIODevice::Text );
+    if ( ret )
+    {
+      cert = QSslCertificate( file.readAll(), format );
+    }
+    file.close();
+  }
+  return cert;
+}
+
+QSsl::KeyAlgorithm QgsSslUtils::keyAlgorithm( const QByteArray& keydata )
+{
+  QString keytxt( keydata );
+  return (( keytxt.contains( "BEGIN DSA P" ) ) ? QSsl::Dsa : QSsl::Rsa );
+}
+
+QSslKey QgsSslUtils::keyFromData( const QByteArray& keydata,
+                                  QSsl::EncodingFormat format,
+                                  QSsl::KeyType type,
+                                  bool hasKeyPhrase,
+                                  const QString& passedinphrase,
+                                  const QString& accessurl )
+{
+  QSsl::KeyAlgorithm algorithm = QgsSslUtils::keyAlgorithm( keydata );
+  QString keyhash = QgsSslUtils::keyHashFromData( keydata );
+  QgsNetworkAccessManager * naM = QgsNetworkAccessManager::instance();
+
+  if ( !passedinphrase.isEmpty() )
+  {
+    // cache passed-in password
+    if ( !naM->hasKeyPass( keyhash ) )
+    {
+      naM->setKeyPass( keyhash, passedinphrase );
+    }
+    QgsDebugMsg( QString( "Creating SSL key using passed-in passphrase" ) );
+  }
+  else if ( hasKeyPhrase && !naM->hasKeyPass( keyhash ) )
+  {
+    QString inputphrase;
+    QgsCredentials * creds = QgsCredentials::instance();
+    creds->lock();
+    bool ok = creds->getSslNoCache( inputphrase, accessurl );
+    creds->unlock();
+    if ( !ok )
+    {
+      return QSslKey( keydata, algorithm, format, type );
+    }
+
+    if ( !inputphrase.isEmpty() )
+    {
+      if ( !naM->hasKeyPass( keyhash ) )
+      {
+        naM->setKeyPass( keyhash, inputphrase );
+      }
+      QgsDebugMsg( QString( "Creating SSL key using input passphrase" ) );
+    }
+  }
+
+  QString passphrase;
+  if ( naM->hasKeyPass( keyhash ) )
+  {
+    passphrase = naM->keyPass( keyhash );
+  }
+
+  // create key
+  QSslKey clientKey = QSslKey( keydata, algorithm, format, type, passphrase.toLocal8Bit() );
+
+  if ( hasKeyPhrase && !passphrase.isEmpty() && clientKey.isNull() )
+  {
+    // assume passphrase didn't work, so make sure it is removed from cache
+    // NOTE: could be other reasons for key creation failure?
+    if ( naM->hasKeyPass( keyhash ) )
+    {
+      naM->removeKeyPass( keyhash );
+    }
+    QgsDebugMsg( QString( "Creating SSL key FAILED using passphrase" ) );
+  }
+
+  return clientKey;
+}
+
+QSslKey QgsSslUtils::keyFromPath( const QString& path,
+                                  QSsl::EncodingFormat format,
+                                  QSsl::KeyType type,
+                                  bool hasKeyPhrase,
+                                  const QString& passphrase,
+                                  const QString& accessurl )
+{
+  QSslKey certkey;
+  QFile file( path );
+  if ( file.exists() )
+  {
+    bool ret = file.open( QIODevice::ReadOnly | QIODevice::Text );
+    if ( ret )
+    {
+      certkey = QgsSslUtils::keyFromData( file.readAll(), format, type, hasKeyPhrase, passphrase, accessurl );
+    }
+    file.close();
+  }
+  return certkey;
+}
+
+const QString QgsSslUtils::keyHashFromData( const QByteArray & data )
+{
+  if ( data.isEmpty() )
+  {
+    return QString();
+  }
+  // MD5 is fine (and faster), since it is not securing anything,
+  // it's just used to represent the key data as a short string
+  return QString( QCryptographicHash::hash( data, QCryptographicHash::Md5 ).toHex() );
+}
+
+const QString QgsSslUtils::keyHashFromPath( const QString& path )
+{
+  QString hash;
+  QFile file( path );
+  if ( file.exists() )
+  {
+    bool ret = file.open( QIODevice::ReadOnly | QIODevice::Text );
+    if ( ret )
+    {
+      hash = QgsSslUtils::keyHashFromData( file.readAll() );
+    }
+    file.close();
+  }
+  return hash;
+}
+
+void QgsSslUtils::updateRequestSslConfiguration( QNetworkRequest &request, const QgsSslCertSettings& pki )
+{
+  if ( !pki.certIsReady() )
+  {
+    return;
+  }
+
+  QSslCertificate clientcert = pki.clientCert();
+  QSslKey certkey = pki.clientCertKey();
+  if ( clientcert.isNull() || certkey.isNull() )
+  {
+    return;
+  }
+
+  QSslConfiguration sslConfig = request.sslConfiguration();
+  //QSslConfiguration sslConfig( QSslConfiguration::defaultConfiguration() );
+
+  sslConfig.setProtocol( QSsl::TlsV1SslV3 );
+
+  QSslCertificate issuercert = pki.issuerCert();
+  if ( !issuercert.isNull() )
+  {
+    QList<QSslCertificate> sslCAs( sslConfig.caCertificates() );
+    sslCAs << issuercert;
+    sslConfig.setCaCertificates( sslCAs );
+  }
+
+  sslConfig.setLocalCertificate( clientcert );
+  sslConfig.setPrivateKey( certkey );
+
+  request.setSslConfiguration( sslConfig );
+}
+
+void QgsSslUtils::updateReplyExpectedSslErrors( QNetworkReply *reply, const QgsSslCertSettings& pki )
+{
+  if ( !pki.certIsReady() )
+  {
+    return;
+  }
+
+  if ( pki.issuerSelfSigned() )
+  {
+    QList<QSslError> expectedSslErrors;
+    QSslError error = QSslError();
+    QString issuer = "";
+    QSslCertificate issuercert = pki.issuerCert();
+
+    if ( !issuercert.isNull() )
+    {
+      issuer = " for defined issuer";
+      error = QSslError( QSslError::SelfSignedCertificate, issuercert );
+    }
+    else
+    {
+      // issuer not defined, but may already be in available CAs
+      issuer = " for ALL in chain";
+      error = QSslError( QSslError::SelfSignedCertificate );
+    }
+    if ( error.error() != QSslError::NoError )
+    {
+      QgsDebugMsg( QString( "Adding self-signed cert expected ssl error%1" ).arg( issuer ) );
+      expectedSslErrors.append( error );
+      reply->ignoreSslErrors( expectedSslErrors );
+    }
+  }
+}

--- a/src/core/qgssslutils.h
+++ b/src/core/qgssslutils.h
@@ -1,0 +1,276 @@
+/***************************************************************************
+    qgssslutils.h
+    ---------------------
+    begin                : 2014/09/12
+    copyright            : (C) 2014 by Boundless Spatial, Inc.
+    web                  : http://boundlessgeo.com
+    author               : Larry Shaffer
+    email                : larrys at dakotacarto dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSSSLUTILS_H
+#define QGSSSLUTILS_H
+
+#include <QCryptographicHash>
+#include <QNetworkReply>
+#include <QNetworkRequest>
+#include <QSslCertificate>
+#include <QSslKey>
+#include <QUrl>
+
+
+/**
+ * @class QgsSslCertSettings
+ * @ingroup core
+ * @brief Settings for working with a SSL certificate, key and optional certificate issuer
+ * @since since 2.6
+ */
+
+class CORE_EXPORT QgsSslCertSettings
+{
+  public:
+
+    /**
+     * @brief The SslStoreType enum defines the type of certificate store, e.g. local ~/.qgis2/cert_store,
+     * which can contain client 'certs', client certificate 'private' keys, and any certificate 'issuers'
+     * @since 2.6
+     */
+    enum SslStoreType
+    {
+      QGISStore = 0
+    };
+
+    QgsSslCertSettings();
+
+    /**
+     * @brief Get the client certificate for this PKI session
+     */
+    QSslCertificate clientCert() const;
+
+    /**
+     * @brief Get the client certificate key for this PKI session
+     */
+    QSslKey clientCertKey() const;
+
+    /**
+     * @brief Get the client certificate's issuer certificate (optional) for this PKI session.
+     * The certificate can be installed in the main OpenSSL store, but defining it here allows it
+     * to specifically skip the blocking error of being self-signed.
+     */
+    QSslCertificate issuerCert() const;
+
+    // TODO: add protocol option, e.g. QSsl::TlsV1SslV3, etc.?
+
+    bool certIsReady() const;
+    /**
+     * @brief Convenience function to set whether the cert is ready for SSL connection.
+     * @note Only useful if you have just validated the cert outside of settings, otherwise may become stale.
+     */
+    void setCertReady( bool ready ) { mCertReady = ready; }
+
+    /**
+     * @brief The certificate store type, generally defauts to QGIS local store at ~/.qgis2/cert_store,
+     * which is then added to the underlying OpenSSL store certificate chain.
+     */
+    QgsSslCertSettings::SslStoreType storeType() const { return mStoreType; }
+    void setStoreType( QgsSslCertSettings::SslStoreType storetype ) { mStoreType = storetype; }
+
+    /**
+     * @brief String representation of the client certificate, e.g. file's basename.ext for QGIS local store.
+     * For other stores, which are not file-based, it may be the PKI component's serial number, etc.
+     */
+    QString certId() const { return mCertId; }
+    void setCertId( const QString& txtid ) { mCertId = txtid; }
+
+    /**
+     * @brief String representation of the client certificate's private key, e.g. file's basename.ext for QGIS local store.
+     * For other stores, which are not file-based, it may be the PKI component's serial number, etc.
+     */
+    QString keyId() const { return mKeyId; }
+    void setKeyId( const QString& txtid ) { mKeyId = txtid; }
+
+    /**
+     * @brief Whether the private key for the client certificate is protected by a passphrase.
+     */
+    bool hasKeyPassphrase() const { return mHasKeyPass; }
+    void setHasKeyPassphrase( bool has ) { mHasKeyPass = has; }
+
+    /**
+     * @brief Temporary storage for the passphrase for private key of the client certificate,
+     * when such a passphrase has been passed to the application in a obfuscated manner, e.g. commandline.
+     * @note Do NOT write this out to disk. Upon valid connection, it is cached elsewhere and can be deleted.
+     * Do NOT consider this secure storage for the password.
+     */
+    QString keyPassphrase() const { return mKeyPass; }
+    void setKeyPassphrase( const QString& passphrase ) { mKeyPass = passphrase; }
+
+    /**
+     * @brief String representation of the client certificate's certificate issuer, e.g. file's basename.ext for QGIS local store.
+     * For other stores, which are not file-based, it may be the PKI component's serial number, etc.
+     */
+    QString issuerId() const { return mIssuerCertId; }
+    void setIssuerId( const QString& txtid ) { mIssuerCertId = txtid; }
+
+    /**
+     * @brief Whether the certificate issuer's trust chain is self-signed.
+     * Only set this for issuer certificates whose origin you TRUST.
+     */
+    bool issuerSelfSigned() const { return mIssuerSelf; }
+    void setIssuerSelfSigned( bool seflsigned ) { mIssuerSelf = seflsigned; }
+
+    /**
+     * @brief Some URL associated with the SSL access. It is not used for any validation of PKI components.
+     * Shown in the private key's password input dialog, so user remembers what scheme://domain.tld:port the key was meant for.
+     */
+    QString accessUrl() const { return mAccessUrl; }
+    void setAccessUrl( const QString& url ) { mAccessUrl = url; }
+
+  private:
+    bool mCertReady;
+
+    QgsSslCertSettings::SslStoreType mStoreType;
+    QString mCertId;
+    QString mKeyId;
+    bool mHasKeyPass;
+    QString mKeyPass;
+    QString mIssuerCertId;
+    bool mIssuerSelf;
+    QString mAccessUrl;
+};
+
+/**
+ * @class QgsSslUtils
+ * @ingroup core
+ * @brief Utilites functions for working with SSL certificates, keys and connections
+ * @since 2.6
+ */
+
+class CORE_EXPORT QgsSslUtils
+{
+
+  public:
+    /**
+     * @brief Path to user-local QGIS directory for certs, keys and issuers
+     */
+    static const QString qgisCertStoreDirPath();
+
+    /**
+     * @brief Create user-local QGIS directory for certs, keys and issuers.
+     * Done automatically upon startup of QGIS Desktop, other uses will need to call this manually.
+     */
+    static bool createQgisCertStoreDir();
+
+    /**
+     * @brief Path specific to QGIS local store: ~/.qgis2/certs
+     */
+    static const QString qgisCertsDirPath();
+    /**
+     * @brief Path specific to QGIS local store: ~/.qgis2/private
+     */
+    static const QString qgisKeysDirPath();
+    /**
+     * @brief Path specific to QGIS local store: ~/.qgis2/issuers
+     */
+    static const QString qgisIssuersDirPath();
+
+    /**
+     * @brief Absolute path of file in QGIS local store: ~/.qgis2/certs/file
+     * @return NULL QString if file does not exist
+     */
+    static const QString qgisCertPath( const QString& file );
+    /**
+     * @brief Absolute path of file in QGIS local store: ~/.qgis2/private/file
+     * @return NULL QString if file does not exist
+     */
+    static const QString qgisKeyPath( const QString& file );
+    /**
+     * @brief Absolute path of file in QGIS local store: ~/.qgis2/issuers/file
+     * @return NULL QString if file does not exist
+     */
+    static const QString qgisIssuerPath( const QString& file );
+
+    // TODO: return different collection type to accommodate all stores (list of QVariants?)
+    /**
+     * @brief Filtered list of all available PEM PKI client certificates.
+     * @param store The store type, e.g. QGIS local store
+     */
+    static const QStringList storeCerts( QgsSslCertSettings::SslStoreType store );
+    /**
+     * @brief Filtered list of all available PEM PKI client certificate keys.
+     * @param store The store type, e.g. QGIS local store
+     */
+    static const QStringList storeKeys( QgsSslCertSettings::SslStoreType store );
+    /**
+     * @brief Filtered list of all available PEM PKI client certificate issuers.
+     * @param store The store type, e.g. QGIS local store
+     */
+    static const QStringList storeIssuers( QgsSslCertSettings::SslStoreType store );
+
+    /**
+     * @brief Get a certificate from an absolute file path.
+     */
+    static QSslCertificate certFromPath( const QString& path, QSsl::EncodingFormat format = QSsl::Pem );
+
+    /**
+     * @brief Get the deduced encryption algorithm used for the client certificate's key.
+     */
+    static QSsl::KeyAlgorithm keyAlgorithm( const QByteArray& keydata );
+
+    /**
+     * @brief Get a private/public key from provided data
+     * @param hasKeyPhrase Whether the key is passphrase-protected
+     * @param passphrase Passphrase of key (if set, you do not need hasKeyPhrase)
+     * @param accessurl Some URL associated with the SSL access. It is not used for any validation of PKI components.
+     * Shown in the private key's password input dialog, so user remembers what scheme://domain.tld:port the key was meant for.
+     */
+    static QSslKey keyFromData( const QByteArray& keydata,
+                                QSsl::EncodingFormat format = QSsl::Pem,
+                                QSsl::KeyType type = QSsl::PrivateKey,
+                                bool hasKeyPhrase = false,
+                                const QString& passphrase = QString(),
+                                const QString& accessurl = QString() );
+    /**
+     * @brief Get a private/public key from provided absolute file path
+     * @param hasKeyPhrase Whether the key is passphrase-protected
+     * @param passphrase Passphrase of key (if set, you do not need hasKeyPhrase)
+     * @param accessurl Some URL associated with the SSL access. It is not used for any validation of PKI components.
+     * Shown in the private key's password input dialog, so user remembers what scheme://domain.tld:port the key was meant for.
+     */
+    static QSslKey keyFromPath( const QString& path,
+                                QSsl::EncodingFormat format = QSsl::Pem,
+                                QSsl::KeyType type = QSsl::PrivateKey,
+                                bool hasKeyPhrase = false,
+                                const QString& passphrase = QString(),
+                                const QString& accessurl = QString() );
+
+    /**
+     * @brief Get hash string from data to be used as key for passphrase storage
+     * @return Hex-based checksum string
+     */
+    static const QString keyHashFromData( const QByteArray & data );
+    /**
+     * @brief Get hash string from absolute file path to be used as key for passphrase storage
+     * @return Hex-based checksum string
+     */
+    static const QString keyHashFromPath( const QString& path );
+
+    /**
+     * @brief Update existing network request SslConfiguration with PKI connection settings
+     * @note This should set up the connection with everything it needs for an (successful) SSL handshake
+     */
+    static void updateRequestSslConfiguration( QNetworkRequest &request, const QgsSslCertSettings& pki );
+    /**
+     * @brief Update existing network reply with expected SSL errors derived from PKI connection settings
+     * @note Generally this is used for ignoring self-signed issuer certificates, individually.
+     */
+    static void updateReplyExpectedSslErrors( QNetworkReply *reply, const QgsSslCertSettings& pki );
+};
+
+#endif // QGSSSLUTILS_H

--- a/src/core/qgssslutils.h
+++ b/src/core/qgssslutils.h
@@ -23,7 +23,10 @@
 #include <QNetworkRequest>
 #include <QSslCertificate>
 #include <QSslKey>
+#include <QSettings>
 #include <QUrl>
+
+#include "qgsdatasourceuri.h"
 
 
 /**
@@ -137,6 +140,15 @@ class CORE_EXPORT QgsSslPkiSettings
      */
     QString accessUrl() const { return mAccessUrl; }
     void setAccessUrl( const QString& url ) { mAccessUrl = url; }
+
+    static void updateOwsConnection( const QSettings& settings,
+                                     const QString& credentialsKey,
+                                     QgsDataSourceURI *uri,
+                                     QString *connectioninfo );
+
+    static void updateOwsCapabilities( QgsSslPkiSettings *pki,
+                                       const QgsDataSourceURI& uri,
+                                       const QString& accessurl );
 
   private:
     bool mCertReady;

--- a/src/core/qgssslutils.h
+++ b/src/core/qgssslutils.h
@@ -143,10 +143,10 @@ class CORE_EXPORT QgsSslPkiSettings
 
     static void updateOwsConnection( const QSettings& settings,
                                      const QString& credentialsKey,
-                                     QgsDataSourceURI *uri,
-                                     QString *connectioninfo );
+                                     QgsDataSourceURI &uri,
+                                     QString &connectioninfo );
 
-    static void updateOwsCapabilities( QgsSslPkiSettings *pki,
+    static void updateOwsCapabilities( QgsSslPkiSettings &pki,
                                        const QgsDataSourceURI& uri,
                                        const QString& accessurl );
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -212,6 +212,7 @@ qgsscalerangewidget.cpp
 qgsscalevisibilitydialog.cpp
 qgssearchquerybuilder.cpp
 qgsslider.cpp
+qgssslcertificatewidget.cpp
 qgssublayersdialog.cpp
 qgssvgannotationitem.cpp
 qgstextannotationitem.cpp
@@ -404,6 +405,7 @@ qgsscalerangewidget.h
 qgsscalevisibilitydialog.h
 qgssearchquerybuilder.h
 qgsslider.h
+qgssslcertificatewidget.h
 qgssublayersdialog.h
 qgsunitselectionwidget.h
 )
@@ -482,6 +484,7 @@ qgsscalerangewidget.h
 qgsscalevisibilitydialog.h
 qgssearchquerybuilder.h
 qgsslider.h
+qgssslcertificatewidget.h
 qgssublayersdialog.h
 qgsvectorlayertools.h
 qgsvertexmarker.h

--- a/src/gui/qgscredentialdialog.h
+++ b/src/gui/qgscredentialdialog.h
@@ -37,11 +37,17 @@ class GUI_EXPORT QgsCredentialDialog : public QDialog, public QgsCredentials, pr
   signals:
     void credentialsRequested( QString, QString *, QString *, QString, bool * );
 
+    void credentialsRequestedSsl( QString *, QString, QString, bool * );
+
   private slots:
     void requestCredentials( QString, QString *, QString *, QString, bool * );
 
+    void requestCredentialsSsl( QString *, QString, QString, bool * );
+
   protected:
     virtual bool request( QString realm, QString &username, QString &password, QString message = QString::null );
+
+    virtual bool requestSsl( QString &password, QString resource = QString::null, QString message = QString::null );
 };
 
 #endif

--- a/src/gui/qgscredentialdialog.h
+++ b/src/gui/qgscredentialdialog.h
@@ -37,17 +37,20 @@ class GUI_EXPORT QgsCredentialDialog : public QDialog, public QgsCredentials, pr
   signals:
     void credentialsRequested( QString, QString *, QString *, QString, bool * );
 
-    void credentialsRequestedSsl( QString *, QString, QString, bool * );
+    void credentialsRequestedSslKey( QString *, QString *, bool, QString, QString, bool * );
 
   private slots:
     void requestCredentials( QString, QString *, QString *, QString, bool * );
 
-    void requestCredentialsSsl( QString *, QString, QString, bool * );
+    void on_tbKeyPathSelect_clicked( bool chkd );
+
+    void requestCredentialsSslKey( QString *, QString *, bool, QString, QString, bool * );
 
   protected:
     virtual bool request( QString realm, QString &username, QString &password, QString message = QString::null );
 
-    virtual bool requestSsl( QString &password, QString resource = QString::null, QString message = QString::null );
+    virtual bool requestSslKey( QString &password, QString &keypath, bool needskeypath,
+                                QString resource, QString message = QString::null );
 };
 
 #endif

--- a/src/gui/qgsnewhttpconnection.cpp
+++ b/src/gui/qgsnewhttpconnection.cpp
@@ -104,10 +104,11 @@ QgsNewHttpConnection::QgsNewHttpConnection(
 
 #ifndef QT_NO_OPENSSL
     mCertWidget->loadSettings(
-      ( QgsSslCertSettings::SslStoreType ) settings.value( credentialsKey + "/ssl/store", QgsSslCertSettings::QGISStore ).toUInt(),
+      ( QgsSslPkiSettings::SslStoreType ) settings.value( credentialsKey + "/ssl/store", QgsSslPkiSettings::QGISStore ).toUInt(),
       settings.value( credentialsKey + "/ssl/certid", "" ).toString(),
       settings.value( credentialsKey + "/ssl/keyid", "" ).toString(),
-      settings.value( credentialsKey + "/ssl/haskeypass", false ).toBool(),
+      settings.value( credentialsKey + "/ssl/needskeypath", true ).toBool(),
+      settings.value( credentialsKey + "/ssl/needskeypass", false ).toBool(),
       settings.value( credentialsKey + "/ssl/issuerid", "" ).toString(),
       settings.value( credentialsKey + "/ssl/issuerself", false ).toBool()
     );
@@ -273,7 +274,8 @@ void QgsNewHttpConnection::accept()
   settings.setValue( credentialsKey + "/ssl/store", ( unsigned ) mCertWidget->ssLStoreType() );
   settings.setValue( credentialsKey + "/ssl/certid", mCertWidget->certId() );
   settings.setValue( credentialsKey + "/ssl/keyid", mCertWidget->keyId() );
-  settings.setValue( credentialsKey + "/ssl/haskeypass", mCertWidget->keyHasPassPhrase() );
+  settings.setValue( credentialsKey + "/ssl/needskeypath", mCertWidget->needsKeyPath() );
+  settings.setValue( credentialsKey + "/ssl/needskeypass", mCertWidget->needsKeyPassphrase() );
   settings.setValue( credentialsKey + "/ssl/issuerid", mCertWidget->issuerId() );
   settings.setValue( credentialsKey + "/ssl/issuerself", mCertWidget->issuerSelfSigned() );
   // this setting is not loaded into the SSL widget, but is stored only on apply and

--- a/src/gui/qgsnewhttpconnection.cpp
+++ b/src/gui/qgsnewhttpconnection.cpp
@@ -26,11 +26,13 @@
 #include <QRegExpValidator>
 
 QgsNewHttpConnection::QgsNewHttpConnection(
-  QWidget *parent, const QString& baseKey, const QString& connName, Qt::WindowFlags fl ):
-    QDialog( parent, fl ),
-    mBaseKey( baseKey ),
-    mOriginalConnName( connName ),
-    mCertWidget( 0 )
+  QWidget *parent, const QString& baseKey, const QString& connName, Qt::WindowFlags fl )
+    : QDialog( parent, fl )
+    , mBaseKey( baseKey )
+    , mOriginalConnName( connName )
+#ifndef QT_NO_OPENSSL
+    , mCertWidget( 0 )
+#endif
 {
   setupUi( this );
 

--- a/src/gui/qgsnewhttpconnection.h
+++ b/src/gui/qgsnewhttpconnection.h
@@ -19,6 +19,7 @@
 #include "ui_qgsnewhttpconnectionbase.h"
 #include "qgisgui.h"
 #include "qgscontexthelp.h"
+#include "qgssslcertificatewidget.h"
 /*!
  * \brief Dialog to allow the user to configure and save connection
  * information for an HTTP Server for WMS, etc.
@@ -46,6 +47,7 @@ class GUI_EXPORT QgsNewHttpConnection : public QDialog, private Ui::QgsNewHttpCo
     QString mBaseKey;
     QString mCredentialsBaseKey;
     QString mOriginalConnName; //store initial name to delete entry in case of rename
+    QgsSslCertificateWidget * mCertWidget;
 };
 
 #endif //  QGSNEWHTTPCONNECTION_H

--- a/src/gui/qgsnewhttpconnection.h
+++ b/src/gui/qgsnewhttpconnection.h
@@ -47,7 +47,9 @@ class GUI_EXPORT QgsNewHttpConnection : public QDialog, private Ui::QgsNewHttpCo
     QString mBaseKey;
     QString mCredentialsBaseKey;
     QString mOriginalConnName; //store initial name to delete entry in case of rename
+#ifndef QT_NO_OPENSSL
     QgsSslCertificateWidget * mCertWidget;
+#endif
 };
 
 #endif //  QGSNEWHTTPCONNECTION_H

--- a/src/gui/qgssslcertificatewidget.cpp
+++ b/src/gui/qgssslcertificatewidget.cpp
@@ -1,0 +1,520 @@
+/***************************************************************************
+    qgssslcertificatewidget.cpp
+                             -------------------
+    begin                : 2014-09-12
+    copyright            : (C) 2014 by Boundless Spatial, Inc.
+    web                  : http://boundlessgeo.com
+    author               : Larry Shaffer
+    email                : larrys at dakotacarto dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgssslcertificatewidget.h"
+#include "qgssslutils.h"
+
+#include <QAction>
+#include <QDateTime>
+#include <QDesktopServices>
+#include <QFileDialog>
+#include <QMenu>
+#include <QUrl>
+
+static QString validGreen_( const QString& selector = "*" )
+{
+  return QString( "%1{color: rgb(0, 170, 0);}" ).arg( selector );
+}
+static QString validRed_( const QString& selector = "*" )
+{
+  return QString( "%1{color: rgb(200, 0, 0);}" ).arg( selector );
+}
+//static QString validGray_( const QString& selector = "*" )
+//{
+//  return QString( "%1{color: rgb(175, 175, 175);}" ).arg( selector );
+//}
+
+QgsSslCertificateWidget::QgsSslCertificateWidget( QWidget *parent, const QString& accessUrl )
+    : QWidget( parent )
+    , mStoreType( QgsSslCertSettings::QGISStore )
+    , mCertValid( false )
+    , mAccessUrl( accessUrl )
+    , mQgisCertsMenu( 0 )
+    , mQgisKeysMenu( 0 )
+    , mQgisIssuersMenu( 0 )
+{
+  setupUi( this );
+
+  clearCert();
+
+  // TODO: reactivate this button and add more validation and information on errors and cert chain
+  btnValidateCert->hide();
+
+  connect( cmbStoreType, SIGNAL( currentIndexChanged( int ) ), stckwCertStore, SLOT( setCurrentIndex( int ) ) );
+
+  connect( btnClearCert, SIGNAL( clicked() ), this, SLOT( clearCert() ) );
+
+  // QGIS user-local store (default store)
+  connect( btnOpenStore, SIGNAL( clicked() ), this, SLOT( openQgisStoreDir() ) );
+  mQgisCertsMenu = new QMenu( this );
+  btnQgisCert->setMenu( mQgisCertsMenu );
+  connect( mQgisCertsMenu, SIGNAL( aboutToShow() ), this, SLOT( populateQgisCertsMenu() ) );
+  connect( mQgisCertsMenu, SIGNAL( triggered( QAction* ) ), this, SLOT( qgisCertsMenuTriggered( QAction* ) ) );
+  mQgisKeysMenu = new QMenu( this );
+  btnQgisKey->setMenu( mQgisKeysMenu );
+  connect( mQgisKeysMenu, SIGNAL( aboutToShow() ), this, SLOT( populateQgisKeysMenu() ) );
+  connect( mQgisKeysMenu, SIGNAL( triggered( QAction* ) ), this, SLOT( qgisKeysMenuTriggered( QAction* ) ) );
+  mQgisIssuersMenu = new QMenu( this );
+  btnQgisIssuer->setMenu( mQgisIssuersMenu );
+  connect( mQgisIssuersMenu, SIGNAL( aboutToShow() ), this, SLOT( populateQgisIssuersMenu() ) );
+  connect( mQgisIssuersMenu, SIGNAL( triggered( QAction* ) ), this, SLOT( qgisIssuersMenuTriggered( QAction* ) ) );
+}
+
+QgsSslCertificateWidget::~QgsSslCertificateWidget()
+{
+}
+
+void QgsSslCertificateWidget::loadSettings( QgsSslCertSettings::SslStoreType storeType, const QString &certId, const QString &keyId,
+    bool keyPassphrase, const QString &issuerId, bool issuerSelf )
+{
+  setSslStoreType( storeType );
+  setCertId( certId );
+  setKeyId( keyId );
+  setKeyHasPassPhrase( keyPassphrase );
+  setIssuerId( issuerId );
+  setIssuerSelfSigned( issuerSelf );
+
+  validateCert();
+}
+
+
+void QgsSslCertificateWidget::loadSslCertSettings( const QgsSslCertSettings& pki )
+{
+  setSslStoreType( pki.storeType() );
+  setCertId( pki.certId() );
+  setKeyId( pki.keyId() );
+  setKeyHasPassPhrase( pki.hasKeyPassphrase() );
+  setIssuerId( pki.issuerId() );
+  setIssuerSelfSigned( pki.issuerSelfSigned() );
+
+  setAccessUrl( pki.accessUrl() );
+
+  validateCert();
+}
+
+QgsSslCertSettings QgsSslCertificateWidget::toSslCertSettings()
+{
+  QgsSslCertSettings pki;
+  pki.setCertReady( certIsValid() );
+  pki.setStoreType( ssLStoreType() );
+  pki.setCertId( certId() );
+  pki.setKeyId( keyId() );
+  pki.setHasKeyPassphrase( keyHasPassPhrase() );
+  pki.setIssuerId( issuerId() );
+  pki.setIssuerSelfSigned( issuerSelfSigned() );
+  pki.setAccessUrl( mAccessUrl );
+
+  return pki;
+}
+
+bool QgsSslCertificateWidget::certIsValid()
+{
+  return mCertValid;
+}
+
+void QgsSslCertificateWidget::fileFound( bool found, QWidget * widget )
+{
+  if ( !found )
+  {
+    widget->setStyleSheet( validRed_( "QLineEdit" ) );
+    widget->setToolTip( tr( "File not found" ) );
+  }
+  else
+  {
+    widget->setStyleSheet( "" );
+    widget->setToolTip( "" );
+  }
+}
+
+void QgsSslCertificateWidget::validateCert()
+{
+  mCertValid = false;
+  bool certFound = false;
+  bool keyFound = false;
+  bool issuerFound = false;
+
+  if ( mStoreType == QgsSslCertSettings::QGISStore )
+  {
+    QString certPath = QgsSslUtils::qgisCertPath( certId() );
+    QString keyPath = QgsSslUtils::qgisKeyPath( keyId() );
+    QString issuerPath = QgsSslUtils::qgisIssuerPath( issuerId() );
+    certFound = !certPath.isNull();
+    keyFound = !keyPath.isNull();
+    issuerFound = !issuerPath.isNull();
+
+    fileFound( certId().isEmpty() || certFound, leQgisCert );
+    fileFound( keyId().isEmpty() || keyFound, leQgisKey );
+    fileFound( issuerId().isEmpty() || issuerFound, leQgisIssuer );
+
+    if ( !certFound || !keyFound )
+    {
+      // invalid, due to missing components
+      clearMessage();
+      mCertValid = false;
+      return;
+    }
+    else
+    {
+      // check for validity, then why it is not
+      QSslCertificate cert( QgsSslUtils::certFromPath( certPath ) );
+      QDateTime startDate( cert.effectiveDate() );
+      QDateTime endDate( cert.expiryDate() );
+
+      mCertValid = cert.isValid();
+
+      writeMessage( tr( "%1 thru %2" ).arg( startDate.toString() ).arg( endDate.toString() ),
+                    ( mCertValid ? Valid : Invalid ) );
+    }
+  }
+}
+
+void QgsSslCertificateWidget::clearMessage()
+{
+  leMsg->clear();
+  leMsg->setStyleSheet( "" );
+  leMsg->hide();
+}
+
+void QgsSslCertificateWidget::writeMessage( const QString& msg, Validity valid )
+{
+  QString ss;
+  QString txt( msg );
+  switch ( valid )
+  {
+    case Valid:
+      ss = validGreen_( "QLineEdit" );
+      txt = tr( "Valid: %1" ).arg( msg );
+      break;
+    case Invalid:
+      ss = validRed_( "QLineEdit" );
+      txt = tr( "Invalid: %1" ).arg( msg );
+      break;
+    case Unknown:
+      ss = "";
+      break;
+    default:
+      ss = "";
+  }
+  leMsg->setStyleSheet( ss );
+  leMsg->setText( txt );
+  leMsg->setCursorPosition( 0 );
+  leMsg->show();
+}
+
+QgsSslCertSettings::SslStoreType QgsSslCertificateWidget::ssLStoreType()
+{
+  return mStoreType;
+}
+
+QString QgsSslCertificateWidget::certId() const
+{
+  if ( mStoreType == QgsSslCertSettings::QGISStore )
+  {
+    return leQgisCert->text();
+  }
+  return "";
+}
+
+QString QgsSslCertificateWidget::keyId() const
+{
+  if ( mStoreType == QgsSslCertSettings::QGISStore )
+  {
+    return leQgisKey->text();
+  }
+  return "";
+}
+
+bool QgsSslCertificateWidget::keyHasPassPhrase()
+{
+  if ( mStoreType == QgsSslCertSettings::QGISStore )
+  {
+    return chkQgisKeyPhrase->isChecked();
+  }
+  return false;
+}
+
+QString QgsSslCertificateWidget::issuerId() const
+{
+  if ( mStoreType == QgsSslCertSettings::QGISStore )
+  {
+    return leQgisIssuer->text();
+  }
+  return "";
+}
+
+bool QgsSslCertificateWidget::issuerSelfSigned()
+{
+  if ( mStoreType == QgsSslCertSettings::QGISStore )
+  {
+    return chkQgisIssuerSelf->isChecked();
+  }
+  return false;
+}
+
+void QgsSslCertificateWidget::setSslStoreType( QgsSslCertSettings::SslStoreType storeType )
+{
+  mStoreType = storeType;
+  cmbStoreType->setCurrentIndex( mStoreType );
+  stckwCertStore->setCurrentIndex( mStoreType );
+}
+
+void QgsSslCertificateWidget::setCertId( const QString& id )
+{
+  if ( mStoreType == QgsSslCertSettings::QGISStore )
+  {
+    leQgisCert->setText( id );
+    leQgisCert->setStyleSheet( "" );
+  }
+}
+
+void QgsSslCertificateWidget::setKeyId( const QString& id )
+{
+  if ( mStoreType == QgsSslCertSettings::QGISStore )
+  {
+    leQgisKey->setText( id );
+    leQgisKey->setStyleSheet( "" );
+  }
+}
+
+void QgsSslCertificateWidget::setKeyHasPassPhrase( bool hasPass )
+{
+  if ( mStoreType == QgsSslCertSettings::QGISStore )
+  {
+    chkQgisKeyPhrase->setChecked( hasPass );
+  }
+}
+
+void QgsSslCertificateWidget::setIssuerId( const QString& id )
+{
+  if ( mStoreType == QgsSslCertSettings::QGISStore )
+  {
+    leQgisIssuer->setText( id );
+    leQgisIssuer->setStyleSheet( "" );
+  }
+}
+
+void QgsSslCertificateWidget::setIssuerSelfSigned( bool selfSigned )
+{
+  if ( mStoreType == QgsSslCertSettings::QGISStore )
+  {
+    chkQgisIssuerSelf->setChecked( selfSigned );
+  }
+}
+
+void QgsSslCertificateWidget::clearCert()
+{
+  clearCertId();
+  clearKeyId();
+  clearKeyHasPassPhrase();
+  clearIssuerId();
+  clearIssuerSelfSigned();
+
+  clearMessage();
+
+//  btnValidateCert->setStyleSheet( "" );
+//  btnValidateCert->setEnabled( false );
+}
+
+void QgsSslCertificateWidget::clearCertId()
+{
+  if ( mStoreType == QgsSslCertSettings::QGISStore )
+  {
+    leQgisCert->clear();
+    leQgisCert->setStyleSheet( "" );
+  }
+}
+
+void QgsSslCertificateWidget::clearKeyId()
+{
+  if ( mStoreType == QgsSslCertSettings::QGISStore )
+  {
+    leQgisKey->clear();
+    leQgisKey->setStyleSheet( "" );
+  }
+  validateCert();
+}
+
+void QgsSslCertificateWidget::clearKeyHasPassPhrase()
+{
+  if ( mStoreType == QgsSslCertSettings::QGISStore )
+  {
+    chkQgisKeyPhrase->setChecked( false );
+  }
+  validateCert();
+}
+
+void QgsSslCertificateWidget::clearIssuerId()
+{
+  if ( mStoreType == QgsSslCertSettings::QGISStore )
+  {
+    leQgisIssuer->clear();
+    leQgisIssuer->setStyleSheet( "" );
+  }
+  validateCert();
+}
+
+void QgsSslCertificateWidget::clearIssuerSelfSigned()
+{
+  if ( mStoreType == QgsSslCertSettings::QGISStore )
+  {
+    chkQgisIssuerSelf->setChecked( false );
+  }
+  validateCert();
+}
+
+QAction * QgsSslCertificateWidget::clearAction()
+{
+  QAction * clearAct = new QAction( tr( "Clear" ), this );
+  clearAct->setData( QVariant( "clear" ) );
+  QFont f( clearAct->font() );
+  f.setItalic( true );
+  clearAct->setFont( f );
+  return clearAct;
+}
+
+QAction * QgsSslCertificateWidget::selectAction()
+{
+  QAction * selectAct = new QAction( tr( "Select..." ), this );
+  selectAct->setData( QVariant( "select" ) );
+  QFont f( selectAct->font() );
+  f.setItalic( true );
+  selectAct->setFont( f );
+  return selectAct;
+}
+
+QString QgsSslCertificateWidget::getOpenFileName( const QString& path )
+{
+  return QFileDialog::getOpenFileName( this, tr( "Open PEM File" ),
+                                       path, tr( "PEM (*.pem)" ) );
+}
+
+void QgsSslCertificateWidget::openQgisStoreDir()
+{
+  QString path = QDir::toNativeSeparators( QgsSslUtils::qgisCertStoreDirPath() );
+  QDesktopServices::openUrl( QUrl( QString( "file:///" ) + path ) );
+}
+
+void QgsSslCertificateWidget::populateQgisCertsMenu()
+{
+  mQgisCertsMenu->clear();
+  mQgisCertsMenu->addAction( clearAction() );
+  mQgisCertsMenu->addSeparator();
+
+  QStringList certs( QgsSslUtils::storeCerts( QgsSslCertSettings::QGISStore ) );
+  foreach ( QString cert, certs )
+  {
+    QAction * act = new QAction( cert, this );
+    mQgisCertsMenu->addAction( act );
+  }
+//  mQgisCertsMenu->addAction( selectAction() );
+}
+
+void QgsSslCertificateWidget::populateQgisKeysMenu()
+{
+  mQgisKeysMenu->clear();
+  mQgisKeysMenu->addAction( clearAction() );
+  mQgisKeysMenu->addSeparator();
+
+  QStringList keys( QgsSslUtils::storeKeys( QgsSslCertSettings::QGISStore ) );
+  foreach ( QString key, keys )
+  {
+    QAction * act = new QAction( key, this );
+    mQgisKeysMenu->addAction( act );
+  }
+//  mQgisKeysMenu->addAction( selectAction() );
+}
+
+void QgsSslCertificateWidget::populateQgisIssuersMenu()
+{
+  mQgisIssuersMenu->clear();
+  mQgisIssuersMenu->addAction( clearAction() );
+  mQgisIssuersMenu->addSeparator();
+
+  QStringList isss( QgsSslUtils::storeIssuers( QgsSslCertSettings::QGISStore ) );
+  foreach ( QString iss, isss )
+  {
+    QAction * act = new QAction( iss, this );
+    mQgisIssuersMenu->addAction( act );
+  }
+//  mQgisIssuersMenu->addAction( selectAction() );
+}
+
+void QgsSslCertificateWidget::qgisCertsMenuTriggered( QAction * act )
+{
+  if ( act->data() == QVariant( "clear" ) )
+  {
+    clearCertId();
+  }
+  else if ( act->data() == QVariant( "select" ) )
+  {
+    const QString& fn = getOpenFileName( QgsSslUtils::qgisCertsDirPath() );
+    if ( !fn.isEmpty() )
+    {
+      setCertId( fn );
+    }
+  }
+  else
+  {
+    setCertId( act->text() );
+  }
+  validateCert();
+}
+
+void QgsSslCertificateWidget::qgisKeysMenuTriggered( QAction * act )
+{
+  if ( act->data() == QVariant( "clear" ) )
+  {
+    clearKeyId();
+  }
+  else if ( act->data() == QVariant( "select" ) )
+  {
+    const QString& fn = getOpenFileName( QgsSslUtils::qgisKeysDirPath() );
+    if ( !fn.isEmpty() )
+    {
+      setKeyId( fn );
+    }
+  }
+  else
+  {
+    setKeyId( act->text() );
+  }
+  validateCert();
+}
+
+void QgsSslCertificateWidget::qgisIssuersMenuTriggered( QAction * act )
+{
+  if ( act->data() == QVariant( "clear" ) )
+  {
+    clearIssuerId();
+  }
+  else if ( act->data() == QVariant( "select" ) )
+  {
+    const QString& fn = getOpenFileName( QgsSslUtils::qgisIssuersDirPath() );
+    if ( !fn.isEmpty() )
+    {
+      setIssuerId( fn );
+    }
+  }
+  else
+  {
+    setIssuerId( act->text() );
+  }
+  validateCert();
+}
+

--- a/src/gui/qgssslcertificatewidget.h
+++ b/src/gui/qgssslcertificatewidget.h
@@ -46,28 +46,29 @@ class GUI_EXPORT QgsSslCertificateWidget : public QWidget, private Ui::QgsSslCer
 
     /**
      * @brief Load settings at once, like from QSettings
-     * @see QgsSslCertSettings
+     * @see QgsSslPkiSettings
      * @note The resource's access url is missing, because it may not be known yet.
      */
-    void loadSettings( QgsSslCertSettings::SslStoreType storeType = QgsSslCertSettings::QGISStore,
+    void loadSettings( QgsSslPkiSettings::SslStoreType storeType = QgsSslPkiSettings::QGISStore,
                        const QString& certId = "",
                        const QString& keyId = "",
-                       bool keyPassphrase = false,
+                       bool needsKeyPath = false,
+                       bool needsKeyPhrase = false,
                        const QString& issuerId = "",
                        bool issuerSelf = false );
 
     /**
-     * @brief Load settings at once from existing QgsSslCertSettings
-     * @see QgsSslCertSettings
+     * @brief Load settings at once from existing QgsSslPkiSettings
+     * @see QgsSslPkiSettings
      * @note Includes the resource's access url, though it may be empty.
      */
-    void loadSslCertSettings( const QgsSslCertSettings& pki );
+    void loadSslCertSettings( const QgsSslPkiSettings& pki );
 
     /**
-     * @brief Get settings as QgsSslCertSettings
+     * @brief Get settings as QgsSslPkiSettings
      * @note Includes the resource's access url, though it may be empty.
      */
-    QgsSslCertSettings toSslCertSettings();
+    QgsSslPkiSettings toSslCertSettings();
 
     /**
      * @brief Whether the cert is valid at the time function is accessed.
@@ -77,39 +78,44 @@ class GUI_EXPORT QgsSslCertificateWidget : public QWidget, private Ui::QgsSslCer
     bool certIsValid();
 
     /**
-     * @see QgsSslCertSettings
+     * @see QgsSslPkiSettings
      */
-    QgsSslCertSettings::SslStoreType ssLStoreType();
+    QgsSslPkiSettings::SslStoreType ssLStoreType();
     /**
-     * @see QgsSslCertSettings
+     * @see QgsSslPkiSettings
      */
     QString certId() const;
     /**
-     * @see QgsSslCertSettings
+     * @see QgsSslPkiSettings
      */
     QString keyId() const;
     /**
-     * @see QgsSslCertSettings
+     * @see QgsSslPkiSettings
      */
-    bool keyHasPassPhrase();
+    bool needsKeyPath();
     /**
-     * @see QgsSslCertSettings
+     * @see QgsSslPkiSettings
+     */
+    bool needsKeyPassphrase();
+    /**
+     * @see QgsSslPkiSettings
      */
     QString issuerId() const;
     /**
-     * @see QgsSslCertSettings
+     * @see QgsSslPkiSettings
      */
     bool issuerSelfSigned();
     /**
-     * @see QgsSslCertSettings
+     * @see QgsSslPkiSettings
      */
     QString accessUrl() const { return mAccessUrl; }
 
   public slots:
-    void setSslStoreType( QgsSslCertSettings::SslStoreType storeType );
+    void setSslStoreType( QgsSslPkiSettings::SslStoreType storeType );
     void setCertId( const QString& id );
     void setKeyId( const QString& id );
-    void setKeyHasPassPhrase( bool hasPass );
+    void setNeedsKeyPath( bool needsPath );
+    void setNeedsKeyPassphrase( bool needsPass );
     void setIssuerId( const QString& id );
     void setIssuerSelfSigned( bool selfSigned );
     void setAccessUrl( const QString& url ) { mAccessUrl = url; }
@@ -149,7 +155,7 @@ class GUI_EXPORT QgsSslCertificateWidget : public QWidget, private Ui::QgsSslCer
     QAction * clearAction();
     QAction * selectAction();
 
-    QgsSslCertSettings::SslStoreType mStoreType;
+    QgsSslPkiSettings::SslStoreType mStoreType;
     bool mCertValid;
     QString mAccessUrl;
 

--- a/src/gui/qgssslcertificatewidget.h
+++ b/src/gui/qgssslcertificatewidget.h
@@ -1,0 +1,162 @@
+/***************************************************************************
+    qgssslcertificatewidget.h
+                             -------------------
+    begin                : 2014-09-12
+    copyright            : (C) 2014 by Boundless Spatial, Inc.
+    web                  : http://boundlessgeo.com
+    author               : Larry Shaffer
+    email                : larrys at dakotacarto dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSSSLCERTIFICATEWIDGET_H
+#define QGSSSLCERTIFICATEWIDGET_H
+
+#include <QWidget>
+
+#include "qgssslutils.h"
+
+#include "ui_qgssslcertificatewidget.h"
+
+
+class GUI_EXPORT QgsSslCertificateWidget : public QWidget, private Ui::QgsSslCertificateWidget
+{
+    Q_OBJECT
+
+  public:
+    enum Validity
+    {
+      Valid,
+      Invalid,
+      Unknown
+    };
+
+    /** Widget for choosing/inspecting SSL certificate, using different store methods, and testing validity
+     */
+    explicit QgsSslCertificateWidget( QWidget *parent = 0, const QString& accessUrl = QString( "" ) );
+    ~QgsSslCertificateWidget();
+
+    /**
+     * @brief Load settings at once, like from QSettings
+     * @see QgsSslCertSettings
+     * @note The resource's access url is missing, because it may not be known yet.
+     */
+    void loadSettings( QgsSslCertSettings::SslStoreType storeType = QgsSslCertSettings::QGISStore,
+                       const QString& certId = "",
+                       const QString& keyId = "",
+                       bool keyPassphrase = false,
+                       const QString& issuerId = "",
+                       bool issuerSelf = false );
+
+    /**
+     * @brief Load settings at once from existing QgsSslCertSettings
+     * @see QgsSslCertSettings
+     * @note Includes the resource's access url, though it may be empty.
+     */
+    void loadSslCertSettings( const QgsSslCertSettings& pki );
+
+    /**
+     * @brief Get settings as QgsSslCertSettings
+     * @note Includes the resource's access url, though it may be empty.
+     */
+    QgsSslCertSettings toSslCertSettings();
+
+    /**
+     * @brief Whether the cert is valid at the time function is accessed.
+     * @note This could easily change later on (e.g. expired cert),
+     * so it doesn't really help to save it for later
+     */
+    bool certIsValid();
+
+    /**
+     * @see QgsSslCertSettings
+     */
+    QgsSslCertSettings::SslStoreType ssLStoreType();
+    /**
+     * @see QgsSslCertSettings
+     */
+    QString certId() const;
+    /**
+     * @see QgsSslCertSettings
+     */
+    QString keyId() const;
+    /**
+     * @see QgsSslCertSettings
+     */
+    bool keyHasPassPhrase();
+    /**
+     * @see QgsSslCertSettings
+     */
+    QString issuerId() const;
+    /**
+     * @see QgsSslCertSettings
+     */
+    bool issuerSelfSigned();
+    /**
+     * @see QgsSslCertSettings
+     */
+    QString accessUrl() const { return mAccessUrl; }
+
+  public slots:
+    void setSslStoreType( QgsSslCertSettings::SslStoreType storeType );
+    void setCertId( const QString& id );
+    void setKeyId( const QString& id );
+    void setKeyHasPassPhrase( bool hasPass );
+    void setIssuerId( const QString& id );
+    void setIssuerSelfSigned( bool selfSigned );
+    void setAccessUrl( const QString& url ) { mAccessUrl = url; }
+
+    /**
+     * @brief Validate certificate and private key combination.
+     * @note This is just lightweight validation, and does not traverse the issuer certificate chain
+     * @see QSslCertificate.isValid()
+     */
+    void validateCert();
+
+  private slots:
+    void clearMessage();
+    void writeMessage( const QString& msg, Validity valid = Unknown );
+
+    void clearCert();
+
+    void clearCertId();
+    void clearKeyId();
+    void clearKeyHasPassPhrase();
+    void clearIssuerId();
+    void clearIssuerSelfSigned();
+
+    // QGIS user-local store
+    void openQgisStoreDir();
+    void populateQgisCertsMenu();
+    void populateQgisKeysMenu();
+    void populateQgisIssuersMenu();
+    void qgisCertsMenuTriggered( QAction * act );
+    void qgisKeysMenuTriggered( QAction * act );
+    void qgisIssuersMenuTriggered( QAction * act );
+
+  private:
+    void fileFound( bool found, QWidget * widget );
+    QString getOpenFileName( const QString& path );
+
+    QAction * clearAction();
+    QAction * selectAction();
+
+    QgsSslCertSettings::SslStoreType mStoreType;
+    bool mCertValid;
+    QString mAccessUrl;
+
+    // QGIS user-local store
+    QMenu * mQgisCertsMenu;
+    QMenu * mQgisKeysMenu;
+    QMenu * mQgisIssuersMenu;
+};
+
+#endif // QGSSSLCERTIFICATEWIDGET_H

--- a/src/providers/wcs/qgswcscapabilities.h
+++ b/src/providers/wcs/qgswcscapabilities.h
@@ -23,6 +23,10 @@
 #include "qgsdatasourceuri.h"
 #include "qgsrectangle.h"
 
+#ifndef QT_NO_OPENSSL
+#include "qgssslutils.h"
+#endif
+
 #include <QString>
 #include <QStringList>
 #include <QDomElement>
@@ -331,6 +335,11 @@ class QgsWcsCapabilities : public QObject
 
     //! Cache load control
     QNetworkRequest::CacheLoadControl mCacheLoadControl;
+
+#ifndef QT_NO_OPENSSL
+    //! Client SSL certificate
+    QgsSslPkiSettings mSslCert;
+#endif
 };
 
 

--- a/src/providers/wfs/qgswfscapabilities.cpp
+++ b/src/providers/wfs/qgswfscapabilities.cpp
@@ -59,8 +59,7 @@ QgsWFSCapabilities::QgsWFSCapabilities( QString theUri )
 #endif
 
 #ifndef QT_NO_OPENSSL
-  QgsSslPkiSettings * owspki = &mSslCert;
-  QgsSslPkiSettings::updateOwsCapabilities( owspki, mUri, theUri );
+  QgsSslPkiSettings::updateOwsCapabilities( mSslCert, mUri, mBaseUrl );
 #endif
 }
 
@@ -210,6 +209,10 @@ void QgsWFSCapabilities::capabilitiesReplyFinished()
     request.setAttribute( QNetworkRequest::CacheSaveControlAttribute, true );
 
     mCapabilitiesReply = QgsNetworkAccessManager::instance()->get( request );
+
+#ifndef QT_NO_OPENSSL
+    QgsSslPkiUtility::instance()->updateReplyExpectedSslErrors( mCapabilitiesReply, mSslCert );
+#endif
 
     connect( mCapabilitiesReply, SIGNAL( finished() ), this, SLOT( capabilitiesReplyFinished() ) );
     return;

--- a/src/providers/wfs/qgswfscapabilities.h
+++ b/src/providers/wfs/qgswfscapabilities.h
@@ -21,6 +21,10 @@
 #include "qgsrectangle.h"
 #include "qgsdatasourceuri.h"
 
+#ifndef QT_NO_OPENSSL
+#include "qgssslutils.h"
+#endif
+
 class QNetworkReply;
 
 class QgsWFSCapabilities : public QObject
@@ -100,6 +104,11 @@ class QgsWFSCapabilities : public QObject
 
     //! Password for basic http authentication
     QString mPassword;
+
+#ifndef QT_NO_OPENSSL
+    //! Client SSL certificate
+    QgsSslPkiSettings mSslCert;
+#endif
 };
 
 #endif // QGSWFSCAPABILITIES_H

--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -48,41 +48,8 @@ bool QgsWmsSettings::parseUri( QString uriString )
   QgsDebugMsg( "set referer to " + mAuth.mReferer );
 
 #ifndef QT_NO_OPENSSL
-  // parse ssl cert
-  if ( uri.hasParam( "certid" ) )
-  {
-    QgsDebugMsg( "ssl cert exists" );
-    mAuth.mSslCert.setStoreType(( QgsSslPkiSettings::SslStoreType ) uri.param( "storetype" ).toInt() );
-    QgsDebugMsg( QString( "ssl cert storetype (enum): %1" ).arg( mAuth.mSslCert.storeType() ) );
-    mAuth.mSslCert.setCertId( uri.param( "certid" ) );
-    QgsDebugMsg( "ssl cert certid: " + mAuth.mSslCert.certId() );
-    mAuth.mSslCert.setKeyId( uri.param( "keyid" ) );
-    QgsDebugMsg( "ssl cert keyid: " + mAuth.mSslCert.keyId() );
-    if ( uri.hasParam( "needskeypath" ) )
-    {
-      mAuth.mSslCert.setNeedsKeyPath( true );
-      QgsDebugMsg( "ssl cert key needs path defined" );
-    }
-    if ( uri.hasParam( "needskeypass" ) )
-    {
-      mAuth.mSslCert.setNeedsKeyPassphrase( true );
-      QgsDebugMsg( "ssl cert key needs password" );
-    }
-    if ( uri.hasParam( "keypass" ) )
-    {
-      mAuth.mSslCert.setNeedsKeyPassphrase( true ); // may not have been in URL
-      mAuth.mSslCert.setKeyPassphrase( uri.param( "keypass" ) );
-      QgsDebugMsg( "ssl cert password passed-in" );
-    }
-    mAuth.mSslCert.setIssuerId( uri.param( "issuerid" ) );
-    QgsDebugMsg( "ssl cert issuerid: " + mAuth.mSslCert.issuerId() );
-    if ( uri.hasParam( "issuerself" ) )
-    {
-      mAuth.mSslCert.setIssuerSelfSigned( true );
-      QgsDebugMsg( "ssl cert self-signed" );
-    }
-    mAuth.mSslCert.setAccessUrl( mHttpUri );
-  }
+  QgsSslPkiSettings * wmspki = &mAuth.mSslCert;
+  QgsSslPkiSettings::updateOwsCapabilities( wmspki, uri, mHttpUri );
 #endif
 
   mActiveSubLayers = uri.params( "layers" );

--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -48,8 +48,7 @@ bool QgsWmsSettings::parseUri( QString uriString )
   QgsDebugMsg( "set referer to " + mAuth.mReferer );
 
 #ifndef QT_NO_OPENSSL
-  QgsSslPkiSettings * wmspki = &mAuth.mSslCert;
-  QgsSslPkiSettings::updateOwsCapabilities( wmspki, uri, mHttpUri );
+  QgsSslPkiSettings::updateOwsCapabilities( mAuth.mSslCert, uri, mHttpUri );
 #endif
 
   mActiveSubLayers = uri.params( "layers" );

--- a/src/providers/wms/qgswmscapabilities.h
+++ b/src/providers/wms/qgswmscapabilities.h
@@ -439,9 +439,14 @@ struct QgsWmsParserSettings
 
 struct QgsWmsAuthorization
 {
-  QgsWmsAuthorization( const QString& userName = QString(), const QString& password = QString(), const QString& referer = QString(),
-                       QgsSslCertSettings sslCert = QgsSslCertSettings() )
-      : mUserName( userName ), mPassword( password ), mReferer( referer ), mSslCert( sslCert ) {}
+  QgsWmsAuthorization( const QString& userName = QString(), const QString& password = QString(), const QString& referer = QString() )
+      : mUserName( userName )
+      , mPassword( password )
+      , mReferer( referer )
+#ifndef QT_NO_OPENSSL
+      , mSslCert( QgsSslPkiSettings() )
+#endif
+  {}
 
   void setAuthorization( QNetworkRequest &request ) const
   {
@@ -456,7 +461,7 @@ struct QgsWmsAuthorization
     }
 
 #ifndef QT_NO_OPENSSL
-    QgsSslUtils::updateRequestSslConfiguration( request, mSslCert );
+    QgsSslPkiUtility::instance()->updateRequestSslConfiguration( request, mSslCert );
 #endif
 
   }
@@ -472,7 +477,7 @@ struct QgsWmsAuthorization
 
 #ifndef QT_NO_OPENSSL
   //! Client SSL certificate
-  QgsSslCertSettings mSslCert;
+  QgsSslPkiSettings mSslCert;
 #endif
 };
 

--- a/src/providers/wms/qgswmscapabilities.h
+++ b/src/providers/wms/qgswmscapabilities.h
@@ -10,6 +10,10 @@
 #include "qgsraster.h"
 #include "qgsrectangle.h"
 
+#ifndef QT_NO_OPENSSL
+#include "qgssslutils.h"
+#endif
+
 class QNetworkReply;
 
 /*
@@ -432,10 +436,12 @@ struct QgsWmsParserSettings
   bool invertAxisOrientation;
 };
 
+
 struct QgsWmsAuthorization
 {
-  QgsWmsAuthorization( const QString& userName = QString(), const QString& password = QString(), const QString& referer = QString() )
-      : mUserName( userName ), mPassword( password ), mReferer( referer ) {}
+  QgsWmsAuthorization( const QString& userName = QString(), const QString& password = QString(), const QString& referer = QString(),
+                       QgsSslCertSettings sslCert = QgsSslCertSettings() )
+      : mUserName( userName ), mPassword( password ), mReferer( referer ), mSslCert( sslCert ) {}
 
   void setAuthorization( QNetworkRequest &request ) const
   {
@@ -448,6 +454,11 @@ struct QgsWmsAuthorization
     {
       request.setRawHeader( "Referer", QString( "%1" ).arg( mReferer ).toAscii() );
     }
+
+#ifndef QT_NO_OPENSSL
+    QgsSslUtils::updateRequestSslConfiguration( request, mSslCert );
+#endif
+
   }
 
   //! Username for basic http authentication
@@ -459,7 +470,10 @@ struct QgsWmsAuthorization
   //! Referer for http requests
   QString mReferer;
 
-
+#ifndef QT_NO_OPENSSL
+  //! Client SSL certificate
+  QgsSslCertSettings mSslCert;
+#endif
 };
 
 

--- a/src/providers/wms/qgswmsconnection.cpp
+++ b/src/providers/wms/qgswmsconnection.cpp
@@ -67,6 +67,43 @@ QgsWMSConnection::QgsWMSConnection( QString theConnName ) :
     mUri.setParam( "password", password );
   }
 
+#ifndef QT_NO_OPENSSL
+  bool validcert = settings.value( credentialsKey + "/ssl/validcert", false ).toBool();
+  if ( validcert )
+  {
+    QString storetype = settings.value( credentialsKey + "/ssl/store" ).toString(); // int(enum) -> string
+    QString certid = settings.value( credentialsKey + "/ssl/certid" ).toString();
+    QString keyid = settings.value( credentialsKey + "/ssl/keyid" ).toString();
+    bool haskeypass = settings.value( credentialsKey + "/ssl/haskeypass", false ).toBool();
+    QString issuerid = settings.value( credentialsKey + "/ssl/issuerid" ).toString();
+    bool issuerself = settings.value( credentialsKey + "/ssl/issuerself", false ).toBool();
+
+    QString sslinfo;
+
+    // store/cert/key should always be non-empty for cert to have validated
+    sslinfo.append( ",storetype=" + storetype + ",certid=" + certid + ",keyid=" + keyid );
+    mUri.setParam( "storetype", storetype );
+    mUri.setParam( "certid", certid );
+    mUri.setParam( "keyid", keyid );
+    if ( haskeypass )
+    {
+      sslinfo.append( ",haskeypass=1" );
+      mUri.setParam( "haskeypass", "1" );
+    }
+    if ( !issuerid.isEmpty() )
+    {
+      sslinfo.append( ",issuerid=" + issuerid );
+      mUri.setParam( "issuerid", issuerid );
+    }
+    if ( issuerself )
+    {
+      sslinfo.append( ",issuerself=1" );
+      mUri.setParam( "issuerself", "1" );
+    }
+    mConnectionInfo.append( sslinfo );
+  }
+#endif
+
   QString referer = settings.value( key + "/referer" ).toString();
   if ( !referer.isEmpty() )
   {

--- a/src/providers/wms/qgswmsconnection.cpp
+++ b/src/providers/wms/qgswmsconnection.cpp
@@ -68,46 +68,8 @@ QgsWMSConnection::QgsWMSConnection( QString theConnName ) :
   }
 
 #ifndef QT_NO_OPENSSL
-  bool validcert = settings.value( credentialsKey + "/ssl/validcert", false ).toBool();
-  if ( validcert )
-  {
-    QString storetype = settings.value( credentialsKey + "/ssl/store" ).toString(); // int(enum) -> string
-    QString certid = settings.value( credentialsKey + "/ssl/certid" ).toString();
-    QString keyid = settings.value( credentialsKey + "/ssl/keyid" ).toString();
-    bool needskeypath = settings.value( credentialsKey + "/ssl/needskeypath", true ).toBool();
-    bool needskeypass = settings.value( credentialsKey + "/ssl/needskeypass", false ).toBool();
-    QString issuerid = settings.value( credentialsKey + "/ssl/issuerid" ).toString();
-    bool issuerself = settings.value( credentialsKey + "/ssl/issuerself", false ).toBool();
-
-    QString sslinfo;
-
-    // store/cert/key should always be non-empty for cert to have validated
-    sslinfo.append( ",storetype=" + storetype + ",certid=" + certid + ",keyid=" + keyid );
-    mUri.setParam( "storetype", storetype );
-    mUri.setParam( "certid", certid );
-    mUri.setParam( "keyid", keyid );
-    if ( needskeypath )
-    {
-      sslinfo.append( ",needskeypath=1" );
-      mUri.setParam( "needskeypath", "1" );
-    }
-    if ( needskeypass )
-    {
-      sslinfo.append( ",needskeypass=1" );
-      mUri.setParam( "needskeypass", "1" );
-    }
-    if ( !issuerid.isEmpty() )
-    {
-      sslinfo.append( ",issuerid=" + issuerid );
-      mUri.setParam( "issuerid", issuerid );
-    }
-    if ( issuerself )
-    {
-      sslinfo.append( ",issuerself=1" );
-      mUri.setParam( "issuerself", "1" );
-    }
-    mConnectionInfo.append( sslinfo );
-  }
+  QgsDataSourceURI * wmsuri = &mUri;
+  QgsSslPkiSettings::updateOwsConnection( settings, credentialsKey, wmsuri, &mConnectionInfo );
 #endif
 
   QString referer = settings.value( key + "/referer" ).toString();

--- a/src/providers/wms/qgswmsconnection.cpp
+++ b/src/providers/wms/qgswmsconnection.cpp
@@ -74,7 +74,8 @@ QgsWMSConnection::QgsWMSConnection( QString theConnName ) :
     QString storetype = settings.value( credentialsKey + "/ssl/store" ).toString(); // int(enum) -> string
     QString certid = settings.value( credentialsKey + "/ssl/certid" ).toString();
     QString keyid = settings.value( credentialsKey + "/ssl/keyid" ).toString();
-    bool haskeypass = settings.value( credentialsKey + "/ssl/haskeypass", false ).toBool();
+    bool needskeypath = settings.value( credentialsKey + "/ssl/needskeypath", true ).toBool();
+    bool needskeypass = settings.value( credentialsKey + "/ssl/needskeypass", false ).toBool();
     QString issuerid = settings.value( credentialsKey + "/ssl/issuerid" ).toString();
     bool issuerself = settings.value( credentialsKey + "/ssl/issuerself", false ).toBool();
 
@@ -85,10 +86,15 @@ QgsWMSConnection::QgsWMSConnection( QString theConnName ) :
     mUri.setParam( "storetype", storetype );
     mUri.setParam( "certid", certid );
     mUri.setParam( "keyid", keyid );
-    if ( haskeypass )
+    if ( needskeypath )
     {
-      sslinfo.append( ",haskeypass=1" );
-      mUri.setParam( "haskeypass", "1" );
+      sslinfo.append( ",needskeypath=1" );
+      mUri.setParam( "needskeypath", "1" );
+    }
+    if ( needskeypass )
+    {
+      sslinfo.append( ",needskeypass=1" );
+      mUri.setParam( "needskeypass", "1" );
     }
     if ( !issuerid.isEmpty() )
     {

--- a/src/providers/wms/qgswmsconnection.cpp
+++ b/src/providers/wms/qgswmsconnection.cpp
@@ -68,8 +68,7 @@ QgsWMSConnection::QgsWMSConnection( QString theConnName ) :
   }
 
 #ifndef QT_NO_OPENSSL
-  QgsDataSourceURI * wmsuri = &mUri;
-  QgsSslPkiSettings::updateOwsConnection( settings, credentialsKey, wmsuri, &mConnectionInfo );
+  QgsSslPkiSettings::updateOwsConnection( settings, credentialsKey, mUri, mConnectionInfo );
 #endif
 
   QString referer = settings.value( key + "/referer" ).toString();

--- a/src/ui/qgscredentialdialog.ui
+++ b/src/ui/qgscredentialdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>365</width>
-    <height>156</height>
+    <width>350</width>
+    <height>190</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -17,58 +17,112 @@
    <property name="fieldGrowthPolicy">
     <enum>QFormLayout::ExpandingFieldsGrow</enum>
    </property>
-   <item row="2" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Username</string>
+   <item row="1" column="0" colspan="2">
+    <widget class="QStackedWidget" name="stackedWidget">
+     <property name="currentIndex">
+      <number>0</number>
      </property>
+     <widget class="QWidget" name="page">
+      <layout class="QFormLayout" name="formLayout_2">
+       <property name="fieldGrowthPolicy">
+        <enum>QFormLayout::ExpandingFieldsGrow</enum>
+       </property>
+       <property name="margin">
+        <number>0</number>
+       </property>
+       <item row="0" column="0">
+        <widget class="QLabel" name="label_3">
+         <property name="text">
+          <string>Realm</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QLabel" name="labelRealm">
+         <property name="text">
+          <string>TextLabel</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label">
+         <property name="text">
+          <string>Username</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="1">
+        <widget class="QLineEdit" name="leUsername"/>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="label_2">
+         <property name="text">
+          <string>Password</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QLineEdit" name="lePassword">
+         <property name="echoMode">
+          <enum>QLineEdit::Password</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="0" colspan="2">
+        <widget class="QLabel" name="labelMessage">
+         <property name="text">
+          <string>TextLabel</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="page_2">
+      <layout class="QVBoxLayout" name="verticalLayout">
+       <item>
+        <widget class="QLabel" name="label_4">
+         <property name="text">
+          <string>Enter SSL key password for:</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="lblKeyResource">
+         <property name="font">
+          <font>
+           <italic>true</italic>
+          </font>
+         </property>
+         <property name="text">
+          <string>TextLabel</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLineEdit" name="leKeyPassword">
+         <property name="echoMode">
+          <enum>QLineEdit::Password</enum>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QLabel" name="lblKeyMessage">
+         <property name="text">
+          <string>TextLabel</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
     </widget>
    </item>
-   <item row="2" column="1">
-    <widget class="QLineEdit" name="leUsername"/>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>Password</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1">
-    <widget class="QLineEdit" name="lePassword">
-     <property name="echoMode">
-      <enum>QLineEdit::Password</enum>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0" colspan="2">
+   <item row="2" column="0" colspan="2">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="1">
-    <widget class="QLabel" name="labelRealm">
-     <property name="text">
-      <string>TextLabel</string>
-     </property>
-    </widget>
-   </item>
-   <item row="4" column="0" colspan="2">
-    <widget class="QLabel" name="labelMessage">
-     <property name="text">
-      <string>TextLabel</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="label_3">
-     <property name="text">
-      <string>Realm</string>
      </property>
     </widget>
    </item>

--- a/src/ui/qgscredentialdialog.ui
+++ b/src/ui/qgscredentialdialog.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>350</width>
-    <height>190</height>
+    <width>352</width>
+    <height>212</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -20,7 +20,7 @@
    <item row="1" column="0" colspan="2">
     <widget class="QStackedWidget" name="stackedWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="page">
       <layout class="QFormLayout" name="formLayout_2">
@@ -78,38 +78,120 @@
       </layout>
      </widget>
      <widget class="QWidget" name="page_2">
-      <layout class="QVBoxLayout" name="verticalLayout">
-       <item>
+      <layout class="QFormLayout" name="formLayout_3">
+       <property name="fieldGrowthPolicy">
+        <enum>QFormLayout::ExpandingFieldsGrow</enum>
+       </property>
+       <property name="margin">
+        <number>0</number>
+       </property>
+       <item row="3" column="0">
         <widget class="QLabel" name="label_4">
          <property name="text">
-          <string>Enter SSL key password for:</string>
+          <string>Password</string>
          </property>
         </widget>
        </item>
-       <item>
-        <widget class="QLabel" name="lblKeyResource">
-         <property name="font">
-          <font>
-           <italic>true</italic>
-          </font>
-         </property>
-         <property name="text">
-          <string>TextLabel</string>
-         </property>
-        </widget>
-       </item>
-       <item>
+       <item row="3" column="1">
         <widget class="QLineEdit" name="leKeyPassword">
+         <property name="text">
+          <string notr="true"/>
+         </property>
          <property name="echoMode">
           <enum>QLineEdit::Password</enum>
          </property>
+         <property name="placeholderText">
+          <string>Optional</string>
+         </property>
         </widget>
        </item>
-       <item>
+       <item row="1" column="1">
+        <widget class="QLabel" name="lblKeyResource">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string notr="true">Resource</string>
+         </property>
+        </widget>
+       </item>
+       <item row="1" column="0">
+        <widget class="QLabel" name="label_5">
+         <property name="text">
+          <string>For</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="0" colspan="2">
         <widget class="QLabel" name="lblKeyMessage">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
          <property name="text">
           <string>TextLabel</string>
          </property>
+        </widget>
+       </item>
+       <item row="0" column="0" colspan="2">
+        <widget class="QLabel" name="label_6">
+         <property name="font">
+          <font>
+           <weight>75</weight>
+           <italic>false</italic>
+           <bold>true</bold>
+          </font>
+         </property>
+         <property name="text">
+          <string>SSL private key (cached for session)</string>
+         </property>
+         <property name="alignment">
+          <set>Qt::AlignCenter</set>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="lblKeyPath">
+         <property name="text">
+          <string>Key file</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QFrame" name="frKeyPath">
+         <layout class="QHBoxLayout" name="layoutKeyPath">
+          <property name="spacing">
+           <number>0</number>
+          </property>
+          <property name="margin">
+           <number>0</number>
+          </property>
+          <item>
+           <widget class="QLineEdit" name="leKeyPath">
+            <property name="text">
+             <string notr="true"/>
+            </property>
+            <property name="readOnly">
+             <bool>true</bool>
+            </property>
+            <property name="placeholderText">
+             <string>Required</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QToolButton" name="tbKeyPathSelect">
+            <property name="text">
+             <string>...</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
         </widget>
        </item>
       </layout>

--- a/src/ui/qgsnewhttpconnectionbase.ui
+++ b/src/ui/qgsnewhttpconnectionbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>475</width>
-    <height>463</height>
+    <width>526</width>
+    <height>721</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -27,13 +27,111 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="0">
+   <item row="1" column="0">
     <widget class="QGroupBox" name="mGroupBox">
      <property name="title">
       <string>Connection details</string>
      </property>
      <layout class="QGridLayout">
-      <item row="8" column="0">
+      <item row="4" column="0" colspan="2">
+       <widget class="QTabWidget" name="tabAuth">
+        <property name="sizePolicy">
+         <sizepolicy hsizetype="Expanding" vsizetype="MinimumExpanding">
+          <horstretch>0</horstretch>
+          <verstretch>0</verstretch>
+         </sizepolicy>
+        </property>
+        <property name="currentIndex">
+         <number>0</number>
+        </property>
+        <widget class="QWidget" name="tab">
+         <attribute name="title">
+          <string>Authentication</string>
+         </attribute>
+         <layout class="QGridLayout" name="gridLayout_3">
+          <item row="1" column="0">
+           <widget class="QLabel" name="label_2">
+            <property name="text">
+             <string>&amp;User name</string>
+            </property>
+            <property name="buddy">
+             <cstring>txtUserName</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="1" column="1">
+           <widget class="QLineEdit" name="txtUserName"/>
+          </item>
+          <item row="0" column="0" colspan="2">
+           <widget class="QLabel" name="label">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="text">
+             <string>If the service requires basic authentication, enter a user name and optional password</string>
+            </property>
+            <property name="textFormat">
+             <enum>Qt::PlainText</enum>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_3">
+            <property name="text">
+             <string>Password</string>
+            </property>
+            <property name="buddy">
+             <cstring>txtPassword</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QLineEdit" name="txtPassword">
+            <property name="echoMode">
+             <enum>QLineEdit::Password</enum>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <spacer name="verticalSpacer">
+            <property name="orientation">
+             <enum>Qt::Vertical</enum>
+            </property>
+            <property name="sizeHint" stdset="0">
+             <size>
+              <width>0</width>
+              <height>0</height>
+             </size>
+            </property>
+           </spacer>
+          </item>
+         </layout>
+        </widget>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="txtName">
+        <property name="minimumSize">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+        <property name="toolTip">
+         <string>Name of the new connection</string>
+        </property>
+        <property name="frame">
+         <bool>true</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0">
        <widget class="QLabel" name="lblDpiMode">
         <property name="text">
          <string>DPI-Mode</string>
@@ -56,45 +154,6 @@
         </property>
        </widget>
       </item>
-      <item row="4" column="0" colspan="3">
-       <widget class="QLabel" name="label">
-        <property name="sizePolicy">
-         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-          <horstretch>0</horstretch>
-          <verstretch>0</verstretch>
-         </sizepolicy>
-        </property>
-        <property name="text">
-         <string>If the service requires basic authentication, enter a user name and optional password</string>
-        </property>
-        <property name="textFormat">
-         <enum>Qt::PlainText</enum>
-        </property>
-        <property name="wordWrap">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
-      <item row="6" column="0">
-       <widget class="QLabel" name="label_3">
-        <property name="text">
-         <string>Password</string>
-        </property>
-        <property name="buddy">
-         <cstring>txtPassword</cstring>
-        </property>
-       </widget>
-      </item>
-      <item row="5" column="0">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>&amp;User name</string>
-        </property>
-        <property name="buddy">
-         <cstring>txtUserName</cstring>
-        </property>
-       </widget>
-      </item>
       <item row="0" column="0">
        <widget class="QLabel" name="TextLabel1_2">
         <property name="text">
@@ -111,22 +170,6 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="1">
-       <widget class="QLineEdit" name="txtName">
-        <property name="minimumSize">
-         <size>
-          <width>0</width>
-          <height>0</height>
-         </size>
-        </property>
-        <property name="toolTip">
-         <string>Name of the new connection</string>
-        </property>
-        <property name="frame">
-         <bool>true</bool>
-        </property>
-       </widget>
-      </item>
       <item row="1" column="1">
        <widget class="QLineEdit" name="txtUrl">
         <property name="toolTip">
@@ -134,55 +177,10 @@
         </property>
        </widget>
       </item>
-      <item row="5" column="1">
-       <widget class="QLineEdit" name="txtUserName"/>
-      </item>
-      <item row="6" column="1">
-       <widget class="QLineEdit" name="txtPassword">
-        <property name="echoMode">
-         <enum>QLineEdit::Password</enum>
-        </property>
-       </widget>
-      </item>
-      <item row="13" column="0" colspan="2">
-       <widget class="QCheckBox" name="cbxIgnoreGetFeatureInfoURI">
-        <property name="text">
-         <string>Ignore GetFeatureInfo URI reported in capabilities</string>
-        </property>
-       </widget>
-      </item>
-      <item row="12" column="0" colspan="2">
-       <widget class="QCheckBox" name="cbxIgnoreGetMapURI">
-        <property name="text">
-         <string>Ignore GetMap/GetTile URI reported in capabilities</string>
-        </property>
-       </widget>
-      </item>
-      <item row="14" column="0" colspan="2">
-       <widget class="QCheckBox" name="cbxIgnoreAxisOrientation">
-        <property name="text">
-         <string>Ignore axis orientation (WMS 1.3/WMTS)</string>
-        </property>
-       </widget>
-      </item>
-      <item row="15" column="0" colspan="2">
-       <widget class="QCheckBox" name="cbxInvertAxisOrientation">
-        <property name="text">
-         <string>Invert axis orientation</string>
-        </property>
-       </widget>
-      </item>
-      <item row="16" column="0" colspan="2">
-       <widget class="QCheckBox" name="cbxSmoothPixmapTransform">
-        <property name="text">
-         <string>Smooth pixmap transform</string>
-        </property>
-       </widget>
-      </item>
       <item row="7" column="1">
-       <widget class="QLineEdit" name="txtReferer"/>
+       <widget class="QComboBox" name="cmbDpiMode"/>
       </item>
-      <item row="7" column="0">
+      <item row="6" column="0">
        <widget class="QLabel" name="lblReferer">
         <property name="text">
          <string>Referer</string>
@@ -192,8 +190,43 @@
         </property>
        </widget>
       </item>
-      <item row="8" column="1">
-       <widget class="QComboBox" name="cmbDpiMode"/>
+      <item row="6" column="1">
+       <widget class="QLineEdit" name="txtReferer"/>
+      </item>
+      <item row="15" column="0" colspan="2">
+       <widget class="QCheckBox" name="cbxSmoothPixmapTransform">
+        <property name="text">
+         <string>Smooth pixmap transform</string>
+        </property>
+       </widget>
+      </item>
+      <item row="14" column="0" colspan="2">
+       <widget class="QCheckBox" name="cbxInvertAxisOrientation">
+        <property name="text">
+         <string>Invert axis orientation</string>
+        </property>
+       </widget>
+      </item>
+      <item row="13" column="0" colspan="2">
+       <widget class="QCheckBox" name="cbxIgnoreAxisOrientation">
+        <property name="text">
+         <string>Ignore axis orientation (WMS 1.3/WMTS)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="11" column="0" colspan="2">
+       <widget class="QCheckBox" name="cbxIgnoreGetMapURI">
+        <property name="text">
+         <string>Ignore GetMap/GetTile URI reported in capabilities</string>
+        </property>
+       </widget>
+      </item>
+      <item row="12" column="0" colspan="2">
+       <widget class="QCheckBox" name="cbxIgnoreGetFeatureInfoURI">
+        <property name="text">
+         <string>Ignore GetFeatureInfo URI reported in capabilities</string>
+        </property>
+       </widget>
       </item>
      </layout>
     </widget>

--- a/src/ui/qgssslcertificatewidget.ui
+++ b/src/ui/qgssslcertificatewidget.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>493</width>
-    <height>221</height>
+    <height>240</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
@@ -169,7 +169,7 @@
           <bool>true</bool>
          </property>
          <property name="placeholderText">
-          <string>Required</string>
+          <string>Optional</string>
          </property>
         </widget>
        </item>

--- a/src/ui/qgssslcertificatewidget.ui
+++ b/src/ui/qgssslcertificatewidget.ui
@@ -1,0 +1,208 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsSslCertificateWidget</class>
+ <widget class="QWidget" name="QgsSslCertificateWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>493</width>
+    <height>221</height>
+   </rect>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="margin">
+    <number>6</number>
+   </property>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QComboBox" name="cmbStoreType">
+       <item>
+        <property name="text">
+         <string>QGIS User Cert Store</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="btnOpenStore">
+       <property name="text">
+        <string>Open...</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="btnValidateCert">
+       <property name="styleSheet">
+        <string notr="true">color: rgb(0, 170, 0);</string>
+       </property>
+       <property name="text">
+        <string>Validate</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="btnClearCert">
+       <property name="text">
+        <string>Clear</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QLineEdit" name="leMsg">
+     <property name="font">
+      <font>
+       <italic>true</italic>
+      </font>
+     </property>
+     <property name="readOnly">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item>
+    <widget class="QStackedWidget" name="stckwCertStore">
+     <widget class="QWidget" name="pageQgisStore">
+      <layout class="QGridLayout" name="gridLayout_2">
+       <property name="margin">
+        <number>0</number>
+       </property>
+       <item row="0" column="0">
+        <widget class="QLabel" name="lblQgisCert">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Cert</string>
+         </property>
+        </widget>
+       </item>
+       <item row="5" column="1">
+        <widget class="QCheckBox" name="chkQgisIssuerSelf">
+         <property name="text">
+          <string>Self-signed</string>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="0">
+        <widget class="QLabel" name="lblQgisIssuer">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Issuer</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="0">
+        <widget class="QLabel" name="lblQgisKey">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="text">
+          <string>Key</string>
+         </property>
+        </widget>
+       </item>
+       <item row="3" column="1">
+        <widget class="QCheckBox" name="chkQgisKeyPhrase">
+         <property name="text">
+          <string>Passphrase-protected</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="2">
+        <widget class="QToolButton" name="btnQgisCert">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="popupMode">
+          <enum>QToolButton::InstantPopup</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="2">
+        <widget class="QToolButton" name="btnQgisKey">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="popupMode">
+          <enum>QToolButton::InstantPopup</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="2">
+        <widget class="QToolButton" name="btnQgisIssuer">
+         <property name="text">
+          <string/>
+         </property>
+         <property name="popupMode">
+          <enum>QToolButton::InstantPopup</enum>
+         </property>
+        </widget>
+       </item>
+       <item row="4" column="1">
+        <widget class="QLineEdit" name="leQgisIssuer">
+         <property name="readOnly">
+          <bool>true</bool>
+         </property>
+         <property name="placeholderText">
+          <string>Optional</string>
+         </property>
+        </widget>
+       </item>
+       <item row="2" column="1">
+        <widget class="QLineEdit" name="leQgisKey">
+         <property name="readOnly">
+          <bool>true</bool>
+         </property>
+         <property name="placeholderText">
+          <string>Required</string>
+         </property>
+        </widget>
+       </item>
+       <item row="0" column="1">
+        <widget class="QLineEdit" name="leQgisCert">
+         <property name="readOnly">
+          <bool>true</bool>
+         </property>
+         <property name="placeholderText">
+          <string>Required</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="page_2"/>
+    </widget>
+   </item>
+   <item>
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>0</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
Sponsored by [Boundless Spatial, US](http://boundlessgeo.com/)
## Adds the following SSL PKI support
-  Reusable SSL PKI setup widget (`QgsSslCertificateWidget`, here inside WMS connection setup dialog): 
  
  ![ssl-cert_widget_cert-missing-sm](https://cloud.githubusercontent.com/assets/1295919/4365066/227b10cc-42a8-11e4-92ed-e00646ef73d4.png)
  It does lightweight validation (dates, etc., see [QSslCertificate.isValid()](http://qt-project.org/doc/qt-4.8/qsslcertificate.html#isValid) )
- SSL certificate settings (QgsSslCertSettings) and utilities (QgsSslUtils) classes
- Configures a local QGIS Store `~/.qgis2/cert_store`
  
  ``` sh
  $ ls -l  ~/.qgis2/cert_store
  drwx------  certs     <-- client certificates, e.g. name.pem
  drwx------  issuers  <-- certificate issuers (not in OpenSSL store, allows for self-signed bypass)
  drwx------  private   <-- client certificate private keys
  ```
- Add `QgsCredentials` key passphrase support, with stacked widget to rotate between inputs (username/password or key passphrase).
- Add SSL Certificate widget to new OWS connections (tabbed widget with Authentication).
- Cache key passphrases in `QgsNetworkManager` singleton, since it did not work with `QgsCredentials`.

**The Good Stuff**
- Support for private keys with passphrase-protection.
- Memory-caching of key passphrase, so it only needs input once per session.
- Key passphrase NOT stored in project file.
- Key passphrase can be input by user via GUI, or via console, when projects/layers are loaded, and across provider/GUI threads (via `QgsCredentials`).
- Support for auto-ignoring self-signed certificate issuer's certificate (per cert or cert chain, but not globally).
- Full Python bindings, where appropriate (e.g. no access to in-memory key passphrase).
- All additions have finally been encapsulated enough to allow for easier addition of different certificate store setups later

**Caveats**
- **Only works for the WMS provider at this time.** Need some feedback on whether this approach is sound, before adding PKI for other OWS connections ... should be fairly easy to do this week. ( @jef-n , @mhugent  ?)
  
  _NOTE:_ the other OWS services do show the certificate GUI, but are not yet functional.
- Base security is not so great. Since the QGIS local store is a know location, any plugin running with user-rights can find private keys, so those should always be passphrase-protected. (Important to note in the users guide).

**Future Improvements**
- Adding additional certificate stores, e.g. the native platform stores (like Apple's keychain), can be done using the robust [Qt Cryptographic Architecture (QCA)](http://delta.affinix.com/qca/). The cross-platform library does have a couple of issues, though:
  - No stable release that works with post-HeartBleed OpenSSL releases. Current development versions work well, though.
  - QCA adds a significant dependency to QGIS. The build should probably be optional, e.g. a '-D WITH-QCA'. May, or may not, be difficult for QCA to become a core requirement, due to the older systems that QGIS continues to support.
- Better certificate validation, including info dialogs to inspect the cert chain of trust.
- Better SSL hanshake error reporting.
- Add some cert conversion functions to allow users to import certs of other varieties, not just PEM-based. (Still stored locally as PEM)

**Testing**

You will need an HTTPS web mapping service with user authentication via PKI turned on. [See this page for some info](https://github.com/dakcarto/QGIS-PKI-Test) on an `OpenGeo Suite` setup with `GeoServer`.
