### PR TITLE
postgres provider: allow to load layers with polyhedral surfaces or TINs

### DIFF
--- a/src/core/geometry/qgsabstractgeometryv2.cpp
+++ b/src/core/geometry/qgsabstractgeometryv2.cpp
@@ -55,12 +55,12 @@ QgsRectangle QgsAbstractGeometryV2::boundingBox() const
 
 bool QgsAbstractGeometryV2::is3D() const
 {
-  return(( mWkbType >= 1001 && mWkbType <= 1012 ) || ( mWkbType > 3000 || mWkbType & 0x80000000 ) );
+  return(( mWkbType >= 1001 && mWkbType <= 1017 ) || ( mWkbType > 3000 || mWkbType & 0x80000000 ) );
 }
 
 bool QgsAbstractGeometryV2::isMeasure() const
 {
-  return ( mWkbType >= 2001 && mWkbType <= 3012 );
+  return ( mWkbType >= 2001 && mWkbType <= 3017 );
 }
 
 #if 0

--- a/tests/testdata/provider/testdata.sql
+++ b/tests/testdata/provider/testdata.sql
@@ -18,12 +18,11 @@ SET client_min_messages = warning;
 -- Name: qgis_test; Type: SCHEMA; Schema: -; Owner: postgres
 --
 
+CREATE EXTENSION IF NOT EXISTS postgis;
+
+DROP SCHEMA IF EXISTS qgis_test CASCADE;
 CREATE SCHEMA qgis_test;
 
-
-ALTER SCHEMA qgis_test OWNER TO postgres;
-
-SET search_path = qgis_test, pg_catalog;
 
 SET default_tablespace = '';
 
@@ -34,7 +33,7 @@ SET default_with_oids = false;
 -- Name: someData; Type: TABLE; Schema: qgis_test; Owner: postgres; Tablespace: 
 --
 
-CREATE TABLE "someData" (
+CREATE TABLE qgis_test."someData" (
     pk SERIAL NOT NULL,
     cnt integer,
     name text DEFAULT 'qgis',
@@ -42,15 +41,13 @@ CREATE TABLE "someData" (
 );
 
 
-ALTER TABLE qgis_test."someData" OWNER TO postgres;
-
 --
 -- TOC entry 4068 (class 0 OID 377761)
 -- Dependencies: 171
 -- Data for Name: someData; Type: TABLE DATA; Schema: qgis_test; Owner: postgres
 --
 
-COPY "someData" (pk, cnt, name, geom) FROM stdin;
+COPY qgis_test."someData" (pk, cnt, name, geom) FROM stdin;
 5	-200	\N	0101000020E61000001D5A643BDFC751C01F85EB51B88E5340
 3	300	Pear	\N
 1	100	Orange	0101000020E61000006891ED7C3F9551C085EB51B81E955040
@@ -64,7 +61,7 @@ COPY "someData" (pk, cnt, name, geom) FROM stdin;
 -- Name: someData_pkey; Type: CONSTRAINT; Schema: qgis_test; Owner: postgres; Tablespace: 
 --
 
-ALTER TABLE ONLY "someData"
+ALTER TABLE ONLY qgis_test."someData"
     ADD CONSTRAINT "someData_pkey" PRIMARY KEY (pk);
 
 
@@ -74,3 +71,119 @@ ALTER TABLE ONLY "someData"
 -- PostgreSQL database dump complete
 --
 
+CREATE TABLE qgis_test.p2d(
+       id int,
+       geom Geometry(Polygon,4326)
+);
+INSERT INTO qgis_test.p2d values (1, 'srid=4326;Polygon((0 0,1 0,1 1,0 1,0 0))'::geometry);
+
+CREATE TABLE qgis_test.p3d(
+       id int,
+       geom Geometry(PolygonZ,4326)
+);
+INSERT INTO qgis_test.p3d values (1, 'srid=4326;Polygon((0 0 0,1 0 0,1 1 0,0 1 0,0 0 0))'::geometry);
+
+CREATE TABLE qgis_test.triangle2d(
+       id int,
+       geom Geometry(Triangle,4326)
+);
+
+INSERT INTO qgis_test.triangle2d values (1, 'srid=4326;triangle((0 0,1 0,1 1,0 0))'::geometry);
+
+CREATE TABLE qgis_test.triangle3d(
+       id int,
+       geom Geometry(TriangleZ,4326)
+);
+
+INSERT INTO qgis_test.triangle3d values (1, 'srid=4326;triangle((0 0 0,1 0 0,1 1 0,0 0 0))'::geometry);
+
+CREATE TABLE qgis_test.tin2d(
+       id int,
+       geom Geometry(TIN,4326)
+);
+
+INSERT INTO qgis_test.tin2d values (1, 'srid=4326;TIN(((0 0,1 0,1 1,0 0)),((0 0,0 1,1 1,0 0)))'::geometry);
+
+CREATE TABLE qgis_test.tin3d(
+       id int,
+       geom Geometry(TINZ,4326)
+);
+
+INSERT INTO qgis_test.tin3d values (1, 'srid=4326;TIN(((0 0 0,1 0 0,1 1 0,0 0 0)),((0 0 0,0 1 0,1 1 0,0 0 0)))'::geometry);
+
+CREATE TABLE qgis_test.ps2d(
+       id int,
+       geom Geometry(PolyhedralSurface,4326)
+);
+
+INSERT INTO qgis_test.ps2d values (1, 'srid=4326;PolyhedralSurface(((0 0,1 0,1 1,0 1,0 0)))'::geometry);
+
+CREATE TABLE qgis_test.ps3d(
+       id int,
+       geom Geometry(PolyhedralSurfaceZ,4326)
+);
+
+INSERT INTO qgis_test.ps3d values (1, 'srid=4326;PolyhedralSurface Z(((0 0 0,0 1 0,1 1 0,1 0 0,0 0 0)),((0 0 1,1 0 1,1 1 1,0 1 1,0 0 1)),((0 0 0,0 0 1,0 1 1,0 1 0,0 0 0)),((0 1 0,0 1 1,1 1 1,1 1 0,0 1 0)),((1 1 0,1 1 1,1 0 1,1 0 0,1 1 0)),((1 0 0,1 0 1,0 0 1,0 0 0,1 0 0)))'::geometry);
+
+CREATE TABLE qgis_test.mp3d(
+       id int,
+       geom Geometry(MultipolygonZ,4326)
+);
+
+INSERT INTO qgis_test.mp3d values (1, 'srid=4326;Multipolygon Z(((0 0 0,0 1 0,1 1 0,1 0 0,0 0 0)),((0 0 1,1 0 1,1 1 1,0 1 1,0 0 1)),((0 0 0,0 0 1,0 1 1,0 1 0,0 0 0)),((0 1 0,0 1 1,1 1 1,1 1 0,0 1 0)),((1 1 0,1 1 1,1 0 1,1 0 0,1 1 0)),((1 0 0,1 0 1,0 0 1,0 0 0,1 0 0)))'::geometry);
+
+CREATE TABLE qgis_test.pt2d(
+       id int,
+       geom Geometry(Point,4326)
+);
+
+INSERT INTO qgis_test.pt2d values (1, 'srid=4326;Point(0 0)'::geometry);
+
+CREATE TABLE qgis_test.pt3d(
+       id int,
+       geom Geometry(PointZ,4326)
+);
+
+INSERT INTO qgis_test.pt3d values (1, 'srid=4326;PointZ(0 0 0)'::geometry);
+
+CREATE TABLE qgis_test.ls2d(
+       id int,
+       geom Geometry(LineString,4326)
+);
+
+INSERT INTO qgis_test.ls2d values (1, 'srid=4326;Linestring(0 0, 1 1)'::geometry);
+
+CREATE TABLE qgis_test.ls3d(
+       id int,
+       geom Geometry(LineStringZ,4326)
+);
+
+INSERT INTO qgis_test.ls3d values (1, 'srid=4326;Linestring(0 0 0, 1 1 1)'::geometry);
+
+CREATE TABLE qgis_test.mpt2d(
+       id int,
+       geom Geometry(MultiPoint,4326)
+);
+
+INSERT INTO qgis_test.mpt2d values (1, 'srid=4326;MultiPoint((0 0),(1 1))'::geometry);
+
+CREATE TABLE qgis_test.mpt3d(
+       id int,
+       geom Geometry(MultiPointZ,4326)
+);
+
+INSERT INTO qgis_test.mpt3d values (1, 'srid=4326;MultiPoint((0 0 0),(1 1 1))'::geometry);
+
+CREATE TABLE qgis_test.mls2d(
+       id int,
+       geom Geometry(MultiLineString,4326)
+);
+
+INSERT INTO qgis_test.mls2d values (1, 'srid=4326;MultiLineString((0 0, 1 1),(2 2, 3 3))'::geometry);
+
+CREATE TABLE qgis_test.mls3d(
+       id int,
+       geom Geometry(MultiLineStringZ,4326)
+);
+
+INSERT INTO qgis_test.mls3d values (1, 'srid=4326;MultiLineString((0 0 0, 1 1 1),(2 2 2, 3 3 3))'::geometry);


### PR DESCRIPTION
This restores a hack that was introduced prior to geometry refactoring in order to be able to load TIN and polyhedral surfaces layers in QGIS (in 2D).

@jef-n @mhugent just to be sure it does not break anything else ...

Would there be any way to setup a postgis provider unit tests ?
