### PR TITLE
Fix QgsGeos::linePointDifference

### DIFF
--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -551,7 +551,7 @@ GEOSGeometry* QgsGeos::linePointDifference( GEOSGeometry* GEOSsplitPoint ) const
       //For each segment
       QgsLineStringV2 newLine;
       newLine.addVertex( line->pointN( 0 ) );
-      int nVertices = newLine.numPoints();
+      int nVertices = line->numPoints();
       for ( int j = 1; j < ( nVertices - 1 ); ++j )
       {
         QgsPointV2 currentPoint = line->pointN( j );


### PR DESCRIPTION
This function would only return a line with the first vertex of the original line, rather than the entire line splitted into two lines at the splitPoint.
(Sorry for the single-line PR, but the topic seems different enough for not integrating it into the other PR that I made.)
