### PR TITLE
[FEATURE] allow pasting of features in attribute table

### DIFF
--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -536,6 +536,12 @@ void QgsAttributeTableDialog::on_mCopySelectedRowsButton_clicked()
   QgisApp::instance()->editCopy( mLayer );
 }
 
+void QgsAttributeTableDialog::on_mPasteFeatures_clicked()
+{
+  QgisApp::instance()->editPaste( mLayer );
+}
+
+
 void QgsAttributeTableDialog::on_mZoomMapToSelectedRowsButton_clicked()
 {
   QgisApp::instance()->mapCanvas()->zoomToSelected( mLayer );

--- a/src/app/qgsattributetabledialog.h
+++ b/src/app/qgsattributetabledialog.h
@@ -74,6 +74,10 @@ class APP_EXPORT QgsAttributeTableDialog : public QDialog, private Ui::QgsAttrib
      */
     void on_mCopySelectedRowsButton_clicked();
     /**
+     * Paste features from the clipboard
+     */
+    void on_mPasteFeatures_clicked();
+    /**
      * Toggles editing mode
      */
     void on_mToggleEditingButton_toggled();

--- a/src/ui/qgsattributetabledialog.ui
+++ b/src/ui/qgsattributetabledialog.ui
@@ -349,6 +349,35 @@
       </widget>
      </item>
      <item>
+      <widget class="QToolButton" name="mPasteFeatures">
+       <property name="toolTip">
+        <string>Paste features from clipboard (Ctrl+V)</string>
+       </property>
+       <property name="whatsThis">
+        <string/>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../../images/images.qrc">
+         <normaloff>:/images/themes/default/mActionEditPaste.png</normaloff>:/images/themes/default/mActionEditPaste.png</iconset>
+       </property>
+       <property name="iconSize">
+        <size>
+         <width>18</width>
+         <height>18</height>
+        </size>
+       </property>
+       <property name="shortcut">
+        <string>Ctrl+V</string>
+       </property>
+       <property name="autoRaise">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="Line" name="line_3">
        <property name="orientation">
         <enum>Qt::Vertical</enum>


### PR DESCRIPTION
Currently we have only "Copy" button in attribute table dialog. Sometimes, when working with attributes having ability to paste features into table is very handy. Of course one can paste features into layer by switching to main QGIS window but this is a bit inconvenient. This pull-request adds "Paste" button and shortcut to the attribute table dialog.
