### PR TITLE
[BUGFIX][QGIS-Server] Add all layers for fixed legend in GetPrint

### DIFF
--- a/src/server/qgswmsprojectparser.cpp
+++ b/src/server/qgswmsprojectparser.cpp
@@ -20,6 +20,7 @@
 #include "qgsconfigparserutils.h"
 #include "qgslogger.h"
 #include "qgsmaplayer.h"
+#include "qgsmaplayerregistry.h"
 #include "qgsmaplayerstylemanager.h"
 #include "qgsmapserviceexception.h"
 #include "qgspallabeling.h"
@@ -38,6 +39,7 @@
 #include "qgscomposerscalebar.h"
 #include "qgscomposershape.h"
 #include "qgslayertreegroup.h"
+#include "qgslayertreelayer.h"
 
 #include <QFileInfo>
 #include <QTextDocument>
@@ -442,16 +444,51 @@ QgsComposition* QgsWMSProjectParser::initComposition( const QString& composerTem
     QgsComposerLegend* legend = dynamic_cast< QgsComposerLegend *>( *itemIt );
     if ( legend )
     {
-#if 0
       QgsLegendModelV2* model = legend->modelV2();
+#if 0
       QgsLayerTreeGroup* root = model->rootGroup();
       QStringList layerIds = root->findLayerIds();
       throw QgsMapServiceException( "Error", "Composer legend layerIds " + layerIds.join( " ," ) );
 #endif
       if ( legend->autoUpdateModel() )
       {
-        QgsLegendModelV2* model = legend->modelV2();
         model->setRootGroup( projectLayerTreeGroup() );
+      }
+      // if the legend has no map
+      // we will load all layers
+      const QgsComposerMap* map = legend->composerMap();
+      if ( !map )
+      {
+        QgsLayerTreeGroup* root = model->rootGroup();
+        QStringList layerIds = root->findLayerIds();
+        // foreach layer find in the layer tree
+        // load it if the layer id is not QgsMapLayerRegistry
+        foreach ( QString layerId, layerIds )
+        {
+          QgsMapLayer * layer = QgsMapLayerRegistry::instance()->mapLayer( layerId );
+          if ( layer )
+          {
+            continue;
+          }
+          
+          QgsLayerTreeLayer* nodeLayer = root->findLayer( layerId );
+          if ( !nodeLayer )
+          {
+            continue;
+          }
+          layer = nodeLayer->layer();
+          if ( !layer )
+          {
+            const QHash< QString, QDomElement > &projectLayerElements = mProjectParser->projectLayerElementsById();
+            QHash< QString, QDomElement >::const_iterator layerElemIt = projectLayerElements.find( layerId );
+            if ( layerElemIt != projectLayerElements.constEnd() )
+            {
+              layer = mProjectParser->createLayerFromElement( layerElemIt.value(), true );
+            }
+          }
+          QgsMapLayerRegistry::instance()->addMapLayer( layer );
+        }
+        legend->updateLegend();
       }
       legendList.push_back( legend );
       continue;


### PR DESCRIPTION
If a legend is not linked to a map, it's a fixed legend and does not depend on
 layers parameter. This bugfix loads all layers needed by legend and update it.
