### PR TITLE
Remove all vertices if removing second to last line point / fourth to last ring point

### DIFF
--- a/src/core/geometry/qgscurvepolygonv2.cpp
+++ b/src/core/geometry/qgscurvepolygonv2.cpp
@@ -702,7 +702,7 @@ bool QgsCurvePolygonV2::deleteVertex( const QgsVertexId& vId )
 
   QgsCurveV2* ring = vId.ring == 0 ? mExteriorRing : mInteriorRings.at( vId.ring - 1 );
   int n = ring->numPoints();
-  if ( n <= 2 )
+  if ( n <= 4 )
   {
     //no points will be left in ring, so remove whole ring
     if ( vId.ring == 0 )

--- a/src/core/geometry/qgslinestringv2.cpp
+++ b/src/core/geometry/qgslinestringv2.cpp
@@ -645,7 +645,7 @@ bool QgsLineStringV2::deleteVertex( const QgsVertexId& position )
     mM.remove( position.vertex );
   }
 
-  if( numPoints() == 1 )
+  if ( numPoints() == 1 )
   {
     clear();
   }

--- a/src/core/geometry/qgslinestringv2.cpp
+++ b/src/core/geometry/qgslinestringv2.cpp
@@ -644,6 +644,12 @@ bool QgsLineStringV2::deleteVertex( const QgsVertexId& position )
   {
     mM.remove( position.vertex );
   }
+
+  if( numPoints() == 1 )
+  {
+    clear();
+  }
+
   mBoundingBox = QgsRectangle(); //set bounding box invalid
   return true;
 }

--- a/tests/src/core/testqgsgeometry.cpp
+++ b/tests/src/core/testqgsgeometry.cpp
@@ -1612,13 +1612,11 @@ void TestQgsGeometry::lineStringV2()
   QCOMPARE( l26.numPoints(), 2 );
   QCOMPARE( l26.pointN( 0 ), QgsPointV2( QgsWKBTypes::PointZM, 1, 2, 2, 3 ) );
   QCOMPARE( l26.pointN( 1 ), QgsPointV2( QgsWKBTypes::PointZM, 21, 22, 6, 7 ) );
-  QVERIFY( l26.deleteVertex( QgsVertexId( 0, 0, 0 ) ) );
-  QCOMPARE( l26.numPoints(), 1 );
-  QCOMPARE( l26.pointN( 0 ), QgsPointV2( QgsWKBTypes::PointZM, 21, 22, 6, 7 ) );
+  //removing the second to last vertex removes both remaining vertices
   QVERIFY( l26.deleteVertex( QgsVertexId( 0, 0, 0 ) ) );
   QCOMPARE( l26.numPoints(), 0 );
+  QVERIFY( !l26.deleteVertex( QgsVertexId( 0, 0, 0 ) ) );
   QVERIFY( l26.isEmpty() );
-
 
   //reversed
   QgsLineStringV2 l27;
@@ -2090,6 +2088,12 @@ void TestQgsGeometry::lineStringV2()
   QVERIFY( qgsDoubleNear( l38.vertexAngle( QgsVertexId( 0, 0, 0 ) ), 2.35619, 0.00001 ) );
   QVERIFY( qgsDoubleNear( l38.vertexAngle( QgsVertexId( 0, 0, 6 ) ), 2.35619, 0.00001 ) );
 
+  //removing the second to last vertex should remove the whole line
+  QgsLineStringV2 l39;
+  l39.setPoints( QList<QgsPointV2>() << QgsPointV2( 0, 0 ) << QgsPointV2( 1, 1 ) );
+  QVERIFY( l39.numPoints() == 2 );
+  l39.deleteVertex( QgsVertexId( 0, 0, 1 ) );
+  QVERIFY( l39.numPoints() == 0 );
 }
 
 void TestQgsGeometry::polygonV2()
@@ -2787,6 +2791,14 @@ void TestQgsGeometry::polygonV2()
   expectedGML3prec3 += QString( "<interior xmlns=\"gml\"><LinearRing xmlns=\"gml\"><coordinates xmlns=\"gml\">0.667,0.667 0.667,1.333 1.333,1.333 1.333,0.667 0.667,0.667</coordinates></LinearRing></interior></Polygon>" );
   QCOMPARE( elemToString( exportPolygonFloat.asGML3( doc, 3 ) ), expectedGML3prec3 );
 
+  //removing the fourth to last vertex removes the whole ring
+  QgsPolygonV2 p20;
+  QgsLineStringV2* p20ExteriorRing = new QgsLineStringV2();
+  p20ExteriorRing->setPoints( QList<QgsPointV2>() << QgsPointV2( 0, 0 ) << QgsPointV2( 1, 0 ) << QgsPointV2( 1, 1 ) << QgsPointV2( 0, 0 ) );
+  p20.setExteriorRing( p20ExteriorRing );
+  QVERIFY( p20.exteriorRing() );
+  p20.deleteVertex( QgsVertexId( 0, 0, 2 ) );
+  QVERIFY( !p20.exteriorRing() );
 }
 
 void TestQgsGeometry::fromQgsPoint()

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -1020,7 +1020,7 @@ class TestQgsGeometry(TestCase):
         assert compareWkt(expwkt, wkt), "Expected:\n%s\nGot:\n%s\n" % (expwkt, wkt)
 
         polyline = QgsGeometry.fromWkt("MultiLineString ((0 0, 1 0, 1 1, 2 1,2 0),(3 0, 3 1, 5 1, 5 0, 6 0))")
-        for i in range(5):
+        for i in range(4):
             assert polyline.deleteVertex(5), "Delete vertex 5 failed"
         expwkt = "MultiLineString ((0 0, 1 0, 1 1, 2 1, 2 0))"
         wkt = polyline.exportToWkt()
@@ -1074,7 +1074,7 @@ class TestQgsGeometry(TestCase):
         assert compareWkt(expwkt, wkt), "Expected:\n%s\nGot:\n%s\n" % (expwkt, wkt)
 
         polygon = QgsGeometry.fromWkt("MultiPolygon (((0 0, 1 0, 1 1, 2 1, 2 2, 0 2, 0 0)),((4 0, 5 0, 5 2, 3 2, 3 1, 4 1, 4 0)))")
-        for i in range(6):
+        for i in range(4):
             assert polygon.deleteVertex(0), "Delete vertex 0 failed"
 
         expwkt = "MultiPolygon (((4 0, 5 0, 5 2, 3 2, 3 1, 4 1, 4 0)))"
@@ -1091,7 +1091,7 @@ class TestQgsGeometry(TestCase):
         polygon = QgsGeometry.fromWkt("Polygon ((0 0, 9 0, 9 3, 0 3, 0 0),(1 1, 2 1, 2 2, 1 2, 1 1),(3 1, 4 1, 4 2, 3 2, 3 1),(5 1, 6 1, 6 2, 5 2, 5 1),(7 1, 8 1, 8 2, 7 2, 7 1))")
         #                                         0   1    2    3    4     5    6    7    8    9     10   11   12   13   14    15   16   17   18   19    20  21   22   23   24
 
-        for i in range(4):
+        for i in range(2):
             assert polygon.deleteVertex(16), "Delete vertex 16 failed" % i
 
         expwkt = "Polygon ((0 0, 9 0, 9 3, 0 3, 0 0),(1 1, 2 1, 2 2, 1 2, 1 1),(3 1, 4 1, 4 2, 3 2, 3 1),(7 1, 8 1, 8 2, 7 2, 7 1))"
@@ -1099,7 +1099,7 @@ class TestQgsGeometry(TestCase):
         assert compareWkt(expwkt, wkt), "Expected:\n%s\nGot:\n%s\n" % (expwkt, wkt)
 
         for i in range(3):
-            for j in range(4):
+            for j in range(2):
                 assert polygon.deleteVertex(5), "Delete vertex 5 failed" % i
 
         expwkt = "Polygon ((0 0, 9 0, 9 3, 0 3, 0 0))"
@@ -1108,7 +1108,7 @@ class TestQgsGeometry(TestCase):
 
         # Remove whole outer ring, inner ring should become outer
         polygon = QgsGeometry.fromWkt("Polygon ((0 0, 9 0, 9 3, 0 3, 0 0),(1 1, 2 1, 2 2, 1 2, 1 1))")
-        for i in range(4):
+        for i in range(2):
             assert polygon.deleteVertex(0), "Delete vertex 16 failed" % i
 
         expwkt = "Polygon ((1 1, 2 1, 2 2, 1 2, 1 1))"


### PR DESCRIPTION
Fix for http://hub.qgis.org/issues/13661. The node tool can handle existing invalid geometries. However it should not allow creation of invalid geometries. Therefore, if the second to last line vertex / fourth to last ring point is removed, the whole geometry is removed.
