### PR TITLE
Fix 'Allow to' typo.

### DIFF
--- a/i18n/qgis_ar.ts
+++ b/i18n/qgis_ar.ts
@@ -20192,7 +20192,7 @@ Please try a lower resolution or a smaller papersize</source>
         <translation>أعمدة متساوية العرض</translation>
     </message>
     <message>
-        <source>Allow to split layer items into multiple columns.</source>
+        <source>Allow splitting layer items into multiple columns.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/qgis_bs.ts
+++ b/i18n/qgis_bs.ts
@@ -20225,7 +20225,7 @@ Pokušajte sa nižom rezolucijom ili manjom veličinom papira</translation>
         <translation>Jednaka širina kolona</translation>
     </message>
     <message>
-        <source>Allow to split layer items into multiple columns.</source>
+        <source>Allow splitting layer items into multiple columns.</source>
         <translation>Dozvoli dijeljenje stavki sloja u više kolona.</translation>
     </message>
     <message>

--- a/i18n/qgis_ca.ts
+++ b/i18n/qgis_ca.ts
@@ -20144,7 +20144,7 @@ Please try a lower resolution or a smaller papersize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Allow to split layer items into multiple columns.</source>
+        <source>Allow splitting layer items into multiple columns.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/qgis_cs.ts
+++ b/i18n/qgis_cs.ts
@@ -20253,7 +20253,7 @@ Please try a lower resolution or a smaller papersize</source>
         <translation>Stejné šířky sloupců</translation>
     </message>
     <message>
-        <source>Allow to split layer items into multiple columns.</source>
+        <source>Allow splitting layer items into multiple columns.</source>
         <translation>Umožňuje rozdělit položky vrstvy do více sloupců.</translation>
     </message>
     <message>

--- a/i18n/qgis_da.ts
+++ b/i18n/qgis_da.ts
@@ -20255,7 +20255,7 @@ Prøv en lavere opløsning eller en mindre papirstørrelse</translation>
         <translation>Ens kolonnebredder</translation>
     </message>
     <message>
-        <source>Allow to split layer items into multiple columns.</source>
+        <source>Allow splitting layer items into multiple columns.</source>
         <translation>Tillad at opdele lagelementer til flere kolonner.</translation>
     </message>
     <message>

--- a/i18n/qgis_de.ts
+++ b/i18n/qgis_de.ts
@@ -20266,7 +20266,7 @@ Bitte versuchen Sie eine niedrigere Auflösung oder ein kleineres Papierformat</
         <translation>Gleiche Spaltenbreite</translation>
     </message>
     <message>
-        <source>Allow to split layer items into multiple columns.</source>
+        <source>Allow splitting layer items into multiple columns.</source>
         <translation>Aufteilung der Layerelemente in mehrere Spalten erlauben.</translation>
     </message>
     <message>

--- a/i18n/qgis_el.ts
+++ b/i18n/qgis_el.ts
@@ -20113,7 +20113,7 @@ Please try a lower resolution or a smaller papersize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Allow to split layer items into multiple columns.</source>
+        <source>Allow splitting layer items into multiple columns.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/qgis_en.ts
+++ b/i18n/qgis_en.ts
@@ -20284,8 +20284,8 @@ Please try a lower resolution or a smaller papersize</translation>
         <translation>Equal column widths</translation>
     </message>
     <message>
-        <source>Allow to split layer items into multiple columns.</source>
-        <translation>Allow to split layer items into multiple columns.</translation>
+        <source>Allow splitting layer items into multiple columns.</source>
+        <translation>Allow splitting layer items into multiple columns.</translation>
     </message>
     <message>
         <source>Split layers</source>

--- a/i18n/qgis_es.ts
+++ b/i18n/qgis_es.ts
@@ -20278,7 +20278,7 @@ Por favor, pruebe una resolución menor o un tamaño de papel más pequeño.</tr
         <translation>Anchura de columnas igual</translation>
     </message>
     <message>
-        <source>Allow to split layer items into multiple columns.</source>
+        <source>Allow splitting layer items into multiple columns.</source>
         <translation>Permitir dividir los elementos de las capas en múltiples columnas.</translation>
     </message>
     <message>

--- a/i18n/qgis_et.ts
+++ b/i18n/qgis_et.ts
@@ -20170,7 +20170,7 @@ Please try a lower resolution or a smaller papersize</source>
         <translation>Võrdsusta veeru laiused</translation>
     </message>
     <message>
-        <source>Allow to split layer items into multiple columns.</source>
+        <source>Allow splitting layer items into multiple columns.</source>
         <translation>Luba kihi elemente mitmeks veeruks tükeldada</translation>
     </message>
     <message>

--- a/i18n/qgis_eu.ts
+++ b/i18n/qgis_eu.ts
@@ -20253,7 +20253,7 @@ Saiatu bereizmen txikiagoarekin edo paper-tamaina txikiagoarekin</translation>
         <translation>Zabalera bereko zutabeak</translation>
     </message>
     <message>
-        <source>Allow to split layer items into multiple columns.</source>
+        <source>Allow splitting layer items into multiple columns.</source>
         <translation>Onartu geruza-elementuak zutabe anitzetan zatitzea.</translation>
     </message>
     <message>

--- a/i18n/qgis_fa.ts
+++ b/i18n/qgis_fa.ts
@@ -20134,7 +20134,7 @@ Please try a lower resolution or a smaller papersize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Allow to split layer items into multiple columns.</source>
+        <source>Allow splitting layer items into multiple columns.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/qgis_fi.ts
+++ b/i18n/qgis_fi.ts
@@ -20276,7 +20276,7 @@ Ole ystävällinen ja yritä pienemmällä resoluutiolla tai pienemmällä paper
         <translation>Tasalevyiset sarakkeet</translation>
     </message>
     <message>
-        <source>Allow to split layer items into multiple columns.</source>
+        <source>Allow splitting layer items into multiple columns.</source>
         <translation>Salli tason jäsenten jako useammalle sarakkeelle.</translation>
     </message>
     <message>

--- a/i18n/qgis_fr.ts
+++ b/i18n/qgis_fr.ts
@@ -20403,7 +20403,7 @@ Essayez une résolution ou une taille de papier inférieur.</translation>
         <translation>Égaliser la largeur des colonnes</translation>
     </message>
     <message>
-        <source>Allow to split layer items into multiple columns.</source>
+        <source>Allow splitting layer items into multiple columns.</source>
         <translation>Permet de répartir les couches dans plusieurs colonnes.</translation>
     </message>
     <message>

--- a/i18n/qgis_gl.ts
+++ b/i18n/qgis_gl.ts
@@ -20277,7 +20277,7 @@ Ténteo cunha resolución baixa ou cun tamaño de papel menor</translation>
         <translation>Anchos de columna iguais</translation>
     </message>
     <message>
-        <source>Allow to split layer items into multiple columns.</source>
+        <source>Allow splitting layer items into multiple columns.</source>
         <translation>Permiti-la división de elementos do mapa en múltiples columnas.</translation>
     </message>
     <message>

--- a/i18n/qgis_hi.ts
+++ b/i18n/qgis_hi.ts
@@ -20231,7 +20231,7 @@ Please try a lower resolution or a smaller papersize</source>
         <translation>बराबर कॉलम चौडाई </translation>
     </message>
     <message>
-        <source>Allow to split layer items into multiple columns.</source>
+        <source>Allow splitting layer items into multiple columns.</source>
         <translation>लेयर वस्‍तुओं को बहु कॉलमों में विभाजित करने की अनुमति दें </translation>
     </message>
     <message>

--- a/i18n/qgis_hr.ts
+++ b/i18n/qgis_hr.ts
@@ -20167,7 +20167,7 @@ Pokušajte s nižom rezolucijom ili manjom veličinom papira</translation>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Allow to split layer items into multiple columns.</source>
+        <source>Allow splitting layer items into multiple columns.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/qgis_hu.ts
+++ b/i18n/qgis_hu.ts
@@ -20236,7 +20236,7 @@ Próbálj kisebb felbontást vagy kisebb papírméretet használni</translation>
         <translation>Egyforma oszlop szélességek</translation>
     </message>
     <message>
-        <source>Allow to split layer items into multiple columns.</source>
+        <source>Allow splitting layer items into multiple columns.</source>
         <translation>Lehetővé teszi a réteg elemek több oszlopba rendezését.</translation>
     </message>
     <message>

--- a/i18n/qgis_id.ts
+++ b/i18n/qgis_id.ts
@@ -20223,7 +20223,7 @@ Silahkan coba turunkan resolusi atau gunakan ukuran kertas yang lebih kecil</tra
         <translation>Kolom lebar sama</translation>
     </message>
     <message>
-        <source>Allow to split layer items into multiple columns.</source>
+        <source>Allow splitting layer items into multiple columns.</source>
         <translation>Izinkan pemisahan layer menjadi beberapa kolom.</translation>
     </message>
     <message>

--- a/i18n/qgis_is.ts
+++ b/i18n/qgis_is.ts
@@ -20122,7 +20122,7 @@ Please try a lower resolution or a smaller papersize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Allow to split layer items into multiple columns.</source>
+        <source>Allow splitting layer items into multiple columns.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/qgis_it.ts
+++ b/i18n/qgis_it.ts
@@ -20270,7 +20270,7 @@ Prova una risoluzione minore o una minor dimensione di stampa</translation>
         <translation>Uguale larghezza delle colonne</translation>
     </message>
     <message>
-        <source>Allow to split layer items into multiple columns.</source>
+        <source>Allow splitting layer items into multiple columns.</source>
         <translation>Consenti di dividere gli oggetti del layer in colonne multiple.</translation>
     </message>
     <message>

--- a/i18n/qgis_ja.ts
+++ b/i18n/qgis_ja.ts
@@ -20259,7 +20259,7 @@ Please try a lower resolution or a smaller papersize</source>
         <translation>列を等幅で作成</translation>
     </message>
     <message>
-        <source>Allow to split layer items into multiple columns.</source>
+        <source>Allow splitting layer items into multiple columns.</source>
         <translation>レイヤの複数列に分割を許可する.</translation>
     </message>
     <message>

--- a/i18n/qgis_km.ts
+++ b/i18n/qgis_km.ts
@@ -20252,7 +20252,7 @@ Please try a lower resolution or a smaller papersize</source>
         <translation>ទទឹង​ជួរឈរ​ស្មើ</translation>
     </message>
     <message>
-        <source>Allow to split layer items into multiple columns.</source>
+        <source>Allow splitting layer items into multiple columns.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/qgis_ko.ts
+++ b/i18n/qgis_ko.ts
@@ -20241,7 +20241,7 @@ Please try a lower resolution or a smaller papersize</source>
         <translation>컬럼 폭이 동일</translation>
     </message>
     <message>
-        <source>Allow to split layer items into multiple columns.</source>
+        <source>Allow splitting layer items into multiple columns.</source>
         <translation>다중 컬럼안에 레이어 항목의 분리를 허용합니다.</translation>
     </message>
     <message>

--- a/i18n/qgis_lt.ts
+++ b/i18n/qgis_lt.ts
@@ -20272,7 +20272,7 @@ Prašome pabandyti mažesnę raišką arba mažesnį lapą</translation>
         <translation>Vienodas stulpelių plotis</translation>
     </message>
     <message>
-        <source>Allow to split layer items into multiple columns.</source>
+        <source>Allow splitting layer items into multiple columns.</source>
         <translation>Leisti dalinti sluoksnio elementus į skirtingus stulpelius.</translation>
     </message>
     <message>

--- a/i18n/qgis_lv.ts
+++ b/i18n/qgis_lv.ts
@@ -20166,7 +20166,7 @@ Please try a lower resolution or a smaller papersize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Allow to split layer items into multiple columns.</source>
+        <source>Allow splitting layer items into multiple columns.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/qgis_mn.ts
+++ b/i18n/qgis_mn.ts
@@ -20101,7 +20101,7 @@ Please try a lower resolution or a smaller papersize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Allow to split layer items into multiple columns.</source>
+        <source>Allow splitting layer items into multiple columns.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/qgis_nb.ts
+++ b/i18n/qgis_nb.ts
@@ -20281,7 +20281,7 @@ Vennligst prøv en lavere oppløsning eller et mindre papirformat</translation>
         <translation>Samme kolonnebredde</translation>
     </message>
     <message>
-        <source>Allow to split layer items into multiple columns.</source>
+        <source>Allow splitting layer items into multiple columns.</source>
         <translation>Tillat oppdeling av lagelementer til flere kolonner.</translation>
     </message>
     <message>

--- a/i18n/qgis_nl.ts
+++ b/i18n/qgis_nl.ts
@@ -20283,7 +20283,7 @@ Probeer alstublieft een lagere resolutie of een kleiner papiergrootte</translati
         <translation>Gelijke kolombreedtes</translation>
     </message>
     <message>
-        <source>Allow to split layer items into multiple columns.</source>
+        <source>Allow splitting layer items into multiple columns.</source>
         <translation>Splitsen van klasses van een kaartlaag over meerdere kolommen toestaan.</translation>
     </message>
     <message>

--- a/i18n/qgis_pl.ts
+++ b/i18n/qgis_pl.ts
@@ -20286,7 +20286,7 @@ Zmniejsz rozdzielczość lub rozmiar papieru.</translation>
         <translation>Równa szerokość kolumn</translation>
     </message>
     <message>
-        <source>Allow to split layer items into multiple columns.</source>
+        <source>Allow splitting layer items into multiple columns.</source>
         <translation>Klasy warstwy w różnych kolumnach.</translation>
     </message>
     <message>

--- a/i18n/qgis_pt_BR.ts
+++ b/i18n/qgis_pt_BR.ts
@@ -20270,7 +20270,7 @@ Tente uma resolução ou um tamanho de papel menor</translation>
         <translation>Larguras de colunas iguais</translation>
     </message>
     <message>
-        <source>Allow to split layer items into multiple columns.</source>
+        <source>Allow splitting layer items into multiple columns.</source>
         <translation>Permite dividir itens da camada em múltiplas colunas.</translation>
     </message>
     <message>

--- a/i18n/qgis_pt_PT.ts
+++ b/i18n/qgis_pt_PT.ts
@@ -20268,7 +20268,7 @@ Por favor, tente uma resolução mais baixa ou um tamanho de papel mais pequeno<
         <translation>Igual largura de colunas</translation>
     </message>
     <message>
-        <source>Allow to split layer items into multiple columns.</source>
+        <source>Allow splitting layer items into multiple columns.</source>
         <translation>Permite dividir os itens de camada em múltiplas colunas.</translation>
     </message>
     <message>

--- a/i18n/qgis_ro.ts
+++ b/i18n/qgis_ro.ts
@@ -20291,7 +20291,7 @@ Vă rog să încercați cu o rezoluție minimă sau mai mică a hârtiei</transl
         <translation>Coloane cu lățimi identice</translation>
     </message>
     <message>
-        <source>Allow to split layer items into multiple columns.</source>
+        <source>Allow splitting layer items into multiple columns.</source>
         <translation>Se permite divizarea elementelor dintr-un strat în coloane multiple.</translation>
     </message>
     <message>

--- a/i18n/qgis_ru.ts
+++ b/i18n/qgis_ru.ts
@@ -20255,7 +20255,7 @@ Please try a lower resolution or a smaller papersize</source>
         <translation>Одинаковая ширина</translation>
     </message>
     <message>
-        <source>Allow to split layer items into multiple columns.</source>
+        <source>Allow splitting layer items into multiple columns.</source>
         <translation>Разрешить перенос элементов слоя в следующую колонку.</translation>
     </message>
     <message>

--- a/i18n/qgis_sk.ts
+++ b/i18n/qgis_sk.ts
@@ -20133,7 +20133,7 @@ Skúste prosím nižšie rozlíšenie alebo menšiu veľkosť papiera</translati
         <translation>Rovnaké šírky stĺpca</translation>
     </message>
     <message>
-        <source>Allow to split layer items into multiple columns.</source>
+        <source>Allow splitting layer items into multiple columns.</source>
         <translation>Rozdeliť položky vrstvy do viacerých stĺpcov.</translation>
     </message>
     <message>

--- a/i18n/qgis_sl.ts
+++ b/i18n/qgis_sl.ts
@@ -20209,7 +20209,7 @@ Prosim zmanjšate ločljivost ali velikost slike</translation>
         <translation>Enaka širina stolpcev</translation>
     </message>
     <message>
-        <source>Allow to split layer items into multiple columns.</source>
+        <source>Allow splitting layer items into multiple columns.</source>
         <translation>Dovoli razdelitev postavk na več stolpcev.</translation>
     </message>
     <message>

--- a/i18n/qgis_sr.ts
+++ b/i18n/qgis_sr.ts
@@ -20130,7 +20130,7 @@ Please try a lower resolution or a smaller papersize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Allow to split layer items into multiple columns.</source>
+        <source>Allow splitting layer items into multiple columns.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/qgis_sr@latin.ts
+++ b/i18n/qgis_sr@latin.ts
@@ -20129,7 +20129,7 @@ Please try a lower resolution or a smaller papersize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Allow to split layer items into multiple columns.</source>
+        <source>Allow splitting layer items into multiple columns.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/qgis_sv.ts
+++ b/i18n/qgis_sv.ts
@@ -20273,7 +20273,7 @@ Var vänlig försök med en lägre upplösning eller mindre pappersstorlek</tran
         <translation>Samma kolumnbredd</translation>
     </message>
     <message>
-        <source>Allow to split layer items into multiple columns.</source>
+        <source>Allow splitting layer items into multiple columns.</source>
         <translation>Tillåt lager att delas på flera kolumner.</translation>
     </message>
     <message>

--- a/i18n/qgis_th.ts
+++ b/i18n/qgis_th.ts
@@ -20099,7 +20099,7 @@ Please try a lower resolution or a smaller papersize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Allow to split layer items into multiple columns.</source>
+        <source>Allow splitting layer items into multiple columns.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/qgis_tr.ts
+++ b/i18n/qgis_tr.ts
@@ -20115,7 +20115,7 @@ Please try a lower resolution or a smaller papersize</source>
         <translation>Eşit sütun genişlikleri</translation>
     </message>
     <message>
-        <source>Allow to split layer items into multiple columns.</source>
+        <source>Allow splitting layer items into multiple columns.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/qgis_uk.ts
+++ b/i18n/qgis_uk.ts
@@ -20122,7 +20122,7 @@ Please try a lower resolution or a smaller papersize</source>
         <translation type="unfinished"></translation>
     </message>
     <message>
-        <source>Allow to split layer items into multiple columns.</source>
+        <source>Allow splitting layer items into multiple columns.</source>
         <translation type="unfinished"></translation>
     </message>
     <message>

--- a/i18n/qgis_vi.ts
+++ b/i18n/qgis_vi.ts
@@ -20227,7 +20227,7 @@ Vui lòng thử độ phân giải thấp hơn hoặc kích thước giấy nh�
         <translation>Chiều rộng cột bằng nhau</translation>
     </message>
     <message>
-        <source>Allow to split layer items into multiple columns.</source>
+        <source>Allow splitting layer items into multiple columns.</source>
         <translation>Cho phép ngắt các mục của lớp ra thành nhiều cột.</translation>
     </message>
     <message>

--- a/i18n/qgis_zh-Hans.ts
+++ b/i18n/qgis_zh-Hans.ts
@@ -20254,7 +20254,7 @@ Please try a lower resolution or a smaller papersize</source>
         <translation>列宽相等</translation>
     </message>
     <message>
-        <source>Allow to split layer items into multiple columns.</source>
+        <source>Allow splitting layer items into multiple columns.</source>
         <translation>允许将图层条目分割到多个列。</translation>
     </message>
     <message>

--- a/i18n/qgis_zh_CN.ts
+++ b/i18n/qgis_zh_CN.ts
@@ -20242,7 +20242,7 @@ Please try a lower resolution or a smaller papersize</source>
         <translation>列宽相等</translation>
     </message>
     <message>
-        <source>Allow to split layer items into multiple columns.</source>
+        <source>Allow splitting layer items into multiple columns.</source>
         <translation>允许将图层条目分割到多个列。</translation>
     </message>
     <message>

--- a/i18n/qgis_zh_TW.ts
+++ b/i18n/qgis_zh_TW.ts
@@ -20234,7 +20234,7 @@ Please try a lower resolution or a smaller papersize</source>
         <translation>等於行寬</translation>
     </message>
     <message>
-        <source>Allow to split layer items into multiple columns.</source>
+        <source>Allow splitting layer items into multiple columns.</source>
         <translation>允許分割圖層項目至多行中。</translation>
     </message>
     <message>

--- a/src/ui/qgscomposerlegendwidgetbase.ui
+++ b/src/ui/qgscomposerlegendwidgetbase.ui
@@ -544,7 +544,7 @@
           <item row="4" column="0" colspan="2">
            <widget class="QCheckBox" name="mSplitLayerCheckBox">
             <property name="toolTip">
-             <string>Allow to split layer items into multiple columns.</string>
+             <string>Allow splitting layer items into multiple columns.</string>
             </property>
             <property name="text">
              <string>Split layers</string>


### PR DESCRIPTION
This issue was reported by the lintian QA tool during the Debian package build.

It's a small variation on the 'Allows to' typo for which `scripts/fix_allows_to.sh` already exists, maybe this fix should be added to the script too?
