### PR TITLE
[Processing] Fix bug with displaying result graphs by adding <html> tags.

### DIFF
--- a/python/plugins/processing/algs/qgis/BarPlot.py
+++ b/python/plugins/processing/algs/qgis/BarPlot.py
@@ -74,5 +74,5 @@ class BarPlot(GeoAlgorithm):
         plotFilename = output + '.png'
         lab.savefig(plotFilename)
         f = open(output, 'w')
-        f.write('<img src="' + plotFilename + '"/>')
+        f.write('<html><img src="' + plotFilename + '"/></html>')
         f.close()

--- a/python/plugins/processing/algs/qgis/MeanAndStdDevPlot.py
+++ b/python/plugins/processing/algs/qgis/MeanAndStdDevPlot.py
@@ -84,5 +84,5 @@ class MeanAndStdDevPlot(GeoAlgorithm):
         plotFilename = output + '.png'
         lab.savefig(plotFilename)
         f = open(output, 'w')
-        f.write('<img src="' + plotFilename + '"/>')
+        f.write('<html><img src="' + plotFilename + '"/></html>')
         f.close()

--- a/python/plugins/processing/algs/qgis/PolarPlot.py
+++ b/python/plugins/processing/algs/qgis/PolarPlot.py
@@ -78,5 +78,5 @@ class PolarPlot(GeoAlgorithm):
         plotFilename = output + '.png'
         lab.savefig(plotFilename)
         f = open(output, 'w')
-        f.write('<img src="' + plotFilename + '"/>')
+        f.write('<html><img src="' + plotFilename + '"/></html>')
         f.close()

--- a/python/plugins/processing/algs/qgis/RasterLayerHistogram.py
+++ b/python/plugins/processing/algs/qgis/RasterLayerHistogram.py
@@ -87,5 +87,5 @@ class RasterLayerHistogram(GeoAlgorithm):
         plotFilename = outputplot + '.png'
         lab.savefig(plotFilename)
         f = open(outputplot, 'w')
-        f.write('<img src="' + plotFilename + '"/>')
+        f.write('<html><img src="' + plotFilename + '"/></html>')
         f.close()

--- a/python/plugins/processing/algs/qgis/VectorLayerHistogram.py
+++ b/python/plugins/processing/algs/qgis/VectorLayerHistogram.py
@@ -72,5 +72,5 @@ class VectorLayerHistogram(GeoAlgorithm):
         plotFilename = output + '.png'
         lab.savefig(plotFilename)
         f = open(output, 'w')
-        f.write('<img src="' + plotFilename + '"/>')
+        f.write('<html><img src="' + plotFilename + '"/></html>')
         f.close()

--- a/python/plugins/processing/algs/qgis/VectorLayerScatterplot.py
+++ b/python/plugins/processing/algs/qgis/VectorLayerScatterplot.py
@@ -75,5 +75,5 @@ class VectorLayerScatterplot(GeoAlgorithm):
         plotFilename = output + '.png'
         lab.savefig(plotFilename)
         f = open(output, 'w')
-        f.write('<img src="' + plotFilename + '"/>')
+        f.write('<html><img src="' + plotFilename + '"/></html>')
         f.close()


### PR DESCRIPTION
The result graphs are not displayed properly in the Processing Results Viewer if there are no <html> tags. Tested with QGIS 2.8.1 on Windows 7 64 bit.
