### PR TITLE
[FEATURE] Add a show/hide all context menu for layer tree symbol items

### DIFF
--- a/python/core/layertree/qgslayertreemodellegendnode.sip
+++ b/python/core/layertree/qgslayertreemodellegendnode.sip
@@ -145,6 +145,19 @@ class QgsSymbolV2LegendNode : QgsLayerTreeModelLegendNode
     //! @note added in 2.10
     QSize minimumIconSize() const;
 
+    /** Returns the symbol used by the legend node.
+     * @see setSymbol()
+     * @note added in QGIS 2.14
+     */
+    const QgsSymbolV2* symbol() const;
+
+    /** Sets the symbol to be used by the legend node.
+     * @param symbol new symbol for node. Ownership is transferred.
+     * @see symbol()
+     * @note added in QGIS 2.14
+     */
+    void setSymbol( QgsSymbolV2* symbol /Transfer/ );
+
   public slots:
 
     /** Checks all items belonging to the same layer as this node.

--- a/python/core/layertree/qgslayertreemodellegendnode.sip
+++ b/python/core/layertree/qgslayertreemodellegendnode.sip
@@ -144,6 +144,21 @@ class QgsSymbolV2LegendNode : QgsLayerTreeModelLegendNode
     //! Get the minimum icon size to prevent cropping
     //! @note added in 2.10
     QSize minimumIconSize() const;
+
+  public slots:
+
+    /** Checks all items belonging to the same layer as this node.
+     * @note added in QGIS 2.14
+     * @see uncheckAllItems()
+     */
+    void checkAllItems();
+
+    /** Unchecks all items belonging to the same layer as this node.
+     * @note added in QGIS 2.14
+     * @see checkAllItems()
+     */
+    void uncheckAllItems();
+
 };
 
 

--- a/python/core/symbology-ng/qgscategorizedsymbolrendererv2.sip
+++ b/python/core/symbology-ng/qgscategorizedsymbolrendererv2.sip
@@ -153,6 +153,8 @@ class QgsCategorizedSymbolRendererV2 : QgsFeatureRendererV2
     // @note added in 2.5
     virtual bool legendSymbolItemChecked( const QString& key );
 
+    virtual void setLegendSymbolItem( const QString& key, QgsSymbolV2* symbol /Transfer/ );
+
     //! item in symbology was checked
     // @note added in 2.5
     virtual void checkLegendSymbolItem( const QString& key, bool state = true );

--- a/python/core/symbology-ng/qgsgraduatedsymbolrendererv2.sip
+++ b/python/core/symbology-ng/qgsgraduatedsymbolrendererv2.sip
@@ -282,6 +282,8 @@ class QgsGraduatedSymbolRendererV2 : QgsFeatureRendererV2
     //! @note added in 2.6
     virtual void checkLegendSymbolItem( const QString& key, bool state = true );
 
+    virtual void setLegendSymbolItem( const QString& key, QgsSymbolV2* symbol /Transfer/ );
+
     //! If supported by the renderer, return classification attribute for the use in legend
     //! @note added in 2.6
     virtual QString legendClassificationAttribute();

--- a/python/core/symbology-ng/qgsrendererv2.sip
+++ b/python/core/symbology-ng/qgsrendererv2.sip
@@ -185,6 +185,13 @@ class QgsFeatureRendererV2
     //! @note added in 2.5
     virtual void checkLegendSymbolItem( const QString& key, bool state = true );
 
+    /** Sets the symbol to be used for a legend symbol item.
+     * @param key rule key for legend symbol
+     * @param symbol new symbol for legend item. Ownership is transferred to renderer.
+     * @note added in QGIS 2.14
+     */
+    virtual void setLegendSymbolItem( const QString& key, QgsSymbolV2* symbol /Transfer/ );
+
     //! return a list of item text / symbol
     //! @note not available in python bindings
     // virtual QgsLegendSymbolList legendSymbolItems( double scaleDenominator = -1, const QString& rule = "" );

--- a/python/core/symbology-ng/qgsrulebasedrendererv2.sip
+++ b/python/core/symbology-ng/qgsrulebasedrendererv2.sip
@@ -356,6 +356,8 @@ class QgsRuleBasedRendererV2 : QgsFeatureRendererV2
     //! @note added in 2.5
     virtual void checkLegendSymbolItem( const QString& key, bool state = true );
 
+    virtual void setLegendSymbolItem( const QString& key, QgsSymbolV2* symbol /Transfer/ );
+
     //! return a list of item text / symbol
     //! @note not available in python bindings
     // virtual QgsLegendSymbolList legendSymbolItems();

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -6,6 +6,7 @@
 #include "qgsclipboard.h"
 #include "qgslayertree.h"
 #include "qgslayertreemodel.h"
+#include "qgslayertreemodellegendnode.h"
 #include "qgslayertreeviewdefaultactions.h"
 #include "qgsmaplayerstyleguiutils.h"
 #include "qgsproject.h"
@@ -188,9 +189,19 @@ QMenu* QgsAppLayerTreeViewMenuProvider::createContextMenu()
     }
 
   }
-  else
+  else if ( QgsLayerTreeModelLegendNode* node = mView->layerTreeModel()->index2legendNode( idx ) )
   {
-    // symbology item?
+    if ( QgsSymbolV2LegendNode* symbolNode = dynamic_cast< QgsSymbolV2LegendNode* >( node ) )
+    {
+      // symbology item
+      if ( symbolNode->flags() & Qt::ItemIsUserCheckable )
+      {
+        menu->addAction( QgsApplication::getThemeIcon( "/mActionShowAllLayers.png" ), tr( "&Show All Items" ),
+                         symbolNode, SLOT( checkAllItems() ) );
+        menu->addAction( QgsApplication::getThemeIcon( "/mActionHideAllLayers.png" ), tr( "&Hide All Items" ),
+                         symbolNode, SLOT( uncheckAllItems() ) );
+      }
+    }
   }
 
   return menu;

--- a/src/app/qgsapplayertreeviewmenuprovider.h
+++ b/src/app/qgsapplayertreeviewmenuprovider.h
@@ -44,6 +44,10 @@ class QgsAppLayerTreeViewMenuProvider : public QObject, public QgsLayerTreeViewM
     QgsMapCanvas* mCanvas;
 
     QMap< QgsMapLayer::LayerType, QList< LegendLayerAction > > mLegendLayerActionMap;
+
+  private slots:
+
+    void editSymbolLegendNodeSymbol();
 };
 
 #endif // QGSAPPLAYERTREEVIEWMENUPROVIDER_H

--- a/src/core/layertree/qgslayertreemodellegendnode.cpp
+++ b/src/core/layertree/qgslayertreemodellegendnode.cpp
@@ -185,6 +185,16 @@ QSize QgsSymbolV2LegendNode::minimumIconSize() const
   return minSz;
 }
 
+void QgsSymbolV2LegendNode::checkAllItems()
+{
+  checkAll( true );
+}
+
+void QgsSymbolV2LegendNode::uncheckAllItems()
+{
+  checkAll( false );
+}
+
 inline
 QgsRenderContext * QgsSymbolV2LegendNode::createTemporaryRenderContext() const
 {
@@ -201,6 +211,22 @@ QgsRenderContext * QgsSymbolV2LegendNode::createTemporaryRenderContext() const
   context->setRendererScale( scale );
   context->setMapToPixel( QgsMapToPixel( mupp ) );
   return validData ? context.take() : 0;
+}
+
+void QgsSymbolV2LegendNode::checkAll( bool state )
+{
+  QgsVectorLayer* vlayer = qobject_cast<QgsVectorLayer*>( mLayerNode->layer() );
+  if ( !vlayer || !vlayer->rendererV2() )
+    return;
+
+  QgsLegendSymbolListV2 symbolList = vlayer->rendererV2()->legendSymbolItemsV2();
+  Q_FOREACH ( const QgsLegendSymbolItemV2& item, symbolList )
+  {
+    vlayer->rendererV2()->checkLegendSymbolItem( item.ruleKey(), state );
+  }
+
+  emit dataChanged();
+  vlayer->triggerRepaint();
 }
 
 QVariant QgsSymbolV2LegendNode::data( int role ) const

--- a/src/core/layertree/qgslayertreemodellegendnode.cpp
+++ b/src/core/layertree/qgslayertreemodellegendnode.cpp
@@ -185,6 +185,29 @@ QSize QgsSymbolV2LegendNode::minimumIconSize() const
   return minSz;
 }
 
+const QgsSymbolV2* QgsSymbolV2LegendNode::symbol() const
+{
+  return mItem.symbol();
+}
+
+void QgsSymbolV2LegendNode::setSymbol( QgsSymbolV2* symbol )
+{
+  if ( !symbol )
+    return;
+
+  QgsVectorLayer* vlayer = qobject_cast<QgsVectorLayer*>( mLayerNode->layer() );
+  if ( !vlayer || !vlayer->rendererV2() )
+    return;
+
+  mItem.setSymbol( symbol );
+  vlayer->rendererV2()->setLegendSymbolItem( mItem.ruleKey(), symbol->clone() );
+
+  mPixmap = QPixmap();
+
+  emit dataChanged();
+  vlayer->triggerRepaint();
+}
+
 void QgsSymbolV2LegendNode::checkAllItems()
 {
   checkAll( true );

--- a/src/core/layertree/qgslayertreemodellegendnode.h
+++ b/src/core/layertree/qgslayertreemodellegendnode.h
@@ -145,6 +145,8 @@ class CORE_EXPORT QgsLayerTreeModelLegendNode : public QObject
  */
 class CORE_EXPORT QgsSymbolV2LegendNode : public QgsLayerTreeModelLegendNode
 {
+    Q_OBJECT
+
   public:
     QgsSymbolV2LegendNode( QgsLayerTreeLayer* nodeLayer, const QgsLegendSymbolItemV2& item, QObject* parent = 0 );
     ~QgsSymbolV2LegendNode();
@@ -173,6 +175,20 @@ class CORE_EXPORT QgsSymbolV2LegendNode : public QgsLayerTreeModelLegendNode
     //! @note added in 2.10
     QSize minimumIconSize() const;
 
+  public slots:
+
+    /** Checks all items belonging to the same layer as this node.
+     * @note added in QGIS 2.14
+     * @see uncheckAllItems()
+     */
+    void checkAllItems();
+
+    /** Unchecks all items belonging to the same layer as this node.
+     * @note added in QGIS 2.14
+     * @see checkAllItems()
+     */
+    void uncheckAllItems();
+
   private:
     void updateLabel();
 
@@ -189,6 +205,10 @@ class CORE_EXPORT QgsSymbolV2LegendNode : public QgsLayerTreeModelLegendNode
     // return a temporary context or null if legendMapViewData are not valid
     QgsRenderContext * createTemporaryRenderContext() const;
 
+    /** Sets all items belonging to the same layer as this node to the same check state.
+     * @param state check state
+     */
+    void checkAll( bool state );
 };
 
 

--- a/src/core/layertree/qgslayertreemodellegendnode.h
+++ b/src/core/layertree/qgslayertreemodellegendnode.h
@@ -175,6 +175,19 @@ class CORE_EXPORT QgsSymbolV2LegendNode : public QgsLayerTreeModelLegendNode
     //! @note added in 2.10
     QSize minimumIconSize() const;
 
+    /** Returns the symbol used by the legend node.
+     * @see setSymbol()
+     * @note added in QGIS 2.14
+     */
+    const QgsSymbolV2* symbol() const;
+
+    /** Sets the symbol to be used by the legend node.
+     * @param symbol new symbol for node. Ownership is transferred.
+     * @see symbol()
+     * @note added in QGIS 2.14
+     */
+    void setSymbol( QgsSymbolV2* symbol );
+
   public slots:
 
     /** Checks all items belonging to the same layer as this node.

--- a/src/core/symbology-ng/qgscategorizedsymbolrendererv2.cpp
+++ b/src/core/symbology-ng/qgscategorizedsymbolrendererv2.cpp
@@ -885,6 +885,16 @@ bool QgsCategorizedSymbolRendererV2::legendSymbolItemChecked( const QString& key
     return true;
 }
 
+void QgsCategorizedSymbolRendererV2::setLegendSymbolItem( const QString& key, QgsSymbolV2* symbol )
+{
+  bool ok;
+  int index = key.toInt( &ok );
+  if ( ok )
+    updateCategorySymbol( index, symbol );
+  else
+    delete symbol;
+}
+
 void QgsCategorizedSymbolRendererV2::checkLegendSymbolItem( const QString& key, bool state )
 {
   bool ok;

--- a/src/core/symbology-ng/qgscategorizedsymbolrendererv2.h
+++ b/src/core/symbology-ng/qgscategorizedsymbolrendererv2.h
@@ -184,6 +184,8 @@ class CORE_EXPORT QgsCategorizedSymbolRendererV2 : public QgsFeatureRendererV2
     // @note added in 2.5
     virtual bool legendSymbolItemChecked( const QString& key ) override;
 
+    virtual void setLegendSymbolItem( const QString& key, QgsSymbolV2* symbol ) override;
+
     //! item in symbology was checked
     // @note added in 2.5
     virtual void checkLegendSymbolItem( const QString& key, bool state = true ) override;

--- a/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.cpp
+++ b/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.cpp
@@ -1433,6 +1433,15 @@ void QgsGraduatedSymbolRendererV2::checkLegendSymbolItem( const QString& key, bo
     updateRangeRenderState( index, state );
 }
 
+void QgsGraduatedSymbolRendererV2::setLegendSymbolItem( const QString& key, QgsSymbolV2* symbol )
+{
+  bool ok;
+  int index = key.toInt( &ok );
+  if ( ok )
+    updateRangeSymbol( index, symbol );
+  else
+    delete symbol;
+}
 
 void QgsGraduatedSymbolRendererV2::addClass( QgsSymbolV2* symbol )
 {

--- a/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.h
+++ b/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.h
@@ -325,6 +325,8 @@ class CORE_EXPORT QgsGraduatedSymbolRendererV2 : public QgsFeatureRendererV2
     //! @note added in 2.6
     virtual void checkLegendSymbolItem( const QString& key, bool state = true ) override;
 
+    virtual void setLegendSymbolItem( const QString& key, QgsSymbolV2* symbol ) override;
+
     //! If supported by the renderer, return classification attribute for the use in legend
     //! @note added in 2.6
     virtual QString legendClassificationAttribute() const override { return classAttribute(); }

--- a/src/core/symbology-ng/qgslegendsymbolitemv2.h
+++ b/src/core/symbology-ng/qgslegendsymbolitemv2.h
@@ -66,7 +66,6 @@ class CORE_EXPORT QgsLegendSymbolItemV2
     //! @note added in 2.8
     QString parentRuleKey() const { return mParentKey; }
 
-  protected:
     //! Set symbol of the item. Takes ownership of symbol.
     void setSymbol( QgsSymbolV2* s );
 

--- a/src/core/symbology-ng/qgsrendererv2.cpp
+++ b/src/core/symbology-ng/qgsrendererv2.cpp
@@ -671,6 +671,12 @@ void QgsFeatureRendererV2::checkLegendSymbolItem( const QString& key, bool state
   Q_UNUSED( state );
 }
 
+void QgsFeatureRendererV2::setLegendSymbolItem( const QString& key, QgsSymbolV2* symbol )
+{
+  Q_UNUSED( key );
+  delete symbol;
+}
+
 QgsLegendSymbolList QgsFeatureRendererV2::legendSymbolItems( double scaleDenominator, const QString& rule )
 {
   Q_UNUSED( scaleDenominator );

--- a/src/core/symbology-ng/qgsrendererv2.h
+++ b/src/core/symbology-ng/qgsrendererv2.h
@@ -224,6 +224,13 @@ class CORE_EXPORT QgsFeatureRendererV2
     //! @note added in 2.5
     virtual void checkLegendSymbolItem( const QString& key, bool state = true );
 
+    /** Sets the symbol to be used for a legend symbol item.
+     * @param key rule key for legend symbol
+     * @param symbol new symbol for legend item. Ownership is transferred to renderer.
+     * @note added in QGIS 2.14
+     */
+    virtual void setLegendSymbolItem( const QString& key, QgsSymbolV2* symbol );
+
     //! return a list of item text / symbol
     //! @note not available in python bindings
     virtual QgsLegendSymbolList legendSymbolItems( double scaleDenominator = -1, const QString& rule = "" );

--- a/src/core/symbology-ng/qgsrulebasedrendererv2.cpp
+++ b/src/core/symbology-ng/qgsrulebasedrendererv2.cpp
@@ -990,6 +990,15 @@ void QgsRuleBasedRendererV2::checkLegendSymbolItem( const QString& key, bool sta
     rule->setCheckState( state );
 }
 
+void QgsRuleBasedRendererV2::setLegendSymbolItem( const QString& key, QgsSymbolV2* symbol )
+{
+  Rule* rule = mRootRule->findRuleByKey( key );
+  if ( rule )
+    rule->setSymbol( symbol );
+  else
+    delete symbol;
+}
+
 QgsLegendSymbolList QgsRuleBasedRendererV2::legendSymbolItems( double scaleDenominator, const QString& rule )
 {
   return mRootRule->legendSymbolItems( scaleDenominator, rule );

--- a/src/core/symbology-ng/qgsrulebasedrendererv2.h
+++ b/src/core/symbology-ng/qgsrulebasedrendererv2.h
@@ -415,6 +415,8 @@ class CORE_EXPORT QgsRuleBasedRendererV2 : public QgsFeatureRendererV2
     //! @note added in 2.5
     virtual void checkLegendSymbolItem( const QString& key, bool state = true ) override;
 
+    virtual void setLegendSymbolItem( const QString& key, QgsSymbolV2* symbol ) override;
+
     //! return a list of item text / symbol
     //! @note not available in python bindings
     virtual QgsLegendSymbolList legendSymbolItems( double scaleDenominator = -1, const QString& rule = "" ) override;


### PR DESCRIPTION
Allows toggling on/off all the symbol items for categorized/graduated/rule based layers via the right click menu on an item. Previously you'd have to manually toggle each item one-by-one. Paolo has it spot-on when he says in http://hub.qgis.org/issues/13458 : "...I need to unselect each of them, which is boring". I had to do this yesterday with a bunch of layers, and yep - it's dead boring!

![symbol_menu](https://cloud.githubusercontent.com/assets/1829991/11525040/0fe5c35c-9924-11e5-9519-6d503e05b1f9.png)
