### PR TITLE
[PROCESSING] Avoid run-time error

### DIFF
--- a/python/plugins/processing/algs/qgis/Eliminate.py
+++ b/python/plugins/processing/algs/qgis/Eliminate.py
@@ -243,6 +243,9 @@ class Eliminate(GeoAlgorithm):
                         # We have a candidate
                         iGeom = geom2Eliminate.intersection(selGeom)
 
+                        if iGeom == None:
+                            continue
+
                         if boundary:
                             selValue = iGeom.length()
                         else:


### PR DESCRIPTION
if intersection geometry is None (happens IMHO if geometries are not valid)
