### PR TITLE
treat PostgreSQL's "xml" field type as string

### DIFF
--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -786,6 +786,7 @@ bool QgsPostgresProvider::loadFields()
                 fieldTypeName == "money" ||
                 fieldTypeName == "ltree" ||
                 fieldTypeName == "uuid" ||
+                fieldTypeName == "xml" ||
                 fieldTypeName.startsWith( "time" ) ||
                 fieldTypeName.startsWith( "date" ) )
       {


### PR DESCRIPTION
Without this change xml columns from PostgreSQL doesn't shown up at all.
