### PR TITLE
Hide the sort indicator in the attribute table until first sort (fixes #6705)

### DIFF
--- a/src/gui/attributetable/qgsattributetableview.cpp
+++ b/src/gui/attributetable/qgsattributetableview.cpp
@@ -53,12 +53,14 @@ QgsAttributeTableView::QgsAttributeTableView( QWidget *parent )
 
   setSelectionBehavior( QAbstractItemView::SelectRows );
   setSelectionMode( QAbstractItemView::ExtendedSelection );
-  setSortingEnabled( true );
+  setSortingEnabled( true ); // At this point no data is in the model yet, so actually nothing is sorted.
+  horizontalHeader()->setSortIndicatorShown( false ); // So hide the indicator to avoid confusion.
 
   verticalHeader()->viewport()->installEventFilter( this );
 
   connect( verticalHeader(), SIGNAL( sectionPressed( int ) ), this, SLOT( selectRow( int ) ) );
   connect( verticalHeader(), SIGNAL( sectionEntered( int ) ), this, SLOT( _q_selectRow( int ) ) );
+  connect( horizontalHeader(), SIGNAL( sortIndicatorChanged( int, Qt::SortOrder ) ), this, SLOT( showHorizontalSortIndicator() ) );
 }
 
 QgsAttributeTableView::~QgsAttributeTableView()
@@ -281,4 +283,9 @@ void QgsAttributeTableView::selectRow( int row, bool anchor )
     else
       mFeatureSelectionModel->selectFeatures( QItemSelection( tl, br ), command );
   }
+}
+
+void QgsAttributeTableView::showHorizontalSortIndicator()
+{
+  horizontalHeader()->setSortIndicatorShown( true );
 }

--- a/src/gui/attributetable/qgsattributetableview.h
+++ b/src/gui/attributetable/qgsattributetableview.h
@@ -139,6 +139,7 @@ class GUI_EXPORT QgsAttributeTableView : public QTableView
 
   private slots:
     void modelDeleted();
+    void showHorizontalSortIndicator();
 
   private:
     void selectRow( int row, bool anchor );


### PR DESCRIPTION
When opening the attribute table, the GUI indicated sorting by the first column. But the data was not sorted at all.
The reason is a bug in Qt: When calling `QTableView::setModel()` on a view that is sorted, the data of the new model is not sorted but the GUI keeps indicating a sort.

This PR fixes it by initially hiding the sort indicator and showing it only after the user actually triggered a sort.

The alternative would have been to sort the new data immediatly after `setModel()` is called. But for large layers this might take quite a time and so I decided to leave it up to the user whether the data should be sorted or not.
