### PR TITLE
Treat NULL values as empty strings in expression concatenation operator

### DIFF
--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -2233,7 +2233,7 @@ QVariant QgsExpression::NodeBinaryOperator::eval( QgsExpression* parent, const Q
   switch ( mOp )
   {
     case boPlus:
-      if ( vL.type() == QVariant::String && vR.type() == QVariant::String )
+      if ( vL.type() == QVariant::String || vR.type() == QVariant::String )
       {
         QString sL = getStringValue( vL, parent ); ENSURE_NO_EVAL_ERROR;
         QString sR = getStringValue( vR, parent ); ENSURE_NO_EVAL_ERROR;


### PR DESCRIPTION
Currently, if either of the two operands to the concatenation operator `||` are NULL, the expression evaluates to an empty value.

It has been suggested that null operands should simply evaluate to empty strings, and hence the non-null values are preserved in the evaluated expression.

I suppose this makes sense, some people might have other opinions though.

Funded by Sourcepole QGIS Enterprise
