### PR TITLE
remove SizeScale and Rotation from Advanced Menu

### DIFF
--- a/src/core/symbology-ng/qgscategorizedsymbolrendererv2.cpp
+++ b/src/core/symbology-ng/qgscategorizedsymbolrendererv2.cpp
@@ -525,46 +525,6 @@ QgsSymbolV2List QgsCategorizedSymbolRendererV2::symbols()
   return lst;
 }
 
-//!@note this function is duplicated in 3 cpp files, it's used to convert
-//! old sizeScale expresssions to symbol level DataDefined size
-inline void convertSymbolSizeScale( QgsSymbolV2 * symbol, QgsSymbolV2::ScaleMethod method, const QString & field )
-{
-  if ( symbol->type() == QgsSymbolV2::Marker )
-  {
-    QgsMarkerSymbolV2 * s = static_cast<QgsMarkerSymbolV2 *>( symbol );
-    if ( QgsSymbolV2::ScaleArea == method )
-    {
-      const QgsDataDefined dd( "sqrt(" + QString::number( s->size() ) + " * (" + field + "))" );
-      s->setDataDefinedSize( dd );
-    }
-    else
-    {
-      const QgsDataDefined dd( QString::number( s->size() ) + " * (" + field + ")" );
-      s->setDataDefinedSize( dd );
-    }
-  }
-  else if ( symbol->type() == QgsSymbolV2::Line )
-  {
-    QgsLineSymbolV2 * s = static_cast<QgsLineSymbolV2 *>( symbol );
-    const QgsDataDefined dd( QString::number( s->width() ) + " * (" + field + ")" );
-    s->setDataDefinedWidth( dd );
-  }
-}
-
-//!@note this function is duplicated in 3 cpp files, it's used to convert
-//! old rotations expresssions to symbol level DataDefined angle
-inline void convertSymbolRotation( QgsSymbolV2 * symbol, const QString & field )
-{
-  if ( symbol->type() == QgsSymbolV2::Marker )
-  {
-    QgsMarkerSymbolV2 * s = static_cast<QgsMarkerSymbolV2 *>( symbol );
-    const QgsDataDefined dd(( s->angle()
-                              ? QString::number( s->angle() ) + " + "
-                              : QString() ) + field );
-    s->setDataDefinedAngle( dd );
-  }
-}
-
 QgsFeatureRendererV2* QgsCategorizedSymbolRendererV2::create( QDomElement& element )
 {
   QDomElement symbolsElem = element.firstChildElement( "symbols" );

--- a/src/core/symbology-ng/qgscategorizedsymbolrendererv2.cpp
+++ b/src/core/symbology-ng/qgscategorizedsymbolrendererv2.cpp
@@ -588,7 +588,6 @@ QgsFeatureRendererV2* QgsCategorizedSymbolRendererV2::create( QDomElement& eleme
   QDomElement rotationElem = element.firstChildElement( "rotation" );
   if ( !rotationElem.isNull() && !rotationElem.attribute( "field" ).isEmpty() )
   {
-    const QgsDataDefined dd( rotationElem.attribute( "field" ) );
     QgsCategoryList::iterator it = r->mCategories.begin();
     for ( ; it != r->mCategories.end(); ++it )
     {

--- a/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.cpp
+++ b/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.cpp
@@ -519,7 +519,7 @@ QgsFeatureRendererV2* QgsGraduatedSymbolRendererV2::clone() const
   r->setUsingSymbolLevels( usingSymbolLevels() );
   r->setRotationField( rotationField() );
   r->setSizeScaleField( sizeScaleField() );
-  r->setScaleMethod( scaleMethod() );
+  //r->setScaleMethod( scaleMethod() );
   r->setLabelFormat( labelFormat() );
   r->setGraduatedMethod( graduatedMethod() );
   copyPaintEffect( r );
@@ -937,6 +937,45 @@ void QgsGraduatedSymbolRendererV2::updateClasses( QgsVectorLayer *vlayer, Mode m
   updateColorRamp( 0, mInvertedColorRamp );
 }
 
+//!@note this function is duplicated in 3 cpp files, it's used to convert
+//! old sizeScale expresssions to symbol level DataDefined size
+inline void convertSymbolSizeScale( QgsSymbolV2 * symbol, QgsSymbolV2::ScaleMethod method, const QString & field )
+{
+  if ( symbol->type() == QgsSymbolV2::Marker )
+  {
+    QgsMarkerSymbolV2 * s = static_cast<QgsMarkerSymbolV2 *>( symbol );
+    if ( QgsSymbolV2::ScaleArea == method )
+    {
+      const QgsDataDefined dd( "sqrt(" + QString::number( s->size() ) + " * (" + field + "))" );
+      s->setDataDefinedSize( dd );
+    }
+    else
+    {
+      const QgsDataDefined dd( QString::number( s->size() ) + " * (" + field + ")" );
+      s->setDataDefinedSize( dd );
+    }
+  }
+  else if ( symbol->type() == QgsSymbolV2::Line )
+  {
+    QgsLineSymbolV2 * s = static_cast<QgsLineSymbolV2 *>( symbol );
+    const QgsDataDefined dd( QString::number( s->width() ) + " * (" + field + ")" );
+    s->setDataDefinedWidth( dd );
+  }
+}
+
+//!@note this function is duplicated in 3 cpp files, it's used to convert
+//! old rotations expresssions to symbol level DataDefined angle
+inline void convertSymbolRotation( QgsSymbolV2 * symbol, const QString & field )
+{
+  if ( symbol->type() == QgsSymbolV2::Marker )
+  {
+    QgsMarkerSymbolV2 * s = static_cast<QgsMarkerSymbolV2 *>( symbol );
+    const QgsDataDefined dd(( s->angle()
+                              ? QString::number( s->angle() ) + " + "
+                              : QString() ) + field );
+    s->setDataDefinedAngle( dd );
+  }
+}
 
 QgsFeatureRendererV2* QgsGraduatedSymbolRendererV2::create( QDomElement& element )
 {
@@ -1027,13 +1066,35 @@ QgsFeatureRendererV2* QgsGraduatedSymbolRendererV2::create( QDomElement& element
   }
 
   QDomElement rotationElem = element.firstChildElement( "rotation" );
-  if ( !rotationElem.isNull() )
-    r->setRotationField( rotationElem.attribute( "field" ) );
+  if ( !rotationElem.isNull() && !rotationElem.attribute( "field" ).isEmpty() )
+  {
+    const QgsDataDefined dd( rotationElem.attribute( "field" ) );
+    for ( QgsRangeList::iterator it = r->mRanges.begin(); it != r->mRanges.end(); ++it )
+    {
+      convertSymbolRotation( it->symbol(), rotationElem.attribute( "field" ) );
+    }
+    if ( r->mSourceSymbol.data() )
+    {
+      convertSymbolRotation( r->mSourceSymbol.data(), rotationElem.attribute( "field" ) );
+    }
+  }
 
   QDomElement sizeScaleElem = element.firstChildElement( "sizescale" );
-  if ( !sizeScaleElem.isNull() )
-    r->setSizeScaleField( sizeScaleElem.attribute( "field" ) );
-  r->setScaleMethod( QgsSymbolLayerV2Utils::decodeScaleMethod( sizeScaleElem.attribute( "scalemethod" ) ) );
+  if ( !sizeScaleElem.isNull() && !sizeScaleElem.attribute( "field" ).isEmpty() )
+  {
+    for ( QgsRangeList::iterator it = r->mRanges.begin(); it != r->mRanges.end(); ++it )
+    {
+      convertSymbolSizeScale( it->symbol(),
+                              QgsSymbolLayerV2Utils::decodeScaleMethod( sizeScaleElem.attribute( "scalemethod" ) ),
+                              sizeScaleElem.attribute( "field" ) );
+    }
+    if ( r->mSourceSymbol.data() && r->mSourceSymbol->type() == QgsSymbolV2::Marker )
+    {
+      convertSymbolSizeScale( r->mSourceSymbol.data(),
+                              QgsSymbolLayerV2Utils::decodeScaleMethod( sizeScaleElem.attribute( "scalemethod" ) ),
+                              sizeScaleElem.attribute( "field" ) );
+    }
+  }
 
   QDomElement labelFormatElem = element.firstChildElement( "labelformat" );
   if ( ! labelFormatElem.isNull() )

--- a/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.cpp
+++ b/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.cpp
@@ -1028,7 +1028,6 @@ QgsFeatureRendererV2* QgsGraduatedSymbolRendererV2::create( QDomElement& element
   QDomElement rotationElem = element.firstChildElement( "rotation" );
   if ( !rotationElem.isNull() && !rotationElem.attribute( "field" ).isEmpty() )
   {
-    const QgsDataDefined dd( rotationElem.attribute( "field" ) );
     for ( QgsRangeList::iterator it = r->mRanges.begin(); it != r->mRanges.end(); ++it )
     {
       convertSymbolRotation( it->symbol(), rotationElem.attribute( "field" ) );

--- a/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.cpp
+++ b/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.cpp
@@ -937,46 +937,6 @@ void QgsGraduatedSymbolRendererV2::updateClasses( QgsVectorLayer *vlayer, Mode m
   updateColorRamp( 0, mInvertedColorRamp );
 }
 
-//!@note this function is duplicated in 3 cpp files, it's used to convert
-//! old sizeScale expresssions to symbol level DataDefined size
-inline void convertSymbolSizeScale( QgsSymbolV2 * symbol, QgsSymbolV2::ScaleMethod method, const QString & field )
-{
-  if ( symbol->type() == QgsSymbolV2::Marker )
-  {
-    QgsMarkerSymbolV2 * s = static_cast<QgsMarkerSymbolV2 *>( symbol );
-    if ( QgsSymbolV2::ScaleArea == method )
-    {
-      const QgsDataDefined dd( "sqrt(" + QString::number( s->size() ) + " * (" + field + "))" );
-      s->setDataDefinedSize( dd );
-    }
-    else
-    {
-      const QgsDataDefined dd( QString::number( s->size() ) + " * (" + field + ")" );
-      s->setDataDefinedSize( dd );
-    }
-  }
-  else if ( symbol->type() == QgsSymbolV2::Line )
-  {
-    QgsLineSymbolV2 * s = static_cast<QgsLineSymbolV2 *>( symbol );
-    const QgsDataDefined dd( QString::number( s->width() ) + " * (" + field + ")" );
-    s->setDataDefinedWidth( dd );
-  }
-}
-
-//!@note this function is duplicated in 3 cpp files, it's used to convert
-//! old rotations expresssions to symbol level DataDefined angle
-inline void convertSymbolRotation( QgsSymbolV2 * symbol, const QString & field )
-{
-  if ( symbol->type() == QgsSymbolV2::Marker )
-  {
-    QgsMarkerSymbolV2 * s = static_cast<QgsMarkerSymbolV2 *>( symbol );
-    const QgsDataDefined dd(( s->angle()
-                              ? QString::number( s->angle() ) + " + "
-                              : QString() ) + field );
-    s->setDataDefinedAngle( dd );
-  }
-}
-
 QgsFeatureRendererV2* QgsGraduatedSymbolRendererV2::create( QDomElement& element )
 {
   QDomElement symbolsElem = element.firstChildElement( "symbols" );

--- a/src/core/symbology-ng/qgsrendererv2.cpp
+++ b/src/core/symbology-ng/qgsrendererv2.cpp
@@ -642,7 +642,7 @@ void QgsFeatureRendererV2::setPaintEffect( QgsPaintEffect *effect )
   mPaintEffect = effect;
 }
 
-void QgsFeatureRendererV2::convertSymbolSizeScale( QgsSymbolV2 * symbol, int method, const QString & field )
+void QgsFeatureRendererV2::convertSymbolSizeScale( QgsSymbolV2 * symbol, QgsSymbolV2::ScaleMethod method, const QString & field )
 {
   if ( symbol->type() == QgsSymbolV2::Marker )
   {

--- a/src/core/symbology-ng/qgsrendererv2.cpp
+++ b/src/core/symbology-ng/qgsrendererv2.cpp
@@ -17,6 +17,7 @@
 #include "qgssymbolv2.h"
 #include "qgssymbollayerv2utils.h"
 #include "qgsrulebasedrendererv2.h"
+#include "qgsdatadefined.h"
 
 #include "qgssinglesymbolrendererv2.h" // for default renderer
 
@@ -639,4 +640,40 @@ void QgsFeatureRendererV2::setPaintEffect( QgsPaintEffect *effect )
 {
   delete mPaintEffect;
   mPaintEffect = effect;
+}
+
+void QgsFeatureRendererV2::convertSymbolSizeScale( QgsSymbolV2 * symbol, int method, const QString & field )
+{
+  if ( symbol->type() == QgsSymbolV2::Marker )
+  {
+    QgsMarkerSymbolV2 * s = static_cast<QgsMarkerSymbolV2 *>( symbol );
+    if ( QgsSymbolV2::ScaleArea == QgsSymbolV2::ScaleMethod( method ) )
+    {
+      const QgsDataDefined dd( "sqrt(" + QString::number( s->size() ) + " * (" + field + "))" );
+      s->setDataDefinedSize( dd );
+    }
+    else
+    {
+      const QgsDataDefined dd( QString::number( s->size() ) + " * (" + field + ")" );
+      s->setDataDefinedSize( dd );
+    }
+  }
+  else if ( symbol->type() == QgsSymbolV2::Line )
+  {
+    QgsLineSymbolV2 * s = static_cast<QgsLineSymbolV2 *>( symbol );
+    const QgsDataDefined dd( QString::number( s->width() ) + " * (" + field + ")" );
+    s->setDataDefinedWidth( dd );
+  }
+}
+
+void QgsFeatureRendererV2::convertSymbolRotation( QgsSymbolV2 * symbol, const QString & field )
+{
+  if ( symbol->type() == QgsSymbolV2::Marker )
+  {
+    QgsMarkerSymbolV2 * s = static_cast<QgsMarkerSymbolV2 *>( symbol );
+    const QgsDataDefined dd(( s->angle()
+                              ? QString::number( s->angle() ) + " + "
+                              : QString() ) + field );
+    s->setDataDefinedAngle( dd );
+  }
 }

--- a/src/core/symbology-ng/qgsrendererv2.h
+++ b/src/core/symbology-ng/qgsrendererv2.h
@@ -19,6 +19,7 @@
 #include "qgis.h"
 #include "qgsrectangle.h"
 #include "qgsrendercontext.h"
+#include "qgssymbolv2.h"
 
 #include <QList>
 #include <QString>
@@ -28,7 +29,6 @@
 #include <QDomDocument>
 #include <QDomElement>
 
-class QgsSymbolV2;
 class QgsFeature;
 class QgsFields;
 class QgsVectorLayer;
@@ -275,7 +275,7 @@ class CORE_EXPORT QgsFeatureRendererV2
     /**@note this function is used to convert old sizeScale expresssions to symbol 
      * level DataDefined size
      */
-    static void convertSymbolSizeScale( QgsSymbolV2 * symbol, int method, const QString & field );
+    static void convertSymbolSizeScale( QgsSymbolV2 * symbol, QgsSymbolV2::ScaleMethod method, const QString & field );
     /**@note this function is used to convert old rotations expresssions to symbol 
      * level DataDefined angle
      */

--- a/src/core/symbology-ng/qgsrendererv2.h
+++ b/src/core/symbology-ng/qgsrendererv2.h
@@ -272,6 +272,15 @@ class CORE_EXPORT QgsFeatureRendererV2
 
     QgsPaintEffect* mPaintEffect;
 
+    /**@note this function is used to convert old sizeScale expresssions to symbol 
+     * level DataDefined size
+     */
+    static void convertSymbolSizeScale( QgsSymbolV2 * symbol, int method, const QString & field );
+    /**@note this function is used to convert old rotations expresssions to symbol 
+     * level DataDefined angle
+     */
+    static void convertSymbolRotation( QgsSymbolV2 * symbol, const QString & field );
+    
   private:
     Q_DISABLE_COPY( QgsFeatureRendererV2 )
 };

--- a/src/core/symbology-ng/qgssinglesymbolrendererv2.cpp
+++ b/src/core/symbology-ng/qgssinglesymbolrendererv2.cpp
@@ -216,45 +216,6 @@ QgsSymbolV2List QgsSingleSymbolRendererV2::symbols()
   return lst;
 }
 
-//!@note this function is duplicated in 3 cpp files, it's used to convert
-//! old sizeScale expresssions to symbol level DataDefined size
-inline void convertSymbolSizeScale( QgsSymbolV2 * symbol, QgsSymbolV2::ScaleMethod method, const QString & field )
-{
-  if ( symbol->type() == QgsSymbolV2::Marker )
-  {
-    QgsMarkerSymbolV2 * s = static_cast<QgsMarkerSymbolV2 *>( symbol );
-    if ( QgsSymbolV2::ScaleArea == method )
-    {
-      const QgsDataDefined dd( "sqrt(" + QString::number( s->size() ) + " * (" + field + "))" );
-      s->setDataDefinedSize( dd );
-    }
-    else
-    {
-      const QgsDataDefined dd( QString::number( s->size() ) + " * (" + field + ")" );
-      s->setDataDefinedSize( dd );
-    }
-  }
-  else if ( symbol->type() == QgsSymbolV2::Line )
-  {
-    QgsLineSymbolV2 * s = static_cast<QgsLineSymbolV2 *>( symbol );
-    const QgsDataDefined dd( QString::number( s->width() ) + " * (" + field + ")" );
-    s->setDataDefinedWidth( dd );
-  }
-}
-
-//!@note this function is duplicated in 3 cpp files, it's used to convert
-//! old rotations expresssions to symbol level DataDefined angle
-inline void convertSymbolRotation( QgsSymbolV2 * symbol, const QString & field )
-{
-  if ( symbol->type() == QgsSymbolV2::Marker )
-  {
-    QgsMarkerSymbolV2 * s = static_cast<QgsMarkerSymbolV2 *>( symbol );
-    const QgsDataDefined dd(( s->angle()
-                              ? QString::number( s->angle() ) + " + "
-                              : QString() ) + field );
-    s->setDataDefinedAngle( dd );
-  }
-}
 
 QgsFeatureRendererV2* QgsSingleSymbolRendererV2::create( QDomElement& element )
 {

--- a/src/gui/symbology-ng/qgsrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgsrendererv2widget.cpp
@@ -241,8 +241,11 @@ QgsRendererV2DataDefinedMenus::QgsRendererV2DataDefinedMenus( QMenu* menu, QgsVe
 
   mSizeScaleMenu->addActions( mSizeMethodActionGroup->actions() );
 
-  menu->addMenu( mRotationMenu );
-  menu->addMenu( mSizeScaleMenu );
+  //@todo cleanup the class since Rotation and SizeScale are now
+  //defined using QgsDataDefinedButton
+  //
+  //menu->addMenu( mRotationMenu );
+  //menu->addMenu( mSizeScaleMenu );
 
   connect( mSizeMethodActionGroup, SIGNAL( triggered( QAction* ) ), this, SLOT( scaleMethodSelected( QAction* ) ) );
   connect( mRotationAttributeActionGroup, SIGNAL( triggered( QAction* ) ), this, SLOT( rotationFieldSelected( QAction* ) ) );


### PR DESCRIPTION
The expressions used in old project are converted to symbol level
DadaDefined size and angle

Note that sice the aspect of a composite marker is fixed for symbol size
and angle, the aspect of the scaled symbol will change for symbols with
offsets and composite markers.
