### PR TITLE
Fix line height and icon size on hipi

### DIFF
--- a/src/gui/attributetable/qgsfeaturelistviewdelegate.cpp
+++ b/src/gui/attributetable/qgsfeaturelistviewdelegate.cpp
@@ -52,9 +52,8 @@ void QgsFeatureListViewDelegate::setEditSelectionModel( QItemSelectionModel* edi
 QSize QgsFeatureListViewDelegate::sizeHint( const QStyleOptionViewItem& option, const QModelIndex& index ) const
 {
   Q_UNUSED( index )
-  QSize size = QItemDelegate::sizeHint( option, index );
-  size.setHeight( option.fontMetrics.height() );
-  return size;
+  int height = sIconSize;
+  return QSize( option.rect.width(), qMax( height, option.fontMetrics.height() ) );
 }
 
 void QgsFeatureListViewDelegate::paint( QPainter *painter, const QStyleOptionViewItem &option, const QModelIndex &index ) const
@@ -80,6 +79,13 @@ void QgsFeatureListViewDelegate::paint( QPainter *painter, const QStyleOptionVie
   {
     icon = QgsApplication::getThemePixmap( "/mIconDeselected.svg" );
   }
+
+  // Scale up the icon if needed
+  if ( option.rect.height() > sIconSize )
+  {
+    icon = icon.scaledToHeight( option.rect.height(), Qt::SmoothTransformation );
+  }
+
 
   // Text layout options
   QRect textLayoutBounds( iconLayoutBounds.x() + iconLayoutBounds.width(), option.rect.y(), option.rect.width() - ( iconLayoutBounds.x() + iconLayoutBounds.width() ), option.rect.height() );


### PR DESCRIPTION
  The icon will scale up but not down, the 2.10
  behaviour is retained on 96dpi screens and
  the icon is scaled up if needed. Tested on 4k
  and on 1024x768
