### PR TITLE
Keep scales ordered in Settings > Options > Predefined scales (fixes #8320)

### DIFF
--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -2152,7 +2152,11 @@ void QgsOptions::on_mButtonExportColors_clicked()
 
 QListWidgetItem* QgsOptions::addScaleToScaleList( const QString &newScale )
 {
-  QListWidgetItem* newItem = new QListWidgetItem();
+  QListWidgetItem* newItem;
+  newItem = mListGlobalScales->findItems( newScale, Qt::MatchExactly ).value( 0 );
+  if ( newItem )
+    return newItem;
+
   int newDenominator = newScale.split( ":" ).value( 1 ).toInt();
   int i;
   for ( i = 0; i < mListGlobalScales->count(); i++ )
@@ -2161,7 +2165,7 @@ QListWidgetItem* QgsOptions::addScaleToScaleList( const QString &newScale )
     if ( newDenominator > denominator )
       break;
   }
-  newItem->setText( newScale );
+  newItem = new QListWidgetItem( newScale );
   newItem->setFlags( Qt::ItemIsEditable | Qt::ItemIsEnabled | Qt::ItemIsSelectable );
   mListGlobalScales->insertItem( i, newItem );
   return newItem;

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -2153,8 +2153,16 @@ void QgsOptions::on_mButtonExportColors_clicked()
 QListWidgetItem* QgsOptions::addScaleToScaleList( const QString &newScale )
 {
   QListWidgetItem* newItem = new QListWidgetItem();
+  int newDenominator = newScale.split( ":" ).value( 1 ).toInt();
+  int i;
+  for ( i = 0; i < mListGlobalScales->count(); i++ )
+  {
+    int denominator = mListGlobalScales->item( i )->text().split( ":" ).value( 1 ).toInt();
+    if ( newDenominator > denominator )
+      break;
+  }
   newItem->setText( newScale );
   newItem->setFlags( Qt::ItemIsEditable | Qt::ItemIsEnabled | Qt::ItemIsSelectable );
-  mListGlobalScales->addItem( newItem );
+  mListGlobalScales->insertItem( i, newItem );
   return newItem;
 }

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -687,11 +687,10 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl ) :
   if ( !myPaths.isEmpty() )
   {
     QStringList myScalesList = myPaths.split( ',' );
-    QStringList::const_iterator scaleIt = myScalesList.constBegin();
-    for ( ; scaleIt != myScalesList.constEnd(); ++scaleIt )
+    Q_FOREACH ( const QString& scale, myScalesList )
     {
       QListWidgetItem* newItem = new QListWidgetItem( mListGlobalScales );
-      newItem->setText( *scaleIt );
+      newItem->setText( scale );
       newItem->setFlags( Qt::ItemIsEditable | Qt::ItemIsEnabled | Qt::ItemIsSelectable );
       mListGlobalScales->addItem( newItem );
     }
@@ -1943,11 +1942,10 @@ void QgsOptions::on_pbnDefaultScaleValues_clicked()
   mListGlobalScales->clear();
 
   QStringList myScalesList = PROJECT_SCALES.split( ',' );
-  QStringList::const_iterator scaleIt = myScalesList.constBegin();
-  for ( ; scaleIt != myScalesList.constEnd(); ++scaleIt )
+  Q_FOREACH ( const QString& scale, myScalesList )
   {
     QListWidgetItem* newItem = new QListWidgetItem( mListGlobalScales );
-    newItem->setText( *scaleIt );
+    newItem->setText( scale );
     newItem->setFlags( Qt::ItemIsEditable | Qt::ItemIsEnabled | Qt::ItemIsSelectable );
     mListGlobalScales->addItem( newItem );
   }
@@ -1969,11 +1967,10 @@ void QgsOptions::on_pbnImportScales_clicked()
     QgsDebugMsg( msg );
   }
 
-  QStringList::const_iterator scaleIt = myScales.constBegin();
-  for ( ; scaleIt != myScales.constEnd(); ++scaleIt )
+  Q_FOREACH ( const QString& scale, myScales )
   {
     QListWidgetItem* newItem = new QListWidgetItem( mListGlobalScales );
-    newItem->setText( *scaleIt );
+    newItem->setText( scale );
     newItem->setFlags( Qt::ItemIsEditable | Qt::ItemIsEnabled | Qt::ItemIsSelectable );
     mListGlobalScales->addItem( newItem );
   }

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -689,10 +689,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl ) :
     QStringList myScalesList = myPaths.split( ',' );
     Q_FOREACH ( const QString& scale, myScalesList )
     {
-      QListWidgetItem* newItem = new QListWidgetItem( mListGlobalScales );
-      newItem->setText( scale );
-      newItem->setFlags( Qt::ItemIsEditable | Qt::ItemIsEnabled | Qt::ItemIsSelectable );
-      mListGlobalScales->addItem( newItem );
+      addScaleToScaleList( scale );
     }
   }
 
@@ -1922,10 +1919,7 @@ void QgsOptions::on_pbnAddScale_clicked()
 
   if ( myScale != -1 )
   {
-    QListWidgetItem* newItem = new QListWidgetItem( mListGlobalScales );
-    newItem->setText( QString( "1:%1" ).arg( myScale ) );
-    newItem->setFlags( Qt::ItemIsEditable | Qt::ItemIsEnabled | Qt::ItemIsSelectable );
-    mListGlobalScales->addItem( newItem );
+    QListWidgetItem* newItem = addScaleToScaleList( QString( "1:%1" ).arg( myScale ) );
     mListGlobalScales->setCurrentItem( newItem );
   }
 }
@@ -1944,10 +1938,7 @@ void QgsOptions::on_pbnDefaultScaleValues_clicked()
   QStringList myScalesList = PROJECT_SCALES.split( ',' );
   Q_FOREACH ( const QString& scale, myScalesList )
   {
-    QListWidgetItem* newItem = new QListWidgetItem( mListGlobalScales );
-    newItem->setText( scale );
-    newItem->setFlags( Qt::ItemIsEditable | Qt::ItemIsEnabled | Qt::ItemIsSelectable );
-    mListGlobalScales->addItem( newItem );
+    addScaleToScaleList( scale );
   }
 }
 
@@ -1969,10 +1960,7 @@ void QgsOptions::on_pbnImportScales_clicked()
 
   Q_FOREACH ( const QString& scale, myScales )
   {
-    QListWidgetItem* newItem = new QListWidgetItem( mListGlobalScales );
-    newItem->setText( scale );
-    newItem->setFlags( Qt::ItemIsEditable | Qt::ItemIsEnabled | Qt::ItemIsSelectable );
-    mListGlobalScales->addItem( newItem );
+    addScaleToScaleList( scale );
   }
 }
 
@@ -2160,4 +2148,13 @@ void QgsOptions::on_mButtonExportColors_clicked()
     QMessageBox::critical( 0, tr( "Error exporting" ), tr( "Error writing palette file" ) );
     return;
   }
+}
+
+QListWidgetItem* QgsOptions::addScaleToScaleList( const QString &newScale )
+{
+  QListWidgetItem* newItem = new QListWidgetItem();
+  newItem->setText( newScale );
+  newItem->setFlags( Qt::ItemIsEditable | Qt::ItemIsEnabled | Qt::ItemIsSelectable );
+  mListGlobalScales->addItem( newItem );
+  return newItem;
 }

--- a/src/app/qgsoptions.h
+++ b/src/app/qgsoptions.h
@@ -214,6 +214,8 @@ class APP_EXPORT QgsOptions : public QgsOptionsDialogBase, private Ui::QgsOption
 
     void saveDefaultDatumTransformations();
 
+    QListWidgetItem* addScaleToScaleList( const QString &newScale );
+
   protected:
     QgisAppStyleSheet* mStyleSheetBuilder;
     QMap<QString, QVariant> mStyleSheetNewOpts;

--- a/src/app/qgsoptions.h
+++ b/src/app/qgsoptions.h
@@ -188,6 +188,9 @@ class APP_EXPORT QgsOptions : public QgsOptionsDialogBase, private Ui::QgsOption
     /** Auto slot executed when the active page in the option section widget is changed */
     void on_mOptionsStackedWidget_currentChanged( int theIndx );
 
+    /** A scale in the list of predefined scales changed */
+    void scaleItemChanged( QListWidgetItem* changedScaleItem );
+
     /* Load the list of drivers available in GDAL */
     void loadGdalDriverList();
 
@@ -215,6 +218,7 @@ class APP_EXPORT QgsOptions : public QgsOptionsDialogBase, private Ui::QgsOption
     void saveDefaultDatumTransformations();
 
     QListWidgetItem* addScaleToScaleList( const QString &newScale );
+    void addScaleToScaleList( QListWidgetItem* newItem );
 
   protected:
     QgisAppStyleSheet* mStyleSheetBuilder;

--- a/src/app/qgsprojectproperties.h
+++ b/src/app/qgsprojectproperties.h
@@ -90,6 +90,9 @@ class APP_EXPORT QgsProjectProperties : public QgsOptionsDialogBase, private Ui:
     /** Let the user load scales from file */
     void on_pbnExportScales_clicked();
 
+    /** A scale in the list of project scales changed */
+    void scaleItemChanged( QListWidgetItem* changedScaleItem );
+
     /*!
      * Slots for WMS project settings
      */
@@ -207,6 +210,12 @@ class APP_EXPORT QgsProjectProperties : public QgsOptionsDialogBase, private Ui:
 
     //! Populates list with ellipsoids from Sqlite3 db
     void populateEllipsoidList();
+
+    //! Create a new scale item and add it to the list of scales
+    QListWidgetItem* addScaleToScaleList( const QString &newScale );
+
+    //! Add a scale item to the list of scales
+    void addScaleToScaleList( QListWidgetItem* newItem );
 
     static const char * GEO_NONE_DESC;
 


### PR DESCRIPTION
New scales always appeared at the bottom of the list. Now they appear in the correct position to keep the list ordered.
Additional fixes:
- Duplicate scales are not added to the list.
- Text that is not a valid scale is not accepted when changing a scale.
- Changed scales are repositioned within the list to keep the list ordered.
