### PR TITLE
Fix non caching behaviour for WFS

### DIFF
--- a/src/providers/wfs/qgswfsprovider.cpp
+++ b/src/providers/wfs/qgswfsprovider.cpp
@@ -287,19 +287,6 @@ QgsFeatureIterator QgsWFSProvider::getFeatures( const QgsFeatureRequest& request
   if ( !( request.flags() & QgsFeatureRequest::NoGeometry ) && !rect.isEmpty() )
   {
       deleteData();
-      mGetExtent = rect;
-
-      QString dsURI = dataSourceUri();
-      dsURI = dsURI.replace( QRegExp( "BBOX=[^&]*" ),
-                               QString( "BBOX=%1,%2,%3,%4" )
-                               .arg( qgsDoubleToString( rect.xMinimum() ) )
-                               .arg( qgsDoubleToString( rect.yMinimum() ) )
-                               .arg( qgsDoubleToString( rect.xMaximum() ) )
-                               .arg( qgsDoubleToString( rect.yMaximum() ) ) );
-      //TODO: BBOX may not be combined with FILTER. WFS spec v. 1.1.0, sec. 14.7.3 ff.
-      //      if a FILTER is present, the BBOX must be merged into it, capabilities permitting.
-      //      Else one criterion must be abandoned and the user warned.  [WBC 111221]
-      setDataSourceUri( dsURI );
       reloadData();
   }
   return new QgsWFSFeatureIterator( new QgsWFSFeatureSource( this ), true, request );

--- a/src/providers/wfs/qgswfsprovider.cpp
+++ b/src/providers/wfs/qgswfsprovider.cpp
@@ -153,7 +153,6 @@ QgsAbstractFeatureSource* QgsWFSProvider::featureSource() const
 
 void QgsWFSProvider::reloadData()
 {
-  mPendingRetrieval = false;
   if (mCached)
       deleteData();
   delete mSpatialIndex;
@@ -162,6 +161,7 @@ void QgsWFSProvider::reloadData()
 
   if ( !mCached )
     emit dataChanged();
+  mPendingRetrieval = false;
 }
 
 void QgsWFSProvider::deleteData()

--- a/src/providers/wfs/qgswfsprovider.cpp
+++ b/src/providers/wfs/qgswfsprovider.cpp
@@ -1737,7 +1737,8 @@ void QgsWFSProvider::extendExtent( const QgsRectangle &extent )
 
   QgsRectangle r( mExtent.intersect( &extent ) );
 
-  if ( mGetExtent.contains( r ) )
+  if ( (extent == mGetExtent || mFeatureCount == 0 || mFeatureCount % 500 != 0)
+      && mGetExtent.contains( r ) )
     return;
 
 #if 0


### PR DESCRIPTION
See https://hub.qgis.org/issues/9444

The original non caching implementation was commented out as a temporary fix for some crash issue:

https://github.com/tomtor/QGIS/commit/945be40a866265dbfe47e7ca500b0369684a570c

I believe the cause for the original bug is some kind of race condition, so I moved the freeing of data and simplified the original implementation.
