### PR TITLE
[Qt5-compat] Change Q_WS_* macroses to Q_OS_*

### DIFF
--- a/src/app/composer/qgscomposer.cpp
+++ b/src/app/composer/qgscomposer.cpp
@@ -195,7 +195,7 @@ QgsComposer::QgsComposer( QgisApp *qgis, const QString& title )
 
   mActionAtlasPreview->setCheckable( true );
 
-#ifdef Q_WS_MAC
+#ifdef Q_OS_MAC
   mActionQuit->setText( tr( "Close" ) );
   mActionQuit->setShortcut( QKeySequence::Close );
   QMenu *appMenu = menuBar()->addMenu( tr( "QGIS" ) );
@@ -307,7 +307,7 @@ QgsComposer::QgsComposer( QgisApp *qgis, const QString& title )
   QShortcut* ctrlEquals = new QShortcut( QKeySequence( "Ctrl+=" ), this );
   connect( ctrlEquals, SIGNAL( activated() ), mActionZoomIn, SLOT( trigger() ) );
 
-#ifndef Q_WS_MAC
+#ifndef Q_OS_MAC
   //disabled for OSX - see #10761
   //also see http://qt-project.org/forums/viewthread/3630 QGraphicsEffects are not well supported on OSX
   QMenu *previewMenu = viewMenu->addMenu( "&Preview" );
@@ -404,7 +404,7 @@ QgsComposer::QgsComposer( QgisApp *qgis, const QString& title )
   QMenu *settingsMenu = menuBar()->addMenu( tr( "&Settings" ) );
   settingsMenu->addAction( mActionOptions );
 
-#ifdef Q_WS_MAC
+#ifdef Q_OS_MAC
   // this doesn't work on Mac anymore: menuBar()->addMenu( mQgis->windowMenu() );
   // QgsComposer::populateWithOtherMenu should work recursively with submenus and regardless of Qt version
   mWindowMenu = new QMenu( tr( "Window" ), this );
@@ -802,7 +802,7 @@ void QgsComposer::activate()
   }
 }
 
-#ifdef Q_WS_MAC
+#ifdef Q_OS_MAC
 void QgsComposer::changeEvent( QEvent* event )
 {
   QMainWindow::changeEvent( event );
@@ -2950,7 +2950,7 @@ void QgsComposer::showEvent( QShowEvent* event )
     restoreComposerMapStates();
   }
 
-#ifdef Q_WS_MAC
+#ifdef Q_OS_MAC
   // add to menu if (re)opening window (event not due to unminimize)
   if ( !event->spontaneous() )
   {

--- a/src/app/composer/qgscomposer.h
+++ b/src/app/composer/qgscomposer.h
@@ -114,7 +114,7 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
 
     virtual void showEvent( QShowEvent* event );
 
-#ifdef Q_WS_MAC
+#ifdef Q_OS_MAC
     //! Change event (update window menu on ActivationChange)
     virtual void changeEvent( QEvent * );
 #endif

--- a/src/app/composer/qgscomposerattributetablewidget.cpp
+++ b/src/app/composer/qgscomposerattributetablewidget.cpp
@@ -288,7 +288,7 @@ void QgsComposerAttributeTableWidget::on_mHeaderFontPushButton_clicked()
   }
 
   bool ok;
-#if defined(Q_WS_MAC) && defined(QT_MAC_USE_COCOA)
+#if defined(Q_OS_MAC) && defined(QT_MAC_USE_COCOA)
   // Native Mac dialog works only for Qt Carbon
   QFont newFont = QFontDialog::getFont( &ok, mComposerTable->headerFont(), 0, tr( "Select Font" ), QFontDialog::DontUseNativeDialog );
 #else
@@ -336,7 +336,7 @@ void QgsComposerAttributeTableWidget::on_mContentFontPushButton_clicked()
   }
 
   bool ok;
-#if defined(Q_WS_MAC) && defined(QT_MAC_USE_COCOA)
+#if defined(Q_OS_MAC) && defined(QT_MAC_USE_COCOA)
   // Native Mac dialog works only for Qt Carbon
   QFont newFont = QFontDialog::getFont( &ok, mComposerTable->contentFont(), 0, tr( "Select Font" ), QFontDialog::DontUseNativeDialog );
 #else

--- a/src/app/composer/qgscomposerlabelwidget.cpp
+++ b/src/app/composer/qgscomposerlabelwidget.cpp
@@ -91,7 +91,7 @@ void QgsComposerLabelWidget::on_mFontButton_clicked()
   if ( mComposerLabel )
   {
     bool ok;
-#if defined(Q_WS_MAC) && defined(QT_MAC_USE_COCOA)
+#if defined(Q_OS_MAC) && defined(QT_MAC_USE_COCOA)
     // Native Mac dialog works only for Qt Carbon
     QFont newFont = QFontDialog::getFont( &ok, mComposerLabel->font(), 0, QString(), QFontDialog::DontUseNativeDialog );
 #else

--- a/src/app/composer/qgscomposerlegendwidget.cpp
+++ b/src/app/composer/qgscomposerlegendwidget.cpp
@@ -368,7 +368,7 @@ void QgsComposerLegendWidget::on_mTitleFontButton_clicked()
   if ( mLegend )
   {
     bool ok;
-#if defined(Q_WS_MAC) && defined(QT_MAC_USE_COCOA)
+#if defined(Q_OS_MAC) && defined(QT_MAC_USE_COCOA)
     // Native Mac dialog works only for Qt Carbon
     QFont newFont = QFontDialog::getFont( &ok, mLegend->style( QgsComposerLegendStyle::Title ).font(), 0, QString(), QFontDialog::DontUseNativeDialog );
 #else
@@ -390,7 +390,7 @@ void QgsComposerLegendWidget::on_mGroupFontButton_clicked()
   if ( mLegend )
   {
     bool ok;
-#if defined(Q_WS_MAC) && defined(QT_MAC_USE_COCOA)
+#if defined(Q_OS_MAC) && defined(QT_MAC_USE_COCOA)
     // Native Mac dialog works only for Qt Carbon
     QFont newFont = QFontDialog::getFont( &ok, mLegend->style( QgsComposerLegendStyle::Group ).font(), 0, QString(), QFontDialog::DontUseNativeDialog );
 #else
@@ -412,7 +412,7 @@ void QgsComposerLegendWidget::on_mLayerFontButton_clicked()
   if ( mLegend )
   {
     bool ok;
-#if defined(Q_WS_MAC) && defined(QT_MAC_USE_COCOA)
+#if defined(Q_OS_MAC) && defined(QT_MAC_USE_COCOA)
     // Native Mac dialog works only for Qt Carbon
     QFont newFont = QFontDialog::getFont( &ok, mLegend->style( QgsComposerLegendStyle::Subgroup ).font(), 0, QString(), QFontDialog::DontUseNativeDialog );
 #else
@@ -434,7 +434,7 @@ void QgsComposerLegendWidget::on_mItemFontButton_clicked()
   if ( mLegend )
   {
     bool ok;
-#if defined(Q_WS_MAC) && defined(QT_MAC_USE_COCOA)
+#if defined(Q_OS_MAC) && defined(QT_MAC_USE_COCOA)
     // Native Mac dialog works only for Qt Carbon
     QFont newFont = QFontDialog::getFont( &ok, mLegend->style( QgsComposerLegendStyle::SymbolLabel ).font(), 0, QString(), QFontDialog::DontUseNativeDialog );
 #else

--- a/src/app/composer/qgscomposermanager.cpp
+++ b/src/app/composer/qgscomposermanager.cpp
@@ -63,7 +63,7 @@ QgsComposerManager::QgsComposerManager( QWidget * parent, Qt::WindowFlags f ): Q
   mButtonBox->addButton( pb, QDialogButtonBox::ActionRole );
   connect( pb, SIGNAL( clicked() ), this, SLOT( rename_clicked() ) );
 
-#ifdef Q_WS_MAC
+#ifdef Q_OS_MAC
   // Create action to select this window
   mWindowAction = new QAction( windowTitle(), this );
   connect( mWindowAction, SIGNAL( triggered() ), this, SLOT( activate() ) );
@@ -285,7 +285,7 @@ void QgsComposerManager::openLocalDirectory( const QString& localDirPath )
   QDesktopServices::openUrl( QUrl::fromLocalFile( localDirPath ) );
 }
 
-#ifdef Q_WS_MAC
+#ifdef Q_OS_MAC
 void QgsComposerManager::showEvent( QShowEvent* event )
 {
   if ( !event->spontaneous() )

--- a/src/app/composer/qgscomposermanager.h
+++ b/src/app/composer/qgscomposermanager.h
@@ -73,7 +73,7 @@ class QgsComposerManager: public QDialog, private Ui::QgsComposerManagerBase
     QString mDefaultTemplatesDir;
     QString mUserTemplatesDir;
 
-#ifdef Q_WS_MAC
+#ifdef Q_OS_MAC
     void showEvent( QShowEvent *event );
     void changeEvent( QEvent * );
 

--- a/src/app/composer/qgscomposermapwidget.cpp
+++ b/src/app/composer/qgscomposermapwidget.cpp
@@ -2055,7 +2055,7 @@ void QgsComposerMapWidget::on_mAnnotationFontButton_clicked()
   }
 
   bool ok;
-#if defined(Q_WS_MAC) && QT_VERSION >= 0x040500 && defined(QT_MAC_USE_COCOA)
+#if defined(Q_OS_MAC) && QT_VERSION >= 0x040500 && defined(QT_MAC_USE_COCOA)
   // Native Mac dialog works only for Qt Carbon
   QFont newFont = QFontDialog::getFont( &ok, grid->annotationFont(), 0, QString(), QFontDialog::DontUseNativeDialog );
 #else

--- a/src/app/composer/qgscomposerscalebarwidget.cpp
+++ b/src/app/composer/qgscomposerscalebarwidget.cpp
@@ -311,7 +311,7 @@ void QgsComposerScaleBarWidget::on_mFontButton_clicked()
 
   bool dialogAccepted;
   QFont oldFont = mComposerScaleBar->font();
-#if defined(Q_WS_MAC) && defined(QT_MAC_USE_COCOA)
+#if defined(Q_OS_MAC) && defined(QT_MAC_USE_COCOA)
   // Native Mac dialog works only for Qt Carbon
   QFont newFont = QFontDialog::getFont( &dialogAccepted, oldFont, 0, QString(), QFontDialog::DontUseNativeDialog );
 #else

--- a/src/app/composer/qgscomposertablewidget.cpp
+++ b/src/app/composer/qgscomposertablewidget.cpp
@@ -215,7 +215,7 @@ void QgsComposerTableWidget::on_mHeaderFontPushButton_clicked()
   }
 
   bool ok;
-#if defined(Q_WS_MAC) && defined(QT_MAC_USE_COCOA)
+#if defined(Q_OS_MAC) && defined(QT_MAC_USE_COCOA)
   // Native Mac dialog works only for Qt Carbon
   QFont newFont = QFontDialog::getFont( &ok, mComposerTable->headerFont(), 0, tr( "Select Font" ), QFontDialog::DontUseNativeDialog );
 #else
@@ -250,7 +250,7 @@ void QgsComposerTableWidget::on_mContentFontPushButton_clicked()
   }
 
   bool ok;
-#if defined(Q_WS_MAC) && defined(QT_MAC_USE_COCOA)
+#if defined(Q_OS_MAC) && defined(QT_MAC_USE_COCOA)
   // Native Mac dialog works only for Qt Carbon
   QFont newFont = QFontDialog::getFont( &ok, mComposerTable->contentFont(), 0, tr( "Select Font" ), QFontDialog::DontUseNativeDialog );
 #else

--- a/src/app/gps/qwtpolar-1.0/qwt_polar_global.h
+++ b/src/app/gps/qwtpolar-1.0/qwt_polar_global.h
@@ -16,7 +16,7 @@
 #define QWT_POLAR_VERSION       0x010000
 #define QWT_POLAR_VERSION_STR   "1.0.0"
 
-#if defined(Q_WS_WIN) || defined(Q_WS_S60)
+#if defined(Q_OS_WIN) || defined(Q_WS_S60)
 
 #if defined(_MSC_VER) /* MSVC Compiler */
 /* template-class specialization 'identifier' is already instantiated */
@@ -34,7 +34,7 @@
 
 #endif // QWT_POLAR_MAKEDLL
 
-#endif // Q_WS_WIN
+#endif // Q_OS_WIN
 
 #ifndef QWT_POLAR_EXPORT
 #define QWT_POLAR_EXPORT

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -631,7 +631,7 @@ int main( int argc, char *argv[] )
   QgsApplication myApp( argc, argv, myUseGuiFlag, configpath );
 
 // (if Windows/Mac, use icon from resource)
-#if !defined(Q_WS_WIN) && !defined(Q_WS_MAC)
+#if !defined(Q_OS_WIN) && !defined(Q_OS_MAC)
   myApp.setWindowIcon( QIcon( QgsApplication::iconsPath() + "qgis-icon-60x60.png" ) );
 #endif
 
@@ -727,7 +727,7 @@ int main( int argc, char *argv[] )
 
         if ( systemEnvVars.contains( envVarName ) && envVarApply == "unset" )
         {
-#ifdef Q_WS_WIN
+#ifdef Q_OS_WIN
           putenv( envVarName.toUtf8().constData() );
 #else
           unsetenv( envVarName.toUtf8().constData() );
@@ -735,7 +735,7 @@ int main( int argc, char *argv[] )
         }
         else
         {
-#ifdef Q_WS_WIN
+#ifdef Q_OS_WIN
           if ( envVarApply != "undefined" || !getenv( envVarName.toUtf8().constData() ) )
             putenv( QString( "%1=%2" ).arg( envVarName ).arg( envVarValue ).toUtf8().constData() );
 #else
@@ -755,7 +755,7 @@ int main( int argc, char *argv[] )
   QString style = mySettings.value( "/qgis/style" ).toString();
   if ( !style.isNull() )
     QApplication::setStyle( style );
-#ifdef Q_WS_WIN
+#ifdef Q_OS_WIN
 #if QT_VERSION < 0x050000
   else
     QApplication::setStyle( new QPlastiqueStyle );
@@ -828,7 +828,7 @@ int main( int argc, char *argv[] )
   // we need to be sure we can find the qt image
   // plugins. In mac be sure to look in the
   // application bundle...
-#ifdef Q_WS_WIN
+#ifdef Q_OS_WIN
   QCoreApplication::addLibraryPath( QApplication::applicationDirPath()
                                     + QDir::separator() + "qtplugins" );
 #endif
@@ -967,7 +967,7 @@ int main( int argc, char *argv[] )
 
   if ( !pythonfile.isEmpty() )
   {
-#ifdef Q_WS_WIN
+#ifdef Q_OS_WIN
     //replace backslashes with forward slashes
     pythonfile.replace( "\\", "/" );
 #endif

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -599,7 +599,7 @@ int main( int argc, char *argv[] )
   // Initialise the application and the translation stuff
   /////////////////////////////////////////////////////////////////////
 
-#ifdef Q_WS_X11
+#ifdef Q_OS_UNIX
   bool myUseGuiFlag = getenv( "DISPLAY" ) != 0;
 #else
   bool myUseGuiFlag = true;

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -664,7 +664,7 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, QWidget * parent, 
   connect( mInternalClipboard, SIGNAL( changed() ), this, SLOT( clipboardChanged() ) );
   mQgisInterface = new QgisAppInterface( this ); // create the interfce
 
-#ifdef Q_WS_MAC
+#ifdef Q_OS_MAC
   // action for Window menu (create before generating WindowTitleChange event))
   mWindowAction = new QAction( this );
   connect( mWindowAction, SIGNAL( triggered() ), this, SLOT( activate() ) );
@@ -1172,7 +1172,7 @@ void QgisApp::createActions()
   connect( mActionStyleManagerV2, SIGNAL( triggered() ), this, SLOT( showStyleManagerV2() ) );
   connect( mActionCustomization, SIGNAL( triggered() ), this, SLOT( customize() ) );
 
-#ifdef Q_WS_MAC
+#ifdef Q_OS_MAC
   // Window Menu Items
 
   mActionWindowMinimize = new QAction( tr( "Minimize" ), this );
@@ -1220,7 +1220,7 @@ void QgisApp::createActions()
 
   // Help Menu Items
 
-#ifdef Q_WS_MAC
+#ifdef Q_OS_MAC
   mActionHelpContents->setShortcut( QString( "Ctrl+?" ) );
   mActionQgisHomePage->setShortcut( QString() );
 #endif
@@ -1297,7 +1297,7 @@ void QgisApp::showPythonDialog()
     mPythonUtils->getError( className, text );
     messageBar()->pushMessage( tr( "Error" ), tr( "Failed to open Python console:" ) + "\n" + className + ": " + text, QgsMessageBar::WARNING );
   }
-#ifdef Q_WS_MAC
+#ifdef Q_OS_MAC
   else
   {
     addWindow( mActionShowPythonDialog );
@@ -1449,14 +1449,14 @@ void QgisApp::createMenus()
   }
 
 
-#ifdef Q_WS_MAC
+#ifdef Q_OS_MAC
   //disabled for OSX - see #10761
   //also see http://qt-project.org/forums/viewthread/3630 QGraphicsEffects are not well supported on OSX
   mMenuPreviewMode->menuAction()->setVisible( false );
 #endif
 
 
-#ifdef Q_WS_MAC
+#ifdef Q_OS_MAC
 
   // keep plugins from hijacking About and Preferences application menus
   // these duplicate actions will be moved to application menus by Qt
@@ -4460,7 +4460,7 @@ void QgisApp::activate()
 
 void QgisApp::bringAllToFront()
 {
-#ifdef Q_WS_MAC
+#ifdef Q_OS_MAC
   // Bring forward all open windows while maintaining layering order
   ProcessSerialNumber psn;
   GetCurrentProcess( &psn );
@@ -4470,7 +4470,7 @@ void QgisApp::bringAllToFront()
 
 void QgisApp::addWindow( QAction *action )
 {
-#ifdef Q_WS_MAC
+#ifdef Q_OS_MAC
   mWindowActions->addAction( action );
   mWindowMenu->addAction( action );
   action->setCheckable( true );
@@ -4482,7 +4482,7 @@ void QgisApp::addWindow( QAction *action )
 
 void QgisApp::removeWindow( QAction *action )
 {
-#ifdef Q_WS_MAC
+#ifdef Q_OS_MAC
   mWindowActions->removeAction( action );
   mWindowMenu->removeAction( action );
 #else
@@ -7368,7 +7368,7 @@ class QgsPythonRunnerImpl : public QgsPythonRunner
 void QgisApp::loadPythonSupport()
 {
   QString pythonlibName( "qgispython" );
-#if defined(Q_WS_MAC) || defined(Q_OS_LINUX)
+#if defined(Q_OS_MAC) || defined(Q_OS_LINUX)
   pythonlibName.prepend( QgsApplication::libraryPath() );
 #endif
 #ifdef __MINGW32__
@@ -8072,7 +8072,7 @@ void QgisApp::closeProject()
 void QgisApp::changeEvent( QEvent* event )
 {
   QMainWindow::changeEvent( event );
-#ifdef Q_WS_MAC
+#ifdef Q_OS_MAC
   switch ( event->type() )
   {
     case QEvent::ActivationChange:
@@ -8120,7 +8120,7 @@ QMenu* QgisApp::getPluginMenu( QString menuName )
    * of the menu.
    */
 
-#ifdef Q_WS_MAC
+#ifdef Q_OS_MAC
   // Mac doesn't have '&' keyboard shortcuts.
   menuName.remove( QChar( '&' ) );
 #endif
@@ -8192,7 +8192,7 @@ void QgisApp::removePluginMenu( QString name, QAction* action )
 
 QMenu* QgisApp::getDatabaseMenu( QString menuName )
 {
-#ifdef Q_WS_MAC
+#ifdef Q_OS_MAC
   // Mac doesn't have '&' keyboard shortcuts.
   menuName.remove( QChar( '&' ) );
 #endif
@@ -8232,7 +8232,7 @@ QMenu* QgisApp::getDatabaseMenu( QString menuName )
 
 QMenu* QgisApp::getRasterMenu( QString menuName )
 {
-#ifdef Q_WS_MAC
+#ifdef Q_OS_MAC
   // Mac doesn't have '&' keyboard shortcuts.
   menuName.remove( QChar( '&' ) );
 #endif
@@ -8282,7 +8282,7 @@ QMenu* QgisApp::getRasterMenu( QString menuName )
 
 QMenu* QgisApp::getVectorMenu( QString menuName )
 {
-#ifdef Q_WS_MAC
+#ifdef Q_OS_MAC
   // Mac doesn't have '&' keyboard shortcuts.
   menuName.remove( QChar( '&' ) );
 #endif
@@ -8322,7 +8322,7 @@ QMenu* QgisApp::getVectorMenu( QString menuName )
 
 QMenu* QgisApp::getWebMenu( QString menuName )
 {
-#ifdef Q_WS_MAC
+#ifdef Q_OS_MAC
   // Mac doesn't have '&' keyboard shortcuts.
   menuName.remove( QChar( '&' ) );
 #endif

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -364,7 +364,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     QAction *actionCustomProjection() { return mActionCustomProjection; }
     QAction *actionConfigureShortcuts() { return mActionConfigureShortcuts; }
 
-#ifdef Q_WS_MAC
+#ifdef Q_OS_MAC
     QAction *actionWindowMinimize() { return mActionWindowMinimize; }
     QAction *actionWindowZoom() { return mActionWindowZoom; }
     QAction *actionWindowAllToFront() { return mActionWindowAllToFront; }
@@ -394,7 +394,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     QMenu *rasterMenu() { return mRasterMenu; }
     QMenu *vectorMenu() { return mVectorMenu; }
     QMenu *webMenu() { return mWebMenu; }
-#ifdef Q_WS_MAC
+#ifdef Q_OS_MAC
     QMenu *firstRightStandardMenu() { return mWindowMenu; }
     QMenu *windowMenu() { return mWindowMenu; }
 #else
@@ -1349,7 +1349,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     // actions for menus and toolbars -----------------
 
-#ifdef Q_WS_MAC
+#ifdef Q_OS_MAC
     QAction *mActionWindowMinimize;
     QAction *mActionWindowZoom;
     QAction *mActionWindowSeparator1;
@@ -1368,7 +1368,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     // menus ------------------------------------------
 
-#ifdef Q_WS_MAC
+#ifdef Q_OS_MAC
     QMenu *mWindowMenu;
 #endif
     QMenu *mPanelMenu;
@@ -1381,7 +1381,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     QDockWidget *mpGpsDock;
     QDockWidget *mLogDock;
 
-#ifdef Q_WS_MAC
+#ifdef Q_OS_MAC
     //! Window menu action to select this window
     QAction *mWindowAction;
 #endif

--- a/src/app/qgisappstylesheet.cpp
+++ b/src/app/qgisappstylesheet.cpp
@@ -262,7 +262,7 @@ void QgisAppStyleSheet::setActiveValues()
 #endif
 
   // window servers
-#ifdef Q_WS_X11
+#ifdef Q_OS_UNIX
   mX11WS = true;
 #else
   mX11WS = false;

--- a/src/app/qgisappstylesheet.cpp
+++ b/src/app/qgisappstylesheet.cpp
@@ -267,12 +267,12 @@ void QgisAppStyleSheet::setActiveValues()
 #else
   mX11WS = false;
 #endif
-#ifdef Q_WS_WIN
+#ifdef Q_OS_WIN
   mWinWS = true;
 #else
   mWinWS = false;
 #endif
-#ifdef Q_WS_MAC
+#ifdef Q_OS_MAC
   mMacWS = true;
 #else
   mMacWS = false;

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -277,7 +277,7 @@ void QgsAppLayerTreeViewMenuProvider::addCustomLayerActions( QMenu* menu, QgsMap
           // find or create menu for given menu name
           // adapted from QgisApp::getPluginMenu( QString menuName )
           QString menuName = lyrActions[i].menu;
-#ifdef Q_WS_MAC
+#ifdef Q_OS_MAC
           // Mac doesn't have '&' keyboard shortcuts.
           menuName.remove( QChar( '&' ) );
 #endif

--- a/src/app/qgsdecorationgriddialog.cpp
+++ b/src/app/qgsdecorationgriddialog.cpp
@@ -275,7 +275,7 @@ void QgsDecorationGridDialog::on_mPbtnUpdateFromLayer_clicked()
 void QgsDecorationGridDialog::on_mAnnotationFontButton_clicked()
 {
   bool ok;
-#if defined(Q_WS_MAC) && defined(QT_MAC_USE_COCOA)
+#if defined(Q_OS_MAC) && defined(QT_MAC_USE_COCOA)
   // Native Mac dialog works only for Qt Carbon
   QFont newFont = QFontDialog::getFont( &ok, mDeco.gridAnnotationFont(), 0, QString(), QFontDialog::DontUseNativeDialog );
 #else

--- a/src/app/qgslabeldialog.cpp
+++ b/src/app/qgslabeldialog.cpp
@@ -277,7 +277,7 @@ void QgsLabelDialog::changeFont( void )
 
   qreal fontSize = mFont.pointSizeF();
   bool resultFlag;
-#if defined(Q_WS_MAC) && defined(QT_MAC_USE_COCOA)
+#if defined(Q_OS_MAC) && defined(QT_MAC_USE_COCOA)
   // Native Mac dialog works only for Qt Carbon
   mFont = QFontDialog::getFont( &resultFlag, mFont, 0, QString(), QFontDialog::DontUseNativeDialog );
 #else

--- a/src/app/qgsmaptooloffsetcurve.cpp
+++ b/src/app/qgsmaptooloffsetcurve.cpp
@@ -304,7 +304,7 @@ void QgsMapToolOffsetCurve::createDistanceItem()
   mDistanceSpinBox->setMaximum( 99999999 );
   mDistanceSpinBox->setDecimals( 2 );
   mDistanceSpinBox->setPrefix( tr( "Offset: " ) );
-#ifndef Q_WS_X11
+#ifndef Q_OS_UNIX
   mDistanceItem = new QGraphicsProxyWidget();
   mDistanceItem->setWidget( mDistanceSpinBox );
   mCanvas->scene()->addItem( mDistanceItem );
@@ -326,7 +326,7 @@ void QgsMapToolOffsetCurve::deleteDistanceItem()
   }
   delete mDistanceItem;
   mDistanceItem = 0;
-#ifdef Q_WS_X11
+#ifdef Q_OS_UNIX
   QgisApp::instance()->statusBar()->removeWidget( mDistanceSpinBox );
   delete mDistanceSpinBox;
 #endif

--- a/src/core/gps/qextserialport/qextserialenumerator.cpp
+++ b/src/core/gps/qextserialport/qextserialenumerator.cpp
@@ -2,7 +2,7 @@
 #include <QDebug>
 #include <QMetaType>
 
-#ifdef Q_WS_WIN
+#ifdef Q_OS_WIN
 #ifdef UNICODE
 #define TCHAR
 #else

--- a/src/core/gps/qgsgpsdetector.cpp
+++ b/src/core/gps/qgsgpsdetector.cpp
@@ -81,7 +81,7 @@ QList< QPair<QString, QString> > QgsGPSDetector::availablePorts()
   }
 #endif
 
-#if defined(Q_WS_WIN) || defined(Q_WS_MAC)
+#if defined(Q_OS_WIN) || defined(Q_OS_MAC)
   QList<QextPortInfo> ports = QextSerialEnumerator::getPorts();
   foreach ( QextPortInfo port, ports )
   {

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -33,7 +33,7 @@
 #include <QPixmap>
 #include <QThreadPool>
 
-#ifndef Q_WS_WIN
+#ifndef Q_OS_WIN
 #include <netinet/in.h>
 #else
 #include <winsock.h>
@@ -153,7 +153,7 @@ void QgsApplication::init( QString customConfigPath )
     char *prefixPath = getenv( "QGIS_PREFIX_PATH" );
     if ( !prefixPath )
     {
-#if defined(Q_WS_MACX) || defined(Q_WS_WIN32) || defined(WIN32)
+#if defined(Q_OS_MACX) || defined(Q_OS_WIN32) || defined(WIN32)
       setPrefixPath( applicationDirPath(), true );
 #elif defined(ANDROID)
       // this is  "/data/data/org.qgis.qgis" in android
@@ -922,7 +922,7 @@ bool QgsApplication::createDB( QString *errorMessage )
     myDir.mkpath( myPamPath ); //fail silently
   }
 
-#if defined(Q_WS_WIN32) || defined(WIN32)
+#if defined(Q_OS_WIN32) || defined(WIN32)
   CPLSetConfigOption( "GDAL_PAM_PROXY_DIR", myPamPath.toUtf8() );
 #else
   //under other OS's we use an environment var so the user can

--- a/src/core/qgsbrowsermodel.cpp
+++ b/src/core/qgsbrowsermodel.cpp
@@ -116,7 +116,7 @@ void QgsBrowserModel::addRootItems()
     mRootItems << item;
   }
 
-#ifdef Q_WS_MAC
+#ifdef Q_OS_MAC
   QString path = QString( "/Volumes" );
   QgsDirectoryItem *vols = new QgsDirectoryItem( NULL, path, path );
   connectItem( vols );

--- a/src/core/qgsgeometry.cpp
+++ b/src/core/qgsgeometry.cpp
@@ -34,7 +34,7 @@ email                : morb at ozemail dot com dot au
 
 #include <QDebug>
 
-#ifndef Q_WS_WIN
+#ifndef Q_OS_WIN
 #include <netinet/in.h>
 #else
 #include <winsock.h>

--- a/src/core/qgsogcutils.cpp
+++ b/src/core/qgsogcutils.cpp
@@ -7,7 +7,7 @@
 #include <QStringList>
 #include <QTextStream>
 
-#ifndef Q_WS_WIN
+#ifndef Q_OS_WIN
 #include <netinet/in.h>
 #else
 #include <winsock.h>

--- a/src/gui/qgscolorbutton.cpp
+++ b/src/gui/qgscolorbutton.cpp
@@ -343,7 +343,7 @@ void QgsColorButton::showContextMenu( QMouseEvent *event )
   QAction* pasteColorAction = new QAction( tr( "Paste color" ), 0 );
   pasteColorAction->setEnabled( false );
   colorContextMenu.addAction( pasteColorAction );
-#ifndef Q_WS_MAC
+#ifndef Q_OS_MAC
   //disabled for OSX, as it is impossible to grab the mouse under OSX
   //see note for QWidget::grabMouse() re OSX Cocoa
   //http://qt-project.org/doc/qt-4.8/qwidget.html#grabMouse
@@ -369,7 +369,7 @@ void QgsColorButton::showContextMenu( QMouseEvent *event )
     //paste color
     setColor( clipColor );
   }
-#ifndef Q_WS_MAC
+#ifndef Q_OS_MAC
   else if ( selectedAction == pickColorAction )
   {
     //pick color

--- a/src/gui/qgscolorbuttonv2.cpp
+++ b/src/gui/qgscolorbuttonv2.cpp
@@ -74,7 +74,7 @@ QgsColorButtonV2::~QgsColorButtonV2()
 QSize QgsColorButtonV2::sizeHint() const
 {
   //make sure height of button looks good under different platforms
-#ifdef Q_WS_WIN
+#ifdef Q_OS_WIN
   return QSize( 120, 22 );
 #else
   return QSize( 120, 28 );
@@ -439,7 +439,7 @@ void QgsColorButtonV2::prepareMenu()
   mMenu->addAction( pasteColorAction );
   connect( pasteColorAction, SIGNAL( triggered() ), this, SLOT( pasteColor() ) );
 
-#ifndef Q_WS_MAC
+#ifndef Q_OS_MAC
   //disabled for OSX, as it is impossible to grab the mouse under OSX
   //see note for QWidget::grabMouse() re OSX Cocoa
   //http://qt-project.org/doc/qt-4.8/qwidget.html#grabMouse
@@ -563,7 +563,7 @@ void QgsColorButtonV2::setButtonBackground( const QColor &color )
       QRect buttonSize = QApplication::style()->subControlRect( QStyle::CC_ToolButton, &opt, QStyle::SC_ToolButton,
                          this );
       //make sure height of icon looks good under different platforms
-#ifdef Q_WS_WIN
+#ifdef Q_OS_WIN
       mIconSize = QSize( buttonSize.width() - 10, height() - 6 );
 #else
       mIconSize = QSize( buttonSize.width() - 10, height() - 12 );
@@ -574,7 +574,7 @@ void QgsColorButtonV2::setButtonBackground( const QColor &color )
   else
   {
     //no menu
-#ifdef Q_WS_WIN
+#ifdef Q_OS_WIN
     currentIconSize = QSize( width() - 10, height() - 6 );
 #else
     currentIconSize = QSize( width() - 10, height() - 12 );

--- a/src/gui/qgscolordialog.cpp
+++ b/src/gui/qgscolordialog.cpp
@@ -235,7 +235,7 @@ QgsColorDialogV2::QgsColorDialogV2( QWidget *parent, Qt::WindowFlags fl, const Q
   int currentTab = settings.value( "/Windows/ColorDialog/activeTab", 0 ).toInt();
   mTabWidget->setCurrentIndex( currentTab );
 
-#ifdef Q_WS_MAC
+#ifdef Q_OS_MAC
   //disable color picker tab for OSX, as it is impossible to grab the mouse under OSX
   //see note for QWidget::grabMouse() re OSX Cocoa
   //http://qt-project.org/doc/qt-4.8/qwidget.html#grabMouse

--- a/src/gui/qgsmapoverviewcanvas.cpp
+++ b/src/gui/qgsmapoverviewcanvas.cpp
@@ -158,7 +158,7 @@ void QgsMapOverviewCanvas::drawExtentRect()
   if ( y1 > y2 )
     std::swap( y1, y2 );
 
-#ifdef Q_WS_MAC
+#ifdef Q_OS_MAC
   // setGeometry (Qt 4.2) is causing Mac window corruption (decorations
   // are drawn at odd locations) if both coords are at limit. This may
   // have something to do with Qt calculating dimensions as x2 - x1 + 1.

--- a/src/gui/qgsrasterformatsaveoptionswidget.cpp
+++ b/src/gui/qgsrasterformatsaveoptionswidget.cpp
@@ -281,7 +281,7 @@ void QgsRasterFormatSaveOptionsWidget::helpOptions()
   textEdit->setText( message );
   dlg->layout()->addWidget( textEdit );
   dlg->resize( 600, 400 );
-#ifdef Q_WS_MAC
+#ifdef Q_OS_MAC
   dlg->exec(); //modal
 #else
   dlg->show(); //non modal

--- a/src/gui/symbology-ng/qgspointdisplacementrendererwidget.cpp
+++ b/src/gui/symbology-ng/qgspointdisplacementrendererwidget.cpp
@@ -186,7 +186,7 @@ void QgsPointDisplacementRendererWidget::on_mRendererSettingsButton_clicked()
   if ( mEmbeddedRendererWidget )
   {
     //create a dialog with the embedded widget
-#ifdef Q_WS_MAC
+#ifdef Q_OS_MAC
     QDialog* d = new QDialog( this->window() );
     d->setWindowModality( Qt::WindowModal );
 #else
@@ -213,7 +213,7 @@ void QgsPointDisplacementRendererWidget::on_mLabelFontButton_clicked()
   }
 
   bool ok;
-#if defined(Q_WS_MAC) && defined(QT_MAC_USE_COCOA)
+#if defined(Q_OS_MAC) && defined(QT_MAC_USE_COCOA)
   // Native Mac dialog works only for QT Carbon
   QFont newFont = QFontDialog::getFont( &ok, mRenderer->labelFont(), 0, tr( "Label Font" ), QFontDialog::DontUseNativeDialog );
 #else

--- a/src/gui/symbology-ng/qgsrulebasedrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgsrulebasedrendererv2widget.cpp
@@ -564,7 +564,7 @@ QgsRendererRulePropsDialog::QgsRendererRulePropsDialog( QgsRuleBasedRendererV2::
     : QDialog( parent ), mRule( rule ), mLayer( layer ), mSymbolSelector( NULL ), mSymbol( NULL )
 {
   setupUi( this );
-#ifdef Q_WS_MAC
+#ifdef Q_OS_MAC
   setWindowModality( Qt::WindowModal );
 #endif
 

--- a/src/gui/symbology-ng/qgsstylev2managerdialog.cpp
+++ b/src/gui/symbology-ng/qgsstylev2managerdialog.cpp
@@ -45,7 +45,7 @@ QgsStyleV2ManagerDialog::QgsStyleV2ManagerDialog( QgsStyleV2* style, QWidget* pa
     : QDialog( parent ), mStyle( style ), mModified( false )
 {
   setupUi( this );
-#ifdef Q_WS_MAC
+#ifdef Q_OS_MAC
   setWindowModality( Qt::WindowModal );
 #endif
 

--- a/src/gui/symbology-ng/qgssymbolv2selectordialog.cpp
+++ b/src/gui/symbology-ng/qgssymbolv2selectordialog.cpp
@@ -142,7 +142,7 @@ class SymbolLayerItem : public QStandardItem
 QgsSymbolV2SelectorDialog::QgsSymbolV2SelectorDialog( QgsSymbolV2* symbol, QgsStyleV2* style, const QgsVectorLayer* vl, QWidget* parent, bool embedded )
     : QDialog( parent ), mAdvancedMenu( NULL ), mVectorLayer( vl )
 {
-#ifdef Q_WS_MAC
+#ifdef Q_OS_MAC
   setWindowModality( Qt::WindowModal );
 #endif
   mStyle = style;

--- a/src/gui/symbology-ng/qgsvectorgradientcolorrampv2dialog.cpp
+++ b/src/gui/symbology-ng/qgsvectorgradientcolorrampv2dialog.cpp
@@ -32,7 +32,7 @@ QgsVectorGradientColorRampV2Dialog::QgsVectorGradientColorRampV2Dialog( QgsVecto
     : QDialog( parent ), mRamp( ramp ), mCurrentItem( 0 )
 {
   setupUi( this );
-#ifdef Q_WS_MAC
+#ifdef Q_OS_MAC
   setWindowModality( Qt::WindowModal );
 #endif
 
@@ -334,7 +334,7 @@ void QgsVectorGradientColorRampV2Dialog::addStop()
 // workaround: call QColorDialog::getColor below instead of here,
 // but not needed at this time because of the other Qt bug
 // FIXME need to also check max QT_VERSION when Qt bug(s) fixed
-#ifndef Q_WS_MAC
+#ifndef Q_OS_MAC
   QColor color = QgsColorDialogV2::getColor( QColor(), this, tr( "Add Color Stop" ), true );
 
   if ( !color.isValid() )
@@ -355,7 +355,7 @@ void QgsVectorGradientColorRampV2Dialog::addStop()
   QStringList lst;
   lst << "." << QString(( val < 10 ) ? '0' + QString::number( val ) : QString::number( val ) );
 
-#ifdef Q_WS_MAC
+#ifdef Q_OS_MAC
   QColor color = QgsColorDialogV2::getColor( QColor(), this, tr( "Add Color Stop" ), true );
 
   if ( !color.isValid() )

--- a/src/helpviewer/main.cpp
+++ b/src/helpviewer/main.cpp
@@ -45,10 +45,10 @@ int main( int argc, char ** argv )
 
   if ( !QgsApplication::isRunningFromBuildDir() )
   {
-#if defined(Q_WS_MACX)
+#if defined(Q_OS_MACX)
     // If we're on Mac, we have the resource library way above us...
     a.setPkgDataPath( QgsApplication::prefixPath() + "/../../../../" + QString( QGIS_DATA_SUBDIR ) );
-#elif defined(Q_WS_WIN)
+#elif defined(Q_OS_WIN)
     a.setPkgDataPath( QgsApplication::prefixPath() + "/" QGIS_DATA_SUBDIR );
 #else
     a.setPkgDataPath( QgsApplication::prefixPath() + "/../" QGIS_DATA_SUBDIR );

--- a/src/plugins/grass/qgsgrassnewmapset.cpp
+++ b/src/plugins/grass/qgsgrassnewmapset.cpp
@@ -62,7 +62,7 @@ QgsGrassNewMapset::QgsGrassNewMapset( QgisInterface *iface,
   QgsDebugMsg( "QgsGrassNewMapset()" );
 
   setupUi( this );
-#ifdef Q_WS_MAC
+#ifdef Q_OS_MAC
   setWizardStyle( QWizard::ClassicStyle );
 #endif
 

--- a/src/server/qgsserverplugins.cpp
+++ b/src/server/qgsserverplugins.cpp
@@ -38,7 +38,7 @@ bool QgsServerPlugins::initPlugins( QgsServerInterface *interface )
 {
 
   QString pythonlibName( "qgispython" );
-#if defined(Q_WS_MAC) || defined(Q_OS_LINUX)
+#if defined(Q_OS_MAC) || defined(Q_OS_LINUX)
   pythonlibName.prepend( QgsApplication::libraryPath() );
 #endif
 #ifdef __MINGW32__

--- a/src/server/qgswcsserver.cpp
+++ b/src/server/qgswcsserver.cpp
@@ -27,7 +27,7 @@
 #include <QTemporaryFile>
 #include <QUrl>
 
-#ifndef Q_WS_WIN
+#ifndef Q_OS_WIN
 #include <netinet/in.h>
 #else
 #include <winsock.h>

--- a/src/server/qgswfsserver.cpp
+++ b/src/server/qgswfsserver.cpp
@@ -53,7 +53,7 @@
 #include <QUrl>
 #include <QPaintEngine>
 
-#ifndef Q_WS_WIN
+#ifndef Q_OS_WIN
 #include <netinet/in.h>
 #else
 #include <winsock.h>

--- a/tests/bench/main.cpp
+++ b/tests/bench/main.cpp
@@ -415,7 +415,7 @@ int main( int argc, char *argv[] )
   // we need to be sure we can find the qt image
   // plugins. In mac be sure to look in the
   // application bundle...
-#ifdef Q_WS_WIN
+#ifdef Q_OS_WIN
   QCoreApplication::addLibraryPath( QApplication::applicationDirPath()
                                     + QDir::separator() + "qtplugins" );
 #endif


### PR DESCRIPTION
Q_WS_\* macros removed from Qt5, to determine platform use Q_OS_\* macros which exists in Qt4 and Qt5
