### PR TITLE
Enable topological editing on first TopoGeometry layer creation

### DIFF
--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -23,6 +23,7 @@
 #include <qgsmessagelog.h>
 #include <qgsrectangle.h>
 #include <qgscoordinatereferencesystem.h>
+#include <qgsproject.h>
 
 #include <QMessageBox>
 
@@ -136,6 +137,9 @@ QgsPostgresProvider::QgsPostgresProvider( QString const & uri )
       disconnectDb();
       return;
     }
+
+    // Enable topological editing
+    QgsProject::instance()->writeEntry( "Digitizing", "/TopologicalEditing", true );
   }
 
   mLayerExtent.setMinimal();


### PR DESCRIPTION
@jef, this was reverted in 314c783b211fb75c2056cb272047739b1874eeaf on your input about
using "editingStarted" signal instead.

I'm using a pull request for discussion here.

I guess you meant to use the signal to limit the scope of configuration change to the sole editing of TopoGeometry layers, is that the case ?
