### PR TITLE
Fix cppcheck reports:

### DIFF
--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -1067,6 +1067,8 @@ bool QgsOgrProvider::addFeature( QgsFeature& f )
   OGR_F_Destroy( feature );
 
   setlocale( LC_NUMERIC, oldlocale );
+  if (oldlocale)
+    free(oldlocale);
 
   return returnValue;
 }
@@ -1265,6 +1267,8 @@ bool QgsOgrProvider::changeAttributeValues( const QgsChangedAttributesMap & attr
     }
 
     setlocale( LC_NUMERIC, oldlocale );
+    if (oldlocale)
+      free(oldlocale);
   }
 
   if ( OGR_L_SyncToDisk( ogrLayer ) != OGRERR_NONE )

--- a/tests/src/core/testqgscolorscheme.cpp
+++ b/tests/src/core/testqgscolorscheme.cpp
@@ -152,6 +152,8 @@ void TestQgsColorScheme::clone()
   QgsColorScheme* dummyScheme2 = dummyScheme->clone();
   QgsNamedColorList colors2 = dummyScheme2->fetchColors();
   QCOMPARE( colors, colors2 );
+  delete dummyScheme;
+  delete dummyScheme2;
 }
 
 QTEST_MAIN( TestQgsColorScheme )


### PR DESCRIPTION
[src/providers/ogr/qgsogrprovider.cpp:1071]: (error) Memory leak: oldlocale
[src/providers/ogr/qgsogrprovider.cpp:1268]: (error) Memory leak: oldlocale
[src/core/spatialite/spatialite.c:50598]: (error) Memory leak: reader
[tests/src/core/testqgscolorscheme.cpp:155]: (error) Memory leak: dummyScheme2
[src/core/spatialite/spatialite.c:40138]: (error) Memory leak: ln
