### PR TITLE
fix loss of expression when subsymbol is changed

### DIFF
--- a/src/gui/symbology-ng/qgssymbolv2selectordialog.h
+++ b/src/gui/symbology-ng/qgssymbolv2selectordialog.h
@@ -20,7 +20,10 @@
 
 #include "ui_qgssymbolv2selectordialogbase.h"
 
+#include "qgsdatadefined.h"
+
 #include <QStandardItemModel>
+#include <QScopedPointer>
 
 class QgsStyleV2;
 class QgsSymbolV2;
@@ -31,6 +34,37 @@ class QMenu;
 class QWidget;
 
 class SymbolLayerItem;
+class QgsMarkerSymbolV2;
+class QgsLineSymbolV2;
+class QgsMarkerSymbolLayerV2;
+class QgsLineSymbolLayerV2;
+
+class DataDefinedRestorer: public QObject
+{
+  Q_OBJECT
+  public:
+    DataDefinedRestorer( QgsSymbolV2* symbol, const QgsSymbolLayerV2* symbolLayer);
+
+  public slots:
+    void restore();
+
+  private:
+    QgsMarkerSymbolV2* mMarker;
+    const QgsMarkerSymbolLayerV2* mMarkerSymbolLayer;
+    double mSize;
+    double mAngle;
+    QPointF mMarkerOffset;
+    QgsDataDefined mDDSize;
+    QgsDataDefined mDDAngle;
+
+    QgsLineSymbolV2* mLine;
+    const QgsLineSymbolLayerV2* mLineSymbolLayer;
+    double mWidth; 
+    double mLineOffset;
+    QgsDataDefined mDDWidth;
+
+    void save();
+};
 
 class GUI_EXPORT QgsSymbolV2SelectorDialog : public QDialog, private Ui::QgsSymbolV2SelectorDialogBase
 {
@@ -95,6 +129,9 @@ class GUI_EXPORT QgsSymbolV2SelectorDialog : public QDialog, private Ui::QgsSymb
 
     QStandardItemModel* model;
     QWidget *mPresentWidget;
+
+  private:
+    QScopedPointer<DataDefinedRestorer> mDataDefineRestorer;
 };
 
 #endif


### PR DESCRIPTION
bug mentionned in issue #13033
if the angle, size, width or offset is changed for a subsymbol which
parent (a marker) has data-defined size, angle or width, restore the
data-defined property for the marker.

@nyalldawson 
