### PR TITLE
initialize tip window with correct parent widget (fixes #8312) (fixes #8365)

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -908,7 +908,7 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, QWidget * parent, 
   if ( settings.value( QString( "/qgis/showTips%1" ).arg( QGis::QGIS_VERSION_INT / 100 ), true ).toBool() )
   {
     mSplash->hide();
-    QgsTipGui myTip;
+    QgsTipGui myTip( this );
     myTip.exec();
   }
   else

--- a/src/app/qgstipgui.cpp
+++ b/src/app/qgstipgui.cpp
@@ -24,11 +24,11 @@
 #include <qgstipfactory.h>
 
 #ifdef Q_OS_MACX
-QgsTipGui::QgsTipGui()
-    : QDialog( nullptr, Qt::WindowSystemMenuHint )  // Modeless dialog with close button only
+QgsTipGui::QgsTipGui( QWidget *parent )
+    : QDialog( parent, Qt::WindowSystemMenuHint )  // Dialog with close button only
 #else
-QgsTipGui::QgsTipGui()
-    : QDialog( nullptr )  // Normal dialog in non Mac-OS
+QgsTipGui::QgsTipGui( QWidget *parent )
+    : QDialog( parent )  // Normal dialog in non Mac-OS
 #endif
 {
   setupUi( this );

--- a/src/app/qgstipgui.h
+++ b/src/app/qgstipgui.h
@@ -24,7 +24,7 @@ class APP_EXPORT QgsTipGui : public QDialog, private Ui::QgsTipGuiBase
 {
     Q_OBJECT
   public:
-    QgsTipGui();
+    QgsTipGui( QWidget *parent = nullptr );
     ~QgsTipGui();
 
   private:


### PR DESCRIPTION
One change, two bugs fixed:
- establishes correct modal behaviour [Redmine #8312](https://hub.qgis.org/issues/8312)
- eliminates the extra icon in the taskbar [Redmine #8365](https://hub.qgis.org/issues/8365)
