### PR TITLE
Add QgsExpressionBuilderWidget::loadFieldsAndValues

### DIFF
--- a/python/gui/qgsexpressionbuilderwidget.sip
+++ b/python/gui/qgsexpressionbuilderwidget.sip
@@ -84,6 +84,11 @@ class QgsExpressionBuilderWidget : QWidget
 
     void loadFieldNames( const QgsFields& fields );
 
+    /** Loads field names and values from the specified map.
+     *  @note The field values must be quoted appropriately if they are strings.
+     */
+    void loadFieldsAndValues(const QMap<QString, QStringList>& fieldValues );
+
     /** Sets geometry calculator used in distance/area calculations. */
     void setGeomCalculator( const QgsDistanceArea & da );
 

--- a/src/gui/qgsexpressionbuilderwidget.h
+++ b/src/gui/qgsexpressionbuilderwidget.h
@@ -123,6 +123,11 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
 
     void loadFieldNames( const QgsFields& fields );
 
+    /** Loads field names and values from the specified map.
+     *  @note The field values must be quoted appropriately if they are strings.
+     */
+    void loadFieldsAndValues( const QMap<QString, QStringList>& fieldValues );
+
     /** Sets geometry calculator used in distance/area calculations. */
     void setGeomCalculator( const QgsDistanceArea & da );
 
@@ -200,7 +205,7 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
   private:
     void runPythonCode( QString code );
     void updateFunctionTree();
-    void fillFieldValues( int fieldIndex, int countLimit );
+    void fillFieldValues( const QString &fieldName, int countLimit );
     QString loadFunctionHelp( QgsExpressionItem* functionName );
 
     /** Formats an expression preview result for display in the widget
@@ -219,6 +224,7 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
     bool mExpressionValid;
     QgsDistanceArea mDa;
     QString mRecentKey;
+    QMap<QString, QStringList> mFieldValues;
 
 };
 


### PR DESCRIPTION
This pull requests adds the possibility to populate the QgsExpressionBuilderWidget with fields values.
A possible use case is a plugin which caches WFS values and then allows users to use these values when constructing a filter expression.
An additional effect of this pull request is that, for data sources which support value queries, the fetched values are cached, i.e. don't need to be fetched again when switching field.

Funded by NIWA
