### PR TITLE
[App] accept option '--' to mark all following arguments as files (refs #3714)

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -133,7 +133,8 @@ void usage( std::string const & appName )
             << "\t[--dxf-scale-denom scale]\tscale for dxf output\n"
             << "\t[--dxf-encoding encoding]\tencoding to use for dxf output\n"
             << "\t[--dxf-preset visiblity-preset]\tlayer visibility preset to use for dxf output\n"
-            << "\t[--help]\t\tthis text\n\n"
+            << "\t[--help]\t\tthis text\n"
+            << "\t[--]\t\ttreat all following arguments as FILEs\n\n"
             << "  FILE:\n"
             << "    Files specified on the command line can include rasters,\n"
             << "    vectors, and QGIS project files (.qgs): \n"
@@ -682,6 +683,11 @@ int main( int argc, char *argv[] )
       else if ( arg == "--dxf-preset" )
       {
         dxfPreset = args[++i];
+      }
+      else if ( arg == "--" )
+      {
+        for ( i++; i < args.size(); ++i )
+          myFileList.append( QDir::toNativeSeparators( QFileInfo( args[i] ).absoluteFilePath() ) );
       }
       else
       {

--- a/tests/src/python/test_qgsappstartup.py
+++ b/tests/src/python/test_qgsappstartup.py
@@ -165,6 +165,17 @@ class TestPyQgsAppStartup(unittest.TestCase):
             timeOut=15,
             env={'PYQGIS_STARTUP': testmod}), msg
 
+    def testOptionsAsFiles(self):
+        # verify QGIS accepts filenames that match options after the special option '--'
+        # '--help' should return immediatly (after displaying the usage hints)
+        # '-- --help' should not exit but try (and probably fail) to load a layer called '--help'
+        for t in [(False, ['--help']), (True, ['--', '--help'])]:
+            assert t[0] == self.doTestStartup(option="--configpath",
+                                              testDir=os.path.join(self.TMP_DIR, 'test_optionsAsFiles'),
+                                              testFile="qgis.db",
+                                              timeOut=15,
+                                              additionalArguments = t[1]), "additional arguments: %s" % ' '.join(t[1])
+
 
 if __name__ == '__main__':
     # look for qgis bin path


### PR DESCRIPTION
If the user wanted to load a file that is named like an option, this was not possible, because the command line argument was always interpreted as an option. This PR makes it possible.

As before, every command line argument is checked whether it matches one of the known options (e.g. `--help`) and if it doesn't, it is treated as a file to load, either project or layer.
Additionally the new option `--` is introduced and every argument following it is treated as a filename.
So to load a layer named _--help_ the correct arguments are now `-- --help`.

This PR includes a test case for the new functionality and some minor improvements to the test.
