### PR TITLE
Provide option for R_LIBS_USER in Processing

### DIFF
--- a/python/plugins/processing/algs/r/RAlgorithm.py
+++ b/python/plugins/processing/algs/r/RAlgorithm.py
@@ -285,6 +285,8 @@ class RAlgorithm(GeoAlgorithm):
         commands.append('options("repos"="http://cran.at.r-project.org/")')
 
         # Try to install packages if needed
+        if isWindows():
+            commands.append('.libPaths(\"' + str(RUtils.RLibs()).replace('\\','/') + '\")')
         packages = RUtils.getRequiredPackages(self.script)
         packages.extend(['rgdal', 'raster'])
         for p in packages:

--- a/python/plugins/processing/algs/r/RAlgorithmProvider.py
+++ b/python/plugins/processing/algs/r/RAlgorithmProvider.py
@@ -63,6 +63,9 @@ class RAlgorithmProvider(AlgorithmProvider):
                 RUtils.R_FOLDER, self.tr('R folder'), RUtils.RFolder()))
             ProcessingConfig.addSetting(Setting(
                 self.getDescription(),
+                RUtils.R_LIBS_USER, self.tr('R user library folder'), RUtils.RLibs()))
+            ProcessingConfig.addSetting(Setting(
+                self.getDescription(),
                 RUtils.R_USE64, self.tr('Use 64 bit version'), False))
 
     def unload(self):
@@ -70,6 +73,7 @@ class RAlgorithmProvider(AlgorithmProvider):
         ProcessingConfig.removeSetting(RUtils.RSCRIPTS_FOLDER)
         if isWindows():
             ProcessingConfig.removeSetting(RUtils.R_FOLDER)
+            ProcessingConfig.removeSetting(RUtils.R_LIBS_USER)
             ProcessingConfig.removeSetting(RUtils.R_USE64)
 
     def getIcon(self):

--- a/python/plugins/processing/algs/r/RUtils.py
+++ b/python/plugins/processing/algs/r/RUtils.py
@@ -41,6 +41,7 @@ class RUtils:
     RSCRIPTS_FOLDER = 'R_SCRIPTS_FOLDER'
     R_FOLDER = 'R_FOLDER'
     R_USE64 = 'R_USE64'
+    R_LIBS_USER = 'R_LIBS_USER'
 
     @staticmethod
     def RFolder():
@@ -48,6 +49,15 @@ class RUtils:
         if folder is None:
             folder = ''
 
+        return os.path.abspath(unicode(folder))
+
+    @staticmethod
+    def RLibs():
+        folder = ProcessingConfig.getSetting(RUtils.R_LIBS_USER)
+        if folder is None:
+            folder = unicode(os.path.join(userFolder(), 'rlibs'))
+        mkdir(folder)
+        
         return os.path.abspath(unicode(folder))
 
     @staticmethod
@@ -90,8 +100,9 @@ class RUtils:
                 'BATCH',
                 '--vanilla',
                 RUtils.getRScriptFilename(),
-                RUtils.getConsoleOutputFilename(),
+                RUtils.getConsoleOutputFilename()
             ]
+
         else:
             os.chmod(RUtils.getRScriptFilename(), stat.S_IEXEC | stat.S_IREAD
                      | stat.S_IWRITE)


### PR DESCRIPTION
This pull request is hopefully a more proper attempt to fix http://hub.qgis.org/issues/11603 directly in Processing by means of providing an option to define a path for user libraries on MS Windows. Background: if the R library path is not writable, R does not work in Processing. Users developed all kinds of workarounds already (like reinstalling R as normal user, editing the startup (QGIS.bat), defining environment settings...). Not sure if this could be useful for other OSes too?
It is tested with QGIS 2.8.1, 32bit standalone installer on Win 7 and works there without issues.
