### PR TITLE
Label pre-rotation

### DIFF
--- a/src/core/qgspalgeometry.h
+++ b/src/core/qgspalgeometry.h
@@ -67,14 +67,14 @@ class QgsPalGeometry : public PalGeometry
         maxoutangle = -95.0;
 
       // create label info!
-      QgsPoint ptZero = xform->toMapCoordinates( 0, 0 );
-      QgsPoint ptSize = xform->toMapCoordinatesF( 0.0, -fm->height() / fontScale );
+      double mapScale = xform->mapUnitsPerPixel();
+      double labelHeight = mapScale * fm->height() / fontScale;
 
       // mLetterSpacing/mWordSpacing = 0.0 is default for non-curved labels
       // (non-curved spacings handled by Qt in QgsPalLayerSettings/QgsPalLabeling)
       qreal charWidth;
       qreal wordSpaceFix;
-      mInfo = new pal::LabelInfo( mText.count(), ptSize.y() - ptZero.y(), maxinangle, maxoutangle );
+      mInfo = new pal::LabelInfo( mText.count(), labelHeight, maxinangle, maxoutangle );
       for ( int i = 0; i < mText.count(); i++ )
       {
         mInfo->char_info[i].chr = mText[i].unicode();
@@ -99,8 +99,8 @@ class QgsPalGeometry : public PalGeometry
           charWidth = fm->width( QString( mText[i] ) ) + wordSpaceFix;
         }
 
-        ptSize = xform->toMapCoordinatesF((( double ) charWidth ) / fontScale, 0.0 );
-        mInfo->char_info[i].width = ptSize.x() - ptZero.x();
+        double labelWidth = mapScale * charWidth / fontScale;
+        mInfo->char_info[i].width = labelWidth;
       }
       return mInfo;
     }

--- a/src/core/qgspallabeling.cpp
+++ b/src/core/qgspallabeling.cpp
@@ -4210,17 +4210,21 @@ void QgsPalLabeling::drawLabel( pal::LabelPosition* label, QgsRenderContext& con
 {
   // NOTE: this is repeatedly called for multi-part labels
   QPainter* painter = context.painter();
-#if 1 // TODO str XXX drop me or fix me (leaks memory)
-  QgsMapToPixel* xform = new QgsMapToPixel(context.mapToPixel());
-  xform->setMapRotation(0,0,0);
+#if 1
+  // features are pre-rotated but not scaled/translated,
+  // so we only disable rotation here. Ideally, they'd be
+  // also pre-scaled/translated, as suggested here:
+  // http://hub.qgis.org/issues/11856
+  QgsMapToPixel xform = context.mapToPixel();
+  xform.setMapRotation(0,0,0);
 #else
-  const QgsMapToPixel* xform = &context.mapToPixel();
+  const QgsMapToPixel& xform = context.mapToPixel();
 #endif
 
   QgsLabelComponent component;
   component.setDpiRatio( dpiRatio );
 
-  QgsPoint outPt = xform->transform( label->getX(), label->getY() );
+  QgsPoint outPt = xform.transform( label->getX(), label->getY() );
 //  QgsPoint outPt2 = xform->transform( label->getX() + label->getWidth(), label->getY() + label->getHeight() );
 //  QRectF labelRect( 0, 0, outPt2.x() - outPt.x(), outPt2.y() - outPt.y() );
 
@@ -4231,8 +4235,8 @@ void QgsPalLabeling::drawLabel( pal::LabelPosition* label, QgsRenderContext& con
   {
     // get rotated label's center point
     QgsPoint centerPt( outPt );
-    QgsPoint outPt2 = xform->transform( label->getX() + label->getWidth() / 2,
-                                        label->getY() + label->getHeight() / 2 );
+    QgsPoint outPt2 = xform.transform( label->getX() + label->getWidth() / 2,
+                                       label->getY() + label->getHeight() / 2 );
 
     double xc = outPt2.x() - outPt.x();
     double yc = outPt2.y() - outPt.y();

--- a/src/core/qgspallabeling.cpp
+++ b/src/core/qgspallabeling.cpp
@@ -3351,14 +3351,7 @@ int QgsPalLabeling::prepareLayer( QgsVectorLayer* layer, QStringList& attrNames,
   lyr.palLayer = l;
   lyr.fieldIndex = layer->fieldNameIndex( lyr.fieldName );
 
-#if 1 // XXX strk drop me or fix me (leaks memory)
-  QgsMapToPixel* m2p = new QgsMapToPixel(mMapSettings->mapToPixel());
-  // TODO: only reset rotation IFF it needs not be considered at rendering time ?
-  m2p->setMapRotation(0,0,0);
-  lyr.xform = m2p;
-#else
   lyr.xform = &mMapSettings->mapToPixel();
-#endif
   lyr.ct = 0;
   if ( mMapSettings->hasCrsTransformEnabled() )
     lyr.ct = new QgsCoordinateTransform( layer->crs(), mMapSettings->destinationCrs() );


### PR DESCRIPTION
Pre-rotate vectors for placing labels.
This was suggested by @dakcarto in http://hub.qgis.org/issues/11814

Limiting pre-transformation to rotation requires later dropping rotation from the transform matrix used to get to device coordinates. This mixed approach would be fixed by directly acting at the device (pixel) level, as suggested in http://hub.qgis.org/issues/11856

\cc @dakcarto @wonder-sk 
