### PR TITLE
[db_manager] backport 2.8.2 fix #12429 run only the selected query

### DIFF
--- a/python/plugins/db_manager/dlg_sql_window.py
+++ b/python/plugins/db_manager/dlg_sql_window.py
@@ -101,7 +101,8 @@ class DlgSqlWindow(QDialog, Ui_Dialog):
     self.presetCombo.setCurrentIndex(-1)
 
   def storePreset(self):
-    query = self.editSql.text()
+    query = self._getSqlQuery()
+    if query == "": return
     name = self.presetName.text()
     QgsProject.instance().writeEntry('DBManager','savedQueries/q'+str(name.__hash__())+'/name', name )
     QgsProject.instance().writeEntry('DBManager','savedQueries/q'+str(name.__hash__())+'/query', query )
@@ -140,12 +141,8 @@ class DlgSqlWindow(QDialog, Ui_Dialog):
 
   def executeSql(self):
 
-    sql = self.editSql.selectedText()
-    if len(sql) == 0:
-        sql = self.editSql.text()
-
-    if sql == "":
-        return
+    sql = self._getSqlQuery()
+    if sql == "": return
 
     QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
 
@@ -184,9 +181,8 @@ class DlgSqlWindow(QDialog, Ui_Dialog):
       QMessageBox.warning(self, self.tr( "DB Manager" ), self.tr( "You must fill the required fields: \ngeometry column - column with unique integer values" ) )
       return
 
-    query = self.editSql.text()
-    if query == "":
-      return
+    query = self._getSqlQuery()
+    if query == "": return
 
     # remove a trailing ';' from query if present
     if query.strip().endswith(';'):
@@ -219,7 +215,7 @@ class DlgSqlWindow(QDialog, Ui_Dialog):
     QApplication.restoreOverrideCursor()
 
   def fillColumnCombos(self):
-    query = self.editSql.text()
+    query = self._getSqlQuery()
     if query == "": return
 
     QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
@@ -318,3 +314,9 @@ class DlgSqlWindow(QDialog, Ui_Dialog):
 
     api.prepare()
     self.editSql.lexer().setAPIs(api)
+        
+  def _getSqlQuery(self):
+    sql = self.editSql.selectedText()
+    if len(sql) == 0:
+      sql = self.editSql.text()
+    return sql


### PR DESCRIPTION
Fix running only the selected query when loading a query into the map canvas or saving it in a preset.
This PR fix http://hub.qgis.org/issues/12429

This feature was in the 2.8 changelog, that's why I ask for a backport.
