### PR TITLE
When we use the node tool we able to select a feature

### DIFF
--- a/src/app/nodetool/qgsmaptoolnodetool.h
+++ b/src/app/nodetool/qgsmaptoolnodetool.h
@@ -62,6 +62,11 @@ class QgsMapToolNodeTool: public QgsMapToolEdit
 
   private:
     /**
+     * Get the feature on the mouse click
+     */
+    QgsFeature getFeatureAtPoint( QgsMapMouseEvent* e );
+
+    /**
      * Deletes the rubber band pointers and clears mRubberBands
      */
     void removeRubberBands();

--- a/src/app/nodetool/qgsmaptoolnodetool.h
+++ b/src/app/nodetool/qgsmaptoolnodetool.h
@@ -67,6 +67,11 @@ class QgsMapToolNodeTool: public QgsMapToolEdit
     QgsFeature getFeatureAtPoint( QgsMapMouseEvent* e );
 
     /**
+     * Update select feature rubber band
+     */
+    void updateSelectFeature();
+
+    /**
      * Deletes the rubber band pointers and clears mRubberBands
      */
     void removeRubberBands();
@@ -120,6 +125,9 @@ class QgsMapToolNodeTool: public QgsMapToolEdit
 
     /** Rubber bands during node move */
     QMap<QgsFeatureId, QgsGeometryRubberBand*> mMoveRubberBands;
+
+    /** Rubber band for selected feature */
+    QgsGeometryRubberBand* mSelectRubberBand;
 
     /** Vertices of features to move */
     QMap<QgsFeatureId, QList< QPair<QgsVertexId, QgsPointV2> > > mMoveVertices;

--- a/src/gui/qgsmapcanvassnapper.cpp
+++ b/src/gui/qgsmapcanvassnapper.cpp
@@ -62,7 +62,8 @@ void QgsMapCanvasSnapper::setMapCanvas( QgsMapCanvas* canvas )
 int QgsMapCanvasSnapper::snapToCurrentLayer( const QPoint& p, QList<QgsSnappingResult>& results,
     QgsSnapper::SnappingType snap_to,
     double snappingTol,
-    const QList<QgsPoint>& excludePoints )
+    const QList<QgsPoint>& excludePoints,
+    bool allResutInTolerance )
 {
   results.clear();
 
@@ -71,7 +72,11 @@ int QgsMapCanvasSnapper::snapToCurrentLayer( const QPoint& p, QList<QgsSnappingR
 
   //topological editing on?
   int topologicalEditing = QgsProject::instance()->readNumEntry( "Digitizing", "/TopologicalEditing", 0 );
-  if ( topologicalEditing == 0 )
+  if ( allResutInTolerance )
+  {
+    mSnapper->setSnapMode( QgsSnapper::SnapWithResultsWithinTolerances);
+  }
+  else if ( topologicalEditing == 0 )
   {
     mSnapper->setSnapMode( QgsSnapper::SnapWithOneResult );
   }

--- a/src/gui/qgsmapcanvassnapper.h
+++ b/src/gui/qgsmapcanvassnapper.h
@@ -50,8 +50,10 @@ class GUI_EXPORT QgsMapCanvasSnapper
        @param results list to which the results are appended
        @param snap_to snap to vertex or to segment
        @param snappingTol snapping tolerance. -1 means that the search radius for vertex edits is taken
-       @param excludePoints a list with (map coordinate) points that should be excluded in the snapping result. Useful e.g. for vertex moves where a vertex should not be snapped to its original position*/
-    int snapToCurrentLayer( const QPoint& p, QList<QgsSnappingResult>& results, QgsSnapper::SnappingType snap_to, double snappingTol = -1, const QList<QgsPoint>& excludePoints = QList<QgsPoint>() );
+       @param excludePoints a list with (map coordinate) points that should be excluded in the snapping result. Useful e.g. for vertex moves where a vertex should not be snapped to its original position
+       @param allResutInTolerance return all thew results in the tollerance
+    */
+    int snapToCurrentLayer( const QPoint& p, QList<QgsSnappingResult>& results, QgsSnapper::SnappingType snap_to, double snappingTol = -1, const QList<QgsPoint>& excludePoints = QList<QgsPoint>(), bool allResutInTolerance = false );
     /** Snaps to the background layers. This method is useful to align the features of the
        edited layers to those of other layers (as described in the project properties).
        Uses snap mode QgsSnapper::SnapWithOneResult. Therefore, only the


### PR DESCRIPTION
When we have two geometry with a node at the same position (we have this many times when the geometries are topicality correct) actually it's not possible when we click on a node to chose witch one is selected.

With this pull request when we click on a feature it will be "selected" (for the node tool).

fix https://hub.qgis.org/issues/11022

These features were funded by: MEDDE (French Ministry of Sustainable Development)
