### PR TITLE
Ensure that rings are closed when adding to polygons

### DIFF
--- a/src/core/geometry/qgspolygonv2.cpp
+++ b/src/core/geometry/qgspolygonv2.cpp
@@ -182,6 +182,12 @@ void QgsPolygonV2::addInteriorRing( QgsCurveV2* ring )
     ring = segmented;
   }
 
+  QgsLineStringV2* lineString = dynamic_cast< QgsLineStringV2*>( ring );
+  if ( lineString && !lineString->isClosed() )
+  {
+    lineString->close();
+  }
+
   if ( mWkbType == QgsWKBTypes::Polygon25D )
   {
     ring->convertTo( QgsWKBTypes::LineString25D );
@@ -207,6 +213,12 @@ void QgsPolygonV2::setExteriorRing( QgsCurveV2* ring )
     QgsCurveV2* line = ring->segmentize();
     delete ring;
     ring = line;
+  }
+
+  QgsLineStringV2* lineString = dynamic_cast< QgsLineStringV2*>( ring );
+  if ( lineString && !lineString->isClosed() )
+  {
+    lineString->close();
   }
 
   mExteriorRing = ring;


### PR DESCRIPTION
I can't see a reason why non-closed rings should be allowed for polygons, but potentially there's a use case I haven't thought about. This should help address issues like:

http://hub.qgis.org/issues/13863
and http://hub.qgis.org/issues/13862

I think it's a safe approach. Ideally we want to accept any geometries, non matter how invalid, and do our best to make them usable and valid.... 
