### PR TITLE
Remove `pending` prefixes from QgsVectorLayer methods

### DIFF
--- a/python/core/qgsvectorlayer.sip
+++ b/python/core/qgsvectorlayer.sip
@@ -569,15 +569,6 @@ class QgsVectorLayer : QgsMapLayer
     bool readSld( const QDomNode& node, QString& errorMessage );
 
     /**
-     * Number of features in the layer. This is necessary if features are
-     * added/deleted or the layer has been subsetted. If the data provider
-     * chooses not to support this feature, the total number of features
-     * can be returned.
-     * @return long containing number of features
-     */
-    virtual long featureCount() const;
-
-    /**
      * Update the data source of the layer. The layer's renderer and legend will be preserved only
      * if the geometry type of the new data source matches the current geometry type of the layer.
      * @param dataSource new layer data source
@@ -816,16 +807,40 @@ class QgsVectorLayer : QgsMapLayer
      *
      * @return A list of fields
      */
-    const QgsFields pendingFields() const;
+    QgsFields pendingFields() const;
 
-    /** Returns list of attributes */
-    QList<int> pendingAllAttributesList();
+    /**
+     * Returns list of attribute indexes. i.e. a list from 0 ... fieldCount()
+     * Alias for {@link attributeList()}
+     */
+    QgsAttributeList pendingAllAttributesList() const;
 
-    /** Returns list of attribute making up the primary key */
-    QList<int> pendingPkAttributesList();
+    /**
+     * Returns list of attribute indexes. i.e. a list from 0 ... fieldCount()
+     * Alias for {@link attributeList()}
+     */
+    QgsAttributeList attributeList() const;
 
-    /** Returns feature count after commit */
-    int pendingFeatureCount();
+    /**
+     * Returns list of attributes making up the primary key
+     * Alias for {@link pkAttributeList()}
+     */
+    QgsAttributeList pendingPkAttributesList() const;
+
+    /** Returns list of attributes making up the primary key */
+    QgsAttributeList pkAttributeList() const;
+
+    /**
+     * Returns feature count including changes which have not yet been committed
+     * Alias for {@link featureCount()}
+     */
+    long pendingFeatureCount() const;
+
+    /**
+     * Returns feature count including changes which have not yet been committed
+     * If you need only the count of committed features call this method on this layer's provider.
+     */
+    long featureCount() const;
 
     /** Make layer read-only (editing disabled) or not
      *  @return false if the layer is in editing yet

--- a/python/core/qgsvectorlayer.sip
+++ b/python/core/qgsvectorlayer.sip
@@ -807,7 +807,16 @@ class QgsVectorLayer : QgsMapLayer
      *
      * @return A list of fields
      */
-    const QgsFields &pendingFields() const;
+    const QgsFields fields() const;
+
+    /**
+     * Returns the list of fields of this layer.
+     * This also includes fields which have not yet been saved to the provider.
+     * Alias for {@link fields()}
+     *
+     * @return A list of fields
+     */
+    const QgsFields pendingFields() const;
 
     /** Returns list of attributes */
     QList<int> pendingAllAttributesList();

--- a/src/analysis/vector/qgsgeometryanalyzer.cpp
+++ b/src/analysis/vector/qgsgeometryanalyzer.cpp
@@ -47,7 +47,7 @@ bool QgsGeometryAnalyzer::simplify( QgsVectorLayer* layer,
   QGis::WkbType outputType = dp->geometryType();
   const QgsCoordinateReferenceSystem crs = layer->crs();
 
-  QgsVectorFileWriter vWriter( shapefileName, dp->encoding(), layer->pendingFields(), outputType, &crs );
+  QgsVectorFileWriter vWriter( shapefileName, dp->encoding(), layer->fields(), outputType, &crs );
   QgsFeature currentFeature;
 
   //take only selection
@@ -163,7 +163,7 @@ bool QgsGeometryAnalyzer::centroids( QgsVectorLayer* layer, const QString& shape
   QGis::WkbType outputType = QGis::WKBPoint;
   const QgsCoordinateReferenceSystem crs = layer->crs();
 
-  QgsVectorFileWriter vWriter( shapefileName, dp->encoding(), layer->pendingFields(), outputType, &crs );
+  QgsVectorFileWriter vWriter( shapefileName, dp->encoding(), layer->fields(), outputType, &crs );
   QgsFeature currentFeature;
 
   //take only selection
@@ -622,7 +622,7 @@ bool QgsGeometryAnalyzer::dissolve( QgsVectorLayer* layer, const QString& shapef
   QGis::WkbType outputType = dp->geometryType();
   const QgsCoordinateReferenceSystem crs = layer->crs();
 
-  QgsVectorFileWriter vWriter( shapefileName, dp->encoding(), layer->pendingFields(), outputType, &crs );
+  QgsVectorFileWriter vWriter( shapefileName, dp->encoding(), layer->fields(), outputType, &crs );
   QgsFeature currentFeature;
   QMultiMap<QString, QgsFeatureId> map;
 
@@ -775,7 +775,7 @@ bool QgsGeometryAnalyzer::buffer( QgsVectorLayer* layer, const QString& shapefil
   }
   const QgsCoordinateReferenceSystem crs = layer->crs();
 
-  QgsVectorFileWriter vWriter( shapefileName, dp->encoding(), layer->pendingFields(), outputType, &crs );
+  QgsVectorFileWriter vWriter( shapefileName, dp->encoding(), layer->fields(), outputType, &crs );
   QgsFeature currentFeature;
   QgsGeometry *dissolveGeometry = 0; //dissolve geometry (if dissolve enabled)
 
@@ -946,14 +946,14 @@ bool QgsGeometryAnalyzer::eventLayer( QgsVectorLayer* lineLayer, QgsVectorLayer*
     }
     fileWriter = new QgsVectorFileWriter( outputLayer,
                                           eventLayer->dataProvider()->encoding(),
-                                          eventLayer->pendingFields(),
+                                          eventLayer->fields(),
                                           memoryProviderType,
                                           &( lineLayer->crs() ),
                                           outputFormat );
   }
   else
   {
-    memoryProvider->addAttributes( eventLayer->pendingFields().toList() );
+    memoryProvider->addAttributes( eventLayer->fields().toList() );
   }
 
   //iterate over eventLayer and write new features to output file or layer

--- a/src/analysis/vector/qgsgeometryanalyzer.cpp
+++ b/src/analysis/vector/qgsgeometryanalyzer.cpp
@@ -961,7 +961,7 @@ bool QgsGeometryAnalyzer::eventLayer( QgsVectorLayer* lineLayer, QgsVectorLayer*
   QgsGeometry* lrsGeom = 0;
   double measure1, measure2 = 0.0;
 
-  int nEventFeatures = eventLayer->pendingFeatureCount();
+  int nEventFeatures = eventLayer->featureCount();
   int featureCounter = 0;
   int nOutputFeatures = 0; //number of output features for the current event feature
   if ( p )

--- a/src/analysis/vector/qgsoverlayanalyzer.cpp
+++ b/src/analysis/vector/qgsoverlayanalyzer.cpp
@@ -45,8 +45,8 @@ bool QgsOverlayAnalyzer::intersection( QgsVectorLayer* layerA, QgsVectorLayer* l
 
   QGis::WkbType outputType = dpA->geometryType();
   const QgsCoordinateReferenceSystem crs = layerA->crs();
-  QgsFields fieldsA = layerA->pendingFields();
-  QgsFields fieldsB = layerB->pendingFields();
+  QgsFields fieldsA = layerA->fields();
+  QgsFields fieldsB = layerB->fields();
   combineFieldLists( fieldsA, fieldsB );
 
   QgsVectorFileWriter vWriter( shapefileName, dpA->encoding(), fieldsA, outputType, &crs );

--- a/src/analysis/vector/qgspointsample.cpp
+++ b/src/analysis/vector/qgspointsample.cpp
@@ -67,7 +67,7 @@ int QgsPointSample::createRandomPoints( QProgressDialog* pd )
   mNCreatedPoints = 0;
 
   QgsFeatureIterator fIt = mInputLayer->getFeatures( QgsFeatureRequest().setSubsetOfAttributes(
-                             QStringList() << mNumberOfPointsAttribute << mMinDistanceAttribute, mInputLayer->pendingFields() ) );
+                             QStringList() << mNumberOfPointsAttribute << mMinDistanceAttribute, mInputLayer->fields() ) );
   while ( fIt.nextFeature( fet ) )
   {
     nPoints = fet.attribute( mNumberOfPointsAttribute ).toInt();

--- a/src/analysis/vector/qgstransectsample.cpp
+++ b/src/analysis/vector/qgstransectsample.cpp
@@ -55,7 +55,7 @@ int QgsTransectSample::createSample( QProgressDialog* pd )
   QVariant::Type stratumIdType = QVariant::Int;
   if ( !mStrataIdAttribute.isEmpty() )
   {
-    stratumIdType = mStrataLayer->pendingFields().field( mStrataIdAttribute ).type();
+    stratumIdType = mStrataLayer->fields().field( mStrataIdAttribute ).type();
   }
 
   //create vector file writers for output
@@ -118,7 +118,7 @@ int QgsTransectSample::createSample( QProgressDialog* pd )
   mt_srand( QTime::currentTime().msec() );
 
   QgsFeatureRequest fr;
-  fr.setSubsetOfAttributes( QStringList() << mStrataIdAttribute << mMinDistanceAttribute << mNPointsAttribute, mStrataLayer->pendingFields() );
+  fr.setSubsetOfAttributes( QStringList() << mStrataIdAttribute << mMinDistanceAttribute << mNPointsAttribute, mStrataLayer->fields() );
   QgsFeatureIterator strataIt = mStrataLayer->getFeatures( fr );
 
   QgsFeature fet;
@@ -333,7 +333,7 @@ QgsGeometry* QgsTransectSample::findBaselineGeometry( QVariant strataId )
     return 0;
   }
 
-  QgsFeatureIterator baseLineIt = mBaselineLayer->getFeatures( QgsFeatureRequest().setSubsetOfAttributes( QStringList( mBaselineStrataId ), mBaselineLayer->pendingFields() ) );
+  QgsFeatureIterator baseLineIt = mBaselineLayer->getFeatures( QgsFeatureRequest().setSubsetOfAttributes( QStringList( mBaselineStrataId ), mBaselineLayer->fields() ) );
   QgsFeature fet;
 
   while ( baseLineIt.nextFeature( fet ) ) //todo: cache this in case there are many baslines

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -6275,11 +6275,11 @@ void QgisApp::editPaste( QgsMapLayer *destinationLayer )
   QgsFeatureList features;
   if ( mMapCanvas->mapSettings().hasCrsTransformEnabled() )
   {
-    features = clipboard()->transformedCopyOf( pasteVectorLayer->crs(), pasteVectorLayer->pendingFields() );
+    features = clipboard()->transformedCopyOf( pasteVectorLayer->crs(), pasteVectorLayer->fields() );
   }
   else
   {
-    features = clipboard()->copyOf( pasteVectorLayer->pendingFields() );
+    features = clipboard()->copyOf( pasteVectorLayer->fields() );
   }
   int nTotalFeatures = features.count();
 
@@ -6295,7 +6295,7 @@ void QgisApp::editPaste( QgsMapLayer *destinationLayer )
     remap.insert( idx, dst );
   }
 
-  int dstAttrCount = pasteVectorLayer->pendingFields().count();
+  int dstAttrCount = pasteVectorLayer->fields().count();
 
   QgsFeatureList::iterator featureIt = features.begin();
   while ( featureIt != features.end() )

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -6285,7 +6285,7 @@ void QgisApp::editPaste( QgsMapLayer *destinationLayer )
 
   QHash<int, int> remap;
   const QgsFields &fields = clipboard()->fields();
-  QgsAttributeList pkAttrList = pasteVectorLayer->pendingPkAttributesList();
+  QgsAttributeList pkAttrList = pasteVectorLayer->pkAttributeList();
   for ( int idx = 0; idx < fields.count(); ++idx )
   {
     int dst = pasteVectorLayer->fieldNameIndex( fields[idx].name() );

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -307,7 +307,7 @@ void QgsAttributeTableDialog::columnBoxInit()
   mFilterButton->addAction( mActionFilterColumnsMenu );
   mFilterButton->addAction( mActionAdvancedFilter );
 
-  QList<QgsField> fields = mLayer->pendingFields().toList();
+  QList<QgsField> fields = mLayer->fields().toList();
 
   foreach ( const QgsField field, fields )
   {
@@ -364,7 +364,7 @@ void QgsAttributeTableDialog::runFieldCalculation( QgsVectorLayer* layer, QStrin
 
   int rownum = 1;
 
-  const QgsField &fld = layer->pendingFields()[ fieldindex ];
+  const QgsField &fld = layer->fields()[ fieldindex ];
 
   //go through all the features and change the new attributes
   QgsFeatureIterator fit = layer->getFeatures( request );
@@ -762,7 +762,7 @@ void QgsAttributeTableDialog::setFilterExpression( QString filterString )
     return;
   }
 
-  if ( ! filterExpression.prepare( mLayer->pendingFields() ) )
+  if ( ! filterExpression.prepare( mLayer->fields() ) )
   {
     QgisApp::instance()->messageBar()->pushMessage( tr( "Evaluation error" ), filterExpression.evalErrorString(), QgsMessageBar::WARNING, QgisApp::instance()->messageTimeout() );
   }
@@ -773,7 +773,7 @@ void QgsAttributeTableDialog::setFilterExpression( QString filterString )
 
   filterExpression.setGeomCalculator( myDa );
   QgsFeatureRequest request( mMainView->masterModel()->request() );
-  request.setSubsetOfAttributes( filterExpression.referencedColumns(), mLayer->pendingFields() );
+  request.setSubsetOfAttributes( filterExpression.referencedColumns(), mLayer->fields() );
   if ( !fetchGeom )
   {
     request.setFlags( QgsFeatureRequest::NoGeometry );

--- a/src/app/qgsattributetypedialog.cpp
+++ b/src/app/qgsattributetypedialog.cpp
@@ -43,7 +43,7 @@ QgsAttributeTypeDialog::QgsAttributeTypeDialog( QgsVectorLayer *vl, int fieldIdx
     , mFieldIdx( fieldIdx )
 {
   setupUi( this );
-  setWindowTitle( tr( "Edit Widget Properties - %1 (%2)" ).arg( vl->pendingFields()[fieldIdx].name() ).arg( vl->name() ) );
+  setWindowTitle( tr( "Edit Widget Properties - %1 (%2)" ).arg( vl->fields()[fieldIdx].name() ).arg( vl->name() ) );
 
   connect( selectionListWidget, SIGNAL( currentRowChanged( int ) ), this, SLOT( setStackPage( int ) ) );
 
@@ -65,8 +65,8 @@ QgsAttributeTypeDialog::QgsAttributeTypeDialog( QgsVectorLayer *vl, int fieldIdx
   selectionListWidget->setMaximumWidth( selectionListWidget->sizeHintForColumn( 0 )
                                         + 2 );
 
-  if ( vl->pendingFields().fieldOrigin( fieldIdx ) == QgsFields::OriginJoin ||
-       vl->pendingFields().fieldOrigin( fieldIdx ) == QgsFields::OriginExpression )
+  if ( vl->fields().fieldOrigin( fieldIdx ) == QgsFields::OriginJoin ||
+       vl->fields().fieldOrigin( fieldIdx ) == QgsFields::OriginExpression )
   {
     isFieldEditableCheckBox->setEnabled( false );
   }

--- a/src/app/qgsclipboard.cpp
+++ b/src/app/qgsclipboard.cpp
@@ -52,7 +52,7 @@ void QgsClipboard::replaceWithCopyOf( QgsVectorLayer *src )
     return;
 
   // Replace the QGis clipboard.
-  mFeatureFields = src->pendingFields();
+  mFeatureFields = src->fields();
   mFeatureClipboard = src->selectedFeatures();
   mCRS = src->crs();
 

--- a/src/app/qgsdelattrdialog.cpp
+++ b/src/app/qgsdelattrdialog.cpp
@@ -31,11 +31,11 @@ QgsDelAttrDialog::QgsDelAttrDialog( const QgsVectorLayer* vl )
   {
     bool canDeleteAttributes = vl->dataProvider()->capabilities() & QgsVectorDataProvider::DeleteAttributes;
     listBox2->clear();
-    const QgsFields& layerAttributes = vl->pendingFields();
+    const QgsFields& layerAttributes = vl->fields();
     for ( int idx = 0; idx < layerAttributes.count(); ++idx )
     {
       QListWidgetItem* item = new QListWidgetItem( layerAttributes[idx].name(), listBox2 );
-      switch ( vl->pendingFields().fieldOrigin( idx ) )
+      switch ( vl->fields().fieldOrigin( idx ) )
       {
         case QgsFields::OriginExpression:
           item->setIcon( QgsApplication::getThemeIcon( "/mIconExpression.svg" ) );

--- a/src/app/qgsdiagramproperties.cpp
+++ b/src/app/qgsdiagramproperties.cpp
@@ -157,7 +157,7 @@ QgsDiagramProperties::QgsDiagramProperties( QgsVectorLayer* layer, QWidget* pare
   mSizeFieldExpressionWidget->setGeomCalculator( myDa );
 
   //insert all attributes into the combo boxes
-  const QgsFields& layerFields = layer->pendingFields();
+  const QgsFields& layerFields = layer->fields();
   for ( int idx = 0; idx < layerFields.count(); ++idx )
   {
     QTreeWidgetItem *newItem = new QTreeWidgetItem( mAttributesTreeWidget );
@@ -342,7 +342,7 @@ QgsDiagramProperties::QgsDiagramProperties( QgsVectorLayer* layer, QWidget* pare
         }
         else
         {
-          mSizeFieldExpressionWidget->setField( mLayer->pendingFields().at( lidr->classificationAttribute() ).name() );
+          mSizeFieldExpressionWidget->setField( mLayer->fields().at( lidr->classificationAttribute() ).name() );
         }
       }
     }
@@ -526,7 +526,7 @@ void QgsDiagramProperties::on_mFindMaximumValueButton_clicked()
   if ( isExpression )
   {
     QgsExpression exp( sizeFieldNameOrExp );
-    exp.prepare( mLayer->pendingFields() );
+    exp.prepare( mLayer->fields() );
     if ( !exp.hasEvalError() )
     {
       QgsFeature feature;
@@ -543,7 +543,7 @@ void QgsDiagramProperties::on_mFindMaximumValueButton_clicked()
   }
   else
   {
-    int attributeNumber = mLayer->pendingFields().fieldNameIndex( sizeFieldNameOrExp );
+    int attributeNumber = mLayer->fields().fieldNameIndex( sizeFieldNameOrExp );
     maxValue = mLayer->maximumValue( attributeNumber ).toFloat();
   }
 
@@ -726,7 +726,7 @@ void QgsDiagramProperties::apply()
     }
     else
     {
-      int attributeNumber = mLayer->pendingFields().fieldNameIndex( sizeFieldNameOrExp );
+      int attributeNumber = mLayer->fields().fieldNameIndex( sizeFieldNameOrExp );
       dr->setClassificationAttribute( attributeNumber );
     }
     dr->setDiagram( diagram );

--- a/src/app/qgsdxfexportdialog.cpp
+++ b/src/app/qgsdxfexportdialog.cpp
@@ -70,8 +70,8 @@ void FieldSelectorDelegate::setEditorData( QWidget *editor, const QModelIndex &i
     return;
 
   int idx = m->attributeIndex( vl );
-  if ( vl->pendingFields().exists( idx ) )
-    fcb->setField( vl->pendingFields()[ idx ].name() );
+  if ( vl->fields().exists( idx ) )
+    fcb->setField( vl->fields()[ idx ].name() );
 }
 
 void FieldSelectorDelegate::setModelData( QWidget *editor, QAbstractItemModel *model, const QModelIndex &index ) const
@@ -215,8 +215,8 @@ QVariant QgsVectorLayerAndAttributeModel::data( const QModelIndex& idx, int role
 
     if ( role == Qt::DisplayRole )
     {
-      if ( vl->pendingFields().exists( idx ) )
-        return vl->pendingFields()[ idx ].name();
+      if ( vl->fields().exists( idx ) )
+        return vl->fields()[ idx ].name();
       else
         return vl->name();
     }

--- a/src/app/qgsfeatureaction.cpp
+++ b/src/app/qgsfeatureaction.cpp
@@ -141,7 +141,7 @@ bool QgsFeatureAction::addFeature( const QgsAttributeMap& defaultAttributes, boo
   QgsDebugMsg( QString( "reuseLastValues: %1" ).arg( reuseLastValues ) );
 
   // add the fields to the QgsFeature
-  const QgsFields& fields = mLayer->pendingFields();
+  const QgsFields& fields = mLayer->fields();
   mFeature.initAttributes( fields.count() );
   for ( int idx = 0; idx < fields.count(); ++idx )
   {
@@ -226,7 +226,7 @@ void QgsFeatureAction::onFeatureSaved( const QgsFeature& feature )
 
   if ( reuseLastValues )
   {
-    QgsFields fields = mLayer->pendingFields();
+    QgsFields fields = mLayer->fields();
     for ( int idx = 0; idx < fields.count(); ++idx )
     {
       QgsAttributes newValues = feature.attributes();

--- a/src/app/qgsfieldcalculator.cpp
+++ b/src/app/qgsfieldcalculator.cpp
@@ -152,7 +152,7 @@ void QgsFieldCalculator::accept()
   QgsExpression exp( calcString );
   exp.setGeomCalculator( myDa );
 
-  if ( ! exp.prepare( mVectorLayer->pendingFields() ) )
+  if ( ! exp.prepare( mVectorLayer->fields() ) )
   {
     QMessageBox::critical( 0, tr( "Evaluation error" ), exp.evalErrorString() );
     return;
@@ -198,7 +198,7 @@ void QgsFieldCalculator::accept()
       }
 
       //get index of the new field
-      const QgsFields& fields = mVectorLayer->pendingFields();
+      const QgsFields& fields = mVectorLayer->fields();
 
       for ( int idx = 0; idx < fields.count(); ++idx )
       {
@@ -209,7 +209,7 @@ void QgsFieldCalculator::accept()
         }
       }
 
-      if ( ! exp.prepare( mVectorLayer->pendingFields() ) )
+      if ( ! exp.prepare( mVectorLayer->fields() ) )
       {
         QApplication::restoreOverrideCursor();
         QMessageBox::critical( 0, tr( "Evaluation error" ), exp.evalErrorString() );
@@ -235,7 +235,7 @@ void QgsFieldCalculator::accept()
     bool useGeometry = exp.needsGeometry();
     int rownum = 1;
 
-    const QgsField& field = mVectorLayer->pendingFields()[mAttributeId];
+    const QgsField& field = mVectorLayer->fields()[mAttributeId];
 
     bool newField = !mUpdateExistingGroupBox->isChecked();
     QVariant emptyAttribute;
@@ -400,7 +400,7 @@ void QgsFieldCalculator::populateFields()
   if ( !mVectorLayer )
     return;
 
-  const QgsFields& fields = mVectorLayer->pendingFields();
+  const QgsFields& fields = mVectorLayer->fields();
   for ( int idx = 0; idx < fields.count(); ++idx )
   {
 

--- a/src/app/qgsfieldsproperties.cpp
+++ b/src/app/qgsfieldsproperties.cpp
@@ -205,7 +205,7 @@ void QgsFieldsProperties::loadAttributeEditorTree()
 void QgsFieldsProperties::loadRows()
 {
   disconnect( mFieldsList, SIGNAL( cellChanged( int, int ) ), this, SLOT( attributesListCellChanged( int, int ) ) );
-  const QgsFields &fields = mLayer->pendingFields();
+  const QgsFields &fields = mLayer->fields();
 
   mIndexedWidgets.clear();
   mFieldsList->setRowCount( 0 );
@@ -223,7 +223,7 @@ void QgsFieldsProperties::setRow( int row, int idx, const QgsField& field )
   dataItem->setData( Qt::DisplayRole, idx );
   DesignerTreeItemData itemData( DesignerTreeItemData::Field, field.name() );
   dataItem->setData( DesignerTreeRole, itemData.asQVariant() );
-  switch ( mLayer->pendingFields().fieldOrigin( idx ) )
+  switch ( mLayer->fields().fieldOrigin( idx ) )
   {
     case QgsFields::OriginExpression:
       dataItem->setIcon( QgsApplication::getThemeIcon( "/mIconExpression.svg" ) );
@@ -244,7 +244,7 @@ void QgsFieldsProperties::setRow( int row, int idx, const QgsField& field )
   mFieldsList->setItem( row, attrTypeNameCol, new QTableWidgetItem( field.typeName() ) );
   mFieldsList->setItem( row, attrLengthCol, new QTableWidgetItem( QString::number( field.length() ) ) );
   mFieldsList->setItem( row, attrPrecCol, new QTableWidgetItem( QString::number( field.precision() ) ) );
-  if ( mLayer->pendingFields().fieldOrigin( idx ) == QgsFields::OriginExpression )
+  if ( mLayer->fields().fieldOrigin( idx ) == QgsFields::OriginExpression )
   {
     QWidget* expressionWidget = new QWidget;
     expressionWidget->setLayout( new QHBoxLayout );
@@ -476,7 +476,7 @@ void QgsFieldsProperties::attributeAdded( int idx )
   if ( sorted )
     mFieldsList->setSortingEnabled( false );
 
-  const QgsFields &fields = mLayer->pendingFields();
+  const QgsFields &fields = mLayer->fields();
   int row = mFieldsList->rowCount();
   mFieldsList->insertRow( row );
   setRow( row, idx, fields[idx] );
@@ -574,7 +574,7 @@ void QgsFieldsProperties::on_mDeleteAttributeButton_clicked()
       if ( idx < 0 )
         continue;
 
-      if ( mLayer->pendingFields().fieldOrigin( idx ) == QgsFields::OriginExpression )
+      if ( mLayer->fields().fieldOrigin( idx ) == QgsFields::OriginExpression )
         expressionFields << idx;
       else
         providerFields << idx;
@@ -620,7 +620,7 @@ void QgsFieldsProperties::updateButtons()
       if ( item->column() == 0 )
       {
         int idx = mIndexedWidgets.indexOf( item );
-        if ( mLayer->pendingFields().fieldOrigin( idx ) != QgsFields::OriginExpression )
+        if ( mLayer->fields().fieldOrigin( idx ) != QgsFields::OriginExpression )
         {
           mDeleteAttributeButton->setEnabled( false );
           break;
@@ -637,7 +637,7 @@ void QgsFieldsProperties::attributesListCellChanged( int row, int column )
   {
     int idx = mFieldsList->item( row, attrIdCol )->text().toInt();
 
-    const QgsFields &fields = mLayer->pendingFields();
+    const QgsFields &fields = mLayer->fields();
 
     if ( idx >= fields.count() )
     {
@@ -860,8 +860,8 @@ QgsFieldsProperties::FieldConfig::FieldConfig( QgsVectorLayer* layer, int idx )
     : mButton( 0 )
 {
   mEditable = layer->fieldEditable( idx );
-  mEditableEnabled = layer->pendingFields().fieldOrigin( idx ) != QgsFields::OriginJoin
-                     && layer->pendingFields().fieldOrigin( idx ) != QgsFields::OriginExpression;
+  mEditableEnabled = layer->fields().fieldOrigin( idx ) != QgsFields::OriginJoin
+                     && layer->fields().fieldOrigin( idx ) != QgsFields::OriginExpression;
   mLabelOnTop = layer->labelOnTop( idx );
   mEditorWidgetV2Type = layer->editorWidgetV2( idx );
   mEditorWidgetV2Config = layer->editorWidgetV2Config( idx );

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -400,7 +400,7 @@ void QgsIdentifyResultsDialog::addFeature( QgsVectorLayer *vlayer, const QgsFeat
     connect( vlayer, SIGNAL( editingStopped() ), this, SLOT( editingToggled() ) );
   }
 
-  QgsIdentifyResultsFeatureItem *featItem = new QgsIdentifyResultsFeatureItem( vlayer->pendingFields(), f, vlayer->crs() );
+  QgsIdentifyResultsFeatureItem *featItem = new QgsIdentifyResultsFeatureItem( vlayer->fields(), f, vlayer->crs() );
   featItem->setData( 0, Qt::UserRole, FID_TO_STRING( f.id() ) );
   featItem->setData( 0, Qt::UserRole + 1, mFeatures.size() );
   mFeatures << f;
@@ -421,13 +421,13 @@ void QgsIdentifyResultsDialog::addFeature( QgsVectorLayer *vlayer, const QgsFeat
   //get valid QgsMapLayerActions for this layer
   QList< QgsMapLayerAction* > registeredActions = QgsMapLayerActionRegistry::instance()->mapLayerActions( vlayer );
 
-  if ( vlayer->pendingFields().size() > 0 || vlayer->actions()->size() || registeredActions.size() )
+  if ( vlayer->fields().size() > 0 || vlayer->actions()->size() || registeredActions.size() )
   {
     QTreeWidgetItem *actionItem = new QTreeWidgetItem( QStringList() << tr( "(Actions)" ) );
     actionItem->setData( 0, Qt::UserRole, "actions" );
     featItem->addChild( actionItem );
 
-    if ( vlayer->pendingFields().size() > 0 )
+    if ( vlayer->fields().size() > 0 )
     {
       QTreeWidgetItem *editItem = new QTreeWidgetItem( QStringList() << "" << ( vlayer->isEditable() ? tr( "Edit feature form" ) : tr( "View feature form" ) ) );
       editItem->setIcon( 0, QgsApplication::getThemeIcon( "/mActionPropertyItem.png" ) );
@@ -463,7 +463,7 @@ void QgsIdentifyResultsDialog::addFeature( QgsVectorLayer *vlayer, const QgsFeat
     }
   }
 
-  const QgsFields &fields = vlayer->pendingFields();
+  const QgsFields &fields = vlayer->fields();
   QgsAttributes attrs = f.attributes();
   bool featureLabeled = false;
   for ( int i = 0; i < attrs.count(); ++i )
@@ -1156,7 +1156,7 @@ void QgsIdentifyResultsDialog::doAction( QTreeWidgetItem *item, int action )
   {
     QString fieldName = item->data( 0, Qt::DisplayRole ).toString();
 
-    const QgsFields& fields = layer->pendingFields();
+    const QgsFields& fields = layer->fields();
     for ( int fldIdx = 0; fldIdx < fields.count(); ++fldIdx )
     {
       if ( fields[fldIdx].name() == fieldName )
@@ -1452,10 +1452,10 @@ void QgsIdentifyResultsDialog::attributeValueChanged( QgsFeatureId fid, int idx,
   if ( !layItem )
     return;
 
-  if ( idx >= vlayer->pendingFields().size() )
+  if ( idx >= vlayer->fields().size() )
     return;
 
-  const QgsField &fld = vlayer->pendingFields().at( idx );
+  const QgsField &fld = vlayer->fields().at( idx );
 
   for ( int i = 0; i < layItem->childCount(); i++ )
   {
@@ -1688,7 +1688,7 @@ void QgsIdentifyResultsDialog::copyFeatureAttributes()
     QgsAttributeMap attributes;
     retrieveAttributes( lstResults->currentItem(), attributes, idx );
 
-    const QgsFields &fields = vlayer->pendingFields();
+    const QgsFields &fields = vlayer->fields();
 
     for ( QgsAttributeMap::const_iterator it = attributes.begin(); it != attributes.end(); ++it )
     {

--- a/src/app/qgsjoindialog.cpp
+++ b/src/app/qgsjoindialog.cpp
@@ -145,7 +145,7 @@ void QgsJoinDialog::joinedLayerChanged( QgsMapLayer* layer )
 
   mUseJoinFieldsSubset->setChecked( false );
   QStandardItemModel* subsetModel = new QStandardItemModel( this );
-  const QgsFields& layerFields = vLayer->pendingFields();
+  const QgsFields& layerFields = vLayer->fields();
   for ( int idx = 0; idx < layerFields.count(); ++idx )
   {
     QStandardItem* subsetItem = new QStandardItem( layerFields[idx].name() );

--- a/src/app/qgslabelpropertydialog.cpp
+++ b/src/app/qgslabelpropertydialog.cpp
@@ -93,7 +93,7 @@ void QgsLabelPropertyDialog::init( const QString& layerId, int featureId, const 
       if ( mCurLabelField >= 0 )
       {
         mLabelTextLineEdit->setText( attributeValues[mCurLabelField].toString() );
-        const QgsFields& layerFields = vlayer->pendingFields();
+        const QgsFields& layerFields = vlayer->fields();
         switch ( layerFields[mCurLabelField].type() )
         {
           case QVariant::Double:
@@ -218,7 +218,7 @@ void QgsLabelPropertyDialog::setDataDefinedValues( const QgsPalLayerSettings &la
       dd->prepareExpression( vlayer );
     }
 
-    QVariant result = layerSettings.dataDefinedValue( propIt.key(), mCurLabelFeat, vlayer->pendingFields() );
+    QVariant result = layerSettings.dataDefinedValue( propIt.key(), mCurLabelFeat, vlayer->fields() );
     if ( !result.isValid() || result.isNull() )
     {
       //could not evaluate data defined value

--- a/src/app/qgsmaptooladdfeature.cpp
+++ b/src/app/qgsmaptooladdfeature.cpp
@@ -124,7 +124,7 @@ void QgsMapToolAddFeature::canvasMapReleaseEvent( QgsMapMouseEvent* e )
     //grass provider has its own mechanism of feature addition
     if ( provider->capabilities() & QgsVectorDataProvider::AddFeatures )
     {
-      QgsFeature f( vlayer->pendingFields(), 0 );
+      QgsFeature f( vlayer->fields(), 0 );
 
       QgsGeometry *g = 0;
       if ( layerWKBType == QGis::WKBPoint || layerWKBType == QGis::WKBPoint25D )
@@ -200,7 +200,7 @@ void QgsMapToolAddFeature::canvasMapReleaseEvent( QgsMapMouseEvent* e )
       }
 
       //create QgsFeature with wkb representation
-      QgsFeature* f = new QgsFeature( vlayer->pendingFields(), 0 );
+      QgsFeature* f = new QgsFeature( vlayer->fields(), 0 );
 
       QgsGeometry *g;
 

--- a/src/app/qgsmaptoolfillring.cpp
+++ b/src/app/qgsmaptoolfillring.cpp
@@ -153,7 +153,7 @@ void QgsMapToolFillRing::canvasMapReleaseEvent( QgsMapMouseEvent * e )
       while ( fit.nextFeature( f ) )
       {
         //create QgsFeature with wkb representation
-        QgsFeature* ft = new QgsFeature( vlayer->pendingFields(), 0 );
+        QgsFeature* ft = new QgsFeature( vlayer->fields(), 0 );
 
         QgsGeometry *g;
         g = QgsGeometry::fromPolygon( QgsPolygon() << points().toVector() );

--- a/src/app/qgsmaptooloffsetcurve.cpp
+++ b/src/app/qgsmaptooloffsetcurve.cpp
@@ -162,8 +162,8 @@ void QgsMapToolOffsetCurve::applyOffset()
     f.setGeometry( mModifiedGeometry );
 
     //add empty values for all fields (allows inserting attribute values via the feature form in the same session)
-    QgsAttributes attrs( layer->pendingFields().count() );
-    const QgsFields& fields = layer->pendingFields();
+    QgsAttributes attrs( layer->fields().count() );
+    const QgsFields& fields = layer->fields();
     for ( int idx = 0; idx < fields.count(); ++idx )
     {
       attrs[idx] = QVariant();

--- a/src/app/qgsmaptoolrotatepointsymbols.cpp
+++ b/src/app/qgsmaptoolrotatepointsymbols.cpp
@@ -278,7 +278,7 @@ void QgsMapToolRotatePointSymbols::createPixmapItem( QgsFeature& f )
   {
     QgsFeatureRendererV2* rv2 = mActiveLayer->rendererV2()->clone();
     rv2->setRotationField( "" );
-    rv2->startRender( renderContext, mActiveLayer->pendingFields() );
+    rv2->startRender( renderContext, mActiveLayer->fields() );
 
     QgsSymbolV2* symbolV2 = rv2->symbolForFeature( f );
     if ( symbolV2 )

--- a/src/app/qgsmaptoolselectutils.cpp
+++ b/src/app/qgsmaptoolselectutils.cpp
@@ -139,13 +139,13 @@ void QgsMapToolSelectUtils::setSelectFeatures( QgsMapCanvas* canvas,
   QgsRenderContext context = QgsRenderContext::fromMapSettings( canvas->mapSettings() );
   QgsFeatureRendererV2* r = vlayer->rendererV2();
   if ( r )
-    r->startRender( context, vlayer->pendingFields() );
+    r->startRender( context, vlayer->fields() );
 
   QgsFeatureRequest request;
   request.setFilterRect( selectGeomTrans.boundingBox() );
   request.setFlags( QgsFeatureRequest::ExactIntersect );
   if ( r )
-    request.setSubsetOfAttributes( r->usedAttributes(), vlayer->pendingFields() );
+    request.setSubsetOfAttributes( r->usedAttributes(), vlayer->fields() );
   else
     request.setSubsetOfAttributes( QgsAttributeList() );
 

--- a/src/app/qgsmergeattributesdialog.cpp
+++ b/src/app/qgsmergeattributesdialog.cpp
@@ -88,7 +88,7 @@ void QgsMergeAttributesDialog::createTableWidgetContents()
 
   //create combo boxes and insert attribute names
   const QgsFields& fields = mVectorLayer->fields();
-  QSet<int> pkAttrList = mVectorLayer->pendingPkAttributesList().toSet();
+  QSet<int> pkAttrList = mVectorLayer->pkAttributeList().toSet();
 
   int col = 0;
   for ( int idx = 0; idx < fields.count(); ++idx )
@@ -487,7 +487,7 @@ void QgsMergeAttributesDialog::on_mFromSelectedPushButton_clicked()
     return;
   }
 
-  QSet<int> pkAttributes = mVectorLayer->pendingPkAttributesList().toSet();
+  QSet<int> pkAttributes = mVectorLayer->pkAttributeList().toSet();
   for ( int i = 0; i < mTableWidget->columnCount(); ++i )
   {
     if ( pkAttributes.contains( i ) )

--- a/src/app/qgsmergeattributesdialog.cpp
+++ b/src/app/qgsmergeattributesdialog.cpp
@@ -87,7 +87,7 @@ void QgsMergeAttributesDialog::createTableWidgetContents()
   mTableWidget->setRowCount( mFeatureList.size() + 2 );
 
   //create combo boxes and insert attribute names
-  const QgsFields& fields = mVectorLayer->pendingFields();
+  const QgsFields& fields = mVectorLayer->fields();
   QSet<int> pkAttrList = mVectorLayer->pendingPkAttributesList().toSet();
 
   int col = 0;
@@ -305,7 +305,7 @@ QVariant QgsMergeAttributesDialog::featureAttribute( int featureId, int col )
   }
   else
   {
-    return QVariant( mVectorLayer->pendingFields()[col].type() );
+    return QVariant( mVectorLayer->fields()[col].type() );
   }
 }
 
@@ -331,7 +331,7 @@ QVariant QgsMergeAttributesDialog::minimumAttribute( int col )
 
   if ( numberOfConsideredFeatures < 1 )
   {
-    return QVariant( mVectorLayer->pendingFields()[col].type() );
+    return QVariant( mVectorLayer->fields()[col].type() );
   }
 
   return QVariant( minimumValue );
@@ -359,7 +359,7 @@ QVariant QgsMergeAttributesDialog::maximumAttribute( int col )
 
   if ( numberOfConsideredFeatures < 1 )
   {
-    return QVariant( mVectorLayer->pendingFields()[col].type() );
+    return QVariant( mVectorLayer->fields()[col].type() );
   }
 
   return QVariant( maximumValue );
@@ -384,7 +384,7 @@ QVariant QgsMergeAttributesDialog::meanAttribute( int col )
 
   if ( numberOfConsideredFeatures < 1 )
   {
-    return QVariant( mVectorLayer->pendingFields()[col].type() );
+    return QVariant( mVectorLayer->fields()[col].type() );
   }
 
   double mean = sum / numberOfConsideredFeatures;
@@ -415,7 +415,7 @@ QVariant QgsMergeAttributesDialog::medianAttribute( int col )
 
   if ( size < 1 )
   {
-    return QVariant( mVectorLayer->pendingFields()[col].type() );
+    return QVariant( mVectorLayer->fields()[col].type() );
   }
 
   bool even = ( size % 2 ) < 1;
@@ -585,7 +585,7 @@ QgsAttributes QgsMergeAttributesDialog::mergedAttributes() const
     return QgsAttributes();
   }
 
-  QgsFields fields = mVectorLayer->pendingFields();
+  QgsFields fields = mVectorLayer->fields();
 
   QgsAttributes results( mTableWidget->columnCount() );
   for ( int i = 0; i < mTableWidget->columnCount(); i++ )

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -154,7 +154,7 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
   // Create the Actions dialog tab
   QVBoxLayout *actionLayout = new QVBoxLayout( actionOptionsFrame );
   actionLayout->setMargin( 0 );
-  const QgsFields &fields = layer->pendingFields();
+  const QgsFields &fields = layer->fields();
   actionDialog = new QgsAttributeActionDialog( layer->actions(), fields, actionOptionsFrame );
   actionDialog->layout()->setMargin( 0 );
   actionLayout->addWidget( actionDialog );
@@ -402,7 +402,7 @@ void QgsVectorLayerProperties::syncToLayer( void )
   }
 
   //get field list for display field combo
-  const QgsFields& myFields = layer->pendingFields();
+  const QgsFields& myFields = layer->fields();
   for ( int idx = 0; idx < myFields.count(); ++idx )
   {
     displayFieldComboBox->addItem( myFields[idx].name() );
@@ -453,7 +453,7 @@ void QgsVectorLayerProperties::syncToLayer( void )
   actionDialog->init();
 
   // reset fields in label dialog
-  layer->label()->setFields( layer->pendingFields() );
+  layer->label()->setFields( layer->fields() );
 
   if ( layer->hasGeometryType() )
   {
@@ -1062,7 +1062,7 @@ void QgsVectorLayerProperties::on_mButtonAddJoin_clicked()
       QgsVectorLayer* joinLayer = qobject_cast<QgsVectorLayer*>( QgsMapLayerRegistry::instance()->mapLayer( info.joinLayerId ) );
       if ( joinLayer )
       {
-        joinLayer->dataProvider()->createAttributeIndex( joinLayer->pendingFields().indexFromName( info.joinFieldName ) );
+        joinLayer->dataProvider()->createAttributeIndex( joinLayer->fields().indexFromName( info.joinFieldName ) );
       }
     }
     layer->addJoin( info );
@@ -1122,7 +1122,7 @@ void QgsVectorLayerProperties::on_mButtonEditJoin_clicked()
       QgsVectorLayer* joinLayer = qobject_cast<QgsVectorLayer*>( QgsMapLayerRegistry::instance()->mapLayer( info.joinLayerId ) );
       if ( joinLayer )
       {
-        joinLayer->dataProvider()->createAttributeIndex( joinLayer->pendingFields().indexFromName( info.joinFieldName ) );
+        joinLayer->dataProvider()->createAttributeIndex( joinLayer->fields().indexFromName( info.joinFieldName ) );
       }
     }
     layer->addJoin( info );
@@ -1147,18 +1147,18 @@ void QgsVectorLayerProperties::addJoinToTreeWidget( const QgsVectorJoinInfo& joi
   joinItem->setText( 0, joinLayer->name() );
   joinItem->setData( 0, Qt::UserRole, join.joinLayerId );
 
-  if ( join.joinFieldName.isEmpty() && join.joinFieldIndex >= 0 && join.joinFieldIndex < joinLayer->pendingFields().count() )
+  if ( join.joinFieldName.isEmpty() && join.joinFieldIndex >= 0 && join.joinFieldIndex < joinLayer->fields().count() )
   {
-    joinItem->setText( 1, joinLayer->pendingFields().field( join.joinFieldIndex ).name() );   //for compatibility with 1.x
+    joinItem->setText( 1, joinLayer->fields().field( join.joinFieldIndex ).name() );   //for compatibility with 1.x
   }
   else
   {
     joinItem->setText( 1, join.joinFieldName );
   }
 
-  if ( join.targetFieldName.isEmpty() && join.targetFieldIndex >= 0 && join.targetFieldIndex < layer->pendingFields().count() )
+  if ( join.targetFieldName.isEmpty() && join.targetFieldIndex >= 0 && join.targetFieldIndex < layer->fields().count() )
   {
-    joinItem->setText( 2, layer->pendingFields().field( join.targetFieldIndex ).name() );   //for compatibility with 1.x
+    joinItem->setText( 2, layer->fields().field( join.targetFieldIndex ).name() );   //for compatibility with 1.x
   }
   else
   {

--- a/src/core/composer/qgsatlascomposition.cpp
+++ b/src/core/composer/qgsatlascomposition.cpp
@@ -158,7 +158,7 @@ void QgsAtlasComposition::setSortKeyAttributeIndex( int idx )
 {
   if ( mCoverageLayer )
   {
-    const QgsFields fields = mCoverageLayer->pendingFields();
+    const QgsFields fields = mCoverageLayer->fields();
     if ( idx >= 0 && idx < fields.count() )
     {
       mSortKeyAttributeName = fields[idx].name();
@@ -235,7 +235,7 @@ int QgsAtlasComposition::updateFeatures()
   {
     if ( !filterExpression.isNull() )
     {
-      QVariant result = filterExpression->evaluate( &feat, mCoverageLayer->pendingFields() );
+      QVariant result = filterExpression->evaluate( &feat, mCoverageLayer->fields() );
       if ( filterExpression->hasEvalError() )
       {
         QgsMessageLog::logMessage( tr( "Atlas filter eval error: %1" ).arg( filterExpression->evalErrorString() ), tr( "Composer" ) );
@@ -707,7 +707,7 @@ void QgsAtlasComposition::readXML( const QDomElement& atlasElem, const QDomDocum
     int idx = mSortKeyAttributeName.toInt( &isIndex );
     if ( isIndex && mCoverageLayer )
     {
-      const QgsFields fields = mCoverageLayer->pendingFields();
+      const QgsFields fields = mCoverageLayer->fields();
       if ( idx >= 0 && idx < fields.count() )
       {
         mSortKeyAttributeName = fields[idx].name();
@@ -786,7 +786,7 @@ bool QgsAtlasComposition::updateFilenameExpression()
     return false;
   }
 
-  const QgsFields& fields = mCoverageLayer->pendingFields();
+  const QgsFields& fields = mCoverageLayer->fields();
 
   if ( mFilenamePattern.size() > 0 )
   {
@@ -816,7 +816,7 @@ bool QgsAtlasComposition::evalFeatureFilename()
   //generate filename for current atlas feature
   if ( mFilenamePattern.size() > 0 && !mFilenameExpr.isNull() )
   {
-    QVariant filenameRes = mFilenameExpr->evaluate( &mCurrentFeature, mCoverageLayer->pendingFields() );
+    QVariant filenameRes = mFilenameExpr->evaluate( &mCurrentFeature, mCoverageLayer->fields() );
     if ( mFilenameExpr->hasEvalError() )
     {
       QgsMessageLog::logMessage( tr( "Atlas filename evaluation error: %1" ).arg( mFilenameExpr->evalErrorString() ), tr( "Composer" ) );

--- a/src/core/composer/qgscomposerattributetable.cpp
+++ b/src/core/composer/qgscomposerattributetable.cpp
@@ -181,7 +181,7 @@ void QgsComposerAttributeTable::resetColumns()
   mColumns.clear();
 
   //rebuild columns list from vector layer fields
-  const QgsFields& fields = mVectorLayer->pendingFields();
+  const QgsFields& fields = mVectorLayer->fields();
   for ( int idx = 0; idx < fields.count(); ++idx )
   {
     QString currentAlias = mVectorLayer->attributeDisplayName( idx );
@@ -274,7 +274,7 @@ void QgsComposerAttributeTable::setDisplayAttributes( const QSet<int>& attr, boo
   qDeleteAll( mColumns );
   mColumns.clear();
 
-  const QgsFields& fields = mVectorLayer->pendingFields();
+  const QgsFields& fields = mVectorLayer->fields();
 
   if ( !attr.empty() )
   {
@@ -424,7 +424,7 @@ bool QgsComposerAttributeTable::getFeatureAttributes( QList<QgsAttributeMap> &at
     //check feature against filter
     if ( activeFilter && !filterExpression.isNull() )
     {
-      QVariant result = filterExpression->evaluate( &f, mVectorLayer->pendingFields() );
+      QVariant result = filterExpression->evaluate( &f, mVectorLayer->fields() );
       // skip this feature if the filter evaluation is false
       if ( !result.toBool() )
       {
@@ -448,7 +448,7 @@ bool QgsComposerAttributeTable::getFeatureAttributes( QList<QgsAttributeMap> &at
         // Lets assume it's an expression
         QgsExpression* expression = new QgsExpression(( *columnIt )->attribute() );
         expression->setCurrentRowNumber( counter + 1 );
-        expression->prepare( mVectorLayer->pendingFields() );
+        expression->prepare( mVectorLayer->fields() );
         QVariant value = expression->evaluate( f );
         attributeMaps.last().insert( i, value.toString() );
       }
@@ -684,7 +684,7 @@ bool QgsComposerAttributeTable::readXML( const QDomElement& itemElem, const QDom
   if ( !sortColumnsElem.isNull() && mVectorLayer )
   {
     QDomNodeList columns = sortColumnsElem.elementsByTagName( "column" );
-    const QgsFields& fields = mVectorLayer->pendingFields();
+    const QgsFields& fields = mVectorLayer->fields();
 
     for ( int i = 0; i < columns.size(); ++i )
     {

--- a/src/core/composer/qgscomposerattributetablev2.cpp
+++ b/src/core/composer/qgscomposerattributetablev2.cpp
@@ -253,7 +253,7 @@ void QgsComposerAttributeTableV2::resetColumns()
   mColumns.clear();
 
   //rebuild columns list from vector layer fields
-  const QgsFields& fields = source->pendingFields();
+  const QgsFields& fields = source->fields();
   for ( int idx = 0; idx < fields.count(); ++idx )
   {
     QString currentAlias = source->attributeDisplayName( idx );
@@ -371,7 +371,7 @@ void QgsComposerAttributeTableV2::setDisplayAttributes( const QSet<int>& attr, b
   qDeleteAll( mColumns );
   mColumns.clear();
 
-  const QgsFields& fields = source->pendingFields();
+  const QgsFields& fields = source->fields();
 
   if ( !attr.empty() )
   {
@@ -530,7 +530,7 @@ bool QgsComposerAttributeTableV2::getTableContents( QgsComposerTableContents &co
     //check feature against filter
     if ( activeFilter && !filterExpression.isNull() )
     {
-      QVariant result = filterExpression->evaluate( &f, layer->pendingFields() );
+      QVariant result = filterExpression->evaluate( &f, layer->fields() );
       // skip this feature if the filter evaluation is false
       if ( !result.toBool() )
       {
@@ -568,7 +568,7 @@ bool QgsComposerAttributeTableV2::getTableContents( QgsComposerTableContents &co
         // Lets assume it's an expression
         QgsExpression* expression = new QgsExpression(( *columnIt )->attribute() );
         expression->setCurrentRowNumber( counter + 1 );
-        expression->prepare( layer->pendingFields() );
+        expression->prepare( layer->fields() );
         QVariant value = expression->evaluate( f );
         currentRow << value;
       }

--- a/src/core/composer/qgscomposerlegend.cpp
+++ b/src/core/composer/qgscomposerlegend.cpp
@@ -602,8 +602,8 @@ QVariant QgsLegendModelV2::data( const QModelIndex& index, int role ) const
       if ( nodeLayer->customProperty( "showFeatureCount", 0 ).toInt() && role == Qt::DisplayRole )
       {
         QgsVectorLayer* vlayer = qobject_cast<QgsVectorLayer*>( nodeLayer->layer() );
-        if ( vlayer && vlayer->pendingFeatureCount() >= 0 )
-          name += QString( " [%1]" ).arg( vlayer->pendingFeatureCount() );
+        if ( vlayer && vlayer->featureCount() >= 0 )
+          name += QString( " [%1]" ).arg( vlayer->featureCount() );
       }
       return name;
     }

--- a/src/core/composer/qgscomposition.cpp
+++ b/src/core/composer/qgscomposition.cpp
@@ -3049,13 +3049,13 @@ bool QgsComposition::dataDefinedEvaluate( QgsComposerObject::DataDefinedProperty
 
   //get fields and feature from atlas
   const QgsFeature* currentFeature = 0;
-  const QgsFields* layerFields = 0;
+  QgsFields layerFields;
   if ( mAtlasComposition.enabled() )
   {
     QgsVectorLayer* atlasLayer = mAtlasComposition.coverageLayer();
     if ( atlasLayer )
     {
-      layerFields = &atlasLayer->pendingFields();
+      layerFields = atlasLayer->fields();
     }
     if ( mAtlasMode != QgsComposition::AtlasOff )
     {
@@ -3104,7 +3104,7 @@ bool QgsComposition::dataDefinedActive( const QgsComposerObject::DataDefinedProp
   return dd->isActive();
 }
 
-QVariant QgsComposition::dataDefinedValue( QgsComposerObject::DataDefinedProperty property, const QgsFeature *feature, const QgsFields *fields, QMap<QgsComposerObject::DataDefinedProperty, QgsDataDefined *> *dataDefinedProperties ) const
+QVariant QgsComposition::dataDefinedValue( QgsComposerObject::DataDefinedProperty property, const QgsFeature *feature, const QgsFields& fields, QMap<QgsComposerObject::DataDefinedProperty, QgsDataDefined *> *dataDefinedProperties ) const
 {
   if ( property == QgsComposerObject::AllProperties || property == QgsComposerObject::NoProperty )
   {
@@ -3154,14 +3154,14 @@ QVariant QgsComposition::dataDefinedValue( QgsComposerObject::DataDefinedPropert
       return QVariant();
     }
   }
-  else if ( !useExpression && !field.isEmpty() && fields )
+  else if ( !useExpression && !field.isEmpty() )
   {
     if ( !feature )
     {
       return QVariant();
     }
     // use direct attribute access instead of evaluating "field" expression (much faster)
-    int indx = fields->indexFromName( field );
+    int indx = fields.indexFromName( field );
     if ( indx != -1 )
     {
       result = feature->attribute( indx );

--- a/src/core/composer/qgscomposition.h
+++ b/src/core/composer/qgscomposition.h
@@ -838,7 +838,7 @@ class CORE_EXPORT QgsComposition : public QGraphicsScene
      * @param dataDefinedProperties map of data defined properties to QgsDataDefined
      * @note this method was added in version 2.5
     */
-    QVariant dataDefinedValue( QgsComposerObject::DataDefinedProperty property, const QgsFeature *feature, const QgsFields *fields,
+    QVariant dataDefinedValue( QgsComposerObject::DataDefinedProperty property, const QgsFeature *feature, const QgsFields& fields,
                                QMap<QgsComposerObject::DataDefinedProperty, QgsDataDefined *> *dataDefinedProperties ) const;
 
 

--- a/src/core/dxf/qgsdxfexport.cpp
+++ b/src/core/dxf/qgsdxfexport.cpp
@@ -901,12 +901,12 @@ void QgsDxfExport::writeEntities()
     {
       continue;
     }
-    renderer->startRender( ctx, vl->pendingFields() );
+    renderer->startRender( ctx, vl->fields() );
 
     QStringList attributes = renderer->usedAttributes();
-    if ( vl->pendingFields().exists( layerIt->second ) )
+    if ( vl->fields().exists( layerIt->second ) )
     {
-      QString layerAttr = vl->pendingFields().at( layerIt->second ).name();
+      QString layerAttr = vl->fields().at( layerIt->second ).name();
       if ( !attributes.contains( layerAttr ) )
         attributes << layerAttr;
     }
@@ -922,7 +922,7 @@ void QgsDxfExport::writeEntities()
       continue;
     }
 
-    QgsFeatureRequest freq = QgsFeatureRequest().setSubsetOfAttributes( attributes, vl->pendingFields() );
+    QgsFeatureRequest freq = QgsFeatureRequest().setSubsetOfAttributes( attributes, vl->fields() );
     if ( !mExtent.isEmpty() )
     {
       freq.setFilterRect( mExtent );
@@ -1001,7 +1001,7 @@ void QgsDxfExport::writeEntitiesSymbolLevels( QgsVectorLayer* layer )
 
   QgsRenderContext ctx = renderContext();
   QgsSymbolV2RenderContext sctx( ctx, QgsSymbolV2::MM, 1.0, false, 0, 0 );
-  renderer->startRender( ctx, layer->pendingFields() );
+  renderer->startRender( ctx, layer->fields() );
 
   // get iterator
   QgsFeatureRequest req;
@@ -1009,7 +1009,7 @@ void QgsDxfExport::writeEntitiesSymbolLevels( QgsVectorLayer* layer )
   {
     req.setFlags( QgsFeatureRequest::NoGeometry );
   }
-  req.setSubsetOfAttributes( QStringList( renderer->usedAttributes() ), layer->pendingFields() );
+  req.setSubsetOfAttributes( QStringList( renderer->usedAttributes() ), layer->fields() );
   if ( !mExtent.isEmpty() )
   {
     req.setFilterRect( mExtent );

--- a/src/core/layertree/qgslayertreemodel.cpp
+++ b/src/core/layertree/qgslayertreemodel.cpp
@@ -168,8 +168,8 @@ QVariant QgsLayerTreeModel::data( const QModelIndex &index, int role ) const
       if ( nodeLayer->customProperty( "showFeatureCount", 0 ).toInt() && role == Qt::DisplayRole )
       {
         QgsVectorLayer* vlayer = qobject_cast<QgsVectorLayer*>( nodeLayer->layer() );
-        if ( vlayer && vlayer->pendingFeatureCount() >= 0 )
-          name += QString( " [%1]" ).arg( vlayer->pendingFeatureCount() );
+        if ( vlayer && vlayer->featureCount() >= 0 )
+          name += QString( " [%1]" ).arg( vlayer->featureCount() );
       }
       return name;
     }

--- a/src/core/layertree/qgslayertreemodellegendnode.cpp
+++ b/src/core/layertree/qgslayertreemodellegendnode.cpp
@@ -413,8 +413,8 @@ void QgsSymbolV2LegendNode::updateLabel()
       layerName = mLayerNode->customProperty( "legend/title-label" ).toString();
 
     mLabel = mUserLabel.isEmpty() ? layerName : mUserLabel;
-    if ( showFeatureCount && vl && vl->pendingFeatureCount() >= 0 )
-      mLabel += QString( " [%1]" ).arg( vl->pendingFeatureCount() );
+    if ( showFeatureCount && vl && vl->featureCount() >= 0 )
+      mLabel += QString( " [%1]" ).arg( vl->featureCount() );
   }
   else
   {

--- a/src/core/qgsattributeaction.cpp
+++ b/src/core/qgsattributeaction.cpp
@@ -149,7 +149,7 @@ QString QgsAttributeAction::expandAction( QString action, const QgsAttributeMap 
   else
     expanded_action = action;
 
-  const QgsFields &fields = mLayer->pendingFields();
+  const QgsFields &fields = mLayer->fields();
 
   for ( int i = 0; i < 4; i++ )
   {
@@ -215,7 +215,7 @@ QString QgsAttributeAction::expandAction( QString action, QgsFeature &feat, cons
       continue;
     }
 
-    QVariant result = exp.evaluate( &feat, mLayer->pendingFields() );
+    QVariant result = exp.evaluate( &feat, mLayer->fields() );
     if ( exp.hasEvalError() )
     {
       QgsDebugMsg( "Expression parser eval error: " + exp.evalErrorString() );

--- a/src/core/qgsdatadefined.cpp
+++ b/src/core/qgsdatadefined.cpp
@@ -150,7 +150,7 @@ bool QgsDataDefined::prepareExpression( QgsVectorLayer* layer )
 {
   if ( layer )
   {
-    return prepareExpression( layer->pendingFields() );
+    return prepareExpression( layer->fields() );
   }
   else
   {
@@ -221,7 +221,7 @@ QStringList QgsDataDefined::referencedColumns( QgsVectorLayer* layer )
 {
   if ( layer )
   {
-    return referencedColumns( layer->pendingFields() );
+    return referencedColumns( layer->fields() );
   }
   else
   {

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -2177,7 +2177,7 @@ QString QgsExpression::replaceExpressionText( const QString &action, const QgsFe
     QVariant result;
     if ( layer )
     {
-      result = exp.evaluate( feat, layer->pendingFields() );
+      result = exp.evaluate( feat, layer->fields() );
     }
     else
     {

--- a/src/core/qgslegacyhelpers.cpp
+++ b/src/core/qgslegacyhelpers.cpp
@@ -140,7 +140,7 @@ const QString QgsLegacyHelpers::convertEditType( QgsVectorLayer::EditType editTy
     {
       widgetType = "TextEdit";
       cfg.insert( "IsMultiline", false );
-      vl->setFieldEditable( vl->pendingFields().fieldNameIndex( name ), false );
+      vl->setFieldEditable( vl->fields().fieldNameIndex( name ), false );
       break;
     }
 

--- a/src/core/qgsmaphittest.cpp
+++ b/src/core/qgsmaphittest.cpp
@@ -54,7 +54,7 @@ void QgsMapHitTest::runHitTestLayer( QgsVectorLayer* vl, SymbolV2Set& usedSymbol
 {
   QgsFeatureRendererV2* r = vl->rendererV2();
   bool moreSymbolsPerFeature = r->capabilities() & QgsFeatureRendererV2::MoreSymbolsPerFeature;
-  r->startRender( context, vl->pendingFields() );
+  r->startRender( context, vl->fields() );
   QgsFeature f;
   QgsFeatureRequest request( context.extent() );
   request.setFlags( QgsFeatureRequest::ExactIntersect );

--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -712,7 +712,7 @@ void QgsOfflineEditing::applyFeaturesAdded( QgsVectorLayer* offlineLayer, QgsVec
   QList<int> newFeatureIds = sqlQueryInts( db, sql );
 
   // get default value for each field
-  const QgsFields& remoteFlds = remoteLayer->pendingFields();
+  const QgsFields& remoteFlds = remoteLayer->fields();
   QVector<QVariant> defaultValues( remoteFlds.count() );
   for ( int i = 0; i < remoteFlds.count(); ++i )
   {
@@ -735,7 +735,7 @@ void QgsOfflineEditing::applyFeaturesAdded( QgsVectorLayer* offlineLayer, QgsVec
   emit progressModeSet( QgsOfflineEditing::AddFeatures, features.size() );
 
   int i = 1;
-  int newAttrsCount = remoteLayer->pendingFields().count();
+  int newAttrsCount = remoteLayer->fields().count();
   for ( QgsFeatureList::iterator it = features.begin(); it != features.end(); ++it )
   {
     QgsFeature f = *it;

--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -883,8 +883,8 @@ void QgsOfflineEditing::copySymbology( QgsVectorLayer* sourceLayer, QgsVectorLay
 // NOTE: use this to map column indices in case the remote geometry column is not last
 QMap<int, int> QgsOfflineEditing::attributeLookup( QgsVectorLayer* offlineLayer, QgsVectorLayer* remoteLayer )
 {
-  const QgsAttributeList& offlineAttrs = offlineLayer->pendingAllAttributesList();
-  const QgsAttributeList& remoteAttrs = remoteLayer->pendingAllAttributesList();
+  const QgsAttributeList& offlineAttrs = offlineLayer->attributeList();
+  const QgsAttributeList& remoteAttrs = remoteLayer->attributeList();
 
   QMap < int /*offline attr*/, int /*remote attr*/ > attrLookup;
   // NOTE: use size of remoteAttrs, as offlineAttrs can have new attributes not yet synced

--- a/src/core/qgspallabeling.cpp
+++ b/src/core/qgspallabeling.cpp
@@ -79,7 +79,6 @@ QgsPalLayerSettings::QgsPalLayerSettings()
     : upsidedownLabels( Upright )
     , palLayer( NULL )
     , mCurFeat( 0 )
-    , mCurFields( 0 )
     , xform( NULL )
     , ct( NULL )
     , extentGeom( NULL )
@@ -323,7 +322,6 @@ QgsPalLayerSettings::QgsPalLayerSettings()
 QgsPalLayerSettings::QgsPalLayerSettings( const QgsPalLayerSettings& s )
     : palLayer( NULL )
     , mCurFeat( NULL )
-    , mCurFields( NULL )
     , fieldIndex( 0 )
     , xform( NULL )
     , ct( NULL )
@@ -1221,7 +1219,7 @@ bool QgsPalLayerSettings::dataDefinedEvaluate( DataDefinedProperties p, QVariant
   // null passed-around QVariant
   exprVal.clear();
 
-  QVariant result = dataDefinedValue( p, *mCurFeat, *mCurFields );
+  QVariant result = dataDefinedValue( p, *mCurFeat, mCurFields );
 
   if ( result.isValid() && !result.isNull() )
   {
@@ -1317,13 +1315,13 @@ void QgsPalLayerSettings::calculateLabelSize( const QFontMetricsF* fm, QString t
   }
   else // called externally with passed-in feature, evaluate data defined
   {
-    QVariant exprVal = dataDefinedValue( QgsPalLayerSettings::MultiLineWrapChar, *f, *mCurFields );
+    QVariant exprVal = dataDefinedValue( QgsPalLayerSettings::MultiLineWrapChar, *f, mCurFields );
     if ( exprVal.isValid() )
     {
       wrapchr = exprVal.toString();
     }
     exprVal.clear();
-    exprVal = dataDefinedValue( QgsPalLayerSettings::MultiLineHeight, *f, *mCurFields );
+    exprVal = dataDefinedValue( QgsPalLayerSettings::MultiLineHeight, *f, mCurFields );
     if ( exprVal.isValid() )
     {
       bool ok;
@@ -1335,7 +1333,7 @@ void QgsPalLayerSettings::calculateLabelSize( const QFontMetricsF* fm, QString t
     }
 
     exprVal.clear();
-    exprVal = dataDefinedValue( QgsPalLayerSettings::DirSymbDraw, *f, *mCurFields );
+    exprVal = dataDefinedValue( QgsPalLayerSettings::DirSymbDraw, *f, mCurFields );
     if ( exprVal.isValid() )
     {
       addDirSymb = exprVal.toBool();
@@ -1344,19 +1342,19 @@ void QgsPalLayerSettings::calculateLabelSize( const QFontMetricsF* fm, QString t
     if ( addDirSymb ) // don't do extra evaluations if not adding a direction symbol
     {
       exprVal.clear();
-      exprVal = dataDefinedValue( QgsPalLayerSettings::DirSymbLeft, *f, *mCurFields );
+      exprVal = dataDefinedValue( QgsPalLayerSettings::DirSymbLeft, *f, mCurFields );
       if ( exprVal.isValid() )
       {
         leftDirSymb = exprVal.toString();
       }
       exprVal.clear();
-      exprVal = dataDefinedValue( QgsPalLayerSettings::DirSymbRight, *f, *mCurFields );
+      exprVal = dataDefinedValue( QgsPalLayerSettings::DirSymbRight, *f, mCurFields );
       if ( exprVal.isValid() )
       {
         rightDirSymb = exprVal.toString();
       }
       exprVal.clear();
-      exprVal = dataDefinedValue( QgsPalLayerSettings::DirSymbPlacement, *f, *mCurFields );
+      exprVal = dataDefinedValue( QgsPalLayerSettings::DirSymbPlacement, *f, mCurFields );
       if ( exprVal.isValid() )
       {
         bool ok;
@@ -3266,7 +3264,7 @@ int QgsPalLabeling::prepareLayer( QgsVectorLayer* layer, QStringList& attrNames,
   // start using the reference to the layer in hashtable instead of local instance
   QgsPalLayerSettings& lyr = mActiveLayers[layer->id()];
 
-  lyr.mCurFields = &( layer->pendingFields() );
+  lyr.mCurFields = layer->fields();
 
   if ( lyrTmp.drawLabels )
   {
@@ -3275,7 +3273,7 @@ int QgsPalLabeling::prepareLayer( QgsVectorLayer* layer, QStringList& attrNames,
     {
       // prepare expression for use in QgsPalLayerSettings::registerFeature()
       QgsExpression* exp = lyr.getLabelExpression();
-      exp->prepare( layer->pendingFields() );
+      exp->prepare( layer->fields() );
       if ( exp->hasEvalError() )
       {
         QgsDebugMsgLevel( "Prepare error:" + exp->evalErrorString(), 4 );
@@ -3455,7 +3453,7 @@ int QgsPalLabeling::addDiagramLayer( QgsVectorLayer* layer, const QgsDiagramLaye
 
   s2.xform = &mMapSettings->mapToPixel();
 
-  s2.fields = layer->pendingFields();
+  s2.fields = layer->fields();
 
   s2.renderer = layer->diagramRenderer()->clone();
 

--- a/src/core/qgspallabeling.h
+++ b/src/core/qgspallabeling.h
@@ -547,7 +547,7 @@ class CORE_EXPORT QgsPalLayerSettings
     // NOTE: not in Python binding
     pal::Layer* palLayer;
     QgsFeature* mCurFeat;
-    const QgsFields* mCurFields;
+    QgsFields mCurFields;
     int fieldIndex;
     const QgsMapToPixel* xform;
     const QgsCoordinateTransform* ct;

--- a/src/core/qgsrelation.cpp
+++ b/src/core/qgsrelation.cpp
@@ -155,8 +155,8 @@ QgsFeatureRequest QgsRelation::getRelatedFeaturesRequest( const QgsFeature& feat
 
   Q_FOREACH ( const QgsRelation::FieldPair& fieldPair, mFieldPairs )
   {
-    int referencingIdx = referencingLayer()->pendingFields().indexFromName( fieldPair.referencingField() );
-    QgsField referencingField = referencingLayer()->pendingFields().at( referencingIdx );
+    int referencingIdx = referencingLayer()->fields().indexFromName( fieldPair.referencingField() );
+    QgsField referencingField = referencingLayer()->fields().at( referencingIdx );
 
     if ( referencingField.type() == QVariant::String )
     {
@@ -185,10 +185,10 @@ QgsFeatureRequest QgsRelation::getReferencedFeatureRequest( const QgsAttributes&
 
   Q_FOREACH ( const QgsRelation::FieldPair& fieldPair, mFieldPairs )
   {
-    int referencedIdx = referencedLayer()->pendingFields().indexFromName( fieldPair.referencedField() );
-    int referencingIdx = referencingLayer()->pendingFields().indexFromName( fieldPair.referencingField() );
+    int referencedIdx = referencedLayer()->fields().indexFromName( fieldPair.referencedField() );
+    int referencingIdx = referencingLayer()->fields().indexFromName( fieldPair.referencingField() );
 
-    QgsField referencedField = referencedLayer()->pendingFields().at( referencedIdx );
+    QgsField referencedField = referencedLayer()->fields().at( referencedIdx );
 
     if ( referencedField.type() == QVariant::String )
     {

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -1945,7 +1945,7 @@ QgsVectorFileWriter::WriterError QgsVectorFileWriter::writeAsVectorFormat( QgsVe
     errorMessage->clear();
   }
 
-  QgsAttributeList allAttr = skipAttributeCreation ? QgsAttributeList() : layer->pendingAllAttributesList();
+  QgsAttributeList allAttr = skipAttributeCreation ? QgsAttributeList() : layer->attributeList();
   QgsFeature fet;
 
   //add possible attributes needed by renderer

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -1872,7 +1872,7 @@ QgsVectorFileWriter::WriterError QgsVectorFileWriter::writeAsVectorFormat( QgsVe
   }
 
   QGis::WkbType wkbType = layer->wkbType();
-  QgsFields fields = skipAttributeCreation ? QgsFields() : layer->pendingFields();
+  QgsFields fields = skipAttributeCreation ? QgsFields() : layer->fields();
 
   if ( layer->providerType() == "ogr" && layer->dataProvider() )
   {
@@ -2672,7 +2672,7 @@ void QgsVectorFileWriter::startRender( QgsVectorLayer* vl ) const
   }
 
   QgsRenderContext ctx = renderContext();
-  renderer->startRender( ctx, vl->pendingFields() );
+  renderer->startRender( ctx, vl->fields() );
 }
 
 void QgsVectorFileWriter::stopRender( QgsVectorLayer* vl ) const

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -675,17 +675,6 @@ bool QgsVectorLayer::diagramsEnabled() const
   return false;
 }
 
-long QgsVectorLayer::featureCount() const
-{
-  if ( !mDataProvider )
-  {
-    QgsDebugMsg( "invoked with null mDataProvider" );
-    return 0;
-  }
-
-  return mDataProvider->featureCount();
-}
-
 long QgsVectorLayer::featureCount( QgsSymbolV2* symbol )
 {
   if ( !mSymbolFeatureCounted ) return -1;
@@ -716,7 +705,7 @@ bool QgsVectorLayer::countSymbolFeatures( bool showProgress )
     mSymbolFeatureCountMap.insert( symbolIt->second, 0 );
   }
 
-  long nFeatures = pendingFeatureCount();
+  long nFeatures = featureCount();
   QProgressDialog progressDialog( tr( "Updating feature count for layer %1" ).arg( name() ), tr( "Abort" ), 0, nFeatures );
   progressDialog.setWindowTitle( tr( "QGIS" ) );
   progressDialog.setWindowModality( Qt::WindowModal );
@@ -2218,12 +2207,7 @@ bool QgsVectorLayer::deleteFeature( QgsFeatureId fid )
   return res;
 }
 
-QgsAttributeList QgsVectorLayer::pendingAllAttributesList()
-{
-  return mUpdatedFields.allAttributesList();
-}
-
-QgsAttributeList QgsVectorLayer::pendingPkAttributesList()
+QgsAttributeList QgsVectorLayer::pkAttributeList() const
 {
   QgsAttributeList pkAttributesList;
 
@@ -2238,7 +2222,7 @@ QgsAttributeList QgsVectorLayer::pendingPkAttributesList()
   return pkAttributesList;
 }
 
-int QgsVectorLayer::pendingFeatureCount()
+long QgsVectorLayer::featureCount() const
 {
   return mDataProvider->featureCount() +
          ( mEditBuffer ? mEditBuffer->mAddedFeatures.size() - mEditBuffer->mDeletedFeatureIds.size() : 0 );
@@ -3563,7 +3547,7 @@ QString QgsVectorLayer::metadata()
     myMetadata += "</p>\n";
   }
 
-  QgsAttributeList pkAttrList = pendingPkAttributesList();
+  QgsAttributeList pkAttrList = pkAttributeList();
   if ( !pkAttrList.isEmpty() )
   {
     myMetadata += "<p class=\"glossy\">" + tr( "Primary key attributes" ) + "</p>\n";

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -244,12 +244,11 @@ void QgsVectorLayer::setDisplayField( QString fldName )
   }
   else
   {
-    const QgsFields &fields = pendingFields();
-    int fieldsSize = fields.size();
+    int fieldsSize = mUpdatedFields.size();
 
-    for ( int idx = 0; idx < fields.count(); ++idx )
+    for ( int idx = 0; idx < mUpdatedFields.count(); ++idx )
     {
-      QString fldName = fields[idx].name();
+      QString fldName = mUpdatedFields[idx].name();
       QgsDebugMsg( "Checking field " + fldName + " of " + QString::number( fieldsSize ) + " total" );
 
       // Check the fields and keep the first one that matches.
@@ -295,7 +294,7 @@ void QgsVectorLayer::setDisplayField( QString fldName )
       }
       else
       {
-        mDisplayField = fields[0].name();
+        mDisplayField = mUpdatedFields[0].name();
       }
     }
 
@@ -324,7 +323,7 @@ void QgsVectorLayer::drawLabels( QgsRenderContext& rendererContext )
       attributes.append( attrNum );
     }
     // make sure the renderer is ready for classification ("symbolForFeature")
-    mRendererV2->startRender( rendererContext, pendingFields() );
+    mRendererV2->startRender( rendererContext, fields() );
 
     // Add fields required for labels
     mLabel->addRequiredFields( attributes );
@@ -728,7 +727,7 @@ bool QgsVectorLayer::countSymbolFeatures( bool showProgress )
   // Renderer (rule based) may depend on context scale, with scale is ignored if 0
   QgsRenderContext renderContext;
   renderContext.setRendererScale( 0 );
-  mRendererV2->startRender( renderContext, pendingFields() );
+  mRendererV2->startRender( renderContext, fields() );
 
   QgsFeature f;
   while ( fit.nextFeature( f ) )
@@ -1704,8 +1703,8 @@ bool QgsVectorLayer::readSymbology( const QDomNode& node, QString& errorMessage 
       {
         int index = aliasElem.attribute( "index" ).toInt();
 
-        if ( index >= 0 && index < pendingFields().count() )
-          field = pendingFields()[ index ].name();
+        if ( index >= 0 && index < fields().count() )
+          field = fields()[ index ].name();
       }
 
       mAttributeAliasMap.insert( field, aliasElem.attribute( "name" ) );
@@ -2092,10 +2091,10 @@ bool QgsVectorLayer::addAttribute( const QgsField &field )
 
 void QgsVectorLayer::remAttributeAlias( int attIndex )
 {
-  if ( attIndex < 0 || attIndex >= pendingFields().count() )
+  if ( attIndex < 0 || attIndex >= fields().count() )
     return;
 
-  QString name = pendingFields()[ attIndex ].name();
+  QString name = fields()[ attIndex ].name();
   if ( mAttributeAliasMap.contains( name ) )
   {
     mAttributeAliasMap.remove( name );
@@ -2105,10 +2104,10 @@ void QgsVectorLayer::remAttributeAlias( int attIndex )
 
 void QgsVectorLayer::addAttributeAlias( int attIndex, QString aliasString )
 {
-  if ( attIndex < 0 || attIndex >= pendingFields().count() )
+  if ( attIndex < 0 || attIndex >= fields().count() )
     return;
 
-  QString name = pendingFields()[ attIndex ].name();
+  QString name = fields()[ attIndex ].name();
 
   mAttributeAliasMap.insert( name, aliasString );
   emit layerModified(); // TODO[MD]: should have a different signal?
@@ -2147,10 +2146,10 @@ const QgsEditorWidgetConfig QgsVectorLayer::editorWidgetV2Config( const QString&
 
 QString QgsVectorLayer::attributeAlias( int attributeIndex ) const
 {
-  if ( attributeIndex < 0 || attributeIndex >= pendingFields().count() )
+  if ( attributeIndex < 0 || attributeIndex >= fields().count() )
     return "";
 
-  QString name = pendingFields()[ attributeIndex ].name();
+  QString name = fields()[ attributeIndex ].name();
 
   return mAttributeAliasMap.value( name, "" );
 }
@@ -2160,10 +2159,9 @@ QString QgsVectorLayer::attributeDisplayName( int attributeIndex ) const
   QString displayName = attributeAlias( attributeIndex );
   if ( displayName.isEmpty() )
   {
-    const QgsFields& fields = pendingFields();
-    if ( attributeIndex >= 0 && attributeIndex < fields.count() )
+    if ( attributeIndex >= 0 && attributeIndex < mUpdatedFields.count() )
     {
-      displayName = fields[attributeIndex].name();
+      displayName = mUpdatedFields[attributeIndex].name();
     }
   }
   return displayName;
@@ -2171,7 +2169,7 @@ QString QgsVectorLayer::attributeDisplayName( int attributeIndex ) const
 
 bool QgsVectorLayer::deleteAttribute( int index )
 {
-  if ( index < 0 || index >= pendingFields().count() )
+  if ( index < 0 || index >= fields().count() )
     return false;
 
   if ( mUpdatedFields.fieldOrigin( index ) == QgsFields::OriginExpression )
@@ -2740,13 +2738,12 @@ QSize QgsVectorLayer::widgetSize( int idx )
 
 bool QgsVectorLayer::fieldEditable( int idx )
 {
-  const QgsFields &fields = pendingFields();
-  if ( idx >= 0 && idx < fields.count() )
+  if ( idx >= 0 && idx < mUpdatedFields.count() )
   {
     if ( mUpdatedFields.fieldOrigin( idx ) == QgsFields::OriginJoin
          || mUpdatedFields.fieldOrigin( idx ) == QgsFields::OriginExpression )
       return false;
-    return mFieldEditables.value( fields[idx].name(), true );
+    return mFieldEditables.value( mUpdatedFields[idx].name(), true );
   }
   else
     return true;
@@ -2754,25 +2751,22 @@ bool QgsVectorLayer::fieldEditable( int idx )
 
 bool QgsVectorLayer::labelOnTop( int idx )
 {
-  const QgsFields &fields = pendingFields();
-  if ( idx >= 0 && idx < fields.count() )
-    return mLabelOnTop.value( fields[idx].name(), false );
+  if ( idx >= 0 && idx < mUpdatedFields.count() )
+    return mLabelOnTop.value( mUpdatedFields[idx].name(), false );
   else
     return false;
 }
 
 void QgsVectorLayer::setFieldEditable( int idx, bool editable )
 {
-  const QgsFields &fields = pendingFields();
-  if ( idx >= 0 && idx < fields.count() )
-    mFieldEditables[ fields[idx].name()] = editable;
+  if ( idx >= 0 && idx < mUpdatedFields.count() )
+    mFieldEditables[ mUpdatedFields[idx].name()] = editable;
 }
 
 void QgsVectorLayer::setLabelOnTop( int idx, bool onTop )
 {
-  const QgsFields &fields = pendingFields();
-  if ( idx >= 0 && idx < fields.count() )
-    mLabelOnTop[ fields[idx].name()] = onTop;
+  if ( idx >= 0 && idx < mUpdatedFields.count() )
+    mLabelOnTop[ mUpdatedFields[idx].name()] = onTop;
 }
 
 QgsFeatureRendererV2* QgsVectorLayer::rendererV2()
@@ -2858,7 +2852,7 @@ void QgsVectorLayer::setCheckedState( int idx, QString checked, QString unchecke
 
 int QgsVectorLayer::fieldNameIndex( const QString& fieldName ) const
 {
-  return pendingFields().fieldNameIndex( fieldName );
+  return fields().fieldNameIndex( fieldName );
 }
 
 bool QgsVectorLayer::addJoin( const QgsVectorJoinInfo& joinInfo )
@@ -3173,7 +3167,7 @@ QList<QVariant> QgsVectorLayer::getValues( const QString &fieldOrExpression, boo
   {
     // try to use expression
     expression.reset( new QgsExpression( fieldOrExpression ) );
-    if ( expression->hasParserError() || !expression->prepare( pendingFields() ) )
+    if ( expression->hasParserError() || !expression->prepare( fields() ) )
     {
       ok = false;
       return values;
@@ -3191,7 +3185,7 @@ QList<QVariant> QgsVectorLayer::getValues( const QString &fieldOrExpression, boo
                               .setFlags(( expression && expression->needsGeometry() ) ?
                                         QgsFeatureRequest::NoFlags :
                                         QgsFeatureRequest::NoGeometry )
-                              .setSubsetOfAttributes( lst, pendingFields() );
+                              .setSubsetOfAttributes( lst, fields() );
 
   QgsFeatureIterator fit;
   if ( !selectedOnly )
@@ -3576,7 +3570,7 @@ QString QgsVectorLayer::metadata()
     myMetadata += "<p>";
     foreach ( int idx, pkAttrList )
     {
-      myMetadata += pendingFields()[ idx ].name() + " ";
+      myMetadata += fields()[ idx ].name() + " ";
     }
     myMetadata += "</p>\n";
   }

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -1306,7 +1306,16 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
      *
      * @return A list of fields
      */
-    const QgsFields &pendingFields() const { return mUpdatedFields; }
+    const inline QgsFields fields() const { return mUpdatedFields; }
+
+    /**
+     * Returns the list of fields of this layer.
+     * This also includes fields which have not yet been saved to the provider.
+     * Alias for {@link fields()}
+     *
+     * @return A list of fields
+     */
+    const inline QgsFields pendingFields() const { return mUpdatedFields; }
 
     /** Returns list of attributes */
     QgsAttributeList pendingAllAttributesList();

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -1062,15 +1062,6 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
     bool readSld( const QDomNode& node, QString& errorMessage ) override;
 
     /**
-     * Number of features in the layer. This is necessary if features are
-     * added/deleted or the layer has been subsetted. If the data provider
-     * chooses not to support this feature, the total number of features
-     * can be returned.
-     * @return long containing number of features
-     */
-    virtual long featureCount() const;
-
-    /**
      * Number of features rendered with specified symbol. Features must be first
      * calculated by countSymbolFeatures()
      * @param symbol the symbol
@@ -1306,7 +1297,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
      *
      * @return A list of fields
      */
-    const inline QgsFields fields() const { return mUpdatedFields; }
+    inline QgsFields fields() const { return mUpdatedFields; }
 
     /**
      * Returns the list of fields of this layer.
@@ -1315,16 +1306,40 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
      *
      * @return A list of fields
      */
-    const inline QgsFields pendingFields() const { return mUpdatedFields; }
+    inline QgsFields pendingFields() const { return mUpdatedFields; }
 
-    /** Returns list of attributes */
-    QgsAttributeList pendingAllAttributesList();
+    /**
+     * Returns list of attribute indexes. i.e. a list from 0 ... fieldCount()
+     * Alias for {@link attributeList()}
+     */
+    inline QgsAttributeList pendingAllAttributesList() const { return mUpdatedFields.allAttributesList(); }
 
-    /** Returns list of attribute making up the primary key */
-    QgsAttributeList pendingPkAttributesList();
+    /**
+     * Returns list of attribute indexes. i.e. a list from 0 ... fieldCount()
+     * Alias for {@link attributeList()}
+     */
+    inline QgsAttributeList attributeList() const { return mUpdatedFields.allAttributesList(); }
 
-    /** Returns feature count after commit */
-    int pendingFeatureCount();
+    /**
+     * Returns list of attributes making up the primary key
+     * Alias for {@link pkAttributeList()}
+     */
+    inline QgsAttributeList pendingPkAttributesList() const { return pkAttributeList(); }
+
+    /** Returns list of attributes making up the primary key */
+    QgsAttributeList pkAttributeList() const;
+
+    /**
+     * Returns feature count including changes which have not yet been committed
+     * Alias for {@link featureCount()}
+     */
+    inline long pendingFeatureCount() const { return featureCount(); }
+
+    /**
+     * Returns feature count including changes which have not yet been committed
+     * If you need only the count of committed features call this method on this layer's provider.
+     */
+    long featureCount() const;
 
     /** Make layer read-only (editing disabled) or not
      *  @return false if the layer is in editing yet

--- a/src/core/qgsvectorlayercache.cpp
+++ b/src/core/qgsvectorlayercache.cpp
@@ -31,7 +31,7 @@ QgsVectorLayerCache::QgsVectorLayerCache( QgsVectorLayer* layer, int cacheSize, 
   connect( mLayer, SIGNAL( layerDeleted() ), SLOT( layerDeleted() ) );
 
   setCacheGeometry( true );
-  setCacheSubsetOfAttributes( mLayer->pendingAllAttributesList() );
+  setCacheSubsetOfAttributes( mLayer->attributeList() );
   setCacheAddedAttributes( true );
 
   connect( mLayer, SIGNAL( attributeDeleted( int ) ), SLOT( attributeDeleted( int ) ) );
@@ -330,7 +330,7 @@ bool QgsVectorLayerCache::checkInformationCovered( const QgsFeatureRequest& feat
 
   if ( !featureRequest.flags().testFlag( QgsFeatureRequest::SubsetOfAttributes ) )
   {
-    requestedAttributes = mLayer->pendingAllAttributesList();
+    requestedAttributes = mLayer->attributeList();
   }
   else
   {

--- a/src/core/qgsvectorlayereditbuffer.cpp
+++ b/src/core/qgsvectorlayereditbuffer.cpp
@@ -196,9 +196,9 @@ bool QgsVectorLayerEditBuffer::changeAttributeValue( QgsFeatureId fid, int field
     return false;
   }
 
-  if ( field < 0 || field >= L->pendingFields().count() ||
-       L->pendingFields().fieldOrigin( field ) == QgsFields::OriginJoin ||
-       L->pendingFields().fieldOrigin( field ) == QgsFields::OriginExpression )
+  if ( field < 0 || field >= L->fields().count() ||
+       L->fields().fieldOrigin( field ) == QgsFields::OriginJoin ||
+       L->fields().fieldOrigin( field ) == QgsFields::OriginExpression )
     return false;
 
   L->undoStack()->push( new QgsVectorLayerUndoCommandChangeAttribute( this, fid, field, newValue, oldValue ) );
@@ -214,7 +214,7 @@ bool QgsVectorLayerEditBuffer::addAttribute( const QgsField &field )
   if ( field.name().isEmpty() )
     return false;
 
-  const QgsFields& updatedFields = L->pendingFields();
+  const QgsFields& updatedFields = L->fields();
   for ( int idx = 0; idx < updatedFields.count(); ++idx )
   {
     if ( updatedFields[idx].name() == field.name() )
@@ -234,12 +234,12 @@ bool QgsVectorLayerEditBuffer::deleteAttribute( int index )
   if ( !( L->dataProvider()->capabilities() & QgsVectorDataProvider::DeleteAttributes ) )
     return false;
 
-  if ( index < 0 || index >= L->pendingFields().count() )
+  if ( index < 0 || index >= L->fields().count() )
     return false;
 
   // find out source of the field
-  QgsFields::FieldOrigin origin = L->pendingFields().fieldOrigin( index );
-  int originIndex = L->pendingFields().fieldOriginIndex( index );
+  QgsFields::FieldOrigin origin = L->fields().fieldOrigin( index );
+  int originIndex = L->fields().fieldOriginIndex( index );
 
   if ( origin == QgsFields::OriginProvider && mDeletedAttributeIds.contains( originIndex ) )
     return false;
@@ -260,7 +260,7 @@ bool QgsVectorLayerEditBuffer::commitChanges( QStringList& commitErrors )
   int cap = provider->capabilities();
   bool success = true;
 
-  QgsFields oldFields = L->pendingFields();
+  QgsFields oldFields = L->fields();
 
   //
   // delete attributes
@@ -328,7 +328,7 @@ bool QgsVectorLayerEditBuffer::commitChanges( QStringList& commitErrors )
   if ( attributesChanged )
   {
     L->updateFields();
-    QgsFields newFields = L->pendingFields();
+    QgsFields newFields = L->fields();
 
     if ( oldFields.count() != newFields.count() )
     {

--- a/src/core/qgsvectorlayerfeatureiterator.cpp
+++ b/src/core/qgsvectorlayerfeatureiterator.cpp
@@ -26,7 +26,7 @@
 QgsVectorLayerFeatureSource::QgsVectorLayerFeatureSource( QgsVectorLayer *layer )
 {
   mProviderFeatureSource = layer->dataProvider()->featureSource();
-  mFields = layer->pendingFields();
+  mFields = layer->fields();
   mJoinBuffer = layer->mJoinBuffer->clone();
   mExpressionFieldBuffer = new QgsExpressionFieldBuffer( *layer->mExpressionFieldBuffer );
 
@@ -465,7 +465,7 @@ void QgsVectorLayerFeatureIterator::prepareJoins()
       if ( joinInfo->joinFieldName.isEmpty() )
         info.joinField = joinInfo->joinFieldIndex;      //for compatibility with 1.x
       else
-        info.joinField = joinLayer->pendingFields().indexFromName( joinInfo->joinFieldName );
+        info.joinField = joinLayer->fields().indexFromName( joinInfo->joinFieldName );
 
       // for joined fields, we always need to request the targetField from the provider too
       if ( !fetchAttributes.contains( info.targetField ) )
@@ -632,8 +632,8 @@ void QgsVectorLayerFeatureIterator::FetchJoinInfo::addJoinedAttributesDirect( Qg
   }
 
   QString joinFieldName;
-  if ( joinInfo->joinFieldName.isEmpty() && joinInfo->joinFieldIndex >= 0 && joinInfo->joinFieldIndex < joinLayer->pendingFields().count() )
-    joinFieldName = joinLayer->pendingFields().field( joinInfo->joinFieldIndex ).name();   // for compatibility with 1.x
+  if ( joinInfo->joinFieldName.isEmpty() && joinInfo->joinFieldIndex >= 0 && joinInfo->joinFieldIndex < joinLayer->fields().count() )
+    joinFieldName = joinLayer->fields().field( joinInfo->joinFieldIndex ).name();   // for compatibility with 1.x
   else
     joinFieldName = joinInfo->joinFieldName;
 

--- a/src/core/qgsvectorlayerimport.cpp
+++ b/src/core/qgsvectorlayerimport.cpp
@@ -243,7 +243,7 @@ QgsVectorLayerImport::importLayer( QgsVectorLayer* layer,
     forceSinglePartGeom = options->take( "forceSinglePartGeometryType" ).toBool();
   }
 
-  QgsFields fields = skipAttributeCreation ? QgsFields() : layer->pendingFields();
+  QgsFields fields = skipAttributeCreation ? QgsFields() : layer->fields();
   QGis::WkbType wkbType = layer->wkbType();
 
   // Special handling for Shapefiles

--- a/src/core/qgsvectorlayerimport.cpp
+++ b/src/core/qgsvectorlayerimport.cpp
@@ -302,7 +302,7 @@ QgsVectorLayerImport::importLayer( QgsVectorLayer* layer,
     errorMessage->clear();
   }
 
-  QgsAttributeList allAttr = skipAttributeCreation ? QgsAttributeList() : layer->pendingAllAttributesList();
+  QgsAttributeList allAttr = skipAttributeCreation ? QgsAttributeList() : layer->attributeList();
   QgsFeature fet;
 
   QgsFeatureRequest req;

--- a/src/core/qgsvectorlayerjoinbuffer.cpp
+++ b/src/core/qgsvectorlayerjoinbuffer.cpp
@@ -123,9 +123,9 @@ void QgsVectorLayerJoinBuffer::cacheJoinLayer( QgsVectorJoinInfo& joinInfo )
     if ( joinInfo.joinFieldName.isEmpty() )
       joinFieldIndex = joinInfo.joinFieldIndex;   //for compatibility with 1.x
     else
-      joinFieldIndex = cacheLayer->pendingFields().indexFromName( joinInfo.joinFieldName );
+      joinFieldIndex = cacheLayer->fields().indexFromName( joinInfo.joinFieldName );
 
-    if ( joinFieldIndex < 0 || joinFieldIndex >= cacheLayer->pendingFields().count() )
+    if ( joinFieldIndex < 0 || joinFieldIndex >= cacheLayer->fields().count() )
       return;
 
     joinInfo.cachedAttributes.clear();
@@ -175,7 +175,7 @@ void QgsVectorLayerJoinBuffer::cacheJoinLayer( QgsVectorJoinInfo& joinInfo )
 QVector<int> QgsVectorLayerJoinBuffer::joinSubsetIndices( QgsVectorLayer* joinLayer, const QStringList& joinFieldsSubset )
 {
   QVector<int> subsetIndices;
-  const QgsFields& fields = joinLayer->pendingFields();
+  const QgsFields& fields = joinLayer->fields();
   for ( int i = 0; i < joinFieldsSubset.count(); ++i )
   {
     QString joinedFieldName = joinFieldsSubset.at( i );
@@ -206,7 +206,7 @@ void QgsVectorLayerJoinBuffer::updateFields( QgsFields& fields )
       continue;
     }
 
-    const QgsFields& joinFields = joinLayer->pendingFields();
+    const QgsFields& joinFields = joinLayer->fields();
     QString joinFieldName;
     if ( joinIt->joinFieldName.isEmpty() && joinIt->joinFieldIndex >= 0 && joinIt->joinFieldIndex < joinFields.count() )
       joinFieldName = joinFields.field( joinIt->joinFieldIndex ).name();  //for compatibility with 1.x

--- a/src/core/qgsvectorlayerrenderer.cpp
+++ b/src/core/qgsvectorlayerrenderer.cpp
@@ -40,7 +40,7 @@
 QgsVectorLayerRenderer::QgsVectorLayerRenderer( QgsVectorLayer* layer, QgsRenderContext& context )
     : QgsMapLayerRenderer( layer->id() )
     , mContext( context )
-    , mFields( layer->pendingFields() )
+    , mFields( layer->fields() )
     , mRendererV2( 0 )
     , mCache( 0 )
     , mLabeling( false )

--- a/src/core/qgsvectorlayerundocommand.cpp
+++ b/src/core/qgsvectorlayerundocommand.cpp
@@ -311,7 +311,7 @@ QgsVectorLayerUndoCommandAddAttribute::QgsVectorLayerUndoCommandAddAttribute( Qg
     : QgsVectorLayerUndoCommand( buffer )
     , mField( field )
 {
-  const QgsFields &fields = layer()->pendingFields();
+  const QgsFields &fields = layer()->fields();
   int i;
   for ( i = 0; i < fields.count() && fields.fieldOrigin( i ) != QgsFields::OriginJoin; i++ )
     ;
@@ -320,7 +320,7 @@ QgsVectorLayerUndoCommandAddAttribute::QgsVectorLayerUndoCommandAddAttribute( Qg
 
 void QgsVectorLayerUndoCommandAddAttribute::undo()
 {
-  int index = layer()->pendingFields().fieldOriginIndex( mFieldIndex );
+  int index = layer()->fields().fieldOriginIndex( mFieldIndex );
 
   mBuffer->mAddedAttributes.removeAt( index );
   mBuffer->updateLayerFields();
@@ -343,7 +343,7 @@ QgsVectorLayerUndoCommandDeleteAttribute::QgsVectorLayerUndoCommandDeleteAttribu
     : QgsVectorLayerUndoCommand( buffer )
     , mFieldIndex( fieldIndex )
 {
-  const QgsFields& fields = layer()->pendingFields();
+  const QgsFields& fields = layer()->fields();
   QgsFields::FieldOrigin origin = fields.fieldOrigin( mFieldIndex );
   mOriginIndex = fields.fieldOriginIndex( mFieldIndex );
   mProviderField = ( origin == QgsFields::OriginProvider );

--- a/src/core/symbology-ng/qgsrendererv2.cpp
+++ b/src/core/symbology-ng/qgsrendererv2.cpp
@@ -233,7 +233,7 @@ QgsFeatureRendererV2* QgsFeatureRendererV2::defaultRenderer( QGis::GeometryType 
 
 void QgsFeatureRendererV2::startRender( QgsRenderContext& context, const QgsVectorLayer* vlayer )
 {
-  startRender( context, vlayer->pendingFields() );
+  startRender( context, vlayer->fields() );
 }
 
 bool QgsFeatureRendererV2::renderFeature( QgsFeature& feature, QgsRenderContext& context, int layer, bool selected, bool drawVertexMarker )

--- a/src/gui/attributetable/qgsattributetablefiltermodel.cpp
+++ b/src/gui/attributetable/qgsattributetablefiltermodel.cpp
@@ -263,7 +263,7 @@ void QgsAttributeTableFilterModel::generateListOfVisibleFeatures()
     filter = renderer && renderer->capabilities() & QgsFeatureRendererV2::Filter;
   }
 
-  renderer->startRender( renderContext, layer()->pendingFields() );
+  renderer->startRender( renderContext, layer()->fields() );
 
   QgsFeatureRequest r( masterModel()->request() );
   if ( !r.filterRect().isNull() )

--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -289,7 +289,7 @@ void QgsAttributeTableModel::loadAttributes()
   bool ins = false, rm = false;
 
   QgsAttributeList attributes;
-  const QgsFields& fields = layer()->pendingFields();
+  const QgsFields& fields = layer()->fields();
 
   mWidgetFactories.clear();
   mAttributeWidgetCaches.clear();
@@ -484,7 +484,7 @@ QVariant QgsAttributeTableModel::headerData( int section, Qt::Orientation orient
       QString attributeName = layer()->attributeAlias( mAttributes[section] );
       if ( attributeName.isEmpty() )
       {
-        QgsField field = layer()->pendingFields()[ mAttributes[section] ];
+        QgsField field = layer()->fields()[ mAttributes[section] ];
         attributeName = field.name();
       }
       return QVariant( attributeName );
@@ -526,7 +526,7 @@ QVariant QgsAttributeTableModel::data( const QModelIndex &index, int role ) cons
   if ( role == FieldIndexRole )
     return fieldId;
 
-  const QgsField& field = layer()->pendingFields()[ fieldId ];
+  const QgsField& field = layer()->fields()[ fieldId ];
 
   QVariant::Type fldType = field.type();
   bool fldNumeric = ( fldType == QVariant::Int || fldType == QVariant::Double || fldType == QVariant::LongLong );
@@ -668,7 +668,7 @@ void QgsAttributeTableModel::prefetchColumnData( int column )
     if ( column >= mAttributes.count() )
       return;
     int fieldId = mAttributes[ column ];
-    const QgsFields& fields = layer()->pendingFields();
+    const QgsFields& fields = layer()->fields();
     QStringList fldNames;
     fldNames << fields[ fieldId ].name();
 

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -91,7 +91,7 @@ void QgsDualView::init( QgsVectorLayer* layer, QgsMapCanvas* mapCanvas, const Qg
 void QgsDualView::columnBoxInit()
 {
   // load fields
-  QList<QgsField> fields = mLayerCache->layer()->pendingFields().toList();
+  QList<QgsField> fields = mLayerCache->layer()->fields().toList();
 
   QString defaultField;
 

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -111,7 +111,7 @@ void QgsDualView::columnBoxInit()
   // if neither diaplay expression nor display field is saved...
   if ( displayExpression == "" )
   {
-    QgsAttributeList pkAttrs = mLayerCache->layer()->pendingPkAttributesList();
+    QgsAttributeList pkAttrs = mLayerCache->layer()->pkAttributeList();
 
     if ( pkAttrs.size() > 0 )
     {

--- a/src/gui/attributetable/qgsfeaturelistmodel.cpp
+++ b/src/gui/attributetable/qgsfeaturelistmodel.cpp
@@ -73,7 +73,7 @@ QVariant QgsFeatureListModel::data( const QModelIndex &index, int role ) const
 
     mFilterModel->layerCache()->featureAtId( idxToFid( index ), feat );
 
-    const QgsFields fields = mFilterModel->layer()->pendingFields();
+    const QgsFields fields = mFilterModel->layer()->fields();
 
     return mExpression->evaluate( &feat, fields );
   }

--- a/src/gui/editorwidgets/core/qgseditorwidgetfactory.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetfactory.cpp
@@ -66,7 +66,7 @@ QString QgsEditorWidgetFactory::representValue( QgsVectorLayer* vl, int fieldIdx
   Q_UNUSED( cache )
   Q_UNUSED( value )
 
-  const QgsField &fld = vl->pendingFields().at( fieldIdx );
+  const QgsField &fld = vl->fields().at( fieldIdx );
   return fld.displayString( value );
 }
 

--- a/src/gui/editorwidgets/core/qgseditorwidgetregistry.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetregistry.cpp
@@ -282,9 +282,9 @@ void QgsEditorWidgetRegistry::writeMapLayer( QgsMapLayer* mapLayer, QDomElement&
 
   QDomNode editTypesNode = doc.createElement( "edittypes" );
 
-  for ( int idx = 0; idx < vectorLayer->pendingFields().count(); ++idx )
+  for ( int idx = 0; idx < vectorLayer->fields().count(); ++idx )
   {
-    const QgsField &field = vectorLayer->pendingFields()[ idx ];
+    const QgsField &field = vectorLayer->fields()[ idx ];
     const QString& widgetType = vectorLayer->editorWidgetV2( idx );
     if ( !mWidgetFactories.contains( widgetType ) )
     {

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
@@ -33,8 +33,8 @@ int QgsEditorWidgetWrapper::fieldIdx()
 
 QgsField QgsEditorWidgetWrapper::field()
 {
-  if ( mFieldIdx < layer()->pendingFields().count() )
-    return layer()->pendingFields()[mFieldIdx];
+  if ( mFieldIdx < layer()->fields().count() )
+    return layer()->fields()[mFieldIdx];
   else
     return QgsField();
 }

--- a/src/gui/editorwidgets/qgsdefaultsearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsdefaultsearchwidgetwrapper.cpp
@@ -52,12 +52,12 @@ void QgsDefaultSearchWidgetWrapper::setCaseString( int caseSensitiveCheckState )
 
 void QgsDefaultSearchWidgetWrapper::setExpression( QString exp )
 {
-  QVariant::Type fldType = layer()->pendingFields()[mFieldIdx].type();
+  QVariant::Type fldType = layer()->fields()[mFieldIdx].type();
   bool numeric = ( fldType == QVariant::Int || fldType == QVariant::Double || fldType == QVariant::LongLong );
 
   QSettings settings;
   QString nullValue = settings.value( "qgis/nullValue", "NULL" ).toString();
-  QString fieldName = layer()->pendingFields()[mFieldIdx].name();
+  QString fieldName = layer()->fields()[mFieldIdx].name();
   QString str;
   if ( exp == nullValue )
   {

--- a/src/gui/editorwidgets/qgsrangeconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsrangeconfigdlg.cpp
@@ -24,13 +24,13 @@ QgsRangeConfigDlg::QgsRangeConfigDlg( QgsVectorLayer* vl, int fieldIdx, QWidget 
 
   QString text;
 
-  switch ( vl->pendingFields()[fieldIdx].type() )
+  switch ( vl->fields()[fieldIdx].type() )
   {
     case QVariant::Int:
     case QVariant::LongLong:
     case QVariant::Double:
     {
-      rangeStackedWidget->setCurrentIndex( vl->pendingFields()[fieldIdx].type() == QVariant::Double ? 1 : 0 );
+      rangeStackedWidget->setCurrentIndex( vl->fields()[fieldIdx].type() == QVariant::Double ? 1 : 0 );
 
       rangeWidget->clear();
       rangeWidget->addItem( tr( "Editable" ), "SpinBox" );
@@ -58,7 +58,7 @@ QgsEditorWidgetConfig QgsRangeConfigDlg::config()
 {
   QgsEditorWidgetConfig cfg;
 
-  switch ( layer()->pendingFields()[field()].type() )
+  switch ( layer()->fields()[field()].type() )
   {
     case QVariant::Int:
     case QVariant::LongLong:

--- a/src/gui/editorwidgets/qgsrangewidgetfactory.cpp
+++ b/src/gui/editorwidgets/qgsrangewidgetfactory.cpp
@@ -73,7 +73,7 @@ void QgsRangeWidgetFactory::writeConfig( const QgsEditorWidgetConfig& config, QD
 
 bool QgsRangeWidgetFactory::isFieldSupported( QgsVectorLayer* vl, int fieldIdx )
 {
-  switch ( vl->pendingFields()[fieldIdx].type() )
+  switch ( vl->fields()[fieldIdx].type() )
   {
     case QVariant::LongLong:
     case QVariant::Double:

--- a/src/gui/editorwidgets/qgsrangewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrangewidgetwrapper.cpp
@@ -45,8 +45,8 @@ QWidget* QgsRangeWidgetWrapper::createWidget( QWidget* parent )
   }
   else
   {
-    QgsDebugMsg( QString( "%1" ).arg(( int )layer()->pendingFields()[fieldIdx()].type() ) );
-    switch ( layer()->pendingFields()[fieldIdx()].type() )
+    QgsDebugMsg( QString( "%1" ).arg(( int )layer()->fields()[fieldIdx()].type() ) );
+    switch ( layer()->fields()[fieldIdx()].type() )
     {
       case QVariant::Double:
       {
@@ -82,10 +82,10 @@ void QgsRangeWidgetWrapper::initWidget( QWidget* editor )
   if ( mDoubleSpinBox )
   {
     // set the precision if field is integer
-    int precision = layer()->pendingFields()[fieldIdx()].precision();
+    int precision = layer()->fields()[fieldIdx()].precision();
     if ( precision > 0 )
     {
-      mDoubleSpinBox->setDecimals( layer()->pendingFields()[fieldIdx()].precision() );
+      mDoubleSpinBox->setDecimals( layer()->fields()[fieldIdx()].precision() );
     }
 
     double minval = min.toDouble();

--- a/src/gui/editorwidgets/qgsrelationreferenceconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferenceconfigdlg.cpp
@@ -156,7 +156,7 @@ void QgsRelationReferenceConfigDlg::loadFields()
   if ( mReferencedLayer )
   {
     QgsVectorLayer* l = mReferencedLayer;
-    const QgsFields& flds = l->pendingFields();
+    const QgsFields& flds = l->fields();
     for ( int i = 0; i < flds.count(); i++ )
     {
       mAvailableFieldsList->addItem( l->attributeAlias( i ).isEmpty() ? flds.at( i ).name() : l->attributeAlias( i ) );

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -245,7 +245,7 @@ void QgsRelationReferenceWidget::setForeignKey( const QVariant& value )
   if ( !mReferencedLayer )
     return;
 
-  QgsAttributes attrs = QgsAttributes( mReferencingLayer->pendingFields().count() );
+  QgsAttributes attrs = QgsAttributes( mReferencingLayer->fields().count() );
   attrs[mFkeyFieldIdx] = value;
 
   QgsFeatureRequest request = mRelation.getReferencedFeatureRequest( attrs );
@@ -348,7 +348,7 @@ QVariant QgsRelationReferenceWidget::foreignKey()
   {
     if ( !mFeature.isValid() )
     {
-      return QVariant( mReferencingLayer->pendingFields().at( mFkeyFieldIdx ).type() );
+      return QVariant( mReferencingLayer->fields().at( mFkeyFieldIdx ).type() );
     }
     else
     {
@@ -442,7 +442,7 @@ void QgsRelationReferenceWidget::init()
         mReferencedLayer->uniqueValues( idx, uniqueValues );
         cb->addItem( mReferencedLayer->attributeAlias( idx ).isEmpty() ? fieldName : mReferencedLayer->attributeAlias( idx ) );
         QVariant nullValue = QSettings().value( "qgis/nullValue", "NULL" );
-        cb->addItem( nullValue.toString(), QVariant( mReferencedLayer->pendingFields()[idx].type() ) );
+        cb->addItem( nullValue.toString(), QVariant( mReferencedLayer->fields()[idx].type() ) );
 
         Q_FOREACH ( QVariant v, uniqueValues )
         {
@@ -488,7 +488,7 @@ void QgsRelationReferenceWidget::init()
 
     layerCache->setCacheSubsetOfAttributes( attributes );
     mMasterModel = new QgsAttributeTableModel( layerCache );
-    mMasterModel->setRequest( QgsFeatureRequest().setFlags( QgsFeatureRequest::NoGeometry ).setSubsetOfAttributes( requestedAttrs.toList(), mReferencedLayer->pendingFields() ) );
+    mMasterModel->setRequest( QgsFeatureRequest().setFlags( QgsFeatureRequest::NoGeometry ).setSubsetOfAttributes( requestedAttrs.toList(), mReferencedLayer->fields() ) );
     mFilterModel = new QgsAttributeTableFilterModel( mCanvas, mMasterModel, mMasterModel );
     mFeatureListModel = new QgsFeatureListModel( mFilterModel, this );
     mFeatureListModel->setDisplayExpression( mReferencedLayer->displayExpression() );
@@ -801,7 +801,7 @@ void QgsRelationReferenceWidget::filterChanged()
       }
       else
       {
-        if ( mReferencedLayer->pendingFields().field( fieldName ).type() == QVariant::String )
+        if ( mReferencedLayer->fields().field( fieldName ).type() == QVariant::String )
         {
           filters << QString( "\"%1\" = '%2'" ).arg( fieldName ).arg( cb->currentText() );
         }

--- a/src/gui/editorwidgets/qgsvaluerelationsearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationsearchwidgetwrapper.cpp
@@ -113,10 +113,10 @@ void QgsValueRelationSearchWidgetWrapper::initWidget( QWidget* editor )
 
   if ( mComboBox )
   {
-    mComboBox->addItem( tr( "Please select" ), QVariant( layer()->pendingFields()[mFieldIdx].type() ) );
+    mComboBox->addItem( tr( "Please select" ), QVariant( layer()->fields()[mFieldIdx].type() ) );
     if ( config( "AllowNull" ).toBool() )
     {
-      mComboBox->addItem( tr( "(no selection)" ), QVariant( layer()->pendingFields()[mFieldIdx].type() ) );
+      mComboBox->addItem( tr( "(no selection)" ), QVariant( layer()->fields()[mFieldIdx].type() ) );
     }
 
     Q_FOREACH ( const ValueRelationItem& element, mCache )

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
@@ -221,7 +221,7 @@ QgsValueRelationWidgetWrapper::ValueRelationCache QgsValueRelationWidgetWrapper:
     if ( !config.value( "FilterExpression" ).toString().isEmpty() )
     {
       e = new QgsExpression( config.value( "FilterExpression" ).toString() );
-      if ( e->hasParserError() || !e->prepare( layer->pendingFields() ) )
+      if ( e->hasParserError() || !e->prepare( layer->fields() ) )
         ki = -1;
     }
 

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -278,8 +278,8 @@ void QgsAttributeForm::onAttributeAdded( int idx )
   if ( mFeature.isValid() )
   {
     QgsAttributes attrs = mFeature.attributes();
-    attrs.insert( idx, QVariant( layer()->pendingFields()[idx].type() ) );
-    mFeature.setFields( layer()->pendingFields() );
+    attrs.insert( idx, QVariant( layer()->fields()[idx].type() ) );
+    mFeature.setFields( layer()->fields() );
     mFeature.setAttributes( attrs );
   }
   init();
@@ -292,7 +292,7 @@ void QgsAttributeForm::onAttributeDeleted( int idx )
   {
     QgsAttributes attrs = mFeature.attributes();
     attrs.remove( idx );
-    mFeature.setFields( layer()->pendingFields() );
+    mFeature.setFields( layer()->fields() );
     mFeature.setAttributes( attrs );
   }
   init();
@@ -436,7 +436,7 @@ void QgsAttributeForm::init()
     layout()->addWidget( scrollArea );
 
     int row = 0;
-    Q_FOREACH ( const QgsField& field, mLayer->pendingFields().toList() )
+    Q_FOREACH ( const QgsField& field, mLayer->fields().toList() )
     {
       int idx = mLayer->fieldNameIndex( field.name() );
       if ( idx < 0 )
@@ -588,7 +588,7 @@ QWidget* QgsAttributeForm::createWidgetFromDef( const QgsAttributeEditorElement 
         break;
 
       int fldIdx = vl->fieldNameIndex( fieldDef->name() );
-      if ( fldIdx < vl->pendingFields().count() && fldIdx >= 0 )
+      if ( fldIdx < vl->fields().count() && fldIdx >= 0 )
       {
         const QString widgetType = mLayer->editorWidgetV2( fldIdx );
         const QgsEditorWidgetConfig widgetConfig = mLayer->editorWidgetV2Config( fldIdx );
@@ -597,7 +597,7 @@ QWidget* QgsAttributeForm::createWidgetFromDef( const QgsAttributeEditorElement 
         newWidget = eww->widget();
         addWidgetWrapper( eww );
 
-        newWidget->setObjectName( mLayer->pendingFields()[ fldIdx ].name() );
+        newWidget->setObjectName( mLayer->fields()[ fldIdx ].name() );
       }
 
       labelOnTop = mLayer->labelOnTop( fieldDef->idx() );
@@ -720,7 +720,7 @@ void QgsAttributeForm::addWidgetWrapper( QgsEditorWidgetWrapper* eww )
 void QgsAttributeForm::createWrappers()
 {
   QList<QWidget*> myWidgets = findChildren<QWidget*>();
-  const QList<QgsField> fields = mLayer->pendingFields().toList();
+  const QList<QgsField> fields = mLayer->fields().toList();
 
   Q_FOREACH ( QWidget* myWidget, myWidgets )
   {

--- a/src/gui/qgsdatadefinedbutton.cpp
+++ b/src/gui/qgsdatadefinedbutton.cpp
@@ -160,7 +160,7 @@ void QgsDataDefinedButton::init( const QgsVectorLayer* vl,
   if ( mVectorLayer )
   {
     // store just a list of fields of unknown type or those that match the expected type
-    const QgsFields& fields = mVectorLayer->pendingFields();
+    const QgsFields& fields = mVectorLayer->fields();
     for ( int i = 0; i < fields.count(); ++i )
     {
       const QgsField& f = fields.at( i );

--- a/src/gui/qgsexpressionbuilderwidget.cpp
+++ b/src/gui/qgsexpressionbuilderwidget.cpp
@@ -258,7 +258,7 @@ void QgsExpressionBuilderWidget::loadFieldNames()
   if ( !mLayer )
     return;
 
-  loadFieldNames( mLayer->pendingFields() );
+  loadFieldNames( mLayer->fields() );
 }
 
 void QgsExpressionBuilderWidget::loadFieldNames( const QgsFields& fields )
@@ -500,7 +500,7 @@ void QgsExpressionBuilderWidget::on_txtExpressionString_textChanged()
 
     if ( mFeature.isValid() )
     {
-      QVariant value = exp.evaluate( &mFeature, mLayer->pendingFields() );
+      QVariant value = exp.evaluate( &mFeature, mLayer->fields() );
       if ( !exp.hasEvalError() )
         lblPreview->setText( formatPreviewString( value.toString() ) );
     }

--- a/src/gui/qgsexpressionselectiondialog.cpp
+++ b/src/gui/qgsexpressionselectiondialog.cpp
@@ -73,7 +73,7 @@ void QgsExpressionSelectionDialog::on_mActionSelect_triggered()
   QgsFeatureIds newSelection;
   QgsExpression* expression = new QgsExpression( mExpressionBuilder->expressionText() );
 
-  const QgsFields fields = mLayer->pendingFields();
+  const QgsFields fields = mLayer->fields();
 
   QgsFeatureIterator features = mLayer->getFeatures();
 
@@ -101,7 +101,7 @@ void QgsExpressionSelectionDialog::on_mActionAddToSelection_triggered()
   QgsFeatureIds newSelection = mLayer->selectedFeaturesIds();
   QgsExpression* expression = new QgsExpression( mExpressionBuilder->expressionText() );
 
-  const QgsFields fields = mLayer->pendingFields();
+  const QgsFields fields = mLayer->fields();
 
   QgsFeatureIterator features = mLayer->getFeatures();
 
@@ -131,7 +131,7 @@ void QgsExpressionSelectionDialog::on_mActionSelectInstersect_triggered()
 
   QgsExpression* expression = new QgsExpression( mExpressionBuilder->expressionText() );
 
-  const QgsFields fields = mLayer->pendingFields();
+  const QgsFields fields = mLayer->fields();
 
   expression->prepare( fields );
 
@@ -168,7 +168,7 @@ void QgsExpressionSelectionDialog::on_mActionRemoveFromSelection_triggered()
 
   QgsExpression* expression = new QgsExpression( mExpressionBuilder->expressionText() );
 
-  const QgsFields fields = mLayer->pendingFields();
+  const QgsFields fields = mLayer->fields();
 
   expression->prepare( fields );
 

--- a/src/gui/qgsfieldexpressionwidget.cpp
+++ b/src/gui/qgsfieldexpressionwidget.cpp
@@ -97,7 +97,7 @@ bool QgsFieldExpressionWidget::isValidExpression( QString *expressionError ) con
 {
   QString temp;
   QgsVectorLayer* vl = layer();
-  return QgsExpression::isValid( currentText(), vl ? vl->pendingFields() : QgsFields(), expressionError ? *expressionError : temp );
+  return QgsExpression::isValid( currentText(), vl ? vl->fields() : QgsFields(), expressionError ? *expressionError : temp );
 }
 
 bool QgsFieldExpressionWidget::isExpression() const
@@ -272,6 +272,6 @@ bool QgsFieldExpressionWidget::isExpressionValid( const QString expressionStr )
   QgsVectorLayer* vl = layer();
 
   QgsExpression expression( expressionStr );
-  expression.prepare( vl ? vl->pendingFields() : QgsFields() );
+  expression.prepare( vl ? vl->fields() : QgsFields() );
   return !expression.hasParserError();
 }

--- a/src/gui/qgsfieldmodel.cpp
+++ b/src/gui/qgsfieldmodel.cpp
@@ -98,7 +98,7 @@ void QgsFieldModel::updateModel()
 {
   if ( mLayer )
   {
-    QgsFields newFields = mLayer->pendingFields();
+    QgsFields newFields = mLayer->fields();
     if ( mFields.toList() != newFields.toList() )
     {
       // Try to handle two special cases: addition of a new field and removal of a field.
@@ -152,7 +152,7 @@ void QgsFieldModel::updateModel()
 
       // general case with reset - not good - resets selections
       beginResetModel();
-      mFields = mLayer->pendingFields();
+      mFields = mLayer->fields();
       endResetModel();
     }
     else
@@ -289,7 +289,7 @@ QVariant QgsFieldModel::data( const QModelIndex &index, int role ) const
       if ( exprIdx >= 0 )
       {
         QgsExpression exp( mExpression[exprIdx] );
-        exp.prepare( mLayer ? mLayer->pendingFields() : QgsFields() );
+        exp.prepare( mLayer ? mLayer->fields() : QgsFields() );
         return !exp.hasParserError();
       }
       return true;
@@ -330,7 +330,7 @@ QVariant QgsFieldModel::data( const QModelIndex &index, int role ) const
       {
         // if expression, test validity
         QgsExpression exp( mExpression[exprIdx] );
-        exp.prepare( mLayer ? mLayer->pendingFields() : QgsFields() );
+        exp.prepare( mLayer ? mLayer->fields() : QgsFields() );
         if ( exp.hasParserError() )
         {
           return QBrush( QColor( Qt::red ) );

--- a/src/gui/qgsformannotationitem.cpp
+++ b/src/gui/qgsformannotationitem.cpp
@@ -93,7 +93,7 @@ QWidget* QgsFormAnnotationItem::createDesignerWidget( const QString& filePath )
     QgsFeature f;
     if ( mVectorLayer->getFeatures( QgsFeatureRequest().setFilterFid( mFeature ).setFlags( QgsFeatureRequest::NoGeometry ) ).nextFeature( f ) )
     {
-      const QgsFields& fields = mVectorLayer->pendingFields();
+      const QgsFields& fields = mVectorLayer->fields();
       QgsAttributes attrs = f.attributes();
       for ( int i = 0; i < attrs.count(); ++i )
       {

--- a/src/gui/qgshighlight.cpp
+++ b/src/gui/qgshighlight.cpp
@@ -368,7 +368,7 @@ void QgsHighlight::paint( QPainter* p )
 
       context.setPainter( imagePainter );
 
-      renderer->startRender( context, layer->pendingFields() );
+      renderer->startRender( context, layer->fields() );
       renderer->renderFeature( mFeature, context );
       renderer->stopRender( context );
 

--- a/src/gui/qgsmaptoolidentify.cpp
+++ b/src/gui/qgsmaptoolidentify.cpp
@@ -248,7 +248,7 @@ bool QgsMapToolIdentify::identifyVectorLayer( QList<IdentifyResult> *results, Qg
   if ( renderer && renderer->capabilities() & QgsFeatureRendererV2::ScaleDependent )
   {
     // setup scale for scale dependent visibility (rule based)
-    renderer->startRender( context, layer->pendingFields() );
+    renderer->startRender( context, layer->fields() );
     filter = renderer->capabilities() & QgsFeatureRendererV2::Filter;
   }
 

--- a/src/gui/qgsquerybuilder.cpp
+++ b/src/gui/qgsquerybuilder.cpp
@@ -69,7 +69,7 @@ void QgsQueryBuilder::showEvent( QShowEvent *event )
 
 void QgsQueryBuilder::populateFields()
 {
-  const QgsFields& fields = mLayer->pendingFields();
+  const QgsFields& fields = mLayer->fields();
   for ( int idx = 0; idx < fields.count(); ++idx )
   {
     if ( fields.fieldOrigin( idx ) != QgsFields::OriginProvider )
@@ -325,7 +325,7 @@ void QgsQueryBuilder::on_lstFields_clicked( const QModelIndex &index )
 
 void QgsQueryBuilder::on_lstFields_doubleClicked( const QModelIndex &index )
 {
-  txtSQL->insertText( "\"" + mLayer->pendingFields()[ mModelFields->data( index, Qt::UserRole+1 ).toInt()].name() + "\"" );
+  txtSQL->insertText( "\"" + mLayer->fields()[ mModelFields->data( index, Qt::UserRole+1 ).toInt()].name() + "\"" );
   txtSQL->setFocus();
 }
 

--- a/src/gui/qgsrelationadddlg.cpp
+++ b/src/gui/qgsrelationadddlg.cpp
@@ -74,7 +74,7 @@ void QgsRelationAddDlg::loadLayerAttributes( QComboBox* cbx, QgsVectorLayer* lay
     return;
   }
 
-  foreach ( QgsField fld, layer->pendingFields().toList() )
+  foreach ( QgsField fld, layer->fields().toList() )
   {
     cbx->addItem( fld.name(), fld.name() );
   }

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -207,7 +207,7 @@ void QgsRelationEditorWidget::addFeature()
 {
   QgsAttributeMap keyAttrs;
 
-  QgsFields fields = mRelation.referencingLayer()->pendingFields();
+  QgsFields fields = mRelation.referencingLayer()->fields();
 
   Q_FOREACH ( QgsRelation::FieldPair fieldPair, mRelation.fieldPairs() )
   {
@@ -262,7 +262,7 @@ void QgsRelationEditorWidget::unlinkFeature()
       QgsDebugMsg( QString( "referencing field %1 not found" ).arg( fieldPair.referencingField() ) );
       return;
     }
-    QgsField fld = mRelation.referencingLayer()->pendingFields().at( idx );
+    QgsField fld = mRelation.referencingLayer()->fields().at( idx );
     keyFields.insert( idx, fld );
   }
 

--- a/src/gui/qgssearchquerybuilder.cpp
+++ b/src/gui/qgssearchquerybuilder.cpp
@@ -73,7 +73,7 @@ void QgsSearchQueryBuilder::populateFields()
     return;
 
   QgsDebugMsg( "entering." );
-  const QgsFields& fields = mLayer->pendingFields();
+  const QgsFields& fields = mLayer->fields();
   for ( int idx = 0; idx < fields.count(); ++idx )
   {
     QString fieldName = fields[idx].name();
@@ -114,7 +114,7 @@ void QgsSearchQueryBuilder::getFieldValues( int limit )
   // determine the field type
   QString fieldName = mModelFields->data( lstFields->currentIndex() ).toString();
   int fieldIndex = mFieldMap[fieldName];
-  QgsField field = mLayer->pendingFields()[fieldIndex];//provider->fields()[fieldIndex];
+  QgsField field = mLayer->fields()[fieldIndex];//provider->fields()[fieldIndex];
   bool numeric = ( field.type() == QVariant::Int || field.type() == QVariant::Double );
 
   QgsFeature feat;
@@ -199,7 +199,7 @@ long QgsSearchQueryBuilder::countRecords( QString searchString )
 
   int count = 0;
   QgsFeature feat;
-  const QgsFields& fields = mLayer->pendingFields();
+  const QgsFields& fields = mLayer->fields();
 
   if ( !search.prepare( fields ) )
   {

--- a/src/gui/symbology-ng/qgscategorizedsymbolrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgscategorizedsymbolrendererv2widget.cpp
@@ -649,7 +649,7 @@ void QgsCategorizedSymbolRendererV2Widget::addCategories()
   {
     // Lets assume it's an expression
     QgsExpression* expression = new QgsExpression( attrName );
-    expression->prepare( mLayer->pendingFields() );
+    expression->prepare( mLayer->fields() );
     QgsFeatureIterator fit = mLayer->getFeatures();
     QgsFeature feature;
     while ( fit.nextFeature( feature ) )

--- a/src/gui/symbology-ng/qgsdatadefinedsymboldialog.cpp
+++ b/src/gui/symbology-ng/qgsdatadefinedsymboldialog.cpp
@@ -17,7 +17,7 @@ QgsDataDefinedSymbolDialog::QgsDataDefinedSymbolDialog( const QList< DataDefined
   QgsFields attributeFields;
   if ( mVectorLayer )
   {
-    attributeFields = mVectorLayer->pendingFields();
+    attributeFields = mVectorLayer->fields();
   }
 
   int i = 0;

--- a/src/gui/symbology-ng/qgspointdisplacementrendererwidget.cpp
+++ b/src/gui/symbology-ng/qgspointdisplacementrendererwidget.cpp
@@ -65,7 +65,7 @@ QgsPointDisplacementRendererWidget::QgsPointDisplacementRendererWidget( QgsVecto
   //insert attributes into combo box
   if ( layer )
   {
-    const QgsFields& layerAttributes = layer->pendingFields();
+    const QgsFields& layerAttributes = layer->fields();
     for ( int idx = 0; idx < layerAttributes.count(); ++idx )
     {
       mLabelFieldComboBox->addItem( layerAttributes[idx].name() );

--- a/src/gui/symbology-ng/qgsrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgsrendererv2widget.cpp
@@ -276,7 +276,7 @@ void QgsRendererV2DataDefinedMenus::populateMenu( QMenu* menu, QString fieldName
   menu->addSeparator();
 
   bool hasField = false;
-  const QgsFields & flds = mLayer->pendingFields();
+  const QgsFields & flds = mLayer->fields();
   for ( int idx = 0; idx < flds.count(); ++idx )
   {
     const QgsField& fld = flds[idx];

--- a/src/gui/symbology-ng/qgsrulebasedrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgsrulebasedrendererv2widget.cpp
@@ -504,7 +504,7 @@ void QgsRuleBasedRendererV2Widget::countFeatures()
 
   QgsRenderContext renderContext;
   renderContext.setRendererScale( 0 ); // ignore scale
-  mRenderer->startRender( renderContext, mLayer->pendingFields() );
+  mRenderer->startRender( renderContext, mLayer->fields() );
 
   int nFeatures = mLayer->pendingFeatureCount();
   QProgressDialog p( tr( "Calculating feature count." ), tr( "Abort" ), 0, nFeatures );
@@ -633,7 +633,7 @@ void QgsRendererRulePropsDialog::testFilter()
     return;
   }
 
-  const QgsFields& fields = mLayer->pendingFields();
+  const QgsFields& fields = mLayer->fields();
 
   if ( !filter.prepare( fields ) )
   {

--- a/src/gui/symbology-ng/qgsrulebasedrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgsrulebasedrendererv2widget.cpp
@@ -506,7 +506,7 @@ void QgsRuleBasedRendererV2Widget::countFeatures()
   renderContext.setRendererScale( 0 ); // ignore scale
   mRenderer->startRender( renderContext, mLayer->fields() );
 
-  int nFeatures = mLayer->pendingFeatureCount();
+  int nFeatures = mLayer->featureCount();
   QProgressDialog p( tr( "Calculating feature count." ), tr( "Abort" ), 0, nFeatures );
   p.setWindowModality( Qt::WindowModal );
   int featuresCounted = 0;

--- a/src/gui/symbology-ng/qgssizescalewidget.cpp
+++ b/src/gui/symbology-ng/qgssizescalewidget.cpp
@@ -207,7 +207,7 @@ void QgsSizeScaleWidget::computeFromLayerTriggered()
     return;
 
   QgsExpression expression( mExpressionWidget->currentField() );
-  if ( ! expression.prepare( mLayer->pendingFields() ) )
+  if ( ! expression.prepare( mLayer->fields() ) )
     return;
 
   QStringList lst( expression.referencedColumns() );
@@ -216,7 +216,7 @@ void QgsSizeScaleWidget::computeFromLayerTriggered()
                              QgsFeatureRequest().setFlags( expression.needsGeometry()
                                                            ? QgsFeatureRequest::NoFlags
                                                            : QgsFeatureRequest::NoGeometry )
-                             .setSubsetOfAttributes( lst, mLayer->pendingFields() ) );
+                             .setSubsetOfAttributes( lst, mLayer->fields() ) );
 
   // create list of non-null attribute values
   double min = DBL_MAX;

--- a/src/gui/symbology-ng/qgsvectorfieldsymbollayerwidget.cpp
+++ b/src/gui/symbology-ng/qgsvectorfieldsymbollayerwidget.cpp
@@ -24,7 +24,7 @@ QgsVectorFieldSymbolLayerWidget::QgsVectorFieldSymbolLayerWidget( const QgsVecto
 
   if ( mVectorLayer )
   {
-    const QgsFields& fm = mVectorLayer->pendingFields();
+    const QgsFields& fm = mVectorLayer->fields();
     mXAttributeComboBox->addItem( "" );
     mYAttributeComboBox->addItem( "" );
     for ( int idx = 0; idx < fm.count(); ++idx )

--- a/src/plugins/heatmap/heatmapgui.cpp
+++ b/src/plugins/heatmap/heatmapgui.cpp
@@ -444,7 +444,7 @@ void HeatmapGui::updateBBox()
   double radiusInMapUnits = 0.0;
   if ( mRadiusFieldCheckBox->isChecked() )
   {
-    int idx = inputLayer->pendingFields().indexFromName( mRadiusFieldCombo->currentField() );
+    int idx = inputLayer->fields().indexFromName( mRadiusFieldCombo->currentField() );
     double maxInField = inputLayer->maximumValue( idx ).toDouble();
 
     if ( mRadiusFieldUnitCombo->currentIndex() == HeatmapGui::Meters )
@@ -552,7 +552,7 @@ int HeatmapGui::radiusField() const
   if ( !inputLayer )
     return 0;
 
-  return inputLayer->pendingFields().indexFromName( mRadiusFieldCombo->currentField() );
+  return inputLayer->fields().indexFromName( mRadiusFieldCombo->currentField() );
 }
 
 int HeatmapGui::weightField() const
@@ -561,7 +561,7 @@ int HeatmapGui::weightField() const
   if ( !inputLayer )
     return 0;
 
-  return inputLayer->pendingFields().indexFromName( mWeightFieldCombo->currentField() );
+  return inputLayer->fields().indexFromName( mWeightFieldCombo->currentField() );
 }
 
 bool HeatmapGui::addToCanvas() const

--- a/src/plugins/roadgraph/shortestpathwidget.cpp
+++ b/src/plugins/roadgraph/shortestpathwidget.cpp
@@ -431,7 +431,7 @@ void RgShortestPathWidget::exportPath()
   p.push_front( ct.transform( p1 ) );
 
   QgsFeature f;
-  f.initAttributes( vl->pendingFields().count() );
+  f.initAttributes( vl->fields().count() );
   f.setGeometry( QgsGeometry::fromPolyline( p ) );
   f.setAttribute( 0, cost / distanceUnit.multipler() );
   f.setAttribute( 1, time / timeUnit.multipler() );

--- a/tests/src/core/testqgsrulebasedrenderer.cpp
+++ b/tests/src/core/testqgsrulebasedrenderer.cpp
@@ -84,7 +84,7 @@ class TestQgsRuleBasedRenderer: public QObject
       QVERIFY( r.capabilities() & QgsFeatureRendererV2::MoreSymbolsPerFeature );
 
       QgsRenderContext ctx; // dummy render context
-      r.startRender( ctx, layer->pendingFields() );
+      r.startRender( ctx, layer->fields() );
 
       // test willRenderFeature
       QVERIFY( r.willRenderFeature( f1 ) );

--- a/tests/src/core/testqgsvectorlayercache.cpp
+++ b/tests/src/core/testqgsvectorlayercache.cpp
@@ -161,7 +161,7 @@ void TestVectorLayerCache::testCacheAttrActions()
   QVERIFY( mVectorLayerCache->featureAtId( 15, f ) );
   QVERIFY( f.attribute( "newAttr" ).isValid() );
 
-  QgsFields allFields = mPointsLayer->pendingFields();
+  QgsFields allFields = mPointsLayer->fields();
   int idx = allFields.indexFromName( "newAttr" );
 
   mPointsLayer->startEditing();
@@ -203,7 +203,7 @@ void TestVectorLayerCache::testSubsetRequest()
 {
   QgsFeature f;
 
-  QgsFields fields = mPointsLayer->pendingFields();
+  QgsFields fields = mPointsLayer->fields();
   QStringList requiredFields;
   requiredFields << "Class" << "Cabin Crew";
 

--- a/tests/src/core/testqgsvectorlayerjoinbuffer.cpp
+++ b/tests/src/core/testqgsvectorlayerjoinbuffer.cpp
@@ -70,7 +70,7 @@ void TestVectorLayerJoinBuffer::initTestCase()
 
   mLayerA = new QgsVectorLayer( "Point?field=id_a:integer", "A", "memory" );
   QVERIFY( mLayerA->isValid() );
-  QVERIFY( mLayerA->pendingFields().count() == 1 );
+  QVERIFY( mLayerA->fields().count() == 1 );
 
   QgsFeature fA1( mLayerA->dataProvider()->fields(), 1 );
   fA1.setAttribute( "id_a", 1 );
@@ -83,7 +83,7 @@ void TestVectorLayerJoinBuffer::initTestCase()
 
   mLayerB = new QgsVectorLayer( "Point?field=id_b:integer&field=value_b", "B", "memory" );
   QVERIFY( mLayerB->isValid() );
-  QVERIFY( mLayerB->pendingFields().count() == 2 );
+  QVERIFY( mLayerB->fields().count() == 2 );
 
   QgsFeature fB1( mLayerB->dataProvider()->fields(), 1 );
   fB1.setAttribute( "id_b", 1 );
@@ -98,7 +98,7 @@ void TestVectorLayerJoinBuffer::initTestCase()
 
   mLayerC = new QgsVectorLayer( "Point?field=id_c:integer&field=value_c", "C", "memory" );
   QVERIFY( mLayerC->isValid() );
-  QVERIFY( mLayerC->pendingFields().count() == 2 );
+  QVERIFY( mLayerC->fields().count() == 2 );
 
   QgsFeature fC1( mLayerC->dataProvider()->fields(), 1 );
   fC1.setAttribute( "id_c", 1 );
@@ -136,7 +136,7 @@ void TestVectorLayerJoinBuffer::testJoinBasic()
 {
   QFETCH( bool, memoryCache );
 
-  QVERIFY( mLayerA->pendingFields().count() == 1 );
+  QVERIFY( mLayerA->fields().count() == 1 );
 
   QgsVectorJoinInfo joinInfo;
   joinInfo.targetFieldName = "id_a";
@@ -145,7 +145,7 @@ void TestVectorLayerJoinBuffer::testJoinBasic()
   joinInfo.memoryCache = memoryCache;
   mLayerA->addJoin( joinInfo );
 
-  QVERIFY( mLayerA->pendingFields().count() == 2 );
+  QVERIFY( mLayerA->fields().count() == 2 );
 
   QgsFeatureIterator fi = mLayerA->getFeatures();
   QgsFeature fA1, fA2;
@@ -158,7 +158,7 @@ void TestVectorLayerJoinBuffer::testJoinBasic()
 
   mLayerA->removeJoin( mLayerB->id() );
 
-  QVERIFY( mLayerA->pendingFields().count() == 1 );
+  QVERIFY( mLayerA->fields().count() == 1 );
 }
 
 void TestVectorLayerJoinBuffer::testJoinTransitive()
@@ -167,7 +167,7 @@ void TestVectorLayerJoinBuffer::testJoinTransitive()
   // first we join A -> B and after that B -> C
   // layer A should automatically update to include joined data from C
 
-  QVERIFY( mLayerA->pendingFields().count() == 1 ); // id_a
+  QVERIFY( mLayerA->fields().count() == 1 ); // id_a
 
   // add join A -> B
 
@@ -177,7 +177,7 @@ void TestVectorLayerJoinBuffer::testJoinTransitive()
   joinInfo1.joinFieldName = "id_b";
   joinInfo1.memoryCache = true;
   mLayerA->addJoin( joinInfo1 );
-  QVERIFY( mLayerA->pendingFields().count() == 2 ); // id_a, B_value_b
+  QVERIFY( mLayerA->fields().count() == 2 ); // id_a, B_value_b
 
   // add join B -> C
 
@@ -187,10 +187,10 @@ void TestVectorLayerJoinBuffer::testJoinTransitive()
   joinInfo2.joinFieldName = "id_c";
   joinInfo2.memoryCache = true;
   mLayerB->addJoin( joinInfo2 );
-  QVERIFY( mLayerB->pendingFields().count() == 3 ); // id_b, value_b, C_value_c
+  QVERIFY( mLayerB->fields().count() == 3 ); // id_b, value_b, C_value_c
 
   // now layer A must include also data from layer C
-  QVERIFY( mLayerA->pendingFields().count() == 3 ); // id_a, B_value_b, B_C_value_c
+  QVERIFY( mLayerA->fields().count() == 3 ); // id_a, B_value_b, B_C_value_c
 
   QgsFeatureIterator fi = mLayerA->getFeatures();
   QgsFeature fA1;
@@ -201,7 +201,7 @@ void TestVectorLayerJoinBuffer::testJoinTransitive()
 
   // test that layer A gets updated when layer C changes its fields
   mLayerC->addExpressionField( "123", QgsField( "dummy", QVariant::Int ) );
-  QVERIFY( mLayerA->pendingFields().count() == 4 ); // id_a, B_value_b, B_C_value_c, B_C_dummy
+  QVERIFY( mLayerA->fields().count() == 4 ); // id_a, B_value_b, B_C_value_c, B_C_dummy
   mLayerC->removeExpressionField( 0 );
 
   // cleanup
@@ -252,7 +252,7 @@ void TestVectorLayerJoinBuffer::testJoinSubset()
 
   QgsVectorLayer* layerX = new QgsVectorLayer( "Point?field=id_x:integer&field=value_x1:integer&field=value_x2", "X", "memory" );
   QVERIFY( layerX->isValid() );
-  QVERIFY( layerX->pendingFields().count() == 3 );
+  QVERIFY( layerX->fields().count() == 3 );
 
   QgsFeature fX1( layerX->dataProvider()->fields(), 1 );
   fX1.setAttribute( "id_x", 1 );
@@ -272,7 +272,7 @@ void TestVectorLayerJoinBuffer::testJoinSubset()
   joinInfo.memoryCache = memoryCache;
   mLayerA->addJoin( joinInfo );
 
-  QCOMPARE( mLayerA->pendingFields().count(), 3 ); // id_a, X_value_x1, X_value_x2
+  QCOMPARE( mLayerA->fields().count(), 3 ); // id_a, X_value_x1, X_value_x2
   QgsFeatureIterator fi = mLayerA->getFeatures();
   QgsFeature fAX;
   fi.nextFeature( fAX );
@@ -289,7 +289,7 @@ void TestVectorLayerJoinBuffer::testJoinSubset()
   joinInfo.setJoinFieldNamesSubset( subset );
   mLayerA->addJoin( joinInfo );
 
-  QCOMPARE( mLayerA->pendingFields().count(), 2 ); // id_a, X_value_x2
+  QCOMPARE( mLayerA->fields().count(), 2 ); // id_a, X_value_x2
 
   fi = mLayerA->getFeatures();
   fi.nextFeature( fAX );
@@ -304,7 +304,7 @@ void TestVectorLayerJoinBuffer::testJoinSubset()
 
 void TestVectorLayerJoinBuffer::testJoinTwoTimes()
 {
-  QVERIFY( mLayerA->pendingFields().count() == 1 );
+  QVERIFY( mLayerA->fields().count() == 1 );
 
   QgsVectorJoinInfo joinInfo1;
   joinInfo1.targetFieldName = "id_a";
@@ -324,7 +324,7 @@ void TestVectorLayerJoinBuffer::testJoinTwoTimes()
 
   QCOMPARE( mLayerA->vectorJoins().count(), 2 );
 
-  QVERIFY( mLayerA->pendingFields().count() == 3 );
+  QVERIFY( mLayerA->fields().count() == 3 );
 
   QgsFeatureIterator fi = mLayerA->getFeatures();
   QgsFeature fA1; //, fA2;

--- a/tests/src/core/testqgsvectorlayerjoinbuffer.cpp
+++ b/tests/src/core/testqgsvectorlayerjoinbuffer.cpp
@@ -77,7 +77,7 @@ void TestVectorLayerJoinBuffer::initTestCase()
   QgsFeature fA2( mLayerA->dataProvider()->fields(), 2 );
   fA2.setAttribute( "id_a", 2 );
   mLayerA->dataProvider()->addFeatures( QgsFeatureList() << fA1 << fA2 );
-  QVERIFY( mLayerA->pendingFeatureCount() == 2 );
+  QVERIFY( mLayerA->featureCount() == 2 );
 
   // LAYER B //
 
@@ -92,7 +92,7 @@ void TestVectorLayerJoinBuffer::initTestCase()
   fB2.setAttribute( "id_b", 2 );
   fB2.setAttribute( "value_b", 12 );
   mLayerB->dataProvider()->addFeatures( QgsFeatureList() << fB1 << fB2 );
-  QVERIFY( mLayerB->pendingFeatureCount() == 2 );
+  QVERIFY( mLayerB->featureCount() == 2 );
 
   // LAYER C //
 
@@ -104,7 +104,7 @@ void TestVectorLayerJoinBuffer::initTestCase()
   fC1.setAttribute( "id_c", 1 );
   fC1.setAttribute( "value_c", 101 );
   mLayerC->dataProvider()->addFeatures( QgsFeatureList() << fC1 );
-  QVERIFY( mLayerC->pendingFeatureCount() == 1 );
+  QVERIFY( mLayerC->featureCount() == 1 );
 
   QgsMapLayerRegistry::instance()->addMapLayer( mLayerA );
   QgsMapLayerRegistry::instance()->addMapLayer( mLayerB );
@@ -259,7 +259,7 @@ void TestVectorLayerJoinBuffer::testJoinSubset()
   fX1.setAttribute( "value_x1", 111 );
   fX1.setAttribute( "value_x2", 222 );
   layerX->dataProvider()->addFeatures( QgsFeatureList() << fX1 );
-  QVERIFY( layerX->pendingFeatureCount() == 1 );
+  QVERIFY( layerX->featureCount() == 1 );
 
   QgsMapLayerRegistry::instance()->addMapLayer( layerX );
 


### PR DESCRIPTION
pendingFields() is not very intuitive and leads to confusion for (new) developers. The name `fields()` is straightforward and even shorter to write.
