### PR TITLE
Add dependency on libqgis-server to libqgis-dev.

### DIFF
--- a/debian/control.in
+++ b/debian/control.in
@@ -224,6 +224,7 @@ Depends:
  libqgis-gui{QGIS_ABI} (= ${binary:Version}),
  libqgis-analysis{QGIS_ABI} (= ${binary:Version}),
  libqgis-networkanalysis{QGIS_ABI} (= ${binary:Version}),
+ libqgis-server{QGIS_ABI} (= ${binary:Version}),
  libqgisgrass{QGIS_ABI} (= ${binary:Version}),
  libqgispython{QGIS_ABI} (= ${binary:Version}),
  libqt4-dev (>= 4.7.0),


### PR DESCRIPTION
Another small Debian packaging fix, adding the new libqgis-server to libqgis-dev too, to fix a broken .so symlink.
