### PR TITLE
Properly handle non matching number of WMS styles and layers in WMS provider

### DIFF
--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -123,7 +123,8 @@ QgsWmsProvider::QgsWmsProvider( QString const& uri, const QgsWmsCapabilities* ca
     return;
   }
 
-  addLayers();
+  if ( !addLayers() )
+    return;
 
   // if there are already parsed capabilities, use them!
   if ( capabilities )
@@ -265,15 +266,14 @@ QString QgsWmsProvider::getLegendGraphicUrl() const
   return url.isEmpty() ? url : prepareUri( url );
 }
 
-void QgsWmsProvider::addLayers()
+bool QgsWmsProvider::addLayers()
 {
   QgsDebugMsg( "Entering: layers:" + mSettings.mActiveSubLayers.join( ", " ) + ", styles:" + mSettings.mActiveSubStyles.join( ", " ) );
 
   if ( mSettings.mActiveSubLayers.size() != mSettings.mActiveSubStyles.size() )
   {
     QgsMessageLog::logMessage( tr( "Number of layers and styles don't match" ), tr( "WMS" ) );
-    mValid = false;
-    return;
+    return false;
   }
 
   // Set the visibility of these new layers on by default
@@ -290,6 +290,8 @@ void QgsWmsProvider::addLayers()
     mTileLayer = 0;
 
   QgsDebugMsg( "Exiting." );
+
+  return true;
 }
 
 void QgsWmsProvider::setConnectionName( QString const &connName )

--- a/src/providers/wms/qgswmsprovider.h
+++ b/src/providers/wms/qgswmsprovider.h
@@ -385,7 +385,7 @@ class QgsWmsProvider : public QgsRasterDataProvider
     /**
      * Add the list of WMS layer names to be rendered by this server
      */
-    void addLayers();
+    bool addLayers();
 
     /**
      * Set the image projection (in WMS CRS format) used in the transfer from the WMS server


### PR DESCRIPTION
`QgsWmsProvider::addLayers()` sets `QgsWmsProvider::mValid` to `false` if the number of layers does not match the number of styles, but the value of `mValid` is not checked by `QgsWmsProvider::QgsWmsProvider` (the caller of `addLayers`) and ultimately set to `true` at the end of `QgsWmsProvider::QgsWmsProvider` unless other errors are detected.

One consequence is QGIS crashing when executing i.e. the following statement in the Python console:

```
QgsMapLayerRegistry.instance().addMapLayer(QgsRasterLayer("url=http://maps.scinfo.org.nz/basemaps/wms&crs=EPSG:2193&format=image/jpeg&layers=topobasemap", "NZ Topographic Baselayer", "wms"))
```

(because `QgsWmsProvider::draw` among other places assumes `mSettings.mActiveSubLayers.size() == mSettings.mActiveSubStyles.size()`).

As a side note, perhaps in `QgsWmsSettings::parseUri` `mActiveSubStyles` should be populated with empty strings to match the size of `mActiveSubLayers`, since I see that some WMS URIs just have `&styles=` in the string, which results in an empty string being added to `mActiveSubStyles`.

Funded by Sourcepole
