### PR TITLE
Framework for context based expressions

### DIFF
--- a/python/core/core.sip
+++ b/python/core/core.sip
@@ -36,6 +36,7 @@
 %Include qgseditorwidgetconfig.sip
 %Include qgserror.sip
 %Include qgsexpression.sip
+%Include qgsexpressioncontext.sip
 %Include qgsfeature.sip
 %Include qgsfeatureiterator.sip
 %Include qgsfeaturerequest.sip

--- a/python/core/qgsexpression.sip
+++ b/python/core/qgsexpression.sip
@@ -17,7 +17,10 @@ class QgsExpression
     const QgsExpression::Node* rootNode() const;
 
     //! Get the expression ready for evaluation - find out column indexes.
-    bool prepare( const QgsFields &fields );
+    bool prepare( const QgsFields &fields ) /Deprecated/;
+
+    //! Get the expression ready for evaluation - find out column indexes.
+    bool prepare( const QgsExpressionContext &context );
 
     /**
      * Get list of columns referenced by the expression.
@@ -34,28 +37,32 @@ class QgsExpression
 
     //! Evaluate the feature and return the result
     //! @note prepare() should be called before calling this method
-    QVariant evaluate( const QgsFeature* f = NULL );
+    QVariant evaluate( const QgsFeature* f ) /Deprecated/;
 
     //! Evaluate the feature and return the result
     //! @note prepare() should be called before calling this method
     //! @note available in python bindings as evaluatePrepared
-    QVariant evaluate( const QgsFeature& f ) /PyName=evaluatePrepared/;
+    QVariant evaluate( const QgsFeature& f ) /PyName=evaluatePrepared,Deprecated/;
 
     //! Evaluate the feature and return the result
     //! @note this method does not expect that prepare() has been called on this instance
-    QVariant evaluate( const QgsFeature* f, const QgsFields& fields );
+    QVariant evaluate( const QgsFeature* f, const QgsFields& fields ) /Deprecated/;
 
     //! Evaluate the feature and return the result
     //! @note this method does not expect that prepare() has been called on this instance
     //! @note not available in python bindings
     // inline QVariant evaluate( const QgsFeature& f, const QgsFields& fields ) { return evaluate( &f, fields ); }
 
+    QVariant evaluate();
+    QVariant evaluate( const QgsExpressionContext& context );
+
+
     //! Returns true if an error occurred when evaluating last input
     bool hasEvalError() const;
     //! Returns evaluation error
     QString evalErrorString() const;
     //! Set evaluation error (used internally by evaluation functions)
-    void setEvalErrorString( QString str );
+    void setEvalErrorString( const QString& str );
 
     //! Set the number for $rownum special column
     void setCurrentRowNumber( int rowNumber );
@@ -77,7 +84,8 @@ class QgsExpression
      */
     bool isField() const;
 
-    static bool isValid( const QString& text, const QgsFields& fields, QString &errorMessage );
+    static bool isValid( const QString& text, const QgsFields& fields, QString &errorMessage ) /Deprecated/;
+    static bool isValid( const QString& text, const QgsExpressionContext& context, QString &errorMessage );
 
     void setScale( double scale );
 
@@ -231,7 +239,8 @@ class QgsExpression
         /** The help text for the function. */
         const QString helptext();
 
-        virtual QVariant func( const QVariantList& values, const QgsFeature* f, QgsExpression* parent ) = 0;
+        virtual QVariant func( const QVariantList& values, const QgsFeature* f, QgsExpression* parent ) /Deprecated/;
+     	virtual QVariant func( const QVariantList& values, const QgsExpressionContext* context, QgsExpression* parent );
 
         virtual bool handlesNull() const;
     };
@@ -243,7 +252,7 @@ class QgsExpression
     static bool unregisterFunction( QString name );
 
     // tells whether the identifier is a name of existing function
-    static bool isFunctionName( QString name );
+    static bool isFunctionName( const QString& name );
 
     // return index of the function in Functions array
     static int functionIndex( const QString& name );
@@ -297,11 +306,13 @@ class QgsExpression
         virtual QgsExpression::NodeType nodeType() const = 0;
         // abstract virtual eval function
         // errors are reported to the parent
-        virtual QVariant eval( QgsExpression* parent, const QgsFeature* f ) = 0;
+        virtual QVariant eval( QgsExpression* parent, const QgsFeature* f ) /Deprecated/;
+	virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context );
 
         // abstract virtual preparation function
         // errors are reported to the parent
-        virtual bool prepare( QgsExpression* parent, const QgsFields &fields ) = 0;
+        virtual bool prepare( QgsExpression* parent, const QgsFields &fields ) /Deprecated/;
+        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext& context );
 
         virtual QString dump() const = 0;
 
@@ -357,8 +368,8 @@ class QgsExpression
         QgsExpression::Node* operand() const;
 
         virtual QgsExpression::NodeType nodeType() const;
-        virtual bool prepare( QgsExpression* parent, const QgsFields &fields );
-        virtual QVariant eval( QgsExpression* parent, const QgsFeature* f );
+        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext& context );
+	virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context );
         virtual QString dump() const;
 
         virtual QStringList referencedColumns() const;
@@ -377,8 +388,8 @@ class QgsExpression
         QgsExpression::Node* opRight() const;
 
         virtual QgsExpression::NodeType nodeType() const;
-        virtual bool prepare( QgsExpression* parent, const QgsFields &fields );
-        virtual QVariant eval( QgsExpression* parent, const QgsFeature* f );
+        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext& context );
+	virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context );
         virtual QString dump() const;
 
         virtual QStringList referencedColumns() const;
@@ -400,8 +411,8 @@ class QgsExpression
         QgsExpression::NodeList* list() const;
 
         virtual QgsExpression::NodeType nodeType() const;
-        virtual bool prepare( QgsExpression* parent, const QgsFields &fields );
-        virtual QVariant eval( QgsExpression* parent, const QgsFeature* f );
+        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext& context );
+	virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context );
         virtual QString dump() const;
 
         virtual QStringList referencedColumns() const;
@@ -420,8 +431,8 @@ class QgsExpression
         QgsExpression::NodeList* args() const;
 
         virtual QgsExpression::NodeType nodeType() const;
-        virtual bool prepare( QgsExpression* parent, const QgsFields &fields );
-        virtual QVariant eval( QgsExpression* parent, const QgsFeature* f );
+        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext& context );
+	virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context );
         virtual QString dump() const;
 
         virtual QStringList referencedColumns() const;
@@ -437,8 +448,8 @@ class QgsExpression
         const QVariant& value() const;
 
         virtual QgsExpression::NodeType nodeType() const;
-        virtual bool prepare( QgsExpression* parent, const QgsFields &fields );
-        virtual QVariant eval( QgsExpression* parent, const QgsFeature* f );
+        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext& context );
+	virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context );
         virtual QString dump() const;
 
         virtual QStringList referencedColumns() const;
@@ -454,8 +465,8 @@ class QgsExpression
         QString name() const;
 
         virtual QgsExpression::NodeType nodeType() const;
-        virtual bool prepare( QgsExpression* parent, const QgsFields &fields );
-        virtual QVariant eval( QgsExpression* parent, const QgsFeature* f );
+        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext& context );
+	virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context );
         virtual QString dump() const;
 
         virtual QStringList referencedColumns() const;
@@ -482,8 +493,8 @@ class QgsExpression
         ~NodeCondition();
 
         virtual QgsExpression::NodeType nodeType() const;
-        virtual QVariant eval( QgsExpression* parent, const QgsFeature* f );
-        virtual bool prepare( QgsExpression* parent, const QgsFields &fields );
+        virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context );
+        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext& context );
         virtual QString dump() const;
 
         virtual QStringList referencedColumns() const;

--- a/python/core/qgsexpression.sip
+++ b/python/core/qgsexpression.sip
@@ -20,7 +20,7 @@ class QgsExpression
     bool prepare( const QgsFields &fields ) /Deprecated/;
 
     //! Get the expression ready for evaluation - find out column indexes.
-    bool prepare( const QgsExpressionContext &context );
+    bool prepare( const QgsExpressionContext *context );
 
     /**
      * Get list of columns referenced by the expression.
@@ -54,7 +54,7 @@ class QgsExpression
     // inline QVariant evaluate( const QgsFeature& f, const QgsFields& fields ) { return evaluate( &f, fields ); }
 
     QVariant evaluate();
-    QVariant evaluate( const QgsExpressionContext& context );
+    QVariant evaluate( const QgsExpressionContext* context );
 
 
     //! Returns true if an error occurred when evaluating last input
@@ -85,7 +85,7 @@ class QgsExpression
     bool isField() const;
 
     static bool isValid( const QString& text, const QgsFields& fields, QString &errorMessage ) /Deprecated/;
-    static bool isValid( const QString& text, const QgsExpressionContext& context, QString &errorMessage );
+    static bool isValid( const QString& text, const QgsExpressionContext* context, QString &errorMessage );
 
     void setScale( double scale );
 
@@ -312,7 +312,7 @@ class QgsExpression
         // abstract virtual preparation function
         // errors are reported to the parent
         virtual bool prepare( QgsExpression* parent, const QgsFields &fields ) /Deprecated/;
-        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext& context );
+        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext* context );
 
         virtual QString dump() const = 0;
 
@@ -368,8 +368,8 @@ class QgsExpression
         QgsExpression::Node* operand() const;
 
         virtual QgsExpression::NodeType nodeType() const;
-        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext& context );
-	virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context );
+        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext* context );
+	    virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context );
         virtual QString dump() const;
 
         virtual QStringList referencedColumns() const;
@@ -388,8 +388,8 @@ class QgsExpression
         QgsExpression::Node* opRight() const;
 
         virtual QgsExpression::NodeType nodeType() const;
-        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext& context );
-	virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context );
+        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext* context );
+	    virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context );
         virtual QString dump() const;
 
         virtual QStringList referencedColumns() const;
@@ -411,8 +411,8 @@ class QgsExpression
         QgsExpression::NodeList* list() const;
 
         virtual QgsExpression::NodeType nodeType() const;
-        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext& context );
-	virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context );
+        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext* context );
+	    virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context );
         virtual QString dump() const;
 
         virtual QStringList referencedColumns() const;
@@ -431,8 +431,8 @@ class QgsExpression
         QgsExpression::NodeList* args() const;
 
         virtual QgsExpression::NodeType nodeType() const;
-        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext& context );
-	virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context );
+        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext* context );
+	    virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context );
         virtual QString dump() const;
 
         virtual QStringList referencedColumns() const;
@@ -448,8 +448,8 @@ class QgsExpression
         const QVariant& value() const;
 
         virtual QgsExpression::NodeType nodeType() const;
-        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext& context );
-	virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context );
+        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext* context );
+	    virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context );
         virtual QString dump() const;
 
         virtual QStringList referencedColumns() const;
@@ -465,8 +465,8 @@ class QgsExpression
         QString name() const;
 
         virtual QgsExpression::NodeType nodeType() const;
-        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext& context );
-	virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context );
+        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext* context );
+	    virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context );
         virtual QString dump() const;
 
         virtual QStringList referencedColumns() const;
@@ -494,7 +494,7 @@ class QgsExpression
 
         virtual QgsExpression::NodeType nodeType() const;
         virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context );
-        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext& context );
+        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext* context );
         virtual QString dump() const;
 
         virtual QStringList referencedColumns() const;

--- a/python/core/qgsexpressioncontext.sip
+++ b/python/core/qgsexpressioncontext.sip
@@ -1,0 +1,300 @@
+/** \ingroup core
+ * \class QgsExpressionContext
+ * \brief Base class for expression contexts. Expression contexts are used to
+ * encapsulate the parameters around which an expression should be evaluated.
+ * Examples include the project's context, which contains information about the
+ * current project such as the project file's location. Expressions can then
+ * utilise the information stored in a context to vary their output result.
+ * Contexts can encapsulate both variables (static values) and functions
+ * (which are calculated only when the expression is evaluated).
+ * \note added in QGIS 2.12
+ */
+
+class QgsExpressionContext
+{
+%TypeHeaderCode
+#include "qgsexpressioncontext.h"
+%End
+
+%ConvertToSubClassCode
+  if ( dynamic_cast<QgsExpressionContextStack*>(sipCpp) != NULL )
+  {
+     sipClass = sipClass_QgsExpressionContextStack;
+  }
+  else if ( dynamic_cast<QgsGlobalExpressionContext*>(sipCpp) != NULL)
+  {
+     sipClass = sipClass_QgsGlobalExpressionContext;
+  }
+  else if ( dynamic_cast<QgsProjectExpressionContext*>(sipCpp) != NULL)
+  {
+     sipClass = sipClass_QgsProjectExpressionContext;
+  }
+  else if ( dynamic_cast<QgsStaticValueExpressionContext*>(sipCpp) != NULL)
+  {
+     sipClass = sipClass_QgsStaticValueExpressionContext;
+  }
+  else if ( dynamic_cast<QgsStaticValueExpressionContext*>(sipCpp) != NULL)
+  {
+     sipClass = sipClass_QgsStaticValueExpressionContext;
+  }
+  else if ( dynamic_cast<QgsExpressionContext*>(sipCpp) != NULL)
+  {
+     sipClass = sipClass_QgsExpressionContext;
+  }
+  else
+  {
+    sipClass = 0;
+  }
+%End
+
+  public:
+
+    /** Constructor for QgsExpressionContext
+     * @param name friendly display name for the context
+     */
+    QgsExpressionContext( const QString& name = QString() );
+
+    virtual ~QgsExpressionContext();
+
+    /** Returns the name of the context.
+     */
+    QString name() const;
+
+    /** Check whether a variable is specified in the context.
+     * @param name variable name
+     * @returns true if variable is set
+     * @see variable
+     * @see variablenames
+     */
+    virtual bool hasVariable( const QString& name ) const;
+
+    /** Fetches a matching variable from the context.
+     * @param name variable name
+     * @returns variable value if set in the context, otherwise an invalid QVariant
+     * @see hasVariable
+     * @see variableNames
+     */
+    virtual QVariant variable( const QString& name ) const;
+
+    /** Returns a list of variables names set in the context.
+     * @returns list of unique variable names
+     * @see hasVariable
+     * @see variable
+     */
+    virtual QStringList variableNames() const;
+
+    /** Returns whether a variable is read only, and should not be modifiable by users.
+     * @param name variable name
+     * @returns true if variable is read only
+     */
+    virtual bool isReadOnly( const QString& name ) const;
+
+    /** Checks whether a specified function is contained in the context.
+     * @param name function name
+     * @returns true if context provides a matching function
+     * @see function
+     */
+    virtual bool hasFunction( const QString& name ) const;
+
+    /** Fetches a matching function from the context.
+     * @param name function name
+     * @returns function if contained by the context, otherwise null
+     * @see hasFunction
+     */
+    virtual QgsExpression::Function* function( const QString& name ) const;
+
+    /** Returns a list of reserved variable names. These variable names
+     * are used internally by QGIS and must not be reused by user
+     * specified variables.
+     */
+    static QStringList reservedVariables();
+
+};
+
+/** \ingroup core
+ * \class QgsExpressionContextStack
+ * \brief A stack of expression contexts. Essentially an expression stack is
+ * an ordered list of expressions contexts, where contexts later in the
+ * stack override earlier contexts. Stacks can be used to combine multiple
+ * QgsExpressionContexts, eg to combine the global expression context
+ * with a project's context, with a particular render operation's context.
+ * \note added in QGIS 2.12
+ */
+
+class QgsExpressionContextStack : QgsExpressionContext
+{
+%TypeHeaderCode
+#include "qgsexpressioncontext.h"
+%End
+  public:
+
+    QgsExpressionContextStack();
+
+    virtual ~QgsExpressionContextStack();
+
+    /** Appends a context to the end of the stack. This context will override
+     * any matching variables or functions provided by existing members of the
+     * stack. Ownership of the context is NOT transferred to the stack.
+     * @param context expression context to append to stack
+     */
+    void appendContext( QgsExpressionContext* context );
+
+    /** Checks whether a stack includes any contexts which specify
+     * a matching variable.
+     * @param name variable name
+     * @returns true if stack includes the specified variable
+     * @see variable
+     * @see variableNames
+     */
+    virtual bool hasVariable( const QString& name ) const;
+
+    /** Fetches a matching variable from the stack. Contexts later in
+     * the stack will take precedence (ie, the stack is searched from
+     * the last added context through to the first and returns the
+     * first matching variable found).
+     * @param name variable name
+     * @returns matching variable value from the stack, or an invalid
+     * QVariant if variable was not found
+     * @see hasVariable
+     * @see variableNames
+     */
+    virtual QVariant variable( const QString& name ) const;
+
+    /** Returns the currently active context from the stack for a specified variable.
+     * As contexts later in the stack override earlier contexts, this will be
+     * the last matching context which contains the variable.
+     * @param name variable name
+     * @returns matching context containing variable, or null if none found
+     */
+    QgsExpressionContext* activeContextForVariable( const QString& name ) const;
+
+    /** Returns a list of unique variable names specified by contexts
+     * within the stack.
+     * @see hasVariable
+     * @see variable
+     */
+    virtual QStringList variableNames() const;
+
+    /** Checks whether a stack includes any contexts which specify
+     * a matching function.
+     * @param name function name
+     * @returns true if stack includes the specified function
+     * @see function
+     */
+    virtual bool hasFunction( const QString& name ) const;
+
+    /** Fetches a matching function from the stack. Contexts later in
+     * the stack will take precedence (ie, the stack is searched from
+     * the last added context through to the first and returns the
+     * first matching function found).
+     * @param name function name
+     * @returns function if contained by the stack, otherwise null
+     * @see hasFunction
+     */
+    virtual QgsExpression::Function* function( const QString& name ) const;
+
+    /** Returns a reference to the list of contexts stored in the stack
+     */
+    QList< QgsExpressionContext* >& stack();
+};
+
+/** \ingroup core
+ * \class QgsStaticValueExpressionContext
+ * \brief Expression context for simple property/value maps.
+ * \note added in QGIS 2.12
+ */
+
+class QgsStaticValueExpressionContext : QgsExpressionContext
+{
+%TypeHeaderCode
+#include "qgsexpressioncontext.h"
+%End
+  public:
+
+    struct StaticVariable
+    {
+      StaticVariable( const QString& name = QString(), const QVariant& value = QVariant(), bool readOnly = false );
+      QString name;
+      QVariant value;
+      bool readOnly;
+    };
+
+    /** Constructor for QgsStaticValueExpressionContext
+     * @param name friendly display name for the context
+     */
+    QgsStaticValueExpressionContext( const QString& name = QString() );
+
+    /** Convenience method for setting a variable in the context. If the variable is already set then
+     * its value is overwritten, otherwise a new variable is added to the context.
+     * @param name variable name
+     * @param value variable value
+     * @see insertVariable
+     */
+    virtual void setVariable( const QString& name, const QVariant& value );
+
+    /** Inserts a variable into the context. If the variable is already set then
+     * its value is overwritten, otherwise a new variable is added to the
+     * context.
+     * @param variable definition of variable to insert
+     * @see setVariable
+     */
+    virtual void insertVariable( const QgsStaticValueExpressionContext::StaticVariable& variable );
+
+    /** Removes a variable from the context, if found.
+     * @param name name of variable to remove
+     */
+    virtual void removeVariable( const QString& name );
+
+    bool hasVariable( const QString& name ) const;
+    QVariant variable( const QString& name ) const;
+    QStringList variableNames() const;
+    virtual bool isReadOnly( const QString& name ) const;
+
+};
+
+/** \ingroup core
+ * \class QgsGlobalExpressionContext
+ * \brief Expression context for global, user-specified variables. These variables
+ * are saved in QGIS settings and are persistent across sessions and projects.
+ * \note added in QGIS 2.12
+ */
+
+class QgsGlobalExpressionContext : QgsStaticValueExpressionContext
+{
+  public:
+
+    /** Saves the variables contained in the context to the user's QGIS settings.
+     */
+    void save();
+
+  protected:
+    QgsGlobalExpressionContext();
+    ~QgsGlobalExpressionContext();
+
+};
+
+
+/** \ingroup core
+ * \class QgsProjectExpressionContext
+ * \brief Expression context for variables attached to a project. The variables
+ * are stored within the project file.
+ * \note added in QGIS 2.12
+ */
+
+class QgsProjectExpressionContext : QgsStaticValueExpressionContext
+{
+  public:
+
+    QgsProjectExpressionContext( QgsProject* project = 0 );
+
+    /** Clears all variables from the project context
+     */
+    void clear();
+
+    /** Loads variables from the current project to the context
+     */
+    void load();
+
+    virtual void insertVariable( const QgsStaticValueExpressionContext::StaticVariable& value );
+
+};

--- a/python/core/qgsproject.sip
+++ b/python/core/qgsproject.sip
@@ -21,6 +21,7 @@ class QgsProject : QObject
 {
 %TypeHeaderCode
 #include <qgsproject.h>
+#include <qgsexpressioncontext.h>
 %End
 
   public:
@@ -257,6 +258,19 @@ class QgsProject : QObject
      * @note added in 2.4
      */
     QgsLayerTreeRegistryBridge* layerTreeRegistryBridge() const;
+
+    /** Return pointer to the project's expression context. This context contains variables
+     * which are stored in the project file
+     * @returns project context
+     * @note added in 2.9
+     */
+    QgsProjectExpressionContext* projectExpressionContext() const;
+
+    /** Return pointer to the expression context stack at project level. This stack includes
+     * both the project's expression context and any contexts from lower level components.
+     * @note added in 2.9
+     */
+    QgsExpressionContextStack* expressionContextStack() const;
 
   protected:
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -93,6 +93,7 @@ SET(QGIS_CORE_SRCS
   qgsdistancearea.cpp
   qgserror.cpp
   qgsexpression.cpp
+  qgsexpressioncontext.cpp
   qgsexpression_texts.cpp
   qgsexpressionfieldbuffer.cpp
   qgsfeature.cpp
@@ -533,6 +534,7 @@ SET(QGIS_CORE_HDRS
   qgserror.h
   qgsexception.h
   qgsexpression.h
+  qgsexpressioncontext.h
   qgsexpressionfieldbuffer.h
   qgsfeature.h
   qgsfeature_p.h

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -22,6 +22,7 @@
 #include "qgsmaplayerregistry.h"
 #include "qgsnetworkaccessmanager.h"
 #include "qgsproviderregistry.h"
+#include "qgsexpressioncontext.h"
 
 #include <QDir>
 #include <QFile>
@@ -623,6 +624,7 @@ void QgsApplication::initQgis()
 
 void QgsApplication::exitQgis()
 {
+  delete QgsGlobalExpressionContext::instance();
   delete QgsProviderRegistry::instance();
 }
 

--- a/src/core/qgsdatadefined.h
+++ b/src/core/qgsdatadefined.h
@@ -53,6 +53,7 @@ class CORE_EXPORT QgsDataDefined
      * Construct a new data defined object, analysing the expression to determine
      * if it's a simple field reference or an expression.
      * @param expression can be null
+     * @note added in QGIS 2.9
      */
     explicit QgsDataDefined( const QgsExpression * expression );
 
@@ -81,7 +82,7 @@ class CORE_EXPORT QgsDataDefined
 
     virtual ~QgsDataDefined();
 
-    /**Returns whether the data defined container is set to all the default
+    /** Returns whether the data defined container is set to all the default
      * values, ie, disabled, with empty expression and no assigned field
      * @returns true if data defined container is set to default values
      * @note added in QGIS 2.7
@@ -144,7 +145,7 @@ class CORE_EXPORT QgsDataDefined
      */
     QgsStringMap toMap( const QString& baseName = QString() ) const;
 
-    /**Returns a DOM element containing the properties of the data defined container.
+    /** Returns a DOM element containing the properties of the data defined container.
      * @param document DOM document
      * @param elementName name for DOM element
      * @returns DOM element corresponding to data defined container
@@ -153,7 +154,7 @@ class CORE_EXPORT QgsDataDefined
      */
     QDomElement toXmlElement( QDomDocument &document, const QString &elementName ) const;
 
-    /**Sets the properties of the data defined container from an XML element. Calling
+    /** Sets the properties of the data defined container from an XML element. Calling
      * this will overwrite all the current properties of the container.
      * @param element DOM element
      * @returns true if properties were successfully read from element

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -35,6 +35,8 @@
 #include "qgssymbollayerv2utils.h"
 #include "qgsvectorcolorrampv2.h"
 #include "qgsstylev2.h"
+#include "qgsexpressioncontext.h"
+#include "qgsproject.h"
 #include "qgsstringutils.h"
 
 // from parser
@@ -370,74 +372,80 @@ static TVL getTVLValue( const QVariant& value, QgsExpression* parent )
 
 //////
 
-static QVariant fcnSqrt( const QVariantList& values, const QgsFeature* /*f*/, QgsExpression* parent )
+static QVariant fcnGetVariable( const QVariantList& values, const QgsExpressionContext* context, QgsExpression* parent )
+{
+  QString name = getStringValue( values.at( 0 ), parent );
+  return context->variable( name );
+}
+
+static QVariant fcnSqrt( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   double x = getDoubleValue( values.at( 0 ), parent );
   return QVariant( sqrt( x ) );
 }
 
-static QVariant fcnAbs( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnAbs( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   double val = getDoubleValue( values.at( 0 ), parent );
   return QVariant( fabs( val ) );
 }
 
-static QVariant fcnSin( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnSin( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   double x = getDoubleValue( values.at( 0 ), parent );
   return QVariant( sin( x ) );
 }
-static QVariant fcnCos( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnCos( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   double x = getDoubleValue( values.at( 0 ), parent );
   return QVariant( cos( x ) );
 }
-static QVariant fcnTan( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnTan( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   double x = getDoubleValue( values.at( 0 ), parent );
   return QVariant( tan( x ) );
 }
-static QVariant fcnAsin( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnAsin( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   double x = getDoubleValue( values.at( 0 ), parent );
   return QVariant( asin( x ) );
 }
-static QVariant fcnAcos( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnAcos( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   double x = getDoubleValue( values.at( 0 ), parent );
   return QVariant( acos( x ) );
 }
-static QVariant fcnAtan( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnAtan( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   double x = getDoubleValue( values.at( 0 ), parent );
   return QVariant( atan( x ) );
 }
-static QVariant fcnAtan2( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnAtan2( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   double y = getDoubleValue( values.at( 0 ), parent );
   double x = getDoubleValue( values.at( 1 ), parent );
   return QVariant( atan2( y, x ) );
 }
-static QVariant fcnExp( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnExp( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   double x = getDoubleValue( values.at( 0 ), parent );
   return QVariant( exp( x ) );
 }
-static QVariant fcnLn( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnLn( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   double x = getDoubleValue( values.at( 0 ), parent );
   if ( x <= 0 )
     return QVariant();
   return QVariant( log( x ) );
 }
-static QVariant fcnLog10( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnLog10( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   double x = getDoubleValue( values.at( 0 ), parent );
   if ( x <= 0 )
     return QVariant();
   return QVariant( log10( x ) );
 }
-static QVariant fcnLog( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnLog( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   double b = getDoubleValue( values.at( 0 ), parent );
   double x = getDoubleValue( values.at( 1 ), parent );
@@ -445,7 +453,7 @@ static QVariant fcnLog( const QVariantList& values, const QgsFeature*, QgsExpres
     return QVariant();
   return QVariant( log( x ) / log( b ) );
 }
-static QVariant fcnRndF( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnRndF( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   double min = getDoubleValue( values.at( 0 ), parent );
   double max = getDoubleValue( values.at( 1 ), parent );
@@ -456,7 +464,7 @@ static QVariant fcnRndF( const QVariantList& values, const QgsFeature*, QgsExpre
   double f = ( double )qrand() / RAND_MAX;
   return QVariant( min + f * ( max - min ) );
 }
-static QVariant fcnRnd( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnRnd( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   int min = getIntValue( values.at( 0 ), parent );
   int max = getIntValue( values.at( 1 ), parent );
@@ -467,7 +475,7 @@ static QVariant fcnRnd( const QVariantList& values, const QgsFeature*, QgsExpres
   return QVariant( min + ( qrand() % ( int )( max - min + 1 ) ) );
 }
 
-static QVariant fcnLinearScale( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnLinearScale( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   double val = getDoubleValue( values.at( 0 ), parent );
   double domainMin = getDoubleValue( values.at( 1 ), parent );
@@ -499,7 +507,7 @@ static QVariant fcnLinearScale( const QVariantList& values, const QgsFeature*, Q
   return QVariant( m * val + c );
 }
 
-static QVariant fcnExpScale( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnExpScale( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   double val = getDoubleValue( values.at( 0 ), parent );
   double domainMin = getDoubleValue( values.at( 1 ), parent );
@@ -533,7 +541,7 @@ static QVariant fcnExpScale( const QVariantList& values, const QgsFeature*, QgsE
   return QVariant((( rangeMax - rangeMin ) / pow( domainMax - domainMin, exponent ) ) * pow( val - domainMin, exponent ) + rangeMin );
 }
 
-static QVariant fcnMax( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnMax( const QVariantList& values, const QgsExpressionContext*, QgsExpression *parent )
 {
   //initially set max as first value
   double maxVal = getDoubleValue( values.at( 0 ), parent );
@@ -551,7 +559,7 @@ static QVariant fcnMax( const QVariantList& values, const QgsFeature*, QgsExpres
   return QVariant( maxVal );
 }
 
-static QVariant fcnMin( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnMin( const QVariantList& values, const QgsExpressionContext*, QgsExpression *parent )
 {
   //initially set min as first value
   double minVal = getDoubleValue( values.at( 0 ), parent );
@@ -569,7 +577,7 @@ static QVariant fcnMin( const QVariantList& values, const QgsFeature*, QgsExpres
   return QVariant( minVal );
 }
 
-static QVariant fcnClamp( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnClamp( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   double minValue = getDoubleValue( values.at( 0 ), parent );
   double testValue = getDoubleValue( values.at( 1 ), parent );
@@ -590,37 +598,37 @@ static QVariant fcnClamp( const QVariantList& values, const QgsFeature*, QgsExpr
   }
 }
 
-static QVariant fcnFloor( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnFloor( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   double x = getDoubleValue( values.at( 0 ), parent );
   return QVariant( floor( x ) );
 }
 
-static QVariant fcnCeil( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnCeil( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   double x = getDoubleValue( values.at( 0 ), parent );
   return QVariant( ceil( x ) );
 }
 
-static QVariant fcnToInt( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnToInt( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   return QVariant( getIntValue( values.at( 0 ), parent ) );
 }
-static QVariant fcnToReal( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnToReal( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   return QVariant( getDoubleValue( values.at( 0 ), parent ) );
 }
-static QVariant fcnToString( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnToString( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   return QVariant( getStringValue( values.at( 0 ), parent ) );
 }
 
-static QVariant fcnToDateTime( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnToDateTime( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   return QVariant( getDateTimeValue( values.at( 0 ), parent ) );
 }
 
-static QVariant fcnCoalesce( const QVariantList& values, const QgsFeature*, QgsExpression* )
+static QVariant fcnCoalesce( const QVariantList& values, const QgsExpressionContext*, QgsExpression* )
 {
   foreach ( const QVariant &value, values )
   {
@@ -630,17 +638,17 @@ static QVariant fcnCoalesce( const QVariantList& values, const QgsFeature*, QgsE
   }
   return QVariant();
 }
-static QVariant fcnLower( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnLower( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   QString str = getStringValue( values.at( 0 ), parent );
   return QVariant( str.toLower() );
 }
-static QVariant fcnUpper( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnUpper( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   QString str = getStringValue( values.at( 0 ), parent );
   return QVariant( str.toUpper() );
 }
-static QVariant fcnTitle( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnTitle( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   QString str = getStringValue( values.at( 0 ), parent );
   QStringList elems = str.split( " " );
@@ -652,27 +660,27 @@ static QVariant fcnTitle( const QVariantList& values, const QgsFeature*, QgsExpr
   return QVariant( elems.join( " " ) );
 }
 
-static QVariant fcnTrim( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnTrim( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   QString str = getStringValue( values.at( 0 ), parent );
   return QVariant( str.trimmed() );
 }
 
-static QVariant fcnLevenshtein( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnLevenshtein( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   QString string1 = getStringValue( values.at( 0 ), parent );
   QString string2 = getStringValue( values.at( 1 ), parent );
   return QVariant( QgsStringUtils::levenshteinDistance( string1, string2, true ) );
 }
 
-static QVariant fcnLCS( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnLCS( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   QString string1 = getStringValue( values.at( 0 ), parent );
   QString string2 = getStringValue( values.at( 1 ), parent );
   return QVariant( QgsStringUtils::longestCommonSubstring( string1, string2, true ) );
 }
 
-static QVariant fcnHamming( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnHamming( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   QString string1 = getStringValue( values.at( 0 ), parent );
   QString string2 = getStringValue( values.at( 1 ), parent );
@@ -680,13 +688,13 @@ static QVariant fcnHamming( const QVariantList& values, const QgsFeature*, QgsEx
   return ( dist < 0 ? QVariant() : QVariant( QgsStringUtils::hammingDistance( string1, string2, true ) ) );
 }
 
-static QVariant fcnSoundex( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnSoundex( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   QString string = getStringValue( values.at( 0 ), parent );
   return QVariant( QgsStringUtils::soundex( string ) );
 }
 
-static QVariant fcnWordwrap( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnWordwrap( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   if ( values.length() == 2 || values.length() == 3 )
   {
@@ -752,19 +760,19 @@ static QVariant fcnWordwrap( const QVariantList& values, const QgsFeature*, QgsE
   return QVariant();
 }
 
-static QVariant fcnLength( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnLength( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   QString str = getStringValue( values.at( 0 ), parent );
   return QVariant( str.length() );
 }
-static QVariant fcnReplace( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnReplace( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   QString str = getStringValue( values.at( 0 ), parent );
   QString before = getStringValue( values.at( 1 ), parent );
   QString after = getStringValue( values.at( 2 ), parent );
   return QVariant( str.replace( before, after ) );
 }
-static QVariant fcnRegexpReplace( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnRegexpReplace( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   QString str = getStringValue( values.at( 0 ), parent );
   QString regexp = getStringValue( values.at( 1 ), parent );
@@ -779,7 +787,7 @@ static QVariant fcnRegexpReplace( const QVariantList& values, const QgsFeature*,
   return QVariant( str.replace( re, after ) );
 }
 
-static QVariant fcnRegexpMatch( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnRegexpMatch( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   QString str = getStringValue( values.at( 0 ), parent );
   QString regexp = getStringValue( values.at( 1 ), parent );
@@ -793,7 +801,7 @@ static QVariant fcnRegexpMatch( const QVariantList& values, const QgsFeature*, Q
   return QVariant( str.contains( re ) ? 1 : 0 );
 }
 
-static QVariant fcnRegexpSubstr( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnRegexpSubstr( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   QString str = getStringValue( values.at( 0 ), parent );
   QString regexp = getStringValue( values.at( 1 ), parent );
@@ -818,12 +826,12 @@ static QVariant fcnRegexpSubstr( const QVariantList& values, const QgsFeature*, 
   }
 }
 
-static QVariant fcnUuid( const QVariantList&, const QgsFeature*, QgsExpression* )
+static QVariant fcnUuid( const QVariantList&, const QgsExpressionContext*, QgsExpression* )
 {
   return QUuid::createUuid().toString();
 }
 
-static QVariant fcnSubstr( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnSubstr( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   QString str = getStringValue( values.at( 0 ), parent );
   int from = getIntValue( values.at( 1 ), parent );
@@ -831,29 +839,33 @@ static QVariant fcnSubstr( const QVariantList& values, const QgsFeature*, QgsExp
   return QVariant( str.mid( from -1, len ) );
 }
 
-static QVariant fcnRowNumber( const QVariantList&, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnRowNumber( const QVariantList&, const QgsExpressionContext*, QgsExpression* parent )
 {
   return QVariant( parent->currentRowNumber() );
 }
 
-static QVariant fcnFeatureId( const QVariantList&, const QgsFeature* f, QgsExpression* )
+#define FEAT_FROM_CONTEXT(c, f) if (!c || !c->hasVariable("feature")) return QVariant(); \
+  QgsFeature f = qvariant_cast<QgsFeature>( context->variable( "feature" ) );
+
+static QVariant fcnFeatureId( const QVariantList&, const QgsExpressionContext* context, QgsExpression* )
 {
+  FEAT_FROM_CONTEXT( context, f );
   // TODO: handling of 64-bit feature ids?
-  return f ? QVariant(( int )f->id() ) : QVariant();
+  return QVariant(( int )f.id() );
 }
 
-static QVariant fcnFeature( const QVariantList&, const QgsFeature* f, QgsExpression* )
+static QVariant fcnFeature( const QVariantList&, const QgsExpressionContext* context, QgsExpression* )
 {
-  return f ? QVariant::fromValue( *f ) : QVariant();
+  return context->variable( "feature" );
 }
-static QVariant fcnAttribute( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnAttribute( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   QgsFeature feat = getFeature( values.at( 0 ), parent );
   QString attr = getStringValue( values.at( 1 ), parent );
 
   return feat.attribute( attr );
 }
-static QVariant fcnConcat( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnConcat( const QVariantList& values, const QgsExpressionContext*, QgsExpression *parent )
 {
   QString concat;
   foreach ( const QVariant &value, values )
@@ -863,27 +875,27 @@ static QVariant fcnConcat( const QVariantList& values, const QgsFeature*, QgsExp
   return concat;
 }
 
-static QVariant fcnStrpos( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnStrpos( const QVariantList& values, const QgsExpressionContext*, QgsExpression *parent )
 {
   QString string = getStringValue( values.at( 0 ), parent );
   return string.indexOf( QRegExp( getStringValue( values.at( 1 ), parent ) ) );
 }
 
-static QVariant fcnRight( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnRight( const QVariantList& values, const QgsExpressionContext*, QgsExpression *parent )
 {
   QString string = getStringValue( values.at( 0 ), parent );
   int pos = getIntValue( values.at( 1 ), parent );
   return string.right( pos );
 }
 
-static QVariant fcnLeft( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnLeft( const QVariantList& values, const QgsExpressionContext*, QgsExpression *parent )
 {
   QString string = getStringValue( values.at( 0 ), parent );
   int pos = getIntValue( values.at( 1 ), parent );
   return string.left( pos );
 }
 
-static QVariant fcnRPad( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnRPad( const QVariantList& values, const QgsExpressionContext*, QgsExpression *parent )
 {
   QString string = getStringValue( values.at( 0 ), parent );
   int length = getIntValue( values.at( 1 ), parent );
@@ -891,7 +903,7 @@ static QVariant fcnRPad( const QVariantList& values, const QgsFeature*, QgsExpre
   return string.leftJustified( length, fill.at( 0 ), true );
 }
 
-static QVariant fcnLPad( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnLPad( const QVariantList& values, const QgsExpressionContext*, QgsExpression *parent )
 {
   QString string = getStringValue( values.at( 0 ), parent );
   int length = getIntValue( values.at( 1 ), parent );
@@ -899,7 +911,7 @@ static QVariant fcnLPad( const QVariantList& values, const QgsFeature*, QgsExpre
   return string.rightJustified( length, fill.at( 0 ), true );
 }
 
-static QVariant fcnFormatString( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnFormatString( const QVariantList& values, const QgsExpressionContext*, QgsExpression *parent )
 {
   QString string = getStringValue( values.at( 0 ), parent );
   for ( int n = 1; n < values.length(); n++ )
@@ -910,27 +922,27 @@ static QVariant fcnFormatString( const QVariantList& values, const QgsFeature*, 
 }
 
 
-static QVariant fcnNow( const QVariantList&, const QgsFeature*, QgsExpression * )
+static QVariant fcnNow( const QVariantList&, const QgsExpressionContext*, QgsExpression * )
 {
   return QVariant( QDateTime::currentDateTime() );
 }
 
-static QVariant fcnToDate( const QVariantList& values, const QgsFeature*, QgsExpression * parent )
+static QVariant fcnToDate( const QVariantList& values, const QgsExpressionContext*, QgsExpression * parent )
 {
   return QVariant( getDateValue( values.at( 0 ), parent ) );
 }
 
-static QVariant fcnToTime( const QVariantList& values, const QgsFeature*, QgsExpression * parent )
+static QVariant fcnToTime( const QVariantList& values, const QgsExpressionContext*, QgsExpression * parent )
 {
   return QVariant( getTimeValue( values.at( 0 ), parent ) );
 }
 
-static QVariant fcnToInterval( const QVariantList& values, const QgsFeature*, QgsExpression * parent )
+static QVariant fcnToInterval( const QVariantList& values, const QgsExpressionContext*, QgsExpression * parent )
 {
   return QVariant::fromValue( getInterval( values.at( 0 ), parent ) );
 }
 
-static QVariant fcnAge( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnAge( const QVariantList& values, const QgsExpressionContext*, QgsExpression *parent )
 {
   QDateTime d1 = getDateTimeValue( values.at( 0 ), parent );
   QDateTime d2 = getDateTimeValue( values.at( 1 ), parent );
@@ -938,7 +950,7 @@ static QVariant fcnAge( const QVariantList& values, const QgsFeature*, QgsExpres
   return QVariant::fromValue( QgsExpression::Interval( seconds ) );
 }
 
-static QVariant fcnDay( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnDay( const QVariantList& values, const QgsExpressionContext*, QgsExpression *parent )
 {
   QVariant value = values.at( 0 );
   QgsExpression::Interval inter = getInterval( value, parent, false );
@@ -953,7 +965,7 @@ static QVariant fcnDay( const QVariantList& values, const QgsFeature*, QgsExpres
   }
 }
 
-static QVariant fcnYear( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnYear( const QVariantList& values, const QgsExpressionContext*, QgsExpression *parent )
 {
   QVariant value = values.at( 0 );
   QgsExpression::Interval inter = getInterval( value, parent, false );
@@ -968,7 +980,7 @@ static QVariant fcnYear( const QVariantList& values, const QgsFeature*, QgsExpre
   }
 }
 
-static QVariant fcnMonth( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnMonth( const QVariantList& values, const QgsExpressionContext*, QgsExpression *parent )
 {
   QVariant value = values.at( 0 );
   QgsExpression::Interval inter = getInterval( value, parent, false );
@@ -983,7 +995,7 @@ static QVariant fcnMonth( const QVariantList& values, const QgsFeature*, QgsExpr
   }
 }
 
-static QVariant fcnWeek( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnWeek( const QVariantList& values, const QgsExpressionContext*, QgsExpression *parent )
 {
   QVariant value = values.at( 0 );
   QgsExpression::Interval inter = getInterval( value, parent, false );
@@ -998,7 +1010,7 @@ static QVariant fcnWeek( const QVariantList& values, const QgsFeature*, QgsExpre
   }
 }
 
-static QVariant fcnHour( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnHour( const QVariantList& values, const QgsExpressionContext*, QgsExpression *parent )
 {
   QVariant value = values.at( 0 );
   QgsExpression::Interval inter = getInterval( value, parent, false );
@@ -1013,7 +1025,7 @@ static QVariant fcnHour( const QVariantList& values, const QgsFeature*, QgsExpre
   }
 }
 
-static QVariant fcnMinute( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnMinute( const QVariantList& values, const QgsExpressionContext*, QgsExpression *parent )
 {
   QVariant value = values.at( 0 );
   QgsExpression::Interval inter = getInterval( value, parent, false );
@@ -1028,7 +1040,7 @@ static QVariant fcnMinute( const QVariantList& values, const QgsFeature*, QgsExp
   }
 }
 
-static QVariant fcnSeconds( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnSeconds( const QVariantList& values, const QgsExpressionContext*, QgsExpression *parent )
 {
   QVariant value = values.at( 0 );
   QgsExpression::Interval inter = getInterval( value, parent, false );
@@ -1044,13 +1056,12 @@ static QVariant fcnSeconds( const QVariantList& values, const QgsFeature*, QgsEx
 }
 
 
-#define ENSURE_GEOM_TYPE(f, g, geomtype)   if (!f) return QVariant(); \
-  const QgsGeometry* g = f->constGeometry(); \
+#define ENSURE_GEOM_TYPE(f, g, geomtype) const QgsGeometry* g = f.constGeometry(); \
   if (!g || g->type() != geomtype) return QVariant();
 
-
-static QVariant fcnX( const QVariantList&, const QgsFeature* f, QgsExpression* )
+static QVariant fcnX( const QVariantList&, const QgsExpressionContext* context, QgsExpression* )
 {
+  FEAT_FROM_CONTEXT( context, f );
   ENSURE_GEOM_TYPE( f, g, QGis::Point );
   if ( g->isMultipart() )
   {
@@ -1061,8 +1072,9 @@ static QVariant fcnX( const QVariantList&, const QgsFeature* f, QgsExpression* )
     return g->asPoint().x();
   }
 }
-static QVariant fcnY( const QVariantList&, const QgsFeature* f, QgsExpression* )
+static QVariant fcnY( const QVariantList&, const QgsExpressionContext* context, QgsExpression* )
 {
+  FEAT_FROM_CONTEXT( context, f );
   ENSURE_GEOM_TYPE( f, g, QGis::Point );
   if ( g->isMultipart() )
   {
@@ -1074,8 +1086,9 @@ static QVariant fcnY( const QVariantList&, const QgsFeature* f, QgsExpression* )
   }
 }
 
-static QVariant pointAt( const QVariantList& values, const QgsFeature* f, QgsExpression* parent ) // helper function
+static QVariant pointAt( const QVariantList& values, const QgsExpressionContext* context, QgsExpression* parent ) // helper function
 {
+  FEAT_FROM_CONTEXT( context, f );
   int idx = getIntValue( values.at( 0 ), parent );
   ENSURE_GEOM_TYPE( f, g, QGis::Line );
   QgsPolyline polyline = g->asPolyline();
@@ -1090,7 +1103,7 @@ static QVariant pointAt( const QVariantList& values, const QgsFeature* f, QgsExp
   return QVariant( QPointF( polyline[idx].x(), polyline[idx].y() ) );
 }
 
-static QVariant fcnXat( const QVariantList& values, const QgsFeature* f, QgsExpression* parent )
+static QVariant fcnXat( const QVariantList& values, const QgsExpressionContext* f, QgsExpression* parent )
 {
   QVariant v = pointAt( values, f, parent );
   if ( v.type() == QVariant::PointF )
@@ -1098,7 +1111,7 @@ static QVariant fcnXat( const QVariantList& values, const QgsFeature* f, QgsExpr
   else
     return QVariant();
 }
-static QVariant fcnYat( const QVariantList& values, const QgsFeature* f, QgsExpression* parent )
+static QVariant fcnYat( const QVariantList& values, const QgsExpressionContext* f, QgsExpression* parent )
 {
   QVariant v = pointAt( values, f, parent );
   if ( v.type() == QVariant::PointF )
@@ -1106,15 +1119,16 @@ static QVariant fcnYat( const QVariantList& values, const QgsFeature* f, QgsExpr
   else
     return QVariant();
 }
-static QVariant fcnGeometry( const QVariantList&, const QgsFeature* f, QgsExpression* )
+static QVariant fcnGeometry( const QVariantList&, const QgsExpressionContext* context, QgsExpression* )
 {
-  const QgsGeometry* geom = f ? f->constGeometry() : 0;
+  FEAT_FROM_CONTEXT( context, f );
+  const QgsGeometry* geom = f.constGeometry();
   if ( geom )
     return  QVariant::fromValue( *geom );
   else
     return QVariant();
 }
-static QVariant fcnGeomFromWKT( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnGeomFromWKT( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   QString wkt = getStringValue( values.at( 0 ), parent );
   QgsGeometry* geom = QgsGeometry::fromWkt( wkt );
@@ -1123,7 +1137,7 @@ static QVariant fcnGeomFromWKT( const QVariantList& values, const QgsFeature*, Q
   else
     return QVariant();
 }
-static QVariant fcnGeomFromGML( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnGeomFromGML( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   QString gml = getStringValue( values.at( 0 ), parent );
   QgsGeometry* geom = QgsOgcUtils::geometryFromGML( gml );
@@ -1134,26 +1148,29 @@ static QVariant fcnGeomFromGML( const QVariantList& values, const QgsFeature*, Q
     return QVariant();
 }
 
-static QVariant fcnGeomArea( const QVariantList&, const QgsFeature* f, QgsExpression* parent )
+static QVariant fcnGeomArea( const QVariantList&, const QgsExpressionContext* context, QgsExpression* parent )
 {
+  FEAT_FROM_CONTEXT( context, f );
   ENSURE_GEOM_TYPE( f, g, QGis::Polygon );
   QgsDistanceArea* calc = parent->geomCalculator();
-  return QVariant( calc->measure( f->constGeometry() ) );
+  return QVariant( calc->measure( f.constGeometry() ) );
 }
-static QVariant fcnGeomLength( const QVariantList&, const QgsFeature* f, QgsExpression* parent )
+static QVariant fcnGeomLength( const QVariantList&, const QgsExpressionContext* context, QgsExpression* parent )
 {
+  FEAT_FROM_CONTEXT( context, f );
   ENSURE_GEOM_TYPE( f, g, QGis::Line );
   QgsDistanceArea* calc = parent->geomCalculator();
-  return QVariant( calc->measure( f->constGeometry() ) );
+  return QVariant( calc->measure( f.constGeometry() ) );
 }
-static QVariant fcnGeomPerimeter( const QVariantList&, const QgsFeature* f, QgsExpression* parent )
+static QVariant fcnGeomPerimeter( const QVariantList&, const QgsExpressionContext* context, QgsExpression* parent )
 {
+  FEAT_FROM_CONTEXT( context, f );
   ENSURE_GEOM_TYPE( f, g, QGis::Polygon );
   QgsDistanceArea* calc = parent->geomCalculator();
-  return QVariant( calc->measurePerimeter( f->constGeometry() ) );
+  return QVariant( calc->measurePerimeter( f.constGeometry() ) );
 }
 
-static QVariant fcnBounds( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnBounds( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   QgsGeometry geom = getGeometry( values.at( 0 ), parent );
   QgsGeometry* geomBounds = QgsGeometry::fromRect( geom.boundingBox() );
@@ -1167,91 +1184,91 @@ static QVariant fcnBounds( const QVariantList& values, const QgsFeature*, QgsExp
   }
 }
 
-static QVariant fcnBoundsWidth( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnBoundsWidth( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   QgsGeometry geom = getGeometry( values.at( 0 ), parent );
   return QVariant::fromValue( geom.boundingBox().width() );
 }
 
-static QVariant fcnBoundsHeight( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnBoundsHeight( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   QgsGeometry geom = getGeometry( values.at( 0 ), parent );
   return QVariant::fromValue( geom.boundingBox().height() );
 }
 
-static QVariant fcnXMin( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnXMin( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   QgsGeometry geom = getGeometry( values.at( 0 ), parent );
   return QVariant::fromValue( geom.boundingBox().xMinimum() );
 }
 
-static QVariant fcnXMax( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnXMax( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   QgsGeometry geom = getGeometry( values.at( 0 ), parent );
   return QVariant::fromValue( geom.boundingBox().xMaximum() );
 }
 
-static QVariant fcnYMin( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnYMin( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   QgsGeometry geom = getGeometry( values.at( 0 ), parent );
   return QVariant::fromValue( geom.boundingBox().yMinimum() );
 }
 
-static QVariant fcnYMax( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnYMax( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   QgsGeometry geom = getGeometry( values.at( 0 ), parent );
   return QVariant::fromValue( geom.boundingBox().yMaximum() );
 }
 
-static QVariant fcnBbox( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnBbox( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = getGeometry( values.at( 1 ), parent );
   return fGeom.intersects( sGeom.boundingBox() ) ? TVL_True : TVL_False;
 }
-static QVariant fcnDisjoint( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnDisjoint( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = getGeometry( values.at( 1 ), parent );
   return fGeom.disjoint( &sGeom ) ? TVL_True : TVL_False;
 }
-static QVariant fcnIntersects( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnIntersects( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = getGeometry( values.at( 1 ), parent );
   return fGeom.intersects( &sGeom ) ? TVL_True : TVL_False;
 }
-static QVariant fcnTouches( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnTouches( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = getGeometry( values.at( 1 ), parent );
   return fGeom.touches( &sGeom ) ? TVL_True : TVL_False;
 }
-static QVariant fcnCrosses( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnCrosses( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = getGeometry( values.at( 1 ), parent );
   return fGeom.crosses( &sGeom ) ? TVL_True : TVL_False;
 }
-static QVariant fcnContains( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnContains( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = getGeometry( values.at( 1 ), parent );
   return fGeom.contains( &sGeom ) ? TVL_True : TVL_False;
 }
-static QVariant fcnOverlaps( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnOverlaps( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = getGeometry( values.at( 1 ), parent );
   return fGeom.overlaps( &sGeom ) ? TVL_True : TVL_False;
 }
-static QVariant fcnWithin( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnWithin( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = getGeometry( values.at( 1 ), parent );
   return fGeom.within( &sGeom ) ? TVL_True : TVL_False;
 }
-static QVariant fcnBuffer( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnBuffer( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   if ( values.length() < 2 || values.length() > 3 )
     return QVariant();
@@ -1267,7 +1284,7 @@ static QVariant fcnBuffer( const QVariantList& values, const QgsFeature*, QgsExp
     return QVariant::fromValue( *geom );
   return QVariant();
 }
-static QVariant fcnCentroid( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnCentroid( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
   QgsGeometry* geom = fGeom.centroid();
@@ -1275,7 +1292,7 @@ static QVariant fcnCentroid( const QVariantList& values, const QgsFeature*, QgsE
     return QVariant::fromValue( *geom );
   return QVariant();
 }
-static QVariant fcnConvexHull( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnConvexHull( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
   QgsGeometry* geom = fGeom.convexHull();
@@ -1283,7 +1300,7 @@ static QVariant fcnConvexHull( const QVariantList& values, const QgsFeature*, Qg
     return QVariant::fromValue( *geom );
   return QVariant();
 }
-static QVariant fcnDifference( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnDifference( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = getGeometry( values.at( 1 ), parent );
@@ -1292,13 +1309,13 @@ static QVariant fcnDifference( const QVariantList& values, const QgsFeature*, Qg
     return QVariant::fromValue( *geom );
   return QVariant();
 }
-static QVariant fcnDistance( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnDistance( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = getGeometry( values.at( 1 ), parent );
   return QVariant( fGeom.distance( sGeom ) );
 }
-static QVariant fcnIntersection( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnIntersection( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = getGeometry( values.at( 1 ), parent );
@@ -1307,7 +1324,7 @@ static QVariant fcnIntersection( const QVariantList& values, const QgsFeature*, 
     return QVariant::fromValue( *geom );
   return QVariant();
 }
-static QVariant fcnSymDifference( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnSymDifference( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = getGeometry( values.at( 1 ), parent );
@@ -1316,7 +1333,7 @@ static QVariant fcnSymDifference( const QVariantList& values, const QgsFeature*,
     return QVariant::fromValue( *geom );
   return QVariant();
 }
-static QVariant fcnCombine( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnCombine( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = getGeometry( values.at( 1 ), parent );
@@ -1325,7 +1342,7 @@ static QVariant fcnCombine( const QVariantList& values, const QgsFeature*, QgsEx
     return QVariant::fromValue( *geom );
   return QVariant();
 }
-static QVariant fcnGeomToWKT( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnGeomToWKT( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   if ( values.length() < 1 || values.length() > 2 )
     return QVariant();
@@ -1338,9 +1355,8 @@ static QVariant fcnGeomToWKT( const QVariantList& values, const QgsFeature*, Qgs
   return QVariant( wkt );
 }
 
-static QVariant fcnRound( const QVariantList& values, const QgsFeature *f, QgsExpression* parent )
+static QVariant fcnRound( const QVariantList& values, const QgsExpressionContext *, QgsExpression* parent )
 {
-  Q_UNUSED( f );
   if ( values.length() == 2 )
   {
     double number = getDoubleValue( values.at( 0 ), parent );
@@ -1357,20 +1373,19 @@ static QVariant fcnRound( const QVariantList& values, const QgsFeature *f, QgsEx
   return QVariant();
 }
 
-static QVariant fcnPi( const QVariantList& values, const QgsFeature *f, QgsExpression* parent )
+static QVariant fcnPi( const QVariantList& values, const QgsExpressionContext *, QgsExpression* parent )
 {
   Q_UNUSED( values );
-  Q_UNUSED( f );
   Q_UNUSED( parent );
   return M_PI;
 }
 
-static QVariant fcnScale( const QVariantList&, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnScale( const QVariantList&, const QgsExpressionContext*, QgsExpression* parent )
 {
   return QVariant( parent->scale() );
 }
 
-static QVariant fcnFormatNumber( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnFormatNumber( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   double value = getDoubleValue( values.at( 0 ), parent );
   int places = getIntValue( values.at( 1 ), parent );
@@ -1382,14 +1397,14 @@ static QVariant fcnFormatNumber( const QVariantList& values, const QgsFeature*, 
   return QString( "%L1" ).arg( value, 0, 'f', places );
 }
 
-static QVariant fcnFormatDate( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnFormatDate( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   QDateTime dt = getDateTimeValue( values.at( 0 ), parent );
   QString format = getStringValue( values.at( 1 ), parent );
   return dt.toString( format );
 }
 
-static QVariant fcnColorRgb( const QVariantList &values, const QgsFeature *, QgsExpression *parent )
+static QVariant fcnColorRgb( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
 {
   int red = getIntValue( values.at( 0 ), parent );
   int green = getIntValue( values.at( 1 ), parent );
@@ -1404,30 +1419,30 @@ static QVariant fcnColorRgb( const QVariantList &values, const QgsFeature *, Qgs
   return QString( "%1,%2,%3" ).arg( color.red() ).arg( color.green() ).arg( color.blue() );
 }
 
-static QVariant fcnIf( const QVariantList &values, const QgsFeature *f, QgsExpression *parent )
+static QVariant fcnIf( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent )
 {
   QgsExpression::Node* node = getNode( values.at( 0 ), parent );
   ENSURE_NO_EVAL_ERROR;
-  QVariant value = node->eval( parent, f );
+  QVariant value = node->eval( parent, context );
   ENSURE_NO_EVAL_ERROR;
   if ( value.toBool() )
   {
     node = getNode( values.at( 1 ), parent );
     ENSURE_NO_EVAL_ERROR;
-    value = node->eval( parent, f );
+    value = node->eval( parent, context );
     ENSURE_NO_EVAL_ERROR;
   }
   else
   {
     node = getNode( values.at( 2 ), parent );
     ENSURE_NO_EVAL_ERROR;
-    value = node->eval( parent, f );
+    value = node->eval( parent, context );
     ENSURE_NO_EVAL_ERROR;
   }
   return value;
 }
 
-static QVariant fncColorRgba( const QVariantList &values, const QgsFeature *, QgsExpression *parent )
+static QVariant fncColorRgba( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
 {
   int red = getIntValue( values.at( 0 ), parent );
   int green = getIntValue( values.at( 1 ), parent );
@@ -1442,7 +1457,7 @@ static QVariant fncColorRgba( const QVariantList &values, const QgsFeature *, Qg
   return QgsSymbolLayerV2Utils::encodeColor( color );
 }
 
-QVariant fcnRampColor( const QVariantList &values, const QgsFeature *, QgsExpression *parent )
+QVariant fcnRampColor( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
 {
   QString rampName = getStringValue( values.at( 0 ), parent );
   const QgsVectorColorRampV2 *mRamp = QgsStyleV2::defaultStyle()->colorRampRef( rampName );
@@ -1456,7 +1471,7 @@ QVariant fcnRampColor( const QVariantList &values, const QgsFeature *, QgsExpres
   return QgsSymbolLayerV2Utils::encodeColor( color );
 }
 
-static QVariant fcnColorHsl( const QVariantList &values, const QgsFeature *, QgsExpression *parent )
+static QVariant fcnColorHsl( const QVariantList &values, const QgsExpressionContext *, QgsExpression *parent )
 {
   // Hue ranges from 0 - 360
   double hue = getIntValue( values.at( 0 ), parent ) / 360.0;
@@ -1476,7 +1491,7 @@ static QVariant fcnColorHsl( const QVariantList &values, const QgsFeature *, Qgs
   return QString( "%1,%2,%3" ).arg( color.red() ).arg( color.green() ).arg( color.blue() );
 }
 
-static QVariant fncColorHsla( const QVariantList &values, const QgsFeature *, QgsExpression *parent )
+static QVariant fncColorHsla( const QVariantList &values, const QgsExpressionContext*, QgsExpression *parent )
 {
   // Hue ranges from 0 - 360
   double hue = getIntValue( values.at( 0 ), parent ) / 360.0;
@@ -1496,7 +1511,7 @@ static QVariant fncColorHsla( const QVariantList &values, const QgsFeature *, Qg
   return QgsSymbolLayerV2Utils::encodeColor( color );
 }
 
-static QVariant fcnColorHsv( const QVariantList &values, const QgsFeature *, QgsExpression *parent )
+static QVariant fcnColorHsv( const QVariantList &values, const QgsExpressionContext*, QgsExpression *parent )
 {
   // Hue ranges from 0 - 360
   double hue = getIntValue( values.at( 0 ), parent ) / 360.0;
@@ -1516,7 +1531,7 @@ static QVariant fcnColorHsv( const QVariantList &values, const QgsFeature *, Qgs
   return QString( "%1,%2,%3" ).arg( color.red() ).arg( color.green() ).arg( color.blue() );
 }
 
-static QVariant fncColorHsva( const QVariantList &values, const QgsFeature *, QgsExpression *parent )
+static QVariant fncColorHsva( const QVariantList &values, const QgsExpressionContext*, QgsExpression *parent )
 {
   // Hue ranges from 0 - 360
   double hue = getIntValue( values.at( 0 ), parent ) / 360.0;
@@ -1536,7 +1551,7 @@ static QVariant fncColorHsva( const QVariantList &values, const QgsFeature *, Qg
   return QgsSymbolLayerV2Utils::encodeColor( color );
 }
 
-static QVariant fcnColorCmyk( const QVariantList &values, const QgsFeature *, QgsExpression *parent )
+static QVariant fcnColorCmyk( const QVariantList &values, const QgsExpressionContext*, QgsExpression *parent )
 {
   // Cyan ranges from 0 - 100
   double cyan = getIntValue( values.at( 0 ), parent ) / 100.0;
@@ -1558,7 +1573,7 @@ static QVariant fcnColorCmyk( const QVariantList &values, const QgsFeature *, Qg
   return QString( "%1,%2,%3" ).arg( color.red() ).arg( color.green() ).arg( color.blue() );
 }
 
-static QVariant fncColorCmyka( const QVariantList &values, const QgsFeature *, QgsExpression *parent )
+static QVariant fncColorCmyka( const QVariantList &values, const QgsExpressionContext*, QgsExpression *parent )
 {
   // Cyan ranges from 0 - 100
   double cyan = getIntValue( values.at( 0 ), parent ) / 100.0;
@@ -1580,13 +1595,13 @@ static QVariant fncColorCmyka( const QVariantList &values, const QgsFeature *, Q
   return QgsSymbolLayerV2Utils::encodeColor( color );
 }
 
-static QVariant fcnSpecialColumn( const QVariantList& values, const QgsFeature* /*f*/, QgsExpression* parent )
+static QVariant fcnSpecialColumn( const QVariantList& values, const QgsExpressionContext* /*f*/, QgsExpression* parent )
 {
   QString varName = getStringValue( values.at( 0 ), parent );
   return QgsExpression::specialColumn( varName );
 }
 
-static QVariant fcnGetGeometry( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnGetGeometry( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   QgsFeature feat = getFeature( values.at( 0 ), parent );
   const QgsGeometry* geom = feat.constGeometry();
@@ -1595,7 +1610,7 @@ static QVariant fcnGetGeometry( const QVariantList& values, const QgsFeature*, Q
   return QVariant();
 }
 
-static QVariant fcnTransformGeometry( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnTransformGeometry( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
   QString sAuthId = getStringValue( values.at( 1 ), parent );
@@ -1614,7 +1629,7 @@ static QVariant fcnTransformGeometry( const QVariantList& values, const QgsFeatu
   return QVariant();
 }
 
-static QVariant fcnGetFeature( const QVariantList& values, const QgsFeature *, QgsExpression* parent )
+static QVariant fcnGetFeature( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   //arguments: 1. layer id / name, 2. key attribute, 3. eq value
   QString layerString = getStringValue( values.at( 0 ), parent );
@@ -1726,8 +1741,9 @@ const QStringList& QgsExpression::BuiltinFunctions()
     << "distance" << "intersection" << "sym_difference" << "combine"
     << "union" << "geom_to_wkt" << "geomToWKT" << "geometry"
     << "transform" << "get_feature" << "getFeature"
-    << "attribute" << "levenshtein" << "longest_common_substring" << "hamming_distance"
+    << "levenshtein" << "longest_common_substring" << "hamming_distance"
     << "soundex"
+    << "attribute" << "var"
     << "$rownum" << "$id" << "$scale" << "_specialcol_";
   }
   return gmBuiltinFunctions;
@@ -1858,6 +1874,7 @@ const QList<QgsExpression::Function*>& QgsExpression::Functions()
     << new StaticFunction( "$scale", 0, fcnScale, "Record" )
     << new StaticFunction( "uuid", 0, fcnUuid, "Record", QString(), false, QStringList(), false, QStringList() << "$uuid" )
     << new StaticFunction( "get_feature", 3, fcnGetFeature, "Record", QString(), false, QStringList(), false, QStringList() << "getFeature" )
+    << new StaticFunction( "var", 1, fcnGetVariable, "Variables" )
 
     //return all attributes string for referencedColumns - this is caught by
     // QgsFeatureRequest::setSubsetOfAttributes and causes all attributes to be fetched by the
@@ -1946,8 +1963,14 @@ bool QgsExpression::hasSpecialColumn( const QString& name )
 
 bool QgsExpression::isValid( const QString &text, const QgsFields &fields, QString &errorMessage )
 {
+  QgsFeatureBasedExpressionContext context( 0, fields );
+  return isValid( text, context, errorMessage );
+}
+
+bool QgsExpression::isValid( const QString &text, const QgsExpressionContext &context, QString &errorMessage )
+{
   QgsExpression exp( text );
-  exp.prepare( fields );
+  exp.prepare( context );
   errorMessage = exp.parserErrorString();
   return !exp.hasParserError();
 }
@@ -1959,7 +1982,7 @@ QList<QgsExpression::Function*> QgsExpression::specialColumns()
   {
     //check for special column group name
     QString group = gmSpecialColumnGroups.value( it.key(), "Record" );
-    defs << new StaticFunction( it.key(), 0, 0, group );
+    defs << new StaticFunction( it.key(), 0, ( FcnEvalContext )0, group );
   }
   return defs;
 }
@@ -1978,7 +2001,7 @@ QString QgsExpression::quotedString( QString text )
   return QString( "'%1'" ).arg( text );
 }
 
-bool QgsExpression::isFunctionName( QString name )
+bool QgsExpression::isFunctionName( const QString &name )
 {
   return functionIndex( name ) != -1;
 }
@@ -2072,14 +2095,28 @@ void QgsExpression::setGeomCalculator( const QgsDistanceArea &calc )
 
 bool QgsExpression::prepare( const QgsFields& fields )
 {
+  QgsFeatureBasedExpressionContext fc( 0, fields );
+  return prepare( fc );
+}
+
+bool QgsExpression::prepare( const QgsExpressionContext &context )
+{
   mEvalErrorString = QString();
+  if ( !mRootNode )
+  {
+    //re-parse expression. Creation of QgsExpressionContexts may have added extra
+    //known functions since this expression was created, so we have another try
+    //at re-parsing it now that the context must have been created
+    mRootNode = ::parseExpression( mExp, mParserErrorString );
+  }
+
   if ( !mRootNode )
   {
     mEvalErrorString = QObject::tr( "No root node! Parsing failed?" );
     return false;
   }
 
-  return mRootNode->prepare( this, fields );
+  return mRootNode->prepare( this, context );
 }
 
 QVariant QgsExpression::evaluate( const QgsFeature* f )
@@ -2091,18 +2128,51 @@ QVariant QgsExpression::evaluate( const QgsFeature* f )
     return QVariant();
   }
 
-  return mRootNode->eval( this, f );
+  QgsFeatureBasedExpressionContext context( f ? *f : QgsFeature(), QgsFields() );
+  return mRootNode->eval( this, &context );
 }
 
 QVariant QgsExpression::evaluate( const QgsFeature* f, const QgsFields& fields )
 {
   // first prepare
-  bool res = prepare( fields );
+  QgsFeatureBasedExpressionContext context( f ? *f : QgsFeature() , fields );
+  bool res = prepare( context );
   if ( !res )
     return QVariant();
 
   // then evaluate
-  return evaluate( f );
+  return evaluate( context );
+}
+
+inline QVariant QgsExpression::evaluate( const QgsFeature& f, const QgsFields& fields )
+{
+  Q_NOWARN_DEPRECATED_PUSH
+  return evaluate( &f, fields );
+  Q_NOWARN_DEPRECATED_POP
+}
+
+QVariant QgsExpression::evaluate()
+{
+  mEvalErrorString = QString();
+  if ( !mRootNode )
+  {
+    mEvalErrorString = QObject::tr( "No root node! Parsing failed?" );
+    return QVariant();
+  }
+
+  return mRootNode->eval( this, ( QgsExpressionContext* )0 );
+}
+
+QVariant QgsExpression::evaluate( const QgsExpressionContext &context )
+{
+  mEvalErrorString = QString();
+  if ( !mRootNode )
+  {
+    mEvalErrorString = QObject::tr( "No root node! Parsing failed?" );
+    return QVariant();
+  }
+
+  return mRootNode->eval( this, &context );
 }
 
 QString QgsExpression::dump() const
@@ -2122,6 +2192,12 @@ void QgsExpression::acceptVisitor( QgsExpression::Visitor& v ) const
 QString QgsExpression::replaceExpressionText( const QString &action, const QgsFeature *feat,
     QgsVectorLayer *layer,
     const QMap<QString, QVariant> *substitutionMap, const QgsDistanceArea *distanceArea )
+{
+  QgsFeatureBasedExpressionContext context( feat ? *feat : QgsFeature(), layer ? layer->pendingFields() : QgsFields() );
+  return replaceExpressionText( action, context, substitutionMap, distanceArea );
+}
+
+QString QgsExpression::replaceExpressionText( const QString &action, const QgsExpressionContext &context, const QMap<QString, QVariant> *substitutionMap, const QgsDistanceArea *distanceArea )
 {
   QString expr_action;
 
@@ -2168,15 +2244,8 @@ QString QgsExpression::replaceExpressionText( const QString &action, const QgsFe
       exp.setGeomCalculator( *distanceArea );
     }
 
-    QVariant result;
-    if ( layer )
-    {
-      result = exp.evaluate( feat, layer->pendingFields() );
-    }
-    else
-    {
-      result = exp.evaluate( feat );
-    }
+    QVariant result = exp.evaluate( context );
+
     if ( exp.hasEvalError() )
     {
       QgsDebugMsg( "Expression parser eval error: " + exp.evalErrorString() );
@@ -2211,7 +2280,8 @@ double QgsExpression::evaluateToDouble( const QString &text, const double fallba
 
   //otherwise try to evalute as expression
   QgsExpression expr( text );
-  QVariant result = expr.evaluate();
+  //evaluate using project context
+  QVariant result = expr.evaluate( *QgsProject::instance()->expressionContextStack() );
   convertedValue = result.toDouble( &ok );
   if ( expr.hasEvalError() || !ok )
   {
@@ -2238,9 +2308,9 @@ QString QgsExpression::NodeList::dump() const
 
 //
 
-QVariant QgsExpression::NodeUnaryOperator::eval( QgsExpression* parent, const QgsFeature* f )
+QVariant QgsExpression::NodeUnaryOperator::eval( QgsExpression *parent, const QgsExpressionContext *context )
 {
-  QVariant val = mOperand->eval( parent, f );
+  QVariant val = mOperand->eval( parent, context );
   ENSURE_NO_EVAL_ERROR;
 
   switch ( mOp )
@@ -2266,9 +2336,9 @@ QVariant QgsExpression::NodeUnaryOperator::eval( QgsExpression* parent, const Qg
   return QVariant();
 }
 
-bool QgsExpression::NodeUnaryOperator::prepare( QgsExpression* parent, const QgsFields& fields )
+bool QgsExpression::NodeUnaryOperator::prepare( QgsExpression *parent, const QgsExpressionContext &context )
 {
-  return mOperand->prepare( parent, fields );
+  return mOperand->prepare( parent, context );
 }
 
 QString QgsExpression::NodeUnaryOperator::dump() const
@@ -2278,11 +2348,11 @@ QString QgsExpression::NodeUnaryOperator::dump() const
 
 //
 
-QVariant QgsExpression::NodeBinaryOperator::eval( QgsExpression* parent, const QgsFeature* f )
+QVariant QgsExpression::NodeBinaryOperator::eval( QgsExpression *parent, const QgsExpressionContext *context )
 {
-  QVariant vL = mOpLeft->eval( parent, f );
+  QVariant vL = mOpLeft->eval( parent, context );
   ENSURE_NO_EVAL_ERROR;
-  QVariant vR = mOpRight->eval( parent, f );
+  QVariant vR = mOpRight->eval( parent, context );
   ENSURE_NO_EVAL_ERROR;
 
   switch ( mOp )
@@ -2520,11 +2590,10 @@ double QgsExpression::NodeBinaryOperator::computeDouble( double x, double y )
   }
 }
 
-
-bool QgsExpression::NodeBinaryOperator::prepare( QgsExpression* parent, const QgsFields& fields )
+bool QgsExpression::NodeBinaryOperator::prepare( QgsExpression *parent, const QgsExpressionContext &context )
 {
-  bool resL = mOpLeft->prepare( parent, fields );
-  bool resR = mOpRight->prepare( parent, fields );
+  bool resL = mOpLeft->prepare( parent, context );
+  bool resR = mOpRight->prepare( parent, context );
   return resL && resR;
 }
 
@@ -2634,11 +2703,11 @@ QString QgsExpression::NodeBinaryOperator::dump() const
 
 //
 
-QVariant QgsExpression::NodeInOperator::eval( QgsExpression* parent, const QgsFeature* f )
+QVariant QgsExpression::NodeInOperator::eval( QgsExpression *parent, const QgsExpressionContext *context )
 {
   if ( mList->count() == 0 )
     return mNotIn ? TVL_True : TVL_False;
-  QVariant v1 = mNode->eval( parent, f );
+  QVariant v1 = mNode->eval( parent, context );
   ENSURE_NO_EVAL_ERROR;
   if ( isNull( v1 ) )
     return TVL_Unknown;
@@ -2647,7 +2716,7 @@ QVariant QgsExpression::NodeInOperator::eval( QgsExpression* parent, const QgsFe
 
   foreach ( Node* n, mList->list() )
   {
-    QVariant v2 = n->eval( parent, f );
+    QVariant v2 = n->eval( parent, context );
     ENSURE_NO_EVAL_ERROR;
     if ( isNull( v2 ) )
       listHasNull = true;
@@ -2680,12 +2749,12 @@ QVariant QgsExpression::NodeInOperator::eval( QgsExpression* parent, const QgsFe
     return mNotIn ? TVL_True : TVL_False;
 }
 
-bool QgsExpression::NodeInOperator::prepare( QgsExpression* parent, const QgsFields& fields )
+bool QgsExpression::NodeInOperator::prepare( QgsExpression *parent, const QgsExpressionContext &context )
 {
-  bool res = mNode->prepare( parent, fields );
+  bool res = mNode->prepare( parent, context );
   foreach ( Node* n, mList->list() )
   {
-    res = res && n->prepare( parent, fields );
+    res = res && n->prepare( parent, context );
   }
   return res;
 }
@@ -2697,9 +2766,10 @@ QString QgsExpression::NodeInOperator::dump() const
 
 //
 
-QVariant QgsExpression::NodeFunction::eval( QgsExpression* parent, const QgsFeature* f )
+QVariant QgsExpression::NodeFunction::eval( QgsExpression *parent, const QgsExpressionContext *context )
 {
-  Function* fd = Functions()[mFnIndex];
+  QString name = Functions()[mFnIndex]->name();
+  Function* fd = context && context->hasFunction( name ) ? context->function( name ) : Functions()[mFnIndex];
 
   // evaluate arguments
   QVariantList argValues;
@@ -2715,7 +2785,7 @@ QVariant QgsExpression::NodeFunction::eval( QgsExpression* parent, const QgsFeat
       }
       else
       {
-        v = n->eval( parent, f );
+        v = n->eval( parent, context );
         ENSURE_NO_EVAL_ERROR;
         if ( isNull( v ) && !fd->handlesNull() )
           return QVariant(); // all "normal" functions return NULL, when any parameter is NULL (so coalesce is abnormal)
@@ -2725,21 +2795,21 @@ QVariant QgsExpression::NodeFunction::eval( QgsExpression* parent, const QgsFeat
   }
 
   // run the function
-  QVariant res = fd->func( argValues, f, parent );
+  QVariant res = fd->func( argValues, context, parent );
   ENSURE_NO_EVAL_ERROR;
 
   // everything went fine
   return res;
 }
 
-bool QgsExpression::NodeFunction::prepare( QgsExpression* parent, const QgsFields& fields )
+bool QgsExpression::NodeFunction::prepare( QgsExpression *parent, const QgsExpressionContext &context )
 {
   bool res = true;
   if ( mArgs )
   {
     foreach ( Node* n, mArgs->list() )
     {
-      res = res && n->prepare( parent, fields );
+      res = res && n->prepare( parent, context );
     }
   }
   return res;
@@ -2776,13 +2846,17 @@ QStringList QgsExpression::NodeFunction::referencedColumns() const
 
 //
 
-QVariant QgsExpression::NodeLiteral::eval( QgsExpression*, const QgsFeature* )
+QVariant QgsExpression::NodeLiteral::eval( QgsExpression *parent, const QgsExpressionContext *context )
 {
+  Q_UNUSED( context );
+  Q_UNUSED( parent );
   return mValue;
 }
 
-bool QgsExpression::NodeLiteral::prepare( QgsExpression* /*parent*/, const QgsFields& /*fields*/ )
+bool QgsExpression::NodeLiteral::prepare( QgsExpression *parent, const QgsExpressionContext &context )
 {
+  Q_UNUSED( parent );
+  Q_UNUSED( context );
   return true;
 }
 
@@ -2803,20 +2877,27 @@ QString QgsExpression::NodeLiteral::dump() const
 
 //
 
-QVariant QgsExpression::NodeColumnRef::eval( QgsExpression* /*parent*/, const QgsFeature* f )
+QVariant QgsExpression::NodeColumnRef::eval( QgsExpression *parent, const QgsExpressionContext *context )
 {
-  if ( f )
+  Q_UNUSED( parent );
+  if ( context && context->hasVariable( "feature" ) )
   {
+    QgsFeature feature = qvariant_cast<QgsFeature>( context->variable( "feature" ) );
     if ( mIndex >= 0 )
-      return f->attribute( mIndex );
+      return feature.attribute( mIndex );
     else
-      return f->attribute( mName );
+      return feature.attribute( mName );
   }
   return QVariant( "[" + mName + "]" );
 }
 
-bool QgsExpression::NodeColumnRef::prepare( QgsExpression* parent, const QgsFields& fields )
+bool QgsExpression::NodeColumnRef::prepare( QgsExpression *parent, const QgsExpressionContext &context )
 {
+  if ( !context.hasVariable( "fields" ) )
+    return false;
+
+  QgsFields fields = qvariant_cast<QgsFields>( context.variable( "fields" ) );
+
   for ( int i = 0; i < fields.count(); ++i )
   {
     if ( QString::compare( fields[i].name(), mName, Qt::CaseInsensitive ) == 0 )
@@ -2837,16 +2918,16 @@ QString QgsExpression::NodeColumnRef::dump() const
 
 //
 
-QVariant QgsExpression::NodeCondition::eval( QgsExpression* parent, const QgsFeature* f )
+QVariant QgsExpression::NodeCondition::eval( QgsExpression *parent, const QgsExpressionContext *context )
 {
   foreach ( WhenThen* cond, mConditions )
   {
-    QVariant vWhen = cond->mWhenExp->eval( parent, f );
+    QVariant vWhen = cond->mWhenExp->eval( parent, context );
     TVL tvl = getTVLValue( vWhen, parent );
     ENSURE_NO_EVAL_ERROR;
     if ( tvl == True )
     {
-      QVariant vRes = cond->mThenExp->eval( parent, f );
+      QVariant vRes = cond->mThenExp->eval( parent, context );
       ENSURE_NO_EVAL_ERROR;
       return vRes;
     }
@@ -2854,7 +2935,7 @@ QVariant QgsExpression::NodeCondition::eval( QgsExpression* parent, const QgsFea
 
   if ( mElseExp )
   {
-    QVariant vElse = mElseExp->eval( parent, f );
+    QVariant vElse = mElseExp->eval( parent, context );
     ENSURE_NO_EVAL_ERROR;
     return vElse;
   }
@@ -2863,18 +2944,18 @@ QVariant QgsExpression::NodeCondition::eval( QgsExpression* parent, const QgsFea
   return QVariant();
 }
 
-bool QgsExpression::NodeCondition::prepare( QgsExpression* parent, const QgsFields& fields )
+bool QgsExpression::NodeCondition::prepare( QgsExpression *parent, const QgsExpressionContext &context )
 {
   bool res;
   foreach ( WhenThen* cond, mConditions )
   {
-    res = cond->mWhenExp->prepare( parent, fields )
-          & cond->mThenExp->prepare( parent, fields );
+    res = cond->mWhenExp->prepare( parent, context )
+          & cond->mThenExp->prepare( parent, context );
     if ( !res ) return false;
   }
 
   if ( mElseExp )
-    return mElseExp->prepare( parent, fields );
+    return mElseExp->prepare( parent, context );
 
   return true;
 }
@@ -2949,4 +3030,61 @@ QString QgsExpression::group( QString name )
   //have a translated name in the gGroups hash, return the name
   //unchanged
   return gGroups.value( name, name );
+}
+
+
+QVariant QgsExpression::Function::func( const QVariantList& values, const QgsFeature* feature, QgsExpression* parent )
+{
+  //default implementation creates a QgsFeatureBasedExpressionContext
+  QgsFeatureBasedExpressionContext c( feature ? *feature : QgsFeature() );
+  return func( values, &c, parent );
+}
+
+QVariant QgsExpression::Function::func( const QVariantList &values, const QgsExpressionContext *context, QgsExpression *parent )
+{
+  //base implementation calls deprecated func to avoid API breakage
+  QgsFeature f;
+  if ( context && context->hasVariable( "feature" ) )
+    f = qvariant_cast<QgsFeature>( context->variable( "feature" ) );
+
+  Q_NOWARN_DEPRECATED_PUSH
+  return func( values, &f, parent );
+  Q_NOWARN_DEPRECATED_POP
+}
+
+QVariant QgsExpression::Node::eval( QgsExpression* parent, const QgsFeature* feature )
+{
+  //default implementation creates a QgsFeatureBasedExpressionContext
+  QgsFeatureBasedExpressionContext c( feature ? *feature : QgsFeature() );
+  return eval( parent, &c );
+}
+
+QVariant QgsExpression::Node::eval( QgsExpression *parent, const QgsExpressionContext *context )
+{
+  //base implementation calls deprecated eval to avoid API breakage
+  QgsFeature f;
+  if ( context && context->hasVariable( "feature" ) )
+    f = qvariant_cast<QgsFeature>( context->variable( "feature" ) );
+
+  Q_NOWARN_DEPRECATED_PUSH
+  return eval( parent, &f );
+  Q_NOWARN_DEPRECATED_POP
+}
+
+bool QgsExpression::Node::prepare( QgsExpression* parent, const QgsFields &fields )
+{
+  QgsFeatureBasedExpressionContext c( 0, fields );
+  return prepare( parent, c );
+}
+
+bool QgsExpression::Node::prepare( QgsExpression* parent, const QgsExpressionContext& context )
+{
+  //base implementation calls deprecated prepare to avoid API breakage
+  QgsFields f;
+  if ( context.hasVariable( "fields" ) )
+    f = qvariant_cast<QgsFields>( context.variable( "fields" ) );
+
+  Q_NOWARN_DEPRECATED_PUSH
+  return prepare( parent, f );
+  Q_NOWARN_DEPRECATED_POP
 }

--- a/src/core/qgsexpression.h
+++ b/src/core/qgsexpression.h
@@ -105,7 +105,7 @@ class CORE_EXPORT QgsExpression
     Q_DECL_DEPRECATED bool prepare( const QgsFields &fields );
 
     //! Get the expression ready for evaluation - find out column indexes.
-    bool prepare( const QgsExpressionContext &context );
+    bool prepare( const QgsExpressionContext *context );
 
     /**
      * Get list of columns referenced by the expression.
@@ -139,7 +139,7 @@ class CORE_EXPORT QgsExpression
     Q_DECL_DEPRECATED inline QVariant evaluate( const QgsFeature& f, const QgsFields& fields );
 
     QVariant evaluate();
-    QVariant evaluate( const QgsExpressionContext& context );
+    QVariant evaluate( const QgsExpressionContext* context );
 
     //! Returns true if an error occurred when evaluating last input
     bool hasEvalError() const { return !mEvalErrorString.isNull(); }
@@ -169,7 +169,7 @@ class CORE_EXPORT QgsExpression
     bool isField() const { return rootNode() && dynamic_cast<const NodeColumnRef*>( rootNode() ) ;}
 
     Q_DECL_DEPRECATED static bool isValid( const QString& text, const QgsFields& fields, QString &errorMessage );
-    static bool isValid( const QString& text, const QgsExpressionContext& context, QString &errorMessage );
+    static bool isValid( const QString& text, const QgsExpressionContext* context, QString &errorMessage );
 
     void setScale( double scale ) { mScale = scale; }
 
@@ -214,7 +214,7 @@ class CORE_EXPORT QgsExpression
         const QgsDistanceArea* distanceArea = 0
                                                           );
 
-    static QString replaceExpressionText( const QString &action, const QgsExpressionContext& context,
+    static QString replaceExpressionText( const QString &action, const QgsExpressionContext* context,
                                           const QMap<QString, QVariant> *substitutionMap = 0,
                                           const QgsDistanceArea* distanceArea = 0
                                         );
@@ -482,7 +482,7 @@ class CORE_EXPORT QgsExpression
         // abstract virtual preparation function
         // errors are reported to the parent
         Q_DECL_DEPRECATED virtual bool prepare( QgsExpression* parent, const QgsFields &fields );
-        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext& context );
+        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext* context );
 
         virtual QString dump() const = 0;
 
@@ -549,7 +549,7 @@ class CORE_EXPORT QgsExpression
         Node* operand() const { return mOperand; }
 
         virtual NodeType nodeType() const override { return ntUnaryOperator; }
-        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext& context ) override;
+        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext* context ) override;
         virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context ) override;
         virtual QString dump() const override;
 
@@ -573,7 +573,7 @@ class CORE_EXPORT QgsExpression
         Node* opRight() const { return mOpRight; }
 
         virtual NodeType nodeType() const override { return ntBinaryOperator; }
-        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext& context ) override;
+        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext* context ) override;
         virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context ) override;
         virtual QString dump() const override;
 
@@ -606,7 +606,7 @@ class CORE_EXPORT QgsExpression
         NodeList* list() const { return mList; }
 
         virtual NodeType nodeType() const override { return ntInOperator; }
-        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext& context ) override;
+        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext* context ) override;
         virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context ) override;
         virtual QString dump() const override;
 
@@ -631,7 +631,7 @@ class CORE_EXPORT QgsExpression
         NodeList* args() const { return mArgs; }
 
         virtual NodeType nodeType() const override { return ntFunction; }
-        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext& context ) override;
+        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext* context ) override;
         virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context ) override;
         virtual QString dump() const override;
 
@@ -657,7 +657,7 @@ class CORE_EXPORT QgsExpression
         inline QVariant value() const { return mValue; }
 
         virtual NodeType nodeType() const override { return ntLiteral; }
-        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext& context ) override;
+        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext* context ) override;
         virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context ) override;
         virtual QString dump() const override;
 
@@ -677,7 +677,7 @@ class CORE_EXPORT QgsExpression
         QString name() const { return mName; }
 
         virtual NodeType nodeType() const override { return ntColumnRef; }
-        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext& context ) override;
+        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext* context ) override;
         virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context ) override;
         virtual QString dump() const override;
 
@@ -711,7 +711,7 @@ class CORE_EXPORT QgsExpression
 
         virtual NodeType nodeType() const override { return ntCondition; }
         virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context ) override;
-        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext& context ) override;
+        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext* context ) override;
         virtual QString dump() const override;
 
         virtual QStringList referencedColumns() const override;

--- a/src/core/qgsexpression.h
+++ b/src/core/qgsexpression.h
@@ -21,6 +21,7 @@
 #include <QVariant>
 #include <QList>
 #include <QDomDocument>
+#include "qgis.h"
 
 class QgsFeature;
 class QgsGeometry;
@@ -31,6 +32,7 @@ class QgsField;
 class QgsFields;
 class QgsDistanceArea;
 class QDomElement;
+class QgsExpressionContext;
 
 /**
 Class for parsing and evaluation of expressions (formerly called "search strings").
@@ -100,7 +102,10 @@ class CORE_EXPORT QgsExpression
     const Node* rootNode() const { return mRootNode; }
 
     //! Get the expression ready for evaluation - find out column indexes.
-    bool prepare( const QgsFields &fields );
+    Q_DECL_DEPRECATED bool prepare( const QgsFields &fields );
+
+    //! Get the expression ready for evaluation - find out column indexes.
+    bool prepare( const QgsExpressionContext &context );
 
     /**
      * Get list of columns referenced by the expression.
@@ -117,28 +122,31 @@ class CORE_EXPORT QgsExpression
 
     //! Evaluate the feature and return the result
     //! @note prepare() should be called before calling this method
-    QVariant evaluate( const QgsFeature* f = NULL );
+    Q_DECL_DEPRECATED QVariant evaluate( const QgsFeature* f );
 
     //! Evaluate the feature and return the result
     //! @note prepare() should be called before calling this method
     //! @note available in python bindings as evaluatePrepared
-    inline QVariant evaluate( const QgsFeature& f ) { return evaluate( &f ); }
+    Q_DECL_DEPRECATED inline QVariant evaluate( const QgsFeature& f ) { Q_NOWARN_DEPRECATED_PUSH return evaluate( &f ); Q_NOWARN_DEPRECATED_POP }
 
     //! Evaluate the feature and return the result
     //! @note this method does not expect that prepare() has been called on this instance
-    QVariant evaluate( const QgsFeature* f, const QgsFields& fields );
+    Q_DECL_DEPRECATED QVariant evaluate( const QgsFeature* f, const QgsFields& fields );
 
     //! Evaluate the feature and return the result
     //! @note this method does not expect that prepare() has been called on this instance
     //! @note not available in python bindings
-    inline QVariant evaluate( const QgsFeature& f, const QgsFields& fields ) { return evaluate( &f, fields ); }
+    Q_DECL_DEPRECATED inline QVariant evaluate( const QgsFeature& f, const QgsFields& fields );
+
+    QVariant evaluate();
+    QVariant evaluate( const QgsExpressionContext& context );
 
     //! Returns true if an error occurred when evaluating last input
     bool hasEvalError() const { return !mEvalErrorString.isNull(); }
     //! Returns evaluation error
     QString evalErrorString() const { return mEvalErrorString; }
     //! Set evaluation error (used internally by evaluation functions)
-    void setEvalErrorString( QString str ) { mEvalErrorString = str; }
+    void setEvalErrorString( const QString& str ) { mEvalErrorString = str; }
 
     //! Set the number for $rownum special column
     void setCurrentRowNumber( int rowNumber ) { mRowNumber = rowNumber; }
@@ -160,7 +168,8 @@ class CORE_EXPORT QgsExpression
      */
     bool isField() const { return rootNode() && dynamic_cast<const NodeColumnRef*>( rootNode() ) ;}
 
-    static bool isValid( const QString& text, const QgsFields& fields, QString &errorMessage );
+    Q_DECL_DEPRECATED static bool isValid( const QString& text, const QgsFields& fields, QString &errorMessage );
+    static bool isValid( const QString& text, const QgsExpressionContext& context, QString &errorMessage );
 
     void setScale( double scale ) { mScale = scale; }
 
@@ -199,13 +208,18 @@ class CORE_EXPORT QgsExpression
        @param distanceArea optional QgsDistanceArea. If specified, the QgsDistanceArea is used for distance
        and area conversion
     */
-    static QString replaceExpressionText( const QString &action, const QgsFeature *feat,
-                                          QgsVectorLayer *layer,
+    Q_DECL_DEPRECATED static QString replaceExpressionText( const QString &action, const QgsFeature *feat,
+        QgsVectorLayer *layer,
+        const QMap<QString, QVariant> *substitutionMap = 0,
+        const QgsDistanceArea* distanceArea = 0
+                                                          );
+
+    static QString replaceExpressionText( const QString &action, const QgsExpressionContext& context,
                                           const QMap<QString, QVariant> *substitutionMap = 0,
                                           const QgsDistanceArea* distanceArea = 0
                                         );
 
-    /**Attempts to evaluate a text string as an expression to a resultant double
+    /** Attempts to evaluate a text string as an expression to a resultant double
      * value.
      * @param text text to evaluate as expression
      * @param fallbackValue value to return if text can not be evaluated as a double
@@ -278,7 +292,7 @@ class CORE_EXPORT QgsExpression
     static const char* UnaryOperatorText[];
 
     typedef QVariant( *FcnEval )( const QVariantList& values, const QgsFeature* f, QgsExpression* parent );
-
+    typedef QVariant( *FcnEvalContext )( const QVariantList& values, const QgsExpressionContext* context, QgsExpression* parent );
 
     /**
       * A abstract base class for defining QgsExpression functions.
@@ -332,7 +346,8 @@ class CORE_EXPORT QgsExpression
         /** The help text for the function. */
         const QString helptext() { return mHelpText.isEmpty() ? QgsExpression::helptext( mName ) : mHelpText; }
 
-        virtual QVariant func( const QVariantList& values, const QgsFeature* f, QgsExpression* parent ) = 0;
+        Q_DECL_DEPRECATED virtual QVariant func( const QVariantList&, const QgsFeature*, QgsExpression* );
+        virtual QVariant func( const QVariantList& values, const QgsExpressionContext* context, QgsExpression* parent );
 
         bool operator==( const Function& other ) const
         {
@@ -375,15 +390,37 @@ class CORE_EXPORT QgsExpression
 
         virtual ~StaticFunction() {}
 
-        virtual QVariant func( const QVariantList& values, const QgsFeature* f, QgsExpression* parent ) override
+        StaticFunction( QString fnname,
+                        int params,
+                        FcnEvalContext fcn,
+                        QString group,
+                        QString helpText = QString(),
+                        bool usesGeometry = false,
+                        QStringList referencedColumns = QStringList(),
+                        bool lazyEval = false,
+                        const QStringList& aliases = QStringList(),
+                        bool handlesNull = false )
+            : Function( fnname, params, group, helpText, usesGeometry, referencedColumns, lazyEval, handlesNull )
+            , mContextFnc( fcn )
+            , mAliases( aliases )
+        {}
+        Q_DECL_DEPRECATED virtual QVariant func( const QVariantList& values, const QgsFeature* f, QgsExpression* parent ) override
         {
+          Q_NOWARN_DEPRECATED_PUSH
           return mFnc( values, f, parent );
+          Q_NOWARN_DEPRECATED_POP
+        }
+
+        virtual QVariant func( const QVariantList& values, const QgsExpressionContext* context, QgsExpression* parent ) override
+        {
+          return mContextFnc( values, context, parent );
         }
 
         virtual QStringList aliases() const override { return mAliases; }
 
       private:
         FcnEval mFnc;
+        FcnEvalContext mContextFnc;
         QStringList mAliases;
     };
 
@@ -397,12 +434,12 @@ class CORE_EXPORT QgsExpression
     static bool unregisterFunction( QString name );
 
     // tells whether the identifier is a name of existing function
-    static bool isFunctionName( QString name );
+    static bool isFunctionName( const QString& name );
 
     // return index of the function in Functions array
     static int functionIndex( const QString& name );
 
-    /**  Returns the number of functions defined in the parser
+    /** Returns the number of functions defined in the parser
       *  @return The number of function defined in the parser.
       */
     static int functionCount();
@@ -439,11 +476,13 @@ class CORE_EXPORT QgsExpression
         virtual NodeType nodeType() const = 0;
         // abstract virtual eval function
         // errors are reported to the parent
-        virtual QVariant eval( QgsExpression* parent, const QgsFeature* f ) = 0;
+        Q_DECL_DEPRECATED virtual QVariant eval( QgsExpression* parent, const QgsFeature* f );
+        virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context );
 
         // abstract virtual preparation function
         // errors are reported to the parent
-        virtual bool prepare( QgsExpression* parent, const QgsFields &fields ) = 0;
+        Q_DECL_DEPRECATED virtual bool prepare( QgsExpression* parent, const QgsFields &fields );
+        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext& context );
 
         virtual QString dump() const = 0;
 
@@ -510,8 +549,8 @@ class CORE_EXPORT QgsExpression
         Node* operand() const { return mOperand; }
 
         virtual NodeType nodeType() const override { return ntUnaryOperator; }
-        virtual bool prepare( QgsExpression* parent, const QgsFields &fields ) override;
-        virtual QVariant eval( QgsExpression* parent, const QgsFeature* f ) override;
+        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext& context ) override;
+        virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context ) override;
         virtual QString dump() const override;
 
         virtual QStringList referencedColumns() const override { return mOperand->referencedColumns(); }
@@ -534,8 +573,8 @@ class CORE_EXPORT QgsExpression
         Node* opRight() const { return mOpRight; }
 
         virtual NodeType nodeType() const override { return ntBinaryOperator; }
-        virtual bool prepare( QgsExpression* parent, const QgsFields &fields ) override;
-        virtual QVariant eval( QgsExpression* parent, const QgsFeature* f ) override;
+        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext& context ) override;
+        virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context ) override;
         virtual QString dump() const override;
 
         virtual QStringList referencedColumns() const override { return mOpLeft->referencedColumns() + mOpRight->referencedColumns(); }
@@ -567,8 +606,8 @@ class CORE_EXPORT QgsExpression
         NodeList* list() const { return mList; }
 
         virtual NodeType nodeType() const override { return ntInOperator; }
-        virtual bool prepare( QgsExpression* parent, const QgsFields &fields ) override;
-        virtual QVariant eval( QgsExpression* parent, const QgsFeature* f ) override;
+        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext& context ) override;
+        virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context ) override;
         virtual QString dump() const override;
 
         virtual QStringList referencedColumns() const override { QStringList lst( mNode->referencedColumns() ); foreach ( Node* n, mList->list() ) lst.append( n->referencedColumns() ); return lst; }
@@ -592,8 +631,8 @@ class CORE_EXPORT QgsExpression
         NodeList* args() const { return mArgs; }
 
         virtual NodeType nodeType() const override { return ntFunction; }
-        virtual bool prepare( QgsExpression* parent, const QgsFields &fields ) override;
-        virtual QVariant eval( QgsExpression* parent, const QgsFeature* f ) override;
+        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext& context ) override;
+        virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context ) override;
         virtual QString dump() const override;
 
         virtual QStringList referencedColumns() const override;
@@ -604,6 +643,10 @@ class CORE_EXPORT QgsExpression
         //QString mName;
         int mFnIndex;
         NodeList* mArgs;
+
+      private:
+
+        QgsExpression::Function* getFunc() const;
     };
 
     class CORE_EXPORT NodeLiteral : public Node
@@ -614,8 +657,8 @@ class CORE_EXPORT QgsExpression
         inline QVariant value() const { return mValue; }
 
         virtual NodeType nodeType() const override { return ntLiteral; }
-        virtual bool prepare( QgsExpression* parent, const QgsFields &fields ) override;
-        virtual QVariant eval( QgsExpression* parent, const QgsFeature* f ) override;
+        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext& context ) override;
+        virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context ) override;
         virtual QString dump() const override;
 
         virtual QStringList referencedColumns() const override { return QStringList(); }
@@ -634,8 +677,8 @@ class CORE_EXPORT QgsExpression
         QString name() const { return mName; }
 
         virtual NodeType nodeType() const override { return ntColumnRef; }
-        virtual bool prepare( QgsExpression* parent, const QgsFields &fields ) override;
-        virtual QVariant eval( QgsExpression* parent, const QgsFeature* f ) override;
+        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext& context ) override;
+        virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context ) override;
         virtual QString dump() const override;
 
         virtual QStringList referencedColumns() const override { return QStringList( mName ); }
@@ -667,8 +710,8 @@ class CORE_EXPORT QgsExpression
         ~NodeCondition() { delete mElseExp; qDeleteAll( mConditions ); }
 
         virtual NodeType nodeType() const override { return ntCondition; }
-        virtual QVariant eval( QgsExpression* parent, const QgsFeature* f ) override;
-        virtual bool prepare( QgsExpression* parent, const QgsFields &fields ) override;
+        virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context ) override;
+        virtual bool prepare( QgsExpression* parent, const QgsExpressionContext& context ) override;
         virtual QString dump() const override;
 
         virtual QStringList referencedColumns() const override;
@@ -682,7 +725,7 @@ class CORE_EXPORT QgsExpression
 
     //////
 
-    /** support for visitor pattern - algorithms dealing with the expressions
+    /** Support for visitor pattern - algorithms dealing with the expressions
         may be implemented without modifying the Node classes */
     class CORE_EXPORT Visitor
     {
@@ -697,7 +740,7 @@ class CORE_EXPORT QgsExpression
         virtual void visit( const NodeCondition& n ) = 0;
     };
 
-    /** entry function for the visitor pattern */
+    /** Entry function for the visitor pattern */
     void acceptVisitor( Visitor& v ) const;
 
     static QString helptext( QString name );

--- a/src/core/qgsexpressioncontext.cpp
+++ b/src/core/qgsexpressioncontext.cpp
@@ -1,0 +1,356 @@
+/***************************************************************************
+     qgsexpressioncontext.cpp
+     ------------------------
+    Date                 : April 2015
+    Copyright            : (C) 2015 by Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsexpressioncontext.h"
+
+#include "qgslogger.h"
+#include "qgsexpression.h"
+#include "qgsfield.h"
+#include "qgsvectorlayer.h"
+#include "qgsproject.h"
+#include <QSettings>
+#include <QDir>
+
+//internal variable names, shouldn't be overwritten
+QStringList QgsExpressionContext::mReservedVariableNames = QStringList()
+    << "feature"
+    << "fields";
+
+
+QgsExpressionContext::~QgsExpressionContext()
+{
+  qDeleteAll( mFunctions );
+}
+
+bool QgsExpressionContext::hasFunction( const QString &name ) const
+{
+  return mFunctions.contains( name );
+}
+
+QgsExpression::Function *QgsExpressionContext::function( const QString &name ) const
+{
+  return mFunctions.contains( name ) ? mFunctions.value( name ) : 0;
+}
+
+//stack
+
+QgsExpressionContextStack::~QgsExpressionContextStack()
+{
+}
+
+void QgsExpressionContextStack::appendContext( QgsExpressionContext *context )
+{
+  mStack.append( context );
+}
+
+bool QgsExpressionContextStack::hasVariable( const QString &name ) const
+{
+  foreach ( QgsExpressionContext* context, mStack )
+  {
+    if ( context->hasVariable( name ) )
+      return true;
+  }
+  return false;
+}
+
+QVariant QgsExpressionContextStack::variable( const QString &name ) const
+{
+  QgsExpressionContext* context = activeContextForVariable( name );
+  return context ? context->variable( name ) : QVariant();
+}
+
+QgsExpressionContext *QgsExpressionContextStack::activeContextForVariable( const QString &name ) const
+{
+  //iterate through stack backwards, so that higher priority variables take precedence
+  QList< QgsExpressionContext* >::const_iterator it = mStack.constEnd();
+  while ( it != mStack.constBegin() )
+  {
+    --it;
+    QgsExpressionContextStack* nextStack = dynamic_cast<QgsExpressionContextStack*>(( *it ) );
+    if ( nextStack )
+    {
+      QgsExpressionContext* contextFromStack = nextStack->activeContextForVariable( name );
+      if ( contextFromStack )
+        return contextFromStack;
+    }
+    else if (( *it )->hasVariable( name ) )
+      return ( *it );
+  }
+  return 0;
+}
+
+QStringList QgsExpressionContextStack::variableNames() const
+{
+  QStringList names;
+  foreach ( QgsExpressionContext* context, mStack )
+  {
+    names << context->variableNames();
+  }
+  return names.toSet().toList();
+}
+
+bool QgsExpressionContextStack::hasFunction( const QString &name ) const
+{
+  foreach ( QgsExpressionContext* context, mStack )
+  {
+    if ( context->hasFunction( name ) )
+      return true;
+  }
+  return false;
+}
+
+QgsExpression::Function *QgsExpressionContextStack::function( const QString &name ) const
+{
+  //iterate through stack backwards, so that higher priority variables take precedence
+  QList< QgsExpressionContext* >::const_iterator it = mStack.constEnd();
+  while ( it != mStack.constBegin() )
+  {
+    --it;
+    if (( *it )->hasFunction( name ) )
+      return ( *it )->function( name );
+  }
+  return 0;
+}
+
+int QgsExpressionContextStack::childCount() const
+{
+  int count = 0;
+  foreach ( QgsExpressionContext* context, mStack )
+  {
+    QgsExpressionContextStack* nextStack = dynamic_cast<QgsExpressionContextStack*>( context );
+    if ( nextStack )
+    {
+      count += nextStack->childCount();
+    }
+    else
+    {
+      count++;
+    }
+  }
+
+  return count;
+}
+
+QgsExpressionContext *QgsExpressionContextStack::getChild( int index )
+{
+  foreach ( QgsExpressionContext* context, mStack )
+  {
+    QgsExpressionContextStack* nextStack = dynamic_cast<QgsExpressionContextStack*>( context );
+    if ( nextStack )
+    {
+      int count = nextStack->childCount();
+      if ( count < index )
+      {
+        return nextStack->getChild( index );
+      }
+      else
+      {
+        index -= count;
+      }
+    }
+    else if ( index == 0 )
+      return context;
+    else
+      index--;
+  }
+  return 0;
+}
+
+
+//
+// QgsStaticValueExpressionContext
+//
+
+void QgsStaticValueExpressionContext::setVariable( const QString &name, const QVariant &value )
+{
+  if ( mVariables.contains( name ) )
+  {
+    StaticVariable existing = mVariables.value( name );
+    existing.value = value;
+    insertVariable( existing );
+  }
+  else
+  {
+    insertVariable( QgsStaticValueExpressionContext::StaticVariable( name, value ) );
+  }
+}
+
+void QgsStaticValueExpressionContext::insertVariable( const QgsStaticValueExpressionContext::StaticVariable &variable )
+{
+  mVariables.insert( variable.name, variable );
+}
+
+void QgsStaticValueExpressionContext::removeVariable( const QString &name )
+{
+  mVariables.remove( name );
+}
+
+bool QgsStaticValueExpressionContext::hasVariable( const QString &name ) const
+{
+  return mRegisteredNames.contains( name ) || mVariables.contains( name );
+}
+
+QVariant QgsStaticValueExpressionContext::variable( const QString &name ) const
+{
+  return mVariables.value( name ).value;
+}
+
+QStringList QgsStaticValueExpressionContext::variableNames() const
+{
+  QStringList names = mVariables.keys();
+  if ( !mRegisteredNames.isEmpty() )
+    names.append( mRegisteredNames );
+  return names;
+}
+
+bool QgsStaticValueExpressionContext::isReadOnly( const QString &name ) const
+{
+  return mRegisteredNames.contains( name ) || mVariables.value( name ).readOnly;
+}
+
+
+
+//
+// QgsGlobalExpressionContext
+//
+
+QgsGlobalExpressionContext::QgsGlobalExpressionContext()
+    : QgsStaticValueExpressionContext( QT_TR_NOOP( "QGIS" ) )
+{
+  //read values from QSettings
+  QSettings settings;
+
+  //check if settings contains any variables
+  if ( settings.contains( QString( "/variables/values" ) ) )
+  {
+    QList< QVariant > customVariableVariants = settings.value( QString( "/variables/values" ) ).toList();
+    QList< QVariant > customVariableNames = settings.value( QString( "/variables/names" ) ).toList();
+    int variableIndex = 0;
+    for ( QList< QVariant >::const_iterator it = customVariableVariants.constBegin();
+          it != customVariableVariants.constEnd(); ++it )
+    {
+      if ( variableIndex >= customVariableNames.length() )
+      {
+        break;
+      }
+
+      QVariant value = ( *it );
+      QString name = customVariableNames.at( variableIndex ).toString();
+
+      setVariable( name, value );
+      variableIndex++;
+    }
+  }
+
+  //add some extra global variables
+  insertVariable( QgsStaticValueExpressionContext::StaticVariable( "qgis_version", QGis::QGIS_VERSION, true ) );
+  insertVariable( QgsStaticValueExpressionContext::StaticVariable( "qgis_version_no", QGis::QGIS_VERSION_INT, true ) );
+  insertVariable( QgsStaticValueExpressionContext::StaticVariable( "qgis_release_name", QGis::QGIS_RELEASE_NAME, true ) );
+}
+
+QgsGlobalExpressionContext::~QgsGlobalExpressionContext()
+{
+  save();
+}
+
+QgsGlobalExpressionContext *QgsGlobalExpressionContext::instance()
+{
+  static QgsGlobalExpressionContext* sInstance( new QgsGlobalExpressionContext() );
+  return sInstance;
+}
+
+void QgsGlobalExpressionContext::save()
+{
+  // save variables to settings
+  QSettings settings;
+  QList< QVariant > keyVariantList;
+  QList< QString > keys = mVariables.keys();
+  QList< QVariant > valueList;
+  foreach ( QString key, keys )
+  {
+    if ( isReadOnly( key ) )
+    {
+      //only save user set (non readonly) variables
+      continue;
+    }
+    keyVariantList << QVariant( key );
+    valueList << mVariables.value( key ).value;
+  }
+  settings.setValue( QString( "/variables/names" ), keyVariantList );
+  settings.setValue( QString( "/variables/values" ), valueList );
+}
+
+QgsProjectExpressionContext::QgsProjectExpressionContext( QgsProject *project )
+    : QgsStaticValueExpressionContext( QT_TR_NOOP( "Project" ) )
+    , mProject( project ? project : QgsProject::instance() )
+{
+  registerVariableNames( QStringList() <<  "project_title" << "project_path" << "project_folder" << "project_filename" );
+  load();
+}
+
+void QgsProjectExpressionContext::load()
+{
+  QStringList variableNames = mProject->readListEntry( "Variables", "/variableNames" );
+  QStringList variableValues = mProject->readListEntry( "Variables", "/variableValues" );
+
+  int varIndex = 0;
+  foreach ( QString variableName, variableNames )
+  {
+    if ( varIndex >= variableValues.length() )
+    {
+      break;
+    }
+
+    QString varValueString = variableValues.at( varIndex );
+    varIndex++;
+    QgsStaticValueExpressionContext::setVariable( variableName, varValueString );
+  }
+}
+
+
+void QgsProjectExpressionContext::insertVariable( const StaticVariable &value )
+{
+  QgsStaticValueExpressionContext::insertVariable( value );
+  //also write to project
+
+  QStringList variableNames = mVariables.keys();
+  QStringList variableValues;
+  foreach ( QString variableName, variableNames )
+  {
+    variableValues << mVariables.value( variableName ).value.toString();
+  }
+  mProject->writeEntry( "Variables", "/variableNames", variableNames );
+  mProject->writeEntry( "Variables", "/variableValues", variableValues );
+}
+
+QVariant QgsProjectExpressionContext::variable( const QString &name ) const
+{
+  if ( name == "project_title" )
+    return mProject->title();
+  else if ( name == "project_path" )
+    return mProject->fileInfo().filePath();
+  else if ( name == "project_folder" )
+    return mProject->fileInfo().dir().path();
+  else if ( name == "project_filename" )
+    return mProject->fileInfo().fileName();
+  else
+    return QgsStaticValueExpressionContext::variable( name );
+}
+
+void QgsProjectExpressionContext::clear()
+{
+  mVariables.clear();
+}
+

--- a/src/core/qgsexpressioncontext.h
+++ b/src/core/qgsexpressioncontext.h
@@ -1,0 +1,378 @@
+/***************************************************************************
+     qgsexpressioncontext.h
+     ----------------------
+    Date                 : April 2015
+    Copyright            : (C) 2015 by Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSEXPRESSIONCONTEXT_H
+#define QGSEXPRESSIONCONTEXT_H
+
+#include <QVariant>
+#include <QHash>
+#include <QString>
+#include <QStringList>
+#include <QSet>
+#include "qgsfield.h"
+#include "qgsfeature.h"
+#include "qgsexpression.h"
+#include "qgsrendercontext.h"
+
+class QgsExpression;
+class QgsVectorLayer;
+class QgsFeature;
+class QgsRenderContext;
+class QgsProject;
+
+/** \ingroup core
+ * \class QgsExpressionContext
+ * \brief Base class for expression contexts. Expression contexts are used to
+ * encapsulate the parameters around which an expression should be evaluated.
+ * Examples include the project's context, which contains information about the
+ * current project such as the project file's location. Expressions can then
+ * utilise the information stored in a context to vary their output result.
+ * Contexts can encapsulate both variables (static values) and functions
+ * (which are calculated only when the expression is evaluated).
+ * \note added in QGIS 2.12
+ */
+class CORE_EXPORT QgsExpressionContext
+{
+  public:
+
+    /** Constructor for QgsExpressionContext
+     * @param name friendly display name for the context
+     */
+    QgsExpressionContext( const QString& name = QString() ) : mName( name ) {}
+
+    virtual ~QgsExpressionContext();
+
+    /** Returns the name of the context.
+     */
+    QString name() const { return mName; }
+
+    /** Check whether a variable is specified in the context.
+     * @param name variable name
+     * @returns true if variable is set
+     * @see variable
+     * @see variablenames
+     */
+    virtual bool hasVariable( const QString& name ) const { Q_UNUSED( name ); return false; }
+
+    /** Fetches a matching variable from the context.
+     * @param name variable name
+     * @returns variable value if set in the context, otherwise an invalid QVariant
+     * @see hasVariable
+     * @see variableNames
+     */
+    virtual QVariant variable( const QString& name ) const { Q_UNUSED( name ); return QVariant(); }
+
+    /** Returns a list of variables names set in the context.
+     * @returns list of unique variable names
+     * @see hasVariable
+     * @see variable
+     */
+    virtual QStringList variableNames() const { return QStringList(); }
+
+    /** Returns whether a variable is read only, and should not be modifiable by users.
+     * @param name variable name
+     * @returns true if variable is read only
+     */
+    virtual bool isReadOnly( const QString& name ) const { Q_UNUSED( name ); return true; }
+
+    /** Checks whether a specified function is contained in the context.
+     * @param name function name
+     * @returns true if context provides a matching function
+     * @see function
+     */
+    virtual bool hasFunction( const QString& name ) const;
+
+    /** Fetches a matching function from the context.
+     * @param name function name
+     * @returns function if contained by the context, otherwise null
+     * @see hasFunction
+     */
+    virtual QgsExpression::Function* function( const QString& name ) const;
+
+    /** Returns a list of reserved variable names. These variable names
+     * are used internally by QGIS and must not be reused by user
+     * specified variables.
+     */
+    static QStringList reservedVariables() { return mReservedVariableNames; }
+
+  protected:
+
+    QHash<QString, QgsExpression::Function*> mFunctions;
+    static QStringList mReservedVariableNames;
+    QString mName;
+
+};
+
+
+/** \ingroup core
+ * \class QgsExpressionContextStack
+ * \brief A stack of expression contexts. Essentially an expression stack is
+ * an ordered list of expressions contexts, where contexts later in the
+ * stack override earlier contexts. Stacks can be used to combine multiple
+ * QgsExpressionContexts, eg to combine the global expression context
+ * with a project's context, with a particular render operation's context.
+ * \note added in QGIS 2.12
+ */
+
+class CORE_EXPORT QgsExpressionContextStack : public QgsExpressionContext
+{
+  public:
+
+    QgsExpressionContextStack() : QgsExpressionContext() {}
+
+    virtual ~QgsExpressionContextStack();
+
+    /** Appends a context to the end of the stack. This context will override
+     * any matching variables or functions provided by existing members of the
+     * stack. Ownership of the context is NOT transferred to the stack.
+     * @param context expression context to append to stack
+     */
+    void appendContext( QgsExpressionContext* context );
+
+    /** Checks whether a stack includes any contexts which specify
+     * a matching variable.
+     * @param name variable name
+     * @returns true if stack includes the specified variable
+     * @see variable
+     * @see variableNames
+     */
+    virtual bool hasVariable( const QString& name ) const override;
+
+    /** Fetches a matching variable from the stack. Contexts later in
+     * the stack will take precedence (ie, the stack is searched from
+     * the last added context through to the first and returns the
+     * first matching variable found).
+     * @param name variable name
+     * @returns matching variable value from the stack, or an invalid
+     * QVariant if variable was not found
+     * @see hasVariable
+     * @see variableNames
+     */
+    virtual QVariant variable( const QString& name ) const override;
+
+    /** Returns the currently active context from the stack for a specified variable.
+     * As contexts later in the stack override earlier contexts, this will be
+     * the last matching context which contains the variable.
+     * @param name variable name
+     * @returns matching context containing variable, or null if none found
+     */
+    QgsExpressionContext* activeContextForVariable( const QString& name ) const;
+
+    /** Returns a list of unique variable names specified by contexts
+     * within the stack.
+     * @see hasVariable
+     * @see variable
+     */
+    virtual QStringList variableNames() const override;
+
+    /** Checks whether a stack includes any contexts which specify
+     * a matching function.
+     * @param name function name
+     * @returns true if stack includes the specified function
+     * @see function
+     */
+    virtual bool hasFunction( const QString& name ) const override;
+
+    /** Fetches a matching function from the stack. Contexts later in
+     * the stack will take precedence (ie, the stack is searched from
+     * the last added context through to the first and returns the
+     * first matching function found).
+     * @param name function name
+     * @returns function if contained by the stack, otherwise null
+     * @see hasFunction
+     */
+    virtual QgsExpression::Function* function( const QString& name ) const override;
+
+    /** Returns a reference to the list of contexts stored in the stack
+     */
+    QList< QgsExpressionContext* >& stack() { return mStack; }
+
+    int childCount() const;
+
+    QgsExpressionContext* getChild( int index );
+
+  private:
+
+    QList< QgsExpressionContext* > mStack;
+
+};
+
+
+/** \ingroup core
+ * \class QgsStaticValueExpressionContext
+ * \brief Expression context for simple property/value maps.
+ * \note added in QGIS 2.12
+ */
+
+class CORE_EXPORT QgsStaticValueExpressionContext : public QgsExpressionContext
+{
+  public:
+
+    struct StaticVariable
+    {
+      StaticVariable( const QString& name = QString(), const QVariant& value = QVariant(), bool readOnly = false ) : name( name ), value( value ), readOnly( readOnly ) {}
+      QString name;
+      QVariant value;
+      bool readOnly;
+    };
+
+    /** Constructor for QgsStaticValueExpressionContext
+     * @param name friendly display name for the context
+     */
+    QgsStaticValueExpressionContext( const QString& name = QString() ) : QgsExpressionContext( name ) {}
+
+    /** Convenience method for setting a variable in the context. If the variable is already set then
+     * its value is overwritten, otherwise a new variable is added to the context.
+     * @param name variable name
+     * @param value variable value
+     * @see insertVariable
+     */
+    void setVariable( const QString& name, const QVariant& value );
+
+    /** Inserts a variable into the context. If the variable is already set then
+     * its value is overwritten, otherwise a new variable is added to the
+     * context.
+     * @param variable definition of variable to insert
+     * @see setVariable
+     */
+    virtual void insertVariable( const QgsStaticValueExpressionContext::StaticVariable& variable );
+
+    /** Removes a variable from the context, if found.
+     * @param name name of variable to remove
+     */
+    virtual void removeVariable( const QString& name );
+
+    bool hasVariable( const QString& name ) const override;
+    QVariant variable( const QString& name ) const override;
+    QStringList variableNames() const override;
+    virtual bool isReadOnly( const QString& name ) const override;
+
+  protected:
+
+    QMap<QString, StaticVariable> mVariables;
+
+    void registerVariableNames( const QStringList& names )
+    {
+      mRegisteredNames = names;
+    }
+
+  private:
+
+    QStringList mRegisteredNames;
+
+};
+
+
+/** \ingroup core
+ * \class QgsGlobalExpressionContext
+ * \brief Expression context for global, user-specified variables. These variables
+ * are saved in QGIS settings and are persistent across sessions and projects.
+ * \note added in QGIS 2.12
+ */
+
+class CORE_EXPORT QgsGlobalExpressionContext : public QgsStaticValueExpressionContext
+{
+  public:
+    static QgsGlobalExpressionContext* instance();
+
+    /** Saves the variables contained in the context to the user's QGIS settings.
+     */
+    void save();
+
+    QgsGlobalExpressionContext();
+    ~QgsGlobalExpressionContext();
+
+};
+
+
+/** \ingroup core
+ * \class QgsProjectExpressionContext
+ * \brief Expression context for variables attached to a project. The variables
+ * are stored within the project file.
+ * \note added in QGIS 2.12
+ */
+
+class CORE_EXPORT QgsProjectExpressionContext : public QgsStaticValueExpressionContext
+{
+  public:
+
+    QgsProjectExpressionContext( QgsProject* project = 0 );
+
+    /** Clears all variables from the project context
+     */
+    void clear();
+
+    /** Loads variables from the current project to the context
+     */
+    void load();
+
+    virtual void insertVariable( const QgsStaticValueExpressionContext::StaticVariable& value ) override;
+
+    QVariant variable( const QString& name ) const override;
+
+  private:
+
+    QgsProject* mProject;
+};
+
+class CORE_EXPORT QgsFeatureBasedExpressionContext : public QgsExpressionContext
+{
+  public:
+
+    /**
+     * Creates an expression context based on a feature
+     * @param feature
+     * @param fields
+     */
+    QgsFeatureBasedExpressionContext( const QgsFeature& feature,
+                                      const QgsFields& fields = QgsFields() )
+        : QgsExpressionContext()
+        , mFeature( feature )
+        , mFields( fields )
+    {
+    }
+
+    bool hasVariable( const QString& name ) const override
+    {
+      return ( name == "feature" ) ||
+             ( name == "fields" && mFields.count() );
+    }
+
+    QVariant variable( const QString& name ) const override
+    {
+      if ( name == "feature" )
+      {
+        return QVariant::fromValue( mFeature );
+      }
+      else if ( name == "fields" )
+      {
+        return QVariant::fromValue( mFields );
+      }
+      return QVariant();
+    }
+
+    QStringList variableNames() const override
+    {
+      return QStringList() << "feature" << "fields";
+    }
+
+  private:
+
+    const QgsFeature mFeature;
+    const QgsFields mFields;
+
+};
+
+
+#endif // QGSEXPRESSIONCONTEXT_H

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -36,12 +36,14 @@
 #include "qgsrectangle.h"
 #include "qgsrelationmanager.h"
 #include "qgsvectorlayer.h"
+#include "qgsexpressioncontext.h"
 
 #include <QApplication>
 #include <QFileInfo>
 #include <QDomNode>
 #include <QObject>
 #include <QTextStream>
+#include <QDir>
 
 // canonical project instance
 QgsProject *QgsProject::theProject_ = 0;
@@ -147,7 +149,7 @@ QgsProperty *findKey_( QString const &scope,
 
 
 
-/** add the given key and value
+/** Add the given key and value
 
 @param scope scope of key
 @param key key name
@@ -304,7 +306,7 @@ struct QgsProject::Imp
     properties_.name() = "properties"; // root property node always this value
   }
 
-  /** clear project properties when a new project is started
+  /** Clear project properties when a new project is started
    */
   void clear()
   {
@@ -325,6 +327,8 @@ QgsProject::QgsProject()
     , mBadLayerHandler( new QgsProjectBadLayerDefaultHandler() )
     , mRelationManager( new QgsRelationManager( this ) )
     , mRootGroup( new QgsLayerTreeGroup )
+    , mProjectContext( new QgsProjectExpressionContext( this ) )
+    , mContextStack( new QgsExpressionContextStack() )
 {
   clear();
 
@@ -333,6 +337,10 @@ QgsProject::QgsProject()
   // layer tree will be updated
   mLayerTreeRegistryBridge = new QgsLayerTreeRegistryBridge( mRootGroup, this );
 
+  //project expression context stack consists of the global expression context
+  //plus a specific project context
+  mContextStack->appendContext( QgsGlobalExpressionContext::instance() );
+  mContextStack->appendContext( mProjectContext );
 } // QgsProject ctor
 
 
@@ -342,6 +350,9 @@ QgsProject::~QgsProject()
   delete mBadLayerHandler;
   delete mRelationManager;
   delete mRootGroup;
+
+  delete mContextStack;
+  delete mProjectContext;
 
   // note that QScopedPointer automatically deletes imp_ when it's destroyed
 } // QgsProject dtor
@@ -406,13 +417,19 @@ void QgsProject::setFileName( QString const &name )
 QString QgsProject::fileName() const
 {
   return imp_->file.fileName();
-} // QString QgsProject::fileName() const
+}
+
+QFileInfo QgsProject::fileInfo() const
+{
+  return QFileInfo( imp_->file );
+}
 
 void QgsProject::clear()
 {
   imp_->clear();
   mEmbeddedLayers.clear();
   mRelationManager->clear();
+  mProjectContext->clear();
 
   mRootGroup->removeAllChildren();
 
@@ -545,7 +562,7 @@ static void _getTitle( QDomDocument const &doc, QString &title )
 } // _getTitle
 
 
-/** return the version string found in the given Dom document
+/** Return the version string found in the given Dom document
 
    @returns the version string or an empty string if none found
  */
@@ -896,6 +913,8 @@ bool QgsProject::read()
 
   // read the project: used by map canvas and legend
   emit readProject( *doc );
+
+  mProjectContext->load();
 
   // if all went well, we're allegedly in pristine state
   if ( clean )

--- a/src/core/qgsproject.h
+++ b/src/core/qgsproject.h
@@ -27,6 +27,7 @@
 #include <QList>
 #include <QObject>
 #include <QPair>
+#include <QFileInfo>
 
 //for the snap settings
 #include "qgssnapper.h"
@@ -45,6 +46,8 @@ class QgsMapLayer;
 class QgsProjectBadLayerHandler;
 class QgsRelationManager;
 class QgsVectorLayer;
+class QgsProjectExpressionContext;
+class QgsExpressionContextStack;
 
 /** \ingroup core
  * Reads and writes project states.
@@ -90,7 +93,7 @@ class CORE_EXPORT QgsProject : public QObject
      *  @note added in 2.4 */
     void setTitle( const QString& title );
 
-    /** returns title */
+    /** Returns title */
     const QString & title() const;
     //@}
 
@@ -116,9 +119,14 @@ class CORE_EXPORT QgsProject : public QObject
     //@{
     void setFileName( const QString & name );
 
-    /** returns file name */
+    /** Returns file name */
     QString fileName() const;
     //@}
+
+    /** Returns QFileInfo object for the project's associated file.
+     * @note added in QGIS 2.9
+     */
+    QFileInfo fileInfo() const;
 
     /** Clear the project
      * @note added in 2.4
@@ -126,7 +134,7 @@ class CORE_EXPORT QgsProject : public QObject
     void clear();
 
 
-    /** read project file
+    /** Read project file
 
        @note Any current plug-in state is erased
 
@@ -148,7 +156,7 @@ class CORE_EXPORT QgsProject : public QObject
     //@}
 
 
-    /** read the layer described in the associated Dom node
+    /** Read the layer described in the associated Dom node
 
         @param layerNode   represents a QgsProject Dom node that maps to a specific layer.
 
@@ -163,7 +171,7 @@ class CORE_EXPORT QgsProject : public QObject
     bool read( QDomNode & layerNode );
 
 
-    /** write project file
+    /** Write project file
 
        XXX How to best get read access to Qgis state?  Actually we can finagle
        that by searching for qgisapp in object hiearchy.
@@ -202,7 +210,7 @@ class CORE_EXPORT QgsProject : public QObject
     bool writeEntry( const QString & scope, const QString & key, const QStringList & value );
     //@}
 
-    /** key value accessors
+    /** Key value accessors
 
         keys would be the familiar QSettings-like '/' delimited entries,
         implying a hierarchy of keys and corresponding values
@@ -220,34 +228,34 @@ class CORE_EXPORT QgsProject : public QObject
     //@}
 
 
-    /** remove the given key */
+    /** Remove the given key */
     bool removeEntry( const QString & scope, const QString & key );
 
 
-    /** return keys with values -- do not return keys that contain other keys
+    /** Return keys with values -- do not return keys that contain other keys
 
       @note equivalent to QSettings entryList()
     */
     QStringList entryList( const QString & scope, const QString & key ) const;
 
-    /** return keys with keys -- do not return keys that contain only values
+    /** Return keys with keys -- do not return keys that contain only values
 
       @note equivalent to QSettings subkeyList()
     */
     QStringList subkeyList( const QString & scope, const QString & key ) const;
 
 
-    /** dump out current project properties to stderr
+    /** Dump out current project properties to stderr
 
       @todo XXX Now slightly broken since re-factoring.  Won't print out top-level key
                 and redundantly prints sub-keys.
     */
     void dumpProperties() const;
 
-    /** prepare a filename to save it to the project file */
+    /** Prepare a filename to save it to the project file */
     QString writePath( QString filename, QString relativeBasePath = QString::null ) const;
 
-    /** turn filename read from the project file to an absolute path */
+    /** Turn filename read from the project file to an absolute path */
     QString readPath( QString filename ) const;
 
     /** Return error message from previous read/write */
@@ -300,6 +308,19 @@ class CORE_EXPORT QgsProject : public QObject
      * @note added in 2.4
      */
     QgsLayerTreeRegistryBridge* layerTreeRegistryBridge() const { return mLayerTreeRegistryBridge; }
+
+    /** Return pointer to the project's expression context. This context contains variables
+     * which are stored in the project file
+     * @returns project context
+     * @note added in 2.9
+     */
+    QgsProjectExpressionContext* projectExpressionContext() const { return mProjectContext; }
+
+    /** Return pointer to the expression context stack at project level. This stack includes
+     * both the project's expression context and any contexts from lower level components.
+     * @note added in 2.9
+     */
+    QgsExpressionContextStack* expressionContextStack() const { return mContextStack; }
 
   protected:
 
@@ -380,7 +401,7 @@ class CORE_EXPORT QgsProject : public QObject
 
     QgsProjectBadLayerHandler* mBadLayerHandler;
 
-    /**Embeded layers which are defined in other projects. Key: layer id,
+    /** Embeded layers which are defined in other projects. Key: layer id,
     value: pair< project file path, save layer yes / no (e.g. if the layer is part of an embedded group, loading/saving is done by the legend)
        If the project file path is empty, QgsProject is going to ignore the layer for saving (e.g. because it is part and managed by an embedded group)*/
     QHash< QString, QPair< QString, bool> > mEmbeddedLayers;
@@ -393,6 +414,9 @@ class CORE_EXPORT QgsProject : public QObject
     QgsLayerTreeGroup* mRootGroup;
 
     QgsLayerTreeRegistryBridge* mLayerTreeRegistryBridge;
+
+    QgsProjectExpressionContext* mProjectContext;
+    QgsExpressionContextStack* mContextStack;
 
 }; // QgsProject
 

--- a/tests/src/core/CMakeLists.txt
+++ b/tests/src/core/CMakeLists.txt
@@ -78,6 +78,7 @@ ENDMACRO (ADD_QGIS_TEST)
 # Tests:
 
 ADD_QGIS_TEST(qgistest testqgis.cpp)
+ADD_QGIS_TEST(expressioncontext testqgsexpressioncontext.cpp)
 ADD_QGIS_TEST(clippertest testqgsclipper.cpp)
 ADD_QGIS_TEST(distanceareatest testqgsdistancearea.cpp)
 ADD_QGIS_TEST(applicationtest testqgsapplication.cpp)

--- a/tests/src/core/testqgsexpressioncontext.cpp
+++ b/tests/src/core/testqgsexpressioncontext.cpp
@@ -1,0 +1,256 @@
+/***************************************************************************
+                         testqgsexpressioncontext.cpp
+                         ----------------------------
+    begin                : April 2015
+    copyright            : (C) 2015 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsexpressioncontext.h"
+#include "qgsexpression.h"
+#include "qgsvectorlayer.h"
+#include "qgsapplication.h"
+#include "qgsproject.h"
+#include <QObject>
+#include <QtTest/QtTest>
+
+class TestQgsExpressionContext : public QObject
+{
+    Q_OBJECT
+
+  private slots:
+    void initTestCase();// will be called before the first testfunction is executed.
+    void cleanupTestCase();// will be called after the last testfunction was executed.
+    void init();// will be called before each testfunction is executed.
+    void cleanup();// will be called after every testfunction.
+    void staticValueContext(); //test for QgsStaticValueExpressionContext
+    void contextStack();
+    void evaluate();
+
+    void globalVariables();
+    void projectVariables();
+
+  private:
+
+    class TestContext : public QgsExpressionContext
+    {
+      public:
+
+        TestContext( int value )
+            : QgsExpressionContext()
+            , mValue( value )
+        {
+          QgsExpression::registerFunction( new GetTestValueFunction( 0 ) );
+          mFunctions.insert( "get_test_value", new GetTestValueFunction( this ) );
+        }
+
+      private:
+
+        class GetTestValueFunction : public QgsExpression::Function
+        {
+          public:
+            GetTestValueFunction( TestContext* context )
+                : QgsExpression::Function( "get_test_value", 1, "test" ), mContext( context ) {}
+
+            virtual QVariant func( const QVariantList&, const QgsExpressionContext*, QgsExpression* ) override
+            {
+              mContext->mValue++;
+              return mContext->mValue;
+            }
+
+          private:
+            TestContext* mContext;
+        };
+
+        int mValue;
+        friend class GetTestValueFunction;
+    };
+};
+
+void TestQgsExpressionContext::initTestCase()
+{
+  QgsApplication::init();
+  QgsApplication::initQgis();
+
+  // Set up the QSettings environment
+  QCoreApplication::setOrganizationName( "QGIS" );
+  QCoreApplication::setOrganizationDomain( "qgis.org" );
+  QCoreApplication::setApplicationName( "QGIS-TEST" );
+}
+
+void TestQgsExpressionContext::cleanupTestCase()
+{
+  QgsApplication::exitQgis();
+}
+
+void TestQgsExpressionContext::init()
+{
+
+}
+
+void TestQgsExpressionContext::cleanup()
+{
+
+}
+
+void TestQgsExpressionContext::staticValueContext()
+{
+  QgsStaticValueExpressionContext context;
+
+  QVERIFY( !context.hasVariable( "test" ) );
+  QVERIFY( !context.variable( "test" ).isValid() );
+  QCOMPARE( context.variableNames().length(), 0 );
+
+  context.setVariable( "test", 5 );
+  QVERIFY( context.hasVariable( "test" ) );
+  QVERIFY( context.variable( "test" ).isValid() );
+  QCOMPARE( context.variable( "test" ).toInt(), 5 );
+  QCOMPARE( context.variableNames().length(), 1 );
+  QCOMPARE( context.variableNames().at( 0 ), QString( "test" ) );
+
+  context.insertVariable( QgsStaticValueExpressionContext::StaticVariable( "readonly", QString( "readonly_test" ), true ) );
+  QVERIFY( context.isReadOnly( "readonly" ) );
+  context.insertVariable( QgsStaticValueExpressionContext::StaticVariable( "notreadonly", QString( "not_readonly_test" ), false ) );
+  QVERIFY( !context.isReadOnly( "notreadonly" ) );
+
+  //updating a read only variable should remain read only
+  context.setVariable( "readonly", "newvalue" );
+  QVERIFY( context.isReadOnly( "readonly" ) );
+}
+
+void TestQgsExpressionContext::contextStack()
+{
+  QgsExpressionContextStack stack;
+  //test retrieving from empty stack
+  QVERIFY( !stack.hasVariable( "test" ) );
+  QVERIFY( !stack.variable( "test" ).isValid() );
+  QCOMPARE( stack.variableNames().length(), 0 );
+
+  //add a context to the stack
+  QgsStaticValueExpressionContext* context1 = new QgsStaticValueExpressionContext();
+  stack.appendContext( context1 );
+  QVERIFY( !stack.hasVariable( "test" ) );
+  QVERIFY( !stack.variable( "test" ).isValid() );
+  QCOMPARE( stack.variableNames().length(), 0 );
+
+  //now add a variable to the first context
+  context1->setVariable( "test", 1 );
+  QVERIFY( stack.hasVariable( "test" ) );
+  QCOMPARE( stack.variable( "test" ).toInt(), 1 );
+  QCOMPARE( stack.variableNames().length(), 1 );
+
+  //add a second context, should override the first
+  QgsStaticValueExpressionContext* context2 = new QgsStaticValueExpressionContext();
+  stack.appendContext( context2 );
+  //test without setting variable first...
+  QVERIFY( stack.hasVariable( "test" ) );
+  QCOMPARE( stack.variable( "test" ).toInt(), 1 );
+  QCOMPARE( stack.variableNames().length(), 1 );
+  //then set the variable so it overrides
+  context2->setVariable( "test", 2 );
+  QVERIFY( stack.hasVariable( "test" ) );
+  QCOMPARE( stack.variable( "test" ).toInt(), 2 );
+  QCOMPARE( stack.variableNames().length(), 1 );
+
+  //make sure stack falls back to earlier contexts
+  context1->setVariable( "test2", 11 );
+  QVERIFY( stack.hasVariable( "test2" ) );
+  QCOMPARE( stack.variable( "test2" ).toInt(), 11 );
+  QCOMPARE( stack.variableNames().length(), 2 );
+}
+
+void TestQgsExpressionContext::evaluate()
+{
+  QgsExpression exp( "1 + 2" );
+  QCOMPARE( exp.evaluate().toInt(), 3 );
+
+  QgsStaticValueExpressionContext context;
+  context.setVariable( "test", 5 );
+  QCOMPARE( exp.evaluate( context ).toInt(), 3 );
+  QgsExpression expWithVariable( "var('test')" );
+  QCOMPARE( expWithVariable.evaluate( context ).toInt(), 5 );
+  context.setVariable( "test", 7 );
+  QCOMPARE( expWithVariable.evaluate( context ).toInt(), 7 );
+  QgsExpression expWithVariable2( "var('test') + var('test2')" );
+  context.setVariable( "test2", 9 );
+  QCOMPARE( expWithVariable2.evaluate( context ).toInt(), 16 );
+
+  QgsExpression expWithVariableBad( "var('bad')" );
+  QVERIFY( !expWithVariableBad.evaluate( context ).isValid() );
+
+  //test with a function provided by a context
+  QgsExpression testExpWContextFunction( "get_test_value(1)" );
+  QVERIFY( !testExpWContextFunction.evaluate( ).isValid() );
+
+  TestContext testContext( 0 );
+  testExpWContextFunction.prepare( testContext );
+  QCOMPARE( testExpWContextFunction.evaluate( testContext ).toInt(), 1 );
+  QCOMPARE( testExpWContextFunction.evaluate( testContext ).toInt(), 2 );
+
+  //test with another context to ensure that expressions are evaulated against correct context
+  TestContext testContext2( 5 );
+  QgsExpression testExpWContextFunction2( "get_test_value(1)" );
+  testExpWContextFunction2.prepare( testContext2 );
+  QCOMPARE( testExpWContextFunction2.evaluate( testContext2 ).toInt(), 6 );
+  QCOMPARE( testExpWContextFunction2.evaluate( testContext2 ).toInt(), 7 );
+  QCOMPARE( testExpWContextFunction2.evaluate( testContext ).toInt(), 3 );
+}
+
+void TestQgsExpressionContext::globalVariables()
+{
+  QgsGlobalExpressionContext* globalContext = new QgsGlobalExpressionContext();
+  globalContext->setVariable( "test", "testval" );
+  delete globalContext;
+
+  QgsGlobalExpressionContext* globalContext2 = new QgsGlobalExpressionContext();
+  QCOMPARE( globalContext2->variable( "test" ).toString(), QString( "testval" ) );
+
+  QgsExpression expGlobal( "var('test')" );
+  QCOMPARE( expGlobal.evaluate( *globalContext2 ).toString(), QString( "testval" ) );
+  delete globalContext2;
+}
+
+void TestQgsExpressionContext::projectVariables()
+{
+  QgsProjectExpressionContext* projectContext = new QgsProjectExpressionContext();
+  projectContext->setVariable( "test", "testval" );
+  projectContext->setVariable( "testdouble", 5.2 );
+  delete projectContext;
+
+  QgsProjectExpressionContext* projectContext2 = new QgsProjectExpressionContext();
+  QCOMPARE( projectContext2->variable( "test" ).toString(), QString( "testval" ) );
+  QCOMPARE( projectContext2->variable( "testdouble" ).toDouble(), 5.2 );
+
+  QgsExpression expProject( "var('test')" );
+  QCOMPARE( expProject.evaluate( *projectContext2 ).toString(), QString( "testval" ) );
+
+  //check that project expression context stack consists of both project and global variables
+  QgsGlobalExpressionContext* globalContext = QgsGlobalExpressionContext::instance();
+  globalContext->setVariable( "stackvar", "global" );
+  QCOMPARE( QgsProject::instance()->expressionContextStack()->variable( "stackvar" ).toString(), QString( "global" ) );
+  QgsProject::instance()->projectExpressionContext()->setVariable( "stackvar", "project" );
+  //'stackvar' variable should be overwritten with project expression context's value
+  QCOMPARE( QgsProject::instance()->expressionContextStack()->variable( "stackvar" ).toString(), QString( "project" ) );
+
+  //test clearing project variables
+  projectContext2->setVariable( "project_var", "val" );
+  projectContext2->clear();
+  QVERIFY( !projectContext2->hasVariable( "project_var" ) );
+
+  QgsProject::instance()->projectExpressionContext()->setVariable( "project_var", "val" );
+  QVERIFY( QgsProject::instance()->projectExpressionContext()->hasVariable( "project_var" ) );
+  QgsProject::instance()->clear();
+  QVERIFY( !QgsProject::instance()->projectExpressionContext()->hasVariable( "project_var" ) );
+}
+
+QTEST_MAIN( TestQgsExpressionContext )
+#include "testqgsexpressioncontext.moc"

--- a/tests/src/core/testqgsexpressioncontext.cpp
+++ b/tests/src/core/testqgsexpressioncontext.cpp
@@ -175,34 +175,34 @@ void TestQgsExpressionContext::evaluate()
 
   QgsStaticValueExpressionContext context;
   context.setVariable( "test", 5 );
-  QCOMPARE( exp.evaluate( context ).toInt(), 3 );
+  QCOMPARE( exp.evaluate( &context ).toInt(), 3 );
   QgsExpression expWithVariable( "var('test')" );
-  QCOMPARE( expWithVariable.evaluate( context ).toInt(), 5 );
+  QCOMPARE( expWithVariable.evaluate( &context ).toInt(), 5 );
   context.setVariable( "test", 7 );
-  QCOMPARE( expWithVariable.evaluate( context ).toInt(), 7 );
+  QCOMPARE( expWithVariable.evaluate( &context ).toInt(), 7 );
   QgsExpression expWithVariable2( "var('test') + var('test2')" );
   context.setVariable( "test2", 9 );
-  QCOMPARE( expWithVariable2.evaluate( context ).toInt(), 16 );
+  QCOMPARE( expWithVariable2.evaluate( &context ).toInt(), 16 );
 
   QgsExpression expWithVariableBad( "var('bad')" );
-  QVERIFY( !expWithVariableBad.evaluate( context ).isValid() );
+  QVERIFY( !expWithVariableBad.evaluate( &context ).isValid() );
 
   //test with a function provided by a context
   QgsExpression testExpWContextFunction( "get_test_value(1)" );
   QVERIFY( !testExpWContextFunction.evaluate( ).isValid() );
 
   TestContext testContext( 0 );
-  testExpWContextFunction.prepare( testContext );
-  QCOMPARE( testExpWContextFunction.evaluate( testContext ).toInt(), 1 );
-  QCOMPARE( testExpWContextFunction.evaluate( testContext ).toInt(), 2 );
+  testExpWContextFunction.prepare( &testContext );
+  QCOMPARE( testExpWContextFunction.evaluate( &testContext ).toInt(), 1 );
+  QCOMPARE( testExpWContextFunction.evaluate( &testContext ).toInt(), 2 );
 
   //test with another context to ensure that expressions are evaulated against correct context
   TestContext testContext2( 5 );
   QgsExpression testExpWContextFunction2( "get_test_value(1)" );
-  testExpWContextFunction2.prepare( testContext2 );
-  QCOMPARE( testExpWContextFunction2.evaluate( testContext2 ).toInt(), 6 );
-  QCOMPARE( testExpWContextFunction2.evaluate( testContext2 ).toInt(), 7 );
-  QCOMPARE( testExpWContextFunction2.evaluate( testContext ).toInt(), 3 );
+  testExpWContextFunction2.prepare( &testContext2 );
+  QCOMPARE( testExpWContextFunction2.evaluate( &testContext2 ).toInt(), 6 );
+  QCOMPARE( testExpWContextFunction2.evaluate( &testContext2 ).toInt(), 7 );
+  QCOMPARE( testExpWContextFunction2.evaluate( &testContext ).toInt(), 3 );
 }
 
 void TestQgsExpressionContext::globalVariables()
@@ -215,7 +215,7 @@ void TestQgsExpressionContext::globalVariables()
   QCOMPARE( globalContext2->variable( "test" ).toString(), QString( "testval" ) );
 
   QgsExpression expGlobal( "var('test')" );
-  QCOMPARE( expGlobal.evaluate( *globalContext2 ).toString(), QString( "testval" ) );
+  QCOMPARE( expGlobal.evaluate( globalContext2 ).toString(), QString( "testval" ) );
   delete globalContext2;
 }
 
@@ -231,7 +231,7 @@ void TestQgsExpressionContext::projectVariables()
   QCOMPARE( projectContext2->variable( "testdouble" ).toDouble(), 5.2 );
 
   QgsExpression expProject( "var('test')" );
-  QCOMPARE( expProject.evaluate( *projectContext2 ).toString(), QString( "testval" ) );
+  QCOMPARE( expProject.evaluate( projectContext2 ).toString(), QString( "testval" ) );
 
   //check that project expression context stack consists of both project and global variables
   QgsGlobalExpressionContext* globalContext = QgsGlobalExpressionContext::instance();


### PR DESCRIPTION
(Please don't merge -- for comment only!)

I'm seeking feedback on this initial implementation of contexts for evaluating expressions. With this change, expressions are no longer evaluated against just a QgsFeature. Now, they are evaluated against an QgsExpressionContext object, which can potentially contain much more information then just a feature. Eg, the QgsProjectExpressionContext has access to the project details such as filename and path, and QgsGlobalExpressionContext has access to information such as the QGIS version number. 

Contexts can be stacked using a QgsExpressionContextStack, where clashing variables provided by individual stack members are overwritten by contexts added later to the stack. For example, a stack could consist of the global context, extended by the project context, extended by a composer context, finally extended by a composer item context. This way, an expression inside a composer label could potentially access everything relevant to itself - global variables (eg qgis version), project variables (filename and path) and composer variables (number of pages, page size, composition name,...), and finally composer item variables (position on page, width, height, item id). 

Travis won't like this one bit (due to all the deprecated warnings), but I'll address those prior to a final merge. GUI and more contexts are still to come.

But for now, I'd appreciate feedback as to whether this implementation  is clean enough and future proof enough for our needs!
