### PR TITLE
[composer] prevent application freeze upon opening composer due to qt / cups bug

### DIFF
--- a/src/app/composer/qgscomposer.h
+++ b/src/app/composer/qgscomposer.h
@@ -505,9 +505,6 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
     //! Updates the "set as atlas feature" map layer action, removing it if atlas is disabled
     void updateAtlasMapLayerAction( bool atlasEnabled );
 
-    //! Set default settings for printer page settings based on composition paper size
-    void setPrinterPageDefaults();
-
     //! Load predefined scales from the project's properties
     void loadAtlasPredefinedScalesFromProject();
 
@@ -543,7 +540,7 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
 
     //! The composer was opened first time (-> set defaults)
     bool mFirstTime;
-
+    
     //! Layout
     QGridLayout *mItemOptionsLayout;
 
@@ -563,6 +560,7 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
 
     //! Page & Printer Setup
     QPrinter* mPrinter;
+    bool mSetPageOrientation;
 
     QUndoView* mUndoView;
 
@@ -641,7 +639,7 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
     void updateAtlasMapLayerAction( QgsVectorLayer* coverageLayer );
 
     //! Sets the printer page orientation when the page orientation changes
-    void setPrinterPageOrientation( QString orientation );
+    void setPrinterPageOrientation();
 
     void disablePreviewMode();
     void activateGrayscalePreview();


### PR DESCRIPTION
This pull request delays the initiation of a QPrinter object until it's needed (either by requesting to print to printer, or editing a printer's page setup). 

Doing so prevents (or at least delay until the user really wants to interface with a printer) QGIS from freezing (for as long as 30 seconds on my machine) when hitting QT /cups printer bugs caused by specific scenarios. For e.g., cups freezes the pooling of printers when a VPN is used system-wide.
