### PR TITLE
fix crash when using opengl in plugin

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -374,6 +374,7 @@ void myMessageOutput( QtMsgType type, const char *msg )
 
 APP_EXPORT int main( int argc, char *argv[] )
 {
+  QCoreApplication::setAttribute( Qt::AA_X11InitThreads );
 #ifdef Q_OS_MACX
   // Increase file resource limits (i.e., number of allowed open files)
   // (from code provided by Larry Biehl, Purdue University, USA, from 'MultiSpec' project)


### PR DESCRIPTION
@wonder-sk 

X server is not thread safe and using opengl contexts in several threads\* makes qgis crash. It works with mesa though, but I wonder if offscreen rendering really accesses the X server, nvidia libs do.

*in a plugin: one for a PluginLayer, another for a widget, and yet another for 3D
