### PR TITLE
Remove the extra argument to getConsoleCommands()

### DIFF
--- a/python/plugins/processing/algs/gdal/rasterize_over.py
+++ b/python/plugins/processing/algs/gdal/rasterize_over.py
@@ -54,7 +54,7 @@ class rasterize_over(OgrAlgorithm):
         self.addParameter(ParameterRaster(self.INPUT_RASTER,
                                           self.tr('Existing raster layer'), False))
 
-    def getConsoleCommands(self, progress):
+    def getConsoleCommands(self):
         inLayer = self.getParameterValue(self.INPUT)
         ogrLayer = self.ogrConnectionString(inLayer)[1:-1]
         inRasterLayer = self.getParameterValue(self.INPUT_RASTER)


### PR DESCRIPTION
getConsoleCommands takes only 1 arg. The extra arg in the method definition causes an error when running the algorithm
