### PR TITLE
Add dependency on openscenegraph-plugin-osgearth to qgis-plugin-globe.

### DIFF
--- a/debian/control.in
+++ b/debian/control.in
@@ -340,6 +340,7 @@ Architecture: any
 Depends:
  qgis (= ${binary:Version}),
  qgis-plugin-globe-common (= ${source:Version}),
+ openscenegraph-plugin-osgearth,
  ${shlibs:Depends},
  ${misc:Depends}
 Description: OSG globe plugin for QGIS


### PR DESCRIPTION
QGIS crashes when using the Globe plugin if this package is not installed,
as reported in [QGIS issue #9818](https://hub.qgis.org/issues/9818) and [Debian Bug #808817](https://bugs.debian.org/808817).
