### PR TITLE
Change comparison back to NULL

### DIFF
--- a/python/plugins/fTools/tools/doSpatialJoin.py
+++ b/python/plugins/fTools/tools/doSpatialJoin.py
@@ -56,7 +56,7 @@ def myself(L):
 
 def filter_null(vals):
     """Takes an iterator of values and returns a new iterator returning the same values but skipping any NULL values"""
-    return (v for v in vals if v is not None)
+    return (v for v in vals if v != NULL)
 
 
 class Dialog(QDialog, Ui_Dialog):


### PR DESCRIPTION
filter_null method previously filtered the NULL values using NULL type in qgis.core which is a QPyNullVariant. 
( See original commit https://github.com/qgis/QGIS/commit/f9e0093ce70b06130a98c1e20278d0746ddb930c )

This was subsequently changed to 'is not None' comparison which is incorrect. The current version fails to filter out the null values.
