### PR TITLE
Set labels in composer legend properties to not be wraped

### DIFF
--- a/src/ui/qgscomposerlegendwidgetbase.ui
+++ b/src/ui/qgscomposerlegendwidgetbase.ui
@@ -87,7 +87,7 @@
              <string>&amp;Title</string>
             </property>
             <property name="wordWrap">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
             <property name="buddy">
              <cstring>mTitleLineEdit</cstring>
@@ -103,7 +103,7 @@
              <string>Map</string>
             </property>
             <property name="wordWrap">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
            </widget>
           </item>
@@ -116,7 +116,7 @@
              <string>Wrap text on</string>
             </property>
             <property name="wordWrap">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
            </widget>
           </item>
@@ -581,7 +581,7 @@
              <string>Symbol width</string>
             </property>
             <property name="wordWrap">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
            </widget>
           </item>
@@ -604,7 +604,7 @@
              <string>Symbol height</string>
             </property>
             <property name="wordWrap">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
            </widget>
           </item>
@@ -651,7 +651,7 @@
              <string>Legend width</string>
             </property>
             <property name="wordWrap">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
            </widget>
           </item>
@@ -677,7 +677,7 @@
              <string>Legend height</string>
             </property>
             <property name="wordWrap">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
            </widget>
           </item>
@@ -730,7 +730,7 @@
              <string>Group Space</string>
             </property>
             <property name="wordWrap">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
            </widget>
           </item>
@@ -753,7 +753,7 @@
              <string>Subgroup space</string>
             </property>
             <property name="wordWrap">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
            </widget>
           </item>
@@ -776,7 +776,7 @@
              <string>Symbol space</string>
             </property>
             <property name="wordWrap">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
            </widget>
           </item>
@@ -799,7 +799,7 @@
              <string>Icon label space</string>
             </property>
             <property name="wordWrap">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
            </widget>
           </item>
@@ -819,7 +819,7 @@
              <string>Box space</string>
             </property>
             <property name="wordWrap">
-             <bool>true</bool>
+             <bool>false</bool>
             </property>
            </widget>
           </item>


### PR DESCRIPTION
fix #10498
Avoid labels in composer legend properties to not be displayed inmore than one line once translated
