### PR TITLE
Make prepare-commit.sh return 0 if nothing was modified

### DIFF
--- a/scripts/prepare-commit.sh
+++ b/scripts/prepare-commit.sh
@@ -48,7 +48,7 @@ fi
 
 if [ -z "$MODIFIED" ]; then
 	echo nothing was modified
-	exit 1
+	exit 0
 fi
 
 # save original changes


### PR DESCRIPTION
If prepare-commit.sh is used as a pre-commit hook, returning 1 if nothing was modified causes git ammend to fail.
