### PR TITLE
Add pertinent example for 'ILIKE' operator

### DIFF
--- a/resources/function_help/ILIKE
+++ b/resources/function_help/ILIKE
@@ -11,5 +11,6 @@ None
 <pre> 'A' ILIKE 'A'  &rarr; returns 1 </pre>
 <pre> 'A' ILIKE 'a'  &rarr; returns 1 </pre>
 <pre> 'A' ILIKE 'B'  &rarr; returns 0 </pre>
-<pre> 'ABC' LIKE 'B'  &rarr; returns 0 </pre>
-<pre> 'ABC' LIKE '%B%'  &rarr; returns 1 </pre>
+<pre> 'ABC' ILIKE 'b'  &rarr; returns 0 </pre>
+<pre> 'ABC' ILIKE '%b%'  &rarr; returns 1 </pre>
+<pre> 'ABC' ILIKE '%B%'  &rarr; returns 1 </pre>

--- a/resources/function_help/ILIKE
+++ b/resources/function_help/ILIKE
@@ -11,3 +11,5 @@ None
 <pre> 'A' ILIKE 'A'  &rarr; returns 1 </pre>
 <pre> 'A' ILIKE 'a'  &rarr; returns 1 </pre>
 <pre> 'A' ILIKE 'B'  &rarr; returns 0 </pre>
+<pre> 'ABC' LIKE 'B'  &rarr; returns 0 </pre>
+<pre> 'ABC' LIKE '%B%'  &rarr; returns 1 </pre>

--- a/resources/function_help/ILIKE
+++ b/resources/function_help/ILIKE
@@ -12,5 +12,6 @@ None
 <pre> 'A' ILIKE 'a'  &rarr; returns 1 </pre>
 <pre> 'A' ILIKE 'B'  &rarr; returns 0 </pre>
 <pre> 'ABC' ILIKE 'b'  &rarr; returns 0 </pre>
+<pre> 'ABC' ILIKE 'B'  &rarr; returns 0 </pre>
 <pre> 'ABC' ILIKE '%b%'  &rarr; returns 1 </pre>
 <pre> 'ABC' ILIKE '%B%'  &rarr; returns 1 </pre>


### PR DESCRIPTION
The usage examples for the 'ILIKE' operator are not really pertinent. The proposed change adds an example that actually illustrates the usual usage of the 'ILIKE' operator.

This is the same change as #2107, but I don't know how to merge them on github.
