### PR TITLE
Fix some oddities in server access control and bindings

### DIFF
--- a/python/server/qgsaccesscontrolfilter.sip
+++ b/python/server/qgsaccesscontrolfilter.sip
@@ -34,9 +34,6 @@ class QgsAccessControlFilter
 {
 %TypeHeaderCode
 #include "qgsaccesscontrolfilter.h"
-#include "qgsserverinterface.h"
-#include "qgsfeature.h"
-#include "qgsmaplayer.h"
 %End
 
   public:
@@ -60,18 +57,18 @@ class QgsAccessControlFilter
     /** Return the QgsServerInterface instance*/
     const QgsServerInterface* serverInterface() const;
     /** Return an additional expression filter */
-    virtual const QString layerFilterExpression( const QgsVectorLayer* layer /Transfer/ ) const;
+    virtual QString layerFilterExpression( const QgsVectorLayer* layer ) const;
     /** Return an additional the subset string (typically SQL) filter.
         Faster than the layerFilterExpression but not supported on all the type of layer */
-    virtual const QString layerFilterSubsetString( const QgsVectorLayer* layer /Transfer/ ) const;
+    virtual QString layerFilterSubsetString( const QgsVectorLayer* layer ) const;
     /** Return the layer permissions */
-    virtual const LayerPermissions layerPermissions( const QgsMapLayer* layer /Transfer/ ) const;
+    virtual LayerPermissions layerPermissions( const QgsMapLayer* layer ) const;
     /** Return the authorized layer attributes */
-    virtual const QStringList* authorizedLayerAttributes( const QgsVectorLayer* layer /Transfer/, const QStringList& attributes ) const;
+    virtual QStringList authorizedLayerAttributes( const QgsVectorLayer* layer, const QStringList& attributes ) const;
     /** Are we authorize to modify the following geometry */
-    virtual bool allowToEdit( const QgsVectorLayer* layer /Transfer/, const QgsFeature& feature /Transfer/ ) const;
+    virtual bool allowToEdit( const QgsVectorLayer* layer, const QgsFeature& feature ) const;
     /** Cache key to used to create the capabilities cache, "" for no cache, shouldn't any contains "-", default to "" */
-    virtual const QString cacheKey() const;
+    virtual QString cacheKey() const;
 };
 
 typedef QMultiMap<int, QgsAccessControlFilter*> QgsAccessControlFilterMap;

--- a/src/server/qgsaccesscontrol.cpp
+++ b/src/server/qgsaccesscontrol.cpp
@@ -30,7 +30,7 @@ void QgsAccessControl::filterFeatures( const QgsVectorLayer* layer, QgsFeatureRe
   QgsAccessControlFilterMap::const_iterator acIterator;
   for ( acIterator = mPluginsAccessControls->constBegin(); acIterator != mPluginsAccessControls->constEnd(); ++acIterator )
   {
-    const QString expression = acIterator.value()->layerFilterExpression( layer );
+    QString expression = acIterator.value()->layerFilterExpression( layer );
     if ( !expression.isEmpty() )
     {
       expressions.append( expression );
@@ -49,13 +49,13 @@ QgsFeatureFilterProvider* QgsAccessControl::clone() const
 }
 
 /** Return an additional subset string (typically SQL) filter */
-const QString QgsAccessControl::extraSubsetString( const QgsVectorLayer* layer ) const
+QString QgsAccessControl::extraSubsetString( const QgsVectorLayer* layer ) const
 {
   QStringList sqls = QStringList();
   QgsAccessControlFilterMap::const_iterator acIterator;
   for ( acIterator = mPluginsAccessControls->constBegin(); acIterator != mPluginsAccessControls->constEnd(); ++acIterator )
   {
-    const QString sql = acIterator.value()->layerFilterSubsetString( layer );
+    QString sql = acIterator.value()->layerFilterSubsetString( layer );
     if ( !sql.isEmpty() )
     {
       sqls.append( sql );
@@ -121,17 +121,13 @@ bool QgsAccessControl::layerDeletePermission( const QgsVectorLayer* layer ) cons
 }
 
 /** Return the authorized layer attributes */
-const QStringList QgsAccessControl::layerAttributes( const QgsVectorLayer* layer, const QStringList attributes ) const
+QStringList QgsAccessControl::layerAttributes( const QgsVectorLayer* layer, const QStringList& attributes ) const
 {
   QStringList currentAttributes( attributes );
   QgsAccessControlFilterMap::const_iterator acIterator;
   for ( acIterator = mPluginsAccessControls->constBegin(); acIterator != mPluginsAccessControls->constEnd(); ++acIterator )
   {
-    const QStringList* newAttributes = acIterator.value()->authorizedLayerAttributes( layer, currentAttributes );
-    if ( newAttributes )
-    {
-      currentAttributes = *newAttributes;
-    }
+    currentAttributes = acIterator.value()->authorizedLayerAttributes( layer, currentAttributes );
   }
   return currentAttributes;
 }

--- a/src/server/qgsaccesscontrol.h
+++ b/src/server/qgsaccesscontrol.h
@@ -67,7 +67,7 @@ class SERVER_EXPORT QgsAccessControl : public QgsFeatureFilterProvider
      * @param layer the layer to control
      * @return the subset string to use
      */
-    const QString extraSubsetString( const QgsVectorLayer* layer ) const;
+    QString extraSubsetString( const QgsVectorLayer* layer ) const;
 
     /** Return the layer read right
      * @param layer the layer to control
@@ -98,7 +98,7 @@ class SERVER_EXPORT QgsAccessControl : public QgsFeatureFilterProvider
      * @param attributes the list of attribute
      * @return the list of visible attributes
      */
-    const QStringList layerAttributes( const QgsVectorLayer* layer, const QStringList attributes ) const;
+    QStringList layerAttributes( const QgsVectorLayer* layer, const QStringList& attributes ) const;
 
     /** Are we authorized to modify the following geometry
      * @param layer the layer to control

--- a/src/server/qgsaccesscontrolfilter.cpp
+++ b/src/server/qgsaccesscontrolfilter.cpp
@@ -38,23 +38,23 @@ QgsAccessControlFilter::~QgsAccessControlFilter()
 }
 
 /** Return an additional layer expression filter */
-const QString QgsAccessControlFilter::layerFilterExpression( const QgsVectorLayer* layer ) const
+QString QgsAccessControlFilter::layerFilterExpression( const QgsVectorLayer* layer ) const
 {
   QgsMessageLog::logMessage( "QgsAccessControlFilter plugin default layerFilterExpression called", "AccessControlFilter", QgsMessageLog::INFO );
   Q_UNUSED( layer );
-  return nullptr;
+  return QString();
 }
 
 /** Return an additional layer subset string (typically SQL) filter */
-const QString QgsAccessControlFilter::layerFilterSubsetString( const QgsVectorLayer* layer ) const
+QString QgsAccessControlFilter::layerFilterSubsetString( const QgsVectorLayer* layer ) const
 {
   QgsMessageLog::logMessage( "QgsAccessControlFilter plugin default layerFilterSQL called", "AccessControlFilter", QgsMessageLog::INFO );
   Q_UNUSED( layer );
-  return nullptr;
+  return QString();
 }
 
 /** Return the layer permissions */
-const QgsAccessControlFilter::LayerPermissions QgsAccessControlFilter::layerPermissions( const QgsMapLayer* layer ) const
+QgsAccessControlFilter::LayerPermissions QgsAccessControlFilter::layerPermissions( const QgsMapLayer* layer ) const
 {
   QgsMessageLog::logMessage( "QgsAccessControlFilter plugin default layerPermissions called", "AccessControlFilter", QgsMessageLog::INFO );
   Q_UNUSED( layer );
@@ -64,12 +64,11 @@ const QgsAccessControlFilter::LayerPermissions QgsAccessControlFilter::layerPerm
 }
 
 /** Return the authorized layer attributes */
-const QStringList* QgsAccessControlFilter::authorizedLayerAttributes( const QgsVectorLayer* layer, const QStringList& attributes ) const
+QStringList QgsAccessControlFilter::authorizedLayerAttributes( const QgsVectorLayer* layer, const QStringList& attributes ) const
 {
   Q_UNUSED( layer );
-  Q_UNUSED( attributes );
   QgsMessageLog::logMessage( "QgsAccessControlFilter plugin default authorizedLayerAttributes called", "AccessControlFilter", QgsMessageLog::INFO );
-  return nullptr;
+  return attributes;
 }
 
 /** Are we authorized to modify the feature */
@@ -82,7 +81,7 @@ bool QgsAccessControlFilter::allowToEdit( const QgsVectorLayer* layer, const Qgs
 }
 
 /** Cache key to used to create the capabilities cache, "" for no cache */
-const QString QgsAccessControlFilter::cacheKey() const
+QString QgsAccessControlFilter::cacheKey() const
 {
-  return "";
+  return QString();
 }

--- a/src/server/qgsaccesscontrolfilter.h
+++ b/src/server/qgsaccesscontrolfilter.h
@@ -69,26 +69,26 @@ class SERVER_EXPORT QgsAccessControlFilter
      * @param layer the layer to control
      * @return the filter expression
      */
-    virtual const QString layerFilterExpression( const QgsVectorLayer* layer ) const;
+    virtual QString layerFilterExpression( const QgsVectorLayer* layer ) const;
 
     /** Return an additional subset string (typically SQL) filter
      * @param layer the layer to control
      * @return the subset string
      */
-    virtual const QString layerFilterSubsetString( const QgsVectorLayer* layer ) const;
+    virtual QString layerFilterSubsetString( const QgsVectorLayer* layer ) const;
 
     /** Return the layer permissions
      * @param layer the layer to control
      * @return the permission to use on the layer
      */
-    virtual const LayerPermissions layerPermissions( const QgsMapLayer* layer ) const;
+    virtual LayerPermissions layerPermissions( const QgsMapLayer* layer ) const;
 
     /** Return the authorized layer attributes
      * @param layer the layer to control
      * @param attributes the current list of visible attribute
      * @return the new list of visible attributes
      */
-    virtual const QStringList* authorizedLayerAttributes( const QgsVectorLayer* layer, const QStringList& attributes ) const;
+    virtual QStringList authorizedLayerAttributes( const QgsVectorLayer* layer, const QStringList& attributes ) const;
 
     /** Are we authorized to modify the following geometry
      * @param layer the layer to control
@@ -100,7 +100,7 @@ class SERVER_EXPORT QgsAccessControlFilter
     /** Cache key to used to create the capabilities cache
      * @return the cache key, "" for no cache
      */
-    virtual const QString cacheKey() const;
+    virtual QString cacheKey() const;
 
   private:
 


### PR DESCRIPTION
I've noticed some strangeness in the access control code and bindings. @sbrunner do you mind taking a look?
- remove map layer and feature /Transfer/ annotations from sip bindings
- change nullptr return values to empty strings
- change attributes from a list pointer to a QStringList, make default implementation return all attributes unchanged
