### PR TITLE
Fix add part tool doesn't work

### DIFF
--- a/src/core/qgsvectorlayereditutils.cpp
+++ b/src/core/qgsvectorlayereditutils.cpp
@@ -163,6 +163,8 @@ int QgsVectorLayerEditUtils::addPart( const QList<QgsPoint> &points, QgsFeatureI
     geometry = *f.geometry();
   }
 
+  geometry.convertToMultiType();
+
   int errorCode = geometry.addPart( points, L->geometryType() );
   if ( errorCode == 0 )
   {
@@ -186,6 +188,8 @@ int QgsVectorLayerEditUtils::addPart( QgsCurveV2* ring, QgsFeatureId featureId )
 
     geometry = *f.geometry();
   }
+
+  geometry.convertToMultiType();
 
   int errorCode = geometry.addPart( ring );
   if ( errorCode == 0 )


### PR DESCRIPTION
Regardless of the underlying layer geometry type, the tool was always reporting that geometries were not multipart. Now geometries are always converted to multipart when trying to add a part.
