### PR TITLE
[gui] sync layer right-click menu & composer legend item icons

### DIFF
--- a/images/images.qrc
+++ b/images/images.qrc
@@ -107,6 +107,7 @@
         <file>themes/default/mActionAddBasicShape.png</file>
         <file>themes/default/mActionAddGPSLayer.png</file>
         <file>themes/default/mActionAddGroup.png</file>
+        <file>themes/default/mActionAddGroup.svg</file>
         <file>themes/default/mActionAddHtml.png</file>
         <file>themes/default/mActionAddImage.png</file>
         <file>themes/default/mActionAddLegend.png</file>

--- a/images/themes/default/mActionAddGroup.svg
+++ b/images/themes/default/mActionAddGroup.svg
@@ -13,7 +13,7 @@
    height="16"
    width="16"
    inkscape:version="0.91+devel r"
-   sodipodi:docname="mActionFolder.svg">
+   sodipodi:docname="mActionAddGroup.svg">
   <sodipodi:namedview
      pagecolor="#ffffff"
      bordercolor="#666666"
@@ -27,9 +27,9 @@
      inkscape:window-height="876"
      id="namedview20"
      showgrid="true"
-     inkscape:zoom="39.333332"
-     inkscape:cx="10.374756"
-     inkscape:cy="6.6662709"
+     inkscape:zoom="9.8333331"
+     inkscape:cx="59.66801"
+     inkscape:cy="-11.884195"
      inkscape:window-x="51"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
@@ -64,7 +64,7 @@
      id="rect4012-9-8-9-0-6-4" />
   <path
      style="fill:none;fill-rule:evenodd;stroke:#415a75;stroke-width:0.26458335px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
-     d="m 1.9843547,1.5875036 4.06e-5,1.0583261 c 0.00603,0.1622428 0.524478,0.1760039 0.5291464,1.1e-5 l 0,-2.2303419 c 0,-0.30092221 -0.5291667,-0.28575163 -0.5291667,-1.449e-5 l 0,0.11368236"
+     d="m 1.9843547,1.5875 4.06e-5,1.0583261 c 0.00603,0.1622428 0.524478,0.1760075 0.5291464,1.46e-5 l 0,-2.2303419 c 0,-0.30092221 -0.5291667,-0.28575163 -0.5291667,-1.449e-5 l 0,0.11368236"
      id="path4199"
      inkscape:connector-curvature="0"
      sodipodi:nodetypes="cccccc" />
@@ -73,4 +73,39 @@
      d="m 0.3968752,2.5026501 0,1.3338083 1.5983331,0"
      id="path4210"
      inkscape:connector-curvature="0" />
+  <g
+     style="display:inline"
+     id="g3772"
+     transform="matrix(0.12211529,0,0,0.12211529,0.06106014,0.32564351)">
+    <rect
+       ry="2.6149368"
+       inkscape:export-ydpi="120"
+       inkscape:export-xdpi="120"
+       y="19"
+       x="19"
+       height="13"
+       width="13"
+       id="rect3563"
+       style="display:inline;fill:#5a8c5a;fill-opacity:1;stroke:#555753;stroke-width:0;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+       inkscape:export-filename="C:\Program Files\QGIS-Dev\themes\gis-0.1\mActionAddOgrLayer.png"
+       rx="2.6149371" />
+    <path
+       inkscape:connector-curvature="0"
+       style="display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:2.5999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 21.6,25.499999 7.8,0"
+       id="path3807"
+       sodipodi:nodetypes="cc" />
+    <path
+       inkscape:connector-curvature="0"
+       id="path3809"
+       d="M 25.5,29.399999 25.5,21.6"
+       style="display:inline;overflow:visible;visibility:visible;fill:#ffffff;fill-opacity:1;fill-rule:evenodd;stroke:#ffffff;stroke-width:2.5999999;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       sodipodi:nodetypes="cc" />
+    <path
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccsssc"
+       id="path6992"
+       d="m 20.3,25.499999 10.4,0 c 0,0 0,0 0,-2.6 C 30.7,20.3 30.05,20.3 25.5,20.3 c -4.55,0 -5.2,0 -5.2,2.599999 0,2.6 0,2.6 0,2.6 z"
+       style="display:inline;opacity:0.3;fill:#fcffff;fill-rule:evenodd;stroke:none;enable-background:new" />
+  </g>
 </svg>

--- a/images/themes/default/mActionDuplicateLayer.svg
+++ b/images/themes/default/mActionDuplicateLayer.svg
@@ -9,11 +9,11 @@
    xmlns="http://www.w3.org/2000/svg"
    xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
    xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
-   width="24"
-   height="24"
+   width="16"
+   height="16"
    id="svg5692"
    version="1.1"
-   inkscape:version="0.48.3.1 r9886"
+   inkscape:version="0.91+devel r"
    sodipodi:docname="mActionDuplicateLayer.svg"
    inkscape:export-filename="/home/denis/Desktop/duplicate-layer.png"
    inkscape:export-xdpi="90"
@@ -79,17 +79,17 @@
      borderopacity="1.0"
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
-     inkscape:zoom="22.539029"
-     inkscape:cx="9.1340686"
-     inkscape:cy="7.5938764"
+     inkscape:zoom="11.269514"
+     inkscape:cx="26.956058"
+     inkscape:cy="0.51009533"
      inkscape:current-layer="layer2"
      showgrid="true"
      inkscape:grid-bbox="true"
      inkscape:document-units="px"
      borderlayer="false"
-     inkscape:window-width="1920"
-     inkscape:window-height="1056"
-     inkscape:window-x="1920"
+     inkscape:window-width="1549"
+     inkscape:window-height="876"
+     inkscape:window-x="51"
      inkscape:window-y="24"
      inkscape:window-maximized="1"
      inkscape:snap-global="true"
@@ -105,8 +105,8 @@
        enabled="true"
        snapvisiblegridlinesonly="true"
        dotted="true"
-       originx="2.5px"
-       originy="2.5px" />
+       originx="0"
+       originy="0" />
   </sodipodi:namedview>
   <metadata
      id="metadata5697">
@@ -159,22 +159,22 @@
      id="layer2"
      inkscape:label="Layer"
      style="display:inline"
-     transform="translate(0,-8)">
+     transform="translate(0,-16)">
     <path
        sodipodi:nodetypes="ccccc"
        id="rect4012-3-0"
-       d="m 1.5,13.5 17,0 0,17 -17,0 0,-17 z"
-       style="fill:#a5a59b;fill-opacity:1;stroke:#5a5c58;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline;enable-background:new"
+       d="m 1.5,19.5 11,0 0,11 -11,0 0,-11 z"
+       style="display:inline;fill:#a5a59b;fill-opacity:1;stroke:#5a5c58;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
        inkscape:connector-curvature="0" />
     <path
        sodipodi:nodetypes="ccccc"
        id="rect4012-3"
-       d="m 4.5,10.5 17,0 0,17 -17,0 0,-17 z"
-       style="fill:#eeeeec;fill-opacity:1;stroke:#888a85;stroke-width:1;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline;enable-background:new"
+       d="m 3.5,17.5 11,0 0,11 -11,0 0,-11 z"
+       style="display:inline;fill:#eeeeec;fill-opacity:1;stroke:#888a85;stroke-width:0.99999994;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
        inkscape:connector-curvature="0" />
     <g
        id="g3001"
-       transform="matrix(0.69230769,0,0,0.69230769,1.8461539,9.8461539)">
+       transform="matrix(0.46153811,0,0,0.46153811,0.23077822,16.230778)">
       <rect
          ry="2.6149368"
          inkscape:export-ydpi="120"
@@ -184,7 +184,7 @@
          height="13"
          width="13"
          id="rect3563"
-         style="fill:#c4a000;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;display:inline"
+         style="display:inline;fill:#c4a000;fill-opacity:1;stroke:#000000;stroke-width:0;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
          inkscape:export-filename="C:\Program Files\QGIS-Dev\themes\gis-0.1\mActionAddOgrLayer.png"
          rx="2.6149371" />
       <path
@@ -192,15 +192,15 @@
          sodipodi:nodetypes="ccsssc"
          id="path6992"
          d="m 20.3,25.499999 10.4,0 c 0,0 0,0 0,-2.6 C 30.7,20.3 30.05,20.3 25.5,20.3 c -4.55,0 -5.2,0 -5.2,2.599999 0,2.6 0,2.6 0,2.6 z"
-         style="opacity:0.3;fill:#fcffff;fill-rule:evenodd;stroke:none;display:inline;enable-background:new" />
+         style="display:inline;opacity:0.3;fill:#fcffff;fill-rule:evenodd;stroke:none;enable-background:new" />
       <g
          transform="matrix(0.60271547,0,0,0.60365952,29.090173,29.540413)"
          id="text3831"
-         style="font-size:40px;font-style:normal;font-weight:normal;line-height:125%;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.49735793;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;font-family:Sans">
+         style="font-style:normal;font-weight:normal;font-size:40px;line-height:125%;font-family:Sans;letter-spacing:0px;word-spacing:0px;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.49735793;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1">
         <path
            inkscape:connector-curvature="0"
            id="path3836"
-           style="font-variant:normal;font-weight:bold;font-stretch:normal;fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.49735793;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;font-family:Century Schoolbook L;-inkscape-font-specification:Century Schoolbook L Bold"
+           style="font-variant:normal;font-weight:bold;font-stretch:normal;font-family:'Century Schoolbook L';-inkscape-font-specification:'Century Schoolbook L Bold';fill:#ffffff;fill-opacity:1;stroke:#ffffff;stroke-width:0.49735793;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
            d="m -6.4566626,-5.8131979 0,0.76 c 0,1.039999 -0.1600005,1.7600009 -0.64,2.68 -0.7199993,1.55999844 -0.8,1.7600006 -0.8,2.36 0,1.1599988 0.880001,2.12 1.92,2.12 1.0799989,0 1.92,-0.9600012 1.92,-2.16 0,-0.3999996 -0.1200003,-0.92000052 -0.4,-1.44 -0.9199991,-1.959998 -1,-2.2800013 -1,-3.56 l 0,-0.76 0.64,0.4 c 0.8399992,0.4799995 1.4800006,1.0400008 2.04,1.84 1.3199987,1.7999982 1.7600011,2.16 2.84,2.16 0.999999,0 1.8,-0.760001 1.8,-1.76 0,-1.2399988 -1.04000156,-2.1600001 -2.6,-2.28 -1.959998,-0.1199999 -2.3200012,-0.2000007 -3.56,-0.88 l -0.64,-0.36 0.64,-0.36 c 0.9199991,-0.5199995 1.600001,-0.76 2.64,-0.8 1.5999984,-0.1599998 1.72000048,-0.1600002 2.2,-0.36 0.7999992,-0.3999996 1.32,-1.1200008 1.32,-1.9600001 0,-1.039999 -0.840001,-1.84 -1.88,-1.84 -0.87999912,0 -1.6000006,0.440001 -2.24,1.4 -1.1199989,1.6799984 -1.3600012,1.9200008 -2.56,2.6400001 l -0.64,0.4 0,-0.76 c 0,-0.999999 0.1600005,-1.7600011 0.64,-2.6800001 0.7599992,-1.599998 0.8,-1.76 0.8,-2.32 0,-1.199999 -0.8800011,-2.16 -1.96,-2.16 -1.039999,0 -1.92,0.960001 -1.92,2.12 0,0.44 0.1200003,0.960001 0.4,1.48 0.959999,1.9999981 1.04,2.2800014 1.04,3.5600001 l 0,0.76 -0.64,-0.4 c -0.9199991,-0.5199995 -1.4400006,-1.0400008 -2.04,-1.88 -0.7999992,-1.1999991 -0.8000003,-1.2000001 -1.1200004,-1.5200001 -0.439999,-0.399999 -1.08,-0.64 -1.6,-0.64 -1.079999,0 -1.92,0.840001 -1.92,1.84 0,1.2399989 1.000002,2.1200002 2.56,2.2400001 2.0399984,0.1199999 2.3600016,0.2000007 3.6000004,0.88 l 0.64,0.36 -0.64,0.4 c -0.8399992,0.4799995 -1.640001,0.7200001 -2.6400004,0.8 -1.559998,0.08 -1.68,0.1200002 -2.2,0.32 -0.799999,0.3599996 -1.32,1.1200008 -1.32,1.96 0,0.999999 0.840001,1.84 1.88,1.84 0.88,0 1.640001,-0.4800009 2.2400004,-1.4 1.0799989,-1.5999984 1.4000012,-1.9600007 2.56,-2.64 l 0.64,-0.4" />
       </g>
     </g>

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2480,7 +2480,7 @@ void QgisApp::initLayerTreeView()
 
   // add group action
   QAction* actionAddGroup = new QAction( tr( "Add Group" ), this );
-  actionAddGroup->setIcon( QgsApplication::getThemeIcon( "/mActionFolder.svg" ) );
+  actionAddGroup->setIcon( QgsApplication::getThemeIcon( "/mActionAddGroup.svg" ) );
   actionAddGroup->setToolTip( tr( "Add Group" ) );
   connect( actionAddGroup, SIGNAL( triggered( bool ) ), mLayerTreeView->defaultActions(), SLOT( addGroup() ) );
 

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -34,8 +34,8 @@ QMenu* QgsAppLayerTreeViewMenuProvider::createContextMenu()
     // global menu
     menu->addAction( actions->actionAddGroup( menu ) );
 
-    menu->addAction( QgsApplication::getThemeIcon( "/mActionExpandTree.png" ), tr( "&Expand All" ), mView, SLOT( expandAll() ) );
-    menu->addAction( QgsApplication::getThemeIcon( "/mActionCollapseTree.png" ), tr( "&Collapse All" ), mView, SLOT( collapseAll() ) );
+    menu->addAction( QgsApplication::getThemeIcon( "/mActionExpandTree.svg" ), tr( "&Expand All" ), mView, SLOT( expandAll() ) );
+    menu->addAction( QgsApplication::getThemeIcon( "/mActionCollapseTree.svg" ), tr( "&Collapse All" ), mView, SLOT( collapseAll() ) );
 
     // TODO: update drawing order
   }

--- a/src/gui/layertree/qgslayertreeviewdefaultactions.cpp
+++ b/src/gui/layertree/qgslayertreeviewdefaultactions.cpp
@@ -33,7 +33,7 @@ QgsLayerTreeViewDefaultActions::QgsLayerTreeViewDefaultActions( QgsLayerTreeView
 
 QAction* QgsLayerTreeViewDefaultActions::actionAddGroup( QObject* parent )
 {
-  QAction* a = new QAction( QgsApplication::getThemeIcon( "/mActionFolder.png" ), tr( "&Add Group" ), parent );
+  QAction* a = new QAction( QgsApplication::getThemeIcon( "/mActionAddGroup.svg" ), tr( "&Add Group" ), parent );
   connect( a, SIGNAL( triggered() ), this, SLOT( addGroup() ) );
   return a;
 }

--- a/src/ui/qgscomposerlegendwidgetbase.ui
+++ b/src/ui/qgscomposerlegendwidgetbase.ui
@@ -279,7 +279,13 @@
               </property>
               <property name="icon">
                <iconset resource="../../images/images.qrc">
-                <normaloff>:/images/themes/default/mActionAddGroup.png</normaloff>:/images/themes/default/mActionAddGroup.png</iconset>
+                <normaloff>:/images/themes/default/mActionAddGroup.svg</normaloff>:/images/themes/default/mActionAddGroup.svg</iconset>
+              </property>
+              <property name="iconSize">
+               <size>
+                <width>20</width>
+                <height>20</height>
+               </size>
               </property>
              </widget>
             </item>
@@ -367,7 +373,7 @@
               </property>
               <property name="icon">
                <iconset resource="../../images/images.qrc">
-                <normaloff>:/images/themes/default/mActionFilter.png</normaloff>:/images/themes/default/mActionFilter.png</iconset>
+                <normaloff>:/images/themes/default/mActionFilter2.svg</normaloff>:/images/themes/default/mActionFilter2.svg</iconset>
               </property>
               <property name="iconSize">
                <size>


### PR DESCRIPTION
This pull request does the following:
- update the composer legend item panel's filter button 
- fix size of the composer legend item panel's add group button and make use of refreshed icon
- update the layer panel's right-click menu items to make use of refreshed icons
- add a [+] green box to the layer panel's add group button (this harmonizes the action icon for the composer legend item and the layer panel)
