### PR TITLE
Fix #11366 Customised graduated renderer labels ignored

### DIFF
--- a/python/core/symbology-ng/qgsgraduatedsymbolrendererv2.sip
+++ b/python/core/symbology-ng/qgsgraduatedsymbolrendererv2.sip
@@ -63,7 +63,7 @@ class QgsRendererRangeV2LabelFormat
     void setTrimTrailingZeroes( bool trimTrailingZeroes );
 
     //! @note labelForLowerUpper in python bindings
-    QString labelForRange( double lower, double upper ) const;
+    QString labelForRange( double lower, double upper ) const /PyName=labelForLowerUpper/;
     QString labelForRange( const QgsRendererRangeV2 &range ) const;
     QString formatNumber( double value ) const;
 
@@ -165,7 +165,7 @@ class QgsGraduatedSymbolRendererV2 : QgsFeatureRendererV2
     //! @param labelFormat The string appended to classification labels
     //! @param updateRanges If true then ranges ending with the old unit string are updated to the new.
     //! @note Added in 2.6
-    void setLabelFormat( const QgsRendererRangeV2LabelFormat &labelFormat, bool updateRanges = true );
+    void setLabelFormat( const QgsRendererRangeV2LabelFormat &labelFormat, bool updateRanges = false );
 
     //! Reset the label decimal places to a numberbased on the minimum class interval
     //! @param updateRanges if true then ranges currently using the default label will be updated

--- a/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.cpp
+++ b/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.cpp
@@ -178,12 +178,14 @@ QgsRendererRangeV2LabelFormat::QgsRendererRangeV2LabelFormat():
     mTrimTrailingZeroes( false ),
     mNumberScale( 1.0 ),
     mNumberSuffix( "" ),
-    mReTrailingZeroes( "[.,]?0*$" )
+    mReTrailingZeroes( "[.,]?0*$" ),
+    mReNegativeZero("^\\-0(?:[.,]0*)?$")
 {
 }
 
 QgsRendererRangeV2LabelFormat::QgsRendererRangeV2LabelFormat( QString format, int precision, bool trimTrailingZeroes ):
-    mReTrailingZeroes( "[.,]?0*$" )
+    mReTrailingZeroes( "[.,]?0*$" ),
+    mReNegativeZero("^\\-0(?:[.,]0*)?$")
 {
   setFormat( format );
   setPrecision( precision );
@@ -231,11 +233,13 @@ QString QgsRendererRangeV2LabelFormat::formatNumber( double value ) const
   {
     QString valueStr=QString::number( value, 'f', mPrecision );
     if( mTrimTrailingZeroes ) valueStr=valueStr.replace(mReTrailingZeroes,"");
+    if( mReNegativeZero.exactMatch(valueStr)) valueStr=valueStr.mid(1);
     return valueStr;
   }
   else
   {
     QString valueStr=QString::number( value*mNumberScale, 'f', 0 );
+    if( valueStr == "-0" ) valueStr="0";
     if( valueStr != "0" ) valueStr=valueStr+mNumberSuffix;
     return valueStr;
   }
@@ -935,7 +939,7 @@ QgsGraduatedSymbolRendererV2* QgsGraduatedSymbolRendererV2::createRenderer(
   r->setSourceColorRamp( ramp->clone() );
   r->setInvertedColorRamp( inverted );
   r->setMode( mode );
-  r->setLabelFormat( labelFormat, false );
+  r->setLabelFormat( labelFormat );
   r->updateClasses( vlayer, mode, classes );
   return r;
 }

--- a/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.h
+++ b/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.h
@@ -104,6 +104,7 @@ class CORE_EXPORT QgsRendererRangeV2LabelFormat
     double mNumberScale;
     QString mNumberSuffix;
     QRegExp mReTrailingZeroes;
+    QRegExp mReNegativeZero;
 };
 
 class QgsVectorLayer;
@@ -195,7 +196,7 @@ class CORE_EXPORT QgsGraduatedSymbolRendererV2 : public QgsFeatureRendererV2
     //! @param labelFormat The string appended to classification labels
     //! @param updateRanges If true then ranges ending with the old unit string are updated to the new.
     //! @note Added in 2.6
-    void setLabelFormat( const QgsRendererRangeV2LabelFormat &labelFormat, bool updateRanges = true );
+    void setLabelFormat( const QgsRendererRangeV2LabelFormat &labelFormat, bool updateRanges = false );
 
     //! Reset the label decimal places to a numberbased on the minimum class interval
     //! @param updateRanges if true then ranges currently using the default label will be updated


### PR DESCRIPTION
@NathanW2

This fixes bug http://hub.qgis.org/issues/11366 - customised labels in graduated renderer not respected.

Also includes code changes from pull request #1613 - I'll merge these back in to #1613 after this is applied. These code changes fix two small issues:
- Missing PyName in SIP
- Handling of negative zero values (avoids -0.00)
