### PR TITLE
[postgresprovider] Determine geometry type and srid directly from column type

### DIFF
--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -124,6 +124,12 @@ int QgsPostgresResult::PQftype( int col )
   return ::PQftype( mRes, col );
 }
 
+int QgsPostgresResult::PQfmod( int col )
+{
+  Q_ASSERT( mRes );
+  return ::PQfmod( mRes, col );
+}
+
 Oid QgsPostgresResult::PQoidValue()
 {
   Q_ASSERT( mRes );

--- a/src/providers/postgres/qgspostgresconn.h
+++ b/src/providers/postgres/qgspostgresconn.h
@@ -167,6 +167,7 @@ class QgsPostgresResult
     QString PQfname( int col );
     int PQftable( int col );
     int PQftype( int col );
+    int PQfmod( int col );
     int PQftablecol( int col );
     Oid PQoidValue();
 

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -2915,7 +2915,7 @@ bool QgsPostgresProvider::getGeometryDetails()
     if ( PGRES_TUPLES_OK == result.PQresultStatus() )
     {
       sql = QString( "SELECT (SELECT t.typname FROM pg_type t WHERE oid = %1), upper(postgis_typmod_type(%2)), postgis_typmod_srid(%2)" )
-          .arg(QString::number( result.PQftype( 0 ) ), QString::number( result.PQfmod( 0 ) ) );
+            .arg( QString::number( result.PQftype( 0 ) ), QString::number( result.PQfmod( 0 ) ) );
       result = connectionRO()->PQexec( sql );
       if ( result.PQntuples() == 1 )
       {
@@ -2930,7 +2930,8 @@ bool QgsPostgresProvider::getGeometryDetails()
           mSpatialColType = sctTopoGeometry;
         else if ( geomColType == "pcpatch" )
           mSpatialColType = sctPcPatch;
-        else {
+        else
+        {
           detectedType = mRequestedGeomType == QGis::WKBUnknown ? "" : QgsPostgresConn::postgisWkbTypeName( mRequestedGeomType );
           detectedSrid = mRequestedSrid;
         }

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -59,6 +59,14 @@ class TestPyQgsPostgresProvider(TestCase, ProviderTestCase):
         assert self.provider.defaultValue(1) == NULL
         assert self.provider.defaultValue(2) == '\'qgis\'::text'
 
+    def testQueryLayers(self):
+        def test_query(dbconn, query, key):
+            ql = QgsVectorLayer('%s srid=4326 table="%s" (geom) key=\'%s\' sql=' % (dbconn, query.replace('"', '\\"'), key), "testgeom", "postgres")
+            print query, key
+            assert(ql.isValid())
+
+        test_query(self.dbconn, '(SELECT NULL::integer "Id1", NULL::integer "Id2", NULL::geometry(Point, 4326) geom LIMIT 0)', '"Id1","Id2"')
+
     def testWkbTypes(self):
         def test_table(dbconn, table_name, wkt):
             vl = QgsVectorLayer('%s srid=4326 table="qgis_test".%s (geom) sql=' % (dbconn, table_name), "testgeom", "postgres")


### PR DESCRIPTION
This PR adds a new way of determining the geometry type and srid for a layer by examining the actual type of the column returned from PostGIS.

Now even empty query layers without a requested geometry type/srid can be added as long as the geometry column is explicitly typed.
So this is a valid layer to add:

``` sql
SELECT
  t.id,
  ST_MakeLine(t.geom)::geometry(Linestring, 4326) AS geom_aggregate
FROM table AS t
WHERE
  t.id = some_non_existing_id
```

This PR uses the new method only as a last resort if everything else fails. But eventually it could be used as the default, replacing the lookups in _geometry_columns_ or _geography_columns_ because for every column mentioned there it would give the same result.
