### PR TITLE
Allow expression functions to include 0 length parameter lists

### DIFF
--- a/src/core/qgsexpressionparser.yy
+++ b/src/core/qgsexpressionparser.yy
@@ -196,6 +196,24 @@ expression:
           delete $1;
         }
 
+    | FUNCTION '(' ')'
+        {
+          int fnIndex = QgsExpression::functionIndex(*$1);
+          if (fnIndex == -1)
+          {
+            // this should not actually happen because already in lexer we check whether an identifier is a known function
+            // (if the name is not known the token is parsed as a column)
+            exp_error(parser_ctx, "Function is not known");
+            YYERROR;
+          }
+          if ( QgsExpression::Functions()[fnIndex]->params() != 0 )
+          {
+            exp_error(parser_ctx, "Function is called with wrong number of arguments");
+            YYERROR;
+          }
+          $$ = new QgsExpression::NodeFunction(fnIndex, new QgsExpression::NodeList());
+        }
+
     | expression IN '(' exp_list ')'     { $$ = new QgsExpression::NodeInOperator($1, $4, false);  }
     | expression NOT IN '(' exp_list ')' { $$ = new QgsExpression::NodeInOperator($1, $5, true); }
 


### PR DESCRIPTION
This change allows for some cleanups to the built in expression functions, by making it possible to differentiate variables (eg $feature) from functions which don't require parameters ( eg uuid(), now()... ). 

Currently, it's not possible for users to tell if $xxx refers to a constant variable (eg $feature) or a dynamic function ($uuid). On it's own this PR solely includes the groundwork for this change, but when PR #2002 lands then aliases will be added for the existing 0-parameter functions. Overall, this change will make expressions more consistent and predictable for users by clearly separating variables from functions.
