### PR TITLE
[Processing] Three small fixes

### DIFF
--- a/python/plugins/processing/core/outputs.py
+++ b/python/plugins/processing/core/outputs.py
@@ -161,7 +161,7 @@ class OutputRaster(Output):
 
     def getDefaultFileExtension(self, alg):
         supported = alg.provider.getSupportedOutputRasterLayerExtensions()
-        default = ProcessingConfig.getSetting(ProcessingConfig.DEFAULT_OUTPUT_VECTOR_LAYER_EXT)
+        default = ProcessingConfig.getSetting(ProcessingConfig.DEFAULT_OUTPUT_RASTER_LAYER_EXT)
         ext = default if default in supported else supported[0]
         return ext
 

--- a/python/plugins/processing/gui/ExtentSelectionPanel.py
+++ b/python/plugins/processing/gui/ExtentSelectionPanel.py
@@ -148,7 +148,8 @@ class ExtentSelectionPanel(BASE, WIDGET):
     def useLayerExtent(self):
         CANVAS_KEY = 'Use canvas extent'
         extentsDict = {}
-        extentsDict[CANVAS_KEY] = iface.mapCanvas().extent()
+        extentsDict[CANVAS_KEY] = {"extent": iface.mapCanvas().extent(),
+                                   "authid": iface.mapCanvas().mapRenderer().destinationCrs().authid()}
         extents = [CANVAS_KEY]
         layers = dataobjects.getAllLayers()
         for layer in layers:

--- a/python/plugins/processing/modeler/ModelerParametersDialog.py
+++ b/python/plugins/processing/modeler/ModelerParametersDialog.py
@@ -277,6 +277,10 @@ class ModelerParametersDialog(QDialog):
             bools = self.getAvailableValuesOfType(ParameterBoolean, None)
             for b in bools:
                 item.addItem(self.resolveValueDescription(b), b)
+            if param.default:
+                item.setCurrentIndex(0)
+            else:
+                item.setCurrentIndex(1)
         elif isinstance(param, ParameterSelection):
             item = QComboBox()
             item.addItems(param.options)


### PR DESCRIPTION
1. Fixes the issue introduced in c58981fd5ede0c66dc0b4d9eb8f757126166374e when setting subset from canvas extent.
2. Use the default value of ParameterBoolean to set the initial Yes/No value in the drop down list in modeler parameter's dialog.
3. Allow providers to set the supported output raster and vector file extensions and use the default values if the provider doesn't have it's own selection. This was the behavior in previous versions of Processing but got changed somewhere along the way.
