### PR TITLE
Sort the indexes when generating layer tree mime data (fixes #4110)

### DIFF
--- a/src/core/layertree/qgslayertreemodel.cpp
+++ b/src/core/layertree/qgslayertreemodel.cpp
@@ -928,7 +928,11 @@ QStringList QgsLayerTreeModel::mimeTypes() const
 
 QMimeData* QgsLayerTreeModel::mimeData( const QModelIndexList& indexes ) const
 {
-  QList<QgsLayerTreeNode*> nodesFinal = indexes2nodes( indexes, true );
+  // Sort the indexes. Depending on how the user selected the items, the indexes may be unsorted.
+  QModelIndexList sortedIndexes = indexes;
+  qSort( sortedIndexes.begin(), sortedIndexes.end(), qLess<QModelIndex>() );
+
+  QList<QgsLayerTreeNode*> nodesFinal = indexes2nodes( sortedIndexes, true );
 
   if ( nodesFinal.count() == 0 )
     return 0;


### PR DESCRIPTION
The mime data generated by `QgsLayerTreeModel::mimeData()` is used by some functions
- drag'n'drop of layers into a group (mentioned in [Redmine # 4110](http://hub.qgis.org/issues/4110))
- export of layers to a qlr-file
- ...

The user usually does _not_ expect these functions to behave differently depending on how the selection was made. Therefore the indexes are now sorted before the actual mime data for the items pointed to by the indexes is returned.
