### PR TITLE
[FIXED] #11572 Filter Legend By Map Content doesn't maintain point displa...

### DIFF
--- a/src/core/qgsmaphittest.cpp
+++ b/src/core/qgsmaphittest.cpp
@@ -3,6 +3,7 @@
 #include "qgsmaplayerregistry.h"
 #include "qgsrendercontext.h"
 #include "qgsrendererv2.h"
+#include "qgspointdisplacementrenderer.h"
 #include "qgsvectorlayer.h"
 
 
@@ -52,6 +53,12 @@ void QgsMapHitTest::run()
 void QgsMapHitTest::runHitTestLayer( QgsVectorLayer* vl, SymbolV2Set& usedSymbols, QgsRenderContext& context )
 {
   QgsFeatureRendererV2* r = vl->rendererV2();
+  
+  // Point displacement case
+  QgsPointDisplacementRenderer* pdr = dynamic_cast<QgsPointDisplacementRenderer*>( r );
+  if ( pdr )
+    r = pdr->embeddedRenderer();
+  
   bool moreSymbolsPerFeature = r->capabilities() & QgsFeatureRendererV2::MoreSymbolsPerFeature;
   r->startRender( context, vl->pendingFields() );
   QgsFeature f;


### PR DESCRIPTION
...cement legend

For point vector layer render with 'displacement point', when 'Filter
 Legend By Map Content' is activated, the legend is not rendered even
 if it has to be.

It's due to QgsPointDisplacementRenderer that embedded the real
 renderer.

The solution proposed in this patch is to get the embedded renderer
 for QgsPointDisplacementRenderer.
