### PR TITLE
Fix single band gray with alpha raster type not recognized (fix #4159)

### DIFF
--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -708,7 +708,19 @@ void QgsRasterLayer::setDataProvider( QString const & provider )
   QgsDebugMsg( "dataType = " + QString::number( mDataProvider->dataType( 1 ) ) );
   if (( mDataProvider->bandCount() > 1 ) )
   {
-    mRasterType = Multiband;
+    // handle singleband gray with alpha
+    if ( mDataProvider->bandCount() == 2
+         && (( mDataProvider->colorInterpretation( 1 ) == QgsRaster::GrayIndex
+               && mDataProvider->colorInterpretation( 2 ) == QgsRaster::AlphaBand )
+             || ( mDataProvider->colorInterpretation( 1 ) == QgsRaster::AlphaBand
+                  && mDataProvider->colorInterpretation( 2 ) == QgsRaster::GrayIndex ) ) )
+    {
+      mRasterType = GrayOrUndefined;
+    }
+    else
+    {
+      mRasterType = Multiband;
+    }
   }
   else if ( mDataProvider->dataType( 1 ) == QGis::ARGB32
             ||  mDataProvider->dataType( 1 ) == QGis::ARGB32_Premultiplied )

--- a/src/providers/wcs/qgswcsprovider.cpp
+++ b/src/providers/wcs/qgswcsprovider.cpp
@@ -913,6 +913,12 @@ QList<QgsColorRampShader::ColorRampItem> QgsWcsProvider::colorTable( int theBand
   return mColorTables.value( theBandNumber - 1 );
 }
 
+int QgsWcsProvider::colorInterpretation( int bandNo ) const
+{
+  GDALRasterBandH myGdalBand = GDALGetRasterBand( mCachedGdalDataset, bandNo );
+  return colorInterpretationFromGdal( GDALGetRasterColorInterpretation( myGdalBand ) );
+}
+
 
 bool QgsWcsProvider::parseServiceExceptionReportDom( QByteArray const & xml, const QString& wcsVersion, QString& errorTitle, QString& errorText )
 {

--- a/src/providers/wcs/qgswcsprovider.h
+++ b/src/providers/wcs/qgswcsprovider.h
@@ -178,6 +178,8 @@ class QgsWcsProvider : public QgsRasterDataProvider, QgsGdalProviderBase
     void reloadData() override;
     QList<QgsColorRampShader::ColorRampItem> colorTable( int bandNo )const override;
 
+    int colorInterpretation( int bandNo ) const override;
+
     static QMap<QString, QString> supportedMimes();
 
     /**


### PR DESCRIPTION
Fix single band gray with alpha raster type not recognized. Fix for [issue # 4159](http://hub.qgis.org/issues/4159)

Also, add band color interpretation for WCS provider (from GDAL provider)
