### PR TITLE
better quotes in processing/ogr import to postgis tools

### DIFF
--- a/python/plugins/processing/algs/gdal/ogr2ogrtabletopostgislist.py
+++ b/python/plugins/processing/algs/gdal/ogr2ogrtabletopostgislist.py
@@ -88,7 +88,7 @@ class Ogr2OgrTableToPostGisList(OgrAlgorithm):
             self.tr('Primary key (existing field, used if the above option is left empty)'),
             self.INPUT_LAYER, optional=True))
         self.addParameter(ParameterString(self.WHERE,
-            self.tr('Select features using a SQL "WHERE" statement (Ex: column="value")'),
+            self.tr('Select features using a SQL "WHERE" statement (Ex: column=\'value\')'),
             '', optional=True))
         self.addParameter(ParameterString(self.GT,
             self.tr('Group N features per transaction (Default: 20000)'),
@@ -128,7 +128,7 @@ class Ogr2OgrTableToPostGisList(OgrAlgorithm):
         pkstring = "-lco FID="+pk
         primary_key = self.getParameterValue(self.PRIMARY_KEY)
         where = unicode(self.getParameterValue(self.WHERE))
-        wherestring = "-where '"+where+"'"
+        wherestring = '-where "'+where+'"'
         gt = unicode(self.getParameterValue(self.GT))
         overwrite = self.getParameterValue(self.OVERWRITE)
         append = self.getParameterValue(self.APPEND)

--- a/python/plugins/processing/algs/gdal/ogr2ogrtabletopostgislist.py
+++ b/python/plugins/processing/algs/gdal/ogr2ogrtabletopostgislist.py
@@ -70,7 +70,7 @@ class Ogr2OgrTableToPostGisList(OgrAlgorithm):
         return settings.childGroups()
 
     def defineCharacteristics(self):
-        self.name = 'Import layer/table as table into PostGIS database (available connections)'
+        self.name = 'Import layer/table as geometryless table into PostgreSQL database'
         self.group = '[OGR] Miscellaneous'
         self.DB_CONNECTIONS = self.dbConnectionNames()
         self.addParameter(ParameterSelection(self.DATABASE,

--- a/python/plugins/processing/algs/gdal/ogr2ogrtopostgis.py
+++ b/python/plugins/processing/algs/gdal/ogr2ogrtopostgis.py
@@ -122,7 +122,7 @@ class Ogr2OgrToPostGis(OgrAlgorithm):
             self.tr('Clip the input layer using the above (rectangle) extent'),
             False))
         self.addParameter(ParameterString(self.WHERE,
-            self.tr('Select features using a SQL "WHERE" statement (Ex: column="value")'),
+            self.tr('Select features using a SQL "WHERE" statement (Ex: column=\'value\')'),
             '', optional=True))
         self.addParameter(ParameterString(self.GT,
             self.tr('Group N features per transaction (Default: 20000)'),
@@ -175,7 +175,7 @@ class Ogr2OgrToPostGis(OgrAlgorithm):
         ogrspat = self.ogrConnectionString(spat)
         clip = self.getParameterValue(self.CLIP)
         where = unicode(self.getParameterValue(self.WHERE))
-        wherestring = "-where '"+where+"'"
+        wherestring = '-where "'+where+'"'
         gt = unicode(self.getParameterValue(self.GT))
         overwrite = self.getParameterValue(self.OVERWRITE)
         append = self.getParameterValue(self.APPEND)

--- a/python/plugins/processing/algs/gdal/ogr2ogrtopostgislist.py
+++ b/python/plugins/processing/algs/gdal/ogr2ogrtopostgislist.py
@@ -124,7 +124,7 @@ class Ogr2OgrToPostGisList(OgrAlgorithm):
             self.tr('Clip the input layer using the above (rectangle) extent'),
             False))
         self.addParameter(ParameterString(self.WHERE,
-            self.tr('Select features using a SQL "WHERE" statement (Ex: column="value")'),
+            self.tr('Select features using a SQL "WHERE" statement (Ex: column=\'value\')'),
             '', optional=True))
         self.addParameter(ParameterString(self.GT,
             self.tr('Group N features per transaction (Default: 20000)'),
@@ -181,7 +181,7 @@ class Ogr2OgrToPostGisList(OgrAlgorithm):
         ogrspat = self.ogrConnectionString(spat)
         clip = self.getParameterValue(self.CLIP)
         where = unicode(self.getParameterValue(self.WHERE))
-        wherestring = "-where '"+where+"'"
+        wherestring = '-where "'+where+'"'
         gt = unicode(self.getParameterValue(self.GT))
         overwrite = self.getParameterValue(self.OVERWRITE)
         append = self.getParameterValue(self.APPEND)


### PR DESCRIPTION
Double quotes of  "where" clauses (ex: column="value") in ogr2ogr will not be valid anymore from GDAL 2.0.

See https://trac.osgeo.org/gdal/wiki/rfc52_strict_sql_quoting

Thanks to Even Rouault for spotting this.
