### PR TITLE
Make annotations aware of CRS (fixes #3618)

### DIFF
--- a/python/gui/qgsannotationitem.sip
+++ b/python/gui/qgsannotationitem.sip
@@ -44,6 +44,12 @@ class QgsAnnotationItem: QgsMapCanvasItem
     virtual void setMapPosition( const QgsPoint& pos );
     QgsPoint mapPosition() const;
 
+    /** Sets the CRS of the map position.
+      @param crs the CRS to set */
+    virtual void setMapPositionCrs( const QgsCoordinateReferenceSystem& crs );
+    /** Returns the CRS of the map position.*/
+    QgsCoordinateReferenceSystem mapPositionCrs() const;
+
     void setFrameSize( const QSizeF& size );
     QSizeF frameSize() const;
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2316,6 +2316,9 @@ void QgisApp::setupConnections()
   connect( mRenderSuppressionCBox, SIGNAL( toggled( bool ) ),
            mMapCanvas, SLOT( setRenderFlag( bool ) ) );
 
+  connect( mMapCanvas, SIGNAL( destinationCrsChanged() ),
+           this, SLOT( reprojectAnnotations() ) );
+
   // connect MapCanvas keyPress event so we can check if selected feature collection must be deleted
   connect( mMapCanvas, SIGNAL( keyPressed( QKeyEvent * ) ),
            this, SLOT( mapCanvas_keyPressed( QKeyEvent * ) ) );
@@ -5159,6 +5162,14 @@ void QgisApp::addSvgAnnotation()
 void QgisApp::modifyAnnotation()
 {
   mMapCanvas->setMapTool( mMapTools.mAnnotation );
+}
+
+void QgisApp::reprojectAnnotations()
+{
+  Q_FOREACH ( QgsAnnotationItem * annotation, annotationItems() )
+  {
+    annotation->updatePosition();
+  }
 }
 
 void QgisApp::labelingFontNotFound( QgsVectorLayer* vlayer, const QString& fontfamily )

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1128,6 +1128,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     void addHtmlAnnotation();
     void addSvgAnnotation();
     void modifyAnnotation();
+    void reprojectAnnotations();
 
     /** Alerts user when labeling font for layer has not been found on system */
     void labelingFontNotFound( QgsVectorLayer *vlayer, const QString& fontfamily );

--- a/src/gui/qgsannotationitem.h
+++ b/src/gui/qgsannotationitem.h
@@ -19,6 +19,7 @@
 #define QGSANNOTATIONITEM_H
 
 #include "qgsmapcanvasitem.h"
+#include "qgscoordinatereferencesystem.h"
 
 class QDomDocument;
 class QDomElement;
@@ -68,6 +69,12 @@ class GUI_EXPORT QgsAnnotationItem: public QgsMapCanvasItem
     virtual void setMapPosition( const QgsPoint& pos );
     QgsPoint mapPosition() const { return mMapPosition; }
 
+    /** Sets the CRS of the map position.
+      @param crs the CRS to set */
+    virtual void setMapPositionCrs( const QgsCoordinateReferenceSystem& crs );
+    /** Returns the CRS of the map position.*/
+    QgsCoordinateReferenceSystem mapPositionCrs() const { return mMapPositionCrs; }
+
     void setFrameSize( const QSizeF& size );
     QSizeF frameSize() const { return mFrameSize; }
 
@@ -98,6 +105,9 @@ class GUI_EXPORT QgsAnnotationItem: public QgsMapCanvasItem
     bool mMapPositionFixed;
     /** Map position (in case mMapPositionFixed is true)*/
     QgsPoint mMapPosition;
+    /** CRS of the map position */
+    QgsCoordinateReferenceSystem mMapPositionCrs;
+
     /** Describes the shift of the item content box to the reference point*/
     QPointF mOffsetFromReferencePoint;
 


### PR DESCRIPTION
Do not just save the position of an annotation but also the CRS. This allows reprojecting the annotation's position when the canvas is reprojected.

The CRS is saved and loaded to/from the project file.
If an old project file is loaded without an explicit CRS for an annotation, the canvas CRS is used.
