### PR TITLE
Switch to combo + list for expression widget functions

### DIFF
--- a/src/gui/qgsexpressionbuilderwidget.h
+++ b/src/gui/qgsexpressionbuilderwidget.h
@@ -83,7 +83,8 @@ class QgsExpressionItem : public QStandardItem
     static const int CustomSortRole = Qt::UserRole + 1;
     //! Item type role
     static const int ItemTypeRole = Qt::UserRole + 2;
-
+    //! Group role
+    static const int GroupRole = Qt::UserRole + 3;
   private:
     QString mExpressionText;
     QString mHelpText;
@@ -103,14 +104,20 @@ class QgsExpressionItemSearchProxy : public QSortFilterProxyModel
       setFilterCaseSensitivity( Qt::CaseInsensitive );
     }
 
+    void setGroupFilter( QString groupName )
+    {
+      groupFilter = groupName;
+      invalidateFilter();
+    }
+
     bool filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const override
     {
       QModelIndex index = sourceModel()->index( source_row, 0, source_parent );
-      QgsExpressionItem::ItemType itemType = QgsExpressionItem::ItemType( sourceModel()->data( index, QgsExpressionItem::ItemTypeRole ).toInt() );
-
-      if ( itemType == QgsExpressionItem::Header )
-        return true;
-
+      if ( !groupFilter.isNull() )
+      {
+        QString group = sourceModel()->data( index, QgsExpressionItem::GroupRole ).toString();
+        return QString::localeAwareCompare( group, groupFilter ) == 0;
+      }
       return QSortFilterProxyModel::filterAcceptsRow( source_row, source_parent );
     }
 
@@ -134,6 +141,9 @@ class QgsExpressionItemSearchProxy : public QSortFilterProxyModel
 
       return QString::localeAwareCompare( leftString, rightString ) < 0;
     }
+
+  private:
+    QString groupFilter;
 };
 
 /** A reusable widget that can be used to build a expression string.
@@ -231,6 +241,7 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
 
   public slots:
     void currentChanged( const QModelIndex &index, const QModelIndex & );
+    void groupChanged( int groupIndex );
     void on_btnRun_pressed();
     void on_btnNewFile_pressed();
     void on_cmbFileNames_currentIndexChanged( int index );
@@ -273,6 +284,7 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
     QString mFunctionsPath;
     QgsVectorLayer *mLayer;
     QStandardItemModel *mModel;
+    QStandardItemModel *mGroupsModel;
     QgsExpressionItemSearchProxy *mProxyModel;
     QMap<QString, QgsExpressionItem*> mExpressionGroups;
     QgsFeature mFeature;

--- a/src/ui/qgsexpressionbuilder.ui
+++ b/src/ui/qgsexpressionbuilder.ui
@@ -340,7 +340,10 @@
                 </widget>
                </item>
                <item>
-                <widget class="QTreeView" name="expressionTree">
+                <widget class="QComboBox" name="expressionGroupsList"/>
+               </item>
+               <item>
+                <widget class="QListView" name="expressionTree">
                  <property name="frameShape">
                   <enum>QFrame::StyledPanel</enum>
                  </property>
@@ -350,18 +353,6 @@
                  <property name="editTriggers">
                   <set>QAbstractItemView::NoEditTriggers</set>
                  </property>
-                 <property name="uniformRowHeights">
-                  <bool>false</bool>
-                 </property>
-                 <property name="sortingEnabled">
-                  <bool>false</bool>
-                 </property>
-                 <property name="animated">
-                  <bool>true</bool>
-                 </property>
-                 <attribute name="headerVisible">
-                  <bool>false</bool>
-                 </attribute>
                 </widget>
                </item>
               </layout>


### PR DESCRIPTION
_For feedback and testing_*

This PR switches the expression function tree out for a combo and list.  The tree was getting very hard to navigate and felt really painful for user experience.

Combo filters the current functions.  Searching will return all functions over all groups

![expressions](https://cloud.githubusercontent.com/assets/381660/9482867/560a17f6-4bdc-11e5-85a7-34d74a4d3f53.gif)

Still needs code clean up and UI tweaks but posted for feedback.
