### PR TITLE
Allows to inspect and change the currently used expression of a virtual field

### DIFF
--- a/python/core/qgsvectorlayer.sip
+++ b/python/core/qgsvectorlayer.sip
@@ -292,9 +292,11 @@ class QgsVectorLayer : QgsMapLayer
      * @param exp The expression which calculates the field
      * @param fld The field to calculate
      *
-     * @note added in 2.6
+     * @return The index of the new field
+     *
+     * @note added in 2.6, return value added in 2.9
      */
-    void addExpressionField( const QString& exp, const QgsField& fld );
+    int addExpressionField( const QString& exp, const QgsField& fld );
 
     /**
      * Remove an expression field
@@ -304,6 +306,24 @@ class QgsVectorLayer : QgsMapLayer
      * @note added in 2.6
      */
     void removeExpressionField( int index );
+
+    /**
+     * Returns the expressoin used for a given expression field
+     *
+     * @param index An index of an epxression based (virtual) field
+     *
+     * @return The expression for the field at index
+     */
+    const QString expressionField( int index );
+
+    /**
+     * Changes the expression used to define an expression based (virtual) field
+     *
+     * @param index The index of the expression to change
+     *
+     * @param exp The new expression to set
+     */
+    void updateExpressionField( int index, const QString& exp );
 
     /** Get the label object associated with this layer */
     QgsLabel *label();

--- a/src/app/qgsfieldsproperties.cpp
+++ b/src/app/qgsfieldsproperties.cpp
@@ -37,6 +37,7 @@
 #include <QMessageBox>
 #include <QSettings>
 #include <QFileDialog>
+#include <QHBoxLayout>
 
 QgsFieldsProperties::QgsFieldsProperties( QgsVectorLayer *layer, QWidget* parent )
     : QWidget( parent )
@@ -242,9 +243,23 @@ void QgsFieldsProperties::setRow( int row, int idx, const QgsField& field )
   mFieldsList->setItem( row, attrTypeNameCol, new QTableWidgetItem( field.typeName() ) );
   mFieldsList->setItem( row, attrLengthCol, new QTableWidgetItem( QString::number( field.length() ) ) );
   mFieldsList->setItem( row, attrPrecCol, new QTableWidgetItem( QString::number( field.precision() ) ) );
-  mFieldsList->setItem( row, attrCommentCol, new QTableWidgetItem( field.comment() ) );
+  if ( mLayer->pendingFields().fieldOrigin( idx ) == QgsFields::OriginExpression )
+  {
+    QWidget* expressionWidget = new QWidget;
+    expressionWidget->setLayout( new QHBoxLayout );
+    QToolButton* editExpressionButton = new QToolButton;
+    editExpressionButton->setIcon( QgsApplication::getThemeIcon( "/mIconExpression.svg" ) );
+    expressionWidget->layout()->setContentsMargins( 0, 0, 0, 0 );
+    expressionWidget->layout()->addWidget( editExpressionButton );
+    expressionWidget->layout()->addWidget( new QLabel( mLayer->expressionField( idx ) ) );
+    mFieldsList->setCellWidget( row, attrCommentCol, expressionWidget );
+  }
+  else
+  {
+    mFieldsList->setItem( row, attrCommentCol, new QTableWidgetItem( field.comment() ) );
+  }
 
-  for ( int i = 0; i < attrEditTypeCol; i++ )
+  for ( int i = 0; i < attrCommentCol; i++ )
     mFieldsList->item( row, i )->setFlags( mFieldsList->item( row, i )->flags() & ~Qt::ItemIsEditable );
 
   FieldConfig cfg( mLayer, idx );

--- a/src/app/qgsfieldsproperties.cpp
+++ b/src/app/qgsfieldsproperties.cpp
@@ -20,6 +20,7 @@
 #include "qgsapplication.h"
 #include "qgsattributetypedialog.h"
 #include "qgsfieldcalculator.h"
+#include "qgsexpressionbuilderdialog.h"
 #include "qgsfieldsproperties.h"
 #include "qgslogger.h"
 #include "qgsmaplayerregistry.h"
@@ -249,6 +250,7 @@ void QgsFieldsProperties::setRow( int row, int idx, const QgsField& field )
     expressionWidget->setLayout( new QHBoxLayout );
     QToolButton* editExpressionButton = new QToolButton;
     editExpressionButton->setIcon( QgsApplication::getThemeIcon( "/mIconExpression.svg" ) );
+    connect( editExpressionButton, SIGNAL(clicked()), this, SLOT(updateExpression()) );
     expressionWidget->layout()->setContentsMargins( 0, 0, 0, 0 );
     expressionWidget->layout()->addWidget( editExpressionButton );
     expressionWidget->layout()->addWidget( new QLabel( mLayer->expressionField( idx ) ) );
@@ -654,6 +656,24 @@ void QgsFieldsProperties::attributesListCellChanged( int row, int column )
         mLayer->remAttributeAlias( idx );
       }
     }
+  }
+}
+
+void QgsFieldsProperties::updateExpression()
+{
+  QToolButton* btn = qobject_cast<QToolButton*>( sender() );
+  Q_ASSERT( btn );
+
+  int index = btn->property( "Index" ).toInt();
+
+  const QString exp = mLayer->expressionField( index );
+
+  QgsExpressionBuilderDialog dlg( mLayer, exp );
+
+  if ( dlg.exec() )
+  {
+    mLayer->updateExpressionField( index, dlg.expressionText() );
+    loadRows();
   }
 }
 

--- a/src/app/qgsfieldsproperties.h
+++ b/src/app/qgsfieldsproperties.h
@@ -183,6 +183,7 @@ class APP_EXPORT QgsFieldsProperties : public QWidget, private Ui_QgsFieldsPrope
 
     void attributesListCellChanged( int row, int column );
 
+    void updateExpression();
 
     /** editing of layer was toggled */
     void editingToggled();

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -2235,8 +2235,8 @@ QVariant QgsExpression::NodeBinaryOperator::eval( QgsExpression* parent, const Q
     case boPlus:
       if ( vL.type() == QVariant::String && vR.type() == QVariant::String )
       {
-        QString sL = getStringValue( vL, parent ); ENSURE_NO_EVAL_ERROR;
-        QString sR = getStringValue( vR, parent ); ENSURE_NO_EVAL_ERROR;
+        QString sL = isNull( vL ) ? QString() : getStringValue( vL, parent ); ENSURE_NO_EVAL_ERROR;
+        QString sR = isNull( vR ) ? QString() : getStringValue( vR, parent ); ENSURE_NO_EVAL_ERROR;
         return QVariant( sL + sR );
       }
       //intentional fall-through

--- a/src/core/qgsexpressionfieldbuffer.cpp
+++ b/src/core/qgsexpressionfieldbuffer.cpp
@@ -33,6 +33,11 @@ void QgsExpressionFieldBuffer::removeExpression( int index )
   mExpressions.removeAt( index );
 }
 
+void QgsExpressionFieldBuffer::updateExpression( int index, const QString& exp )
+{
+  mExpressions[index].expression = exp;
+}
+
 void QgsExpressionFieldBuffer::writeXml( QDomNode& layerNode, QDomDocument& document ) const
 {
   QDomElement expressionFieldsElem = document.createElement( "expressionfields" );

--- a/src/core/qgsexpressionfieldbuffer.h
+++ b/src/core/qgsexpressionfieldbuffer.h
@@ -59,6 +59,14 @@ class CORE_EXPORT QgsExpressionFieldBuffer
     void removeExpression( int index );
 
     /**
+     * Changes the expression at a given index
+     *
+     * @param index The index of the expression to change
+     * @param exp   The new expression to set
+     */
+    void updateExpression( int index, const QString& exp );
+
+    /**
      * Saves expressions to xml under the layer node
      */
     void writeXml( QDomNode& layer_node, QDomDocument& document ) const;

--- a/src/core/qgsexpressionfieldbuffer.h
+++ b/src/core/qgsexpressionfieldbuffer.h
@@ -75,7 +75,7 @@ class CORE_EXPORT QgsExpressionFieldBuffer
      */
     void updateFields( QgsFields& flds );
 
-    const QList<ExpressionField> expressions() const { return mExpressions; }
+    const QList<ExpressionField>& expressions() const { return mExpressions; }
 
   private:
     QList<ExpressionField> mExpressions;

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -2843,12 +2843,13 @@ const QList< QgsVectorJoinInfo >& QgsVectorLayer::vectorJoins() const
   return mJoinBuffer->vectorJoins();
 }
 
-void QgsVectorLayer::addExpressionField( const QString& exp, const QgsField& fld )
+int QgsVectorLayer::addExpressionField( const QString& exp, const QgsField& fld )
 {
   mExpressionFieldBuffer->addExpression( exp, fld );
   updateFields();
   int idx = mUpdatedFields.indexFromName( fld.name() );
   emit attributeAdded( idx );
+  return idx;
 }
 
 void QgsVectorLayer::removeExpressionField( int index )
@@ -2863,6 +2864,12 @@ const QString QgsVectorLayer::expressionField( int index )
 {
   int oi = mUpdatedFields.fieldOriginIndex( index );
   return mExpressionFieldBuffer->expressions().value( oi ).expression;
+}
+
+void QgsVectorLayer::updateExpressionField(   int index, const QString& exp )
+{
+  int oi = mUpdatedFields.fieldOriginIndex( index );
+  mExpressionFieldBuffer->updateExpression( oi, exp );
 }
 
 void QgsVectorLayer::updateFields()

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -2859,6 +2859,12 @@ void QgsVectorLayer::removeExpressionField( int index )
   emit attributeDeleted( index );
 }
 
+const QString QgsVectorLayer::expressionField( int index )
+{
+  int oi = mUpdatedFields.fieldOriginIndex( index );
+  return mExpressionFieldBuffer->expressions().value( oi ).expression;
+}
+
 void QgsVectorLayer::updateFields()
 {
   if ( !mDataProvider )

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -655,9 +655,11 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
      * @param exp The expression which calculates the field
      * @param fld The field to calculate
      *
-     * @note added in 2.6
+     * @return The index of the new field
+     *
+     * @note added in 2.6, return value added in 2.9
      */
-    void addExpressionField( const QString& exp, const QgsField& fld );
+    int addExpressionField( const QString& exp, const QgsField& fld );
 
     /**
      * Remove an expression field
@@ -668,7 +670,23 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
      */
     void removeExpressionField( int index );
 
+    /**
+     * Returns the expressoin used for a given expression field
+     *
+     * @param index An index of an epxression based (virtual) field
+     *
+     * @return The expression for the field at index
+     */
     const QString expressionField( int index );
+
+    /**
+     * Changes the expression used to define an expression based (virtual) field
+     *
+     * @param index The index of the expression to change
+     *
+     * @param exp The new expression to set
+     */
+    void updateExpressionField( int index, const QString& exp );
 
     /** Get the label object associated with this layer */
     QgsLabel *label();

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -668,6 +668,8 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
      */
     void removeExpressionField( int index );
 
+    const QString expressionField( int index );
+
     /** Get the label object associated with this layer */
     QgsLabel *label();
 

--- a/tests/src/python/test_qgsvectorlayer.py
+++ b/tests/src/python/test_qgsvectorlayer.py
@@ -954,6 +954,24 @@ class TestQgsVectorLayer(TestCase):
         assert self.blendModeTest == QPainter.CompositionMode_Screen
         assert layer.featureBlendMode() == QPainter.CompositionMode_Screen
 
+    def test_ExpressionField( self ):
+        layer = createLayerWithOnePoint()
+
+        cnt = layer.pendingFields().count()
+
+        idx = layer.addExpressionField( '5', QgsField( 'test', QVariant.LongLong ) )
+
+        assert( layer.getFeatures().next()[idx] == 5 )
+        assert( layer.pendingFields().count() == cnt + 1 )
+
+        layer.updateExpressionField( idx, '9' )
+
+        assert( layer.getFeatures().next()[idx] == 9 )
+
+        layer.removeExpressionField( idx )
+
+        assert( layer.pendingFields().count() == cnt )
+
     def onLayerTransparencyChanged( self, tr ):
         self.transparencyTest = tr
 


### PR DESCRIPTION
At the moment the comment field is used. I don't think there is a collision, as far as I know this field is read only and the content fetched from the provider.

Also added some unit tests for virtual fields

![screenshot from 2015-03-24 11 42 41](https://cloud.githubusercontent.com/assets/588407/6800004/0173d99c-d21b-11e4-879c-45434834c93e.png)
