### PR TITLE
Fix reshape tool not working on polygons when first/last node is involved

### DIFF
--- a/src/core/qgsgeometry.cpp
+++ b/src/core/qgsgeometry.cpp
@@ -5172,7 +5172,7 @@ GEOSGeometry* QgsGeometry::reshapeLine( const GEOSGeometry* line, const GEOSGeom
       currentGeomOverlapsReshapeLine = true;
 
     //logic to decide if this part belongs to the result
-    if ( nEndpointsSameAsOriginalLine == 1 && nEndpointsOnOriginalLine == 2 && currentGeomOverlapsOriginalGeom )
+    if ( !isRing && nEndpointsSameAsOriginalLine == 1 && nEndpointsOnOriginalLine == 2 && currentGeomOverlapsOriginalGeom )
     {
       resultLineParts.push_back( GEOSGeom_clone_r( geosinit.ctxt, currentGeom ) );
     }


### PR DESCRIPTION
Fix reshape tool not working on polygons when first/last node is involved.

Funded by Sourcepole QGIS Enterprise
