### PR TITLE
Make QgsRenderContext available to more renderer methods

### DIFF
--- a/python/core/symbology-ng/qgscategorizedsymbolrendererv2.sip
+++ b/python/core/symbology-ng/qgscategorizedsymbolrendererv2.sip
@@ -45,9 +45,9 @@ class QgsCategorizedSymbolRendererV2 : QgsFeatureRendererV2
 
     virtual ~QgsCategorizedSymbolRendererV2();
 
-    virtual QgsSymbolV2* symbolForFeature( QgsFeature& feature );
+    virtual QgsSymbolV2* symbolForFeature( QgsFeature& feature, QgsRenderContext& context );
 
-    virtual QgsSymbolV2* originalSymbolForFeature( QgsFeature& feature );
+    virtual QgsSymbolV2* originalSymbolForFeature( QgsFeature& feature, QgsRenderContext& context );
 
     virtual void startRender( QgsRenderContext& context, const QgsFields& fields );
 
@@ -64,7 +64,7 @@ class QgsCategorizedSymbolRendererV2 : QgsFeatureRendererV2
     //! returns bitwise OR-ed capabilities of the renderer
     virtual int capabilities();
 
-    virtual QgsSymbolV2List symbols();
+    virtual QgsSymbolV2List symbols( QgsRenderContext& context );
     void updateSymbols( QgsSymbolV2 * sym );
 
     const QgsCategoryList& categories() const;

--- a/python/core/symbology-ng/qgsgraduatedsymbolrendererv2.sip
+++ b/python/core/symbology-ng/qgsgraduatedsymbolrendererv2.sip
@@ -87,9 +87,9 @@ class QgsGraduatedSymbolRendererV2 : QgsFeatureRendererV2
 
     virtual ~QgsGraduatedSymbolRendererV2();
 
-    virtual QgsSymbolV2* symbolForFeature( QgsFeature& feature );
+    virtual QgsSymbolV2* symbolForFeature( QgsFeature& feature, QgsRenderContext& context );
 
-    virtual QgsSymbolV2* originalSymbolForFeature( QgsFeature& feature );
+    virtual QgsSymbolV2* originalSymbolForFeature( QgsFeature& feature, QgsRenderContext& context );
 
     virtual void startRender( QgsRenderContext& context, const QgsFields& fields );
 
@@ -106,7 +106,7 @@ class QgsGraduatedSymbolRendererV2 : QgsFeatureRendererV2
     //! returns bitwise OR-ed capabilities of the renderer
     virtual int capabilities();
 
-    virtual QgsSymbolV2List symbols();
+    virtual QgsSymbolV2List symbols( QgsRenderContext& context );
 
     QString classAttribute() const;
     void setClassAttribute( QString attr );

--- a/python/core/symbology-ng/qgsheatmaprenderer.sip
+++ b/python/core/symbology-ng/qgsheatmaprenderer.sip
@@ -13,8 +13,8 @@ class QgsHeatmapRenderer : QgsFeatureRendererV2
     virtual void startRender( QgsRenderContext& context, const QgsFields& fields );
     virtual bool renderFeature( QgsFeature& feature, QgsRenderContext& context, int layer = -1, bool selected = false, bool drawVertexMarker = false );
     virtual void stopRender( QgsRenderContext& context );
-    virtual QgsSymbolV2* symbolForFeature( QgsFeature& feature );
-    virtual QgsSymbolV2List symbols();
+    virtual QgsSymbolV2* symbolForFeature( QgsFeature& feature, QgsRenderContext& context );
+    virtual QgsSymbolV2List symbols( QgsRenderContext& context );
     virtual QString dump() const;
     virtual QList<QString> usedAttributes();
     static QgsFeatureRendererV2* create( QDomElement& element ) /Factory/;

--- a/python/core/symbology-ng/qgsinvertedpolygonrenderer.sip
+++ b/python/core/symbology-ng/qgsinvertedpolygonrenderer.sip
@@ -41,15 +41,15 @@ class QgsInvertedPolygonRenderer : QgsFeatureRendererV2
     /** Proxy that will call this method on the embedded renderer. */
     virtual int capabilities();
     /** Proxy that will call this method on the embedded renderer. */
-    virtual QgsSymbolV2List symbols();
+    virtual QgsSymbolV2List symbols( QgsRenderContext& context );
     /** Proxy that will call this method on the embedded renderer. */
-    virtual QgsSymbolV2* symbolForFeature( QgsFeature& feature );
+    virtual QgsSymbolV2* symbolForFeature( QgsFeature& feature, QgsRenderContext& context );
     /** Proxy that will call this method on the embedded renderer. */
-    virtual QgsSymbolV2* originalSymbolForFeature( QgsFeature& feat );
+    virtual QgsSymbolV2* originalSymbolForFeature( QgsFeature& feat, QgsRenderContext& context );
     /** Proxy that will call this method on the embedded renderer. */
-    virtual QgsSymbolV2List symbolsForFeature( QgsFeature& feat );
+    virtual QgsSymbolV2List symbolsForFeature( QgsFeature& feat, QgsRenderContext& context );
     /** Proxy that will call this method on the embedded renderer. */
-    virtual QgsSymbolV2List originalSymbolsForFeature( QgsFeature& feat );
+    virtual QgsSymbolV2List originalSymbolsForFeature( QgsFeature& feat, QgsRenderContext& context );
     /** Proxy that will call this method on the embedded renderer. */
     virtual QgsLegendSymbologyList legendSymbologyItems( QSize iconSize );
     /** Proxy that will call this method on the embedded renderer.
@@ -57,7 +57,7 @@ class QgsInvertedPolygonRenderer : QgsFeatureRendererV2
      */
     // virtual QgsLegendSymbolList legendSymbolItems( double scaleDenominator = -1, QString rule = "" );
     /** Proxy that will call this method on the embedded renderer. */
-    virtual bool willRenderFeature( QgsFeature& feat );
+    virtual bool willRenderFeature( QgsFeature& feat, QgsRenderContext& context );
 
     /** Creates a renderer out of an XML, for loading*/
     static QgsFeatureRendererV2* create( QDomElement& element ) /Factory/;

--- a/python/core/symbology-ng/qgspointdisplacementrenderer.sip
+++ b/python/core/symbology-ng/qgspointdisplacementrenderer.sip
@@ -14,14 +14,26 @@ class QgsPointDisplacementRenderer : QgsFeatureRendererV2
     /** Reimplemented from QgsFeatureRendererV2*/
     bool renderFeature( QgsFeature& feature, QgsRenderContext& context, int layer = -1, bool selected = false, bool drawVertexMarker = false );
 
-    QgsSymbolV2* symbolForFeature( QgsFeature& feature );
+    /** Partial proxy that will call this method on the embedded renderer. */
+    virtual QList<QString> usedAttributes();
+    /** Proxy that will call this method on the embedded renderer. */
+    virtual int capabilities();
+    /** Proxy that will call this method on the embedded renderer. */
+    virtual QgsSymbolV2List symbols( QgsRenderContext& context );
+    /** Proxy that will call this method on the embedded renderer. */
+    virtual QgsSymbolV2* symbolForFeature( QgsFeature& feature, QgsRenderContext& context );
+    /** Proxy that will call this method on the embedded renderer. */
+    virtual QgsSymbolV2* originalSymbolForFeature( QgsFeature& feat, QgsRenderContext& context );
+    /** Proxy that will call this method on the embedded renderer. */
+    virtual QgsSymbolV2List symbolsForFeature( QgsFeature& feat, QgsRenderContext& context );
+    /** Proxy that will call this method on the embedded renderer. */
+    virtual QgsSymbolV2List originalSymbolsForFeature( QgsFeature& feat, QgsRenderContext& context );
+    /** Proxy that will call this method on the embedded renderer. */
+    virtual bool willRenderFeature( QgsFeature& feat, QgsRenderContext& context );
 
     virtual void startRender( QgsRenderContext& context, const QgsFields& fields );
 
     void stopRender( QgsRenderContext& context );
-
-    QList<QString> usedAttributes();
-    QgsSymbolV2List symbols();
 
     //! create a renderer from XML element
     static QgsFeatureRendererV2* create( QDomElement& symbologyElem ) /Factory/;

--- a/python/core/symbology-ng/qgsrendererv2.sip
+++ b/python/core/symbology-ng/qgsrendererv2.sip
@@ -65,7 +65,16 @@ class QgsFeatureRendererV2
      * @param feature feature
      * @return returns pointer to symbol or 0 if symbol was not found
      */
-    virtual QgsSymbolV2* symbolForFeature( QgsFeature& feature ) = 0;
+    virtual QgsSymbolV2* symbolForFeature( QgsFeature& feature ) /Deprecated/;
+
+    /** To be overridden
+     * @param feature feature
+     * @param context render context
+     * @return returns pointer to symbol or 0 if symbol was not found
+     * @note added in QGIS 2.12
+     */
+    //TODO - make pure virtual when above method is removed
+    virtual QgsSymbolV2* symbolForFeature( QgsFeature& feature, QgsRenderContext& context );
 
     /**
      * Return symbol for feature. The difference compared to symbolForFeature() is that it returns original
@@ -73,7 +82,15 @@ class QgsFeatureRendererV2
      * of a symbol for use in rendering.
      * @note added in 2.6
      */
-    virtual QgsSymbolV2* originalSymbolForFeature( QgsFeature& feature );
+    virtual QgsSymbolV2* originalSymbolForFeature( QgsFeature& feature ) /Deprecated/;
+
+    /**
+     * Return symbol for feature. The difference compared to symbolForFeature() is that it returns original
+     * symbol which can be used as an identifier for renderer's rule - the former may return a temporary replacement
+     * of a symbol for use in rendering.
+     * @note added in 2.12
+     */
+    virtual QgsSymbolV2* originalSymbolForFeature( QgsFeature& feature, QgsRenderContext& context );
 
     virtual void startRender( QgsRenderContext& context, const QgsFields& fields ) = 0;
 
@@ -108,7 +125,7 @@ class QgsFeatureRendererV2
     virtual int capabilities();
 
     //! for symbol levels
-    virtual QgsSymbolV2List symbols() = 0;
+    virtual QgsSymbolV2List symbols( QgsRenderContext& context ) = 0;
 
     bool usingSymbolLevels() const;
     void setUsingSymbolLevels( bool usingSymbolLevels );
@@ -180,17 +197,34 @@ class QgsFeatureRendererV2
     //! return whether the renderer will render a feature or not.
     //! Must be called between startRender() and stopRender() calls.
     //! Default implementation uses symbolForFeature().
-    virtual bool willRenderFeature( QgsFeature& feat );
+    virtual bool willRenderFeature( QgsFeature& feat ) /Deprecated/;
+
+    /** Returns whether the renderer will render a feature or not.
+     * Must be called between startRender() and stopRender() calls.
+     * Default implementation uses symbolForFeature().
+     * @note added in QGIS 2.12
+     */
+    virtual bool willRenderFeature( QgsFeature& feat, QgsRenderContext& context );
 
     //! return list of symbols used for rendering the feature.
     //! For renderers that do not support MoreSymbolsPerFeature it is more efficient
     //! to use symbolForFeature()
-    virtual QgsSymbolV2List symbolsForFeature( QgsFeature& feat );
+    virtual QgsSymbolV2List symbolsForFeature( QgsFeature& feat ) /Deprecated/;
+
+    //! return list of symbols used for rendering the feature.
+    //! For renderers that do not support MoreSymbolsPerFeature it is more efficient
+    //! to use symbolForFeature()
+    virtual QgsSymbolV2List symbolsForFeature( QgsFeature& feat, QgsRenderContext& context );
 
     //! Equivalent of originalSymbolsForFeature() call
     //! extended to support renderers that may use more symbols per feature - similar to symbolsForFeature()
     //! @note added in 2.6
-    virtual QgsSymbolV2List originalSymbolsForFeature( QgsFeature& feat );
+    virtual QgsSymbolV2List originalSymbolsForFeature( QgsFeature& feat ) /Deprecated/;
+
+    //! Equivalent of originalSymbolsForFeature() call
+    //! extended to support renderers that may use more symbols per feature - similar to symbolsForFeature()
+    //! @note added in 2.6
+    virtual QgsSymbolV2List originalSymbolsForFeature( QgsFeature& feat, QgsRenderContext& context );
 
     /** Allows for a renderer to modify the extent of a feature request prior to rendering
      * @param extent reference to request's filter extent. Modify extent to change the

--- a/python/core/symbology-ng/qgsrulebasedrendererv2.sip
+++ b/python/core/symbology-ng/qgsrulebasedrendererv2.sip
@@ -60,12 +60,12 @@ class QgsRuleBasedRendererV2 : QgsFeatureRendererV2
         ~Rule();
         QString dump( int offset = 0 ) const;
         QSet<QString> usedAttributes();
-        QgsSymbolV2List symbols();
+        QgsSymbolV2List symbols( const QgsRenderContext& context = QgsRenderContext() );
         //! @note not available in python bindings
         // QgsLegendSymbolList legendSymbolItems();
         //! @note added in 2.6
         QgsLegendSymbolListV2 legendSymbolItemsV2( int currentLevel = -1 ) const;
-        bool isFilterOK( QgsFeature& f ) const;
+        bool isFilterOK( QgsFeature& f, QgsRenderContext* context = 0 ) const;
         bool isScaleOK( double scale ) const;
 
         QgsSymbolV2* symbol();
@@ -117,13 +117,13 @@ class QgsRuleBasedRendererV2 : QgsFeatureRendererV2
         bool renderFeature( QgsRuleBasedRendererV2::FeatureToRender& featToRender, QgsRenderContext& context, QgsRuleBasedRendererV2::RenderQueue& renderQueue );
 
         //! only tell whether a feature will be rendered without actually rendering it
-        bool willRenderFeature( QgsFeature& feat );
+        bool willRenderFeature( QgsFeature& feat, QgsRenderContext* context = 0);
 
         //! tell which symbols will be used to render the feature
-        QgsSymbolV2List symbolsForFeature( QgsFeature& feat );
+        QgsSymbolV2List symbolsForFeature( QgsFeature& feat, QgsRenderContext* context = 0 );
 
         //! tell which rules will be used to render the feature
-        QList<QgsRuleBasedRendererV2::Rule*> rulesForFeature( QgsFeature& feat );
+        QList<QgsRuleBasedRendererV2::Rule*> rulesForFeature( QgsFeature& feat, QgsRenderContext* context = 0 );
 
         void stopRender( QgsRenderContext& context );
 
@@ -171,7 +171,7 @@ class QgsRuleBasedRendererV2 : QgsFeatureRendererV2
     ~QgsRuleBasedRendererV2();
 
     //! return symbol for current feature. Should not be used individually: there could be more symbols for a feature
-    virtual QgsSymbolV2* symbolForFeature( QgsFeature& feature );
+    virtual QgsSymbolV2* symbolForFeature( QgsFeature& feature, QgsRenderContext &context );
 
     virtual bool renderFeature( QgsFeature& feature, QgsRenderContext& context, int layer = -1, bool selected = false, bool drawVertexMarker = false );
 
@@ -189,7 +189,7 @@ class QgsRuleBasedRendererV2 : QgsFeatureRendererV2
 
     static QgsFeatureRendererV2* createFromSld( QDomElement& element, QGis::GeometryType geomType ) /Factory/;
 
-    virtual QgsSymbolV2List symbols();
+    virtual QgsSymbolV2List symbols( QgsRenderContext &context );
 
     //! store renderer info to XML element
     virtual QDomElement save( QDomDocument& doc );
@@ -223,14 +223,14 @@ class QgsRuleBasedRendererV2 : QgsFeatureRendererV2
 
     //! return whether the renderer will render a feature or not.
     //! Must be called between startRender() and stopRender() calls.
-    virtual bool willRenderFeature( QgsFeature& feat );
+    virtual bool willRenderFeature( QgsFeature& feat, QgsRenderContext &context );
 
     //! return list of symbols used for rendering the feature.
     //! For renderers that do not support MoreSymbolsPerFeature it is more efficient
     //! to use symbolForFeature()
-    virtual QgsSymbolV2List symbolsForFeature( QgsFeature& feat );
+    virtual QgsSymbolV2List symbolsForFeature( QgsFeature& feat, QgsRenderContext &context );
 
-    virtual QgsSymbolV2List originalSymbolsForFeature( QgsFeature& feat );
+    virtual QgsSymbolV2List originalSymbolsForFeature( QgsFeature& feat, QgsRenderContext &context );
 
     //! returns bitwise OR-ed capabilities of the renderer
     virtual int capabilities();

--- a/python/core/symbology-ng/qgssinglesymbolrendererv2.sip
+++ b/python/core/symbology-ng/qgssinglesymbolrendererv2.sip
@@ -9,9 +9,9 @@ class QgsSingleSymbolRendererV2 : QgsFeatureRendererV2
 
     virtual ~QgsSingleSymbolRendererV2();
 
-    virtual QgsSymbolV2* symbolForFeature( QgsFeature& feature );
+    virtual QgsSymbolV2* symbolForFeature( QgsFeature& feature, QgsRenderContext& context );
 
-    virtual QgsSymbolV2* originalSymbolForFeature( QgsFeature& feature );
+    virtual QgsSymbolV2* originalSymbolForFeature( QgsFeature& feature, QgsRenderContext& context );
 
     virtual void startRender( QgsRenderContext& context, const QgsFields& fields );
 
@@ -41,7 +41,7 @@ class QgsSingleSymbolRendererV2 : QgsFeatureRendererV2
     //! returns bitwise OR-ed capabilities of the renderer
     virtual int capabilities();
 
-    virtual QgsSymbolV2List symbols();
+    virtual QgsSymbolV2List symbols( QgsRenderContext& context );
 
     //! create renderer from XML element
     static QgsFeatureRendererV2* create( QDomElement& element ) /Factory/;

--- a/src/app/qgsmaptoolrotatepointsymbols.cpp
+++ b/src/app/qgsmaptoolrotatepointsymbols.cpp
@@ -117,7 +117,7 @@ void QgsMapToolRotatePointSymbols::canvasPressEvent( QMouseEvent *e )
   if ( renderer->capabilities() & QgsFeatureRendererV2::MoreSymbolsPerFeature )
   {
     //could be multiple symbols for this feature, so check them all
-    foreach ( QgsSymbolV2* s, renderer->originalSymbolsForFeature( pointFeature ) )
+    foreach ( QgsSymbolV2* s, renderer->originalSymbolsForFeature( pointFeature, context ) )
     {
       if ( s && s->type() == QgsSymbolV2::Marker )
       {
@@ -135,7 +135,7 @@ void QgsMapToolRotatePointSymbols::canvasPressEvent( QMouseEvent *e )
   }
   else
   {
-    QgsSymbolV2* s = renderer->originalSymbolForFeature( pointFeature );
+    QgsSymbolV2* s = renderer->originalSymbolForFeature( pointFeature, context );
     if ( s && s->type() == QgsSymbolV2::Marker )
     {
       markerSymbol = static_cast< QgsMarkerSymbolV2* >( s );

--- a/src/app/qgsmaptoolselectutils.cpp
+++ b/src/app/qgsmaptoolselectutils.cpp
@@ -159,7 +159,7 @@ void QgsMapToolSelectUtils::setSelectFeatures( QgsMapCanvas* canvas,
   while ( fit.nextFeature( f ) )
   {
     // make sure to only use features that are visible
-    if ( r && !r->willRenderFeature( f ) )
+    if ( r && !r->willRenderFeature( f, context ) )
       continue;
 
     const QgsGeometry* g = f.constGeometry();

--- a/src/core/dxf/qgsdxfexport.cpp
+++ b/src/core/dxf/qgsdxfexport.cpp
@@ -554,10 +554,11 @@ void QgsDxfExport::writeTables()
   writeGroup( 2, "TABLES" );
 
   // Iterate through all layers and get symbol layer pointers
+  QgsRenderContext context = renderContext();
   QList< QPair< QgsSymbolLayerV2*, QgsSymbolV2* > > slList;
   if ( mSymbologyExport != NoSymbology )
   {
-    slList = symbolLayers();
+    slList = symbolLayers( context );
   }
 
   // Line types
@@ -813,11 +814,13 @@ void QgsDxfExport::writeBlocks()
     writeGroup( 100, "AcDbBlockEnd" );
   }
 
+  QgsRenderContext ct = renderContext();
+
   // Iterate through all layers and get symbol layer pointers
   QList< QPair< QgsSymbolLayerV2*, QgsSymbolV2* > > slList;
   if ( mSymbologyExport != NoSymbology )
   {
-    slList = symbolLayers();
+    slList = symbolLayers( ct );
   }
 
   QList< QPair< QgsSymbolLayerV2*, QgsSymbolV2* > >::const_iterator slIt = slList.constBegin();
@@ -828,7 +831,6 @@ void QgsDxfExport::writeBlocks()
       continue;
 
     // if point symbol layer and no data defined properties: write block
-    QgsRenderContext ct;
     QgsSymbolV2RenderContext ctx( ct, QgsSymbolV2::MapUnit, slIt->second->alpha(), false, slIt->second->renderHints(), 0 );
     ml->startRender( ctx );
 
@@ -941,7 +943,7 @@ void QgsDxfExport::writeEntities()
       }
       else
       {
-        QgsSymbolV2List symbolList = renderer->symbolsForFeature( fet );
+        QgsSymbolV2List symbolList = renderer->symbolsForFeature( fet, ctx );
         if ( symbolList.size() < 1 )
         {
           continue;
@@ -1021,7 +1023,7 @@ void QgsDxfExport::writeEntitiesSymbolLevels( QgsVectorLayer* layer )
   QgsSymbolV2* featureSymbol = 0;
   while ( fit.nextFeature( fet ) )
   {
-    featureSymbol = renderer->symbolForFeature( fet );
+    featureSymbol = renderer->symbolForFeature( fet, ctx );
     if ( !featureSymbol )
     {
       continue;
@@ -1037,7 +1039,7 @@ void QgsDxfExport::writeEntitiesSymbolLevels( QgsVectorLayer* layer )
 
   // find out order
   QgsSymbolV2LevelOrder levels;
-  QgsSymbolV2List symbols = renderer->symbols();
+  QgsSymbolV2List symbols = renderer->symbols( ctx );
   for ( int i = 0; i < symbols.count(); i++ )
   {
     QgsSymbolV2* sym = symbols[i];
@@ -3818,7 +3820,7 @@ double QgsDxfExport::mapUnitScaleFactor( double scaleDenominator, QgsSymbolV2::O
   return scaleDenominator * QGis::fromUnitToUnitFactor( QGis::Meters, mapUnits ) / 1000.0;
 }
 
-QList< QPair< QgsSymbolLayerV2*, QgsSymbolV2* > > QgsDxfExport::symbolLayers()
+QList< QPair< QgsSymbolLayerV2*, QgsSymbolV2* > > QgsDxfExport::symbolLayers( QgsRenderContext &context )
 {
   QList< QPair< QgsSymbolLayerV2*, QgsSymbolV2* > > symbolLayers;
 
@@ -3840,7 +3842,7 @@ QList< QPair< QgsSymbolLayerV2*, QgsSymbolV2* > > QgsDxfExport::symbolLayers()
     }
 
     // get all symbols
-    QgsSymbolV2List symbols = r->symbols();
+    QgsSymbolV2List symbols = r->symbols( context );
     QgsSymbolV2List::iterator symbolIt = symbols.begin();
     for ( ; symbolIt != symbols.end(); ++symbolIt )
     {

--- a/src/core/dxf/qgsdxfexport.h
+++ b/src/core/dxf/qgsdxfexport.h
@@ -172,7 +172,7 @@ class CORE_EXPORT QgsDxfExport
     //helper functions for symbology export
     QgsRenderContext renderContext() const;
 
-    QList< QPair< QgsSymbolLayerV2 *, QgsSymbolV2 * > > symbolLayers();
+    QList< QPair< QgsSymbolLayerV2 *, QgsSymbolV2 * > > symbolLayers( QgsRenderContext& context );
     static int nLineTypes( const QList< QPair< QgsSymbolLayerV2*, QgsSymbolV2*> > &symbolLayers );
     static bool hasDataDefinedProperties( const QgsSymbolLayerV2 *sl, const QgsSymbolV2 *symbol );
     double dashSize() const;

--- a/src/core/qgsmaphittest.cpp
+++ b/src/core/qgsmaphittest.cpp
@@ -63,11 +63,11 @@ void QgsMapHitTest::runHitTestLayer( QgsVectorLayer* vl, SymbolV2Set& usedSymbol
   {
     if ( moreSymbolsPerFeature )
     {
-      foreach ( QgsSymbolV2* s, r->originalSymbolsForFeature( f ) )
+      foreach ( QgsSymbolV2* s, r->originalSymbolsForFeature( f, context ) )
         usedSymbols.insert( s );
     }
     else
-      usedSymbols.insert( r->originalSymbolForFeature( f ) );
+      usedSymbols.insert( r->originalSymbolForFeature( f, context ) );
   }
   r->stopRender( context );
 }

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -81,6 +81,8 @@ QgsVectorFileWriter::QgsVectorFileWriter(
   QStringList layOptions = layerOptions;
   QStringList dsOptions = datasourceOptions;
 
+  mRenderContext.setRendererScale( mSymbologyScaleDenominator );
+
   if ( theVectorFileName.isEmpty() )
   {
     mErrorMessage = QObject::tr( "Empty filename given" );
@@ -1572,7 +1574,7 @@ bool QgsVectorFileWriter::addFeature( QgsFeature& feature, QgsFeatureRendererV2*
   if ( mSymbologyExport != NoSymbology && renderer )
   {
     //SymbolLayerSymbology: concatenate ogr styles of all symbollayers
-    QgsSymbolV2List symbols = renderer->symbolsForFeature( feature );
+    QgsSymbolV2List symbols = renderer->symbolsForFeature( feature, mRenderContext );
     QString styleString;
     QString currentStyle;
 
@@ -2109,6 +2111,12 @@ bool QgsVectorFileWriter::deleteShapeFile( QString theFileName )
   return ok;
 }
 
+void QgsVectorFileWriter::setSymbologyScaleDenominator( double d )
+{
+  mSymbologyScaleDenominator = d;
+  mRenderContext.setRendererScale( mSymbologyScaleDenominator );
+}
+
 QMap< QString, QString> QgsVectorFileWriter::supportedFiltersAndFormats()
 {
   QMap<QString, QString> resultMap;
@@ -2466,7 +2474,7 @@ void QgsVectorFileWriter::createSymbolLayerTable( QgsVectorLayer* vl,  const Qgs
 
   //get symbols
   int nTotalLevels = 0;
-  QgsSymbolV2List symbolList = renderer->symbols();
+  QgsSymbolV2List symbolList = renderer->symbols( mRenderContext );
   QgsSymbolV2List::iterator symbolIt = symbolList.begin();
   for ( ; symbolIt != symbolList.end(); ++symbolIt )
   {
@@ -2533,7 +2541,7 @@ QgsVectorFileWriter::WriterError QgsVectorFileWriter::exportFeaturesSymbolLevels
       }
     }
 
-    featureSymbol = renderer->symbolForFeature( fet );
+    featureSymbol = renderer->symbolForFeature( fet, mRenderContext );
     if ( !featureSymbol )
     {
       continue;
@@ -2549,7 +2557,7 @@ QgsVectorFileWriter::WriterError QgsVectorFileWriter::exportFeaturesSymbolLevels
 
   //find out order
   QgsSymbolV2LevelOrder levels;
-  QgsSymbolV2List symbols = renderer->symbols();
+  QgsSymbolV2List symbols = renderer->symbols( mRenderContext );
   for ( int i = 0; i < symbols.count(); i++ )
   {
     QgsSymbolV2* sym = symbols[i];
@@ -2656,14 +2664,7 @@ double QgsVectorFileWriter::mapUnitScaleFactor( double scaleDenominator, QgsSymb
   return 1.0;
 }
 
-QgsRenderContext QgsVectorFileWriter::renderContext() const
-{
-  QgsRenderContext context;
-  context.setRendererScale( mSymbologyScaleDenominator );
-  return context;
-}
-
-void QgsVectorFileWriter::startRender( QgsVectorLayer* vl ) const
+void QgsVectorFileWriter::startRender( QgsVectorLayer* vl )
 {
   QgsFeatureRendererV2* renderer = symbologyRenderer( vl );
   if ( !renderer )
@@ -2671,11 +2672,10 @@ void QgsVectorFileWriter::startRender( QgsVectorLayer* vl ) const
     return;
   }
 
-  QgsRenderContext ctx = renderContext();
-  renderer->startRender( ctx, vl->fields() );
+  renderer->startRender( mRenderContext, vl->fields() );
 }
 
-void QgsVectorFileWriter::stopRender( QgsVectorLayer* vl ) const
+void QgsVectorFileWriter::stopRender( QgsVectorLayer* vl )
 {
   QgsFeatureRendererV2* renderer = symbologyRenderer( vl );
   if ( !renderer )
@@ -2683,8 +2683,7 @@ void QgsVectorFileWriter::stopRender( QgsVectorLayer* vl ) const
     return;
   }
 
-  QgsRenderContext ctx = renderContext();
-  renderer->stopRender( ctx );
+  renderer->stopRender( mRenderContext );
 }
 
 QgsFeatureRendererV2* QgsVectorFileWriter::symbologyRenderer( QgsVectorLayer* vl ) const

--- a/src/core/qgsvectorfilewriter.h
+++ b/src/core/qgsvectorfilewriter.h
@@ -265,7 +265,7 @@ class CORE_EXPORT QgsVectorFileWriter
     void setSymbologyExport( SymbologyExport symExport ) { mSymbologyExport = symExport; }
 
     double symbologyScaleDenominator() const { return mSymbologyScaleDenominator; }
-    void setSymbologyScaleDenominator( double d ) { mSymbologyScaleDenominator = d; }
+    void setSymbologyScaleDenominator( double d );
 
     static bool driverMetadata( const QString& driverName, MetaData& driverMetadata );
 
@@ -301,6 +301,8 @@ class CORE_EXPORT QgsVectorFileWriter
     double mSymbologyScaleDenominator;
 
   private:
+    QgsRenderContext mRenderContext;
+
     static QMap<QString, MetaData> initMetaData();
     /**
      * @deprecated
@@ -314,9 +316,9 @@ class CORE_EXPORT QgsVectorFileWriter
     WriterError exportFeaturesSymbolLevels( QgsVectorLayer* layer, QgsFeatureIterator& fit, const QgsCoordinateTransform* ct, QString* errorMessage = 0 );
     double mmScaleFactor( double scaleDenominator, QgsSymbolV2::OutputUnit symbolUnits, QGis::UnitType mapUnits );
     double mapUnitScaleFactor( double scaleDenominator, QgsSymbolV2::OutputUnit symbolUnits, QGis::UnitType mapUnits );
-    QgsRenderContext renderContext() const;
-    void startRender( QgsVectorLayer* vl ) const;
-    void stopRender( QgsVectorLayer* vl ) const;
+
+    void startRender( QgsVectorLayer* vl );
+    void stopRender( QgsVectorLayer* vl );
     QgsFeatureRendererV2* symbologyRenderer( QgsVectorLayer* vl ) const;
     /** Adds attributes needed for classification*/
     void addRendererAttributes( QgsVectorLayer* vl, QgsAttributeList& attList );

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -343,7 +343,7 @@ void QgsVectorLayer::drawLabels( QgsRenderContext& rendererContext )
       QgsFeature fet;
       while ( fit.nextFeature( fet ) )
       {
-        if ( mRendererV2->willRenderFeature( fet ) )
+        if ( mRendererV2->willRenderFeature( fet, rendererContext ) )
         {
           bool sel = mSelectedFeatureIds.contains( fet.id() );
           mLabel->renderLabel( rendererContext, fet, sel, 0 );
@@ -721,7 +721,7 @@ bool QgsVectorLayer::countSymbolFeatures( bool showProgress )
   QgsFeature f;
   while ( fit.nextFeature( f ) )
   {
-    QgsSymbolV2List featureSymbolList = mRendererV2->originalSymbolsForFeature( f );
+    QgsSymbolV2List featureSymbolList = mRendererV2->originalSymbolsForFeature( f, renderContext );
     for ( QgsSymbolV2List::iterator symbolIt = featureSymbolList.begin(); symbolIt != featureSymbolList.end(); ++symbolIt )
     {
       mSymbolFeatureCountMap[*symbolIt] += 1;

--- a/src/core/qgsvectorlayerrenderer.cpp
+++ b/src/core/qgsvectorlayerrenderer.cpp
@@ -344,7 +344,7 @@ void QgsVectorLayerRenderer::drawRendererV2Levels( QgsFeatureIterator& fit )
       return;
     }
 
-    QgsSymbolV2* sym = mRendererV2->symbolForFeature( fet );
+    QgsSymbolV2* sym = mRendererV2->symbolForFeature( fet, mContext );
     if ( !sym )
     {
       continue;
@@ -377,7 +377,7 @@ void QgsVectorLayerRenderer::drawRendererV2Levels( QgsFeatureIterator& fit )
 
   // find out the order
   QgsSymbolV2LevelOrder levels;
-  QgsSymbolV2List symbols = mRendererV2->symbols();
+  QgsSymbolV2List symbols = mRendererV2->symbols( mContext );
   for ( int i = 0; i < symbols.count(); i++ )
   {
     QgsSymbolV2* sym = symbols[i];

--- a/src/core/symbology-ng/qgscategorizedsymbolrendererv2.cpp
+++ b/src/core/symbology-ng/qgscategorizedsymbolrendererv2.cpp
@@ -201,9 +201,9 @@ QgsSymbolV2* QgsCategorizedSymbolRendererV2::symbolForValue( QVariant value )
   return *it;
 }
 
-QgsSymbolV2* QgsCategorizedSymbolRendererV2::symbolForFeature( QgsFeature& feature )
+QgsSymbolV2* QgsCategorizedSymbolRendererV2::symbolForFeature( QgsFeature& feature, QgsRenderContext &context )
 {
-  QgsSymbolV2* symbol = originalSymbolForFeature( feature );
+  QgsSymbolV2* symbol = originalSymbolForFeature( feature, context );
   if ( !symbol )
     return 0;
 
@@ -235,8 +235,9 @@ QgsSymbolV2* QgsCategorizedSymbolRendererV2::symbolForFeature( QgsFeature& featu
 }
 
 
-QgsSymbolV2* QgsCategorizedSymbolRendererV2::originalSymbolForFeature( QgsFeature& feature )
+QgsSymbolV2* QgsCategorizedSymbolRendererV2::originalSymbolForFeature( QgsFeature& feature, QgsRenderContext &context )
 {
+  Q_UNUSED( context );
   QgsAttributes attrs = feature.attributes();
   QVariant value;
   if ( mAttrNum == -1 )
@@ -516,8 +517,9 @@ void QgsCategorizedSymbolRendererV2::toSld( QDomDocument &doc, QDomElement &elem
   }
 }
 
-QgsSymbolV2List QgsCategorizedSymbolRendererV2::symbols()
+QgsSymbolV2List QgsCategorizedSymbolRendererV2::symbols( QgsRenderContext &context )
 {
+  Q_UNUSED( context );
   QgsSymbolV2List lst;
   for ( int i = 0; i < mCategories.count(); i++ )
     lst.append( mCategories[i].symbol() );
@@ -912,7 +914,8 @@ QgsCategorizedSymbolRendererV2* QgsCategorizedSymbolRendererV2::convertFromRende
   // Could have applied this to specific renderer types (singleSymbol, graduatedSymbo)
 
   QgsCategorizedSymbolRendererV2* r = new QgsCategorizedSymbolRendererV2( "", QgsCategoryList() );
-  QgsSymbolV2List symbols = const_cast<QgsFeatureRendererV2 *>( renderer )->symbols();
+  QgsRenderContext context;
+  QgsSymbolV2List symbols = const_cast<QgsFeatureRendererV2 *>( renderer )->symbols( context );
   if ( symbols.size() > 0 )
   {
     r->setSourceSymbol( symbols.at( 0 )->clone() );

--- a/src/core/symbology-ng/qgscategorizedsymbolrendererv2.h
+++ b/src/core/symbology-ng/qgscategorizedsymbolrendererv2.h
@@ -75,9 +75,9 @@ class CORE_EXPORT QgsCategorizedSymbolRendererV2 : public QgsFeatureRendererV2
 
     virtual ~QgsCategorizedSymbolRendererV2();
 
-    virtual QgsSymbolV2* symbolForFeature( QgsFeature& feature ) override;
+    virtual QgsSymbolV2* symbolForFeature( QgsFeature& feature, QgsRenderContext& context ) override;
 
-    virtual QgsSymbolV2* originalSymbolForFeature( QgsFeature& feature ) override;
+    virtual QgsSymbolV2* originalSymbolForFeature( QgsFeature& feature, QgsRenderContext& context ) override;
 
     virtual void startRender( QgsRenderContext& context, const QgsFields& fields ) override;
 
@@ -94,7 +94,7 @@ class CORE_EXPORT QgsCategorizedSymbolRendererV2 : public QgsFeatureRendererV2
     //! returns bitwise OR-ed capabilities of the renderer
     virtual int capabilities() override { return SymbolLevels | RotationField | Filter; }
 
-    virtual QgsSymbolV2List symbols() override;
+    virtual QgsSymbolV2List symbols( QgsRenderContext& context ) override;
     void updateSymbols( QgsSymbolV2 * sym );
 
     const QgsCategoryList& categories() const { return mCategories; }

--- a/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.cpp
+++ b/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.cpp
@@ -316,9 +316,9 @@ QgsSymbolV2* QgsGraduatedSymbolRendererV2::symbolForValue( double value )
   return NULL;
 }
 
-QgsSymbolV2* QgsGraduatedSymbolRendererV2::symbolForFeature( QgsFeature& feature )
+QgsSymbolV2* QgsGraduatedSymbolRendererV2::symbolForFeature( QgsFeature& feature, QgsRenderContext &context )
 {
-  QgsSymbolV2* symbol = originalSymbolForFeature( feature );
+  QgsSymbolV2* symbol = originalSymbolForFeature( feature, context );
   if ( symbol == NULL )
     return NULL;
 
@@ -348,8 +348,9 @@ QgsSymbolV2* QgsGraduatedSymbolRendererV2::symbolForFeature( QgsFeature& feature
   return tempSymbol;
 }
 
-QgsSymbolV2* QgsGraduatedSymbolRendererV2::originalSymbolForFeature( QgsFeature& feature )
+QgsSymbolV2* QgsGraduatedSymbolRendererV2::originalSymbolForFeature( QgsFeature& feature, QgsRenderContext &context )
 {
+  Q_UNUSED( context );
   QgsAttributes attrs = feature.attributes();
   QVariant value;
   if ( mAttrNum < 0 || mAttrNum >= attrs.count() )
@@ -543,8 +544,9 @@ void QgsGraduatedSymbolRendererV2::toSld( QDomDocument& doc, QDomElement &elemen
   }
 }
 
-QgsSymbolV2List QgsGraduatedSymbolRendererV2::symbols()
+QgsSymbolV2List QgsGraduatedSymbolRendererV2::symbols( QgsRenderContext &context )
 {
+  Q_UNUSED( context );
   QgsSymbolV2List lst;
   for ( int i = 0; i < mRanges.count(); i++ )
     lst.append( mRanges[i].symbol() );
@@ -1662,7 +1664,8 @@ QgsGraduatedSymbolRendererV2* QgsGraduatedSymbolRendererV2::convertFromRenderer(
   // Could have applied this to specific renderer types (singleSymbol, graduatedSymbo)
 
   QgsGraduatedSymbolRendererV2* r = new QgsGraduatedSymbolRendererV2( "", QgsRangeList() );
-  QgsSymbolV2List symbols = const_cast<QgsFeatureRendererV2 *>( renderer )->symbols();
+  QgsRenderContext context;
+  QgsSymbolV2List symbols = const_cast<QgsFeatureRendererV2 *>( renderer )->symbols( context );
   if ( symbols.size() > 0 )
   {
     r->setSourceSymbol( symbols.at( 0 )->clone() );

--- a/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.h
+++ b/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.h
@@ -119,9 +119,9 @@ class CORE_EXPORT QgsGraduatedSymbolRendererV2 : public QgsFeatureRendererV2
 
     virtual ~QgsGraduatedSymbolRendererV2();
 
-    virtual QgsSymbolV2* symbolForFeature( QgsFeature& feature ) override;
+    virtual QgsSymbolV2* symbolForFeature( QgsFeature& feature, QgsRenderContext &context ) override;
 
-    virtual QgsSymbolV2* originalSymbolForFeature( QgsFeature& feature ) override;
+    virtual QgsSymbolV2* originalSymbolForFeature( QgsFeature& feature, QgsRenderContext &context ) override;
 
     virtual void startRender( QgsRenderContext& context, const QgsFields& fields ) override;
 
@@ -138,7 +138,7 @@ class CORE_EXPORT QgsGraduatedSymbolRendererV2 : public QgsFeatureRendererV2
     //! returns bitwise OR-ed capabilities of the renderer
     virtual int capabilities() override { return SymbolLevels | RotationField | Filter; }
 
-    virtual QgsSymbolV2List symbols() override;
+    virtual QgsSymbolV2List symbols( QgsRenderContext &context ) override;
 
     QString classAttribute() const { return mAttrName; }
     void setClassAttribute( QString attr ) { mAttrName = attr; }

--- a/src/core/symbology-ng/qgsheatmaprenderer.cpp
+++ b/src/core/symbology-ng/qgsheatmaprenderer.cpp
@@ -367,13 +367,13 @@ QDomElement QgsHeatmapRenderer::save( QDomDocument& doc )
   return rendererElem;
 }
 
-QgsSymbolV2* QgsHeatmapRenderer::symbolForFeature( QgsFeature& feature )
+QgsSymbolV2* QgsHeatmapRenderer::symbolForFeature( QgsFeature& feature, QgsRenderContext& )
 {
   Q_UNUSED( feature );
   return 0;
 }
 
-QgsSymbolV2List QgsHeatmapRenderer::symbols()
+QgsSymbolV2List QgsHeatmapRenderer::symbols( QgsRenderContext& )
 {
   return QgsSymbolV2List();
 }

--- a/src/core/symbology-ng/qgsheatmaprenderer.h
+++ b/src/core/symbology-ng/qgsheatmaprenderer.h
@@ -42,8 +42,8 @@ class CORE_EXPORT QgsHeatmapRenderer : public QgsFeatureRendererV2
     virtual void startRender( QgsRenderContext& context, const QgsFields& fields ) override;
     virtual bool renderFeature( QgsFeature& feature, QgsRenderContext& context, int layer = -1, bool selected = false, bool drawVertexMarker = false ) override;
     virtual void stopRender( QgsRenderContext& context ) override;
-    virtual QgsSymbolV2* symbolForFeature( QgsFeature& feature ) override;
-    virtual QgsSymbolV2List symbols() override;
+    virtual QgsSymbolV2* symbolForFeature( QgsFeature& feature, QgsRenderContext &context ) override;
+    virtual QgsSymbolV2List symbols( QgsRenderContext &context ) override;
     virtual QString dump() const override;
     virtual QList<QString> usedAttributes() override;
     static QgsFeatureRendererV2* create( QDomElement& element );

--- a/src/core/symbology-ng/qgsinvertedpolygonrenderer.cpp
+++ b/src/core/symbology-ng/qgsinvertedpolygonrenderer.cpp
@@ -153,7 +153,7 @@ bool QgsInvertedPolygonRenderer::renderFeature( QgsFeature& feature, QgsRenderCo
   QByteArray catId;
   if ( capabilities() & MoreSymbolsPerFeature )
   {
-    QgsSymbolV2List syms( mSubRenderer->symbolsForFeature( feature ) );
+    QgsSymbolV2List syms( mSubRenderer->symbolsForFeature( feature, context ) );
     foreach ( QgsSymbolV2* sym, syms )
     {
       // append the memory address
@@ -162,7 +162,7 @@ bool QgsInvertedPolygonRenderer::renderFeature( QgsFeature& feature, QgsRenderCo
   }
   else
   {
-    QgsSymbolV2* sym = mSubRenderer->symbolForFeature( feature );
+    QgsSymbolV2* sym = mSubRenderer->symbolForFeature( feature, context );
     if ( sym )
     {
       catId.append( reinterpret_cast<const char*>( &sym ), sizeof( sym ) );
@@ -376,45 +376,45 @@ QDomElement QgsInvertedPolygonRenderer::save( QDomDocument& doc )
   return rendererElem;
 }
 
-QgsSymbolV2* QgsInvertedPolygonRenderer::symbolForFeature( QgsFeature& feature )
+QgsSymbolV2* QgsInvertedPolygonRenderer::symbolForFeature( QgsFeature& feature, QgsRenderContext& context )
 {
   if ( !mSubRenderer )
   {
     return 0;
   }
-  return mSubRenderer->symbolForFeature( feature );
+  return mSubRenderer->symbolForFeature( feature, context );
 }
 
-QgsSymbolV2* QgsInvertedPolygonRenderer::originalSymbolForFeature( QgsFeature& feat )
+QgsSymbolV2* QgsInvertedPolygonRenderer::originalSymbolForFeature( QgsFeature& feat, QgsRenderContext& context )
 {
   if ( !mSubRenderer )
     return 0;
-  return mSubRenderer->originalSymbolForFeature( feat );
+  return mSubRenderer->originalSymbolForFeature( feat, context );
 }
 
-QgsSymbolV2List QgsInvertedPolygonRenderer::symbolsForFeature( QgsFeature& feature )
+QgsSymbolV2List QgsInvertedPolygonRenderer::symbolsForFeature( QgsFeature& feature, QgsRenderContext& context )
 {
   if ( !mSubRenderer )
   {
     return QgsSymbolV2List();
   }
-  return mSubRenderer->symbolsForFeature( feature );
+  return mSubRenderer->symbolsForFeature( feature, context );
 }
 
-QgsSymbolV2List QgsInvertedPolygonRenderer::originalSymbolsForFeature( QgsFeature& feat )
+QgsSymbolV2List QgsInvertedPolygonRenderer::originalSymbolsForFeature( QgsFeature& feat, QgsRenderContext& context )
 {
   if ( !mSubRenderer )
     return QgsSymbolV2List();
-  return mSubRenderer->originalSymbolsForFeature( feat );
+  return mSubRenderer->originalSymbolsForFeature( feat, context );
 }
 
-QgsSymbolV2List QgsInvertedPolygonRenderer::symbols()
+QgsSymbolV2List QgsInvertedPolygonRenderer::symbols( QgsRenderContext& context )
 {
   if ( !mSubRenderer )
   {
     return QgsSymbolV2List();
   }
-  return mSubRenderer->symbols();
+  return mSubRenderer->symbols( context );
 }
 
 int QgsInvertedPolygonRenderer::capabilities()
@@ -453,13 +453,13 @@ QgsLegendSymbolList QgsInvertedPolygonRenderer::legendSymbolItems( double scaleD
   return mSubRenderer->legendSymbolItems( scaleDenominator, rule );
 }
 
-bool QgsInvertedPolygonRenderer::willRenderFeature( QgsFeature& feat )
+bool QgsInvertedPolygonRenderer::willRenderFeature( QgsFeature& feat, QgsRenderContext& context )
 {
   if ( !mSubRenderer )
   {
     return false;
   }
-  return mSubRenderer->willRenderFeature( feat );
+  return mSubRenderer->willRenderFeature( feat, context );
 }
 
 QgsInvertedPolygonRenderer* QgsInvertedPolygonRenderer::convertFromRenderer( const QgsFeatureRendererV2 *renderer )

--- a/src/core/symbology-ng/qgsinvertedpolygonrenderer.h
+++ b/src/core/symbology-ng/qgsinvertedpolygonrenderer.h
@@ -77,15 +77,15 @@ class CORE_EXPORT QgsInvertedPolygonRenderer : public QgsFeatureRendererV2
     /** Proxy that will call this method on the embedded renderer. */
     virtual int capabilities() override;
     /** Proxy that will call this method on the embedded renderer. */
-    virtual QgsSymbolV2List symbols() override;
+    virtual QgsSymbolV2List symbols( QgsRenderContext& context ) override;
     /** Proxy that will call this method on the embedded renderer. */
-    virtual QgsSymbolV2* symbolForFeature( QgsFeature& feature ) override;
+    virtual QgsSymbolV2* symbolForFeature( QgsFeature& feature, QgsRenderContext& context ) override;
     /** Proxy that will call this method on the embedded renderer. */
-    virtual QgsSymbolV2* originalSymbolForFeature( QgsFeature& feat ) override;
+    virtual QgsSymbolV2* originalSymbolForFeature( QgsFeature& feat, QgsRenderContext& context ) override;
     /** Proxy that will call this method on the embedded renderer. */
-    virtual QgsSymbolV2List symbolsForFeature( QgsFeature& feat ) override;
+    virtual QgsSymbolV2List symbolsForFeature( QgsFeature& feat, QgsRenderContext& context ) override;
     /** Proxy that will call this method on the embedded renderer. */
-    virtual QgsSymbolV2List originalSymbolsForFeature( QgsFeature& feat ) override;
+    virtual QgsSymbolV2List originalSymbolsForFeature( QgsFeature& feat, QgsRenderContext& context ) override;
     /** Proxy that will call this method on the embedded renderer. */
     virtual QgsLegendSymbologyList legendSymbologyItems( QSize iconSize ) override;
     /** Proxy that will call this method on the embedded renderer.
@@ -93,7 +93,7 @@ class CORE_EXPORT QgsInvertedPolygonRenderer : public QgsFeatureRendererV2
      */
     virtual QgsLegendSymbolList legendSymbolItems( double scaleDenominator = -1, QString rule = "" ) override;
     /** Proxy that will call this method on the embedded renderer. */
-    virtual bool willRenderFeature( QgsFeature& feat ) override;
+    virtual bool willRenderFeature( QgsFeature& feat, QgsRenderContext& context ) override;
 
     /** Creates a renderer out of an XML, for loading*/
     static QgsFeatureRendererV2* create( QDomElement& element );

--- a/src/core/symbology-ng/qgspointdisplacementrenderer.cpp
+++ b/src/core/symbology-ng/qgspointdisplacementrenderer.cpp
@@ -88,7 +88,7 @@ bool QgsPointDisplacementRenderer::renderFeature( QgsFeature& feature, QgsRender
   if ( !feature.constGeometry() )
     return false;
 
-  QgsSymbolV2* symbol = firstSymbolForFeature( mRenderer, feature );
+  QgsSymbolV2* symbol = firstSymbolForFeature( mRenderer, feature, context );
 
   //if the feature has no symbol (eg, no matching rule in a rule-based renderer), skip it
   if ( !symbol )
@@ -228,54 +228,54 @@ int QgsPointDisplacementRenderer::capabilities()
   return mRenderer->capabilities();
 }
 
-QgsSymbolV2List QgsPointDisplacementRenderer::symbols()
+QgsSymbolV2List QgsPointDisplacementRenderer::symbols( QgsRenderContext& context )
 {
   if ( !mRenderer )
   {
     return QgsSymbolV2List();
   }
-  return mRenderer->symbols();
+  return mRenderer->symbols( context );
 }
 
-QgsSymbolV2* QgsPointDisplacementRenderer::symbolForFeature( QgsFeature& feature )
+QgsSymbolV2* QgsPointDisplacementRenderer::symbolForFeature( QgsFeature& feature, QgsRenderContext& context )
 {
   if ( !mRenderer )
   {
     return 0;
   }
-  return mRenderer->symbolForFeature( feature );
+  return mRenderer->symbolForFeature( feature, context );
 }
 
-QgsSymbolV2* QgsPointDisplacementRenderer::originalSymbolForFeature( QgsFeature& feat )
+QgsSymbolV2* QgsPointDisplacementRenderer::originalSymbolForFeature( QgsFeature& feat, QgsRenderContext& context )
 {
   if ( !mRenderer )
     return 0;
-  return mRenderer->originalSymbolForFeature( feat );
+  return mRenderer->originalSymbolForFeature( feat, context );
 }
 
-QgsSymbolV2List QgsPointDisplacementRenderer::symbolsForFeature( QgsFeature& feature )
+QgsSymbolV2List QgsPointDisplacementRenderer::symbolsForFeature( QgsFeature& feature, QgsRenderContext& context )
 {
   if ( !mRenderer )
   {
     return QgsSymbolV2List();
   }
-  return mRenderer->symbolsForFeature( feature );
+  return mRenderer->symbolsForFeature( feature, context );
 }
 
-QgsSymbolV2List QgsPointDisplacementRenderer::originalSymbolsForFeature( QgsFeature& feat )
+QgsSymbolV2List QgsPointDisplacementRenderer::originalSymbolsForFeature( QgsFeature& feat, QgsRenderContext& context )
 {
   if ( !mRenderer )
     return QgsSymbolV2List();
-  return mRenderer->originalSymbolsForFeature( feat );
+  return mRenderer->originalSymbolsForFeature( feat, context );
 }
 
-bool QgsPointDisplacementRenderer::willRenderFeature( QgsFeature& feat )
+bool QgsPointDisplacementRenderer::willRenderFeature( QgsFeature& feat, QgsRenderContext& context )
 {
   if ( !mRenderer )
   {
     return false;
   }
-  return mRenderer->willRenderFeature( feat );
+  return mRenderer->willRenderFeature( feat, context );
 }
 
 
@@ -562,14 +562,14 @@ void QgsPointDisplacementRenderer::drawLabels( const QPointF& centerPoint, QgsSy
   }
 }
 
-QgsSymbolV2* QgsPointDisplacementRenderer::firstSymbolForFeature( QgsFeatureRendererV2* r, QgsFeature& f )
+QgsSymbolV2* QgsPointDisplacementRenderer::firstSymbolForFeature( QgsFeatureRendererV2* r, QgsFeature& f, QgsRenderContext &context )
 {
   if ( !r )
   {
     return 0;
   }
 
-  QgsSymbolV2List symbolList = r->symbolsForFeature( f );
+  QgsSymbolV2List symbolList = r->symbolsForFeature( f, context );
   if ( symbolList.size() < 1 )
   {
     return 0;

--- a/src/core/symbology-ng/qgspointdisplacementrenderer.h
+++ b/src/core/symbology-ng/qgspointdisplacementrenderer.h
@@ -46,17 +46,17 @@ class CORE_EXPORT QgsPointDisplacementRenderer: public QgsFeatureRendererV2
     /** Proxy that will call this method on the embedded renderer. */
     virtual int capabilities() override;
     /** Proxy that will call this method on the embedded renderer. */
-    virtual QgsSymbolV2List symbols() override;
+    virtual QgsSymbolV2List symbols( QgsRenderContext& context ) override;
     /** Proxy that will call this method on the embedded renderer. */
-    virtual QgsSymbolV2* symbolForFeature( QgsFeature& feature ) override;
+    virtual QgsSymbolV2* symbolForFeature( QgsFeature& feature, QgsRenderContext& context ) override;
     /** Proxy that will call this method on the embedded renderer. */
-    virtual QgsSymbolV2* originalSymbolForFeature( QgsFeature& feat ) override;
+    virtual QgsSymbolV2* originalSymbolForFeature( QgsFeature& feat, QgsRenderContext& context ) override;
     /** Proxy that will call this method on the embedded renderer. */
-    virtual QgsSymbolV2List symbolsForFeature( QgsFeature& feat ) override;
+    virtual QgsSymbolV2List symbolsForFeature( QgsFeature& feat, QgsRenderContext& context ) override;
     /** Proxy that will call this method on the embedded renderer. */
-    virtual QgsSymbolV2List originalSymbolsForFeature( QgsFeature& feat ) override;
+    virtual QgsSymbolV2List originalSymbolsForFeature( QgsFeature& feat, QgsRenderContext& context ) override;
     /** Proxy that will call this method on the embedded renderer. */
-    virtual bool willRenderFeature( QgsFeature& feat ) override;
+    virtual bool willRenderFeature( QgsFeature& feat, QgsRenderContext& context ) override;
 
     virtual void startRender( QgsRenderContext& context, const QgsFields& fields ) override;
 
@@ -172,7 +172,7 @@ class CORE_EXPORT QgsPointDisplacementRenderer: public QgsFeatureRendererV2
     void drawSymbols( const QgsFeature& f, QgsRenderContext& context, const QList<QgsMarkerSymbolV2*>& symbolList, const QList<QPointF>& symbolPositions, bool selected = false );
     void drawLabels( const QPointF& centerPoint, QgsSymbolV2RenderContext& context, const QList<QPointF>& labelShifts, const QStringList& labelList );
     /** Returns first symbol for feature or 0 if none*/
-    QgsSymbolV2* firstSymbolForFeature( QgsFeatureRendererV2* r, QgsFeature& f );
+    QgsSymbolV2* firstSymbolForFeature( QgsFeatureRendererV2* r, QgsFeature& f, QgsRenderContext& context );
 };
 
 #endif // QGSPOINTDISPLACEMENTRENDERER_H

--- a/src/core/symbology-ng/qgsrendererv2.cpp
+++ b/src/core/symbology-ng/qgsrendererv2.cpp
@@ -231,6 +231,33 @@ QgsFeatureRendererV2* QgsFeatureRendererV2::defaultRenderer( QGis::GeometryType 
   return new QgsSingleSymbolRendererV2( QgsSymbolV2::defaultSymbol( geomType ) );
 }
 
+QgsSymbolV2* QgsFeatureRendererV2::symbolForFeature( QgsFeature& feature )
+{
+  QgsRenderContext context;
+  return symbolForFeature( feature, context );
+}
+
+QgsSymbolV2* QgsFeatureRendererV2::symbolForFeature( QgsFeature &feature, QgsRenderContext &context )
+{
+  Q_UNUSED( context );
+  // base method calls deprecated symbolForFeature to maintain API
+  Q_NOWARN_DEPRECATED_PUSH
+  return symbolForFeature( feature );
+  Q_NOWARN_DEPRECATED_POP
+}
+
+QgsSymbolV2 *QgsFeatureRendererV2::originalSymbolForFeature( QgsFeature &feature )
+{
+  Q_NOWARN_DEPRECATED_PUSH
+  return symbolForFeature( feature );
+  Q_NOWARN_DEPRECATED_POP
+}
+
+QgsSymbolV2 *QgsFeatureRendererV2::originalSymbolForFeature( QgsFeature &feature, QgsRenderContext &context )
+{
+  return symbolForFeature( feature, context );
+}
+
 void QgsFeatureRendererV2::startRender( QgsRenderContext& context, const QgsVectorLayer* vlayer )
 {
   startRender( context, vlayer->fields() );
@@ -238,7 +265,7 @@ void QgsFeatureRendererV2::startRender( QgsRenderContext& context, const QgsVect
 
 bool QgsFeatureRendererV2::renderFeature( QgsFeature& feature, QgsRenderContext& context, int layer, bool selected, bool drawVertexMarker )
 {
-  QgsSymbolV2* symbol = symbolForFeature( feature );
+  QgsSymbolV2* symbol = symbolForFeature( feature, context );
   if ( symbol == NULL )
     return false;
 
@@ -411,6 +438,22 @@ void QgsFeatureRendererV2::renderFeatureWithSymbol( QgsFeature& feature, QgsSymb
 QString QgsFeatureRendererV2::dump() const
 {
   return "UNKNOWN RENDERER\n";
+}
+
+QgsSymbolV2List QgsFeatureRendererV2::symbols()
+{
+  QgsRenderContext context;
+  return symbols( context );
+}
+
+QgsSymbolV2List QgsFeatureRendererV2::symbols( QgsRenderContext &context )
+{
+  Q_UNUSED( context );
+
+  //base implementation calls deprecated method to maintain API
+  Q_NOWARN_DEPRECATED_PUSH
+  return symbols();
+  Q_NOWARN_DEPRECATED_POP
 }
 
 
@@ -614,6 +657,18 @@ void QgsFeatureRendererV2::setVertexMarkerAppearance( int type, int size )
   mCurrentVertexMarkerSize = size;
 }
 
+bool QgsFeatureRendererV2::willRenderFeature( QgsFeature &feat )
+{
+  Q_NOWARN_DEPRECATED_PUSH
+  return symbolForFeature( feat ) != NULL;
+  Q_NOWARN_DEPRECATED_POP
+}
+
+bool QgsFeatureRendererV2::willRenderFeature( QgsFeature &feat, QgsRenderContext &context )
+{
+  return symbolForFeature( feat, context ) != NULL;
+}
+
 void QgsFeatureRendererV2::renderVertexMarker( QPointF& pt, QgsRenderContext& context )
 {
   QgsVectorLayer::drawVertexMarker( pt.x(), pt.y(), *context.painter(),
@@ -645,7 +700,17 @@ void QgsFeatureRendererV2::renderVertexMarkerPolygon( QPolygonF& pts, QList<QPol
 QgsSymbolV2List QgsFeatureRendererV2::symbolsForFeature( QgsFeature& feat )
 {
   QgsSymbolV2List lst;
+  Q_NOWARN_DEPRECATED_PUSH
   QgsSymbolV2* s = symbolForFeature( feat );
+  Q_NOWARN_DEPRECATED_POP
+  if ( s ) lst.append( s );
+  return lst;
+}
+
+QgsSymbolV2List QgsFeatureRendererV2::symbolsForFeature( QgsFeature &feat, QgsRenderContext &context )
+{
+  QgsSymbolV2List lst;
+  QgsSymbolV2* s = symbolForFeature( feat, context );
   if ( s ) lst.append( s );
   return lst;
 }
@@ -653,7 +718,17 @@ QgsSymbolV2List QgsFeatureRendererV2::symbolsForFeature( QgsFeature& feat )
 QgsSymbolV2List QgsFeatureRendererV2::originalSymbolsForFeature( QgsFeature& feat )
 {
   QgsSymbolV2List lst;
+  Q_NOWARN_DEPRECATED_PUSH
   QgsSymbolV2* s = originalSymbolForFeature( feat );
+  Q_NOWARN_DEPRECATED_POP
+  if ( s ) lst.append( s );
+  return lst;
+}
+
+QgsSymbolV2List QgsFeatureRendererV2::originalSymbolsForFeature( QgsFeature &feat, QgsRenderContext &context )
+{
+  QgsSymbolV2List lst;
+  QgsSymbolV2* s = originalSymbolForFeature( feat, context );
   if ( s ) lst.append( s );
   return lst;
 }

--- a/src/core/symbology-ng/qgsrendererv2.h
+++ b/src/core/symbology-ng/qgsrendererv2.h
@@ -85,7 +85,16 @@ class CORE_EXPORT QgsFeatureRendererV2
      * @param feature feature
      * @return returns pointer to symbol or 0 if symbol was not found
      */
-    virtual QgsSymbolV2* symbolForFeature( QgsFeature& feature ) = 0;
+    Q_DECL_DEPRECATED virtual QgsSymbolV2* symbolForFeature( QgsFeature& feature );
+
+    /** To be overridden
+     * @param feature feature
+     * @param context render context
+     * @return returns pointer to symbol or 0 if symbol was not found
+     * @note added in QGIS 2.12
+     */
+    //TODO - make pure virtual when above method is removed
+    virtual QgsSymbolV2* symbolForFeature( QgsFeature& feature, QgsRenderContext& context );
 
     /**
      * Return symbol for feature. The difference compared to symbolForFeature() is that it returns original
@@ -93,7 +102,15 @@ class CORE_EXPORT QgsFeatureRendererV2
      * of a symbol for use in rendering.
      * @note added in 2.6
      */
-    virtual QgsSymbolV2* originalSymbolForFeature( QgsFeature& feature ) { return symbolForFeature( feature ); }
+    Q_DECL_DEPRECATED virtual QgsSymbolV2* originalSymbolForFeature( QgsFeature& feature );
+
+    /**
+     * Return symbol for feature. The difference compared to symbolForFeature() is that it returns original
+     * symbol which can be used as an identifier for renderer's rule - the former may return a temporary replacement
+     * of a symbol for use in rendering.
+     * @note added in 2.12
+     */
+    virtual QgsSymbolV2* originalSymbolForFeature( QgsFeature& feature, QgsRenderContext& context );
 
     /**
      * Needs to be called when a new render cycle is started
@@ -146,7 +163,13 @@ class CORE_EXPORT QgsFeatureRendererV2
     virtual int capabilities() { return 0; }
 
     //! for symbol levels
-    virtual QgsSymbolV2List symbols() = 0;
+    Q_DECL_DEPRECATED virtual QgsSymbolV2List symbols();
+
+    /** Returns list of symbols used by the renderer.
+     * @param context render context
+     * @note added in QGIS 2.12
+     */
+    virtual QgsSymbolV2List symbols( QgsRenderContext& context );
 
     bool usingSymbolLevels() const { return mUsingSymbolLevels; }
     void setUsingSymbolLevels( bool usingSymbolLevels ) { mUsingSymbolLevels = usingSymbolLevels; }
@@ -221,17 +244,34 @@ class CORE_EXPORT QgsFeatureRendererV2
     //! return whether the renderer will render a feature or not.
     //! Must be called between startRender() and stopRender() calls.
     //! Default implementation uses symbolForFeature().
-    virtual bool willRenderFeature( QgsFeature& feat ) { return symbolForFeature( feat ) != NULL; }
+    Q_DECL_DEPRECATED virtual bool willRenderFeature( QgsFeature& feat );
+
+    /** Returns whether the renderer will render a feature or not.
+     * Must be called between startRender() and stopRender() calls.
+     * Default implementation uses symbolForFeature().
+     * @note added in QGIS 2.12
+     */
+    virtual bool willRenderFeature( QgsFeature& feat, QgsRenderContext& context );
 
     //! return list of symbols used for rendering the feature.
     //! For renderers that do not support MoreSymbolsPerFeature it is more efficient
     //! to use symbolForFeature()
-    virtual QgsSymbolV2List symbolsForFeature( QgsFeature& feat );
+    Q_DECL_DEPRECATED virtual QgsSymbolV2List symbolsForFeature( QgsFeature& feat );
+
+    //! return list of symbols used for rendering the feature.
+    //! For renderers that do not support MoreSymbolsPerFeature it is more efficient
+    //! to use symbolForFeature()
+    virtual QgsSymbolV2List symbolsForFeature( QgsFeature& feat, QgsRenderContext& context );
 
     //! Equivalent of originalSymbolsForFeature() call
     //! extended to support renderers that may use more symbols per feature - similar to symbolsForFeature()
     //! @note added in 2.6
-    virtual QgsSymbolV2List originalSymbolsForFeature( QgsFeature& feat );
+    Q_DECL_DEPRECATED virtual QgsSymbolV2List originalSymbolsForFeature( QgsFeature& feat );
+
+    //! Equivalent of originalSymbolsForFeature() call
+    //! extended to support renderers that may use more symbols per feature - similar to symbolsForFeature()
+    //! @note added in 2.6
+    virtual QgsSymbolV2List originalSymbolsForFeature( QgsFeature& feat, QgsRenderContext& context );
 
     /** Allows for a renderer to modify the extent of a feature request prior to rendering
      * @param extent reference to request's filter extent. Modify extent to change the

--- a/src/core/symbology-ng/qgsrulebasedrendererv2.h
+++ b/src/core/symbology-ng/qgsrulebasedrendererv2.h
@@ -90,12 +90,12 @@ class CORE_EXPORT QgsRuleBasedRendererV2 : public QgsFeatureRendererV2
         ~Rule();
         QString dump( int offset = 0 ) const;
         QSet<QString> usedAttributes();
-        QgsSymbolV2List symbols();
+        QgsSymbolV2List symbols( const QgsRenderContext& context = QgsRenderContext() );
         //! @note not available in python bindings
         QgsLegendSymbolList legendSymbolItems( double scaleDenominator = -1, QString rule = "" );
         //! @note added in 2.6
         QgsLegendSymbolListV2 legendSymbolItemsV2( int currentLevel = -1 ) const;
-        bool isFilterOK( QgsFeature& f ) const;
+        bool isFilterOK( QgsFeature& f, QgsRenderContext *context = 0 ) const;
         bool isScaleOK( double scale ) const;
 
         QgsSymbolV2* symbol() { return mSymbol; }
@@ -147,13 +147,13 @@ class CORE_EXPORT QgsRuleBasedRendererV2 : public QgsFeatureRendererV2
         bool renderFeature( FeatureToRender& featToRender, QgsRenderContext& context, RenderQueue& renderQueue );
 
         //! only tell whether a feature will be rendered without actually rendering it
-        bool willRenderFeature( QgsFeature& feat );
+        bool willRenderFeature( QgsFeature& feat, QgsRenderContext* context = 0 );
 
         //! tell which symbols will be used to render the feature
-        QgsSymbolV2List symbolsForFeature( QgsFeature& feat );
+        QgsSymbolV2List symbolsForFeature( QgsFeature& feat, QgsRenderContext* context = 0 );
 
         //! tell which rules will be used to render the feature
-        RuleList rulesForFeature( QgsFeature& feat );
+        RuleList rulesForFeature( QgsFeature& feat, QgsRenderContext* context = 0 );
 
         void stopRender( QgsRenderContext& context );
 
@@ -218,7 +218,7 @@ class CORE_EXPORT QgsRuleBasedRendererV2 : public QgsFeatureRendererV2
     ~QgsRuleBasedRendererV2();
 
     //! return symbol for current feature. Should not be used individually: there could be more symbols for a feature
-    virtual QgsSymbolV2* symbolForFeature( QgsFeature& feature ) override;
+    virtual QgsSymbolV2* symbolForFeature( QgsFeature& feature, QgsRenderContext& context ) override;
 
     virtual bool renderFeature( QgsFeature& feature, QgsRenderContext& context, int layer = -1, bool selected = false, bool drawVertexMarker = false ) override;
 
@@ -236,7 +236,7 @@ class CORE_EXPORT QgsRuleBasedRendererV2 : public QgsFeatureRendererV2
 
     static QgsFeatureRendererV2* createFromSld( QDomElement& element, QGis::GeometryType geomType );
 
-    virtual QgsSymbolV2List symbols() override;
+    virtual QgsSymbolV2List symbols( QgsRenderContext& context ) override;
 
     //! store renderer info to XML element
     virtual QDomElement save( QDomDocument& doc ) override;
@@ -270,14 +270,14 @@ class CORE_EXPORT QgsRuleBasedRendererV2 : public QgsFeatureRendererV2
 
     //! return whether the renderer will render a feature or not.
     //! Must be called between startRender() and stopRender() calls.
-    virtual bool willRenderFeature( QgsFeature& feat ) override;
+    virtual bool willRenderFeature( QgsFeature& feat, QgsRenderContext& context ) override;
 
     //! return list of symbols used for rendering the feature.
     //! For renderers that do not support MoreSymbolsPerFeature it is more efficient
     //! to use symbolForFeature()
-    virtual QgsSymbolV2List symbolsForFeature( QgsFeature& feat ) override;
+    virtual QgsSymbolV2List symbolsForFeature( QgsFeature& feat, QgsRenderContext& context ) override;
 
-    virtual QgsSymbolV2List originalSymbolsForFeature( QgsFeature& feat ) override;
+    virtual QgsSymbolV2List originalSymbolsForFeature( QgsFeature& feat, QgsRenderContext& context ) override;
 
     //! returns bitwise OR-ed capabilities of the renderer
     virtual int capabilities() override { return MoreSymbolsPerFeature | Filter | ScaleDependent; }

--- a/src/core/symbology-ng/qgssinglesymbolrendererv2.cpp
+++ b/src/core/symbology-ng/qgssinglesymbolrendererv2.cpp
@@ -45,8 +45,9 @@ QgsSingleSymbolRendererV2::~QgsSingleSymbolRendererV2()
 {
 }
 
-QgsSymbolV2* QgsSingleSymbolRendererV2::symbolForFeature( QgsFeature& feature )
+QgsSymbolV2* QgsSingleSymbolRendererV2::symbolForFeature( QgsFeature& feature, QgsRenderContext &context )
 {
+  Q_UNUSED( context );
   if ( !mRotation.data() && !mSizeScale.data() ) return mSymbol.data();
 
   const double rotation = mRotation.data() ? mRotation->evaluate( feature ).toDouble() : 0;
@@ -73,8 +74,9 @@ QgsSymbolV2* QgsSingleSymbolRendererV2::symbolForFeature( QgsFeature& feature )
   return mTempSymbol.data();
 }
 
-QgsSymbolV2* QgsSingleSymbolRendererV2::originalSymbolForFeature( QgsFeature& feature )
+QgsSymbolV2* QgsSingleSymbolRendererV2::originalSymbolForFeature( QgsFeature& feature, QgsRenderContext &context )
 {
+  Q_UNUSED( context );
   Q_UNUSED( feature );
   return mSymbol.data();
 }
@@ -221,8 +223,9 @@ void QgsSingleSymbolRendererV2::toSld( QDomDocument& doc, QDomElement &element )
   if ( mSymbol.data() ) mSymbol->toSld( doc, ruleElem, props );
 }
 
-QgsSymbolV2List QgsSingleSymbolRendererV2::symbols()
+QgsSymbolV2List QgsSingleSymbolRendererV2::symbols( QgsRenderContext &context )
 {
+  Q_UNUSED( context );
   QgsSymbolV2List lst;
   lst.append( mSymbol.data() );
   return lst;
@@ -450,7 +453,8 @@ QgsSingleSymbolRendererV2* QgsSingleSymbolRendererV2::convertFromRenderer( const
       return convertFromRenderer( invertedPolygonRenderer->embeddedRenderer() );
   }
 
-  QgsSymbolV2List symbols = const_cast<QgsFeatureRendererV2 *>( renderer )->symbols();
+  QgsRenderContext context;
+  QgsSymbolV2List symbols = const_cast<QgsFeatureRendererV2 *>( renderer )->symbols( context );
   if ( symbols.size() > 0 )
   {
     return new QgsSingleSymbolRendererV2( symbols.at( 0 )->clone() );

--- a/src/core/symbology-ng/qgssinglesymbolrendererv2.h
+++ b/src/core/symbology-ng/qgssinglesymbolrendererv2.h
@@ -29,9 +29,9 @@ class CORE_EXPORT QgsSingleSymbolRendererV2 : public QgsFeatureRendererV2
 
     virtual ~QgsSingleSymbolRendererV2();
 
-    virtual QgsSymbolV2* symbolForFeature( QgsFeature& feature ) override;
+    virtual QgsSymbolV2* symbolForFeature( QgsFeature& feature, QgsRenderContext& context ) override;
 
-    virtual QgsSymbolV2* originalSymbolForFeature( QgsFeature& feature ) override;
+    virtual QgsSymbolV2* originalSymbolForFeature( QgsFeature& feature, QgsRenderContext& context ) override;
 
     virtual void startRender( QgsRenderContext& context, const QgsFields& fields ) override;
 
@@ -61,7 +61,7 @@ class CORE_EXPORT QgsSingleSymbolRendererV2 : public QgsFeatureRendererV2
     //! returns bitwise OR-ed capabilities of the renderer
     virtual int capabilities() override { return SymbolLevels | RotationField; }
 
-    virtual QgsSymbolV2List symbols() override;
+    virtual QgsSymbolV2List symbols( QgsRenderContext& context ) override;
 
     //! create renderer from XML element
     static QgsFeatureRendererV2* create( QDomElement& element );

--- a/src/gui/attributetable/qgsattributetablefiltermodel.cpp
+++ b/src/gui/attributetable/qgsattributetablefiltermodel.cpp
@@ -280,7 +280,7 @@ void QgsAttributeTableFilterModel::generateListOfVisibleFeatures()
 
   while ( features.nextFeature( f ) )
   {
-    if ( !filter || renderer->willRenderFeature( f ) )
+    if ( !filter || renderer->willRenderFeature( f, renderContext ) )
     {
       mFilteredFeatures << f.id();
     }

--- a/src/gui/qgshighlight.cpp
+++ b/src/gui/qgshighlight.cpp
@@ -125,7 +125,7 @@ void QgsHighlight::setFillColor( const QColor & fillColor )
   mBrush.setStyle( Qt::SolidPattern );
 }
 
-QgsFeatureRendererV2 * QgsHighlight::getRenderer( const QgsRenderContext & context, const QColor & color, const QColor & fillColor )
+QgsFeatureRendererV2 * QgsHighlight::getRenderer( QgsRenderContext & context, const QColor & color, const QColor & fillColor )
 {
   QgsFeatureRendererV2 *renderer = 0;
   QgsVectorLayer *layer = qobject_cast<QgsVectorLayer*>( mLayer );
@@ -135,7 +135,7 @@ QgsFeatureRendererV2 * QgsHighlight::getRenderer( const QgsRenderContext & conte
   }
   if ( renderer )
   {
-    foreach ( QgsSymbolV2* symbol, renderer->symbols() )
+    foreach ( QgsSymbolV2* symbol, renderer->symbols( context ) )
     {
       if ( !symbol ) continue;
       setSymbol( symbol, context, color, fillColor );

--- a/src/gui/qgshighlight.h
+++ b/src/gui/qgshighlight.h
@@ -81,7 +81,7 @@ class GUI_EXPORT QgsHighlight: public QgsMapCanvasItem
     void setSymbol( QgsSymbolV2* symbol, const QgsRenderContext & context, const QColor & color, const QColor & fillColor );
     double getSymbolWidth( const QgsRenderContext & context, double width, QgsSymbolV2::OutputUnit unit );
     /** Get renderer for current color mode and colors. The renderer should be freed by caller. */
-    QgsFeatureRendererV2 * getRenderer( const QgsRenderContext & context, const QColor & color, const QColor & fillColor );
+    QgsFeatureRendererV2 * getRenderer( QgsRenderContext &context, const QColor & color, const QColor & fillColor );
     void paintPoint( QPainter *p, QgsPoint point );
     void paintLine( QPainter *p, QgsPolyline line );
     void paintPolygon( QPainter *p, QgsPolygon polygon );

--- a/src/gui/qgsmaptoolidentify.cpp
+++ b/src/gui/qgsmaptoolidentify.cpp
@@ -258,7 +258,7 @@ bool QgsMapToolIdentify::identifyVectorLayer( QList<IdentifyResult> *results, Qg
 
     QgsFeatureId fid = f_it->id();
 
-    if ( filter && !renderer->willRenderFeature( *f_it ) )
+    if ( filter && !renderer->willRenderFeature( *f_it, context ) )
       continue;
 
     featureCount++;

--- a/src/gui/symbology-ng/qgsrulebasedrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgsrulebasedrendererv2widget.cpp
@@ -514,7 +514,7 @@ void QgsRuleBasedRendererV2Widget::countFeatures()
   QgsFeature f;
   while ( fit.nextFeature( f ) )
   {
-    QgsRuleBasedRendererV2::RuleList featureRuleList = mRenderer->rootRule()->rulesForFeature( f );
+    QgsRuleBasedRendererV2::RuleList featureRuleList = mRenderer->rootRule()->rulesForFeature( f, &renderContext );
 
     foreach ( QgsRuleBasedRendererV2::Rule* rule, featureRuleList )
     {

--- a/src/server/qgswmsserver.cpp
+++ b/src/server/qgswmsserver.cpp
@@ -951,11 +951,11 @@ void QgsWMSServer::runHitTestLayer( QgsVectorLayer* vl, SymbolV2Set& usedSymbols
   {
     if ( moreSymbolsPerFeature )
     {
-      foreach ( QgsSymbolV2* s, r->originalSymbolsForFeature( f ) )
+      foreach ( QgsSymbolV2* s, r->originalSymbolsForFeature( f, context ) )
         usedSymbols.insert( s );
     }
     else
-      usedSymbols.insert( r->originalSymbolForFeature( f ) );
+      usedSymbols.insert( r->originalSymbolForFeature( f, context ) );
   }
   r->stopRender( context );
 }
@@ -2075,7 +2075,7 @@ int QgsWMSServer::featureInfoFromVectorLayer( QgsVectorLayer* layer,
 
     //check if feature is rendered at all
     r2->startRender( renderContext, layer->pendingFields() );
-    bool renderV2 = r2->willRenderFeature( feature );
+    bool renderV2 = r2->willRenderFeature( feature, renderContext );
     r2->stopRender( renderContext );
     if ( !renderV2 )
     {
@@ -2682,7 +2682,8 @@ void QgsWMSServer::applyOpacities( const QStringList& layerList, QList< QPair< Q
       //backup old renderer
       vectorRenderers.push_back( qMakePair( vl, rendererV2->clone() ) );
       //modify symbols of current renderer
-      QgsSymbolV2List symbolList = rendererV2->symbols();
+      QgsRenderContext context;
+      QgsSymbolV2List symbolList = rendererV2->symbols( context );
       QgsSymbolV2List::iterator symbolIt = symbolList.begin();
       for ( ; symbolIt != symbolList.end(); ++symbolIt )
       {

--- a/tests/src/core/testqgsrulebasedrenderer.cpp
+++ b/tests/src/core/testqgsrulebasedrenderer.cpp
@@ -87,16 +87,16 @@ class TestQgsRuleBasedRenderer: public QObject
       r.startRender( ctx, layer->fields() );
 
       // test willRenderFeature
-      QVERIFY( r.willRenderFeature( f1 ) );
-      QVERIFY( r.willRenderFeature( f2 ) );
-      QVERIFY( !r.willRenderFeature( f3 ) );
+      QVERIFY( r.willRenderFeature( f1, ctx ) );
+      QVERIFY( r.willRenderFeature( f2, ctx ) );
+      QVERIFY( !r.willRenderFeature( f3, ctx ) );
 
       // test symbolsForFeature
-      QgsSymbolV2List lst1 = r.symbolsForFeature( f1 );
+      QgsSymbolV2List lst1 = r.symbolsForFeature( f1, ctx );
       QVERIFY( lst1.count() == 1 );
-      QgsSymbolV2List lst2 = r.symbolsForFeature( f2 );
+      QgsSymbolV2List lst2 = r.symbolsForFeature( f2, ctx );
       QVERIFY( lst2.count() == 2 );
-      QgsSymbolV2List lst3 = r.symbolsForFeature( f3 );
+      QgsSymbolV2List lst3 = r.symbolsForFeature( f3, ctx );
       QVERIFY( lst3.count() == 0 );
 
       r.stopRender( ctx );

--- a/tests/src/python/test_qgsgraduatedsymbolrendererv2.py
+++ b/tests/src/python/test_qgsgraduatedsymbolrendererv2.py
@@ -29,6 +29,7 @@ from qgis.core import (QgsGraduatedSymbolRendererV2,
                        QgsPoint,
                        QgsSymbolV2,
                        QgsSymbolLayerV2Utils,
+                       QgsRenderContext
                        )
 from PyQt4.QtCore import Qt
 from PyQt4.QtXml import QDomDocument
@@ -344,7 +345,8 @@ class TestQgsGraduatedSymbolRendererV2(TestCase):
         self.assertEqual(renderer.maxSymbolSize(), 13)
         self.assertEqual(renderer.minSymbolSize(), 2)
         refSizes = [2, (13+2)*.5, 13]
-        for idx, symbol in enumerate(renderer.symbols()):
+        ctx = QgsRenderContext()
+        for idx, symbol in enumerate(renderer.symbols(ctx)):
             self.assertEqual(symbol.size(), refSizes[idx])
 
 


### PR DESCRIPTION
This is a prerequisite for expression contexts - basically it makes it more of the renderer methods (eg symbolForFeature, originalSymbolForFeature, etc) able to access the QgsRenderContext of the renderer.
