### PR TITLE
Suppress attribute feature form if no fields in layer

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -3899,6 +3899,7 @@ void QgisApp::newMemoryLayer()
     layers << newLayer;
 
     QgsMapLayerRegistry::instance()->addMapLayers( layers );
+    newLayer->startEditing();
   }
 }
 

--- a/src/app/qgsfeatureaction.cpp
+++ b/src/app/qgsfeatureaction.cpp
@@ -163,8 +163,10 @@ bool QgsFeatureAction::addFeature( const QgsAttributeMap& defaultAttributes, boo
     mFeature.setAttribute( idx, v );
   }
 
-  // show the dialog to enter attribute values
-  bool isDisabledAttributeValuesDlg = settings.value( "/qgis/digitizing/disable_enter_attribute_values_dialog", false ).toBool();
+  //show the dialog to enter attribute values
+  //only show if enabled in settings and layer has fields
+  bool isDisabledAttributeValuesDlg = ( fields.count() == 0 ) || settings.value( "/qgis/digitizing/disable_enter_attribute_values_dialog", false ).toBool();
+
   // override application-wide setting with any layer setting
   switch ( mLayer->featureFormSuppress() )
   {


### PR DESCRIPTION
This change prevents an empty form popup for layers with no fields (eg memory layers). If desired, this behaviour can be overriden by the layer's feature form suppress option, eg if form has python logic which makes it useful even with no fields. 

The change was discussed in https://hub.qgis.org/issues/10775 and set as wontfix at the time, but I believe that by respecting the layer's feature form suppress option we don't lose any functionality by this change. If acceptable I will backport this fix to 2.8 too.

(also includes a tiny change to make the scratch layer editable by default)
