### PR TITLE
Offline Editing: Preserve joins and legend structure

### DIFF
--- a/python/gui/qgsmessagebar.sip
+++ b/python/gui/qgsmessagebar.sip
@@ -68,6 +68,34 @@ class QgsMessageBar: QFrame
      */
     bool clearWidgets();
 
+    /**
+     * Pushes a warning with default timeout to the message bar
+     * @param message The message to be displayed
+     * @note added in 2.8
+     */
+    void pushSuccess( const QString& title, const QString& message );
+
+    /**
+     * Pushes a warning with default timeout to the message bar
+     * @param message The message to be displayed
+     * @note added in 2.8
+     */
+    void pushInfo( const QString& title, const QString& message );
+
+    /**
+     * Pushes a warning with default timeout to the message bar
+     * @param message The message to be displayed
+     * @note added in 2.8
+     */
+    void pushWarning( const QString& title, const QString& message );
+
+    /**
+     * Pushes a warning with default timeout to the message bar
+     * @param message The message to be displayed
+     * @note added in 2.8
+     */
+    void pushCritical( const QString& title, const QString& message );
+
   protected:
     void mousePressEvent( QMouseEvent * e );
 };

--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -524,7 +524,7 @@ void QgsOfflineEditing::copyVectorLayer( QgsVectorLayer* layer, sqlite3* db, con
       // NOTE: force feature recount for PostGIS layer, else only visible features are counted, before iterating over all features (WORKAROUND)
       layer->setSubsetString( "" );
 
-      QgsFeatureIterator fit = layer->getFeatures();
+      QgsFeatureIterator fit = layer->dataProvider()->getFeatures();
 
       emit progressModeSet( QgsOfflineEditing::CopyFeatures, layer->featureCount() );
       int featureCount = 1;

--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -95,7 +95,24 @@ bool QgsOfflineEditing::convertToOfflineProject( const QString& offlineDataPath,
       {
         QgsMapLayer* layer = QgsMapLayerRegistry::instance()->mapLayer( layerIds.at( i ) );
         QgsVectorLayer* vl = qobject_cast<QgsVectorLayer*>( layer );
-        const QgsVectorJoinList& joins = vl->vectorJoins();
+        QgsVectorJoinList joins = vl->vectorJoins();
+
+        // Layer names will be appended an _offline suffix
+        // Join fields are prefixed with the layer name and we do not want the
+        // field name to change so we stabilize the field name by defining a
+        // custom prefix with the layername without _offline suffix.
+        QgsVectorJoinList::iterator it = joins.begin();
+        while ( it != joins.end() )
+        {
+          if (( *it ).prefix.isNull() )
+          {
+            QgsVectorLayer* vl = qobject_cast<QgsVectorLayer*>( QgsMapLayerRegistry::instance()->mapLayer(( *it ).joinLayerId ) );
+
+            if ( vl )
+              ( *it ).prefix = vl->name() + "_";
+          }
+          ++it;
+        }
         joinInfoBuffer.insert( vl->id(), joins );
       }
 

--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -425,7 +425,7 @@ void QgsOfflineEditing::copyVectorLayer( QgsVectorLayer* layer, sqlite3* db, con
     }
     else
     {
-      showWarning( tr( "Unknown data type %1" ).arg( type ) );
+      showWarning( tr( "%1: Unknown data type %2. Not using type affinity for thie field." ).arg( fields[idx].name() ).arg( QVariant::typeToName( type ) ) );
     }
 
     sql += delim + QString( "'%1' %2" ).arg( fields[idx].name() ).arg( dataType );
@@ -817,7 +817,7 @@ QMap<int, int> QgsOfflineEditing::attributeLookup( QgsVectorLayer* offlineLayer,
 
 void QgsOfflineEditing::showWarning( const QString& message )
 {
-  QMessageBox::warning( NULL, tr( "Offline Editing Plugin" ), message );
+  emit warning( tr( "Offline Editing Plugin" ), message );
 }
 
 sqlite3* QgsOfflineEditing::openLoggingDb()

--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -838,17 +838,15 @@ void QgsOfflineEditing::updateFidLookup( QgsVectorLayer* remoteLayer, sqlite3* d
   }
 }
 
-void QgsOfflineEditing::copySymbology( const QgsVectorLayer* sourceLayer, QgsVectorLayer* targetLayer )
+void QgsOfflineEditing::copySymbology( QgsVectorLayer* sourceLayer, QgsVectorLayer* targetLayer )
 {
   QString error;
   QDomDocument doc;
-  QDomElement node = doc.createElement( "symbology" );
-  doc.appendChild( node );
-  sourceLayer->writeSymbology( node, doc, error );
+  sourceLayer->exportNamedStyle( doc, error );
 
   if ( error.isEmpty() )
   {
-    targetLayer->readSymbology( node, error );
+    targetLayer->importNamedStyle( doc, error );
   }
   if ( !error.isEmpty() )
   {

--- a/src/core/qgsofflineediting.h
+++ b/src/core/qgsofflineediting.h
@@ -96,7 +96,7 @@ class CORE_EXPORT QgsOfflineEditing : public QObject
     void initializeSpatialMetadata( sqlite3 *sqlite_handle );
     bool createSpatialiteDB( const QString& offlineDbPath );
     void createLoggingTables( sqlite3* db );
-    void copyVectorLayer( QgsVectorLayer* layer, sqlite3* db, const QString& offlineDbPath );
+    QgsVectorLayer* copyVectorLayer( QgsVectorLayer* layer, sqlite3* db, const QString& offlineDbPath );
 
     void applyAttributesAdded( QgsVectorLayer* remoteLayer, sqlite3* db, int layerId, int commitNo );
     void applyFeaturesAdded( QgsVectorLayer* offlineLayer, QgsVectorLayer* remoteLayer, sqlite3* db, int layerId );

--- a/src/core/qgsofflineediting.h
+++ b/src/core/qgsofflineediting.h
@@ -85,6 +85,13 @@ class CORE_EXPORT QgsOfflineEditing : public QObject
     /** emit a signal that processing of all layers has finished */
     void progressStopped();
 
+    /**
+     * Emitted when a warning needs to be displayed.
+     *
+     * @param message A descriptive message for the warning
+     */
+    void warning( const QString& title, const QString& message );
+
   private:
     void initializeSpatialMetadata( sqlite3 *sqlite_handle );
     bool createSpatialiteDB( const QString& offlineDbPath );

--- a/src/core/qgsofflineediting.h
+++ b/src/core/qgsofflineediting.h
@@ -104,7 +104,7 @@ class CORE_EXPORT QgsOfflineEditing : public QObject
     void applyAttributeValueChanges( QgsVectorLayer* offlineLayer, QgsVectorLayer* remoteLayer, sqlite3* db, int layerId, int commitNo );
     void applyGeometryChanges( QgsVectorLayer* remoteLayer, sqlite3* db, int layerId, int commitNo );
     void updateFidLookup( QgsVectorLayer* remoteLayer, sqlite3* db, int layerId );
-    void copySymbology( const QgsVectorLayer* sourceLayer, QgsVectorLayer* targetLayer );
+    void copySymbology( QgsVectorLayer* sourceLayer, QgsVectorLayer* targetLayer );
     QMap<int, int> attributeLookup( QgsVectorLayer* offlineLayer, QgsVectorLayer* remoteLayer );
 
     void showWarning( const QString& message );

--- a/src/gui/qgsmessagebar.cpp
+++ b/src/gui/qgsmessagebar.cpp
@@ -206,6 +206,26 @@ bool QgsMessageBar::clearWidgets()
   return !mCurrentItem && mItems.empty();
 }
 
+void QgsMessageBar::pushSuccess( const QString& title, const QString& message )
+{
+  pushMessage( title, message, SUCCESS );
+}
+
+void QgsMessageBar::pushInfo( const QString& title, const QString& message )
+{
+  pushMessage( title, message, INFO );
+}
+
+void QgsMessageBar::pushWarning( const QString& title, const QString& message )
+{
+  pushMessage( title, message, WARNING );
+}
+
+void QgsMessageBar::pushCritical( const QString& title, const QString& message )
+{
+  pushMessage( title, message, CRITICAL );
+}
+
 void QgsMessageBar::showItem( QgsMessageBarItem *item )
 {
   Q_ASSERT( item );

--- a/src/gui/qgsmessagebar.h
+++ b/src/gui/qgsmessagebar.h
@@ -107,6 +107,34 @@ class GUI_EXPORT QgsMessageBar: public QFrame
      */
     bool clearWidgets();
 
+    /**
+     * Pushes a warning with default timeout to the message bar
+     * @param message The message to be displayed
+     * @note added in 2.8
+     */
+    void pushSuccess( const QString& title, const QString& message );
+
+    /**
+     * Pushes a warning with default timeout to the message bar
+     * @param message The message to be displayed
+     * @note added in 2.8
+     */
+    void pushInfo( const QString& title, const QString& message );
+
+    /**
+     * Pushes a warning with default timeout to the message bar
+     * @param message The message to be displayed
+     * @note added in 2.8
+     */
+    void pushWarning( const QString& title, const QString& message );
+
+    /**
+     * Pushes a warning with default timeout to the message bar
+     * @param message The message to be displayed
+     * @note added in 2.8
+     */
+    void pushCritical( const QString& title, const QString& message );
+
   protected:
     void mousePressEvent( QMouseEvent * e ) override;
 

--- a/src/plugins/offline_editing/offline_editing_plugin.cpp
+++ b/src/plugins/offline_editing/offline_editing_plugin.cpp
@@ -24,6 +24,7 @@
 #include <qgisgui.h>
 #include <qgsmaplayerregistry.h>
 #include <qgsproject.h>
+#include <qgsmessagebar.h>
 
 #include <QAction>
 
@@ -81,6 +82,7 @@ void QgsOfflineEditingPlugin::initGui()
   connect( mOfflineEditing, SIGNAL( progressModeSet( QgsOfflineEditing::ProgressMode, int ) ), this, SLOT( setProgressMode( QgsOfflineEditing::ProgressMode, int ) ) );
   connect( mOfflineEditing, SIGNAL( progressUpdated( int ) ), this, SLOT( updateProgress( int ) ) );
   connect( mOfflineEditing, SIGNAL( progressStopped() ), this, SLOT( hideProgress() ) );
+  connect( mOfflineEditing, SIGNAL( warning( QString, QString ) ), mQGisIface->messageBar(), SLOT( pushWarning( QString, QString ) ) );
 
   connect( mQGisIface->mainWindow(), SIGNAL( projectRead() ), this, SLOT( updateActions() ) );
   connect( mQGisIface->mainWindow(), SIGNAL( newProject() ), this, SLOT( updateActions() ) );
@@ -203,7 +205,6 @@ void QgsOfflineEditingPlugin::hideProgress()
 {
   mProgressDialog->hide();
 }
-
 
 /**
  * Required extern functions needed  for every plugin


### PR DESCRIPTION
- Only copy fields from the provider and none from the layer (joins/virtual fields). Now, only provider fields are created in the sqlite db but it is attempted to copy all fields. This caused crashes.
- Make unknown datatype warning more verbose
- Send warnings to message bar instead of message box
- Preserve legend tree structure when converting to offline project
- Preserve join information when converting to offline project
- Preserve scale based visibility

MessageBar: Add some convenience slots to push messages
