### PR TITLE
Papercut fix for inconsistent spelling of Raster Layer vs Vector layer

### DIFF
--- a/python/plugins/processing/modeler/ModelerParameterDefinitionDialog.py
+++ b/python/plugins/processing/modeler/ModelerParameterDefinitionDialog.py
@@ -47,7 +47,7 @@ from processing.core.parameters import ParameterFile
 class ModelerParameterDefinitionDialog(QDialog):
 
     PARAMETER_NUMBER = 'Number'
-    PARAMETER_RASTER = 'Raster Layer'
+    PARAMETER_RASTER = 'Raster layer'
     PARAMETER_TABLE = 'Table'
     PARAMETER_VECTOR = 'Vector layer'
     PARAMETER_STRING = 'String'


### PR DESCRIPTION
I'm not sure if there are any knock on effect from making this change?
