### PR TITLE
Sldfix 11863

### DIFF
--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -2218,7 +2218,7 @@ bool QgsExpression::NodeUnaryOperator::prepare( QgsExpression* parent, const Qgs
 
 QString QgsExpression::NodeUnaryOperator::dump() const
 {
-  return QString( "%1%2" ).arg( UnaryOperatorText[mOp] ).arg( mOperand->dump() );
+  return QString( "%1 %2" ).arg( UnaryOperatorText[mOp] ).arg( mOperand->dump() );
 }
 
 //

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -2218,7 +2218,7 @@ bool QgsExpression::NodeUnaryOperator::prepare( QgsExpression* parent, const Qgs
 
 QString QgsExpression::NodeUnaryOperator::dump() const
 {
-  return QString( "%1 %2" ).arg( UnaryOperatorText[mOp] ).arg( mOperand->dump() );
+  return QString( "%1%2" ).arg( UnaryOperatorText[mOp] ).arg( mOperand->dump() );
 }
 
 //

--- a/src/core/qgsogcutils.cpp
+++ b/src/core/qgsogcutils.cpp
@@ -1948,9 +1948,10 @@ QDomElement QgsOgcUtils::expressionUnaryOperatorToOgcFilter( const QgsExpression
         uoElem.appendChild( doc.createTextNode( "-" + operandElem.text() ) );
         doc.removeChild(operandElem);
       }
-      else // not sure if this will ever happen
+      else
       {
-        uoElem.appendChild( doc.createTextNode( "-" ) );
+          errorMessage = QString( "This use of unary operator not implemented yet" );
+          return QDomElement();
       }
       break;
     case QgsExpression::uoNot:


### PR DESCRIPTION
This fixes http://hub.qgis.org/issues/11863

in which non valid xml was generated due to the dual generation of literal layers.

not sure if this is the obvious solution, but it works for the example case which is in the issue.

I also found out that using a minus in a column name raises other problems. Not related to this one as there the minus is not seen as an unary operator.

https://github.com/qgis/QGIS/commit/6122a9fff7697658c61b9f909179c87517aed67a is a minimal dump fix.
