### PR TITLE
Add export as SVG/PNG to style manager

### DIFF
--- a/src/core/symbology-ng/qgsstylev2.cpp
+++ b/src/core/symbology-ng/qgsstylev2.cpp
@@ -30,6 +30,7 @@
 #include <QFile>
 #include <QTextStream>
 #include <QByteArray>
+#include <QSvgGenerator>
 
 #include <sqlite3.h>
 
@@ -133,6 +134,31 @@ bool QgsStyleV2::saveSymbol( QString name, QgsSymbolV2* symbol, int groupid, QSt
   emit symbolSaved( name, symbol );
 
   return true;
+}
+
+void QgsStyleV2::exportSymbol( QString folder, QString name, QString format, QSize size )
+{
+  QString fullname = folder + "/" + name + "." + format;
+  QgsSymbolV2 *sym = symbol( name );
+  if ( format.toLower() == "svg" )
+  {
+    QSvgGenerator generator;
+    generator.setFileName( fullname );
+    generator.setSize( size );
+    generator.setViewBox( QRect( 0, 0, size.height(), size.height() ) );
+    generator.setTitle( name );
+    generator.setDescription( tr( "Exported symbol from QGIS" ) );
+
+
+    QPainter painter( &generator );
+    sym->drawPreviewIcon( &painter, size );
+    painter.end();
+  }
+  else
+  {
+    QImage image = sym->asImage( size );
+    image.save( fullname );
+  }
 }
 
 bool QgsStyleV2::removeSymbol( QString name )

--- a/src/core/symbology-ng/qgsstylev2.h
+++ b/src/core/symbology-ng/qgsstylev2.h
@@ -167,6 +167,9 @@ class CORE_EXPORT QgsStyleV2 : public QObject
      */
     bool detagSymbol( StyleEntity type, QString symbol, QStringList tags );
 
+    //! export symbol as image
+    void exportSymbol( QString path, QString name, QString format, QSize size );
+
     //! remove symbol from style (and delete it)
     bool removeSymbol( QString name );
 

--- a/src/gui/symbology-ng/qgsstylev2managerdialog.cpp
+++ b/src/gui/symbology-ng/qgsstylev2managerdialog.cpp
@@ -40,7 +40,6 @@
 #include "qgsapplication.h"
 #include "qgslogger.h"
 
-
 QgsStyleV2ManagerDialog::QgsStyleV2ManagerDialog( QgsStyleV2* style, QWidget* parent )
     : QDialog( parent ), mStyle( style ), mModified( false )
 {
@@ -66,10 +65,16 @@ QgsStyleV2ManagerDialog::QgsStyleV2ManagerDialog( QgsStyleV2* style, QWidget* pa
   connect( btnRemoveItem, SIGNAL( clicked() ), this, SLOT( removeItem() ) );
 
   QMenu *shareMenu = new QMenu( tr( "Share Menu" ), this );
+  QAction *exportAsPNGAction = shareMenu->addAction( tr( "Export as PNG" ) );
+  QAction *exportAsSVGAction = shareMenu->addAction( tr( "Export as SVG" ) );
   QAction *exportAction = shareMenu->addAction( tr( "Export" ) );
   QAction *importAction = shareMenu->addAction( tr( "Import" ) );
+  exportAsPNGAction->setIcon( QIcon( QgsApplication::iconPath( "mActionSharingExport.svg" ) ) );
+  exportAsSVGAction->setIcon( QIcon( QgsApplication::iconPath( "mActionSharingExport.svg" ) ) );
   exportAction->setIcon( QIcon( QgsApplication::iconPath( "mActionSharingExport.svg" ) ) );
   importAction->setIcon( QIcon( QgsApplication::iconPath( "mActionSharingImport.svg" ) ) );
+  connect( exportAsPNGAction, SIGNAL( triggered() ), this, SLOT( exportItemsPNG() ) );
+  connect( exportAsSVGAction, SIGNAL( triggered() ), this, SLOT( exportItemsSVG() ) );
   connect( exportAction, SIGNAL( triggered() ), this, SLOT( exportItems() ) );
   connect( importAction, SIGNAL( triggered() ), this, SLOT( importItems() ) );
   btnShare->setMenu( shareMenu );
@@ -727,6 +732,38 @@ void QgsStyleV2ManagerDialog::itemChanged( QStandardItem* item )
     QMessageBox::critical( this, tr( "Cannot rename item" ),
                            tr( "Name is already taken by another item. Choose a different name." ) );
     item->setText( oldName );
+  }
+}
+
+void QgsStyleV2ManagerDialog::exportItemsPNG()
+{
+  QString dir = QFileDialog::getExistingDirectory( this, tr( "Exported selected symbols as PNG" ),
+                QDir::home().absolutePath(),
+                QFileDialog::ShowDirsOnly
+                | QFileDialog::DontResolveSymlinks );
+  exportSelectedItemsImages( dir, "png", QSize( 32, 32 ) );
+}
+
+void QgsStyleV2ManagerDialog::exportItemsSVG()
+{
+  QString dir = QFileDialog::getExistingDirectory( this, tr( "Exported selected symbols as SVG" ),
+                QDir::home().absolutePath(),
+                QFileDialog::ShowDirsOnly
+                | QFileDialog::DontResolveSymlinks );
+  exportSelectedItemsImages( dir, "svg", QSize( 32, 32 ) );
+}
+
+
+void QgsStyleV2ManagerDialog::exportSelectedItemsImages( QString dir, QString format, QSize size )
+{
+  if ( dir.isEmpty() )
+    return;
+
+  QModelIndexList indexes =  listItems->selectionModel()->selection().indexes();
+  foreach ( QModelIndex index, indexes )
+  {
+    QString name = index.data().toString();
+    mStyle->exportSymbol( dir, name, format, size );
   }
 }
 

--- a/src/gui/symbology-ng/qgsstylev2managerdialog.h
+++ b/src/gui/symbology-ng/qgsstylev2managerdialog.h
@@ -41,6 +41,9 @@ class GUI_EXPORT QgsStyleV2ManagerDialog : public QDialog, private Ui::QgsStyleV
     void addItem();
     void editItem();
     void removeItem();
+    void exportItemsSVG();
+    void exportItemsPNG();
+    void exportSelectedItemsImages( QString dir, QString format, QSize size );
     void exportItems();
     void importItems();
 


### PR DESCRIPTION
This PR adds Export as PNG and Export as SVG options to the symbol manager to export selected items to images. Quite handy for custom legends, documents, etc

This isn't a complete PR and still needs work.  Pushed for early review and ideas.

TODO
- [ ]   SIP Bindings
- [ ]   Rename normal Export -> "Export to style file"
