### PR TITLE
[welcome page] set normal & highlight text color for theme compatibility

### DIFF
--- a/src/app/qgswelcomepageitemsmodel.cpp
+++ b/src/app/qgswelcomepageitemsmodel.cpp
@@ -37,22 +37,26 @@ void QgsWelcomePageItemDelegate::paint( QPainter* painter, const QStyleOptionVie
 
   QTextDocument doc;
   QAbstractTextDocumentLayout::PaintContext ctx;
+  QStyleOptionViewItemV4 optionV4 = option;
 
   QColor color;
   if ( option.state & QStyle::State_Selected )
   {
     color = QColor( 255, 255, 255, 60 );
+    ctx.palette.setColor( QPalette::Text, optionV4.palette.color( QPalette::Active, QPalette::HighlightedText ) );
+
     QStyle *style = QApplication::style();
     style->drawPrimitive( QStyle::PE_PanelItemViewItem, &option, painter, NULL );
   }
   else if ( option.state & QStyle::State_Enabled )
   {
     color = QColor( 100, 100, 100, 30 );
+    ctx.palette.setColor( QPalette::Text, optionV4.palette.color( QPalette::Active, QPalette::Text ) );
   }
   else
   {
     color = QColor( 100, 100, 100, 30 );
-    ctx.palette.setColor( QPalette::Text, QColor( 150, 150, 150, 255 ) );
+    ctx.palette.setColor( QPalette::Text, optionV4.palette.color( QPalette::Disabled, QPalette::Text ) );
   }
 
   painter->setRenderHint( QPainter::Antialiasing );


### PR DESCRIPTION
This PR improves the welcome page coloring of text by relying on system / theme defined colors. Practically speaking, it improves:

1/ highlighted item text color, improving the look of the welcome page on a wider range of OS themes.
![style_text](https://cloud.githubusercontent.com/assets/1728657/10036322/2e4da8a4-61d0-11e5-9510-c042af6b6acc.png)

2/ text color under custom themes (feature implemented by @NathanW2 during this dev cycle)
![dark](https://cloud.githubusercontent.com/assets/1728657/10036333/42fc92ce-61d0-11e5-9af1-2fd69c82d728.png)
