### PR TITLE
Allow provider-level filtering on layers with joined fields

### DIFF
--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -148,7 +148,7 @@ QMenu* QgsAppLayerTreeViewMenuProvider::createContextMenu()
         menu->addAction( tr( "Save As..." ), QgisApp::instance(), SLOT( saveAsFile() ) );
         menu->addAction( tr( "Save As Layer Definition File..." ), QgisApp::instance(), SLOT( saveAsLayerDefinition() ) );
 
-        if ( !vlayer->isEditable() && vlayer->dataProvider()->supportsSubsetString() && vlayer->vectorJoins().isEmpty() )
+        if ( !vlayer->isEditable() && vlayer->dataProvider()->supportsSubsetString() )
           menu->addAction( tr( "&Filter..." ), QgisApp::instance(), SLOT( layerSubsetString() ) );
 
         menu->addAction( actions->actionShowFeatureCount( menu ) );

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -306,7 +306,7 @@ void QgsVectorLayerProperties::toggleEditing()
   emit toggleEditing( layer );
 
   pbnQueryBuilder->setEnabled( layer->dataProvider() && layer->dataProvider()->supportsSubsetString() &&
-                               !layer->isEditable() && layer->vectorJoins().size() < 1 );
+                               !layer->isEditable() );
   if ( layer->isEditable() )
   {
     pbnQueryBuilder->setToolTip( tr( "Stop editing mode to enable this." ) );
@@ -392,7 +392,7 @@ void QgsVectorLayerProperties::syncToLayer( void )
   // a mechanism to check it must be implemented.
   txtSubsetSQL->setEnabled( false );
   pbnQueryBuilder->setEnabled( layer->dataProvider() && layer->dataProvider()->supportsSubsetString() &&
-                               !layer->isEditable() && layer->vectorJoins().size() < 1 );
+                               !layer->isEditable() );
   if ( layer->isEditable() )
   {
     pbnQueryBuilder->setToolTip( tr( "Stop editing mode to enable this." ) );
@@ -1060,7 +1060,7 @@ void QgsVectorLayerProperties::on_mButtonAddJoin_clicked()
       layer->addJoin( info );
       addJoinToTreeWidget( info );
       pbnQueryBuilder->setEnabled( layer && layer->dataProvider() && layer->dataProvider()->supportsSubsetString() &&
-                                   !layer->isEditable() && layer->vectorJoins().size() < 1 );
+                                   !layer->isEditable() );
     }
     mFieldsPropertiesDialog->init();
   }
@@ -1108,7 +1108,7 @@ void QgsVectorLayerProperties::on_mButtonRemoveJoin_clicked()
   layer->removeJoin( currentJoinItem->data( 0, Qt::UserRole ).toString() );
   mJoinTreeWidget->takeTopLevelItem( mJoinTreeWidget->indexOfTopLevelItem( currentJoinItem ) );
   pbnQueryBuilder->setEnabled( layer && layer->dataProvider() && layer->dataProvider()->supportsSubsetString() &&
-                               !layer->isEditable() && layer->vectorJoins().size() < 1 );
+                               !layer->isEditable() );
   mFieldsPropertiesDialog->init();
 }
 

--- a/src/gui/qgsquerybuilder.cpp
+++ b/src/gui/qgsquerybuilder.cpp
@@ -72,6 +72,11 @@ void QgsQueryBuilder::populateFields()
   const QgsFields& fields = mLayer->pendingFields();
   for ( int idx = 0; idx < fields.count(); ++idx )
   {
+    if ( fields.fieldOrigin(idx) != QgsFields::OriginProvider )
+    {
+      // only consider native fields
+      continue;
+    }
     QStandardItem *myItem = new QStandardItem( fields[idx].name() );
     myItem->setData( idx );
     myItem->setEditable( false );


### PR DESCRIPTION
Restrict QgsQueryBuilder to list fields of the provider (no joined fields, no virtual fields) and enable menu items in GUI to allow for filtering.
So that we can filter layers with joins, but only on "main" fields (not on joined fields)
