### PR TITLE
[welcome page] fix font size on HiDPI display and improve disabled item style

### DIFF
--- a/src/app/qgswelcomepageitemsmodel.cpp
+++ b/src/app/qgswelcomepageitemsmodel.cpp
@@ -71,7 +71,7 @@ void QgsWelcomePageItemDelegate::paint( QPainter* painter, const QStyleOptionVie
   int textSize = titleSize * 0.85;
 
   doc.setHtml( QString( "<div style='font-size:%1px;'><span style='font-size:%2px;font-weight:bold;'>%3</span><br>%4<br>%5</div>" ).arg( textSize ).arg( titleSize ).arg( index.data( QgsWelcomePageItemsModel::TitleRole ).toString() ).arg( index.data( QgsWelcomePageItemsModel::PathRole ).toString() ).arg( index.data( QgsWelcomePageItemsModel::CrsRole ).toString() ) );
-  doc.setTextWidth( 800 );
+  doc.setTextWidth( 2800 );
 
   QPixmap icon = qvariant_cast<QPixmap>( index.data( Qt::DecorationRole ) );
   if ( !icon.isNull() )
@@ -94,7 +94,7 @@ QSize QgsWelcomePageItemDelegate::sizeHint( const QStyleOptionViewItem & option,
   int textSize = titleSize * 0.85;
 
   doc.setHtml( QString( "<div style='font-size:%1px;'><span style='font-size:%2px;font-weight:bold;'>%3</span><br>%4<br>%5</div>" ).arg( textSize ).arg( titleSize ).arg( index.data( QgsWelcomePageItemsModel::TitleRole ).toString() ).arg( index.data( QgsWelcomePageItemsModel::PathRole ).toString() ).arg( index.data( QgsWelcomePageItemsModel::CrsRole ).toString() ) );
-  doc.setTextWidth( 800 );
+  doc.setTextWidth( 2800 );
 
   QPixmap icon = qvariant_cast<QPixmap>( index.data( Qt::DecorationRole ) );
 

--- a/src/app/qgswelcomepageitemsmodel.cpp
+++ b/src/app/qgswelcomepageitemsmodel.cpp
@@ -44,11 +44,17 @@ void QgsWelcomePageItemDelegate::paint( QPainter* painter, const QStyleOptionVie
   {
     color = QColor( 255, 255, 255, 60 );
     ctx.palette.setColor( QPalette::Text, optionV4.palette.color( QPalette::Active, QPalette::HighlightedText ) );
+
+    QStyle *style = QApplication::style();
+    style->drawPrimitive( QStyle::PE_PanelItemViewItem, &option, painter, NULL );
   }
   else if ( option.state & QStyle::State_Enabled )
   {
     color = QColor( 100, 100, 100, 30 );
     ctx.palette.setColor( QPalette::Text, optionV4.palette.color( QPalette::Active, QPalette::Text ) );
+
+    QStyle *style = QApplication::style();
+    style->drawPrimitive( QStyle::PE_PanelItemViewItem, &option, painter, NULL );
   }
   else
   {
@@ -56,15 +62,15 @@ void QgsWelcomePageItemDelegate::paint( QPainter* painter, const QStyleOptionVie
     ctx.palette.setColor( QPalette::Text, optionV4.palette.color( QPalette::Disabled, QPalette::Text ) );
   }
 
-  QStyle *style = QApplication::style();
-  style->drawPrimitive( QStyle::PE_PanelItemViewItem, &option, painter, NULL );
-
   painter->setRenderHint( QPainter::Antialiasing );
   painter->setPen( QColor( 0, 0, 0, 0 ) );
   painter->setBrush( QBrush( color ) );
   painter->drawRoundedRect( option.rect.left() + 5, option.rect.top() + 5, option.rect.width() - 10, option.rect.height() - 10, 8, 8 );
 
-  doc.setHtml( QString( "<span style='font-size:18px;font-weight:bold;'>%1</span><br>%2<br>%3" ).arg( index.data( QgsWelcomePageItemsModel::TitleRole ).toString() ).arg( index.data( QgsWelcomePageItemsModel::PathRole ).toString() ).arg( index.data( QgsWelcomePageItemsModel::CrsRole ).toString() ) );
+  int titleSize = QApplication::fontMetrics().height() * 1.1;
+  int textSize = titleSize * 0.85;
+
+  doc.setHtml( QString( "<div style='font-size:%1px;'><span style='font-size:%2px;font-weight:bold;'>%3</span><br>%4<br>%5</div>" ).arg( textSize ).arg( titleSize ).arg( index.data( QgsWelcomePageItemsModel::TitleRole ).toString() ).arg( index.data( QgsWelcomePageItemsModel::PathRole ).toString() ).arg( index.data( QgsWelcomePageItemsModel::CrsRole ).toString() ) );
   doc.setTextWidth( 800 );
 
   QPixmap icon = qvariant_cast<QPixmap>( index.data( Qt::DecorationRole ) );
@@ -84,7 +90,10 @@ QSize QgsWelcomePageItemDelegate::sizeHint( const QStyleOptionViewItem & option,
 {
   QTextDocument doc;
 
-  doc.setHtml( QString( "<span style='font-size:18px;font-weight:bold;'>%1</span><br>%2<br>%3" ).arg( index.data( QgsWelcomePageItemsModel::TitleRole ).toString() ).arg( index.data( QgsWelcomePageItemsModel::PathRole ).toString() ).arg( index.data( QgsWelcomePageItemsModel::CrsRole ).toString() ) );
+  int titleSize = QApplication::fontMetrics().height() * 1.1;
+  int textSize = titleSize * 0.85;
+
+  doc.setHtml( QString( "<div style='font-size:%1px;'><span style='font-size:%2px;font-weight:bold;'>%3</span><br>%4<br>%5</div>" ).arg( textSize ).arg( titleSize ).arg( index.data( QgsWelcomePageItemsModel::TitleRole ).toString() ).arg( index.data( QgsWelcomePageItemsModel::PathRole ).toString() ).arg( index.data( QgsWelcomePageItemsModel::CrsRole ).toString() ) );
   doc.setTextWidth( 800 );
 
   QPixmap icon = qvariant_cast<QPixmap>( index.data( Qt::DecorationRole ) );


### PR DESCRIPTION
This PR improve the welcome page font metric by letting go of a fixed font size in favor of sizes derived from QApplication::fontMetrics(). This should fix @anitagraser 's issue (http://hub.qgis.org/issues/13469). I don't have an HiDPI screen to verify the issue is resolved, I'll let Anita change the status if it's the case.

The commit also improves the styling of disabled items by avoiding to draw a rather ugly gray background for those.
