### PR TITLE
Delete r.average.txt

### DIFF
--- a/python/plugins/processing/algs/grass7/description/r.average.txt
+++ b/python/plugins/processing/algs/grass7/description/r.average.txt
@@ -1,7 +1,0 @@
-r.average
-r.average - Finds the average of values in a cover raster layer  within areas assigned the same category value in a user-specified base layer.
-Raster (r.*)
-ParameterRaster|base|Base raster layer|False
-ParameterRaster|cover|Cover raster layer|False
-ParameterBoolean|-c|Cover values extracted from the category labels of the cover map|False
-OutputRaster|output|Average values


### PR DESCRIPTION
Superseded by r.statistics, see http://trac.osgeo.org/grass/wiki/Grass7/NewFeatures#Removedmodules
