### PR TITLE
Allow opening Postgres materialised views directly

### DIFF
--- a/src/providers/postgres/qgspostgresconn.h
+++ b/src/providers/postgres/qgspostgresconn.h
@@ -365,6 +365,8 @@ class QgsPostgresConn : public QObject
     /** count number of spatial columns in a given relation */
     void addColumnInfo( QgsPostgresLayerProperty& layerProperty, const QString& schemaName, const QString& viewName, bool fetchPkCandidates );
 
+    static QStringList mSystemColumns;
+
     //! List of the supported layers
     QVector<QgsPostgresLayerProperty> mLayersSupported;
 


### PR DESCRIPTION
Previously, the primary key column for materialised views was incorrectly set to the system column "tableoid" (which exists as the first column in pg_attribute for materialised views).

System columns are now skipped when building up a list of primary key candidates.
