### PR TITLE
Update README.md with complete licence info

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,9 +18,9 @@ daily GIS data viewing and editing needs. QGIS supports a number of raster
 and vector data formats, with new support easily added using the plugin
 architecture.
 
-QGIS is released under the GNU Public License (GPL) Version 2. Developing
-QGIS under this license means that you can (if you want to) inspect and
-modify the source code and guarantees that you, our happy user will always
+QGIS is released under the GNU Public License (GPL) Version 2 or above.
+Developing QGIS under this license means that you can (if you want to) inspect
+and modify the source code and guarantees that you, our happy user will always
 have access to a GIS program that is free of cost and can be freely
 modified.
 


### PR DESCRIPTION
The actual QGIS licence (viewable in any source file, e.g. src/core/qgis.cpp) shows that the software is licenced under GPL version 2 "or (at your option) any later version".

This PR updates README.md to remove the current potential confusion that may lead to some users believing QGIS is GPL version 2 only.
