### PR TITLE
Switch to using flags for render context settings

### DIFF
--- a/python/core/qgsrendercontext.sip
+++ b/python/core/qgsrendercontext.sip
@@ -10,6 +10,26 @@ class QgsRenderContext
     QgsRenderContext();
     ~QgsRenderContext();
 
+    //! Enumeration of flags that affect rendering operations
+    enum Flag
+    {
+      DrawEditingInfo,  //!< Enable drawing of vertex markers for layers in editing mode
+      ForceVectorOutput,  //!< Vector graphics should not be cached and drawn as raster images
+      UseAdvancedEffects,  //!< Enable layer transparency and blending effects
+      UseRenderingOptimization, //!< Enable vector simplification and other rendering optimizations
+      DrawSelection,  //!< Whether vector selections should be shown in the rendered map
+    };
+    typedef QFlags<QgsRenderContext::Flag> Flags;
+
+    //! Set combination of flags that will be used for rendering
+    void setFlags( const QgsRenderContext::Flags& flags );
+    //! Enable or disable a particular flag (other flags are not affected)
+    void setFlag( Flag flag, bool on = true );
+    //! Return combination of flags used for rendering
+    Flags flags() const;
+    //! Check whether a particular flag is enabled
+    bool testFlag( Flag flag ) const;
+
     //! create initialized QgsRenderContext instance from given QgsMapSettings
     //! @note added in 2.4
     static QgsRenderContext fromMapSettings( const QgsMapSettings& mapSettings );
@@ -31,14 +51,21 @@ class QgsRenderContext
 
     bool renderingStopped() const;
 
-    bool forceVectorOutput() const;
+    //! @deprecated use testFlag( QgsRenderContext::ForceVectorOutput ) instead
+    bool forceVectorOutput() const /Deprecated/;
 
-    /** Returns true if advanced effects such as blend modes such be used */
-    bool useAdvancedEffects() const;
-    /** Used to enable or disable advanced effects such as blend modes */
-    void setUseAdvancedEffects( bool enabled );
+    /** Returns true if advanced effects such as blend modes such be used
+     * @deprecated use testFlag( QgsRenderContext::UseAdvancedEffects ) instead
+    */
+    bool useAdvancedEffects() const /Deprecated/;
 
-    bool drawEditingInformation() const;
+    /** Used to enable or disable advanced effects such as blend modes
+     * @deprecated use setFlag( QgsRenderContext::UseAdvancedEffects, enabled ) instead
+    */
+    void setUseAdvancedEffects( bool enabled ) /Deprecated/;
+
+    //! @deprecated use testFlag( QgsRenderContext::DrawEditingInfo ) instead
+    bool drawEditingInformation() const /Deprecated/;
 
     double rendererScale() const;
 
@@ -51,8 +78,9 @@ class QgsRenderContext
      * @see setShowSelection
      * @see selectionColor
      * @note Added in QGIS v2.4
+     * @deprecated use testFlag( QgsRenderContext::DrawSelection ) instead
     */
-    bool showSelection() const;
+    bool showSelection() const /Deprecated/;
 
     //setters
 
@@ -60,13 +88,19 @@ class QgsRenderContext
     void setCoordinateTransform( const QgsCoordinateTransform* t );
     void setMapToPixel( const QgsMapToPixel& mtp );
     void setExtent( const QgsRectangle& extent );
-    void setDrawEditingInformation( bool b );
+
+    //! @deprecated use setFlag( QgsRenderContext::DrawEditingInfo, b ) instead
+    void setDrawEditingInformation( bool b ) /Deprecated/;
+
     void setRenderingStopped( bool stopped );
     void setScaleFactor( double factor );
     void setRasterScaleFactor( double factor );
     void setRendererScale( double scale );
     void setPainter( QPainter* p );
-    void setForceVectorOutput( bool force );
+
+    //! @deprecated use setFlag( QgsRenderContext::ForceVectorOutput, b ) instead
+    void setForceVectorOutput( bool force ) /Deprecated/;
+
     void setLabelingEngine( QgsLabelingEngineInterface* iface );
     void setSelectionColor( const QColor& color );
 
@@ -75,16 +109,43 @@ class QgsRenderContext
      * @see showSelection
      * @see setSelectionColor
      * @note Added in QGIS v2.4
+     * @deprecated use setFlag( QgsRenderContext::DrawSelection, showSelection ) instead
     */
-    void setShowSelection( const bool showSelection );
+    void setShowSelection( const bool showSelection ) /Deprecated/;
 
-    /** Returns true if the rendering optimization (geometry simplification) can be executed*/
-    bool useRenderingOptimization() const;
-    void setUseRenderingOptimization( bool enabled );
+    /** Returns true if the rendering optimization (geometry simplification) can be executed
+     * @deprecated use testFlag( QgsRenderContext::UseRenderingOptimization ) instead
+    */
+    bool useRenderingOptimization() const /Deprecated/;
+
+    //! @deprecated use setFlag( QgsRenderContext::UseRenderingOptimization, b ) instead
+    void setUseRenderingOptimization( bool enabled ) /Deprecated/;
 
     //! Added in QGIS v2.4
     const QgsVectorSimplifyMethod& vectorSimplifyMethod() const;
     void setVectorSimplifyMethod( const QgsVectorSimplifyMethod& simplifyMethod );
+
+    /** Sets the expression context. This context is used for all expression evaluation
+     * associated with this render context.
+     * @see expressionContext()
+     * @note added in QGIS 2.12
+     */
+    void setExpressionContext( const QgsExpressionContext& context );
+
+    /** Gets the expression context. This context should be used for all expression evaluation
+     * associated with this render context.
+     * @see setExpressionContext()
+     * @note added in QGIS 2.12
+     */
+    QgsExpressionContext& expressionContext();
+
+    /** Gets the expression context (const version). This context should be used for all expression evaluation
+     * associated with this render context.
+     * @see setExpressionContext()
+     * @note added in QGIS 2.12
+     * @note not available in Python bindings
+     */
+    //const QgsExpressionContext& expressionContext() const;
 
     /** Returns pointer to the unsegmentized geometry
         @return the geometry*/

--- a/src/core/composer/qgscomposerarrow.cpp
+++ b/src/core/composer/qgscomposerarrow.cpp
@@ -184,7 +184,7 @@ void QgsComposerArrow::drawLine( QPainter *painter )
   //context units should be in dots
   ms.setOutputDpi( painter->device()->logicalDpiX() );
   QgsRenderContext context = QgsRenderContext::fromMapSettings( ms );
-  context.setForceVectorOutput( true );
+  context.setFlag( QgsRenderContext::ForceVectorOutput, true );
   context.setPainter( painter );
   QgsExpressionContext* expressionContext = createExpressionContext();
   context.setExpressionContext( *expressionContext );

--- a/src/core/composer/qgscomposermapgrid.cpp
+++ b/src/core/composer/qgscomposermapgrid.cpp
@@ -679,7 +679,7 @@ void QgsComposerMapGrid::draw( QPainter* p )
   ms.setExtent( *mComposerMap->currentMapExtent() );
   ms.setOutputDpi( p->device()->logicalDpiX() );
   QgsRenderContext context = QgsRenderContext::fromMapSettings( ms );
-  context.setForceVectorOutput( true );
+  context.setFlag( QgsRenderContext::ForceVectorOutput, true );
   context.setPainter( p );
   QgsExpressionContext* expressionContext = createExpressionContext();
   context.setExpressionContext( *expressionContext );

--- a/src/core/composer/qgscomposermapoverview.cpp
+++ b/src/core/composer/qgscomposermapoverview.cpp
@@ -95,7 +95,7 @@ void QgsComposerMapOverview::draw( QPainter *painter )
   ms.setExtent( *mComposerMap->currentMapExtent() );
   ms.setOutputDpi( painter->device()->logicalDpiX() );
   QgsRenderContext context = QgsRenderContext::fromMapSettings( ms );
-  context.setForceVectorOutput( true );
+  context.setFlag( QgsRenderContext::ForceVectorOutput, true );
   context.setPainter( painter );
   QgsExpressionContext* expressionContext = createExpressionContext();
   context.setExpressionContext( *expressionContext );

--- a/src/core/composer/qgscomposershape.cpp
+++ b/src/core/composer/qgscomposershape.cpp
@@ -181,7 +181,7 @@ void QgsComposerShape::drawShapeUsingSymbol( QPainter* p )
   ms.setOutputDpi( p->device()->logicalDpiX() );
   QgsRenderContext context = QgsRenderContext::fromMapSettings( ms );
   context.setPainter( p );
-  context.setForceVectorOutput( true );
+  context.setFlag( QgsRenderContext::ForceVectorOutput, true );
   QgsExpressionContext* expressionContext = createExpressionContext();
   context.setExpressionContext( *expressionContext );
   delete expressionContext;

--- a/src/core/composer/qgspaperitem.cpp
+++ b/src/core/composer/qgspaperitem.cpp
@@ -163,7 +163,7 @@ void QgsPaperItem::paint( QPainter* painter, const QStyleOptionGraphicsItem* ite
   ms.setOutputDpi( painter->device()->logicalDpiX() );
   QgsRenderContext context = QgsRenderContext::fromMapSettings( ms );
   context.setPainter( painter );
-  context.setForceVectorOutput( true );
+  context.setFlag( QgsRenderContext::ForceVectorOutput, true );
   QgsExpressionContext* expressionContext = createExpressionContext();
   context.setExpressionContext( *expressionContext );
   delete expressionContext;

--- a/src/core/layertree/qgslayertreemodellegendnode.cpp
+++ b/src/core/layertree/qgslayertreemodellegendnode.cpp
@@ -307,7 +307,7 @@ QSizeF QgsSymbolV2LegendNode::drawSymbol( const QgsLegendSettings& settings, Ite
   context.setScaleFactor( settings.dpi() / 25.4 );
   context.setRendererScale( settings.mapScale() );
   context.setMapToPixel( QgsMapToPixel( 1 / ( settings.mmPerMapUnit() * context.scaleFactor() ) ) );
-  context.setForceVectorOutput( true );
+  context.setFlag( QgsRenderContext::ForceVectorOutput, true );
   context.setPainter( ctx ? ctx->painter : 0 );
 
   //Consider symbol size for point markers

--- a/src/core/qgsmaprenderer.cpp
+++ b/src/core/qgsmaprenderer.cpp
@@ -282,7 +282,7 @@ void QgsMapRenderer::render( QPainter* painter, double* forceWidthScale )
 #endif
 
   if ( mOverview )
-    mRenderContext.setDrawEditingInformation( !mOverview );
+    mRenderContext.setFlag( QgsRenderContext::DrawEditingInfo, !mOverview );
 
   mRenderContext.setPainter( painter );
   mRenderContext.setCoordinateTransform( 0 );
@@ -386,7 +386,7 @@ void QgsMapRenderer::render( QPainter* painter, double* forceWidthScale )
                  .arg( ml->blendMode() )
                );
 
-    if ( mRenderContext.useAdvancedEffects() )
+    if ( mRenderContext.testFlag( QgsRenderContext::UseAdvancedEffects ) )
     {
       // Set the QPainter composition mode so that this layer is rendered using
       // the desired blending mode
@@ -442,7 +442,7 @@ void QgsMapRenderer::render( QPainter* painter, double* forceWidthScale )
       // blending occuring between objects on the layer
       // (this is not required for raster layers or when layer caching is enabled, since that has the same effect)
       bool flattenedLayer = false;
-      if (( mRenderContext.useAdvancedEffects() ) && ( ml->type() == QgsMapLayer::VectorLayer ) )
+      if ( mRenderContext.testFlag( QgsRenderContext::UseAdvancedEffects ) && ( ml->type() == QgsMapLayer::VectorLayer ) )
       {
         QgsVectorLayer* vl = qobject_cast<QgsVectorLayer *>( ml );
         if ((( vl->blendMode() != QPainter::CompositionMode_SourceOver )
@@ -471,7 +471,7 @@ void QgsMapRenderer::render( QPainter* painter, double* forceWidthScale )
       }
 
       // Per feature blending mode
-      if (( mRenderContext.useAdvancedEffects() ) && ( ml->type() == QgsMapLayer::VectorLayer ) )
+      if ( mRenderContext.testFlag( QgsRenderContext::UseAdvancedEffects ) && ( ml->type() == QgsMapLayer::VectorLayer ) )
       {
         QgsVectorLayer* vl = qobject_cast<QgsVectorLayer *>( ml );
         if ( vl->featureBlendMode() != QPainter::CompositionMode_SourceOver )
@@ -520,7 +520,7 @@ void QgsMapRenderer::render( QPainter* painter, double* forceWidthScale )
       }
 
       //apply layer transparency for vector layers
-      if (( mRenderContext.useAdvancedEffects() ) && ( ml->type() == QgsMapLayer::VectorLayer ) )
+      if ( mRenderContext.testFlag( QgsRenderContext::UseAdvancedEffects ) && ( ml->type() == QgsMapLayer::VectorLayer ) )
       {
         QgsVectorLayer* vl = qobject_cast<QgsVectorLayer *>( ml );
         if ( vl->layerTransparency() != 0 )

--- a/src/core/qgsmaprenderercustompainterjob.cpp
+++ b/src/core/qgsmaprenderercustompainterjob.cpp
@@ -240,7 +240,7 @@ void QgsMapRendererCustomPainterJob::doRender()
     if ( job.context.renderingStopped() )
       break;
 
-    if ( job.context.useAdvancedEffects() )
+    if ( job.context.testFlag( QgsRenderContext::UseAdvancedEffects ) )
     {
       // Set the QPainter composition mode so that this layer is rendered using
       // the desired blending mode

--- a/src/core/qgspallabeling.cpp
+++ b/src/core/qgspallabeling.cpp
@@ -4430,7 +4430,7 @@ void QgsPalLabeling::drawLabelBuffer( QgsRenderContext& context,
   }
 
   p->save();
-  if ( context.useAdvancedEffects() )
+  if ( context.testFlag( QgsRenderContext::UseAdvancedEffects ) )
   {
     p->setCompositionMode( tmpLyr.bufferBlendMode );
   }
@@ -4596,7 +4596,7 @@ void QgsPalLabeling::drawLabelBackground( QgsRenderContext& context,
                                          ( 100.0 - ( double )( tmpLyr.shapeTransparency ) ) / 100.0 );
 
     p->save();
-    if ( context.useAdvancedEffects() )
+    if ( context.testFlag( QgsRenderContext::UseAdvancedEffects ) )
     {
       p->setCompositionMode( tmpLyr.shapeBlendMode );
     }
@@ -4729,7 +4729,7 @@ void QgsPalLabeling::drawLabelBackground( QgsRenderContext& context,
     }
 
     p->setOpacity(( 100.0 - ( double )( tmpLyr.shapeTransparency ) ) / 100.0 );
-    if ( context.useAdvancedEffects() )
+    if ( context.testFlag( QgsRenderContext::UseAdvancedEffects ) )
     {
       p->setCompositionMode( tmpLyr.shapeBlendMode );
     }
@@ -4835,7 +4835,7 @@ void QgsPalLabeling::drawLabelShadow( QgsRenderContext& context,
 
   p->save();
   p->setRenderHints( QPainter::Antialiasing | QPainter::SmoothPixmapTransform );
-  if ( context.useAdvancedEffects() )
+  if ( context.testFlag( QgsRenderContext::UseAdvancedEffects ) )
   {
     p->setCompositionMode( tmpLyr.shadowBlendMode );
   }

--- a/src/core/qgsrendercontext.cpp
+++ b/src/core/qgsrendercontext.cpp
@@ -21,19 +21,15 @@
 #include "qgsmapsettings.h"
 
 QgsRenderContext::QgsRenderContext()
-    : mPainter( 0 )
+    : mFlags( DrawEditingInfo | UseAdvancedEffects | DrawSelection | UseRenderingOptimization )
+    , mPainter( 0 )
     , mCoordTransform( 0 )
-    , mDrawEditingInformation( true )
-    , mForceVectorOutput( false )
-    , mUseAdvancedEffects( true )
     , mRenderingStopped( false )
     , mScaleFactor( 1.0 )
     , mRasterScaleFactor( 1.0 )
     , mRendererScale( 1.0 )
     , mLabelingEngine( NULL )
     , mLabelingEngine2( 0 )
-    , mShowSelection( true )
-    , mUseRenderingOptimization( true )
     , mGeometry( 0 )
 {
   mVectorSimplifyMethod.setSimplifyHints( QgsVectorSimplifyMethod::NoSimplification );
@@ -43,18 +39,41 @@ QgsRenderContext::~QgsRenderContext()
 {
 }
 
+void QgsRenderContext::setFlags( const QgsRenderContext::Flags& flags )
+{
+  mFlags = flags;
+}
+
+void QgsRenderContext::setFlag( QgsRenderContext::Flag flag, bool on )
+{
+  if ( on )
+    mFlags |= flag;
+  else
+    mFlags &= ~flag;
+}
+
+QgsRenderContext::Flags QgsRenderContext::flags() const
+{
+  return mFlags;
+}
+
+bool QgsRenderContext::testFlag( QgsRenderContext::Flag flag ) const
+{
+  return mFlags.testFlag( flag );
+}
+
 QgsRenderContext QgsRenderContext::fromMapSettings( const QgsMapSettings& mapSettings )
 {
   QgsRenderContext ctx;
   ctx.setMapToPixel( mapSettings.mapToPixel() );
   ctx.setExtent( mapSettings.visibleExtent() );
-  ctx.setDrawEditingInformation( mapSettings.testFlag( QgsMapSettings::DrawEditingInfo ) );
-  ctx.setForceVectorOutput( mapSettings.testFlag( QgsMapSettings::ForceVectorOutput ) );
-  ctx.setUseAdvancedEffects( mapSettings.testFlag( QgsMapSettings::UseAdvancedEffects ) );
-  ctx.setUseRenderingOptimization( mapSettings.testFlag( QgsMapSettings::UseRenderingOptimization ) );
+  ctx.setFlag( DrawEditingInfo, mapSettings.testFlag( QgsMapSettings::DrawEditingInfo ) );
+  ctx.setFlag( ForceVectorOutput, mapSettings.testFlag( QgsMapSettings::ForceVectorOutput ) );
+  ctx.setFlag( UseAdvancedEffects, mapSettings.testFlag( QgsMapSettings::UseAdvancedEffects ) );
+  ctx.setFlag( UseRenderingOptimization, mapSettings.testFlag( QgsMapSettings::UseRenderingOptimization ) );
   ctx.setCoordinateTransform( 0 );
   ctx.setSelectionColor( mapSettings.selectionColor() );
-  ctx.setShowSelection( mapSettings.testFlag( QgsMapSettings::DrawSelection ) );
+  ctx.setFlag( DrawSelection, mapSettings.testFlag( QgsMapSettings::DrawSelection ) );
   ctx.setRasterScaleFactor( 1.0 );
   ctx.setScaleFactor( mapSettings.outputDpi() / 25.4 ); // = pixels per mm
   ctx.setRendererScale( mapSettings.scale() );
@@ -67,7 +86,57 @@ QgsRenderContext QgsRenderContext::fromMapSettings( const QgsMapSettings& mapSet
   return ctx;
 }
 
+bool QgsRenderContext::forceVectorOutput() const
+{
+  return mFlags.testFlag( ForceVectorOutput );
+}
+
+bool QgsRenderContext::useAdvancedEffects() const
+{
+  return mFlags.testFlag( UseAdvancedEffects );
+}
+
+void QgsRenderContext::setUseAdvancedEffects( bool enabled )
+{
+  setFlag( UseAdvancedEffects, enabled );
+}
+
+bool QgsRenderContext::drawEditingInformation() const
+{
+  return mFlags.testFlag( DrawEditingInfo );
+}
+
+bool QgsRenderContext::showSelection() const
+{
+  return mFlags.testFlag( DrawSelection );
+}
+
 void QgsRenderContext::setCoordinateTransform( const QgsCoordinateTransform* t )
 {
   mCoordTransform = t;
+}
+
+void QgsRenderContext::setDrawEditingInformation( bool b )
+{
+  setFlag( DrawEditingInfo, b );
+}
+
+void QgsRenderContext::setForceVectorOutput( bool force )
+{
+  setFlag( ForceVectorOutput, force );
+}
+
+void QgsRenderContext::setShowSelection( const bool showSelection )
+{
+  setFlag( DrawSelection, showSelection );
+}
+
+bool QgsRenderContext::useRenderingOptimization() const
+{
+  return mFlags.testFlag( UseRenderingOptimization );
+}
+
+void QgsRenderContext::setUseRenderingOptimization( bool enabled )
+{
+  setFlag( UseRenderingOptimization, enabled );
 }

--- a/src/core/qgsrendercontext.h
+++ b/src/core/qgsrendercontext.h
@@ -45,6 +45,26 @@ class CORE_EXPORT QgsRenderContext
     QgsRenderContext();
     ~QgsRenderContext();
 
+    //! Enumeration of flags that affect rendering operations
+    enum Flag
+    {
+      DrawEditingInfo    = 0x01,  //!< Enable drawing of vertex markers for layers in editing mode
+      ForceVectorOutput  = 0x02,  //!< Vector graphics should not be cached and drawn as raster images
+      UseAdvancedEffects = 0x04,  //!< Enable layer transparency and blending effects
+      UseRenderingOptimization = 0x08, //!< Enable vector simplification and other rendering optimizations
+      DrawSelection      = 0x10,  //!< Whether vector selections should be shown in the rendered map
+    };
+    Q_DECLARE_FLAGS( Flags, Flag )
+
+    //! Set combination of flags that will be used for rendering
+    void setFlags( const QgsRenderContext::Flags& flags );
+    //! Enable or disable a particular flag (other flags are not affected)
+    void setFlag( Flag flag, bool on = true );
+    //! Return combination of flags used for rendering
+    Flags flags() const;
+    //! Check whether a particular flag is enabled
+    bool testFlag( Flag flag ) const;
+
     //! create initialized QgsRenderContext instance from given QgsMapSettings
     //! @note added in 2.4
     static QgsRenderContext fromMapSettings( const QgsMapSettings& mapSettings );
@@ -66,14 +86,21 @@ class CORE_EXPORT QgsRenderContext
 
     bool renderingStopped() const {return mRenderingStopped;}
 
-    bool forceVectorOutput() const {return mForceVectorOutput;}
+    //! @deprecated use testFlag( QgsRenderContext::ForceVectorOutput ) instead
+    Q_DECL_DEPRECATED bool forceVectorOutput() const;
 
-    /** Returns true if advanced effects such as blend modes such be used */
-    bool useAdvancedEffects() const {return mUseAdvancedEffects;}
-    /** Used to enable or disable advanced effects such as blend modes */
-    void setUseAdvancedEffects( bool enabled ) { mUseAdvancedEffects = enabled; }
+    /** Returns true if advanced effects such as blend modes such be used
+     * @deprecated use testFlag( QgsRenderContext::UseAdvancedEffects ) instead
+    */
+    Q_DECL_DEPRECATED bool useAdvancedEffects() const;
 
-    bool drawEditingInformation() const {return mDrawEditingInformation;}
+    /** Used to enable or disable advanced effects such as blend modes
+     * @deprecated use setFlag( QgsRenderContext::UseAdvancedEffects, enabled ) instead
+    */
+    Q_DECL_DEPRECATED void setUseAdvancedEffects( bool enabled );
+
+    //! @deprecated use testFlag( QgsRenderContext::DrawEditingInfo ) instead
+    Q_DECL_DEPRECATED bool drawEditingInformation() const;
 
     double rendererScale() const {return mRendererScale;}
 
@@ -89,8 +116,9 @@ class CORE_EXPORT QgsRenderContext
      * @see setShowSelection
      * @see selectionColor
      * @note Added in QGIS v2.4
+     * @deprecated use testFlag( QgsRenderContext::DrawSelection ) instead
     */
-    bool showSelection() const { return mShowSelection; }
+    Q_DECL_DEPRECATED bool showSelection() const;
 
     //setters
 
@@ -98,13 +126,19 @@ class CORE_EXPORT QgsRenderContext
     void setCoordinateTransform( const QgsCoordinateTransform* t );
     void setMapToPixel( const QgsMapToPixel& mtp ) {mMapToPixel = mtp;}
     void setExtent( const QgsRectangle& extent ) {mExtent = extent;}
-    void setDrawEditingInformation( bool b ) {mDrawEditingInformation = b;}
+
+    //! @deprecated use setFlag( QgsRenderContext::DrawEditingInfo, b ) instead
+    Q_DECL_DEPRECATED void setDrawEditingInformation( bool b );
+
     void setRenderingStopped( bool stopped ) {mRenderingStopped = stopped;}
     void setScaleFactor( double factor ) {mScaleFactor = factor;}
     void setRasterScaleFactor( double factor ) {mRasterScaleFactor = factor;}
     void setRendererScale( double scale ) {mRendererScale = scale;}
     void setPainter( QPainter* p ) {mPainter = p;}
-    void setForceVectorOutput( bool force ) {mForceVectorOutput = force;}
+
+    //! @deprecated use setFlag( QgsRenderContext::ForceVectorOutput, b ) instead
+    Q_DECL_DEPRECATED void setForceVectorOutput( bool force );
+
     void setLabelingEngine( QgsLabelingEngineInterface* iface ) { mLabelingEngine = iface; }
     //! Assign new labeling engine
     void setLabelingEngineV2( QgsLabelingEngineV2* engine2 ) { mLabelingEngine2 = engine2; }
@@ -115,12 +149,17 @@ class CORE_EXPORT QgsRenderContext
      * @see showSelection
      * @see setSelectionColor
      * @note Added in QGIS v2.4
+     * @deprecated use setFlag( QgsRenderContext::DrawSelection, showSelection ) instead
     */
-    void setShowSelection( const bool showSelection ) { mShowSelection = showSelection; }
+    Q_DECL_DEPRECATED void setShowSelection( const bool showSelection );
 
-    /** Returns true if the rendering optimization (geometry simplification) can be executed*/
-    bool useRenderingOptimization() const { return mUseRenderingOptimization; }
-    void setUseRenderingOptimization( bool enabled ) { mUseRenderingOptimization = enabled; }
+    /** Returns true if the rendering optimization (geometry simplification) can be executed
+     * @deprecated use testFlag( QgsRenderContext::UseRenderingOptimization ) instead
+    */
+    Q_DECL_DEPRECATED bool useRenderingOptimization() const;
+
+    //! @deprecated use setFlag( QgsRenderContext::UseRenderingOptimization, b ) instead
+    Q_DECL_DEPRECATED void setUseRenderingOptimization( bool enabled );
 
     //! Added in QGIS v2.4
     const QgsVectorSimplifyMethod& vectorSimplifyMethod() const { return mVectorSimplifyMethod; }
@@ -144,6 +183,7 @@ class CORE_EXPORT QgsRenderContext
      * associated with this render context.
      * @see setExpressionContext()
      * @note added in QGIS 2.12
+     * @note not available in Python bindings
      */
     const QgsExpressionContext& expressionContext() const { return mExpressionContext; }
 
@@ -154,22 +194,15 @@ class CORE_EXPORT QgsRenderContext
 
   private:
 
+    Flags mFlags;
+
     /** Painter for rendering operations*/
     QPainter* mPainter;
 
     /** For transformation between coordinate systems. Can be 0 if on-the-fly reprojection is not used*/
     const QgsCoordinateTransform* mCoordTransform;
 
-    /** True if vertex markers for editing should be drawn*/
-    bool mDrawEditingInformation;
-
     QgsRectangle mExtent;
-
-    /** If true then no rendered vector elements should be cached as image*/
-    bool mForceVectorOutput;
-
-    /** Flag if advanced visual effects such as blend modes should be used. True by default*/
-    bool mUseAdvancedEffects;
 
     QgsMapToPixel mMapToPixel;
 
@@ -191,14 +224,8 @@ class CORE_EXPORT QgsRenderContext
     /** Newer labeling engine implementation (can be NULL) */
     QgsLabelingEngineV2* mLabelingEngine2;
 
-    /** Whether selection should be shown*/
-    bool mShowSelection;
-
     /** Color used for features that are marked as selected */
     QColor mSelectionColor;
-
-    /** True if the rendering optimization (geometry simplification) can be executed*/
-    bool mUseRenderingOptimization;
 
     /** Simplification object which holds the information about how to simplify the features for fast rendering */
     QgsVectorSimplifyMethod mVectorSimplifyMethod;
@@ -209,5 +236,7 @@ class CORE_EXPORT QgsRenderContext
     /** Pointer to the (unsegmentized) geometry*/
     const QgsAbstractGeometryV2* mGeometry;
 };
+
+Q_DECLARE_OPERATORS_FOR_FLAGS( QgsRenderContext::Flags )
 
 #endif

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -914,7 +914,7 @@ bool QgsVectorLayer::setSubsetString( const QString& subset )
 
 bool QgsVectorLayer::simplifyDrawingCanbeApplied( const QgsRenderContext& renderContext, QgsVectorSimplifyMethod::SimplifyHint simplifyHint ) const
 {
-  if ( mValid && mDataProvider && !mEditBuffer && ( hasGeometryType() && geometryType() != QGis::Point ) && ( mSimplifyMethod.simplifyHints() & simplifyHint ) && renderContext.useRenderingOptimization() )
+  if ( mValid && mDataProvider && !mEditBuffer && ( hasGeometryType() && geometryType() != QGis::Point ) && ( mSimplifyMethod.simplifyHints() & simplifyHint ) && renderContext.testFlag( QgsRenderContext::UseRenderingOptimization ) )
   {
     double maximumSimplificationScale = mSimplifyMethod.maximumScale();
 

--- a/src/core/qgsvectorlayerlabelprovider.cpp
+++ b/src/core/qgsvectorlayerlabelprovider.cpp
@@ -631,7 +631,7 @@ void QgsVectorLayerLabelProvider::drawLabelPrivate( pal::LabelPosition* label, Q
         }
 
         // paint the text
-        if ( context.useAdvancedEffects() )
+        if ( context.testFlag( QgsRenderContext::UseAdvancedEffects ) )
         {
           painter->setCompositionMode( tmpLyr.blendMode );
         }

--- a/src/core/qgsvectorlayerrenderer.cpp
+++ b/src/core/qgsvectorlayerrenderer.cpp
@@ -134,7 +134,7 @@ bool QgsVectorLayerRenderer::render()
   }
 
   // Per feature blending mode
-  if ( mContext.useAdvancedEffects() && mFeatureBlendMode != QPainter::CompositionMode_SourceOver )
+  if ( mContext.testFlag( QgsRenderContext::UseAdvancedEffects ) && mFeatureBlendMode != QPainter::CompositionMode_SourceOver )
   {
     // set the painter to the feature blend mode, so that features drawn
     // on this layer will interact and blend with each other
@@ -245,7 +245,7 @@ bool QgsVectorLayerRenderer::render()
   }
 
   //apply layer transparency for vector layers
-  if ( mContext.useAdvancedEffects() && mLayerTransparency != 0 )
+  if ( mContext.testFlag( QgsRenderContext::UseAdvancedEffects ) && mLayerTransparency != 0 )
   {
     // a layer transparency has been set, so update the alpha for the flattened layer
     // by combining it with the layer transparency
@@ -290,8 +290,8 @@ void QgsVectorLayerRenderer::drawRendererV2( QgsFeatureIterator& fit )
 
       mContext.expressionContext().setFeature( fet );
 
-      bool sel = mContext.showSelection() && mSelectedFeatureIds.contains( fet.id() );
-      bool drawMarker = ( mDrawVertexMarkers && mContext.drawEditingInformation() && ( !mVertexMarkerOnlyForSelection || sel ) );
+      bool sel = mContext.testFlag( QgsRenderContext::DrawSelection ) && mSelectedFeatureIds.contains( fet.id() );
+      bool drawMarker = ( mDrawVertexMarkers && mContext.testFlag( QgsRenderContext::DrawEditingInfo ) && ( !mVertexMarkerOnlyForSelection || sel ) );
 
       if ( mCache )
       {
@@ -456,7 +456,7 @@ void QgsVectorLayerRenderer::drawRendererV2Levels( QgsFeatureIterator& fit )
 
         bool sel = mSelectedFeatureIds.contains( fit->id() );
         // maybe vertex markers should be drawn only during the last pass...
-        bool drawMarker = ( mDrawVertexMarkers && mContext.drawEditingInformation() && ( !mVertexMarkerOnlyForSelection || sel ) );
+        bool drawMarker = ( mDrawVertexMarkers && mContext.testFlag( QgsRenderContext::DrawEditingInfo ) && ( !mVertexMarkerOnlyForSelection || sel ) );
 
         mContext.expressionContext().setFeature( *fit );
 

--- a/src/core/symbology-ng/qgsfillsymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgsfillsymbollayerv2.cpp
@@ -2732,7 +2732,7 @@ void QgsLinePatternFillSymbolLayer::applyPattern( const QgsSymbolV2RenderContext
   lineRenderContext.setScaleFactor( context.renderContext().scaleFactor() * context.renderContext().rasterScaleFactor() );
   QgsMapToPixel mtp( context.renderContext().mapToPixel().mapUnitsPerPixel() / context.renderContext().rasterScaleFactor() );
   lineRenderContext.setMapToPixel( mtp );
-  lineRenderContext.setForceVectorOutput( false );
+  lineRenderContext.setFlag( QgsRenderContext::ForceVectorOutput, false );
   lineRenderContext.setExpressionContext( context.renderContext().expressionContext() );
 
   fillLineSymbol->startRender( lineRenderContext, context.fields() );
@@ -3147,7 +3147,7 @@ void QgsPointPatternFillSymbolLayer::applyPattern( const QgsSymbolV2RenderContex
     pointRenderContext.setScaleFactor( context.renderContext().scaleFactor() * context.renderContext().rasterScaleFactor() );
     QgsMapToPixel mtp( context.renderContext().mapToPixel().mapUnitsPerPixel() / context.renderContext().rasterScaleFactor() );
     pointRenderContext.setMapToPixel( mtp );
-    pointRenderContext.setForceVectorOutput( false );
+    pointRenderContext.setFlag( QgsRenderContext::ForceVectorOutput, false );
     pointRenderContext.setExpressionContext( context.renderContext().expressionContext() );
 
     mMarkerSymbol->startRender( pointRenderContext, context.fields() );

--- a/src/core/symbology-ng/qgsmarkersymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgsmarkersymbollayerv2.cpp
@@ -187,7 +187,7 @@ void QgsSimpleMarkerSymbolLayerV2::startRender( QgsSymbolV2RenderContext& contex
   // use caching only when:
   // - size, rotation, shape, color, border color is not data-defined
   // - drawing to screen (not printer)
-  mUsingCache = !hasDataDefinedRotation && !hasDataDefinedSize && !context.renderContext().forceVectorOutput()
+  mUsingCache = !hasDataDefinedRotation && !hasDataDefinedSize && !context.renderContext().testFlag( QgsRenderContext::ForceVectorOutput )
                 && !hasDataDefinedProperty( QgsSymbolLayerV2::EXPR_NAME ) && !hasDataDefinedProperty( QgsSymbolLayerV2::EXPR_COLOR ) && !hasDataDefinedProperty( QgsSymbolLayerV2::EXPR_COLOR_BORDER )
                 && !hasDataDefinedProperty( QgsSymbolLayerV2::EXPR_OUTLINE_WIDTH ) && !hasDataDefinedProperty( QgsSymbolLayerV2::EXPR_OUTLINE_STYLE ) &&
                 !hasDataDefinedProperty( QgsSymbolLayerV2::EXPR_SIZE );
@@ -1319,7 +1319,7 @@ void QgsSvgMarkerSymbolLayerV2::renderPoint( const QPointF& point, QgsSymbolV2Re
   bool fitsInCache = true;
   bool usePict = true;
   double hwRatio = 1.0;
-  if ( !context.renderContext().forceVectorOutput() && !rotated )
+  if ( !context.renderContext().testFlag( QgsRenderContext::ForceVectorOutput ) && !rotated )
   {
     usePict = false;
     const QImage& img = QgsSvgCache::instance()->svgAsImage( path, size, fillColor, outlineColor, outlineWidth,
@@ -1346,7 +1346,7 @@ void QgsSvgMarkerSymbolLayerV2::renderPoint( const QPointF& point, QgsSymbolV2Re
   {
     p->setOpacity( context.alpha() );
     const QPicture& pct = QgsSvgCache::instance()->svgAsPicture( path, size, fillColor, outlineColor, outlineWidth,
-                          context.renderContext().scaleFactor(), context.renderContext().rasterScaleFactor(), context.renderContext().forceVectorOutput() );
+                          context.renderContext().scaleFactor(), context.renderContext().rasterScaleFactor(), context.renderContext().testFlag( QgsRenderContext::ForceVectorOutput ) );
 
     if ( pct.width() > 1 )
     {

--- a/src/core/symbology-ng/qgssymbollayerv2utils.cpp
+++ b/src/core/symbology-ng/qgssymbollayerv2utils.cpp
@@ -580,7 +580,7 @@ QPicture QgsSymbolLayerV2Utils::symbolLayerPreviewPicture( QgsSymbolLayerV2* lay
   painter.begin( &picture );
   painter.setRenderHint( QPainter::Antialiasing );
   QgsRenderContext renderContext = createRenderContext( &painter );
-  renderContext.setForceVectorOutput( true );
+  renderContext.setFlag( QgsRenderContext::ForceVectorOutput, true );
   QgsSymbolV2RenderContext symbolContext( renderContext, units, 1.0, false, 0, 0, 0, scale );
   layer->drawPreviewIcon( symbolContext, size );
   painter.end();

--- a/src/core/symbology-ng/qgssymbolv2.cpp
+++ b/src/core/symbology-ng/qgssymbolv2.cpp
@@ -331,7 +331,7 @@ QColor QgsSymbolV2::color() const
 void QgsSymbolV2::drawPreviewIcon( QPainter* painter, QSize size, QgsRenderContext* customContext )
 {
   QgsRenderContext context = customContext ? *customContext : QgsSymbolLayerV2Utils::createRenderContext( painter );
-  context.setForceVectorOutput( true );
+  context.setFlag( QgsRenderContext::ForceVectorOutput, true );
   QgsSymbolV2RenderContext symbolContext( context, outputUnit(), mAlpha, false, mRenderHints, 0, 0, mapUnitScale() );
 
   for ( QgsSymbolLayerV2List::iterator it = mLayers.begin(); it != mLayers.end(); ++it )

--- a/src/gui/qgsmapcanvasitem.cpp
+++ b/src/gui/qgsmapcanvasitem.cpp
@@ -132,7 +132,7 @@ bool QgsMapCanvasItem::setRenderContextVariables( QPainter* p, QgsRenderContext&
   context.setScaleFactor( ms.outputDpi() / 25.4 );
   context.setRasterScaleFactor( 1.0 );
 
-  context.setForceVectorOutput( true );
+  context.setFlag( QgsRenderContext::ForceVectorOutput, true );
   return true;
 }
 


### PR DESCRIPTION
This commit switches QgsRenderContext to use flags for boolean properties instead of separate getters/setters.  It's motivated by two things:
- better consistency with QgsMapSettings
- I want to add some extra boolean properties to QgsRenderContext (relating to debug style drawing for unit testing) but don't want to clutter up the QgsRenderContext API with these extra methods
