### PR TITLE
Processing bylocation operators

### DIFF
--- a/python/plugins/processing/algs/qgis/ExtractByLocation.py
+++ b/python/plugins/processing/algs/qgis/ExtractByLocation.py
@@ -28,7 +28,7 @@ __revision__ = '$Format:%H$'
 from qgis.core import QGis, QgsFeatureRequest, QgsGeometry
 from processing.core.GeoAlgorithm import GeoAlgorithm
 from processing.core.parameters import ParameterVector
-from processing.core.parameters import ParameterBoolean
+from processing.core.parameters import ParameterGeometryPredicate
 from processing.core.outputs import OutputVector
 from processing.tools import dataobjects, vector
 
@@ -37,36 +37,21 @@ class ExtractByLocation(GeoAlgorithm):
 
     INPUT = 'INPUT'
     INTERSECT = 'INTERSECT'
-    TOUCHES = 'TOUCHES'
-    OVERLAPS = 'OVERLAPS'
-    WITHIN = 'WITHIN'
+    PREDICATE = 'PREDICATE'
     OUTPUT = 'OUTPUT'
-
-    METHODS = ['creating new selection', 'adding to current selection',
-               'removing from current selection']
-    opFlags = 0
-    operators = {'TOUCHES':1,'OVERLAPS':2,'WITHIN':4}
 
     def defineCharacteristics(self):
         self.name = 'Extract by location'
         self.group = 'Vector selection tools'
         self.addParameter(ParameterVector(self.INPUT,
-            self.tr('Layer to select from'), [ParameterVector.VECTOR_TYPE_ANY]))
+            self.tr('Layer to select from'),
+            [ParameterVector.VECTOR_TYPE_ANY]))
         self.addParameter(ParameterVector(self.INTERSECT,
             self.tr('Additional layer (intersection layer)'),
             [ParameterVector.VECTOR_TYPE_ANY]))
-        self.addParameter(ParameterBoolean(
-            self.TOUCHES,
-            self.tr('Include input features that touch the selection features'),
-            [True]))
-        self.addParameter(ParameterBoolean(
-            self.OVERLAPS,
-            self.tr('Include input features that overlap/cross the selection features'),
-            [True]))
-        self.addParameter(ParameterBoolean(
-            self.WITHIN,
-            self.tr('Include input features completely within the selection features'),
-            [True]))
+        self.addParameter(ParameterGeometryPredicate(self.PREDICATE,
+            self.tr('Geometric predicate'),
+            left=self.INPUT, right=self.INTERSECT))
         self.addOutput(OutputVector(self.OUTPUT, self.tr('Selection')))
 
     def processAlgorithm(self, progress):
@@ -74,45 +59,18 @@ class ExtractByLocation(GeoAlgorithm):
         layer = dataobjects.getObjectFromUri(filename)
         filename = self.getParameterValue(self.INTERSECT)
         selectLayer = dataobjects.getObjectFromUri(filename)
+        predicates = self.getParameterValue(self.PREDICATE)
+
         index = vector.spatialindex(layer)
-
-        def _points_op(geomA,geomB):
-            return geomA.intersects(geomB)
-
-        def _poly_lines_op(geomA,geomB):
-            if geomA.disjoint(geomB):
-                return False
-            intersects = False
-            if self.opFlags & self.operators['TOUCHES']:
-                intersects |= geomA.touches(geomB)
-            if not intersects and (self.opFlags & self.operators['OVERLAPS']):
-                if geomB.type() == QGis.Line or geomA.type() == QGis.Line:
-                    intersects |= geomA.crosses(geomB)
-                else:
-                    intersects |= geomA.overlaps(geomB)
-            if not intersects and (self.opFlags & self.operators['WITHIN']):
-                intersects |= geomA.contains(geomB)
-            return intersects
-
-        def _sp_operator():
-            if layer.geometryType() == QGis.Point:
-                return _points_op
-            else:
-                return _poly_lines_op
-
-        self.opFlags = 0
-        if self.getParameterValue(self.TOUCHES):
-            self.opFlags |= self.operators['TOUCHES']
-        if self.getParameterValue(self.OVERLAPS):
-            self.opFlags |= self.operators['OVERLAPS']
-        if self.getParameterValue(self.WITHIN):
-            self.opFlags |= self.operators['WITHIN']
-
-        sp_operator = _sp_operator()
 
         output = self.getOutputFromName(self.OUTPUT)
         writer = output.getVectorWriter(layer.pendingFields(),
                 layer.dataProvider().geometryType(), layer.crs())
+
+        if 'disjoint' in predicates:
+            disjoinSet = []
+            for feat in vector.features(layer):
+                disjoinSet.append(feat.id())
 
         geom = QgsGeometry()
         selectedSet = []
@@ -120,16 +78,44 @@ class ExtractByLocation(GeoAlgorithm):
         features = vector.features(selectLayer)
         featureCount = len(features)
         total = 100.0 / float(len(features))
-        for current,f in enumerate(features):
+        for current, f in enumerate(features):
             geom = QgsGeometry(f.geometry())
             intersects = index.intersects(geom.boundingBox())
             for i in intersects:
                 request = QgsFeatureRequest().setFilterFid(i)
                 feat = layer.getFeatures(request).next()
                 tmpGeom = QgsGeometry(feat.geometry())
-                if sp_operator(geom,tmpGeom):
-                    selectedSet.append(feat.id())
+                res = False
+                for predicate in predicates:
+                    if predicate == 'disjoint':
+                        if tmpGeom.intersects(geom):
+                            try:
+                                disjoinSet.remove(feat.id())
+                            except:
+                                pass  # already removed
+                    else:
+                        if predicate == 'intersects':
+                            res = tmpGeom.intersects()
+                        elif predicate == 'contains':
+                            res = tmpGeom.contains(geom)
+                        elif predicate == 'equals':
+                            res = tmpGeom.equals(geom)
+                        elif predicate == 'touches':
+                            res = tmpGeom.touches(geom)
+                        elif predicate == 'overlaps':
+                            res = tmpGeom.overlaps(geom)
+                        elif predicate == 'within':
+                            res = tmpGeom.within(geom)
+                        elif predicate == 'crosses':
+                            res = tmpGeom.crosses(geom)
+                        if res:
+                            selectedSet.append(feat.id())
+                            break
+
             progress.setPercentage(int(current * total))
+
+        if 'disjoint' in predicates:
+            selectedSet = selectedSet + disjoinSet
 
         for i, f in enumerate(vector.features(layer)):
             if f.id() in selectedSet:

--- a/python/plugins/processing/algs/qgis/SelectByLocation.py
+++ b/python/plugins/processing/algs/qgis/SelectByLocation.py
@@ -29,7 +29,7 @@ from qgis.core import QGis, QgsGeometry, QgsFeatureRequest
 from processing.core.GeoAlgorithm import GeoAlgorithm
 from processing.core.parameters import ParameterSelection
 from processing.core.parameters import ParameterVector
-from processing.core.parameters import ParameterBoolean
+from processing.core.parameters import ParameterGeometryPredicate
 from processing.core.outputs import OutputVector
 from processing.tools import dataobjects, vector
 
@@ -38,38 +38,30 @@ class SelectByLocation(GeoAlgorithm):
 
     INPUT = 'INPUT'
     INTERSECT = 'INTERSECT'
-    TOUCHES = 'TOUCHES'
-    OVERLAPS = 'OVERLAPS'
-    WITHIN = 'WITHIN'
+    PREDICATE = 'PREDICATE'
     METHOD = 'METHOD'
     OUTPUT = 'OUTPUT'
 
-    METHODS = ['creating new selection', 'adding to current selection',
+    METHODS = ['creating new selection',
+               'adding to current selection',
                'removing from current selection']
-    opFlags = 0
-    operators = {'TOUCHES':1,'OVERLAPS':2,'WITHIN':4}
-
 
     def defineCharacteristics(self):
         self.name = 'Select by location'
         self.group = 'Vector selection tools'
-        self.addParameter(ParameterVector(self.INPUT, 'Layer to select from',
-                          [ParameterVector.VECTOR_TYPE_ANY]))
+        self.addParameter(ParameterVector(self.INPUT,
+            self.tr('Layer to select from'),
+            [ParameterVector.VECTOR_TYPE_ANY]))
         self.addParameter(ParameterVector(self.INTERSECT,
-                          'Additional layer (intersection layer)',
-                          [ParameterVector.VECTOR_TYPE_ANY]))
-        self.addParameter(ParameterBoolean(self.TOUCHES,
-                          'Include input features that touch the selection features',
-                          [True]))
-        self.addParameter(ParameterBoolean(self.OVERLAPS,
-                          'Include input features that overlap/cross the selection features',
-                          [True]))
-        self.addParameter(ParameterBoolean(self.WITHIN,
-                          'Include input features completely within the selection features',
-                          [True]))
+            self.tr('Additional layer (intersection layer)'),
+            [ParameterVector.VECTOR_TYPE_ANY]))
+        self.addParameter(ParameterGeometryPredicate(self.PREDICATE,
+            self.tr('Geometric predicate'),
+            left=self.INPUT, right=self.INTERSECT))
         self.addParameter(ParameterSelection(self.METHOD,
-                          'Modify current selection by', self.METHODS, 0))
-        self.addOutput(OutputVector(self.OUTPUT, 'Selection', True))
+            self.tr('Modify current selection by'),
+            self.METHODS, 0))
+        self.addOutput(OutputVector(self.OUTPUT, self.tr('Selection'), True))
 
     def processAlgorithm(self, progress):
         filename = self.getParameterValue(self.INPUT)
@@ -77,44 +69,16 @@ class SelectByLocation(GeoAlgorithm):
         method = self.getParameterValue(self.METHOD)
         filename = self.getParameterValue(self.INTERSECT)
         selectLayer = dataobjects.getObjectFromUri(filename)
+        predicates = self.getParameterValue(self.PREDICATE)
 
         oldSelection = set(inputLayer.selectedFeaturesIds())
         inputLayer.removeSelection()
         index = vector.spatialindex(inputLayer)
 
-        def _points_op(geomA,geomB):
-            return geomA.intersects(geomB)
-
-        def _poly_lines_op(geomA,geomB):
-            if geomA.disjoint(geomB):
-                return False
-            intersects = False
-            if self.opFlags & self.operators['TOUCHES']:
-                intersects |= geomA.touches(geomB)
-            if not intersects and (self.opFlags & self.operators['OVERLAPS']):
-                if geomB.type() == QGis.Line or geomA.type() == QGis.Line:
-                    intersects |= geomA.crosses(geomB)
-                else:
-                    intersects |= geomA.overlaps(geomB)
-            if not intersects and (self.opFlags & self.operators['WITHIN']):
-                intersects |= geomA.contains(geomB)
-            return intersects
-
-        def _sp_operator():
-            if inputLayer.geometryType() == QGis.Point:
-                return _points_op
-            else:
-                return _poly_lines_op
-
-        self.opFlags = 0
-        if self.getParameterValue(self.TOUCHES):
-            self.opFlags |= self.operators['TOUCHES']
-        if self.getParameterValue(self.OVERLAPS):
-            self.opFlags |= self.operators['OVERLAPS']
-        if self.getParameterValue(self.WITHIN):
-            self.opFlags |= self.operators['WITHIN']
-
-        sp_operator = _sp_operator()
+        if 'disjoint' in predicates:
+            disjoinSet = []
+            for feat in vector.features(inputLayer):
+                disjoinSet.append(feat.id())
 
         geom = QgsGeometry()
         selectedSet = []
@@ -123,15 +87,44 @@ class SelectByLocation(GeoAlgorithm):
         total = 100.0 / float(len(features))
         for f in features:
             geom = QgsGeometry(f.geometry())
+
             intersects = index.intersects(geom.boundingBox())
             for i in intersects:
                 request = QgsFeatureRequest().setFilterFid(i)
                 feat = inputLayer.getFeatures(request).next()
                 tmpGeom = QgsGeometry(feat.geometry())
-                if sp_operator(geom,tmpGeom):
-                    selectedSet.append(feat.id())
+                res = False
+                for predicate in predicates:
+                    if predicate == 'disjoint':
+                        if tmpGeom.intersects(geom):
+                            try:
+                                disjoinSet.remove(feat.id())
+                            except:
+                                pass  # already removed
+                    else:
+                        if predicate == 'intersects':
+                            res = tmpGeom.intersects()
+                        elif predicate == 'contains':
+                            res = tmpGeom.contains(geom)
+                        elif predicate == 'equals':
+                            res = tmpGeom.equals(geom)
+                        elif predicate == 'touches':
+                            res = tmpGeom.touches(geom)
+                        elif predicate == 'overlaps':
+                            res = tmpGeom.overlaps(geom)
+                        elif predicate == 'within':
+                            res = tmpGeom.within(geom)
+                        elif predicate == 'crosses':
+                            res = tmpGeom.crosses(geom)
+                        if res:
+                            selectedSet.append(feat.id())
+                            break
+
             current += 1
             progress.setPercentage(int(current * total))
+
+        if 'disjoint' in predicates:
+            selectedSet = selectedSet + disjoinSet
 
         if method == 1:
             selectedSet = list(oldSelection.union(selectedSet))

--- a/python/plugins/processing/core/parameters.py
+++ b/python/plugins/processing/core/parameters.py
@@ -782,3 +782,41 @@ class ParameterVector(ParameterDataObject):
                 types += 'any, '
 
         return types[:-2]
+
+
+class ParameterGeometryPredicate(Parameter):
+
+    predicates = ('intersects',
+                  'contains',
+                  'disjoint',
+                  'equals',
+                  'touches',
+                  'overlaps',
+                  'within',
+                  'crosses')
+
+    def __init__(self, name='', description='', left=None, right=None,
+                 optional=False, enabledPredicates=None):
+        Parameter.__init__(self, name, description)
+        self.left = left
+        self.right = right
+        self.value = None
+        self.default = []
+        self.optional = parseBool(optional)
+        self.enabledPredicates = enabledPredicates
+        if self.enabledPredicates is None:
+            self.enabledPredicates = self.predicates
+
+    def getValueAsCommandLineParameter(self):
+        return '"' + unicode(self.value) + '"'
+
+    def setValue(self, value):
+        if value is None:
+            return self.optional
+        elif len(value) == 0:
+            return self.optional
+        if isinstance(value, unicode):
+            self.value = value.split(';') # relates to ModelerAlgorithm.resolveValue
+        else:
+            self.value = value
+        return True

--- a/python/plugins/processing/gui/AlgorithmDialog.py
+++ b/python/plugins/processing/gui/AlgorithmDialog.py
@@ -50,6 +50,7 @@ from processing.core.parameters import ParameterString
 from processing.core.parameters import ParameterNumber
 from processing.core.parameters import ParameterFile
 from processing.core.parameters import ParameterCrs
+from processing.core.parameters import ParameterGeometryPredicate
 
 from processing.core.outputs import OutputRaster
 from processing.core.outputs import OutputVector
@@ -135,6 +136,8 @@ class AlgorithmDialog(AlgorithmDialogBase):
                 return param.setValue(unicode(widget.toPlainText()))
             else:
                 return param.setValue(unicode(widget.text()))
+        elif isinstance(param, ParameterGeometryPredicate):
+            return param.setValue(widget.value())
         else:
             return param.setValue(unicode(widget.text()))
 

--- a/python/plugins/processing/gui/BatchAlgorithmDialog.py
+++ b/python/plugins/processing/gui/BatchAlgorithmDialog.py
@@ -45,6 +45,7 @@ from processing.core.parameters import ParameterBoolean
 from processing.core.parameters import ParameterSelection
 from processing.core.parameters import ParameterFixedTable
 from processing.core.parameters import ParameterMultipleInput
+from processing.core.parameters import ParameterGeometryPredicate
 from processing.core.outputs import OutputNumber
 from processing.core.outputs import OutputString
 from processing.core.outputs import OutputHTML
@@ -84,6 +85,8 @@ class BatchAlgorithmDialog(AlgorithmDialogBase):
             return param.setValue(widget.getValue())
         elif isinstance(param, (ParameterCrs, ParameterFile)):
             return param.setValue(widget.getValue())
+        elif isinstance(param, ParameterGeometryPredicate):
+            return param.setValue(widget.value())
         else:
             return param.setValue(widget.text())
 

--- a/python/plugins/processing/gui/BatchPanel.py
+++ b/python/plugins/processing/gui/BatchPanel.py
@@ -35,6 +35,7 @@ from processing.gui.ExtentSelectionPanel import ExtentSelectionPanel
 from processing.gui.FixedTablePanel import FixedTablePanel
 from processing.gui.BatchInputSelectionPanel import BatchInputSelectionPanel
 from processing.gui.BatchOutputSelectionPanel import BatchOutputSelectionPanel
+from processing.gui.GeometryPredicateSelectionPanel import GeometryPredicateSelectionPanel
 
 from processing.core.parameters import ParameterFile
 from processing.core.parameters import ParameterRaster
@@ -46,6 +47,7 @@ from processing.core.parameters import ParameterBoolean
 from processing.core.parameters import ParameterSelection
 from processing.core.parameters import ParameterFixedTable
 from processing.core.parameters import ParameterMultipleInput
+from processing.core.parameters import ParameterGeometryPredicate
 
 from processing.ui.ui_widgetBatchPanel import Ui_Form
 
@@ -136,6 +138,11 @@ class BatchPanel(QWidget, Ui_Form):
             item = CrsSelectionPanel(param.default)
         elif isinstance(param, ParameterFile):
             item = FileSelectionPanel(param.isFolder)
+        elif isinstance(param, ParameterGeometryPredicate):
+            item = GeometryPredicateSelectionPanel(param.enabledPredicates, rows=1)
+            width = max(self.tblParameters.columnWidth(col),
+                        item.sizeHint().width())
+            self.tblParameters.setColumnWidth(col, width)
         else:
             item = QLineEdit()
             try:
@@ -214,6 +221,10 @@ class BatchPanel(QWidget, Ui_Form):
             widgetValue = widget.getText()
             for row in range(1, self.tblParameters.rowCount()):
                 self.tblParameters.cellWidget(row, column).setText(widgetValue)
+        elif isinstance(widget, GeometryPredicateSelectionPanel):
+            widgetValue = widget.value()
+            for row in range(1, self.tblParameters.rowCount()):
+                self.tblParameters.cellWidget(row, column).setValue(widgetValue)
         else:
             pass
 

--- a/python/plugins/processing/gui/GeometryPredicateSelectionPanel.py
+++ b/python/plugins/processing/gui/GeometryPredicateSelectionPanel.py
@@ -1,0 +1,116 @@
+# -*- coding: utf-8 -*-
+
+"""
+***************************************************************************
+    PredicatePanel.py
+    ---------------------
+    Date                 : January 2015
+    Copyright            : (C) 2015 by Arnaud Morvan
+    Email                : arnaud dot morvan at camptocamp dot com
+    Contributors         : Arnaud Morvan
+***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************
+"""
+
+__author__ = 'Arnaud Morvan'
+__date__ = 'January 2015'
+__copyright__ = '(C) 2015, Arnaud Morvan'
+
+# This will get replaced with a git SHA1 when you do a git archive
+__revision__ = '$Format:%H$'
+
+
+from PyQt4.QtGui import QWidget, QCheckBox
+from qgis.core import QGis, QgsVectorLayer
+
+from processing.core.parameters import ParameterGeometryPredicate
+from processing.ui.ui_widgetGeometryPredicateSelector import Ui_Form
+
+
+class GeometryPredicateSelectionPanel(QWidget, Ui_Form):
+
+    unusablePredicates = {
+        QGis.Point : {
+            QGis.Point : ('touches', 'crosses'),
+            QGis.Line : ('equals', 'contains', 'overlaps'),
+            QGis.Polygon : ('equals', 'contains', 'overlaps')
+        },
+        QGis.Line : {
+            QGis.Point : ('equals', 'within', 'overlaps'),
+            QGis.Line : [],
+            QGis.Polygon : ('equals', 'contains', 'overlaps')
+        },
+        QGis.Polygon : {
+            QGis.Point : ('equals', 'within', 'overlaps'),
+            QGis.Line : ('equals', 'within', 'overlaps'),
+            QGis.Polygon : ('crosses')
+        }
+    }
+
+    def __init__(self,
+                 enabledPredicated=ParameterGeometryPredicate.predicates,
+                 rows=4):
+        QWidget.__init__(self)
+        self.setupUi(self)
+
+        self.enabledPredicated = enabledPredicated
+        self.leftLayer = None
+        self.rightLayer = None
+        self.setRows(rows)
+        self.updatePredicates()
+
+    def onLeftLayerChange(self):
+        sender = self.sender()
+        self.leftLayer = sender.itemData(sender.currentIndex())
+        self.updatePredicates()
+
+    def onRightLayerChange(self):
+        sender = self.sender()
+        self.rightLayer = sender.itemData(sender.currentIndex())
+        self.updatePredicates()
+
+    def updatePredicates(self):
+        if (isinstance(self.leftLayer, QgsVectorLayer)
+            and isinstance(self.rightLayer, QgsVectorLayer)):
+            leftType = self.leftLayer.geometryType()
+            rightType = self.rightLayer.geometryType()
+            unusablePredicates = self.unusablePredicates[leftType][rightType]
+        else:
+            unusablePredicates = []
+        for predicate in ParameterGeometryPredicate.predicates:
+            widget = self.getWidget(predicate)
+            widget.setEnabled(predicate in self.enabledPredicated
+                              and not predicate in unusablePredicates)
+
+    def setRows(self, rows):
+        widgets = []
+        for predicate in ParameterGeometryPredicate.predicates:
+            widget = self.getWidget(predicate)
+            self.gridLayout.removeWidget(widget)
+            widgets.append(widget)
+        for i in xrange(0, len(widgets)):
+            widget = widgets[i]
+            self.gridLayout.addWidget(widget, i % rows, i / rows)
+
+    def getWidget(self, predicate):
+        return self.findChild(QCheckBox, predicate + 'Box')
+
+    def value(self):
+        values = []
+        for predicate in ParameterGeometryPredicate.predicates:
+            widget = self.getWidget(predicate)
+            if widget.isEnabled() and widget.isChecked():
+                values.append(predicate)
+        return values
+
+    def setValue(self, values):
+        for predicate in ParameterGeometryPredicate.predicates:
+            widget = self.getWidget(predicate)
+            widget.setChecked(predicate in values)
+        return True

--- a/python/plugins/processing/gui/ParametersPanel.py
+++ b/python/plugins/processing/gui/ParametersPanel.py
@@ -47,6 +47,8 @@ from processing.gui.NumberInputPanel import NumberInputPanel
 from processing.gui.ExtentSelectionPanel import ExtentSelectionPanel
 from processing.gui.FileSelectionPanel import FileSelectionPanel
 from processing.gui.CrsSelectionPanel import CrsSelectionPanel
+from processing.gui.GeometryPredicateSelectionPanel import \
+    GeometryPredicateSelectionPanel
 
 from processing.core.parameters import ParameterRaster
 from processing.core.parameters import ParameterVector
@@ -62,6 +64,7 @@ from processing.core.parameters import ParameterExtent
 from processing.core.parameters import ParameterFile
 from processing.core.parameters import ParameterCrs
 from processing.core.parameters import ParameterString
+from processing.core.parameters import ParameterGeometryPredicate
 
 from processing.core.outputs import OutputRaster
 from processing.core.outputs import OutputTable
@@ -321,6 +324,22 @@ class ParametersPanel(QWidget, Ui_Form):
             else:
                 item = QLineEdit()
                 item.setText(str(param.default))
+        elif isinstance(param, ParameterGeometryPredicate):
+            item = GeometryPredicateSelectionPanel(param.enabledPredicates)
+            if param.left:
+                widget = self.valueItems[param.left]
+                if isinstance(widget, InputLayerSelectorPanel):
+                    widget = widget.cmbText
+                widget.currentIndexChanged.connect(item.onLeftLayerChange)
+                item.leftLayer = widget.itemData(widget.currentIndex())
+            if param.right:
+                widget = self.valueItems[param.right]
+                if isinstance(widget, InputLayerSelectorPanel):
+                    widget = widget.cmbText
+                widget.currentIndexChanged.connect(item.onRightLayerChange)
+                item.rightLayer = widget.itemData(widget.currentIndex())
+            item.updatePredicates()
+            item.setValue(param.default)
         else:
             item = QLineEdit()
             item.setText(str(param.default))

--- a/python/plugins/processing/modeler/ModelerParametersDialog.py
+++ b/python/plugins/processing/modeler/ModelerParametersDialog.py
@@ -35,8 +35,10 @@ from processing.gui.CrsSelectionPanel import CrsSelectionPanel
 from processing.gui.MultipleInputPanel import MultipleInputPanel
 from processing.gui.FixedTablePanel import FixedTablePanel
 from processing.gui.RangePanel import RangePanel
+from processing.gui.GeometryPredicateSelectionPanel import \
+    GeometryPredicateSelectionPanel
 from processing.modeler.MultilineTextPanel import MultilineTextPanel
-from processing.core.parameters import ParameterExtent, ParameterRaster, ParameterVector, ParameterBoolean, ParameterTable, ParameterFixedTable, ParameterMultipleInput, ParameterSelection, ParameterRange, ParameterNumber, ParameterString, ParameterCrs, ParameterTableField, ParameterFile
+from processing.core.parameters import ParameterExtent, ParameterRaster, ParameterVector, ParameterBoolean, ParameterTable, ParameterFixedTable, ParameterMultipleInput, ParameterSelection, ParameterRange, ParameterNumber, ParameterString, ParameterCrs, ParameterTableField, ParameterFile, ParameterGeometryPredicate
 from processing.core.outputs import OutputRaster, OutputVector, OutputTable, OutputHTML, OutputFile, OutputDirectory, OutputNumber, OutputString, OutputExtent
 
 
@@ -335,6 +337,8 @@ class ModelerParametersDialog(QDialog):
             files = self.getAvailableValuesOfType(ParameterFile, OutputFile)
             for f in files:
                 item.addItem(self.resolveValueDescription(f), f)
+        elif isinstance(param, ParameterGeometryPredicate):
+            item = GeometryPredicateSelectionPanel(param.enabledPredicates)
         else:
             item = QLineEdit()
             try:
@@ -438,6 +442,8 @@ class ModelerParametersDialog(QDialog):
                         if opt in value:
                             selected.append(i)
                     widget.setSelectedItems(selected)
+                elif isinstance(param, ParameterGeometryPredicate):
+                    widget.setValue(value)
 
             for name, out in alg.outputs.iteritems():
                 widget = self.valueItems[name].setText(out.description)
@@ -618,6 +624,9 @@ class ModelerParametersDialog(QDialog):
             if len(values) == 0 and not param.optional:
                 return False
             alg.params[param.name] = values
+            return True
+        elif isinstance(param, ParameterGeometryPredicate):
+            alg.params[param.name] = widget.value()
             return True
         else:
             alg.params[param.name] = unicode(widget.text())

--- a/python/plugins/processing/ui/ui_widgetGeometryPredicateSelector.py
+++ b/python/plugins/processing/ui/ui_widgetGeometryPredicateSelector.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+
+# Form implementation generated from reading ui file 'widgetGeometryPredicateSelector.ui'
+#
+# Created: Mon Jan 19 11:52:29 2015
+#      by: PyQt4 UI code generator 4.10.4
+#
+# WARNING! All changes made in this file will be lost!
+
+from PyQt4 import QtCore, QtGui
+
+try:
+    _fromUtf8 = QtCore.QString.fromUtf8
+except AttributeError:
+    def _fromUtf8(s):
+        return s
+
+try:
+    _encoding = QtGui.QApplication.UnicodeUTF8
+    def _translate(context, text, disambig):
+        return QtGui.QApplication.translate(context, text, disambig, _encoding)
+except AttributeError:
+    def _translate(context, text, disambig):
+        return QtGui.QApplication.translate(context, text, disambig)
+
+class Ui_Form(object):
+    def setupUi(self, Form):
+        Form.setObjectName(_fromUtf8("Form"))
+        Form.resize(609, 213)
+        self.gridLayout = QtGui.QGridLayout(Form)
+        self.gridLayout.setMargin(0)
+        self.gridLayout.setObjectName(_fromUtf8("gridLayout"))
+        self.equalsBox = QtGui.QCheckBox(Form)
+        self.equalsBox.setObjectName(_fromUtf8("equalsBox"))
+        self.gridLayout.addWidget(self.equalsBox, 0, 0, 1, 1)
+        self.containsBox = QtGui.QCheckBox(Form)
+        self.containsBox.setObjectName(_fromUtf8("containsBox"))
+        self.gridLayout.addWidget(self.containsBox, 1, 0, 1, 1)
+        self.touchesBox = QtGui.QCheckBox(Form)
+        self.touchesBox.setObjectName(_fromUtf8("touchesBox"))
+        self.gridLayout.addWidget(self.touchesBox, 3, 0, 1, 1)
+        self.intersectsBox = QtGui.QCheckBox(Form)
+        self.intersectsBox.setObjectName(_fromUtf8("intersectsBox"))
+        self.gridLayout.addWidget(self.intersectsBox, 2, 0, 1, 1)
+        self.withinBox = QtGui.QCheckBox(Form)
+        self.withinBox.setObjectName(_fromUtf8("withinBox"))
+        self.gridLayout.addWidget(self.withinBox, 0, 1, 1, 1)
+        self.overlapsBox = QtGui.QCheckBox(Form)
+        self.overlapsBox.setObjectName(_fromUtf8("overlapsBox"))
+        self.gridLayout.addWidget(self.overlapsBox, 1, 1, 1, 1)
+        self.crossesBox = QtGui.QCheckBox(Form)
+        self.crossesBox.setObjectName(_fromUtf8("crossesBox"))
+        self.gridLayout.addWidget(self.crossesBox, 2, 1, 1, 1)
+        self.disjointBox = QtGui.QCheckBox(Form)
+        self.disjointBox.setObjectName(_fromUtf8("disjointBox"))
+        self.gridLayout.addWidget(self.disjointBox, 3, 1, 1, 1)
+
+        self.retranslateUi(Form)
+        QtCore.QMetaObject.connectSlotsByName(Form)
+
+    def retranslateUi(self, Form):
+        Form.setWindowTitle(_translate("Form", "Form", None))
+        self.equalsBox.setText(_translate("Form", "equals", None))
+        self.containsBox.setText(_translate("Form", "contains", None))
+        self.touchesBox.setText(_translate("Form", "touches", None))
+        self.intersectsBox.setText(_translate("Form", "intersects", None))
+        self.withinBox.setText(_translate("Form", "within", None))
+        self.overlapsBox.setText(_translate("Form", "overlaps", None))
+        self.crossesBox.setText(_translate("Form", "crosses", None))
+        self.disjointBox.setText(_translate("Form", "disjoint", None))
+

--- a/python/plugins/processing/ui/widgetGeometryPredicateSelector.ui
+++ b/python/plugins/processing/ui/widgetGeometryPredicateSelector.ui
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Form</class>
+ <widget class="QWidget" name="Form">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>609</width>
+    <height>213</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <property name="margin">
+    <number>0</number>
+   </property>
+   <item row="0" column="0">
+    <widget class="QCheckBox" name="equalsBox">
+     <property name="text">
+      <string>equals</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QCheckBox" name="containsBox">
+     <property name="text">
+      <string>contains</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QCheckBox" name="touchesBox">
+     <property name="text">
+      <string>touches</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QCheckBox" name="intersectsBox">
+     <property name="text">
+      <string>intersects</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QCheckBox" name="withinBox">
+     <property name="text">
+      <string>within</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QCheckBox" name="overlapsBox">
+     <property name="text">
+      <string>overlaps</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QCheckBox" name="crossesBox">
+     <property name="text">
+      <string>crosses</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QCheckBox" name="disjointBox">
+     <property name="text">
+      <string>disjoint</string>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
Adds a new **ParameterGeometryPredicate** class and related widget **GeometryPredicateSelectionPanel**.

With this new widget, the user can select precisely the predicates he wants in this list:
('intersects', 'contains', 'disjoint', 'equals', 'touches', 'overlaps', 'within', 'crosses')
in an boolean "or" like manner.

Alter **SelectByLocation**, **ExtractByLocation** and **SpatialJoin** (Join attributes by location) algorithms to use this new parameter type.

The first input layer is used as left operand and the second as the right operand, this seems to natural in user point of view.

Maybe this can break some scripts using altered algorithms.

After merge, I'll make a pull request to add he new ParameterGeometryPredicate in processing console mode documentation.
## In modeler

Fully fonctionnal.
## In batch mode

Display all checkboxes horizontally.
## In console mode

``` python
import processing
processing.runalg("qgis:selectbylocation",
                  "ARRONDISSEMENT",
                  "DEPARTEMENT",
                  ["within"],
                  0)
```
