### PR TITLE
New features for QGIS fTools plugin

### DIFF
--- a/python/plugins/fTools/tools/doPointsInPolygon.py
+++ b/python/plugins/fTools/tools/doPointsInPolygon.py
@@ -34,6 +34,10 @@ import ftools_utils
 from qgis.core import *
 from ui_frmPointsInPolygon import Ui_Dialog
 
+
+typeInt = 1
+typeDouble = 2
+
 class Dialog(QDialog, Ui_Dialog):
 
     def __init__(self, iface):
@@ -46,6 +50,9 @@ class Dialog(QDialog, Ui_Dialog):
         self.btnClose = self.buttonBox.button( QDialogButtonBox.Close )
 
         QObject.connect(self.toolOut, SIGNAL("clicked()"), self.outFile)
+        QObject.connect(self.inPoint, SIGNAL("currentIndexChanged(QString)"), self.listPointFields)
+        QObject.connect(self.inPoint, SIGNAL("activated(QString)"), self.listPointFields)
+        
         self.progressBar.setValue(0)
         self.populateLayers()
 
@@ -57,6 +64,26 @@ class Dialog(QDialog, Ui_Dialog):
         self.inPoint.clear()
         layers = ftools_utils.getLayerNames([QGis.Point])
         self.inPoint.addItems(layers)
+        
+    def listPointFields(self):
+        if self.inPoint.currentText() == "":
+            pass
+
+        inPnts = ftools_utils.getVectorLayerByName(self.inPoint.currentText())
+        if inPnts:
+            pointFieldList = ftools_utils.getFieldList(inPnts)
+            
+            self.attributeList.clear()
+            for field in pointFieldList:
+                if field.type() == QVariant.Int or field.type() ==QVariant.Double:
+                    if field.type() == QVariant.Int:
+                        global typeInt
+                        item = QListWidgetItem(str(field.name()),  None,  typeInt)
+                    else:
+                        global typeDouble
+                        item = QListWidgetItem(str(field.name()),  None,  typeDouble)
+                    item.setToolTip("Attribute <%s> of type %s"%(field.name(),  field.typeName()))
+                    self.attributeList.addItem(item)
 
     def outFile(self):
         self.outShape.clear()
@@ -84,13 +111,14 @@ class Dialog(QDialog, Ui_Dialog):
 
             polyProvider = inPoly.dataProvider()
             pointProvider = inPnts.dataProvider()
-            if polyProvider.crs() <> pointProvider.crs():
+            if polyProvider.crs() != pointProvider.crs():
                 QMessageBox.warning(self, self.tr("CRS warning!"),
                                     self.tr("Warning: Input layers have non-matching CRS.\nThis may cause unexpected results."))
 
             self.btnOk.setEnabled(False)
 
-            self.workThread = PointsInPolygonThread(inPoly, inPnts, self.lnField.text(), self.outShape.text(), self.encoding)
+            self.workThread = PointsInPolygonThread(self, inPoly, inPnts, self.lnField.text(), self.outShape.text(), self.encoding, 
+                                                    self.attributeList,  self.statisticSelector)
 
             QObject.connect(self.workThread, SIGNAL("rangeChanged(int)"), self.setProgressRange)
             QObject.connect(self.workThread, SIGNAL("updateProgress()"), self.updateProgress)
@@ -141,7 +169,7 @@ class Dialog(QDialog, Ui_Dialog):
         self.btnOk.setEnabled(True)
 
 class PointsInPolygonThread(QThread):
-    def __init__( self, inPoly, inPoints, fieldName, outPath, encoding ):
+    def __init__( self, widget,  inPoly, inPoints, fieldName, outPath, encoding,  attributeList,  statisticSelector):
         QThread.__init__( self, QThread.currentThread() )
         self.mutex = QMutex()
         self.stopMe = 0
@@ -152,6 +180,9 @@ class PointsInPolygonThread(QThread):
         self.fieldName = fieldName
         self.outPath = outPath
         self.encoding = encoding
+        self.attributeList = attributeList
+        self.statistics = statisticSelector.currentText()
+        self.widget = widget
 
     def run(self):
         self.mutex.lock()
@@ -163,11 +194,23 @@ class PointsInPolygonThread(QThread):
         polyProvider = self.layerPoly.dataProvider()
         pointProvider = self.layerPoints.dataProvider()
 
-        fieldList = ftools_utils.getFieldList(self.layerPoly)
+        fieldList = ftools_utils.getFieldList(self.layerPoly)        
         index = polyProvider.fieldNameIndex(unicode(self.fieldName))
         if index == -1:
             index = polyProvider.fields().count()
             fieldList.append( QgsField(unicode(self.fieldName), QVariant.Int, "int", 10, 0, self.tr("point count field")) )
+
+        # Add the selected vector fields to the output polygon vector layer
+        selectedItems = self.attributeList.selectedItems()
+        for item in selectedItems:
+            global typeDouble
+            columnName = unicode(item.text() + "_" + self.statistics)
+            index = polyProvider.fieldNameIndex(unicode(columnName))
+            if index == -1:
+                if item.type() == typeDouble or self.statistics == "mean":
+                    fieldList.append( QgsField(columnName, QVariant.Double, "double", 10, 2,  "Value") )
+                else:
+                    fieldList.append( QgsField(columnName, QVariant.Int, "int", 10, 0,  "Value") )
 
         sRs = polyProvider.crs()
         if QFile(self.outPath).exists():
@@ -189,7 +232,7 @@ class PointsInPolygonThread(QThread):
         while polyFit.nextFeature(polyFeat):
             inGeom = polyFeat.geometry()
             atMap = polyFeat.attributes()
-            outFeat.setAttributes(atMap)
+            outFeat.setAttributes(atMap)   
             outFeat.setGeometry(inGeom)
 
             count = 0
@@ -202,12 +245,17 @@ class PointsInPolygonThread(QThread):
                 hasIntersection = False
 
             if hasIntersection:
+                valueList = {}
+                for item in selectedItems:
+                    valueList[item.text()] = []
                 for p in pointList:
                     pointProvider.getFeatures( QgsFeatureRequest().setFilterFid( p ) ).nextFeature( pntFeat )
                     tmpGeom = QgsGeometry(pntFeat.geometry())
                     if inGeom.intersects(tmpGeom):
                         count += 1
-
+                        for item in selectedItems:
+                            valueList[item.text()].append(pntFeat.attribute(item.text()))
+                            
                     self.mutex.lock()
                     s = self.stopMe
                     self.mutex.unlock()
@@ -215,10 +263,27 @@ class PointsInPolygonThread(QThread):
                         interrupted = True
                         break
 
-            atMap.append(count)
+                atMap.append(count)
+
+                # Compute the statistical values for selected vector attributes
+                for item in selectedItems:
+                    values = valueList[item.text()]
+                    if values and len(values) > 0:
+                        if self.statistics == "sum":
+                            value = reduce(myAdder,  values)
+                        elif self.statistics == "mean":
+                            value = reduce(myAdder,  values) / float(len(values))
+                        elif self.statistics == "min":
+                            values.sort()
+                            value = values[0]
+                        elif self.statistics == "max":
+                            values.sort()
+                            value = values[-1]
+                        atMap.append(value)
+
             outFeat.setAttributes(atMap)
             writer.addFeature(outFeat)
-
+            
             self.emit( SIGNAL( "updateProgress()" ) )
 
             self.mutex.lock()
@@ -241,3 +306,6 @@ class PointsInPolygonThread(QThread):
         self.mutex.unlock()
 
         QThread.wait( self )
+        
+def myAdder(x,y): 
+    return x+y

--- a/python/plugins/fTools/tools/doVectorGrid.py
+++ b/python/plugins/fTools/tools/doVectorGrid.py
@@ -264,7 +264,6 @@ class Dialog(QDialog, Ui_Dialog):
                     pt4 = QgsPoint(x, y - yOffset)
                     pt5 = QgsPoint(x, y)
                     
-                    print self.angle.value()
                     if self.angle.value() != 0.0:
                         self.rotatePoint(pt1)
                         self.rotatePoint(pt2)

--- a/python/plugins/fTools/tools/doVectorGrid.py
+++ b/python/plugins/fTools/tools/doVectorGrid.py
@@ -159,6 +159,9 @@ class Dialog(QDialog, Ui_Dialog):
     def compute( self, bound, xOffset, yOffset, polygon ):
         crs = None
         layer = ftools_utils.getMapLayerByName(unicode(self.inShape.currentText()))
+        
+        if self.angle.value() != 0.0:
+            bound = self.initRotation(bound)
 
         if layer is None:
           crs = self.iface.mapCanvas().mapRenderer().destinationCrs()
@@ -204,6 +207,11 @@ class Dialog(QDialog, Ui_Dialog):
             while y >= bound.yMinimum():
                 pt1 = QgsPoint(bound.xMinimum(), y)
                 pt2 = QgsPoint(bound.xMaximum(), y)
+                
+                if self.angle.value() != 0.0:
+                    self.rotatePoint(pt1)
+                    self.rotatePoint(pt2)
+
                 line = [pt1, pt2]
                 outFeat.setGeometry(outGeom.fromPolyline(line))
                 outFeat.setAttribute(0, idVar)
@@ -224,6 +232,11 @@ class Dialog(QDialog, Ui_Dialog):
             while x <= bound.xMaximum():
                 pt1 = QgsPoint(x, bound.yMaximum())
                 pt2 = QgsPoint(x, bound.yMinimum())
+
+                if self.angle.value() != 0.0:
+                    self.rotatePoint(pt1)
+                    self.rotatePoint(pt2)
+
                 line = [pt1, pt2]
                 outFeat.setGeometry(outGeom.fromPolyline(line))
                 outFeat.setAttribute(0, idVar)
@@ -244,11 +257,21 @@ class Dialog(QDialog, Ui_Dialog):
             while y >= bound.yMinimum():
                 x = bound.xMinimum()
                 while x <= bound.xMaximum():
+                        
                     pt1 = QgsPoint(x, y)
                     pt2 = QgsPoint(x + xOffset, y)
                     pt3 = QgsPoint(x + xOffset, y - yOffset)
                     pt4 = QgsPoint(x, y - yOffset)
                     pt5 = QgsPoint(x, y)
+                    
+                    print self.angle.value()
+                    if self.angle.value() != 0.0:
+                        self.rotatePoint(pt1)
+                        self.rotatePoint(pt2)
+                        self.rotatePoint(pt3)
+                        self.rotatePoint(pt4)
+                        self.rotatePoint(pt5)
+                        
                     polygon = [[pt1, pt2, pt3, pt4, pt5]]
                     outFeat.setGeometry(outGeom.fromPolygon(polygon))
                     outFeat.setAttribute(0, idVar)
@@ -266,6 +289,40 @@ class Dialog(QDialog, Ui_Dialog):
 
         self.progressBar.setValue( 100 )
         del writer
+
+    def initRotation(self,  boundBox):
+        # calculate rotation parameters..interpreted from affine transformation plugin
+
+        anchorPoint = boundBox.center()
+        # We convert the angle from degree to radiant
+        rad = self.angle.value()  * math.pi / 180.0
+
+        a = math.cos( rad );
+        b = -1 * math.sin( rad );
+        c = anchorPoint.x() - math.cos( rad ) * anchorPoint.x() + math.sin( rad ) * anchorPoint.y();
+        d = math.sin( rad );
+        e = math.cos( rad );
+        f = anchorPoint.y() - math.sin( rad ) * anchorPoint.x() - math.cos( rad ) * anchorPoint.y();
+
+        self.rotationParams = (a,b,c,d,e,f)
+        
+        # Rotate the bounding box to set a new extent
+        ptMin = QgsPoint(boundBox.xMinimum(),  boundBox.yMinimum())
+        ptMax = QgsPoint(boundBox.xMaximum(),  boundBox.yMaximum())
+        
+        self.rotatePoint(ptMin)
+        self.rotatePoint(ptMax)
+        
+        newBoundBox = QgsRectangle(ptMin,  ptMax)
+        newBoundBox.combineExtentWith(boundBox)
+        
+        return newBoundBox
+
+    def rotatePoint(self,  point):
+        x = self.rotationParams[0] * point.x() + self.rotationParams[1] * point.y() + self.rotationParams[2];
+        y = self.rotationParams[3] * point.x() + self.rotationParams[4] * point.y() + self.rotationParams[5];
+        point.setX(x)
+        point.setY(y)
 
     def outFile(self):
         self.outShape.clear()

--- a/python/plugins/fTools/tools/frmPointsInPolygon.ui
+++ b/python/plugins/fTools/tools/frmPointsInPolygon.ui
@@ -6,27 +6,20 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
-    <height>351</height>
+    <width>396</width>
+    <height>563</height>
    </rect>
   </property>
   <property name="windowTitle">
    <string>Count Points In Polygons</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0">
-    <layout class="QVBoxLayout" name="verticalLayout_2">
-     <item>
-      <widget class="QLabel" name="label_3">
-       <property name="text">
-        <string>Input polygon vector layer</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="inPolygon"/>
-     </item>
-    </layout>
+   <item row="5" column="0">
+    <widget class="QLabel" name="label_6">
+     <property name="text">
+      <string>Statistical method for atribute aggregation</string>
+     </property>
+    </widget>
    </item>
    <item row="1" column="0">
     <layout class="QVBoxLayout" name="verticalLayout_3">
@@ -42,42 +35,21 @@
      </item>
     </layout>
    </item>
-   <item row="2" column="0">
-    <layout class="QHBoxLayout">
-     <item>
-      <widget class="QLabel" name="label_5">
-       <property name="text">
-        <string>Output count field name</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QLineEdit" name="lnField">
-       <property name="text">
-        <string>PNTCNT</string>
-       </property>
-       <property name="maxLength">
-        <number>10</number>
-       </property>
-      </widget>
-     </item>
-    </layout>
-   </item>
-   <item row="3" column="0">
-    <spacer name="verticalSpacer">
-     <property name="orientation">
-      <enum>Qt::Vertical</enum>
-     </property>
-     <property name="sizeHint" stdset="0">
-      <size>
-       <width>20</width>
-       <height>40</height>
-      </size>
-     </property>
-    </spacer>
-   </item>
-   <item row="4" column="0">
+   <item row="9" column="0">
     <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <spacer name="verticalSpacer">
+       <property name="orientation">
+        <enum>Qt::Vertical</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>20</width>
+         <height>40</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
      <item>
       <widget class="QLabel" name="label_2">
        <property name="text">
@@ -105,17 +77,21 @@
      </item>
     </layout>
    </item>
-   <item row="5" column="0">
+   <item row="3" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Input point vector layer attributes to aggregate</string>
+     </property>
+    </widget>
+   </item>
+   <item row="21" column="0">
     <widget class="QCheckBox" name="addToCanvasCheck">
      <property name="text">
       <string>Add result to canvas</string>
      </property>
-     <property name="checked">
-      <bool>true</bool>
-     </property>
     </widget>
    </item>
-   <item row="6" column="0">
+   <item row="22" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
       <widget class="QProgressBar" name="progressBar">
@@ -141,6 +117,82 @@
       </widget>
      </item>
     </layout>
+   </item>
+   <item row="0" column="0">
+    <layout class="QVBoxLayout" name="verticalLayout_2">
+     <item>
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>Input polygon vector layer</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="inPolygon"/>
+     </item>
+    </layout>
+   </item>
+   <item row="4" column="0">
+    <widget class="QListWidget" name="attributeList">
+     <property name="toolTip">
+      <string>Select columns</string>
+     </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::MultiSelection</enum>
+     </property>
+     <property name="uniformItemSizes">
+      <bool>false</bool>
+     </property>
+     <property name="sortingEnabled">
+      <bool>true</bool>
+     </property>
+    </widget>
+   </item>
+   <item row="6" column="0">
+    <widget class="QComboBox" name="statisticSelector">
+     <item>
+      <property name="text">
+       <string>sum</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>stddev</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>mean</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>max</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>min</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="8" column="0">
+    <widget class="QLineEdit" name="lnField">
+     <property name="text">
+      <string>PNTCNT</string>
+     </property>
+     <property name="maxLength">
+      <number>10</number>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0">
+    <widget class="QLabel" name="label_5">
+     <property name="text">
+      <string>Output count field name</string>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/python/plugins/fTools/tools/frmVectorGrid.ui
+++ b/python/plugins/fTools/tools/frmVectorGrid.ui
@@ -205,7 +205,7 @@
          <number>10</number>
         </property>
         <property name="minimum">
-         <double>0.000100000000000</double>
+         <double>0.000001000000000</double>
         </property>
         <property name="maximum">
          <double>1000000000.000000000000000</double>
@@ -270,7 +270,7 @@
          <number>10</number>
         </property>
         <property name="minimum">
-         <double>0.000100000000000</double>
+         <double>0.000001000000000</double>
         </property>
         <property name="maximum">
          <double>1000000000.000000000000000</double>
@@ -286,7 +286,7 @@
          <string>Output grid as polygons</string>
         </property>
         <property name="checked">
-         <bool>false</bool>
+         <bool>true</bool>
         </property>
        </widget>
       </item>
@@ -296,7 +296,24 @@
          <string>Output grid as lines</string>
         </property>
         <property name="checked">
-         <bool>true</bool>
+         <bool>false</bool>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="3">
+       <widget class="QDoubleSpinBox" name="angle">
+        <property name="minimum">
+         <double>-360.000000000000000</double>
+        </property>
+        <property name="maximum">
+         <double>360.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="3" colspan="2">
+       <widget class="QLabel" name="angleLabel">
+        <property name="text">
+         <string>Rotation angle in degrees</string>
         </property>
        </widget>
       </item>

--- a/python/plugins/fTools/tools/frmVectorGrid.ui
+++ b/python/plugins/fTools/tools/frmVectorGrid.ui
@@ -205,7 +205,7 @@
          <number>10</number>
         </property>
         <property name="minimum">
-         <double>0.000001000000000</double>
+         <double>0.000100000000000</double>
         </property>
         <property name="maximum">
          <double>1000000000.000000000000000</double>
@@ -270,7 +270,7 @@
          <number>10</number>
         </property>
         <property name="minimum">
-         <double>0.000001000000000</double>
+         <double>0.000100000000000</double>
         </property>
         <property name="maximum">
          <double>1000000000.000000000000000</double>
@@ -286,7 +286,7 @@
          <string>Output grid as polygons</string>
         </property>
         <property name="checked">
-         <bool>true</bool>
+         <bool>false</bool>
         </property>
        </widget>
       </item>
@@ -296,7 +296,7 @@
          <string>Output grid as lines</string>
         </property>
         <property name="checked">
-         <bool>false</bool>
+         <bool>true</bool>
         </property>
        </widget>
       </item>
@@ -368,9 +368,6 @@
     <widget class="QCheckBox" name="addToCanvasCheck">
      <property name="text">
       <string>Add result to canvas</string>
-     </property>
-     <property name="checked">
-      <bool>true</bool>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
We have modified the fTools plugin in QGIS and added the following features:

1.) We added the ability to rotate the grid of the vector grid generator tool by a user defined value in degrees
2.) We added the ability to the points in polygon tool to compute vector point layer statistics (sum, mean, min, max, stddev) of numerical attributes and insert them into the resulting vector polygon layer. 
