### PR TITLE
UI improvement for digitizing maptools

### DIFF
--- a/python/gui/qgsmaptoolcapture.sip
+++ b/python/gui/qgsmaptoolcapture.sip
@@ -25,6 +25,9 @@ class QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
     //! destructor
     virtual ~QgsMapToolCapture();
 
+    //! active the tool
+    virtual void activate();
+
     //! deactive the tool
     virtual void deactivate();
 

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -75,8 +75,19 @@ QgsMapToolCapture::~QgsMapToolCapture()
   }
 }
 
+void QgsMapToolCapture::activate()
+{
+  if ( mTempRubberBand )
+    mTempRubberBand->show();
+
+  QgsMapToolAdvancedDigitizing::activate();
+}
+
 void QgsMapToolCapture::deactivate()
 {
+  if ( mTempRubberBand )
+    mTempRubberBand->hide();
+
   delete mSnappingMarker;
   mSnappingMarker = nullptr;
 

--- a/src/gui/qgsmaptoolcapture.h
+++ b/src/gui/qgsmaptoolcapture.h
@@ -42,6 +42,9 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
     //! destructor
     virtual ~QgsMapToolCapture();
 
+    //! active the tool
+    virtual void activate() override;
+
     //! deactive the tool
     virtual void deactivate() override;
 


### PR DESCRIPTION
When the mouse cursor leaves the map canvas during digitizing, the temporary rubberband (from the last digitized point to the current mouse position) is now hidden. It is shown again when the cursor reenters the map canvas.
