### PR TITLE
add a save button for subform (1-n relations)

### DIFF
--- a/python/gui/qgsvectorlayertools.sip
+++ b/python/gui/qgsvectorlayertools.sip
@@ -37,4 +37,11 @@ class QgsVectorLayerTools
      */
     virtual bool stopEditing( QgsVectorLayer* layer, bool allowCancel = true ) const = 0;
 
+    /**
+     * Should be called, when the features should be commited but the editing session is not ended.
+     *
+     * @param layer       The layer to commit
+     * @return            True if successful
+     */
+    virtual bool saveEdits( QgsVectorLayer* layer) const = 0;
 };

--- a/src/app/qgsguivectorlayertools.cpp
+++ b/src/app/qgsguivectorlayertools.cpp
@@ -65,6 +65,32 @@ bool QgsGuiVectorLayerTools::startEditing( QgsVectorLayer* layer ) const
   return res;
 }
 
+bool QgsGuiVectorLayerTools::saveEdits( QgsVectorLayer* layer) const
+{
+  bool res = true;
+
+  if ( layer->isModified() )
+  {
+		if ( !layer->commitChanges() )
+		{
+		  commitError( layer );
+		  // Leave the in-memory editing state alone,
+		  // to give the user a chance to enter different values
+		  // and try the commit again later
+		  res = false;
+		}
+    layer->triggerRepaint();
+		layer->startEditing();
+  }
+  else //layer not modified
+	{
+	  res = true;
+	  layer->triggerRepaint();
+	}
+  return res;
+}
+
+
 bool QgsGuiVectorLayerTools::stopEditing( QgsVectorLayer* layer, bool allowCancel ) const
 {
   bool res = true;

--- a/src/app/qgsguivectorlayertools.cpp
+++ b/src/app/qgsguivectorlayertools.cpp
@@ -84,7 +84,6 @@ bool QgsGuiVectorLayerTools::saveEdits( QgsVectorLayer* layer ) const
   else //layer not modified
   {
     res = true;
-    layer->triggerRepaint();
   }
   return res;
 }

--- a/src/app/qgsguivectorlayertools.cpp
+++ b/src/app/qgsguivectorlayertools.cpp
@@ -65,28 +65,27 @@ bool QgsGuiVectorLayerTools::startEditing( QgsVectorLayer* layer ) const
   return res;
 }
 
-bool QgsGuiVectorLayerTools::saveEdits( QgsVectorLayer* layer) const
+bool QgsGuiVectorLayerTools::saveEdits( QgsVectorLayer* layer ) const
 {
   bool res = true;
 
   if ( layer->isModified() )
   {
-		if ( !layer->commitChanges() )
-		{
-		  commitError( layer );
-		  // Leave the in-memory editing state alone,
-		  // to give the user a chance to enter different values
-		  // and try the commit again later
-		  res = false;
-		}
-    layer->triggerRepaint();
-		layer->startEditing();
+    if ( !layer->commitChanges() )
+    {
+      commitError( layer );
+      // Leave the in-memory editing state alone,
+      // to give the user a chance to enter different values
+      // and try the commit again later
+      res = false;
+    }
+    layer->startEditing();
   }
   else //layer not modified
-	{
-	  res = true;
-	  layer->triggerRepaint();
-	}
+  {
+    res = true;
+    layer->triggerRepaint();
+  }
   return res;
 }
 

--- a/src/app/qgsguivectorlayertools.h
+++ b/src/app/qgsguivectorlayertools.h
@@ -61,6 +61,14 @@ class QgsGuiVectorLayerTools : public QgsVectorLayerTools, public QObject
      */
     bool stopEditing( QgsVectorLayer* layer, bool allowCancel = true ) const;
 
+    /**
+     * Should be called, when the features should be commited but the editing session is not ended.
+     *
+     * @param layer       The layer to commit
+     * @return            True if successful
+     */
+    bool saveEdits( QgsVectorLayer* layer) const;
+
   private:
     void commitError( QgsVectorLayer* vlayer ) const;
 };

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -50,6 +50,12 @@ QgsRelationEditorWidget::QgsRelationEditorWidget( QWidget* parent )
   mToggleEditingButton->setEnabled( false );
   mToggleEditingButton->setCheckable( true );
   buttonLayout->addWidget( mToggleEditingButton );
+  // save Edits
+  mSaveEditsButton = new QToolButton( this );
+  mSaveEditsButton->setIcon( QgsApplication::getThemeIcon( "/mActionSaveEdits.svg" ) );
+  mSaveEditsButton->setText( tr( "Save layer edits" ) );
+  mSaveEditsButton->setEnabled( true );
+  buttonLayout->addWidget( mSaveEditsButton );
   // add feature
   mAddFeatureButton = new QToolButton( this );
   mAddFeatureButton->setIcon( QgsApplication::getThemeIcon( "/mActionAdd.svg" ) );
@@ -111,6 +117,7 @@ QgsRelationEditorWidget::QgsRelationEditorWidget( QWidget* parent )
   connect( this, SIGNAL( collapsedStateChanged( bool ) ), this, SLOT( onCollapsedStateChanged( bool ) ) );
   connect( mViewModeButtonGroup, SIGNAL( buttonClicked( int ) ), this, SLOT( setViewMode( int ) ) );
   connect( mToggleEditingButton, SIGNAL( clicked( bool ) ), this, SLOT( toggleEditing( bool ) ) );
+  connect( mSaveEditsButton, SIGNAL( clicked() ), this, SLOT( saveEdits() ) );
   connect( mAddFeatureButton, SIGNAL( clicked() ), this, SLOT( addFeature() ) );
   connect( mDeleteFeatureButton, SIGNAL( clicked() ), this, SLOT( deleteFeature() ) );
   connect( mLinkFeatureButton, SIGNAL( clicked() ), this, SLOT( linkFeature() ) );
@@ -174,6 +181,7 @@ void QgsRelationEditorWidget::referencingLayerEditingToggled()
   mDeleteFeatureButton->setEnabled( editable );
   mUnlinkFeatureButton->setEnabled( editable );
   mToggleEditingButton->setChecked( editable );
+  mSaveEditsButton->setEnabled( editable );
 }
 
 void QgsRelationEditorWidget::addFeature()
@@ -255,6 +263,11 @@ void QgsRelationEditorWidget::toggleEditing( bool state )
   {
     mEditorContext.vectorLayerTools()->stopEditing( mRelation.referencingLayer() );
   }
+}
+
+void QgsRelationEditorWidget::saveEdits()
+{
+	 mEditorContext.vectorLayerTools()->saveEdits(mRelation.referencingLayer() );
 }
 
 void QgsRelationEditorWidget::onCollapsedStateChanged( bool collapsed )

--- a/src/gui/qgsrelationeditorwidget.h
+++ b/src/gui/qgsrelationeditorwidget.h
@@ -64,6 +64,7 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsCollapsibleGroupBox
     void linkFeature();
     void deleteFeature();
     void unlinkFeature();
+    void saveEdits();
     void toggleEditing( bool state );
     void onCollapsedStateChanged( bool collapsed );
 
@@ -77,6 +78,7 @@ class GUI_EXPORT QgsRelationEditorWidget : public QgsCollapsibleGroupBox
     QgsFeature mFeature;
 
     QToolButton* mToggleEditingButton;
+    QToolButton* mSaveEditsButton;
     QToolButton* mAddFeatureButton;
     QToolButton* mDeleteFeatureButton;
     QToolButton* mLinkFeatureButton;

--- a/src/gui/qgsvectorlayertools.h
+++ b/src/gui/qgsvectorlayertools.h
@@ -71,6 +71,14 @@ class GUI_EXPORT QgsVectorLayerTools
      */
     virtual bool stopEditing( QgsVectorLayer* layer, bool allowCancel = true ) const = 0;
 
+		/**
+		 * Should be called, when the features should be commited but the editing session is not ended.
+		 *
+		 * @param layer       The layer to commit
+		 * @return            True if successful
+		 */
+    virtual bool saveEdits( QgsVectorLayer* layer ) const = 0;
+
 };
 
 #endif // QGSVECTORLAYERTOOLS_H


### PR DESCRIPTION
Add a save button next to the toggle editing in subform. 

feature request: https://hub.qgis.org/issues/9680
more details: http://osgeo-org.1560.x6.nabble.com/Save-button-in-1-n-relations-form-td5106563.html
