### PR TITLE
Store result of OGR_FD_GetGeomType into a OGRwkbGeometryType, not in an int, ...

### DIFF
--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -650,7 +650,7 @@ bool QgsVectorLayer::hasGeometryType() const
 
 QGis::WkbType QgsVectorLayer::wkbType() const
 {
-  return ( QGis::WkbType )( mWkbType );
+  return mWkbType;
 }
 
 QgsRectangle QgsVectorLayer::boundingBoxOfSelected()
@@ -2143,7 +2143,7 @@ bool QgsVectorLayer::deleteAttributes( QList<int> attrs )
 
   qSort( attrs.begin(), attrs.end(), qGreater<int>() );
 
-  Q_FOREACH ( int attr, attrs )
+  Q_FOREACH( int attr, attrs )
   {
     if ( deleteAttribute( attr ) )
     {
@@ -2839,7 +2839,7 @@ void QgsVectorLayer::uniqueValues( int index, QList<QVariant> &uniqueValues, int
     if ( mEditBuffer )
     {
       QSet<QString> vals;
-      Q_FOREACH ( const QVariant& v, uniqueValues )
+      Q_FOREACH( const QVariant& v, uniqueValues )
       {
         vals << v.toString();
       }
@@ -3565,13 +3565,13 @@ void QgsVectorLayer::invalidateSymbolCountedFlag()
 
 void QgsVectorLayer::onRelationsLoaded()
 {
-  Q_FOREACH ( QgsAttributeEditorElement* elem, mAttributeEditorElements )
+  Q_FOREACH( QgsAttributeEditorElement* elem, mAttributeEditorElements )
   {
     if ( elem->type() == QgsAttributeEditorElement::AeTypeContainer )
     {
       QgsAttributeEditorContainer* cont = dynamic_cast< QgsAttributeEditorContainer* >( elem );
       QList<QgsAttributeEditorElement*> relations = cont->findElements( QgsAttributeEditorElement::AeTypeRelation );
-      Q_FOREACH ( QgsAttributeEditorElement* relElem, relations )
+      Q_FOREACH( QgsAttributeEditorElement* relElem, relations )
       {
         QgsAttributeEditorRelation* rel = dynamic_cast< QgsAttributeEditorRelation* >( relElem );
         rel->init( QgsProject::instance()->relationManager() );
@@ -3627,7 +3627,7 @@ QDomElement QgsAttributeEditorContainer::toDomElement( QDomDocument& doc ) const
   QDomElement elem = doc.createElement( "attributeEditorContainer" );
   elem.setAttribute( "name", mName );
 
-  Q_FOREACH ( QgsAttributeEditorElement* child, mChildren )
+  Q_FOREACH( QgsAttributeEditorElement* child, mChildren )
   {
     elem.appendChild( child->toDomElement( doc ) );
   }
@@ -3643,7 +3643,7 @@ QList<QgsAttributeEditorElement*> QgsAttributeEditorContainer::findElements( Qgs
 {
   QList<QgsAttributeEditorElement*> results;
 
-  Q_FOREACH ( QgsAttributeEditorElement* elem, mChildren )
+  Q_FOREACH( QgsAttributeEditorElement* elem, mChildren )
   {
     if ( elem->type() == type )
     {

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -1735,7 +1735,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
     QList< TabData > mTabs;
 
     /** Geometry type as defined in enum WkbType (qgis.h) */
-    int mWkbType;
+    QGis::WkbType mWkbType;
 
     /** Renderer object which holds the information about how to display the features */
     QgsFeatureRendererV2 *mRendererV2;

--- a/src/providers/ogr/qgsogrdataitems.cpp
+++ b/src/providers/ogr/qgsogrdataitems.cpp
@@ -140,7 +140,7 @@ static QgsOgrLayerItem* dataItemForLayer( QgsDataItem* parentItem, QString name,
   OGRFeatureDefnH hDef = OGR_L_GetLayerDefn( hLayer );
 
   QgsLayerItem::LayerType layerType = QgsLayerItem::Vector;
-  int ogrType = QgsOgrProvider::getOgrGeomType( hLayer );
+  OGRwkbGeometryType ogrType = QgsOgrProvider::getOgrGeomType( hLayer );
   switch ( ogrType )
   {
     case wkbUnknown:

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -695,10 +695,10 @@ void QgsOgrProvider::setEncoding( const QString& e )
 }
 
 // This is reused by dataItem
-int QgsOgrProvider::getOgrGeomType( OGRLayerH ogrLayer )
+OGRwkbGeometryType QgsOgrProvider::getOgrGeomType( OGRLayerH ogrLayer )
 {
   OGRFeatureDefnH fdef = OGR_L_GetLayerDefn( ogrLayer );
-  int geomType = wkbUnknown;
+  OGRwkbGeometryType geomType = wkbUnknown;
   if ( fdef )
   {
     geomType = OGR_FD_GetGeomType( fdef );
@@ -935,7 +935,7 @@ size_t QgsOgrProvider::layerCount() const
  */
 QGis::WkbType QgsOgrProvider::geometryType() const
 {
-  return ( QGis::WkbType ) geomType;
+  return static_cast<QGis::WkbType>( geomType );
 }
 
 /**

--- a/src/providers/ogr/qgsogrprovider.h
+++ b/src/providers/ogr/qgsogrprovider.h
@@ -248,7 +248,7 @@ class QgsOgrProvider : public QgsVectorDataProvider
     virtual bool doesStrictFeatureTypeCheck() const { return false;}
 
     /** return OGR geometry type */
-    static int getOgrGeomType( OGRLayerH ogrLayer );
+    static OGRwkbGeometryType getOgrGeomType( OGRLayerH ogrLayer );
 
     /** Get single flatten geometry type */
     static OGRwkbGeometryType ogrWkbSingleFlatten( OGRwkbGeometryType type );
@@ -325,7 +325,7 @@ class QgsOgrProvider : public QgsVectorDataProvider
     bool valid;
     //! Flag to indicate that spatial intersect should be used in selecting features
     bool mUseIntersect;
-    int geomType;
+    OGRwkbGeometryType geomType;
     long featuresCounted;
 
     //! Data has been modified - REPACK before creating a spatialindex


### PR DESCRIPTION
In `qgsogrprovider.cpp`, the result of `OGR_FD_GetGeomType` (which returns an `OGRwkbGeometryType`) is assigned to an `int`. All 2.5 D fields of `OGRwkbGeometryType` cause the signed int to overflow (`int32_t` overflows after `0x7FFFFFFF`):

```
wkbPoint25D = 0x80000001, /**< 2.5D extension as per 99-402 */
wkbLineString25D = 0x80000002, /**< 2.5D extension as per 99-402 */
wkbPolygon25D = 0x80000003, /**< 2.5D extension as per 99-402 */
wkbMultiPoint25D = 0x80000004, /**< 2.5D extension as per 99-402 */
wkbMultiLineString25D = 0x80000005, /**< 2.5D extension as per 99-402 */
wkbMultiPolygon25D = 0x80000006, /**< 2.5D extension as per 99-402 */
wkbGeometryCollection25D = 0x80000007 /**< 2.5D extension as per 99-402 */
```

Since the value is later casted to a `QGis::WkbType`, this should not be an issue on most platforms, assuming the compiler will choose `QGis::WkbType` to be an `uint32_t`, and hence the value overflows back. However, since the compiler is allowed to freely choose the integer type to use for an enum, this is not robust.

Similar situation arises with `QgsVectorLayer::mWkbType` being an int, and it being assigned a `Qgis::WkbType`.

This commit changes the types to ensure no potentially dangerous casts are performed.

Funded by Sourcepole
