### PR TITLE
Fix for function editor

### DIFF
--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -131,6 +131,8 @@ void QgsExpressionBuilderWidget::runPythonCode( QString code )
     QgsPythonRunner::run( pythontext );
   }
   updateFunctionTree();
+  loadFieldNames();
+  loadRecent( mRecentKey );
 }
 
 void QgsExpressionBuilderWidget::saveFunctionFile( QString fileName )
@@ -346,6 +348,7 @@ void QgsExpressionBuilderWidget::saveToRecent( QString key )
 
 void QgsExpressionBuilderWidget::loadRecent( QString key )
 {
+  mRecentKey = key;
   QString name = tr( "Recent (%1)" ).arg( key );
   if ( mExpressionGroups.contains( name ) )
   {

--- a/src/gui/qgsexpressionbuilderwidget.h
+++ b/src/gui/qgsexpressionbuilderwidget.h
@@ -218,6 +218,7 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
     QgsExpressionHighlighter* highlighter;
     bool mExpressionValid;
     QgsDistanceArea mDa;
+    QString mRecentKey;
 
 };
 


### PR DESCRIPTION
when running the script the entries "Fields and values" and "Recent"
into the functions list of the expression builder disappear.

/cc @NathanW2 
