### PR TITLE
add method for getting datasource feature ID by internal QGIS feature ID

### DIFF
--- a/python/core/qgsvectordataprovider.sip
+++ b/python/core/qgsvectordataprovider.sip
@@ -240,6 +240,13 @@ class QgsVectorDataProvider : QgsDataProvider
     int fieldNameIndex( const QString& fieldName ) const;
 
     /**
+     * Returns feature datasource ID from the internal QGIS feature ID
+     *
+     * @note added in 2.14
+     */
+    virtual QVariant dataSourceFeatureId( const QgsFeatureId fid ) const;
+
+    /**
      * Return a map where the key is the name of the field and the value is its index
      */
     QMap<QString, int> fieldNameMap() const;

--- a/src/core/qgsvectordataprovider.cpp
+++ b/src/core/qgsvectordataprovider.cpp
@@ -210,7 +210,6 @@ QString QgsVectorDataProvider::capabilitiesString() const
 
 }
 
-
 int QgsVectorDataProvider::fieldNameIndex( const QString& fieldName ) const
 {
   const QgsFields &theFields = fields();
@@ -223,6 +222,12 @@ int QgsVectorDataProvider::fieldNameIndex( const QString& fieldName ) const
     }
   }
   return -1;
+}
+
+QVariant QgsVectorDataProvider::dataSourceFeatureId( const QgsFeatureId fid ) const
+{
+  Q_UNUSED( fid );
+  return QVariant();
 }
 
 QMap<QString, int> QgsVectorDataProvider::fieldNameMap() const

--- a/src/core/qgsvectordataprovider.h
+++ b/src/core/qgsvectordataprovider.h
@@ -290,6 +290,13 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider
     int fieldNameIndex( const QString& fieldName ) const;
 
     /**
+     * Returns feature datasource ID from the internal QGIS feature ID
+     *
+     * @note added in 2.14
+     */
+    virtual QVariant dataSourceFeatureId( const QgsFeatureId fid ) const;
+
+    /**
      * Return a map where the key is the name of the field and the value is its index
      */
     QMap<QString, int> fieldNameMap() const;

--- a/src/providers/wfs/qgswfsprovider.cpp
+++ b/src/providers/wfs/qgswfsprovider.cpp
@@ -1637,6 +1637,12 @@ void QgsWFSProvider::appendSupportedOperations( const QDomElement& operationsEle
   }
 }
 
+QVariant QgsWFSProvider::dataSourceFeatureId( const QgsFeatureId fid ) const
+{
+  QMap< QgsFeatureId, QString >::const_iterator idIt = mIdMap.find( fid );
+  return QVariant( idIt.value() );
+}
+
 #if 0
 //initialization for getRenderedOnly option
 //(formerly "Only request features overlapping the current view extent")

--- a/src/providers/wfs/qgswfsprovider.h
+++ b/src/providers/wfs/qgswfsprovider.h
@@ -144,6 +144,11 @@ class QgsWFSProvider : public QgsVectorDataProvider
      */
     virtual bool changeAttributeValues( const QgsChangedAttributesMap &attr_map ) override;
 
+    /**
+     * Returns feature datasource ID from the internal QGIS feature ID
+     */
+    virtual QVariant dataSourceFeatureId( const QgsFeatureId fid ) const override;
+
     /** Collects information about the field types. Is called internally from QgsWFSProvider ctor. The method delegates the work to request specific ones and gives back the name of the geometry attribute and the thematic attributes with their types*/
     int describeFeatureType( const QString& uri, QString& geometryAttribute,
                              QgsFields& fields, QGis::WkbType& geomType );


### PR DESCRIPTION
This may be useful for 3rd party tools that need to operate with datasource IDs. 

For example, one may need custom identify tool which query additional information from associated tables or download associated with feature data files.

For now makes sense only for WFS provider, as only this provider generates internal IDs for layer features.
