### PR TITLE
[Qt5] Fix Qt5 build with override specifier

### DIFF
--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -751,11 +751,19 @@ QString QgsMapLayer::lastError()
   return QString();
 }
 
+#if QT_VERSION < 0x050000
 void QgsMapLayer::connectNotify( const char * signal )
 {
   Q_UNUSED( signal );
   QgsDebugMsgLevel( "QgsMapLayer connected to " + QString( signal ), 3 );
-} //  QgsMapLayer::connectNotify
+} // QgsMapLayer::connectNotify
+#else
+void QgsMapLayer::connectNotify( const QMetaMethod &signal )
+{
+  Q_UNUSED( signal );
+  QgsDebugMsgLevel( "QgsMapLayer connected to " + QString( signal.methodSignature() ), 3 );
+} // QgsMapLayer::connectNotify
+#endif
 
 
 

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -26,6 +26,10 @@
 #include <QDomNode>
 #include <QPainter>
 
+#if QT_VERSION >= 0x050000
+#include <QMetaMethod>
+#endif
+
 #include "qgis.h"
 #include "qgserror.h"
 #include "qgsrectangle.h"
@@ -555,7 +559,11 @@ class CORE_EXPORT QgsMapLayer : public QObject
     void writeStyleManager( QDomNode& layerNode, QDomDocument& doc ) const;
 
     /** debugging member - invoked when a connect() is made to this object */
+#if QT_VERSION < 0x050000
     void connectNotify( const char * signal ) override;
+#else
+    void connectNotify( const QMetaMethod &signal ) override;
+#endif
 
     /** Add error message */
     void appendError( const QgsErrorMessage & theMessage ) { mError.append( theMessage );}

--- a/src/core/qgsmaplayerregistry.cpp
+++ b/src/core/qgsmaplayerregistry.cpp
@@ -161,9 +161,16 @@ const QMap<QString, QgsMapLayer*>& QgsMapLayerRegistry::mapLayers()
 }
 
 
-
+#if QT_VERSION < 0x050000
 void QgsMapLayerRegistry::connectNotify( const char * signal )
 {
   Q_UNUSED( signal );
   //QgsDebugMsg("QgsMapLayerRegistry connected to " + QString(signal));
-} //  QgsMapLayerRegistry::connectNotify
+} // QgsMapLayerRegistry::connectNotify
+#else
+void QgsMapLayerRegistry::connectNotify( const QMetaMethod &signal )
+{
+  Q_UNUSED( signal );
+  //QgsDebugMsg("QgsMapLayerRegistry connected to " + QString(signal.methodSignature()));
+} // QgsMapLayerRegistry::connectNotify
+#endif

--- a/src/core/qgsmaplayerregistry.h
+++ b/src/core/qgsmaplayerregistry.h
@@ -24,6 +24,10 @@
 #include <QObject>
 #include <QStringList>
 
+#if QT_VERSION >= 0x050000
+#include <QMetaMethod>
+#endif
+
 #include "qgssingleton.h"
 class QString;
 class QgsMapLayer;
@@ -232,7 +236,11 @@ class CORE_EXPORT QgsMapLayerRegistry : public QObject, public QgsSingleton<QgsM
     /** debugging member
         invoked when a connect() is made to this object
     */
+#if QT_VERSION < 0x050000
     void connectNotify( const char * signal ) override;
+#else
+    void connectNotify( const QMetaMethod &signal ) override;
+#endif
 
   private:
     //! private singleton constructor

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -1624,11 +1624,19 @@ void QgsMapCanvas::setRenderFlag( bool theFlag )
     stopRendering();
 }
 
+#if QT_VERSION < 0x050000
 void QgsMapCanvas::connectNotify( const char * signal )
 {
   Q_UNUSED( signal );
   QgsDebugMsg( "QgsMapCanvas connected to " + QString( signal ) );
 } //connectNotify
+#else
+void QgsMapCanvas::connectNotify( const QMetaMethod &signal )
+{
+  Q_UNUSED( signal );
+  QgsDebugMsg( "QgsMapCanvas connected to " + QString( signal.methodSignature() ) );
+} //connectNotify
+#endif
 
 
 void QgsMapCanvas::updateDatumTransformEntries()

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -590,7 +590,11 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     /**debugging member
        invoked when a connect() is made to this object
     */
+#if QT_VERSION < 0x050000
     void connectNotify( const char * signal ) override;
+#else
+    void connectNotify( const QMetaMethod &signal ) override;
+#endif
 
     //! Make sure the datum transform store is properly populated
     void updateDatumTransformEntries();


### PR DESCRIPTION
QObject::connectNotify( const char \* ) in Qt4 changed to QObject::connectNotify( const QMetaMethod & ) in Qt5.
