### PR TITLE
Allow "order features by value" for relation reference widget

### DIFF
--- a/src/gui/editorwidgets/qgsrelationreferenceconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferenceconfigdlg.cpp
@@ -45,6 +45,11 @@ void QgsRelationReferenceConfigDlg::setConfig( const QMap<QString, QVariant>& co
     mCbxAllowNull->setChecked( config[ "AllowNULL" ].toBool() );
   }
 
+  if ( config.contains( "OrderByValue" ) )
+  {
+    mCbxOrderByValue->setChecked( config[ "OrderByValue" ].toBool() );
+  }
+
   if ( config.contains( "ShowForm" ) )
   {
     mCbxShowForm->setChecked( config[ "ShowForm" ].toBool() );
@@ -84,6 +89,7 @@ QgsEditorWidgetConfig QgsRelationReferenceConfigDlg::config()
 {
   QgsEditorWidgetConfig myConfig;
   myConfig.insert( "AllowNULL", mCbxAllowNull->isChecked() );
+  myConfig.insert( "OrderByValue", mCbxOrderByValue->isChecked() );
   myConfig.insert( "ShowForm", mCbxShowForm->isChecked() );
   myConfig.insert( "MapIdentification", mCbxMapIdentification->isEnabled() && mCbxMapIdentification->isChecked() );
   myConfig.insert( "ReadOnly", mCbxReadOnly->isChecked() );

--- a/src/gui/editorwidgets/qgsrelationreferencefactory.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencefactory.cpp
@@ -42,6 +42,7 @@ QgsEditorWidgetConfig QgsRelationReferenceFactory::readConfig( const QDomElement
   QMap<QString, QVariant> cfg;
 
   cfg.insert( "AllowNULL", configElement.attribute( "AllowNULL" ) == "1" );
+  cfg.insert( "OrderByValue", configElement.attribute( "OrderByValue" ) == "1" );
   cfg.insert( "ShowForm", configElement.attribute( "ShowForm" ) == "1" );
   cfg.insert( "Relation", configElement.attribute( "Relation" ) );
   cfg.insert( "MapIdentification", configElement.attribute( "MapIdentification" ) == "1" );
@@ -57,6 +58,7 @@ void QgsRelationReferenceFactory::writeConfig( const QgsEditorWidgetConfig& conf
   Q_UNUSED( fieldIdx );
 
   configElement.setAttribute( "AllowNULL", config["AllowNULL"].toBool() );
+  configElement.setAttribute( "OrderByValue", config["OrderByValue"].toBool() );
   configElement.setAttribute( "ShowForm", config["ShowForm"].toBool() );
   configElement.setAttribute( "Relation", config["Relation"].toString() );
   configElement.setAttribute( "MapIdentification", config["MapIdentification"].toBool() );

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.h
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.h
@@ -36,6 +36,9 @@ class GUI_EXPORT QgsRelationReferenceWidget : public QWidget
     Q_PROPERTY( bool openFormButtonVisible READ openFormButtonVisible WRITE setOpenFormButtonVisible )
 
   public:
+    typedef QPair < QVariant, QgsFeatureId > ValueRelationItem;
+    typedef QVector < ValueRelationItem > ValueRelationCache;
+
     enum CanvasExtent
     {
       Fixed,
@@ -70,6 +73,11 @@ class GUI_EXPORT QgsRelationReferenceWidget : public QWidget
     //! determines if the widge offers the possibility to select the related feature on the map (using a dedicated map tool)
     bool allowMapIdentification() {return mAllowMapIdentification;}
     void setAllowMapIdentification( bool allowMapIdentification );
+
+    //! If the widget will order the combobox entries by value
+    bool orderByValue() { return mOrderByValue; }
+    //! Set if the widget will order the combobox entries by value
+    void setOrderByValue( bool orderByValue );
 
     //! determines the open form button is visible in the widget
     bool openFormButtonVisible() {return mOpenFormButtonVisible;}
@@ -133,6 +141,7 @@ class GUI_EXPORT QgsRelationReferenceWidget : public QWidget
     bool mEmbedForm;
     bool mReadOnlySelector;
     bool mAllowMapIdentification;
+    bool mOrderByValue;
     bool mOpenFormButtonVisible;
 
     // UI

--- a/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
@@ -48,10 +48,12 @@ void QgsRelationReferenceWidgetWrapper::initWidget( QWidget* editor )
   bool showForm = config( "ShowForm", true ).toBool();
   bool mapIdent = config( "MapIdentification", false ).toBool();
   bool readOnlyWidget = config( "ReadOnly", false ).toBool();
+  bool orderByValue = config( "OrderByValue", false ).toBool();
 
   mWidget->setEmbedForm( showForm );
   mWidget->setReadOnlySelector( readOnlyWidget );
   mWidget->setAllowMapIdentification( mapIdent );
+  mWidget->setOrderByValue( orderByValue );
 
   QgsRelation relation = QgsProject::instance()->relationManager()->relation( config( "Relation" ).toString() );
 

--- a/src/ui/editorwidgets/qgsrelationreferenceconfigdlgbase.ui
+++ b/src/ui/editorwidgets/qgsrelationreferenceconfigdlgbase.ui
@@ -44,24 +44,31 @@
      </property>
     </widget>
    </item>
-   <item row="7" column="0" colspan="2">
+   <item row="8" column="0" colspan="2">
     <widget class="QCheckBox" name="mCbxShowForm">
      <property name="text">
       <string>Show embedded form</string>
      </property>
     </widget>
    </item>
-   <item row="8" column="0" colspan="2">
+   <item row="9" column="0" colspan="2">
     <widget class="QCheckBox" name="mCbxMapIdentification">
      <property name="text">
       <string>On map identification (for geometric layers only)</string>
      </property>
     </widget>
    </item>
-   <item row="9" column="0" colspan="2">
+   <item row="10" column="0" colspan="2">
     <widget class="QCheckBox" name="mCbxReadOnly">
      <property name="text">
       <string>Use a read-only line edit instead of a combobox</string>
+     </property>
+    </widget>
+   </item>
+   <item row="7" column="0" colspan="2">
+    <widget class="QCheckBox" name="mCbxOrderByValue">
+     <property name="text">
+      <string>Order by value</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
This commit allows to order the entries in the combobox for the relation reference widget by their values. This code is strongly based on the concept for the value relation widget that contains the same functionality.

This is an important addon for a cleanwater module that will be released with the 2.8 version of QGIS.
