### PR TITLE
Make QgsExpression::evaluate() and prepare() const

### DIFF
--- a/python/core/qgsexpression.sip
+++ b/python/core/qgsexpression.sip
@@ -17,7 +17,7 @@ class QgsExpression
     const QgsExpression::Node* rootNode() const;
 
     //! Get the expression ready for evaluation - find out column indexes.
-    bool prepare( const QgsFields &fields );
+    bool prepare( const QgsFields &fields ) const;
 
     /**Get list of columns referenced by the expression.
      * @note if the returned list contains the QgsFeatureRequest::AllAttributes constant then
@@ -33,21 +33,21 @@ class QgsExpression
 
     //! Evaluate the feature and return the result
     //! @note prepare() should be called before calling this method
-    QVariant evaluate( const QgsFeature* f = NULL );
+    QVariant evaluate( const QgsFeature* f = NULL ) const;
 
     //! Evaluate the feature and return the result
     //! @note prepare() should be called before calling this method
     //! @note available in python bindings as evaluatePrepared
-    QVariant evaluate( const QgsFeature& f ) /PyName=evaluatePrepared/;
+    QVariant evaluate( const QgsFeature& f ) const /PyName=evaluatePrepared/;
 
     //! Evaluate the feature and return the result
     //! @note this method does not expect that prepare() has been called on this instance
-    QVariant evaluate( const QgsFeature* f, const QgsFields& fields );
+    QVariant evaluate( const QgsFeature* f, const QgsFields& fields ) const;
 
     //! Evaluate the feature and return the result
     //! @note this method does not expect that prepare() has been called on this instance
     //! @note not available in python bindings
-    // inline QVariant evaluate( const QgsFeature& f, const QgsFields& fields ) { return evaluate( &f, fields ); }
+    // inline QVariant evaluate( const QgsFeature& f, const QgsFields& fields ) const { return evaluate( &f, fields ); }
 
     //! Returns true if an error occurred when evaluating last input
     bool hasEvalError() const;
@@ -183,7 +183,7 @@ class QgsExpression
         /** The help text for the function. */
         QString helptext();
 
-        virtual QVariant func( const QVariantList& values, const QgsFeature* f, QgsExpression* parent ) = 0;
+        virtual QVariant func( const QVariantList& values, const QgsFeature* f, const QgsExpression* parent ) = 0;
     };
 
 
@@ -237,11 +237,11 @@ class QgsExpression
         virtual QgsExpression::NodeType nodeType() const = 0;
         // abstract virtual eval function
         // errors are reported to the parent
-        virtual QVariant eval( QgsExpression* parent, const QgsFeature* f ) = 0;
+        virtual QVariant eval( const QgsExpression* parent, const QgsFeature* f ) const = 0;
 
         // abstract virtual preparation function
         // errors are reported to the parent
-        virtual bool prepare( QgsExpression* parent, const QgsFields &fields ) = 0;
+        virtual bool prepare( const QgsExpression* parent, const QgsFields &fields ) const = 0;
 
         virtual QString dump() const = 0;
 
@@ -296,8 +296,8 @@ class QgsExpression
         QgsExpression::Node* operand() const;
 
         virtual QgsExpression::NodeType nodeType() const;
-        virtual bool prepare( QgsExpression* parent, const QgsFields &fields );
-        virtual QVariant eval( QgsExpression* parent, const QgsFeature* f );
+        virtual bool prepare( const QgsExpression* parent, const QgsFields &fields ) const;
+        virtual QVariant eval( const QgsExpression* parent, const QgsFeature* f ) const;
         virtual QString dump() const;
 
         virtual QStringList referencedColumns() const;
@@ -316,8 +316,8 @@ class QgsExpression
         QgsExpression::Node* opRight() const;
 
         virtual QgsExpression::NodeType nodeType() const;
-        virtual bool prepare( QgsExpression* parent, const QgsFields &fields );
-        virtual QVariant eval( QgsExpression* parent, const QgsFeature* f );
+        virtual bool prepare( const QgsExpression* parent, const QgsFields &fields ) const;
+        virtual QVariant eval( const QgsExpression* parent, const QgsFeature* f ) const;
         virtual QString dump() const;
 
         virtual QStringList referencedColumns() const;
@@ -338,8 +338,8 @@ class QgsExpression
         QgsExpression::NodeList* list() const;
 
         virtual QgsExpression::NodeType nodeType() const;
-        virtual bool prepare( QgsExpression* parent, const QgsFields &fields );
-        virtual QVariant eval( QgsExpression* parent, const QgsFeature* f );
+        virtual bool prepare( const QgsExpression* parent, const QgsFields &fields ) const;
+        virtual QVariant eval( const QgsExpression* parent, const QgsFeature* f ) const;
         virtual QString dump() const;
 
         virtual QStringList referencedColumns() const;
@@ -358,8 +358,8 @@ class QgsExpression
         QgsExpression::NodeList* args() const;
 
         virtual QgsExpression::NodeType nodeType() const;
-        virtual bool prepare( QgsExpression* parent, const QgsFields &fields );
-        virtual QVariant eval( QgsExpression* parent, const QgsFeature* f );
+        virtual bool prepare( const QgsExpression* parent, const QgsFields &fields ) const;
+        virtual QVariant eval( const QgsExpression* parent, const QgsFeature* f ) const;
         virtual QString dump() const;
 
         virtual QStringList referencedColumns() const;
@@ -375,8 +375,8 @@ class QgsExpression
         QVariant value() const;
 
         virtual QgsExpression::NodeType nodeType() const;
-        virtual bool prepare( QgsExpression* parent, const QgsFields &fields );
-        virtual QVariant eval( QgsExpression* parent, const QgsFeature* f );
+        virtual bool prepare( const QgsExpression* parent, const QgsFields &fields ) const;
+        virtual QVariant eval( const QgsExpression* parent, const QgsFeature* f ) const;
         virtual QString dump() const;
 
         virtual QStringList referencedColumns() const;
@@ -392,8 +392,8 @@ class QgsExpression
         QString name() const;
 
         virtual QgsExpression::NodeType nodeType() const;
-        virtual bool prepare( QgsExpression* parent, const QgsFields &fields );
-        virtual QVariant eval( QgsExpression* parent, const QgsFeature* f );
+        virtual bool prepare( const QgsExpression* parent, const QgsFields &fields ) const;
+        virtual QVariant eval( const QgsExpression* parent, const QgsFeature* f ) const;
         virtual QString dump() const;
 
         virtual QStringList referencedColumns() const;
@@ -420,8 +420,8 @@ class QgsExpression
         ~NodeCondition();
 
         virtual QgsExpression::NodeType nodeType() const;
-        virtual QVariant eval( QgsExpression* parent, const QgsFeature* f );
-        virtual bool prepare( QgsExpression* parent, const QgsFields &fields );
+        virtual QVariant eval( const QgsExpression* parent, const QgsFeature* f ) const;
+        virtual bool prepare( const QgsExpression* parent, const QgsFields &fields ) const;
         virtual QString dump() const;
 
         virtual QStringList referencedColumns() const;

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -221,12 +221,12 @@ const char* QgsExpression::UnaryOperatorText[] =
 // functions
 
 // implicit conversion to string
-static QString getStringValue( const QVariant& value, QgsExpression* )
+static QString getStringValue( const QVariant& value, const QgsExpression* )
 {
   return value.toString();
 }
 
-static double getDoubleValue( const QVariant& value, QgsExpression* parent )
+static double getDoubleValue( const QVariant& value, const QgsExpression* parent )
 {
   bool ok;
   double x = value.toDouble( &ok );
@@ -238,7 +238,7 @@ static double getDoubleValue( const QVariant& value, QgsExpression* parent )
   return x;
 }
 
-static int getIntValue( const QVariant& value, QgsExpression* parent )
+static int getIntValue( const QVariant& value, const QgsExpression* parent )
 {
   bool ok;
   qint64 x = value.toLongLong( &ok );
@@ -253,7 +253,7 @@ static int getIntValue( const QVariant& value, QgsExpression* parent )
   }
 }
 
-static QDateTime getDateTimeValue( const QVariant& value, QgsExpression* parent )
+static QDateTime getDateTimeValue( const QVariant& value, const QgsExpression* parent )
 {
   QDateTime d = value.toDateTime();
   if ( d.isValid() )
@@ -267,7 +267,7 @@ static QDateTime getDateTimeValue( const QVariant& value, QgsExpression* parent 
   }
 }
 
-static QDate getDateValue( const QVariant& value, QgsExpression* parent )
+static QDate getDateValue( const QVariant& value, const QgsExpression* parent )
 {
   QDate d = value.toDate();
   if ( d.isValid() )
@@ -281,7 +281,7 @@ static QDate getDateValue( const QVariant& value, QgsExpression* parent )
   }
 }
 
-static QTime getTimeValue( const QVariant& value, QgsExpression* parent )
+static QTime getTimeValue( const QVariant& value, const QgsExpression* parent )
 {
   QTime t = value.toTime();
   if ( t.isValid() )
@@ -295,7 +295,7 @@ static QTime getTimeValue( const QVariant& value, QgsExpression* parent )
   }
 }
 
-static QgsExpression::Interval getInterval( const QVariant& value, QgsExpression* parent, bool report_error = false )
+static QgsExpression::Interval getInterval( const QVariant& value, const QgsExpression* parent, bool report_error = false )
 {
   if ( value.canConvert<QgsExpression::Interval>() )
     return value.value<QgsExpression::Interval>();
@@ -312,7 +312,7 @@ static QgsExpression::Interval getInterval( const QVariant& value, QgsExpression
   return QgsExpression::Interval::invalidInterVal();
 }
 
-static QgsGeometry getGeometry( const QVariant& value, QgsExpression* parent )
+static QgsGeometry getGeometry( const QVariant& value, const QgsExpression* parent )
 {
   if ( value.canConvert<QgsGeometry>() )
     return value.value<QgsGeometry>();
@@ -321,7 +321,7 @@ static QgsGeometry getGeometry( const QVariant& value, QgsExpression* parent )
   return QgsGeometry();
 }
 
-static QgsFeature getFeature( const QVariant& value, QgsExpression* parent )
+static QgsFeature getFeature( const QVariant& value, const QgsExpression* parent )
 {
   if ( value.canConvert<QgsFeature>() )
     return value.value<QgsFeature>();
@@ -331,7 +331,7 @@ static QgsFeature getFeature( const QVariant& value, QgsExpression* parent )
 }
 
 // this handles also NULL values
-static TVL getTVLValue( const QVariant& value, QgsExpression* parent )
+static TVL getTVLValue( const QVariant& value, const QgsExpression* parent )
 {
   // we need to convert to TVL
   if ( value.isNull() )
@@ -352,74 +352,74 @@ static TVL getTVLValue( const QVariant& value, QgsExpression* parent )
 
 //////
 
-static QVariant fcnSqrt( const QVariantList& values, const QgsFeature* /*f*/, QgsExpression* parent )
+static QVariant fcnSqrt( const QVariantList& values, const QgsFeature* /*f*/, const QgsExpression* parent )
 {
   double x = getDoubleValue( values.at( 0 ), parent );
   return QVariant( sqrt( x ) );
 }
 
-static QVariant fcnAbs( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnAbs( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   double val = getDoubleValue( values.at( 0 ), parent );
   return QVariant( fabs( val ) );
 }
 
-static QVariant fcnSin( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnSin( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   double x = getDoubleValue( values.at( 0 ), parent );
   return QVariant( sin( x ) );
 }
-static QVariant fcnCos( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnCos( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   double x = getDoubleValue( values.at( 0 ), parent );
   return QVariant( cos( x ) );
 }
-static QVariant fcnTan( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnTan( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   double x = getDoubleValue( values.at( 0 ), parent );
   return QVariant( tan( x ) );
 }
-static QVariant fcnAsin( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnAsin( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   double x = getDoubleValue( values.at( 0 ), parent );
   return QVariant( asin( x ) );
 }
-static QVariant fcnAcos( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnAcos( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   double x = getDoubleValue( values.at( 0 ), parent );
   return QVariant( acos( x ) );
 }
-static QVariant fcnAtan( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnAtan( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   double x = getDoubleValue( values.at( 0 ), parent );
   return QVariant( atan( x ) );
 }
-static QVariant fcnAtan2( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnAtan2( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   double y = getDoubleValue( values.at( 0 ), parent );
   double x = getDoubleValue( values.at( 1 ), parent );
   return QVariant( atan2( y, x ) );
 }
-static QVariant fcnExp( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnExp( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   double x = getDoubleValue( values.at( 0 ), parent );
   return QVariant( exp( x ) );
 }
-static QVariant fcnLn( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnLn( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   double x = getDoubleValue( values.at( 0 ), parent );
   if ( x <= 0 )
     return QVariant();
   return QVariant( log( x ) );
 }
-static QVariant fcnLog10( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnLog10( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   double x = getDoubleValue( values.at( 0 ), parent );
   if ( x <= 0 )
     return QVariant();
   return QVariant( log10( x ) );
 }
-static QVariant fcnLog( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnLog( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   double b = getDoubleValue( values.at( 0 ), parent );
   double x = getDoubleValue( values.at( 1 ), parent );
@@ -427,7 +427,7 @@ static QVariant fcnLog( const QVariantList& values, const QgsFeature*, QgsExpres
     return QVariant();
   return QVariant( log( x ) / log( b ) );
 }
-static QVariant fcnRndF( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnRndF( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   double min = getDoubleValue( values.at( 0 ), parent );
   double max = getDoubleValue( values.at( 1 ), parent );
@@ -438,7 +438,7 @@ static QVariant fcnRndF( const QVariantList& values, const QgsFeature*, QgsExpre
   double f = ( double )rand() / RAND_MAX;
   return QVariant( min + f * ( max - min ) );
 }
-static QVariant fcnRnd( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnRnd( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   int min = getIntValue( values.at( 0 ), parent );
   int max = getIntValue( values.at( 1 ), parent );
@@ -449,7 +449,7 @@ static QVariant fcnRnd( const QVariantList& values, const QgsFeature*, QgsExpres
   return QVariant( min + ( rand() % ( int )( max - min + 1 ) ) );
 }
 
-static QVariant fcnLinearScale( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnLinearScale( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   double val = getDoubleValue( values.at( 0 ), parent );
   double domainMin = getDoubleValue( values.at( 1 ), parent );
@@ -481,7 +481,7 @@ static QVariant fcnLinearScale( const QVariantList& values, const QgsFeature*, Q
   return QVariant( m * val + c );
 }
 
-static QVariant fcnExpScale( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnExpScale( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   double val = getDoubleValue( values.at( 0 ), parent );
   double domainMin = getDoubleValue( values.at( 1 ), parent );
@@ -515,7 +515,7 @@ static QVariant fcnExpScale( const QVariantList& values, const QgsFeature*, QgsE
   return QVariant((( rangeMax - rangeMin ) / pow( domainMax - domainMin, exponent ) ) * pow( val - domainMin, exponent ) + rangeMin );
 }
 
-static QVariant fcnMax( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnMax( const QVariantList& values, const QgsFeature*, const QgsExpression *parent )
 {
   //initially set max as first value
   double maxVal = getDoubleValue( values.at( 0 ), parent );
@@ -533,7 +533,7 @@ static QVariant fcnMax( const QVariantList& values, const QgsFeature*, QgsExpres
   return QVariant( maxVal );
 }
 
-static QVariant fcnMin( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnMin( const QVariantList& values, const QgsFeature*, const QgsExpression *parent )
 {
   //initially set min as first value
   double minVal = getDoubleValue( values.at( 0 ), parent );
@@ -551,7 +551,7 @@ static QVariant fcnMin( const QVariantList& values, const QgsFeature*, QgsExpres
   return QVariant( minVal );
 }
 
-static QVariant fcnClamp( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnClamp( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   double minValue = getDoubleValue( values.at( 0 ), parent );
   double testValue = getDoubleValue( values.at( 1 ), parent );
@@ -572,37 +572,37 @@ static QVariant fcnClamp( const QVariantList& values, const QgsFeature*, QgsExpr
   }
 }
 
-static QVariant fcnFloor( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnFloor( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   double x = getDoubleValue( values.at( 0 ), parent );
   return QVariant( floor( x ) );
 }
 
-static QVariant fcnCeil( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnCeil( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   double x = getDoubleValue( values.at( 0 ), parent );
   return QVariant( ceil( x ) );
 }
 
-static QVariant fcnToInt( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnToInt( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   return QVariant( getIntValue( values.at( 0 ), parent ) );
 }
-static QVariant fcnToReal( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnToReal( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   return QVariant( getDoubleValue( values.at( 0 ), parent ) );
 }
-static QVariant fcnToString( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnToString( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   return QVariant( getStringValue( values.at( 0 ), parent ) );
 }
 
-static QVariant fcnToDateTime( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnToDateTime( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   return QVariant( getDateTimeValue( values.at( 0 ), parent ) );
 }
 
-static QVariant fcnCoalesce( const QVariantList& values, const QgsFeature*, QgsExpression* )
+static QVariant fcnCoalesce( const QVariantList& values, const QgsFeature*, const QgsExpression* )
 {
   foreach ( const QVariant &value, values )
   {
@@ -612,17 +612,17 @@ static QVariant fcnCoalesce( const QVariantList& values, const QgsFeature*, QgsE
   }
   return QVariant();
 }
-static QVariant fcnLower( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnLower( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QString str = getStringValue( values.at( 0 ), parent );
   return QVariant( str.toLower() );
 }
-static QVariant fcnUpper( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnUpper( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QString str = getStringValue( values.at( 0 ), parent );
   return QVariant( str.toUpper() );
 }
-static QVariant fcnTitle( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnTitle( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QString str = getStringValue( values.at( 0 ), parent );
   QStringList elems = str.split( " " );
@@ -634,13 +634,13 @@ static QVariant fcnTitle( const QVariantList& values, const QgsFeature*, QgsExpr
   return QVariant( elems.join( " " ) );
 }
 
-static QVariant fcnTrim( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnTrim( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QString str = getStringValue( values.at( 0 ), parent );
   return QVariant( str.trimmed() );
 }
 
-static QVariant fcnWordwrap( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnWordwrap( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   if ( values.length() == 2 || values.length() == 3 )
   {
@@ -706,19 +706,19 @@ static QVariant fcnWordwrap( const QVariantList& values, const QgsFeature*, QgsE
   return QVariant();
 }
 
-static QVariant fcnLength( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnLength( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QString str = getStringValue( values.at( 0 ), parent );
   return QVariant( str.length() );
 }
-static QVariant fcnReplace( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnReplace( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QString str = getStringValue( values.at( 0 ), parent );
   QString before = getStringValue( values.at( 1 ), parent );
   QString after = getStringValue( values.at( 2 ), parent );
   return QVariant( str.replace( before, after ) );
 }
-static QVariant fcnRegexpReplace( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnRegexpReplace( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QString str = getStringValue( values.at( 0 ), parent );
   QString regexp = getStringValue( values.at( 1 ), parent );
@@ -733,7 +733,7 @@ static QVariant fcnRegexpReplace( const QVariantList& values, const QgsFeature*,
   return QVariant( str.replace( re, after ) );
 }
 
-static QVariant fcnRegexpMatch( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnRegexpMatch( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QString str = getStringValue( values.at( 0 ), parent );
   QString regexp = getStringValue( values.at( 1 ), parent );
@@ -747,7 +747,7 @@ static QVariant fcnRegexpMatch( const QVariantList& values, const QgsFeature*, Q
   return QVariant( str.contains( re ) ? 1 : 0 );
 }
 
-static QVariant fcnRegexpSubstr( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnRegexpSubstr( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QString str = getStringValue( values.at( 0 ), parent );
   QString regexp = getStringValue( values.at( 1 ), parent );
@@ -772,12 +772,12 @@ static QVariant fcnRegexpSubstr( const QVariantList& values, const QgsFeature*, 
   }
 }
 
-static QVariant fcnUuid( const QVariantList&, const QgsFeature*, QgsExpression* )
+static QVariant fcnUuid( const QVariantList&, const QgsFeature*, const QgsExpression* )
 {
   return QUuid::createUuid().toString();
 }
 
-static QVariant fcnSubstr( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnSubstr( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QString str = getStringValue( values.at( 0 ), parent );
   int from = getIntValue( values.at( 1 ), parent );
@@ -785,29 +785,29 @@ static QVariant fcnSubstr( const QVariantList& values, const QgsFeature*, QgsExp
   return QVariant( str.mid( from -1, len ) );
 }
 
-static QVariant fcnRowNumber( const QVariantList&, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnRowNumber( const QVariantList&, const QgsFeature*, const QgsExpression* parent )
 {
   return QVariant( parent->currentRowNumber() );
 }
 
-static QVariant fcnFeatureId( const QVariantList&, const QgsFeature* f, QgsExpression* )
+static QVariant fcnFeatureId( const QVariantList&, const QgsFeature* f, const QgsExpression* )
 {
   // TODO: handling of 64-bit feature ids?
   return f ? QVariant(( int )f->id() ) : QVariant();
 }
 
-static QVariant fcnFeature( const QVariantList&, const QgsFeature* f, QgsExpression* )
+static QVariant fcnFeature( const QVariantList&, const QgsFeature* f, const QgsExpression* )
 {
   return f ? QVariant::fromValue( *f ) : QVariant();
 }
-static QVariant fcnAttribute( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnAttribute( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QgsFeature feat = getFeature( values.at( 0 ), parent );
   QString attr = getStringValue( values.at( 1 ), parent );
 
   return feat.attribute( attr );
 }
-static QVariant fcnConcat( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnConcat( const QVariantList& values, const QgsFeature*, const QgsExpression *parent )
 {
   QString concat;
   foreach ( const QVariant &value, values )
@@ -817,27 +817,27 @@ static QVariant fcnConcat( const QVariantList& values, const QgsFeature*, QgsExp
   return concat;
 }
 
-static QVariant fcnStrpos( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnStrpos( const QVariantList& values, const QgsFeature*, const QgsExpression *parent )
 {
   QString string = getStringValue( values.at( 0 ), parent );
   return string.indexOf( QRegExp( getStringValue( values.at( 1 ), parent ) ) );
 }
 
-static QVariant fcnRight( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnRight( const QVariantList& values, const QgsFeature*, const QgsExpression *parent )
 {
   QString string = getStringValue( values.at( 0 ), parent );
   int pos = getIntValue( values.at( 1 ), parent );
   return string.right( pos );
 }
 
-static QVariant fcnLeft( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnLeft( const QVariantList& values, const QgsFeature*, const QgsExpression *parent )
 {
   QString string = getStringValue( values.at( 0 ), parent );
   int pos = getIntValue( values.at( 1 ), parent );
   return string.left( pos );
 }
 
-static QVariant fcnRPad( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnRPad( const QVariantList& values, const QgsFeature*, const QgsExpression *parent )
 {
   QString string = getStringValue( values.at( 0 ), parent );
   int length = getIntValue( values.at( 1 ), parent );
@@ -845,7 +845,7 @@ static QVariant fcnRPad( const QVariantList& values, const QgsFeature*, QgsExpre
   return string.leftJustified( length, fill.at( 0 ), true );
 }
 
-static QVariant fcnLPad( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnLPad( const QVariantList& values, const QgsFeature*, const QgsExpression *parent )
 {
   QString string = getStringValue( values.at( 0 ), parent );
   int length = getIntValue( values.at( 1 ), parent );
@@ -853,7 +853,7 @@ static QVariant fcnLPad( const QVariantList& values, const QgsFeature*, QgsExpre
   return string.rightJustified( length, fill.at( 0 ), true );
 }
 
-static QVariant fcnFormatString( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnFormatString( const QVariantList& values, const QgsFeature*, const QgsExpression *parent )
 {
   QString string = getStringValue( values.at( 0 ), parent );
   for ( int n = 1; n < values.length(); n++ )
@@ -864,27 +864,27 @@ static QVariant fcnFormatString( const QVariantList& values, const QgsFeature*, 
 }
 
 
-static QVariant fcnNow( const QVariantList&, const QgsFeature*, QgsExpression * )
+static QVariant fcnNow( const QVariantList&, const QgsFeature*, const QgsExpression * )
 {
   return QVariant( QDateTime::currentDateTime() );
 }
 
-static QVariant fcnToDate( const QVariantList& values, const QgsFeature*, QgsExpression * parent )
+static QVariant fcnToDate( const QVariantList& values, const QgsFeature*, const QgsExpression * parent )
 {
   return QVariant( getDateValue( values.at( 0 ), parent ) );
 }
 
-static QVariant fcnToTime( const QVariantList& values, const QgsFeature*, QgsExpression * parent )
+static QVariant fcnToTime( const QVariantList& values, const QgsFeature*, const QgsExpression * parent )
 {
   return QVariant( getTimeValue( values.at( 0 ), parent ) );
 }
 
-static QVariant fcnToInterval( const QVariantList& values, const QgsFeature*, QgsExpression * parent )
+static QVariant fcnToInterval( const QVariantList& values, const QgsFeature*, const QgsExpression * parent )
 {
   return QVariant::fromValue( getInterval( values.at( 0 ), parent ) );
 }
 
-static QVariant fcnAge( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnAge( const QVariantList& values, const QgsFeature*, const QgsExpression *parent )
 {
   QDateTime d1 = getDateTimeValue( values.at( 0 ), parent );
   QDateTime d2 = getDateTimeValue( values.at( 1 ), parent );
@@ -892,7 +892,7 @@ static QVariant fcnAge( const QVariantList& values, const QgsFeature*, QgsExpres
   return QVariant::fromValue( QgsExpression::Interval( seconds ) );
 }
 
-static QVariant fcnDay( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnDay( const QVariantList& values, const QgsFeature*, const QgsExpression *parent )
 {
   QVariant value = values.at( 0 );
   QgsExpression::Interval inter = getInterval( value, parent, false );
@@ -907,7 +907,7 @@ static QVariant fcnDay( const QVariantList& values, const QgsFeature*, QgsExpres
   }
 }
 
-static QVariant fcnYear( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnYear( const QVariantList& values, const QgsFeature*, const QgsExpression *parent )
 {
   QVariant value = values.at( 0 );
   QgsExpression::Interval inter = getInterval( value, parent, false );
@@ -922,7 +922,7 @@ static QVariant fcnYear( const QVariantList& values, const QgsFeature*, QgsExpre
   }
 }
 
-static QVariant fcnMonth( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnMonth( const QVariantList& values, const QgsFeature*, const QgsExpression *parent )
 {
   QVariant value = values.at( 0 );
   QgsExpression::Interval inter = getInterval( value, parent, false );
@@ -937,7 +937,7 @@ static QVariant fcnMonth( const QVariantList& values, const QgsFeature*, QgsExpr
   }
 }
 
-static QVariant fcnWeek( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnWeek( const QVariantList& values, const QgsFeature*, const QgsExpression *parent )
 {
   QVariant value = values.at( 0 );
   QgsExpression::Interval inter = getInterval( value, parent, false );
@@ -952,7 +952,7 @@ static QVariant fcnWeek( const QVariantList& values, const QgsFeature*, QgsExpre
   }
 }
 
-static QVariant fcnHour( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnHour( const QVariantList& values, const QgsFeature*, const QgsExpression *parent )
 {
   QVariant value = values.at( 0 );
   QgsExpression::Interval inter = getInterval( value, parent, false );
@@ -967,7 +967,7 @@ static QVariant fcnHour( const QVariantList& values, const QgsFeature*, QgsExpre
   }
 }
 
-static QVariant fcnMinute( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnMinute( const QVariantList& values, const QgsFeature*, const QgsExpression *parent )
 {
   QVariant value = values.at( 0 );
   QgsExpression::Interval inter = getInterval( value, parent, false );
@@ -982,7 +982,7 @@ static QVariant fcnMinute( const QVariantList& values, const QgsFeature*, QgsExp
   }
 }
 
-static QVariant fcnSeconds( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnSeconds( const QVariantList& values, const QgsFeature*, const QgsExpression *parent )
 {
   QVariant value = values.at( 0 );
   QgsExpression::Interval inter = getInterval( value, parent, false );
@@ -1003,7 +1003,7 @@ static QVariant fcnSeconds( const QVariantList& values, const QgsFeature*, QgsEx
   if (!g || g->type() != geomtype) return QVariant();
 
 
-static QVariant fcnX( const QVariantList&, const QgsFeature* f, QgsExpression* )
+static QVariant fcnX( const QVariantList&, const QgsFeature* f, const QgsExpression* )
 {
   ENSURE_GEOM_TYPE( f, g, QGis::Point );
   if ( g->isMultipart() )
@@ -1015,7 +1015,7 @@ static QVariant fcnX( const QVariantList&, const QgsFeature* f, QgsExpression* )
     return g->asPoint().x();
   }
 }
-static QVariant fcnY( const QVariantList&, const QgsFeature* f, QgsExpression* )
+static QVariant fcnY( const QVariantList&, const QgsFeature* f, const QgsExpression* )
 {
   ENSURE_GEOM_TYPE( f, g, QGis::Point );
   if ( g->isMultipart() )
@@ -1028,7 +1028,7 @@ static QVariant fcnY( const QVariantList&, const QgsFeature* f, QgsExpression* )
   }
 }
 
-static QVariant pointAt( const QVariantList& values, const QgsFeature* f, QgsExpression* parent ) // helper function
+static QVariant pointAt( const QVariantList& values, const QgsFeature* f, const QgsExpression* parent ) // helper function
 {
   int idx = getIntValue( values.at( 0 ), parent );
   ENSURE_GEOM_TYPE( f, g, QGis::Line );
@@ -1044,7 +1044,7 @@ static QVariant pointAt( const QVariantList& values, const QgsFeature* f, QgsExp
   return QVariant( QPointF( polyline[idx].x(), polyline[idx].y() ) );
 }
 
-static QVariant fcnXat( const QVariantList& values, const QgsFeature* f, QgsExpression* parent )
+static QVariant fcnXat( const QVariantList& values, const QgsFeature* f, const QgsExpression* parent )
 {
   QVariant v = pointAt( values, f, parent );
   if ( v.type() == QVariant::PointF )
@@ -1052,7 +1052,7 @@ static QVariant fcnXat( const QVariantList& values, const QgsFeature* f, QgsExpr
   else
     return QVariant();
 }
-static QVariant fcnYat( const QVariantList& values, const QgsFeature* f, QgsExpression* parent )
+static QVariant fcnYat( const QVariantList& values, const QgsFeature* f, const QgsExpression* parent )
 {
   QVariant v = pointAt( values, f, parent );
   if ( v.type() == QVariant::PointF )
@@ -1060,7 +1060,7 @@ static QVariant fcnYat( const QVariantList& values, const QgsFeature* f, QgsExpr
   else
     return QVariant();
 }
-static QVariant fcnGeometry( const QVariantList&, const QgsFeature* f, QgsExpression* )
+static QVariant fcnGeometry( const QVariantList&, const QgsFeature* f, const QgsExpression* )
 {
   QgsGeometry* geom = f ? f->geometry() : 0;
   if ( geom )
@@ -1068,7 +1068,7 @@ static QVariant fcnGeometry( const QVariantList&, const QgsFeature* f, QgsExpres
   else
     return QVariant();
 }
-static QVariant fcnGeomFromWKT( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnGeomFromWKT( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QString wkt = getStringValue( values.at( 0 ), parent );
   QgsGeometry* geom = QgsGeometry::fromWkt( wkt );
@@ -1077,7 +1077,7 @@ static QVariant fcnGeomFromWKT( const QVariantList& values, const QgsFeature*, Q
   else
     return QVariant();
 }
-static QVariant fcnGeomFromGML( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnGeomFromGML( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QString gml = getStringValue( values.at( 0 ), parent );
   QgsGeometry* geom = QgsOgcUtils::geometryFromGML( gml );
@@ -1088,26 +1088,26 @@ static QVariant fcnGeomFromGML( const QVariantList& values, const QgsFeature*, Q
     return QVariant();
 }
 
-static QVariant fcnGeomArea( const QVariantList&, const QgsFeature* f, QgsExpression* parent )
+static QVariant fcnGeomArea( const QVariantList&, const QgsFeature* f, const QgsExpression* parent )
 {
   ENSURE_GEOM_TYPE( f, g, QGis::Polygon );
   QgsDistanceArea* calc = parent->geomCalculator();
   return QVariant( calc->measure( f->geometry() ) );
 }
-static QVariant fcnGeomLength( const QVariantList&, const QgsFeature* f, QgsExpression* parent )
+static QVariant fcnGeomLength( const QVariantList&, const QgsFeature* f, const QgsExpression* parent )
 {
   ENSURE_GEOM_TYPE( f, g, QGis::Line );
   QgsDistanceArea* calc = parent->geomCalculator();
   return QVariant( calc->measure( f->geometry() ) );
 }
-static QVariant fcnGeomPerimeter( const QVariantList&, const QgsFeature* f, QgsExpression* parent )
+static QVariant fcnGeomPerimeter( const QVariantList&, const QgsFeature* f, const QgsExpression* parent )
 {
   ENSURE_GEOM_TYPE( f, g, QGis::Polygon );
   QgsDistanceArea* calc = parent->geomCalculator();
   return QVariant( calc->measurePerimeter( f->geometry() ) );
 }
 
-static QVariant fcnBounds( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnBounds( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QgsGeometry geom = getGeometry( values.at( 0 ), parent );
   QgsGeometry* geomBounds = QgsGeometry::fromRect( geom.boundingBox() );
@@ -1121,91 +1121,91 @@ static QVariant fcnBounds( const QVariantList& values, const QgsFeature*, QgsExp
   }
 }
 
-static QVariant fcnBoundsWidth( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnBoundsWidth( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QgsGeometry geom = getGeometry( values.at( 0 ), parent );
   return QVariant::fromValue( geom.boundingBox().width() );
 }
 
-static QVariant fcnBoundsHeight( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnBoundsHeight( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QgsGeometry geom = getGeometry( values.at( 0 ), parent );
   return QVariant::fromValue( geom.boundingBox().height() );
 }
 
-static QVariant fcnXMin( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnXMin( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QgsGeometry geom = getGeometry( values.at( 0 ), parent );
   return QVariant::fromValue( geom.boundingBox().xMinimum() );
 }
 
-static QVariant fcnXMax( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnXMax( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QgsGeometry geom = getGeometry( values.at( 0 ), parent );
   return QVariant::fromValue( geom.boundingBox().xMaximum() );
 }
 
-static QVariant fcnYMin( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnYMin( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QgsGeometry geom = getGeometry( values.at( 0 ), parent );
   return QVariant::fromValue( geom.boundingBox().yMinimum() );
 }
 
-static QVariant fcnYMax( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnYMax( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QgsGeometry geom = getGeometry( values.at( 0 ), parent );
   return QVariant::fromValue( geom.boundingBox().yMaximum() );
 }
 
-static QVariant fcnBbox( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnBbox( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = getGeometry( values.at( 1 ), parent );
   return fGeom.intersects( sGeom.boundingBox() ) ? TVL_True : TVL_False;
 }
-static QVariant fcnDisjoint( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnDisjoint( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = getGeometry( values.at( 1 ), parent );
   return fGeom.disjoint( &sGeom ) ? TVL_True : TVL_False;
 }
-static QVariant fcnIntersects( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnIntersects( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = getGeometry( values.at( 1 ), parent );
   return fGeom.intersects( &sGeom ) ? TVL_True : TVL_False;
 }
-static QVariant fcnTouches( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnTouches( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = getGeometry( values.at( 1 ), parent );
   return fGeom.touches( &sGeom ) ? TVL_True : TVL_False;
 }
-static QVariant fcnCrosses( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnCrosses( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = getGeometry( values.at( 1 ), parent );
   return fGeom.crosses( &sGeom ) ? TVL_True : TVL_False;
 }
-static QVariant fcnContains( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnContains( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = getGeometry( values.at( 1 ), parent );
   return fGeom.contains( &sGeom ) ? TVL_True : TVL_False;
 }
-static QVariant fcnOverlaps( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnOverlaps( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = getGeometry( values.at( 1 ), parent );
   return fGeom.overlaps( &sGeom ) ? TVL_True : TVL_False;
 }
-static QVariant fcnWithin( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnWithin( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = getGeometry( values.at( 1 ), parent );
   return fGeom.within( &sGeom ) ? TVL_True : TVL_False;
 }
-static QVariant fcnBuffer( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnBuffer( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   if ( values.length() < 2 || values.length() > 3 )
     return QVariant();
@@ -1221,7 +1221,7 @@ static QVariant fcnBuffer( const QVariantList& values, const QgsFeature*, QgsExp
     return QVariant::fromValue( *geom );
   return QVariant();
 }
-static QVariant fcnCentroid( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnCentroid( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
   QgsGeometry* geom = fGeom.centroid();
@@ -1229,7 +1229,7 @@ static QVariant fcnCentroid( const QVariantList& values, const QgsFeature*, QgsE
     return QVariant::fromValue( *geom );
   return QVariant();
 }
-static QVariant fcnConvexHull( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnConvexHull( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
   QgsGeometry* geom = fGeom.convexHull();
@@ -1237,7 +1237,7 @@ static QVariant fcnConvexHull( const QVariantList& values, const QgsFeature*, Qg
     return QVariant::fromValue( *geom );
   return QVariant();
 }
-static QVariant fcnDifference( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnDifference( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = getGeometry( values.at( 1 ), parent );
@@ -1246,13 +1246,13 @@ static QVariant fcnDifference( const QVariantList& values, const QgsFeature*, Qg
     return QVariant::fromValue( *geom );
   return QVariant();
 }
-static QVariant fcnDistance( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnDistance( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = getGeometry( values.at( 1 ), parent );
   return QVariant( fGeom.distance( sGeom ) );
 }
-static QVariant fcnIntersection( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnIntersection( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = getGeometry( values.at( 1 ), parent );
@@ -1261,7 +1261,7 @@ static QVariant fcnIntersection( const QVariantList& values, const QgsFeature*, 
     return QVariant::fromValue( *geom );
   return QVariant();
 }
-static QVariant fcnSymDifference( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnSymDifference( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = getGeometry( values.at( 1 ), parent );
@@ -1270,7 +1270,7 @@ static QVariant fcnSymDifference( const QVariantList& values, const QgsFeature*,
     return QVariant::fromValue( *geom );
   return QVariant();
 }
-static QVariant fcnCombine( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnCombine( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = getGeometry( values.at( 1 ), parent );
@@ -1279,14 +1279,14 @@ static QVariant fcnCombine( const QVariantList& values, const QgsFeature*, QgsEx
     return QVariant::fromValue( *geom );
   return QVariant();
 }
-static QVariant fcnGeomToWKT( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnGeomToWKT( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
   QString wkt = fGeom.exportToWkt();
   return QVariant( wkt );
 }
 
-static QVariant fcnRound( const QVariantList& values, const QgsFeature *f, QgsExpression* parent )
+static QVariant fcnRound( const QVariantList& values, const QgsFeature *f, const QgsExpression* parent )
 {
   Q_UNUSED( f );
   if ( values.length() == 2 )
@@ -1305,7 +1305,7 @@ static QVariant fcnRound( const QVariantList& values, const QgsFeature *f, QgsEx
   return QVariant();
 }
 
-static QVariant fcnPi( const QVariantList& values, const QgsFeature *f, QgsExpression* parent )
+static QVariant fcnPi( const QVariantList& values, const QgsFeature *f, const QgsExpression* parent )
 {
   Q_UNUSED( values );
   Q_UNUSED( f );
@@ -1313,26 +1313,26 @@ static QVariant fcnPi( const QVariantList& values, const QgsFeature *f, QgsExpre
   return M_PI;
 }
 
-static QVariant fcnScale( const QVariantList&, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnScale( const QVariantList&, const QgsFeature*, const QgsExpression* parent )
 {
   return QVariant( parent->scale() );
 }
 
-static QVariant fcnFormatNumber( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnFormatNumber( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   double value = getDoubleValue( values.at( 0 ), parent );
   int places = getIntValue( values.at( 1 ), parent );
   return QString( "%L1" ).arg( value, 0, 'f', places );
 }
 
-static QVariant fcnFormatDate( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnFormatDate( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QDateTime dt = getDateTimeValue( values.at( 0 ), parent );
   QString format = getStringValue( values.at( 1 ), parent );
   return dt.toString( format );
 }
 
-static QVariant fcnColorRgb( const QVariantList &values, const QgsFeature *, QgsExpression *parent )
+static QVariant fcnColorRgb( const QVariantList &values, const QgsFeature *, const QgsExpression *parent )
 {
   int red = getIntValue( values.at( 0 ), parent );
   int green = getIntValue( values.at( 1 ), parent );
@@ -1347,7 +1347,7 @@ static QVariant fcnColorRgb( const QVariantList &values, const QgsFeature *, Qgs
   return QString( "%1,%2,%3" ).arg( color.red() ).arg( color.green() ).arg( color.blue() );
 }
 
-static QVariant fncColorRgba( const QVariantList &values, const QgsFeature *, QgsExpression *parent )
+static QVariant fncColorRgba( const QVariantList &values, const QgsFeature *, const QgsExpression *parent )
 {
   int red = getIntValue( values.at( 0 ), parent );
   int green = getIntValue( values.at( 1 ), parent );
@@ -1362,7 +1362,7 @@ static QVariant fncColorRgba( const QVariantList &values, const QgsFeature *, Qg
   return QgsSymbolLayerV2Utils::encodeColor( color );
 }
 
-QVariant fcnRampColor( const QVariantList &values, const QgsFeature *, QgsExpression *parent )
+QVariant fcnRampColor( const QVariantList &values, const QgsFeature *, const QgsExpression *parent )
 {
   QString rampName = getStringValue( values.at( 0 ), parent );
   const QgsVectorColorRampV2 *mRamp = QgsStyleV2::defaultStyle()->colorRampRef( rampName );
@@ -1376,7 +1376,7 @@ QVariant fcnRampColor( const QVariantList &values, const QgsFeature *, QgsExpres
   return QgsSymbolLayerV2Utils::encodeColor( color );
 }
 
-static QVariant fcnColorHsl( const QVariantList &values, const QgsFeature *, QgsExpression *parent )
+static QVariant fcnColorHsl( const QVariantList &values, const QgsFeature *, const QgsExpression *parent )
 {
   // Hue ranges from 0 - 360
   double hue = getIntValue( values.at( 0 ), parent ) / 360.0;
@@ -1396,7 +1396,7 @@ static QVariant fcnColorHsl( const QVariantList &values, const QgsFeature *, Qgs
   return QString( "%1,%2,%3" ).arg( color.red() ).arg( color.green() ).arg( color.blue() );
 }
 
-static QVariant fncColorHsla( const QVariantList &values, const QgsFeature *, QgsExpression *parent )
+static QVariant fncColorHsla( const QVariantList &values, const QgsFeature *, const QgsExpression *parent )
 {
   // Hue ranges from 0 - 360
   double hue = getIntValue( values.at( 0 ), parent ) / 360.0;
@@ -1416,7 +1416,7 @@ static QVariant fncColorHsla( const QVariantList &values, const QgsFeature *, Qg
   return QgsSymbolLayerV2Utils::encodeColor( color );
 }
 
-static QVariant fcnColorHsv( const QVariantList &values, const QgsFeature *, QgsExpression *parent )
+static QVariant fcnColorHsv( const QVariantList &values, const QgsFeature *, const QgsExpression *parent )
 {
   // Hue ranges from 0 - 360
   double hue = getIntValue( values.at( 0 ), parent ) / 360.0;
@@ -1436,7 +1436,7 @@ static QVariant fcnColorHsv( const QVariantList &values, const QgsFeature *, Qgs
   return QString( "%1,%2,%3" ).arg( color.red() ).arg( color.green() ).arg( color.blue() );
 }
 
-static QVariant fncColorHsva( const QVariantList &values, const QgsFeature *, QgsExpression *parent )
+static QVariant fncColorHsva( const QVariantList &values, const QgsFeature *, const QgsExpression *parent )
 {
   // Hue ranges from 0 - 360
   double hue = getIntValue( values.at( 0 ), parent ) / 360.0;
@@ -1456,7 +1456,7 @@ static QVariant fncColorHsva( const QVariantList &values, const QgsFeature *, Qg
   return QgsSymbolLayerV2Utils::encodeColor( color );
 }
 
-static QVariant fcnColorCmyk( const QVariantList &values, const QgsFeature *, QgsExpression *parent )
+static QVariant fcnColorCmyk( const QVariantList &values, const QgsFeature *, const QgsExpression *parent )
 {
   // Cyan ranges from 0 - 100
   double cyan = getIntValue( values.at( 0 ), parent ) / 100.0;
@@ -1478,7 +1478,7 @@ static QVariant fcnColorCmyk( const QVariantList &values, const QgsFeature *, Qg
   return QString( "%1,%2,%3" ).arg( color.red() ).arg( color.green() ).arg( color.blue() );
 }
 
-static QVariant fncColorCmyka( const QVariantList &values, const QgsFeature *, QgsExpression *parent )
+static QVariant fncColorCmyka( const QVariantList &values, const QgsFeature *, const QgsExpression *parent )
 {
   // Cyan ranges from 0 - 100
   double cyan = getIntValue( values.at( 0 ), parent ) / 100.0;
@@ -1500,13 +1500,13 @@ static QVariant fncColorCmyka( const QVariantList &values, const QgsFeature *, Q
   return QgsSymbolLayerV2Utils::encodeColor( color );
 }
 
-static QVariant fcnSpecialColumn( const QVariantList& values, const QgsFeature* /*f*/, QgsExpression* parent )
+static QVariant fcnSpecialColumn( const QVariantList& values, const QgsFeature* /*f*/, const QgsExpression* parent )
 {
   QString varName = getStringValue( values.at( 0 ), parent );
   return QgsExpression::specialColumn( varName );
 }
 
-static QVariant fcnGetFeature( const QVariantList& values, const QgsFeature *, QgsExpression* parent )
+static QVariant fcnGetFeature( const QVariantList& values, const QgsFeature *, const QgsExpression* parent )
 {
   //arguments: 1. layer id / name, 2. key attribute, 3. eq value
   QString layerString = getStringValue( values.at( 0 ), parent );
@@ -1915,14 +1915,14 @@ QStringList QgsExpression::referencedColumns()
   return columns;
 }
 
-bool QgsExpression::needsGeometry()
+bool QgsExpression::needsGeometry() const
 {
   if ( !mRootNode )
     return false;
   return mRootNode->needsGeometry();
 }
 
-void QgsExpression::initGeomCalculator()
+void QgsExpression::initGeomCalculator() const
 {
   if ( mCalc )
     return;
@@ -1938,7 +1938,7 @@ void QgsExpression::setGeomCalculator( const QgsDistanceArea &calc )
   mCalc = new QgsDistanceArea( calc );
 }
 
-bool QgsExpression::prepare( const QgsFields& fields )
+bool QgsExpression::prepare( const QgsFields& fields ) const
 {
   mEvalErrorString = QString();
   if ( !mRootNode )
@@ -1950,7 +1950,7 @@ bool QgsExpression::prepare( const QgsFields& fields )
   return mRootNode->prepare( this, fields );
 }
 
-QVariant QgsExpression::evaluate( const QgsFeature* f )
+QVariant QgsExpression::evaluate( const QgsFeature* f ) const
 {
   mEvalErrorString = QString();
   if ( !mRootNode )
@@ -1962,7 +1962,7 @@ QVariant QgsExpression::evaluate( const QgsFeature* f )
   return mRootNode->eval( this, f );
 }
 
-QVariant QgsExpression::evaluate( const QgsFeature* f, const QgsFields& fields )
+QVariant QgsExpression::evaluate( const QgsFeature* f, const QgsFields& fields ) const
 {
   // first prepare
   bool res = prepare( fields );
@@ -2085,7 +2085,7 @@ QString QgsExpression::NodeList::dump() const
 
 //
 
-QVariant QgsExpression::NodeUnaryOperator::eval( QgsExpression* parent, const QgsFeature* f )
+QVariant QgsExpression::NodeUnaryOperator::eval( const QgsExpression* parent, const QgsFeature* f ) const
 {
   QVariant val = mOperand->eval( parent, f );
   ENSURE_NO_EVAL_ERROR;
@@ -2113,7 +2113,7 @@ QVariant QgsExpression::NodeUnaryOperator::eval( QgsExpression* parent, const Qg
   return QVariant();
 }
 
-bool QgsExpression::NodeUnaryOperator::prepare( QgsExpression* parent, const QgsFields& fields )
+bool QgsExpression::NodeUnaryOperator::prepare( const QgsExpression* parent, const QgsFields& fields ) const
 {
   return mOperand->prepare( parent, fields );
 }
@@ -2125,7 +2125,7 @@ QString QgsExpression::NodeUnaryOperator::dump() const
 
 //
 
-QVariant QgsExpression::NodeBinaryOperator::eval( QgsExpression* parent, const QgsFeature* f )
+QVariant QgsExpression::NodeBinaryOperator::eval( const QgsExpression* parent, const QgsFeature* f ) const
 {
   QVariant vL = mOpLeft->eval( parent, f );
   ENSURE_NO_EVAL_ERROR;
@@ -2303,7 +2303,7 @@ QVariant QgsExpression::NodeBinaryOperator::eval( QgsExpression* parent, const Q
   return QVariant();
 }
 
-bool QgsExpression::NodeBinaryOperator::compare( double diff )
+bool QgsExpression::NodeBinaryOperator::compare( double diff ) const
 {
   switch ( mOp )
   {
@@ -2317,7 +2317,7 @@ bool QgsExpression::NodeBinaryOperator::compare( double diff )
   }
 }
 
-int QgsExpression::NodeBinaryOperator::computeInt( int x, int y )
+int QgsExpression::NodeBinaryOperator::computeInt( int x, int y ) const
 {
   switch ( mOp )
   {
@@ -2330,7 +2330,7 @@ int QgsExpression::NodeBinaryOperator::computeInt( int x, int y )
   }
 }
 
-QDateTime QgsExpression::NodeBinaryOperator::computeDateTimeFromInterval( QDateTime d, QgsExpression::Interval *i )
+QDateTime QgsExpression::NodeBinaryOperator::computeDateTimeFromInterval( QDateTime d, QgsExpression::Interval *i ) const
 {
   switch ( mOp )
   {
@@ -2340,7 +2340,7 @@ QDateTime QgsExpression::NodeBinaryOperator::computeDateTimeFromInterval( QDateT
   }
 }
 
-double QgsExpression::NodeBinaryOperator::computeDouble( double x, double y )
+double QgsExpression::NodeBinaryOperator::computeDouble( double x, double y ) const
 {
   switch ( mOp )
   {
@@ -2354,7 +2354,7 @@ double QgsExpression::NodeBinaryOperator::computeDouble( double x, double y )
 }
 
 
-bool QgsExpression::NodeBinaryOperator::prepare( QgsExpression* parent, const QgsFields& fields )
+bool QgsExpression::NodeBinaryOperator::prepare( const QgsExpression* parent, const QgsFields& fields ) const
 {
   bool resL = mOpLeft->prepare( parent, fields );
   bool resR = mOpRight->prepare( parent, fields );
@@ -2421,7 +2421,7 @@ QString QgsExpression::NodeBinaryOperator::dump() const
 
 //
 
-QVariant QgsExpression::NodeInOperator::eval( QgsExpression* parent, const QgsFeature* f )
+QVariant QgsExpression::NodeInOperator::eval( const QgsExpression* parent, const QgsFeature* f ) const
 {
   if ( mList->count() == 0 )
     return mNotIn ? TVL_True : TVL_False;
@@ -2467,7 +2467,7 @@ QVariant QgsExpression::NodeInOperator::eval( QgsExpression* parent, const QgsFe
     return mNotIn ? TVL_True : TVL_False;
 }
 
-bool QgsExpression::NodeInOperator::prepare( QgsExpression* parent, const QgsFields& fields )
+bool QgsExpression::NodeInOperator::prepare( const QgsExpression* parent, const QgsFields& fields ) const
 {
   bool res = mNode->prepare( parent, fields );
   foreach ( Node* n, mList->list() )
@@ -2484,7 +2484,7 @@ QString QgsExpression::NodeInOperator::dump() const
 
 //
 
-QVariant QgsExpression::NodeFunction::eval( QgsExpression* parent, const QgsFeature* f )
+QVariant QgsExpression::NodeFunction::eval( const QgsExpression* parent, const QgsFeature* f ) const
 {
   Function* fd = Functions()[mFnIndex];
 
@@ -2510,7 +2510,7 @@ QVariant QgsExpression::NodeFunction::eval( QgsExpression* parent, const QgsFeat
   return res;
 }
 
-bool QgsExpression::NodeFunction::prepare( QgsExpression* parent, const QgsFields& fields )
+bool QgsExpression::NodeFunction::prepare( const QgsExpression* parent, const QgsFields& fields ) const
 {
   bool res = true;
   if ( mArgs )
@@ -2554,12 +2554,12 @@ QStringList QgsExpression::NodeFunction::referencedColumns() const
 
 //
 
-QVariant QgsExpression::NodeLiteral::eval( QgsExpression*, const QgsFeature* )
+QVariant QgsExpression::NodeLiteral::eval( const QgsExpression*, const QgsFeature* ) const
 {
   return mValue;
 }
 
-bool QgsExpression::NodeLiteral::prepare( QgsExpression* /*parent*/, const QgsFields& /*fields*/ )
+bool QgsExpression::NodeLiteral::prepare( const QgsExpression* /*parent*/, const QgsFields& /*fields*/ ) const
 {
   return true;
 }
@@ -2581,7 +2581,7 @@ QString QgsExpression::NodeLiteral::dump() const
 
 //
 
-QVariant QgsExpression::NodeColumnRef::eval( QgsExpression* /*parent*/, const QgsFeature* f )
+QVariant QgsExpression::NodeColumnRef::eval( const QgsExpression* /*parent*/, const QgsFeature* f ) const
 {
   if ( f )
   {
@@ -2593,7 +2593,7 @@ QVariant QgsExpression::NodeColumnRef::eval( QgsExpression* /*parent*/, const Qg
   return QVariant( "[" + mName + "]" );
 }
 
-bool QgsExpression::NodeColumnRef::prepare( QgsExpression* parent, const QgsFields& fields )
+bool QgsExpression::NodeColumnRef::prepare( const QgsExpression* parent, const QgsFields& fields ) const
 {
   for ( int i = 0; i < fields.count(); ++i )
   {
@@ -2615,7 +2615,7 @@ QString QgsExpression::NodeColumnRef::dump() const
 
 //
 
-QVariant QgsExpression::NodeCondition::eval( QgsExpression* parent, const QgsFeature* f )
+QVariant QgsExpression::NodeCondition::eval( const QgsExpression* parent, const QgsFeature* f ) const
 {
   foreach ( WhenThen* cond, mConditions )
   {
@@ -2641,7 +2641,7 @@ QVariant QgsExpression::NodeCondition::eval( QgsExpression* parent, const QgsFea
   return QVariant();
 }
 
-bool QgsExpression::NodeCondition::prepare( QgsExpression* parent, const QgsFields& fields )
+bool QgsExpression::NodeCondition::prepare( const QgsExpression* parent, const QgsFields& fields ) const
 {
   bool res;
   foreach ( WhenThen* cond, mConditions )

--- a/src/core/qgsexpression.h
+++ b/src/core/qgsexpression.h
@@ -101,7 +101,7 @@ class CORE_EXPORT QgsExpression
     const Node* rootNode() const { return mRootNode; }
 
     //! Get the expression ready for evaluation - find out column indexes.
-    bool prepare( const QgsFields &fields );
+    bool prepare( const QgsFields &fields ) const;
 
     /**Get list of columns referenced by the expression.
      * @note if the returned list contains the QgsFeatureRequest::AllAttributes constant then
@@ -111,39 +111,39 @@ class CORE_EXPORT QgsExpression
     QStringList referencedColumns();
 
     //! Returns true if the expression uses feature geometry for some computation
-    bool needsGeometry();
+    bool needsGeometry() const;
 
     // evaluation
 
     //! Evaluate the feature and return the result
     //! @note prepare() should be called before calling this method
-    QVariant evaluate( const QgsFeature* f = NULL );
+    QVariant evaluate( const QgsFeature* f = NULL ) const;
 
     //! Evaluate the feature and return the result
     //! @note prepare() should be called before calling this method
     //! @note available in python bindings as evaluatePrepared
-    inline QVariant evaluate( const QgsFeature& f ) { return evaluate( &f ); }
+    inline QVariant evaluate( const QgsFeature& f ) const { return evaluate( &f ); }
 
     //! Evaluate the feature and return the result
     //! @note this method does not expect that prepare() has been called on this instance
-    QVariant evaluate( const QgsFeature* f, const QgsFields& fields );
+    QVariant evaluate( const QgsFeature* f, const QgsFields& fields ) const;
 
     //! Evaluate the feature and return the result
     //! @note this method does not expect that prepare() has been called on this instance
     //! @note not available in python bindings
-    inline QVariant evaluate( const QgsFeature& f, const QgsFields& fields ) { return evaluate( &f, fields ); }
+    inline QVariant evaluate( const QgsFeature& f, const QgsFields& fields ) const { return evaluate( &f, fields ); }
 
     //! Returns true if an error occurred when evaluating last input
     bool hasEvalError() const { return !mEvalErrorString.isNull(); }
     //! Returns evaluation error
     QString evalErrorString() const { return mEvalErrorString; }
     //! Set evaluation error (used internally by evaluation functions)
-    void setEvalErrorString( QString str ) { mEvalErrorString = str; }
+    void setEvalErrorString( QString str ) const { mEvalErrorString = str; }
 
     //! Set the number for $rownum special column
     void setCurrentRowNumber( int rowNumber ) { mRowNumber = rowNumber; }
     //! Return the number used for $rownum special column
-    int currentRowNumber() { return mRowNumber; }
+    int currentRowNumber() const { return mRowNumber; }
 
     //! Assign a special column
     static void setSpecialColumn( const QString& name, QVariant value );
@@ -159,7 +159,7 @@ class CORE_EXPORT QgsExpression
 
     void setScale( double scale ) { mScale = scale; }
 
-    double scale() { return mScale; }
+    double scale() const { return mScale; }
 
     //! Alias for dump()
     const QString expression() const { return dump(); }
@@ -169,7 +169,7 @@ class CORE_EXPORT QgsExpression
 
     //! Return calculator used for distance and area calculations
     //! (used by internal functions)
-    QgsDistanceArea *geomCalculator() { initGeomCalculator(); return mCalc; }
+    QgsDistanceArea *geomCalculator() const { initGeomCalculator(); return mCalc; }
 
     //! Sets the geometry calculator used in evaluation of expressions,
     // instead of the default.
@@ -246,7 +246,7 @@ class CORE_EXPORT QgsExpression
     static const char* BinaryOperatorText[];
     static const char* UnaryOperatorText[];
 
-    typedef QVariant( *FcnEval )( const QVariantList& values, const QgsFeature* f, QgsExpression* parent );
+    typedef QVariant( *FcnEval )( const QVariantList& values, const QgsFeature* f, const QgsExpression* parent );
 
 
     /**
@@ -271,7 +271,7 @@ class CORE_EXPORT QgsExpression
         /** The help text for the function. */
         QString helptext() { return mHelpText.isEmpty() ? QgsExpression::helptext( mName ) : mHelpText; }
 
-        virtual QVariant func( const QVariantList& values, const QgsFeature* f, QgsExpression* parent ) = 0;
+        virtual QVariant func( const QVariantList& values, const QgsFeature* f, const QgsExpression* parent ) = 0;
 
         bool operator==( const Function& other ) const
         {
@@ -296,7 +296,7 @@ class CORE_EXPORT QgsExpression
         StaticFunction( QString fnname, int params, FcnEval fcn, QString group, QString helpText = QString(), bool usesGeometry = false, QStringList referencedColumns = QStringList() )
             : Function( fnname, params, group, helpText, usesGeometry, referencedColumns ), mFnc( fcn ) {}
 
-        virtual QVariant func( const QVariantList& values, const QgsFeature* f, QgsExpression* parent )
+        virtual QVariant func( const QVariantList& values, const QgsFeature* f, const QgsExpression* parent )
         {
           return mFnc( values, f, parent );
         }
@@ -357,11 +357,11 @@ class CORE_EXPORT QgsExpression
         virtual NodeType nodeType() const = 0;
         // abstract virtual eval function
         // errors are reported to the parent
-        virtual QVariant eval( QgsExpression* parent, const QgsFeature* f ) = 0;
+        virtual QVariant eval( const QgsExpression* parent, const QgsFeature* f ) const = 0;
 
         // abstract virtual preparation function
         // errors are reported to the parent
-        virtual bool prepare( QgsExpression* parent, const QgsFields &fields ) = 0;
+        virtual bool prepare( const QgsExpression* parent, const QgsFields &fields ) const = 0;
 
         virtual QString dump() const = 0;
 
@@ -427,8 +427,8 @@ class CORE_EXPORT QgsExpression
         Node* operand() const { return mOperand; }
 
         virtual NodeType nodeType() const { return ntUnaryOperator; }
-        virtual bool prepare( QgsExpression* parent, const QgsFields &fields );
-        virtual QVariant eval( QgsExpression* parent, const QgsFeature* f );
+        virtual bool prepare( const QgsExpression* parent, const QgsFields &fields ) const;
+        virtual QVariant eval( const QgsExpression* parent, const QgsFeature* f ) const;
         virtual QString dump() const;
 
         virtual QStringList referencedColumns() const { return mOperand->referencedColumns(); }
@@ -451,8 +451,8 @@ class CORE_EXPORT QgsExpression
         Node* opRight() const { return mOpRight; }
 
         virtual NodeType nodeType() const { return ntBinaryOperator; }
-        virtual bool prepare( QgsExpression* parent, const QgsFields &fields );
-        virtual QVariant eval( QgsExpression* parent, const QgsFeature* f );
+        virtual bool prepare( const QgsExpression* parent, const QgsFields &fields ) const;
+        virtual QVariant eval( const QgsExpression* parent, const QgsFeature* f ) const;
         virtual QString dump() const;
 
         virtual QStringList referencedColumns() const { return mOpLeft->referencedColumns() + mOpRight->referencedColumns(); }
@@ -462,10 +462,10 @@ class CORE_EXPORT QgsExpression
         int precedence() const;
 
       protected:
-        bool compare( double diff );
-        int computeInt( int x, int y );
-        double computeDouble( double x, double y );
-        QDateTime computeDateTimeFromInterval( QDateTime d, QgsExpression::Interval *i );
+        bool compare( double diff ) const;
+        int computeInt( int x, int y ) const;
+        double computeDouble( double x, double y ) const;
+        QDateTime computeDateTimeFromInterval( QDateTime d, QgsExpression::Interval *i ) const;
 
         BinaryOperator mOp;
         Node* mOpLeft;
@@ -483,8 +483,8 @@ class CORE_EXPORT QgsExpression
         NodeList* list() const { return mList; }
 
         virtual NodeType nodeType() const { return ntInOperator; }
-        virtual bool prepare( QgsExpression* parent, const QgsFields &fields );
-        virtual QVariant eval( QgsExpression* parent, const QgsFeature* f );
+        virtual bool prepare( const QgsExpression* parent, const QgsFields &fields ) const;
+        virtual QVariant eval( const QgsExpression* parent, const QgsFeature* f ) const;
         virtual QString dump() const;
 
         virtual QStringList referencedColumns() const { QStringList lst( mNode->referencedColumns() ); foreach ( Node* n, mList->list() ) lst.append( n->referencedColumns() ); return lst; }
@@ -508,8 +508,8 @@ class CORE_EXPORT QgsExpression
         NodeList* args() const { return mArgs; }
 
         virtual NodeType nodeType() const { return ntFunction; }
-        virtual bool prepare( QgsExpression* parent, const QgsFields &fields );
-        virtual QVariant eval( QgsExpression* parent, const QgsFeature* f );
+        virtual bool prepare( const QgsExpression* parent, const QgsFields &fields ) const;
+        virtual QVariant eval( const QgsExpression* parent, const QgsFeature* f ) const;
         virtual QString dump() const;
 
         virtual QStringList referencedColumns() const;
@@ -530,8 +530,8 @@ class CORE_EXPORT QgsExpression
         QVariant value() const { return mValue; }
 
         virtual NodeType nodeType() const { return ntLiteral; }
-        virtual bool prepare( QgsExpression* parent, const QgsFields &fields );
-        virtual QVariant eval( QgsExpression* parent, const QgsFeature* f );
+        virtual bool prepare( const QgsExpression* parent, const QgsFields &fields ) const;
+        virtual QVariant eval( const QgsExpression* parent, const QgsFeature* f ) const;
         virtual QString dump() const;
 
         virtual QStringList referencedColumns() const { return QStringList(); }
@@ -550,8 +550,8 @@ class CORE_EXPORT QgsExpression
         QString name() const { return mName; }
 
         virtual NodeType nodeType() const { return ntColumnRef; }
-        virtual bool prepare( QgsExpression* parent, const QgsFields &fields );
-        virtual QVariant eval( QgsExpression* parent, const QgsFeature* f );
+        virtual bool prepare( const QgsExpression* parent, const QgsFields &fields ) const;
+        virtual QVariant eval( const QgsExpression* parent, const QgsFeature* f ) const;
         virtual QString dump() const;
 
         virtual QStringList referencedColumns() const { return QStringList( mName ); }
@@ -561,7 +561,7 @@ class CORE_EXPORT QgsExpression
 
       protected:
         QString mName;
-        int mIndex;
+        mutable int mIndex;
     };
 
     class CORE_EXPORT WhenThen
@@ -583,8 +583,8 @@ class CORE_EXPORT QgsExpression
         ~NodeCondition() { delete mElseExp; qDeleteAll( mConditions ); }
 
         virtual NodeType nodeType() const { return ntCondition; }
-        virtual QVariant eval( QgsExpression* parent, const QgsFeature* f );
-        virtual bool prepare( QgsExpression* parent, const QgsFields &fields );
+        virtual QVariant eval( const QgsExpression* parent, const QgsFeature* f ) const;
+        virtual bool prepare( const QgsExpression* parent, const QgsFields &fields ) const;
         virtual QString dump() const;
 
         virtual QStringList referencedColumns() const;
@@ -623,12 +623,13 @@ class CORE_EXPORT QgsExpression
     // internally used to create an empty expression
     QgsExpression() : mRootNode( 0 ), mRowNumber( 0 ), mCalc( 0 ) {}
 
-    void initGeomCalculator();
+    void initGeomCalculator() const;
 
     Node* mRootNode;
 
-    QString mParserErrorString;
-    QString mEvalErrorString;
+    //! setting parsing / evaluation error should not change constness
+    mutable QString mParserErrorString;
+    mutable QString mEvalErrorString;
 
     int mRowNumber;
     double mScale;
@@ -637,7 +638,7 @@ class CORE_EXPORT QgsExpression
     static QMap<QString, QVariant> gmSpecialColumns;
     static QMap<QString, QString> gmSpecialColumnGroups;
 
-    QgsDistanceArea *mCalc;
+    mutable QgsDistanceArea *mCalc;
 
     friend class QgsOgcUtils;
 


### PR DESCRIPTION
Conceptually, evaluating an expression does not have to "modify" it.
evaluate() did write to some members to carry errors, which are now
tagged as mutable. In a future version, this could be replaced by an
evaluation method that returns errors somehow.
Similarly, prepare() which is used for optimisation is a good place for
being tagged mutable.
