### PR TITLE
[fixes #8493] "Save as Image" defaults to PNG

### DIFF
--- a/src/gui/qgisgui.cpp
+++ b/src/gui/qgisgui.cpp
@@ -93,7 +93,7 @@ namespace QgisGui
       if ( format ==  "svg" )
         continue;
 
-      filterMap.insert( createFileFilter_( format.toUpper() + " format", "*." + format ), format );
+      filterMap.insert( createFileFilter_( format ), format );
     }
 
 #ifdef QGISDEBUG
@@ -104,14 +104,13 @@ namespace QgisGui
     }
 #endif
 
-    //find out the last used filter
     QSettings settings;  // where we keep last used filter in persistent state
-    QString lastUsedFilter = settings.value( "/UI/lastSaveAsImageFilter" ).toString();
     QString lastUsedDir = settings.value( "/UI/lastSaveAsImageDir", "." ).toString();
 
-    QString outputFileName;
-    QString selectedFilter = lastUsedFilter;
-    QString ext;
+    // Prefer "png" format unless the user previously chose a different format
+    QString pngExtension = "png";
+    QString pngFilter = createFileFilter_( pngExtension );
+    QString selectedFilter = settings.value( "/UI/lastSaveAsImageFilter", pngFilter ).toString();
 
     QString initialPath;
     if ( defaultFilename.isNull() )
@@ -125,6 +124,8 @@ namespace QgisGui
       initialPath = QDir( lastUsedDir ).filePath( defaultFilename );
     }
 
+    QString outputFileName;
+    QString ext;
 #if defined(Q_OS_WIN) || defined(Q_OS_MAC) || defined(Q_OS_LINUX)
     outputFileName = QFileDialog::getSaveFileName( theParent, theMessage, initialPath, QStringList( filterMap.keys() ).join( ";;" ), &selectedFilter );
 
@@ -174,9 +175,9 @@ namespace QgisGui
     return qMakePair<QString, QString>( outputFileName, ext );
   }
 
-  QString createFileFilter_( QString const &longName, QString const &glob )
+  QString createFileFilter_( QString const &format )
   {
-    return longName + " (" + glob.toLower() + " " + glob.toUpper() + ")";
+    return QString( "%1 format (*.%2 *.%1)" ).arg( format.toUpper() ).arg( format.toLower() );
   }
 
 } // end of QgisGui namespace

--- a/src/gui/qgisgui.cpp
+++ b/src/gui/qgisgui.cpp
@@ -182,8 +182,8 @@ namespace QgisGui
 
   QString createFileFilter_( QString const &format )
   {
-    QString longName = format + " format";
-    QString glob = "*" + format;
+    QString longName = format.toUpper() + " format";
+    QString glob = "*." + format;
     return createFileFilter_( longName, glob );
   }
 

--- a/src/gui/qgisgui.h
+++ b/src/gui/qgisgui.h
@@ -83,14 +83,12 @@ namespace QgisGui
   QPair<QString, QString> GUI_EXPORT getSaveAsImageName( QWidget * theParent, QString theMessage, QString defaultFilename = QString::null );
 
   /**
-    Convenience function for readily creating file filters.
-
-    Given a long name for a file filter and a regular expression, return
-    a file filter string suitable for use in a QFileDialog::OpenFiles()
-    call.  The regular express, glob, will have both all lower and upper
-    case versions added.
-  */
-  QString createFileFilter_( QString const &longName, QString const &glob );
+   * Create file filters suitable for use with QFileDialog
+   *
+   * @param format extension e.g. "png"
+   * @return QString e.g. "PNG format (*.png, *.PNG)"
+   */
+  QString createFileFilter_( QString const &format );
 }
 
 #endif

--- a/tests/src/gui/CMakeLists.txt
+++ b/tests/src/gui/CMakeLists.txt
@@ -117,6 +117,7 @@ ADD_QGIS_TEST(zoomtest testqgsmaptoolzoom.cpp)
 
 #ADD_QGIS_TEST(histogramtest testqgsrasterhistogram.cpp)
 ADD_QGIS_TEST(projectionissues testprojectionissues.cpp)
+ADD_QGIS_TEST(qgsguitest testqgsgui.cpp)
 ADD_QGIS_TEST(scalecombobox testqgsscalecombobox.cpp)
 ADD_QGIS_TEST(dualviewtest testqgsdualview.cpp )
 ADD_QGIS_TEST(doublespinbox testqgsdoublespinbox.cpp)

--- a/tests/src/gui/testqgsgui.cpp
+++ b/tests/src/gui/testqgsgui.cpp
@@ -1,0 +1,36 @@
+/***************************************************************************
+    testqgsgui.cpp
+     --------------------------------------
+    Date                 : 26.1.2015
+    Copyright            : (C) 2015 Michael Kirk
+    Email                : michael at jackpine dot me
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <QtTest/QtTest>
+#include <qgisgui.h>
+
+class TestQgsGui : public QObject
+{
+    Q_OBJECT
+  private slots:
+    void createFileFilter();
+
+};
+
+void TestQgsGui::createFileFilter()
+{
+  QString expected = "FOO format (*.foo *.FOO)";
+  QString actual = QgisGui::createFileFilter_("foo");;
+
+  QCOMPARE( actual, expected );
+}
+
+QTEST_MAIN( TestQgsGui )
+#include "testqgsgui.moc"

--- a/tests/src/gui/testqgsgui.cpp
+++ b/tests/src/gui/testqgsgui.cpp
@@ -20,14 +20,23 @@ class TestQgsGui : public QObject
 {
     Q_OBJECT
   private slots:
+    void createFileFilterForFormat();
     void createFileFilter();
 
 };
 
-void TestQgsGui::createFileFilter()
+void TestQgsGui::createFileFilterForFormat()
 {
   QString expected = "FOO format (*.foo *.FOO)";
-  QString actual = QgisGui::createFileFilter_("foo");;
+  QString actual = QgisGui::createFileFilter_("foo");
+
+  QCOMPARE( actual, expected );
+}
+
+void TestQgsGui::createFileFilter()
+{
+  QString expected = "My Description (my_regex MY_REGEX)";
+  QString actual = QgisGui::createFileFilter_("My Description", "my_regex");
 
   QCOMPARE( actual, expected );
 }


### PR DESCRIPTION
Fixes [#8493 - "Save as Image" defaults to archaic media type](https://hub.qgis.org/issues/8493)

The first time a user does File->"Save as Image" the file format used to default to BMP, but now defaults to PNG. On subsequent attempts to "Save as Image" we continue to defer to whatever you chose last time.

This is my first commit to this project and what's more, my first C++, so please tell me if I did something ridiculous.
