### PR TITLE
Processing algorithm speedups

### DIFF
--- a/python/plugins/processing/algs/qgis/PointsInPolygon.py
+++ b/python/plugins/processing/algs/qgis/PointsInPolygon.py
@@ -76,26 +76,25 @@ class PointsInPolygon(GeoAlgorithm):
         geom = QgsGeometry()
 
         current = 0
-        hasIntersections = False
 
         features = vector.features(polyLayer)
         total = 100.0 / float(len(features))
         for ftPoly in features:
             geom = ftPoly.geometry()
+            engine = QgsGeometry.createGeometryEngine(geom.geometry())
+            engine.prepareGeometry()
+
             attrs = ftPoly.attributes()
 
             count = 0
-            hasIntersections = False
             points = spatialIndex.intersects(geom.boundingBox())
             if len(points) > 0:
-                hasIntersections = True
-
-            if hasIntersections:
-                for i in points:
-                    request = QgsFeatureRequest().setFilterFid(i)
-                    ftPoint = pointLayer.getFeatures(request).next()
-                    tmpGeom = QgsGeometry(ftPoint.geometry())
-                    if geom.contains(tmpGeom):
+                request = QgsFeatureRequest().setFilterFids(points)
+                fit = pointLayer.getFeatures(request)
+                ftPoint = QgsFeature()
+                while fit.nextFeature(ftPoint):
+                    tmpGeom = ftPoint.geometry()
+                    if engine.contains(tmpGeom.geometry()):
                         count += 1
 
             outFeat.setGeometry(geom)

--- a/python/plugins/processing/algs/qgis/PointsInPolygonUnique.py
+++ b/python/plugins/processing/algs/qgis/PointsInPolygonUnique.py
@@ -90,7 +90,7 @@ class PointsInPolygonUnique(GeoAlgorithm):
 
             attrs = ftPoly.attributes()
 
-            classes = []
+            classes = set()
             points = spatialIndex.intersects(geom.boundingBox())
             if len(points) > 0:
                 request = QgsFeatureRequest().setFilterFids(points)
@@ -101,7 +101,7 @@ class PointsInPolygonUnique(GeoAlgorithm):
                     if engine.contains(tmpGeom.geometry()):
                         clazz = ftPoint.attributes()[classFieldIndex]
                         if clazz not in classes:
-                            classes.append(clazz)
+                            classes.add(clazz)
 
             outFeat.setGeometry(geom)
             if idxCount == len(attrs):

--- a/python/plugins/processing/algs/qgis/PointsInPolygonUnique.py
+++ b/python/plugins/processing/algs/qgis/PointsInPolygonUnique.py
@@ -80,26 +80,25 @@ class PointsInPolygonUnique(GeoAlgorithm):
         geom = QgsGeometry()
 
         current = 0
-        hasIntersections = False
 
         features = vector.features(polyLayer)
         total = 100.0 / float(len(features))
         for ftPoly in features:
             geom = ftPoly.geometry()
+            engine = QgsGeometry.createGeometryEngine(geom.geometry())
+            engine.prepareGeometry()
+
             attrs = ftPoly.attributes()
 
             classes = []
-            hasIntersections = False
             points = spatialIndex.intersects(geom.boundingBox())
             if len(points) > 0:
-                hasIntersections = True
-
-            if hasIntersections:
-                for i in points:
-                    request = QgsFeatureRequest().setFilterFid(i)
-                    ftPoint = pointLayer.getFeatures(request).next()
+                request = QgsFeatureRequest().setFilterFids(points)
+                fit = pointLayer.getFeatures(request)
+                ftPoint = QgsFeature()
+                while fit.nextFeature(ftPoint):
                     tmpGeom = QgsGeometry(ftPoint.geometry())
-                    if geom.contains(tmpGeom):
+                    if engine.contains(tmpGeom.geometry()):
                         clazz = ftPoint.attributes()[classFieldIndex]
                         if clazz not in classes:
                             classes.append(clazz)


### PR DESCRIPTION
Here's a small set of speed up for some processing algorithms:

SelectByAttribute: switches to using an expression based filter request instead of fetching all features and testing against expression. For providers which compile expressions (currently only PostGIS) this results in a huge speedup, as it allows the provider to take advantage of any indices which exist on the attribute. Quick benchmark:
For a 4 million point PostGIS layer (with an index on attribute)
BEFORE: gave up and cancelled after 20 mins
AFTER: ~2 seconds to select

PointsInPolygon/PointsInPolygonUnique/PointsInPolygonWeighted:
Avoids using separate feature requests for every point (much faster). Also have switched to using prepared GEOS geometries for the contains test, which are much much faster. Quick benchmarks:

~1500 point layer
BEFORE: 17 seconds
AFTER: 3 seconds

~900k point layer
BEFORE: 30 mins = gave up and canceled at 20%
AFTER: 2.5 mins = 100% complete
