### PR TITLE
[QGIS-Server] FIX 10489 QGIS Server getcapabilites response is not WMS c...

### DIFF
--- a/src/server/CMakeLists.txt
+++ b/src/server/CMakeLists.txt
@@ -184,6 +184,7 @@ INSTALL(TARGETS
 INSTALL(FILES
   admin.sld
   wms_metadata.xml
+  schemaExtension.xsd
   DESTINATION ${QGIS_CGIBIN_DIR}
   )
 

--- a/src/server/qgshttprequesthandler.cpp
+++ b/src/server/qgshttprequesthandler.cpp
@@ -268,10 +268,16 @@ void QgsHttpRequestHandler::setGetCapabilitiesResponse( const QDomDocument& doc 
   setHttpResponse( &ba, "text/xml" );
 }
 
-void QgsHttpRequestHandler::setGetStyleResponse( const QDomDocument& doc )
+void QgsHttpRequestHandler::setXmlResponse( const QDomDocument& doc )
 {
   QByteArray ba = doc.toByteArray();
   setHttpResponse( &ba, "text/xml" );
+}
+
+void QgsHttpRequestHandler::setXmlResponse( const QDomDocument& doc, const QString& mimeType )
+{
+  QByteArray ba = doc.toByteArray();
+  setHttpResponse( &ba, mimeType );
 }
 
 void QgsHttpRequestHandler::setGetFeatureInfoResponse( const QDomDocument& infoDoc, const QString& infoFormat )

--- a/src/server/qgshttprequesthandler.h
+++ b/src/server/qgshttprequesthandler.h
@@ -39,7 +39,8 @@ class QgsHttpRequestHandler: public QgsRequestHandler
     virtual void setGetCapabilitiesResponse( const QDomDocument& doc );
     virtual void setGetFeatureInfoResponse( const QDomDocument& infoDoc, const QString& infoFormat );
     virtual void setServiceException( QgsMapServiceException ex );
-    virtual void setGetStyleResponse( const QDomDocument& doc );
+    virtual void setXmlResponse( const QDomDocument& doc );
+    virtual void setXmlResponse( const QDomDocument& doc, const QString& mimeType );
     virtual void setGetPrintResponse( QByteArray* ba );
     virtual bool startGetFeatureResponse( QByteArray* ba, const QString& infoFormat );
     virtual void setGetFeatureResponse( QByteArray* ba );

--- a/src/server/qgsrequesthandler.h
+++ b/src/server/qgsrequesthandler.h
@@ -53,7 +53,8 @@ class QgsRequestHandler
     virtual void setGetCapabilitiesResponse( const QDomDocument& doc ) = 0;
     virtual void setGetFeatureInfoResponse( const QDomDocument& infoDoc, const QString& infoFormat ) = 0;
     virtual void setServiceException( QgsMapServiceException ex ) = 0;
-    virtual void setGetStyleResponse( const QDomDocument& doc ) = 0;
+    virtual void setXmlResponse( const QDomDocument& doc ) = 0;
+    virtual void setXmlResponse( const QDomDocument& doc, const QString& mimeType ) = 0;
     virtual void setGetPrintResponse( QByteArray* b ) = 0;
     virtual bool startGetFeatureResponse( QByteArray* ba, const QString& infoFormat ) = 0;
     virtual void setGetFeatureResponse( QByteArray* ba ) = 0;

--- a/src/server/qgssoaprequesthandler.cpp
+++ b/src/server/qgssoaprequesthandler.cpp
@@ -394,7 +394,7 @@ void QgsSOAPRequestHandler::setGetFeatureInfoResponse( const QDomDocument& infoD
   setHttpResponse( &ba, "text/xml" );
 }
 
-void QgsSOAPRequestHandler::setGetStyleResponse( const QDomDocument& infoDoc )
+void QgsSOAPRequestHandler::setXmlResponse( const QDomDocument& infoDoc )
 {
   QDomDocument featureInfoResponseDoc;
 
@@ -413,6 +413,12 @@ void QgsSOAPRequestHandler::setGetStyleResponse( const QDomDocument& infoDoc )
   //now set message
   QByteArray ba = featureInfoResponseDoc.toByteArray();
   setHttpResponse( &ba, "text/xml" );
+}
+
+void QgsSOAPRequestHandler::setXmlResponse( const QDomDocument& infoDoc, const QString& mimeType )
+{
+  Q_UNUSED( mimeType );
+  setXmlResponse( infoDoc );
 }
 
 void QgsSOAPRequestHandler::setGetPrintResponse( QByteArray* ba ) const

--- a/src/server/qgssoaprequesthandler.h
+++ b/src/server/qgssoaprequesthandler.h
@@ -33,7 +33,8 @@ class QgsSOAPRequestHandler: public QgsHttpRequestHandler
     void setGetCapabilitiesResponse( const QDomDocument& doc );
     void setGetFeatureInfoResponse( const QDomDocument& infoDoc, const QString& infoFormat );
     void setServiceException( const QgsMapServiceException& ex );
-    void setGetStyleResponse( const QDomDocument& doc );
+    void setXmlResponse( const QDomDocument& doc );
+    void setXmlResponse( const QDomDocument& doc, const QString& mimeType );
     void setGetPrintResponse( QByteArray* ba ) const;
   private:
     /**Parses the xml of a getMap request and fills the parameters into the map. Returns 0 in case of success*/

--- a/src/server/qgswmsserver.cpp
+++ b/src/server/qgswmsserver.cpp
@@ -37,6 +37,7 @@
 #include "qgsvectordataprovider.h"
 #include "qgsvectorlayer.h"
 #include "qgslogger.h"
+#include "qgsmessagelog.h"
 #include "qgsmapserviceexception.h"
 #include "qgssldconfigparser.h"
 #include "qgssymbolv2.h"
@@ -199,7 +200,20 @@ void QgsWMSServer::executeRequest()
     try
     {
       QDomDocument doc = getContext();
-      mRequestHandler->setGetStyleResponse( doc );
+      mRequestHandler->setXmlResponse( doc );
+    }
+    catch ( QgsMapServiceException& ex )
+    {
+      mRequestHandler->setServiceException( ex );
+    }
+  }
+  //GetSchemaExtension
+  else if ( request.compare( "GetSchemaExtension", Qt::CaseInsensitive ) == 0 )
+  {
+    try
+    {
+      QDomDocument doc = getSchemaExtension();
+      mRequestHandler->setXmlResponse( doc );
     }
     catch ( QgsMapServiceException& ex )
     {
@@ -212,7 +226,7 @@ void QgsWMSServer::executeRequest()
     try
     {
       QDomDocument doc = getStyle();
-      mRequestHandler->setGetStyleResponse( doc );
+      mRequestHandler->setXmlResponse( doc );
     }
     catch ( QgsMapServiceException& ex )
     {
@@ -222,23 +236,17 @@ void QgsWMSServer::executeRequest()
   //GetStyles
   else if ( request.compare( "GetStyles", Qt::CaseInsensitive ) == 0 )
   {
-    // GetStyles is only defined for WMS1.1.1/SLD1.0
-    if ( version != "1.1.1" )
-    {
-      mRequestHandler->setServiceException( QgsMapServiceException( "OperationNotSupported", "GetStyles method is only available in WMS version 1.1.1" ) );
-    }
-    else
-    {
-      try
-      {
-        QDomDocument doc = getStyles();
-        mRequestHandler->setGetStyleResponse( doc );
-      }
-      catch ( QgsMapServiceException& ex )
-      {
-        mRequestHandler->setServiceException( ex );
-      }
-    }
+    // GetStyles is defined for WMS1.1.1/SLD1.0
+    // and in qgis-server WMS1.3.0 extension
+	  try
+	  {
+      QDomDocument doc = getStyles();
+      mRequestHandler->setXmlResponse( doc );
+	  }
+	  catch ( QgsMapServiceException& ex )
+	  {
+      mRequestHandler->setServiceException( ex );
+	  }
   }
   //GetLegendGraphic
   else if ( request.compare( "GetLegendGraphic", Qt::CaseInsensitive ) == 0 ||
@@ -313,6 +321,13 @@ QDomDocument QgsWMSServer::getCapabilities( QString version, bool fullProjectInf
   QDomDocument doc;
   QDomElement wmsCapabilitiesElement;
 
+  //Prepare url
+  QString hrefString = mConfigParser->serviceUrl();
+  if ( hrefString.isEmpty() )
+  {
+    hrefString = serviceUrl();
+  }
+
   if ( version == "1.1.1" )
   {
     doc = QDomDocument( "WMT_MS_Capabilities SYSTEM 'http://schemas.opengis.net/wms/1.1.1/WMS_MS_Capabilities.dtd'" );  //WMS 1.1.1 needs DOCTYPE  "SYSTEM http://schemas.opengis.net/wms/1.1.1/WMS_MS_Capabilities.dtd"
@@ -324,8 +339,16 @@ QDomDocument QgsWMSServer::getCapabilities( QString version, bool fullProjectInf
     addXMLDeclaration( doc );
     wmsCapabilitiesElement = doc.createElement( "WMS_Capabilities"/*wms:WMS_Capabilities*/ );
     wmsCapabilitiesElement.setAttribute( "xmlns", "http://www.opengis.net/wms" );
+    wmsCapabilitiesElement.setAttribute( "xmlns:sld", "http://www.opengis.net/sld" );
+    wmsCapabilitiesElement.setAttribute( "xmlns:qgs", "http://www.qgis.org/wms" );
     wmsCapabilitiesElement.setAttribute( "xmlns:xsi", "http://www.w3.org/2001/XMLSchema-instance" );
-    wmsCapabilitiesElement.setAttribute( "xsi:schemaLocation", "http://www.opengis.net/wms http://qgis.org/wms_1_3_0.xsd" );
+    QString schemaLocation = "http://www.opengis.net/wms";
+    schemaLocation += " http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd";
+    schemaLocation += " http://www.opengis.net/sld";
+    schemaLocation += " http://schemas.opengis.net/sld/1.1.0/sld_capabilities.xsd";
+    schemaLocation += " http://www.qgis.org/wms";
+    schemaLocation += " "+ hrefString +"SERVICE=WMS&REQUEST=GetSchemaExtension";
+    wmsCapabilitiesElement.setAttribute( "xsi:schemaLocation", schemaLocation );
   }
   wmsCapabilitiesElement.setAttribute( "version", version );
   doc.appendChild( wmsCapabilitiesElement );
@@ -354,14 +377,6 @@ QDomDocument QgsWMSServer::getCapabilities( QString version, bool fullProjectInf
   appendFormats( doc, elem, QStringList() << ( version == "1.1.1" ? "application/vnd.ogc.wms_xml" : "text/xml" ) );
   elem.appendChild( dcpTypeElement );
   requestElement.appendChild( elem );
-
-  //Prepare url
-  QString hrefString = mConfigParser->serviceUrl();
-  if ( hrefString.isEmpty() )
-  {
-    hrefString = serviceUrl();
-  }
-
 
   // SOAP platform
   //only give this information if it is not a WMS request to be in sync with the WMS capabilities schema
@@ -411,19 +426,19 @@ QDomDocument QgsWMSServer::getCapabilities( QString version, bool fullProjectInf
   requestElement.appendChild( elem );
 
   //wms:GetLegendGraphic
-  elem = doc.createElement( "GetLegendGraphic"/*wms:GetLegendGraphic*/ );
+  elem = doc.createElement( ( version == "1.1.1" ? "GetLegendGraphic" : "sld:GetLegendGraphic" )/*wms:GetLegendGraphic*/ );
   appendFormats( doc, elem, QStringList() << "image/jpeg" << "image/png" );
   elem.appendChild( dcpTypeElement.cloneNode().toElement() ); // this is the same as for 'GetCapabilities'
   requestElement.appendChild( elem );
 
   //wms:GetStyles
-  elem = doc.createElement( "GetStyles"/*wms:GetStyles*/ );
+  elem = doc.createElement( ( version == "1.1.1" ? "GetStyles" : "qgs:GetStyles" )/*wms:GetStyles*/ );
   appendFormats( doc, elem, QStringList() << "text/xml" );
   elem.appendChild( dcpTypeElement.cloneNode().toElement() ); //this is the same as for 'GetCapabilities'
   requestElement.appendChild( elem );
 
   //wms:GetPrint
-  elem = doc.createElement( "GetPrint"/*wms:GetPrint*/ );
+  elem = doc.createElement( ( version == "1.1.1" ? "GetPrint" : "qgs:GetPrint" ) /*wms:GetPrint*/ );
   appendFormats( doc, elem, QStringList() << "svg" << "png" << "pdf" );
   elem.appendChild( dcpTypeElement.cloneNode().toElement() ); //this is the same as for 'GetCapabilities'
   requestElement.appendChild( elem );
@@ -956,6 +971,42 @@ void QgsWMSServer::legendParameters( double& boxSpace, double& layerSpace, doubl
   }
 }
 
+QDomDocument QgsWMSServer::getSchemaExtension()
+{
+  QDomDocument xsdDoc;
+  
+  QFileInfo xsdFileInfo( "schemaExtension.xsd" );
+  if ( !xsdFileInfo.exists() )
+  {
+    QgsMessageLog::logMessage( "Error, xsd file 'schemaExtension.xsd' does not exist", "Server", QgsMessageLog::CRITICAL );
+    return xsdDoc;
+  }
+  
+  QString xsdFilePath = xsdFileInfo.absoluteFilePath();
+  QFile xsdFile( xsdFilePath );
+  if ( !xsdFile.exists() )
+  {
+    QgsMessageLog::logMessage( "Error, xsd file 'schemaExtension.xsd' does not exist", "Server", QgsMessageLog::CRITICAL );
+    return xsdDoc;
+  }
+  
+  if ( !xsdFile.open( QIODevice::ReadOnly ) )
+  {
+    QgsMessageLog::logMessage( "Error, cannot open xsd file 'schemaExtension.xsd' does not exist", "Server", QgsMessageLog::CRITICAL );
+    return xsdDoc;
+  }
+  
+  QString errorMsg;
+  int line, column;
+  if ( !xsdDoc.setContent( &xsdFile, true, &errorMsg, &line, &column ) )
+  {
+    QgsMessageLog::logMessage( "Error parsing file 'schemaExtension.xsd" +
+                               QString( "': parse error %1 at row %2, column %3" ).arg( errorMsg ).arg( line ).arg( column ), "Server", QgsMessageLog::CRITICAL );
+    return xsdDoc;
+  }
+  return xsdDoc;
+}
+
 QDomDocument QgsWMSServer::getStyle()
 {
   QDomDocument doc;
@@ -975,7 +1026,7 @@ QDomDocument QgsWMSServer::getStyle()
   return mConfigParser->getStyle( styleName, layerName );
 }
 
-// GetStyles is only defined for WMS1.1.1/SLD1.0
+// GetStyles is defined for WMS1.1.1/SLD1.0 and in WMS 1.3.0 SLD Extension
 QDomDocument QgsWMSServer::getStyles()
 {
   QDomDocument doc;

--- a/src/server/qgswmsserver.cpp
+++ b/src/server/qgswmsserver.cpp
@@ -437,18 +437,21 @@ QDomDocument QgsWMSServer::getCapabilities( QString version, bool fullProjectInf
   elem.appendChild( dcpTypeElement.cloneNode().toElement() ); //this is the same as for 'GetCapabilities'
   requestElement.appendChild( elem );
 
-  //wms:GetPrint
-  elem = doc.createElement( ( version == "1.1.1" ? "GetPrint" : "qgs:GetPrint" ) /*wms:GetPrint*/ );
-  appendFormats( doc, elem, QStringList() << "svg" << "png" << "pdf" );
-  elem.appendChild( dcpTypeElement.cloneNode().toElement() ); //this is the same as for 'GetCapabilities'
-  requestElement.appendChild( elem );
+  if ( fullProjectInformation ) //remove composer templates from GetCapabilities in the long term
+  {
+    //wms:GetPrint
+    elem = doc.createElement( "GetPrint" /*wms:GetPrint*/ );
+    appendFormats( doc, elem, QStringList() << "svg" << "png" << "pdf" );
+    elem.appendChild( dcpTypeElement.cloneNode().toElement() ); //this is the same as for 'GetCapabilities'
+    requestElement.appendChild( elem );
+  }
 
   //Exception element is mandatory
   elem = doc.createElement( "Exception" );
   appendFormats( doc, elem, QStringList() << ( version == "1.1.1" ? "application/vnd.ogc.se_xml" : "text/xml" ) );
   capabilityElement.appendChild( elem );
 
-  if ( mConfigParser /*&& fullProjectInformation*/ ) //remove composer templates from GetCapabilities in the long term
+  if ( mConfigParser && fullProjectInformation ) //remove composer templates from GetCapabilities in the long term
   {
     //Insert <ComposerTemplate> elements derived from wms:_ExtendedCapabilities
     mConfigParser->printCapabilities( capabilityElement, doc );

--- a/src/server/qgswmsserver.h
+++ b/src/server/qgswmsserver.h
@@ -100,6 +100,9 @@ class QgsWMSServer: public QgsOWSServer
 
     /**Sets configuration parser for administration settings. Does not take ownership*/
     void setAdminConfigParser( QgsWMSConfigParser* parser ) { mConfigParser = parser; }
+    
+    /**Returns the schemaExtension for WMS 1.3.0 capabilities*/
+    QDomDocument getSchemaExtension();
 
   private:
     /**Don't use the default constructor*/

--- a/src/server/schemaExtension.xsd
+++ b/src/server/schemaExtension.xsd
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<schema xmlns="http://www.w3.org/2001/XMLSchema" xmlns:wms="http://www.opengis.net/wms" xmlns:qgs="http://www.qgis.org/wms" targetNamespace="http://www.qgis.org/wms" elementFormDefault="qualified" version="1.0.0">
+  <import namespace="http://www.opengis.net/wms" schemaLocation="http://schemas.opengis.net/wms/1.3.0/capabilities_1_3_0.xsd"/>
+  <element name="GetPrint" type="wms:OperationType" substitutionGroup="wms:_ExtendedOperation" />
+  <element name="GetStyles" type="wms:OperationType" substitutionGroup="wms:_ExtendedOperation" />
+</schema>


### PR DESCRIPTION
...ompliant

To be fully compliant with WMS 1.3.0 standard, I propose to add :
- SLD namespace for GetLegendGraphic element
- schemaExtension.xsd distributed with QGIS-Server for GetStyles and GetPrint
- GetSchemaExtension to retrieve schemaExtension.xsd like MapServer

The solution was inspired by
 http://demo.mapserver.org/cgi-bin/wms?SERVICE=WMS&VERSION=1.3.0&REQUEST=GetCapabilities
And the standard description
Styled Layer Descriptor profile of the Web Map Service Implementation Specification
http://portal.opengeospatial.org/files/?artifact_id=22364
