### PR TITLE
Add $vertices support in expression evaluator

### DIFF
--- a/resources/function_help/json/num_points
+++ b/resources/function_help/json/num_points
@@ -1,0 +1,7 @@
+{
+  "function": "num_points",
+  "description": "Returns the number of vertices in a geometry.",
+  "arguments": [ {"arg":"geom","description":"a geometry"}],
+  "examples": [ { "expression":"num_points($geometry)", "returns":"number of vertices in $geometry"}]
+}
+

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -1265,6 +1265,11 @@ static QVariant fcnGeomPerimeter( const QVariantList&, const QgsExpressionContex
   QgsDistanceArea* calc = parent->geomCalculator();
   return QVariant( calc->measurePerimeter( f.constGeometry() ) );
 }
+static QVariant fcnGeomNumPoints( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
+{
+  QgsGeometry geom = getGeometry( values.at( 0 ), parent );
+  return QVariant( geom.geometry()->nCoordinates() );
+}
 
 static QVariant fcnBounds( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
@@ -1912,7 +1917,7 @@ const QStringList& QgsExpression::BuiltinFunctions()
     << "color_hsl" << "color_hsla" << "color_hsv" << "color_hsva"
     << "color_cymk" << "color_cymka"
     << "xat" << "yat" << "$area"
-    << "$length" << "$perimeter" << "$x" << "$y"
+    << "$length" << "$perimeter" << "$x" << "$y" << "num_points"
     << "x_at" << "xat" << "y_at" << "yat" << "x_min" << "xmin" << "x_max" << "xmax"
     << "y_min" << "ymin" << "y_max" << "ymax" << "geom_from_wkt" << "geomFromWKT"
     << "geom_from_gml" << "geomFromGML" << "intersects_bbox" << "bbox"
@@ -2038,6 +2043,7 @@ const QList<QgsExpression::Function*>& QgsExpression::Functions()
     << new StaticFunction( "buffer", -1, fcnBuffer, "GeometryGroup" )
     << new StaticFunction( "centroid", 1, fcnCentroid, "GeometryGroup" )
     << new StaticFunction( "bounds", 1, fcnBounds, "GeometryGroup", "", true )
+    << new StaticFunction( "num_points", 1, fcnGeomNumPoints, "GeometryGroup", "", true )
     << new StaticFunction( "bounds_width", 1, fcnBoundsWidth, "GeometryGroup", "", true )
     << new StaticFunction( "bounds_height", 1, fcnBoundsHeight, "GeometryGroup", "", true )
     << new StaticFunction( "convex_hull", 1, fcnConvexHull, "GeometryGroup", QString(), false, QStringList(), false, QStringList() << "convexHull" )

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -396,6 +396,9 @@ class TestQgsExpression: public QObject
       QTest::newRow( "double to text" ) << "tostring(1.23)" << false << QVariant( "1.23" );
       QTest::newRow( "null to text" ) << "tostring(null)" << false << QVariant();
 
+      // geometry functions
+      QTest::newRow( "num_points" ) << "num_points(geom_from_wkt('GEOMETRYCOLLECTION(LINESTRING(0 0, 1 0),POINT(6 5))'))" << false << QVariant( 3 );
+
       // string functions
       QTest::newRow( "lower" ) << "lower('HeLLo')" << false << QVariant( "hello" );
       QTest::newRow( "upper" ) << "upper('HeLLo')" << false << QVariant( "HELLO" );
@@ -934,6 +937,11 @@ class TestQgsExpression: public QObject
 
       exp9.evaluate( &context );
       QCOMPARE( vYMax.toDouble(), 6.0 );
+
+      QgsExpression exp10( "num_points($geometry)" );
+      QVariant vVertices = exp10.evaluate( &fPolygon );
+      QCOMPARE( vVertices.toInt(), 5 );
+
 
       Q_NOWARN_DEPRECATED_POP
 


### PR DESCRIPTION
@nyalldawson I see you recently marked those symbols as deprecated, could you please check I'm not walking on a dead road here ? Thank you.
