### PR TITLE
[StyleManager] Respect entered groupname when importing symbols (fixes #14048)

### DIFF
--- a/src/gui/symbology-ng/qgsstylev2exportimportdialog.cpp
+++ b/src/gui/symbology-ng/qgsstylev2exportimportdialog.cpp
@@ -227,8 +227,8 @@ void QgsStyleV2ExportImportDialog::moveStyles( QModelIndexList* selection, QgsSt
   // get the groupid when going for import
   if ( mDialogMode == Import )
   {
-    int index = groupCombo->currentIndex();
-    QString name = groupCombo->itemText( index );
+    // get the name the user entered
+    QString name = groupCombo->currentText();
     if ( name.isEmpty() )
     {
       // get name of the group

--- a/src/gui/symbology-ng/qgsstylev2exportimportdialog.cpp
+++ b/src/gui/symbology-ng/qgsstylev2exportimportdialog.cpp
@@ -231,35 +231,8 @@ void QgsStyleV2ExportImportDialog::moveStyles( QModelIndexList* selection, QgsSt
     QString name = groupCombo->currentText();
     if ( name.isEmpty() )
     {
-      // get name of the group
-      bool nameInvalid = true;
-      while ( nameInvalid )
-      {
-        bool ok;
-        name = QInputDialog::getText( this, tr( "Group Name" ),
-                                      tr( "Please enter a name for new group:" ),
-                                      QLineEdit::Normal,
-                                      tr( "imported" ),
-                                      &ok );
-        if ( !ok )
-        {
-          QMessageBox::warning( this, tr( "New Group" ),
-                                tr( "New group cannot be created without a name. Kindly enter a name." ) );
-          continue;
-        }
-        // validate name
-        if ( name.isEmpty() )
-        {
-          QMessageBox::warning( this, tr( "New group" ),
-                                tr( "Cannot create a group without name. Enter a name." ) );
-        }
-        else
-        {
-          // valid name
-          nameInvalid = false;
-        }
-      }
-      groupid = dst->addGroup( name );
+      // import to "ungrouped"
+      groupid = 0;
     }
     else if ( dst->groupNames().contains( name ) )
     {


### PR DESCRIPTION
When importing symbols in the style manager, the imported symbols where either placed into
- a group named after the file, creating this group if not existent, or
- one of the existing groups

even if the user changed or deleted the text for the groupname (see [Redmine #14048](https://hub.qgis.org/issues/14048)).

Additionally there was no way to import symbols without grouping them.

This PR fixes both:
- The user can enter an arbitrary group name and the imported symbols will be placed in that group, creating it if neccessary.
- If the group name is empty, the imported symbols will not be placed into any group. They appear under the _ungrouped_ entry in this case.
