### PR TITLE
Rotation labels

### DIFF
--- a/src/core/qgspallabeling.cpp
+++ b/src/core/qgspallabeling.cpp
@@ -4121,16 +4121,14 @@ QgsPalLabeling::Search QgsPalLabeling::searchMethod() const
 void QgsPalLabeling::drawLabelCandidateRect( pal::LabelPosition* lp, QPainter* painter, const QgsMapToPixel* xform )
 {
   QgsPoint outPt = xform->transform( lp->getX(), lp->getY() );
+  QgsPoint outPt2 = xform->transform( lp->getX() + lp->getWidth(), lp->getY() + lp->getHeight() );
 
   painter->save();
 
-  double rotation = xform->mapRotation();
   QRectF rect;
-    QgsPoint outPt2 = xform->transform( lp->getX() + lp->getWidth(), lp->getY() + lp->getHeight() );
-    rect = QRectF( 0, 0, outPt2.x() - outPt.x(), outPt2.y() - outPt.y() );
-    painter->translate( QPointF( outPt.x(), outPt.y() ) );
-    painter->rotate( -lp->getAlpha() * 180 / M_PI );
-
+  painter->translate( QPointF( outPt.x(), outPt.y() ) );
+  painter->rotate( -lp->getAlpha() * 180 / M_PI );
+  rect = QRectF( 0, 0, outPt2.x() - outPt.x(), outPt2.y() - outPt.y() );
   painter->drawRect( rect );
   painter->restore();
 
@@ -4182,7 +4180,7 @@ void QgsPalLabeling::drawLabel( pal::LabelPosition* label, QgsRenderContext& con
     drawLabelBackground( context, component, tmpLyr );
   }
 
-  else if ( drawType == QgsPalLabeling::LabelBuffer
+  if ( drawType == QgsPalLabeling::LabelBuffer
        || drawType == QgsPalLabeling::LabelText )
   {
 
@@ -4265,8 +4263,8 @@ void QgsPalLabeling::drawLabel( pal::LabelPosition* label, QgsRenderContext& con
     for ( int i = 0; i < lines; ++i )
     {
       painter->save();
-        painter->translate( QPointF( outPt.x(), outPt.y() ) );
-        painter->rotate( -label->getAlpha() * 180 / M_PI );
+      painter->translate( QPointF( outPt.x(), outPt.y() ) );
+      painter->rotate( -label->getAlpha() * 180 / M_PI );
 
       // scale down painter: the font size has been multiplied by raster scale factor
       // to workaround a Qt font scaling bug with small font sizes

--- a/src/core/qgspallabeling.cpp
+++ b/src/core/qgspallabeling.cpp
@@ -4126,32 +4126,10 @@ void QgsPalLabeling::drawLabelCandidateRect( pal::LabelPosition* lp, QPainter* p
 
   double rotation = xform->mapRotation();
   QRectF rect;
-  if ( rotation ) {
-    double w = lp->getWidth();
-    double h = lp->getHeight();
-    double cx = lp->getX() + w/2.0;
-    double cy = lp->getY() + h/2.0;
-    double scale = 1.0/xform->mapUnitsPerPixel();
-    double sw = w * scale;
-    double sh = h * scale;
-    rect = QRectF( -sw/2, -sh/2, sw, sh );
-
-    painter->translate( xform->transform( QPointF(cx, cy) ).toQPointF() );
-    if ( rotation ) {
-      // Only if not horizontal
-      if ( lp->getFeaturePart()->getLayer()->getArrangement() != P_HORIZ ) {
-        painter->rotate( rotation );
-      }
-    }
-    painter->translate( rect.bottomLeft() );
-    painter->rotate( -lp->getAlpha() * 180 / M_PI );
-    painter->translate( -rect.bottomLeft() );
-  } else {
     QgsPoint outPt2 = xform->transform( lp->getX() + lp->getWidth(), lp->getY() + lp->getHeight() );
     rect = QRectF( 0, 0, outPt2.x() - outPt.x(), outPt2.y() - outPt.y() );
     painter->translate( QPointF( outPt.x(), outPt.y() ) );
     painter->rotate( -lp->getAlpha() * 180 / M_PI );
-  }
 
   painter->drawRect( rect );
   painter->restore();
@@ -4287,30 +4265,8 @@ void QgsPalLabeling::drawLabel( pal::LabelPosition* label, QgsRenderContext& con
     for ( int i = 0; i < lines; ++i )
     {
       painter->save();
-      double rotation = xform->mapRotation();
-      if ( rotation ) {
-        LabelPosition* lp = label;
-        double w = lp->getWidth();
-        double h = lp->getHeight();
-        double cx = lp->getX() + w/2.0;
-        double cy = lp->getY() + h/2.0;
-        double scale = 1.0/xform->mapUnitsPerPixel();
-        double sw = w * scale;
-        double sh = h * scale;
-        QRectF rect( -sw/2, -sh/2, sw, sh );
-        painter->translate( xform->transform( QPointF(cx, cy) ).toQPointF() );
-        if ( rotation ) {
-          // Only if not horizontal
-          if ( lp->getFeaturePart()->getLayer()->getArrangement() != P_HORIZ ) {
-            painter->rotate( rotation );
-          }
-        }
-        painter->translate( rect.bottomLeft() );
-        painter->rotate( -lp->getAlpha() * 180 / M_PI );
-      } else {
         painter->translate( QPointF( outPt.x(), outPt.y() ) );
         painter->rotate( -label->getAlpha() * 180 / M_PI );
-      }
 
       // scale down painter: the font size has been multiplied by raster scale factor
       // to workaround a Qt font scaling bug with small font sizes

--- a/src/core/qgspallabeling.cpp
+++ b/src/core/qgspallabeling.cpp
@@ -1415,10 +1415,16 @@ void QgsPalLayerSettings::calculateLabelSize( const QFontMetricsF* fm, QString t
     }
   }
   w /= rasterCompressFactor;
-  QgsPoint ptSize = xform->toMapCoordinatesF( w, h );
 
+#if 0 // XXX strk
+  QgsPoint ptSize = xform->toMapCoordinatesF( w, h );
   labelX = qAbs( ptSize.x() - ptZero.x() );
   labelY = qAbs( ptSize.y() - ptZero.y() );
+#else
+  double uPP = xform->mapUnitsPerPixel();
+  labelX = w * uPP;
+  labelY = h * uPP;
+#endif
 }
 
 void QgsPalLayerSettings::registerFeature( QgsFeature& f, const QgsRenderContext& context, QString dxfLayer )

--- a/src/core/qgspallabeling.cpp
+++ b/src/core/qgspallabeling.cpp
@@ -1416,7 +1416,7 @@ void QgsPalLayerSettings::calculateLabelSize( const QFontMetricsF* fm, QString t
   }
   w /= rasterCompressFactor;
 
-#if 0 // XXX strk
+#if 1 // XXX strk
   QgsPoint ptSize = xform->toMapCoordinatesF( w, h );
   labelX = qAbs( ptSize.x() - ptZero.x() );
   labelY = qAbs( ptSize.y() - ptZero.y() );

--- a/src/core/qgspallabeling.cpp
+++ b/src/core/qgspallabeling.cpp
@@ -4121,12 +4121,37 @@ QgsPalLabeling::Search QgsPalLabeling::searchMethod() const
 void QgsPalLabeling::drawLabelCandidateRect( pal::LabelPosition* lp, QPainter* painter, const QgsMapToPixel* xform )
 {
   QgsPoint outPt = xform->transform( lp->getX(), lp->getY() );
-  QgsPoint outPt2 = xform->transform( lp->getX() + lp->getWidth(), lp->getY() + lp->getHeight() );
 
   painter->save();
+
+#if 1 // TODO: generalize some of this
+  double w = lp->getWidth();
+  double h = lp->getHeight();
+  double cx = lp->getX() + w/2.0;
+  double cy = lp->getY() + h/2.0;
+  double scale = 1.0/xform->mapUnitsPerPixel();
+  double rotation = xform->mapRotation();
+  double sw = w * scale;
+  double sh = h * scale;
+  QRectF rect( -sw/2, -sh/2, sw, sh );
+
+  painter->translate( xform->transform( QPointF(cx, cy) ).toQPointF() );
+  if ( rotation ) {
+    // Only if not horizontal
+    if ( lp->getFeaturePart()->getLayer()->getArrangement() != P_HORIZ ) {
+      painter->rotate( rotation );
+    }
+  }
+  painter->translate( rect.bottomLeft() );
+  painter->rotate( -lp->getAlpha() * 180 / M_PI );
+  painter->translate( -rect.bottomLeft() );
+#else
+  QgsPoint outPt2 = xform->transform( lp->getX() + lp->getWidth(), lp->getY() + lp->getHeight() );
+  QRectF rect( 0, 0, outPt2.x() - outPt.x(), outPt2.y() - outPt.y() );
   painter->translate( QPointF( outPt.x(), outPt.y() ) );
   painter->rotate( -lp->getAlpha() * 180 / M_PI );
-  QRectF rect( 0, 0, outPt2.x() - outPt.x(), outPt2.y() - outPt.y() );
+#endif
+
   painter->drawRect( rect );
   painter->restore();
 
@@ -4178,7 +4203,7 @@ void QgsPalLabeling::drawLabel( pal::LabelPosition* label, QgsRenderContext& con
     drawLabelBackground( context, component, tmpLyr );
   }
 
-  if ( drawType == QgsPalLabeling::LabelBuffer
+  else if ( drawType == QgsPalLabeling::LabelBuffer
        || drawType == QgsPalLabeling::LabelText )
   {
 
@@ -4261,8 +4286,30 @@ void QgsPalLabeling::drawLabel( pal::LabelPosition* label, QgsRenderContext& con
     for ( int i = 0; i < lines; ++i )
     {
       painter->save();
+#if 1 // TODO: generalize some of this
+      LabelPosition* lp = label;
+      double w = lp->getWidth();
+      double h = lp->getHeight();
+      double cx = lp->getX() + w/2.0;
+      double cy = lp->getY() + h/2.0;
+      double scale = 1.0/xform->mapUnitsPerPixel();
+      double rotation = xform->mapRotation();
+      double sw = w * scale;
+      double sh = h * scale;
+      QRectF rect( -sw/2, -sh/2, sw, sh );
+      painter->translate( xform->transform( QPointF(cx, cy) ).toQPointF() );
+      if ( rotation ) {
+        // Only if not horizontal
+        if ( lp->getFeaturePart()->getLayer()->getArrangement() != P_HORIZ ) {
+          painter->rotate( rotation );
+        }
+      }
+      painter->translate( rect.bottomLeft() );
+      painter->rotate( -lp->getAlpha() * 180 / M_PI );
+#else
       painter->translate( QPointF( outPt.x(), outPt.y() ) );
       painter->rotate( -label->getAlpha() * 180 / M_PI );
+#endif
 
       // scale down painter: the font size has been multiplied by raster scale factor
       // to workaround a Qt font scaling bug with small font sizes

--- a/src/core/qgspallabeling.cpp
+++ b/src/core/qgspallabeling.cpp
@@ -4124,33 +4124,34 @@ void QgsPalLabeling::drawLabelCandidateRect( pal::LabelPosition* lp, QPainter* p
 
   painter->save();
 
-#if 1 // TODO: generalize some of this
-  double w = lp->getWidth();
-  double h = lp->getHeight();
-  double cx = lp->getX() + w/2.0;
-  double cy = lp->getY() + h/2.0;
-  double scale = 1.0/xform->mapUnitsPerPixel();
   double rotation = xform->mapRotation();
-  double sw = w * scale;
-  double sh = h * scale;
-  QRectF rect( -sw/2, -sh/2, sw, sh );
-
-  painter->translate( xform->transform( QPointF(cx, cy) ).toQPointF() );
+  QRectF rect;
   if ( rotation ) {
-    // Only if not horizontal
-    if ( lp->getFeaturePart()->getLayer()->getArrangement() != P_HORIZ ) {
-      painter->rotate( rotation );
+    double w = lp->getWidth();
+    double h = lp->getHeight();
+    double cx = lp->getX() + w/2.0;
+    double cy = lp->getY() + h/2.0;
+    double scale = 1.0/xform->mapUnitsPerPixel();
+    double sw = w * scale;
+    double sh = h * scale;
+    rect = QRectF( -sw/2, -sh/2, sw, sh );
+
+    painter->translate( xform->transform( QPointF(cx, cy) ).toQPointF() );
+    if ( rotation ) {
+      // Only if not horizontal
+      if ( lp->getFeaturePart()->getLayer()->getArrangement() != P_HORIZ ) {
+        painter->rotate( rotation );
+      }
     }
+    painter->translate( rect.bottomLeft() );
+    painter->rotate( -lp->getAlpha() * 180 / M_PI );
+    painter->translate( -rect.bottomLeft() );
+  } else {
+    QgsPoint outPt2 = xform->transform( lp->getX() + lp->getWidth(), lp->getY() + lp->getHeight() );
+    rect = QRectF( 0, 0, outPt2.x() - outPt.x(), outPt2.y() - outPt.y() );
+    painter->translate( QPointF( outPt.x(), outPt.y() ) );
+    painter->rotate( -lp->getAlpha() * 180 / M_PI );
   }
-  painter->translate( rect.bottomLeft() );
-  painter->rotate( -lp->getAlpha() * 180 / M_PI );
-  painter->translate( -rect.bottomLeft() );
-#else
-  QgsPoint outPt2 = xform->transform( lp->getX() + lp->getWidth(), lp->getY() + lp->getHeight() );
-  QRectF rect( 0, 0, outPt2.x() - outPt.x(), outPt2.y() - outPt.y() );
-  painter->translate( QPointF( outPt.x(), outPt.y() ) );
-  painter->rotate( -lp->getAlpha() * 180 / M_PI );
-#endif
 
   painter->drawRect( rect );
   painter->restore();
@@ -4286,30 +4287,30 @@ void QgsPalLabeling::drawLabel( pal::LabelPosition* label, QgsRenderContext& con
     for ( int i = 0; i < lines; ++i )
     {
       painter->save();
-#if 1 // TODO: generalize some of this
-      LabelPosition* lp = label;
-      double w = lp->getWidth();
-      double h = lp->getHeight();
-      double cx = lp->getX() + w/2.0;
-      double cy = lp->getY() + h/2.0;
-      double scale = 1.0/xform->mapUnitsPerPixel();
       double rotation = xform->mapRotation();
-      double sw = w * scale;
-      double sh = h * scale;
-      QRectF rect( -sw/2, -sh/2, sw, sh );
-      painter->translate( xform->transform( QPointF(cx, cy) ).toQPointF() );
       if ( rotation ) {
-        // Only if not horizontal
-        if ( lp->getFeaturePart()->getLayer()->getArrangement() != P_HORIZ ) {
-          painter->rotate( rotation );
+        LabelPosition* lp = label;
+        double w = lp->getWidth();
+        double h = lp->getHeight();
+        double cx = lp->getX() + w/2.0;
+        double cy = lp->getY() + h/2.0;
+        double scale = 1.0/xform->mapUnitsPerPixel();
+        double sw = w * scale;
+        double sh = h * scale;
+        QRectF rect( -sw/2, -sh/2, sw, sh );
+        painter->translate( xform->transform( QPointF(cx, cy) ).toQPointF() );
+        if ( rotation ) {
+          // Only if not horizontal
+          if ( lp->getFeaturePart()->getLayer()->getArrangement() != P_HORIZ ) {
+            painter->rotate( rotation );
+          }
         }
+        painter->translate( rect.bottomLeft() );
+        painter->rotate( -lp->getAlpha() * 180 / M_PI );
+      } else {
+        painter->translate( QPointF( outPt.x(), outPt.y() ) );
+        painter->rotate( -label->getAlpha() * 180 / M_PI );
       }
-      painter->translate( rect.bottomLeft() );
-      painter->rotate( -lp->getAlpha() * 180 / M_PI );
-#else
-      painter->translate( QPointF( outPt.x(), outPt.y() ) );
-      painter->rotate( -label->getAlpha() * 180 / M_PI );
-#endif
 
       // scale down painter: the font size has been multiplied by raster scale factor
       // to workaround a Qt font scaling bug with small font sizes


### PR DESCRIPTION
Add some map rotation knowledge in label renderer.
Horizontal and parallel line labels are now drawn correctly.
Curved labels are still suffering and I hadn't tested backshadow and such.

\cc @dakcarto for review

Related hub ticket: http://hub.qgis.org/issues/11814
