### PR TITLE
Read source from provider before saving memory layer (fixes #8997)

### DIFF
--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -46,6 +46,7 @@
 #include "qgsrasterlayer.h"
 #include "qgsrectangle.h"
 #include "qgsvectorlayer.h"
+#include "qgsvectordataprovider.h"
 
 
 QgsMapLayer::QgsMapLayer( QgsMapLayer::LayerType type,
@@ -568,6 +569,11 @@ bool QgsMapLayer::writeLayerXML( QDomElement& layerElement, QDomDocument& docume
     QUrl urlDest = QUrl::fromLocalFile( QgsProject::instance()->writePath( urlSource.toLocalFile(), relativeBasePath ) );
     urlDest.setQueryItems( urlSource.queryItems() );
     src = QString::fromAscii( urlDest.toEncoded() );
+  }
+  else if ( vlayer && vlayer->providerType() == "memory" )
+  {
+    // Refetch the source from the provider, because adding fields actually changes the source for this provider.
+    src = vlayer->dataProvider()->dataSourceUri();
   }
   else
   {

--- a/tests/src/python/test_provider_memory.py
+++ b/tests/src/python/test_provider_memory.py
@@ -17,7 +17,7 @@ import tempfile
 import shutil
 import glob
 
-from qgis.core import QGis, QgsField, QgsPoint, QgsVectorLayer, QgsFeatureRequest, QgsFeature, QgsProviderRegistry, \
+from qgis.core import QGis, QgsField, QgsPoint, QgsMapLayer, QgsVectorLayer, QgsFeatureRequest, QgsFeature, QgsProviderRegistry, \
     QgsGeometry, NULL
 from PyQt4.QtCore import QSettings
 from utilities import (unitTestDataPath,
@@ -170,6 +170,39 @@ class TestPyQgsMemoryProvider(TestCase, ProviderTestCase):
         assert myMemoryLayer is not None, 'Provider not initialised'
         myProvider = myMemoryLayer.dataProvider()
         assert myProvider is not None
+
+    def testSaveFields(self):
+        # Create a new memory layer with no fields
+        myMemoryLayer = QgsVectorLayer(
+            ('Point?crs=epsg:4326&index=yes'),
+            'test',
+            'memory')
+
+        # Add some fields to the layer
+        myFields = [QgsField('TestInt', QVariant.Int, 'integer', 2, 0),
+                    QgsField('TestDbl', QVariant.Double, 'double', 8, 6),
+                    QgsField('TestString', QVariant.String, 'string', 50, 0)]
+        assert myMemoryLayer.startEditing()
+        for f in myFields:
+            assert myMemoryLayer.addAttribute(f)
+        assert myMemoryLayer.commitChanges()
+        myMemoryLayer.updateFields()
+
+        # Export the layer to a layer-definition-XML
+        qlr = QgsMapLayer.asLayerDefinition([myMemoryLayer])
+        assert qlr is not None
+
+        # Import the layer from the layer-definition-XML
+        layers = QgsMapLayer.fromLayerDefinition(qlr)
+        assert layers is not None
+        myImportedLayer = layers[0]
+        assert myImportedLayer is not None
+
+        # Check for the presence of the fields
+        importedFields = myImportedLayer.fields()
+        assert importedFields is not None
+        for f in myFields:
+            assert f == importedFields.field(f.name())
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Because the [memory provider saves field definitions within the source](https://github.com/qgis/QGIS/blob/dbc0f072c638981db982011776d7b110215e80b7/src/providers/memory/qgsmemoryprovider.cpp#L237-L244) the source needs to be re-read before saving a memory-based vector layer.
