### PR TITLE
[Bugfix] Avoid using copyStyle() / pasteStyle() within duplicateLayers()

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -7469,8 +7469,15 @@ void QgisApp::duplicateLayers( const QList<QgsMapLayer *>& lyrList )
     nodeDupLayer->setVisible( Qt::Unchecked );
 
     // duplicate the layer style
-    copyStyle( selectedLyr );
-    pasteStyle( dupLayer );
+    QString errMsg;
+    QDomDocument style;
+    selectedLyr->exportNamedStyle( style, errMsg );
+    if ( errMsg.isEmpty() )
+      dupLayer->importNamedStyle( style, errMsg );
+    if ( !errMsg.isEmpty() )
+      messageBar()->pushMessage( errMsg,
+                                 tr( "Cannot copy style to duplicated layer." ),
+                                 QgsMessageBar::CRITICAL, messageTimeout() );
 
     QgsVectorLayer* vLayer = dynamic_cast<QgsVectorLayer*>( selectedLyr );
     QgsVectorLayer* vDupLayer = dynamic_cast<QgsVectorLayer*>( dupLayer );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -6812,24 +6812,6 @@ void QgisApp::copyStyle( QgsMapLayer * sourceLayer )
     rootNode.setAttribute( "minimumScale", QString::number( selectionLayer->minimumScale() ) );
     rootNode.setAttribute( "maximumScale", QString::number( selectionLayer->maximumScale() ) );
 
-    /*
-     * Check to see if the layer is vector - in which case we should also copy its geometryType
-     * to avoid eventually pasting to a layer with a different geometry
-    */
-    if ( selectionLayer->type() == 0 )
-    {
-      //Getting the selectionLayer geometry
-      QgsVectorLayer *SelectionGeometry = static_cast<QgsVectorLayer*>( selectionLayer );
-      QString geoType = QString::number( SelectionGeometry->geometryType() );
-
-      //Adding geometryinformation
-      QDomElement layerGeometryType = doc.createElement( "layerGeometryType" );
-      QDomText type = doc.createTextNode( geoType );
-
-      layerGeometryType.appendChild( type );
-      rootNode.appendChild( layerGeometryType );
-    }
-
     QString errorMsg;
     if ( !selectionLayer->writeSymbology( rootNode, doc, errorMsg ) )
     {
@@ -6870,20 +6852,6 @@ void QgisApp::pasteStyle( QgsMapLayer * destinationLayer )
       }
 
       QDomElement rootNode = doc.firstChildElement( "qgis" );
-
-      //Test for matching geometry type on vector layers when pasting
-      if ( selectionLayer->type() == QgsMapLayer::VectorLayer )
-      {
-        QgsVectorLayer *selectionVectorLayer = static_cast<QgsVectorLayer*>( selectionLayer );
-        int pasteLayerGeometryType = doc.elementsByTagName( "layerGeometryType" ).item( 0 ).toElement().text().toInt();
-        if ( selectionVectorLayer->geometryType() != pasteLayerGeometryType )
-        {
-          messageBar()->pushMessage( tr( "Cannot paste style to layer with a different geometry type" ),
-                                     tr( "Your copied style does not match the layer you are pasting to" ),
-                                     QgsMessageBar::INFO, messageTimeout() );
-          return;
-        }
-      }
 
       if ( !selectionLayer->readSymbology( rootNode, errorMsg ) )
       {

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -1147,8 +1147,15 @@ QString QgsMapLayer::loadNamedStyle( const QString &theURI, bool &theResultFlag 
 
 bool QgsMapLayer::importNamedStyle( QDomDocument& myDocument, QString& myErrorMessage )
 {
+  QDomElement myRoot = myDocument.firstChildElement( "qgis" );
+  if ( myRoot.isNull() )
+  {
+    myErrorMessage = tr( "Root <qgis> element could not be found" );
+    return false;
+  }
+
   // get style file version string, if any
-  QgsProjectVersion fileVersion( myDocument.firstChildElement( "qgis" ).attribute( "version" ) );
+  QgsProjectVersion fileVersion( myRoot.attribute( "version" ) );
   QgsProjectVersion thisVersion( QGis::QGIS_VERSION );
 
   if ( thisVersion > fileVersion )
@@ -1162,15 +1169,6 @@ bool QgsMapLayer::importNamedStyle( QDomDocument& myDocument, QString& myErrorMe
     // styleFile.dump();
     styleFile.updateRevision( thisVersion );
     // styleFile.dump();
-  }
-
-  // now get the layer node out and pass it over to the layer
-  // to deserialise...
-  QDomElement myRoot = myDocument.firstChildElement( "qgis" );
-  if ( myRoot.isNull() )
-  {
-    myErrorMessage = tr( "Root <qgis> element could not be found" );
-    return false;
   }
 
   //Test for matching geometry type on vector layers when applying, if geometry type is given in the style

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -1173,6 +1173,18 @@ bool QgsMapLayer::importNamedStyle( QDomDocument& myDocument, QString& myErrorMe
     return false;
   }
 
+  //Test for matching geometry type on vector layers when applying, if geometry type is given in the style
+  if ( type() == QgsMapLayer::VectorLayer && !myRoot.firstChildElement( "layerGeometryType" ).isNull() )
+  {
+    QgsVectorLayer *vl = static_cast<QgsVectorLayer*>( this );
+    int importLayerGeometryType = myRoot.firstChildElement( "layerGeometryType" ).text().toInt();
+    if ( vl->geometryType() != importLayerGeometryType )
+    {
+      myErrorMessage = tr( "Cannot apply style to layer with a different geometry type" );
+      return false;
+    }
+  }
+
   // use scale dependent visibility flag
   setScaleBasedVisibility( myRoot.attribute( "hasScaleBasedVisibilityFlag" ).toInt() == 1 );
   setMinimumScale( myRoot.attribute( "minimumScale" ).toFloat() );
@@ -1220,6 +1232,25 @@ void QgsMapLayer::exportNamedStyle( QDomDocument &doc, QString &errorMsg )
     errorMsg = QObject::tr( "Could not save symbology because:\n%1" ).arg( errorMsg );
     return;
   }
+
+  /*
+   * Check to see if the layer is vector - in which case we should also export its geometryType
+   * to avoid eventually pasting to a layer with a different geometry
+  */
+  if ( type() == QgsMapLayer::VectorLayer )
+  {
+    //Getting the selectionLayer geometry
+    QgsVectorLayer *vl = static_cast<QgsVectorLayer*>( this );
+    QString geoType = QString::number( vl->geometryType() );
+
+    //Adding geometryinformation
+    QDomElement layerGeometryType = myDocument.createElement( "layerGeometryType" );
+    QDomText type = myDocument.createTextNode( geoType );
+
+    layerGeometryType.appendChild( type );
+    myRootNode.appendChild( layerGeometryType );
+  }
+
   doc = myDocument;
 }
 


### PR DESCRIPTION
When duplicating layers, the style was applied to the new layers by means of `copyStyle()` and `pasteStyle()`. This is considered ~~poor programming~~ a bug as the clipboard may only be used when the user specifically commands it.
While fixing this, a few other things popped up:
- `pasteStyle()` checked the geometry type on vector layers, but `loadNamedStyle()` did not
- `copyStyle()` and `pasteStyle()` contained pretty much the same code as `importNamedStyle()` and `exportNamedStyle()`, which already led to [bug # 13746](https://hub.qgis.org/issues/13746) because a new feature was only added to one of them

To make it easier for the reviewer I did not squash all commits into one. But I can do it, if it is favored.
