### PR TITLE
[FEATURE][QGIS-Server] Legend filtering based on map in GetPrint Request

### DIFF
--- a/python/core/layertree/qgslayertreegroup.sip
+++ b/python/core/layertree/qgslayertreegroup.sip
@@ -41,6 +41,8 @@ class QgsLayerTreeGroup : QgsLayerTreeNode
     void removeLayer( QgsMapLayer* layer );
     //! Remove child nodes from index "from". The nodes will be deleted.
     void removeChildren( int from, int count );
+    //! Remove all child group nodes without layers. The groupnodes will be deleted.
+    void removeChildrenGroupWithoutLayers();
     //! Remove all child nodes. The nodes will be deleted.
     void removeAllChildren();
 

--- a/src/core/composer/qgscomposerlabel.cpp
+++ b/src/core/composer/qgscomposerlabel.cpp
@@ -98,7 +98,6 @@ void QgsComposerLabel::paint( QPainter* painter, const QStyleOptionGraphicsItem*
   if ( mHtmlState )
   {
     painter->scale( 1.0 / mHtmlUnitsToMM / 10.0, 1.0 / mHtmlUnitsToMM / 10.0 );
-
     QWebPage *webPage = new QWebPage();
     webPage->setNetworkAccessManager( QgsNetworkAccessManager::instance() );
 
@@ -149,7 +148,6 @@ void QgsComposerLabel::paint( QPainter* painter, const QStyleOptionGraphicsItem*
       // Pause until html is loaded
       loop.exec();
     }
-
     webPage->mainFrame()->render( painter );//DELETE WEBPAGE ?
   }
   else

--- a/src/core/layertree/qgslayertreegroup.cpp
+++ b/src/core/layertree/qgslayertreegroup.cpp
@@ -119,6 +119,22 @@ void QgsLayerTreeGroup::removeChildren( int from, int count )
   updateVisibilityFromChildren();
 }
 
+void QgsLayerTreeGroup::removeChildrenGroupWithoutLayers()
+{	
+  // clean the layer tree by removing empty group
+  foreach ( QgsLayerTreeNode* treeNode, children() )
+  {
+    if ( treeNode->nodeType() == QgsLayerTreeNode::NodeGroup )
+    {
+	  QgsLayerTreeGroup* treeGroup = qobject_cast<QgsLayerTreeGroup*>( treeNode );
+	  if ( treeGroup->findLayerIds().count() == 0 )
+	    removeChildNode( treeNode );
+	  else
+	    treeGroup->removeChildrenGroupWithoutLayers();
+    }
+  }
+}
+
 void QgsLayerTreeGroup::removeAllChildren()
 {
   removeChildren( 0, mChildren.count() );

--- a/src/core/layertree/qgslayertreegroup.h
+++ b/src/core/layertree/qgslayertreegroup.h
@@ -62,6 +62,8 @@ class CORE_EXPORT QgsLayerTreeGroup : public QgsLayerTreeNode
     void removeLayer( QgsMapLayer* layer );
     //! Remove child nodes from index "from". The nodes will be deleted.
     void removeChildren( int from, int count );
+    //! Remove all child group nodes without layers. The groupnodes will be deleted.
+    void removeChildrenGroupWithoutLayers();
     //! Remove all child nodes. The nodes will be deleted.
     void removeAllChildren();
 

--- a/src/mapserver/qgssldconfigparser.cpp
+++ b/src/mapserver/qgssldconfigparser.cpp
@@ -696,11 +696,11 @@ QgsComposition* QgsSLDConfigParser::createPrintComposition( const QString& compo
   return 0;
 }
 
-QgsComposition* QgsSLDConfigParser::initComposition( const QString& composerTemplate, QgsMapRenderer* mapRenderer, QList< QgsComposerMap*>& mapList, QList< QgsComposerLabel* >& labelList, QList<const QgsComposerHtml *>& htmlFrameList ) const
+QgsComposition* QgsSLDConfigParser::initComposition( const QString& composerTemplate, QgsMapRenderer* mapRenderer, QList< QgsComposerMap*>& mapList, QList< QgsComposerLegend* >& legendList, QList< QgsComposerLabel* >& labelList, QList<const QgsComposerHtml *>& htmlFrameList ) const
 {
   if ( mFallbackParser )
   {
-    return mFallbackParser->initComposition( composerTemplate, mapRenderer, mapList, labelList, htmlFrameList );
+    return mFallbackParser->initComposition( composerTemplate, mapRenderer, mapList, legendList, labelList, htmlFrameList );
   }
   return 0;
 }

--- a/src/mapserver/qgssldconfigparser.h
+++ b/src/mapserver/qgssldconfigparser.h
@@ -107,7 +107,7 @@ class QgsSLDConfigParser : public QgsWMSConfigParser
     QgsComposition* createPrintComposition( const QString& composerTemplate, QgsMapRenderer* mapRenderer, const QMap< QString, QString >& parameterMap ) const;
 
     /**Creates a composition from the project file (probably delegated to the fallback parser)*/
-    QgsComposition* initComposition( const QString& composerTemplate, QgsMapRenderer* mapRenderer, QList< QgsComposerMap*>& mapList, QList< QgsComposerLabel* >& labelList, QList<const QgsComposerHtml *>& htmlFrameList ) const;
+    QgsComposition* initComposition( const QString& composerTemplate, QgsMapRenderer* mapRenderer, QList< QgsComposerMap*>& mapList, QList< QgsComposerLegend* >& legendList, QList< QgsComposerLabel* >& labelList, QList<const QgsComposerHtml *>& htmlFrameList ) const;
 
     /**Adds print capabilities to xml document. ParentElem usually is the <Capabilities> element*/
     void printCapabilities( QDomElement& parentElement, QDomDocument& doc ) const;

--- a/src/mapserver/qgswmsconfigparser.h
+++ b/src/mapserver/qgswmsconfigparser.h
@@ -22,6 +22,7 @@
 
 class QgsComposerHtml;
 class QgsComposerLabel;
+class QgsComposerLegend;
 class QgsComposerMap;
 class QgsComposition;
 class QgsMapLayer;
@@ -107,7 +108,7 @@ class QgsWMSConfigParser
     QgsComposition* createPrintComposition( const QString& composerTemplate, QgsMapRenderer* mapRenderer, const QMap< QString, QString >& parameterMap ) const;
 
     /**Creates a composition from the project file (probably delegated to the fallback parser)*/
-    virtual QgsComposition* initComposition( const QString& composerTemplate, QgsMapRenderer* mapRenderer, QList< QgsComposerMap*>& mapList, QList< QgsComposerLabel* >& labelList, QList<const QgsComposerHtml *>& htmlFrameList ) const = 0;
+    virtual QgsComposition* initComposition( const QString& composerTemplate, QgsMapRenderer* mapRenderer, QList< QgsComposerMap*>& mapList, QList< QgsComposerLegend* >& legendList, QList< QgsComposerLabel* >& labelList, QList<const QgsComposerHtml *>& htmlFrameList ) const = 0;
 
     /**Adds print capabilities to xml document. ParentElem usually is the <Capabilities> element*/
     virtual void printCapabilities( QDomElement& parentElement, QDomDocument& doc ) const = 0;

--- a/src/mapserver/qgswmsprojectparser.h
+++ b/src/mapserver/qgswmsprojectparser.h
@@ -20,6 +20,7 @@
 
 #include "qgswmsconfigparser.h"
 #include "qgsserverprojectparser.h"
+#include "qgslayertreegroup.h"
 
 class QTextDocument;
 class QSvgRenderer;
@@ -59,7 +60,7 @@ class QgsWMSProjectParser : public QgsWMSConfigParser
     int WMSPrecision() const;
 
     //printing
-    QgsComposition* initComposition( const QString& composerTemplate, QgsMapRenderer* mapRenderer, QList< QgsComposerMap*>& mapList, QList< QgsComposerLabel* >& labelList, QList<const QgsComposerHtml *>& htmlFrameList ) const;
+    QgsComposition* initComposition( const QString& composerTemplate, QgsMapRenderer* mapRenderer, QList< QgsComposerMap* >& mapList, QList< QgsComposerLegend* >& legendList, QList< QgsComposerLabel* >& labelList, QList<const QgsComposerHtml *>& htmlFrameList ) const;
 
     void printCapabilities( QDomElement& parentElement, QDomDocument& doc ) const;
 
@@ -147,6 +148,7 @@ class QgsWMSProjectParser : public QgsWMSConfigParser
     void addLayersFromGroup( const QDomElement& legendGroupElem, QMap< int, QgsMapLayer*>& layers, bool useCache = true ) const;
 
     QDomElement composerByName( const QString& composerName ) const;
+    QgsLayerTreeGroup* projectLayerTreeGroup() const;
 
     static bool annotationPosition( const QDomElement& elem, double scaleFactor, double& xPos, double& yPos );
     static void drawAnnotationRectangle( QPainter* p, const QDomElement& elem, double scaleFactor, double xPos, double yPos, int itemWidth, int itemHeight );


### PR DESCRIPTION
Feature funded by Tecnostudi Ambiente, Faunalia and Andromede-oceanologie.

The legend in composition was fixed and did not represent the layers in the map.
With the work made by @wonder-sk on layer-tree and QgsComposerLegend users will be able
 to configure composer legend as based on all the project layer tree with auto-update
 model or filtered by map.
This commit reused these two QgsComposerLegend's properties to filter it based on map in
 GetPrint Request

The issue #4003 qgis_mapserver getPrint legend options can be closed.
