### PR TITLE
Fix a bug when deleting style categories (fixes #12043)

### DIFF
--- a/src/gui/symbology-ng/qgscategorizedsymbolrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgscategorizedsymbolrendererv2widget.cpp
@@ -309,6 +309,7 @@ bool QgsCategorizedSymbolRendererV2Model::dropMimeData( const QMimeData *data, Q
 
 void QgsCategorizedSymbolRendererV2Model::deleteRows( QList<int> rows )
 {
+  qSort( rows ); // list might be unsorted, depending on how the user selected the rows
   for ( int i = rows.size() - 1; i >= 0; i-- )
   {
     beginRemoveRows( QModelIndex(), rows[i], rows[i] );


### PR DESCRIPTION
Depending on how the user selected the categories to delete, some unselected categories were deleted while some selected categories remained ([Redmine #12043](https://hub.qgis.org/issues/12043)).
