### PR TITLE
Fix atlas with fixed scale

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,4 +16,4 @@ install:
   - cmake -DWITH_MAPSERVER=ON -DWITH_STAGED_PLUGINS=OFF -DWITH_GRASS=OFF -DSUPPRESS_QT_WARNINGS=ON ..
   - make -j2
 
-script: xvfb-run ctest -j2 --output-on-failure -E 'PyQgsPalLabelingCanvas|PyQgsPalLabelingServer|PyQgsSymbolLayerV2|qgis_atlascompositiontest|PyQgsAtlasComposition' -D Experimental
+script: xvfb-run ctest -j2 --output-on-failure -E 'PyQgsPalLabelingCanvas|PyQgsPalLabelingServer|PyQgsSymbolLayerV2' -D Experimental

--- a/src/core/composer/qgsatlascomposition.cpp
+++ b/src/core/composer/qgsatlascomposition.cpp
@@ -514,7 +514,7 @@ void QgsAtlasComposition::prepareMap( QgsComposerMap* map )
   double ya1 = mTransformedFeatureBounds.yMinimum();
   double ya2 = mTransformedFeatureBounds.yMaximum();
   QgsRectangle newExtent = mTransformedFeatureBounds;
-  QgsRectangle mOrigExtent( map->extent() );
+  QgsRectangle mOrigExtent( *map->currentMapExtent() );
 
   //sanity check - only allow fixed scale mode for point layers
   bool isPointLayer = false;


### PR DESCRIPTION
Tests with fixed scale atlas were breaking for on ubuntu precise since commit 6d7c5f885db because the map was not rendered at all.
This PR proposes a fix for this.
