### PR TITLE
[processing] Update OGR tools

### DIFF
--- a/python/plugins/processing/algs/gdal/ogrinfo.py
+++ b/python/plugins/processing/algs/gdal/ogrinfo.py
@@ -27,6 +27,8 @@ __revision__ = '$Format:%H$'
 
 
 from processing.core.parameters import ParameterVector
+from processing.core.parameters import ParameterBoolean
+
 from processing.core.outputs import OutputHTML
 
 from processing.algs.gdal.GdalUtils import GdalUtils
@@ -36,6 +38,7 @@ from processing.algs.gdal.OgrAlgorithm import OgrAlgorithm
 class OgrInfo(OgrAlgorithm):
 
     INPUT = 'INPUT'
+    SUMMARY_ONLY = 'SUMMARY_ONLY'
     OUTPUT = 'OUTPUT'
 
     def defineCharacteristics(self):
@@ -44,13 +47,17 @@ class OgrInfo(OgrAlgorithm):
 
         self.addParameter(ParameterVector(self.INPUT, self.tr('Input layer'),
                           [ParameterVector.VECTOR_TYPE_ANY], False))
+        self.addParameter(ParameterBoolean(self.SUMMARY_ONLY,
+                                           self.tr('Summary output only'),
+                                           True))
 
         self.addOutput(OutputHTML(self.OUTPUT, self.tr('Layer information')))
 
     def getConsoleCommands(self):
         arguments = ["ogrinfo"]
         arguments.append('-al')
-        arguments.append('-so')
+        if self.getParameterValue(self.SUMMARY_ONLY):
+            arguments.append('-so')
         layer = self.getParameterValue(self.INPUT)
         conn = self.ogrConnectionString(layer)
         arguments.append(conn)

--- a/python/plugins/processing/algs/gdal/ogrsql.py
+++ b/python/plugins/processing/algs/gdal/ogrsql.py
@@ -65,7 +65,7 @@ class OgrSql(OgrAlgorithm):
         arguments.append(outFile)
 
         layer = self.getParameterValue(self.INPUT)
-        conn = self.ogrConnectionString(layer)
+        conn = self.ogrConnectionString(layer)[1:-1]
         arguments.append(conn)
 
         return ['ogr2ogr', GdalUtils.escapeAndJoin(arguments)]

--- a/python/plugins/processing/algs/gdal/ogrsql.py
+++ b/python/plugins/processing/algs/gdal/ogrsql.py
@@ -28,17 +28,21 @@ __revision__ = '$Format:%H$'
 from processing.core.GeoAlgorithmExecutionException import GeoAlgorithmExecutionException
 from processing.core.parameters import ParameterVector
 from processing.core.parameters import ParameterString
+from processing.core.parameters import ParameterSelection
 from processing.core.outputs import OutputVector
 
 from processing.algs.gdal.GdalUtils import GdalUtils
 from processing.algs.gdal.OgrAlgorithm import OgrAlgorithm
 
 
+DIALECTS = [None, 'ogrsql', 'sqlite']
+
 class OgrSql(OgrAlgorithm):
 
     INPUT = 'INPUT'
     OUTPUT = 'OUTPUT'
     SQL = 'SQL'
+    DIALECT = 'DIALECT'
 
     def defineCharacteristics(self):
         self.name, self.i18n_name = self.trAlgorithm('Execute SQL')
@@ -47,6 +51,12 @@ class OgrSql(OgrAlgorithm):
         self.addParameter(ParameterVector(self.INPUT, self.tr('Input layer'),
                           [ParameterVector.VECTOR_TYPE_ANY], False))
         self.addParameter(ParameterString(self.SQL, self.tr('SQL'), ''))
+
+        self.addParameter(ParameterSelection(
+            self.DIALECT,
+            self.tr('Dialect'),
+            DIALECTS)
+        )
 
         self.addOutput(OutputVector(self.OUTPUT, self.tr('SQL result')))
 
@@ -59,6 +69,13 @@ class OgrSql(OgrAlgorithm):
         arguments = []
         arguments.append('-sql')
         arguments.append(sql)
+
+        dialectIdx = self.getParameterValue(self.DIALECT)
+        dialect = DIALECTS[dialectIdx]
+
+        if dialect:
+            arguments.append("-dialect")
+            arguments.append(dialect)
 
         output = self.getOutputFromName(self.OUTPUT)
         outFile = output.value


### PR DESCRIPTION
I've made two modifications to the processing OGR tools:
- In the ogrinfo tool I've added the ability to turn off summary output as a boolean option (it's enabled by default).
- In the ogr2ogr SQL tool I've fixed the input path quoting, and added the abilty to select a SQL dialect via a dropdown menu (as an optional argument - default is still no dialect).

Note that these tools to change the arguments for these tools so scripts using them may be incompatible with the updated version. That said, the current SQL execution didn't work at all due to the extra quotes, so I believe that won't be an issue.
