### PR TITLE
enable/disable buttons in the rule based style dialog (fixes #6708)

### DIFF
--- a/python/gui/symbology-ng/qgsrulebasedrendererv2widget.sip
+++ b/python/gui/symbology-ng/qgsrulebasedrendererv2widget.sip
@@ -79,6 +79,7 @@ class QgsRuleBasedRendererV2Widget : QgsRendererV2Widget
     void setRenderingOrder();
 
     void currentRuleChanged( const QModelIndex& current = QModelIndex(), const QModelIndex& previous = QModelIndex() );
+    void selectedRulesChanged();
 
     void saveSectionWidth( int section, int oldSize, int newSize );
     void restoreSectionWidths();

--- a/src/gui/symbology-ng/qgsrulebasedrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgsrulebasedrendererv2widget.cpp
@@ -95,6 +95,7 @@ QgsRuleBasedRendererV2Widget::QgsRuleBasedRendererV2Widget( QgsVectorLayer* laye
   connect( viewRules, SIGNAL( customContextMenuRequested( const QPoint& ) ),  this, SLOT( contextMenuViewCategories( const QPoint& ) ) );
 
   connect( viewRules->selectionModel(), SIGNAL( currentChanged( QModelIndex, QModelIndex ) ), this, SLOT( currentRuleChanged( QModelIndex, QModelIndex ) ) );
+  connect( viewRules->selectionModel(), SIGNAL( selectionChanged( QItemSelection, QItemSelection ) ), this, SLOT( selectedRulesChanged() ) );
 
   connect( btnAddRule, SIGNAL( clicked() ), this, SLOT( addRule() ) );
   connect( btnEditRule, SIGNAL( clicked() ), this, SLOT( editRule() ) );
@@ -105,6 +106,7 @@ QgsRuleBasedRendererV2Widget::QgsRuleBasedRendererV2Widget( QgsVectorLayer* laye
   connect( btnRenderingOrder, SIGNAL( clicked() ), this, SLOT( setRenderingOrder() ) );
 
   currentRuleChanged();
+  selectedRulesChanged();
 
   // store/restore header section widths
   connect( viewRules->header(), SIGNAL( sectionResized( int, int, int ) ), this, SLOT( saveSectionWidth( int, int, int ) ) );
@@ -200,7 +202,7 @@ void QgsRuleBasedRendererV2Widget::removeRule()
 void QgsRuleBasedRendererV2Widget::currentRuleChanged( const QModelIndex& current, const QModelIndex& previous )
 {
   Q_UNUSED( previous );
-  btnRefineRule->setEnabled( current.isValid() );
+  btnEditRule->setEnabled( current.isValid() );
 }
 
 
@@ -576,6 +578,13 @@ void QgsRuleBasedRendererV2Widget::countFeatures()
 #endif
 
   mModel->setFeatureCounts( countMap );
+}
+
+void QgsRuleBasedRendererV2Widget::selectedRulesChanged()
+{
+  bool enabled = !viewRules->selectionModel()->selectedIndexes().isEmpty();
+  btnRefineRule->setEnabled( enabled );
+  btnRemoveRule->setEnabled( enabled );
 }
 
 ///////////

--- a/src/gui/symbology-ng/qgsrulebasedrendererv2widget.h
+++ b/src/gui/symbology-ng/qgsrulebasedrendererv2widget.h
@@ -126,6 +126,7 @@ class GUI_EXPORT QgsRuleBasedRendererV2Widget : public QgsRendererV2Widget, priv
     void setRenderingOrder();
 
     void currentRuleChanged( const QModelIndex& current = QModelIndex(), const QModelIndex& previous = QModelIndex() );
+    void selectedRulesChanged();
 
     void saveSectionWidth( int section, int oldSize, int newSize );
     void restoreSectionWidths();

--- a/src/ui/qgsrulebasedrendererv2widget.ui
+++ b/src/ui/qgsrulebasedrendererv2widget.ui
@@ -64,7 +64,7 @@
      <item>
       <widget class="QPushButton" name="btnEditRule">
        <property name="toolTip">
-        <string>Edit rule</string>
+        <string>Edit current rule</string>
        </property>
        <property name="text">
         <string/>
@@ -78,7 +78,7 @@
      <item>
       <widget class="QPushButton" name="btnRemoveRule">
        <property name="toolTip">
-        <string>Remove rule</string>
+        <string>Remove selected rules</string>
        </property>
        <property name="text">
         <string/>
@@ -95,7 +95,7 @@
         <bool>true</bool>
        </property>
        <property name="text">
-        <string>Refine current rules</string>
+        <string>Refine selected rules</string>
        </property>
        <property name="checkable">
         <bool>false</bool>


### PR DESCRIPTION
This PR fixes the logic when certain buttons should be enabled/disabled in `QgsRuleBasedRendererV2Widget`.
Also changed a button label and a tooltip to be more precise, because the difference between _current_ and _selected_ can be very subtle (e.g. one row is the current row, but another one is selected).
