### PR TITLE
Render incremental rendering image at proper location

### DIFF
--- a/src/core/qgsmaprendererjob.cpp
+++ b/src/core/qgsmaprendererjob.cpp
@@ -56,6 +56,11 @@ void QgsMapRendererJob::setCache( QgsMapRendererCache* cache )
   mCache = cache;
 }
 
+const QgsMapSettings& QgsMapRendererJob::mapSettings() const
+{
+  return mSettings;
+}
+
 
 bool QgsMapRendererJob::reprojectToLayerExtent( const QgsCoordinateTransform* ct, bool layerCrsGeographic, QgsRectangle& extent, QgsRectangle& r2 )
 {

--- a/src/core/qgsmaprendererjob.h
+++ b/src/core/qgsmaprendererjob.h
@@ -126,6 +126,9 @@ class CORE_EXPORT QgsMapRendererJob : public QObject
     //! Find out how log it took to finish the job (in miliseconds)
     int renderingTime() const { return mRenderingTime; }
 
+    //! Return map settings with which this job was started
+    const QgsMapSettings& mapSettings() const;
+
   signals:
 
     //! emitted when asynchronous rendering is finished (or canceled).

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -737,9 +737,8 @@ void QgsMapCanvas::rendererJobFinished()
 
 void QgsMapCanvas::mapUpdateTimeout()
 {
-  mMap->setContent( mJob->renderedImage(), mSettings.visibleExtent() );
+  mMap->setContent( mJob->renderedImage(), mJob->mapSettings().visibleExtent() );
 }
-
 
 void QgsMapCanvas::stopRendering()
 {


### PR DESCRIPTION
The old behavior was to render it at the currently visibleExtent based on the
map canvas. The job may however originally have been scheduled for a different extent (calling `refresh()` only delayed for performance reasons) and therefore rendered at an improper location.
