### PR TITLE
[georef] apply user preference icon size to toolbars

### DIFF
--- a/src/plugins/georeferencer/qgsgeorefplugingui.cpp
+++ b/src/plugins/georeferencer/qgsgeorefplugingui.cpp
@@ -994,6 +994,13 @@ void QgsGeorefPluginGui::createMenus()
   mToolbarMenu->addAction( toolBarEdit->toggleViewAction() );
   mToolbarMenu->addAction( toolBarView->toggleViewAction() );
 
+  QSettings s;
+  int size = s.value( "/IconSize", 32 ).toInt();
+  toolBarFile->setIconSize( QSize( size, size ) );
+  toolBarEdit->setIconSize( QSize( size, size ) );
+  toolBarView->setIconSize( QSize( size, size ) );
+  toolBarHistogramStretch->setIconSize( QSize( size, size ) );
+  
   // View menu
   if ( layout != QDialogButtonBox::KdeLayout )
   {

--- a/src/plugins/georeferencer/qgsgeorefpluginguibase.ui
+++ b/src/plugins/georeferencer/qgsgeorefpluginguibase.ui
@@ -164,7 +164,7 @@
   </widget>
   <widget class="QToolBar" name="toolBarHistogramStretch">
    <property name="windowTitle">
-    <string>toolBar</string>
+    <string>Histogram</string>
    </property>
    <attribute name="toolBarArea">
     <enum>TopToolBarArea</enum>


### PR DESCRIPTION
Simple pull request, title says it all. As a user who sets his icon size to 16 and use the georeferencer quite a lot, I can vouch for this being a nice improvement for my small screen.

@nyalldawson , your wave of improvements inspired me, thanks ;) 
