### PR TITLE
[symbology] improve marker line's rotation along line to support data-defined angle scenario

### DIFF
--- a/python/core/symbology-ng/qgssymbollayerv2.sip
+++ b/python/core/symbology-ng/qgssymbollayerv2.sip
@@ -324,7 +324,7 @@ class QgsMarkerSymbolLayerV2 : QgsSymbolLayerV2
      * @param lineangle Angle in degrees, valid values are between 0 and 360
      * @note added in QGIS 2.9
     */
-    void setLineAngle( double lineangle );
+    void setLineAngle( double lineAngle );
 
     void setSize( double size );
     double size() const;

--- a/python/core/symbology-ng/qgssymbollayerv2.sip
+++ b/python/core/symbology-ng/qgssymbollayerv2.sip
@@ -317,6 +317,14 @@ class QgsMarkerSymbolLayerV2 : QgsSymbolLayerV2
 
     void setAngle( double angle );
     double angle() const;
+    
+    /** Sets the line angle modification for the symbol's angle. This angle is added to 
+     * the marker's rotation and data defined rotation before rendering the symbol, and 
+     * is usually used for orienting symbols to match a line's angle.
+     * @param lineangle Angle in degrees, valid values are between 0 and 360
+     * @note added in QGIS 2.9
+    */
+    void setLineAngle( double lineangle );
 
     void setSize( double size );
     double size() const;

--- a/python/core/symbology-ng/qgssymbolv2.sip
+++ b/python/core/symbology-ng/qgssymbolv2.sip
@@ -236,6 +236,14 @@ class QgsMarkerSymbolV2 : QgsSymbolV2
 
     void setAngle( double angle );
     double angle();
+    
+    /** Sets the line angle modification for the symbol's angle. This angle is added to 
+     * the marker's rotation and data defined rotation before rendering the symbol, and 
+     * is usually used for orienting symbols to match a line's angle.
+     * @param lineangle Angle in degrees, valid values are between 0 and 360
+     * @note added in QGIS 2.9
+    */
+    void setLineAngle( double lineangle );
 
     void setSize( double size );
     double size();

--- a/python/core/symbology-ng/qgssymbolv2.sip
+++ b/python/core/symbology-ng/qgssymbolv2.sip
@@ -243,7 +243,7 @@ class QgsMarkerSymbolV2 : QgsSymbolV2
      * @param lineangle Angle in degrees, valid values are between 0 and 360
      * @note added in QGIS 2.9
     */
-    void setLineAngle( double lineangle );
+    void setLineAngle( double lineAngle );
 
     void setSize( double size );
     double size();

--- a/src/core/symbology-ng/qgsellipsesymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgsellipsesymbollayerv2.cpp
@@ -251,11 +251,11 @@ void QgsEllipseSymbolLayerV2::renderPoint( const QPointF& point, QgsSymbolV2Rend
   double rotation = 0.0;
   if ( hasDataDefinedProperty( "rotation" ) )
   {
-    rotation = evaluateDataDefinedProperty( "rotation", context.feature(), mAngle ).toDouble();
+    rotation = evaluateDataDefinedProperty( "rotation", context.feature(), mAngle ).toDouble() + mLineAngle;
   }
-  else if ( !qgsDoubleNear( mAngle, 0.0 ) )
+  else if ( !qgsDoubleNear( mAngle + mLineAngle, 0.0 ) )
   {
-    rotation = mAngle;
+    rotation = mAngle + mLineAngle;
   }
   if ( rotation )
     off = _rotatedOffset( off, rotation );
@@ -630,11 +630,11 @@ bool QgsEllipseSymbolLayerV2::writeDxf( QgsDxfExport& e, double mmMapUnitScaleFa
   double rotation = 0.0;
   if ( hasDataDefinedProperty( "rotation" ) )
   {
-    rotation = evaluateDataDefinedProperty( "rotation", f, mAngle ).toDouble();
+    rotation = evaluateDataDefinedProperty( "rotation", f, mAngle ).toDouble() + mLineAngle;
   }
-  else if ( !qgsDoubleNear( mAngle, 0.0 ) )
+  else if ( !qgsDoubleNear( mAngle + mLineAngle, 0.0 ) )
   {
-    rotation = mAngle;
+    rotation = mAngle + mLineAngle;
   }
   rotation = -rotation; //rotation in Qt is counterclockwise
   if ( rotation )

--- a/src/core/symbology-ng/qgslinesymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgslinesymbollayerv2.cpp
@@ -881,7 +881,6 @@ void QgsMarkerLineSymbolLayerV2::renderPolylineInterval( const QPolygonF& points
   QPointF lastPt = points[0];
   double lengthLeft = 0; // how much is left until next marker
   bool first = mOffsetAlongLine ? false : true; //only draw marker at first vertex when no offset along line is set
-  double origAngle = mMarker->angle();
 
   QgsRenderContext& rc = context.renderContext();
   double interval = mInterval;
@@ -923,7 +922,7 @@ void QgsMarkerLineSymbolLayerV2::renderPolylineInterval( const QPolygonF& points
     // rotate marker (if desired)
     if ( mRotateMarker )
     {
-      mMarker->setAngle( origAngle + ( l.angle() * 180 / M_PI ) );
+      mMarker->setLineAngle( l.angle() * 180 / M_PI );
     }
 
     // draw first marker
@@ -945,10 +944,6 @@ void QgsMarkerLineSymbolLayerV2::renderPolylineInterval( const QPolygonF& points
 
     lastPt = pt;
   }
-
-  // restore original rotation
-  mMarker->setAngle( origAngle );
-
 }
 
 static double _averageAngle( const QPointF& prevPt, const QPointF& pt, const QPointF& nextPt )

--- a/src/core/symbology-ng/qgsmarkersymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgsmarkersymbollayerv2.cpp
@@ -492,11 +492,11 @@ void QgsSimpleMarkerSymbolLayerV2::renderPoint( const QPointF& point, QgsSymbolV
   QPointF off( offsetX, offsetY );
 
   //angle
-  double angle = mAngle;
+  double angle = mAngle + mLineAngle;
   bool usingDataDefinedRotation = false;
   if ( hasDataDefinedProperty( "angle" ) )
   {
-    angle = evaluateDataDefinedProperty( "angle", context.feature(), mAngle, &ok ).toDouble();
+    angle = evaluateDataDefinedProperty( "angle", context.feature(), mAngle, &ok ).toDouble() + mLineAngle;;
     usingDataDefinedRotation = ok;
   }
 
@@ -873,10 +873,10 @@ bool QgsSimpleMarkerSymbolLayerV2::writeDxf( QgsDxfExport& e, double mmMapUnitSc
   QPointF off( offsetX, offsetY );
 
   //angle
-  double angle = mAngle;
+  double angle = mAngle + mLineAngle;
   if ( context && hasDataDefinedProperty( "angle" ) )
   {
-    angle = evaluateDataDefinedProperty( "angle", f, mAngle ).toDouble();
+    angle = evaluateDataDefinedProperty( "angle", f, mAngle ).toDouble() + mLineAngle;
   }
 
   angle = -angle; //rotation in Qt is counterclockwise
@@ -1271,10 +1271,10 @@ void QgsSvgMarkerSymbolLayerV2::renderPoint( const QPointF& point, QgsSymbolV2Re
   markerOffset( context, scaledSize, scaledSize, offsetX, offsetY );
   QPointF outputOffset( offsetX, offsetY );
 
-  double angle = mAngle;
+  double angle = mAngle + mLineAngle;
   if ( hasDataDefinedProperty( "angle" ) )
   {
-    angle = evaluateDataDefinedProperty( "angle", context.feature(), mAngle ).toDouble();
+    angle = evaluateDataDefinedProperty( "angle", context.feature(), mAngle ).toDouble() + mLineAngle;
   }
 
   bool hasDataDefinedRotation = context.renderHints() & QgsSymbolV2::DataDefinedRotation || hasDataDefinedProperty( "angle" );
@@ -1603,10 +1603,10 @@ bool QgsSvgMarkerSymbolLayerV2::writeDxf( QgsDxfExport& e, double mmMapUnitScale
 
   QPointF outputOffset( offsetX, offsetY );
 
-  double angle = mAngle;
+  double angle = mAngle + mLineAngle;
   if ( hasDataDefinedProperty( "angle" ) )
   {
-    angle = evaluateDataDefinedProperty( "angle", f, mAngle ).toDouble();
+    angle = evaluateDataDefinedProperty( "angle", f, mAngle ).toDouble() + mLineAngle;
   }
   //angle = -angle; //rotation in Qt is counterclockwise
   if ( angle )
@@ -1721,8 +1721,8 @@ void QgsFontMarkerSymbolLayerV2::renderPoint( const QPointF& point, QgsSymbolV2R
   double offsetY = 0;
   markerOffset( context, offsetX, offsetY );
   QPointF outputOffset( offsetX, offsetY );
-  if ( mAngle )
-    outputOffset = _rotatedOffset( outputOffset, mAngle );
+  if ( !qgsDoubleNear( mAngle + mLineAngle, 0.0 ) )
+    outputOffset = _rotatedOffset( outputOffset, mAngle + mLineAngle );
   p->translate( point + outputOffset );
 
   if ( context.renderHints() & QgsSymbolV2::DataDefinedSizeScale )
@@ -1731,8 +1731,8 @@ void QgsFontMarkerSymbolLayerV2::renderPoint( const QPointF& point, QgsSymbolV2R
     p->scale( s, s );
   }
 
-  if ( mAngle != 0 )
-    p->rotate( mAngle );
+  if ( !qgsDoubleNear( mAngle + mLineAngle, 0.0 ) )
+    p->rotate( mAngle + mLineAngle );
 
   p->drawText( -mChrOffset, mChr );
   p->restore();

--- a/src/core/symbology-ng/qgssymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgssymbollayerv2.cpp
@@ -354,6 +354,7 @@ void QgsSymbolLayerV2::copyPaintEffect( QgsSymbolLayerV2 *destLayer ) const
 QgsMarkerSymbolLayerV2::QgsMarkerSymbolLayerV2( bool locked )
     : QgsSymbolLayerV2( QgsSymbolV2::Marker, locked )
     , mAngle( 0 )
+    , mLineAngle( 0 )
     , mSize( 2.0 )
     , mSizeUnit( QgsSymbolV2::MM )
     , mOffsetUnit( QgsSymbolV2::MM )

--- a/src/core/symbology-ng/qgssymbollayerv2.h
+++ b/src/core/symbology-ng/qgssymbollayerv2.h
@@ -315,6 +315,14 @@ class CORE_EXPORT QgsMarkerSymbolLayerV2 : public QgsSymbolLayerV2
     void setAngle( double angle ) { mAngle = angle; }
     double angle() const { return mAngle; }
 
+    /** Sets the line angle modification for the symbol's angle. This angle is added to 
+     * the marker's rotation and data defined rotation before rendering the symbol, and 
+     * is usually used for orienting symbols to match a line's angle.
+     * @param lineangle Angle in degrees, valid values are between 0 and 360
+     * @note added in QGIS 2.9
+    */
+    void setLineAngle( double lineAngle ) { mLineAngle = lineAngle; }
+
     void setSize( double size ) { mSize = size; }
     double size() const { return mSize; }
 
@@ -370,6 +378,7 @@ class CORE_EXPORT QgsMarkerSymbolLayerV2 : public QgsSymbolLayerV2
     static QPointF _rotatedOffset( const QPointF& offset, double angle );
 
     double mAngle;
+    double mLineAngle;
     double mSize;
     QgsSymbolV2::OutputUnit mSizeUnit;
     QgsMapUnitScale mSizeMapUnitScale;

--- a/src/core/symbology-ng/qgssymbolv2.cpp
+++ b/src/core/symbology-ng/qgssymbolv2.cpp
@@ -519,6 +519,7 @@ void QgsMarkerSymbolV2::setAngle( double ang )
   }
 }
 
+
 double QgsMarkerSymbolV2::angle()
 {
   QgsSymbolLayerV2List::const_iterator it = mLayers.begin();
@@ -529,6 +530,15 @@ double QgsMarkerSymbolV2::angle()
   // return angle of the first symbol layer
   const QgsMarkerSymbolLayerV2* layer = static_cast<const QgsMarkerSymbolLayerV2 *>( *it );
   return layer->angle();
+}
+
+void QgsMarkerSymbolV2::setLineAngle( double lineAng )
+{
+  for ( QgsSymbolLayerV2List::iterator it = mLayers.begin(); it != mLayers.end(); ++it )
+  {
+    QgsMarkerSymbolLayerV2* layer = ( QgsMarkerSymbolLayerV2* ) * it;
+    layer->setLineAngle( lineAng );
+  }
 }
 
 void QgsMarkerSymbolV2::setSize( double s )

--- a/src/core/symbology-ng/qgssymbolv2.h
+++ b/src/core/symbology-ng/qgssymbolv2.h
@@ -282,6 +282,14 @@ class CORE_EXPORT QgsMarkerSymbolV2 : public QgsSymbolV2
     void setAngle( double angle );
     double angle();
 
+    /** Sets the line angle modification for the symbol's angle. This angle is added to 
+     * the marker's rotation and data defined rotation before rendering the symbol, and 
+     * is usually used for orienting symbols to match a line's angle.
+     * @param lineangle Angle in degrees, valid values are between 0 and 360
+     * @note added in QGIS 2.9
+    */
+    void setLineAngle( double lineAngle );
+
     void setSize( double size );
     double size();
 


### PR DESCRIPTION
Marker line's "rotate marker" option allows for the angle of the line to be added to the marker's rotation. The way its currently being implemented doesn't support data-defined rotation.

This pull request improve the implementation, and add support for line angle with data-defined rotations.

Thanks to @nyalldawson who - once again - walked me through the git steps to make this pull request.

(This is a follow up to pull request #2038)
