### PR TITLE
[OSM] improve handling of closed ways

### DIFF
--- a/src/analysis/openstreetmap/qgsosmdatabase.cpp
+++ b/src/analysis/openstreetmap/qgsosmdatabase.cpp
@@ -471,10 +471,12 @@ void QgsOSMDatabase::exportSpatiaLiteWays( bool closed, const QString& tableName
       continue; // invalid way
 
     bool isArea = ( polyline.first() == polyline.last() ); // closed way?
-    // some closed ways are not really areas
+    // filter out closed way that are not areas through tags
     if ( isArea && ( t.contains( "highway" ) || t.contains( "barrier" ) ) )
     {
-      if ( t.value( "area" ) != "yes" ) // even though "highway" is line by default, "area"="yes" may override that
+      // make sure tags that indicate areas are taken into consideration when deciding on a closed way is or isn't an area
+      // and allow for a closed way to be exported both as a polygon and a line in case both area and non-area tags are present
+      if ( ( t.value( "area" ) != "yes" && !t.contains( "amenity" ) && !t.contains( "landuse" ) && !t.contains( "building" ) && !t.contains( "natural" ) ) || !closed )
         isArea = false;
     }
 


### PR DESCRIPTION
This PR adds a number of area-defining tags when considering whether a closed way tagged with highway or barrier is an area, or only a line. The proposed handling better reflects OSM's behavior (see http://wiki.openstreetmap.org/wiki/Key:area).

The commit also allows for a same closed way tagged with highway or barrier to be exported both as a polygon - when area-defining tags are present - _as well as_ lines. For e.g., if a closed way is flagged as an amenity=embassy, and barrier=wall, the closed way will export both to a polygon, and a line. 

Prior to this PR, the area intent (defined through tags) would simply be lost, and only a line would be exported. 
