### PR TITLE
Add scalebar sizing mode to fit a desired scalebar width

### DIFF
--- a/python/core/composer/qgscomposerscalebar.sip
+++ b/python/core/composer/qgscomposerscalebar.sip
@@ -25,6 +25,12 @@ class QgsComposerScaleBar: QgsComposerItem
       NauticalMiles
     };
 
+    enum SegmentSizeMode
+    {
+      SegmentSizeFixed = 0,
+      SegmentSizeFitWidth = 1
+    };
+
     QgsComposerScaleBar( QgsComposition* composition /TransferThis/ );
     ~QgsComposerScaleBar();
 
@@ -43,6 +49,15 @@ class QgsComposerScaleBar: QgsComposerItem
 
     double numUnitsPerSegment() const;
     void setNumUnitsPerSegment( double units );
+
+    SegmentSizeMode segmentSizeMode() const;
+    void setSegmentSizeMode( SegmentSizeMode mode );
+
+    double minBarWidth() const;
+    void setMinBarWidth( double minWidth );
+
+    double maxBarWidth() const;
+    void setMaxBarWidth( double maxWidth );
 
     double numMapUnitsPerScaleBarUnit() const;
     void setNumMapUnitsPerScaleBarUnit( double d );

--- a/src/app/composer/qgscomposerscalebarwidget.cpp
+++ b/src/app/composer/qgscomposerscalebarwidget.cpp
@@ -32,6 +32,10 @@ QgsComposerScaleBarWidget::QgsComposerScaleBarWidget( QgsComposerScaleBar* scale
   QgsComposerItemWidget* itemPropertiesWidget = new QgsComposerItemWidget( this, scaleBar );
   mainLayout->addWidget( itemPropertiesWidget );
 
+  mSegmentSizeRadioGroup.addButton( mFixedSizeRadio );
+  mSegmentSizeRadioGroup.addButton( mFitWidthRadio );
+  connect( &mSegmentSizeRadioGroup, SIGNAL( buttonClicked( QAbstractButton* ) ), this, SLOT( segmentSizeRadioChanged( QAbstractButton* ) ) );
+
   blockMemberSignals( true );
 
   //style combo box
@@ -220,6 +224,23 @@ void QgsComposerScaleBarWidget::setGuiElements()
 
   //units
   mUnitsComboBox->setCurrentIndex( mUnitsComboBox->findData(( int )mComposerScaleBar->units() ) );
+
+  if ( mComposerScaleBar->segmentSizeMode() == QgsComposerScaleBar::SegmentSizeFixed )
+  {
+    mFixedSizeRadio->setChecked( true );
+    mSegmentSizeSpinBox->setEnabled( true );
+    mMinWidthSpinBox->setEnabled( false );
+    mMaxWidthSpinBox->setEnabled( false );
+  }
+  else /*if(mComposerScaleBar->segmentSizeMode() == QgsComposerScaleBar::SegmentSizeFitWidth)*/
+  {
+    mFitWidthRadio->setChecked( true );
+    mSegmentSizeSpinBox->setEnabled( false );
+    mMinWidthSpinBox->setEnabled( true );
+    mMaxWidthSpinBox->setEnabled( true );
+  }
+  mMinWidthSpinBox->setValue( mComposerScaleBar->minBarWidth() );
+  mMaxWidthSpinBox->setValue( mComposerScaleBar->maxBarWidth() );
 
   blockMemberSignals( false );
 }
@@ -621,6 +642,7 @@ void QgsComposerScaleBarWidget::blockMemberSignals( bool block )
   mFillColorButton->blockSignals( block );
   mFillColor2Button->blockSignals( block );
   mStrokeColorButton->blockSignals( block );
+  mSegmentSizeRadioGroup.blockSignals( block );
 }
 
 void QgsComposerScaleBarWidget::connectUpdateSignal()
@@ -662,5 +684,62 @@ void QgsComposerScaleBarWidget::on_mLineCapStyleCombo_currentIndexChanged( int i
 
   mComposerScaleBar->beginCommand( tr( "Scalebar line cap style" ) );
   mComposerScaleBar->setLineCapStyle( mLineCapStyleCombo->penCapStyle() );
+  mComposerScaleBar->endCommand();
+}
+
+void QgsComposerScaleBarWidget::segmentSizeRadioChanged( QAbstractButton* radio )
+{
+  bool fixedSizeMode = radio == mFixedSizeRadio;
+  mMinWidthSpinBox->setEnabled( !fixedSizeMode );
+  mMaxWidthSpinBox->setEnabled( !fixedSizeMode );
+  mSegmentSizeSpinBox->setEnabled( fixedSizeMode );
+
+  if ( !mComposerScaleBar )
+  {
+    return;
+  }
+
+  mComposerScaleBar->beginCommand( tr( "Scalebar segment size mode" ), QgsComposerMergeCommand::ScaleBarSegmentSize );
+  disconnectUpdateSignal();
+  if ( mFixedSizeRadio->isChecked() )
+  {
+    mComposerScaleBar->setSegmentSizeMode( QgsComposerScaleBar::SegmentSizeFixed );
+  }
+  else /*if(mFitWidthRadio->isChecked())*/
+  {
+    mComposerScaleBar->setSegmentSizeMode( QgsComposerScaleBar::SegmentSizeFitWidth );
+  }
+  mComposerScaleBar->update();
+  connectUpdateSignal();
+  mComposerScaleBar->endCommand();
+}
+
+void QgsComposerScaleBarWidget::on_mMinWidthSpinBox_valueChanged( int )
+{
+  if ( !mComposerScaleBar )
+  {
+    return;
+  }
+
+  mComposerScaleBar->beginCommand( tr( "Scalebar segment size mode" ), QgsComposerMergeCommand::ScaleBarSegmentSize );
+  disconnectUpdateSignal();
+  mComposerScaleBar->setMinBarWidth( mMinWidthSpinBox->value() );
+  mComposerScaleBar->update();
+  connectUpdateSignal();
+  mComposerScaleBar->endCommand();
+}
+
+void QgsComposerScaleBarWidget::on_mMaxWidthSpinBox_valueChanged( int )
+{
+  if ( !mComposerScaleBar )
+  {
+    return;
+  }
+
+  mComposerScaleBar->beginCommand( tr( "Scalebar segment size mode" ), QgsComposerMergeCommand::ScaleBarSegmentSize );
+  disconnectUpdateSignal();
+  mComposerScaleBar->setMaxBarWidth( mMaxWidthSpinBox->value() );
+  mComposerScaleBar->update();
+  connectUpdateSignal();
   mComposerScaleBar->endCommand();
 }

--- a/src/app/composer/qgscomposerscalebarwidget.h
+++ b/src/app/composer/qgscomposerscalebarwidget.h
@@ -54,15 +54,19 @@ class QgsComposerScaleBarWidget: public QgsComposerItemBaseWidget, private Ui::Q
     void on_mUnitsComboBox_currentIndexChanged( int index );
     void on_mLineJoinStyleCombo_currentIndexChanged( int index );
     void on_mLineCapStyleCombo_currentIndexChanged( int index );
+    void on_mMinWidthSpinBox_valueChanged( int i );
+    void on_mMaxWidthSpinBox_valueChanged( int i );
 
   private slots:
     void setGuiElements();
+    void segmentSizeRadioChanged( QAbstractButton*radio );
 
   protected:
     void showEvent( QShowEvent * event ) override;
 
   private:
     QgsComposerScaleBar* mComposerScaleBar;
+    QButtonGroup mSegmentSizeRadioGroup;
 
     void refreshMapComboBox();
     /**Enables/disables the signals of the input gui elements*/

--- a/src/core/composer/qgscomposerscalebar.cpp
+++ b/src/core/composer/qgscomposerscalebar.cpp
@@ -39,6 +39,9 @@ QgsComposerScaleBar::QgsComposerScaleBar( QgsComposition* composition )
     : QgsComposerItem( composition )
     , mComposerMap( 0 )
     , mNumUnitsPerSegment( 0 )
+    , mSegmentSizeMode( SegmentSizeFixed )
+    , mMinBarWidth( 50 )
+    , mMaxBarWidth( 150 )
     , mFontColor( QColor( 0, 0, 0 ) )
     , mStyle( 0 )
     , mSegmentMillimeters( 0.0 )
@@ -114,6 +117,51 @@ void QgsComposerScaleBar::setNumUnitsPerSegment( double units )
   emit itemChanged();
 }
 
+void QgsComposerScaleBar::setSegmentSizeMode( SegmentSizeMode mode )
+{
+  if ( !mStyle )
+  {
+    mSegmentSizeMode = mode;
+    return;
+  }
+  double width = mStyle->calculateBoxSize().width();
+  mSegmentSizeMode = mode;
+  refreshSegmentMillimeters();
+  double widthAfter = mStyle->calculateBoxSize().width();
+  correctXPositionAlignment( width, widthAfter );
+  emit itemChanged();
+}
+
+void QgsComposerScaleBar::setMinBarWidth( double minWidth )
+{
+  if ( !mStyle )
+  {
+    mMinBarWidth = minWidth;
+    return;
+  }
+  double width = mStyle->calculateBoxSize().width();
+  mMinBarWidth = minWidth;
+  refreshSegmentMillimeters();
+  double widthAfter = mStyle->calculateBoxSize().width();
+  correctXPositionAlignment( width, widthAfter );
+  emit itemChanged();
+}
+
+void QgsComposerScaleBar::setMaxBarWidth( double maxWidth )
+{
+  if ( !mStyle )
+  {
+    mMaxBarWidth = maxWidth;
+    return;
+  }
+  double width = mStyle->calculateBoxSize().width();
+  mMaxBarWidth = maxWidth;
+  refreshSegmentMillimeters();
+  double widthAfter = mStyle->calculateBoxSize().width();
+  correctXPositionAlignment( width, widthAfter );
+  emit itemChanged();
+}
+
 void QgsComposerScaleBar::setNumSegmentsLeft( int nSegmentsLeft )
 {
   if ( !mStyle )
@@ -175,18 +223,65 @@ void QgsComposerScaleBar::invalidateCurrentMap()
   mComposerMap = 0;
 }
 
+// nextNiceNumber(4573.23, d) = 5000 (d=1) -> 4600 (d=10) -> 4580 (d=100) -> 4574 (d=1000) -> etc
+inline double nextNiceNumber( double a, double d = 1 )
+{
+  double s = pow10( floor( log10( a ) ) ) / d;
+  return ceil( a / s ) * s;
+}
+
+// prevNiceNumber(4573.23, d) = 4000 (d=1) -> 4500 (d=10) -> 4570 (d=100) -> 4573 (d=1000) -> etc
+inline double prevNiceNumber( double a, double d = 1 )
+{
+  double s = pow10( floor( log10( a ) ) ) / d;
+  return floor( a / s ) * s;
+}
+
 void QgsComposerScaleBar::refreshSegmentMillimeters()
 {
   if ( mComposerMap )
   {
-    //get extent of composer map
-    QgsRectangle composerMapRect = *( mComposerMap->currentMapExtent() );
-
     //get mm dimension of composer map
     QRectF composerItemRect = mComposerMap->rect();
 
-    //calculate size depending on mNumUnitsPerSegment
-    mSegmentMillimeters = composerItemRect.width() / mapWidth() * mNumUnitsPerSegment;
+    if ( mSegmentSizeMode == SegmentSizeFixed )
+    {
+      //calculate size depending on mNumUnitsPerSegment
+      mSegmentMillimeters = composerItemRect.width() / mapWidth() * mNumUnitsPerSegment;
+    }
+    else /*if(mSegmentSizeMode == SegmentSizeFitWidth)*/
+    {
+      if ( mMaxBarWidth < mMinBarWidth )
+      {
+        mSegmentMillimeters = 0;
+      }
+      else
+      {
+        double nSegments = ( mNumSegmentsLeft != 0 ) + mNumSegments;
+        // unitsPerSegments which fit minBarWidth resp. maxBarWidth
+        double minUnitsPerSeg = ( mMinBarWidth * mapWidth() ) / ( nSegments * composerItemRect.width() );
+        double maxUnitsPerSeg = ( mMaxBarWidth * mapWidth() ) / ( nSegments * composerItemRect.width() );
+
+        // Start with coarsest "nice" number closest to minUnitsPerSeg resp
+        // maxUnitsPerSeg, then proceed to finer numbers as long as neither
+        // lowerNiceUnitsPerSeg nor upperNiceUnitsPerSeg are are in
+        // [minUnitsPerSeg, maxUnitsPerSeg]
+        double lowerNiceUnitsPerSeg = nextNiceNumber( minUnitsPerSeg );
+        double upperNiceUnitsPerSeg = prevNiceNumber( maxUnitsPerSeg );
+
+        double d = 1;
+        while ( lowerNiceUnitsPerSeg > maxUnitsPerSeg && upperNiceUnitsPerSeg < minUnitsPerSeg )
+        {
+          d *= 10;
+          lowerNiceUnitsPerSeg = nextNiceNumber( minUnitsPerSeg, d );
+          upperNiceUnitsPerSeg = prevNiceNumber( maxUnitsPerSeg, d );
+        }
+
+        // Pick mNumUnitsPerSegment from {lowerNiceUnitsPerSeg, upperNiceUnitsPerSeg}, use the larger if possible
+        mNumUnitsPerSegment = upperNiceUnitsPerSeg < minUnitsPerSeg ? lowerNiceUnitsPerSeg : upperNiceUnitsPerSeg;
+        mSegmentMillimeters = composerItemRect.width() / mapWidth() * mNumUnitsPerSegment;
+      }
+    }
   }
 }
 
@@ -568,6 +663,9 @@ bool QgsComposerScaleBar::writeXML( QDomElement& elem, QDomDocument & doc ) cons
   composerScaleBarElem.setAttribute( "numSegments", mNumSegments );
   composerScaleBarElem.setAttribute( "numSegmentsLeft", mNumSegmentsLeft );
   composerScaleBarElem.setAttribute( "numUnitsPerSegment", QString::number( mNumUnitsPerSegment ) );
+  composerScaleBarElem.setAttribute( "segmentSizeMode", mSegmentSizeMode );
+  composerScaleBarElem.setAttribute( "minBarWidth", mMinBarWidth );
+  composerScaleBarElem.setAttribute( "maxBarWidth", mMaxBarWidth );
   composerScaleBarElem.setAttribute( "segmentMillimeters", QString::number( mSegmentMillimeters ) );
   composerScaleBarElem.setAttribute( "numMapUnitsPerScaleBarUnit", QString::number( mNumMapUnitsPerScaleBarUnit ) );
   composerScaleBarElem.setAttribute( "font", mFont.toString() );
@@ -646,6 +744,9 @@ bool QgsComposerScaleBar::readXML( const QDomElement& itemElem, const QDomDocume
   mNumSegments = itemElem.attribute( "numSegments", "2" ).toInt();
   mNumSegmentsLeft = itemElem.attribute( "numSegmentsLeft", "0" ).toInt();
   mNumUnitsPerSegment = itemElem.attribute( "numUnitsPerSegment", "1.0" ).toDouble();
+  mSegmentSizeMode = static_cast<SegmentSizeMode>( itemElem.attribute( "segmentSizeMode", "0" ).toInt() );
+  mMinBarWidth = itemElem.attribute( "minBarWidth", "50" ).toInt();
+  mMaxBarWidth = itemElem.attribute( "maxBarWidth", "150" ).toInt();
   mSegmentMillimeters = itemElem.attribute( "segmentMillimeters", "0.0" ).toDouble();
   mNumMapUnitsPerScaleBarUnit = itemElem.attribute( "numMapUnitsPerScaleBarUnit", "1.0" ).toDouble();
   mPen.setWidthF( itemElem.attribute( "outlineWidth", "1.0" ).toDouble() );

--- a/src/core/composer/qgscomposerscalebar.h
+++ b/src/core/composer/qgscomposerscalebar.h
@@ -48,6 +48,12 @@ class CORE_EXPORT QgsComposerScaleBar: public QgsComposerItem
       NauticalMiles
     };
 
+    enum SegmentSizeMode
+    {
+      SegmentSizeFixed = 0,
+      SegmentSizeFitWidth = 1
+    };
+
     QgsComposerScaleBar( QgsComposition* composition );
     ~QgsComposerScaleBar();
 
@@ -66,6 +72,15 @@ class CORE_EXPORT QgsComposerScaleBar: public QgsComposerItem
 
     double numUnitsPerSegment() const {return mNumUnitsPerSegment;}
     void setNumUnitsPerSegment( double units );
+
+    SegmentSizeMode segmentSizeMode() const { return mSegmentSizeMode; }
+    void setSegmentSizeMode( SegmentSizeMode mode );
+
+    double minBarWidth() const { return mMinBarWidth; }
+    void setMinBarWidth( double minWidth );
+
+    double maxBarWidth() const { return mMaxBarWidth; }
+    void setMaxBarWidth( double maxWidth );
 
     double numMapUnitsPerScaleBarUnit() const {return mNumMapUnitsPerScaleBarUnit;}
     void setNumMapUnitsPerScaleBarUnit( double d ) {mNumMapUnitsPerScaleBarUnit = d;}
@@ -249,6 +264,12 @@ class CORE_EXPORT QgsComposerScaleBar: public QgsComposerItem
     double mNumUnitsPerSegment;
     /**Number of map units per scale bar units (e.g. 1000 to have km for a map with m units)*/
     double mNumMapUnitsPerScaleBarUnit;
+    /**Either fixed (i.e. mNumUnitsPerSegment) or try to best fit scale bar width (mMinBarWidth, mMaxBarWidth)*/
+    SegmentSizeMode mSegmentSizeMode;
+    /**Minimum allowed bar width, when mSegmentSizeMode is FitWidth*/
+    double mMinBarWidth;
+    /**Maximum allowed bar width, when mSegmentSizeMode is FitWidth*/
+    double mMaxBarWidth;
 
     /**Labeling of map units*/
     QString mUnitLabeling;

--- a/src/ui/qgscomposerscalebarwidgetbase.ui
+++ b/src/ui/qgscomposerscalebarwidgetbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>358</width>
-    <height>429</height>
+    <width>405</width>
+    <height>525</height>
    </rect>
   </property>
   <property name="sizePolicy">
@@ -23,7 +23,16 @@
    <property name="spacing">
     <number>0</number>
    </property>
-   <property name="margin">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
     <number>0</number>
    </property>
    <item>
@@ -51,9 +60,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-73</y>
-        <width>340</width>
-        <height>819</height>
+        <y>0</y>
+        <width>440</width>
+        <height>801</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="mainLayout">
@@ -81,7 +90,7 @@
              </sizepolicy>
             </property>
             <property name="text">
-             <string>Map</string>
+             <string>&amp;Map</string>
             </property>
             <property name="wordWrap">
              <bool>true</bool>
@@ -107,7 +116,7 @@
           <item row="1" column="0">
            <widget class="QLabel" name="mStyleLabel">
             <property name="text">
-             <string>Style</string>
+             <string>St&amp;yle</string>
             </property>
             <property name="buddy">
              <cstring>mStyleComboBox</cstring>
@@ -138,7 +147,7 @@
           <item row="1" column="0">
            <widget class="QLabel" name="mUnitLabelLabel">
             <property name="text">
-             <string>Label</string>
+             <string>&amp;Label</string>
             </property>
             <property name="wordWrap">
              <bool>true</bool>
@@ -154,7 +163,7 @@
           <item row="2" column="0">
            <widget class="QLabel" name="mMapUnitsPerBarUnitLabel">
             <property name="text">
-             <string>Map units per bar unit</string>
+             <string>Map &amp;units per bar unit</string>
             </property>
             <property name="wordWrap">
              <bool>false</bool>
@@ -172,7 +181,7 @@
             <property name="maximum">
              <double>9999999999999.000000000000000</double>
             </property>
-            <property name="showClearButton">
+            <property name="showClearButton" stdset="0">
              <bool>false</bool>
             </property>
            </widget>
@@ -197,15 +206,38 @@
          <property name="collapsed" stdset="0">
           <bool>false</bool>
          </property>
-         <layout class="QGridLayout" name="gridLayout_3" columnstretch="0,1">
-          <item row="0" column="0">
-           <widget class="QLabel" name="mSegmentLabel">
+         <layout class="QGridLayout" name="gridLayout_3" columnstretch="0,0,0">
+          <item row="1" column="1">
+           <widget class="QRadioButton" name="mFixedSizeRadio">
             <property name="text">
-             <string>Segments</string>
+             <string>Fi&amp;xed</string>
+            </property>
+            <property name="checked">
+             <bool>true</bool>
             </property>
            </widget>
           </item>
-          <item row="0" column="1">
+          <item row="3" column="2">
+           <widget class="QgsSpinBox" name="mHeightSpinBox">
+            <property name="suffix">
+             <string> mm</string>
+            </property>
+            <property name="prefix">
+             <string/>
+            </property>
+            <property name="showClearButton" stdset="0">
+             <bool>false</bool>
+            </property>
+           </widget>
+          </item>
+          <item row="2" column="1">
+           <widget class="QRadioButton" name="mFitWidthRadio">
+            <property name="text">
+             <string>Fit scalebar width</string>
+            </property>
+           </widget>
+          </item>
+          <item row="0" column="2">
            <layout class="QHBoxLayout" name="horizontalLayout">
             <item>
              <widget class="QgsSpinBox" name="mSegmentsLeftSpinBox">
@@ -232,20 +264,7 @@
             </item>
            </layout>
           </item>
-          <item row="1" column="0">
-           <widget class="QLabel" name="mSegmentSizeLabel">
-            <property name="text">
-             <string>Size</string>
-            </property>
-            <property name="wordWrap">
-             <bool>true</bool>
-            </property>
-            <property name="buddy">
-             <cstring>mSegmentSizeSpinBox</cstring>
-            </property>
-           </widget>
-          </item>
-          <item row="1" column="1">
+          <item row="1" column="2">
            <widget class="QgsDoubleSpinBox" name="mSegmentSizeSpinBox">
             <property name="suffix">
              <string> units</string>
@@ -256,28 +275,71 @@
             <property name="maximum">
              <double>9999999999999.000000000000000</double>
             </property>
-            <property name="showClearButton">
+            <property name="showClearButton" stdset="0">
              <bool>false</bool>
             </property>
            </widget>
           </item>
-          <item row="2" column="0">
+          <item row="2" column="2">
+           <layout class="QHBoxLayout" name="horizontalLayout_6">
+            <item>
+             <widget class="QgsSpinBox" name="mMinWidthSpinBox">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="suffix">
+               <string> mm</string>
+              </property>
+              <property name="prefix">
+               <string>min </string>
+              </property>
+              <property name="maximum">
+               <number>999</number>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QgsSpinBox" name="mMaxWidthSpinBox">
+              <property name="enabled">
+               <bool>false</bool>
+              </property>
+              <property name="suffix">
+               <string> mm</string>
+              </property>
+              <property name="prefix">
+               <string>max </string>
+              </property>
+              <property name="maximum">
+               <number>999</number>
+              </property>
+             </widget>
+            </item>
+           </layout>
+          </item>
+          <item row="1" column="0" rowspan="2">
+           <widget class="QLabel" name="mSegmentSizeLabel">
+            <property name="text">
+             <string>Si&amp;ze</string>
+            </property>
+            <property name="wordWrap">
+             <bool>true</bool>
+            </property>
+            <property name="buddy">
+             <cstring>mSegmentSizeSpinBox</cstring>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0" colspan="2">
            <widget class="QLabel" name="label">
             <property name="text">
              <string>Height</string>
             </property>
            </widget>
           </item>
-          <item row="2" column="1">
-           <widget class="QgsSpinBox" name="mHeightSpinBox">
-            <property name="suffix">
-             <string> mm</string>
-            </property>
-            <property name="prefix">
-             <string/>
-            </property>
-            <property name="showClearButton">
-             <bool>false</bool>
+          <item row="0" column="0" colspan="2">
+           <widget class="QLabel" name="mSegmentLabel">
+            <property name="text">
+             <string>Segments</string>
             </property>
            </widget>
           </item>
@@ -363,7 +425,7 @@
             <property name="value">
              <double>0.200000000000000</double>
             </property>
-            <property name="showClearButton">
+            <property name="showClearButton" stdset="0">
              <bool>false</bool>
             </property>
            </widget>


### PR DESCRIPTION
This commits adds an option to the composer scalebar which allows the user to set a desired minimum and maximum width of the scale bar, based on which the size of the segments is computed automatically, in such way that the segment widths are as "nice" numbers as possible.

Funded by Sourcepole QGIS Enterprise
