### PR TITLE
fix #13067 : bad geometries in the difference tool

### DIFF
--- a/python/plugins/fTools/tools/doGeoprocessing.py
+++ b/python/plugins/fTools/tools/doGeoprocessing.py
@@ -893,6 +893,10 @@ class geoprocessingThread( QThread ):
             try:
               if diff_geom.intersects( tmpGeom ):
                 diff_geom = QgsGeometry( diff_geom.difference( tmpGeom ) )
+              if diff_geom.isGeosEmpty():
+                GEOS_EXCEPT = False
+                add = False
+                break
             except:
               GEOS_EXCEPT = False
               add = False

--- a/python/plugins/processing/algs/qgis/Difference.py
+++ b/python/plugins/processing/algs/qgis/Difference.py
@@ -92,6 +92,10 @@ class Difference(GeoAlgorithm):
                 try:
                     if diff_geom.intersects(tmpGeom):
                         diff_geom = QgsGeometry(diff_geom.difference(tmpGeom))
+                    if diff_geom.isGeosEmpty():
+                        GEOS_EXCEPT = False
+                        add = False
+                        break
                 except:
                     GEOS_EXCEPT = False
                     add = False


### PR DESCRIPTION
Ticket : http://hub.qgis.org/issues/13067

It seems that the new geometry class doesn't raise an exception if the geometry is null.
However, the "difference" algorithm was skipping the feature only if it caught an exception.
With @timlinux we decided to fix this issue by checking the validity of the geometry.
