### PR TITLE
Bump minimum Qt version to 4.8

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -245,7 +245,7 @@ IF (WITH_QTWEBKIT)
 ENDIF(WITH_QTWEBKIT)
 #############################################################
 # search for Qt4
-SET(QT_MIN_VERSION 4.7.0)
+SET(QT_MIN_VERSION 4.8.0)
 SET (ENABLE_QT5 FALSE CACHE BOOL "If enabled will try to find Qt5 before looking for Qt4")
 IF (ENABLE_QT5)
   FIND_PACKAGE(Qt5Core QUIET)

--- a/INSTALL
+++ b/INSTALL
@@ -97,7 +97,7 @@ Required build tools:
 
 Required build dependencies:
 
-- Qt >= 4.7.0
+- Qt >= 4.8.0
 - Proj >= 4.4.x
 - GEOS >= 3.0
 - Sqlite3 >= 3.0.0
@@ -555,23 +555,23 @@ it, just point the installer to c:\msys\mingw
 
 When Qt installation is complete:
 
-Edit C:\Qt\4.7.0\bin\qtvars.bat and add the following lines:
+Edit C:\Qt\4.8.0\bin\qtvars.bat and add the following lines:
 
   set PATH=%PATH%;C:\msys\local\bin;c:\msys\local\lib 
   set PATH=%PATH%;"C:\Program Files\Subversion\bin" 
 
-I suggest you also add C:\Qt\4.7.0\bin\ to your Environment Variables Path in
+I suggest you also add C:\Qt\4.8.0\bin\ to your Environment Variables Path in
 the windows system preferences.
 
 If you plan to do some debugging, you'll need to compile debug version of Qt:
-C:\Qt\4.7.0\bin\qtvars.bat compile_debug
+C:\Qt\4.8.0\bin\qtvars.bat compile_debug
 
-Note: there is a problem when compiling debug version of Qt 4.7, the script ends with
+Note: there is a problem when compiling debug version of Qt 4.8, the script ends with
 this message  "mingw32-make: *** No rule to make target `debug'.  Stop.". To 
 compile the debug version you have to go out of src directory and execute the
 following command:
 
-  c:\Qt\4.7.0 make 
+  c:\Qt\4.8.0 make 
 
 
     4.2.3. Flex and Bison
@@ -611,7 +611,7 @@ to get versions that match your current Qt installed version.
       4.2.4.3. Compile SIP
       ====================
 
-  c:\Qt\4.7.0\bin\qtvars.bat 
+  c:\Qt\4.8.0\bin\qtvars.bat 
   python configure.py -p win32-g++ 
   make 
   make install 
@@ -620,7 +620,7 @@ to get versions that match your current Qt installed version.
       4.2.4.4. Compile PyQt
       =====================
 
-  c:\Qt\4.7.0\bin\qtvars.bat 
+  c:\Qt\4.8.0\bin\qtvars.bat 
   python configure.py 
   make 
   make install 
@@ -673,9 +673,9 @@ this document.
 Start a cmd.exe window ( Start -> Run -> cmd.exe ) if you don't have one
 already.  Add paths to compiler and our MSYS environment:
 
-  c:\Qt\4.7.0\bin\qtvars.bat 
+  c:\Qt\4.8.0\bin\qtvars.bat 
 
-For ease of use add c:\Qt\4.7.0\bin\ to your system path in system
+For ease of use add c:\Qt\4.8.0\bin\ to your system path in system
 properties so you can just type qtvars.bat when you open the cmd console.
 Create build directory and set it as current directory:
 
@@ -1036,7 +1036,7 @@ Snow Leopard+ note: If you are building on Snow Leopard+, you will need to
 decide between 32-bit support in the older Qt Carbon branch, or 64-bit
 support in the Qt Cocoa branch. Appropriate installers are available for both
 as of Qt-4.5.2, though they stopped making Carbon packages at Qt 4.7.4.
-Qt 4.6+ is recommended for Cocoa.
+
 Starting with Lion, Carbon may not work properly, if at all.
 Starting with Qt 4.8, only 64bit Cocoa installers are available.
 

--- a/doc/INSTALL.html
+++ b/doc/INSTALL.html
@@ -204,7 +204,7 @@ Required build dependencies:
 </P>
 
 <UL>
-<LI>Qt &gt;= 4.7.0
+<LI>Qt &gt;= 4.8.0
 <LI>Proj &gt;= 4.4.x
 <LI>GEOS &gt;= 3.0
 <LI>Sqlite3 &gt;= 3.0.0
@@ -836,7 +836,7 @@ it, just point the installer to c:\msys\mingw
 When Qt installation is complete:
 </P>
 <P>
-Edit C:\Qt\4.7.0\bin\qtvars.bat and add the following lines:
+Edit C:\Qt\4.8.0\bin\qtvars.bat and add the following lines:
 </P>
 
 <div class="code"><PRE>
@@ -845,22 +845,22 @@ set PATH=%PATH%;"C:\Program Files\Subversion\bin"
 </PRE></div>
 
 <P>
-I suggest you also add C:\Qt\4.7.0\bin\ to your Environment Variables Path in
+I suggest you also add C:\Qt\4.8.0\bin\ to your Environment Variables Path in
 the windows system preferences.
 </P>
 <P>
 If you plan to do some debugging, you'll need to compile debug version of Qt:
-C:\Qt\4.7.0\bin\qtvars.bat compile_debug
+C:\Qt\4.8.0\bin\qtvars.bat compile_debug
 </P>
 <P>
-Note: there is a problem when compiling debug version of Qt 4.7, the script ends with
+Note: there is a problem when compiling debug version of Qt 4.8, the script ends with
 this message  "mingw32-make: *** No rule to make target `debug'.  Stop.". To 
 compile the debug version you have to go out of src directory and execute the
 following command:
 </P>
 
 <div class="code"><PRE>
-c:\Qt\4.7.0 make 
+c:\Qt\4.8.0 make 
 </PRE></div>
 
 <H3>4.2.3. Flex and Bison</H3>
@@ -902,7 +902,7 @@ to get versions that match your current Qt installed version.
 <H4>4.2.4.3. Compile SIP</H4>
 
 <div class="code"><PRE>
-c:\Qt\4.7.0\bin\qtvars.bat 
+c:\Qt\4.8.0\bin\qtvars.bat 
 python configure.py -p win32-g++ 
 make 
 make install 
@@ -911,7 +911,7 @@ make install
 <H4>4.2.4.4. Compile PyQt</H4>
 
 <div class="code"><PRE>
-c:\Qt\4.7.0\bin\qtvars.bat 
+c:\Qt\4.8.0\bin\qtvars.bat 
 python configure.py 
 make 
 make install 
@@ -975,11 +975,11 @@ already.  Add paths to compiler and our MSYS environment:
 </P>
 
 <div class="code"><PRE>
-c:\Qt\4.7.0\bin\qtvars.bat 
+c:\Qt\4.8.0\bin\qtvars.bat 
 </PRE></div>
 
 <P>
-For ease of use add c:\Qt\4.7.0\bin\ to your system path in system
+For ease of use add c:\Qt\4.8.0\bin\ to your system path in system
 properties so you can just type qtvars.bat when you open the cmd console.
 Create build directory and set it as current directory:
 </P>
@@ -1443,7 +1443,7 @@ only.  This is available in the Libraries section of the Qt download page.
 decide between 32-bit support in the older Qt Carbon branch, or 64-bit
 support in the Qt Cocoa branch. Appropriate installers are available for both
 as of Qt-4.5.2, though they stopped making Carbon packages at Qt 4.7.4.
-Qt 4.6+ is recommended for Cocoa.
+
 Starting with Lion, Carbon may not work properly, if at all.
 Starting with Qt 4.8, only 64bit Cocoa installers are available.
 </P>

--- a/doc/overview.t2t
+++ b/doc/overview.t2t
@@ -15,7 +15,7 @@ Required build tools:
 
 Required build dependencies:
 
-- Qt >= 4.7.0
+- Qt >= 4.8.0
 - Proj >= 4.4.x
 - GEOS >= 3.0
 - Sqlite3 >= 3.0.0

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -746,11 +746,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl ) :
   QStringList myI18nList = i18nList();
   foreach ( QString l, myI18nList )
   {
-#if QT_VERSION >= 0x040800
     cboLocale->addItem( QIcon( QString( ":/images/flags/%1.png" ).arg( l ) ), QLocale( l ).nativeLanguageName(), l );
-#else
-    cboLocale->addItem( QIcon( QString( ":/images/flags/%1.png" ).arg( l ) ), l, l );
-#endif
   }
   cboLocale->setCurrentIndex( cboLocale->findData( myUserLocale ) );
   bool myLocaleOverrideFlag = settings.value( "locale/overrideFlag", false ).toBool();

--- a/src/core/qgsnetworkaccessmanager.cpp
+++ b/src/core/qgsnetworkaccessmanager.cpp
@@ -322,7 +322,6 @@ void QgsNetworkAccessManager::setupDefaultProxyAndCache()
     }
   }
 
-#if QT_VERSION >= 0x40500
   setFallbackProxyAndExcludes( proxy, excludes );
 
   QNetworkDiskCache *newcache = qobject_cast<QNetworkDiskCache*>( cache() );
@@ -340,8 +339,5 @@ void QgsNetworkAccessManager::setupDefaultProxyAndCache()
 
   if ( cache() != newcache )
     setCache( newcache );
-#else
-  setProxy( proxy );
-#endif
 }
 

--- a/src/core/qgspallabeling.cpp
+++ b/src/core/qgspallabeling.cpp
@@ -2070,9 +2070,7 @@ void QgsPalLayerSettings::registerFeature( QgsFeature& f, const QgsRenderContext
   geometries.append( lbl );
 
   // store the label's calculated font for later use during painting
-#if QT_VERSION >= 0x040800
   QgsDebugMsgLevel( QString( "PAL font stored definedFont: %1, Style: %2" ).arg( labelFont.toString() ).arg( labelFont.styleName() ), 4 );
-#endif
   lbl->setDefinedFont( labelFont );
 
   // set repeat distance
@@ -4185,11 +4183,8 @@ void QgsPalLabeling::drawLabeling( QgsRenderContext& context )
 
     //font
     QFont dFont = palGeometry->definedFont();
-    // following debug is >= Qt 4.8 only ( because of QFont::styleName() )
-#if QT_VERSION >= 0x040800
     QgsDebugMsgLevel( QString( "PAL font tmpLyr: %1, Style: %2" ).arg( tmpLyr.textFont.toString() ).arg( QFontInfo( tmpLyr.textFont ).styleName() ), 4 );
     QgsDebugMsgLevel( QString( "PAL font definedFont: %1, Style: %2" ).arg( dFont.toString() ).arg( dFont.styleName() ), 4 );
-#endif
     tmpLyr.textFont = dFont;
 
     if ( tmpLyr.multilineAlign == QgsPalLayerSettings::MultiFollowPlacement )

--- a/src/gui/raster/qwt5_histogram_item.cpp
+++ b/src/gui/raster/qwt5_histogram_item.cpp
@@ -258,12 +258,7 @@ void HistogramItem::drawBar( QPainter *painter,
 {
   painter->save();
 
-#if QT_VERSION >= 0x040000
   const QRect r = rect.normalized();
-#else
-  const QRect r = rect.normalize();
-#endif
-
   painter->setBrush( d_data->color );
 
   if ( d_data->flat )
@@ -286,50 +281,26 @@ void HistogramItem::drawBar( QPainter *painter,
     painter->setBrush( Qt::NoBrush );
 
     painter->setPen( QPen( light, 2 ) );
-#if QT_VERSION >= 0x040000
     QwtPainter::drawLine( painter,
                           r.left() + 1, r.top() + 2, r.right() + 1, r.top() + 2 );
-#else
-    QwtPainter::drawLine( painter,
-                          r.left(), r.top() + 2, r.right() + 1, r.top() + 2 );
-#endif
 
     painter->setPen( QPen( dark, 2 ) );
-#if QT_VERSION >= 0x040000
     QwtPainter::drawLine( painter,
                           r.left() + 1, r.bottom(), r.right() + 1, r.bottom() );
-#else
-    QwtPainter::drawLine( painter,
-                          r.left(), r.bottom(), r.right() + 1, r.bottom() );
-#endif
 
     painter->setPen( QPen( light, 1 ) );
 
-#if QT_VERSION >= 0x040000
     QwtPainter::drawLine( painter,
                           r.left(), r.top() + 1, r.left(), r.bottom() );
     QwtPainter::drawLine( painter,
                           r.left() + 1, r.top() + 2, r.left() + 1, r.bottom() - 1 );
-#else
-    QwtPainter::drawLine( painter,
-                          r.left(), r.top() + 1, r.left(), r.bottom() + 1 );
-    QwtPainter::drawLine( painter,
-                          r.left() + 1, r.top() + 2, r.left() + 1, r.bottom() );
-#endif
 
     painter->setPen( QPen( dark, 1 ) );
 
-#if QT_VERSION >= 0x040000
     QwtPainter::drawLine( painter,
                           r.right() + 1, r.top() + 1, r.right() + 1, r.bottom() );
     QwtPainter::drawLine( painter,
                           r.right(), r.top() + 2, r.right(), r.bottom() - 1 );
-#else
-    QwtPainter::drawLine( painter,
-                          r.right() + 1, r.top() + 1, r.right() + 1, r.bottom() + 1 );
-    QwtPainter::drawLine( painter,
-                          r.right(), r.top() + 2, r.right(), r.bottom() );
-#endif
   }
 
   painter->restore();
@@ -350,11 +321,7 @@ void HistogramItem::updateLegend( QwtLegend *legend ) const
 
   QwtLegendItem *legendItem = ( QwtLegendItem * )widget;
 
-#if QT_VERSION < 0x040000
-  const bool doUpdate = legendItem->isUpdatesEnabled();
-#else
   const bool doUpdate = legendItem->updatesEnabled();
-#endif
   legendItem->setUpdatesEnabled( false );
 
   const int policy = legend->displayPolicy();

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -26,11 +26,6 @@
 #include <qgsgeometry.h>
 #include <qgsrenderchecker.h>
 
-#if QT_VERSION < 0x40701
-// See http://hub.qgis.org/issues/4284
-Q_DECLARE_METATYPE( QVariant )
-#endif
-
 static void _parseAndEvalExpr( int arg )
 {
   Q_UNUSED( arg );

--- a/tests/src/core/testqgsrulebasedrenderer.cpp
+++ b/tests/src/core/testqgsrulebasedrenderer.cpp
@@ -22,11 +22,6 @@
 #include <qgssymbolv2.h>
 #include <qgsvectorlayer.h>
 
-#if QT_VERSION < 0x40701
-// See http://hub.qgis.org/issues/4284
-Q_DECLARE_METATYPE( QVariant )
-#endif
-
 typedef QgsRuleBasedRendererV2::Rule RRule;
 
 class TestQgsRuleBasedRenderer: public QObject

--- a/tests/src/core/testqgsscaleexpression.cpp
+++ b/tests/src/core/testqgsscaleexpression.cpp
@@ -19,11 +19,6 @@
 
 #include <qgsscaleexpression.h>
 
-#if QT_VERSION < 0x40701
-// See http://hub.qgis.org/issues/4284
-Q_DECLARE_METATYPE( QVariant )
-#endif
-
 class TestQgsScaleExpression: public QObject
 {
     Q_OBJECT

--- a/tests/src/core/testqgsspatialindex.cpp
+++ b/tests/src/core/testqgsspatialindex.cpp
@@ -23,12 +23,6 @@
 #include <qgsvectordataprovider.h>
 #include <qgsvectorlayer.h>
 
-
-#if QT_VERSION < 0x40701
-// See http://hub.qgis.org/issues/4284
-Q_DECLARE_METATYPE( QVariant )
-#endif
-
 static QgsFeature _pointFeature( QgsFeatureId id, qreal x, qreal y )
 {
   QgsFeature f( id );

--- a/tests/src/core/testqgsvectordataprovider.cpp
+++ b/tests/src/core/testqgsvectordataprovider.cpp
@@ -22,11 +22,6 @@
 #include <qgsvectordataprovider.h>
 #include <qgsvectorlayer.h>
 
-#if QT_VERSION < 0x40701
-// See http://hub.qgis.org/issues/4284
-Q_DECLARE_METATYPE( QVariant )
-#endif
-
 Q_DECLARE_METATYPE( QgsFeatureRequest );
 
 class TestQgsVectorDataProvider : public QObject


### PR DESCRIPTION
As discussed on gitter.... raise the minimum Qt dependency to 4.8. Required for methods need to stablise font saving/loading, which were added in Qt 4.8.
