### PR TITLE
Fix processing ParameterTable.setValue

### DIFF
--- a/python/plugins/processing/core/parameters.py
+++ b/python/plugins/processing/core/parameters.py
@@ -620,9 +620,10 @@ class ParameterTable(ParameterDataObject):
             self.value = source
             return True
         else:
-            layers = dataobjects.getVectorLayers()
+            self.value = unicode(obj)
+            layers = dataobjects.getTables()
             for layer in layers:
-                if layer.name() == self.value:
+                if layer.name() == self.value or layer.source() == self.value:
                     source = unicode(layer.source())
                     self.value = source
                     return True


### PR DESCRIPTION
Fix https://hub.qgis.org/issues/12801
In ParameterTable.setValue, loaded layer was not found by name.
I've fixed parameter table using parameter vector as a model.
(and used getTables intead of getVectorLayer which seems to me more appropriate)
