### PR TITLE
[FEATURE] assistant for varying line width

### DIFF
--- a/python/core/qgsscaleexpression.sip
+++ b/python/core/qgsscaleexpression.sip
@@ -36,8 +36,9 @@ class QgsScaleExpression : QgsExpression
      * @param minSize minimum size
      * @param maxSize maximum size
      * @param nullSize size in case expression evaluates to NULL
+     * @param exponent to use in case of Exponential type
      */
-    QgsScaleExpression( Type type, const QString& baseExpression, double minValue, double maxValue, double minSize, double maxSize, double nullSize = 0 );
+    QgsScaleExpression( Type type, const QString& baseExpression, double minValue, double maxValue, double minSize, double maxSize, double nullSize = 0, double exponent = 1 );
 
     operator bool() const;
 
@@ -73,6 +74,11 @@ class QgsScaleExpression : QgsExpression
      * @see nullSize
      */
     double nullSize() const;
+
+    /** Returns the exponent of the exponential expression.
+     * @see exponent
+     */
+    double exponent() const;
 
     /** Returns the base expression string (or field reference) used for
      * calculating the values to be mapped to a size.

--- a/python/core/symbology-ng/qgslinesymbollayerv2.sip
+++ b/python/core/symbology-ng/qgslinesymbollayerv2.sip
@@ -209,6 +209,8 @@ class QgsMarkerLineSymbolLayerV2 : QgsLineSymbolLayerV2
 
     QSet<QString> usedAttributes() const;
 
+    void setDataDefinedProperty( const QString& property, QgsDataDefined* dataDefined /Transfer/ );
+
   protected:
 
     void renderPolylineInterval( const QPolygonF& points, QgsSymbolV2RenderContext& context );

--- a/src/core/qgsscaleexpression.cpp
+++ b/src/core/qgsscaleexpression.cpp
@@ -26,12 +26,13 @@ QgsScaleExpression::QgsScaleExpression( const QString& expression )
     , mMinValue( 0 )
     , mMaxValue( 100 )
     , mNullSize( 0 )
+    , mExponent( 1 )
 {
   init();
 }
 
-QgsScaleExpression::QgsScaleExpression( Type type, const QString& baseExpression, double minValue, double maxValue, double minSize, double maxSize, double nullSize )
-    : QgsExpression( createExpression( type, baseExpression, minValue, maxValue, minSize, maxSize, nullSize ) )
+QgsScaleExpression::QgsScaleExpression( Type type, const QString& baseExpression, double minValue, double maxValue, double minSize, double maxSize, double nullSize, double exponent )
+    : QgsExpression( createExpression( type, baseExpression, minValue, maxValue, minSize, maxSize, nullSize, exponent ) )
     , mExpression( baseExpression )
     , mType( type )
     , mMinSize( minSize )
@@ -39,8 +40,25 @@ QgsScaleExpression::QgsScaleExpression( Type type, const QString& baseExpression
     , mMinValue( minValue )
     , mMaxValue( maxValue )
     , mNullSize( nullSize )
+    , mExponent( 1 )
 {
-
+  switch ( type )
+  {
+    case Linear:
+      mExponent = 1;
+      break;
+    case Area:
+      mExponent = .5;
+      break;
+    case Flannery:
+      mExponent = .57;
+      break;
+    case Exponential:
+      mExponent = exponent;
+      break;
+    case Unknown:
+      break;
+  }
 }
 
 void QgsScaleExpression::init()
@@ -76,17 +94,15 @@ void QgsScaleExpression::init()
   }
   else if ( "scale_exp" == Functions()[f->fnIndex()]->name() )
   {
-    const double exp = QgsExpression( args[5]->dump() ).evaluate().toDouble( &ok );
+    mExponent = QgsExpression( args[5]->dump() ).evaluate().toDouble( &ok );
     if ( ! ok )
       return;
-    if ( qgsDoubleNear( exp, 0.57, 0.001 ) )
+    if ( qgsDoubleNear( mExponent, 0.57, 0.001 ) )
       mType = Flannery;
-    else if ( qgsDoubleNear( exp, 0.5, 0.001 ) )
+    else if ( qgsDoubleNear( mExponent, 0.5, 0.001 ) )
       mType = Area;
     else
-    {
-      return;
-    }
+      mType = Exponential;
   }
   else
   {
@@ -111,13 +127,14 @@ void QgsScaleExpression::init()
   mExpression = args[0]->dump();
 }
 
-QString QgsScaleExpression::createExpression( Type type, const QString & baseExpr, double minValue, double maxValue, double minSize, double maxSize, double nullSize )
+QString QgsScaleExpression::createExpression( Type type, const QString & baseExpr, double minValue, double maxValue, double minSize, double maxSize, double nullSize, double exponent )
 {
   QString minValueString = QString::number( minValue );
   QString maxValueString = QString::number( maxValue );
   QString minSizeString = QString::number( minSize );
   QString maxSizeString = QString::number( maxSize );
   QString nullSizeString = QString::number( nullSize );
+  QString exponentString = QString::number( exponent );
 
   switch ( type )
   {
@@ -125,10 +142,9 @@ QString QgsScaleExpression::createExpression( Type type, const QString & baseExp
       return QString( "coalesce(scale_linear(%1, %2, %3, %4, %5), %6)" ).arg( baseExpr, minValueString, maxValueString, minSizeString, maxSizeString, nullSizeString );
 
     case Area:
-      return QString( "coalesce(scale_exp(%1, %2, %3, %4, %5, 0.5), %6)" ).arg( baseExpr, minValueString, maxValueString, minSizeString, maxSizeString, nullSizeString );
-
     case Flannery:
-      return QString( "coalesce(scale_exp(%1, %2, %3, %4, %5, 0.57), %6)" ).arg( baseExpr, minValueString, maxValueString, minSizeString, maxSizeString, nullSizeString );
+    case Exponential:
+      return QString( "coalesce(scale_exp(%1, %2, %3, %4, %5, %6), %7)" ).arg( baseExpr, minValueString, maxValueString, minSizeString, maxSizeString, exponentString, nullSizeString );
 
     case Unknown:
       break;
@@ -144,10 +160,9 @@ double QgsScaleExpression::size( double value ) const
       return mMinSize + ( qBound( mMinValue, value, mMaxValue ) - mMinValue ) * ( mMaxSize - mMinSize ) / ( mMaxValue - mMinValue );
 
     case Area:
-      return mMinSize + qPow( qBound( mMinValue, value, mMaxValue ) - mMinValue, .5 ) * ( mMaxSize - mMinSize ) / qPow( mMaxValue - mMinValue, .5 );
-
     case Flannery:
-      return mMinSize + qPow( qBound( mMinValue, value, mMaxValue ) - mMinValue, .57 ) * ( mMaxSize - mMinSize ) / qPow( mMaxValue - mMinValue, .57 );
+    case Exponential:
+      return mMinSize + qPow( qBound( mMinValue, value, mMaxValue ) - mMinValue, mExponent ) * ( mMaxSize - mMinSize ) / qPow( mMaxValue - mMinValue, mExponent );
 
     case Unknown:
       break;

--- a/src/core/qgsscaleexpression.h
+++ b/src/core/qgsscaleexpression.h
@@ -34,6 +34,7 @@ class CORE_EXPORT QgsScaleExpression : public QgsExpression
       Linear,
       Area,
       Flannery,
+      Exponential,
       Unknown
     };
 
@@ -52,8 +53,9 @@ class CORE_EXPORT QgsScaleExpression : public QgsExpression
      * @param minSize minimum size
      * @param maxSize maximum size
      * @param nullSize size in case expression evaluates to NULL
+     * @param exponent to use in case of Exponential type
      */
-    QgsScaleExpression( Type type, const QString& baseExpression, double minValue, double maxValue, double minSize, double maxSize, double nullSize = 0 );
+    QgsScaleExpression( Type type, const QString& baseExpression, double minValue, double maxValue, double minSize, double maxSize, double nullSize = 0, double exponent = 1 );
 
     operator bool() const { return ! mExpression.isEmpty(); }
 
@@ -90,6 +92,11 @@ class CORE_EXPORT QgsScaleExpression : public QgsExpression
      */
     double nullSize() const { return mNullSize; }
 
+    /** Returns the exponent of the exponential expression.
+     * @see exponent
+     */
+    double exponent() const { return mExponent; }
+
     /** Returns the base expression string (or field reference) used for
      * calculating the values to be mapped to a size.
      */
@@ -108,9 +115,10 @@ class CORE_EXPORT QgsScaleExpression : public QgsExpression
     double mMinValue;
     double mMaxValue;
     double mNullSize;
+    double mExponent;
 
     void init();
-    static QString createExpression( Type type, const QString& baseExpr, double minValue, double maxValue, double minSize, double maxSize, double nullSize );
+    static QString createExpression( Type type, const QString& baseExpr, double minValue, double maxValue, double minSize, double maxSize, double nullSize, double exponent );
 
 };
 

--- a/src/core/symbology-ng/qgslinesymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgslinesymbollayerv2.cpp
@@ -1502,6 +1502,15 @@ void QgsMarkerLineSymbolLayerV2::setWidth( double width )
   mMarker->setSize( width );
 }
 
+void QgsMarkerLineSymbolLayerV2::setDataDefinedProperty( const QString& property, QgsDataDefined* dataDefined )
+{
+  if ( property == QgsSymbolLayerV2::EXPR_WIDTH && mMarker && dataDefined )
+  {
+    mMarker->setDataDefinedSize( *dataDefined );
+  }
+  QgsLineSymbolLayerV2::setDataDefinedProperty( property, dataDefined );
+}
+
 double QgsMarkerLineSymbolLayerV2::width() const
 {
   return mMarker->size();

--- a/src/core/symbology-ng/qgslinesymbollayerv2.h
+++ b/src/core/symbology-ng/qgslinesymbollayerv2.h
@@ -259,6 +259,9 @@ class CORE_EXPORT QgsMarkerLineSymbolLayerV2 : public QgsLineSymbolLayerV2
 
     QSet<QString> usedAttributes() const override;
 
+    void setDataDefinedProperty( const QString& property, QgsDataDefined* dataDefined ) override;
+
+
   protected:
 
     void renderPolylineInterval( const QPolygonF& points, QgsSymbolV2RenderContext& context );

--- a/src/gui/symbology-ng/qgssizescalewidget.h
+++ b/src/gui/symbology-ng/qgssizescalewidget.h
@@ -24,7 +24,7 @@
 #include <QStandardItemModel>
 
 class QgsVectorLayer;
-class QgsMarkerSymbolV2;
+class QgsSymbolV2;
 class QgsLayerTreeLayer;
 class QgsScaleExpression;
 class QgsDataDefined;
@@ -35,7 +35,7 @@ class GUI_EXPORT QgsSizeScaleWidget : public QgsDataDefinedAssistant, private Ui
     Q_OBJECT
 
   public:
-    QgsSizeScaleWidget( const QgsVectorLayer * layer, const QgsMarkerSymbolV2 * symbol );
+    QgsSizeScaleWidget( const QgsVectorLayer * layer, const QgsSymbolV2 * symbol );
 
     QgsDataDefined dataDefined() const override;
 
@@ -54,7 +54,7 @@ class GUI_EXPORT QgsSizeScaleWidget : public QgsDataDefinedAssistant, private Ui
 
   private:
 
-    const QgsMarkerSymbolV2* mSymbol;
+    const QgsSymbolV2* mSymbol;
     QgsVectorLayer* mLayer;
     QgsLayerTreeLayer* mLayerTreeLayer;
     QgsLayerTreeGroup mRoot;

--- a/src/gui/symbology-ng/qgssymbollayerv2widget.h
+++ b/src/gui/symbology-ng/qgssymbollayerv2widget.h
@@ -112,6 +112,8 @@ class GUI_EXPORT QgsSimpleLineSymbolLayerV2Widget : public QgsSymbolLayerV2Widge
   public:
     QgsSimpleLineSymbolLayerV2Widget( const QgsVectorLayer* vl, QWidget* parent = NULL );
 
+    ~QgsSimpleLineSymbolLayerV2Widget();
+
     static QgsSymbolLayerV2Widget* create( const QgsVectorLayer* vl ) { return new QgsSimpleLineSymbolLayerV2Widget( vl ); }
 
     // from base class
@@ -135,6 +137,14 @@ class GUI_EXPORT QgsSimpleLineSymbolLayerV2Widget : public QgsSymbolLayerV2Widge
 
     //creates a new icon for the 'change pattern' button
     void updatePatternIcon();
+
+  private slots:
+
+    void updateAssistantSymbol();
+
+  private:
+
+    QgsLineSymbolV2* mAssistantPreviewSymbol;
 
 };
 

--- a/src/gui/symbology-ng/qgssymbolslistwidget.cpp
+++ b/src/gui/symbology-ng/qgssymbolslistwidget.cpp
@@ -73,7 +73,7 @@ QgsSymbolsListWidget::QgsSymbolsListWidget( QgsSymbolV2* symbol, QgsStyleV2* sty
   groupsCombo->addItem( "" );
   populateGroups();
   QStringList groups = style->smartgroupNames();
-  Q_FOREACH ( const QString& group, groups )
+  Q_FOREACH( const QString& group, groups )
   {
     groupsCombo->addItem( group, QVariant( "smart" ) );
   }
@@ -109,7 +109,9 @@ QgsSymbolsListWidget::QgsSymbolsListWidget( QgsSymbolV2* symbol, QgsStyleV2* sty
   connect( mWidthDDBtn, SIGNAL( dataDefinedActivated( bool ) ), this, SLOT( updateDataDefinedLineWidth() ) );
 
   if ( mSymbol->type() == QgsSymbolV2::Marker && mLayer )
-    mSizeDDBtn->setAssistant( tr( "Size Assistant..." ), new QgsSizeScaleWidget( mLayer, static_cast<const QgsMarkerSymbolV2*>( mSymbol ) ) );
+    mSizeDDBtn->setAssistant( tr( "Size Assistant..." ), new QgsSizeScaleWidget( mLayer, mSymbol ) );
+  else if ( mSymbol->type() == QgsSymbolV2::Line && mLayer )
+    mWidthDDBtn->setAssistant( tr( "Width Assistant..." ), new QgsSizeScaleWidget( mLayer, mSymbol ) );
 
   // Live color updates are not undoable to child symbol layers
   btnColor->setAcceptLiveUpdates( false );
@@ -128,11 +130,11 @@ QgsSymbolsListWidget::~QgsSymbolsListWidget()
 void QgsSymbolsListWidget::setMapCanvas( QgsMapCanvas* canvas )
 {
   mMapCanvas = canvas;
-  Q_FOREACH ( QgsUnitSelectionWidget* unitWidget, findChildren<QgsUnitSelectionWidget*>() )
+  Q_FOREACH( QgsUnitSelectionWidget* unitWidget, findChildren<QgsUnitSelectionWidget*>() )
   {
     unitWidget->setMapCanvas( canvas );
   }
-  Q_FOREACH ( QgsDataDefinedButton* ddButton, findChildren<QgsDataDefinedButton*>() )
+  Q_FOREACH( QgsDataDefinedButton* ddButton, findChildren<QgsDataDefinedButton*>() )
   {
     if ( ddButton->assistant() )
       ddButton->assistant()->setMapCanvas( mMapCanvas );
@@ -427,7 +429,7 @@ void QgsSymbolsListWidget::updateSymbolInfo()
 {
   updateSymbolColor();
 
-  Q_FOREACH ( QgsDataDefinedButton* button, findChildren< QgsDataDefinedButton* >() )
+  Q_FOREACH( QgsDataDefinedButton* button, findChildren< QgsDataDefinedButton* >() )
   {
     button->registerGetExpressionContextCallback( &_getExpressionContext, this );
   }

--- a/src/ui/symbollayer/widget_size_scale.ui
+++ b/src/ui/symbollayer/widget_size_scale.ui
@@ -30,14 +30,14 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="0">
+     <item row="3" column="0">
       <widget class="QLabel" name="label_5">
        <property name="text">
         <string>Size from</string>
        </property>
       </widget>
      </item>
-     <item row="2" column="1">
+     <item row="3" column="1">
       <widget class="QgsDoubleSpinBox" name="minSizeSpinBox">
        <property name="decimals">
         <number>6</number>
@@ -53,14 +53,14 @@
        </property>
       </widget>
      </item>
-     <item row="2" column="2">
+     <item row="3" column="2">
       <widget class="QLabel" name="label_6">
        <property name="text">
         <string>to</string>
        </property>
       </widget>
      </item>
-     <item row="2" column="3">
+     <item row="3" column="3">
       <widget class="QgsDoubleSpinBox" name="maxSizeSpinBox">
        <property name="decimals">
         <number>6</number>
@@ -73,14 +73,14 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="0">
+     <item row="4" column="0">
       <widget class="QLabel" name="label_3">
        <property name="text">
         <string>Values from</string>
        </property>
       </widget>
      </item>
-     <item row="3" column="1">
+     <item row="4" column="1">
       <widget class="QgsDoubleSpinBox" name="minValueSpinBox">
        <property name="decimals">
         <number>6</number>
@@ -93,14 +93,14 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="2">
+     <item row="4" column="2">
       <widget class="QLabel" name="label_4">
        <property name="text">
         <string>to</string>
        </property>
       </widget>
      </item>
-     <item row="3" column="3">
+     <item row="4" column="3">
       <widget class="QgsDoubleSpinBox" name="maxValueSpinBox">
        <property name="decimals">
         <number>6</number>
@@ -113,7 +113,7 @@
        </property>
       </widget>
      </item>
-     <item row="3" column="4">
+     <item row="4" column="4">
       <widget class="QToolButton" name="computeValuesButton">
        <property name="maximumSize">
         <size>
@@ -142,8 +142,18 @@
        </property>
       </widget>
      </item>
-     <item row="1" column="1" colspan="3">
+     <item row="1" column="1" colspan="2">
       <widget class="QComboBox" name="scaleMethodComboBox"/>
+     </item>
+     <item row="1" column="3">
+      <widget class="QgsDoubleSpinBox" name="exponentSpinBox">
+       <property name="minimum">
+        <double>0.000000000000000</double>
+       </property>
+       <property name="value">
+        <double>0.570000000000000</double>
+       </property>
+      </widget>
      </item>
     </layout>
    </item>

--- a/tests/src/core/testqgsscaleexpression.cpp
+++ b/tests/src/core/testqgsscaleexpression.cpp
@@ -79,8 +79,8 @@ class TestQgsScaleExpression: public QObject
       }
       {
         QgsScaleExpression exp( "coalesce(scale_exp(column, 1, 7, 2, 10, 0.51), 0)" );
-        QCOMPARE( bool( exp ), false );
-        QCOMPARE( exp.type(), QgsScaleExpression::Unknown );
+        QCOMPARE( bool( exp ), true );
+        QCOMPARE( exp.type(), QgsScaleExpression::Exponential );
       }
       {
         QgsScaleExpression exp( "coalesce(scale_exp(column, 1, 7, a, 10, 0.5), 0)" );


### PR DESCRIPTION
The qgssizescalewidget as been modified to handle line symbols as well
as markers.
The scale expression has been enhanced to support general exponentials
(i.e. exponents different from Flanery .57 and Area .5a)
The assistant as been modified to display the exponent when Exponential
scaling is required.
