### PR TITLE
Improve digitizing tools for circular strings

### DIFF
--- a/src/app/qgsmaptooladdcircularstring.cpp
+++ b/src/app/qgsmaptooladdcircularstring.cpp
@@ -83,7 +83,6 @@ void QgsMapToolAddCircularString::keyPressEvent( QKeyEvent* e )
   if ( e && e->key() == Qt::Key_R )
   {
     mShowCenterPointRubberBand = true;
-
     createCenterPointRubberBand();
   }
 }
@@ -176,10 +175,7 @@ void QgsMapToolAddCircularString::createCenterPointRubberBand()
     const QgsAbstractGeometryV2* rubberBandGeom = mTempRubberBand->geometry();
     if ( rubberBandGeom )
     {
-      QgsVertexId idx;
-      idx.part = 0;
-      idx.ring = 0;
-      idx.vertex = 2;
+      QgsVertexId idx( 0, 0, 2 );
       QgsPointV2 pt = rubberBandGeom->vertexAt( idx );
       updateCenterPointRubberBand( pt );
     }
@@ -206,17 +202,17 @@ void QgsMapToolAddCircularString::updateCenterPointRubberBand( const QgsPointV2&
   csPoints.append( pt );
   cs->setPoints( csPoints );
 
-  double centerX, centerY;
+  QgsPointV2 center;
   double radius;
-  QgsGeometryUtils::circleCenterRadius( csPoints.at( 0 ), csPoints.at( 1 ), csPoints.at( 2 ), radius, centerX, centerY );
+  QgsGeometryUtils::circleCenterRadius( csPoints.at( 0 ), csPoints.at( 1 ), csPoints.at( 2 ), radius, center.rx(), center.ry() );
 
   QgsLineStringV2* segment1 = new QgsLineStringV2();
-  segment1->addVertex( QgsPointV2( centerX, centerY ) );
+  segment1->addVertex( center );
   segment1->addVertex( csPoints.at( 0 ) );
 
   QgsLineStringV2* segment2 = new QgsLineStringV2();
   segment2->addVertex( csPoints.at( 2 ) );
-  segment2->addVertex( QgsPointV2( centerX, centerY ) );
+  segment2->addVertex( center );
 
   QgsCompoundCurveV2* cc = new QgsCompoundCurveV2();
   cc->addCurve( segment1 );

--- a/src/app/qgsmaptooladdcircularstring.cpp
+++ b/src/app/qgsmaptooladdcircularstring.cpp
@@ -144,6 +144,16 @@ void QgsMapToolAddCircularString::activate()
           QgsPointV2 endPointLayerCoord = curve->endPoint();
           QgsPoint mapPoint = toMapCoordinates( mCanvas->currentLayer(), QgsPoint( endPointLayerCoord.x(), endPointLayerCoord.y() ) );
           mPoints.append( QgsPointV2( mapPoint ) );
+          if ( !mTempRubberBand )
+          {
+            mTempRubberBand = createGeometryRubberBand(( mode() == CapturePolygon ) ? QGis::Polygon : QGis::Line, true );
+            mTempRubberBand->show();
+          }
+          QgsCircularStringV2* c = new QgsCircularStringV2();
+          QList< QgsPointV2 > rubberBandPoints = mPoints;
+          rubberBandPoints.append( QgsPointV2( mapPoint ) );
+          c->setPoints( rubberBandPoints );
+          mTempRubberBand->setGeometry( c );
         }
       }
     }

--- a/src/app/qgsmaptooladdcircularstring.cpp
+++ b/src/app/qgsmaptooladdcircularstring.cpp
@@ -85,6 +85,18 @@ void QgsMapToolAddCircularString::keyPressEvent( QKeyEvent* e )
     mShowCenterPointRubberBand = true;
     createCenterPointRubberBand();
   }
+
+  if ( e && e->key() == Qt::Key_Escape )
+  {
+    mPoints.clear();
+    delete mRubberBand;
+    mRubberBand = nullptr;
+    delete mTempRubberBand;
+    mTempRubberBand = nullptr;
+    removeCenterPointRubberBand();
+    if ( mParentTool )
+      mParentTool->keyPressEvent( e );
+  }
 }
 
 void QgsMapToolAddCircularString::keyReleaseEvent( QKeyEvent* e )

--- a/src/app/qgsmaptooladdcircularstring.cpp
+++ b/src/app/qgsmaptooladdcircularstring.cpp
@@ -126,6 +126,22 @@ void QgsMapToolAddCircularString::activate()
   if ( mParentTool )
   {
     mParentTool->deleteTempRubberBand();
+    if ( mPoints.isEmpty() )
+    {
+      // if the parent tool has a curve, use its last point as the first point in this curve
+      const QgsCompoundCurveV2* compoundCurve = mParentTool->captureCurve();
+      if ( compoundCurve && compoundCurve->nCurves() > 0 )
+      {
+        const QgsCurveV2* curve = compoundCurve->curveAt( compoundCurve->nCurves() - 1 );
+        if ( curve )
+        {
+          //mParentTool->captureCurve() is in layer coordinates, but we need map coordinates
+          QgsPointV2 endPointLayerCoord = curve->endPoint();
+          QgsPoint mapPoint = toMapCoordinates( mCanvas->currentLayer(), QgsPoint( endPointLayerCoord.x(), endPointLayerCoord.y() ) );
+          mPoints.append( QgsPointV2( mapPoint ) );
+        }
+      }
+    }
   }
   QgsMapToolCapture::activate();
 }

--- a/src/app/qgsmaptooladdcircularstring.cpp
+++ b/src/app/qgsmaptooladdcircularstring.cpp
@@ -28,6 +28,7 @@ QgsMapToolAddCircularString::QgsMapToolAddCircularString( QgsMapToolCapture* par
     : QgsMapToolCapture( canvas, QgisApp::instance()->cadDockWidget(), mode )
     , mParentTool( parentTool )
     , mRubberBand( nullptr )
+    , mTempRubberBand( nullptr )
     , mShowCenterPointRubberBand( false )
     , mCenterPointRubberBand( nullptr )
 {
@@ -41,6 +42,7 @@ QgsMapToolAddCircularString::QgsMapToolAddCircularString( QgsMapCanvas* canvas )
     : QgsMapToolCapture( canvas, QgisApp::instance()->cadDockWidget() )
     , mParentTool( nullptr )
     , mRubberBand( nullptr )
+    , mTempRubberBand( nullptr )
     , mShowCenterPointRubberBand( false )
     , mCenterPointRubberBand( nullptr )
 {
@@ -53,6 +55,7 @@ QgsMapToolAddCircularString::QgsMapToolAddCircularString( QgsMapCanvas* canvas )
 QgsMapToolAddCircularString::~QgsMapToolAddCircularString()
 {
   delete mRubberBand;
+  delete mTempRubberBand;
   removeCenterPointRubberBand();
 }
 
@@ -117,6 +120,8 @@ void QgsMapToolAddCircularString::deactivate()
   mPoints.clear();
   delete mRubberBand;
   mRubberBand = nullptr;
+  delete mTempRubberBand;
+  mTempRubberBand = nullptr;
   removeCenterPointRubberBand();
   QgsMapToolCapture::deactivate();
 }
@@ -156,15 +161,15 @@ void QgsMapToolAddCircularString::createCenterPointRubberBand()
   mCenterPointRubberBand = createGeometryRubberBand( QGis::Polygon );
   mCenterPointRubberBand->show();
 
-  if ( mRubberBand )
+  if ( mTempRubberBand )
   {
-    const QgsAbstractGeometryV2* rubberBandGeom = mRubberBand->geometry();
+    const QgsAbstractGeometryV2* rubberBandGeom = mTempRubberBand->geometry();
     if ( rubberBandGeom )
     {
       QgsVertexId idx;
       idx.part = 0;
       idx.ring = 0;
-      idx.vertex = mPoints.size();
+      idx.vertex = 2;
       QgsPointV2 pt = rubberBandGeom->vertexAt( idx );
       updateCenterPointRubberBand( pt );
     }

--- a/src/app/qgsmaptooladdcircularstring.h
+++ b/src/app/qgsmaptooladdcircularstring.h
@@ -40,10 +40,16 @@ class QgsMapToolAddCircularString: public QgsMapToolCapture
   protected:
     explicit QgsMapToolAddCircularString( QgsMapCanvas* canvas ); //forbidden
 
+    /** The parent map tool, e.g. the add feature tool.
+     *  Completed circular strings will be added to this tool by calling its addCurve() method.
+     * */
     QgsMapToolCapture* mParentTool;
     /** Circular string points (in map coordinates)*/
     QList< QgsPointV2 > mPoints;
+    //! The rubberband to show the already completed circular strings
     QgsGeometryRubberBand* mRubberBand;
+    //! The rubberband to show the circular string currently working on
+    QgsGeometryRubberBand* mTempRubberBand;
 
     //center point rubber band
     bool mShowCenterPointRubberBand;

--- a/src/app/qgsmaptoolcircularstringcurvepoint.cpp
+++ b/src/app/qgsmaptoolcircularstringcurvepoint.cpp
@@ -31,6 +31,20 @@ void QgsMapToolCircularStringCurvePoint::cadCanvasReleaseEvent( QgsMapMouseEvent
 
     if ( mPoints.size() >= 1 )
     {
+      if ( !mTempRubberBand )
+      {
+        mTempRubberBand = createGeometryRubberBand(( mode() == CapturePolygon ) ? QGis::Polygon : QGis::Line, true );
+        mTempRubberBand->show();
+      }
+
+      QgsCircularStringV2* c = new QgsCircularStringV2();
+      QList< QgsPointV2 > rubberBandPoints = mPoints.mid( mPoints.size() - 1 - ( mPoints.size() + 1 ) % 2 );
+      rubberBandPoints.append( mapPoint );
+      c->setPoints( rubberBandPoints );
+      mTempRubberBand->setGeometry( c );
+    }
+    if ( mPoints.size() > 1 && ( mPoints.size() ) % 2 == 1 )
+    {
       if ( !mRubberBand )
       {
         mRubberBand = createGeometryRubberBand(( mode() == CapturePolygon ) ? QGis::Polygon : QGis::Line );
@@ -42,9 +56,6 @@ void QgsMapToolCircularStringCurvePoint::cadCanvasReleaseEvent( QgsMapMouseEvent
       rubberBandPoints.append( mapPoint );
       c->setPoints( rubberBandPoints );
       mRubberBand->setGeometry( c );
-    }
-    if (( mPoints.size() ) % 2 == 1 )
-    {
       removeCenterPointRubberBand();
     }
   }
@@ -64,10 +75,10 @@ void QgsMapToolCircularStringCurvePoint::cadCanvasMoveEvent( QgsMapMouseEvent* e
   QgsVertexId idx;
   idx.part = 0;
   idx.ring = 0;
-  idx.vertex = mPoints.size();
-  if ( mRubberBand )
+  idx.vertex = 1 + ( mPoints.size() + 1 ) % 2;
+  if ( mTempRubberBand )
   {
-    mRubberBand->moveVertex( idx, mapPoint );
+    mTempRubberBand->moveVertex( idx, mapPoint );
     updateCenterPointRubberBand( mapPoint );
   }
 }

--- a/src/app/qgsmaptoolcircularstringcurvepoint.cpp
+++ b/src/app/qgsmaptoolcircularstringcurvepoint.cpp
@@ -23,24 +23,6 @@ void QgsMapToolCircularStringCurvePoint::cadCanvasReleaseEvent( QgsMapMouseEvent
 
   if ( e->button() == Qt::LeftButton )
   {
-    if ( mPoints.size() < 1 ) //connection to vertex of previous line segment needed?
-    {
-      const QgsCompoundCurveV2* compoundCurve = mParentTool->captureCurve();
-      if ( compoundCurve )
-      {
-        if ( compoundCurve->nCurves() > 0 )
-        {
-          const QgsCurveV2* curve = compoundCurve->curveAt( compoundCurve->nCurves() - 1 );
-          if ( curve )
-          {
-            //mParentTool->captureCurve() is in layer coordinates, but we need map coordinates
-            QgsPointV2 endPointLayerCoord = curve->endPoint();
-            QgsPoint mapPoint = toMapCoordinates( mCanvas->currentLayer(), QgsPoint( endPointLayerCoord.x(), endPointLayerCoord.y() ) );
-            mPoints.append( QgsPointV2( mapPoint.x(), mapPoint.y() ) );
-          }
-        }
-      }
-    }
     mPoints.append( mapPoint );
     if ( !mCenterPointRubberBand && mShowCenterPointRubberBand )
     {

--- a/src/app/qgsmaptoolcircularstringcurvepoint.cpp
+++ b/src/app/qgsmaptoolcircularstringcurvepoint.cpp
@@ -19,7 +19,7 @@ QgsMapToolCircularStringCurvePoint::~QgsMapToolCircularStringCurvePoint()
 
 void QgsMapToolCircularStringCurvePoint::cadCanvasReleaseEvent( QgsMapMouseEvent* e )
 {
-  QgsPointV2 mapPoint( e->mapPoint().x(), e->mapPoint().y() );
+  QgsPointV2 mapPoint( e->mapPoint() );
 
   if ( e->button() == Qt::LeftButton )
   {
@@ -29,7 +29,7 @@ void QgsMapToolCircularStringCurvePoint::cadCanvasReleaseEvent( QgsMapMouseEvent
       createCenterPointRubberBand();
     }
 
-    if ( mPoints.size() >= 1 )
+    if ( !mPoints.isEmpty() )
     {
       if ( !mTempRubberBand )
       {
@@ -43,7 +43,7 @@ void QgsMapToolCircularStringCurvePoint::cadCanvasReleaseEvent( QgsMapMouseEvent
       c->setPoints( rubberBandPoints );
       mTempRubberBand->setGeometry( c );
     }
-    if ( mPoints.size() > 1 && ( mPoints.size() ) % 2 == 1 )
+    if ( mPoints.size() > 1 && mPoints.size() % 2 )
     {
       if ( !mRubberBand )
       {
@@ -71,11 +71,8 @@ void QgsMapToolCircularStringCurvePoint::cadCanvasReleaseEvent( QgsMapMouseEvent
 
 void QgsMapToolCircularStringCurvePoint::cadCanvasMoveEvent( QgsMapMouseEvent* e )
 {
-  QgsPointV2 mapPoint( e->mapPoint().x(), e->mapPoint().y() );
-  QgsVertexId idx;
-  idx.part = 0;
-  idx.ring = 0;
-  idx.vertex = 1 + ( mPoints.size() + 1 ) % 2;
+  QgsPointV2 mapPoint( e->mapPoint() );
+  QgsVertexId idx( 0, 0, 1 + ( mPoints.size() + 1 ) % 2 );
   if ( mTempRubberBand )
   {
     mTempRubberBand->moveVertex( idx, mapPoint );

--- a/src/app/qgsmaptoolcircularstringradius.cpp
+++ b/src/app/qgsmaptoolcircularstringradius.cpp
@@ -49,24 +49,8 @@ void QgsMapToolCircularStringRadius::cadCanvasReleaseEvent( QgsMapMouseEvent* e 
   {
     if ( mPoints.isEmpty() )
     {
-      //get first point from parent tool if there. Todo: move to upper class
-      const QgsCompoundCurveV2* compoundCurve = mParentTool->captureCurve();
-      if ( compoundCurve && compoundCurve->nCurves() > 0 )
-      {
-        const QgsCurveV2* curve = compoundCurve->curveAt( compoundCurve->nCurves() - 1 );
-        if ( curve )
-        {
-          //mParentTool->captureCurve() is in layer coordinates, but we need map coordinates
-          QgsPointV2 endPointLayerCoord = curve->endPoint();
-          QgsPoint mapPoint = toMapCoordinates( mCanvas->currentLayer(), QgsPoint( endPointLayerCoord.x(), endPointLayerCoord.y() ) );
-          mPoints.append( QgsPointV2( mapPoint.x(), mapPoint.y() ) );
-        }
-      }
-      else
-      {
-        mPoints.append( mapPoint );
-        return;
-      }
+      mPoints.append( mapPoint );
+      return;
     }
 
     if ( mPoints.size() % 2 == 1 )

--- a/src/app/qgsmaptoolcircularstringradius.h
+++ b/src/app/qgsmaptoolcircularstringradius.h
@@ -39,11 +39,12 @@ class QgsMapToolCircularStringRadius: public QgsMapToolAddCircularString
   private:
     QgsPointV2 mTemporaryEndPoint;
     double mRadius;
-    QgsPointV2 mLastMouseMapPos;
     QDoubleSpinBox* mRadiusSpinBox;
 
-    //! recalculate the rubberband and the temporary rubberband
-    void recalculateCircularString();
+    //! recalculate the rubberband
+    void recalculateRubberBand();
+    //! recalculate the temporary rubberband using the given mouse position
+    void recalculateTempRubberBand( const QgsPoint& mousePosition );
     //! (re-)create the spin box to enter the radius
     void createRadiusSpinBox();
     //! delete the spin box to enter the radius, if it exists

--- a/src/app/qgsmaptoolcircularstringradius.h
+++ b/src/app/qgsmaptoolcircularstringradius.h
@@ -37,15 +37,16 @@ class QgsMapToolCircularStringRadius: public QgsMapToolAddCircularString
     void updateRadiusFromSpinBox( double radius );
 
   private:
-    double mTemporaryEndPointX;
-    double mTemporaryEndPointY;
+    QgsPointV2 mTemporaryEndPoint;
     double mRadius;
     QgsPointV2 mLastMouseMapPos;
     QDoubleSpinBox* mRadiusSpinBox;
 
-    //recalculate circular string and rubber band depending on mRadius/mLeft and endpoints
+    //! recalculate the rubberband and the temporary rubberband
     void recalculateCircularString();
+    //! (re-)create the spin box to enter the radius
     void createRadiusSpinBox();
+    //! delete the spin box to enter the radius, if it exists
     void deleteRadiusSpinBox();
 };
 

--- a/src/app/qgsmaptoolcircularstringradius.h
+++ b/src/app/qgsmaptoolcircularstringradius.h
@@ -31,6 +31,7 @@ class QgsMapToolCircularStringRadius: public QgsMapToolAddCircularString
 
     virtual void cadCanvasReleaseEvent( QgsMapMouseEvent* e ) override;
     virtual void cadCanvasMoveEvent( QgsMapMouseEvent* e ) override;
+    virtual void deactivate() override;
 
   private slots:
     void updateRadiusFromSpinBox( double radius );
@@ -38,7 +39,6 @@ class QgsMapToolCircularStringRadius: public QgsMapToolAddCircularString
   private:
     double mTemporaryEndPointX;
     double mTemporaryEndPointY;
-    bool mRadiusMode;
     double mRadius;
     QgsPointV2 mLastMouseMapPos;
     QDoubleSpinBox* mRadiusSpinBox;

--- a/src/gui/qgsmaptooledit.cpp
+++ b/src/gui/qgsmaptooledit.cpp
@@ -97,7 +97,7 @@ int QgsMapToolEdit::addTopologicalPoints( const QList<QgsPoint>& geom )
   return 0;
 }
 
-QgsGeometryRubberBand* QgsMapToolEdit::createGeometryRubberBand( QGis::GeometryType geometryType ) const
+QgsGeometryRubberBand* QgsMapToolEdit::createGeometryRubberBand( QGis::GeometryType geometryType, bool alternativeBand ) const
 {
   QSettings settings;
   QgsGeometryRubberBand* rb = new QgsGeometryRubberBand( mCanvas, geometryType );
@@ -105,6 +105,11 @@ QgsGeometryRubberBand* QgsMapToolEdit::createGeometryRubberBand( QGis::GeometryT
                 settings.value( "/qgis/digitizing/line_color_green", 0 ).toInt(),
                 settings.value( "/qgis/digitizing/line_color_blue", 0 ).toInt() );
   double myAlpha = settings.value( "/qgis/digitizing/line_color_alpha", 200 ).toInt() / 255.0 ;
+  if ( alternativeBand )
+  {
+    myAlpha = myAlpha * settings.value( "/qgis/digitizing/line_color_alpha_scale", 0.75 ).toDouble();
+    rb->setLineStyle( Qt::DotLine );
+  }
   color.setAlphaF( myAlpha );
   rb->setOutlineColor( color );
   rb->setFillColor( color );

--- a/src/gui/qgsmaptooledit.h
+++ b/src/gui/qgsmaptooledit.h
@@ -49,7 +49,7 @@ class GUI_EXPORT QgsMapToolEdit: public QgsMapTool
     */
     QgsRubberBand* createRubberBand( QGis::GeometryType geometryType = QGis::Line, bool alternativeBand = false );
 
-    QgsGeometryRubberBand* createGeometryRubberBand( QGis::GeometryType geometryType = QGis::Line ) const;
+    QgsGeometryRubberBand* createGeometryRubberBand( QGis::GeometryType geometryType = QGis::Line , bool alternativeBand = false ) const;
 
     /** Returns the current vector layer of the map canvas or 0*/
     QgsVectorLayer* currentVectorLayer();


### PR DESCRIPTION
While working on #2540 I dove into the map capture tools and especially the circular string tools gave me a hard time. So I decided to go into battle and here is the result.

This PR fixes:
- The rubberband is not shown when changing from _add feature_ map tool to _add circular string by point_ map tool.
- The _add circular string by point_ map tool does not use a temporary rubberband (red dotted line).
- The _add circular string by radius_ map tool does not use a temporary rubberband (red dotted line).
- The centerpoint-rubberband (Hotkey R) does not work for the _add circular string by radius_ map tool.
- The circular string map tools do not react to the ESC key.

Furthermore some optimizations and a general cleanup of the code to make it more maintainable and reusable. But this process is not finished yet.
