### PR TITLE
FFE request - [composer] Add view menu option to hide bounding boxes

### DIFF
--- a/python/core/composer/qgscomposition.sip
+++ b/python/core/composer/qgscomposition.sip
@@ -222,6 +222,20 @@ class QgsComposition : QGraphicsScene
      * @note Added in QGIS 2.5
     */
     int snapTolerance() const;
+	
+    /**Sets whether selection bounding boxes should be shown in the composition
+     * @param boundsVisible set to true to show selection bounding box
+     * @see boundingBoxesVisible
+     * @note added in QGIS 2.5
+    */
+    void setBoundingBoxesVisible( const bool boundsVisible );
+
+    /**Returns whether selection bounding boxes should be shown in the composition
+     * @returns true if selection bounding boxes should be shown
+     * @see setBoundingBoxesVisible
+     * @note added in QGIS 2.5
+    */
+    bool boundingBoxesVisible() const;	
 
     /**Returns pointer to undo/redo command storage*/
     QUndoStack* undoStack();

--- a/src/app/composer/qgscomposer.cpp
+++ b/src/app/composer/qgscomposer.cpp
@@ -189,6 +189,7 @@ QgsComposer::QgsComposer( QgisApp *qgis, const QString& title )
   mActionSnapGuides->setCheckable( true );
   mActionSmartGuides->setCheckable( true );
   mActionShowRulers->setCheckable( true );
+  mActionShowBoxes->setCheckable( true );
 
   mActionAtlasPreview->setCheckable( true );
 
@@ -331,6 +332,7 @@ QgsComposer::QgsComposer( QgisApp *qgis, const QString& title )
   viewMenu->addAction( mActionSmartGuides );
   viewMenu->addAction( mActionClearGuides );
   viewMenu->addSeparator();
+  viewMenu->addAction( mActionShowBoxes );
   viewMenu->addAction( mActionShowRulers );
 
   // Panel and toolbar submenus
@@ -1173,6 +1175,15 @@ void QgsComposer::on_mActionSmartGuides_triggered( bool checked )
   if ( mComposition )
   {
     mComposition->setSmartGuidesEnabled( checked );
+  }
+}
+
+void QgsComposer::on_mActionShowBoxes_triggered( bool checked )
+{
+  //show or hide bounding boxes
+  if ( mComposition )
+  {
+    mComposition->setBoundingBoxesVisible( checked );
   }
 }
 
@@ -3135,6 +3146,8 @@ void QgsComposer::restoreGridSettings()
   mActionShowGuides->setChecked( mComposition->snapLinesVisible() );
   mActionSnapGuides->setChecked( mComposition->alignmentSnap() );
   mActionSmartGuides->setChecked( mComposition->smartGuidesEnabled() );
+  //general view settings
+  mActionShowBoxes->setChecked( mComposition->boundingBoxesVisible() );
 }
 
 void QgsComposer::deleteItemWidgets()

--- a/src/app/composer/qgscomposer.h
+++ b/src/app/composer/qgscomposer.h
@@ -321,6 +321,9 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
     //!Enable or disable smart guides
     void on_mActionSmartGuides_triggered( bool checked );
 
+    //!Show/hide bounding boxes
+    void on_mActionShowBoxes_triggered( bool checked );
+
     //!Show/hide rulers
     void toggleRulers( bool checked );
 

--- a/src/core/composer/qgscomposermousehandles.cpp
+++ b/src/core/composer/qgscomposermousehandles.cpp
@@ -89,12 +89,18 @@ void QgsComposerMouseHandles::paint( QPainter* painter, const QStyleOptionGraphi
     return;
   }
 
-  //draw resize handles around bounds of entire selection
-  double rectHandlerSize = rectHandlerBorderTolerance();
-  drawHandles( painter, rectHandlerSize );
+  if ( mComposition->boundingBoxesVisible() )
+  {
+    //draw resize handles around bounds of entire selection
+    double rectHandlerSize = rectHandlerBorderTolerance();
+    drawHandles( painter, rectHandlerSize );
+  }
 
-  //draw dotted boxes around selected items
-  drawSelectedItemBounds( painter );
+  if ( mIsResizing || mIsDragging || mComposition->boundingBoxesVisible() )
+  {
+    //draw dotted boxes around selected items
+    drawSelectedItemBounds( painter );
+  }
 }
 
 void QgsComposerMouseHandles::drawHandles( QPainter* painter, double rectHandlerSize )
@@ -589,6 +595,7 @@ void QgsComposerMouseHandles::mouseReleaseEvent( QGraphicsSceneMouseEvent* event
   {
     mIsDragging = false;
     mIsResizing = false;
+    update();
     return;
   }
 

--- a/src/core/composer/qgscomposition.cpp
+++ b/src/core/composer/qgscomposition.cpp
@@ -96,6 +96,7 @@ void QgsComposition::init()
   mGuidesVisible = true;
   mSmartGuides = true;
   mSnapTolerance = 0;
+  mBoundingBoxesVisible = true;
   mSelectionHandles = 0;
   mActiveItemCommand = 0;
   mActiveMultiFrameCommand = 0;
@@ -215,6 +216,7 @@ void QgsComposition::loadDefaults()
   mSnapGridOffsetX = settings.value( "/Composer/defaultSnapGridOffsetX", 0 ).toDouble();
   mSnapGridOffsetY = settings.value( "/Composer/defaultSnapGridOffsetY", 0 ).toDouble();
   mSnapTolerance = settings.value( "/Composer/defaultSnapTolerancePixels", 5 ).toInt();
+  mBoundingBoxesVisible = settings.value( "/Composer/showBoundingBoxes", true ).toBool();
 }
 
 void QgsComposition::updateBounds()
@@ -2081,6 +2083,20 @@ void QgsComposition::setGridStyle( const GridStyle s )
 {
   mGridStyle = s;
   updatePaperItems();
+}
+
+void QgsComposition::setBoundingBoxesVisible( const bool boundsVisible )
+{
+  mBoundingBoxesVisible = boundsVisible;
+
+  //save to settings
+  QSettings settings;
+  settings.setValue( "/Composer/showBoundingBoxes", mBoundingBoxesVisible );
+
+  if ( mSelectionHandles )
+  {
+    mSelectionHandles->update();
+  }
 }
 
 void QgsComposition::updateSettings()

--- a/src/core/composer/qgscomposition.h
+++ b/src/core/composer/qgscomposition.h
@@ -285,6 +285,20 @@ class CORE_EXPORT QgsComposition : public QGraphicsScene
     */
     int snapTolerance() const { return mSnapTolerance; }
 
+    /**Sets whether selection bounding boxes should be shown in the composition
+     * @param boundsVisible set to true to show selection bounding box
+     * @see boundingBoxesVisible
+     * @note added in QGIS 2.5
+    */
+    void setBoundingBoxesVisible( const bool boundsVisible );
+
+    /**Returns whether selection bounding boxes should be shown in the composition
+     * @returns true if selection bounding boxes should be shown
+     * @see setBoundingBoxesVisible
+     * @note added in QGIS 2.5
+    */
+    bool boundingBoxesVisible() const { return mBoundingBoxesVisible; }
+
     /**Returns pointer to undo/redo command storage*/
     QUndoStack* undoStack() { return mUndoStack; }
 
@@ -730,6 +744,7 @@ class CORE_EXPORT QgsComposition : public QGraphicsScene
     /**Arbitraty snap lines (horizontal and vertical)*/
     QList< QGraphicsLineItem* > mSnapLines;
 
+    bool mBoundingBoxesVisible;
     QgsComposerMouseHandles* mSelectionHandles;
 
     QUndoStack* mUndoStack;

--- a/src/ui/qgscomposerbase.ui
+++ b/src/ui/qgscomposerbase.ui
@@ -21,7 +21,16 @@
     <bool>true</bool>
    </property>
    <layout class="QGridLayout" name="gridLayout">
-    <property name="margin">
+    <property name="leftMargin">
+     <number>0</number>
+    </property>
+    <property name="topMargin">
+     <number>0</number>
+    </property>
+    <property name="rightMargin">
+     <number>0</number>
+    </property>
+    <property name="bottomMargin">
      <number>0</number>
     </property>
     <item row="0" column="0">
@@ -992,6 +1001,17 @@
    </property>
    <property name="text">
     <string>Atlas Settings</string>
+   </property>
+  </action>
+  <action name="mActionShowBoxes">
+   <property name="text">
+    <string>Show Bounding Boxes</string>
+   </property>
+   <property name="toolTip">
+    <string>Show bounding boxes</string>
+   </property>
+   <property name="shortcut">
+    <string>Ctrl+Shift+B</string>
    </property>
   </action>
  </widget>


### PR DESCRIPTION
I'm requesting a feature freeze exemption to get this feature into 2.6. What it does is add an option in the view menu for compositions to hide the bounding boxes of the currently selected feature. It's a standard feature in design programs as it allows you to tweak the size and position of items and see exactly what the result is without the bounding boxes / mouse resize handles getting in the way.

Reasons for an exemption:
- the code is self contained, it has no impact on any other code areas, so it's very low risk
- I know this part of the code base backwards - these changes don't introduce any regressions
- it's a really handy feature to have and it's ready to go
