### PR TITLE
falls back to non-data-defined values for legend

### DIFF
--- a/src/core/symbology-ng/qgslinesymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgslinesymbollayerv2.cpp
@@ -28,6 +28,11 @@
 
 #include <cmath>
 
+inline bool evaluable( const QgsExpression * expr, const QgsSymbolV2RenderContext& context )
+{
+  return expr && ( context.feature() || !expr->referencedColumns().size() );
+}
+
 QgsSimpleLineSymbolLayerV2::QgsSimpleLineSymbolLayerV2( QColor color, double width, Qt::PenStyle penStyle )
     : mPenStyle( penStyle )
     , mPenJoinStyle( DEFAULT_SIMPLELINE_JOINSTYLE )
@@ -482,7 +487,7 @@ void QgsSimpleLineSymbolLayerV2::applyDataDefinedSymbology( QgsSymbolV2RenderCon
 
   //data defined properties
   QgsExpression* strokeWidthExpression = expression( "width" );
-  if ( strokeWidthExpression )
+  if ( evaluable( strokeWidthExpression, context ) )
   {
     double scaledWidth = strokeWidthExpression->evaluate( const_cast<QgsFeature*>( context.feature() ) ).toDouble()
                          * QgsSymbolLayerV2Utils::lineWidthScaleFactor( context.renderContext(), mWidthUnit, mWidthMapUnitScale );
@@ -492,21 +497,21 @@ void QgsSimpleLineSymbolLayerV2::applyDataDefinedSymbology( QgsSymbolV2RenderCon
 
   //color
   QgsExpression* strokeColorExpression = expression( "color" );
-  if ( strokeColorExpression )
+  if ( evaluable( strokeColorExpression, context ) )
   {
     pen.setColor( QgsSymbolLayerV2Utils::decodeColor( strokeColorExpression->evaluate( const_cast<QgsFeature*>( context.feature() ) ).toString() ) );
   }
 
   //offset
   QgsExpression* lineOffsetExpression = expression( "offset" );
-  if ( lineOffsetExpression )
+  if ( evaluable( lineOffsetExpression, context ) )
   {
     offset = lineOffsetExpression->evaluate( const_cast<QgsFeature*>( context.feature() ) ).toDouble();
   }
 
   //dash dot vector
   QgsExpression* dashPatternExpression = expression( "customdash" );
-  if ( dashPatternExpression )
+  if ( evaluable( dashPatternExpression, context ) )
   {
     double scaledWidth = mWidth * QgsSymbolLayerV2Utils::lineWidthScaleFactor( context.renderContext(), mWidthUnit, mWidthMapUnitScale );
     double dashWidthDiv = mPen.widthF();
@@ -538,7 +543,7 @@ void QgsSimpleLineSymbolLayerV2::applyDataDefinedSymbology( QgsSymbolV2RenderCon
 
   //line style
   QgsExpression* lineStyleExpression = expression( "line_style" );
-  if ( lineStyleExpression )
+  if ( evaluable( lineStyleExpression, context ) )
   {
     QString lineStyleString = lineStyleExpression->evaluate( const_cast<QgsFeature*>( context.feature() ) ).toString();
     pen.setStyle( QgsSymbolLayerV2Utils::decodePenStyle( lineStyleString ) );
@@ -546,7 +551,7 @@ void QgsSimpleLineSymbolLayerV2::applyDataDefinedSymbology( QgsSymbolV2RenderCon
 
   //join style
   QgsExpression* joinStyleExpression = expression( "joinstyle" );
-  if ( joinStyleExpression )
+  if ( evaluable( joinStyleExpression, context ) )
   {
     QString joinStyleString = joinStyleExpression->evaluate( const_cast<QgsFeature*>( context.feature() ) ).toString();
     pen.setJoinStyle( QgsSymbolLayerV2Utils::decodePenJoinStyle( joinStyleString ) );
@@ -554,7 +559,7 @@ void QgsSimpleLineSymbolLayerV2::applyDataDefinedSymbology( QgsSymbolV2RenderCon
 
   //cap style
   QgsExpression* capStyleExpression = expression( "capstyle" );
-  if ( capStyleExpression )
+  if ( evaluable( capStyleExpression, context ) )
   {
     QString capStyleString = capStyleExpression->evaluate( const_cast<QgsFeature*>( context.feature() ) ).toString();
     pen.setCapStyle( QgsSymbolLayerV2Utils::decodePenCapStyle( capStyleString ) );

--- a/src/core/symbology-ng/qgslinesymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgslinesymbollayerv2.cpp
@@ -28,11 +28,6 @@
 
 #include <cmath>
 
-inline bool evaluable( const QgsExpression * expr, const QgsSymbolV2RenderContext& context )
-{
-  return expr && ( context.feature() || !expr->referencedColumns().size() );
-}
-
 QgsSimpleLineSymbolLayerV2::QgsSimpleLineSymbolLayerV2( QColor color, double width, Qt::PenStyle penStyle )
     : mPenStyle( penStyle )
     , mPenJoinStyle( DEFAULT_SIMPLELINE_JOINSTYLE )
@@ -487,7 +482,7 @@ void QgsSimpleLineSymbolLayerV2::applyDataDefinedSymbology( QgsSymbolV2RenderCon
 
   //data defined properties
   QgsExpression* strokeWidthExpression = expression( "width" );
-  if ( evaluable( strokeWidthExpression, context ) )
+  if ( strokeWidthExpression && context.feature() )
   {
     double scaledWidth = strokeWidthExpression->evaluate( const_cast<QgsFeature*>( context.feature() ) ).toDouble()
                          * QgsSymbolLayerV2Utils::lineWidthScaleFactor( context.renderContext(), mWidthUnit, mWidthMapUnitScale );
@@ -497,21 +492,21 @@ void QgsSimpleLineSymbolLayerV2::applyDataDefinedSymbology( QgsSymbolV2RenderCon
 
   //color
   QgsExpression* strokeColorExpression = expression( "color" );
-  if ( evaluable( strokeColorExpression, context ) )
+  if ( strokeColorExpression && context.feature() )
   {
     pen.setColor( QgsSymbolLayerV2Utils::decodeColor( strokeColorExpression->evaluate( const_cast<QgsFeature*>( context.feature() ) ).toString() ) );
   }
 
   //offset
   QgsExpression* lineOffsetExpression = expression( "offset" );
-  if ( evaluable( lineOffsetExpression, context ) )
+  if ( lineOffsetExpression && context.feature() )
   {
     offset = lineOffsetExpression->evaluate( const_cast<QgsFeature*>( context.feature() ) ).toDouble();
   }
 
   //dash dot vector
   QgsExpression* dashPatternExpression = expression( "customdash" );
-  if ( evaluable( dashPatternExpression, context ) )
+  if ( dashPatternExpression && context.feature() )
   {
     double scaledWidth = mWidth * QgsSymbolLayerV2Utils::lineWidthScaleFactor( context.renderContext(), mWidthUnit, mWidthMapUnitScale );
     double dashWidthDiv = mPen.widthF();
@@ -543,7 +538,7 @@ void QgsSimpleLineSymbolLayerV2::applyDataDefinedSymbology( QgsSymbolV2RenderCon
 
   //line style
   QgsExpression* lineStyleExpression = expression( "line_style" );
-  if ( evaluable( lineStyleExpression, context ) )
+  if ( lineStyleExpression && context.feature() )
   {
     QString lineStyleString = lineStyleExpression->evaluate( const_cast<QgsFeature*>( context.feature() ) ).toString();
     pen.setStyle( QgsSymbolLayerV2Utils::decodePenStyle( lineStyleString ) );
@@ -551,7 +546,7 @@ void QgsSimpleLineSymbolLayerV2::applyDataDefinedSymbology( QgsSymbolV2RenderCon
 
   //join style
   QgsExpression* joinStyleExpression = expression( "joinstyle" );
-  if ( evaluable( joinStyleExpression, context ) )
+  if ( joinStyleExpression && context.feature() )
   {
     QString joinStyleString = joinStyleExpression->evaluate( const_cast<QgsFeature*>( context.feature() ) ).toString();
     pen.setJoinStyle( QgsSymbolLayerV2Utils::decodePenJoinStyle( joinStyleString ) );
@@ -559,7 +554,7 @@ void QgsSimpleLineSymbolLayerV2::applyDataDefinedSymbology( QgsSymbolV2RenderCon
 
   //cap style
   QgsExpression* capStyleExpression = expression( "capstyle" );
-  if ( evaluable( capStyleExpression, context ) )
+  if ( capStyleExpression && context.feature() )
   {
     QString capStyleString = capStyleExpression->evaluate( const_cast<QgsFeature*>( context.feature() ) ).toString();
     pen.setCapStyle( QgsSymbolLayerV2Utils::decodePenCapStyle( capStyleString ) );

--- a/src/core/symbology-ng/qgsmarkersymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgsmarkersymbollayerv2.cpp
@@ -36,11 +36,6 @@ Q_GUI_EXPORT extern int qt_defaultDpiX();
 Q_GUI_EXPORT extern int qt_defaultDpiY();
 
 
-inline bool evaluable( const QgsExpression * expr, const QgsSymbolV2RenderContext& context )
-{
-  return expr && ( context.feature() || !expr->referencedColumns().size() );
-}
-
 static void _fixQPictureDPI( QPainter* p )
 {
   // QPicture makes an assumption that we drawing to it with system DPI.
@@ -523,7 +518,7 @@ void QgsSimpleMarkerSymbolLayerV2::renderPoint( const QPointF& point, QgsSymbolV
   double scaledSize = mSize;
   if ( hasDataDefinedSize )
   {
-    if ( evaluable( sizeExpression, context ) )
+    if ( sizeExpression && context.feature() )
     {
       scaledSize = sizeExpression->evaluate( const_cast<QgsFeature*>( context.feature() ) ).toDouble();
     }
@@ -542,7 +537,7 @@ void QgsSimpleMarkerSymbolLayerV2::renderPoint( const QPointF& point, QgsSymbolV
 
   //angle
   double angle = mAngle;
-  if ( evaluable( mAngleExpression, context ) )
+  if ( mAngleExpression && context.feature() )
   {
     angle = mAngleExpression->evaluate( const_cast<QgsFeature*>( context.feature() ) ).toDouble();
   }
@@ -551,7 +546,7 @@ void QgsSimpleMarkerSymbolLayerV2::renderPoint( const QPointF& point, QgsSymbolV
 
   //data defined shape?
   bool createdNewPath = false;
-  if ( evaluable( mNameExpression, context ) )
+  if ( mNameExpression && context.feature() )
   {
     QString name = mNameExpression->evaluate( const_cast<QgsFeature*>( context.feature() ) ).toString();
     if ( !prepareShape( name ) ) // drawing as a polygon
@@ -593,22 +588,22 @@ void QgsSimpleMarkerSymbolLayerV2::renderPoint( const QPointF& point, QgsSymbolV
     QgsExpression* colorBorderExpression = expression( "color_border" );
     QgsExpression* outlineWidthExpression = expression( "outline_width" );
     QgsExpression* outlineStyleExpression = expression( "outline_style" );
-    if ( evaluable( colorExpression, context ) )
+    if ( colorExpression && context.feature() )
     {
       mBrush.setColor( QgsSymbolLayerV2Utils::decodeColor( colorExpression->evaluate( const_cast<QgsFeature*>( context.feature() ) ).toString() ) );
     }
-    if ( evaluable( colorBorderExpression, context ) )
+    if ( colorBorderExpression && context.feature() )
     {
       mPen.setColor( QgsSymbolLayerV2Utils::decodeColor( colorBorderExpression->evaluate( const_cast<QgsFeature*>( context.feature() ) ).toString() ) );
       mSelPen.setColor( QgsSymbolLayerV2Utils::decodeColor( colorBorderExpression->evaluate( const_cast<QgsFeature*>( context.feature() ) ).toString() ) );
     }
-    if ( evaluable( outlineWidthExpression, context ) )
+    if ( outlineWidthExpression && context.feature() )
     {
       double outlineWidth = outlineWidthExpression->evaluate( const_cast<QgsFeature*>( context.feature() ) ).toDouble();
       mPen.setWidthF( outlineWidth * QgsSymbolLayerV2Utils::lineWidthScaleFactor( context.renderContext(), mOutlineWidthUnit, mOutlineWidthMapUnitScale ) );
       mSelPen.setWidthF( outlineWidth * QgsSymbolLayerV2Utils::lineWidthScaleFactor( context.renderContext(), mOutlineWidthUnit, mOutlineWidthMapUnitScale ) );
     }
-    if ( evaluable( outlineStyleExpression, context ) )
+    if ( outlineStyleExpression && context.feature() )
     {
       QString outlineStyle = outlineStyleExpression->evaluate( const_cast<QgsFeature*>( context.feature() ) ).toString();
       mPen.setStyle( QgsSymbolLayerV2Utils::decodePenStyle( outlineStyle ) );

--- a/src/core/symbology-ng/qgsmarkersymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgsmarkersymbollayerv2.cpp
@@ -35,6 +35,12 @@
 Q_GUI_EXPORT extern int qt_defaultDpiX();
 Q_GUI_EXPORT extern int qt_defaultDpiY();
 
+
+inline bool evaluable( const QgsExpression * expr, const QgsSymbolV2RenderContext& context )
+{
+  return expr && ( context.feature() || !expr->referencedColumns().size() );
+}
+
 static void _fixQPictureDPI( QPainter* p )
 {
   // QPicture makes an assumption that we drawing to it with system DPI.
@@ -517,7 +523,7 @@ void QgsSimpleMarkerSymbolLayerV2::renderPoint( const QPointF& point, QgsSymbolV
   double scaledSize = mSize;
   if ( hasDataDefinedSize )
   {
-    if ( sizeExpression )
+    if ( evaluable( sizeExpression, context ) )
     {
       scaledSize = sizeExpression->evaluate( const_cast<QgsFeature*>( context.feature() ) ).toDouble();
     }
@@ -536,7 +542,7 @@ void QgsSimpleMarkerSymbolLayerV2::renderPoint( const QPointF& point, QgsSymbolV
 
   //angle
   double angle = mAngle;
-  if ( mAngleExpression )
+  if ( evaluable( mAngleExpression, context ) )
   {
     angle = mAngleExpression->evaluate( const_cast<QgsFeature*>( context.feature() ) ).toDouble();
   }
@@ -545,7 +551,7 @@ void QgsSimpleMarkerSymbolLayerV2::renderPoint( const QPointF& point, QgsSymbolV
 
   //data defined shape?
   bool createdNewPath = false;
-  if ( mNameExpression )
+  if ( evaluable( mNameExpression, context ) )
   {
     QString name = mNameExpression->evaluate( const_cast<QgsFeature*>( context.feature() ) ).toString();
     if ( !prepareShape( name ) ) // drawing as a polygon
@@ -587,22 +593,22 @@ void QgsSimpleMarkerSymbolLayerV2::renderPoint( const QPointF& point, QgsSymbolV
     QgsExpression* colorBorderExpression = expression( "color_border" );
     QgsExpression* outlineWidthExpression = expression( "outline_width" );
     QgsExpression* outlineStyleExpression = expression( "outline_style" );
-    if ( colorExpression )
+    if ( evaluable( colorExpression, context ) )
     {
       mBrush.setColor( QgsSymbolLayerV2Utils::decodeColor( colorExpression->evaluate( const_cast<QgsFeature*>( context.feature() ) ).toString() ) );
     }
-    if ( colorBorderExpression )
+    if ( evaluable( colorBorderExpression, context ) )
     {
       mPen.setColor( QgsSymbolLayerV2Utils::decodeColor( colorBorderExpression->evaluate( const_cast<QgsFeature*>( context.feature() ) ).toString() ) );
       mSelPen.setColor( QgsSymbolLayerV2Utils::decodeColor( colorBorderExpression->evaluate( const_cast<QgsFeature*>( context.feature() ) ).toString() ) );
     }
-    if ( outlineWidthExpression )
+    if ( evaluable( outlineWidthExpression, context ) )
     {
       double outlineWidth = outlineWidthExpression->evaluate( const_cast<QgsFeature*>( context.feature() ) ).toDouble();
       mPen.setWidthF( outlineWidth * QgsSymbolLayerV2Utils::lineWidthScaleFactor( context.renderContext(), mOutlineWidthUnit, mOutlineWidthMapUnitScale ) );
       mSelPen.setWidthF( outlineWidth * QgsSymbolLayerV2Utils::lineWidthScaleFactor( context.renderContext(), mOutlineWidthUnit, mOutlineWidthMapUnitScale ) );
     }
-    if ( outlineStyleExpression )
+    if ( evaluable( outlineStyleExpression, context ) )
     {
       QString outlineStyle = outlineStyleExpression->evaluate( const_cast<QgsFeature*>( context.feature() ) ).toString();
       mPen.setStyle( QgsSymbolLayerV2Utils::decodePenStyle( outlineStyle ) );

--- a/src/core/symbology-ng/qgssymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgssymbollayerv2.cpp
@@ -26,11 +26,6 @@
 #include <QPointF>
 #include <QPolygonF>
 
-inline bool evaluable( const QgsExpression * expr, const QgsSymbolV2RenderContext& context )
-{
-  return expr && ( context.feature() || !expr->referencedColumns().size() );
-}
-
 const QgsExpression* QgsSymbolLayerV2::dataDefinedProperty( const QString& property ) const
 {
   QMap< QString, QgsExpression* >::const_iterator it = mDataDefinedProperties.find( property );
@@ -264,7 +259,7 @@ void QgsMarkerSymbolLayerV2::markerOffset( const QgsSymbolV2RenderContext& conte
   offsetX = mOffset.x();
   offsetY = mOffset.y();
 
-  if ( evaluable( mOffsetExpression, context ) )
+  if ( mOffsetExpression && context.feature() )
   {
     QPointF offset = QgsSymbolLayerV2Utils::decodePoint( mOffsetExpression->evaluate( const_cast<QgsFeature*>( context.feature() ) ).toString() );
     offsetX = offset.x();
@@ -276,11 +271,11 @@ void QgsMarkerSymbolLayerV2::markerOffset( const QgsSymbolV2RenderContext& conte
 
   HorizontalAnchorPoint horizontalAnchorPoint = mHorizontalAnchorPoint;
   VerticalAnchorPoint verticalAnchorPoint = mVerticalAnchorPoint;
-  if ( evaluable( mHorizontalAnchorExpression, context ) )
+  if ( mHorizontalAnchorExpression && context.feature() )
   {
     horizontalAnchorPoint = decodeHorizontalAnchorPoint( mHorizontalAnchorExpression->evaluate( const_cast<QgsFeature*>( context.feature() ) ).toString() );
   }
-  if ( evaluable( mVerticalAnchorExpression, context ) )
+  if ( mVerticalAnchorExpression && context.feature() )
   {
     verticalAnchorPoint = decodeVerticalAnchorPoint( mVerticalAnchorExpression->evaluate( const_cast<QgsFeature*>( context.feature() ) ).toString() );
   }

--- a/src/core/symbology-ng/qgssymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgssymbollayerv2.cpp
@@ -26,6 +26,11 @@
 #include <QPointF>
 #include <QPolygonF>
 
+inline bool evaluable( const QgsExpression * expr, const QgsSymbolV2RenderContext& context )
+{
+  return expr && ( context.feature() || !expr->referencedColumns().size() );
+}
+
 const QgsExpression* QgsSymbolLayerV2::dataDefinedProperty( const QString& property ) const
 {
   QMap< QString, QgsExpression* >::const_iterator it = mDataDefinedProperties.find( property );
@@ -259,7 +264,7 @@ void QgsMarkerSymbolLayerV2::markerOffset( const QgsSymbolV2RenderContext& conte
   offsetX = mOffset.x();
   offsetY = mOffset.y();
 
-  if ( mOffsetExpression )
+  if ( evaluable( mOffsetExpression, context ) )
   {
     QPointF offset = QgsSymbolLayerV2Utils::decodePoint( mOffsetExpression->evaluate( const_cast<QgsFeature*>( context.feature() ) ).toString() );
     offsetX = offset.x();
@@ -271,11 +276,11 @@ void QgsMarkerSymbolLayerV2::markerOffset( const QgsSymbolV2RenderContext& conte
 
   HorizontalAnchorPoint horizontalAnchorPoint = mHorizontalAnchorPoint;
   VerticalAnchorPoint verticalAnchorPoint = mVerticalAnchorPoint;
-  if ( mHorizontalAnchorExpression )
+  if ( evaluable( mHorizontalAnchorExpression, context ) )
   {
     horizontalAnchorPoint = decodeHorizontalAnchorPoint( mHorizontalAnchorExpression->evaluate( const_cast<QgsFeature*>( context.feature() ) ).toString() );
   }
-  if ( mVerticalAnchorExpression )
+  if ( evaluable( mVerticalAnchorExpression, context ) )
   {
     verticalAnchorPoint = decodeVerticalAnchorPoint( mVerticalAnchorExpression->evaluate( const_cast<QgsFeature*>( context.feature() ) ).toString() );
   }


### PR DESCRIPTION
so that a symbol can be generated

When the legend symbols are generated the feature is missing from the
context, if the symbol style is data-defined and the feature is
actually needed by the expression, we use the value that is not data-defined.

This is related to https://hub.qgis.org/issues/11491, but is not a fix.

I only did it for maker and line symbol layers, if the principle is accepted, I can do that for the other symbology layer classes.
