### PR TITLE
[feature] add expressions at the symbollist level

### DIFF
--- a/python/core/layertree/qgslayertreemodellegendnode.sip
+++ b/python/core/layertree/qgslayertreemodellegendnode.sip
@@ -134,6 +134,8 @@ class QgsSymbolV2LegendNode : QgsLayerTreeModelLegendNode
     virtual bool isScaleOK( double scale ) const;
 
     virtual void invalidateMapBasedData();
+
+    void setIconSize(const QSize& sz);
 };
 
 

--- a/python/core/qgsdatadefined.sip
+++ b/python/core/qgsdatadefined.sip
@@ -30,6 +30,14 @@ class QgsDataDefined
      */
     QgsDataDefined( const QgsExpression * expression );
 
+    /**
+     * Construct a new data defined object, analyse the expression to determine
+     * if it's a simple field
+     *
+     * @param expression can be empty
+     */
+    QgsDataDefined( const QString& expressionStr );
+
     ~QgsDataDefined();
 
     /**Returns whether the data defined container is set to all the default

--- a/python/gui/symbology-ng/qgssymbolslistwidget.sip
+++ b/python/gui/symbology-ng/qgssymbolslistwidget.sip
@@ -4,7 +4,7 @@ class QgsSymbolsListWidget : QWidget
 #include <qgssymbolslistwidget.h>
 %End
   public:
-    QgsSymbolsListWidget( QgsSymbolV2* symbol, QgsStyleV2* style, QMenu* menu, QWidget* parent /TransferThis/ = 0 );
+    QgsSymbolsListWidget( const QgsVectorLayer * layer, QgsSymbolV2* symbol, QgsStyleV2* style, QMenu* menu, QWidget* parent /TransferThis/ = 0 );
 
   public slots:
     void setSymbolFromStyle( const QModelIndex & index );

--- a/src/core/layertree/qgslayertreemodellegendnode.cpp
+++ b/src/core/layertree/qgslayertreemodellegendnode.cpp
@@ -136,6 +136,7 @@ QgsSymbolV2LegendNode::QgsSymbolV2LegendNode( QgsLayerTreeLayer* nodeLayer, cons
     , mItem( item )
     , mSymbolUsesMapUnits( false )
     , mIconSize( 16, 16 )
+    , mCrop( true )
 {
   updateLabel();
 
@@ -188,7 +189,7 @@ QVariant QgsSymbolV2LegendNode::data( int role ) const
         context.setMapToPixel( QgsMapToPixel( mupp ) ); // hope it's ok to leave out other params
 
         // crop
-        if ( mItem.symbol()->type() == QgsSymbolV2::Marker )
+        if ( mItem.symbol()->type() == QgsSymbolV2::Marker && mCrop )
         {
           pix = QgsSymbolLayerV2Utils::symbolPreviewPixmap( mItem.symbol(), QSize( 512, 512 ), validData ? &context : 0 );
           QImage img = pix.toImage();
@@ -217,9 +218,9 @@ QVariant QgsSymbolV2LegendNode::data( int role ) const
             ymin = qMax(( ymax + ymin ) / 2 - mIconSize.height() / 2, 0 );
             ymax = ymin + mIconSize.height();
           }
-          pix.convertFromImage( img.copy( xmin, ymin, xmax - xmin, ymax - ymin ) );
+          pix = QPixmap::fromImage( img.copy( xmin, ymin, xmax - xmin, ymax - ymin ) );
         }
-        else if ( mItem.symbol()->type() == QgsSymbolV2::Line )
+        else if ( mItem.symbol()->type() == QgsSymbolV2::Line && mCrop )
         {
           pix = QgsSymbolLayerV2Utils::symbolPreviewPixmap( mItem.symbol(), QSize( mIconSize.width(), 512 ), validData ? &context : 0 );
           QImage img = pix.toImage();
@@ -238,7 +239,7 @@ QVariant QgsSymbolV2LegendNode::data( int role ) const
             ymin = qMax(( ymax + ymin ) / 2 - mIconSize.height() / 2, 0 );
             ymax = ymin + mIconSize.height();
           }
-          pix.convertFromImage( img.copy( 0, ymin, mIconSize.width(), ymax - ymin ) );
+          pix = QPixmap::fromImage( img.copy( 0, ymin, mIconSize.width(), ymax - ymin ) );
         }
         else
         {

--- a/src/core/layertree/qgslayertreemodellegendnode.h
+++ b/src/core/layertree/qgslayertreemodellegendnode.h
@@ -163,6 +163,10 @@ class CORE_EXPORT QgsSymbolV2LegendNode : public QgsLayerTreeModelLegendNode
     virtual void invalidateMapBasedData() override;
 
     void setIconSize( const QSize& sz ) { mIconSize = sz; }
+    QSize iconSize() const { return mIconSize; }
+
+    void setCrop( bool isCropRequired ) { mCrop = isCropRequired; }
+
   private:
     void updateLabel();
 
@@ -172,6 +176,7 @@ class CORE_EXPORT QgsSymbolV2LegendNode : public QgsLayerTreeModelLegendNode
     QString mLabel;
     bool mSymbolUsesMapUnits;
     QSize mIconSize;
+    bool mCrop;
 };
 
 

--- a/src/core/layertree/qgslayertreemodellegendnode.h
+++ b/src/core/layertree/qgslayertreemodellegendnode.h
@@ -162,6 +162,7 @@ class CORE_EXPORT QgsSymbolV2LegendNode : public QgsLayerTreeModelLegendNode
 
     virtual void invalidateMapBasedData() override;
 
+    void setIconSize( const QSize& sz ) { mIconSize = sz; }
   private:
     void updateLabel();
 
@@ -170,6 +171,7 @@ class CORE_EXPORT QgsSymbolV2LegendNode : public QgsLayerTreeModelLegendNode
     mutable QPixmap mPixmap; // cached symbol preview
     QString mLabel;
     bool mSymbolUsesMapUnits;
+    QSize mIconSize;
 };
 
 

--- a/src/core/qgsdatadefined.cpp
+++ b/src/core/qgsdatadefined.cpp
@@ -43,6 +43,18 @@ QgsDataDefined::QgsDataDefined( const QgsExpression * expression )
   mExpressionPrepared = false;
 }
 
+QgsDataDefined::QgsDataDefined( const QString & expressionString )
+{
+  QgsExpression expression( expressionString );
+  mActive = expression.rootNode();
+  mUseExpression = expression.rootNode() && !dynamic_cast<const QgsExpression::NodeColumnRef*>( expression.rootNode() );
+  mExpressionString = mUseExpression ? expression.expression() : "";
+  mField = !mUseExpression ? expression.expression() : "";
+  mExpression = 0;
+  mExpressionPrepared = false;
+}
+
+
 QgsDataDefined::~QgsDataDefined()
 {
   mExpressionParams.clear();

--- a/src/core/qgsdatadefined.h
+++ b/src/core/qgsdatadefined.h
@@ -52,6 +52,14 @@ class CORE_EXPORT QgsDataDefined
      */
     explicit QgsDataDefined( const QgsExpression * expression );
 
+    /**
+     * Construct a new data defined object, analyse the expression to determine
+     * if it's a simple field
+     *
+     * @param expression can be empty
+     */
+    explicit QgsDataDefined( const QString& expressionStr );
+
     ~QgsDataDefined();
 
     /**Returns whether the data defined container is set to all the default

--- a/src/core/qgsmaplayerlegend.cpp
+++ b/src/core/qgsmaplayerlegend.cpp
@@ -198,10 +198,32 @@ QList<QgsLayerTreeModelLegendNode*> QgsDefaultVectorLayerLegend::createLayerTree
     nodes.append( new QgsSimpleLegendNode( nodeLayer, r->legendClassificationAttribute() ) );
   }
 
+  // we have varying icon sizes, and we want icon to be centered and
+  // text to be left aligned, so we have to compute the max size of icons
+  QList<QgsSymbolV2LegendNode*> symbolNodes;
+  int widthMax = 0;
   foreach ( const QgsLegendSymbolItemV2& i, r->legendSymbolItemsV2() )
   {
-    nodes.append( new QgsSymbolV2LegendNode( nodeLayer, i ) );
+    QgsSymbolV2LegendNode * n = new QgsSymbolV2LegendNode( nodeLayer, i );
+    nodes.append( n );
+    if ( i.symbol() )
+    {
+      symbolNodes.append( n );
+      n->setCrop( true );
+      QPixmap pix( n->data( Qt::DecorationRole ).value<QPixmap>() );
+      widthMax = qMax( pix.width(), widthMax );
+      n->setCrop( false );
+      n->setIconSize( pix.size() );
+    }
   }
+
+  foreach ( QgsSymbolV2LegendNode* n, symbolNodes )
+  {
+    Q_ASSERT( widthMax > 0 );
+    n->setIconSize( QSize( widthMax + 2, n->iconSize().rheight() + 2 ) );
+    n->setCrop( false );
+  }
+
 
   if ( nodes.count() == 1 && nodes[0]->data( Qt::EditRole ).toString().isEmpty() )
     nodes[0]->setEmbeddedInParent( true );

--- a/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.cpp
+++ b/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.cpp
@@ -612,151 +612,6 @@ static QList<double> _calcQuantileBreaks( QList<double> values, int classes )
   return breaks;
 }
 
-static QList<double> _calcPrettyBreaks( double minimum, double maximum, int classes )
-{
-
-  // C++ implementation of R's pretty algorithm
-  // Based on code for determining optimal tick placement for statistical graphics
-  // from the R statistical programming language.
-  // Code ported from R implementation from 'labeling' R package
-  //
-  // Computes a sequence of about 'classes' equally spaced round values
-  // which cover the range of values from 'minimum' to 'maximum'.
-  // The values are chosen so that they are 1, 2 or 5 times a power of 10.
-
-  QList<double> breaks;
-  if ( classes < 1 )
-  {
-    breaks.append( maximum );
-    return breaks;
-  }
-
-  int minimumCount = ( int ) classes / 3;
-  double shrink = 0.75;
-  double highBias = 1.5;
-  double adjustBias = 0.5 + 1.5 * highBias;
-  int divisions = classes;
-  double h = highBias;
-  double cell;
-  int U;
-  bool small = false;
-  double dx = maximum - minimum;
-
-  if ( dx == 0 && maximum == 0 )
-  {
-    cell = 1.0;
-    small = true;
-    U = 1;
-  }
-  else
-  {
-    cell = qMax( qAbs( minimum ), qAbs( maximum ) );
-    if ( adjustBias >= 1.5 * h + 0.5 )
-    {
-      U = 1 + ( 1.0 / ( 1 + h ) );
-    }
-    else
-    {
-      U = 1 + ( 1.5 / ( 1 + adjustBias ) );
-    }
-    small = dx < ( cell * U * qMax( 1, divisions ) * 1e-07 * 3.0 );
-  }
-
-  if ( small )
-  {
-    if ( cell > 10 )
-    {
-      cell = 9 + cell / 10;
-      cell = cell * shrink;
-    }
-    if ( minimumCount > 1 )
-    {
-      cell = cell / minimumCount;
-    }
-  }
-  else
-  {
-    cell = dx;
-    if ( divisions > 1 )
-    {
-      cell = cell / divisions;
-    }
-  }
-  if ( cell < 20 * 1e-07 )
-  {
-    cell = 20 * 1e-07;
-  }
-
-  double base = pow( 10.0, floor( log10( cell ) ) );
-  double unit = base;
-  if (( 2 * base ) - cell < h *( cell - unit ) )
-  {
-    unit = 2.0 * base;
-    if (( 5 * base ) - cell < adjustBias *( cell - unit ) )
-    {
-      unit = 5.0 * base;
-      if (( 10.0 * base ) - cell < h *( cell - unit ) )
-      {
-        unit = 10.0 * base;
-      }
-    }
-  }
-  // Maybe used to correct for the epsilon here??
-  int start = floor( minimum / unit + 1e-07 );
-  int end = ceil( maximum / unit - 1e-07 );
-
-  // Extend the range out beyond the data. Does this ever happen??
-  while ( start * unit > minimum + ( 1e-07 * unit ) )
-  {
-    start = start - 1;
-  }
-  while ( end * unit < maximum - ( 1e-07 * unit ) )
-  {
-    end = end + 1;
-  }
-  QgsDebugMsg( QString( "pretty classes: %1" ).arg( end ) );
-
-  // If we don't have quite enough labels, extend the range out
-  // to make more (these labels are beyond the data :( )
-  int k = floor( 0.5 + end - start );
-  if ( k < minimumCount )
-  {
-    k = minimumCount - k;
-    if ( start >= 0 )
-    {
-      end = end + k / 2;
-      start = start - k / 2 + k % 2;
-    }
-    else
-    {
-      start = start - k / 2;
-      end = end + k / 2 + k % 2;
-    }
-  }
-  double minimumBreak = start * unit;
-  //double maximumBreak = end * unit;
-  int count = end - start;
-
-  for ( int i = 1; i < count + 1; i++ )
-  {
-    breaks.append( minimumBreak + i * unit );
-  }
-
-  if ( breaks.isEmpty() )
-    return breaks;
-
-  if ( breaks.first() < minimum )
-  {
-    breaks[0] = minimum;
-  }
-  if ( breaks.last() > maximum )
-  {
-    breaks[breaks.count()-1] = maximum;
-  }
-
-  return breaks;
-} // _calcPrettyBreaks
-
 
 static QList<double> _calcStdDevBreaks( QList<double> values, int classes, QList<double> &labels )
 {
@@ -765,7 +620,7 @@ static QList<double> _calcStdDevBreaks( QList<double> values, int classes, QList
   // as implemented in the 'classInt' package available for the R statistical
   // prgramming language.
 
-  // Returns breaks based on '_calcPrettyBreaks' of the centred and scaled
+  // Returns breaks based on 'prettyBreaks' of the centred and scaled
   // values of 'values', and may have a number of classes different from 'classes'.
 
   // If there are no values to process: bail out
@@ -794,7 +649,7 @@ static QList<double> _calcStdDevBreaks( QList<double> values, int classes, QList
   }
   stdDev = sqrt( stdDev / n );
 
-  QList<double> breaks = _calcPrettyBreaks(( minimum - mean ) / stdDev, ( maximum - mean ) / stdDev, classes );
+  QList<double> breaks = QgsSymbolLayerV2Utils::prettyBreaks(( minimum - mean ) / stdDev, ( maximum - mean ) / stdDev, classes );
   for ( int i = 0; i < breaks.count(); i++ )
   {
     labels.append( breaks[i] );
@@ -1040,7 +895,7 @@ void QgsGraduatedSymbolRendererV2::updateClasses( QgsVectorLayer *vlayer, Mode m
   }
   else if ( mode == Pretty )
   {
-    breaks = _calcPrettyBreaks( minimum, maximum, nclasses );
+    breaks = QgsSymbolLayerV2Utils::prettyBreaks( minimum, maximum, nclasses );
   }
   else if ( mode == Quantile || mode == Jenks || mode == StdDev )
   {

--- a/src/core/symbology-ng/qgssymbollayerv2.h
+++ b/src/core/symbology-ng/qgssymbollayerv2.h
@@ -192,7 +192,7 @@ class CORE_EXPORT QgsMarkerSymbolLayerV2 : public QgsSymbolLayerV2
     QgsSymbolV2::ScaleMethod scaleMethod() const { return mScaleMethod; }
 
     void setOffset( QPointF offset ) { mOffset = offset; }
-    QPointF offset() { return mOffset; }
+    QPointF offset() const { return mOffset; }
 
     virtual void toSld( QDomDocument &doc, QDomElement &element, QgsStringMap props ) const override;
 

--- a/src/core/symbology-ng/qgssymbollayerv2utils.cpp
+++ b/src/core/symbology-ng/qgssymbollayerv2utils.cpp
@@ -3756,3 +3756,146 @@ QString QgsSymbolLayerV2Utils::fieldOrExpressionFromExpression( QgsExpression* e
   return expression->expression();
 }
 
+QList<double> QgsSymbolLayerV2Utils::prettyBreaks( double minimum, double maximum, int classes )
+{
+  // C++ implementation of R's pretty algorithm
+  // Based on code for determining optimal tick placement for statistical graphics
+  // from the R statistical programming language.
+  // Code ported from R implementation from 'labeling' R package
+  //
+  // Computes a sequence of about 'classes' equally spaced round values
+  // which cover the range of values from 'minimum' to 'maximum'.
+  // The values are chosen so that they are 1, 2 or 5 times a power of 10.
+
+  QList<double> breaks;
+  if ( classes < 1 )
+  {
+    breaks.append( maximum );
+    return breaks;
+  }
+
+  int minimumCount = ( int ) classes / 3;
+  double shrink = 0.75;
+  double highBias = 1.5;
+  double adjustBias = 0.5 + 1.5 * highBias;
+  int divisions = classes;
+  double h = highBias;
+  double cell;
+  int U;
+  bool small = false;
+  double dx = maximum - minimum;
+
+  if ( dx == 0 && maximum == 0 )
+  {
+    cell = 1.0;
+    small = true;
+    U = 1;
+  }
+  else
+  {
+    cell = qMax( qAbs( minimum ), qAbs( maximum ) );
+    if ( adjustBias >= 1.5 * h + 0.5 )
+    {
+      U = 1 + ( 1.0 / ( 1 + h ) );
+    }
+    else
+    {
+      U = 1 + ( 1.5 / ( 1 + adjustBias ) );
+    }
+    small = dx < ( cell * U * qMax( 1, divisions ) * 1e-07 * 3.0 );
+  }
+
+  if ( small )
+  {
+    if ( cell > 10 )
+    {
+      cell = 9 + cell / 10;
+      cell = cell * shrink;
+    }
+    if ( minimumCount > 1 )
+    {
+      cell = cell / minimumCount;
+    }
+  }
+  else
+  {
+    cell = dx;
+    if ( divisions > 1 )
+    {
+      cell = cell / divisions;
+    }
+  }
+  if ( cell < 20 * 1e-07 )
+  {
+    cell = 20 * 1e-07;
+  }
+
+  double base = pow( 10.0, floor( log10( cell ) ) );
+  double unit = base;
+  if (( 2 * base ) - cell < h *( cell - unit ) )
+  {
+    unit = 2.0 * base;
+    if (( 5 * base ) - cell < adjustBias *( cell - unit ) )
+    {
+      unit = 5.0 * base;
+      if (( 10.0 * base ) - cell < h *( cell - unit ) )
+      {
+        unit = 10.0 * base;
+      }
+    }
+  }
+  // Maybe used to correct for the epsilon here??
+  int start = floor( minimum / unit + 1e-07 );
+  int end = ceil( maximum / unit - 1e-07 );
+
+  // Extend the range out beyond the data. Does this ever happen??
+  while ( start * unit > minimum + ( 1e-07 * unit ) )
+  {
+    start = start - 1;
+  }
+  while ( end * unit < maximum - ( 1e-07 * unit ) )
+  {
+    end = end + 1;
+  }
+  QgsDebugMsg( QString( "pretty classes: %1" ).arg( end ) );
+
+  // If we don't have quite enough labels, extend the range out
+  // to make more (these labels are beyond the data :( )
+  int k = floor( 0.5 + end - start );
+  if ( k < minimumCount )
+  {
+    k = minimumCount - k;
+    if ( start >= 0 )
+    {
+      end = end + k / 2;
+      start = start - k / 2 + k % 2;
+    }
+    else
+    {
+      start = start - k / 2;
+      end = end + k / 2 + k % 2;
+    }
+  }
+  double minimumBreak = start * unit;
+  //double maximumBreak = end * unit;
+  int count = end - start;
+
+  for ( int i = 1; i < count + 1; i++ )
+  {
+    breaks.append( minimumBreak + i * unit );
+  }
+
+  if ( breaks.isEmpty() )
+    return breaks;
+
+  if ( breaks.first() < minimum )
+  {
+    breaks[0] = minimum;
+  }
+  if ( breaks.last() > maximum )
+  {
+    breaks[breaks.count()-1] = maximum;
+  }
+
+  return breaks;
+} // prettyBreaks

--- a/src/core/symbology-ng/qgssymbollayerv2utils.h
+++ b/src/core/symbology-ng/qgssymbollayerv2utils.h
@@ -416,6 +416,13 @@ class CORE_EXPORT QgsSymbolLayerV2Utils
      */
     static QString fieldOrExpressionFromExpression( QgsExpression* expression );
 
+    /** Computes a sequence of about 'classes' equally spaced round values
+     *  which cover the range of values from 'minimum' to 'maximum'.
+     *  The values are chosen so that they are 1, 2 or 5 times a power of 10.
+     * @note added in 2.10
+     */
+    static QList<double> prettyBreaks( double minimum, double maximum, int classes );
+
 };
 
 class QPolygonF;

--- a/src/core/symbology-ng/qgssymbolv2.cpp
+++ b/src/core/symbology-ng/qgssymbolv2.cpp
@@ -26,12 +26,41 @@
 #include "qgsproject.h"
 #include "qgsstylev2.h"
 
+#include "qgsdatadefined.h"
+
 #include <QColor>
 #include <QImage>
 #include <QPainter>
 #include <QSize>
 
 #include <cmath>
+
+inline
+QString rotateEnMasse( double additionalRotation, const QString & exprStr )
+{
+  return additionalRotation
+         ? QgsExpression( QString::number( additionalRotation ) + " + (" + exprStr + ")" ).dump()
+         : QgsExpression( exprStr ).dump();
+}
+
+inline
+QString scaleEnMasse( double scaleFactor, const QString & exprStr )
+{
+  return ( qAbs( scaleFactor - 1 ) > 1e-6 )
+         ? QgsExpression( QString::number( scaleFactor ) + "*(" + exprStr + ")" ).dump()
+         : QgsExpression( exprStr ).dump();
+}
+
+inline
+QString scaleEnMasseOffset( double scaleFactorX, double scaleFactorY, const QString & exprStr )
+{
+  return QgsExpression(
+           ( scaleFactorX ? "tostring(" + QString::number( scaleFactorX ) + "*(" + exprStr + "))" : "'0'" ) +
+           "|| ',' || " +
+           ( scaleFactorY ? "tostring(" + QString::number( scaleFactorY ) + "*(" + exprStr + "))" : "'0'" ) ).dump();
+}
+
+////////////////////
 
 QgsSymbolV2::QgsSymbolV2( SymbolType type, QgsSymbolLayerV2List layers )
     : mType( type ), mLayers( layers ), mAlpha( 1.0 ), mRenderHints( 0 ), mLayer( NULL )
@@ -494,7 +523,6 @@ QgsFillSymbolV2* QgsFillSymbolV2::createSimple( const QgsStringMap& properties )
 
 ///////////////////
 
-
 QgsMarkerSymbolV2::QgsMarkerSymbolV2( QgsSymbolLayerV2List layers )
     : QgsSymbolV2( Marker, layers )
 {
@@ -513,7 +541,7 @@ void QgsMarkerSymbolV2::setAngle( double ang )
   }
 }
 
-double QgsMarkerSymbolV2::angle()
+double QgsMarkerSymbolV2::angle() const
 {
   QgsSymbolLayerV2List::const_iterator it = mLayers.begin();
 
@@ -525,6 +553,52 @@ double QgsMarkerSymbolV2::angle()
   return layer->angle();
 }
 
+void QgsMarkerSymbolV2::setAngleExpression( const QString & exprStr )
+{
+  const double rot = angle();
+  for ( QgsSymbolLayerV2List::iterator it = mLayers.begin(); it != mLayers.end(); ++it )
+  {
+    QgsMarkerSymbolLayerV2* layer = static_cast<QgsMarkerSymbolLayerV2 *>( *it );
+    if ( !exprStr.length() )
+      layer->removeDataDefinedProperty( "angle" );
+    else
+      layer->setDataDefinedProperty( "angle", rotateEnMasse( layer->angle() - rot, exprStr ) );
+  }
+}
+
+QString QgsMarkerSymbolV2::angleExpression() const
+{
+  const double rot = angle();
+  QScopedPointer< QgsExpression > expr;
+
+  // find the base of the "en masse" pattern
+  for ( QgsSymbolLayerV2List::const_iterator it = mLayers.begin(); it != mLayers.end(); ++it )
+  {
+    const QgsMarkerSymbolLayerV2* layer = static_cast<const QgsMarkerSymbolLayerV2 *>( *it );
+    if ( layer->angle() == rot && layer->dataDefinedProperty( "angle" ) )
+    {
+      expr.reset( new QgsExpression( layer->dataDefinedPropertyString( "angle" ) ) );
+      break;
+    }
+  }
+
+  if ( !expr.data() ) return "";
+
+  // check that all layers angle expressions match the "en masse" pattern
+  const QString exprStr( expr.data() ? expr->dump() : "" );
+  for ( QgsSymbolLayerV2List::const_iterator it = mLayers.begin(); it != mLayers.end(); ++it )
+  {
+    const QgsMarkerSymbolLayerV2* layer = static_cast<const QgsMarkerSymbolLayerV2 *>( *it );
+    const QString sizeExpr( QgsExpression( layer->dataDefinedPropertyString( "angle" ) ).dump() );
+    if ( rotateEnMasse( layer->angle() - rot, exprStr ) != sizeExpr )
+      expr.reset();
+    break;
+  }
+
+  return expr.data() ? expr->dump() : "";
+}
+
+
 void QgsMarkerSymbolV2::setSize( double s )
 {
   double origSize = size();
@@ -534,16 +608,19 @@ void QgsMarkerSymbolV2::setSize( double s )
     QgsMarkerSymbolLayerV2* layer = static_cast<QgsMarkerSymbolLayerV2*>( *it );
     if ( layer->size() == origSize )
       layer->setSize( s );
-    else
+    else if ( origSize != 0 )
     {
       // proportionally scale size
-      if ( origSize != 0 )
-        layer->setSize( layer->size() * s / origSize );
+      layer->setSize( layer->size() * s / origSize );
     }
+    // also scale offset to maintain relative position
+    if ( origSize != 0 && ( layer->offset().x() || layer->offset().y() ) )
+      layer->setOffset( QPointF( layer->offset().x() * s / origSize,
+                                 layer->offset().y() * s / origSize ) );
   }
 }
 
-double QgsMarkerSymbolV2::size()
+double QgsMarkerSymbolV2::size() const
 {
   // return size of the largest symbol
   double maxSize = 0;
@@ -557,6 +634,68 @@ double QgsMarkerSymbolV2::size()
   return maxSize;
 }
 
+void QgsMarkerSymbolV2::setSizeExpression( const QString & exprStr )
+{
+  const double sz = size();
+
+  if ( sz == 0 ) return;
+
+  for ( QgsSymbolLayerV2List::iterator it = mLayers.begin(); it != mLayers.end(); ++it )
+  {
+    QgsMarkerSymbolLayerV2* layer = static_cast<QgsMarkerSymbolLayerV2 *>( *it );
+    if ( !exprStr.length() )
+    {
+      layer->removeDataDefinedProperty( "size" );
+      layer->removeDataDefinedProperty( "offset" );
+    }
+    else
+    {
+      layer->setDataDefinedProperty( "size", scaleEnMasse( layer->size() / sz, exprStr ) );
+      if ( layer->offset().x() || layer->offset().y() )
+        layer->setDataDefinedProperty( "offset", scaleEnMasseOffset(
+                                         layer->offset().x() / sz, layer->offset().y() / sz, exprStr ) );
+    }
+  }
+}
+
+QString QgsMarkerSymbolV2::sizeExpression() const
+{
+  const double sz = size();
+
+  if ( !sz ) return "";
+
+  QScopedPointer< QgsExpression > expr;
+
+  // find the base of the "en masse" pattern
+  for ( QgsSymbolLayerV2List::const_iterator it = mLayers.begin(); it != mLayers.end(); ++it )
+  {
+    const QgsMarkerSymbolLayerV2* layer = static_cast<const QgsMarkerSymbolLayerV2 *>( *it );
+    if ( layer->size() == sz && layer->dataDefinedProperty( "size" ) )
+    {
+      expr.reset( new QgsExpression( layer->dataDefinedPropertyString( "size" ) ) );
+      break;
+    }
+  }
+
+  if ( !expr.data() ) return "";
+
+  // check that all layers size expressions match the "en masse" pattern
+  const QString exprStr( expr.data() ? expr->dump() : "" );
+  for ( QgsSymbolLayerV2List::const_iterator it = mLayers.begin(); it != mLayers.end(); ++it )
+  {
+    const QgsMarkerSymbolLayerV2* layer = static_cast<const QgsMarkerSymbolLayerV2 *>( *it );
+    const QString sizeExpr( QgsExpression( layer->dataDefinedPropertyString( "size" ) ).dump() );
+    const QString offsetExpr( QgsExpression( layer->dataDefinedPropertyString( "offset" ) ).dump() );
+    if ( scaleEnMasse( layer->size() / sz, exprStr ) != sizeExpr
+         || (( layer->offset().x() || layer->offset().y() ) && scaleEnMasseOffset( layer->offset().x() / sz, layer->offset().y() / sz, exprStr ) != offsetExpr ) )
+    {
+      expr.reset();
+      break;
+    }
+  }
+
+  return expr.data() ? expr->dump() : "";
+}
 
 void QgsMarkerSymbolV2::setScaleMethod( QgsSymbolV2::ScaleMethod scaleMethod )
 {
@@ -627,16 +766,18 @@ void QgsLineSymbolV2::setWidth( double w )
     {
       layer->setWidth( w );
     }
-    else
+    else if ( origWidth != 0 )
     {
       // proportionally scale the width
-      if ( origWidth != 0 )
-        layer->setWidth( layer->width() * w / origWidth );
+      layer->setWidth( layer->width() * w / origWidth );
     }
+    // also scale offset to maintain relative position
+    if ( origWidth != 0 && layer->offset() )
+      layer->setOffset( layer->offset() * w / origWidth );
   }
 }
 
-double QgsLineSymbolV2::width()
+double QgsLineSymbolV2::width() const
 {
   double maxWidth = 0;
   for ( QgsSymbolLayerV2List::const_iterator it = mLayers.begin(); it != mLayers.end(); ++it )
@@ -647,6 +788,68 @@ double QgsLineSymbolV2::width()
       maxWidth = width;
   }
   return maxWidth;
+}
+
+void QgsLineSymbolV2::setWidthExpression( const QString & exprStr )
+{
+  const double wd = width();
+
+  if ( wd == 0 ) return;
+
+  for ( QgsSymbolLayerV2List::iterator it = mLayers.begin(); it != mLayers.end(); ++it )
+  {
+    QgsLineSymbolLayerV2* layer = static_cast<QgsLineSymbolLayerV2*>( *it );
+    if ( !exprStr.length() )
+    {
+      layer->removeDataDefinedProperty( "width" );
+      layer->removeDataDefinedProperty( "offset" );
+    }
+    else
+    {
+      layer->setDataDefinedProperty( "width", scaleEnMasse( layer->width() / wd, exprStr ) );
+      if ( layer->offset() )
+        layer->setDataDefinedProperty( "offset", scaleEnMasse( layer->offset() / wd, exprStr ) );
+    }
+  }
+}
+
+QString QgsLineSymbolV2::widthExpression() const
+{
+  const double wd = width();
+
+  if ( !wd ) return "";
+
+  QScopedPointer< QgsExpression > expr;
+
+  // find the base of the "en masse" pattern
+  for ( QgsSymbolLayerV2List::const_iterator it = mLayers.begin(); it != mLayers.end(); ++it )
+  {
+    const QgsLineSymbolLayerV2* layer = static_cast<const QgsLineSymbolLayerV2*>( *it );
+    if ( layer->width() == wd && layer->dataDefinedProperty( "width" ) )
+    {
+      expr.reset( new QgsExpression( layer->dataDefinedPropertyString( "width" ) ) );
+      break;
+    }
+  }
+
+  if ( !expr.data() ) return "";
+
+  // check that all layers width expressions match the "en masse" pattern
+  const QString exprStr( expr.data() ? expr->dump() : "" );
+  for ( QgsSymbolLayerV2List::const_iterator it = mLayers.begin(); it != mLayers.end(); ++it )
+  {
+    const QgsLineSymbolLayerV2* layer = static_cast<const QgsLineSymbolLayerV2*>( *it );
+    const QString sizeExpr( QgsExpression( layer->dataDefinedPropertyString( "width" ) ).dump() );
+    const QString offsetExpr( QgsExpression( layer->dataDefinedPropertyString( "offset" ) ).dump() );
+    if ( scaleEnMasse( layer->width() / wd, exprStr ) != sizeExpr
+         || ( layer->offset() && scaleEnMasse( layer->offset() / wd, exprStr ) != offsetExpr ) )
+    {
+      expr.reset();
+      break;
+    }
+  }
+
+  return expr.data() ? expr->dump() : "";
 }
 
 void QgsLineSymbolV2::renderPolyline( const QPolygonF& points, const QgsFeature* f, QgsRenderContext& context, int layer, bool selected )

--- a/src/core/symbology-ng/qgssymbolv2.h
+++ b/src/core/symbology-ng/qgssymbolv2.h
@@ -159,6 +159,7 @@ class CORE_EXPORT QgsSymbolV2
 
     QSet<QString> usedAttributes() const;
 
+    //! @note the layer will be NULL after stopRender
     void setLayer( const QgsVectorLayer* layer ) { mLayer = layer; }
     const QgsVectorLayer* layer() const { return mLayer; }
 
@@ -254,10 +255,26 @@ class CORE_EXPORT QgsMarkerSymbolV2 : public QgsSymbolV2
     QgsMarkerSymbolV2( QgsSymbolLayerV2List layers = QgsSymbolLayerV2List() );
 
     void setAngle( double angle );
-    double angle();
+    double angle() const;
+
+    /** Set "en masse" expression for angle
+     */
+    void setAngleExpression( const QString & exprStr );
+    /** Get "en masse" expression for angle
+     * @return empty if not an expession at the marker level
+     */
+    QString angleExpression() const;
 
     void setSize( double size );
-    double size();
+    double size() const;
+
+    /** Set "en masse" expression for size
+     */
+    void setSizeExpression( const QString & exprStr );
+    /** Get "en masse" expression for size
+     * @return empty if not an expession at the marker level
+     */
+    QString sizeExpression() const;
 
     void setScaleMethod( QgsSymbolV2::ScaleMethod scaleMethod );
     ScaleMethod scaleMethod();
@@ -280,7 +297,15 @@ class CORE_EXPORT QgsLineSymbolV2 : public QgsSymbolV2
     QgsLineSymbolV2( QgsSymbolLayerV2List layers = QgsSymbolLayerV2List() );
 
     void setWidth( double width );
-    double width();
+    double width() const;
+
+    /** Set "en masse" expression for width
+     */
+    void setWidthExpression( const QString & exprStr );
+    /** Get "en masse" expression for width
+     * @return empty if not an expession at the marker level
+     */
+    QString widthExpression() const;
 
     void renderPolyline( const QPolygonF& points, const QgsFeature* f, QgsRenderContext& context, int layer = -1, bool selected = false );
 

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -39,6 +39,7 @@ symbology-ng/qgssymbolslistwidget.cpp
 symbology-ng/qgssvgselectorwidget.cpp
 symbology-ng/qgslayerpropertieswidget.cpp
 symbology-ng/qgssmartgroupeditordialog.cpp
+symbology-ng/qgssizescalewidget.cpp
 
 attributetable/qgsattributetabledelegate.cpp
 attributetable/qgsattributetablefiltermodel.cpp
@@ -364,6 +365,7 @@ SET(QGIS_GUI_MOC_HDRS
   symbology-ng/qgsvectorfieldsymbollayerwidget.h
   symbology-ng/qgsvectorgradientcolorrampv2dialog.h
   symbology-ng/qgsvectorrandomcolorrampv2dialog.h
+  symbology-ng/qgssizescalewidget.h
 
   attributetable/qgsattributetabledelegate.h
   attributetable/qgsattributetablefiltermodel.h

--- a/src/gui/qgsdatadefinedbutton.cpp
+++ b/src/gui/qgsdatadefinedbutton.cpp
@@ -84,6 +84,7 @@ QgsDataDefinedButton::QgsDataDefinedButton( QWidget* parent,
   mActionPasteExpr = new QAction( tr( "Paste" ), this );
   mActionCopyExpr = new QAction( tr( "Copy" ), this );
   mActionClearExpr = new QAction( tr( "Clear" ), this );
+  mActionAssistant = new QAction( tr( "Assistant..." ), this );
 
   // set up sibling widget connections
   connect( this, SIGNAL( dataDefinedActivated( bool ) ), this, SLOT( disableEnabledWidgets( bool ) ) );
@@ -322,6 +323,11 @@ void QgsDataDefinedButton::aboutToShowMenu()
     mDefineMenu->addAction( mActionPasteExpr );
   }
 
+  if ( mAssistant.data() )
+  {
+    mDefineMenu->addSeparator();
+    mDefineMenu->addAction( mActionAssistant );
+  }
 }
 
 void QgsDataDefinedButton::menuActionTriggered( QAction* action )
@@ -371,6 +377,10 @@ void QgsDataDefinedButton::menuActionTriggered( QAction* action )
     setExpression( QString( "" ) );
     updateGui();
   }
+  else if ( action == mActionAssistant )
+  {
+    showAsssistant();
+  }
   else if ( mFieldsMenu->actions().contains( action ) )  // a field name clicked
   {
     if ( action->isEnabled() )
@@ -392,6 +402,21 @@ void QgsDataDefinedButton::showDescriptionDialog()
   mv->setWindowTitle( tr( "Data definition description" ) );
   mv->setMessageAsHtml( mFullDescription );
   mv->exec();
+}
+
+void QgsDataDefinedButton::showAsssistant()
+{
+  if ( mAssistant->exec() == QDialog::Accepted )
+  {
+    const QString newExp = mAssistant->expressionText();
+    setExpression( newExp.trimmed() );
+    bool hasExp = !newExp.isEmpty();
+
+    setUseExpression( hasExp );
+    setActive( hasExp );
+    updateGui();
+  }
+  activateWindow(); // reset focus to parent window
 }
 
 void QgsDataDefinedButton::showExpressionDialog()

--- a/src/gui/qgsdatadefinedbutton.h
+++ b/src/gui/qgsdatadefinedbutton.h
@@ -18,12 +18,24 @@
 #include <qgsfield.h>
 #include <qgsdatadefined.h>
 
+#include <QDialog>
 #include <QFlags>
 #include <QMap>
 #include <QPointer>
 #include <QToolButton>
+#include <QScopedPointer>
 
 class QgsVectorLayer;
+
+/** \ingroup gui
+ * \class Qgs
+ * A button for defining data source field mappings or expressions.
+ */
+class GUI_EXPORT QgsDataDefinedAssistant: public QDialog
+{
+  public:
+    virtual QString expressionText() const = 0;
+};
 
 /** \ingroup gui
  * \class QgsDataDefinedButton
@@ -168,6 +180,12 @@ class GUI_EXPORT QgsDataDefinedButton: public QToolButton
     void clearCheckedWidgets() { mCheckedWidgets.clear(); }
 
     /**
+     * Set an assistant to define expression
+     * takes ownership
+     */
+    void setAssistant( QgsDataDefinedAssistant * assistant ) { mAssistant.reset( assistant ); }
+
+    /**
      * Common descriptions for expected input values
      */
     static QString trString();
@@ -255,6 +273,7 @@ class GUI_EXPORT QgsDataDefinedButton: public QToolButton
   private:
     void showDescriptionDialog();
     void showExpressionDialog();
+    void showAsssistant();
     void updateGui();
 
     const QgsVectorLayer* mVectorLayer;
@@ -276,6 +295,7 @@ class GUI_EXPORT QgsDataDefinedButton: public QToolButton
     QAction* mActionPasteExpr;
     QAction* mActionCopyExpr;
     QAction* mActionClearExpr;
+    QAction* mActionAssistant;
 
     DataTypes mDataTypes;
     QString mDataTypesString;
@@ -283,6 +303,8 @@ class GUI_EXPORT QgsDataDefinedButton: public QToolButton
     QString mFullDescription;
     QString mUsageInfo;
     QString mCurrentDefinition;
+
+    QScopedPointer<QgsDataDefinedAssistant> mAssistant;
 
     static QIcon mIconDataDefine;
     static QIcon mIconDataDefineOn;

--- a/src/gui/symbology-ng/qgsrendererv2widget.h
+++ b/src/gui/symbology-ng/qgsrendererv2widget.h
@@ -73,6 +73,8 @@ class GUI_EXPORT QgsRendererV2Widget : public QWidget
     void changeSymbolWidth();
     /**Change marker sizes of selected symbols*/
     void changeSymbolSize();
+    /**Change marker angles of selected symbols*/
+    void changeSymbolAngle();
 
     virtual void copy() {}
     virtual void paste() {}
@@ -125,5 +127,101 @@ class QgsRendererV2DataDefinedMenus : public QObject
     QActionGroup *mSizeAttributeActionGroup;
     QgsVectorLayer* mLayer;
 };
+
+////////////
+
+#include "ui_widget_en_masse_value.h"
+#include "qgssizescalewidget.h"
+
+/**
+Utility classes for "en masse" size definition
+*/
+class QgsEnMasseValueDialog : public QDialog, public Ui::QgsEnMasseValueDialog
+{
+    Q_OBJECT
+
+  public:
+    /** Constructor
+     * @param symbolList must not be empty
+     * @param layer must not be null
+     */
+    QgsEnMasseValueDialog( const QList<QgsSymbolV2*>& symbolList, QgsVectorLayer * layer, const QString & label );
+    virtual ~QgsEnMasseValueDialog() {};
+
+  public slots:
+    void setSymbolExpression( const QString & definition );
+    void setActiveSymbolExpression( bool active );
+
+  protected:
+    QgsDataDefined symbolExpression() const;
+    void init( const QString & description ); // needed in children ctor to call virtual
+
+    virtual QgsDataDefined expression( const QgsSymbolV2 * ) const = 0;
+    virtual double value( const QgsSymbolV2 * ) const = 0;
+    virtual void setExpression( QgsSymbolV2 * symbol, const QString & exprStr ) = 0;
+
+    QList<QgsSymbolV2*>  mSymbolList;
+    QgsVectorLayer * mLayer;
+};
+
+class QgsEnMasseSizeDialog : public QgsEnMasseValueDialog
+{
+    Q_OBJECT
+  public:
+    QgsEnMasseSizeDialog( const QList<QgsSymbolV2*>& symbolList, QgsVectorLayer * layer )
+        : QgsEnMasseValueDialog( symbolList, layer, tr( "Size" ) )
+    {
+      init( tr( "En masse size expression" ) );
+      if ( symbolList.length() )
+        mDDBtn->setAssistant( new QgsSizeScaleWidget( mLayer, static_cast<const QgsMarkerSymbolV2*>( symbolList[0] ) ) );
+
+    }
+
+  protected:
+    QgsDataDefined expression( const QgsSymbolV2 * symbol ) const { return QgsDataDefined( static_cast<const QgsMarkerSymbolV2*>( symbol )->sizeExpression() ); }
+
+    double value( const QgsSymbolV2 * symbol ) const { return static_cast<const QgsMarkerSymbolV2*>( symbol )->size(); }
+
+    void setExpression( QgsSymbolV2 * symbol, const QString & exprStr ) { static_cast<QgsMarkerSymbolV2*>( symbol )->setSizeExpression( exprStr ); }
+};
+
+class QgsEnMasseRotationDialog : public QgsEnMasseValueDialog
+{
+    Q_OBJECT
+  public:
+    QgsEnMasseRotationDialog( const QList<QgsSymbolV2*>& symbolList, QgsVectorLayer * layer )
+        : QgsEnMasseValueDialog( symbolList, layer, tr( "Rotation" ) )
+    {
+      init( tr( "En masse rotation expression" ) );
+    }
+
+  protected:
+    QgsDataDefined expression( const QgsSymbolV2 * symbol ) const { return QgsDataDefined( static_cast<const QgsMarkerSymbolV2*>( symbol )->angleExpression() ); }
+
+    double value( const QgsSymbolV2 * symbol ) const { return static_cast<const QgsMarkerSymbolV2*>( symbol )->angle(); }
+
+    void setExpression( QgsSymbolV2 * symbol, const QString & exprStr ) { static_cast<QgsMarkerSymbolV2*>( symbol )->setAngleExpression( exprStr ); }
+};
+
+
+class QgsEnMasseWidthDialog : public QgsEnMasseValueDialog
+{
+    Q_OBJECT
+  public:
+    QgsEnMasseWidthDialog( const QList<QgsSymbolV2*>& symbolList, QgsVectorLayer * layer )
+        : QgsEnMasseValueDialog( symbolList, layer, tr( "Width" ) )
+    {
+      init( tr( "En masse width expression" ) );
+    }
+
+  protected:
+    QgsDataDefined expression( const QgsSymbolV2 * symbol ) const { return QgsDataDefined( static_cast<const QgsLineSymbolV2*>( symbol )->widthExpression() ); }
+
+    double value( const QgsSymbolV2 * symbol ) const { return static_cast<const QgsLineSymbolV2*>( symbol )->width(); }
+
+    void setExpression( QgsSymbolV2 * symbol, const QString & exprStr ) { static_cast<QgsLineSymbolV2*>( symbol )->setWidthExpression( exprStr ); }
+};
+
+
 
 #endif // QGSRENDERERV2WIDGET_H

--- a/src/gui/symbology-ng/qgssizescalewidget.cpp
+++ b/src/gui/symbology-ng/qgssizescalewidget.cpp
@@ -1,0 +1,216 @@
+/***************************************************************************
+ qgssizescalewidget.cpp - continuous size scale assistant
+
+ ---------------------
+ begin                : March 2015
+ copyright            : (C) 2015 by Vincent Mora
+ email                : vincent dot mora at oslandia dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgssizescalewidget.h"
+
+#include <qgsvectorlayer.h>
+#include <qgsmaplayerregistry.h>
+#include <qgssymbolv2.h>
+#include <qgslayertreelayer.h>
+#include <qgslayertreemodellegendnode.h>
+#include <qgssymbollayerv2utils.h>
+
+#include <QMenu>
+#include <QAction>
+#include <QItemDelegate>
+
+#include <limits>
+
+
+
+struct ItemDelegate : QItemDelegate
+{
+  ItemDelegate( QStandardItemModel * model ): mModel( model ) {}
+
+  QSize sizeHint( const QStyleOptionViewItem & /*option*/, const QModelIndex & index ) const
+  {
+    return mModel->item( index.row() )->icon().actualSize( QSize( 512, 512 ) );
+  }
+private:
+  QStandardItemModel * mModel;
+
+};
+
+QgsSizeScaleWidget::QgsSizeScaleWidget( const QgsVectorLayer * layer, const QgsMarkerSymbolV2 * symbol )
+    : mSymbol( symbol )
+    // we just use the minimumValue and maximumValue from the layer, unfortunately they are
+    // non const, so we get the layer from the registry instead
+    , mLayer( dynamic_cast<QgsVectorLayer *>( QgsMapLayerRegistry::instance()->mapLayer( layer->id() ) ) )
+//  , mModel( &mRoot, this )
+{
+  setupUi( this );
+  setWindowFlags( Qt::WindowStaysOnTopHint );
+
+  mLayerTreeLayer = new QgsLayerTreeLayer( mLayer );
+  mRoot.addChildNode( mLayerTreeLayer ); // takes ownership
+
+  treeView->setModel( &mPreviewList );
+  treeView->setItemDelegate( new ItemDelegate( &mPreviewList ) );
+  treeView->setHeaderHidden( true );
+  treeView->expandAll();
+
+  QScopedPointer<QAction> computeFromLayer( new QAction( tr( "Compute from layer" ), this ) );
+  connect( computeFromLayer.data(), SIGNAL( triggered() ), this, SLOT( computeFromLayerTriggered() ) );
+
+  QScopedPointer<QMenu> menu( new QMenu );
+  menu->addAction( computeFromLayer.take() );
+  computeValuesButton->setMenu( menu.take() );
+  connect( computeValuesButton, SIGNAL( clicked() ), computeValuesButton, SLOT( showMenu() ) );
+
+  fieldComboBox->addItem( tr( "[choose field]" ) );
+  const QgsFields& fields = mLayer->pendingFields();
+  for ( int i = 0; i < fields.count(); ++i )
+  {
+    fieldComboBox->addItem( fields.at( i ).name() );
+  }
+
+  scaleMethodComboBox->addItem( tr( "Flannery" ) );
+  scaleMethodComboBox->addItem( tr( "Surface" ) );
+  scaleMethodComboBox->addItem( tr( "Radius" ) );
+
+  // parse the current size expression of the symbol if it exists
+  QString expr = mSymbol->sizeExpression();
+  if ( expr.length() )
+  {
+    QStringList args;
+    if ( expr.indexOf( "scale_linear(" ) == 0 )
+    {
+      args = expr.mid( 13, expr.length() - 14 ).split( "," );
+      if ( args.length() == 5 )
+        scaleMethodComboBox->setCurrentIndex( 2 );
+      else
+        args = QStringList();
+    }
+    else if ( expr.indexOf( "scale_exp(" ) == 0 )
+    {
+      args = expr.mid( 10, expr.length() - 11 ).split( "," );
+      if ( args.length() == 6 )
+      {
+        if ( qAbs( QVariant( args[5] ).toDouble() - .57 ) < .001 )
+          scaleMethodComboBox->setCurrentIndex( 1 );
+        else
+          scaleMethodComboBox->setCurrentIndex( 0 );
+      }
+      else
+        args = QStringList();
+    }
+
+    if ( args.length() >= 5 )
+    {
+      for ( int i = 0; i < fieldComboBox->count(); i++ )
+      {
+        if ( args[0].trimmed().replace( "\"", "" ) == fieldComboBox->itemText( i ) )
+        {
+          fieldComboBox->setCurrentIndex( i );
+          break;
+        }
+      }
+      minValueSpinBox->setValue( QVariant( args[1] ).toDouble() );
+      maxValueSpinBox->setValue( QVariant( args[2] ).toDouble() );
+      minSizeSpinBox->setValue( QVariant( args[3] ).toDouble() );
+      maxSizeSpinBox->setValue( QVariant( args[4] ).toDouble() );
+      updatePreview();
+    }
+  }
+
+  connect( minSizeSpinBox, SIGNAL( valueChanged( double ) ), this, SLOT( updatePreview() ) );
+  connect( maxSizeSpinBox, SIGNAL( valueChanged( double ) ), this, SLOT( updatePreview() ) );
+  connect( minValueSpinBox, SIGNAL( valueChanged( double ) ), this, SLOT( updatePreview() ) );
+  connect( maxValueSpinBox, SIGNAL( valueChanged( double ) ), this, SLOT( updatePreview() ) );
+  connect( fieldComboBox, SIGNAL( currentIndexChanged( int ) ), this, SLOT( computeFromLayerTriggered() ) );
+  connect( scaleMethodComboBox, SIGNAL( currentIndexChanged( int ) ), this, SLOT( updatePreview() ) );
+}
+
+QString QgsSizeScaleWidget::expressionText() const
+{
+  return expressionTextImpl();
+}
+
+QString QgsSizeScaleWidget::expressionTextImpl( const QString & value ) const
+{
+  const QString args =
+    ( value.length() ? value : QgsExpression::quotedColumnRef( fieldComboBox->currentText() ) )
+    + QString( ", " )
+    + QString::number( minValueSpinBox->value() ) + ", "
+    + QString::number( maxValueSpinBox->value() ) + ", "
+    + QString::number( minSizeSpinBox->value() ) + ", "
+    + QString::number( maxSizeSpinBox->value() );
+  switch ( scaleMethodComboBox->currentIndex() )
+  {
+    case 0: return "scale_exp("+args+", .57)";
+    case 1: return "scale_exp("+args+", .5)";
+    case 2: return "scale_linear("+args+")";
+  }
+  return "";
+}
+
+void QgsSizeScaleWidget::updatePreview()
+{
+  const double min = minValueSpinBox->value();
+  const double max = maxValueSpinBox->value();
+  QList<double> breaks = QgsSymbolLayerV2Utils::prettyBreaks( min, max, 5 );
+
+  treeView->setIconSize( QSize( 512, 512 ) );
+  mPreviewList.clear();
+  int widthMax = 0;
+  for ( int i = 0; i < breaks.length(); i++ )
+  {
+    QScopedPointer< QgsMarkerSymbolV2 > symbol( dynamic_cast<QgsMarkerSymbolV2*>( mSymbol->clone() ) );
+    QgsExpression ex( expressionTextImpl( QString::number( breaks[i] ) ) );
+    symbol->setSizeExpression( "" );
+    symbol->setAngleExpression( "" ); // to avoid symbol not beeing drawn
+    symbol->setSize( ex.evaluate().toDouble() );
+    QgsSymbolV2LegendNode node( mLayerTreeLayer, QgsLegendSymbolItemV2( symbol.data(), QString::number( i ), 0 ) );
+    QScopedPointer< QStandardItem > item( new QStandardItem( node.data( Qt::DecorationRole ).value<QPixmap>(), QString::number( breaks[i] ) ) );
+    widthMax = qMax( item->icon().actualSize( QSize( 512, 512 ) ).rwidth(), widthMax );
+    mPreviewList.appendRow( item.take() );
+  }
+
+  // center icon and align text left by givinq icons the same width
+  // @todo maybe add some space so that icons don't touch
+  for ( int i = 0; i < breaks.length(); i++ )
+  {
+    QPixmap img( mPreviewList.item( i )->icon().pixmap( mPreviewList.item( i )->icon().actualSize( QSize( 512, 512 ) ) ) );
+    QPixmap enlarged( widthMax, img.height() );
+    // fill transparent and add original image
+    {
+      enlarged.fill( Qt::transparent );
+      QPainter p( &enlarged );
+      p.setCompositionMode( QPainter::CompositionMode_DestinationOver );
+      p.drawPixmap( QPoint(( widthMax - img.width() ) / 2, 0 ), img );
+    }
+    mPreviewList.item( i )->setIcon( enlarged );
+  }
+
+  //mModel.refreshLayerLegend( mLayerTreeLayer );
+}
+
+void QgsSizeScaleWidget::computeFromLayerTriggered()
+{
+  const int idx = mLayer->fieldNameIndex( fieldComboBox->currentText() );
+  bool minOk, maxOk;
+  double min = mLayer->minimumValue( idx ).toDouble( &minOk );
+  double max = mLayer->maximumValue( idx ).toDouble( &maxOk );
+  if ( !( minOk && maxOk ) )
+  {
+    min = 0;
+    max = 0;
+  }
+  minValueSpinBox->setValue( min );
+  maxValueSpinBox->setValue( max );
+  updatePreview();
+}
+

--- a/src/gui/symbology-ng/qgssizescalewidget.cpp
+++ b/src/gui/symbology-ng/qgssizescalewidget.cpp
@@ -100,9 +100,9 @@ QgsSizeScaleWidget::QgsSizeScaleWidget( const QgsVectorLayer * layer, const QgsM
       if ( args.length() == 6 )
       {
         if ( qAbs( QVariant( args[5] ).toDouble() - .57 ) < .001 )
-          scaleMethodComboBox->setCurrentIndex( 1 );
-        else
           scaleMethodComboBox->setCurrentIndex( 0 );
+        else
+          scaleMethodComboBox->setCurrentIndex( 1 );
       }
       else
         args = QStringList();
@@ -161,7 +161,7 @@ void QgsSizeScaleWidget::updatePreview()
 {
   const double min = minValueSpinBox->value();
   const double max = maxValueSpinBox->value();
-  QList<double> breaks = QgsSymbolLayerV2Utils::prettyBreaks( min, max, 5 );
+  QList<double> breaks = QgsSymbolLayerV2Utils::prettyBreaks( min, max, 4 );
 
   treeView->setIconSize( QSize( 512, 512 ) );
   mPreviewList.clear();

--- a/src/gui/symbology-ng/qgssizescalewidget.h
+++ b/src/gui/symbology-ng/qgssizescalewidget.h
@@ -1,0 +1,60 @@
+/***************************************************************************
+ qgssizescalewidget.h - continuous size scale assistant
+
+ ---------------------
+ begin                : March 2015
+ copyright            : (C) 2015 by Vincent Mora
+ email                : vincent dot mora at oslandia dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSSIZESCALEWIDGET_H
+#define QGSSIZESCALEWIDGET_H
+
+#include <qgsdatadefinedbutton.h>
+#include <qgslayertreegroup.h>
+#include <qgslayertreemodel.h>
+
+#include <ui_widget_size_scale.h>
+
+#include <QStandardItemModel>
+
+class QgsVectorLayer;
+class QgsMarkerSymbolV2;
+class QgsLayerTreeLayer;
+
+class GUI_EXPORT QgsSizeScaleWidget : public QgsDataDefinedAssistant, private Ui_SizeScaleBase
+{
+    Q_OBJECT
+
+  public:
+    QgsSizeScaleWidget( const QgsVectorLayer * layer, const QgsMarkerSymbolV2 * symbol );
+
+    QString expressionText() const;
+
+  private slots:
+    void computeFromLayerTriggered();
+    void updatePreview();
+
+
+  private:
+    const QgsMarkerSymbolV2 * mSymbol;
+    QgsVectorLayer * mLayer;
+    QgsLayerTreeLayer* mLayerTreeLayer;
+    QgsLayerTreeGroup mRoot;
+    //QgsLayerTreeModel mModel;
+    QStandardItemModel mPreviewList;
+
+
+    QString expressionTextImpl( const QString & value = "" ) const;
+
+
+};
+
+#endif

--- a/src/gui/symbology-ng/qgssymbolslistwidget.cpp
+++ b/src/gui/symbology-ng/qgssymbolslistwidget.cpp
@@ -16,11 +16,14 @@
 
 #include "qgssymbolslistwidget.h"
 
+#include "qgssizescalewidget.h"
+
 #include "qgsstylev2managerdialog.h"
 
 #include "qgssymbolv2.h"
 #include "qgsstylev2.h"
 #include "qgssymbollayerv2utils.h"
+#include "qgsmarkersymbollayerv2.h"
 
 #include "qgsapplication.h"
 
@@ -33,13 +36,14 @@
 #include <QInputDialog>
 #include <QMessageBox>
 #include <QMenu>
+#include <QScopedPointer>
 
-
-QgsSymbolsListWidget::QgsSymbolsListWidget( QgsSymbolV2* symbol, QgsStyleV2* style, QMenu* menu, QWidget* parent ) : QWidget( parent )
+QgsSymbolsListWidget::QgsSymbolsListWidget( const QgsVectorLayer * layer, QgsSymbolV2* symbol, QgsStyleV2* style, QMenu* menu, QWidget* parent )
+    : QWidget( parent )
+    , mSymbol( symbol )
+    , mStyle( style )
+    , mLayer( layer )
 {
-  mSymbol = symbol;
-  mStyle = style;
-
   setupUi( this );
 
   mSymbolUnitWidget->setUnits( QgsSymbolV2::OutputUnitList() << QgsSymbolV2::MM << QgsSymbolV2::MapUnit );
@@ -82,6 +86,17 @@ QgsSymbolsListWidget::QgsSymbolsListWidget( QgsSymbolV2* symbol, QgsStyleV2* sty
   connect( spinAngle, SIGNAL( valueChanged( double ) ), this, SLOT( setMarkerAngle( double ) ) );
   connect( spinSize, SIGNAL( valueChanged( double ) ), this, SLOT( setMarkerSize( double ) ) );
   connect( spinWidth, SIGNAL( valueChanged( double ) ), this, SLOT( setLineWidth( double ) ) );
+
+  connect( mRotationDDBtn, SIGNAL( dataDefinedChanged( const QString& ) ), this, SLOT( setMarkerRotationExpression( const QString& ) ) );
+  connect( mRotationDDBtn, SIGNAL( dataDefinedActivated( bool ) ), this, SLOT( setActiveMarkerRotationExpression( bool ) ) );
+  connect( mSizeDDBtn, SIGNAL( dataDefinedChanged( const QString& ) ), this, SLOT( setMarkerSizeExpression( const QString& ) ) );
+  connect( mSizeDDBtn, SIGNAL( dataDefinedActivated( bool ) ), this, SLOT( setActiveMarkerSizeExpression( bool ) ) );
+  connect( mWidthDDBtn, SIGNAL( dataDefinedChanged( const QString& ) ), this, SLOT( setLineWidthExpression( const QString& ) ) );
+  connect( mWidthDDBtn, SIGNAL( dataDefinedActivated( bool ) ), this, SLOT( setActiveLineWidthExpression( bool ) ) );
+
+  if ( mSymbol->type() == QgsSymbolV2::Marker )
+    mSizeDDBtn->setAssistant( new QgsSizeScaleWidget( mLayer, static_cast<const QgsMarkerSymbolV2*>( mSymbol ) ) );
+
 
   // Live color updates are not undoable to child symbol layers
   btnColor->setAcceptLiveUpdates( false );
@@ -178,6 +193,28 @@ void QgsSymbolsListWidget::setMarkerAngle( double angle )
   emit changed();
 }
 
+void QgsSymbolsListWidget::setActiveMarkerRotationExpression( bool active )
+{
+  if ( active )
+    setMarkerRotationExpression( mRotationDDBtn->currentDefinition() );
+  else
+    setMarkerRotationExpression( QString() );
+  spinAngle->setEnabled( !active );
+}
+
+void QgsSymbolsListWidget::setMarkerRotationExpression( const QString & definition )
+{
+  QgsMarkerSymbolV2* markerSymbol = static_cast<QgsMarkerSymbolV2*>( mSymbol );
+  if ( // shall we remove datadefined expressions for layers ?
+    ( markerSymbol->angleExpression().length() && !definition.length() )
+    // shall we set the "en masse" expression for properties ?
+    || definition.length() )
+  {
+    markerSymbol->setAngleExpression( definition );
+    emit changed();
+  }
+}
+
 void QgsSymbolsListWidget::setMarkerSize( double size )
 {
   QgsMarkerSymbolV2* markerSymbol = static_cast<QgsMarkerSymbolV2*>( mSymbol );
@@ -187,6 +224,28 @@ void QgsSymbolsListWidget::setMarkerSize( double size )
   emit changed();
 }
 
+void QgsSymbolsListWidget::setActiveMarkerSizeExpression( bool active )
+{
+  if ( active )
+    setMarkerSizeExpression( mSizeDDBtn->currentDefinition() );
+  else
+    setMarkerSizeExpression( QString() );
+  spinSize->setEnabled( !active );
+}
+
+void QgsSymbolsListWidget::setMarkerSizeExpression( const QString & definition )
+{
+  QgsMarkerSymbolV2* markerSymbol = static_cast<QgsMarkerSymbolV2*>( mSymbol );
+  if ( // shall we remove datadefined expressions for layers ?
+    ( markerSymbol->sizeExpression().length() && !definition.length() )
+    // shall we set the "en masse" expression for properties ?
+    || definition.length() )
+  {
+    markerSymbol->setSizeExpression( definition );
+    emit changed();
+  }
+}
+
 void QgsSymbolsListWidget::setLineWidth( double width )
 {
   QgsLineSymbolV2* lineSymbol = static_cast<QgsLineSymbolV2*>( mSymbol );
@@ -194,6 +253,29 @@ void QgsSymbolsListWidget::setLineWidth( double width )
     return;
   lineSymbol->setWidth( width );
   emit changed();
+}
+
+void QgsSymbolsListWidget::setActiveLineWidthExpression( bool active )
+{
+  if ( active )
+    setLineWidthExpression( mSizeDDBtn->currentDefinition() );
+  else
+    setLineWidthExpression( QString() );
+  spinWidth->setEnabled( !active );
+}
+
+
+void QgsSymbolsListWidget::setLineWidthExpression( const QString & definition )
+{
+  QgsLineSymbolV2* lineSymbol = static_cast<QgsLineSymbolV2*>( mSymbol );
+  if ( // shall we remove datadefined expressions for layers ?
+    ( lineSymbol->widthExpression().length() && !definition.length() )
+    // shall we set the "en masse" expression for properties ?
+    || definition.length() )
+  {
+    lineSymbol->setWidthExpression( definition );
+    emit changed();
+  }
 }
 
 void QgsSymbolsListWidget::symbolAddedToStyle( QString name, QgsSymbolV2* symbol )
@@ -277,11 +359,28 @@ void QgsSymbolsListWidget::updateSymbolInfo()
     QgsMarkerSymbolV2* markerSymbol = static_cast<QgsMarkerSymbolV2*>( mSymbol );
     spinSize->setValue( markerSymbol->size() );
     spinAngle->setValue( markerSymbol->angle() );
+
+    {
+      QgsDataDefined dd( markerSymbol->sizeExpression() );
+      mSizeDDBtn->init( mLayer, &dd, QgsDataDefinedButton::Double, "En masse size expression" );
+      spinSize->setEnabled( !mSizeDDBtn->isActive() );
+    }
+    {
+      QgsDataDefined dd( markerSymbol->angleExpression() );
+      mRotationDDBtn->init( mLayer, &dd, QgsDataDefinedButton::Double, "En masse rotation expression" );
+      spinAngle->setEnabled( !mRotationDDBtn->isActive() );
+    }
   }
   else if ( mSymbol->type() == QgsSymbolV2::Line )
   {
     QgsLineSymbolV2* lineSymbol = static_cast<QgsLineSymbolV2*>( mSymbol );
     spinWidth->setValue( lineSymbol->width() );
+
+    {
+      QgsDataDefined dd( lineSymbol->widthExpression() );
+      mWidthDDBtn->init( mLayer, &dd, QgsDataDefinedButton::Double, "En masse width expression" );
+      spinWidth->setEnabled( !mWidthDDBtn->isActive() );
+    }
   }
 
   mSymbolUnitWidget->blockSignals( true );

--- a/src/gui/symbology-ng/qgssymbolslistwidget.h
+++ b/src/gui/symbology-ng/qgssymbolslistwidget.h
@@ -30,7 +30,7 @@ class GUI_EXPORT QgsSymbolsListWidget : public QWidget, private Ui::SymbolsListW
     Q_OBJECT
 
   public:
-    QgsSymbolsListWidget( QgsSymbolV2* symbol, QgsStyleV2* style, QMenu* menu, QWidget* parent );
+    QgsSymbolsListWidget( const QgsVectorLayer * layer, QgsSymbolV2* symbol, QgsStyleV2* style, QMenu* menu, QWidget* parent );
 
   public slots:
     void setSymbolFromStyle( const QModelIndex & index );
@@ -48,12 +48,20 @@ class GUI_EXPORT QgsSymbolsListWidget : public QWidget, private Ui::SymbolsListW
 
     void openStyleManager();
 
+    void setActiveMarkerSizeExpression( bool active );
+    void setMarkerSizeExpression( const QString & definition );
+    void setActiveMarkerRotationExpression( bool active );
+    void setMarkerRotationExpression( const QString & definition );
+    void setActiveLineWidthExpression( bool active );
+    void setLineWidthExpression( const QString & definition );
+
   signals:
     void changed();
 
   protected:
     QgsSymbolV2* mSymbol;
     QgsStyleV2* mStyle;
+    const QgsVectorLayer* mLayer;
 
     void populateSymbolView();
     void populateSymbols( QStringList symbols );

--- a/src/gui/symbology-ng/qgssymbolv2selectordialog.cpp
+++ b/src/gui/symbology-ng/qgssymbolv2selectordialog.cpp
@@ -110,31 +110,31 @@ class SymbolLayerItem : public QStandardItem
     QVariant data( int role ) const override
     {
       if ( role == Qt::DisplayRole || role == Qt::EditRole )
+  {
+    if ( mIsLayer )
+        return QgsSymbolLayerV2Registry::instance()->symbolLayerMetadata( mLayer->layerType() )->visibleName();
+      else
       {
-        if ( mIsLayer )
-          return QgsSymbolLayerV2Registry::instance()->symbolLayerMetadata( mLayer->layerType() )->visibleName();
-        else
+        switch ( mSymbol->type() )
         {
-          switch ( mSymbol->type() )
-          {
-            case QgsSymbolV2::Marker : return "Marker";
-            case QgsSymbolV2::Fill   : return "Fill";
-            case QgsSymbolV2::Line   : return "Line";
-            default: return "Symbol";
-          }
+          case QgsSymbolV2::Marker : return "Marker";
+          case QgsSymbolV2::Fill   : return "Fill";
+          case QgsSymbolV2::Line   : return "Line";
+          default: return "Symbol";
         }
       }
-      if ( role == Qt::SizeHintRole )
-        return QVariant( QSize( 32, 32 ) );
-      if ( role == Qt::CheckStateRole )
-        return QVariant(); // could be true/false
-      return QStandardItem::data( role );
     }
+    if ( role == Qt::SizeHintRole )
+    return QVariant( QSize( 32, 32 ) );
+    if ( role == Qt::CheckStateRole )
+      return QVariant(); // could be true/false
+      return QStandardItem::data( role );
+      }
 
-  protected:
-    QgsSymbolLayerV2* mLayer;
-    QgsSymbolV2* mSymbol;
-    bool mIsLayer;
+    protected:
+      QgsSymbolLayerV2* mLayer;
+  QgsSymbolV2* mSymbol;
+  bool mIsLayer;
 };
 
 //////////
@@ -333,8 +333,9 @@ void QgsSymbolV2SelectorDialog::layerChanged()
   else
   {
     // then it must be a symbol
+    currentItem->symbol()->setLayer( mVectorLayer );
     // Now populate symbols of that type using the symbols list widget:
-    QWidget *symbolsList = new QgsSymbolsListWidget( currentItem->symbol(), mStyle, mAdvancedMenu, this );
+    QWidget *symbolsList = new QgsSymbolsListWidget( mVectorLayer, currentItem->symbol(), mStyle, mAdvancedMenu, this );
     setWidget( symbolsList );
     connect( symbolsList, SIGNAL( changed() ), this, SLOT( symbolChanged() ) );
   }

--- a/src/ui/symbollayer/widget_en_masse_value.ui
+++ b/src/ui/symbollayer/widget_en_masse_value.ui
@@ -1,0 +1,88 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsEnMasseValueDialog</class>
+ <widget class="QDialog" name="QgsEnMasseValueDialog">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>400</width>
+    <height>99</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="mLabel">
+     <property name="text">
+      <string>Label</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QDoubleSpinBox" name="mSpinBox"/>
+   </item>
+   <item row="0" column="2">
+    <widget class="QgsDataDefinedButton" name="mDDBtn">
+     <property name="text">
+      <string>...</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0" colspan="3">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsDataDefinedButton</class>
+   <extends>QToolButton</extends>
+   <header>qgsdatadefinedbutton.h</header>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>QgsEnMasseValueDialog</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>QgsEnMasseValueDialog</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/ui/symbollayer/widget_size_scale.ui
+++ b/src/ui/symbollayer/widget_size_scale.ui
@@ -1,0 +1,152 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>SizeScaleBase</class>
+ <widget class="QDialog" name="SizeScaleBase">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>576</width>
+    <height>343</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Dialog</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_2">
+   <item row="0" column="0">
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Field</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Scale method</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="label_5">
+       <property name="text">
+        <string>Size from</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QDoubleSpinBox" name="minSizeSpinBox">
+       <property name="value">
+        <double>1.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="2">
+      <widget class="QLabel" name="label_6">
+       <property name="text">
+        <string>to</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="3">
+      <widget class="QDoubleSpinBox" name="maxSizeSpinBox">
+       <property name="value">
+        <double>10.000000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="0">
+      <widget class="QLabel" name="label_3">
+       <property name="text">
+        <string>Values from</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="1">
+      <widget class="QDoubleSpinBox" name="minValueSpinBox"/>
+     </item>
+     <item row="3" column="2">
+      <widget class="QLabel" name="label_4">
+       <property name="text">
+        <string>to</string>
+       </property>
+      </widget>
+     </item>
+     <item row="3" column="3">
+      <widget class="QDoubleSpinBox" name="maxValueSpinBox"/>
+     </item>
+     <item row="3" column="4">
+      <widget class="QToolButton" name="computeValuesButton">
+       <property name="maximumSize">
+        <size>
+         <width>20</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1" colspan="4">
+      <widget class="QComboBox" name="scaleMethodComboBox"/>
+     </item>
+     <item row="0" column="1" colspan="4">
+      <widget class="QComboBox" name="fieldComboBox"/>
+     </item>
+    </layout>
+   </item>
+   <item row="0" column="1">
+    <widget class="QTreeView" name="treeView"/>
+   </item>
+   <item row="1" column="0" colspan="2">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>SizeScaleBase</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>SizeScaleBase</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/ui/symbollayer/widget_symbolslist.ui
+++ b/src/ui/symbollayer/widget_symbolslist.ui
@@ -84,6 +84,7 @@
          <property name="text">
           <string/>
          </property>
+         <zorder>stackedWidget</zorder>
         </widget>
        </item>
        <item row="0" column="1">
@@ -104,7 +105,51 @@
        </property>
        <widget class="QWidget" name="pageMarker">
         <layout class="QGridLayout" name="gridLayout">
-         <item row="0" column="1">
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_2">
+           <property name="text">
+            <string>Size</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="3">
+          <widget class="QgsDataDefinedButton" name="mSizeDDBtn">
+           <property name="text">
+            <string>...</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="3">
+          <widget class="QgsDataDefinedButton" name="mRotationDDBtn">
+           <property name="text">
+            <string>...</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="2">
+          <widget class="QgsDoubleSpinBox" name="spinAngle">
+           <property name="suffix">
+            <string> °</string>
+           </property>
+           <property name="decimals">
+            <number>2</number>
+           </property>
+           <property name="maximum">
+            <double>360.000000000000000</double>
+           </property>
+           <property name="singleStep">
+            <double>0.500000000000000</double>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_3">
+           <property name="text">
+            <string>Rotation</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="2">
           <widget class="QgsDoubleSpinBox" name="spinSize">
            <property name="decimals">
             <number>5</number>
@@ -120,36 +165,6 @@
            </property>
            <property name="showClearButton" stdset="0">
             <bool>false</bool>
-           </property>
-          </widget>
-         </item>
-         <item row="0" column="0">
-          <widget class="QLabel" name="label_2">
-           <property name="text">
-            <string>Size</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="0">
-          <widget class="QLabel" name="label_3">
-           <property name="text">
-            <string>Rotation</string>
-           </property>
-          </widget>
-         </item>
-         <item row="2" column="1">
-          <widget class="QgsDoubleSpinBox" name="spinAngle">
-           <property name="suffix">
-            <string> °</string>
-           </property>
-           <property name="decimals">
-            <number>2</number>
-           </property>
-           <property name="maximum">
-            <double>360.000000000000000</double>
-           </property>
-           <property name="singleStep">
-            <double>0.500000000000000</double>
            </property>
           </widget>
          </item>
@@ -173,6 +188,13 @@
            </property>
            <property name="showClearButton" stdset="0">
             <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="2">
+          <widget class="QgsDataDefinedButton" name="mWidthDDBtn">
+           <property name="text">
+            <string>...</string>
            </property>
           </widget>
          </item>
@@ -334,17 +356,25 @@
    <header>qgsunitselectionwidget.h</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>QgsDataDefinedButton</class>
+   <extends>QToolButton</extends>
+   <header>qgsdatadefinedbutton.h</header>
+  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>mTransparencySlider</tabstop>
   <tabstop>spinSize</tabstop>
+  <tabstop>mSizeDDBtn</tabstop>
+  <tabstop>spinWidth</tabstop>
+  <tabstop>mWidthDDBtn</tabstop>
   <tabstop>btnColor</tabstop>
   <tabstop>spinAngle</tabstop>
+  <tabstop>mRotationDDBtn</tabstop>
   <tabstop>groupsCombo</tabstop>
   <tabstop>openStyleManagerButton</tabstop>
   <tabstop>viewSymbols</tabstop>
   <tabstop>btnAdvanced</tabstop>
-  <tabstop>spinWidth</tabstop>
  </tabstops>
  <resources/>
  <connections/>


### PR DESCRIPTION
Size and Rotation can be defined by an expression for all symbols
composing a marker Width can be defined by an expression for all symbols
composing a line

The line symbol layer as been refactored to avoid code duplication and
expose the offset and offset units in the base class. This refacto was
necessary for this feature to avoid unnecessary dynamic cast. Note that
the added functions in the base class where already defined in all child
classes.

Also sets the symbols layer ptr when cloning.

Added a widged for use in categorized/classified symbology gui to set
the expression if needed.

The offset is now set along with size to maintain the relative position
of symbols composing a marker.

An asistant, with preview, is accessible through the data defined button
to help the user define the size expression. Three methods are
available: Frannery, Area and Radius.

Note: breaking change in the symbolslist widget. The widget ctor now
takes the layer as a parameter, this is necessary for the assistant and
for the data-defined buttons. The widget is used only in one place and
although it's a change to the public interface, the likelyhood of
breaking plugins dependent on this widget seems low enought.
