### PR TITLE
Cleanup symbol definition widgets when switching between symbol layers

### DIFF
--- a/src/gui/symbology-ng/qgssymbolslistwidget.cpp
+++ b/src/gui/symbology-ng/qgssymbolslistwidget.cpp
@@ -118,6 +118,13 @@ QgsSymbolsListWidget::QgsSymbolsListWidget( QgsSymbolV2* symbol, QgsStyleV2* sty
   btnColor->setContext( "symbology" );
 }
 
+QgsSymbolsListWidget::~QgsSymbolsListWidget()
+{
+  // This action was added to the menu by this widget, clean it up
+  // The menu can be passed in the constructor, so may live longer than this widget
+  btnAdvanced->menu()->removeAction( mClipFeaturesAction );
+}
+
 void QgsSymbolsListWidget::setMapCanvas( QgsMapCanvas* canvas )
 {
   mMapCanvas = canvas;

--- a/src/gui/symbology-ng/qgssymbolslistwidget.h
+++ b/src/gui/symbology-ng/qgssymbolslistwidget.h
@@ -32,12 +32,16 @@ class GUI_EXPORT QgsSymbolsListWidget : public QWidget, private Ui::SymbolsListW
   public:
     QgsSymbolsListWidget( QgsSymbolV2* symbol, QgsStyleV2* style, QMenu* menu, QWidget* parent, const QgsVectorLayer * layer = 0 );
 
+    //! Destructor
+    virtual ~QgsSymbolsListWidget();
+
     /** Returns the expression context used for the widget, if set. This expression context is used for
      * evaluating data defined symbol properties and for populating based expression widgets in
      * the list widget.
      * @note added in QGIS 2.12
      * @see setExpressionContext()
      */
+
     QgsExpressionContext* expressionContext() const { return mPresetExpressionContext; }
 
     /** Sets the map canvas associated with the widget. This allows the widget to retrieve the current

--- a/src/gui/symbology-ng/qgssymbolv2selectordialog.cpp
+++ b/src/gui/symbology-ng/qgssymbolv2selectordialog.cpp
@@ -472,13 +472,8 @@ void QgsSymbolV2SelectorDialog::setWidget( QWidget* widget )
 {
   int index = stackedWidget->addWidget( widget );
   stackedWidget->setCurrentIndex( index );
-  if ( mPresentWidget )
-  {
-    stackedWidget->removeWidget( mPresentWidget );
-    QWidget *dummy = mPresentWidget;
-    mPresentWidget = widget;
-    delete dummy; // auto disconnects all signals
-  }
+  delete mPresentWidget;
+  mPresentWidget = widget;
 }
 
 void QgsSymbolV2SelectorDialog::updateLockButton()


### PR DESCRIPTION
Fix #13549
