### PR TITLE
deactivate qgis_wcsprovidertest

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ install:
   - cd build
   - cmake -DWITH_MAPSERVER=ON -DWITH_STAGED_PLUGINS=OFF -DWITH_GRASS=OFF -DSUPPRESS_QT_WARNINGS=ON ..
 
-script: xvfb-run ctest -V -E 'PyQgsPalLabelingCanvas|PyQgsPalLabelingServer|qgis_atlascompositiontest|PyQgsAtlasComposition' -S ../qgis-test-travis.ctest --output-on-failure
+script: xvfb-run ctest -V -E 'PyQgsPalLabelingCanvas|PyQgsPalLabelingServer|qgis_atlascompositiontest|PyQgsAtlasComposition|qgis_wcsprovidertest' -S ../qgis-test-travis.ctest --output-on-failure


### PR DESCRIPTION
Disabling on behalf of @m-kuhn since the wcs server used in qgis_wcsprovidertest is not really reliable. Often the test fails due to server problem.
We should use a more solid server or make the test handle connections problems
