### PR TITLE
Snap directly to target layer CRS for capture list (fixes #13745)

### DIFF
--- a/python/core/qgssnappingutils.sip
+++ b/python/core/qgssnappingutils.sip
@@ -87,17 +87,17 @@ class QgsSnappingUtils : QObject
     /** Query whether to consider intersections of nearby segments for snapping */
     bool snapOnIntersections() const;
 
+    //! enum of possible settings for the coordinate system to snap to
     enum SnapToType
     {
-      Invalid = 0,      //!< This value is invalid
-      SnapToMap = 1,    //!< Perform snapping with map coordinates
-      SnapToLayer = 2,  //!< Perform snapping with (current) layer coordinates
+      SnapToMap,        //!< Perform snapping with map coordinates
+      SnapToLayer       //!< Perform snapping with (current) layer coordinates
     };
 
     /** Set whether snapping occurs with map or layer coordinates */
-    void setSnapToType( int snapToType );
+    void setSnapToType( SnapToType snapToType );
     /** Find out whether snapping occurs with map or layer coordinates */
-    int getSnapToType();
+    SnapToType getSnapToType();
 
   public slots:
     /** Read snapping configuration from the project */

--- a/python/core/qgssnappingutils.sip
+++ b/python/core/qgssnappingutils.sip
@@ -87,6 +87,18 @@ class QgsSnappingUtils : QObject
     /** Query whether to consider intersections of nearby segments for snapping */
     bool snapOnIntersections() const;
 
+    enum SnapToType
+    {
+      Invalid = 0,      //!< This value is invalid
+      SnapToMap = 1,    //!< Perform snapping with map coordinates
+      SnapToLayer = 2,  //!< Perform snapping with (current) layer coordinates
+    };
+
+    /** Set whether snapping occurs with map or layer coordinates */
+    void setSnapToType( int snapToType );
+    /** Find out whether snapping occurs with map or layer coordinates */
+    int getSnapToType();
+
   public slots:
     /** Read snapping configuration from the project */
     void readConfigFromProject();

--- a/python/gui/qgsmapmouseevent.sip
+++ b/python/gui/qgsmapmouseevent.sip
@@ -86,7 +86,15 @@ class QgsMapMouseEvent : QMouseEvent
      */
     void setMapPoint( const QgsPoint& point );
 
+    /*
+     * @brief layerPoint returns the point in coordinates
+     * @return the point in layer coordinates, after snapping if requested in the event.
+     */
+    QgsPoint layerPoint() const;
+
     QgsPoint originalMapPoint() const;
+
+    QgsPoint originalLayerPoint() const;
 
     QPoint pixelPoint() const;
 

--- a/python/gui/qgsmapmouseevent.sip
+++ b/python/gui/qgsmapmouseevent.sip
@@ -94,6 +94,11 @@ class QgsMapMouseEvent : QMouseEvent
 
     QgsPoint originalMapPoint() const;
 
+    /**
+     * Returns the original, unmodified layer point of the mouse cursor.
+     *
+     * @return The cursor position in layer coordinates.
+     */
     QgsPoint originalLayerPoint() const;
 
     QPoint pixelPoint() const;

--- a/python/gui/qgsmaptoolcapture.sip
+++ b/python/gui/qgsmaptoolcapture.sip
@@ -72,7 +72,14 @@ class QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
     int nextPoint( const QPoint &p, QgsPoint &layerPoint, QgsPoint &mapPoint );
 
     /** Adds a point to the rubber band (in map coordinates) and to the capture list (in layer coordinates)
-     @return 0 in case of success, 1 if current layer is not a vector layer, 2 if coordinate transformation failed*/
+      * @param mapPoint The point in map coordinates
+      * @param layerPoint The point in the crs of the current layer
+      * @return 0 in case of success, 1 if current layer is not a vector layer, 2 if coordinate transformation failed*/
+    int addVertex( const QgsPoint& mapPoint, const QgsPoint& layerPoint );
+
+    /** Adds a point to the rubber band (in map coordinates) and to the capture list (in layer coordinates).
+      * @deprecated Use addVertex( mapPoint, layerPoint ) instead
+      * @return 0 in case of success, 1 if current layer is not a vector layer, 2 if coordinate transformation failed*/
     int addVertex( const QgsPoint& point );
 
     /** Removes the last vertex from mRubberBand and mCaptureList*/

--- a/python/gui/qgsmaptoolcapture.sip
+++ b/python/gui/qgsmaptoolcapture.sip
@@ -80,7 +80,7 @@ class QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
     /** Adds a point to the rubber band (in map coordinates) and to the capture list (in layer coordinates).
       * @deprecated Use addVertex( mapPoint, layerPoint ) instead
       * @return 0 in case of success, 1 if current layer is not a vector layer, 2 if coordinate transformation failed*/
-    int addVertex( const QgsPoint& point );
+    int addVertex( const QgsPoint& point ) /Deprecated/;
 
     /** Removes the last vertex from mRubberBand and mCaptureList*/
     void undo();

--- a/src/app/qgsmaptooladdfeature.cpp
+++ b/src/app/qgsmaptooladdfeature.cpp
@@ -173,7 +173,7 @@ void QgsMapToolAddFeature::cadCanvasReleaseEvent( QgsMapMouseEvent* e )
     //add point to list and to rubber band
     if ( e->button() == Qt::LeftButton )
     {
-      int error = addVertex( e->mapPoint() );
+      int error = addVertex( e->mapPoint(), e->layerPoint() );
       if ( error == 1 )
       {
         //current layer is not a vector layer

--- a/src/app/qgsmaptooladdpart.cpp
+++ b/src/app/qgsmaptooladdpart.cpp
@@ -95,7 +95,7 @@ void QgsMapToolAddPart::cadCanvasReleaseEvent( QgsMapMouseEvent * e )
       //add point to list and to rubber band
       if ( e->button() == Qt::LeftButton )
       {
-        int error = addVertex( e->mapPoint() );
+        int error = addVertex( e->mapPoint(), e->layerPoint() );
         if ( error == 1 )
         {
           QgsDebugMsg( "current layer is not a vector layer" );

--- a/src/app/qgsmaptooladdring.cpp
+++ b/src/app/qgsmaptooladdring.cpp
@@ -58,7 +58,7 @@ void QgsMapToolAddRing::cadCanvasReleaseEvent( QgsMapMouseEvent * e )
   //add point to list and to rubber band
   if ( e->button() == Qt::LeftButton )
   {
-    int error = addVertex( e->mapPoint() );
+    int error = addVertex( e->mapPoint(), e->layerPoint() );
     if ( error == 1 )
     {
       //current layer is not a vector layer

--- a/src/app/qgsmaptoolfillring.cpp
+++ b/src/app/qgsmaptoolfillring.cpp
@@ -54,7 +54,7 @@ void QgsMapToolFillRing::cadCanvasReleaseEvent( QgsMapMouseEvent * e )
   //add point to list and to rubber band
   if ( e->button() == Qt::LeftButton )
   {
-    int error = addVertex( e->mapPoint() );
+    int error = addVertex( e->mapPoint(), e->layerPoint() );
     if ( error == 1 )
     {
       //current layer is not a vector layer

--- a/src/app/qgsmaptoolreshape.cpp
+++ b/src/app/qgsmaptoolreshape.cpp
@@ -50,7 +50,7 @@ void QgsMapToolReshape::cadCanvasReleaseEvent( QgsMapMouseEvent * e )
   //add point to list and to rubber band
   if ( e->button() == Qt::LeftButton )
   {
-    int error = addVertex( e->mapPoint() );
+    int error = addVertex( e->mapPoint(), e->layerPoint() );
     if ( error == 1 )
     {
       //current layer is not a vector layer

--- a/src/app/qgsmaptoolsplitfeatures.cpp
+++ b/src/app/qgsmaptoolsplitfeatures.cpp
@@ -67,7 +67,7 @@ void QgsMapToolSplitFeatures::cadCanvasReleaseEvent( QgsMapMouseEvent * e )
       }
     }
 
-    int error = addVertex( e->mapPoint() );
+    int error = addVertex( e->mapPoint(), e->layerPoint() );
     if ( error == 1 )
     {
       //current layer is not a vector layer

--- a/src/app/qgsmaptoolsplitparts.cpp
+++ b/src/app/qgsmaptoolsplitparts.cpp
@@ -66,7 +66,7 @@ void QgsMapToolSplitParts::cadCanvasReleaseEvent( QgsMapMouseEvent * e )
       }
     }
 
-    int error = addVertex( e->mapPoint() );
+    int error = addVertex( e->mapPoint(), e->layerPoint() );
     if ( error == 1 )
     {
       //current layer is not a vector layer

--- a/src/core/qgssnappingutils.cpp
+++ b/src/core/qgssnappingutils.cpp
@@ -55,7 +55,7 @@ QgsPointLocator* QgsSnappingUtils::locatorForLayer( QgsVectorLayer* vl )
   else if ( mSnapToType == SnapToType::SnapToLayer )
     locators = &mToLayerLocators;
   else
-    return NULL;
+    return nullptr;
 
   if ( !locators->contains( vl ) )
   {
@@ -104,7 +104,7 @@ QgsPointLocator* QgsSnappingUtils::temporaryLocatorForLayer( QgsVectorLayer* vl,
   else if ( mSnapToType == SnapToType::SnapToLayer )
     locators = &mTemporaryToLayerLocators;
   else
-    return NULL;
+    return nullptr;
 
   if ( locators->contains( vl ) )
     delete locators->take( vl );
@@ -477,9 +477,9 @@ const QgsCoordinateReferenceSystem* QgsSnappingUtils::destCRS()
   if ( mSnapToType == SnapToType::SnapToMap )
     return mMapSettings.hasCrsTransformEnabled() ? &mMapSettings.destinationCrs() : nullptr;
   else if ( mSnapToType == SnapToType::SnapToLayer )
-    return mMapSettings.hasCrsTransformEnabled() ? &mCurrentLayer->crs() : 0;
+    return mMapSettings.hasCrsTransformEnabled() ? &mCurrentLayer->crs() : nullptr;
   else
-    return 0;
+    return nullptr;
 }
 
 void QgsSnappingUtils::setSnapToType( SnapToType snapToType )

--- a/src/core/qgssnappingutils.cpp
+++ b/src/core/qgssnappingutils.cpp
@@ -476,7 +476,7 @@ const QgsCoordinateReferenceSystem* QgsSnappingUtils::destCRS()
     return NULL;
 }
 
-void QgsSnappingUtils::setSnapToType( int snapToType )
+void QgsSnappingUtils::setSnapToType( SnapToType snapToType )
 {
   mSnapToType = snapToType;
 }

--- a/src/core/qgssnappingutils.cpp
+++ b/src/core/qgssnappingutils.cpp
@@ -395,16 +395,6 @@ QgsPointLocator::Match QgsSnappingUtils::snapToCurrentLayer( const QPoint& point
   return bestMatch;
 }
 
-void QgsSnappingUtils::setCurrentLayer( QgsVectorLayer* layer )
-{
-  QString oldDestCRS = mCurrentLayer ? mCurrentLayer->crs().authid() : QString();
-  QString newDestCRS = layer ? layer->crs().authid() : QString();
-  mCurrentLayer = layer;
-
-  if ( newDestCRS != oldDestCRS )
-    clearAllToLayerLocators();
-}
-
 void QgsSnappingUtils::setMapSettings( const QgsMapSettings& settings )
 {
   QString oldDestCRS = mMapSettings.hasCrsTransformEnabled() ? mMapSettings.destinationCrs().authid() : QString();
@@ -417,7 +407,12 @@ void QgsSnappingUtils::setMapSettings( const QgsMapSettings& settings )
 
 void QgsSnappingUtils::setCurrentLayer( QgsVectorLayer* layer )
 {
+  QString oldDestCRS = mCurrentLayer ? mCurrentLayer->crs().authid() : QString();
+  QString newDestCRS = layer ? layer->crs().authid() : QString();
   mCurrentLayer = layer;
+
+  if ( newDestCRS != oldDestCRS )
+    clearAllToLayerLocators();
 }
 
 void QgsSnappingUtils::setSnapToMapMode( QgsSnappingUtils::SnapToMapMode mode )

--- a/src/core/qgssnappingutils.cpp
+++ b/src/core/qgssnappingutils.cpp
@@ -20,6 +20,7 @@
 #include "qgsproject.h"
 #include "qgsvectorlayer.h"
 
+#include <QLinkedList>
 
 QgsSnappingUtils::QgsSnappingUtils( QObject* parent )
     : QObject( parent )
@@ -560,29 +561,13 @@ void QgsSnappingUtils::readConfigFromProject()
 
 void QgsSnappingUtils::onLayersWillBeRemoved( const QStringList& layerIds )
 {
-  LocatorsMap* locators;
+  QLinkedList<LocatorsMap*> locatorsMapList;
+  locatorsMapList << &mLocators << &mTemporaryLocators << &mToLayerLocators << &mTemporaryToLayerLocators;
   // remove locators for layers that are going to be deleted
   Q_FOREACH ( const QString& layerId, layerIds )
   {
-    for ( int i = 1; i <= 4; i++ )
+    Q_FOREACH ( LocatorsMap* locators, locatorsMapList )
     {
-      switch ( i )
-      {
-        case 1:
-          locators = &mLocators;
-          break;
-        case 2:
-          locators = &mTemporaryLocators;
-          break;
-        case 3:
-          locators = &mToLayerLocators;
-          break;
-        case 4:
-          locators = &mTemporaryToLayerLocators;
-          break;
-        default:
-          locators = NULL;
-      }
       for ( LocatorsMap::iterator it = locators->begin(); it != locators->end(); )
       {
         if ( it.key()->id() == layerId )

--- a/src/core/qgssnappingutils.cpp
+++ b/src/core/qgssnappingutils.cpp
@@ -250,7 +250,13 @@ QgsPointLocator::Match QgsSnappingUtils::snapToMap( const QgsPoint& pointMap, Qg
     prepareIndex( QList<QgsVectorLayer*>() << mCurrentLayer );
 
     // data from project
-    double tolerance = QgsTolerance::toleranceInProjectUnits( mDefaultTolerance, mCurrentLayer, mMapSettings, mDefaultUnit );
+    double tolerance;
+    if ( mSnapToType == SnapToType::SnapToMap )
+      tolerance = QgsTolerance::toleranceInProjectUnits( mDefaultTolerance, mCurrentLayer, mMapSettings, mDefaultUnit );
+    else if ( mSnapToType == SnapToType::SnapToLayer )
+      tolerance = QgsTolerance::toleranceInMapUnits( mDefaultTolerance, mCurrentLayer, mMapSettings, mDefaultUnit );
+    else
+      tolerance = mDefaultTolerance;
     int type = mDefaultType;
 
     // use ad-hoc locator

--- a/src/core/qgssnappingutils.cpp
+++ b/src/core/qgssnappingutils.cpp
@@ -471,9 +471,9 @@ const QgsCoordinateReferenceSystem* QgsSnappingUtils::destCRS()
   if ( mSnapToType == SnapToType::SnapToMap )
     return mMapSettings.hasCrsTransformEnabled() ? &mMapSettings.destinationCrs() : nullptr;
   else if ( mSnapToType == SnapToType::SnapToLayer )
-    return &mCurrentLayer->crs();
+    return mMapSettings.hasCrsTransformEnabled() ? &mCurrentLayer->crs() : 0;
   else
-    return NULL;
+    return 0;
 }
 
 void QgsSnappingUtils::setSnapToType( SnapToType snapToType )

--- a/src/core/qgssnappingutils.h
+++ b/src/core/qgssnappingutils.h
@@ -136,6 +136,18 @@ class CORE_EXPORT QgsSnappingUtils : public QObject
     /** Query whether to consider intersections of nearby segments for snapping */
     bool snapOnIntersections() const { return mSnapOnIntersection; }
 
+    enum SnapToType
+    {
+      Invalid = 0,      //!< This value is invalid
+      SnapToMap = 1,    //!< Perform snapping with map coordinates
+      SnapToLayer = 2,  //!< Perform snapping with (current) layer coordinates
+    };
+
+    /** Set whether snapping occurs with map or layer coordinates */
+    void setSnapToType( int snapToType );
+    /** Find out whether snapping occurs with map or layer coordinates */
+    int getSnapToType() { return mSnapToType; }
+
   public slots:
     /** Read snapping configuration from the project */
     void readConfigFromProject();
@@ -159,8 +171,11 @@ class CORE_EXPORT QgsSnappingUtils : public QObject
     //! get from map settings pointer to destination CRS - or 0 if projections are disabled
     const QgsCoordinateReferenceSystem* destCRS();
 
-    //! delete all existing locators (e.g. when destination CRS has changed and we need to reindex)
-    void clearAllLocators();
+    //! delete all existing locators to map coordinates (e.g. when map CRS has changed and we need to reindex)
+    void clearAllToMapLocators();
+
+    //! delete all existing locators to layer coordinates (e.g. when current layer has changed and we need to reindex)
+    void clearAllToLayerLocators();
 
     //! return a locator (temporary or not) according to the indexing strategy
     QgsPointLocator* locatorForLayerUsingStrategy( QgsVectorLayer* vl, const QgsPoint& pointMap, double tolerance );
@@ -183,15 +198,20 @@ class CORE_EXPORT QgsSnappingUtils : public QObject
     int mDefaultType;
     double mDefaultTolerance;
     QgsTolerance::UnitType mDefaultUnit;
+    int mSnapToType;
     QList<LayerConfig> mLayers;
     bool mSnapOnIntersection;
 
     // internal data
     typedef QMap<QgsVectorLayer*, QgsPointLocator*> LocatorsMap;
-    //! on-demand locators used (locators are owned)
+    //! on-demand locators used (locators are owned) for snapping to map coordinates
     LocatorsMap mLocators;
-    //! temporary locators (indexing just a part of layers). owned by the instance
+    //! temporary locators (indexing just a part of layers) for snapping to map coordinates. owned by the instance
     LocatorsMap mTemporaryLocators;
+    //! on-demand locators used (locators are owned) for snapping to layer coordinates
+    LocatorsMap mToLayerLocators;
+    //! temporary locators (indexing just a part of layers) for snapping to layer coordinates. owned by the instance
+    LocatorsMap mTemporaryToLayerLocators;
     //! list of layer IDs that are too large to be indexed (hybrid strategy will use temporary locators for those)
     QSet<QString> mHybridNonindexableLayers;
 

--- a/src/core/qgssnappingutils.h
+++ b/src/core/qgssnappingutils.h
@@ -136,17 +136,17 @@ class CORE_EXPORT QgsSnappingUtils : public QObject
     /** Query whether to consider intersections of nearby segments for snapping */
     bool snapOnIntersections() const { return mSnapOnIntersection; }
 
+    //! enum of possible settings for the coordinate system to snap to
     enum SnapToType
     {
-      Invalid = 0,      //!< This value is invalid
-      SnapToMap = 1,    //!< Perform snapping with map coordinates
-      SnapToLayer = 2,  //!< Perform snapping with (current) layer coordinates
+      SnapToMap,        //!< Perform snapping with map coordinates
+      SnapToLayer       //!< Perform snapping with (current) layer coordinates
     };
 
     /** Set whether snapping occurs with map or layer coordinates */
-    void setSnapToType( int snapToType );
+    void setSnapToType( SnapToType snapToType );
     /** Find out whether snapping occurs with map or layer coordinates */
-    int getSnapToType() { return mSnapToType; }
+    SnapToType getSnapToType() { return mSnapToType; }
 
   public slots:
     /** Read snapping configuration from the project */
@@ -198,7 +198,7 @@ class CORE_EXPORT QgsSnappingUtils : public QObject
     int mDefaultType;
     double mDefaultTolerance;
     QgsTolerance::UnitType mDefaultUnit;
-    int mSnapToType;
+    SnapToType mSnapToType;
     QList<LayerConfig> mLayers;
     bool mSnapOnIntersection;
 

--- a/src/gui/qgsmapmouseevent.cpp
+++ b/src/gui/qgsmapmouseevent.cpp
@@ -63,7 +63,7 @@ QgsMapMouseEvent::QgsMapMouseEvent( QgsMapCanvas* mapCanvas, QEvent::Type type, 
 
 QgsPoint QgsMapMouseEvent::snapPoint( SnappingMode snappingMode )
 {
-  int snapToType;
+  QgsSnappingUtils::SnapToType snapToType;
 
   // Use cached result
   if ( mSnappingMode == snappingMode )
@@ -153,7 +153,7 @@ QList<QgsPoint> QgsMapMouseEvent::snapSegment( SnappingMode snappingMode, bool* 
       int type;
       double tolerance;
       QgsTolerance::UnitType unit;
-      int snapToType;
+      QgsSnappingUtils::SnapToType snapToType;
       snappingUtils->defaultSettings( type, tolerance, unit );
       snapToType = snappingUtils->getSnapToType();
       snappingUtils->setSnapToMapMode( QgsSnappingUtils::SnapAllLayers );

--- a/src/gui/qgsmapmouseevent.cpp
+++ b/src/gui/qgsmapmouseevent.cpp
@@ -32,11 +32,11 @@ QgsMapMouseEvent::QgsMapMouseEvent( QgsMapCanvas* mapCanvas, QMouseEvent* event 
     , mSnappingMode( NoSnapping )
     , mOriginalMapPoint( mapCanvas ? mapCanvas->mapSettings().mapToPixel().toMapCoordinates( event->pos() ) : QgsPoint() )
     , mOriginalLayerPoint( mapCanvas && mapCanvas->currentLayer() ?
-                             mapCanvas->mapSettings().mapToLayerCoordinates(
-                               mapCanvas->currentLayer(),
-                               mapCanvas->mapSettings().mapToPixel().toMapCoordinates( event->pos() )
-                             ) :
-                             QgsPoint() )
+                           mapCanvas->mapSettings().mapToLayerCoordinates(
+                             mapCanvas->currentLayer(),
+                             mapCanvas->mapSettings().mapToPixel().toMapCoordinates( event->pos() )
+                           ) :
+                           QgsPoint() )
     , mMapPoint( mOriginalMapPoint )
     , mLayerPoint( mOriginalLayerPoint )
     , mPixelPoint( event->pos() )
@@ -49,11 +49,11 @@ QgsMapMouseEvent::QgsMapMouseEvent( QgsMapCanvas* mapCanvas, QEvent::Type type, 
     , mSnappingMode( NoSnapping )
     , mOriginalMapPoint( mapCanvas ? mapCanvas->mapSettings().mapToPixel().toMapCoordinates( pos ) : QgsPoint() )
     , mOriginalLayerPoint( mapCanvas && mapCanvas->currentLayer() ?
-                             mapCanvas->mapSettings().mapToLayerCoordinates(
-                               mapCanvas->currentLayer(),
-                               mapCanvas->mapSettings().mapToPixel().toMapCoordinates( pos )
-                             ) :
-                             QgsPoint() )
+                           mapCanvas->mapSettings().mapToLayerCoordinates(
+                             mapCanvas->currentLayer(),
+                             mapCanvas->mapSettings().mapToPixel().toMapCoordinates( pos )
+                           ) :
+                           QgsPoint() )
     , mMapPoint( mOriginalMapPoint )
     , mLayerPoint( mOriginalLayerPoint )
     , mPixelPoint( pos )

--- a/src/gui/qgsmapmouseevent.h
+++ b/src/gui/qgsmapmouseevent.h
@@ -85,13 +85,19 @@ class GUI_EXPORT QgsMapMouseEvent : public QMouseEvent
      *
      * @return True if there is a snapped point cached.
      */
-    bool isSnapped() const { return mSnapMatch.isValid(); }
+    bool isSnapped() const { return mSnapMatchMap.isValid(); }
 
     /**
      * @brief mapPoint returns the point in coordinates
      * @return the point in map coordinates, after snapping if requested in the event.
      */
     inline QgsPoint mapPoint() const { return mMapPoint; }
+
+    /**
+      * @brief layerPoint returns the point in coordinates
+      * @return the point in layer coordinates, after snapping if requested in the event.
+      */
+    inline QgsPoint layerPoint() const { return mLayerPoint; }
 
     /**
      * Set the (snapped) point this event points to in map coordinates.
@@ -106,7 +112,14 @@ class GUI_EXPORT QgsMapMouseEvent : public QMouseEvent
      *
      * @return The cursor position in map coordinates.
      */
-    QgsPoint originalMapPoint() const { return mMapPoint; }
+    QgsPoint originalMapPoint() const { return mOriginalMapPoint; }
+
+    /**
+     * Returns the original, unmodified layer point of the mouse cursor.
+     *
+     * @return The cursor position in layer coordinates.
+     */
+    QgsPoint originalLayerPoint() const { return mOriginalLayerPoint; }
 
     /**
      * The snapped mouse cursor in pixel coordinates.
@@ -132,8 +145,14 @@ class GUI_EXPORT QgsMapMouseEvent : public QMouseEvent
     //! Unsnapped point in map coordinates.
     QgsPoint mOriginalMapPoint;
 
+    //! Unsnapped point in layer coordinates.
+    QgsPoint mOriginalLayerPoint;
+
     //! Location in map coordinates. May be snapped.
     QgsPoint mMapPoint;
+
+    //! Location in current layer coordinates. May be snapped.
+    QgsPoint mLayerPoint;
 
     //! Location in pixel coordinates. May be snapped.
     //! Original pixel point available through the parent QMouseEvent.
@@ -142,7 +161,8 @@ class GUI_EXPORT QgsMapMouseEvent : public QMouseEvent
     //! The map canvas on which the event was triggered.
     QgsMapCanvas* mMapCanvas;
 
-    QgsPointLocator::Match mSnapMatch;
+    QgsPointLocator::Match mSnapMatchMap;
+    QgsPointLocator::Match mSnapMatchLayer;
 };
 
 #endif // QGSMAPMOUSEEVENT_H

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -196,7 +196,7 @@ bool QgsMapToolCapture::tracingMouseMove( QgsMapMouseEvent* e )
 }
 
 
-bool QgsMapToolCapture::tracingAddVertex( const QgsPoint& point )
+bool QgsMapToolCapture::tracingAddVertex( const QgsPoint& mapPoint, const QgsPoint& layerPoint )
 {
   QgsMapCanvasTracer* tracer = QgsMapCanvasTracer::tracerForCanvas( mCanvas );
   if ( !tracer )
@@ -211,13 +211,10 @@ bool QgsMapToolCapture::tracingAddVertex( const QgsPoint& point )
     }
 
     // only accept first point if it is snapped to the graph (to vertex or edge)
-    bool res = tracer->isPointSnapped( point );
+    bool res = tracer->isPointSnapped( mapPoint );
     if ( res )
     {
-      QgsPoint layerPoint;
-      nextPoint( point, layerPoint ); // assuming the transform went fine earlier
-
-      mRubberBand->addPoint( point );
+      mRubberBand->addPoint( mapPoint );
       mCaptureCurve.addVertex( QgsPointV2( layerPoint.x(), layerPoint.y() ) );
     }
     return res;
@@ -228,7 +225,7 @@ bool QgsMapToolCapture::tracingAddVertex( const QgsPoint& point )
     return false;
 
   QgsTracer::PathError err;
-  QVector<QgsPoint> points = tracer->findShortestPath( pt0, point, &err );
+  QVector<QgsPoint> points = tracer->findShortestPath( pt0, mapPoint, &err );
   if ( points.isEmpty() )
     return false; // ignore the vertex - can't find path to the end point!
 
@@ -383,13 +380,13 @@ int QgsMapToolCapture::addVertex( const QgsPoint& mapPoint, const QgsPoint& laye
   bool traceCreated = false;
   if ( tracingEnabled() )
   {
-    traceCreated = tracingAddVertex( point );
+    traceCreated = tracingAddVertex( mapPoint, layerPoint );
   }
 
   if ( !traceCreated )
   {
     // ordinary digitizing
-    mRubberBand->addPoint( point );
+    mRubberBand->addPoint( mapPoint );
     mCaptureCurve.addVertex( QgsPointV2( layerPoint.x(), layerPoint.y() ) );
   }
 

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -347,18 +347,23 @@ int QgsMapToolCapture::nextPoint( const QPoint &p, QgsPoint &layerPoint, QgsPoin
 
 int QgsMapToolCapture::addVertex( const QgsPoint& point )
 {
-  if ( mode() == CaptureNone )
-  {
-    QgsDebugMsg( "invalid capture mode" );
-    return 2;
-  }
-
   int res;
   QgsPoint layerPoint;
   res = nextPoint( point, layerPoint );
   if ( res != 0 )
   {
     return res;
+  }
+
+  return addVertex( point, layerPoint );
+}
+
+int QgsMapToolCapture::addVertex( const QgsPoint& mapPoint, const QgsPoint& layerPoint )
+{
+  if ( mode() == CaptureNone )
+  {
+    QgsDebugMsg( "invalid capture mode" );
+    return 2;
   }
 
   if ( !mRubberBand )
@@ -390,14 +395,14 @@ int QgsMapToolCapture::addVertex( const QgsPoint& point )
 
   if ( mCaptureMode == CaptureLine )
   {
-    mTempRubberBand->addPoint( point );
+    mTempRubberBand->addPoint( mapPoint );
   }
   else if ( mCaptureMode == CapturePolygon )
   {
     const QgsPoint *firstPoint = mRubberBand->getPoint( 0, 0 );
     mTempRubberBand->addPoint( *firstPoint );
-    mTempRubberBand->movePoint( point );
-    mTempRubberBand->addPoint( point );
+    mTempRubberBand->movePoint( mapPoint );
+    mTempRubberBand->addPoint( mapPoint );
   }
 
   validateGeometry();

--- a/src/gui/qgsmaptoolcapture.h
+++ b/src/gui/qgsmaptoolcapture.h
@@ -92,8 +92,10 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
     int nextPoint( const QPoint &p, QgsPoint &layerPoint, QgsPoint &mapPoint );
 
     /** Adds a point to the rubber band (in map coordinates) and to the capture list (in layer coordinates)
-     @return 0 in case of success, 1 if current layer is not a vector layer, 2 if coordinate transformation failed*/
-    int addVertex( const QgsPoint& point );
+      * @param mapPoint The point in map coordinates
+      * @param layerPoint The point in the crs of the current layer
+      * @return 0 in case of success, 1 if current layer is not a vector layer, 2 if coordinate transformation failed*/
+    int addVertex( const QgsPoint& mapPoint, const QgsPoint& layerPoint );
 
     /** Removes the last vertex from mRubberBand and mCaptureList*/
     void undo();
@@ -139,6 +141,13 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
      * Close an open polygon
      */
     void closePolygon();
+
+    // deprecated methods
+
+    /** Adds a point to the rubber band (in map coordinates) and to the capture list (in layer coordinates).
+      * @deprecated Use addVertex( mapPoint, layerPoint ) instead
+      * @return 0 in case of success, 1 if current layer is not a vector layer, 2 if coordinate transformation failed*/
+    Q_DECL_DEPRECATED int addVertex( const QgsPoint& point );
 
   private:
     //! whether tracing has been requested by the user

--- a/src/gui/qgsmaptoolcapture.h
+++ b/src/gui/qgsmaptoolcapture.h
@@ -157,7 +157,7 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
     //! handle of mouse movement when tracing enabled and capturing has started
     bool tracingMouseMove( QgsMapMouseEvent* e );
     //! handle of addition of clicked point (with the rest of the trace) when tracing enabled
-    bool tracingAddVertex( const QgsPoint& point );
+    bool tracingAddVertex( const QgsPoint& mapPoint, const QgsPoint& layerPoint );
 
   private:
     /** Flag to indicate a map canvas capture operation is taking place */

--- a/tests/src/core/testqgssnappingutils.cpp
+++ b/tests/src/core/testqgssnappingutils.cpp
@@ -120,7 +120,7 @@ class TestQgsSnappingUtils : public QObject
       QVERIFY( !m3.isValid() );
    }
 
-   void testSnapModeCurrentOTF()
+   void testSnapModeCurrentWithReprojection()
    {
       // test with OTF reprojection enabled.
       // test with UTM<->Pseudo-Mercator, both with meters as units.
@@ -159,14 +159,14 @@ class TestQgsSnappingUtils : public QObject
 
       u.setMapSettings( mapSettings );
 
-      m = u.snapToMap( mapSettings.mapToLayerCoordinates( mVL, mapSettings.mapToPixel().toMapCoordinates( QPoint( 100, 100 ) ) ) );
-      QVERIFY( m.isValid() );
-      QVERIFY( m.hasVertex() );
-      QCOMPARE( m.point(), QgsPoint( 1, 0 ) );
+      QgsPointLocator::Match m3 = u.snapToMap( mapSettings.mapToLayerCoordinates( mVL, mapSettings.mapToPixel().toMapCoordinates( QPoint( 100, 100 ) ) ) );
+      QVERIFY( m3.isValid() );
+      QVERIFY( m3.hasVertex() );
+      QCOMPARE( m3.point(), QgsPoint( 1, 0 ) );
 
-      m2 = u.snapToMap( mapSettings.mapToLayerCoordinates( mVL, mapSettings.mapToPixel().toMapCoordinates( QPoint( 0, 100 ) ) ) );
-      QVERIFY( !m2.isValid() );
-      QVERIFY( !m2.hasVertex() );
+      QgsPointLocator::Match m4 = u.snapToMap( mapSettings.mapToLayerCoordinates( mVL, mapSettings.mapToPixel().toMapCoordinates( QPoint( 0, 100 ) ) ) );
+      QVERIFY( !m4.isValid() );
+      QVERIFY( !m4.hasVertex() );
     }
 
     void testSnapModeAll()

--- a/tests/src/core/testqgssnappingutils.cpp
+++ b/tests/src/core/testqgssnappingutils.cpp
@@ -118,10 +118,10 @@ class TestQgsSnappingUtils : public QObject
       FilterExcludePoint myFilter( QgsPoint( 1, 0 ) );
       QgsPointLocator::Match m3 = u.snapToMap( QPoint( 100, 100 ), &myFilter );
       QVERIFY( !m3.isValid() );
-   }
+    }
 
-   void testSnapModeCurrentWithReprojection()
-   {
+    void testSnapModeCurrentWithReprojection()
+    {
       // test with OTF reprojection enabled.
       // test with UTM<->Pseudo-Mercator, both with meters as units.
       QgsCoordinateReferenceSystem* destCrs;

--- a/tests/src/core/testqgssnappingutils.cpp
+++ b/tests/src/core/testqgssnappingutils.cpp
@@ -61,7 +61,7 @@ class TestQgsSnappingUtils : public QObject
       //         \ |
       //          \|
       //           + (1,0)
-      mVL = new QgsVectorLayer( "Polygon", "x", "memory" );
+      mVL = new QgsVectorLayer( "Polygon?crs=epsg:32650", "x", "memory" );
       QgsFeature ff( 0 );
       QgsPolygon polygon;
       QgsPolyline polyline;
@@ -118,6 +118,55 @@ class TestQgsSnappingUtils : public QObject
       FilterExcludePoint myFilter( QgsPoint( 1, 0 ) );
       QgsPointLocator::Match m3 = u.snapToMap( QPoint( 100, 100 ), &myFilter );
       QVERIFY( !m3.isValid() );
+   }
+
+   void testSnapModeCurrentOTF()
+   {
+      // test with OTF reprojection enabled.
+      // test with UTM<->Pseudo-Mercator, both with meters as units.
+      QgsCoordinateReferenceSystem* destCrs;
+      destCrs = new QgsCoordinateReferenceSystem( "epsg:3857" );
+      QgsMapSettings mapSettings;
+      mapSettings.setOutputSize( QSize( 100, 100 ) );
+      mapSettings.setDestinationCrs( *destCrs );
+      mapSettings.setCrsTransformEnabled( true );
+      mapSettings.setExtent( QgsRectangle( 12524695.738, 0, 12524696.735, 1.004 ) );
+      QVERIFY( mapSettings.hasValidSettings() );
+
+      QgsSnappingUtils u;
+      u.setCurrentLayer( mVL );
+      u.setMapSettings( mapSettings );
+      u.setSnapToType( QgsSnappingUtils::SnapToLayer );
+
+      u.setDefaultSettings( QgsPointLocator::Vertex | QgsPointLocator::Edge, 10, QgsTolerance::Pixels );
+
+      QgsPointLocator::Match m = u.snapToMap( mapSettings.mapToLayerCoordinates( mVL, mapSettings.mapToPixel().toMapCoordinates( QPoint( 100, 100 ) ) ) );
+      QVERIFY( m.isValid() );
+      QVERIFY( m.hasVertex() );
+      QCOMPARE( m.point(), QgsPoint( 1, 0 ) );
+
+      QgsPointLocator::Match m2 = u.snapToMap( mapSettings.mapToLayerCoordinates( mVL, mapSettings.mapToPixel().toMapCoordinates( QPoint( 0, 100 ) ) ) );
+      QVERIFY( !m2.isValid() );
+      QVERIFY( !m2.hasVertex() );
+
+      // Test with UTM<->WGS84, which have a different unit type, so that
+      // tolerance conversion is tested properly.
+      delete destCrs;
+      destCrs = new QgsCoordinateReferenceSystem( "epsg:4326" );
+      mapSettings.setDestinationCrs( *destCrs );
+      mapSettings.setExtent( QgsRectangle( 112.5112561152933, 0, 112.51126507429, 0.000009019375921546616 ) );
+      QVERIFY( mapSettings.hasValidSettings() );
+
+      u.setMapSettings( mapSettings );
+
+      m = u.snapToMap( mapSettings.mapToLayerCoordinates( mVL, mapSettings.mapToPixel().toMapCoordinates( QPoint( 100, 100 ) ) ) );
+      QVERIFY( m.isValid() );
+      QVERIFY( m.hasVertex() );
+      QCOMPARE( m.point(), QgsPoint( 1, 0 ) );
+
+      m2 = u.snapToMap( mapSettings.mapToLayerCoordinates( mVL, mapSettings.mapToPixel().toMapCoordinates( QPoint( 0, 100 ) ) ) );
+      QVERIFY( !m2.isValid() );
+      QVERIFY( !m2.hasVertex() );
     }
 
     void testSnapModeAll()


### PR DESCRIPTION
The bug report is not _entirely_ correct, so to summarize: The snapping function doesn't snap exactly to vertices when on-the-fly reprojection is activated. The cause is a typical floating-point-accuracy. The digitisation tools keep a separate rubber band (in map coordinates) and capture list (in target layer coordinates). However, until now the mouse cursor position is always first converted to map coordinates, then snapped, and then converted (back) to layer coordinates, then put on the capture list. This back-and-forth-conversion leads to floating point inaccuracies.

I have tried to remedy this by letting QgsSnappingUtils have two separate sets of point locators: one to snap to map coordinates and one to snap to layer coordinates. This is used by QgsMapMouseEvent to provide the point, directly snapped to layer coordinates, to the digitisation tools, that can then use a new second parameter to QgsMapToolCapture::addVertex to directly insert the point in layer coordinates into the capture list, thus bypassing the transformation to map coordinates and back.

Things I've tried to take into account:
- Handle tolerance settings correctly
- Don't change existing API interfaces (I've overloaded QgsMapToolCapture::addVertex)
- Update Python bindings

Things I'm explicitly not sure about:
- How does this relate to the CAD digitisation tools?
- Unit tests?
- I hope my solution is a sensible approach at all.
