### PR TITLE
[rendering order] fix order setting not saved in rule-based symb. (fixes #14043)

### DIFF
--- a/src/core/symbology-ng/qgsinvertedpolygonrenderer.cpp
+++ b/src/core/symbology-ng/qgsinvertedpolygonrenderer.cpp
@@ -379,6 +379,13 @@ QDomElement QgsInvertedPolygonRenderer::save( QDomDocument& doc )
   if ( mPaintEffect && !QgsPaintEffectRegistry::isDefaultStack( mPaintEffect ) )
     mPaintEffect->saveProperties( doc, rendererElem );
 
+  if ( !mOrderBy.isEmpty() )
+  {
+    QDomElement orderBy = doc.createElement( "orderby" );
+    mOrderBy.save( orderBy );
+    rendererElem.appendChild( orderBy );
+  }
+
   return rendererElem;
 }
 

--- a/src/core/symbology-ng/qgspointdisplacementrenderer.cpp
+++ b/src/core/symbology-ng/qgspointdisplacementrenderer.cpp
@@ -418,6 +418,13 @@ QDomElement QgsPointDisplacementRenderer::save( QDomDocument& doc )
   if ( mPaintEffect && !QgsPaintEffectRegistry::isDefaultStack( mPaintEffect ) )
     mPaintEffect->saveProperties( doc, rendererElement );
 
+  if ( !mOrderBy.isEmpty() )
+  {
+    QDomElement orderBy = doc.createElement( "orderby" );
+    mOrderBy.save( orderBy );
+    rendererElement.appendChild( orderBy );
+  }
+
   return rendererElement;
 }
 

--- a/src/core/symbology-ng/qgsrulebasedrendererv2.cpp
+++ b/src/core/symbology-ng/qgsrulebasedrendererv2.cpp
@@ -945,6 +945,13 @@ QDomElement QgsRuleBasedRendererV2::save( QDomDocument& doc )
   if ( mPaintEffect && !QgsPaintEffectRegistry::isDefaultStack( mPaintEffect ) )
     mPaintEffect->saveProperties( doc, rendererElem );
 
+  if ( !mOrderBy.isEmpty() )
+  {
+    QDomElement orderBy = doc.createElement( "orderby" );
+    mOrderBy.save( orderBy );
+    rendererElem.appendChild( orderBy );
+  }
+
   return rendererElem;
 }
 


### PR DESCRIPTION
@m-kuhn , looked into issue 14043 (http://hub.qgis.org/issues/14043) some more, turns out rule based symbology didn't save the order settings to the dom. This PR fixes it.
