### PR TITLE
[processing] fixed issues with saga 2.1.2

### DIFF
--- a/python/plugins/processing/algs/saga/SagaAlgorithm.py
+++ b/python/plugins/processing/algs/saga/SagaAlgorithm.py
@@ -354,7 +354,7 @@ class SagaAlgorithm(GeoAlgorithm):
     def checkBeforeOpeningParametersDialog(self):
         msg = SagaUtils.checkSagaIsInstalled()
         if msg is not None:
-            print msg
+            return msg
             html = '<p>This algorithm requires SAGA to be run.Unfortunately, \
                    it seems that SAGA is not installed in your system, or it \
                    is not correctly configured to be used from QGIS</p>'

--- a/python/plugins/processing/algs/saga/SagaAlgorithmProvider.py
+++ b/python/plugins/processing/algs/saga/SagaAlgorithmProvider.py
@@ -47,12 +47,14 @@ class SagaAlgorithmProvider(AlgorithmProvider):
     def initializeSettings(self):
         AlgorithmProvider.initializeSettings(self)
         if SagaUtils.findSagaFolder() is None:
-            ProcessingConfig.addSetting(Setting(self.getDescription(),
-                                        SagaUtils.SAGA_208,
-                                        'Use SAGA 2.0.8 syntax', not isMac()))
             if isWindows() or isMac():
                 ProcessingConfig.addSetting(Setting(self.getDescription(),
                                             SagaUtils.SAGA_FOLDER, 'SAGA folder', ''))
+                ProcessingConfig.addSetting(Setting(self.getDescription(),
+                    SagaUtils.SAGA_LATEST,
+                    'Use latest most recent version(%s) instead of base one (%s)'
+                    % (SagaUtils.LATEST_VERSION_NUMBER, SagaUtils.BASE_VERSION_NUMBER),
+                    not isMac()))
         ProcessingConfig.addSetting(Setting(self.getDescription(),
                                     SagaUtils.SAGA_IMPORT_EXPORT_OPTIMIZATION,
                                     'Enable SAGA Import/Export optimizations',

--- a/python/plugins/processing/algs/saga/ext/supervisedclassification.py
+++ b/python/plugins/processing/algs/saga/ext/supervisedclassification.py
@@ -31,8 +31,8 @@ from processing.tests.TestData import table
 
 
 def editCommands(commands):
-    saga208 = ProcessingConfig.getSetting(SagaUtils.SAGA_208)
-    if saga208 is not None and not saga208:
+    sagaLatest = ProcessingConfig.getSetting(SagaUtils.SAGA_LATEST)
+    if sagaLatest:
         commands[-3] = commands[-3] + ' -STATS ' + table()
         return commands
     else:


### PR DESCRIPTION
This commit sets a differnt way of handling SAGA versions and a new way of checking saga installations

SAGA 2.0.8 is supposed to be the base version, with support for the current latest one (2.1.2). Intermediate versions are not supported

This is done to fix the messy situation that SAGA causes due to its API changing in each release.
