### PR TITLE
Add pertinent example for 'LIKE' operator

### DIFF
--- a/resources/function_help/LIKE
+++ b/resources/function_help/LIKE
@@ -11,3 +11,5 @@ None
 <pre> 'A' LIKE 'A'  &rarr; returns 1 </pre>
 <pre> 'A' LIKE 'a'  &rarr; returns 0 </pre>
 <pre> 'A' LIKE 'B'  &rarr; returns 0 </pre>
+<pre> 'ABC' LIKE 'B'  &rarr; returns 0 </pre>
+<pre> 'ABC' LIKE '%B%'  &rarr; returns 1 </pre>


### PR DESCRIPTION
The usage examples for the 'LIKE' operator are not really pertinent. The proposed change adds an example that actually illustrates the usual usage of the 'LIKE' operator.

This is the same change as #2108 , but I don't know how to merge them on github.
