### PR TITLE
filter the attribute table only if there is a selection (feature request #7541)

### DIFF
--- a/src/gui/attributetable/qgsattributetablefiltermodel.cpp
+++ b/src/gui/attributetable/qgsattributetablefiltermodel.cpp
@@ -177,7 +177,7 @@ bool QgsAttributeTableFilterModel::filterAcceptsRow( int sourceRow, const QModel
       return mFilteredFeatures.contains( masterModel()->rowToId( sourceRow ) );
 
     case ShowSelected:
-      return layer()->selectedFeaturesIds().contains( masterModel()->rowToId( sourceRow ) );
+      return layer()->selectedFeaturesIds().isEmpty() || layer()->selectedFeaturesIds().contains( masterModel()->rowToId( sourceRow ) );
 
     case ShowVisible:
       return mFilteredFeatures.contains( masterModel()->rowToId( sourceRow ) );


### PR DESCRIPTION
Show all records when you have no selection and open the attribute table in "show selection only" mode.

Before change, when doing so, the attribute table opened showing no record at all, which was kind of useless...

Ongoing discussion about this on qgis-ux ML (Attribute table - show selected features only when no selection), maybe it's better to wait for 2-3 more opinions before merging.
