### PR TITLE
[App] Do not instantiate dummy QCoreApplication object (fixes #3714)

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -520,13 +520,28 @@ int main( int argc, char *argv[] )
   QgsDebugMsg( QString( "Android: configpath set to %1" ).arg( configpath ) );
 #endif
 
+#if defined(Q_OS_UNIX) && !defined(Q_OS_MAC) && !defined(ANDROID)
+  bool myUseGuiFlag = nullptr != getenv( "DISPLAY" );
+#else
+  bool myUseGuiFlag = true;
+#endif
+  if ( !myUseGuiFlag )
+  {
+    std::cerr << QObject::tr(
+                "QGIS starting in non-interactive mode not supported.\n"
+                "You are seeing this message most likely because you "
+                "have no DISPLAY environment variable set.\n"
+              ).toUtf8().constData();
+    exit( 1 ); //exit for now until a version of qgis is capabable of running non interactive
+  }
+
+  QgsApplication myApp( argc, argv, myUseGuiFlag, QString(), "desktop", true );
   QStringList args;
 
   if ( !bundleclicked( argc, argv ) )
   {
     // Build a local QCoreApplication from arguments. This way, arguments are correctly parsed from their native locale
     // It will use QString::fromLocal8Bit( argv ) under Unix and GetCommandLine() under Windows.
-    QCoreApplication coreApp( argc, argv );
     args = QCoreApplication::arguments();
 
     for ( int i = 1; i < args.size(); ++i )
@@ -719,21 +734,6 @@ int main( int argc, char *argv[] )
   // Initialise the application and the translation stuff
   /////////////////////////////////////////////////////////////////////
 
-#if defined(Q_OS_UNIX) && !defined(Q_OS_MAC) && !defined(ANDROID)
-  bool myUseGuiFlag = nullptr != getenv( "DISPLAY" );
-#else
-  bool myUseGuiFlag = true;
-#endif
-  if ( !myUseGuiFlag )
-  {
-    std::cerr << QObject::tr(
-                "QGIS starting in non-interactive mode not supported.\n"
-                "You are seeing this message most likely because you "
-                "have no DISPLAY environment variable set.\n"
-              ).toUtf8().constData();
-    exit( 1 ); //exit for now until a version of qgis is capabable of running non interactive
-  }
-
   if ( !optionpath.isEmpty() || !configpath.isEmpty() )
   {
     // tell QSettings to use INI format and save the file in custom config path
@@ -748,7 +748,7 @@ int main( int argc, char *argv[] )
     QgsCustomization::instance()->setEnabled( false );
   }
 
-  QgsApplication myApp( argc, argv, myUseGuiFlag, configpath );
+  myApp.init( configpath );
 
   myApp.setWindowIcon( QIcon( QgsApplication::appIconPath() ) );
 

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -99,12 +99,13 @@ const char* QgsApplication::QGIS_APPLICATION_NAME = "QGIS2";
   so that platform-conditional code is minimized and paths are easier
   to change due to centralization.
 */
-QgsApplication::QgsApplication( int & argc, char ** argv, bool GUIenabled, const QString& customConfigPath, const QString& platformName )
+QgsApplication::QgsApplication( int & argc, char ** argv, bool GUIenabled, const QString& customConfigPath, const QString& platformName, bool initLater )
     : QApplication( argc, argv, GUIenabled )
 {
   sPlatformName = platformName;
 
-  init( customConfigPath ); // init can also be called directly by e.g. unit tests that don't inherit QApplication.
+  if ( !initLater )
+    init( customConfigPath ); // init can also be called directly by e.g. unit tests that don't inherit QApplication.
 }
 
 void QgsApplication::init( QString customConfigPath )

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -38,7 +38,16 @@ class CORE_EXPORT QgsApplication : public QApplication
     static const char* QGIS_ORGANIZATION_NAME;
     static const char* QGIS_ORGANIZATION_DOMAIN;
     static const char* QGIS_APPLICATION_NAME;
-    QgsApplication( int & argc, char ** argv, bool GUIenabled, const QString& customConfigPath = QString(), const QString& platformName = "desktop" );
+
+    /** Constructor
+        @param argc,argv command line arguments
+        @param GUIenabled set to true to construct a GUI application
+        @param customConfigPath passed to init() when @p initLater is set to false
+        @param platformName the name of the platform, will be returned by @p platform()
+        @param initLater set to true to skip the call to init() within the constructor
+        @note if you set @p initLater to true make sure to call init() before calling exec()
+      */
+    QgsApplication( int & argc, char ** argv, bool GUIenabled, const QString& customConfigPath = QString(), const QString& platformName = "desktop", bool initLater = false );
     virtual ~QgsApplication();
 
     /** This method initialises paths etc for QGIS. Called by the ctor or call it manually


### PR DESCRIPTION
This PR separates the instantiation of the `QgsApplication` object and the call to `QgsApplication.init()` thereby allowing to do the instantiation earlier in the initialization process and removing the need for a dummy `QCoreApplication` object.
By doing this all commandline arguments relevant for `QApplication` (e.g. _-reverse_) are hidden from QGIS and no warnings about unknown ~~arguments~~ layers are produced.

I am not a `QApplication` specialist, so could someone please verify that this does not have any unwanted side effects?
