### PR TITLE
[BUGFIX] #11484 QGIS server: embedded layers are not published (GetCapab...

### DIFF
--- a/src/mapserver/qgsconfigcache.cpp
+++ b/src/mapserver/qgsconfigcache.cpp
@@ -40,6 +40,12 @@ QgsConfigCache::~QgsConfigCache()
 {
 }
 
+QgsServerProjectParser* QgsConfigCache::serverConfiguration( const QString& filePath )
+{
+  QDomDocument* doc = xmlDocument( filePath );
+  return new QgsServerProjectParser( doc, filePath );
+}
+
 QgsWCSProjectParser* QgsConfigCache::wcsConfiguration( const QString& filePath )
 {
   QgsWCSProjectParser* p = mWCSConfigCache.object( filePath );

--- a/src/mapserver/qgsconfigcache.h
+++ b/src/mapserver/qgsconfigcache.h
@@ -23,6 +23,7 @@
 #include <QMap>
 #include <QObject>
 
+class QgsServerProjectParser;
 class QgsWCSProjectParser;
 class QgsWFSProjectParser;
 class QgsWMSConfigParser;
@@ -36,6 +37,7 @@ class QgsConfigCache: public QObject
     static QgsConfigCache* instance();
     ~QgsConfigCache();
 
+    QgsServerProjectParser* serverConfiguration( const QString& filePath );
     QgsWCSProjectParser* wcsConfiguration( const QString& filePath );
     QgsWFSProjectParser* wfsConfiguration( const QString& filePath );
     QgsWMSConfigParser* wmsConfiguration( const QString& filePath, const QMap<QString, QString>& parameterMap = ( QMap< QString, QString >() ) );

--- a/src/mapserver/qgsserverprojectparser.cpp
+++ b/src/mapserver/qgsserverprojectparser.cpp
@@ -225,24 +225,15 @@ QgsMapLayer* QgsServerProjectParser::createLayerFromElement( const QDomElement& 
   }
   else if ( elem.attribute( "embedded" ) == "1" ) //layer is embedded from another project file
   {
-    //todo: fixme
-    /*
     QString project = convertToAbsolutePath( elem.attribute( "project" ) );
     QgsDebugMsg( QString( "Project path: %1" ).arg( project ) );
-
-    QgsProjectParser* otherConfig = dynamic_cast<QgsProjectParser*>( QgsConfigCache::instance()->searchConfiguration( project ) );
+    
+    QgsServerProjectParser* otherConfig = QgsConfigCache::instance()->serverConfiguration( project );
     if ( !otherConfig )
     {
       return 0;
     }
-
-    QHash< QString, QDomElement >::const_iterator layerIt = otherConfig->mProjectLayerElementsById.find( elem.attribute( "id" ) );
-    if ( layerIt == otherConfig->mProjectLayerElementsById.constEnd() )
-    {
-      return 0;
-    }
-    return otherConfig->createLayerFromElement( layerIt.value() );
-    */
+    return otherConfig->mapLayerFromLayerId( elem.attribute( "id" ), useCache );
   }
 
   if ( layer )


### PR DESCRIPTION
...ilities, GetMap, etc)

Issue #1072 QGIS server: embedded groups do not render in GetMap requests if
 leave layers are requested has been fixed 40d91457f6f069886c5ba1c28db1efb2ff4ccac7

But another fix about embedded layers lacks. A fixme annotation is in the
 QgsServerProjectParser::createLayerFromElement. This one is about return the
 layer if it is embedded.

In QgsServerProjectParser::createLayerFromElement, we need to generate a
 QgsServerProjectParser of the parent project to return the mapLayer for
 embedded layers. To do it, I use QgsCacheConfig to get the
 QgsServerProjectParser for the parent project.

Funded by 3Liz.
