### PR TITLE
make qt5 build on ubuntu 15.10

### DIFF
--- a/cmake/FindQScintilla.cmake
+++ b/cmake/FindQScintilla.cmake
@@ -28,12 +28,13 @@ ELSE(EXISTS QSCINTILLA_VERSION_STR)
     NAMES Qsci/qsciglobal.h
     PATHS
       "${QT_INCLUDE_DIR}"
+      /usr/include/x86_64-linux-gnu/qt5
       /usr/local/include
       /usr/include
     )
 
   if(ENABLE_QT5)
-    set(QSCINTILLA_LIBRARY_NAMES qscintilla2-qt5 libqscintilla2-qt5 libqscintilla2-qt5.dylib)
+    set(QSCINTILLA_LIBRARY_NAMES qscintilla2-qt5 qt5scintilla2 libqscintilla2-qt5 libqscintilla2-qt5.dylib)
   else(ENABLE_QT5)
     set(QSCINTILLA_LIBRARY_NAMES qscintilla2 libqscintilla2 libqscintilla2.dylib)
   endif(ENABLE_QT5)

--- a/cmake/FindQScintilla.cmake
+++ b/cmake/FindQScintilla.cmake
@@ -28,8 +28,8 @@ ELSE(EXISTS QSCINTILLA_VERSION_STR)
     NAMES Qsci/qsciglobal.h
     PATHS
       "${QT_INCLUDE_DIR}"
-      /usr/include/x86_64-linux-gnu/qt5
       /usr/local/include
+      /usr/include/x86_64-linux-gnu/qt5
       /usr/include
     )
 


### PR DESCRIPTION
this allows finding qscintilla (installed from packages) on ubuntu 15.10 when building using qt5
