### PR TITLE
Fix #12257 - allow creation of expression field on delimited text layer

### DIFF
--- a/src/app/qgsfieldcalculator.cpp
+++ b/src/app/qgsfieldcalculator.cpp
@@ -158,7 +158,11 @@ void QgsFieldCalculator::accept()
     return;
   }
 
-  if ( mNewFieldGroupBox->isChecked() && mCreateVirtualFieldCheckbox->isChecked() )
+  // Test for creating expression field based on ! mUpdateExistingGroupBox checked rather
+  // than on mNewFieldGroupBox checked, as if the provider does not support adding attributes
+  // then mUpdateExistingGroupBox is set to not checkable, and hence is not checked.  This
+  // is a minimum fix to resolve this - better would be some GUI redesign...
+  if ( ! mUpdateExistingGroupBox->isChecked() && mCreateVirtualFieldCheckbox->isChecked() )
   {
     mVectorLayer->addExpressionField( calcString, fieldDefinition() );
   }


### PR DESCRIPTION
This is a minimal fix to allow creating virtual expression attributes on delimited text layers (or layers for any other provider that does not allow adding new fields).  Could be improved with a minor GUI redesign - but this at least is a functional fix.

Please backport to 2.8 if approved..
