### PR TITLE
[FEATURE][QGIS Server] Add short name to layers, groups and project

### DIFF
--- a/python/core/qgsapplication.sip
+++ b/python/core/qgsapplication.sip
@@ -228,6 +228,9 @@ static void qtgui_UpdatePyArgv(PyObject *argvlist, int argc, char **argv)
     //! Returns the path to user's style.
     static QString userStyleV2Path();
 
+    //! Returns the short name regular exprecience for line edit validator
+    static QRegExp shortNameRegExp();
+
     //! Returns the path to user's themes folder
     static QString userThemesFolder();
 

--- a/python/core/qgsmaplayer.sip
+++ b/python/core/qgsmaplayer.sip
@@ -76,6 +76,17 @@ class QgsMapLayer : QObject
      */
     QString originalName() const;
 
+    /** Set the short name of the layer
+     *  used by QGIS Server to identify the layer
+     * @return the layer short name
+     */
+    void setShortName( const QString& shortName );
+    /** Get the short name of the layer
+     *  used by QGIS Server to identify the layer
+     * @return the layer short name
+     */
+    QString shortName() const;
+
     /** Set the title of the layer
      *  used by QGIS Server in GetCapabilities request
      * @return the layer title

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -205,6 +205,7 @@
 #include "qgsrectangle.h"
 #include "qgsscalecombobox.h"
 #include "qgsscalevisibilitydialog.h"
+#include "qgsgroupwmsdatadialog.h"
 #include "qgsshortcutsmanager.h"
 #include "qgssinglebandgrayrenderer.h"
 #include "qgssnappingdialog.h"
@@ -7830,6 +7831,24 @@ void QgisApp::legendGroupSetCRS()
       nodeLayer->layer()->triggerRepaint();
     }
   }
+}
+
+void QgisApp::legendGroupSetWMSData()
+{
+  QgsLayerTreeGroup* currentGroup = mLayerTreeView->currentGroupNode();
+  if ( !currentGroup )
+    return;
+  QgsGroupWMSDataDialog* dlg = new QgsGroupWMSDataDialog( this );
+  dlg->setGroupShortName( currentGroup->customProperty( "wmsShortName" ).toString() );
+  dlg->setGroupTitle( currentGroup->customProperty( "wmsTitle" ).toString() );
+  dlg->setGroupTitle( currentGroup->customProperty( "wmsAbstract" ).toString() );
+  if ( dlg->exec() )
+  {
+    currentGroup->setCustomProperty( "wmsShortName", dlg->groupShortName() );
+    currentGroup->setCustomProperty( "wmsTitle", dlg->groupTitle() );
+    currentGroup->setCustomProperty( "wmsAbstract", dlg->groupAbstract() );
+  }
+  delete dlg;
 }
 
 void QgisApp::zoomToLayerExtent()

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -753,6 +753,8 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     /** Set the CRS of the current legend group*/
     void legendGroupSetCRS();
+    /** Set the WMS data of the current legend group*/
+    void legendGroupSetWMSData();
 
     //! zoom to extent of layer
     void zoomToLayerExtent();

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -61,6 +61,8 @@ QMenu* QgsAppLayerTreeViewMenuProvider::createContextMenu()
 
       menu->addAction( actions->actionRenameGroupOrLayer( menu ) );
 
+      menu->addAction( tr( "&Set Group WMS data" ), QgisApp::instance(), SLOT( legendGroupSetWMSData() ) );
+
       menu->addAction( actions->actionMutuallyExclusiveGroup( menu ) );
 
       if ( mView->selectedNodes( true ).count() >= 2 )

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -262,6 +262,7 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas* mapCanvas, QWidget *pa
 
   grpOWSServiceCapabilities->setChecked( QgsProject::instance()->readBoolEntry( "WMSServiceCapabilities", "/", false ) );
   mWMSTitle->setText( QgsProject::instance()->readEntry( "WMSServiceTitle", "/" ) );
+  mWMSName->setText( QgsProject::instance()->readEntry( "WMSRootName", "/" ) );
   mWMSContactOrganization->setText( QgsProject::instance()->readEntry( "WMSContactOrganization", "/", "" ) );
   mWMSContactPerson->setText( QgsProject::instance()->readEntry( "WMSContactPerson", "/", "" ) );
   mWMSContactMail->setText( QgsProject::instance()->readEntry( "WMSContactMail", "/", "" ) );
@@ -270,6 +271,10 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas* mapCanvas, QWidget *pa
   mWMSOnlineResourceLineEdit->setText( QgsProject::instance()->readEntry( "WMSOnlineResource", "/", "" ) );
   mWMSUrlLineEdit->setText( QgsProject::instance()->readEntry( "WMSUrl", "/", "" ) );
   mWMSKeywordList->setText( QgsProject::instance()->readListEntry( "WMSKeywordList", "/" ).join( ", " ) );
+
+  // WMS Name validator
+  QValidator *shortNameValidator = new QRegExpValidator( QgsApplication::shortNameRegExp(), this );
+  mWMSName->setValidator( shortNameValidator );
 
   // WMS Contact Position
   QString contactPositionText = QgsProject::instance()->readEntry( "WMSContactPosition", "/", "" );
@@ -785,6 +790,7 @@ void QgsProjectProperties::apply()
 
   QgsProject::instance()->writeEntry( "WMSServiceCapabilities", "/", grpOWSServiceCapabilities->isChecked() );
   QgsProject::instance()->writeEntry( "WMSServiceTitle", "/", mWMSTitle->text() );
+  QgsProject::instance()->writeEntry( "WMSRootName", "/", mWMSName->text() );
   QgsProject::instance()->writeEntry( "WMSContactOrganization", "/", mWMSContactOrganization->text() );
   QgsProject::instance()->writeEntry( "WMSContactPerson", "/", mWMSContactPerson->text() );
   QgsProject::instance()->writeEntry( "WMSContactMail", "/", mWMSContactMail->text() );

--- a/src/app/qgsrasterlayerproperties.cpp
+++ b/src/app/qgsrasterlayerproperties.cpp
@@ -750,6 +750,13 @@ void QgsRasterLayerProperties::sync()
   txtbMetadata->document()->setDefaultStyleSheet( myStyle );
   txtbMetadata->setHtml( mRasterLayer->metadata() );
 
+  // WMS Name as layer short name
+  mLayerShortNameLineEdit->setText( mRasterLayer->shortName() );
+  // WMS Name validator
+  QValidator *shortNameValidator = new QRegExpValidator( QgsApplication::shortNameRegExp(), this );
+  mLayerShortNameLineEdit->setValidator( shortNameValidator );
+
+  //layer title and abstract
   mLayerTitleLineEdit->setText( mRasterLayer->title() );
   mLayerAbstractTextEdit->setPlainText( mRasterLayer->abstract() );
   mLayerKeywordListLineEdit->setText( mRasterLayer->keywordList() );
@@ -934,6 +941,7 @@ void QgsRasterLayerProperties::apply()
   QPixmap thumbnail = QPixmap::fromImage( mRasterLayer->previewAsImage( pixmapThumbnail->size() ) );
   pixmapThumbnail->setPixmap( thumbnail );
 
+  mRasterLayer->setShortName( mLayerShortNameLineEdit->text() );
   mRasterLayer->setTitle( mLayerTitleLineEdit->text() );
   mRasterLayer->setAbstract( mLayerAbstractTextEdit->toPlainText() );
   mRasterLayer->setKeywordList( mLayerKeywordListLineEdit->text() );

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -249,6 +249,11 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
   diagLayout->addWidget( diagramPropertiesDialog );
   mDiagramFrame->setLayout( diagLayout );
 
+  // WMS Name as layer short name
+  mLayerShortNameLineEdit->setText( layer->shortName() );
+  // WMS Name validator
+  QValidator *shortNameValidator = new QRegExpValidator( QgsApplication::shortNameRegExp(), this );
+  mLayerShortNameLineEdit->setValidator( shortNameValidator );
 
   //layer title and abstract
   mLayerTitleLineEdit->setText( layer->title() );
@@ -588,6 +593,7 @@ void QgsVectorLayerProperties::apply()
   diagramPropertiesDialog->apply();
 
   //layer title and abstract
+  layer->setShortName( mLayerShortNameLineEdit->text() );
   layer->setTitle( mLayerTitleLineEdit->text() );
   layer->setAbstract( mLayerAbstractTextEdit->toPlainText() );
   layer->setKeywordList( mLayerKeywordListLineEdit->text() );

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -717,6 +717,11 @@ QString QgsApplication::userStyleV2Path()
   return qgisSettingsDirPath() + QLatin1String( "symbology-ng-style.db" );
 }
 
+QRegExp QgsApplication::shortNameRegExp()
+{
+  return QRegExp( "^[A-Za-z][A-Za-z0-9\\._-]*" );
+}
+
 QString QgsApplication::userThemesFolder()
 {
   return qgisSettingsDirPath() + QLatin1String( "/themes" );

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -190,6 +190,9 @@ class CORE_EXPORT QgsApplication : public QApplication
     //! Returns the path to user's style.
     static QString userStyleV2Path();
 
+    //! Returns the short name regular exprecience for line edit validator
+    static QRegExp shortNameRegExp();
+
     //! Returns the path to user's themes folder
     static QString userThemesFolder();
 

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -67,6 +67,9 @@ QgsMapLayer::QgsMapLayer( QgsMapLayer::LayerType type,
   mLayerName = capitaliseLayerName( mLayerOrigName );
   QgsDebugMsg( "display name: '" + mLayerName + '\'' );
 
+  // Set short name = the first original name
+  mShortName = lyrname;
+
   // Generate the unique ID of this layer
   QDateTime dt = QDateTime::currentDateTime();
   mID = lyrname + dt.toString( "yyyyMMddhhmmsszzz" );
@@ -425,6 +428,13 @@ bool QgsMapLayer::readLayerXML( const QDomElement& layerElement )
   mne = mnl.toElement();
   setLayerName( mne.text() );
 
+  //short name
+  QDomElement shortNameElem = layerElement.firstChildElement( "shortname" );
+  if ( !shortNameElem.isNull() )
+  {
+    mShortName = shortNameElem.text();
+  }
+
   //title
   QDomElement titleElem = layerElement.firstChildElement( "title" );
   if ( !titleElem.isNull() )
@@ -640,6 +650,11 @@ bool QgsMapLayer::writeLayerXML( QDomElement& layerElement, QDomDocument& docume
   QDomText layerNameText = document.createTextNode( originalName() );
   layerName.appendChild( layerNameText );
 
+  // layer short name
+  QDomElement layerShortName = document.createElement( "shortname" );
+  QDomText layerShortNameText = document.createTextNode( shortName() );
+  layerShortName.appendChild( layerShortNameText );
+
   // layer title
   QDomElement layerTitle = document.createElement( "title" );
   QDomText layerTitleText = document.createTextNode( title() );
@@ -651,6 +666,7 @@ bool QgsMapLayer::writeLayerXML( QDomElement& layerElement, QDomDocument& docume
   layerAbstract.appendChild( layerAbstractText );
 
   layerElement.appendChild( layerName );
+  layerElement.appendChild( layerShortName );
   layerElement.appendChild( layerTitle );
   layerElement.appendChild( layerAbstract );
 

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -92,6 +92,17 @@ class CORE_EXPORT QgsMapLayer : public QObject
      */
     QString originalName() const { return mLayerOrigName; }
 
+    /** Set the short name of the layer
+     *  used by QGIS Server to identify the layer
+     * @return the layer short name
+     */
+    void setShortName( const QString& shortName ) { mShortName = shortName; }
+    /** Get the short name of the layer
+     *  used by QGIS Server to identify the layer
+     * @return the layer short name
+     */
+    QString shortName() const { return mShortName; }
+
     /** Set the title of the layer
      *  used by QGIS Server in GetCapabilities request
      * @return the layer title
@@ -677,6 +688,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
      */
     QString mLayerOrigName;
 
+    QString mShortName;
     QString mTitle;
 
     /** Description of the layer*/

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -265,6 +265,7 @@ SET(QGIS_GUI_SRCS
   qgsvertexmarker.cpp
   qgsunitselectionwidget.cpp
   qgslegendfilterbutton.cpp
+  qgsgroupwmsdatadialog.cpp
 )
 
 IF (WITH_QTWEBKIT)
@@ -392,6 +393,7 @@ SET(QGIS_GUI_MOC_HDRS
   qgsunitselectionwidget.h
   qgsuserinputdockwidget.h
   qgslegendfilterbutton.h
+  qgsgroupwmsdatadialog.h
 
   raster/qgsrasterminmaxwidget.h
   raster/qgspalettedrendererwidget.h

--- a/src/gui/qgsgroupwmsdatadialog.cpp
+++ b/src/gui/qgsgroupwmsdatadialog.cpp
@@ -1,0 +1,57 @@
+/***************************************************************************
+   qgsscalevisibilitydialog.cpp
+    --------------------------------------
+   Date                 : 20.05.2014
+   Copyright            : (C) 2014 Denis Rouzaud
+   Email                : denis.rouzaud@gmail.com
+***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************/
+
+#include "qgsapplication.h"
+#include "qgsgroupwmsdatadialog.h"
+
+
+QgsGroupWMSDataDialog::QgsGroupWMSDataDialog( QWidget *parent, const Qt::WindowFlags& fl ) :
+    QDialog( parent, fl )
+{
+  setupUi( this );
+  // WMS Name validator
+  QValidator *shortNameValidator = new QRegExpValidator( QgsApplication::shortNameRegExp(), this );
+  mShortNameLineEdit->setValidator( shortNameValidator );
+}
+
+QString QgsGroupWMSDataDialog::groupShortName()
+{
+  return mShortNameLineEdit->text();
+}
+
+void QgsGroupWMSDataDialog::setGroupShortName( QString shortName )
+{
+  mShortNameLineEdit->setText( shortName );
+}
+
+QString QgsGroupWMSDataDialog::groupTitle()
+{
+  return mTitleLineEdit->text();
+}
+
+void QgsGroupWMSDataDialog::setGroupTitle( QString title )
+{
+  mTitleLineEdit->setText( title );
+}
+
+QString QgsGroupWMSDataDialog::groupAbstract()
+{
+  return mAbstractTextEdit->toPlainText();
+}
+
+void QgsGroupWMSDataDialog::setGroupAbstract( QString abstract )
+{
+  mAbstractTextEdit->setPlainText( abstract );
+}

--- a/src/gui/qgsgroupwmsdatadialog.h
+++ b/src/gui/qgsgroupwmsdatadialog.h
@@ -1,0 +1,62 @@
+/***************************************************************************
+   qgsscalevisibilitydialog.cpp
+    --------------------------------------
+   Date                 : 20.05.2014
+   Copyright            : (C) 2014 Denis Rouzaud
+   Email                : denis.rouzaud@gmail.com
+***************************************************************************
+*                                                                         *
+*   This program is free software; you can redistribute it and/or modify  *
+*   it under the terms of the GNU General Public License as published by  *
+*   the Free Software Foundation; either version 2 of the License, or     *
+*   (at your option) any later version.                                   *
+*                                                                         *
+***************************************************************************/
+
+#ifndef QGSGROUPWMSDATADIALOG_H
+#define QGSGROUPWMSDATADIALOG_H
+
+#include "ui_qgsgroupwmsdatadialogbase.h"
+#include "qgisgui.h"
+#include "qgscontexthelp.h"
+
+#include "qgis.h"
+
+class GUI_EXPORT QgsGroupWMSDataDialog: public QDialog, private Ui::QgsGroupWMSDataDialogBase
+{
+    Q_OBJECT
+
+  public:
+    //! Constructor
+    QgsGroupWMSDataDialog( QWidget *parent = 0, const Qt::WindowFlags& fl = QgisGui::ModalDialogFlags );
+    //~QgsGroupWMSDataDialog();
+
+    //! return group WMS title
+    QString groupTitle();
+
+    //! return group WMS short name
+    QString groupShortName();
+
+    //! return group WMS abstract
+    QString groupAbstract();
+
+
+  public slots:
+    //! set group WMS title
+    void setGroupTitle( QString title );
+
+    //! set group WMS short name
+    void setGroupShortName( QString shortName );
+
+    //! set group WMS abstract
+    void setGroupAbstract( QString abstract );
+
+
+  private:
+
+    QString mGroupTitle;
+    QString mGroupShortName;
+
+};
+
+#endif // QGSGROUPWMSDATADIALOG_H

--- a/src/server/qgsserverprojectparser.h
+++ b/src/server/qgsserverprojectparser.h
@@ -30,6 +30,7 @@ class QgsCoordinateReferenceSystem;
 class QgsMapLayer;
 class QgsRectangle;
 class QDomDocument;
+class QgsLayerTreeGroup;
 
 class SERVER_EXPORT QgsServerProjectParser
 {
@@ -100,7 +101,7 @@ class SERVER_EXPORT QgsServerProjectParser
     QList< QPair< QString, QgsLayerCoordinateTransform > > layerCoordinateTransforms() const;
 
     /** Returns the text of the <layername> element for a layer element
-    @return id or a null string in case of error*/
+    @return name or a null string in case of error*/
     QString layerName( const QDomElement& layerElem ) const;
 
     QString serviceUrl() const;
@@ -119,6 +120,10 @@ class SERVER_EXPORT QgsServerProjectParser
     /** Returns the text of the <id> element for a layer element
     @return id or a null string in case of error*/
     QString layerId( const QDomElement& layerElem ) const;
+
+    /** Returns the text of the <id> element for a layer element
+    @return id or a null string in case of error*/
+    QString layerShortName( const QDomElement& layerElem ) const;
 
     QgsRectangle projectExtent() const;
 
@@ -163,6 +168,9 @@ class SERVER_EXPORT QgsServerProjectParser
     QStringList mCustomLayerOrder;
 
     bool findUseLayerIDs() const;
+
+    QList<QDomElement> findLegendGroupElements() const;
+    QList<QDomElement> setLegendGroupElementsWithLayerTree( QgsLayerTreeGroup* layerTreeGroup, QDomElement legendElement ) const;
 
     /** Adds sublayers of an embedded group to layer set*/
     static void sublayersOfEmbeddedGroup( const QString& projectFilePath, const QString& groupName, QSet<QString>& layerSet );

--- a/src/server/qgswcsprojectparser.cpp
+++ b/src/server/qgswcsprojectparser.cpp
@@ -110,6 +110,8 @@ void QgsWCSProjectParser::wcsContentMetadata( QDomElement& parentElement, QDomDo
         //We use the layer name even though it might not be unique.
         //Because the id sometimes contains user/pw information and the name is more descriptive
         QString typeName = layer->name();
+        if ( !layer->shortName().isEmpty() )
+          typeName = layer->shortName();
         typeName = typeName.replace( " ", "_" );
         QDomText nameText = doc.createTextNode( typeName );
         nameElem.appendChild( nameText );
@@ -231,6 +233,8 @@ void QgsWCSProjectParser::describeCoverage( const QString& aCoveName, QDomElemen
 #endif
 
       QString coveName = rLayer->name();
+      if ( !rLayer->shortName().isEmpty() )
+        coveName = rLayer->shortName();
       coveName = coveName.replace( " ", "_" );
       if ( wcsLayersId.contains( rLayer->id() ) && ( aCoveName == "" || coveNameList.contains( coveName ) ) )
       {
@@ -242,6 +246,8 @@ void QgsWCSProjectParser::describeCoverage( const QString& aCoveName, QDomElemen
         //We use the layer name even though it might not be unique.
         //Because the id sometimes contains user/pw information and the name is more descriptive
         QString typeName = rLayer->name();
+        if ( !rLayer->shortName().isEmpty() )
+          typeName = rLayer->shortName();
         typeName = typeName.replace( " ", "_" );
         QDomText nameText = doc.createTextNode( typeName );
         nameElem.appendChild( nameText );
@@ -435,6 +441,8 @@ QList<QgsMapLayer*> QgsWCSProjectParser::mapLayerFromCoverage( const QString& cN
         return layerList;
 
       QString coveName = layer->name();
+      if ( !layer->shortName().isEmpty() )
+        coveName = layer->shortName();
       coveName = coveName.replace( " ", "_" );
       if ( cName == coveName )
       {

--- a/src/server/qgswfsprojectparser.cpp
+++ b/src/server/qgswfsprojectparser.cpp
@@ -101,6 +101,8 @@ void QgsWFSProjectParser::featureTypeList( QDomElement& parentElement, QDomDocum
       //We use the layer name even though it might not be unique.
       //Because the id sometimes contains user/pw information and the name is more descriptive
       QString typeName = layer->name();
+      if ( !layer->shortName().isEmpty() )
+        typeName = layer->shortName();
       typeName = typeName.replace( " ", "_" );
       QDomText nameText = doc.createTextNode( typeName );
       nameElem.appendChild( nameText );
@@ -356,6 +358,8 @@ void QgsWFSProjectParser::describeFeatureType( const QString& aTypeName, QDomEle
 #endif
 
       QString typeName = layer->name();
+      if ( !layer->shortName().isEmpty() )
+        typeName = layer->shortName();
       typeName = typeName.replace( " ", "_" );
 
       if ( wfsLayersId.contains( layer->id() ) && ( aTypeName == "" || typeNameList.contains( typeName ) ) )
@@ -546,6 +550,8 @@ QList<QgsMapLayer*> QgsWFSProjectParser::mapLayerFromTypeName( const QString& aT
         continue;
 
       QString typeName = layer->name();
+      if ( !layer->shortName().isEmpty() )
+        typeName = layer->shortName();
       typeName = typeName.replace( " ", "_" );
 
       if ( wfsLayersId.contains( layer->id() ) && ( aTypeName == "" || typeNameList.contains( typeName ) ) )

--- a/src/server/qgswmsprojectparser.h
+++ b/src/server/qgswmsprojectparser.h
@@ -146,6 +146,7 @@ class SERVER_EXPORT QgsWMSProjectParser : public QgsWMSConfigParser
     void addLayers( QDomDocument &doc,
                     QDomElement &parentLayer,
                     const QDomElement &legendElem,
+                    QgsLayerTreeGroup *layerTreeGroup,
                     const QMap<QString, QgsMapLayer *> &layerMap,
                     const QStringList &nonIdentifiableLayers,
                     QString version, //1.1.1 or 1.3.0

--- a/src/ui/qgsgroupwmsdatadialogbase.ui
+++ b/src/ui/qgsgroupwmsdatadialogbase.ui
@@ -1,0 +1,127 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsGroupWMSDataDialogBase</class>
+ <widget class="QDialog" name="QgsGroupWMSDataDialogBase">
+  <property name="windowModality">
+   <enum>Qt::WindowModal</enum>
+  </property>
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>500</width>
+    <height>206</height>
+   </rect>
+  </property>
+  <property name="sizePolicy">
+   <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
+    <horstretch>0</horstretch>
+    <verstretch>0</verstretch>
+   </sizepolicy>
+  </property>
+  <property name="minimumSize">
+   <size>
+    <width>500</width>
+    <height>150</height>
+   </size>
+  </property>
+  <property name="windowTitle">
+   <string>Set group WMS data</string>
+  </property>
+  <property name="windowIcon">
+   <iconset>
+    <normaloff/>
+   </iconset>
+  </property>
+  <layout class="QGridLayout" name="gridLayout_5">
+   <item row="1" column="0">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Save</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <layout class="QGridLayout" name="gridLayout">
+     <item row="0" column="0">
+      <widget class="QLabel" name="mShortNameLabel">
+       <property name="text">
+        <string>Short name</string>
+       </property>
+      </widget>
+     </item>
+     <item row="0" column="1">
+      <widget class="QLineEdit" name="mShortNameLineEdit">
+       <property name="placeholderText">
+        <string>The short name is a text string used for machine-to-machine communication</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="1">
+      <widget class="QLineEdit" name="mTitleLineEdit">
+       <property name="placeholderText">
+        <string>The title is a text string for the benefit of humans</string>
+       </property>
+      </widget>
+     </item>
+     <item row="1" column="0">
+      <widget class="QLabel" name="mTitleLabel">
+       <property name="text">
+        <string>Title</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="0">
+      <widget class="QLabel" name="mAbstractLabel">
+       <property name="text">
+        <string>Abstract</string>
+       </property>
+      </widget>
+     </item>
+     <item row="2" column="1">
+      <widget class="QTextEdit" name="mAbstractTextEdit"/>
+     </item>
+    </layout>
+   </item>
+  </layout>
+ </widget>
+ <layoutdefault spacing="6" margin="11"/>
+ <tabstops>
+  <tabstop>buttonBox</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>QgsGroupWMSDataDialogBase</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>451</x>
+     <y>699</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>481</x>
+     <y>297</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>buttonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>QgsGroupWMSDataDialogBase</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>392</x>
+     <y>699</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>281</x>
+     <y>339</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/ui/qgsprojectpropertiesbase.ui
+++ b/src/ui/qgsprojectpropertiesbase.ui
@@ -1449,7 +1449,7 @@
                   <string notr="true">projowsserver</string>
                  </property>
                  <layout class="QGridLayout" name="gridLayout_6">
-                  <item row="0" column="0">
+                  <item row="1" column="0">
                    <widget class="QLabel" name="label_10">
                     <property name="text">
                      <string>Title</string>
@@ -1459,17 +1459,17 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="2" column="1">
+                  <item row="3" column="1">
                    <widget class="QLineEdit" name="mWMSOnlineResourceLineEdit"/>
                   </item>
-                  <item row="2" column="0">
+                  <item row="3" column="0">
                    <widget class="QLabel" name="mWMSOnlineResourceLabel">
                     <property name="text">
                      <string>Online resource</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="3" column="0">
+                  <item row="4" column="0">
                    <widget class="QLabel" name="label_9">
                     <property name="text">
                      <string>Person</string>
@@ -1479,23 +1479,23 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="5" column="1">
+                  <item row="6" column="1">
                    <widget class="QLineEdit" name="mWMSContactMail"/>
                   </item>
-                  <item row="3" column="1">
+                  <item row="4" column="1">
                    <widget class="QLineEdit" name="mWMSContactPerson"/>
                   </item>
-                  <item row="5" column="0">
+                  <item row="6" column="0">
                    <widget class="QLabel" name="label_13">
                     <property name="text">
                      <string>E-Mail</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="1" column="1">
+                  <item row="2" column="1">
                    <widget class="QLineEdit" name="mWMSContactOrganization"/>
                   </item>
-                  <item row="6" column="0">
+                  <item row="7" column="0">
                    <widget class="QLabel" name="label_12">
                     <property name="text">
                      <string>Phone</string>
@@ -1505,10 +1505,14 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="0" column="1">
-                   <widget class="QLineEdit" name="mWMSTitle"/>
+                  <item row="1" column="1">
+                   <widget class="QLineEdit" name="mWMSTitle">
+                    <property name="placeholderText">
+                     <string>The title is a text string for the benefit of humans</string>
+                    </property>
+                   </widget>
                   </item>
-                  <item row="7" column="0">
+                  <item row="8" column="0">
                    <widget class="QLabel" name="label_15">
                     <property name="text">
                      <string>Abstract</string>
@@ -1518,23 +1522,23 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="6" column="1">
+                  <item row="7" column="1">
                    <widget class="QLineEdit" name="mWMSContactPhone"/>
                   </item>
-                  <item row="7" column="1">
+                  <item row="8" column="1">
                    <widget class="QTextEdit" name="mWMSAbstract"/>
                   </item>
-                  <item row="10" column="0">
+                  <item row="11" column="0">
                    <widget class="QLabel" name="mWMSKeywordListLabel">
                     <property name="text">
                      <string>Keyword list</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="10" column="1">
+                  <item row="11" column="1">
                    <widget class="QLineEdit" name="mWMSKeywordList"/>
                   </item>
-                  <item row="1" column="0">
+                  <item row="2" column="0">
                    <widget class="QLabel" name="label_11">
                     <property name="text">
                      <string>Organization</string>
@@ -1544,45 +1548,59 @@
                     </property>
                    </widget>
                   </item>
-                  <item row="9" column="0">
+                  <item row="10" column="0">
                    <widget class="QLabel" name="mWMSAccessConstraintsLabel">
                     <property name="text">
                      <string>Access constraints</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="8" column="0">
+                  <item row="9" column="0">
                    <widget class="QLabel" name="mWMSFeesLabel">
                     <property name="text">
                      <string>Fees</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="8" column="1">
+                  <item row="9" column="1">
                    <widget class="QComboBox" name="mWMSFeesCb">
                     <property name="editable">
                      <bool>true</bool>
                     </property>
                    </widget>
                   </item>
-                  <item row="9" column="1">
+                  <item row="10" column="1">
                    <widget class="QComboBox" name="mWMSAccessConstraintsCb">
                     <property name="editable">
                      <bool>true</bool>
                     </property>
                    </widget>
                   </item>
-                  <item row="4" column="0">
+                  <item row="5" column="0">
                    <widget class="QLabel" name="label_20">
                     <property name="text">
                      <string>Position</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="4" column="1">
+                  <item row="5" column="1">
                    <widget class="QComboBox" name="mWMSContactPositionCb">
                     <property name="editable">
                      <bool>true</bool>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="1">
+                   <widget class="QLineEdit" name="mWMSName">
+                    <property name="placeholderText">
+                     <string>The short name is a text string used for machine-to-machine communication</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="0">
+                   <widget class="QLabel" name="label_6">
+                    <property name="text">
+                     <string>Short name</string>
                     </property>
                    </widget>
                   </item>

--- a/src/ui/qgsrasterlayerpropertiesbase.ui
+++ b/src/ui/qgsrasterlayerpropertiesbase.ui
@@ -1752,7 +1752,11 @@ p, li { white-space: pre-wrap; }
                    </widget>
                   </item>
                   <item row="1" column="1">
-                   <widget class="QLineEdit" name="mLayerTitleLineEdit"/>
+                   <widget class="QLineEdit" name="mLayerTitleLineEdit">
+                    <property name="placeholderText">
+                     <string>The title is a text string for the benefit of humans</string>
+                    </property>
+                   </widget>
                   </item>
                   <item row="3" column="0">
                    <widget class="QLabel" name="mLayerAbstractLabel">
@@ -1824,6 +1828,20 @@ p, li { white-space: pre-wrap; }
                    <widget class="QLabel" name="mLayerKeywordListLabel_3">
                     <property name="text">
                      <string>Data Url</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="0">
+                   <widget class="QLabel" name="mLayerShortNameLabel">
+                    <property name="text">
+                     <string>Short name</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="1">
+                   <widget class="QLineEdit" name="mLayerShortNameLineEdit">
+                    <property name="placeholderText">
+                     <string>The short name is a text string used for machine-to-machine communication</string>
                     </property>
                    </widget>
                   </item>

--- a/src/ui/qgsvectorlayerpropertiesbase.ui
+++ b/src/ui/qgsvectorlayerpropertiesbase.ui
@@ -1438,7 +1438,11 @@
                    </widget>
                   </item>
                   <item row="1" column="1">
-                   <widget class="QLineEdit" name="mLayerTitleLineEdit"/>
+                   <widget class="QLineEdit" name="mLayerTitleLineEdit">
+                    <property name="placeholderText">
+                     <string>The title is a text string for the benefit of humans</string>
+                    </property>
+                   </widget>
                   </item>
                   <item row="3" column="0">
                    <widget class="QLabel" name="mLayerAbstractLabel">
@@ -1512,6 +1516,26 @@
                      </widget>
                     </item>
                    </layout>
+                  </item>
+                  <item row="0" column="0">
+                   <widget class="QLabel" name="mLayerShortNameLabel">
+                    <property name="text">
+                     <string>Short name</string>
+                    </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="1">
+                   <widget class="QLineEdit" name="mLayerShortNameLineEdit">
+                    <property name="inputMask">
+                     <string/>
+                    </property>
+                    <property name="text">
+                     <string/>
+                    </property>
+                    <property name="placeholderText">
+                     <string>The short name is a text string used for machine-to-machine communication</string>
+                    </property>
+                   </widget>
                   </item>
                  </layout>
                 </widget>

--- a/tests/testdata/qgis_server/getprojectsettings.txt
+++ b/tests/testdata/qgis_server/getprojectsettings.txt
@@ -125,6 +125,7 @@ Content-Type: text/xml; charset=utf-8
    </EX_GeographicBoundingBox>
    <BoundingBox CRS="EPSG:3857" maxx="913283" minx="913171" maxy="5.60604e+06" miny="5.60599e+06"/>
    <BoundingBox CRS="EPSG:4326" maxx="44.9016" minx="44.9012" maxy="8.20416" miny="8.20315"/>
+   <TreeName>QGIS Test Project</TreeName>
    <Layer displayField="name" geometryType="WKBPoint" queryable="1" visible="1">
     <Name>testlayer èé</Name>
     <Title>A test vector layer</Title>
@@ -147,6 +148,7 @@ Content-Type: text/xml; charset=utf-8
       <OnlineResource xlink:type="simple" xmlns:xlink="http://www.w3.org/1999/xlink" xlink:href="http:?MAP=/home/ale/dev/QGIS/tests/testdata/qgis_server/test%2Bproject.qgs&amp;&amp;SERVICE=WMS&amp;VERSION=1.3.0&amp;REQUEST=GetLegendGraphic&amp;LAYER=testlayer èé&amp;FORMAT=image/png&amp;STYLE=default&amp;SLD_VERSION=1.1.0"/>
      </LegendURL>
     </Style>
+    <TreeName>testlayer èé</TreeName>
     <Attributes>
      <Attribute typeName="Integer" precision="0" length="10" editType="TextEdit" type="int" comment="" name="id"/>
      <Attribute typeName="String" precision="0" length="10" editType="TextEdit" type="QString" comment="" name="name"/>


### PR DESCRIPTION
A number of elements have both a <Name> and a <Title>. The Name is a text string used for machine-to-machine communication while the Title is for the benefit of humans. For example, a dataset might have the descriptive Title “Maximum Atmospheric Temperature” and be requested using the abbreviated Name “ATMAX”.

User can already set title for layers, groups and project. OWS name is based on the name used in layer tree. This name is more a label for humans than a name for machine-to-machine communication.

To add the capability to users to define Name as a text string for machine-to-machine communication, this pull-request adds:
- short name line edits to layers properties
- WMS data dialog to layer tree group
- short name line edits to project properties
- add a regexp validator "^[A-Za-z][A-Za-z0-9._-]*" to short name line edit

If a short name has been set for layers, groups and project it is used by QGIS Sever as the layer name.
