### PR TITLE
Make vector joins work within layer-definition-files

### DIFF
--- a/python/core/qgslayerdefinition.sip
+++ b/python/core/qgslayerdefinition.sip
@@ -17,5 +17,7 @@ class QgsLayerDefinition
     static bool loadLayerDefinition( QDomDocument doc, QgsLayerTreeGroup* rootGroup, QString &errorMessage /Out/ );
     /** Export the selected layer tree nodes to a QLR file */
     static bool exportLayerDefinition( QString path, const QList<QgsLayerTreeNode*>& selectedTreeNodes, QString &errorMessage /Out/ );
+    /** Export the selected layer tree nodes to a QLR-XML document */
+    static bool exportLayerDefinition( QDomDocument doc, const QList<QgsLayerTreeNode*>& selectedTreeNodes, QString &errorMessage, const QString& relativeBasePath = QString::null );
 };
 

--- a/src/core/qgslayerdefinition.cpp
+++ b/src/core/qgslayerdefinition.cpp
@@ -119,6 +119,24 @@ bool QgsLayerDefinition::exportLayerDefinition( QString path, const QList<QgsLay
   QFileInfo fileinfo( file );
 
   QDomDocument doc( "qgis-layer-definition" );
+  if ( !exportLayerDefinition( doc, selectedTreeNodes, errorMessage, fileinfo.canonicalFilePath() ) )
+    return false;
+  if ( file.open( QFile::WriteOnly | QFile::Truncate ) )
+  {
+    QTextStream qlayerstream( &file );
+    doc.save( qlayerstream, 2 );
+    return true;
+  }
+  else
+  {
+    errorMessage = file.errorString();
+    return false;
+  }
+}
+
+bool QgsLayerDefinition::exportLayerDefinition( QDomDocument doc, const QList<QgsLayerTreeNode*>& selectedTreeNodes, QString &errorMessage, const QString& relativeBasePath )
+{
+  Q_UNUSED( errorMessage );
   QDomElement qgiselm = doc.createElement( "qlr" );
   doc.appendChild( qgiselm );
   QList<QgsLayerTreeNode*> nodes = selectedTreeNodes;
@@ -135,20 +153,9 @@ bool QgsLayerDefinition::exportLayerDefinition( QString path, const QList<QgsLay
   Q_FOREACH ( QgsLayerTreeLayer* layer, layers )
   {
     QDomElement layerelm = doc.createElement( "maplayer" );
-    layer->layer()->writeLayerXML( layerelm, doc, fileinfo.canonicalFilePath() );
+    layer->layer()->writeLayerXML( layerelm, doc, relativeBasePath );
     layerselm.appendChild( layerelm );
   }
   qgiselm.appendChild( layerselm );
-
-  if ( file.open( QFile::WriteOnly | QFile::Truncate ) )
-  {
-    QTextStream qlayerstream( &file );
-    doc.save( qlayerstream, 2 );
-    return true;
-  }
-  else
-  {
-    errorMessage = file.errorString();
-    return false;
-  }
+  return true;
 }

--- a/src/core/qgslayerdefinition.cpp
+++ b/src/core/qgslayerdefinition.cpp
@@ -6,6 +6,7 @@
 
 #include "qgslogger.h"
 #include "qgsmaplayer.h"
+#include "qgsvectorlayer.h"
 #include "qgslayertree.h"
 #include "qgsmaplayerregistry.h"
 #include "qgslayerdefinition.h"
@@ -62,6 +63,18 @@ bool QgsLayerDefinition::loadLayerDefinition( QDomDocument doc, QgsLayerTreeGrou
         layerNode.toElement().setAttribute( "id", newid );
       }
     }
+
+    // change layer IDs for vector joins
+    QDomNodeList vectorJoinNodes = doc.elementsByTagName( "join" ); // TODO: Find a better way of searching for vectorjoins, there might be other <join> elements within the project.
+    for ( int j = 0; j < vectorJoinNodes.size(); ++j )
+    {
+      QDomNode joinNode = vectorJoinNodes.at( j );
+      QDomElement joinElement = joinNode.toElement();
+      if ( joinElement.attribute( "joinLayerId" ) == oldid )
+      {
+        joinNode.toElement().setAttribute( "joinLayerId", newid );
+      }
+    }
   }
 
   QDomElement layerTreeElem = doc.documentElement().firstChildElement( "layer-tree-group" );
@@ -74,6 +87,17 @@ bool QgsLayerDefinition::loadLayerDefinition( QDomDocument doc, QgsLayerTreeGrou
 
   QList<QgsMapLayer*> layers = QgsMapLayer::fromLayerDefinition( doc );
   QgsMapLayerRegistry::instance()->addMapLayers( layers, loadInLegend );
+
+  // Now that all layers are loaded, refresh the vectorjoins to get the joined fields
+  Q_FOREACH ( QgsMapLayer* layer, layers )
+  {
+    QgsVectorLayer* vlayer = static_cast< QgsVectorLayer * >( layer );
+    if ( vlayer )
+    {
+      vlayer->createJoinCaches();
+      vlayer->updateFields();
+    }
+  }
 
   QList<QgsLayerTreeNode*> nodes = root->children();
   Q_FOREACH ( QgsLayerTreeNode *node, nodes )

--- a/src/core/qgslayerdefinition.h
+++ b/src/core/qgslayerdefinition.h
@@ -19,6 +19,8 @@ class CORE_EXPORT QgsLayerDefinition
     static bool loadLayerDefinition( QDomDocument doc, QgsLayerTreeGroup* rootGroup, QString &errorMessage );
     /** Export the selected layer tree nodes to a QLR file */
     static bool exportLayerDefinition( QString path, const QList<QgsLayerTreeNode*>& selectedTreeNodes, QString &errorMessage );
+    /** Export the selected layer tree nodes to a QLR-XML document */
+    static bool exportLayerDefinition( QDomDocument doc, const QList<QgsLayerTreeNode*>& selectedTreeNodes, QString &errorMessage, const QString& relativeBasePath = QString::null );
 };
 
 #endif // QGSLAYERDEFINITION_H


### PR DESCRIPTION
The joins were already exported correctly to the QLR-file. The missing steps were:
- Update target layer-ids of the joins.
  
  When loading a QLR-file, the layer-ids are changed, but the targets of vector-joins were kept unchanged, hence pointing to non-existent layer-ids.
- Refresh the joins.
  
  The joins need to be refreshed after all layers are added to the `QgsMapLayerRegistry`.

This PR comes with a unit-test.

Note that I divided the function to generate a QLR file into two separate functions, one for generating the XML and another one for writing it to the QLR file. This allowed writing a test without extra files and is consistent with the functions to load a QLR file.
