### PR TITLE
fix a_nodata parameter in gdal processing

### DIFF
--- a/python/plugins/processing/algs/gdal/ClipByExtent.py
+++ b/python/plugins/processing/algs/gdal/ClipByExtent.py
@@ -49,8 +49,8 @@ class ClipByExtent(GdalAlgorithm):
         self.addParameter(ParameterRaster(
             self.INPUT, self.tr('Input layer'), False))
         self.addParameter(ParameterString(self.NO_DATA,
-            self.tr("Nodata value, leave as 'none' to take the nodata value from input"),
-            'none'))
+            self.tr("Nodata value, leave blank to take the nodata value from input"),
+            ''))
         self.addParameter(ParameterExtent(self.PROJWIN, self.tr('Clipping extent')))
         self.addParameter(ParameterString(self.EXTRA,
             self.tr('Additional creation parameters'), '', optional=True))
@@ -65,8 +65,9 @@ class ClipByExtent(GdalAlgorithm):
         arguments = []
         arguments.append('-of')
         arguments.append(GdalUtils.getFormatShortNameFromFilename(out))
-        arguments.append('-a_nodata')
-        arguments.append(noData)
+        if len(noData) > 0:
+            arguments.append('-a_nodata')
+            arguments.append(noData)
 
         regionCoords = projwin.split(',')
         arguments.append('-projwin')

--- a/python/plugins/processing/algs/gdal/translate.py
+++ b/python/plugins/processing/algs/gdal/translate.py
@@ -68,8 +68,8 @@ class translate(GdalAlgorithm):
         self.addParameter(ParameterBoolean(self.OUTSIZE_PERC,
             self.tr('Output size is a percentage of input size'), True))
         self.addParameter(ParameterString(self.NO_DATA,
-            self.tr("Nodata value, leave as 'none' to take the nodata value from input"),
-            'none'))
+            self.tr("Nodata value, leave blank to take the nodata value from input"),
+            ''))
         self.addParameter(ParameterSelection(self.EXPAND,
             self.tr('Expand'), ['none', 'gray', 'rgb', 'rgba']))
         self.addParameter(ParameterCrs(self.SRS,
@@ -111,8 +111,9 @@ class translate(GdalAlgorithm):
             arguments.append('-outsize')
             arguments.append(outsize)
             arguments.append(outsize)
-        arguments.append('-a_nodata')
-        arguments.append(noData)
+        if len(noData) > 0:
+            arguments.append('-a_nodata')
+            arguments.append(noData)
         if expand != 'none':
             arguments.append('-expand')
             arguments.append(expand)


### PR DESCRIPTION
A couple of comments about this:

1) the gdal manual says about the a_nodata parameter ---> -a_nodata value: Assign a specified nodata value to output bands. Starting with GDAL 1.8.0, can be set to none to avoid setting a nodata value to the output file if one exists for the source file.

This can be misinterpreted because it can seems that to keep the original nodata value it should be used "a_nodata none" but it not true. To keep the original raster nodata no "a_nodata" parameter should be passed to gdal. The tools in the qgis raster menu do this the right way.

2) if in Processing a user removes the default "none" value in an effort to do not pass the "a_nodata" parameter then a pyhton error is thrown, this PR fixes also this

Uncaught error while executing algorithm
Traceback (most recent call last):
Traceback (most recent call last):
  File "/usr/share/qgis/python/plugins/processing/core/GeoAlgorithm.py", line 232, in execute
    self.processAlgorithm(progress)
  File "/usr/share/qgis/python/plugins/processing/algs/gdal/translate.py", line 166, in processAlgorithm
    GdalUtils.escapeAndJoin(arguments)], progress)
  File "/usr/share/qgis/python/plugins/processing/algs/gdal/GdalUtils.py", line 147, in escapeAndJoin
    if s[0] != '-' and ' ' in s:
IndexError: string index out of range
