### PR TITLE
Do not reapply default value to shortcuts that are set to "none" (fixes #7905)

### DIFF
--- a/src/app/qgsshortcutsmanager.cpp
+++ b/src/app/qgsshortcutsmanager.cpp
@@ -47,8 +47,7 @@ bool QgsShortcutsManager::registerAction( QAction* action, const QString& defaul
   QSettings settings;
   QString shortcut = settings.value( "/shortcuts/" + actionText, defaultShortcut ).toString();
 
-  if ( !shortcut.isEmpty() )
-    action->setShortcut( shortcut );
+  action->setShortcut( shortcut );
 
   return true;
 }


### PR DESCRIPTION
Shortcuts, that have been set to _none_ by the user, retain their setting even after QGIS is restarted.

@wonder-sk, do you want to have a quick look at this, as you seem to be the one who originally added the configurable shortcuts feature in 2967d946b9dd240632fe153bce13935244079aa8?
