### PR TITLE
[atlas] fix crash when choosing a coverage layer which has not geometry

### DIFF
--- a/src/app/composer/qgsatlascompositionwidget.cpp
+++ b/src/app/composer/qgsatlascompositionwidget.cpp
@@ -42,7 +42,7 @@ QgsAtlasCompositionWidget::QgsAtlasCompositionWidget( QWidget* parent, QgsCompos
 {
   setupUi( this );
 
-  mAtlasCoverageLayerComboBox->setFilters( QgsMapLayerProxyModel::VectorLayer );
+  mAtlasCoverageLayerComboBox->setFilters( QgsMapLayerProxyModel::HasGeometry );
 
   connect( mAtlasCoverageLayerComboBox, SIGNAL( layerChanged( QgsMapLayer* ) ), mAtlasSortFeatureKeyComboBox, SLOT( setLayer( QgsMapLayer* ) ) );
   connect( mAtlasCoverageLayerComboBox, SIGNAL( layerChanged( QgsMapLayer* ) ), this, SLOT( changeCoverageLayer( QgsMapLayer* ) ) );


### PR DESCRIPTION
@nyalldawson I don't know why it was not crashing in earlier version, but now it does. I guess a layer without geometry can not be used as coverage, right?
