### PR TITLE
Use readlink -f to determine source directory in scripts/prepare-commit.sh

### DIFF
--- a/scripts/prepare-commit.sh
+++ b/scripts/prepare-commit.sh
@@ -15,7 +15,7 @@
 ###########################################################################
 
 
-PATH=$PATH:$(dirname $0)
+PATH=$PATH:$(dirname $(readlink -f $0))
 
 if ! type -p astyle.sh >/dev/null; then
 	echo astyle.sh not found


### PR DESCRIPTION
This makes it possible to use prepare-commit.sh as a git pre-commit hook by just symlinking `prepare-commit.sh`:

```
cd .git/hooks
ln -s ../../scripts/prepare-commit.sh pre-commit
```

(Without readlink, `dirname $0` returns the `hooks` directory instead of the `scripts` directory).
