### PR TITLE
Use appropriate buffer for QgsGeometry::XXXContainedInLine. Fix #10999.

### DIFF
--- a/src/app/qgsmaptoolreshape.cpp
+++ b/src/app/qgsmaptoolreshape.cpp
@@ -96,7 +96,15 @@ void QgsMapToolReshape::canvasReleaseEvent( QMouseEvent * e )
       QgsGeometry* geom = f.geometry();
       if ( geom )
       {
-        reshapeReturn = geom->reshapeGeometry( points() );
+        try {
+          reshapeReturn = geom->reshapeGeometry( points() );
+        } catch( ... ) {
+          vlayer->destroyEditCommand();
+          stopCapturing();
+          emit messageEmitted( tr( "An error occurs during the reshaping, capture has been cancelled" ), QgsMessageBar::WARNING );
+          return;
+        }
+
         if ( reshapeReturn == 0 )
         {
           vlayer->changeGeometry( f.id(), geom );

--- a/src/core/qgsgeometry.cpp
+++ b/src/core/qgsgeometry.cpp
@@ -5221,7 +5221,7 @@ int QgsGeometry::lineContainedInLine( const GEOSGeometry* line1, const GEOSGeome
     return -1;
   }
 
-  double bufferDistance = pow( 1.0L, geomDigits( line2 ) - 11 );
+  double bufferDistance = pow( 0.1L, geomDigits( line2 ) - 1 );
 
   GEOSGeometry* bufferGeom = GEOSBuffer_r( geosinit.ctxt, line2, bufferDistance, DEFAULT_QUADRANT_SEGMENTS );
   if ( !bufferGeom )
@@ -5251,7 +5251,7 @@ int QgsGeometry::pointContainedInLine( const GEOSGeometry* point, const GEOSGeom
   if ( !point || !line )
     return -1;
 
-  double bufferDistance = pow( 1.0L, geomDigits( line ) - 11 );
+  double bufferDistance = pow( 0.1L, geomDigits( line ) - 1 );
 
   GEOSGeometry* lineBuffer = GEOSBuffer_r( geosinit.ctxt, line, bufferDistance, 8 );
   if ( !lineBuffer )


### PR DESCRIPTION
We have reduced the problem by reducing the size of the buffer used in QgsGeometry::XXXContainedInLine functions.
The error may still occur depending on:
   the accuracy of the projection used,
   the distance between the object to modify and the nearest point.
So we caught the error, stop capturing and displaying a more specific message.
