### PR TITLE
[StyleManager] Keep group actions enabled while in grouping mode (fixes #14049)

### DIFF
--- a/src/gui/symbology-ng/qgsstylev2managerdialog.cpp
+++ b/src/gui/symbology-ng/qgsstylev2managerdialog.cpp
@@ -1252,7 +1252,7 @@ void QgsStyleV2ManagerDialog::enableSymbolInputs( bool enable )
   groupTree->setEnabled( enable );
   btnAddGroup->setEnabled( enable );
   btnRemoveGroup->setEnabled( enable );
-  btnManageGroups->setEnabled( enable );
+  btnManageGroups->setEnabled( enable || mGrouppingMode ); // always enabled in grouping mode, as it is the only way to leave grouping mode
   searchBox->setEnabled( enable );
   tagsLineEdit->setEnabled( enable );
 }
@@ -1261,7 +1261,7 @@ void QgsStyleV2ManagerDialog::enableGroupInputs( bool enable )
 {
   btnAddGroup->setEnabled( enable );
   btnRemoveGroup->setEnabled( enable );
-  btnManageGroups->setEnabled( enable );
+  btnManageGroups->setEnabled( enable || mGrouppingMode ); // always enabled in grouping mode, as it is the only way to leave grouping mode
 }
 
 void QgsStyleV2ManagerDialog::enableItemsForGroupingMode( bool enable )


### PR DESCRIPTION
Group actions must be enabled during grouping mode to have the option of leaving grouping mode again. This PR fixes [Redmine #14049](http://hub.qgis.org/issues/14049).
