### PR TITLE
Fix #11243: Data corruption with feature simplification

### DIFF
--- a/src/core/qgsvectorlayerrenderer.cpp
+++ b/src/core/qgsvectorlayerrenderer.cpp
@@ -135,6 +135,7 @@ bool QgsVectorLayerRenderer::render()
   if ( mSimplifyGeometry )
   {
     double map2pixelTol = mSimplifyMethod.threshold();
+    bool validTransform = true;
 
     const QgsMapToPixel& mtp = mContext.mapToPixel();
     map2pixelTol *= mtp.mapUnitsPerPixel();
@@ -174,18 +175,28 @@ bool QgsVectorLayerRenderer::render()
       catch ( QgsCsException &cse )
       {
         QgsMessageLog::logMessage( QObject::tr( "Simplify transform error caught: %1" ).arg( cse.what() ), QObject::tr( "CRS" ) );
+        validTransform = false;
       }
     }
 
-    QgsSimplifyMethod simplifyMethod;
-    simplifyMethod.setMethodType( QgsSimplifyMethod::OptimizeForRendering );
-    simplifyMethod.setTolerance( map2pixelTol );
-    simplifyMethod.setForceLocalOptimization( mSimplifyMethod.forceLocalOptimization() );
+    if ( validTransform )
+    {
+      QgsSimplifyMethod simplifyMethod;
+      simplifyMethod.setMethodType( QgsSimplifyMethod::OptimizeForRendering );
+      simplifyMethod.setTolerance( map2pixelTol );
+      simplifyMethod.setForceLocalOptimization( mSimplifyMethod.forceLocalOptimization() );
 
-    featureRequest.setSimplifyMethod( simplifyMethod );
+      featureRequest.setSimplifyMethod( simplifyMethod );
 
-    QgsVectorSimplifyMethod vectorMethod = mSimplifyMethod;
-    mContext.setVectorSimplifyMethod( vectorMethod );
+      QgsVectorSimplifyMethod vectorMethod = mSimplifyMethod;
+      mContext.setVectorSimplifyMethod( vectorMethod );
+    }
+    else
+    {
+      QgsVectorSimplifyMethod vectorMethod;
+      vectorMethod.setSimplifyHints( QgsVectorSimplifyMethod::NoSimplification );
+      mContext.setVectorSimplifyMethod( vectorMethod );
+    }
   }
   else
   {


### PR DESCRIPTION
This PR fixes the bug #11243 ( http://hub.qgis.org/issues/11243 ).

It disables the simplification when the reverse transform to calculate the center of current visible extent fails.

The QgsCoordinateTransform::transformBoundingBox() method swap the sign of the maximum longitude value when it is greater than 180.0 as in attached map-data of the issue. Maybe this method needs a fix in order to preserve the sign of the minimun and maximum longitude values of the visible extent. 
