### PR TITLE
[rotation] prevent rotation of labels when placed around or over a point / centroid

### DIFF
--- a/src/core/qgspallabeling.cpp
+++ b/src/core/qgspallabeling.cpp
@@ -4139,7 +4139,9 @@ void QgsPalLabeling::drawLabelCandidateRect( pal::LabelPosition* lp, QPainter* p
   if ( rotation )
   {
     // Only if not horizontal
-    if ( lp->getFeaturePart()->getLayer()->getArrangement() != P_HORIZ )
+    if ( lp->getFeaturePart()->getLayer()->getArrangement() != P_POINT &&
+         lp->getFeaturePart()->getLayer()->getArrangement() != P_POINT_OVER &&
+         lp->getFeaturePart()->getLayer()->getArrangement() != P_HORIZ )
     {
       painter->rotate( rotation );
     }
@@ -4303,7 +4305,9 @@ void QgsPalLabeling::drawLabel( pal::LabelPosition* label, QgsRenderContext& con
       if ( rotation )
       {
         // Only if not horizontal
-        if ( lp->getFeaturePart()->getLayer()->getArrangement() != P_HORIZ )
+        if ( lp->getFeaturePart()->getLayer()->getArrangement() != P_POINT &&
+             lp->getFeaturePart()->getLayer()->getArrangement() != P_POINT_OVER &&
+             lp->getFeaturePart()->getLayer()->getArrangement() != P_HORIZ )
         {
           painter->rotate( rotation );
         }


### PR DESCRIPTION
Right now, only the labels which are set to horizontal placement are displayed to the horizontal of the canvas. That behavior should be extended to labels with placement set to be around point/centroid of offset of point/centroid. This pull request does it in the simplest of ways.

Right now, this is how things look for labels placed around point / centroid when rotation value is 45 degrees:
![45_rotation-current_label](https://cloud.githubusercontent.com/assets/1728657/5602331/8bd4cd62-9378-11e4-8cd5-115f232e00d6.jpg)

With my pull request applied, the labels placed around point / centroid with rotation value of 45 are rendered as such:
![45_rotation-proposed_label](https://cloud.githubusercontent.com/assets/1728657/5602333/aa1df4b0-9378-11e4-9e1e-bd978f3de149.jpg)

Is far from perfect, as long labels can look detached from respective points (see the Chamka Chrey Khang Tbong label and its triangle point below it, quite far when compared to other labels for the triangle symbology). But to fix that, it'll probably require a much deeper refactoring.

This patch is a quick band-aid until a deeper code change occurs.

@dakcarto , @strk , could we apply this for the immediate benefits prior to a bigger re-thinking of how rotated labels should work?
