### PR TITLE
Fixed timing/dangling pointer error in delimited text provider

### DIFF
--- a/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.cpp
@@ -40,7 +40,7 @@ QgsDelimitedTextFeatureIterator::QgsDelimitedTextFeatureIterator( QgsDelimitedTe
   // Does the layer have an explicit or implicit subset (implicit subset is if we have geometry which can
   // be invalid)
 
-  mTestSubset = mSource->mSubsetExpression;
+  mTestSubset = *(mSource->mSubsetExpressionPtr);
   mTestGeometry = false;
 
   mMode = FileScan;
@@ -120,7 +120,7 @@ QgsDelimitedTextFeatureIterator::QgsDelimitedTextFeatureIterator( QgsDelimitedTe
        && (
          !( mRequest.flags() & QgsFeatureRequest::NoGeometry )
          || mTestGeometry
-         || ( mTestSubset && mSource->mSubsetExpression->needsGeometry() )
+         || ( mTestSubset && (*(mSource->mSubsetExpressionPtr))->needsGeometry() )
        )
      )
   {
@@ -335,8 +335,8 @@ bool QgsDelimitedTextFeatureIterator::nextFeatureInternal( QgsFeature& feature )
 
     if ( mTestSubset )
     {
-      QVariant isOk = mSource->mSubsetExpression->evaluate( &feature );
-      if ( mSource->mSubsetExpression->hasEvalError() ) continue;
+      QVariant isOk = (*(mSource->mSubsetExpressionPtr))->evaluate( &feature );
+      if ( (*(mSource->mSubsetExpressionPtr))->hasEvalError() ) continue;
       if ( ! isOk.toBool() ) continue;
     }
 
@@ -447,7 +447,7 @@ void QgsDelimitedTextFeatureIterator::fetchAttribute( QgsFeature& feature, int f
 
 QgsDelimitedTextFeatureSource::QgsDelimitedTextFeatureSource( const QgsDelimitedTextProvider* p )
     : mGeomRep( p->mGeomRep )
-    , mSubsetExpression( p->mSubsetExpression )
+    , mSubsetExpressionPtr ( &(p->mSubsetExpression) )
     , mExtent( p->mExtent )
     , mUseSpatialIndex( p->mUseSpatialIndex )
     , mSpatialIndex( p->mSpatialIndex ? new QgsSpatialIndex( *p->mSpatialIndex ) : 0 )

--- a/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.cpp
@@ -36,11 +36,10 @@ QgsDelimitedTextFeatureIterator::QgsDelimitedTextFeatureIterator( QgsDelimitedTe
   // Does the layer have geometry - will revise later to determine if we actually need to
   // load it.
   bool hasGeometry = mSource->mGeomRep != QgsDelimitedTextProvider::GeomNone;
-
   // Does the layer have an explicit or implicit subset (implicit subset is if we have geometry which can
   // be invalid)
 
-  mTestSubset = *(mSource->mSubsetExpressionPtr);
+  mTestSubset = !mSource->mSubsetString.isEmpty();
   mTestGeometry = false;
 
   mMode = FileScan;
@@ -116,11 +115,12 @@ QgsDelimitedTextFeatureIterator::QgsDelimitedTextFeatureIterator( QgsDelimitedTe
   // We need it if it is asked for explicitly in the request,
   // if we are testing geometry (ie spatial filter), or
   // if testing the subset expression.
+  QgsExpression * expr = new QgsExpression(mSource->mSubsetString);
   if ( hasGeometry
        && (
          !( mRequest.flags() & QgsFeatureRequest::NoGeometry )
          || mTestGeometry
-         || ( mTestSubset && (*(mSource->mSubsetExpressionPtr))->needsGeometry() )
+         || ( mTestSubset && expr->needsGeometry() )
        )
      )
   {
@@ -335,8 +335,9 @@ bool QgsDelimitedTextFeatureIterator::nextFeatureInternal( QgsFeature& feature )
 
     if ( mTestSubset )
     {
-      QVariant isOk = (*(mSource->mSubsetExpressionPtr))->evaluate( &feature );
-      if ( (*(mSource->mSubsetExpressionPtr))->hasEvalError() ) continue;
+      QgsExpression * expr = new QgsExpression(mSource->mSubsetString);
+      QVariant isOk = expr->evaluate( &feature );
+      if ( expr->hasEvalError() ) continue;
       if ( ! isOk.toBool() ) continue;
     }
 
@@ -447,7 +448,7 @@ void QgsDelimitedTextFeatureIterator::fetchAttribute( QgsFeature& feature, int f
 
 QgsDelimitedTextFeatureSource::QgsDelimitedTextFeatureSource( const QgsDelimitedTextProvider* p )
     : mGeomRep( p->mGeomRep )
-    , mSubsetExpressionPtr ( &(p->mSubsetExpression) )
+    , mSubsetString ( p->mSubsetExpression ? p->mSubsetExpression->expression() : QString() )
     , mExtent( p->mExtent )
     , mUseSpatialIndex( p->mUseSpatialIndex )
     , mSpatialIndex( p->mSpatialIndex ? new QgsSpatialIndex( *p->mSpatialIndex ) : 0 )

--- a/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.h
+++ b/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.h
@@ -31,7 +31,7 @@ class QgsDelimitedTextFeatureSource : public QgsAbstractFeatureSource
 
   protected:
     QgsDelimitedTextProvider::GeomRepresentationType mGeomRep;
-    QgsExpression * const * mSubsetExpressionPtr;
+    QString mSubsetString;
     QgsRectangle mExtent;
     bool mUseSpatialIndex;
     QgsSpatialIndex *mSpatialIndex;

--- a/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.h
+++ b/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.h
@@ -31,7 +31,7 @@ class QgsDelimitedTextFeatureSource : public QgsAbstractFeatureSource
 
   protected:
     QgsDelimitedTextProvider::GeomRepresentationType mGeomRep;
-    QgsExpression *mSubsetExpression;
+    QgsExpression * const * mSubsetExpressionPtr;
     QgsRectangle mExtent;
     bool mUseSpatialIndex;
     QgsSpatialIndex *mSpatialIndex;

--- a/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
@@ -997,12 +997,14 @@ bool QgsDelimitedTextProvider::setSubsetString( QString subset, bool updateFeatu
 
   if ( valid )
   {
-
-    if ( mSubsetExpression ) delete mSubsetExpression;
+    QgsExpression * tmpSubsetExpression = mSubsetExpression;
+    // using a tmp pointer to avoid the pointer being dereferenced by
+    // a friend class after it has been freed but before it has been
+    // reassigned
     QString previousSubset = mSubsetString;
     mSubsetString = subset;
     mSubsetExpression = expression;
-
+    if ( tmpSubsetExpression ) delete tmpSubsetExpression;
     // Update the feature count and extents if requested
 
     // Usage of updateFeatureCount is a bit painful, basically expect that it


### PR DESCRIPTION
Hello! I debugged the following problem in QGIS in the delimited text provider and have a suggested fix for it:

The QgsDelimitedTextFeatureSource has a copy of the subsetExpression in the QgsDelimitedProvider. It can happen that the object in the provider gets freed and reallocated without the feature source getting updated in time, if the subset expression changes very fast. I looked though the issues in hub.qgis.org but nobody else had noticed this problem. This is reasonable, because for the problem to happen you need to have a kindof big text file and also have some script that changes the subsetString quite rapidly. I recompiled QGIS with my changes and the problem is gone. 

My fix uses the address of the pointer as the object that is passed to the feature source. This means that the changes are immediately visible to the feature source. I also modified the provider to first set the mSubsetExpression to the new one and then free the old object, but this was not the main problem.

I am available to do modifications on this PR if you have comments.

The original stacktrace is here:

```
[New Thread 0x7fff53fff700 (LWP 5690)]

Program received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0x7fff60eea700 (LWP 5676)]
0x00007ffff41c1835 in QgsExpression::evaluate(QgsFeature const*) () from /usr/lib/libqgis_core.so.2.6.1
(gdb) up
#1  0x00007fff73990b58 in QgsDelimitedTextFeatureIterator::nextFeatureInternal(QgsFeature&) () from /usr/lib/qgis/plugins/libdelimitedtextprovider.so
(gdb) up
#2  0x00007fff73990dc3 in QgsDelimitedTextFeatureIterator::fetchFeature(QgsFeature&) () from /usr/lib/qgis/plugins/libdelimitedtextprovider.so
(gdb) up
#3  0x00007ffff41e904d in QgsAbstractFeatureIterator::nextFeature(QgsFeature&) () from /usr/lib/libqgis_core.so.2.6.1
(gdb) up
#4  0x00007ffff433a7c9 in QgsVectorLayerFeatureIterator::fetchFeature(QgsFeature&) () from /usr/lib/libqgis_core.so.2.6.1
(gdb) up
#5  0x00007ffff41e904d in QgsAbstractFeatureIterator::nextFeature(QgsFeature&) () from /usr/lib/libqgis_core.so.2.6.1
(gdb) up
#6  0x00007ffff434456d in QgsVectorLayerRenderer::drawRendererV2(QgsFeatureIterator&) () from /usr/lib/libqgis_core.so.2.6.1
(gdb) up
#7  0x00007ffff434558d in QgsVectorLayerRenderer::render() () from /usr/lib/libqgis_core.so.2.6.1
(gdb) up
#8  0x00007ffff4259213 in QgsMapRendererCustomPainterJob::doRender() () from /usr/lib/libqgis_core.so.2.6.1
(gdb) up
#9  0x00007ffff4259279 in QgsMapRendererCustomPainterJob::staticRender(QgsMapRendererCustomPainterJob*) () from /usr/lib/libqgis_core.so.2.6.1
(gdb) up
#10 0x00007ffff425a49b in QtConcurrent::RunFunctionTask<void>::run() () from /usr/lib/libqgis_core.so.2.6.1
(gdb) up
#11 0x00007ffff2ee1fee in ?? () from /usr/lib/x86_64-linux-gnu/libQtCore.so.4
```
