### PR TITLE
[expression] add point_on_surface function

### DIFF
--- a/resources/function_help/json/point_on_surface
+++ b/resources/function_help/json/point_on_surface
@@ -1,0 +1,7 @@
+{
+  "name": "point_on_surface",
+  "type": "function",
+  "description": "Returns a point on the surface of a geometry.",
+  "arguments": [ {"arg":"geom","description":"a geometry"}],
+  "examples": [ { "expression":"point_on_surface($geometry)", "returns":"a point geometry"}]
+}

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -1736,6 +1736,14 @@ static QVariant fcnCentroid( const QVariantList& values, const QgsExpressionCont
   delete geom;
   return result;
 }
+static QVariant fcnPointOnSurface( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
+{
+  QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
+  QgsGeometry* geom = fGeom.pointOnSurface();
+  QVariant result = geom ? QVariant::fromValue( *geom ) : QVariant();
+  delete geom;
+  return result;
+}
 static QVariant fcnConvexHull( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   QgsGeometry fGeom = getGeometry( values.at( 0 ), parent );
@@ -2548,6 +2556,7 @@ const QList<QgsExpression::Function*>& QgsExpression::Functions()
     << new StaticFunction( "translate", 3, fcnTranslate, "GeometryGroup" )
     << new StaticFunction( "buffer", -1, fcnBuffer, "GeometryGroup" )
     << new StaticFunction( "centroid", 1, fcnCentroid, "GeometryGroup" )
+    << new StaticFunction( "point_on_surface", 1, fcnPointOnSurface, "GeometryGroup" )
     << new StaticFunction( "reverse", 1, fcnReverse, "GeometryGroup" )
     << new StaticFunction( "bounds", 1, fcnBounds, "GeometryGroup" )
     << new StaticFunction( "num_points", 1, fcnGeomNumPoints, "GeometryGroup" )

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -1464,6 +1464,10 @@ class TestQgsExpression: public QObject
       geom = QgsGeometry::fromPolygon( polygon );
       QTest::newRow( "centroid multi polygon" ) << "centroid( geomFromWKT('MULTIPOLYGON(((0 0,0 1,1 1,1 0,0 0)),((2 0,2 1,3 1,3 0,2 0)))') )" << ( void* ) geom << false << false << ( void* ) QgsGeometry::fromWkt( "POINT (1.5 0.5)" );
       geom = QgsGeometry::fromPolygon( polygon );
+      QTest::newRow( "point on surface polygon" ) << "point_on_surface ( $geometry )" << ( void* ) geom << false << true << ( void* ) geom->pointOnSurface();
+      geom = QgsGeometry::fromPolygon( polygon );
+      QTest::newRow( "point on surface multi polygon" ) << "point_on_surface( geomFromWKT('MULTIPOLYGON(((0 0,0 1,1 1,1 0,0 0)),((2 0,2 1,3 1,3 0,2 0)))') )" << ( void* ) geom << false << false << ( void* ) QgsGeometry::fromWkt( "POINT (0.5 0.5)" );
+      geom = QgsGeometry::fromPolygon( polygon );
       QTest::newRow( "convexHull simple" ) << "convexHull( $geometry )" << ( void* ) geom << false << true << ( void* ) geom->convexHull();
       geom = QgsGeometry::fromPolygon( polygon );
       QTest::newRow( "convexHull multi" ) << "convexHull( geomFromWKT('GEOMETRYCOLLECTION(POINT(0 1), POINT(0 0), POINT(1 0), POINT(1 1))') )" << ( void* ) geom << false << false << ( void* ) QgsGeometry::fromWkt( "POLYGON ((0 0,0 1,1 1,1 0,0 0))" );


### PR DESCRIPTION
@m-kuhn @nyalldawson as discussed, here's a point_on_surface geometry function for the expression engine. 

Here's a screenshot of centroid vs point_on_surface (made possible thanks to the geometry generator feature):
![pos](https://cloud.githubusercontent.com/assets/1728657/11734497/8dda1b60-9fea-11e5-9a8d-80fa5151ea7e.png)
