### PR TITLE
Fix FilterExpression feature requests will ignore expression sometimes

### DIFF
--- a/src/core/qgsvectorlayerfeatureiterator.cpp
+++ b/src/core/qgsvectorlayerfeatureiterator.cpp
@@ -236,6 +236,17 @@ bool QgsVectorLayerFeatureIterator::fetchFeature( QgsFeature& f )
     if ( mHasVirtualAttributes )
       addVirtualAttributes( f );
 
+    if ( mRequest.filterType() == QgsFeatureRequest::FilterExpression && mProviderRequest.filterType() != QgsFeatureRequest::FilterExpression )
+    {
+        //filtering by expression, and couldn't do it on the provider side
+        mRequest.expressionContext()->setFeature( f );
+        if ( !mRequest.filterExpression()->evaluate( mRequest.expressionContext() ).toBool() )
+        {
+          //feature did not match filter
+          continue;
+        }
+    }
+
     // update geometry
     // TODO[MK]: FilterRect check after updating the geometry
     if ( !( mRequest.flags() & QgsFeatureRequest::NoGeometry ) )


### PR DESCRIPTION
eg, if using virtual fields or other complex filters.

This fixes the second issue described in http://hub.qgis.org/issues/13695 , which seems to have been introduced by 480a0f17c3

I'm not 100% sure there aren't further issues or repercussions of this fix, so would value a second opinion. @m-kuhn?
