### PR TITLE
[welcome page] use item delegate to add html style to labels

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -50,6 +50,7 @@ SET(QGIS_APP_SRCS
   qgsmapmouseevent.cpp
   qgssavestyletodbdialog.cpp
   qgsguivectorlayertools.cpp
+  qgswelcomepageitemdelegate.cpp
   qgswelcomepageitemsmodel.cpp
   qgswelcomepage.cpp
   qgsversioninfo.cpp
@@ -214,6 +215,7 @@ SET (QGIS_APP_MOC_HDRS
   qgsshortcutsmanager.h
   qgsapplayertreeviewmenuprovider.h
   qgsguivectorlayertools.h
+  qgswelcomepageitemdelegate.h
   qgswelcomepageitemsmodel.h
   qgswelcomepage.h
   qgsversioninfo.h

--- a/src/app/qgswelcomepage.cpp
+++ b/src/app/qgswelcomepage.cpp
@@ -14,6 +14,7 @@
  ***************************************************************************/
 
 #include "qgswelcomepage.h"
+#include "qgswelcomepageitemdelegate.h"
 #include "qgsproject.h"
 #include "qgisapp.h"
 #include "qgsversioninfo.h"
@@ -45,6 +46,7 @@ QgsWelcomePage::QgsWelcomePage( QWidget* parent )
   QListView* recentProjectsListView = new QListView();
   mModel = new QgsWelcomePageItemsModel( recentProjectsListView );
   recentProjectsListView->setModel( mModel );
+  recentProjectsListView->setItemDelegate( new QgsWelcomePageItemDelegate( recentProjectsListView ) );
   recentProjectsListView->setStyleSheet( "QListView::item {"
                                          "  margin-top: 5px;"
                                          "  margin-bottom: 5px;"

--- a/src/app/qgswelcomepage.h
+++ b/src/app/qgswelcomepage.h
@@ -21,7 +21,6 @@
 #include <QLabel>
 
 #include "qgswelcomepageitemsmodel.h"
-#include "qgswelcomepageitemdelegate.h"
 
 class QgsVersionInfo;
 

--- a/src/app/qgswelcomepageitemdelegate.cpp
+++ b/src/app/qgswelcomepageitemdelegate.cpp
@@ -1,0 +1,52 @@
+/***************************************************************************
+
+               ----------------------------------------------------
+              date                 : 17.8.2015
+              copyright            : (C) 2015 by Matthias Kuhn
+              email                : matthias (at) opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgswelcomepageitemdelegate.h"
+#include "qgsmessagelog.h"
+
+#include <QApplication>
+#include <QPainter>
+#include <QTextDocument>
+
+QgsWelcomePageItemDelegate::QgsWelcomePageItemDelegate( QObject * parent ) : QStyledItemDelegate( parent ) {}
+
+void QgsWelcomePageItemDelegate::paint(QPainter* painter, const QStyleOptionViewItem & option, const QModelIndex &index) const
+{
+    painter->save();
+    
+    QStyle *style = QApplication::style();
+    style->drawPrimitive( QStyle::PE_PanelItemViewItem, &option, painter, NULL );
+    
+    QTextDocument doc;
+    doc.setHtml( index.data( Qt::DisplayRole ).toString() );
+    doc.setTextWidth( 800 );
+
+    painter->translate( option.rect.left(), option.rect.top() );
+    QRect clip( 0, 0, option.rect.width(), option.rect.height() );
+    doc.drawContents( painter, clip );
+
+    painter->restore();
+}
+
+QSize QgsWelcomePageItemDelegate::sizeHint ( const QStyleOptionViewItem & option, const QModelIndex & index ) const
+{    
+    QgsMessageLog::logMessage( QString( "width: %1" ).arg( index.data( Qt::DisplayRole ).toString() ) );
+    
+    QTextDocument doc;
+    doc.setHtml( index.data( Qt::DisplayRole ).toString() );
+    doc.setTextWidth( 800 );
+    return QSize( option.rect.width(), doc.size().height() );
+}
+

--- a/src/app/qgswelcomepageitemdelegate.cpp
+++ b/src/app/qgswelcomepageitemdelegate.cpp
@@ -42,7 +42,7 @@ void QgsWelcomePageItemDelegate::paint(QPainter* painter, const QStyleOptionView
 
 QSize QgsWelcomePageItemDelegate::sizeHint ( const QStyleOptionViewItem & option, const QModelIndex & index ) const
 {    
-    QgsMessageLog::logMessage( QString( "width: %1" ).arg( index.data( Qt::DisplayRole ).toString() ) );
+    QgsMessageLog::logMessage( QString( "width: %1" ).arg( option.rect.width() ) );
     
     QTextDocument doc;
     doc.setHtml( index.data( Qt::DisplayRole ).toString() );

--- a/src/app/qgswelcomepageitemdelegate.h
+++ b/src/app/qgswelcomepageitemdelegate.h
@@ -1,7 +1,7 @@
 /***************************************************************************
 
                ----------------------------------------------------
-              date                 : 18.8.2015
+              date                 : 17.8.2015
               copyright            : (C) 2015 by Matthias Kuhn
               email                : matthias (at) opengis.ch
  ***************************************************************************
@@ -13,38 +13,19 @@
  *                                                                         *
  ***************************************************************************/
 
-#ifndef QGSWELCOMEDIALOG_H
-#define QGSWELCOMEDIALOG_H
+#ifndef QGSWELCOMEPAGEITEMDELEGATE_H
+#define QGSWELCOMEPAGEITEMDELEGATE_H
 
-#include <QTabWidget>
-#include <QWidget>
-#include <QLabel>
+#include <QStyledItemDelegate>
 
-#include "qgswelcomepageitemsmodel.h"
-#include "qgswelcomepageitemdelegate.h"
-
-class QgsVersionInfo;
-
-class QgsWelcomePage : public QTabWidget
+class QgsWelcomePageItemDelegate : public QStyledItemDelegate
 {
     Q_OBJECT
 
   public:
-    QgsWelcomePage( QWidget* parent = 0 );
-
-    ~QgsWelcomePage();
-
-    void setRecentProjects( const QList<QgsWelcomePageItemsModel::RecentProjectData>& recentProjects );
-
-  private slots:
-    void itemActivated( const QModelIndex& index );
-    void versionInfoReceived();
-    void whatsNewLinkClicked( const QUrl& url );
-
-  private:
-    QgsWelcomePageItemsModel* mModel;
-    QLabel* mVersionInformation;
-    QgsVersionInfo* mVersionInfo;
+    QgsWelcomePageItemDelegate( QObject * parent = 0 );
+    void paint ( QPainter * painter, const QStyleOptionViewItem & option, const QModelIndex & index ) const override;
+    QSize sizeHint ( const QStyleOptionViewItem & option, const QModelIndex & index ) const override;
 };
 
-#endif // QGSWELCOMEDIALOG_H
+#endif // QGSWELCOMEPAGEITEMDELEGATE_H

--- a/src/app/qgswelcomepageitemsmodel.cpp
+++ b/src/app/qgswelcomepageitemsmodel.cpp
@@ -14,6 +14,7 @@
  ***************************************************************************/
 
 #include "qgswelcomepageitemsmodel.h"
+#include "qgsmessagelog.h"
 
 #include <QPixmap>
 #include <QFile>
@@ -44,10 +45,23 @@ QVariant QgsWelcomePageItemsModel::data( const QModelIndex& index, int role ) co
   switch ( role )
   {
     case Qt::DisplayRole:
-      return mRecentProjects.at( index.row() ).title;
+      if ( mRecentProjects.at( index.row() ).previewImagePath != "" )
+      {
+      return QString( "<table style='border:0;' cellpadding='0'><tr>"
+                      "<td style='padding:6px;background-color:#dddddd;'><img src='%1'></td>"
+                      "<td style='padding:10px 10px 10px 10px;'><span style='font-size:18px;font-weight:bold;'>%2</span><br>%3</td"
+                      "</tr></table>" ).arg( mRecentProjects.at( index.row() ).previewImagePath ).arg( mRecentProjects.at( index.row() ).title != mRecentProjects.at( index.row() ).path ? mRecentProjects.at( index.row() ).title : QString( "- untitled -" ) ).arg( mRecentProjects.at( index.row() ).path );
+      }
+      else
+      {
+      return QString( "<table style='border:0;' cellpadding='5'><tr>"
+                      "<td width='262' height='170' style='padding:6px;background-color:#dddddd;'></td>"
+                      "<td style='padding:10px 10px 10px 10px;'><span style='font-size:18px;font-weight:bold;'>%1</span><br>%2</td"
+                      "</tr></table>" ).arg( mRecentProjects.at( index.row() ).title != mRecentProjects.at( index.row() ).path ? mRecentProjects.at( index.row() ).title : QString( "- untitled -" ) ).arg( mRecentProjects.at( index.row() ).path );
+      }
       break;
 
-    case Qt::DecorationRole:
+    /*case Qt::DecorationRole:
     {
       QImage thumbnail( mRecentProjects.at( index.row() ).previewImagePath );
       if ( thumbnail.isNull() )
@@ -67,7 +81,7 @@ QVariant QgsWelcomePageItemsModel::data( const QModelIndex& index, int role ) co
 
       return QPixmap::fromImage( previewImage );
       break;
-    }
+    }*/
 
     case Qt::ToolTipRole:
       return mRecentProjects.at( index.row() ).path;


### PR DESCRIPTION
@m-kuhn , @nyalldawson , @NathanW2 , please excuse the pitiful state of this branch. It's not meant to be committed, but simply to brainstorm about the possibility of adding html styling to the welcome page's recent project list.

Using this branch, the home page looks like this:
![v0](https://cloud.githubusercontent.com/assets/1728657/9702563/162b5c02-548e-11e5-9020-b6efa0b1ade3.png)

There's lots of unfinished stuff in there (e.g., different text color for disabled items, translatable "untitled" if we decide to label untitled projects as such, etc.). But as a general question, is it worth investing energy in improving and cleaning up?
