### PR TITLE
Added support for Unicode translations in fTools visual

### DIFF
--- a/python/plugins/fTools/tools/doVisual.py
+++ b/python/plugins/fTools/tools/doVisual.py
@@ -180,7 +180,10 @@ class VisualDialog(QDialog, Ui_Dialog):
         else:
             self.tblUnique.setColumnCount(2)
             for rec in range(numRows):
-                tmp = result[rec].split(":")
+                if ":" not in result[rec]:
+                	tmp = result[rec].split(u"\uff1a")
+                else:
+                	tmp = result[rec].split(":")
                 item = QTableWidgetItem(tmp[0])
                 self.tblUnique.setItem(rec, 0, item)
                 item = QTableWidgetItem(tmp[1])


### PR DESCRIPTION
A student of mine who uses the Simplified Chinese translation for QGIS receives the following error message and an incomplete list of results when running the Basic Statistics plugin:

IndexError: list index out of range 
Traceback (most recent call last):
  File "/Applications/QGIS.app/Contents/Resources/python/plugins/fTools/tools/doVisual.py", line 186, in runFinishedFromThread
    item = QTableWidgetItem(tmp[1])
IndexError: list index out of range

I noticed that when Unicode characters for the Simplified Chinese translation are included in a result string, the ":" character used to split the string is encoded as "\uff1a".  This patch adds support for splitting the result string when the colon is encoded with its Unicode value.
