### PR TITLE
Disable GRASS plugin (on sid), doesn't support GRASS 7.

### DIFF
--- a/debian/control.in
+++ b/debian/control.in
@@ -9,7 +9,7 @@ Build-Depends:
 #sid jessie wheezy saucy sid-oracle trusty utopic vivid# debhelper (>= 9),
 #precise# debhelper (>= 7),
  flex,
- grass-dev (<< 7),
+#!sid# grass-dev,
  libexpat1-dev,
  libfcgi-dev,
 #sid jessie sid-oracle trusty utopic vivid# libgdal-dev (>= 1.10.1-0~),
@@ -69,7 +69,7 @@ Depends:
  qgis-providers (= ${binary:Version}),
  qgis-common (= ${source:Version})
 Recommends:
- qgis-plugin-grass,
+#!sid# qgis-plugin-grass,
  qgis-plugin-globe,
  python-qgis
 Suggests: gpsbabel
@@ -145,18 +145,18 @@ Description: QGIS - shared network analysis library
  .
  This package contains the shared network analysis library.
 
-Package: libqgisgrass{QGIS_ABI}
-Architecture: any
-Section: libs
-Depends:
- ${shlibs:Depends},
- ${misc:Depends}
-Replaces: libqgis{QGIS_ABI}
-Description: QGIS - shared grass library
- QGIS is a Geographic Information System (GIS) which manages, analyzes and
- display databases of geographic information.
- .
- This package contains the shared grass library.
+#!sid#Package: libqgisgrass{QGIS_ABI}
+#!sid#Architecture: any
+#!sid#Section: libs
+#!sid#Depends:
+#!sid# ${shlibs:Depends},
+#!sid# ${misc:Depends}
+#!sid#Replaces: libqgis{QGIS_ABI}
+#!sid#Description: QGIS - shared grass library
+#!sid# QGIS is a Geographic Information System (GIS) which manages, analyzes and
+#!sid# display databases of geographic information.
+#!sid# .
+#!sid# This package contains the shared grass library.
 
 Package: libqgispython{QGIS_ABI}
 Architecture: any
@@ -210,7 +210,7 @@ Package: libqgis-dev
 Architecture: any
 Section: libdevel
 Depends:
- grass-dev (<< 7),
+#!sid# grass-dev,
  libexpat1-dev,
 #sid jessie sid-oracle trusty utopic vivid# libgdal-dev (>= 1.10.1-0~),
 #precise# libgdal-dev (>= 1.9.0) | libgdal1-dev (<< 1.9.0),
@@ -225,7 +225,7 @@ Depends:
  libqgis-analysis{QGIS_ABI} (= ${binary:Version}),
  libqgis-networkanalysis{QGIS_ABI} (= ${binary:Version}),
  libqgis-server{QGIS_ABI} (= ${binary:Version}),
- libqgisgrass{QGIS_ABI} (= ${binary:Version}),
+#!sid# libqgisgrass{QGIS_ABI} (= ${binary:Version}),
  libqgispython{QGIS_ABI} (= ${binary:Version}),
  libqt4-dev (>= 4.7.0),
  libsqlite3-dev,
@@ -244,35 +244,55 @@ Description: QGIS - development files
  This package contains the headers and libraries needed to develop plugins for
  QGIS.
 
-Package: qgis-plugin-grass
+Package: qgis-dbg
 Architecture: any
+Section: debug
+Priority: extra
 Depends:
- qgis (= ${binary:Version}),
- qgis-plugin-grass-common (= ${source:Version}),
- ${shlibs:Depends},
- ${misc:Depends},
-#!precise# grass-core (<< 7)
-#precise# grass (<< 7)
-Description: GRASS plugin for QGIS
- QGIS is a Geographic Information System (GIS) which manages, analyzes and
- display databases of geographic information.
- .
- This plugin enables GRASS data access in the QGIS geographic data viewer.
-
-Package: qgis-plugin-grass-common
-Architecture: all
-Depends:
-#sid jessie saucy sid-oracle trusty# python2.7,
-#wheezy precise# python,
+ libqgis-core{QGIS_ABI} (= ${binary:Version}),
+ libqgis-gui{QGIS_ABI} (= ${binary:Version}),
+ libqgis-analysis{QGIS_ABI} (= ${binary:Version}),
+ libqgis-networkanalysis{QGIS_ABI} (= ${binary:Version}),
+ libqgis-server{QGIS_ABI} (= ${binary:Version}),
+#!sid# libqgisgrass{QGIS_ABI} (= ${binary:Version}),
+ libqgispython{QGIS_ABI} (= ${binary:Version}),
  ${misc:Depends}
-Breaks: qgis-common (<< 1.5)
-Replaces: qgis-common (<< 1.5)
-Description: GRASS plugin for QGIS - architecture-independent data
+Suggests: gdb
+Description: QGIS - debugging symbols
  QGIS is a Geographic Information System (GIS) which manages, analyzes and
  display databases of geographic information.
  .
- This package contains architecture-independent supporting data files for use
- with the QGIS GRASS plugin.
+ This package contains debugging symbols.
+
+#!sid#Package: qgis-plugin-grass
+#!sid#Architecture: any
+#!sid#Depends:
+#!sid# qgis (= ${binary:Version}),
+#!sid# qgis-plugin-grass-common (= ${source:Version}),
+#!sid# ${shlibs:Depends},
+#!sid# ${misc:Depends},
+#!sid !precise# grass-core (<< 7)
+#!sid precise# grass (<< 7)
+#!sid#Description: GRASS plugin for QGIS
+#!sid# QGIS is a Geographic Information System (GIS) which manages, analyzes and
+#!sid# display databases of geographic information.
+#!sid# .
+#!sid# This plugin enables GRASS data access in the QGIS geographic data viewer.
+
+#!sid#Package: qgis-plugin-grass-common
+#!sid#Architecture: all
+#!sid#Depends:
+#jessie saucy trusty# python2.7,
+#wheezy precise# python,
+#!sid# ${misc:Depends}
+#!sid#Breaks: qgis-common (<< 1.5)
+#!sid#Replaces: qgis-common (<< 1.5)
+#!sid#Description: GRASS plugin for QGIS - architecture-independent data
+#!sid# QGIS is a Geographic Information System (GIS) which manages, analyzes and
+#!sid# display databases of geographic information.
+#!sid# .
+#!sid# This package contains architecture-independent supporting data files for use
+#!sid# with the QGIS GRASS plugin.
 
 Package: qgis-plugin-globe
 Architecture: any

--- a/debian/rules
+++ b/debian/rules
@@ -69,6 +69,10 @@ ifneq (,$(filter parallel=%,$(DEB_BUILD_OPTIONS)))
 	MAKEFLAGS += -j$(NUMJOBS)
 endif
 
+ifneq (,$(findstring $(DISTRIBUTION),"sid"))
+	CMAKE_OPTS += -DWITH_GRASS=FALSE
+endif
+
 ifneq (,$(findstring $(DISTRIBUTION),"wheezy jessie sid precise"))
 	CMAKE_OPTS += -DWITH_PYSPATIALITE=TRUE
 endif


### PR DESCRIPTION
Because GRASS 7 is not supported in 2.8 LTR, the plugin needs to be disabled on the distributions where GRASS 7 is used instead of GRASS 6.

The GRASS 7.0.1 packages in Debian experimental will soon be moved to unstable.
