### PR TITLE
[FEATURE] Allow override of geometry type in vector save as dialog

### DIFF
--- a/python/core/qgsvectorfilewriter.sip
+++ b/python/core/qgsvectorfilewriter.sip
@@ -121,7 +121,10 @@ class QgsVectorFileWriter
     @param newFilename QString pointer which will contain the new file name created (in case it is different to fileName).
     @param symbologyExport symbology to export
     @param symbologyScale scale of symbology
-    @param filterExtent if not a null pointer, only features intersecting the extent will be saved
+    @param filterExtent if not a null pointer, only features intersecting the extent will be saved (added in QGIS 2.4)
+    allows for conversion of geometryless tables to null geometries, etc (added in QGIS 2.14)
+    @param forceMulti set to true to force creation of multi* geometries (added in QGIS 2.14)
+    @param includeZ set to true to include z dimension in output. This option is only valid if overrideGeometryType is set. (added in QGIS 2.14)
     */
     static WriterError writeAsVectorFormat( QgsVectorLayer* layer,
                                             const QString& fileName,
@@ -136,10 +139,33 @@ class QgsVectorFileWriter
                                             QString *newFilename = 0,
                                             SymbologyExport symbologyExport = NoSymbology,
                                             double symbologyScale = 1.0,
-                                            const QgsRectangle* filterExtent = 0 // added in 2.4
+                                            const QgsRectangle* filterExtent = 0,
+                                            QgsWKBTypes::Type overrideGeometryType = QgsWKBTypes::Unknown,
+                                            bool forceMulti = false,
+                                            bool includeZ = false
                                           );
 
-    //! @note added in v2.2
+    /** Writes a layer out to a vector file.
+     * @param layer layer to write
+     * @param fileName file name to write to
+     * @param fileEncoding encoding to use
+     * @param ct
+     * @param driverName OGR driver to use
+     * @param onlySelected write only selected features of layer
+     * @param errorMessage pointer to buffer fo error message
+     * @param datasourceOptions list of OGR data source creation options
+     * @param layerOptions list of OGR layer creation options
+     * @param skipAttributeCreation only write geometries
+     * @param newFilename QString pointer which will contain the new file name created (in case it is different to fileName).
+     * @param symbologyExport symbology to export
+     * @param symbologyScale scale of symbology
+     * @param filterExtent if not a null pointer, only features intersecting the extent will be saved (added in QGIS 2.4)
+     * @param overrideGeometryType set to a valid geometry type to override the default geometry type for the layer. This parameter
+     * allows for conversion of geometryless tables to null geometries, etc (added in QGIS 2.14)
+     * @param forceMulti set to true to force creation of multi* geometries (added in QGIS 2.14)
+     * @param includeZ set to true to include z dimension in output. This option is only valid if overrideGeometryType is set. (added in QGIS 2.14)
+     * @note added in v2.2
+     */
     static WriterError writeAsVectorFormat( QgsVectorLayer* layer,
                                             const QString& fileName,
                                             const QString& fileEncoding,
@@ -153,7 +179,10 @@ class QgsVectorFileWriter
                                             QString *newFilename = 0,
                                             SymbologyExport symbologyExport = NoSymbology,
                                             double symbologyScale = 1.0,
-                                            const QgsRectangle* filterExtent = 0 // added in 2.4
+                                            const QgsRectangle* filterExtent = 0,
+                                            QgsWKBTypes::Type overrideGeometryType = QgsWKBTypes::Unknown,
+                                            bool forceMulti = false,
+                                            bool includeZ = false
                                           );
 
     /** Create shapefile and initialize it */

--- a/src/app/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/app/ogr/qgsvectorlayersaveasdialog.cpp
@@ -67,6 +67,15 @@ void QgsVectorLayerSaveAsDialog::setup()
   mFormatComboBox->setCurrentIndex( mFormatComboBox->findData( format ) );
   mFormatComboBox->blockSignals( false );
 
+  //add geometry types to combobox
+  mGeometryTypeComboBox->addItem( tr( "Automatic" ), -1 );
+  mGeometryTypeComboBox->addItem( QgsWKBTypes::displayString( QgsWKBTypes::Point ), QgsWKBTypes::Point );
+  mGeometryTypeComboBox->addItem( QgsWKBTypes::displayString( QgsWKBTypes::LineString ), QgsWKBTypes::LineString );
+  mGeometryTypeComboBox->addItem( QgsWKBTypes::displayString( QgsWKBTypes::Polygon ), QgsWKBTypes::Polygon );
+  mGeometryTypeComboBox->addItem( QgsWKBTypes::displayString( QgsWKBTypes::GeometryCollection ), QgsWKBTypes::GeometryCollection );
+  mGeometryTypeComboBox->addItem( tr( "No geometry" ), QgsWKBTypes::NoGeometry );
+  mGeometryTypeComboBox->setCurrentIndex( mGeometryTypeComboBox->findData( -1 ) );
+
   mEncodingComboBox->addItems( QgsVectorDataProvider::availableEncodings() );
 
   QString enc = settings.value( "/UI/encoding", "System" ).toString();
@@ -458,6 +467,44 @@ bool QgsVectorLayerSaveAsDialog::onlySelected() const
   return mSelectedOnly->isChecked();
 }
 
+QgsWKBTypes::Type QgsVectorLayerSaveAsDialog::geometryType() const
+{
+  int currentIndexData = mGeometryTypeComboBox->itemData( mGeometryTypeComboBox->currentIndex() ).toInt();
+  if ( currentIndexData == -1 )
+  {
+    //automatic
+    return QgsWKBTypes::Unknown;
+  }
+
+  return ( QgsWKBTypes::Type )currentIndexData;
+}
+
+bool QgsVectorLayerSaveAsDialog::automaticGeometryType() const
+{
+  int currentIndexData = mGeometryTypeComboBox->itemData( mGeometryTypeComboBox->currentIndex() ).toInt();
+  return currentIndexData == -1;
+}
+
+bool QgsVectorLayerSaveAsDialog::forceMulti() const
+{
+  return mForceMultiCheckBox->isChecked();
+}
+
+void QgsVectorLayerSaveAsDialog::setForceMulti( bool checked )
+{
+  mForceMultiCheckBox->setChecked( checked );
+}
+
+bool QgsVectorLayerSaveAsDialog::includeZ() const
+{
+  return mIncludeZCheckBox->isChecked();
+}
+
+void QgsVectorLayerSaveAsDialog::setIncludeZ( bool checked )
+{
+  mIncludeZCheckBox->setChecked( checked );
+}
+
 void QgsVectorLayerSaveAsDialog::on_mSymbologyExportComboBox_currentIndexChanged( const QString& text )
 {
   bool scaleEnabled = true;
@@ -467,4 +514,12 @@ void QgsVectorLayerSaveAsDialog::on_mSymbologyExportComboBox_currentIndexChanged
   }
   mScaleSpinBox->setEnabled( scaleEnabled );
   mScaleLabel->setEnabled( scaleEnabled );
+}
+
+void QgsVectorLayerSaveAsDialog::on_mGeometryTypeComboBox_currentIndexChanged( int index )
+{
+  int currentIndexData = mGeometryTypeComboBox->itemData( index ).toInt();
+
+  mForceMultiCheckBox->setEnabled( currentIndexData != -1 );
+  mIncludeZCheckBox->setEnabled( currentIndexData != -1 );
 }

--- a/src/app/ogr/qgsvectorlayersaveasdialog.h
+++ b/src/app/ogr/qgsvectorlayersaveasdialog.h
@@ -65,6 +65,36 @@ class QgsVectorLayerSaveAsDialog : public QDialog, private Ui::QgsVectorLayerSav
 
     bool onlySelected() const;
 
+    /** Returns the selected flat geometry type for the export.
+     * @see automaticGeometryType()
+     * @see forceMulti()
+     * @see includeZ()
+     */
+    QgsWKBTypes::Type geometryType() const;
+
+    /** Returns true if geometry type is set to automatic.
+     * @see geometryType()
+     */
+    bool automaticGeometryType() const;
+
+    /** Returns true if force multi geometry type is checked.
+     * @see includeZ()
+     */
+    bool forceMulti() const;
+
+    /** Sets whether the force multi geometry checkbox should be checked.
+     */
+    void setForceMulti( bool checked );
+
+    /** Returns true if include z dimension is checked.
+     * @see forceMulti()
+     */
+    bool includeZ() const;
+
+    /** Sets whether the include z dimension checkbox should be checked.
+     */
+    void setIncludeZ( bool checked );
+
   private slots:
     void on_mFormatComboBox_currentIndexChanged( int idx );
     void on_leFilename_textChanged( const QString& text );
@@ -72,6 +102,7 @@ class QgsVectorLayerSaveAsDialog : public QDialog, private Ui::QgsVectorLayerSav
     void on_mCrsSelector_crsChanged( const QgsCoordinateReferenceSystem& crs );
     void on_buttonBox_helpRequested() { QgsContextHelp::run( metaObject()->className() ); }
     void on_mSymbologyExportComboBox_currentIndexChanged( const QString& text );
+    void on_mGeometryTypeComboBox_currentIndexChanged( int index );
     void accept() override;
 
   private:

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5476,6 +5476,7 @@ void QgisApp::saveAsVectorFileGeneral( QgsVectorLayer* vlayer, bool symbologyOpt
   QgsVectorLayerSaveAsDialog *dialog = new QgsVectorLayerSaveAsDialog( vlayer->crs().srsid(), vlayer->extent(), vlayer->selectedFeatureCount() != 0, options, this );
 
   dialog->setCanvasExtent( mMapCanvas->mapSettings().visibleExtent(), mMapCanvas->mapSettings().destinationCrs() );
+  dialog->setIncludeZ( QgsWKBTypes::hasZ( QGis::fromOldWkbType( vlayer->wkbType() ) ) );
 
   if ( dialog->exec() == QDialog::Accepted )
   {
@@ -5483,6 +5484,8 @@ void QgisApp::saveAsVectorFileGeneral( QgsVectorLayer* vlayer, bool symbologyOpt
     QString vectorFilename = dialog->filename();
     QString format = dialog->format();
     QStringList datasourceOptions = dialog->datasourceOptions();
+    bool autoGeometryType = dialog->automaticGeometryType();
+    QgsWKBTypes::Type forcedGeometryType = dialog->geometryType();
 
     QgsCoordinateTransform* ct = 0;
     destCRS = QgsCoordinateReferenceSystem( dialog->crs(), QgsCoordinateReferenceSystem::InternalCrsId );
@@ -5529,7 +5532,11 @@ void QgisApp::saveAsVectorFileGeneral( QgsVectorLayer* vlayer, bool symbologyOpt
               &newFilename,
               ( QgsVectorFileWriter::SymbologyExport )( dialog->symbologyExport() ),
               dialog->scaleDenominator(),
-              dialog->hasFilterExtent() ? &filterExtent : 0 );
+              dialog->hasFilterExtent() ? &filterExtent : 0,
+              autoGeometryType ? QgsWKBTypes::Unknown : forcedGeometryType,
+              dialog->forceMulti(),
+              dialog->includeZ()
+            );
 
     delete ct;
 

--- a/src/core/qgsvectorfilewriter.h
+++ b/src/core/qgsvectorfilewriter.h
@@ -174,7 +174,11 @@ class CORE_EXPORT QgsVectorFileWriter
     @param newFilename QString pointer which will contain the new file name created (in case it is different to fileName).
     @param symbologyExport symbology to export
     @param symbologyScale scale of symbology
-    @param filterExtent if not a null pointer, only features intersecting the extent will be saved
+    @param filterExtent if not a null pointer, only features intersecting the extent will be saved (added in QGIS 2.4)
+    @param overrideGeometryType set to a valid geometry type to override the default geometry type for the layer. This parameter
+    allows for conversion of geometryless tables to null geometries, etc (added in QGIS 2.14)
+    @param forceMulti set to true to force creation of multi* geometries (added in QGIS 2.14)
+    @param includeZ set to true to include z dimension in output. This option is only valid if overrideGeometryType is set. (added in QGIS 2.14)
     */
     static WriterError writeAsVectorFormat( QgsVectorLayer* layer,
                                             const QString& fileName,
@@ -189,10 +193,33 @@ class CORE_EXPORT QgsVectorFileWriter
                                             QString *newFilename = 0,
                                             SymbologyExport symbologyExport = NoSymbology,
                                             double symbologyScale = 1.0,
-                                            const QgsRectangle* filterExtent = 0 // added in 2.4
+                                            const QgsRectangle* filterExtent = 0,
+                                            QgsWKBTypes::Type overrideGeometryType = QgsWKBTypes::Unknown,
+                                            bool forceMulti = false,
+                                            bool includeZ = false
                                           );
 
-    //! @note added in v2.2
+    /** Writes a layer out to a vector file.
+     * @param layer layer to write
+     * @param fileName file name to write to
+     * @param fileEncoding encoding to use
+     * @param ct
+     * @param driverName OGR driver to use
+     * @param onlySelected write only selected features of layer
+     * @param errorMessage pointer to buffer fo error message
+     * @param datasourceOptions list of OGR data source creation options
+     * @param layerOptions list of OGR layer creation options
+     * @param skipAttributeCreation only write geometries
+     * @param newFilename QString pointer which will contain the new file name created (in case it is different to fileName).
+     * @param symbologyExport symbology to export
+     * @param symbologyScale scale of symbology
+     * @param filterExtent if not a null pointer, only features intersecting the extent will be saved (added in QGIS 2.4)
+     * @param overrideGeometryType set to a valid geometry type to override the default geometry type for the layer. This parameter
+     * allows for conversion of geometryless tables to null geometries, etc (added in QGIS 2.14)
+     * @param forceMulti set to true to force creation of multi* geometries (added in QGIS 2.14)
+     * @param includeZ set to true to include z dimension in output. This option is only valid if overrideGeometryType is set. (added in QGIS 2.14)
+     * @note added in v2.2
+     */
     static WriterError writeAsVectorFormat( QgsVectorLayer* layer,
                                             const QString& fileName,
                                             const QString& fileEncoding,
@@ -206,7 +233,10 @@ class CORE_EXPORT QgsVectorFileWriter
                                             QString *newFilename = 0,
                                             SymbologyExport symbologyExport = NoSymbology,
                                             double symbologyScale = 1.0,
-                                            const QgsRectangle* filterExtent = 0 // added in 2.4
+                                            const QgsRectangle* filterExtent = 0,
+                                            QgsWKBTypes::Type overrideGeometryType = QgsWKBTypes::Unknown,
+                                            bool forceMulti = false,
+                                            bool includeZ = false
                                           );
 
     /** Create shapefile and initialize it */

--- a/src/ui/qgsvectorlayersaveasdialogbase.ui
+++ b/src/ui/qgsvectorlayersaveasdialogbase.ui
@@ -91,7 +91,7 @@
         <x>0</x>
         <y>0</y>
         <width>555</width>
-        <height>523</height>
+        <height>650</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout">
@@ -176,6 +176,43 @@
           </widget>
          </item>
         </layout>
+       </item>
+       <item>
+        <widget class="QgsCollapsibleGroupBox" name="mGeometryGroupBox">
+         <property name="title">
+          <string>Geometry</string>
+         </property>
+         <layout class="QVBoxLayout" name="verticalLayout_3">
+          <item>
+           <layout class="QHBoxLayout" name="horizontalLayout_4">
+            <item>
+             <widget class="QLabel" name="mSymbologyExportLabel_2">
+              <property name="text">
+               <string>Geometry type</string>
+              </property>
+             </widget>
+            </item>
+            <item>
+             <widget class="QComboBox" name="mGeometryTypeComboBox"/>
+            </item>
+           </layout>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="mForceMultiCheckBox">
+            <property name="text">
+             <string>Force multi-type</string>
+            </property>
+           </widget>
+          </item>
+          <item>
+           <widget class="QCheckBox" name="mIncludeZCheckBox">
+            <property name="text">
+             <string>Include z-dimension</string>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
        </item>
        <item>
         <widget class="QgsExtentGroupBox" name="mExtentGroupBox"/>
@@ -320,15 +357,15 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsCollapsibleGroupBox</class>
-   <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
+   <class>QgsProjectionSelectionWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsprojectionselectionwidget.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsProjectionSelectionWidget</class>
-   <extends>QWidget</extends>
-   <header location="global">qgsprojectionselectionwidget.h</header>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
    <container>1</container>
   </customwidget>
   <customwidget>
@@ -350,6 +387,9 @@
   <tabstop>mAddToCanvas</tabstop>
   <tabstop>mSymbologyExportComboBox</tabstop>
   <tabstop>mScaleSpinBox</tabstop>
+  <tabstop>mGeometryTypeComboBox</tabstop>
+  <tabstop>mForceMultiCheckBox</tabstop>
+  <tabstop>mIncludeZCheckBox</tabstop>
   <tabstop>mOgrDatasourceOptions</tabstop>
   <tabstop>mOgrLayerOptions</tabstop>
   <tabstop>buttonBox</tabstop>


### PR DESCRIPTION
This also allows users to override the default geometry type when saving a vector layer to a file. It makes it possible to do things like save a geometryless table to a file WITH a geometry type, so that geometries can then be manually added to rows. Previously this was only possible to do in QGIS by resorting to dummy joins or other hacks.

There's also new options for forcing output file to be multi type, or to include z dimension.

(Note that adding z values seems problematic, likely due to a bug in how QgsVectorFileWriter converts 3d geometries. I've made a comment in the code about the likely fix)
