### PR TITLE
Separate const geometry getter for QgsFeature

### DIFF
--- a/python/core/qgsfeature.sip
+++ b/python/core/qgsfeature.sip
@@ -313,7 +313,7 @@ class QgsFeature
     /**
      * Get the geometry object associated with this feature
      */
-    QgsGeometry* geometry() const;
+    QgsGeometry* geometry();
 
     /** Gets a const pointer to the geometry object associated with this feature
      * @note added in QGIS 2.9

--- a/src/core/qgsfeature.cpp
+++ b/src/core/qgsfeature.cpp
@@ -108,8 +108,7 @@ void QgsFeature::deleteAttribute( int field )
   mAttributes.remove( field );
 }
 
-
-QgsGeometry *QgsFeature::geometry() const
+QgsGeometry *QgsFeature::geometry()
 {
   return mGeometry;
 }

--- a/src/core/qgsfeature.h
+++ b/src/core/qgsfeature.h
@@ -185,7 +185,7 @@ class CORE_EXPORT QgsFeature
     /**
      * Get the geometry object associated with this feature
      */
-    QgsGeometry* geometry() const;
+    QgsGeometry* geometry();
 
     /** Gets a const pointer to the geometry object associated with this feature
      * @note added in QGIS 2.9


### PR DESCRIPTION
The key change in this PR is the modifications to the geometry getter in QgsFeature:

```
-QgsGeometry* geometry() const;
+QgsGeometry* geometry();
+const QgsGeometry* constGeometry() const;
```

The rationale behind this change is to allow the transformation of QgsFeature to an implicitly shared class. Currently, the non-const pointer returned by the "QgsGeometry\* geometry() const" getter allows for modification of the feature's geometry.That const has been removed and a new constGeometry getter added which returns a const pointer. This makes it clear whether the caller is intending to modify the geometry or not.

The bulk of this PR consists of updating calls to QgsFeature::geometry -> QgsFeature::constGeometry where applicable.
