### PR TITLE
[recent projects] do not insert path twice in the recent project file menu

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2755,7 +2755,15 @@ void QgisApp::updateRecentProjectPaths()
 
   Q_FOREACH ( const QgsWelcomePageItemsModel::RecentProjectData& recentProject, mRecentProjects )
   {
-    QAction* action = mRecentProjectsMenu->addAction( QString( "%1 (%2)" ).arg( recentProject.title ).arg( recentProject.path ) );
+    QAction* action;
+    if ( recentProject.title != recentProject.path )
+    {
+      action = mRecentProjectsMenu->addAction( QString( "%1 (%2)" ).arg( recentProject.title ).arg( recentProject.path ) );
+    }
+    else
+    {
+      action = mRecentProjectsMenu->addAction( QString( "%1" ).arg( recentProject.path ) );
+    }
     action->setEnabled( QFile::exists(( recentProject.path ) ) );
     action->setData( recentProject.path );
   }


### PR DESCRIPTION
At the moment, the recent project menu (under the File menu) adds the path twice when a project title is missing. This pull request fixes that by not adding the project title if it is equal to the project path.

Before:
![check](https://cloud.githubusercontent.com/assets/1728657/9677869/22a93aa2-5309-11e5-95aa-7b43b5afb683.png)

After:
![fixed](https://cloud.githubusercontent.com/assets/1728657/9677870/286ee748-5309-11e5-9f5b-7f050f928636.png)
