### PR TITLE
Write to project join memory cache property value instead of not cache is empty

### DIFF
--- a/src/core/qgsvectorlayerjoinbuffer.cpp
+++ b/src/core/qgsvectorlayerjoinbuffer.cpp
@@ -281,7 +281,7 @@ void QgsVectorLayerJoinBuffer::writeXml( QDomNode& layer_node, QDomDocument& doc
     else
       joinElem.setAttribute( "joinFieldName", joinIt->joinFieldName );
 
-    joinElem.setAttribute( "memoryCache", !joinIt->cachedAttributes.isEmpty() );
+    joinElem.setAttribute( "memoryCache", joinIt->memoryCache );
 
     if ( joinIt->joinFieldNamesSubset() )
     {


### PR DESCRIPTION
With existing behavior which write !joinIt->cachedAttributes.isEmpty() to project, if the joined table is empty, the memory cache fall down to false on project saving.
When using existing project with a new fresh database, this is very inconvenient.
It seems smarter to write the content of the memoryCache property.
