### PR TITLE
[labelling] set fill rule of qpainterpath for text/buffer rendering

### DIFF
--- a/src/core/qgspallabeling.cpp
+++ b/src/core/qgspallabeling.cpp
@@ -4802,6 +4802,7 @@ void QgsPalLabeling::drawLabel( pal::LabelPosition* label, QgsRenderContext& con
       {
         // draw label's text, QPainterPath method
         QPainterPath path;
+        path.setFillRule( Qt::WindingFill );
         path.addText( 0, 0, tmpLyr.textFont, component.text() );
 
         // store text's drawing in QPicture for drop shadow call
@@ -4870,6 +4871,7 @@ void QgsPalLabeling::drawLabelBuffer( QgsRenderContext& context,
                    ( tmpLyr.bufferSizeInMapUnits ? QgsPalLayerSettings::MapUnits : QgsPalLayerSettings::MM ), true, tmpLyr.bufferSizeMapUnitScale );
 
   QPainterPath path;
+  path.setFillRule( Qt::WindingFill );
   path.addText( 0, 0, tmpLyr.textFont, component.text() );
   QPen pen( tmpLyr.bufferColor );
   pen.setWidthF( penSize );


### PR DESCRIPTION
At the moment, when labels' text and buffer are rendered as outline (which is the default option), undesired artifacts can appear. It's especially true for complex scripts (such as Burmese). This occurs because the QPainterPath object used to draw the text and buffer areas uses as a default fill which isn't appropriate for this purpose (see http://doc.qt.io/qt-4.8/qpainterpath.html#setFillRule).

The pull request simply adds a call to the QPainterPath's setFillRule() function to use the appropriate non-default WindingFill rule.

For the record, here's an image that shows the current problem which this pull request fixes:
![bad_vs_good](https://cloud.githubusercontent.com/assets/1728657/9677604/4f766a80-5306-11e5-887f-fe35c8e2e7ac.png)
