### PR TITLE
update MetaSearch plugin metadata

### DIFF
--- a/python/plugins/MetaSearch/metadata.txt
+++ b/python/plugins/MetaSearch/metadata.txt
@@ -8,8 +8,8 @@ icon=images/MetaSearch.png
 author=Tom Kralidis
 email=tomkralidis@gmail.com
 tags=web,catalogue,service,metadata,csw
-homepage=https://hub.qgis.org/projects/MetaSearch
-tracker=https://hub.qgis.org/projects/MetaSearch/issues
+homepage=https://hub.qgis.org/wiki/quantum-gis/MetaSearch
+tracker=https://hub.qgis.org/projects/quantum-gis/issues?category_id=107&set_filter=1&status_id=o
 repository=https://github.com/qgis/QGIS/tree/master/python/plugins/MetaSearch
 experimental=False
 deprecated=False


### PR DESCRIPTION
### Overview

Given MetaSearch is a core QGIS plugin, we (thanks @gioman) moved the MetaSearch subproject wiki and issues on https://hub.qgis.org into the main QGIS Application workspace.

This PR updates the links in the plugin metadata to navigate users accordingly.
