### PR TITLE
[travis] Use newer clang 3.7 for linux builds

### DIFF
--- a/ci/travis/linux/before_install.sh
+++ b/ci/travis/linux/before_install.sh
@@ -1,9 +1,14 @@
 export DEBIAN_FRONTEND=noninteractive
+
+wget -O - http://llvm.org/apt/llvm-snapshot.gpg.key | sudo apt-key add -
+sudo add-apt-repository 'deb http://llvm.org/apt/precise/ llvm-toolchain-precise-3.7 main' -y
+
 sudo add-apt-repository ppa:ubuntugis/ppa -y
 sudo add-apt-repository ppa:ubuntugis/ubuntugis-unstable -y # For postgresql-9.1-postgis-2.1
 sudo add-apt-repository ppa:grass/grass-stable -y
 sudo add-apt-repository ppa:smspillaz/cmake-3.0.2 -y
 sudo add-apt-repository ppa:kedazo/doxygen-updates-precise -y # For doxygen 1.8.8
+sudo add-apt-repository ppa:ubuntu-toolchain-r/test -y
 sudo apt-get update -qq
 sudo apt-get install --force-yes --no-install-recommends --no-install-suggests \
         bison \
@@ -54,5 +59,11 @@ sudo apt-get install --force-yes --no-install-recommends --no-install-suggests \
         xfonts-scalable \
         xvfb \
         postgresql-9.1-postgis-2.1/precise # from ubuntugis-unstable, not pgdg
+
+#update clang
+sudo apt-get install --force-yes llvm-3.7 llvm-3.7-dev clang-3.7 libstdc++-4.9-dev
+export CXX="clang++-3.7" 
+export CC="clang-3.7"
+
 cmake --version
 clang --version

--- a/ci/travis/linux/install.sh
+++ b/ci/travis/linux/install.sh
@@ -1,5 +1,7 @@
 mkdir build
 cd build
+export CXX="clang++-3.7"
+export CC="clang-3.7"
 cmake -DWITH_SERVER=ON \
       -DWITH_STAGED_PLUGINS=OFF \
       -DWITH_GRASS=ON \


### PR DESCRIPTION
This PR switches the Travis linux builds to use the newer clang 3.7 release, instead of the previous 3.4 version. 3.7 brings some really nice warnings which would be good to catch before commit, like a "missing override" warning (see test run results here http://dash.orfeo-toolbox.org/viewBuildError.php?type=1&buildid=207994 ).

Hoping that it this will also make it possible to get coverage reports working properly on Travis too.
