### PR TITLE
Symbol color variable for labeling

### DIFF
--- a/python/core/qgsexpressioncontext.sip
+++ b/python/core/qgsexpressioncontext.sip
@@ -480,6 +480,16 @@ class QgsExpressionContextUtils
      */
     static QgsExpressionContextScope* mapSettingsScope( const QgsMapSettings &mapSettings ) /Factory/;
 
+    /** Adds variables related to a QgsSymbolV2 to an expression context. Note that unlike the other
+     * methods in QgsExpressionContextUtils, this method adds its variable directly to the final
+     * scope in the context. This is designed to allow the method to be used thousands of times
+     * with the same context without the cost of adding additional scopes for each symbol.
+     * @param context expression context to add symbol scope variables to
+     * @param symbol symbol to extract properties from
+     * @note added in QGIS 2.14
+     */
+    static void addSymbolScope( QgsExpressionContext& context, const QgsSymbolV2* symbol );
+
     /** Creates a new scope which contains variables and functions relating to a QgsComposition.
      * For instance, number of pages and page sizes.
      * @param composition source composition

--- a/src/app/qgslabelinggui.cpp
+++ b/src/app/qgslabelinggui.cpp
@@ -50,9 +50,11 @@ static QgsExpressionContext _getExpressionContext( const void* context )
   if ( layer )
     expContext << QgsExpressionContextUtils::layerScope( layer );
 
+  QgsExpressionContextUtils::addSymbolScope( expContext, 0 );
+
   //TODO - show actual value
   expContext.setOriginalValueVariable( QVariant() );
-  expContext.setHighlightedVariables( QStringList() << QgsExpressionContext::EXPR_ORIGINAL_VALUE );
+  expContext.setHighlightedVariables( QStringList() << QgsExpressionContext::EXPR_ORIGINAL_VALUE << QgsExpressionContext::EXPR_SYMBOL_COLOR );
 
   return expContext;
 }

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -3809,6 +3809,9 @@ void QgsExpression::initVariableHelp()
   gVariableHelpTexts.insert( "row_number", QCoreApplication::translate( "variable_help", "Stores the number of the current row." ) );
   gVariableHelpTexts.insert( "grid_number", QCoreApplication::translate( "variable_help", "Current grid annotation value." ) );
   gVariableHelpTexts.insert( "grid_axis", QCoreApplication::translate( "variable_help", "Current grid annotation axis (eg, 'x' for longitude, 'y' for latitude)." ) );
+
+  gVariableHelpTexts.insert( "symbol_color", QCoreApplication::translate( "symbol_color", "Color of symbol used to render the feature." ) );
+  gVariableHelpTexts.insert( "symbol_angle", QCoreApplication::translate( "symbol_angle", "Angle of symbol used to render the feature (valid for marker symbols only)." ) );
 }
 
 QString QgsExpression::variableHelpText( const QString &variableName, bool showValue, const QVariant &value )

--- a/src/core/qgsexpressioncontext.cpp
+++ b/src/core/qgsexpressioncontext.cpp
@@ -28,12 +28,13 @@
 #include <QSettings>
 #include <QDir>
 
-
+/// @cond
 const QString QgsExpressionContext::EXPR_FIELDS( "_fields_" );
 const QString QgsExpressionContext::EXPR_FEATURE( "_feature_" );
 const QString QgsExpressionContext::EXPR_ORIGINAL_VALUE( "value" );
 const QString QgsExpressionContext::EXPR_SYMBOL_COLOR( "symbol_color" );
 const QString QgsExpressionContext::EXPR_SYMBOL_ANGLE( "symbol_angle" );
+/// @endcond
 
 //
 // QgsExpressionContextScope

--- a/src/core/qgsexpressioncontext.cpp
+++ b/src/core/qgsexpressioncontext.cpp
@@ -32,6 +32,8 @@
 const QString QgsExpressionContext::EXPR_FIELDS( "_fields_" );
 const QString QgsExpressionContext::EXPR_FEATURE( "_feature_" );
 const QString QgsExpressionContext::EXPR_ORIGINAL_VALUE( "value" );
+const QString QgsExpressionContext::EXPR_SYMBOL_COLOR( "symbol_color" );
+const QString QgsExpressionContext::EXPR_SYMBOL_ANGLE( "symbol_angle" );
 
 //
 // QgsExpressionContextScope
@@ -700,6 +702,29 @@ QgsExpressionContextScope* QgsExpressionContextUtils::mapSettingsScope( const Qg
   scope->addVariable( QgsExpressionContextScope::StaticVariable( "map_scale", mapSettings.scale(), true ) );
 
   return scope;
+}
+
+void QgsExpressionContextUtils::addSymbolScope( QgsExpressionContext& context, const QgsSymbolV2* symbol )
+{
+  QgsExpressionContextScope* scope = context.lastScope();
+
+  if ( !scope )
+  {
+    context.appendScope( new QgsExpressionContextScope() );
+    scope = context.lastScope();
+  }
+
+  //careful, symbol may validly be null here
+
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QgsExpressionContext::EXPR_SYMBOL_COLOR, symbol ? symbol->color().name() : QString(), true ) );
+
+  double angle = 0.0;
+  const QgsMarkerSymbolV2* markerSymbol = dynamic_cast< const QgsMarkerSymbolV2* >( symbol );
+  if ( markerSymbol )
+  {
+    angle = markerSymbol->angle();
+  }
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( QgsExpressionContext::EXPR_SYMBOL_ANGLE, angle, true ) );
 }
 
 QgsExpressionContextScope *QgsExpressionContextUtils::compositionScope( const QgsComposition *composition )

--- a/src/core/qgsexpressioncontext.h
+++ b/src/core/qgsexpressioncontext.h
@@ -418,11 +418,13 @@ class CORE_EXPORT QgsExpressionContext
      */
     void setOriginalValueVariable( const QVariant& value );
 
+    /// @cond
     static const QString EXPR_FIELDS;
     static const QString EXPR_FEATURE;
     static const QString EXPR_ORIGINAL_VALUE;
     static const QString EXPR_SYMBOL_COLOR;
     static const QString EXPR_SYMBOL_ANGLE;
+    /// @endcond
 
   private:
 

--- a/src/core/qgsexpressioncontext.h
+++ b/src/core/qgsexpressioncontext.h
@@ -28,6 +28,7 @@ class QgsComposition;
 class QgsComposerItem;
 class QgsAtlasComposition;
 class QgsMapSettings;
+class QgsSymbolV2;
 
 /** \ingroup core
  * \class QgsScopedExpressionFunction
@@ -420,6 +421,8 @@ class CORE_EXPORT QgsExpressionContext
     static const QString EXPR_FIELDS;
     static const QString EXPR_FEATURE;
     static const QString EXPR_ORIGINAL_VALUE;
+    static const QString EXPR_SYMBOL_COLOR;
+    static const QString EXPR_SYMBOL_ANGLE;
 
   private:
 
@@ -513,6 +516,16 @@ class CORE_EXPORT QgsExpressionContextUtils
      * For instance, map scale and rotation.
      */
     static QgsExpressionContextScope* mapSettingsScope( const QgsMapSettings &mapSettings );
+
+    /** Adds variables related to a QgsSymbolV2 to an expression context. Note that unlike the other
+     * methods in QgsExpressionContextUtils, this method adds its variable directly to the final
+     * scope in the context. This is designed to allow the method to be used thousands of times
+     * with the same context without the cost of adding additional scopes for each symbol.
+     * @param context expression context to add symbol scope variables to
+     * @param symbol symbol to extract properties from
+     * @note added in QGIS 2.14
+     */
+    static void addSymbolScope( QgsExpressionContext& context, const QgsSymbolV2* symbol );
 
     /** Creates a new scope which contains variables and functions relating to a QgsComposition.
      * For instance, number of pages and page sizes.

--- a/src/core/qgsvectorlayerlabelprovider.h
+++ b/src/core/qgsvectorlayerlabelprovider.h
@@ -17,9 +17,11 @@
 #define QGSVECTORLAYERLABELPROVIDER_H
 
 #include "qgslabelingenginev2.h"
+#include "qgsrendererv2.h"
 
 class QgsAbstractFeatureSource;
 class QgsFeatureRendererV2;
+class QgsSymbolV2;
 
 /**
  * @brief The QgsVectorLayerLabelProvider class implements a label provider
@@ -78,10 +80,10 @@ class CORE_EXPORT QgsVectorLayerLabelProvider : public QgsAbstractLabelProvider
      * point, and ensures that labels will not overlap large or offset points.
      * @param fet point feature
      * @param context render context
-     * @param renderer renderer used for layer, required to determine symbols rendered for point feature
+     * @param symbols symbols rendered for point feature
      * @note added in QGIS 2.14
      */
-    static QgsGeometry* getPointObstacleGeometry( QgsFeature& fet, QgsRenderContext& context, QgsFeatureRendererV2* renderer );
+    static QgsGeometry* getPointObstacleGeometry( QgsFeature& fet, QgsRenderContext& context, const QgsSymbolV2List& symbols );
 
   protected:
     //! initialization method - called from constructors

--- a/src/core/qgsvectorlayerrenderer.cpp
+++ b/src/core/qgsvectorlayerrenderer.cpp
@@ -327,10 +327,17 @@ void QgsVectorLayerRenderer::drawRendererV2( QgsFeatureIterator& fit )
         if ( mContext.labelingEngineV2() )
         {
           QScopedPointer<QgsGeometry> obstacleGeometry;
-          if ( fet.constGeometry()->type() == QGis::Point )
+          QgsSymbolV2List symbols = mRendererV2->originalSymbolsForFeature( fet, mContext );
+
+          if ( !symbols.isEmpty() && fet.constGeometry()->type() == QGis::Point )
           {
-            obstacleGeometry.reset( QgsVectorLayerLabelProvider::getPointObstacleGeometry( fet, mContext, mRendererV2 ) );
+            obstacleGeometry.reset( QgsVectorLayerLabelProvider::getPointObstacleGeometry( fet, mContext, symbols ) );
           }
+          if ( !symbols.isEmpty() )
+          {
+            QgsExpressionContextUtils::addSymbolScope( mContext.expressionContext(), symbols.at( 0 ) );
+          }
+
           if ( mLabelProvider )
           {
             mLabelProvider->registerFeature( fet, mContext, obstacleGeometry.data() );
@@ -415,10 +422,17 @@ void QgsVectorLayerRenderer::drawRendererV2Levels( QgsFeatureIterator& fit )
     if ( mContext.labelingEngineV2() )
     {
       QScopedPointer<QgsGeometry> obstacleGeometry;
-      if ( fet.constGeometry()->type() == QGis::Point )
+      QgsSymbolV2List symbols = mRendererV2->originalSymbolsForFeature( fet, mContext );
+
+      if ( !symbols.isEmpty() && fet.constGeometry()->type() == QGis::Point )
       {
-        obstacleGeometry.reset( QgsVectorLayerLabelProvider::getPointObstacleGeometry( fet, mContext, mRendererV2 ) );
+        obstacleGeometry.reset( QgsVectorLayerLabelProvider::getPointObstacleGeometry( fet, mContext, symbols ) );
       }
+      if ( !symbols.isEmpty() )
+      {
+        QgsExpressionContextUtils::addSymbolScope( mContext.expressionContext(), symbols.at( 0 ) );
+      }
+
       if ( mLabelProvider )
       {
         mLabelProvider->registerFeature( fet, mContext, obstacleGeometry.data() );


### PR DESCRIPTION
This adds new variables for @symbol_color and @symbol_angle for use in labelling. At render time, they will be filled with the matching value from the FIRST symbol rendered for the labelled feature (eg, for rule-based renderers, only the first match will be used for the variable values).

The @symbol_color variable can be used with data defined expression for label color (or buffer color, shadow color, etc) to return the matching color of the symbol used for rendering the current feature. This makes it really easy to match label colors to categorised/graduated class colors! (especially useful when combined with the set_color_part function)

@symbol_angle is possibly less useful (especially given that rotation for symbols and labels are in opposite directions! ;@ ), but it's easy enough to add and may be useful for someone.

Todo:
- add tests
- handle data defined colors/angles
