### PR TITLE
Postgresql provider - Use ST_RemoveRepeatedPoints instead of ST_SnapToGrid

### DIFF
--- a/python/core/qgssimplifymethod.sip
+++ b/python/core/qgssimplifymethod.sip
@@ -26,10 +26,15 @@ class QgsSimplifyMethod
     //! Gets the simplification type
     MethodType methodType() const;
 
-    //! Sets the tolerance of simplification. Represents the maximum distance between two coordinates which can be considered equal
+    //! Sets the tolerance of simplification in map units. Represents the maximum distance between two coordinates which can be considered equal
     void setTolerance( double tolerance );
-    //! Gets the tolerance of simplification
+    //! Gets the tolerance of simplification in map units
     double tolerance() const;
+
+    //! Sets the simplification threshold in pixels. Represents the maximum distance in pixels between two coordinates which can be considered equal.
+    void setThreshold( float threshold );
+    //! Gets the simplification threshold in pixels. Represents the maximum distance in pixels between two coordinates which can be considered equal.
+    float threshold() const;
 
     //! Sets whether the simplification executes after fetch the geometries from provider, otherwise it executes, when supported, in provider before fetch the geometries
     void setForceLocalOptimization( bool localOptimization );

--- a/src/core/qgssimplifymethod.cpp
+++ b/src/core/qgssimplifymethod.cpp
@@ -21,6 +21,7 @@
 QgsSimplifyMethod::QgsSimplifyMethod()
     : mMethodType( QgsSimplifyMethod::NoSimplification )
     , mTolerance( 1 )
+    , mThreshold( 1 )
     , mForceLocalOptimization( true )
 {
 }
@@ -34,6 +35,7 @@ QgsSimplifyMethod& QgsSimplifyMethod::operator=( const QgsSimplifyMethod & rh )
 {
   mMethodType = rh.mMethodType;
   mTolerance = rh.mTolerance;
+  mThreshold = rh.mThreshold;
   mForceLocalOptimization = rh.mForceLocalOptimization;
 
   return *this;

--- a/src/core/qgssimplifymethod.h
+++ b/src/core/qgssimplifymethod.h
@@ -44,10 +44,15 @@ class CORE_EXPORT QgsSimplifyMethod
     //! Gets the simplification type
     inline MethodType methodType() const { return mMethodType; }
 
-    //! Sets the tolerance of simplification. Represents the maximum distance between two coordinates which can be considered equal
+    //! Sets the tolerance of simplification in map units. Represents the maximum distance in map units between two coordinates which can be considered equal.
     void setTolerance( double tolerance );
-    //! Gets the tolerance of simplification
+    //! Gets the tolerance of simplification in map units . Represents the maximum distance in map units between two coordinates which can be considered equal.
     inline double tolerance() const { return mTolerance; }
+
+    //! Sets the simplification threshold in pixels. Represents the maximum distance in pixels between two coordinates which can be considered equal.
+    void setThreshold( float threshold ) { mThreshold = threshold; }
+    //! Gets the simplification threshold in pixels. Represents the maximum distance in pixels between two coordinates which can be considered equal.
+    inline float threshold() const { return mThreshold; }
 
     //! Sets whether the simplification executes after fetch the geometries from provider, otherwise it executes, when supported, in provider before fetch the geometries
     void setForceLocalOptimization( bool localOptimization );
@@ -62,6 +67,8 @@ class CORE_EXPORT QgsSimplifyMethod
     MethodType mMethodType;
     //! Tolerance of simplification, it represents the maximum distance between two coordinates which can be considered equal
     double mTolerance;
+    /** Simplification threshold */
+    float mThreshold;
     //! Simplification executes after fetch the geometries from provider, otherwise it executes, when supported, in provider before fetch the geometries
     bool mForceLocalOptimization;
 };

--- a/src/core/qgsvectorlayerrenderer.cpp
+++ b/src/core/qgsvectorlayerrenderer.cpp
@@ -218,6 +218,8 @@ bool QgsVectorLayerRenderer::render()
       QgsSimplifyMethod simplifyMethod;
       simplifyMethod.setMethodType( QgsSimplifyMethod::OptimizeForRendering );
       simplifyMethod.setTolerance( map2pixelTol );
+      simplifyMethod.setThreshold( mSimplifyMethod.threshold() );
+
       simplifyMethod.setForceLocalOptimization( mSimplifyMethod.forceLocalOptimization() );
 
       featureRequest.setSimplifyMethod( simplifyMethod );


### PR DESCRIPTION
When using a PostGIS 2.2 instance, we can now use the ST_RemoveRepeatedPoints function instead of the ST_SnapToGrid function, as described by Paul Ramsey : http://blog.cartodb.com/smaller-faster/
