### PR TITLE
Initialise QgsMapNodeTool::mSelectRubberBand to NULL

### DIFF
--- a/src/app/nodetool/qgsmaptoolnodetool.cpp
+++ b/src/app/nodetool/qgsmaptoolnodetool.cpp
@@ -33,6 +33,7 @@
 
 QgsMapToolNodeTool::QgsMapToolNodeTool( QgsMapCanvas* canvas )
     : QgsMapToolEdit( canvas )
+    , mSelectRubberBand( 0 )
     , mSelectedFeature( 0 )
     , mNodeEditor( 0 )
     , mMoving( true )


### PR DESCRIPTION
Currently QGis crashes (for me) after closing it. QgsMapNodeTool::mSelectRubberBand isn't initialised to NULL, so that it might point to a random location in memory, so that freeing the memory in the destructor leads to a segmentation fault (I use Linux at the moment).
