### PR TITLE
Add function editor to expression widget

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -257,6 +257,7 @@ ENDIF(WITH_CUSTOM_WIDGETS)
 SET(PY_FILES
   __init__.py
   utils.py  
+  user.py  
 )
 
 ADD_CUSTOM_TARGET(pyutils ALL)

--- a/python/gui/qgsexpressionbuilderwidget.sip
+++ b/python/gui/qgsexpressionbuilderwidget.sip
@@ -111,6 +111,26 @@ class QgsExpressionBuilderWidget : QWidget
 
     void loadRecent( QString key );
 
+    /** Create a new file in the function editor
+     */
+    void newFunctionFile( QString fileName = "scratch");
+
+    /** Save the current function editor text to the given file.
+     */
+    void saveFunctionFile( QString fileName );
+
+    /** Load code from the given file into the function editor
+     */
+    void loadCodeFromFile( QString path );
+
+    /** Load code into the function editor
+     */
+    void loadFunctionCode( QString code );
+
+    /** Update the list of function files found at the given path
+     */
+    void updateFunctionFileList( QString path );
+
   public slots:
     void currentChanged( const QModelIndex &index, const QModelIndex & );
     void on_expressionTree_doubleClicked( const QModelIndex &index );

--- a/python/user.py
+++ b/python/user.py
@@ -1,36 +1,30 @@
 import os
 import sys
 import glob
+import expressions
 
-def startup(userpythonhome):
-    """
-    Run startup logic for this QGIS user
-    """
-    try:
-        # Start up can be a startup.py or a startup package
-        import startup
-    except ImportError:
-        pass 
+from qgis.core import QgsApplication 
 
-    expressionspath = os.path.join(userpythonhome, "expressions")
-    load_user_expressions([expressionspath])
-
-
-def load_user_expressions(paths):
+def load_user_expressions(path):
     """
     Load all user expressions from the given paths
     """
     #Loop all py files and import them
-    for path in paths:
-        sys.path.append(path)
-        modules = glob.glob(path + "/*.py")
-        names = [os.path.basename(f)[:-3] for f in modules]
-        for name in names:
-            if name == "__init__":
-                continue
-            # As user expression functions should be registed with qgsfunction
-            # just importing the file is enough to get it to load the functions into QGIS
-            __import__(name, locals(), globals())
+    modules = glob.glob(path + "/*.py")
+    names = [os.path.basename(f)[:-3] for f in modules]
+    for name in names:
+        if name == "__init__":
+            continue
+        # As user expression functions should be registed with qgsfunction
+        # just importing the file is enough to get it to load the functions into QGIS
+        __import__("expressions.{0}".format(name), locals(), globals())
 
 
+userpythonhome = os.path.join(QgsApplication.qgisSettingsDirPath(), "python")
+expressionspath = os.path.join(userpythonhome, "expressions")
+
+# TODO Look for the startup.py and execfile it
+
+expressions.load = load_user_expressions
+expressions.load(expressionspath)
 

--- a/python/user.py
+++ b/python/user.py
@@ -1,0 +1,36 @@
+import os
+import sys
+import glob
+
+def startup(userpythonhome):
+    """
+    Run startup logic for this QGIS user
+    """
+    try:
+        # Start up can be a startup.py or a startup package
+        import startup
+    except ImportError:
+        pass 
+
+    expressionspath = os.path.join(userpythonhome, "expressions")
+    load_user_expressions([expressionspath])
+
+
+def load_user_expressions(paths):
+    """
+    Load all user expressions from the given paths
+    """
+    #Loop all py files and import them
+    for path in paths:
+        sys.path.append(path)
+        modules = glob.glob(path + "/*.py")
+        names = [os.path.basename(f)[:-3] for f in modules]
+        for name in names:
+            if name == "__init__":
+                continue
+            # As user expression functions should be registed with qgsfunction
+            # just importing the file is enough to get it to load the functions into QGIS
+            __import__(name, locals(), globals())
+
+
+

--- a/python/user.py
+++ b/python/user.py
@@ -1,7 +1,6 @@
 import os
 import sys
 import glob
-import expressions
 
 from qgis.core import QgsApplication 
 
@@ -22,8 +21,20 @@ def load_user_expressions(path):
 
 userpythonhome = os.path.join(QgsApplication.qgisSettingsDirPath(), "python")
 expressionspath = os.path.join(userpythonhome, "expressions")
+startuppy = os.path.join(userpythonhome, "startup.py")
 
-# TODO Look for the startup.py and execfile it
+# exec startup script
+if os.path.exists(startuppy):
+    execfile(startuppy, locals(), globals())
+
+if not os.path.exists(expressionspath):
+    os.makedirs(expressionspath)
+
+initfile = os.path.join(expressionspath, "__init__.py")
+if not os.path.exists(initfile):
+    open(initfile, "w").close()
+
+import expressions
 
 expressions.load = load_user_expressions
 expressions.load(expressionspath)

--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -65,9 +65,16 @@ QgsExpressionBuilderWidget::QgsExpressionBuilderWidget( QWidget *parent )
 
   updateFunctionTree();
 
-  mFunctionsPath = QgsApplication::qgisSettingsDirPath() + QDir::separator() + "python" + QDir::separator() + "expressions";
-  loadFunctionFiles( mFunctionsPath );
-  newFunctionFile();
+  if ( QgsPythonRunner::isValid() )
+  {
+    QgsPythonRunner::eval( "qgis.user.expressionpath", mFunctionsPath );
+    loadFunctionFiles( mFunctionsPath );
+    newFunctionFile();
+  }
+  else
+  {
+    tab_2->setEnabled( false );
+  }
 }
 
 
@@ -151,10 +158,11 @@ void QgsExpressionBuilderWidget::loadFunctionFiles( QString path )
   dir.setNameFilters( QStringList() << "*.py" );
   QStringList files = dir.entryList( QDir::Files );
   cmbFileNames->clear();
-  foreach( QString name, files ){
-      QFileInfo info( mFunctionsPath + QDir::separator() + name );
-      cmbFileNames->addItem( info.baseName() );
-    }
+  foreach ( QString name, files )
+  {
+    QFileInfo info( mFunctionsPath + QDir::separator() + name );
+    cmbFileNames->addItem( info.baseName() );
+  }
 }
 
 void QgsExpressionBuilderWidget::newFunctionFile( QString fileName )
@@ -164,9 +172,9 @@ void QgsExpressionBuilderWidget::newFunctionFile( QString fileName )
                       "@qgsfunction(args=-1, group='Custom')\n"
                       "def func(values, feature, parent):\n"
                       "    return str(values)" );
-  int index = cmbFileNames->findText(fileName);
+  int index = cmbFileNames->findText( fileName );
   if ( index == -1 )
-      cmbFileNames->setEditText( fileName );
+    cmbFileNames->setEditText( fileName );
   else
     cmbFileNames->setCurrentIndex( index );
 }
@@ -187,8 +195,8 @@ void QgsExpressionBuilderWidget::on_cmbFileNames_currentIndexChanged( int index 
 
 void QgsExpressionBuilderWidget::loadCodeFromFile( QString path )
 {
-  if ( !path.endsWith(".py"))
-    path.append(".py");
+  if ( !path.endsWith( ".py" ) )
+    path.append( ".py" );
 
   txtPython->loadScript( path );
 }
@@ -202,7 +210,7 @@ void QgsExpressionBuilderWidget::on_btnSaveFile_pressed()
 {
   QString name = cmbFileNames->currentText();
   saveFunctionFile( name );
-  int index = cmbFileNames->findText(name);
+  int index = cmbFileNames->findText( name );
   if ( index == -1 )
   {
     cmbFileNames->addItem( name );

--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -65,7 +65,7 @@ QgsExpressionBuilderWidget::QgsExpressionBuilderWidget( QWidget *parent )
 
   updateFunctionTree();
 
-  mFunctionsPath = QgsApplication::qgisSettingsDirPath() + QString( "functions" );
+  mFunctionsPath = QgsApplication::qgisSettingsDirPath() + QDir::separator() + "python" + QDir::separator() + "expressions";
   loadFunctionFiles( mFunctionsPath );
   newFunctionFile();
 }

--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -25,6 +25,8 @@
 #include <QFile>
 #include <QTextStream>
 #include <QSettings>
+#include <QDir>
+#include <QComboBox>
 
 QgsExpressionBuilderWidget::QgsExpressionBuilderWidget( QWidget *parent )
     : QWidget( parent )
@@ -54,71 +56,18 @@ QgsExpressionBuilderWidget::QgsExpressionBuilderWidget( QWidget *parent )
     connect( button, SIGNAL( pressed() ), this, SLOT( operatorButtonClicked() ) );
   }
 
-  // TODO Can we move this stuff to QgsExpression, like the functions?
-  registerItem( "Operators", "+", " + ", tr( "Addition operator" ) );
-  registerItem( "Operators", "-", " - ", tr( "Subtraction operator" ) );
-  registerItem( "Operators", "*", " * ", tr( "Multiplication operator" ) );
-  registerItem( "Operators", "/", " / ", tr( "Division operator" ) );
-  registerItem( "Operators", "%", " % ", tr( "Modulo operator" ) );
-  registerItem( "Operators", "^", " ^ ", tr( "Power operator" ) );
-  registerItem( "Operators", "=", " = ", tr( "Equal operator" ) );
-  registerItem( "Operators", ">", " > ", tr( "Greater as operator" ) );
-  registerItem( "Operators", "<", " < ", tr( "Less than operator" ) );
-  registerItem( "Operators", "<>", " <> ", tr( "Unequal operator" ) );
-  registerItem( "Operators", "<=", " <= ", tr( "Less or equal operator" ) );
-  registerItem( "Operators", ">=", " >= ", tr( "Greater or equal operator" ) );
-  registerItem( "Operators", "||", " || ",
-                QString( "<b>|| %1</b><br><i>%2</i><br><i>%3:</i>%4" )
-                .arg( tr( "(String Concatenation)" ) )
-                .arg( tr( "Joins two values together into a string" ) )
-                .arg( tr( "Usage" ) )
-                .arg( tr( "'Dia' || Diameter" ) ) );
-  registerItem( "Operators", "IN", " IN " );
-  registerItem( "Operators", "LIKE", " LIKE " );
-  registerItem( "Operators", "ILIKE", " ILIKE " );
-  registerItem( "Operators", "IS", " IS " );
-  registerItem( "Operators", "OR", " OR " );
-  registerItem( "Operators", "AND", " AND " );
-  registerItem( "Operators", "NOT", " NOT " );
-
-  QString casestring = "CASE WHEN condition THEN result END";
-  QString caseelsestring = "CASE WHEN condition THEN result ELSE result END";
-  registerItem( "Conditionals", "CASE", casestring );
-  registerItem( "Conditionals", "CASE ELSE", caseelsestring );
-
-  // Load the functions from the QgsExpression class
-  int count = QgsExpression::functionCount();
-  for ( int i = 0; i < count; i++ )
-  {
-    QgsExpression::Function* func = QgsExpression::Functions()[i];
-    QString name = func->name();
-    if ( name.startsWith( "_" ) ) // do not display private functions
-      continue;
-    if ( func->params() != 0 )
-      name += "(";
-    registerItem( func->group(), func->name(), " " + name + " ", func->helptext() );
-  }
-
-  QList<QgsExpression::Function*> specials = QgsExpression::specialColumns();
-  for ( int i = 0; i < specials.size(); ++i )
-  {
-    QString name = specials[i]->name();
-    registerItem( specials[i]->group(), name, " " + name + " " );
-  }
-
   txtSearchEdit->setPlaceholderText( tr( "Search" ) );
 
   QSettings settings;
   splitter->restoreState( settings.value( "/windows/QgsExpressionBuilderWidget/splitter" ).toByteArray() );
-//  splitter_2->restoreState( settings.value( "/windows/QgsExpressionBuilderWidget/splitter2" ).toByteArray() );
 
   txtExpressionString->setFoldingVisible( false );
-//  customFunctionBotton->setVisible( QgsPythonRunner::isValid() );
-  txtPython->setVisible( false );
-  cgbCustomFunction->setCollapsed( true );
-  txtPython->setText( "@qgsfunction(args=-1, group='Custom')\n"
-                      "def func(values, feature, parent):\n"
-                      "    return str(values)" );
+
+  updateFunctionTree();
+
+  mFunctionsPath = QgsApplication::qgisSettingsDirPath() + QString( "functions" );
+  loadFunctionFiles( mFunctionsPath );
+  newFunctionFile();
 }
 
 
@@ -154,6 +103,111 @@ void QgsExpressionBuilderWidget::currentChanged( const QModelIndex &index, const
   QString help = loadFunctionHelp( item );
   txtHelpText->setText( help );
   txtHelpText->setToolTip( txtHelpText->toPlainText() );
+}
+
+void QgsExpressionBuilderWidget::on_btnRun_pressed()
+{
+  saveFunctionFile( cmbFileNames->currentText() );
+  runPythonCode( txtPython->text() );
+}
+
+void QgsExpressionBuilderWidget::runPythonCode( QString code )
+{
+  if ( QgsPythonRunner::isValid() )
+  {
+    QString pythontext = code;
+    QgsPythonRunner::run( pythontext );
+  }
+  updateFunctionTree();
+}
+
+void QgsExpressionBuilderWidget::saveFunctionFile( QString fileName )
+{
+  QDir myDir( mFunctionsPath );
+  if ( !myDir.exists() )
+  {
+    myDir.mkpath( mFunctionsPath );
+  }
+
+  if ( !fileName.endsWith( ".py" ) )
+  {
+    fileName.append( ".py" );
+  }
+
+  fileName = mFunctionsPath + QDir::separator() + fileName;
+  QFile myFile( fileName );
+  if ( myFile.open( QIODevice::WriteOnly | QIODevice::Text ) )
+  {
+    QTextStream myFileStream( &myFile );
+    myFileStream << txtPython->text() << endl;
+    myFile.close();
+  }
+}
+
+void QgsExpressionBuilderWidget::loadFunctionFiles( QString path )
+{
+  mFunctionsPath = path;
+  QDir dir( path );
+  dir.setNameFilters( QStringList() << "*.py" );
+  QStringList files = dir.entryList( QDir::Files );
+  cmbFileNames->clear();
+  foreach( QString name, files ){
+      QFileInfo info( mFunctionsPath + QDir::separator() + name );
+      cmbFileNames->addItem( info.baseName() );
+    }
+}
+
+void QgsExpressionBuilderWidget::newFunctionFile( QString fileName )
+{
+  txtPython->setText( "from qgis.core import *\n"
+                      "from qgis.gui import *\n\n"
+                      "@qgsfunction(args=-1, group='Custom')\n"
+                      "def func(values, feature, parent):\n"
+                      "    return str(values)" );
+  int index = cmbFileNames->findText(fileName);
+  if ( index == -1 )
+      cmbFileNames->setEditText( fileName );
+  else
+    cmbFileNames->setCurrentIndex( index );
+}
+
+void QgsExpressionBuilderWidget::on_btnNewFile_pressed()
+{
+  newFunctionFile();
+}
+
+void QgsExpressionBuilderWidget::on_cmbFileNames_currentIndexChanged( int index )
+{
+  if ( index == -1 )
+    return;
+
+  QString path = mFunctionsPath + QDir::separator() + cmbFileNames->currentText();
+  loadCodeFromFile( path );
+}
+
+void QgsExpressionBuilderWidget::loadCodeFromFile( QString path )
+{
+  if ( !path.endsWith(".py"))
+    path.append(".py");
+
+  txtPython->loadScript( path );
+}
+
+void QgsExpressionBuilderWidget::loadFunctionCode( QString code )
+{
+  txtPython->setText( code );
+}
+
+void QgsExpressionBuilderWidget::on_btnSaveFile_pressed()
+{
+  QString name = cmbFileNames->currentText();
+  saveFunctionFile( name );
+  int index = cmbFileNames->findText(name);
+  if ( index == -1 )
+  {
+    cmbFileNames->addItem( name );
+    cmbFileNames->setCurrentIndex( cmbFileNames->count() - 1 );
+  }
 }
 
 void QgsExpressionBuilderWidget::on_expressionTree_doubleClicked( const QModelIndex &index )
@@ -292,6 +346,63 @@ void QgsExpressionBuilderWidget::loadRecent( QString key )
   }
 }
 
+void QgsExpressionBuilderWidget::updateFunctionTree()
+{
+  mModel->clear();
+  mExpressionGroups.clear();
+  // TODO Can we move this stuff to QgsExpression, like the functions?
+  registerItem( "Operators", "+", " + ", tr( "Addition operator" ) );
+  registerItem( "Operators", "-", " - ", tr( "Subtraction operator" ) );
+  registerItem( "Operators", "*", " * ", tr( "Multiplication operator" ) );
+  registerItem( "Operators", "/", " / ", tr( "Division operator" ) );
+  registerItem( "Operators", "%", " % ", tr( "Modulo operator" ) );
+  registerItem( "Operators", "^", " ^ ", tr( "Power operator" ) );
+  registerItem( "Operators", "=", " = ", tr( "Equal operator" ) );
+  registerItem( "Operators", ">", " > ", tr( "Greater as operator" ) );
+  registerItem( "Operators", "<", " < ", tr( "Less than operator" ) );
+  registerItem( "Operators", "<>", " <> ", tr( "Unequal operator" ) );
+  registerItem( "Operators", "<=", " <= ", tr( "Less or equal operator" ) );
+  registerItem( "Operators", ">=", " >= ", tr( "Greater or equal operator" ) );
+  registerItem( "Operators", "||", " || ",
+                QString( "<b>|| %1</b><br><i>%2</i><br><i>%3:</i>%4" )
+                .arg( tr( "(String Concatenation)" ) )
+                .arg( tr( "Joins two values together into a string" ) )
+                .arg( tr( "Usage" ) )
+                .arg( tr( "'Dia' || Diameter" ) ) );
+  registerItem( "Operators", "IN", " IN " );
+  registerItem( "Operators", "LIKE", " LIKE " );
+  registerItem( "Operators", "ILIKE", " ILIKE " );
+  registerItem( "Operators", "IS", " IS " );
+  registerItem( "Operators", "OR", " OR " );
+  registerItem( "Operators", "AND", " AND " );
+  registerItem( "Operators", "NOT", " NOT " );
+
+  QString casestring = "CASE WHEN condition THEN result END";
+  QString caseelsestring = "CASE WHEN condition THEN result ELSE result END";
+  registerItem( "Conditionals", "CASE", casestring );
+  registerItem( "Conditionals", "CASE ELSE", caseelsestring );
+
+  // Load the functions from the QgsExpression class
+  int count = QgsExpression::functionCount();
+  for ( int i = 0; i < count; i++ )
+  {
+    QgsExpression::Function* func = QgsExpression::Functions()[i];
+    QString name = func->name();
+    if ( name.startsWith( "_" ) ) // do not display private functions
+      continue;
+    if ( func->params() != 0 )
+      name += "(";
+    registerItem( func->group(), func->name(), " " + name + " ", func->helptext() );
+  }
+
+  QList<QgsExpression::Function*> specials = QgsExpression::specialColumns();
+  for ( int i = 0; i < specials.size(); ++i )
+  {
+    QString name = specials[i]->name();
+    registerItem( specials[i]->group(), name, " " + name + " " );
+  }
+}
+
 void QgsExpressionBuilderWidget::setGeomCalculator( const QgsDistanceArea & da )
 {
   mDa = da;
@@ -299,11 +410,6 @@ void QgsExpressionBuilderWidget::setGeomCalculator( const QgsDistanceArea & da )
 
 QString QgsExpressionBuilderWidget::expressionText()
 {
-  if ( QgsPythonRunner::isValid() )
-  {
-    QString pythontext = txtPython->text();
-    QgsPythonRunner::run( pythontext );
-  }
   return txtExpressionString->text();
 }
 

--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -161,6 +161,7 @@ void QgsExpressionBuilderWidget::updateFunctionFileList( QString path )
   foreach ( QString name, files )
   {
     QFileInfo info( mFunctionsPath + QDir::separator() + name );
+    if ( info.baseName() == "__init__" ) continue;
     cmbFileNames->addItem( info.baseName() );
   }
 }

--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -67,8 +67,8 @@ QgsExpressionBuilderWidget::QgsExpressionBuilderWidget( QWidget *parent )
 
   if ( QgsPythonRunner::isValid() )
   {
-    QgsPythonRunner::eval( "qgis.user.expressionpath", mFunctionsPath );
-    loadFunctionFiles( mFunctionsPath );
+    QgsPythonRunner::eval( "qgis.user.expressionspath", mFunctionsPath );
+    updateFunctionFileList( mFunctionsPath );
     newFunctionFile();
   }
   else
@@ -151,7 +151,7 @@ void QgsExpressionBuilderWidget::saveFunctionFile( QString fileName )
   }
 }
 
-void QgsExpressionBuilderWidget::loadFunctionFiles( QString path )
+void QgsExpressionBuilderWidget::updateFunctionFileList( QString path )
 {
   mFunctionsPath = path;
   QDir dir( path );

--- a/src/gui/qgsexpressionbuilderwidget.h
+++ b/src/gui/qgsexpressionbuilderwidget.h
@@ -150,19 +150,25 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
 
     void loadRecent( QString key );
 
+    /** Create a new file in the function editor
+     */
     void newFunctionFile( QString fileName = "scratch");
 
+    /** Save the current function editor text to the given file.
+     */
     void saveFunctionFile( QString fileName );
 
+    /** Load code from the given file into the function editor
+     */
     void loadCodeFromFile( QString path );
 
+    /** Load code into the function editor
+     */
     void loadFunctionCode( QString code );
 
-    void loadFunctionFiles( QString path );
-
-    void runPythonCode( QString code );
-
-    void updateFunctionTree();
+    /** Update the list of function files found at the given path
+     */
+    void updateFunctionFileList( QString path );
 
   public slots:
     void currentChanged( const QModelIndex &index, const QModelIndex & );
@@ -192,6 +198,8 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
     void expressionParsed( bool isValid );
 
   private:
+    void runPythonCode( QString code );
+    void updateFunctionTree();
     void fillFieldValues( int fieldIndex, int countLimit );
     QString loadFunctionHelp( QgsExpressionItem* functionName );
 

--- a/src/gui/qgsexpressionbuilderwidget.h
+++ b/src/gui/qgsexpressionbuilderwidget.h
@@ -150,8 +150,26 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
 
     void loadRecent( QString key );
 
+    void newFunctionFile( QString fileName = "scratch");
+
+    void saveFunctionFile( QString fileName );
+
+    void loadCodeFromFile( QString path );
+
+    void loadFunctionCode( QString code );
+
+    void loadFunctionFiles( QString path );
+
+    void runPythonCode( QString code );
+
+    void updateFunctionTree();
+
   public slots:
     void currentChanged( const QModelIndex &index, const QModelIndex & );
+    void on_btnRun_pressed();
+    void on_btnNewFile_pressed();
+    void on_cmbFileNames_currentIndexChanged( int index );
+    void on_btnSaveFile_pressed();
     void on_expressionTree_doubleClicked( const QModelIndex &index );
     void on_txtExpressionString_textChanged();
     void on_txtSearchEdit_textChanged();
@@ -177,6 +195,7 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
     void fillFieldValues( int fieldIndex, int countLimit );
     QString loadFunctionHelp( QgsExpressionItem* functionName );
 
+    QString mFunctionsPath;
     QgsVectorLayer *mLayer;
     QStandardItemModel *mModel;
     QgsExpressionItemSearchProxy *mProxyModel;

--- a/src/gui/symbology-ng/qgsdatadefinedsymboldialog.cpp
+++ b/src/gui/symbology-ng/qgsdatadefinedsymboldialog.cpp
@@ -5,6 +5,7 @@
 #include "qgslogger.h"
 
 #include <QCheckBox>
+#include <QSettings>
 
 
 QgsDataDefinedSymbolDialog::QgsDataDefinedSymbolDialog( const QList< DataDefinedSymbolEntry >& entries, const QgsVectorLayer* vl, QWidget * parent, Qt::WindowFlags f )

--- a/src/python/qgspythonutilsimpl.cpp
+++ b/src/python/qgspythonutilsimpl.cpp
@@ -157,14 +157,6 @@ void QgsPythonUtilsImpl::initPython( QgisInterface* interface )
     return;
   }
 
-  // import QGIS user
-  error_msg = QObject::tr( "Couldn't load QGIS user." ) + "\n" + QObject::tr( "Python support will be disabled." );
-  if ( !runString( "import qgis.user", error_msg ) )
-  {
-    // Should we really bail because of this?!
-    exitPython();
-    return;
-  }
 
   // tell the utils script where to look for the plugins
   runString( "qgis.utils.plugin_paths = [" + pluginpaths.join( "," ) + "]" );
@@ -178,7 +170,14 @@ void QgsPythonUtilsImpl::initPython( QgisInterface* interface )
   // initialize 'iface' object
   runString( "qgis.utils.initInterface(" + QString::number(( unsigned long ) interface ) + ")" );
 
-  runString( QString("qgis.user.startup(%1)").arg( homePythonPath() ) );
+  // import QGIS user
+  error_msg = QObject::tr( "Couldn't load QGIS user." ) + "\n" + QObject::tr( "Python support will be disabled." );
+  if ( !runString( "import qgis.user", error_msg ) )
+  {
+    // Should we really bail because of this?!
+    exitPython();
+    return;
+  }
 
   // release GIL!
   // Later on, we acquire GIL just before doing some Python calls and

--- a/src/python/qgspythonutilsimpl.cpp
+++ b/src/python/qgspythonutilsimpl.cpp
@@ -157,6 +157,15 @@ void QgsPythonUtilsImpl::initPython( QgisInterface* interface )
     return;
   }
 
+  // import QGIS user
+  error_msg = QObject::tr( "Couldn't load QGIS user." ) + "\n" + QObject::tr( "Python support will be disabled." );
+  if ( !runString( "import qgis.user", error_msg ) )
+  {
+    // Should we really bail because of this?!
+    exitPython();
+    return;
+  }
+
   // tell the utils script where to look for the plugins
   runString( "qgis.utils.plugin_paths = [" + pluginpaths.join( "," ) + "]" );
   runString( "qgis.utils.sys_plugin_path = \"" + pluginsPath() + "\"" );
@@ -169,8 +178,7 @@ void QgsPythonUtilsImpl::initPython( QgisInterface* interface )
   // initialize 'iface' object
   runString( "qgis.utils.initInterface(" + QString::number(( unsigned long ) interface ) + ")" );
 
-  QString startuppath = homePythonPath() + " + \"/startup.py\"";
-  runString( "if os.path.exists(" + startuppath + "): from startup import *\n" );
+  runString( QString("qgis.user.startup(%1)").arg( homePythonPath() ) );
 
   // release GIL!
   // Later on, we acquire GIL just before doing some Python calls and

--- a/src/ui/qgsexpressionbuilder.ui
+++ b/src/ui/qgsexpressionbuilder.ui
@@ -35,7 +35,7 @@
    <item row="0" column="0">
     <widget class="QTabWidget" name="tabWidget">
      <property name="currentIndex">
-      <number>1</number>
+      <number>0</number>
      </property>
      <property name="documentMode">
       <bool>true</bool>

--- a/src/ui/qgsexpressionbuilder.ui
+++ b/src/ui/qgsexpressionbuilder.ui
@@ -583,8 +583,8 @@
             <string>...</string>
            </property>
            <property name="icon">
-            <iconset resource="../plugins/georeferencer/georeferencer.qrc">
-             <normaloff>:/icons/default/mActionStartGeoref.png</normaloff>:/icons/default/mActionStartGeoref.png</iconset>
+            <iconset resource="../../images/images.qrc">
+             <normaloff>:/images/themes/default/console/iconRunScriptConsole.png</normaloff>:/images/themes/default/console/iconRunScriptConsole.png</iconset>
            </property>
            <property name="autoRaise">
             <bool>true</bool>
@@ -614,7 +614,7 @@
            </property>
            <property name="icon">
             <iconset resource="../../images/images.qrc">
-             <normaloff>:/images/themes/default/mActionFileNew.svg</normaloff>:/images/themes/default/mActionFileNew.svg</iconset>
+             <normaloff>:/images/themes/default/console/iconTabEditorConsole.png</normaloff>:/images/themes/default/console/iconTabEditorConsole.png</iconset>
            </property>
            <property name="autoRaise">
             <bool>true</bool>
@@ -640,8 +640,8 @@
             <string>Save</string>
            </property>
            <property name="icon">
-            <iconset resource="../plugins/georeferencer/georeferencer.qrc">
-             <normaloff>:/icons/default/mActionSaveRasterAs.png</normaloff>:/icons/default/mActionSaveRasterAs.png</iconset>
+            <iconset resource="../../images/images.qrc">
+             <normaloff>:/images/themes/default/console/iconSaveConsole.png</normaloff>:/images/themes/default/console/iconSaveConsole.png</iconset>
            </property>
            <property name="autoRaise">
             <bool>true</bool>
@@ -690,7 +690,6 @@
  </customwidgets>
  <resources>
   <include location="../../images/images.qrc"/>
-  <include location="../plugins/georeferencer/georeferencer.qrc"/>
  </resources>
  <connections/>
 </ui>

--- a/src/ui/qgsexpressionbuilder.ui
+++ b/src/ui/qgsexpressionbuilder.ui
@@ -19,357 +19,37 @@
   <property name="windowTitle">
    <string>Form</string>
   </property>
-  <layout class="QHBoxLayout" name="horizontalLayout_3">
-   <property name="margin">
+  <layout class="QGridLayout" name="gridLayout_2">
+   <property name="leftMargin">
     <number>0</number>
    </property>
-   <item>
-    <widget class="QSplitter" name="splitter">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
+    <number>0</number>
+   </property>
+   <item row="0" column="0">
+    <widget class="QTabWidget" name="tabWidget">
+     <property name="currentIndex">
+      <number>1</number>
      </property>
-     <property name="handleWidth">
-      <number>4</number>
+     <property name="documentMode">
+      <bool>true</bool>
      </property>
-     <widget class="QWidget" name="layoutWidget_1">
-      <layout class="QVBoxLayout" name="verticalLayout">
-       <item>
-        <widget class="QGroupBox" name="groupBox">
-         <property name="sizePolicy">
-          <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-           <horstretch>0</horstretch>
-           <verstretch>0</verstretch>
-          </sizepolicy>
-         </property>
-         <property name="minimumSize">
-          <size>
-           <width>0</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="maximumSize">
-          <size>
-           <width>16777215</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="baseSize">
-          <size>
-           <width>0</width>
-           <height>0</height>
-          </size>
-         </property>
-         <property name="title">
-          <string>Expression</string>
-         </property>
-         <property name="flat">
-          <bool>true</bool>
-         </property>
-         <layout class="QGridLayout" name="gridLayout">
-          <property name="margin">
-           <number>0</number>
-          </property>
-          <item row="1" column="0" colspan="2">
-           <widget class="QgsCodeEditorSQL" name="txtExpressionString" native="true"/>
-          </item>
-          <item row="0" column="0">
-           <widget class="QFrame" name="mOperatorsGroupBox">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Fixed" vsizetype="Maximum">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>27</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>300</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="sizeIncrement">
-             <size>
-              <width>20</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="baseSize">
-             <size>
-              <width>7</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="layoutDirection">
-             <enum>Qt::LeftToRight</enum>
-            </property>
-            <property name="autoFillBackground">
-             <bool>false</bool>
-            </property>
-            <layout class="QHBoxLayout" name="horizontalLayout_2">
-             <property name="spacing">
-              <number>2</number>
-             </property>
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <item>
-              <widget class="QPushButton" name="btnEqualPushButton">
-               <property name="toolTip">
-                <string>Equal operator</string>
-               </property>
-               <property name="text">
-                <string>=</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QPushButton" name="btnPlusPushButton">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="toolTip">
-                <string>Addition operator</string>
-               </property>
-               <property name="text">
-                <string>+</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QPushButton" name="btnMinusPushButton">
-               <property name="toolTip">
-                <string>Subtraction operator</string>
-               </property>
-               <property name="text">
-                <string>-</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QPushButton" name="btnDividePushButton">
-               <property name="toolTip">
-                <string>Division operator</string>
-               </property>
-               <property name="text">
-                <string>/</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QPushButton" name="btnMultiplyPushButton">
-               <property name="toolTip">
-                <string>Multiplication operator</string>
-               </property>
-               <property name="text">
-                <string>*</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QPushButton" name="btnExpButton">
-               <property name="toolTip">
-                <string>Power operator</string>
-               </property>
-               <property name="text">
-                <string>^</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QPushButton" name="btnConcatButton">
-               <property name="toolTip">
-                <string>String Concatenation</string>
-               </property>
-               <property name="text">
-                <string>||</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QPushButton" name="btnOpenBracketPushButton">
-               <property name="sizePolicy">
-                <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
-                 <horstretch>0</horstretch>
-                 <verstretch>0</verstretch>
-                </sizepolicy>
-               </property>
-               <property name="minimumSize">
-                <size>
-                 <width>0</width>
-                 <height>10</height>
-                </size>
-               </property>
-               <property name="toolTip">
-                <string>Open Bracket </string>
-               </property>
-               <property name="text">
-                <string>(</string>
-               </property>
-              </widget>
-             </item>
-             <item>
-              <widget class="QPushButton" name="btnCloseBracketPushButton">
-               <property name="toolTip">
-                <string>Close Bracket </string>
-               </property>
-               <property name="text">
-                <string>)</string>
-               </property>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-          <item row="3" column="0" colspan="2">
-           <layout class="QHBoxLayout" name="horizontalLayout_4">
-            <item>
-             <widget class="QLabel" name="label_2">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="toolTip">
-               <string>Output preview is generated &lt;br&gt; using the first feature from the layer.</string>
-              </property>
-              <property name="text">
-               <string>Output preview: </string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QLabel" name="lblPreview">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="font">
-               <font>
-                <weight>50</weight>
-                <italic>true</italic>
-                <bold>false</bold>
-                <underline>false</underline>
-               </font>
-              </property>
-              <property name="toolTip">
-               <string>Output preview is generated &lt;br&gt; using the first feature from the layer.</string>
-              </property>
-              <property name="frameShape">
-               <enum>QFrame::NoFrame</enum>
-              </property>
-              <property name="frameShadow">
-               <enum>QFrame::Sunken</enum>
-              </property>
-              <property name="lineWidth">
-               <number>0</number>
-              </property>
-              <property name="midLineWidth">
-               <number>0</number>
-              </property>
-              <property name="text">
-               <string/>
-              </property>
-              <property name="scaledContents">
-               <bool>false</bool>
-              </property>
-              <property name="wordWrap">
-               <bool>false</bool>
-              </property>
-              <property name="textInteractionFlags">
-               <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </item>
-          <item row="2" column="0">
-           <widget class="QgsCollapsibleGroupBox" name="cgbCustomFunction">
-            <property name="sizePolicy">
-             <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-              <horstretch>0</horstretch>
-              <verstretch>0</verstretch>
-             </sizepolicy>
-            </property>
-            <property name="minimumSize">
-             <size>
-              <width>0</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="maximumSize">
-             <size>
-              <width>16777215</width>
-              <height>16777215</height>
-             </size>
-            </property>
-            <property name="baseSize">
-             <size>
-              <width>0</width>
-              <height>0</height>
-             </size>
-            </property>
-            <property name="title">
-             <string>Custom function</string>
-            </property>
-            <property name="flat">
-             <bool>true</bool>
-            </property>
-            <layout class="QGridLayout" name="gridLayout_5">
-             <property name="leftMargin">
-              <number>0</number>
-             </property>
-             <property name="topMargin">
-              <number>9</number>
-             </property>
-             <property name="rightMargin">
-              <number>0</number>
-             </property>
-             <property name="bottomMargin">
-              <number>0</number>
-             </property>
-             <item row="0" column="0" colspan="2">
-              <widget class="QgsCodeEditorPython" name="txtPython" native="true">
-               <zorder>mOperatorsGroupBox</zorder>
-              </widget>
-             </item>
-            </layout>
-           </widget>
-          </item>
-         </layout>
-        </widget>
-       </item>
-      </layout>
-     </widget>
-     <widget class="QGroupBox" name="moperationListGroup">
-      <property name="title">
-       <string>Functions</string>
-      </property>
-      <property name="flat">
-       <bool>true</bool>
-      </property>
-      <layout class="QGridLayout" name="gridLayout_6">
+     <widget class="QWidget" name="tab">
+      <attribute name="title">
+       <string>Expression</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout_3">
        <property name="leftMargin">
         <number>0</number>
        </property>
        <property name="topMargin">
-        <number>3</number>
+        <number>0</number>
        </property>
        <property name="rightMargin">
         <number>0</number>
@@ -377,164 +57,609 @@
        <property name="bottomMargin">
         <number>0</number>
        </property>
-       <property name="horizontalSpacing">
-        <number>6</number>
-       </property>
-       <property name="verticalSpacing">
+       <item row="0" column="0">
+        <widget class="QSplitter" name="splitter">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="handleWidth">
+          <number>4</number>
+         </property>
+         <widget class="QWidget" name="layoutWidget_1">
+          <layout class="QVBoxLayout" name="verticalLayout">
+           <item>
+            <widget class="QGroupBox" name="groupBox">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="minimumSize">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="maximumSize">
+              <size>
+               <width>16777215</width>
+               <height>16777215</height>
+              </size>
+             </property>
+             <property name="baseSize">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+             <property name="title">
+              <string>Expression</string>
+             </property>
+             <property name="flat">
+              <bool>true</bool>
+             </property>
+             <layout class="QGridLayout" name="gridLayout">
+              <property name="leftMargin">
+               <number>0</number>
+              </property>
+              <property name="topMargin">
+               <number>0</number>
+              </property>
+              <property name="rightMargin">
+               <number>0</number>
+              </property>
+              <property name="bottomMargin">
+               <number>0</number>
+              </property>
+              <item row="2" column="0" colspan="2">
+               <layout class="QHBoxLayout" name="horizontalLayout_4">
+                <item>
+                 <widget class="QLabel" name="label_2">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="toolTip">
+                   <string>Output preview is generated &lt;br&gt; using the first feature from the layer.</string>
+                  </property>
+                  <property name="text">
+                   <string>Output preview: </string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QLabel" name="lblPreview">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="font">
+                   <font>
+                    <weight>50</weight>
+                    <italic>true</italic>
+                    <bold>false</bold>
+                    <underline>false</underline>
+                   </font>
+                  </property>
+                  <property name="toolTip">
+                   <string>Output preview is generated &lt;br&gt; using the first feature from the layer.</string>
+                  </property>
+                  <property name="frameShape">
+                   <enum>QFrame::NoFrame</enum>
+                  </property>
+                  <property name="frameShadow">
+                   <enum>QFrame::Sunken</enum>
+                  </property>
+                  <property name="lineWidth">
+                   <number>0</number>
+                  </property>
+                  <property name="midLineWidth">
+                   <number>0</number>
+                  </property>
+                  <property name="text">
+                   <string/>
+                  </property>
+                  <property name="scaledContents">
+                   <bool>false</bool>
+                  </property>
+                  <property name="wordWrap">
+                   <bool>false</bool>
+                  </property>
+                  <property name="textInteractionFlags">
+                   <set>Qt::LinksAccessibleByMouse|Qt::TextSelectableByMouse</set>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </item>
+              <item row="0" column="0">
+               <widget class="QFrame" name="mOperatorsGroupBox">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Fixed" vsizetype="Maximum">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="minimumSize">
+                 <size>
+                  <width>27</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="maximumSize">
+                 <size>
+                  <width>300</width>
+                  <height>16777215</height>
+                 </size>
+                </property>
+                <property name="sizeIncrement">
+                 <size>
+                  <width>20</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="baseSize">
+                 <size>
+                  <width>7</width>
+                  <height>0</height>
+                 </size>
+                </property>
+                <property name="layoutDirection">
+                 <enum>Qt::LeftToRight</enum>
+                </property>
+                <property name="autoFillBackground">
+                 <bool>false</bool>
+                </property>
+                <layout class="QHBoxLayout" name="horizontalLayout_2">
+                 <property name="spacing">
+                  <number>2</number>
+                 </property>
+                 <property name="leftMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="rightMargin">
+                  <number>0</number>
+                 </property>
+                 <property name="bottomMargin">
+                  <number>0</number>
+                 </property>
+                 <item>
+                  <widget class="QPushButton" name="btnEqualPushButton">
+                   <property name="toolTip">
+                    <string>Equal operator</string>
+                   </property>
+                   <property name="text">
+                    <string>=</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QPushButton" name="btnPlusPushButton">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="toolTip">
+                    <string>Addition operator</string>
+                   </property>
+                   <property name="text">
+                    <string>+</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QPushButton" name="btnMinusPushButton">
+                   <property name="toolTip">
+                    <string>Subtraction operator</string>
+                   </property>
+                   <property name="text">
+                    <string>-</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QPushButton" name="btnDividePushButton">
+                   <property name="toolTip">
+                    <string>Division operator</string>
+                   </property>
+                   <property name="text">
+                    <string>/</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QPushButton" name="btnMultiplyPushButton">
+                   <property name="toolTip">
+                    <string>Multiplication operator</string>
+                   </property>
+                   <property name="text">
+                    <string>*</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QPushButton" name="btnExpButton">
+                   <property name="toolTip">
+                    <string>Power operator</string>
+                   </property>
+                   <property name="text">
+                    <string>^</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QPushButton" name="btnConcatButton">
+                   <property name="toolTip">
+                    <string>String Concatenation</string>
+                   </property>
+                   <property name="text">
+                    <string>||</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QPushButton" name="btnOpenBracketPushButton">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Minimum" vsizetype="Maximum">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="minimumSize">
+                    <size>
+                     <width>0</width>
+                     <height>10</height>
+                    </size>
+                   </property>
+                   <property name="toolTip">
+                    <string>Open Bracket </string>
+                   </property>
+                   <property name="text">
+                    <string>(</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item>
+                  <widget class="QPushButton" name="btnCloseBracketPushButton">
+                   <property name="toolTip">
+                    <string>Close Bracket </string>
+                   </property>
+                   <property name="text">
+                    <string>)</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+              <item row="1" column="0" colspan="2">
+               <widget class="QgsCodeEditorSQL" name="txtExpressionString" native="true"/>
+              </item>
+             </layout>
+            </widget>
+           </item>
+          </layout>
+         </widget>
+         <widget class="QGroupBox" name="moperationListGroup">
+          <property name="title">
+           <string>Functions</string>
+          </property>
+          <property name="flat">
+           <bool>true</bool>
+          </property>
+          <layout class="QGridLayout" name="gridLayout_6">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>3</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
+            <number>0</number>
+           </property>
+           <property name="horizontalSpacing">
+            <number>6</number>
+           </property>
+           <property name="verticalSpacing">
+            <number>0</number>
+           </property>
+           <item row="2" column="0">
+            <widget class="QgsFilterLineEdit" name="txtSearchEdit">
+             <property name="enabled">
+              <bool>true</bool>
+             </property>
+            </widget>
+           </item>
+           <item row="4" column="0">
+            <widget class="QTreeView" name="expressionTree">
+             <property name="frameShape">
+              <enum>QFrame::StyledPanel</enum>
+             </property>
+             <property name="frameShadow">
+              <enum>QFrame::Sunken</enum>
+             </property>
+             <property name="editTriggers">
+              <set>QAbstractItemView::NoEditTriggers</set>
+             </property>
+             <property name="uniformRowHeights">
+              <bool>false</bool>
+             </property>
+             <property name="sortingEnabled">
+              <bool>false</bool>
+             </property>
+             <property name="animated">
+              <bool>true</bool>
+             </property>
+             <attribute name="headerVisible">
+              <bool>false</bool>
+             </attribute>
+            </widget>
+           </item>
+           <item row="5" column="0">
+            <layout class="QVBoxLayout" name="verticalLayout_2">
+             <property name="spacing">
+              <number>0</number>
+             </property>
+             <property name="sizeConstraint">
+              <enum>QLayout::SetDefaultConstraint</enum>
+             </property>
+             <property name="topMargin">
+              <number>0</number>
+             </property>
+             <property name="rightMargin">
+              <number>0</number>
+             </property>
+             <property name="bottomMargin">
+              <number>0</number>
+             </property>
+             <item>
+              <widget class="QFrame" name="mValueGroupBox">
+               <layout class="QGridLayout" name="gridLayout_7">
+                <property name="leftMargin">
+                 <number>0</number>
+                </property>
+                <property name="topMargin">
+                 <number>0</number>
+                </property>
+                <property name="rightMargin">
+                 <number>0</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>0</number>
+                </property>
+                <property name="spacing">
+                 <number>0</number>
+                </property>
+                <item row="1" column="0" colspan="2">
+                 <widget class="QListWidget" name="mValueListWidget">
+                  <property name="sizePolicy">
+                   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+                    <horstretch>0</horstretch>
+                    <verstretch>0</verstretch>
+                   </sizepolicy>
+                  </property>
+                  <property name="maximumSize">
+                   <size>
+                    <width>16777215</width>
+                    <height>16777215</height>
+                   </size>
+                  </property>
+                  <property name="autoFillBackground">
+                   <bool>false</bool>
+                  </property>
+                  <property name="editTriggers">
+                   <set>QAbstractItemView::NoEditTriggers</set>
+                  </property>
+                  <property name="showDropIndicator" stdset="0">
+                   <bool>false</bool>
+                  </property>
+                  <property name="alternatingRowColors">
+                   <bool>true</bool>
+                  </property>
+                  <property name="viewMode">
+                   <enum>QListView::ListMode</enum>
+                  </property>
+                 </widget>
+                </item>
+                <item row="0" column="0">
+                 <widget class="QLabel" name="label_4">
+                  <property name="text">
+                   <string>Values</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+             <item>
+              <widget class="QWidget" name="mLoadGroupBox" native="true">
+               <layout class="QHBoxLayout" name="horizontalLayout">
+                <property name="leftMargin">
+                 <number>0</number>
+                </property>
+                <property name="topMargin">
+                 <number>0</number>
+                </property>
+                <property name="rightMargin">
+                 <number>0</number>
+                </property>
+                <property name="bottomMargin">
+                 <number>0</number>
+                </property>
+                <item>
+                 <spacer name="horizontalSpacer">
+                  <property name="orientation">
+                   <enum>Qt::Horizontal</enum>
+                  </property>
+                  <property name="sizeHint" stdset="0">
+                   <size>
+                    <width>5</width>
+                    <height>20</height>
+                   </size>
+                  </property>
+                 </spacer>
+                </item>
+                <item>
+                 <widget class="QLabel" name="lblLoad">
+                  <property name="text">
+                   <string>Load values</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="btnLoadAll">
+                  <property name="text">
+                   <string>all unique</string>
+                  </property>
+                 </widget>
+                </item>
+                <item>
+                 <widget class="QPushButton" name="btnLoadSample">
+                  <property name="text">
+                   <string>10 samples</string>
+                  </property>
+                 </widget>
+                </item>
+               </layout>
+              </widget>
+             </item>
+            </layout>
+           </item>
+           <item row="2" column="1" rowspan="4">
+            <layout class="QVBoxLayout" name="verticalLayout_3">
+             <item>
+              <widget class="QTextEdit" name="txtHelpText">
+               <property name="readOnly">
+                <bool>true</bool>
+               </property>
+              </widget>
+             </item>
+            </layout>
+           </item>
+          </layout>
+         </widget>
+        </widget>
+       </item>
+      </layout>
+     </widget>
+     <widget class="QWidget" name="tab_2">
+      <attribute name="title">
+       <string>Function Editor</string>
+      </attribute>
+      <layout class="QGridLayout" name="gridLayout_4">
+       <property name="leftMargin">
         <number>0</number>
        </property>
-       <item row="2" column="0">
-        <widget class="QgsFilterLineEdit" name="txtSearchEdit">
-         <property name="enabled">
-          <bool>true</bool>
-         </property>
-        </widget>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
+        <number>0</number>
+       </property>
+       <item row="1" column="0">
+        <widget class="QgsCodeEditorPython" name="txtPython" native="true"/>
        </item>
-       <item row="4" column="0">
-        <widget class="QTreeView" name="expressionTree">
-         <property name="frameShape">
-          <enum>QFrame::StyledPanel</enum>
-         </property>
-         <property name="frameShadow">
-          <enum>QFrame::Sunken</enum>
-         </property>
-         <property name="editTriggers">
-          <set>QAbstractItemView::NoEditTriggers</set>
-         </property>
-         <property name="uniformRowHeights">
-          <bool>false</bool>
-         </property>
-         <property name="sortingEnabled">
-          <bool>false</bool>
-         </property>
-         <property name="animated">
-          <bool>true</bool>
-         </property>
-         <attribute name="headerVisible">
-          <bool>false</bool>
-         </attribute>
-        </widget>
-       </item>
-       <item row="5" column="0">
-        <layout class="QVBoxLayout" name="verticalLayout_2">
-         <property name="spacing">
-          <number>0</number>
-         </property>
+       <item row="0" column="0">
+        <layout class="QHBoxLayout" name="horizontalLayout_5">
          <property name="sizeConstraint">
           <enum>QLayout::SetDefaultConstraint</enum>
          </property>
-         <property name="topMargin">
-          <number>0</number>
-         </property>
-         <property name="rightMargin">
-          <number>0</number>
-         </property>
-         <property name="bottomMargin">
-          <number>0</number>
-         </property>
          <item>
-          <widget class="QFrame" name="mValueGroupBox">
-           <layout class="QGridLayout" name="gridLayout_7">
-            <property name="margin">
-             <number>0</number>
-            </property>
-            <property name="spacing">
-             <number>0</number>
-            </property>
-            <item row="1" column="0" colspan="2">
-             <widget class="QListWidget" name="mValueListWidget">
-              <property name="sizePolicy">
-               <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
-                <horstretch>0</horstretch>
-                <verstretch>0</verstretch>
-               </sizepolicy>
-              </property>
-              <property name="maximumSize">
-               <size>
-                <width>16777215</width>
-                <height>16777215</height>
-               </size>
-              </property>
-              <property name="autoFillBackground">
-               <bool>false</bool>
-              </property>
-              <property name="editTriggers">
-               <set>QAbstractItemView::NoEditTriggers</set>
-              </property>
-              <property name="showDropIndicator" stdset="0">
-               <bool>false</bool>
-              </property>
-              <property name="alternatingRowColors">
-               <bool>true</bool>
-              </property>
-              <property name="viewMode">
-               <enum>QListView::ListMode</enum>
-              </property>
-             </widget>
-            </item>
-            <item row="0" column="0">
-             <widget class="QLabel" name="label_4">
-              <property name="text">
-               <string>Values</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </widget>
-         </item>
-         <item>
-          <widget class="QWidget" name="mLoadGroupBox" native="true">
-           <layout class="QHBoxLayout" name="horizontalLayout">
-            <property name="margin">
-             <number>0</number>
-            </property>
-            <item>
-             <spacer name="horizontalSpacer">
-              <property name="orientation">
-               <enum>Qt::Horizontal</enum>
-              </property>
-              <property name="sizeHint" stdset="0">
-               <size>
-                <width>5</width>
-                <height>20</height>
-               </size>
-              </property>
-             </spacer>
-            </item>
-            <item>
-             <widget class="QLabel" name="lblLoad">
-              <property name="text">
-               <string>Load values</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QPushButton" name="btnLoadAll">
-              <property name="text">
-               <string>all unique</string>
-              </property>
-             </widget>
-            </item>
-            <item>
-             <widget class="QPushButton" name="btnLoadSample">
-              <property name="text">
-               <string>10 samples</string>
-              </property>
-             </widget>
-            </item>
-           </layout>
-          </widget>
-         </item>
-        </layout>
-       </item>
-       <item row="2" column="1" rowspan="4">
-        <layout class="QVBoxLayout" name="verticalLayout_3">
-         <item>
-          <widget class="QTextEdit" name="txtHelpText">
-           <property name="readOnly">
+          <widget class="QToolButton" name="btnRun">
+           <property name="text">
+            <string>...</string>
+           </property>
+           <property name="icon">
+            <iconset resource="../plugins/georeferencer/georeferencer.qrc">
+             <normaloff>:/icons/default/mActionStartGeoref.png</normaloff>:/icons/default/mActionStartGeoref.png</iconset>
+           </property>
+           <property name="autoRaise">
             <bool>true</bool>
            </property>
           </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_3">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeType">
+            <enum>QSizePolicy::Minimum</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>20</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+         <item>
+          <widget class="QToolButton" name="btnNewFile">
+           <property name="text">
+            <string>New</string>
+           </property>
+           <property name="icon">
+            <iconset resource="../../images/images.qrc">
+             <normaloff>:/images/themes/default/mActionFileNew.svg</normaloff>:/images/themes/default/mActionFileNew.svg</iconset>
+           </property>
+           <property name="autoRaise">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QComboBox" name="cmbFileNames">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="MinimumExpanding" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="editable">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QToolButton" name="btnSaveFile">
+           <property name="text">
+            <string>Save</string>
+           </property>
+           <property name="icon">
+            <iconset resource="../plugins/georeferencer/georeferencer.qrc">
+             <normaloff>:/icons/default/mActionSaveRasterAs.png</normaloff>:/icons/default/mActionSaveRasterAs.png</iconset>
+           </property>
+           <property name="autoRaise">
+            <bool>true</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer_2">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
          </item>
         </layout>
        </item>
@@ -543,21 +668,12 @@
     </widget>
    </item>
   </layout>
-  <zorder>mLoadGroupBox</zorder>
-  <zorder>splitter</zorder>
-  <zorder>groupBox</zorder>
  </widget>
  <customwidgets>
   <customwidget>
    <class>QgsFilterLineEdit</class>
    <extends>QLineEdit</extends>
    <header>qgsfilterlineedit.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsCollapsibleGroupBox</class>
-   <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
-   <container>1</container>
   </customwidget>
   <customwidget>
    <class>QgsCodeEditorSQL</class>
@@ -572,6 +688,9 @@
    <container>1</container>
   </customwidget>
  </customwidgets>
- <resources/>
+ <resources>
+  <include location="../../images/images.qrc"/>
+  <include location="../plugins/georeferencer/georeferencer.qrc"/>
+ </resources>
  <connections/>
 </ui>


### PR DESCRIPTION
**Note: For review and feedback. Not for merging yet**

This PR moves the custom function text area to a tab in the expression widget and allows for loading and saving of expression function files.  Expression function files are just normal Python files that live in `qgis2/functions` and are loaded at QGIS load time (not included in this PR yet).  Existing function files can be loaded from the combo box at the top of the widget.

![screenshot from 2015-01-12 18 43 27](https://cloud.githubusercontent.com/assets/381660/5700536/635afc02-9a8b-11e4-8053-19a20036abf0.png)

Pressing the run button will run the Python code in the current session (no syntax or error handling yet) but also save the current file.  Changing the text in the combo box will create a new file if not found or save over the existing one.  Changing the combo box value will load that file into the editor if found.

The rational for this change is because after I added the custom function text edit area it became apparent that you could not access the Python code you had just written (doh!).  I toyed with the idea of being able to store the Python code with the function and allow loading function code from the function tree however that lead to many user issues after testing like:
- Allows for more then one function per file. How do you load just the function you selected in the tree?
- Any smart file naming or auto saving/restoring felt really hacky
- Not a lot of room for more advanced logic 

Talking to Martin and Nyall this seemed like the smarter move.  It moves the focus more onto a code editor where you can define custom functions rather then a custom Python function (think ArcGIS) which the old UI implied 

This new method seems more clear to me as it allows for function grouping into single files, sharing of function files, larger code editor, clearer intent.

Feel free to try the code and leave any feedback. It's still not 100% yet but it does work.
