### PR TITLE
Add an eval expression

### DIFF
--- a/resources/function_help/json/eval
+++ b/resources/function_help/json/eval
@@ -1,0 +1,10 @@
+{
+  "name": "eval",
+  "type": "function",
+  "description": "Evaluates an expression which is passed in a string. Useful to expand dynamic parameters passed as context variables or fields.",
+  "arguments": [ {"arg":"expression","description":"an expression string"}],
+  "examples": [
+    { "expression":"eval('\\'nice\\'')", "returns":"'nice'"},
+    { "expression":"eval(@expression_var)", "returns":"[whatever the result of evaluating @expression_var might be...]"}
+  ]
+}

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -409,6 +409,16 @@ static QVariant fcnGetVariable( const QVariantList& values, const QgsExpressionC
   return context->variable( name );
 }
 
+static QVariant fcnEval( const QVariantList& values, const QgsExpressionContext* context, QgsExpression* parent )
+{
+  if ( !context )
+    return QVariant();
+
+  QString expString = getStringValue( values.at( 0 ), parent );
+  QgsExpression expression( expString );
+  return expression.evaluate( context );
+}
+
 static QVariant fcnSqrt( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   double x = getDoubleValue( values.at( 0 ), parent );
@@ -2518,6 +2528,7 @@ const QList<QgsExpression::Function*>& QgsExpression::Functions()
     << new StaticFunction( "get_feature", 3, fcnGetFeature, "Record", QString(), false, QStringList(), false, QStringList() << "getFeature" )
     << new StaticFunction( "layer_property", 2, fcnGetLayerProperty, "General" )
     << new StaticFunction( "var", 1, fcnGetVariable, "General" )
+    << new StaticFunction( "eval", 1, fcnEval, "General" )
 
     //return all attributes string for referencedColumns - this is caught by
     // QgsFeatureRequest::setSubsetOfAttributes and causes all attributes to be fetched by the

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -1530,6 +1530,36 @@ class TestQgsExpression: public QObject
       Q_NOWARN_DEPRECATED_POP
     }
 
+    void eval_eval()
+    {
+      QgsFeature f( 100 );
+      QgsFields fields;
+      fields.append( QgsField( "col1" ) );
+      fields.append( QgsField( "second_column", QVariant::Int ) );
+      f.setFields( fields, true );
+      f.setAttribute( QString( "col1" ), QString( "test value" ) );
+      f.setAttribute( QString( "second_column" ), 5 );
+
+      QgsExpressionContext context = QgsExpressionContextUtils::createFeatureBasedContext( f, QgsFields() );
+
+      QgsExpression exp1( "eval()" );
+      QVariant v1 = exp1.evaluate( &context );
+
+      Q_ASSERT( !v1.isValid() );
+
+      QgsExpression exp2( "eval('4')" );
+      QVariant v2 = exp2.evaluate( &context );
+      QCOMPARE( v2, QVariant( 4 ) );
+
+      QgsExpression exp3( "eval('\"second_column\" * 2')" );
+      QVariant v3 = exp3.evaluate( &context );
+      QCOMPARE( v3, QVariant( 10 ) );
+
+      QgsExpression exp4( "eval('\"col1\"')" );
+      QVariant v4 = exp4.evaluate( &context );
+      QCOMPARE( v4, QVariant( "test value" ) );
+    }
+
     void expression_from_expression_data()
     {
       QTest::addColumn<QString>( "string" );


### PR DESCRIPTION
Helps to evaluate expressions which originate from the context.

Can be used to expand an expression from a field or a context variable.

Expression: `eval(@height)` will evaluate the context variable `height`. If it contains a static value `4`, this will be used. If it contains a reference to a field `levels` instead, it will use the reference to a field. Or `levels * 2.2` for a height calculated by number of floors times 2.2.

This is helpful to parametrize complex expressions where the same references are used multiple times.
