### PR TITLE
QgsFeatureRendererV2::Capabilities to flags

### DIFF
--- a/python/core/symbology-ng/qgscategorizedsymbolrendererv2.sip
+++ b/python/core/symbology-ng/qgscategorizedsymbolrendererv2.sip
@@ -68,7 +68,7 @@ class QgsCategorizedSymbolRendererV2 : QgsFeatureRendererV2
     virtual void toSld( QDomDocument& doc, QDomElement &element ) const;
 
     //! returns bitwise OR-ed capabilities of the renderer
-    virtual int capabilities();
+    virtual QgsFeatureRendererV2::Capabilities capabilities();
 
     virtual QString filter( const QgsFields& fields = QgsFields() );
 

--- a/python/core/symbology-ng/qgsgraduatedsymbolrendererv2.sip
+++ b/python/core/symbology-ng/qgsgraduatedsymbolrendererv2.sip
@@ -111,7 +111,7 @@ class QgsGraduatedSymbolRendererV2 : QgsFeatureRendererV2
     virtual void toSld( QDomDocument& doc, QDomElement &element ) const;
 
     //! returns bitwise OR-ed capabilities of the renderer
-    virtual int capabilities();
+    virtual QgsFeatureRendererV2::Capabilities capabilities();
 
     //! @note symbol2 in python bindings
     virtual QgsSymbolV2List symbols( QgsRenderContext& context ) /PyName=symbols2/;

--- a/python/core/symbology-ng/qgsinvertedpolygonrenderer.sip
+++ b/python/core/symbology-ng/qgsinvertedpolygonrenderer.sip
@@ -41,7 +41,7 @@ class QgsInvertedPolygonRenderer : QgsFeatureRendererV2
     /** Proxy that will call this method on the embedded renderer. */
     virtual QList<QString> usedAttributes();
     /** Proxy that will call this method on the embedded renderer. */
-    virtual int capabilities();
+    virtual QgsFeatureRendererV2::Capabilities capabilities();
     /** Proxy that will call this method on the embedded renderer.
      * @note available in python bindings as symbol2
      */

--- a/python/core/symbology-ng/qgspointdisplacementrenderer.sip
+++ b/python/core/symbology-ng/qgspointdisplacementrenderer.sip
@@ -26,7 +26,7 @@ class QgsPointDisplacementRenderer : QgsFeatureRendererV2
     /** Partial proxy that will call this method on the embedded renderer. */
     virtual QList<QString> usedAttributes();
     /** Proxy that will call this method on the embedded renderer. */
-    virtual int capabilities();
+    virtual QgsFeatureRendererV2::Capabilities capabilities();
     /** Proxy that will call this method on the embedded renderer.
       @note available in python as symbols2
      */

--- a/python/core/symbology-ng/qgsrendererv2.sip
+++ b/python/core/symbology-ng/qgsrendererv2.sip
@@ -172,7 +172,7 @@ class QgsFeatureRendererV2
     //! for debugging
     virtual QString dump() const;
 
-    enum Capabilities
+    enum Capability
     {
       SymbolLevels,           // rendering with symbol levels (i.e. implements symbols(), symbolForFeature())
       RotationField,          // rotate symbols by attribute value
@@ -181,8 +181,10 @@ class QgsFeatureRendererV2
       ScaleDependent          // depends on scale if feature will be rendered (rule based )
     };
 
+    typedef QFlags<QgsFeatureRendererV2::Capability> Capabilities;
+
     //! returns bitwise OR-ed capabilities of the renderer
-    virtual int capabilities();
+    virtual QgsFeatureRendererV2::Capabilities capabilities();
 
     /** For symbol levels
      * @deprecated use symbols( QgsRenderContext& context ) instead

--- a/python/core/symbology-ng/qgsrulebasedrendererv2.sip
+++ b/python/core/symbology-ng/qgsrulebasedrendererv2.sip
@@ -418,7 +418,7 @@ class QgsRuleBasedRendererV2 : QgsFeatureRendererV2
     virtual QSet<QString> legendKeysForFeature( QgsFeature& feature, QgsRenderContext& context );
 
     //! returns bitwise OR-ed capabilities of the renderer
-    virtual int capabilities();
+    virtual QgsFeatureRendererV2::Capabilities capabilities();
 
     /////
 

--- a/python/core/symbology-ng/qgssinglesymbolrendererv2.sip
+++ b/python/core/symbology-ng/qgssinglesymbolrendererv2.sip
@@ -41,7 +41,7 @@ class QgsSingleSymbolRendererV2 : QgsFeatureRendererV2
     static QgsFeatureRendererV2* createFromSld( QDomElement& element, Qgis::GeometryType geomType );
 
     //! returns bitwise OR-ed capabilities of the renderer
-    virtual int capabilities();
+    virtual QgsFeatureRendererV2::Capabilities capabilities();
 
     //! @note available in python as symbol2
     virtual QgsSymbolV2List symbols( QgsRenderContext& context ) /PyName=symbols2/;

--- a/src/core/symbology-ng/qgscategorizedsymbolrendererv2.h
+++ b/src/core/symbology-ng/qgscategorizedsymbolrendererv2.h
@@ -102,7 +102,7 @@ class CORE_EXPORT QgsCategorizedSymbolRendererV2 : public QgsFeatureRendererV2
     virtual void toSld( QDomDocument& doc, QDomElement &element ) const override;
 
     //! returns bitwise OR-ed capabilities of the renderer
-    virtual int capabilities() override { return SymbolLevels | RotationField | Filter; }
+    virtual Capabilities capabilities() override { return SymbolLevels | RotationField | Filter; }
 
     virtual QString filter( const QgsFields& fields = QgsFields() ) override;
 

--- a/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.h
+++ b/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.h
@@ -155,7 +155,7 @@ class CORE_EXPORT QgsGraduatedSymbolRendererV2 : public QgsFeatureRendererV2
     virtual void toSld( QDomDocument& doc, QDomElement &element ) const override;
 
     //! returns bitwise OR-ed capabilities of the renderer
-    virtual int capabilities() override { return SymbolLevels | RotationField | Filter; }
+    virtual Capabilities capabilities() override { return SymbolLevels | RotationField | Filter; }
 
     //! @note symbol2 in python bindings
     virtual QgsSymbolV2List symbols( QgsRenderContext &context ) override;

--- a/src/core/symbology-ng/qgsinvertedpolygonrenderer.cpp
+++ b/src/core/symbology-ng/qgsinvertedpolygonrenderer.cpp
@@ -455,7 +455,7 @@ QgsSymbolV2List QgsInvertedPolygonRenderer::symbols( QgsRenderContext& context )
   return mSubRenderer->symbols( context );
 }
 
-int QgsInvertedPolygonRenderer::capabilities()
+QgsFeatureRendererV2::Capabilities QgsInvertedPolygonRenderer::capabilities()
 {
   if ( !mSubRenderer )
   {

--- a/src/core/symbology-ng/qgsinvertedpolygonrenderer.h
+++ b/src/core/symbology-ng/qgsinvertedpolygonrenderer.h
@@ -76,7 +76,7 @@ class CORE_EXPORT QgsInvertedPolygonRenderer : public QgsFeatureRendererV2
     /** Proxy that will call this method on the embedded renderer. */
     virtual QList<QString> usedAttributes() override;
     /** Proxy that will call this method on the embedded renderer. */
-    virtual int capabilities() override;
+    virtual Capabilities capabilities() override;
     /** Proxy that will call this method on the embedded renderer.
      * @note available in python bindings as symbol2
      */

--- a/src/core/symbology-ng/qgspointdisplacementrenderer.cpp
+++ b/src/core/symbology-ng/qgspointdisplacementrenderer.cpp
@@ -275,7 +275,7 @@ QList<QString> QgsPointDisplacementRenderer::usedAttributes()
   return attributeList;
 }
 
-int QgsPointDisplacementRenderer::capabilities()
+QgsFeatureRendererV2::Capabilities QgsPointDisplacementRenderer::capabilities()
 {
   if ( !mRenderer )
   {

--- a/src/core/symbology-ng/qgspointdisplacementrenderer.h
+++ b/src/core/symbology-ng/qgspointdisplacementrenderer.h
@@ -54,7 +54,7 @@ class CORE_EXPORT QgsPointDisplacementRenderer: public QgsFeatureRendererV2
     /** Partial proxy that will call this method on the embedded renderer. */
     virtual QList<QString> usedAttributes() override;
     /** Proxy that will call this method on the embedded renderer. */
-    virtual int capabilities() override;
+    virtual Capabilities capabilities() override;
     /** Proxy that will call this method on the embedded renderer.
       @note available in python as symbols2
      */

--- a/src/core/symbology-ng/qgsrulebasedrendererv2.h
+++ b/src/core/symbology-ng/qgsrulebasedrendererv2.h
@@ -489,7 +489,7 @@ class CORE_EXPORT QgsRuleBasedRendererV2 : public QgsFeatureRendererV2
     virtual QSet<QString> legendKeysForFeature( QgsFeature& feature, QgsRenderContext& context ) override;
 
     //! returns bitwise OR-ed capabilities of the renderer
-    virtual int capabilities() override { return MoreSymbolsPerFeature | Filter | ScaleDependent; }
+    virtual Capabilities capabilities() override { return MoreSymbolsPerFeature | Filter | ScaleDependent; }
 
     /////
 

--- a/src/core/symbology-ng/qgssinglesymbolrendererv2.h
+++ b/src/core/symbology-ng/qgssinglesymbolrendererv2.h
@@ -65,7 +65,7 @@ class CORE_EXPORT QgsSingleSymbolRendererV2 : public QgsFeatureRendererV2
     static QgsFeatureRendererV2* createFromSld( QDomElement& element, Qgis::GeometryType geomType );
 
     //! returns bitwise OR-ed capabilities of the renderer
-    virtual int capabilities() override { return SymbolLevels | RotationField; }
+    virtual Capabilities capabilities() override { return SymbolLevels | RotationField; }
 
     //! @note available in python as symbol2
     virtual QgsSymbolV2List symbols( QgsRenderContext& context ) override;


### PR DESCRIPTION
Instead of using magic numbers.

Should this wait for QGIS 3? It's an API break but is not expected to affect python code.
