### PR TITLE
Remove const from labeling QgsRenderContext usage

### DIFF
--- a/python/core/qgsmaprenderer.sip
+++ b/python/core/qgsmaprenderer.sip
@@ -56,9 +56,9 @@ class QgsLabelingEngineInterface
     //! @deprecated since 2.12 - use prepareDiagramLayer()
     virtual int addDiagramLayer( QgsVectorLayer* layer, const QgsDiagramLayerSettings* s ) /Deprecated/;
     //! called for every feature
-    virtual void registerFeature( const QString& layerID, QgsFeature& feat, const QgsRenderContext& context = QgsRenderContext(), QString dxfLayer = QString::null ) = 0;
+    virtual void registerFeature( const QString& layerID, QgsFeature& feat, QgsRenderContext& context, QString dxfLayer = QString::null ) = 0;
     //! called for every diagram feature
-    virtual void registerDiagramFeature( const QString& layerID, QgsFeature& feat, const QgsRenderContext& context = QgsRenderContext() );
+    virtual void registerDiagramFeature( const QString& layerID, QgsFeature& feat, QgsRenderContext& context );
     //! called when the map is drawn and labels should be placed
     virtual void drawLabeling( QgsRenderContext& context ) = 0;
     //! called when we're done with rendering

--- a/python/core/qgspallabeling.sip
+++ b/python/core/qgspallabeling.sip
@@ -485,7 +485,7 @@ class QgsPalLayerSettings
     double rasterCompressFactor; //pixel resolution scale factor
 
     // called from register feature hook
-    void calculateLabelSize( const QFontMetricsF* fm, QString text, double& labelX, double& labelY, QgsFeature* f = 0, const QgsRenderContext* context = 0 );
+    void calculateLabelSize( const QFontMetricsF* fm, QString text, double& labelX, double& labelY, QgsFeature* f = 0, QgsRenderContext* context = 0 );
 
     /** Register a feature for labelling.
      * @param f feature to label
@@ -493,7 +493,7 @@ class QgsPalLayerSettings
      * must have already had the feature and fields sets prior to calling this method.
      * @param dxfLayer dxfLayer name
      */
-    void registerFeature( QgsFeature& f, const QgsRenderContext& context, QString dxfLayer );
+    void registerFeature( QgsFeature& f, QgsRenderContext& context, QString dxfLayer );
 
     void readFromLayer( QgsVectorLayer* layer );
     void writeToLayer( QgsVectorLayer* layer );
@@ -766,9 +766,9 @@ class QgsPalLabeling : QgsLabelingEngineInterface
      * must have already had the feature and fields sets prior to calling this method.
      * @param dxfLayer dxfLayer name
      */
-    virtual void registerFeature( const QString& layerID, QgsFeature& feat, const QgsRenderContext& context = QgsRenderContext(), QString dxfLayer = QString::null );
+    virtual void registerFeature( const QString& layerID, QgsFeature& feat, QgsRenderContext& context, QString dxfLayer = QString::null );
 
-    virtual void registerDiagramFeature( const QString& layerID, QgsFeature& feat, const QgsRenderContext& context = QgsRenderContext() );
+    virtual void registerDiagramFeature( const QString& layerID, QgsFeature& feat, QgsRenderContext& context );
     //! called when the map is drawn and labels should be placed
     virtual void drawLabeling( QgsRenderContext& context );
     //! called when we're done with rendering
@@ -823,7 +823,7 @@ class QgsPalLabeling : QgsLabelingEngineInterface
      * @returns prepared geometry
      * @note added in QGIS 2.9
      */
-    static QgsGeometry* prepareGeometry( const QgsGeometry *geometry, const QgsRenderContext &context, const QgsCoordinateTransform *ct, QgsGeometry *clipGeometry = 0 ) /Factory/;
+    static QgsGeometry* prepareGeometry( const QgsGeometry *geometry, QgsRenderContext &context, const QgsCoordinateTransform *ct, QgsGeometry *clipGeometry = 0 ) /Factory/;
 
     /** Checks whether a geometry requires preparation before registration with PAL
      * @param geometry geometry to prepare
@@ -833,7 +833,7 @@ class QgsPalLabeling : QgsLabelingEngineInterface
      * @returns true if geometry requires preparation
      * @note added in QGIS 2.9
      */
-    static bool geometryRequiresPreparation( const QgsGeometry *geometry, const QgsRenderContext &context, const QgsCoordinateTransform *ct, QgsGeometry *clipGeometry = 0 );
+    static bool geometryRequiresPreparation( const QgsGeometry *geometry, QgsRenderContext &context, const QgsCoordinateTransform *ct, QgsGeometry *clipGeometry = 0 );
 
     /** Splits a text string to a list of separate lines, using a specified wrap character.
      * The text string will be split on either newline characters or the wrap character.

--- a/src/core/dxf/qgsdxfpallabeling.cpp
+++ b/src/core/dxf/qgsdxfpallabeling.cpp
@@ -139,7 +139,7 @@ void QgsDxfLabelProvider::drawLabel( QgsRenderContext& context, pal::LabelPositi
   }
 }
 
-void QgsDxfLabelProvider::registerDxfFeature( QgsFeature& feature, const QgsRenderContext& context, const QString& dxfLayerName )
+void QgsDxfLabelProvider::registerDxfFeature( QgsFeature& feature, QgsRenderContext& context, const QString& dxfLayerName )
 {
   registerFeature( feature, context );
   mDxfLayerNames[feature.id()] = dxfLayerName;

--- a/src/core/dxf/qgsdxfpallabeling.h
+++ b/src/core/dxf/qgsdxfpallabeling.h
@@ -39,7 +39,7 @@ class QgsDxfLabelProvider : public QgsVectorLayerLabelProvider
     virtual void drawLabel( QgsRenderContext& context, pal::LabelPosition* label ) const override;
 
     //! registration method that keeps track of DXF layer names of individual features
-    void registerDxfFeature( QgsFeature& feature, const QgsRenderContext& context, const QString& dxfLayerName );
+    void registerDxfFeature( QgsFeature& feature, QgsRenderContext &context, const QString& dxfLayerName );
 
   protected:
     //! pointer to parent DXF export where this instance is used

--- a/src/core/qgslabelingenginev2.cpp
+++ b/src/core/qgslabelingenginev2.cpp
@@ -188,7 +188,7 @@ void QgsLabelingEngineV2::run( QgsRenderContext& context )
 
   // NOW DO THE LAYOUT (from QgsPalLabeling::drawLabeling)
 
-  QPainter* painter = const_cast<QgsRenderContext&>( context ).painter();
+  QPainter* painter = context.painter();
 
   QgsGeometry* extentGeom( QgsGeometry::fromRect( mMapSettings.visibleExtent() ) );
   if ( !qgsDoubleNear( mMapSettings.rotation(), 0.0 ) )

--- a/src/core/qgslabelingenginev2.h
+++ b/src/core/qgslabelingenginev2.h
@@ -267,7 +267,7 @@ class CORE_EXPORT QgsAbstractLabelProvider
     Q_DECLARE_FLAGS( Flags, Flag )
 
     //! Return list of label features (they are owned by the provider and thus deleted on its destruction)
-    virtual QList<QgsLabelFeature*> labelFeatures( const QgsRenderContext& context ) = 0;
+    virtual QList<QgsLabelFeature*> labelFeatures( QgsRenderContext& context ) = 0;
 
     //! draw this label at the position determined by the labeling engine
     virtual void drawLabel( QgsRenderContext& context, pal::LabelPosition* label ) const = 0;

--- a/src/core/qgsmaprenderer.h
+++ b/src/core/qgsmaprenderer.h
@@ -95,9 +95,9 @@ class CORE_EXPORT QgsLabelingEngineInterface
     Q_DECL_DEPRECATED virtual int addDiagramLayer( QgsVectorLayer* layer, const QgsDiagramLayerSettings* s )
     { Q_UNUSED( layer ); Q_UNUSED( s ); return 0; }
     //! called for every feature
-    virtual void registerFeature( const QString& layerID, QgsFeature& feat, const QgsRenderContext& context = QgsRenderContext(), QString dxfLayer = QString::null ) = 0;
+    virtual void registerFeature( const QString& layerID, QgsFeature& feat, QgsRenderContext& context, QString dxfLayer = QString::null ) = 0;
     //! called for every diagram feature
-    virtual void registerDiagramFeature( const QString& layerID, QgsFeature& feat, const QgsRenderContext& context = QgsRenderContext() )
+    virtual void registerDiagramFeature( const QString& layerID, QgsFeature& feat, QgsRenderContext& context )
     { Q_UNUSED( layerID ); Q_UNUSED( feat ); Q_UNUSED( context ); }
     //! called when the map is drawn and labels should be placed
     virtual void drawLabeling( QgsRenderContext& context ) = 0;

--- a/src/core/qgspallabeling.cpp
+++ b/src/core/qgspallabeling.cpp
@@ -1719,7 +1719,7 @@ bool QgsPalLayerSettings::checkMinimumSizeMM( const QgsRenderContext& ct, const 
   return QgsPalLabeling::checkMinimumSizeMM( ct, geom, minSize );
 }
 
-void QgsPalLayerSettings::calculateLabelSize( const QFontMetricsF* fm, QString text, double& labelX, double& labelY, QgsFeature* f, const QgsRenderContext *context )
+void QgsPalLayerSettings::calculateLabelSize( const QFontMetricsF* fm, QString text, double& labelX, double& labelY, QgsFeature* f, QgsRenderContext *context )
 {
   if ( !fm || !f )
   {
@@ -1891,7 +1891,7 @@ void QgsPalLayerSettings::calculateLabelSize( const QFontMetricsF* fm, QString t
 }
 
 
-void QgsPalLayerSettings::registerFeature( QgsFeature& f, const QgsRenderContext& context, QString dxfLayer, QgsLabelFeature** labelFeature )
+void QgsPalLayerSettings::registerFeature( QgsFeature& f, QgsRenderContext &context, QString dxfLayer, QgsLabelFeature** labelFeature )
 {
   // either used in QgsPalLabeling (palLayer is set) or in QgsLabelingEngineV2 (labelFeature is set)
   Q_ASSERT( labelFeature );
@@ -2700,7 +2700,7 @@ void QgsPalLayerSettings::registerFeature( QgsFeature& f, const QgsRenderContext
 }
 
 
-void QgsPalLayerSettings::registerObstacleFeature( QgsFeature& f, const QgsRenderContext& context, QString dxfLayer , QgsLabelFeature** obstacleFeature )
+void QgsPalLayerSettings::registerObstacleFeature( QgsFeature& f, QgsRenderContext &context, QString dxfLayer , QgsLabelFeature** obstacleFeature )
 {
   Q_UNUSED( dxfLayer ); // now handled in QgsDxfLabelProvider
 
@@ -2919,7 +2919,7 @@ bool QgsPalLayerSettings::dataDefinedValEval( DataDefinedValueType valType,
 
 void QgsPalLayerSettings::parseTextStyle( QFont& labelFont,
     QgsPalLayerSettings::SizeUnit fontunits,
-    const QgsRenderContext& context )
+    QgsRenderContext &context )
 {
   // NOTE: labelFont already has pixelSize set, so pointSize or pointSizeF might return -1
 
@@ -3127,7 +3127,7 @@ void QgsPalLayerSettings::parseTextStyle( QFont& labelFont,
 
 }
 
-void QgsPalLayerSettings::parseTextBuffer( const QgsRenderContext &context )
+void QgsPalLayerSettings::parseTextBuffer( QgsRenderContext &context )
 {
   QVariant exprVal; // value() is repeatedly nulled on data defined evaluation and replaced when successful
 
@@ -3180,7 +3180,7 @@ void QgsPalLayerSettings::parseTextBuffer( const QgsRenderContext &context )
   dataDefinedValEval( DDBlendMode, QgsPalLayerSettings::BufferBlendMode, exprVal, context.expressionContext() );
 }
 
-void QgsPalLayerSettings::parseTextFormatting( const QgsRenderContext &context )
+void QgsPalLayerSettings::parseTextFormatting( QgsRenderContext &context )
 {
   QVariant exprVal; // value() is repeatedly nulled on data defined evaluation and replaced when successful
 
@@ -3266,7 +3266,7 @@ void QgsPalLayerSettings::parseTextFormatting( const QgsRenderContext &context )
   // formatting for numbers is inline with generation of base label text and not passed to label painting
 }
 
-void QgsPalLayerSettings::parseShapeBackground( const QgsRenderContext &context )
+void QgsPalLayerSettings::parseShapeBackground( QgsRenderContext &context )
 {
   QVariant exprVal; // value() is repeatedly nulled on data defined evaluation and replaced when successful
 
@@ -3467,7 +3467,7 @@ void QgsPalLayerSettings::parseShapeBackground( const QgsRenderContext &context 
 
 }
 
-void QgsPalLayerSettings::parseDropShadow( const QgsRenderContext &context )
+void QgsPalLayerSettings::parseDropShadow( QgsRenderContext &context )
 {
   QVariant exprVal; // value() is repeatedly nulled on data defined evaluation and replaced when successful
 
@@ -3688,14 +3688,14 @@ int QgsPalLabeling::addDiagramLayer( QgsVectorLayer* layer, const QgsDiagramLaye
   return 0;
 }
 
-void QgsPalLabeling::registerFeature( const QString& layerID, QgsFeature& f, const QgsRenderContext& context, QString dxfLayer )
+void QgsPalLabeling::registerFeature( const QString& layerID, QgsFeature& f, QgsRenderContext &context, QString dxfLayer )
 {
   Q_UNUSED( dxfLayer ); // now handled by QgsDxfLabelProvider
   if ( QgsVectorLayerLabelProvider* provider = mLabelProviders.value( layerID, 0 ) )
     provider->registerFeature( f, context );
 }
 
-bool QgsPalLabeling::geometryRequiresPreparation( const QgsGeometry* geometry, const QgsRenderContext& context, const QgsCoordinateTransform* ct, QgsGeometry* clipGeometry )
+bool QgsPalLabeling::geometryRequiresPreparation( const QgsGeometry* geometry, QgsRenderContext &context, const QgsCoordinateTransform* ct, QgsGeometry* clipGeometry )
 {
   if ( !geometry )
   {
@@ -3755,7 +3755,7 @@ QStringList QgsPalLabeling::splitToGraphemes( const QString &text )
   return graphemes;
 }
 
-QgsGeometry* QgsPalLabeling::prepareGeometry( const QgsGeometry* geometry, const QgsRenderContext& context, const QgsCoordinateTransform* ct, QgsGeometry* clipGeometry )
+QgsGeometry* QgsPalLabeling::prepareGeometry( const QgsGeometry* geometry, QgsRenderContext &context, const QgsCoordinateTransform* ct, QgsGeometry* clipGeometry )
 {
   if ( !geometry )
   {
@@ -3875,7 +3875,7 @@ bool QgsPalLabeling::checkMinimumSizeMM( const QgsRenderContext& context, const 
   return true; //should never be reached. Return true in this case to label such geometries anyway.
 }
 
-void QgsPalLabeling::registerDiagramFeature( const QString& layerID, QgsFeature& feat, const QgsRenderContext& context )
+void QgsPalLabeling::registerDiagramFeature( const QString& layerID, QgsFeature& feat, QgsRenderContext &context )
 {
   if ( QgsVectorLayerDiagramProvider* provider = mDiagramProviders.value( layerID, 0 ) )
     provider->registerFeature( feat, context );

--- a/src/core/qgspallabeling.h
+++ b/src/core/qgspallabeling.h
@@ -467,7 +467,7 @@ class CORE_EXPORT QgsPalLayerSettings
     double rasterCompressFactor; //pixel resolution scale factor
 
     // called from register feature hook
-    void calculateLabelSize( const QFontMetricsF* fm, QString text, double& labelX, double& labelY, QgsFeature* f = 0, const QgsRenderContext* context = 0 );
+    void calculateLabelSize( const QFontMetricsF* fm, QString text, double& labelX, double& labelY, QgsFeature* f = 0, QgsRenderContext* context = 0 );
 
     /** Register a feature for labelling.
      * @param f feature to label
@@ -476,7 +476,7 @@ class CORE_EXPORT QgsPalLayerSettings
      * @param dxfLayer dxfLayer name
      * @param labelFeature if using QgsLabelingEngineV2, this will receive the label feature
      */
-    void registerFeature( QgsFeature& f, const QgsRenderContext& context, QString dxfLayer, QgsLabelFeature** labelFeature = 0 );
+    void registerFeature( QgsFeature& f, QgsRenderContext& context, QString dxfLayer, QgsLabelFeature** labelFeature = 0 );
 
     void readFromLayer( QgsVectorLayer* layer );
     void writeToLayer( QgsVectorLayer* layer );
@@ -628,15 +628,15 @@ class CORE_EXPORT QgsPalLayerSettings
 
     void parseTextStyle( QFont& labelFont,
                          QgsPalLayerSettings::SizeUnit fontunits,
-                         const QgsRenderContext& context );
+                         QgsRenderContext& context );
 
-    void parseTextBuffer( const QgsRenderContext& context );
+    void parseTextBuffer( QgsRenderContext& context );
 
-    void parseTextFormatting( const QgsRenderContext& context );
+    void parseTextFormatting( QgsRenderContext& context );
 
-    void parseShapeBackground( const QgsRenderContext& context );
+    void parseShapeBackground( QgsRenderContext& context );
 
-    void parseDropShadow( const QgsRenderContext& context );
+    void parseDropShadow( QgsRenderContext& context );
 
     /** Checks if a feature is larger than a minimum size (in mm)
     @return true if above size, false if below*/
@@ -644,7 +644,7 @@ class CORE_EXPORT QgsPalLayerSettings
 
     /** Registers a feature as an obstacle only (no label rendered)
      */
-    void registerObstacleFeature( QgsFeature &f, const QgsRenderContext &context, QString dxfLayer, QgsLabelFeature** obstacleFeature );
+    void registerObstacleFeature( QgsFeature &f, QgsRenderContext &context, QString dxfLayer, QgsLabelFeature** obstacleFeature );
 
     QMap<DataDefinedProperties, QVariant> dataDefinedValues;
     QgsExpression* expression;
@@ -880,9 +880,9 @@ class CORE_EXPORT QgsPalLabeling : public QgsLabelingEngineInterface
      * must have already had the feature and fields sets prior to calling this method.
      * @param dxfLayer dxfLayer name
      */
-    virtual void registerFeature( const QString& layerID, QgsFeature& feat, const QgsRenderContext& context = QgsRenderContext(), QString dxfLayer = QString::null ) override;
+    virtual void registerFeature( const QString& layerID, QgsFeature& feat, QgsRenderContext& context, QString dxfLayer = QString::null ) override;
 
-    virtual void registerDiagramFeature( const QString& layerID, QgsFeature& feat, const QgsRenderContext& context = QgsRenderContext() ) override;
+    virtual void registerDiagramFeature( const QString& layerID, QgsFeature& feat, QgsRenderContext& context ) override;
     //! called when the map is drawn and labels should be placed
     virtual void drawLabeling( QgsRenderContext& context ) override;
     //! called when we're done with rendering
@@ -934,7 +934,7 @@ class CORE_EXPORT QgsPalLabeling : public QgsLabelingEngineInterface
      * @returns prepared geometry, the caller takes ownership
      * @note added in QGIS 2.9
      */
-    static QgsGeometry* prepareGeometry( const QgsGeometry *geometry, const QgsRenderContext &context, const QgsCoordinateTransform *ct, QgsGeometry *clipGeometry = 0 );
+    static QgsGeometry* prepareGeometry( const QgsGeometry *geometry, QgsRenderContext &context, const QgsCoordinateTransform *ct, QgsGeometry *clipGeometry = 0 );
 
     /** Checks whether a geometry requires preparation before registration with PAL
      * @param geometry geometry to prepare
@@ -944,7 +944,7 @@ class CORE_EXPORT QgsPalLabeling : public QgsLabelingEngineInterface
      * @returns true if geometry requires preparation
      * @note added in QGIS 2.9
      */
-    static bool geometryRequiresPreparation( const QgsGeometry *geometry, const QgsRenderContext &context, const QgsCoordinateTransform *ct, QgsGeometry *clipGeometry = 0 );
+    static bool geometryRequiresPreparation( const QgsGeometry *geometry, QgsRenderContext &context, const QgsCoordinateTransform *ct, QgsGeometry *clipGeometry = 0 );
 
     /** Splits a text string to a list of separate lines, using a specified wrap character.
      * The text string will be split on either newline characters or the wrap character.

--- a/src/core/qgsrulebasedlabeling.cpp
+++ b/src/core/qgsrulebasedlabeling.cpp
@@ -25,7 +25,7 @@ bool QgsRuleBasedLabelProvider::prepare( const QgsRenderContext& context, QStrin
   return true;
 }
 
-void QgsRuleBasedLabelProvider::registerFeature( QgsFeature& feature, const QgsRenderContext& context )
+void QgsRuleBasedLabelProvider::registerFeature( QgsFeature& feature, QgsRenderContext &context )
 {
   // will register the feature to relevant sub-providers
   mRules.rootRule()->registerFeature( feature, context, mSubProviders );
@@ -241,9 +241,9 @@ void QgsRuleBasedLabeling::Rule::prepare( const QgsRenderContext& context, QStri
   }
 }
 
-QgsRuleBasedLabeling::Rule::RegisterResult QgsRuleBasedLabeling::Rule::registerFeature( QgsFeature& feature, const QgsRenderContext& context, QgsRuleBasedLabeling::RuleToProviderMap& subProviders )
+QgsRuleBasedLabeling::Rule::RegisterResult QgsRuleBasedLabeling::Rule::registerFeature( QgsFeature& feature, QgsRenderContext &context, QgsRuleBasedLabeling::RuleToProviderMap& subProviders )
 {
-  if ( !isFilterOK( feature, const_cast<QgsRenderContext&>( context ) )
+  if ( !isFilterOK( feature, context )
        || !isScaleOK( context.rendererScale() ) )
     return Filtered;
 

--- a/src/core/qgsrulebasedlabeling.h
+++ b/src/core/qgsrulebasedlabeling.h
@@ -166,7 +166,7 @@ class CORE_EXPORT QgsRuleBasedLabeling : public QgsAbstractVectorLayerLabeling
         void prepare( const QgsRenderContext& context, QStringList& attributeNames, RuleToProviderMap& subProviders );
 
         //! register individual features
-        RegisterResult registerFeature( QgsFeature& feature, const QgsRenderContext& context, RuleToProviderMap& subProviders );
+        RegisterResult registerFeature( QgsFeature& feature, QgsRenderContext& context, RuleToProviderMap& subProviders );
 
       protected:
         /**
@@ -243,7 +243,7 @@ class CORE_EXPORT QgsRuleBasedLabelProvider : public QgsVectorLayerLabelProvider
 
     virtual bool prepare( const QgsRenderContext& context, QStringList& attributeNames ) override;
 
-    virtual void registerFeature( QgsFeature& feature, const QgsRenderContext& context ) override;
+    virtual void registerFeature( QgsFeature& feature, QgsRenderContext& context ) override;
 
     // new methods
 

--- a/src/core/qgsvectorlayerdiagramprovider.cpp
+++ b/src/core/qgsvectorlayerdiagramprovider.cpp
@@ -78,7 +78,7 @@ QgsVectorLayerDiagramProvider::~QgsVectorLayerDiagramProvider()
 }
 
 
-QList<QgsLabelFeature*> QgsVectorLayerDiagramProvider::labelFeatures( const QgsRenderContext& context )
+QList<QgsLabelFeature*> QgsVectorLayerDiagramProvider::labelFeatures( QgsRenderContext &context )
 {
   if ( !mSource )
   {
@@ -226,7 +226,7 @@ bool QgsVectorLayerDiagramProvider::prepare( const QgsRenderContext& context, QS
 }
 
 
-void QgsVectorLayerDiagramProvider::registerFeature( QgsFeature& feature, const QgsRenderContext& context )
+void QgsVectorLayerDiagramProvider::registerFeature( QgsFeature& feature, QgsRenderContext& context )
 {
   QgsLabelFeature* label = registerDiagram( feature, context );
   if ( label )
@@ -234,7 +234,7 @@ void QgsVectorLayerDiagramProvider::registerFeature( QgsFeature& feature, const 
 }
 
 
-QgsLabelFeature* QgsVectorLayerDiagramProvider::registerDiagram( QgsFeature& feat, const QgsRenderContext& context )
+QgsLabelFeature* QgsVectorLayerDiagramProvider::registerDiagram( QgsFeature& feat, QgsRenderContext &context )
 {
   const QgsMapSettings& mapSettings = mEngine->mapSettings();
 

--- a/src/core/qgsvectorlayerdiagramprovider.h
+++ b/src/core/qgsvectorlayerdiagramprovider.h
@@ -70,7 +70,7 @@ class CORE_EXPORT QgsVectorLayerDiagramProvider : public QgsAbstractLabelProvide
     //! Clean up
     ~QgsVectorLayerDiagramProvider();
 
-    virtual QList<QgsLabelFeature*> labelFeatures( const QgsRenderContext& context ) override;
+    virtual QList<QgsLabelFeature*> labelFeatures( QgsRenderContext& context ) override;
 
     virtual void drawLabel( QgsRenderContext& context, pal::LabelPosition* label ) const override;
 
@@ -91,13 +91,13 @@ class CORE_EXPORT QgsVectorLayerDiagramProvider : public QgsAbstractLabelProvide
      * @param context render context. The QgsExpressionContext contained within the render context
      * must have already had the feature and fields sets prior to calling this method.
      */
-    virtual void registerFeature( QgsFeature& feature, const QgsRenderContext& context );
+    virtual void registerFeature( QgsFeature& feature, QgsRenderContext &context );
 
   protected:
     //! initialization method - called from constructors
     void init();
     //! helper method to register one diagram feautre
-    QgsLabelFeature* registerDiagram( QgsFeature& feat, const QgsRenderContext& context );
+    QgsLabelFeature* registerDiagram( QgsFeature& feat, QgsRenderContext& context );
 
   protected:
 

--- a/src/core/qgsvectorlayerlabelprovider.cpp
+++ b/src/core/qgsvectorlayerlabelprovider.cpp
@@ -237,7 +237,7 @@ bool QgsVectorLayerLabelProvider::prepare( const QgsRenderContext& context, QStr
 
 
 
-QList<QgsLabelFeature*> QgsVectorLayerLabelProvider::labelFeatures( const QgsRenderContext& ctx )
+QList<QgsLabelFeature*> QgsVectorLayerLabelProvider::labelFeatures( QgsRenderContext &ctx )
 {
   if ( !mSource )
   {
@@ -269,7 +269,7 @@ QList<QgsLabelFeature*> QgsVectorLayerLabelProvider::labelFeatures( const QgsRen
 }
 
 
-void QgsVectorLayerLabelProvider::registerFeature( QgsFeature& feature, const QgsRenderContext& context )
+void QgsVectorLayerLabelProvider::registerFeature( QgsFeature& feature, QgsRenderContext& context )
 {
   QgsLabelFeature* label = 0;
   mSettings.registerFeature( feature, context, QString(), &label );

--- a/src/core/qgsvectorlayerlabelprovider.h
+++ b/src/core/qgsvectorlayerlabelprovider.h
@@ -44,7 +44,7 @@ class CORE_EXPORT QgsVectorLayerLabelProvider : public QgsAbstractLabelProvider
 
     ~QgsVectorLayerLabelProvider();
 
-    virtual QList<QgsLabelFeature*> labelFeatures( const QgsRenderContext& context ) override;
+    virtual QList<QgsLabelFeature*> labelFeatures( QgsRenderContext& context ) override;
 
     virtual void drawLabel( QgsRenderContext& context, pal::LabelPosition* label ) const override;
 
@@ -65,7 +65,7 @@ class CORE_EXPORT QgsVectorLayerLabelProvider : public QgsAbstractLabelProvider
      * @param context render context. The QgsExpressionContext contained within the render context
      * must have already had the feature and fields sets prior to calling this method.
      */
-    virtual void registerFeature( QgsFeature& feature, const QgsRenderContext& context );
+    virtual void registerFeature( QgsFeature& feature, QgsRenderContext &context );
 
   protected:
     //! initialization method - called from constructors


### PR DESCRIPTION
Const is too restrictive in this case and required the use of messy const_casts. @wonder-sk this looks ok to you?
