### PR TITLE
Restore original subsetString() when QgsVectorLayerProperties dialog is canceled (fix #13620)

### DIFF
--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -532,7 +532,7 @@ void QgsVectorLayerProperties::apply()
     layer->setSubsetString( txtSubsetSQL->toPlainText() );
     mMetadataFilled = false;
   }
-  mOriginalSubsetSQL = txtSubsetSQL->toPlainText();
+  mOriginalSubsetSQL = layer->subsetString();
 
   // set up the scale based layer visibility stuff....
   layer->setScaleBasedVisibility( mScaleVisibilityGroupBox->isChecked() );

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -76,6 +76,7 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
     : QgsOptionsDialogBase( "VectorLayerProperties", parent, fl )
     , layer( lyr )
     , mMetadataFilled( false )
+    , mOriginalSubsetSQL( lyr->subsetString() )
     , mSaveAsMenu( 0 )
     , mLoadStyleMenu( 0 )
     , mRendererDialog( 0 )
@@ -531,6 +532,7 @@ void QgsVectorLayerProperties::apply()
     layer->setSubsetString( txtSubsetSQL->toPlainText() );
     mMetadataFilled = false;
   }
+  mOriginalSubsetSQL = txtSubsetSQL->toPlainText();
 
   // set up the scale based layer visibility stuff....
   layer->setScaleBasedVisibility( mScaleVisibilityGroupBox->isChecked() );
@@ -643,6 +645,14 @@ void QgsVectorLayerProperties::onCancel()
 
     Q_FOREACH ( const QgsVectorJoinInfo& info, mOldJoins )
       layer->addJoin( info );
+  }
+
+  if ( mOriginalSubsetSQL != layer->subsetString() )
+  {
+    // need to undo changes in subset string - they are applied directly to the layer (not in apply())
+    // by QgsQueryBuilder::accept()
+
+    layer->setSubsetString( mOriginalSubsetSQL );
   }
 }
 

--- a/src/app/qgsvectorlayerproperties.h
+++ b/src/app/qgsvectorlayerproperties.h
@@ -163,6 +163,8 @@ class APP_EXPORT QgsVectorLayerProperties : public QgsOptionsDialogBase, private
 
     bool mMetadataFilled;
 
+    QString mOriginalSubsetSQL;
+
     QMenu *mSaveAsMenu;
     QMenu *mLoadStyleMenu;
 


### PR DESCRIPTION
This PR saves the original `subsetString()` of the layer and restores it when the user cancels the properties dialog. This is necessary because [QgsQueryBuilder::accept()](https://github.com/qgis/QGIS/blob/dc0639c7944320ceeca40413d5dc2147f5c2d328/src/gui/qgsquerybuilder.cpp#L231) stores the new subset string directly in the layer thereby making it persistent even if the user cancels the QgsVectorLayerProperties dialog.
