### PR TITLE
Don't keep dangling pointers in QgisApp::mPrintComposers

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5667,7 +5667,7 @@ bool QgisApp::loadComposersFromProject( const QDomDocument& doc )
 void QgisApp::deletePrintComposers()
 {
   QSet<QgsComposer*>::iterator it = mPrintComposers.begin();
-  for ( ; it != mPrintComposers.end(); ++it )
+  while ( it != mPrintComposers.end() )
   {
     emit composerWillBeRemoved(( *it )->view() );
 
@@ -5683,8 +5683,8 @@ void QgisApp::deletePrintComposers()
     {
       delete composition;
     }
+    it = mPrintComposers.erase( it );
   }
-  mPrintComposers.clear();
   mLastComposerId = 0;
   markDirty();
 }


### PR DESCRIPTION
When composers are removed in `QgisApp::deletePrintComposers`, for each composer the `composerWillBeRemoved` signal is emitted and the composer deleted, but the (at that point dangling) pointer to the composer is not removed until all composers are deleted.

If the list of composers (i.e. through `iface.activeComposers()`) is queried as a reaction to `composerWillBeRemoved` while the composers are being deleted, that list will contain dangling pointers if there is more than one composer in the list.
