### PR TITLE
Stop capturing on QgsMapToolCapture deactivate.

### DIFF
--- a/src/app/qgsmaptoolcapture.cpp
+++ b/src/app/qgsmaptoolcapture.cpp
@@ -77,6 +77,7 @@ void QgsMapToolCapture::deactivate()
   delete mSnappingMarker;
   mSnappingMarker = 0;
 
+  stopCapturing();
   QgsMapToolEdit::deactivate();
 }
 


### PR DESCRIPTION
When deactivating a QgsMapToolCapture (i.e. when switching mapTools in
the mapCanvas), stopCapturing should be called to delete unfinished
features.

Currently stopCapturing is only called on QgsMapToolCapture destruction, which 
happens at QGis exit only, not when switching mapTools or creating a new project.

This should fix http://hub.qgis.org/issues/4237
