### PR TITLE
[projection selector] apply selected projection on double click

### DIFF
--- a/python/gui/qgsprojectionselector.sip
+++ b/python/gui/qgsprojectionselector.sip
@@ -105,4 +105,7 @@ class QgsProjectionSelector : QWidget
     //! Notify others that the widget is now fully initialized, including deferred selection of projection
     //! @note added in 2.4
     void initialized();
+    //! Apply projection on double click
+    //! @note added in 2.14
+    void projectionDoubleClicked();
 };

--- a/src/gui/qgsgenericprojectionselector.cpp
+++ b/src/gui/qgsgenericprojectionselector.cpp
@@ -36,6 +36,9 @@ QgsGenericProjectionSelector::QgsGenericProjectionSelector( QWidget *parent,
 
   //we will show this only when a message is set
   textEdit->hide();
+
+  //apply selected projection upon double click on item
+  connect( projectionSelector, SIGNAL(projectionDoubleClicked() ), this, SLOT(accept()));
 }
 
 void QgsGenericProjectionSelector::setMessage( QString theMessage )

--- a/src/gui/qgsprojectionselector.cpp
+++ b/src/gui/qgsprojectionselector.cpp
@@ -18,6 +18,7 @@
 #include "qgsapplication.h"
 #include "qgslogger.h"
 #include "qgscoordinatereferencesystem.h"
+#include "qgsmessagelog.h"
 
 //qt includes
 #include <QFileInfo>
@@ -718,6 +719,22 @@ void QgsProjectionSelector::on_lstCoordinateSystems_currentItemChanged( QTreeWid
   }
 }
 
+void QgsProjectionSelector::on_lstCoordinateSystems_itemDoubleClicked( QTreeWidgetItem *current, int column )
+{
+  QgsDebugMsg( "Entered." );
+
+  if ( !current )
+  {
+    QgsDebugMsg( "no current item" );
+    return;
+  }
+
+  // If the item has children, it's not an end node in the tree, and
+  // hence is just a grouping thingy, not an actual CRS.
+  if ( current->childCount() == 0 )
+    emit projectionDoubleClicked();
+}
+
 void QgsProjectionSelector::on_lstRecent_currentItemChanged( QTreeWidgetItem *current, QTreeWidgetItem * )
 {
   QgsDebugMsg( "Entered." );
@@ -733,6 +750,21 @@ void QgsProjectionSelector::on_lstRecent_currentItemChanged( QTreeWidgetItem *cu
   QList<QTreeWidgetItem*> nodes = lstCoordinateSystems->findItems( current->text( QGIS_CRS_ID_COLUMN ), Qt::MatchExactly | Qt::MatchRecursive, QGIS_CRS_ID_COLUMN );
   if ( !nodes.isEmpty() )
     lstCoordinateSystems->setCurrentItem( nodes.first() );
+}
+
+void QgsProjectionSelector::on_lstRecent_itemDoubleClicked( QTreeWidgetItem *current, int column )
+{
+  QgsDebugMsg( "Entered." );
+
+  if ( !current )
+  {
+    QgsDebugMsg( "no current item" );
+    return;
+  }
+
+  QList<QTreeWidgetItem*> nodes = lstCoordinateSystems->findItems( current->text( QGIS_CRS_ID_COLUMN ), Qt::MatchExactly | Qt::MatchRecursive, QGIS_CRS_ID_COLUMN );
+  if ( !nodes.isEmpty() )
+    emit projectionDoubleClicked();
 }
 
 void QgsProjectionSelector::hideDeprecated( QTreeWidgetItem *item )

--- a/src/gui/qgsprojectionselector.cpp
+++ b/src/gui/qgsprojectionselector.cpp
@@ -721,6 +721,8 @@ void QgsProjectionSelector::on_lstCoordinateSystems_currentItemChanged( QTreeWid
 
 void QgsProjectionSelector::on_lstCoordinateSystems_itemDoubleClicked( QTreeWidgetItem *current, int column )
 {
+  Q_UNUSED( column );
+
   QgsDebugMsg( "Entered." );
 
   if ( !current )
@@ -754,6 +756,8 @@ void QgsProjectionSelector::on_lstRecent_currentItemChanged( QTreeWidgetItem *cu
 
 void QgsProjectionSelector::on_lstRecent_itemDoubleClicked( QTreeWidgetItem *current, int column )
 {
+  Q_UNUSED( column );
+
   QgsDebugMsg( "Entered." );
 
   if ( !current )

--- a/src/gui/qgsprojectionselector.h
+++ b/src/gui/qgsprojectionselector.h
@@ -100,7 +100,9 @@ class GUI_EXPORT QgsProjectionSelector : public QWidget, private Ui::QgsProjecti
      */
     void setOgcWmsCrsFilter( const QSet<QString>& crsFilter );
     void on_lstCoordinateSystems_currentItemChanged( QTreeWidgetItem *current, QTreeWidgetItem *prev );
+    void on_lstCoordinateSystems_itemDoubleClicked( QTreeWidgetItem *current, int column );
     void on_lstRecent_currentItemChanged( QTreeWidgetItem *current, QTreeWidgetItem *prev );
+    void on_lstRecent_itemDoubleClicked( QTreeWidgetItem *current, int column );
     void on_cbxHideDeprecated_stateChanged();
     void on_leSearch_textChanged( const QString & );
 
@@ -208,6 +210,9 @@ class GUI_EXPORT QgsProjectionSelector : public QWidget, private Ui::QgsProjecti
     //! Notify others that the widget is now fully initialized, including deferred selection of projection
     //! @note added in 2.4
     void initialized();
+    //! Apply projection on double click
+    //! @note added in 2.14
+    void projectionDoubleClicked();
 };
 
 #endif


### PR DESCRIPTION
This PR fixes a UX issue that has bothered me for years, hope it'll please others :smile: 

When the user double clicks on a projection item (in the recent projection list or CRS list), the projection selector dialog will apply it. No more need to move the mouse to the "OK" button and click on it.
