### PR TITLE
Fix QgsSymbolLayerV2 test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ install:
   - cmake -DWITH_MAPSERVER=ON -DWITH_STAGED_PLUGINS=OFF -DWITH_GRASS=OFF -DSUPPRESS_QT_WARNINGS=ON ..
   - make -j2
 
-script: xvfb-run ctest -j2 --output-on-failure -E 'PyQgsPalLabelingCanvas|PyQgsPalLabelingServer|PyQgsSymbolLayerV2|qgis_atlascompositiontest|PyQgsAtlasComposition' -D Experimental
+script: xvfb-run ctest -j2 --output-on-failure -E 'PyQgsPalLabelingCanvas|PyQgsPalLabelingServer|qgis_atlascompositiontest|PyQgsAtlasComposition' -D Experimental

--- a/src/core/symbology-ng/qgssymbollayerv2utils.cpp
+++ b/src/core/symbology-ng/qgssymbollayerv2utils.cpp
@@ -2438,8 +2438,8 @@ bool QgsSymbolLayerV2Utils::createFunctionElement( QDomDocument &doc, QDomElemen
 
 bool QgsSymbolLayerV2Utils::functionFromSldElement( QDomElement &element, QString &function )
 {
-  QgsDebugMsg( "Entered." );
-  QDomElement elem;
+  QDomElement elem = element;
+#if 0
   if ( element.tagName() == "Filter" )
   {
     elem = element;
@@ -2457,7 +2457,7 @@ bool QgsSymbolLayerV2Utils::functionFromSldElement( QDomElement &element, QStrin
   {
     return false;
   }
-
+#endif
 
   QgsExpression *expr = QgsOgcUtils::expressionFromOgcFilter( elem );
   if ( !expr )


### PR DESCRIPTION
The code in `functionFromSldElement` looks for a element with the name `Filter` If there is none found, the method returns.
In the testdata, there is no `Filter` defined, just a `Literal` which because of the aforementioned condition never gets parsed.

This PR more or less reverts parts of 3e98d7d8 which is not necessarily a good idea, but I fail to see the proper way of handling this.
