### PR TITLE
[SERVER][FEATURE] Add DescribeLayer Method to WMS

### DIFF
--- a/src/server/qgsserverprojectparser.h
+++ b/src/server/qgsserverprojectparser.h
@@ -91,6 +91,7 @@ class QgsServerProjectParser
     void layerFromLegendLayer( const QDomElement& legendLayerElem, QMap< int, QgsMapLayer*>& layers, bool useCache = true ) const;
 
     QStringList wfsLayerNames() const;
+    QStringList wcsLayerNames() const;
 
     QDomElement firstComposerLegendElement() const;
 
@@ -103,8 +104,11 @@ class QgsServerProjectParser
     QString layerName( const QDomElement& layerElem ) const;
 
     QString serviceUrl() const;
+    QString wfsServiceUrl() const;
+    QString wcsServiceUrl() const;
 
     QStringList wfsLayers() const;
+    QStringList wcsLayers() const;
 
     void addJoinLayersForElement( const QDomElement& layerElem, bool useCache = true ) const;
 

--- a/src/server/qgssldconfigparser.cpp
+++ b/src/server/qgssldconfigparser.cpp
@@ -482,6 +482,15 @@ QDomDocument QgsSLDConfigParser::getStyles( QStringList& layerList ) const
   return styleDoc;
 }
 
+QDomDocument QgsSLDConfigParser::describeLayer( QStringList& layerList, const QString& hrefString ) const
+{
+  if ( mFallbackParser )
+  {
+    return mFallbackParser->describeLayer( layerList, hrefString );
+  }
+  return QDomDocument();
+}
+
 QgsMapRenderer::OutputUnits QgsSLDConfigParser::outputUnits() const
 {
   return mOutputUnits;

--- a/src/server/qgssldconfigparser.h
+++ b/src/server/qgssldconfigparser.h
@@ -51,6 +51,9 @@ class QgsSLDConfigParser : public QgsWMSConfigParser
 
     /**Returns the xml fragment of layers styles*/
     QDomDocument getStyles( QStringList& layerList ) const override;
+    
+    /**Returns the xml fragment of layers styles description*/
+    QDomDocument describeLayer( QStringList& layerList, const QString& hrefString ) const override;
 
     /**Returns if output are MM or PIXEL*/
     QgsMapRenderer::OutputUnits outputUnits() const override;

--- a/src/server/qgswfsprojectparser.cpp
+++ b/src/server/qgswfsprojectparser.cpp
@@ -43,23 +43,7 @@ QString QgsWFSProjectParser::serviceUrl() const
 
 QString QgsWFSProjectParser::wfsServiceUrl() const
 {
-  QString url;
-
-  if ( !mProjectParser->xmlDocument() )
-  {
-    return url;
-  }
-
-  QDomElement propertiesElem = mProjectParser->propertiesElem();
-  if ( !propertiesElem.isNull() )
-  {
-    QDomElement wfsUrlElem = propertiesElem.firstChildElement( "WFSUrl" );
-    if ( !wfsUrlElem.isNull() )
-    {
-      url = wfsUrlElem.text();
-    }
-  }
-  return url;
+  return mProjectParser->wfsServiceUrl();
 }
 
 void QgsWFSProjectParser::featureTypeList( QDomElement& parentElement, QDomDocument& doc ) const

--- a/src/server/qgswmsconfigparser.h
+++ b/src/server/qgswmsconfigparser.h
@@ -50,6 +50,9 @@ class QgsWMSConfigParser
 
     /**Returns the xml fragment of layers styles*/
     virtual QDomDocument getStyles( QStringList& layerList ) const = 0;
+    
+    /**Returns the xml fragment of layers styles description*/
+    virtual QDomDocument describeLayer( QStringList& layerList, const QString& hrefString ) const = 0;
 
     /**Returns if output are MM or PIXEL*/
     virtual QgsMapRenderer::OutputUnits outputUnits() const = 0;

--- a/src/server/qgswmsprojectparser.h
+++ b/src/server/qgswmsprojectparser.h
@@ -79,6 +79,9 @@ class QgsWMSProjectParser : public QgsWMSConfigParser
     /**Returns the xml fragment of layers styles*/
     QDomDocument getStyles( QStringList& layerList ) const override;
 
+    /**Returns the xml fragment of layers styles description*/
+    QDomDocument describeLayer( QStringList& layerList, const QString& hrefString ) const override;
+
     /**Returns if output are MM or PIXEL*/
     QgsMapRenderer::OutputUnits outputUnits() const override;
 

--- a/src/server/qgswmsserver.h
+++ b/src/server/qgswmsserver.h
@@ -88,6 +88,8 @@ class QgsWMSServer: public QgsOWSServer
     QDomDocument getStyle();
     /**Returns an SLD file with the styles of the requested layers. Exception is raised in case of troubles :-)*/
     QDomDocument getStyles();
+    /**Returns a describeLayer file with the onlineResource of the requested layers. Exception is raised in case of troubles :-)*/
+    QDomDocument describeLayer();
 
     /**Returns printed page as binary
       @param formatString out: format of the print output (e.g. pdf, svg, png, ...)


### PR DESCRIPTION
_Styled Layer Descriptor profile of the Web Map Service_ : DescribeLayer

http://www.opengeospatial.org/standards/sld

Defining a user-defined style requires information about the features being
 symbolized, or at least their feature/coverage type. Since user-defined styles
 can be applied to a named layer, there needs to be a mechanism by which a
 client can obtain feature/coverage-type information for a named layer. This is
 another example of bridging the gap between the WMS concepts of layers and
 styles and WFS/WCS concepts such as feature-type and coverage layer. To allow
 this, a WMS may optionally support the DescribeLayer request.

DescribeLayer method has been thought to be a better approach than overloading
 the WMS capabilities document even more.

For each named layer, the description should indicate if it is indeed based on
 feature data and if so it should indicate the WFS/WCS (by a URL prefix) and
 the feature/coverage types. Note that it is perfectly valid for a named layer
 not to be describable in this way.
