### PR TITLE
Removed RangePanel spinboxes range limit

### DIFF
--- a/python/plugins/processing/gui/RangePanel.py
+++ b/python/plugins/processing/gui/RangePanel.py
@@ -47,11 +47,13 @@ class RangePanel(QWidget, Ui_Form):
         self.spnMin.setValue(minVal)
         self.spnMax.setValue(maxVal)
 
-        self.spnMin.setMaximum(maxVal)
-        self.spnMin.setMinimum(minVal)
+        # TODO: Set a better default range (0-1 as default can be problematic)
 
-        self.spnMax.setMaximum(maxVal)
-        self.spnMax.setMinimum(minVal)
+        # self.spnMin.setMaximum(maxVal)
+        # self.spnMin.setMinimum(minVal)
+
+        # self.spnMax.setMaximum(maxVal)
+        # self.spnMax.setMinimum(minVal)
 
     def getValue(self):
         return '{},{}'.format(self.spnMin.value(), self.spnMax.value())


### PR DESCRIPTION
Some plugins (r.rescale.eq from grass for example) do not specify min and max values.
The current code sets the min and max values of the spinbox to the values of the param.default parameter (0 and 1).
Because of this, these plugins have range parameters stuck between 0 and 1, which is not as intended.

I think the param.default parameter should be used to set the default values of the spinboxes, but not the range limit. Or the default range should be unlimited instead of 0-1.

![grass_r rescale eq](https://cloud.githubusercontent.com/assets/2394008/6598877/c41b21a4-c806-11e4-83f6-705f3673c1aa.png)
