### PR TITLE
Fix accumulating "Not supported" hints

### DIFF
--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -435,16 +435,24 @@ void QgsVectorLayerProperties::syncToLayer( void )
   mSimplifyDrawingGroupBox->setChecked( simplifyMethod.simplifyHints() != QgsVectorSimplifyMethod::NoSimplification );
   mSimplifyDrawingSpinBox->setValue( simplifyMethod.threshold() );
 
+  QString remark = QString( " (%1)" ).arg( tr( "Not supported" ) );
   if ( !( layer->dataProvider()->capabilities() & QgsVectorDataProvider::SimplifyGeometries ) )
   {
     mSimplifyDrawingAtProvider->setChecked( false );
     mSimplifyDrawingAtProvider->setEnabled( false );
-    mSimplifyDrawingAtProvider->setText( QString( "%1 (%2)" ).arg( mSimplifyDrawingAtProvider->text(), tr( "Not supported" ) ) );
+    if ( !mSimplifyDrawingAtProvider->text().endsWith( remark ) )
+      mSimplifyDrawingAtProvider->setText( mSimplifyDrawingAtProvider->text().append( remark ) );
   }
   else
   {
     mSimplifyDrawingAtProvider->setChecked( !simplifyMethod.forceLocalOptimization() );
     mSimplifyDrawingAtProvider->setEnabled( mSimplifyDrawingGroupBox->isChecked() );
+    if ( mSimplifyDrawingAtProvider->text().endsWith( remark ) )
+    {
+      QString newText = mSimplifyDrawingAtProvider->text();
+      newText.chop( remark.size() );
+      mSimplifyDrawingAtProvider->setText( newText );
+    }
   }
 
   // disable simplification for point layers, now it is not implemented


### PR DESCRIPTION
When the provider does not support geometry simplification, the phrase "Not supported" was appended to the label _Simplify on provider side_ each time `QgsVectorLayerProperties::syncToLayer()` was called.

Since `syncToLayer()` is called on various occasions, e.g. when loading a style, the phrase "Not supported" could accumulate.

Additionally the phrase was never removed, although I don't know if that would ever be needed.

This PR fixes it by appending the phrase only if it is not present and removing it only if it is present.

![qgisaccnotsupported](https://cloud.githubusercontent.com/assets/15147421/12059604/d1bf19e2-af5e-11e5-9f0c-57f053fd8f4e.png)
