### PR TITLE
Send travis logs to #qgis-tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ compiler:
 cache: apt
 
 notifications:
-  irc: "chat.freenode.net#qgis"
+  irc: "chat.freenode.net#qgis-tests"
   on_failure: change
   on_success: change
 


### PR DESCRIPTION
Any forks of QGIS will also report status to #qgis which is pretty annoying.

Thought logs in IRC would be a cool idea, turns out not so much ;)
