### PR TITLE
Categorized renderer fixes

### DIFF
--- a/python/core/symbology-ng/qgsgraduatedsymbolrendererv2.sip
+++ b/python/core/symbology-ng/qgsgraduatedsymbolrendererv2.sip
@@ -54,8 +54,8 @@ class QgsRendererRangeV2LabelFormat
     QString format() const;
     void setFormat( QString format );
 
-    int decimalPlaces() const;
-    void setDecimalPlaces( int decimalPlaces );
+    int precision();
+    void setPrecision( int precision );
 
     bool trimTrailingZeroes() const;
     void setTrimTrailingZeroes( bool trimTrailingZeroes );

--- a/python/core/symbology-ng/qgsgraduatedsymbolrendererv2.sip
+++ b/python/core/symbology-ng/qgsgraduatedsymbolrendererv2.sip
@@ -41,17 +41,17 @@ typedef QList<QgsRendererRangeV2> QgsRangeList;
 
 
 // @note added in 2.6
-class QgsRendererRangeV2LegendFormat
+class QgsRendererRangeV2LabelFormat
 {
 %TypeHeaderCode
 #include <qgsgraduatedsymbolrendererv2.h>
 %End
   public:
-    QgsRendererRangeV2LegendFormat();
-    QgsRendererRangeV2LegendFormat( QString format, int precision = 4, bool trimTrailingZeroes = false );
+    QgsRendererRangeV2LabelFormat();
+    QgsRendererRangeV2LabelFormat( QString format, int precision = 4, bool trimTrailingZeroes = false );
 
-    bool operator==( const QgsRendererRangeV2LegendFormat & other ) const;
-    bool operator!=( const QgsRendererRangeV2LegendFormat & other ) const;
+    bool operator==( const QgsRendererRangeV2LabelFormat & other ) const;
+    bool operator!=( const QgsRendererRangeV2LabelFormat & other ) const;
 
     QString format() const;
     void setFormat( QString format );
@@ -63,8 +63,8 @@ class QgsRendererRangeV2LegendFormat
     void setTrimTrailingZeroes( bool trimTrailingZeroes );
 
     //! @note labelForLowerUpper in python bindings
-    QString legendForRange( double lower, double upper ) const;
-    QString legendForRange( const QgsRendererRangeV2 &range ) const;
+    QString labelForRange( double lower, double upper ) const;
+    QString labelForRange( const QgsRendererRangeV2 &range ) const;
     QString formatNumber( double value ) const;
 
     void setFromDomElement( QDomElement &element );
@@ -160,12 +160,12 @@ class QgsGraduatedSymbolRendererV2 : QgsFeatureRendererV2
 
     //! Return the label format used to generate default classification labels
     //! @note Added in 2.6
-    const QgsRendererRangeV2LegendFormat &legendFormat() const;
+    const QgsRendererRangeV2LabelFormat &labelFormat() const;
     //! Set the label format used to generate default classification labels
     //! @param labelFormat The string appended to classification labels
     //! @param updateRanges If true then ranges ending with the old unit string are updated to the new.
     //! @note Added in 2.6
-    void setLegendFormat( const QgsRendererRangeV2LegendFormat &legendFormat, bool updateRanges = true );
+    void setLabelFormat( const QgsRendererRangeV2LabelFormat &labelFormat, bool updateRanges = true );
 
     //! Reset the label decimal places to a numberbased on the minimum class interval
     //! @param updateRanges if true then ranges currently using the default label will be updated
@@ -180,7 +180,7 @@ class QgsGraduatedSymbolRendererV2 : QgsFeatureRendererV2
       QgsSymbolV2* symbol /Transfer/,
       QgsVectorColorRampV2* ramp /Transfer/,
       bool inverted = false,
-      QgsRendererRangeV2LegendFormat labelFormat=QgsRendererRangeV2LegendFormat()
+      QgsRendererRangeV2LabelFormat labelFormat=QgsRendererRangeV2LabelFormat()
       );
 
     //! create renderer from XML element

--- a/python/core/symbology-ng/qgsgraduatedsymbolrendererv2.sip
+++ b/python/core/symbology-ng/qgsgraduatedsymbolrendererv2.sip
@@ -69,6 +69,10 @@ class QgsRendererRangeV2LegendFormat
 
     void setFromDomElement( QDomElement &element );
     void saveToDomElement( QDomElement &element );
+
+    static int MaxPrecision;
+    static int MinPrecision;
+
 };
 
 

--- a/python/core/symbology-ng/qgsgraduatedsymbolrendererv2.sip
+++ b/python/core/symbology-ng/qgsgraduatedsymbolrendererv2.sip
@@ -39,17 +39,19 @@ class QgsRendererRangeV2
 
 typedef QList<QgsRendererRangeV2> QgsRangeList;
 
-class QgsRendererRangeV2LabelFormat
+
+// @note added in 2.6
+class QgsRendererRangeV2LegendFormat
 {
 %TypeHeaderCode
 #include <qgsgraduatedsymbolrendererv2.h>
 %End
   public:
-    QgsRendererRangeV2LabelFormat();
-    QgsRendererRangeV2LabelFormat( QString format, int decimalPlaces=4, bool trimTrailingZeroes=false );
+    QgsRendererRangeV2LegendFormat();
+    QgsRendererRangeV2LegendFormat( QString format, int precision = 4, bool trimTrailingZeroes = false );
 
-    bool operator==( const QgsRendererRangeV2LabelFormat & other ) const;
-    bool operator!=( const QgsRendererRangeV2LabelFormat & other ) const;
+    bool operator==( const QgsRendererRangeV2LegendFormat & other ) const;
+    bool operator!=( const QgsRendererRangeV2LegendFormat & other ) const;
 
     QString format() const;
     void setFormat( QString format );
@@ -61,8 +63,9 @@ class QgsRendererRangeV2LabelFormat
     void setTrimTrailingZeroes( bool trimTrailingZeroes );
 
     //! @note labelForLowerUpper in python bindings
-    QString labelForRange( double lower, double upper ) /PyName=labelForLowerUpper/;
-    QString labelForRange( const QgsRendererRangeV2 &range );
+    QString legendForRange( double lower, double upper ) const;
+    QString legendForRange( const QgsRendererRangeV2 &range ) const;
+    QString formatNumber( double value ) const;
 
     void setFromDomElement( QDomElement &element );
     void saveToDomElement( QDomElement &element );
@@ -153,17 +156,17 @@ class QgsGraduatedSymbolRendererV2 : QgsFeatureRendererV2
 
     //! Return the label format used to generate default classification labels
     //! @note Added in 2.6
-    const QgsRendererRangeV2LabelFormat &labelFormat();
+    const QgsRendererRangeV2LegendFormat &legendFormat() const;
     //! Set the label format used to generate default classification labels
     //! @param labelFormat The string appended to classification labels
     //! @param updateRanges If true then ranges ending with the old unit string are updated to the new.
     //! @note Added in 2.6
-    void setLabelFormat( const QgsRendererRangeV2LabelFormat &labelFormat, bool updateRanges=true );
+    void setLegendFormat( const QgsRendererRangeV2LegendFormat &legendFormat, bool updateRanges = true );
 
     //! Reset the label decimal places to a numberbased on the minimum class interval
     //! @param updateRanges if true then ranges currently using the default label will be updated
     //! @note Added in 2.6
-    void calculateLabelDecimalPlaces( bool updateRanges=true );
+    void calculateLabelPrecision( bool updateRanges = true );
 
     static QgsGraduatedSymbolRendererV2* createRenderer(
       QgsVectorLayer* vlayer,
@@ -173,7 +176,7 @@ class QgsGraduatedSymbolRendererV2 : QgsFeatureRendererV2
       QgsSymbolV2* symbol /Transfer/,
       QgsVectorColorRampV2* ramp /Transfer/,
       bool inverted = false,
-      QgsRendererRangeV2LabelFormat labelFormat=QgsRendererRangeV2LabelFormat()
+      QgsRendererRangeV2LegendFormat labelFormat=QgsRendererRangeV2LegendFormat()
       );
 
     //! create renderer from XML element

--- a/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.cpp
+++ b/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.cpp
@@ -223,7 +223,9 @@ QString QgsRendererRangeV2LabelFormat::labelForRange( double lower, double upper
     if ( upperStr.contains( '.' ) ) upperStr = upperStr.replace( mReTrailingZeroes, "" );
   }
 
-  return mFormat.arg( lowerStr, upperStr );
+  QString legend(mFormat);
+
+  return legend.replace( "%1",lowerStr).replace("%2",upperStr );
 }
 
 void QgsRendererRangeV2LabelFormat::setFromDomElement( QDomElement &element )

--- a/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.cpp
+++ b/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.cpp
@@ -169,10 +169,10 @@ void QgsRendererRangeV2::toSld( QDomDocument &doc, QDomElement &element, QgsStri
 
 ///////////
 
-int QgsRendererRangeV2LabelFormat::MaxPrecision=15;
-int QgsRendererRangeV2LabelFormat::MinPrecision=-6;
+int QgsRendererRangeV2LegendFormat::MaxPrecision=15;
+int QgsRendererRangeV2LegendFormat::MinPrecision=-6;
 
-QgsRendererRangeV2LabelFormat::QgsRendererRangeV2LabelFormat():
+QgsRendererRangeV2LegendFormat::QgsRendererRangeV2LegendFormat():
     mFormat( " %1 - %2 " ),
     mPrecision( 4 ),
     mTrimTrailingZeroes( false ),
@@ -182,7 +182,7 @@ QgsRendererRangeV2LabelFormat::QgsRendererRangeV2LabelFormat():
 {
 }
 
-QgsRendererRangeV2LabelFormat::QgsRendererRangeV2LabelFormat( QString format, int precision, bool trimTrailingZeroes ):
+QgsRendererRangeV2LegendFormat::QgsRendererRangeV2LegendFormat( QString format, int precision, bool trimTrailingZeroes ):
     mReTrailingZeroes( "[.,]?0*$" )
 {
   setFormat( format );
@@ -191,7 +191,7 @@ QgsRendererRangeV2LabelFormat::QgsRendererRangeV2LabelFormat( QString format, in
 }
 
 
-bool QgsRendererRangeV2LabelFormat::operator==( const QgsRendererRangeV2LabelFormat &other ) const
+bool QgsRendererRangeV2LegendFormat::operator==( const QgsRendererRangeV2LegendFormat &other ) const
 {
   return
     format() == other.format() &&
@@ -199,12 +199,12 @@ bool QgsRendererRangeV2LabelFormat::operator==( const QgsRendererRangeV2LabelFor
     trimTrailingZeroes() == other.trimTrailingZeroes();
 }
 
-bool QgsRendererRangeV2LabelFormat::operator!=( const QgsRendererRangeV2LabelFormat &other ) const
+bool QgsRendererRangeV2LegendFormat::operator!=( const QgsRendererRangeV2LegendFormat &other ) const
 {
   return !( *this == other );
 }
 
-void QgsRendererRangeV2LabelFormat::setPrecision( int precision )
+void QgsRendererRangeV2LegendFormat::setPrecision( int precision )
 {
   // Limit the range of decimal places to a reasonable range
   if ( precision < MinPrecision ) precision = MinPrecision;
@@ -220,12 +220,12 @@ void QgsRendererRangeV2LabelFormat::setPrecision( int precision )
   }
 }
 
-QString QgsRendererRangeV2LabelFormat::labelForRange( const QgsRendererRangeV2 &range ) const
+QString QgsRendererRangeV2LegendFormat::legendForRange( const QgsRendererRangeV2 &range ) const
 {
-  return labelForRange( range.lowerValue(), range.upperValue() );
+  return legendForRange( range.lowerValue(), range.upperValue() );
 }
 
-QString QgsRendererRangeV2LabelFormat::formatNumber( double value ) const
+QString QgsRendererRangeV2LegendFormat::formatNumber( double value ) const
 {
   if( mPrecision > 0 )
   {
@@ -241,7 +241,7 @@ QString QgsRendererRangeV2LabelFormat::formatNumber( double value ) const
   }
 }
 
-QString QgsRendererRangeV2LabelFormat::labelForRange( double lower, double upper ) const
+QString QgsRendererRangeV2LegendFormat::legendForRange( double lower, double upper ) const
 {
   QString lowerStr=formatNumber(lower);
   QString upperStr=formatNumber(upper);
@@ -250,7 +250,7 @@ QString QgsRendererRangeV2LabelFormat::labelForRange( double lower, double upper
   return legend.replace( "%1",lowerStr).replace("%2",upperStr );
 }
 
-void QgsRendererRangeV2LabelFormat::setFromDomElement( QDomElement &element )
+void QgsRendererRangeV2LegendFormat::setFromDomElement( QDomElement &element )
 {
   mFormat = element.attribute( "format",
                                element.attribute( "prefix", " " ) + "%1" +
@@ -261,7 +261,7 @@ void QgsRendererRangeV2LabelFormat::setFromDomElement( QDomElement &element )
   mTrimTrailingZeroes = element.attribute( "trimtrailingzeroes", "false" ) == "true";
 }
 
-void QgsRendererRangeV2LabelFormat::saveToDomElement( QDomElement &element )
+void QgsRendererRangeV2LegendFormat::saveToDomElement( QDomElement &element )
 {
   element.setAttribute( "format", mFormat );
   element.setAttribute( "decimalplaces", mPrecision );
@@ -450,9 +450,9 @@ bool QgsGraduatedSymbolRendererV2::updateRangeUpperValue( int rangeIndex, double
   if ( rangeIndex < 0 || rangeIndex >= mRanges.size() )
     return false;
   QgsRendererRangeV2 &range = mRanges[rangeIndex];
-  bool isDefaultLabel = range.label() == mLabelFormat.labelForRange( range );
+  bool isDefaultLabel = range.label() == mLabelFormat.legendForRange( range );
   range.setUpperValue( value );
-  if ( isDefaultLabel ) range.setLabel( mLabelFormat.labelForRange( range ) );
+  if ( isDefaultLabel ) range.setLabel( mLabelFormat.legendForRange( range ) );
   return true;
 }
 
@@ -461,9 +461,9 @@ bool QgsGraduatedSymbolRendererV2::updateRangeLowerValue( int rangeIndex, double
   if ( rangeIndex < 0 || rangeIndex >= mRanges.size() )
     return false;
   QgsRendererRangeV2 &range = mRanges[rangeIndex];
-  bool isDefaultLabel = range.label() == mLabelFormat.labelForRange( range );
+  bool isDefaultLabel = range.label() == mLabelFormat.legendForRange( range );
   range.setLowerValue( value );
-  if ( isDefaultLabel ) range.setLabel( mLabelFormat.labelForRange( range ) );
+  if ( isDefaultLabel ) range.setLabel( mLabelFormat.legendForRange( range ) );
   return true;
 }
 
@@ -498,7 +498,7 @@ QgsFeatureRendererV2* QgsGraduatedSymbolRendererV2::clone() const
   r->setRotationField( rotationField() );
   r->setSizeScaleField( sizeScaleField() );
   r->setScaleMethod( scaleMethod() );
-  r->setLabelFormat( labelFormat() );
+  r->setLegendFormat( legendFormat() );
   return r;
 }
 
@@ -926,7 +926,7 @@ QgsGraduatedSymbolRendererV2* QgsGraduatedSymbolRendererV2::createRenderer(
   QgsSymbolV2* symbol,
   QgsVectorColorRampV2* ramp,
   bool inverted,
-  QgsRendererRangeV2LabelFormat labelFormat
+  QgsRendererRangeV2LegendFormat labelFormat
 )
 {
   QgsRangeList ranges;
@@ -935,7 +935,7 @@ QgsGraduatedSymbolRendererV2* QgsGraduatedSymbolRendererV2::createRenderer(
   r->setSourceColorRamp( ramp->clone() );
   r->setInvertedColorRamp( inverted );
   r->setMode( mode );
-  r->setLabelFormat( labelFormat, false );
+  r->setLegendFormat( labelFormat, false );
   r->updateClasses( vlayer, mode, classes );
   return r;
 }
@@ -1076,7 +1076,7 @@ void QgsGraduatedSymbolRendererV2::updateClasses( QgsVectorLayer *vlayer, Mode m
     }
     else
     {
-      label = mLabelFormat.labelForRange( lower, upper );
+      label = mLabelFormat.legendForRange( lower, upper );
     }
     QgsSymbolV2* newSymbol = mSourceSymbol->clone();
     addClass( QgsRendererRangeV2( lower, upper, newSymbol, label ) );
@@ -1176,9 +1176,9 @@ QgsFeatureRendererV2* QgsGraduatedSymbolRendererV2::create( QDomElement& element
   QDomElement labelFormatElem = element.firstChildElement( "labelformat" );
   if ( ! labelFormatElem.isNull() )
   {
-    QgsRendererRangeV2LabelFormat labelFormat;
+    QgsRendererRangeV2LegendFormat labelFormat;
     labelFormat.setFromDomElement( labelFormatElem );
-    r->setLabelFormat( labelFormat );
+    r->setLegendFormat( labelFormat );
   }
   // TODO: symbol levels
   return r;
@@ -1422,7 +1422,7 @@ void QgsGraduatedSymbolRendererV2::addClass( QgsSymbolV2* symbol )
 void QgsGraduatedSymbolRendererV2::addClass( double lower, double upper )
 {
   QgsSymbolV2* newSymbol = mSourceSymbol->clone();
-  QString label = mLabelFormat.labelForRange( lower, upper );
+  QString label = mLabelFormat.legendForRange( lower, upper );
   mRanges.append( QgsRendererRangeV2( lower, upper, newSymbol, label ) );
 }
 
@@ -1441,20 +1441,20 @@ void QgsGraduatedSymbolRendererV2::deleteAllClasses()
   mRanges.clear();
 }
 
-void QgsGraduatedSymbolRendererV2::setLabelFormat( const QgsRendererRangeV2LabelFormat &labelFormat, bool updateRanges )
+void QgsGraduatedSymbolRendererV2::setLegendFormat( const QgsRendererRangeV2LegendFormat &labelFormat, bool updateRanges )
 {
   if ( updateRanges && labelFormat != mLabelFormat )
   {
     for ( QgsRangeList::iterator it = mRanges.begin(); it != mRanges.end(); ++it )
     {
-      it->setLabel( labelFormat.labelForRange( *it ) );
+      it->setLabel( labelFormat.legendForRange( *it ) );
     }
   }
   mLabelFormat = labelFormat;
 }
 
 
-void QgsGraduatedSymbolRendererV2::calculateLabelDecimalPlaces( bool updateRanges )
+void QgsGraduatedSymbolRendererV2::calculateLabelPrecision( bool updateRanges )
 {
   // Find the minimum size of a class
   double minClassRange = 0.0;
@@ -1477,7 +1477,7 @@ void QgsGraduatedSymbolRendererV2::calculateLabelDecimalPlaces( bool updateRange
     nextDpMinRange *= 10.0;
   }
   mLabelFormat.setPrecision( ndp );
-  if ( updateRanges ) setLabelFormat( mLabelFormat, true );
+  if ( updateRanges ) setLegendFormat( mLabelFormat, true );
 }
 
 void QgsGraduatedSymbolRendererV2::moveClass( int from, int to )

--- a/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.cpp
+++ b/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.cpp
@@ -169,10 +169,10 @@ void QgsRendererRangeV2::toSld( QDomDocument &doc, QDomElement &element, QgsStri
 
 ///////////
 
-int QgsRendererRangeV2LegendFormat::MaxPrecision=15;
-int QgsRendererRangeV2LegendFormat::MinPrecision=-6;
+int QgsRendererRangeV2LabelFormat::MaxPrecision=15;
+int QgsRendererRangeV2LabelFormat::MinPrecision=-6;
 
-QgsRendererRangeV2LegendFormat::QgsRendererRangeV2LegendFormat():
+QgsRendererRangeV2LabelFormat::QgsRendererRangeV2LabelFormat():
     mFormat( " %1 - %2 " ),
     mPrecision( 4 ),
     mTrimTrailingZeroes( false ),
@@ -182,7 +182,7 @@ QgsRendererRangeV2LegendFormat::QgsRendererRangeV2LegendFormat():
 {
 }
 
-QgsRendererRangeV2LegendFormat::QgsRendererRangeV2LegendFormat( QString format, int precision, bool trimTrailingZeroes ):
+QgsRendererRangeV2LabelFormat::QgsRendererRangeV2LabelFormat( QString format, int precision, bool trimTrailingZeroes ):
     mReTrailingZeroes( "[.,]?0*$" )
 {
   setFormat( format );
@@ -191,7 +191,7 @@ QgsRendererRangeV2LegendFormat::QgsRendererRangeV2LegendFormat( QString format, 
 }
 
 
-bool QgsRendererRangeV2LegendFormat::operator==( const QgsRendererRangeV2LegendFormat &other ) const
+bool QgsRendererRangeV2LabelFormat::operator==( const QgsRendererRangeV2LabelFormat &other ) const
 {
   return
     format() == other.format() &&
@@ -199,12 +199,12 @@ bool QgsRendererRangeV2LegendFormat::operator==( const QgsRendererRangeV2LegendF
     trimTrailingZeroes() == other.trimTrailingZeroes();
 }
 
-bool QgsRendererRangeV2LegendFormat::operator!=( const QgsRendererRangeV2LegendFormat &other ) const
+bool QgsRendererRangeV2LabelFormat::operator!=( const QgsRendererRangeV2LabelFormat &other ) const
 {
   return !( *this == other );
 }
 
-void QgsRendererRangeV2LegendFormat::setPrecision( int precision )
+void QgsRendererRangeV2LabelFormat::setPrecision( int precision )
 {
   // Limit the range of decimal places to a reasonable range
   if ( precision < MinPrecision ) precision = MinPrecision;
@@ -220,12 +220,12 @@ void QgsRendererRangeV2LegendFormat::setPrecision( int precision )
   }
 }
 
-QString QgsRendererRangeV2LegendFormat::legendForRange( const QgsRendererRangeV2 &range ) const
+QString QgsRendererRangeV2LabelFormat::labelForRange( const QgsRendererRangeV2 &range ) const
 {
-  return legendForRange( range.lowerValue(), range.upperValue() );
+  return labelForRange( range.lowerValue(), range.upperValue() );
 }
 
-QString QgsRendererRangeV2LegendFormat::formatNumber( double value ) const
+QString QgsRendererRangeV2LabelFormat::formatNumber( double value ) const
 {
   if( mPrecision > 0 )
   {
@@ -241,7 +241,7 @@ QString QgsRendererRangeV2LegendFormat::formatNumber( double value ) const
   }
 }
 
-QString QgsRendererRangeV2LegendFormat::legendForRange( double lower, double upper ) const
+QString QgsRendererRangeV2LabelFormat::labelForRange( double lower, double upper ) const
 {
   QString lowerStr=formatNumber(lower);
   QString upperStr=formatNumber(upper);
@@ -250,7 +250,7 @@ QString QgsRendererRangeV2LegendFormat::legendForRange( double lower, double upp
   return legend.replace( "%1",lowerStr).replace("%2",upperStr );
 }
 
-void QgsRendererRangeV2LegendFormat::setFromDomElement( QDomElement &element )
+void QgsRendererRangeV2LabelFormat::setFromDomElement( QDomElement &element )
 {
   mFormat = element.attribute( "format",
                                element.attribute( "prefix", " " ) + "%1" +
@@ -261,7 +261,7 @@ void QgsRendererRangeV2LegendFormat::setFromDomElement( QDomElement &element )
   mTrimTrailingZeroes = element.attribute( "trimtrailingzeroes", "false" ) == "true";
 }
 
-void QgsRendererRangeV2LegendFormat::saveToDomElement( QDomElement &element )
+void QgsRendererRangeV2LabelFormat::saveToDomElement( QDomElement &element )
 {
   element.setAttribute( "format", mFormat );
   element.setAttribute( "decimalplaces", mPrecision );
@@ -450,9 +450,9 @@ bool QgsGraduatedSymbolRendererV2::updateRangeUpperValue( int rangeIndex, double
   if ( rangeIndex < 0 || rangeIndex >= mRanges.size() )
     return false;
   QgsRendererRangeV2 &range = mRanges[rangeIndex];
-  bool isDefaultLabel = range.label() == mLabelFormat.legendForRange( range );
+  bool isDefaultLabel = range.label() == mLabelFormat.labelForRange( range );
   range.setUpperValue( value );
-  if ( isDefaultLabel ) range.setLabel( mLabelFormat.legendForRange( range ) );
+  if ( isDefaultLabel ) range.setLabel( mLabelFormat.labelForRange( range ) );
   return true;
 }
 
@@ -461,9 +461,9 @@ bool QgsGraduatedSymbolRendererV2::updateRangeLowerValue( int rangeIndex, double
   if ( rangeIndex < 0 || rangeIndex >= mRanges.size() )
     return false;
   QgsRendererRangeV2 &range = mRanges[rangeIndex];
-  bool isDefaultLabel = range.label() == mLabelFormat.legendForRange( range );
+  bool isDefaultLabel = range.label() == mLabelFormat.labelForRange( range );
   range.setLowerValue( value );
-  if ( isDefaultLabel ) range.setLabel( mLabelFormat.legendForRange( range ) );
+  if ( isDefaultLabel ) range.setLabel( mLabelFormat.labelForRange( range ) );
   return true;
 }
 
@@ -498,7 +498,7 @@ QgsFeatureRendererV2* QgsGraduatedSymbolRendererV2::clone() const
   r->setRotationField( rotationField() );
   r->setSizeScaleField( sizeScaleField() );
   r->setScaleMethod( scaleMethod() );
-  r->setLegendFormat( legendFormat() );
+  r->setLabelFormat( labelFormat() );
   return r;
 }
 
@@ -926,7 +926,7 @@ QgsGraduatedSymbolRendererV2* QgsGraduatedSymbolRendererV2::createRenderer(
   QgsSymbolV2* symbol,
   QgsVectorColorRampV2* ramp,
   bool inverted,
-  QgsRendererRangeV2LegendFormat labelFormat
+  QgsRendererRangeV2LabelFormat labelFormat
 )
 {
   QgsRangeList ranges;
@@ -935,7 +935,7 @@ QgsGraduatedSymbolRendererV2* QgsGraduatedSymbolRendererV2::createRenderer(
   r->setSourceColorRamp( ramp->clone() );
   r->setInvertedColorRamp( inverted );
   r->setMode( mode );
-  r->setLegendFormat( labelFormat, false );
+  r->setLabelFormat( labelFormat, false );
   r->updateClasses( vlayer, mode, classes );
   return r;
 }
@@ -1076,7 +1076,7 @@ void QgsGraduatedSymbolRendererV2::updateClasses( QgsVectorLayer *vlayer, Mode m
     }
     else
     {
-      label = mLabelFormat.legendForRange( lower, upper );
+      label = mLabelFormat.labelForRange( lower, upper );
     }
     QgsSymbolV2* newSymbol = mSourceSymbol->clone();
     addClass( QgsRendererRangeV2( lower, upper, newSymbol, label ) );
@@ -1176,9 +1176,9 @@ QgsFeatureRendererV2* QgsGraduatedSymbolRendererV2::create( QDomElement& element
   QDomElement labelFormatElem = element.firstChildElement( "labelformat" );
   if ( ! labelFormatElem.isNull() )
   {
-    QgsRendererRangeV2LegendFormat labelFormat;
+    QgsRendererRangeV2LabelFormat labelFormat;
     labelFormat.setFromDomElement( labelFormatElem );
-    r->setLegendFormat( labelFormat );
+    r->setLabelFormat( labelFormat );
   }
   // TODO: symbol levels
   return r;
@@ -1422,7 +1422,7 @@ void QgsGraduatedSymbolRendererV2::addClass( QgsSymbolV2* symbol )
 void QgsGraduatedSymbolRendererV2::addClass( double lower, double upper )
 {
   QgsSymbolV2* newSymbol = mSourceSymbol->clone();
-  QString label = mLabelFormat.legendForRange( lower, upper );
+  QString label = mLabelFormat.labelForRange( lower, upper );
   mRanges.append( QgsRendererRangeV2( lower, upper, newSymbol, label ) );
 }
 
@@ -1441,13 +1441,13 @@ void QgsGraduatedSymbolRendererV2::deleteAllClasses()
   mRanges.clear();
 }
 
-void QgsGraduatedSymbolRendererV2::setLegendFormat( const QgsRendererRangeV2LegendFormat &labelFormat, bool updateRanges )
+void QgsGraduatedSymbolRendererV2::setLabelFormat( const QgsRendererRangeV2LabelFormat &labelFormat, bool updateRanges )
 {
   if ( updateRanges && labelFormat != mLabelFormat )
   {
     for ( QgsRangeList::iterator it = mRanges.begin(); it != mRanges.end(); ++it )
     {
-      it->setLabel( labelFormat.legendForRange( *it ) );
+      it->setLabel( labelFormat.labelForRange( *it ) );
     }
   }
   mLabelFormat = labelFormat;
@@ -1477,7 +1477,7 @@ void QgsGraduatedSymbolRendererV2::calculateLabelPrecision( bool updateRanges )
     nextDpMinRange *= 10.0;
   }
   mLabelFormat.setPrecision( ndp );
-  if ( updateRanges ) setLegendFormat( mLabelFormat, true );
+  if ( updateRanges ) setLabelFormat( mLabelFormat, true );
 }
 
 void QgsGraduatedSymbolRendererV2::moveClass( int from, int to )

--- a/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.h
+++ b/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.h
@@ -67,14 +67,14 @@ typedef QList<QgsRendererRangeV2> QgsRangeList;
 
 
 // @note added in 2.6
-class CORE_EXPORT QgsRendererRangeV2LegendFormat
+class CORE_EXPORT QgsRendererRangeV2LabelFormat
 {
   public:
-    QgsRendererRangeV2LegendFormat();
-    QgsRendererRangeV2LegendFormat( QString format, int precision = 4, bool trimTrailingZeroes = false );
+    QgsRendererRangeV2LabelFormat();
+    QgsRendererRangeV2LabelFormat( QString format, int precision = 4, bool trimTrailingZeroes = false );
 
-    bool operator==( const QgsRendererRangeV2LegendFormat & other ) const;
-    bool operator!=( const QgsRendererRangeV2LegendFormat & other ) const;
+    bool operator==( const QgsRendererRangeV2LabelFormat & other ) const;
+    bool operator!=( const QgsRendererRangeV2LabelFormat & other ) const;
 
     QString format() const { return mFormat; }
     void setFormat( QString format ) { mFormat = format; }
@@ -86,8 +86,8 @@ class CORE_EXPORT QgsRendererRangeV2LegendFormat
     void setTrimTrailingZeroes( bool trimTrailingZeroes ) { mTrimTrailingZeroes = trimTrailingZeroes; }
 
     //! @note labelForLowerUpper in python bindings
-    QString legendForRange( double lower, double upper ) const;
-    QString legendForRange( const QgsRendererRangeV2 &range ) const;
+    QString labelForRange( double lower, double upper ) const;
+    QString labelForRange( const QgsRendererRangeV2 &range ) const;
     QString formatNumber( double value ) const;
 
     void setFromDomElement( QDomElement &element );
@@ -190,12 +190,12 @@ class CORE_EXPORT QgsGraduatedSymbolRendererV2 : public QgsFeatureRendererV2
 
     //! Return the label format used to generate default classification labels
     //! @note Added in 2.6
-    const QgsRendererRangeV2LegendFormat &legendFormat() const { return mLabelFormat; }
+    const QgsRendererRangeV2LabelFormat &labelFormat() const { return mLabelFormat; }
     //! Set the label format used to generate default classification labels
     //! @param labelFormat The string appended to classification labels
     //! @param updateRanges If true then ranges ending with the old unit string are updated to the new.
     //! @note Added in 2.6
-    void setLegendFormat( const QgsRendererRangeV2LegendFormat &legendFormat, bool updateRanges = true );
+    void setLabelFormat( const QgsRendererRangeV2LabelFormat &labelFormat, bool updateRanges = true );
 
     //! Reset the label decimal places to a numberbased on the minimum class interval
     //! @param updateRanges if true then ranges currently using the default label will be updated
@@ -210,7 +210,7 @@ class CORE_EXPORT QgsGraduatedSymbolRendererV2 : public QgsFeatureRendererV2
       QgsSymbolV2* symbol,
       QgsVectorColorRampV2* ramp,
       bool inverted = false,
-      QgsRendererRangeV2LegendFormat legendFormat = QgsRendererRangeV2LegendFormat()
+      QgsRendererRangeV2LabelFormat legendFormat = QgsRendererRangeV2LabelFormat()
     );
 
     //! create renderer from XML element
@@ -287,7 +287,7 @@ class CORE_EXPORT QgsGraduatedSymbolRendererV2 : public QgsFeatureRendererV2
     QScopedPointer<QgsSymbolV2> mSourceSymbol;
     QScopedPointer<QgsVectorColorRampV2> mSourceColorRamp;
     bool mInvertedColorRamp;
-    QgsRendererRangeV2LegendFormat mLabelFormat;
+    QgsRendererRangeV2LabelFormat mLabelFormat;
     QScopedPointer<QgsExpression> mRotation;
     QScopedPointer<QgsExpression> mSizeScale;
     QgsSymbolV2::ScaleMethod mScaleMethod;

--- a/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.h
+++ b/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.h
@@ -71,7 +71,7 @@ class CORE_EXPORT QgsRendererRangeV2LabelFormat
 {
   public:
     QgsRendererRangeV2LabelFormat();
-    QgsRendererRangeV2LabelFormat( QString format, int decimalPlaces = 4, bool trimTrailingZeroes = false );
+    QgsRendererRangeV2LabelFormat( QString format, int precision = 4, bool trimTrailingZeroes = false );
 
     bool operator==( const QgsRendererRangeV2LabelFormat & other ) const;
     bool operator!=( const QgsRendererRangeV2LabelFormat & other ) const;
@@ -79,8 +79,8 @@ class CORE_EXPORT QgsRendererRangeV2LabelFormat
     QString format() const { return mFormat; }
     void setFormat( QString format ) { mFormat = format; }
 
-    int decimalPlaces() const { return mDecimalPlaces; }
-    void setDecimalPlaces( int decimalPlaces );
+    int precision() const { return mPrecision; }
+    void setPrecision( int precision );
 
     bool trimTrailingZeroes() const { return mTrimTrailingZeroes; }
     void setTrimTrailingZeroes( bool trimTrailingZeroes ) { mTrimTrailingZeroes = trimTrailingZeroes; }
@@ -88,14 +88,21 @@ class CORE_EXPORT QgsRendererRangeV2LabelFormat
     //! @note labelForLowerUpper in python bindings
     QString labelForRange( double lower, double upper ) const;
     QString labelForRange( const QgsRendererRangeV2 &range ) const;
+    QString formatNumber( double value ) const;
 
     void setFromDomElement( QDomElement &element );
     void saveToDomElement( QDomElement &element );
 
+    static int MaxPrecision;
+    static int MinPrecision;
+
   protected:
     QString mFormat;
-    int mDecimalPlaces;
+    int mPrecision;
     bool mTrimTrailingZeroes;
+    // values used to manage number formatting - precision and trailing zeroes
+    double mNumberScale;
+    QString mNumberSuffix;
     QRegExp mReTrailingZeroes;
 };
 

--- a/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.h
+++ b/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.h
@@ -67,14 +67,14 @@ typedef QList<QgsRendererRangeV2> QgsRangeList;
 
 
 // @note added in 2.6
-class CORE_EXPORT QgsRendererRangeV2LabelFormat
+class CORE_EXPORT QgsRendererRangeV2LegendFormat
 {
   public:
-    QgsRendererRangeV2LabelFormat();
-    QgsRendererRangeV2LabelFormat( QString format, int precision = 4, bool trimTrailingZeroes = false );
+    QgsRendererRangeV2LegendFormat();
+    QgsRendererRangeV2LegendFormat( QString format, int precision = 4, bool trimTrailingZeroes = false );
 
-    bool operator==( const QgsRendererRangeV2LabelFormat & other ) const;
-    bool operator!=( const QgsRendererRangeV2LabelFormat & other ) const;
+    bool operator==( const QgsRendererRangeV2LegendFormat & other ) const;
+    bool operator!=( const QgsRendererRangeV2LegendFormat & other ) const;
 
     QString format() const { return mFormat; }
     void setFormat( QString format ) { mFormat = format; }
@@ -86,8 +86,8 @@ class CORE_EXPORT QgsRendererRangeV2LabelFormat
     void setTrimTrailingZeroes( bool trimTrailingZeroes ) { mTrimTrailingZeroes = trimTrailingZeroes; }
 
     //! @note labelForLowerUpper in python bindings
-    QString labelForRange( double lower, double upper ) const;
-    QString labelForRange( const QgsRendererRangeV2 &range ) const;
+    QString legendForRange( double lower, double upper ) const;
+    QString legendForRange( const QgsRendererRangeV2 &range ) const;
     QString formatNumber( double value ) const;
 
     void setFromDomElement( QDomElement &element );
@@ -190,17 +190,17 @@ class CORE_EXPORT QgsGraduatedSymbolRendererV2 : public QgsFeatureRendererV2
 
     //! Return the label format used to generate default classification labels
     //! @note Added in 2.6
-    const QgsRendererRangeV2LabelFormat &labelFormat() const { return mLabelFormat; }
+    const QgsRendererRangeV2LegendFormat &legendFormat() const { return mLabelFormat; }
     //! Set the label format used to generate default classification labels
     //! @param labelFormat The string appended to classification labels
     //! @param updateRanges If true then ranges ending with the old unit string are updated to the new.
     //! @note Added in 2.6
-    void setLabelFormat( const QgsRendererRangeV2LabelFormat &labelFormat, bool updateRanges = true );
+    void setLegendFormat( const QgsRendererRangeV2LegendFormat &legendFormat, bool updateRanges = true );
 
     //! Reset the label decimal places to a numberbased on the minimum class interval
     //! @param updateRanges if true then ranges currently using the default label will be updated
     //! @note Added in 2.6
-    void calculateLabelDecimalPlaces( bool updateRanges = true );
+    void calculateLabelPrecision( bool updateRanges = true );
 
     static QgsGraduatedSymbolRendererV2* createRenderer(
       QgsVectorLayer* vlayer,
@@ -210,7 +210,7 @@ class CORE_EXPORT QgsGraduatedSymbolRendererV2 : public QgsFeatureRendererV2
       QgsSymbolV2* symbol,
       QgsVectorColorRampV2* ramp,
       bool inverted = false,
-      QgsRendererRangeV2LabelFormat labelFormat = QgsRendererRangeV2LabelFormat()
+      QgsRendererRangeV2LegendFormat legendFormat = QgsRendererRangeV2LegendFormat()
     );
 
     //! create renderer from XML element
@@ -287,7 +287,7 @@ class CORE_EXPORT QgsGraduatedSymbolRendererV2 : public QgsFeatureRendererV2
     QScopedPointer<QgsSymbolV2> mSourceSymbol;
     QScopedPointer<QgsVectorColorRampV2> mSourceColorRamp;
     bool mInvertedColorRamp;
-    QgsRendererRangeV2LabelFormat mLabelFormat;
+    QgsRendererRangeV2LegendFormat mLabelFormat;
     QScopedPointer<QgsExpression> mRotation;
     QScopedPointer<QgsExpression> mSizeScale;
     QgsSymbolV2::ScaleMethod mScaleMethod;

--- a/src/gui/symbology-ng/qgscategorizedsymbolrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgscategorizedsymbolrendererv2widget.cpp
@@ -197,7 +197,7 @@ QVariant QgsCategorizedSymbolRendererV2Model::headerData( int section, Qt::Orien
 {
   if ( orientation == Qt::Horizontal && role == Qt::DisplayRole && section >= 0 && section < 3 )
   {
-    QStringList lst; lst << tr( "Symbol" ) << tr( "Value" ) << tr( "Label" );
+    QStringList lst; lst << tr( "Symbol" ) << tr( "Value" ) << tr( "Legend" );
     return lst.value( section );
   }
   return QVariant();

--- a/src/gui/symbology-ng/qgsgraduatedsymbolrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgsgraduatedsymbolrendererv2widget.cpp
@@ -129,7 +129,7 @@ QVariant QgsGraduatedSymbolRendererV2Model::data( const QModelIndex &index, int 
     {
       case 1:
         {
-          int decimalPlaces=mRenderer->legendFormat().precision()+2;
+          int decimalPlaces=mRenderer->labelFormat().precision()+2;
           if( decimalPlaces < 0 ) decimalPlaces=0;
           return QString::number( range.lowerValue(), 'f', decimalPlaces ) + " - " + QString::number( range.upperValue(), 'f', decimalPlaces );
         }
@@ -397,8 +397,8 @@ QgsGraduatedSymbolRendererV2Widget::QgsGraduatedSymbolRendererV2Widget( QgsVecto
 
   cboGraduatedColorRamp->populate( mStyle );
 
-  spinPrecision->setMinimum( QgsRendererRangeV2LegendFormat::MinPrecision);
-  spinPrecision->setMaximum( QgsRendererRangeV2LegendFormat::MaxPrecision);
+  spinPrecision->setMinimum( QgsRendererRangeV2LabelFormat::MinPrecision);
+  spinPrecision->setMaximum( QgsRendererRangeV2LabelFormat::MaxPrecision);
 
   // set project default color ramp
   QString defaultColorRamp = QgsProject::instance()->readEntry( "DefaultStyles", "/ColorRamp", "" );
@@ -521,7 +521,7 @@ void QgsGraduatedSymbolRendererV2Widget::updateUiFromRenderer( bool updateCount 
     cbxInvertedColorRamp->setChecked( mRenderer->invertedColorRamp() );
   }
 
-  QgsRendererRangeV2LegendFormat labelFormat = mRenderer->legendFormat();
+  QgsRendererRangeV2LabelFormat labelFormat = mRenderer->labelFormat();
   txtFormat->setText( labelFormat.format() );
   spinPrecision->setValue( labelFormat.precision() );
   cbxTrimTrailingZeroes->setChecked( labelFormat.trimTrailingZeroes() );
@@ -742,7 +742,7 @@ void QgsGraduatedSymbolRendererV2Widget::changeRange( int rangeIdx )
   const QgsRendererRangeV2& range = mRenderer->ranges()[rangeIdx];
   // Add arbitrary 2 to number of decimal places to retain a bit extra.
   // Ensures users can see if legend is not completely honest!
-  int decimalPlaces = mRenderer->legendFormat().precision()+2;
+  int decimalPlaces = mRenderer->labelFormat().precision()+2;
   if( decimalPlaces < 0 ) decimalPlaces=0;
   dialog.setLowerValue( QString::number( range.lowerValue(), 'f', decimalPlaces ) );
   dialog.setUpperValue( QString::number( range.upperValue(), 'f', decimalPlaces ) );
@@ -858,11 +858,11 @@ void QgsGraduatedSymbolRendererV2Widget::scaleMethodChanged( QgsSymbolV2::ScaleM
 
 void QgsGraduatedSymbolRendererV2Widget::labelFormatChanged()
 {
-  QgsRendererRangeV2LegendFormat labelFormat = QgsRendererRangeV2LegendFormat(
+  QgsRendererRangeV2LabelFormat labelFormat = QgsRendererRangeV2LabelFormat(
         txtFormat->text(),
         spinPrecision->value(),
         cbxTrimTrailingZeroes->isChecked() );
-  mRenderer->setLegendFormat( labelFormat, true );
+  mRenderer->setLabelFormat( labelFormat, true );
   mModel->updateLabels();
 }
 

--- a/src/gui/symbology-ng/qgsgraduatedsymbolrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgsgraduatedsymbolrendererv2widget.cpp
@@ -326,6 +326,7 @@ void QgsGraduatedSymbolRendererV2Model::sort( int column, Qt::SortOrder order )
   {
     mRenderer->sortByLabel( order );
   }
+  emit rowsMoved();
   emit dataChanged( createIndex( 0, 0, 0 ), createIndex( mRenderer->ranges().size(), 0 ) );
   QgsDebugMsg( "Done" );
 }
@@ -798,22 +799,19 @@ void QgsGraduatedSymbolRendererV2Widget::toggleBoundariesLink( bool linked )
   //This is done by updating all lower ranges to the upper value of the range above
   if ( linked )
   {
-    // Cannot link ranges if they are not sorted - results will be crazy
-    // qSort( mRenderer->ranges() );
-    // Could not get qSort to work with copy/swap idiom on QgsVectorRange
-
     if ( ! rowsOrdered() )
     {
       int result = QMessageBox::warning(
                      this,
                      tr( "Linked range warning" ),
-                     tr( "Linking ranges that are not ordered may produced unexpected results. Proceed?" ),
+                     tr( "Rows will be reordered before linking boundaries. Continue?" ),
                      QMessageBox::Ok | QMessageBox::Cancel );
       if ( result != QMessageBox::Ok )
       {
         cbxLinkBoundaries->setChecked( false );
         return;
       }
+      mRenderer->sortByValue();
     }
 
     // Ok to proceed
@@ -920,14 +918,14 @@ void QgsGraduatedSymbolRendererV2Widget::showSymbolLevels()
 void QgsGraduatedSymbolRendererV2Widget::rowsMoved()
 {
   viewGraduated->selectionModel()->clear();
-}
-
-void QgsGraduatedSymbolRendererV2Widget::modelDataChanged()
-{
   if ( ! rowsOrdered() )
   {
     cbxLinkBoundaries->setChecked( false );
   }
+}
+
+void QgsGraduatedSymbolRendererV2Widget::modelDataChanged()
+{
 }
 
 void QgsGraduatedSymbolRendererV2Widget::keyPressEvent( QKeyEvent* event )

--- a/src/gui/symbology-ng/qgsgraduatedsymbolrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgsgraduatedsymbolrendererv2widget.cpp
@@ -129,7 +129,7 @@ QVariant QgsGraduatedSymbolRendererV2Model::data( const QModelIndex &index, int 
     {
       case 1:
         {
-          int decimalPlaces=mRenderer->labelFormat().precision()+2;
+          int decimalPlaces=mRenderer->legendFormat().precision()+2;
           if( decimalPlaces < 0 ) decimalPlaces=0;
           return QString::number( range.lowerValue(), 'f', decimalPlaces ) + " - " + QString::number( range.upperValue(), 'f', decimalPlaces );
         }
@@ -193,7 +193,7 @@ QVariant QgsGraduatedSymbolRendererV2Model::headerData( int section, Qt::Orienta
 {
   if ( orientation == Qt::Horizontal && role == Qt::DisplayRole && section >= 0 && section < 3 )
   {
-    QStringList lst; lst << tr( "Symbol" ) << tr( "Value" ) << tr( "Label" );
+    QStringList lst; lst << tr( "Symbol" ) << tr( "Values" ) << tr( "Legend" );
     return lst.value( section );
   }
   return QVariant();
@@ -397,8 +397,8 @@ QgsGraduatedSymbolRendererV2Widget::QgsGraduatedSymbolRendererV2Widget( QgsVecto
 
   cboGraduatedColorRamp->populate( mStyle );
 
-  spinPrecision->setMinimum( QgsRendererRangeV2LabelFormat::MinPrecision);
-  spinPrecision->setMaximum( QgsRendererRangeV2LabelFormat::MaxPrecision);
+  spinPrecision->setMinimum( QgsRendererRangeV2LegendFormat::MinPrecision);
+  spinPrecision->setMaximum( QgsRendererRangeV2LegendFormat::MaxPrecision);
 
   // set project default color ramp
   QString defaultColorRamp = QgsProject::instance()->readEntry( "DefaultStyles", "/ColorRamp", "" );
@@ -521,7 +521,7 @@ void QgsGraduatedSymbolRendererV2Widget::updateUiFromRenderer( bool updateCount 
     cbxInvertedColorRamp->setChecked( mRenderer->invertedColorRamp() );
   }
 
-  QgsRendererRangeV2LabelFormat labelFormat = mRenderer->labelFormat();
+  QgsRendererRangeV2LegendFormat labelFormat = mRenderer->legendFormat();
   txtFormat->setText( labelFormat.format() );
   spinPrecision->setValue( labelFormat.precision() );
   cbxTrimTrailingZeroes->setChecked( labelFormat.trimTrailingZeroes() );
@@ -587,7 +587,7 @@ void QgsGraduatedSymbolRendererV2Widget::classifyGraduated()
   bool updateUiCount = true;
   QApplication::setOverrideCursor( Qt::WaitCursor );
   mRenderer->updateClasses( mLayer, mode, nclasses );
-  mRenderer->calculateLabelDecimalPlaces();
+  mRenderer->calculateLabelPrecision();
   QApplication::restoreOverrideCursor();
   // PrettyBreaks and StdDev calculation don't generate exact
   // number of classes - leave user interface unchanged for these
@@ -742,7 +742,7 @@ void QgsGraduatedSymbolRendererV2Widget::changeRange( int rangeIdx )
   const QgsRendererRangeV2& range = mRenderer->ranges()[rangeIdx];
   // Add arbitrary 2 to number of decimal places to retain a bit extra.
   // Ensures users can see if legend is not completely honest!
-  int decimalPlaces = mRenderer->labelFormat().precision()+2;
+  int decimalPlaces = mRenderer->legendFormat().precision()+2;
   if( decimalPlaces < 0 ) decimalPlaces=0;
   dialog.setLowerValue( QString::number( range.lowerValue(), 'f', decimalPlaces ) );
   dialog.setUpperValue( QString::number( range.upperValue(), 'f', decimalPlaces ) );
@@ -858,11 +858,11 @@ void QgsGraduatedSymbolRendererV2Widget::scaleMethodChanged( QgsSymbolV2::ScaleM
 
 void QgsGraduatedSymbolRendererV2Widget::labelFormatChanged()
 {
-  QgsRendererRangeV2LabelFormat labelFormat = QgsRendererRangeV2LabelFormat(
+  QgsRendererRangeV2LegendFormat labelFormat = QgsRendererRangeV2LegendFormat(
         txtFormat->text(),
         spinPrecision->value(),
         cbxTrimTrailingZeroes->isChecked() );
-  mRenderer->setLabelFormat( labelFormat, true );
+  mRenderer->setLegendFormat( labelFormat, true );
   mModel->updateLabels();
 }
 

--- a/src/ui/qgsgraduatedsymbolrendererv2widget.ui
+++ b/src/ui/qgsgraduatedsymbolrendererv2widget.ui
@@ -235,7 +235,7 @@ Use &quot;%1&quot; for the lower bound of the classification, and &quot;%2&quot;
      <item row="6" column="0">
       <widget class="QLabel" name="label">
        <property name="text">
-        <string>Label Format</string>
+        <string>Legend Format</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>

--- a/src/ui/qgsgraduatedsymbolrendererv2widget.ui
+++ b/src/ui/qgsgraduatedsymbolrendererv2widget.ui
@@ -22,12 +22,17 @@
      <item row="6" column="3">
       <layout class="QHBoxLayout" name="horizontalLayout_7">
        <item>
-        <widget class="QSpinBox" name="spinDecimalPlaces">
+        <widget class="QSpinBox" name="spinPrecision">
          <property name="sizePolicy">
           <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
+         </property>
+         <property name="toolTip">
+          <string>Precision of upper and lower values in label text.
+Positive is number of decimal places
+Negative rounds to powers of 10</string>
          </property>
          <property name="minimum">
           <number>0</number>
@@ -42,6 +47,9 @@
        </item>
        <item>
         <widget class="QCheckBox" name="cbxTrimTrailingZeroes">
+         <property name="toolTip">
+          <string>Check to remove trailing zeroes after the decimal point from the upper and lower values in the legend.</string>
+         </property>
          <property name="text">
           <string>Trim</string>
          </property>
@@ -240,13 +248,13 @@ Use &quot;%1&quot; for the lower bound of the classification, and &quot;%2&quot;
      <item row="6" column="2">
       <widget class="QLabel" name="label_16">
        <property name="text">
-        <string>Decimal places</string>
+        <string>Precision</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
        </property>
        <property name="buddy">
-        <cstring>spinDecimalPlaces</cstring>
+        <cstring>spinPrecision</cstring>
        </property>
       </widget>
      </item>
@@ -361,7 +369,7 @@ Use &quot;%1&quot; for the lower bound of the classification, and &quot;%2&quot;
   <tabstop>cbxInvertedColorRamp</tabstop>
   <tabstop>cboGraduatedMode</tabstop>
   <tabstop>txtFormat</tabstop>
-  <tabstop>spinDecimalPlaces</tabstop>
+  <tabstop>spinPrecision</tabstop>
   <tabstop>cbxTrimTrailingZeroes</tabstop>
   <tabstop>viewGraduated</tabstop>
   <tabstop>btnGraduatedClassify</tabstop>

--- a/src/ui/qgsgraduatedsymbolrendererv2widget.ui
+++ b/src/ui/qgsgraduatedsymbolrendererv2widget.ui
@@ -19,7 +19,48 @@
      <property name="rightMargin">
       <number>6</number>
      </property>
-     <item row="6" column="2">
+     <item row="6" column="3">
+      <layout class="QHBoxLayout" name="horizontalLayout_7">
+       <item>
+        <widget class="QSpinBox" name="spinDecimalPlaces">
+         <property name="sizePolicy">
+          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+           <horstretch>0</horstretch>
+           <verstretch>0</verstretch>
+          </sizepolicy>
+         </property>
+         <property name="minimum">
+          <number>0</number>
+         </property>
+         <property name="maximum">
+          <number>10</number>
+         </property>
+         <property name="value">
+          <number>4</number>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <widget class="QCheckBox" name="cbxTrimTrailingZeroes">
+         <property name="text">
+          <string>Trim</string>
+         </property>
+        </widget>
+       </item>
+      </layout>
+     </item>
+     <item row="6" column="1">
+      <widget class="QLineEdit" name="txtFormat">
+       <property name="toolTip">
+        <string>Template for the legend text associated with each classification.  
+Use &quot;%1&quot; for the lower bound of the classification, and &quot;%2&quot; for the upper bound.</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+       </property>
+      </widget>
+     </item>
+     <item row="5" column="2">
       <widget class="QLabel" name="label_8">
        <property name="text">
         <string>Mode</string>
@@ -32,7 +73,7 @@
        </property>
       </widget>
      </item>
-     <item row="6" column="0">
+     <item row="5" column="0">
       <widget class="QLabel" name="label_7">
        <property name="text">
         <string>Color ramp</string>
@@ -42,7 +83,7 @@
        </property>
       </widget>
      </item>
-     <item row="6" column="3">
+     <item row="5" column="3">
       <widget class="QComboBox" name="cboGraduatedMode">
        <item>
         <property name="text">
@@ -71,7 +112,7 @@
        </item>
       </widget>
      </item>
-     <item row="5" column="0">
+     <item row="4" column="0">
       <widget class="QLabel" name="label_6">
        <property name="text">
         <string>Symbol</string>
@@ -81,7 +122,7 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="1">
+     <item row="4" column="1">
       <widget class="QPushButton" name="btnChangeGraduatedSymbol">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -94,7 +135,7 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="3">
+     <item row="4" column="3">
       <widget class="QSpinBox" name="spinGraduatedClasses">
        <property name="sizePolicy">
         <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
@@ -113,7 +154,7 @@
        </property>
       </widget>
      </item>
-     <item row="5" column="2">
+     <item row="4" column="2">
       <widget class="QLabel" name="label_5">
        <property name="text">
         <string>Classes</string>
@@ -126,7 +167,7 @@
        </property>
       </widget>
      </item>
-     <item row="6" column="1">
+     <item row="5" column="1">
       <layout class="QHBoxLayout" name="horizontalLayout_2">
        <item>
         <widget class="QgsColorRampComboBox" name="cboGraduatedColorRamp"/>
@@ -183,7 +224,7 @@
        </item>
       </layout>
      </item>
-     <item row="3" column="0">
+     <item row="6" column="0">
       <widget class="QLabel" name="label">
        <property name="text">
         <string>Label Format</string>
@@ -196,51 +237,7 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="1">
-      <layout class="QHBoxLayout" name="horizontalLayout_3">
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <item>
-        <widget class="QLineEdit" name="txtFormat">
-         <property name="alignment">
-          <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
-     <item row="3" column="3">
-      <layout class="QHBoxLayout" name="horizontalLayout_7">
-       <item>
-        <widget class="QSpinBox" name="spinDecimalPlaces">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimum">
-          <number>0</number>
-         </property>
-         <property name="maximum">
-          <number>10</number>
-         </property>
-         <property name="value">
-          <number>4</number>
-         </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QCheckBox" name="cbxTrimTrailingZeroes">
-         <property name="text">
-          <string>Trim</string>
-         </property>
-        </widget>
-       </item>
-      </layout>
-     </item>
-     <item row="3" column="2">
+     <item row="6" column="2">
       <widget class="QLabel" name="label_16">
        <property name="text">
         <string>Decimal places</string>
@@ -358,14 +355,14 @@
   </customwidget>
  </customwidgets>
  <tabstops>
-  <tabstop>txtFormat</tabstop>
-  <tabstop>spinDecimalPlaces</tabstop>
-  <tabstop>cbxTrimTrailingZeroes</tabstop>
   <tabstop>btnChangeGraduatedSymbol</tabstop>
   <tabstop>spinGraduatedClasses</tabstop>
   <tabstop>cboGraduatedColorRamp</tabstop>
   <tabstop>cbxInvertedColorRamp</tabstop>
   <tabstop>cboGraduatedMode</tabstop>
+  <tabstop>txtFormat</tabstop>
+  <tabstop>spinDecimalPlaces</tabstop>
+  <tabstop>cbxTrimTrailingZeroes</tabstop>
   <tabstop>viewGraduated</tabstop>
   <tabstop>btnGraduatedClassify</tabstop>
   <tabstop>btnGraduatedAdd</tabstop>


### PR DESCRIPTION
@NathanW2 @nyalldawson  @leyan

Three fixes to categorized renderer

1) Fixed interaction between model reordering and link boundaries option so that link boundaries will sort before relinking
2) Changed label formatting to use QString.replace instead of QString.args to ensure that %1 and %2 are replaced by lower and upper bounds string respectively.  Also added tool tips and moved label format options down in GUI to reflect significance and position in grid below
3) Changed decimalPlaces to precision and allowed negative values as per Nyall's suggestion
