### PR TITLE
Comments for expressions

### DIFF
--- a/python/core/qgsexpression.sip
+++ b/python/core/qgsexpression.sip
@@ -24,10 +24,10 @@ class QgsExpression
      * all attributes from the layer are required for evaluation of the expression.
      * QgsFeatureRequest::setSubsetOfAttributes automatically handles this case.
      */
-    QStringList referencedColumns();
+    QStringList referencedColumns() const;
 
     //! Returns true if the expression uses feature geometry for some computation
-    bool needsGeometry();
+    bool needsGeometry() const;
 
     // evaluation
 

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -1891,7 +1891,7 @@ QgsExpression::~QgsExpression()
   delete mRootNode;
 }
 
-QStringList QgsExpression::referencedColumns()
+QStringList QgsExpression::referencedColumns() const
 {
   if ( !mRootNode )
     return QStringList();
@@ -1915,7 +1915,7 @@ QStringList QgsExpression::referencedColumns()
   return columns;
 }
 
-bool QgsExpression::needsGeometry()
+bool QgsExpression::needsGeometry() const
 {
   if ( !mRootNode )
     return false;

--- a/src/core/qgsexpression.h
+++ b/src/core/qgsexpression.h
@@ -162,7 +162,13 @@ class CORE_EXPORT QgsExpression
     double scale() { return mScale; }
 
     //! Alias for dump()
-    const QString expression() const { return dump(); }
+    const QString expression() const
+    {
+      if ( !mExp.isNull() )
+        return mExp;
+      else
+        return dump();
+    }
 
     //! Return the expression string that represents this QgsExpression.
     QString dump() const;
@@ -620,7 +626,9 @@ class CORE_EXPORT QgsExpression
     static QString group( QString group );
 
   protected:
-    // internally used to create an empty expression
+    /**
+     * Used by QgsOgcUtils to create an empty
+     */
     QgsExpression() : mRootNode( 0 ), mRowNumber( 0 ), mCalc( 0 ) {}
 
     void initGeomCalculator();
@@ -634,16 +642,17 @@ class CORE_EXPORT QgsExpression
     double mScale;
     QString mExp;
 
+    QgsDistanceArea *mCalc;
+
     static QMap<QString, QVariant> gmSpecialColumns;
     static QMap<QString, QString> gmSpecialColumnGroups;
 
-    QgsDistanceArea *mCalc;
-
-    friend class QgsOgcUtils;
-
-    static void initFunctionHelp();
     static QHash<QString, QString> gFunctionHelpTexts;
     static QHash<QString, QString> gGroups;
+
+    static void initFunctionHelp();
+
+    friend class QgsOgcUtils;
 
   private:
     Q_DISABLE_COPY( QgsExpression )  // for now - until we have proper copy constructor / implicit sharing

--- a/src/core/qgsexpression.h
+++ b/src/core/qgsexpression.h
@@ -103,15 +103,16 @@ class CORE_EXPORT QgsExpression
     //! Get the expression ready for evaluation - find out column indexes.
     bool prepare( const QgsFields &fields );
 
-    /**Get list of columns referenced by the expression.
+    /**
+     * Get list of columns referenced by the expression.
      * @note if the returned list contains the QgsFeatureRequest::AllAttributes constant then
      * all attributes from the layer are required for evaluation of the expression.
      * QgsFeatureRequest::setSubsetOfAttributes automatically handles this case.
      */
-    QStringList referencedColumns();
+    QStringList referencedColumns() const;
 
     //! Returns true if the expression uses feature geometry for some computation
-    bool needsGeometry();
+    bool needsGeometry() const;
 
     // evaluation
 

--- a/src/core/qgsexpressionlexer.ll
+++ b/src/core/qgsexpressionlexer.ll
@@ -95,7 +95,9 @@ static QLocale cLocale("C");
 
 %}
 
-%s IN_COMMENT
+%s BLOCK_COMMENT
+
+line_comment \-\-[^\r\n]*[\r\n]?
 
 white       [ \t\r\n]+
 
@@ -120,9 +122,9 @@ string      "'"{str_char}*"'"
 %%
 
 <INITIAL>{
-  "/*" BEGIN(IN_COMMENT);
+  "/*" BEGIN(BLOCK_COMMENT);
 }
-<IN_COMMENT>{
+<BLOCK_COMMENT>{
   "*/" BEGIN(INITIAL);
   [^*\n]+   // eat comment in chunks
   "*"       // eat the lone star
@@ -194,6 +196,8 @@ string      "'"{str_char}*"'"
 {column_ref_quoted}  { TEXT_FILTER(stripColumnRef); return COLUMN_REF; }
 
 {white}    /* skip blanks and tabs */
+
+{line_comment} /* skip line comments */
 
 .       { return Unknown_CHARACTER; }
 

--- a/src/core/qgsexpressionlexer.ll
+++ b/src/core/qgsexpressionlexer.ll
@@ -95,6 +95,8 @@ static QLocale cLocale("C");
 
 %}
 
+%s IN_COMMENT
+
 white       [ \t\r\n]+
 
 non_ascii    [\x80-\xFF]
@@ -116,6 +118,16 @@ str_char    ('')|(\\.)|[^'\\]
 string      "'"{str_char}*"'"
 
 %%
+
+<INITIAL>{
+  "/*" BEGIN(IN_COMMENT);
+}
+<IN_COMMENT>{
+  "*/" BEGIN(INITIAL);
+  [^*\n]+   // eat comment in chunks
+  "*"       // eat the lone star
+  \n        yylineno++;
+}
 
 "NOT"   { U_OP(uoNot); return NOT; }
 "AND"   { B_OP(boAnd); return AND; }
@@ -184,5 +196,6 @@ string      "'"{str_char}*"'"
 {white}    /* skip blanks and tabs */
 
 .       { return Unknown_CHARACTER; }
+
 
 %%

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -89,7 +89,7 @@ class TestQgsExpression: public QObject
       QTest::newRow( "string literal" ) << "'test'" << true;
       QTest::newRow( "column reference" ) << "my_col" << true;
       QTest::newRow( "quoted column" ) << "\"my col\"" << true;
-      QTest::newRow( "unary minus" ) << "--3" << true;
+      QTest::newRow( "unary minus" ) << "-(-3)" << true;
       QTest::newRow( "function" ) << "cos(0)" << true;
       QTest::newRow( "function2" ) << "atan2(0,1)" << true;
       QTest::newRow( "operator IN" ) << "x in (a,b)" << true;

--- a/tests/src/python/test_qgsexpression.py
+++ b/tests/src/python/test_qgsexpression.py
@@ -84,7 +84,14 @@ class TestQgsExpressionCustomFunctions(TestCase):
 		self.assertFalse(success)
 
 	def testDump(self):
-		for txt in ["id", u"idä", "\"id abc\"", "\"id	abc\""]:
+		for txt in [
+			"id",
+			u"idä",
+			"\"id abc\"",
+			"\"id	abc\"",
+			"  abc   ",
+			" /* co */ da ",
+		]:
 			self.assertEqual( txt, QgsExpression(txt).expression() )
 
 	def testBlockComment(self):
@@ -103,6 +110,21 @@ class TestQgsExpressionCustomFunctions(TestCase):
 			/**
 			comment
 			**/""": 'test*/'
+		}
+		for e, exp_res in expressions.iteritems():
+			exp = QgsExpression(e)
+			result = exp.evaluate()
+			self.assertEqual(exp_res, result)
+
+
+	def testComment(self):
+		expressions = {
+			"'test' -- comment\n": 'test',
+			"'test--'\n": 'test--',
+			"'--test'\n": '--test',
+			"'test' -- comment": 'test',
+			"'test--'": 'test--',
+			"'--test'": '--test',
 		}
 		for e, exp_res in expressions.iteritems():
 			exp = QgsExpression(e)

--- a/tests/src/python/test_qgsexpression.py
+++ b/tests/src/python/test_qgsexpression.py
@@ -87,5 +87,27 @@ class TestQgsExpressionCustomFunctions(TestCase):
 		for txt in ["id", u"idä", "\"id abc\"", "\"id	abc\""]:
 			self.assertEqual( txt, QgsExpression(txt).expression() )
 
+	def testBlockComment(self):
+		expressions = {
+			"'test' /* comment */": 'test',
+			"/* comment */'test'": 'test',
+		    "/* comment */'test*/'": 'test*/',
+			"/** comment */'test*/'": 'test*/',
+			"/* comment **/'test*/' /* comment */": 'test*/',
+			"'test/*'/* comment */": 'test/*',
+			"""/**
+			comment
+			**/
+			'test*/'""": 'test*/',
+			"""'test*/'
+			/**
+			comment
+			**/""": 'test*/'
+		}
+		for e, exp_res in expressions.iteritems():
+			exp = QgsExpression(e)
+			result = exp.evaluate()
+			self.assertEqual(exp_res, result)
+
 if __name__ == "__main__":
 	unittest.main()


### PR DESCRIPTION
Adds support for comments in QgsExpressions. The syntax is based on the SQL standard
## Block comments

``` sql
    /*
     * This is
     * a multi-line block comment
     */

```
## Line comments

``` sql
    CASE
      WHEN name = 'QGIS' THEN 'Yay' -- Using the good stuff
      ELSE 'Nay' -- You can get it on http://qgis.org
    END
```
