### PR TITLE
Removing print from help method

### DIFF
--- a/python/plugins/processing/modeler/ModelerAlgorithm.py
+++ b/python/plugins/processing/modeler/ModelerAlgorithm.py
@@ -475,7 +475,6 @@ class ModelerAlgorithm(GeoAlgorithm):
             self.modelerdialog.repaintModel()
 
     def help(self):
-        print self.helpContent
         try:
             return True, getHtmlFromDescriptionsDict(self, self.helpContent)
         except:


### PR DESCRIPTION
I found a print in ModelerAlgorithm help method that causes some trouble
 for PyWPS-QGIS-Processing. I removed it.
