### PR TITLE
[welcome page] add delegate to style display

### DIFF
--- a/src/app/qgswelcomepage.cpp
+++ b/src/app/qgswelcomepage.cpp
@@ -45,20 +45,7 @@ QgsWelcomePage::QgsWelcomePage( QWidget* parent )
   QListView* recentProjectsListView = new QListView();
   mModel = new QgsWelcomePageItemsModel( recentProjectsListView );
   recentProjectsListView->setModel( mModel );
-  recentProjectsListView->setStyleSheet( "QListView::item {"
-                                         "  margin-top: 5px;"
-                                         "  margin-bottom: 5px;"
-                                         "  margin-left: 15px;"
-                                         "  margin-right: 15px;"
-                                         "  border-width: 1px;"
-                                         "  border-color: #999;"
-                                         "  border-radius: 9px;"
-                                         "  background: #eee;"
-                                         "  padding: 10px;"
-                                         "}"
-                                         "QListView::item:selected:active {"
-                                         "  background: #aaaaaa;"
-                                         "}" );
+  recentProjectsListView->setItemDelegate( new QgsWelcomePageItemDelegate( recentProjectsListView ) );
 
   recentProjctsContainer->layout()->addWidget( recentProjectsListView );
 

--- a/src/app/qgswelcomepageitemsmodel.h
+++ b/src/app/qgswelcomepageitemsmodel.h
@@ -18,6 +18,17 @@
 
 #include <QAbstractListModel>
 #include <QStringList>
+#include <QStyledItemDelegate>
+
+class QgsWelcomePageItemDelegate : public QStyledItemDelegate
+{
+    Q_OBJECT
+
+  public:
+    QgsWelcomePageItemDelegate( QObject * parent = 0 );
+    void paint( QPainter * painter, const QStyleOptionViewItem & option, const QModelIndex & index ) const override;
+    QSize sizeHint( const QStyleOptionViewItem & option, const QModelIndex & index ) const override;
+};
 
 class QgsWelcomePageItemsModel : public QAbstractListModel
 {


### PR DESCRIPTION
This pull request adds an item delegate to the recent project's list view in order to style the project title and path display.

This is how it looks like:
![v0](https://cloud.githubusercontent.com/assets/1728657/9708612/a491af5e-5548-11e5-9460-24fb8a8537e0.png)

Hope this is another step in the right direction.
