### PR TITLE
Don`t change current visibility flag of rubberband on updates

### DIFF
--- a/src/gui/qgsrubberband.cpp
+++ b/src/gui/qgsrubberband.cpp
@@ -182,6 +182,7 @@ void QgsRubberBand::addPoint( const QgsPoint & p, bool doUpdate /* = true */, in
 
   if ( doUpdate )
   {
+    setVisible( true );
     updateRect();
     update();
   }
@@ -418,6 +419,7 @@ void QgsRubberBand::addGeometry( QgsGeometry* geom, QgsVectorLayer* layer )
       return;
   }
 
+  setVisible( true );
   updateRect();
   update();
 }
@@ -567,7 +569,6 @@ void QgsRubberBand::updateRect()
   QgsRectangle rect( topLeft.x(), topLeft.y(), topLeft.x() + r.width()*res, topLeft.y() - r.height()*res );
 
   setRect( rect );
-  setVisible( isVisible() );
 }
 
 void QgsRubberBand::updatePosition( )

--- a/src/gui/qgsrubberband.cpp
+++ b/src/gui/qgsrubberband.cpp
@@ -567,7 +567,7 @@ void QgsRubberBand::updateRect()
   QgsRectangle rect( topLeft.x(), topLeft.y(), topLeft.x() + r.width()*res, topLeft.y() - r.height()*res );
 
   setRect( rect );
-  setVisible( true );
+  setVisible( isVisible() );
 }
 
 void QgsRubberBand::updatePosition( )

--- a/tests/src/gui/testqgsrubberband.cpp
+++ b/tests/src/gui/testqgsrubberband.cpp
@@ -128,6 +128,7 @@ void TestQgsRubberband::testBoundingRect()
   mRubberband->setIconSize( 5 ); // default, but better be explicit
   mRubberband->setWidth( 1 );    // default, but better be explicit
   mRubberband->addGeometry( geom.data(), mPolygonLayer );
+  mRubberband->setVisible( true );
 
   // 20 pixels for the extent + 3 for pen & icon per side + 2 of padding
   QCOMPARE( mRubberband->boundingRect(), QRectF(QPointF(-1,-1),QSizeF(28,28)) );
@@ -151,6 +152,11 @@ void TestQgsRubberband::testBoundingRect()
     mapSize.height() - ( 30 + 3 ) * 2
   ) );
 
+  // Check visibility after zoom
+  mRubberband->setVisible( false );
+  mCanvas->zoomIn();
+  QCOMPARE( mRubberband->isVisible(), false );
+  
 }
 
 


### PR DESCRIPTION
If you hide rubberband and then zoom map, rubberband will be shown again.
