### PR TITLE
added layerSavedAs signal

### DIFF
--- a/python/gui/qgisinterface.sip
+++ b/python/gui/qgisinterface.sip
@@ -522,4 +522,9 @@ class QgisInterface : QObject
         signal for when this happens.
       */
     void newProjectCreated();
+    /**This signal is emitted when a layer has been saved using save as
+       @note
+       added in version 2.7
+    */
+    void layerSavedAs( QgsMapLayer* l, QString path );
 };

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -4993,6 +4993,10 @@ void QgisApp::saveAsRasterFile()
                             QMessageBox::Ok );
 
     }
+    else
+    {
+      emit layerSavedAs( rasterLayer, d.outputFileName() );
+    }
     delete pipe;
   }
 }
@@ -5139,6 +5143,7 @@ void QgisApp::saveAsVectorFileGeneral( QgsVectorLayer* vlayer, bool symbologyOpt
       {
         addVectorLayers( QStringList( newFilename ), encoding, "file" );
       }
+      emit layerSavedAs( vlayer, vectorFilename );
       messageBar()->pushMessage( tr( "Saving done" ),
                                  tr( "Export to vector file has been completed" ),
                                  QgsMessageBar::INFO, messageTimeout() );

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1254,6 +1254,11 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     void customSrsValidation( QgsCoordinateReferenceSystem &crs );
 
+    /**This signal is emitted when a layer has been saved using save as
+       @note added in version 2.7
+    */
+    void layerSavedAs( QgsMapLayer* l, QString path );
+
   private:
     /** This method will open a dialog so the user can select GDAL sublayers to load
      * @returns true if any items were loaded

--- a/src/app/qgisappinterface.cpp
+++ b/src/app/qgisappinterface.cpp
@@ -65,6 +65,8 @@ QgisAppInterface::QgisAppInterface( QgisApp * _qgis )
            this, SIGNAL( newProjectCreated() ) );
   connect( qgis, SIGNAL( projectRead() ),
            this, SIGNAL( projectRead() ) );
+  connect( qgis, SIGNAL( layerSavedAs( QgsMapLayer*, QString ) ),
+           this, SIGNAL( layerSavedAs(QgsMapLayer*, QString ) ) );
 }
 
 QgisAppInterface::~QgisAppInterface()

--- a/src/gui/qgisinterface.h
+++ b/src/gui/qgisinterface.h
@@ -575,6 +575,12 @@ class GUI_EXPORT QgisInterface : public QObject
         signal for when this happens.
       */
     void newProjectCreated();
+
+    /**This signal is emitted when a layer has been saved using save as
+       @note
+       added in version 2.7
+    */
+    void layerSavedAs( QgsMapLayer* l, QString path );
 };
 
 // FIXME: also in core/qgis.h


### PR DESCRIPTION
I added a signal layerSavedAs that is emitted when a QgsMapLayer is saved as vector or raster file using the save as functionality.
