### PR TITLE
Add qgis-dbg package to provide debug symbols.

### DIFF
--- a/debian/control.in
+++ b/debian/control.in
@@ -244,6 +244,26 @@ Description: QGIS - development files
  This package contains the headers and libraries needed to develop plugins for
  QGIS.
 
+Package: qgis-dbg
+Architecture: any
+Section: debug
+Priority: extra
+Depends:
+ libqgis-core{QGIS_ABI} (= ${binary:Version}),
+ libqgis-gui{QGIS_ABI} (= ${binary:Version}),
+ libqgis-analysis{QGIS_ABI} (= ${binary:Version}),
+ libqgis-networkanalysis{QGIS_ABI} (= ${binary:Version}),
+ libqgis-server{QGIS_ABI} (= ${binary:Version}),
+ libqgisgrass{QGIS_ABI} (= ${binary:Version}),
+ libqgispython{QGIS_ABI} (= ${binary:Version}),
+ ${misc:Depends}
+Suggests: gdb
+Description: QGIS - debugging symbols
+ QGIS is a Geographic Information System (GIS) which manages, analyzes and
+ display databases of geographic information.
+ .
+ This package contains debugging symbols.
+
 Package: qgis-plugin-grass
 Architecture: any
 Depends:

--- a/debian/rules
+++ b/debian/rules
@@ -274,3 +274,7 @@ override_dh_makeshlibs:
 
 override_dh_shlibdeps:
 	dh_shlibdeps -l/usr/lib/$(GRASS)/lib
+
+override_dh_strip:
+	dh_strip --dbg-package=qgis-dbg
+


### PR DESCRIPTION
The debug package was requested in [Debian Bug #786985](https://bugs.debian.org/786985).
