### PR TITLE
Add QgsConnectionPool::dropConnections, delete connection groups when pool is destroyed

### DIFF
--- a/src/core/qgsconnectionpool.h
+++ b/src/core/qgsconnectionpool.h
@@ -228,6 +228,17 @@ class QgsConnectionPool
 
     typedef QMap<QString, T_Group*> T_Groups;
 
+    virtual ~QgsConnectionPool()
+    {
+      mMutex.lock();
+      foreach ( T_Group* group, mGroups )
+      {
+        delete group;
+      }
+      mGroups.clear();
+      mMutex.unlock();
+    }
+
     //! Try to acquire a connection: if no connections are available, the thread will get blocked.
     //! @return initialized connection or null on error
     T acquireConnection( const QString& connInfo )

--- a/src/providers/ogr/qgsogrfeatureiterator.cpp
+++ b/src/providers/ogr/qgsogrfeatureiterator.cpp
@@ -342,6 +342,12 @@ QgsOgrFeatureSource::QgsOgrFeatureSource( const QgsOgrProvider* p )
   mFields = p->mAttributeFields;
   mDriverName = p->ogrDriverName;
   mOgrGeometryTypeFilter = wkbFlatten( p->mOgrGeometryTypeFilter );
+  QgsOgrConnPool::instance()->ref( mFilePath );
+}
+
+QgsOgrFeatureSource::~QgsOgrFeatureSource()
+{
+  QgsOgrConnPool::instance()->unref( mFilePath );
 }
 
 QgsFeatureIterator QgsOgrFeatureSource::getFeatures( const QgsFeatureRequest& request )

--- a/src/providers/ogr/qgsogrfeatureiterator.h
+++ b/src/providers/ogr/qgsogrfeatureiterator.h
@@ -28,6 +28,7 @@ class QgsOgrFeatureSource : public QgsAbstractFeatureSource
 {
   public:
     QgsOgrFeatureSource( const QgsOgrProvider* p );
+    ~QgsOgrFeatureSource();
 
     virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest& request ) override;
 

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -450,6 +450,8 @@ QgsOgrProvider::QgsOgrProvider( QString const & uri )
     mNativeTypes
     << QgsVectorDataProvider::NativeType( tr( "Date & Time" ), "datetime", QVariant::DateTime );
   }
+
+  QgsOgrConnPool::instance()->ref( mFilePath );
 }
 
 QgsOgrProvider::~QgsOgrProvider()
@@ -470,6 +472,8 @@ QgsOgrProvider::~QgsOgrProvider()
     free( extent_ );
     extent_ = 0;
   }
+
+  QgsOgrConnPool::instance()->unref( mFilePath );
 }
 
 QgsAbstractFeatureSource* QgsOgrProvider::featureSource() const


### PR DESCRIPTION
First commit should fix #13082 by adding a `QgsConnectionPool::dropConnections` method to force dropping all connections to a resource.

Second commit ensures allocated `QgsConnectionPoolGroup`s are destroyed together with the parent `QgsConnectionPool`.
