### PR TITLE
Fix legend symbol size when using map units (fix #13078)

### DIFF
--- a/src/core/layertree/qgslayertreemodellegendnode.cpp
+++ b/src/core/layertree/qgslayertreemodellegendnode.cpp
@@ -159,13 +159,14 @@ Qt::ItemFlags QgsSymbolV2LegendNode::flags() const
 
 QSize QgsSymbolV2LegendNode::minimumIconSize() const
 {
-  QSize minSz;
+  QSize minSz( 16, 16 );
   if ( mItem.symbol() && mItem.symbol()->type() == QgsSymbolV2::Marker )
   {
     QScopedPointer<QgsRenderContext> context( createTemporaryRenderContext() );
     minSz = QgsImageOperation::nonTransparentImageRect(
-              QgsSymbolLayerV2Utils::symbolPreviewPixmap( mItem.symbol(), QSize( 512, 512 ), context.data() ).toImage(),
-              mIconSize,
+              QgsSymbolLayerV2Utils::symbolPreviewPixmap( mItem.symbol(), QSize( 512, 512 ),
+                  context.data() ).toImage(),
+              minSz,
               true ).size();
   }
   else if ( mItem.symbol() && mItem.symbol()->type() == QgsSymbolV2::Line )
@@ -174,16 +175,12 @@ QSize QgsSymbolV2LegendNode::minimumIconSize() const
     minSz = QgsImageOperation::nonTransparentImageRect(
               QgsSymbolLayerV2Utils::symbolPreviewPixmap( mItem.symbol(), QSize( mIconSize.width(), 512 ),
                   context.data() ).toImage(),
-              mIconSize,
+              minSz,
               true ).size();
-  }
-  else
-  {
-    minSz = mIconSize;
   }
 
   if ( mItem.level() != 0 && !( model() && model()->testFlag( QgsLayerTreeModel::ShowLegendAsTree ) ) )
-    minSz.setWidth( indentSize + minSz.width() );
+    minSz.setWidth( mItem.level() * indentSize + minSz.width() );
 
   return minSz;
 }

--- a/src/core/qgsmaplayerlegend.cpp
+++ b/src/core/qgsmaplayerlegend.cpp
@@ -199,33 +199,10 @@ QList<QgsLayerTreeModelLegendNode*> QgsDefaultVectorLayerLegend::createLayerTree
     nodes.append( new QgsSimpleLegendNode( nodeLayer, r->legendClassificationAttribute() ) );
   }
 
-  // we have varying icon sizes, and we want icon to be centered and
-  // text to be left aligned, so we have to compute the max width of icons
-  //
-  // we do that for nodes who share a common parent
-
-  QList<QgsSymbolV2LegendNode*> symbolNodes;
-  QMap<QString, int> widthMax;
   foreach ( const QgsLegendSymbolItemV2& i, r->legendSymbolItemsV2() )
   {
     QgsSymbolV2LegendNode * n = new QgsSymbolV2LegendNode( nodeLayer, i );
     nodes.append( n );
-    if ( i.symbol() )
-    {
-      const QSize sz( n->minimumIconSize() );
-      const QString parentKey( n->data( QgsLayerTreeModelLegendNode::ParentRuleKeyRole ).toString() );
-      widthMax[parentKey] = qMax( sz.width(), widthMax.contains( parentKey ) ? widthMax[parentKey] : 0 );
-      n->setIconSize( sz );
-      symbolNodes.append( n );
-    }
-  }
-
-  foreach ( QgsSymbolV2LegendNode* n, symbolNodes )
-  {
-    const QString parentKey( n->data( QgsLayerTreeModelLegendNode::ParentRuleKeyRole ).toString() );
-    Q_ASSERT( widthMax[parentKey] > 0 );
-    const int twiceMarginWidth = 2; // a one pixel margin avoids hugly rendering of icon
-    n->setIconSize( QSize( widthMax[parentKey] + twiceMarginWidth, n->iconSize().rheight() + twiceMarginWidth ) );
   }
 
   if ( nodes.count() == 1 && nodes[0]->data( Qt::EditRole ).toString().isEmpty() )


### PR DESCRIPTION
The computation of icon sizes for legend symbols has been moved to QgsLayerTreeModel::legendInvalidateMapBasedData() susch that icon size is recomputed when zooming.

@wonder-sk thanks a lot for the pointers, does that look good to you ?
