### PR TITLE
[labeling] allows data defined to align multiline when wordwrap function is used as expression (fix #11805)

### DIFF
--- a/src/core/qgspallabeling.cpp
+++ b/src/core/qgspallabeling.cpp
@@ -3554,7 +3554,7 @@ void QgsPalLabeling::dataDefinedTextFormatting( QgsPalLayerSettings& tmpLyr,
     tmpLyr.wrapChar = ddValues.value( QgsPalLayerSettings::MultiLineWrapChar ).toString();
   }
 
-  if ( !tmpLyr.wrapChar.isEmpty() )
+  if ( !tmpLyr.wrapChar.isEmpty() || tmpLyr.getLabelExpression()->expression().contains( "wordwrap" ) )
   {
 
     if ( ddValues.contains( QgsPalLayerSettings::MultiLineHeight ) )


### PR DESCRIPTION
Currently it is not possible to use data defined to align multiline text if wordwrap function is used for the label expression. This change allows to do it working. See: http://hub.qgis.org/issues/11805
