### PR TITLE
Stop the capture map tools automatically (refs #4237)

### DIFF
--- a/python/gui/qgsmaptoolcapture.sip
+++ b/python/gui/qgsmaptoolcapture.sip
@@ -77,10 +77,12 @@ class QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
 
     void startCapturing();
     bool isCapturing() const;
-    void stopCapturing();
 
     int size();
     QList<QgsPoint> points();
     void setPoints( const QList<QgsPoint>& pointList );
     void closePolygon();
+
+  protected slots:
+    void stopCapturing();
 };

--- a/src/app/qgsmaptooladdcircularstring.cpp
+++ b/src/app/qgsmaptooladdcircularstring.cpp
@@ -35,6 +35,8 @@ QgsMapToolAddCircularString::QgsMapToolAddCircularString( QgsMapToolCapture* par
   {
     connect( mCanvas, SIGNAL( mapToolSet( QgsMapTool*, QgsMapTool* ) ), this, SLOT( setParentTool( QgsMapTool*, QgsMapTool* ) ) );
   }
+  connect( QgisApp::instance(), SIGNAL( newProject() ), this, SLOT( stopCapturing() ) );
+  connect( QgisApp::instance(), SIGNAL( projectRead() ), this, SLOT( stopCapturing() ) );
 }
 
 QgsMapToolAddCircularString::QgsMapToolAddCircularString( QgsMapCanvas* canvas )

--- a/src/app/qgsmaptooladdfeature.cpp
+++ b/src/app/qgsmaptooladdfeature.cpp
@@ -40,6 +40,8 @@ QgsMapToolAddFeature::QgsMapToolAddFeature( QgsMapCanvas* canvas, CaptureMode mo
     , mCheckGeometryType( true )
 {
   mToolName = tr( "Add feature" );
+  connect( QgisApp::instance(), SIGNAL( newProject() ), this, SLOT( stopCapturing() ) );
+  connect( QgisApp::instance(), SIGNAL( projectRead() ), this, SLOT( stopCapturing() ) );
 }
 
 QgsMapToolAddFeature::~QgsMapToolAddFeature()

--- a/src/app/qgsmaptooladdpart.cpp
+++ b/src/app/qgsmaptooladdpart.cpp
@@ -30,6 +30,8 @@ QgsMapToolAddPart::QgsMapToolAddPart( QgsMapCanvas* canvas )
     : QgsMapToolCapture( canvas, QgisApp::instance()->cadDockWidget() )
 {
   mToolName = tr( "Add part" );
+  connect( QgisApp::instance(), SIGNAL( newProject() ), this, SLOT( stopCapturing() ) );
+  connect( QgisApp::instance(), SIGNAL( projectRead() ), this, SLOT( stopCapturing() ) );
 }
 
 QgsMapToolAddPart::~QgsMapToolAddPart()

--- a/src/app/qgsmaptooladdring.cpp
+++ b/src/app/qgsmaptooladdring.cpp
@@ -29,6 +29,8 @@ QgsMapToolAddRing::QgsMapToolAddRing( QgsMapCanvas* canvas )
     : QgsMapToolCapture( canvas, QgisApp::instance()->cadDockWidget(), QgsMapToolCapture::CapturePolygon )
 {
   mToolName = tr( "Add ring" );
+  connect( QgisApp::instance(), SIGNAL( newProject() ), this, SLOT( stopCapturing() ) );
+  connect( QgisApp::instance(), SIGNAL( projectRead() ), this, SLOT( stopCapturing() ) );
 }
 
 QgsMapToolAddRing::~QgsMapToolAddRing()

--- a/src/gui/qgsmaptoolcapture.h
+++ b/src/gui/qgsmaptoolcapture.h
@@ -108,11 +108,6 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
     bool isCapturing() const;
 
     /**
-     * Stop capturing
-     */
-    void stopCapturing();
-
-    /**
      * Number of points digitized
      *
      * @return Number of points
@@ -136,6 +131,12 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
      * Close an open polygon
      */
     void closePolygon();
+
+  protected slots:
+    /**
+     * Stop capturing
+     */
+    void stopCapturing();
 
   private:
     /** Flag to indicate a map canvas capture operation is taking place */


### PR DESCRIPTION
Stops the capturing when leaving edit mode for the current layer or when changing the current layer. Avoids _ghost lines_ and other weird effects ([Redmine # 4237](https://hub.qgis.org/issues/4237)) when starting to digitize on one layer, but finishing it on another one (e.g. projection issues).
