### PR TITLE
Fix infinite loop when painting grid with bad paramters

### DIFF
--- a/src/core/composer/qgscomposermapgrid.cpp
+++ b/src/core/composer/qgscomposermapgrid.cpp
@@ -1641,6 +1641,8 @@ int QgsComposerMapGrid::xGridLinesCRSTransform( const QgsRectangle& bbox, const 
   double minX = bbox.xMinimum();
   double maxX = bbox.xMaximum();
   double step = ( maxX - minX ) / 20;
+  if ( step == 0 )
+    return 0;
 
   bool crosses180 = false;
   bool crossed180 = false;
@@ -1713,6 +1715,8 @@ int QgsComposerMapGrid::yGridLinesCRSTransform( const QgsRectangle& bbox, const 
   double minY = bbox.yMinimum();
   double maxY = bbox.yMaximum();
   double step = ( maxY - minY ) / 20;
+  if ( step == 0 )
+    return 0;
 
   bool crosses180 = false;
   bool crossed180 = false;


### PR DESCRIPTION
This adds a security check on bad parameters for painting grid lines leading to an infinite loop.
This was triggered when the dialog for "Export Composer to PDF" was being opened and about to warn the user that there are effects which require rasterization.
