### PR TITLE
[DB Manager] Allow execution of the selected text in the SQL window

### DIFF
--- a/python/plugins/db_manager/dlg_sql_window.py
+++ b/python/plugins/db_manager/dlg_sql_window.py
@@ -130,7 +130,13 @@ class DlgSqlWindow(QDialog, Ui_Dialog):
     self.editSql.setFocus()
 
   def executeSql(self):
-    sql = self.editSql.text()
+      
+    sql = ""
+    if self.editSql.hasSelectedText():
+        sql = self.editSql.selectedText()
+    else:
+        sql = self.editSql.text()
+    
     if sql == "":
         return
 


### PR DESCRIPTION
In the SQL window of DB Manager, if some text is selected, only the selected text will be executed. Like in pgadmin.
