### PR TITLE
fix NULL field in size expression beeing drawn

### DIFF
--- a/python/core/qgsscaleexpression.sip
+++ b/python/core/qgsscaleexpression.sip
@@ -35,8 +35,9 @@ class QgsScaleExpression : QgsExpression
      * @param maxValue maximum value, corresponds to specified maximum size
      * @param minSize minimum size
      * @param maxSize maximum size
+     * @param nullSize size in case expression evaluates to NULL
      */
-    QgsScaleExpression( Type type, const QString& baseExpression, double minValue, double maxValue, double minSize, double maxSize );
+    QgsScaleExpression( Type type, const QString& baseExpression, double minValue, double maxValue, double minSize, double maxSize, double nullSize = 0 );
 
     operator bool() const;
 
@@ -67,6 +68,11 @@ class QgsScaleExpression : QgsExpression
      * @see minValue
      */
     double maxValue() const;
+
+    /** Returns the size value when expression evaluates to NULL.
+     * @see nullSize
+     */
+    double nullSize() const;
 
     /** Returns the base expression string (or field reference) used for
      * calculating the values to be mapped to a size.

--- a/src/core/qgsscaleexpression.h
+++ b/src/core/qgsscaleexpression.h
@@ -51,8 +51,9 @@ class CORE_EXPORT QgsScaleExpression : public QgsExpression
      * @param maxValue maximum value, corresponds to specified maximum size
      * @param minSize minimum size
      * @param maxSize maximum size
+     * @param nullSize size in case expression evaluates to NULL
      */
-    QgsScaleExpression( Type type, const QString& baseExpression, double minValue, double maxValue, double minSize, double maxSize );
+    QgsScaleExpression( Type type, const QString& baseExpression, double minValue, double maxValue, double minSize, double maxSize, double nullSize = 0 );
 
     operator bool() const { return ! mExpression.isEmpty(); }
 
@@ -84,6 +85,11 @@ class CORE_EXPORT QgsScaleExpression : public QgsExpression
      */
     double maxValue() const { return mMaxValue; }
 
+    /** Returns the size value when expression evaluates to NULL.
+     * @see nullSize
+     */
+    double nullSize() const { return mNullSize; }
+
     /** Returns the base expression string (or field reference) used for
      * calculating the values to be mapped to a size.
      */
@@ -101,9 +107,10 @@ class CORE_EXPORT QgsScaleExpression : public QgsExpression
     double mMaxSize;
     double mMinValue;
     double mMaxValue;
+    double mNullSize;
 
     void init();
-    static QString createExpression( Type type, const QString& baseExpr, double minValue, double maxValue, double minSize, double maxSize );
+    static QString createExpression( Type type, const QString& baseExpr, double minValue, double maxValue, double minSize, double maxSize, double nullSize );
 
 };
 

--- a/src/gui/symbology-ng/qgssizescalewidget.cpp
+++ b/src/gui/symbology-ng/qgssizescalewidget.cpp
@@ -73,6 +73,7 @@ void QgsSizeScaleWidget::setFromSymbol()
     maxValueSpinBox->setValue( expr.maxValue() );
     minSizeSpinBox->setValue( expr.minSize() );
     maxSizeSpinBox->setValue( expr.maxSize() );
+    nullSizeSpinBox->setValue( expr.nullSize() );
   }
   updatePreview();
 }
@@ -113,6 +114,7 @@ QgsSizeScaleWidget::QgsSizeScaleWidget( const QgsVectorLayer * layer, const QgsM
   maxSizeSpinBox->setShowClearButton( false );
   minValueSpinBox->setShowClearButton( false );
   maxValueSpinBox->setShowClearButton( false );
+  nullSizeSpinBox->setShowClearButton( false );
 
   // setup ui from expression if any
   setFromSymbol();
@@ -121,6 +123,7 @@ QgsSizeScaleWidget::QgsSizeScaleWidget( const QgsVectorLayer * layer, const QgsM
   connect( maxSizeSpinBox, SIGNAL( valueChanged( double ) ), this, SLOT( updatePreview() ) );
   connect( minValueSpinBox, SIGNAL( valueChanged( double ) ), this, SLOT( updatePreview() ) );
   connect( maxValueSpinBox, SIGNAL( valueChanged( double ) ), this, SLOT( updatePreview() ) );
+  connect( nullSizeSpinBox, SIGNAL( valueChanged( double ) ), this, SLOT( updatePreview() ) );
   //potentially very expensive for large layers:
   connect( mExpressionWidget, SIGNAL( fieldChanged( QString ) ), this, SLOT( computeFromLayerTriggered() ) );
   connect( scaleMethodComboBox, SIGNAL( currentIndexChanged( int ) ), this, SLOT( updatePreview() ) );
@@ -144,7 +147,8 @@ QgsScaleExpression *QgsSizeScaleWidget::createExpression() const
                                  minValueSpinBox->value(),
                                  maxValueSpinBox->value(),
                                  minSizeSpinBox->value(),
-                                 maxSizeSpinBox->value() );
+                                 maxSizeSpinBox->value(),
+                                 nullSizeSpinBox->value() );
 }
 
 void QgsSizeScaleWidget::updatePreview()

--- a/src/ui/symbollayer/widget_size_scale.ui
+++ b/src/ui/symbollayer/widget_size_scale.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>576</width>
+    <width>644</width>
     <height>343</height>
    </rect>
   </property>
@@ -14,7 +14,7 @@
    <string>Dialog</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
-   <item row="0" column="0">
+   <item row="0" column="1">
     <layout class="QGridLayout" name="gridLayout">
      <item row="0" column="0">
       <widget class="QLabel" name="label_2">
@@ -150,10 +150,7 @@
      </item>
     </layout>
    </item>
-   <item row="0" column="1" rowspan="2">
-    <widget class="QTreeView" name="treeView"/>
-   </item>
-   <item row="1" column="0">
+   <item row="1" column="1">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -166,7 +163,10 @@
      </property>
     </spacer>
    </item>
-   <item row="2" column="0" colspan="2">
+   <item row="0" column="2" rowspan="2">
+    <widget class="QTreeView" name="treeView"/>
+   </item>
+   <item row="6" column="1" colspan="2">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -175,6 +175,37 @@
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
+   </item>
+   <item row="2" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout_3">
+     <item>
+      <widget class="QLabel" name="label_8">
+       <property name="text">
+        <string>Size when field is NULL</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QgsDoubleSpinBox" name="nullSizeSpinBox">
+       <property name="singleStep">
+        <double>0.100000000000000</double>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
    </item>
   </layout>
  </widget>

--- a/tests/src/core/testqgsscaleexpression.cpp
+++ b/tests/src/core/testqgsscaleexpression.cpp
@@ -30,6 +30,26 @@ class TestQgsScaleExpression: public QObject
     void parsing()
     {
       {
+        QgsScaleExpression exp( "coalesce(scale_linear(column, 1, 7, 2, 10), 0)" );
+        QCOMPARE( bool( exp ), true );
+        QCOMPARE( exp.type(), QgsScaleExpression::Linear );
+        QCOMPARE( exp.baseExpression(), QString( "column" ) );
+        QCOMPARE( exp.minValue(), 1. );
+        QCOMPARE( exp.maxValue(), 7. );
+        QCOMPARE( exp.minSize(), 2. );
+        QCOMPARE( exp.maxSize(), 10. );
+      }
+      {
+        QgsScaleExpression exp( "coalesce(scale_exp(column, 1, 7, 2, 10, 0.5), 0)" );
+        QCOMPARE( bool( exp ), true );
+        QCOMPARE( exp.type(), QgsScaleExpression::Area );
+      }
+      {
+        QgsScaleExpression exp( "coalesce(scale_exp(column, 1, 7, 2, 10, 0.57), 0)" );
+        QCOMPARE( bool( exp ), true );
+        QCOMPARE( exp.type(), QgsScaleExpression::Flannery );
+      }
+      {
         QgsScaleExpression exp( "scale_linear(column, 1, 7, 2, 10)" );
         QCOMPARE( bool( exp ), true );
         QCOMPARE( exp.type(), QgsScaleExpression::Linear );
@@ -50,17 +70,17 @@ class TestQgsScaleExpression: public QObject
         QCOMPARE( exp.type(), QgsScaleExpression::Flannery );
       }
       {
-        QgsScaleExpression exp( "scale_exp(column, 1, 7, 2, 10, 0.51)" );
+        QgsScaleExpression exp( "coalesce(scale_exp(column, 1, 7, 2, 10, 0.51), 0)" );
         QCOMPARE( bool( exp ), false );
         QCOMPARE( exp.type(), QgsScaleExpression::Unknown );
       }
       {
-        QgsScaleExpression exp( "scale_exp(column, 1, 7, a, 10, 0.5)" );
+        QgsScaleExpression exp( "coalesce(scale_exp(column, 1, 7, a, 10, 0.5), 0)" );
         QCOMPARE( bool( exp ), false );
         QCOMPARE( exp.type(), QgsScaleExpression::Unknown );
       }
       {
-        QgsScaleExpression exp( "scale_exp(column, 1, 7)" );
+        QgsScaleExpression exp( "coalesce(scale_exp(column, 1, 7), 0)" );
         QCOMPARE( bool( exp ), false );
         QCOMPARE( exp.type(), QgsScaleExpression::Unknown );
       }


### PR DESCRIPTION
the expression generated by the assistant was causing symbol with size
expr evaluated to NULL to be drawn with default size, wich is not what
the default should be.

The generated size expression is now composed with coalesce(...,0)
so the symbol is not drawn when the size expression is NULL

The expression is still recognized without the coalesce to allow the
legend to be drawn even in the absence of coalesce: this can be used
to have the default size for NULL expression and use a conditional expr
fro color to highlight symbols where value is NULL.
