### PR TITLE
[graduated symbology] increase precision of float values when saving to dom

### DIFF
--- a/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.cpp
+++ b/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.cpp
@@ -1100,8 +1100,8 @@ QDomElement QgsGraduatedSymbolRendererV2::save( QDomDocument& doc )
     symbols.insert( symbolName, range.symbol() );
 
     QDomElement rangeElem = doc.createElement( "range" );
-    rangeElem.setAttribute( "lower", QString::number( range.lowerValue(), 'f' ) );
-    rangeElem.setAttribute( "upper", QString::number( range.upperValue(), 'f' ) );
+    rangeElem.setAttribute( "lower", QString::number( range.lowerValue(), 'f', 15 ) );
+    rangeElem.setAttribute( "upper", QString::number( range.upperValue(), 'f', 15 ) );
     rangeElem.setAttribute( "symbol", symbolName );
     rangeElem.setAttribute( "label", range.label() );
     rangeElem.setAttribute( "render", range.renderState() ? "true" : "false" );


### PR DESCRIPTION
When saving the range lower and upper values (double) to the DOM, the number is truncated to 6 decimal values, which is a problem when your range is composed of double values with a precision above 6 decimals.

This PR simply increase the precision to 15.

This fixes a pretty serious issue whereas re-opening a project with layers rendered via graduated symbology would not look the same (because the classes values were truncated), leading to a different visual look, and often the highest feature(s) would not be rendered as the values would be above the truncated value saved in the dom. That issue was raised in http://hub.qgis.org/issues/14036 (with wrong initial assumptions, subsequently rectified :smile:).
