### PR TITLE
[FEATURE] Transactional editing for postgres layers

### DIFF
--- a/python/core/core.sip
+++ b/python/core/core.sip
@@ -12,6 +12,7 @@
 
 %Include qgis.sip
 
+%Include qgstransaction.sip
 %Include qgsapplication.sip
 %Include qgsattributeaction.sip
 %Include qgsbrowsermodel.sip

--- a/python/core/qgstransaction.sip
+++ b/python/core/qgstransaction.sip
@@ -1,0 +1,51 @@
+/**
+ * This class allows to include a set of layers in a database-side transaction,
+ * provided the layer data providers support transactions and are compatible
+ * with each other.
+ *
+ * Only layers which are not in edit mode can be included in a transaction,
+ * and all layers need to be in read-only mode for a transaction to be committed
+ * or rolled back.
+ *
+ * Layers cannot only be included in one transaction at a time.
+ *
+ * When editing layers which are part of a transaction group, all changes are
+ * sent directly to the data provider (bypassing the undo/redo stack), and the
+ * changes can either be committed or rolled back on the database side via the
+ * QgsTransaction::commit and QgsTransaction::rollback methods.
+ *
+ * As long as the transaction is active, the state of all layer features reflects
+ * the current state in the transaction.
+ *
+ * Edits on features can get rejected if another conflicting transaction is active.
+ */
+class QgsTransaction /Abstract/
+{
+%TypeHeaderCode
+#include <qgstransaction.h>
+%End
+  public:
+    /** Creates a transaction for the specified connection string and provider */
+    static QgsTransaction* create( const QString& connString, const QString& providerKey ) /Factory/;
+
+    /** Creates a transaction which includes the specified layers. Connection string
+     *  and data provider are taken from the first layer */
+    static QgsTransaction* create( const QStringList& layerIds ) /Factory/;
+
+    virtual ~QgsTransaction();
+
+	/** Add layer to the transaction. The layer must not be in edit mode. The transaction must not be active. */
+    bool addLayer( const QString& layerId );
+
+    /** Begin transaction */
+    bool begin( QString& errorMsg );
+
+    /** Commit transaction. All layers need to be in read-only mode. */
+    bool commit( QString& errorMsg );
+
+    /** Roll back transaction. All layers need to be in read-only mode. */
+    bool rollback( QString& errorMsg );
+
+    /** Executes sql */
+    virtual bool executeSql( const QString& sql, QString& error ) = 0;
+};

--- a/python/core/qgsvectordataprovider.sip
+++ b/python/core/qgsvectordataprovider.sip
@@ -313,6 +313,8 @@ class QgsVectorDataProvider : QgsDataProvider
 
     static QVariant convertValue( QVariant::Type type, QString value );
 
+    virtual QgsTransaction* transaction() const;
+
   protected:
     void clearMinMaxCache();
     void fillMinMaxCache();

--- a/python/core/qgsvectorlayer.sip
+++ b/python/core/qgsvectorlayer.sip
@@ -578,7 +578,7 @@ class QgsVectorLayer : QgsMapLayer
     /** Deletes the selected features
      *  @return true in case of success and false otherwise
      */
-    bool deleteSelectedFeatures();
+    bool deleteSelectedFeatures(int* deletedCount = 0);
 
     /**Adds a ring to polygon/multipolygon features
      @return

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5246,8 +5246,8 @@ void QgisApp::deleteSelected( QgsMapLayer *layer, QWidget* parent, bool promptCo
   }
 
   //validate selection
-  int numberOfDeletedFeatures = vlayer->selectedFeaturesIds().size();
-  if ( numberOfDeletedFeatures == 0 )
+  int numberOfSelectedFeatures = vlayer->selectedFeaturesIds().size();
+  if ( numberOfSelectedFeatures == 0 )
   {
     messageBar()->pushMessage( tr( "No Features Selected" ),
                                tr( "The current layer has no selected features" ),
@@ -5255,21 +5255,22 @@ void QgisApp::deleteSelected( QgsMapLayer *layer, QWidget* parent, bool promptCo
     return;
   }
   //display a warning
-  if ( promptConfirmation && QMessageBox::warning( parent, tr( "Delete features" ), tr( "Delete %n feature(s)?", "number of features to delete", numberOfDeletedFeatures ), QMessageBox::Ok | QMessageBox::Cancel ) == QMessageBox::Cancel )
+  if ( promptConfirmation && QMessageBox::warning( parent, tr( "Delete features" ), tr( "Delete %n feature(s)?", "number of features to delete", numberOfSelectedFeatures ), QMessageBox::Ok | QMessageBox::Cancel ) == QMessageBox::Cancel )
   {
     return;
   }
 
   vlayer->beginEditCommand( tr( "Features deleted" ) );
-  if ( !vlayer->deleteSelectedFeatures() )
+  int deletedCount = 0;
+  if ( !vlayer->deleteSelectedFeatures( &deletedCount ) )
   {
     messageBar()->pushMessage( tr( "Problem deleting features" ),
-                               tr( "A problem occured during deletion of features" ),
+                               tr( "A problem occured during deletion of %1 feature(s)" ).arg( numberOfSelectedFeatures - deletedCount ),
                                QgsMessageBar::WARNING );
   }
   else
   {
-    showStatusMessage( tr( "%n feature(s) deleted.", "number of features deleted", numberOfDeletedFeatures ) );
+    showStatusMessage( tr( "%n feature(s) deleted.", "number of features deleted", numberOfSelectedFeatures ) );
   }
 
   vlayer->endEditCommand();

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -153,12 +153,14 @@ SET(QGIS_CORE_SRCS
   qgssimplifymethod.cpp
   qgssnapper.cpp
   qgsspatialindex.cpp
+  qgstransaction.cpp
   qgstolerance.cpp
   qgsvectordataprovider.cpp
   qgsvectorfilewriter.cpp
   qgsvectorlayer.cpp
   qgsvectorlayercache.cpp
   qgsvectorlayereditbuffer.cpp
+  qgsvectorlayereditpassthrough.cpp
   qgsvectorlayereditutils.cpp
   qgsvectorlayerfeatureiterator.cpp
   qgsvectorlayerimport.cpp
@@ -188,7 +190,7 @@ SET(QGIS_CORE_SRCS
   composer/qgscomposermapoverview.cpp
   composer/qgscomposertable.cpp
   composer/qgscomposertablev2.cpp
-  composer/qgscomposertablecolumn.cpp  
+  composer/qgscomposertablecolumn.cpp
   composer/qgscomposerattributetable.cpp
   composer/qgscomposerattributetablev2.cpp
   composer/qgscomposerattributetablemodel.cpp
@@ -211,7 +213,7 @@ SET(QGIS_CORE_SRCS
   composer/qgscomposermultiframe.cpp
   composer/qgscomposermodel.cpp
   composer/qgscomposition.cpp
-  
+
   dxf/qgsdxfexport.cpp
   dxf/qgsdxfpaintdevice.cpp
   dxf/qgsdxfpaintengine.cpp
@@ -269,7 +271,7 @@ SET(QGIS_CORE_SRCS
   raster/qgssinglebandgrayrenderer.cpp
   raster/qgssinglebandpseudocolorrenderer.cpp
   raster/qgsbrightnesscontrastfilter.cpp
-  raster/qgshuesaturationfilter.cpp  
+  raster/qgshuesaturationfilter.cpp
 )
 
 IF(ENABLE_MODELTEST)
@@ -360,6 +362,7 @@ SET(QGIS_CORE_MOC_HDRS
   qgsrunprocess.h
   qgsrelationmanager.h
   qgsvectorlayer.h
+  qgsvectorlayereditpassthrough.h
   qgsvectorlayereditbuffer.h
   qgsnetworkaccessmanager.h
   qgsvectordataprovider.h
@@ -378,14 +381,14 @@ SET(QGIS_CORE_MOC_HDRS
   composer/qgscomposerobject.h
   composer/qgscomposeritem.h
   composer/qgscomposeritemgroup.h
-  composer/qgscomposermousehandles.h  
+  composer/qgscomposermousehandles.h
   composer/qgscomposerlabel.h
   composer/qgscomposershape.h
   composer/qgscomposerattributetable.h
   composer/qgscomposerattributetablev2.h
   composer/qgscomposerattributetablemodel.h
-  composer/qgscomposerattributetablemodelv2.h    
-  composer/qgscomposertable.h  
+  composer/qgscomposerattributetablemodelv2.h
+  composer/qgscomposertable.h
   composer/qgscomposertablev2.h
   composer/qgscomposertablecolumn.h
   composer/qgscomposerhtml.h
@@ -459,6 +462,8 @@ SET(QGIS_CORE_HDRS
   qgsclipper.h
   qgscolorscheme.h
   qgscolorschemeregistry.h
+  qgsconnectionpool.h
+  qgscontexthelp.h
   qgscoordinatereferencesystem.h
   qgscrscache.h
   qgscsexception.h
@@ -526,6 +531,9 @@ SET(QGIS_CORE_HDRS
   qgssnapper.h
   qgsspatialindex.h
   qgstolerance.h
+  qgstransaction.h
+  qgsvectordataprovider.h
+  qgsvectorlayercache.h
   qgsvectorfilewriter.h
   qgsvectorlayereditutils.h
   qgsvectorlayerfeatureiterator.h

--- a/src/core/qgstransaction.cpp
+++ b/src/core/qgstransaction.cpp
@@ -1,0 +1,213 @@
+/***************************************************************************
+                              qgstransaction.cpp
+                              ------------------
+  begin                : May 5, 2014
+  copyright            : (C) 2014 by Marco Hugentobler
+  email                : marco dot hugentobler at sourcepole dot ch
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <QLibrary>
+
+#include "qgstransaction.h"
+#include "qgsdatasourceuri.h"
+#include "qgsmaplayerregistry.h"
+#include "qgsproviderregistry.h"
+#include "qgsvectordataprovider.h"
+#include "qgsvectorlayer.h"
+
+typedef QgsTransaction* createTransaction_t( const QString& connString );
+
+QgsTransaction* QgsTransaction::create( const QString& connString, const QString& providerKey )
+{
+
+  QLibrary* lib = QgsProviderRegistry::instance()->providerLibrary( providerKey );
+  if ( !lib )
+  {
+    return 0;
+  }
+
+  createTransaction_t* createTransaction = ( createTransaction_t* ) cast_to_fptr( lib->resolve( "createTransaction" ) );
+  if ( !createTransaction )
+  {
+    return 0;
+  }
+
+  QgsTransaction* ts = createTransaction( connString );
+
+  delete lib;
+
+  return ts;
+}
+
+QgsTransaction* QgsTransaction::create( const QStringList& layerIds )
+{
+  if ( layerIds.isEmpty() )
+  {
+    return 0;
+  }
+
+  QgsVectorLayer* layer = qobject_cast<QgsVectorLayer*>( QgsMapLayerRegistry::instance()->mapLayer( layerIds.first() ) );
+  if ( !layer )
+  {
+    return 0;
+  }
+
+  QString connStr = QgsDataSourceURI( layer->source() ).connectionInfo();
+  QString providerKey = layer->dataProvider()->name();
+  QgsTransaction* ts = QgsTransaction::create( connStr, providerKey );
+  if ( !ts )
+  {
+    return 0;
+  }
+
+  foreach ( const QString& layerId, layerIds )
+  {
+    if ( !ts->addLayer( layerId ) )
+    {
+      delete ts;
+      return 0;
+    }
+  }
+  return ts;
+}
+
+
+QgsTransaction::QgsTransaction( const QString& connString )
+    : mConnString( connString ), mTransactionActive( false )
+{
+}
+
+QgsTransaction::~QgsTransaction()
+{
+  setLayerTransactionIds( 0 );
+}
+
+bool QgsTransaction::addLayer( const QString& layerId )
+{
+  if ( mTransactionActive )
+  {
+    return false;
+  }
+
+  QgsVectorLayer* layer = qobject_cast<QgsVectorLayer*>( QgsMapLayerRegistry::instance()->mapLayer( layerId ) );
+  if ( !layer )
+  {
+    return false;
+  }
+
+  if ( layer->isEditable() )
+  {
+    return false;
+  }
+
+  //test if provider supports transactions
+  if ( !layer->dataProvider() || !layer->dataProvider()->capabilities() & QgsVectorDataProvider::TransactionSupport )
+  {
+    return false;
+  }
+
+  if ( layer->dataProvider()->transaction() != 0 )
+  {
+    return false;
+  }
+
+  //connection string not compatible
+  if ( QgsDataSourceURI( layer->source() ).connectionInfo() != mConnString )
+  {
+    return false;
+  }
+
+  mLayers.insert( layerId );
+  return true;
+}
+
+bool QgsTransaction::begin( QString& errorMsg, int statementTimeout )
+{
+  if ( mTransactionActive )
+  {
+    return false;
+  }
+
+  //Set all layers to direct edit mode
+  if ( !beginTransaction( errorMsg, statementTimeout ) )
+  {
+    return false;
+  }
+
+  setLayerTransactionIds( this );
+  mTransactionActive = true;
+  return true;
+}
+
+bool QgsTransaction::commit( QString& errorMsg )
+{
+  if ( !mTransactionActive )
+  {
+    return false;
+  }
+
+  foreach ( const QString& layerid, mLayers )
+  {
+    QgsMapLayer* l = QgsMapLayerRegistry::instance()->mapLayer( layerid );
+    if ( !l || l->isEditable() )
+    {
+      return false;
+    }
+  }
+
+  if ( !commitTransaction( errorMsg ) )
+  {
+    return false;
+  }
+
+  setLayerTransactionIds( 0 );
+  mTransactionActive = false;
+  return true;
+}
+
+bool QgsTransaction::rollback( QString& errorMsg )
+{
+  if ( !mTransactionActive )
+  {
+    return false;
+  }
+
+  foreach ( const QString& layerid, mLayers )
+  {
+    QgsMapLayer* l = QgsMapLayerRegistry::instance()->mapLayer( layerid );
+    if ( !l || l->isEditable() )
+    {
+      return false;
+    }
+  }
+
+  if ( !rollbackTransaction( errorMsg ) )
+  {
+    return false;
+  }
+
+  setLayerTransactionIds( 0 );
+  mTransactionActive = false;
+  return true;
+}
+
+void QgsTransaction::setLayerTransactionIds( QgsTransaction* transaction )
+{
+  foreach ( const QString& layerid, mLayers )
+  {
+    QgsVectorLayer* vl = qobject_cast<QgsVectorLayer*>( QgsMapLayerRegistry::instance()->mapLayer( layerid ) );
+    if ( vl && vl->dataProvider() )
+    {
+      vl->dataProvider()->setTransaction( transaction );
+    }
+  }
+}

--- a/src/core/qgstransaction.h
+++ b/src/core/qgstransaction.h
@@ -1,0 +1,100 @@
+/***************************************************************************
+                              qgstransaction.h
+                              ----------------
+  begin                : May 5, 2014
+  copyright            : (C) 2014 by Marco Hugentobler
+  email                : marco dot hugentobler at sourcepole dot ch
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSTRANSACTION_H
+#define QGSTRANSACTION_H
+
+#include <QSet>
+#include <QString>
+
+class QgsVectorDataProvider;
+
+/**
+ * This class allows to include a set of layers in a database-side transaction,
+ * provided the layer data providers support transactions and are compatible
+ * with each other.
+ *
+ * Only layers which are not in edit mode can be included in a transaction,
+ * and all layers need to be in read-only mode for a transaction to be committed
+ * or rolled back.
+ *
+ * Layers cannot only be included in one transaction at a time.
+ *
+ * When editing layers which are part of a transaction group, all changes are
+ * sent directly to the data provider (bypassing the undo/redo stack), and the
+ * changes can either be committed or rolled back on the database side via the
+ * QgsTransaction::commit and QgsTransaction::rollback methods.
+ *
+ * As long as the transaction is active, the state of all layer features reflects
+ * the current state in the transaction.
+ *
+ * Edits on features can get rejected if another conflicting transaction is active.
+ */
+class CORE_EXPORT QgsTransaction
+{
+  public:
+    /** Creates a transaction for the specified connection string and provider */
+    static QgsTransaction* create( const QString& connString, const QString& providerKey );
+
+    /** Creates a transaction which includes the specified layers. Connection string
+     *  and data provider are taken from the first layer */
+    static QgsTransaction* create( const QStringList& layerIds );
+
+    virtual ~QgsTransaction();
+
+    /** Add layer to the transaction. The layer must not be in edit mode. The transaction must not be active. */
+    bool addLayer( const QString& layerId );
+
+    /** Begin transaction
+     *  The statement timeout, in seconds, specifies how long an sql statement
+     *  is allowed to block QGIS before it is aborted. Statements can block,
+     *  depending on the provider, if multiple transactions are active and a
+     *  statement would produce a conflicting state. In these cases, the
+     *  statements block until the conflicting transaction is committed or
+     *  rolled back.
+     *  Some providers might not honour the statement timeout. */
+    bool begin( QString& errorMsg, int statementTimeout = 20 );
+
+    /** Commit transaction. All layers need to be in read-only mode. */
+    bool commit( QString& errorMsg );
+
+    /** Roll back transaction. All layers need to be in read-only mode. */
+    bool rollback( QString& errorMsg );
+
+    /** Executes sql */
+    virtual bool executeSql( const QString& sql, QString& error ) = 0;
+
+  protected:
+    QgsTransaction( const QString& connString );
+
+    QString mConnString;
+
+  private:
+    QgsTransaction( const QgsTransaction& other );
+    const QgsTransaction& operator=( const QgsTransaction& other );
+
+    bool mTransactionActive;
+    QSet<QString> mLayers;
+
+    void setLayerTransactionIds( QgsTransaction *transaction );
+
+    virtual bool beginTransaction( QString& error, int statementTimeout ) = 0;
+    virtual bool commitTransaction( QString& error ) = 0;
+    virtual bool rollbackTransaction( QString& error ) = 0;
+};
+
+#endif // QGSTRANSACTION_H

--- a/src/core/qgsvectordataprovider.h
+++ b/src/core/qgsvectordataprovider.h
@@ -34,6 +34,7 @@ typedef QSet<int> QgsAttributeIds;
 typedef QHash<int, QString> QgsAttrPalIndexNameHash;
 
 class QgsFeatureIterator;
+class QgsTransaction;
 
 #include "qgsfeaturerequest.h"
 
@@ -48,6 +49,8 @@ class QgsFeatureIterator;
 class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider
 {
     Q_OBJECT
+
+    friend class QgsTransaction;
 
   public:
 
@@ -90,6 +93,8 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider
       SimplifyGeometries =           1 << 14,
       /** supports topological simplification of geometries on provider side according to a distance tolerance */
       SimplifyGeometriesWithTopologicalValidation = 1 << 15,
+      /** supports transactions*/
+      TransactionSupport = 1 << 16
     };
 
     /** bitmask of all provider's editing capabilities */
@@ -359,6 +364,11 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider
 
     static QVariant convertValue( QVariant::Type type, QString value );
 
+    /**
+     * Returns the transaction this data provider is included in, if any.
+     */
+    virtual QgsTransaction* transaction() const { return 0; }
+
   protected:
     void clearMinMaxCache();
     void fillMinMaxCache();
@@ -394,6 +404,11 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider
     QStringList mErrors;
 
     static QStringList smEncodings;
+
+    /**
+     * Includes this data provider in the specified transaction. Ownership of transaction is not transferred.
+     */
+    virtual void setTransaction( QgsTransaction* /*transaction*/ ) {}
 
 };
 

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -1036,7 +1036,7 @@ bool QgsVectorLayer::deleteVertex( QgsFeatureId atFeatureId, int atVertex )
 }
 
 
-bool QgsVectorLayer::deleteSelectedFeatures()
+bool QgsVectorLayer::deleteSelectedFeatures( int* deletedCount )
 {
   if ( !( mDataProvider->capabilities() & QgsVectorDataProvider::DeleteFeatures ) )
   {
@@ -1048,19 +1048,24 @@ bool QgsVectorLayer::deleteSelectedFeatures()
     return false;
   }
 
-  if ( mSelectedFeatureIds.size() == 0 )
-    return true;
-
-  while ( mSelectedFeatureIds.size() > 0 )
+  int deleted = 0;
+  int count = mSelectedFeatureIds.size();
+  // Make a copy since deleteFeature modifies mSelectedFeatureIds
+  QgsFeatureIds selectedFeatures( mSelectedFeatureIds );
+  foreach ( QgsFeatureId fid, selectedFeatures )
   {
-    QgsFeatureId fid = *mSelectedFeatureIds.begin();
-    deleteFeature( fid );  // removes from selection
+    deleted += deleteFeature( fid );  // removes from selection
   }
 
   triggerRepaint();
   updateExtents();
 
-  return true;
+  if ( deletedCount )
+  {
+    *deletedCount = deleted;
+  }
+
+  return deleted == count;
 }
 
 int QgsVectorLayer::addRing( const QList<QgsPoint>& ring )

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -940,7 +940,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
     /** Deletes the selected features
      *  @return true in case of success and false otherwise
      */
-    bool deleteSelectedFeatures();
+    bool deleteSelectedFeatures( int *deletedCount = 0 );
 
     /**Adds a ring to polygon/multipolygon features
      @return

--- a/src/core/qgsvectorlayereditbuffer.h
+++ b/src/core/qgsvectorlayereditbuffer.h
@@ -38,33 +38,33 @@ class CORE_EXPORT QgsVectorLayerEditBuffer : public QObject
     ~QgsVectorLayerEditBuffer();
 
     /** Returns true if the provider has been modified since the last commit */
-    bool isModified() const;
+    virtual bool isModified() const;
 
 
     /** Adds a feature
         @param f feature to add
         @return True in case of success and False in case of error
      */
-    bool addFeature( QgsFeature& f );
+    virtual bool addFeature( QgsFeature& f );
 
     /** Insert a copy of the given features into the layer  (but does not commit it) */
-    bool addFeatures( QgsFeatureList& features );
+    virtual bool addFeatures( QgsFeatureList& features );
 
     /** delete a feature from the layer (but does not commit it) */
-    bool deleteFeature( QgsFeatureId fid );
+    virtual bool deleteFeature( QgsFeatureId fid );
 
     /** change feature's geometry */
-    bool changeGeometry( QgsFeatureId fid, QgsGeometry* geom );
+    virtual bool changeGeometry( QgsFeatureId fid, QgsGeometry* geom );
 
     /** changed an attribute value (but does not commit it) */
-    bool changeAttributeValue( QgsFeatureId fid, int field, const QVariant &newValue, const QVariant &oldValue = QVariant() );
+    virtual bool changeAttributeValue( QgsFeatureId fid, int field, const QVariant &newValue, const QVariant &oldValue = QVariant() );
 
     /** add an attribute field (but does not commit it)
         returns true if the field was added */
-    bool addAttribute( const QgsField &field );
+    virtual bool addAttribute( const QgsField &field );
 
     /** delete an attribute field (but does not commit it) */
-    bool deleteAttribute( int attr );
+    virtual bool deleteAttribute( int attr );
 
 
     /**
@@ -82,10 +82,10 @@ class CORE_EXPORT QgsVectorLayerEditBuffer : public QObject
       Therefore any error message also includes which stage failed so
       that the user has some chance of repairing the damage cleanly.
      */
-    bool commitChanges( QStringList& commitErrors );
+    virtual bool commitChanges( QStringList& commitErrors );
 
     /** Stop editing and discard the edits */
-    void rollBack();
+    virtual void rollBack();
 
 
 
@@ -130,6 +130,8 @@ class CORE_EXPORT QgsVectorLayerEditBuffer : public QObject
     void committedGeometriesChanges( const QString& layerId, const QgsGeometryMap& changedGeometries );
 
   protected:
+
+    QgsVectorLayerEditBuffer() {}
 
     void updateFields( QgsFields& fields );
 

--- a/src/core/qgsvectorlayereditpassthrough.cpp
+++ b/src/core/qgsvectorlayereditpassthrough.cpp
@@ -1,0 +1,107 @@
+/***************************************************************************
+    qgsvectorlayereditpassthrough.cpp
+    ---------------------
+    begin                : Jan 12 2015
+    copyright            : (C) 2015 by Sandro Mani
+    email                : manisandro at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsvectorlayereditpassthrough.h"
+#include "qgsvectorlayer.h"
+#include "qgsvectordataprovider.h"
+
+bool QgsVectorLayerEditPassthrough::addFeature( QgsFeature& f )
+{
+
+  if ( L->dataProvider()->addFeatures( QgsFeatureList() << f ) )
+  {
+    emit featureAdded( f.id() );
+    return true;
+  }
+  return false;
+}
+
+bool QgsVectorLayerEditPassthrough::addFeatures( QgsFeatureList& features )
+{
+  if ( L->dataProvider()->addFeatures( features ) )
+  {
+    foreach ( const QgsFeature& f, features )
+    {
+      emit featureAdded( f.id() );
+    }
+    return true;
+  }
+  return false;
+}
+
+bool QgsVectorLayerEditPassthrough::deleteFeature( QgsFeatureId fid )
+{
+  if ( L->dataProvider()->deleteFeatures( QgsFeatureIds() << fid ) )
+  {
+    emit featureDeleted( fid );
+    return true;
+  }
+  return false;
+}
+
+bool QgsVectorLayerEditPassthrough::changeGeometry( QgsFeatureId fid, QgsGeometry* geom )
+{
+  QgsGeometryMap geomMap;
+  geomMap.insert( fid, *geom );
+  if ( L->dataProvider()->changeGeometryValues( geomMap ) )
+  {
+    emit geometryChanged( fid, *geom );
+    return true;
+  }
+  return false;
+}
+
+bool QgsVectorLayerEditPassthrough::changeAttributeValue( QgsFeatureId fid, int field, const QVariant &newValue, const QVariant &/*oldValue*/ )
+{
+  QgsAttributeMap map;
+  map.insert( field, newValue );
+  QgsChangedAttributesMap attribMap;
+  attribMap.insert( fid, map );
+  if ( L->dataProvider()->changeAttributeValues( attribMap ) )
+  {
+    emit attributeValueChanged( fid, field, newValue );
+    return true;
+  }
+  return false;
+}
+
+bool QgsVectorLayerEditPassthrough::addAttribute( const QgsField &field )
+{
+  if ( L->dataProvider()->addAttributes( QList<QgsField>() << field ) )
+  {
+    emit attributeAdded( L->dataProvider()->fieldNameIndex( field.name() ) );
+    return true;
+  }
+  return false;
+}
+
+bool QgsVectorLayerEditPassthrough::deleteAttribute( int attr )
+{
+  if ( L->dataProvider()->deleteAttributes( QgsAttributeIds() << attr ) )
+  {
+    emit attributeDeleted( attr );
+    return true;
+  }
+  return false;
+}
+
+bool QgsVectorLayerEditPassthrough::commitChanges( QStringList& /*commitErrors*/ )
+{
+  return true;
+}
+
+void QgsVectorLayerEditPassthrough::rollBack()
+{
+}

--- a/src/core/qgsvectorlayereditpassthrough.h
+++ b/src/core/qgsvectorlayereditpassthrough.h
@@ -1,0 +1,40 @@
+/***************************************************************************
+    qgsvectorlayereditpassthrough.h
+    ---------------------
+    begin                : Jan 12 2015
+    copyright            : (C) 2015 by Sandro Mani
+    email                : manisandro at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSVECTORLAYEREDITPASSTHROUGH_H
+#define QGSVECTORLAYEREDITPASSTHROUGH_H
+
+#include "qgsvectorlayereditbuffer.h"
+
+class QgsVectorLayer;
+
+class CORE_EXPORT QgsVectorLayerEditPassthrough : public QgsVectorLayerEditBuffer
+{
+    Q_OBJECT
+  public:
+    QgsVectorLayerEditPassthrough( QgsVectorLayer* layer ) { L = layer; }
+    bool isModified() const { return false; }
+    bool addFeature( QgsFeature& f );
+    bool addFeatures( QgsFeatureList& features );
+    bool deleteFeature( QgsFeatureId fid );
+    bool changeGeometry( QgsFeatureId fid, QgsGeometry* geom );
+    bool changeAttributeValue( QgsFeatureId fid, int field, const QVariant &newValue, const QVariant &oldValue = QVariant() );
+    bool addAttribute( const QgsField &field );
+    bool deleteAttribute( int attr );
+    bool commitChanges( QStringList& commitErrors );
+    void rollBack();
+
+};
+
+#endif // QGSVECTORLAYEREDITPASSTHROUGH_H

--- a/src/providers/postgres/CMakeLists.txt
+++ b/src/providers/postgres/CMakeLists.txt
@@ -8,6 +8,7 @@ SET(PG_SRCS
   qgspostgresconnpool.cpp
   qgspostgresdataitems.cpp
   qgspostgresfeatureiterator.cpp
+  qgspostgrestransaction.cpp
   qgspgsourceselect.cpp
   qgspgnewconnection.cpp
   qgspgtablemodel.cpp
@@ -24,6 +25,9 @@ SET(PG_MOC_HDRS
   qgscolumntypethread.h
 )
 
+SET(PG_HDRS
+  qgspostgrestransaction.h
+)
 
 ########################################################
 # Build
@@ -40,7 +44,7 @@ INCLUDE_DIRECTORIES(
   ${CMAKE_CURRENT_BINARY_DIR}/../../ui
 )
 
-ADD_LIBRARY (postgresprovider MODULE ${PG_SRCS} ${PG_MOC_SRCS})
+ADD_LIBRARY (postgresprovider MODULE ${PG_SRCS} ${PG_HDRS} ${PG_MOC_SRCS})
 
 TARGET_LINK_LIBRARIES (postgresprovider
   ${POSTGRES_LIBRARY}

--- a/src/providers/postgres/qgscolumntypethread.cpp
+++ b/src/providers/postgres/qgscolumntypethread.cpp
@@ -62,7 +62,7 @@ void QgsGeomColumnTypeThread::run()
                                 mAllowGeometrylessTables ) ||
        layerProperties.isEmpty() )
   {
-    mConn->disconnect();
+    mConn->unref();
     mConn = 0;
     return;
   }
@@ -108,6 +108,6 @@ void QgsGeomColumnTypeThread::run()
   emit progress( 0, 0 );
   emit progressMessage( tr( "Table retrieval finished." ) );
 
-  mConn->disconnect();
+  mConn->unref();
   mConn = 0;
 }

--- a/src/providers/postgres/qgspgnewconnection.cpp
+++ b/src/providers/postgres/qgspgnewconnection.cpp
@@ -191,7 +191,7 @@ void QgsPgNewConnection::testConnection()
                               tr( "Connection to %1 was successful" ).arg( txtDatabase->text() ) );
 
     // free pg connection resources
-    conn->disconnect();
+    conn->unref();
   }
   else
   {

--- a/src/providers/postgres/qgspostgresconnpool.h
+++ b/src/providers/postgres/qgspostgresconnpool.h
@@ -33,7 +33,7 @@ inline void qgsConnectionPool_ConnectionCreate( QString connInfo, QgsPostgresCon
 
 inline void qgsConnectionPool_ConnectionDestroy( QgsPostgresConn* c )
 {
-  c->disconnect(); // will delete itself
+  c->unref(); // will delete itself
 }
 
 

--- a/src/providers/postgres/qgspostgresfeatureiterator.h
+++ b/src/providers/postgres/qgspostgresfeatureiterator.h
@@ -23,12 +23,14 @@
 
 class QgsPostgresProvider;
 class QgsPostgresResult;
+class QgsPostgresTransaction;
 
 
 class QgsPostgresFeatureSource : public QgsAbstractFeatureSource
 {
   public:
     QgsPostgresFeatureSource( const QgsPostgresProvider* p );
+    ~QgsPostgresFeatureSource();
 
     virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest& request ) override;
 
@@ -52,6 +54,13 @@ class QgsPostgresFeatureSource : public QgsAbstractFeatureSource
 
     QSharedPointer<QgsPostgresSharedData> mShared;
 
+    /* The transaction connection (if any) gets refed/unrefed when creating/
+     * destroying the QgsPostfresFeatureSource, to ensure that the transaction
+     * connection remains valid during the life time of the feature source
+     * even if the QgsPostgresTransaction object which initially created the
+     * connection has since been destroyed. */
+    QgsPostgresConn* mTransactionConnection;
+
     friend class QgsPostgresFeatureIterator;
 };
 
@@ -61,7 +70,7 @@ class QgsPostgresConn;
 class QgsPostgresFeatureIterator : public QgsAbstractFeatureIteratorFromSource<QgsPostgresFeatureSource>
 {
   public:
-    QgsPostgresFeatureIterator( QgsPostgresFeatureSource* source, bool ownSource, const QgsFeatureRequest& request );
+    QgsPostgresFeatureIterator( QgsPostgresFeatureSource* source, bool ownSource, const QgsFeatureRequest &request );
 
     ~QgsPostgresFeatureIterator();
 
@@ -102,6 +111,8 @@ class QgsPostgresFeatureIterator : public QgsAbstractFeatureIteratorFromSource<Q
 
     //! Set to true, if geometry is in the requested columns
     bool mFetchGeometry;
+
+    bool mIsTransactionConnection;
 
     static const int sFeatureQueueSize;
 

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -31,9 +31,11 @@
 #include "qgsproviderextentcalcevent.h"
 #include "qgspostgresprovider.h"
 #include "qgspostgresconn.h"
+#include "qgspostgresconnpool.h"
 #include "qgspgsourceselect.h"
 #include "qgspostgresdataitems.h"
 #include "qgspostgresfeatureiterator.h"
+#include "qgspostgrestransaction.h"
 #include "qgslogger.h"
 
 const QString POSTGRES_KEY = "postgres";
@@ -53,6 +55,7 @@ QgsPostgresProvider::QgsPostgresProvider( QString const & uri )
     , mSelectAtIdDisabled( false )
     , mConnectionRO( 0 )
     , mConnectionRW( 0 )
+    , mTransaction( 0 )
 {
 
   QgsDebugMsg( QString( "URI: %1 " ).arg( uri ) );
@@ -227,18 +230,46 @@ QgsAbstractFeatureSource* QgsPostgresProvider::featureSource() const
   return new QgsPostgresFeatureSource( this );
 }
 
+QgsPostgresConn* QgsPostgresProvider::connectionRO() const
+{
+  return mTransaction ? mTransaction->connection() : mConnectionRO;
+}
+
+QgsPostgresConn* QgsPostgresProvider::connectionRW()
+{
+  if ( mTransaction )
+  {
+    return mTransaction->connection();
+  }
+  else if ( !mConnectionRW )
+  {
+    mConnectionRW = QgsPostgresConn::connectDb( mUri.connectionInfo(), false );
+  }
+  return mConnectionRW;
+}
+
+QgsTransaction* QgsPostgresProvider::transaction() const
+{
+  return static_cast<QgsTransaction*>( mTransaction );
+}
+
+void QgsPostgresProvider::setTransaction( QgsTransaction* transaction )
+{
+  // static_cast since layers cannot be added to a transaction of a non-matching provider
+  mTransaction = static_cast<QgsPostgresTransaction*>( transaction );
+}
 
 void QgsPostgresProvider::disconnectDb()
 {
   if ( mConnectionRO )
   {
-    mConnectionRO->disconnect();
+    mConnectionRO->unref();
     mConnectionRO = 0;
   }
 
   if ( mConnectionRW )
   {
-    mConnectionRW->disconnect();
+    mConnectionRW->unref();
     mConnectionRW = 0;
   }
 }
@@ -336,7 +367,8 @@ QgsFeatureIterator QgsPostgresProvider::getFeatures( const QgsFeatureRequest& re
     return QgsFeatureIterator();
   }
 
-  return QgsFeatureIterator( new QgsPostgresFeatureIterator( static_cast<QgsPostgresFeatureSource*>( featureSource() ), false, request ) );
+  QgsPostgresFeatureSource* featureSrc = static_cast<QgsPostgresFeatureSource*>( featureSource() );
+  return QgsFeatureIterator( new QgsPostgresFeatureIterator( featureSrc, false, request ) );
 }
 
 
@@ -371,7 +403,7 @@ QString QgsPostgresProvider::pkParamWhereClause( int offset, const char *alias )
         int idx = mPrimaryKeyAttrs[i];
         const QgsField &fld = field( idx );
 
-        whereClause += delim + QString( "%3%1=$%2" ).arg( mConnectionRO->fieldExpression( fld ) ).arg( offset++ ).arg( aliased );
+        whereClause += delim + QString( "%3%1=$%2" ).arg( connectionRO()->fieldExpression( fld ) ).arg( offset++ ).arg( aliased );
         delim = " AND ";
       }
     }
@@ -443,7 +475,7 @@ void QgsPostgresProvider::appendPkParams( QgsFeatureId featureId, QStringList &p
 
 QString QgsPostgresProvider::whereClause( QgsFeatureId featureId ) const
 {
-  return QgsPostgresUtils::whereClause( featureId, mAttributeFields, mConnectionRO, mPrimaryKeyType, mPrimaryKeyAttrs, mShared );
+  return QgsPostgresUtils::whereClause( featureId, mAttributeFields, connectionRO(), mPrimaryKeyType, mPrimaryKeyAttrs, mShared );
 }
 
 
@@ -529,7 +561,7 @@ QString QgsPostgresProvider::filterWhereClause() const
   if ( !mRequestedSrid.isEmpty() && ( mRequestedSrid != mDetectedSrid || mRequestedSrid.toInt() == 0 ) )
   {
     where += delim + QString( "%1(%2%3)=%4" )
-             .arg( mConnectionRO->majorVersion() < 2 ? "srid" : "st_srid" )
+             .arg( connectionRO()->majorVersion() < 2 ? "srid" : "st_srid" )
              .arg( quotedIdentifier( mGeometryColumn ) )
              .arg( mSpatialColType == sctGeography ? "::geography" : "" )
              .arg( mRequestedSrid );
@@ -607,12 +639,12 @@ bool QgsPostgresProvider::loadFields()
 
     // Get the relation oid for use in later queries
     QString sql = QString( "SELECT regclass(%1)::oid" ).arg( quotedValue( mQuery ) );
-    QgsPostgresResult tresult = mConnectionRO->PQexec( sql );
+    QgsPostgresResult tresult = connectionRO()->PQexec( sql );
     QString tableoid = tresult.PQgetvalue( 0, 0 );
 
     // Get the table description
     sql = QString( "SELECT description FROM pg_description WHERE objoid=%1 AND objsubid=0" ).arg( tableoid );
-    tresult = mConnectionRO->PQexec( sql );
+    tresult = connectionRO()->PQexec( sql );
     if ( tresult.PQntuples() > 0 )
       mDataComment = tresult.PQgetvalue( 0, 0 );
   }
@@ -621,7 +653,7 @@ bool QgsPostgresProvider::loadFields()
   // field name, type, length, and precision (if numeric)
   QString sql = QString( "SELECT * FROM %1 LIMIT 0" ).arg( mQuery );
 
-  QgsPostgresResult result = mConnectionRO->PQexec( sql );
+  QgsPostgresResult result = connectionRO()->PQexec( sql );
 
   QSet<QString> fields;
 
@@ -646,7 +678,7 @@ bool QgsPostgresProvider::loadFields()
     //      "oid = (SELECT Distinct typelem FROM pg_type WHERE "  //needs DISTINCT to guard against 2 or more rows on int2
     //      "typelem = " + typOid + " AND typlen = -1)";
 
-    QgsPostgresResult oidResult = mConnectionRO->PQexec( sql );
+    QgsPostgresResult oidResult = connectionRO()->PQexec( sql );
     QString fieldTypeName = oidResult.PQgetvalue( 0, 0 );
     QString fieldTType = oidResult.PQgetvalue( 0, 1 );
     QString fieldElem = oidResult.PQgetvalue( 0, 2 );
@@ -658,14 +690,14 @@ bool QgsPostgresProvider::loadFields()
       sql = QString( "SELECT pg_catalog.format_type(atttypid,atttypmod) FROM pg_attribute WHERE attrelid=%1 AND attnum=%2" )
             .arg( tableoid ).arg( quotedValue( attnum ) );
 
-      QgsPostgresResult tresult = mConnectionRO->PQexec( sql );
+      QgsPostgresResult tresult = connectionRO()->PQexec( sql );
       if ( tresult.PQntuples() > 0 )
         formattedFieldType = tresult.PQgetvalue( 0, 0 );
 
       sql = QString( "SELECT description FROM pg_description WHERE objoid=%1 AND objsubid=%2" )
             .arg( tableoid ).arg( attnum );
 
-      tresult = mConnectionRO->PQexec( sql );
+      tresult = connectionRO()->PQexec( sql );
       if ( tresult.PQntuples() > 0 )
         fieldComment = tresult.PQgetvalue( 0, 0 );
     }
@@ -845,7 +877,7 @@ bool QgsPostgresProvider::hasSufficientPermsAndCapabilities()
   {
     // Check that we can read from the table (i.e., we have select permission).
     QString sql = QString( "SELECT * FROM %1 LIMIT 1" ).arg( mQuery );
-    QgsPostgresResult testAccess = mConnectionRO->PQexec( sql );
+    QgsPostgresResult testAccess = connectionRO()->PQexec( sql );
     if ( testAccess.PQresultStatus() != PGRES_TUPLES_OK )
     {
       QgsMessageLog::logMessage( tr( "Unable to access the %1 relation.\nThe error message from the database was:\n%2.\nSQL: %3" )
@@ -857,9 +889,9 @@ bool QgsPostgresProvider::hasSufficientPermsAndCapabilities()
 
     bool inRecovery = false;
 
-    if ( mConnectionRO->pgVersion() >= 90000 )
+    if ( connectionRO()->pgVersion() >= 90000 )
     {
-      testAccess = mConnectionRO->PQexec( "SELECT pg_is_in_recovery()" );
+      testAccess = connectionRO()->PQexec( "SELECT pg_is_in_recovery()" );
       if ( testAccess.PQresultStatus() != PGRES_TUPLES_OK || testAccess.PQgetvalue( 0, 0 ) == "t" )
       {
         QgsMessageLog::logMessage( tr( "PostgreSQL is still in recovery after a database crash\n(or you are connected to a (read-only) slave).\nWrite accesses will be denied." ), tr( "PostGIS" ) );
@@ -876,7 +908,7 @@ bool QgsPostgresProvider::hasSufficientPermsAndCapabilities()
 
     if ( !inRecovery )
     {
-      if ( mConnectionRO->pgVersion() >= 80400 )
+      if ( connectionRO()->pgVersion() >= 80400 )
       {
         sql = QString( "SELECT "
                        "has_table_privilege(%1,'DELETE'),"
@@ -903,7 +935,7 @@ bool QgsPostgresProvider::hasSufficientPermsAndCapabilities()
               .arg( quotedValue( mQuery ) );
       }
 
-      testAccess = mConnectionRO->PQexec( sql );
+      testAccess = connectionRO()->PQexec( sql );
       if ( testAccess.PQresultStatus() != PGRES_TUPLES_OK )
       {
         QgsMessageLog::logMessage( tr( "Unable to determine table access privileges for the %1 relation.\nThe error message from the database was:\n%2.\nSQL: %3" )
@@ -948,7 +980,7 @@ bool QgsPostgresProvider::hasSufficientPermsAndCapabilities()
                      "relname=%1 AND nspname=%2" )
             .arg( quotedValue( mTableName ) )
             .arg( quotedValue( mSchemaName ) );
-      testAccess = mConnectionRO->PQexec( sql );
+      testAccess = connectionRO()->PQexec( sql );
       if ( testAccess.PQresultStatus() == PGRES_TUPLES_OK && testAccess.PQntuples() == 1 )
       {
         mEnabledCapabilities |= QgsVectorDataProvider::AddAttributes | QgsVectorDataProvider::DeleteAttributes;
@@ -984,7 +1016,7 @@ bool QgsPostgresProvider::hasSufficientPermsAndCapabilities()
 
     QString sql = QString( "SELECT * FROM %1 LIMIT 1" ).arg( mQuery );
 
-    testAccess = mConnectionRO->PQexec( sql );
+    testAccess = connectionRO()->PQexec( sql );
     if ( testAccess.PQresultStatus() != PGRES_TUPLES_OK )
     {
       QgsMessageLog::logMessage( tr( "Unable to execute the query.\nThe error message from the database was:\n%1.\nSQL: %2" )
@@ -1002,6 +1034,8 @@ bool QgsPostgresProvider::hasSufficientPermsAndCapabilities()
   // supports geometry simplification on provider side
   mEnabledCapabilities |= ( QgsVectorDataProvider::SimplifyGeometries | QgsVectorDataProvider::SimplifyGeometriesWithTopologicalValidation );
 
+  //supports transactions
+  mEnabledCapabilities |= QgsVectorDataProvider::TransactionSupport;
   return true;
 }
 
@@ -1022,7 +1056,7 @@ bool QgsPostgresProvider::determinePrimaryKey()
     sql = QString( "SELECT indexrelid FROM pg_index WHERE indrelid=%1::regclass AND (indisprimary OR indisunique) ORDER BY CASE WHEN indisprimary THEN 1 ELSE 2 END LIMIT 1" ).arg( quotedValue( mQuery ) );
     QgsDebugMsg( QString( "Retrieving first primary or unique index: %1" ).arg( sql ) );
 
-    QgsPostgresResult res = mConnectionRO->PQexec( sql );
+    QgsPostgresResult res = connectionRO()->PQexec( sql );
     QgsDebugMsg( QString( "Got %1 rows." ).arg( res.PQntuples() ) );
 
     QStringList log;
@@ -1038,7 +1072,7 @@ bool QgsPostgresProvider::determinePrimaryKey()
       // the primary key.
 
       sql = QString( "SELECT relkind FROM pg_class WHERE oid=regclass(%1)::oid" ).arg( quotedValue( mQuery ) );
-      res = mConnectionRO->PQexec( sql );
+      res = connectionRO()->PQexec( sql );
       QString type = res.PQgetvalue( 0, 0 );
 
       if ( type == "r" ) // the relation is a table
@@ -1050,7 +1084,7 @@ bool QgsPostgresProvider::determinePrimaryKey()
         // If there is an oid on the table, use that instead,
         sql = QString( "SELECT attname FROM pg_attribute WHERE attname='oid' AND attrelid=regclass(%1)" ).arg( quotedValue( mQuery ) );
 
-        res = mConnectionRO->PQexec( sql );
+        res = connectionRO()->PQexec( sql );
         if ( res.PQntuples() == 1 )
         {
           // Could warn the user here that performance will suffer if
@@ -1062,7 +1096,7 @@ bool QgsPostgresProvider::determinePrimaryKey()
         {
           sql = QString( "SELECT attname FROM pg_attribute WHERE attname='ctid' AND attrelid=regclass(%1)" ).arg( quotedValue( mQuery ) );
 
-          res = mConnectionRO->PQexec( sql );
+          res = connectionRO()->PQexec( sql );
           if ( res.PQntuples() == 1 )
           {
             mPrimaryKeyType = pktTid;
@@ -1117,7 +1151,7 @@ bool QgsPostgresProvider::determinePrimaryKey()
       sql = QString( "SELECT attname FROM pg_index,pg_attribute WHERE indexrelid=%1 AND indrelid=attrelid AND pg_attribute.attnum=any(pg_index.indkey)" ).arg( indrelid );
 
       QgsDebugMsg( "Retrieving key columns: " + sql );
-      res = mConnectionRO->PQexec( sql );
+      res = connectionRO()->PQexec( sql );
       QgsDebugMsg( QString( "Got %1 rows." ).arg( res.PQntuples() ) );
 
       bool isInt = true;
@@ -1179,7 +1213,7 @@ bool QgsPostgresProvider::uniqueData( QString query, QString colName )
                 .arg( mQuery )
                 .arg( filterWhereClause() );
 
-  QgsPostgresResult unique = mConnectionRO->PQexec( sql );
+  QgsPostgresResult unique = connectionRO()->PQexec( sql );
 
   if ( unique.PQresultStatus() != PGRES_TUPLES_OK )
   {
@@ -1206,7 +1240,7 @@ QVariant QgsPostgresProvider::minimumValue( int index )
       sql += QString( " WHERE %1" ).arg( mSqlWhereClause );
     }
 
-    QgsPostgresResult rmin = mConnectionRO->PQexec( sql );
+    QgsPostgresResult rmin = connectionRO()->PQexec( sql );
     return convertValue( fld.type(), rmin.PQgetvalue( 0, 0 ) );
   }
   catch ( PGFieldNotFound )
@@ -1241,7 +1275,7 @@ void QgsPostgresProvider::uniqueValues( int index, QList<QVariant> &uniqueValues
       sql += QString( " LIMIT %1" ).arg( limit );
     }
 
-    QgsPostgresResult res = mConnectionRO->PQexec( sql );
+    QgsPostgresResult res = connectionRO()->PQexec( sql );
     if ( res.PQresultStatus() == PGRES_TUPLES_OK )
     {
       for ( int i = 0; i < res.PQntuples(); i++ )
@@ -1266,7 +1300,7 @@ void QgsPostgresProvider::enumValues( int index, QStringList& enumList )
 
   //is type an enum?
   QString typeSql = QString( "SELECT typtype FROM pg_type WHERE typname=%1" ).arg( quotedValue( typeName ) );
-  QgsPostgresResult typeRes = mConnectionRO->PQexec( typeSql );
+  QgsPostgresResult typeRes = connectionRO()->PQexec( typeSql );
   if ( typeRes.PQresultStatus() != PGRES_TUPLES_OK || typeRes.PQntuples() < 1 )
   {
     return;
@@ -1299,7 +1333,7 @@ bool QgsPostgresProvider::parseEnumRange( QStringList& enumValues, const QString
   QString enumRangeSql = QString( "SELECT enumlabel FROM pg_catalog.pg_enum WHERE enumtypid=(SELECT atttypid::regclass FROM pg_attribute WHERE attrelid=%1::regclass AND attname=%2)" )
                          .arg( quotedValue( mQuery ) )
                          .arg( quotedValue( attributeName ) );
-  QgsPostgresResult enumRangeRes = mConnectionRO->PQexec( enumRangeSql );
+  QgsPostgresResult enumRangeRes = connectionRO()->PQexec( enumRangeSql );
 
   if ( enumRangeRes.PQresultStatus() != PGRES_TUPLES_OK )
     return false;
@@ -1318,12 +1352,12 @@ bool QgsPostgresProvider::parseDomainCheckConstraint( QStringList& enumValues, c
 
   //is it a domain type with a check constraint?
   QString domainSql = QString( "SELECT domain_name FROM information_schema.columns WHERE table_name=%1 AND column_name=%2" ).arg( quotedValue( mTableName ) ).arg( quotedValue( attributeName ) );
-  QgsPostgresResult domainResult = mConnectionRO->PQexec( domainSql );
+  QgsPostgresResult domainResult = connectionRO()->PQexec( domainSql );
   if ( domainResult.PQresultStatus() == PGRES_TUPLES_OK && domainResult.PQntuples() > 0 )
   {
     //a domain type
     QString domainCheckDefinitionSql = QString( "SELECT consrc FROM pg_constraint WHERE conname=(SELECT constraint_name FROM information_schema.domain_constraints WHERE domain_name=%1)" ).arg( quotedValue( domainResult.PQgetvalue( 0, 0 ) ) );
-    QgsPostgresResult domainCheckRes = mConnectionRO->PQexec( domainCheckDefinitionSql );
+    QgsPostgresResult domainCheckRes = connectionRO()->PQexec( domainCheckDefinitionSql );
     if ( domainCheckRes.PQresultStatus() == PGRES_TUPLES_OK && domainCheckRes.PQntuples() > 0 )
     {
       QString checkDefinition = domainCheckRes.PQgetvalue( 0, 0 );
@@ -1379,7 +1413,7 @@ QVariant QgsPostgresProvider::maximumValue( int index )
       sql += QString( " WHERE %1" ).arg( mSqlWhereClause );
     }
 
-    QgsPostgresResult rmax = mConnectionRO->PQexec( sql );
+    QgsPostgresResult rmax = connectionRO()->PQexec( sql );
     return convertValue( fld.type(), rmax.PQgetvalue( 0, 0 ) );
   }
   catch ( PGFieldNotFound )
@@ -1414,7 +1448,7 @@ QVariant QgsPostgresProvider::defaultValue( QString fieldName, QString tableName
 
   QVariant defaultValue( QString::null );
 
-  QgsPostgresResult result = mConnectionRO->PQexec( sql );
+  QgsPostgresResult result = connectionRO()->PQexec( sql );
 
   if ( result.PQntuples() == 1 )
     defaultValue = result.PQgetvalue( 0, 0 );
@@ -1441,7 +1475,7 @@ QString QgsPostgresProvider::paramValue( QString fieldValue, const QString &defa
 
   if ( fieldValue == defaultValue && !defaultValue.isNull() )
   {
-    QgsPostgresResult result = mConnectionRW->PQexec( QString( "SELECT %1" ).arg( defaultValue ) );
+    QgsPostgresResult result = connectionRO()->PQexec( QString( "SELECT %1" ).arg( defaultValue ) );
     if ( result.PQresultStatus() != PGRES_TUPLES_OK )
       throw PGException( result );
 
@@ -1462,7 +1496,7 @@ bool QgsPostgresProvider::getTopoLayerInfo()
                 .arg( quotedValue( mSchemaName ) )
                 .arg( quotedValue( mTableName ) )
                 .arg( quotedValue( mGeometryColumn ) );
-  QgsPostgresResult result = mConnectionRO->PQexec( sql );
+  QgsPostgresResult result = connectionRO()->PQexec( sql );
   if ( result.PQresultStatus() != PGRES_TUPLES_OK )
   {
     throw PGException( result ); // we should probably not do this
@@ -1495,7 +1529,7 @@ void QgsPostgresProvider::dropOrphanedTopoGeoms()
 
   QgsDebugMsg( "TopoGeom orphans cleanup query: " + sql );
 
-  mConnectionRW->PQexecNR( sql );
+  connectionRW()->PQexecNR( sql );
 }
 
 QString QgsPostgresProvider::geomParam( int offset ) const
@@ -1537,13 +1571,13 @@ QString QgsPostgresProvider::geomParam( int offset ) const
 
   if ( forceMulti )
   {
-    geometry += mConnectionRO->majorVersion() < 2 ? "multi(" : "st_multi(";
+    geometry += connectionRO()->majorVersion() < 2 ? "multi(" : "st_multi(";
   }
 
   geometry += QString( "%1($%2%3,%4)" )
-              .arg( mConnectionRO->majorVersion() < 2 ? "geomfromwkb" : "st_geomfromwkb" )
+              .arg( connectionRO()->majorVersion() < 2 ? "geomfromwkb" : "st_geomfromwkb" )
               .arg( offset )
-              .arg( mConnectionRW->useWkbHex() ? "" : "::bytea" )
+              .arg( connectionRO()->useWkbHex() ? "" : "::bytea" )
               .arg( mRequestedSrid.isEmpty() ? mDetectedSrid : mRequestedSrid );
 
   if ( forceMulti )
@@ -1569,14 +1603,18 @@ bool QgsPostgresProvider::addFeatures( QgsFeatureList &flist )
   if ( mIsQuery )
     return false;
 
-  if ( !connectRW() )
+  QgsPostgresConn* conn = connectionRW();
+  if ( !conn )
+  {
     return false;
+  }
+  conn->lock();
 
   bool returnvalue = true;
 
   try
   {
-    mConnectionRW->PQexecNR( "BEGIN" );
+    conn->begin();
 
     // Prepare the INSERT statement
     QString insert = QString( "INSERT INTO %1(" ).arg( mQuery );
@@ -1660,7 +1698,7 @@ bool QgsPostgresProvider::addFeatures( QgsFeatureList &flist )
         {
           values += QString( "%1%2(%3)" )
                     .arg( delim )
-                    .arg( mConnectionRO->majorVersion() < 2 ? "geomfromewkt" : "st_geomfromewkt" )
+                    .arg( connectionRO()->majorVersion() < 2 ? "geomfromewkt" : "st_geomfromewkt" )
                     .arg( quotedValue( v.toString() ) );
         }
         else if ( fieldTypeName == "geography" )
@@ -1681,7 +1719,7 @@ bool QgsPostgresProvider::addFeatures( QgsFeatureList &flist )
         {
           values += QString( "%1%2($%3)" )
                     .arg( delim )
-                    .arg( mConnectionRO->majorVersion() < 2 ? "geomfromewkt" : "st_geomfromewkt" )
+                    .arg( connectionRO()->majorVersion() < 2 ? "geomfromewkt" : "st_geomfromewkt" )
                     .arg( defaultValues.size() + offset );
         }
         else if ( fieldTypeName == "geography" )
@@ -1706,7 +1744,7 @@ bool QgsPostgresProvider::addFeatures( QgsFeatureList &flist )
     insert += values + ")";
 
     QgsDebugMsg( QString( "prepare addfeatures: %1" ).arg( insert ) );
-    QgsPostgresResult stmt = mConnectionRW->PQprepare( "addfeatures", insert, fieldId.size() + offset - 1, NULL );
+    QgsPostgresResult stmt = conn->PQprepare( "addfeatures", insert, fieldId.size() + offset - 1, NULL );
     if ( stmt.PQresultStatus() != PGRES_COMMAND_OK )
       throw PGException( stmt );
 
@@ -1745,7 +1783,7 @@ bool QgsPostgresProvider::addFeatures( QgsFeatureList &flist )
         params << v;
       }
 
-      QgsPostgresResult result = mConnectionRW->PQexecPrepared( "addfeatures", params );
+      QgsPostgresResult result = conn->PQexecPrepared( "addfeatures", params );
       if ( result.PQresultStatus() != PGRES_COMMAND_OK )
         throw PGException( result );
 
@@ -1782,19 +1820,20 @@ bool QgsPostgresProvider::addFeatures( QgsFeatureList &flist )
       }
     }
 
-    mConnectionRW->PQexecNR( "DEALLOCATE addfeatures" );
-    mConnectionRW->PQexecNR( "COMMIT" );
+    conn->PQexecNR( "DEALLOCATE addfeatures" );
+    conn->commit();
 
     mShared->addFeaturesCounted( flist.size() );
   }
   catch ( PGException &e )
   {
     pushError( tr( "PostGIS error while adding features: %1" ).arg( e.errorMessage() ) );
-    mConnectionRW->PQexecNR( "ROLLBACK" );
-    mConnectionRW->PQexecNR( "DEALLOCATE addfeatures" );
+    conn->rollback();
+    conn->PQexecNR( "DEALLOCATE addfeatures" );
     returnvalue = false;
   }
 
+  conn->unlock();
   return returnvalue;
 }
 
@@ -1805,12 +1844,16 @@ bool QgsPostgresProvider::deleteFeatures( const QgsFeatureIds & id )
   if ( mIsQuery )
     return false;
 
-  if ( !connectRW() )
+  QgsPostgresConn* conn = connectionRW();
+  if ( !conn )
+  {
     return false;
+  }
+  conn->lock();
 
   try
   {
-    mConnectionRW->PQexecNR( "BEGIN" );
+    conn->begin();
 
     for ( QgsFeatureIds::const_iterator it = id.begin(); it != id.end(); ++it )
     {
@@ -1819,14 +1862,14 @@ bool QgsPostgresProvider::deleteFeatures( const QgsFeatureIds & id )
       QgsDebugMsg( "delete sql: " + sql );
 
       //send DELETE statement and do error handling
-      QgsPostgresResult result = mConnectionRW->PQexec( sql );
+      QgsPostgresResult result = conn->PQexec( sql );
       if ( result.PQresultStatus() != PGRES_COMMAND_OK && result.PQresultStatus() != PGRES_TUPLES_OK )
         throw PGException( result );
 
       mShared->removeFid( *it );
     }
 
-    mConnectionRW->PQexecNR( "COMMIT" );
+    conn->commit();
 
     if ( mSpatialColType == sctTopoGeometry )
     {
@@ -1844,10 +1887,11 @@ bool QgsPostgresProvider::deleteFeatures( const QgsFeatureIds & id )
   catch ( PGException &e )
   {
     pushError( tr( "PostGIS error while deleting features: %1" ).arg( e.errorMessage() ) );
-    mConnectionRW->PQexecNR( "ROLLBACK" );
+    conn->rollback();
     returnvalue = false;
   }
 
+  conn->unlock();
   return returnvalue;
 }
 
@@ -1858,12 +1902,16 @@ bool QgsPostgresProvider::addAttributes( const QList<QgsField> &attributes )
   if ( mIsQuery )
     return false;
 
-  if ( !connectRW() )
+  QgsPostgresConn* conn = connectionRW();
+  if ( !conn )
+  {
     return false;
+  }
+  conn->lock();
 
   try
   {
-    mConnectionRW->PQexecNR( "BEGIN" );
+    conn->begin();
 
     for ( QList<QgsField>::const_iterator iter = attributes.begin(); iter != attributes.end(); ++iter )
     {
@@ -1886,7 +1934,7 @@ bool QgsPostgresProvider::addAttributes( const QList<QgsField> &attributes )
       QgsDebugMsg( sql );
 
       //send sql statement and do error handling
-      QgsPostgresResult result = mConnectionRW->PQexec( sql );
+      QgsPostgresResult result = conn->PQexec( sql );
       if ( result.PQresultStatus() != PGRES_COMMAND_OK )
         throw PGException( result );
 
@@ -1896,22 +1944,23 @@ bool QgsPostgresProvider::addAttributes( const QList<QgsField> &attributes )
               .arg( mQuery )
               .arg( quotedIdentifier( iter->name() ) )
               .arg( quotedValue( iter->comment() ) );
-        result = mConnectionRW->PQexec( sql );
+        result = conn->PQexec( sql );
         if ( result.PQresultStatus() != PGRES_COMMAND_OK )
           throw PGException( result );
       }
     }
 
-    mConnectionRW->PQexecNR( "COMMIT" );
+    conn->commit();
   }
   catch ( PGException &e )
   {
     pushError( tr( "PostGIS error while adding attributes: %1" ).arg( e.errorMessage() ) );
-    mConnectionRW->PQexecNR( "ROLLBACK" );
+    conn->rollback();
     returnvalue = false;
   }
 
   loadFields();
+  conn->unlock();
   return returnvalue;
 }
 
@@ -1922,12 +1971,16 @@ bool QgsPostgresProvider::deleteAttributes( const QgsAttributeIds& ids )
   if ( mIsQuery )
     return false;
 
-  if ( !connectRW() )
+  QgsPostgresConn* conn = connectionRW();
+  if ( !conn )
+  {
     return false;
+  }
+  conn->lock();
 
   try
   {
-    mConnectionRW->PQexecNR( "BEGIN" );
+    conn->begin();
 
     QList<int> idsList = ids.values();
     qSort( idsList.begin(), idsList.end(), qGreater<int>() );
@@ -1944,7 +1997,7 @@ bool QgsPostgresProvider::deleteAttributes( const QgsAttributeIds& ids )
                     .arg( quotedIdentifier( column ) );
 
       //send sql statement and do error handling
-      QgsPostgresResult result = mConnectionRW->PQexec( sql );
+      QgsPostgresResult result = conn->PQexec( sql );
       if ( result.PQresultStatus() != PGRES_COMMAND_OK )
         throw PGException( result );
 
@@ -1952,16 +2005,17 @@ bool QgsPostgresProvider::deleteAttributes( const QgsAttributeIds& ids )
       mAttributeFields.remove( index );
     }
 
-    mConnectionRW->PQexecNR( "COMMIT" );
+    conn->commit();
   }
   catch ( PGException &e )
   {
     pushError( tr( "PostGIS error while deleting attributes: %1" ).arg( e.errorMessage() ) );
-    mConnectionRW->PQexecNR( "ROLLBACK" );
+    conn->rollback();
     returnvalue = false;
   }
 
   loadFields();
+  conn->unlock();
   return returnvalue;
 }
 
@@ -1972,12 +2026,16 @@ bool QgsPostgresProvider::changeAttributeValues( const QgsChangedAttributesMap &
   if ( mIsQuery )
     return false;
 
-  if ( !connectRW() )
+  QgsPostgresConn* conn = connectionRW();
+  if ( !conn )
+  {
     return false;
+  }
+  conn->lock();
 
   try
   {
-    mConnectionRW->PQexecNR( "BEGIN" );
+    conn->begin();
 
     // cycle through the features
     for ( QgsChangedAttributesMap::const_iterator iter = attr_map.begin(); iter != attr_map.end(); ++iter )
@@ -2009,7 +2067,7 @@ bool QgsPostgresProvider::changeAttributeValues( const QgsChangedAttributesMap &
           if ( fld.typeName() == "geometry" )
           {
             sql += QString( "%1(%2)" )
-                   .arg( mConnectionRO->majorVersion() < 2 ? "geomfromewkt" : "st_geomfromewkt" )
+                   .arg( connectionRO()->majorVersion() < 2 ? "geomfromewkt" : "st_geomfromewkt" )
                    .arg( quotedValue( siter->toString() ) );
           }
           else if ( fld.typeName() == "geography" )
@@ -2030,7 +2088,7 @@ bool QgsPostgresProvider::changeAttributeValues( const QgsChangedAttributesMap &
 
       sql += QString( " WHERE %1" ).arg( whereClause( fid ) );
 
-      QgsPostgresResult result = mConnectionRW->PQexec( sql );
+      QgsPostgresResult result = conn->PQexec( sql );
       if ( result.PQresultStatus() != PGRES_COMMAND_OK && result.PQresultStatus() != PGRES_TUPLES_OK )
         throw PGException( result );
 
@@ -2054,15 +2112,16 @@ bool QgsPostgresProvider::changeAttributeValues( const QgsChangedAttributesMap &
       }
     }
 
-    mConnectionRW->PQexecNR( "COMMIT" );
+    conn->commit();
   }
   catch ( PGException &e )
   {
     pushError( tr( "PostGIS error while changing attributes: %1" ).arg( e.errorMessage() ) );
-    mConnectionRW->PQexecNR( "ROLLBACK" );
+    conn->rollback();
     returnvalue = false;
   }
 
+  conn->unlock();
   return returnvalue;
 }
 
@@ -2078,7 +2137,7 @@ void QgsPostgresProvider::appendGeomParam( QgsGeometry *geom, QStringList &param
   const unsigned char *buf = geom->asWkb();
   for ( uint i = 0; i < geom->wkbSize(); ++i )
   {
-    if ( mConnectionRW->useWkbHex() )
+    if ( connectionRO()->useWkbHex() )
       param += QString( "%1" ).arg(( int ) buf[i], 2, 16, QChar( '0' ) );
     else
       param += QString( "\\%1" ).arg(( int ) buf[i], 3, 8, QChar( '0' ) );
@@ -2093,15 +2152,19 @@ bool QgsPostgresProvider::changeGeometryValues( QgsGeometryMap & geometry_map )
   if ( mIsQuery || mGeometryColumn.isNull() )
     return false;
 
-  if ( !connectRW() )
+  QgsPostgresConn* conn = connectionRW();
+  if ( !conn )
+  {
     return false;
+  }
+  conn->lock();
 
   bool returnvalue = true;
 
   try
   {
     // Start the PostGIS transaction
-    mConnectionRW->PQexecNR( "BEGIN" );
+    conn->begin();
 
     QString update;
     QgsPostgresResult result;
@@ -2124,7 +2187,7 @@ bool QgsPostgresProvider::changeGeometryValues( QgsGeometryMap & geometry_map )
 
       QgsDebugMsg( "getting old topogeometry id: " + getid );
 
-      result = mConnectionRO->PQprepare( "getid", getid, 1, NULL );
+      result = connectionRO()->PQprepare( "getid", getid, 1, NULL );
       if ( result.PQresultStatus() != PGRES_COMMAND_OK )
       {
         QgsDebugMsg( QString( "Exception thrown due to PQprepare of this query returning != PGRES_COMMAND_OK (%1 != expected %2): %3" )
@@ -2139,7 +2202,7 @@ bool QgsPostgresProvider::changeGeometryValues( QgsGeometryMap & geometry_map )
                         .arg( quotedIdentifier( mGeometryColumn ) )
                         .arg( pkParamWhereClause( 2 ) );
       QgsDebugMsg( "TopoGeom swap: " + replace );
-      result = mConnectionRW->PQprepare( "replacetopogeom", replace, 2, NULL );
+      result = conn->PQprepare( "replacetopogeom", replace, 2, NULL );
       if ( result.PQresultStatus() != PGRES_COMMAND_OK )
       {
         QgsDebugMsg( QString( "Exception thrown due to PQprepare of this query returning != PGRES_COMMAND_OK (%1 != expected %2): %3" )
@@ -2159,7 +2222,7 @@ bool QgsPostgresProvider::changeGeometryValues( QgsGeometryMap & geometry_map )
 
     QgsDebugMsg( "updating: " + update );
 
-    result = mConnectionRW->PQprepare( "updatefeatures", update, 2, NULL );
+    result = conn->PQprepare( "updatefeatures", update, 2, NULL );
     if ( result.PQresultStatus() != PGRES_COMMAND_OK && result.PQresultStatus() != PGRES_TUPLES_OK )
     {
       QgsDebugMsg( QString( "Exception thrown due to PQprepare of this query returning != PGRES_COMMAND_OK (%1 != expected %2): %3" )
@@ -2181,7 +2244,7 @@ bool QgsPostgresProvider::changeGeometryValues( QgsGeometryMap & geometry_map )
       {
         QStringList params;
         appendPkParams( iter.key(), params );
-        result = mConnectionRO->PQexecPrepared( "getid", params );
+        result = connectionRO()->PQexecPrepared( "getid", params );
         if ( result.PQresultStatus() != PGRES_TUPLES_OK )
         {
           QgsDebugMsg( QString( "Exception thrown due to PQexecPrepared of 'getid' returning != PGRES_TUPLES_OK (%1 != expected %2)" )
@@ -2197,7 +2260,7 @@ bool QgsPostgresProvider::changeGeometryValues( QgsGeometryMap & geometry_map )
       appendGeomParam( &*iter, params );
       appendPkParams( iter.key(), params );
 
-      result = mConnectionRW->PQexecPrepared( "updatefeatures", params );
+      result = conn->PQexecPrepared( "updatefeatures", params );
       if ( result.PQresultStatus() != PGRES_COMMAND_OK && result.PQresultStatus() != PGRES_TUPLES_OK )
         throw PGException( result );
 
@@ -2213,7 +2276,7 @@ bool QgsPostgresProvider::changeGeometryValues( QgsGeometryMap & geometry_map )
                           .arg( quotedIdentifier( mTopoLayerInfo.topologyName ) )
                           .arg( mTopoLayerInfo.layerId )
                           .arg( old_tg_id );
-        result = mConnectionRW->PQexec( replace );
+        result = conn->PQexec( replace );
         if ( result.PQresultStatus() != PGRES_COMMAND_OK )
         {
           QgsDebugMsg( QString( "Exception thrown due to PQexec of this query returning != PGRES_COMMAND_OK (%1 != expected %2): %3" )
@@ -2228,7 +2291,7 @@ bool QgsPostgresProvider::changeGeometryValues( QgsGeometryMap & geometry_map )
                   .arg( mTopoLayerInfo.layerId )
                   .arg( new_tg_id );
         QgsDebugMsg( "relation swap: " + replace );
-        result = mConnectionRW->PQexec( replace );
+        result = conn->PQexec( replace );
         if ( result.PQresultStatus() != PGRES_COMMAND_OK )
         {
           QgsDebugMsg( QString( "Exception thrown due to PQexec of this query returning != PGRES_COMMAND_OK (%1 != expected %2): %3" )
@@ -2239,18 +2302,18 @@ bool QgsPostgresProvider::changeGeometryValues( QgsGeometryMap & geometry_map )
 
     } // for each feature
 
-    mConnectionRW->PQexecNR( "DEALLOCATE updatefeatures" );
+    conn->PQexecNR( "DEALLOCATE updatefeatures" );
     if ( mSpatialColType == sctTopoGeometry )
     {
-      mConnectionRO->PQexecNR( "DEALLOCATE getid" );
-      mConnectionRW->PQexecNR( "DEALLOCATE replacetopogeom" );
+      connectionRO()->PQexecNR( "DEALLOCATE getid" );
+      conn->PQexecNR( "DEALLOCATE replacetopogeom" );
     }
-    mConnectionRW->PQexecNR( "COMMIT" );
+    conn->commit();
   }
   catch ( PGException &e )
   {
     pushError( tr( "PostGIS error while changing geometry values: %1" ).arg( e.errorMessage() ) );
-    mConnectionRW->PQexecNR( "ROLLBACK" );
+    conn->rollback();
     mConnectionRW->PQexecNR( "DEALLOCATE updatefeatures" );
     if ( mSpatialColType == sctTopoGeometry )
     {
@@ -2259,6 +2322,8 @@ bool QgsPostgresProvider::changeGeometryValues( QgsGeometryMap & geometry_map )
     }
     returnvalue = false;
   }
+
+  conn->unlock();
 
   QgsDebugMsg( "exiting." );
 
@@ -2293,7 +2358,7 @@ bool QgsPostgresProvider::setSubsetString( QString theSQL, bool updateFeatureCou
 
   sql += " LIMIT 0";
 
-  QgsPostgresResult res = mConnectionRO->PQexec( sql );
+  QgsPostgresResult res = connectionRO()->PQexec( sql );
   if ( res.PQresultStatus() != PGRES_TUPLES_OK )
   {
     pushError( res.PQresultErrorMessage() );
@@ -2349,7 +2414,7 @@ long QgsPostgresProvider::featureCount() const
     sql = QString( "SELECT count(*) FROM %1%2" ).arg( mQuery ).arg( filterWhereClause() );
   }
 
-  QgsPostgresResult result = mConnectionRO->PQexec( sql );
+  QgsPostgresResult result = connectionRO()->PQexec( sql );
 
   QgsDebugMsg( "number of features as text: " + result.PQgetvalue( 0, 0 ) );
 
@@ -2383,20 +2448,20 @@ QgsRectangle QgsPostgresProvider::extent()
             .arg( quotedValue( mSchemaName ) )
             .arg( quotedValue( mTableName ) )
             .arg( quotedValue( mGeometryColumn ) );
-      result = mConnectionRO->PQexec( sql );
+      result = connectionRO()->PQexec( sql );
       if ( result.PQresultStatus() == PGRES_TUPLES_OK && result.PQntuples() == 1 )
       {
         if ( result.PQgetvalue( 0, 0 ).toInt() > 0 )
         {
           sql = QString( "SELECT reltuples::int FROM pg_catalog.pg_class WHERE oid=regclass(%1)::oid" ).arg( quotedValue( mQuery ) );
-          result = mConnectionRO->PQexec( sql );
+          result = connectionRO()->PQexec( sql );
           if ( result.PQresultStatus() == PGRES_TUPLES_OK
                && result.PQntuples() == 1
                && result.PQgetvalue( 0, 0 ).toLong() > 0 )
           {
             sql = QString( "SELECT %1(%2,%3,%4)" )
-                  .arg( mConnectionRO->majorVersion() < 2 ? "estimated_extent" :
-                        ( mConnectionRO->majorVersion() == 2 && mConnectionRO->minorVersion() < 1 ? "st_estimated_extent" : "st_estimatedextent" ) )
+                  .arg( connectionRO()->majorVersion() < 2 ? "estimated_extent" :
+                        ( connectionRO()->majorVersion() == 2 && connectionRO()->minorVersion() < 1 ? "st_estimated_extent" : "st_estimatedextent" ) )
                   .arg( quotedValue( mSchemaName ) )
                   .arg( quotedValue( mTableName ) )
                   .arg( quotedValue( mGeometryColumn ) );
@@ -2431,14 +2496,14 @@ QgsRectangle QgsPostgresProvider::extent()
     if ( ext.isEmpty() )
     {
       sql = QString( "SELECT %1(%2) FROM %3%4" )
-            .arg( mConnectionRO->majorVersion() < 2 ? "extent" : "st_extent" )
+            .arg( connectionRO()->majorVersion() < 2 ? "extent" : "st_extent" )
             .arg( quotedIdentifier( mGeometryColumn ) )
             .arg( mQuery )
             .arg( filterWhereClause() );
 
-      result = mConnectionRO->PQexec( sql );
+      result = connectionRO()->PQexec( sql );
       if ( result.PQresultStatus() != PGRES_TUPLES_OK )
-        mConnectionRO->PQexecNR( "ROLLBACK" );
+        connectionRO()->PQexecNR( "ROLLBACK" );
       else if ( result.PQntuples() == 1 && !result.PQgetisnull( 0, 0 ) )
         ext = result.PQgetvalue( 0, 0 );
     }
@@ -2497,17 +2562,17 @@ bool QgsPostgresProvider::getGeometryDetails()
 
     QgsDebugMsg( QString( "Getting geometry column: %1" ).arg( sql ) );
 
-    QgsPostgresResult result = mConnectionRO->PQexec( sql );
+    QgsPostgresResult result = connectionRO()->PQexec( sql );
     if ( PGRES_TUPLES_OK == result.PQresultStatus() )
     {
       Oid tableoid = result.PQftable( 0 );
       int column = result.PQftablecol( 0 );
 
-      result = mConnectionRO->PQexec( sql );
+      result = connectionRO()->PQexec( sql );
       if ( tableoid > 0 && PGRES_TUPLES_OK == result.PQresultStatus() )
       {
         sql = QString( "SELECT pg_namespace.nspname,pg_class.relname FROM pg_class,pg_namespace WHERE pg_class.relnamespace=pg_namespace.oid AND pg_class.oid=%1" ).arg( tableoid );
-        result = mConnectionRO->PQexec( sql );
+        result = connectionRO()->PQexec( sql );
 
         if ( PGRES_TUPLES_OK == result.PQresultStatus() && 1 == result.PQntuples() )
         {
@@ -2515,7 +2580,7 @@ bool QgsPostgresProvider::getGeometryDetails()
           tableName = result.PQgetvalue( 0, 1 );
 
           sql = QString( "SELECT a.attname, t.typname FROM pg_attribute a, pg_type t WHERE a.attrelid=%1 AND a.attnum=%2 AND a.atttypid = t.oid" ).arg( tableoid ).arg( column );
-          result = mConnectionRO->PQexec( sql );
+          result = connectionRO()->PQexec( sql );
           if ( PGRES_TUPLES_OK == result.PQresultStatus() && 1 == result.PQntuples() )
           {
             geomCol = result.PQgetvalue( 0, 0 );
@@ -2560,7 +2625,7 @@ bool QgsPostgresProvider::getGeometryDetails()
           .arg( quotedValue( schemaName ) );
 
     QgsDebugMsg( QString( "Getting geometry column: %1" ).arg( sql ) );
-    result = mConnectionRO->PQexec( sql );
+    result = connectionRO()->PQexec( sql );
     QgsDebugMsg( QString( "Geometry column query returned %1 rows" ).arg( result.PQntuples() ) );
 
     if ( result.PQntuples() == 1 )
@@ -2573,7 +2638,7 @@ bool QgsPostgresProvider::getGeometryDetails()
     }
     else
     {
-      mConnectionRO->PQexecNR( "COMMIT" );
+      connectionRO()->PQexecNR( "COMMIT" );
     }
 
     if ( detectedType.isEmpty() )
@@ -2585,7 +2650,7 @@ bool QgsPostgresProvider::getGeometryDetails()
             .arg( quotedValue( schemaName ) );
 
       QgsDebugMsg( QString( "Getting geography column: %1" ).arg( sql ) );
-      result = mConnectionRO->PQexec( sql, false );
+      result = connectionRO()->PQexec( sql, false );
       QgsDebugMsg( QString( "Geography column query returned %1" ).arg( result.PQntuples() ) );
 
       if ( result.PQntuples() == 1 )
@@ -2596,11 +2661,11 @@ bool QgsPostgresProvider::getGeometryDetails()
       }
       else
       {
-        mConnectionRO->PQexecNR( "COMMIT" );
+        connectionRO()->PQexecNR( "COMMIT" );
       }
     }
 
-    if ( detectedType.isEmpty() && mConnectionRO->hasTopology() )
+    if ( detectedType.isEmpty() && connectionRO()->hasTopology() )
     {
       // check topology.layer
       sql = QString( "SELECT CASE "
@@ -2616,7 +2681,7 @@ bool QgsPostgresProvider::getGeometryDetails()
             .arg( quotedValue( schemaName ) );
 
       QgsDebugMsg( QString( "Getting TopoGeometry column: %1" ).arg( sql ) );
-      result = mConnectionRO->PQexec( sql, false );
+      result = connectionRO()->PQexec( sql, false );
       QgsDebugMsg( QString( "TopoGeometry column query returned %1" ).arg( result.PQntuples() ) );
 
       if ( result.PQntuples() == 1 )
@@ -2627,7 +2692,7 @@ bool QgsPostgresProvider::getGeometryDetails()
       }
       else
       {
-        mConnectionRO->PQexecNR( "COMMIT" );
+        connectionRO()->PQexecNR( "COMMIT" );
       }
     }
 
@@ -2642,7 +2707,7 @@ bool QgsPostgresProvider::getGeometryDetails()
             .arg( quotedValue( geomCol ) )
             .arg( quotedValue( schemaName ) );
       QgsDebugMsg( QString( "Getting column datatype: %1" ).arg( sql ) );
-      result = mConnectionRO->PQexec( sql, false );
+      result = connectionRO()->PQexec( sql, false );
       QgsDebugMsg( QString( "Column datatype query returned %1" ).arg( result.PQntuples() ) );
       if ( result.PQntuples() == 1 )
       {
@@ -2656,7 +2721,7 @@ bool QgsPostgresProvider::getGeometryDetails()
       }
       else
       {
-        mConnectionRO->PQexecNR( "COMMIT" );
+        connectionRO()->PQexecNR( "COMMIT" );
       }
     }
   }
@@ -2695,7 +2760,7 @@ bool QgsPostgresProvider::getGeometryDetails()
       delim = " AND ";
     }
 
-    mConnectionRO->retrieveLayerTypes( layerProperty, mUseEstimatedMetadata );
+    connectionRO()->retrieveLayerTypes( layerProperty, mUseEstimatedMetadata );
 
     mSpatialColType = layerProperty.geometryColType;
 
@@ -3014,10 +3079,10 @@ QgsVectorLayerImport::ImportError QgsPostgresProvider::createEmptyLayer(
                       .arg( e.errorMessage() );
 
     conn->PQexecNR( "ROLLBACK" );
-    conn->disconnect();
+    conn->unref();
     return QgsVectorLayerImport::ErrCreateLayer;
   }
-  conn->disconnect();
+  conn->unref();
 
   QgsDebugMsg( QString( "layer %1 created" ).arg( schemaTableName ) );
 
@@ -3110,7 +3175,7 @@ QgsCoordinateReferenceSystem QgsPostgresProvider::crs()
   srs.createFromSrid( srid );
   if ( !srs.isValid() )
   {
-    QgsPostgresResult result = mConnectionRO->PQexec( QString( "SELECT proj4text FROM spatial_ref_sys WHERE srid=%1" ).arg( srid ) );
+    QgsPostgresResult result = connectionRO()->PQexec( QString( "SELECT proj4text FROM spatial_ref_sys WHERE srid=%1" ).arg( srid ) );
     if ( result.PQresultStatus() == PGRES_TUPLES_OK )
       srs.createFromProj4( result.PQgetvalue( 0, 0 ) );
   }
@@ -3143,17 +3208,17 @@ QString  QgsPostgresProvider::description() const
   QString pgVersion( tr( "PostgreSQL version: unknown" ) );
   QString postgisVersion( tr( "unknown" ) );
 
-  if ( mConnectionRO )
+  if ( connectionRO() )
   {
     QgsPostgresResult result;
 
-    result = mConnectionRO->PQexec( "SELECT version()" );
+    result = connectionRO()->PQexec( "SELECT version()" );
     if ( result.PQresultStatus() == PGRES_TUPLES_OK )
     {
       pgVersion = result.PQgetvalue( 0, 0 );
     }
 
-    result = mConnectionRO->PQexec( "SELECT postgis_version()" );
+    result = connectionRO()->PQexec( "SELECT postgis_version()" );
     if ( result.PQresultStatus() == PGRES_TUPLES_OK )
     {
       postgisVersion = result.PQgetvalue( 0, 0 );
@@ -3268,7 +3333,7 @@ QGISEXTERN bool deleteLayer( const QString& uri, QString& errCause )
     errCause = QObject::tr( "Unable to delete layer %1: \n%2" )
                .arg( schemaTableName )
                .arg( result.PQresultErrorMessage() );
-    conn->disconnect();
+    conn->unref();
     return false;
   }
 
@@ -3296,11 +3361,11 @@ QGISEXTERN bool deleteLayer( const QString& uri, QString& errCause )
     errCause = QObject::tr( "Unable to delete layer %1: \n%2" )
                .arg( schemaTableName )
                .arg( result.PQresultErrorMessage() );
-    conn->disconnect();
+    conn->unref();
     return false;
   }
 
-  conn->disconnect();
+  conn->unref();
   return true;
 }
 
@@ -3338,7 +3403,7 @@ QGISEXTERN bool saveStyle( const QString& uri, const QString& qmlStyle, const QS
     if ( res.PQresultStatus() != PGRES_COMMAND_OK )
     {
       errCause = QObject::tr( "Unable to save layer style. It's not possible to create the destination table on the database. Maybe this is due to table permissions (user=%1). Please contact your database admin" ).arg( dsUri.username() );
-      conn->disconnect();
+      conn->unref();
       return false;
     }
   }
@@ -3397,7 +3462,7 @@ QGISEXTERN bool saveStyle( const QString& uri, const QString& qmlStyle, const QS
                                 QMessageBox::Yes | QMessageBox::No ) == QMessageBox::No )
     {
       errCause = QObject::tr( "Operation aborted. No changes were made in the database" );
-      conn->disconnect();
+      conn->unref();
       return false;
     }
 
@@ -3446,7 +3511,7 @@ QGISEXTERN bool saveStyle( const QString& uri, const QString& qmlStyle, const QS
   if ( !saved )
     errCause = QObject::tr( "Unable to save layer style. It's not possible to insert a new record into the style table. Maybe this is due to table permissions (user=%1). Please contact your database administrator." ).arg( dsUri.username() );
 
-  conn->disconnect();
+  conn->unref();
 
   return saved;
 }
@@ -3479,7 +3544,7 @@ QGISEXTERN QString loadStyle( const QString& uri, QString& errCause )
   QgsPostgresResult result = conn->PQexec( selectQmlQuery, false );
 
   QString style = result.PQntuples() == 1 ? result.PQgetvalue( 0, 0 ) : "";
-  conn->disconnect();
+  conn->unref();
   return style;
 }
 
@@ -3511,7 +3576,7 @@ QGISEXTERN int listStyles( const QString &uri, QStringList &ids, QStringList &na
   {
     QgsMessageLog::logMessage( QObject::tr( "Error executing query: %1" ).arg( selectRelatedQuery ) );
     errCause = QObject::tr( "Error executing the select query for related styles. The query was logged" );
-    conn->disconnect();
+    conn->unref();
     return -1;
   }
 
@@ -3537,7 +3602,7 @@ QGISEXTERN int listStyles( const QString &uri, QStringList &ids, QStringList &na
   {
     QgsMessageLog::logMessage( QObject::tr( "Error executing query: %1" ).arg( selectOthersQuery ) );
     errCause = QObject::tr( "Error executing the select query for unrelated styles. The query was logged" );
-    conn->disconnect();
+    conn->unref();
     return -1;
   }
 
@@ -3548,7 +3613,7 @@ QGISEXTERN int listStyles( const QString &uri, QStringList &ids, QStringList &na
     descriptions.append( result.PQgetvalue( i, 2 ) );
   }
 
-  conn->disconnect();
+  conn->unref();
 
   return numberOfRelatedStyles;
 }
@@ -3580,9 +3645,14 @@ QGISEXTERN QString getStyleById( const QString& uri, QString styleId, QString& e
     errCause = QObject::tr( "Error executing the select query. The query was logged" );
   }
 
-  conn->disconnect();
+  conn->unref();
 
   return style;
+}
+
+QGISEXTERN QgsTransaction* createTransaction( const QString& connString )
+{
+  return new QgsPostgresTransaction( connString );
 }
 
 

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -30,6 +30,7 @@ class QgsGeometry;
 
 class QgsPostgresFeatureIterator;
 class QgsPostgresSharedData;
+class QgsPostgresTransaction;
 
 #include "qgsdatasourceuri.h"
 
@@ -275,6 +276,11 @@ class QgsPostgresProvider : public QgsVectorDataProvider
     */
     QString description() const override;
 
+    /**
+     * Returns the transaction this data provider is included in, if any.
+     */
+    virtual QgsTransaction* transaction() const;
+
   signals:
     /**
      *   This is emitted whenever the worker thread has fully calculated the
@@ -464,16 +470,8 @@ class QgsPostgresProvider : public QgsVectorDataProvider
     QgsPostgresConn *mConnectionRO; //! read-only database connection (initially)
     QgsPostgresConn *mConnectionRW; //! read-write database connection (on update)
 
-    //! establish read-write connection
-    bool connectRW()
-    {
-      if ( mConnectionRW )
-        return mConnectionRW;
-
-      mConnectionRW = QgsPostgresConn::connectDb( mUri.connectionInfo(), false );
-
-      return mConnectionRW;
-    }
+    QgsPostgresConn* connectionRO() const;
+    QgsPostgresConn* connectionRW();
 
     void disconnectDb();
 
@@ -481,6 +479,10 @@ class QgsPostgresProvider : public QgsVectorDataProvider
     static QString quotedValue( QVariant value ) { return QgsPostgresConn::quotedValue( value ); }
 
     friend class QgsPostgresFeatureSource;
+
+    QgsPostgresTransaction* mTransaction;
+
+    void setTransaction( QgsTransaction* transaction );
 };
 
 

--- a/src/providers/postgres/qgspostgrestransaction.cpp
+++ b/src/providers/postgres/qgspostgrestransaction.cpp
@@ -1,0 +1,78 @@
+/***************************************************************************
+    qgspostgrestransaction.cpp  -  Transaction support for PostgreSQL/PostGIS layers
+                             -------------------
+    begin                : Jan 8, 2015
+    copyright            : (C) 2015 by Sandro Mani
+    email                : manisandro at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgspostgrestransaction.h"
+#include "qgspostgresconn.h"
+#include "qgslogger.h"
+#include "qgis.h"
+
+QgsPostgresTransaction::QgsPostgresTransaction( const QString &connString )
+    : QgsTransaction( connString ), mConn( 0 )
+{
+
+}
+
+bool QgsPostgresTransaction::beginTransaction( QString &error , int statementTimeout )
+{
+  mConn = QgsPostgresConn::connectDb( mConnString, false /*readonly*/, false /*shared*/, true /*transaction*/ );
+
+  return executeSql( QString( "SET statement_timeout = %1" ).arg( statementTimeout * 1000 ), error )
+         && executeSql( "BEGIN TRANSACTION", error );
+}
+
+bool QgsPostgresTransaction::commitTransaction( QString &error )
+{
+  if ( executeSql( "COMMIT TRANSACTION", error ) )
+  {
+    mConn->unref();
+    mConn = 0;
+    return true;
+  }
+  return false;
+}
+
+bool QgsPostgresTransaction::rollbackTransaction( QString &error )
+{
+  if ( executeSql( "ROLLBACK TRANSACTION", error ) )
+  {
+    mConn->unref();
+    mConn = 0;
+    return true;
+  }
+  return false;
+}
+
+bool QgsPostgresTransaction::executeSql( const QString &sql, QString &errorMsg )
+{
+  if ( !mConn )
+  {
+    return false;
+  }
+
+  QgsDebugMsg( QString( "Transaction sql: %1" ).arg( sql ) );
+  mConn->lock();
+  QgsPostgresResult r = mConn->PQexec( sql, true );
+  mConn->unlock();
+  if ( r.PQresultStatus() != PGRES_COMMAND_OK )
+  {
+    errorMsg = QString( "Status %1 (%2)" ).arg( r.PQresultStatus() ).arg( r.PQresultErrorMessage() );
+    QgsDebugMsg( errorMsg );
+    return false;
+  }
+  QgsDebugMsg( QString( "Status %1 (OK)" ).arg( r.PQresultStatus() ) );
+  return true;
+}

--- a/src/providers/postgres/qgspostgrestransaction.h
+++ b/src/providers/postgres/qgspostgrestransaction.h
@@ -1,0 +1,41 @@
+/***************************************************************************
+    qgspostgrestransaction.h  -  Transaction support for PostgreSQL/PostGIS layers
+                             -------------------
+    begin                : Jan 8, 2015
+    copyright            : (C) 2015 by Sandro Mani
+    email                : manisandro at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSPOSTGRESTRANSACTION_H
+#define QGSPOSTGRESTRANSACTION_H
+
+#include "qgstransaction.h"
+
+class QgsPostgresConn;
+
+class QgsPostgresTransaction : public QgsTransaction
+{
+  public:
+    QgsPostgresTransaction( const QString& connString );
+    bool executeSql( const QString& sql, QString& error );
+    QgsPostgresConn* connection() const { return mConn; }
+
+  private:
+    QgsPostgresConn* mConn;
+
+    bool beginTransaction( QString& error, int statementTimeout );
+    bool commitTransaction( QString& error );
+    bool rollbackTransaction( QString& error );
+
+};
+
+#endif // QGSPOSTGRESTRANSACTION_H


### PR DESCRIPTION
This is a re-worked patch of pull #1367. From #1367:

This pull request adds a transaction mode to a group of layers. Within these layers, edits are bypassing the QGIS edit buffer and are directly written into a database transaction. The edits are visible for layers outside the group or for external tools once the transaction is commited.

Further details in ticket #1367. 

Compared to the initial version in #1367, this patch does the following differently:
- `QgsTransaction` is an abstract class, each provider supporting transactions provides an appropriate concrete class.
- The `QgsPostgresTransaction` class holds the connection, the connection pool is not touched anymore.
- A "pass-through" edit buffer is introduced to forward layer changes directly to the data provider, avoiding lots of fragile if-else code in the `QgsVectorLayer`
- The postgres provider consistently uses the transaction connection, if in transaction mode, for all queries.

A small plugin to test this is here https://github.com/manisandro/qgis-transaction-test-plugin
