### PR TITLE
Changes about pseudocolor raster shader; when qreal is float not double and etc

### DIFF
--- a/src/core/geometry/qgscircularstringv2.cpp
+++ b/src/core/geometry/qgscircularstringv2.cpp
@@ -603,13 +603,9 @@ void QgsCircularStringV2::transform( const QTransform& t )
   int nPoints = numPoints();
   for ( int i = 0; i < nPoints; ++i )
   {
-#ifdef QT_ARCH_ARM
     qreal x, y;
     t.map( mX[i], mY[i], &x, &y );
     mX[i] = x; mY[i] = y;
-#else
-    t.map( mX[i], mY[i], &mX[i], &mY[i] );
-#endif
   }
 }
 

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -44,7 +44,7 @@ email                : morb at ozemail dot com dot au
 #include "qgspolygonv2.h"
 #include "qgslinestringv2.h"
 
-#ifndef Q_OS_WIN32
+#ifndef Q_OS_WIN
 #include <netinet/in.h>
 #else
 #include <winsock.h>

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -44,7 +44,7 @@ email                : morb at ozemail dot com dot au
 #include "qgspolygonv2.h"
 #include "qgslinestringv2.h"
 
-#ifndef Q_WS_WIN
+#ifndef Q_OS_WIN32
 #include <netinet/in.h>
 #else
 #include <winsock.h>

--- a/src/core/geometry/qgspointv2.cpp
+++ b/src/core/geometry/qgspointv2.cpp
@@ -241,11 +241,7 @@ bool QgsPointV2::nextVertex( QgsVertexId& id, QgsPointV2& vertex ) const
 
 void QgsPointV2::transform( const QTransform& t )
 {
-#ifdef QT_ARCH_ARM
   qreal x, y;
   t.map( mX, mY, &x, &y );
   mX = x; mY = y;
-#else
-  t.map( mX, mY, &mX, &mY );
-#endif
 }

--- a/src/core/geometry/qgswkbptr.h
+++ b/src/core/geometry/qgswkbptr.h
@@ -47,14 +47,12 @@ class CORE_EXPORT QgsConstWkbPtr
     QgsWKBTypes::Type readHeader() const;
 
     inline const QgsConstWkbPtr &operator>>( double &v ) const { read( v ); return *this; }
-    inline const QgsConstWkbPtr &operator>>( int &v ) const { read( v ); return *this; }
+    inline const QgsConstWkbPtr &operator>>( float &r ) const { double v; read(v); r = v; return *this; }
+    inline const QgsConstWkbPtr &operator>>(int &v) const { read(v); return *this; }
     inline const QgsConstWkbPtr &operator>>( unsigned int &v ) const { read( v ); return *this; }
     inline const QgsConstWkbPtr &operator>>( char &v ) const { read( v ); return *this; }
     inline const QgsConstWkbPtr &operator>>( QGis::WkbType &v ) const { read( v ); return *this; }
     inline const QgsConstWkbPtr &operator>>( QgsWKBTypes::Type &v ) const { read( v ); return *this; }
-#ifdef QT_ARCH_ARM
-    inline const QgsConstWkbPtr &operator>>( qreal &r ) const { double v; read( v ); r = v; return *this; }
-#endif
 
     inline void operator+=( int n ) { mP += n; }
     inline void operator-=( int n ) { mP -= n; }

--- a/src/core/layertree/qgslayertreemodel.cpp
+++ b/src/core/layertree/qgslayertreemodel.cpp
@@ -477,6 +477,8 @@ void QgsLayerTreeModel::refreshLayerLegend( QgsLayerTreeLayer* nodeLayer )
 
   // update children
   int oldNodeCount = rowCount( idx );
+  if (oldNodeCount == 0) // In case of EmbeddedInParent (in vector layers without children)
+     ++oldNodeCount;
   beginRemoveRows( idx, 0, oldNodeCount - 1 );
   removeLegendFromLayer( nodeLayer );
   endRemoveRows();

--- a/src/core/layertree/qgslayertreemodel.cpp
+++ b/src/core/layertree/qgslayertreemodel.cpp
@@ -477,8 +477,6 @@ void QgsLayerTreeModel::refreshLayerLegend( QgsLayerTreeLayer* nodeLayer )
 
   // update children
   int oldNodeCount = rowCount( idx );
-  if (oldNodeCount == 0) // In case of EmbeddedInParent (in vector layers without children)
-     ++oldNodeCount;
   beginRemoveRows( idx, 0, oldNodeCount - 1 );
   removeLegendFromLayer( nodeLayer );
   endRemoveRows();

--- a/src/core/qgscoordinatetransform.cpp
+++ b/src/core/qgscoordinatetransform.cpp
@@ -369,7 +369,43 @@ void QgsCoordinateTransform::transformInPlace( double& x, double& y, double& z,
   }
 }
 
-void QgsCoordinateTransform::transformPolygon( QPolygonF& poly, TransformDirection direction ) const
+void QgsCoordinateTransform::transformInPlace(float& x, float& y, double& z,
+   TransformDirection direction) const
+{
+   double xd = (double)x, yd = (double)y;
+   transformInPlace(xd, yd, z, direction);
+   x = xd;
+   y = yd;
+}
+
+void QgsCoordinateTransform::transformInPlace(float& x, float& y, float& z,
+   TransformDirection direction) const
+{
+   if (mShortCircuit || !mInitialisedFlag)
+      return;
+#ifdef QGISDEBUG
+   // QgsDebugMsg(QString("Using transform in place %1 %2").arg(__FILE__).arg(__LINE__));
+#endif
+   // transform x
+   try
+   {
+      double xd = x;
+      double yd = y;
+      double zd = z;
+      transformCoords(1, &xd, &yd, &zd, direction);
+      x = xd;
+      y = yd;
+      z = zd;
+   }
+   catch (QgsCsException &)
+   {
+      // rethrow the exception
+      QgsDebugMsg("rethrowing exception");
+      throw;
+   }
+}
+
+void QgsCoordinateTransform::transformPolygon(QPolygonF& poly, TransformDirection direction) const
 {
   if ( mShortCircuit || !mInitialisedFlag )
   {
@@ -436,44 +472,6 @@ void QgsCoordinateTransform::transformInPlace(
   }
 }
 
-#ifdef QT_ARCH_ARM
-void QgsCoordinateTransform::transformInPlace( qreal& x, qreal& y, double& z,
-    TransformDirection direction ) const
-{
-  double xd = ( double ) x, yd = ( double ) y;
-  transformInPlace( xd, yd, z, direction );
-  x = xd;
-  y = yd;
-}
-#endif
-
-#ifdef ANDROID
-void QgsCoordinateTransform::transformInPlace( float& x, float& y, float& z,
-    TransformDirection direction ) const
-{
-  if ( mShortCircuit || !mInitialisedFlag )
-    return;
-#ifdef QGISDEBUG
-// QgsDebugMsg(QString("Using transform in place %1 %2").arg(__FILE__).arg(__LINE__));
-#endif
-  // transform x
-  try
-  {
-    double xd = x;
-    double yd = y;
-    double zd = z;
-    transformCoords( 1, &xd, &yd, &zd, direction );
-    x = xd;
-    y = yd;
-    z = zd;
-  }
-  catch ( QgsCsException & )
-  {
-    // rethrow the exception
-    QgsDebugMsg( "rethrowing exception" );
-    throw;
-  }
-}
 
 void QgsCoordinateTransform::transformInPlace(
   QVector<float>& x, QVector<float>& y, QVector<float>& z,
@@ -519,8 +517,6 @@ void QgsCoordinateTransform::transformInPlace(
     throw;
   }
 }
-#endif //ANDROID
-
 
 QgsRectangle QgsCoordinateTransform::transformBoundingBox( const QgsRectangle &rect, TransformDirection direction, const bool handle180Crossover ) const
 {

--- a/src/core/qgscoordinatetransform.h
+++ b/src/core/qgscoordinatetransform.h
@@ -158,22 +158,18 @@ class CORE_EXPORT QgsCoordinateTransform : public QObject
     // and y variables in place. The second one works with good old-fashioned
     // C style arrays.
     void transformInPlace( double& x, double& y, double &z, TransformDirection direction = ForwardTransform ) const;
-#ifdef QT_ARCH_ARM
-    void transformInPlace( qreal& x, qreal& y, double &z, TransformDirection direction = ForwardTransform ) const;
-#endif
+    void transformInPlace( float& x, float& y, double &z, TransformDirection direction = ForwardTransform) const;
+    void transformInPlace( float& x, float& y, float& z, TransformDirection direction = ForwardTransform ) const;
+
+    void transformInPlace( QVector<float>& x, QVector<float>& y, QVector<float>& z,
+                           TransformDirection direction = ForwardTransform ) const;
+
 
     //! @note not available in python bindings
     void transformInPlace( QVector<double>& x, QVector<double>& y, QVector<double>& z,
                            TransformDirection direction = ForwardTransform ) const;
 
     void transformPolygon( QPolygonF& poly, TransformDirection direction = ForwardTransform ) const;
-
-#ifdef ANDROID
-    void transformInPlace( float& x, float& y, float& z, TransformDirection direction = ForwardTransform ) const;
-
-    void transformInPlace( QVector<float>& x, QVector<float>& y, QVector<float>& z,
-                           TransformDirection direction = ForwardTransform ) const;
-#endif
 
     /*! Transform a QgsRectangle to the dest Coordinate system
      * If the direction is ForwardTransform then coordinates are transformed from layer CS --> map canvas CS,

--- a/src/core/qgsmaptopixel.cpp
+++ b/src/core/qgsmaptopixel.cpp
@@ -111,13 +111,14 @@ bool QgsMapToPixel::updateMatrix()
   return true;
 }
 
-QgsPoint QgsMapToPixel::toMapPoint( qreal x, qreal y ) const
+QgsPoint QgsMapToPixel::toMapPoint( double x, double y ) const
 {
   bool invertible;
   QTransform matrix = mMatrix.inverted( &invertible );
   assert( invertible );
   qreal mx, my;
-  matrix.map( x, y, &mx, &my );
+  qreal x_qreal = x, y_qreal = y;
+  matrix.map(x_qreal, y_qreal, &mx, &my);
   //QgsDebugMsg(QString("XXX toMapPoint x:%1 y:%2 -> x:%3 y:%4").arg(x).arg(y).arg(mx).arg(my));
   return QgsPoint( mx, my );
 }
@@ -315,13 +316,21 @@ void QgsMapToPixel::transform( QgsPoint *p ) const
   p->set( x, y );
 }
 
-void QgsMapToPixel::transformInPlace( qreal &x, qreal &y ) const
+void QgsMapToPixel::transformInPlace( double& x, double& y ) const
 {
-  // Map 2 Pixel
-  qreal mx, my;
-  mMatrix.map( x, y, &mx, &my );
-  //QgsDebugMsg(QString("XXX transformInPlace X : %1-->%2, Y: %3 -->%4").arg(x).arg(mx).arg(y).arg(my));
-  x = mx; y = my;
+   // Map 2 Pixel
+   qreal mx, my;
+   qreal x_qreal = x, y_qreal = y;
+   mMatrix.map(x_qreal, y_qreal, &mx, &my);
+   //QgsDebugMsg(QString("XXX transformInPlace X : %1-->%2, Y: %3 -->%4").arg(x).arg(mx).arg(y).arg(my));
+   x = mx; y = my;
+}
+
+void QgsMapToPixel::transformInPlace( float& x, float& y ) const
+{
+   double mx = x, my = y;
+   transformInPlace(mx, my);
+   x = mx; y = my;
 }
 
 QTransform QgsMapToPixel::transform() const

--- a/src/core/qgsmaptopixel.h
+++ b/src/core/qgsmaptopixel.h
@@ -102,7 +102,9 @@ class CORE_EXPORT QgsMapToPixel
      * given coordinates in place. Intended as a fast way to do the
      * transform.
      */
-    void transformInPlace( qreal& x, qreal& y ) const;
+    void transformInPlace(double& x, double& y) const;
+    void transformInPlace(float& x, float& y) const;
+
 
     /**
      * Transform device coordinates to map coordinates. Modifies the
@@ -130,7 +132,7 @@ class CORE_EXPORT QgsMapToPixel
      */
     QgsPoint toMapCoordinates( QPoint p ) const;
 
-    QgsPoint toMapPoint( qreal x, qreal y ) const;
+    QgsPoint toMapPoint( double x, double y ) const;
 
     /**
      * Set map units per pixel

--- a/src/core/qgspallabeling.cpp
+++ b/src/core/qgspallabeling.cpp
@@ -2035,8 +2035,10 @@ void QgsPalLayerSettings::registerFeature( QgsFeature& f, const QgsRenderContext
           t.rotate( -m2p.mapRotation() );
           t.translate( -center.x(), -center.y() );
           qreal xPosR, yPosR;
-          t.map( xPos, yPos, &xPosR, &yPosR );
+          qreal xPos_qreal = xPos, yPos_qreal = yPos;
+          t.map( xPos_qreal, yPos_qreal, &xPosR, &yPosR );
           xPos = xPosR; yPos = yPosR;
+
         }
 
         xPos += xdiff;

--- a/src/core/qgsproviderregistry.cpp
+++ b/src/core/qgsproviderregistry.cpp
@@ -69,6 +69,12 @@ QgsProviderRegistry::QgsProviderRegistry( QString pluginPath )
   QString mLibraryDirectory = baseDir + "/lib";
 #endif
   mLibraryDirectory = pluginPath;
+  init();
+} 
+
+
+void QgsProviderRegistry::init()
+{
   mLibraryDirectory.setSorting( QDir::Name | QDir::IgnoreCase );
   mLibraryDirectory.setFilter( QDir::Files | QDir::NoSymLinks );
 
@@ -220,7 +226,7 @@ QgsProviderRegistry::QgsProviderRegistry( QString pluginPath )
 // typedef for the unload dataprovider function
 typedef void cleanupProviderFunction_t();
 
-QgsProviderRegistry::~QgsProviderRegistry()
+void QgsProviderRegistry::clean()
 {
   QgsMapLayerRegistry::instance()->removeAllMapLayers();
 
@@ -239,6 +245,11 @@ QgsProviderRegistry::~QgsProviderRegistry()
     }
     ++it;
   }
+}
+
+QgsProviderRegistry::~QgsProviderRegistry()
+{
+   clean();
 }
 
 
@@ -312,12 +323,12 @@ QString QgsProviderRegistry::pluginList( bool asHTML ) const
   return list;
 }
 
-
 void QgsProviderRegistry::setLibraryDirectory( QDir const & path )
 {
   mLibraryDirectory = path;
+  clean();
+  init();
 }
-
 
 QDir const & QgsProviderRegistry::libraryDirectory() const
 {

--- a/src/core/qgsproviderregistry.h
+++ b/src/core/qgsproviderregistry.h
@@ -172,6 +172,9 @@ class CORE_EXPORT QgsProviderRegistry
     /** ctor private since instance() creates it */
     QgsProviderRegistry( QString pluginPath );
 
+    void init();
+    void clean();
+
     /** associative container of provider metadata handles */
     Providers mProviders;
 

--- a/src/core/qgswebframe.h
+++ b/src/core/qgswebframe.h
@@ -17,7 +17,7 @@
 #define QGSWEBFRAME_H
 
 #ifdef WITH_QTWEBKIT
-#include <QtWebKit/QWebFrame>
+#include <QWebFrame>
 #else
 
 #include <QObject>

--- a/src/core/qgswebview.h
+++ b/src/core/qgswebview.h
@@ -20,7 +20,7 @@
 #include <QPrinter>
 
 #ifdef WITH_QTWEBKIT
-#include <QtWebKit/QWebView>
+#include <QWebView>
 
 class CORE_EXPORT QgsWebView : public QWebView
 {

--- a/src/core/raster/qgspseudocolorshader.cpp
+++ b/src/core/raster/qgspseudocolorshader.cpp
@@ -27,58 +27,59 @@ QgsPseudoColorShader::QgsPseudoColorShader( double theMinimumValue, double theMa
   setClassBreaks();
 }
 
-
-bool QgsPseudoColorShader::shade( double theValue, int* theReturnRedValue, int* theReturnGreenValue, int* theReturnBlueValue )
+bool QgsPseudoColorShader::shade(double theValue, int* theReturnRedValue, int* theReturnGreenValue, int* theReturnBlueValue, int *theReturnAlphaValue)
 {
-  double myPixelValue = theValue;
+   double myPixelValue = theValue;
 
-  //double check that myInt >= min and <= max
-  //this is relevant if we are plotting within stddevs
-  if ( myPixelValue < mMinimumValue )
-  {
-    myPixelValue = mMinimumValue;
-  }
-  if ( myPixelValue > mMaximumValue )
-  {
-    myPixelValue = mMaximumValue;
-  }
+   //double check that myInt >= min and <= max
+   //this is relevant if we are plotting within stddevs
+   if (myPixelValue < mMinimumValue)
+   {
+      myPixelValue = mMinimumValue;
+   }
+   if (myPixelValue > mMaximumValue)
+   {
+      myPixelValue = mMaximumValue;
+   }
 
-  //check if we are in the first class break
-  if (( myPixelValue >= mClassBreakMin1 ) && ( myPixelValue < mClassBreakMax1 ) )
-  {
-    *theReturnRedValue = 0;
-    *theReturnGreenValue = static_cast < int >((( 255 / mMinimumMaximumRange ) * ( myPixelValue - mClassBreakMin1 ) ) * 3 );
-    *theReturnBlueValue = 255;
-  }
-  //check if we are in the second class break
-  else if (( myPixelValue >= mClassBreakMin2 ) && ( myPixelValue < mClassBreakMax2 ) )
-  {
-    *theReturnRedValue = static_cast < int >((( 255 / mMinimumMaximumRange ) * (( myPixelValue - mClassBreakMin2 ) / 1 ) ) * 3 );
-    *theReturnGreenValue = 255;
-    *theReturnBlueValue = static_cast < int >( 255 - ((( 255 / mMinimumMaximumRange ) * (( myPixelValue - mClassBreakMin2 ) / 1 ) ) * 3 ) );
-  }
-  //otherwise we must be in the third classbreak
-  else
-  {
-    *theReturnRedValue = 255;
-    *theReturnGreenValue = static_cast < int >( 255 - ((( 255 / mMinimumMaximumRange ) * (( myPixelValue - mClassBreakMin3 ) / 1 ) * 3 ) ) );
-    *theReturnBlueValue = 0;
-  }
-
-  return true;
+   //check if we are in the first class break
+   if ((myPixelValue >= mClassBreakMin1) && (myPixelValue < mClassBreakMax1))
+   {
+      *theReturnRedValue = 0;
+      *theReturnGreenValue = static_cast < int >(((255 / mMinimumMaximumRange) * (myPixelValue - mClassBreakMin1)) * 3);
+      *theReturnBlueValue = 255;
+   }
+   //check if we are in the second class break
+   else if ((myPixelValue >= mClassBreakMin2) && (myPixelValue < mClassBreakMax2))
+   {
+      *theReturnRedValue = static_cast < int >(((255 / mMinimumMaximumRange) * ((myPixelValue - mClassBreakMin2) / 1)) * 3);
+      *theReturnGreenValue = 255;
+      *theReturnBlueValue = static_cast < int >(255 - (((255 / mMinimumMaximumRange) * ((myPixelValue - mClassBreakMin2) / 1)) * 3));
+   }
+   //otherwise we must be in the third classbreak
+   else
+   {
+      *theReturnRedValue = 255;
+      *theReturnGreenValue = static_cast < int >(255 - (((255 / mMinimumMaximumRange) * ((myPixelValue - mClassBreakMin3) / 1) * 3)));
+      *theReturnBlueValue = 0;
+   }
+   *theReturnAlphaValue = 255;
+   return true;
 }
 
-bool QgsPseudoColorShader::shade( double theRedValue, double theGreenValue, double theBlueValue, int* theReturnRedValue, int* theReturnGreenValue, int* theReturnBlueValue )
+bool QgsPseudoColorShader::shade(double theRedValue, double theGreenValue, double theBlueValue, double theAlphaValue, int* theReturnRedValue, int* theReturnGreenValue, int* theReturnBlueValue, int* theReturnAlphaValue)
 {
-  Q_UNUSED( theRedValue );
-  Q_UNUSED( theGreenValue );
-  Q_UNUSED( theBlueValue );
+   Q_UNUSED(theRedValue);
+   Q_UNUSED(theGreenValue);
+   Q_UNUSED(theBlueValue);
+   Q_UNUSED(theAlphaValue);
 
-  *theReturnRedValue = 0;
-  *theReturnGreenValue = 0;
-  *theReturnBlueValue = 0;
+   *theReturnRedValue = 0;
+   *theReturnGreenValue = 0;
+   *theReturnBlueValue = 0;
+   *theReturnAlphaValue = 0;
 
-  return false;
+   return false;
 }
 
 void QgsPseudoColorShader::setClassBreaks()
@@ -114,4 +115,10 @@ void QgsPseudoColorShader::setMinimumValue( double theValue )
   mMinimumValue = theValue;
   mMinimumMaximumRange = mMaximumValue - mMinimumValue;
   setClassBreaks();
+}
+
+void QgsPseudoColorShader::legendSymbologyItems(QList< QPair< QString, QColor > >& symbolItems) const
+{
+   symbolItems.push_back(qMakePair(QString::number(mMinimumValue), QColor(0, 0, 255)));
+   symbolItems.push_back(qMakePair(QString::number(mMaximumValue), QColor(255, 0, 0)));
 }

--- a/src/core/raster/qgspseudocolorshader.h
+++ b/src/core/raster/qgspseudocolorshader.h
@@ -32,11 +32,13 @@ class CORE_EXPORT QgsPseudoColorShader : public QgsRasterShaderFunction
   public:
     QgsPseudoColorShader( double theMinimumValue = 0.0, double theMaximumValue = 255.0 );
 
-    /** \brief generates and new RGB value based on one input value */
-    bool shade( double, int*, int*, int* );
+    /** \brief Generates and new RGB value based on one input value */
+    bool shade(double, int*, int*, int*, int*) override;
 
-    /** \brief generates and new RGB value based on original RGB value */
-    bool shade( double, double, double, int*, int*, int* );
+    /** \brief Generates and new RGB value based on original RGB value */
+    bool shade(double, double, double, double, int*, int*, int*, int*) override;
+
+    void legendSymbologyItems(QList< QPair< QString, QColor > >& symbolItems) const override;
 
     /** \brief Set the maximum value */
     void setMaximumValue( double ) override;

--- a/src/core/raster/qgsrasterrendererregistry.cpp
+++ b/src/core/raster/qgsrasterrendererregistry.cpp
@@ -21,6 +21,7 @@
 #include "qgssinglebandcolordatarenderer.h"
 #include "qgssinglebandgrayrenderer.h"
 #include "qgssinglebandpseudocolorrenderer.h"
+#include "qgspseudocolorshader.h"
 #include <QSettings>
 
 QgsRasterRendererRegistryEntry::QgsRasterRendererRegistryEntry( const QString& theName, const QString& theVisibleName,
@@ -172,7 +173,9 @@ QgsRasterRenderer* QgsRasterRendererRegistry::defaultRendererForDrawingStyle( co
       // TODO: avoid calculating statistics if not necessary (default style loaded)
       minMaxValuesForBand( bandNo, provider, minValue, maxValue );
       QgsRasterShader* shader = new QgsRasterShader( minValue, maxValue );
-      renderer = new QgsSingleBandPseudoColorRenderer( provider, bandNo, shader );
+      QgsRasterShaderFunction *fun = new QgsPseudoColorShader(minValue, maxValue);
+      shader->setRasterShaderFunction(fun);
+      renderer = new QgsSingleBandPseudoColorRenderer(provider, bandNo, shader);
       break;
     }
     case QgsRaster::MultiBandColor:

--- a/src/core/raster/qgsrastershader.cpp
+++ b/src/core/raster/qgsrastershader.cpp
@@ -18,6 +18,7 @@ email                : ersts@amnh.org
 
 #include "qgslogger.h"
 #include "qgscolorrampshader.h"
+#include "qgspseudocolorshader.h"
 #include "qgsrastershader.h"
 #include <QDomDocument>
 #include <QDomElement>
@@ -158,7 +159,15 @@ void QgsRasterShader::writeXML( QDomDocument& doc, QDomElement& parent ) const
     }
     rasterShaderElem.appendChild( colorRampShaderElem );
   }
-  parent.appendChild( rasterShaderElem );
+  QgsPseudoColorShader * pseudoColorShader = dynamic_cast< QgsPseudoColorShader *>(mRasterShaderFunction);
+  if (pseudoColorShader)
+  {
+     QDomElement pseudoColorShaderElem = doc.createElement("pseudocolorshader");
+     pseudoColorShaderElem.setAttribute("minval", pseudoColorShader->minimumValue());
+     pseudoColorShaderElem.setAttribute("maxval", pseudoColorShader->maximumValue());
+     rasterShaderElem.appendChild(pseudoColorShaderElem);
+  }
+  parent.appendChild(rasterShaderElem);
 }
 
 void QgsRasterShader::readXML( const QDomElement& elem )
@@ -190,5 +199,13 @@ void QgsRasterShader::readXML( const QDomElement& elem )
     }
     colorRampShader->setColorRampItemList( itemList );
     setRasterShaderFunction( colorRampShader );
+  }
+  QDomElement pseudoColorShaderElem = elem.firstChildElement("pseudocolorshader");
+  if (!pseudoColorShaderElem.isNull())
+  {
+     mMinimumValue = pseudoColorShaderElem.attribute("minval", "0.0").toDouble();
+     mMaximumValue = pseudoColorShaderElem.attribute("maxval", "255.0").toDouble();
+     QgsPseudoColorShader* pseudoColorShader = new QgsPseudoColorShader(mMinimumValue, mMaximumValue);
+     setRasterShaderFunction(pseudoColorShader);
   }
 }

--- a/src/core/raster/qgssinglebandpseudocolorrenderer.cpp
+++ b/src/core/raster/qgssinglebandpseudocolorrenderer.cpp
@@ -17,6 +17,7 @@
 
 #include "qgssinglebandpseudocolorrenderer.h"
 #include "qgsrastershader.h"
+#include "qgspseudocolorshader.h"
 #include "qgsrastertransparency.h"
 #include "qgsrasterviewport.h"
 #include <QDomDocument>
@@ -55,9 +56,8 @@ QgsRasterInterface * QgsSingleBandPseudoColorRenderer::clone() const
   {
     shader = new QgsRasterShader( mShader->minimumValue(), mShader->maximumValue() );
 
-    // Shader function
+    // Shader functions
     const QgsColorRampShader* origColorRampShader = dynamic_cast<const QgsColorRampShader*>( mShader->rasterShaderFunction() );
-
     if ( origColorRampShader )
     {
       QgsColorRampShader * colorRampShader = new QgsColorRampShader( mShader->minimumValue(), mShader->maximumValue() );
@@ -67,6 +67,14 @@ QgsRasterInterface * QgsSingleBandPseudoColorRenderer::clone() const
       colorRampShader->setColorRampItemList( origColorRampShader->colorRampItemList() );
       shader->setRasterShaderFunction( colorRampShader );
     }
+
+    const QgsPseudoColorShader* origPseudoColorShader = dynamic_cast<const QgsPseudoColorShader*>( mShader->rasterShaderFunction() );
+    if (origPseudoColorShader)
+    {
+       QgsPseudoColorShader * pseudoColorShader = new QgsPseudoColorShader(mShader->minimumValue(), mShader->maximumValue());
+       shader->setRasterShaderFunction(pseudoColorShader);
+    }
+
   }
   QgsSingleBandPseudoColorRenderer * renderer = new QgsSingleBandPseudoColorRenderer( 0, mBand, shader );
 

--- a/src/gui/editorwidgets/core/qgseditorwidgetregistry.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetregistry.cpp
@@ -35,7 +35,9 @@
 #include "qgsvaluerelationwidgetfactory.h"
 #include "qgsuuidwidgetfactory.h"
 #include "qgsphotowidgetfactory.h"
+#ifdef WITH_QTWEBKIT
 #include "qgswebviewwidgetfactory.h"
+#endif
 #include "qgscolorwidgetfactory.h"
 #include "qgsrelationreferencefactory.h"
 #include "qgsdatetimeeditfactory.h"

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -202,6 +202,7 @@ QgsMapCanvas::QgsMapCanvas( QWidget * parent, const char *name )
   mCurrentLayer = NULL;
   mMapOverview = NULL;
   mMapTool = NULL;
+  mOldCursor = cursor();
   mLastNonZoomMapTool = NULL;
 
   mFrozen = false;
@@ -1486,7 +1487,10 @@ void QgsMapCanvas::setMapTool( QgsMapTool* tool )
     disconnect( mMapTool, SIGNAL( destroyed() ), this, SLOT( mapToolDestroyed() ) );
     mMapTool->deactivate();
   }
-
+  else
+  {
+     mOldCursor = cursor();
+  }
   if ( tool->isTransient() && mMapTool && !mMapTool->isTransient() )
   {
     // if zoom or pan tool will be active, save old tool
@@ -1508,7 +1512,6 @@ void QgsMapCanvas::setMapTool( QgsMapTool* tool )
     connect( mMapTool, SIGNAL( destroyed() ), this, SLOT( mapToolDestroyed() ) );
     mMapTool->activate();
   }
-
   emit mapToolSet( mMapTool );
   emit mapToolSet( mMapTool, oldTool );
 } // setMapTool
@@ -1519,7 +1522,7 @@ void QgsMapCanvas::unsetMapTool( QgsMapTool* tool )
   {
     mMapTool->deactivate();
     mMapTool = NULL;
-    setCursor( Qt::ArrowCursor );
+    setCursor( mOldCursor );
     emit mapToolSet( NULL );
     emit mapToolSet( NULL, mMapTool );
   }

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -1519,9 +1519,9 @@ void QgsMapCanvas::unsetMapTool( QgsMapTool* tool )
   {
     mMapTool->deactivate();
     mMapTool = NULL;
+    setCursor( Qt::ArrowCursor );
     emit mapToolSet( NULL );
     emit mapToolSet( NULL, mMapTool );
-    setCursor( Qt::ArrowCursor );
   }
 
   if ( mLastNonZoomMapTool && mLastNonZoomMapTool == tool )

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -697,6 +697,8 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
 
     QgsSnappingUtils* mSnappingUtils;
 
+    QCursor mOldCursor;
+
 }; // class QgsMapCanvas
 
 


### PR DESCRIPTION
qreal could be float not only on ARM_ARCH. There are overload methods for float and double. Depending on the type of qreal, one or other overloaded method is used.

Implementation of pseudocolor raster shader.

Restore the type of the cursor when maptool is unset.

Various small changes.
