### PR TITLE
the test for uniqueness now also works for multiple columns

### DIFF
--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -1324,12 +1324,12 @@ bool QgsPostgresProvider::determinePrimaryKey()
   return mValid;
 }
 
-bool QgsPostgresProvider::uniqueData( QString query, QString quotedColName )
+bool QgsPostgresProvider::uniqueData( QString query, QString quotedColNames )
 {
   Q_UNUSED( query );
-  // Check to see if the given column contains unique data
-  QString sql = QString( "SELECT count(distinct %1)=count(%1) FROM %2%3" )
-                .arg( quotedColName,
+  // Check to see if the given columns contain unique data
+  QString sql = QString( "SELECT count(distinct (%1))=count((%1)) AND bool_and((%1) IS NOT NULL) FROM %2%3" )
+                .arg( quotedColNames,
                       mQuery,
                       filterWhereClause() );
 

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -452,9 +452,9 @@ class QgsPostgresProvider : public QgsVectorDataProvider
       QString mWhat;
     };
 
-    // A function that determines if the given schema.table.column
-    // contains unqiue entries
-    bool uniqueData( QString query, QString colName );
+    // A function that determines if the given columns
+    // contain unique entries
+    bool uniqueData( QString query, QString quotedColNames );
 
     int mEnabledCapabilities;
 


### PR DESCRIPTION
When adding a **PostGIS layer** based on a **view** with a **primary key spanning more than one column** from a database **without _useEstimatedMetaData_** the layer is not added but an error is shown:
_Primary key field 'id1, id2' for view not unique._

The query to determine the uniqueness breaks and gives a syntax error when passed more than one column.
