### PR TITLE
Fix FTBFS on arm* by casting doubles to qreal.

### DIFF
--- a/src/app/qgsdecorationgrid.cpp
+++ b/src/app/qgsdecorationgrid.cpp
@@ -605,7 +605,7 @@ int QgsDecorationGrid::xGridLines( QList< QPair< double, QLineF > >& lines ) con
     QLineF line( p0, p1 );
     clipByRect( line, canvasPoly );
     line = QLineF( m2p.transform( QgsPoint( line.pointAt( 0 ) ) ).toQPointF(), m2p.transform( QgsPoint( line.pointAt( 1 ) ) ).toQPointF() );
-    lines.push_back( qMakePair( p0.y(), line ) );
+    lines.push_back( qMakePair( (double)p0.y(), line ) );
     dist += mGridIntervalY;
   }
 
@@ -652,7 +652,7 @@ int QgsDecorationGrid::yGridLines( QList< QPair< double, QLineF > >& lines ) con
     QLineF line( p0, p1 );
     clipByRect( line, canvasPoly );
     line = QLineF( m2p.transform( QgsPoint( line.pointAt( 0 ) ) ).toQPointF(), m2p.transform( QgsPoint( line.pointAt( 1 ) ) ).toQPointF() );
-    lines.push_back( qMakePair( p0.x(), line ) );
+    lines.push_back( qMakePair( (double)p0.x(), line ) );
     dist += mGridIntervalX;
   }
 

--- a/src/app/qgsmapmouseevent.cpp
+++ b/src/app/qgsmapmouseevent.cpp
@@ -86,8 +86,8 @@ void QgsMapMouseEvent::snapPoint()
 
 QPoint QgsMapMouseEvent::mapToPixelCoordinates( QgsMapCanvas* canvas, const QgsPoint& point )
 {
-  double x = point.x();
-  double y = point.y();
+  qreal x = point.x();
+  qreal y = point.y();
 
   canvas->mapSettings().mapToPixel().transformInPlace( x, y );
 

--- a/src/core/composer/qgscomposermapgrid.cpp
+++ b/src/core/composer/qgscomposermapgrid.cpp
@@ -1886,10 +1886,10 @@ QgsComposerMapGrid::BorderSide QgsComposerMapGrid::borderForLineCoord( const QPo
 
   //otherwise, guess side based on closest map side to point
   QList< QPair<double, QgsComposerMapGrid::BorderSide > > distanceToSide;
-  distanceToSide << qMakePair( p.x(), QgsComposerMapGrid::Left );
-  distanceToSide << qMakePair( mComposerMap->rect().width() - p.x(), QgsComposerMapGrid::Right );
-  distanceToSide << qMakePair( p.y(), QgsComposerMapGrid::Top );
-  distanceToSide << qMakePair( mComposerMap->rect().height() - p.y(), QgsComposerMapGrid::Bottom );
+  distanceToSide << qMakePair( (double)p.x(), QgsComposerMapGrid::Left );
+  distanceToSide << qMakePair( (double)(mComposerMap->rect().width() - p.x()), QgsComposerMapGrid::Right );
+  distanceToSide << qMakePair( (double)p.y(), QgsComposerMapGrid::Top );
+  distanceToSide << qMakePair( (double)(mComposerMap->rect().height() - p.y()), QgsComposerMapGrid::Bottom );
 
   qSort( distanceToSide.begin(), distanceToSide.end(), sortByDistance );
   return distanceToSide.at( 0 ).second;

--- a/src/core/qgsgeometry.cpp
+++ b/src/core/qgsgeometry.cpp
@@ -4683,7 +4683,13 @@ void QgsGeometry::transformVertex( QgsWkbPtr &wkbPtr, const QTransform& trans, b
 
   QgsWkbPtr tmp = wkbPtr;
   tmp >> x >> y;
-  trans.map( x, y, &rotated_x, &rotated_y );
+
+  qreal qx = (qreal) x;
+  qreal qy = (qreal) y;
+  qreal qrx = (qreal) rotated_x;
+  qreal qry = (qreal) rotated_y;
+
+  trans.map( qx, qy, &qrx, &qry );
   wkbPtr << rotated_x << rotated_y;
 
   if ( hasZValue )

--- a/src/core/qgsmaptopixel.cpp
+++ b/src/core/qgsmaptopixel.cpp
@@ -124,7 +124,16 @@ QgsPoint QgsMapToPixel::toMapPoint( double x, double y ) const
   QTransform matrix = mMatrix.inverted( &invertible );
   assert( invertible );
   double mx, my;
-  matrix.map( x, y, &mx, &my );
+
+  qreal qx = (qreal) x;
+  qreal qy = (qreal) y;
+  qreal qmx, qmy;
+
+  matrix.map( qx, qy, &qmx, &qmy );
+
+  mx = (double) qmx;
+  my = (double) qmy;
+
   QgsPoint ret( mx, my );
 
   //QgsDebugMsg(QString("XXX toMapPoint x:%1 y:%2 -> x:%3 y:%4").arg(x).arg(y).arg(mx).arg(my));
@@ -238,7 +247,14 @@ QString QgsMapToPixel::showParameters() const
 
 QgsPoint QgsMapToPixel::transform( double x, double y ) const
 {
-  transformInPlace( x, y );
+  qreal qx = (qreal) x;
+  qreal qy = (qreal) y;
+
+  transformInPlace( qx, qy );
+  
+  x = (double) qx;
+  y = (double) qy;
+
   return QgsPoint( x, y );
 }
 
@@ -246,7 +262,14 @@ QgsPoint QgsMapToPixel::transform( const QgsPoint& p ) const
 {
   double dx = p.x();
   double dy = p.y();
-  transformInPlace( dx, dy );
+  
+  qreal qdx = (qreal) dx;
+  qreal qdy = (qreal) dy;
+
+  transformInPlace( qdx, qdy );
+
+  dx = (double) qdx;
+  dy = (double) qdy;
 
 // QgsDebugMsg(QString("Point to pixel...X : %1-->%2, Y: %3 -->%4").arg(p.x()).arg(dx).arg(p.y()).arg(dy));
   return QgsPoint( dx, dy );
@@ -256,7 +279,14 @@ void QgsMapToPixel::transform( QgsPoint* p ) const
 {
   double x = p->x();
   double y = p->y();
-  transformInPlace( x, y );
+
+  qreal qx = (qreal) x;
+  qreal qy = (qreal) y;
+
+  transformInPlace( qx, qy );
+
+  x = (double) qx;
+  y = (double) qy;
 
 #ifdef QGISDEBUG
 // QgsDebugMsg(QString("Point to pixel...X : %1-->%2, Y: %3 -->%4").arg(p->x()).arg(x).arg(p->y()).arg(y));
@@ -267,7 +297,7 @@ void QgsMapToPixel::transform( QgsPoint* p ) const
 void QgsMapToPixel::transformInPlace( qreal& x, qreal& y ) const
 {
   // Map 2 Pixel
-  double mx, my;
+  qreal mx, my;
   mMatrix.map( x, y, &mx, &my );
   //QgsDebugMsg(QString("XXX transformInPlace X : %1-->%2, Y: %3 -->%4").arg(x).arg(mx).arg(y).arg(my));
   x = mx; y = my;

--- a/src/core/qgspallabeling.cpp
+++ b/src/core/qgspallabeling.cpp
@@ -2106,7 +2106,16 @@ void QgsPalLayerSettings::registerFeature( QgsFeature& f, const QgsRenderContext
           t.rotate( -m2p.mapRotation() );
           t.translate( -center.x(), -center.y() );
           double xPosR, yPosR;
-          t.map( xPos, yPos, &xPosR, &yPosR );
+
+          qreal qxPos = (qreal) xPos;
+          qreal qyPos = (qreal) yPos;
+          qreal qxPosR, qyPosR;
+
+          t.map( qxPos, qyPos, &qxPosR, &qyPosR );
+
+          xPosR = (double) qxPosR;
+          yPosR = (double) qyPosR;
+
           xPos = xPosR; yPos = yPosR;
         }
 

--- a/src/core/symbology-ng/qgsrendererv2.cpp
+++ b/src/core/symbology-ng/qgsrendererv2.cpp
@@ -53,7 +53,10 @@ const unsigned char* QgsFeatureRendererV2::_getPoint( QPointF& pt, QgsRenderCont
     context.coordinateTransform()->transformInPlace( x, y, z );
   }
 
-  context.mapToPixel().transformInPlace( x, y );
+  qreal qx = (qreal) x;
+  qreal qy = (qreal) y;
+
+  context.mapToPixel().transformInPlace( qx, qy );
 
   pt = QPointF( x, y );
   return wkbPtr;

--- a/src/gui/qgsmapcanvasitem.cpp
+++ b/src/gui/qgsmapcanvasitem.cpp
@@ -63,7 +63,7 @@ QgsPoint QgsMapCanvasItem::toMapCoordinates( const QPoint& point ) const
 
 QPointF QgsMapCanvasItem::toCanvasCoordinates( const QgsPoint& point ) const
 {
-  double x = point.x(), y = point.y();
+  qreal x = point.x(), y = point.y();
   mMapCanvas->getCoordinateTransform()->transformInPlace( x, y );
   return QPointF( x, y ) + mPanningOffset;
 }

--- a/src/gui/qgsmaptool.cpp
+++ b/src/gui/qgsmaptool.cpp
@@ -68,7 +68,7 @@ QgsRectangle QgsMapTool::toLayerCoordinates( QgsMapLayer* layer, const QgsRectan
 
 QPoint QgsMapTool::toCanvasCoordinates( const QgsPoint& point )
 {
-  double x = point.x(), y = point.y();
+  qreal x = point.x(), y = point.y();
   mCanvas->getCoordinateTransform()->transformInPlace( x, y );
   return QPoint( qRound( x ), qRound( y ) );
 }


### PR DESCRIPTION
In qt4 on arm architectures qreal is defined as float while on other
architectures it is defined as double.

While these changes fix the build failure, I'm pretty sure it's not a
fully proper patch. Please review carefully.
