### PR TITLE
Bad layer dialog improvements (Funded by Sourcepole)

### DIFF
--- a/python/core/qgsproviderregistry.sip
+++ b/python/core/qgsproviderregistry.sip
@@ -39,6 +39,12 @@ class QgsProviderRegistry
     QgsDataProvider *provider( const QString & providerKey,
                                const QString & dataSource );
 
+    /** Return the provider capabilities
+        @param providerKey identificator of the provider
+        @note Added in 2.6
+    */
+    int getProviderCapabilities( const QString& providerKey ) const;
+
     QWidget *selectWidget( const QString & providerKey,
                            QWidget * parent = 0, Qt::WindowFlags fl = 0 );
 

--- a/src/core/qgsdataitem.h
+++ b/src/core/qgsdataitem.h
@@ -32,8 +32,6 @@
 class QgsDataProvider;
 class QgsDataItem;
 
-// TODO: bad place, where to put this? qgsproviderregistry.h?
-typedef int dataCapabilities_t();
 typedef QgsDataItem * dataItem_t( QString, QgsDataItem* );
 
 

--- a/src/core/qgsdataprovider.h
+++ b/src/core/qgsdataprovider.h
@@ -24,6 +24,8 @@
 //#include "qgsdataitem.h"
 #include "qgserror.h"
 
+typedef int dataCapabilities_t();
+
 class QgsRectangle;
 class QgsCoordinateReferenceSystem;
 

--- a/src/core/qgsproviderregistry.cpp
+++ b/src/core/qgsproviderregistry.cpp
@@ -371,6 +371,21 @@ QgsDataProvider *QgsProviderRegistry::provider( QString const & providerKey, QSt
   return dataProvider;
 } // QgsProviderRegistry::setDataProvider
 
+int QgsProviderRegistry::getProviderCapabilities( const QString &providerKey ) const
+{
+  QLibrary *library = providerLibrary( providerKey );
+  if ( !library )
+  {
+    return QgsDataProvider::NoDataCapabilities;
+  }
+  dataCapabilities_t * dataCapabilities = ( dataCapabilities_t * ) cast_to_fptr( library->resolve( "dataCapabilities" ) );
+  if ( !dataCapabilities )
+  {
+    return QgsDataProvider::NoDataCapabilities;
+  }
+  return dataCapabilities();
+}
+
 // This should be QWidget, not QDialog
 typedef QWidget * selectFactoryFunction_t( QWidget * parent, Qt::WindowFlags fl );
 

--- a/src/core/qgsproviderregistry.h
+++ b/src/core/qgsproviderregistry.h
@@ -68,6 +68,12 @@ class CORE_EXPORT QgsProviderRegistry
     QgsDataProvider *provider( const QString & providerKey,
                                const QString & dataSource );
 
+    /** Return the provider capabilities
+        @param providerKey identificator of the provider
+        @note Added in 2.6
+    */
+    int getProviderCapabilities( const QString& providerKey ) const;
+
     QWidget *selectWidget( const QString & providerKey,
                            QWidget * parent = 0, Qt::WindowFlags fl = 0 );
 


### PR DESCRIPTION
This commit contains the following improvements:
- The browse button is disabled if the layer data provider does not support files (a `QgsProviderRegistry::getProviderCapabilities()` method is added for this)
- Fix the `accept()` slot being fired twice (the `accept()` slot is already connected in `ui_qgshandlebadlayerbase.h`)
- Use a folder selection dialog when selecting a new directory for multiple selected items

Funded by Sourcepole QGIS Enterprise.
