### PR TITLE
Allow linking API docs to Qt docs

### DIFF
--- a/cmake_templates/Doxyfile.in
+++ b/cmake_templates/Doxyfile.in
@@ -1404,7 +1404,7 @@ SKIP_FUNCTION_MACROS   = YES
 # If a tag file is not located in the directory in which doxygen
 # is run, you must also specify the path to the tagfile here.
 
-TAGFILES               =
+TAGFILES               = @DOXYGEN_TAGS@
 
 # When a file name is specified after GENERATE_TAGFILE, doxygen will create
 # a tag file that is based on the input files it reads.

--- a/doc/CMakeLists.txt
+++ b/doc/CMakeLists.txt
@@ -4,6 +4,9 @@ SET (WITH_APIDOC FALSE CACHE BOOL "Determines whether the QGIS API doxygen docum
 # include doxygen documentation
 SET (WITH_TXT2TAGS_PDF FALSE CACHE BOOL "Determines whether PDF should be generate for the txt2tags documentation")
 
+# include Qt documentation
+SET (QT_DOC_URL "http://doc.qt.io/qt-4.8/" CACHE STRING "URL for Qt docs")
+
 INCLUDE(Txt2Tags)
 FIND_TXT2TAGS()
 
@@ -28,6 +31,16 @@ INSTALL(FILES ../images/icons/qgis-icon-60x60.png DESTINATION ${QGIS_DATA_DIR}/d
 IF(WITH_APIDOC)
   FIND_PACKAGE(Doxygen)
   IF(DOXYGEN_FOUND)
+
+    FIND_FILE(QT_TAG_FILE
+      NAMES qt4.tags qt4.tag qt.tags qt.tag
+      PATHS "${QT_DOC_DIR}"
+      DOC "Path to Qt documentation tag file (eg qt.tags)"
+    )
+    IF(QT_TAG_FILE)
+      SET(DOXYGEN_TAGS ${QT_TAG_FILE}=${QT_DOC_URL})
+    ENDIF(QT_TAG_FILE)
+
     CONFIGURE_FILE(${CMAKE_SOURCE_DIR}/cmake_templates/Doxyfile.in ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile @ONLY)
     ADD_CUSTOM_TARGET(apidoc ALL
             COMMAND ${DOXYGEN_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/Doxyfile


### PR DESCRIPTION
This PR allows using a Qt documentation tagfile within the QGIS docs. Using the tag file will link QGIS api docs to the upstream Qt docs, and allows nice things like seeing the full inheritance for Qt classes and being able to directly click on a Qt class to see its associated upstream documentation. 
