### PR TITLE
Fix GPS Information panel Autodetect being set when Internal is not available

### DIFF
--- a/src/app/gps/qgsgpsinformationwidget.cpp
+++ b/src/app/gps/qgsgpsinformationwidget.cpp
@@ -203,10 +203,17 @@ QgsGPSInformationWidget::QgsGPSInformationWidget( QgsMapCanvas * thepCanvas, QWi
   {
     mRadGpsd->setChecked( true );
   }
-  //disable the internal port method if build is without QtLocation
+  //hide the internal port method and Hacc, Vacc fields if build is without QtLocation
 #ifndef HAVE_QT_MOBILITY_LOCATION
-  mRadInternal->setDisabled( true );
-  mRadAutodetect->setChecked( true );
+  if ( mRadInternal->isChecked() )
+  {
+    mRadAutodetect->setChecked( true );
+  }
+  mRadInternal->hide();
+  mLblHacc->hide();
+  mTxtHacc->hide();
+  mLblVacc->hide();
+  mTxtVacc->hide();
 #endif
 
   //auto digitising behaviour

--- a/src/ui/qgsgpsinformationwidgetbase.ui
+++ b/src/ui/qgsgpsinformationwidgetbase.ui
@@ -616,14 +616,14 @@ gray = no data
              <item row="12" column="0">
               <widget class="QLabel" name="mLblHacc">
                <property name="text">
-                <string>H accurancy</string>
+                <string>H accuracy</string>
                </property>
               </widget>
              </item>
              <item row="13" column="0">
               <widget class="QLabel" name="mLblVacc">
                <property name="text">
-                <string>V accurancy</string>
+                <string>V accuracy</string>
                </property>
               </widget>
              </item>


### PR DESCRIPTION
This fixes GPS Information panel where on QGIS start the Autodetect connection is always selected even though another, like Serial device, was previously used and should have been restored.  

Also, the 'H accurancy' (sic) and 'V accurancy' fields always show -1 when GPS is connected. Note that that the labels are misspelled as '... accurancy' instead of '... accuracy' .

I found in qgsgpsinformationwidget.cpp that there is a test for HAVE_QT_MOBILITY_LOCATION not defined that forces the Autodetect to be selected (negating the restored choice) and the Internal button to be disabled.
As the test is for a compile-time setting the user has absolutely no influence on, I consider that the Internal radiobutton being displayed when there is no Internal availability is just noise. Therefore it should be hidden.

Additionally, I find that the H accurancy and V accurancy display fields' data are from the internal location module.  These are also noise as they don't get any data if there is no internal connection.
1. setting Autodetect only if Internal just happened to be the stored connection (it shouldn't happen in normal use)
2. hiding the Internal radiobutton
3. hiding the H and V accuracy labels/text boxes
   when HAVE_QT_MOBILITY_LOCATION is not defined.
4. fixes the Hacc, Vacc labels' spelling

context: http://hub.qgis.org/issues/13233
