### PR TITLE
[processing] Set the parameter table field optional in "Line intersections" algo

### DIFF
--- a/python/plugins/processing/algs/qgis/LinesIntersection.py
+++ b/python/plugins/processing/algs/qgis/LinesIntersection.py
@@ -50,10 +50,16 @@ class LinesIntersection(GeoAlgorithm):
             self.tr('Input layer'), [ParameterVector.VECTOR_TYPE_LINE]))
         self.addParameter(ParameterVector(self.INPUT_B,
             self.tr('Intersect layer'), [ParameterVector.VECTOR_TYPE_LINE]))
-        self.addParameter(ParameterTableField(self.FIELD_A,
-            self.tr('Input unique ID field'), self.INPUT_A))
-        self.addParameter(ParameterTableField(self.FIELD_B,
-            self.tr('Intersect unique ID field'), self.INPUT_B))
+        self.addParameter(ParameterTableField(
+            self.FIELD_A,
+            self.tr('Input unique ID field'),
+            self.INPUT_A,
+            optional=True))
+        self.addParameter(ParameterTableField(
+            self.FIELD_B,
+            self.tr('Intersect unique ID field'),
+            self.INPUT_B,
+            optional=True))
 
         self.addOutput(OutputVector(self.OUTPUT, self.tr('Output layer')))
 


### PR DESCRIPTION
We may run this algorithm without setting the "unique ID field" for each layers.
This PR makes these two parameters optionals.

Assign : @volaya @alexbruy  
