### PR TITLE
fix different issues in SAGA grid calculator module and add a couple of useful options

### DIFF
--- a/python/plugins/processing/algs/saga/description/2.1.2/GridCalculator.txt
+++ b/python/plugins/processing/algs/saga/description/2.1.2/GridCalculator.txt
@@ -1,7 +1,9 @@
-Raster calculator|Grid calcualtor
+Raster calculator|Grid Calculator
 grid_calculus
 AllowUnmatching
-ParameterRaster|XGRID|Main input layer|False
-ParameterMultipleInput|GRIDS|Additional layers|3|False
+ParameterRaster|GRIDS|Main input layer|False
+ParameterMultipleInput|XGRIDS|Additional layers|3|True
 ParameterString|FORMULA|Formula|
+ParameterBoolean|USE_NODATA|Use NoData|False
+ParameterSelection|TYPE|Output Data Type|[0] bit;[1] unsigned 1 byte integer;[2] signed 1 byte integer;[3] unsigned 2 byte integer;[4] signed 2 byte integer;[5] unsigned 4 byte integer;[6] signed 4 byte integer;[7] 4 byte floating point number;[8] 8 byte floating point number|7
 OutputRaster|RESULT|Result layer

--- a/python/plugins/processing/algs/saga/description/2.1.3/GridCalculator.txt
+++ b/python/plugins/processing/algs/saga/description/2.1.3/GridCalculator.txt
@@ -1,7 +1,9 @@
-Raster calculator|Grid calcualtor
+Raster calculator|Grid Calculator
 grid_calculus
 AllowUnmatching
-ParameterRaster|XGRID|Main input layer|False
-ParameterMultipleInput|GRIDS|Additional layers|3|False
+ParameterRaster|GRIDS|Main input layer|False
+ParameterMultipleInput|XGRIDS|Additional layers|3|True
 ParameterString|FORMULA|Formula|
+ParameterBoolean|USE_NODATA|Use NoData|False
+ParameterSelection|TYPE|Output Data Type|[0] bit;[1] unsigned 1 byte integer;[2] signed 1 byte integer;[3] unsigned 2 byte integer;[4] signed 2 byte integer;[5] unsigned 4 byte integer;[6] signed 4 byte integer;[7] 4 byte floating point number;[8] 8 byte floating point number|7
 OutputRaster|RESULT|Result layer


### PR DESCRIPTION
- typo in the first line
- wrong parameters name
- optional input raster maps defined as mandatory

added the options to
- use the values used as nodata in input maps
- define the data type of output
