### PR TITLE
Make QgsDataSourceURI uri string parser skip invalid portions instead of skipping the entire string

### DIFF
--- a/src/core/qgsdatasourceuri.cpp
+++ b/src/core/qgsdatasourceuri.cpp
@@ -63,8 +63,8 @@ QgsDataSourceURI::QgsDataSourceURI( QString uri )
 
     if ( i == uri.length() || uri[i] != '=' )
     {
-      QgsDebugMsg( "= expected after parameter name" );
-      return;
+      QgsDebugMsg( QString( "= expected after parameter name, skipping text '%1'" ).arg( pname ) );
+      continue;
     }
 
     i++;
@@ -100,7 +100,6 @@ QgsDataSourceURI::QgsDataSourceURI( QString uri )
           i++;
 
           int start = i;
-          QString col;
           while ( i < uri.length() && uri[i] != ')' )
           {
             if ( uri[i] == '\\' )

--- a/tests/src/core/CMakeLists.txt
+++ b/tests/src/core/CMakeLists.txt
@@ -5,7 +5,7 @@ SET (util_SRCS qgscompositionchecker.cpp)
 #####################################################
 # Don't forget to include output directory, otherwise
 # the UI file won't be wrapped!
-INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR} 
+INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_BINARY_DIR}
   ${CMAKE_SOURCE_DIR}/src/core
   ${CMAKE_SOURCE_DIR}/src/core/composer
@@ -48,7 +48,7 @@ ENDIF (APPLE)
 #qtests in the executable file list as the moc is
 #directly included in the sources
 #and should not be compiled twice. Trying to include
-#them in will cause an error at build time 
+#them in will cause an error at build time
 
 #No relinking and full RPATH for the install tree
 #See: http://www.cmake.org/Wiki/CMake_RPATH_handling#No_relinking_and_full_RPATH_for_the_install_tree
@@ -152,3 +152,4 @@ ADD_QGIS_TEST(snappingutilstest testqgssnappingutils.cpp )
 ADD_QGIS_TEST(imageoperationtest testqgsimageoperation.cpp)
 ADD_QGIS_TEST(painteffecttest testqgspainteffect.cpp)
 ADD_QGIS_TEST(painteffectregistrytest testqgspainteffectregistry.cpp)
+ADD_QGIS_TEST(datasourceuritest testqgsdatasourceuri.cpp)

--- a/tests/src/core/testqgsdatasourceuri.cpp
+++ b/tests/src/core/testqgsdatasourceuri.cpp
@@ -1,0 +1,137 @@
+/***************************************************************************
+     testqgsrectangle.cpp
+     --------------------------------------
+    Date                 : Thu Apr 16 2015
+    Copyright            : (C) 2015 by Sandro Mani
+    Email                : manisandro@gmail.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include <QtTest/QtTest>
+#include <QObject>
+#include <QString>
+#include <QObject>
+//header for class being tested
+#include <qgsdatasourceuri.h>
+
+Q_DECLARE_METATYPE( QGis::WkbType )
+Q_DECLARE_METATYPE( QgsDataSourceURI::SSLmode )
+
+class TestQgsDataSourceUri: public QObject
+{
+    Q_OBJECT
+  private slots:
+    void checkparser();
+    void checkparser_data();
+};
+
+void TestQgsDataSourceUri::checkparser_data()
+{
+  QTest::addColumn<QString>( "uri" );
+  QTest::addColumn<QString>( "table" );
+  QTest::addColumn<QString>( "geometrycolumn" );
+  QTest::addColumn<QString>( "key" );
+  QTest::addColumn<bool>( "estimatedmetadata" );
+  QTest::addColumn<QString>( "srid" );
+  QTest::addColumn<QGis::WkbType>( "type" );
+  QTest::addColumn<bool>( "selectatid" );
+  QTest::addColumn<QString>( "service" );
+  QTest::addColumn<QString>( "user" );
+  QTest::addColumn<QString>( "password" );
+  QTest::addColumn<QString>( "dbname" );
+  QTest::addColumn<QString>( "host" );
+  QTest::addColumn<QString>( "port" );
+  QTest::addColumn<QgsDataSourceURI::SSLmode>( "sslmode" );
+  QTest::addColumn<QString>( "sql" );
+  QTest::addColumn<QString>( "myparam" );
+
+  QTest::newRow( "oci" )
+  << "host=myhost port=1234 user='myname' password='mypasswd' estimatedmetadata=true srid=1000003007 table=\"myschema\".\"mytable\" (GEOM) myparam='myvalue' sql="
+  << "mytable" // table
+  << "GEOM" // geometrycolumn
+  << "" // key
+  << true // estimatedmetadata
+  << "1000003007" // srid
+  << QGis::WKBUnknown // type
+  << false // selectatid
+  << "" // service
+  << "myname" // user
+  << "mypasswd" // password
+  << "" // dbname
+  << "myhost" // host
+  << "1234" // port
+  << QgsDataSourceURI::SSLprefer // sslmode
+  << "" // sql
+  << "myvalue" // myparam
+  ;
+
+  QTest::newRow( "pgrast" )
+  << "PG: dbname=mydb host=myhost user=myname password=mypasswd port=5432 mode=2 schema=public column=geom table=mytable"
+  << "mytable" // table
+  << "" // geometrycolumn
+  << "" // key
+  << false // estimatedmetadata
+  << "" // srid
+  << QGis::WKBUnknown // type
+  << false // selectatid
+  << "" // service
+  << "myname" // user
+  << "mypasswd" // password
+  << "mydb" // dbname
+  << "myhost" // host
+  << "5432" // port
+  << QgsDataSourceURI::SSLprefer // sslmode
+  << "" // sql
+  << "" // myparam
+  ;
+
+}
+
+void TestQgsDataSourceUri::checkparser()
+{
+  QFETCH( QString, uri );
+  QFETCH( QString, table );
+  QFETCH( QString, geometrycolumn );
+  QFETCH( QString, key );
+  QFETCH( bool, estimatedmetadata );
+  QFETCH( QString, srid );
+  QFETCH( QGis::WkbType, type );
+  QFETCH( bool, selectatid );
+  QFETCH( QString, service );
+  QFETCH( QString, user );
+  QFETCH( QString, password );
+  QFETCH( QString, dbname );
+  QFETCH( QString, host );
+  QFETCH( QString, port );
+  QFETCH( QgsDataSourceURI::SSLmode, sslmode );
+  QFETCH( QString, sql );
+  QFETCH( QString, myparam );
+
+  QgsDataSourceURI ds( uri );
+  QCOMPARE( ds.table(), table );
+  QCOMPARE( ds.geometryColumn(), geometrycolumn );
+  QCOMPARE( ds.keyColumn(), key );
+  QCOMPARE( ds.useEstimatedMetadata(), estimatedmetadata );
+  QCOMPARE( ds.srid(), srid );
+  QCOMPARE( ds.wkbType(), type );
+  QCOMPARE( ds.selectAtIdDisabled(), selectatid );
+  QCOMPARE( ds.service(), service );
+  QCOMPARE( ds.username(), user );
+  QCOMPARE( ds.password(), password );
+  QCOMPARE( ds.database(), dbname );
+  QCOMPARE( ds.host(), host );
+  QCOMPARE( ds.port(), port );
+  QCOMPARE( ds.sslMode(), sslmode );
+  QCOMPARE( ds.sql(), sql );
+  QCOMPARE( ds.param( "myparam" ), myparam );
+}
+
+
+QTEST_MAIN( TestQgsDataSourceUri )
+#include "testqgsdatasourceuri.moc"
+


### PR DESCRIPTION
Currently `QgsDataSourceURI` fails to parse uri strings such as

```
'PG: dbname=db_name host=hostname user=username password=passwd port=5432 mode=2 schema=public column=rast table=tablename'
```

the reason being the `PG:` which to the parser looks like a parameter name without a value. (Such uri strings are obtained for instance when adding a PG raster via DB Manager).

The commit changes the parser behaviour to just skip the invalid portions of the uri string, instead of skipping the entire string altogether.

Funded by Sourcepole
