### PR TITLE
Update rubber band after editing nodes

### DIFF
--- a/src/app/nodetool/qgsmaptoolnodetool.cpp
+++ b/src/app/nodetool/qgsmaptoolnodetool.cpp
@@ -114,8 +114,12 @@ void QgsMapToolNodeTool::canvasMoveEvent( QgsMapMouseEvent* e )
   {
     if ( mMoveRubberBands.empty() )
     {
-      delete mSelectRubberBand;
-      mSelectRubberBand = 0;
+      QSettings settings;
+      bool ghostLine = settings.value( "/qgis/digitizing/line_ghost", true ).toBool();
+      if ( !ghostLine ) {
+        delete mSelectRubberBand;
+        mSelectRubberBand = nullptr;
+      }
       QgsGeometryRubberBand* rb = new QgsGeometryRubberBand( mCanvas, mSelectedFeature->geometry()->type() );
       rb->setOutlineColor( Qt::blue );
       rb->setBrushStyle( Qt::NoBrush );
@@ -397,7 +401,9 @@ void QgsMapToolNodeTool::selectedFeatureDestroyed()
 
 void QgsMapToolNodeTool::geometryChanged( QgsFeatureId fid, QgsGeometry &geom )
 {
-  if ( mSelectedFeature && ( mSelectedFeature->featureId() == fid ) )
+  QSettings settings;
+  bool ghostLine = settings.value( "/qgis/digitizing/line_ghost", true ).toBool();
+  if ( !ghostLine && mSelectedFeature && ( mSelectedFeature->featureId() == fid ) )
   {
     updateSelectFeature( geom );
   }
@@ -518,8 +524,6 @@ void QgsMapToolNodeTool::canvasReleaseEvent( QgsMapMouseEvent* e )
 
     mDeselectOnRelease = -1;
   }
-
-  updateSelectFeature();
 }
 
 void QgsMapToolNodeTool::deactivate()

--- a/src/app/nodetool/qgsmaptoolnodetool.cpp
+++ b/src/app/nodetool/qgsmaptoolnodetool.cpp
@@ -366,23 +366,27 @@ void QgsMapToolNodeTool::updateSelectFeature( QgsGeometry &geom )
 {
   delete mSelectRubberBand;
 
-  mSelectRubberBand = new QgsGeometryRubberBand( mCanvas, mSelectedFeature->geometry()->type() );
-  mSelectRubberBand->setBrushStyle( Qt::SolidPattern );
+  if ( geom.geometry() ) {
+    mSelectRubberBand = new QgsGeometryRubberBand( mCanvas, mSelectedFeature->geometry()->type() );
+    mSelectRubberBand->setBrushStyle( Qt::SolidPattern );
 
-  QSettings settings;
-  QColor color(
-    settings.value( "/qgis/digitizing/select_color_red", 255 ).toInt(),
-    settings.value( "/qgis/digitizing/select_color_green", 0 ).toInt(),
-    settings.value( "/qgis/digitizing/select_color_blue", 0 ).toInt() );
-  double myAlpha = settings.value( "/qgis/digitizing/select_color_alpha", 30 ).toInt() / 255.0 ;
-  color.setAlphaF( myAlpha );
-  mSelectRubberBand->setFillColor( color );
+    QSettings settings;
+    QColor color(
+      settings.value( "/qgis/digitizing/select_color_red", 255 ).toInt(),
+      settings.value( "/qgis/digitizing/select_color_green", 0 ).toInt(),
+      settings.value( "/qgis/digitizing/select_color_blue", 0 ).toInt() );
+    double myAlpha = settings.value( "/qgis/digitizing/select_color_alpha", 30 ).toInt() / 255.0 ;
+    color.setAlphaF( myAlpha );
+    mSelectRubberBand->setFillColor( color );
 
-  QgsAbstractGeometryV2* rbGeom = geom.geometry()->clone();
-  QgsVectorLayer *vlayer = mSelectedFeature->vlayer();
-  if ( mCanvas->mapSettings().layerTransform( vlayer ) )
-    rbGeom->transform( *mCanvas->mapSettings().layerTransform( vlayer ) );
-  mSelectRubberBand->setGeometry( rbGeom );
+    QgsAbstractGeometryV2* rbGeom = geom.geometry()->clone();
+    QgsVectorLayer *vlayer = mSelectedFeature->vlayer();
+    if ( mCanvas->mapSettings().layerTransform( vlayer ) )
+      rbGeom->transform( *mCanvas->mapSettings().layerTransform( vlayer ) );
+    mSelectRubberBand->setGeometry( rbGeom );
+  } else {
+    mSelectRubberBand = 0;
+  }
 }
 
 void QgsMapToolNodeTool::selectedFeatureDestroyed()

--- a/src/app/nodetool/qgsmaptoolnodetool.cpp
+++ b/src/app/nodetool/qgsmaptoolnodetool.cpp
@@ -114,11 +114,8 @@ void QgsMapToolNodeTool::canvasMoveEvent( QgsMapMouseEvent* e )
   {
     if ( mMoveRubberBands.empty() )
     {
-      if ( mSelectRubberBand )
-      {
-        delete mSelectRubberBand;
-        mSelectRubberBand = 0;
-      }
+      delete mSelectRubberBand;
+      mSelectRubberBand = 0;
       QgsGeometryRubberBand* rb = new QgsGeometryRubberBand( mCanvas, mSelectedFeature->geometry()->type() );
       rb->setOutlineColor( Qt::blue );
       rb->setBrushStyle( Qt::NoBrush );

--- a/src/app/nodetool/qgsmaptoolnodetool.cpp
+++ b/src/app/nodetool/qgsmaptoolnodetool.cpp
@@ -115,7 +115,7 @@ void QgsMapToolNodeTool::canvasMoveEvent( QgsMapMouseEvent* e )
     if ( mMoveRubberBands.empty() )
     {
       QSettings settings;
-      bool ghostLine = settings.value( "/qgis/digitizing/line_ghost", true ).toBool();
+      bool ghostLine = settings.value( "/qgis/digitizing/line_ghost", false ).toBool();
       if ( !ghostLine )
       {
         delete mSelectRubberBand;
@@ -406,7 +406,7 @@ void QgsMapToolNodeTool::selectedFeatureDestroyed()
 void QgsMapToolNodeTool::geometryChanged( QgsFeatureId fid, QgsGeometry &geom )
 {
   QSettings settings;
-  bool ghostLine = settings.value( "/qgis/digitizing/line_ghost", true ).toBool();
+  bool ghostLine = settings.value( "/qgis/digitizing/line_ghost", false ).toBool();
   if ( !ghostLine && mSelectedFeature && ( mSelectedFeature->featureId() == fid ) )
   {
     updateSelectFeature( geom );

--- a/src/app/nodetool/qgsmaptoolnodetool.cpp
+++ b/src/app/nodetool/qgsmaptoolnodetool.cpp
@@ -116,7 +116,8 @@ void QgsMapToolNodeTool::canvasMoveEvent( QgsMapMouseEvent* e )
     {
       QSettings settings;
       bool ghostLine = settings.value( "/qgis/digitizing/line_ghost", true ).toBool();
-      if ( !ghostLine ) {
+      if ( !ghostLine )
+      {
         delete mSelectRubberBand;
         mSelectRubberBand = nullptr;
       }
@@ -370,7 +371,8 @@ void QgsMapToolNodeTool::updateSelectFeature( QgsGeometry &geom )
 {
   delete mSelectRubberBand;
 
-  if ( geom.geometry() ) {
+  if ( geom.geometry() )
+  {
     mSelectRubberBand = new QgsGeometryRubberBand( mCanvas, mSelectedFeature->geometry()->type() );
     mSelectRubberBand->setBrushStyle( Qt::SolidPattern );
 
@@ -388,8 +390,10 @@ void QgsMapToolNodeTool::updateSelectFeature( QgsGeometry &geom )
     if ( mCanvas->mapSettings().layerTransform( vlayer ) )
       rbGeom->transform( *mCanvas->mapSettings().layerTransform( vlayer ) );
     mSelectRubberBand->setGeometry( rbGeom );
-  } else {
-    mSelectRubberBand = 0;
+  }
+  else
+  {
+    mSelectRubberBand = nullptr;
   }
 }
 

--- a/src/app/nodetool/qgsmaptoolnodetool.h
+++ b/src/app/nodetool/qgsmaptoolnodetool.h
@@ -51,6 +51,11 @@ class QgsMapToolNodeTool: public QgsMapToolEdit
     void selectedFeatureDestroyed();
 
     /*
+     * the geometry for the selected feature has changed
+     */
+    void geometryChanged( QgsFeatureId fid, QgsGeometry &geom );
+
+    /*
      * the current layer changed
      */
     void currentLayerChanged( QgsMapLayer *layer );
@@ -70,6 +75,11 @@ class QgsMapToolNodeTool: public QgsMapToolEdit
      * Update select feature rubber band
      */
     void updateSelectFeature();
+
+    /**
+     * Update select feature rubber band using a certain geometry
+     */
+    void updateSelectFeature( QgsGeometry &geom );
 
     /**
      * Deletes the rubber band pointers and clears mRubberBands

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -803,6 +803,8 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl ) :
   mFillColorToolButton->setContext( "gui" );
   mFillColorToolButton->setDefaultColor( QColor( 255, 0, 0, 30 ) );
 
+  mLineGhostCheckBox->setChecked( settings.value( "/qgis/digitizing/line_ghost", false ).toBool() );
+
   //default snap mode
   mDefaultSnapModeComboBox->insertItem( 0, tr( "To vertex" ), "to vertex" );
   mDefaultSnapModeComboBox->insertItem( 1, tr( "To segment" ), "to segment" );
@@ -1302,6 +1304,8 @@ void QgsOptions::saveOptions()
   settings.setValue( "/qgis/digitizing/fill_color_green", digitizingColor.green() );
   settings.setValue( "/qgis/digitizing/fill_color_blue", digitizingColor.blue() );
   settings.setValue( "/qgis/digitizing/fill_color_alpha", digitizingColor.alpha() );
+
+  settings.setValue( "/qgis/digitizing/line_ghost", mLineGhostCheckBox->isChecked() );
 
   //default snap mode
   QString defaultSnapModeString = mDefaultSnapModeComboBox->itemData( mDefaultSnapModeComboBox->currentIndex() ).toString();

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -3670,6 +3670,13 @@
                     </property>
                    </widget>
                   </item>
+                  <item row="1" column="0" colspan="7">
+                   <widget class="QCheckBox" name="mLineGhostCheckBox">
+                    <property name="text">
+                     <string>Don't update rubber band during node editing</string>
+                    </property>
+                   </widget>
+                  </item>
                  </layout>
                 </widget>
                </item>


### PR DESCRIPTION
It is a nice new functionality that the node editor puts a rubber band on the feature currently being edited. However, so far this rubber band is not updated when the nodes of the feature are actually edited. This PR is to ~~fix~~ change that.

It uses a geometryChanged signal rather than just adding updateSelectFeature() in a few places, because only in this way the rubber band is also correctly updated after an undo operation. It splits updateSelectFeature() into two parts, because the geometryChanged signal is emitted with the new (or in case of an undo: previous) geometry as a parameter, before the geometry of the feature is actually changed.

Edit: As result of the discussion, an option has been added to choose between both kinds of behaviour.
