### PR TITLE
[Processing] Fixed bad variable references

### DIFF
--- a/python/plugins/processing/algs/qgis/scripts/Create_points_along_lines.py
+++ b/python/plugins/processing/algs/qgis/scripts/Create_points_along_lines.py
@@ -3,7 +3,7 @@
 ##Distance=number 1
 ##Startpoint=number 0
 ##Endpoint=number 0
-##Points along lines=output vector
+##output=output vector
 
 from PyQt4.QtCore import QVariant
 from qgis.core import QGis, QgsFeature, QgsField
@@ -15,14 +15,14 @@ def create_points(feat):
     length = geom.length()
     currentdistance = 0
 
-    if endpoint > 0:
-        length = endpoint
+    if Endpoint > 0:
+        length = Endpoint
 
     out = QgsFeature()
 
-    while startpoint + currentdistance <= length:
-        point = geom.interpolate(startpoint + currentdistance)
-        currentdistance = currentdistance + distance
+    while Startpoint + currentdistance <= length:
+        point = geom.interpolate(Startpoint + currentdistance)
+        currentdistance = currentdistance + Distance
         out.setGeometry(point)
         attrs = feat.attributes()
         attrs.append(currentdistance)
@@ -30,7 +30,7 @@ def create_points(feat):
         writer.addFeature(out)
 
 
-layer = processing.getObject(lines)
+layer = processing.getObject(Lines)
 fields = layer.dataProvider().fields()
 fields.append(QgsField('Distance', QVariant.Double))
 writer = VectorWriter(output, None, fields, QGis.WKBPoint,


### PR DESCRIPTION
The "Create points along line" processing script had bad variable names and was producing errors when attempting to run. I fixed the variable names - it should be working correctly now.
