### PR TITLE
Decrease the number of round-trips to the postgres server when reading and creating fields

### DIFF
--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -455,6 +455,14 @@ class QgsPostgresProvider : public QgsVectorDataProvider
       QString mWhat;
     };
 
+    struct PGTypeInfo
+    {
+      QString typeName;
+      QString typeType;
+      QString typeElem;
+      int typeLen;
+    };
+
     // A function that determines if the given schema.table.column
     // contains unqiue entries
     bool uniqueData( QString query, QString colName );


### PR DESCRIPTION
Currently `QgsPostgresProvider::loadFields` executes three queries per attribute, these can be reduced to just three overall.

Similarly, when adding attributes in `QgsPostgresProvider::addAttributes`, all columns can be added in one single query instead of running one query for each column to add. (For comments, however, it seems that one query per column is the only way).

For a dataset with 200 fields, doing a `QgsVectorLayerImport` over a decently fast internet connection now takes 4 seconds instead of 45.

Funded by Sourcepole.
