### PR TITLE
Fix bug #11489: Crash with force point inside polygon in centroid fill style

### DIFF
--- a/src/core/qgsgeometry.cpp
+++ b/src/core/qgsgeometry.cpp
@@ -360,6 +360,9 @@ static GEOSGeometry *createGeosPolygon( const QgsPolygon& polygon )
       if ( ring ) geoms << ring;
     }
 
+    if ( geoms.size() == 0 )
+      return 0;
+
     return createGeosPolygon( geoms );
   }
   catch ( GEOSException &e )
@@ -441,7 +444,10 @@ QgsGeometry* QgsGeometry::fromMultiPolyline( const QgsMultiPolyline& multiline )
   try
   {
     for ( int i = 0; i < multiline.count(); i++ )
-      geoms << createGeosLineString( multiline[i] );
+    {
+      GEOSGeometry *lineString = createGeosLineString( multiline[i] );
+      if ( lineString ) geoms << lineString;
+    }
 
     return fromGeosGeom( createGeosCollection( GEOS_MULTILINESTRING, geoms ) );
   }
@@ -466,7 +472,10 @@ QgsGeometry* QgsGeometry::fromMultiPolygon( const QgsMultiPolygon& multipoly )
   try
   {
     for ( int i = 0; i < multipoly.count(); i++ )
-      geoms << createGeosPolygon( multipoly[i] );
+    {
+      GEOSGeometry *polygon = createGeosPolygon( multipoly[i] );
+      if ( polygon ) geoms << polygon;
+    }
 
     return fromGeosGeom( createGeosCollection( GEOS_MULTIPOLYGON, geoms ) );
   }

--- a/src/core/symbology-ng/qgssymbollayerv2utils.cpp
+++ b/src/core/symbology-ng/qgssymbollayerv2utils.cpp
@@ -3662,6 +3662,9 @@ QPointF QgsSymbolLayerV2Utils::polygonCentroid( const QPolygonF& points )
 
 QPointF QgsSymbolLayerV2Utils::polygonPointOnSurface( const QPolygonF& points )
 {
+  if ( points.count() <= 3 )
+    return points.count() == 0 ? QPointF() : points[0];
+
   QPointF centroid = QgsSymbolLayerV2Utils::polygonCentroid( points );
 
   // check if centroid inside in polygon


### PR DESCRIPTION
This PR fixes the issue #11489 ( http://hub.qgis.org/issues/11489 )

It avoids calculate a point inside invalid polygons (maybe after simplification) using GEOS.
