### PR TITLE
Processing enhancements and fixes

### DIFF
--- a/python/plugins/processing/algs/qgis/QGISAlgorithmProvider.py
+++ b/python/plugins/processing/algs/qgis/QGISAlgorithmProvider.py
@@ -131,6 +131,7 @@ from FieldsMapper import FieldsMapper
 from Datasources2Vrt import Datasources2Vrt
 from CheckValidity import CheckValidity
 from OrientedMinimumBoundingBox import OrientedMinimumBoundingBox
+from Smooth import Smooth
 
 pluginPath = os.path.normpath(os.path.join(
     os.path.split(os.path.dirname(__file__))[0], os.pardir))
@@ -179,7 +180,7 @@ class QGISAlgorithmProvider(AlgorithmProvider):
                         SelectByExpression(), HypsometricCurves(),
                         SplitLinesWithLines(), CreateConstantRaster(),
                         FieldsMapper(), SelectByAttributeSum(), Datasources2Vrt(),
-                        CheckValidity(), OrientedMinimumBoundingBox()
+                        CheckValidity(), OrientedMinimumBoundingBox(), Smooth()
                         ]
 
         if hasMatplotlib:

--- a/python/plugins/processing/algs/qgis/QGISAlgorithmProvider.py
+++ b/python/plugins/processing/algs/qgis/QGISAlgorithmProvider.py
@@ -132,6 +132,7 @@ from Datasources2Vrt import Datasources2Vrt
 from CheckValidity import CheckValidity
 from OrientedMinimumBoundingBox import OrientedMinimumBoundingBox
 from Smooth import Smooth
+from ReverseLineDirection import ReverseLineDirection
 
 pluginPath = os.path.normpath(os.path.join(
     os.path.split(os.path.dirname(__file__))[0], os.pardir))
@@ -180,7 +181,8 @@ class QGISAlgorithmProvider(AlgorithmProvider):
                         SelectByExpression(), HypsometricCurves(),
                         SplitLinesWithLines(), CreateConstantRaster(),
                         FieldsMapper(), SelectByAttributeSum(), Datasources2Vrt(),
-                        CheckValidity(), OrientedMinimumBoundingBox(), Smooth()
+                        CheckValidity(), OrientedMinimumBoundingBox(), Smooth(),
+                        ReverseLineDirection()
                         ]
 
         if hasMatplotlib:

--- a/python/plugins/processing/algs/qgis/ReverseLineDirection.py
+++ b/python/plugins/processing/algs/qgis/ReverseLineDirection.py
@@ -1,0 +1,84 @@
+# -*- coding: utf-8 -*-
+
+"""
+***************************************************************************
+    ReverseLineDirection.py
+    -----------------------
+    Date                 : November 2015
+    Copyright            : (C) 2015 by Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************
+"""
+
+__author__ = 'Nyall Dawson'
+__date__ = 'November 2015'
+__copyright__ = '(C) 2015, Nyall Dawson'
+
+# This will get replaced with a git SHA1 when you do a git archive323
+
+__revision__ = '$Format:%H$'
+
+from qgis.core import QGis, QgsGeometry, QgsFeature
+from processing.core.GeoAlgorithm import GeoAlgorithm
+from processing.core.GeoAlgorithmExecutionException import GeoAlgorithmExecutionException
+from processing.core.parameters import ParameterVector, ParameterNumber
+from processing.core.outputs import OutputVector
+from processing.tools import dataobjects, vector
+
+
+class ReverseLineDirection(GeoAlgorithm):
+
+    INPUT_LAYER = 'INPUT_LAYER'
+    OUTPUT_LAYER = 'OUTPUT_LAYER'
+
+    def defineCharacteristics(self):
+        self.name, self.i18n_name = self.trAlgorithm('Reverse line direction')
+        self.group, self.i18n_group = self.trAlgorithm('Vector geometry tools')
+
+        self.addParameter(ParameterVector(self.INPUT_LAYER,
+                                          self.tr('Input layer'), [ParameterVector.VECTOR_TYPE_LINE]))
+        self.addOutput(OutputVector(self.OUTPUT_LAYER, self.tr('Reversed')))
+
+    def processAlgorithm(self, progress):
+        layer = dataobjects.getObjectFromUri(
+            self.getParameterValue(self.INPUT_LAYER))
+        provider = layer.dataProvider()
+
+        writer = self.getOutputFromName(
+            self.OUTPUT_LAYER).getVectorWriter(
+                layer.fields().toList(),
+                provider.geometryType(),
+                layer.crs())
+
+        outFeat = QgsFeature()
+
+        features = vector.features(layer)
+        total = 100.0 / float(len(features))
+        current = 0
+
+        for inFeat in features:
+            inGeom = inFeat.constGeometry()
+            attrs = inFeat.attributes()
+
+            outGeom = None
+            if inGeom and not inGeom.isEmpty():
+                reversedLine = inGeom.geometry().reversed()
+                if reversedLine is None:
+                    raise GeoAlgorithmExecutionException(
+                        self.tr('Error reversing line'))
+                outGeom = QgsGeometry(reversedLine)
+
+            outFeat.setGeometry(outGeom)
+            outFeat.setAttributes(attrs)
+            writer.addFeature(outFeat)
+            current += 1
+            progress.setPercentage(int(current * total))
+
+        del writer

--- a/python/plugins/processing/algs/qgis/Smooth.py
+++ b/python/plugins/processing/algs/qgis/Smooth.py
@@ -1,0 +1,89 @@
+# -*- coding: utf-8 -*-
+
+"""
+***************************************************************************
+    Smooth.py
+    ---------
+    Date                 : November 2015
+    Copyright            : (C) 2015 by Nyall Dawson
+    Email                : nyall dot dawson at gmail dot com
+***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************
+"""
+
+__author__ = 'Nyall Dawson'
+__date__ = 'November 2015'
+__copyright__ = '(C) 2015, Nyall Dawson'
+
+# This will get replaced with a git SHA1 when you do a git archive323
+
+__revision__ = '$Format:%H$'
+
+from qgis.core import QGis, QgsGeometry, QgsFeature
+from processing.core.GeoAlgorithm import GeoAlgorithm
+from processing.core.GeoAlgorithmExecutionException import GeoAlgorithmExecutionException
+from processing.core.parameters import ParameterVector, ParameterNumber
+from processing.core.outputs import OutputVector
+from processing.tools import dataobjects, vector
+
+
+class Smooth(GeoAlgorithm):
+
+    INPUT_LAYER = 'INPUT_LAYER'
+    OUTPUT_LAYER = 'OUTPUT_LAYER'
+    ITERATIONS = 'ITERATIONS'
+    OFFSET = 'OFFSET'
+
+    def defineCharacteristics(self):
+        self.name, self.i18n_name = self.trAlgorithm('Smooth geometry')
+        self.group, self.i18n_group = self.trAlgorithm('Vector geometry tools')
+
+        self.addParameter(ParameterVector(self.INPUT_LAYER,
+                                          self.tr('Input layer'), [ParameterVector.VECTOR_TYPE_POLYGON, ParameterVector.VECTOR_TYPE_LINE]))
+        self.addParameter(ParameterNumber(self.ITERATIONS,
+                                          self.tr('Iterations'), default=1, minValue=1, maxValue=10))
+        self.addParameter(ParameterNumber(self.OFFSET,
+                                          self.tr('Offset'), default=0.25, minValue=0.0, maxValue=0.5))
+        self.addOutput(OutputVector(self.OUTPUT_LAYER, self.tr('Smoothed')))
+
+    def processAlgorithm(self, progress):
+        layer = dataobjects.getObjectFromUri(
+            self.getParameterValue(self.INPUT_LAYER))
+        provider = layer.dataProvider()
+        iterations = self.getParameterValue(self.ITERATIONS)
+        offset = self.getParameterValue(self.OFFSET)
+
+        writer = self.getOutputFromName(
+            self.OUTPUT_LAYER).getVectorWriter(
+                layer.fields().toList(),
+                provider.geometryType(),
+                layer.crs())
+
+        outFeat = QgsFeature()
+
+        features = vector.features(layer)
+        total = 100.0 / float(len(features))
+        current = 0
+
+        for inFeat in features:
+            inGeom = inFeat.constGeometry()
+            attrs = inFeat.attributes()
+
+            outGeom = inGeom.smooth(iterations, offset)
+            if outGeom is None:
+                raise GeoAlgorithmExecutionException(
+                    self.tr('Error smoothing geometry'))
+
+            outFeat.setGeometry(outGeom)
+            outFeat.setAttributes(attrs)
+            writer.addFeature(outFeat)
+            current += 1
+            progress.setPercentage(int(current * total))
+
+        del writer

--- a/python/plugins/processing/gui/ConfigDialog.py
+++ b/python/plugins/processing/gui/ConfigDialog.py
@@ -32,8 +32,9 @@ from PyQt4 import uic
 from PyQt4.QtCore import Qt, QEvent, QPyNullVariant
 from PyQt4.QtGui import (QFileDialog, QDialog, QIcon, QStyle,
                          QStandardItemModel, QStandardItem, QMessageBox, QStyledItemDelegate,
-                         QLineEdit, QSpinBox, QDoubleSpinBox, QWidget, QToolButton, QHBoxLayout,
+                         QLineEdit, QWidget, QToolButton, QHBoxLayout,
                          QComboBox)
+from qgis.gui import QgsDoubleSpinBox, QgsSpinBox
 
 from processing.core.ProcessingConfig import ProcessingConfig, Setting
 from processing.core.Processing import Processing
@@ -198,11 +199,11 @@ class SettingDelegate(QStyledItemDelegate):
         else:
             value = self.convertValue(index.model().data(index, Qt.EditRole))
             if isinstance(value, (int, long)):
-                spnBox = QSpinBox(parent)
+                spnBox = QgsSpinBox(parent)
                 spnBox.setRange(-999999999, 999999999)
                 return spnBox
             elif isinstance(value, float):
-                spnBox = QDoubleSpinBox(parent)
+                spnBox = QgsDoubleSpinBox(parent)
                 spnBox.setRange(-999999999.999999, 999999999.999999)
                 spnBox.setDecimals(6)
                 return spnBox

--- a/python/plugins/processing/gui/NumberInputPanel.py
+++ b/python/plugins/processing/gui/NumberInputPanel.py
@@ -29,6 +29,7 @@ import os
 
 from PyQt4 import uic
 
+from math import log10, floor
 from processing.gui.NumberInputDialog import NumberInputDialog
 
 pluginPath = os.path.split(os.path.dirname(__file__))[0]
@@ -45,6 +46,11 @@ class NumberInputPanel(BASE, WIDGET):
         self.isInteger = isInteger
         if self.isInteger:
             self.spnValue.setDecimals(0)
+        else:
+            #Guess reasonable step value
+            if (maximum == 0 or maximum) and (minimum == 0 or minimum):
+                self.spnValue.setSingleStep(self.calculateStep(minimum, maximum))
+
         if maximum == 0 or maximum:
             self.spnValue.setMaximum(maximum)
         else:
@@ -66,3 +72,12 @@ class NumberInputPanel(BASE, WIDGET):
 
     def getValue(self):
         return self.spnValue.value()
+
+    def calculateStep(self, minimum, maximum):
+        valueRange = maximum - minimum
+        if valueRange <= 1.0:
+            step = valueRange / 10.0
+            # round to 1 significant figure
+            return round(step, -int(floor(log10(step))))
+        else:
+            return 1.0

--- a/python/plugins/processing/gui/NumberInputPanel.py
+++ b/python/plugins/processing/gui/NumberInputPanel.py
@@ -45,14 +45,14 @@ class NumberInputPanel(BASE, WIDGET):
         self.isInteger = isInteger
         if self.isInteger:
             self.spnValue.setDecimals(0)
-            if maximum == 0 or maximum:
-                self.spnValue.setMaximum(maximum)
-            else:
-                self.spnValue.setMaximum(99999999)
-            if minimum == 0 or minimum:
-                self.spnValue.setMinimum(minimum)
-            else:
-                self.spnValue.setMinimum(-99999999)
+        if maximum == 0 or maximum:
+            self.spnValue.setMaximum(maximum)
+        else:
+            self.spnValue.setMaximum(99999999)
+        if minimum == 0 or minimum:
+            self.spnValue.setMinimum(minimum)
+        else:
+            self.spnValue.setMinimum(-99999999)
 
         self.spnValue.setValue(float(number))
 

--- a/python/plugins/processing/gui/NumberInputPanel.py
+++ b/python/plugins/processing/gui/NumberInputPanel.py
@@ -61,6 +61,7 @@ class NumberInputPanel(BASE, WIDGET):
             self.spnValue.setMinimum(-99999999)
 
         self.spnValue.setValue(float(number))
+        self.spnValue.setClearValue(float(number))
 
         self.btnCalc.clicked.connect(self.showNumberInputDialog)
 

--- a/python/plugins/processing/ui/widgetNumberSelector.ui
+++ b/python/plugins/processing/ui/widgetNumberSelector.ui
@@ -21,7 +21,7 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QDoubleSpinBox" name="spnValue">
+    <widget class="QgsDoubleSpinBox" name="spnValue">
      <property name="decimals">
       <number>6</number>
      </property>
@@ -45,6 +45,14 @@
    </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsDoubleSpinBox</class>
+   <extends>QDoubleSpinBox</extends>
+   <header>qgis.gui</header>
+   <container>1</container>
+  </customwidget> 
+ </customwidgets>
  <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
A few assorted processing enhancements:

Fix maximum/minimum not respected for float spinboxes- seems that the max/min were only being set for the spinbox for integer parameters. This commit makes the GUI for float parameters also respect the specified min/max value.

Guess sensible step sizes for float spin boxes: For float parameters with max values <= 1.0, the default spin box step size of 1 doesn't make any sense. This commit sets a sensible step size if the max value <= 1.0. It's done by dividing the valid range into 10 steps, and then making sure the step size only has a single significant digit.

Use QgsDoubleSpinBox instead of QSpinBox: QgsDoubleSpinBox has a number of improvements over the stock Qt spin box, including the ability to enter simple expressions (eg 10/3) into the box and have them instantly calculated. It also adds a reset control to the spin box for resetting the value to the parameter default.

Finally, two new algorithms have been added, for Smooth and Reversing Line Directions.
