### PR TITLE
fix Empty console Output on R under processing. refs #7643

### DIFF
--- a/python/plugins/processing/algs/r/RUtils.py
+++ b/python/plugins/processing/algs/r/RUtils.py
@@ -124,7 +124,7 @@ class RUtils:
         if os.path.exists(RUtils.getConsoleOutputFilename()):
             lines = open(RUtils.getConsoleOutputFilename())
             for line in lines:
-                line = line.strip('\n').strip(' ')
+                line = line.strip().strip(' ')
                 if line.startswith('>'):
                     line = line[1:].strip(' ')
                     if line in RUtils.verboseCommands:


### PR DESCRIPTION
This commit will fix the problem of empty console output on R under processing.
- This problem seems to occur in windows 32bit only.
- I think that a fundamental cause is probably the handling of new line code of python 2.7.4. 
  - QGIS on windows 64bit depends on python 2.7.5 doesn't occur this problem.
- In the original code, the carriage return remains when line feed are removed. So the part of compare string will always be in false.
