### PR TITLE
Increase mDefaultMaxLayers

### DIFF
--- a/src/server/qgsmslayercache.cpp
+++ b/src/server/qgsmslayercache.cpp
@@ -30,7 +30,7 @@ QgsMSLayerCache* QgsMSLayerCache::instance()
 QgsMSLayerCache::QgsMSLayerCache()
     : mProjectMaxLayers( 0 )
 {
-  mDefaultMaxLayers = 100;
+  mDefaultMaxLayers = 500;
   //max layer from environment variable overrides default
   char* maxLayerEnv = getenv( "MAX_CACHE_LAYERS" );
   if ( maxLayerEnv )


### PR DESCRIPTION
I would like to see the mDefaultMaxLayers value increased. 100 is too low; for i.e. mapServer has a 255 limit. We could put it to 500?
