### PR TITLE
Added FWTools dialog message at plugin load/reload

### DIFF
--- a/python/plugins/fTools/fTools.py
+++ b/python/plugins/fTools/fTools.py
@@ -316,6 +316,43 @@ class fToolsPlugin:
         QObject.connect(self.mergeShapes, SIGNAL("triggered()"), self.doMergeShapes)
         QObject.connect(self.spatialIndex, SIGNAL("triggered()"), self.doSpatIndex)
 
+        # if qgis version is > 2.10 than warn user that the application of
+        # the new geometry V2 engine make ftools prone to geometry errors
+        if int(self.QgisVersion) >= 21000:
+
+            def notifySeverWarning():
+                # remove listener if it has been registered at startup
+                try:
+                    self.iface.initializationCompleted.disconnect(notifySeverWarning)
+                except:
+                    pass
+
+                QMessageBox.warning(
+                    self.iface.mainWindow(),
+                    "FWTools message title",
+                    """ <style>p { margin-bottom: 1em; }</style>
+                        
+                        <p>...General description of the reason of the message...</p>
+                        
+                        <ul>
+                            <li><p><b>...a bold title about the content of the message...</b></p>
+                                
+                                <p>...detailed and polite description of message related with FWTool</p>
+                                
+                                <p><a href="https://github.com/qgis//put_here_issue_hiperlink">
+                                    Click here to read more details of the issue
+                                </a></p>
+                            </li>
+                        </ul>
+                    """
+                )
+
+            # notify severe warning only when the desktop interface has been loaded
+            if self.iface.mainWindow().isVisible():
+                notifySeverWarning()
+            else:
+                self.iface.initializationCompleted.connect(notifySeverWarning)
+
     def unload(self):
         self.menu.removeAction(self.analysisMenu.menuAction())
         self.menu.removeAction(self.researchMenu.menuAction())


### PR DESCRIPTION
The scope of this pull request have to be verified by people present during Grancanaria hackfest and PSC.
It is pulled as draft. A gentle message have to be set before merge.
Please evaluate the opportunity to merge and show the message.

The pull request is applied only to FWTool plugin (not to FWTool ported into processing framework).

The shown dialog is showned only if QGIS version > 2.10 and plugin is active or activated.

NEXT STEPS:
If the pull request is updated and accepted, a plugin package have to be  created with new plugin version to oveload current running plugin.
