### PR TITLE
Pre 2.10 geometry API cleanup

### DIFF
--- a/python/core/geometry/qgsgeometry.sip
+++ b/python/core/geometry/qgsgeometry.sip
@@ -21,6 +21,15 @@ typedef unsigned long size_t;
 typedef unsigned int size_t;
 %End
 
+/** \ingroup core
+ * A geometry is the spatial representation of a feature. Since QGIS 2.10, QgsGeometry acts as a generic container
+ * for geometry objects. QgsGeometry is implicitly shared, so making copies of geometries is inexpensive. The geometry
+ * container class can also be stored inside a QVariant object.
+ *
+ * The actual geometry representation is stored as a @link QgsAbstractGeometryV2 @endlink within the container, and
+ * can be accessed via the @link geometry @endlink method or set using the @link setGeometry @endlink method.
+ */
+
 class QgsGeometry
 {
 %TypeHeaderCode

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -299,7 +299,7 @@ SET(QGIS_CORE_SRCS
   geometry/qgsgeometry.cpp
   geometry/qgsgeometrycollectionv2.cpp
   geometry/qgsgeometryeditutils.cpp
-  geometry/qgsgeometryimport.cpp
+  geometry/qgsgeometryfactory.cpp
   geometry/qgsgeometryutils.cpp
   geometry/qgsgeos.cpp
   geometry/qgspointv2.cpp

--- a/src/core/dxf/qgsdxfpaintengine.h
+++ b/src/core/dxf/qgsdxfpaintengine.h
@@ -19,7 +19,7 @@
 #define QGSDXFPAINTENGINE_H
 
 #include <QPaintEngine>
-#include <qgsgeometryimport.h>
+#include "qgsgeometryfactory.h"
 
 class QgsDxfExport;
 class QgsDxfPaintDevice;

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -21,7 +21,7 @@ email                : morb at ozemail dot com dot au
 #include "qgis.h"
 #include "qgsgeometry.h"
 #include "qgsgeometryeditutils.h"
-#include "qgsgeometryimport.h"
+#include "qgsgeometryfactory.h"
 #include "qgsgeometryutils.h"
 #include "qgsgeos.h"
 #include "qgsapplication.h"
@@ -156,7 +156,7 @@ bool QgsGeometry::isEmpty() const
 
 QgsGeometry* QgsGeometry::fromWkt( QString wkt )
 {
-  QgsAbstractGeometryV2* geom = QgsGeometryImport::geomFromWkt( wkt );
+  QgsAbstractGeometryV2* geom = QgsGeometryFactory::geomFromWkt( wkt );
   if ( !geom )
   {
     return 0;
@@ -166,7 +166,7 @@ QgsGeometry* QgsGeometry::fromWkt( QString wkt )
 
 QgsGeometry* QgsGeometry::fromPoint( const QgsPoint& point )
 {
-  QgsAbstractGeometryV2* geom = QgsGeometryImport::fromPoint( point );
+  QgsAbstractGeometryV2* geom = QgsGeometryFactory::fromPoint( point );
   if ( geom )
   {
     return new QgsGeometry( geom );
@@ -176,7 +176,7 @@ QgsGeometry* QgsGeometry::fromPoint( const QgsPoint& point )
 
 QgsGeometry* QgsGeometry::fromPolyline( const QgsPolyline& polyline )
 {
-  QgsAbstractGeometryV2* geom = QgsGeometryImport::fromPolyline( polyline );
+  QgsAbstractGeometryV2* geom = QgsGeometryFactory::fromPolyline( polyline );
   if ( geom )
   {
     return new QgsGeometry( geom );
@@ -186,7 +186,7 @@ QgsGeometry* QgsGeometry::fromPolyline( const QgsPolyline& polyline )
 
 QgsGeometry* QgsGeometry::fromPolygon( const QgsPolygon& polygon )
 {
-  QgsAbstractGeometryV2* geom = QgsGeometryImport::fromPolygon( polygon );
+  QgsAbstractGeometryV2* geom = QgsGeometryFactory::fromPolygon( polygon );
   if ( geom )
   {
     return new QgsGeometry( geom );
@@ -196,7 +196,7 @@ QgsGeometry* QgsGeometry::fromPolygon( const QgsPolygon& polygon )
 
 QgsGeometry* QgsGeometry::fromMultiPoint( const QgsMultiPoint& multipoint )
 {
-  QgsAbstractGeometryV2* geom = QgsGeometryImport::fromMultiPoint( multipoint );
+  QgsAbstractGeometryV2* geom = QgsGeometryFactory::fromMultiPoint( multipoint );
   if ( geom )
   {
     return new QgsGeometry( geom );
@@ -206,7 +206,7 @@ QgsGeometry* QgsGeometry::fromMultiPoint( const QgsMultiPoint& multipoint )
 
 QgsGeometry* QgsGeometry::fromMultiPolyline( const QgsMultiPolyline& multiline )
 {
-  QgsAbstractGeometryV2* geom = QgsGeometryImport::fromMultiPolyline( multiline );
+  QgsAbstractGeometryV2* geom = QgsGeometryFactory::fromMultiPolyline( multiline );
   if ( geom )
   {
     return new QgsGeometry( geom );
@@ -216,7 +216,7 @@ QgsGeometry* QgsGeometry::fromMultiPolyline( const QgsMultiPolyline& multiline )
 
 QgsGeometry* QgsGeometry::fromMultiPolygon( const QgsMultiPolygon& multipoly )
 {
-  QgsAbstractGeometryV2* geom = QgsGeometryImport::fromMultiPolygon( multipoly );
+  QgsAbstractGeometryV2* geom = QgsGeometryFactory::fromMultiPolygon( multipoly );
   if ( geom )
   {
     return new QgsGeometry( geom );
@@ -254,7 +254,7 @@ void QgsGeometry::fromWkb( unsigned char *wkb, size_t length )
     delete d->geometry;
     removeWkbGeos();
   }
-  d->geometry = QgsGeometryImport::geomFromWkb( wkb );
+  d->geometry = QgsGeometryFactory::geomFromWkb( wkb );
   d->mWkb = wkb;
   d->mWkbSize = length;
 }
@@ -908,7 +908,7 @@ bool QgsGeometry::convertToMultiType()
   }
 
   QgsGeometryCollectionV2* multiGeom = dynamic_cast<QgsGeometryCollectionV2*>
-                                       ( QgsGeometryImport::geomFromWkbType( QgsWKBTypes::multiType( d->geometry->wkbType() ) ) );
+                                       ( QgsGeometryFactory::geomFromWkbType( QgsWKBTypes::multiType( d->geometry->wkbType() ) ) );
   if ( !multiGeom )
   {
     return false;

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -64,7 +64,13 @@ class QgsConstWkbPtr;
 struct QgsGeometryPrivate;
 
 /** \ingroup core
-- * A geometry is the spatial representation of a feature. This class is deprecated. Please use QgsAbstractGeometryV2 directly for new code*/
+ * A geometry is the spatial representation of a feature. Since QGIS 2.10, QgsGeometry acts as a generic container
+ * for geometry objects. QgsGeometry is implicitly shared, so making copies of geometries is inexpensive. The geometry
+ * container class can also be stored inside a QVariant object.
+ *
+ * The actual geometry representation is stored as a @link QgsAbstractGeometryV2 @endlink within the container, and
+ * can be accessed via the @link geometry @endlink method or set using the @link setGeometry @endlink method.
+ */
 
 class CORE_EXPORT QgsGeometry
 {

--- a/src/core/geometry/qgsgeometrycollectionv2.cpp
+++ b/src/core/geometry/qgsgeometrycollectionv2.cpp
@@ -15,7 +15,7 @@ email                : marco.hugentobler at sourcepole dot com
 
 #include "qgsgeometrycollectionv2.h"
 #include "qgsapplication.h"
-#include "qgsgeometryimport.h"
+#include "qgsgeometryfactory.h"
 #include "qgsgeometryutils.h"
 #include "qgscircularstringv2.h"
 #include "qgscompoundcurvev2.h"
@@ -181,7 +181,7 @@ bool QgsGeometryCollectionV2::fromWkb( const unsigned char * wkb )
   QList<QgsAbstractGeometryV2*> geometryList;
   for ( int i = 0; i < nGeometries; ++i )
   {
-    QgsAbstractGeometryV2* geom = QgsGeometryImport::geomFromWkb( wkbPtr );
+    QgsAbstractGeometryV2* geom = QgsGeometryFactory::geomFromWkb( wkbPtr );
     if ( geom )
     {
       geometryList.append( geom );
@@ -479,7 +479,7 @@ bool QgsGeometryCollectionV2::hasCurvedSegments() const
 
 QgsAbstractGeometryV2* QgsGeometryCollectionV2::segmentize() const
 {
-  QgsAbstractGeometryV2* geom = QgsGeometryImport::geomFromWkbType( mWkbType );
+  QgsAbstractGeometryV2* geom = QgsGeometryFactory::geomFromWkbType( mWkbType );
   QgsGeometryCollectionV2* geomCollection = dynamic_cast<QgsGeometryCollectionV2*>( geom );
   if ( !geomCollection )
   {

--- a/src/core/geometry/qgsgeometryfactory.cpp
+++ b/src/core/geometry/qgsgeometryfactory.cpp
@@ -1,5 +1,5 @@
 /***************************************************************************
-                           qgsgeometryimport.cpp
+                           qgsgeometryfactory.cpp
                          ------------------------
     begin                : September 2014
     copyright            : (C) 2014 by Marco Hugentobler
@@ -15,7 +15,7 @@
  *                                                                         *
  ***************************************************************************/
 
-#include "qgsgeometryimport.h"
+#include "qgsgeometryfactory.h"
 #include "qgscircularstringv2.h"
 #include "qgscompoundcurvev2.h"
 #include "qgscurvepolygonv2.h"
@@ -29,7 +29,7 @@
 #include "qgsmultisurfacev2.h"
 #include "qgswkbtypes.h"
 
-QgsAbstractGeometryV2* QgsGeometryImport::geomFromWkb( const unsigned char* wkb )
+QgsAbstractGeometryV2* QgsGeometryFactory::geomFromWkb( const unsigned char* wkb )
 {
   if ( !wkb )
   {
@@ -50,7 +50,7 @@ QgsAbstractGeometryV2* QgsGeometryImport::geomFromWkb( const unsigned char* wkb 
   return geom;
 }
 
-QgsAbstractGeometryV2* QgsGeometryImport::geomFromWkt( const QString& text )
+QgsAbstractGeometryV2* QgsGeometryFactory::geomFromWkt( const QString& text )
 {
   QgsAbstractGeometryV2* geom = 0;
   if ( text.startsWith( "Point", Qt::CaseInsensitive ) )
@@ -112,12 +112,12 @@ QgsAbstractGeometryV2* QgsGeometryImport::geomFromWkt( const QString& text )
   return geom;
 }
 
-QgsAbstractGeometryV2* QgsGeometryImport::fromPoint( const QgsPoint& point )
+QgsAbstractGeometryV2* QgsGeometryFactory::fromPoint( const QgsPoint& point )
 {
   return new QgsPointV2( point.x(), point.y() );
 }
 
-QgsAbstractGeometryV2* QgsGeometryImport::fromMultiPoint( const QgsMultiPoint& multipoint )
+QgsAbstractGeometryV2* QgsGeometryFactory::fromMultiPoint( const QgsMultiPoint& multipoint )
 {
   QgsMultiPointV2* mp = new QgsMultiPointV2();
   QgsMultiPoint::const_iterator ptIt = multipoint.constBegin();
@@ -129,12 +129,12 @@ QgsAbstractGeometryV2* QgsGeometryImport::fromMultiPoint( const QgsMultiPoint& m
   return mp;
 }
 
-QgsAbstractGeometryV2* QgsGeometryImport::fromPolyline( const QgsPolyline& polyline )
+QgsAbstractGeometryV2* QgsGeometryFactory::fromPolyline( const QgsPolyline& polyline )
 {
   return linestringFromPolyline( polyline );
 }
 
-QgsAbstractGeometryV2* QgsGeometryImport::fromMultiPolyline( const QgsMultiPolyline& multiline )
+QgsAbstractGeometryV2* QgsGeometryFactory::fromMultiPolyline( const QgsMultiPolyline& multiline )
 {
   QgsMultiLineStringV2* mLine = new QgsMultiLineStringV2();
   for ( int i = 0; i < multiline.size(); ++i )
@@ -144,7 +144,7 @@ QgsAbstractGeometryV2* QgsGeometryImport::fromMultiPolyline( const QgsMultiPolyl
   return mLine;
 }
 
-QgsAbstractGeometryV2* QgsGeometryImport::fromPolygon( const QgsPolygon& polygon )
+QgsAbstractGeometryV2* QgsGeometryFactory::fromPolygon( const QgsPolygon& polygon )
 {
   QgsPolygonV2* poly = new QgsPolygonV2();
 
@@ -167,7 +167,7 @@ QgsAbstractGeometryV2* QgsGeometryImport::fromPolygon( const QgsPolygon& polygon
   return poly;
 }
 
-QgsAbstractGeometryV2* QgsGeometryImport::fromMultiPolygon( const QgsMultiPolygon& multipoly )
+QgsAbstractGeometryV2* QgsGeometryFactory::fromMultiPolygon( const QgsMultiPolygon& multipoly )
 {
   QgsMultiPolygonV2* mp = new QgsMultiPolygonV2();
   for ( int i = 0; i < multipoly.size(); ++i )
@@ -177,7 +177,7 @@ QgsAbstractGeometryV2* QgsGeometryImport::fromMultiPolygon( const QgsMultiPolygo
   return mp;
 }
 
-QgsAbstractGeometryV2* QgsGeometryImport::fromRect( const QgsRectangle& rect )
+QgsAbstractGeometryV2* QgsGeometryFactory::fromRect( const QgsRectangle& rect )
 {
   QgsPolyline ring;
   ring.append( QgsPoint( rect.xMinimum(), rect.yMinimum() ) );
@@ -192,7 +192,7 @@ QgsAbstractGeometryV2* QgsGeometryImport::fromRect( const QgsRectangle& rect )
   return fromPolygon( polygon );
 }
 
-QgsLineStringV2* QgsGeometryImport::linestringFromPolyline( const QgsPolyline& polyline )
+QgsLineStringV2* QgsGeometryFactory::linestringFromPolyline( const QgsPolyline& polyline )
 {
   QgsLineStringV2* line = new QgsLineStringV2();
 
@@ -206,7 +206,7 @@ QgsLineStringV2* QgsGeometryImport::linestringFromPolyline( const QgsPolyline& p
   return line;
 }
 
-QgsAbstractGeometryV2* QgsGeometryImport::geomFromWkbType( QgsWKBTypes::Type t )
+QgsAbstractGeometryV2* QgsGeometryFactory::geomFromWkbType( QgsWKBTypes::Type t )
 {
   QgsWKBTypes::Type type = QgsWKBTypes::flatType( t );
   switch ( type )

--- a/src/core/geometry/qgsgeometryfactory.h
+++ b/src/core/geometry/qgsgeometryfactory.h
@@ -1,5 +1,5 @@
 /***************************************************************************
-                           qgsgeometryimport.h
+                           qgsgeometryfactory.h
                          -----------------------
     begin                : September 2014
     copyright            : (C) 2014 by Marco Hugentobler
@@ -15,8 +15,8 @@
  *                                                                         *
  ***************************************************************************/
 
-#ifndef QGSGEOMETRYIMPORT_H
-#define QGSGEOMETRYIMPORT_H
+#ifndef QGSGEOMETRYFACTORY_H
+#define QGSGEOMETRYFACTORY_H
 
 #include "qgsrectangle.h"
 #include "qgswkbtypes.h"
@@ -34,11 +34,11 @@ typedef QVector<QgsPolyline> QgsMultiPolyline;
 typedef QVector<QgsPolygon> QgsMultiPolygon;
 
 /**\ingroup core
- * \class QgsGeometryImport
- * \brief Contains geometry importing routines.
+ * \class QgsGeometryFactory
+ * \brief Contains geometry creation routines.
  * \note added in QGIS 2.10
  */
-class CORE_EXPORT QgsGeometryImport
+class CORE_EXPORT QgsGeometryFactory
 {
   public:
     /** Construct geometry from a WKB string.
@@ -70,4 +70,4 @@ class CORE_EXPORT QgsGeometryImport
     static QgsLineStringV2* linestringFromPolyline( const QgsPolyline& polyline );
 };
 
-#endif // QGSGEOMETRYIMPORT_H
+#endif // QGSGEOMETRYFACTORY_H

--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -16,7 +16,7 @@ email                : marco.hugentobler at sourcepole dot com
 #include "qgsgeos.h"
 #include "qgsabstractgeometryv2.h"
 #include "qgsgeometrycollectionv2.h"
-#include "qgsgeometryimport.h"
+#include "qgsgeometryfactory.h"
 #include "qgslinestringv2.h"
 #include "qgsmessagelog.h"
 #include "qgsmulticurvev2.h"


### PR DESCRIPTION
- Updated docs to reflect that QgsGeometry isn't deprecated, and will be used as a generic, shared container for geometry objects
- Rename QgsGeometryImport -> QgsGeometryFactory to better reflect what the class does
