### PR TITLE
add support for NULL values in range widget

### DIFF
--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -68,6 +68,7 @@ editorwidgets/qgsdatetimeedit.cpp
 editorwidgets/qgsdatetimeeditfactory.cpp
 editorwidgets/qgsdatetimeeditconfig.cpp
 editorwidgets/qgsdatetimeeditwrapper.cpp
+editorwidgets/qgsdoublespinbox.cpp
 editorwidgets/qgsdummyconfigdlg.cpp
 editorwidgets/qgsenumerationwidgetwrapper.cpp
 editorwidgets/qgsenumerationwidgetfactory.cpp
@@ -81,6 +82,7 @@ editorwidgets/qgsphotowidgetfactory.cpp
 editorwidgets/qgsrangeconfigdlg.cpp
 editorwidgets/qgsrangewidgetwrapper.cpp
 editorwidgets/qgsrangewidgetfactory.cpp
+editorwidgets/qgsspinbox.cpp
 editorwidgets/qgsrelationwidgetwrapper.cpp
 editorwidgets/qgsrelationreferenceconfigdlg.cpp
 editorwidgets/qgsrelationreferencefactory.cpp
@@ -294,6 +296,7 @@ editorwidgets/qgscolorwidgetwrapper.h
 editorwidgets/qgsdatetimeedit.h
 editorwidgets/qgsdatetimeeditconfig.h
 editorwidgets/qgsdatetimeeditwrapper.h
+editorwidgets/qgsdoublespinbox.h
 editorwidgets/qgsdummyconfigdlg.h
 editorwidgets/qgsenumerationwidgetwrapper.h
 editorwidgets/qgsfilenamewidgetwrapper.h
@@ -306,6 +309,7 @@ editorwidgets/qgsrelationreferenceconfigdlg.h
 editorwidgets/qgsrelationreferencewidget.h
 editorwidgets/qgsrelationreferencewidgetwrapper.h
 editorwidgets/qgsrelationwidgetwrapper.h
+editorwidgets/qgsspinbox.h
 editorwidgets/qgstexteditconfigdlg.h
 editorwidgets/qgstexteditwrapper.h
 editorwidgets/qgsuniquevaluesconfigdlg.h
@@ -524,6 +528,7 @@ editorwidgets/qgsdatetimeedit.h
 editorwidgets/qgsdatetimeeditfactory.h
 editorwidgets/qgsdatetimeeditconfig.h
 editorwidgets/qgsdatetimeeditwrapper.h
+editorwidgets/qgsdoublespinbox.h
 editorwidgets/qgsdummyconfigdlg.h
 editorwidgets/qgsenumerationwidgetwrapper.h
 editorwidgets/qgsenumerationwidgetfactory.h
@@ -537,6 +542,7 @@ editorwidgets/qgsphotowidgetfactory.h
 editorwidgets/qgsrangeconfigdlg.h
 editorwidgets/qgsrangewidgetwrapper.h
 editorwidgets/qgsrangewidgetfactory.h
+editorwidgets/qgsspinbox.h
 editorwidgets/qgsrelationreferenceconfigdlg.h
 editorwidgets/qgsrelationreferencefactory.h
 editorwidgets/qgsrelationreferencewidget.h

--- a/src/gui/editorwidgets/qgsdoublespinbox.cpp
+++ b/src/gui/editorwidgets/qgsdoublespinbox.cpp
@@ -39,17 +39,30 @@ QgsDoubleSpinBox::QgsDoubleSpinBox( QWidget *parent )
   QSize msz = minimumSizeHint();
   setMinimumSize( qMax( msz.width(), mClearButton->sizeHint().height() + frameWidth() * 2 + 2 ),
                   qMax( msz.height(), mClearButton->sizeHint().height() + frameWidth() * 2 + 2 ) );
+
+  connect( this, SIGNAL( valueChanged( double ) ), this, SLOT( changed( double ) ) );
 }
 
 void QgsDoubleSpinBox::setAllowNull( bool allowNull )
 {
   mAllowNull = allowNull;
-  mClearButton->setVisible( mAllowNull );
+  mClearButton->setVisible( mAllowNull && isEnabled() && value() != minimum() );
+}
+
+void QgsDoubleSpinBox::changeEvent( QEvent *event )
+{
+  QDoubleSpinBox::changeEvent( event );
+  mClearButton->setVisible( mAllowNull && isEnabled() && value() != minimum() );
+}
+
+void QgsDoubleSpinBox::changed( const double& value )
+{
+  mClearButton->setVisible( mAllowNull && isEnabled() && value != minimum() );
 }
 
 void QgsDoubleSpinBox::clear()
 {
-  setValue(minimum());
+  setValue( minimum() );
 }
 
 int QgsDoubleSpinBox::frameWidth() const

--- a/src/gui/editorwidgets/qgsdoublespinbox.cpp
+++ b/src/gui/editorwidgets/qgsdoublespinbox.cpp
@@ -1,0 +1,69 @@
+/***************************************************************************
+    qgsdoublespinbox.cpp
+     --------------------------------------
+    Date                 : 09.2014
+    Copyright            : (C) 2014 Denis Rouzaud
+    Email                : denis.rouzaud@gmail.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <QLineEdit>
+#include <QMouseEvent>
+#include <QSettings>
+#include <QStyle>
+#include <QToolButton>
+
+#include "qgsdoublespinbox.h"
+
+#include "qgsapplication.h"
+#include "qgslogger.h"
+
+QgsDoubleSpinBox::QgsDoubleSpinBox( QWidget *parent )
+    : QDoubleSpinBox( parent )
+    , mAllowNull( true )
+{
+  mClearButton = new QToolButton( this );
+  mClearButton->setIcon( QgsApplication::getThemeIcon( "/mIconClear.svg" ) );
+  mClearButton->setCursor( Qt::ArrowCursor );
+  mClearButton->setStyleSheet( "position: absolute; border: none; padding: 0px;" );
+  connect( mClearButton, SIGNAL( clicked() ), this, SLOT( clear() ) );
+
+  setStyleSheet( QString( "padding-right: %1px;" ).arg( mClearButton->sizeHint().width() + 18 + frameWidth() + 1 ) );
+
+  QSize msz = minimumSizeHint();
+  setMinimumSize( qMax( msz.width(), mClearButton->sizeHint().height() + frameWidth() * 2 + 2 ),
+                  qMax( msz.height(), mClearButton->sizeHint().height() + frameWidth() * 2 + 2 ) );
+}
+
+void QgsDoubleSpinBox::setAllowNull( bool allowNull )
+{
+  mAllowNull = allowNull;
+  mClearButton->setVisible( mAllowNull );
+}
+
+void QgsDoubleSpinBox::clear()
+{
+  setValue(minimum());
+}
+
+int QgsDoubleSpinBox::frameWidth() const
+{
+  return style()->pixelMetric( QStyle::PM_DefaultFrameWidth );
+}
+
+void QgsDoubleSpinBox::resizeEvent( QResizeEvent * event )
+{
+  QDoubleSpinBox::resizeEvent( event );
+
+  QSize sz = mClearButton->sizeHint();
+
+  mClearButton->move( rect().right() - frameWidth() - 18 - sz.width() ,
+                      ( rect().bottom() + 1 - sz.height() ) / 2 );
+
+}

--- a/src/gui/editorwidgets/qgsdoublespinbox.h
+++ b/src/gui/editorwidgets/qgsdoublespinbox.h
@@ -1,0 +1,54 @@
+/***************************************************************************
+    qgsdoublespinbox.h
+     --------------------------------------
+    Date                 : 09.2014
+    Copyright            : (C) 2014 Denis Rouzaud
+    Email                : denis.rouzaud@gmail.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSDOUBLESPPINBOX_H
+#define QGSDOUBLESPPINBOX_H
+
+#include <QDoubleSpinBox>
+#include <QToolButton>
+
+/**
+ * @brief The QgsSpinBox is a spin box with a clear button that will set the value to the minimum. This minum can then be handled by a special value text.
+ */
+class GUI_EXPORT QgsDoubleSpinBox : public QDoubleSpinBox
+{
+    Q_OBJECT
+    Q_PROPERTY( bool allowNull READ allowNull WRITE setAllowNull )
+
+  public:
+    explicit QgsDoubleSpinBox( QWidget *parent = 0 );
+
+    //! determines if the widget allows setting null date/time.
+    void setAllowNull( bool allowNull );
+    bool allowNull() const {return mAllowNull;}
+
+
+    //! Set the current value to the minimum
+    //! @note if the widget is not configured to accept NULL values, this will have no effect
+    virtual void clear();
+
+  protected:
+    virtual void resizeEvent( QResizeEvent* event );
+
+  private:
+    int spinButtonWidth() const;
+    int frameWidth() const;
+
+    bool mAllowNull;
+
+    QToolButton* mClearButton;
+};
+
+#endif // QGSDOUBLESPPINBOX_H

--- a/src/gui/editorwidgets/qgsdoublespinbox.h
+++ b/src/gui/editorwidgets/qgsdoublespinbox.h
@@ -41,6 +41,10 @@ class GUI_EXPORT QgsDoubleSpinBox : public QDoubleSpinBox
 
   protected:
     virtual void resizeEvent( QResizeEvent* event );
+    virtual void changeEvent( QEvent* event );
+
+  private slots:
+    void changed( const double &value );
 
   private:
     int spinButtonWidth() const;

--- a/src/gui/editorwidgets/qgsrangeconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsrangeconfigdlg.cpp
@@ -66,6 +66,8 @@ QgsRangeConfigDlg::QgsRangeConfigDlg( QgsVectorLayer* vl, int fieldIdx, QWidget 
   }
 
   valuesLabel->setText( text );
+
+  connect( rangeWidget, SIGNAL( currentIndexChanged( int ) ), this, SLOT( rangeWidgetChanged( int ) ) );
 }
 
 QgsEditorWidgetConfig QgsRangeConfigDlg::config()
@@ -92,6 +94,7 @@ QgsEditorWidgetConfig QgsRangeConfigDlg::config()
   }
 
   cfg.insert( "Style", rangeWidget->itemData( rangeWidget->currentIndex() ).toString() );
+  cfg.insert( "AllowNull", allowNullCheckBox->isChecked() );
 
   if ( suffixLineEdit->text() != "" )
   {
@@ -114,4 +117,12 @@ void QgsRangeConfigDlg::setConfig( const QgsEditorWidgetConfig& config )
   rangeWidget->setCurrentIndex( rangeWidget->findData( config.value( "Style", "SpinBox" ) ) );
 
   suffixLineEdit->setText( config.value( "Suffix" ).toString() );
+
+  allowNullCheckBox->setChecked( config.value( "AllowNull", true ).toBool() );
+}
+
+void QgsRangeConfigDlg::rangeWidgetChanged( int index )
+{
+  QString style = rangeWidget->itemData( index ).toString();
+  allowNullCheckBox->setEnabled( style == "SpinBox" );
 }

--- a/src/gui/editorwidgets/qgsrangeconfigdlg.h
+++ b/src/gui/editorwidgets/qgsrangeconfigdlg.h
@@ -27,6 +27,9 @@ class GUI_EXPORT QgsRangeConfigDlg : public QgsEditorConfigWidget, private Ui::Q
     explicit QgsRangeConfigDlg( QgsVectorLayer* vl, int fieldIdx, QWidget* parent );
     virtual QgsEditorWidgetConfig config();
     virtual void setConfig( const QgsEditorWidgetConfig& config );
+
+  protected slots:
+    void rangeWidgetChanged( int index );
 };
 
 #endif // QGSRANGECONFIGDLG_H

--- a/src/gui/editorwidgets/qgsrangewidgetfactory.cpp
+++ b/src/gui/editorwidgets/qgsrangewidgetfactory.cpp
@@ -44,6 +44,7 @@ QgsEditorWidgetConfig QgsRangeWidgetFactory::readConfig( const QDomElement& conf
   cfg.insert( "Min", configElement.attribute( "Min" ).toInt() );
   cfg.insert( "Max", configElement.attribute( "Max" ).toInt() );
   cfg.insert( "Step", configElement.attribute( "Step" ).toInt() );
+  cfg.insert( "AllowNull", configElement.attribute( "AllowNull" ) == "1" );
 
   if ( configElement.hasAttribute( "Suffix" ) )
   {
@@ -63,6 +64,7 @@ void QgsRangeWidgetFactory::writeConfig( const QgsEditorWidgetConfig& config, QD
   configElement.setAttribute( "Min", config["Min"].toInt() );
   configElement.setAttribute( "Max", config["Max"].toInt() );
   configElement.setAttribute( "Step", config["Step"].toInt() );
+  configElement.setAttribute( "AllowNull", config["AllowNull"].toBool() );
   if ( config.contains( "Suffix" ) )
   {
     configElement.setAttribute( "Suffix", config["Suffix"].toString() );

--- a/src/gui/editorwidgets/qgsspinbox.cpp
+++ b/src/gui/editorwidgets/qgsspinbox.cpp
@@ -39,17 +39,30 @@ QgsSpinBox::QgsSpinBox( QWidget *parent )
   QSize msz = minimumSizeHint();
   setMinimumSize( qMax( msz.width(), mClearButton->sizeHint().height() + frameWidth() * 2 + 2 ),
                   qMax( msz.height(), mClearButton->sizeHint().height() + frameWidth() * 2 + 2 ) );
+
+  connect( this, SIGNAL( valueChanged( int ) ), this, SLOT( changed( int ) ) );
 }
 
 void QgsSpinBox::setAllowNull( bool allowNull )
 {
   mAllowNull = allowNull;
-  mClearButton->setVisible( mAllowNull );
+  mClearButton->setVisible( mAllowNull && isEnabled() && value() != minimum() );
+}
+
+void QgsSpinBox::changeEvent( QEvent *event )
+{
+  QSpinBox::changeEvent( event );
+  mClearButton->setVisible( mAllowNull && isEnabled() && value() != minimum() );
+}
+
+void QgsSpinBox::changed( const int& value )
+{
+  mClearButton->setVisible( mAllowNull && isEnabled() && value != minimum() );
 }
 
 void QgsSpinBox::clear()
 {
-  setValue(minimum());
+  setValue( minimum() );
 }
 
 int QgsSpinBox::frameWidth() const

--- a/src/gui/editorwidgets/qgsspinbox.cpp
+++ b/src/gui/editorwidgets/qgsspinbox.cpp
@@ -1,0 +1,69 @@
+/***************************************************************************
+    qgsspinbox.cpp
+     --------------------------------------
+    Date                 : 09.2014
+    Copyright            : (C) 2014 Denis Rouzaud
+    Email                : denis.rouzaud@gmail.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <QLineEdit>
+#include <QMouseEvent>
+#include <QSettings>
+#include <QStyle>
+#include <QToolButton>
+
+#include "qgsspinbox.h"
+
+#include "qgsapplication.h"
+#include "qgslogger.h"
+
+QgsSpinBox::QgsSpinBox( QWidget *parent )
+    : QSpinBox( parent )
+    , mAllowNull( true )
+{
+  mClearButton = new QToolButton( this );
+  mClearButton->setIcon( QgsApplication::getThemeIcon( "/mIconClear.svg" ) );
+  mClearButton->setCursor( Qt::ArrowCursor );
+  mClearButton->setStyleSheet( "position: absolute; border: none; padding: 0px;" );
+  connect( mClearButton, SIGNAL( clicked() ), this, SLOT( clear() ) );
+
+  setStyleSheet( QString( "padding-right: %1px;" ).arg( mClearButton->sizeHint().width() + 18 + frameWidth() + 1 ) );
+
+  QSize msz = minimumSizeHint();
+  setMinimumSize( qMax( msz.width(), mClearButton->sizeHint().height() + frameWidth() * 2 + 2 ),
+                  qMax( msz.height(), mClearButton->sizeHint().height() + frameWidth() * 2 + 2 ) );
+}
+
+void QgsSpinBox::setAllowNull( bool allowNull )
+{
+  mAllowNull = allowNull;
+  mClearButton->setVisible( mAllowNull );
+}
+
+void QgsSpinBox::clear()
+{
+  setValue(minimum());
+}
+
+int QgsSpinBox::frameWidth() const
+{
+  return style()->pixelMetric( QStyle::PM_DefaultFrameWidth );
+}
+
+void QgsSpinBox::resizeEvent( QResizeEvent * event )
+{
+  QSpinBox::resizeEvent( event );
+
+  QSize sz = mClearButton->sizeHint();
+
+  mClearButton->move( rect().right() - frameWidth() - 18 - sz.width() ,
+                      ( rect().bottom() + 1 - sz.height() ) / 2 );
+
+}

--- a/src/gui/editorwidgets/qgsspinbox.h
+++ b/src/gui/editorwidgets/qgsspinbox.h
@@ -41,6 +41,10 @@ class GUI_EXPORT QgsSpinBox : public QSpinBox
 
   protected:
     virtual void resizeEvent( QResizeEvent* event );
+    virtual void changeEvent( QEvent* event );
+
+  private slots:
+    void changed( const int& value );
 
   private:
     int spinButtonWidth() const;

--- a/src/gui/editorwidgets/qgsspinbox.h
+++ b/src/gui/editorwidgets/qgsspinbox.h
@@ -1,0 +1,54 @@
+/***************************************************************************
+    qgsspinbox.h
+     --------------------------------------
+    Date                 : 09.2014
+    Copyright            : (C) 2014 Denis Rouzaud
+    Email                : denis.rouzaud@gmail.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSSPPINBOX_H
+#define QGSSPPINBOX_H
+
+#include <QSpinBox>
+#include <QToolButton>
+
+/**
+ * @brief The QgsSpinBox is a spin box with a clear button that will set the value to the minimum. This minum can then be handled by a special value text.
+ */
+class GUI_EXPORT QgsSpinBox : public QSpinBox
+{
+    Q_OBJECT
+    Q_PROPERTY( bool allowNull READ allowNull WRITE setAllowNull )
+
+  public:
+    explicit QgsSpinBox( QWidget *parent = 0 );
+
+    //! determines if the widget allows setting null date/time.
+    void setAllowNull( bool allowNull );
+    bool allowNull() const {return mAllowNull;}
+
+
+    //! Set the current value to the minimum
+    //! @note if the widget is not configured to accept NULL values, this will have no effect
+    virtual void clear();
+
+  protected:
+    virtual void resizeEvent( QResizeEvent* event );
+
+  private:
+    int spinButtonWidth() const;
+    int frameWidth() const;
+
+    bool mAllowNull;
+
+    QToolButton* mClearButton;
+};
+
+#endif // QGSSPPINBOX_H

--- a/src/ui/editorwidgets/qgsrangeconfigdlgbase.ui
+++ b/src/ui/editorwidgets/qgsrangeconfigdlgbase.ui
@@ -25,19 +25,32 @@
     </widget>
    </item>
    <item row="4" column="0">
-    <widget class="QLabel" name="valuesLabel">
-     <property name="text">
-      <string>Local minimum/maximum = 0/0</string>
+    <widget class="QgsCollapsibleGroupBox" name="groupBox">
+     <property name="title">
+      <string>Advanced options</string>
      </property>
-     <property name="wordWrap">
-      <bool>true</bool>
-     </property>
+     <layout class="QFormLayout" name="formLayout_3">
+      <item row="0" column="0">
+       <widget class="QLabel" name="suffixLabel">
+        <property name="text">
+         <string>Suffix</string>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="1">
+       <widget class="QLineEdit" name="suffixLineEdit">
+        <property name="placeholderText">
+         <string>Inactive</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
     </widget>
    </item>
    <item row="1" column="0" colspan="2">
     <widget class="QComboBox" name="rangeWidget"/>
    </item>
-   <item row="5" column="0">
+   <item row="6" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -50,13 +63,26 @@
      </property>
     </spacer>
    </item>
+   <item row="5" column="0">
+    <widget class="QLabel" name="valuesLabel">
+     <property name="text">
+      <string>Local minimum/maximum = 0/0</string>
+     </property>
+     <property name="wordWrap">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
    <item row="2" column="0">
     <widget class="QStackedWidget" name="rangeStackedWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="intPage">
       <layout class="QFormLayout" name="formLayout">
+       <property name="bottomMargin">
+        <number>3</number>
+       </property>
        <item row="0" column="0">
         <widget class="QLabel" name="minimumLabel">
          <property name="text">
@@ -115,6 +141,9 @@
      </widget>
      <widget class="QWidget" name="doublePage">
       <layout class="QFormLayout" name="formLayout_2">
+       <property name="bottomMargin">
+        <number>3</number>
+       </property>
        <item row="2" column="0">
         <widget class="QLabel" name="stepLabel_2">
          <property name="text">
@@ -174,26 +203,10 @@
     </widget>
    </item>
    <item row="3" column="0">
-    <widget class="QgsCollapsibleGroupBox" name="groupBox">
-     <property name="title">
-      <string>Advanced options</string>
+    <widget class="QCheckBox" name="allowNullCheckBox">
+     <property name="text">
+      <string>Allow NULL</string>
      </property>
-     <layout class="QFormLayout" name="formLayout_3">
-      <item row="0" column="0">
-       <widget class="QLabel" name="suffixLabel">
-        <property name="text">
-         <string>Suffix</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="1">
-       <widget class="QLineEdit" name="suffixLineEdit">
-        <property name="placeholderText">
-         <string>Inactive</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
     </widget>
    </item>
   </layout>


### PR DESCRIPTION
This also create new Qgs(Double)SpinBox classes to show the clear button.

The idea is to decrease the minimum value and use it as special text value.
The advantage of doing it is that forms with standard QSpinBox (not QgsSpinBox) will still be able to show the NULL values. They just won't show the clear icon.

SIP and custom widgets will follow once merged.
