### PR TITLE
Make QgsVectorLayer::setDataSource maintain renderer where possible

### DIFF
--- a/python/core/qgsvectorlayer.sip
+++ b/python/core/qgsvectorlayer.sip
@@ -577,7 +577,17 @@ class QgsVectorLayer : QgsMapLayer
      */
     virtual long featureCount() const;
 
-    void setDataSource(QString dataSource, QString baseName, QString provider, bool loadDefaultStyleFlag = true);
+    /**
+     * Update the data source of the layer. The layer's renderer and legend will be preserved only
+     * if the geometry type of the new data source matches the current geometry type of the layer.
+     * @param dataSource new layer data source
+     * @param baseName base name of the layer
+     * @param provider provider string
+     * @param loadDefaultStyleFlag set to true to reset the layer's style to the default for the
+     * data source
+     * @note added in QGIS 2.10
+     */
+    void setDataSource( QString dataSource, QString baseName, QString provider, bool loadDefaultStyleFlag = false );
 
     /**
      * Number of features rendered with specified symbol. Features must be first

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -1078,9 +1078,16 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
     long featureCount( QgsSymbolV2* symbol );
 
     /**
-     * Update the data source of the layer
+     * Update the data source of the layer. The layer's renderer and legend will be preserved only
+     * if the geometry type of the new data source matches the current geometry type of the layer.
+     * @param dataSource new layer data source
+     * @param baseName base name of the layer
+     * @param provider provider string
+     * @param loadDefaultStyleFlag set to true to reset the layer's style to the default for the
+     * data source
+     * @note added in QGIS 2.10
      */
-    void setDataSource( QString dataSource, QString baseName, QString provider , bool loadDefaultStyleFlag = false );
+    void setDataSource( QString dataSource, QString baseName, QString provider, bool loadDefaultStyleFlag = false );
 
     /**
      * Count features for symbols. Feature counts may be get by featureCount( QgsSymbolV2*).


### PR DESCRIPTION
If the layer's geometry type hasn't changed, then keep the existing renderer and legend when calling setDataSource. Would be nice to correct this behaviour before this method has been added to public api.
