### PR TITLE
Preserve 0/NULL values from postgres int columns

### DIFF
--- a/python/core/qgsfeature.sip
+++ b/python/core/qgsfeature.sip
@@ -1,15 +1,13 @@
 
 typedef qint64 QgsFeatureId;
-
-// key = field index, value = field value
 typedef QMap<int, QVariant> QgsAttributeMap;
-
 typedef QVector<QVariant> QgsAttributes;
+
 // QgsAttributes is implemented as a Python list of Python objects.
 %MappedType QgsAttributes /DocType="list-of-attributes"/
 {
 %TypeHeaderCode
-#include <qvector.h>
+#include <qgsfeature.h>
 %End
 
 %ConvertFromTypeCode
@@ -53,7 +51,7 @@ typedef QVector<QVariant> QgsAttributes;
       return 1;
     }
 
-    QVector<QVariant> *qv = new QVector<QVariant>;
+    QgsAttributes* qv = new QgsAttributes;
 
     for (SIP_SSIZE_T i = 0; i < PyList_GET_SIZE(sipPy); ++i)
     {

--- a/src/core/qgsfeature.h
+++ b/src/core/qgsfeature.h
@@ -103,7 +103,50 @@ typedef int QgsFeatureId;
 // key = field index, value = field value
 typedef QMap<int, QVariant> QgsAttributeMap;
 
-typedef QVector<QVariant> QgsAttributes;
+/**
+ * A vector of attributes. Mostly equal to QVector<QVariant>.
+ */
+class CORE_EXPORT QgsAttributes : public QVector<QVariant>
+{
+  public:
+    QgsAttributes()
+        : QVector<QVariant>()
+    {}
+    QgsAttributes( int size )
+        : QVector<QVariant>( size )
+    {}
+    QgsAttributes( int size, const QVariant& v )
+        : QVector<QVariant>( size, v )
+    {}
+
+    QgsAttributes( const QVector<QVariant>& v )
+        : QVector<QVariant>( v )
+    {}
+
+    /**
+     * @brief Compares two vectors of attributes.
+     * They are considered equal if all their members contain the same value and NULL flag.
+     * This was introduced because the default Qt implementation of QVariant comparison does not
+     * handle NULL values for certain types (like int).
+     *
+     * @param v The attributes to compare
+     * @return True if v is equal
+     */
+    bool operator==( const QgsAttributes &v ) const
+    {
+      if ( size() != v.size() )
+        return false;
+      const QVariant* b = constData();
+      const QVariant* i = b + size();
+      const QVariant* j = v.constData() + size();
+      while ( i != b )
+        if ( !( *--i == *--j && i->isNull() == j->isNull() ) )
+          return false;
+      return true;
+    }
+
+    inline bool operator!=( const QgsAttributes &v ) const { return !( *this == v ); }
+};
 
 class QgsField;
 

--- a/src/providers/postgres/qgspostgresfeatureiterator.cpp
+++ b/src/providers/postgres/qgspostgresfeatureiterator.cpp
@@ -158,21 +158,7 @@ bool QgsPostgresFeatureIterator::fetchFeature( QgsFeature& feature )
     return false;
   }
 
-  // Now return the next feature from the queue
-  if ( !mFetchGeometry )
-  {
-    feature.setGeometryAndOwnership( 0, 0 );
-  }
-  else
-  {
-    Q_NOWARN_DEPRECATED_PUSH
-    feature.setGeometry( mFeatureQueue.front().geometryAndOwnership() );
-    Q_NOWARN_DEPRECATED_POP
-  }
-  feature.setFeatureId( mFeatureQueue.front().id() );
-  feature.setAttributes( mFeatureQueue.front().attributes() );
-
-  mFeatureQueue.dequeue();
+  feature = mFeatureQueue.dequeue();
   mFetched++;
 
   feature.setValid( true );

--- a/tests/src/python/test_qgsfeature.py
+++ b/tests/src/python/test_qgsfeature.py
@@ -15,12 +15,14 @@ __revision__ = '$Format:%H$'
 import qgis
 import os
 
-from qgis.core import QgsFeature, QgsGeometry, QgsPoint, QgsVectorLayer
+from qgis.core import QgsFeature, QgsGeometry, QgsPoint, QgsVectorLayer, NULL
 from utilities import (unitTestDataPath,
                        getQgisTestApp,
                        TestCase,
                        unittest
                        )
+from unittest import expectedFailure
+
 QGISAPP, CANVAS, IFACE, PARENT = getQgisTestApp()
 
 
@@ -67,6 +69,14 @@ class TestQgsFeature(TestCase):
         )
 
         assert myAttributes == myExpectedAttributes, myMessage
+
+    @expectedFailure
+    def test_SetAttribute(self):
+        feat = QgsFeature()
+        feat.initAttributes(1)
+        feat.setAttributes([0])
+        feat.setAttributes([NULL])
+        assert [NULL] == feat.attributes()
 
     def test_DeleteAttribute(self):
         feat = QgsFeature()

--- a/tests/src/python/test_qgsfeature.py
+++ b/tests/src/python/test_qgsfeature.py
@@ -70,7 +70,6 @@ class TestQgsFeature(TestCase):
 
         assert myAttributes == myExpectedAttributes, myMessage
 
-    @expectedFailure
     def test_SetAttribute(self):
         feat = QgsFeature()
         feat.initAttributes(1)


### PR DESCRIPTION
Actually, the headline only says half of it. I think this patch is fine to apply but it does not solve the underlying problem.

It seems that the check on this line here fails to properly distinguish 0 from NULL in the attributes
https://github.com/qgis/QGIS/blob/master/src/core/qgsfeature.cpp#L97

We could as well remove the check and have some unnecessary detaches happen once in a while (not sure how often or bad that would be).

The underlying problem is that IIRC Qt returns true for `QVariant(int) == QVariant(0)` a thing that should be solved upstream. We could maybe implement our own helper method to compare QVariants and have it take care of such things.

@jef-n assigning you since you are the postgres provider wizard.

Thoughts?
