### PR TITLE
Fix armv7hl build

### DIFF
--- a/src/app/qgswelcomepageitemsmodel.cpp
+++ b/src/app/qgswelcomepageitemsmodel.cpp
@@ -114,7 +114,7 @@ QSize QgsWelcomePageItemDelegate::sizeHint( const QStyleOptionViewItem & option,
                      index.data( QgsWelcomePageItemsModel::CrsRole ).toString() ) );
   doc.setTextWidth( width - ( !icon.isNull() ? icon.width() + 35 : 35 ) );
 
-  return QSize( width, qMax( doc.size().height() + 10, ( double )icon.height() ) + 20 );
+  return QSize( width, qMax( ( double ) doc.size().height() + 10, ( double )icon.height() ) + 20 );
 }
 
 QgsWelcomePageItemsModel::QgsWelcomePageItemsModel( QObject* parent )


### PR DESCRIPTION
I'm not sure if the approach is correct, but it fixes the build.

[ 72%] Building CXX object src/plugins/roadgraph/CMakeFiles/roadgraphplugin.dir/linevectorlayerwidget.cpp.o
cd /builddir/build/BUILD/qgis-2.12.0/src/plugins/roadgraph && /usr/bin/c++   -DQT_CORE_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_NO_CAST_TO_ASCII -DQT_NO_DEBUG -DQT_SQL_LIB -DQT_SVG_LIB -DQT_WEBKIT_LIB -DQT_XML_LIB -DWITH_QTWEBKIT -Droadgraphplugin_EXPORTS -isystem /usr/include/QtSvg -isystem /usr/include/QtWebKit -isystem /usr/include/QtGui -isystem /usr/include/QtXml -isystem /usr/include/QtSql -isystem /usr/include/QtNetwork -isystem /usr/include/QtCore -I/builddir/build/BUILD/qgis-2.12.0 -I/builddir/build/BUILD/qgis-2.12.0/src/plugins/roadgraph -I/builddir/build/BUILD/qgis-2.12.0/src/plugins/roadgraph/../../core -I/builddir/build/BUILD/qgis-2.12.0/src/plugins/roadgraph/../../core/geometry -I/builddir/build/BUILD/qgis-2.12.0/src/plugins/roadgraph/../../gui -I/builddir/build/BUILD/qgis-2.12.0/src/plugins/roadgraph/../../analysis/network -I/builddir/build/BUILD/qgis-2.12.0/src/plugins/roadgraph/..  -O2 -g -pipe -Wall -Werror=format-security -Wp,-D_FORTIFY_SOURCE=2 -fexceptions -fstack-protector-strong --param=ssp-buffer-size=4 -grecord-gcc-switches -specs=/usr/lib/rpm/redhat/redhat-hardened-cc1 -march=armv7-a -mfpu=vfpv3-d16  -mfloat-abi=hard  -DSPATIALITE_VERSION_GE_4_0_0 -DSPATIALITE_VERSION_G_4_1_1 -DSPATIALITE_HAS_INIT_EX -std=c++11 -Wall -Wextra -Wno-long-long -Wformat-security -Wno-strict-aliasing -fvisibility=hidden -fvisibility-inlines-hidden -fPIC   -DCORE_EXPORT= -DGUI_EXPORT= -DPYTHON_EXPORT= -DANALYSIS_EXPORT= -DAPP_EXPORT= -DCUSTOMWIDGETS_EXPORT= -DSERVER_EXPORT= -o CMakeFiles/roadgraphplugin.dir/linevectorlayerwidget.cpp.o -c /builddir/build/BUILD/qgis-2.12.0/src/plugins/roadgraph/linevectorlayerwidget.cpp
/builddir/build/BUILD/qgis-2.12.0/src/app/qgswelcomepageitemsmodel.cpp: In member function 'virtual QSize QgsWelcomePageItemDelegate::sizeHint(const QStyleOptionViewItem&, const QModelIndex&) const':
/builddir/build/BUILD/qgis-2.12.0/src/app/qgswelcomepageitemsmodel.cpp:117:80: error: no matching function for call to 'qMax(qreal, double)'
   return QSize( width, qMax( doc.size().height() + 10, ( double )icon.height() ) + 20 );
                                                                                ^
In file included from /usr/include/QtCore/qatomic.h:45:0,
                 from /usr/include/QtCore/qvariant.h:45,
                 from /usr/include/QtCore/qabstractitemmodel.h:45,
                 from /usr/include/QtCore/QAbstractListModel:1,
                 from /builddir/build/BUILD/qgis-2.12.0/src/app/qgswelcomepageitemsmodel.h:19,
                 from /builddir/build/BUILD/qgis-2.12.0/src/app/qgswelcomepageitemsmodel.cpp:16:
/usr/include/QtCore/qglobal.h:1328:34: note: candidate: template<class T> constexpr const T& qMax(const T&, const T&)
 Q_DECL_CONSTEXPR inline const T &qMax(const T &a, const T &b) { return (a < b) ? b : a; }
                                  ^
/usr/include/QtCore/qglobal.h:1328:34: note:   template argument deduction/substitution failed:
/builddir/build/BUILD/qgis-2.12.0/src/app/qgswelcomepageitemsmodel.cpp:117:80: note:   deduced conflicting types for parameter 'const T' ('float' and 'double')
   return QSize( width, qMax( doc.size().height() + 10, ( double )icon.height() ) + 20 );
                                                                                ^
src/app/CMakeFiles/qgis_app.dir/build.make:1945: recipe for target 'src/app/CMakeFiles/qgis_app.dir/qgswelcomepageitemsmodel.cpp.o' failed
make[2]: **\* [src/app/CMakeFiles/qgis_app.dir/qgswelcomepageitemsmodel.cpp.o] Error 1
