### PR TITLE
Allow hiding paths from the browser

### DIFF
--- a/src/app/qgsbrowserdockwidget.cpp
+++ b/src/app/qgsbrowserdockwidget.cpp
@@ -608,6 +608,7 @@ void QgsBrowserDockWidget::showContextMenu( const QPoint & pt )
       menu->addAction( tr( "Remove favourite" ), this, SLOT( removeFavourite() ) );
     }
     menu->addAction( tr( "Properties" ), this, SLOT( showProperties() ) );
+    menu->addAction( tr( "Hide from browser" ), this, SLOT( hideItem() ) );
     QAction *action = menu->addAction( tr( "Fast scan this dir." ), this, SLOT( toggleFastScan() ) );
     action->setCheckable( true );
     action->setChecked( settings.value( "/qgis/scanItemsFastScanUris",
@@ -791,6 +792,19 @@ void QgsBrowserDockWidget::addSelectedLayers()
   }
 
   QApplication::restoreOverrideCursor();
+}
+
+void QgsBrowserDockWidget::hideItem()
+{
+  QModelIndex index = mProxyModel->mapToSource( mBrowserView->currentIndex() );
+  QgsDataItem* item = mModel->dataItem( index );
+  if ( ! item )
+    return;
+
+  if ( item->type() == QgsDataItem::Directory )
+  {
+    mModel->hidePath( item );
+  }
 }
 
 void QgsBrowserDockWidget::showProperties()

--- a/src/app/qgsbrowserdockwidget.h
+++ b/src/app/qgsbrowserdockwidget.h
@@ -126,6 +126,7 @@ class APP_EXPORT QgsBrowserDockWidget : public QDockWidget, private Ui::QgsBrows
     void addCurrentLayer();
     void addSelectedLayers();
     void showProperties();
+    void hideItem();
     void toggleFastScan();
 
     void selectionChanged( const QItemSelection & selected, const QItemSelection & deselected );

--- a/src/core/qgsbrowsermodel.h
+++ b/src/core/qgsbrowsermodel.h
@@ -138,6 +138,8 @@ class CORE_EXPORT QgsBrowserModel : public QAbstractItemModel
     void removeFavourite( const QModelIndex &index );
     void updateProjectHome();
 
+    void hidePath( QgsDataItem *item );
+
   protected:
     // populates the model
     void addRootItems();

--- a/src/core/qgsdataitem.cpp
+++ b/src/core/qgsdataitem.cpp
@@ -787,10 +787,14 @@ QVector<QgsDataItem*> QgsDirectoryItem::createChildren()
       deleteLater( children );
       return children;
     }
+
     QString subdirPath = dir.absoluteFilePath( subdir );
+
     QgsDebugMsgLevel( QString( "creating subdir: %1" ).arg( subdirPath ), 2 );
 
     QString path = mPath + '/' + subdir; // may differ from subdirPath
+    if ( QgsDirectoryItem::hiddenPath( path ) )
+      continue;
     QgsDirectoryItem *item = new QgsDirectoryItem( this, subdir, subdirPath, path );
     // propagate signals up to top
 
@@ -878,6 +882,15 @@ void QgsDirectoryItem::directoryChanged()
   {
     refresh();
   }
+}
+
+bool QgsDirectoryItem::hiddenPath( QString path )
+{
+  QSettings settings;
+  QStringList hiddenItems = settings.value( "/browser/hiddenPaths",
+                            QStringList() ).toStringList();
+  int idx = hiddenItems.indexOf( path );
+  return ( idx > -1 );
 }
 
 void QgsDirectoryItem::childrenCreated()

--- a/src/core/qgsdataitem.h
+++ b/src/core/qgsdataitem.h
@@ -409,6 +409,8 @@ class CORE_EXPORT QgsDirectoryItem : public QgsDataCollectionItem
     //! @note deprecated since 2.10 - use QgsDataItemProviderRegistry
     Q_DECL_DEPRECATED static QVector<QLibrary*> mLibraries;
 
+    static bool hiddenPath( QString path );
+
   public slots:
     virtual void childrenCreated() override;
     void directoryChanged();


### PR DESCRIPTION
This PR adds the ability to hide paths from the the browser model.  Mainly implemented so I can hide network drives, etc that I will never have GIS data in. Favorites do the same kind of thing however I think this just keeps the tree cleaner if you don't need those drives.   

TODO: 
- Requires a UI to unhide paths.
- ~~Update SIP bindings~~
