### PR TITLE
FTools - Restore "Add result to canvas" option as default

### DIFF
--- a/python/plugins/fTools/tools/frmPointsInPolygon.ui
+++ b/python/plugins/fTools/tools/frmPointsInPolygon.ui
@@ -89,6 +89,9 @@
      <property name="text">
       <string>Add result to canvas</string>
      </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
     </widget>
    </item>
    <item row="22" column="0">

--- a/python/plugins/fTools/tools/frmVectorGrid.ui
+++ b/python/plugins/fTools/tools/frmVectorGrid.ui
@@ -369,6 +369,9 @@
      <property name="text">
       <string>Add result to canvas</string>
      </property>
+     <property name="checked">
+      <bool>true</bool>
+     </property>
     </widget>
    </item>
    <item row="6" column="0">


### PR DESCRIPTION
fixes #13647
Check the "Add Result to Canvas" option for "Points in Polygon" and "Grid vector" tools in Vector menu
