### PR TITLE
Add feature limit support for feature requests

### DIFF
--- a/python/core/qgsfeaturerequest.sip
+++ b/python/core/qgsfeaturerequest.sip
@@ -92,6 +92,19 @@ class QgsFeatureRequest
      */
     QgsFeatureRequest& disableFilter();
 
+    /** Set the maximum number of features to request.
+     * @param limit maximum number of features, or -1 to request all features.
+     * @see limit()
+     * @note added in QGIS 2.14
+     */
+    QgsFeatureRequest& setLimit( long limit );
+
+    /** Returns the maximum number of features to request, or -1 if no limit set.
+     * @see setLimit
+     * @note added in QGIS 2.14
+     */
+    long limit() const;
+
     //! Set flags that affect how features will be fetched
     QgsFeatureRequest& setFlags( const Flags& flags );
     const Flags& flags() const;

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -2184,6 +2184,7 @@ static QVariant fcnGetFeature( const QVariantList& values, const QgsExpressionCo
   QgsFeatureRequest req;
   req.setFilterExpression( QString( "%1=%2" ).arg( QgsExpression::quotedColumnRef( attribute ),
                            QgsExpression::quotedString( attVal.toString() ) ) );
+  req.setLimit( 1 );
   if ( !parent->needsGeometry() )
   {
     req.setFlags( QgsFeatureRequest::NoGeometry );

--- a/src/core/qgsfeatureiterator.cpp
+++ b/src/core/qgsfeatureiterator.cpp
@@ -22,6 +22,7 @@ QgsAbstractFeatureIterator::QgsAbstractFeatureIterator( const QgsFeatureRequest&
     : mRequest( request )
     , mClosed( false )
     , refs( 0 )
+    , mFetchedCount( 0 )
     , mGeometrySimplifier( NULL )
     , mLocalSimplification( false )
 {
@@ -36,6 +37,10 @@ QgsAbstractFeatureIterator::~QgsAbstractFeatureIterator()
 bool QgsAbstractFeatureIterator::nextFeature( QgsFeature& f )
 {
   bool dataOk = false;
+  if ( mRequest.limit() >= 0 && mFetchedCount >= mRequest.limit() )
+  {
+    return false;
+  }
 
   switch ( mRequest.filterType() )
   {
@@ -59,6 +64,9 @@ bool QgsAbstractFeatureIterator::nextFeature( QgsFeature& f )
     if ( geometry )
       simplify( f );
   }
+  if ( dataOk )
+    mFetchedCount++;
+
   return dataOk;
 }
 

--- a/src/core/qgsfeatureiterator.h
+++ b/src/core/qgsfeatureiterator.h
@@ -87,6 +87,9 @@ class CORE_EXPORT QgsAbstractFeatureIterator
     void deref(); //!< remove reference, delete if refs == 0
     friend class QgsFeatureIterator;
 
+    //! Number of features already fetched by iterator
+    long mFetchedCount;
+
     //! Setup the simplification of geometries to fetch using the specified simplify method
     virtual bool prepareSimplification( const QgsSimplifyMethod& simplifyMethod );
 
@@ -198,11 +201,17 @@ inline bool QgsFeatureIterator::nextFeature( QgsFeature& f )
 
 inline bool QgsFeatureIterator::rewind()
 {
+  if ( mIter )
+    mIter->mFetchedCount = 0;
+
   return mIter ? mIter->rewind() : false;
 }
 
 inline bool QgsFeatureIterator::close()
 {
+  if ( mIter )
+    mIter->mFetchedCount = 0;
+
   return mIter ? mIter->close() : false;
 }
 

--- a/src/core/qgsfeaturerequest.cpp
+++ b/src/core/qgsfeaturerequest.cpp
@@ -27,6 +27,7 @@ QgsFeatureRequest::QgsFeatureRequest()
     , mFilterFid( -1 )
     , mFilterExpression( 0 )
     , mFlags( 0 )
+    , mLimit( -1 )
 {
 }
 
@@ -35,6 +36,7 @@ QgsFeatureRequest::QgsFeatureRequest( QgsFeatureId fid )
     , mFilterFid( fid )
     , mFilterExpression( 0 )
     , mFlags( 0 )
+    , mLimit( -1 )
 {
 }
 
@@ -44,6 +46,7 @@ QgsFeatureRequest::QgsFeatureRequest( const QgsRectangle& rect )
     , mFilterFid( -1 )
     , mFilterExpression( 0 )
     , mFlags( 0 )
+    , mLimit( -1 )
 {
 }
 
@@ -53,6 +56,7 @@ QgsFeatureRequest::QgsFeatureRequest( const QgsExpression& expr, const QgsExpres
     , mFilterExpression( new QgsExpression( expr.expression() ) )
     , mExpressionContext( context )
     , mFlags( 0 )
+    , mLimit( -1 )
 {
 }
 
@@ -79,6 +83,7 @@ QgsFeatureRequest& QgsFeatureRequest::operator=( const QgsFeatureRequest & rh )
   mExpressionContext = rh.mExpressionContext;
   mAttrs = rh.mAttrs;
   mSimplifyMethod = rh.mSimplifyMethod;
+  mLimit = rh.mLimit;
   return *this;
 }
 
@@ -102,7 +107,7 @@ QgsFeatureRequest& QgsFeatureRequest::setFilterFid( QgsFeatureId fid )
   return *this;
 }
 
-QgsFeatureRequest&QgsFeatureRequest::setFilterFids( const QgsFeatureIds& fids )
+QgsFeatureRequest& QgsFeatureRequest::setFilterFids( const QgsFeatureIds& fids )
 {
   mFilter = FilterFids;
   mFilterFids = fids;
@@ -117,7 +122,7 @@ QgsFeatureRequest& QgsFeatureRequest::setFilterExpression( const QString& expres
   return *this;
 }
 
-QgsFeatureRequest&QgsFeatureRequest::combineFilterExpression( const QString& expression )
+QgsFeatureRequest& QgsFeatureRequest::combineFilterExpression( const QString& expression )
 {
   if ( mFilterExpression )
   {
@@ -133,6 +138,12 @@ QgsFeatureRequest&QgsFeatureRequest::combineFilterExpression( const QString& exp
 QgsFeatureRequest &QgsFeatureRequest::setExpressionContext( const QgsExpressionContext &context )
 {
   mExpressionContext = context;
+  return *this;
+}
+
+QgsFeatureRequest& QgsFeatureRequest::setLimit( long limit )
+{
+  mLimit = limit;
   return *this;
 }
 

--- a/src/core/qgsfeaturerequest.h
+++ b/src/core/qgsfeaturerequest.h
@@ -175,6 +175,19 @@ class CORE_EXPORT QgsFeatureRequest
      */
     QgsFeatureRequest& disableFilter() { mFilter = FilterNone; return *this; }
 
+    /** Set the maximum number of features to request.
+     * @param limit maximum number of features, or -1 to request all features.
+     * @see limit()
+     * @note added in QGIS 2.14
+     */
+    QgsFeatureRequest& setLimit( long limit );
+
+    /** Returns the maximum number of features to request, or -1 if no limit set.
+     * @see setLimit
+     * @note added in QGIS 2.14
+     */
+    long limit() const { return mLimit; }
+
     //! Set flags that affect how features will be fetched
     QgsFeatureRequest& setFlags( const QgsFeatureRequest::Flags& flags );
     const Flags& flags() const { return mFlags; }
@@ -223,6 +236,7 @@ class CORE_EXPORT QgsFeatureRequest
     Flags mFlags;
     QgsAttributeList mAttrs;
     QgsSimplifyMethod mSimplifyMethod;
+    long mLimit;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsFeatureRequest::Flags )

--- a/src/providers/mssql/qgsmssqlfeatureiterator.cpp
+++ b/src/providers/mssql/qgsmssqlfeatureiterator.cpp
@@ -63,6 +63,9 @@ void QgsMssqlFeatureIterator::BuildStatement( const QgsFeatureRequest& request )
   // build sql statement
   mStatement = QString( "SELECT " );
 
+  if ( request.limit() >= 0 && request.filterType() != QgsFeatureRequest::FilterExpression )
+    mStatement += QString( "TOP %1 " ).arg( mRequest.limit() );
+
   mStatement += QString( "[%1]" ).arg( mSource->mFidColName );
   mFidCol = mSource->mFields.indexFromName( mSource->mFidColName );
   mAttributesToFetch.append( mFidCol );

--- a/src/providers/postgres/qgspostgresfeatureiterator.h
+++ b/src/providers/postgres/qgspostgresfeatureiterator.h
@@ -97,7 +97,7 @@ class QgsPostgresFeatureIterator : public QgsAbstractFeatureIteratorFromSource<Q
     QString whereClauseRect();
     bool getFeature( QgsPostgresResult &queryResult, int row, QgsFeature &feature );
     void getFeatureAttribute( int idx, QgsPostgresResult& queryResult, int row, int& col, QgsFeature& feature );
-    bool declareCursor( const QString& whereClause );
+    bool declareCursor( const QString& whereClause, long limit = -1 );
 
     QString mCursorName;
 

--- a/src/providers/spatialite/qgsspatialitefeatureiterator.h
+++ b/src/providers/spatialite/qgsspatialitefeatureiterator.h
@@ -77,7 +77,7 @@ class QgsSpatiaLiteFeatureIterator : public QgsAbstractFeatureIteratorFromSource
     QString whereClauseFid();
     QString whereClauseFids();
     QString mbr( const QgsRectangle& rect );
-    bool prepareStatement( const QString& whereClause );
+    bool prepareStatement( const QString& whereClause, long limit = -1 );
     QString quotedPrimaryKey();
     bool getFeature( sqlite3_stmt *stmt, QgsFeature &feature );
     QString fieldName( const QgsField& fld );


### PR DESCRIPTION
Here's an implementation of adding limits to QgsFeatureRequest. Setting a limit will restrict the maximum number of features returned by the request. This limit can be passed on to the provider for limiting the query results on the server side, yielding performance benefits when only a set number of features is required.

I'm looking for feedback on the approach and whether this is the right way to implement this.
