### PR TITLE
[recent project] make use of baseName() in the file menu too to be consistent the welcome page display

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2764,15 +2764,7 @@ void QgisApp::updateRecentProjectPaths()
 
   Q_FOREACH ( const QgsWelcomePageItemsModel::RecentProjectData& recentProject, mRecentProjects )
   {
-    QAction* action;
-    if ( recentProject.title != recentProject.path )
-    {
-      action = mRecentProjectsMenu->addAction( QString( "%1 (%2)" ).arg( recentProject.title ).arg( recentProject.path ) );
-    }
-    else
-    {
-      action = mRecentProjectsMenu->addAction( QString( "%1" ).arg( recentProject.path ) );
-    }
+    QAction* action = mRecentProjectsMenu->addAction( QString( "%1 (%2)" ).arg( recentProject.title != recentProject.path ? recentProject.title : QFileInfo( recentProject.path ).baseName() ).arg( recentProject.path ) );
     action->setEnabled( QFile::exists(( recentProject.path ) ) );
     action->setData( recentProject.path );
   }


### PR DESCRIPTION
@m-kuhn following the use of baseName() for empty titles in the welcome page, I think we should do the same in the recent project list under the file menu.
