### PR TITLE
[welcome page] fix recent project list not resizing on window / docked panel size change

### DIFF
--- a/src/app/qgswelcomepage.cpp
+++ b/src/app/qgswelcomepage.cpp
@@ -42,6 +42,8 @@ QgsWelcomePage::QgsWelcomePage( QWidget* parent )
   recentProjctsContainer->layout()->addWidget( recentProjectsTitle );
 
   QListView* recentProjectsListView = new QListView();
+  recentProjectsListView->setResizeMode( QListView::Adjust );
+
   mModel = new QgsWelcomePageItemsModel( recentProjectsListView );
   recentProjectsListView->setModel( mModel );
   recentProjectsListView->setItemDelegate( new QgsWelcomePageItemDelegate( recentProjectsListView ) );

--- a/src/app/qgswelcomepageitemsmodel.cpp
+++ b/src/app/qgswelcomepageitemsmodel.cpp
@@ -92,13 +92,23 @@ QSize QgsWelcomePageItemDelegate::sizeHint( const QStyleOptionViewItem & option,
   QTextDocument doc;
   QPixmap icon = qvariant_cast<QPixmap>( index.data( Qt::DecorationRole ) );
 
+  int width;
+  if ( option.rect.width() < 450 )
+  {
+    width = 450;
+  } 
+  else 
+  {
+    width = option.rect.width();
+  }
+
   int titleSize = QApplication::fontMetrics().height() * 1.1;
   int textSize = titleSize * 0.85;
 
   doc.setHtml( QString( "<div style='font-size:%1px;'><span style='font-size:%2px;font-weight:bold;'>%3</span><br>%4<br>%5</div>" ).arg( textSize ).arg( titleSize ).arg( index.data( QgsWelcomePageItemsModel::TitleRole ).toString() ).arg( index.data( QgsWelcomePageItemsModel::PathRole ).toString() ).arg( index.data( QgsWelcomePageItemsModel::CrsRole ).toString() ) );
-  doc.setTextWidth( option.rect.width() - ( !icon.isNull() ? icon.width() + 35 : 35 ) );
+  doc.setTextWidth( width - ( !icon.isNull() ? icon.width() + 35 : 35 ) );
 
-  return QSize( option.rect.width(), qMax( doc.size().height() + 10, ( double )icon.height() ) + 20 );
+  return QSize( width, qMax( doc.size().height() + 10, ( double )icon.height() ) + 20 );
 }
 
 QgsWelcomePageItemsModel::QgsWelcomePageItemsModel( QObject* parent )

--- a/src/app/qgswelcomepageitemsmodel.cpp
+++ b/src/app/qgswelcomepageitemsmodel.cpp
@@ -36,6 +36,8 @@ void QgsWelcomePageItemDelegate::paint( QPainter* painter, const QStyleOptionVie
   painter->save();
 
   QTextDocument doc;
+  QPixmap icon = qvariant_cast<QPixmap>( index.data( Qt::DecorationRole ) );
+
   QAbstractTextDocumentLayout::PaintContext ctx;
   QStyleOptionViewItemV4 optionV4 = option;
 
@@ -71,9 +73,8 @@ void QgsWelcomePageItemDelegate::paint( QPainter* painter, const QStyleOptionVie
   int textSize = titleSize * 0.85;
 
   doc.setHtml( QString( "<div style='font-size:%1px;'><span style='font-size:%2px;font-weight:bold;'>%3</span><br>%4<br>%5</div>" ).arg( textSize ).arg( titleSize ).arg( index.data( QgsWelcomePageItemsModel::TitleRole ).toString() ).arg( index.data( QgsWelcomePageItemsModel::PathRole ).toString() ).arg( index.data( QgsWelcomePageItemsModel::CrsRole ).toString() ) );
-  doc.setTextWidth( 2800 );
+  doc.setTextWidth( option.rect.width() - ( !icon.isNull() ? icon.width() + 35 : 35 ) );
 
-  QPixmap icon = qvariant_cast<QPixmap>( index.data( Qt::DecorationRole ) );
   if ( !icon.isNull() )
   {
     painter->drawPixmap( option.rect.left() + 10, option.rect.top()  + 10, icon );
@@ -89,14 +90,13 @@ void QgsWelcomePageItemDelegate::paint( QPainter* painter, const QStyleOptionVie
 QSize QgsWelcomePageItemDelegate::sizeHint( const QStyleOptionViewItem & option, const QModelIndex & index ) const
 {
   QTextDocument doc;
+  QPixmap icon = qvariant_cast<QPixmap>( index.data( Qt::DecorationRole ) );
 
   int titleSize = QApplication::fontMetrics().height() * 1.1;
   int textSize = titleSize * 0.85;
 
   doc.setHtml( QString( "<div style='font-size:%1px;'><span style='font-size:%2px;font-weight:bold;'>%3</span><br>%4<br>%5</div>" ).arg( textSize ).arg( titleSize ).arg( index.data( QgsWelcomePageItemsModel::TitleRole ).toString() ).arg( index.data( QgsWelcomePageItemsModel::PathRole ).toString() ).arg( index.data( QgsWelcomePageItemsModel::CrsRole ).toString() ) );
-  doc.setTextWidth( 2800 );
-
-  QPixmap icon = qvariant_cast<QPixmap>( index.data( Qt::DecorationRole ) );
+  doc.setTextWidth( option.rect.width() - ( !icon.isNull() ? icon.width() + 35 : 35 ) );
 
   return QSize( option.rect.width(), qMax( doc.size().height() + 10, ( double )icon.height() ) + 20 );
 }


### PR DESCRIPTION
@nyalldawson , @m-kuhn , the QListView was using the default QListView::Fixed resize mode, which prevented the recent project list item from resizing alongside the main window resizing. 

It also fixed the weird option.rect.width() value popping up before, so I've replaced the arbitrary setTextWidth value with a proper dynamically computed value.

_whew_ glad we'll fix this before 2.12 is released.
