### PR TITLE
Add some pg table comments handling

### DIFF
--- a/src/app/qgsbrowserdockwidget.cpp
+++ b/src/app/qgsbrowserdockwidget.cpp
@@ -200,7 +200,10 @@ class QgsBrowserTreeFilterProxyModel : public QSortFilterProxyModel
       if ( mFilter == "" || !mModel ) return true;
 
       QModelIndex sourceIndex = mModel->index( sourceRow, 0, sourceParent );
-      return filterAcceptsItem( sourceIndex ) || filterAcceptsAncestor( sourceIndex ) || filterAcceptsDescendant( sourceIndex );
+      // also look into the comment column
+      QModelIndex commentIndex = mModel->index( sourceRow, 1, sourceParent );
+      return filterAcceptsItem( sourceIndex ) || filterAcceptsAncestor( sourceIndex ) || filterAcceptsDescendant( sourceIndex ) ||
+        filterAcceptsItem( commentIndex ) || filterAcceptsAncestor( commentIndex ) || filterAcceptsDescendant( commentIndex );
     }
 
     // returns true if at least one ancestor is accepted by filter
@@ -228,6 +231,11 @@ class QgsBrowserTreeFilterProxyModel : public QSortFilterProxyModel
       {
         QgsDebugMsg( QString( "i = %1" ).arg( i ) );
         QModelIndex sourceChildIndex = mModel->index( i, 0, sourceIndex );
+        if ( filterAcceptsItem( sourceChildIndex ) )
+          return true;
+        if ( filterAcceptsDescendant( sourceChildIndex ) )
+          return true;
+        sourceChildIndex = mModel->index( i, 1, sourceIndex );
         if ( filterAcceptsItem( sourceChildIndex ) )
           return true;
         if ( filterAcceptsDescendant( sourceChildIndex ) )
@@ -532,6 +540,7 @@ void QgsBrowserDockWidget::showEvent( QShowEvent * e )
     // provide a horizontal scroll bar instead of using ellipse (...) for longer items
     mBrowserView->setTextElideMode( Qt::ElideNone );
     mBrowserView->header()->setResizeMode( 0, QHeaderView::ResizeToContents );
+    mBrowserView->header()->setResizeMode( 1, QHeaderView::ResizeToContents );
     mBrowserView->header()->setStretchLastSection( false );
 
     // selectionModel is created when model is set on tree

--- a/src/core/qgsbrowsermodel.cpp
+++ b/src/core/qgsbrowsermodel.cpp
@@ -202,7 +202,16 @@ QVariant QgsBrowserModel::data( const QModelIndex &index, int role ) const
   }
   else if ( role == Qt::DisplayRole )
   {
-    return item->name();
+    if ( index.column() == 0 )
+    {
+      return item->name();
+    }
+    if ( item->type() == QgsDataItem::Layer )
+    {
+      QgsLayerItem* lyrItem = qobject_cast<QgsLayerItem*>(item);
+      return lyrItem->comments();
+    }
+    return "";
   }
   else if ( role == Qt::ToolTipRole )
   {

--- a/src/core/qgsdataitem.h
+++ b/src/core/qgsdataitem.h
@@ -305,13 +305,13 @@ class CORE_EXPORT QgsLayerItem : public QgsDataItem
 
     // --- New virtual methods for layer item derived classes ---
 
-    // Returns QgsMapLayer::LayerType
+    /** Returns QgsMapLayer::LayerType */
     QgsMapLayer::LayerType mapLayerType();
 
-    // Returns layer uri or empty string if layer cannot be created
+    /** Returns layer uri or empty string if layer cannot be created */
     QString uri() { return mUri; }
 
-    // Returns provider key
+    /** Returns provider key */
     QString providerKey() { return mProviderKey; }
 
     /** Returns the supported CRS
@@ -324,12 +324,22 @@ class CORE_EXPORT QgsLayerItem : public QgsDataItem
      */
     QStringList supportedFormats() { return mSupportFormats; }
 
+    /** Returns comments of the layer
+     * @note added in 2.12
+     */
+    virtual QString comments() const { return ""; }
+
   protected:
 
+    /** the provider key */
     QString mProviderKey;
+    /** the URI */
     QString mUri;
+    /** the layer type */
     LayerType mLayerType;
+    /** the list of supported CRS */
     QStringList mSupportedCRS;
+    /** the list of supported formats */
     QStringList mSupportFormats;
 
   public:
@@ -340,6 +350,7 @@ class CORE_EXPORT QgsLayerItem : public QgsDataItem
     static const QIcon &iconRaster();
     static const QIcon &iconDefault();
 
+    /** returns the layer name */
     virtual QString layerName() const { return name(); }
 };
 

--- a/src/providers/postgres/qgspgsourceselect.cpp
+++ b/src/providers/postgres/qgspgsourceselect.cpp
@@ -235,6 +235,7 @@ QgsPgSourceSelect::QgsPgSourceSelect( QWidget *parent, Qt::WindowFlags fl, bool 
   mSearchColumnComboBox->addItem( tr( "All" ) );
   mSearchColumnComboBox->addItem( tr( "Schema" ) );
   mSearchColumnComboBox->addItem( tr( "Table" ) );
+  mSearchColumnComboBox->addItem( tr( "Comment" ) );
   mSearchColumnComboBox->addItem( tr( "Type" ) );
   mSearchColumnComboBox->addItem( tr( "Geometry column" ) );
   mSearchColumnComboBox->addItem( tr( "Feature id" ) );
@@ -410,6 +411,10 @@ void QgsPgSourceSelect::on_mSearchColumnComboBox_currentIndexChanged( const QStr
   else if ( text == tr( "Table" ) )
   {
     mProxyModel.setFilterKeyColumn( QgsPgTableModel::dbtmTable );
+  }
+  else if ( text == tr( "Comment" ) )
+  {
+    mProxyModel.setFilterKeyColumn( QgsPgTableModel::dbtmComment );
   }
   else if ( text == tr( "Type" ) )
   {

--- a/src/providers/postgres/qgspgtablemodel.cpp
+++ b/src/providers/postgres/qgspgtablemodel.cpp
@@ -28,6 +28,7 @@ QgsPgTableModel::QgsPgTableModel()
   QStringList headerLabels;
   headerLabels << tr( "Schema" );
   headerLabels << tr( "Table" );
+  headerLabels << tr( "Comment" );
   headerLabels << tr( "Column" );
   headerLabels << tr( "Data Type" );
   headerLabels << tr( "Spatial Type" );
@@ -83,6 +84,7 @@ void QgsPgTableModel::addTableEntry( const QgsPostgresLayerProperty& layerProper
     QStandardItem *geomTypeItem = new QStandardItem( QgsPostgresConn::displayStringForGeomType( layerProperty.geometryColType ) );
 
     QStandardItem *tableItem = new QStandardItem( layerProperty.tableName );
+    QStandardItem *commentItem = new QStandardItem( layerProperty.tableComment );
     QStandardItem *geomItem  = new QStandardItem( layerProperty.geometryColName );
     QStandardItem *sridItem  = new QStandardItem( wkbType != QGis::WKBNoGeometry ? QString::number( srid ) : "" );
     sridItem->setEditable( wkbType != QGis::WKBNoGeometry && srid == INT_MIN );
@@ -115,6 +117,7 @@ void QgsPgTableModel::addTableEntry( const QgsPostgresLayerProperty& layerProper
 
     childItemList << schemaNameItem;
     childItemList << tableItem;
+    childItemList << commentItem;
     childItemList << geomItem;
     childItemList << geomTypeItem;
     childItemList << typeItem;

--- a/src/providers/postgres/qgspgtablemodel.h
+++ b/src/providers/postgres/qgspgtablemodel.h
@@ -46,6 +46,7 @@ class QgsPgTableModel : public QStandardItemModel
     {
       dbtmSchema = 0,
       dbtmTable,
+      dbtmComment,
       dbtmGeomCol,
       dbtmGeomType, // Data type (geometry, geography, topogeometry, ...)
       dbtmType, // Spatial type (point, line, polygon, ...)

--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -435,7 +435,7 @@ bool QgsPostgresConn::getTableInfo( bool searchGeometryColumnsOnly, bool searchP
 
     // The following query returns only tables that exist and the user has SELECT privilege on.
     // Can't use regclass here because table must exist, else error occurs.
-    sql = QString( "SELECT %1,%2,%3,%4,%5,%6,c.relkind"
+    sql = QString( "SELECT %1,%2,%3,%4,%5,%6,c.relkind,obj_description(c.oid)"
                    " FROM %7 l,pg_class c,pg_namespace n"
                    " WHERE c.relname=%1"
                    " AND %2=n.nspname"
@@ -471,6 +471,7 @@ bool QgsPostgresConn::getTableInfo( bool searchGeometryColumnsOnly, bool searchP
       int dim = result.PQgetvalue( idx, 5 ).toInt();
       QString relkind = result.PQgetvalue( idx, 6 );
       bool isView = relkind == "v" || relkind == "m";
+      QString comment = result.PQgetvalue( idx, 7 );
 
       int srid = ssrid.isEmpty() ? INT_MIN : ssrid.toInt();
       if ( majorVersion() >= 2 && srid == 0 )
@@ -498,6 +499,7 @@ bool QgsPostgresConn::getTableInfo( bool searchGeometryColumnsOnly, bool searchP
       layerProperty.sql = "";
       layerProperty.relKind = relkind;
       layerProperty.isView = isView;
+      layerProperty.tableComment = comment;
       /*
        * force2d may get a false negative value
        * (dim == 2 but is not really constrained)
@@ -529,6 +531,7 @@ bool QgsPostgresConn::getTableInfo( bool searchGeometryColumnsOnly, bool searchP
                   ",a.attname"
                   ",c.relkind"
                   ",CASE WHEN t.typname IN ('geometry','geography','topogeometry') THEN t.typname ELSE b.typname END AS coltype"
+                  ",obj_description(c.oid)"
                   " FROM pg_attribute a"
                   " JOIN pg_class c ON c.oid=a.attrelid"
                   " JOIN pg_namespace n ON n.oid=c.relnamespace"
@@ -593,6 +596,7 @@ bool QgsPostgresConn::getTableInfo( bool searchGeometryColumnsOnly, bool searchP
       QString relkind    = result.PQgetvalue( i, 3 ); // relation kind
       QString coltype    = result.PQgetvalue( i, 4 ); // column type
       bool isView = relkind == "v" || relkind == "m";
+      QString comment    = result.PQgetvalue( i, 5 ); // table comment
 
       //QgsDebugMsg( QString( "%1.%2.%3: %4" ).arg( schemaName ).arg( tableName ).arg( column ).arg( relkind ) );
 
@@ -603,6 +607,7 @@ bool QgsPostgresConn::getTableInfo( bool searchGeometryColumnsOnly, bool searchP
       layerProperty.geometryColName = column;
       layerProperty.relKind = relkind;
       layerProperty.isView = isView;
+      layerProperty.tableComment = comment;
       if ( coltype == "geometry" )
       {
         layerProperty.geometryColType = sctGeometry;
@@ -644,6 +649,7 @@ bool QgsPostgresConn::getTableInfo( bool searchGeometryColumnsOnly, bool searchP
                   "pg_class.relname"
                   ",pg_namespace.nspname"
                   ",pg_class.relkind"
+                  ",obj_description(pg_class.oid)"
                   " FROM "
                   " pg_class"
                   ",pg_namespace"
@@ -677,6 +683,7 @@ bool QgsPostgresConn::getTableInfo( bool searchGeometryColumnsOnly, bool searchP
       QString schema  = result.PQgetvalue( i, 1 ); // nspname
       QString relkind = result.PQgetvalue( i, 2 ); // relation kind
       bool isView = relkind == "v" || relkind == "m";
+      QString comment = result.PQgetvalue( i, 3 ); // table comment
 
       //QgsDebugMsg( QString( "%1.%2: %3" ).arg( schema ).arg( table ).arg( relkind ) );
 
@@ -688,6 +695,7 @@ bool QgsPostgresConn::getTableInfo( bool searchGeometryColumnsOnly, bool searchP
       layerProperty.geometryColType = sctNone;
       layerProperty.relKind = relkind;
       layerProperty.isView = isView;
+      layerProperty.tableComment = comment;
 
       //check if we've already added this layer in some form
       bool alreadyFound = false;

--- a/src/providers/postgres/qgspostgresconn.h
+++ b/src/providers/postgres/qgspostgresconn.h
@@ -79,6 +79,7 @@ struct QgsPostgresLayerProperty
   bool                          force2d;
   QString                       relKind;
   bool                          isView;
+  QString                       tableComment;
 
 
   // TODO: rename this !
@@ -109,6 +110,7 @@ struct QgsPostgresLayerProperty
     property.force2d         = force2d;
     property.relKind         = relKind;
     property.isView          = isView;
+    property.tableComment    = tableComment;
 
     return property;
   }

--- a/src/providers/postgres/qgspostgresdataitems.cpp
+++ b/src/providers/postgres/qgspostgresdataitems.cpp
@@ -281,6 +281,11 @@ QgsPGLayerItem::QgsPGLayerItem( QgsDataItem* parent, QString name, QString path,
   Q_ASSERT( mLayerProperty.size() == 1 );
 }
 
+QString QgsPGLayerItem::comments() const
+{
+  return mLayerProperty.tableComment;
+}
+
 QgsPGLayerItem::~QgsPGLayerItem()
 {
 }
@@ -645,6 +650,10 @@ QgsPGLayerItem *QgsPGSchemaItem::createLayer( QgsPostgresLayerProperty layerProp
   //QgsDebugMsg( "schemaName = " + layerProperty.schemaName + " tableName = " + layerProperty.tableName + " geometryColName = " + layerProperty.geometryColName );
   QGis::WkbType wkbType = layerProperty.types[0];
   QString tip = tr( "%1 as %2 in %3" ).arg( layerProperty.geometryColName ).arg( QgsPostgresConn::displayStringForWkbType( wkbType ) ).arg( layerProperty.srids[0] );
+  if ( !layerProperty.tableComment.isEmpty() )
+  {
+    tip = layerProperty.tableComment + "\n" + tip;
+  }
 
   QgsLayerItem::LayerType layerType;
   QgsWKBTypes::GeometryType geomType = QgsWKBTypes::geometryType(( QgsWKBTypes::Type )wkbType );

--- a/src/providers/postgres/qgspostgresdataitems.h
+++ b/src/providers/postgres/qgspostgresdataitems.h
@@ -111,6 +111,9 @@ class QgsPGLayerItem : public QgsLayerItem
 
     virtual QList<QAction*> actions() override;
 
+    /** Returns comments of the layer */
+    virtual QString comments() const override;
+
   public slots:
     void deleteLayer();
     void renameLayer();


### PR DESCRIPTION
This adds a column "comment" to the postgres' source select widget, so that comments of a table is displayed and can be search for.
Similarly, comments are exposed in the browser so that the "filter" button can now search also into comments.
