### PR TITLE
Add ORACLE_INCLUDEDIR, ORACLE_LIBDIR CMake variables

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,8 @@ SET (WITH_QSPATIALITE FALSE CACHE BOOL "Determines whether QSPATIALITE sql drive
 SET (WITH_ORACLE FALSE CACHE BOOL "Determines whether Oracle support should be built")
 IF(WITH_ORACLE)
   SET(HAVE_ORACLE TRUE)
+  SET(ORACLE_INCLUDEDIR "" CACHE STRING "Path to OCI headers")
+  SET(ORACLE_LIBDIR "" CACHE STRING "Path to OCI libraries")
 ENDIF(WITH_ORACLE)
 
 

--- a/src/providers/oracle/ocispatial/cmake/FindOCI.cmake
+++ b/src/providers/oracle/ocispatial/cmake/FindOCI.cmake
@@ -12,6 +12,7 @@
 
 FIND_PATH(OCI_INCLUDE_DIR oci.h
   PATHS
+  ${ORACLE_INCLUDEDIR}
   /usr/include/oracle/11.2/client64
   $ENV{OSGEO4W_ROOT}/include
   $ENV{ORACLE_HOME}/rdbms/public
@@ -19,6 +20,7 @@ FIND_PATH(OCI_INCLUDE_DIR oci.h
 
 FIND_LIBRARY(OCI_LIBRARY clntsh oci
   PATHS
+  ${ORACLE_LIBDIR}
   /usr/lib/oracle/11.2/client64/lib/
   $ENV{OSGEO4W_ROOT}/lib
   $ENV{ORACLE_HOME}/lib


### PR DESCRIPTION
This patch makes Oracle detection more flexible.
