### PR TITLE
[pyqgis-console] Don't import pyqtconfig

### DIFF
--- a/python/console/console.py
+++ b/python/console/console.py
@@ -25,7 +25,6 @@ from PyQt4.QtGui import QDockWidget, QToolBar, QToolButton, QWidget,\
     QSplitter, QTreeWidget, QAction, QFileDialog, QCheckBox, QSizePolicy, QMenu, QGridLayout, QApplication, \
     QDesktopServices
 from PyQt4.QtGui import QVBoxLayout
-from PyQt4 import pyqtconfig
 from qgis.utils import iface
 from console_sci import ShellScintilla
 from console_output import ShellOutputScintilla
@@ -482,10 +481,7 @@ class PythonConsoleWidget(QWidget):
         self.lineEditFind = QgsFilterLineEdit()
         placeHolderTxt = QCoreApplication.translate("PythonConsole", "Enter text to find...")
 
-        if pyqtconfig.Configuration().qt_version >= 0x40700:
-            self.lineEditFind.setPlaceholderText(placeHolderTxt)
-        else:
-            self.lineEditFind.setToolTip(placeHolderTxt)
+        self.lineEditFind.setPlaceholderText(placeHolderTxt)
         self.findNextButton = QToolButton()
         self.findNextButton.setEnabled(False)
         toolTipfindNext = QCoreApplication.translate("PythonConsole", "Find Next")


### PR DESCRIPTION
pyqtconfig may not have been installed by PyQt4, leading to an error.

Was used to test for qt_version >= 0x40700 but CMakeLists.txt now checks
for QT_MIN_VERSION 4.8.0
