### PR TITLE
Refresh the label style widget when loading a new style (fixes #13667)

### DIFF
--- a/src/app/qgslabelingwidget.cpp
+++ b/src/app/qgslabelingwidget.cpp
@@ -20,6 +20,13 @@ QgsLabelingWidget::QgsLabelingWidget( QgsVectorLayer* layer, QgsMapCanvas* canva
 
   connect( mLabelModeComboBox, SIGNAL( currentIndexChanged( int ) ), this, SLOT( labelModeChanged( int ) ) );
 
+  adaptToLayer();
+}
+
+void QgsLabelingWidget::adaptToLayer()
+{
+  mLabelModeComboBox->setCurrentIndex( -1 );
+
   // pick the right mode of the layer
   if ( mLayer->labeling() && mLayer->labeling()->type() == "rule-based" )
   {
@@ -68,6 +75,9 @@ void QgsLabelingWidget::apply()
 
 void QgsLabelingWidget::labelModeChanged( int index )
 {
+  if ( index < 0 )
+    return;
+
   if ( index < 3 )
   {
     if ( QgsLabelingGui* widgetSimple = qobject_cast<QgsLabelingGui*>( mWidget ) )

--- a/src/app/qgslabelingwidget.h
+++ b/src/app/qgslabelingwidget.h
@@ -26,6 +26,9 @@ class QgsLabelingWidget : public QWidget, private Ui::QgsLabelingWidget
     //! Saves the labeling configuration and immediately updates the map canvas to reflect the changes
     void apply();
 
+    //! reload the settings shown in the dialog from the current layer
+    void adaptToLayer();
+
   protected slots:
     void labelModeChanged( int index );
     void showEngineConfigDialog();

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -466,6 +466,8 @@ void QgsVectorLayerProperties::syncToLayer( void )
 
   actionDialog->init();
 
+  labelingDialog->adaptToLayer();
+
   // reset fields in label dialog
   layer->label()->setFields( layer->fields() );
 


### PR DESCRIPTION
the `QgsLabelingWidget` is triggered to reload its settings when
- loading a style file
- loading a style from a database
- loading the default style
