### PR TITLE
Update QgsFields nameToIndex hash on field removed

### DIFF
--- a/src/core/qgsfield.cpp
+++ b/src/core/qgsfield.cpp
@@ -259,8 +259,12 @@ void QgsFields::remove( int fieldIdx )
   if ( !exists( fieldIdx ) )
     return;
 
-  d->nameToIndex.remove( d->fields[fieldIdx].field.name() );
   d->fields.remove( fieldIdx );
+  d->nameToIndex.clear();
+  for ( int idx = 0; idx < count(); ++idx )
+  {
+    d->nameToIndex.insert( d->fields[idx].field.name(), idx );
+  }
 }
 
 void QgsFields::extend( const QgsFields& other )

--- a/tests/src/core/testqgsfields.cpp
+++ b/tests/src/core/testqgsfields.cpp
@@ -230,6 +230,7 @@ void TestQgsFields::remove()
   fields.remove( 0 );
   QCOMPARE( fields.count(), 1 );
   QCOMPARE( fields.at( 0 ).name(), QString( "testfield2" ) );
+  QCOMPARE( fields.indexFromName(QString( "testfield2" )), 0);
 }
 
 void TestQgsFields::extend()


### PR DESCRIPTION
QgsField nameToIndex hash has be refreshed after field removed.
Fix https://hub.qgis.org/issues/12778
