### PR TITLE
Call QgsMapTool::deactivate() to uncheck assigned action/button

### DIFF
--- a/src/gui/qgsmaptoolzoom.cpp
+++ b/src/gui/qgsmaptoolzoom.cpp
@@ -129,4 +129,6 @@ void QgsMapToolZoom::deactivate()
 {
   delete mRubberBand;
   mRubberBand = 0;
+
+  QgsMapTool::deactivate();
 }


### PR DESCRIPTION
QgsMapToolZoom overrides deactivate() method and dont uncheck assigned action/button on setting new map tool.
