### PR TITLE
[Processing] Changed default value of argument updateList in Processing.addProvider

### DIFF
--- a/python/plugins/processing/core/Processing.py
+++ b/python/plugins/processing/core/Processing.py
@@ -76,7 +76,7 @@ class Processing:
     modeler = ModelerAlgorithmProvider()
 
     @staticmethod
-    def addProvider(provider, updateList=False):
+    def addProvider(provider, updateList=True):
         """Use this method to add algorithms from external providers.
         """
 
@@ -127,18 +127,18 @@ class Processing:
     @staticmethod
     def initialize():
         # Add the basic providers
-        Processing.addProvider(QGISAlgorithmProvider())
-        Processing.addProvider(ModelerOnlyAlgorithmProvider())
-        Processing.addProvider(GdalOgrAlgorithmProvider())
-        Processing.addProvider(LidarToolsAlgorithmProvider())
-        Processing.addProvider(OTBAlgorithmProvider())
-        Processing.addProvider(RAlgorithmProvider())
-        Processing.addProvider(SagaAlgorithmProvider())
-        Processing.addProvider(GrassAlgorithmProvider())
-        Processing.addProvider(Grass7AlgorithmProvider())
-        Processing.addProvider(ScriptAlgorithmProvider())
-        Processing.addProvider(TauDEMAlgorithmProvider())
-        Processing.addProvider(Processing.modeler)
+        Processing.addProvider(QGISAlgorithmProvider(), updateList=False)
+        Processing.addProvider(ModelerOnlyAlgorithmProvider(), updateList=False)
+        Processing.addProvider(GdalOgrAlgorithmProvider(), updateList=False)
+        Processing.addProvider(LidarToolsAlgorithmProvider(), updateList=False)
+        Processing.addProvider(OTBAlgorithmProvider(), updateList=False)
+        Processing.addProvider(RAlgorithmProvider(), updateList=False)
+        Processing.addProvider(SagaAlgorithmProvider(), updateList=False)
+        Processing.addProvider(GrassAlgorithmProvider(), updateList=False)
+        Processing.addProvider(Grass7AlgorithmProvider(), updateList=False)
+        Processing.addProvider(ScriptAlgorithmProvider(), updateList=False)
+        Processing.addProvider(TauDEMAlgorithmProvider(), updateList=False)
+        Processing.addProvider(Processing.modeler, updateList=False)
         Processing.modeler.initializeSettings()
 
         # And initialize


### PR DESCRIPTION
This pull request is mostly about changing the default behaviour of the `Processing.addProvider()` method.

Currently, plugin authors implementing custom Processing providers must remember to set the argument `updateList=True` when they add a provider. If not, since this argument defaults to `False`, then Processing will not update the algorithms list (in the toolbox and modeller) until the user manually opens the Processing Settings dialog and presses the OK button.

Furthermore, there does not seem to be any place where a plugin author could discover that this parameter should be changed from its default value (other than reading `processing.core.Processing` source code). See [1] for an example of this not being very obvious.

Changing the `updateList` argument to `True` by default avoids this potential pitfall and (I guess) will keep both users and plugin authors happy :)

The impact of this change to existing code should be only positive. This pull request already takes care of the necessary changes to `Processing.core`. As for external plugins, the ones that were broken (by not changing the default value of `updateList`) will be automatically fixed while the plugins that did explicitly change the `updateList` parameter will continue to work correctly.

[1] - http://hub.qgis.org/issues/12513
