### PR TITLE
add CopyAction to the list of supported drop actions in the Layer Tree

### DIFF
--- a/src/core/layertree/qgslayertreemodel.cpp
+++ b/src/core/layertree/qgslayertreemodel.cpp
@@ -915,7 +915,7 @@ void QgsLayerTreeModel::recursivelyEmitDataChanged( const QModelIndex& idx )
 
 Qt::DropActions QgsLayerTreeModel::supportedDropActions() const
 {
-  return Qt::MoveAction;
+  return Qt::CopyAction | Qt::MoveAction;
 }
 
 QStringList QgsLayerTreeModel::mimeTypes() const

--- a/src/gui/layertree/qgscustomlayerorderwidget.cpp
+++ b/src/gui/layertree/qgscustomlayerorderwidget.cpp
@@ -39,8 +39,8 @@ QgsCustomLayerOrderWidget::QgsCustomLayerOrderWidget( QgsLayerTreeMapCanvasBridg
   mView->setDragEnabled( true );
   mView->setAcceptDrops( true );
   mView->setDropIndicatorShown( true );
-  mView->setDragDropMode( QAbstractItemView::InternalMove );
   mView->setSelectionMode( QAbstractItemView::ExtendedSelection );
+  mView->setDefaultDropAction( Qt::MoveAction );
 
   mView->setModel( mModel );
 
@@ -89,6 +89,7 @@ void QgsCustomLayerOrderWidget::modelUpdated()
 {
   mBridge->setCustomLayerOrder( mModel->order() );
 }
+
 
 
 ///@cond PRIVATE
@@ -155,7 +156,7 @@ Qt::ItemFlags CustomLayerOrderModel::flags( const QModelIndex& index ) const
 
 Qt::DropActions CustomLayerOrderModel::supportedDropActions() const
 {
-  return Qt::MoveAction;
+  return Qt::CopyAction | Qt::MoveAction;
 }
 
 QStringList CustomLayerOrderModel::mimeTypes() const

--- a/src/gui/layertree/qgslayertreeview.cpp
+++ b/src/gui/layertree/qgslayertreeview.cpp
@@ -38,6 +38,7 @@ QgsLayerTreeView::QgsLayerTreeView( QWidget *parent )
   setExpandsOnDoubleClick( false ); // normally used for other actions
 
   setSelectionMode( ExtendedSelection );
+  setDefaultDropAction( Qt::MoveAction );
 
   connect( this, SIGNAL( collapsed( QModelIndex ) ), this, SLOT( updateExpandedStateToNode( QModelIndex ) ) );
   connect( this, SIGNAL( expanded( QModelIndex ) ), this, SLOT( updateExpandedStateToNode( QModelIndex ) ) );


### PR DESCRIPTION
Currently it is only possible to move layers from Layer Tree to another place using drag'n'drop. In some cases it is necessary to have ability to copy layer. This PR extends supported drag'n'drop actions with CopyAction to allow such behavior.
