### PR TITLE
Fix fieldsmapper

### DIFF
--- a/python/plugins/processing/algs/qgis/ui/FieldsMappingPanel.py
+++ b/python/plugins/processing/algs/qgis/ui/FieldsMappingPanel.py
@@ -132,7 +132,7 @@ class FieldsMappingModel(QtCore.QAbstractTableModel):
 
             fieldType = column_def['type']
             if fieldType == QtCore.QVariant.Type:
-                if value == 0:
+                if value == QtCore.QVariant.Invalid:
                     return ''
                 return self.fieldTypes[value]
             return value
@@ -277,6 +277,8 @@ class FieldDelegate(QtGui.QStyledItemDelegate):
         fieldType = FieldsMappingModel.columns[column]['type']
         if fieldType == QtCore.QVariant.Type:
             value = editor.itemData(editor.currentIndex())
+            if value is None:
+                value = QtCore.QVariant.Invalid
             model.setData(index, value)
 
         elif fieldType == QgsExpression:

--- a/python/plugins/processing/algs/qgis/ui/FieldsMappingPanel.py
+++ b/python/plugins/processing/algs/qgis/ui/FieldsMappingPanel.py
@@ -243,7 +243,7 @@ class FieldDelegate(QtGui.QStyledItemDelegate):
         elif fieldType == QgsExpression:
             editor = QgsFieldExpressionWidget(parent)
             editor.setLayer(index.model().layer())
-            # editor.fieldChanged.connect(self.on_expression_fieldChange)
+            editor.fieldChanged.connect(self.on_expression_fieldChange)
 
         else:
             editor = QtGui.QStyledItemDelegate.createEditor(self, parent, option, index)
@@ -291,9 +291,8 @@ class FieldDelegate(QtGui.QStyledItemDelegate):
     def updateEditorGeometry(self, editor, option, index):
         editor.setGeometry(option.rect)
 
-    def on_expression_fieldChange(self, fieldName, isValid):
-        # self.commitData.emit(self.sender())
-        pass
+    def on_expression_fieldChange(self, fieldName):
+        self.commitData.emit(self.sender())
 
 
 class FieldsMappingPanel(QtGui.QWidget, Ui_Form):


### PR DESCRIPTION
Fix recent tickets on Processing FieldsMapper algorithm.

http://hub.qgis.org/issues/12182
QgsExpressionWidget editor is not closed automatically like combo and line edit on run clicked.
Workaround by emmiting commitData on QgsExpressionWidget.fieldChanged signal.

http://hub.qgis.org/issues/12183
After edit on field type, if none selected, set model data to QtCore.QVariant.Invalid which is correctly handled in model.data method.
