### PR TITLE
[memory layer] improve data source uid to be unique across different sessions

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -63,6 +63,7 @@
 #include <QtGlobal>
 #include <QTimer>
 #include <QToolButton>
+#include <QUuid>
 #include <QVBoxLayout>
 #include <QWhatsThis>
 #include <QThread>
@@ -6343,8 +6344,7 @@ QgsVectorLayer *QgisApp::pasteToNewMemoryVector()
 
   QString typeName = QString( QGis::featureType( wkbType ) ).replace( "WKB", "" );
 
-  static int pastedFeatureLayers = 0;
-  typeName += QString( "?memoryid=pasted_features%1" ).arg( ++pastedFeatureLayers );
+  typeName += QString( "?memoryid=%1" ).arg( QUuid::createUuid().toString() );
 
   QgsDebugMsg( QString( "output wkbType = %1 typeName = %2" ).arg( wkbType ).arg( typeName ) );
 

--- a/src/gui/qgsnewmemorylayerdialog.cpp
+++ b/src/gui/qgsnewmemorylayerdialog.cpp
@@ -26,6 +26,7 @@
 #include <QComboBox>
 #include <QLibrary>
 #include <QSettings>
+#include <QUuid>
 #include <QFileDialog>
 
 QgsVectorLayer *QgsNewMemoryLayerDialog::runAndCreateLayer( QWidget *parent )
@@ -64,8 +65,7 @@ QgsVectorLayer *QgsNewMemoryLayerDialog::runAndCreateLayer( QWidget *parent )
       geomType = "point";
   }
 
-  static int createScratchLayers = 0;
-  QString layerProperties = QString( "%1?crs=%2&memoryid=scratchlayer%3" ).arg( geomType ).arg( crsId ).arg( ++createScratchLayers );
+  QString layerProperties = QString( "%1?crs=%2&memoryid=%3" ).arg( geomType ).arg( crsId ).arg( QUuid::createUuid().toString() );
   QString name = dialog.layerName().isEmpty() ? tr( "New scratch layer" ) : dialog.layerName();
   QgsVectorLayer* newLayer = new QgsVectorLayer( layerProperties, name, QString( "memory" ) );
   return newLayer;

--- a/src/plugins/roadgraph/exportdlg.cpp
+++ b/src/plugins/roadgraph/exportdlg.cpp
@@ -15,6 +15,7 @@
 #include <qcombobox.h>
 #include <QHBoxLayout>
 #include <QVBoxLayout>
+#include <QUuid>
 #include <qdialogbuttonbox.h>
 #include <qmessagebox.h>
 
@@ -76,8 +77,7 @@ QgsVectorLayer* RgExportDlg::mapLayer() const
   if ( layerId == QString( "-1" ) )
   {
     // create a temporary layer
-    static int createdLayers = 0;
-    myLayer = new QgsVectorLayer( QString( "LineString?crs=epsg:4326&memoryid=rglayer%1" ).arg( ++createdLayers ), "shortest path", "memory" );
+    myLayer = new QgsVectorLayer( QString( "LineString?crs=epsg:4326&memoryid=%1" ).arg( QUuid::createUuid().toString() ), "shortest path", "memory" );
 
     QgsVectorDataProvider *prov = myLayer->dataProvider();
     if ( prov == NULL )


### PR DESCRIPTION
@jef-n , building on the fix you applied yesterday, I've changed the static int counter to a QUuid string. That way, the data source uri of new memory layers created across sessions (i.e. when qgis is re-opened) will remain unique. That's important for people who keep memory layers across sessions using the memory layer saver plugin.
