### PR TITLE
line symbol layer refacto to avoid code duplication

### DIFF
--- a/python/core/symbology-ng/qgslinesymbollayerv2.sip
+++ b/python/core/symbology-ng/qgslinesymbollayerv2.sip
@@ -54,15 +54,6 @@ class QgsSimpleLineSymbolLayerV2 : QgsLineSymbolLayerV2
     Qt::PenCapStyle penCapStyle() const;
     void setPenCapStyle( Qt::PenCapStyle style );
 
-    double offset() const;
-    void setOffset( double offset );
-
-    void setOffsetUnit( QgsSymbolV2::OutputUnit unit );
-    QgsSymbolV2::OutputUnit offsetUnit() const;
-
-    void setOffsetMapUnitScale( const QgsMapUnitScale& scale);
-    const QgsMapUnitScale& offsetMapUnitScale() const;
-
     bool useCustomDashPattern() const;
     void setUseCustomDashPattern( bool b );
 
@@ -151,9 +142,6 @@ class QgsMarkerLineSymbolLayerV2 : QgsLineSymbolLayerV2
     double interval() const;
     void setInterval( double interval );
 
-    double offset() const;
-    void setOffset( double offset );
-
     Placement placement() const;
     void setPlacement( Placement p );
 
@@ -211,12 +199,6 @@ class QgsMarkerLineSymbolLayerV2 : QgsLineSymbolLayerV2
 
     void setIntervalMapUnitScale( const QgsMapUnitScale& scale );
     const QgsMapUnitScale& intervalMapUnitScale() const;
-
-    void setOffsetUnit( QgsSymbolV2::OutputUnit unit );
-    QgsSymbolV2::OutputUnit offsetUnit() const;
-
-    void setOffsetMapUnitScale( const QgsMapUnitScale& scale );
-    const QgsMapUnitScale& offsetMapUnitScale() const;
 
     void setOutputUnit( QgsSymbolV2::OutputUnit unit );
     QgsSymbolV2::OutputUnit outputUnit() const;

--- a/python/core/symbology-ng/qgssymbollayerv2.sip
+++ b/python/core/symbology-ng/qgssymbollayerv2.sip
@@ -262,11 +262,20 @@ class QgsLineSymbolLayerV2 : QgsSymbolLayerV2
     virtual void setWidth( double width );
     virtual double width() const;
 
+    double offset() const;
+    void setOffset( double offset );
+
     void setWidthUnit( QgsSymbolV2::OutputUnit unit );
     QgsSymbolV2::OutputUnit widthUnit() const;
 
     void setWidthMapUnitScale( const QgsMapUnitScale& scale);
     const QgsMapUnitScale& widthMapUnitScale() const;
+
+    void setOffsetUnit( QgsSymbolV2::OutputUnit unit );
+    QgsSymbolV2::OutputUnit offsetUnit() const;
+
+    void setOffsetMapUnitScale( const QgsMapUnitScale& scale );
+    const QgsMapUnitScale& offsetMapUnitScale() const;
 
     void setOutputUnit( QgsSymbolV2::OutputUnit unit );
     QgsSymbolV2::OutputUnit outputUnit() const;

--- a/src/core/symbology-ng/qgslinesymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgslinesymbollayerv2.cpp
@@ -32,8 +32,6 @@ QgsSimpleLineSymbolLayerV2::QgsSimpleLineSymbolLayerV2( QColor color, double wid
     : mPenStyle( penStyle )
     , mPenJoinStyle( DEFAULT_SIMPLELINE_JOINSTYLE )
     , mPenCapStyle( DEFAULT_SIMPLELINE_CAPSTYLE )
-    , mOffset( 0 )
-    , mOffsetUnit( QgsSymbolV2::MM )
     , mUseCustomDashPattern( false )
     , mCustomDashPatternUnit( QgsSymbolV2::MM )
     , mDrawInsidePolygon( false )
@@ -691,8 +689,6 @@ QgsMarkerLineSymbolLayerV2::QgsMarkerLineSymbolLayerV2( bool rotateMarker, doubl
   mInterval = interval;
   mIntervalUnit = QgsSymbolV2::MM;
   mMarker = NULL;
-  mOffset = 0;
-  mOffsetUnit = QgsSymbolV2::MM;
   mPlacement = Interval;
   mOffsetAlongLine = 0;
   mOffsetAlongLineUnit = QgsSymbolV2::MM;

--- a/src/core/symbology-ng/qgslinesymbollayerv2.h
+++ b/src/core/symbology-ng/qgslinesymbollayerv2.h
@@ -82,15 +82,6 @@ class CORE_EXPORT QgsSimpleLineSymbolLayerV2 : public QgsLineSymbolLayerV2
     Qt::PenCapStyle penCapStyle() const { return mPenCapStyle; }
     void setPenCapStyle( Qt::PenCapStyle style ) { mPenCapStyle = style; }
 
-    double offset() const { return mOffset; }
-    void setOffset( double offset ) { mOffset = offset; }
-
-    void setOffsetUnit( QgsSymbolV2::OutputUnit unit ) { mOffsetUnit = unit; }
-    QgsSymbolV2::OutputUnit offsetUnit() const { return mOffsetUnit; }
-
-    void setOffsetMapUnitScale( const QgsMapUnitScale& scale ) { mOffsetMapUnitScale = scale; }
-    const QgsMapUnitScale& offsetMapUnitScale() const { return mOffsetMapUnitScale; }
-
     bool useCustomDashPattern() const { return mUseCustomDashPattern; }
     void setUseCustomDashPattern( bool b ) { mUseCustomDashPattern = b; }
 
@@ -121,9 +112,6 @@ class CORE_EXPORT QgsSimpleLineSymbolLayerV2 : public QgsLineSymbolLayerV2
     Qt::PenCapStyle mPenCapStyle;
     QPen mPen;
     QPen mSelPen;
-    double mOffset;
-    QgsSymbolV2::OutputUnit mOffsetUnit;
-    QgsMapUnitScale mOffsetMapUnitScale;
 
     //use a custom dash dot pattern instead of the predefined ones
     bool mUseCustomDashPattern;
@@ -204,9 +192,6 @@ class CORE_EXPORT QgsMarkerLineSymbolLayerV2 : public QgsLineSymbolLayerV2
     double interval() const { return mInterval; }
     void setInterval( double interval ) { mInterval = interval; }
 
-    double offset() const { return mOffset; }
-    void setOffset( double offset ) { mOffset = offset; }
-
     Placement placement() const { return mPlacement; }
     void setPlacement( Placement p ) { mPlacement = p; }
 
@@ -265,12 +250,6 @@ class CORE_EXPORT QgsMarkerLineSymbolLayerV2 : public QgsLineSymbolLayerV2
     void setIntervalMapUnitScale( const QgsMapUnitScale& scale ) { mIntervalMapUnitScale = scale; }
     const QgsMapUnitScale& intervalMapUnitScale() const { return mIntervalMapUnitScale; }
 
-    void setOffsetUnit( QgsSymbolV2::OutputUnit unit ) { mOffsetUnit = unit; }
-    QgsSymbolV2::OutputUnit offsetUnit() const { return mOffsetUnit; }
-
-    void setOffsetMapUnitScale( const QgsMapUnitScale& scale ) { mOffsetMapUnitScale = scale; }
-    const QgsMapUnitScale& offsetMapUnitScale() const { return mOffsetMapUnitScale; }
-
     void setOutputUnit( QgsSymbolV2::OutputUnit unit ) override;
     QgsSymbolV2::OutputUnit outputUnit() const override;
 
@@ -289,9 +268,6 @@ class CORE_EXPORT QgsMarkerLineSymbolLayerV2 : public QgsLineSymbolLayerV2
     QgsSymbolV2::OutputUnit mIntervalUnit;
     QgsMapUnitScale mIntervalMapUnitScale;
     QgsMarkerSymbolV2* mMarker;
-    double mOffset;
-    QgsSymbolV2::OutputUnit mOffsetUnit;
-    QgsMapUnitScale mOffsetMapUnitScale;
     Placement mPlacement;
     double mOffsetAlongLine; //distance to offset along line before marker is drawn
     QgsSymbolV2::OutputUnit mOffsetAlongLineUnit; //unit for offset along line

--- a/src/core/symbology-ng/qgssymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgssymbollayerv2.cpp
@@ -225,6 +225,8 @@ QgsMarkerSymbolLayerV2::QgsMarkerSymbolLayerV2( bool locked )
 QgsLineSymbolLayerV2::QgsLineSymbolLayerV2( bool locked )
     : QgsSymbolLayerV2( QgsSymbolV2::Line, locked )
     , mWidthUnit( QgsSymbolV2::MM )
+    , mOffset( 0 )
+    , mOffsetUnit( QgsSymbolV2::MM )
 {
 }
 

--- a/src/core/symbology-ng/qgssymbollayerv2.h
+++ b/src/core/symbology-ng/qgssymbollayerv2.h
@@ -269,11 +269,20 @@ class CORE_EXPORT QgsLineSymbolLayerV2 : public QgsSymbolLayerV2
     virtual void setWidth( double width ) { mWidth = width; }
     virtual double width() const { return mWidth; }
 
+    double offset() const { return mOffset; }
+    void setOffset( double offset ) { mOffset = offset; }
+
     void setWidthUnit( QgsSymbolV2::OutputUnit unit ) { mWidthUnit = unit; }
     QgsSymbolV2::OutputUnit widthUnit() const { return mWidthUnit; }
 
     void setWidthMapUnitScale( const QgsMapUnitScale& scale ) { mWidthMapUnitScale = scale; }
     const QgsMapUnitScale& widthMapUnitScale() const { return mWidthMapUnitScale; }
+
+    void setOffsetUnit( QgsSymbolV2::OutputUnit unit ) { mOffsetUnit = unit; }
+    QgsSymbolV2::OutputUnit offsetUnit() const { return mOffsetUnit; }
+
+    void setOffsetMapUnitScale( const QgsMapUnitScale& scale ) { mOffsetMapUnitScale = scale; }
+    const QgsMapUnitScale& offsetMapUnitScale() const { return mOffsetMapUnitScale; }
 
     void setOutputUnit( QgsSymbolV2::OutputUnit unit ) override;
     QgsSymbolV2::OutputUnit outputUnit() const override;
@@ -291,6 +300,9 @@ class CORE_EXPORT QgsLineSymbolLayerV2 : public QgsSymbolLayerV2
     double mWidth;
     QgsSymbolV2::OutputUnit mWidthUnit;
     QgsMapUnitScale mWidthMapUnitScale;
+    double mOffset;
+    QgsSymbolV2::OutputUnit mOffsetUnit;
+    QgsMapUnitScale mOffsetMapUnitScale;
 };
 
 class CORE_EXPORT QgsFillSymbolLayerV2 : public QgsSymbolLayerV2

--- a/src/core/symbology-ng/qgssymbolv2.cpp
+++ b/src/core/symbology-ng/qgssymbolv2.cpp
@@ -601,6 +601,7 @@ QgsSymbolV2* QgsMarkerSymbolV2::clone() const
 {
   QgsSymbolV2* cloneSymbol = new QgsMarkerSymbolV2( cloneLayers() );
   cloneSymbol->setAlpha( mAlpha );
+  cloneSymbol->setLayer( mLayer );
   return cloneSymbol;
 }
 
@@ -671,6 +672,7 @@ QgsSymbolV2* QgsLineSymbolV2::clone() const
 {
   QgsSymbolV2* cloneSymbol = new QgsLineSymbolV2( cloneLayers() );
   cloneSymbol->setAlpha( mAlpha );
+  cloneSymbol->setLayer( mLayer );
   return cloneSymbol;
 }
 
@@ -722,6 +724,7 @@ QgsSymbolV2* QgsFillSymbolV2::clone() const
 {
   QgsSymbolV2* cloneSymbol = new QgsFillSymbolV2( cloneLayers() );
   cloneSymbol->setAlpha( mAlpha );
+  cloneSymbol->setLayer( mLayer );
   return cloneSymbol;
 }
 


### PR DESCRIPTION
The line symbol layer as been refactored to avoid code duplication and
expose the offset and offset units in the base class. Note that
the added functions in the base class where already defined in all
child classes.

@nyalldawson here is the piece you required in #1853
