### PR TITLE
[Processing]  Disable logging when loading models.

### DIFF
--- a/python/plugins/processing/modeler/ModelerAlgorithm.py
+++ b/python/plugins/processing/modeler/ModelerAlgorithm.py
@@ -33,6 +33,7 @@ import time
 import json
 import codecs
 import traceback
+import logging
 from PyQt4.QtCore import QCoreApplication, QPointF
 from PyQt4.QtGui import QIcon
 from qgis.core import QgsRasterLayer, QgsVectorLayer
@@ -552,7 +553,9 @@ class ModelerAlgorithm(GeoAlgorithm):
                     return QPointF(values["x"], values["y"])
 
                 def _import(name):
+                    logging.disable(logging.INFO)
                     __import__(name)
+                    logging.disable(logging.NOTSET)
                     return sys.modules[name]
 
                 if moduleName.startswith("processing.parameters"):


### PR DESCRIPTION
Fixes QGIS hanging during closing in certain circumstances. 

To reproduce:
1. Create a simple model (e.g. including just r.neighbors algorithm)
2. Open Python Console
3. Close QGIS

The hanging happens when Processing tries to reload models while some algorithm providers have already been removed due to QGIS closing. I don't know if this PR is the best solution but it seems to fix the problem. 
