### PR TITLE
Connection pool fixes

### DIFF
--- a/src/core/qgsconnectionpool.h
+++ b/src/core/qgsconnectionpool.h
@@ -123,9 +123,8 @@ class QgsConnectionPoolGroup
 
     void release( T conn )
     {
-      acquiredConns.removeAll( conn );
-
       connMutex.lock();
+      acquiredConns.removeAll( conn );
       Item i;
       i.c = conn;
       i.lastUsedTime = QTime::currentTime();
@@ -254,6 +253,20 @@ class QgsConnectionPool
 
       group->release( conn );
     }
+
+    //! Invalidates all connections to the specified resource.
+    //! The internal state of certain handles (for instance OGR) are altered
+    //! when a dataset is modified. Consquently, all open handles need to be
+    //! invalidated when such datasets are changed to ensure the handles are
+    //! refreshed. See the OGR provider for an example where this is needed.
+    void invalidateConnections( const QString& connInfo )
+    {
+      mMutex.lock();
+      if ( mGroups.contains( connInfo ) )
+        mGroups[connInfo]->invalidateConnections();
+      mMutex.unlock();
+    }
+
 
   protected:
     T_Groups mGroups;

--- a/src/providers/ogr/qgsogrconnpool.cpp
+++ b/src/providers/ogr/qgsogrconnpool.cpp
@@ -31,11 +31,3 @@ QgsOgrConnPool::~QgsOgrConnPool()
 {
   QgsDebugCall;
 }
-
-void QgsOgrConnPool::invalidateHandles( const QString& connInfo )
-{
-  mMutex.lock();
-  if ( mGroups.contains( connInfo ) )
-    mGroups[connInfo]->invalidateConnections();
-  mMutex.unlock();
-}

--- a/src/providers/ogr/qgsogrconnpool.h
+++ b/src/providers/ogr/qgsogrconnpool.h
@@ -79,8 +79,6 @@ class QgsOgrConnPool : public QgsConnectionPool<QgsOgrConn*, QgsOgrConnPoolGroup
   public:
     static QgsOgrConnPool* instance();
 
-    void invalidateHandles( const QString& connInfo );
-
   protected:
     Q_DISABLE_COPY( QgsOgrConnPool )
 

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -741,7 +741,7 @@ OGRwkbGeometryType QgsOgrProvider::getOgrGeomType( OGRLayerH ogrLayer )
 
 void QgsOgrProvider::loadFields()
 {
-  QgsOgrConnPool::instance()->invalidateHandles( filePath() );
+  QgsOgrConnPool::instance()->invalidateConnections( filePath() );
   //the attribute fields need to be read again when the encoding changes
   mAttributeFields.clear();
 
@@ -2524,7 +2524,7 @@ void QgsOgrProvider::recalculateFeatureCount()
     OGR_L_SetSpatialFilter( ogrLayer, filter );
   }
 
-  QgsOgrConnPool::instance()->invalidateHandles( filePath() );
+  QgsOgrConnPool::instance()->invalidateConnections( filePath() );
 }
 
 OGRwkbGeometryType QgsOgrProvider::ogrWkbSingleFlatten( OGRwkbGeometryType type )


### PR DESCRIPTION
- Fixes unsafe access to `QgsConnectionPoolGroup::acquiredConns`
- Moves `QgsOgrConnPool::invalidateHandles` to `QgsConnectionPool::invalidateConnections` and adds documentation
