### PR TITLE
Adds capability to have an updatable data source via ogr connection

### DIFF
--- a/src/providers/ogr/qgsogrconnpool.h
+++ b/src/providers/ogr/qgsogrconnpool.h
@@ -35,7 +35,10 @@ inline QString qgsConnectionPool_ConnectionToName( QgsOgrConn* c )
 inline void qgsConnectionPool_ConnectionCreate( QString connInfo, QgsOgrConn*& c )
 {
   c = new QgsOgrConn;
-  c->ds = OGROpen( connInfo.toUtf8().constData(), false, nullptr );
+  // try read-write connection first
+  c->ds = OGROpen( connInfo.toUtf8().constData(), true, nullptr );
+  if ( !c->ds )
+    c->ds = OGROpen( connInfo.toUtf8().constData(), false, nullptr );
   c->path = connInfo;
   c->valid = true;
 }


### PR DESCRIPTION
Not doing it like this gives us a read only data source the next time we try to access it (if for some reason we invalidate the connection - for instance via forceReload )
@m-kuhn 
