### PR TITLE
Make the qgisstyle tool fix multiple statements on a single line

### DIFF
--- a/scripts/astyle.sh
+++ b/scripts/astyle.sh
@@ -63,7 +63,6 @@ astyleit()
 		--indent-namespaces \
 		--indent-switches \
 		--one-line=keep-blocks \
-		--one-line=keep-statements \
 		--max-instatement-indent=40 \
 		--min-conditional-indent=-1 \
 		--suffix=none \

--- a/src/analysis/interpolation/DualEdgeTriangulation.cc
+++ b/src/analysis/interpolation/DualEdgeTriangulation.cc
@@ -1527,7 +1527,8 @@ int DualEdgeTriangulation::insertForcedSegment( int p1, int p2, bool breakline )
 
   //set the necessary nexts of leftPolygon(exept the first)
   int actedgel = leftPolygon[1];
-  leftiter = leftPolygon.constBegin(); leftiter += 2;
+  leftiter = leftPolygon.constBegin();
+  leftiter += 2;
   for ( ; leftiter != leftPolygon.constEnd(); ++leftiter )
   {
     mHalfEdge[actedgel]->setNext(( *leftiter ) );
@@ -1536,7 +1537,8 @@ int DualEdgeTriangulation::insertForcedSegment( int p1, int p2, bool breakline )
 
   //set all the necessary nexts of rightPolygon
   int actedger = rightPolygon[1];
-  rightiter = rightPolygon.constBegin(); rightiter += 2;
+  rightiter = rightPolygon.constBegin();
+  rightiter += 2;
   for ( ; rightiter != rightPolygon.constEnd(); ++rightiter )
   {
     mHalfEdge[actedger]->setNext(( *rightiter ) );
@@ -2526,7 +2528,8 @@ void DualEdgeTriangulation::triangulatePolygon( QList<int>* poly, QList<int>* fr
       mHalfEdge[( *( --poly->end() ) )]->setNext( inserta );
 
       QList<int> polya;
-      iterator = poly->constBegin(); iterator += 2;
+      iterator = poly->constBegin();
+      iterator += 2;
       while ( iterator != poly->constEnd() )
       {
         polya.append(( *iterator ) );

--- a/src/analysis/raster/qgsrastermatrix.cpp
+++ b/src/analysis/raster/qgsrastermatrix.cpp
@@ -72,7 +72,9 @@ void QgsRasterMatrix::setData( int cols, int rows, double* data, double nodataVa
 double* QgsRasterMatrix::takeData()
 {
   double* data = mData;
-  mData = nullptr; mColumns = 0; mRows = 0;
+  mData = nullptr;
+  mColumns = 0;
+  mRows = 0;
   return data;
 }
 
@@ -337,7 +339,8 @@ bool QgsRasterMatrix::twoArgumentOperation( TwoArgOperator op, const QgsRasterMa
 
     for ( int i = 0; i < nEntries; ++i )
     {
-      value1 = mData[i]; value2 = matrix[i];
+      value1 = mData[i];
+      value2 = matrix[i];
       if ( value1 == mNodataValue || value2 == other.mNodataValue )
       {
         mData[i] = mNodataValue;
@@ -357,7 +360,9 @@ bool QgsRasterMatrix::twoArgumentOperation( TwoArgOperator op, const QgsRasterMa
     int nEntries = other.nColumns() * other.nRows();
     double value = mData[0];
     delete[] mData;
-    mData = new double[nEntries]; mColumns = other.nColumns(); mRows = other.nRows();
+    mData = new double[nEntries];
+    mColumns = other.nColumns();
+    mRows = other.nRows();
     mNodataValue = other.nodataValue();
 
     if ( value == mNodataValue )

--- a/src/analysis/raster/qgsrelief.cpp
+++ b/src/analysis/raster/qgsrelief.cpp
@@ -330,7 +330,9 @@ bool QgsRelief::processNineCellWindow( float* x1, float* x2, float* x3, float* x
     }
     else
     {
-      r2 = hillShadeValue315; g2 = hillShadeValue315; b2 = hillShadeValue315;
+      r2 = hillShadeValue315;
+      g2 = hillShadeValue315;
+      b2 = hillShadeValue315;
     }
 
     //combine with r,g,b with 70 percentage coverage

--- a/src/analysis/vector/qgsgeometryanalyzer.cpp
+++ b/src/analysis/vector/qgsgeometryanalyzer.cpp
@@ -1303,7 +1303,9 @@ const unsigned char* QgsGeometryAnalyzer::locateBetweenWkbString( const unsigned
         }
       }
     }
-    prevx = *x; prevy = *y; prevz = *z;
+    prevx = *x;
+    prevy = *y;
+    prevz = *z;
   }
   return ptr;
 }
@@ -1339,7 +1341,9 @@ const unsigned char* QgsGeometryAnalyzer::locateAlongWkbString( const unsigned c
         result.append( pt2 );
       }
     }
-    prevx = *x; prevy = *y; prevz = *z;
+    prevx = *x;
+    prevy = *y;
+    prevz = *z;
   }
   return ptr;
 }
@@ -1385,13 +1389,17 @@ bool QgsGeometryAnalyzer::clipSegmentByRange( double x1, double y1, double m1, d
   {
     if ( reversed )
     {
-      pt1.setX( x2 ); pt1.setY( y2 );
-      pt2.setX( x1 ); pt2.setY( y1 );
+      pt1.setX( x2 );
+      pt1.setY( y2 );
+      pt2.setX( x1 );
+      pt2.setY( y1 );
     }
     else
     {
-      pt1.setX( x1 ); pt1.setY( y1 );
-      pt2.setX( x2 ); pt2.setY( y2 );
+      pt1.setX( x1 );
+      pt1.setY( y1 );
+      pt2.setX( x2 );
+      pt2.setY( y2 );
     }
     secondPointClipped = false;
     return true;
@@ -1400,7 +1408,8 @@ bool QgsGeometryAnalyzer::clipSegmentByRange( double x1, double y1, double m1, d
   //m1 inside and m2 not
   if ( m1 >= range1 && m1 <= range2 )
   {
-    pt1.setX( x1 ); pt1.setY( y1 );
+    pt1.setX( x1 );
+    pt1.setY( y1 );
     double dist = ( range2 - m1 ) / ( m2 - m1 );
     pt2.setX( x1 + ( x2 - x1 ) * dist );
     pt2.setY( y1 + ( y2 - y1 ) * dist );
@@ -1410,7 +1419,8 @@ bool QgsGeometryAnalyzer::clipSegmentByRange( double x1, double y1, double m1, d
   //m2 inside and m1 not
   if ( m2 >= range1 && m2 <= range2 )
   {
-    pt2.setX( x2 ); pt2.setY( y2 );
+    pt2.setX( x2 );
+    pt2.setY( y2 );
     double dist = ( m2 - range1 ) / ( m2 - m1 );
     pt1.setX( x2 - ( x2 - x1 ) * dist );
     pt1.setY( y2 - ( y2 - y1 ) * dist );
@@ -1468,12 +1478,14 @@ void QgsGeometryAnalyzer::locateAlongSegment( double x1, double y1, double m1, d
     if ( reversed )
     {
       pt2Ok = true;
-      pt2.setX( x2 ); pt2.setY( y2 );
+      pt2.setX( x2 );
+      pt2.setY( y2 );
     }
     else
     {
       pt1Ok = true;
-      pt1.setX( x1 ); pt1.setY( y1 );
+      pt1.setX( x1 );
+      pt1.setY( y1 );
     }
   }
 
@@ -1483,12 +1495,14 @@ void QgsGeometryAnalyzer::locateAlongSegment( double x1, double y1, double m1, d
     if ( reversed )
     {
       pt1Ok = true;
-      pt1.setX( x1 ); pt1.setY( y1 );
+      pt1.setX( x1 );
+      pt1.setY( y1 );
     }
     else
     {
       pt2Ok = true;
-      pt2.setX( x2 ); pt2.setY( y2 );
+      pt2.setX( x2 );
+      pt2.setY( y2 );
     }
   }
 

--- a/src/analysis/vector/qgstransectsample.cpp
+++ b/src/analysis/vector/qgstransectsample.cpp
@@ -235,14 +235,16 @@ int QgsTransectSample::createSample( QProgressDialog* pd )
       QgsGeometry* lineClipStratum = lineFarAwayGeom->intersection( strataGeom );
       if ( !lineClipStratum )
       {
-        delete lineFarAwayGeom; delete lineClipStratum;
+        delete lineFarAwayGeom;
+        delete lineClipStratum;
         continue;
       }
 
       //cancel if distance between sample point and line is too large (line does not start at point
       if ( lineClipStratum->distance( *samplePoint ) > 0.000001 )
       {
-        delete lineFarAwayGeom; delete lineClipStratum;
+        delete lineFarAwayGeom;
+        delete lineClipStratum;
         continue;
       }
 
@@ -262,14 +264,16 @@ int QgsTransectSample::createSample( QProgressDialog* pd )
       double transectLength = distanceArea.measureLength( lineClipStratum );
       if ( transectLength < mMinTransectLength )
       {
-        delete lineFarAwayGeom; delete lineClipStratum;
+        delete lineFarAwayGeom;
+        delete lineClipStratum;
         continue;
       }
 
       //search closest existing profile. Cancel if dist < minDist
       if ( otherTransectWithinDistance( lineClipStratum, minDistanceLayerUnits, minDistance, sIndex, lineFeatureMap, distanceArea ) )
       {
-        delete lineFarAwayGeom; delete lineClipStratum;
+        delete lineFarAwayGeom;
+        delete lineClipStratum;
         continue;
       }
 
@@ -441,22 +445,30 @@ bool QgsTransectSample::closestSegmentPoints( QgsGeometry& g1, QgsGeometry& g2, 
 
     if ( d1 <= d2 && d1 <= d3 && d1 <= d4 )
     {
-      dist = sqrt( d1 ); pt1 = p11; pt2 = minDistPoint1;
+      dist = sqrt( d1 );
+      pt1 = p11;
+      pt2 = minDistPoint1;
       return true;
     }
     else if ( d2 <= d1 && d2 <= d3 && d2 <= d4 )
     {
-      dist = sqrt( d2 );  pt1 = p12; pt2 = minDistPoint2;
+      dist = sqrt( d2 );
+      pt1 = p12;
+      pt2 = minDistPoint2;
       return true;
     }
     else if ( d3 <= d1 && d3 <= d2 && d3 <= d4 )
     {
-      dist = sqrt( d3 ); pt1 = p21; pt2 = minDistPoint3;
+      dist = sqrt( d3 );
+      pt1 = p21;
+      pt2 = minDistPoint3;
       return true;
     }
     else
     {
-      dist = sqrt( d4 ); pt1 = p21; pt2 = minDistPoint4;
+      dist = sqrt( d4 );
+      pt1 = p21;
+      pt2 = minDistPoint4;
       return true;
     }
   }

--- a/src/analysis/vector/qgszonalstatistics.cpp
+++ b/src/analysis/vector/qgszonalstatistics.cpp
@@ -392,7 +392,10 @@ int QgsZonalStatistics::cellInfoForBBox( const QgsRectangle& rasterBBox, const Q
   QgsRectangle intersectBox = rasterBBox.intersect( &featureBBox );
   if ( intersectBox.isEmpty() )
   {
-    nCellsX = 0; nCellsY = 0; offsetX = 0; offsetY = 0;
+    nCellsX = 0;
+    nCellsY = 0;
+    offsetX = 0;
+    offsetY = 0;
     return 0;
   }
 

--- a/src/app/composer/qgscomposerpicturewidget.cpp
+++ b/src/app/composer/qgscomposerpicturewidget.cpp
@@ -475,7 +475,8 @@ int QgsComposerPictureWidget::addDirectoryToPreview( const QString& path )
     //exclude files that are not svg or image
     if ( !fileIsSvg && !fileIsPixel )
     {
-      ++counter; continue;
+      ++counter;
+      continue;
     }
 
     QListWidgetItem * listItem = new QListWidgetItem( mPreviewListWidget );
@@ -491,7 +492,8 @@ int QgsComposerPictureWidget::addDirectoryToPreview( const QString& path )
       QPixmap iconPixmap( filePath );
       if ( iconPixmap.isNull() )
       {
-        ++counter; continue; //unknown file format or other problem
+        ++counter;
+        continue; //unknown file format or other problem
       }
       //set pixmap hardcoded to 30/30, same as icon size for mPreviewListWidget
       QPixmap scaledPixmap( iconPixmap.scaled( QSize( 30, 30 ), Qt::KeepAspectRatio ) );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1831,11 +1831,21 @@ void QgisApp::createToolBars()
   QAction* defSelectAction = mActionSelectFeatures;
   switch ( settings.value( "/UI/selectTool", 0 ).toInt() )
   {
-    case 0: defSelectAction = mActionSelectFeatures; break;
-    case 1: defSelectAction = mActionSelectFeatures; break;
-    case 2: defSelectAction = mActionSelectRadius; break;
-    case 3: defSelectAction = mActionSelectPolygon; break;
-    case 4: defSelectAction = mActionSelectFreehand; break;
+    case 0:
+      defSelectAction = mActionSelectFeatures;
+      break;
+    case 1:
+      defSelectAction = mActionSelectFeatures;
+      break;
+    case 2:
+      defSelectAction = mActionSelectRadius;
+      break;
+    case 3:
+      defSelectAction = mActionSelectPolygon;
+      break;
+    case 4:
+      defSelectAction = mActionSelectFreehand;
+      break;
   }
   bt->setDefaultAction( defSelectAction );
   QAction* selectAction = mAttributesToolBar->insertWidget( mActionDeselectAll, bt );
@@ -1865,9 +1875,15 @@ void QgisApp::createToolBars()
   QAction* defMeasureAction = mActionMeasure;
   switch ( settings.value( "/UI/measureTool", 0 ).toInt() )
   {
-    case 0: defMeasureAction = mActionMeasure; break;
-    case 1: defMeasureAction = mActionMeasureArea; break;
-    case 2: defMeasureAction = mActionMeasureAngle; break;
+    case 0:
+      defMeasureAction = mActionMeasure;
+      break;
+    case 1:
+      defMeasureAction = mActionMeasureArea;
+      break;
+    case 2:
+      defMeasureAction = mActionMeasureAngle;
+      break;
   }
   bt->setDefaultAction( defMeasureAction );
   QAction* measureAction = mAttributesToolBar->insertWidget( mActionMapTips, bt );
@@ -1887,11 +1903,21 @@ void QgisApp::createToolBars()
   QAction* defAnnotationAction = mActionTextAnnotation;
   switch ( settings.value( "/UI/annotationTool", 0 ).toInt() )
   {
-    case 0: defAnnotationAction = mActionTextAnnotation; break;
-    case 1: defAnnotationAction = mActionFormAnnotation; break;
-    case 2: defAnnotationAction = mActionHtmlAnnotation; break;
-    case 3: defAnnotationAction = mActionSvgAnnotation; break;
-    case 4: defAnnotationAction =  mActionAnnotation; break;
+    case 0:
+      defAnnotationAction = mActionTextAnnotation;
+      break;
+    case 1:
+      defAnnotationAction = mActionFormAnnotation;
+      break;
+    case 2:
+      defAnnotationAction = mActionHtmlAnnotation;
+      break;
+    case 3:
+      defAnnotationAction = mActionSvgAnnotation;
+      break;
+    case 4:
+      defAnnotationAction =  mActionAnnotation;
+      break;
 
   }
   bt->setDefaultAction( defAnnotationAction );
@@ -1914,9 +1940,15 @@ void QgisApp::createToolBars()
   QAction* defNewLayerAction = mActionNewVectorLayer;
   switch ( settings.value( "/UI/defaultNewLayer", 1 ).toInt() )
   {
-    case 0: defNewLayerAction = mActionNewSpatiaLiteLayer; break;
-    case 1: defNewLayerAction = mActionNewVectorLayer; break;
-    case 2: defNewLayerAction = mActionNewMemoryLayer; break;
+    case 0:
+      defNewLayerAction = mActionNewSpatiaLiteLayer;
+      break;
+    case 1:
+      defNewLayerAction = mActionNewVectorLayer;
+      break;
+    case 2:
+      defNewLayerAction = mActionNewMemoryLayer;
+      break;
   }
   bt->setDefaultAction( defNewLayerAction );
   QAction* newLayerAction = mLayerToolBar->addWidget( bt );

--- a/src/app/qgsconfigureshortcutsdialog.cpp
+++ b/src/app/qgsconfigureshortcutsdialog.cpp
@@ -81,7 +81,8 @@ void QgsConfigureShortcutsDialog::populateActions()
     QString actionText = actions[i]->text();
     actionText.remove( '&' ); // remove the accelerator
 
-    QStringList lst; lst << actionText << actions[i]->shortcut().toString();
+    QStringList lst;
+    lst << actionText << actions[i]->shortcut().toString();
     QTreeWidgetItem* item = new QTreeWidgetItem( lst );
     item->setIcon( 0, actions[i]->icon() );
     item->setData( 0, Qt::UserRole, qVariantFromValue(( QObject* )actions[i] ) );

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -795,7 +795,8 @@ void QgsIdentifyResultsDialog::addFeature( QgsRasterLayer *layer,
 
     tblResults->resizeRowToContents( j );
 
-    j++; i++;
+    j++;
+    i++;
   }
   //tblResults->resizeColumnToContents( 1 );
 

--- a/src/app/qgsmaptooladdcircularstring.cpp
+++ b/src/app/qgsmaptooladdcircularstring.cpp
@@ -115,7 +115,8 @@ void QgsMapToolAddCircularString::deactivate()
   c->setPoints( mPoints );
   mParentTool->addCurve( c );
   mPoints.clear();
-  delete mRubberBand; mRubberBand = nullptr;
+  delete mRubberBand;
+  mRubberBand = nullptr;
   removeCenterPointRubberBand();
   QgsMapToolCapture::deactivate();
 }
@@ -144,7 +145,10 @@ void QgsMapToolAddCircularString::createCenterPointRubberBand()
     const QgsAbstractGeometryV2* rubberBandGeom = mRubberBand->geometry();
     if ( rubberBandGeom )
     {
-      QgsVertexId idx; idx.part = 0; idx.ring = 0; idx.vertex = mPoints.size();
+      QgsVertexId idx;
+      idx.part = 0;
+      idx.ring = 0;
+      idx.vertex = mPoints.size();
       QgsPointV2 pt = rubberBandGeom->vertexAt( idx );
       updateCenterPointRubberBand( pt );
     }
@@ -196,5 +200,6 @@ void QgsMapToolAddCircularString::updateCenterPointRubberBand( const QgsPointV2&
 
 void QgsMapToolAddCircularString::removeCenterPointRubberBand()
 {
-  delete mCenterPointRubberBand; mCenterPointRubberBand = nullptr;
+  delete mCenterPointRubberBand;
+  mCenterPointRubberBand = nullptr;
 }

--- a/src/app/qgsmaptoolannotation.cpp
+++ b/src/app/qgsmaptoolannotation.cpp
@@ -214,11 +214,15 @@ void QgsMapToolAnnotation::canvasMoveEvent( QgsMapMouseEvent* e )
       double tmp;
       if ( xmax < xmin )
       {
-        tmp = xmax; xmax = xmin; xmin = tmp;
+        tmp = xmax;
+        xmax = xmin;
+        xmin = tmp;
       }
       if ( ymax < ymin )
       {
-        tmp = ymax; ymax = ymin; ymin = tmp;
+        tmp = ymax;
+        ymax = ymin;
+        ymin = tmp;
       }
 
       sItem->setOffsetFromReferencePoint( QPointF( xmin, ymin ) );

--- a/src/app/qgsmaptoolcircularstringcurvepoint.cpp
+++ b/src/app/qgsmaptoolcircularstringcurvepoint.cpp
@@ -79,7 +79,10 @@ void QgsMapToolCircularStringCurvePoint::cadCanvasReleaseEvent( QgsMapMouseEvent
 void QgsMapToolCircularStringCurvePoint::cadCanvasMoveEvent( QgsMapMouseEvent* e )
 {
   QgsPointV2 mapPoint( e->mapPoint().x(), e->mapPoint().y() );
-  QgsVertexId idx; idx.part = 0; idx.ring = 0; idx.vertex = mPoints.size();
+  QgsVertexId idx;
+  idx.part = 0;
+  idx.ring = 0;
+  idx.vertex = mPoints.size();
   if ( mRubberBand )
   {
     mRubberBand->moveVertex( idx, mapPoint );

--- a/src/app/qgsmaptoolcircularstringradius.cpp
+++ b/src/app/qgsmaptoolcircularstringradius.cpp
@@ -73,7 +73,8 @@ void QgsMapToolCircularStringRadius::cadCanvasReleaseEvent( QgsMapMouseEvent* e 
     {
       if ( !mRadiusMode )
       {
-        delete mRubberBand; mRubberBand = nullptr;
+        delete mRubberBand;
+        mRubberBand = nullptr;
         mTemporaryEndPointX = mapPoint.x();
         mTemporaryEndPointY = mapPoint.y();
         mRadiusMode = true;
@@ -135,7 +136,9 @@ void QgsMapToolCircularStringRadius::recalculateCircularString()
     return;
   }
 
-  QList<QgsPointV2> rubberBandPoints = mPoints; rubberBandPoints.append( midPoint ); rubberBandPoints.append( QgsPointV2( mTemporaryEndPointX, mTemporaryEndPointY ) );
+  QList<QgsPointV2> rubberBandPoints = mPoints;
+  rubberBandPoints.append( midPoint );
+  rubberBandPoints.append( QgsPointV2( mTemporaryEndPointX, mTemporaryEndPointY ) );
   QgsCircularStringV2* cString = new QgsCircularStringV2();
   cString->setPoints( rubberBandPoints );
   delete mRubberBand;
@@ -164,7 +167,8 @@ void QgsMapToolCircularStringRadius::deleteRadiusSpinBox()
     return;
   }
   QgisApp::instance()->statusBar()->removeWidget( mRadiusSpinBox );
-  delete mRadiusSpinBox; mRadiusSpinBox = nullptr;
+  delete mRadiusSpinBox;
+  mRadiusSpinBox = nullptr;
 }
 
 void QgsMapToolCircularStringRadius::updateRadiusFromSpinBox( double radius )

--- a/src/app/qgsmaptoollabel.cpp
+++ b/src/app/qgsmaptoollabel.cpp
@@ -118,9 +118,12 @@ void QgsMapToolLabel::createRubberBands()
 
 void QgsMapToolLabel::deleteRubberBands()
 {
-  delete mLabelRubberBand; mLabelRubberBand = nullptr;
-  delete mFeatureRubberBand; mFeatureRubberBand = nullptr;
-  delete mFixPointRubberBand; mFixPointRubberBand = nullptr;
+  delete mLabelRubberBand;
+  mLabelRubberBand = nullptr;
+  delete mFeatureRubberBand;
+  mFeatureRubberBand = nullptr;
+  delete mFixPointRubberBand;
+  mFixPointRubberBand = nullptr;
 }
 
 QgsVectorLayer* QgsMapToolLabel::currentLayer()

--- a/src/app/qgsmaptooloffsetcurve.cpp
+++ b/src/app/qgsmaptooloffsetcurve.cpp
@@ -183,7 +183,8 @@ void QgsMapToolOffsetCurve::applyOffset()
 
   deleteRubberBandAndGeometry();
   deleteDistanceWidget();
-  delete mSnapVertexMarker; mSnapVertexMarker = nullptr;
+  delete mSnapVertexMarker;
+  mSnapVertexMarker = nullptr;
   mForceCopy = false;
   mCanvas->refresh();
 }
@@ -391,7 +392,8 @@ void QgsMapToolOffsetCurve::setOffsetForRubberBand( double offset )
     {
       deleteRubberBandAndGeometry();
       deleteDistanceWidget();
-      delete mSnapVertexMarker; mSnapVertexMarker = nullptr;
+      delete mSnapVertexMarker;
+      mSnapVertexMarker = nullptr;
       mForceCopy = false;
       mGeometryModified = false;
       deleteDistanceWidget();

--- a/src/app/qgsrulebasedlabelingwidget.cpp
+++ b/src/app/qgsrulebasedlabelingwidget.cpp
@@ -211,7 +211,8 @@ QVariant QgsRuleBasedLabelingModel::data( const QModelIndex& index, int role ) c
   {
     switch ( index.column() )
     {
-      case 0: return rule->description();
+      case 0:
+        return rule->description();
       case 1:
         if ( rule->isElse() )
         {
@@ -221,10 +222,14 @@ QVariant QgsRuleBasedLabelingModel::data( const QModelIndex& index, int role ) c
         {
           return rule->filterExpression().isEmpty() ? tr( "(no filter)" ) : rule->filterExpression();
         }
-      case 2: return rule->dependsOnScale() ? _formatScale( rule->scaleMaxDenom() ) : QVariant();
-      case 3: return rule->dependsOnScale() ? _formatScale( rule->scaleMinDenom() ) : QVariant();
-      case 4: return rule->settings() ? rule->settings()->fieldName : QVariant();
-      default: return QVariant();
+      case 2:
+        return rule->dependsOnScale() ? _formatScale( rule->scaleMaxDenom() ) : QVariant();
+      case 3:
+        return rule->dependsOnScale() ? _formatScale( rule->scaleMinDenom() ) : QVariant();
+      case 4:
+        return rule->settings() ? rule->settings()->fieldName : QVariant();
+      default:
+        return QVariant();
     }
   }
   else if ( role == Qt::DecorationRole && index.column() == 0 && rule->settings() )
@@ -250,12 +255,18 @@ QVariant QgsRuleBasedLabelingModel::data( const QModelIndex& index, int role ) c
   {
     switch ( index.column() )
     {
-      case 0: return rule->description();
-      case 1: return rule->filterExpression();
-      case 2: return rule->scaleMaxDenom();
-      case 3: return rule->scaleMinDenom();
-      case 4: return rule->settings() ? rule->settings()->fieldName : QVariant();
-      default: return QVariant();
+      case 0:
+        return rule->description();
+      case 1:
+        return rule->filterExpression();
+      case 2:
+        return rule->scaleMaxDenom();
+      case 3:
+        return rule->scaleMinDenom();
+      case 4:
+        return rule->settings() ? rule->settings()->fieldName : QVariant();
+      default:
+        return QVariant();
     }
   }
   else if ( role == Qt::CheckStateRole )
@@ -272,7 +283,8 @@ QVariant QgsRuleBasedLabelingModel::headerData( int section, Qt::Orientation ori
 {
   if ( orientation == Qt::Horizontal && role == Qt::DisplayRole && section >= 0 && section < 5 )
   {
-    QStringList lst; lst << tr( "Label" ) << tr( "Rule" ) << tr( "Min. scale" ) << tr( "Max. scale" ) << tr( "Text" ); // << tr( "Count" ) << tr( "Duplicate count" );
+    QStringList lst;
+    lst << tr( "Label" ) << tr( "Rule" ) << tr( "Min. scale" ) << tr( "Max. scale" ) << tr( "Text" ); // << tr( "Count" ) << tr( "Duplicate count" );
     return lst[section];
   }
 

--- a/src/app/qgssnappingdialog.cpp
+++ b/src/app/qgssnappingdialog.cpp
@@ -195,9 +195,15 @@ void QgsSnappingDialog::apply()
   QString snapMode;
   switch ( mSnapModeComboBox->currentIndex() )
   {
-    case 0: snapMode = "current_layer"; break;
-    case 1: snapMode = "all_layers"; break;
-    default: snapMode = "advanced"; break;
+    case 0:
+      snapMode = "current_layer";
+      break;
+    case 1:
+      snapMode = "all_layers";
+      break;
+    default:
+      snapMode = "advanced";
+      break;
   }
   QgsProject::instance()->writeEntry( "Digitizing", "/SnappingMode", snapMode );
 

--- a/src/core/composer/qgscomposerarrow.cpp
+++ b/src/core/composer/qgscomposerarrow.cpp
@@ -278,11 +278,13 @@ void QgsComposerArrow::drawSVGMarker( QPainter* p, MarkerType type, const QStrin
     QPointF fixPoint;
     if ( type == StartMarker )
     {
-      fixPoint.setX( 0 ); fixPoint.setY( arrowHeadHeight / 2.0 );
+      fixPoint.setX( 0 );
+      fixPoint.setY( arrowHeadHeight / 2.0 );
     }
     else
     {
-      fixPoint.setX( 0 ); fixPoint.setY( -arrowHeadHeight / 2.0 );
+      fixPoint.setX( 0 );
+      fixPoint.setY( -arrowHeadHeight / 2.0 );
     }
     QPointF rotatedFixPoint;
     double angleRad = ang / 180 * M_PI;

--- a/src/core/composer/qgscomposermapgrid.cpp
+++ b/src/core/composer/qgscomposermapgrid.cpp
@@ -1578,7 +1578,8 @@ int QgsComposerMapGrid::xGridLines( QList< QPair< double, QLineF > >& lines ) co
     if ( mGridUnit == CM )
     {
       annotationScale = 0.1;
-      gridIntervalY *= 10; gridOffsetY *= 10;
+      gridIntervalY *= 10;
+      gridOffsetY *= 10;
     }
   }
 
@@ -1662,7 +1663,8 @@ int QgsComposerMapGrid::yGridLines( QList< QPair< double, QLineF > >& lines ) co
     if ( mGridUnit == CM )
     {
       annotationScale = 0.1;
-      gridIntervalX *= 10; gridOffsetX *= 10;
+      gridIntervalX *= 10;
+      gridOffsetX *= 10;
     }
   }
 

--- a/src/core/composer/qgscomposermousehandles.cpp
+++ b/src/core/composer/qgscomposermousehandles.cpp
@@ -888,11 +888,17 @@ void QgsComposerMouseHandles::resizeMouseMove( const QPointF& currentPosition, b
       if ( ratio )
       {
         diffX = (( mBeginHandleHeight - diffY ) * ratio ) - mBeginHandleWidth;
-        mx = -diffX / 2; my = diffY; rx = diffX; ry = -diffY;
+        mx = -diffX / 2;
+        my = diffY;
+        rx = diffX;
+        ry = -diffY;
       }
       else
       {
-        mx = 0; my = diffY; rx = 0; ry = -diffY;
+        mx = 0;
+        my = diffY;
+        rx = 0;
+        ry = -diffY;
       }
       break;
     }
@@ -902,11 +908,17 @@ void QgsComposerMouseHandles::resizeMouseMove( const QPointF& currentPosition, b
       if ( ratio )
       {
         diffX = (( mBeginHandleHeight + diffY ) * ratio ) - mBeginHandleWidth;
-        mx = -diffX / 2; my = 0; rx = diffX; ry = diffY;
+        mx = -diffX / 2;
+        my = 0;
+        rx = diffX;
+        ry = diffY;
       }
       else
       {
-        mx = 0; my = 0; rx = 0; ry = diffY;
+        mx = 0;
+        my = 0;
+        rx = 0;
+        ry = diffY;
       }
       break;
     }
@@ -917,11 +929,16 @@ void QgsComposerMouseHandles::resizeMouseMove( const QPointF& currentPosition, b
       if ( ratio )
       {
         diffY = (( mBeginHandleWidth - diffX ) / ratio ) - mBeginHandleHeight;
-        mx = diffX; my = -diffY / 2; rx = -diffX; ry = diffY;
+        mx = diffX;
+        my = -diffY / 2;
+        rx = -diffX;
+        ry = diffY;
       }
       else
       {
-        mx = diffX, my = 0; rx = -diffX; ry = 0;
+        mx = diffX, my = 0;
+        rx = -diffX;
+        ry = 0;
       }
       break;
     }
@@ -931,11 +948,16 @@ void QgsComposerMouseHandles::resizeMouseMove( const QPointF& currentPosition, b
       if ( ratio )
       {
         diffY = (( mBeginHandleWidth + diffX ) / ratio ) - mBeginHandleHeight;
-        mx = 0; my = -diffY / 2; rx = diffX; ry = diffY;
+        mx = 0;
+        my = -diffY / 2;
+        rx = diffX;
+        ry = diffY;
       }
       else
       {
-        mx = 0; my = 0; rx = diffX, ry = 0;
+        mx = 0;
+        my = 0;
+        rx = diffX, ry = 0;
       }
       break;
     }
@@ -955,7 +977,9 @@ void QgsComposerMouseHandles::resizeMouseMove( const QPointF& currentPosition, b
           diffY = mBeginHandleHeight - (( mBeginHandleWidth - diffX ) / ratio );
         }
       }
-      mx = diffX, my = diffY; rx = -diffX; ry = -diffY;
+      mx = diffX, my = diffY;
+      rx = -diffX;
+      ry = -diffY;
       break;
     }
 
@@ -973,7 +997,9 @@ void QgsComposerMouseHandles::resizeMouseMove( const QPointF& currentPosition, b
           diffY = (( mBeginHandleWidth + diffX ) / ratio ) - mBeginHandleHeight;
         }
       }
-      mx = 0; my = 0; rx = diffX, ry = diffY;
+      mx = 0;
+      my = 0;
+      rx = diffX, ry = diffY;
       break;
     }
 
@@ -991,7 +1017,8 @@ void QgsComposerMouseHandles::resizeMouseMove( const QPointF& currentPosition, b
           diffY = mBeginHandleHeight - (( mBeginHandleWidth + diffX ) / ratio );
         }
       }
-      mx = 0; my = diffY, rx = diffX, ry = -diffY;
+      mx = 0;
+      my = diffY, rx = diffX, ry = -diffY;
       break;
     }
 
@@ -1009,7 +1036,9 @@ void QgsComposerMouseHandles::resizeMouseMove( const QPointF& currentPosition, b
           diffY = (( mBeginHandleWidth - diffX ) / ratio ) - mBeginHandleHeight;
         }
       }
-      mx = diffX, my = 0; rx = -diffX; ry = diffY;
+      mx = diffX, my = 0;
+      rx = -diffX;
+      ry = diffY;
       break;
     }
 

--- a/src/core/diagram/qgstextdiagram.cpp
+++ b/src/core/diagram/qgstextdiagram.cpp
@@ -146,7 +146,8 @@ void QgsTextDiagram::renderDiagram( const QgsFeature& feature, QgsRenderContext&
     //draw separator lines
     QList<QPointF> intersect; //intersections between shape and separation lines
     QPointF center( baseX + w / 2.0, baseY + h / 2.0 );
-    double r1 = w / 2.0; double r2 = h / 2.0;
+    double r1 = w / 2.0;
+    double r2 = h / 2.0;
 
     for ( int i = 1; i < nCategories; ++i )
     {

--- a/src/core/geometry/qgsabstractgeometryv2.cpp
+++ b/src/core/geometry/qgsabstractgeometryv2.cpp
@@ -276,6 +276,7 @@ bool QgsAbstractGeometryV2::convertTo( QgsWKBTypes::Type type )
 
 bool QgsAbstractGeometryV2::isEmpty() const
 {
-  QgsVertexId vId; QgsPointV2 vertex;
+  QgsVertexId vId;
+  QgsPointV2 vertex;
   return !nextVertex( vId, vertex );
 }

--- a/src/core/geometry/qgscircularstringv2.cpp
+++ b/src/core/geometry/qgscircularstringv2.cpp
@@ -423,7 +423,11 @@ void QgsCircularStringV2::setPoints( const QList<QgsPointV2>& points )
 {
   if ( points.size() < 1 )
   {
-    mWkbType = QgsWKBTypes::Unknown; mX.clear(); mY.clear(); mZ.clear(); mM.clear();
+    mWkbType = QgsWKBTypes::Unknown;
+    mX.clear();
+    mY.clear();
+    mZ.clear();
+    mM.clear();
     return;
   }
 
@@ -634,7 +638,8 @@ void QgsCircularStringV2::transform( const QTransform& t )
   {
     qreal x, y;
     t.map( mX.at( i ), mY.at( i ), &x, &y );
-    mX[i] = x; mY[i] = y;
+    mX[i] = x;
+    mY[i] = y;
   }
 }
 
@@ -816,7 +821,8 @@ double QgsCircularStringV2::closestSegment( const QgsPointV2& pt, QgsPointV2& se
 
   segmentPt = minDistSegmentPoint;
   vertexAfter = minDistVertexAfter;
-  vertexAfter.part = 0; vertexAfter.ring = 0;
+  vertexAfter.part = 0;
+  vertexAfter.ring = 0;
   if ( leftOf )
   {
     *leftOf = minDistLeftOf;

--- a/src/core/geometry/qgscompoundcurvev2.cpp
+++ b/src/core/geometry/qgscompoundcurvev2.cpp
@@ -550,7 +550,10 @@ QList< QPair<int, QgsVertexId> > QgsCompoundCurveV2::curveVertexId( const QgsVer
     if ( id.vertex >= currentVertexIndex && id.vertex <= currentVertexIndex + increment )
     {
       int curveVertexId = id.vertex - currentVertexIndex;
-      QgsVertexId vid; vid.part = 0; vid.ring = 0; vid.vertex = curveVertexId;
+      QgsVertexId vid;
+      vid.part = 0;
+      vid.ring = 0;
+      vid.vertex = curveVertexId;
       curveIds.append( qMakePair( i, vid ) );
       if ( curveVertexId == increment && i < ( mCurves.size() - 1 ) ) //add first vertex of next curve
       {

--- a/src/core/geometry/qgscurvepolygonv2.cpp
+++ b/src/core/geometry/qgscurvepolygonv2.cpp
@@ -624,7 +624,8 @@ bool QgsCurvePolygonV2::nextVertex( QgsVertexId& vId, QgsPointV2& vertex ) const
 
   if ( vId.ring < 0 )
   {
-    vId.ring = 0; vId.vertex = -1;
+    vId.ring = 0;
+    vId.vertex = -1;
     if ( vId.part < 0 )
     {
       vId.part = 0;

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -383,7 +383,8 @@ void QgsGeometry::adjacentVertices( int atVertex, int& beforeVertex, int& afterV
   QgsVertexId id;
   if ( !vertexIdFromVertexNr( atVertex, id ) )
   {
-    beforeVertex = -1; afterVertex = -1;
+    beforeVertex = -1;
+    afterVertex = -1;
     return;
   }
 

--- a/src/core/geometry/qgsgeometrycollectionv2.cpp
+++ b/src/core/geometry/qgsgeometrycollectionv2.cpp
@@ -355,7 +355,9 @@ bool QgsGeometryCollectionV2::nextVertex( QgsVertexId& id, QgsPointV2& vertex ) 
 {
   if ( id.part < 0 )
   {
-    id.part = 0; id.ring = -1; id.vertex = -1;
+    id.part = 0;
+    id.ring = -1;
+    id.vertex = -1;
   }
 
   QgsAbstractGeometryV2* geom = mGeometries.at( id.part );
@@ -367,7 +369,9 @@ bool QgsGeometryCollectionV2::nextVertex( QgsVertexId& id, QgsPointV2& vertex ) 
   {
     return false;
   }
-  ++id.part; id.ring = -1; id.vertex = -1;
+  ++id.part;
+  id.ring = -1;
+  id.vertex = -1;
   return mGeometries.at( id.part )->nextVertex( id, vertex );
 }
 
@@ -538,7 +542,8 @@ QgsAbstractGeometryV2* QgsGeometryCollectionV2::segmentize() const
   QgsGeometryCollectionV2* geomCollection = dynamic_cast<QgsGeometryCollectionV2*>( geom );
   if ( !geomCollection )
   {
-    delete geom; return clone();
+    delete geom;
+    return clone();
   }
 
   QVector< QgsAbstractGeometryV2* >::const_iterator geomIt = mGeometries.constBegin();

--- a/src/core/geometry/qgsgeometryeditutils.cpp
+++ b/src/core/geometry/qgsgeometryeditutils.cpp
@@ -50,17 +50,20 @@ int QgsGeometryEditUtils::addRing( QgsAbstractGeometryV2* geom, QgsCurveV2* ring
   }
   else
   {
-    delete ring; return 1; //not polygon / multipolygon;
+    delete ring;
+    return 1; //not polygon / multipolygon;
   }
 
   //ring must be closed
   if ( !ring->isClosed() )
   {
-    delete ring; return 2;
+    delete ring;
+    return 2;
   }
   else if ( !ring->isRing() )
   {
-    delete ring; return 3;
+    delete ring;
+    return 3;
   }
 
   QScopedPointer<QgsGeometryEngine> ringGeom( QgsGeometry::createGeometryEngine( ring ) );
@@ -78,7 +81,8 @@ int QgsGeometryEditUtils::addRing( QgsAbstractGeometryV2* geom, QgsCurveV2* ring
       {
         if ( !ringGeom->disjoint( *( *polyIter )->interiorRing( i ) ) )
         {
-          delete ring; return 4;
+          delete ring;
+          return 4;
         }
       }
 
@@ -92,7 +96,8 @@ int QgsGeometryEditUtils::addRing( QgsAbstractGeometryV2* geom, QgsCurveV2* ring
       return 0; //success
     }
   }
-  delete ring; return 5; //not contained in any outer ring
+  delete ring;
+  return 5; //not contained in any outer ring
 }
 
 int QgsGeometryEditUtils::addPart( QgsAbstractGeometryV2* geom, QgsAbstractGeometryV2* part )
@@ -150,14 +155,16 @@ int QgsGeometryEditUtils::addPart( QgsAbstractGeometryV2* geom, QgsAbstractGeome
       {
         while ( geomCollection->numGeometries() > n )
           geomCollection->removeGeometry( n );
-        delete part; return 2;
+        delete part;
+        return 2;
       }
 
       delete part;
     }
     else
     {
-      delete part; return 2;
+      delete part;
+      return 2;
     }
   }
   else

--- a/src/core/geometry/qgsgeometryfactory.cpp
+++ b/src/core/geometry/qgsgeometryfactory.cpp
@@ -106,7 +106,8 @@ QgsAbstractGeometryV2* QgsGeometryFactory::geomFromWkt( const QString& text )
   {
     if ( !geom->fromWkt( text ) )
     {
-      delete geom; return nullptr;
+      delete geom;
+      return nullptr;
     }
   }
   return geom;

--- a/src/core/geometry/qgsgeometryutils.cpp
+++ b/src/core/geometry/qgsgeometryutils.cpp
@@ -73,15 +73,23 @@ void QgsGeometryUtils::adjacentVertices( const QgsAbstractGeometryV2& geom, cons
   //vertex in the middle
   if ( atVertex.vertex > 0 && atVertex.vertex < ring.size() - 1 )
   {
-    beforeVertex.part = atVertex.part; beforeVertex.ring = atVertex.ring; beforeVertex.vertex = atVertex.vertex - 1;
-    afterVertex.part = atVertex.part; afterVertex.ring = atVertex.ring; afterVertex.vertex = atVertex.vertex + 1;
+    beforeVertex.part = atVertex.part;
+    beforeVertex.ring = atVertex.ring;
+    beforeVertex.vertex = atVertex.vertex - 1;
+    afterVertex.part = atVertex.part;
+    afterVertex.ring = atVertex.ring;
+    afterVertex.vertex = atVertex.vertex + 1;
   }
   else if ( atVertex.vertex == 0 )
   {
-    afterVertex.part = atVertex.part; afterVertex.ring = atVertex.ring; afterVertex.vertex = atVertex.vertex + 1;
+    afterVertex.part = atVertex.part;
+    afterVertex.ring = atVertex.ring;
+    afterVertex.vertex = atVertex.vertex + 1;
     if ( polygonType && ring.size() > 3 )
     {
-      beforeVertex.part = atVertex.part; beforeVertex.ring = atVertex.ring; beforeVertex.vertex = ring.size() - 2;
+      beforeVertex.part = atVertex.part;
+      beforeVertex.ring = atVertex.ring;
+      beforeVertex.vertex = ring.size() - 2;
     }
     else
     {
@@ -90,10 +98,14 @@ void QgsGeometryUtils::adjacentVertices( const QgsAbstractGeometryV2& geom, cons
   }
   else if ( atVertex.vertex == ring.size() - 1 )
   {
-    beforeVertex.part = atVertex.part; beforeVertex.ring = atVertex.ring; beforeVertex.vertex = atVertex.vertex - 1;
+    beforeVertex.part = atVertex.part;
+    beforeVertex.ring = atVertex.ring;
+    beforeVertex.vertex = atVertex.vertex - 1;
     if ( polygonType )
     {
-      afterVertex.part = atVertex.part; afterVertex.ring = atVertex.ring; afterVertex.vertex = 1;
+      afterVertex.part = atVertex.part;
+      afterVertex.ring = atVertex.ring;
+      afterVertex.vertex = 1;
     }
     else
     {

--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -537,7 +537,8 @@ GEOSGeometry* QgsGeos::linePointDifference( GEOSGeometry* GEOSsplitPoint ) const
   QgsPointV2* splitPoint = dynamic_cast<QgsPointV2*>( splitGeom );
   if ( !splitPoint )
   {
-    delete splitGeom; return nullptr;
+    delete splitGeom;
+    return nullptr;
   }
 
   QgsMultiCurveV2 lines;
@@ -1341,7 +1342,8 @@ bool QgsGeos::centroid( QgsPointV2& pt, QString* errorMsg ) const
   double x, y;
   GEOSGeomGetX_r( geosinit.ctxt, geos.get(), &x );
   GEOSGeomGetY_r( geosinit.ctxt, geos.get(), &y );
-  pt.setX( x ); pt.setY( y );
+  pt.setX( x );
+  pt.setY( y );
   return true;
 }
 

--- a/src/core/geometry/qgslinestringv2.cpp
+++ b/src/core/geometry/qgslinestringv2.cpp
@@ -569,7 +569,8 @@ void QgsLineStringV2::transform( const QTransform& t )
   {
     qreal x, y;
     t.map( mX.at( i ), mY.at( i ), &x, &y );
-    mX[i] = x; mY[i] = y;
+    mX[i] = x;
+    mY[i] = y;
   }
   mBoundingBox = QgsRectangle();
 }
@@ -707,7 +708,9 @@ double QgsLineStringV2::closestSegment( const QgsPointV2& pt, QgsPointV2& segmen
       {
         *leftOf = ( QgsGeometryUtils::leftOfLine( pt.x(), pt.y(), prevX, prevY, currentX, currentY ) < 0 );
       }
-      vertexAfter.part = 0; vertexAfter.ring = 0; vertexAfter.vertex = i;
+      vertexAfter.part = 0;
+      vertexAfter.ring = 0;
+      vertexAfter.vertex = i;
     }
   }
   return sqrDist;

--- a/src/core/geometry/qgspointv2.cpp
+++ b/src/core/geometry/qgspointv2.cpp
@@ -298,7 +298,8 @@ bool QgsPointV2::moveVertex( const QgsVertexId& position, const QgsPointV2& newP
 
 double QgsPointV2::closestSegment( const QgsPointV2& pt, QgsPointV2& segmentPt,  QgsVertexId& vertexAfter, bool* leftOf, double epsilon ) const
 {
-  Q_UNUSED( leftOf ); Q_UNUSED( epsilon );
+  Q_UNUSED( leftOf );
+  Q_UNUSED( epsilon );
   segmentPt = *this;
   vertexAfter = QgsVertexId( 0, 0, 0 );
   return QgsGeometryUtils::sqrDistance2D( *this, pt );
@@ -357,7 +358,8 @@ void QgsPointV2::transform( const QTransform& t )
   mBoundingBox = QgsRectangle();
   qreal x, y;
   t.map( mX, mY, &x, &y );
-  mX = x; mY = y;
+  mX = x;
+  mY = y;
 }
 
 

--- a/src/core/gps/gmath.c
+++ b/src/core/gps/gmath.c
@@ -252,7 +252,8 @@ int nmea_move_horz(
 
   if ( NMEA_POSIX( isnan )( end_pos->lat ) || NMEA_POSIX( isnan )( end_pos->lon ) )
   {
-    end_pos->lat = 0; end_pos->lon = 0;
+    end_pos->lat = 0;
+    end_pos->lon = 0;
     RetVal = 0;
   }
 

--- a/src/core/gps/tok.c
+++ b/src/core/gps/tok.c
@@ -199,7 +199,8 @@ int nmea_scanf( const char *buff, int buff_sz, const char *format, ... )
         tok_type = NMEA_TOKS_COMPARE;
         tok_count++;
 
-        parg_target = 0; width = ( int )( buff - beg_tok );
+        parg_target = 0;
+        width = ( int )( buff - beg_tok );
 
         switch ( *format )
         {

--- a/src/core/layertree/qgslayertreeutils.cpp
+++ b/src/core/layertree/qgslayertreeutils.cpp
@@ -184,9 +184,13 @@ QString QgsLayerTreeUtils::checkStateToXml( Qt::CheckState state )
 {
   switch ( state )
   {
-    case Qt::Unchecked:        return "Qt::Unchecked";
-    case Qt::PartiallyChecked: return "Qt::PartiallyChecked";
-  case Qt::Checked: default: return "Qt::Checked";
+    case Qt::Unchecked:
+      return "Qt::Unchecked";
+    case Qt::PartiallyChecked:
+      return "Qt::PartiallyChecked";
+    case Qt::Checked:
+    default:
+      return "Qt::Checked";
   }
 }
 

--- a/src/core/pal/labelposition.h
+++ b/src/core/pal/labelposition.h
@@ -166,7 +166,8 @@ namespace pal
        *  called from pal.cpp during extraction */
       void setProblemIds( int probFid, int lpId )
       {
-        probFeat = probFid; id = lpId;
+        probFeat = probFid;
+        id = lpId;
         if ( nextPart ) nextPart->setProblemIds( probFid, lpId );
       }
 

--- a/src/core/pal/pointset.h
+++ b/src/core/pal/pointset.h
@@ -116,8 +116,10 @@ namespace pal
 
       void getBoundingBox( double min[2], double max[2] ) const
       {
-        min[0] = xmin; min[1] = ymin;
-        max[0] = xmax; max[1] = ymax;
+        min[0] = xmin;
+        min[1] = ymin;
+        max[0] = xmax;
+        max[1] = ymax;
       }
 
       /** Returns NULL if this isn't a hole. Otherwise returns pointer to parent pointset. */

--- a/src/core/qgis.cpp
+++ b/src/core/qgis.cpp
@@ -104,21 +104,36 @@ QgsWKBTypes::Type QGis::fromOldWkbType( QGis::WkbType type )
 {
   switch ( type )
   {
-    case QGis::WKBPoint: return QgsWKBTypes::Point;
-    case QGis::WKBLineString: return QgsWKBTypes::LineString;
-    case QGis::WKBPolygon: return QgsWKBTypes::Polygon;
-    case QGis::WKBMultiPoint: return QgsWKBTypes::MultiPoint;
-    case QGis::WKBMultiLineString: return QgsWKBTypes::MultiLineString;
-    case QGis::WKBMultiPolygon: return QgsWKBTypes::MultiPolygon;
-    case QGis::WKBNoGeometry: return QgsWKBTypes::NoGeometry;
-    case QGis::WKBPoint25D: return QgsWKBTypes::PointZ;
-    case QGis::WKBLineString25D: return QgsWKBTypes::LineStringZ;
-    case QGis::WKBPolygon25D: return QgsWKBTypes::PolygonZ;
-    case QGis::WKBMultiPoint25D: return QgsWKBTypes::MultiPointZ;
-    case QGis::WKBMultiLineString25D: return QgsWKBTypes::MultiLineStringZ;
-    case QGis::WKBMultiPolygon25D: return QgsWKBTypes::MultiPolygonZ;
-    case QGis::WKBUnknown: return QgsWKBTypes::Unknown;
-    default: break;
+    case QGis::WKBPoint:
+      return QgsWKBTypes::Point;
+    case QGis::WKBLineString:
+      return QgsWKBTypes::LineString;
+    case QGis::WKBPolygon:
+      return QgsWKBTypes::Polygon;
+    case QGis::WKBMultiPoint:
+      return QgsWKBTypes::MultiPoint;
+    case QGis::WKBMultiLineString:
+      return QgsWKBTypes::MultiLineString;
+    case QGis::WKBMultiPolygon:
+      return QgsWKBTypes::MultiPolygon;
+    case QGis::WKBNoGeometry:
+      return QgsWKBTypes::NoGeometry;
+    case QGis::WKBPoint25D:
+      return QgsWKBTypes::PointZ;
+    case QGis::WKBLineString25D:
+      return QgsWKBTypes::LineStringZ;
+    case QGis::WKBPolygon25D:
+      return QgsWKBTypes::PolygonZ;
+    case QGis::WKBMultiPoint25D:
+      return QgsWKBTypes::MultiPointZ;
+    case QGis::WKBMultiLineString25D:
+      return QgsWKBTypes::MultiLineStringZ;
+    case QGis::WKBMultiPolygon25D:
+      return QgsWKBTypes::MultiPolygonZ;
+    case QGis::WKBUnknown:
+      return QgsWKBTypes::Unknown;
+    default:
+      break;
   }
 
   QgsDebugMsg( QString( "unexpected old wkbType=%1" ).arg( type ) );
@@ -129,20 +144,34 @@ QGis::WkbType QGis::fromNewWkbType( QgsWKBTypes::Type type )
 {
   switch ( type )
   {
-    case QgsWKBTypes::Point: return QGis::WKBPoint;
-    case QgsWKBTypes::LineString: return QGis::WKBLineString;
-    case QgsWKBTypes::Polygon: return QGis::WKBPolygon;
-    case QgsWKBTypes::MultiPoint: return QGis::WKBMultiPoint;
-    case QgsWKBTypes::MultiLineString: return QGis::WKBMultiLineString;
-    case QgsWKBTypes::MultiPolygon: return QGis::WKBMultiPolygon;
-    case QgsWKBTypes::NoGeometry: return QGis::WKBNoGeometry;
-    case QgsWKBTypes::PointZ: return QGis::WKBPoint25D;
-    case QgsWKBTypes::LineStringZ: return QGis::WKBLineString25D;
-    case QgsWKBTypes::PolygonZ: return QGis::WKBPolygon25D;
-    case QgsWKBTypes::MultiPointZ: return QGis::WKBMultiPoint25D;
-    case QgsWKBTypes::MultiLineStringZ: return QGis::WKBMultiLineString25D;
-    case QgsWKBTypes::MultiPolygonZ: return QGis::WKBMultiPolygon25D;
-    default: break;
+    case QgsWKBTypes::Point:
+      return QGis::WKBPoint;
+    case QgsWKBTypes::LineString:
+      return QGis::WKBLineString;
+    case QgsWKBTypes::Polygon:
+      return QGis::WKBPolygon;
+    case QgsWKBTypes::MultiPoint:
+      return QGis::WKBMultiPoint;
+    case QgsWKBTypes::MultiLineString:
+      return QGis::WKBMultiLineString;
+    case QgsWKBTypes::MultiPolygon:
+      return QGis::WKBMultiPolygon;
+    case QgsWKBTypes::NoGeometry:
+      return QGis::WKBNoGeometry;
+    case QgsWKBTypes::PointZ:
+      return QGis::WKBPoint25D;
+    case QgsWKBTypes::LineStringZ:
+      return QGis::WKBLineString25D;
+    case QgsWKBTypes::PolygonZ:
+      return QGis::WKBPolygon25D;
+    case QgsWKBTypes::MultiPointZ:
+      return QGis::WKBMultiPoint25D;
+    case QgsWKBTypes::MultiLineStringZ:
+      return QGis::WKBMultiLineString25D;
+    case QgsWKBTypes::MultiPolygonZ:
+      return QGis::WKBMultiPolygon25D;
+    default:
+      break;
   }
 
   QgsDebugMsg( QString( "unexpected new wkbType=%1" ).arg( type ) );
@@ -338,13 +367,20 @@ QGis::WkbType QGis::singleType( QGis::WkbType type )
 {
   switch ( type )
   {
-    case WKBMultiPoint:         return WKBPoint;
-    case WKBMultiLineString:    return WKBLineString;
-    case WKBMultiPolygon:       return WKBPolygon;
-    case WKBMultiPoint25D:      return WKBPoint25D;
-    case WKBMultiLineString25D: return WKBLineString25D;
-    case WKBMultiPolygon25D:    return WKBPolygon25D;
-    default:                    return fromNewWkbType( QgsWKBTypes::singleType( fromOldWkbType( type ) ) );
+    case WKBMultiPoint:
+      return WKBPoint;
+    case WKBMultiLineString:
+      return WKBLineString;
+    case WKBMultiPolygon:
+      return WKBPolygon;
+    case WKBMultiPoint25D:
+      return WKBPoint25D;
+    case WKBMultiLineString25D:
+      return WKBLineString25D;
+    case WKBMultiPolygon25D:
+      return WKBPolygon25D;
+    default:
+      return fromNewWkbType( QgsWKBTypes::singleType( fromOldWkbType( type ) ) );
   }
 }
 
@@ -352,13 +388,20 @@ QGis::WkbType QGis::multiType( QGis::WkbType type )
 {
   switch ( type )
   {
-    case WKBPoint:         return WKBMultiPoint;
-    case WKBLineString:    return WKBMultiLineString;
-    case WKBPolygon:       return WKBMultiPolygon;
-    case WKBPoint25D:      return WKBMultiPoint25D;
-    case WKBLineString25D: return WKBMultiLineString25D;
-    case WKBPolygon25D:    return WKBMultiPolygon25D;
-    default:               return fromNewWkbType( QgsWKBTypes::multiType( fromOldWkbType( type ) ) );
+    case WKBPoint:
+      return WKBMultiPoint;
+    case WKBLineString:
+      return WKBMultiLineString;
+    case WKBPolygon:
+      return WKBMultiPolygon;
+    case WKBPoint25D:
+      return WKBMultiPoint25D;
+    case WKBLineString25D:
+      return WKBMultiLineString25D;
+    case WKBPolygon25D:
+      return WKBMultiPolygon25D;
+    default:
+      return fromNewWkbType( QgsWKBTypes::multiType( fromOldWkbType( type ) ) );
   }
 }
 
@@ -366,13 +409,20 @@ QGis::WkbType QGis::flatType( QGis::WkbType type )
 {
   switch ( type )
   {
-    case WKBPoint25D:           return WKBPoint;
-    case WKBLineString25D:      return WKBLineString;
-    case WKBPolygon25D:         return WKBPolygon;
-    case WKBMultiPoint25D:      return WKBMultiPoint;
-    case WKBMultiLineString25D: return WKBMultiLineString;
-    case WKBMultiPolygon25D:    return WKBMultiPolygon;
-    default:                    return fromNewWkbType( QgsWKBTypes::flatType( fromOldWkbType( type ) ) );
+    case WKBPoint25D:
+      return WKBPoint;
+    case WKBLineString25D:
+      return WKBLineString;
+    case WKBPolygon25D:
+      return WKBPolygon;
+    case WKBMultiPoint25D:
+      return WKBMultiPoint;
+    case WKBMultiLineString25D:
+      return WKBMultiLineString;
+    case WKBMultiPolygon25D:
+      return WKBMultiPolygon;
+    default:
+      return fromNewWkbType( QgsWKBTypes::flatType( fromOldWkbType( type ) ) );
   }
 }
 
@@ -399,12 +449,18 @@ const char *QGis::vectorGeometryType( QGis::GeometryType type )
 {
   switch ( type )
   {
-    case Point:           return "Point";
-    case Line:            return "Line";
-    case Polygon:         return "Polygon";
-    case UnknownGeometry: return "Unknown geometry";
-    case NoGeometry:      return "No geometry";
-    default:              return "Invalid type";
+    case Point:
+      return "Point";
+    case Line:
+      return "Line";
+    case Polygon:
+      return "Polygon";
+    case UnknownGeometry:
+      return "Unknown geometry";
+    case NoGeometry:
+      return "No geometry";
+    default:
+      return "Invalid type";
   }
 }
 
@@ -413,21 +469,36 @@ const char *QGis::featureType( QGis::WkbType type )
 {
   switch ( type )
   {
-    case WKBUnknown:            return "WKBUnknown";
-    case WKBPoint:              return "WKBPoint";
-    case WKBLineString:         return "WKBLineString";
-    case WKBPolygon:            return "WKBPolygon";
-    case WKBMultiPoint:         return "WKBMultiPoint";
-    case WKBMultiLineString:    return "WKBMultiLineString";
-    case WKBMultiPolygon:       return "WKBMultiPolygon";
-    case WKBNoGeometry:         return "WKBNoGeometry";
-    case WKBPoint25D:           return "WKBPoint25D";
-    case WKBLineString25D:      return "WKBLineString25D";
-    case WKBPolygon25D:         return "WKBPolygon25D";
-    case WKBMultiPoint25D:      return "WKBMultiPoint25D";
-    case WKBMultiLineString25D: return "WKBMultiLineString25D";
-    case WKBMultiPolygon25D:    return "WKBMultiPolygon25D";
-    default:                    return "invalid wkbtype";
+    case WKBUnknown:
+      return "WKBUnknown";
+    case WKBPoint:
+      return "WKBPoint";
+    case WKBLineString:
+      return "WKBLineString";
+    case WKBPolygon:
+      return "WKBPolygon";
+    case WKBMultiPoint:
+      return "WKBMultiPoint";
+    case WKBMultiLineString:
+      return "WKBMultiLineString";
+    case WKBMultiPolygon:
+      return "WKBMultiPolygon";
+    case WKBNoGeometry:
+      return "WKBNoGeometry";
+    case WKBPoint25D:
+      return "WKBPoint25D";
+    case WKBLineString25D:
+      return "WKBLineString25D";
+    case WKBPolygon25D:
+      return "WKBPolygon25D";
+    case WKBMultiPoint25D:
+      return "WKBMultiPoint25D";
+    case WKBMultiLineString25D:
+      return "WKBMultiLineString25D";
+    case WKBMultiPolygon25D:
+      return "WKBMultiPolygon25D";
+    default:
+      return "invalid wkbtype";
 
   }
 }

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -53,7 +53,8 @@ class CORE_EXPORT QGis
     //! Used for symbology operations
     // Feature types
     // @deprecated use QgsWKBTypes::Type
-    /* Q_DECL_DEPRECATED */ enum WkbType
+    /* Q_DECL_DEPRECATED */
+    enum WkbType
     {
       WKBUnknown = 0,
       WKBPoint = 1,
@@ -73,27 +74,33 @@ class CORE_EXPORT QGis
 
     //! Map multi to single type
     // @deprecated use QgsWKBTypes::singleType
-    /* Q_DECL_DEPRECATED */ static WkbType singleType( WkbType type );
+    /* Q_DECL_DEPRECATED */
+    static WkbType singleType( WkbType type );
 
     //! Map single to multitype type
     // @deprecated use QgsWKBTypes::multiType
-    /* Q_DECL_DEPRECATED */ static WkbType multiType( WkbType type );
+    /* Q_DECL_DEPRECATED */
+    static WkbType multiType( WkbType type );
 
     //! Map 2d+ to 2d type
     // @deprecated use QgsWKBTypes::flatType
-    /* Q_DECL_DEPRECATED */ static WkbType flatType( WkbType type );
+    /* Q_DECL_DEPRECATED */
+    static WkbType flatType( WkbType type );
 
     //! Return if type is a single type
     // @deprecated use QgsWKBTypes::isSingleType
-    /* Q_DECL_DEPRECATED */ static bool isSingleType( WkbType type );
+    /* Q_DECL_DEPRECATED */
+    static bool isSingleType( WkbType type );
 
     //! Return if type is a multi type
     // @deprecated use QgsWKBTypes::isMultiType
-    /* Q_DECL_DEPRECATED */ static bool isMultiType( WkbType type );
+    /* Q_DECL_DEPRECATED */
+    static bool isMultiType( WkbType type );
 
     // get dimension of points
     // @deprecated use QgsWKBTypes::hasZ() and QgsWKBTypes::hasM()
-    /* Q_DECL_DEPRECATED */ static int wkbDimensions( WkbType type );
+    /* Q_DECL_DEPRECATED */
+    static int wkbDimensions( WkbType type );
 
     //! Converts from old (pre 2.10) WKB type to new WKB type
     static QgsWKBTypes::Type fromOldWkbType( QGis::WkbType type );

--- a/src/core/qgsattributeaction.cpp
+++ b/src/core/qgsattributeaction.cpp
@@ -175,10 +175,18 @@ QString QgsAttributeAction::expandAction( QString action, const QgsAttributeMap 
       QString to_replace;
       switch ( i )
       {
-        case 0: to_replace = "[%" + fields[attrIdx].name() + ']'; break;
-        case 1: to_replace = "[%" + mLayer->attributeDisplayName( attrIdx ) + ']'; break;
-        case 2: to_replace = '%' + fields[attrIdx].name(); break;
-        case 3: to_replace = '%' + mLayer->attributeDisplayName( attrIdx ); break;
+        case 0:
+          to_replace = "[%" + fields[attrIdx].name() + ']';
+          break;
+        case 1:
+          to_replace = "[%" + mLayer->attributeDisplayName( attrIdx ) + ']';
+          break;
+        case 2:
+          to_replace = '%' + fields[attrIdx].name();
+          break;
+        case 3:
+          to_replace = '%' + mLayer->attributeDisplayName( attrIdx );
+          break;
       }
 
       expanded_action = expanded_action.replace( to_replace, it.value().toString() );

--- a/src/core/qgsclipper.cpp
+++ b/src/core/qgsclipper.cpp
@@ -79,7 +79,8 @@ const unsigned char* QgsClipper::clippedLineWKB( const unsigned char* wkb, const
       if ( hasMValue )
         wkbPtr += sizeof( double );
 
-      p1x_c = p1x; p1y_c = p1y;
+      p1x_c = p1x;
+      p1y_c = p1y;
       if ( clipLineSegment( clipExtent.xMinimum(), clipExtent.xMaximum(), clipExtent.yMinimum(), clipExtent.yMaximum(),
                             p0x, p0y, p1x_c,  p1y_c ) )
       {
@@ -96,7 +97,8 @@ const unsigned char* QgsClipper::clippedLineWKB( const unsigned char* wkb, const
         }
 
         //add second point
-        lastClipX = p1x_c; lastClipY = p1y_c;
+        lastClipX = p1x_c;
+        lastClipY = p1y_c;
         line << QPointF( p1x_c,  p1y_c );
       }
     }

--- a/src/core/qgscoordinatetransform.cpp
+++ b/src/core/qgscoordinatetransform.cpp
@@ -915,7 +915,8 @@ void QgsCoordinateTransform::searchDatumTransform( const QString& sql, QList< in
   int prepareRes = sqlite3_prepare( db, sql.toAscii(), sql.size(), &stmt, nullptr );
   if ( prepareRes != SQLITE_OK )
   {
-    sqlite3_finalize( stmt ); sqlite3_close( db );
+    sqlite3_finalize( stmt );
+    sqlite3_close( db );
     return;
   }
 
@@ -925,7 +926,8 @@ void QgsCoordinateTransform::searchDatumTransform( const QString& sql, QList< in
     cOpCode = ( const char * ) sqlite3_column_text( stmt, 0 );
     transforms.push_back( cOpCode.toInt() );
   }
-  sqlite3_finalize( stmt ); sqlite3_close( db );
+  sqlite3_finalize( stmt );
+  sqlite3_close( db );
 }
 
 QString QgsCoordinateTransform::datumTransformString( int datumTransform )
@@ -945,7 +947,8 @@ QString QgsCoordinateTransform::datumTransformString( int datumTransform )
   int prepareRes = sqlite3_prepare( db, sql.toAscii(), sql.size(), &stmt, nullptr );
   if ( prepareRes != SQLITE_OK )
   {
-    sqlite3_finalize( stmt ); sqlite3_close( db );
+    sqlite3_finalize( stmt );
+    sqlite3_close( db );
     return transformString;
   }
 
@@ -978,7 +981,8 @@ QString QgsCoordinateTransform::datumTransformString( int datumTransform )
     }
   }
 
-  sqlite3_finalize( stmt ); sqlite3_close( db );
+  sqlite3_finalize( stmt );
+  sqlite3_close( db );
   return transformString;
 }
 
@@ -997,7 +1001,8 @@ bool QgsCoordinateTransform::datumTransformCrsInfo( int datumTransform, int& eps
   int prepareRes = sqlite3_prepare( db, sql.toAscii(), sql.size(), &stmt, nullptr );
   if ( prepareRes != SQLITE_OK )
   {
-    sqlite3_finalize( stmt ); sqlite3_close( db );
+    sqlite3_finalize( stmt );
+    sqlite3_close( db );
     return false;
   }
 

--- a/src/core/qgsdataitem.cpp
+++ b/src/core/qgsdataitem.cpp
@@ -675,14 +675,28 @@ QgsLayerItem::QgsLayerItem( QgsDataItem* parent, const QString& name, const QStr
 {
   switch ( layerType )
   {
-    case Point:      mIconName = "/mIconPointLayer.svg"; break;
-    case Line:       mIconName = "/mIconLineLayer.svg"; break;
-    case Polygon:    mIconName = "/mIconPolygonLayer.svg"; break;
+    case Point:
+      mIconName = "/mIconPointLayer.svg";
+      break;
+    case Line:
+      mIconName = "/mIconLineLayer.svg";
+      break;
+    case Polygon:
+      mIconName = "/mIconPolygonLayer.svg";
+      break;
       // TODO add a new icon for generic Vector layers
-    case Vector :    mIconName = "/mIconPolygonLayer.svg"; break;
-    case TableLayer: mIconName = "/mIconTableLayer.png"; break;
-    case Raster:     mIconName = "/mIconRaster.svg"; break;
-    default:         mIconName = "/mIconLayer.png"; break;
+    case Vector :
+      mIconName = "/mIconPolygonLayer.svg";
+      break;
+    case TableLayer:
+      mIconName = "/mIconTableLayer.png";
+      break;
+    case Raster:
+      mIconName = "/mIconRaster.svg";
+      break;
+    default:
+      mIconName = "/mIconLayer.png";
+      break;
   }
 }
 

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -158,8 +158,10 @@ static QVariant tvl2variant( TVL v )
 {
   switch ( v )
   {
-    case False: return 0;
-    case True: return 1;
+    case False:
+      return 0;
+    case True:
+      return 1;
     case Unknown:
     default:
       return QVariant();
@@ -3384,10 +3386,12 @@ QgsExpression::NodeList* QgsExpression::NodeList::clone() const
 
 QString QgsExpression::NodeList::dump() const
 {
-  QString msg; bool first = true;
+  QString msg;
+  bool first = true;
   Q_FOREACH ( Node* n, mList )
   {
-    if ( !first ) msg += ", "; else first = false;
+    if ( !first ) msg += ", ";
+    else first = false;
     msg += n->dump();
   }
   return msg;
@@ -3453,8 +3457,10 @@ QVariant QgsExpression::NodeBinaryOperator::eval( QgsExpression *parent, const Q
     case boPlus:
       if ( vL.type() == QVariant::String && vR.type() == QVariant::String )
       {
-        QString sL = isNull( vL ) ? QString() : getStringValue( vL, parent ); ENSURE_NO_EVAL_ERROR;
-        QString sR = isNull( vR ) ? QString() : getStringValue( vR, parent ); ENSURE_NO_EVAL_ERROR;
+        QString sL = isNull( vL ) ? QString() : getStringValue( vL, parent );
+        ENSURE_NO_EVAL_ERROR;
+        QString sR = isNull( vR ) ? QString() : getStringValue( vR, parent );
+        ENSURE_NO_EVAL_ERROR;
         return QVariant( sL + sR );
       }
       //intentional fall-through
@@ -3468,8 +3474,10 @@ QVariant QgsExpression::NodeBinaryOperator::eval( QgsExpression *parent, const Q
       else if ( mOp != boDiv && isIntSafe( vL ) && isIntSafe( vR ) )
       {
         // both are integers - let's use integer arithmetics
-        int iL = getIntValue( vL, parent ); ENSURE_NO_EVAL_ERROR;
-        int iR = getIntValue( vR, parent ); ENSURE_NO_EVAL_ERROR;
+        int iL = getIntValue( vL, parent );
+        ENSURE_NO_EVAL_ERROR;
+        int iR = getIntValue( vR, parent );
+        ENSURE_NO_EVAL_ERROR;
 
         if ( mOp == boMod && iR == 0 )
           return QVariant();
@@ -3478,8 +3486,10 @@ QVariant QgsExpression::NodeBinaryOperator::eval( QgsExpression *parent, const Q
       }
       else if ( isDateTimeSafe( vL ) && isIntervalSafe( vR ) )
       {
-        QDateTime dL = getDateTimeValue( vL, parent );  ENSURE_NO_EVAL_ERROR;
-        QgsExpression::Interval iL = getInterval( vR, parent ); ENSURE_NO_EVAL_ERROR;
+        QDateTime dL = getDateTimeValue( vL, parent );
+        ENSURE_NO_EVAL_ERROR;
+        QgsExpression::Interval iL = getInterval( vR, parent );
+        ENSURE_NO_EVAL_ERROR;
         if ( mOp == boDiv || mOp == boMul || mOp == boMod )
         {
           parent->setEvalErrorString( tr( "Can't preform /, *, or % on DateTime and Interval" ) );
@@ -3490,8 +3500,10 @@ QVariant QgsExpression::NodeBinaryOperator::eval( QgsExpression *parent, const Q
       else
       {
         // general floating point arithmetic
-        double fL = getDoubleValue( vL, parent ); ENSURE_NO_EVAL_ERROR;
-        double fR = getDoubleValue( vR, parent ); ENSURE_NO_EVAL_ERROR;
+        double fL = getDoubleValue( vL, parent );
+        ENSURE_NO_EVAL_ERROR;
+        double fR = getDoubleValue( vR, parent );
+        ENSURE_NO_EVAL_ERROR;
         if (( mOp == boDiv || mOp == boMod ) && fR == 0. )
           return QVariant(); // silently handle division by zero and return NULL
         return QVariant( computeDouble( fL, fR ) );
@@ -3500,8 +3512,10 @@ QVariant QgsExpression::NodeBinaryOperator::eval( QgsExpression *parent, const Q
     case boIntDiv:
     {
       //integer division
-      double fL = getDoubleValue( vL, parent ); ENSURE_NO_EVAL_ERROR;
-      double fR = getDoubleValue( vR, parent ); ENSURE_NO_EVAL_ERROR;
+      double fL = getDoubleValue( vL, parent );
+      ENSURE_NO_EVAL_ERROR;
+      double fR = getDoubleValue( vR, parent );
+      ENSURE_NO_EVAL_ERROR;
       if ( fR == 0. )
         return QVariant(); // silently handle division by zero and return NULL
       return QVariant( qFloor( fL / fR ) );
@@ -3511,8 +3525,10 @@ QVariant QgsExpression::NodeBinaryOperator::eval( QgsExpression *parent, const Q
         return QVariant();
       else
       {
-        double fL = getDoubleValue( vL, parent ); ENSURE_NO_EVAL_ERROR;
-        double fR = getDoubleValue( vR, parent ); ENSURE_NO_EVAL_ERROR;
+        double fL = getDoubleValue( vL, parent );
+        ENSURE_NO_EVAL_ERROR;
+        double fR = getDoubleValue( vR, parent );
+        ENSURE_NO_EVAL_ERROR;
         return QVariant( pow( fL, fR ) );
       }
 
@@ -3543,15 +3559,19 @@ QVariant QgsExpression::NodeBinaryOperator::eval( QgsExpression *parent, const Q
       else if ( isDoubleSafe( vL ) && isDoubleSafe( vR ) )
       {
         // do numeric comparison if both operators can be converted to numbers
-        double fL = getDoubleValue( vL, parent ); ENSURE_NO_EVAL_ERROR;
-        double fR = getDoubleValue( vR, parent ); ENSURE_NO_EVAL_ERROR;
+        double fL = getDoubleValue( vL, parent );
+        ENSURE_NO_EVAL_ERROR;
+        double fR = getDoubleValue( vR, parent );
+        ENSURE_NO_EVAL_ERROR;
         return compare( fL - fR ) ? TVL_True : TVL_False;
       }
       else
       {
         // do string comparison otherwise
-        QString sL = getStringValue( vL, parent ); ENSURE_NO_EVAL_ERROR;
-        QString sR = getStringValue( vR, parent ); ENSURE_NO_EVAL_ERROR;
+        QString sL = getStringValue( vL, parent );
+        ENSURE_NO_EVAL_ERROR;
+        QString sR = getStringValue( vR, parent );
+        ENSURE_NO_EVAL_ERROR;
         int diff = QString::compare( sL, sR );
         return compare( diff ) ? TVL_True : TVL_False;
       }
@@ -3567,14 +3587,18 @@ QVariant QgsExpression::NodeBinaryOperator::eval( QgsExpression *parent, const Q
         bool equal = false;
         if ( isDoubleSafe( vL ) && isDoubleSafe( vR ) )
         {
-          double fL = getDoubleValue( vL, parent ); ENSURE_NO_EVAL_ERROR;
-          double fR = getDoubleValue( vR, parent ); ENSURE_NO_EVAL_ERROR;
+          double fL = getDoubleValue( vL, parent );
+          ENSURE_NO_EVAL_ERROR;
+          double fR = getDoubleValue( vR, parent );
+          ENSURE_NO_EVAL_ERROR;
           equal = fL == fR;
         }
         else
         {
-          QString sL = getStringValue( vL, parent ); ENSURE_NO_EVAL_ERROR;
-          QString sR = getStringValue( vR, parent ); ENSURE_NO_EVAL_ERROR;
+          QString sL = getStringValue( vL, parent );
+          ENSURE_NO_EVAL_ERROR;
+          QString sR = getStringValue( vR, parent );
+          ENSURE_NO_EVAL_ERROR;
           equal = QString::compare( sL, sR ) == 0;
         }
         if ( equal )
@@ -3592,8 +3616,10 @@ QVariant QgsExpression::NodeBinaryOperator::eval( QgsExpression *parent, const Q
         return TVL_Unknown;
       else
       {
-        QString str    = getStringValue( vL, parent ); ENSURE_NO_EVAL_ERROR;
-        QString regexp = getStringValue( vR, parent ); ENSURE_NO_EVAL_ERROR;
+        QString str    = getStringValue( vL, parent );
+        ENSURE_NO_EVAL_ERROR;
+        QString regexp = getStringValue( vR, parent );
+        ENSURE_NO_EVAL_ERROR;
         // TODO: cache QRegExp in case that regexp is a literal string (i.e. it will stay constant)
         bool matches;
         if ( mOp == boLike || mOp == boILike || mOp == boNotLike || mOp == boNotILike ) // change from LIKE syntax to regexp
@@ -3622,12 +3648,15 @@ QVariant QgsExpression::NodeBinaryOperator::eval( QgsExpression *parent, const Q
         return QVariant();
       else
       {
-        QString sL = getStringValue( vL, parent ); ENSURE_NO_EVAL_ERROR;
-        QString sR = getStringValue( vR, parent ); ENSURE_NO_EVAL_ERROR;
+        QString sL = getStringValue( vL, parent );
+        ENSURE_NO_EVAL_ERROR;
+        QString sR = getStringValue( vR, parent );
+        ENSURE_NO_EVAL_ERROR;
         return QVariant( sL + sR );
       }
 
-    default: break;
+    default:
+      break;
   }
   Q_ASSERT( false );
   return QVariant();
@@ -3637,13 +3666,21 @@ bool QgsExpression::NodeBinaryOperator::compare( double diff )
 {
   switch ( mOp )
   {
-    case boEQ: return diff == 0;
-    case boNE: return diff != 0;
-    case boLT: return diff < 0;
-    case boGT: return diff > 0;
-    case boLE: return diff <= 0;
-    case boGE: return diff >= 0;
-    default: Q_ASSERT( false ); return false;
+    case boEQ:
+      return diff == 0;
+    case boNE:
+      return diff != 0;
+    case boLT:
+      return diff < 0;
+    case boGT:
+      return diff > 0;
+    case boLE:
+      return diff <= 0;
+    case boGE:
+      return diff >= 0;
+    default:
+      Q_ASSERT( false );
+      return false;
   }
 }
 
@@ -3651,12 +3688,19 @@ int QgsExpression::NodeBinaryOperator::computeInt( int x, int y )
 {
   switch ( mOp )
   {
-    case boPlus: return x+y;
-    case boMinus: return x-y;
-    case boMul: return x*y;
-    case boDiv: return x/y;
-    case boMod: return x%y;
-    default: Q_ASSERT( false ); return 0;
+    case boPlus:
+      return x + y;
+    case boMinus:
+      return x -y;
+    case boMul:
+      return x*y;
+    case boDiv:
+      return x / y;
+    case boMod:
+      return x % y;
+    default:
+      Q_ASSERT( false );
+      return 0;
   }
 }
 
@@ -3664,9 +3708,13 @@ QDateTime QgsExpression::NodeBinaryOperator::computeDateTimeFromInterval( const 
 {
   switch ( mOp )
   {
-    case boPlus: return d.addSecs( i->seconds() );
-    case boMinus: return d.addSecs( -i->seconds() );
-    default: Q_ASSERT( false ); return QDateTime();
+    case boPlus:
+      return d.addSecs( i->seconds() );
+    case boMinus:
+      return d.addSecs( -i->seconds() );
+    default:
+      Q_ASSERT( false );
+      return QDateTime();
   }
 }
 
@@ -3674,12 +3722,19 @@ double QgsExpression::NodeBinaryOperator::computeDouble( double x, double y )
 {
   switch ( mOp )
   {
-    case boPlus: return x+y;
-    case boMinus: return x-y;
-    case boMul: return x*y;
-    case boDiv: return x/y;
-    case boMod: return fmod( x,y );
-    default: Q_ASSERT( false ); return 0;
+    case boPlus:
+      return x + y;
+    case boMinus:
+      return x -y;
+    case boMul:
+      return x*y;
+    case boDiv:
+      return x / y;
+    case boMod:
+      return fmod( x, y );
+    default:
+      Q_ASSERT( false );
+      return 0;
   }
 }
 
@@ -3824,14 +3879,18 @@ QVariant QgsExpression::NodeInOperator::eval( QgsExpression *parent, const QgsEx
       // check whether they are equal
       if ( isDoubleSafe( v1 ) && isDoubleSafe( v2 ) )
       {
-        double f1 = getDoubleValue( v1, parent ); ENSURE_NO_EVAL_ERROR;
-        double f2 = getDoubleValue( v2, parent ); ENSURE_NO_EVAL_ERROR;
+        double f1 = getDoubleValue( v1, parent );
+        ENSURE_NO_EVAL_ERROR;
+        double f2 = getDoubleValue( v2, parent );
+        ENSURE_NO_EVAL_ERROR;
         equal = f1 == f2;
       }
       else
       {
-        QString s1 = getStringValue( v1, parent ); ENSURE_NO_EVAL_ERROR;
-        QString s2 = getStringValue( v2, parent ); ENSURE_NO_EVAL_ERROR;
+        QString s1 = getStringValue( v1, parent );
+        ENSURE_NO_EVAL_ERROR;
+        QString s2 = getStringValue( v2, parent );
+        ENSURE_NO_EVAL_ERROR;
         equal = QString::compare( s1, s2 ) == 0;
       }
 
@@ -3976,11 +4035,16 @@ QString QgsExpression::NodeLiteral::dump() const
 
   switch ( mValue.type() )
   {
-    case QVariant::Int: return QString::number( mValue.toInt() );
-    case QVariant::Double: return QString::number( mValue.toDouble() );
-    case QVariant::String: return quotedString( mValue.toString() );
-    case QVariant::Bool: return mValue.toBool() ? "TRUE" : "FALSE";
-    default: return tr( "[unsupported type;%1; value:%2]" ).arg( mValue.typeName(), mValue.toString() );
+    case QVariant::Int:
+      return QString::number( mValue.toInt() );
+    case QVariant::Double:
+      return QString::number( mValue.toDouble() );
+    case QVariant::String:
+      return quotedString( mValue.toString() );
+    case QVariant::Bool:
+      return mValue.toBool() ? "TRUE" : "FALSE";
+    default:
+      return tr( "[unsupported type;%1; value:%2]" ).arg( mValue.typeName(), mValue.toString() );
   }
 }
 

--- a/src/core/qgslabelingenginev2.cpp
+++ b/src/core/qgslabelingenginev2.cpp
@@ -72,13 +72,27 @@ void QgsLabelingEngineV2::processProvider( QgsAbstractLabelProvider* provider, Q
   pal::Arrangement arrangement;
   switch ( provider->placement() )
   {
-    case QgsPalLayerSettings::AroundPoint: arrangement = pal::P_POINT; break;
-    case QgsPalLayerSettings::OverPoint:   arrangement = pal::P_POINT_OVER; break;
-    case QgsPalLayerSettings::Line:        arrangement = pal::P_LINE; break;
-    case QgsPalLayerSettings::Curved:      arrangement = pal::P_CURVED; break;
-    case QgsPalLayerSettings::Horizontal:  arrangement = pal::P_HORIZ; break;
-    case QgsPalLayerSettings::Free:        arrangement = pal::P_FREE; break;
-    default: Q_ASSERT( "unsupported placement" && 0 ); return;
+    case QgsPalLayerSettings::AroundPoint:
+      arrangement = pal::P_POINT;
+      break;
+    case QgsPalLayerSettings::OverPoint:
+      arrangement = pal::P_POINT_OVER;
+      break;
+    case QgsPalLayerSettings::Line:
+      arrangement = pal::P_LINE;
+      break;
+    case QgsPalLayerSettings::Curved:
+      arrangement = pal::P_CURVED;
+      break;
+    case QgsPalLayerSettings::Horizontal:
+      arrangement = pal::P_HORIZ;
+      break;
+    case QgsPalLayerSettings::Free:
+      arrangement = pal::P_FREE;
+      break;
+    default:
+      Q_ASSERT( "unsupported placement" && 0 );
+      return;
   }
 
   QgsAbstractLabelProvider::Flags flags = provider->flags();
@@ -125,10 +139,18 @@ void QgsLabelingEngineV2::processProvider( QgsAbstractLabelProvider* provider, Q
   pal::Layer::UpsideDownLabels upsdnlabels;
   switch ( provider->upsidedownLabels() )
   {
-    case QgsPalLayerSettings::Upright:     upsdnlabels = pal::Layer::Upright; break;
-    case QgsPalLayerSettings::ShowDefined: upsdnlabels = pal::Layer::ShowDefined; break;
-    case QgsPalLayerSettings::ShowAll:     upsdnlabels = pal::Layer::ShowAll; break;
-    default: Q_ASSERT( "unsupported upside-down label setting" && 0 ); return;
+    case QgsPalLayerSettings::Upright:
+      upsdnlabels = pal::Layer::Upright;
+      break;
+    case QgsPalLayerSettings::ShowDefined:
+      upsdnlabels = pal::Layer::ShowDefined;
+      break;
+    case QgsPalLayerSettings::ShowAll:
+      upsdnlabels = pal::Layer::ShowAll;
+      break;
+    default:
+      Q_ASSERT( "unsupported upside-down label setting" && 0 );
+      return;
   }
   l->setUpsidedownLabels( upsdnlabels );
 
@@ -166,11 +188,21 @@ void QgsLabelingEngineV2::run( QgsRenderContext& context )
   switch ( mSearchMethod )
   {
     default:
-    case QgsPalLabeling::Chain: s = pal::CHAIN; break;
-    case QgsPalLabeling::Popmusic_Tabu: s = pal::POPMUSIC_TABU; break;
-    case QgsPalLabeling::Popmusic_Chain: s = pal::POPMUSIC_CHAIN; break;
-    case QgsPalLabeling::Popmusic_Tabu_Chain: s = pal::POPMUSIC_TABU_CHAIN; break;
-    case QgsPalLabeling::Falp: s = pal::FALP; break;
+    case QgsPalLabeling::Chain:
+      s = pal::CHAIN;
+      break;
+    case QgsPalLabeling::Popmusic_Tabu:
+      s = pal::POPMUSIC_TABU;
+      break;
+    case QgsPalLabeling::Popmusic_Chain:
+      s = pal::POPMUSIC_CHAIN;
+      break;
+    case QgsPalLabeling::Popmusic_Tabu_Chain:
+      s = pal::POPMUSIC_TABU_CHAIN;
+      break;
+    case QgsPalLabeling::Falp:
+      s = pal::FALP;
+      break;
   }
   p.setSearch( s );
 

--- a/src/core/qgslabelsearchtree.cpp
+++ b/src/core/qgslabelsearchtree.cpp
@@ -33,8 +33,12 @@ QgsLabelSearchTree::~QgsLabelSearchTree()
 
 void QgsLabelSearchTree::label( const QgsPoint& p, QList<QgsLabelPosition*>& posList ) const
 {
-  double c_min[2]; c_min[0] = p.x() - 0.1; c_min[1] = p.y() - 0.1;
-  double c_max[2]; c_max[0] = p.x() + 0.1; c_max[1] = p.y() + 0.1;
+  double c_min[2];
+  c_min[0] = p.x() - 0.1;
+  c_min[1] = p.y() - 0.1;
+  double c_max[2];
+  c_max[0] = p.x() + 0.1;
+  c_max[1] = p.y() + 0.1;
 
   QList<QgsLabelPosition*> searchResults;
   mSpatialIndex.Search( c_min, c_max, searchCallback, &searchResults );
@@ -53,8 +57,12 @@ void QgsLabelSearchTree::label( const QgsPoint& p, QList<QgsLabelPosition*>& pos
 
 void QgsLabelSearchTree::labelsInRect( const QgsRectangle& r, QList<QgsLabelPosition*>& posList ) const
 {
-  double c_min[2]; c_min[0] = r.xMinimum(); c_min[1] = r.yMinimum();
-  double c_max[2]; c_max[0] = r.xMaximum(); c_max[1] = r.yMaximum();
+  double c_min[2];
+  c_min[0] = r.xMinimum();
+  c_min[1] = r.yMinimum();
+  double c_max[2];
+  c_max[0] = r.xMaximum();
+  c_max[1] = r.yMaximum();
 
   QList<QgsLabelPosition*> searchResults;
   mSpatialIndex.Search( c_min, c_max, searchCallback, &searchResults );

--- a/src/core/qgslegendrenderer.cpp
+++ b/src/core/qgslegendrenderer.cpp
@@ -609,10 +609,17 @@ void QgsLegendRenderer::setNodeLegendStyle( QgsLayerTreeNode* node, QgsComposerL
   QString str;
   switch ( style )
   {
-    case QgsComposerLegendStyle::Hidden:   str = "hidden"; break;
-    case QgsComposerLegendStyle::Group:    str = "group"; break;
-    case QgsComposerLegendStyle::Subgroup: str = "subgroup"; break;
-    default: break; // nothing
+    case QgsComposerLegendStyle::Hidden:
+      str = "hidden";
+      break;
+    case QgsComposerLegendStyle::Group:
+      str = "group";
+      break;
+    case QgsComposerLegendStyle::Subgroup:
+      str = "subgroup";
+      break;
+    default:
+      break; // nothing
   }
 
   if ( !str.isEmpty() )

--- a/src/core/qgsmaptopixel.cpp
+++ b/src/core/qgsmaptopixel.cpp
@@ -323,14 +323,16 @@ void QgsMapToPixel::transformInPlace( double& x, double& y ) const
   qreal x_qreal = x, y_qreal = y;
   mMatrix.map( x_qreal, y_qreal, &mx, &my );
   //QgsDebugMsg(QString("XXX transformInPlace X : %1-->%2, Y: %3 -->%4").arg(x).arg(mx).arg(y).arg(my));
-  x = mx; y = my;
+  x = mx;
+  y = my;
 }
 
 void QgsMapToPixel::transformInPlace( float& x, float& y ) const
 {
   double mx = x, my = y;
   transformInPlace( mx, my );
-  x = mx; y = my;
+  x = mx;
+  y = my;
 }
 
 QTransform QgsMapToPixel::transform() const

--- a/src/core/qgsmaptopixelgeometrysimplifier.cpp
+++ b/src/core/qgsmaptopixelgeometrysimplifier.cpp
@@ -52,8 +52,10 @@ inline static QgsRectangle calculateBoundingBox( QGis::WkbType wkbType, const un
 
   for ( size_t i = 0; i < numPoints; ++i )
   {
-    memcpy( &x, wkb, sizeof( double ) ); wkb += sizeOfDoubleX;
-    memcpy( &y, wkb, sizeof( double ) ); wkb += sizeOfDoubleY;
+    memcpy( &x, wkb, sizeof( double ) );
+    wkb += sizeOfDoubleX;
+    memcpy( &y, wkb, sizeof( double ) );
+    wkb += sizeOfDoubleY;
     r.combineExtentWith( x, y );
   }
 
@@ -116,11 +118,15 @@ static bool generalizeWkbGeometryByBoundingBox(
     memcpy( targetWkb, &numPoints, 4 ); // numPoints;
     targetWkb += 4;
 
-    memcpy( targetWkb, &x1, sizeof( double ) ); targetWkb += sizeof( double );
-    memcpy( targetWkb, &y1, sizeof( double ) ); targetWkb += sizeof( double );
+    memcpy( targetWkb, &x1, sizeof( double ) );
+    targetWkb += sizeof( double );
+    memcpy( targetWkb, &y1, sizeof( double ) );
+    targetWkb += sizeof( double );
 
-    memcpy( targetWkb, &x2, sizeof( double ) ); targetWkb += sizeof( double );
-    memcpy( targetWkb, &y2, sizeof( double ) ); targetWkb += sizeof( double );
+    memcpy( targetWkb, &x2, sizeof( double ) );
+    targetWkb += sizeof( double );
+    memcpy( targetWkb, &y2, sizeof( double ) );
+    targetWkb += sizeof( double );
   }
   else
   {
@@ -128,20 +134,30 @@ static bool generalizeWkbGeometryByBoundingBox(
     memcpy( targetWkb, &numPoints, 4 ); // numPoints;
     targetWkb += 4;
 
-    memcpy( targetWkb, &x1, sizeof( double ) ); targetWkb += sizeof( double );
-    memcpy( targetWkb, &y1, sizeof( double ) ); targetWkb += sizeof( double );
+    memcpy( targetWkb, &x1, sizeof( double ) );
+    targetWkb += sizeof( double );
+    memcpy( targetWkb, &y1, sizeof( double ) );
+    targetWkb += sizeof( double );
 
-    memcpy( targetWkb, &x2, sizeof( double ) ); targetWkb += sizeof( double );
-    memcpy( targetWkb, &y1, sizeof( double ) ); targetWkb += sizeof( double );
+    memcpy( targetWkb, &x2, sizeof( double ) );
+    targetWkb += sizeof( double );
+    memcpy( targetWkb, &y1, sizeof( double ) );
+    targetWkb += sizeof( double );
 
-    memcpy( targetWkb, &x2, sizeof( double ) ); targetWkb += sizeof( double );
-    memcpy( targetWkb, &y2, sizeof( double ) ); targetWkb += sizeof( double );
+    memcpy( targetWkb, &x2, sizeof( double ) );
+    targetWkb += sizeof( double );
+    memcpy( targetWkb, &y2, sizeof( double ) );
+    targetWkb += sizeof( double );
 
-    memcpy( targetWkb, &x1, sizeof( double ) ); targetWkb += sizeof( double );
-    memcpy( targetWkb, &y2, sizeof( double ) ); targetWkb += sizeof( double );
+    memcpy( targetWkb, &x1, sizeof( double ) );
+    targetWkb += sizeof( double );
+    memcpy( targetWkb, &y2, sizeof( double ) );
+    targetWkb += sizeof( double );
 
-    memcpy( targetWkb, &x1, sizeof( double ) ); targetWkb += sizeof( double );
-    memcpy( targetWkb, &y1, sizeof( double ) ); targetWkb += sizeof( double );
+    memcpy( targetWkb, &x1, sizeof( double ) );
+    targetWkb += sizeof( double );
+    memcpy( targetWkb, &y1, sizeof( double ) );
+    targetWkb += sizeof( double );
   }
   targetWkbSize += targetWkb - wkb2;
 
@@ -245,8 +261,10 @@ bool QgsMapToPixelSimplifier::simplifyWkbGeometry(
     // Process each vertex...
     for ( int i = 0; i < numPoints; ++i )
     {
-      memcpy( &x, sourceWkb, sizeof( double ) ); sourceWkb += sizeOfDoubleX;
-      memcpy( &y, sourceWkb, sizeof( double ) ); sourceWkb += sizeOfDoubleY;
+      memcpy( &x, sourceWkb, sizeof( double ) );
+      sourceWkb += sizeOfDoubleX;
+      memcpy( &y, sourceWkb, sizeof( double ) );
+      sourceWkb += sizeOfDoubleY;
 
       isLongSegment = false;
 
@@ -255,8 +273,12 @@ bool QgsMapToPixelSimplifier::simplifyWkbGeometry(
            ( isLongSegment = ( calculateLengthSquared2D( x, y, lastX, lastY ) > map2pixelTol ) ) ||
            ( !isaLinearRing && ( i == 1 || i >= numPoints - 2 ) ) )
       {
-        memcpy( ptr, &x, sizeof( double ) ); lastX = x; ptr++;
-        memcpy( ptr, &y, sizeof( double ) ); lastY = y; ptr++;
+        memcpy( ptr, &x, sizeof( double ) );
+        lastX = x;
+        ptr++;
+        memcpy( ptr, &y, sizeof( double ) );
+        lastY = y;
+        ptr++;
         numTargetPoints++;
 
         hasLongSegments |= isLongSegment;
@@ -301,8 +323,10 @@ bool QgsMapToPixelSimplifier::simplifyWkbGeometry(
       memcpy( &y, targetWkb + sizeof( double ), sizeof( double ) );
       if ( lastX != x || lastY != y )
       {
-        memcpy( ptr, &x, sizeof( double ) ); ptr++;
-        memcpy( ptr, &y, sizeof( double ) ); ptr++;
+        memcpy( ptr, &x, sizeof( double ) );
+        ptr++;
+        memcpy( ptr, &y, sizeof( double ) );
+        ptr++;
         numTargetPoints++;
       }
     }

--- a/src/core/qgspallabeling.cpp
+++ b/src/core/qgspallabeling.cpp
@@ -2558,7 +2558,8 @@ void QgsPalLayerSettings::registerFeature( QgsFeature& f, QgsRenderContext &cont
           qreal xPosR, yPosR;
           qreal xPos_qreal = xPos, yPos_qreal = yPos;
           t.map( xPos_qreal, yPos_qreal, &xPosR, &yPosR );
-          xPos = xPosR; yPos = yPosR;
+          xPos = xPosR;
+          yPos = yPosR;
 
         }
 

--- a/src/core/qgspointlocator.cpp
+++ b/src/core/qgspointlocator.cpp
@@ -560,7 +560,8 @@ class QgsPointLocator_DumpTree : public SpatialIndex::IQueryStrategy
 
       if ( ! ids.empty() )
       {
-        nextEntry = ids.back(); ids.pop();
+        nextEntry = ids.back();
+        ids.pop();
         hasNext = true;
       }
       else

--- a/src/core/qgsrectangle.cpp
+++ b/src/core/qgsrectangle.cpp
@@ -376,8 +376,12 @@ bool QgsRectangle::isFinite() const
 void QgsRectangle::invert()
 {
   double tmp;
-  tmp = xmin; xmin = ymin; ymin = tmp;
-  tmp = xmax; xmax = ymax; ymax = tmp;
+  tmp = xmin;
+  xmin = ymin;
+  ymin = tmp;
+  tmp = xmax;
+  xmax = ymax;
+  ymax = tmp;
 }
 
 QDataStream& operator<<( QDataStream& out, const QgsRectangle& rectangle )

--- a/src/core/qgssnappingutils.cpp
+++ b/src/core/qgssnappingutils.cpp
@@ -323,12 +323,14 @@ void QgsSnappingUtils::prepareIndex( const QList<QgsVectorLayer*>& layers )
   if ( !layersToIndex.isEmpty() )
   {
     // build indexes
-    QTime t; t.start();
+    QTime t;
+    t.start();
     int i = 0;
     prepareIndexStarting( layersToIndex.count() );
     Q_FOREACH ( QgsVectorLayer* vl, layersToIndex )
     {
-      QTime tt; tt.start();
+      QTime tt;
+      tt.start();
       if ( !locatorForLayer( vl )->init( mStrategy == IndexHybrid ? 1000000 : -1 ) )
         mHybridNonindexableLayers.insert( vl->id() );
       QgsDebugMsg( QString( "Index init: %1 ms (%2)" ).arg( tt.elapsed() ).arg( vl->id() ) );

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -1738,7 +1738,8 @@ bool QgsVectorLayer::readSymbology( const QDomNode& node, QString& errorMessage 
     }
 
     //diagram renderer and diagram layer settings
-    delete mDiagramRenderer; mDiagramRenderer = nullptr;
+    delete mDiagramRenderer;
+    mDiagramRenderer = nullptr;
     QDomElement singleCatDiagramElem = node.firstChildElement( "SingleCategoryDiagramRenderer" );
     if ( !singleCatDiagramElem.isNull() )
     {

--- a/src/core/qgsvectorlayereditutils.cpp
+++ b/src/core/qgsvectorlayereditutils.cpp
@@ -301,8 +301,10 @@ int QgsVectorLayerEditUtils::splitFeatures( const QList<QgsPoint>& splitLine, bo
   {
     if ( boundingBoxFromPointList( splitLine, xMin, yMin, xMax, yMax ) == 0 )
     {
-      bBox.setXMinimum( xMin ); bBox.setYMinimum( yMin );
-      bBox.setXMaximum( xMax ); bBox.setYMaximum( yMax );
+      bBox.setXMinimum( xMin );
+      bBox.setYMinimum( yMin );
+      bBox.setXMaximum( xMax );
+      bBox.setYMaximum( yMax );
     }
     else
     {
@@ -433,8 +435,10 @@ int QgsVectorLayerEditUtils::splitParts( const QList<QgsPoint>& splitLine, bool 
   {
     if ( boundingBoxFromPointList( splitLine, xMin, yMin, xMax, yMax ) == 0 )
     {
-      bBox.setXMinimum( xMin ); bBox.setYMinimum( yMin );
-      bBox.setXMaximum( xMax ); bBox.setYMaximum( yMax );
+      bBox.setXMinimum( xMin );
+      bBox.setYMinimum( yMin );
+      bBox.setXMaximum( xMax );
+      bBox.setYMaximum( yMax );
     }
     else
     {

--- a/src/core/raster/qgscubicrasterresampler.cpp
+++ b/src/core/raster/qgscubicrasterresampler.cpp
@@ -191,10 +191,14 @@ void QgsCubicRasterResampler::resample( const QImage& srcImage, QImage& dstImage
       }
 
       //bernstein polynomials
-      bp0u = calcBernsteinPolyN3( 0, u ); bp1u = calcBernsteinPolyN3( 1, u );
-      bp2u = calcBernsteinPolyN3( 2, u ); bp3u = calcBernsteinPolyN3( 3, u );
-      bp0v = calcBernsteinPolyN3( 0, v ); bp1v = calcBernsteinPolyN3( 1, v );
-      bp2v = calcBernsteinPolyN3( 2, v ); bp3v = calcBernsteinPolyN3( 3, v );
+      bp0u = calcBernsteinPolyN3( 0, u );
+      bp1u = calcBernsteinPolyN3( 1, u );
+      bp2u = calcBernsteinPolyN3( 2, u );
+      bp3u = calcBernsteinPolyN3( 3, u );
+      bp0v = calcBernsteinPolyN3( 0, v );
+      bp1v = calcBernsteinPolyN3( 1, v );
+      bp2v = calcBernsteinPolyN3( 2, v );
+      bp3v = calcBernsteinPolyN3( 3, v );
 
       //then calculate value based on bernstein form of Bezier patch
       //todo: move into function
@@ -356,52 +360,100 @@ void QgsCubicRasterResampler::calculateControlPoints( int nCols, int nRows, int 
   int idx11 = idx01 + 1;
 
   //corner points
-  cRed00 = redMatrix[idx00]; cGreen00 = greenMatrix[idx00]; cBlue00 = blueMatrix[idx00]; cAlpha00 = alphaMatrix[idx00];
-  cRed30 = redMatrix[idx10]; cGreen30 = greenMatrix[idx10]; cBlue30 = blueMatrix[idx10]; cAlpha30 = alphaMatrix[idx10];
-  cRed03 = redMatrix[idx01]; cGreen03 = greenMatrix[idx01]; cBlue03 = blueMatrix[idx01]; cAlpha03 = alphaMatrix[idx01];
-  cRed33 = redMatrix[idx11]; cGreen33 = greenMatrix[idx11]; cBlue33 = blueMatrix[idx11]; cAlpha33 = alphaMatrix[idx11];
+  cRed00 = redMatrix[idx00];
+  cGreen00 = greenMatrix[idx00];
+  cBlue00 = blueMatrix[idx00];
+  cAlpha00 = alphaMatrix[idx00];
+  cRed30 = redMatrix[idx10];
+  cGreen30 = greenMatrix[idx10];
+  cBlue30 = blueMatrix[idx10];
+  cAlpha30 = alphaMatrix[idx10];
+  cRed03 = redMatrix[idx01];
+  cGreen03 = greenMatrix[idx01];
+  cBlue03 = blueMatrix[idx01];
+  cAlpha03 = alphaMatrix[idx01];
+  cRed33 = redMatrix[idx11];
+  cGreen33 = greenMatrix[idx11];
+  cBlue33 = blueMatrix[idx11];
+  cAlpha33 = alphaMatrix[idx11];
 
   //control points near c00
-  cRed10 = cRed00 + 0.333 * xDerivativeMatrixRed[idx00]; cGreen10 = cGreen00 + 0.333 * xDerivativeMatrixGreen[idx00];
-  cBlue10 = cBlue00 + 0.333 * xDerivativeMatrixBlue[idx00];cAlpha10 = cAlpha00 + 0.333 * xDerivativeMatrixAlpha[idx00];
-  cRed01 = cRed00 + 0.333 * yDerivativeMatrixRed[idx00]; cGreen01 = cGreen00 + 0.333 * yDerivativeMatrixGreen[idx00];
-  cBlue01 = cBlue00 + 0.333 * yDerivativeMatrixBlue[idx00];cAlpha01 = cAlpha00 + 0.333 * yDerivativeMatrixAlpha[idx00];
-  cRed11 = cRed10 + 0.333 * yDerivativeMatrixRed[idx00]; cGreen11 = cGreen10 + 0.333 * yDerivativeMatrixGreen[idx00];
-  cBlue11 = cBlue10 + 0.333 * yDerivativeMatrixBlue[idx00];cAlpha11 = cAlpha10 + 0.333 * yDerivativeMatrixAlpha[idx00];
+  cRed10 = cRed00 + 0.333 * xDerivativeMatrixRed[idx00];
+  cGreen10 = cGreen00 + 0.333 * xDerivativeMatrixGreen[idx00];
+  cBlue10 = cBlue00 + 0.333 * xDerivativeMatrixBlue[idx00];
+  cAlpha10 = cAlpha00 + 0.333 * xDerivativeMatrixAlpha[idx00];
+  cRed01 = cRed00 + 0.333 * yDerivativeMatrixRed[idx00];
+  cGreen01 = cGreen00 + 0.333 * yDerivativeMatrixGreen[idx00];
+  cBlue01 = cBlue00 + 0.333 * yDerivativeMatrixBlue[idx00];
+  cAlpha01 = cAlpha00 + 0.333 * yDerivativeMatrixAlpha[idx00];
+  cRed11 = cRed10 + 0.333 * yDerivativeMatrixRed[idx00];
+  cGreen11 = cGreen10 + 0.333 * yDerivativeMatrixGreen[idx00];
+  cBlue11 = cBlue10 + 0.333 * yDerivativeMatrixBlue[idx00];
+  cAlpha11 = cAlpha10 + 0.333 * yDerivativeMatrixAlpha[idx00];
 
   //control points near c30
-  cRed20 = cRed30 - 0.333 * xDerivativeMatrixRed[idx10]; cGreen20 = cGreen30 - 0.333 * xDerivativeMatrixGreen[idx10];
-  cBlue20 = cBlue30 - 0.333 * xDerivativeMatrixBlue[idx10]; cAlpha20 = cAlpha30 - 0.333 * xDerivativeMatrixAlpha[idx10];
-  cRed31 = cRed30 + 0.333 * yDerivativeMatrixRed[idx10]; cGreen31 = cGreen30 + 0.333 * yDerivativeMatrixGreen[idx10];
-  cBlue31 = cBlue30 + 0.333 * yDerivativeMatrixBlue[idx10]; cAlpha31 = cAlpha30 + 0.333 * yDerivativeMatrixAlpha[idx10];
-  cRed21 = cRed20 + 0.333 * yDerivativeMatrixRed[idx10]; cGreen21 = cGreen20 + 0.333 * yDerivativeMatrixGreen[idx10];
-  cBlue21 = cBlue20 + 0.333 * yDerivativeMatrixBlue[idx10]; cAlpha21 = cAlpha20 + 0.333 * yDerivativeMatrixAlpha[idx10];
+  cRed20 = cRed30 - 0.333 * xDerivativeMatrixRed[idx10];
+  cGreen20 = cGreen30 - 0.333 * xDerivativeMatrixGreen[idx10];
+  cBlue20 = cBlue30 - 0.333 * xDerivativeMatrixBlue[idx10];
+  cAlpha20 = cAlpha30 - 0.333 * xDerivativeMatrixAlpha[idx10];
+  cRed31 = cRed30 + 0.333 * yDerivativeMatrixRed[idx10];
+  cGreen31 = cGreen30 + 0.333 * yDerivativeMatrixGreen[idx10];
+  cBlue31 = cBlue30 + 0.333 * yDerivativeMatrixBlue[idx10];
+  cAlpha31 = cAlpha30 + 0.333 * yDerivativeMatrixAlpha[idx10];
+  cRed21 = cRed20 + 0.333 * yDerivativeMatrixRed[idx10];
+  cGreen21 = cGreen20 + 0.333 * yDerivativeMatrixGreen[idx10];
+  cBlue21 = cBlue20 + 0.333 * yDerivativeMatrixBlue[idx10];
+  cAlpha21 = cAlpha20 + 0.333 * yDerivativeMatrixAlpha[idx10];
 
   //control points near c03
-  cRed13 = cRed03 + 0.333 * xDerivativeMatrixRed[idx01]; cGreen13 = cGreen03 + 0.333 * xDerivativeMatrixGreen[idx01];
-  cBlue13 = cBlue03 + 0.333 * xDerivativeMatrixBlue[idx01]; cAlpha13 = cAlpha03 + 0.333 * xDerivativeMatrixAlpha[idx01];
-  cRed02 = cRed03 - 0.333 * yDerivativeMatrixRed[idx01]; cGreen02 = cGreen03 - 0.333 * yDerivativeMatrixGreen[idx01];
-  cBlue02 = cBlue03 - 0.333 * yDerivativeMatrixBlue[idx01]; cAlpha02 = cAlpha03 - 0.333 * yDerivativeMatrixAlpha[idx01];
-  cRed12 = cRed02 + 0.333 * xDerivativeMatrixRed[idx01]; cGreen12 = cGreen02 + 0.333 * xDerivativeMatrixGreen[idx01];
-  cBlue12 = cBlue02 + 0.333 * xDerivativeMatrixBlue[idx01]; cAlpha12 = cAlpha02 + 0.333 * xDerivativeMatrixAlpha[idx01];
+  cRed13 = cRed03 + 0.333 * xDerivativeMatrixRed[idx01];
+  cGreen13 = cGreen03 + 0.333 * xDerivativeMatrixGreen[idx01];
+  cBlue13 = cBlue03 + 0.333 * xDerivativeMatrixBlue[idx01];
+  cAlpha13 = cAlpha03 + 0.333 * xDerivativeMatrixAlpha[idx01];
+  cRed02 = cRed03 - 0.333 * yDerivativeMatrixRed[idx01];
+  cGreen02 = cGreen03 - 0.333 * yDerivativeMatrixGreen[idx01];
+  cBlue02 = cBlue03 - 0.333 * yDerivativeMatrixBlue[idx01];
+  cAlpha02 = cAlpha03 - 0.333 * yDerivativeMatrixAlpha[idx01];
+  cRed12 = cRed02 + 0.333 * xDerivativeMatrixRed[idx01];
+  cGreen12 = cGreen02 + 0.333 * xDerivativeMatrixGreen[idx01];
+  cBlue12 = cBlue02 + 0.333 * xDerivativeMatrixBlue[idx01];
+  cAlpha12 = cAlpha02 + 0.333 * xDerivativeMatrixAlpha[idx01];
 
   //control points near c33
-  cRed23 = cRed33 - 0.333 * xDerivativeMatrixRed[idx11]; cGreen23 = cGreen33 - 0.333 * xDerivativeMatrixGreen[idx11];
-  cBlue23 = cBlue33 - 0.333 * xDerivativeMatrixBlue[idx11]; cAlpha23 = cAlpha33 - 0.333 * xDerivativeMatrixAlpha[idx11];
-  cRed32 = cRed33 - 0.333 * yDerivativeMatrixRed[idx11]; cGreen32 = cGreen33 - 0.333 * yDerivativeMatrixGreen[idx11];
-  cBlue32 = cBlue33 - 0.333 * yDerivativeMatrixBlue[idx11]; cAlpha32 = cAlpha33 - 0.333 * yDerivativeMatrixAlpha[idx11];
-  cRed22 = cRed32 - 0.333 * xDerivativeMatrixRed[idx11]; cGreen22 = cGreen32 - 0.333 * xDerivativeMatrixGreen[idx11];
-  cBlue22 = cBlue32 - 0.333 * xDerivativeMatrixBlue[idx11]; cAlpha22 = cAlpha32 - 0.333 * xDerivativeMatrixAlpha[idx11];
+  cRed23 = cRed33 - 0.333 * xDerivativeMatrixRed[idx11];
+  cGreen23 = cGreen33 - 0.333 * xDerivativeMatrixGreen[idx11];
+  cBlue23 = cBlue33 - 0.333 * xDerivativeMatrixBlue[idx11];
+  cAlpha23 = cAlpha33 - 0.333 * xDerivativeMatrixAlpha[idx11];
+  cRed32 = cRed33 - 0.333 * yDerivativeMatrixRed[idx11];
+  cGreen32 = cGreen33 - 0.333 * yDerivativeMatrixGreen[idx11];
+  cBlue32 = cBlue33 - 0.333 * yDerivativeMatrixBlue[idx11];
+  cAlpha32 = cAlpha33 - 0.333 * yDerivativeMatrixAlpha[idx11];
+  cRed22 = cRed32 - 0.333 * xDerivativeMatrixRed[idx11];
+  cGreen22 = cGreen32 - 0.333 * xDerivativeMatrixGreen[idx11];
+  cBlue22 = cBlue32 - 0.333 * xDerivativeMatrixBlue[idx11];
+  cAlpha22 = cAlpha32 - 0.333 * xDerivativeMatrixAlpha[idx11];
 }
 
 QRgb QgsCubicRasterResampler::curveInterpolation( QRgb pt1, QRgb pt2, double t, double d1red, double d1green, double d1blue, double d1alpha,
     double d2red, double d2green, double d2blue, double d2alpha )
 {
   //control points
-  double p0r = qRed( pt1 ); double p1r = p0r + 0.333 * d1red; double p3r = qRed( pt2 ); double p2r = p3r - 0.333 * d2red;
-  double p0g = qGreen( pt1 ); double p1g = p0g + 0.333 * d1green; double p3g = qGreen( pt2 ); double p2g = p3g - 0.333 * d2green;
-  double p0b = qBlue( pt1 ); double p1b = p0b + 0.333 * d1blue; double p3b = qBlue( pt2 ); double p2b = p3b - 0.333 * d2blue;
-  double p0a = qAlpha( pt1 ); double p1a = p0a + 0.333 * d1alpha; double p3a = qAlpha( pt2 ); double p2a = p3a - 0.333 * d2alpha;
+  double p0r = qRed( pt1 );
+  double p1r = p0r + 0.333 * d1red;
+  double p3r = qRed( pt2 );
+  double p2r = p3r - 0.333 * d2red;
+  double p0g = qGreen( pt1 );
+  double p1g = p0g + 0.333 * d1green;
+  double p3g = qGreen( pt2 );
+  double p2g = p3g - 0.333 * d2green;
+  double p0b = qBlue( pt1 );
+  double p1b = p0b + 0.333 * d1blue;
+  double p3b = qBlue( pt2 );
+  double p2b = p3b - 0.333 * d2blue;
+  double p0a = qAlpha( pt1 );
+  double p1a = p0a + 0.333 * d1alpha;
+  double p3a = qAlpha( pt2 );
+  double p2a = p3a - 0.333 * d2alpha;
 
   //bernstein polynomials
   double bp0 = calcBernsteinPolyN3( 0, t );

--- a/src/core/raster/qgscubicrasterresampler.h
+++ b/src/core/raster/qgscubicrasterresampler.h
@@ -55,17 +55,73 @@ class CORE_EXPORT QgsCubicRasterResampler: public QgsRasterResampler
     //control points
 
     //red
-    double cRed00; double cRed10; double cRed20; double cRed30; double cRed01; double cRed11; double cRed21; double cRed31;
-    double cRed02; double cRed12; double cRed22; double cRed32; double cRed03; double cRed13; double cRed23; double cRed33;
+    double cRed00;
+    double cRed10;
+    double cRed20;
+    double cRed30;
+    double cRed01;
+    double cRed11;
+    double cRed21;
+    double cRed31;
+    double cRed02;
+    double cRed12;
+    double cRed22;
+    double cRed32;
+    double cRed03;
+    double cRed13;
+    double cRed23;
+    double cRed33;
     //green
-    double cGreen00; double cGreen10; double cGreen20; double cGreen30; double cGreen01; double cGreen11; double cGreen21; double cGreen31;
-    double cGreen02; double cGreen12; double cGreen22; double cGreen32; double cGreen03; double cGreen13; double cGreen23; double cGreen33;
+    double cGreen00;
+    double cGreen10;
+    double cGreen20;
+    double cGreen30;
+    double cGreen01;
+    double cGreen11;
+    double cGreen21;
+    double cGreen31;
+    double cGreen02;
+    double cGreen12;
+    double cGreen22;
+    double cGreen32;
+    double cGreen03;
+    double cGreen13;
+    double cGreen23;
+    double cGreen33;
     //blue
-    double cBlue00; double cBlue10; double cBlue20; double cBlue30; double cBlue01; double cBlue11; double cBlue21; double cBlue31;
-    double cBlue02; double cBlue12; double cBlue22; double cBlue32; double cBlue03; double cBlue13; double cBlue23; double cBlue33;
+    double cBlue00;
+    double cBlue10;
+    double cBlue20;
+    double cBlue30;
+    double cBlue01;
+    double cBlue11;
+    double cBlue21;
+    double cBlue31;
+    double cBlue02;
+    double cBlue12;
+    double cBlue22;
+    double cBlue32;
+    double cBlue03;
+    double cBlue13;
+    double cBlue23;
+    double cBlue33;
     //alpha
-    double cAlpha00; double cAlpha10; double cAlpha20; double cAlpha30; double cAlpha01; double cAlpha11; double cAlpha21; double cAlpha31;
-    double cAlpha02; double cAlpha12; double cAlpha22; double cAlpha32; double cAlpha03; double cAlpha13; double cAlpha23; double cAlpha33;
+    double cAlpha00;
+    double cAlpha10;
+    double cAlpha20;
+    double cAlpha30;
+    double cAlpha01;
+    double cAlpha11;
+    double cAlpha21;
+    double cAlpha31;
+    double cAlpha02;
+    double cAlpha12;
+    double cAlpha22;
+    double cAlpha32;
+    double cAlpha03;
+    double cAlpha13;
+    double cAlpha23;
+    double cAlpha33;
 
 
 };

--- a/src/core/raster/qgsmultibandcolorrenderer.cpp
+++ b/src/core/raster/qgsmultibandcolorrenderer.cpp
@@ -64,17 +64,20 @@ QgsMultiBandColorRenderer* QgsMultiBandColorRenderer::clone() const
 
 void QgsMultiBandColorRenderer::setRedContrastEnhancement( QgsContrastEnhancement* ce )
 {
-  delete mRedContrastEnhancement; mRedContrastEnhancement = ce;
+  delete mRedContrastEnhancement;
+  mRedContrastEnhancement = ce;
 }
 
 void QgsMultiBandColorRenderer::setGreenContrastEnhancement( QgsContrastEnhancement* ce )
 {
-  delete mGreenContrastEnhancement; mGreenContrastEnhancement = ce;
+  delete mGreenContrastEnhancement;
+  mGreenContrastEnhancement = ce;
 }
 
 void QgsMultiBandColorRenderer::setBlueContrastEnhancement( QgsContrastEnhancement* ce )
 {
-  delete mBlueContrastEnhancement; mBlueContrastEnhancement = ce;
+  delete mBlueContrastEnhancement;
+  mBlueContrastEnhancement = ce;
 }
 
 QgsRasterRenderer* QgsMultiBandColorRenderer::create( const QDomElement& elem, QgsRasterInterface* input )

--- a/src/core/raster/qgsrasterdataprovider.h
+++ b/src/core/raster/qgsrasterdataprovider.h
@@ -269,8 +269,10 @@ class CORE_EXPORT QgsRasterDataProvider : public QgsDataProvider, public QgsRast
                                    QgsRaster::RasterPyramidsFormat theFormat = QgsRaster::PyramidsGTiff,
                                    const QStringList & theConfigOptions = QStringList() )
     {
-      Q_UNUSED( thePyramidList ); Q_UNUSED( theResamplingMethod );
-      Q_UNUSED( theFormat ); Q_UNUSED( theConfigOptions );
+      Q_UNUSED( thePyramidList );
+      Q_UNUSED( theResamplingMethod );
+      Q_UNUSED( theFormat );
+      Q_UNUSED( theConfigOptions );
       return "FAILED_NOT_SUPPORTED";
     }
 

--- a/src/core/raster/qgsrasterdrawer.cpp
+++ b/src/core/raster/qgsrasterdrawer.cpp
@@ -140,11 +140,13 @@ void QgsRasterDrawer::drawImage( QPainter* p, QgsRasterViewPort* viewPort, const
   p->drawLine( QLineF( br.x(), br.y(), br.x() + br.width(), br.y() + br.height() ) );
   p->drawLine( QLineF( br.x() + br.width(), br.y(), br.x(), br.y() + br.height() ) );
 
-  double nw = br.width() * 0.5; double nh = br.height() * 0.5;
+  double nw = br.width() * 0.5;
+  double nh = br.height() * 0.5;
   br = QRectF( c - QPointF( nw / 2, nh / 2 ), QSize( nw, nh ) );
   p->drawRoundedRect( br, rad, rad );
 
-  nw = br.width() * 0.5; nh = br.height() * 0.5;
+  nw = br.width() * 0.5;
+  nh = br.height() * 0.5;
   br = QRectF( c - QPointF( nw / 2, nh / 2 ), QSize( nw, nh ) );
   p->drawRoundedRect( br, rad, rad );
 #endif

--- a/src/core/raster/qgsrasterfilewriter.cpp
+++ b/src/core/raster/qgsrasterfilewriter.cpp
@@ -540,7 +540,9 @@ QgsRasterFileWriter::WriterError QgsRasterFileWriter::writeImageRaster( QgsRaste
     {
       QRgb c = inputBlock->color( i );
       alpha = qAlpha( c );
-      red = qRed( c ); green = qGreen( c ); blue = qBlue( c );
+      red = qRed( c );
+      green = qGreen( c );
+      blue = qBlue( c );
 
       if ( inputDataType == QGis::ARGB32_Premultiplied )
       {
@@ -595,7 +597,10 @@ QgsRasterFileWriter::WriterError QgsRasterFileWriter::writeImageRaster( QgsRaste
   if ( destProvider )
     delete destProvider;
 
-  qgsFree( redData ); qgsFree( greenData ); qgsFree( blueData ); qgsFree( alphaData );
+  qgsFree( redData );
+  qgsFree( greenData );
+  qgsFree( blueData );
+  qgsFree( alphaData );
 
   if ( progressDialog )
   {

--- a/src/core/raster/qgsrasterprojector.h
+++ b/src/core/raster/qgsrasterprojector.h
@@ -103,7 +103,8 @@ class CORE_EXPORT QgsRasterProjector : public QgsRasterInterface
     /** \brief set maximum source resolution */
     void setMaxSrcRes( double theMaxSrcXRes, double theMaxSrcYRes )
     {
-      mMaxSrcXRes = theMaxSrcXRes; mMaxSrcYRes = theMaxSrcYRes;
+      mMaxSrcXRes = theMaxSrcXRes;
+      mMaxSrcYRes = theMaxSrcYRes;
     }
 
     Precision precision() const { return mPrecision; }

--- a/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.cpp
+++ b/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.cpp
@@ -1700,8 +1700,10 @@ const char * QgsGraduatedSymbolRendererV2::graduatedMethodStr( GraduatedMethod m
 {
   switch ( method )
   {
-    case GraduatedColor: return "GraduatedColor";
-    case GraduatedSize: return "GraduatedSize";
+    case GraduatedColor:
+      return "GraduatedColor";
+    case GraduatedSize:
+      return "GraduatedSize";
   }
   return "";
 }

--- a/src/core/symbology-ng/qgslinesymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgslinesymbollayerv2.cpp
@@ -1053,12 +1053,14 @@ void QgsMarkerLineSymbolLayerV2::renderPolylineVertex( const QPolygonF& points, 
           || ( placement == CurvePoint && vId.type == QgsVertexId::CurveVertex ) )
       {
         //transform
-        x = vPoint.x(), y = vPoint.y(); z = vPoint.z();
+        x = vPoint.x(), y = vPoint.y();
+        z = vPoint.z();
         if ( ct )
         {
           ct->transformInPlace( x, y, z );
         }
-        mapPoint.setX( x ); mapPoint.setY( y );
+        mapPoint.setX( x );
+        mapPoint.setY( y );
         mtp.transformInPlace( mapPoint.rx(), mapPoint.ry() );
         if ( mRotateMarker )
         {

--- a/src/core/symbology-ng/qgsrendererv2.cpp
+++ b/src/core/symbology-ng/qgsrendererv2.cpp
@@ -80,7 +80,8 @@ const unsigned char* QgsFeatureRendererV2::_getLineString( QPolygonF& pts, QgsRe
   if ( clipToExtent && nPoints > 1 )
   {
     const QgsRectangle& e = context.extent();
-    double cw = e.width() / 10; double ch = e.height() / 10;
+    double cw = e.width() / 10;
+    double ch = e.height() / 10;
     QgsRectangle clipRect( e.xMinimum() - cw, e.yMinimum() - ch, e.xMaximum() + cw, e.yMaximum() + ch );
     wkbPtr = QgsConstWkbPtr( QgsClipper::clippedLineWKB( wkb, clipRect, pts ) );
   }
@@ -135,7 +136,8 @@ const unsigned char* QgsFeatureRendererV2::_getPolygon( QPolygonF& pts, QList<QP
   const QgsCoordinateTransform* ct = context.coordinateTransform();
   const QgsMapToPixel& mtp = context.mapToPixel();
   const QgsRectangle& e = context.extent();
-  double cw = e.width() / 10; double ch = e.height() / 10;
+  double cw = e.width() / 10;
+  double ch = e.height() / 10;
   QgsRectangle clipRect( e.xMinimum() - cw, e.yMinimum() - ch, e.xMaximum() + cw, e.yMaximum() + ch );
 
   for ( unsigned int idx = 0; idx < numRings; idx++ )

--- a/src/core/symbology-ng/qgssymbollayerv2utils.cpp
+++ b/src/core/symbology-ng/qgssymbollayerv2utils.cpp
@@ -83,10 +83,14 @@ QString QgsSymbolLayerV2Utils::encodeSldFontStyle( QFont::Style style )
 {
   switch ( style )
   {
-    case QFont::StyleNormal:  return "normal";
-    case QFont::StyleItalic:  return "italic";
-    case QFont::StyleOblique: return "oblique";
-    default: return "";
+    case QFont::StyleNormal:
+      return "normal";
+    case QFont::StyleItalic:
+      return "italic";
+    case QFont::StyleOblique:
+      return "oblique";
+    default:
+      return "";
   }
 }
 
@@ -128,13 +132,20 @@ QString QgsSymbolLayerV2Utils::encodePenStyle( Qt::PenStyle style )
 {
   switch ( style )
   {
-    case Qt::NoPen:          return "no";
-    case Qt::SolidLine:      return "solid";
-    case Qt::DashLine:       return "dash";
-    case Qt::DotLine:        return "dot";
-    case Qt::DashDotLine:    return "dash dot";
-    case Qt::DashDotDotLine: return "dash dot dot";
-    default: return "???";
+    case Qt::NoPen:
+      return "no";
+    case Qt::SolidLine:
+      return "solid";
+    case Qt::DashLine:
+      return "dash";
+    case Qt::DotLine:
+      return "dot";
+    case Qt::DashDotLine:
+      return "dash dot";
+    case Qt::DashDotDotLine:
+      return "dash dot dot";
+    default:
+      return "???";
   }
 }
 
@@ -153,10 +164,14 @@ QString QgsSymbolLayerV2Utils::encodePenJoinStyle( Qt::PenJoinStyle style )
 {
   switch ( style )
   {
-    case Qt::BevelJoin: return "bevel";
-    case Qt::MiterJoin: return "miter";
-    case Qt::RoundJoin: return "round";
-    default: return "???";
+    case Qt::BevelJoin:
+      return "bevel";
+    case Qt::MiterJoin:
+      return "miter";
+    case Qt::RoundJoin:
+      return "round";
+    default:
+      return "???";
   }
 }
 
@@ -172,10 +187,14 @@ QString QgsSymbolLayerV2Utils::encodeSldLineJoinStyle( Qt::PenJoinStyle style )
 {
   switch ( style )
   {
-    case Qt::BevelJoin: return "bevel";
-    case Qt::MiterJoin: return "mitre";
-    case Qt::RoundJoin: return "round";
-    default: return "";
+    case Qt::BevelJoin:
+      return "bevel";
+    case Qt::MiterJoin:
+      return "mitre";
+    case Qt::RoundJoin:
+      return "round";
+    default:
+      return "";
   }
 }
 
@@ -191,10 +210,14 @@ QString QgsSymbolLayerV2Utils::encodePenCapStyle( Qt::PenCapStyle style )
 {
   switch ( style )
   {
-    case Qt::SquareCap: return "square";
-    case Qt::FlatCap:   return "flat";
-    case Qt::RoundCap:  return "round";
-    default: return "???";
+    case Qt::SquareCap:
+      return "square";
+    case Qt::FlatCap:
+      return "flat";
+    case Qt::RoundCap:
+      return "round";
+    default:
+      return "???";
   }
 }
 
@@ -210,10 +233,14 @@ QString QgsSymbolLayerV2Utils::encodeSldLineCapStyle( Qt::PenCapStyle style )
 {
   switch ( style )
   {
-    case Qt::SquareCap: return "square";
-    case Qt::FlatCap:   return "butt";
-    case Qt::RoundCap:  return "round";
-    default: return "";
+    case Qt::SquareCap:
+      return "square";
+    case Qt::FlatCap:
+      return "butt";
+    case Qt::RoundCap:
+      return "round";
+    default:
+      return "";
   }
 }
 
@@ -229,22 +256,38 @@ QString QgsSymbolLayerV2Utils::encodeBrushStyle( Qt::BrushStyle style )
 {
   switch ( style )
   {
-    case Qt::SolidPattern : return "solid";
-    case Qt::HorPattern : return "horizontal";
-    case Qt::VerPattern : return "vertical";
-    case Qt::CrossPattern : return "cross";
-    case Qt::BDiagPattern : return "b_diagonal";
-    case Qt::FDiagPattern : return  "f_diagonal";
-    case Qt::DiagCrossPattern : return "diagonal_x";
-    case Qt::Dense1Pattern  : return "dense1";
-    case Qt::Dense2Pattern  : return "dense2";
-    case Qt::Dense3Pattern  : return "dense3";
-    case Qt::Dense4Pattern  : return "dense4";
-    case Qt::Dense5Pattern  : return "dense5";
-    case Qt::Dense6Pattern  : return "dense6";
-    case Qt::Dense7Pattern  : return "dense7";
-    case Qt::NoBrush : return "no";
-    default: return "???";
+    case Qt::SolidPattern :
+      return "solid";
+    case Qt::HorPattern :
+      return "horizontal";
+    case Qt::VerPattern :
+      return "vertical";
+    case Qt::CrossPattern :
+      return "cross";
+    case Qt::BDiagPattern :
+      return "b_diagonal";
+    case Qt::FDiagPattern :
+      return  "f_diagonal";
+    case Qt::DiagCrossPattern :
+      return "diagonal_x";
+    case Qt::Dense1Pattern  :
+      return "dense1";
+    case Qt::Dense2Pattern  :
+      return "dense2";
+    case Qt::Dense3Pattern  :
+      return "dense3";
+    case Qt::Dense4Pattern  :
+      return "dense4";
+    case Qt::Dense5Pattern  :
+      return "dense5";
+    case Qt::Dense6Pattern  :
+      return "dense6";
+    case Qt::Dense7Pattern  :
+      return "dense7";
+    case Qt::NoBrush :
+      return "no";
+    default:
+      return "???";
   }
 }
 
@@ -272,17 +315,23 @@ QString QgsSymbolLayerV2Utils::encodeSldBrushStyle( Qt::BrushStyle style )
 {
   switch ( style )
   {
-    case Qt::CrossPattern: return "cross";
-    case Qt::DiagCrossPattern: return "x";
+    case Qt::CrossPattern:
+      return "cross";
+    case Qt::DiagCrossPattern:
+      return "x";
 
       /* The following names are taken from the presentation "GeoServer
        * Cartographic Rendering" by Andrea Aime at the FOSS4G 2010.
        * (see http://2010.foss4g.org/presentations/3588.pdf)
        */
-    case Qt::HorPattern: return "horline";
-    case Qt::VerPattern: return "line";
-    case Qt::BDiagPattern: return "slash";
-    case Qt::FDiagPattern: return "backslash";
+    case Qt::HorPattern:
+      return "horline";
+    case Qt::VerPattern:
+      return "line";
+    case Qt::BDiagPattern:
+      return "slash";
+    case Qt::FDiagPattern:
+      return "backslash";
 
       /* define the other names following the same pattern used above */
     case Qt::Dense1Pattern:
@@ -701,8 +750,12 @@ static QPointF linesIntersection( QPointF p1, double t1, QPointF p2, double t2 )
     // swap them so that line 2 is with undefined tangent
     if ( t1 == DBL_MAX )
     {
-      QPointF pSwp = p1; p1 = p2; p2 = pSwp;
-      double  tSwp = t1; t1 = t2; t2 = tSwp;
+      QPointF pSwp = p1;
+      p1 = p2;
+      p2 = pSwp;
+      double  tSwp = t1;
+      t1 = t2;
+      t2 = tSwp;
     }
 
     x = p2.x();
@@ -999,10 +1052,14 @@ static QString _nameForSymbolType( QgsSymbolV2::SymbolType type )
 {
   switch ( type )
   {
-    case QgsSymbolV2::Line: return "line";
-    case QgsSymbolV2::Marker: return "marker";
-    case QgsSymbolV2::Fill: return "fill";
-    default: return "";
+    case QgsSymbolV2::Line:
+      return "line";
+    case QgsSymbolV2::Marker:
+      return "marker";
+    case QgsSymbolV2::Fill:
+      return "fill";
+    default:
+      return "";
   }
 }
 

--- a/src/core/symbology-ng/qgssymbolv2.cpp
+++ b/src/core/symbology-ng/qgssymbolv2.cpp
@@ -124,7 +124,8 @@ const unsigned char* QgsSymbolV2::_getLineString( QPolygonF& pts, QgsRenderConte
   if ( clipToExtent && nPoints > 1 )
   {
     const QgsRectangle& e = context.extent();
-    double cw = e.width() / 10; double ch = e.height() / 10;
+    double cw = e.width() / 10;
+    double ch = e.height() / 10;
     QgsRectangle clipRect( e.xMinimum() - cw, e.yMinimum() - ch, e.xMaximum() + cw, e.yMaximum() + ch );
     wkbPtr = QgsConstWkbPtr( QgsClipper::clippedLineWKB( wkb, clipRect, pts ) );
   }
@@ -179,7 +180,8 @@ const unsigned char* QgsSymbolV2::_getPolygon( QPolygonF& pts, QList<QPolygonF>&
   const QgsCoordinateTransform* ct = context.coordinateTransform();
   const QgsMapToPixel& mtp = context.mapToPixel();
   const QgsRectangle& e = context.extent();
-  double cw = e.width() / 10; double ch = e.height() / 10;
+  double cw = e.width() / 10;
+  double ch = e.height() / 10;
   QgsRectangle clipRect( e.xMinimum() - cw, e.yMinimum() - ch, e.xMaximum() + cw, e.yMaximum() + ch );
 
   for ( unsigned int idx = 0; idx < numRings; idx++ )
@@ -315,7 +317,9 @@ QgsSymbolV2* QgsSymbolV2::defaultSymbol( QGis::GeometryType geomType )
     case QGis::Polygon :
       defaultSymbol = QgsProject::instance()->readEntry( "DefaultStyles", "/Fill", "" );
       break;
-    default: defaultSymbol = ""; break;
+    default:
+      defaultSymbol = "";
+      break;
   }
   if ( defaultSymbol != "" )
     s = QgsStyleV2::defaultStyle()->symbol( defaultSymbol );
@@ -325,10 +329,18 @@ QgsSymbolV2* QgsSymbolV2::defaultSymbol( QGis::GeometryType geomType )
   {
     switch ( geomType )
     {
-      case QGis::Point: s = new QgsMarkerSymbolV2(); break;
-      case QGis::Line:  s = new QgsLineSymbolV2(); break;
-      case QGis::Polygon: s = new QgsFillSymbolV2(); break;
-      default: QgsDebugMsg( "unknown layer's geometry type" ); return nullptr;
+      case QGis::Point:
+        s = new QgsMarkerSymbolV2();
+        break;
+      case QGis::Line:
+        s = new QgsLineSymbolV2();
+        break;
+      case QGis::Polygon:
+        s = new QgsFillSymbolV2();
+        break;
+      default:
+        QgsDebugMsg( "unknown layer's geometry type" );
+        return nullptr;
     }
   }
 
@@ -570,10 +582,17 @@ QString QgsSymbolV2::dump() const
   QString t;
   switch ( type() )
   {
-    case QgsSymbolV2::Marker: t = "MARKER"; break;
-    case QgsSymbolV2::Line: t = "LINE"; break;
-    case QgsSymbolV2::Fill: t = "FILL"; break;
-    default: Q_ASSERT( 0 && "unknown symbol type" );
+    case QgsSymbolV2::Marker:
+      t = "MARKER";
+      break;
+    case QgsSymbolV2::Line:
+      t = "LINE";
+      break;
+    case QgsSymbolV2::Fill:
+      t = "FILL";
+      break;
+    default:
+      Q_ASSERT( 0 && "unknown symbol type" );
   }
   QString s = QString( "%1 SYMBOL (%2 layers) color %3" ).arg( t ).arg( mLayers.count() ).arg( QgsSymbolLayerV2Utils::encodeColor( color() ) );
 
@@ -830,12 +849,15 @@ void QgsSymbolV2::renderFeature( const QgsFeature& feature, QgsRenderContext& co
     while ( geom->geometry()->nextVertex( vertexId, vertexPoint ) )
     {
       //transform
-      x = vertexPoint.x(); y = vertexPoint.y(); z = vertexPoint.z();
+      x = vertexPoint.x();
+      y = vertexPoint.y();
+      z = vertexPoint.z();
       if ( ct )
       {
         ct->transformInPlace( x, y, z );
       }
-      mapPoint.setX( x ); mapPoint.setY( y );
+      mapPoint.setX( x );
+      mapPoint.setY( y );
       mtp.transformInPlace( mapPoint.rx(), mapPoint.ry() );
       QgsVectorLayer::drawVertexMarker( mapPoint.x(), mapPoint.y(), *context.painter(),
                                         static_cast< QgsVectorLayer::VertexMarkerType >( currentVertexMarkerType ),

--- a/src/gui/qgsannotationitem.cpp
+++ b/src/gui/qgsannotationitem.cpp
@@ -140,7 +140,10 @@ void QgsAnnotationItem::updateBalloon()
 
   //edge list
   QList<QLineF> segmentList;
-  segmentList << segment( 0 ); segmentList << segment( 1 ); segmentList << segment( 2 ); segmentList << segment( 3 );
+  segmentList << segment( 0 );
+  segmentList << segment( 1 );
+  segmentList << segment( 2 );
+  segmentList << segment( 3 );
 
   //find  closest edge / closest edge point
   double minEdgeDist = DBL_MAX;

--- a/src/gui/qgsmapcanvasmap.cpp
+++ b/src/gui/qgsmapcanvasmap.cpp
@@ -65,11 +65,13 @@ void QgsMapCanvasMap::paint( QPainter* painter )
   painter->drawLine( QLineF( 0, 0, br.width(), br.height() ) );
   painter->drawLine( QLineF( br.width(), 0, 0, br.height() ) );
 
-  double nw = br.width() * 0.5; double nh = br.height() * 0.5;
+  double nw = br.width() * 0.5;
+  double nh = br.height() * 0.5;
   br = QRectF( c - QPointF( nw / 2, nh / 2 ), QSize( nw, nh ) );
   painter->drawRoundedRect( br, rad, rad );
 
-  nw = br.width() * 0.5; nh = br.height() * 0.5;
+  nw = br.width() * 0.5;
+  nh = br.height() * 0.5;
   br = QRectF( c - QPointF( nw / 2, nh / 2 ), QSize( nw, nh ) );
   painter->drawRoundedRect( br, rad, rad );
 #endif

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -312,7 +312,9 @@ void QgsMapToolCapture::undo()
     }
 
     QgsVertexId vertexToRemove;
-    vertexToRemove.part = 0; vertexToRemove.ring = 0; vertexToRemove.vertex = size() - 1;
+    vertexToRemove.part = 0;
+    vertexToRemove.ring = 0;
+    vertexToRemove.vertex = size() - 1;
     mCaptureCurve.deleteVertex( vertexToRemove );
 
     validateGeometry();

--- a/src/gui/symbology-ng/qgscategorizedsymbolrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgscategorizedsymbolrendererv2widget.cpp
@@ -125,9 +125,12 @@ QVariant QgsCategorizedSymbolRendererV2Model::data( const QModelIndex &index, in
   {
     switch ( index.column() )
     {
-      case 1: return category.value().toString();
-      case 2: return category.label();
-      default: return QVariant();
+      case 1:
+        return category.value().toString();
+      case 2:
+        return category.label();
+      default:
+        return QVariant();
     }
   }
   else if ( role == Qt::DecorationRole && index.column() == 0 && category.symbol() )
@@ -142,9 +145,12 @@ QVariant QgsCategorizedSymbolRendererV2Model::data( const QModelIndex &index, in
   {
     switch ( index.column() )
     {
-      case 1: return category.value();
-      case 2: return category.label();
-      default: return QVariant();
+      case 1:
+        return category.value();
+      case 2:
+        return category.label();
+      default:
+        return QVariant();
     }
   }
 
@@ -202,7 +208,8 @@ QVariant QgsCategorizedSymbolRendererV2Model::headerData( int section, Qt::Orien
 {
   if ( orientation == Qt::Horizontal && role == Qt::DisplayRole && section >= 0 && section < 3 )
   {
-    QStringList lst; lst << tr( "Symbol" ) << tr( "Value" ) << tr( "Legend" );
+    QStringList lst;
+    lst << tr( "Symbol" ) << tr( "Value" ) << tr( "Legend" );
     return lst.value( section );
   }
   return QVariant();

--- a/src/gui/symbology-ng/qgsgraduatedsymbolrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgsgraduatedsymbolrendererv2widget.cpp
@@ -137,8 +137,10 @@ QVariant QgsGraduatedSymbolRendererV2Model::data( const QModelIndex &index, int 
         if ( decimalPlaces < 0 ) decimalPlaces = 0;
         return QString::number( range.lowerValue(), 'f', decimalPlaces ) + " - " + QString::number( range.upperValue(), 'f', decimalPlaces );
       }
-      case 2: return range.label();
-      default: return QVariant();
+      case 2:
+        return range.label();
+      default:
+        return QVariant();
     }
   }
   else if ( role == Qt::DecorationRole && index.column() == 0 && range.symbol() )
@@ -154,8 +156,10 @@ QVariant QgsGraduatedSymbolRendererV2Model::data( const QModelIndex &index, int 
     switch ( index.column() )
     {
         // case 1: return rangeStr;
-      case 2: return range.label();
-      default: return QVariant();
+      case 2:
+        return range.label();
+      default:
+        return QVariant();
     }
   }
 
@@ -196,7 +200,8 @@ QVariant QgsGraduatedSymbolRendererV2Model::headerData( int section, Qt::Orienta
 {
   if ( orientation == Qt::Horizontal && role == Qt::DisplayRole && section >= 0 && section < 3 )
   {
-    QStringList lst; lst << tr( "Symbol" ) << tr( "Values" ) << tr( "Legend" );
+    QStringList lst;
+    lst << tr( "Symbol" ) << tr( "Values" ) << tr( "Legend" );
     return lst.value( section );
   }
   return QVariant();

--- a/src/gui/symbology-ng/qgsrulebasedrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgsrulebasedrendererv2widget.cpp
@@ -789,7 +789,8 @@ QVariant QgsRuleBasedRendererV2Model::data( const QModelIndex &index, int role )
   {
     switch ( index.column() )
     {
-      case 0: return rule->label();
+      case 0:
+        return rule->label();
       case 1:
         if ( rule->isElse() )
         {
@@ -799,8 +800,10 @@ QVariant QgsRuleBasedRendererV2Model::data( const QModelIndex &index, int role )
         {
           return rule->filterExpression().isEmpty() ? tr( "(no filter)" ) : rule->filterExpression();
         }
-      case 2: return rule->dependsOnScale() ? _formatScale( rule->scaleMaxDenom() ) : QVariant();
-      case 3: return rule->dependsOnScale() ? _formatScale( rule->scaleMinDenom() ) : QVariant();
+      case 2:
+        return rule->dependsOnScale() ? _formatScale( rule->scaleMaxDenom() ) : QVariant();
+      case 3:
+        return rule->dependsOnScale() ? _formatScale( rule->scaleMinDenom() ) : QVariant();
       case 4:
         if ( mFeatureCountMap.count( rule ) == 1 )
         {
@@ -834,7 +837,8 @@ QVariant QgsRuleBasedRendererV2Model::data( const QModelIndex &index, int role )
           }
         }
         return QVariant();
-      default: return QVariant();
+      default:
+        return QVariant();
     }
   }
   else if ( role == Qt::DecorationRole && index.column() == 0 && rule->symbol() )
@@ -859,11 +863,16 @@ QVariant QgsRuleBasedRendererV2Model::data( const QModelIndex &index, int role )
   {
     switch ( index.column() )
     {
-      case 0: return rule->label();
-      case 1: return rule->filterExpression();
-      case 2: return rule->scaleMaxDenom();
-      case 3: return rule->scaleMinDenom();
-      default: return QVariant();
+      case 0:
+        return rule->label();
+      case 1:
+        return rule->filterExpression();
+      case 2:
+        return rule->scaleMaxDenom();
+      case 3:
+        return rule->scaleMinDenom();
+      default:
+        return QVariant();
     }
   }
   else if ( role == Qt::CheckStateRole )
@@ -880,7 +889,8 @@ QVariant QgsRuleBasedRendererV2Model::headerData( int section, Qt::Orientation o
 {
   if ( orientation == Qt::Horizontal && role == Qt::DisplayRole && section >= 0 && section < 7 )
   {
-    QStringList lst; lst << tr( "Label" ) << tr( "Rule" ) << tr( "Min. scale" ) << tr( "Max. scale" ) << tr( "Count" ) << tr( "Duplicate count" );
+    QStringList lst;
+    lst << tr( "Label" ) << tr( "Rule" ) << tr( "Min. scale" ) << tr( "Max. scale" ) << tr( "Count" ) << tr( "Duplicate count" );
     return lst[section];
   }
   else if ( orientation == Qt::Horizontal && role == Qt::ToolTipRole )

--- a/src/gui/symbology-ng/qgsstylev2exportimportdialog.cpp
+++ b/src/gui/symbology-ng/qgsstylev2exportimportdialog.cpp
@@ -349,7 +349,8 @@ void QgsStyleV2ExportImportDialog::moveStyles( QModelIndexList* selection, QgsSt
             prompt = false;
             overwrite = true;
             break;
-          case QMessageBox::NoToAll:  prompt = false;
+          case QMessageBox::NoToAll:
+            prompt = false;
             overwrite = false;
             break;
         }

--- a/src/gui/symbology-ng/qgsstylev2managerdialog.cpp
+++ b/src/gui/symbology-ng/qgsstylev2managerdialog.cpp
@@ -163,7 +163,8 @@ void QgsStyleV2ManagerDialog::populateTypes()
       case QgsSymbolV2::Fill:
         fillCount++;
         break;
-      default: Q_ASSERT( 0 && "unknown symbol type" );
+      default:
+        Q_ASSERT( 0 && "unknown symbol type" );
         break;
     }
   }
@@ -290,11 +291,16 @@ int QgsStyleV2ManagerDialog::currentItemType()
 {
   switch ( tabItemType->currentIndex() )
   {
-    case 0: return QgsSymbolV2::Marker;
-    case 1: return QgsSymbolV2::Line;
-    case 2: return QgsSymbolV2::Fill;
-    case 3: return 3;
-    default: return 0;
+    case 0:
+      return QgsSymbolV2::Marker;
+    case 1:
+      return QgsSymbolV2::Line;
+    case 2:
+      return QgsSymbolV2::Fill;
+    case 3:
+      return 3;
+    default:
+      return 0;
   }
 }
 

--- a/src/gui/symbology-ng/qgssymbolv2selectordialog.cpp
+++ b/src/gui/symbology-ng/qgssymbolv2selectordialog.cpp
@@ -181,10 +181,14 @@ class SymbolLayerItem : public QStandardItem
         {
           switch ( mSymbol->type() )
           {
-            case QgsSymbolV2::Marker : return QCoreApplication::translate( "SymbolLayerItem", "Marker", nullptr, QCoreApplication::UnicodeUTF8 );
-            case QgsSymbolV2::Fill   : return QCoreApplication::translate( "SymbolLayerItem", "Fill", nullptr, QCoreApplication::UnicodeUTF8 );
-            case QgsSymbolV2::Line   : return QCoreApplication::translate( "SymbolLayerItem", "Line", nullptr, QCoreApplication::UnicodeUTF8 );
-            default: return "Symbol";
+            case QgsSymbolV2::Marker :
+              return QCoreApplication::translate( "SymbolLayerItem", "Marker", nullptr, QCoreApplication::UnicodeUTF8 );
+            case QgsSymbolV2::Fill   :
+              return QCoreApplication::translate( "SymbolLayerItem", "Fill", nullptr, QCoreApplication::UnicodeUTF8 );
+            case QgsSymbolV2::Line   :
+              return QCoreApplication::translate( "SymbolLayerItem", "Line", nullptr, QCoreApplication::UnicodeUTF8 );
+            default:
+              return "Symbol";
           }
         }
       }

--- a/src/plugins/georeferencer/qgsgeorefplugingui.cpp
+++ b/src/plugins/georeferencer/qgsgeorefplugingui.cpp
@@ -1804,8 +1804,10 @@ void QgsGeorefPluginGui::updateTransformParamLabel()
   if ( mGeorefTransform.getOriginScaleRotation( origin, scaleX, scaleY, rotation ) )
   {
     labelString += ' ';
-    labelString += tr( "Translation (%1, %2)" ).arg( origin.x() ).arg( origin.y() ); labelString += ' ';
-    labelString += tr( "Scale (%1, %2)" ).arg( scaleX ).arg( scaleY ); labelString += ' ';
+    labelString += tr( "Translation (%1, %2)" ).arg( origin.x() ).arg( origin.y() );
+    labelString += ' ';
+    labelString += tr( "Scale (%1, %2)" ).arg( scaleX ).arg( scaleY );
+    labelString += ' ';
     labelString += tr( "Rotation: %1" ).arg( rotation * 180 / M_PI );
   }
 

--- a/src/plugins/georeferencer/qgsgeoreftransform.cpp
+++ b/src/plugins/georeferencer/qgsgeoreftransform.cpp
@@ -253,14 +253,22 @@ QgsGeorefTransformInterface *QgsGeorefTransform::createImplementation( Transform
 {
   switch ( parametrisation )
   {
-    case Linear:           return new QgsLinearGeorefTransform;
-    case Helmert:          return new QgsHelmertGeorefTransform;
-    case PolynomialOrder1: return new QgsGDALGeorefTransform( false, 1 );
-    case PolynomialOrder2: return new QgsGDALGeorefTransform( false, 2 );
-    case PolynomialOrder3: return new QgsGDALGeorefTransform( false, 3 );
-    case ThinPlateSpline:  return new QgsGDALGeorefTransform( true, 0 );
-    case Projective:       return new QgsProjectiveGeorefTransform;
-    default:               return nullptr;
+    case Linear:
+      return new QgsLinearGeorefTransform;
+    case Helmert:
+      return new QgsHelmertGeorefTransform;
+    case PolynomialOrder1:
+      return new QgsGDALGeorefTransform( false, 1 );
+    case PolynomialOrder2:
+      return new QgsGDALGeorefTransform( false, 2 );
+    case PolynomialOrder3:
+      return new QgsGDALGeorefTransform( false, 3 );
+    case ThinPlateSpline:
+      return new QgsGDALGeorefTransform( true, 0 );
+    case Projective:
+      return new QgsProjectiveGeorefTransform;
+    default:
+      return nullptr;
   }
 }
 

--- a/src/plugins/georeferencer/qgsleastsquares.cpp
+++ b/src/plugins/georeferencer/qgsleastsquares.cpp
@@ -210,13 +210,25 @@ void normalizeCoordinates( const std::vector<QgsPoint> &coords, std::vector<QgsP
     normalizedCoords[i] = QgsPoint(( coords[i].x() - cogX ) * D, ( coords[i].y() - cogY ) * D );
   }
 
-  normalizeMatrix[0] =   D; normalizeMatrix[1] = 0.0; normalizeMatrix[2] = -cogX * D;
-  normalizeMatrix[3] = 0.0; normalizeMatrix[4] =   D; normalizeMatrix[5] = -cogY * D;
-  normalizeMatrix[6] = 0.0; normalizeMatrix[7] = 0.0; normalizeMatrix[8] =   1.0;
+  normalizeMatrix[0] =   D;
+  normalizeMatrix[1] = 0.0;
+  normalizeMatrix[2] = -cogX * D;
+  normalizeMatrix[3] = 0.0;
+  normalizeMatrix[4] =   D;
+  normalizeMatrix[5] = -cogY * D;
+  normalizeMatrix[6] = 0.0;
+  normalizeMatrix[7] = 0.0;
+  normalizeMatrix[8] =   1.0;
 
-  denormalizeMatrix[0] = OOD; denormalizeMatrix[1] = 0.0; denormalizeMatrix[2] = cogX;
-  denormalizeMatrix[3] = 0.0; denormalizeMatrix[4] = OOD; denormalizeMatrix[5] = cogY;
-  denormalizeMatrix[6] = 0.0; denormalizeMatrix[7] = 0.0; denormalizeMatrix[8] =  1.0;
+  denormalizeMatrix[0] = OOD;
+  denormalizeMatrix[1] = 0.0;
+  denormalizeMatrix[2] = cogX;
+  denormalizeMatrix[3] = 0.0;
+  denormalizeMatrix[4] = OOD;
+  denormalizeMatrix[5] = cogY;
+  denormalizeMatrix[6] = 0.0;
+  denormalizeMatrix[7] = 0.0;
+  denormalizeMatrix[8] =  1.0;
 }
 
 // Fits a homography to the given corresponding points, and

--- a/src/plugins/gps_importer/qgsgpsplugin.cpp
+++ b/src/plugins/gps_importer/qgsgpsplugin.cpp
@@ -325,10 +325,18 @@ void QgsGPSPlugin::convertGPSFile( const QString& inputFileName,
 
   switch ( convertType )
   {
-    case 0: convertStrings << "-x" << "transform,wpt=rte,del"; break;
-    case 1: convertStrings << "-x" << "transform,rte=wpt,del"; break;
-    case 2: convertStrings << "-x" << "transform,trk=wpt,del"; break;
-    case 3: convertStrings << "-x" << "transform,wpt=trk,del"; break;
+    case 0:
+      convertStrings << "-x" << "transform,wpt=rte,del";
+      break;
+    case 1:
+      convertStrings << "-x" << "transform,rte=wpt,del";
+      break;
+    case 2:
+      convertStrings << "-x" << "transform,trk=wpt,del";
+      break;
+    case 3:
+      convertStrings << "-x" << "transform,wpt=trk,del";
+      break;
     default:
       QgsDebugMsg( "Illegal conversion index!" );
       return;

--- a/src/providers/gdal/qgsgdalproviderbase.cpp
+++ b/src/providers/gdal/qgsgdalproviderbase.cpp
@@ -150,17 +150,28 @@ QGis::DataType QgsGdalProviderBase::dataTypeFromGdal( const GDALDataType theGdal
 {
   switch ( theGdalDataType )
   {
-    case GDT_Byte: return QGis::Byte;
-    case GDT_UInt16: return QGis::UInt16;
-    case GDT_Int16: return QGis::Int16;
-    case GDT_UInt32: return QGis::UInt32;
-    case GDT_Int32: return QGis::Int32;
-    case GDT_Float32: return QGis::Float32;
-    case GDT_Float64: return QGis::Float64;
-    case GDT_CInt16: return QGis::CInt16;
-    case GDT_CInt32: return QGis::CInt32;
-    case GDT_CFloat32: return QGis::CFloat32;
-    case GDT_CFloat64: return QGis::CFloat64;
+    case GDT_Byte:
+      return QGis::Byte;
+    case GDT_UInt16:
+      return QGis::UInt16;
+    case GDT_Int16:
+      return QGis::Int16;
+    case GDT_UInt32:
+      return QGis::UInt32;
+    case GDT_Int32:
+      return QGis::Int32;
+    case GDT_Float32:
+      return QGis::Float32;
+    case GDT_Float64:
+      return QGis::Float64;
+    case GDT_CInt16:
+      return QGis::CInt16;
+    case GDT_CInt32:
+      return QGis::CInt32;
+    case GDT_CFloat32:
+      return QGis::CFloat32;
+    case GDT_CFloat64:
+      return QGis::CFloat64;
     case GDT_Unknown:
     case GDT_TypeCount:
       return QGis::UnknownDataType;
@@ -172,23 +183,40 @@ int QgsGdalProviderBase::colorInterpretationFromGdal( const GDALColorInterp gdal
 {
   switch ( gdalColorInterpretation )
   {
-    case GCI_GrayIndex: return QgsRaster::GrayIndex;
-    case GCI_PaletteIndex: return QgsRaster::PaletteIndex;
-    case GCI_RedBand: return QgsRaster::RedBand;
-    case GCI_GreenBand: return QgsRaster::GreenBand;
-    case GCI_BlueBand: return QgsRaster::BlueBand;
-    case GCI_AlphaBand: return QgsRaster::AlphaBand;
-    case GCI_HueBand: return QgsRaster::HueBand;
-    case GCI_SaturationBand: return QgsRaster::SaturationBand;
-    case GCI_LightnessBand: return QgsRaster::LightnessBand;
-    case GCI_CyanBand: return QgsRaster::CyanBand;
-    case GCI_MagentaBand: return QgsRaster::MagentaBand;
-    case GCI_YellowBand: return QgsRaster::YellowBand;
-    case GCI_BlackBand: return QgsRaster::BlackBand;
-    case GCI_YCbCr_YBand: return QgsRaster::YCbCr_YBand;
-    case GCI_YCbCr_CbBand: return QgsRaster::YCbCr_CbBand;
-    case GCI_YCbCr_CrBand: return QgsRaster::YCbCr_CrBand;
-    case GCI_Undefined: return QgsRaster::UndefinedColorInterpretation;
+    case GCI_GrayIndex:
+      return QgsRaster::GrayIndex;
+    case GCI_PaletteIndex:
+      return QgsRaster::PaletteIndex;
+    case GCI_RedBand:
+      return QgsRaster::RedBand;
+    case GCI_GreenBand:
+      return QgsRaster::GreenBand;
+    case GCI_BlueBand:
+      return QgsRaster::BlueBand;
+    case GCI_AlphaBand:
+      return QgsRaster::AlphaBand;
+    case GCI_HueBand:
+      return QgsRaster::HueBand;
+    case GCI_SaturationBand:
+      return QgsRaster::SaturationBand;
+    case GCI_LightnessBand:
+      return QgsRaster::LightnessBand;
+    case GCI_CyanBand:
+      return QgsRaster::CyanBand;
+    case GCI_MagentaBand:
+      return QgsRaster::MagentaBand;
+    case GCI_YellowBand:
+      return QgsRaster::YellowBand;
+    case GCI_BlackBand:
+      return QgsRaster::BlackBand;
+    case GCI_YCbCr_YBand:
+      return QgsRaster::YCbCr_YBand;
+    case GCI_YCbCr_CbBand:
+      return QgsRaster::YCbCr_CbBand;
+    case GCI_YCbCr_CrBand:
+      return QgsRaster::YCbCr_CrBand;
+    case GCI_Undefined:
+      return QgsRaster::UndefinedColorInterpretation;
   }
   return QgsRaster::UndefinedColorInterpretation;
 }

--- a/src/providers/gpx/qgsgpxprovider.cpp
+++ b/src/providers/gpx/qgsgpxprovider.cpp
@@ -354,12 +354,24 @@ bool QgsGPXProvider::addFeature( QgsFeature& f )
     {
       switch ( indexToAttr.at( i ) )
       {
-        case NameAttr:    obj->name    = attrs.at( i ).toString(); break;
-        case CmtAttr:     obj->cmt     = attrs.at( i ).toString(); break;
-        case DscAttr:     obj->desc    = attrs.at( i ).toString(); break;
-        case SrcAttr:     obj->src     = attrs.at( i ).toString(); break;
-        case URLAttr:     obj->url     = attrs.at( i ).toString(); break;
-        case URLNameAttr: obj->urlname = attrs.at( i ).toString(); break;
+        case NameAttr:
+          obj->name    = attrs.at( i ).toString();
+          break;
+        case CmtAttr:
+          obj->cmt     = attrs.at( i ).toString();
+          break;
+        case DscAttr:
+          obj->desc    = attrs.at( i ).toString();
+          break;
+        case SrcAttr:
+          obj->src     = attrs.at( i ).toString();
+          break;
+        case URLAttr:
+          obj->url     = attrs.at( i ).toString();
+          break;
+        case URLNameAttr:
+          obj->urlname = attrs.at( i ).toString();
+          break;
       }
     }
   }
@@ -452,12 +464,24 @@ void QgsGPXProvider::changeAttributeValues( QgsGPSObject& obj, const QgsAttribut
     // common attributes
     switch ( indexToAttr.at( i ) )
     {
-      case NameAttr:    obj.name    = v.toString(); break;
-      case CmtAttr:     obj.cmt     = v.toString(); break;
-      case DscAttr:     obj.desc    = v.toString(); break;
-      case SrcAttr:     obj.src     = v.toString(); break;
-      case URLAttr:     obj.url     = v.toString(); break;
-      case URLNameAttr: obj.urlname = v.toString(); break;
+      case NameAttr:
+        obj.name    = v.toString();
+        break;
+      case CmtAttr:
+        obj.cmt     = v.toString();
+        break;
+      case DscAttr:
+        obj.desc    = v.toString();
+        break;
+      case SrcAttr:
+        obj.src     = v.toString();
+        break;
+      case URLAttr:
+        obj.url     = v.toString();
+        break;
+      case URLNameAttr:
+        obj.urlname = v.toString();
+        break;
     }
 
     // waypoint-specific attributes

--- a/src/providers/grass/qgsgrassfeatureiterator.cpp
+++ b/src/providers/grass/qgsgrassfeatureiterator.cpp
@@ -135,9 +135,12 @@ void QgsGrassFeatureIterator::setSelectionRect( const QgsRectangle& rect, bool u
   mSelection.fill( false );
 
   BOUND_BOX box;
-  box.N = rect.yMaximum(); box.S = rect.yMinimum();
-  box.E = rect.xMaximum(); box.W = rect.xMinimum();
-  box.T = PORT_DOUBLE_MAX; box.B = -PORT_DOUBLE_MAX;
+  box.N = rect.yMaximum();
+  box.S = rect.yMinimum();
+  box.E = rect.xMaximum();
+  box.W = rect.xMinimum();
+  box.T = PORT_DOUBLE_MAX;
+  box.B = -PORT_DOUBLE_MAX;
 
   // Init structures
   struct ilist * list = Vect_new_list();
@@ -551,7 +554,8 @@ bool QgsGrassFeatureIterator::fetchFeature( QgsFeature& feature )
       int nlines = Vect_get_node_n_lines( mSource->map(), lid );
       for ( int i = 0; i < nlines; i++ )
       {
-        int line = Vect_get_node_line( mSource->map(), lid, i );  QgsDebugMsg( "cancel" );
+        int line = Vect_get_node_line( mSource->map(), lid, i );
+        QgsDebugMsg( "cancel" );
         if ( i > 0 ) lines += ",";
         lines += QString::number( line );
       }

--- a/src/providers/grass/qgsgrassrasterprovider.cpp
+++ b/src/providers/grass/qgsgrassrasterprovider.cpp
@@ -421,7 +421,10 @@ QList<QgsColorRampShader::ColorRampItem> QgsGrassRasterProvider::colorTable( int
     ct.append( ctItem2 );
     QgsDebugMsg( QString( "color %1 %2 %3 %4" ).arg( i->value2 ).arg( i->red2 ).arg( i->green2 ).arg( i->blue2 ) );
 
-    v = i->value2; r = i->red2; g = i->green2; b = i->blue2;
+    v = i->value2;
+    r = i->red2;
+    g = i->green2;
+    b = i->blue2;
   }
   return ct;
 }

--- a/src/providers/grass/qgsgrassvectormap.cpp
+++ b/src/providers/grass/qgsgrassvectormap.cpp
@@ -346,7 +346,8 @@ bool QgsGrassVectorMap::closeEdit( bool newMap )
 #endif
 
   mIsEdited = false;
-  QgsGrass::unlock();closeAllIterators(); // blocking
+  QgsGrass::unlock();
+  closeAllIterators(); // blocking
 
   closeMap();
   openMap();

--- a/src/providers/mssql/qgsmssqltablemodel.cpp
+++ b/src/providers/mssql/qgsmssqltablemodel.cpp
@@ -96,9 +96,16 @@ void QgsMssqlTableModel::addTableEntry( const QgsMssqlLayerProperty &layerProper
   QString pkText, pkCol = "";
   switch ( layerProperty.pkCols.size() )
   {
-    case 0:   pkText = ""; break;
-    case 1:   pkText = layerProperty.pkCols[0]; pkCol = pkText; break;
-    default:  pkText = tr( "Select..." ); break;
+    case 0:
+      pkText = "";
+      break;
+    case 1:
+      pkText = layerProperty.pkCols[0];
+      pkCol = pkText;
+      break;
+    default:
+      pkText = tr( "Select..." );
+      break;
   }
 
   QStandardItem *pkItem = new QStandardItem( pkText );

--- a/src/providers/ogr/qgsogrfeatureiterator.cpp
+++ b/src/providers/ogr/qgsogrfeatureiterator.cpp
@@ -277,12 +277,20 @@ void QgsOgrFeatureIterator::getFeatureAttribute( OGRFeatureH ogrFet, QgsFeature 
   {
     switch ( mSource->mFields.at( attindex ).type() )
     {
-      case QVariant::String: value = QVariant( mSource->mEncoding->toUnicode( OGR_F_GetFieldAsString( ogrFet, attindex ) ) ); break;
-      case QVariant::Int: value = QVariant( OGR_F_GetFieldAsInteger( ogrFet, attindex ) ); break;
+      case QVariant::String:
+        value = QVariant( mSource->mEncoding->toUnicode( OGR_F_GetFieldAsString( ogrFet, attindex ) ) );
+        break;
+      case QVariant::Int:
+        value = QVariant( OGR_F_GetFieldAsInteger( ogrFet, attindex ) );
+        break;
 #if defined(GDAL_VERSION_NUM) && GDAL_VERSION_NUM >= 2000000
-      case QVariant::LongLong: value = QVariant( OGR_F_GetFieldAsInteger64( ogrFet, attindex ) ); break;
+      case QVariant::LongLong:
+        value = QVariant( OGR_F_GetFieldAsInteger64( ogrFet, attindex ) );
+        break;
 #endif
-      case QVariant::Double: value = QVariant( OGR_F_GetFieldAsDouble( ogrFet, attindex ) ); break;
+      case QVariant::Double:
+        value = QVariant( OGR_F_GetFieldAsDouble( ogrFet, attindex ) );
+        break;
       case QVariant::Date:
       case QVariant::DateTime:
       {

--- a/src/providers/ogr/qgsogrgeometrysimplifier.cpp
+++ b/src/providers/ogr/qgsogrgeometrysimplifier.cpp
@@ -149,16 +149,22 @@ bool QgsOgrMapToPixelSimplifier::simplifyOgrGeometry( QGis::GeometryType geometr
 
   for ( int i = 0, numPoints = geometryType == QGis::Polygon ? pointCount - 1 : pointCount; i < numPoints; ++i )
   {
-    memcpy( &x, xsourcePtr, sizeof( double ) ); xsourcePtr += xStride;
-    memcpy( &y, ysourcePtr, sizeof( double ) ); ysourcePtr += yStride;
+    memcpy( &x, xsourcePtr, sizeof( double ) );
+    xsourcePtr += xStride;
+    memcpy( &y, ysourcePtr, sizeof( double ) );
+    ysourcePtr += yStride;
 
     if ( i == 0 ||
          !isGeneralizable ||
          calculateLengthSquared2D( x, y, lastX, lastY ) > map2pixelTol ||
          ( geometryType == QGis::Line && ( i == 1 || i >= numPoints - 2 ) ) )
     {
-      memcpy( xtargetPtr, &x, sizeof( double ) ); lastX = x; xtargetPtr += xStride;
-      memcpy( ytargetPtr, &y, sizeof( double ) ); lastY = y; ytargetPtr += yStride;
+      memcpy( xtargetPtr, &x, sizeof( double ) );
+      lastX = x;
+      xtargetPtr += xStride;
+      memcpy( ytargetPtr, &y, sizeof( double ) );
+      lastY = y;
+      ytargetPtr += yStride;
       pointSimplifiedCount++;
     }
   }

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -579,24 +579,59 @@ QString QgsOgrProvider::ogrWkbGeometryTypeName( OGRwkbGeometryType type ) const
   QString geom;
   switch (( long )type )
   {
-    case wkbUnknown:            geom = "Unknown"; break;
-    case wkbPoint:              geom = "Point"; break;
-    case wkbLineString:         geom = "LineString"; break;
-    case wkbPolygon:            geom = "Polygon"; break;
-    case wkbMultiPoint:         geom = "MultiPoint"; break;
-    case wkbMultiLineString:    geom = "MultiLineString"; break;
-    case wkbMultiPolygon:       geom = "MultiPolygon"; break;
-    case wkbGeometryCollection: geom = "GeometryCollection"; break;
-    case wkbNone:               geom = "None"; break;
-    case wkbUnknown | wkb25DBit:geom = "Unknown25D"; break;
-    case wkbPoint25D:           geom = "Point25D"; break;
-    case wkbLineString25D:      geom = "LineString25D"; break;
-    case wkbPolygon25D:         geom = "Polygon25D"; break;
-    case wkbMultiPoint25D:      geom = "MultiPoint25D"; break;
-    case wkbMultiLineString25D: geom = "MultiLineString25D"; break;
-    case wkbMultiPolygon25D:    geom = "MultiPolygon25D"; break;
-    case wkbGeometryCollection25D: geom = "GeometryCollection25D"; break;
-    default:                    geom = QString( "Unknown WKB: %1" ).arg( type );
+    case wkbUnknown:
+      geom = "Unknown";
+      break;
+    case wkbPoint:
+      geom = "Point";
+      break;
+    case wkbLineString:
+      geom = "LineString";
+      break;
+    case wkbPolygon:
+      geom = "Polygon";
+      break;
+    case wkbMultiPoint:
+      geom = "MultiPoint";
+      break;
+    case wkbMultiLineString:
+      geom = "MultiLineString";
+      break;
+    case wkbMultiPolygon:
+      geom = "MultiPolygon";
+      break;
+    case wkbGeometryCollection:
+      geom = "GeometryCollection";
+      break;
+    case wkbNone:
+      geom = "None";
+      break;
+    case wkbUnknown | wkb25DBit:
+      geom = "Unknown25D";
+      break;
+    case wkbPoint25D:
+      geom = "Point25D";
+      break;
+    case wkbLineString25D:
+      geom = "LineString25D";
+      break;
+    case wkbPolygon25D:
+      geom = "Polygon25D";
+      break;
+    case wkbMultiPoint25D:
+      geom = "MultiPoint25D";
+      break;
+    case wkbMultiLineString25D:
+      geom = "MultiLineString25D";
+      break;
+    case wkbMultiPolygon25D:
+      geom = "MultiPolygon25D";
+      break;
+    case wkbGeometryCollection25D:
+      geom = "GeometryCollection25D";
+      break;
+    default:
+      geom = QString( "Unknown WKB: %1" ).arg( type );
   }
   return geom;
 }
@@ -778,17 +813,28 @@ void QgsOgrProvider::loadFields()
       QVariant::Type varType;
       switch ( ogrType )
       {
-        case OFTInteger: varType = QVariant::Int; break;
+        case OFTInteger:
+          varType = QVariant::Int;
+          break;
 #if defined(GDAL_VERSION_NUM) && GDAL_VERSION_NUM >= 2000000
-        case OFTInteger64: varType = QVariant::LongLong; break;
+        case OFTInteger64:
+          varType = QVariant::LongLong;
+          break;
 #endif
-        case OFTReal: varType = QVariant::Double; break;
+        case OFTReal:
+          varType = QVariant::Double;
+          break;
 #if defined(GDAL_VERSION_NUM) && GDAL_VERSION_NUM >= 1400
-        case OFTDate: varType = QVariant::Date; break;
-        case OFTDateTime: varType = QVariant::DateTime; break;
+        case OFTDate:
+          varType = QVariant::Date;
+          break;
+        case OFTDateTime:
+          varType = QVariant::DateTime;
+          break;
         case OFTString:
 #endif
-        default: varType = QVariant::String; // other unsupported, leave it as a string
+        default:
+          varType = QVariant::String; // other unsupported, leave it as a string
       }
 
       //TODO: fix this hack
@@ -2702,10 +2748,14 @@ OGRwkbGeometryType QgsOgrProvider::ogrWkbSingleFlatten( OGRwkbGeometryType type 
   type = wkbFlatten( type );
   switch ( type )
   {
-    case wkbMultiPoint: return wkbPoint;
-    case wkbMultiLineString: return wkbLineString;
-    case wkbMultiPolygon: return wkbPolygon;
-    default: return type;
+    case wkbMultiPoint:
+      return wkbPoint;
+    case wkbMultiLineString:
+      return wkbLineString;
+    case wkbMultiPolygon:
+      return wkbPolygon;
+    default:
+      return type;
   }
 }
 

--- a/src/providers/spatialite/qgsspatialitedataitems.cpp
+++ b/src/providers/spatialite/qgsspatialitedataitems.cpp
@@ -116,11 +116,21 @@ QVector<QgsDataItem*> QgsSLConnectionItem::createChildren()
     QString msg;
     switch ( err )
     {
-      case QgsSpatiaLiteConnection::NotExists: msg = tr( "Database does not exist" ); break;
-      case QgsSpatiaLiteConnection::FailedToOpen: msg = tr( "Failed to open database" ); break;
-      case QgsSpatiaLiteConnection::FailedToCheckMetadata: msg = tr( "Failed to check metadata" ); break;
-      case QgsSpatiaLiteConnection::FailedToGetTables: msg = tr( "Failed to get list of tables" ); break;
-      default: msg = tr( "Unknown error" ); break;
+      case QgsSpatiaLiteConnection::NotExists:
+        msg = tr( "Database does not exist" );
+        break;
+      case QgsSpatiaLiteConnection::FailedToOpen:
+        msg = tr( "Failed to open database" );
+        break;
+      case QgsSpatiaLiteConnection::FailedToCheckMetadata:
+        msg = tr( "Failed to check metadata" );
+        break;
+      case QgsSpatiaLiteConnection::FailedToGetTables:
+        msg = tr( "Failed to get list of tables" );
+        break;
+      default:
+        msg = tr( "Unknown error" );
+        break;
     }
     QString msgDetails = connection.errorMessage();
     if ( !msgDetails.isEmpty() )

--- a/src/providers/virtual/qgsvirtuallayerblob.cpp
+++ b/src/providers/virtual/qgsvirtuallayerblob.cpp
@@ -26,13 +26,20 @@ void SpatialiteBlobHeader::readFrom( const char* p )
 {
   // we cannot use directly memcpy( this, p, sizeof(this) ),
   // since there may be padding between struct members
-  memcpy( &start, p, 1 ); p++;
-  memcpy( &endianness, p, 1 ); p++;
-  memcpy( &srid, p, 4 ); p += 4;
-  memcpy( &mbrMinX, p, 8 ); p += 8;
-  memcpy( &mbrMinY, p, 8 ); p += 8;
-  memcpy( &mbrMaxX, p, 8 ); p += 8;
-  memcpy( &mbrMaxY, p, 8 ); p += 8;
+  memcpy( &start, p, 1 );
+  p++;
+  memcpy( &endianness, p, 1 );
+  p++;
+  memcpy( &srid, p, 4 );
+  p += 4;
+  memcpy( &mbrMinX, p, 8 );
+  p += 8;
+  memcpy( &mbrMinY, p, 8 );
+  p += 8;
+  memcpy( &mbrMaxX, p, 8 );
+  p += 8;
+  memcpy( &mbrMaxY, p, 8 );
+  p += 8;
   memcpy( &end, p, 1 );
 }
 
@@ -40,13 +47,20 @@ void SpatialiteBlobHeader::writeTo( char* p ) const
 {
   // we cannot use directly memcpy( this, p, sizeof(this) ),
   // since there may be padding between struct members
-  memcpy( p, &start, 1 ); p++;
-  memcpy( p, &endianness, 1 ); p++;
-  memcpy( p, &srid, 4 ); p += 4;
-  memcpy( p, &mbrMinX, 8 ); p += 8;
-  memcpy( p, &mbrMinY, 8 ); p += 8;
-  memcpy( p, &mbrMaxX, 8 ); p += 8;
-  memcpy( p, &mbrMaxY, 8 ); p += 8;
+  memcpy( p, &start, 1 );
+  p++;
+  memcpy( p, &endianness, 1 );
+  p++;
+  memcpy( p, &srid, 4 );
+  p += 4;
+  memcpy( p, &mbrMinX, 8 );
+  p += 8;
+  memcpy( p, &mbrMinY, 8 );
+  p += 8;
+  memcpy( p, &mbrMaxX, 8 );
+  p += 8;
+  memcpy( p, &mbrMaxY, 8 );
+  p += 8;
   memcpy( p, &end, 1 );
 }
 
@@ -118,7 +132,8 @@ void copySpatialiteSingleWkbToQgsGeometry( QgsWKBTypes::Type type, const char* i
     {
       uint32_t n_points = *( uint32_t* )iwkb;
       memcpy( owkb, iwkb, 4 );
-      iwkb += 4; owkb += 4;
+      iwkb += 4;
+      owkb += 4;
       for ( uint32_t i = 0; i < n_points; i++ )
       {
         memcpy( owkb, iwkb, n_dims*8 );
@@ -132,13 +147,15 @@ void copySpatialiteSingleWkbToQgsGeometry( QgsWKBTypes::Type type, const char* i
     {
       uint32_t n_rings = *( uint32_t* )iwkb;
       memcpy( owkb, iwkb, 4 );
-      iwkb += 4; owkb += 4;
+      iwkb += 4;
+      owkb += 4;
       osize = 4;
       for ( uint32_t i = 0; i < n_rings; i++ )
       {
         uint32_t n_points = *( uint32_t* )iwkb;
         memcpy( owkb, iwkb, 4 );
-        iwkb += 4; owkb += 4;
+        iwkb += 4;
+        owkb += 4;
         osize += 4;
         for ( uint32_t j = 0; j < n_points; j++ )
         {

--- a/src/providers/wfs/qgswfssourceselect.cpp
+++ b/src/providers/wfs/qgswfssourceselect.cpp
@@ -201,10 +201,18 @@ void QgsWFSSourceSelect::capabilitiesReplyFinished()
     QString title;
     switch ( err )
     {
-      case QgsWFSCapabilities::NetworkError: title = tr( "Network Error" ); break;
-      case QgsWFSCapabilities::XmlError:     title = tr( "Capabilities document is not valid" ); break;
-      case QgsWFSCapabilities::ServerExceptionError: title = tr( "Server Exception" ); break;
-      default: tr( "Error" ); break;
+      case QgsWFSCapabilities::NetworkError:
+        title = tr( "Network Error" );
+        break;
+      case QgsWFSCapabilities::XmlError:
+        title = tr( "Capabilities document is not valid" );
+        break;
+      case QgsWFSCapabilities::ServerExceptionError:
+        title = tr( "Server Exception" );
+        break;
+      default:
+        tr( "Error" );
+        break;
     }
     // handle errors
     QMessageBox::critical( nullptr, title, mCapabilities->errorMessage() );

--- a/src/server/qgshttprequesthandler.cpp
+++ b/src/server/qgshttprequesthandler.cpp
@@ -897,7 +897,10 @@ bool QgsHttpRequestHandler::minMaxRange( const QgsColorBox& colorBox, int& redRa
   int bMax = INT_MIN;
   int aMax = INT_MIN;
 
-  int currentRed = 0; int currentGreen = 0; int currentBlue = 0; int currentAlpha = 0;
+  int currentRed = 0;
+  int currentGreen = 0;
+  int currentBlue = 0;
+  int currentAlpha = 0;
 
   QgsColorBox::const_iterator colorBoxIt = colorBox.constBegin();
   for ( ; colorBoxIt != colorBox.constEnd(); ++colorBoxIt )

--- a/src/server/qgswcsprojectparser.cpp
+++ b/src/server/qgswcsprojectparser.cpp
@@ -33,7 +33,8 @@ QgsWCSProjectParser::QgsWCSProjectParser(
 #endif
 )
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
-    : mAccessControl( as )
+    :
+    mAccessControl( as )
 #endif
 {
   mProjectParser = QgsConfigCache::instance()->serverConfiguration( filePath );

--- a/src/server/qgswcsserver.cpp
+++ b/src/server/qgswcsserver.cpp
@@ -317,7 +317,10 @@ QByteArray* QgsWCSServer::getCoverage()
   QMap<QString, QString>::const_iterator bbIt = mParameters.constFind( "BBOX" );
   if ( bbIt == mParameters.constEnd() )
   {
-    minx = 0; miny = 0; maxx = 0; maxy = 0;
+    minx = 0;
+    miny = 0;
+    maxx = 0;
+    maxy = 0;
   }
   else
   {

--- a/src/server/qgswfsprojectparser.cpp
+++ b/src/server/qgswfsprojectparser.cpp
@@ -30,7 +30,8 @@ QgsWFSProjectParser::QgsWFSProjectParser(
 #endif
 )
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
-    : mAccessControl( ac )
+    :
+    mAccessControl( ac )
 #endif
 {
   mProjectParser = QgsConfigCache::instance()->serverConfiguration( filePath );

--- a/src/server/qgswfsserver.cpp
+++ b/src/server/qgswfsserver.cpp
@@ -789,7 +789,10 @@ int QgsWFSServer::getFeature( QgsRequestHandler& request, const QString& format 
       QMap<QString, QString>::const_iterator bbIt = mParameters.constFind( "BBOX" );
       if ( bbIt == mParameters.constEnd() )
       {
-        minx = 0; miny = 0; maxx = 0; maxy = 0;
+        minx = 0;
+        miny = 0;
+        maxx = 0;
+        maxy = 0;
       }
       else
       {

--- a/src/server/qgswmsconfigparser.cpp
+++ b/src/server/qgswmsconfigparser.cpp
@@ -73,13 +73,17 @@ QgsComposition* QgsWMSConfigParser::createPrintComposition( const QString& compo
     if ( extent.isEmpty() ) //map extent is mandatory
     {
       //remove map from composition if not referenced by the request
-      c->removeItem( currentMap ); delete currentMap; continue;
+      c->removeItem( currentMap );
+      delete currentMap;
+      continue;
     }
 
     QStringList coordList = extent.split( "," );
     if ( coordList.size() < 4 )
     {
-      c->removeItem( currentMap ); delete currentMap; continue; //need at least four coordinates
+      c->removeItem( currentMap );
+      delete currentMap;
+      continue; //need at least four coordinates
     }
 
     bool xMinOk, yMinOk, xMaxOk, yMaxOk;
@@ -89,7 +93,9 @@ QgsComposition* QgsWMSConfigParser::createPrintComposition( const QString& compo
     double ymax = coordList.at( 3 ).toDouble( &yMaxOk );
     if ( !xMinOk || !yMinOk || !xMaxOk || !yMaxOk )
     {
-      c->removeItem( currentMap ); delete currentMap; continue;
+      c->removeItem( currentMap );
+      delete currentMap;
+      continue;
     }
 
     QgsRectangle r( xmin, ymin, xmax, ymax );

--- a/tests/src/core/testqgsrulebasedrenderer.cpp
+++ b/tests/src/core/testqgsrulebasedrenderer.cpp
@@ -69,9 +69,15 @@ class TestQgsRuleBasedRenderer: public QObject
       QgsVectorLayer* layer = new QgsVectorLayer( "point?field=fld:int", "x", "memory" );
       int idx = layer->fieldNameIndex( "fld" );
       QVERIFY( idx != -1 );
-      QgsFeature f1; f1.initAttributes( 1 ); f1.setAttribute( idx, QVariant( 2 ) );
-      QgsFeature f2; f2.initAttributes( 1 ); f2.setAttribute( idx, QVariant( 8 ) );
-      QgsFeature f3; f3.initAttributes( 1 ); f3.setAttribute( idx, QVariant( 100 ) );
+      QgsFeature f1;
+      f1.initAttributes( 1 );
+      f1.setAttribute( idx, QVariant( 2 ) );
+      QgsFeature f2;
+      f2.initAttributes( 1 );
+      f2.setAttribute( idx, QVariant( 8 ) );
+      QgsFeature f3;
+      f3.initAttributes( 1 );
+      f3.setAttribute( idx, QVariant( 100 ) );
 
       // prepare renderer
       QgsSymbolV2* s1 = QgsSymbolV2::defaultSymbol( QGis::Point );


### PR DESCRIPTION
```
foo(); bar();
```

becomes

```
foo();
bar();
```

[Suggested](https://github.com/qgis/QGIS/pull/2595#discussion_r48018096) by @m-kuhn:

> I think having each command on it's own line makes code much more readable and today's screens fortunately are big enough to show a couple of lines so we don't need to save vertical space ;)

This PR also contains a commit fixing all current instances of this issue.
