### PR TITLE
[welcome page] fix sorting of recent projects on startup

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1174,12 +1174,20 @@ void QgisApp::readSettings()
   settings.endGroup();
 
   settings.beginGroup( "/UI/recentProjects" );
-  QStringList projectKeys = settings.childGroups();
+  QStringList projectKeysList = settings.childGroups();
 
-  Q_FOREACH ( const QString& key, projectKeys )
+  //convert list to int values to obtain proper order
+  QList<int> projectKeys;
+  Q_FOREACH ( const QString& key, projectKeysList )
+  {
+    projectKeys.append( key.toInt() );
+  }
+  qSort( projectKeys );
+
+  Q_FOREACH ( const int& key, projectKeys )
   {
     QgsWelcomePageItemsModel::RecentProjectData data;
-    settings.beginGroup( key );
+    settings.beginGroup( QString::number( key ) );
     data.title = settings.value( "title" ).toString();
     data.path = settings.value( "path" ).toString();
     data.previewImagePath = settings.value( "previewImage" ).toString();
@@ -10759,4 +10767,3 @@ LONG WINAPI QgisApp::qgisCrashDump( struct _EXCEPTION_POINTERS *ExceptionInfo )
   return EXCEPTION_EXECUTE_HANDLER;
 }
 #endif
-


### PR DESCRIPTION
When @NathanW2 recently increased number of recent projects saved to 10 (thanks for that!), it resulted in a sorting issue upon QGIS startup whereas the keys, retrieved as strings, would end up sorted as follow: "1", "10", "2", "3", etc.

This pull request converts the keys to int values and sort those to obtain the proper ordering.
