### PR TITLE
Refactored the python init function selector

### DIFF
--- a/python/core/qgseditformconfig.sip
+++ b/python/core/qgseditformconfig.sip
@@ -58,6 +58,18 @@ class QgsEditFormConfig : QObject
     };
 
     /**
+     * The python init code source options.
+     */
+    enum PythonInitCodeSource
+    {
+      CodeSourceNone = 0,             //!< Do not use python code at all
+      CodeSourceFile = 1,             //!< Load the python code from a file
+      CodeSourceDialog = 2,           //!< Use the python code provided in the dialog
+      CodeSourceEnvironment = 3       //!< Use the python code available in the python environment
+    };
+
+
+    /**
      * This is only useful in combination with EditorLayout::TabLayout.
      *
      * Adds a new tab to the layout. Should be a QgsAttributeEditorContainer.
@@ -208,15 +220,6 @@ class QgsEditFormConfig : QObject
     void setLabelOnTop( int idx, bool onTop );
 
 
-
-
-
-
-
-
-
-
-
     // Python stuff
 
 
@@ -237,9 +240,21 @@ class QgsEditFormConfig : QObject
     void setInitFunction( const QString& function );
 
     /**
-     * Get python code for edit form initialization.
+     * Get python code for edit form initialization from the configuration dialog.
      */
     QString initCode() const;
+
+    /**
+     * Get python external file path for edit form initialization.
+     */
+    QString initFilePath() const;
+
+    /**
+     * Set python external file path for edit form initialization.
+     * Make sure that you also set the appropriate function name in
+     * @link setInitFunction @endlink
+     */
+    void setInitFilePath( const QString& filePath );
 
     /**
      * Get python code for edit form initialization.
@@ -248,11 +263,15 @@ class QgsEditFormConfig : QObject
      */
     void setInitCode( const QString& code );
 
-    /** Return if python code shall be loaded for edit form initialization */
-    bool useInitCode() const;
+    /** Return python code source for edit form initialization
+     *  (if it shall be loaded from a file, read from the
+     *  provided dialog editor or just read from the environment
+     */
+    PythonInitCodeSource initCodeSource() const;
 
     /** Set if python code shall be used for edit form initialization */
-    void setUseInitCode( const bool useCode );
+    void setInitCodeSource( const PythonInitCodeSource initCodeSource );
+
 
     /** Type of feature form pop-up suppression after feature creation (overrides app setting) */
     FeatureFormSuppress suppress() const;

--- a/src/app/qgsfieldsproperties.cpp
+++ b/src/app/qgsfieldsproperties.cpp
@@ -469,6 +469,7 @@ void QgsFieldsProperties::on_mInitCodeSourceComboBox_currentIndexChanged( int co
   mPythonInitCodeGroupBox->setVisible( codeSource == QgsEditFormConfig::PythonInitCodeSource::CodeSourceDialog );
   mInitFilePathLineEdit->setVisible( codeSource == QgsEditFormConfig::PythonInitCodeSource::CodeSourceFile );
   mInitFilePathLabel->setVisible( codeSource == QgsEditFormConfig::PythonInitCodeSource::CodeSourceFile );
+  pbtnSelectInitFilePath->setVisible( codeSource == QgsEditFormConfig::PythonInitCodeSource::CodeSourceFile );
 }
 
 void QgsFieldsProperties::attributeTypeDialog()

--- a/src/app/qgsfieldsproperties.cpp
+++ b/src/app/qgsfieldsproperties.cpp
@@ -115,6 +115,12 @@ QgsFieldsProperties::QgsFieldsProperties( QgsVectorLayer *layer, QWidget* parent
   mRelationsList->setHorizontalHeaderItem( RelFieldCol, new QTableWidgetItem( tr( "Field" ) ) );
   mRelationsList->verticalHeader()->hide();
 
+  // Init function stuff
+  mInitCodeSourceComboBox->addItem( tr( "" ) );
+  mInitCodeSourceComboBox->addItem( tr( "Load from external file" ) );
+  mInitCodeSourceComboBox->addItem( tr( "Provide code in this dialog" ) );
+  mInitCodeSourceComboBox->addItem( tr( "Load from the environment" ) );
+
   loadRelations();
 
   updateButtons();
@@ -183,11 +189,15 @@ QTreeWidgetItem *QgsFieldsProperties::loadAttributeEditorTreeItem( QgsAttributeE
   return newWidget;
 }
 
-void QgsFieldsProperties::setEditFormInit( const QString &editForm, const QString &editFormInit, const QString &editFormInitCode, const bool editFormInitUseCode )
+void QgsFieldsProperties::setEditFormInit( const QString &editForm,
+    const QString &initFunction,
+    const QString &initCode,
+    const QString &initFilePath,
+    const QgsEditFormConfig::PythonInitCodeSource &codeSource )
 {
 
   // Python init function and code
-  QString code( editFormInitCode );
+  QString code( initCode );
   if ( code.isEmpty( ) )
   {
     code.append( tr( "# -*- coding: utf-8 -*-\n\"\"\"\n"
@@ -206,12 +216,11 @@ void QgsFieldsProperties::setEditFormInit( const QString &editForm, const QStrin
                      "\tcontrol = dialog.findChild(QWidget, \"MyLineEdit\")\n" ) );
 
   }
-  leEditForm->setText( editForm );
-  leEditFormInitCode->setText( code );
-  leEditFormInit->setText( editFormInit );
-  leEditFormInitUseCode->setChecked( editFormInitUseCode );
-  // Show or hide as needed
-  mPythonInitCodeGroupBox->setVisible( editFormInitUseCode );
+  mEditFormLineEdit->setText( editForm );
+  mInitFilePathLineEdit->setText( initFilePath );
+  mInitCodeEditorPython->setText( code );
+  mInitFunctionLineEdit->setText( initFunction );
+  mInitCodeSourceComboBox->setCurrentIndex( codeSource );
 }
 
 
@@ -453,9 +462,13 @@ void QgsFieldsProperties::on_mMoveUpItem_clicked()
   }
 }
 
-void QgsFieldsProperties::on_leEditFormInitUseCode_toggled( bool checked )
+void QgsFieldsProperties::on_mInitCodeSourceComboBox_currentIndexChanged( int codeSource )
 {
-  mPythonInitCodeGroupBox->setVisible( checked );
+  // Show or hide ui elements as needed
+  mInitFunctionContainer->setVisible( codeSource != QgsEditFormConfig::PythonInitCodeSource::CodeSourceNone );
+  mPythonInitCodeGroupBox->setVisible( codeSource == QgsEditFormConfig::PythonInitCodeSource::CodeSourceDialog );
+  mInitFilePathLineEdit->setVisible( codeSource == QgsEditFormConfig::PythonInitCodeSource::CodeSourceFile );
+  mInitFilePathLabel->setVisible( codeSource == QgsEditFormConfig::PythonInitCodeSource::CodeSourceFile );
 }
 
 void QgsFieldsProperties::attributeTypeDialog()
@@ -805,6 +818,22 @@ QgsAttributeEditorElement* QgsFieldsProperties::createAttributeEditorWidget( QTr
   return widgetDef;
 }
 
+
+void QgsFieldsProperties::on_pbtnSelectInitFilePath_clicked()
+{
+  QSettings myQSettings;
+  QString lastUsedDir = myQSettings.value( "style/lastUIDir", "." ).toString();
+  QString pyfilename = QFileDialog::getOpenFileName( this, tr( "Select Python file" ), lastUsedDir, tr( "Python file" )  + " (*.py)" );
+
+  if ( pyfilename.isNull() )
+    return;
+
+  QFileInfo fi( pyfilename );
+  myQSettings.setValue( "style/lastUIDir", fi.path() );
+  mInitFilePathLineEdit->setText( pyfilename );
+}
+
+
 void QgsFieldsProperties::on_pbnSelectEditForm_clicked()
 {
   QSettings myQSettings;
@@ -816,7 +845,7 @@ void QgsFieldsProperties::on_pbnSelectEditForm_clicked()
 
   QFileInfo fi( uifilename );
   myQSettings.setValue( "style/lastUIDir", fi.path() );
-  leEditForm->setText( uifilename );
+  mEditFormLineEdit->setText( uifilename );
 }
 
 void QgsFieldsProperties::on_mEditorLayoutComboBox_currentIndexChanged( int index )
@@ -875,10 +904,14 @@ void QgsFieldsProperties::apply()
 
   mLayer->editFormConfig()->setLayout(( QgsEditFormConfig::EditorLayout ) mEditorLayoutComboBox->currentIndex() );
   if ( mEditorLayoutComboBox->currentIndex() == QgsEditFormConfig::UiFileLayout )
-    mLayer->editFormConfig()->setUiForm( leEditForm->text() );
-  mLayer->editFormConfig()->setInitFunction( leEditFormInit->text() );
-  mLayer->editFormConfig()->setUseInitCode( leEditFormInitUseCode->isChecked() );
-  mLayer->editFormConfig()->setInitCode( leEditFormInitCode->text() );
+    mLayer->editFormConfig()->setUiForm( mEditFormLineEdit->text() );
+
+  // Init function configuration
+  mLayer->editFormConfig()->setInitFunction( mInitFunctionLineEdit->text( ) );
+  mLayer->editFormConfig()->setInitCode( mInitCodeEditorPython->text( ) );
+  mLayer->editFormConfig()->setInitFilePath( mInitFilePathLineEdit->text( ) );
+  mLayer->editFormConfig()->setInitCodeSource(( QgsEditFormConfig::PythonInitCodeSource )mInitCodeSourceComboBox->currentIndex() );
+
   mLayer->editFormConfig()->setSuppress(( QgsEditFormConfig::FeatureFormSuppress )mFormSuppressCmbBx->currentIndex() );
 
   mLayer->setExcludeAttributesWMS( excludeAttributesWMS );

--- a/src/app/qgsfieldsproperties.h
+++ b/src/app/qgsfieldsproperties.h
@@ -163,11 +163,16 @@ class APP_EXPORT QgsFieldsProperties : public QWidget, private Ui_QgsFieldsPrope
     /**
      * @brief setEditFormInit set the private ui fields
      * @param editForm
-     * @param editFormInit
-     * @param editFormInitCode
-     * @param editFormInitUseCode
+     * @param initFunction
+     * @param initCode
+     * @param initFilePath
+     * @param codeSource
      */
-    void setEditFormInit( const QString &editForm, const QString &editFormInit, const QString &editFormInitCode, const bool editFormInitUseCode );
+    void setEditFormInit( const QString &editForm,
+                          const QString &initFunction,
+                          const QString &initCode,
+                          const QString &initFilePath,
+                          const QgsEditFormConfig::PythonInitCodeSource &codeSource );
 
   signals:
     void toggleEditing();
@@ -177,9 +182,10 @@ class APP_EXPORT QgsFieldsProperties : public QWidget, private Ui_QgsFieldsPrope
     void on_mDeleteAttributeButton_clicked();
     void on_mCalculateFieldButton_clicked();
     void onAttributeSelectionChanged();
+    void on_pbtnSelectInitFilePath_clicked();
     void on_pbnSelectEditForm_clicked();
     void on_mEditorLayoutComboBox_currentIndexChanged( int index );
-    void on_leEditFormInitUseCode_toggled( bool checked );
+    void on_mInitCodeSourceComboBox_currentIndexChanged( int codeSource );
     void attributeAdded( int idx );
     void attributeDeleted( int idx );
     void attributeTypeDialog();

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -1317,5 +1317,5 @@ void QgsVectorLayerProperties::updateVariableEditor()
 void QgsVectorLayerProperties::updateFieldsPropertiesDialog()
 {
   QgsEditFormConfig* cfg = layer->editFormConfig();
-  mFieldsPropertiesDialog->setEditFormInit( cfg->uiForm(), cfg->initFunction(), cfg->initCode(), cfg->useInitCode() );
+  mFieldsPropertiesDialog->setEditFormInit( cfg->uiForm(), cfg->initFunction(), cfg->initCode(), cfg->initFilePath(), cfg->initCodeSource() );
 }

--- a/src/core/qgseditformconfig.cpp
+++ b/src/core/qgseditformconfig.cpp
@@ -4,8 +4,8 @@
 QgsEditFormConfig::QgsEditFormConfig( QObject* parent )
     : QObject( parent )
     , mEditorLayout( GeneratedLayout )
+    , mInitCodeSource( QgsEditFormConfig::PythonInitCodeSource::CodeSourceNone )
     , mFeatureFormSuppress( SuppressDefault )
-    , mUseInitCode( false )
 {
   connect( QgsProject::instance()->relationManager(), SIGNAL( relationsLoaded() ), this, SLOT( onRelationsLoaded() ) );
 }

--- a/src/core/qgseditformconfig.h
+++ b/src/core/qgseditformconfig.h
@@ -271,6 +271,7 @@ class CORE_EXPORT QgsEditFormConfig : public QObject
     Q_OBJECT
 
   public:
+
     /** The different types to layout the attribute editor. */
     enum EditorLayout
     {
@@ -306,6 +307,17 @@ class CORE_EXPORT QgsEditFormConfig : public QObject
       SuppressDefault = 0, //!< Use the application-wide setting
       SuppressOn = 1,      //!< Suppress feature form
       SuppressOff = 2      //!< Do not suppress feature form
+    };
+
+    /**
+     * The python init code source options.
+     */
+    enum PythonInitCodeSource
+    {
+      CodeSourceNone = 0,             //!< Do not use python code at all
+      CodeSourceFile = 1,             //!< Load the python code from an external file
+      CodeSourceDialog = 2,           //!< Use the python code provided in the dialog
+      CodeSourceEnvironment = 3       //!< Use the python code available in the python environment
     };
 
     /**
@@ -459,17 +471,7 @@ class CORE_EXPORT QgsEditFormConfig : public QObject
     void setLabelOnTop( int idx, bool onTop );
 
 
-
-
-
-
-
-
-
-
-
-    // Python stuff
-
+    // Python form init function stuff
 
     /**
      * Get python function for edit form initialization.
@@ -490,20 +492,35 @@ class CORE_EXPORT QgsEditFormConfig : public QObject
     /**
      * Get python code for edit form initialization.
      */
-    QString initCode() const { return mEditFormInitCode; }
+    QString initCode() const { return mInitCode; }
 
     /**
-     * Get python code for edit form initialization.
+     * Set python code for edit form initialization.
      * Make sure that you also set the appropriate function name in
      * @link setInitFunction @endlink
      */
-    void setInitCode( const QString& code ) { mEditFormInitCode = code; }
+    void setInitCode( const QString& code ) { mInitCode = code; }
 
-    /** Return if python code shall be loaded for edit form initialization */
-    bool useInitCode() const { return mUseInitCode; }
+    /**
+     * Get python external file path for edit form initialization.
+     */
+    QString initFilePath() const { return mInitFilePath; }
 
-    /** Set if python code shall be used for edit form initialization */
-    void setUseInitCode( const bool useCode ) { mUseInitCode = useCode; }
+    /**
+     * Set python external file path for edit form initialization.
+     * Make sure that you also set the appropriate function name in
+     * @link setInitFunction @endlink
+     */
+    void setInitFilePath( const QString& filePath ) { mInitFilePath = filePath; }
+
+    /** Return python code source for edit form initialization
+     *  (if it shall be loaded from a file, read from the
+     *  provided dialog editor or inherited from the environment)
+     */
+    PythonInitCodeSource initCodeSource() const { return mInitCodeSource; }
+
+    /** Set if python code shall be used for edit form initialization and its origin */
+    void setInitCodeSource( const PythonInitCodeSource initCodeSource ) { mInitCodeSource = initCodeSource; }
 
     /** Type of feature form pop-up suppression after feature creation (overrides app setting) */
     FeatureFormSuppress suppress() const { return mFeatureFormSuppress; }
@@ -547,9 +564,16 @@ class CORE_EXPORT QgsEditFormConfig : public QObject
     /** Defines the default layout to use for the attribute editor (Drag and drop, UI File, Generated) */
     EditorLayout mEditorLayout;
 
+    /** Init form instance */
     QString mEditForm;
+    /** Name of the python form init function */
     QString mInitFunction;
-    QString mEditFormInitCode;
+    /** Path of the python external file to be loaded */
+    QString mInitFilePath;
+    /** Choose the source of the init founction */
+    PythonInitCodeSource mInitCodeSource;
+    /** Python init code provided in the dialog */
+    QString mInitCode;
 
     /** Type of feature form suppression after feature creation */
     FeatureFormSuppress mFeatureFormSuppress;

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -2080,7 +2080,7 @@ bool QgsVectorLayer::writeSymbology( QDomNode& node, QDomDocument& doc, QString&
   node.appendChild( eficsField );
 
   QDomElement efifpField  = doc.createElement( "editforminitfilepath" );
-  efifpField.appendChild( doc.createTextNode( mEditFormConfig->initFilePath() ) );
+  efifpField.appendChild( doc.createTextNode( QgsProject::instance()->writePath( mEditFormConfig->initFilePath() ) ) );
   node.appendChild( efifpField );
 
 

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -1780,17 +1780,32 @@ bool QgsVectorLayer::readSymbology( const QDomNode& node, QString& errorMessage 
     mEditFormConfig->setInitFunction( editFormInitNode.toElement().text() );
   }
 
+  QDomNode editFormInitCodeSourceNode = node.namedItem( "editforminitcodesource" );
+  if ( !editFormInitCodeSourceNode.isNull() || ( !editFormInitCodeSourceNode.isNull() && !editFormInitCodeSourceNode.toElement().text().isEmpty() ) )
+  {
+    mEditFormConfig->setInitCodeSource(( QgsEditFormConfig::PythonInitCodeSource ) editFormInitCodeSourceNode.toElement().text().toInt() );
+  }
+
   QDomNode editFormInitCodeNode = node.namedItem( "editforminitcode" );
   if ( !editFormInitCodeNode.isNull() )
   {
     mEditFormConfig->setInitCode( editFormInitCodeNode.toElement().text() );
   }
 
-  QDomNode editFormInitCodeSourceNode = node.namedItem( "editforminitcodesource" );
-  if ( !editFormInitCodeSourceNode.isNull() || ( !editFormInitCodeSourceNode.isNull() && !editFormInitCodeSourceNode.toElement().text().isEmpty() ) )
+  // Temporary < 2.12 b/w compatibility "dot" support patch
+  // @see: https://github.com/qgis/QGIS/pull/2498
+  // For b/w compatibility, check if there's a dot in the function name
+  // and if yes, transform it in an import statement for the module
+  // and set the PythonInitCodeSource to CodeSourceDialog
+  QString initFunction = mEditFormConfig->initFunction();
+  int dotPos = initFunction.lastIndexOf( '.' );
+  if ( dotPos >= 0 ) // It's a module
   {
-    mEditFormConfig->setInitCodeSource(( QgsEditFormConfig::PythonInitCodeSource ) editFormInitCodeSourceNode.toElement().text().toInt() );
+    mEditFormConfig->setInitCodeSource( QgsEditFormConfig::PythonInitCodeSource::CodeSourceDialog );
+    mEditFormConfig->setInitFunction( initFunction.mid( dotPos + 1 ) );
+    mEditFormConfig->setInitCode( QString( "from %1 import %2\n" ).arg( initFunction.left( dotPos ), initFunction.mid( dotPos + 1 ) ) );
   }
+
 
   QDomNode editFormInitFilePathNode = node.namedItem( "editforminitfilepath" );
   if ( !editFormInitFilePathNode.isNull() || ( !editFormInitFilePathNode.isNull() && !editFormInitFilePathNode.toElement().text().isEmpty() ) )

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -1786,10 +1786,16 @@ bool QgsVectorLayer::readSymbology( const QDomNode& node, QString& errorMessage 
     mEditFormConfig->setInitCode( editFormInitCodeNode.toElement().text() );
   }
 
-  QDomNode editFormInitUseCodeNode = node.namedItem( "editforminitusecode" );
-  if ( !editFormInitCodeNode.isNull() || ( !editFormInitNode.isNull() && !editFormInitNode.toElement().text().isEmpty() ) )
+  QDomNode editFormInitCodeSourceNode = node.namedItem( "editforminitcodesource" );
+  if ( !editFormInitCodeSourceNode.isNull() || ( !editFormInitCodeSourceNode.isNull() && !editFormInitCodeSourceNode.toElement().text().isEmpty() ) )
   {
-    mEditFormConfig->setUseInitCode( editFormInitUseCodeNode.toElement().text().toInt() );
+    mEditFormConfig->setInitCodeSource(( QgsEditFormConfig::PythonInitCodeSource ) editFormInitCodeSourceNode.toElement().text().toInt() );
+  }
+
+  QDomNode editFormInitFilePathNode = node.namedItem( "editforminitfilepath" );
+  if ( !editFormInitFilePathNode.isNull() || ( !editFormInitFilePathNode.isNull() && !editFormInitFilePathNode.toElement().text().isEmpty() ) )
+  {
+    mEditFormConfig->setInitFilePath( editFormInitFilePathNode.toElement().text() );
   }
 
   QDomNode fFSuppNode = node.namedItem( "featformsuppress" );
@@ -2054,9 +2060,14 @@ bool QgsVectorLayer::writeSymbology( QDomNode& node, QDomDocument& doc, QString&
     efiField.appendChild( doc.createTextNode( mEditFormConfig->initFunction() ) );
   node.appendChild( efiField );
 
-  QDomElement efiucField  = doc.createElement( "editforminitusecode" );
-  efiucField.appendChild( doc.createTextNode( mEditFormConfig->useInitCode() ? "1" : "0" ) );
-  node.appendChild( efiucField );
+  QDomElement eficsField  = doc.createElement( "editforminitcodesource" );
+  eficsField.appendChild( doc.createTextNode( QString::number( mEditFormConfig->initCodeSource() ) ) );
+  node.appendChild( eficsField );
+
+  QDomElement efifpField  = doc.createElement( "editforminitfilepath" );
+  efifpField.appendChild( doc.createTextNode( mEditFormConfig->initFilePath() ) );
+  node.appendChild( efifpField );
+
 
   QDomElement eficField  = doc.createElement( "editforminitcode" );
   eficField.appendChild( doc.createCDATASection( mEditFormConfig->initCode() ) );

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -37,6 +37,7 @@
 #include <QScrollArea>
 #include <QTabWidget>
 #include <QUiLoader>
+#include <QMessageBox>
 
 int QgsAttributeForm::sFormCounter = 0;
 
@@ -576,7 +577,8 @@ void QgsAttributeForm::initPython()
 {
   cleanPython();
 
-  // Init Python
+  // Init Python, if init function is not empty and the combo indicates
+  // the source for the function code
   if ( !mLayer->editFormConfig()->initFunction().isEmpty()
        && mLayer->editFormConfig()->initCodeSource() != QgsEditFormConfig::PythonInitCodeSource::CodeSourceNone )
   {
@@ -621,7 +623,7 @@ void QgsAttributeForm::initPython()
       case( QgsEditFormConfig::PythonInitCodeSource::CodeSourceEnvironment ):
       case( QgsEditFormConfig::PythonInitCodeSource::CodeSourceNone ):
       default:
-        // Nothing to do
+        // Nothing to do: the function code should be already in the environment
         break;
     }
 
@@ -655,6 +657,10 @@ void QgsAttributeForm::initPython()
       }
       else
       {
+        // If we get here, it means that the function doesn't accept three arguments
+        QMessageBox msgBox;
+        msgBox.setText( tr( "The python init function (<code>%1</code>) does not accept three arguments as expected!<br>Please check the function name in the  <b>Fields</b> tab of the layer properties." ).arg( initFunction ) );
+        msgBox.exec();
 #if 0
         QString expr = QString( "%1(%2)" )
                        .arg( mLayer->editFormInit() )
@@ -667,7 +673,10 @@ void QgsAttributeForm::initPython()
     }
     else
     {
-      QgsLogger::warning( QString( "There was an error evaluating the python init function!" ) );
+      // If we get here, it means that inspect couldn't find the function
+      QMessageBox msgBox;
+      msgBox.setText( tr( "The python init function (<code>%1</code>) could not be found!<br>Please check the function name in the <b>Fields</b> tab of the layer properties." ).arg( initFunction ) );
+      msgBox.exec();
     }
   }
 }

--- a/src/ui/qgsfieldspropertiesbase.ui
+++ b/src/ui/qgsfieldspropertiesbase.ui
@@ -6,12 +6,12 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>965</width>
-    <height>634</height>
+    <width>614</width>
+    <height>423</height>
    </rect>
   </property>
   <layout class="QGridLayout" name="gridLayout_6">
-   <item row="1" column="0" colspan="7">
+   <item row="0" column="0">
     <layout class="QHBoxLayout" name="horizontalLayout_3">
      <item>
       <widget class="QLabel" name="label_2">
@@ -66,16 +66,21 @@
        <property name="toolTip">
         <string>QGIS forms can have a Python function that is called when the form is opened.
 Use this function to add extra logic to your forms.
+The function code of the function can be loaded from the source code entered 
+in this dialog,  from an external python file or from the environment (for example 
+from a plugin or from startup.py).
 
-An example is (in module MyForms.py):
+An example is:
 
-          def open(dialog, layer, feature):
+          from PyQt4.QtGui import QWidget
+
+          def my_form_open(dialog, layer, feature):
 	geom = feature.geometry()
 	control = dialog.findChild(QWidget,&quot;MyLineEdit&quot;)
 
-Reference in Python Init Function like so: MyForms.open
+Reference in function name: my_form_open
 
-MyForms.py must live on PYTHONPATH, .qgis/python, or inside the project folder.</string>
+</string>
        </property>
        <property name="text">
         <string>Python Init function</string>
@@ -83,54 +88,92 @@ MyForms.py must live on PYTHONPATH, .qgis/python, or inside the project folder.<
       </widget>
      </item>
      <item>
-      <widget class="QLineEdit" name="leEditFormInit">
+      <widget class="QComboBox" name="mInitCodeSourceComboBox">
        <property name="toolTip">
         <string>QGIS forms can have a Python function that is called when the form is opened.
-Use this function to add extra logic to your forms. You can either provide the python 
-code directly in this dialog or run the code from an external file (that must live on 
-PYTHONPATH, .qgis/python, or inside the project folder).
+Use this function to add extra logic to your forms.
+The function code of the function can be loaded from the source code entered 
+in this dialog,  from an external python file or from the environment (for example 
+from a plugin or from startup.py).
 
-An example is (in module MyForms.py):
+An example is:
 
-          def open(dialog, layer, feature):
+          from PyQt4.QtGui import QWidget
+
+          def my_form_open(dialog, layer, feature):
 	geom = feature.geometry()
 	control = dialog.findChild(QWidget,&quot;MyLineEdit&quot;)
 
-Reference in Python Init Function like so: &quot;MyForms.open&quot; or just &quot;open&quot; if provided
-directly in this dialog. 
-
+Reference in function name: my_form_open
 
 </string>
        </property>
       </widget>
      </item>
+    </layout>
+   </item>
+   <item row="3" column="0">
+    <layout class="QHBoxLayout" name="horizontalLayout">
      <item>
-      <spacer name="horizontalSpacer_3">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
+      <widget class="QLabel" name="mFormSuppressLabel">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Maximum">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
        </property>
-       <property name="sizeHint" stdset="0">
+       <property name="minimumSize">
         <size>
-         <width>40</width>
-         <height>20</height>
+         <width>150</width>
+         <height>0</height>
         </size>
        </property>
-      </spacer>
+       <property name="text">
+        <string>Suppress attribute form pop-up after feature creation</string>
+       </property>
+       <property name="alignment">
+        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+       </property>
+       <property name="wordWrap">
+        <bool>true</bool>
+       </property>
+      </widget>
      </item>
      <item>
-      <widget class="QCheckBox" name="leEditFormInitUseCode">
-       <property name="toolTip">
-        <string>Check this box to provide python init function code here instead of using an external file.</string>
+      <widget class="QComboBox" name="mFormSuppressCmbBx">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
        </property>
-       <property name="text">
-        <string>Use provided code</string>
-       </property>
+       <item>
+        <property name="text">
+         <string>Default</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>On</string>
+        </property>
+       </item>
+       <item>
+        <property name="text">
+         <string>Off</string>
+        </property>
+       </item>
       </widget>
      </item>
     </layout>
    </item>
-   <item row="2" column="0" colspan="7">
+   <item row="2" column="0">
     <widget class="QSplitter" name="mSplitter">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
      </property>
@@ -164,7 +207,7 @@ directly in this dialog.
                </property>
                <property name="icon">
                 <iconset>
-                 <normaloff>.designer/xpm/delete_attribute.png</normaloff>.designer/xpm/delete_attribute.png</iconset>
+                 <normaloff>../../../../.designer/backup/.designer/xpm/delete_attribute.png</normaloff>../../../../.designer/backup/.designer/xpm/delete_attribute.png</iconset>
                </property>
                <property name="shortcut">
                 <string>Ctrl+X</string>
@@ -219,7 +262,7 @@ directly in this dialog.
                </property>
                <property name="icon">
                 <iconset>
-                 <normaloff>.designer/xpm/new_attribute.png</normaloff>.designer/xpm/new_attribute.png</iconset>
+                 <normaloff>../../../../.designer/backup/.designer/xpm/new_attribute.png</normaloff>../../../../.designer/backup/.designer/xpm/new_attribute.png</iconset>
                </property>
                <property name="shortcut">
                 <string>Ctrl+N</string>
@@ -264,7 +307,7 @@ directly in this dialog.
           </property>
           <layout class="QGridLayout" name="gridLayout">
            <item row="0" column="0">
-            <widget class="QgsCodeEditorPython" name="leEditFormInitCode" native="true"/>
+            <widget class="QgsCodeEditorPython" name="mInitCodeEditorPython" native="true"/>
            </item>
           </layout>
          </widget>
@@ -293,7 +336,7 @@ directly in this dialog.
         <item row="0" column="1">
          <layout class="QHBoxLayout" name="horizontalLayout_2">
           <item>
-           <widget class="QLineEdit" name="leEditForm"/>
+           <widget class="QLineEdit" name="mEditFormLineEdit"/>
           </item>
           <item>
            <widget class="QToolButton" name="pbnSelectEditForm">
@@ -486,59 +529,73 @@ directly in this dialog.
      </widget>
     </widget>
    </item>
-   <item row="3" column="0" colspan="7">
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QLabel" name="mFormSuppressLabel">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="MinimumExpanding" vsizetype="Maximum">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <property name="minimumSize">
-        <size>
-         <width>150</width>
-         <height>0</height>
-        </size>
-       </property>
-       <property name="text">
-        <string>Suppress attribute form pop-up after feature creation</string>
-       </property>
-       <property name="alignment">
-        <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
-       </property>
-       <property name="wordWrap">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QComboBox" name="mFormSuppressCmbBx">
-       <property name="sizePolicy">
-        <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-         <horstretch>0</horstretch>
-         <verstretch>0</verstretch>
-        </sizepolicy>
-       </property>
-       <item>
+   <item row="1" column="0">
+    <widget class="QWidget" name="mInitFunctionContainer" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Preferred" vsizetype="Minimum">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <layout class="QHBoxLayout" name="horizontalLayout_4">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
+       <number>0</number>
+      </property>
+      <item>
+       <widget class="QLabel" name="mInitFunctionLabel">
         <property name="text">
-         <string>Default</string>
+         <string>Function name</string>
         </property>
-       </item>
-       <item>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLineEdit" name="mInitFunctionLineEdit">
+        <property name="toolTip">
+         <string>Enter the name of the form init function.</string>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLabel" name="mInitFilePathLabel">
         <property name="text">
-         <string>On</string>
+         <string>External file</string>
         </property>
-       </item>
-       <item>
+       </widget>
+      </item>
+      <item>
+       <widget class="QLineEdit" name="mInitFilePathLineEdit"/>
+      </item>
+      <item>
+       <widget class="QToolButton" name="pbtnSelectInitFilePath">
         <property name="text">
-         <string>Off</string>
+         <string>...</string>
         </property>
-       </item>
-      </widget>
-     </item>
-    </layout>
+       </widget>
+      </item>
+      <item>
+       <spacer name="horizontalSpacer_4">
+        <property name="orientation">
+         <enum>Qt::Horizontal</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>0</width>
+          <height>0</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
    </item>
   </layout>
  </widget>
@@ -558,12 +615,11 @@ directly in this dialog.
  </customwidgets>
  <tabstops>
   <tabstop>mEditorLayoutComboBox</tabstop>
-  <tabstop>leEditFormInit</tabstop>
   <tabstop>mAddAttributeButton</tabstop>
   <tabstop>mDeleteAttributeButton</tabstop>
   <tabstop>mToggleEditingButton</tabstop>
   <tabstop>mCalculateFieldButton</tabstop>
-  <tabstop>leEditForm</tabstop>
+  <tabstop>mEditFormLineEdit</tabstop>
   <tabstop>pbnSelectEditForm</tabstop>
   <tabstop>mAddTabOrGroupButton</tabstop>
   <tabstop>mRemoveTabGroupItemButton</tabstop>


### PR DESCRIPTION
Do not rely on the presence of a dot to load
a module. Loading a module can now be achieved
through the code editor in the dialog.
- added an option to load from environment
- added a file selector to specify the file
- changed tooltips accordingly

This is the new GUI:

![qgis_store_python_code_latest](https://cloud.githubusercontent.com/assets/142164/11364767/b3e10742-92a2-11e5-9d94-14207756dc29.png)

When loading from external file:

![qgis_store_python_code_latest_ext_file](https://cloud.githubusercontent.com/assets/142164/11364799/ed4a0d9e-92a2-11e5-9c68-859c29da5ee9.png)
