### PR TITLE
Update vertex size spinbox step in editing mode

### DIFF
--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -3837,7 +3837,7 @@
                      <number>3</number>
                     </property>
                     <property name="singleStep">
-                     <number>2</number>
+                     <number>1</number>
                     </property>
                    </widget>
                   </item>


### PR DESCRIPTION
fixes #12943

Set the step of vertex marker size spinbox in Settings menu > Options > Digitizing to 1 instead of 2
