### PR TITLE
Groups and layers embedding fix 

### DIFF
--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -1685,8 +1685,17 @@ bool QgsProject::createEmbeddedLayer( const QString &layerId, const QString &pro
         else
         {
           QDomElement dsElem = mapLayerElem.firstChildElement( "datasource" );
-          QString debug( QFileInfo( projectFilePath ).absolutePath() + "/" + dsElem.text() );
-          QFileInfo absoluteDs( QFileInfo( projectFilePath ).absolutePath() + "/" + dsElem.text() );
+          //QString debug( QFileInfo( projectFilePath ).absolutePath() + "/" + dsElem.text() );
+          QFileInfo absoluteDs;
+          if ( dsElem.text().contains( '|', Qt::CaseSensitive ) )
+          {
+            QStringList dsElemParts = dsElem.text().split( "|" );
+            absoluteDs = QFileInfo( projectFilePath ).absolutePath() + "/" + dsElemParts.at( 0 );
+          }
+          else
+          {
+            absoluteDs = QFileInfo( projectFilePath ).absolutePath() + "/" + dsElem.text();
+          }
           if ( absoluteDs.exists() )
           {
             dsElem.removeChild( dsElem.childNodes().at( 0 ) );


### PR DESCRIPTION
groups and layers are loaded into the project but with a wrong path. e.g a DXF file which may contain in the path an `|` symbol
