### PR TITLE
Fix attribute sync to layer for python init code and make QgsAttributeDialog reachable form python

### DIFF
--- a/src/app/qgsfieldsproperties.cpp
+++ b/src/app/qgsfieldsproperties.cpp
@@ -115,34 +115,6 @@ QgsFieldsProperties::QgsFieldsProperties( QgsVectorLayer *layer, QWidget* parent
   mRelationsList->setHorizontalHeaderItem( RelFieldCol, new QTableWidgetItem( tr( "Field" ) ) );
   mRelationsList->verticalHeader()->hide();
 
-  // Python init function and code
-  leEditForm->setText( layer->editForm() );
-  leEditFormInit->setText( layer->editFormInit() );
-  leEditFormInitUseCode->setChecked( layer->editFormInitUseCode() );
-  QString code( layer->editFormInitCode() );
-  if ( code.isEmpty( ) )
-  {
-    code.append( tr( "# -*- coding: utf-8 -*-\n\"\"\"\n"
-                     "QGIS forms can have a Python function that is called when the form is\n"
-                     "opened.\n"
-                     "\n"
-                     "Use this function to add extra logic to your forms.\n"
-                     "\n"
-                     "Enter the name of the function in the \"Python Init function\"\n"
-                     "field.\n"
-                     "An example follows:\n"
-                     "\"\"\"\n"
-                     "from PyQt4.QtGui import QWidget\n\n"
-                     "def my_form_open(dialog, layer, feature):\n"
-                     "\tgeom = feature.geometry()\n"
-                     "\tcontrol = dialog.findChild(QWidget, \"MyLineEdit\")\n" ) );
-
-  }
-  leEditFormInitCode->setText( code );
-  // Show or hide as needed
-  mPythonInitCodeGroupBox->setVisible( layer->editFormInitUseCode() );
-  connect( leEditFormInitUseCode, SIGNAL( toggled( bool ) ), this, SLOT( on_leEditFormInitUseCodeToggled( bool ) ) );
-
   loadRelations();
 
   updateButtons();
@@ -213,10 +185,33 @@ QTreeWidgetItem *QgsFieldsProperties::loadAttributeEditorTreeItem( QgsAttributeE
 
 void QgsFieldsProperties::setEditFormInit( const QString &editForm, const QString &editFormInit, const QString &editFormInitCode, const bool editFormInitUseCode )
 {
+
+  // Python init function and code
+  QString code( editFormInitCode );
+  if ( code.isEmpty( ) )
+  {
+    code.append( tr( "# -*- coding: utf-8 -*-\n\"\"\"\n"
+                     "QGIS forms can have a Python function that is called when the form is\n"
+                     "opened.\n"
+                     "\n"
+                     "Use this function to add extra logic to your forms.\n"
+                     "\n"
+                     "Enter the name of the function in the \"Python Init function\"\n"
+                     "field.\n"
+                     "An example follows:\n"
+                     "\"\"\"\n"
+                     "from PyQt4.QtGui import QWidget\n\n"
+                     "def my_form_open(dialog, layer, feature):\n"
+                     "\tgeom = feature.geometry()\n"
+                     "\tcontrol = dialog.findChild(QWidget, \"MyLineEdit\")\n" ) );
+
+  }
   leEditForm->setText( editForm );
+  leEditFormInitCode->setText( code );
   leEditFormInit->setText( editFormInit );
-  leEditFormInitCode->setText( editFormInitCode );
   leEditFormInitUseCode->setChecked( editFormInitUseCode );
+  // Show or hide as needed
+  mPythonInitCodeGroupBox->setVisible( editFormInitUseCode );
 }
 
 
@@ -458,7 +453,7 @@ void QgsFieldsProperties::on_mMoveUpItem_clicked()
   }
 }
 
-void QgsFieldsProperties::on_leEditFormInitUseCodeToggled( bool checked )
+void QgsFieldsProperties::on_leEditFormInitUseCode_toggled( bool checked )
 {
   mPythonInitCodeGroupBox->setVisible( checked );
 }

--- a/src/app/qgsfieldsproperties.h
+++ b/src/app/qgsfieldsproperties.h
@@ -179,7 +179,7 @@ class APP_EXPORT QgsFieldsProperties : public QWidget, private Ui_QgsFieldsPrope
     void onAttributeSelectionChanged();
     void on_pbnSelectEditForm_clicked();
     void on_mEditorLayoutComboBox_currentIndexChanged( int index );
-    void on_leEditFormInitUseCodeToggled( bool checked );
+    void on_leEditFormInitUseCode_toggled( bool checked );
     void attributeAdded( int idx );
     void attributeDeleted( int idx );
     void attributeTypeDialog();

--- a/src/gui/qgsattributedialog.cpp
+++ b/src/gui/qgsattributedialog.cpp
@@ -33,7 +33,7 @@ QgsAttributeDialog::QgsAttributeDialog( QgsVectorLayer* vl, QgsFeature* thepFeat
   QgsAttributeEditorContext context;
   context.setDistanceArea( myDa );
 
-  init( vl, thepFeature, context, parent );
+  init( vl, thepFeature, context );
 
   if ( !showDialogButtons )
     mAttributeForm->hideButtonBox();
@@ -44,7 +44,7 @@ QgsAttributeDialog::QgsAttributeDialog( QgsVectorLayer* vl, QgsFeature* thepFeat
     , mHighlight( 0 )
     , mOwnedFeature( featureOwner ? thepFeature : 0 )
 {
-  init( vl, thepFeature, context, parent );
+  init( vl, thepFeature, context );
 
   if ( !showDialogButtons )
     mAttributeForm->hideButtonBox();
@@ -97,12 +97,12 @@ void QgsAttributeDialog::show( bool autoDelete )
   activateWindow();
 }
 
-void QgsAttributeDialog::init( QgsVectorLayer* layer, QgsFeature* feature, const QgsAttributeEditorContext &context, QWidget* parent )
+void QgsAttributeDialog::init( QgsVectorLayer* layer, QgsFeature* feature, const QgsAttributeEditorContext &context )
 {
   setWindowTitle( tr( "%1 - Feature Attributes" ).arg( layer->name() ) );
   setLayout( new QGridLayout() );
   layout()->setMargin( 0 );
-  mAttributeForm = new QgsAttributeForm( layer, *feature, context, parent );
+  mAttributeForm = new QgsAttributeForm( layer, *feature, context, this );
   mAttributeForm->disconnectButtonBox();
   layout()->addWidget( mAttributeForm );
   QDialogButtonBox* buttonBox = mAttributeForm->findChild<QDialogButtonBox*>();

--- a/src/gui/qgsattributedialog.h
+++ b/src/gui/qgsattributedialog.h
@@ -135,7 +135,7 @@ class GUI_EXPORT QgsAttributeDialog : public QDialog
     void show( bool autoDelete = true );
 
   private:
-    void init( QgsVectorLayer* layer, QgsFeature* feature, const QgsAttributeEditorContext& context, QWidget* parent );
+    void init( QgsVectorLayer* layer, QgsFeature* feature, const QgsAttributeEditorContext& context );
 
     QString mSettingsPath;
     // Used to sync multiple widgets for the same field


### PR DESCRIPTION
This PR fixes a bug in https://github.com/qgis/QGIS/pull/2420
and in a separate commit Fixes #11517 indirectly by allowing access to container QgsAttributeDialog
from attributes form via python code.
