### PR TITLE
Be able to refresh the attribute table

### DIFF
--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -212,6 +212,7 @@ QgsAttributeTableDialog::QgsAttributeTableDialog( QgsVectorLayer *theLayer, QWid
   mToggleEditingButton->blockSignals( false );
 
   mSaveEditsButton->setEnabled( mToggleEditingButton->isEnabled() && mLayer->isEditable() );
+  mReloadButton->setEnabled( ! mLayer->isEditable() );
   mAddAttribute->setEnabled(( canChangeAttributes || canAddAttributes ) && mLayer->isEditable() );
   mDeleteSelectedButton->setEnabled( canDeleteFeatures && mLayer->isEditable() );
   mAddFeature->setEnabled( canAddFeatures && mLayer->isEditable() );
@@ -579,6 +580,11 @@ void QgsAttributeTableDialog::on_mSaveEditsButton_clicked()
   QgisApp::instance()->saveEdits( mLayer, true, true );
 }
 
+void QgsAttributeTableDialog::on_mReloadButton_clicked()
+{
+  mMainView->masterModel()->layer()->dataProvider()->forceReload();
+}
+
 void QgsAttributeTableDialog::on_mAddFeature_clicked()
 {
   if ( !mLayer->isEditable() )
@@ -658,6 +664,7 @@ void QgsAttributeTableDialog::editingToggled()
   mToggleEditingButton->blockSignals( true );
   mToggleEditingButton->setChecked( mLayer->isEditable() );
   mSaveEditsButton->setEnabled( mLayer->isEditable() );
+  mReloadButton->setEnabled( ! mLayer->isEditable() );
   mToggleEditingButton->blockSignals( false );
 
   bool canChangeAttributes = mLayer->dataProvider()->capabilities() & QgsVectorDataProvider::ChangeAttributeValues;

--- a/src/app/qgsattributetabledialog.h
+++ b/src/app/qgsattributetabledialog.h
@@ -86,6 +86,10 @@ class APP_EXPORT QgsAttributeTableDialog : public QDialog, private Ui::QgsAttrib
      * Saves edits
      */
     void on_mSaveEditsButton_clicked();
+    /**
+     * Reload the data
+     */
+    void on_mReloadButton_clicked();
 
     /**
      * Inverts selection

--- a/src/core/qgsvectordataprovider.h
+++ b/src/core/qgsvectordataprovider.h
@@ -378,7 +378,9 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider
      * This forces QGIS to reopen a file or connection.
      * This can be required if the underlying file is replaced.
      */
-    virtual void forceReload() {}
+    virtual void forceReload() {
+      emit dataChanged();
+    }
 
   protected:
     void clearMinMaxCache();

--- a/src/ui/qgsattributetabledialog.ui
+++ b/src/ui/qgsattributetabledialog.ui
@@ -99,6 +99,32 @@
       </widget>
      </item>
      <item>
+      <widget class="QToolButton" name="mReloadButton">
+       <property name="toolTip">
+        <string>Reload the table</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../../images/images.qrc">
+         <normaloff>:/images/themes/default/mActionRefresh.png</normaloff>:/images/themes/default/mActionRefresh.png</iconset>
+       </property>
+       <property name="iconSize">
+        <size>
+         <width>18</width>
+         <height>18</height>
+        </size>
+       </property>
+       <property name="checkable">
+        <bool>false</bool>
+       </property>
+       <property name="autoRaise">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="Line" name="line">
        <property name="orientation">
         <enum>Qt::Vertical</enum>
@@ -827,6 +853,22 @@
     <hint type="destinationlabel">
      <x>393</x>
      <y>266</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>mToggleEditingButton</sender>
+   <signal>toggled(bool)</signal>
+   <receiver>mReloadButton</receiver>
+   <slot>setDisabled(bool)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>14</x>
+     <y>15</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>74</x>
+     <y>15</y>
     </hint>
    </hints>
   </connection>


### PR DESCRIPTION
Add a button in the attribute table to refresh the data if there was a modification in the background.

These features were funded by: MEDDE (French Ministry of Sustainable Development)
