### PR TITLE
Add reverse-translation map for font styles

### DIFF
--- a/src/core/qgsfontutils.h
+++ b/src/core/qgsfontutils.h
@@ -113,6 +113,18 @@ class CORE_EXPORT QgsFontUtils
      * @see toXmlElement
      */
     static bool setFromXmlChildNode( QFont& font, const QDomElement& element, const QString& childNode );
+
+    /**Returns the localized named style of a font, if such a translation is available.
+     * @param namedStyle a named style, i.e. "Bold", "Italic", etc
+     * @returns The localized named style
+     */
+    static QString translateNamedStyle( const QString& namedStyle );
+
+    /**Returns the english named style of a font, if possible.
+     * @param namedStyle a localized named style, i.e. "Fett", "Kursiv", etc
+     * @returns The english named style
+     */
+    static QString untranslateNamedStyle( const QString& namedStyle );
 };
 
 #endif // QGSFONTUTILS_H

--- a/src/core/qgspallabeling.cpp
+++ b/src/core/qgspallabeling.cpp
@@ -742,7 +742,7 @@ void QgsPalLayerSettings::readFromLayer( QgsVectorLayer* layer )
   bool fontItalic = layer->customProperty( "labeling/fontItalic" ).toBool();
   textFont = QFont( fontFamily, fontSize, fontWeight, fontItalic );
   textFont.setPointSizeF( fontSize ); //double precision needed because of map units
-  textNamedStyle = layer->customProperty( "labeling/namedStyle", QVariant( "" ) ).toString();
+  textNamedStyle = QgsFontUtils::translateNamedStyle( layer->customProperty( "labeling/namedStyle", QVariant( "" ) ).toString() );
   QgsFontUtils::updateFontViaStyle( textFont, textNamedStyle ); // must come after textFont.setPointSizeF()
   textFont.setCapitalization(( QFont::Capitalization )layer->customProperty( "labeling/fontCapitals", QVariant( 0 ) ).toUInt() );
   textFont.setUnderline( layer->customProperty( "labeling/fontUnderline" ).toBool() );
@@ -930,7 +930,7 @@ void QgsPalLayerSettings::writeToLayer( QgsVectorLayer* layer )
   layer->setCustomProperty( "labeling/fieldName", fieldName );
   layer->setCustomProperty( "labeling/isExpression", isExpression );
   layer->setCustomProperty( "labeling/fontFamily", textFont.family() );
-  layer->setCustomProperty( "labeling/namedStyle", textNamedStyle );
+  layer->setCustomProperty( "labeling/namedStyle", QgsFontUtils::untranslateNamedStyle( textNamedStyle ) );
   layer->setCustomProperty( "labeling/fontSize", textFont.pointSizeF() );
   layer->setCustomProperty( "labeling/fontSizeInMapUnits", fontSizeInMapUnits );
   layer->setCustomProperty( "labeling/fontSizeMapUnitMinScale", fontSizeMapUnitScale.minScale );


### PR DESCRIPTION
Labeling font styles in QGIS project files are stored localized (because `QFontDatabase::styles()` returns localized names). This causes potential loss of the font style settings if the project is opened with a differently localized QGIS.

A somewhat hacky solution for the most common font styles is to add a reverse translation lookup table to get the English style name to store in the project file. The items in the table are those localized in `QFontDatabase` (see `qfontdatabase.cpp`). When reading a project file, style strings are translated back to the localized language.

This should not cause any regressions since, if a project still contains localized translations strings, `QCoreApplication::translate( "QFontDatabase", <translatedStyleWord>)` simply returns the unmodified word (assuming that there isn't a language where style names collide with English names and have different meaning...).

There can still be some cases (when font faces offer some extra special styles) where the localized strings end up in the project file. The reason is that FreeType itself can return localized font styles (search for `style_name` in [1]).

Funded by Sourcepole QGIS Enterprise.

[1] http://www.freetype.org/freetype2/docs/reference/ft2-base_interface.html
