### PR TITLE
Smoothing algorithm for geometries

### DIFF
--- a/python/core/qgsgeometry.sip
+++ b/python/core/qgsgeometry.sip
@@ -341,6 +341,17 @@ class QgsGeometry
 
     /** Returns a simplified version of this geometry using a specified tolerance value */
     QgsGeometry* simplify( double tolerance ) /Factory/;
+    
+    /**Smooths a geometry by rounding off corners using the Chaikin algorithm. This operation
+     * roughly doubles the number of vertices in a geometry.
+     * @param iterations number of smoothing iterations to run. More iterations results
+     * in a smoother geometry
+     * @param offset fraction of line to create new vertices along, between 0 and 1.0
+     * eg the default value of 0.25 will create new vertices 25% and 75% along each line segment
+     * of the geometry for each iteration. Smaller values result in "tighter" smoothing.
+     * @note added in 2.9
+     */
+    QgsGeometry* smooth( const unsigned int iterations = 1, const double offset = 0.25 ) /Factory/;
 
     /** Returns the center of mass of a geometry
     * @note for line based geometries, the center point of the line is returned,
@@ -353,7 +364,7 @@ class QgsGeometry
     /** Returns the smallest convex polygon that contains all the points in the geometry. */
     QgsGeometry* convexHull() /Factory/;
 
-    /* Return interpolated point on line at distance */
+    /** Return interpolated point on line at distance */
     QgsGeometry* interpolate( double distance ) /Factory/;
 
     /** Returns a geometry representing the points shared by this geometry and other. */

--- a/src/core/qgsgeometry.cpp
+++ b/src/core/qgsgeometry.cpp
@@ -5797,6 +5797,116 @@ QgsGeometry* QgsGeometry::simplify( double tolerance )
   CATCH_GEOS( 0 )
 }
 
+QgsGeometry* QgsGeometry::smooth( const unsigned int iterations, const double offset )
+{
+  switch ( wkbType() )
+  {
+    case QGis::WKBPoint:
+    case QGis::WKBPoint25D:
+    case QGis::WKBMultiPoint:
+    case QGis::WKBMultiPoint25D:
+      //can't smooth a point based geometry
+      return new QgsGeometry( *this );
+
+    case QGis::WKBLineString:
+    case QGis::WKBLineString25D:
+    {
+      QgsPolyline line = asPolyline();
+      return QgsGeometry::fromPolyline( smoothLine( line, iterations, offset ) );
+    }
+
+    case QGis::WKBMultiLineString:
+    case QGis::WKBMultiLineString25D:
+    {
+      QgsMultiPolyline multiline = asMultiPolyline();
+      QgsMultiPolyline resultMultiline;
+      QgsMultiPolyline::const_iterator lineIt = multiline.constBegin();
+      for ( ; lineIt != multiline.constEnd(); ++lineIt )
+      {
+        resultMultiline << smoothLine( *lineIt, iterations, offset );
+      }
+      return QgsGeometry::fromMultiPolyline( resultMultiline );
+    }
+
+    case QGis::WKBPolygon:
+    case QGis::WKBPolygon25D:
+    {
+      QgsPolygon poly = asPolygon();
+      return QgsGeometry::fromPolygon( smoothPolygon( poly, iterations, offset ) );
+    }
+
+    case QGis::WKBMultiPolygon:
+    case QGis::WKBMultiPolygon25D:
+    {
+      QgsMultiPolygon multipoly = asMultiPolygon();
+      QgsMultiPolygon resultMultipoly;
+      QgsMultiPolygon::const_iterator polyIt = multipoly.constBegin();
+      for ( ; polyIt != multipoly.constEnd(); ++polyIt )
+      {
+        resultMultipoly << smoothPolygon( *polyIt, iterations, offset );
+      }
+      return QgsGeometry::fromMultiPolygon( resultMultipoly );
+    }
+    break;
+
+    case QGis::WKBUnknown:
+    default:
+      return new QgsGeometry( *this );
+  }
+}
+
+inline QgsPoint interpolatePointOnLine( const QgsPoint& p1, const QgsPoint& p2, const double offset )
+{
+  double deltaX = p2.x() - p1.x();
+  double deltaY = p2.y() - p1.y();
+  return QgsPoint( p1.x() + deltaX * offset, p1.y() + deltaY * offset );
+}
+
+QgsPolyline QgsGeometry::smoothLine( const QgsPolyline& polyline, const unsigned int iterations, const double offset ) const
+{
+  QgsPolyline result = polyline;
+  for ( unsigned int iteration = 0; iteration < iterations; ++iteration )
+  {
+    QgsPolyline outputLine = QgsPolyline();
+    for ( int i = 0; i < result.count() - 1; i++ )
+    {
+      const QgsPoint& p1 = result.at( i );
+      const QgsPoint& p2 = result.at( i + 1 );
+      outputLine << ( i == 0 ? result.at( i ) : interpolatePointOnLine( p1, p2, offset ) );
+      outputLine << ( i == result.count() - 2 ? result.at( i + 1 ) : interpolatePointOnLine( p1, p2, 1.0 - offset ) );
+    }
+    result = outputLine;
+  }
+  return result;
+}
+
+QgsPolygon QgsGeometry::smoothPolygon( const QgsPolygon& polygon, const unsigned int iterations, const double offset ) const
+{
+  QgsPolygon resultPoly;
+  QgsPolygon::const_iterator ringIt = polygon.constBegin();
+  for ( ; ringIt != polygon.constEnd(); ++ringIt )
+  {
+    QgsPolyline resultRing = *ringIt;
+    for ( unsigned int iteration = 0; iteration < iterations; ++iteration )
+    {
+      QgsPolyline outputRing = QgsPolyline();
+      for ( int i = 0; i < resultRing.count() - 1; ++i )
+      {
+        const QgsPoint& p1 = resultRing.at( i );
+        const QgsPoint& p2 = resultRing.at( i + 1 );
+        outputRing << interpolatePointOnLine( p1, p2, offset );
+        outputRing << interpolatePointOnLine( p1, p2, 1.0 - offset );
+      }
+      //close polygon
+      outputRing << outputRing.at( 0 );
+
+      resultRing = outputRing;
+    }
+    resultPoly << resultRing;
+  }
+  return resultPoly;
+}
+
 QgsGeometry* QgsGeometry::centroid()
 {
   if ( mDirtyGeos )

--- a/src/core/qgsgeometry.h
+++ b/src/core/qgsgeometry.h
@@ -384,6 +384,17 @@ class CORE_EXPORT QgsGeometry
     /** Returns a simplified version of this geometry using a specified tolerance value */
     QgsGeometry* simplify( double tolerance );
 
+    /**Smooths a geometry by rounding off corners using the Chaikin algorithm. This operation
+     * roughly doubles the number of vertices in a geometry.
+     * @param iterations number of smoothing iterations to run. More iterations results
+     * in a smoother geometry
+     * @param offset fraction of line to create new vertices along, between 0 and 1.0
+     * eg the default value of 0.25 will create new vertices 25% and 75% along each line segment
+     * of the geometry for each iteration. Smaller values result in "tighter" smoothing.
+     * @note added in 2.9
+     */
+    QgsGeometry* smooth( const unsigned int iterations = 1, const double offset = 0.25 );
+
     /** Returns the center of mass of a geometry
     * @note for line based geometries, the center point of the line is returned,
     * and for point based geometries, the point itself is returned */
@@ -395,7 +406,7 @@ class CORE_EXPORT QgsGeometry
     /** Returns the smallest convex polygon that contains all the points in the geometry. */
     QgsGeometry* convexHull();
 
-    /* Return interpolated point on line at distance */
+    /** Return interpolated point on line at distance */
     QgsGeometry* interpolate( double distance );
 
     /** Returns a geometry representing the points shared by this geometry and other. */
@@ -619,6 +630,11 @@ class CORE_EXPORT QgsGeometry
     @param reshapeLineGeos the reshape line
     @return the reshaped polygon or 0 in case of error*/
     static GEOSGeometry* reshapePolygon( const GEOSGeometry* polygon, const GEOSGeometry* reshapeLineGeos );
+
+    /**Smooths a polygon using the Chaikin algorithm*/
+    QgsPolygon smoothPolygon( const QgsPolygon &polygon, const unsigned int iterations = 1, const double offset = 0.25 ) const;
+    /**Smooths a polyline using the Chaikin algorithm*/
+    QgsPolyline smoothLine( const QgsPolyline &polyline, const unsigned int iterations = 1, const double offset = 0.25 ) const;
 
     /**Nodes together a split line and a (multi-) polygon geometry in a multilinestring
      @return the noded multiline geometry or 0 in case of error. The calling function takes ownership of the node geometry*/


### PR DESCRIPTION
Adds a new "smooth" method to QgsGeometry, which implements the Chaikin smoothing algorithm for polylines/polygons.

Backend changes only for now, but if accepted I'll integrate this method into the existing simplify tool.
