### PR TITLE
LayerTree - keep checkstate of the moved layer

### DIFF
--- a/python/core/layertree/qgslayertreegroup.sip
+++ b/python/core/layertree/qgslayertreegroup.sip
@@ -24,7 +24,7 @@ class QgsLayerTreeGroup : QgsLayerTreeNode
     //! Append a new group node with given name. Newly created node is owned by this group.
     QgsLayerTreeGroup* addGroup( const QString& name );
     //! Insert a new layer node for given map layer at specified position. Newly created node is owned by this group.
-    QgsLayerTreeLayer* insertLayer( int index, QgsMapLayer* layer, Qt::CheckState checked );
+    QgsLayerTreeLayer* insertLayer( int index, QgsMapLayer* layer, Qt::CheckState checked = Qt::Checked );
     //! Append a new layer node for given map layer. Newly created node is owned by this group.
     QgsLayerTreeLayer* addLayer( QgsMapLayer* layer );
 

--- a/python/core/layertree/qgslayertreegroup.sip
+++ b/python/core/layertree/qgslayertreegroup.sip
@@ -24,7 +24,7 @@ class QgsLayerTreeGroup : QgsLayerTreeNode
     //! Append a new group node with given name. Newly created node is owned by this group.
     QgsLayerTreeGroup* addGroup( const QString& name );
     //! Insert a new layer node for given map layer at specified position. Newly created node is owned by this group.
-    QgsLayerTreeLayer* insertLayer( int index, QgsMapLayer* layer );
+    QgsLayerTreeLayer* insertLayer( int index, QgsMapLayer* layer, Qt::CheckState checked );
     //! Append a new layer node for given map layer. Newly created node is owned by this group.
     QgsLayerTreeLayer* addLayer( QgsMapLayer* layer );
 

--- a/src/app/legend/qgsapplegendinterface.cpp
+++ b/src/app/legend/qgsapplegendinterface.cpp
@@ -85,7 +85,8 @@ void QgsAppLegendInterface::moveLayer( QgsMapLayer * ml, int groupIndex )
   if ( !nodeLayer || !QgsLayerTree::isGroup( nodeLayer->parent() ) )
     return;
 
-  group->insertLayer( 0, ml );
+  Qt::CheckState checked = nodeLayer->isVisible();
+  group->insertLayer( 0, ml, checked );
 
   QgsLayerTreeGroup* nodeLayerParentGroup = QgsLayerTree::toGroup( nodeLayer->parent() );
   nodeLayerParentGroup->removeChildNode( nodeLayer );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -6978,10 +6978,10 @@ void QgisApp::duplicateLayers( QList<QgsMapLayer *> lyrList )
     Q_ASSERT( QgsLayerTree::isGroup( nodeSelectedLyr->parent() ) );
     QgsLayerTreeGroup* parentGroup = QgsLayerTree::toGroup( nodeSelectedLyr->parent() );
 
-    QgsLayerTreeLayer* nodeDupLayer = parentGroup->insertLayer( parentGroup->children().indexOf( nodeSelectedLyr ) + 1, dupLayer );
-
     // always set duplicated layers to not visible so layer can be configured before being turned on
-    nodeDupLayer->setVisible( Qt::Unchecked );
+    Qt::CheckState checked;
+    QgsLayerTreeLayer* nodeDupLayer = parentGroup->insertLayer( parentGroup->children().indexOf( nodeSelectedLyr ) + 1, dupLayer, checked = Qt::Unchecked );
+    Q_UNUSED( nodeDupLayer );
 
     // duplicate the layer style
     copyStyle( selectedLyr );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -6978,10 +6978,10 @@ void QgisApp::duplicateLayers( QList<QgsMapLayer *> lyrList )
     Q_ASSERT( QgsLayerTree::isGroup( nodeSelectedLyr->parent() ) );
     QgsLayerTreeGroup* parentGroup = QgsLayerTree::toGroup( nodeSelectedLyr->parent() );
 
+    QgsLayerTreeLayer* nodeDupLayer = parentGroup->insertLayer( parentGroup->children().indexOf( nodeSelectedLyr ) + 1, dupLayer );
+
     // always set duplicated layers to not visible so layer can be configured before being turned on
-    Qt::CheckState checked;
-    QgsLayerTreeLayer* nodeDupLayer = parentGroup->insertLayer( parentGroup->children().indexOf( nodeSelectedLyr ) + 1, dupLayer, checked = Qt::Unchecked );
-    Q_UNUSED( nodeDupLayer );
+    nodeDupLayer->setVisible( Qt::Unchecked );
 
     // duplicate the layer style
     copyStyle( selectedLyr );

--- a/src/core/layertree/qgslayertreegroup.cpp
+++ b/src/core/layertree/qgslayertreegroup.cpp
@@ -55,9 +55,11 @@ QgsLayerTreeGroup* QgsLayerTreeGroup::addGroup( const QString &name )
   return grp;
 }
 
-QgsLayerTreeLayer*QgsLayerTreeGroup::insertLayer( int index, QgsMapLayer* layer )
+QgsLayerTreeLayer*QgsLayerTreeGroup::insertLayer( int index, QgsMapLayer* layer, Qt::CheckState checked )
 {
   QgsLayerTreeLayer* ll = new QgsLayerTreeLayer( layer );
+  ll->setVisible( checked );
+
   insertChildNode( index, ll );
   return ll;
 }

--- a/src/core/layertree/qgslayertreegroup.h
+++ b/src/core/layertree/qgslayertreegroup.h
@@ -45,7 +45,7 @@ class CORE_EXPORT QgsLayerTreeGroup : public QgsLayerTreeNode
     //! Append a new group node with given name. Newly created node is owned by this group.
     QgsLayerTreeGroup* addGroup( const QString& name );
     //! Insert a new layer node for given map layer at specified position. Newly created node is owned by this group.
-    QgsLayerTreeLayer* insertLayer( int index, QgsMapLayer* layer );
+    QgsLayerTreeLayer* insertLayer( int index, QgsMapLayer* layer , Qt::CheckState checked );
     //! Append a new layer node for given map layer. Newly created node is owned by this group.
     QgsLayerTreeLayer* addLayer( QgsMapLayer* layer );
 

--- a/src/core/layertree/qgslayertreegroup.h
+++ b/src/core/layertree/qgslayertreegroup.h
@@ -45,7 +45,7 @@ class CORE_EXPORT QgsLayerTreeGroup : public QgsLayerTreeNode
     //! Append a new group node with given name. Newly created node is owned by this group.
     QgsLayerTreeGroup* addGroup( const QString& name );
     //! Insert a new layer node for given map layer at specified position. Newly created node is owned by this group.
-    QgsLayerTreeLayer* insertLayer( int index, QgsMapLayer* layer , Qt::CheckState checked );
+    QgsLayerTreeLayer* insertLayer( int index, QgsMapLayer* layer , Qt::CheckState checked = Qt::Checked );
     //! Append a new layer node for given map layer. Newly created node is owned by this group.
     QgsLayerTreeLayer* addLayer( QgsMapLayer* layer );
 


### PR DESCRIPTION
refs: http://hub.qgis.org/issues/11382

the current behavior does not keep the state of the moved layer when you call the `moveLayer` method, the layer will always be visible (checked), I think it make more sense to keep the checkstate of the layer when moved to group.

The below snippet does the layer `vl` visible altough you call `setLayerVisible(vl, False)`

``` python
vl = iface.activeLayer()
legend = iface.legendInterface()

myGroup = legend.addGroup("myGroup", False)
legend.setLayerVisible(vl, False)
legend.moveLayer(vl, myGroup)
```

with the patch the `vl` layer will be unchecked into layer tree.
