### PR TITLE
Added float types additionally to double, qreal can be now float or double.

### DIFF
--- a/src/core/geometry/qgscircularstringv2.cpp
+++ b/src/core/geometry/qgscircularstringv2.cpp
@@ -603,13 +603,9 @@ void QgsCircularStringV2::transform( const QTransform& t )
   int nPoints = numPoints();
   for ( int i = 0; i < nPoints; ++i )
   {
-#ifdef QT_ARCH_ARM
     qreal x, y;
     t.map( mX[i], mY[i], &x, &y );
     mX[i] = x; mY[i] = y;
-#else
-    t.map( mX[i], mY[i], &mX[i], &mY[i] );
-#endif
   }
 }
 

--- a/src/core/geometry/qgspointv2.cpp
+++ b/src/core/geometry/qgspointv2.cpp
@@ -241,11 +241,7 @@ bool QgsPointV2::nextVertex( QgsVertexId& id, QgsPointV2& vertex ) const
 
 void QgsPointV2::transform( const QTransform& t )
 {
-#ifdef QT_ARCH_ARM
   qreal x, y;
   t.map( mX, mY, &x, &y );
   mX = x; mY = y;
-#else
-  t.map( mX, mY, &mX, &mY );
-#endif
 }

--- a/src/core/geometry/qgswkbptr.h
+++ b/src/core/geometry/qgswkbptr.h
@@ -47,14 +47,12 @@ class CORE_EXPORT QgsConstWkbPtr
     QgsWKBTypes::Type readHeader() const;
 
     inline const QgsConstWkbPtr &operator>>( double &v ) const { read( v ); return *this; }
-    inline const QgsConstWkbPtr &operator>>( int &v ) const { read( v ); return *this; }
+    inline const QgsConstWkbPtr &operator>>( float &r ) const { double v; read(v); r = v; return *this; }
+    inline const QgsConstWkbPtr &operator>>(int &v) const { read(v); return *this; }
     inline const QgsConstWkbPtr &operator>>( unsigned int &v ) const { read( v ); return *this; }
     inline const QgsConstWkbPtr &operator>>( char &v ) const { read( v ); return *this; }
     inline const QgsConstWkbPtr &operator>>( QGis::WkbType &v ) const { read( v ); return *this; }
     inline const QgsConstWkbPtr &operator>>( QgsWKBTypes::Type &v ) const { read( v ); return *this; }
-#ifdef QT_ARCH_ARM
-    inline const QgsConstWkbPtr &operator>>( qreal &r ) const { double v; read( v ); r = v; return *this; }
-#endif
 
     inline void operator+=( int n ) { mP += n; }
     inline void operator-=( int n ) { mP -= n; }

--- a/src/core/qgscoordinatetransform.cpp
+++ b/src/core/qgscoordinatetransform.cpp
@@ -369,7 +369,43 @@ void QgsCoordinateTransform::transformInPlace( double& x, double& y, double& z,
   }
 }
 
-void QgsCoordinateTransform::transformPolygon( QPolygonF& poly, TransformDirection direction ) const
+void QgsCoordinateTransform::transformInPlace(float& x, float& y, double& z,
+   TransformDirection direction) const
+{
+   double xd = (double)x, yd = (double)y;
+   transformInPlace(xd, yd, z, direction);
+   x = xd;
+   y = yd;
+}
+
+void QgsCoordinateTransform::transformInPlace(float& x, float& y, float& z,
+   TransformDirection direction) const
+{
+   if (mShortCircuit || !mInitialisedFlag)
+      return;
+#ifdef QGISDEBUG
+   // QgsDebugMsg(QString("Using transform in place %1 %2").arg(__FILE__).arg(__LINE__));
+#endif
+   // transform x
+   try
+   {
+      double xd = x;
+      double yd = y;
+      double zd = z;
+      transformCoords(1, &xd, &yd, &zd, direction);
+      x = xd;
+      y = yd;
+      z = zd;
+   }
+   catch (QgsCsException &)
+   {
+      // rethrow the exception
+      QgsDebugMsg("rethrowing exception");
+      throw;
+   }
+}
+
+void QgsCoordinateTransform::transformPolygon(QPolygonF& poly, TransformDirection direction) const
 {
   if ( mShortCircuit || !mInitialisedFlag )
   {
@@ -436,44 +472,6 @@ void QgsCoordinateTransform::transformInPlace(
   }
 }
 
-#ifdef QT_ARCH_ARM
-void QgsCoordinateTransform::transformInPlace( qreal& x, qreal& y, double& z,
-    TransformDirection direction ) const
-{
-  double xd = ( double ) x, yd = ( double ) y;
-  transformInPlace( xd, yd, z, direction );
-  x = xd;
-  y = yd;
-}
-#endif
-
-#ifdef ANDROID
-void QgsCoordinateTransform::transformInPlace( float& x, float& y, float& z,
-    TransformDirection direction ) const
-{
-  if ( mShortCircuit || !mInitialisedFlag )
-    return;
-#ifdef QGISDEBUG
-// QgsDebugMsg(QString("Using transform in place %1 %2").arg(__FILE__).arg(__LINE__));
-#endif
-  // transform x
-  try
-  {
-    double xd = x;
-    double yd = y;
-    double zd = z;
-    transformCoords( 1, &xd, &yd, &zd, direction );
-    x = xd;
-    y = yd;
-    z = zd;
-  }
-  catch ( QgsCsException & )
-  {
-    // rethrow the exception
-    QgsDebugMsg( "rethrowing exception" );
-    throw;
-  }
-}
 
 void QgsCoordinateTransform::transformInPlace(
   QVector<float>& x, QVector<float>& y, QVector<float>& z,
@@ -519,8 +517,6 @@ void QgsCoordinateTransform::transformInPlace(
     throw;
   }
 }
-#endif //ANDROID
-
 
 QgsRectangle QgsCoordinateTransform::transformBoundingBox( const QgsRectangle &rect, TransformDirection direction, const bool handle180Crossover ) const
 {

--- a/src/core/qgscoordinatetransform.h
+++ b/src/core/qgscoordinatetransform.h
@@ -158,22 +158,18 @@ class CORE_EXPORT QgsCoordinateTransform : public QObject
     // and y variables in place. The second one works with good old-fashioned
     // C style arrays.
     void transformInPlace( double& x, double& y, double &z, TransformDirection direction = ForwardTransform ) const;
-#ifdef QT_ARCH_ARM
-    void transformInPlace( qreal& x, qreal& y, double &z, TransformDirection direction = ForwardTransform ) const;
-#endif
+    void transformInPlace( float& x, float& y, double &z, TransformDirection direction = ForwardTransform) const;
+    void transformInPlace( float& x, float& y, float& z, TransformDirection direction = ForwardTransform ) const;
+
+    void transformInPlace( QVector<float>& x, QVector<float>& y, QVector<float>& z,
+                           TransformDirection direction = ForwardTransform ) const;
+
 
     //! @note not available in python bindings
     void transformInPlace( QVector<double>& x, QVector<double>& y, QVector<double>& z,
                            TransformDirection direction = ForwardTransform ) const;
 
     void transformPolygon( QPolygonF& poly, TransformDirection direction = ForwardTransform ) const;
-
-#ifdef ANDROID
-    void transformInPlace( float& x, float& y, float& z, TransformDirection direction = ForwardTransform ) const;
-
-    void transformInPlace( QVector<float>& x, QVector<float>& y, QVector<float>& z,
-                           TransformDirection direction = ForwardTransform ) const;
-#endif
 
     /*! Transform a QgsRectangle to the dest Coordinate system
      * If the direction is ForwardTransform then coordinates are transformed from layer CS --> map canvas CS,

--- a/src/core/qgsmaptopixel.cpp
+++ b/src/core/qgsmaptopixel.cpp
@@ -111,13 +111,14 @@ bool QgsMapToPixel::updateMatrix()
   return true;
 }
 
-QgsPoint QgsMapToPixel::toMapPoint( qreal x, qreal y ) const
+QgsPoint QgsMapToPixel::toMapPoint( double x, double y ) const
 {
   bool invertible;
   QTransform matrix = mMatrix.inverted( &invertible );
   assert( invertible );
   qreal mx, my;
-  matrix.map( x, y, &mx, &my );
+  qreal x_qreal = x, y_qreal = y;
+  matrix.map(x_qreal, y_qreal, &mx, &my);
   //QgsDebugMsg(QString("XXX toMapPoint x:%1 y:%2 -> x:%3 y:%4").arg(x).arg(y).arg(mx).arg(my));
   return QgsPoint( mx, my );
 }
@@ -315,13 +316,21 @@ void QgsMapToPixel::transform( QgsPoint *p ) const
   p->set( x, y );
 }
 
-void QgsMapToPixel::transformInPlace( qreal &x, qreal &y ) const
+void QgsMapToPixel::transformInPlace( double& x, double& y ) const
 {
-  // Map 2 Pixel
-  qreal mx, my;
-  mMatrix.map( x, y, &mx, &my );
-  //QgsDebugMsg(QString("XXX transformInPlace X : %1-->%2, Y: %3 -->%4").arg(x).arg(mx).arg(y).arg(my));
-  x = mx; y = my;
+   // Map 2 Pixel
+   qreal mx, my;
+   qreal x_qreal = x, y_qreal = y;
+   mMatrix.map(x_qreal, y_qreal, &mx, &my);
+   //QgsDebugMsg(QString("XXX transformInPlace X : %1-->%2, Y: %3 -->%4").arg(x).arg(mx).arg(y).arg(my));
+   x = mx; y = my;
+}
+
+void QgsMapToPixel::transformInPlace( float& x, float& y ) const
+{
+   double mx = x, my = y;
+   transformInPlace(mx, my);
+   x = mx; y = my;
 }
 
 QTransform QgsMapToPixel::transform() const

--- a/src/core/qgsmaptopixel.h
+++ b/src/core/qgsmaptopixel.h
@@ -102,7 +102,9 @@ class CORE_EXPORT QgsMapToPixel
      * given coordinates in place. Intended as a fast way to do the
      * transform.
      */
-    void transformInPlace( qreal& x, qreal& y ) const;
+    void transformInPlace(double& x, double& y) const;
+    void transformInPlace(float& x, float& y) const;
+
 
     /**
      * Transform device coordinates to map coordinates. Modifies the
@@ -130,7 +132,7 @@ class CORE_EXPORT QgsMapToPixel
      */
     QgsPoint toMapCoordinates( QPoint p ) const;
 
-    QgsPoint toMapPoint( qreal x, qreal y ) const;
+    QgsPoint toMapPoint( double x, double y ) const;
 
     /**
      * Set map units per pixel

--- a/src/core/qgspallabeling.cpp
+++ b/src/core/qgspallabeling.cpp
@@ -2035,8 +2035,10 @@ void QgsPalLayerSettings::registerFeature( QgsFeature& f, const QgsRenderContext
           t.rotate( -m2p.mapRotation() );
           t.translate( -center.x(), -center.y() );
           qreal xPosR, yPosR;
-          t.map( xPos, yPos, &xPosR, &yPosR );
+          qreal xPos_qreal = xPos, yPos_qreal = yPos;
+          t.map( xPos_qreal, yPos_qreal, &xPosR, &yPosR );
           xPos = xPosR; yPos = yPosR;
+
         }
 
         xPos += xdiff;


### PR DESCRIPTION
Removed QT_ARCH_ARM. qreal can be float not only on ARM. There are overload functions for both types.

(cherry picked from commit 06819e80528c23434e9f55105cdd41566d7a84d8)
