### PR TITLE
Fix isIntSafe and isDoubleSafe not considering some QVariant types

### DIFF
--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -162,13 +162,20 @@ static QVariant tvl2variant( TVL v )
 inline bool isIntSafe( const QVariant& v )
 {
   if ( v.type() == QVariant::Int ) return true;
+  if ( v.type() == QVariant::UInt ) return true;
+  if ( v.type() == QVariant::LongLong ) return true;
+  if ( v.type() == QVariant::ULongLong ) return true;
   if ( v.type() == QVariant::Double ) return false;
   if ( v.type() == QVariant::String ) { bool ok; v.toString().toInt( &ok ); return ok; }
   return false;
 }
 inline bool isDoubleSafe( const QVariant& v )
 {
-  if ( v.type() == QVariant::Double || v.type() == QVariant::Int ) return true;
+  if ( v.type() == QVariant::Double ) return true;
+  if ( v.type() == QVariant::Int ) return true;
+  if ( v.type() == QVariant::UInt ) return true;
+  if ( v.type() == QVariant::LongLong ) return true;
+  if ( v.type() == QVariant::ULongLong ) return true;
   if ( v.type() == QVariant::String ) { bool ok; v.toString().toDouble( &ok ); return ok; }
   return false;
 }


### PR DESCRIPTION
In `qgsexpression.cpp`, the functions `isIntSafe` and `isDoubleSafe` does not test for `QVariant::UInt`, `QVariant::LongLong` or `QVariant::ULongLong`. This causes for instance the expression `"attribute_name" < somevalue` to fail if `"attribute_name"` is a `BIGINT` column of a PostGIS database.

Funded by Sourcepole
