### PR TITLE
Make QgsExpression::evaluate() and prepare() const

### DIFF
--- a/python/core/qgsexpression.sip
+++ b/python/core/qgsexpression.sip
@@ -17,7 +17,7 @@ class QgsExpression
     const QgsExpression::Node* rootNode() const;
 
     //! Get the expression ready for evaluation - find out column indexes.
-    bool prepare( const QgsFields &fields );
+    bool prepare( const QgsFields &fields ) const;
 
     /**
      * Get list of columns referenced by the expression.
@@ -34,21 +34,21 @@ class QgsExpression
 
     //! Evaluate the feature and return the result
     //! @note prepare() should be called before calling this method
-    QVariant evaluate( const QgsFeature* f = NULL );
+    QVariant evaluate( const QgsFeature* f = NULL ) const;
 
     //! Evaluate the feature and return the result
     //! @note prepare() should be called before calling this method
     //! @note available in python bindings as evaluatePrepared
-    QVariant evaluate( const QgsFeature& f ) /PyName=evaluatePrepared/;
+    QVariant evaluate( const QgsFeature& f ) const /PyName=evaluatePrepared/;
 
     //! Evaluate the feature and return the result
     //! @note this method does not expect that prepare() has been called on this instance
-    QVariant evaluate( const QgsFeature* f, const QgsFields& fields );
+    QVariant evaluate( const QgsFeature* f, const QgsFields& fields ) const;
 
     //! Evaluate the feature and return the result
     //! @note this method does not expect that prepare() has been called on this instance
     //! @note not available in python bindings
-    // inline QVariant evaluate( const QgsFeature& f, const QgsFields& fields ) { return evaluate( &f, fields ); }
+    // inline QVariant evaluate( const QgsFeature& f, const QgsFields& fields ) const { return evaluate( &f, fields ); }
 
     //! Returns true if an error occurred when evaluating last input
     bool hasEvalError() const;
@@ -231,7 +231,7 @@ class QgsExpression
         /** The help text for the function. */
         const QString helptext();
 
-        virtual QVariant func( const QVariantList& values, const QgsFeature* f, QgsExpression* parent ) = 0;
+        virtual QVariant func( const QVariantList& values, const QgsFeature* f, const QgsExpression* parent ) = 0;
 
         virtual bool handlesNull() const;
     };
@@ -297,11 +297,11 @@ class QgsExpression
         virtual QgsExpression::NodeType nodeType() const = 0;
         // abstract virtual eval function
         // errors are reported to the parent
-        virtual QVariant eval( QgsExpression* parent, const QgsFeature* f ) = 0;
+        virtual QVariant eval( const QgsExpression* parent, const QgsFeature* f ) const = 0;
 
         // abstract virtual preparation function
         // errors are reported to the parent
-        virtual bool prepare( QgsExpression* parent, const QgsFields &fields ) = 0;
+        virtual bool prepare( const QgsExpression* parent, const QgsFields &fields ) const = 0;
 
         virtual QString dump() const = 0;
 
@@ -357,8 +357,8 @@ class QgsExpression
         QgsExpression::Node* operand() const;
 
         virtual QgsExpression::NodeType nodeType() const;
-        virtual bool prepare( QgsExpression* parent, const QgsFields &fields );
-        virtual QVariant eval( QgsExpression* parent, const QgsFeature* f );
+        virtual bool prepare( const QgsExpression* parent, const QgsFields &fields ) const;
+        virtual QVariant eval( const QgsExpression* parent, const QgsFeature* f ) const;
         virtual QString dump() const;
 
         virtual QStringList referencedColumns() const;
@@ -377,8 +377,8 @@ class QgsExpression
         QgsExpression::Node* opRight() const;
 
         virtual QgsExpression::NodeType nodeType() const;
-        virtual bool prepare( QgsExpression* parent, const QgsFields &fields );
-        virtual QVariant eval( QgsExpression* parent, const QgsFeature* f );
+        virtual bool prepare( const QgsExpression* parent, const QgsFields &fields ) const;
+        virtual QVariant eval( const QgsExpression* parent, const QgsFeature* f ) const;
         virtual QString dump() const;
 
         virtual QStringList referencedColumns() const;
@@ -400,8 +400,8 @@ class QgsExpression
         QgsExpression::NodeList* list() const;
 
         virtual QgsExpression::NodeType nodeType() const;
-        virtual bool prepare( QgsExpression* parent, const QgsFields &fields );
-        virtual QVariant eval( QgsExpression* parent, const QgsFeature* f );
+        virtual bool prepare( const QgsExpression* parent, const QgsFields &fields ) const;
+        virtual QVariant eval( const QgsExpression* parent, const QgsFeature* f ) const;
         virtual QString dump() const;
 
         virtual QStringList referencedColumns() const;
@@ -420,8 +420,8 @@ class QgsExpression
         QgsExpression::NodeList* args() const;
 
         virtual QgsExpression::NodeType nodeType() const;
-        virtual bool prepare( QgsExpression* parent, const QgsFields &fields );
-        virtual QVariant eval( QgsExpression* parent, const QgsFeature* f );
+        virtual bool prepare( const QgsExpression* parent, const QgsFields &fields ) const;
+        virtual QVariant eval( const QgsExpression* parent, const QgsFeature* f ) const;
         virtual QString dump() const;
 
         virtual QStringList referencedColumns() const;
@@ -437,8 +437,8 @@ class QgsExpression
         const QVariant& value() const;
 
         virtual QgsExpression::NodeType nodeType() const;
-        virtual bool prepare( QgsExpression* parent, const QgsFields &fields );
-        virtual QVariant eval( QgsExpression* parent, const QgsFeature* f );
+        virtual bool prepare( const QgsExpression* parent, const QgsFields &fields ) const;
+        virtual QVariant eval( const QgsExpression* parent, const QgsFeature* f ) const;
         virtual QString dump() const;
 
         virtual QStringList referencedColumns() const;
@@ -454,8 +454,8 @@ class QgsExpression
         QString name() const;
 
         virtual QgsExpression::NodeType nodeType() const;
-        virtual bool prepare( QgsExpression* parent, const QgsFields &fields );
-        virtual QVariant eval( QgsExpression* parent, const QgsFeature* f );
+        virtual bool prepare( const QgsExpression* parent, const QgsFields &fields ) const;
+        virtual QVariant eval( const QgsExpression* parent, const QgsFeature* f ) const;
         virtual QString dump() const;
 
         virtual QStringList referencedColumns() const;
@@ -482,8 +482,8 @@ class QgsExpression
         ~NodeCondition();
 
         virtual QgsExpression::NodeType nodeType() const;
-        virtual QVariant eval( QgsExpression* parent, const QgsFeature* f );
-        virtual bool prepare( QgsExpression* parent, const QgsFields &fields );
+        virtual QVariant eval( const QgsExpression* parent, const QgsFeature* f ) const;
+        virtual bool prepare( const QgsExpression* parent, const QgsFields &fields ) const;
         virtual QString dump() const;
 
         virtual QStringList referencedColumns() const;

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -230,12 +230,12 @@ const char* QgsExpression::UnaryOperatorText[] =
 // functions
 
 // implicit conversion to string
-static QString getStringValue( const QVariant& value, QgsExpression* )
+static QString getStringValue( const QVariant& value, const QgsExpression* )
 {
   return value.toString();
 }
 
-static double getDoubleValue( const QVariant& value, QgsExpression* parent )
+static double getDoubleValue( const QVariant& value, const QgsExpression* parent )
 {
   bool ok;
   double x = value.toDouble( &ok );
@@ -247,7 +247,7 @@ static double getDoubleValue( const QVariant& value, QgsExpression* parent )
   return x;
 }
 
-static int getIntValue( const QVariant& value, QgsExpression* parent )
+static int getIntValue( const QVariant& value, const QgsExpression* parent )
 {
   bool ok;
   qint64 x = value.toLongLong( &ok );
@@ -262,7 +262,7 @@ static int getIntValue( const QVariant& value, QgsExpression* parent )
   }
 }
 
-static QDateTime getDateTimeValue( const QVariant& value, QgsExpression* parent )
+static QDateTime getDateTimeValue( const QVariant& value, const QgsExpression* parent )
 {
   QDateTime d = value.toDateTime();
   if ( d.isValid() )
@@ -276,7 +276,7 @@ static QDateTime getDateTimeValue( const QVariant& value, QgsExpression* parent 
   }
 }
 
-static QDate getDateValue( const QVariant& value, QgsExpression* parent )
+static QDate getDateValue( const QVariant& value, const QgsExpression* parent )
 {
   QDate d = value.toDate();
   if ( d.isValid() )
@@ -290,7 +290,7 @@ static QDate getDateValue( const QVariant& value, QgsExpression* parent )
   }
 }
 
-static QTime getTimeValue( const QVariant& value, QgsExpression* parent )
+static QTime getTimeValue( const QVariant& value, const QgsExpression* parent )
 {
   QTime t = value.toTime();
   if ( t.isValid() )
@@ -304,7 +304,7 @@ static QTime getTimeValue( const QVariant& value, QgsExpression* parent )
   }
 }
 
-static QgsExpression::Interval getInterval( const QVariant& value, QgsExpression* parent, bool report_error = false )
+static QgsExpression::Interval getInterval( const QVariant& value, const QgsExpression* parent, bool report_error = false )
 {
   if ( value.canConvert<QgsExpression::Interval>() )
     return value.value<QgsExpression::Interval>();
@@ -321,7 +321,7 @@ static QgsExpression::Interval getInterval( const QVariant& value, QgsExpression
   return QgsExpression::Interval::invalidInterVal();
 }
 
-static QgsGeometry getGeometry( const QVariant& value, QgsExpression* parent )
+static QgsGeometry getGeometry( const QVariant& value, const QgsExpression* parent )
 {
   if ( value.canConvert<QgsGeometry>() )
     return value.value<QgsGeometry>();
@@ -330,7 +330,7 @@ static QgsGeometry getGeometry( const QVariant& value, QgsExpression* parent )
   return QgsGeometry();
 }
 
-static QgsFeature getFeature( const QVariant& value, QgsExpression* parent )
+static QgsFeature getFeature( const QVariant& value, const QgsExpression* parent )
 {
   if ( value.canConvert<QgsFeature>() )
     return value.value<QgsFeature>();
@@ -339,7 +339,7 @@ static QgsFeature getFeature( const QVariant& value, QgsExpression* parent )
   return 0;
 }
 
-static QgsExpression::Node* getNode( const QVariant& value, QgsExpression* parent )
+static QgsExpression::Node* getNode( const QVariant& value, const QgsExpression* parent )
 {
   if ( value.canConvert<QgsExpression::Node*>() )
     return value.value<QgsExpression::Node*>();
@@ -349,7 +349,7 @@ static QgsExpression::Node* getNode( const QVariant& value, QgsExpression* paren
 }
 
 // this handles also NULL values
-static TVL getTVLValue( const QVariant& value, QgsExpression* parent )
+static TVL getTVLValue( const QVariant& value, const QgsExpression* parent )
 {
   // we need to convert to TVL
   if ( value.isNull() )
@@ -370,74 +370,74 @@ static TVL getTVLValue( const QVariant& value, QgsExpression* parent )
 
 //////
 
-static QVariant fcnSqrt( const QVariantList& values, const QgsFeature* /*f*/, QgsExpression* parent )
+static QVariant fcnSqrt( const QVariantList& values, const QgsFeature* /*f*/, const QgsExpression* parent )
 {
   double x = getDoubleValue( values.at( 0 ), parent );
   return QVariant( sqrt( x ) );
 }
 
-static QVariant fcnAbs( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnAbs( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   double val = getDoubleValue( values.at( 0 ), parent );
   return QVariant( fabs( val ) );
 }
 
-static QVariant fcnSin( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnSin( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   double x = getDoubleValue( values.at( 0 ), parent );
   return QVariant( sin( x ) );
 }
-static QVariant fcnCos( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnCos( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   double x = getDoubleValue( values.at( 0 ), parent );
   return QVariant( cos( x ) );
 }
-static QVariant fcnTan( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnTan( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   double x = getDoubleValue( values.at( 0 ), parent );
   return QVariant( tan( x ) );
 }
-static QVariant fcnAsin( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnAsin( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   double x = getDoubleValue( values.at( 0 ), parent );
   return QVariant( asin( x ) );
 }
-static QVariant fcnAcos( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnAcos( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   double x = getDoubleValue( values.at( 0 ), parent );
   return QVariant( acos( x ) );
 }
-static QVariant fcnAtan( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnAtan( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   double x = getDoubleValue( values.at( 0 ), parent );
   return QVariant( atan( x ) );
 }
-static QVariant fcnAtan2( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnAtan2( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   double y = getDoubleValue( values.at( 0 ), parent );
   double x = getDoubleValue( values.at( 1 ), parent );
   return QVariant( atan2( y, x ) );
 }
-static QVariant fcnExp( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnExp( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   double x = getDoubleValue( values.at( 0 ), parent );
   return QVariant( exp( x ) );
 }
-static QVariant fcnLn( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnLn( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   double x = getDoubleValue( values.at( 0 ), parent );
   if ( x <= 0 )
     return QVariant();
   return QVariant( log( x ) );
 }
-static QVariant fcnLog10( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnLog10( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   double x = getDoubleValue( values.at( 0 ), parent );
   if ( x <= 0 )
     return QVariant();
   return QVariant( log10( x ) );
 }
-static QVariant fcnLog( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnLog( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   double b = getDoubleValue( values.at( 0 ), parent );
   double x = getDoubleValue( values.at( 1 ), parent );
@@ -445,7 +445,7 @@ static QVariant fcnLog( const QVariantList& values, const QgsFeature*, QgsExpres
     return QVariant();
   return QVariant( log( x ) / log( b ) );
 }
-static QVariant fcnRndF( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnRndF( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   double min = getDoubleValue( values.at( 0 ), parent );
   double max = getDoubleValue( values.at( 1 ), parent );
@@ -456,7 +456,7 @@ static QVariant fcnRndF( const QVariantList& values, const QgsFeature*, QgsExpre
   double f = ( double )qrand() / RAND_MAX;
   return QVariant( min + f * ( max - min ) );
 }
-static QVariant fcnRnd( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnRnd( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   int min = getIntValue( values.at( 0 ), parent );
   int max = getIntValue( values.at( 1 ), parent );
@@ -467,7 +467,7 @@ static QVariant fcnRnd( const QVariantList& values, const QgsFeature*, QgsExpres
   return QVariant( min + ( qrand() % ( int )( max - min + 1 ) ) );
 }
 
-static QVariant fcnLinearScale( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnLinearScale( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   double val = getDoubleValue( values.at( 0 ), parent );
   double domainMin = getDoubleValue( values.at( 1 ), parent );
@@ -499,7 +499,7 @@ static QVariant fcnLinearScale( const QVariantList& values, const QgsFeature*, Q
   return QVariant( m * val + c );
 }
 
-static QVariant fcnExpScale( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnExpScale( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   double val = getDoubleValue( values.at( 0 ), parent );
   double domainMin = getDoubleValue( values.at( 1 ), parent );
@@ -533,7 +533,7 @@ static QVariant fcnExpScale( const QVariantList& values, const QgsFeature*, QgsE
   return QVariant((( rangeMax - rangeMin ) / pow( domainMax - domainMin, exponent ) ) * pow( val - domainMin, exponent ) + rangeMin );
 }
 
-static QVariant fcnMax( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnMax( const QVariantList& values, const QgsFeature*, const QgsExpression *parent )
 {
   //initially set max as first value
   double maxVal = getDoubleValue( values.at( 0 ), parent );
@@ -551,7 +551,7 @@ static QVariant fcnMax( const QVariantList& values, const QgsFeature*, QgsExpres
   return QVariant( maxVal );
 }
 
-static QVariant fcnMin( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnMin( const QVariantList& values, const QgsFeature*, const QgsExpression *parent )
 {
   //initially set min as first value
   double minVal = getDoubleValue( values.at( 0 ), parent );
@@ -569,7 +569,7 @@ static QVariant fcnMin( const QVariantList& values, const QgsFeature*, QgsExpres
   return QVariant( minVal );
 }
 
-static QVariant fcnClamp( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnClamp( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   double minValue = getDoubleValue( values.at( 0 ), parent );
   double testValue = getDoubleValue( values.at( 1 ), parent );
@@ -590,37 +590,37 @@ static QVariant fcnClamp( const QVariantList& values, const QgsFeature*, QgsExpr
   }
 }
 
-static QVariant fcnFloor( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnFloor( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   double x = getDoubleValue( values.at( 0 ), parent );
   return QVariant( floor( x ) );
 }
 
-static QVariant fcnCeil( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnCeil( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   double x = getDoubleValue( values.at( 0 ), parent );
   return QVariant( ceil( x ) );
 }
 
-static QVariant fcnToInt( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnToInt( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   return QVariant( getIntValue( values.at( 0 ), parent ) );
 }
-static QVariant fcnToReal( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnToReal( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   return QVariant( getDoubleValue( values.at( 0 ), parent ) );
 }
-static QVariant fcnToString( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnToString( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   return QVariant( getStringValue( values.at( 0 ), parent ) );
 }
 
-static QVariant fcnToDateTime( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnToDateTime( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   return QVariant( getDateTimeValue( values.at( 0 ), parent ) );
 }
 
-static QVariant fcnCoalesce( const QVariantList& values, const QgsFeature*, QgsExpression* )
+static QVariant fcnCoalesce( const QVariantList& values, const QgsFeature*, const QgsExpression* )
 {
   foreach ( const QVariant &value, values )
   {
@@ -630,17 +630,17 @@ static QVariant fcnCoalesce( const QVariantList& values, const QgsFeature*, QgsE
   }
   return QVariant();
 }
-static QVariant fcnLower( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnLower( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QString str = getStringValue( values.at( 0 ), parent );
   return QVariant( str.toLower() );
 }
-static QVariant fcnUpper( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnUpper( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QString str = getStringValue( values.at( 0 ), parent );
   return QVariant( str.toUpper() );
 }
-static QVariant fcnTitle( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnTitle( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QString str = getStringValue( values.at( 0 ), parent );
   QStringList elems = str.split( " " );
@@ -652,27 +652,27 @@ static QVariant fcnTitle( const QVariantList& values, const QgsFeature*, QgsExpr
   return QVariant( elems.join( " " ) );
 }
 
-static QVariant fcnTrim( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnTrim( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QString str = getStringValue( values.at( 0 ), parent );
   return QVariant( str.trimmed() );
 }
 
-static QVariant fcnLevenshtein( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnLevenshtein( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QString string1 = getStringValue( values.at( 0 ), parent );
   QString string2 = getStringValue( values.at( 1 ), parent );
   return QVariant( QgsStringUtils::levenshteinDistance( string1, string2, true) );
 }
 
-static QVariant fcnLCS( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnLCS( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QString string1 = getStringValue( values.at( 0 ), parent );
   QString string2 = getStringValue( values.at( 1 ), parent );
   return QVariant( QgsStringUtils::longestCommonSubstring( string1, string2, true ) );
 }
 
-static QVariant fcnHamming( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnHamming( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QString string1 = getStringValue( values.at( 0 ), parent );
   QString string2 = getStringValue( values.at( 1 ), parent );
@@ -680,13 +680,13 @@ static QVariant fcnHamming( const QVariantList& values, const QgsFeature*, QgsEx
   return ( dist < 0 ? QVariant() : QVariant( QgsStringUtils::hammingDistance( string1, string2, true ) ) );
 }
 
-static QVariant fcnSoundex( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnSoundex( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QString string = getStringValue( values.at( 0 ), parent );
   return QVariant( QgsStringUtils::soundex( string ) );
 }
 
-static QVariant fcnWordwrap( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnWordwrap( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   if ( values.length() == 2 || values.length() == 3 )
   {
@@ -752,19 +752,19 @@ static QVariant fcnWordwrap( const QVariantList& values, const QgsFeature*, QgsE
   return QVariant();
 }
 
-static QVariant fcnLength( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnLength( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QString str = getStringValue( values.at( 0 ), parent );
   return QVariant( str.length() );
 }
-static QVariant fcnReplace( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnReplace( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QString str = getStringValue( values.at( 0 ), parent );
   QString before = getStringValue( values.at( 1 ), parent );
   QString after = getStringValue( values.at( 2 ), parent );
   return QVariant( str.replace( before, after ) );
 }
-static QVariant fcnRegexpReplace( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnRegexpReplace( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QString str = getStringValue( values.at( 0 ), parent );
   QString regexp = getStringValue( values.at( 1 ), parent );
@@ -779,7 +779,7 @@ static QVariant fcnRegexpReplace( const QVariantList& values, const QgsFeature*,
   return QVariant( str.replace( re, after ) );
 }
 
-static QVariant fcnRegexpMatch( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnRegexpMatch( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QString str = getStringValue( values.at( 0 ), parent );
   QString regexp = getStringValue( values.at( 1 ), parent );
@@ -793,7 +793,7 @@ static QVariant fcnRegexpMatch( const QVariantList& values, const QgsFeature*, Q
   return QVariant( str.contains( re ) ? 1 : 0 );
 }
 
-static QVariant fcnRegexpSubstr( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnRegexpSubstr( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QString str = getStringValue( values.at( 0 ), parent );
   QString regexp = getStringValue( values.at( 1 ), parent );
@@ -818,12 +818,12 @@ static QVariant fcnRegexpSubstr( const QVariantList& values, const QgsFeature*, 
   }
 }
 
-static QVariant fcnUuid( const QVariantList&, const QgsFeature*, QgsExpression* )
+static QVariant fcnUuid( const QVariantList&, const QgsFeature*, const QgsExpression* )
 {
   return QUuid::createUuid().toString();
 }
 
-static QVariant fcnSubstr( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnSubstr( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QString str = getStringValue( values.at( 0 ), parent );
   int from = getIntValue( values.at( 1 ), parent );
@@ -831,29 +831,29 @@ static QVariant fcnSubstr( const QVariantList& values, const QgsFeature*, QgsExp
   return QVariant( str.mid( from -1, len ) );
 }
 
-static QVariant fcnRowNumber( const QVariantList&, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnRowNumber( const QVariantList&, const QgsFeature*, const QgsExpression* parent )
 {
   return QVariant( parent->currentRowNumber() );
 }
 
-static QVariant fcnFeatureId( const QVariantList&, const QgsFeature* f, QgsExpression* )
+static QVariant fcnFeatureId( const QVariantList&, const QgsFeature* f, const QgsExpression* )
 {
   // TODO: handling of 64-bit feature ids?
   return f ? QVariant(( int )f->id() ) : QVariant();
 }
 
-static QVariant fcnFeature( const QVariantList&, const QgsFeature* f, QgsExpression* )
+static QVariant fcnFeature( const QVariantList&, const QgsFeature* f, const QgsExpression* )
 {
   return f ? QVariant::fromValue( *f ) : QVariant();
 }
-static QVariant fcnAttribute( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnAttribute( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QgsFeature feat = getFeature( values.at( 0 ), parent );
   QString attr = getStringValue( values.at( 1 ), parent );
 
   return feat.attribute( attr );
 }
-static QVariant fcnConcat( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnConcat( const QVariantList& values, const QgsFeature*, const QgsExpression *parent )
 {
   QString concat;
   foreach ( const QVariant &value, values )
@@ -863,27 +863,27 @@ static QVariant fcnConcat( const QVariantList& values, const QgsFeature*, QgsExp
   return concat;
 }
 
-static QVariant fcnStrpos( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnStrpos( const QVariantList& values, const QgsFeature*, const QgsExpression *parent )
 {
   QString string = getStringValue( values.at( 0 ), parent );
   return string.indexOf( QRegExp( getStringValue( values.at( 1 ), parent ) ) );
 }
 
-static QVariant fcnRight( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnRight( const QVariantList& values, const QgsFeature*, const QgsExpression *parent )
 {
   QString string = getStringValue( values.at( 0 ), parent );
   int pos = getIntValue( values.at( 1 ), parent );
   return string.right( pos );
 }
 
-static QVariant fcnLeft( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnLeft( const QVariantList& values, const QgsFeature*, const QgsExpression *parent )
 {
   QString string = getStringValue( values.at( 0 ), parent );
   int pos = getIntValue( values.at( 1 ), parent );
   return string.left( pos );
 }
 
-static QVariant fcnRPad( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnRPad( const QVariantList& values, const QgsFeature*, const QgsExpression *parent )
 {
   QString string = getStringValue( values.at( 0 ), parent );
   int length = getIntValue( values.at( 1 ), parent );
@@ -891,7 +891,7 @@ static QVariant fcnRPad( const QVariantList& values, const QgsFeature*, QgsExpre
   return string.leftJustified( length, fill.at( 0 ), true );
 }
 
-static QVariant fcnLPad( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnLPad( const QVariantList& values, const QgsFeature*, const QgsExpression *parent )
 {
   QString string = getStringValue( values.at( 0 ), parent );
   int length = getIntValue( values.at( 1 ), parent );
@@ -899,7 +899,7 @@ static QVariant fcnLPad( const QVariantList& values, const QgsFeature*, QgsExpre
   return string.rightJustified( length, fill.at( 0 ), true );
 }
 
-static QVariant fcnFormatString( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnFormatString( const QVariantList& values, const QgsFeature*, const QgsExpression *parent )
 {
   QString string = getStringValue( values.at( 0 ), parent );
   for ( int n = 1; n < values.length(); n++ )
@@ -910,27 +910,27 @@ static QVariant fcnFormatString( const QVariantList& values, const QgsFeature*, 
 }
 
 
-static QVariant fcnNow( const QVariantList&, const QgsFeature*, QgsExpression * )
+static QVariant fcnNow( const QVariantList&, const QgsFeature*, const QgsExpression * )
 {
   return QVariant( QDateTime::currentDateTime() );
 }
 
-static QVariant fcnToDate( const QVariantList& values, const QgsFeature*, QgsExpression * parent )
+static QVariant fcnToDate( const QVariantList& values, const QgsFeature*, const QgsExpression * parent )
 {
   return QVariant( getDateValue( values.at( 0 ), parent ) );
 }
 
-static QVariant fcnToTime( const QVariantList& values, const QgsFeature*, QgsExpression * parent )
+static QVariant fcnToTime( const QVariantList& values, const QgsFeature*, const QgsExpression * parent )
 {
   return QVariant( getTimeValue( values.at( 0 ), parent ) );
 }
 
-static QVariant fcnToInterval( const QVariantList& values, const QgsFeature*, QgsExpression * parent )
+static QVariant fcnToInterval( const QVariantList& values, const QgsFeature*, const QgsExpression * parent )
 {
   return QVariant::fromValue( getInterval( values.at( 0 ), parent ) );
 }
 
-static QVariant fcnAge( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnAge( const QVariantList& values, const QgsFeature*, const QgsExpression *parent )
 {
   QDateTime d1 = getDateTimeValue( values.at( 0 ), parent );
   QDateTime d2 = getDateTimeValue( values.at( 1 ), parent );
@@ -938,7 +938,7 @@ static QVariant fcnAge( const QVariantList& values, const QgsFeature*, QgsExpres
   return QVariant::fromValue( QgsExpression::Interval( seconds ) );
 }
 
-static QVariant fcnDay( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnDay( const QVariantList& values, const QgsFeature*, const QgsExpression *parent )
 {
   QVariant value = values.at( 0 );
   QgsExpression::Interval inter = getInterval( value, parent, false );
@@ -953,7 +953,7 @@ static QVariant fcnDay( const QVariantList& values, const QgsFeature*, QgsExpres
   }
 }
 
-static QVariant fcnYear( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnYear( const QVariantList& values, const QgsFeature*, const QgsExpression *parent )
 {
   QVariant value = values.at( 0 );
   QgsExpression::Interval inter = getInterval( value, parent, false );
@@ -968,7 +968,7 @@ static QVariant fcnYear( const QVariantList& values, const QgsFeature*, QgsExpre
   }
 }
 
-static QVariant fcnMonth( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnMonth( const QVariantList& values, const QgsFeature*, const QgsExpression *parent )
 {
   QVariant value = values.at( 0 );
   QgsExpression::Interval inter = getInterval( value, parent, false );
@@ -983,7 +983,7 @@ static QVariant fcnMonth( const QVariantList& values, const QgsFeature*, QgsExpr
   }
 }
 
-static QVariant fcnWeek( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnWeek( const QVariantList& values, const QgsFeature*, const QgsExpression *parent )
 {
   QVariant value = values.at( 0 );
   QgsExpression::Interval inter = getInterval( value, parent, false );
@@ -998,7 +998,7 @@ static QVariant fcnWeek( const QVariantList& values, const QgsFeature*, QgsExpre
   }
 }
 
-static QVariant fcnHour( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnHour( const QVariantList& values, const QgsFeature*, const QgsExpression *parent )
 {
   QVariant value = values.at( 0 );
   QgsExpression::Interval inter = getInterval( value, parent, false );
@@ -1013,7 +1013,7 @@ static QVariant fcnHour( const QVariantList& values, const QgsFeature*, QgsExpre
   }
 }
 
-static QVariant fcnMinute( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnMinute( const QVariantList& values, const QgsFeature*, const QgsExpression *parent )
 {
   QVariant value = values.at( 0 );
   QgsExpression::Interval inter = getInterval( value, parent, false );
@@ -1028,7 +1028,7 @@ static QVariant fcnMinute( const QVariantList& values, const QgsFeature*, QgsExp
   }
 }
 
-static QVariant fcnSeconds( const QVariantList& values, const QgsFeature*, QgsExpression *parent )
+static QVariant fcnSeconds( const QVariantList& values, const QgsFeature*, const QgsExpression *parent )
 {
   QVariant value = values.at( 0 );
   QgsExpression::Interval inter = getInterval( value, parent, false );
@@ -1049,7 +1049,7 @@ static QVariant fcnSeconds( const QVariantList& values, const QgsFeature*, QgsEx
   if (!g || g->type() != geomtype) return QVariant();
 
 
-static QVariant fcnX( const QVariantList&, const QgsFeature* f, QgsExpression* )
+static QVariant fcnX( const QVariantList&, const QgsFeature* f, const QgsExpression* )
 {
   ENSURE_GEOM_TYPE( f, g, QGis::Point );
   if ( g->isMultipart() )
@@ -1061,7 +1061,7 @@ static QVariant fcnX( const QVariantList&, const QgsFeature* f, QgsExpression* )
     return g->asPoint().x();
   }
 }
-static QVariant fcnY( const QVariantList&, const QgsFeature* f, QgsExpression* )
+static QVariant fcnY( const QVariantList&, const QgsFeature* f, const QgsExpression* )
 {
   ENSURE_GEOM_TYPE( f, g, QGis::Point );
   if ( g->isMultipart() )
@@ -1074,7 +1074,7 @@ static QVariant fcnY( const QVariantList&, const QgsFeature* f, QgsExpression* )
   }
 }
 
-static QVariant pointAt( const QVariantList& values, const QgsFeature* f, QgsExpression* parent ) // helper function
+static QVariant pointAt( const QVariantList& values, const QgsFeature* f, const QgsExpression* parent ) // helper function
 {
   int idx = getIntValue( values.at( 0 ), parent );
   ENSURE_GEOM_TYPE( f, g, QGis::Line );
@@ -1090,7 +1090,7 @@ static QVariant pointAt( const QVariantList& values, const QgsFeature* f, QgsExp
   return QVariant( QPointF( polyline[idx].x(), polyline[idx].y() ) );
 }
 
-static QVariant fcnXat( const QVariantList& values, const QgsFeature* f, QgsExpression* parent )
+static QVariant fcnXat( const QVariantList& values, const QgsFeature* f, const QgsExpression* parent )
 {
   QVariant v = pointAt( values, f, parent );
   if ( v.type() == QVariant::PointF )
@@ -1098,7 +1098,7 @@ static QVariant fcnXat( const QVariantList& values, const QgsFeature* f, QgsExpr
   else
     return QVariant();
 }
-static QVariant fcnYat( const QVariantList& values, const QgsFeature* f, QgsExpression* parent )
+static QVariant fcnYat( const QVariantList& values, const QgsFeature* f, const QgsExpression* parent )
 {
   QVariant v = pointAt( values, f, parent );
   if ( v.type() == QVariant::PointF )
@@ -1106,7 +1106,7 @@ static QVariant fcnYat( const QVariantList& values, const QgsFeature* f, QgsExpr
   else
     return QVariant();
 }
-static QVariant fcnGeometry( const QVariantList&, const QgsFeature* f, QgsExpression* )
+static QVariant fcnGeometry( const QVariantList&, const QgsFeature* f, const QgsExpression* )
 {
   const QgsGeometry* geom = f ? f->constGeometry() : 0;
   if ( geom )
@@ -1114,7 +1114,7 @@ static QVariant fcnGeometry( const QVariantList&, const QgsFeature* f, QgsExpres
   else
     return QVariant();
 }
-static QVariant fcnGeomFromWKT( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnGeomFromWKT( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QString wkt = getStringValue( values.at( 0 ), parent );
   QgsGeometry* geom = QgsGeometry::fromWkt( wkt );
@@ -1123,7 +1123,7 @@ static QVariant fcnGeomFromWKT( const QVariantList& values, const QgsFeature*, Q
   else
     return QVariant();
 }
-static QVariant fcnGeomFromGML( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnGeomFromGML( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QString gml = getStringValue( values.at( 0 ), parent );
   QgsGeometry* geom = QgsOgcUtils::geometryFromGML( gml );
@@ -1134,26 +1134,26 @@ static QVariant fcnGeomFromGML( const QVariantList& values, const QgsFeature*, Q
     return QVariant();
 }
 
-static QVariant fcnGeomArea( const QVariantList&, const QgsFeature* f, QgsExpression* parent )
+static QVariant fcnGeomArea( const QVariantList&, const QgsFeature* f, const QgsExpression* parent )
 {
   ENSURE_GEOM_TYPE( f, g, QGis::Polygon );
   QgsDistanceArea* calc = parent->geomCalculator();
   return QVariant( calc->measure( f->constGeometry() ) );
 }
-static QVariant fcnGeomLength( const QVariantList&, const QgsFeature* f, QgsExpression* parent )
+static QVariant fcnGeomLength( const QVariantList&, const QgsFeature* f, const QgsExpression* parent )
 {
   ENSURE_GEOM_TYPE( f, g, QGis::Line );
   QgsDistanceArea* calc = parent->geomCalculator();
   return QVariant( calc->measure( f->constGeometry() ) );
 }
-static QVariant fcnGeomPerimeter( const QVariantList&, const QgsFeature* f, QgsExpression* parent )
+static QVariant fcnGeomPerimeter( const QVariantList&, const QgsFeature* f, const QgsExpression* parent )
 {
   ENSURE_GEOM_TYPE( f, g, QGis::Polygon );
   QgsDistanceArea* calc = parent->geomCalculator();
   return QVariant( calc->measurePerimeter( f->constGeometry() ) );
 }
 
-static QVariant fcnBounds( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnBounds( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QgsGeometry geom = getGeometry( values.at( 0 ), parent );
   QgsGeometry* geomBounds = QgsGeometry::fromRect( geom.boundingBox() );
@@ -1167,91 +1167,91 @@ static QVariant fcnBounds( const QVariantList& values, const QgsFeature*, QgsExp
   }
 }
 
-static QVariant fcnBoundsWidth( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnBoundsWidth( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QgsGeometry geom = getGeometry( values.at( 0 ), parent );
   return QVariant::fromValue( geom.boundingBox().width() );
 }
 
-static QVariant fcnBoundsHeight( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnBoundsHeight( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QgsGeometry geom = getGeometry( values.at( 0 ), parent );
   return QVariant::fromValue( geom.boundingBox().height() );
 }
 
-static QVariant fcnXMin( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnXMin( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QgsGeometry geom = getGeometry( values.at( 0 ), parent );
   return QVariant::fromValue( geom.boundingBox().xMinimum() );
 }
 
-static QVariant fcnXMax( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnXMax( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QgsGeometry geom = getGeometry( values.at( 0 ), parent );
   return QVariant::fromValue( geom.boundingBox().xMaximum() );
 }
 
-static QVariant fcnYMin( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnYMin( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QgsGeometry geom = getGeometry( values.at( 0 ), parent );
   return QVariant::fromValue( geom.boundingBox().yMinimum() );
 }
 
-static QVariant fcnYMax( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnYMax( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QgsGeometry geom = getGeometry( values.at( 0 ), parent );
   return QVariant::fromValue( geom.boundingBox().yMaximum() );
 }
 
-static QVariant fcnBbox( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnBbox( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = getGeometry( values.at( 1 ), parent );
   return fGeom.intersects( sGeom.boundingBox() ) ? TVL_True : TVL_False;
 }
-static QVariant fcnDisjoint( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnDisjoint( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = getGeometry( values.at( 1 ), parent );
   return fGeom.disjoint( &sGeom ) ? TVL_True : TVL_False;
 }
-static QVariant fcnIntersects( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnIntersects( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = getGeometry( values.at( 1 ), parent );
   return fGeom.intersects( &sGeom ) ? TVL_True : TVL_False;
 }
-static QVariant fcnTouches( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnTouches( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = getGeometry( values.at( 1 ), parent );
   return fGeom.touches( &sGeom ) ? TVL_True : TVL_False;
 }
-static QVariant fcnCrosses( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnCrosses( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = getGeometry( values.at( 1 ), parent );
   return fGeom.crosses( &sGeom ) ? TVL_True : TVL_False;
 }
-static QVariant fcnContains( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnContains( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = getGeometry( values.at( 1 ), parent );
   return fGeom.contains( &sGeom ) ? TVL_True : TVL_False;
 }
-static QVariant fcnOverlaps( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnOverlaps( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = getGeometry( values.at( 1 ), parent );
   return fGeom.overlaps( &sGeom ) ? TVL_True : TVL_False;
 }
-static QVariant fcnWithin( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnWithin( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = getGeometry( values.at( 1 ), parent );
   return fGeom.within( &sGeom ) ? TVL_True : TVL_False;
 }
-static QVariant fcnBuffer( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnBuffer( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   if ( values.length() < 2 || values.length() > 3 )
     return QVariant();
@@ -1267,7 +1267,7 @@ static QVariant fcnBuffer( const QVariantList& values, const QgsFeature*, QgsExp
     return QVariant::fromValue( *geom );
   return QVariant();
 }
-static QVariant fcnCentroid( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnCentroid( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
   QgsGeometry* geom = fGeom.centroid();
@@ -1275,7 +1275,7 @@ static QVariant fcnCentroid( const QVariantList& values, const QgsFeature*, QgsE
     return QVariant::fromValue( *geom );
   return QVariant();
 }
-static QVariant fcnConvexHull( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnConvexHull( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
   QgsGeometry* geom = fGeom.convexHull();
@@ -1283,7 +1283,7 @@ static QVariant fcnConvexHull( const QVariantList& values, const QgsFeature*, Qg
     return QVariant::fromValue( *geom );
   return QVariant();
 }
-static QVariant fcnDifference( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnDifference( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = getGeometry( values.at( 1 ), parent );
@@ -1292,13 +1292,13 @@ static QVariant fcnDifference( const QVariantList& values, const QgsFeature*, Qg
     return QVariant::fromValue( *geom );
   return QVariant();
 }
-static QVariant fcnDistance( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnDistance( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = getGeometry( values.at( 1 ), parent );
   return QVariant( fGeom.distance( sGeom ) );
 }
-static QVariant fcnIntersection( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnIntersection( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = getGeometry( values.at( 1 ), parent );
@@ -1307,7 +1307,7 @@ static QVariant fcnIntersection( const QVariantList& values, const QgsFeature*, 
     return QVariant::fromValue( *geom );
   return QVariant();
 }
-static QVariant fcnSymDifference( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnSymDifference( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = getGeometry( values.at( 1 ), parent );
@@ -1316,7 +1316,7 @@ static QVariant fcnSymDifference( const QVariantList& values, const QgsFeature*,
     return QVariant::fromValue( *geom );
   return QVariant();
 }
-static QVariant fcnCombine( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnCombine( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
   QgsGeometry sGeom = getGeometry( values.at( 1 ), parent );
@@ -1325,7 +1325,7 @@ static QVariant fcnCombine( const QVariantList& values, const QgsFeature*, QgsEx
     return QVariant::fromValue( *geom );
   return QVariant();
 }
-static QVariant fcnGeomToWKT( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnGeomToWKT( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   if ( values.length() < 1 || values.length() > 2 )
     return QVariant();
@@ -1338,7 +1338,7 @@ static QVariant fcnGeomToWKT( const QVariantList& values, const QgsFeature*, Qgs
   return QVariant( wkt );
 }
 
-static QVariant fcnRound( const QVariantList& values, const QgsFeature *f, QgsExpression* parent )
+static QVariant fcnRound( const QVariantList& values, const QgsFeature *f, const QgsExpression* parent )
 {
   Q_UNUSED( f );
   if ( values.length() == 2 )
@@ -1357,7 +1357,7 @@ static QVariant fcnRound( const QVariantList& values, const QgsFeature *f, QgsEx
   return QVariant();
 }
 
-static QVariant fcnPi( const QVariantList& values, const QgsFeature *f, QgsExpression* parent )
+static QVariant fcnPi( const QVariantList& values, const QgsFeature *f, const QgsExpression* parent )
 {
   Q_UNUSED( values );
   Q_UNUSED( f );
@@ -1365,12 +1365,12 @@ static QVariant fcnPi( const QVariantList& values, const QgsFeature *f, QgsExpre
   return M_PI;
 }
 
-static QVariant fcnScale( const QVariantList&, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnScale( const QVariantList&, const QgsFeature*, const QgsExpression* parent )
 {
   return QVariant( parent->scale() );
 }
 
-static QVariant fcnFormatNumber( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnFormatNumber( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   double value = getDoubleValue( values.at( 0 ), parent );
   int places = getIntValue( values.at( 1 ), parent );
@@ -1382,14 +1382,14 @@ static QVariant fcnFormatNumber( const QVariantList& values, const QgsFeature*, 
   return QString( "%L1" ).arg( value, 0, 'f', places );
 }
 
-static QVariant fcnFormatDate( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnFormatDate( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QDateTime dt = getDateTimeValue( values.at( 0 ), parent );
   QString format = getStringValue( values.at( 1 ), parent );
   return dt.toString( format );
 }
 
-static QVariant fcnColorRgb( const QVariantList &values, const QgsFeature *, QgsExpression *parent )
+static QVariant fcnColorRgb( const QVariantList &values, const QgsFeature *, const QgsExpression *parent )
 {
   int red = getIntValue( values.at( 0 ), parent );
   int green = getIntValue( values.at( 1 ), parent );
@@ -1404,7 +1404,7 @@ static QVariant fcnColorRgb( const QVariantList &values, const QgsFeature *, Qgs
   return QString( "%1,%2,%3" ).arg( color.red() ).arg( color.green() ).arg( color.blue() );
 }
 
-static QVariant fcnIf( const QVariantList &values, const QgsFeature *f, QgsExpression *parent )
+static QVariant fcnIf( const QVariantList &values, const QgsFeature *f, const QgsExpression *parent )
 {
   QgsExpression::Node* node = getNode( values.at( 0 ), parent );
   ENSURE_NO_EVAL_ERROR;
@@ -1427,7 +1427,7 @@ static QVariant fcnIf( const QVariantList &values, const QgsFeature *f, QgsExpre
   return value;
 }
 
-static QVariant fncColorRgba( const QVariantList &values, const QgsFeature *, QgsExpression *parent )
+static QVariant fncColorRgba( const QVariantList &values, const QgsFeature *, const QgsExpression *parent )
 {
   int red = getIntValue( values.at( 0 ), parent );
   int green = getIntValue( values.at( 1 ), parent );
@@ -1442,7 +1442,7 @@ static QVariant fncColorRgba( const QVariantList &values, const QgsFeature *, Qg
   return QgsSymbolLayerV2Utils::encodeColor( color );
 }
 
-QVariant fcnRampColor( const QVariantList &values, const QgsFeature *, QgsExpression *parent )
+QVariant fcnRampColor( const QVariantList &values, const QgsFeature *, const QgsExpression *parent )
 {
   QString rampName = getStringValue( values.at( 0 ), parent );
   const QgsVectorColorRampV2 *mRamp = QgsStyleV2::defaultStyle()->colorRampRef( rampName );
@@ -1456,7 +1456,7 @@ QVariant fcnRampColor( const QVariantList &values, const QgsFeature *, QgsExpres
   return QgsSymbolLayerV2Utils::encodeColor( color );
 }
 
-static QVariant fcnColorHsl( const QVariantList &values, const QgsFeature *, QgsExpression *parent )
+static QVariant fcnColorHsl( const QVariantList &values, const QgsFeature *, const QgsExpression *parent )
 {
   // Hue ranges from 0 - 360
   double hue = getIntValue( values.at( 0 ), parent ) / 360.0;
@@ -1476,7 +1476,7 @@ static QVariant fcnColorHsl( const QVariantList &values, const QgsFeature *, Qgs
   return QString( "%1,%2,%3" ).arg( color.red() ).arg( color.green() ).arg( color.blue() );
 }
 
-static QVariant fncColorHsla( const QVariantList &values, const QgsFeature *, QgsExpression *parent )
+static QVariant fncColorHsla( const QVariantList &values, const QgsFeature *, const QgsExpression *parent )
 {
   // Hue ranges from 0 - 360
   double hue = getIntValue( values.at( 0 ), parent ) / 360.0;
@@ -1496,7 +1496,7 @@ static QVariant fncColorHsla( const QVariantList &values, const QgsFeature *, Qg
   return QgsSymbolLayerV2Utils::encodeColor( color );
 }
 
-static QVariant fcnColorHsv( const QVariantList &values, const QgsFeature *, QgsExpression *parent )
+static QVariant fcnColorHsv( const QVariantList &values, const QgsFeature *, const QgsExpression *parent )
 {
   // Hue ranges from 0 - 360
   double hue = getIntValue( values.at( 0 ), parent ) / 360.0;
@@ -1516,7 +1516,7 @@ static QVariant fcnColorHsv( const QVariantList &values, const QgsFeature *, Qgs
   return QString( "%1,%2,%3" ).arg( color.red() ).arg( color.green() ).arg( color.blue() );
 }
 
-static QVariant fncColorHsva( const QVariantList &values, const QgsFeature *, QgsExpression *parent )
+static QVariant fncColorHsva( const QVariantList &values, const QgsFeature *, const QgsExpression *parent )
 {
   // Hue ranges from 0 - 360
   double hue = getIntValue( values.at( 0 ), parent ) / 360.0;
@@ -1536,7 +1536,7 @@ static QVariant fncColorHsva( const QVariantList &values, const QgsFeature *, Qg
   return QgsSymbolLayerV2Utils::encodeColor( color );
 }
 
-static QVariant fcnColorCmyk( const QVariantList &values, const QgsFeature *, QgsExpression *parent )
+static QVariant fcnColorCmyk( const QVariantList &values, const QgsFeature *, const QgsExpression *parent )
 {
   // Cyan ranges from 0 - 100
   double cyan = getIntValue( values.at( 0 ), parent ) / 100.0;
@@ -1558,7 +1558,7 @@ static QVariant fcnColorCmyk( const QVariantList &values, const QgsFeature *, Qg
   return QString( "%1,%2,%3" ).arg( color.red() ).arg( color.green() ).arg( color.blue() );
 }
 
-static QVariant fncColorCmyka( const QVariantList &values, const QgsFeature *, QgsExpression *parent )
+static QVariant fncColorCmyka( const QVariantList &values, const QgsFeature *, const QgsExpression *parent )
 {
   // Cyan ranges from 0 - 100
   double cyan = getIntValue( values.at( 0 ), parent ) / 100.0;
@@ -1580,13 +1580,13 @@ static QVariant fncColorCmyka( const QVariantList &values, const QgsFeature *, Q
   return QgsSymbolLayerV2Utils::encodeColor( color );
 }
 
-static QVariant fcnSpecialColumn( const QVariantList& values, const QgsFeature* /*f*/, QgsExpression* parent )
+static QVariant fcnSpecialColumn( const QVariantList& values, const QgsFeature* /*f*/, const QgsExpression* parent )
 {
   QString varName = getStringValue( values.at( 0 ), parent );
   return QgsExpression::specialColumn( varName );
 }
 
-static QVariant fcnGetGeometry( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnGetGeometry( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QgsFeature feat = getFeature( values.at( 0 ), parent );
   const QgsGeometry* geom = feat.constGeometry();
@@ -1595,7 +1595,7 @@ static QVariant fcnGetGeometry( const QVariantList& values, const QgsFeature*, Q
   return QVariant();
 }
 
-static QVariant fcnTransformGeometry( const QVariantList& values, const QgsFeature*, QgsExpression* parent )
+static QVariant fcnTransformGeometry( const QVariantList& values, const QgsFeature*, const QgsExpression* parent )
 {
   QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
   QString sAuthId = getStringValue( values.at( 1 ), parent );
@@ -1614,7 +1614,7 @@ static QVariant fcnTransformGeometry( const QVariantList& values, const QgsFeatu
   return QVariant();
 }
 
-static QVariant fcnGetFeature( const QVariantList& values, const QgsFeature *, QgsExpression* parent )
+static QVariant fcnGetFeature( const QVariantList& values, const QgsFeature *, const QgsExpression* parent )
 {
   //arguments: 1. layer id / name, 2. key attribute, 3. eq value
   QString layerString = getStringValue( values.at( 0 ), parent );
@@ -2054,7 +2054,7 @@ bool QgsExpression::needsGeometry() const
   return mRootNode->needsGeometry();
 }
 
-void QgsExpression::initGeomCalculator()
+void QgsExpression::initGeomCalculator() const
 {
   if ( mCalc )
     return;
@@ -2070,7 +2070,7 @@ void QgsExpression::setGeomCalculator( const QgsDistanceArea &calc )
   mCalc = new QgsDistanceArea( calc );
 }
 
-bool QgsExpression::prepare( const QgsFields& fields )
+bool QgsExpression::prepare( const QgsFields& fields ) const
 {
   mEvalErrorString = QString();
   if ( !mRootNode )
@@ -2082,7 +2082,7 @@ bool QgsExpression::prepare( const QgsFields& fields )
   return mRootNode->prepare( this, fields );
 }
 
-QVariant QgsExpression::evaluate( const QgsFeature* f )
+QVariant QgsExpression::evaluate( const QgsFeature* f ) const
 {
   mEvalErrorString = QString();
   if ( !mRootNode )
@@ -2094,7 +2094,7 @@ QVariant QgsExpression::evaluate( const QgsFeature* f )
   return mRootNode->eval( this, f );
 }
 
-QVariant QgsExpression::evaluate( const QgsFeature* f, const QgsFields& fields )
+QVariant QgsExpression::evaluate( const QgsFeature* f, const QgsFields& fields ) const
 {
   // first prepare
   bool res = prepare( fields );
@@ -2238,7 +2238,7 @@ QString QgsExpression::NodeList::dump() const
 
 //
 
-QVariant QgsExpression::NodeUnaryOperator::eval( QgsExpression* parent, const QgsFeature* f )
+QVariant QgsExpression::NodeUnaryOperator::eval( const QgsExpression* parent, const QgsFeature* f ) const
 {
   QVariant val = mOperand->eval( parent, f );
   ENSURE_NO_EVAL_ERROR;
@@ -2266,7 +2266,7 @@ QVariant QgsExpression::NodeUnaryOperator::eval( QgsExpression* parent, const Qg
   return QVariant();
 }
 
-bool QgsExpression::NodeUnaryOperator::prepare( QgsExpression* parent, const QgsFields& fields )
+bool QgsExpression::NodeUnaryOperator::prepare( const QgsExpression* parent, const QgsFields& fields ) const
 {
   return mOperand->prepare( parent, fields );
 }
@@ -2278,7 +2278,7 @@ QString QgsExpression::NodeUnaryOperator::dump() const
 
 //
 
-QVariant QgsExpression::NodeBinaryOperator::eval( QgsExpression* parent, const QgsFeature* f )
+QVariant QgsExpression::NodeBinaryOperator::eval( const QgsExpression* parent, const QgsFeature* f ) const
 {
   QVariant vL = mOpLeft->eval( parent, f );
   ENSURE_NO_EVAL_ERROR;
@@ -2470,7 +2470,7 @@ QVariant QgsExpression::NodeBinaryOperator::eval( QgsExpression* parent, const Q
   return QVariant();
 }
 
-bool QgsExpression::NodeBinaryOperator::compare( double diff )
+bool QgsExpression::NodeBinaryOperator::compare( double diff ) const
 {
   switch ( mOp )
   {
@@ -2484,7 +2484,7 @@ bool QgsExpression::NodeBinaryOperator::compare( double diff )
   }
 }
 
-int QgsExpression::NodeBinaryOperator::computeInt( int x, int y )
+int QgsExpression::NodeBinaryOperator::computeInt( int x, int y ) const
 {
   switch ( mOp )
   {
@@ -2497,7 +2497,7 @@ int QgsExpression::NodeBinaryOperator::computeInt( int x, int y )
   }
 }
 
-QDateTime QgsExpression::NodeBinaryOperator::computeDateTimeFromInterval( QDateTime d, QgsExpression::Interval *i )
+QDateTime QgsExpression::NodeBinaryOperator::computeDateTimeFromInterval( QDateTime d, QgsExpression::Interval *i ) const
 {
   switch ( mOp )
   {
@@ -2507,7 +2507,7 @@ QDateTime QgsExpression::NodeBinaryOperator::computeDateTimeFromInterval( QDateT
   }
 }
 
-double QgsExpression::NodeBinaryOperator::computeDouble( double x, double y )
+double QgsExpression::NodeBinaryOperator::computeDouble( double x, double y ) const
 {
   switch ( mOp )
   {
@@ -2521,7 +2521,7 @@ double QgsExpression::NodeBinaryOperator::computeDouble( double x, double y )
 }
 
 
-bool QgsExpression::NodeBinaryOperator::prepare( QgsExpression* parent, const QgsFields& fields )
+bool QgsExpression::NodeBinaryOperator::prepare( const QgsExpression* parent, const QgsFields& fields ) const
 {
   bool resL = mOpLeft->prepare( parent, fields );
   bool resR = mOpRight->prepare( parent, fields );
@@ -2634,7 +2634,7 @@ QString QgsExpression::NodeBinaryOperator::dump() const
 
 //
 
-QVariant QgsExpression::NodeInOperator::eval( QgsExpression* parent, const QgsFeature* f )
+QVariant QgsExpression::NodeInOperator::eval( const QgsExpression* parent, const QgsFeature* f ) const
 {
   if ( mList->count() == 0 )
     return mNotIn ? TVL_True : TVL_False;
@@ -2680,7 +2680,7 @@ QVariant QgsExpression::NodeInOperator::eval( QgsExpression* parent, const QgsFe
     return mNotIn ? TVL_True : TVL_False;
 }
 
-bool QgsExpression::NodeInOperator::prepare( QgsExpression* parent, const QgsFields& fields )
+bool QgsExpression::NodeInOperator::prepare( const QgsExpression* parent, const QgsFields& fields ) const
 {
   bool res = mNode->prepare( parent, fields );
   foreach ( Node* n, mList->list() )
@@ -2697,7 +2697,7 @@ QString QgsExpression::NodeInOperator::dump() const
 
 //
 
-QVariant QgsExpression::NodeFunction::eval( QgsExpression* parent, const QgsFeature* f )
+QVariant QgsExpression::NodeFunction::eval( const QgsExpression* parent, const QgsFeature* f ) const
 {
   Function* fd = Functions()[mFnIndex];
 
@@ -2732,7 +2732,7 @@ QVariant QgsExpression::NodeFunction::eval( QgsExpression* parent, const QgsFeat
   return res;
 }
 
-bool QgsExpression::NodeFunction::prepare( QgsExpression* parent, const QgsFields& fields )
+bool QgsExpression::NodeFunction::prepare( const QgsExpression* parent, const QgsFields& fields ) const
 {
   bool res = true;
   if ( mArgs )
@@ -2776,12 +2776,12 @@ QStringList QgsExpression::NodeFunction::referencedColumns() const
 
 //
 
-QVariant QgsExpression::NodeLiteral::eval( QgsExpression*, const QgsFeature* )
+QVariant QgsExpression::NodeLiteral::eval( const QgsExpression*, const QgsFeature* ) const
 {
   return mValue;
 }
 
-bool QgsExpression::NodeLiteral::prepare( QgsExpression* /*parent*/, const QgsFields& /*fields*/ )
+bool QgsExpression::NodeLiteral::prepare( const QgsExpression* /*parent*/, const QgsFields& /*fields*/ ) const
 {
   return true;
 }
@@ -2803,7 +2803,7 @@ QString QgsExpression::NodeLiteral::dump() const
 
 //
 
-QVariant QgsExpression::NodeColumnRef::eval( QgsExpression* /*parent*/, const QgsFeature* f )
+QVariant QgsExpression::NodeColumnRef::eval( const QgsExpression* /*parent*/, const QgsFeature* f ) const
 {
   if ( f )
   {
@@ -2815,7 +2815,7 @@ QVariant QgsExpression::NodeColumnRef::eval( QgsExpression* /*parent*/, const Qg
   return QVariant( "[" + mName + "]" );
 }
 
-bool QgsExpression::NodeColumnRef::prepare( QgsExpression* parent, const QgsFields& fields )
+bool QgsExpression::NodeColumnRef::prepare( const QgsExpression* parent, const QgsFields& fields ) const
 {
   for ( int i = 0; i < fields.count(); ++i )
   {
@@ -2837,7 +2837,7 @@ QString QgsExpression::NodeColumnRef::dump() const
 
 //
 
-QVariant QgsExpression::NodeCondition::eval( QgsExpression* parent, const QgsFeature* f )
+QVariant QgsExpression::NodeCondition::eval( const QgsExpression* parent, const QgsFeature* f ) const
 {
   foreach ( WhenThen* cond, mConditions )
   {
@@ -2863,7 +2863,7 @@ QVariant QgsExpression::NodeCondition::eval( QgsExpression* parent, const QgsFea
   return QVariant();
 }
 
-bool QgsExpression::NodeCondition::prepare( QgsExpression* parent, const QgsFields& fields )
+bool QgsExpression::NodeCondition::prepare( const QgsExpression* parent, const QgsFields& fields ) const
 {
   bool res;
   foreach ( WhenThen* cond, mConditions )


### PR DESCRIPTION
The previous (unsync) PR was #2184, and some discussions started there.

Conceptually, evaluating an expression does not have to "modify" it.
evaluate() did write to some members to carry errors, which are now
tagged as mutable. In a future version, this could be replaced by an
evaluation function that returns the errors somehow.
Similarly, prepare() which is used for optimisation is a good place for
being tagged mutable.
