### PR TITLE
Allow storing QgsField and QgsFields in a QVariant

### DIFF
--- a/src/core/qgsfield.h
+++ b/src/core/qgsfield.h
@@ -154,6 +154,8 @@ class CORE_EXPORT QgsField
 
 }; // class QgsField
 
+Q_DECLARE_METATYPE( QgsField );
+
 
 /** \class QgsFields
  * \ingroup core
@@ -269,5 +271,7 @@ class CORE_EXPORT QgsFields
     QSharedDataPointer<QgsFieldsPrivate> d;
 
 };
+
+Q_DECLARE_METATYPE( QgsFields );
 
 #endif

--- a/tests/src/core/testqgsfield.cpp
+++ b/tests/src/core/testqgsfield.cpp
@@ -35,6 +35,7 @@ class TestQgsField: public QObject
     void assignment();
     void gettersSetters(); //test getters and setters
     void equality(); //test equality operators
+    void asVariant(); //test conversion to and from a QVariant
   private:
 };
 
@@ -145,6 +146,18 @@ void TestQgsField::equality()
   QVERIFY( !( field1 == field2 ) );
   QVERIFY( field1 != field2 );
   field2.setPrecision( 2 );
+}
+
+void TestQgsField::asVariant()
+{
+  QgsField original( "original", QVariant::Double, "double", 5, 2, "comment" );
+
+  //convert to and from a QVariant
+  QVariant var = QVariant::fromValue( original );
+  QVERIFY( var.isValid() );
+
+  QgsField fromVar = qvariant_cast<QgsField>( var );
+  QCOMPARE( fromVar, original );
 }
 
 QTEST_MAIN( TestQgsField )

--- a/tests/src/core/testqgsfields.cpp
+++ b/tests/src/core/testqgsfields.cpp
@@ -34,6 +34,7 @@ class TestQgsFields: public QObject
     void copy();// test cpy destruction (double delete)
     void assignment();
     void equality(); //test equality operators
+    void asVariant(); //test conversion to and from a QVariant
   private:
 };
 
@@ -123,6 +124,24 @@ void TestQgsFields::equality()
   fields2.append( field3 );
   QVERIFY( !( fields1 == fields2 ) );
   QVERIFY( fields1 != fields2 );
+}
+
+void TestQgsFields::asVariant()
+{
+  QgsField field1;
+  field1.setName( "name" );
+  QgsField field2;
+  field2.setName( "name" );
+  QgsFields original;
+  original.append( field1 );
+  original.append( field2 );
+
+  //convert to and from a QVariant
+  QVariant var = QVariant::fromValue( original );
+  QVERIFY( var.isValid() );
+
+  QgsFields fromVar = qvariant_cast<QgsFields>( var );
+  QCOMPARE( fromVar, original );
 }
 
 QTEST_MAIN( TestQgsFields )


### PR DESCRIPTION
Title says it all... this allows for QgsField/QgsFields to be stored in a QVariant. It's a prerequisite step for expression contexts.
