### PR TITLE
Fixes line height and icon size on hidpi screens

### DIFF
--- a/src/gui/attributetable/qgsfeaturelistviewdelegate.cpp
+++ b/src/gui/attributetable/qgsfeaturelistviewdelegate.cpp
@@ -51,8 +51,10 @@ void QgsFeatureListViewDelegate::setEditSelectionModel( QItemSelectionModel* edi
 
 QSize QgsFeatureListViewDelegate::sizeHint( const QStyleOptionViewItem& option, const QModelIndex& index ) const
 {
-  Q_UNUSED( index )
-  return QSize( option.rect.width(), sIconSize );
+  Q_UNUSED( index );
+  QSize size = QItemDelegate::sizeHint(option, index);
+  size.setHeight( option.fontMetrics.height() );
+  return size;
 }
 
 void QgsFeatureListViewDelegate::paint( QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index ) const
@@ -78,6 +80,8 @@ void QgsFeatureListViewDelegate::paint( QPainter *painter, const QStyleOptionVie
   {
     icon = QgsApplication::getThemePixmap( "/mIconDeselected.svg" );
   }
+
+  icon = icon.scaledToWidth( option.rect.height() );
 
   // Text layout options
   QRect textLayoutBounds( iconLayoutBounds.x() + iconLayoutBounds.width(), option.rect.y(), option.rect.width() - ( iconLayoutBounds.x() + iconLayoutBounds.width() ), option.rect.height() );

--- a/src/gui/attributetable/qgsfeaturelistviewdelegate.cpp
+++ b/src/gui/attributetable/qgsfeaturelistviewdelegate.cpp
@@ -81,7 +81,7 @@ void QgsFeatureListViewDelegate::paint( QPainter *painter, const QStyleOptionVie
     icon = QgsApplication::getThemePixmap( "/mIconDeselected.svg" );
   }
 
-  icon = icon.scaledToWidth( option.rect.height() );
+  icon = icon.scaledToWidth( option.rect.height() - 1 );
 
   // Text layout options
   QRect textLayoutBounds( iconLayoutBounds.x() + iconLayoutBounds.width(), option.rect.y(), option.rect.width() - ( iconLayoutBounds.x() + iconLayoutBounds.width() ), option.rect.height() );

--- a/src/gui/attributetable/qgsfeaturelistviewdelegate.cpp
+++ b/src/gui/attributetable/qgsfeaturelistviewdelegate.cpp
@@ -52,7 +52,7 @@ void QgsFeatureListViewDelegate::setEditSelectionModel( QItemSelectionModel* edi
 QSize QgsFeatureListViewDelegate::sizeHint( const QStyleOptionViewItem& option, const QModelIndex& index ) const
 {
   Q_UNUSED( index );
-  QSize size = QItemDelegate::sizeHint(option, index);
+  QSize size = QItemDelegate::sizeHint( option, index );
   size.setHeight( option.fontMetrics.height() );
   return size;
 }


### PR DESCRIPTION
@nirvn (or any other with a 96dpi screen) would you please test this on a normal screen? 

2.10:
![qgis_unpatched](https://cloud.githubusercontent.com/assets/142164/10315455/bc126e42-6c5a-11e5-909c-ddc57d1f43c0.png)

this PR:
![qgis_patched](https://cloud.githubusercontent.com/assets/142164/10315456/bc46c638-6c5a-11e5-8059-349f05b31e8c.png)
