### PR TITLE
CI shouldn't ignore build errors

### DIFF
--- a/qgis-test-travis.ctest
+++ b/qgis-test-travis.ctest
@@ -5,7 +5,7 @@ SET (CTEST_BINARY_DIRECTORY "$ENV{TRAVIS_BUILD_DIR}/build")
 
 SET( CTEST_CMAKE_GENERATOR  "Unix Makefiles" )
 SET (CTEST_CMAKE_COMMAND "cmake" )
-SET (CTEST_BUILD_COMMAND "/usr/bin/make -j2 -i -k" )
+SET (CTEST_BUILD_COMMAND "/usr/bin/make -j2" )
 SET (CTEST_SITE "travis-ci.org" )
 IF ($ENV{TRAVIS_PULL_REQUEST} STREQUAL "false")
   # No pull request


### PR DESCRIPTION
I got hung up for a while debugging a failing test in CI. The test failed because the project failed to build completely, but the build error was lost way up in the CI output.

Is there ever an argument for passing CI given that the build has errored?
