### PR TITLE
Symbols in attribute table.

### DIFF
--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -506,7 +506,10 @@ QVariant QgsAttributeTableModel::headerData( int section, Qt::Orientation orient
     layer()->rendererV2()->startRender( ctx, layer()->pendingFields() );
     QgsSymbolV2List symbols = layer()->rendererV2()->symbolsForFeature( feature );
     if ( symbols.count() == 0 )
+      {
+    layer()->rendererV2()->stopRender( ctx );
       return 0;
+      }
 
     QgsSymbolV2* symbol = symbols.first();
     QPixmap pix = QgsSymbolLayerV2Utils::symbolPreviewPixmap( symbol, mIconSize );

--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -495,14 +495,19 @@ QVariant QgsAttributeTableModel::headerData( int section, Qt::Orientation orient
       return tr( "feature id" );
     }
   }
-  else if ( role == Qt::DecorationRole && orientation == Qt::Vertical )
+  else if ( role == Qt::DecorationRole
+            && orientation == Qt::Vertical
+            && layer()->geometryType() != QGis::NoGeometry )
   {
     QgsRenderContext ctx;
-    layer()->rendererV2()->startRender( ctx, layer()->pendingFields() );
-    QgsFeatureId id = mRowIdMap[section];
     QgsFeature feature;
-    mLayerCache->featureAtId( id, feature );
+    mLayerCache->featureAtId( mRowIdMap[section], feature );
+
+    layer()->rendererV2()->startRender( ctx, layer()->pendingFields() );
     QgsSymbolV2List symbols = layer()->rendererV2()->symbolsForFeature( feature );
+    if ( symbols.count() == 0 )
+      return 0;
+
     QgsSymbolV2* symbol = symbols.first();
     QPixmap pix = QgsSymbolLayerV2Utils::symbolPreviewPixmap( symbol, mIconSize );
     layer()->rendererV2()->stopRender( ctx );

--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -236,6 +236,7 @@ void QgsAttributeTableModel::layerDeleted()
   mAttributeWidgetCaches.clear();
   mAttributes.clear();
   mWidgetFactories.clear();
+  mWidgetConfigs.clear();
 }
 
 void QgsAttributeTableModel::attributeValueChanged( QgsFeatureId fid, int idx, const QVariant &value )

--- a/src/gui/attributetable/qgsattributetablemodel.h
+++ b/src/gui/attributetable/qgsattributetablemodel.h
@@ -292,7 +292,6 @@ class GUI_EXPORT QgsAttributeTableModel: public QAbstractTableModel
 
     QHash<QgsFeatureId, int> mIdRowMap;
     QHash<int, QgsFeatureId> mRowIdMap;
-    QHash<int, QPixmap> mRowImageMap;
 
     /**
       * Gets mFieldCount, mAttributes and mValueMaps
@@ -315,6 +314,8 @@ class GUI_EXPORT QgsAttributeTableModel: public QAbstractTableModel
     int mCachedField;
     /** Allows caching of one specific column (used for sorting) */
     QHash<QgsFeatureId, QVariant> mFieldCache;
+
+    QSize mIconSize;
 
     /**
      * Holds the bounds of changed cells while an update operation is running

--- a/src/gui/attributetable/qgsattributetablemodel.h
+++ b/src/gui/attributetable/qgsattributetablemodel.h
@@ -292,6 +292,7 @@ class GUI_EXPORT QgsAttributeTableModel: public QAbstractTableModel
 
     QHash<QgsFeatureId, int> mIdRowMap;
     QHash<int, QgsFeatureId> mRowIdMap;
+    QHash<int, QPixmap> mRowImageMap;
 
     /**
       * Gets mFieldCount, mAttributes and mValueMaps


### PR DESCRIPTION
Review only - not for merge yet.

This PR adds symbol icons for each feature to the header row of the attribute table.  I thought this was a cool idea to tie the feature in the table to the feature in the map.

![image](https://cloud.githubusercontent.com/assets/381660/8590074/426ba792-2660-11e5-9fe3-cd28fc833471.png)

![image](https://cloud.githubusercontent.com/assets/381660/8590085/6a47cbec-2660-11e5-84fb-9a8f38f8d9d2.png)

![image](https://cloud.githubusercontent.com/assets/381660/8590107/9c5ab568-2660-11e5-9716-58785fb6ba38.png)

Is very cool when you have `Show Visible Features on Map` set in the attribute table.

Looking for people to test performance.  Doesn't seem to have much effect on my datasets.
