### PR TITLE
Fix problem with QSpinBox error in Processing dialog windows, fixes #13884

### DIFF
--- a/python/plugins/processing/gui/ConfigDialog.py
+++ b/python/plugins/processing/gui/ConfigDialog.py
@@ -230,7 +230,7 @@ class SettingDelegate(QStyledItemDelegate):
                 model.setData(index, editor.value(), Qt.EditRole)
 
     def sizeHint(self, option, index):
-        return QSpinBox().sizeHint()
+        return QgsSpinBox().sizeHint()
 
     def eventFilter(self, editor, event):
         if event.type() == QEvent.FocusOut and hasattr(editor, 'canFocusOut'):


### PR DESCRIPTION
fixes #13884
This will cause QGIS to crash, when accessing Processing > Options
items.
See ticket:
http://hub.qgis.org/issues/13884
