### PR TITLE
Add methods for retrieving extra parameters from symbol render

### DIFF
--- a/python/core/symbology-ng/qgsrendererv2.sip
+++ b/python/core/symbology-ng/qgsrendererv2.sip
@@ -263,6 +263,15 @@ class QgsFeatureRendererV2
      */
     void setForceRasterRender( bool forceRaster );
 
+    /** Returns the result of the feature rendering operation. This should only be
+     * called immediately after a rendering operation (eg calling renderFeature).
+     * @note added in QGIS 2.12
+     * @note this is a temporary method until QGIS 3.0. For QGIS 3.0 renderFeature
+     * will return a QgsRenderResult object
+     */
+    // TODO - QGIS 3.0. Remove and make renderFeature return a QgsRenderResult
+    const QgsRenderResult& renderResult() const;
+
   protected:
     QgsFeatureRendererV2( QString type );
 
@@ -290,6 +299,16 @@ class QgsFeatureRendererV2
      * @param destRenderer destination renderer for copied effect
      */
     void copyPaintEffect( QgsFeatureRendererV2 *destRenderer ) const;
+
+    /** Sets the result of the symbol rendering operation. Subclasses should call
+     * this method after rendering a feature and update the render result to reflect
+     * to actual result of the feature render.
+     * @note added in QGIS 2.12
+     * @note this is a temporary method until QGIS 3.0. For QGIS 3.0 the renderFeature method
+     * will return a QgsRenderResult object
+     */
+    // TODO - QGIS 3.0. Remove and make renderPoint, etc return a QgsRenderResult
+    void setRenderResult( const QgsRenderResult& result );
 
   private:
     QgsFeatureRendererV2( const QgsFeatureRendererV2 & );

--- a/python/core/symbology-ng/qgssymbollayerv2.sip
+++ b/python/core/symbology-ng/qgssymbollayerv2.sip
@@ -260,6 +260,15 @@ class QgsSymbolLayerV2
      */
     void setPaintEffect( QgsPaintEffect* effect /Transfer/);
 
+    /** Returns the result of the symbol rendering operation. This should only be
+     * called immediately after a rendering operation (eg calling renderPoint).
+     * @note added in QGIS 2.12
+     * @note this is a temporary method until QGIS 3.0. For QGIS 3.0 the render methods
+     * will return a QgsRenderResult object
+     */
+    // TODO - QGIS 3.0. Remove and make renderPoint, etc return a QgsRenderResult
+    const QgsRenderResult& renderResult() const;
+
   protected:
     QgsSymbolLayerV2( QgsSymbolV2::SymbolType type, bool locked = false );
 
@@ -305,6 +314,16 @@ class QgsSymbolLayerV2
      * @note added in QGIS 2.9
      */
     void copyPaintEffect( QgsSymbolLayerV2* destLayer ) const;
+
+    /** Sets the result of the symbol rendering operation. Subclasses should call
+     * this method after rendering a symbol and update the render result to reflect
+     * to actual result of the symbol render.
+     * @note added in QGIS 2.12
+     * @note this is a temporary method until QGIS 3.0. For QGIS 3.0 the render methods
+     * will return a QgsRenderResult object
+     */
+    // TODO - QGIS 3.0. Remove and make renderPoint, etc return a QgsRenderResult
+    void setRenderResult( const QgsRenderResult& result );
 
 };
 

--- a/python/core/symbology-ng/qgssymbolv2.sip
+++ b/python/core/symbology-ng/qgssymbolv2.sip
@@ -1,6 +1,39 @@
 
 typedef QList<QgsSymbolLayerV2*> QgsSymbolLayerV2List;
 
+/** \ingroup core
+ * \class QgsRenderResult
+ * \brief A simple container for the results of a rendering operation
+ * \note Added in version 2.12
+ */
+
+class QgsRenderResult
+{
+%TypeHeaderCode
+#include <qgssymbolv2.h>
+%End
+  public:
+
+    /** Constructor for QgsRenderResult
+     * @param symbolRendered initial value for symbolRendered member
+     */
+    QgsRenderResult( bool symbolRendered );
+
+    /** Bounds of rendered symbol shape.
+     * @note only implemented for marker symbol types
+     */
+    QRectF symbolBounds;
+
+    //! True if a symbol was rendered during the render operation
+    bool symbolRendered;
+
+    /** Unites the render result with another QgsRenderResult object
+     * @param other other render result
+     */
+    void unite( const QgsRenderResult& other );
+};
+
+
 class QgsSymbolV2
 {
 %TypeHeaderCode
@@ -158,6 +191,15 @@ class QgsSymbolV2
 
     void setLayer( const QgsVectorLayer* layer );
     const QgsVectorLayer* layer() const;
+
+     /** Returns the result of the symbol rendering operation. This should only be
+     * called immediately after a rendering operation (eg calling renderPoint).
+     * @note added in QGIS 2.12
+     * @note this is a temporary method until QGIS 3.0. For QGIS 3.0 the render methods
+     * will return a QgsRenderResult object
+     */
+    // TODO - QGIS 3.0. Remove and make renderPoint, etc return a QgsRenderResult
+    const QgsRenderResult& renderResult() const;
 
   protected:
     QgsSymbolV2( SymbolType type, QgsSymbolLayerV2List layers /Transfer/ ); // can't be instantiated

--- a/src/core/symbology-ng/qgsmarkersymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgsmarkersymbollayerv2.cpp
@@ -541,15 +541,18 @@ void QgsSimpleMarkerSymbolLayerV2::renderPoint( const QPointF& point, QgsSymbolV
     }
   }
 
+  QgsRenderResult result( true );
   if ( mUsingCache )
   {
     //QgsDebugMsg( QString("XXX using cache") );
     // we will use cached image
     QImage &img = context.selected() ? mSelCache : mCache;
     double s = img.width() / context.renderContext().rasterScaleFactor();
-    p->drawImage( QRectF( point.x() - s / 2.0 + off.x(),
-                          point.y() - s / 2.0 + off.y(),
-                          s, s ), img );
+    QRectF imgRect( point.x() - s / 2.0 + off.x(),
+                    point.y() - s / 2.0 + off.y(),
+                    s, s );
+    p->drawImage( imgRect, img );
+    result.symbolBounds = imgRect;
   }
   else
   {
@@ -606,11 +609,25 @@ void QgsSimpleMarkerSymbolLayerV2::renderPoint( const QPointF& point, QgsSymbolV
     p->setBrush( context.selected() ? mSelBrush : mBrush );
     p->setPen( context.selected() ? mSelPen : mPen );
 
+    QRectF boundingRect;
     if ( !mPolygon.isEmpty() )
-      p->drawPolygon( transform.map( mPolygon ) );
+    {
+      QPolygonF transformed = transform.map( mPolygon );
+      boundingRect = transformed.boundingRect();
+      p->drawPolygon( transformed );
+
+    }
     else
-      p->drawPath( transform.map( mPath ) );
+    {
+      QPainterPath transformed = transform.map( mPath );
+      boundingRect = transformed.boundingRect();
+      p->drawPath( transformed );
+    }
+    //adjust bounding rect for pen width
+    result.symbolBounds = boundingRect.adjusted( -mPen.widthF() / 2.0, -mPen.widthF() / 2.0,
+                          mPen.widthF() / 2.0, mPen.widthF() / 2.0 );
   }
+  setRenderResult( result );
 }
 
 

--- a/src/core/symbology-ng/qgsrendererv2.cpp
+++ b/src/core/symbology-ng/qgsrendererv2.cpp
@@ -216,6 +216,7 @@ QgsFeatureRendererV2::QgsFeatureRendererV2( QString type )
     , mCurrentVertexMarkerSize( 3 )
     , mPaintEffect( 0 )
     , mForceRaster( false )
+    , mRenderResult( QgsRenderResult( true ) )
 {
   mPaintEffect = QgsPaintEffectRegistry::defaultStack();
   mPaintEffect->setEnabled( false );
@@ -268,9 +269,13 @@ bool QgsFeatureRendererV2::renderFeature( QgsFeature& feature, QgsRenderContext&
 {
   QgsSymbolV2* symbol = symbolForFeature( feature, context );
   if ( symbol == NULL )
+  {
+    setRenderResult( QgsRenderResult( false ) );
     return false;
+  }
 
   renderFeatureWithSymbol( feature, symbol, context, layer, selected, drawVertexMarker );
+  setRenderResult( symbol->renderResult() );
   return true;
 }
 
@@ -780,4 +785,9 @@ void QgsFeatureRendererV2::convertSymbolRotation( QgsSymbolV2 * symbol, const QS
                               : QString() ) + field );
     s->setDataDefinedAngle( dd );
   }
+}
+
+void QgsFeatureRendererV2::setRenderResult( const QgsRenderResult& result )
+{
+  mRenderResult = result;
 }

--- a/src/core/symbology-ng/qgsrendererv2.h
+++ b/src/core/symbology-ng/qgsrendererv2.h
@@ -310,6 +310,15 @@ class CORE_EXPORT QgsFeatureRendererV2
      */
     void setForceRasterRender( bool forceRaster ) { mForceRaster = forceRaster; }
 
+    /** Returns the result of the feature rendering operation. This should only be
+     * called immediately after a rendering operation (eg calling renderFeature).
+     * @note added in QGIS 2.12
+     * @note this is a temporary method until QGIS 3.0. For QGIS 3.0 renderFeature
+     * will return a QgsRenderResult object
+     */
+    // TODO - QGIS 3.0. Remove and make renderFeature return a QgsRenderResult
+    const QgsRenderResult& renderResult() const { return mRenderResult; }
+
   protected:
     QgsFeatureRendererV2( QString type );
 
@@ -360,8 +369,20 @@ class CORE_EXPORT QgsFeatureRendererV2
      */
     static void convertSymbolRotation( QgsSymbolV2 * symbol, const QString & field );
 
+    /** Sets the result of the symbol rendering operation. Subclasses should call
+     * this method after rendering a feature and update the render result to reflect
+     * to actual result of the feature render.
+     * @note added in QGIS 2.12
+     * @note this is a temporary method until QGIS 3.0. For QGIS 3.0 the renderFeature method
+     * will return a QgsRenderResult object
+     */
+    // TODO - QGIS 3.0. Remove and make renderPoint, etc return a QgsRenderResult
+    void setRenderResult( const QgsRenderResult& result );
+
   private:
     Q_DISABLE_COPY( QgsFeatureRendererV2 )
+
+    QgsRenderResult mRenderResult;
 };
 
 // for some reason SIP compilation fails if these lines are not included:

--- a/src/core/symbology-ng/qgsrulebasedrendererv2.cpp
+++ b/src/core/symbology-ng/qgsrulebasedrendererv2.cpp
@@ -812,6 +812,8 @@ bool QgsRuleBasedRendererV2::renderFeature( QgsFeature& feature,
 {
   Q_UNUSED( layer );
 
+  setRenderResult( QgsRenderResult( false ) );
+
   int flags = ( selected ? FeatIsSelected : 0 ) | ( drawVertexMarker ? FeatDrawMarkers : 0 );
   mCurrentFeatures.append( FeatureToRender( feature, flags ) );
 
@@ -869,6 +871,10 @@ void QgsRuleBasedRendererV2::stopRender( QgsRenderContext& context )
         {
           int flags = job->ftr.flags;
           renderFeatureWithSymbol( job->ftr.feat, job->symbol, context, i, flags & FeatIsSelected, flags & FeatDrawMarkers );
+
+          QgsRenderResult newRenderResult = job->symbol->renderResult();
+          newRenderResult.unite( renderResult() );
+          setRenderResult( newRenderResult );
         }
       }
     }

--- a/src/core/symbology-ng/qgssymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgssymbollayerv2.cpp
@@ -334,6 +334,7 @@ QgsSymbolLayerV2::QgsSymbolLayerV2( QgsSymbolV2::SymbolType type, bool locked )
     , mLocked( locked )
     , mRenderingPass( 0 )
     , mPaintEffect( 0 )
+    , mRenderResult( QgsRenderResult( true ) )
 {
   mPaintEffect = QgsPaintEffectRegistry::defaultStack();
   mPaintEffect->setEnabled( false );
@@ -480,6 +481,11 @@ void QgsSymbolLayerV2::copyPaintEffect( QgsSymbolLayerV2 *destLayer ) const
     return;
 
   destLayer->setPaintEffect( mPaintEffect->clone() );
+}
+
+void QgsSymbolLayerV2::setRenderResult( const QgsRenderResult& result )
+{
+  mRenderResult = result;
 }
 
 QgsMarkerSymbolLayerV2::QgsMarkerSymbolLayerV2( bool locked )

--- a/src/core/symbology-ng/qgssymbollayerv2.h
+++ b/src/core/symbology-ng/qgssymbollayerv2.h
@@ -247,6 +247,15 @@ class CORE_EXPORT QgsSymbolLayerV2
      */
     void setPaintEffect( QgsPaintEffect* effect );
 
+    /** Returns the result of the symbol rendering operation. This should only be
+     * called immediately after a rendering operation (eg calling renderPoint).
+     * @note added in QGIS 2.12
+     * @note this is a temporary method until QGIS 3.0. For QGIS 3.0 the render methods
+     * will return a QgsRenderResult object
+     */
+    // TODO - QGIS 3.0. Remove and make renderPoint, etc return a QgsRenderResult
+    const QgsRenderResult& renderResult() const { return mRenderResult; }
+
   protected:
     QgsSymbolLayerV2( QgsSymbolV2::SymbolType type, bool locked = false );
 
@@ -307,6 +316,16 @@ class CORE_EXPORT QgsSymbolLayerV2
      */
     void copyPaintEffect( QgsSymbolLayerV2* destLayer ) const;
 
+    /** Sets the result of the symbol rendering operation. Subclasses should call
+     * this method after rendering a symbol and update the render result to reflect
+     * to actual result of the symbol render.
+     * @note added in QGIS 2.12
+     * @note this is a temporary method until QGIS 3.0. For QGIS 3.0 the render methods
+     * will return a QgsRenderResult object
+     */
+    // TODO - QGIS 3.0. Remove and make renderPoint, etc return a QgsRenderResult
+    void setRenderResult( const QgsRenderResult& result );
+
     static const QString EXPR_SIZE;
     static const QString EXPR_ANGLE;
     static const QString EXPR_NAME;
@@ -365,6 +384,10 @@ class CORE_EXPORT QgsSymbolLayerV2
     static const QString EXPR_OFFSET_ALONG_LINE;
     static const QString EXPR_HORIZONTAL_ANCHOR_POINT;
     static const QString EXPR_VERTICAL_ANCHOR_POINT;
+
+  private:
+
+    QgsRenderResult mRenderResult;
 };
 
 //////////////////////

--- a/src/core/symbology-ng/qgssymbolv2.cpp
+++ b/src/core/symbology-ng/qgssymbolv2.cpp
@@ -81,6 +81,7 @@ QgsSymbolV2::QgsSymbolV2( SymbolType type, QgsSymbolLayerV2List layers )
     , mRenderHints( 0 )
     , mClipFeaturesToExtent( true )
     , mLayer( 0 )
+    , mRenderResult( QgsRenderResult( true ) )
 {
 
   // check they're all correct symbol layers
@@ -828,6 +829,8 @@ void QgsMarkerSymbolV2::renderPointUsingLayer( QgsMarkerSymbolLayerV2* layer, co
   {
     layer->renderPoint( point, context );
   }
+
+  mRenderResult = layer->renderResult();
 }
 
 void QgsMarkerSymbolV2::renderPoint( const QPointF& point, const QgsFeature* f, QgsRenderContext& context, int layer, bool selected )
@@ -843,10 +846,13 @@ void QgsMarkerSymbolV2::renderPoint( const QPointF& point, const QgsFeature* f, 
     return;
   }
 
+  QgsRenderResult combinedResult( false );
   for ( QgsSymbolLayerV2List::iterator it = mLayers.begin(); it != mLayers.end(); ++it )
   {
     renderPointUsingLayer(( QgsMarkerSymbolLayerV2* ) * it, point, symbolContext );
+    combinedResult.unite(( *it )->renderResult() );
   }
+  mRenderResult = combinedResult;
 }
 
 QgsSymbolV2* QgsMarkerSymbolV2::clone() const
@@ -1029,6 +1035,8 @@ void QgsLineSymbolV2::renderPolylineUsingLayer( QgsLineSymbolLayerV2 *layer, con
   {
     layer->renderPolyline( points, context );
   }
+
+  mRenderResult = layer->renderResult();
 }
 
 
@@ -1109,6 +1117,8 @@ void QgsFillSymbolV2::renderPolygonUsingLayer( QgsSymbolLayerV2* layer, const QP
       (( QgsLineSymbolLayerV2* )layer )->renderPolygonOutline( points, rings, context );
     }
   }
+
+  mRenderResult = layer->renderResult();
 }
 
 QRectF QgsFillSymbolV2::polygonBounds( const QPolygonF& points, const QList<QPolygonF>* rings ) const

--- a/src/core/symbology-ng/qgssymbolv2.h
+++ b/src/core/symbology-ng/qgssymbolv2.h
@@ -45,6 +45,48 @@ class QgsDataDefined;
 
 typedef QList<QgsSymbolLayerV2*> QgsSymbolLayerV2List;
 
+
+/** \ingroup core
+ * \class QgsRenderResult
+ * \brief A simple container for the results of a rendering operation
+ * \note Added in version 2.12
+ */
+
+class QgsRenderResult
+{
+  public:
+
+    /** Constructor for QgsRenderResult
+     * @param symbolRendered initial value for symbolRendered member
+     */
+    QgsRenderResult( bool symbolRendered )
+        : symbolRendered( symbolRendered )
+    { }
+
+    /** Bounds of rendered symbol shape.
+     * @note only implemented for marker symbol types
+     */
+    QRectF symbolBounds;
+
+    //! True if a symbol was rendered during the render operation
+    bool symbolRendered;
+
+    /** Unites the render result with another QgsRenderResult object
+     * @param other other render result
+     */
+    void unite( const QgsRenderResult& other )
+    {
+      symbolRendered = symbolRendered || other.symbolRendered;
+      if ( !symbolBounds.isValid() )
+        symbolBounds = other.symbolBounds;
+      else
+        symbolBounds = symbolBounds.united( other.symbolBounds );
+    }
+};
+
+
+//////////////////////
+
 class CORE_EXPORT QgsSymbolV2
 {
   public:
@@ -208,6 +250,15 @@ class CORE_EXPORT QgsSymbolV2
     void setLayer( const QgsVectorLayer* layer ) { mLayer = layer; }
     const QgsVectorLayer* layer() const { return mLayer; }
 
+    /** Returns the result of the symbol rendering operation. This should only be
+     * called immediately after a rendering operation (eg calling renderPoint).
+     * @note added in QGIS 2.12
+     * @note this is a temporary method until QGIS 3.0. For QGIS 3.0 the render methods
+     * will return a QgsRenderResult object
+     */
+    // TODO - QGIS 3.0. Remove and make renderPoint, etc return a QgsRenderResult
+    const QgsRenderResult& renderResult() const { return mRenderResult; }
+
   protected:
     QgsSymbolV2( SymbolType type, QgsSymbolLayerV2List layers ); // can't be instantiated
 
@@ -227,6 +278,8 @@ class CORE_EXPORT QgsSymbolV2
     bool mClipFeaturesToExtent;
 
     const QgsVectorLayer* mLayer; //current vectorlayer
+
+    QgsRenderResult mRenderResult;
 
 };
 
@@ -286,9 +339,7 @@ class CORE_EXPORT QgsSymbolV2RenderContext
 };
 
 
-
 //////////////////////
-
 
 
 class CORE_EXPORT QgsMarkerSymbolV2 : public QgsSymbolV2


### PR DESCRIPTION
For upcoming labeling work I need to make the labelling engine aware of the actual size of rendered marker symbols. This isn't currently possible without effectively double-rendering the symbol (calling symbolForFeature, rendering it to a picture, finding bounds of result...). 

So this PR implements a method of retrieving additional parameters following a feature render operation. At the moment this only includes the bounding box of marker symbols (and in this PR I've only implemented it for one simple marker types), but it could later be extended to include other properties which are known only at render time as required.

I'm not super-happy with the approach (requiring render operations to set a render result and then having a new function to retrieve these following the render), but it's the only way I can do this without changing the signature of the various virtual render functions and breaking API in a large way.

Includes lots of notes on how this will be fixed for QGIS 3.0 ;)
