### PR TITLE
Make the georeferencer tool use a snapping cursor

### DIFF
--- a/src/plugins/georeferencer/qgsmapcoordsdialog.cpp
+++ b/src/plugins/georeferencer/qgsmapcoordsdialog.cpp
@@ -16,7 +16,6 @@
 #include <QPushButton>
 
 #include "qgsmapcanvas.h"
-#include "qgssnappingutils.h"
 
 #include "qgsgeorefvalidators.h"
 #include "qgsmapcoordsdialog.h"
@@ -45,8 +44,6 @@ QgsMapCoordsDialog::QgsMapCoordsDialog( QgsMapCanvas* qgisCanvas, const QgsPoint
 
   mToolEmitPoint = new QgsGeorefMapToolEmitPoint( qgisCanvas );
   mToolEmitPoint->setButton( mPointFromCanvasPushButton );
-
-  mSnapToBackgroundLayerBox->setChecked( s.value( "/Plugin-GeoReferencer/snapToBackgroundLayers", QVariant( false ) ).toBool() );
 
   connect( mPointFromCanvasPushButton, SIGNAL( clicked( bool ) ), this, SLOT( setToolEmitPoint( bool ) ) );
 
@@ -91,8 +88,6 @@ void QgsMapCoordsDialog::on_buttonBox_accepted()
     y = dmsToDD( leYCoord->text() );
 
   emit pointAdded( mPixelCoords, QgsPoint( x, y ) );
-  QSettings s;
-  s.setValue( "/Plugin-GeoReferencer/snapToBackgroundLayers", mSnapToBackgroundLayerBox->isChecked() );
   close();
 }
 
@@ -102,12 +97,6 @@ void QgsMapCoordsDialog::maybeSetXY( const QgsPoint & xy, Qt::MouseButton button
   if ( Qt::LeftButton == button )
   {
     QgsPoint mapCoordPoint = xy;
-    if ( mQgisCanvas && mSnapToBackgroundLayerBox->isChecked() )
-    {
-      QgsPointLocator::Match m = mQgisCanvas->snappingUtils()->snapToMap( xy );
-      if ( m.isValid() )
-        mapCoordPoint = m.point();
-    }
 
     leXCoord->clear();
     leYCoord->clear();

--- a/src/plugins/georeferencer/qgsmapcoordsdialog.h
+++ b/src/plugins/georeferencer/qgsmapcoordsdialog.h
@@ -37,19 +37,19 @@ class QgsGeorefMapToolEmitPoint : public QgsMapTool
 
     virtual ~QgsGeorefMapToolEmitPoint()
     {
-        delete mSnappingMarker;
-        mSnappingMarker = nullptr;
+      delete mSnappingMarker;
+      mSnappingMarker = nullptr;
     }
 
-    void canvasMoveEvent(QgsMapMouseEvent *e) override
+    void canvasMoveEvent( QgsMapMouseEvent *e ) override
     {
-       MappedPoint mapped = mapPoint(e);
+      MappedPoint mapped = mapPoint( e );
 
-       if ( !mapped.snapped )
-       {
-         delete mSnappingMarker;
-         mSnappingMarker = nullptr;
-       }
+      if ( !mapped.snapped )
+      {
+        delete mSnappingMarker;
+        mSnappingMarker = nullptr;
+      }
       else
       {
         if ( !mSnappingMarker )
@@ -65,7 +65,7 @@ class QgsGeorefMapToolEmitPoint : public QgsMapTool
 
     void canvasPressEvent( QgsMapMouseEvent * e ) override
     {
-      MappedPoint mapped = mapPoint(e);
+      MappedPoint mapped = mapPoint( e );
       emit canvasClicked( mapped.point, e->button() );
     }
 
@@ -90,20 +90,20 @@ class QgsGeorefMapToolEmitPoint : public QgsMapTool
   private:
     struct MappedPoint
     {
-        QgsPoint point;
-        bool snapped = false;
+      QgsPoint point;
+      bool snapped = false;
     };
 
-    MappedPoint mapPoint(QMouseEvent *e)
+    MappedPoint mapPoint( QMouseEvent *e )
     {
-       QgsPoint pnt = toMapCoordinates( e->pos() );
-       QgsSnappingUtils* snappingUtils = canvas()->snappingUtils();
-       auto match = snappingUtils->snapToMap( pnt );
+      QgsPoint pnt = toMapCoordinates( e->pos() );
+      QgsSnappingUtils* snappingUtils = canvas()->snappingUtils();
+      auto match = snappingUtils->snapToMap( pnt );
 
-       MappedPoint ret;
-       ret.snapped = match.isValid();
-       ret.point = ret.snapped ? match.point() : pnt;
-       return ret;
+      MappedPoint ret;
+      ret.snapped = match.isValid();
+      ret.point = ret.snapped ? match.point() : pnt;
+      return ret;
     }
 
     QgsVertexMarker* mSnappingMarker = nullptr;

--- a/src/plugins/georeferencer/qgsmapcoordsdialog.h
+++ b/src/plugins/georeferencer/qgsmapcoordsdialog.h
@@ -13,32 +13,100 @@
 #define MAPCOORDSDIALOG_H
 
 #include <QDialog>
+#include <QMouseEvent>
 
 #include "qgsmaptoolemitpoint.h"
+#include "qgssnappingutils.h"
 #include "qgspoint.h"
+#include "qgsvertexmarker.h"
+#include "qgsmapcanvas.h"
 
 #include <ui_qgsmapcoordsdialogbase.h>
 
 class QPushButton;
 
-class QgsGeorefMapToolEmitPoint : public QgsMapToolEmitPoint
+class QgsGeorefMapToolEmitPoint : public QgsMapTool
 {
     Q_OBJECT
 
   public:
     explicit QgsGeorefMapToolEmitPoint( QgsMapCanvas *canvas )
-        : QgsMapToolEmitPoint( canvas )
+        : QgsMapTool( canvas )
     {
     }
 
-    void canvasReleaseEvent( QgsMapMouseEvent* e ) override
+    virtual ~QgsGeorefMapToolEmitPoint()
     {
-      QgsMapToolEmitPoint::canvasReleaseEvent( e );
+        delete mSnappingMarker;
+        mSnappingMarker = nullptr;
+    }
+
+    void canvasMoveEvent(QgsMapMouseEvent *e) override
+    {
+       MappedPoint mapped = mapPoint(e);
+
+       if ( !mapped.snapped )
+       {
+         delete mSnappingMarker;
+         mSnappingMarker = nullptr;
+       }
+      else
+      {
+        if ( !mSnappingMarker )
+        {
+          mSnappingMarker = new QgsVertexMarker( mCanvas );
+          mSnappingMarker->setIconType( QgsVertexMarker::ICON_CROSS );
+          mSnappingMarker->setColor( Qt::magenta );
+          mSnappingMarker->setPenWidth( 3 );
+        }
+        mSnappingMarker->setCenter( mapped.point );
+      }
+    }
+
+    void canvasPressEvent( QgsMapMouseEvent * e ) override
+    {
+      MappedPoint mapped = mapPoint(e);
+      emit canvasClicked( mapped.point, e->button() );
+    }
+
+    void canvasReleaseEvent( QgsMapMouseEvent *e ) override
+    {
+      QgsMapTool::canvasReleaseEvent( e );
       emit mouseReleased();
     }
 
+    void deactivate() override
+    {
+      delete mSnappingMarker;
+      mSnappingMarker = 0;
+
+      QgsMapTool::deactivate();
+    }
+
   signals:
+    void canvasClicked( const QgsPoint& point, Qt::MouseButton button );
     void mouseReleased();
+
+  private:
+    struct MappedPoint
+    {
+        QgsPoint point;
+        bool snapped = false;
+    };
+
+    MappedPoint mapPoint(QMouseEvent *e)
+    {
+       QgsPoint pnt = toMapCoordinates( e->pos() );
+       QgsSnappingUtils* snappingUtils = canvas()->snappingUtils();
+       auto match = snappingUtils->snapToMap( pnt );
+
+       MappedPoint ret;
+       ret.snapped = match.isValid();
+       ret.point = ret.snapped ? match.point() : pnt;
+       return ret;
+    }
+
+    QgsVertexMarker* mSnappingMarker = nullptr;
 };
 
 class QgsMapCoordsDialog : public QDialog, private Ui::QgsMapCoordsDialogBase

--- a/src/plugins/georeferencer/qgsmapcoordsdialogbase.ui
+++ b/src/plugins/georeferencer/qgsmapcoordsdialogbase.ui
@@ -16,7 +16,7 @@
   <property name="sizeGripEnabled">
    <bool>true</bool>
   </property>
-  <layout class="QGridLayout" name="gridLayout" columnstretch="0,1,0,1">
+  <layout class="QGridLayout" name="gridLayout" columnstretch="0,0,0,0">
    <item row="0" column="0" colspan="4">
     <widget class="QLabel" name="label">
      <property name="text">
@@ -47,21 +47,14 @@
    <item row="1" column="1">
     <widget class="QLineEdit" name="leXCoord"/>
    </item>
-   <item row="3" column="0" colspan="3">
-    <widget class="QCheckBox" name="mSnapToBackgroundLayerBox">
-     <property name="text">
-      <string>Snap to background layers</string>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0" colspan="4">
+   <item row="4" column="0" colspan="4">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="standardButtons">
       <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
      </property>
     </widget>
    </item>
-   <item row="4" column="0">
+   <item row="3" column="0">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -80,7 +73,6 @@
  <tabstops>
   <tabstop>leXCoord</tabstop>
   <tabstop>leYCoord</tabstop>
-  <tabstop>mSnapToBackgroundLayerBox</tabstop>
  </tabstops>
  <resources/>
  <connections>


### PR DESCRIPTION
The georeferencer plugin currently has a snap to background layer option
that applies a snapping after one has picked a location on the main map.
Other tools in the system show a crosshairs that will snap to project
snapping options.

This change makes the coordinate selection tool in the georeferencer
plugin use a snapping crosshairs. Since this tool will use the snapping
objects from the project, the "snap to background layers" checkbox has
been removed.
