### PR TITLE
Make the "Merge shapefiles" tool correctly handle features without geometries

### DIFF
--- a/python/plugins/fTools/tools/doMergeShapes.py
+++ b/python/plugins/fTools/tools/doMergeShapes.py
@@ -317,8 +317,9 @@ class ShapeMergeThread( QThread ):
             mergedAttrs[ fieldMap[shapeIndex][fieldIndex] ] = v
           fieldIndex += 1
 
-        inGeom = QgsGeometry( inFeat.geometry() )
-        outFeat.setGeometry( inGeom )
+        if inFeat.geometry() is not None:
+            inGeom = QgsGeometry( inFeat.geometry() )
+            outFeat.setGeometry( inGeom )
         outFeat.setAttributes( mergedAttrs )
         writer.addFeature( outFeat )
         self.emit( SIGNAL( "featureProcessed()" ) )


### PR DESCRIPTION
At the moment, the fTools "Merge shapefiles" plugin will crash when trying to merge shapefiles that include features without geometries. This commit checks whether a feature has a geometry before trying to copy the geometry.
