### PR TITLE
Dont dump projects to console when reading them

### DIFF
--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -876,11 +876,13 @@ bool QgsProject::read()
     emit oldProjectVersionWarning( fileVersion.text() );
     QgsDebugMsg( "Emitting oldProjectVersionWarning(oldVersion)." );
 
-    projectFile.dump();
+    // Commented out by Tim  - overly verbose on console
+    // projectFile.dump();
 
     projectFile.updateRevision( thisVersion );
 
-    projectFile.dump();
+    // Commented out by Tim  - overly verbose on console
+    // projectFile.dump();
 
   }
 


### PR DESCRIPTION
Dumping out the project file may be useful for debuggin in some cases but it creates a lot of noise on stdout. In this PR I am proposing to disable dumps to stdout on project read.
