### PR TITLE
Mapserver: using bbox filter on features in GetFeatureInfo only when BBOX parameter is given

### DIFF
--- a/src/server/qgswmsserver.cpp
+++ b/src/server/qgswmsserver.cpp
@@ -1981,7 +1981,7 @@ int QgsWMSServer::featureInfoFromVectorLayer( QgsVectorLayer* layer,
     searchRect.set( infoPoint->x() - searchRadius, infoPoint->y() - searchRadius,
                     infoPoint->x() + searchRadius, infoPoint->y() + searchRadius );
   }
-  else
+  else if ( mParameters.contains( "BBOX" ) )
   {
     searchRect = layerRect;
   }


### PR DESCRIPTION
There is a potential problem in GetFeatureInfo searching request with FILTER parameter. If you have a project with layer with POINT geometry type, and layer's CRS is different than project's CRS, then some points can be omitted in GetFeatureInfo response. Because when BBOX is not used, it will be computed from matched feaures (of all layers) and it will be later used again in feature request for each individual layer (featureInfoFromVectorLayer). And beacause this bbox will be transformed to project's CRS and then back to layer's CRS, slight rounding of numbers can happen points which lay exactly on bbox may be omitted.

This patch is using bbox in feature request only when BBOX parameter was passed in GetFeatureInfo request - when searching on specific bbox area.
