### PR TITLE
Refactor displayField to displayExpression/mapTipTemplate

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -479,6 +479,8 @@ plugins calling this method will need to be updated.</li>
 setExcludeAttributesWms()</li>
 <li>excludeAttributesWFS() and setExcludeAttributesWFS() have been renamed to excludeAttributesWfs() and 
 setExcludeAttributesWfs()</li>
+<li>The displayField property has been separated from the mapTip. For a plain text short title use the
+displayExpression instead. For the map tip use mapTipTemplate() instead.</li>
 <li>changeGeometry() now accepts a geometry reference, not a pointer.</li>
 <li>The geometryChanged() signal now uses a const QgsGeometry reference.</li>
 <li>The deprecated removePolygonIntersections has been removed.</li>

--- a/python/core/qgsvectorlayer.sip
+++ b/python/core/qgsvectorlayer.sip
@@ -187,11 +187,14 @@ class QgsVectorLayer : QgsMapLayer
     /** Returns a comment for the data in the layer */
     QString dataComment() const;
 
-    /** Set the primary display field to be used in the identify results dialog */
-    void setDisplayField( const QString& fldName = "" );
-
-    /** Returns the primary display field name used in the identify results dialog */
-    const QString displayField() const;
+    /**
+     * This is a shorthand for accessing the displayExpression if it is a simple field.
+     * If the displayExpression is more complex than a simple field, a null string will
+     * be returned.
+     *
+     * @see displayExpression
+     */
+    QString displayField() const;
 
     /** Set the preview expression, used to create a human readable preview string.
      *  Used e.g. in the attribute table feature list. Uses { @link QgsExpression }.
@@ -1414,6 +1417,24 @@ class QgsVectorLayer : QgsMapLayer
      */
     void setAttributeTableConfig( const QgsAttributeTableConfig& attributeTableConfig );
 
+    /**
+     * The mapTip is a pretty, html representation for feature information.
+     *
+     * It may also contain embedded expressions.
+     *
+     * @note added in 3.0
+     */
+    QString mapTipTemplate() const;
+
+    /**
+     * The mapTip is a pretty, html representation for feature information.
+     *
+     * It may also contain embedded expressions.
+     *
+     * @note added in 3.0
+     */
+    void setMapTipTemplate( const QString& mapTipTemplate );
+
   public slots:
     /**
      * Select feature by its ID
@@ -1674,6 +1695,20 @@ class QgsVectorLayer : QgsMapLayer
      * @param errorMessage Write error messages into this string.
      */
     void writeCustomSymbology( QDomElement& element, QDomDocument& doc, QString& errorMessage ) const;
+
+    /**
+     * Emitted when the map tip changes
+     *
+     * @note added in 3.0
+     */
+    void mapTipTemplateChanged();
+
+    /**
+     * Emitted when the display expression changes
+     *
+     * @note added in 3.0
+     */
+    void displayExpressionChanged();
 
     /**
      * Signals an error related to this vector layer.

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -3150,6 +3150,8 @@ void QgisApp::createMapTips()
   connect( mpMapTipsTimer, SIGNAL( timeout() ), this, SLOT( showMapTip() ) );
   // set the interval to 0.850 seconds - timer will be started next time the mouse moves
   mpMapTipsTimer->setInterval( 850 );
+  mpMapTipsTimer->setSingleShot( true );
+
   // Create the maptips object
   mpMaptip = new QgsMapTip();
 }
@@ -10158,32 +10160,21 @@ void QgisApp::removeMapToolMessage()
 // Show the maptip using tooltip
 void QgisApp::showMapTip()
 {
-  // Stop the timer while we look for a maptip
-  mpMapTipsTimer->stop();
+  QPoint myPointerPos = mMapCanvas->mouseLastXY();
 
-  // Only show tooltip if the mouse is over the canvas
-  if ( mMapCanvas->underMouse() )
+  //  Make sure there is an active layer before proceeding
+  QgsMapLayer* mypLayer = mMapCanvas->currentLayer();
+  if ( mypLayer )
   {
-    QPoint myPointerPos = mMapCanvas->mouseLastXY();
-
-    //  Make sure there is an active layer before proceeding
-    QgsMapLayer* mypLayer = mMapCanvas->currentLayer();
-    if ( mypLayer )
+    //QgsDebugMsg("Current layer for maptip display is: " + mypLayer->source());
+    // only process vector layers
+    if ( mypLayer->type() == QgsMapLayer::VectorLayer )
     {
-      //QgsDebugMsg("Current layer for maptip display is: " + mypLayer->source());
-      // only process vector layers
-      if ( mypLayer->type() == QgsMapLayer::VectorLayer )
+      // Show the maptip if the maptips button is depressed
+      if ( mMapTipsVisible )
       {
-        // Show the maptip if the maptips button is depressed
-        if ( mMapTipsVisible )
-        {
-          mpMaptip->showMapTip( mypLayer, mLastMapPosition, myPointerPos, mMapCanvas );
-        }
+        mpMaptip->showMapTip( mypLayer, mLastMapPosition, myPointerPos, mMapCanvas );
       }
-    }
-    else
-    {
-      showStatusMessage( tr( "Maptips require an active layer" ) );
     }
   }
 }

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -473,10 +473,11 @@ void QgsIdentifyResultsDialog::addFeature( QgsVectorLayer *vlayer, const QgsFeat
   const QgsFields &fields = vlayer->fields();
   QgsAttributes attrs = f.attributes();
   bool featureLabeled = false;
+
   for ( int i = 0; i < attrs.count(); ++i )
   {
     if ( i >= fields.count() )
-      continue;
+      break;
 
     if ( vlayer->editFormConfig()->widgetType( i ) == "Hidden" )
     {
@@ -524,8 +525,14 @@ void QgsIdentifyResultsDialog::addFeature( QgsVectorLayer *vlayer, const QgsFeat
 
   if ( !featureLabeled )
   {
-    featItem->setText( 0, tr( "feature id" ) );
-    featItem->setText( 1, QString::number( f.id() ) );
+    featItem->setText( 0, tr( "Title" ) );
+    QgsExpressionContext context;
+    context << QgsExpressionContextUtils::globalScope()
+    << QgsExpressionContextUtils::projectScope()
+    << QgsExpressionContextUtils::layerScope( vlayer );
+    context.setFeature( f );
+
+    featItem->setText( 1, QgsExpression( vlayer->displayExpression() ).evaluate( &context ).toString() );
   }
 
   // table

--- a/src/app/qgsvectorlayerproperties.h
+++ b/src/app/qgsvectorlayerproperties.h
@@ -57,9 +57,6 @@ class APP_EXPORT QgsVectorLayerProperties : public QgsOptionsDialogBase, private
     QString displayName();
     void setRendererDirty( bool ) {}
 
-    /** Sets the attribute that is used in the Identify Results dialog box*/
-    void setDisplayField( const QString& name );
-
     /** Adds an attribute to the table (but does not commit it yet)
     @param field the field to add
     @return false in case of a name conflict, true in case of success */
@@ -75,10 +72,7 @@ class APP_EXPORT QgsVectorLayerProperties : public QgsOptionsDialogBase, private
 
   public slots:
 
-    /** Insert a field in the expression text for the map tip **/
-    void insertField();
-
-    void insertExpression();
+    void insertFieldOrExpression();
 
     /** Reset to original (vector layer) values */
     void syncToLayer();
@@ -146,7 +140,7 @@ class APP_EXPORT QgsVectorLayerProperties : public QgsOptionsDialogBase, private
      */
     void updateFieldsPropertiesDialog();
 
-  protected:
+  private:
 
     void saveStyleAs( StyleType styleType );
 
@@ -194,6 +188,10 @@ class APP_EXPORT QgsVectorLayerProperties : public QgsOptionsDialogBase, private
 
     /** Adds a new join to mJoinTreeWidget*/
     void addJoinToTreeWidget( const QgsVectorJoinInfo& join , const int insertIndex = -1 );
+
+    QgsExpressionContext mContext;
+
+    static QgsExpressionContext _getExpressionContext( const void* context );
 
   private slots:
     void openPanel( QgsPanelWidget* panel );

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -409,6 +409,9 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
 {
     Q_OBJECT
 
+    Q_PROPERTY( QString displayExpression READ displayExpression WRITE setDisplayExpression NOTIFY displayExpressionChanged )
+    Q_PROPERTY( QString mapTipTemplate READ mapTipTemplate WRITE setMapTipTemplate NOTIFY mapTipTemplateChanged )
+
   public:
 
     typedef QgsEditFormConfig::GroupData GroupData;
@@ -552,11 +555,14 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
     /** Returns a comment for the data in the layer */
     QString dataComment() const;
 
-    /** Set the primary display field to be used in the identify results dialog */
-    void setDisplayField( const QString& fldName = "" );
-
-    /** Returns the primary display field name used in the identify results dialog */
-    const QString displayField() const;
+    /**
+     * This is a shorthand for accessing the displayExpression if it is a simple field.
+     * If the displayExpression is more complex than a simple field, a null string will
+     * be returned.
+     *
+     * @see displayExpression
+     */
+    QString displayField() const;
 
     /** Set the preview expression, used to create a human readable preview string.
      *  Used e.g. in the attribute table feature list. Uses { @link QgsExpression }.
@@ -564,7 +570,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
      *  @param displayExpression The expression which will be used to preview features
      *                           for this layer
      */
-    void setDisplayExpression( const QString &displayExpression );
+    void setDisplayExpression( const QString& displayExpression );
 
     /**
      *  Get the preview expression, used to create a human readable preview string.
@@ -626,7 +632,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
     void removeExpressionField( int index );
 
     /**
-     * Returns the expressoin used for a given expression field
+     * Returns the expression used for a given expression field
      *
      * @param index An index of an epxression based (virtual) field
      *
@@ -1821,6 +1827,24 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
      */
     void setAttributeTableConfig( const QgsAttributeTableConfig& attributeTableConfig );
 
+    /**
+     * The mapTip is a pretty, html representation for feature information.
+     *
+     * It may also contain embedded expressions.
+     *
+     * @note added in 3.0
+     */
+    QString mapTipTemplate() const;
+
+    /**
+     * The mapTip is a pretty, html representation for feature information.
+     *
+     * It may also contain embedded expressions.
+     *
+     * @note added in 3.0
+     */
+    void setMapTipTemplate( const QString& mapTipTemplate );
+
   public slots:
     /**
      * Select feature by its ID
@@ -2083,6 +2107,20 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
     void writeCustomSymbology( QDomElement& element, QDomDocument& doc, QString& errorMessage ) const;
 
     /**
+     * Emitted when the map tip changes
+     *
+     * @note added in 3.0
+     */
+    void mapTipTemplateChanged();
+
+    /**
+     * Emitted when the display expression changes
+     *
+     * @note added in 3.0
+     */
+    void displayExpressionChanged();
+
+    /**
      * Signals an error related to this vector layer.
      */
     void raiseError( const QString& msg );
@@ -2141,11 +2179,10 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
     /** Pointer to data provider derived from the abastract base class QgsDataProvider */
     QgsVectorDataProvider *mDataProvider;
 
-    /** Index of the primary label field */
-    QString mDisplayField;
-
     /** The preview expression used to generate a human readable preview string for features */
     QString mDisplayExpression;
+
+    QString mMapTipTemplate;
 
     /** Data provider key */
     QString mProviderKey;

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -126,55 +126,10 @@ void QgsDualView::columnBoxInit()
   // default expression: saved value
   QString displayExpression = mLayerCache->layer()->displayExpression();
 
-  // if no display expression is saved: use display field instead
   if ( displayExpression.isEmpty() )
   {
-    if ( !mLayerCache->layer()->displayField().isEmpty() )
-    {
-      defaultField = mLayerCache->layer()->displayField();
-      displayExpression = QString( "COALESCE(\"%1\", '<NULL>')" ).arg( defaultField );
-    }
-  }
-
-  // if neither display expression nor display field is saved...
-  if ( displayExpression.isEmpty() )
-  {
-    QgsAttributeList pkAttrs = mLayerCache->layer()->pkAttributeList();
-
-    if ( !pkAttrs.isEmpty() )
-    {
-      if ( pkAttrs.size() == 1 )
-        defaultField = pkAttrs.at( 0 );
-
-      // ... If there are primary key(s) defined
-      QStringList pkFields;
-
-      Q_FOREACH ( int attr, pkAttrs )
-      {
-        pkFields.append( "COALESCE(\"" + fields[attr].name() + "\", '<NULL>')" );
-      }
-
-      displayExpression = pkFields.join( "||', '||" );
-    }
-    else if ( !fields.isEmpty() )
-    {
-      if ( fields.size() == 1 )
-        defaultField = fields.at( 0 ).name();
-
-      // ... concat all fields
-      QStringList fieldNames;
-      Q_FOREACH ( const QgsField& field, fields )
-      {
-        fieldNames.append( "COALESCE(\"" + field.name() + "\", '<NULL>')" );
-      }
-
-      displayExpression = fieldNames.join( "||', '||" );
-    }
-    else
-    {
-      // ... there isn't really much to display
-      displayExpression = "'[Please define preview text]'";
-    }
+    // ... there isn't really much to display
+    displayExpression = "'[Please define preview text]'";
   }
 
   mFeatureListPreviewButton->addAction( mActionExpressionPreview );

--- a/src/gui/qgsmaptip.h
+++ b/src/gui/qgsmaptip.h
@@ -32,7 +32,7 @@ class QgsWebView;
  * when a mouse is hovered over a feature.
  *
  * Since QGIS 2.16 a maptip can show full html.
- * QgsMapTip is a QgsWebview, so you can load full HTML/JS/CSS in it.
+ * QgsMapTip is a QgsWebView, so you can load full HTML/JS/CSS in it.
  *
  * The code found in the map tips tab is inserted in a inline-block div
  * so the frame can be resized based on the content size.
@@ -46,7 +46,7 @@ class QgsWebView;
  * discourages link rel="stylesheet" in the body, but all browsers allow it.
  * see https://jakearchibald.com/2016/link-in-body/
  */
-class GUI_EXPORT QgsMapTip: public QWidget
+class GUI_EXPORT QgsMapTip : public QWidget
 {
     Q_OBJECT
   public:
@@ -78,7 +78,7 @@ class GUI_EXPORT QgsMapTip: public QWidget
     // Only the first feature in the search radius is used
     QString fetchFeature( QgsMapLayer * thepLayer,
                           QgsPoint & theMapPosition,
-                          QgsMapCanvas *thepMapCanvas );
+                          QgsMapCanvas *mapCanvas );
 
     QString replaceText(
       QString displayText, QgsVectorLayer *layer, QgsFeature &feat );

--- a/src/server/qgsserverprojectparser.cpp
+++ b/src/server/qgsserverprojectparser.cpp
@@ -774,8 +774,15 @@ void QgsServerProjectParser::addLayerProjectSettings( QDomElement& layerElem, QD
   {
     QgsVectorLayer* vLayer = static_cast<QgsVectorLayer*>( currentLayer );
     const QSet<QString>& excludedAttributes = vLayer->excludeAttributesWms();
-    int displayFieldIdx = vLayer->fieldNameIndex( vLayer->displayField() );
-    QString displayField = displayFieldIdx < 0 ? "maptip" : vLayer->displayField();
+
+    int displayFieldIdx = -1;
+    QString displayField = "maptip";
+    QgsExpression exp( vLayer->displayExpression() );
+    if ( exp.isField() )
+    {
+      displayField = static_cast<const QgsExpression::NodeColumnRef*>( exp.rootNode() )->name();
+      displayFieldIdx = vLayer->fieldNameIndex( displayField );
+    }
 
     //attributes
     QDomElement attributesElem = doc.createElement( "Attributes" );

--- a/src/server/qgswmsserver.cpp
+++ b/src/server/qgswmsserver.cpp
@@ -2332,16 +2332,13 @@ int QgsWmsServer::featureInfoFromVectorLayer( QgsVectorLayer* layer,
       }
 
       //add maptip attribute based on html/expression (in case there is no maptip attribute)
-      if ( layer->fieldNameIndex( layer->displayField() ) < 0 )
+      QString mapTip = layer->mapTipTemplate();
+      if ( !mapTip.isEmpty() )
       {
-        QString displayField = layer->displayField();
-        if ( !displayField.isEmpty() )
-        {
-          QDomElement maptipElem = infoDocument.createElement( "Attribute" );
-          maptipElem.setAttribute( "name", "maptip" );
-          maptipElem.setAttribute( "value",  QgsExpression::replaceExpressionText( displayField, &renderContext.expressionContext() ) );
-          featureElement.appendChild( maptipElem );
-        }
+        QDomElement maptipElem = infoDocument.createElement( "Attribute" );
+        maptipElem.setAttribute( "name", "maptip" );
+        maptipElem.setAttribute( "value",  QgsExpression::replaceExpressionText( mapTip, &renderContext.expressionContext() ) );
+        featureElement.appendChild( maptipElem );
       }
 
       //append feature bounding box to feature info xml
@@ -3303,12 +3300,13 @@ QDomElement QgsWmsServer::createFeatureGML(
   }
 
   //add maptip attribute based on html/expression (in case there is no maptip attribute)
-  if ( layer && layer->fieldNameIndex( layer->displayField() ) < 0 )
+  if ( layer )
   {
-    QString displayField = layer->displayField();
-    if ( !displayField.isEmpty() )
+    QString mapTip = layer->mapTipTemplate();
+
+    if ( !mapTip.isEmpty() )
     {
-      QString fieldTextString = QgsExpression::replaceExpressionText( displayField, &expressionContext );
+      QString fieldTextString = QgsExpression::replaceExpressionText( mapTip, &expressionContext );
       QDomElement fieldElem = doc.createElement( "qgs:maptip" );
       QDomText maptipText = doc.createTextNode( fieldTextString );
       fieldElem.appendChild( maptipText );

--- a/src/ui/qgsvectorlayerpropertiesbase.ui
+++ b/src/ui/qgsvectorlayerpropertiesbase.ui
@@ -270,7 +270,7 @@
           </sizepolicy>
          </property>
          <property name="currentIndex">
-          <number>0</number>
+          <number>5</number>
          </property>
          <widget class="QWidget" name="mOptsPage_General">
           <layout class="QVBoxLayout" name="verticalLayout_14">
@@ -299,8 +299,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>730</width>
-                <height>537</height>
+                <width>303</width>
+                <height>443</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_13">
@@ -758,8 +758,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>721</width>
-                <height>232</height>
+                <width>709</width>
+                <height>250</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_32">
@@ -921,166 +921,82 @@
             <number>0</number>
            </property>
            <item>
-            <widget class="QScrollArea" name="scrollArea_10">
-             <property name="frameShape">
-              <enum>QFrame::NoFrame</enum>
-             </property>
-             <property name="widgetResizable">
+            <widget class="QWidget" name="scrollArea_10" native="true">
+             <property name="widgetResizable" stdset="0">
               <bool>true</bool>
              </property>
-             <widget class="QWidget" name="scrollAreaWidgetContents_10">
-              <property name="geometry">
-               <rect>
-                <x>0</x>
-                <y>0</y>
-                <width>487</width>
-                <height>182</height>
-               </rect>
-              </property>
-              <layout class="QVBoxLayout" name="verticalLayout_26">
-               <property name="leftMargin">
-                <number>0</number>
-               </property>
-               <property name="topMargin">
-                <number>0</number>
-               </property>
-               <property name="rightMargin">
-                <number>0</number>
-               </property>
-               <property name="bottomMargin">
-                <number>0</number>
-               </property>
-               <item>
-                <widget class="QGroupBox" name="groupBox_2">
-                 <property name="title">
-                  <string>Map tip display text</string>
-                 </property>
-                 <property name="syncGroup" stdset="0">
-                  <string notr="true">vectordisplay</string>
-                 </property>
-                 <layout class="QGridLayout" name="gridLayout_18">
-                  <item row="4" column="2">
-                   <layout class="QHBoxLayout" name="horizontalLayout_14">
-                    <item>
-                     <widget class="QPushButton" name="insertExpressionButton">
-                      <property name="enabled">
-                       <bool>false</bool>
-                      </property>
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="toolTip">
-                       <string>Inserts an expression into the action</string>
-                      </property>
-                      <property name="text">
-                       <string>Insert expression...</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <spacer name="horizontalSpacer_4">
-                      <property name="orientation">
-                       <enum>Qt::Horizontal</enum>
-                      </property>
-                      <property name="sizeType">
-                       <enum>QSizePolicy::Fixed</enum>
-                      </property>
-                      <property name="sizeHint" stdset="0">
-                       <size>
-                        <width>40</width>
-                        <height>20</height>
-                       </size>
-                      </property>
-                     </spacer>
-                    </item>
-                    <item>
-                     <widget class="QgsFieldComboBox" name="fieldComboBox">
-                      <property name="enabled">
-                       <bool>false</bool>
-                      </property>
-                      <property name="toolTip">
-                       <string>The valid attribute names for this layer</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <widget class="QPushButton" name="insertFieldButton">
-                      <property name="enabled">
-                       <bool>false</bool>
-                      </property>
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="toolTip">
-                       <string>Inserts the selected field into the action</string>
-                      </property>
-                      <property name="text">
-                       <string>Insert field</string>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </item>
-                  <item row="2" column="2">
-                   <widget class="QTextEdit" name="htmlMapTip">
-                    <property name="enabled">
-                     <bool>false</bool>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="2" column="0">
-                   <layout class="QVBoxLayout" name="verticalLayout_5">
-                    <item>
-                     <widget class="QRadioButton" name="htmlRadio">
-                      <property name="text">
-                       <string>HTML</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item>
-                     <spacer name="verticalSpacer_2">
-                      <property name="orientation">
-                       <enum>Qt::Vertical</enum>
-                      </property>
-                      <property name="sizeHint" stdset="0">
-                       <size>
-                        <width>20</width>
-                        <height>0</height>
-                       </size>
-                      </property>
-                     </spacer>
-                    </item>
-                   </layout>
-                  </item>
-                  <item row="1" column="0">
-                   <layout class="QVBoxLayout" name="verticalLayout_6">
-                    <item>
-                     <widget class="QRadioButton" name="fieldComboRadio">
-                      <property name="text">
-                       <string>Field</string>
-                      </property>
-                     </widget>
-                    </item>
-                   </layout>
-                  </item>
-                  <item row="1" column="2">
-                   <widget class="QgsFieldComboBox" name="displayFieldComboBox">
-                    <property name="enabled">
-                     <bool>false</bool>
-                    </property>
-                   </widget>
-                  </item>
-                 </layout>
-                </widget>
-               </item>
-              </layout>
-             </widget>
+             <layout class="QGridLayout" name="gridLayout_10">
+              <item row="0" column="0">
+               <widget class="QLabel" name="label">
+                <property name="text">
+                 <string>Display expression</string>
+                </property>
+               </widget>
+              </item>
+              <item row="0" column="1">
+               <widget class="QgsFieldExpressionWidget" name="mDisplayExpressionWidget"/>
+              </item>
+              <item row="1" column="0" colspan="2">
+               <widget class="QGroupBox" name="groupBox_2">
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="title">
+                 <string>Map Tip</string>
+                </property>
+                <layout class="QGridLayout" name="gridLayout_8">
+                 <item row="1" column="2">
+                  <widget class="QPushButton" name="mInsertExpressionButton">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="toolTip">
+                    <string>Inserts the selected field or expression into the map tip</string>
+                   </property>
+                   <property name="text">
+                    <string>Insert</string>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="0" column="0" colspan="3">
+                  <widget class="QgsCodeEditorHTML" name="mMapTipWidget">
+                   <property name="sizePolicy">
+                    <sizepolicy hsizetype="Preferred" vsizetype="MinimumExpanding">
+                     <horstretch>0</horstretch>
+                     <verstretch>0</verstretch>
+                    </sizepolicy>
+                   </property>
+                   <property name="minimumSize">
+                    <size>
+                     <width>0</width>
+                     <height>100</height>
+                    </size>
+                   </property>
+                   <property name="frameShape">
+                    <enum>QFrame::StyledPanel</enum>
+                   </property>
+                   <property name="frameShadow">
+                    <enum>QFrame::Raised</enum>
+                   </property>
+                  </widget>
+                 </item>
+                 <item row="1" column="0" colspan="2">
+                  <widget class="QgsFieldExpressionWidget" name="mMapTipExpressionFieldWidget">
+                   <property name="toolTip">
+                    <string>The valid attribute names for this layer</string>
+                   </property>
+                  </widget>
+                 </item>
+                </layout>
+               </widget>
+              </item>
+             </layout>
             </widget>
            </item>
           </layout>
@@ -1178,8 +1094,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>134</width>
-                <height>113</height>
+                <width>152</width>
+                <height>115</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_23">
@@ -1347,8 +1263,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>393</width>
-                <height>641</height>
+                <width>351</width>
+                <height>681</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_3">
@@ -1842,12 +1758,6 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsFieldComboBox</class>
-   <extends>QComboBox</extends>
-   <header>qgsfieldcombobox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsProjectionSelectionWidget</class>
    <extends>QWidget</extends>
    <header>qgsprojectionselectionwidget.h</header>
@@ -1875,6 +1785,17 @@
    <header>qgslayertreeembeddedconfigwidget.h</header>
    <container>1</container>
   </customwidget>
+  <customwidget>
+   <class>QgsFieldExpressionWidget</class>
+   <extends>QComboBox</extends>
+   <header>qgsfieldexpressionwidget.h</header>
+  </customwidget>
+  <customwidget>
+   <class>QgsCodeEditorHTML</class>
+   <extends>QFrame</extends>
+   <header>qgscodeeditorhtml.h</header>
+   <container>1</container>
+  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>mOptionsListWidget</tabstop>
@@ -1899,13 +1820,6 @@
   <tabstop>mSimplifyMaximumScaleComboBox</tabstop>
   <tabstop>mForceRasterCheckBox</tabstop>
   <tabstop>scrollArea_10</tabstop>
-  <tabstop>fieldComboRadio</tabstop>
-  <tabstop>displayFieldComboBox</tabstop>
-  <tabstop>htmlRadio</tabstop>
-  <tabstop>htmlMapTip</tabstop>
-  <tabstop>insertExpressionButton</tabstop>
-  <tabstop>fieldComboBox</tabstop>
-  <tabstop>insertFieldButton</tabstop>
   <tabstop>scrollArea_6</tabstop>
   <tabstop>mJoinTreeWidget</tabstop>
   <tabstop>scrollArea_7</tabstop>


### PR DESCRIPTION
Previously there was the expressionField (a field name or an expression) mainly
used for the feature list in the form view of the dual view.
On the other hand there was the displayField which could contain either a
simple field name or a complex HTML structure with embedded expressions. And to
know what it was you could compare it's content with the field names, if a
field name matched, you used it as a displayField (original purpose) and if
not... well, you could deal with HTML if you had a use for it.

The main problem is that there are two different usages for this kind of thing
- plain text identifier (field or expression)
- pretty, rich text feature info

This commit cleans up with this. You want rich text and a lot of info: go for
the mapTip. You want a plain text string to identify features: go for the
featureTitle.
