### PR TITLE
Relation reference widget: Pre-filters

### DIFF
--- a/src/gui/attributetable/qgsattributetablefiltermodel.h
+++ b/src/gui/attributetable/qgsattributetablefiltermodel.h
@@ -52,6 +52,13 @@ class GUI_EXPORT QgsAttributeTableFilterModel: public QSortFilterProxyModel, pub
      */
     QgsAttributeTableFilterModel( QgsMapCanvas* canvas, QgsAttributeTableModel* sourceModel, QObject* parent = 0 );
 
+    /**
+     * Set the attribute table model that backs this model
+     *
+     * @param sourceModel The model
+     *
+     * @note added in 2.0
+     */
     void setSourceModel( QgsAttributeTableModel* sourceModel );
 
     /**
@@ -77,6 +84,11 @@ class GUI_EXPORT QgsAttributeTableFilterModel: public QSortFilterProxyModel, pub
      */
     virtual void setFilteredFeatures( QgsFeatureIds ids );
 
+    /**
+     * Get a list of currently filtered feature ids
+     *
+     * @return A list of feature ids
+     */
     QgsFeatureIds filteredFeatures();
 
     /**
@@ -86,6 +98,11 @@ class GUI_EXPORT QgsAttributeTableFilterModel: public QSortFilterProxyModel, pub
      */
     void setFilterMode( FilterMode filterMode );
 
+    /**
+     * The current filterModel
+     *
+     * @return Mode
+     */
     FilterMode filterMode() { return mFilterMode; }
 
     /**
@@ -125,6 +142,15 @@ class GUI_EXPORT QgsAttributeTableFilterModel: public QSortFilterProxyModel, pub
 
     virtual QModelIndex mapFromMaster( const QModelIndex &sourceIndex ) const;
 
+    /**
+     * Sort by the given column using the given order.
+     * Prefetches all the data from the layer to speed up sorting.
+     *
+     * @param column The column which should be sorted
+     * @param order  The order ( Qt::AscendingOrder or Qt::DescendingOrder )
+     */
+    virtual void sort( int column, Qt::SortOrder order = Qt::AscendingOrder ) override;
+
   protected:
     /**
      * Returns true if the source row will be accepted
@@ -145,15 +171,6 @@ class GUI_EXPORT QgsAttributeTableFilterModel: public QSortFilterProxyModel, pub
      * selection state of the feature in case selected features are to be shown on top.
      */
     bool lessThan( const QModelIndex &left, const QModelIndex &right ) const override;
-
-    /**
-     * Sort by the given column using the given order.
-     * Prefetches all the data from the layer to speed up sorting.
-     *
-     * @param column The column which should be sorted
-     * @param order  The order ( Qt::AscendingOrder or Qt::DescendingOrder )
-     */
-    virtual void sort( int column, Qt::SortOrder order = Qt::AscendingOrder ) override;
 
   public slots:
     /**

--- a/src/gui/attributetable/qgsfeaturelistmodel.h
+++ b/src/gui/attributetable/qgsfeaturelistmodel.h
@@ -46,6 +46,20 @@ class GUI_EXPORT QgsFeatureListModel : public QAbstractProxyModel, public QgsFea
     virtual QVariant data( const QModelIndex& index, int role ) const override;
     virtual Qt::ItemFlags flags( const QModelIndex& index ) const override;
 
+    /**
+     * @brief If true is specified, a NULL value will be injected
+     * @param injectNull state of null value injection
+     * @note added in 2.9
+     */
+    void setInjectNull( bool injectNull );
+
+    /**
+     * @brief Returns the current state of null value injection
+     * @return If a NULL value is added
+     * @note added in 2.9
+     */
+    bool injectNull();
+
     QgsAttributeTableModel* masterModel();
 
     /**
@@ -94,6 +108,7 @@ class GUI_EXPORT QgsFeatureListModel : public QAbstractProxyModel, public QgsFea
     QgsExpression* mExpression;
     QgsAttributeTableFilterModel* mFilterModel;
     QString mParserErrorString;
+    bool mInjectNull;
 };
 
 Q_DECLARE_METATYPE( QgsFeatureListModel::FeatureInfo )

--- a/src/gui/editorwidgets/qgsrelationreferenceconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferenceconfigdlg.cpp
@@ -22,8 +22,10 @@
 #include "qgsvectorlayer.h"
 #include "qgsexpressionbuilderdialog.h"
 
+
 QgsRelationReferenceConfigDlg::QgsRelationReferenceConfigDlg( QgsVectorLayer* vl, int fieldIdx, QWidget* parent )
     : QgsEditorConfigWidget( vl, fieldIdx, parent )
+    , mReferencedLayer( 0 )
 {
   setupUi( this );
   connect( mComboRelation, SIGNAL( currentIndexChanged( int ) ), this, SLOT( relationChanged( int ) ) );
@@ -58,6 +60,7 @@ void QgsRelationReferenceConfigDlg::setConfig( const QMap<QString, QVariant>& co
   if ( config.contains( "Relation" ) )
   {
     mComboRelation->setCurrentIndex( mComboRelation->findData( config[ "Relation" ].toString() ) );
+    relationChanged( mComboRelation->currentIndex() );
   }
 
   if ( config.contains( "MapIdentification" ) )
@@ -69,6 +72,15 @@ void QgsRelationReferenceConfigDlg::setConfig( const QMap<QString, QVariant>& co
   {
     mCbxReadOnly->setChecked( config[ "ReadOnly"].toBool() );
   }
+
+  if ( config.contains( "FilterFields" ) )
+  {
+    mFilterGroupBox->setChecked( true );
+    Q_FOREACH ( const QString& fld, config["FilterFields"].toStringList() )
+    {
+      addFilterField( fld );
+    }
+  }
 }
 
 void QgsRelationReferenceConfigDlg::relationChanged( int idx )
@@ -76,12 +88,31 @@ void QgsRelationReferenceConfigDlg::relationChanged( int idx )
   QString relName = mComboRelation->itemData( idx ).toString();
   QgsRelation rel = QgsProject::instance()->relationManager()->relation( relName );
 
-  QgsVectorLayer* referencedLayer = rel.referencedLayer();
-  mExpressionWidget->setLayer( referencedLayer ); // set even if 0
-  if ( referencedLayer )
+  mReferencedLayer = rel.referencedLayer();
+  mExpressionWidget->setLayer( mReferencedLayer ); // set even if 0
+  if ( mReferencedLayer )
   {
-    mExpressionWidget->setField( referencedLayer->displayExpression() );
-    mCbxMapIdentification->setEnabled( referencedLayer->hasGeometryType() );
+    mExpressionWidget->setField( mReferencedLayer->displayExpression() );
+    mCbxMapIdentification->setEnabled( mReferencedLayer->hasGeometryType() );
+  }
+
+  loadFields();
+}
+
+void QgsRelationReferenceConfigDlg::on_mAddFilterButton_clicked()
+{
+  Q_FOREACH ( QListWidgetItem* item, mAvailableFieldsList->selectedItems() )
+  {
+    addFilterField( item );
+  }
+}
+
+void QgsRelationReferenceConfigDlg::on_mRemoveFilterButton_clicked()
+{
+  Q_FOREACH ( QListWidgetItem* item , mFilterFieldsList->selectedItems() )
+  {
+    mFilterFieldsList->takeItem( indexFromListWidgetItem( item ) );
+    mAvailableFieldsList->addItem( item );
   }
 }
 
@@ -95,14 +126,68 @@ QgsEditorWidgetConfig QgsRelationReferenceConfigDlg::config()
   myConfig.insert( "ReadOnly", mCbxReadOnly->isChecked() );
   myConfig.insert( "Relation", mComboRelation->itemData( mComboRelation->currentIndex() ) );
 
-  QString relName = mComboRelation->itemData( mComboRelation->currentIndex() ).toString();
-  QgsRelation relation = QgsProject::instance()->relationManager()->relation( relName );
-
-  if ( relation.isValid() )
+  if ( mFilterGroupBox->isChecked() )
   {
-    relation.referencedLayer()->setDisplayExpression( mExpressionWidget->currentField() );
+    QStringList filterFields;
+    for ( int i = 0; i < mFilterFieldsList->count(); i++ )
+    {
+      filterFields << mFilterFieldsList->item( i )->data( Qt::UserRole ).toString();
+    }
+    myConfig.insert( "FilterFields", filterFields );
+  }
+
+  if ( mReferencedLayer )
+  {
+    mReferencedLayer->setDisplayExpression( mExpressionWidget->currentField() );
   }
 
   return myConfig;
 }
 
+void QgsRelationReferenceConfigDlg::loadFields()
+{
+  mAvailableFieldsList->clear();
+  mFilterFieldsList->clear();
+
+  if ( mReferencedLayer )
+  {
+    QgsVectorLayer* l = mReferencedLayer;
+    const QgsFields& flds = l->pendingFields();
+    for ( int i = 0; i < flds.count(); i++ )
+    {
+      mAvailableFieldsList->addItem( l->attributeAlias( i ).isEmpty() ? flds.at( i ).name() : l->attributeAlias( i ) );
+      mAvailableFieldsList->item( mAvailableFieldsList->count() - 1 )->setData( Qt::UserRole, flds.at( i ).name() );
+    }
+  }
+}
+
+void QgsRelationReferenceConfigDlg::addFilterField( const QString& field )
+{
+  for ( int i = 0; i < mAvailableFieldsList->count(); i++ )
+  {
+    if ( mAvailableFieldsList->item( i )->data( Qt::UserRole ).toString() == field )
+    {
+      addFilterField( mAvailableFieldsList->item( i ) );
+      break;
+    }
+  }
+}
+
+void QgsRelationReferenceConfigDlg::addFilterField( QListWidgetItem* item )
+{
+  mAvailableFieldsList->takeItem( indexFromListWidgetItem( item ) );
+  mFilterFieldsList->addItem( item );
+}
+
+int QgsRelationReferenceConfigDlg::indexFromListWidgetItem( QListWidgetItem* item )
+{
+  QListWidget* lw = item->listWidget();
+
+  for ( int i = 0; i < lw->count(); i++ )
+  {
+    if ( lw->item( i ) == item )
+      return i;
+  }
+
+  return -1;
+}

--- a/src/gui/editorwidgets/qgsrelationreferenceconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferenceconfigdlg.cpp
@@ -80,6 +80,8 @@ void QgsRelationReferenceConfigDlg::setConfig( const QMap<QString, QVariant>& co
     {
       addFilterField( fld );
     }
+
+    mCbxChainFilters->setChecked( config["ChainFilters"].toBool() );
   }
 }
 
@@ -134,6 +136,8 @@ QgsEditorWidgetConfig QgsRelationReferenceConfigDlg::config()
       filterFields << mFilterFieldsList->item( i )->data( Qt::UserRole ).toString();
     }
     myConfig.insert( "FilterFields", filterFields );
+
+    myConfig.insert( "ChainFilters", mCbxChainFilters->isChecked() );
   }
 
   if ( mReferencedLayer )

--- a/src/gui/editorwidgets/qgsrelationreferenceconfigdlg.h
+++ b/src/gui/editorwidgets/qgsrelationreferenceconfigdlg.h
@@ -16,6 +16,8 @@
 #ifndef QGSRELATIONREFERENCECONFIGDLGBASE_H
 #define QGSRELATIONREFERENCECONFIGDLGBASE_H
 
+#include <QListWidget>
+
 #include "ui_qgsrelationreferenceconfigdlgbase.h"
 #include "qgseditorconfigwidget.h"
 
@@ -28,8 +30,18 @@ class GUI_EXPORT QgsRelationReferenceConfigDlg : public QgsEditorConfigWidget, p
     virtual QgsEditorWidgetConfig config() override;
     virtual void setConfig( const QgsEditorWidgetConfig& config ) override;
 
+  private:
+    void loadFields();
+    void addFilterField( const QString& field );
+    void addFilterField( QListWidgetItem* item );
+    int indexFromListWidgetItem( QListWidgetItem* item );
+
+    QgsVectorLayer* mReferencedLayer;
+
   private slots:
     void relationChanged( int idx );
+    void on_mAddFilterButton_clicked();
+    void on_mRemoveFilterButton_clicked();
 };
 
 #endif // QGSRELATIONREFERENCECONFIGDLGBASE_H

--- a/src/gui/editorwidgets/qgsrelationreferencefactory.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencefactory.cpp
@@ -59,6 +59,8 @@ QgsEditorWidgetConfig QgsRelationReferenceFactory::readConfig( const QDomElement
       filterFields << fieldElement.attribute( "name" );
     }
     cfg.insert( "FilterFields", filterFields );
+
+    cfg.insert( "ChainFilters", filterNode.toElement().attribute( "ChainFilters" ) == "1" );
   }
   return cfg;
 }
@@ -87,5 +89,7 @@ void QgsRelationReferenceFactory::writeConfig( const QgsEditorWidgetConfig& conf
       filterFields.appendChild( fieldElem );
     }
     configElement.appendChild( filterFields );
+
+    filterFields.setAttribute( "ChainFilters", config["ChainFilters"].toBool() );
   }
 }

--- a/src/gui/editorwidgets/qgsrelationreferencefactory.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencefactory.cpp
@@ -48,6 +48,18 @@ QgsEditorWidgetConfig QgsRelationReferenceFactory::readConfig( const QDomElement
   cfg.insert( "MapIdentification", configElement.attribute( "MapIdentification" ) == "1" );
   cfg.insert( "ReadOnly", configElement.attribute( "ReadOnly" ) == "1" );
 
+  QDomNode filterNode = configElement.elementsByTagName( "FilterFields" ).at( 0 );
+  if ( !filterNode.isNull() )
+  {
+    QStringList filterFields;
+    QDomNodeList fieldNodes = filterNode.toElement().elementsByTagName( "field" );
+    for ( int i = 0; i < fieldNodes.size(); i++ )
+    {
+      QDomElement fieldElement = fieldNodes.at( i ).toElement();
+      filterFields << fieldElement.attribute( "name" );
+    }
+    cfg.insert( "FilterFields", filterFields );
+  }
   return cfg;
 }
 
@@ -63,4 +75,17 @@ void QgsRelationReferenceFactory::writeConfig( const QgsEditorWidgetConfig& conf
   configElement.setAttribute( "Relation", config["Relation"].toString() );
   configElement.setAttribute( "MapIdentification", config["MapIdentification"].toBool() );
   configElement.setAttribute( "ReadOnly", config["ReadOnly"].toBool() );
+
+  if ( config.contains( "FilterFields" ) )
+  {
+    QDomElement filterFields = doc.createElement( "FilterFields" );
+
+    Q_FOREACH ( const QString& field, config["FilterFields"].toStringList() )
+    {
+      QDomElement fieldElem = doc.createElement( "field" );
+      fieldElem.setAttribute( "name", field );
+      filterFields.appendChild( fieldElem );
+    }
+    configElement.appendChild( filterFields );
+  }
 }

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -32,6 +32,7 @@
 #include "qgsmessagebar.h"
 #include "qgsrelationreferenceconfigdlg.h"
 #include "qgsvectorlayer.h"
+#include "qgsattributetablemodel.h"
 
 bool orderByLessThan( const QgsRelationReferenceWidget::ValueRelationItem& p1
                       , const QgsRelationReferenceWidget::ValueRelationItem& p2 )
@@ -68,6 +69,9 @@ QgsRelationReferenceWidget::QgsRelationReferenceWidget( QWidget* parent )
     , mReferencedAttributeForm( NULL )
     , mReferencedLayer( NULL )
     , mReferencingLayer( NULL )
+    , mMasterModel( 0 )
+    , mFilterModel( 0 )
+    , mFeatureListModel( 0 )
     , mWindowWidget( NULL )
     , mShown( false )
     , mIsEditable( true )
@@ -86,9 +90,19 @@ QgsRelationReferenceWidget::QgsRelationReferenceWidget( QWidget* parent )
   editLayout->setContentsMargins( 0, 0, 0, 0 );
   editLayout->setSpacing( 2 );
 
+  // Prepare the container and layout for the filter comboboxes
+  mChooserGroupBox = new QGroupBox( this );
+  editLayout->addWidget( mChooserGroupBox );
+  QHBoxLayout* chooserLayout = new QHBoxLayout;
+  chooserLayout->setContentsMargins( 0, 0, 0, 0 );
+  mFilterLayout = new QFormLayout;
+  mFilterLayout->setContentsMargins( 0, 0, 0, 0 );
+  mChooserGroupBox->setLayout( chooserLayout );
+  chooserLayout->addLayout( mFilterLayout );
+
   // combobox (for non-geometric relation)
   mComboBox = new QComboBox( this );
-  editLayout->addWidget( mComboBox );
+  mChooserGroupBox->layout()->addWidget( mComboBox );
 
   // read-only line edit
   mLineEdit = new QLineEdit( this );
@@ -366,7 +380,7 @@ void QgsRelationReferenceWidget::setEmbedForm( bool display )
 
 void QgsRelationReferenceWidget::setReadOnlySelector( bool readOnly )
 {
-  mComboBox->setHidden( readOnly );
+  mChooserGroupBox->setHidden( readOnly );
   mLineEdit->setVisible( readOnly );
   mRemoveFKButton->setVisible( mAllowNull && readOnly );
   mReadOnlySelector = readOnly;
@@ -382,6 +396,11 @@ void QgsRelationReferenceWidget::setAllowMapIdentification( bool allowMapIdentif
 void QgsRelationReferenceWidget::setOrderByValue( bool orderByValue )
 {
   mOrderByValue = orderByValue;
+}
+
+void QgsRelationReferenceWidget::setFilterFields( QStringList filterFields )
+{
+  mFilterFields = filterFields;
 }
 
 void QgsRelationReferenceWidget::setOpenFormButtonVisible( bool openFormButtonVisible )
@@ -404,6 +423,56 @@ void QgsRelationReferenceWidget::init()
   if ( !mReadOnlySelector && mComboBox->count() == 0 && mReferencedLayer )
   {
     QApplication::setOverrideCursor( Qt::WaitCursor );
+
+    QSet<QString> requestedAttrs;
+
+    Q_FOREACH ( const QString& fieldName, mFilterFields )
+    {
+      QVariantList uniqueValues;
+      int idx = mReferencedLayer->fieldNameIndex( fieldName );
+      QComboBox* cb = new QComboBox();
+      cb->setProperty( "Field", fieldName );
+      mFilterComboBoxes << cb;
+      mReferencedLayer->uniqueValues( idx, uniqueValues );
+      cb->addItem( tr( " - All - " ) );
+      Q_FOREACH ( QVariant v, uniqueValues )
+      {
+        cb->addItem( v.toString(), v );
+      }
+
+      connect( cb, SIGNAL( currentIndexChanged( int ) ), this, SLOT( filterChanged() ) );
+
+      // Request this attribute for caching
+      requestedAttrs << fieldName;
+
+      mFilterLayout->addRow( mReferencedLayer->attributeAlias( idx ).isEmpty() ? fieldName : mReferencedLayer->attributeAlias( idx ) , cb );
+    }
+
+    QgsVectorLayerCache* layerCache = new QgsVectorLayerCache( mReferencedLayer, 10000, this );
+    QgsFeature ft;
+    QgsFeatureIterator it = layerCache->getFeatures();
+    while ( it.nextFeature( ft ) )
+      QgsDebugMsg( ft.attribute( 0 ).toString() );
+
+    QgsExpression exp( mReferencedLayer->displayExpression() );
+
+    requestedAttrs += exp.referencedColumns().toSet();
+    requestedAttrs << mRelation.fieldPairs().first().second;
+
+    QgsAttributeList attributes;
+    Q_FOREACH ( const QString& attr, requestedAttrs )
+      attributes << mReferencedLayer->fieldNameIndex( attr );
+
+    layerCache->setCacheSubsetOfAttributes( attributes );
+    mMasterModel = new QgsAttributeTableModel( layerCache );
+    mMasterModel->setRequest( QgsFeatureRequest().setFlags( QgsFeatureRequest::NoGeometry ).setSubsetOfAttributes( requestedAttrs.toList(), mReferencedLayer->pendingFields() ) );
+    mFilterModel = new QgsAttributeTableFilterModel( mCanvas, mMasterModel, mMasterModel );
+    mFeatureListModel = new QgsFeatureListModel( mFilterModel, this );
+    mFeatureListModel->setDisplayExpression( mReferencedLayer->displayExpression() );
+
+    mMasterModel->loadLayer();
+
+    mComboBox->setModel( mFeatureListModel );
     if ( mAllowNull )
     {
       const QString nullValue = QSettings().value( "qgis/nullValue", "NULL" ).toString();
@@ -412,12 +481,7 @@ void QgsRelationReferenceWidget::init()
       mComboBox->setItemData( 0, QColor( Qt::gray ), Qt::ForegroundRole );
     }
 
-    QgsExpression exp( mReferencedLayer->displayExpression() );
-
-    QStringList attrs = exp.referencedColumns();
-    attrs << mRelation.fieldPairs().first().second;
-
-    QgsFeatureIterator fit = mReferencedLayer->getFeatures( QgsFeatureRequest().setFlags( QgsFeatureRequest::NoGeometry ).setSubsetOfAttributes( attrs, mReferencedLayer->pendingFields() ) );
+    QgsFeatureIterator fit = mReferencedLayer->getFeatures( QgsFeatureRequest().setFlags( QgsFeatureRequest::NoGeometry ).setSubsetOfAttributes( requestedAttrs.toList(), mReferencedLayer->pendingFields() ) );
 
     exp.prepare( mReferencedLayer->pendingFields() );
 
@@ -674,3 +738,51 @@ void QgsRelationReferenceWidget::mapToolDeactivated()
   mMessageBarItem = NULL;
 }
 
+void QgsRelationReferenceWidget::filterChanged()
+{
+  QStringList filters;
+  QgsAttributeList attrs;
+
+  Q_FOREACH ( QComboBox* cb, mFilterComboBoxes )
+  {
+    if ( cb->currentIndex() != 0 )
+    {
+      const QString fieldName = cb->property( "Field" ).toString();
+
+      cb->itemData( cb->currentIndex() );
+
+      if ( mReferencedLayer->pendingFields().field( fieldName ).type() == QVariant::String )
+      {
+        filters << QString( "\"%1\" = '%2'" ).arg( fieldName ).arg( cb->itemData( cb->currentIndex() ).toString() );
+      }
+      else
+      {
+        filters << QString( "\"%1\" = %2" ).arg( fieldName ).arg( cb->itemData( cb->currentIndex() ).toString() );
+      }
+
+      attrs << mReferencedLayer->fieldNameIndex( fieldName );
+    }
+  }
+
+  QString filterExpression = filters.join( " AND " );
+
+  QgsFeatureIterator it( mMasterModel->layerCache()->getFeatures( QgsFeatureRequest().setFilterExpression( filterExpression ).setSubsetOfAttributes( attrs ) ) );
+
+  QgsFeature f;
+  QgsFeatureIds featureIds;
+
+  while ( it.nextFeature( f ) )
+  {
+    featureIds << f.id();
+  }
+
+  mFilterModel->setFilteredFeatures( featureIds );
+
+  if ( mAllowNull )
+  {
+    const QString nullValue = QSettings().value( "qgis/nullValue", "NULL" ).toString();
+
+    mComboBox->addItem( tr( "%1 (no selection)" ).arg( nullValue ), QVariant( QVariant::Int ) );
+    mComboBox->setItemData( 0, QColor( Qt::gray ), Qt::ForegroundRole );
+  }
+}

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.h
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.h
@@ -21,11 +21,14 @@
 #include "qgsfeature.h"
 #include "qgshighlight.h"
 #include "qgsmaptoolidentifyfeature.h"
+#include "qgsattributetablemodel.h"
+#include "qgsattributetablefiltermodel.h"
+#include "qgsfeaturelistmodel.h"
 
 #include <QComboBox>
 #include <QToolButton>
 #include <QLineEdit>
-#include <QVBoxLayout>
+#include <QFormLayout>
 
 class QgsAttributeForm;
 class QgsVectorLayerTools;
@@ -78,6 +81,8 @@ class GUI_EXPORT QgsRelationReferenceWidget : public QWidget
     bool orderByValue() { return mOrderByValue; }
     //! Set if the widget will order the combobox entries by value
     void setOrderByValue( bool orderByValue );
+    //! Set the fields for which filter comboboxes will be created
+    void setFilterFields( QStringList filterFields );
 
     //! determines the open form button is visible in the widget
     bool openFormButtonVisible() {return mOpenFormButtonVisible;}
@@ -112,6 +117,7 @@ class GUI_EXPORT QgsRelationReferenceWidget : public QWidget
     void featureIdentified( const QgsFeature& feature );
     void unsetMapTool();
     void mapToolDeactivated();
+    void filterChanged();
 
   private:
     void highlightFeature( QgsFeature f = QgsFeature(), CanvasExtent canvasExtent = Fixed );
@@ -132,10 +138,15 @@ class GUI_EXPORT QgsRelationReferenceWidget : public QWidget
     QgsAttributeForm* mReferencedAttributeForm;
     QgsVectorLayer* mReferencedLayer;
     QgsVectorLayer* mReferencingLayer;
+    QgsAttributeTableModel* mMasterModel;
+    QgsAttributeTableFilterModel* mFilterModel;
+    QgsFeatureListModel* mFeatureListModel;
+    QList<QComboBox*> mFilterComboBoxes;
     QWidget* mWindowWidget;
     bool mShown;
     QgsRelation mRelation;
     bool mIsEditable;
+    QStringList mFilterFields;
 
     // Q_PROPERTY
     bool mEmbedForm;
@@ -155,6 +166,8 @@ class GUI_EXPORT QgsRelationReferenceWidget : public QWidget
     QAction* mScaleHighlightFeatureAction;
     QAction* mPanHighlightFeatureAction;
     QComboBox* mComboBox;
+    QGroupBox* mChooserGroupBox;
+    QFormLayout* mFilterLayout;
     QgsCollapsibleGroupBox* mAttributeEditorFrame;
     QVBoxLayout* mAttributeEditorLayout;
     QLineEdit* mLineEdit;

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.h
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.h
@@ -129,7 +129,7 @@ class GUI_EXPORT QgsRelationReferenceWidget : public QWidget
     QgsMapCanvas* mCanvas;
     QgsMessageBar* mMessageBar;
     QVariant mForeignKey;
-    QgsFeatureId mFeatureId;
+    QgsFeature mFeature;
     int mFkeyFieldIdx;
     bool mAllowNull;
     QgsHighlight* mHighlight;
@@ -169,6 +169,7 @@ class GUI_EXPORT QgsRelationReferenceWidget : public QWidget
     QAction* mPanHighlightFeatureAction;
     QComboBox* mComboBox;
     QGroupBox* mChooserGroupBox;
+    QWidget* mFilterContainer;
     QHBoxLayout* mFilterLayout;
     QgsCollapsibleGroupBox* mAttributeEditorFrame;
     QVBoxLayout* mAttributeEditorLayout;

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.h
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.h
@@ -28,7 +28,8 @@
 #include <QComboBox>
 #include <QToolButton>
 #include <QLineEdit>
-#include <QFormLayout>
+#include <QHBoxLayout>
+#include <QStandardItemModel>
 
 class QgsAttributeForm;
 class QgsVectorLayerTools;
@@ -147,6 +148,7 @@ class GUI_EXPORT QgsRelationReferenceWidget : public QWidget
     QgsRelation mRelation;
     bool mIsEditable;
     QStringList mFilterFields;
+    QMap<QString, QMap<QString, QSet<QString> > > mFilterCache;
 
     // Q_PROPERTY
     bool mEmbedForm;
@@ -167,7 +169,7 @@ class GUI_EXPORT QgsRelationReferenceWidget : public QWidget
     QAction* mPanHighlightFeatureAction;
     QComboBox* mComboBox;
     QGroupBox* mChooserGroupBox;
-    QFormLayout* mFilterLayout;
+    QHBoxLayout* mFilterLayout;
     QgsCollapsibleGroupBox* mAttributeEditorFrame;
     QVBoxLayout* mAttributeEditorLayout;
     QLineEdit* mLineEdit;

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.h
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.h
@@ -89,6 +89,22 @@ class GUI_EXPORT QgsRelationReferenceWidget : public QWidget
     bool openFormButtonVisible() {return mOpenFormButtonVisible;}
     void setOpenFormButtonVisible( bool openFormButtonVisible );
 
+    /**
+     * Determines if the filters are chained
+     *
+     * @return True if filters are chained
+     */
+    bool chainFilters() { return mChainFilters; }
+
+
+    /**
+     * Set if filters are chained.
+     * Chained filters restrict the option of subsequent filters based on the selection of a previous filter.
+     *
+     * @param chainFilters If chaining should be enabled
+     */
+    void setChainFilters( bool chainFilters );
+
     //! return the related feature (from the referenced layer)
     //! if no feature is related, it returns an invalid feature
     QgsFeature referencedFeature();
@@ -156,6 +172,7 @@ class GUI_EXPORT QgsRelationReferenceWidget : public QWidget
     bool mAllowMapIdentification;
     bool mOrderByValue;
     bool mOpenFormButtonVisible;
+    bool mChainFilters;
 
     // UI
     QVBoxLayout* mTopLayout;

--- a/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
@@ -55,6 +55,10 @@ void QgsRelationReferenceWidgetWrapper::initWidget( QWidget* editor )
   mWidget->setReadOnlySelector( readOnlyWidget );
   mWidget->setAllowMapIdentification( mapIdent );
   mWidget->setOrderByValue( orderByValue );
+  if ( config( "FilterFields", QVariant() ).isValid() )
+  {
+    mWidget->setFilterFields( config( "FilterFields" ).toStringList() );
+  }
 
   QgsRelation relation = QgsProject::instance()->relationManager()->relation( config( "Relation" ).toString() );
 

--- a/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
@@ -58,6 +58,7 @@ void QgsRelationReferenceWidgetWrapper::initWidget( QWidget* editor )
   if ( config( "FilterFields", QVariant() ).isValid() )
   {
     mWidget->setFilterFields( config( "FilterFields" ).toStringList() );
+    mWidget->setChainFilters( config( "ChainFilters" ).toBool() );
   }
 
   QgsRelation relation = QgsProject::instance()->relationManager()->relation( config( "Relation" ).toString() );

--- a/src/ui/editorwidgets/qgsrelationreferenceconfigdlgbase.ui
+++ b/src/ui/editorwidgets/qgsrelationreferenceconfigdlgbase.ui
@@ -138,6 +138,16 @@
       <item row="1" column="0" rowspan="4">
        <widget class="QListWidget" name="mAvailableFieldsList"/>
       </item>
+      <item row="5" column="0" colspan="3">
+       <widget class="QCheckBox" name="mCbxChainFilters">
+        <property name="toolTip">
+         <string>When activated, the filters will restrict the choices of fields to options that are </string>
+        </property>
+        <property name="text">
+         <string>Chain filters</string>
+        </property>
+       </widget>
+      </item>
      </layout>
     </widget>
    </item>

--- a/src/ui/editorwidgets/qgsrelationreferenceconfigdlgbase.ui
+++ b/src/ui/editorwidgets/qgsrelationreferenceconfigdlgbase.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>470</width>
-    <height>240</height>
+    <height>481</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -72,6 +72,75 @@
      </property>
     </widget>
    </item>
+   <item row="11" column="0" colspan="2">
+    <widget class="QgsCollapsibleGroupBox" name="mFilterGroupBox">
+     <property name="title">
+      <string>Filters</string>
+     </property>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <property name="checked">
+      <bool>false</bool>
+     </property>
+     <layout class="QGridLayout" name="gridLayout">
+      <item row="4" column="1">
+       <spacer name="verticalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="2" column="1">
+       <widget class="QToolButton" name="mAddFilterButton">
+        <property name="text">
+         <string>...</string>
+        </property>
+        <property name="icon">
+         <iconset resource="../../../images/images.qrc">
+          <normaloff>:/images/themes/default/mActionSignPlus.png</normaloff>:/images/themes/default/mActionSignPlus.png</iconset>
+        </property>
+       </widget>
+      </item>
+      <item row="3" column="1">
+       <widget class="QToolButton" name="mRemoveFilterButton">
+        <property name="text">
+         <string>...</string>
+        </property>
+        <property name="icon">
+         <iconset resource="../../../images/images.qrc">
+          <normaloff>:/images/themes/default/mActionSignMinus.png</normaloff>:/images/themes/default/mActionSignMinus.png</iconset>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <spacer name="verticalSpacer">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>40</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item row="1" column="2" rowspan="4">
+       <widget class="QListWidget" name="mFilterFieldsList"/>
+      </item>
+      <item row="1" column="0" rowspan="4">
+       <widget class="QListWidget" name="mAvailableFieldsList"/>
+      </item>
+     </layout>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -81,7 +150,15 @@
    <header location="global">qgsfieldexpressionwidget.h</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
  </customwidgets>
- <resources/>
+ <resources>
+  <include location="../../../images/images.qrc"/>
+ </resources>
  <connections/>
 </ui>


### PR DESCRIPTION
Adds the possibility to choose a set of fields of the referenced layer for which comboboxes are created with available values.
The combobox that shows the available features for reference will then be live-filtered according to the chosen filter values.
