### PR TITLE
Wait for the current rendering to finish before touching the cache

### DIFF
--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -554,6 +554,12 @@ void QgsMapCanvas::setCachingEnabled( bool enabled )
   if ( enabled == isCachingEnabled() )
     return;
 
+  if ( mJob && mJob->isActive() )
+  {
+    // wait for the current rendering to finish, before touching the cache
+    mJob->waitForFinished();
+  }
+
   if ( enabled )
   {
     mCache = new QgsMapRendererCache;


### PR DESCRIPTION
When the cache is enabled or disabled during a rendering, then bad things may occur (deadlock or segfault).
With this patch, the current rendering is waited for completion before creating or deleting the cache.
