### PR TITLE
[Processing] Remove provider actions when removing a provider

### DIFF
--- a/python/plugins/processing/core/Processing.py
+++ b/python/plugins/processing/core/Processing.py
@@ -106,6 +106,8 @@ class Processing:
         try:
             provider.unload()
             Processing.providers.remove(provider)
+            if provider.getName() in Processing.actions.keys():
+                Processing.actions.remove(provider.getName())
             ProcessingConfig.readSettings()
             Processing.updateAlgsList()
         except:


### PR DESCRIPTION
Fixes the issue of QGIS hanging during closing when a Processing Provider plugin which contains its own actions is activated. 
