### PR TITLE
show correct coordinates in status bar when projected CRS used and canvas units set to degrees (fix #12395)

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -6989,14 +6989,20 @@ void QgisApp::showMouseCoordinate( const QgsPoint & p )
   {
     if ( mMapCanvas->mapUnits() == QGis::Degrees )
     {
+      QgsPoint geo = p;
+      if ( !mMapCanvas->mapSettings().destinationCrs().geographicFlag() )
+      {
+        QgsCoordinateTransform ct( mMapCanvas->mapSettings().destinationCrs(), QgsCoordinateReferenceSystem( GEOSRID ) );
+        geo = ct.transform( p );
+      }
       QString format = QgsProject::instance()->readEntry( "PositionPrecision", "/DegreeFormat", "D" );
 
       if ( format == "DM" )
-        mCoordsEdit->setText( p.toDegreesMinutes( mMousePrecisionDecimalPlaces ) );
+        mCoordsEdit->setText( geo.toDegreesMinutes( mMousePrecisionDecimalPlaces ) );
       else if ( format == "DMS" )
-        mCoordsEdit->setText( p.toDegreesMinutesSeconds( mMousePrecisionDecimalPlaces ) );
+        mCoordsEdit->setText( geo.toDegreesMinutesSeconds( mMousePrecisionDecimalPlaces ) );
       else
-        mCoordsEdit->setText( p.toString( mMousePrecisionDecimalPlaces ) );
+        mCoordsEdit->setText( geo.toString( mMousePrecisionDecimalPlaces ) );
     }
     else
     {

--- a/src/core/qgspoint.cpp
+++ b/src/core/qgspoint.cpp
@@ -153,13 +153,25 @@ QString QgsPoint::toDegreesMinutesSeconds( int thePrecision, const bool useSuffi
     myWrappedX = myWrappedX + 360.0;
   }
 
+  //first, limit latitude to -180 to 180 degree range
+  double myWrappedY = fmod( m_y, 180.0 );
+  //next, wrap around latitudes > 90 or < -90 degrees, so that eg "110S" -> "70N"
+  if ( myWrappedY > 90.0 )
+  {
+    myWrappedY = myWrappedY - 180.0;
+  }
+  else if ( myWrappedY < -90.0 )
+  {
+    myWrappedY = myWrappedY + 180.0;
+  }
+
   int myDegreesX = int( qAbs( myWrappedX ) );
   double myFloatMinutesX = double(( qAbs( myWrappedX ) - myDegreesX ) * 60 );
   int myIntMinutesX = int( myFloatMinutesX );
   double mySecondsX = double( myFloatMinutesX - myIntMinutesX ) * 60;
 
-  int myDegreesY = int( qAbs( m_y ) );
-  double myFloatMinutesY = double(( qAbs( m_y ) - myDegreesY ) * 60 );
+  int myDegreesY = int( qAbs( myWrappedY ) );
+  double myFloatMinutesY = double(( qAbs( myWrappedY ) - myDegreesY ) * 60 );
   int myIntMinutesY = int( myFloatMinutesY );
   double mySecondsY = double( myFloatMinutesY - myIntMinutesY ) * 60;
 
@@ -192,7 +204,7 @@ QString QgsPoint::toDegreesMinutesSeconds( int thePrecision, const bool useSuffi
   if ( useSuffix )
   {
     myXHemisphere = myWrappedX < 0 ? QObject::tr( "W" ) : QObject::tr( "E" );
-    myYHemisphere = m_y < 0 ? QObject::tr( "S" ) : QObject::tr( "N" );
+    myYHemisphere = myWrappedY < 0 ? QObject::tr( "S" ) : QObject::tr( "N" );
   }
   else
   {
@@ -200,7 +212,7 @@ QString QgsPoint::toDegreesMinutesSeconds( int thePrecision, const bool useSuffi
     {
       myXSign = QObject::tr( "-" );
     }
-    if ( m_y < 0 )
+    if ( myWrappedY < 0 )
     {
       myYSign = QObject::tr( "-" );
     }

--- a/tests/src/core/testqgspoint.cpp
+++ b/tests/src/core/testqgspoint.cpp
@@ -220,6 +220,38 @@ void TestQgsPoint::toDegreesMinutesSeconds()
                     QString( "0" ) + QChar( 0x2032 ) + QString( "0.00" ) + QChar( 0x2033 );
   QCOMPARE( QgsPoint( -359, 0 ).toDegreesMinutesSeconds( 2 ), myControlString );
 
+  //check if latitudes > 90 or <-90 wrap around
+  myControlString = QString( "0" ) + QChar( 176 ) +
+                    QString( "0" ) + QChar( 0x2032 ) + QString( "0.00" ) + QChar( 0x2033 ) +
+                    QString( ",10" ) + QChar( 176 ) +
+                    QString( "0" ) + QChar( 0x2032 ) + QString( "0.00" ) + QChar( 0x2033 ) + QString( "N" );
+  QCOMPARE( QgsPoint( 0, 190 ).toDegreesMinutesSeconds( 2 ), myControlString );
+  myControlString = QString( "0" ) + QChar( 176 ) +
+                    QString( "0" ) + QChar( 0x2032 ) + QString( "0.00" ) + QChar( 0x2033 ) +
+                    QString( ",10" ) + QChar( 176 ) +
+                    QString( "0" ) + QChar( 0x2032 ) + QString( "0.00" ) + QChar( 0x2033 ) + QString( "S" );
+  QCOMPARE( QgsPoint( 0, -190 ).toDegreesMinutesSeconds( 2 ), myControlString );
+  myControlString = QString( "0" ) + QChar( 176 ) +
+                    QString( "0" ) + QChar( 0x2032 ) + QString( "0.00" ) + QChar( 0x2033 ) +
+                    QString( ",89" ) + QChar( 176 ) +
+                    QString( "0" ) + QChar( 0x2032 ) + QString( "0.00" ) + QChar( 0x2033 ) + QString( "S" );
+  QCOMPARE( QgsPoint( 0, 91 ).toDegreesMinutesSeconds( 2 ), myControlString );
+  myControlString = QString( "0" ) + QChar( 176 ) +
+                    QString( "0" ) + QChar( 0x2032 ) + QString( "0.00" ) + QChar( 0x2033 ) +
+                    QString( ",89" ) + QChar( 176 ) +
+                    QString( "0" ) + QChar( 0x2032 ) + QString( "0.00" ) + QChar( 0x2033 ) + QString( "N" );
+  QCOMPARE( QgsPoint( 0, -91 ).toDegreesMinutesSeconds( 2 ), myControlString );
+  myControlString = QString( "0" ) + QChar( 176 ) +
+                    QString( "0" ) + QChar( 0x2032 ) + QString( "0.00" ) + QChar( 0x2033 ) +
+                    QString( ",1" ) + QChar( 176 ) +
+                    QString( "0" ) + QChar( 0x2032 ) + QString( "0.00" ) + QChar( 0x2033 ) + QString( "S" );
+  QCOMPARE( QgsPoint( 0, 179 ).toDegreesMinutesSeconds( 2 ), myControlString );
+  myControlString = QString( "0" ) + QChar( 176 ) +
+                    QString( "0" ) + QChar( 0x2032 ) + QString( "0.00" ) + QChar( 0x2033 ) +
+                    QString( ",1" ) + QChar( 176 ) +
+                    QString( "0" ) + QChar( 0x2032 ) + QString( "0.00" ) + QChar( 0x2033 ) + QString( "N" );
+  QCOMPARE( QgsPoint( 0, -179 ).toDegreesMinutesSeconds( 2 ), myControlString );
+
   //should be no directional suffixes for 0 degree coordinates
   myControlString = QString( "0" ) + QChar( 176 ) +
                     QString( "0" ) + QChar( 0x2032 ) + QString( "0.00" ) +
@@ -258,9 +290,9 @@ void TestQgsPoint::toDegreesMinutesSeconds()
   //test rounding does not create seconds >= 60
   myControlString = QString( "100" ) + QChar( 176 ) +
                     QString( "0" ) + QChar( 0x2032 ) + QString( "0.00" ) + QChar( 0x2033 ) + QString( "E" ) +
-                    QString( ",100" ) + QChar( 176 ) +
+                    QString( ",90" ) + QChar( 176 ) +
                     QString( "0" ) + QChar( 0x2032 ) + QString( "0.00" ) + QChar( 0x2033 ) + QString( "N" );
-  QCOMPARE( QgsPoint( 99.999999, 99.999999 ).toDegreesMinutesSeconds( 2 ), myControlString );
+  QCOMPARE( QgsPoint( 99.999999, 89.999999 ).toDegreesMinutesSeconds( 2 ), myControlString );
 
   //should be no directional suffixes for 180 degree longitudes
   myControlString = QString( "180" ) + QChar( 176 ) +


### PR DESCRIPTION
Seems toDegreesMinutesSeconds() method accepts only decimal degrees and fails when coordinates in meters (or other projected units). So we need to transform coordinates to geographic CRS before passing them to this method. Also it seems that this method misses handling of latitude ranges and corresponding wrapping
