### PR TITLE
Fix calculation of spatialite SelectAtId capability

### DIFF
--- a/src/providers/spatialite/qgsspatialiteprovider.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovider.cpp
@@ -588,8 +588,23 @@ QgsAbstractFeatureSource* QgsSpatiaLiteProvider::featureSource() const
   return new QgsSpatiaLiteFeatureSource( this );
 }
 
+void QgsSpatiaLiteProvider::updatePrimaryKeyCapabilities()
+{
+  if ( mPrimaryKey.isEmpty() )
+  {
+    enabledCapabilities &= ~QgsVectorDataProvider::SelectAtId;
+    enabledCapabilities &= ~QgsVectorDataProvider::SelectGeometryAtId;
+  }
+  else
+  {
+    enabledCapabilities |= QgsVectorDataProvider::SelectAtId;
+    enabledCapabilities |= QgsVectorDataProvider::SelectGeometryAtId;
+  }
+}
+
 #ifdef SPATIALITE_VERSION_GE_4_0_0
 // only if libspatialite version is >= 4.0.0
+
 void QgsSpatiaLiteProvider::loadFieldsAbstractInterface( gaiaVectorLayerPtr lyr )
 {
   if ( lyr == NULL )
@@ -657,6 +672,9 @@ void QgsSpatiaLiteProvider::loadFieldsAbstractInterface( gaiaVectorLayerPtr lyr 
       mPrimaryKeyAttrs << i - 1;
     }
   }
+
+  updatePrimaryKeyCapabilities();
+
   sqlite3_free_table( results );
 }
 #endif
@@ -848,6 +866,8 @@ void QgsSpatiaLiteProvider::loadFields()
     // setting the Primary Key column name
     mPrimaryKey = pkName;
   }
+
+  updatePrimaryKeyCapabilities();
 
   return;
 

--- a/src/providers/spatialite/qgsspatialiteprovider.h
+++ b/src/providers/spatialite/qgsspatialiteprovider.h
@@ -426,6 +426,8 @@ class QgsSpatiaLiteProvider: public QgsVectorDataProvider
     static int computeMultiWKB3Dsize( const unsigned char *p_in, int little_endian,
                                       int endian_arch );
   private:
+    void updatePrimaryKeyCapabilities();
+
     int computeSizeFromMultiWKB2D( const unsigned char *p_in, int nDims,
                                    int little_endian,
                                    int endian_arch );
@@ -496,6 +498,7 @@ class QgsSpatiaLiteProvider: public QgsVectorDataProvider
     QgsSqliteHandle *handle;
 
     friend class QgsSpatiaLiteFeatureSource;
+
 };
 
 #endif


### PR DESCRIPTION
Looks to me like the Spatialite provider isn't correctly reporting the SelectAtId capability. It's currently being set BEFORE the primary key is calculated, so even if the primary key can be deduced it's not being used for feature id/ids requests.
