### PR TITLE
Add warning for WFS feature count limit (multiple of 500)

### DIFF
--- a/src/providers/wfs/qgswfsprovider.cpp
+++ b/src/providers/wfs/qgswfsprovider.cpp
@@ -63,6 +63,7 @@ QgsWFSProvider::QgsWFSProvider( const QString& uri )
     , mWKBType( QGis::WKBUnknown )
     , mSourceCRS( 0 )
     , mFeatureCount( 0 )
+    , mMaxFeatureCount ( 0 )
     , mValid( true )
     , mCached( false )
     , mPendingRetrieval( false )
@@ -733,6 +734,15 @@ int QgsWFSProvider::getFeatureGET( const QString& uri, const QString& geometryAt
     }
   }
   mFeatureCount = mFeatures.size();
+
+  if (mFeatureCount && mFeatureCount >= mMaxFeatureCount && mFeatureCount % 500 == 0)
+    QgsMessageLog::logMessage(
+      tr("%1: %2 features fetched hints at reaching a download limit. ").arg(typeName).arg(mFeatureCount) +
+      tr("Zoom in to fetch all data if your layer has the 'current view extent' option enabled."),
+      "WFS" );
+
+  if (mFeatureCount > mMaxFeatureCount)
+    mMaxFeatureCount = mFeatureCount;
 
   return 0;
 }

--- a/src/providers/wfs/qgswfsprovider.h
+++ b/src/providers/wfs/qgswfsprovider.h
@@ -203,6 +203,7 @@ class QgsWFSProvider : public QgsVectorDataProvider
     /** Source CRS*/
     QgsCoordinateReferenceSystem mSourceCRS;
     int mFeatureCount;
+    int mMaxFeatureCount;
     /** Flag if provider is valid*/
     bool mValid;
     bool mCached;


### PR DESCRIPTION
Show a messagebar warning when an exact multiple of 500 features is retrieved
