### PR TITLE
fix offset curve: allow input in spinbox by switching to click-click mode

### DIFF
--- a/src/app/qgsmaptooloffsetcurve.cpp
+++ b/src/app/qgsmaptooloffsetcurve.cpp
@@ -356,13 +356,15 @@ void QgsMapToolOffsetCurve::deleteDistanceItem()
 {
   if ( mDistanceSpinBox )
   {
+    QObject::disconnect( mDistanceSpinBox, SIGNAL( valueChanged( double ) ), this, SLOT( placeOffsetCurveToValue() ) );
+    QObject::disconnect( mDistanceSpinBox, SIGNAL( editingFinished() ), this, SLOT( applyOffset() ) );
     mDistanceSpinBox->releaseKeyboard();
   }
   delete mDistanceItem;
   mDistanceItem = 0;
 #ifdef Q_OS_UNIX
   mDistanceSpinBox->deleteLater();
-  delete mDistanceSpinBox;
+  mDistanceSpinBox = 0;
 #endif
   mDistanceSpinBox = 0;
 }

--- a/src/app/qgsmaptooloffsetcurve.h
+++ b/src/app/qgsmaptooloffsetcurve.h
@@ -31,16 +31,17 @@ class APP_EXPORT QgsMapToolOffsetCurve: public QgsMapToolEdit
     QgsMapToolOffsetCurve( QgsMapCanvas* canvas );
     ~QgsMapToolOffsetCurve();
 
-    void canvasPressEvent( QMouseEvent * e ) override;
     void canvasReleaseEvent( QMouseEvent * e ) override;
     void canvasMoveEvent( QMouseEvent * e ) override;
 
   private slots:
-    /**Places curve offset to value entered in the spin box*/
+    /** Places curve offset to value entered in the spin box*/
     void placeOffsetCurveToValue();
 
-  private:
+    /** Apply the offset either from the spin box or from the mouse event */
+    void applyOffset();
 
+  private:
     /**Rubberband that shows the position of the offset curve*/
     QgsRubberBand* mRubberBand;
     /**Geometry to manipulate*/


### PR DESCRIPTION
This changes the behavior of the offset curve map tool: instead of drag'n'drop, it uses click - move the mouse freely - click mode.

Hence, the user can properly use the spin box to enter values for the offset (which not feasible on linux, and not really nice on windows).

@mhugent @andreasneumann can you have a look since you were involved at the origin?
