### PR TITLE
Update and adaptation of some GRASS plugin modules

### DIFF
--- a/src/plugins/grass/modules/db.out.ogr.qgm
+++ b/src/plugins/grass/modules/db.out.ogr.qgm
@@ -4,7 +4,7 @@
 <qgisgrassmodule label="Exports attribute tables into various format" module="db.out.ogr">
 	<option key="input" />
 	<file key="dsn" type="new" version_max="6.4"/>
-	<file key="output" type="new" version_max="7.0"/>
+	<file key="output" type="new" version_min="7.0"/>
 	<option key="format" />
 	<option key="db_table" version_max="6.4"/>
 	<option key="table" version_min="7.0"/>

--- a/src/plugins/grass/modules/r.basins.fill.qgm
+++ b/src/plugins/grass/modules/r.basins.fill.qgm
@@ -4,7 +4,10 @@
 <!-- direct note: the module runs, but it was not tested with real data -->
 <qgisgrassmodule label="Create watershed subbasins raster" module="r.basins.fill" direct="1">
 	<option key="number" />
-	<option key="c_map" />
-	<option key="t_map" />
-	<option key="result" />
+	<option key="c_map" version_max="6.4"/>
+	<option key="cnetwork" version_min="7.0"/>
+	<option key="t_map" version_max="6.4"/>
+	<option key="tnetwork" version_min="7.0"/>
+	<option key="result" version_max="6.4"/>
+	<option key="output" version_min="7.0"/>
 </qgisgrassmodule>

--- a/src/plugins/grass/modules/r.carve.qgm
+++ b/src/plugins/grass/modules/r.carve.qgm
@@ -2,8 +2,10 @@
 <!DOCTYPE qgisgrassmodule SYSTEM "http://mrcc.com/qgisgrassmodule.dtd">
 
 <qgisgrassmodule label="Take vector stream data, transform it to raster, and subtract depth from the output DEM" module="r.carve">
-	<option key="rast" />
-	<option key="vect" />
+	<option key="rast" version_max="6.4"/>
+	<option key="raster" version_min="7.0"/>
+	<option key="vect" version_max="6.4"/>
+	<option key="vector" version_min="7.0"/>
 	<option key="width" />
 	<option key="depth" />
 	<flag key="n" />

--- a/src/plugins/grass/modules/r.circle.qgm
+++ b/src/plugins/grass/modules/r.circle.qgm
@@ -2,9 +2,11 @@
 <!DOCTYPE qgisgrassmodule SYSTEM "http://mrcc.com/qgisgrassmodule.dtd">
 
 <qgisgrassmodule label="Create a map containing concentric rings" module="r.circle">
-	<option key="coordinate" />
+	<option key="coordinate" version_max="6.4"/>
+	<option key="coordinates" version_min="7.0"/>
 	<option key="min" answer="0" />
 	<option key="max" />
-	<option key="mult" answer="1"/>
+	<option key="mult" answer="1" version_max="6.4"/>
+	<option key="multiplier" answer="1" version_min="7.0"/>
 	<option key="output" />
 </qgisgrassmodule>

--- a/src/plugins/grass/modules/r.fill.dir.qgm
+++ b/src/plugins/grass/modules/r.fill.dir.qgm
@@ -3,7 +3,9 @@
 
 <qgisgrassmodule label="Filter and create depressionless elevation map and flow direction map from elevation raster" module="r.fill.dir">
 	<option key="input" />
-	<option key="type" answer="grass" hidden="yes"/>
-	<option key="elevation" />
+	<option key="type" answer="grass" hidden="yes" version_max="6.4"/>
+	<option key="format" answer="grass" hidden="yes" version_min="7.0"/>
+	<option key="elevation" version_max="6.4"/>
+	<option key="output" version_min="7.0"/>
 	<option key="direction" />
 </qgisgrassmodule>

--- a/src/plugins/grass/modules/r.lake.seed.qgm
+++ b/src/plugins/grass/modules/r.lake.seed.qgm
@@ -2,8 +2,10 @@
 <!DOCTYPE qgisgrassmodule SYSTEM "http://mrcc.com/qgisgrassmodule.dtd">
 
 <qgisgrassmodule label="Fill lake from seed at given level" module="r.lake">
-	<option key="dem" />
+	<option key="dem" version_max="6.4"/>
+	<option key="elevation" version_max="7.0"/>
 	<option key="seed" />
-	<option key="wl" />
+	<option key="wl" version_max="6.4"/>
+	<option key="water_level" version_min="7.0"/>
 	<option key="lake" />
 </qgisgrassmodule>

--- a/src/plugins/grass/modules/r.lake.seed.qgm
+++ b/src/plugins/grass/modules/r.lake.seed.qgm
@@ -3,7 +3,7 @@
 
 <qgisgrassmodule label="Fill lake from seed at given level" module="r.lake">
 	<option key="dem" version_max="6.4"/>
-	<option key="elevation" version_max="7.0"/>
+	<option key="elevation" version_min="7.0"/>
 	<option key="seed" />
 	<option key="wl" version_max="6.4"/>
 	<option key="water_level" version_min="7.0"/>

--- a/src/plugins/grass/modules/r.lake.xy.qgm
+++ b/src/plugins/grass/modules/r.lake.xy.qgm
@@ -3,7 +3,7 @@
 
 <qgisgrassmodule label="Fill lake from seed point at given level" module="r.lake">
 	<option key="dem" version_max="6.4"/>
-	<option key="elevation" version_max="7.0"/>
+	<option key="elevation" version_min="7.0"/>
 	<option key="xy" version_max="6.4"/>
 	<option key="coordinates" version_min="7.0"/>
 	<option key="wl" version_max="6.4"/>

--- a/src/plugins/grass/modules/r.lake.xy.qgm
+++ b/src/plugins/grass/modules/r.lake.xy.qgm
@@ -2,9 +2,12 @@
 <!DOCTYPE qgisgrassmodule SYSTEM "http://mrcc.com/qgisgrassmodule.dtd">
 
 <qgisgrassmodule label="Fill lake from seed point at given level" module="r.lake">
-	<option key="dem" />
-	<option key="xy" />
-	<option key="wl" />
+	<option key="dem" version_max="6.4"/>
+	<option key="elevation" version_max="7.0"/>
+	<option key="xy" version_max="6.4"/>
+	<option key="coordinates" version_min="7.0"/>
+	<option key="wl" version_max="6.4"/>
+	<option key="water_level" version_min="7.0"/>
 	<flag key="n" />
 	<flag key="o" />
 	<option key="lake" />

--- a/src/plugins/grass/modules/r.random.qgm
+++ b/src/plugins/grass/modules/r.random.qgm
@@ -3,6 +3,8 @@
 
 <qgisgrassmodule label="Create random vector point contained in raster" module="r.random">
 	<option key="input"/>
-	<option key="n" answer="1" hidden="no"/>
-	<option key="vector_output" />
+	<option key="n" answer="1" hidden="no" version_max="6.4"/>
+	<option key="npoints" answer="1" hidden="no" version_min="7.0"/>
+	<option key="vector_output" version_max="6.4"/>
+	<option key="vector" version_min="7.0"/>
 </qgisgrassmodule>

--- a/src/plugins/grass/modules/r.random.raster.qgm
+++ b/src/plugins/grass/modules/r.random.raster.qgm
@@ -3,6 +3,8 @@
 
 <qgisgrassmodule label="Create random raster" module="r.random" direct="1">
 	<option key="input"/>
-	<option key="n" answer="1" hidden="no"/>
-	<option key="raster_output" />
+	<option key="n" answer="1" hidden="no" version_max="6.4"/>
+	<option key="npoints" answer="1" hidden="no" version_min="7.0"/>
+	<option key="raster_output" version_max="6.4"/>
+	<option key="raster" version_min="7.0"/>
 </qgisgrassmodule>

--- a/src/plugins/grass/modules/r.reclass.area.greater.qgm
+++ b/src/plugins/grass/modules/r.reclass.area.greater.qgm
@@ -3,6 +3,8 @@
 
 <qgisgrassmodule label="Reclass raster with patches larger than user-defined area size (in hectares)" module="r.reclass.area">
 	<option key="input" />
-	<option key="greater" />
+	<option key="greater" version_max="6.4"/>
+	<option key="mode" answer="greater" hidden="yes" version_min="7.0"/>
+	<option key="value" version_min="7.0"/>
 	<option key="output" />
 </qgisgrassmodule>

--- a/src/plugins/grass/modules/r.reclass.area.lesser.qgm
+++ b/src/plugins/grass/modules/r.reclass.area.lesser.qgm
@@ -3,6 +3,8 @@
 
 <qgisgrassmodule label="Reclass raster with patches smaller than user-defined area size (in hectares)" module="r.reclass.area">
 	<option key="input" />
-	<option key="lesser" />
+	<option key="lesser" version_max="6.4"/>
+	<option key="mode" answer="lesser" hidden="yes" version_min="7.0"/>
+	<option key="value" version_min="7.0"/>
 	<option key="output" />
 </qgisgrassmodule>

--- a/src/plugins/grass/modules/r.water.outlet.qgm
+++ b/src/plugins/grass/modules/r.water.outlet.qgm
@@ -2,8 +2,11 @@
 <!DOCTYPE qgisgrassmodule SYSTEM "http://mrcc.com/qgisgrassmodule.dtd">
 
 <qgisgrassmodule label="Create watershed basin" module="r.water.outlet">
-	<option key="drainage" />
-	<option key="easting" />
-	<option key="northing" />
-	<option key="basin" />
+	<option key="drainage" version_max="6.4"/>
+	<option key="input" version_min="7.0"/>
+	<option key="easting" version_max="6.4"/>
+	<option key="northing" version_max="6.4"/>
+	<option key="coordinates" version_min="7.0"/>
+	<option key="basin" version_max="6.4"/>
+	<option key="output" version_min="7.0"/>
 </qgisgrassmodule>

--- a/src/plugins/grass/modules/v.in.ogr.qgis.loc.qgm
+++ b/src/plugins/grass/modules/v.in.ogr.qgis.loc.qgm
@@ -3,7 +3,7 @@
 
 <qgisgrassmodule label="Import loaded vector and create a fitted location" module="v.in.ogr"> 
 	<ogr key="dsn" layeroption="layer" whereoption="where" label="Loaded layer" version_max="6.4"/>
-	<ogr key="input" layeroption="layer" whereoption="where" label="Loaded layer" version_max="6.4"/>
+	<ogr key="input" layeroption="layer" whereoption="where" label="Loaded layer" version_min="7.0"/>
 	<option key="output" />	
 	<option key="location" />
         <option key="type" advanced="yes"/>

--- a/src/plugins/grass/modules/v.normal.qgm
+++ b/src/plugins/grass/modules/v.normal.qgm
@@ -3,7 +3,7 @@
 
 <qgisgrassmodule label="Tests of normality on vector points" module="v.normal">
 	<option key="map" typemask="point" />
-	<field key="column" layer="input" type="integer,double" label="Attribute field" />
+	<field key="column" layer="map" type="integer,double" label="Attribute field" />
 	<option key="tests" answer="1-1000000" hidden="yes" />
 	<flag key="r" answer="off" hidden="no" />
 </qgisgrassmodule>


### PR DESCRIPTION
Update and adaptation of GRASS plugin modules (db.out.ogr, r.basins.fill, r.carve, r.circle, r.fill.dir, r.lake.seed, r.lake.xy, r.random, r.random.raster, r.reclass.area.greater, r.reclass.area.lesser, r.water.outlet, v.in.ogr.qgis.loc, v.normal) to GRASS 6 and 7
