### PR TITLE
fix processing GRASS 7 v.out.ogr

### DIFF
--- a/python/plugins/processing/algs/grass7/Grass7Algorithm.py
+++ b/python/plugins/processing/algs/grass7/Grass7Algorithm.py
@@ -402,21 +402,21 @@ class Grass7Algorithm(GeoAlgorithm):
                 outtype = ('auto' if typeidx
                            is None else self.OUTPUT_TYPES[typeidx])
                 if self.grass7Name == 'r.flow':
-                    command = 'v.out.ogr type=line layer=0 -c -s -e input=' + out.name + uniqueSufix
+                    command = 'v.out.ogr type=line layer=0 -s -e input=' + out.name + uniqueSufix
                 elif self.grass7Name == 'v.voronoi':
                     if '-l' in command:
-                        command = 'v.out.ogr type=line layer=0 -c -s -e input=' + out.name + uniqueSufix
+                        command = 'v.out.ogr type=line layer=0 -s -e input=' + out.name + uniqueSufix
                     else:
-                        command = 'v.out.ogr -c -s -e input=' + out.name + uniqueSufix
+                        command = 'v.out.ogr -s -e input=' + out.name + uniqueSufix
                         command += ' type=' + outtype
                 elif self.grass7Name == 'v.sample':
-                    command = 'v.out.ogr type=point -c -s -e input=' + out.name + uniqueSufix
+                    command = 'v.out.ogr type=point -s -e input=' + out.name + uniqueSufix
                 else:
-                    command = 'v.out.ogr -c -s -e input=' + out.name + uniqueSufix
+                    command = 'v.out.ogr -s -e input=' + out.name + uniqueSufix
                     command += ' type=' + outtype
                 command += ' output="' + os.path.dirname(out.value) + '"'
                 command += ' format=ESRI_Shapefile'
-                command += ' olayer=' + os.path.basename(out.value)[:-4]
+                command += ' output_layer=' + os.path.basename(out.value)[:-4]
                 commands.append(command)
                 outputCommands.append(command)
 


### PR DESCRIPTION
Just noticed that GRASS 7 v.out.ogr had a wrong parameter ("output_layer" not "olayer", that is the GRASS 6 one) and that the "-c" switch does not seems a good default (moreover I found that in some cases it makes GRASS crash). I will provide a patch to add "-c" and "-m" as optional, advanced parameters.
