### PR TITLE
Check for short-circuit in QgsCoordinateTransform::transformCoords

### DIFF
--- a/src/core/qgscoordinatetransform.cpp
+++ b/src/core/qgscoordinatetransform.cpp
@@ -634,6 +634,11 @@ QgsRectangle QgsCoordinateTransform::transformBoundingBox( const QgsRectangle &r
 
 void QgsCoordinateTransform::transformCoords( const int& numPoints, double *x, double *y, double *z, TransformDirection direction ) const
 {
+  // Usually this check is performed by the caller already (in this class).
+  // However, QgsLineStringV2 and QgsCircularStringV2 call this function
+  // directly without performing this check, so it is also necessary here.
+  if ( mShortCircuit || !mInitialisedFlag )
+    return;
   // Refuse to transform the points if the srs's are invalid
   if ( !mSourceCRS.isValid() )
   {


### PR DESCRIPTION
As the comment in the added code says: QgsCoordinateTransform::transformCoords is usually used internally inside the QgsCoordinateTransform class, where the callers check for mShortCircuit in order to not transform anything (and thus to avoid floating point errors) if, for example, source and destination CRS are the same. However, QgsCoordinateTransform::transformCoords is also called directly from within the transform methods of QgsLineStringV2 and QgsCircularStringV2. Thus, this method also needs to be equipped with this check.

(P.S. This problem is what broke my other pull request: https://github.com/qgis/QGIS/pull/2434)
