### PR TITLE
[db manager] add 'way' to geometry column

### DIFF
--- a/python/plugins/db_manager/dlg_sql_window.py
+++ b/python/plugins/db_manager/dlg_sql_window.py
@@ -261,7 +261,7 @@ class DlgSqlWindow(QDialog, Ui_Dialog):
 
     # get sensible default columns. do this before sorting in case there's hints in the column order (eg, id is more likely to be first)
     try:
-      defaultGeomCol = next(col for col in cols if col in ['geom','geometry','the_geom'])
+      defaultGeomCol = next(col for col in cols if col in ['geom','geometry','the_geom','way'])
     except:
       defaultGeomCol = None
     try:


### PR DESCRIPTION
The default geometric column with OSM (osm2pgsql for instance) is 'way', so it's convenient if the column can be auto-detected.
