### PR TITLE
Read alpha component of selection color from project properties (fixes #13994)

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -4336,10 +4336,11 @@ bool QgisApp::addProject( const QString& projectFile )
   mOverviewCanvas->setBackgroundColor( myColor );
 
   QgsDebugMsg( "Canvas background color restored..." );
+  int myAlphaInt = QgsProject::instance()->readNumEntry( "Gui", "/SelectionColorAlphaPart", 255 );
   myRedInt = QgsProject::instance()->readNumEntry( "Gui", "/SelectionColorRedPart", 255 );
   myGreenInt = QgsProject::instance()->readNumEntry( "Gui", "/SelectionColorGreenPart", 255 );
   myBlueInt = QgsProject::instance()->readNumEntry( "Gui", "/SelectionColorBluePart", 0 );
-  myColor = QColor( myRedInt, myGreenInt, myBlueInt );
+  myColor = QColor( myRedInt, myGreenInt, myBlueInt, myAlphaInt );
   mMapCanvas->setSelectionColor( myColor ); //this is selection color before rendering starts
 
   //load project scales


### PR DESCRIPTION
When reading the color used for selected geometries from the project properties, only the RGB channels were read, the alpha channel was omitted (see [Redmine #13994](https://hub.qgis.org/issues/13994)). This PR fixes that.
