### PR TITLE
[GUI] Refresh icons for the layer, browser, and identify panels

### DIFF
--- a/images/images.qrc
+++ b/images/images.qrc
@@ -152,6 +152,7 @@
         <file>themes/default/mActionChangeLabelProperties.png</file>
         <file>themes/default/mActionCheckQgisVersion.png</file>
         <file>themes/default/mActionCollapseTree.png</file>
+        <file>themes/default/mActionCollapseTree.svg</file>
         <file>themes/default/mActionComposerManager.svg</file>
         <file>themes/default/mActionContextHelp.png</file>
         <file>themes/default/mActionCopySelected.png</file>
@@ -172,7 +173,9 @@
         <file>themes/default/mActionEditCut.png</file>
         <file>themes/default/mActionEditPaste.png</file>
         <file>themes/default/mActionExpandNewTree.png</file>
+        <file>themes/default/mActionExpandNewTree.svg</file>
         <file>themes/default/mActionExpandTree.png</file>
+        <file>themes/default/mActionExpandTree.svg</file>
         <file>themes/default/mActionExportMapServer.png</file>
         <file>themes/default/mActionFileExit.png</file>
         <file>themes/default/mActionFileNew.svg</file>
@@ -184,7 +187,9 @@
         <file>themes/default/mActionFillRing.svg</file>
         <file>themes/default/mActionFilter.png</file>
         <file>themes/default/mActionFilter.svg</file>
+        <file>themes/default/mActionFilter2.svg</file>
         <file>themes/default/mActionFolder.png</file>
+        <file>themes/default/mActionFolder.svg</file>
         <file>themes/default/mActionFormAnnotation.png</file>
         <file>themes/default/mActionFromSelectedFeature.png</file>
         <file>themes/default/mActionFullCumulativeCutStretch.png</file>
@@ -195,6 +200,7 @@
         <file>themes/default/mActionHelpContents.svg</file>
         <file>themes/default/mActionHelpSponsors.png</file>
         <file>themes/default/mActionHideAllLayers.png</file>
+        <file>themes/default/mActionHideAllLayers.svg</file>
         <file>themes/default/mActionHideSelectedLayers.png</file>
         <file>themes/default/mActionIdentify.svg</file>
         <file>themes/default/mActionIncreaseBrightness.svg</file>
@@ -233,7 +239,9 @@
         <file>themes/default/mActionPinLabels.svg</file>
         <file>themes/default/mActionProjectProperties.png</file>
         <file>themes/default/mActionPropertiesWidget.png</file>
+        <file>themes/default/mActionPropertiesWidget.svg</file>
         <file>themes/default/mActionPropertyItem.png</file>
+        <file>themes/default/mActionPropertyItem.svg</file>
         <file>themes/default/mActionQgisHomePage.png</file>
         <file>themes/default/mActionRaiseItems.png</file>
         <file>themes/default/mActionRedo.png</file>
@@ -264,6 +272,7 @@
         <file>themes/default/mActionSelectRectangle.svg</file>
         <file>themes/default/mActionSetProjection.svg</file>
         <file>themes/default/mActionShowAllLayers.png</file>
+        <file>themes/default/mActionShowAllLayers.svg</file>
         <file>themes/default/mActionShowBookmarks.png</file>
         <file>themes/default/mActionShowHideLabels.svg</file>
         <file>themes/default/mActionShowPinnedLabels.svg</file>

--- a/images/themes/default/mActionCollapseTree.svg
+++ b/images/themes/default/mActionCollapseTree.svg
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   id="svg5477"
+   viewBox="0 0 6.3499999 6.3500002"
+   height="24"
+   width="24">
+  <defs
+     id="defs5479" />
+  <metadata
+     id="metadata5482">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(0,-290.64998)"
+     id="layer1">
+    <path
+       id="path4488-8-2-9-6"
+       d="m 5.55625,291.31143 -5.29166668,0"
+       style="fill:#888a85;fill-opacity:1;fill-rule:evenodd;stroke:#888a85;stroke-width:0.26458329;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <rect
+       y="294.35416"
+       x="2.0661364"
+       height="1.3229089"
+       width="1.3229116"
+       id="rect4471-25-2-3"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;color-interpolation:sRGB;color-interpolation-filters:linearRGB;fill:#f7941d;fill-opacity:1;fill-rule:evenodd;stroke:#f7941d;stroke-width:0;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:2.20000005;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <rect
+       y="292.10519"
+       x="2.0587449"
+       height="1.3229089"
+       width="1.3229116"
+       id="rect4471-2-7-1-2"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;color-interpolation:sRGB;color-interpolation-filters:linearRGB;fill:#f7941d;fill-opacity:1;fill-rule:evenodd;stroke:#f7941d;stroke-width:0;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:2.20000005;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       id="path4488-8-2-9"
+       d="m 1.1906249,291.44372 0,3.70417"
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#b2b2b2;stroke-width:0.26458329;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path4490-0-9-3"
+       d="m 1.0583333,292.76665 0.79375,0"
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#b2b2b2;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path4490-8-8-2-9"
+       d="m 1.0583333,295.01561 0.79375,0"
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#b2b2b2;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="display:inline;fill:#6d97c4;fill-opacity:1;fill-rule:evenodd;stroke:#415a75;stroke-width:0.26459044;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+       d="m 4.7625006,290.78227 1.4552229,1.65917 -0.9701491,0 -1.8e-6,2.83874 -0.970148,0 0,-2.83874 -0.970148,0 z"
+       id="path2848-7-3-9" />
+  </g>
+</svg>

--- a/images/themes/default/mActionExpandNewTree.svg
+++ b/images/themes/default/mActionExpandNewTree.svg
@@ -1,0 +1,393 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg2"
+   height="24"
+   width="24">
+  <metadata
+     id="metadata122">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Mouse Pointer</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <title
+     id="title4">Mouse Pointer</title>
+  <defs
+     id="defs12">
+    <linearGradient
+       y2="1"
+       id="svg_1">
+      <stop
+         id="stop15"
+         offset="0"
+         stop-color="#e8e8e8" />
+      <stop
+         id="stop17"
+         offset="1"
+         stop-color="#171717" />
+    </linearGradient>
+    <linearGradient
+       spreadMethod="pad"
+       x2="1"
+       y1="0"
+       x1="0"
+       y2="1"
+       id="svg_2">
+      <stop
+         id="stop20"
+         offset="0"
+         stop-color="#e8e8e8" />
+      <stop
+         id="stop22"
+         offset="1"
+         stop-color="#171717" />
+    </linearGradient>
+    <linearGradient
+       spreadMethod="pad"
+       x2="1"
+       y1="0.36328101"
+       x1="0.48828101"
+       y2="1"
+       id="svg_3">
+      <stop
+         id="stop25"
+         offset="0"
+         stop-color="#e8e8e8" />
+      <stop
+         id="stop27"
+         offset="1"
+         stop-color="#171717" />
+    </linearGradient>
+    <linearGradient
+       spreadMethod="pad"
+       x2="1"
+       y1="0"
+       x1="0"
+       y2="1"
+       id="svg_4">
+      <stop
+         id="stop30"
+         offset="0"
+         stop-opacity="0.996094"
+         stop-color="#efefef" />
+      <stop
+         id="stop32"
+         offset="1"
+         stop-opacity="0.996094"
+         stop-color="#828282" />
+    </linearGradient>
+    <linearGradient
+       spreadMethod="pad"
+       x2="1"
+       y1="0"
+       x1="0"
+       y2="1"
+       id="svg_5">
+      <stop
+         id="stop35"
+         offset="0"
+         stop-opacity="0.992188"
+         stop-color="#ffffff" />
+      <stop
+         id="stop37"
+         offset="1"
+         stop-opacity="0.996094"
+         stop-color="#828282" />
+    </linearGradient>
+    <linearGradient
+       spreadMethod="pad"
+       x2="1"
+       y1="0"
+       x1="0"
+       y2="1"
+       id="svg_6">
+      <stop
+         id="stop40"
+         offset="0"
+         stop-opacity="0.992188"
+         stop-color="#ffffff" />
+      <stop
+         id="stop42"
+         offset="1"
+         stop-opacity="0.996094"
+         stop-color="#828282" />
+      <stop
+         id="stop44"
+         offset="1"
+         stop-opacity="0.996094"
+         stop-color="#828282" />
+    </linearGradient>
+    <linearGradient
+       spreadMethod="pad"
+       x2="1"
+       y1="0"
+       x1="0"
+       y2="1"
+       id="svg_7">
+      <stop
+         id="stop47"
+         offset="0"
+         stop-opacity="0.988281"
+         stop-color="#ffffff" />
+      <stop
+         id="stop49"
+         offset="1"
+         stop-opacity="0.992188"
+         stop-color="#cccccc" />
+      <stop
+         id="stop51"
+         offset="1"
+         stop-opacity="0.996094"
+         stop-color="#828282" />
+      <stop
+         id="stop53"
+         offset="1"
+         stop-opacity="0.996094"
+         stop-color="#828282" />
+      <stop
+         id="stop55"
+         offset="1"
+         stop-opacity="0.996094"
+         stop-color="#828282" />
+    </linearGradient>
+    <linearGradient
+       spreadMethod="pad"
+       x2="1"
+       y1="0"
+       x1="0"
+       y2="1"
+       id="svg_8">
+      <stop
+         id="stop58"
+         offset="0"
+         stop-opacity="0.988281"
+         stop-color="#ffffff" />
+      <stop
+         id="stop60"
+         offset="1"
+         stop-opacity="0.992188"
+         stop-color="#cccccc" />
+      <stop
+         id="stop62"
+         offset="1"
+         stop-opacity="0.992188"
+         stop-color="#cccccc" />
+      <stop
+         id="stop64"
+         offset="1"
+         stop-opacity="0.996094"
+         stop-color="#828282" />
+      <stop
+         id="stop66"
+         offset="1"
+         stop-opacity="0.996094"
+         stop-color="#828282" />
+      <stop
+         id="stop68"
+         offset="1"
+         stop-opacity="0.996094"
+         stop-color="#828282" />
+    </linearGradient>
+    <linearGradient
+       id="svg_9">
+      <stop
+         id="stop71"
+         offset="0"
+         stop-color="#ffffff" />
+      <stop
+         id="stop73"
+         offset="1"
+         stop-color="#000000" />
+    </linearGradient>
+    <linearGradient
+       id="svg_10">
+      <stop
+         id="stop76"
+         offset="0"
+         stop-color="#ffffff" />
+      <stop
+         id="stop78"
+         offset="1"
+         stop-opacity="0.996094"
+         stop-color="#dddddd" />
+    </linearGradient>
+    <linearGradient
+       y2="1"
+       x2="1"
+       y1="0"
+       x1="0"
+       id="svg_11">
+      <stop
+         id="stop81"
+         offset="0"
+         stop-color="#ffffff" />
+      <stop
+         id="stop83"
+         offset="1"
+         stop-opacity="0.996094"
+         stop-color="#dddddd" />
+    </linearGradient>
+    <linearGradient
+       y2="1"
+       x2="1"
+       y1="0"
+       x1="0"
+       id="svg_12">
+      <stop
+         id="stop86"
+         offset="0"
+         stop-color="#ffffff" />
+      <stop
+         id="stop88"
+         offset="1"
+         stop-opacity="0.992188"
+         stop-color="#f2f2f2" />
+    </linearGradient>
+    <linearGradient
+       y2="1"
+       x2="1"
+       id="svg_13">
+      <stop
+         id="stop91"
+         offset="0"
+         stop-opacity="0.996094"
+         stop-color="#ffffff" />
+      <stop
+         id="stop93"
+         offset="1"
+         stop-opacity="0.996094"
+         stop-color="#c1c1c1" />
+    </linearGradient>
+    <linearGradient
+       y1="0"
+       x1="0"
+       y2="1"
+       x2="1"
+       id="svg_14">
+      <stop
+         id="stop96"
+         offset="0"
+         stop-opacity="0.996094"
+         stop-color="#ffffff" />
+      <stop
+         id="stop98"
+         offset="1"
+         stop-opacity="0.996094"
+         stop-color="#c1c1c1" />
+    </linearGradient>
+    <linearGradient
+       spreadMethod="pad"
+       x2="1"
+       y1="0"
+       x1="0"
+       y2="1"
+       id="svg_15">
+      <stop
+         id="stop101"
+         offset="0"
+         stop-opacity="0.996094"
+         stop-color="#efefef" />
+      <stop
+         id="stop103"
+         offset="1"
+         stop-opacity="0.996094"
+         stop-color="#828282" />
+    </linearGradient>
+    <linearGradient
+       y2="1"
+       x2="1"
+       id="svg_16">
+      <stop
+         id="stop106"
+         offset="0"
+         stop-color="#ffffff" />
+      <stop
+         id="stop108"
+         offset="1"
+         stop-color="#000000" />
+    </linearGradient>
+    <linearGradient
+       y1="0"
+       x1="0"
+       y2="1"
+       x2="1"
+       id="svg_17">
+      <stop
+         id="stop111"
+         offset="0"
+         stop-color="#ffffff" />
+      <stop
+         id="stop113"
+         offset="1"
+         stop-opacity="0.996094"
+         stop-color="#e0e0e0" />
+    </linearGradient>
+    <linearGradient
+       y1="0"
+       x1="0"
+       y2="1"
+       x2="1"
+       id="svg_18">
+      <stop
+         id="stop116"
+         offset="0"
+         stop-color="#ffffff" />
+      <stop
+         id="stop118"
+         offset="1"
+         stop-opacity="0.992188"
+         stop-color="#cecece" />
+    </linearGradient>
+  </defs>
+  <path
+     id="path4488-8-2-9-6"
+     d="m 21,2.4999744 -20,0"
+     style="fill:#888a85;fill-opacity:1;fill-rule:evenodd;stroke:#888a85;stroke-width:0.99999982;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <rect
+     y="14.00004"
+     x="7.8090291"
+     height="4.9999704"
+     width="4.9999809"
+     id="rect4471-25-2-3"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;color-interpolation:sRGB;color-interpolation-filters:linearRGB;fill:#f7941d;fill-opacity:1;fill-rule:evenodd;stroke:#f7941d;stroke-width:0;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:2.20000005;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <rect
+     y="5.5000253"
+     x="7.781075"
+     height="4.9999704"
+     width="4.9999809"
+     id="rect4471-2-7-1-2"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;color-interpolation:sRGB;color-interpolation-filters:linearRGB;fill:#f7941d;fill-opacity:1;fill-rule:evenodd;stroke:#f7941d;stroke-width:0;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:2.20000005;stroke-opacity:1;marker:none;enable-background:accumulate" />
+  <path
+     id="path4488-8-2-9"
+     d="M 4.5,2.9999684 4.5,16.99998"
+     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#b2b2b2;stroke-width:0.99999982;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     id="path4490-0-9-3"
+     d="m 4,8.0000184 3,0"
+     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#b2b2b2;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     id="path4490-8-8-2-9"
+     d="m 4,16.500024 3,0"
+     style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#b2b2b2;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  <path
+     style="display:inline;fill:#6d97c4;fill-opacity:1;fill-rule:evenodd;stroke:#415a75;stroke-width:1.00002682;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+     d="m 18,23.500012 -5.50006,-6.270879 3.66671,0 10e-6,-10.7290956 3.6667,0 0,10.7290956 3.6667,0 z"
+     id="path2848-7-3-9" />
+  <path
+     transform="matrix(0.67707707,0.13704148,-0.13689702,0.67756099,-27.729206,5.0704624)"
+     d="M 61.522245,-0.05190652 54.081798,-0.69203829 49.33637,5.0743244 47.645947,-2.1997729 40.695392,-4.9310388 47.0911,-8.7865464 l 0.449749,-7.4543776 5.643188,4.891262 7.228515,-1.875793 -2.908026,6.8784744 z"
+     id="path4336"
+     style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;color-interpolation:sRGB;color-interpolation-filters:linearRGB;fill:#fffd00;fill-opacity:1;fill-rule:evenodd;stroke:#f8a70a;stroke-width:1.44711649;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:10;stroke-dasharray:none;stroke-dashoffset:2.20000005;stroke-opacity:1;marker:none;enable-background:accumulate" />
+</svg>

--- a/images/themes/default/mActionExpandTree.svg
+++ b/images/themes/default/mActionExpandTree.svg
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   version="1.1"
+   id="svg5477"
+   viewBox="0 0 6.3499999 6.3500002"
+   height="24"
+   width="24">
+  <defs
+     id="defs5479" />
+  <metadata
+     id="metadata5482">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(0,-290.64998)"
+     id="layer1">
+    <path
+       id="path4488-8-2-9-6"
+       d="m 5.55625,291.31143 -5.29166668,0"
+       style="fill:#888a85;fill-opacity:1;fill-rule:evenodd;stroke:#888a85;stroke-width:0.26458329;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <rect
+       y="294.35416"
+       x="2.0661364"
+       height="1.3229089"
+       width="1.3229116"
+       id="rect4471-25-2-3"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;color-interpolation:sRGB;color-interpolation-filters:linearRGB;fill:#f7941d;fill-opacity:1;fill-rule:evenodd;stroke:#f7941d;stroke-width:0;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:2.20000005;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <rect
+       y="292.10519"
+       x="2.0587449"
+       height="1.3229089"
+       width="1.3229116"
+       id="rect4471-2-7-1-2"
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;color-interpolation:sRGB;color-interpolation-filters:linearRGB;fill:#f7941d;fill-opacity:1;fill-rule:evenodd;stroke:#f7941d;stroke-width:0;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:2.20000005;stroke-opacity:1;marker:none;enable-background:accumulate" />
+    <path
+       id="path4488-8-2-9"
+       d="m 1.1906249,291.44372 0,3.70417"
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#b2b2b2;stroke-width:0.26458329;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path4490-0-9-3"
+       d="m 1.0583333,292.76665 0.79375,0"
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#b2b2b2;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path4490-8-8-2-9"
+       d="m 1.0583333,295.01561 0.79375,0"
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#b2b2b2;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       style="display:inline;fill:#6d97c4;fill-opacity:1;fill-rule:evenodd;stroke:#415a75;stroke-width:0.26459044;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+       d="m 4.7624995,296.86769 -1.4552229,-1.65917 0.9701491,0 1.8e-6,-2.83874 0.970148,0 0,2.83874 0.970148,0 z"
+       id="path2848-7-3-9" />
+  </g>
+</svg>

--- a/images/themes/default/mActionFilter2.svg
+++ b/images/themes/default/mActionFilter2.svg
@@ -1,0 +1,671 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   width="24"
+   height="24"
+   id="svg2"
+   version="1.1"
+   viewBox="0 0 24 24">
+  <metadata
+     id="metadata122">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Mouse Pointer</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <title
+     id="title4">Mouse Pointer</title>
+  <defs
+     id="defs12">
+    <linearGradient
+       id="svg_1"
+       y2="1">
+      <stop
+         stop-color="#e8e8e8"
+         offset="0"
+         id="stop15" />
+      <stop
+         stop-color="#171717"
+         offset="1"
+         id="stop17" />
+    </linearGradient>
+    <linearGradient
+       id="svg_2"
+       y2="1"
+       x1="0"
+       y1="0"
+       x2="1"
+       spreadMethod="pad">
+      <stop
+         stop-color="#e8e8e8"
+         offset="0"
+         id="stop20" />
+      <stop
+         stop-color="#171717"
+         offset="1"
+         id="stop22" />
+    </linearGradient>
+    <linearGradient
+       id="svg_3"
+       y2="1"
+       x1="0.48828101"
+       y1="0.36328101"
+       x2="1"
+       spreadMethod="pad">
+      <stop
+         stop-color="#e8e8e8"
+         offset="0"
+         id="stop25" />
+      <stop
+         stop-color="#171717"
+         offset="1"
+         id="stop27" />
+    </linearGradient>
+    <linearGradient
+       id="svg_4"
+       y2="1"
+       x1="0"
+       y1="0"
+       x2="1"
+       spreadMethod="pad">
+      <stop
+         stop-color="#efefef"
+         stop-opacity="0.996094"
+         offset="0"
+         id="stop30" />
+      <stop
+         stop-color="#828282"
+         stop-opacity="0.996094"
+         offset="1"
+         id="stop32" />
+    </linearGradient>
+    <linearGradient
+       id="svg_5"
+       y2="1"
+       x1="0"
+       y1="0"
+       x2="1"
+       spreadMethod="pad">
+      <stop
+         stop-color="#ffffff"
+         stop-opacity="0.992188"
+         offset="0"
+         id="stop35" />
+      <stop
+         stop-color="#828282"
+         stop-opacity="0.996094"
+         offset="1"
+         id="stop37" />
+    </linearGradient>
+    <linearGradient
+       id="svg_6"
+       y2="1"
+       x1="0"
+       y1="0"
+       x2="1"
+       spreadMethod="pad">
+      <stop
+         stop-color="#ffffff"
+         stop-opacity="0.992188"
+         offset="0"
+         id="stop40" />
+      <stop
+         stop-color="#828282"
+         stop-opacity="0.996094"
+         offset="1"
+         id="stop42" />
+      <stop
+         stop-color="#828282"
+         stop-opacity="0.996094"
+         offset="1"
+         id="stop44" />
+    </linearGradient>
+    <linearGradient
+       id="svg_7"
+       y2="1"
+       x1="0"
+       y1="0"
+       x2="1"
+       spreadMethod="pad">
+      <stop
+         stop-color="#ffffff"
+         stop-opacity="0.988281"
+         offset="0"
+         id="stop47" />
+      <stop
+         stop-color="#cccccc"
+         stop-opacity="0.992188"
+         offset="1"
+         id="stop49" />
+      <stop
+         stop-color="#828282"
+         stop-opacity="0.996094"
+         offset="1"
+         id="stop51" />
+      <stop
+         stop-color="#828282"
+         stop-opacity="0.996094"
+         offset="1"
+         id="stop53" />
+      <stop
+         stop-color="#828282"
+         stop-opacity="0.996094"
+         offset="1"
+         id="stop55" />
+    </linearGradient>
+    <linearGradient
+       id="svg_8"
+       y2="1"
+       x1="0"
+       y1="0"
+       x2="1"
+       spreadMethod="pad">
+      <stop
+         stop-color="#ffffff"
+         stop-opacity="0.988281"
+         offset="0"
+         id="stop58" />
+      <stop
+         stop-color="#cccccc"
+         stop-opacity="0.992188"
+         offset="1"
+         id="stop60" />
+      <stop
+         stop-color="#cccccc"
+         stop-opacity="0.992188"
+         offset="1"
+         id="stop62" />
+      <stop
+         stop-color="#828282"
+         stop-opacity="0.996094"
+         offset="1"
+         id="stop64" />
+      <stop
+         stop-color="#828282"
+         stop-opacity="0.996094"
+         offset="1"
+         id="stop66" />
+      <stop
+         stop-color="#828282"
+         stop-opacity="0.996094"
+         offset="1"
+         id="stop68" />
+    </linearGradient>
+    <linearGradient
+       id="svg_9">
+      <stop
+         stop-color="#ffffff"
+         offset="0"
+         id="stop71" />
+      <stop
+         stop-color="#000000"
+         offset="1"
+         id="stop73" />
+    </linearGradient>
+    <linearGradient
+       id="svg_10">
+      <stop
+         stop-color="#ffffff"
+         offset="0"
+         id="stop76" />
+      <stop
+         stop-color="#dddddd"
+         stop-opacity="0.996094"
+         offset="1"
+         id="stop78" />
+    </linearGradient>
+    <linearGradient
+       id="svg_11"
+       x1="0"
+       y1="0"
+       x2="1"
+       y2="1">
+      <stop
+         stop-color="#ffffff"
+         offset="0"
+         id="stop81" />
+      <stop
+         stop-color="#dddddd"
+         stop-opacity="0.996094"
+         offset="1"
+         id="stop83" />
+    </linearGradient>
+    <linearGradient
+       id="svg_12"
+       x1="0"
+       y1="0"
+       x2="1"
+       y2="1">
+      <stop
+         stop-color="#ffffff"
+         offset="0"
+         id="stop86" />
+      <stop
+         stop-color="#f2f2f2"
+         stop-opacity="0.992188"
+         offset="1"
+         id="stop88" />
+    </linearGradient>
+    <linearGradient
+       id="svg_13"
+       x2="1"
+       y2="1">
+      <stop
+         stop-color="#ffffff"
+         stop-opacity="0.996094"
+         offset="0"
+         id="stop91" />
+      <stop
+         stop-color="#c1c1c1"
+         stop-opacity="0.996094"
+         offset="1"
+         id="stop93" />
+    </linearGradient>
+    <linearGradient
+       id="svg_14"
+       x2="1"
+       y2="1"
+       x1="0"
+       y1="0">
+      <stop
+         stop-color="#ffffff"
+         stop-opacity="0.996094"
+         offset="0"
+         id="stop96" />
+      <stop
+         stop-color="#c1c1c1"
+         stop-opacity="0.996094"
+         offset="1"
+         id="stop98" />
+    </linearGradient>
+    <linearGradient
+       id="svg_15"
+       y2="1"
+       x1="0"
+       y1="0"
+       x2="1"
+       spreadMethod="pad">
+      <stop
+         stop-color="#efefef"
+         stop-opacity="0.996094"
+         offset="0"
+         id="stop101" />
+      <stop
+         stop-color="#828282"
+         stop-opacity="0.996094"
+         offset="1"
+         id="stop103" />
+    </linearGradient>
+    <linearGradient
+       id="svg_16"
+       x2="1"
+       y2="1">
+      <stop
+         stop-color="#ffffff"
+         offset="0"
+         id="stop106" />
+      <stop
+         stop-color="#000000"
+         offset="1"
+         id="stop108" />
+    </linearGradient>
+    <linearGradient
+       id="svg_17"
+       x2="1"
+       y2="1"
+       x1="0"
+       y1="0">
+      <stop
+         stop-color="#ffffff"
+         offset="0"
+         id="stop111" />
+      <stop
+         stop-color="#e0e0e0"
+         stop-opacity="0.996094"
+         offset="1"
+         id="stop113" />
+    </linearGradient>
+    <linearGradient
+       id="svg_18"
+       x2="1"
+       y2="1"
+       x1="0"
+       y1="0">
+      <stop
+         stop-color="#ffffff"
+         offset="0"
+         id="stop116" />
+      <stop
+         stop-color="#cecece"
+         stop-opacity="0.992188"
+         offset="1"
+         id="stop118" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4137-3">
+      <stop
+         id="stop4139-9"
+         offset="0"
+         style="stop-color:#555753;stop-opacity:1;" />
+      <stop
+         id="stop4141-0"
+         offset="1"
+         style="stop-color:#555753;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="21"
+       x2="23"
+       y1="15"
+       x1="23"
+       id="linearGradient4143"
+       xlink:href="#linearGradient4137-3" />
+    <linearGradient
+       id="linearGradient4691">
+      <stop
+         id="stop4693"
+         offset="0"
+         style="stop-color:#8cbe8c;stop-opacity:1;" />
+      <stop
+         id="stop4695"
+         offset="1"
+         style="stop-color:#a1daa1;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="5"
+       x2="4"
+       y1="9"
+       x1="10"
+       id="linearGradient4697"
+       xlink:href="#linearGradient4691" />
+    <linearGradient
+       xlink:href="#linearGradient3718"
+       id="linearGradient3724"
+       x1="11.5"
+       y1="23.5"
+       x2="11.499999"
+       y2="14.5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-21,3)" />
+    <radialGradient
+       xlink:href="#linearGradient3710"
+       id="radialGradient3716"
+       cx="11.72698"
+       cy="30.008162"
+       fx="11.72698"
+       fy="30.008162"
+       r="13.875"
+       gradientTransform="matrix(1.90991,2.4623411e-8,-1.6458322e-8,0.64864861,-31.897477,7.035247)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#linearGradient3696"
+       id="linearGradient3694"
+       x1="20.5"
+       y1="30.5"
+       x2="3.5"
+       y2="30.5"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#linearGradient2937"
+       id="linearGradient2947"
+       gradientUnits="userSpaceOnUse"
+       x1="7"
+       y1="17"
+       x2="2"
+       y2="22"
+       gradientTransform="matrix(-1,0,0,-1,26,30)" />
+    <linearGradient
+       xlink:href="#linearGradient2937"
+       id="linearGradient2943"
+       x1="7"
+       y1="17"
+       x2="2"
+       y2="22"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient2835">
+      <stop
+         style="stop-color:#ccf2a6;stop-opacity:1;"
+         offset="0"
+         id="stop2837" />
+      <stop
+         style="stop-color:#8ae234;stop-opacity:1;"
+         offset="1"
+         id="stop2839" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2843">
+      <stop
+         style="stop-color:#eeeeec;stop-opacity:1;"
+         offset="0"
+         id="stop2845" />
+      <stop
+         style="stop-color:#c8c8c2;stop-opacity:1;"
+         offset="1"
+         id="stop2847" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7614">
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:1;"
+         offset="0"
+         id="stop7616" />
+      <stop
+         id="stop7636"
+         offset="0.40000001"
+         style="stop-color:#d3d7cf;stop-opacity:0.38666666;" />
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:0;"
+         offset="0.5"
+         id="stop7638" />
+      <stop
+         id="stop7622"
+         offset="0.60000002"
+         style="stop-color:#d3d7cf;stop-opacity:0.39215687;" />
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:1;"
+         offset="1"
+         id="stop7618" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7624">
+      <stop
+         style="stop-color:#555753;stop-opacity:1;"
+         offset="0"
+         id="stop7626" />
+      <stop
+         id="stop7634"
+         offset="0.40000001"
+         style="stop-color:#555753;stop-opacity:0.39215687;" />
+      <stop
+         style="stop-color:#555753;stop-opacity:0;"
+         offset="0.5"
+         id="stop7640" />
+      <stop
+         id="stop7632"
+         offset="0.60000002"
+         style="stop-color:#555753;stop-opacity:0.39215687;" />
+      <stop
+         style="stop-color:#555753;stop-opacity:1;"
+         offset="1"
+         id="stop7628" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2937">
+      <stop
+         style="stop-color:#ce5c00;stop-opacity:1;"
+         offset="0"
+         id="stop2939" />
+      <stop
+         style="stop-color:#ce5c00;stop-opacity:0;"
+         offset="1"
+         id="stop2941" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3688">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3690" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3692" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3696">
+      <stop
+         id="stop3698"
+         offset="0"
+         style="stop-color:#ff0000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0.5"
+         id="stop3702" />
+      <stop
+         id="stop3700"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3710">
+      <stop
+         style="stop-color:#9a9c96;stop-opacity:1;"
+         offset="0"
+         id="stop3712" />
+      <stop
+         style="stop-color:#eff0ef;stop-opacity:1;"
+         offset="1"
+         id="stop3714" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3718">
+      <stop
+         style="stop-color:#9a9c96;stop-opacity:1"
+         offset="0"
+         id="stop3720" />
+      <stop
+         style="stop-color:#d8d9d7;stop-opacity:1"
+         offset="1"
+         id="stop3722" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="22"
+       x2="2"
+       y1="17"
+       x1="7"
+       id="linearGradient5151"
+       xlink:href="#linearGradient2937" />
+    <linearGradient
+       gradientTransform="matrix(-1,0,0,-1,26,30)"
+       y2="22"
+       x2="2"
+       y1="17"
+       x1="7"
+       gradientUnits="userSpaceOnUse"
+       id="linearGradient5153"
+       xlink:href="#linearGradient2937" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="30.5"
+       x2="3.5"
+       y1="30.5"
+       x1="20.5"
+       id="linearGradient5160"
+       xlink:href="#linearGradient3696" />
+    <radialGradient
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="matrix(1.90991,2.4623411e-8,-1.6458322e-8,0.64864861,-31.897477,7.035247)"
+       r="13.875"
+       fy="30.008162"
+       fx="11.72698"
+       cy="30.008162"
+       cx="11.72698"
+       id="radialGradient3716-5"
+       xlink:href="#linearGradient3710" />
+    <linearGradient
+       gradientTransform="translate(-21,3)"
+       gradientUnits="userSpaceOnUse"
+       y2="14.5"
+       x2="11.499999"
+       y1="23.5"
+       x1="11.5"
+       id="linearGradient5163"
+       xlink:href="#linearGradient3718" />
+    <linearGradient
+       xlink:href="#linearGradient2937"
+       id="linearGradient4454"
+       x1="7"
+       y1="17"
+       x2="2"
+       y2="22"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#linearGradient2937"
+       id="linearGradient4456"
+       gradientUnits="userSpaceOnUse"
+       x1="7"
+       y1="17"
+       x2="2"
+       y2="22"
+       gradientTransform="matrix(-1,0,0,-1,26,30)" />
+    <linearGradient
+       xlink:href="#linearGradient3696"
+       id="linearGradient4463"
+       x1="20.5"
+       y1="30.5"
+       x2="3.5"
+       y2="30.5"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       xlink:href="#linearGradient3710"
+       id="radialGradient3716-7"
+       cx="11.72698"
+       cy="30.008162"
+       fx="11.72698"
+       fy="30.008162"
+       r="13.875"
+       gradientTransform="matrix(1.90991,2.4623411e-8,-1.6458322e-8,0.64864861,-31.897477,7.035247)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#linearGradient3718"
+       id="linearGradient4466"
+       x1="11.5"
+       y1="23.5"
+       x2="11.499999"
+       y2="14.5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-21,3)" />
+  </defs>
+  <path
+     id="path3777"
+     style="fill:#6d97c4;fill-opacity:1;stroke:#415a75;stroke-width:1;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 2.5,1.4999996 18.999999,0 0,3.7068748 -7.388888,7.4668426 0,10.5185 -4.222222,-2.1037 0,-8.4148 L 2.5,5.2068744 2.5,1.4999996" />
+  <path
+     style="fill:#ffffff;fill-opacity:0.49746194;stroke:none;stroke-width:1;stroke-linecap:square;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 3.0004284,2 0,3 7.3886716,7.466797 0,8.416016 0.895184,0.409583 0,-9.333259 L 3.519962,4.205078 3.519962,2 Z"
+     id="path3777-1" />
+  <rect
+     style="opacity:1;fill:#fce94f;fill-opacity:1;stroke:none;stroke-width:0.99999988;stroke-linecap:square;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     id="rect4797"
+     width="18"
+     height="3"
+     x="3.0004284"
+     y="2" />
+  <path
+     style="fill:none;fill-rule:evenodd;stroke:#415a75;stroke-width:0.99999994px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 3,5.5 18,0"
+     id="path4799" />
+</svg>

--- a/images/themes/default/mActionFolder.svg
+++ b/images/themes/default/mActionFolder.svg
@@ -1,0 +1,72 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="svg5477"
+   viewBox="0 0 6.3499999 6.3500002"
+   height="24"
+   width="24"
+   inkscape:version="0.91+devel r"
+   sodipodi:docname="mActionFolder.svg">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1600"
+     inkscape:window-height="875"
+     id="namedview20"
+     showgrid="false"
+     inkscape:zoom="2.4583333"
+     inkscape:cx="89.214916"
+     inkscape:cy="-23.280641"
+     inkscape:window-x="0"
+     inkscape:window-y="25"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg5477" />
+  <defs
+     id="defs5479" />
+  <metadata
+     id="metadata5482">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;fill:#eeeeec;fill-opacity:1;stroke:#888a85;stroke-width:0.29872316;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+     d="m 2.0148354,0.91066875 3.4054436,0 0,3.40544355 -3.4054436,0 0,-3.40544355 z"
+     id="rect4012-9-8-9-0-6-5" />
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;fill:#eeeeec;fill-opacity:1;stroke:#888a85;stroke-width:0.29872316;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+     d="m 0.94311159,1.7368615 3.40544361,0 0,3.4054436 -3.40544361,0 0,-3.4054436 z"
+     id="rect4012-9-8-9-0-6-4" />
+  <path
+     style="fill:none;fill-rule:evenodd;stroke:#415a75;stroke-width:0.26458335px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 3.2462835,2.460066 0,1.4170905 c 0.010264,0.2754011 0.6109093,0.2987416 0.618856,0 l 0,-3.27814144 c 0,-0.51080442 -0.9148305,-0.48502823 -0.9148305,0 l 0,0.16446453"
+     id="path4199"
+     inkscape:connector-curvature="0"
+     sodipodi:nodetypes="cccccc" />
+  <path
+     style="fill:none;fill-rule:evenodd;stroke:#888a85;stroke-width:0.26458335px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+     d="m 0.39687501,3.4244512 0,2.2640905 2.72071329,0"
+     id="path4210"
+     inkscape:connector-curvature="0" />
+</svg>

--- a/images/themes/default/mActionHideAllLayers.svg
+++ b/images/themes/default/mActionHideAllLayers.svg
@@ -1,0 +1,302 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg5692"
+   height="24"
+   width="24">
+  <title
+     id="title2829">GIS icon theme 0.2</title>
+  <defs
+     id="defs5694">
+    <linearGradient
+       id="linearGradient4137-3">
+      <stop
+         id="stop4139-9"
+         offset="0"
+         style="stop-color:#555753;stop-opacity:1;" />
+      <stop
+         id="stop4141-0"
+         offset="1"
+         style="stop-color:#555753;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4137">
+      <stop
+         id="stop4139"
+         offset="0"
+         style="stop-color:#555753;stop-opacity:1;" />
+      <stop
+         id="stop4141"
+         offset="1"
+         style="stop-color:#555753;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="21"
+       x2="23"
+       y1="15"
+       x1="23"
+       id="linearGradient4143"
+       xlink:href="#linearGradient4137" />
+    <linearGradient
+       id="linearGradient4691">
+      <stop
+         id="stop4693"
+         offset="0"
+         style="stop-color:#8cbe8c;stop-opacity:1;" />
+      <stop
+         id="stop4695"
+         offset="1"
+         style="stop-color:#a1daa1;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="5"
+       x2="4"
+       y1="9"
+       x1="10"
+       id="linearGradient4697"
+       xlink:href="#linearGradient4691" />
+    <linearGradient
+       xlink:href="#linearGradient3718"
+       id="linearGradient3724"
+       x1="11.5"
+       y1="23.5"
+       x2="11.499999"
+       y2="14.5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-21,3)" />
+    <radialGradient
+       xlink:href="#linearGradient3710"
+       id="radialGradient3716"
+       cx="11.72698"
+       cy="30.008162"
+       fx="11.72698"
+       fy="30.008162"
+       r="13.875"
+       gradientTransform="matrix(1.90991,2.4623411e-8,-1.6458322e-8,0.64864861,-31.897477,7.035247)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#linearGradient3696"
+       id="linearGradient3694"
+       x1="20.5"
+       y1="30.5"
+       x2="3.5"
+       y2="30.5"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#linearGradient2937"
+       id="linearGradient2947"
+       gradientUnits="userSpaceOnUse"
+       x1="7"
+       y1="17"
+       x2="2"
+       y2="22"
+       gradientTransform="rotate(180,13,15)" />
+    <linearGradient
+       xlink:href="#linearGradient2937"
+       id="linearGradient2943"
+       x1="7"
+       y1="17"
+       x2="2"
+       y2="22"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient2835">
+      <stop
+         style="stop-color:#ccf2a6;stop-opacity:1;"
+         offset="0"
+         id="stop2837" />
+      <stop
+         style="stop-color:#8ae234;stop-opacity:1;"
+         offset="1"
+         id="stop2839" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2843">
+      <stop
+         style="stop-color:#eeeeec;stop-opacity:1;"
+         offset="0"
+         id="stop2845" />
+      <stop
+         style="stop-color:#c8c8c2;stop-opacity:1;"
+         offset="1"
+         id="stop2847" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7614">
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:1;"
+         offset="0"
+         id="stop7616" />
+      <stop
+         id="stop7636"
+         offset="0.40000001"
+         style="stop-color:#d3d7cf;stop-opacity:0.38666666;" />
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:0;"
+         offset="0.5"
+         id="stop7638" />
+      <stop
+         id="stop7622"
+         offset="0.60000002"
+         style="stop-color:#d3d7cf;stop-opacity:0.39215687;" />
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:1;"
+         offset="1"
+         id="stop7618" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7624">
+      <stop
+         style="stop-color:#555753;stop-opacity:1;"
+         offset="0"
+         id="stop7626" />
+      <stop
+         id="stop7634"
+         offset="0.40000001"
+         style="stop-color:#555753;stop-opacity:0.39215687;" />
+      <stop
+         style="stop-color:#555753;stop-opacity:0;"
+         offset="0.5"
+         id="stop7640" />
+      <stop
+         id="stop7632"
+         offset="0.60000002"
+         style="stop-color:#555753;stop-opacity:0.39215687;" />
+      <stop
+         style="stop-color:#555753;stop-opacity:1;"
+         offset="1"
+         id="stop7628" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2937">
+      <stop
+         style="stop-color:#ce5c00;stop-opacity:1;"
+         offset="0"
+         id="stop2939" />
+      <stop
+         style="stop-color:#ce5c00;stop-opacity:0;"
+         offset="1"
+         id="stop2941" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3688">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3690" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3692" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3696">
+      <stop
+         id="stop3698"
+         offset="0"
+         style="stop-color:#ff0000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0.5"
+         id="stop3702" />
+      <stop
+         id="stop3700"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3710">
+      <stop
+         style="stop-color:#9a9c96;stop-opacity:1;"
+         offset="0"
+         id="stop3712" />
+      <stop
+         style="stop-color:#eff0ef;stop-opacity:1;"
+         offset="1"
+         id="stop3714" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3718">
+      <stop
+         style="stop-color:#9a9c96;stop-opacity:1"
+         offset="0"
+         id="stop3720" />
+      <stop
+         style="stop-color:#d8d9d7;stop-opacity:1"
+         offset="1"
+         id="stop3722" />
+    </linearGradient>
+  </defs>
+  <metadata
+     id="metadata5697">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>GIS icon theme 0.2</dc:title>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Robert Szczepanek</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>Robert Szczepanek</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>GIS icons</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:coverage>GIS icons</dc:coverage>
+        <dc:description>http://robert.szczepanek.pl/</dc:description>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by-sa/3.0/" />
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by-sa/3.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#ShareAlike" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(0,-8)"
+     style="display:inline"
+     id="layer2">
+    <path
+       id="path4389-5-0-7"
+       d="m 23.920726,22.589049 c 0,0 -0.204601,-0.652217 -1.183864,-1.741642 -0.626778,-0.697285 1.133965,-4.759717 -4.203989,-7.462595 -2.843013,-1.439563 -8.9684055,0.115819 -11.2570483,0.515667 -5.0919021,0.889605 -4.9405237,1.461199 -5.466197,2.832546 -0.3947767,1.029871 -0.205755,4.210676 -0.193479,4.489383 -0.01888,0.230131 1.214539,2.152487 2.867438,3.325547 1.508743,1.070752 3.592552,2.336622 5.9029663,2.73289 2.79582,0.479522 3.821514,0.379776 6.481198,-0.469869 1.39945,-0.447059 3.888123,-2.570867 3.888123,-2.570867 0,0 0.521038,-0.348323 1.332925,-0.951893 0.700164,-0.520511 1.831927,-0.699167 1.831927,-0.699167 z"
+       style="display:inline;fill:#eeeeec;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path4421-4"
+       d="m 1.1431106,15.424331 c 5.0059781,-1.495379 8.5535321,-2.062068 10.9931454,-2.285946 5.222126,-0.479224 7.062158,0.400175 8.402611,1.388166 1.448462,1.0676 1.763071,1.760039 1.763071,1.760039"
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path4389-5-0"
+       d="m 23.514476,22.589049 c -0.0074,-1.621158 -1.489833,-0.70922 -2.121364,-0.366642 -1.345528,0.583965 -4.05405,3.175877 -5.922739,3.568655 -2.150462,0.452003 -4.650818,0.144881 -6.7882983,-0.765583 -2.09114,-0.890725 -3.6035308,-2.157143 -5.122447,-3.292454 -0.983278,-0.734949 -1.955755,-0.414323 -1.943479,-0.135617 -0.01888,0.230131 1.214539,1.777488 2.867438,2.950547 1.508743,1.070753 3.592552,2.336622 5.9029663,2.73289 2.79582,0.479522 3.821514,0.379776 6.481198,-0.469869 1.39945,-0.447059 3.888123,-2.570867 3.888123,-2.570867 0,0 0.521038,-0.348323 1.332925,-0.951893 0.700164,-0.520511 1.425677,-0.699167 1.425677,-0.699167 z"
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  </g>
+</svg>

--- a/images/themes/default/mActionPropertiesWidget.svg
+++ b/images/themes/default/mActionPropertiesWidget.svg
@@ -1,0 +1,374 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   width="24"
+   height="24"
+   id="svg2"
+   version="1.1">
+  <metadata
+     id="metadata122">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>Mouse Pointer</dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <title
+     id="title4">Mouse Pointer</title>
+  <defs
+     id="defs12">
+    <linearGradient
+       id="svg_1"
+       y2="1">
+      <stop
+         stop-color="#e8e8e8"
+         offset="0"
+         id="stop15" />
+      <stop
+         stop-color="#171717"
+         offset="1"
+         id="stop17" />
+    </linearGradient>
+    <linearGradient
+       id="svg_2"
+       y2="1"
+       x1="0"
+       y1="0"
+       x2="1"
+       spreadMethod="pad">
+      <stop
+         stop-color="#e8e8e8"
+         offset="0"
+         id="stop20" />
+      <stop
+         stop-color="#171717"
+         offset="1"
+         id="stop22" />
+    </linearGradient>
+    <linearGradient
+       id="svg_3"
+       y2="1"
+       x1="0.48828101"
+       y1="0.36328101"
+       x2="1"
+       spreadMethod="pad">
+      <stop
+         stop-color="#e8e8e8"
+         offset="0"
+         id="stop25" />
+      <stop
+         stop-color="#171717"
+         offset="1"
+         id="stop27" />
+    </linearGradient>
+    <linearGradient
+       id="svg_4"
+       y2="1"
+       x1="0"
+       y1="0"
+       x2="1"
+       spreadMethod="pad">
+      <stop
+         stop-color="#efefef"
+         stop-opacity="0.996094"
+         offset="0"
+         id="stop30" />
+      <stop
+         stop-color="#828282"
+         stop-opacity="0.996094"
+         offset="1"
+         id="stop32" />
+    </linearGradient>
+    <linearGradient
+       id="svg_5"
+       y2="1"
+       x1="0"
+       y1="0"
+       x2="1"
+       spreadMethod="pad">
+      <stop
+         stop-color="#ffffff"
+         stop-opacity="0.992188"
+         offset="0"
+         id="stop35" />
+      <stop
+         stop-color="#828282"
+         stop-opacity="0.996094"
+         offset="1"
+         id="stop37" />
+    </linearGradient>
+    <linearGradient
+       id="svg_6"
+       y2="1"
+       x1="0"
+       y1="0"
+       x2="1"
+       spreadMethod="pad">
+      <stop
+         stop-color="#ffffff"
+         stop-opacity="0.992188"
+         offset="0"
+         id="stop40" />
+      <stop
+         stop-color="#828282"
+         stop-opacity="0.996094"
+         offset="1"
+         id="stop42" />
+      <stop
+         stop-color="#828282"
+         stop-opacity="0.996094"
+         offset="1"
+         id="stop44" />
+    </linearGradient>
+    <linearGradient
+       id="svg_7"
+       y2="1"
+       x1="0"
+       y1="0"
+       x2="1"
+       spreadMethod="pad">
+      <stop
+         stop-color="#ffffff"
+         stop-opacity="0.988281"
+         offset="0"
+         id="stop47" />
+      <stop
+         stop-color="#cccccc"
+         stop-opacity="0.992188"
+         offset="1"
+         id="stop49" />
+      <stop
+         stop-color="#828282"
+         stop-opacity="0.996094"
+         offset="1"
+         id="stop51" />
+      <stop
+         stop-color="#828282"
+         stop-opacity="0.996094"
+         offset="1"
+         id="stop53" />
+      <stop
+         stop-color="#828282"
+         stop-opacity="0.996094"
+         offset="1"
+         id="stop55" />
+    </linearGradient>
+    <linearGradient
+       id="svg_8"
+       y2="1"
+       x1="0"
+       y1="0"
+       x2="1"
+       spreadMethod="pad">
+      <stop
+         stop-color="#ffffff"
+         stop-opacity="0.988281"
+         offset="0"
+         id="stop58" />
+      <stop
+         stop-color="#cccccc"
+         stop-opacity="0.992188"
+         offset="1"
+         id="stop60" />
+      <stop
+         stop-color="#cccccc"
+         stop-opacity="0.992188"
+         offset="1"
+         id="stop62" />
+      <stop
+         stop-color="#828282"
+         stop-opacity="0.996094"
+         offset="1"
+         id="stop64" />
+      <stop
+         stop-color="#828282"
+         stop-opacity="0.996094"
+         offset="1"
+         id="stop66" />
+      <stop
+         stop-color="#828282"
+         stop-opacity="0.996094"
+         offset="1"
+         id="stop68" />
+    </linearGradient>
+    <linearGradient
+       id="svg_9">
+      <stop
+         stop-color="#ffffff"
+         offset="0"
+         id="stop71" />
+      <stop
+         stop-color="#000000"
+         offset="1"
+         id="stop73" />
+    </linearGradient>
+    <linearGradient
+       id="svg_10">
+      <stop
+         stop-color="#ffffff"
+         offset="0"
+         id="stop76" />
+      <stop
+         stop-color="#dddddd"
+         stop-opacity="0.996094"
+         offset="1"
+         id="stop78" />
+    </linearGradient>
+    <linearGradient
+       id="svg_11"
+       x1="0"
+       y1="0"
+       x2="1"
+       y2="1">
+      <stop
+         stop-color="#ffffff"
+         offset="0"
+         id="stop81" />
+      <stop
+         stop-color="#dddddd"
+         stop-opacity="0.996094"
+         offset="1"
+         id="stop83" />
+    </linearGradient>
+    <linearGradient
+       id="svg_12"
+       x1="0"
+       y1="0"
+       x2="1"
+       y2="1">
+      <stop
+         stop-color="#ffffff"
+         offset="0"
+         id="stop86" />
+      <stop
+         stop-color="#f2f2f2"
+         stop-opacity="0.992188"
+         offset="1"
+         id="stop88" />
+    </linearGradient>
+    <linearGradient
+       id="svg_13"
+       x2="1"
+       y2="1">
+      <stop
+         stop-color="#ffffff"
+         stop-opacity="0.996094"
+         offset="0"
+         id="stop91" />
+      <stop
+         stop-color="#c1c1c1"
+         stop-opacity="0.996094"
+         offset="1"
+         id="stop93" />
+    </linearGradient>
+    <linearGradient
+       id="svg_14"
+       x2="1"
+       y2="1"
+       x1="0"
+       y1="0">
+      <stop
+         stop-color="#ffffff"
+         stop-opacity="0.996094"
+         offset="0"
+         id="stop96" />
+      <stop
+         stop-color="#c1c1c1"
+         stop-opacity="0.996094"
+         offset="1"
+         id="stop98" />
+    </linearGradient>
+    <linearGradient
+       id="svg_15"
+       y2="1"
+       x1="0"
+       y1="0"
+       x2="1"
+       spreadMethod="pad">
+      <stop
+         stop-color="#efefef"
+         stop-opacity="0.996094"
+         offset="0"
+         id="stop101" />
+      <stop
+         stop-color="#828282"
+         stop-opacity="0.996094"
+         offset="1"
+         id="stop103" />
+    </linearGradient>
+    <linearGradient
+       id="svg_16"
+       x2="1"
+       y2="1">
+      <stop
+         stop-color="#ffffff"
+         offset="0"
+         id="stop106" />
+      <stop
+         stop-color="#000000"
+         offset="1"
+         id="stop108" />
+    </linearGradient>
+    <linearGradient
+       id="svg_17"
+       x2="1"
+       y2="1"
+       x1="0"
+       y1="0">
+      <stop
+         stop-color="#ffffff"
+         offset="0"
+         id="stop111" />
+      <stop
+         stop-color="#e0e0e0"
+         stop-opacity="0.996094"
+         offset="1"
+         id="stop113" />
+    </linearGradient>
+    <linearGradient
+       id="svg_18"
+       x2="1"
+       y2="1"
+       x1="0"
+       y1="0">
+      <stop
+         stop-color="#ffffff"
+         offset="0"
+         id="stop116" />
+      <stop
+         stop-color="#cecece"
+         stop-opacity="0.992188"
+         offset="1"
+         id="stop118" />
+    </linearGradient>
+  </defs>
+  <circle
+     r="9.5"
+     style="fill:#6d97c4;fill-opacity:1;stroke:#445e75;stroke-width:1;stroke-miterlimit:10;stroke-dasharray:none;stroke-opacity:1"
+     stroke-miterlimit="10"
+     cx="12"
+     cy="12"
+     id="circle3" />
+  <path
+     style="opacity:0.3;fill:#ffffff;stroke-width:0.65832847"
+     d="M 4.3057227,13.721911 C 4.5482083,10.932997 5.0928069,9.259781 6.8246566,7.5279317 8.6949753,5.6576117 10.427157,4.7896995 13.700048,4.0450162 15.308006,3.6793012 12.522734,2.4668743 8.6684745,3.908867 6.5980715,4.6833635 4.4965307,6.7047388 3.759136,9.650342 c -0.8934195,3.566391 0.4356126,5.348593 0.5465867,4.071569 z"
+     id="path5" />
+  <path
+     style="fill:#ffffff;stroke:#34497d;stroke-width:0.5;stroke-miterlimit:10;stroke-dasharray:none"
+     stroke-miterlimit="10"
+     d="m 14.277442,15.998692 -0.235198,-0.234536 c -0.214326,-0.213996 -0.624764,-0.171594 -0.794371,0.08216 -0.106336,0.159338 -0.597933,0.668161 -0.907665,0.907334 0.03843,-0.158677 0.111968,-0.401161 0.250436,-0.794703 l 1.242242,-3.526642 c 0.291842,-0.835117 0.468076,-1.339301 0.468076,-1.769282 0,-0.680417 -0.501534,-1.120336 -1.277024,-1.120336 -1.958766,0 -3.4918577,1.768951 -4.0593134,2.528871 -0.00728,0.0096 -0.013913,0.01889 -0.019877,0.02716 -0.097722,0.110973 -0.1364805,0.259048 -0.1060038,0.410768 0.02352,0.117267 0.087785,0.230891 0.186171,0.329277 l 0.1762324,0.175901 c 0.1053415,0.105342 0.2421536,0.163313 0.3855913,0.163313 0.1069983,0 0.2673302,-0.03346 0.4250115,-0.192796 l 0.02916,-0.03411 c 0.20439,-0.272299 0.586338,-0.684062 0.865593,-0.937478 -0.04804,0.162982 -0.115942,0.363065 -0.195778,0.593295 l -0.8636069,2.517278 c -0.6151585,1.778558 -0.8453869,2.444069 -0.8453869,2.814754 0,0.484639 0.3097321,1.002074 1.1789698,1.002074 2.70146,0 4.033142,-2.006798 4.17923,-2.240341 0.148739,-0.249111 0.120249,-0.497891 -0.08249,-0.701949 z"
+     id="path7" />
+  <path
+     style="fill:#ffffff;stroke:#34497d;stroke-width:0.5;stroke-miterlimit:10;stroke-dasharray:none"
+     stroke-miterlimit="10"
+     d="m 13.180294,5.5009239 c -0.868575,0 -1.630152,0.7523016 -1.630152,1.6102767 0,0.9782234 0.655241,1.6102749 1.669242,1.6102749 0.99545,0 1.767295,-0.918264 1.767295,-1.7083301 3.31e-4,-0.6973112 -0.472715,-1.5122215 -1.806385,-1.5122215 z"
+     id="path9" />
+</svg>

--- a/images/themes/default/mActionPropertyItem.svg
+++ b/images/themes/default/mActionPropertyItem.svg
@@ -1,0 +1,976 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   viewBox="0 0 6.3499999 6.3500002"
+   id="svg5477"
+   version="1.1"
+   inkscape:version="0.91+devel r"
+   sodipodi:docname="mActionPropertyItem.svg">
+  <defs
+     id="defs5479">
+    <inkscape:perspective
+       id="perspective3486"
+       inkscape:persp3d-origin="16 : 10.666667 : 1"
+       inkscape:vp_z="32 : 16 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 16 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       id="perspective3496" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       id="perspective3600" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       id="perspective7871" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       id="perspective8710" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       id="perspective9811" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       id="perspective4762" />
+    <inkscape:perspective
+       id="perspective2958"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3012"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective2895"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective4025"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective4004"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3979"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3958"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3211"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3186"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective8121"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective8093"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective8076"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective8047"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <linearGradient
+       id="linearGradient4137-3">
+      <stop
+         id="stop4139-9"
+         offset="0"
+         style="stop-color:#555753;stop-opacity:1;" />
+      <stop
+         id="stop4141-0"
+         offset="1"
+         style="stop-color:#555753;stop-opacity:0;" />
+    </linearGradient>
+    <inkscape:perspective
+       id="perspective3274"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective8019"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective8003"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective7972"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="21"
+       x2="23"
+       y1="15"
+       x1="23"
+       id="linearGradient4143"
+       xlink:href="#linearGradient4137-3"
+       inkscape:collect="always" />
+    <inkscape:perspective
+       id="perspective7951"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <linearGradient
+       id="linearGradient4691">
+      <stop
+         id="stop4693"
+         offset="0"
+         style="stop-color:#8cbe8c;stop-opacity:1;" />
+      <stop
+         id="stop4695"
+         offset="1"
+         style="stop-color:#a1daa1;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="5"
+       x2="4"
+       y1="9"
+       x1="10"
+       id="linearGradient4697"
+       xlink:href="#linearGradient4691"
+       inkscape:collect="always" />
+    <inkscape:perspective
+       id="perspective7932"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3718"
+       id="linearGradient3724"
+       x1="11.5"
+       y1="23.5"
+       x2="11.499999"
+       y2="14.5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-21,3)" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3710"
+       id="radialGradient3716"
+       cx="11.72698"
+       cy="30.008162"
+       fx="11.72698"
+       fy="30.008162"
+       r="13.875"
+       gradientTransform="matrix(1.90991,2.4623411e-8,-1.6458322e-8,0.64864861,-31.897477,7.035247)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient3696"
+       id="linearGradient3694"
+       x1="20.5"
+       y1="30.5"
+       x2="3.5"
+       y2="30.5"
+       gradientUnits="userSpaceOnUse" />
+    <inkscape:perspective
+       id="perspective4981"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective4921"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective4880"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective4855"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective4866"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2937"
+       id="linearGradient2947"
+       gradientUnits="userSpaceOnUse"
+       x1="7"
+       y1="17"
+       x2="2"
+       y2="22"
+       gradientTransform="rotate(180,13,15)" />
+    <linearGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient2937"
+       id="linearGradient2943"
+       x1="7"
+       y1="17"
+       x2="2"
+       y2="22"
+       gradientUnits="userSpaceOnUse" />
+    <inkscape:perspective
+       id="perspective6861"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective14200"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective14145"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective8320"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective8299"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective8278"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective8225-40"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective8225-0"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective8225-4"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective8225-2"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective8225"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective8196-6"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective8196"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective8175"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective8138-4"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective8138-2"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective8138"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective8031"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective7227"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective7196"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective7131"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3221"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective8612"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective8590"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3528"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3494"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3800"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective6018"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective5981"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective5932"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective5892"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective5850"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective5795"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3034"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective6803"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective2978"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective2842"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective2979"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective2905"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective4053"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective4032"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective4002"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3968"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3929"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3869"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective3803"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective8279"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective8219"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective8095"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective8057"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective8023"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective7934"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       id="perspective6979"
+       inkscape:persp3d-origin="0.5 : 0.33333333 : 1"
+       inkscape:vp_z="1 : 0.5 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_x="0 : 0.5 : 1"
+       sodipodi:type="inkscape:persp3d" />
+    <inkscape:perspective
+       sodipodi:type="inkscape:persp3d"
+       inkscape:vp_x="0 : 16 : 1"
+       inkscape:vp_y="0 : 1000 : 0"
+       inkscape:vp_z="32 : 16 : 1"
+       inkscape:persp3d-origin="16 : 10.666667 : 1"
+       id="perspective3257" />
+    <linearGradient
+       id="linearGradient2835">
+      <stop
+         style="stop-color:#ccf2a6;stop-opacity:1;"
+         offset="0"
+         id="stop2837" />
+      <stop
+         style="stop-color:#8ae234;stop-opacity:1;"
+         offset="1"
+         id="stop2839" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2843">
+      <stop
+         style="stop-color:#eeeeec;stop-opacity:1;"
+         offset="0"
+         id="stop2845" />
+      <stop
+         style="stop-color:#c8c8c2;stop-opacity:1;"
+         offset="1"
+         id="stop2847" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7614">
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:1;"
+         offset="0"
+         id="stop7616" />
+      <stop
+         id="stop7636"
+         offset="0.40000001"
+         style="stop-color:#d3d7cf;stop-opacity:0.38666666;" />
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:0;"
+         offset="0.5"
+         id="stop7638" />
+      <stop
+         id="stop7622"
+         offset="0.60000002"
+         style="stop-color:#d3d7cf;stop-opacity:0.39215687;" />
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:1;"
+         offset="1"
+         id="stop7618" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7624">
+      <stop
+         style="stop-color:#555753;stop-opacity:1;"
+         offset="0"
+         id="stop7626" />
+      <stop
+         id="stop7634"
+         offset="0.40000001"
+         style="stop-color:#555753;stop-opacity:0.39215687;" />
+      <stop
+         style="stop-color:#555753;stop-opacity:0;"
+         offset="0.5"
+         id="stop7640" />
+      <stop
+         id="stop7632"
+         offset="0.60000002"
+         style="stop-color:#555753;stop-opacity:0.39215687;" />
+      <stop
+         style="stop-color:#555753;stop-opacity:1;"
+         offset="1"
+         id="stop7628" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient2937">
+      <stop
+         style="stop-color:#ce5c00;stop-opacity:1;"
+         offset="0"
+         id="stop2939" />
+      <stop
+         style="stop-color:#ce5c00;stop-opacity:0;"
+         offset="1"
+         id="stop2941" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3688">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3690" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3692" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3696">
+      <stop
+         id="stop3698"
+         offset="0"
+         style="stop-color:#ff0000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0.5"
+         id="stop3702" />
+      <stop
+         id="stop3700"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3710">
+      <stop
+         style="stop-color:#9a9c96;stop-opacity:1;"
+         offset="0"
+         id="stop3712" />
+      <stop
+         style="stop-color:#eff0ef;stop-opacity:1;"
+         offset="1"
+         id="stop3714" />
+    </linearGradient>
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient3718">
+      <stop
+         style="stop-color:#9a9c96;stop-opacity:1"
+         offset="0"
+         id="stop3720" />
+      <stop
+         style="stop-color:#d8d9d7;stop-opacity:1"
+         offset="1"
+         id="stop3722" />
+    </linearGradient>
+    <inkscape:path-effect
+       effect="spiro"
+       id="path-effect3780"
+       is_visible="true" />
+    <inkscape:path-effect
+       is_visible="true"
+       id="path-effect3798"
+       effect="spiro" />
+    <inkscape:path-effect
+       is_visible="true"
+       id="path-effect3802"
+       effect="spiro" />
+    <inkscape:path-effect
+       is_visible="true"
+       id="path-effect3804"
+       effect="spiro" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="3.959798"
+     inkscape:cx="6.1340315"
+     inkscape:cy="-13.238177"
+     inkscape:document-units="mm"
+     inkscape:current-layer="layer1"
+     showgrid="false"
+     units="px"
+     inkscape:window-width="1867"
+     inkscape:window-height="1056"
+     inkscape:window-x="53"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1" />
+  <metadata
+     id="metadata5482">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-290.64998)">
+    <path
+       inkscape:connector-curvature="0"
+       style="display:inline;fill:#eeeeec;fill-opacity:1;stroke:#888a85;stroke-width:0.26458338;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+       d="m 90.285228,76.772541 5.027083,0 0,5.027081 -5.027083,0 0,-5.027081 z"
+       id="rect4012-9-8-9"
+       sodipodi:nodetypes="ccccc" />
+    <rect
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;color-interpolation:sRGB;color-interpolation-filters:linearRGB;fill:#f7941d;fill-opacity:1;fill-rule:evenodd;stroke:#f7941d;stroke-width:0;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:2.20000005;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="rect4471-25-2"
+       width="1.3229116"
+       height="1.3229089"
+       x="91.954605"
+       y="79.784637" />
+    <rect
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;color-interpolation:sRGB;color-interpolation-filters:linearRGB;fill:#f7941d;fill-opacity:1;fill-rule:evenodd;stroke:#f7941d;stroke-width:0;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:2.20000005;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="rect4471-2-7-1"
+       width="1.3229116"
+       height="1.3229089"
+       x="91.947098"
+       y="77.489044" />
+    <path
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#b2b2b2;stroke-width:0.26078698;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 91.072268,76.903561 0,3.68319"
+       id="path4488-8-2"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cc" />
+    <path
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#b2b2b2;stroke-width:0.27906913;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 91.124288,78.150481 0.57817,0"
+       id="path4490-0-9"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#b2b2b2;stroke-width:0.27906913;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 91.124288,80.446081 0.57817,0"
+       id="path4490-8-8-2"
+       inkscape:connector-curvature="0" />
+    <path
+       sodipodi:nodetypes="cccccccc"
+       id="path2848-7-3"
+       d="m 94.223935,76.771801 1.455142,1.45514 -0.970095,0 -2e-6,2.457481 -0.970094,0 0,-2.457481 -0.970094,0 z"
+       style="display:inline;fill:#6d97c4;fill-opacity:1;fill-rule:evenodd;stroke:#415a75;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+       inkscape:connector-curvature="0" />
+    <rect
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;color-interpolation:sRGB;color-interpolation-filters:linearRGB;fill:#f7941d;fill-opacity:1;fill-rule:evenodd;stroke:#f7941d;stroke-width:0;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:2.20000005;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="rect4471-25-2-3"
+       width="1.3229116"
+       height="1.3229089"
+       x="2.0661364"
+       y="294.35416" />
+    <rect
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;color-interpolation:sRGB;color-interpolation-filters:linearRGB;fill:#eeeeec;fill-opacity:1;fill-rule:evenodd;stroke:#888a85;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:2.20000005;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="rect4471-2-7-1-2"
+       width="3.7041667"
+       height="1.3229166"
+       x="1.984375"
+       y="292.10519" />
+    <rect
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;color-interpolation:sRGB;color-interpolation-filters:linearRGB;fill:#eeeeec;fill-opacity:1;fill-rule:evenodd;stroke:#888a85;stroke-width:0.26458332;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:2.20000005;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="rect4471-2-7-1-2-1"
+       width="3.7041667"
+       height="1.3229166"
+       x="1.984375"
+       y="294.48642" />
+    <rect
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;color-interpolation:sRGB;color-interpolation-filters:linearRGB;fill:#888a85;fill-opacity:1;fill-rule:evenodd;stroke:#f7941d;stroke-width:0;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:2.20000005;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="rect4471-2-7-1-2-9-3"
+       width="1.3229067"
+       height="1.0583233"
+       x="0.26458833"
+       y="292.23746" />
+    <rect
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;color-interpolation:sRGB;color-interpolation-filters:linearRGB;fill:#888a85;fill-opacity:1;fill-rule:evenodd;stroke:#f7941d;stroke-width:0;stroke-linecap:butt;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:2.20000005;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="rect4471-2-7-1-2-9-3-6"
+       width="1.3229067"
+       height="1.0583233"
+       x="0.26458833"
+       y="294.61874" />
+    <path
+       style="fill:#415a75;fill-opacity:1;fill-rule:evenodd;stroke:#415a75;stroke-width:0.5291667;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 2.38125,292.76665 2.38125,0"
+       id="path4596"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#415a75;fill-opacity:1;fill-rule:evenodd;stroke:#415a75;stroke-width:0.52916676;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       d="m 2.3812499,295.14789 2.9104167,0"
+       id="path4596-7"
+       inkscape:connector-curvature="0" />
+  </g>
+</svg>

--- a/images/themes/default/mActionShowAllLayers.svg
+++ b/images/themes/default/mActionShowAllLayers.svg
@@ -1,0 +1,341 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   viewBox="0 0 24 24"
+   version="1.1"
+   id="svg5692"
+   height="24"
+   width="24">
+  <title
+     id="title2829">GIS icon theme 0.2</title>
+  <defs
+     id="defs5694">
+    <linearGradient
+       id="linearGradient4379">
+      <stop
+         id="stop4381"
+         offset="0"
+         style="stop-color:#bed1e5;stop-opacity:1" />
+      <stop
+         id="stop4383"
+         offset="1"
+         style="stop-color:#6d97c4;stop-opacity:1" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4137-3">
+      <stop
+         id="stop4139-9"
+         offset="0"
+         style="stop-color:#555753;stop-opacity:1;" />
+      <stop
+         id="stop4141-0"
+         offset="1"
+         style="stop-color:#555753;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient4137">
+      <stop
+         id="stop4139"
+         offset="0"
+         style="stop-color:#555753;stop-opacity:1;" />
+      <stop
+         id="stop4141"
+         offset="1"
+         style="stop-color:#555753;stop-opacity:0;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="21"
+       x2="23"
+       y1="15"
+       x1="23"
+       id="linearGradient4143"
+       xlink:href="#linearGradient4137" />
+    <linearGradient
+       id="linearGradient4691">
+      <stop
+         id="stop4693"
+         offset="0"
+         style="stop-color:#8cbe8c;stop-opacity:1;" />
+      <stop
+         id="stop4695"
+         offset="1"
+         style="stop-color:#a1daa1;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       gradientUnits="userSpaceOnUse"
+       y2="5"
+       x2="4"
+       y1="9"
+       x1="10"
+       id="linearGradient4697"
+       xlink:href="#linearGradient4691" />
+    <linearGradient
+       xlink:href="#linearGradient3718"
+       id="linearGradient3724"
+       x1="11.5"
+       y1="23.5"
+       x2="11.499999"
+       y2="14.5"
+       gradientUnits="userSpaceOnUse"
+       gradientTransform="translate(-21,3)" />
+    <radialGradient
+       xlink:href="#linearGradient3710"
+       id="radialGradient3716"
+       cx="11.72698"
+       cy="30.008162"
+       fx="11.72698"
+       fy="30.008162"
+       r="13.875"
+       gradientTransform="matrix(1.90991,2.4623411e-8,-1.6458322e-8,0.64864861,-31.897477,7.035247)"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#linearGradient3696"
+       id="linearGradient3694"
+       x1="20.5"
+       y1="30.5"
+       x2="3.5"
+       y2="30.5"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       xlink:href="#linearGradient2937"
+       id="linearGradient2947"
+       gradientUnits="userSpaceOnUse"
+       x1="7"
+       y1="17"
+       x2="2"
+       y2="22"
+       gradientTransform="rotate(180,13,15)" />
+    <linearGradient
+       xlink:href="#linearGradient2937"
+       id="linearGradient2943"
+       x1="7"
+       y1="17"
+       x2="2"
+       y2="22"
+       gradientUnits="userSpaceOnUse" />
+    <linearGradient
+       id="linearGradient2835">
+      <stop
+         style="stop-color:#ccf2a6;stop-opacity:1;"
+         offset="0"
+         id="stop2837" />
+      <stop
+         style="stop-color:#8ae234;stop-opacity:1;"
+         offset="1"
+         id="stop2839" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2843">
+      <stop
+         style="stop-color:#eeeeec;stop-opacity:1;"
+         offset="0"
+         id="stop2845" />
+      <stop
+         style="stop-color:#c8c8c2;stop-opacity:1;"
+         offset="1"
+         id="stop2847" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7614">
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:1;"
+         offset="0"
+         id="stop7616" />
+      <stop
+         id="stop7636"
+         offset="0.40000001"
+         style="stop-color:#d3d7cf;stop-opacity:0.38666666;" />
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:0;"
+         offset="0.5"
+         id="stop7638" />
+      <stop
+         id="stop7622"
+         offset="0.60000002"
+         style="stop-color:#d3d7cf;stop-opacity:0.39215687;" />
+      <stop
+         style="stop-color:#d3d7cf;stop-opacity:1;"
+         offset="1"
+         id="stop7618" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient7624">
+      <stop
+         style="stop-color:#555753;stop-opacity:1;"
+         offset="0"
+         id="stop7626" />
+      <stop
+         id="stop7634"
+         offset="0.40000001"
+         style="stop-color:#555753;stop-opacity:0.39215687;" />
+      <stop
+         style="stop-color:#555753;stop-opacity:0;"
+         offset="0.5"
+         id="stop7640" />
+      <stop
+         id="stop7632"
+         offset="0.60000002"
+         style="stop-color:#555753;stop-opacity:0.39215687;" />
+      <stop
+         style="stop-color:#555753;stop-opacity:1;"
+         offset="1"
+         id="stop7628" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient2937">
+      <stop
+         style="stop-color:#ce5c00;stop-opacity:1;"
+         offset="0"
+         id="stop2939" />
+      <stop
+         style="stop-color:#ce5c00;stop-opacity:0;"
+         offset="1"
+         id="stop2941" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3688">
+      <stop
+         style="stop-color:#000000;stop-opacity:1;"
+         offset="0"
+         id="stop3690" />
+      <stop
+         style="stop-color:#000000;stop-opacity:0;"
+         offset="1"
+         id="stop3692" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3696">
+      <stop
+         id="stop3698"
+         offset="0"
+         style="stop-color:#ff0000;stop-opacity:1;" />
+      <stop
+         style="stop-color:#ffffff;stop-opacity:1;"
+         offset="0.5"
+         id="stop3702" />
+      <stop
+         id="stop3700"
+         offset="1"
+         style="stop-color:#ffffff;stop-opacity:1;" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3710">
+      <stop
+         style="stop-color:#9a9c96;stop-opacity:1;"
+         offset="0"
+         id="stop3712" />
+      <stop
+         style="stop-color:#eff0ef;stop-opacity:1;"
+         offset="1"
+         id="stop3714" />
+    </linearGradient>
+    <linearGradient
+       id="linearGradient3718">
+      <stop
+         style="stop-color:#9a9c96;stop-opacity:1"
+         offset="0"
+         id="stop3720" />
+      <stop
+         style="stop-color:#d8d9d7;stop-opacity:1"
+         offset="1"
+         id="stop3722" />
+    </linearGradient>
+    <radialGradient
+       gradientTransform="matrix(0.71392723,1.0641605,-0.69302733,0.45911438,-10.291955,4.6155606)"
+       gradientUnits="userSpaceOnUse"
+       r="7.0000001"
+       fy="-12.5"
+       fx="16.5"
+       cy="-12.5"
+       cx="16.5"
+       id="radialGradient4385"
+       xlink:href="#linearGradient4379" />
+  </defs>
+  <metadata
+     id="metadata5697">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title>GIS icon theme 0.2</dc:title>
+        <dc:creator>
+          <cc:Agent>
+            <dc:title>Robert Szczepanek</dc:title>
+          </cc:Agent>
+        </dc:creator>
+        <dc:rights>
+          <cc:Agent>
+            <dc:title>Robert Szczepanek</dc:title>
+          </cc:Agent>
+        </dc:rights>
+        <dc:subject>
+          <rdf:Bag>
+            <rdf:li>GIS icons</rdf:li>
+          </rdf:Bag>
+        </dc:subject>
+        <dc:coverage>GIS icons</dc:coverage>
+        <dc:description>http://robert.szczepanek.pl/</dc:description>
+        <cc:license
+           rdf:resource="http://creativecommons.org/licenses/by-sa/3.0/" />
+      </cc:Work>
+      <cc:License
+         rdf:about="http://creativecommons.org/licenses/by-sa/3.0/">
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Reproduction" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#Distribution" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Notice" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#Attribution" />
+        <cc:permits
+           rdf:resource="http://creativecommons.org/ns#DerivativeWorks" />
+        <cc:requires
+           rdf:resource="http://creativecommons.org/ns#ShareAlike" />
+      </cc:License>
+    </rdf:RDF>
+  </metadata>
+  <g
+     transform="translate(0,-8)"
+     style="display:inline"
+     id="layer2">
+    <path
+       id="path4389-5-0-7"
+       d="m 23.920726,22.589049 c 0,0 -1.892101,-0.277217 -2.871364,-1.366642 -0.626778,-0.697285 -3.678535,-3.947217 -5.453989,-4.650095 -2.962962,-1.172997 -5.321805,-1.134553 -7.5695483,-0.546833 -2.09114,0.546775 -3.530204,1.337547 -4.903697,2.645046 -0.639528,0.608801 -1.518255,2.273176 -1.505979,2.551883 -0.01888,0.230131 1.214539,2.152487 2.867438,3.325547 1.508743,1.070752 3.592552,2.336622 5.9029663,2.73289 2.79582,0.479522 3.821514,0.379776 6.481198,-0.469869 1.39945,-0.447059 3.888123,-2.570867 3.888123,-2.570867 0,0 0.521038,-0.348323 1.332925,-0.951893 0.700164,-0.520511 1.831927,-0.699167 1.831927,-0.699167 z"
+       style="display:inline;fill:#eeeeec;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path4377"
+       d="m 10.703793,15.636921 c -0.7881923,0.02907 -1.0668593,0.04567 -1.9065573,0.207793 -0.480734,0.09555 -1.032406,0.24279 -1.259721,0.314658 -0.82902,0.985202 -1.232344,2.302381 -1.232555,3.586626 3.34e-4,3.02468 2.467746,5.476585 5.5115563,5.476917 3.043809,-3.33e-4 5.511221,-2.452237 5.511555,-5.476917 -0.0019,-0.802706 0.04206,-1.574914 -0.302154,-2.301101 -0.523643,-0.400667 -1.160508,-0.754077 -1.584197,-0.91776 -1.870192,-0.722509 -3.334895,-0.941964 -4.737927,-0.890216 z"
+       style="opacity:1;fill:url(#radialGradient4385);fill-opacity:1;stroke:#415a75;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <ellipse
+       ry="2.2123857"
+       rx="2.2263777"
+       cy="19.659227"
+       cx="11.816514"
+       id="path4387"
+       style="opacity:1;fill:#000000;fill-opacity:1;stroke:none;stroke-width:1.44337571;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path4421-4"
+       d="m 1.1431106,15.424331 c 5.0059781,-1.495379 8.5535321,-2.062068 10.9931454,-2.285946 5.222126,-0.479224 7.062158,0.400175 8.402611,1.388166 1.448462,1.0676 1.763071,1.760039 1.763071,1.760039"
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <path
+       id="path4389-5-0"
+       d="m 23.920726,22.589049 c 0,0 -1.892101,-0.277217 -2.871364,-1.366642 -0.626778,-0.697285 -3.678535,-3.947217 -5.453989,-4.650095 -2.962962,-1.172997 -5.321805,-1.134553 -7.5695483,-0.546833 -2.09114,0.546775 -3.530204,1.337547 -4.903697,2.645046 -0.639528,0.608801 -1.518255,2.273177 -1.505979,2.551883 -0.01888,0.230131 1.214539,2.152488 2.867438,3.325547 1.508743,1.070753 3.592552,2.336622 5.9029663,2.73289 2.79582,0.479522 3.821514,0.379776 6.481198,-0.469869 1.39945,-0.447059 3.888123,-2.570867 3.888123,-2.570867 0,0 0.521038,-0.348323 1.332925,-0.951893 0.700164,-0.520511 1.831927,-0.699167 1.831927,-0.699167 z"
+       style="display:inline;fill:none;fill-rule:evenodd;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+    <ellipse
+       ry="0.88495421"
+       rx="0.89055109"
+       cy="18.742189"
+       cx="11.169984"
+       id="path4387-3"
+       style="display:inline;opacity:1;fill:#eeeeec;fill-opacity:1;stroke:none;stroke-width:0.57735026;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1" />
+  </g>
+</svg>

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2457,7 +2457,7 @@ void QgisApp::initLayerTreeView()
   // add group tool button
   QToolButton* btnAddGroup = new QToolButton;
   btnAddGroup->setAutoRaise( true );
-  btnAddGroup->setIcon( QgsApplication::getThemeIcon( "/mActionFolder.png" ) );
+  btnAddGroup->setIcon( QgsApplication::getThemeIcon( "/mActionFolder.svg" ) );
   btnAddGroup->setToolTip( tr( "Add Group" ) );
   connect( btnAddGroup, SIGNAL( clicked() ), mLayerTreeView->defaultActions(), SLOT( addGroup() ) );
 
@@ -2465,7 +2465,7 @@ void QgisApp::initLayerTreeView()
   QToolButton* btnVisibilityPresets = new QToolButton;
   btnVisibilityPresets->setAutoRaise( true );
   btnVisibilityPresets->setToolTip( tr( "Manage Layer Visibility" ) );
-  btnVisibilityPresets->setIcon( QgsApplication::getThemeIcon( "/mActionShowAllLayers.png" ) );
+  btnVisibilityPresets->setIcon( QgsApplication::getThemeIcon( "/mActionShowAllLayers.svg" ) );
   btnVisibilityPresets->setPopupMode( QToolButton::InstantPopup );
   btnVisibilityPresets->setMenu( QgsVisibilityPresets::instance()->menu() );
 
@@ -2474,18 +2474,18 @@ void QgisApp::initLayerTreeView()
   mBtnFilterLegend->setAutoRaise( true );
   mBtnFilterLegend->setCheckable( true );
   mBtnFilterLegend->setToolTip( tr( "Filter Legend By Map Content" ) );
-  mBtnFilterLegend->setIcon( QgsApplication::getThemeIcon( "/mActionFilter.png" ) );
+  mBtnFilterLegend->setIcon( QgsApplication::getThemeIcon( "/mActionFilter2.svg" ) );
   connect( mBtnFilterLegend, SIGNAL( clicked() ), this, SLOT( toggleFilterLegendByMap() ) );
 
   // expand / collapse tool buttons
   QToolButton* btnExpandAll = new QToolButton;
   btnExpandAll->setAutoRaise( true );
-  btnExpandAll->setIcon( QgsApplication::getThemeIcon( "/mActionExpandTree.png" ) );
+  btnExpandAll->setIcon( QgsApplication::getThemeIcon( "/mActionExpandTree.svg" ) );
   btnExpandAll->setToolTip( tr( "Expand All" ) );
   connect( btnExpandAll, SIGNAL( clicked() ), mLayerTreeView, SLOT( expandAll() ) );
   QToolButton* btnCollapseAll = new QToolButton;
   btnCollapseAll->setAutoRaise( true );
-  btnCollapseAll->setIcon( QgsApplication::getThemeIcon( "/mActionCollapseTree.png" ) );
+  btnCollapseAll->setIcon( QgsApplication::getThemeIcon( "/mActionCollapseTree.svg" ) );
   btnCollapseAll->setToolTip( tr( "Collapse All" ) );
   connect( btnCollapseAll, SIGNAL( clicked() ), mLayerTreeView, SLOT( collapseAll() ) );
 

--- a/src/app/qgsbrowserdockwidget.cpp
+++ b/src/app/qgsbrowserdockwidget.cpp
@@ -449,8 +449,8 @@ QgsBrowserDockWidget::QgsBrowserDockWidget( QString name, QWidget * parent ) :
 
   mBtnRefresh->setIcon( QgsApplication::getThemeIcon( "mActionDraw.svg" ) );
   mBtnAddLayers->setIcon( QgsApplication::getThemeIcon( "mActionAdd.svg" ) );
-  mBtnCollapse->setIcon( QgsApplication::getThemeIcon( "mActionCollapseTree.png" ) );
-  mBtnPropertiesWidget->setIcon( QgsApplication::getThemeIcon( "mActionPropertiesWidget.png" ) );
+  mBtnCollapse->setIcon( QgsApplication::getThemeIcon( "mActionCollapseTree.svg" ) );
+  mBtnPropertiesWidget->setIcon( QgsApplication::getThemeIcon( "mActionPropertiesWidget.svg" ) );
 
   mWidgetFilter->hide();
   mLeFilter->setPlaceholderText( tr( "Type here to filter current item..." ) );

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -255,12 +255,12 @@ QgsIdentifyResultsDialog::QgsIdentifyResultsDialog( QgsMapCanvas *canvas, QWidge
 {
   setupUi( this );
 
-  mExpandToolButton->setIcon( QgsApplication::getThemeIcon( "/mActionExpandTree.png" ) );
-  mCollapseToolButton->setIcon( QgsApplication::getThemeIcon( "/mActionCollapseTree.png" ) );
-  mExpandNewToolButton->setIcon( QgsApplication::getThemeIcon( "/mActionExpandNewTree.png" ) );
+  mExpandToolButton->setIcon( QgsApplication::getThemeIcon( "/mActionExpandTree.svg" ) );
+  mCollapseToolButton->setIcon( QgsApplication::getThemeIcon( "/mActionCollapseTree.svg" ) );
+  mExpandNewToolButton->setIcon( QgsApplication::getThemeIcon( "/mActionExpandNewTree.svg" ) );
   mCopyToolButton->setIcon( QgsApplication::getThemeIcon( "/mActionEditCopy.png" ) );
   mPrintToolButton->setIcon( QgsApplication::getThemeIcon( "/mActionFilePrint.png" ) );
-  mOpenFormButton->setIcon( QgsApplication::getThemeIcon( "/mActionPropertyItem.png" ) );
+  mOpenFormButton->setIcon( QgsApplication::getThemeIcon( "/mActionPropertyItem.svg" ) );
   mOpenFormButton->setDisabled( true );
 
   QSettings mySettings;

--- a/src/ui/qgsbrowserdockwidgetbase.ui
+++ b/src/ui/qgsbrowserdockwidgetbase.ui
@@ -76,7 +76,7 @@
         </property>
         <property name="icon">
          <iconset resource="../../images/images.qrc">
-          <normaloff>:/images/themes/default/mActionFilter.png</normaloff>:/images/themes/default/mActionFilter.png</iconset>
+          <normaloff>:/images/themes/default/mActionFilter2.svg</normaloff>:/images/themes/default/mActionFilter2.svg</iconset>
         </property>
         <property name="checkable">
          <bool>true</bool>


### PR DESCRIPTION
I've taken the time to refresh icons for the layer, browser, and identify panels to better fit QGIS' default theme. In addition, the new icons are now all vector-based, which has become important now that the tool buttons within dock-able panels follow the icon size preferred by users.

Old icons (left) and refreshed icons (right):
![before_after](https://cloud.githubusercontent.com/assets/1728657/7857107/48471602-0558-11e5-83ed-24b6d055f501.png)
