### PR TITLE
Proposal to use data-defined button for diagram size

### DIFF
--- a/src/app/qgsdiagramproperties.h
+++ b/src/app/qgsdiagramproperties.h
@@ -19,9 +19,11 @@
 #define QGSDIAGRAMPROPERTIES_H
 
 #include <QDialog>
+#include <QScopedPointer>
 #include <ui_qgsdiagrampropertiesbase.h>
 
 class QgsVectorLayer;
+class QgsMarkerSymbolV2;
 
 class APP_EXPORT QgsDiagramProperties : public QWidget, private Ui::QgsDiagramPropertiesBase
 {
@@ -40,7 +42,6 @@ class APP_EXPORT QgsDiagramProperties : public QWidget, private Ui::QgsDiagramPr
     void on_mDiagramTypeComboBox_currentIndexChanged( int index );
     void on_mAddCategoryPushButton_clicked();
     void on_mAttributesTreeWidget_itemDoubleClicked( QTreeWidgetItem * item, int column );
-    void on_mFindMaximumValueButton_clicked();
     void on_mRemoveCategoryPushButton_clicked();
     void on_mDiagramFontButton_clicked();
     void on_mDiagramAttributesTreeWidget_itemDoubleClicked( QTreeWidgetItem * item, int column );
@@ -58,6 +59,7 @@ class APP_EXPORT QgsDiagramProperties : public QWidget, private Ui::QgsDiagramPr
 
     QString guessLegendText( const QString &expression );
 
+    QScopedPointer<QgsMarkerSymbolV2> mAssistantPreviewSymbol;
 };
 
 #endif // QGSDIAGRAMPROPERTIES_H

--- a/src/ui/qgsdiagrampropertiesbase.ui
+++ b/src/ui/qgsdiagrampropertiesbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>688</width>
-    <height>491</height>
+    <width>614</width>
+    <height>612</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout_8" stretch="0,0,1">
@@ -245,15 +245,6 @@
             </item>
             <item>
              <property name="text">
-              <string>Size</string>
-             </property>
-             <property name="icon">
-              <iconset resource="../../images/images.qrc">
-               <normaloff>:/images/themes/default/propertyicons/transparency.png</normaloff>:/images/themes/default/propertyicons/transparency.png</iconset>
-             </property>
-            </item>
-            <item>
-             <property name="text">
               <string>Placement</string>
              </property>
              <property name="toolTip">
@@ -306,7 +297,7 @@
           <item>
            <widget class="QStackedWidget" name="mDiagramStackedWidget">
             <property name="currentIndex">
-             <number>0</number>
+             <number>1</number>
             </property>
             <widget class="QWidget" name="mDiagramPage_Attributes">
              <layout class="QVBoxLayout" name="verticalLayout_9">
@@ -571,7 +562,7 @@
                 </property>
                </widget>
               </item>
-              <item>
+              <item row="5" column="0" colspan="4">
                <widget class="QScrollArea" name="scrollArea_4">
                 <property name="frameShape">
                  <enum>QFrame::NoFrame</enum>
@@ -588,28 +579,97 @@
                    <height>376</height>
                   </rect>
                  </property>
-                 <layout class="QVBoxLayout" name="verticalLayout">
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>6</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                  <item>
-                   <layout class="QGridLayout" name="gridLayout_7" rowstretch="0,0">
+                 <layout class="QGridLayout" name="gridLayout_17">
+                  <item row="0" column="0">
+                   <layout class="QGridLayout" name="gridLayout_20">
                     <item row="0" column="0">
-                     <widget class="QLabel" name="label_2">
+                     <widget class="QLabel" name="mSizeLabel">
                       <property name="text">
-                       <string>Format</string>
+                       <string>Size</string>
                       </property>
                      </widget>
                     </item>
+                    <item row="1" column="0">
+                     <widget class="QFrame" name="frame_3">
+                      <property name="frameShape">
+                       <enum>QFrame::NoFrame</enum>
+                      </property>
+                      <property name="frameShadow">
+                       <enum>QFrame::Raised</enum>
+                      </property>
+                      <layout class="QGridLayout" name="gridLayout_21">
+                       <property name="leftMargin">
+                        <number>20</number>
+                       </property>
+                       <item row="0" column="2">
+                        <spacer name="horizontalSpacer_11">
+                         <property name="orientation">
+                          <enum>Qt::Horizontal</enum>
+                         </property>
+                         <property name="sizeHint" stdset="0">
+                          <size>
+                           <width>40</width>
+                           <height>20</height>
+                          </size>
+                         </property>
+                        </spacer>
+                       </item>
+                       <item row="0" column="1">
+                        <widget class="QgsDataDefinedButton" name="mSizeDDBtn">
+                         <property name="text">
+                          <string>...</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="0" column="4">
+                        <widget class="QgsUnitSelectionWidget" name="mSizeUnitWidget" native="true"/>
+                       </item>
+                       <item row="0" column="3">
+                        <widget class="QLabel" name="mSizeUnitLabel">
+                         <property name="text">
+                          <string>Unit</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="0" column="0">
+                        <widget class="QgsDoubleSpinBox" name="mSpinSize">
+                         <property name="decimals">
+                          <number>5</number>
+                         </property>
+                         <property name="maximum">
+                          <double>99999999.989999994635582</double>
+                         </property>
+                         <property name="singleStep">
+                          <double>0.200000000000000</double>
+                         </property>
+                         <property name="value">
+                          <double>1.000000000000000</double>
+                         </property>
+                         <property name="showClearButton" stdset="0">
+                          <bool>false</bool>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="0" column="5">
+                        <spacer name="horizontalSpacer_10">
+                         <property name="orientation">
+                          <enum>Qt::Horizontal</enum>
+                         </property>
+                         <property name="sizeHint" stdset="0">
+                          <size>
+                           <width>40</width>
+                           <height>20</height>
+                          </size>
+                         </property>
+                        </spacer>
+                       </item>
+                      </layout>
+                     </widget>
+                    </item>
+                   </layout>
+                  </item>
+                  <item row="1" column="0">
+                   <layout class="QGridLayout" name="gridLayout_7" rowstretch="0,0">
                     <item row="1" column="0">
                      <widget class="QFrame" name="frame">
                       <property name="frameShape">
@@ -811,9 +871,16 @@
                       </layout>
                      </widget>
                     </item>
+                    <item row="0" column="0">
+                     <widget class="QLabel" name="label_2">
+                      <property name="text">
+                       <string>Format</string>
+                      </property>
+                     </widget>
+                    </item>
                    </layout>
                   </item>
-                  <item>
+                  <item row="2" column="0">
                    <layout class="QGridLayout" name="gridLayout_9" rowstretch="0,1">
                     <property name="topMargin">
                      <number>0</number>
@@ -882,7 +949,7 @@
                     </item>
                    </layout>
                   </item>
-                  <item>
+                  <item row="3" column="0">
                    <spacer name="verticalSpacer_2">
                     <property name="orientation">
                      <enum>Qt::Vertical</enum>
@@ -891,302 +958,6 @@
                      <size>
                       <width>20</width>
                       <height>40</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                 </layout>
-                </widget>
-               </widget>
-              </item>
-             </layout>
-            </widget>
-            <widget class="QWidget" name="mDiagramPage_Size">
-             <layout class="QVBoxLayout" name="verticalLayout_6">
-              <property name="leftMargin">
-               <number>0</number>
-              </property>
-              <property name="topMargin">
-               <number>0</number>
-              </property>
-              <property name="rightMargin">
-               <number>0</number>
-              </property>
-              <property name="bottomMargin">
-               <number>0</number>
-              </property>
-              <item>
-               <widget class="QLabel" name="label_40">
-                <property name="styleSheet">
-                 <string notr="true">text-decoration: underline;</string>
-                </property>
-                <property name="text">
-                 <string>Size</string>
-                </property>
-               </widget>
-              </item>
-              <item>
-               <widget class="QScrollArea" name="scrollArea_5">
-                <property name="frameShape">
-                 <enum>QFrame::NoFrame</enum>
-                </property>
-                <property name="widgetResizable">
-                 <bool>true</bool>
-                </property>
-                <widget class="QWidget" name="scrollAreaWidgetContents_6">
-                 <property name="geometry">
-                  <rect>
-                   <x>0</x>
-                   <y>0</y>
-                   <width>630</width>
-                   <height>376</height>
-                  </rect>
-                 </property>
-                 <layout class="QGridLayout" name="gridLayout_11">
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>6</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                  <item row="0" column="0">
-                   <widget class="QLabel" name="mDiagramUnitsLabel">
-                    <property name="text">
-                     <string>Size units</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="0">
-                   <widget class="QRadioButton" name="mFixedSizeRadio">
-                    <property name="text">
-                     <string>Fixed size</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="1">
-                   <widget class="QgsDoubleSpinBox" name="mDiagramSizeSpinBox">
-                    <property name="enabled">
-                     <bool>false</bool>
-                    </property>
-                    <property name="decimals">
-                     <number>5</number>
-                    </property>
-                    <property name="maximum">
-                     <double>9999999.990000000223517</double>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="1">
-                   <widget class="QComboBox" name="mDiagramUnitComboBox"/>
-                  </item>
-                  <item row="4" column="0">
-                   <spacer name="verticalSpacer_3">
-                    <property name="orientation">
-                     <enum>Qt::Vertical</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>20</width>
-                      <height>40</height>
-                     </size>
-                    </property>
-                   </spacer>
-                  </item>
-                  <item row="3" column="0" colspan="3">
-                   <widget class="QFrame" name="mLinearScaleFrame">
-                    <property name="frameShape">
-                     <enum>QFrame::NoFrame</enum>
-                    </property>
-                    <property name="frameShadow">
-                     <enum>QFrame::Plain</enum>
-                    </property>
-                    <layout class="QVBoxLayout" name="verticalLayout_2">
-                     <property name="leftMargin">
-                      <number>20</number>
-                     </property>
-                     <property name="topMargin">
-                      <number>0</number>
-                     </property>
-                     <property name="rightMargin">
-                      <number>0</number>
-                     </property>
-                     <property name="bottomMargin">
-                      <number>0</number>
-                     </property>
-                     <item>
-                      <widget class="QLabel" name="mLinearlyScalingLabel">
-                       <property name="text">
-                        <string>Scale linearly between 0 and the following attribute value / diagram size:</string>
-                       </property>
-                       <property name="wordWrap">
-                        <bool>true</bool>
-                       </property>
-                      </widget>
-                     </item>
-                     <item>
-                      <layout class="QGridLayout" name="gridLayout">
-                       <item row="3" column="0">
-                        <widget class="QLabel" name="mSizeLabel">
-                         <property name="text">
-                          <string>Size</string>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="3" column="1" colspan="2">
-                        <widget class="QgsSpinBox" name="mSizeSpinBox">
-                         <property name="maximum">
-                          <number>10000000</number>
-                         </property>
-                         <property name="value">
-                          <number>50</number>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="2" column="0">
-                        <widget class="QLabel" name="label_4">
-                         <property name="text">
-                          <string>Maximum value</string>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="0" column="0" rowspan="2">
-                        <widget class="QLabel" name="mSizeAttributeLabel">
-                         <property name="text">
-                          <string>Attribute</string>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="0" column="1" rowspan="2" colspan="4">
-                        <widget class="QgsFieldExpressionWidget" name="mSizeFieldExpressionWidget" native="true">
-                         <property name="sizePolicy">
-                          <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                           <horstretch>0</horstretch>
-                           <verstretch>0</verstretch>
-                          </sizepolicy>
-                         </property>
-                         <property name="maximumSize">
-                          <size>
-                           <width>16777215</width>
-                           <height>16777215</height>
-                          </size>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="3" column="3">
-                        <widget class="QLabel" name="mScaleDependencyLabel">
-                         <property name="text">
-                          <string>Scale</string>
-                         </property>
-                        </widget>
-                       </item>
-                       <item row="3" column="4">
-                        <widget class="QComboBox" name="mScaleDependencyComboBox"/>
-                       </item>
-                       <item row="2" column="1" colspan="2">
-                        <layout class="QHBoxLayout" name="horizontalLayout_2">
-                         <item>
-                          <widget class="QgsDoubleSpinBox" name="mMaxValueSpinBox">
-                           <property name="decimals">
-                            <number>6</number>
-                           </property>
-                           <property name="minimum">
-                            <double>-99999999.000000000000000</double>
-                           </property>
-                           <property name="maximum">
-                            <double>99999999.000000000000000</double>
-                           </property>
-                          </widget>
-                         </item>
-                         <item>
-                          <widget class="QPushButton" name="mFindMaximumValueButton">
-                           <property name="text">
-                            <string>Find</string>
-                           </property>
-                          </widget>
-                         </item>
-                        </layout>
-                       </item>
-                       <item row="4" column="0" colspan="5">
-                        <widget class="QFrame" name="mFrameIncreaseSize">
-                         <property name="frameShape">
-                          <enum>QFrame::NoFrame</enum>
-                         </property>
-                         <property name="frameShadow">
-                          <enum>QFrame::Raised</enum>
-                         </property>
-                         <layout class="QHBoxLayout" name="horizontalLayout">
-                          <property name="leftMargin">
-                           <number>0</number>
-                          </property>
-                          <property name="topMargin">
-                           <number>0</number>
-                          </property>
-                          <property name="rightMargin">
-                           <number>0</number>
-                          </property>
-                          <property name="bottomMargin">
-                           <number>0</number>
-                          </property>
-                          <item>
-                           <widget class="QCheckBox" name="mIncreaseSmallDiagramsCheck">
-                            <property name="text">
-                             <string>Increase size of small diagrams</string>
-                            </property>
-                           </widget>
-                          </item>
-                          <item>
-                           <widget class="QLabel" name="mIncreaseMinimumSizeLabel">
-                            <property name="text">
-                             <string>Minimum size</string>
-                            </property>
-                           </widget>
-                          </item>
-                          <item>
-                           <widget class="QgsDoubleSpinBox" name="mIncreaseMinimumSizeSpinBox"/>
-                          </item>
-                          <item>
-                           <spacer name="horizontalSpacer_4">
-                            <property name="orientation">
-                             <enum>Qt::Horizontal</enum>
-                            </property>
-                            <property name="sizeHint" stdset="0">
-                             <size>
-                              <width>40</width>
-                              <height>20</height>
-                             </size>
-                            </property>
-                           </spacer>
-                          </item>
-                         </layout>
-                        </widget>
-                       </item>
-                      </layout>
-                     </item>
-                    </layout>
-                   </widget>
-                  </item>
-                  <item row="2" column="0">
-                   <widget class="QRadioButton" name="mAttributeBasedScalingRadio">
-                    <property name="text">
-                     <string>Scaled size</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="2">
-                   <spacer name="horizontalSpacer_3">
-                    <property name="orientation">
-                     <enum>Qt::Horizontal</enum>
-                    </property>
-                    <property name="sizeHint" stdset="0">
-                     <size>
-                      <width>40</width>
-                      <height>20</height>
                      </size>
                     </property>
                    </spacer>
@@ -1789,6 +1560,17 @@
    <extends>QWidget</extends>
    <header>qgsscalerangewidget.h</header>
   </customwidget>
+  <customwidget>
+   <class>QgsUnitSelectionWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsunitselectionwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsDataDefinedButton</class>
+   <extends>QToolButton</extends>
+   <header>qgsdatadefinedbutton.h</header>
+  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>mEnableDiagramsCheckBox</tabstop>
@@ -1857,70 +1639,6 @@
     <hint type="destinationlabel">
      <x>397</x>
      <y>297</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>mFixedSizeRadio</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>mDiagramSizeSpinBox</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>111</x>
-     <y>153</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>235</x>
-     <y>154</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>mAttributeBasedScalingRadio</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>mLinearScaleFrame</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>111</x>
-     <y>184</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>352</x>
-     <y>279</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>mIncreaseSmallDiagramsCheck</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>mIncreaseMinimumSizeSpinBox</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>248</x>
-     <y>341</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>589</x>
-     <y>342</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>mIncreaseSmallDiagramsCheck</sender>
-   <signal>toggled(bool)</signal>
-   <receiver>mIncreaseMinimumSizeLabel</receiver>
-   <slot>setEnabled(bool)</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>248</x>
-     <y>341</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>476</x>
-     <y>342</y>
     </hint>
    </hints>
   </connection>


### PR DESCRIPTION
Hi @nyalldawson and @m-kuhn,

This is a first attempt to get the diagram size defined with a Data Defined Button and a size assistant for preview.

I did not change the underlying classes because there is a lot of things exposed in the API for diagram properties and I don't see how to put DataDefined in there without breaking the API (believe me I tried hard).

I have two questions:
- The first and foremost is: why is it impossible to set a fixed size for bar diagrams ? Agreed, the same size for different values can be misleading when reading bar diagrams on different points, but then the specified height could be associated with a max value, and scaling could be applied afterward (for both height and width). So we would have two additional fields  for bars (for max and min values).
- The second question concerns the layout of the widgets, I removed the size tab to have a Size field in appearance with a DD button, it's homogeneous with what is done in Style, but the size tab could also remain to display the DD assistant. What do you think is the best option ? 
