### PR TITLE
[FEATURE] allow geometryless memory layers

### DIFF
--- a/src/providers/memory/qgsmemoryprovider.cpp
+++ b/src/providers/memory/qgsmemoryprovider.cpp
@@ -60,6 +60,8 @@ QgsMemoryProvider::QgsMemoryProvider( const QString& uri )
     mWkbType = QGis::WKBMultiLineString;
   else if ( geometry == "multipolygon" )
     mWkbType = QGis::WKBMultiPolygon;
+  else if ( geometry == "none" )
+    mWkbType = QGis::WKBNoGeometry;
   else
     mWkbType = QGis::WKBUnknown;
 
@@ -200,6 +202,9 @@ QString QgsMemoryProvider::dataSourceUri( bool expandAuthConfig ) const
       break;
     case QGis::WKBMultiPolygon :
       geometry = "MultiPolygon";
+      break;
+    case QGis::WKBNoGeometry :
+      geometry = "None";
       break;
     default:
       geometry = "";

--- a/src/ui/qgsnewmemorylayerdialogbase.ui
+++ b/src/ui/qgsnewmemorylayerdialogbase.ui
@@ -24,50 +24,64 @@
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
    <item>
-    <widget class="QGroupBox" name="buttonGroup1">
+    <widget class="QGroupBox" name="buttonGroupGeometry">
      <property name="title">
-      <string>Type</string>
+      <string>Geometry type and CRS</string>
      </property>
-     <layout class="QGridLayout" name="gridLayout">
-      <item row="0" column="0">
-       <widget class="QRadioButton" name="mPointRadioButton">
-        <property name="text">
-         <string>Point</string>
-        </property>
-       </widget>
+     <property name="checkable">
+      <bool>true</bool>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <layout class="QGridLayout" name="gridLayout">
+        <item row="1" column="0">
+         <widget class="QRadioButton" name="mMultiPointRadioButton">
+          <property name="text">
+           <string>Multipoint</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="2">
+         <widget class="QRadioButton" name="mMultiPolygonRadioButton">
+          <property name="text">
+           <string>Multipolygon</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="2">
+         <widget class="QRadioButton" name="mPolygonRadioButton">
+          <property name="text">
+           <string>Polygon</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="0">
+         <widget class="QRadioButton" name="mPointRadioButton">
+          <property name="text">
+           <string>Point</string>
+          </property>
+         </widget>
+        </item>
+        <item row="0" column="1">
+         <widget class="QRadioButton" name="mLineRadioButton">
+          <property name="text">
+           <string>Line</string>
+          </property>
+         </widget>
+        </item>
+        <item row="1" column="1">
+         <widget class="QRadioButton" name="mMultiLineRadioButton">
+          <property name="text">
+           <string>Multiline</string>
+          </property>
+         </widget>
+        </item>
+       </layout>
       </item>
-      <item row="0" column="1">
-       <widget class="QRadioButton" name="mLineRadioButton">
-        <property name="text">
-         <string>Line</string>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="2">
-       <widget class="QRadioButton" name="mPolygonRadioButton">
-        <property name="text">
-         <string>Polygon</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="0">
-       <widget class="QRadioButton" name="mMultiPointRadioButton">
-        <property name="text">
-         <string>Multipoint</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QRadioButton" name="mMultiLineRadioButton">
-        <property name="text">
-         <string>Multiline</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="2">
-       <widget class="QRadioButton" name="mMultiPolygonRadioButton">
-        <property name="text">
-         <string>Multipolygon</string>
+      <item>
+       <widget class="QgsProjectionSelectionWidget" name="mCrsSelector" native="true">
+        <property name="focusPolicy">
+         <enum>Qt::StrongFocus</enum>
         </property>
        </widget>
       </item>
@@ -87,13 +101,6 @@
       <widget class="QLineEdit" name="mNameLineEdit"/>
      </item>
     </layout>
-   </item>
-   <item>
-    <widget class="QgsProjectionSelectionWidget" name="mCrsSelector" native="true">
-     <property name="focusPolicy">
-      <enum>Qt::StrongFocus</enum>
-     </property>
-    </widget>
    </item>
    <item>
     <widget class="QLabel" name="label_2">
@@ -144,6 +151,7 @@
  </customwidgets>
  <tabstops>
   <tabstop>mNameLineEdit</tabstop>
+  <tabstop>buttonGroupGeometry</tabstop>
   <tabstop>mPointRadioButton</tabstop>
   <tabstop>mLineRadioButton</tabstop>
   <tabstop>mPolygonRadioButton</tabstop>
@@ -151,7 +159,6 @@
   <tabstop>mMultiLineRadioButton</tabstop>
   <tabstop>mMultiPolygonRadioButton</tabstop>
   <tabstop>mCrsSelector</tabstop>
-  <tabstop>mButtonBox</tabstop>
  </tabstops>
  <resources/>
  <connections>

--- a/tests/src/python/test_provider_memory.py
+++ b/tests/src/python/test_provider_memory.py
@@ -69,20 +69,30 @@ class TestPyQgsMemoryProvider(TestCase, ProviderTestCase):
     def tearDownClass(cls):
         """Run after all tests"""
 
-    def testPointCtor(self):
-        layer = QgsVectorLayer("Point", "test", "memory")
-        assert layer.isValid(), "Failed to create valid point memory layer"
+    def testCtors(self):
+        testVectors = ["Point", "LineString", "Polygon", "MultiPoint", "MultiLineString", "MultiPolygon", "None"]
+        for v in testVectors:
+            layer = QgsVectorLayer(v, "test", "memory")
+            assert layer.isValid(), "Failed to create valid %s memory layer" % (v)
 
     def testLayerGeometry(self):
-        layer = QgsVectorLayer("Point", "test", "memory")
+        testVectors = [("Point", QGis.Point, QGis.WKBPoint),
+                       ("LineString", QGis.Line, QGis.WKBLineString),
+                       ("Polygon", QGis.Polygon, QGis.WKBPolygon),
+                       ("MultiPoint", QGis.Point, QGis.WKBMultiPoint),
+                       ("MultiLineString", QGis.Line, QGis.WKBMultiLineString),
+                       ("MultiPolygon", QGis.Polygon, QGis.WKBMultiPolygon),
+                       ("None", QGis.NoGeometry, QGis.WKBNoGeometry)]
+        for v in testVectors:
+            layer = QgsVectorLayer(v[0], "test", "memory")
 
-        myMessage = ('Expected: %s\nGot: %s\n' %
-                     (QGis.Point, layer.geometryType()))
-        assert layer.geometryType() == QGis.Point, myMessage
+            myMessage = ('Expected: %s\nGot: %s\n' %
+                         (v[1], layer.geometryType()))
+            assert layer.geometryType() == v[1], myMessage
 
-        myMessage = ('Expected: %s\nGot: %s\n' %
-                     (QGis.WKBPoint, layer.wkbType()))
-        assert layer.wkbType() == QGis.WKBPoint, myMessage
+            myMessage = ('Expected: %s\nGot: %s\n' %
+                         (v[2], layer.wkbType()))
+            assert layer.wkbType() == v[2], myMessage
 
     def testAddFeatures(self):
         layer = QgsVectorLayer("Point", "test", "memory")


### PR DESCRIPTION
This PR adds the option to create a memory layer without geometries.
It includes a test for this new functionality.

![qgismemorylayergeometryless](https://cloud.githubusercontent.com/assets/15147421/12205372/811b68f0-b63a-11e5-825c-ad25d225877b.png)
