### PR TITLE
Uninstall custom excepthook for server

### DIFF
--- a/python/utils.py
+++ b/python/utils.py
@@ -525,7 +525,7 @@ serverIface = None
 def initServerInterface(pointer):
     from qgis.server import QgsServerInterface
     from sip import wrapinstance
-
+    sys.excepthook = sys.__excepthook__
     global serverIface
     serverIface = wrapinstance(pointer, QgsServerInterface)
 


### PR DESCRIPTION
Avoid server error when using python plugins that throw exceptions, iface doesn't exist in that case (and messagebar neither)
