### PR TITLE
[FIXED] #11572 Filter Legend By Map Content doesn't maintain point displ...

### DIFF
--- a/src/core/qgsmaphittest.cpp
+++ b/src/core/qgsmaphittest.cpp
@@ -53,12 +53,6 @@ void QgsMapHitTest::run()
 void QgsMapHitTest::runHitTestLayer( QgsVectorLayer* vl, SymbolV2Set& usedSymbols, QgsRenderContext& context )
 {
   QgsFeatureRendererV2* r = vl->rendererV2();
-  
-  // Point displacement case
-  QgsPointDisplacementRenderer* pdr = dynamic_cast<QgsPointDisplacementRenderer*>( r );
-  if ( pdr )
-    r = pdr->embeddedRenderer();
-  
   bool moreSymbolsPerFeature = r->capabilities() & QgsFeatureRendererV2::MoreSymbolsPerFeature;
   r->startRender( context, vl->pendingFields() );
   QgsFeature f;

--- a/src/core/symbology-ng/qgspointdisplacementrenderer.cpp
+++ b/src/core/symbology-ng/qgspointdisplacementrenderer.cpp
@@ -196,11 +196,79 @@ void QgsPointDisplacementRenderer::setEmbeddedRenderer( QgsFeatureRendererV2* r 
   mRenderer = r;
 }
 
+QList<QString> QgsPointDisplacementRenderer::usedAttributes()
+{
+  QList<QString> attributeList;
+  if ( !mLabelAttributeName.isEmpty() )
+  {
+    attributeList.push_back( mLabelAttributeName );
+  }
+  if ( mRenderer )
+  {
+    attributeList += mRenderer->usedAttributes();
+  }
+  return attributeList;
+}
+
+int QgsPointDisplacementRenderer::capabilities()
+{
+  if ( !mRenderer )
+  {
+    return 0;
+  }
+  return mRenderer->capabilities();
+}
+
+QgsSymbolV2List QgsPointDisplacementRenderer::symbols()
+{
+  if ( !mRenderer )
+  {
+    return QgsSymbolV2List();
+  }
+  return mRenderer->symbols();
+}
+
 QgsSymbolV2* QgsPointDisplacementRenderer::symbolForFeature( QgsFeature& feature )
 {
-  Q_UNUSED( feature );
-  return 0; //not used any more
+  if ( !mRenderer )
+  {
+    return 0;
+  }
+  return mRenderer->symbolForFeature( feature );
 }
+
+QgsSymbolV2* QgsPointDisplacementRenderer::originalSymbolForFeature( QgsFeature& feat )
+{
+  if ( !mRenderer )
+    return 0;
+  return mRenderer->originalSymbolForFeature( feat );
+}
+
+QgsSymbolV2List QgsPointDisplacementRenderer::symbolsForFeature( QgsFeature& feature )
+{
+  if ( !mRenderer )
+  {
+    return QgsSymbolV2List();
+  }
+  return mRenderer->symbolsForFeature( feature );
+}
+
+QgsSymbolV2List QgsPointDisplacementRenderer::originalSymbolsForFeature( QgsFeature& feat )
+{
+  if ( !mRenderer )
+    return QgsSymbolV2List();
+  return mRenderer->originalSymbolsForFeature( feat );
+}
+
+bool QgsPointDisplacementRenderer::willRenderFeature( QgsFeature& feat )
+{
+  if ( !mRenderer )
+  {
+    return false;
+  }
+  return mRenderer->willRenderFeature( feat );
+}
+
 
 void QgsPointDisplacementRenderer::startRender( QgsRenderContext& context, const QgsFields& fields )
 {
@@ -254,32 +322,6 @@ void QgsPointDisplacementRenderer::stopRender( QgsRenderContext& context )
   if ( mCenterSymbol )
   {
     mCenterSymbol->stopRender( context );
-  }
-}
-
-QList<QString> QgsPointDisplacementRenderer::usedAttributes()
-{
-  QList<QString> attributeList;
-  if ( !mLabelAttributeName.isEmpty() )
-  {
-    attributeList.push_back( mLabelAttributeName );
-  }
-  if ( mRenderer )
-  {
-    attributeList += mRenderer->usedAttributes();
-  }
-  return attributeList;
-}
-
-QgsSymbolV2List QgsPointDisplacementRenderer::symbols()
-{
-  if ( mRenderer )
-  {
-    return mRenderer->symbols();
-  }
-  else
-  {
-    return QgsSymbolV2List();
   }
 }
 

--- a/src/core/symbology-ng/qgspointdisplacementrenderer.h
+++ b/src/core/symbology-ng/qgspointdisplacementrenderer.h
@@ -41,14 +41,26 @@ class CORE_EXPORT QgsPointDisplacementRenderer: public QgsFeatureRendererV2
     /**Reimplemented from QgsFeatureRendererV2*/
     bool renderFeature( QgsFeature& feature, QgsRenderContext& context, int layer = -1, bool selected = false, bool drawVertexMarker = false );
 
-    QgsSymbolV2* symbolForFeature( QgsFeature& feature );
+    /** Partial proxy that will call this method on the embedded renderer. */
+    virtual QList<QString> usedAttributes();
+    /** Proxy that will call this method on the embedded renderer. */
+    virtual int capabilities();
+    /** Proxy that will call this method on the embedded renderer. */
+    virtual QgsSymbolV2List symbols();
+    /** Proxy that will call this method on the embedded renderer. */
+    virtual QgsSymbolV2* symbolForFeature( QgsFeature& feature );
+    /** Proxy that will call this method on the embedded renderer. */
+    virtual QgsSymbolV2* originalSymbolForFeature( QgsFeature& feat );
+    /** Proxy that will call this method on the embedded renderer. */
+    virtual QgsSymbolV2List symbolsForFeature( QgsFeature& feat );
+    /** Proxy that will call this method on the embedded renderer. */
+    virtual QgsSymbolV2List originalSymbolsForFeature( QgsFeature& feat );
+    /** Proxy that will call this method on the embedded renderer. */
+    virtual bool willRenderFeature( QgsFeature& feat );
 
     void startRender( QgsRenderContext& context, const QgsFields& fields );
 
     void stopRender( QgsRenderContext& context );
-
-    QList<QString> usedAttributes();
-    QgsSymbolV2List symbols();
 
     //! create a renderer from XML element
     static QgsFeatureRendererV2* create( QDomElement& symbologyElem );


### PR DESCRIPTION
...acement legend

The fix from https://github.com/qgis/QGIS/pull/1673 has to be enhance to have
 something more generic.

This fix add methods to QgsPointDisplacementRenderer:
- capabilities
- symbolForFeature
- originalSymbolForFeature
- symbolsForFeature
- originalSymbolsForFeature
- willRenderFeature
