### PR TITLE
Also handle WhiteToBlack case in QgsSingleBandGrayRenderer::legendSymbologyItems

### DIFF
--- a/src/core/raster/qgssinglebandgrayrenderer.cpp
+++ b/src/core/raster/qgssinglebandgrayrenderer.cpp
@@ -213,8 +213,16 @@ void QgsSingleBandGrayRenderer::legendSymbologyItems( QList< QPair< QString, QCo
 {
   if ( mContrastEnhancement && mContrastEnhancement->contrastEnhancementAlgorithm() != QgsContrastEnhancement::NoEnhancement )
   {
-    symbolItems.push_back( qMakePair( QString::number( mContrastEnhancement->minimumValue() ), QColor( 0, 0, 0 ) ) );
-    symbolItems.push_back( qMakePair( QString::number( mContrastEnhancement->maximumValue() ), QColor( 255, 255, 255 ) ) );
+    if ( mGradient == BlackToWhite )
+    {
+      symbolItems.push_back( qMakePair( QString::number( mContrastEnhancement->minimumValue() ), QColor( 0, 0, 0 ) ) );
+      symbolItems.push_back( qMakePair( QString::number( mContrastEnhancement->maximumValue() ), QColor( 255, 255, 255 ) ) );
+    }
+    else
+    {
+      symbolItems.push_back( qMakePair( QString::number( mContrastEnhancement->minimumValue() ), QColor( 255, 255, 255 ) ) );
+      symbolItems.push_back( qMakePair( QString::number( mContrastEnhancement->maximumValue() ), QColor( 0, 0, 0 ) ) );
+    }
   }
 }
 


### PR DESCRIPTION
The legend for raster layers rendered as singleband gray currently displays black as min and white as max value regardless of the color gradient direction (White to black vs Black to white). This commit fixes this.

Funded by Sourcepole QGIS Enterprise.
