### PR TITLE
Fix typo in braces example in style guide.

### DIFF
--- a/doc/CODING.html
+++ b/doc/CODING.html
@@ -422,7 +422,8 @@ Braces should start on the line following the expression:
   {
     // do stuff
     ...
-   }else
+  }
+  else
   {
     // do something else
     ...


### PR DESCRIPTION
I'm 99% sure this is a typo - but correct me if I'm wrong.

Since braces are supposed to go on their own line, I think the example should read like

```
if ( foo ) 
{
  // do something
}
else
{
  // do something else
}
```

not this:

```
if ( foo ) 
{
  // do something
  }else
{
  // do something else
}
```
