### PR TITLE
Add GeoPackage/GPKG writable driver support

### DIFF
--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -2270,6 +2270,13 @@ bool QgsVectorFileWriter::driverMetadata( QString driverName, QString &longName,
     glob = "*.geojson";
     ext = "geojson";
   }
+  else if ( driverName.startsWith( "GPKG" ) )
+  {
+    longName = "GeoPackage";
+    trLongName = QObject::tr( "GeoPackage" );
+    glob = "*.gpkg";
+    ext = "gpkg";
+  }
   else if ( driverName.startsWith( "GeoRSS" ) )
   {
     longName = "GeoRSS";


### PR DESCRIPTION
Referring to this issue https://hub.qgis.org/issues/12187 and the short discussion on qgis-dev mailinglist, these seem to be the only changes needed to add GeoPackage/GPKG writable driver support to QGIS. Yay!
