### PR TITLE
Fix SpatialIndex include

### DIFF
--- a/src/core/qgspointlocator.cpp
+++ b/src/core/qgspointlocator.cpp
@@ -18,7 +18,7 @@
 #include "qgsgeometry.h"
 #include "qgsvectorlayer.h"
 
-#include <spatialindex/SpatialIndex.h>
+#include "SpatialIndex.h"
 
 #include <QLinkedListIterator>
 

--- a/src/core/qgspointlocator.h
+++ b/src/core/qgspointlocator.h
@@ -23,9 +23,12 @@ class QgsVectorLayer;
 #include "qgspoint.h"
 #include "qgsrectangle.h"
 
-
-#include <spatialindex/SpatialIndex.h>
-
+// forward declaration
+namespace SpatialIndex
+{
+  class IStorageManager;
+  class ISpatialIndex;
+}
 
 class QgsCoordinateTransform;
 class QgsCoordinateReferenceSystem;


### PR DESCRIPTION
This fix compilation of qgis_gui/qgis_app/qgis when using libSpatialIndex in different directory (not system) and its include dir not added to this subprojects like in qgis_core (src/core/CMakeLists.txt:661).
