### PR TITLE
Refactor edit form configuration out of QgsVectorLayer

### DIFF
--- a/python/core/core.sip
+++ b/python/core/core.sip
@@ -40,6 +40,7 @@
 %Include qgsdatumtransformstore.sip
 %Include qgsdbfilterproxymodel.sip
 %Include qgsdistancearea.sip
+%Include qgseditformconfig.sip
 %Include qgseditorwidgetconfig.sip
 %Include qgserror.sip
 %Include qgsexpression.sip

--- a/python/core/qgseditformconfig.sip
+++ b/python/core/qgseditformconfig.sip
@@ -190,9 +190,9 @@ class QgsEditFormConfig : QObject
     QgsEditorWidgetConfig widgetConfig( const QString& fieldName ) const;
 
     /**
-     * If this returns false, the widget at the given index will always be read-only.
+     * If this returns true, the field is manually set to read only.
      */
-    bool fieldEditable( int idx );
+    bool readOnly( int idx );
 
     /**
      * If set to false, the widget at the given index will be read-only, regardless of the
@@ -200,7 +200,7 @@ class QgsEditFormConfig : QObject
      * If it is set to true, the widget's editable state will be synchronized with the layer's
      * edit state.
      */
-    void setFieldEditable( int idx, bool editable );
+    void setReadOnly(int idx, bool readOnly );
 
     /**
      * If this returns true, the widget at the given index will receive its label on the previous line

--- a/python/core/qgseditformconfig.sip
+++ b/python/core/qgseditformconfig.sip
@@ -1,0 +1,253 @@
+/***************************************************************************
+                          qgseditformconfig.sip
+                             -------------------
+    begin                : Nov 18, 2015
+    copyright            : (C) 2015 by Matthias Kuhn
+    email                : matthias at opengis dot ch
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+class QgsEditFormConfig : QObject
+{
+%TypeHeaderCode
+#include <qgseditformconfig.h>
+%End
+
+  public:
+    /** The different types to layout the attribute editor. */
+    enum EditorLayout
+    {
+      GeneratedLayout = 0, //!< Autogenerate a simple tabular layout for the form
+      TabLayout = 1,       //!< Use a layout with tabs and group boxes. Needs to be configured.
+      UiFileLayout = 2     //!< Load a .ui file for the layout. Needs to be configured.
+    };
+
+    struct GroupData
+    {
+      GroupData();
+      GroupData( const QString& name, const QList<QString>& fields );
+      QString mName;
+      QList<QString> mFields;
+    };
+
+    struct TabData
+    {
+      TabData();
+      TabData( const QString& name, const QList<QString>& fields, const QList<QgsEditFormConfig::GroupData>& groups );
+      QString mName;
+      QList<QString> mFields;
+      QList<QgsEditFormConfig::GroupData> mGroups;
+    };
+
+    /**
+     * Types of feature form suppression after feature creation
+     */
+    enum FeatureFormSuppress
+    {
+      SuppressDefault = 0, //!< Use the application-wide setting
+      SuppressOn = 1,      //!< Suppress feature form
+      SuppressOff = 2      //!< Do not suppress feature form
+    };
+
+    explicit QgsEditFormConfig( QObject* parent = nullptr );
+
+    /**
+     * This is only useful in combination with EditorLayout::TabLayout.
+     *
+     * Adds a new tab to the layout. Should be a QgsAttributeEditorContainer.
+     */
+    void addTab( QgsAttributeEditorElement* data );
+
+    /**
+     * Returns a list of tabs for EditorLayout::TabLayout.
+     */
+    QList< QgsAttributeEditorElement* > tabs();
+
+    /**
+     * Clears all the tabs for the attribute editor form with EditorLayout::TabLayout.
+     */
+    void clearTabs();
+
+    /** Get the active layout style for the attribute editor for this layer */
+    EditorLayout layout();
+
+    /** Set the active layout style for the attribute editor for this layer */
+    void setLayout( EditorLayout editorLayout );
+
+    /** Get path to the .ui form. Only meaningful with EditorLayout::UiFileLayout. */
+    QString uiForm() const;
+
+    /**
+     * Set path to the .ui form.
+     * When a string is provided, the layout style will be set to EditorLayout::UiFileLayout,
+     * if an empty or a null string is provided, the layout style will be set to
+     * EditorLayout::GeneratedLayout.
+     */
+    void setUiForm( const QString& ui );
+
+
+
+
+
+
+
+
+    // Widget stuff
+
+    /**
+     * Set the editor widget type for a field
+     *
+     * QGIS ships the following widget types, additional types may be available depending
+     * on plugins.
+     *
+     * <ul>
+     * <li>CheckBox (QgsCheckboxWidgetWrapper)</li>
+     * <li>Classification (QgsClassificationWidgetWrapper)</li>
+     * <li>Color (QgsColorWidgetWrapper)</li>
+     * <li>DateTime (QgsDateTimeEditWrapper)</li>
+     * <li>Enumeration (QgsEnumerationWidgetWrapper)</li>
+     * <li>FileName (QgsFileNameWidgetWrapper)</li>
+     * <li>Hidden (QgsHiddenWidgetWrapper)</li>
+     * <li>Photo (QgsPhotoWidgetWrapper)</li>
+     * <li>Range (QgsRangeWidgetWrapper)</li>
+     * <li>RelationReference (QgsRelationReferenceWidgetWrapper)</li>
+     * <li>TextEdit (QgsTextEditWrapper)</li>
+     * <li>UniqueValues (QgsUniqueValuesWidgetWrapper)</li>
+     * <li>UuidGenerator (QgsUuidWidgetWrapper)</li>
+     * <li>ValueMap (QgsValueMapWidgetWrapper)</li>
+     * <li>ValueRelation (QgsValueRelationWidgetWrapper)</li>
+     * <li>WebView (QgsWebViewWidgetWrapper)</li>
+     * </ul>
+     *
+     * @param attrIdx     Index of the field
+     * @param widgetType  Type id of the editor widget to use
+     */
+    void setWidgetType( int fieldIdx, const QString& widgetType );
+
+    /**
+     * Get the id for the editor widget used to represent the field at the given index
+     *
+     * @param fieldIdx  The index of the field
+     *
+     * @return The id for the editor widget or a NULL string if not applicable
+     */
+    QString widgetType( int fieldIdx ) const;
+
+    /**
+     * Get the id for the editor widget used to represent the field at the given index
+     *
+     * @param fieldName  The name of the field
+     *
+     * @return The id for the editor widget or a NULL string if not applicable
+     *
+     * @note python method name editorWidgetV2ByName
+     */
+    QString widgetType( const QString& fieldName ) const;
+
+    /**
+     * Set the editor widget config for a field.
+     *
+     * Python: Will accept a map.
+     *
+     * Example:
+     * \code{.py}
+     *   layer.setEditorWidgetV2Config( 1, { 'Layer': 'otherlayerid_1234', 'Key': 'Keyfield', 'Value': 'ValueField' } )
+     * \endcode
+     *
+     * @param attrIdx     Index of the field
+     * @param config      The config to set for this field
+     *
+     * @see setEditorWidgetV2() for a list of widgets and choose the widget to see the available options.
+     */
+    void setWidgetConfig( int attrIdx, const QgsEditorWidgetConfig& config );
+
+    /**
+     * Get the configuration for the editor widget used to represent the field at the given index
+     *
+     * @param fieldIdx  The index of the field
+     *
+     * @return The configuration for the editor widget or an empty config if the field does not exist
+     */
+    QgsEditorWidgetConfig widgetConfig( int fieldIdx ) const;
+
+    /**
+     * Get the configuration for the editor widget used to represent the field with the given name
+     *
+     * @param fieldName The name of the field
+     *
+     * @return The configuration for the editor widget or an empty config if the field does not exist
+     *
+     * @note python method name is editorWidgetV2ConfigByName
+     */
+    QgsEditorWidgetConfig widgetConfig( const QString& fieldName ) const;
+
+    /**
+     * If this returns false, the widget at the given index will always be read-only.
+     */
+    bool fieldEditable( int idx );
+
+    /**
+     * If set to false, the widget at the given index will be read-only, regardless of the
+     * layer's editable state and data provider capacities.
+     * If it is set to true, the widget's editable state will be synchronized with the layer's
+     * edit state.
+     */
+    void setFieldEditable( int idx, bool editable );
+
+    /**
+     * If this returns true, the widget at the given index will receive its label on the previous line
+     * while if it returns false, the widget will receive its label on the left hand side.
+     * Labeling on top leaves more horizontal space for the widget itself.
+     **/
+    bool labelOnTop( int idx );
+
+    /**
+     * If this is set to true, the widget at the given index will receive its label on
+     * the previous line while if it is set to false, the widget will receive its label
+     * on the left hand side.
+     * Labeling on top leaves more horizontal space for the widget itself.
+     **/
+    void setLabelOnTop( int idx, bool onTop );
+
+
+
+
+
+
+
+
+
+
+
+    // Python stuff
+
+
+    /** Get python function for edit form initialization */
+    QString initFunction() const;
+
+    /** Set python function for edit form initialization */
+    void setInitFunction( const QString& function );
+
+    /** Get python code for edit form initialization */
+    QString initCode() const;
+
+    /** Set python code for edit form initialization */
+    void setInitCode( const QString& code );
+
+    /** Return if python code shall be loaded for edit form initialization */
+    bool useInitCode() const;
+
+    /** Set if python code shall be used for edit form initialization */
+    void setUseInitCode( const bool useCode );
+
+    FeatureFormSuppress suppress() const;
+    void setSuppress( FeatureFormSuppress s );
+};

--- a/python/core/qgseditformconfig.sip
+++ b/python/core/qgseditformconfig.sip
@@ -57,7 +57,6 @@ class QgsEditFormConfig : QObject
       SuppressOff = 2      //!< Do not suppress feature form
     };
 
-    explicit QgsEditFormConfig( QObject* parent = nullptr );
 
     /**
      * This is only useful in combination with EditorLayout::TabLayout.

--- a/python/core/qgsvectorlayer.sip
+++ b/python/core/qgsvectorlayer.sip
@@ -1097,7 +1097,7 @@ class QgsVectorLayer : QgsMapLayer
     /**
      * Returns a list of tabs holding groups and fields
      */
-    QList< QgsAttributeEditorElement* > &attributeEditorElements();
+    QList< QgsAttributeEditorElement* > attributeEditorElements();
     /**
      * Clears all the tabs for the attribute editor form
      */
@@ -1255,20 +1255,8 @@ class QgsVectorLayer : QgsMapLayer
     /** Get python function for edit form initialization */
     QString editFormInit();
 
-    /** Get python code for edit form initialization */
-    QString editFormInitCode();
-
-    /** Reeturn if python code has to be loaded for edit form initialization */
-    bool editFormInitUseCode();
-
     /** Set python function for edit form initialization */
     void setEditFormInit( const QString& function );
-
-    /** Set python code for edit form initialization */
-    void setEditFormInitCode( const QString& code );
-
-    /** Set python code for edit form initialization */
-    void setEditFormInitUseCode( const bool useCode );
 
     /**
      * Access value map

--- a/python/core/qgsvectorlayer.sip
+++ b/python/core/qgsvectorlayer.sip
@@ -1098,6 +1098,15 @@ class QgsVectorLayer : QgsMapLayer
      * Returns a list of tabs holding groups and fields
      */
     QList< QgsAttributeEditorElement* > attributeEditorElements();
+
+    /**
+     * Get the configuration of the form used to represent this vector layer.
+     * This is a writable configuration that can directly be changed in place.
+     *
+     * @return The configuration of this layers' form
+     */
+    QgsEditFormConfig* editFormConfig() const;
+
     /**
      * Clears all the tabs for the attribute editor form
      */

--- a/python/core/qgsvectorlayer.sip
+++ b/python/core/qgsvectorlayer.sip
@@ -1006,7 +1006,7 @@ class QgsVectorLayer : QgsMapLayer
     /** Make layer read-only (editing disabled) or not
      *  @return false if the layer is in editing yet
      */
-    bool setReadOnly( bool readonly = true );
+    bool setFieldEditable( bool editable = true );
 
     /**
      * Make layer editable.

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -336,7 +336,7 @@ void QgsAttributeTableDialog::columnBoxInit()
     if ( idx < 0 )
       continue;
 
-    if ( mLayer->editorWidgetV2( idx ) != "Hidden" )
+    if ( mLayer->editFormConfig()->widgetType( idx ) != "Hidden" )
     {
       QIcon icon = QgsApplication::getThemeIcon( "/mActionNewAttribute.png" );
       QString alias = mLayer->attributeDisplayName( idx );
@@ -460,8 +460,8 @@ void QgsAttributeTableDialog::filterColumnChanged( QObject* filterAction )
   int fldIdx = mLayer->fieldNameIndex( fieldName );
   if ( fldIdx < 0 )
     return;
-  const QString widgetType = mLayer->editorWidgetV2( fldIdx );
-  const QgsEditorWidgetConfig widgetConfig = mLayer->editorWidgetV2Config( fldIdx );
+  const QString widgetType = mLayer->editFormConfig()->widgetType( fldIdx );
+  const QgsEditorWidgetConfig widgetConfig = mLayer->editFormConfig()->widgetConfig( fldIdx );
   mCurrentSearchWidgetWrapper = QgsEditorWidgetRegistry::instance()->
                                 createSearchWidget( widgetType, mLayer, fldIdx, widgetConfig, mFilterContainer );
   if ( mCurrentSearchWidgetWrapper->applyDirectly() )

--- a/src/app/qgsfeatureaction.cpp
+++ b/src/app/qgsfeatureaction.cpp
@@ -168,15 +168,15 @@ bool QgsFeatureAction::addFeature( const QgsAttributeMap& defaultAttributes, boo
   bool isDisabledAttributeValuesDlg = ( fields.count() == 0 ) || settings.value( "/qgis/digitizing/disable_enter_attribute_values_dialog", false ).toBool();
 
   // override application-wide setting with any layer setting
-  switch ( mLayer->featureFormSuppress() )
+  switch ( mLayer->editFormConfig()->suppress() )
   {
-    case QgsVectorLayer::SuppressOn:
+    case QgsEditFormConfig::SuppressOn:
       isDisabledAttributeValuesDlg = true;
       break;
-    case QgsVectorLayer::SuppressOff:
+    case QgsEditFormConfig::SuppressOff:
       isDisabledAttributeValuesDlg = false;
       break;
-    case QgsVectorLayer::SuppressDefault:
+    case QgsEditFormConfig::SuppressDefault:
       break;
   }
   if ( isDisabledAttributeValuesDlg )

--- a/src/app/qgsfieldsproperties.cpp
+++ b/src/app/qgsfieldsproperties.cpp
@@ -848,7 +848,7 @@ void QgsFieldsProperties::apply()
     int idx = mFieldsList->item( i, attrIdCol )->text().toInt();
     FieldConfig cfg = configForRow( i );
 
-    mLayer->editFormConfig()->setFieldEditable( i, cfg.mEditable );
+    mLayer->editFormConfig()->setReadOnly( i, !cfg.mEditable );
     mLayer->editFormConfig()->setLabelOnTop( i, cfg.mLabelOnTop );
 
     mLayer->editFormConfig()->setWidgetType( idx, cfg.mEditorWidgetV2Type );
@@ -900,7 +900,7 @@ QgsFieldsProperties::FieldConfig::FieldConfig()
 QgsFieldsProperties::FieldConfig::FieldConfig( QgsVectorLayer* layer, int idx )
     : mButton( 0 )
 {
-  mEditable = layer->editFormConfig()->fieldEditable( idx );
+  mEditable = !layer->editFormConfig()->readOnly( idx );
   mEditableEnabled = layer->fields().fieldOrigin( idx ) != QgsFields::OriginJoin
                      && layer->fields().fieldOrigin( idx ) != QgsFields::OriginExpression;
   mLabelOnTop = layer->editFormConfig()->labelOnTop( idx );

--- a/src/app/qgsfieldsproperties.cpp
+++ b/src/app/qgsfieldsproperties.cpp
@@ -43,9 +43,9 @@
 QgsFieldsProperties::QgsFieldsProperties( QgsVectorLayer *layer, QWidget* parent )
     : QWidget( parent )
     , mLayer( layer )
-    , mDesignerTree( NULL )
-    , mFieldsList( NULL )
-    , mRelationsList( NULL )
+    , mDesignerTree( nullptr )
+    , mFieldsList( nullptr )
+    , mRelationsList( nullptr )
 {
   if ( !layer )
     return;
@@ -129,8 +129,8 @@ void QgsFieldsProperties::init()
 {
   loadRows();
 
-  mEditorLayoutComboBox->setCurrentIndex( mLayer->editorLayout() );
-  mFormSuppressCmbBx->setCurrentIndex( mLayer->featureFormSuppress() );
+  mEditorLayoutComboBox->setCurrentIndex( mLayer->editFormConfig()->layout() );
+  mFormSuppressCmbBx->setCurrentIndex( mLayer->editFormConfig()->suppress() );
 
   loadAttributeEditorTree();
 }
@@ -225,7 +225,7 @@ void QgsFieldsProperties::loadAttributeEditorTree()
   mDesignerTree->setAcceptDrops( true );
   mDesignerTree->setDragDropMode( QAbstractItemView::DragDrop );
 
-  Q_FOREACH ( QgsAttributeEditorElement* wdg, mLayer->attributeEditorElements() )
+  Q_FOREACH ( QgsAttributeEditorElement* wdg, mLayer->editFormConfig()->tabs() )
   {
     loadAttributeEditorTreeItem( wdg, mDesignerTree->invisibleRootItem() );
   }
@@ -848,11 +848,11 @@ void QgsFieldsProperties::apply()
     int idx = mFieldsList->item( i, attrIdCol )->text().toInt();
     FieldConfig cfg = configForRow( i );
 
-    mLayer->setFieldEditable( i, cfg.mEditable );
-    mLayer->setLabelOnTop( i, cfg.mLabelOnTop );
+    mLayer->editFormConfig()->setFieldEditable( i, cfg.mEditable );
+    mLayer->editFormConfig()->setLabelOnTop( i, cfg.mLabelOnTop );
 
-    mLayer->setEditorWidgetV2( idx, cfg.mEditorWidgetV2Type );
-    mLayer->setEditorWidgetV2Config( idx, cfg.mEditorWidgetV2Config );
+    mLayer->editFormConfig()->setWidgetType( idx, cfg.mEditorWidgetV2Type );
+    mLayer->editFormConfig()->setWidgetConfig( idx, cfg.mEditorWidgetV2Config );
 
     if ( mFieldsList->item( i, attrWMSCol )->checkState() == Qt::Unchecked )
     {
@@ -870,16 +870,16 @@ void QgsFieldsProperties::apply()
   {
     QTreeWidgetItem* tabItem = mDesignerTree->invisibleRootItem()->child( t );
 
-    mLayer->addAttributeEditorWidget( createAttributeEditorWidget( tabItem, mLayer ) );
+    mLayer->editFormConfig()->addTab( createAttributeEditorWidget( tabItem, mLayer ) );
   }
 
-  mLayer->setEditorLayout(( QgsVectorLayer::EditorLayout ) mEditorLayoutComboBox->currentIndex() );
-  if ( mEditorLayoutComboBox->currentIndex() == QgsVectorLayer::UiFileLayout )
-    mLayer->setEditForm( leEditForm->text() );
-  mLayer->setEditFormInit( leEditFormInit->text() );
-  mLayer->setEditFormInitUseCode( leEditFormInitUseCode->isChecked() );
-  mLayer->setEditFormInitCode( leEditFormInitCode->text() );
-  mLayer->setFeatureFormSuppress(( QgsVectorLayer::FeatureFormSuppress )mFormSuppressCmbBx->currentIndex() );
+  mLayer->editFormConfig()->setLayout(( QgsEditFormConfig::EditorLayout ) mEditorLayoutComboBox->currentIndex() );
+  if ( mEditorLayoutComboBox->currentIndex() == QgsEditFormConfig::UiFileLayout )
+    mLayer->editFormConfig()->setUiForm( leEditForm->text() );
+  mLayer->editFormConfig()->setInitFunction( leEditFormInit->text() );
+  mLayer->editFormConfig()->setUseInitCode( leEditFormInitUseCode->isChecked() );
+  mLayer->editFormConfig()->setInitCode( leEditFormInitCode->text() );
+  mLayer->editFormConfig()->setSuppress(( QgsEditFormConfig::FeatureFormSuppress )mFormSuppressCmbBx->currentIndex() );
 
   mLayer->setExcludeAttributesWMS( excludeAttributesWMS );
   mLayer->setExcludeAttributesWFS( excludeAttributesWFS );
@@ -900,12 +900,12 @@ QgsFieldsProperties::FieldConfig::FieldConfig()
 QgsFieldsProperties::FieldConfig::FieldConfig( QgsVectorLayer* layer, int idx )
     : mButton( 0 )
 {
-  mEditable = layer->fieldEditable( idx );
+  mEditable = layer->editFormConfig()->fieldEditable( idx );
   mEditableEnabled = layer->fields().fieldOrigin( idx ) != QgsFields::OriginJoin
                      && layer->fields().fieldOrigin( idx ) != QgsFields::OriginExpression;
-  mLabelOnTop = layer->labelOnTop( idx );
-  mEditorWidgetV2Type = layer->editorWidgetV2( idx );
-  mEditorWidgetV2Config = layer->editorWidgetV2Config( idx );
+  mLabelOnTop = layer->editFormConfig()->labelOnTop( idx );
+  mEditorWidgetV2Type = layer->editFormConfig()->widgetType( idx );
+  mEditorWidgetV2Config = layer->editFormConfig()->widgetConfig( idx );
 
 }
 
@@ -921,12 +921,12 @@ QStringList QgsFieldsProperties::DragList::mimeTypes() const
 QMimeData* QgsFieldsProperties::DragList::mimeData( const QList<QTableWidgetItem*> items ) const
 {
   if ( items.count() <= 0 )
-    return NULL;
+    return nullptr;
 
   QStringList types = mimeTypes();
 
   if ( types.isEmpty() )
-    return NULL;
+    return nullptr;
 
   QMimeData* data = new QMimeData();
   QString format = types.at( 0 );
@@ -1091,12 +1091,12 @@ QStringList QgsFieldsProperties::DesignerTree::mimeTypes() const
 QMimeData* QgsFieldsProperties::DesignerTree::mimeData( const QList<QTreeWidgetItem*> items ) const
 {
   if ( items.count() <= 0 )
-    return NULL;
+    return nullptr;
 
   QStringList types = mimeTypes();
 
   if ( types.isEmpty() )
-    return NULL;
+    return nullptr;
 
   QMimeData* data = new QMimeData();
   QString format = types.at( 0 );

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -480,7 +480,7 @@ void QgsIdentifyResultsDialog::addFeature( QgsVectorLayer *vlayer, const QgsFeat
 
     attrItem->setData( 1, Qt::UserRole, value );
 
-    if ( vlayer->editorWidgetV2( i ) == "Hidden" )
+    if ( vlayer->editFormConfig()->widgetType( i ) == "Hidden" )
     {
       delete attrItem;
       continue;
@@ -640,7 +640,7 @@ QString QgsIdentifyResultsDialog::representValue( QgsVectorLayer* vlayer, const 
   QVariant cache;
   QMap<QString, QVariant>& layerCaches = mWidgetCaches[vlayer->id()];
 
-  QString widgetType = vlayer->editorWidgetV2( fieldName );
+  QString widgetType = vlayer->editFormConfig()->widgetType( fieldName );
   QgsEditorWidgetFactory* factory = QgsEditorWidgetRegistry::instance()->factory( widgetType );
 
   int idx = vlayer->fieldNameIndex( fieldName );
@@ -654,11 +654,11 @@ QString QgsIdentifyResultsDialog::representValue( QgsVectorLayer* vlayer, const 
   }
   else
   {
-    cache = factory->createCache( vlayer, idx, vlayer->editorWidgetV2Config( fieldName ) );
+    cache = factory->createCache( vlayer, idx, vlayer->editFormConfig()->widgetConfig( fieldName ) );
     layerCaches.insert( fieldName, cache );
   }
 
-  return factory->representValue( vlayer, idx, vlayer->editorWidgetV2Config( fieldName ), cache, value );
+  return factory->representValue( vlayer, idx, vlayer->editFormConfig()->widgetConfig( fieldName ), cache, value );
 }
 
 void QgsIdentifyResultsDialog::addFeature( QgsRasterLayer *layer,

--- a/src/app/qgsmergeattributesdialog.cpp
+++ b/src/app/qgsmergeattributesdialog.cpp
@@ -113,8 +113,8 @@ void QgsMergeAttributesDialog::createTableWidgetContents()
   int col = 0;
   for ( int idx = 0; idx < fields.count(); ++idx )
   {
-    if ( mVectorLayer->editorWidgetV2( idx ) == "Hidden" ||
-         mVectorLayer->editorWidgetV2( idx ) == "Immutable" )
+    if ( mVectorLayer->editFormConfig()->widgetType( idx ) == "Hidden" ||
+         mVectorLayer->editFormConfig()->widgetType( idx ) == "Immutable" )
       continue;
 
     mTableWidget->setColumnCount( col + 1 );

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -1316,5 +1316,6 @@ void QgsVectorLayerProperties::updateVariableEditor()
 
 void QgsVectorLayerProperties::updateFieldsPropertiesDialog()
 {
-  mFieldsPropertiesDialog->setEditFormInit( layer->editForm(), layer->editFormInit(), layer->editFormInitCode(), layer->editFormInitUseCode() );
+  QgsEditFormConfig* cfg = layer->editFormConfig();
+  mFieldsPropertiesDialog->setEditFormInit( cfg->uiForm(), cfg->initFunction(), cfg->initCode(), cfg->useInitCode() );
 }

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -98,6 +98,7 @@ SET(QGIS_CORE_SRCS
   qgsdbfilterproxymodel.cpp
   qgsdiagramrendererv2.cpp
   qgsdistancearea.cpp
+  qgseditformconfig.cpp
   qgserror.cpp
   qgsexpression.cpp
   qgsexpressioncontext.cpp
@@ -403,6 +404,7 @@ SET(QGIS_CORE_MOC_HDRS
   qgscoordinatetransform.h
   qgsdataitem.h
   qgsdataprovider.h
+  qgseditformconfig.h
   qgsgml.h
   qgsgmlschema.h
   qgsmaplayer.h

--- a/src/core/qgseditformconfig.cpp
+++ b/src/core/qgseditformconfig.cpp
@@ -4,8 +4,8 @@
 QgsEditFormConfig::QgsEditFormConfig( QObject* parent )
     : QObject( parent )
     , mEditorLayout( GeneratedLayout )
-    , mUseInitCode( false )
     , mFeatureFormSuppress( SuppressDefault )
+    , mUseInitCode( false )
 {
   connect( QgsProject::instance()->relationManager(), SIGNAL( relationsLoaded() ), this, SLOT( onRelationsLoaded() ) );
 }
@@ -72,17 +72,17 @@ void QgsEditFormConfig::setUiForm( const QString& ui )
   mEditForm = ui;
 }
 
-bool QgsEditFormConfig::fieldEditable( int idx )
+bool QgsEditFormConfig::readOnly( int idx )
 {
   if ( idx >= 0 && idx < mFields.count() )
   {
     if ( mFields.fieldOrigin( idx ) == QgsFields::OriginJoin
          || mFields.fieldOrigin( idx ) == QgsFields::OriginExpression )
-      return false;
-    return mFieldEditables.value( mFields.at( idx ).name(), true );
+      return true;
+    return !mFieldEditables.value( mFields.at( idx ).name(), true );
   }
   else
-    return true;
+    return false;
 }
 
 bool QgsEditFormConfig::labelOnTop( int idx )
@@ -93,10 +93,10 @@ bool QgsEditFormConfig::labelOnTop( int idx )
     return false;
 }
 
-void QgsEditFormConfig::setFieldEditable( int idx, bool editable )
+void QgsEditFormConfig::setReadOnly( int idx, bool readOnly )
 {
   if ( idx >= 0 && idx < mFields.count() )
-    mFieldEditables[ mFields.at( idx ).name()] = editable;
+    mFieldEditables[ mFields.at( idx ).name()] = !readOnly;
 }
 
 void QgsEditFormConfig::setLabelOnTop( int idx, bool onTop )

--- a/src/core/qgseditformconfig.cpp
+++ b/src/core/qgseditformconfig.cpp
@@ -1,0 +1,129 @@
+#include "qgseditformconfig.h"
+#include "qgsproject.h"
+
+QgsEditFormConfig::QgsEditFormConfig( QObject* parent )
+    : QObject( parent )
+    , mEditorLayout( GeneratedLayout )
+    , mUseInitCode( false )
+    , mFeatureFormSuppress( SuppressDefault )
+{
+  connect( QgsProject::instance()->relationManager(), SIGNAL( relationsLoaded() ), this, SLOT( onRelationsLoaded() ) );
+}
+
+QString QgsEditFormConfig::widgetType( int fieldIdx ) const
+{
+  if ( fieldIdx < 0 || fieldIdx >= mFields.count() )
+    return "TextEdit";
+
+  return mEditorWidgetV2Types.value( mFields[fieldIdx].name(), "TextEdit" );
+}
+
+QString QgsEditFormConfig::widgetType( const QString& fieldName ) const
+{
+  return mEditorWidgetV2Types.value( fieldName, "TextEdit" );
+}
+
+QgsEditorWidgetConfig QgsEditFormConfig::widgetConfig( int fieldIdx ) const
+{
+  if ( fieldIdx < 0 || fieldIdx >= mFields.count() )
+    return QgsEditorWidgetConfig();
+
+  return mEditorWidgetV2Configs.value( mFields[fieldIdx].name() );
+}
+
+QgsEditorWidgetConfig QgsEditFormConfig::widgetConfig( const QString& fieldName ) const
+{
+  return mEditorWidgetV2Configs.value( fieldName );
+}
+
+void QgsEditFormConfig::setFields( const QgsFields& fields )
+{
+  mFields = fields;
+}
+
+
+void QgsEditFormConfig::setWidgetType( int attrIdx, const QString& widgetType )
+{
+  if ( attrIdx >= 0 && attrIdx < mFields.count() )
+    mEditorWidgetV2Types[ mFields.at( attrIdx ).name()] = widgetType;
+}
+
+void QgsEditFormConfig::setWidgetConfig( int attrIdx, const QgsEditorWidgetConfig& config )
+{
+  if ( attrIdx >= 0 && attrIdx < mFields.count() )
+    mEditorWidgetV2Configs[ mFields.at( attrIdx ).name()] = config;
+}
+
+QString QgsEditFormConfig::uiForm() const
+{
+  return mEditForm;
+}
+
+void QgsEditFormConfig::setUiForm( const QString& ui )
+{
+  if ( ui.isEmpty() || ui.isNull() )
+  {
+    setLayout( GeneratedLayout );
+  }
+  else
+  {
+    setLayout( UiFileLayout );
+  }
+  mEditForm = ui;
+}
+
+bool QgsEditFormConfig::fieldEditable( int idx )
+{
+  if ( idx >= 0 && idx < mFields.count() )
+  {
+    if ( mFields.fieldOrigin( idx ) == QgsFields::OriginJoin
+         || mFields.fieldOrigin( idx ) == QgsFields::OriginExpression )
+      return false;
+    return mFieldEditables.value( mFields.at( idx ).name(), true );
+  }
+  else
+    return true;
+}
+
+bool QgsEditFormConfig::labelOnTop( int idx )
+{
+  if ( idx >= 0 && idx < mFields.count() )
+    return mLabelOnTop.value( mFields.at( idx ).name(), false );
+  else
+    return false;
+}
+
+void QgsEditFormConfig::setFieldEditable( int idx, bool editable )
+{
+  if ( idx >= 0 && idx < mFields.count() )
+    mFieldEditables[ mFields.at( idx ).name()] = editable;
+}
+
+void QgsEditFormConfig::setLabelOnTop( int idx, bool onTop )
+{
+  if ( idx >= 0 && idx < mFields.count() )
+    mLabelOnTop[ mFields.at( idx ).name()] = onTop;
+}
+
+void QgsEditFormConfig::onRelationsLoaded()
+{
+  Q_FOREACH ( QgsAttributeEditorElement* elem, mAttributeEditorElements )
+  {
+    if ( elem->type() == QgsAttributeEditorElement::AeTypeContainer )
+    {
+      QgsAttributeEditorContainer* cont = dynamic_cast< QgsAttributeEditorContainer* >( elem );
+      if ( !cont )
+        continue;
+
+      QList<QgsAttributeEditorElement*> relations = cont->findElements( QgsAttributeEditorElement::AeTypeRelation );
+      Q_FOREACH ( QgsAttributeEditorElement* relElem, relations )
+      {
+        QgsAttributeEditorRelation* rel = dynamic_cast< QgsAttributeEditorRelation* >( relElem );
+        if ( !rel )
+          continue;
+
+        rel->init( QgsProject::instance()->relationManager() );
+      }
+    }
+  }
+}

--- a/src/core/qgseditformconfig.h
+++ b/src/core/qgseditformconfig.h
@@ -1,0 +1,569 @@
+/***************************************************************************
+                          qgseditformconfig.h
+                             -------------------
+    begin                : Nov 18, 2015
+    copyright            : (C) 2015 by Matthias Kuhn
+    email                : matthias at opengis dot ch
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSEDITFORMCONFIG_H
+#define QGSEDITFORMCONFIG_H
+
+#include <QMap>
+
+#include "qgseditorwidgetconfig.h"
+#include "qgsrelationmanager.h"
+
+/**
+ * This is an abstract base class for any elements of a drag and drop form.
+ *
+ * This can either be a container which will be represented on the screen
+ * as a tab widget or ca collapsible group box. Or it can be a field which will
+ * then be represented based on the QgsEditorWidgetV2 type and configuration.
+ * Or it can be a relation and embed the form of several children of another
+ * layer.
+ */
+class CORE_EXPORT QgsAttributeEditorElement : public QObject
+{
+    Q_OBJECT
+  public:
+
+    enum AttributeEditorType
+    {
+      AeTypeContainer, //!< A container
+      AeTypeField,     //!< A field
+      AeTypeRelation,  //!< A relation
+      AeTypeInvalid    //!< Invalid
+    };
+
+    /**
+     * Constructor
+     *
+     * @param type The type of the new element. Should never
+     * @param name
+     * @param parent
+     */
+    QgsAttributeEditorElement( AttributeEditorType type, const QString& name, QObject *parent = NULL )
+        : QObject( parent ), mType( type ), mName( name ) {}
+
+    //! Destructor
+    virtual ~QgsAttributeEditorElement() {}
+
+    /**
+     * Return the name of this element
+     *
+     * @return The name for this element
+     */
+    QString name() const { return mName; }
+
+    /**
+     * The type of this element
+     *
+     * @return The type
+     */
+    AttributeEditorType type() const { return mType; }
+
+    /**
+     * Is reimplemented in classes inheriting from this to serialize it.
+     *
+     * @param doc The QDomDocument which is used to create new XML elements
+     *
+     * @return An DOM element which represents this element
+     */
+    virtual QDomElement toDomElement( QDomDocument& doc ) const = 0;
+
+  protected:
+    AttributeEditorType mType;
+    QString mName;
+};
+
+
+/**
+ * This is a container for attribute editors, used to group them visually in the
+ * attribute form if it is set to the drag and drop designer.
+ */
+class CORE_EXPORT QgsAttributeEditorContainer : public QgsAttributeEditorElement
+{
+  public:
+    /**
+     * Creates a new attribute editor container
+     *
+     * @param name   The name to show as title
+     * @param parent The parent. May be another container.
+     */
+    QgsAttributeEditorContainer( const QString& name, QObject *parent )
+        : QgsAttributeEditorElement( AeTypeContainer, name, parent )
+        , mIsGroupBox( true )
+    {}
+
+    //! Destructor
+    virtual ~QgsAttributeEditorContainer() {}
+
+    /**
+     * Will serialize this containers information into a QDomElement for saving it in an XML file.
+     *
+     * @param doc The QDomDocument used to generate the QDomElement
+     *
+     * @return The XML element
+     */
+    virtual QDomElement toDomElement( QDomDocument& doc ) const override;
+
+    /**
+     * Add a child element to this container. This may be another container, a field or a relation.
+     *
+     * @param element The element to add as child
+     */
+    virtual void addChildElement( QgsAttributeEditorElement* element );
+
+    /**
+     * Determines if this container is rendered as collapsible group box or tab in a tabwidget
+     *
+     * @param isGroupBox If true, this will be a group box
+     */
+    virtual void setIsGroupBox( bool isGroupBox ) { mIsGroupBox = isGroupBox; }
+
+    /**
+     * Returns if this container is going to be rendered as a group box
+     *
+     * @return True if it will be a group box, false if it will be a tab
+     */
+    virtual bool isGroupBox() const { return mIsGroupBox; }
+
+    /**
+     * Get a list of the children elements of this container
+     *
+     * @return A list of elements
+     */
+    QList<QgsAttributeEditorElement*> children() const { return mChildren; }
+
+    /**
+     * Traverses the element tree to find any element of the specified type
+     *
+     * @param type The type which should be searched
+     *
+     * @return A list of elements of the type which has been searched for
+     */
+    virtual QList<QgsAttributeEditorElement*> findElements( AttributeEditorType type ) const;
+
+    /**
+     * Change the name of this container
+     *
+     * @param name
+     */
+    void setName( const QString& name );
+
+  private:
+    bool mIsGroupBox;
+    QList<QgsAttributeEditorElement*> mChildren;
+};
+
+/**
+ * This element will load a field's widget onto the form.
+ */
+class CORE_EXPORT QgsAttributeEditorField : public QgsAttributeEditorElement
+{
+  public:
+    /**
+     * Creates a new attribute editor element which represents a field
+     *
+     * @param name   The name of the element
+     * @param idx    The index of the field which should be embedded
+     * @param parent The parent of this widget (used as container)
+     */
+    QgsAttributeEditorField( const QString& name, int idx, QObject *parent )
+        : QgsAttributeEditorElement( AeTypeField, name, parent ), mIdx( idx ) {}
+
+    //! Destructor
+    virtual ~QgsAttributeEditorField() {}
+
+    /**
+     * Will serialize this elements information into a QDomElement for saving it in an XML file.
+     *
+     * @param doc The QDomDocument used to generate the QDomElement
+     *
+     * @return The XML element
+     */
+    virtual QDomElement toDomElement( QDomDocument& doc ) const override;
+
+    /**
+     * Return the index of the field
+     * @return
+     */
+    int idx() const { return mIdx; }
+
+  private:
+    int mIdx;
+};
+
+/**
+ * This element will load a relation editor onto the form.
+ */
+class CORE_EXPORT QgsAttributeEditorRelation : public QgsAttributeEditorElement
+{
+  public:
+    /**
+     * Creates a new element which embeds a relation.
+     *
+     * @param name         The name of this element
+     * @param relationId   The id of the relation to embed
+     * @param parent       The parent (used as container)
+     */
+    QgsAttributeEditorRelation( const QString& name, const QString &relationId, QObject *parent )
+        : QgsAttributeEditorElement( AeTypeRelation, name, parent )
+        , mRelationId( relationId ) {}
+
+    /**
+     * Creates a new element which embeds a relation.
+     *
+     * @param name         The name of this element
+     * @param relation     The relation to embed
+     * @param parent       The parent (used as container)
+     */
+    QgsAttributeEditorRelation( const QString& name, const QgsRelation& relation, QObject *parent )
+        : QgsAttributeEditorElement( AeTypeRelation, name, parent )
+        , mRelationId( relation.id() )
+        , mRelation( relation ) {}
+
+    //! Destructor
+    virtual ~QgsAttributeEditorRelation() {}
+
+    /**
+     * Will serialize this elements information into a QDomElement for saving it in an XML file.
+     *
+     * @param doc The QDomDocument used to generate the QDomElement
+     *
+     * @return The XML element
+     */
+    virtual QDomElement toDomElement( QDomDocument& doc ) const override;
+
+    /**
+     * Get the id of the relation which shall be embedded
+     *
+     * @return the id
+     */
+    const QgsRelation& relation() const { return mRelation; }
+
+    /**
+     * Initializes the relation from the id
+     *
+     * @param relManager The relation manager to use for the initialization
+     * @return true if the relation was found in the relationmanager
+     */
+    bool init( QgsRelationManager *relManager );
+
+  private:
+    QString mRelationId;
+    QgsRelation mRelation;
+};
+
+
+class CORE_EXPORT QgsEditFormConfig : public QObject
+{
+    Q_OBJECT
+
+  public:
+    /** The different types to layout the attribute editor. */
+    enum EditorLayout
+    {
+      GeneratedLayout = 0, //!< Autogenerate a simple tabular layout for the form
+      TabLayout = 1,       //!< Use a layout with tabs and group boxes. Needs to be configured.
+      UiFileLayout = 2     //!< Load a .ui file for the layout. Needs to be configured.
+    };
+
+    struct GroupData
+    {
+      GroupData() {}
+      GroupData( const QString& name, const QList<QString>& fields )
+          : mName( name ), mFields( fields ) {}
+      QString mName;
+      QList<QString> mFields;
+    };
+
+    struct TabData
+    {
+      TabData() {}
+      TabData( const QString& name, const QList<QString>& fields, const QList<GroupData>& groups )
+          : mName( name ), mFields( fields ), mGroups( groups ) {}
+      QString mName;
+      QList<QString> mFields;
+      QList<GroupData> mGroups;
+    };
+
+    /**
+     * Types of feature form suppression after feature creation
+     */
+    enum FeatureFormSuppress
+    {
+      SuppressDefault = 0, //!< Use the application-wide setting
+      SuppressOn = 1,      //!< Suppress feature form
+      SuppressOff = 2      //!< Do not suppress feature form
+    };
+
+    explicit QgsEditFormConfig( QObject* parent = nullptr );
+
+    /**
+     * This is only useful in combination with EditorLayout::TabLayout.
+     *
+     * Adds a new tab to the layout. Should be a QgsAttributeEditorContainer.
+     */
+    void addTab( QgsAttributeEditorElement* data ) { mAttributeEditorElements.append( data ); }
+
+    /**
+     * Returns a list of tabs for EditorLayout::TabLayout.
+     */
+    QList< QgsAttributeEditorElement* > tabs() { return mAttributeEditorElements; }
+
+    /**
+     * Clears all the tabs for the attribute editor form with EditorLayout::TabLayout.
+     */
+    void clearTabs() { mAttributeEditorElements.clear(); }
+
+    /** Get the active layout style for the attribute editor for this layer */
+    EditorLayout layout() { return mEditorLayout; }
+
+    /** Set the active layout style for the attribute editor for this layer */
+    void setLayout( EditorLayout editorLayout ) { mEditorLayout = editorLayout; }
+
+    /** Get path to the .ui form. Only meaningful with EditorLayout::UiFileLayout. */
+    QString uiForm() const;
+
+    /**
+     * Set path to the .ui form.
+     * When a string is provided, the layout style will be set to EditorLayout::UiFileLayout,
+     * if an empty or a null string is provided, the layout style will be set to
+     * EditorLayout::GeneratedLayout.
+     */
+    void setUiForm( const QString& ui );
+
+
+
+
+
+
+
+
+    // Widget stuff
+
+    /**
+     * Set the editor widget type for a field
+     *
+     * QGIS ships the following widget types, additional types may be available depending
+     * on plugins.
+     *
+     * <ul>
+     * <li>CheckBox (QgsCheckboxWidgetWrapper)</li>
+     * <li>Classification (QgsClassificationWidgetWrapper)</li>
+     * <li>Color (QgsColorWidgetWrapper)</li>
+     * <li>DateTime (QgsDateTimeEditWrapper)</li>
+     * <li>Enumeration (QgsEnumerationWidgetWrapper)</li>
+     * <li>FileName (QgsFileNameWidgetWrapper)</li>
+     * <li>Hidden (QgsHiddenWidgetWrapper)</li>
+     * <li>Photo (QgsPhotoWidgetWrapper)</li>
+     * <li>Range (QgsRangeWidgetWrapper)</li>
+     * <li>RelationReference (QgsRelationReferenceWidgetWrapper)</li>
+     * <li>TextEdit (QgsTextEditWrapper)</li>
+     * <li>UniqueValues (QgsUniqueValuesWidgetWrapper)</li>
+     * <li>UuidGenerator (QgsUuidWidgetWrapper)</li>
+     * <li>ValueMap (QgsValueMapWidgetWrapper)</li>
+     * <li>ValueRelation (QgsValueRelationWidgetWrapper)</li>
+     * <li>WebView (QgsWebViewWidgetWrapper)</li>
+     * </ul>
+     *
+     * @param attrIdx     Index of the field
+     * @param widgetType  Type id of the editor widget to use
+     */
+    void setWidgetType( int fieldIdx, const QString& widgetType );
+
+    /**
+     * Get the id for the editor widget used to represent the field at the given index
+     *
+     * @param fieldIdx  The index of the field
+     *
+     * @return The id for the editor widget or a NULL string if not applicable
+     */
+    QString widgetType( int fieldIdx ) const;
+
+    /**
+     * Get the id for the editor widget used to represent the field at the given index
+     *
+     * @param fieldName  The name of the field
+     *
+     * @return The id for the editor widget or a NULL string if not applicable
+     *
+     * @note python method name editorWidgetV2ByName
+     */
+    QString widgetType( const QString& fieldName ) const;
+
+    /**
+     * Set the editor widget config for a field.
+     *
+     * Python: Will accept a map.
+     *
+     * Example:
+     * \code{.py}
+     *   layer.setEditorWidgetV2Config( 1, { 'Layer': 'otherlayerid_1234', 'Key': 'Keyfield', 'Value': 'ValueField' } )
+     * \endcode
+     *
+     * @param attrIdx     Index of the field
+     * @param config      The config to set for this field
+     *
+     * @see setEditorWidgetV2() for a list of widgets and choose the widget to see the available options.
+     */
+    void setWidgetConfig( int attrIdx, const QgsEditorWidgetConfig& config );
+
+    /**
+     * Get the configuration for the editor widget used to represent the field at the given index
+     *
+     * @param fieldIdx  The index of the field
+     *
+     * @return The configuration for the editor widget or an empty config if the field does not exist
+     */
+    QgsEditorWidgetConfig widgetConfig( int fieldIdx ) const;
+
+    /**
+     * Get the configuration for the editor widget used to represent the field with the given name
+     *
+     * @param fieldName The name of the field
+     *
+     * @return The configuration for the editor widget or an empty config if the field does not exist
+     *
+     * @note python method name is editorWidgetV2ConfigByName
+     */
+    QgsEditorWidgetConfig widgetConfig( const QString& fieldName ) const;
+
+    /**
+     * If this returns false, the widget at the given index will always be read-only.
+     */
+    bool fieldEditable( int idx );
+
+    /**
+     * If set to false, the widget at the given index will be read-only, regardless of the
+     * layer's editable state and data provider capacities.
+     * If it is set to true, the widget's editable state will be synchronized with the layer's
+     * edit state.
+     */
+    void setFieldEditable( int idx, bool editable );
+
+    /**
+     * If this returns true, the widget at the given index will receive its label on the previous line
+     * while if it returns false, the widget will receive its label on the left hand side.
+     * Labeling on top leaves more horizontal space for the widget itself.
+     **/
+    bool labelOnTop( int idx );
+
+    /**
+     * If this is set to true, the widget at the given index will receive its label on
+     * the previous line while if it is set to false, the widget will receive its label
+     * on the left hand side.
+     * Labeling on top leaves more horizontal space for the widget itself.
+     **/
+    void setLabelOnTop( int idx, bool onTop );
+
+
+
+
+
+
+
+
+
+
+
+    // Python stuff
+
+
+    /**
+     * Get python function for edit form initialization.
+     * Will be looked up in a python file relative to the project folder if it
+     * includes a module name or if it's a pure function name it will searched
+     * in the python code set with @link setInitCode @endlink.
+     */
+    QString initFunction() const { return mInitFunction; }
+
+    /**
+     * Set python function for edit form initialization.
+     * Will be looked up in a python file relative to the project folder if it
+     * includes a module name or if it's a pure function name it will searched
+     * in the python code set with @link setInitCode @endlink.
+     */
+    void setInitFunction( const QString& function ) { mInitFunction = function; }
+
+    /**
+     * Get python code for edit form initialization.
+     */
+    QString initCode() const { return mEditFormInitCode; }
+
+    /**
+     * Get python code for edit form initialization.
+     * Make sure that you also set the appropriate function name in
+     * @link setInitFunction @endlink
+     */
+    void setInitCode( const QString& code ) { mEditFormInitCode = code; }
+
+
+    /** Return if python code shall be loaded for edit form initialization */
+    bool useInitCode() const { return mUseInitCode; }
+
+    /** Set if python code shall be used for edit form initialization */
+    void setUseInitCode( const bool useCode ) { mUseInitCode = useCode; }
+
+    /** Type of feature form pop-up suppression after feature creation (overrides app setting) */
+    FeatureFormSuppress suppress() const { return mFeatureFormSuppress; }
+    /** Set type of feature form pop-up suppression after feature creation (overrides app setting) */
+    void setSuppress( FeatureFormSuppress s ) { mFeatureFormSuppress = s; }
+
+  private slots:
+    void onRelationsLoaded();
+
+  private:
+
+    // Internal stuff
+
+    /**
+     * Used internally to set the fields when they change.
+     * This should only be called from QgsVectorLayer for synchronization reasons
+     *
+     * @param fields The fields
+     */
+    void setFields( const QgsFields& fields );
+
+  private:
+    /** Stores a list of attribute editor elements (Each holding a tree structure for a tab in the attribute editor)*/
+    QList< QgsAttributeEditorElement* > mAttributeEditorElements;
+
+    /** Map that stores the tab for attributes in the edit form. Key is the tab order and value the tab name*/
+    QList< TabData > mTabs;
+
+    QMap< QString, bool> mFieldEditables;
+    QMap< QString, bool> mLabelOnTop;
+
+    QMap<QString, QString> mEditorWidgetV2Types;
+    QMap<QString, QgsEditorWidgetConfig > mEditorWidgetV2Configs;
+
+    /** Defines the default layout to use for the attribute editor (Drag and drop, UI File, Generated) */
+    EditorLayout mEditorLayout;
+
+    QString mEditForm;
+    QString mInitFunction;
+    QString mEditFormInitCode;
+
+    /** Type of feature form suppression after feature creation */
+    FeatureFormSuppress mFeatureFormSuppress;
+
+    QgsFields mFields;
+
+    bool mUseInitCode;
+
+    friend class QgsVectorLayer;
+};
+
+#endif // QGSEDITFORMCONFIG_H

--- a/src/core/qgseditformconfig.h
+++ b/src/core/qgseditformconfig.h
@@ -378,7 +378,7 @@ class CORE_EXPORT QgsEditFormConfig : public QObject
      * <li>WebView (QgsWebViewWidgetWrapper)</li>
      * </ul>
      *
-     * @param attrIdx     Index of the field
+     * @param fieldIdx    Index of the field
      * @param widgetType  Type id of the editor widget to use
      */
     void setWidgetType( int fieldIdx, const QString& widgetType );

--- a/src/core/qgseditformconfig.h
+++ b/src/core/qgseditformconfig.h
@@ -441,17 +441,15 @@ class CORE_EXPORT QgsEditFormConfig : public QObject
     QgsEditorWidgetConfig widgetConfig( const QString& fieldName ) const;
 
     /**
-     * If this returns false, the widget at the given index will always be read-only.
+     * This returns true if the field is manually set to read only or if the field
+     * does not support editing like joins or vitual fields.
      */
-    bool fieldEditable( int idx );
+    bool readOnly( int idx );
 
     /**
-     * If set to false, the widget at the given index will be read-only, regardless of the
-     * layer's editable state and data provider capacities.
-     * If it is set to true, the widget's editable state will be synchronized with the layer's
-     * edit state.
+     * If set to false, the widget at the given index will be read-only.
      */
-    void setFieldEditable( int idx, bool editable );
+    void setReadOnly( int idx, bool readOnly = true );
 
     /**
      * If this returns true, the widget at the given index will receive its label on the previous line

--- a/src/core/qgseditformconfig.h
+++ b/src/core/qgseditformconfig.h
@@ -308,8 +308,6 @@ class CORE_EXPORT QgsEditFormConfig : public QObject
       SuppressOff = 2      //!< Do not suppress feature form
     };
 
-    explicit QgsEditFormConfig( QObject* parent = nullptr );
-
     /**
      * This is only useful in combination with EditorLayout::TabLayout.
      *
@@ -522,9 +520,15 @@ class CORE_EXPORT QgsEditFormConfig : public QObject
   private slots:
     void onRelationsLoaded();
 
-  private:
-
+  protected:
     // Internal stuff
+
+    /**
+     * Create a new edit form config. Normally invoked by QgsVectorLayer
+     */
+    explicit QgsEditFormConfig( QObject* parent = nullptr );
+
+  private:
 
     /**
      * Used internally to set the fields when they change.

--- a/src/core/qgsrulebasedlabeling.h
+++ b/src/core/qgsrulebasedlabeling.h
@@ -37,9 +37,36 @@ class CORE_EXPORT QgsRuleBasedLabeling : public QgsAbstractVectorLayerLabeling
           Registered    //!< Something was registered
         };
 
+        /**
+         * Get the labeling settings. May return a null pointer.
+         */
         QgsPalLayerSettings* settings() const { return mSettings; }
+
+        /**
+         * Determines if scale based labeling is active
+         *
+         * @return True if scale based labeling is active
+         */
         bool dependsOnScale() const { return mScaleMinDenom != 0 || mScaleMaxDenom != 0; }
+
+        /**
+         * The minimum scale at which this label rule should be applied
+         *
+         * E.g. Denominator 1000 is a scale of 1:1000, where a rule with minimum denominator
+         * of 900 will not be applied while a rule with 2000 will be applied.
+         *
+         * @return The minimum scale denominator
+         */
         int scaleMinDenom() const { return mScaleMinDenom; }
+
+        /**
+         * The maximum scale denominator at which this label rule should be applied
+         *
+         * E.g. Denominator 1000 is a scale of 1:1000, where a rule with maximum denominator
+         * of 900 will be applied while a rule with 2000 will not be applied.
+         *
+         * @return The maximum scale denominator
+         */
         int scaleMaxDenom() const { return mScaleMaxDenom; }
         /**
          * A filter that will check if this rule applies
@@ -186,6 +213,9 @@ class CORE_EXPORT QgsRuleBasedLabeling : public QgsAbstractVectorLayerLabeling
          */
         bool isScaleOK( double scale ) const;
 
+        /**
+         * Initialize filters. Automatically called by setFilterExpression.
+         */
         void initFilter();
 
         /**

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -2719,7 +2719,7 @@ bool QgsVectorLayer::isReadOnly() const
   return mReadOnly;
 }
 
-bool QgsVectorLayer::setReadOnly( bool readonly )
+bool QgsVectorLayer::setFieldEditable( bool readonly )
 {
   // exit if the layer is in editing mode
   if ( readonly && mEditBuffer )

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -1126,7 +1126,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
     /** Make layer read-only (editing disabled) or not
      *  @return false if the layer is in editing yet
      */
-    bool setReadOnly( bool readonly = true );
+    bool setFieldEditable( bool editable = true );
 
     /**
      * Make layer editable.
@@ -1469,9 +1469,9 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
     /**
      * Is edit widget editable
      *
-     * @deprecated Use `editFormConfig()->readOnly()` instead
+     * @deprecated Use `editFormConfig()->fieldEditable()` instead
      */
-    Q_DECL_DEPRECATED bool fieldEditable( int idx ) { return mEditFormConfig->readOnly( idx ); }
+    Q_DECL_DEPRECATED bool fieldEditable( int idx ) { return !mEditFormConfig->readOnly( idx ); }
 
     /**
      * Label widget on top
@@ -1481,9 +1481,9 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
 
     /**
      * Set edit widget editable
-     * @deprecated Use `editFormConfig()->setReadOnly()` instead
+     * @deprecated Use `editFormConfig()->setFieldEditable()` instead
      */
-    Q_DECL_DEPRECATED void setReadOnly( int idx, bool editable ) { mEditFormConfig->setFieldEditable( idx, editable ); }
+    Q_DECL_DEPRECATED void setFieldEditable( int idx, bool editable ) { mEditFormConfig->setReadOnly( idx, !editable ); }
 
     /**
      * Label widget on top

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -1171,6 +1171,8 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
 
     /**
      * Adds a tab (for the attribute editor form) holding groups and fields
+     *
+     * @deprecated Use `editFormConfig()->addTab()` instead
      */
     Q_DECL_DEPRECATED void addAttributeEditorWidget( QgsAttributeEditorElement* data ) {mEditFormConfig->addTab( data );}
 
@@ -1180,6 +1182,8 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
      * @param fieldIdx  The index of the field
      *
      * @return The id for the editor widget or a NULL string if not applicable
+     *
+     * @deprecated Use `editFormConfig()->widgetType()` instead
      */
     Q_DECL_DEPRECATED const QString editorWidgetV2( int fieldIdx ) const { return mEditFormConfig->widgetType( fieldIdx ); }
 
@@ -1191,6 +1195,8 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
      * @return The id for the editor widget or a NULL string if not applicable
      *
      * @note python method name editorWidgetV2ByName
+     *
+     * @deprecated Use `editFormConfig()->widgetType()` instead
      */
     Q_DECL_DEPRECATED const QString editorWidgetV2( const QString& fieldName ) const { return mEditFormConfig->widgetType( fieldName ); }
 
@@ -1200,6 +1206,8 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
      * @param fieldIdx  The index of the field
      *
      * @return The configuration for the editor widget or an empty config if the field does not exist
+     *
+     * @deprecated Use `editFormConfig()->widgetConfig()` instead
      */
     Q_DECL_DEPRECATED const QgsEditorWidgetConfig editorWidgetV2Config( int fieldIdx ) const { return mEditFormConfig->widgetConfig( fieldIdx ); }
 
@@ -1211,11 +1219,15 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
      * @return The configuration for the editor widget or an empty config if the field does not exist
      *
      * @note python method name is editorWidgetV2ConfigByName
+     *
+     * @deprecated Use `editFormConfig()->widgetConfig()` instead
      */
     Q_DECL_DEPRECATED const QgsEditorWidgetConfig editorWidgetV2Config( const QString& fieldName ) const { return mEditFormConfig->widgetConfig( fieldName ); }
 
     /**
      * Returns a list of tabs holding groups and fields
+     *
+     * @deprecated Use `editFormConfig()->tabs()` instead
      */
     Q_DECL_DEPRECATED QList< QgsAttributeEditorElement* > attributeEditorElements() { return mEditFormConfig->tabs(); }
 
@@ -1290,21 +1302,27 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
     /**
      * Get edit type
      *
-     * @deprecated Use editorWidgetV2() instead
+     * @deprecated Use `editFormConfig()->widgetType()` instead
      */
     Q_DECL_DEPRECATED EditType editType( int idx );
 
     /**
      * Get edit type
      *
-     * @deprecated Use setEditorWidgetV2() instead
+     * @deprecated Use `editFormConfig()->setWidgetType()` instead
      */
     Q_DECL_DEPRECATED void setEditType( int idx, EditType edit );
 
-    /** Get the active layout for the attribute editor for this layer */
+    /**
+     * Get the active layout for the attribute editor for this layer
+     * @deprecated Use `editFormConfig()->layout()` instead
+     */
     Q_DECL_DEPRECATED EditorLayout editorLayout() { return ( EditorLayout )mEditFormConfig->layout(); }
 
-    /** Set the active layout for the attribute editor for this layer */
+    /**
+     * Set the active layout for the attribute editor for this layer
+     * @deprecated Use `editFormConfig()->setLayout()` instead
+     */
     Q_DECL_DEPRECATED void setEditorLayout( EditorLayout editorLayout ) { mEditFormConfig->setLayout(( QgsEditFormConfig::EditorLayout )editorLayout ); }
 
     /**
@@ -1334,6 +1352,8 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
      *
      * @param attrIdx     Index of the field
      * @param widgetType  Type id of the editor widget to use
+     *
+     * @deprecated Use `editFormConfig()->setWidgetType()` instead
      */
     Q_DECL_DEPRECATED void setEditorWidgetV2( int attrIdx, const QString& widgetType ) { mEditFormConfig->setWidgetType( attrIdx, widgetType ); }
 
@@ -1351,28 +1371,41 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
      * @param config      The config to set for this field
      *
      * @see setEditorWidgetV2() for a list of widgets and choose the widget to see the available options.
+     *
+     * @deprecated Use `editFormConfig()->setWidgetConfig()` instead
      */
     Q_DECL_DEPRECATED void setEditorWidgetV2Config( int attrIdx, const QgsEditorWidgetConfig& config ) { mEditFormConfig->setWidgetConfig( attrIdx, config ); }
 
     /**
      * Set string representing 'true' for a checkbox
      *
-     * @deprecated Use setEditorWidgetV2Config() instead
+     * @deprecated Use @deprecated Use `editFormConfig()->setWidgetConfig()` instead
      */
     Q_DECL_DEPRECATED void setCheckedState( int idx, const QString& checked, const QString& notChecked );
 
-    /** Get edit form */
+    /**
+     * Get edit form
+     *
+     * @deprecated Use `editFormConfig()->uiForm()` instead
+     */
     Q_DECL_DEPRECATED QString editForm() const { return mEditFormConfig->uiForm(); }
 
-    /** Set edit form */
+    /**
+     * Set edit form
+     * @deprecated Use `editFormConfig()->setUiForm()` instead
+     */
     Q_DECL_DEPRECATED void setEditForm( const QString& ui ) { mEditFormConfig->setUiForm( ui ); }
 
     /** Type of feature form pop-up suppression after feature creation (overrides app setting)
-     * @note added in 2.1 */
+     * @note added in 2.1
+     * @deprecated Use `editFormConfig()->suppress()` instead
+     */
     Q_DECL_DEPRECATED QgsVectorLayer::FeatureFormSuppress featureFormSuppress() const { return ( FeatureFormSuppress )mEditFormConfig->suppress(); }
 
     /** Set type of feature form pop-up suppression after feature creation (overrides app setting)
-     * @note added in 2.1 */
+     * @note added in 2.1
+     * @deprecated Use `editFormConfig()->setSuppress()` instead
+     */
     Q_DECL_DEPRECATED void setFeatureFormSuppress( QgsVectorLayer::FeatureFormSuppress s ) { mEditFormConfig->setSuppress(( QgsEditFormConfig::FeatureFormSuppress )s ); }
 
     /** Get annotation form */
@@ -1381,22 +1414,30 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
     /** Set annotation form for layer */
     void setAnnotationForm( const QString& ui );
 
-    /** Get python function for edit form initialization */
+    /**
+     * Get python function for edit form initialization
+     *
+     * @deprecated Use `editFormConfig()->initFunction()` instead
+     */
     Q_DECL_DEPRECATED QString editFormInit() const { return mEditFormConfig->initFunction(); }
 
-    /** Set python function for edit form initialization */
+    /**
+     * Set python function for edit form initialization
+     *
+     * @deprecated Use `editFormConfig()->setInitFunction()` instead
+     */
     Q_DECL_DEPRECATED void setEditFormInit( const QString& function ) { mEditFormConfig->setInitFunction( function ); }
 
     /**
      * Access value map
-     * @deprecated Use editorWidgetV2Config() instead
+     * @deprecated Use `editFormConfig()->widgetConfig()` instead
      */
     Q_DECL_DEPRECATED QMap<QString, QVariant> valueMap( int idx );
 
     /**
      * Access range widget config data
      *
-     * @deprecated Use editorWidgetV2Config() instead
+     * @deprecated Use `editFormConfig()->widgetConfig()` instead
      */
     Q_DECL_DEPRECATED RangeData range( int idx );
 
@@ -1414,27 +1455,40 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
     /**
      * Access date format
      *
-     * @deprecated Use setEditorWidgetV2Config() instead
+     * @deprecated Use `editFormConfig()->widgetConfig()` instead
      */
     Q_DECL_DEPRECATED QString dateFormat( int idx );
 
     /**
      * Access widget size for photo and webview widget
      *
-     * @deprecated Use setEditorWidgetV2Config() instead
+     * @deprecated Use `editFormConfig()->widgetConfig()` instead
      */
     Q_DECL_DEPRECATED QSize widgetSize( int idx );
 
-    /** Is edit widget editable **/
-    Q_DECL_DEPRECATED bool fieldEditable( int idx ) { return mEditFormConfig->fieldEditable( idx ); }
+    /**
+     * Is edit widget editable
+     *
+     * @deprecated Use `editFormConfig()->readOnly()` instead
+     */
+    Q_DECL_DEPRECATED bool fieldEditable( int idx ) { return mEditFormConfig->readOnly( idx ); }
 
-    /** Label widget on top **/
+    /**
+     * Label widget on top
+     * @deprecated Use `editFormConfig()->labelOnTop()` instead
+     */
     Q_DECL_DEPRECATED bool labelOnTop( int idx ) { return mEditFormConfig->labelOnTop( idx ); }
 
-    /** Set edit widget editable **/
-    Q_DECL_DEPRECATED void setFieldEditable( int idx, bool editable ) { mEditFormConfig->setFieldEditable( idx, editable ); }
+    /**
+     * Set edit widget editable
+     * @deprecated Use `editFormConfig()->setReadOnly()` instead
+     */
+    Q_DECL_DEPRECATED void setReadOnly( int idx, bool editable ) { mEditFormConfig->setFieldEditable( idx, editable ); }
 
-    /** Label widget on top **/
+    /**
+     * Label widget on top
+     * @deprecated Use `editFormConfig()->setLabelOnTop()` instead
+     */
     Q_DECL_DEPRECATED void setLabelOnTop( int idx, bool onTop ) { mEditFormConfig->setLabelOnTop( idx, onTop ); }
 
     //! Buffer with uncommitted editing operations. Only valid after editing has been turned on.

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -32,8 +32,8 @@
 #include "qgseditorwidgetconfig.h"
 #include "qgsfield.h"
 #include "qgssnapper.h"
-#include "qgsrelation.h"
 #include "qgsvectorsimplifymethod.h"
+#include "qgseditformconfig.h"
 
 class QPainter;
 class QImage;
@@ -68,250 +68,6 @@ class QgsPointV2;
 
 typedef QList<int> QgsAttributeList;
 typedef QSet<int> QgsAttributeIds;
-
-
-/**
- * This is an abstract base class for any elements of a drag and drop form.
- *
- * This can either be a container which will be represented on the screen
- * as a tab widget or ca collapsible group box. Or it can be a field which will
- * then be represented based on the QgsEditorWidgetV2 type and configuration.
- * Or it can be a relation and embed the form of several children of another
- * layer.
- */
-class CORE_EXPORT QgsAttributeEditorElement : public QObject
-{
-    Q_OBJECT
-  public:
-
-    enum AttributeEditorType
-    {
-      AeTypeContainer, //!< A container
-      AeTypeField,     //!< A field
-      AeTypeRelation,  //!< A relation
-      AeTypeInvalid    //!< Invalid
-    };
-
-    /**
-     * Constructor
-     *
-     * @param type The type of the new element. Should never
-     * @param name
-     * @param parent
-     */
-    QgsAttributeEditorElement( AttributeEditorType type, const QString& name, QObject *parent = NULL )
-        : QObject( parent ), mType( type ), mName( name ) {}
-
-    //! Destructor
-    virtual ~QgsAttributeEditorElement() {}
-
-    /**
-     * Return the name of this element
-     *
-     * @return The name for this element
-     */
-    QString name() const { return mName; }
-
-    /**
-     * The type of this element
-     *
-     * @return The type
-     */
-    AttributeEditorType type() const { return mType; }
-
-    /**
-     * Is reimplemented in classes inheriting from this to serialize it.
-     *
-     * @param doc The QDomDocument which is used to create new XML elements
-     *
-     * @return An DOM element which represents this element
-     */
-    virtual QDomElement toDomElement( QDomDocument& doc ) const = 0;
-
-  protected:
-    AttributeEditorType mType;
-    QString mName;
-};
-
-/**
- * This is a container for attribute editors, used to group them visually in the
- * attribute form if it is set to the drag and drop designer.
- */
-class CORE_EXPORT QgsAttributeEditorContainer : public QgsAttributeEditorElement
-{
-  public:
-    /**
-     * Creates a new attribute editor container
-     *
-     * @param name   The name to show as title
-     * @param parent The parent. May be another container.
-     */
-    QgsAttributeEditorContainer( const QString& name, QObject *parent )
-        : QgsAttributeEditorElement( AeTypeContainer, name, parent )
-        , mIsGroupBox( true )
-    {}
-
-    //! Destructor
-    virtual ~QgsAttributeEditorContainer() {}
-
-    /**
-     * Will serialize this containers information into a QDomElement for saving it in an XML file.
-     *
-     * @param doc The QDomDocument used to generate the QDomElement
-     *
-     * @return The XML element
-     */
-    virtual QDomElement toDomElement( QDomDocument& doc ) const override;
-
-    /**
-     * Add a child element to this container. This may be another container, a field or a relation.
-     *
-     * @param element The element to add as child
-     */
-    virtual void addChildElement( QgsAttributeEditorElement* element );
-
-    /**
-     * Determines if this container is rendered as collapsible group box or tab in a tabwidget
-     *
-     * @param isGroupBox If true, this will be a group box
-     */
-    virtual void setIsGroupBox( bool isGroupBox ) { mIsGroupBox = isGroupBox; }
-
-    /**
-     * Returns if this container is going to be rendered as a group box
-     *
-     * @return True if it will be a group box, false if it will be a tab
-     */
-    virtual bool isGroupBox() const { return mIsGroupBox; }
-
-    /**
-     * Get a list of the children elements of this container
-     *
-     * @return A list of elements
-     */
-    QList<QgsAttributeEditorElement*> children() const { return mChildren; }
-
-    /**
-     * Traverses the element tree to find any element of the specified type
-     *
-     * @param type The type which should be searched
-     *
-     * @return A list of elements of the type which has been searched for
-     */
-    virtual QList<QgsAttributeEditorElement*> findElements( AttributeEditorType type ) const;
-
-    /**
-     * Change the name of this container
-     *
-     * @param name
-     */
-    void setName( const QString& name );
-
-  private:
-    bool mIsGroupBox;
-    QList<QgsAttributeEditorElement*> mChildren;
-};
-
-/**
- * This element will load a field's widget onto the form.
- */
-class CORE_EXPORT QgsAttributeEditorField : public QgsAttributeEditorElement
-{
-  public:
-    /**
-     * Creates a new attribute editor element which represents a field
-     *
-     * @param name   The name of the element
-     * @param idx    The index of the field which should be embedded
-     * @param parent The parent of this widget (used as container)
-     */
-    QgsAttributeEditorField( const QString& name, int idx, QObject *parent )
-        : QgsAttributeEditorElement( AeTypeField, name, parent ), mIdx( idx ) {}
-
-    //! Destructor
-    virtual ~QgsAttributeEditorField() {}
-
-    /**
-     * Will serialize this elements information into a QDomElement for saving it in an XML file.
-     *
-     * @param doc The QDomDocument used to generate the QDomElement
-     *
-     * @return The XML element
-     */
-    virtual QDomElement toDomElement( QDomDocument& doc ) const override;
-
-    /**
-     * Return the index of the field
-     * @return
-     */
-    int idx() const { return mIdx; }
-
-  private:
-    int mIdx;
-};
-
-/**
- * This element will load a relation editor onto the form.
- *
- * @note Added in 2.1
- */
-class CORE_EXPORT QgsAttributeEditorRelation : public QgsAttributeEditorElement
-{
-  public:
-    /**
-     * Creates a new element which embeds a relation.
-     *
-     * @param name         The name of this element
-     * @param relationId   The id of the relation to embed
-     * @param parent       The parent (used as container)
-     */
-    QgsAttributeEditorRelation( const QString& name, const QString &relationId, QObject *parent )
-        : QgsAttributeEditorElement( AeTypeRelation, name, parent )
-        , mRelationId( relationId ) {}
-
-    /**
-     * Creates a new element which embeds a relation.
-     *
-     * @param name         The name of this element
-     * @param relation     The relation to embed
-     * @param parent       The parent (used as container)
-     */
-    QgsAttributeEditorRelation( const QString& name, const QgsRelation& relation, QObject *parent )
-        : QgsAttributeEditorElement( AeTypeRelation, name, parent )
-        , mRelationId( relation.id() )
-        , mRelation( relation ) {}
-
-    //! Destructor
-    virtual ~QgsAttributeEditorRelation() {}
-
-    /**
-     * Will serialize this elements information into a QDomElement for saving it in an XML file.
-     *
-     * @param doc The QDomDocument used to generate the QDomElement
-     *
-     * @return The XML element
-     */
-    virtual QDomElement toDomElement( QDomDocument& doc ) const override;
-
-    /**
-     * Get the id of the relation which shall be embedded
-     *
-     * @return the id
-     */
-    const QgsRelation& relation() const { return mRelation; }
-
-    /**
-     * Initializes the relation from the id
-     *
-     * @param relManager The relation manager to use for the initialization
-     * @return true if the relation was found in the relationmanager
-     */
-    bool init( QgsRelationManager *relManager );
-
-  private:
-    QString mRelationId;
-    QgsRelation mRelation;
-};
 
 
 struct CORE_EXPORT QgsVectorJoinInfo
@@ -630,7 +386,10 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
     Q_OBJECT
 
   public:
-    /** The different types to layout the attribute editor. */
+
+    typedef QgsEditFormConfig::GroupData GroupData;
+    typedef QgsEditFormConfig::TabData TabData;
+
     enum EditorLayout
     {
       GeneratedLayout = 0,
@@ -638,47 +397,10 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
       UiFileLayout = 2
     };
 
-    /**
-     * @deprecated Use the editorWidgetV2() system instead
-     */
-    enum EditType
-    {
-      LineEdit,
-      UniqueValues,
-      UniqueValuesEditable,
-      ValueMap,
-      Classification,
-      EditRange,
-      SliderRange,
-      CheckBox,
-      FileName,
-      Enumeration,
-      Immutable,      /**< The attribute value should not be changed in the attribute form */
-      Hidden,         /**< The attribute value should not be shown in the attribute form */
-      TextEdit,       /**< multiline edit */
-      Calendar,       /**< calendar widget */
-      DialRange,      /**< dial range */
-      ValueRelation,  /**< value map from an table */
-      UuidGenerator,  /**< uuid generator - readonly and automatically intialized */
-      Photo,          /**< phote widget */
-      WebView,        /**< webview widget */
-      Color,          /**< color */
-      EditorWidgetV2, /**< modularized edit widgets @note added in 2.1 */
-    };
-
-    /** Types of feature form suppression after feature creation
-     * @note added in 2.1 */
-    enum FeatureFormSuppress
-    {
-      SuppressDefault = 0, // use the application-wide setting
-      SuppressOn = 1,
-      SuppressOff = 2
-    };
-
     struct RangeData
     {
-      RangeData() { mMin = QVariant( 0 ); mMax = QVariant( 5 ); mStep = QVariant( 1 );}
-      RangeData( const QVariant& theMin, const QVariant& theMax, const QVariant& theStep )
+      Q_DECL_DEPRECATED RangeData() { mMin = QVariant( 0 ); mMax = QVariant( 5 ); mStep = QVariant( 1 );}
+      Q_DECL_DEPRECATED RangeData( const QVariant& theMin, const QVariant& theMax, const QVariant& theStep )
           : mMin( theMin ), mMax( theMax ), mStep( theStep ) {}
 
       QVariant mMin;
@@ -710,23 +432,44 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
       bool mAllowMulti;  /* allow selection of multiple keys */
     };
 
-    struct GroupData
+    /**
+     * Types of feature form suppression after feature creation
+     * @note added in 2.1
+     * @deprecated in 2.14, Use QgsEditFormConfig instead
+     */
+    enum FeatureFormSuppress
     {
-      GroupData() {}
-      GroupData( const QString& name, const QList<QString>& fields )
-          : mName( name ), mFields( fields ) {}
-      QString mName;
-      QList<QString> mFields;
+      SuppressDefault = 0, // use the application-wide setting
+      SuppressOn = 1,
+      SuppressOff = 2
     };
 
-    struct TabData
+    /**
+     * @deprecated Use the editorWidgetV2() system instead
+     */
+    enum EditType
     {
-      TabData() {}
-      TabData( const QString& name, const QList<QString>& fields, const QList<GroupData>& groups )
-          : mName( name ), mFields( fields ), mGroups( groups ) {}
-      QString mName;
-      QList<QString> mFields;
-      QList<GroupData> mGroups;
+      LineEdit,
+      UniqueValues,
+      UniqueValuesEditable,
+      ValueMap,
+      Classification,
+      EditRange,
+      SliderRange,
+      CheckBox,
+      FileName,
+      Enumeration,
+      Immutable,      /**< The attribute value should not be changed in the attribute form */
+      Hidden,         /**< The attribute value should not be shown in the attribute form */
+      TextEdit,       /**< multiline edit */
+      Calendar,       /**< calendar widget */
+      DialRange,      /**< dial range */
+      ValueRelation,  /**< value map from an table */
+      UuidGenerator,  /**< uuid generator - readonly and automatically intialized */
+      Photo,          /**< phote widget */
+      WebView,        /**< webview widget */
+      Color,          /**< color */
+      EditorWidgetV2, /**< modularized edit widgets @note added in 2.1 */
     };
 
     /** Constructor - creates a vector layer
@@ -1429,7 +1172,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
     /**
      * Adds a tab (for the attribute editor form) holding groups and fields
      */
-    void addAttributeEditorWidget( QgsAttributeEditorElement* data );
+    Q_DECL_DEPRECATED void addAttributeEditorWidget( QgsAttributeEditorElement* data ) {mEditFormConfig->addTab( data );}
 
     /**
      * Get the id for the editor widget used to represent the field at the given index
@@ -1438,7 +1181,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
      *
      * @return The id for the editor widget or a NULL string if not applicable
      */
-    const QString editorWidgetV2( int fieldIdx ) const;
+    Q_DECL_DEPRECATED const QString editorWidgetV2( int fieldIdx ) const { return mEditFormConfig->widgetType( fieldIdx ); }
 
     /**
      * Get the id for the editor widget used to represent the field at the given index
@@ -1449,7 +1192,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
      *
      * @note python method name editorWidgetV2ByName
      */
-    const QString editorWidgetV2( const QString& fieldName ) const;
+    Q_DECL_DEPRECATED const QString editorWidgetV2( const QString& fieldName ) const { return mEditFormConfig->widgetType( fieldName ); }
 
     /**
      * Get the configuration for the editor widget used to represent the field at the given index
@@ -1458,7 +1201,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
      *
      * @return The configuration for the editor widget or an empty config if the field does not exist
      */
-    const QgsEditorWidgetConfig editorWidgetV2Config( int fieldIdx ) const;
+    Q_DECL_DEPRECATED const QgsEditorWidgetConfig editorWidgetV2Config( int fieldIdx ) const { return mEditFormConfig->widgetConfig( fieldIdx ); }
 
     /**
      * Get the configuration for the editor widget used to represent the field with the given name
@@ -1469,16 +1212,25 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
      *
      * @note python method name is editorWidgetV2ConfigByName
      */
-    const QgsEditorWidgetConfig editorWidgetV2Config( const QString& fieldName ) const;
+    Q_DECL_DEPRECATED const QgsEditorWidgetConfig editorWidgetV2Config( const QString& fieldName ) const { return mEditFormConfig->widgetConfig( fieldName ); }
 
     /**
      * Returns a list of tabs holding groups and fields
      */
-    QList< QgsAttributeEditorElement* > &attributeEditorElements();
+    Q_DECL_DEPRECATED QList< QgsAttributeEditorElement* > attributeEditorElements() { return mEditFormConfig->tabs(); }
+
+    /**
+     * Get the configuration of the form used to represent this vector layer.
+     * This is a writable configuration that can directly be changed in place.
+     *
+     * @return The configuration of this layers' form
+     */
+    QgsEditFormConfig* editFormConfig() const { return mEditFormConfig; }
+
     /**
      * Clears all the tabs for the attribute editor form
      */
-    void clearAttributeEditorWidgets();
+    void clearAttributeEditorWidgets() { mEditFormConfig->clearTabs(); }
 
     /** Returns the alias of an attribute name or an empty string if there is no alias */
     QString attributeAlias( int attributeIndex ) const;
@@ -1550,10 +1302,10 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
     Q_DECL_DEPRECATED void setEditType( int idx, EditType edit );
 
     /** Get the active layout for the attribute editor for this layer */
-    EditorLayout editorLayout();
+    Q_DECL_DEPRECATED EditorLayout editorLayout() { return ( EditorLayout )mEditFormConfig->layout(); }
 
     /** Set the active layout for the attribute editor for this layer */
-    void setEditorLayout( EditorLayout editorLayout );
+    Q_DECL_DEPRECATED void setEditorLayout( EditorLayout editorLayout ) { mEditFormConfig->setLayout(( QgsEditFormConfig::EditorLayout )editorLayout ); }
 
     /**
      * Set the editor widget type for a field
@@ -1583,7 +1335,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
      * @param attrIdx     Index of the field
      * @param widgetType  Type id of the editor widget to use
      */
-    void setEditorWidgetV2( int attrIdx, const QString& widgetType );
+    Q_DECL_DEPRECATED void setEditorWidgetV2( int attrIdx, const QString& widgetType ) { mEditFormConfig->setWidgetType( attrIdx, widgetType ); }
 
     /**
      * Set the editor widget config for a field.
@@ -1600,7 +1352,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
      *
      * @see setEditorWidgetV2() for a list of widgets and choose the widget to see the available options.
      */
-    void setEditorWidgetV2Config( int attrIdx, const QgsEditorWidgetConfig& config );
+    Q_DECL_DEPRECATED void setEditorWidgetV2Config( int attrIdx, const QgsEditorWidgetConfig& config ) { mEditFormConfig->setWidgetConfig( attrIdx, config ); }
 
     /**
      * Set string representing 'true' for a checkbox
@@ -1610,18 +1362,18 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
     Q_DECL_DEPRECATED void setCheckedState( int idx, const QString& checked, const QString& notChecked );
 
     /** Get edit form */
-    QString editForm();
+    Q_DECL_DEPRECATED QString editForm() const { return mEditFormConfig->uiForm(); }
 
     /** Set edit form */
-    void setEditForm( const QString& ui );
+    Q_DECL_DEPRECATED void setEditForm( const QString& ui ) { mEditFormConfig->setUiForm( ui ); }
 
     /** Type of feature form pop-up suppression after feature creation (overrides app setting)
      * @note added in 2.1 */
-    QgsVectorLayer::FeatureFormSuppress featureFormSuppress() const { return mFeatureFormSuppress; }
+    Q_DECL_DEPRECATED QgsVectorLayer::FeatureFormSuppress featureFormSuppress() const { return ( FeatureFormSuppress )mEditFormConfig->suppress(); }
 
     /** Set type of feature form pop-up suppression after feature creation (overrides app setting)
      * @note added in 2.1 */
-    void setFeatureFormSuppress( QgsVectorLayer::FeatureFormSuppress s ) { mFeatureFormSuppress = s; }
+    Q_DECL_DEPRECATED void setFeatureFormSuppress( QgsVectorLayer::FeatureFormSuppress s ) { mEditFormConfig->setSuppress(( QgsEditFormConfig::FeatureFormSuppress )s ); }
 
     /** Get annotation form */
     QString annotationForm() const { return mAnnotationForm; }
@@ -1630,22 +1382,10 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
     void setAnnotationForm( const QString& ui );
 
     /** Get python function for edit form initialization */
-    QString editFormInit();
-
-    /** Get python code for edit form initialization */
-    QString editFormInitCode();
-
-    /** Reeturn if python code has to be loaded for edit form initialization */
-    bool editFormInitUseCode();
+    Q_DECL_DEPRECATED QString editFormInit() const { return mEditFormConfig->initFunction(); }
 
     /** Set python function for edit form initialization */
-    void setEditFormInit( const QString& function );
-
-    /** Set python code for edit form initialization */
-    void setEditFormInitCode( const QString& code );
-
-    /** Set python code for edit form initialization */
-    void setEditFormInitUseCode( const bool useCode );
+    Q_DECL_DEPRECATED void setEditFormInit( const QString& function ) { mEditFormConfig->setInitFunction( function ); }
 
     /**
      * Access value map
@@ -1686,16 +1426,16 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
     Q_DECL_DEPRECATED QSize widgetSize( int idx );
 
     /** Is edit widget editable **/
-    bool fieldEditable( int idx );
+    Q_DECL_DEPRECATED bool fieldEditable( int idx ) { return mEditFormConfig->fieldEditable( idx ); }
 
     /** Label widget on top **/
-    bool labelOnTop( int idx );
+    Q_DECL_DEPRECATED bool labelOnTop( int idx ) { return mEditFormConfig->labelOnTop( idx ); }
 
     /** Set edit widget editable **/
-    void setFieldEditable( int idx, bool editable );
+    Q_DECL_DEPRECATED void setFieldEditable( int idx, bool editable ) { mEditFormConfig->setFieldEditable( idx, editable ); }
 
     /** Label widget on top **/
-    void setLabelOnTop( int idx, bool onTop );
+    Q_DECL_DEPRECATED void setLabelOnTop( int idx, bool onTop ) { mEditFormConfig->setLabelOnTop( idx, onTop ); }
 
     //! Buffer with uncommitted editing operations. Only valid after editing has been turned on.
     QgsVectorLayerEditBuffer* editBuffer() { return mEditBuffer; }
@@ -2029,7 +1769,6 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
     void writeCustomSymbology( QDomElement& element, QDomDocument& doc, QString& errorMessage ) const;
 
   private slots:
-    void onRelationsLoaded();
     void onJoinedFieldsChanged();
     void onFeatureDeleted( const QgsFeatureId& fid );
 
@@ -2110,16 +1849,14 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
     /** Map that stores the aliases for attributes. Key is the attribute name and value the alias for that attribute*/
     QMap< QString, QString > mAttributeAliasMap;
 
-    /** Stores a list of attribute editor elements (Each holding a tree structure for a tab in the attribute editor)*/
-    QList< QgsAttributeEditorElement* > mAttributeEditorElements;
+    /** Holds the configuration for the edit form */
+    QgsEditFormConfig* mEditFormConfig;
 
     /** Attributes which are not published in WMS*/
     QSet<QString> mExcludeAttributesWMS;
+
     /** Attributes which are not published in WFS*/
     QSet<QString> mExcludeAttributesWFS;
-
-    /** Map that stores the tab for attributes in the edit form. Key is the tab order and value the tab name*/
-    QList< TabData > mTabs;
 
     /** Geometry type as defined in enum WkbType (qgis.h) */
     QGis::WkbType mWkbType;
@@ -2153,23 +1890,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
 
     QStringList mCommitErrors;
 
-    QMap< QString, bool> mFieldEditables;
-    QMap< QString, bool> mLabelOnTop;
-
-    QMap<QString, QString> mEditorWidgetV2Types;
-    QMap<QString, QgsEditorWidgetConfig > mEditorWidgetV2Configs;
-
-    /** Defines the default layout to use for the attribute editor (Drag and drop, UI File, Generated) */
-    EditorLayout mEditorLayout;
-
-    QString mEditForm, mEditFormInit, mEditFormInitCode;
-    bool mEditFormInitUseCode;
-
-    /** Type of feature form suppression after feature creation
-     * @note added in 2.1 */
-    QgsVectorLayer::FeatureFormSuppress mFeatureFormSuppress;
-
-    //annotation form for this layer
+    //! Annotation form for this layer
     QString mAnnotationForm;
 
     //! cache for some vector layer data - currently only geometries for faster editing

--- a/src/gui/attributetable/qgsattributetabledelegate.cpp
+++ b/src/gui/attributetable/qgsattributetabledelegate.cpp
@@ -75,7 +75,7 @@ QWidget *QgsAttributeTableDelegate::createEditor(
 
   w->setAutoFillBackground( true );
 
-  eww->setEnabled( vl->editFormConfig()->fieldEditable( fieldIdx ) );
+  eww->setEnabled( !vl->editFormConfig()->readOnly( fieldIdx ) );
 
   return w;
 }

--- a/src/gui/attributetable/qgsattributetabledelegate.cpp
+++ b/src/gui/attributetable/qgsattributetabledelegate.cpp
@@ -67,15 +67,15 @@ QWidget *QgsAttributeTableDelegate::createEditor(
 
   int fieldIdx = index.model()->data( index, QgsAttributeTableModel::FieldIndexRole ).toInt();
 
-  QString widgetType = vl->editorWidgetV2( fieldIdx );
-  QgsEditorWidgetConfig cfg = vl->editorWidgetV2Config( fieldIdx );
+  QString widgetType = vl->editFormConfig()->widgetType( fieldIdx );
+  QgsEditorWidgetConfig cfg = vl->editFormConfig()->widgetConfig( fieldIdx );
   QgsAttributeEditorContext context( masterModel( index.model() )->editorContext(), QgsAttributeEditorContext::Popup );
   QgsEditorWidgetWrapper* eww = QgsEditorWidgetRegistry::instance()->create( widgetType, vl, fieldIdx, cfg, 0, parent, context );
   QWidget* w = eww->widget();
 
   w->setAutoFillBackground( true );
 
-  eww->setEnabled( vl->fieldEditable( fieldIdx ) );
+  eww->setEnabled( vl->editFormConfig()->fieldEditable( fieldIdx ) );
 
   return w;
 }

--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -304,12 +304,12 @@ void QgsAttributeTableModel::loadAttributes()
 
   for ( int idx = 0; idx < fields.count(); ++idx )
   {
-    const QString widgetType = layer()->editorWidgetV2( idx );
+    const QString widgetType = layer()->editFormConfig()->widgetType( idx );
     QgsEditorWidgetFactory* widgetFactory = QgsEditorWidgetRegistry::instance()->factory( widgetType );
     if ( widgetFactory && widgetType != "Hidden" )
     {
       mWidgetFactories.append( widgetFactory );
-      mWidgetConfigs.append( layer()->editorWidgetV2Config( idx ) );
+      mWidgetConfigs.append( layer()->editFormConfig()->widgetConfig( idx ) );
       mAttributeWidgetCaches.append( widgetFactory->createCache( layer(), idx, mWidgetConfigs.last() ) );
 
       attributes << idx;
@@ -681,7 +681,7 @@ Qt::ItemFlags QgsAttributeTableModel::flags( const QModelIndex &index ) const
   Qt::ItemFlags flags = QAbstractItemModel::flags( index );
 
   if ( layer()->isEditable() &&
-       layer()->fieldEditable( mAttributes[ index.column()] ) &&
+       layer()->editFormConfig()->fieldEditable( mAttributes[ index.column()] ) &&
        (( layer()->dataProvider() && layer()->dataProvider()->capabilities() & QgsVectorDataProvider::ChangeAttributeValues ) ||
         FID_IS_NEW( rowToId( index.row() ) ) ) )
     flags |= Qt::ItemIsEditable;

--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -681,7 +681,7 @@ Qt::ItemFlags QgsAttributeTableModel::flags( const QModelIndex &index ) const
   Qt::ItemFlags flags = QAbstractItemModel::flags( index );
 
   if ( layer()->isEditable() &&
-       layer()->editFormConfig()->fieldEditable( mAttributes[ index.column()] ) &&
+       !layer()->editFormConfig()->readOnly( mAttributes[ index.column()] ) &&
        (( layer()->dataProvider() && layer()->dataProvider()->capabilities() & QgsVectorDataProvider::ChangeAttributeValues ) ||
         FID_IS_NEW( rowToId( index.row() ) ) ) )
     flags |= Qt::ItemIsEditable;

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -165,7 +165,7 @@ void QgsDualView::columnBoxInit()
     if ( fieldIndex == -1 )
       continue;
 
-    if ( mLayerCache->layer()->editorWidgetV2( fieldIndex ) != "Hidden" )
+    if ( mLayerCache->layer()->editFormConfig()->widgetType( fieldIndex ) != "Hidden" )
     {
       QIcon icon = QgsApplication::getThemeIcon( "/mActionNewAttribute.png" );
       QString text = field.name();

--- a/src/gui/editorwidgets/core/qgseditorwidgetregistry.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetregistry.cpp
@@ -245,7 +245,7 @@ void QgsEditorWidgetRegistry::readMapLayer( QgsMapLayer* mapLayer, const QDomEle
         cfg = mWidgetFactories[ewv2Type]->readEditorConfig( ewv2CfgElem, vectorLayer, idx );
       }
 
-      vectorLayer->editFormConfig()->setFieldEditable( idx, ewv2CfgElem.attribute( "fieldEditable", "1" ) == "1" );
+      vectorLayer->editFormConfig()->setReadOnly( idx, ewv2CfgElem.attribute( "fieldEditable", "1" ) != "1" );
       vectorLayer->editFormConfig()->setLabelOnTop( idx, ewv2CfgElem.attribute( "labelOnTop", "0" ) == "1" );
       vectorLayer->editFormConfig()->setWidgetConfig( idx, cfg );
     }
@@ -301,7 +301,7 @@ void QgsEditorWidgetRegistry::writeMapLayer( QgsMapLayer* mapLayer, QDomElement&
     if ( mWidgetFactories.contains( widgetType ) )
     {
       QDomElement ewv2CfgElem = doc.createElement( "widgetv2config" );
-      ewv2CfgElem.setAttribute( "fieldEditable", vectorLayer->editFormConfig()->fieldEditable( idx ) );
+      ewv2CfgElem.setAttribute( "fieldEditable", !vectorLayer->editFormConfig()->readOnly( idx ) );
       ewv2CfgElem.setAttribute( "labelOnTop", vectorLayer->editFormConfig()->labelOnTop( idx ) );
 
       mWidgetFactories[widgetType]->writeConfig( vectorLayer->editFormConfig()->widgetConfig( idx ), ewv2CfgElem, doc, vectorLayer, idx );

--- a/src/gui/editorwidgets/core/qgseditorwidgetregistry.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetregistry.cpp
@@ -237,7 +237,7 @@ void QgsEditorWidgetRegistry::readMapLayer( QgsMapLayer* mapLayer, const QDomEle
 
     if ( mWidgetFactories.contains( ewv2Type ) )
     {
-      vectorLayer->setEditorWidgetV2( idx, ewv2Type );
+      vectorLayer->editFormConfig()->setWidgetType( idx, ewv2Type );
       QDomElement ewv2CfgElem = editTypeElement.namedItem( "widgetv2config" ).toElement();
 
       if ( !ewv2CfgElem.isNull() )
@@ -245,9 +245,9 @@ void QgsEditorWidgetRegistry::readMapLayer( QgsMapLayer* mapLayer, const QDomEle
         cfg = mWidgetFactories[ewv2Type]->readEditorConfig( ewv2CfgElem, vectorLayer, idx );
       }
 
-      vectorLayer->setFieldEditable( idx, ewv2CfgElem.attribute( "fieldEditable", "1" ) == "1" );
-      vectorLayer->setLabelOnTop( idx, ewv2CfgElem.attribute( "labelOnTop", "0" ) == "1" );
-      vectorLayer->setEditorWidgetV2Config( idx, cfg );
+      vectorLayer->editFormConfig()->setFieldEditable( idx, ewv2CfgElem.attribute( "fieldEditable", "1" ) == "1" );
+      vectorLayer->editFormConfig()->setLabelOnTop( idx, ewv2CfgElem.attribute( "labelOnTop", "0" ) == "1" );
+      vectorLayer->editFormConfig()->setWidgetConfig( idx, cfg );
     }
     else
     {
@@ -286,7 +286,7 @@ void QgsEditorWidgetRegistry::writeMapLayer( QgsMapLayer* mapLayer, QDomElement&
   for ( int idx = 0; idx < fields.count(); ++idx )
   {
     const QgsField &field = fields.at( idx );
-    const QString& widgetType = vectorLayer->editorWidgetV2( idx );
+    const QString& widgetType = vectorLayer->editFormConfig()->widgetType( idx );
     if ( !mWidgetFactories.contains( widgetType ) )
     {
       QgsMessageLog::logMessage( tr( "Could not save unknown editor widget type '%1'." ).arg( widgetType ) );
@@ -301,10 +301,10 @@ void QgsEditorWidgetRegistry::writeMapLayer( QgsMapLayer* mapLayer, QDomElement&
     if ( mWidgetFactories.contains( widgetType ) )
     {
       QDomElement ewv2CfgElem = doc.createElement( "widgetv2config" );
-      ewv2CfgElem.setAttribute( "fieldEditable", vectorLayer->fieldEditable( idx ) );
-      ewv2CfgElem.setAttribute( "labelOnTop", vectorLayer->labelOnTop( idx ) );
+      ewv2CfgElem.setAttribute( "fieldEditable", vectorLayer->editFormConfig()->fieldEditable( idx ) );
+      ewv2CfgElem.setAttribute( "labelOnTop", vectorLayer->editFormConfig()->labelOnTop( idx ) );
 
-      mWidgetFactories[widgetType]->writeConfig( vectorLayer->editorWidgetV2Config( idx ), ewv2CfgElem, doc, vectorLayer, idx );
+      mWidgetFactories[widgetType]->writeConfig( vectorLayer->editFormConfig()->widgetConfig( idx ), ewv2CfgElem, doc, vectorLayer, idx );
 
       editTypeElement.appendChild( ewv2CfgElem );
     }

--- a/src/gui/qgsattributeeditor.cpp
+++ b/src/gui/qgsattributeeditor.cpp
@@ -43,8 +43,8 @@ QWidget *QgsAttributeEditor::createAttributeEditor( QWidget *parent, QWidget *ed
 
 QWidget* QgsAttributeEditor::createAttributeEditor( QWidget* parent, QWidget* editor, QgsVectorLayer* vl, int idx, const QVariant& value, QgsAttributeEditorContext& context )
 {
-  QString widgetType = vl->editorWidgetV2( idx );
-  QgsEditorWidgetConfig cfg = vl->editorWidgetV2Config( idx );
+  QString widgetType = vl->editFormConfig()->widgetType( idx );
+  QgsEditorWidgetConfig cfg = vl->editFormConfig()->widgetConfig( idx );
 
   QgsEditorWidgetWrapper* eww = QgsEditorWidgetRegistry::instance()->create( widgetType, vl, idx, cfg, editor, parent, context );
 

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -175,7 +175,7 @@ bool QgsAttributeForm::save()
         QVariant srcVar = eww->value();
         // need to check dstVar.isNull() != srcVar.isNull()
         // otherwise if dstVar=NULL and scrVar=0, then dstVar = srcVar
-        if (( dstVar != srcVar || dstVar.isNull() != srcVar.isNull() ) && srcVar.isValid() && mLayer->editFormConfig()->fieldEditable( eww->fieldIdx() ) )
+        if (( dstVar != srcVar || dstVar.isNull() != srcVar.isNull() ) && srcVar.isValid() && !mLayer->editFormConfig()->readOnly( eww->fieldIdx() ) )
         {
           dst[eww->fieldIdx()] = srcVar;
 
@@ -220,7 +220,7 @@ bool QgsAttributeForm::save()
         {
           if (( dst.at( i ) == src.at( i ) && dst.at( i ).isNull() == src.at( i ).isNull() )  // If field is not changed...
               || !dst.at( i ).isValid()                                     // or the widget returns invalid (== do not change)
-              || !mLayer->editFormConfig()->fieldEditable( i ) )                           // or the field cannot be edited ...
+              || mLayer->editFormConfig()->readOnly( i ) )                           // or the field cannot be edited ...
           {
             continue;
           }
@@ -367,7 +367,7 @@ void QgsAttributeForm::synchronizeEnabledState()
     QgsEditorWidgetWrapper* eww = qobject_cast<QgsEditorWidgetWrapper*>( ww );
     if ( eww )
     {
-      fieldEditable = mLayer->editFormConfig()->fieldEditable( eww->fieldIdx() ) &&
+      fieldEditable = !mLayer->editFormConfig()->readOnly( eww->fieldIdx() ) &&
                       (( mLayer->dataProvider() && layer()->dataProvider()->capabilities() & QgsVectorDataProvider::ChangeAttributeValues ) ||
                        FID_IS_NEW( mFeature.id() ) );
     }

--- a/src/plugins/geometry_checker/ui/qgsgeometrycheckerresulttab.cpp
+++ b/src/plugins/geometry_checker/ui/qgsgeometrycheckerresulttab.cpp
@@ -78,7 +78,7 @@ QgsGeometryCheckerResultTab::QgsGeometryCheckerResultTab( QgisInterface* iface, 
 QgsGeometryCheckerResultTab::~QgsGeometryCheckerResultTab()
 {
   if ( mFeaturePool->getLayer() )
-    mFeaturePool->getLayer()->setReadOnly( false );
+    mFeaturePool->getLayer()->setFieldEditable( false );
   delete mChecker;
   delete mFeaturePool;
   qDeleteAll( mCurrentRubberBands );

--- a/src/plugins/geometry_checker/ui/qgsgeometrycheckersetuptab.cpp
+++ b/src/plugins/geometry_checker/ui/qgsgeometrycheckersetuptab.cpp
@@ -286,7 +286,7 @@ void QgsGeometryCheckerSetupTab::runChecks()
   emit checkerStarted( checker, featurePool );
 
   /** Add result layer (do this after checkerStarted, otherwise warning about removing of result layer may appear) **/
-  layer->setReadOnly( true );
+  layer->setFieldEditable( true );
   if ( ui.radioButtonOutputNew->isChecked() )
   {
     QgsMapLayerRegistry::instance()->addMapLayers( QList<QgsMapLayer*>() << layer );

--- a/src/plugins/geometry_snapper/qgsgeometrysnapperdialog.cpp
+++ b/src/plugins/geometry_snapper/qgsgeometrysnapperdialog.cpp
@@ -261,7 +261,7 @@ void QgsGeometrySnapperDialog::run()
     }
   }
 
-  layer->setReadOnly( true );
+  layer->setFieldEditable( true );
   if ( ui.radioButtonOutputNew->isChecked() )
   {
     QgsMapLayerRegistry::instance()->addMapLayers( QList<QgsMapLayer*>() << layer );
@@ -294,7 +294,7 @@ void QgsGeometrySnapperDialog::run()
   ui.progressBar->hide();
   ui.widgetInputs->setEnabled( true );
 
-  layer->setReadOnly( false );
+  layer->setFieldEditable( false );
 
   /** Refresh canvas **/
   mIface->mapCanvas()->refresh();

--- a/src/plugins/grass/qgsgrassplugin.cpp
+++ b/src/plugins/grass/qgsgrassplugin.cpp
@@ -401,7 +401,7 @@ void QgsGrassPlugin::onEditingStarted()
     return;
 
   mOldStyles[vectorLayer] = vectorLayer->styleManager()->currentStyle();
-  mFormSuppress[vectorLayer] = vectorLayer->featureFormSuppress();
+  mFormSuppress[vectorLayer] = vectorLayer->editFormConfig()->suppress();
 
   // Because the edit style may be stored to project:
   // - do not translate because it may be loaded in QGIS running with different language
@@ -494,7 +494,7 @@ void QgsGrassPlugin::addFeature()
     QgsDebugMsg( "grassProvider is null" );
     return;
   }
-  QgsVectorLayer::FeatureFormSuppress formSuppress = mFormSuppress.value( vectorLayer );
+  QgsEditFormConfig::FeatureFormSuppress formSuppress = mFormSuppress.value( vectorLayer );
   if ( sender() == mAddPointAction )
   {
     qGisInterface->mapCanvas()->setMapTool( mAddPoint );
@@ -509,7 +509,7 @@ void QgsGrassPlugin::addFeature()
   {
     qGisInterface->mapCanvas()->setMapTool( mAddBoundary );
     grassProvider->setNewFeatureType( GV_BOUNDARY );
-    formSuppress = QgsVectorLayer::SuppressOn;
+    formSuppress = QgsEditFormConfig::SuppressOn;
   }
   else if ( sender() == mAddCentroidAction )
   {
@@ -520,9 +520,9 @@ void QgsGrassPlugin::addFeature()
   {
     qGisInterface->mapCanvas()->setMapTool( mAddArea );
     grassProvider->setNewFeatureType( GV_AREA );
-    formSuppress = QgsVectorLayer::SuppressOn;
+    formSuppress = QgsEditFormConfig::SuppressOn;
   }
-  vectorLayer->setFeatureFormSuppress( formSuppress );
+  vectorLayer->editFormConfig()->setSuppress( formSuppress );
 }
 
 void QgsGrassPlugin::onSplitFeaturesTriggered( bool checked )

--- a/src/plugins/grass/qgsgrassplugin.h
+++ b/src/plugins/grass/qgsgrassplugin.h
@@ -178,7 +178,7 @@ class QgsGrassPlugin : public QObject, public QgisPlugin
     // Names of layer styles before editing started
     QMap<QgsVectorLayer *, QString> mOldStyles;
     // Original layer form suppress
-    QMap<QgsVectorLayer *, QgsVectorLayer::FeatureFormSuppress> mFormSuppress;
+    QMap<QgsVectorLayer *, QgsEditFormConfig::FeatureFormSuppress> mFormSuppress;
 };
 
 #endif // QGSGRASSPLUGIN_H

--- a/src/providers/grass/qgsgrassprovider.cpp
+++ b/src/providers/grass/qgsgrassprovider.cpp
@@ -1138,8 +1138,8 @@ void QgsGrassProvider::startEditing( QgsVectorLayer *vectorLayer )
 
   // TODO: enable cats editing once all consequences are implemented
   // disable cat and topo symbol editing
-  vectorLayer->setFieldEditable( mLayer->keyColumn(), false );
-  vectorLayer->setFieldEditable( mLayer->fields().size() - 1, false );
+  vectorLayer->editFormConfig()->setFieldEditable( mLayer->keyColumn(), false );
+  vectorLayer->editFormConfig()->setFieldEditable( mLayer->fields().size() - 1, false );
 
   mEditedCount++;
 

--- a/src/providers/grass/qgsgrassprovider.cpp
+++ b/src/providers/grass/qgsgrassprovider.cpp
@@ -1138,8 +1138,8 @@ void QgsGrassProvider::startEditing( QgsVectorLayer *vectorLayer )
 
   // TODO: enable cats editing once all consequences are implemented
   // disable cat and topo symbol editing
-  vectorLayer->editFormConfig()->setFieldEditable( mLayer->keyColumn(), false );
-  vectorLayer->editFormConfig()->setFieldEditable( mLayer->fields().size() - 1, false );
+  vectorLayer->editFormConfig()->setReadOnly( mLayer->keyColumn(), true );
+  vectorLayer->editFormConfig()->setReadOnly( mLayer->fields().size() - 1, true );
 
   mEditedCount++;
 

--- a/src/server/qgsserverprojectparser.cpp
+++ b/src/server/qgsserverprojectparser.cpp
@@ -744,7 +744,7 @@ void QgsServerProjectParser::addLayerProjectSettings( QDomElement& layerElem, QD
       }
 
       //edit type to text
-      attributeElem.setAttribute( "editType", vLayer->editorWidgetV2( idx ) );
+      attributeElem.setAttribute( "editType", vLayer->editFormConfig()->widgetType( idx ) );
       attributeElem.setAttribute( "comment", field.comment() );
       attributeElem.setAttribute( "length", field.length() );
       attributeElem.setAttribute( "precision", field.precision() );
@@ -1423,10 +1423,10 @@ void QgsServerProjectParser::addValueRelationLayersForLayer( const QgsVectorLaye
 
   for ( int idx = 0; idx < vl->pendingFields().size(); idx++ )
   {
-    if ( vl->editorWidgetV2( idx ) != "ValueRelation" )
+    if ( vl->editFormConfig()->widgetType( idx ) != "ValueRelation" )
       continue;
 
-    QgsEditorWidgetConfig cfg( vl->editorWidgetV2Config( idx ) );
+    QgsEditorWidgetConfig cfg( vl->editFormConfig()->widgetConfig( idx ) );
     if ( !cfg.contains( "Layer" ) )
       continue;
 

--- a/src/server/qgswmsserver.cpp
+++ b/src/server/qgswmsserver.cpp
@@ -3115,9 +3115,9 @@ QDomElement QgsWMSServer::createFeatureGML(
 
 QString QgsWMSServer::replaceValueMapAndRelation( QgsVectorLayer* vl, int idx, const QString& attributeVal )
 {
-  if ( QgsEditorWidgetFactory *factory = QgsEditorWidgetRegistry::instance()->factory( vl->editorWidgetV2( idx ) ) )
+  if ( QgsEditorWidgetFactory *factory = QgsEditorWidgetRegistry::instance()->factory( vl->editFormConfig()->widgetType( idx ) ) )
   {
-    QgsEditorWidgetConfig cfg( vl->editorWidgetV2Config( idx ) );
+    QgsEditorWidgetConfig cfg( vl->editFormConfig()->widgetConfig( idx ) );
     QString value( factory->representValue( vl, idx, cfg, QVariant(), attributeVal ) );
     if ( cfg.value( "AllowMulti" ).toBool() && value.startsWith( "{" ) && value.endsWith( "}" ) )
     {


### PR DESCRIPTION
The class QgsVectorLayer is terribly overcrowded.

This commit refactors everything related to the edit form out.

Instead of accessing

```
layer.labelOnTop(1)
```

You will now do

```
layer.editFormConfig().labelOnTop(1)
```

Some methods have been renamed in their new incarnation, because their scope in the edit form is implicit:

E.g.
`editFormInit` -> `initFunction`

The old methods are still there as deprecated functions, so code will just continue to work.
