### PR TITLE
Fix to #11428 and #4064. Remove -write_absolute_path option, since it…

### DIFF
--- a/python/plugins/GdalTools/tools/doTileIndex.py
+++ b/python/plugins/GdalTools/tools/doTileIndex.py
@@ -48,7 +48,6 @@ class GdalToolsDialog(QWidget, Ui_Widget, BasePluginWidget):
             #( self.recurseCheck, SIGNAL( "stateChanged( int )" ),
             (self.outSelector, SIGNAL("filenameChanged()")),
             (self.indexFieldEdit, SIGNAL("textChanged( const QString & )"), self.indexFieldCheck),
-            (self.absolutePathCheck, SIGNAL("stateChanged( int )"), None, 1500),
             (self.skipDifferentProjCheck, SIGNAL("stateChanged( int )"), None, 1500)
         ])
 
@@ -77,8 +76,6 @@ class GdalToolsDialog(QWidget, Ui_Widget, BasePluginWidget):
         if self.indexFieldCheck.isChecked() and self.indexFieldEdit.text():
             arguments.append("-tileindex")
             arguments.append(self.indexFieldEdit.text())
-        if self.absolutePathCheck.isChecked():
-            arguments.append("-write_absolute_path")
         if self.skipDifferentProjCheck.isChecked():
             arguments.append("-skip_different_projection")
         arguments.append(self.getOutputFileName())

--- a/python/plugins/GdalTools/tools/widgetTileIndex.ui
+++ b/python/plugins/GdalTools/tools/widgetTileIndex.ui
@@ -7,7 +7,7 @@
     <x>0</x>
     <y>0</y>
     <width>400</width>
-    <height>181</height>
+    <height>153</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -67,13 +67,6 @@
       <widget class="GdalToolsInOutSelector" name="outSelector" native="true"/>
      </item>
     </layout>
-   </item>
-   <item>
-    <widget class="QCheckBox" name="absolutePathCheck">
-     <property name="text">
-      <string>Write absolute path</string>
-     </property>
-    </widget>
    </item>
    <item>
     <widget class="QCheckBox" name="skipDifferentProjCheck">


### PR DESCRIPTION
… has no influence, because absolute paths are always recorded in the attribute table.
