### PR TITLE
Oriented Minimum Bounding Box - processing version as requested #2116

### DIFF
--- a/python/plugins/processing/algs/qgis/OrientedMinimumBoundingBox.py
+++ b/python/plugins/processing/algs/qgis/OrientedMinimumBoundingBox.py
@@ -1,0 +1,182 @@
+# -*- coding: utf-8 -*-
+
+"""
+***************************************************************************
+    OrientedMinimumBoundingBox.py
+    ---------------------
+    Date                 : June 2015
+    Copyright            : (C) 2015, Loïc BARTOLETTI
+    Email                : coder at tuxfamily dot org
+***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************
+"""
+
+__author__ = 'Loïc BARTOLETTI'
+__date__ = 'June 2015'
+__copyright__ = '(C) 2015, Loïc BARTOLETTI'
+
+# This will get replaced with a git SHA1 when you do a git archive
+
+__revision__ = '$Format:%H$'
+
+from PyQt4.QtCore import QVariant
+from qgis.core import QGis, QgsField, QgsPoint, QgsGeometry, QgsFeature
+from processing.core.GeoAlgorithm import GeoAlgorithm
+from processing.core.parameters import ParameterVector
+from processing.core.parameters import ParameterBoolean
+from processing.core.outputs import OutputVector
+from processing.tools import dataobjects, vector
+from math import *
+
+
+
+class OrientedMinimumBoundingBox(GeoAlgorithm):
+
+    INPUT_LAYER = 'INPUT_LAYER'
+    BY_FEATURE = 'BY_FEATURE'
+
+    OUTPUT = 'OUTPUT'
+
+    def defineCharacteristics(self):
+        self.name = 'Oriented Minimum Bounding Box'
+        self.group = 'Vector general tools'
+
+        self.addParameter(ParameterVector(self.INPUT_LAYER,
+            self.tr('Input layer'), [ParameterVector.VECTOR_TYPE_ANY]))
+        self.addParameter(ParameterBoolean(self.BY_FEATURE,
+            self.tr('Calculate OMBB for each feature separately'), True))
+
+        self.addOutput(OutputVector(self.OUTPUT, self.tr('Oriented_MBBox')))
+
+    def processAlgorithm(self, progress):
+        layer = dataobjects.getObjectFromUri(
+            self.getParameterValue(self.INPUT_LAYER))
+        byFeature = self.getParameterValue(self.BY_FEATURE)
+        
+        if byFeature and layer.geometryType() == 0:
+            progress.setInfo(self.tr("Can't calculate an OMBB for each point, it's a point."))
+            byFeature = False
+            
+        fields = [ 
+            QgsField('AREA', QVariant.Double),
+            QgsField('ANGLE', QVariant.Double),
+            QgsField('PERIMETER', QVariant.Double),
+            QgsField('WIDTH', QVariant.Double),
+            QgsField('HEIGHT', QVariant.Double),
+        ]
+
+        writer = self.getOutputFromName(self.OUTPUT).getVectorWriter(fields,
+                QGis.WKBPolygon, layer.crs())
+
+        if byFeature:
+            self.featureOmbb(layer, writer, progress)
+        else:
+            self.layerOmmb(layer, writer, progress)
+
+        del writer
+
+    def layerOmmb(self, layer, writer, progress):
+        current = 0
+        vprovider = layer.dataProvider()
+
+        fit = vprovider.getFeatures()
+        inFeat = QgsFeature()
+        total = 100.0 / float(vprovider.featureCount())
+        newgeometry = QgsGeometry()
+        first = True
+        while fit.nextFeature(inFeat):
+            if first:
+                newgeometry = QgsGeometry(inFeat.geometry())
+                first = False
+            else:
+                newgeometry = newgeometry.combine(inFeat.geometry())
+            current += 1
+            progress.setPercentage(int(current * total))
+
+        geometry, area, perim, angle, width, height = self.OMBBox(newgeometry)
+
+        if geometry:
+            outFeat = QgsFeature()
+
+            outFeat.setGeometry(geometry)
+            outFeat.setAttributes([ area,
+                                    perim,
+                                    angle,
+                                    width,
+                                    height])
+            writer.addFeature(outFeat)
+
+    def featureOmbb(self, layer, writer, progress):
+        current = 0
+        features = vector.features(layer)
+        total = 100.0 / float(len(features))
+        outFeat = QgsFeature()
+        inFeat = QgsFeature()
+        for inFeat in features:
+            geometry, area, perim, angle, width, height = self.OMBBox(
+                    inFeat.geometry())
+            if geometry:
+                outFeat.setGeometry(geometry)
+                outFeat.setAttributes([ area,
+                                        perim,
+                                        angle,
+                                        width,
+                                        height])
+                writer.addFeature(outFeat)
+            else:
+                progress.setInfo(self.tr("Can't calculate an OMBB for features n°") + str(inFeat.id()) + ".")
+            current += 1
+            progress.setPercentage(int(current * total))
+            
+    def GetAngleOfLineBetweenTwoPoints(self, p1, p2, angle_unit="degrees"):
+        xDiff = p2.x() - p1.x()
+        yDiff = p2.y() - p1.y()
+        if angle_unit == "radians":
+            return atan2(yDiff, xDiff)
+        else:
+            return degrees(atan2(yDiff, xDiff))
+        
+    def OMBBox(self, geom):
+
+        g = geom.convexHull()
+        
+        if g.type() != 2:
+            return None, None, None, None, None, None
+        r = g.asPolygon()[0]
+
+        p0 = QgsPoint(r[0][0], r[0][1])
+
+        i = 0
+        l = len(r)
+        OMBBox = QgsGeometry()
+        gBBox = g.boundingBox()
+        OMBBox_area = gBBox.height() * gBBox.width()
+        OMBBox_angle = 0
+        OMBBox_width = 0
+        OMBBox_heigth = 0
+        OMBBox_perim = 0
+        while i < l - 1:
+            x = QgsGeometry(g)
+            angle = self.GetAngleOfLineBetweenTwoPoints(r[i], r[i + 1])
+            x.rotate(angle, p0)
+            bbox = x.boundingBox()
+            bb = QgsGeometry.fromWkt(bbox.asWktPolygon())
+            bb.rotate(-angle, p0)
+
+            a = bb.area()
+            if a <= OMBBox_area:
+                OMBBox = QgsGeometry(bb)
+                OMBBox_area = a
+                OMBBox_angle = angle
+                OMBBox_width = bbox.width()
+                OMBBox_heigth = bbox.height()
+                OMBBox_perim = 2 * OMBBox_width + 2 * OMBBox_heigth
+            i += 1
+
+        return OMBBox, OMBBox_area, OMBBox_perim, OMBBox_angle, OMBBox_width, OMBBox_heigth

--- a/python/plugins/processing/algs/qgis/OrientedMinimumBoundingBox.py
+++ b/python/plugins/processing/algs/qgis/OrientedMinimumBoundingBox.py
@@ -65,8 +65,8 @@ class OrientedMinimumBoundingBox(GeoAlgorithm):
             
         fields = [ 
             QgsField('AREA', QVariant.Double),
-            QgsField('ANGLE', QVariant.Double),
             QgsField('PERIMETER', QVariant.Double),
+            QgsField('ANGLE', QVariant.Double),
             QgsField('WIDTH', QVariant.Double),
             QgsField('HEIGHT', QVariant.Double),
         ]

--- a/python/plugins/processing/algs/qgis/QGISAlgorithmProvider.py
+++ b/python/plugins/processing/algs/qgis/QGISAlgorithmProvider.py
@@ -130,6 +130,7 @@ from SplitLinesWithLines import SplitLinesWithLines
 from FieldsMapper import FieldsMapper
 from Datasources2Vrt import Datasources2Vrt
 from CheckValidity import CheckValidity
+from OrientedMinimumBoundingBox import OrientedMinimumBoundingBox
 
 pluginPath = os.path.normpath(os.path.join(
     os.path.split(os.path.dirname(__file__))[0], os.pardir))
@@ -178,7 +179,7 @@ class QGISAlgorithmProvider(AlgorithmProvider):
                         SelectByExpression(), HypsometricCurves(),
                         SplitLinesWithLines(), CreateConstantRaster(),
                         FieldsMapper(),SelectByAttributeSum(), Datasources2Vrt(),
-                        CheckValidity()
+                        CheckValidity(), OrientedMinimumBoundingBox()
                         ]
 
         if hasMatplotlib:


### PR DESCRIPTION
## As requested, a new version of the tools for processing.

Hello,

Instead of write a new plugins for this function, I suggest an add into fTools. Today, we can only compute Minimum Bounding Box (Extent) from a Layer or a Feature. I implemented rotating calipers algorithm for return Oriented Minimum Bounding Box.

You can compute OMBB for:

```
Whole layer
Distinct for each features

(Selected features options are removed into processing version)
```

Regards.
