### PR TITLE
Cast attribute values to text in QgsPostgresProvider::uniqueValues

### DIFF
--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -1262,7 +1262,7 @@ void QgsPostgresProvider::uniqueValues( int index, QList<QVariant> &uniqueValues
     // get the field name
     const QgsField &fld = field( index );
     QString sql = QString( "SELECT DISTINCT %1 FROM %2" )
-                  .arg( quotedIdentifier( fld.name() ) )
+                  .arg( quotedIdentifier( fld.name() ) + "::text" )
                   .arg( mQuery );
 
     if ( !mSqlWhereClause.isEmpty() )


### PR DESCRIPTION
In Postgres, fields of type `character` are padded up to the specified with with values. When retrieving these field values, if they are casted to text via `::text`, Postgres strips the trailing spaces, otherwise they are preserved.

In `QgsPostgresProvider::getFeatures` (via `QgsPostgresFeatureIterator::QgsPostgresFeatureIterator` -> `QgsPostgresFeatureIterator::declareCursor` -> `QgsPostgresConn::fieldExpression`), the `::text` cast is included in the query, in `QgsPostgresProvider::uniqueValues` however it is not. This breaks the categorized renderer, since the category keys are obtained via `QgsPostgresProvider::uniqueValues`, while the feature field values are obtained via `QgsPostgresProvider::getFeatures`, hence i.e. for a `character(4)` field, the category key might be `foo<space>` but the field value which should match is `foo`, without trailing space.

Funded by Sourcepole QGIS Enterprise.
