### PR TITLE
[ui] move the save symbol button

### DIFF
--- a/python/gui/symbology-ng/qgssymbolslistwidget.sip
+++ b/python/gui/symbology-ng/qgssymbolslistwidget.sip
@@ -51,6 +51,7 @@ class QgsSymbolsListWidget : QWidget
     void setMarkerSize( double size );
     void setLineWidth( double width );
     void addSymbolToStyle();
+    void saveSymbol();
     void symbolAddedToStyle( const QString& name, QgsSymbolV2* symbol );
     void on_mSymbolUnitWidget_changed();
     void on_mTransparencySlider_valueChanged( int value );

--- a/python/gui/symbology-ng/qgssymbolv2selectordialog.sip
+++ b/python/gui/symbology-ng/qgssymbolv2selectordialog.sip
@@ -64,8 +64,9 @@ class QgsSymbolV2SelectorDialog : QDialog
     void addLayer();
     void removeLayer();
 
-    void saveSymbol();
     void lockLayer();
+
+    void saveSymbol() /Deprecated/;
 
     //! Duplicates the current symbol layer and places the duplicated layer above the current symbol layer
     //! @note added in QGIS 2.14

--- a/src/gui/symbology-ng/qgssymbolslistwidget.cpp
+++ b/src/gui/symbology-ng/qgssymbolslistwidget.cpp
@@ -118,6 +118,8 @@ QgsSymbolsListWidget::QgsSymbolsListWidget( QgsSymbolV2* symbol, QgsStyleV2* sty
   btnColor->setAllowAlpha( true );
   btnColor->setColorDialogTitle( tr( "Select color" ) );
   btnColor->setContext( "symbology" );
+
+  connect( btnSaveSymbol, SIGNAL( clicked() ), this, SLOT( saveSymbol() ) );
 }
 
 QgsSymbolsListWidget::~QgsSymbolsListWidget()
@@ -358,6 +360,34 @@ void QgsSymbolsListWidget::addSymbolToStyle()
   // make sure the symbol is stored
   mStyle->saveSymbol( name, mSymbol->clone(), 0, QStringList() );
   populateSymbolView();
+}
+
+void QgsSymbolsListWidget::saveSymbol()
+{
+  bool ok;
+  QString name = QInputDialog::getText( this, tr( "Symbol name" ),
+                                        tr( "Please enter name for the symbol:" ), QLineEdit::Normal, tr( "New symbol" ), &ok );
+  if ( !ok || name.isEmpty() )
+    return;
+
+  // check if there is no symbol with same name
+  if ( mStyle->symbolNames().contains( name ) )
+  {
+    int res = QMessageBox::warning( this, tr( "Save symbol" ),
+                                    tr( "Symbol with name '%1' already exists. Overwrite?" )
+                                    .arg( name ),
+                                    QMessageBox::Yes | QMessageBox::No );
+    if ( res != QMessageBox::Yes )
+    {
+      return;
+    }
+  }
+
+  // add new symbol to style and re-populate the list
+  mStyle->addSymbol( name, mSymbol->clone() );
+
+  // make sure the symbol is stored
+  mStyle->saveSymbol( name, mSymbol->clone(), 0, QStringList() );
 }
 
 void QgsSymbolsListWidget::on_mSymbolUnitWidget_changed()

--- a/src/gui/symbology-ng/qgssymbolslistwidget.h
+++ b/src/gui/symbology-ng/qgssymbolslistwidget.h
@@ -81,6 +81,7 @@ class GUI_EXPORT QgsSymbolsListWidget : public QWidget, private Ui::SymbolsListW
     void setMarkerSize( double size );
     void setLineWidth( double width );
     void addSymbolToStyle();
+    void saveSymbol();
     void symbolAddedToStyle( const QString& name, QgsSymbolV2* symbol );
     void on_mSymbolUnitWidget_changed();
     void on_mTransparencySlider_valueChanged( int value );

--- a/src/gui/symbology-ng/qgssymbolv2selectordialog.cpp
+++ b/src/gui/symbology-ng/qgssymbolv2selectordialog.cpp
@@ -261,7 +261,6 @@ QgsSymbolV2SelectorDialog::QgsSymbolV2SelectorDialog( QgsSymbolV2* symbol, QgsSt
   connect( btnRemoveLayer, SIGNAL( clicked() ), this, SLOT( removeLayer() ) );
   connect( btnLock, SIGNAL( clicked() ), this, SLOT( lockLayer() ) );
   connect( btnDuplicate, SIGNAL( clicked() ), this, SLOT( duplicateLayer() ) );
-  connect( btnSaveSymbol, SIGNAL( clicked() ), this, SLOT( saveSymbol() ) );
 
   updateUi();
 

--- a/src/gui/symbology-ng/qgssymbolv2selectordialog.h
+++ b/src/gui/symbology-ng/qgssymbolv2selectordialog.h
@@ -136,8 +136,9 @@ class GUI_EXPORT QgsSymbolV2SelectorDialog : public QDialog, private Ui::QgsSymb
     void addLayer();
     void removeLayer();
 
-    void saveSymbol();
     void lockLayer();
+
+    Q_DECL_DEPRECATED void saveSymbol();
 
     //! Duplicates the current symbol layer and places the duplicated layer above the current symbol layer
     //! @note added in QGIS 2.14

--- a/src/ui/qgssymbolv2selectordialogbase.ui
+++ b/src/ui/qgssymbolv2selectordialogbase.ui
@@ -159,22 +159,6 @@
          </property>
         </spacer>
        </item>
-       <item>
-        <widget class="QPushButton" name="btnSaveSymbol">
-         <property name="maximumSize">
-          <size>
-           <width>70</width>
-           <height>16777215</height>
-          </size>
-         </property>
-         <property name="toolTip">
-          <string>Save symbol</string>
-         </property>
-         <property name="text">
-          <string>Save</string>
-         </property>
-        </widget>
-       </item>
       </layout>
      </item>
     </layout>

--- a/src/ui/symbollayer/widget_symbolslist.ui
+++ b/src/ui/symbollayer/widget_symbolslist.ui
@@ -338,6 +338,22 @@
       </spacer>
      </item>
      <item>
+      <widget class="QPushButton" name="btnSaveSymbol">
+       <property name="maximumSize">
+        <size>
+         <width>70</width>
+         <height>16777215</height>
+        </size>
+       </property>
+       <property name="toolTip">
+        <string>Save symbol</string>
+       </property>
+       <property name="text">
+        <string>Save</string>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QPushButton" name="btnAdvanced">
        <property name="text">
         <string>Advanced</string>
@@ -391,6 +407,7 @@
   <tabstop>groupsCombo</tabstop>
   <tabstop>openStyleManagerButton</tabstop>
   <tabstop>viewSymbols</tabstop>
+  <tabstop>btnSaveSymbol</tabstop>
   <tabstop>btnAdvanced</tabstop>
  </tabstops>
  <resources/>


### PR DESCRIPTION
With the addition of a duplicate button in the symbol layer selection area, I feel the width is becoming overly large, creating lots of unused empty white space. 

To remedy to this, I'm thinking we could move the save symbol button to be located next to the advanced button in the symbol selector panel. In addition to saving space, it would IMO make better sense as the save symbol button does _not_, contrary to the other buttons next to it ATM, affect a symbol layer.

As it stands currently:
![original](https://cloud.githubusercontent.com/assets/1728657/12162212/46df9936-b531-11e5-9888-45336ee33ffc.png)

Proposal:
![moved](https://cloud.githubusercontent.com/assets/1728657/12162217/4d390588-b531-11e5-8151-e9c7a6f69229.png)

@nyalldawson , @anitagraser , what do you think of this?
