### PR TITLE
Layer dependencies

### DIFF
--- a/python/core/qgslayerdefinition.sip
+++ b/python/core/qgslayerdefinition.sip
@@ -19,5 +19,26 @@ class QgsLayerDefinition
     static bool exportLayerDefinition( QString path, const QList<QgsLayerTreeNode*>& selectedTreeNodes, QString &errorMessage /Out/ );
     /** Export the selected layer tree nodes to a QLR-XML document */
     static bool exportLayerDefinition( QDomDocument doc, const QList<QgsLayerTreeNode*>& selectedTreeNodes, QString &errorMessage, const QString& relativeBasePath = QString::null );
+
+    /**
+     * Class used to work with layer dependencies stored in a XML project or layer definition file
+     */
+    class DependencySorter
+    {
+    public:
+      /** Constructor
+       * @param doc The XML document containing maplayer elements
+       */
+      DependencySorter( QDomDocument doc );
+
+      /** Get the layer nodes in an order where they can be loaded incrementally without dependency break */
+      QVector<QDomNode> sortedLayerNodes() const;
+
+      /** Whether some cyclic dependency has been detected */
+      bool hasCycle() const;
+
+      /** Whether some dependency is missing */
+      bool hasMissingDependency() const;
+    };
 };
 

--- a/python/core/qgslayerdefinition.sip
+++ b/python/core/qgslayerdefinition.sip
@@ -31,8 +31,16 @@ class QgsLayerDefinition
        */
       DependencySorter( QDomDocument doc );
 
+      /** Constructor
+       * @param fileName The filename where the XML document is stored
+       */
+      DependencySorter( const QString& fileName );
+
       /** Get the layer nodes in an order where they can be loaded incrementally without dependency break */
       QVector<QDomNode> sortedLayerNodes() const;
+
+      /** Get the layer IDs in an order where they can be loaded incrementally without dependency break */
+      QStringList sortedLayerIds() const;
 
       /** Whether some cyclic dependency has been detected */
       bool hasCycle() const;

--- a/python/core/qgsmaplayer.sip
+++ b/python/core/qgsmaplayer.sip
@@ -317,7 +317,7 @@ class QgsMapLayer : QObject
 
     /** Creates a new layer from a layer defininition document
     */
-    static QList<QgsMapLayer*> fromLayerDefinition( QDomDocument& document );
+    static QList<QgsMapLayer*> fromLayerDefinition( QDomDocument& document, bool addToRegistry = false, bool addToLegend = false );
     static QList<QgsMapLayer*> fromLayerDefinitionFile( const QString &qlrfile );
 
     /** Set a custom property for layer. Properties are stored in a map and saved in project file. */

--- a/python/core/qgsvectordataprovider.sip
+++ b/python/core/qgsvectordataprovider.sip
@@ -322,6 +322,11 @@ class QgsVectorDataProvider : QgsDataProvider
 
     virtual void forceReload();
 
+    /**
+     * Get the list of layer ids on which this layer depends. This in particular determines the order of layer loading.
+     */
+    virtual QSet<QString> layerDependencies() const;
+
   protected:
     void clearMinMaxCache();
     void fillMinMaxCache();

--- a/python/core/qgsvectorlayer.sip
+++ b/python/core/qgsvectorlayer.sip
@@ -442,6 +442,11 @@ class QgsVectorLayer : QgsMapLayer
     const QList<QgsVectorJoinInfo> vectorJoins() const;
 
     /**
+     * Get the list of layer ids on which this layer depends. This in particular determines the order of layer loading.
+     */
+    virtual QSet<QString> layerDependencies() const;
+
+    /**
      * Add a new field which is calculated by the expression specified
      *
      * @param exp The expression which calculates the field

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -8467,11 +8467,18 @@ void QgisApp::embedLayers()
     //layer ids
     QList<QDomNode> brokenNodes;
     QList< QPair< QgsVectorLayer*, QDomElement > > vectorLayerList;
+
+    // resolve dependencies
+    QgsLayerDefinition::DependencySorter depSorter( projectFile );
+    QStringList sortedIds = depSorter.sortedLayerIds();
     QStringList layerIds = d.selectedLayerIds();
-    QStringList::const_iterator layerIt = layerIds.constBegin();
-    for ( ; layerIt != layerIds.constEnd(); ++layerIt )
+    foreach ( QString id, sortedIds )
     {
-      QgsProject::instance()->createEmbeddedLayer( *layerIt, projectFile, brokenNodes, vectorLayerList );
+      foreach ( QString selId, layerIds )
+      {
+        if ( selId == id )
+          QgsProject::instance()->createEmbeddedLayer( selId, projectFile, brokenNodes, vectorLayerList );
+      }
     }
 
     mMapCanvas->freeze( false );

--- a/src/core/qgslayerdefinition.h
+++ b/src/core/qgslayerdefinition.h
@@ -21,6 +21,32 @@ class CORE_EXPORT QgsLayerDefinition
     static bool exportLayerDefinition( QString path, const QList<QgsLayerTreeNode*>& selectedTreeNodes, QString &errorMessage );
     /** Export the selected layer tree nodes to a QLR-XML document */
     static bool exportLayerDefinition( QDomDocument doc, const QList<QgsLayerTreeNode*>& selectedTreeNodes, QString &errorMessage, const QString& relativeBasePath = QString::null );
+
+    /**
+     * Class used to work with layer dependencies stored in a XML project or layer definition file
+     */
+    class CORE_EXPORT DependencySorter
+    {
+      public:
+        /** Constructor
+         * @param doc The XML document containing maplayer elements
+         */
+        DependencySorter( QDomDocument doc );
+
+        /** Get the layer nodes in an order where they can be loaded incrementally without dependency break */
+        QVector<QDomNode> sortedLayerNodes() const { return mSortedLayerNodes; }
+
+        /** Whether some cyclic dependency has been detected */
+        bool hasCycle() const { return mHasCycle; }
+
+        /** Whether some dependency is missing */
+        bool hasMissingDependency() const { return mHasMissingDependency; }
+
+      private:
+        QVector<QDomNode> mSortedLayerNodes;
+        bool mHasCycle;
+        bool mHasMissingDependency;
+    };
 };
 
 #endif // QGSLAYERDEFINITION_H

--- a/src/core/qgslayerdefinition.h
+++ b/src/core/qgslayerdefinition.h
@@ -33,8 +33,16 @@ class CORE_EXPORT QgsLayerDefinition
          */
         DependencySorter( QDomDocument doc );
 
+        /** Constructor
+         * @param fileName The filename where the XML document is stored
+         */
+        DependencySorter( const QString& fileName );
+
         /** Get the layer nodes in an order where they can be loaded incrementally without dependency break */
         QVector<QDomNode> sortedLayerNodes() const { return mSortedLayerNodes; }
+
+        /** Get the layer IDs in an order where they can be loaded incrementally without dependency break */
+        QStringList sortedLayerIds() const { return mSortedLayerIds; }
 
         /** Whether some cyclic dependency has been detected */
         bool hasCycle() const { return mHasCycle; }
@@ -44,8 +52,10 @@ class CORE_EXPORT QgsLayerDefinition
 
       private:
         QVector<QDomNode> mSortedLayerNodes;
+        QStringList mSortedLayerIds;
         bool mHasCycle;
         bool mHasMissingDependency;
+        void init( QDomDocument doc );
     };
 };
 

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -47,6 +47,7 @@
 #include "qgsrectangle.h"
 #include "qgsvectorlayer.h"
 #include "qgsvectordataprovider.h"
+#include "qgsmaplayerregistry.h"
 
 
 QgsMapLayer::QgsMapLayer( QgsMapLayer::LayerType type,
@@ -788,7 +789,7 @@ QDomDocument QgsMapLayer::asLayerDefinition( const QList<QgsMapLayer *>& layers,
   return doc;
 }
 
-QList<QgsMapLayer*> QgsMapLayer::fromLayerDefinition( QDomDocument& document )
+QList<QgsMapLayer*> QgsMapLayer::fromLayerDefinition( QDomDocument& document, bool addToRegistry, bool addToLegend )
 {
   QList<QgsMapLayer*> layers;
   QDomNodeList layernodes = document.elementsByTagName( "maplayer" );
@@ -820,7 +821,11 @@ QList<QgsMapLayer*> QgsMapLayer::fromLayerDefinition( QDomDocument& document )
 
     bool ok = layer->readLayerXML( layerElem );
     if ( ok )
+    {
       layers << layer;
+      if ( addToRegistry )
+        QgsMapLayerRegistry::instance()->addMapLayer( layer, addToLegend );
+    }
   }
   return layers;
 }

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -333,7 +333,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
 
     /** Creates a new layer from a layer defininition document
     */
-    static QList<QgsMapLayer*> fromLayerDefinition( QDomDocument& document );
+    static QList<QgsMapLayer*> fromLayerDefinition( QDomDocument& document, bool addToRegistry = false, bool addToLegend = false );
     static QList<QgsMapLayer*> fromLayerDefinitionFile( const QString &qlrfile );
 
     /** Set a custom property for layer. Properties are stored in a map and saved in project file. */

--- a/src/core/qgsvectordataprovider.cpp
+++ b/src/core/qgsvectordataprovider.cpp
@@ -548,4 +548,9 @@ void QgsVectorDataProvider::pushError( const QString& msg )
   mErrors << msg;
 }
 
+QSet<QString> QgsVectorDataProvider::layerDependencies() const
+{
+  return QSet<QString>();
+}
+
 QStringList QgsVectorDataProvider::smEncodings;

--- a/src/core/qgsvectordataprovider.h
+++ b/src/core/qgsvectordataprovider.h
@@ -383,6 +383,11 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider
       emit dataChanged();
     }
 
+    /**
+     * Get the list of layer ids on which this layer depends. This in particular determines the order of layer loading.
+     */
+    virtual QSet<QString> layerDependencies() const;
+
   protected:
     void clearMinMaxCache();
     void fillMinMaxCache();

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -1620,6 +1620,16 @@ bool QgsVectorLayer::writeXml( QDomNode & layer_node,
   //save joins
   mJoinBuffer->writeXml( layer_node, document );
 
+  // dependencies
+  QDomElement dependenciesElement = document.createElement( "layerDependencies" );
+  foreach ( QString layerId, layerDependencies() )
+  {
+    QDomElement depElem = document.createElement( "layer" );
+    depElem.setAttribute( "id", layerId );
+    dependenciesElement.appendChild( depElem );
+  }
+  layer_node.appendChild( dependenciesElement );
+
   // save expression fields
   mExpressionFieldBuffer->writeXml( layer_node, document );
 
@@ -3910,4 +3920,13 @@ bool QgsAttributeEditorRelation::init( QgsRelationManager* relationManager )
 {
   mRelation = relationManager->relation( mRelationId );
   return mRelation.isValid();
+}
+
+QSet<QString> QgsVectorLayer::layerDependencies() const
+{
+  if ( mDataProvider )
+  {
+    return mDataProvider->layerDependencies();
+  }
+  return QSet<QString>();
 }

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -549,6 +549,11 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
     const QList<QgsVectorJoinInfo> vectorJoins() const;
 
     /**
+     * Get the list of layer ids on which this layer depends. This in particular determines the order of layer loading.
+     */
+    virtual QSet<QString> layerDependencies() const;
+
+    /**
      * Add a new field which is calculated by the expression specified
      *
      * @param exp The expression which calculates the field

--- a/src/providers/virtual/qgsvirtuallayerprovider.cpp
+++ b/src/providers/virtual/qgsvirtuallayerprovider.cpp
@@ -600,6 +600,17 @@ QgsAttributeList QgsVirtualLayerProvider::pkAttributeIndexes()
   return QgsAttributeList();
 }
 
+QSet<QString> QgsVirtualLayerProvider::layerDependencies() const
+{
+  QSet<QString> deps;
+  foreach ( const QgsVirtualLayerDefinition::SourceLayer& l, mDefinition.sourceLayers() )
+  {
+    if ( l.isReferenced() )
+      deps << l.reference();
+  }
+  return deps;
+}
+
 /**
  * Class factory to return a pointer to a newly created
  * QgsSpatiaLiteProvider object

--- a/src/providers/virtual/qgsvirtuallayerprovider.h
+++ b/src/providers/virtual/qgsvirtuallayerprovider.h
@@ -89,6 +89,9 @@ class QgsVirtualLayerProvider: public QgsVectorDataProvider
     /** Return list of indexes of fields that make up the primary key */
     QgsAttributeList pkAttributeIndexes() override;
 
+    /** Get the list of layer ids on which this layer depends */
+    QSet<QString> layerDependencies() const override;
+
   private:
 
     // file on disk

--- a/tests/src/python/CMakeLists.txt
+++ b/tests/src/python/CMakeLists.txt
@@ -67,6 +67,7 @@ ADD_PYTHON_TEST(PyQgsZonalStatistics test_qgszonalstatistics.py)
 ADD_PYTHON_TEST(PyQgsMapLayerRegistry test_qgsmaplayerregistry.py)
 ADD_PYTHON_TEST(PyQgsVirtualLayerProvider test_provider_virtual.py)
 ADD_PYTHON_TEST(PyQgsVirtualLayerDefinition test_qgsvirtuallayerdefinition.py)
+ADD_PYTHON_TEST(PyQgsLayerDefinition test_qgslayerdefinition.py)
 
 IF (NOT WIN32)
   ADD_PYTHON_TEST(PyQgsLogger test_qgslogger.py)

--- a/tests/src/python/test_provider_virtual.py
+++ b/tests/src/python/test_provider_virtual.py
@@ -29,7 +29,7 @@ from qgis.core import (QGis,
                        QgsErrorMessage,
                        QgsProviderRegistry,
                        QgsVirtualLayerDefinition,
-                       QgsWKBTypes
+                       QgsWKBTypes,
                        QgsProject
                        )
 


### PR DESCRIPTION
Allow to declare dependencies between layers.
Main usage: allow to properly save and load back a project with virtual layers that have references to live layers. Virtual layers must be loaded after all their dependencies.
