### PR TITLE
[feature] add expressions at the symbollist level

### DIFF
--- a/python/core/symbology-ng/qgslinesymbollayerv2.sip
+++ b/python/core/symbology-ng/qgslinesymbollayerv2.sip
@@ -54,15 +54,6 @@ class QgsSimpleLineSymbolLayerV2 : QgsLineSymbolLayerV2
     Qt::PenCapStyle penCapStyle() const;
     void setPenCapStyle( Qt::PenCapStyle style );
 
-    double offset() const;
-    void setOffset( double offset );
-
-    void setOffsetUnit( QgsSymbolV2::OutputUnit unit );
-    QgsSymbolV2::OutputUnit offsetUnit() const;
-
-    void setOffsetMapUnitScale( const QgsMapUnitScale& scale);
-    const QgsMapUnitScale& offsetMapUnitScale() const;
-
     bool useCustomDashPattern() const;
     void setUseCustomDashPattern( bool b );
 
@@ -151,9 +142,6 @@ class QgsMarkerLineSymbolLayerV2 : QgsLineSymbolLayerV2
     double interval() const;
     void setInterval( double interval );
 
-    double offset() const;
-    void setOffset( double offset );
-
     Placement placement() const;
     void setPlacement( Placement p );
 
@@ -211,12 +199,6 @@ class QgsMarkerLineSymbolLayerV2 : QgsLineSymbolLayerV2
 
     void setIntervalMapUnitScale( const QgsMapUnitScale& scale );
     const QgsMapUnitScale& intervalMapUnitScale() const;
-
-    void setOffsetUnit( QgsSymbolV2::OutputUnit unit );
-    QgsSymbolV2::OutputUnit offsetUnit() const;
-
-    void setOffsetMapUnitScale( const QgsMapUnitScale& scale );
-    const QgsMapUnitScale& offsetMapUnitScale() const;
 
     void setOutputUnit( QgsSymbolV2::OutputUnit unit );
     QgsSymbolV2::OutputUnit outputUnit() const;

--- a/python/core/symbology-ng/qgssymbollayerv2.sip
+++ b/python/core/symbology-ng/qgssymbollayerv2.sip
@@ -261,11 +261,20 @@ class QgsLineSymbolLayerV2 : QgsSymbolLayerV2
     virtual void setWidth( double width );
     virtual double width() const;
 
+    double offset() const;
+    void setOffset( double offset );
+
     void setWidthUnit( QgsSymbolV2::OutputUnit unit );
     QgsSymbolV2::OutputUnit widthUnit() const;
 
     void setWidthMapUnitScale( const QgsMapUnitScale& scale);
     const QgsMapUnitScale& widthMapUnitScale() const;
+
+    void setOffsetUnit( QgsSymbolV2::OutputUnit unit );
+    QgsSymbolV2::OutputUnit offsetUnit() const;
+
+    void setOffsetMapUnitScale( const QgsMapUnitScale& scale );
+    const QgsMapUnitScale& offsetMapUnitScale() const;
 
     void setOutputUnit( QgsSymbolV2::OutputUnit unit );
     QgsSymbolV2::OutputUnit outputUnit() const;

--- a/src/core/symbology-ng/qgslinesymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgslinesymbollayerv2.cpp
@@ -32,8 +32,6 @@ QgsSimpleLineSymbolLayerV2::QgsSimpleLineSymbolLayerV2( QColor color, double wid
     : mPenStyle( penStyle )
     , mPenJoinStyle( DEFAULT_SIMPLELINE_JOINSTYLE )
     , mPenCapStyle( DEFAULT_SIMPLELINE_CAPSTYLE )
-    , mOffset( 0 )
-    , mOffsetUnit( QgsSymbolV2::MM )
     , mUseCustomDashPattern( false )
     , mCustomDashPatternUnit( QgsSymbolV2::MM )
     , mDrawInsidePolygon( false )
@@ -680,8 +678,6 @@ QgsMarkerLineSymbolLayerV2::QgsMarkerLineSymbolLayerV2( bool rotateMarker, doubl
   mInterval = interval;
   mIntervalUnit = QgsSymbolV2::MM;
   mMarker = NULL;
-  mOffset = 0;
-  mOffsetUnit = QgsSymbolV2::MM;
   mPlacement = Interval;
   mOffsetAlongLine = 0;
   mOffsetAlongLineUnit = QgsSymbolV2::MM;

--- a/src/core/symbology-ng/qgslinesymbollayerv2.h
+++ b/src/core/symbology-ng/qgslinesymbollayerv2.h
@@ -82,15 +82,6 @@ class CORE_EXPORT QgsSimpleLineSymbolLayerV2 : public QgsLineSymbolLayerV2
     Qt::PenCapStyle penCapStyle() const { return mPenCapStyle; }
     void setPenCapStyle( Qt::PenCapStyle style ) { mPenCapStyle = style; }
 
-    double offset() const { return mOffset; }
-    void setOffset( double offset ) { mOffset = offset; }
-
-    void setOffsetUnit( QgsSymbolV2::OutputUnit unit ) { mOffsetUnit = unit; }
-    QgsSymbolV2::OutputUnit offsetUnit() const { return mOffsetUnit; }
-
-    void setOffsetMapUnitScale( const QgsMapUnitScale& scale ) { mOffsetMapUnitScale = scale; }
-    const QgsMapUnitScale& offsetMapUnitScale() const { return mOffsetMapUnitScale; }
-
     bool useCustomDashPattern() const { return mUseCustomDashPattern; }
     void setUseCustomDashPattern( bool b ) { mUseCustomDashPattern = b; }
 
@@ -120,9 +111,6 @@ class CORE_EXPORT QgsSimpleLineSymbolLayerV2 : public QgsLineSymbolLayerV2
     Qt::PenCapStyle mPenCapStyle;
     QPen mPen;
     QPen mSelPen;
-    double mOffset;
-    QgsSymbolV2::OutputUnit mOffsetUnit;
-    QgsMapUnitScale mOffsetMapUnitScale;
 
     //use a custom dash dot pattern instead of the predefined ones
     bool mUseCustomDashPattern;
@@ -203,9 +191,6 @@ class CORE_EXPORT QgsMarkerLineSymbolLayerV2 : public QgsLineSymbolLayerV2
     double interval() const { return mInterval; }
     void setInterval( double interval ) { mInterval = interval; }
 
-    double offset() const { return mOffset; }
-    void setOffset( double offset ) { mOffset = offset; }
-
     Placement placement() const { return mPlacement; }
     void setPlacement( Placement p ) { mPlacement = p; }
 
@@ -264,12 +249,6 @@ class CORE_EXPORT QgsMarkerLineSymbolLayerV2 : public QgsLineSymbolLayerV2
     void setIntervalMapUnitScale( const QgsMapUnitScale& scale ) { mIntervalMapUnitScale = scale; }
     const QgsMapUnitScale& intervalMapUnitScale() const { return mIntervalMapUnitScale; }
 
-    void setOffsetUnit( QgsSymbolV2::OutputUnit unit ) { mOffsetUnit = unit; }
-    QgsSymbolV2::OutputUnit offsetUnit() const { return mOffsetUnit; }
-
-    void setOffsetMapUnitScale( const QgsMapUnitScale& scale ) { mOffsetMapUnitScale = scale; }
-    const QgsMapUnitScale& offsetMapUnitScale() const { return mOffsetMapUnitScale; }
-
     void setOutputUnit( QgsSymbolV2::OutputUnit unit ) override;
     QgsSymbolV2::OutputUnit outputUnit() const override;
 
@@ -288,9 +267,6 @@ class CORE_EXPORT QgsMarkerLineSymbolLayerV2 : public QgsLineSymbolLayerV2
     QgsSymbolV2::OutputUnit mIntervalUnit;
     QgsMapUnitScale mIntervalMapUnitScale;
     QgsMarkerSymbolV2* mMarker;
-    double mOffset;
-    QgsSymbolV2::OutputUnit mOffsetUnit;
-    QgsMapUnitScale mOffsetMapUnitScale;
     Placement mPlacement;
     double mOffsetAlongLine; //distance to offset along line before marker is drawn
     QgsSymbolV2::OutputUnit mOffsetAlongLineUnit; //unit for offset along line

--- a/src/core/symbology-ng/qgssymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgssymbollayerv2.cpp
@@ -218,6 +218,8 @@ QgsMarkerSymbolLayerV2::QgsMarkerSymbolLayerV2( bool locked )
 QgsLineSymbolLayerV2::QgsLineSymbolLayerV2( bool locked )
     : QgsSymbolLayerV2( QgsSymbolV2::Line, locked )
     , mWidthUnit( QgsSymbolV2::MM )
+    , mOffset( 0 )
+    , mOffsetUnit( QgsSymbolV2::MM )
 {
 }
 

--- a/src/core/symbology-ng/qgssymbollayerv2.h
+++ b/src/core/symbology-ng/qgssymbollayerv2.h
@@ -268,11 +268,20 @@ class CORE_EXPORT QgsLineSymbolLayerV2 : public QgsSymbolLayerV2
     virtual void setWidth( double width ) { mWidth = width; }
     virtual double width() const { return mWidth; }
 
+    double offset() const { return mOffset; }
+    void setOffset( double offset ) { mOffset = offset; }
+
     void setWidthUnit( QgsSymbolV2::OutputUnit unit ) { mWidthUnit = unit; }
     QgsSymbolV2::OutputUnit widthUnit() const { return mWidthUnit; }
 
     void setWidthMapUnitScale( const QgsMapUnitScale& scale ) { mWidthMapUnitScale = scale; }
     const QgsMapUnitScale& widthMapUnitScale() const { return mWidthMapUnitScale; }
+
+    void setOffsetUnit( QgsSymbolV2::OutputUnit unit ) { mOffsetUnit = unit; }
+    QgsSymbolV2::OutputUnit offsetUnit() const { return mOffsetUnit; }
+
+    void setOffsetMapUnitScale( const QgsMapUnitScale& scale ) { mOffsetMapUnitScale = scale; }
+    const QgsMapUnitScale& offsetMapUnitScale() const { return mOffsetMapUnitScale; }
 
     void setOutputUnit( QgsSymbolV2::OutputUnit unit ) override;
     QgsSymbolV2::OutputUnit outputUnit() const override;
@@ -290,6 +299,9 @@ class CORE_EXPORT QgsLineSymbolLayerV2 : public QgsSymbolLayerV2
     double mWidth;
     QgsSymbolV2::OutputUnit mWidthUnit;
     QgsMapUnitScale mWidthMapUnitScale;
+    double mOffset;
+    QgsSymbolV2::OutputUnit mOffsetUnit;
+    QgsMapUnitScale mOffsetMapUnitScale;
 };
 
 class CORE_EXPORT QgsFillSymbolLayerV2 : public QgsSymbolLayerV2

--- a/src/core/symbology-ng/qgssymbolv2.cpp
+++ b/src/core/symbology-ng/qgssymbolv2.cpp
@@ -601,6 +601,7 @@ QgsSymbolV2* QgsMarkerSymbolV2::clone() const
 {
   QgsSymbolV2* cloneSymbol = new QgsMarkerSymbolV2( cloneLayers() );
   cloneSymbol->setAlpha( mAlpha );
+  cloneSymbol->setLayer( mLayer );
   return cloneSymbol;
 }
 
@@ -671,6 +672,7 @@ QgsSymbolV2* QgsLineSymbolV2::clone() const
 {
   QgsSymbolV2* cloneSymbol = new QgsLineSymbolV2( cloneLayers() );
   cloneSymbol->setAlpha( mAlpha );
+  cloneSymbol->setLayer( mLayer );
   return cloneSymbol;
 }
 
@@ -722,6 +724,7 @@ QgsSymbolV2* QgsFillSymbolV2::clone() const
 {
   QgsSymbolV2* cloneSymbol = new QgsFillSymbolV2( cloneLayers() );
   cloneSymbol->setAlpha( mAlpha );
+  cloneSymbol->setLayer( mLayer );
   return cloneSymbol;
 }
 

--- a/src/gui/symbology-ng/qgssymbolslistwidget.h
+++ b/src/gui/symbology-ng/qgssymbolslistwidget.h
@@ -48,6 +48,13 @@ class GUI_EXPORT QgsSymbolsListWidget : public QWidget, private Ui::SymbolsListW
 
     void openStyleManager();
 
+    void setActiveMarkerSizeExpression( bool active ); 
+    void setMarkerSizeExpression(  const QString & definition ); 
+    void setActiveMarkerRotationExpression( bool active ); 
+    void setMarkerRotationExpression(  const QString & definition ); 
+    void setActiveLineWidthExpression( bool active ); 
+    void setLineWidthExpression(  const QString & definition ); 
+
   signals:
     void changed();
 

--- a/src/gui/symbology-ng/qgssymbolv2selectordialog.cpp
+++ b/src/gui/symbology-ng/qgssymbolv2selectordialog.cpp
@@ -333,6 +333,7 @@ void QgsSymbolV2SelectorDialog::layerChanged()
   else
   {
     // then it must be a symbol
+    currentItem->symbol()->setLayer( mVectorLayer );
     // Now populate symbols of that type using the symbols list widget:
     QWidget *symbolsList = new QgsSymbolsListWidget( currentItem->symbol(), mStyle, mAdvancedMenu, this );
     setWidget( symbolsList );

--- a/src/ui/symbollayer/widget_symbolslist.ui
+++ b/src/ui/symbollayer/widget_symbolslist.ui
@@ -84,6 +84,7 @@
          <property name="text">
           <string/>
          </property>
+         <zorder>stackedWidget</zorder>
         </widget>
        </item>
        <item row="0" column="1">
@@ -104,7 +105,51 @@
        </property>
        <widget class="QWidget" name="pageMarker">
         <layout class="QGridLayout" name="gridLayout">
-         <item row="0" column="1">
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_2">
+           <property name="text">
+            <string>Size</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="3">
+          <widget class="QgsDataDefinedButton" name="mSizeDDBtn">
+           <property name="text">
+            <string>...</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="3">
+          <widget class="QgsDataDefinedButton" name="mRotationDDBtn">
+           <property name="text">
+            <string>...</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="2">
+          <widget class="QgsDoubleSpinBox" name="spinAngle">
+           <property name="suffix">
+            <string> °</string>
+           </property>
+           <property name="decimals">
+            <number>2</number>
+           </property>
+           <property name="maximum">
+            <double>360.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.500000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_3">
+           <property name="text">
+            <string>Rotation</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="2">
           <widget class="QgsDoubleSpinBox" name="spinSize">
            <property name="decimals">
             <number>5</number>
@@ -120,36 +165,6 @@
            </property>
            <property name="showClearButton" stdset="0">
             <bool>false</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="0">
-          <widget class="QLabel" name="label_2">
-           <property name="text">
-            <string>Size</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0">
-          <widget class="QLabel" name="label_3">
-           <property name="text">
-            <string>Rotation</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="1">
-          <widget class="QgsDoubleSpinBox" name="spinAngle">
-           <property name="suffix">
-            <string> °</string>
-           </property>
-           <property name="decimals">
-            <number>2</number>
-           </property>
-           <property name="maximum">
-            <double>360.000000000000000</double>
-           </property>
-           <property name="singleStep">
-            <double>0.500000000000000</double>
            </property>
           </widget>
          </item>
@@ -173,6 +188,13 @@
            </property>
            <property name="showClearButton" stdset="0">
             <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="2">
+          <widget class="QgsDataDefinedButton" name="mWidthDDBtn">
+           <property name="text">
+            <string>...</string>
            </property>
           </widget>
          </item>
@@ -334,17 +356,25 @@
    <header>qgsunitselectionwidget.h</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>QgsDataDefinedButton</class>
+   <extends>QToolButton</extends>
+   <header>qgsdatadefinedbutton.h</header>
+  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>mTransparencySlider</tabstop>
   <tabstop>spinSize</tabstop>
+  <tabstop>mSizeDDBtn</tabstop>
+  <tabstop>spinWidth</tabstop>
+  <tabstop>mWidthDDBtn</tabstop>
   <tabstop>btnColor</tabstop>
   <tabstop>spinAngle</tabstop>
+  <tabstop>mRotationDDBtn</tabstop>
   <tabstop>groupsCombo</tabstop>
   <tabstop>openStyleManagerButton</tabstop>
   <tabstop>viewSymbols</tabstop>
   <tabstop>btnAdvanced</tabstop>
-  <tabstop>spinWidth</tabstop>
  </tabstops>
  <resources/>
  <connections/>


### PR DESCRIPTION
Size and Rotation can be defined by an expression for all symbols composing a marker
Width can be defined by an expression for all symbols composing a line

The line symbol layer as been refactored to avoid code duplication and
expose the offset and offset units in the base class. This refacto was
necessary for this feature to avoid unnecessary dynamic cast. Note that
the added functions in the base class where already defined in all
child classes.

Also sets the symbols layer ptr when cloning.
