### PR TITLE
[Bugfix] Avoid a warning when opening QgsScaleVisibilityDialog

### DIFF
--- a/src/gui/qgsscalevisibilitydialog.cpp
+++ b/src/gui/qgsscalevisibilitydialog.cpp
@@ -36,7 +36,7 @@ QgsScaleVisibilityDialog::QgsScaleVisibilityDialog( QWidget *parent, const QStri
   mGroupBox->setCheckable( true );
   mGroupBox->setTitle( tr( "Scale visibility " ) );
 
-  QGridLayout* gbLayout = new QGridLayout( this );
+  QGridLayout* gbLayout = new QGridLayout( mGroupBox );
   //gbLayout->setContentsMargins( 0, 0, 0, 0 );
 
   mScaleWidget = new QgsScaleRangeWidget( this );
@@ -45,7 +45,6 @@ QgsScaleVisibilityDialog::QgsScaleVisibilityDialog( QWidget *parent, const QStri
     mScaleWidget->setMapCanvas( mapCanvas );
   }
   gbLayout->addWidget( mScaleWidget, 0, 0 );
-  mGroupBox->setLayout( gbLayout );
 
   QDialogButtonBox* buttonBox = new QDialogButtonBox( QDialogButtonBox::Cancel | QDialogButtonBox::Ok, Qt::Horizontal, this );
   connect( buttonBox, SIGNAL( accepted() ), this, SLOT( accept() ) );


### PR DESCRIPTION
When opening the `QgsScaleVisibilityDialog` the following warning was generated by Qt:
_Warning: QLayout: Attempting to add QLayout "" to QgsScaleVisibilityDialog "", which already has a layout_

However, this did not affect the functionality because the `QLayout` in question is not supposed to be set for the `QgsScaleVisibilityDialog` anyway. It is meant to be for `mGroupBox`.
