### PR TITLE
Improve QgsCoordinateReferenceSystem::readXML()

### DIFF
--- a/python/core/qgscoordinatereferencesystem.sip
+++ b/python/core/qgscoordinatereferencesystem.sip
@@ -185,7 +185,7 @@ class QgsCoordinateReferenceSystem
      * @param theNode The node from which state will be restored
      * @return bool True on success, False on failure
      */
-    bool readXML( QDomNode & theNode );
+    bool readXML( const QDomNode & theNode );
     /** Stores state to the given Dom node in the given document.
      * Below is an example of the generated tag.
      \code{.xml}

--- a/src/core/composer/qgscomposermapgrid.cpp
+++ b/src/core/composer/qgscomposermapgrid.cpp
@@ -400,16 +400,9 @@ bool QgsComposerMapGrid::readXML( const QDomElement& itemElem, const QDomDocumen
     }
   }
 
-
-  QDomElement crsElem = itemElem.firstChildElement( "spatialrefsys" );
-  if ( !crsElem.isNull() )
-  {
-    mCRS.readXML( itemElem );
-  }
-  else
-  {
+  if ( !mCRS.readXML( itemElem ) )
     mCRS = QgsCoordinateReferenceSystem();
-  }
+
   mBlendMode = ( QPainter::CompositionMode )( itemElem.attribute( "blendMode", "0" ).toUInt() );
 
   //annotation

--- a/src/core/composer/qgscomposermapgrid.cpp
+++ b/src/core/composer/qgscomposermapgrid.cpp
@@ -404,7 +404,7 @@ bool QgsComposerMapGrid::readXML( const QDomElement& itemElem, const QDomDocumen
   QDomElement crsElem = itemElem.firstChildElement( "spatialrefsys" );
   if ( !crsElem.isNull() )
   {
-    mCRS.readXML( const_cast<QDomElement&>( itemElem ) ); //better would be to change argument in QgsCoordinateReferenceSystem::readXML to const
+    mCRS.readXML( itemElem );
   }
   else
   {

--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -1145,7 +1145,7 @@ QString QgsCoordinateReferenceSystem::toWkt() const
   return mWkt;
 }
 
-bool QgsCoordinateReferenceSystem::readXML( QDomNode & theNode )
+bool QgsCoordinateReferenceSystem::readXML( const QDomNode & theNode )
 {
   QgsDebugMsg( "Reading Spatial Ref Sys from xml ------------------------!" );
   QDomNode srsNode  = theNode.namedItem( "spatialrefsys" );

--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -1148,6 +1148,7 @@ QString QgsCoordinateReferenceSystem::toWkt() const
 bool QgsCoordinateReferenceSystem::readXML( const QDomNode & theNode )
 {
   QgsDebugMsg( "Reading Spatial Ref Sys from xml ------------------------!" );
+  bool result = true;
   QDomNode srsNode  = theNode.namedItem( "spatialrefsys" );
 
   if ( ! srsNode.isNull() )
@@ -1260,8 +1261,9 @@ bool QgsCoordinateReferenceSystem::readXML( const QDomNode & theNode )
   {
     // Return default CRS if none was found in the XML.
     createFromId( GEOCRS_ID, InternalCrsId );
+    result = false;
   }
-  return true;
+  return result;
 }
 
 bool QgsCoordinateReferenceSystem::writeXML( QDomNode & theNode, QDomDocument & theDoc ) const

--- a/src/core/qgscoordinatereferencesystem.h
+++ b/src/core/qgscoordinatereferencesystem.h
@@ -230,7 +230,7 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      * @param theNode The node from which state will be restored
      * @return bool True on success, False on failure
      */
-    bool readXML( QDomNode & theNode );
+    bool readXML( const QDomNode & theNode );
     /** Stores state to the given Dom node in the given document.
      * Below is an example of the generated tag.
      \code{.xml}


### PR DESCRIPTION
The parameter passed to `QgsCoordinateReferenceSystem::readXML()` was not _const_ although the method did not change it and - more important - is not expected to. This imposed the need to use `const_cast<>` when calling it with a _const_ variable.

The return value was always true, even on failure, although the documentation says: return _False on failure_. Catching an error was only possible using a workaround.
