### PR TITLE
[gui] apply icon size user preference to dock widget tool buttons

### DIFF
--- a/src/app/qgisappstylesheet.cpp
+++ b/src/app/qgisappstylesheet.cpp
@@ -18,6 +18,7 @@
 
 #include "qgisappstylesheet.h"
 #include "qgsapplication.h"
+#include "qgisapp.h"
 #include "qgslogger.h"
 
 #include <QFont>
@@ -91,6 +92,8 @@ QMap<QString, QVariant> QgisAppStyleSheet::defaultOptions()
 
   settings.endGroup(); // "qgis/stylesheet"
 
+  opts.insert( "iconSize", settings.value( "/IconSize", QGIS_ICON_SIZE ) );
+  
   return opts;
 }
 
@@ -173,6 +176,11 @@ void QgisAppStyleSheet::buildStyleSheet( const QMap<QString, QVariant>& opts )
         .arg( palette.highlight().color().name() )
         .arg( palette.highlightedText().color().name() );
 
+  QString iconSize = opts.value( "iconSize" ).toString();
+  QgsDebugMsg( QString( "iconSize: %1" ).arg( iconSize ) );
+  if ( iconSize.isEmpty() ) { return; }
+  ss += QString( "QDockWidget QToolButton { icon-size: %1px; }" ).arg( iconSize );
+  
   QgsDebugMsg( QString( "Stylesheet built: %1" ).arg( ss ) );
 
   emit appStyleSheetChanged( ss );

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -925,6 +925,9 @@ void QgsOptions::on_pbnTemplateFolderReset_pressed()
 void QgsOptions::iconSizeChanged( const QString &iconSize )
 {
   QgisApp::instance()->setIconSizes( iconSize.toInt() );
+  
+  mStyleSheetNewOpts.insert( "iconSize", QVariant( iconSize.toInt() ) );
+  mStyleSheetBuilder->buildStyleSheet( mStyleSheetNewOpts );
 }
 
 void QgsOptions::on_mProjectOnLaunchCmbBx_currentIndexChanged( int indx )


### PR DESCRIPTION
This pull request adds a app-wide style sheet setting to allow for dock widget's tool buttons to respect the user-set icon size setting. This improves the appearance of QGIS under several GTK themes, including gnome shell's default Adwaita theme. See http://hub.qgis.org/issues/12816 for a screenshot of the problem under gnome shell's default theme.

It also allows for dock tool buttons to grow to larger sizes (i.e. > 24 pixels), which might be desirable on high resolution screens / tablets.

Since this harmonizes the size of the toolbar buttons and the dock widget tool buttons, it has an impact on how QGIS looks by default on Windows and on Ubuntu. On both of these OSes, the default dock widget tool button size is set to 16 x 16 (smaller than QGIS' default icon size of 24 x 24). The result is that on those systems, the layer dock widget will have slightly bigger buttons by default, unless and until the user customizes the icon size setting if desired. IMO, this looks better due to being more visually consistent.
