### PR TITLE
[Processing] Allow "progress" to be specified when calling processing.runalg

### DIFF
--- a/python/plugins/processing/core/Processing.py
+++ b/python/plugins/processing/core/Processing.py
@@ -336,10 +336,10 @@ class Processing:
             print 'Warning: Not all input layers use the same CRS.\n' \
                 + 'This can cause unexpected results.'
 
+        # Don't set the wait cursor twice, because then when you
+        # restore it, it will still be a wait cursor.
+        overrideCursor = False
         if iface is not None:
-            # Don't set the wait cursor twice, because then when you
-            # restore it, it will still be a wait cursor.
-            overrideCursor = False
             cursor = QApplication.overrideCursor()
             if cursor is None or cursor == 0:
                 QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
@@ -353,6 +353,7 @@ class Processing:
             progress = kwargs["progress"] 
         elif iface is not None :
             progress = MessageBarProgress()
+        
         ret = runalg(alg, progress)
         if ret:
             if onFinish is not None:
@@ -361,7 +362,7 @@ class Processing:
             print ("There were errors executing the algorithm.\n"
                     "Check the QGIS log to get more information")
 
-        if iface is not None and overrideCursor:
+        if overrideCursor:
             QApplication.restoreOverrideCursor()
         if isinstance(progress, MessageBarProgress):
             progress.close()

--- a/python/plugins/processing/tools/general.py
+++ b/python/plugins/processing/tools/general.py
@@ -67,11 +67,11 @@ def alghelp(name):
         print 'Algorithm not found'
 
 
-def runalg(algOrName, *args):
-    alg = Processing.runAlgorithm(algOrName, None, *args)
+def runalg(algOrName, *args, **kwargs):
+    alg = Processing.runAlgorithm(algOrName, None, *args, **kwargs)
     if alg is not None:
         return alg.getOutputValuesAsDictionary()
 
 
-def runandload(name, *args):
-    return Processing.runAlgorithm(name, handleAlgorithmResults, *args)
+def runandload(name, *args, **kwargs):
+    return Processing.runAlgorithm(name, handleAlgorithmResults, *args, **kwargs)


### PR DESCRIPTION
This is mostly so that algorithms executed in Processing scripts can
display messages in the same way as if they were executed directly from
Processing toolbox.

Also fixes a small issue with busy cursor being reset too early when
algorithms were executed from Processing scripts.
