### PR TITLE
[BUGFIX] Update DatumTransformInfo on layerCrsChanged

### DIFF
--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -417,6 +417,7 @@ void QgsMapCanvas::setLayerSet( QList<QgsMapCanvasLayer> &layers )
       if ( !currentLayer )
         continue;
       disconnect( currentLayer, SIGNAL( repaintRequested() ), this, SLOT( refresh() ) );
+      disconnect( currentLayer, SIGNAL( layerCrsChanged() ), this, SLOT( layerCrsChange() ) );
       QgsVectorLayer *isVectLyr = qobject_cast<QgsVectorLayer *>( currentLayer );
       if ( isVectLyr )
       {
@@ -432,6 +433,7 @@ void QgsMapCanvas::setLayerSet( QList<QgsMapCanvasLayer> &layers )
       // Ticket #811 - racicot
       QgsMapLayer *currentLayer = layer( i );
       connect( currentLayer, SIGNAL( repaintRequested() ), this, SLOT( refresh() ) );
+      connect( currentLayer, SIGNAL( layerCrsChanged() ), this, SLOT( layerCrsChange() ) );
       QgsVectorLayer *isVectLyr = qobject_cast<QgsVectorLayer *>( currentLayer );
       if ( isVectLyr )
       {
@@ -1578,6 +1580,15 @@ void QgsMapCanvas::layerStateChange()
 
 } // layerStateChange
 
+void QgsMapCanvas::layerCrsChange()
+{
+  // called when a layer's CRS has been changed
+  QObject *theSender = sender();
+  QgsMapLayer *layer = qobject_cast<QgsMapLayer *>( theSender );
+  QString destAuthId = mSettings.destinationCrs().authid();
+  getDatumTransformInfo( layer, layer->crs().authid(), destAuthId );
+
+} // layerCrsChange
 
 
 void QgsMapCanvas::freeze( bool frz )

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -409,6 +409,9 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
 
     //! This slot is connected to the visibility change of one or more layers
     void layerStateChange();
+    
+    //! This slot is connected to the layer's CRS change
+    void layerCrsChange();
 
     //! Whether to suppress rendering or not
     void setRenderFlag( bool theFlag );


### PR DESCRIPTION
The QgsMapCanvas datumTransformInfo is not updated after a layerCrsChanged.
 This causes a bug in QGIS-Server which does not use the right srcAuthId.

To update QgsMapCanvas datumTransformInfo, the user had to change the map
 canvas CRS or to disable/enable transform.

This patch add a SLOT to the QgsMapLayer layerCrs Changed SIGNAL to update
 QgsMapCanvas datumTransformInfo.
