### PR TITLE
Fix zoomwheel regression

### DIFF
--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -724,7 +724,7 @@ void QgsMapCanvas::rendererJobFinished()
     p.end();
 
     QgsRectangle rect = mSettings.visibleExtent();
-    mMap->setContent( img, rect );
+    mMap->setContent( img, rect, mSettings.rotation() );
   }
 
   // now we are in a slot called from mJob - do not delete it immediately

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -723,7 +723,13 @@ void QgsMapCanvas::rendererJobFinished()
 
     p.end();
 
-    QgsRectangle rect = mSettings.visibleExtent();
+    // This is an hack to pass QgsMapCanvasItem::setRect what it
+    // expects (encoding of position and size of the item)
+    const QgsMapToPixel& m2p = mSettings.mapToPixel();
+    QgsPoint topLeft = m2p.toMapPoint(0,0);
+    double res = m2p.mapUnitsPerPixel();
+    QgsRectangle rect(topLeft.x(), topLeft.y(), topLeft.x() + img.width()*res, topLeft.y() - img.height()*res);
+
     mMap->setContent( img, rect );
   }
 

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -724,7 +724,7 @@ void QgsMapCanvas::rendererJobFinished()
     p.end();
 
     QgsRectangle rect = mSettings.visibleExtent();
-    mMap->setContent( img, rect, mSettings.rotation() );
+    mMap->setContent( img, rect );
   }
 
   // now we are in a slot called from mJob - do not delete it immediately

--- a/src/gui/qgsmapcanvasitem.cpp
+++ b/src/gui/qgsmapcanvasitem.cpp
@@ -67,21 +67,6 @@ QPointF QgsMapCanvasItem::toCanvasCoordinates( const QgsPoint& point )
   return QPointF( x, y ) + mPanningOffset;
 }
 
-// private
-QRectF QgsMapCanvasItem::toCanvasCoordinates( const QRectF& rect )
-{
-  QPointF tl( toCanvasCoordinates( rect.topLeft() ) );
-  QPointF bl( toCanvasCoordinates( rect.bottomLeft() ) );
-  QPointF br( toCanvasCoordinates( rect.bottomRight() ) );
-  QPointF tr( toCanvasCoordinates( rect.topRight() ) );
-  double xmin = std::min( tl.x(), std::min( bl.x(), std::min( br.x(), tr.x() ) ) );
-  double ymin = std::min( tl.y(), std::min( bl.y(), std::min( br.y(), tr.y() ) ) );
-  double xmax = std::max( tl.x(), std::max( bl.x(), std::max( br.x(), tr.x() ) ) );
-  double ymax = std::max( tl.y(), std::max( bl.y(), std::max( br.y(), tr.y() ) ) );
-  return QRectF( QPointF( xmin, ymin ), QPointF( xmax, ymax ) );
-}
-
-
 QgsRectangle QgsMapCanvasItem::rect() const
 {
   return mRect;

--- a/src/gui/qgsmapcanvasitem.cpp
+++ b/src/gui/qgsmapcanvasitem.cpp
@@ -96,13 +96,17 @@ void QgsMapCanvasItem::setRect( const QgsRectangle& rect )
   QRectF r; // empty rect by default
   if ( !mRect.isEmpty() )
   {
-    r = toCanvasCoordinates( mRect.toRectF() );
-    r = r.normalized();
+    // rect encodes origin of the item (xMin,yMax from map to canvas units)
+    // and size (rect size / map units per pixel)
+    r.setTopLeft( toCanvasCoordinates( QPointF(mRect.xMinimum(), mRect.yMaximum()) ) );
+    const QgsMapToPixel* m2p = mMapCanvas->getCoordinateTransform();
+    double res = m2p->mapUnitsPerPixel();
+    r.setSize( QSizeF(mRect.width()/res, mRect.height()/res) );
   }
 
   // set position in canvas where the item will have coordinate (0,0)
   prepareGeometryChange();
-  setPos( r.topLeft() ); // TODO: compute from (0,0) using toMapCoordinates ?
+  setPos( r.topLeft() );
   mItemSize = QSizeF( r.width() + 2, r.height() + 2 );
 
   // QgsDebugMsg(QString("[%1,%2]-[%3x%4]").arg((int) r.left()).arg((int) r.top()).arg((int) r.width()).arg((int) r.height()));

--- a/src/gui/qgsmapcanvasitem.h
+++ b/src/gui/qgsmapcanvasitem.h
@@ -82,22 +82,23 @@ class GUI_EXPORT QgsMapCanvasItem : public QGraphicsItem
     //! pointer to map canvas
     QgsMapCanvas* mMapCanvas;
 
-    //! canvas item rectangle (in map coordinates)
+    //! cached canvas item rectangle in map coordinates
+    //! encodes position (xmin,ymax) and size (width/height)
+    //! used to re-position and re-size the item on zoom/pan
+    //! while waiting for the renderer to complete.
+    //!
+    //! NOTE: does not include rotation information, so cannot
+    //!       be used to correctly present pre-rendered map
+    //!       on rotation change
     QgsRectangle mRect;
 
     //! offset from normal position due current panning operation,
     //! used when converting map coordinates to move map canvas items
+    //! @deprecated since v2.4
     QPoint mPanningOffset;
 
     //! cached size of the item (to return in boundingRect())
     QSizeF mItemSize;
-
-  private:
-
-    //! transformation from map coordinates to screen coordinates
-    //! if rotation is set it is taken in consideration so that
-    //! the returned rectangle is the bounding box of the rotated input
-    QRectF toCanvasCoordinates( const QRectF& rect );
 
 };
 

--- a/src/gui/qgsmapcanvasmap.cpp
+++ b/src/gui/qgsmapcanvasmap.cpp
@@ -23,7 +23,7 @@
 #include <QPainter>
 
 QgsMapCanvasMap::QgsMapCanvasMap( QgsMapCanvas* canvas )
-    : QgsMapCanvasItem( canvas ), mRotation(0.0)
+    : QgsMapCanvasItem( canvas )
 {
   setZValue( -10 );
 }
@@ -32,9 +32,8 @@ QgsMapCanvasMap::~QgsMapCanvasMap()
 {
 }
 
-void QgsMapCanvasMap::setContent( const QImage& image, const QgsRectangle& rect, double rotation )
+void QgsMapCanvasMap::setContent( const QImage& image, const QgsRectangle& rect )
 {
-  mRotation = rotation;
   mImage = image;
 
   // For true retro fans: this is approximately how the graphics looked like in 1990
@@ -48,27 +47,12 @@ void QgsMapCanvasMap::setContent( const QImage& image, const QgsRectangle& rect,
 void QgsMapCanvasMap::paint( QPainter* painter )
 {
   int w = qRound( boundingRect().width() ) - 2, h = qRound( boundingRect().height() ) - 2; // setRect() makes the size +2 :-(
-  int wi = mImage.width();
-  int hi = mImage.height();
-
-  double ar = h ? double(w)/h : 0.0; // aspect ratio of bounding rect
-  double ari = hi ? double(wi)/hi : 0.0; // aspect ratio of image
-  double ard = fabs(ari-ar); // aspect ratio difference
-
-#if 0
-  QgsDebugMsg( QString( "XXXX img %1,%2 (%3) item %4,%5 (%6) ardiff %7" )
-    .arg( wi ).arg( hi ).arg( ari )
-    .arg( w ).arg( h ).arg( ar )
-    .arg ( ard )
-  );
-#endif
-
   if ( mImage.size() != QSize( w, h ) )
   {
-    QgsDebugMsg( QString( "map paint DIFFERENT SIZE: img %1,%2  item %3,%4" ).arg( wi ).arg( hi ).arg( w ).arg( h ) );
+    QgsDebugMsg( QString( "map paint DIFFERENT SIZE: img %1,%2  item %3,%4" ).arg( mImage.width() ).arg( mImage.height() ).arg( w ).arg( h ) );
   }
 
-  if ( mRotation )
+  if ( mMapCanvas->getCoordinateTransform()->mapRotation() )
   {
     int tX = ( w - mImage.width() ) / 2.0;
     int tY = ( h - mImage.height() ) / 2.0;

--- a/src/gui/qgsmapcanvasmap.cpp
+++ b/src/gui/qgsmapcanvasmap.cpp
@@ -52,20 +52,7 @@ void QgsMapCanvasMap::paint( QPainter* painter )
     QgsDebugMsg( QString( "map paint DIFFERENT SIZE: img %1,%2  item %3,%4" ).arg( mImage.width() ).arg( mImage.height() ).arg( w ).arg( h ) );
   }
 
-  if ( mMapCanvas->getCoordinateTransform()->mapRotation() )
-  {
-    int tX = ( w - mImage.width() ) / 2.0;
-    int tY = ( h - mImage.height() ) / 2.0;
-    int fX = 0;
-    int fY = 0;
-    int fW = w;
-    int fH = h;
-    painter->drawImage( tX, tY, mImage, fX, fY, fW, fH );
-  }
-  else
-  {
-    painter->drawImage( QRect( 0, 0, w, h ), mImage );
-  }
+  painter->drawImage( QRect( 0, 0, w, h ), mImage );
 
   // For debugging:
 #if 0

--- a/src/gui/qgsmapcanvasmap.cpp
+++ b/src/gui/qgsmapcanvasmap.cpp
@@ -23,7 +23,7 @@
 #include <QPainter>
 
 QgsMapCanvasMap::QgsMapCanvasMap( QgsMapCanvas* canvas )
-    : QgsMapCanvasItem( canvas )
+    : QgsMapCanvasItem( canvas ), mRotation(0.0)
 {
   setZValue( -10 );
 }
@@ -32,8 +32,9 @@ QgsMapCanvasMap::~QgsMapCanvasMap()
 {
 }
 
-void QgsMapCanvasMap::setContent( const QImage& image, const QgsRectangle& rect )
+void QgsMapCanvasMap::setContent( const QImage& image, const QgsRectangle& rect, double rotation )
 {
+  mRotation = rotation;
   mImage = image;
 
   // For true retro fans: this is approximately how the graphics looked like in 1990
@@ -47,9 +48,28 @@ void QgsMapCanvasMap::setContent( const QImage& image, const QgsRectangle& rect 
 void QgsMapCanvasMap::paint( QPainter* painter )
 {
   int w = qRound( boundingRect().width() ) - 2, h = qRound( boundingRect().height() ) - 2; // setRect() makes the size +2 :-(
+  int wi = mImage.width();
+  int hi = mImage.height();
+
+  double ar = h ? double(w)/h : 0.0; // aspect ratio of bounding rect
+  double ari = hi ? double(wi)/hi : 0.0; // aspect ratio of image
+  double ard = fabs(ari-ar); // aspect ratio difference
+
+#if 0
+  QgsDebugMsg( QString( "XXXX img %1,%2 (%3) item %4,%5 (%6) ardiff %7" )
+    .arg( wi ).arg( hi ).arg( ari )
+    .arg( w ).arg( h ).arg( ar )
+    .arg ( ard )
+  );
+#endif
+
   if ( mImage.size() != QSize( w, h ) )
   {
-    QgsDebugMsg( QString( "map paint DIFFERENT SIZE: img %1,%2  item %3,%4" ).arg( mImage.width() ).arg( mImage.height() ).arg( w ).arg( h ) );
+    QgsDebugMsg( QString( "map paint DIFFERENT SIZE: img %1,%2  item %3,%4" ).arg( wi ).arg( hi ).arg( w ).arg( h ) );
+  }
+
+  if ( mRotation )
+  {
     int tX = ( w - mImage.width() ) / 2.0;
     int tY = ( h - mImage.height() ) / 2.0;
     int fX = 0;

--- a/src/gui/qgsmapcanvasmap.cpp
+++ b/src/gui/qgsmapcanvasmap.cpp
@@ -50,6 +50,8 @@ void QgsMapCanvasMap::paint( QPainter* painter )
   if ( mImage.size() != QSize( w, h ) )
   {
     QgsDebugMsg( QString( "map paint DIFFERENT SIZE: img %1,%2  item %3,%4" ).arg( mImage.width() ).arg( mImage.height() ).arg( w ).arg( h ) );
+    // This happens on zoom events when ::paint is called before
+    // the renderer has completed
   }
 
   painter->drawImage( QRect( 0, 0, w, h ), mImage );

--- a/src/gui/qgsmapcanvasmap.h
+++ b/src/gui/qgsmapcanvasmap.h
@@ -41,8 +41,7 @@ class GUI_EXPORT QgsMapCanvasMap : public QgsMapCanvasItem  // public QObject, p
     ~QgsMapCanvasMap();
 
     //! @note added in 2.4
-    //! @note rotation parameter added in 2.8
-    void setContent( const QImage& image, const QgsRectangle& rect, double rotation=0.0 );
+    void setContent( const QImage& image, const QgsRectangle& rect );
 
     //! @note added in 2.4
     QImage contentImage() const { return mImage; }
@@ -76,8 +75,6 @@ class GUI_EXPORT QgsMapCanvasMap : public QgsMapCanvasItem  // public QObject, p
   private:
 
     QImage mImage;
-
-    double mRotation;
 };
 
 #endif

--- a/src/gui/qgsmapcanvasmap.h
+++ b/src/gui/qgsmapcanvasmap.h
@@ -41,7 +41,8 @@ class GUI_EXPORT QgsMapCanvasMap : public QgsMapCanvasItem  // public QObject, p
     ~QgsMapCanvasMap();
 
     //! @note added in 2.4
-    void setContent( const QImage& image, const QgsRectangle& rect );
+    //! @note rotation parameter added in 2.8
+    void setContent( const QImage& image, const QgsRectangle& rect, double rotation=0.0 );
 
     //! @note added in 2.4
     QImage contentImage() const { return mImage; }
@@ -75,6 +76,8 @@ class GUI_EXPORT QgsMapCanvasMap : public QgsMapCanvasItem  // public QObject, p
   private:
 
     QImage mImage;
+
+    double mRotation;
 };
 
 #endif


### PR DESCRIPTION
Fixes the regression with pre-rendering user feedback for
non-rotated maps. The glitch is still there for rotated maps
but that's not a regression.

See http://hub.qgis.org/issues/11811
