### PR TITLE
Consistently set parent on composer child dialogs

### DIFF
--- a/src/app/composer/qgscomposerarrowwidget.cpp
+++ b/src/app/composer/qgscomposerarrowwidget.cpp
@@ -264,7 +264,7 @@ void QgsComposerArrowWidget::on_mStartMarkerToolButton_clicked()
     openDir = s.value( "/UI/lastComposerMarkerDir", "" ).toString();
   }
 
-  QString svgFileName = QFileDialog::getOpenFileName( 0, tr( "Start marker svg file" ), openDir );
+  QString svgFileName = QFileDialog::getOpenFileName( this, tr( "Start marker svg file" ), openDir );
   if ( !svgFileName.isNull() )
   {
     QFileInfo fileInfo( svgFileName );
@@ -291,7 +291,7 @@ void QgsComposerArrowWidget::on_mEndMarkerToolButton_clicked()
     openDir = s.value( "/UI/lastComposerMarkerDir", "" ).toString();
   }
 
-  QString svgFileName = QFileDialog::getOpenFileName( 0, tr( "End marker svg file" ), openDir );
+  QString svgFileName = QFileDialog::getOpenFileName( this, tr( "End marker svg file" ), openDir );
   if ( !svgFileName.isNull() )
   {
     QFileInfo fileInfo( svgFileName );
@@ -310,7 +310,7 @@ void QgsComposerArrowWidget::on_mLineStyleButton_clicked()
   }
 
   QgsLineSymbolV2* newSymbol = dynamic_cast<QgsLineSymbolV2*>( mArrow->lineSymbol()->clone() );
-  QgsSymbolV2SelectorDialog d( newSymbol, QgsStyleV2::defaultStyle(), 0 );
+  QgsSymbolV2SelectorDialog d( newSymbol, QgsStyleV2::defaultStyle(), 0, this );
 
   if ( d.exec() == QDialog::Accepted )
   {

--- a/src/app/composer/qgscomposerattributetablewidget.cpp
+++ b/src/app/composer/qgscomposerattributetablewidget.cpp
@@ -182,7 +182,7 @@ void QgsComposerAttributeTableWidget::on_mAttributesPushButton_clicked()
   //temporarily block updates for the window, to stop table trying to repaint under windows (#11462)
   window()->setUpdatesEnabled( false );
 
-  QgsAttributeSelectionDialog d( mComposerTable, mComposerTable->sourceLayer(), 0 );
+  QgsAttributeSelectionDialog d( mComposerTable, mComposerTable->sourceLayer(), this );
   if ( d.exec() == QDialog::Accepted )
   {
     mComposerTable->refreshAttributes();
@@ -290,9 +290,9 @@ void QgsComposerAttributeTableWidget::on_mHeaderFontPushButton_clicked()
   bool ok;
 #if defined(Q_OS_MAC) && defined(QT_MAC_USE_COCOA)
   // Native Mac dialog works only for Qt Carbon
-  QFont newFont = QFontDialog::getFont( &ok, mComposerTable->headerFont(), 0, tr( "Select Font" ), QFontDialog::DontUseNativeDialog );
+  QFont newFont = QFontDialog::getFont( &ok, mComposerTable->headerFont(), this, tr( "Select Font" ), QFontDialog::DontUseNativeDialog );
 #else
-  QFont newFont = QFontDialog::getFont( &ok, mComposerTable->headerFont(), 0, tr( "Select Font" ) );
+  QFont newFont = QFontDialog::getFont( &ok, mComposerTable->headerFont(), this, tr( "Select Font" ) );
 #endif
   if ( ok )
   {
@@ -338,9 +338,9 @@ void QgsComposerAttributeTableWidget::on_mContentFontPushButton_clicked()
   bool ok;
 #if defined(Q_OS_MAC) && defined(QT_MAC_USE_COCOA)
   // Native Mac dialog works only for Qt Carbon
-  QFont newFont = QFontDialog::getFont( &ok, mComposerTable->contentFont(), 0, tr( "Select Font" ), QFontDialog::DontUseNativeDialog );
+  QFont newFont = QFontDialog::getFont( &ok, mComposerTable->contentFont(), this, tr( "Select Font" ), QFontDialog::DontUseNativeDialog );
 #else
-  QFont newFont = QFontDialog::getFont( &ok, mComposerTable->contentFont(), 0, tr( "Select Font" ) );
+  QFont newFont = QFontDialog::getFont( &ok, mComposerTable->contentFont(), this, tr( "Select Font" ) );
 #endif
   if ( ok )
   {
@@ -575,7 +575,7 @@ void QgsComposerAttributeTableWidget::updateRelationsCombo()
   if ( atlasLayer )
   {
     QList<QgsRelation> relations = QgsProject::instance()->relationManager()->referencedRelations( atlasLayer );
-    Q_FOREACH ( const QgsRelation& relation, relations )
+    Q_FOREACH( const QgsRelation& relation, relations )
     {
       mRelationsComboBox->addItem( relation.name(), relation.id() );
     }

--- a/src/app/composer/qgscomposerlabelwidget.cpp
+++ b/src/app/composer/qgscomposerlabelwidget.cpp
@@ -93,9 +93,9 @@ void QgsComposerLabelWidget::on_mFontButton_clicked()
     bool ok;
 #if defined(Q_OS_MAC) && defined(QT_MAC_USE_COCOA)
     // Native Mac dialog works only for Qt Carbon
-    QFont newFont = QFontDialog::getFont( &ok, mComposerLabel->font(), 0, QString(), QFontDialog::DontUseNativeDialog );
+    QFont newFont = QFontDialog::getFont( &ok, mComposerLabel->font(), this, QString(), QFontDialog::DontUseNativeDialog );
 #else
-    QFont newFont = QFontDialog::getFont( &ok, mComposerLabel->font() );
+    QFont newFont = QFontDialog::getFont( &ok, mComposerLabel->font(), this );
 #endif
     if ( ok )
     {

--- a/src/app/composer/qgscomposerlegendwidget.cpp
+++ b/src/app/composer/qgscomposerlegendwidget.cpp
@@ -371,9 +371,9 @@ void QgsComposerLegendWidget::on_mTitleFontButton_clicked()
     bool ok;
 #if defined(Q_OS_MAC) && defined(QT_MAC_USE_COCOA)
     // Native Mac dialog works only for Qt Carbon
-    QFont newFont = QFontDialog::getFont( &ok, mLegend->style( QgsComposerLegendStyle::Title ).font(), 0, QString(), QFontDialog::DontUseNativeDialog );
+    QFont newFont = QFontDialog::getFont( &ok, mLegend->style( QgsComposerLegendStyle::Title ).font(), this, QString(), QFontDialog::DontUseNativeDialog );
 #else
-    QFont newFont = QFontDialog::getFont( &ok, mLegend->style( QgsComposerLegendStyle::Title ).font() );
+    QFont newFont = QFontDialog::getFont( &ok, mLegend->style( QgsComposerLegendStyle::Title ).font(), this );
 #endif
     if ( ok )
     {
@@ -393,9 +393,9 @@ void QgsComposerLegendWidget::on_mGroupFontButton_clicked()
     bool ok;
 #if defined(Q_OS_MAC) && defined(QT_MAC_USE_COCOA)
     // Native Mac dialog works only for Qt Carbon
-    QFont newFont = QFontDialog::getFont( &ok, mLegend->style( QgsComposerLegendStyle::Group ).font(), 0, QString(), QFontDialog::DontUseNativeDialog );
+    QFont newFont = QFontDialog::getFont( &ok, mLegend->style( QgsComposerLegendStyle::Group ).font(), this, QString(), QFontDialog::DontUseNativeDialog );
 #else
-    QFont newFont = QFontDialog::getFont( &ok, mLegend->style( QgsComposerLegendStyle::Group ).font() );
+    QFont newFont = QFontDialog::getFont( &ok, mLegend->style( QgsComposerLegendStyle::Group ).font(), this );
 #endif
     if ( ok )
     {
@@ -415,9 +415,9 @@ void QgsComposerLegendWidget::on_mLayerFontButton_clicked()
     bool ok;
 #if defined(Q_OS_MAC) && defined(QT_MAC_USE_COCOA)
     // Native Mac dialog works only for Qt Carbon
-    QFont newFont = QFontDialog::getFont( &ok, mLegend->style( QgsComposerLegendStyle::Subgroup ).font(), 0, QString(), QFontDialog::DontUseNativeDialog );
+    QFont newFont = QFontDialog::getFont( &ok, mLegend->style( QgsComposerLegendStyle::Subgroup ).font(), this, QString(), QFontDialog::DontUseNativeDialog );
 #else
-    QFont newFont = QFontDialog::getFont( &ok, mLegend->style( QgsComposerLegendStyle::Subgroup ).font() );
+    QFont newFont = QFontDialog::getFont( &ok, mLegend->style( QgsComposerLegendStyle::Subgroup ).font(), this );
 #endif
     if ( ok )
     {
@@ -437,9 +437,9 @@ void QgsComposerLegendWidget::on_mItemFontButton_clicked()
     bool ok;
 #if defined(Q_OS_MAC) && defined(QT_MAC_USE_COCOA)
     // Native Mac dialog works only for Qt Carbon
-    QFont newFont = QFontDialog::getFont( &ok, mLegend->style( QgsComposerLegendStyle::SymbolLabel ).font(), 0, QString(), QFontDialog::DontUseNativeDialog );
+    QFont newFont = QFontDialog::getFont( &ok, mLegend->style( QgsComposerLegendStyle::SymbolLabel ).font(), this, QString(), QFontDialog::DontUseNativeDialog );
 #else
-    QFont newFont = QFontDialog::getFont( &ok, mLegend->style( QgsComposerLegendStyle::SymbolLabel ).font() );
+    QFont newFont = QFontDialog::getFont( &ok, mLegend->style( QgsComposerLegendStyle::SymbolLabel ).font(), this );
 #endif
     if ( ok )
     {
@@ -652,7 +652,7 @@ void QgsComposerLegendWidget::on_mAddToolButton_clicked()
   {
     QList<QgsMapLayer*> layers = canvas->layers();
 
-    QgsComposerLegendLayersDialog addDialog( layers );
+    QgsComposerLegendLayersDialog addDialog( layers, this );
     if ( addDialog.exec() == QDialog::Accepted )
     {
       QgsMapLayer* layer = addDialog.selectedLayer();

--- a/src/app/composer/qgscomposermapwidget.cpp
+++ b/src/app/composer/qgscomposermapwidget.cpp
@@ -1556,7 +1556,7 @@ void QgsComposerMapWidget::on_mGridLineStyleButton_clicked()
   }
 
   QgsLineSymbolV2* newSymbol = dynamic_cast<QgsLineSymbolV2*>( grid->lineSymbol()->clone() );
-  QgsSymbolV2SelectorDialog d( newSymbol, QgsStyleV2::defaultStyle(), 0 );
+  QgsSymbolV2SelectorDialog d( newSymbol, QgsStyleV2::defaultStyle(), 0, this );
 
   if ( d.exec() == QDialog::Accepted )
   {
@@ -1581,7 +1581,7 @@ void QgsComposerMapWidget::on_mGridMarkerStyleButton_clicked()
   }
 
   QgsMarkerSymbolV2* newSymbol = dynamic_cast<QgsMarkerSymbolV2*>( grid->markerSymbol()->clone() );
-  QgsSymbolV2SelectorDialog d( newSymbol, QgsStyleV2::defaultStyle(), 0 );
+  QgsSymbolV2SelectorDialog d( newSymbol, QgsStyleV2::defaultStyle(), 0, this );
 
   if ( d.exec() == QDialog::Accepted )
   {
@@ -2088,9 +2088,9 @@ void QgsComposerMapWidget::on_mAnnotationFontButton_clicked()
   bool ok;
 #if defined(Q_OS_MAC) && QT_VERSION >= 0x040500 && defined(QT_MAC_USE_COCOA)
   // Native Mac dialog works only for Qt Carbon
-  QFont newFont = QFontDialog::getFont( &ok, grid->annotationFont(), 0, QString(), QFontDialog::DontUseNativeDialog );
+  QFont newFont = QFontDialog::getFont( &ok, grid->annotationFont(), this, QString(), QFontDialog::DontUseNativeDialog );
 #else
-  QFont newFont = QFontDialog::getFont( &ok, grid->annotationFont() );
+  QFont newFont = QFontDialog::getFont( &ok, grid->annotationFont(), this );
 #endif
   if ( ok )
   {
@@ -2561,7 +2561,7 @@ void QgsComposerMapWidget::on_mOverviewFrameStyleButton_clicked()
   }
 
   QgsFillSymbolV2* newSymbol = dynamic_cast<QgsFillSymbolV2*>( overview->frameSymbol()->clone() );
-  QgsSymbolV2SelectorDialog d( newSymbol, QgsStyleV2::defaultStyle(), 0 );
+  QgsSymbolV2SelectorDialog d( newSymbol, QgsStyleV2::defaultStyle(), 0, this );
 
   if ( d.exec() == QDialog::Accepted )
   {

--- a/src/app/composer/qgscomposerpicturewidget.cpp
+++ b/src/app/composer/qgscomposerpicturewidget.cpp
@@ -90,7 +90,7 @@ void QgsComposerPictureWidget::on_mPictureBrowseButton_clicked()
   }
 
   //show file dialog
-  QString filePath = QFileDialog::getOpenFileName( 0, tr( "Select svg or image file" ), openDir );
+  QString filePath = QFileDialog::getOpenFileName( this, tr( "Select svg or image file" ), openDir );
   if ( filePath.isEmpty() )
   {
     return;
@@ -165,7 +165,7 @@ void QgsComposerPictureWidget::on_mPreviewListWidget_currentItemChanged( QListWi
 void QgsComposerPictureWidget::on_mAddDirectoryButton_clicked()
 {
   //let user select a directory
-  QString directory = QFileDialog::getExistingDirectory( 0, tr( "Select new preview directory" ) );
+  QString directory = QFileDialog::getExistingDirectory( this, tr( "Select new preview directory" ) );
   if ( directory.isNull() )
   {
     return; //dialog canceled by user

--- a/src/app/composer/qgscomposerscalebarwidget.cpp
+++ b/src/app/composer/qgscomposerscalebarwidget.cpp
@@ -313,9 +313,9 @@ void QgsComposerScaleBarWidget::on_mFontButton_clicked()
   QFont oldFont = mComposerScaleBar->font();
 #if defined(Q_OS_MAC) && defined(QT_MAC_USE_COCOA)
   // Native Mac dialog works only for Qt Carbon
-  QFont newFont = QFontDialog::getFont( &dialogAccepted, oldFont, 0, QString(), QFontDialog::DontUseNativeDialog );
+  QFont newFont = QFontDialog::getFont( &dialogAccepted, oldFont, this, QString(), QFontDialog::DontUseNativeDialog );
 #else
-  QFont newFont = QFontDialog::getFont( &dialogAccepted, oldFont, 0 );
+  QFont newFont = QFontDialog::getFont( &dialogAccepted, oldFont, this );
 #endif
   if ( dialogAccepted )
   {

--- a/src/app/composer/qgscomposershapewidget.cpp
+++ b/src/app/composer/qgscomposershapewidget.cpp
@@ -108,7 +108,7 @@ void QgsComposerShapeWidget::on_mShapeStyleButton_clicked()
   QgsVectorLayer* coverageLayer = atlasCoverageLayer();
 
   QgsFillSymbolV2* newSymbol = dynamic_cast<QgsFillSymbolV2*>( mComposerShape->shapeStyleSymbol()->clone() );
-  QgsSymbolV2SelectorDialog d( newSymbol, QgsStyleV2::defaultStyle(), coverageLayer );
+  QgsSymbolV2SelectorDialog d( newSymbol, QgsStyleV2::defaultStyle(), coverageLayer, this );
 
   if ( d.exec() == QDialog::Accepted )
   {

--- a/src/app/composer/qgscomposertablewidget.cpp
+++ b/src/app/composer/qgscomposertablewidget.cpp
@@ -132,7 +132,7 @@ void QgsComposerTableWidget::on_mAttributesPushButton_clicked()
 
   mComposerTable->beginCommand( tr( "Table attribute settings" ) );
 
-  QgsAttributeSelectionDialog d( mComposerTable, mComposerTable->vectorLayer(), 0 );
+  QgsAttributeSelectionDialog d( mComposerTable, mComposerTable->vectorLayer(), this );
   if ( d.exec() == QDialog::Accepted )
   {
     mComposerTable->refreshAttributes();
@@ -217,9 +217,9 @@ void QgsComposerTableWidget::on_mHeaderFontPushButton_clicked()
   bool ok;
 #if defined(Q_OS_MAC) && defined(QT_MAC_USE_COCOA)
   // Native Mac dialog works only for Qt Carbon
-  QFont newFont = QFontDialog::getFont( &ok, mComposerTable->headerFont(), 0, tr( "Select Font" ), QFontDialog::DontUseNativeDialog );
+  QFont newFont = QFontDialog::getFont( &ok, mComposerTable->headerFont(), this, tr( "Select Font" ), QFontDialog::DontUseNativeDialog );
 #else
-  QFont newFont = QFontDialog::getFont( &ok, mComposerTable->headerFont(), 0, tr( "Select Font" ) );
+  QFont newFont = QFontDialog::getFont( &ok, mComposerTable->headerFont(), this, tr( "Select Font" ) );
 #endif
   if ( ok )
   {
@@ -252,9 +252,9 @@ void QgsComposerTableWidget::on_mContentFontPushButton_clicked()
   bool ok;
 #if defined(Q_OS_MAC) && defined(QT_MAC_USE_COCOA)
   // Native Mac dialog works only for Qt Carbon
-  QFont newFont = QFontDialog::getFont( &ok, mComposerTable->contentFont(), 0, tr( "Select Font" ), QFontDialog::DontUseNativeDialog );
+  QFont newFont = QFontDialog::getFont( &ok, mComposerTable->contentFont(), this, tr( "Select Font" ), QFontDialog::DontUseNativeDialog );
 #else
-  QFont newFont = QFontDialog::getFont( &ok, mComposerTable->contentFont(), 0, tr( "Select Font" ) );
+  QFont newFont = QFontDialog::getFont( &ok, mComposerTable->contentFont(), this, tr( "Select Font" ) );
 #endif
   if ( ok )
   {

--- a/src/app/composer/qgscompositionwidget.cpp
+++ b/src/app/composer/qgscompositionwidget.cpp
@@ -531,7 +531,7 @@ void QgsCompositionWidget::on_mPageStyleButton_clicked()
   {
     newSymbol = new QgsFillSymbolV2();
   }
-  QgsSymbolV2SelectorDialog d( newSymbol, QgsStyleV2::defaultStyle(), coverageLayer );
+  QgsSymbolV2SelectorDialog d( newSymbol, QgsStyleV2::defaultStyle(), coverageLayer, this );
 
   if ( d.exec() == QDialog::Accepted )
   {


### PR DESCRIPTION
Various child dialogs in the composer window do not set the parent. This commit fixes this.

Funded by Sourcepole QGIS Enterprise
