### PR TITLE
[OSM] add two more tags to determine area of closed ways with highway / barrier

### DIFF
--- a/src/analysis/openstreetmap/qgsosmdatabase.cpp
+++ b/src/analysis/openstreetmap/qgsosmdatabase.cpp
@@ -476,7 +476,7 @@ void QgsOSMDatabase::exportSpatiaLiteWays( bool closed, const QString& tableName
     {
       // make sure tags that indicate areas are taken into consideration when deciding on a closed way is or isn't an area
       // and allow for a closed way to be exported both as a polygon and a line in case both area and non-area tags are present
-      if ( ( t.value( "area" ) != "yes" && !t.contains( "amenity" ) && !t.contains( "landuse" ) && !t.contains( "building" ) && !t.contains( "natural" ) ) || !closed )
+      if ( ( t.value( "area" ) != "yes" && !t.contains( "amenity" ) && !t.contains( "landuse" ) && !t.contains( "building" ) && !t.contains( "natural" ) && !t.contains( "leisure" ) && !t.contains( "aeroway" ) ) || !closed )
         isArea = false;
     }
 


### PR DESCRIPTION
See pull #2100 for the first set of improvements. This pull request adds two additional tags (leisure=\* and aeorway=_) to trigger an area when a closed way is also tagged with highway=_ or barrier=*

@wonder-sk , I should have added those in the earlier pull request, sorry for the noise this is causing :)
