### PR TITLE
[fix #11475] expressions: add left and right associavity for dump of binary operators

### DIFF
--- a/python/core/qgsexpression.sip
+++ b/python/core/qgsexpression.sip
@@ -335,6 +335,8 @@ class QgsExpression
         virtual void accept( QgsExpression::Visitor& v ) const;
 
         int precedence() const;
+        bool leftAssociative() const;
+        bool rightAssociative() const;
     };
 
     class NodeInOperator : QgsExpression::Node

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -2445,15 +2445,87 @@ int QgsExpression::NodeBinaryOperator::precedence() const
   return -1;
 }
 
+bool QgsExpression::NodeBinaryOperator::leftAssociative() const
+{
+  // see left/right in qgsexpressionparser.yy
+  switch ( mOp )
+  {
+    case boOr:
+    case boAnd:
+    case boEQ:
+    case boNE:
+    case boLE:
+    case boGE:
+    case boLT:
+    case boGT:
+    case boRegexp:
+    case boLike:
+    case boILike:
+    case boNotLike:
+    case boNotILike:
+    case boIs:
+    case boIsNot:
+    case boPlus:
+    case boMinus:
+    case boMul:
+    case boDiv:
+    case boIntDiv:
+    case boMod:
+    case boConcat:
+      return true;
+
+    case boPow:
+      return false;
+  }
+  Q_ASSERT( 0 && "unexpected binary operator" );
+  return -1;
+}
+
+bool QgsExpression::NodeBinaryOperator::rightAssociative() const
+{
+  // see left/right in qgsexpressionparser.yy
+  switch ( mOp )
+  {
+    case boOr:
+    case boAnd:
+    case boEQ:
+    case boNE:
+    case boLE:
+    case boGE:
+    case boLT:
+    case boGT:
+    case boRegexp:
+    case boLike:
+    case boILike:
+    case boNotLike:
+    case boNotILike:
+    case boIs:
+    case boIsNot:
+    case boPlus:
+    case boMul:
+    case boMod:
+    case boConcat:
+    case boPow:
+      return true;
+
+    case boMinus:
+    case boDiv:
+    case boIntDiv:
+      return false;
+  }
+  Q_ASSERT( 0 && "unexpected binary operator" );
+  return -1;
+}
+
 QString QgsExpression::NodeBinaryOperator::dump() const
 {
   QgsExpression::NodeBinaryOperator *lOp = dynamic_cast<QgsExpression::NodeBinaryOperator *>( mOpLeft );
   QgsExpression::NodeBinaryOperator *rOp = dynamic_cast<QgsExpression::NodeBinaryOperator *>( mOpRight );
 
   QString fmt;
-  fmt += lOp && lOp->precedence() < precedence() ? "(%1)" : "%1";
+  fmt += lOp && ( lOp->precedence() < precedence() || !lOp->leftAssociative() ) ? "(%1)" : "%1";
   fmt += " %2 ";
-  fmt += rOp && rOp->precedence() <= precedence() ? "(%3)" : "%3";
+  fmt += rOp && ( rOp->precedence() < precedence() || !rOp->rightAssociative() ) ? "(%3)" : "%3";
 
   return fmt.arg( mOpLeft->dump() ).arg( BinaryOperatorText[mOp] ).arg( mOpRight->dump() );
 }

--- a/src/core/qgsexpression.h
+++ b/src/core/qgsexpression.h
@@ -487,6 +487,8 @@ class CORE_EXPORT QgsExpression
         virtual void accept( Visitor& v ) const { v.visit( *this ); }
 
         int precedence() const;
+        bool leftAssociative() const;
+        bool rightAssociative() const;
 
       protected:
         bool compare( double diff );

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -479,6 +479,9 @@ class TestQgsExpression: public QObject
 
       QgsExpression e2( e1.dump() );
       QCOMPARE( e2.evaluate().toInt(), 21 );
+
+      QgsExpression e3( "(2^3)^2" );
+      QCOMPARE( QgsExpression( e3.dump() ).evaluate().toInt(), 64 );
     }
 
     void eval_columns()


### PR DESCRIPTION
Previous fix  2c7378bb16f7e6433363340b9c16e40c3ad654ae solved original bug by assuming that all operators were left associative, which is not true for power operator.

This introduces left and right associativity in the dump.
This fixes the bug and I suppose will remove a bit more brackets.

see http://hub.qgis.org/issues/11475
