### PR TITLE
support icons in map layer actions

### DIFF
--- a/python/gui/qgsmaplayeractionregistry.sip
+++ b/python/gui/qgsmaplayeractionregistry.sip
@@ -16,13 +16,13 @@ class QgsMapLayerAction : QAction
 
     //! Creates a map layer action which can run on any layer
     //! @note using AllActions as a target probably does not make a lot of sense. This default action was settled for API compatiblity reasons.
-    QgsMapLayerAction( QString name, QObject *parent, Targets targets = AllActions );
+    QgsMapLayerAction( QString name, QObject *parent, Targets targets = AllActions, QIcon icon = QIcon() );
 
     //! Creates a map layer action which can run only on a specific layer
-    QgsMapLayerAction( QString name, QObject *parent, QgsMapLayer* layer, Targets targets = AllActions );
+    QgsMapLayerAction( QString name, QObject *parent, QgsMapLayer* layer, Targets targets = AllActions, QIcon icon = QIcon() );
 
     //! Creates a map layer action which can run on a specific type of layer
-    QgsMapLayerAction( QString name, QObject *parent, QgsMapLayer::LayerType layerType, Targets targets = AllActions );
+    QgsMapLayerAction( QString name, QObject *parent, QgsMapLayer::LayerType layerType, Targets targets = AllActions, QIcon icon = QIcon() );
 
     ~QgsMapLayerAction();
 

--- a/src/app/composer/qgscomposer.cpp
+++ b/src/app/composer/qgscomposer.cpp
@@ -3607,7 +3607,9 @@ void QgsComposer::updateAtlasMapLayerAction( QgsVectorLayer *coverageLayer )
 
   if ( coverageLayer )
   {
-    mAtlasFeatureAction = new QgsMapLayerAction( QString( tr( "Set as atlas feature for %1" ) ).arg( mTitle ), this, coverageLayer, QgsMapLayerAction::SingleFeature );
+    mAtlasFeatureAction = new QgsMapLayerAction( QString( tr( "Set as atlas feature for %1" ) ).arg( mTitle ),
+        this, coverageLayer, QgsMapLayerAction::SingleFeature ,
+        QgsApplication::getThemeIcon( "/mIconAtlas.svg" ) );
     QgsMapLayerActionRegistry::instance()->addMapLayerAction( mAtlasFeatureAction );
     connect( mAtlasFeatureAction, SIGNAL( triggeredForFeature( QgsMapLayer*, const QgsFeature& ) ), this, SLOT( setAtlasFeature( QgsMapLayer*, const QgsFeature& ) ) );
   }
@@ -3652,7 +3654,9 @@ void QgsComposer::updateAtlasMapLayerAction( bool atlasEnabled )
   if ( atlasEnabled )
   {
     QgsAtlasComposition& atlas = mComposition->atlasComposition();
-    mAtlasFeatureAction = new QgsMapLayerAction( QString( tr( "Set as atlas feature for %1" ) ).arg( mTitle ), this, atlas.coverageLayer(), QgsMapLayerAction::SingleFeature );
+    mAtlasFeatureAction = new QgsMapLayerAction( QString( tr( "Set as atlas feature for %1" ) ).arg( mTitle ),
+        this, atlas.coverageLayer(), QgsMapLayerAction::SingleFeature ,
+        QgsApplication::getThemeIcon( "/mIconAtlas.svg" ) );
     QgsMapLayerActionRegistry::instance()->addMapLayerAction( mAtlasFeatureAction );
     connect( mAtlasFeatureAction, SIGNAL( triggeredForFeature( QgsMapLayer*, const QgsFeature& ) ), this, SLOT( setAtlasFeature( QgsMapLayer*, const QgsFeature& ) ) );
   }

--- a/src/gui/qgsactionmenu.cpp
+++ b/src/gui/qgsactionmenu.cpp
@@ -151,7 +151,7 @@ void QgsActionMenu::reloadActions()
     for ( int i = 0; i < mapLayerActions.size(); ++i )
     {
       QgsMapLayerAction* qaction = mapLayerActions.at( i );
-      QAction* action = new QAction( qaction->text(), this );
+      QAction* action = new QAction( qaction->icon(), qaction->text(), this );
       action->setData( QVariant::fromValue<ActionData>( ActionData( qaction, mFeatureId, mLayer ) ) );
       addAction( action );
       connect( action, SIGNAL( triggered() ), this, SLOT( triggerAction() ) );

--- a/src/gui/qgsmaplayeractionregistry.cpp
+++ b/src/gui/qgsmaplayeractionregistry.cpp
@@ -16,8 +16,8 @@
 #include "qgsmaplayeractionregistry.h"
 
 
-QgsMapLayerAction::QgsMapLayerAction( QString name, QObject* parent, Targets targets )
-    : QAction( name, parent )
+QgsMapLayerAction::QgsMapLayerAction( QString name, QObject* parent, Targets targets, QIcon icon )
+    : QAction( icon, name, parent )
     , mSingleLayer( false )
     , mActionLayer( 0 )
     , mSpecificLayerType( false )
@@ -26,8 +26,8 @@ QgsMapLayerAction::QgsMapLayerAction( QString name, QObject* parent, Targets tar
 }
 
 /**Creates a map layer action which can run only on a specific layer*/
-QgsMapLayerAction::QgsMapLayerAction( QString name, QObject* parent, QgsMapLayer* layer, Targets targets )
-    : QAction( name, parent )
+QgsMapLayerAction::QgsMapLayerAction( QString name, QObject* parent, QgsMapLayer* layer , Targets targets, QIcon icon )
+    : QAction( icon, name, parent )
     , mSingleLayer( true )
     , mActionLayer( layer )
     , mSpecificLayerType( false )
@@ -36,8 +36,8 @@ QgsMapLayerAction::QgsMapLayerAction( QString name, QObject* parent, QgsMapLayer
 }
 
 /**Creates a map layer action which can run on a specific type of layer*/
-QgsMapLayerAction::QgsMapLayerAction( QString name, QObject* parent, QgsMapLayer::LayerType layerType, Targets targets )
-    : QAction( name, parent )
+QgsMapLayerAction::QgsMapLayerAction( QString name, QObject* parent, QgsMapLayer::LayerType layerType, Targets targets, QIcon icon )
+    : QAction( icon, name, parent )
     , mSingleLayer( false )
     , mActionLayer( 0 )
     , mSpecificLayerType( true )

--- a/src/gui/qgsmaplayeractionregistry.h
+++ b/src/gui/qgsmaplayeractionregistry.h
@@ -45,13 +45,13 @@ class GUI_EXPORT QgsMapLayerAction : public QAction
 
     //! Creates a map layer action which can run on any layer
     //! @note using AllActions as a target probably does not make a lot of sense. This default action was settled for API compatiblity reasons.
-    QgsMapLayerAction( QString name, QObject *parent, Targets targets = AllActions );
+    QgsMapLayerAction( QString name, QObject *parent, Targets targets = AllActions, QIcon icon = QIcon() );
 
     //! Creates a map layer action which can run only on a specific layer
-    QgsMapLayerAction( QString name, QObject *parent, QgsMapLayer* layer, Targets targets = AllActions );
+    QgsMapLayerAction( QString name, QObject *parent, QgsMapLayer* layer, Targets targets = AllActions, QIcon icon = QIcon() );
 
     //! Creates a map layer action which can run on a specific type of layer
-    QgsMapLayerAction( QString name, QObject *parent, QgsMapLayer::LayerType layerType, Targets targets = AllActions );
+    QgsMapLayerAction( QString name, QObject *parent, QgsMapLayer::LayerType layerType, Targets targets = AllActions, QIcon icon = QIcon() );
 
     ~QgsMapLayerAction();
 


### PR DESCRIPTION
This follows the addition of icons in attribute actions by adding icon capability to map layer actions too.

It also adds the atlas icon to its dedicated icon.

Although not a big one, I suppose it's a new feature so it has to wait.

@nyalldawson ok for you?
