### PR TITLE
fix value relation search widget

### DIFF
--- a/src/gui/editorwidgets/core/qgssearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/core/qgssearchwidgetwrapper.cpp
@@ -33,3 +33,8 @@ void QgsSearchWidgetWrapper::setFeature( const QgsFeature& feature )
   Q_UNUSED( feature )
 }
 
+void QgsSearchWidgetWrapper::clearExpression()
+{
+  mExpression = QString( "TRUE" );
+}
+

--- a/src/gui/editorwidgets/core/qgssearchwidgetwrapper.h
+++ b/src/gui/editorwidgets/core/qgssearchwidgetwrapper.h
@@ -81,6 +81,9 @@ class GUI_EXPORT QgsSearchWidgetWrapper : public QgsWidgetWrapper
     void setFeature( const QgsFeature& feature ) override;
 
   protected:
+    //! clears the expression to search for all features
+    void clearExpression();
+
     QString mExpression;
     int mFieldIdx;
 

--- a/src/gui/editorwidgets/qgsdefaultsearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsdefaultsearchwidgetwrapper.cpp
@@ -68,8 +68,8 @@ void QgsDefaultSearchWidgetWrapper::setExpression( QString exp )
     str = QString( "%1 %2 '%3'" )
           .arg( QgsExpression::quotedColumnRef( fieldName ),
                 numeric ? "=" : mCaseString,
-                numeric
-                ? exp.replace( '\'', "''" )
+                numeric ?
+                exp.replace( '\'', "''" )
                 :
                 '%' + exp.replace( '\'', "''" ) + '%' ); // escape quotes
   }

--- a/src/gui/editorwidgets/qgsvaluemapsearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapsearchwidgetwrapper.cpp
@@ -23,7 +23,7 @@
 #include <QSizePolicy>
 
 QgsValueMapSearchWidgetWrapper::QgsValueMapSearchWidgetWrapper( QgsVectorLayer* vl, int fieldIdx, QWidget* parent )
-    : QgsDefaultSearchWidgetWrapper( vl, fieldIdx, parent ),
+    : QgsSearchWidgetWrapper( vl, fieldIdx, parent ),
     mComboBox( NULL )
 {
 }
@@ -33,13 +33,26 @@ QWidget* QgsValueMapSearchWidgetWrapper::createWidget( QWidget* parent )
   return new QComboBox( parent );
 }
 
-void QgsValueMapSearchWidgetWrapper::comboBoxIndexChanged( int )
+void QgsValueMapSearchWidgetWrapper::comboBoxIndexChanged( int idx )
 {
   if ( mComboBox )
-    setExpression( mComboBox->itemData( mComboBox->currentIndex() ).toString() );
+  {
+    setExpression( mComboBox->itemData( idx ).toString() );
+    emit expressionChanged( mExpression );
+  }
 }
 
 bool QgsValueMapSearchWidgetWrapper::applyDirectly()
+{
+  return true;
+}
+
+QString QgsValueMapSearchWidgetWrapper::expression()
+{
+  return mExpression;
+}
+
+bool QgsValueMapSearchWidgetWrapper::valid()
 {
   return true;
 }
@@ -61,5 +74,17 @@ void QgsValueMapSearchWidgetWrapper::initWidget( QWidget* editor )
     }
     connect( mComboBox, SIGNAL( currentIndexChanged( int ) ), this, SLOT( comboBoxIndexChanged( int ) ) );
   }
+}
+
+void QgsValueMapSearchWidgetWrapper::setExpression( QString exp )
+{
+  QString fieldName = layer()->fields().at( mFieldIdx ).name();
+  QString str;
+
+  str = QString( "%1 = '%2'" )
+        .arg( QgsExpression::quotedColumnRef( fieldName ),
+              exp.replace( '\'', "''" ) );
+
+  mExpression = str;
 }
 

--- a/src/gui/editorwidgets/qgsvaluemapsearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapsearchwidgetwrapper.cpp
@@ -37,7 +37,14 @@ void QgsValueMapSearchWidgetWrapper::comboBoxIndexChanged( int idx )
 {
   if ( mComboBox )
   {
-    setExpression( mComboBox->itemData( idx ).toString() );
+    if ( idx == 0 )
+    {
+      clearExpression();
+    }
+    else
+    {
+      setExpression( mComboBox->itemData( idx ).toString() );
+    }
     emit expressionChanged( mExpression );
   }
 }

--- a/src/gui/editorwidgets/qgsvaluemapsearchwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsvaluemapsearchwidgetwrapper.h
@@ -16,24 +16,33 @@
 #ifndef QGSVALUEMAPSEARCHWIDGETWRAPPER_H
 #define QGSVALUEMAPSEARCHWIDGETWRAPPER_H
 
-#include "qgsdefaultsearchwidgetwrapper.h"
+#include "qgssearchwidgetwrapper.h"
 #include <QComboBox>
 
+/**
+ * Wraps a value map search widget. This widget will offer a combobox with values from another layer
+ * referenced by a foreign key (a constraint may be set but is not required on data level).
+ * It will be used as a search widget and produces expression to look for in the layer.
+ */
 
-
-class GUI_EXPORT QgsValueMapSearchWidgetWrapper : public QgsDefaultSearchWidgetWrapper
+class GUI_EXPORT QgsValueMapSearchWidgetWrapper : public QgsSearchWidgetWrapper
 {
     Q_OBJECT
   public:
     explicit QgsValueMapSearchWidgetWrapper( QgsVectorLayer* vl, int fieldIdx, QWidget* parent = 0 );
     bool applyDirectly() override;
+    QString expression() override;
+    bool valid() override;
 
   protected:
     QWidget* createWidget( QWidget* parent ) override;
     void initWidget( QWidget* editor ) override;
 
+  protected slots:
+    void setExpression( QString exp ) override;
+
   private slots:
-    void comboBoxIndexChanged( int );
+    void comboBoxIndexChanged( int idx );
 
   private:
     QComboBox * mComboBox;

--- a/src/gui/editorwidgets/qgsvaluerelationsearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationsearchwidgetwrapper.cpp
@@ -97,8 +97,15 @@ bool QgsValueRelationSearchWidgetWrapper::valid()
 void QgsValueRelationSearchWidgetWrapper::valueChanged()
 {
   QVariant vl = value();
-  QSettings settings;
-  setExpression( vl.isNull() ? settings.value( "qgis/nullValue", "NULL" ).toString() : vl.toString() );
+  if ( !vl.isValid() )
+  {
+    clearExpression();
+  }
+  else
+  {
+    QSettings settings;
+    setExpression( vl.isNull() ? settings.value( "qgis/nullValue", "NULL" ).toString() : vl.toString() );
+  }
   emit expressionChanged( mExpression );
 }
 
@@ -149,7 +156,7 @@ void QgsValueRelationSearchWidgetWrapper::initWidget( QWidget* editor )
 
   if ( mComboBox )
   {
-    mComboBox->addItem( tr( "Please select" ), QVariant( layer()->fields().at( mFieldIdx ).type() ) );
+    mComboBox->addItem( tr( "Please select" ), QVariant() ); // creates an invalid to allow selecting all features
     if ( config( "AllowNull" ).toBool() )
     {
       mComboBox->addItem( tr( "(no selection)" ), QVariant( layer()->fields().at( mFieldIdx ).type() ) );

--- a/src/gui/editorwidgets/qgsvaluerelationsearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationsearchwidgetwrapper.cpp
@@ -86,6 +86,7 @@ QVariant QgsValueRelationSearchWidgetWrapper::value()
 void QgsValueRelationSearchWidgetWrapper::valueChanged()
 {
   setExpression( value().toString() );
+  emit expressionChanged( mExpression );
 }
 
 QWidget* QgsValueRelationSearchWidgetWrapper::createWidget( QWidget* parent )

--- a/src/gui/editorwidgets/qgsvaluerelationsearchwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsvaluerelationsearchwidgetwrapper.h
@@ -16,7 +16,7 @@
 #ifndef QGSVALUERELATIONSEARCHWIDGETWRAPPER_H
 #define QGSVALUERELATIONSEARCHWIDGETWRAPPER_H
 
-#include "qgsdefaultsearchwidgetwrapper.h"
+#include "qgssearchwidgetwrapper.h"
 #include "qgsvaluerelationwidgetwrapper.h"
 
 #include <QComboBox>
@@ -26,26 +26,12 @@
 class QgsValueRelationWidgetFactory;
 
 /**
- * Wraps a value relation widget. This widget will offer a combobox with values from another layer
+ * Wraps a value relation search  widget. This widget will offer a combobox with values from another layer
  * referenced by a foreign key (a constraint may be set but is not required on data level).
- * This is useful for having value lists on a separate layer containing codes and their
- * translation to human readable names.
- *
- * Options:
- *
- * <ul>
- * <li><b>Layer</b> <i>The id of the referenced layer.</i></li>
- * <li><b>Key</b> <i>The key field on the referenced layer (code).</i></li>
- * <li><b>Value</b> <i>The value field on the referenced layer (human readable name).</i></li>
- * <li><b>AllowMulti</b> <i>If set to True, will allow multiple selections. This requires the data type to be a string. This does NOT work with normalized database structures.</i></li>
- * <li><b>AllowNull</b> <i>Will offer NULL as a possible value.</i></li>
- * <li><b>FilterExpression</b> <i>If not empty, will be used as expression. Only if this evaluates to True, the value will be shown.</i></li>
- * <li><b>OrderByValue</b> <i>Will order by value instead of key.</i></li>
- * </ul>
- *
+ * It will be used as a search widget and produces expression to look for in the layer.
  */
 
-class GUI_EXPORT QgsValueRelationSearchWidgetWrapper : public QgsDefaultSearchWidgetWrapper
+class GUI_EXPORT QgsValueRelationSearchWidgetWrapper : public QgsSearchWidgetWrapper
 {
     Q_OBJECT
 
@@ -56,8 +42,9 @@ class GUI_EXPORT QgsValueRelationSearchWidgetWrapper : public QgsDefaultSearchWi
   public:
     explicit QgsValueRelationSearchWidgetWrapper( QgsVectorLayer* vl, int fieldIdx, QWidget* parent = 0 );
     bool applyDirectly() override;
-    QVariant value();
-
+    QString expression() override;
+    bool valid() override;
+    QVariant value() const;
 
   protected:
     QWidget* createWidget( QWidget* parent ) override;
@@ -65,6 +52,9 @@ class GUI_EXPORT QgsValueRelationSearchWidgetWrapper : public QgsDefaultSearchWi
 
   public slots:
     void valueChanged();
+
+  protected slots:
+    void setExpression( QString exp ) override;
 
   private:
     QComboBox* mComboBox;


### PR DESCRIPTION
currently, changing the entr doesn't do anything in the attribute table since no signal is emitted

The hierarchy of the classes is not really clear to me.
Why do we need to inherit from QgsDefaultSearchWidget and not directly QgsSearchWidget. If QgsValueRelation inherit from QgsDefaultSearchWidget, why not mergin QgsDefaultSearchW and QgsSearchW ?

I would have use the slot `filterChanged()` but it's private.
So I used `emit expressionChanged`

@m-kuhn ok for you like this?

should be backported to 2.12
