### PR TITLE
Don't build internal pyspatialite on Debian jessie & sid

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -69,7 +69,7 @@ ifneq (,$(filter parallel=%,$(DEB_BUILD_OPTIONS)))
 	MAKEFLAGS += -j$(NUMJOBS)
 endif
 
-ifneq (,$(findstring $(DISTRIBUTION),"wheezy jessie sid precise"))
+ifneq (,$(findstring $(DISTRIBUTION),"wheezy precise"))
 	CMAKE_OPTS += -DWITH_PYSPATIALITE=TRUE
 endif
 


### PR DESCRIPTION
On Debian jessie & sid among others the python-pyspatialite package is used instead of the copy included in QGIS.

The rules file built the internal pyspatialite on jessie & sid despite the availability of the package via the python-qgis dependencies.

The inclusion of pyspatialite in python-qgis triggered an upgrade problem reported by Andreas Beckmann in [Debian Bug #779933](https://bugs.debian.org/779933).
