### PR TITLE
changes to annotations mark the project dirty (fixes #7586)

### DIFF
--- a/src/app/qgsmaptoolannotation.cpp
+++ b/src/app/qgsmaptoolannotation.cpp
@@ -26,6 +26,7 @@
 #include "qgstextannotationitem.h"
 #include "qgssvgannotationdialog.h"
 #include "qgssvgannotationitem.h"
+#include "qgsproject.h"
 #include <QDialog>
 #include <QMouseEvent>
 
@@ -141,6 +142,7 @@ void QgsMapToolAnnotation::keyPressEvent( QKeyEvent* e )
         mCanvas->scene()->removeItem( sItem );
         delete sItem;
         mCanvas->setCursor( neutralCursor );
+        QgsProject::instance()->setDirty( true ); // TODO QGIS3: Rework the whole annotation code to be MVC compliant, see PR #2506
 
         // Override default shortcut management in MapCanvas
         e->ignore();
@@ -158,6 +160,7 @@ void QgsMapToolAnnotation::canvasMoveEvent( QgsMapMouseEvent* e )
     {
       sItem->setMapPosition( toMapCoordinates( e->pos() ) );
       sItem->update();
+      QgsProject::instance()->setDirty( true );
     }
     else if ( mCurrentMoveAction == QgsAnnotationItem::MoveFramePosition )
     {
@@ -171,6 +174,7 @@ void QgsMapToolAnnotation::canvasMoveEvent( QgsMapMouseEvent* e )
         sItem->setMapPosition( toMapCoordinates( newCanvasPos.toPoint() ) );
       }
       sItem->update();
+      QgsProject::instance()->setDirty( true );
     }
     else if ( mCurrentMoveAction != QgsAnnotationItem::NoAction )
     {
@@ -220,6 +224,7 @@ void QgsMapToolAnnotation::canvasMoveEvent( QgsMapMouseEvent* e )
       sItem->setOffsetFromReferencePoint( QPointF( xmin, ymin ) );
       sItem->setFrameSize( QSizeF( xmax - xmin, ymax - ymin ) );
       sItem->update();
+      QgsProject::instance()->setDirty( true );
     }
   }
   else if ( sItem )
@@ -243,7 +248,8 @@ void QgsMapToolAnnotation::canvasDoubleClickEvent( QgsMapMouseEvent* e )
   QDialog* itemEditor = createItemEditor( item );
   if ( itemEditor )
   {
-    itemEditor->exec();
+    if ( itemEditor->exec() )
+      QgsProject::instance()->setDirty( true );
     delete itemEditor;
   }
 }

--- a/src/app/qgsmaptoolformannotation.cpp
+++ b/src/app/qgsmaptoolformannotation.cpp
@@ -19,6 +19,7 @@
 #include "qgsformannotationitem.h"
 #include "qgsmapcanvas.h"
 #include "qgsvectorlayer.h"
+#include "qgsproject.h"
 #include <QMouseEvent>
 
 QgsMapToolFormAnnotation::QgsMapToolFormAnnotation( QgsMapCanvas* canvas ): QgsMapToolAnnotation( canvas )
@@ -48,6 +49,7 @@ QgsAnnotationItem* QgsMapToolFormAnnotation::createItem( QMouseEvent* e )
   formItem->setMapPosition( toMapCoordinates( e->pos() ) );
   formItem->setSelected( true );
   formItem->setFrameSize( QSizeF( 200, 100 ) );
+  QgsProject::instance()->setDirty( true );
   return formItem;
 }
 

--- a/src/app/qgsmaptoolhtmlannotation.cpp
+++ b/src/app/qgsmaptoolhtmlannotation.cpp
@@ -19,6 +19,7 @@
 #include "qgshtmlannotationitem.h"
 #include "qgsmapcanvas.h"
 #include "qgsvectorlayer.h"
+#include "qgsproject.h"
 #include <QMouseEvent>
 
 QgsMapToolHtmlAnnotation::QgsMapToolHtmlAnnotation( QgsMapCanvas* canvas ): QgsMapToolAnnotation( canvas )
@@ -48,6 +49,7 @@ QgsAnnotationItem* QgsMapToolHtmlAnnotation::createItem( QMouseEvent* e )
   formItem->setMapPosition( toMapCoordinates( e->pos() ) );
   formItem->setSelected( true );
   formItem->setFrameSize( QSizeF( 200, 100 ) );
+  QgsProject::instance()->setDirty( true );
   return formItem;
 }
 

--- a/src/app/qgsmaptoolsvgannotation.cpp
+++ b/src/app/qgsmaptoolsvgannotation.cpp
@@ -17,6 +17,7 @@
 
 #include "qgsmaptoolsvgannotation.h"
 #include "qgssvgannotationitem.h"
+#include "qgsproject.h"
 #include <QMouseEvent>
 
 QgsMapToolSvgAnnotation::QgsMapToolSvgAnnotation( QgsMapCanvas* canvas ): QgsMapToolAnnotation( canvas )
@@ -35,5 +36,6 @@ QgsAnnotationItem* QgsMapToolSvgAnnotation::createItem( QMouseEvent* e )
   svgItem->setMapPosition( toMapCoordinates( e->pos() ) );
   svgItem->setSelected( true );
   svgItem->setFrameSize( QSizeF( 200, 100 ) );
+  QgsProject::instance()->setDirty( true );
   return svgItem;
 }

--- a/src/app/qgsmaptooltextannotation.cpp
+++ b/src/app/qgsmaptooltextannotation.cpp
@@ -17,6 +17,7 @@
 
 #include "qgsmaptooltextannotation.h"
 #include "qgstextannotationitem.h"
+#include "qgsproject.h"
 #include <QMouseEvent>
 
 QgsMapToolTextAnnotation::QgsMapToolTextAnnotation( QgsMapCanvas* canvas ): QgsMapToolAnnotation( canvas )
@@ -36,6 +37,7 @@ QgsAnnotationItem* QgsMapToolTextAnnotation::createItem( QMouseEvent* e )
   textItem->setMapPosition( toMapCoordinates( e->pos() ) );
   textItem->setFrameSize( QSizeF( 200, 100 ) );
   textItem->setSelected( true );
+  QgsProject::instance()->setDirty( true );
   return textItem;
 }
 


### PR DESCRIPTION
Changes to annotations (adding, editing, resizing, moving, deleting) now mark the project dirty. So these changes can't just vanish unnoticed when closing the project.

When testing please keep in mind [Redmine # 13887](https://hub.qgis.org/issues/13887), e.g. make sure to have at least one layer in the project.
