### PR TITLE
Fix some UI issues in style manager

### DIFF
--- a/python/core/symbology-ng/qgsstylev2.sip
+++ b/python/core/symbology-ng/qgsstylev2.sip
@@ -127,6 +127,8 @@ class QgsStyleV2 : QObject
     int symbolId( const QString& name );
     //! return the DB id for the given group name
     int groupId( const QString& group );
+    //! return the group name for the given DB id
+    QString groupName( int groupId ) const;
     //! return the DB id for the given tag name
     int tagId( const QString& tag );
     //! return the DB id for the given smartgroup name
@@ -134,6 +136,9 @@ class QgsStyleV2 : QObject
 
     //! return the all the groups in the style
     QStringList groupNames();
+
+    //! return the ids of all the groups in the style
+    QList<int> groupIds() const;
 
     //! returns the symbolnames of a given groupid
     /*!
@@ -269,6 +274,9 @@ class QgsStyleV2 : QObject
 
     //! gets the id from the table for the given name from the database, 0 if not found
     int getId( const QString& table, const QString& name );
+
+    //! gets the name from the table for the given id from the database, empty if not found
+    QString getName( const QString& table, int id ) const;
 
     //! updates the properties of an existing symbol/colorramp
     /*!

--- a/python/gui/symbology-ng/qgsstylev2managerdialog.sip
+++ b/python/gui/symbology-ng/qgsstylev2managerdialog.sip
@@ -55,6 +55,9 @@ class QgsStyleV2ManagerDialog : QDialog
     //! Perform symbol specific tasks when selected
     void symbolSelected( const QModelIndex& );
 
+    //! Perform tasks when the selected symbols change
+    void selectedSymbolsChanged( const QItemSelection& selected, const QItemSelection& deselected );
+
     //! Context menu for the groupTree
     void grouptreeContextMenu( const QPoint& );
 

--- a/python/gui/symbology-ng/qgsstylev2managerdialog.sip
+++ b/python/gui/symbology-ng/qgsstylev2managerdialog.sip
@@ -66,6 +66,7 @@ class QgsStyleV2ManagerDialog : QDialog
 
   protected slots:
     bool addColorRamp( QAction* action );
+    void groupSelectedSymbols();
 
   protected:
 

--- a/src/core/symbology-ng/qgsstylev2.h
+++ b/src/core/symbology-ng/qgsstylev2.h
@@ -190,6 +190,8 @@ class CORE_EXPORT QgsStyleV2 : public QObject
     int symbolId( const QString& name );
     //! return the DB id for the given group name
     int groupId( const QString& group );
+    //! return the group name for the given DB id
+    QString groupName( int groupId ) const;
     //! return the DB id for the given tag name
     int tagId( const QString& tag );
     //! return the DB id for the given smartgroup name
@@ -197,6 +199,9 @@ class CORE_EXPORT QgsStyleV2 : public QObject
 
     //! return the all the groups in the style
     QStringList groupNames();
+
+    //! return the ids of all the groups in the style
+    QList<int> groupIds() const;
 
     //! returns the symbolnames of a given groupid
     /*!
@@ -343,6 +348,9 @@ class CORE_EXPORT QgsStyleV2 : public QObject
 
     //! gets the id from the table for the given name from the database, 0 if not found
     int getId( const QString& table, const QString& name );
+
+    //! gets the name from the table for the given id from the database, empty if not found
+    QString getName( const QString& table, int id ) const;
 
     //! updates the properties of an existing symbol/colorramp
     /*!

--- a/src/gui/symbology-ng/qgsstylev2exportimportdialog.cpp
+++ b/src/gui/symbology-ng/qgsstylev2exportimportdialog.cpp
@@ -63,7 +63,7 @@ QgsStyleV2ExportImportDialog::QgsStyleV2ExportImportDialog( QgsStyleV2* style, Q
 
   if ( mDialogMode == Import )
   {
-    setWindowTitle( tr( "Import style(s)" ) );
+    setWindowTitle( tr( "Import symbol(s)" ) );
     // populate the import types
     importTypeCombo->addItem( tr( "file specified below" ), QVariant( "file" ) );
     // importTypeCombo->addItem( "official QGIS repo online", QVariant( "official" ) );
@@ -85,7 +85,7 @@ QgsStyleV2ExportImportDialog::QgsStyleV2ExportImportDialog( QgsStyleV2* style, Q
   }
   else
   {
-    setWindowTitle( tr( "Export style(s)" ) );
+    setWindowTitle( tr( "Export symbol(s)" ) );
     // hide import specific controls when exporting
     btnBrowse->setHidden( true );
     fromLabel->setHidden( true );

--- a/src/gui/symbology-ng/qgsstylev2exportimportdialog.cpp
+++ b/src/gui/symbology-ng/qgsstylev2exportimportdialog.cpp
@@ -51,6 +51,8 @@ QgsStyleV2ExportImportDialog::QgsStyleV2ExportImportDialog( QgsStyleV2* style, Q
   QStandardItemModel* model = new QStandardItemModel( listItems );
 
   listItems->setModel( model );
+  connect( listItems->selectionModel(), SIGNAL( selectionChanged( const QItemSelection&, const QItemSelection& ) ),
+           this, SLOT( selectionChanged( const QItemSelection&, const QItemSelection& ) ) );
 
   mTempStyle = new QgsStyleV2();
   // TODO validate
@@ -109,6 +111,7 @@ QgsStyleV2ExportImportDialog::QgsStyleV2ExportImportDialog( QgsStyleV2* style, Q
   // use Ok button for starting import and export operations
   disconnect( buttonBox, SIGNAL( accepted() ), this, SLOT( accept() ) );
   connect( buttonBox, SIGNAL( accepted() ), this, SLOT( doExportImport() ) );
+  buttonBox->button( QDialogButtonBox::Ok )->setEnabled( false );
 }
 
 void QgsStyleV2ExportImportDialog::doExportImport()
@@ -593,4 +596,12 @@ void QgsStyleV2ExportImportDialog::downloadCanceled()
   mNetReply->abort();
   mTempFile->remove();
   mFileName = "";
+}
+
+void QgsStyleV2ExportImportDialog::selectionChanged( const QItemSelection & selected, const QItemSelection & deselected )
+{
+  Q_UNUSED( selected );
+  Q_UNUSED( deselected );
+  bool nothingSelected = listItems->selectionModel()->selectedIndexes().empty();
+  buttonBox->button( QDialogButtonBox::Ok )->setDisabled( nothingSelected );
 }

--- a/src/gui/symbology-ng/qgsstylev2exportimportdialog.h
+++ b/src/gui/symbology-ng/qgsstylev2exportimportdialog.h
@@ -100,6 +100,7 @@ class GUI_EXPORT QgsStyleV2ExportImportDialog : public QDialog, private Ui::QgsS
     void fileReadyRead();
     void updateProgress( qint64, qint64 );
     void downloadCanceled();
+    void selectionChanged( const QItemSelection & selected, const QItemSelection & deselected );
 
   private:
     void downloadStyleXML( const QUrl& url );

--- a/src/gui/symbology-ng/qgsstylev2managerdialog.cpp
+++ b/src/gui/symbology-ng/qgsstylev2managerdialog.cpp
@@ -1327,10 +1327,13 @@ void QgsStyleV2ManagerDialog::listitemsContextMenu( const QPoint& point )
   // Clear all actions and create new actions for every group
   mGroupListMenu->clear();
 
-  QStringList groups = mStyle->groupNames();
-  Q_FOREACH ( const QString& group, groups )
+  QAction* a;
+  QList<int> groupIds = mStyle->groupIds();
+  Q_FOREACH ( int groupId, groupIds )
   {
-    mGroupListMenu->addAction( new QAction( group, mGroupListMenu ) );
+    a = new QAction( mStyle->groupName( groupId ), mGroupListMenu );
+    a->setData( groupId );
+    mGroupListMenu->addAction( a );
   }
 
   QAction* selectedItem = mGroupMenu->exec( globalPos );
@@ -1343,11 +1346,7 @@ void QgsStyleV2ManagerDialog::listitemsContextMenu( const QPoint& point )
       QgsDebugMsg( "unknow entity type" );
       return;
     }
-    int groupId = 0;
-    if ( selectedItem->text() != tr( "Un-group" ) )
-    {
-      groupId = mStyle->groupId( selectedItem->text() );
-    }
+    int groupId = selectedItem->data().toInt();
     QModelIndexList indexes =  listItems->selectionModel()->selectedIndexes();
     Q_FOREACH ( const QModelIndex& index, indexes )
     {

--- a/src/gui/symbology-ng/qgsstylev2managerdialog.cpp
+++ b/src/gui/symbology-ng/qgsstylev2managerdialog.cpp
@@ -109,10 +109,9 @@ QgsStyleV2ManagerDialog::QgsStyleV2ManagerDialog( QgsStyleV2* style, QWidget* pa
 
   QMenu *groupMenu = new QMenu( tr( "Group actions" ), this );
   QAction *groupSymbols = groupMenu->addAction( tr( "Group symbols" ) );
-  QAction *editSmartgroup = groupMenu->addAction( tr( "Edit smart group" ) );
+  groupMenu->addAction( actnEditSmartGroup );
   btnManageGroups->setMenu( groupMenu );
   connect( groupSymbols, SIGNAL( triggered() ), this, SLOT( groupSymbolsAction() ) );
-  connect( editSmartgroup, SIGNAL( triggered() ), this, SLOT( editSmartgroupAction() ) );
 
   connect( searchBox, SIGNAL( textChanged( QString ) ), this, SLOT( filterSymbols( QString ) ) );
   tagsLineEdit->installEventFilter( this );
@@ -935,6 +934,27 @@ void QgsStyleV2ManagerDialog::groupChanged( const QModelIndex& index )
   }
   if ( mGrouppingMode )
     setSymbolsChecked( groupSymbols );
+
+  actnEditSmartGroup->setVisible( false );
+  actnAddGroup->setVisible( false );
+  actnRemoveGroup->setVisible( false );
+
+  if ( index.parent().isValid() && ( index.data().toString() != "Ungrouped" ) )
+  {
+    if ( index.parent().data( Qt::UserRole + 1 ).toString() == "smartgroups" )
+    {
+      actnEditSmartGroup->setVisible( true );
+    }
+    else
+    {
+      actnAddGroup->setVisible( true );
+    }
+    actnRemoveGroup->setVisible( true );
+  }
+  else if ( index.data( Qt::UserRole + 1 ) == "groups" || index.data( Qt::UserRole + 1 ) == "smartgroups" )
+  {
+    actnAddGroup->setVisible( true );
+  }
 }
 
 void QgsStyleV2ManagerDialog::addGroup()
@@ -1324,28 +1344,8 @@ void QgsStyleV2ManagerDialog::grouptreeContextMenu( const QPoint& point )
   QModelIndex index = groupTree->indexAt( point );
   QgsDebugMsg( "Now you clicked: " + index.data().toString() );
 
-  actnEditSmartGroup->setVisible( false );
-  actnAddGroup->setVisible( false );
-  actnRemoveGroup->setVisible( false );
-
-  if ( index.parent().isValid() && ( index.data().toString() != "Ungrouped" ) )
-  {
-    if ( index.parent().data( Qt::UserRole + 1 ).toString() == "smartgroups" )
-    {
-      actnEditSmartGroup->setVisible( true );
-    }
-    else
-    {
-      actnAddGroup->setVisible( true );
-    }
-    actnRemoveGroup->setVisible( true );
-  }
-  else if ( index.data( Qt::UserRole + 1 ) == "groups" || index.data( Qt::UserRole + 1 ) == "smartgroups" )
-  {
-    actnAddGroup->setVisible( true );
-  }
-
-  mGroupTreeContextMenu->popup( globalPos );
+  if ( index.isValid() )
+    mGroupTreeContextMenu->popup( globalPos );
 }
 
 void QgsStyleV2ManagerDialog::listitemsContextMenu( const QPoint& point )

--- a/src/gui/symbology-ng/qgsstylev2managerdialog.cpp
+++ b/src/gui/symbology-ng/qgsstylev2managerdialog.cpp
@@ -713,6 +713,12 @@ void QgsStyleV2ManagerDialog::removeItem()
 bool QgsStyleV2ManagerDialog::removeSymbol()
 {
   QModelIndexList indexes = listItems->selectionModel()->selectedIndexes();
+  if ( QMessageBox::Yes != QMessageBox::question( this, tr( "Confirm removal" ),
+       QString( tr( "Do you really want to remove %n symbol(s)?", nullptr, indexes.count() ) ),
+       QMessageBox::Yes,
+       QMessageBox::No ) )
+    return false;
+
   Q_FOREACH ( const QModelIndex& index, indexes )
   {
     QString symbolName = index.data().toString();
@@ -728,6 +734,11 @@ bool QgsStyleV2ManagerDialog::removeColorRamp()
 {
   QString rampName = currentItemName();
   if ( rampName.isEmpty() )
+    return false;
+  if ( QMessageBox::Yes != QMessageBox::question( this, tr( "Confirm removal" ),
+       QString( tr( "Do you really want to remove the colorramp '%1'?" ) ).arg( rampName ),
+       QMessageBox::Yes,
+       QMessageBox::No ) )
     return false;
 
   mStyle->removeColorRamp( rampName );

--- a/src/gui/symbology-ng/qgsstylev2managerdialog.cpp
+++ b/src/gui/symbology-ng/qgsstylev2managerdialog.cpp
@@ -64,11 +64,11 @@ QgsStyleV2ManagerDialog::QgsStyleV2ManagerDialog( QgsStyleV2* style, QWidget* pa
   connect( btnEditItem, SIGNAL( clicked() ), this, SLOT( editItem() ) );
   connect( btnRemoveItem, SIGNAL( clicked() ), this, SLOT( removeItem() ) );
 
-  QMenu *shareMenu = new QMenu( tr( "Share Menu" ), this );
-  QAction *exportAsPNGAction = shareMenu->addAction( tr( "Export as PNG" ) );
-  QAction *exportAsSVGAction = shareMenu->addAction( tr( "Export as SVG" ) );
-  QAction *exportAction = shareMenu->addAction( tr( "Export" ) );
-  QAction *importAction = shareMenu->addAction( tr( "Import" ) );
+  QMenu *shareMenu = new QMenu( tr( "Share menu" ), this );
+  QAction *exportAsPNGAction = shareMenu->addAction( tr( "Export selected symbols as PNG" ) );
+  QAction *exportAsSVGAction = shareMenu->addAction( tr( "Export selected symbols as SVG" ) );
+  QAction *exportAction = shareMenu->addAction( tr( "Export..." ) );
+  QAction *importAction = shareMenu->addAction( tr( "Import..." ) );
   exportAsPNGAction->setIcon( QIcon( QgsApplication::iconPath( "mActionSharingExport.svg" ) ) );
   exportAsSVGAction->setIcon( QIcon( QgsApplication::iconPath( "mActionSharingExport.svg" ) ) );
   exportAction->setIcon( QIcon( QgsApplication::iconPath( "mActionSharingExport.svg" ) ) );
@@ -101,9 +101,9 @@ QgsStyleV2ManagerDialog::QgsStyleV2ManagerDialog( QgsStyleV2* style, QWidget* pa
   connect( groupModel, SIGNAL( itemChanged( QStandardItem* ) ),
            this, SLOT( groupRenamed( QStandardItem* ) ) );
 
-  QMenu *groupMenu = new QMenu( tr( "Group Actions" ), this );
-  QAction *groupSymbols = groupMenu->addAction( tr( "Group Symbols" ) );
-  QAction *editSmartgroup = groupMenu->addAction( tr( "Edit Smart Group" ) );
+  QMenu *groupMenu = new QMenu( tr( "Group actions" ), this );
+  QAction *groupSymbols = groupMenu->addAction( tr( "Group symbols" ) );
+  QAction *editSmartgroup = groupMenu->addAction( tr( "Edit smart group" ) );
   btnManageGroups->setMenu( groupMenu );
   connect( groupSymbols, SIGNAL( triggered() ), this, SLOT( groupSymbolsAction() ) );
   connect( editSmartgroup, SIGNAL( triggered() ), this, SLOT( editSmartgroupAction() ) );
@@ -1057,7 +1057,7 @@ void QgsStyleV2ManagerDialog::groupSymbolsAction()
   if ( mGrouppingMode )
   {
     mGrouppingMode = false;
-    senderAction->setText( tr( "Group Symbols" ) );
+    senderAction->setText( tr( "Group symbols" ) );
     // disconnect slot which handles regrouping
     disconnect( model, SIGNAL( itemChanged( QStandardItem* ) ),
                 this, SLOT( regrouped( QStandardItem* ) ) );
@@ -1094,7 +1094,7 @@ void QgsStyleV2ManagerDialog::groupSymbolsAction()
 
     mGrouppingMode = true;
     // Change the text menu
-    senderAction->setText( tr( "Finish Grouping" ) );
+    senderAction->setText( tr( "Finish grouping" ) );
     // Remove all Symbol editing functionalities
     disconnect( treeModel, SIGNAL( itemChanged( QStandardItem* ) ),
                 this, SLOT( groupRenamed( QStandardItem* ) ) );
@@ -1296,17 +1296,17 @@ void QgsStyleV2ManagerDialog::grouptreeContextMenu( const QPoint& point )
   {
     if ( index.parent().data( Qt::UserRole + 1 ).toString() == "smartgroups" )
     {
-      groupMenu.addAction( tr( "Edit Group" ) );
+      groupMenu.addAction( tr( "Edit smart group" ) );
     }
     else
     {
-      groupMenu.addAction( tr( "Add Group" ) );
+      groupMenu.addAction( tr( "Add group" ) );
     }
-    groupMenu.addAction( tr( "Remove Group" ) );
+    groupMenu.addAction( tr( "Remove group" ) );
   }
   else if ( index.data( Qt::UserRole + 1 ) == "groups" || index.data( Qt::UserRole + 1 ) == "smartgroups" )
   {
-    groupMenu.addAction( tr( "Add Group" ) );
+    groupMenu.addAction( tr( "Add group" ) );
   }
 
 
@@ -1314,11 +1314,11 @@ void QgsStyleV2ManagerDialog::grouptreeContextMenu( const QPoint& point )
 
   if ( selectedItem )
   {
-    if ( selectedItem->text() == tr( "Add Group" ) )
+    if ( selectedItem->text() == tr( "Add group" ) )
       addGroup();
-    else if ( selectedItem->text() == tr( "Remove Group" ) )
+    else if ( selectedItem->text() == tr( "Remove group" ) )
       removeGroup();
-    else if ( selectedItem->text() == tr( "Edit Group" ) )
+    else if ( selectedItem->text() == tr( "Edit smart group" ) )
       editSmartgroupAction();
   }
 }

--- a/src/gui/symbology-ng/qgsstylev2managerdialog.h
+++ b/src/gui/symbology-ng/qgsstylev2managerdialog.h
@@ -81,6 +81,9 @@ class GUI_EXPORT QgsStyleV2ManagerDialog : public QDialog, private Ui::QgsStyleV
     //! Perform symbol specific tasks when selected
     void symbolSelected( const QModelIndex& );
 
+    //! Perform tasks when the selected symbols change
+    void selectedSymbolsChanged( const QItemSelection& selected, const QItemSelection& deselected );
+
     //! Context menu for the groupTree
     void grouptreeContextMenu( const QPoint& );
 

--- a/src/gui/symbology-ng/qgsstylev2managerdialog.h
+++ b/src/gui/symbology-ng/qgsstylev2managerdialog.h
@@ -146,6 +146,15 @@ class GUI_EXPORT QgsStyleV2ManagerDialog : public QDialog, private Ui::QgsStyleV
 
     //! space to store symbol tags
     QStringList mTagList;
+
+    //! Context menu for the symbols/colorramps
+    QMenu *mGroupMenu;
+
+    //! Sub-menu of @c mGroupMenu, dynamically filled to show one entry for every group
+    QMenu *mGroupListMenu;
+
+    //! Menu for the "Add item" toolbutton when in colorramp mode
+    QMenu* mMenuBtnAddItemColorRamp;
 };
 
 #endif

--- a/src/gui/symbology-ng/qgsstylev2managerdialog.h
+++ b/src/gui/symbology-ng/qgsstylev2managerdialog.h
@@ -92,6 +92,7 @@ class GUI_EXPORT QgsStyleV2ManagerDialog : public QDialog, private Ui::QgsStyleV
 
   protected slots:
     bool addColorRamp( QAction* action );
+    void groupSelectedSymbols();
 
   protected:
 
@@ -155,6 +156,9 @@ class GUI_EXPORT QgsStyleV2ManagerDialog : public QDialog, private Ui::QgsStyleV
 
     //! Sub-menu of @c mGroupMenu, dynamically filled to show one entry for every group
     QMenu *mGroupListMenu;
+
+    //! Context menu for the group tree
+    QMenu* mGroupTreeContextMenu;
 
     //! Menu for the "Add item" toolbutton when in colorramp mode
     QMenu* mMenuBtnAddItemColorRamp;

--- a/src/ui/qgsstylev2managerdialogbase.ui
+++ b/src/ui/qgsstylev2managerdialogbase.ui
@@ -461,6 +461,29 @@ QMenu::item:selected {  background-color: gray; } */
     <string>Ungroup</string>
    </property>
   </action>
+  <action name="actnEditSmartGroup">
+   <property name="text">
+    <string>Edit smart group...</string>
+   </property>
+  </action>
+  <action name="actnAddGroup">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/symbologyAdd.png</normaloff>:/images/themes/default/symbologyAdd.png</iconset>
+   </property>
+   <property name="text">
+    <string>Add group</string>
+   </property>
+  </action>
+  <action name="actnRemoveGroup">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/symbologyRemove.png</normaloff>:/images/themes/default/symbologyRemove.png</iconset>
+   </property>
+   <property name="text">
+    <string>Remove group</string>
+   </property>
+  </action>
   <action name="actnExportAsPNG">
    <property name="enabled">
     <bool>false</bool>
@@ -530,6 +553,38 @@ QMenu::item:selected {  background-color: gray; } */
     <hint type="destinationlabel">
      <x>299</x>
      <y>351</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>btnAddGroup</sender>
+   <signal>clicked()</signal>
+   <receiver>actnAddGroup</receiver>
+   <slot>trigger()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>46</x>
+     <y>362</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>-1</x>
+     <y>-1</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>btnRemoveGroup</sender>
+   <signal>clicked()</signal>
+   <receiver>actnRemoveGroup</receiver>
+   <slot>trigger()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>133</x>
+     <y>362</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>-1</x>
+     <y>-1</y>
     </hint>
    </hints>
   </connection>

--- a/src/ui/qgsstylev2managerdialogbase.ui
+++ b/src/ui/qgsstylev2managerdialogbase.ui
@@ -420,6 +420,17 @@ QMenu::item:selected {  background-color: gray; } */
     </widget>
    </item>
   </layout>
+  <action name="actnUngroup">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="text">
+    <string>Ungroup</string>
+   </property>
+   <property name="toolTip">
+    <string>Ungroup</string>
+   </property>
+  </action>
  </widget>
  <customwidgets>
   <customwidget>

--- a/src/ui/qgsstylev2managerdialogbase.ui
+++ b/src/ui/qgsstylev2managerdialogbase.ui
@@ -420,6 +420,36 @@ QMenu::item:selected {  background-color: gray; } */
     </widget>
    </item>
   </layout>
+  <action name="actnRemoveItem">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/symbologyRemove.png</normaloff>:/images/themes/default/symbologyRemove.png</iconset>
+   </property>
+   <property name="text">
+    <string>Remove item(s)</string>
+   </property>
+   <property name="toolTip">
+    <string>Remove item(s)</string>
+   </property>
+  </action>
+  <action name="actnEditItem">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionProjectProperties.png</normaloff>:/images/themes/default/mActionProjectProperties.png</iconset>
+   </property>
+   <property name="text">
+    <string>Edit item...</string>
+   </property>
+   <property name="toolTip">
+    <string>Edit item</string>
+   </property>
+  </action>
   <action name="actnUngroup">
    <property name="enabled">
     <bool>false</bool>
@@ -429,6 +459,36 @@ QMenu::item:selected {  background-color: gray; } */
    </property>
    <property name="toolTip">
     <string>Ungroup</string>
+   </property>
+  </action>
+  <action name="actnExportAsPNG">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionSharingExport.svg</normaloff>:/images/themes/default/mActionSharingExport.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Export selected symbol(s) as PNG...</string>
+   </property>
+   <property name="toolTip">
+    <string>Export selected symbo(s) as PNG</string>
+   </property>
+  </action>
+  <action name="actnExportAsSVG">
+   <property name="enabled">
+    <bool>false</bool>
+   </property>
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionSharingExport.svg</normaloff>:/images/themes/default/mActionSharingExport.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Export selected symbol(s) as SVG...</string>
+   </property>
+   <property name="toolTip">
+    <string>Export selected symbol(s) as SVG</string>
    </property>
   </action>
  </widget>

--- a/src/ui/qgsstylev2managerdialogbase.ui
+++ b/src/ui/qgsstylev2managerdialogbase.ui
@@ -484,6 +484,22 @@ QMenu::item:selected {  background-color: gray; } */
     <string>Remove group</string>
    </property>
   </action>
+  <action name="actnGroupSymbols">
+   <property name="text">
+    <string>Group symbols</string>
+   </property>
+  </action>
+  <action name="actnFinishGrouping">
+   <property name="enabled">
+    <bool>true</bool>
+   </property>
+   <property name="text">
+    <string>Finish grouping</string>
+   </property>
+   <property name="visible">
+    <bool>true</bool>
+   </property>
+  </action>
   <action name="actnExportAsPNG">
    <property name="enabled">
     <bool>false</bool>


### PR DESCRIPTION
While fixing some bugs in style manager I stumbled upon a few UI issues:
- minor **memory leaks** caused by orphaned `QMenu`s and `QAction`s
- **labels**
  - not following the guidelines regarding capitalization or usage of '...'
  - being unclear
  - denominating the wrong entity type (_style_ instead of _symbol_)
  - being different for identical action
- **actions**
  - still enabled when not available
  - missing in context menu
