### PR TITLE
Hidpi improvements2

### DIFF
--- a/src/app/pluginmanager/qgspluginitemdelegate.cpp
+++ b/src/app/pluginmanager/qgspluginitemdelegate.cpp
@@ -31,7 +31,9 @@ QSize QgsPluginItemDelegate::sizeHint( const QStyleOptionViewItem & option, cons
 {
   Q_UNUSED( option );
   Q_UNUSED( index );
-  return QSize( 20, 20 );
+  // Calculate row height, adds some 20% padding
+  int pixelsHigh = int(QApplication::fontMetrics().height() * 1.2);
+  return QSize( pixelsHigh, pixelsHigh );
 }
 
 
@@ -40,6 +42,7 @@ void QgsPluginItemDelegate::paint( QPainter *painter, const QStyleOptionViewItem
   painter->save();
   painter->setRenderHint( QPainter::SmoothPixmapTransform );
   QStyle *style = QApplication::style();
+  int pixelsHigh = QApplication::fontMetrics().height();
 
   // Draw the background
   style->drawPrimitive( QStyle::PE_PanelItemViewItem, &option, painter, NULL );
@@ -66,7 +69,7 @@ void QgsPluginItemDelegate::paint( QPainter *painter, const QStyleOptionViewItem
   if ( !iconPixmap.isNull() )
   {
     int iconSize = option.rect.height();
-    painter->drawPixmap( option.rect.left() + 24, option.rect.top(), iconSize, iconSize, iconPixmap );
+    painter->drawPixmap( option.rect.left() + pixelsHigh , option.rect.top(), iconSize, iconSize, iconPixmap );
   }
 
   // Draw the text
@@ -92,8 +95,7 @@ void QgsPluginItemDelegate::paint( QPainter *painter, const QStyleOptionViewItem
     font.setBold( true );
     painter->setFont( font );
   }
-
-  painter->drawText( option.rect.left() + 48, option.rect.bottom() - 3, index.data( Qt::DisplayRole ).toString() );
+  painter->drawText( option.rect.left() + int( pixelsHigh * 2.3 ), option.rect.bottom() - int( pixelsHigh / 6), index.data( Qt::DisplayRole ).toString() );
 
   painter->restore();
 }

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1822,7 +1822,7 @@ void QgisApp::createStatusBar()
   // so we need to set font for it separately
   mScaleEdit->lineEdit()->setFont( myFont );
   mScaleEdit->setMinimumWidth( 10 );
-  mScaleEdit->setMaximumWidth( 100 );
+  //mScaleEdit->setMaximumWidth( 100 );
   //mScaleEdit->setMaximumHeight( 20 );
   mScaleEdit->setContentsMargins( 0, 0, 0, 0 );
   mScaleEdit->setWhatsThis( tr( "Displays the current map scale" ) );

--- a/src/ui/qgspluginmanagerbase.ui
+++ b/src/ui/qgspluginmanagerbase.ui
@@ -46,7 +46,7 @@
       </property>
       <property name="maximumSize">
        <size>
-        <width>200</width>
+        <width>400</width>
         <height>16777215</height>
        </size>
       </property>


### PR DESCRIPTION
Some more fixes for HiDPI screens:
1. fix narrow scale edit widget in status bar
2. fix plugin manager unreadable rows by removing hardcoded values and increased small maximumWidth in tabs (see attached image)

May need some more testing on platforms different from Linux Ubuntu HD (141 dpi)  and HiDPI (282 dpi) screens.

![qgis-hidpi-pluginmanager](https://cloud.githubusercontent.com/assets/142164/7370087/d73091f8-edb7-11e4-8432-edc1cd09dd97.png)
