### PR TITLE
[Processing]  Improve the robustness of models... 

### DIFF
--- a/python/plugins/processing/modeler/ModelerAlgorithm.py
+++ b/python/plugins/processing/modeler/ModelerAlgorithm.py
@@ -35,6 +35,8 @@ import traceback
 from PyQt4.QtCore import QCoreApplication, QPointF
 from PyQt4.QtGui import QIcon
 from qgis.core import QgsRasterLayer, QgsVectorLayer
+from qgis.gui import QgsMessageBar
+from qgis.utils import iface
 from processing.core.GeoAlgorithm import GeoAlgorithm
 from processing.modeler.WrongModelException import WrongModelException
 from processing.core.GeoAlgorithmExecutionException import GeoAlgorithmExecutionException
@@ -332,7 +334,13 @@ class ModelerAlgorithm(GeoAlgorithm):
         algInstance = alg.algorithm
         for param in algInstance.parameters:
             if not param.hidden:
-                value = self.resolveValue(alg.params[param.name])
+                if param.name in alg.params:
+                    value = self.resolveValue(alg.params[param.name])
+                else:
+                    iface.messageBar().pushMessage(self.tr("Warning"),
+                                                   self.tr("Parameter %s in algorithm %s in the model is run with default value! Edit the model to make sure that this is correct." % (param.name, alg.name)), 
+                                                   QgsMessageBar.WARNING, 4)
+                    value = None
                 if value is None and isinstance(param, ParameterExtent):
                     value = self.getMinCoveringExtent()
                 # We allow unexistent filepaths, since that allows

--- a/python/plugins/processing/modeler/ModelerParametersDialog.py
+++ b/python/plugins/processing/modeler/ModelerParametersDialog.py
@@ -410,7 +410,10 @@ class ModelerParametersDialog(QDialog):
                 if param.hidden:
                     continue
                 widget = self.valueItems[param.name]
-                value = alg.params[param.name]
+                if param.name in alg.params:
+                    value = alg.params[param.name]
+                else:
+                    value = None
                 if isinstance(param, (
                         ParameterRaster,
                         ParameterVector,

--- a/python/plugins/processing/modeler/ModelerScene.py
+++ b/python/plugins/processing/modeler/ModelerScene.py
@@ -98,7 +98,10 @@ class ModelerScene(QtGui.QGraphicsScene):
             idx = 0
             for parameter in alg.algorithm.parameters:
                 if not parameter.hidden:
-                    value = alg.params[parameter.name]
+                    if parameter.name in alg.params:
+                        value = alg.params[parameter.name]
+                    else:
+                        value = None
                     sourceItems = self.getItemsFromParamValue(value)
                     for sourceItem, sourceIdx in sourceItems:
                         arrow = ModelerArrowItem(sourceItem, sourceIdx, self.algItems[alg.name], idx)


### PR DESCRIPTION
...when the parameters in the included algorithms change.

For example, new parameters where recently added to GDAL Translate. Any model which includes this algorithm and which was created before the addition of new parameters can't be run any more. Also it can't be edited. Both actions cause an error. 

With the proposed changes, the model can be run (and edited) and the new parameters are given their default values. In addition a warning is displayed to the user when the model is executed, informing them that they should edit the model and assign proper values to the new parameters.

In my opinion this is a bug fix and should be included in QGIS 2.8.2 as well.
