### PR TITLE
[svg markers] allow setting alpha value for fill and outline colors

### DIFF
--- a/src/core/symbology-ng/qgssvgcache.cpp
+++ b/src/core/symbology-ng/qgssvgcache.cpp
@@ -620,13 +620,21 @@ void QgsSvgCache::replaceElemParams( QDomElement& elem, const QColor& fill, cons
         }
         QString key = keyValueSplit.at( 0 );
         QString value = keyValueSplit.at( 1 );
-        if ( value.startsWith( "param(fill" ) )
+        if ( value.startsWith( "param(fill)" ) )
         {
           value = fill.name();
+        }
+        else if ( value.startsWith( "param(fill-opacity)" ) )
+        {
+          value = fill.alphaF();
         }
         else if ( value.startsWith( "param(outline)" ) )
         {
           value = outline.name();
+        }
+        else if ( value.startsWith( "param(outline-opacity)" ) )
+        {
+          value = outline.alphaF();
         }
         else if ( value.startsWith( "param(outline-width)" ) )
         {
@@ -648,9 +656,17 @@ void QgsSvgCache::replaceElemParams( QDomElement& elem, const QColor& fill, cons
       {
         elem.setAttribute( attribute.name(), fill.name() );
       }
+      else if ( value.startsWith( "param(fill-opacity)" ) )
+      {
+        elem.setAttribute( attribute.name(), fill.alphaF() );
+      }
       else if ( value.startsWith( "param(outline)" ) )
       {
         elem.setAttribute( attribute.name(), outline.name() );
+      }
+      else if ( value.startsWith( "param(outline-opacity)" ) )
+      {
+        elem.setAttribute( attribute.name(), outline.alphaF() );
       }
       else if ( value.startsWith( "param(outline-width)" ) )
       {

--- a/src/gui/symbology-ng/qgssymbollayerv2widget.cpp
+++ b/src/gui/symbology-ng/qgssymbollayerv2widget.cpp
@@ -1564,11 +1564,12 @@ QgsSvgMarkerSymbolLayerV2Widget::QgsSvgMarkerSymbolLayerV2Widget( const QgsVecto
   mBorderWidthUnitWidget->setUnits( QgsSymbolV2::OutputUnitList() << QgsSymbolV2::MM << QgsSymbolV2::MapUnit << QgsSymbolV2::Pixel );
   mOffsetUnitWidget->setUnits( QgsSymbolV2::OutputUnitList() << QgsSymbolV2::MM << QgsSymbolV2::MapUnit << QgsSymbolV2::Pixel );
   viewGroups->setHeaderHidden( true );
-
+  mChangeColorButton->setAllowAlpha( true );
   mChangeColorButton->setColorDialogTitle( tr( "Select fill color" ) );
   mChangeColorButton->setContext( "symbology" );
+  mChangeBorderColorButton->setAllowAlpha( true );
   mChangeBorderColorButton->setColorDialogTitle( tr( "Select border color" ) );
-  mChangeColorButton->setContext( "symbology" );
+  mChangeBorderColorButton->setContext( "symbology" );
 
   spinOffsetX->setClearValue( 0.0 );
   spinOffsetY->setClearValue( 0.0 );


### PR DESCRIPTION
This PR makes it possible for alpha value to be attached to the fill and outline colors of SVG markers by adding a fill-opacity and stroke-opacity value when those are declared as param()s in SVG files.

SVG files bundled with QGIS will need to be updated to support this, @nyalldawson mentioned it could be done relatively easily via a mass grep replace command.
