### PR TITLE
[FEATURE] add darker() and lighter() expression functions

### DIFF
--- a/resources/function_help/json/darker
+++ b/resources/function_help/json/darker
@@ -1,0 +1,10 @@
+{
+  "name": "darker",
+  "type": "function",
+  "description": "Returns a darker (or lighter) color string",
+  "arguments": [
+               {"arg":"color", "description":"a color string"},
+	{"arg":"factor", "description":"a integer number corresponding to the darkening factor:<ul><li>if the factor is greater than 100, this functions returns a darker color (for e.g., setting factor to 300 returns a color that has one-third the brightness);</li><li>if the factor is less than 100, the return color is lighter, but using the lighter() function for this purpose is recommended;</li><li>if the factor is 0 or negative, the return value is unspecified.</li></ul>"}
+	          ],
+  "examples": [ { "expression":"darker('200,10,30',300)", "returns":"'66,3,10,255'"}]
+}

--- a/resources/function_help/json/lighter
+++ b/resources/function_help/json/lighter
@@ -1,0 +1,10 @@
+{
+  "name": "lighter",
+  "type": "function",
+  "description": "Returns a lighter (or darker) color string",
+  "arguments": [
+               {"arg":"color", "description":"a color string"},
+	{"arg":"factor", "description":"a integer number corresponding to the lightening factor:<ul><li>if the factor is greater than 100, this functions returns a lighter color (for e.g., setting factor to 150 returns a color that is 50% brighter);</li><li>if the factor is less than 100, the return color is darker, but using the darker() function for this purpose is recommended;</li><li>if the factor is 0 or negative, the return value is unspecified.</li></ul>"}
+	          ],
+  "examples": [ { "expression":"lighter('200,10,30',200)", "returns":"'255,158,168,255'"}]
+}

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -2135,6 +2135,34 @@ static QVariant fncSetColorPart( const QVariantList &values, const QgsExpression
   return QgsSymbolLayerV2Utils::encodeColor( color );
 }
 
+static QVariant fncDarker( const QVariantList &values, const QgsExpressionContext*, QgsExpression *parent )
+{
+  QColor color = QgsSymbolLayerV2Utils::decodeColor( values.at( 0 ).toString() );
+  if ( ! color.isValid() )
+  {
+    parent->setEvalErrorString( QObject::tr( "Cannot convert '%1' to color" ).arg( values.at( 0 ).toString() ) );
+    return QVariant();
+  }
+
+  color = color.darker( getIntValue( values.at( 1 ), parent ) );
+
+  return QgsSymbolLayerV2Utils::encodeColor( color );
+}
+
+static QVariant fncLighter( const QVariantList &values, const QgsExpressionContext*, QgsExpression *parent )
+{
+  QColor color = QgsSymbolLayerV2Utils::decodeColor( values.at( 0 ).toString() );
+  if ( ! color.isValid() )
+  {
+    parent->setEvalErrorString( QObject::tr( "Cannot convert '%1' to color" ).arg( values.at( 0 ).toString() ) );
+    return QVariant();
+  }
+
+  color = color.lighter( getIntValue( values.at( 1 ), parent ) );
+
+  return QgsSymbolLayerV2Utils::encodeColor( color );
+}
+
 static QVariant fcnSpecialColumn( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   QString varName = getStringValue( values.at( 0 ), parent );
@@ -2466,6 +2494,8 @@ const QList<QgsExpression::Function*>& QgsExpression::Functions()
     << new StaticFunction( "color_cmyk", 4, fcnColorCmyk, "Color" )
     << new StaticFunction( "color_cmyka", 5, fncColorCmyka, "Color" )
     << new StaticFunction( "color_part", 2, fncColorPart, "Color" )
+    << new StaticFunction( "darker", 2, fncDarker, "Color" )
+    << new StaticFunction( "lighter", 2, fncLighter, "Color" )
     << new StaticFunction( "set_color_part", 3, fncSetColorPart, "Color" )
     << new StaticFunction( "$geometry", 0, fcnGeometry, "GeometryGroup", QString(), true )
     << new StaticFunction( "$area", 0, fcnGeomArea, "GeometryGroup", QString(), true )

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -608,7 +608,9 @@ class TestQgsExpression: public QObject
       QTest::newRow( "set color part black" ) << "to_int(color_part(set_color_part(color_cmyk(21,0,92,70),'black',100),'black'))" << false << QVariant( 100 );
 
       QTest::newRow( "color darker" ) << "darker('200,100,30',150)" << false << QVariant( "133,66,20,255" );
+      QTest::newRow( "color darker bad color" ) << "darker('notacolor',150)" << true << QVariant();
       QTest::newRow( "color lighter" ) << "lighter('200,100,30',150)" << false << QVariant( "255,154,83,255" );
+      QTest::newRow( "color lighter bad color" ) << "lighter('notacolor',150)" << true << QVariant();
 
       // Precedence and associativity
       QTest::newRow( "multiplication first" ) << "1+2*3" << false << QVariant( 7 );

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -607,6 +607,9 @@ class TestQgsExpression: public QObject
       QTest::newRow( "set color part yellow" ) << "to_int(color_part(set_color_part(color_cmyk(21,0,92,70),'yellow',96),'yellow'))" << false << QVariant( 96 );
       QTest::newRow( "set color part black" ) << "to_int(color_part(set_color_part(color_cmyk(21,0,92,70),'black',100),'black'))" << false << QVariant( 100 );
 
+      QTest::newRow( "color darker" ) << "darker('200,100,30',150)" << false << QVariant( "133,66,20,255" );
+      QTest::newRow( "color lighter" ) << "lighter('200,100,30',150)" << false << QVariant( "255,154,83,255" );
+
       // Precedence and associativity
       QTest::newRow( "multiplication first" ) << "1+2*3" << false << QVariant( 7 );
       QTest::newRow( "brackets first" ) << "(1+2)*(3+4)" << false << QVariant( 21 );


### PR DESCRIPTION
This PR adds a darker() and a lighter() color functions to the expression engine. Coupled with variables (especially the @symbol_color stuff @nyalldawson is cooking) or the color_project() function, this can produce artful data-defined colors for labels (text color, buffer, shield, etc.).
