### PR TITLE
Implicit sharing for QgsExpression

### DIFF
--- a/python/core/qgsexpression.sip
+++ b/python/core/qgsexpression.sip
@@ -125,10 +125,15 @@ class QgsExpression
 
     double scale();
 
-    //! Alias for dump()
-    const QString expression() const;
+    //! Return the original, unmodified expression string.
+    //! If there was none supplied because it was constructed by sole
+    //! API calls, dump() will be used to create one instead.
+    QString expression() const;
 
-    //! Return the expression string that represents this QgsExpression.
+    //! Return an expression string, constructed from the internal
+    //! abstract syntax tree. This does not contain any nice whitespace
+    //! formatting or comments. In general it is preferrable to use
+    //! expression() instead.
     QString dump() const;
 
     //! Return calculator used for distance and area calculations
@@ -435,6 +440,15 @@ class QgsExpression
 
         virtual QString dump() const = 0;
 
+        /**
+         * Generate a clone of this node.
+         * Make sure that the clone does not contain any information which is
+         * generated in prepare and context related.
+         * Ownership is transferred to the caller.
+         *
+         * @return a deep copy of this node.
+         */
+        virtual QgsExpression::Node* clone() const = 0;
         virtual QStringList referencedColumns() const = 0;
         virtual bool needsGeometry() const = 0;
 
@@ -451,6 +465,8 @@ class QgsExpression
         void append( QgsExpression::Node* node /Transfer/ );
         int count();
         const QList<QgsExpression::Node*>& list();
+        /** Creates a deep copy of this list. Ownership is transferred to the caller */
+        QgsExpression::NodeList* clone() const;
 
         virtual QString dump() const;
 
@@ -494,6 +510,7 @@ class QgsExpression
         virtual QStringList referencedColumns() const;
         virtual bool needsGeometry() const;
         virtual void accept( QgsExpression::Visitor& v ) const;
+        virtual QgsExpression::Node* clone() const;
     };
 
     class NodeBinaryOperator : QgsExpression::Node
@@ -514,6 +531,7 @@ class QgsExpression
         virtual QStringList referencedColumns() const;
         virtual bool needsGeometry() const;
         virtual void accept( QgsExpression::Visitor& v ) const;
+        virtual QgsExpression::Node* clone() const;
 
         int precedence() const;
         bool leftAssociative() const;
@@ -537,6 +555,7 @@ class QgsExpression
         virtual QStringList referencedColumns() const;
         virtual bool needsGeometry() const;
         virtual void accept( QgsExpression::Visitor& v ) const;
+        virtual QgsExpression::Node* clone() const;
     };
 
     class NodeFunction : QgsExpression::Node
@@ -557,6 +576,7 @@ class QgsExpression
         virtual QStringList referencedColumns() const;
         virtual bool needsGeometry() const;
         virtual void accept( QgsExpression::Visitor& v ) const;
+        virtual QgsExpression::Node* clone() const;
     };
 
     class NodeLiteral : QgsExpression::Node
@@ -570,6 +590,7 @@ class QgsExpression
         virtual bool prepare( QgsExpression* parent, const QgsExpressionContext* context );
 	    virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context );
         virtual QString dump() const;
+        virtual QgsExpression::Node* clone() const;
 
         virtual QStringList referencedColumns() const;
         virtual bool needsGeometry() const;
@@ -592,6 +613,7 @@ class QgsExpression
         virtual bool needsGeometry() const;
 
         virtual void accept( QgsExpression::Visitor& v ) const;
+        virtual QgsExpression::Node* clone() const;
     };
 
     class WhenThen
@@ -619,6 +641,7 @@ class QgsExpression
         virtual QStringList referencedColumns() const;
         virtual bool needsGeometry() const;
         virtual void accept( QgsExpression::Visitor& v ) const;
+        virtual QgsExpression::Node* clone() const;
     };
 
     //////
@@ -661,8 +684,4 @@ class QgsExpression
 
   protected:
     void initGeomCalculator();
-
-  private:
-    QgsExpression( const QgsExpression& );
-    QgsExpression & operator=( const QgsExpression& );
 };

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -42,6 +42,7 @@
 #include "qgsgeometrycollectionv2.h"
 #include "qgspointv2.h"
 #include "qgspolygonv2.h"
+#include "qgsexpressionprivate.h"
 
 #if QT_VERSION < 0x050000
 #include <qtextdocument.h>
@@ -2660,6 +2661,18 @@ bool QgsExpression::isValid( const QString &text, const QgsExpressionContext *co
   return !exp.hasParserError();
 }
 
+void QgsExpression::setScale( double scale ) { d->mScale = scale; }
+
+double QgsExpression::scale() { return d->mScale; }
+
+const QString QgsExpression::expression() const
+{
+  if ( !d->mExp.isNull() )
+    return d->mExp;
+  else
+    return dump();
+}
+
 QList<QgsExpression::Function*> QgsExpression::specialColumns()
 {
   QList<Function*> defs;
@@ -2741,29 +2754,48 @@ int QgsExpression::functionCount()
 
 
 QgsExpression::QgsExpression( const QString& expr )
-    : mRowNumber( 0 )
-    , mScale( 0 )
-    , mExp( expr )
-    , mCalc( 0 )
+    : d( new QgsExpressionPrivate )
 {
-  mRootNode = ::parseExpression( expr, mParserErrorString );
+  d->mRootNode = ::parseExpression( expr, d->mParserErrorString );
+  d->mExp = expr;
+  Q_ASSERT( !d->mParserErrorString.isNull() || d->mRootNode );
+}
 
-  if ( mParserErrorString.isNull() )
-    Q_ASSERT( mRootNode );
+QgsExpression::QgsExpression( const QgsExpression& other )
+    : d( other.d )
+{
+  d->ref.ref();
+}
+
+QgsExpression& QgsExpression::operator=( const QgsExpression & other )
+{
+  d = other.d;
+  d->ref.ref();
+  return *this;
+}
+
+QgsExpression::QgsExpression()
+    : d( new QgsExpressionPrivate )
+{
 }
 
 QgsExpression::~QgsExpression()
 {
-  delete mCalc;
-  delete mRootNode;
+  Q_ASSERT( d );
+  if ( !d->ref.deref() )
+    delete d;
 }
+
+bool QgsExpression::hasParserError() const { return !d->mParserErrorString.isNull(); }
+
+QString QgsExpression::parserErrorString() const { return d->mParserErrorString; }
 
 QStringList QgsExpression::referencedColumns() const
 {
-  if ( !mRootNode )
+  if ( !d->mRootNode )
     return QStringList();
 
-  QStringList columns = mRootNode->referencedColumns();
+  QStringList columns = d->mRootNode->referencedColumns();
 
   // filter out duplicates
   for ( int i = 0; i < columns.count(); i++ )
@@ -2784,64 +2816,77 @@ QStringList QgsExpression::referencedColumns() const
 
 bool QgsExpression::needsGeometry() const
 {
-  if ( !mRootNode )
+  if ( !d->mRootNode )
     return false;
-  return mRootNode->needsGeometry();
+  return d->mRootNode->needsGeometry();
 }
 
 void QgsExpression::initGeomCalculator()
 {
-  if ( mCalc )
+  if ( d->mCalc.data() )
     return;
 
   // Use planimetric as default
-  mCalc = new QgsDistanceArea();
-  mCalc->setEllipsoidalMode( false );
+  d->mCalc = QSharedPointer<QgsDistanceArea>( new QgsDistanceArea() );
+  d->mCalc->setEllipsoidalMode( false );
+}
+
+void QgsExpression::detach()
+{
+  Q_ASSERT( d );
+
+  if ( d->ref > 1 )
+  {
+    d->ref.deref();
+
+    d = new QgsExpressionPrivate( *d );
+  }
 }
 
 void QgsExpression::setGeomCalculator( const QgsDistanceArea &calc )
 {
-  delete mCalc;
-  mCalc = new QgsDistanceArea( calc );
+  d->mCalc = QSharedPointer<QgsDistanceArea>( new QgsDistanceArea( calc ) );
 }
 
 bool QgsExpression::prepare( const QgsFields& fields )
 {
+  detach();
   QgsExpressionContext fc = QgsExpressionContextUtils::createFeatureBasedContext( 0, fields );
   return prepare( &fc );
 }
 
 bool QgsExpression::prepare( const QgsExpressionContext *context )
 {
-  mEvalErrorString = QString();
-  if ( !mRootNode )
+  detach();
+  d->mEvalErrorString = QString();
+  if ( !d->mRootNode )
   {
     //re-parse expression. Creation of QgsExpressionContexts may have added extra
     //known functions since this expression was created, so we have another try
     //at re-parsing it now that the context must have been created
-    mRootNode = ::parseExpression( mExp, mParserErrorString );
+    d->mRootNode = ::parseExpression( d->mExp, d->mParserErrorString );
   }
 
-  if ( !mRootNode )
+  if ( !d->mRootNode )
   {
-    mEvalErrorString = tr( "No root node! Parsing failed?" );
+    d->mEvalErrorString = tr( "No root node! Parsing failed?" );
     return false;
   }
 
-  return mRootNode->prepare( this, context );
+  return d->mRootNode->prepare( this, context );
 }
 
 QVariant QgsExpression::evaluate( const QgsFeature* f )
 {
-  mEvalErrorString = QString();
-  if ( !mRootNode )
+  d->mEvalErrorString = QString();
+  if ( !d->mRootNode )
   {
-    mEvalErrorString = tr( "No root node! Parsing failed?" );
+    d->mEvalErrorString = tr( "No root node! Parsing failed?" );
     return QVariant();
   }
 
   QgsExpressionContext context = QgsExpressionContextUtils::createFeatureBasedContext( f ? *f : QgsFeature(), QgsFields() );
-  return mRootNode->eval( this, &context );
+  return d->mRootNode->eval( this, &context );
 }
 
 QVariant QgsExpression::evaluate( const QgsFeature &f )
@@ -2872,40 +2917,68 @@ inline QVariant QgsExpression::evaluate( const QgsFeature& f, const QgsFields& f
 
 QVariant QgsExpression::evaluate()
 {
-  mEvalErrorString = QString();
-  if ( !mRootNode )
+  d->mEvalErrorString = QString();
+  if ( !d->mRootNode )
   {
-    mEvalErrorString = tr( "No root node! Parsing failed?" );
+    d->mEvalErrorString = tr( "No root node! Parsing failed?" );
     return QVariant();
   }
 
-  return mRootNode->eval( this, ( QgsExpressionContext* )0 );
+  return d->mRootNode->eval( this, ( QgsExpressionContext* )0 );
 }
 
 QVariant QgsExpression::evaluate( const QgsExpressionContext *context )
 {
-  mEvalErrorString = QString();
-  if ( !mRootNode )
+  d->mEvalErrorString = QString();
+  if ( !d->mRootNode )
   {
-    mEvalErrorString = tr( "No root node! Parsing failed?" );
+    d->mEvalErrorString = tr( "No root node! Parsing failed?" );
     return QVariant();
   }
 
-  return mRootNode->eval( this, context );
+  return d->mRootNode->eval( this, context );
 }
+
+bool QgsExpression::hasEvalError() const
+{
+  return !d->mEvalErrorString.isNull();
+}
+
+QString QgsExpression::evalErrorString() const
+{
+  return d->mEvalErrorString;
+}
+
+void QgsExpression::setEvalErrorString( const QString& str )
+{
+  d->mEvalErrorString = str;
+}
+
+void QgsExpression::setCurrentRowNumber( int rowNumber )
+{
+  d->mRowNumber = rowNumber;
+}
+
+int QgsExpression::currentRowNumber() { return d->mRowNumber; }
 
 QString QgsExpression::dump() const
 {
-  if ( !mRootNode )
+  if ( !d->mRootNode )
     return tr( "(no root)" );
 
-  return mRootNode->dump();
+  return d->mRootNode->dump();
+}
+
+QgsDistanceArea* QgsExpression::geomCalculator()
+{
+  initGeomCalculator();
+  return d->mCalc.data();
 }
 
 void QgsExpression::acceptVisitor( QgsExpression::Visitor& v ) const
 {
-  if ( mRootNode )
-    mRootNode->accept( v );
+  if ( d->mRootNode )
+    d->mRootNode->accept( v );
 }
 
 QString QgsExpression::replaceExpressionText( const QString &action, const QgsFeature *feat,
@@ -3021,6 +3094,17 @@ double QgsExpression::evaluateToDouble( const QString &text, const double fallba
 ///////////////////////////////////////////////
 // nodes
 
+QgsExpression::NodeList* QgsExpression::NodeList::clone() const
+{
+  NodeList* nl = new NodeList;
+  Q_FOREACH ( Node* node, mList )
+  {
+    nl->mList.append( node->clone() );
+  }
+
+  return nl;
+}
+
 QString QgsExpression::NodeList::dump() const
 {
   QString msg; bool first = true;
@@ -3071,6 +3155,11 @@ bool QgsExpression::NodeUnaryOperator::prepare( QgsExpression *parent, const Qgs
 QString QgsExpression::NodeUnaryOperator::dump() const
 {
   return QString( "%1 %2" ).arg( UnaryOperatorText[mOp], mOperand->dump() );
+}
+
+QgsExpression::Node*QgsExpression::NodeUnaryOperator::clone() const
+{
+  return new NodeUnaryOperator( mOp, mOperand->clone() );
 }
 
 //
@@ -3428,6 +3517,11 @@ QString QgsExpression::NodeBinaryOperator::dump() const
   return fmt.arg( mOpLeft->dump(), BinaryOperatorText[mOp], mOpRight->dump() );
 }
 
+QgsExpression::Node* QgsExpression::NodeBinaryOperator::clone() const
+{
+  return new NodeBinaryOperator( mOp, mOpLeft->clone(), mOpRight->clone() );
+}
+
 //
 
 QVariant QgsExpression::NodeInOperator::eval( QgsExpression *parent, const QgsExpressionContext *context )
@@ -3489,6 +3583,11 @@ bool QgsExpression::NodeInOperator::prepare( QgsExpression *parent, const QgsExp
 QString QgsExpression::NodeInOperator::dump() const
 {
   return QString( "%1 %2 IN (%3)" ).arg( mNode->dump(), mNotIn ? "NOT" : "", mList->dump() );
+}
+
+QgsExpression::Node*QgsExpression::NodeInOperator::clone() const
+{
+  return new NodeInOperator( mNode->clone(), mList->clone(), mNotIn );
 }
 
 //
@@ -3571,6 +3670,11 @@ QStringList QgsExpression::NodeFunction::referencedColumns() const
   return functionColumns.toSet().toList();
 }
 
+QgsExpression::Node* QgsExpression::NodeFunction::clone() const
+{
+  return new NodeFunction( mFnIndex, mArgs ? mArgs->clone() : nullptr );
+}
+
 //
 
 QVariant QgsExpression::NodeLiteral::eval( QgsExpression *parent, const QgsExpressionContext *context )
@@ -3603,6 +3707,11 @@ QString QgsExpression::NodeLiteral::dump() const
   }
 }
 
+QgsExpression::Node*QgsExpression::NodeLiteral::clone() const
+{
+  return new NodeLiteral( mValue );
+}
+
 //
 
 QVariant QgsExpression::NodeColumnRef::eval( QgsExpression *parent, const QgsExpressionContext *context )
@@ -3633,7 +3742,7 @@ bool QgsExpression::NodeColumnRef::prepare( QgsExpression *parent, const QgsExpr
   }
   else
   {
-    parent->mEvalErrorString = tr( "Column '%1' not found" ).arg( mName );
+    parent->d->mEvalErrorString = tr( "Column '%1' not found" ).arg( mName );
     mIndex = -1;
     return false;
   }
@@ -3642,6 +3751,11 @@ bool QgsExpression::NodeColumnRef::prepare( QgsExpression *parent, const QgsExpr
 QString QgsExpression::NodeColumnRef::dump() const
 {
   return QRegExp( "^[A-Za-z_\x80-\xff][A-Za-z0-9_\x80-\xff]*$" ).exactMatch( mName ) ? mName : quotedColumnRef( mName );
+}
+
+QgsExpression::Node*QgsExpression::NodeColumnRef::clone() const
+{
+  return new NodeColumnRef( mName );
 }
 
 //
@@ -3728,6 +3842,14 @@ bool QgsExpression::NodeCondition::needsGeometry() const
     return true;
 
   return false;
+}
+
+QgsExpression::Node* QgsExpression::NodeCondition::clone() const
+{
+  WhenThenList conditions;
+  Q_FOREACH ( WhenThen* wt, mConditions )
+    conditions.append( new WhenThen( wt->mWhenExp->clone(), wt->mThenExp->clone() ) );
+  return new NodeCondition( &conditions, mElseExp->clone() );
 }
 
 
@@ -3953,7 +4075,6 @@ QString QgsExpression::group( const QString& name )
   return gGroups.value( name, name );
 }
 
-
 QVariant QgsExpression::Function::func( const QVariantList& values, const QgsFeature* feature, QgsExpression* parent )
 {
   //default implementation creates a QgsFeatureBasedExpressionContext
@@ -4016,3 +4137,5 @@ QVariant QgsExpression::StaticFunction::func( const QVariantList &values, const 
   return mFnc ? mFnc( values, f, parent ) : QVariant();
   Q_NOWARN_DEPRECATED_POP
 }
+
+const QgsExpression::Node* QgsExpression::rootNode() const { return d->mRootNode; }

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -2665,7 +2665,7 @@ void QgsExpression::setScale( double scale ) { d->mScale = scale; }
 
 double QgsExpression::scale() { return d->mScale; }
 
-const QString QgsExpression::expression() const
+QString QgsExpression::expression() const
 {
   if ( !d->mExp.isNull() )
     return d->mExp;

--- a/src/core/qgsexpressionprivate.h
+++ b/src/core/qgsexpressionprivate.h
@@ -23,6 +23,12 @@
 #include "qgsexpression.h"
 #include "qgsdistancearea.h"
 
+///@cond
+/**
+ * This class exists only for implicit sharing of QgsExpression
+ * and is not part of the public API.
+ * It should be considered an implementation detail.
+ */
 class QgsExpressionPrivate
 {
   public:
@@ -62,5 +68,6 @@ class QgsExpressionPrivate
 
     QSharedPointer<QgsDistanceArea> mCalc;
 };
+///@endcond
 
 #endif // QGSEXPRESSIONPRIVATE_H

--- a/src/core/qgsexpressionprivate.h
+++ b/src/core/qgsexpressionprivate.h
@@ -1,0 +1,66 @@
+/***************************************************************************
+ qgsexpressionprivate.h
+
+ ---------------------
+ begin                : 9.12.2015
+ copyright            : (C) 2015 by Matthias Kuhn
+ email                : matthias@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSEXPRESSIONPRIVATE_H
+#define QGSEXPRESSIONPRIVATE_H
+
+#include <QString>
+#include <QSharedPointer>
+
+#include "qgsexpression.h"
+#include "qgsdistancearea.h"
+
+class QgsExpressionPrivate
+{
+  public:
+    QgsExpressionPrivate()
+        : ref( 1 )
+        , mRootNode( nullptr )
+        , mRowNumber( 0 )
+        , mScale( 0 )
+        , mCalc( nullptr )
+    {}
+
+    QgsExpressionPrivate( const QgsExpressionPrivate& other )
+        : ref( 1 )
+        , mRootNode( other.mRootNode ? other.mRootNode->clone() : nullptr )
+        , mParserErrorString( other.mParserErrorString )
+        , mRowNumber( 0 )
+        , mScale( other.mScale )
+        , mExp( other.mExp )
+        , mCalc( other.mCalc )
+    {}
+
+    ~QgsExpressionPrivate()
+    {
+      delete mRootNode;
+    }
+
+    QAtomicInt ref;
+
+    QgsExpression::Node* mRootNode;
+
+    QString mParserErrorString;
+    QString mEvalErrorString;
+
+    int mRowNumber;
+    double mScale;
+    QString mExp;
+
+    QSharedPointer<QgsDistanceArea> mCalc;
+};
+
+#endif // QGSEXPRESSIONPRIVATE_H

--- a/src/core/qgsfeaturerequest.cpp
+++ b/src/core/qgsfeaturerequest.cpp
@@ -53,7 +53,7 @@ QgsFeatureRequest::QgsFeatureRequest( const QgsRectangle& rect )
 QgsFeatureRequest::QgsFeatureRequest( const QgsExpression& expr, const QgsExpressionContext &context )
     : mFilter( FilterExpression )
     , mFilterFid( -1 )
-    , mFilterExpression( new QgsExpression( expr.expression() ) )
+    , mFilterExpression( new QgsExpression( expr ) )
     , mExpressionContext( context )
     , mFlags( 0 )
     , mLimit( -1 )
@@ -74,7 +74,7 @@ QgsFeatureRequest& QgsFeatureRequest::operator=( const QgsFeatureRequest & rh )
   mFilterFids = rh.mFilterFids;
   if ( rh.mFilterExpression )
   {
-    mFilterExpression = new QgsExpression( rh.mFilterExpression->expression() );
+    mFilterExpression = new QgsExpression( *rh.mFilterExpression );
   }
   else
   {

--- a/src/core/qgsogcutils.cpp
+++ b/src/core/qgsogcutils.cpp
@@ -1,6 +1,7 @@
 #include "qgsogcutils.h"
 
 #include "qgsexpression.h"
+#include "qgsexpressionprivate.h"
 #include "qgsgeometry.h"
 #include "qgswkbptr.h"
 
@@ -1457,25 +1458,25 @@ QgsExpression* QgsOgcUtils::expressionFromOgcFilter( const QDomElement& element 
     if ( !node )
     {
       // invalid expression, parser error
-      expr->mParserErrorString = errorMsg;
+      expr->d->mParserErrorString = errorMsg;
       return expr;
     }
 
     // use the concat binary operator to append to the root node
-    if ( !expr->mRootNode )
+    if ( !expr->d->mRootNode )
     {
-      expr->mRootNode = node;
+      expr->d->mRootNode = node;
     }
     else
     {
-      expr->mRootNode = new QgsExpression::NodeBinaryOperator( QgsExpression::boConcat, expr->mRootNode, node );
+      expr->d->mRootNode = new QgsExpression::NodeBinaryOperator( QgsExpression::boConcat, expr->d->mRootNode, node );
     }
 
     childElem = childElem.nextSiblingElement();
   }
 
   // update expression string
-  expr->mExp = expr->dump();
+  expr->d->mExp = expr->dump();
 
   return expr;
 }

--- a/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.cpp
@@ -470,7 +470,7 @@ void QgsDelimitedTextFeatureIterator::fetchAttribute( QgsFeature& feature, int f
 
 QgsDelimitedTextFeatureSource::QgsDelimitedTextFeatureSource( const QgsDelimitedTextProvider* p )
     : mGeomRep( p->mGeomRep )
-    , mSubsetExpression( p->mSubsetExpression ? new QgsExpression( p->mSubsetExpression->expression() ) : 0 )
+    , mSubsetExpression( p->mSubsetExpression ? new QgsExpression( *p->mSubsetExpression ) : 0 )
     , mExtent( p->mExtent )
     , mUseSpatialIndex( p->mUseSpatialIndex )
     , mSpatialIndex( p->mSpatialIndex ? new QgsSpatialIndex( *p->mSpatialIndex ) : 0 )

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -1644,6 +1644,82 @@ class TestQgsExpression: public QObject
       QCOMPARE( QgsExpression( "sqrt(foo)" ).isField(), false );
       QCOMPARE( QgsExpression( "foo + bar" ).isField(), false );
     }
+
+    void test_implicitSharing()
+    {
+      QgsExpression* exp = new QgsExpression( "Pilots > 2" );
+
+      QgsExpression expcopy( *exp );
+
+      QVERIFY( expcopy.rootNode() );
+      QCOMPARE( expcopy.expression(), QString( "Pilots > 2" ) );
+
+      // Delete original instance, should preserve copy.
+      delete exp;
+
+      // This mainly should not crash, root node should have outlived the original one
+      QVERIFY( !expcopy.rootNode()->dump().isEmpty() );
+
+
+      // Let's take another copy
+      QgsExpression expcopy2( expcopy );
+
+      QgsExpressionContext ctx = QgsExpressionContextUtils::createFeatureBasedContext( 0, mPointsLayer->fields() );
+
+      // Prepare with the current set of fields
+      expcopy.prepare( &ctx );
+
+      QgsFeatureIterator it = mPointsLayer->getFeatures();
+      QgsFeature feat;
+
+      // Let's count some features
+      int count = 0;
+      while ( it.nextFeature( feat ) )
+      {
+        QgsExpressionContext ctx = QgsExpressionContextUtils::createFeatureBasedContext( feat, mPointsLayer->fields() );
+        if ( expcopy.evaluate( &ctx ).toBool() )
+          count++;
+      }
+
+      QCOMPARE( count, 6 );
+
+      // Let's remove the field referenced in the expression
+      mPointsLayer->startEditing();
+      mPointsLayer->deleteAttribute( mPointsLayer->fieldNameIndex( "Pilots" ) );
+
+      // Now the prepared expression is broken
+      // The cached field index points to the index which now is
+      // used by "Cabin Crew". Not a particularly good test
+      // since it actually relies on undefined behavior (changing
+      // fields after prepare() )
+
+      it = mPointsLayer->getFeatures();
+      count = 0;
+      while ( it.nextFeature( feat ) )
+      {
+        QgsExpressionContext ctx = QgsExpressionContextUtils::createFeatureBasedContext( feat, mPointsLayer->fields() );
+        if ( expcopy.evaluate( &ctx ).toBool() )
+          count++;
+      }
+
+      QCOMPARE( count, 3 );
+
+      // But the copy should not have cached field indexes
+      it = mPointsLayer->getFeatures();
+      count = 0;
+      while ( it.nextFeature( feat ) )
+      {
+        QgsExpressionContext ctx = QgsExpressionContextUtils::createFeatureBasedContext( feat, mPointsLayer->fields() );
+        if ( expcopy2.evaluate( &ctx ).toBool() )
+          count++;
+      }
+
+      QCOMPARE( count, 0 );
+
+      // Detach a more complex expression
+      QgsExpression nodeExpression( "1 IN (1, 2, 3, 4)" );
+      QgsExpression nodeExpression2( nodeExpression );
+    }
 };
 
 QTEST_MAIN( TestQgsExpression )

--- a/tests/src/python/test_qgsrelationeditwidget.py
+++ b/tests/src/python/test_qgsrelationeditwidget.py
@@ -62,7 +62,7 @@ from utilities import (unitTestDataPath,
 QGISAPP, CANVAS, IFACE, PARENT = getQgisTestApp()
 
 
-class TestQgsTextEditWidget(TestCase):
+class TestQgsRelationEditWidget(TestCase):
 
     @classmethod
     def setUpClass(cls):


### PR DESCRIPTION
Title says it all.

So far one had to do

```
QgsExpression exp( "a>1" );
QgsExpression exp2( exp.expression() );
```

resulting in parsing the expression twice

Now one can do

```
QgsExpression exp( "a>1" );
QgsExpression exp2( exp );
```

The expression will only be parsed once.

Note that results of `prepare()` are not copied. The main effect of this is, that the column index cache is not copied.

The basic idea behind this is, that expressions should only always exist as a prepared copy when using them on one particular iterator, since that's the guaranteed lifetime of a `QgsFields` instance. And if an expression is `prepare()`'d it is detached.

```
// Will detach
exp.prepare( contextWithFields );
```

In short this means for the usage: keep a master copy of your expressions.
And whenever you use them with a new iterator, make a copy of them and prepare(). That's it.
