### PR TITLE
Attribute table performance when deleting features

### DIFF
--- a/python/core/qgsvectorlayer.sip
+++ b/python/core/qgsvectorlayer.sip
@@ -1293,6 +1293,16 @@ class QgsVectorLayer : QgsMapLayer
     void featureAdded( QgsFeatureId fid );
     void featureDeleted( QgsFeatureId fid );
     /**
+     * Emitted when features have been deleted.
+     *
+     * If features are deleted within an edit command, this will only be emitted once at the end
+     * to allow connected slots to minimize the overhead.
+     * If features are delted outside of an edit command, this signal will be emitted once per feature.
+     *
+     * @param fids The feature ids that have been deleted.
+     */
+    void featuresDeleted( QgsFeatureIds fids );
+    /**
      * Is emitted, whenever the fields available from this layer have been changed.
      * This can be due to manually adding attributes or due to a join.
      */

--- a/python/gui/attributetable/qgsattributetablemodel.sip
+++ b/python/gui/attributetable/qgsattributetablemodel.sip
@@ -198,10 +198,10 @@ class QgsAttributeTableModel : QAbstractTableModel
      */
     virtual void attributeValueChanged( QgsFeatureId fid, int idx, const QVariant &value );
     /**
-     * Launched when a feature has been deleted
-     * @param fid feature id
+     * Launched when eatures have been deleted
+     * @param fids feature ids
      */
-    virtual void featureDeleted( QgsFeatureId fid );
+    virtual void featuresDeleted( QgsFeatureIds fid );
     /**
      * Launched when a feature has been added
      * @param fid feature id

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -139,6 +139,8 @@ QgsAttributeTableDialog::QgsAttributeTableDialog( QgsVectorLayer *theLayer, QWid
   connect( mLayer, SIGNAL( editingStopped() ), this, SLOT( editingToggled() ) );
   connect( mLayer, SIGNAL( layerDeleted() ), this, SLOT( close() ) );
   connect( mLayer, SIGNAL( selectionChanged() ), this, SLOT( updateTitle() ) );
+  connect( mLayer, SIGNAL( featureAdded( QgsFeatureId ) ), this, SLOT( updateTitle() ) );
+  connect( mLayer, SIGNAL( featuresDeleted( QgsFeatureIds ) ), this, SLOT( updateTitle() ) );
   connect( mLayer, SIGNAL( attributeAdded( int ) ), this, SLOT( columnBoxInit() ) );
   connect( mLayer, SIGNAL( attributeDeleted( int ) ), this, SLOT( columnBoxInit() ) );
 
@@ -405,12 +407,12 @@ void QgsAttributeTableDialog::runFieldCalculation( QgsVectorLayer* layer, QStrin
   mLayer->endEditCommand();
 }
 
-void QgsAttributeTableDialog::replaceSearchWidget(QWidget* oldw, QWidget* neww)
+void QgsAttributeTableDialog::replaceSearchWidget( QWidget* oldw, QWidget* neww )
 {
-    mFilterLayout->removeWidget(oldw);
-    oldw->setVisible(false);
-    mFilterLayout->addWidget(neww,0,0,0);
-    neww->setVisible(true);
+  mFilterLayout->removeWidget( oldw );
+  oldw->setVisible( false );
+  mFilterLayout->addWidget( neww, 0, 0, 0 );
+  neww->setVisible( true );
 }
 
 void QgsAttributeTableDialog::filterColumnChanged( QObject* filterAction )
@@ -427,14 +429,14 @@ void QgsAttributeTableDialog::filterColumnChanged( QObject* filterAction )
   QString fieldName = mFilterButton->defaultAction()->text();
   // get the search widget
   int fldIdx = mLayer->fieldNameIndex( fieldName );
-    if ( fldIdx < 0 )
-      return;
+  if ( fldIdx < 0 )
+    return;
   const QString widgetType = mLayer->editorWidgetV2( fldIdx );
   const QgsEditorWidgetConfig widgetConfig = mLayer->editorWidgetV2Config( fldIdx );
-  mCurrentSearchWidgetWrapper= QgsEditorWidgetRegistry::instance()->
-      createSearchWidget(widgetType, mLayer, fldIdx, widgetConfig, mFilterContainer);
+  mCurrentSearchWidgetWrapper = QgsEditorWidgetRegistry::instance()->
+                                createSearchWidget( widgetType, mLayer, fldIdx, widgetConfig, mFilterContainer );
 
-  replaceSearchWidget(mFilterQuery, mCurrentSearchWidgetWrapper->widget());
+  replaceSearchWidget( mFilterQuery, mCurrentSearchWidgetWrapper->widget() );
 
   mApplyFilterButton->setVisible( true );
 }
@@ -723,7 +725,7 @@ void QgsAttributeTableDialog::filterQueryChanged( const QString& query )
     QString nullValue = settings.value( "qgis/nullValue", "NULL" ).toString();
     QString value = mCurrentSearchWidgetWrapper->value().toString();
 
-    if (  value == nullValue )
+    if ( value == nullValue )
     {
       str = QString( "%1 IS NULL" ).arg( QgsExpression::quotedColumnRef( fieldName ) );
     }
@@ -745,9 +747,9 @@ void QgsAttributeTableDialog::filterQueryChanged( const QString& query )
 
 void QgsAttributeTableDialog::filterQueryAccepted()
 {
-  if ( (mFilterQuery->isVisible() && mFilterQuery->text().isEmpty()) ||
-          (mCurrentSearchWidgetWrapper!=0 && mCurrentSearchWidgetWrapper->widget()->isVisible()
-           && mCurrentSearchWidgetWrapper->value().toString().isEmpty() ))
+  if (( mFilterQuery->isVisible() && mFilterQuery->text().isEmpty() ) ||
+      ( mCurrentSearchWidgetWrapper != 0 && mCurrentSearchWidgetWrapper->widget()->isVisible()
+        && mCurrentSearchWidgetWrapper->value().toString().isEmpty() ) )
   {
     filterShowAll();
     return;
@@ -763,9 +765,9 @@ void QgsAttributeTableDialog::setFilterExpression( QString filterString )
   mCbxCaseSensitive->setVisible( false );
 
   mFilterQuery->setVisible( true );
-  if ( mCurrentSearchWidgetWrapper != 0 ) 
+  if ( mCurrentSearchWidgetWrapper != 0 )
   {
-      replaceSearchWidget(mCurrentSearchWidgetWrapper->widget(),mFilterQuery);
+    replaceSearchWidget( mCurrentSearchWidgetWrapper->widget(), mFilterQuery );
   }
   mApplyFilterButton->setVisible( true );
   mMainView->setFilterMode( QgsAttributeTableFilterModel::ShowFilteredList );

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -1656,8 +1656,31 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
      * @see updatedFields()
      */
     void attributeDeleted( int idx );
+    /**
+     * Emitted when a new feature has been added to the layer
+     *
+     * @param fid The id of the new feature
+     */
     void featureAdded( QgsFeatureId fid );
+    /**
+     * Emitted when a feature has been deleted.
+     *
+     * If you do expensive operations in a slot connected to this, you should prever to use
+     * {@link featuresDeleted(QgsFeatureIds)}.
+     *
+     * @param fid The id of the feature which has been deleted
+     */
     void featureDeleted( QgsFeatureId fid );
+    /**
+     * Emitted when features have been deleted.
+     *
+     * If features are deleted within an edit command, this will only be emitted once at the end
+     * to allow connected slots to minimize the overhead.
+     * If features are delted outside of an edit command, this signal will be emitted once per feature.
+     *
+     * @param fids The feature ids that have been deleted.
+     */
+    void featuresDeleted( QgsFeatureIds fids );
     /**
      * Is emitted, whenever the fields available from this layer have been changed.
      * This can be due to manually adding attributes or due to a join.
@@ -1734,6 +1757,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
   private slots:
     void onRelationsLoaded();
     void onJoinedFieldsChanged();
+    void onFeatureDeleted( const QgsFeatureId& fid );
 
   protected:
     /** Set the extent */
@@ -1895,6 +1919,11 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
 
     // Feature counts for each renderer symbol
     QMap<QgsSymbolV2*, long> mSymbolFeatureCountMap;
+
+    //! True while an undo command is active
+    bool mEditCommandActive;
+
+    QgsFeatureIds mDeletedFids;
 
     friend class QgsVectorLayerFeatureSource;
 };

--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -53,7 +53,7 @@ QgsAttributeTableModel::QgsAttributeTableModel( QgsVectorLayerCache *layerCache,
   loadAttributes();
 
   connect( mLayerCache, SIGNAL( attributeValueChanged( QgsFeatureId, int, const QVariant& ) ), this, SLOT( attributeValueChanged( QgsFeatureId, int, const QVariant& ) ) );
-  connect( layer(), SIGNAL( featureDeleted( QgsFeatureId ) ), this, SLOT( featureDeleted( QgsFeatureId ) ) );
+  connect( layer(), SIGNAL( featuresDeleted( QgsFeatureIds ) ), this, SLOT( featuresDeleted( QgsFeatureIds ) ) );
   connect( layer(), SIGNAL( attributeDeleted( int ) ), this, SLOT( attributeDeleted( int ) ) );
   connect( layer(), SIGNAL( updatedFields() ), this, SLOT( updatedFields() ) );
   connect( layer(), SIGNAL( editCommandEnded() ), this, SLOT( editCommandEnded() ) );
@@ -73,29 +73,74 @@ bool QgsAttributeTableModel::loadFeatureAtId( QgsFeatureId fid ) const
   return mLayerCache->featureAtId( fid, mFeat );
 }
 
-void QgsAttributeTableModel::featureDeleted( QgsFeatureId fid )
+void QgsAttributeTableModel::featuresDeleted( QgsFeatureIds fids )
 {
-  QgsDebugMsgLevel( QString( "(%2) fid: %1" ).arg( fid ).arg( mFeatureRequest.filterType() ), 4 );
-  mFieldCache.remove( fid );
+  QList<int> rows;
 
-  int row = idToRow( fid );
-
-  if ( row != -1 )
+  Q_FOREACH ( const QgsFeatureId& fid, fids )
   {
-    beginRemoveRows( QModelIndex(), row, row );
-    removeRow( row );
-    endRemoveRows();
+    QgsDebugMsgLevel( QString( "(%2) fid: %1" ).arg( fid ).arg( mFeatureRequest.filterType() ), 4 );
+
+    int row = idToRow( fid );
+    if ( row != -1 )
+      rows << row;
   }
+
+  qSort( rows );
+
+  int lastRow = -1;
+  int beginRow = -1;
+  int currentRowCount = 0;
+  int removedRows = 0;
+  bool reset = false;
+
+  Q_FOREACH ( int row, rows )
+  {
+#if 0
+    qDebug() << "Row: " << row << ", begin " << beginRow << ", last " << lastRow << ", current " << currentRowCount << ", removed " << removedRows;
+#endif
+    if ( lastRow == -1 )
+    {
+      beginRow = row;
+    }
+
+    if ( row != lastRow + 1 && lastRow != -1 )
+    {
+      if ( rows.count() > 100 && currentRowCount < 10 )
+      {
+        reset = true;
+        break;
+      }
+      removeRows( beginRow - removedRows, currentRowCount );
+
+      beginRow = row;
+      removedRows += currentRowCount;
+      currentRowCount = 0;
+    }
+
+    currentRowCount++;
+
+    lastRow = row;
+  }
+
+  if ( !reset )
+    removeRows( beginRow - removedRows, currentRowCount );
+  else
+    resetModel();
 }
 
 bool QgsAttributeTableModel::removeRows( int row, int count, const QModelIndex &parent )
 {
-  Q_UNUSED( parent );
-  QgsDebugMsgLevel( QString( "remove %2 rows at %1 (rows %3, ids %4)" ).arg( row ).arg( count ).arg( mRowIdMap.size() ).arg( mIdRowMap.size() ), 3 );
+  beginRemoveRows( parent, row, row + count );
+#ifdef QGISDEBUG
+  if ( 3 > QgsLogger::debugLevel() )
+    QgsDebugMsgLevel( QString( "remove %2 rows at %1 (rows %3, ids %4)" ).arg( row ).arg( count ).arg( mRowIdMap.size() ).arg( mIdRowMap.size() ), 3 );
+#endif
 
   // clean old references
   for ( int i = row; i < row + count; i++ )
   {
+    mFieldCache.remove( mRowIdMap[i] );
     mIdRowMap.remove( mRowIdMap[ i ] );
     mRowIdMap.remove( i );
   }
@@ -111,19 +156,24 @@ bool QgsAttributeTableModel::removeRows( int row, int count, const QModelIndex &
   }
 
 #ifdef QGISDEBUG
-  QgsDebugMsgLevel( QString( "after removal rows %1, ids %2" ).arg( mRowIdMap.size() ).arg( mIdRowMap.size() ), 4 );
-  QgsDebugMsgLevel( "id->row", 4 );
-  for ( QHash<QgsFeatureId, int>::iterator it = mIdRowMap.begin(); it != mIdRowMap.end(); ++it )
-    QgsDebugMsgLevel( QString( "%1->%2" ).arg( FID_TO_STRING( it.key() ) ).arg( *it ), 4 );
+  if ( 4 > QgsLogger::debugLevel() )
+  {
+    QgsDebugMsgLevel( QString( "after removal rows %1, ids %2" ).arg( mRowIdMap.size() ).arg( mIdRowMap.size() ), 4 );
+    QgsDebugMsgLevel( "id->row", 4 );
+    for ( QHash<QgsFeatureId, int>::iterator it = mIdRowMap.begin(); it != mIdRowMap.end(); ++it )
+      QgsDebugMsgLevel( QString( "%1->%2" ).arg( FID_TO_STRING( it.key() ) ).arg( *it ), 4 );
 
-  QHash<QgsFeatureId, int>::iterator idit;
+    QHash<QgsFeatureId, int>::iterator idit;
 
-  QgsDebugMsgLevel( "row->id", 4 );
-  for ( QHash<int, QgsFeatureId>::iterator it = mRowIdMap.begin(); it != mRowIdMap.end(); ++it )
-    QgsDebugMsgLevel( QString( "%1->%2" ).arg( it.key() ).arg( FID_TO_STRING( *it ) ), 4 );
+    QgsDebugMsgLevel( "row->id", 4 );
+    for ( QHash<int, QgsFeatureId>::iterator it = mRowIdMap.begin(); it != mRowIdMap.end(); ++it )
+      QgsDebugMsgLevel( QString( "%1->%2" ).arg( it.key() ).arg( FID_TO_STRING( *it ) ), 4 );
+  }
 #endif
 
   Q_ASSERT( mRowIdMap.size() == mIdRowMap.size() );
+
+  endRemoveRows();
 
   return true;
 }
@@ -179,9 +229,7 @@ void QgsAttributeTableModel::layerDeleted()
 {
   QgsDebugMsg( "entered." );
 
-  beginRemoveRows( QModelIndex(), 0, rowCount() - 1 );
   removeRows( 0, rowCount() );
-  endRemoveRows();
 
   mAttributeWidgetCaches.clear();
   mAttributes.clear();
@@ -223,7 +271,7 @@ void QgsAttributeTableModel::attributeValueChanged( QgsFeatureId fid, int idx, c
         if ( mIdRowMap.contains( fid ) )
         {
           // Feature changed such, that it is no longer shown
-          featureDeleted( fid );
+          featuresDeleted( QgsFeatureIds() << fid );
         }
         // else: we don't care
       }
@@ -291,9 +339,7 @@ void QgsAttributeTableModel::loadLayer()
 
   if ( rowCount() != 0 )
   {
-    beginRemoveRows( QModelIndex(), 0, rowCount() - 1 );
     removeRows( 0, rowCount() );
-    endRemoveRows();
   }
 
   QgsFeatureIterator features = mLayerCache->getFeatures( mFeatureRequest );
@@ -575,6 +621,7 @@ void QgsAttributeTableModel::reload( const QModelIndex &index1, const QModelInde
 void QgsAttributeTableModel::resetModel()
 {
   beginResetModel();
+  loadLayer();
   endResetModel();
 }
 

--- a/src/gui/attributetable/qgsattributetablemodel.h
+++ b/src/gui/attributetable/qgsattributetablemodel.h
@@ -261,10 +261,10 @@ class GUI_EXPORT QgsAttributeTableModel: public QAbstractTableModel
      */
     virtual void attributeValueChanged( QgsFeatureId fid, int idx, const QVariant &value );
     /**
-     * Launched when a feature has been deleted
-     * @param fid feature id
+     * Launched when eatures have been deleted
+     * @param fids feature ids
      */
-    virtual void featureDeleted( QgsFeatureId fid );
+    virtual void featuresDeleted( QgsFeatureIds fid );
     /**
      * Launched when a feature has been added
      * @param fid feature id

--- a/tests/src/python/CMakeLists.txt
+++ b/tests/src/python/CMakeLists.txt
@@ -45,6 +45,7 @@ ADD_PYTHON_TEST(PyQgsGraduatedSymbolRendererV2 test_qgsgraduatedsymbolrendererv2
 ADD_PYTHON_TEST(PyQgsNetworkContentFetcher test_qgsnetworkcontentfetcher.py)
 ADD_PYTHON_TEST(PyQgsEditWidgets test_qgseditwidgets.py)
 ADD_PYTHON_TEST(PyQgsRangeWidgets test_qgsrangewidgets.py)
+ADD_PYTHON_TEST(PyQgsAttributeTableModel test_qgsattributetablemodel.py)
 IF (ENABLE_PGTEST)
   ADD_PYTHON_TEST(PyQgsPostgresProvider test_provider_postgres.py)
 ENDIF (ENABLE_PGTEST)

--- a/tests/src/python/test_qgsattributetablemodel.py
+++ b/tests/src/python/test_qgsattributetablemodel.py
@@ -1,0 +1,88 @@
+# -*- coding: utf-8 -*-
+"""QGIS Unit tests for the attribute table model.
+
+.. note:: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+"""
+__author__ = 'Matthias Kuhn'
+__date__ = '27/05/2015'
+__copyright__ = 'Copyright 2015, The QGIS Project'
+# This will get replaced with a git SHA1 when you do a git archive
+__revision__ = '$Format:%H$'
+
+from qgis.gui import QgsAttributeTableModel, QgsEditorWidgetRegistry
+from qgis.core import QgsFeature, QgsGeometry, QgsPoint, QgsVectorLayer, QgsVectorLayerCache, NULL
+
+from utilities import (unitTestDataPath,
+                       getQgisTestApp,
+                       TestCase,
+                       unittest
+                       )
+QGISAPP, CANVAS, IFACE, PARENT = getQgisTestApp()
+
+
+class TestQgsAttributeTableModel(TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        QgsEditorWidgetRegistry.initEditors()
+
+    def setUp(self):
+        self.layer = self.createLayer()
+        self.cache = QgsVectorLayerCache(self.layer, 100)
+        self.am = QgsAttributeTableModel(self.cache)
+        self.am.loadLayer()
+        self.am.loadAttributes()
+
+    def tearDown(self):
+        del self.am
+        del self.cache
+        del self.layer
+
+    def createLayer(self):
+        layer = QgsVectorLayer("Point?field=fldtxt:string&field=fldint:integer",
+                               "addfeat", "memory")
+        pr = layer.dataProvider()
+        features = list()
+        for i in range(10):
+            f = QgsFeature()
+            f.setAttributes(["test", i])
+            f.setGeometry(QgsGeometry.fromPoint(QgsPoint(100,200)))
+            features.append(f)
+
+        assert pr.addFeatures(features)
+        return layer
+
+    def testLoad(self):
+        assert self.am.rowCount() == 10, self.am.rowCount()
+        assert self.am.columnCount() == 2, self.am.columnCount()
+
+    def testRemove(self):
+        self.layer.startEditing()
+        self.layer.deleteFeature(5)
+        assert self.am.rowCount() == 9, self.am.rowCount()
+        self.layer.setSelectedFeatures([1,3,6,7])
+        self.layer.deleteSelectedFeatures()
+        assert self.am.rowCount() == 5, self.am.rowCount()
+
+    def testAdd(self):
+        self.layer.startEditing()
+
+        f = QgsFeature()
+        f.setAttributes(["test", 8])
+        f.setGeometry(QgsGeometry.fromPoint(QgsPoint(100,200)))
+        self.layer.addFeature(f)
+
+        assert self.am.rowCount() == 11, self.am.rowCount()
+
+    def testRemoveColumns(self):
+        self.layer.startEditing()
+
+        self.layer.deleteAttribute(1)
+
+        assert self.am.columnCount() == 1, self.am.columnCount()
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
This fixes performance issues with the attribute table visible when deleting a
large number of features.

The attribute table tries to behave smart in the following way:
- It tries to remove only the deleted rows as long as they are in one or a few
  single blocks
- If there are more than 100 rows to delete and it starts to delete blocks
  of a size smaller than 10 it assumes that the selection to delete is widely
  distributed and that a reload of the whole model is less expensive than a
  differential update.

Fix #10167
