### PR TITLE
[spatialite] Allow a query without primary key

### DIFF
--- a/src/providers/spatialite/qgsspatialitefeatureiterator.h
+++ b/src/providers/spatialite/qgsspatialitefeatureiterator.h
@@ -93,6 +93,9 @@ class QgsSpatiaLiteFeatureIterator : public QgsAbstractFeatureIteratorFromSource
 
     //! Set to true, if geometry is in the requested columns
     bool mFetchGeometry;
+
+    bool mHasPrimaryKey;
+    QgsFeatureId mRowNumber;
 };
 
 #endif // QGSSPATIALITEFEATUREITERATOR_H

--- a/src/providers/spatialite/qgsspatialiteprovider.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovider.cpp
@@ -497,7 +497,7 @@ QgsSpatiaLiteProvider::QgsSpatiaLiteProvider( QString const &uri )
     closeDb();
     return;
   }
-  enabledCapabilities = QgsVectorDataProvider::SelectAtId | QgsVectorDataProvider::SelectGeometryAtId;
+  enabledCapabilities = mPrimaryKey.isEmpty() ? 0 : (QgsVectorDataProvider::SelectAtId | QgsVectorDataProvider::SelectGeometryAtId);
   if (( mTableBased || mViewBased ) &&  !mReadOnly )
   {
     // enabling editing only for Tables [excluding Views and VirtualShapes]

--- a/tests/src/python/test_qgsspatialiteprovider.py
+++ b/tests/src/python/test_qgsspatialiteprovider.py
@@ -76,10 +76,10 @@ class TestQgsSpatialiteProvider(TestCase):
         sql = "SELECT AddGeometryColumn('test_q', 'geometry', 4326, 'POLYGON', 'XY')"
         cur.execute(sql)
         sql = "INSERT INTO test_q (id, name, geometry) "
-        sql +=    "VALUES (1, 'toto', GeomFromText('POLYGON((0 0,1 0,1 1,0 1,0 0))', 4326))"
+        sql +=    "VALUES (11, 'toto', GeomFromText('POLYGON((0 0,1 0,1 1,0 1,0 0))', 4326))"
         cur.execute(sql)
         sql = "INSERT INTO test_q (id, name, geometry) "
-        sql +=    "VALUES (2, 'toto', GeomFromText('POLYGON((0 0,1 0,1 1,0 1,0 0))', 4326))"
+        sql +=    "VALUES (21, 'toto', GeomFromText('POLYGON((0 0,1 0,1 1,0 1,0 0))', 4326))"
         cur.execute(sql)
 
         # simple table with a geometry column named 'Geometry'
@@ -150,32 +150,31 @@ class TestQgsSpatialiteProvider(TestCase):
         """Test loading of query-based layers"""
 
         # a query with a geometry, but no unique id
-        # this allows to load a query without unique id
-        # however, functions relying on such a unique id would fail
+        # the id will be autoincremented
         l = QgsVectorLayer("dbname=%s table='(select * from test_q)' (geometry)" % self.dbname, "test_pg_query1", "spatialite")
         assert(l.isValid())
-        # the id() is not consistent
+        # the id() is autoincremented
         sum_id1 = sum(f.id() for f in l.getFeatures())
         # the attribute 'id' works
         sum_id2 = sum(f.attributes()[0] for f in l.getFeatures())
-        assert(sum_id1 == 0)
-        assert(sum_id2 == 3)
+        assert(sum_id1 == 3) # 1+2
+        assert(sum_id2 == 32) # 11 + 21
 
         # and now with an id declared
         l = QgsVectorLayer("dbname=%s table='(select * from test_q)' (geometry) key='id'" % self.dbname, "test_pg_query1", "spatialite")
         assert(l.isValid())
         sum_id1 = sum(f.id() for f in l.getFeatures())
         sum_id2 = sum(f.attributes()[0] for f in l.getFeatures())
-        assert(sum_id1 == 3)
-        assert(sum_id2 == 3)
+        assert(sum_id1 == 32)
+        assert(sum_id2 == 32)
 
         # a query, but no geometry
         l = QgsVectorLayer("dbname=%s table='(select id,name from test_q)' key='id'" % self.dbname, "test_pg_query1", "spatialite")
         assert(l.isValid())
         sum_id1 = sum(f.id() for f in l.getFeatures())
         sum_id2 = sum(f.attributes()[0] for f in l.getFeatures())
-        assert(sum_id1 == 3)
-        assert(sum_id2 == 3)
+        assert(sum_id1 == 32)
+        assert(sum_id2 == 32)
 
     def test_case(self):
         """Test case sensitivity issues"""


### PR DESCRIPTION
This allows to use a query as a table without primary key. It will auto increments an internal counter as feature id in this case.
