### PR TITLE
Two bug fixes for graduated renderer

### DIFF
--- a/python/core/symbology-ng/qgsgraduatedsymbolrendererv2.sip
+++ b/python/core/symbology-ng/qgsgraduatedsymbolrendererv2.sip
@@ -6,7 +6,7 @@ class QgsRendererRangeV2
 
   public:
     QgsRendererRangeV2();
-    QgsRendererRangeV2( double lowerValue, double upperValue, QgsSymbolV2* symbol, QString label, bool render = true );
+    QgsRendererRangeV2( double lowerValue, double upperValue, QgsSymbolV2* symbol /Transfer/, QString label, bool render = true );
     QgsRendererRangeV2( const QgsRendererRangeV2& range );
 
     // default dtor is ok

--- a/src/gui/symbology-ng/qgsgraduatedsymbolrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgsgraduatedsymbolrendererv2widget.cpp
@@ -378,6 +378,7 @@ QgsGraduatedSymbolRendererV2Widget::QgsGraduatedSymbolRendererV2Widget( QgsVecto
     , mModel( 0 )
 {
 
+
   // try to recognize the previous renderer
   // (null renderer means "no previous renderer")
   if ( renderer )
@@ -391,6 +392,7 @@ QgsGraduatedSymbolRendererV2Widget::QgsGraduatedSymbolRendererV2Widget( QgsVecto
 
   // setup user interface
   setupUi( this );
+  mModel = new QgsGraduatedSymbolRendererV2Model( this );
 
   mExpressionWidget->setFilters( QgsFieldProxyModel::Numeric | QgsFieldProxyModel::Date );
   mExpressionWidget->setLayer( mLayer );
@@ -526,7 +528,6 @@ void QgsGraduatedSymbolRendererV2Widget::updateUiFromRenderer( bool updateCount 
   spinPrecision->setValue( labelFormat.precision() );
   cbxTrimTrailingZeroes->setChecked( labelFormat.trimTrailingZeroes() );
 
-  mModel = new QgsGraduatedSymbolRendererV2Model( this );
   mModel->setRenderer( mRenderer );
   viewGraduated->setModel( mModel );
   viewGraduated->resizeColumnToContents( 0 );


### PR DESCRIPTION
@NathanW2 

This fixes two issues:

1) SIP ownership issue in QgsRendererRangeV2 identified while building python tests for renderer

2) Disconnect/connect issues identified by Giovanni in issue #11329.  (This is also causing a memory leak).
