### PR TITLE
[expressions] Make int/int return double results

### DIFF
--- a/python/core/qgsexpression.sip
+++ b/python/core/qgsexpression.sip
@@ -150,6 +150,7 @@ class QgsExpression
       boMinus,
       boMul,
       boDiv,
+      boIntDiv,
       boMod,
       boPow,
 

--- a/src/core/qgsexpression.h
+++ b/src/core/qgsexpression.h
@@ -241,6 +241,7 @@ class CORE_EXPORT QgsExpression
       boMinus,
       boMul,
       boDiv,
+      boIntDiv,
       boMod,
       boPow,
 

--- a/src/core/qgsexpressionlexer.ll
+++ b/src/core/qgsexpressionlexer.ll
@@ -155,6 +155,7 @@ string      "'"{str_char}*"'"
 "+"  { B_OP(boPlus); return PLUS; }
 "-"  { B_OP(boMinus); return MINUS; }
 "*"  { B_OP(boMul); return MUL; }
+"//"  { B_OP(boIntDiv); return INTDIV; }
 "/"  { B_OP(boDiv); return DIV; }
 "%"  { B_OP(boMod); return MOD; }
 "^"  { B_OP(boPow); return POW; }

--- a/src/core/qgsexpressionparser.yy
+++ b/src/core/qgsexpressionparser.yy
@@ -94,7 +94,7 @@ struct expression_parser_context
 //
 
 // operator tokens
-%token <b_op> OR AND EQ NE LE GE LT GT REGEXP LIKE IS PLUS MINUS MUL DIV MOD CONCAT POW
+%token <b_op> OR AND EQ NE LE GE LT GT REGEXP LIKE IS PLUS MINUS MUL DIV INTDIV MOD CONCAT POW
 %token <u_op> NOT
 %token IN
 
@@ -136,7 +136,7 @@ struct expression_parser_context
 %right NOT
 %left EQ NE LE GE LT GT REGEXP LIKE IS IN
 %left PLUS MINUS
-%left MUL DIV MOD
+%left MUL DIV INTDIV MOD
 %right POW
 %left CONCAT
 
@@ -168,6 +168,7 @@ expression:
     | expression PLUS expression      { $$ = BINOP($2, $1, $3); }
     | expression MINUS expression     { $$ = BINOP($2, $1, $3); }
     | expression MUL expression       { $$ = BINOP($2, $1, $3); }
+    | expression INTDIV expression    { $$ = BINOP($2, $1, $3); }
     | expression DIV expression       { $$ = BINOP($2, $1, $3); }
     | expression MOD expression       { $$ = BINOP($2, $1, $3); }
     | expression POW expression       { $$ = BINOP($2, $1, $3); }

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -172,7 +172,7 @@ class TestQgsExpression: public QObject
       QTest::newRow( "plus invalid" ) << "1+'foo'" << true << QVariant();
       QTest::newRow( "minus int" ) << "1-3" << false << QVariant( -2 );
       QTest::newRow( "mul int" ) << "8*7" << false << QVariant( 56 );
-      QTest::newRow( "div int" ) << "20/6" << false << QVariant( 3 );
+      QTest::newRow( "div int" ) << "5/2" << false << QVariant( 2.5 );
       QTest::newRow( "mod int" ) << "20%6" << false << QVariant( 2 );
       QTest::newRow( "minus double" ) << "5.2-3.1" << false << QVariant( 2.1 );
       QTest::newRow( "mul double" ) << "2.1*5" << false << QVariant( 10.5 );
@@ -181,6 +181,12 @@ class TestQgsExpression: public QObject
       QTest::newRow( "pow" ) << "2^8" << false << QVariant( 256. );
       QTest::newRow( "division by zero" ) << "1/0" << false << QVariant();
       QTest::newRow( "division by zero" ) << "1.0/0.0" << false << QVariant();
+      QTest::newRow( "int division" ) << "5//2" << false << QVariant( 2 );
+      QTest::newRow( "int division with doubles" ) << "5.0//2.0" << false << QVariant( 2 );
+      QTest::newRow( "negative int division" ) << "-5//2" << false << QVariant( -3 );
+      QTest::newRow( "negative int division with doubles" ) << "-5.0//2.0" << false << QVariant( -3 );
+      QTest::newRow( "int division by zero" ) << "1//0" << false << QVariant();
+      QTest::newRow( "int division by zero with floats" ) << "1.0//0.0" << false << QVariant();
 
       // comparison
       QTest::newRow( "eq int" ) << "1+1 = 2" << false << QVariant( 1 );


### PR DESCRIPTION
The new default is for int/int = double result, which is much more predictable for users from a non-programming background. It also matches the behaviour of ArcGIS, MapInfo, python >= 3, Excel, ... 

A new operator "//" has been added to force integer division. This matches the behaviour of python >= 3.
