### PR TITLE
[composer] save and restore font family styles (fix #12644)

### DIFF
--- a/src/core/composer/qgscomposerlabel.cpp
+++ b/src/core/composer/qgscomposerlabel.cpp
@@ -19,6 +19,7 @@
 #include "qgscomposition.h"
 #include "qgscomposerutils.h"
 #include "qgsexpression.h"
+#include "qgsfontutils.h"
 #include "qgsnetworkaccessmanager.h"
 #include "qgscomposermodel.h"
 #include "qgsvectorlayer.h"
@@ -379,8 +380,10 @@ bool QgsComposerLabel::writeXML( QDomElement& elem, QDomDocument & doc ) const
   composerLabelElem.setAttribute( "valign", mVAlignment );
 
   //font
+  QFontInfo fi = QFontInfo( mFont );
   QDomElement labelFontElem = doc.createElement( "LabelFont" );
   labelFontElem.setAttribute( "description", mFont.toString() );
+  labelFontElem.setAttribute( "style", fi.styleName() );
   composerLabelElem.appendChild( labelFontElem );
 
   //font color
@@ -436,6 +439,7 @@ bool QgsComposerLabel::readXML( const QDomElement& itemElem, const QDomDocument&
   {
     QDomElement labelFontElem = labelFontList.at( 0 ).toElement();
     mFont.fromString( labelFontElem.attribute( "description" ) );
+    QgsFontUtils::updateFontViaStyle( mFont, labelFontElem.attribute( "style" ) );
   }
 
   //font color

--- a/src/core/composer/qgscomposerlegendstyle.cpp
+++ b/src/core/composer/qgscomposerlegendstyle.cpp
@@ -17,6 +17,7 @@
 
 #include "qgscomposerlegendstyle.h"
 #include "qgscomposition.h"
+#include "qgsfontutils.h"
 #include <QFont>
 #include <QMap>
 #include <QSettings>
@@ -61,7 +62,9 @@ void QgsComposerLegendStyle::writeXML( QString name, QDomElement& elem, QDomDocu
   if ( mMarginMap[Left] != 0 ) styleElem.setAttribute( "marginLeft", QString::number( mMarginMap[Left] ) );
   if ( mMarginMap[Right] != 0 ) styleElem.setAttribute( "marginRight", QString::number( mMarginMap[Right] ) );
 
+  QFontInfo fi = QFontInfo( mFont );
   styleElem.setAttribute( "font", mFont.toString() );
+  styleElem.setAttribute( "fontStyle", fi.styleName() );
 
   elem.appendChild( styleElem );
 }
@@ -72,6 +75,7 @@ void QgsComposerLegendStyle::readXML( const QDomElement& elem, const QDomDocumen
   if ( elem.isNull() ) return;
 
   mFont.fromString( elem.attribute( "font" ) );
+  QgsFontUtils::updateFontViaStyle( mFont, elem.attribute( "fontStyle" ) );
 
   mMarginMap[Top] = elem.attribute( "marginTop", "0" ).toDouble();
   mMarginMap[Bottom] = elem.attribute( "marginBottom", "0" ).toDouble();

--- a/src/core/composer/qgscomposermapgrid.cpp
+++ b/src/core/composer/qgscomposermapgrid.cpp
@@ -21,6 +21,7 @@
 #include "qgsgeometry.h"
 #include "qgscomposermap.h"
 #include "qgscomposition.h"
+#include "qgsfontutils.h"
 #include "qgsmaprenderer.h"
 #include "qgsrendercontext.h"
 #include "qgssymbollayerv2utils.h"
@@ -308,11 +309,15 @@ bool QgsComposerMapGrid::writeXML( QDomElement& elem, QDomDocument& doc ) const
   mapGridElem.setAttribute( "topAnnotationDirection", mTopGridAnnotationDirection );
   mapGridElem.setAttribute( "bottomAnnotationDirection", mBottomGridAnnotationDirection );
   mapGridElem.setAttribute( "frameAnnotationDistance", QString::number( mAnnotationFrameDistance ) );
-  mapGridElem.setAttribute( "annotationFont", mGridAnnotationFont.toString() );
-  mapGridElem.setAttribute( "annotationFontColor", QgsSymbolLayerV2Utils::encodeColor( mGridAnnotationFontColor ) );
   mapGridElem.setAttribute( "annotationPrecision", mGridAnnotationPrecision );
   mapGridElem.setAttribute( "unit", mGridUnit );
   mapGridElem.setAttribute( "blendMode", mBlendMode );
+  
+  //font
+  QFontInfo fi = QFontInfo( mGridAnnotationFont );
+  mapGridElem.setAttribute( "annotationFont", mGridAnnotationFont.toString() );
+  mapGridElem.setAttribute( "annotationFontStyle", fi.styleName() );
+  mapGridElem.setAttribute( "annotationFontColor", QgsSymbolLayerV2Utils::encodeColor( mGridAnnotationFontColor ) );
 
   bool ok = QgsComposerMapItem::writeXML( mapGridElem, doc );
   elem.appendChild( mapGridElem );
@@ -428,8 +433,9 @@ bool QgsComposerMapGrid::readXML( const QDomElement& itemElem, const QDomDocumen
   mRightGridAnnotationDirection = QgsComposerMapGrid::AnnotationDirection( itemElem.attribute( "rightAnnotationDirection", "0" ).toInt() );
   mTopGridAnnotationDirection = QgsComposerMapGrid::AnnotationDirection( itemElem.attribute( "topAnnotationDirection", "0" ).toInt() );
   mBottomGridAnnotationDirection = QgsComposerMapGrid::AnnotationDirection( itemElem.attribute( "bottomAnnotationDirection", "0" ).toInt() );
-  mAnnotationFrameDistance = itemElem.attribute( "frameAnnotationDistance", "0" ).toDouble();
+  mAnnotationFrameDistance = itemElem.attribute( "frameAnnotationDistance", "0" ).toDouble(); 
   mGridAnnotationFont.fromString( itemElem.attribute( "annotationFont", "" ) );
+  QgsFontUtils::updateFontViaStyle( mGridAnnotationFont, itemElem.attribute( "annotationFontStyle" ) );
   mGridAnnotationFontColor = QgsSymbolLayerV2Utils::decodeColor( itemElem.attribute( "annotationFontColor", "0,0,0,255" ) );
   mGridAnnotationPrecision = itemElem.attribute( "annotationPrecision", "3" ).toInt();
   int gridUnitInt =  itemElem.attribute( "unit", QString::number( MapUnit ) ).toInt();

--- a/src/core/composer/qgscomposerscalebar.cpp
+++ b/src/core/composer/qgscomposerscalebar.cpp
@@ -21,6 +21,7 @@
 #include "qgsdistancearea.h"
 #include "qgsscalebarstyle.h"
 #include "qgsdoubleboxscalebarstyle.h"
+#include "qgsfontutils.h"
 #include "qgsmaprenderer.h"
 #include "qgsnumericscalebarstyle.h"
 #include "qgssingleboxscalebarstyle.h"
@@ -668,13 +669,17 @@ bool QgsComposerScaleBar::writeXML( QDomElement& elem, QDomDocument & doc ) cons
   composerScaleBarElem.setAttribute( "maxBarWidth", mMaxBarWidth );
   composerScaleBarElem.setAttribute( "segmentMillimeters", QString::number( mSegmentMillimeters ) );
   composerScaleBarElem.setAttribute( "numMapUnitsPerScaleBarUnit", QString::number( mNumMapUnitsPerScaleBarUnit ) );
-  composerScaleBarElem.setAttribute( "font", mFont.toString() );
   composerScaleBarElem.setAttribute( "outlineWidth", QString::number( mPen.widthF() ) );
   composerScaleBarElem.setAttribute( "unitLabel", mUnitLabeling );
   composerScaleBarElem.setAttribute( "units", mUnits );
   composerScaleBarElem.setAttribute( "lineJoinStyle", QgsSymbolLayerV2Utils::encodePenJoinStyle( mLineJoinStyle ) );
   composerScaleBarElem.setAttribute( "lineCapStyle", QgsSymbolLayerV2Utils::encodePenCapStyle( mLineCapStyle ) );
 
+  //font
+  QFontInfo fi = QFontInfo( mFont );
+  composerScaleBarElem.setAttribute( "font", mFont.toString() );
+  composerScaleBarElem.setAttribute( "fontStyle", fi.styleName() );
+  
   //style
   if ( mStyle )
   {
@@ -759,8 +764,8 @@ bool QgsComposerScaleBar::readXML( const QDomElement& itemElem, const QDomDocume
   if ( !fontString.isEmpty() )
   {
     mFont.fromString( fontString );
+    QgsFontUtils::updateFontViaStyle( mFont, itemElem.attribute( "fontStyle" ) );
   }
-
   //colors
   //fill color
   QDomNodeList fillColorList = itemElem.elementsByTagName( "fillColor" );

--- a/src/core/composer/qgscomposertable.cpp
+++ b/src/core/composer/qgscomposertable.cpp
@@ -19,6 +19,7 @@
 #include "qgscomposertablecolumn.h"
 #include "qgssymbollayerv2utils.h"
 #include "qgscomposerutils.h"
+#include "qgsfontutils.h"
 #include <QPainter>
 #include <QSettings>
 
@@ -267,14 +268,20 @@ void QgsComposerTable::setColumns( QList<QgsComposerTableColumn*> columns )
 bool QgsComposerTable::tableWriteXML( QDomElement& elem, QDomDocument & doc ) const
 {
   elem.setAttribute( "lineTextDist", QString::number( mLineTextDistance ) );
-  elem.setAttribute( "headerFont", mHeaderFont.toString() );
-  elem.setAttribute( "headerFontColor", QgsSymbolLayerV2Utils::encodeColor( mHeaderFontColor ) );
   elem.setAttribute( "headerHAlignment", QString::number(( int )mHeaderHAlignment ) );
-  elem.setAttribute( "contentFont", mContentFont.toString() );
-  elem.setAttribute( "contentFontColor", QgsSymbolLayerV2Utils::encodeColor( mContentFontColor ) );
   elem.setAttribute( "gridStrokeWidth", QString::number( mGridStrokeWidth ) );
   elem.setAttribute( "gridColor", QgsSymbolLayerV2Utils::encodeColor( mGridColor ) );
   elem.setAttribute( "showGrid", mShowGrid );
+  
+  //font
+  QFontInfo fi = QFontInfo( mHeaderFont );
+  elem.setAttribute( "headerFont", mHeaderFont.toString() );
+  elem.setAttribute( "headerFontStyle", fi.styleName() );
+  elem.setAttribute( "headerFontColor", QgsSymbolLayerV2Utils::encodeColor( mHeaderFontColor ) );
+  fi = QFontInfo( mContentFont );
+  elem.setAttribute( "contentFont", mContentFont.toString() );
+  elem.setAttribute( "contentFontStyle", fi.styleName() );
+  elem.setAttribute( "contentFontColor", QgsSymbolLayerV2Utils::encodeColor( mContentFontColor ) );
 
   //columns
   QDomElement displayColumnsElem = doc.createElement( "displayColumns" );
@@ -298,9 +305,11 @@ bool QgsComposerTable::tableReadXML( const QDomElement& itemElem, const QDomDocu
   }
 
   mHeaderFont.fromString( itemElem.attribute( "headerFont", "" ) );
+  QgsFontUtils::updateFontViaStyle( mHeaderFont, itemElem.attribute( "headerFontStyle" ) );
   mHeaderFontColor = QgsSymbolLayerV2Utils::decodeColor( itemElem.attribute( "headerFontColor", "0,0,0,255" ) );
   mHeaderHAlignment = QgsComposerTable::HeaderHAlignment( itemElem.attribute( "headerHAlignment", "0" ).toInt() );
   mContentFont.fromString( itemElem.attribute( "contentFont", "" ) );
+  QgsFontUtils::updateFontViaStyle( mContentFont, itemElem.attribute( "contentFontStyle" ) );
   mContentFontColor = QgsSymbolLayerV2Utils::decodeColor( itemElem.attribute( "contentFontColor", "0,0,0,255" ) );
   mLineTextDistance = itemElem.attribute( "lineTextDist", "1.0" ).toDouble();
   mGridStrokeWidth = itemElem.attribute( "gridStrokeWidth", "0.5" ).toDouble();


### PR DESCRIPTION
Until now, composer items would not save the style of a font family, which would cause the font style to be lost when loading a project (see a visual of the consequence of this here: http://hub.qgis.org/issues/12644)

I've tested this pull request using various fonts, using exotic styles such as Ultra Light Italic, etc. and all is properly restored upon project load.
