### PR TITLE
Remove the 'layercount' attribute in a project file

### DIFF
--- a/python/plugins/processing/tests/data/project.qgs
+++ b/python/plugins/processing/tests/data/project.qgs
@@ -45,7 +45,7 @@
             </filegroup>
         </legendlayer>
     </legend>
-    <projectlayers layercount="4">
+    <projectlayers>
         <maplayer minimumScale="0" maximumScale="1e+08" geometry="Line" type="vector" hasScaleBasedVisibilityFlag="0">
             <id>lines20130323011923044</id>
             <datasource>./lines.shp</datasource>

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -1058,7 +1058,6 @@ bool QgsProject::write()
   // Iterate over layers in zOrder
   // Call writeXML() on each
   QDomElement projectLayersNode = doc->createElement( "projectlayers" );
-  projectLayersNode.setAttribute( "layercount", qulonglong( layers.size() ) );
 
   QMap<QString, QgsMapLayer*>::ConstIterator li = layers.constBegin();
   while ( li != layers.end() )

--- a/tests/testdata/labeling/test-labeling.qgs
+++ b/tests/testdata/labeling/test-labeling.qgs
@@ -42,7 +42,7 @@
             </filegroup>
         </legendlayer>
     </legend>
-    <projectlayers layercount="3">
+    <projectlayers>
         <maplayer minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="1" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" geometry="Polygon" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
             <id>aoi20130902095858570</id>
             <datasource>dbname='./pal_features_v3.sqlite' table="aoi" (geometry) sql=</datasource>

--- a/tests/testdata/qgis_local_server/test-project/test-server.qgs
+++ b/tests/testdata/qgis_local_server/test-project/test-server.qgs
@@ -37,7 +37,7 @@
             </filegroup>
         </legendlayer>
     </legend>
-    <projectlayers layercount="2">
+    <projectlayers>
         <maplayer minimumScale="0" maximumScale="1e+08" simplifyDrawingHints="1" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" geometry="Polygon" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
             <id>aoi20130902095858570</id>
             <datasource>dbname='./features_v3.sqlite' table="aoi" (geometry) sql=</datasource>

--- a/tests/testdata/qgis_server/test+project.qgs
+++ b/tests/testdata/qgis_server/test+project.qgs
@@ -47,7 +47,7 @@
       </filegroup>
     </legendlayer>
   </legend>
-  <projectlayers layercount="1">
+  <projectlayers>
     <maplayer minimumScale="-4.65661e-10" maximumScale="1e+08" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" geometry="Point" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
       <id>testlayer20150528120452665</id>
       <datasource>./testlayer.shp</datasource>

--- a/tests/testdata/qgis_server/test+project_wfs.qgs
+++ b/tests/testdata/qgis_server/test+project_wfs.qgs
@@ -72,7 +72,7 @@
       <layer_coordinate_transform destAuthId="EPSG:4326" srcAuthId="EPSG:4326" srcDatumTransform="-1" destDatumTransform="-1" layerid="testlayer20150528120452665"/>
     </layer_coordinate_transform_info>
   </mapcanvas>
-  <projectlayers layercount="1">
+  <projectlayers>
     <maplayer minimumScale="-4.65661e-10" maximumScale="1e+08" simplifyDrawingHints="0" minLabelScale="0" maxLabelScale="1e+08" simplifyDrawingTol="1" geometry="Point" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
       <id>testlayer20150528120452665</id>
       <datasource>./testlayer.shp</datasource>

--- a/tests/testdata/qgis_server_accesscontrol/project.qgs
+++ b/tests/testdata/qgis_server_accesscontrol/project.qgs
@@ -375,7 +375,7 @@
       </ComposerLabel>
     </Composition>
   </Composer>
-  <projectlayers layercount="5">
+  <projectlayers>
     <maplayer minimumScale="-4.65661e-10" maximumScale="1e+08" simplifyDrawingHints="1" minLabelScale="1" maxLabelScale="1e+08" simplifyDrawingTol="1" geometry="Polygon" simplifyMaxScale="1" type="vector" hasScaleBasedVisibilityFlag="0" simplifyLocal="1" scaleBasedLabelVisibilityFlag="0">
       <id>Hello_copy20150804164427541</id>
       <datasource>dbname='./helloworld.db' table="hello" (geom) sql=</datasource>


### PR DESCRIPTION
The `layercount` attribute of the `projectlayers` element in a project file is expected to show the number of its direct children, the `maplayer` elements.
However when a project contains embedded groups, there is no `maplayer` element created for the layers within these embedded groups. The `layercount` still counted them and the value was too high.

Please note that the `layercount` attribute is only written to the file, but I did not find any code within QGIS that actually uses it.
