### PR TITLE
[GUI] Keep dock icons one size smaller than toolbar icons

### DIFF
--- a/src/app/qgisappstylesheet.cpp
+++ b/src/app/qgisappstylesheet.cpp
@@ -176,9 +176,21 @@ void QgisAppStyleSheet::buildStyleSheet( const QMap<QString, QVariant>& opts )
         .arg( palette.highlight().color().name() )
         .arg( palette.highlightedText().color().name() );
 
-  QString iconSize = opts.value( "iconSize" ).toString();
+  int iconSize = opts.value( "iconSize" ).toInt();
+  if ( iconSize > 32 )
+  {
+    iconSize -= 16;
+  }
+  else if ( iconSize == 32 ) 
+  {
+    iconSize = 24;
+  }
+  else
+  {
+    iconSize = 16;
+  }
+  
   QgsDebugMsg( QString( "iconSize: %1" ).arg( iconSize ) );
-  if ( iconSize.isEmpty() ) { return; }
   ss += QString( "QDockWidget QToolButton { icon-size: %1px; }" ).arg( iconSize );
   
   QgsDebugMsg( QString( "Stylesheet built: %1" ).arg( ss ) );

--- a/src/ui/qgsbrowserdockwidgetbase.ui
+++ b/src/ui/qgsbrowserdockwidgetbase.ui
@@ -33,10 +33,10 @@
        <number>6</number>
       </property>
       <property name="leftMargin">
-       <number>0</number>
+       <number>5</number>
       </property>
       <property name="rightMargin">
-       <number>0</number>
+       <number>5</number>
       </property>
       <item>
        <widget class="QToolButton" name="mBtnRefresh">


### PR DESCRIPTION
See the discussion in issue #2071 for background on this pull request.

This pull request attaches this logic to the dock icons size:
- Toolbar icon size set to 16 x 16 -> dock icon size set to 16 x 16
- Toolbar icon size set to 24 x 24 -> dock icon size set to 16 x 16 (default setting)
- Toolbar icon size set to 32 x 32 -> dock icon size set to 24 x 24
- Toolbar icon size set to 48 x 48 -> dock icon size set to 32 x 32
- Toolbar icon size set to 64 x 64 -> dock icon size set to 48 x 48

I'm also including a tiny commit that adds left and right margin to the browser panel row of buttons to be consistent with the layer and identity panels.
