### PR TITLE
Backport 2.10 #13067 : bad geometries in the difference tool

### DIFF
--- a/python/plugins/fTools/tools/doGeoprocessing.py
+++ b/python/plugins/fTools/tools/doGeoprocessing.py
@@ -893,6 +893,10 @@ class geoprocessingThread( QThread ):
             try:
               if diff_geom.intersects( tmpGeom ):
                 diff_geom = QgsGeometry( diff_geom.difference( tmpGeom ) )
+              if diff_geom.isGeosEmpty():
+                GEOS_EXCEPT = False
+                add = False
+                break
             except:
               GEOS_EXCEPT = False
               add = False

--- a/python/plugins/processing/algs/qgis/Difference.py
+++ b/python/plugins/processing/algs/qgis/Difference.py
@@ -92,6 +92,10 @@ class Difference(GeoAlgorithm):
                 try:
                     if diff_geom.intersects(tmpGeom):
                         diff_geom = QgsGeometry(diff_geom.difference(tmpGeom))
+                    if diff_geom.isGeosEmpty():
+                        GEOS_EXCEPT = False
+                        add = False
+                        break
                 except:
                     GEOS_EXCEPT = False
                     add = False


### PR DESCRIPTION
Backport https://github.com/qgis/QGIS/pull/2192 to 2.10

Ticket : http://hub.qgis.org/issues/13067

It seems that the new geometry class doesn't raise an exception if the geometry is null.
However, the "difference" algorithm was skipping the feature only if it caught an exception.

CC : @jef-n 
