### PR TITLE
[symbology] increase maximum size of natural break classification

### DIFF
--- a/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.cpp
+++ b/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.cpp
@@ -679,7 +679,7 @@ static QList<double> _calcStdDevBreaks( QList<double> values, int classes, QList
 
 static QList<double> _calcJenksBreaks( QList<double> values, int classes,
                                        double minimum, double maximum,
-                                       int maximumSize = 1000 )
+                                       int maximumSize = 3000 )
 {
   // Jenks Optimal (Natural Breaks) algorithm
   // Based on the Jenks algorithm from the 'classInt' package available for


### PR DESCRIPTION
Five years ago, when the natural break classification method was added to the graduated symbology, an arbitrary maximum dataset size of 1,000 features was attached to the code to prevent the classification from taking too much time to compute. 

Half a decade later, I think it's pretty safe to increase that arbitrary maximum to 3,000 features, since CPUs have improved, speeding up computation time. The increase from one to three thousand features is arbitrary. I've tried a 2,010 features dataset on my 5-year-old laptop without noticing any visible difference in computation time.

On the long run, it could be good to introduce an option (either in QGIS' preference window, or at the symbology level) to allow to change this maximum size value, or switch off the maximum value entirely. In the meantime, this PR doesn't hurt :)

See http://hub.qgis.org/issues/14036 for some more background.
