### PR TITLE
Fix desktop-file-valide issues.

### DIFF
--- a/debian/qbrowser.desktop
+++ b/debian/qbrowser.desktop
@@ -53,4 +53,4 @@ Exec=/usr/bin/qbrowser %F
 Terminal=false
 StartupNotify=false
 Categories=Qt;Education;Science;Geography;
-Keywords=map;globe;postgis;wms;wfs;ogc;osgeo
+Keywords=map;globe;postgis;wms;wfs;ogc;osgeo;

--- a/debian/qgis.desktop
+++ b/debian/qgis.desktop
@@ -54,4 +54,4 @@ Terminal=false
 StartupNotify=false
 Categories=Qt;Education;Science;Geography;
 MimeType=application/x-qgis-project;image/tiff;image/jpeg;image/jp2;application/x-raster-aig;application/x-raster-ecw;application/x-raster-mrsid;application/x-mapinfo-mif;application/x-esri-shape;
-Keywords=map;globe;postgis;wms;wfs;ogc;osgeo
+Keywords=map;globe;postgis;wms;wfs;ogc;osgeo;


### PR DESCRIPTION
The `desktop-file-valide` utility reported the following issues:

```
debian/qbrowser.desktop: hint: value "Qt;Education;Science;Geography;" for key "Categories" in group "Desktop Entry" contains more than one main category; application might appear more than once in the application menu
debian/qbrowser.desktop: error: value "map;globe;postgis;wms;wfs;ogc;osgeo" for locale string list key "Keywords" in group "Desktop Entry" does not have a semicolon (';') as trailing character

debian/qgis.desktop: hint: value "Qt;Education;Science;Geography;" for key "Categories" in group "Desktop Entry" contains more than one main category; application might appear more than once in the application menu
debian/qgis.desktop: error: value "map;globe;postgis;wms;wfs;ogc;osgeo" for locale string list key "Keywords" in group "Desktop Entry" does not have a semicolon (';') as trailing character
```

Only the `Keywords` syntax error is addressed, the `Categories` hint is left as-is.
