### PR TITLE
Update Debian package copyright file.

### DIFF
--- a/debian/copyright
+++ b/debian/copyright
@@ -91,7 +91,6 @@ Copyright:                   Carl Anderson
                        2014, Michael Douchin
                        2014, Niccolo' Marchi <sciurusurbanus@hotmail.it>
                        2014, Radoslaw Guzinski <rmgu@dhi-gras.com>
-                       2015, Tom Kralidis <tomkralidis@gmail.com>
        2004-2006, 2009-2015, Radim Blazek <blazek@itc.it>
                   2005-2015, Martin Dobias <wonder.sk@gmail.com>
                   2012-2015, Victor Olaya <volayaf@gmail.com>
@@ -101,6 +100,7 @@ Copyright:                   Carl Anderson
                   2014-2015, Arnaud Morvan <arnaud.morvan@camptocamp.com>
                   2014-2015, Sandro Mani <manisandro@gmail.com>
                   2014-2015, Sandro Santilli <strk@keybit.net>
+                  2014-2015, Tom Kralidis <tomkralidis@gmail.com>
                        2015, Michael Kirk <michael.john.kirk@gmail.com>
 License: GPL-2+
 


### PR DESCRIPTION
Update copyright years for Tom Kralidis, because MetaSearch is (C) 2014.

The 2015 changes are not reflected in the copyright statements in the source though.
