### PR TITLE
Add lazy evaluation support to expression functions and if function

### DIFF
--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -1367,15 +1367,18 @@ static QVariant fcnIf( const QVariantList &values, const QgsFeature *f, QgsExpre
   QgsExpression::Node* node = getNode( values.at( 0 ), parent );
   ENSURE_NO_EVAL_ERROR;
   QVariant value = node->eval( parent, f );
+  ENSURE_NO_EVAL_ERROR;
   if ( value.toBool() ) {
     node = getNode( values.at( 1 ), parent );
     ENSURE_NO_EVAL_ERROR;
     value = node->eval( parent, f );
+    ENSURE_NO_EVAL_ERROR;
   }
   else {
     node = getNode( values.at( 2 ), parent );
     ENSURE_NO_EVAL_ERROR;
     value = node->eval( parent, f );
+    ENSURE_NO_EVAL_ERROR;
   }
   return value;
 }

--- a/src/core/qgsexpression.h
+++ b/src/core/qgsexpression.h
@@ -374,7 +374,6 @@ class CORE_EXPORT QgsExpression
     class CORE_EXPORT Node
     {
       public:
-        Node() {}
         virtual ~Node() {}
         virtual NodeType nodeType() const = 0;
         // abstract virtual eval function

--- a/src/core/qgsexpression.h
+++ b/src/core/qgsexpression.h
@@ -273,14 +273,16 @@ class CORE_EXPORT QgsExpression
     class CORE_EXPORT Function
     {
       public:
-        Function( QString fnname, int params, QString group, QString helpText = QString(), bool usesGeometry = false, QStringList referencedColumns = QStringList() )
-            : mName( fnname ), mParams( params ), mUsesGeometry( usesGeometry ), mGroup( group ), mHelpText( helpText ), mReferencedColumns( referencedColumns ) {}
+        Function( QString fnname, int params, QString group, QString helpText = QString(), bool usesGeometry = false, QStringList referencedColumns = QStringList(), bool lazyEval = false )
+            : mName( fnname ), mParams( params ), mUsesGeometry( usesGeometry ), mGroup( group ), mHelpText( helpText ), mReferencedColumns( referencedColumns ), mLazyEval( lazyEval ) {}
         /** The name of the function. */
         QString name() { return mName; }
         /** The number of parameters this function takes. */
         int params() { return mParams; }
         /** Does this function use a geometry object. */
         bool usesgeometry() { return mUsesGeometry; }
+
+        bool lazyEval() { return mLazyEval; }
 
         virtual QStringList referencedColumns() const { return mReferencedColumns; }
 
@@ -306,13 +308,14 @@ class CORE_EXPORT QgsExpression
         QString mGroup;
         QString mHelpText;
         QStringList mReferencedColumns;
+        bool mLazyEval;
     };
 
     class StaticFunction : public Function
     {
       public:
-        StaticFunction( QString fnname, int params, FcnEval fcn, QString group, QString helpText = QString(), bool usesGeometry = false, QStringList referencedColumns = QStringList() )
-            : Function( fnname, params, group, helpText, usesGeometry, referencedColumns ), mFnc( fcn ) {}
+        StaticFunction( QString fnname, int params, FcnEval fcn, QString group, QString helpText = QString(), bool usesGeometry = false, QStringList referencedColumns = QStringList(), bool lazyEval = false )
+            : Function( fnname, params, group, helpText, usesGeometry, referencedColumns, lazyEval ), mFnc( fcn ) {}
 
         virtual QVariant func( const QVariantList& values, const QgsFeature* f, QgsExpression* parent )
         {
@@ -371,6 +374,7 @@ class CORE_EXPORT QgsExpression
     class CORE_EXPORT Node
     {
       public:
+        Node() {}
         virtual ~Node() {}
         virtual NodeType nodeType() const = 0;
         // abstract virtual eval function
@@ -671,5 +675,6 @@ class CORE_EXPORT QgsExpression
 };
 
 Q_DECLARE_METATYPE( QgsExpression::Interval );
+Q_DECLARE_METATYPE( QgsExpression::Node* );
 
 #endif // QGSEXPRESSION_H

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -377,6 +377,8 @@ class TestQgsExpression: public QObject
       QTest::newRow( "regexp match invalid" ) << "regexp_match('abc DEF','[[[')" << true << QVariant();
       QTest::newRow( "regexp match escaped" ) << "regexp_match('abc DEF','\\\\s[A-Z]+')" << false << QVariant( 1 );
       QTest::newRow( "regexp match false" ) << "regexp_match('abc DEF','\\\\s[a-z]+')" << false << QVariant( 0 );
+      QTest::newRow( "if true" ) << "if(1=1, 1, 0)" << false << QVariant( 1 );
+      QTest::newRow( "if false" ) << "if(1=2, 1, 0)" << false << QVariant( 0 );
 
       // Datetime functions
       QTest::newRow( "to date" ) << "todate('2012-06-28')" << false << QVariant( QDate( 2012, 6, 28 ) );


### PR DESCRIPTION
Adds lazy evaluation support for functions to QgsExpression. Lazy functions are passed the expression node rather than the result. Functions can decide what to do with each node it is given. 

Also add `if(cond, true, false)` function using lazy evaluation feature. Each branch of the `if` is evaluate as needed rather than up front.
