### PR TITLE
Re-Read the cached project file when its contents have changed

### DIFF
--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -1667,9 +1667,12 @@ bool QgsProject::createEmbeddedLayer( const QString &layerId, const QString &pro
   QgsDebugCall;
 
   static QString prevProjectFilePath;
+  static QDateTime prevProjectFileTimestamp;
   static QDomDocument projectDocument;
 
-  if ( projectFilePath != prevProjectFilePath )
+  QDateTime projectFileTimestamp = QFileInfo( projectFilePath ).lastModified();
+
+  if ( projectFilePath != prevProjectFilePath || projectFileTimestamp != prevProjectFileTimestamp )
   {
     prevProjectFilePath.clear();
 
@@ -1685,6 +1688,7 @@ bool QgsProject::createEmbeddedLayer( const QString &layerId, const QString &pro
     }
 
     prevProjectFilePath = projectFilePath;
+    prevProjectFileTimestamp = projectFileTimestamp;
   }
 
   // does project store pathes absolute or relative?


### PR DESCRIPTION
When embedding layers, `QgsProject::createEmbeddedLayer()` caches the parsed contents of the last project file it operated on. This cache was only refreshed when embedding layers from a different file. Now it is refreshed when the `lastModified()` timestamp changes, too.
