### PR TITLE
Refactor QgsGeometryEngine

### DIFF
--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -316,6 +316,7 @@ SET(QGIS_CORE_SRCS
   geometry/qgscurvev2.cpp
   geometry/qgscurvepolygonv2.cpp
   geometry/qgsgeometry.cpp
+  geometry/qgsgeometryengine.cpp
   geometry/qgsgeometrycollectionv2.cpp
   geometry/qgsgeometryeditutils.cpp
   geometry/qgsgeometryfactory.cpp
@@ -784,6 +785,7 @@ SET(QGIS_CORE_HDRS
   layertree/qgslayertreeutils.h
 
   geometry/qgsgeometry.h
+  geometry/qgsgeometryengine.h
   geometry/qgsabstractgeometryv2.h
   geometry/qgswkbtypes.h
   geometry/qgspointv2.h

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -23,7 +23,7 @@ email                : morb at ozemail dot com dot au
 #include "qgsgeometryeditutils.h"
 #include "qgsgeometryfactory.h"
 #include "qgsgeometryutils.h"
-#include "qgsgeos.h"
+#include "qgsgeometryengine.h"
 #include "qgsapplication.h"
 #include "qgslogger.h"
 #include "qgsmessagelog.h"
@@ -2272,7 +2272,7 @@ QgsGeometry* QgsGeometry::convertToPolygon( bool destMultipart ) const
 
 QgsGeometryEngine* QgsGeometry::createGeometryEngine( const QgsAbstractGeometryV2* geometry )
 {
-  return new QgsGeos( geometry );
+  return new QgsGeometryEngine( geometry );
 }
 
 QDataStream& operator<<( QDataStream& out, const QgsGeometry& geometry )

--- a/src/core/geometry/qgsgeometryeditutils.cpp
+++ b/src/core/geometry/qgsgeometryeditutils.cpp
@@ -19,7 +19,7 @@ email                : marco.hugentobler at sourcepole dot com
 #include "qgspolygonv2.h"
 #include "qgsgeometryutils.h"
 #include "qgsgeometry.h"
-#include "qgsgeos.h"
+#include "qgsgeometryengine.h"
 #include "qgsmaplayerregistry.h"
 #include "qgsmultisurfacev2.h"
 #include "qgsproject.h"
@@ -283,14 +283,14 @@ QgsAbstractGeometryV2* QgsGeometryEditUtils::avoidIntersections( const QgsAbstra
   }
 
 
-  QgsAbstractGeometryV2* combinedGeometries = geomEngine.data()->combine( nearGeometries );
+  QgsAbstractGeometryV2* combinedGeometries = geomEngine->combine( nearGeometries );
   qDeleteAll( nearGeometries );
   if ( !combinedGeometries )
   {
     return nullptr;
   }
 
-  QgsAbstractGeometryV2* diffGeom = geomEngine.data()->difference( *combinedGeometries );
+  QgsAbstractGeometryV2* diffGeom = geomEngine->difference( *combinedGeometries );
 
   delete combinedGeometries;
   return diffGeom;

--- a/src/core/geometry/qgsgeometryengine.cpp
+++ b/src/core/geometry/qgsgeometryengine.cpp
@@ -1,0 +1,203 @@
+/***************************************************************************
+  qgsgeometryengine.cpp
+
+ ---------------------
+ begin                : 11.1.2016
+ copyright            : (C) 2016 by mku
+ email                : matthias@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsgeometryengine.h"
+
+QgsGeometryEngine::QgsGeometryEngine( const QgsAbstractGeometryV2* geometry , int precision )
+    : mGeometry( geometry )
+    , mPrecision( precision )
+    , mGeosEngine( nullptr )
+{
+
+}
+
+QgsGeometryEngine::~QgsGeometryEngine()
+{
+  delete mGeosEngine;
+}
+
+void QgsGeometryEngine::geometryChanged()
+{
+  geosEngine()->geometryChanged();
+}
+
+void QgsGeometryEngine::prepareGeometry()
+{
+  geosEngine()->prepareGeometry();
+}
+
+QgsAbstractGeometryV2* QgsGeometryEngine::intersection( const QgsAbstractGeometryV2& geom, QString* errorMsg ) const
+{
+  return geosEngine()->intersection( geom, errorMsg );
+}
+
+QgsAbstractGeometryV2* QgsGeometryEngine::difference( const QgsAbstractGeometryV2& geom, QString* errorMsg ) const
+{
+  return geosEngine()->intersection( geom, errorMsg );
+}
+
+QgsAbstractGeometryV2* QgsGeometryEngine::combine( const QgsAbstractGeometryV2& geom, QString* errorMsg ) const
+{
+  return geosEngine()->combine( geom, errorMsg );
+}
+
+QgsAbstractGeometryV2* QgsGeometryEngine::combine( const QList<QgsAbstractGeometryV2*>& geomList, QString* errorMsg ) const
+{
+  return geosEngine()->combine( geomList, errorMsg );
+}
+
+QgsAbstractGeometryV2* QgsGeometryEngine::symDifference( const QgsAbstractGeometryV2& geom, QString* errorMsg ) const
+{
+  return geosEngine()->symDifference( geom, errorMsg );
+}
+
+QgsAbstractGeometryV2* QgsGeometryEngine::buffer( double distance, int segments, QString* errorMsg ) const
+{
+  return geosEngine()->buffer( distance, segments, errorMsg );
+}
+
+QgsAbstractGeometryV2* QgsGeometryEngine::buffer( double distance, int segments, int endCapStyle, int joinStyle, double mitreLimit, QString* errorMsg ) const
+{
+  return geosEngine()->buffer( distance, segments, endCapStyle, joinStyle, mitreLimit, errorMsg );
+}
+
+QgsAbstractGeometryV2* QgsGeometryEngine::simplify( double tolerance, QString* errorMsg ) const
+{
+  return geosEngine()->simplify( tolerance, errorMsg );
+}
+
+QgsAbstractGeometryV2* QgsGeometryEngine::interpolate( double distance, QString* errorMsg ) const
+{
+  return geosEngine()->interpolate( distance, errorMsg );
+}
+
+QgsAbstractGeometryV2* QgsGeometryEngine::envelope( QString* errorMsg ) const
+{
+  return geosEngine()->envelope( errorMsg );
+}
+
+bool QgsGeometryEngine::centroid( QgsPointV2& pt, QString* errorMsg ) const
+{
+  return geosEngine()->centroid( pt, errorMsg );
+}
+
+bool QgsGeometryEngine::pointOnSurface( QgsPointV2& pt, QString* errorMsg ) const
+{
+  return geosEngine()->pointOnSurface( pt, errorMsg );
+}
+
+QgsAbstractGeometryV2* QgsGeometryEngine::convexHull( QString* errorMsg ) const
+{
+  return geosEngine()->convexHull( errorMsg );
+}
+
+double QgsGeometryEngine::distance( const QgsAbstractGeometryV2& geom, QString* errorMsg ) const
+{
+  return geosEngine()->distance( geom, errorMsg );
+}
+
+bool QgsGeometryEngine::intersects( const QgsAbstractGeometryV2& geom, QString* errorMsg ) const
+{
+  return geosEngine()->intersects( geom, errorMsg );
+}
+
+bool QgsGeometryEngine::touches( const QgsAbstractGeometryV2& geom, QString* errorMsg ) const
+{
+  return geosEngine()->touches( geom, errorMsg );
+}
+
+bool QgsGeometryEngine::crosses( const QgsAbstractGeometryV2& geom, QString* errorMsg ) const
+{
+  return geosEngine()->crosses( geom, errorMsg );
+}
+
+bool QgsGeometryEngine::within( const QgsAbstractGeometryV2& geom, QString* errorMsg ) const
+{
+  return geosEngine()->within( geom, errorMsg );
+}
+
+bool QgsGeometryEngine::overlaps( const QgsAbstractGeometryV2& geom, QString* errorMsg ) const
+{
+  return geosEngine()->overlaps( geom, errorMsg );
+}
+
+bool QgsGeometryEngine::contains( const QgsAbstractGeometryV2& geom, QString* errorMsg ) const
+{
+  return geosEngine()->contains( geom, errorMsg );
+}
+
+bool QgsGeometryEngine::disjoint( const QgsAbstractGeometryV2& geom, QString* errorMsg ) const
+{
+  return geosEngine()->disjoint( geom, errorMsg );
+}
+
+QString QgsGeometryEngine::relate( const QgsAbstractGeometryV2& geom, QString* errorMsg ) const
+{
+  return geosEngine()->relate( geom, errorMsg );
+}
+
+bool QgsGeometryEngine::relatePattern( const QgsAbstractGeometryV2& geom, const QString& pattern, QString* errorMsg ) const
+{
+  return geosEngine()->relatePattern( geom, pattern, errorMsg );
+}
+
+double QgsGeometryEngine::area( QString* errorMsg ) const
+{
+  return geosEngine()->area( errorMsg );
+}
+
+double QgsGeometryEngine::length( QString* errorMsg ) const
+{
+  return geosEngine()->length( errorMsg ) ;
+}
+
+bool QgsGeometryEngine::isValid( QString* errorMsg ) const
+{
+  return geosEngine()->isValid( errorMsg );
+}
+
+bool QgsGeometryEngine::isEqual( const QgsAbstractGeometryV2& geom, QString* errorMsg ) const
+{
+  return geosEngine()->isEqual( geom, errorMsg );
+}
+
+bool QgsGeometryEngine::isEmpty( QString* errorMsg ) const
+{
+  return geosEngine()->isEmpty( errorMsg );
+}
+
+int QgsGeometryEngine::splitGeometry( const QgsLineStringV2& splitLine, QList<QgsAbstractGeometryV2*>& newGeometries, bool topological, QList<QgsPointV2>& topologyTestPoints, QString* errorMsg ) const
+{
+  Q_UNUSED( splitLine );
+  Q_UNUSED( newGeometries );
+  Q_UNUSED( topological );
+  Q_UNUSED( topologyTestPoints );
+  Q_UNUSED( errorMsg );
+  return 2;
+}
+
+QgsAbstractGeometryV2* QgsGeometryEngine::offsetCurve( double distance, int segments, int joinStyle, double mitreLimit, QString* errorMsg ) const
+{
+  return geosEngine()->offsetCurve( distance, segments, joinStyle, mitreLimit, errorMsg );
+}
+
+QgsGeos* QgsGeometryEngine::geosEngine() const
+{
+  if ( !mGeosEngine )
+    mGeosEngine = new QgsGeos( mGeometry, mPrecision );
+
+  return mGeosEngine;
+}

--- a/src/core/geometry/qgsgeometryengine.h
+++ b/src/core/geometry/qgsgeometryengine.h
@@ -13,11 +13,12 @@ email                : marco.hugentobler at sourcepole dot com
  *                                                                         *
  ***************************************************************************/
 
-#ifndef QGSVECTORTOPOLOGY_H
-#define QGSVECTORTOPOLOGY_H
+#ifndef QGSGEOMETRYENGINE_H
+#define QGSGEOMETRYENGINE_H
 
 #include "qgspointv2.h"
 #include "qgslinestringv2.h"
+#include "qgsgeos.h"
 
 #include <QList>
 
@@ -32,33 +33,46 @@ class QgsAbstractGeometryV2;
 class CORE_EXPORT QgsGeometryEngine
 {
   public:
-    QgsGeometryEngine( const QgsAbstractGeometryV2* geometry ): mGeometry( geometry ) {}
-    virtual ~QgsGeometryEngine() {}
+    QgsGeometryEngine( const QgsAbstractGeometryV2* geometry, int precision = 0 );
+    ~QgsGeometryEngine();
 
-    virtual void geometryChanged() = 0;
-    virtual void prepareGeometry() = 0;
+    /**
+     * Will clear any cached geometry data.
+     *
+     * TODO QGIS3: remove this and use implicitly shared QgsGeometry instead.
+     */
+    void geometryChanged();
 
-    virtual QgsAbstractGeometryV2* intersection( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const = 0;
-    virtual QgsAbstractGeometryV2* difference( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const = 0;
-    virtual QgsAbstractGeometryV2* combine( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const = 0;
-    virtual QgsAbstractGeometryV2* combine( const QList< QgsAbstractGeometryV2* >&, QString* errorMsg = nullptr ) const = 0;
-    virtual QgsAbstractGeometryV2* symDifference( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const = 0;
-    virtual QgsAbstractGeometryV2* buffer( double distance, int segments, QString* errorMsg = nullptr ) const = 0;
-    virtual QgsAbstractGeometryV2* buffer( double distance, int segments, int endCapStyle, int joinStyle, double mitreLimit, QString* errorMsg = nullptr ) const = 0;
-    virtual QgsAbstractGeometryV2* simplify( double tolerance, QString* errorMsg = nullptr ) const = 0;
-    virtual QgsAbstractGeometryV2* interpolate( double distance, QString* errorMsg = nullptr ) const = 0;
-    virtual QgsAbstractGeometryV2* envelope( QString* errorMsg = nullptr ) const = 0;
-    virtual bool centroid( QgsPointV2& pt, QString* errorMsg = nullptr ) const = 0;
-    virtual bool pointOnSurface( QgsPointV2& pt, QString* errorMsg = nullptr ) const = 0;
-    virtual QgsAbstractGeometryV2* convexHull( QString* errorMsg = nullptr ) const = 0;
-    virtual double distance( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const = 0;
-    virtual bool intersects( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const = 0;
-    virtual bool touches( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const = 0;
-    virtual bool crosses( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const = 0;
-    virtual bool within( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const = 0;
-    virtual bool overlaps( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const = 0;
-    virtual bool contains( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const = 0;
-    virtual bool disjoint( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const = 0;
+    /**
+     * Prepare the geomtetry for efficient processing.
+     *
+     * TODO: What is the optimal strategy for this in regards to different backends?
+     * Should the caller have to deal with this kind of lowlevel functionality?
+     * Do we need prepareGeosGeometry() instead?
+     */
+    void prepareGeometry();
+
+    QgsAbstractGeometryV2* intersection( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const;
+    QgsAbstractGeometryV2* difference( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const;
+    QgsAbstractGeometryV2* combine( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const;
+    QgsAbstractGeometryV2* combine( const QList< QgsAbstractGeometryV2* >&geomList, QString* errorMsg = nullptr ) const;
+    QgsAbstractGeometryV2* symDifference( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const;
+    QgsAbstractGeometryV2* buffer( double distance, int segments, QString* errorMsg = nullptr ) const;
+    QgsAbstractGeometryV2* buffer( double distance, int segments, int endCapStyle, int joinStyle, double mitreLimit, QString* errorMsg = nullptr ) const;
+    QgsAbstractGeometryV2* simplify( double tolerance, QString* errorMsg = nullptr ) const;
+    QgsAbstractGeometryV2* interpolate( double distance, QString* errorMsg = nullptr ) const;
+    QgsAbstractGeometryV2* envelope( QString* errorMsg = nullptr ) const;
+    bool centroid( QgsPointV2& pt, QString* errorMsg = nullptr ) const;
+    bool pointOnSurface( QgsPointV2& pt, QString* errorMsg = nullptr ) const;
+    QgsAbstractGeometryV2* convexHull( QString* errorMsg = nullptr ) const;
+    double distance( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const;
+    bool intersects( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const;
+    bool touches( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const;
+    bool crosses( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const;
+    bool within( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const;
+    bool overlaps( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const;
+    bool contains( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const;
+    bool disjoint( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const;
 
     /** Returns the Dimensional Extended 9 Intersection Model (DE-9IM) representation of the
      * relationship between the geometries.
@@ -67,7 +81,7 @@ class CORE_EXPORT QgsGeometryEngine
      * @returns DE-9IM string for relationship, or an empty string if an error occurred
      * @note added in QGIS 2.12
      */
-    virtual QString relate( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const = 0;
+    QString relate( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const;
 
     /** Tests whether two geometries are related by a specified Dimensional Extended 9 Intersection Model (DE-9IM)
      * pattern.
@@ -77,33 +91,35 @@ class CORE_EXPORT QgsGeometryEngine
      * @returns true if geometry relationship matches with pattern
      * @note added in QGIS 2.14
      */
-    virtual bool relatePattern( const QgsAbstractGeometryV2& geom, const QString& pattern, QString* errorMsg = nullptr ) const = 0;
+    bool relatePattern( const QgsAbstractGeometryV2& geom, const QString& pattern, QString* errorMsg = nullptr ) const;
 
-    virtual double area( QString* errorMsg = nullptr ) const = 0;
-    virtual double length( QString* errorMsg = nullptr ) const = 0;
-    virtual bool isValid( QString* errorMsg = nullptr ) const = 0;
-    virtual bool isEqual( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const = 0;
-    virtual bool isEmpty( QString* errorMsg ) const = 0;
+    double area( QString* errorMsg = nullptr ) const;
+    double length( QString* errorMsg = nullptr ) const;
+    bool isValid( QString* errorMsg = nullptr ) const;
+    bool isEqual( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const;
+    bool isEmpty( QString* errorMsg ) const;
 
-    virtual int splitGeometry( const QgsLineStringV2& splitLine,
-                               QList<QgsAbstractGeometryV2*>& newGeometries,
-                               bool topological,
-                               QList<QgsPointV2> &topologyTestPoints, QString* errorMsg = nullptr ) const
-    {
-      Q_UNUSED( splitLine );
-      Q_UNUSED( newGeometries );
-      Q_UNUSED( topological );
-      Q_UNUSED( topologyTestPoints );
-      Q_UNUSED( errorMsg );
-      return 2;
-    }
+    int splitGeometry( const QgsLineStringV2& splitLine,
+                       QList<QgsAbstractGeometryV2*>& newGeometries,
+                       bool topological,
+                       QList<QgsPointV2> &topologyTestPoints, QString* errorMsg = nullptr ) const;
 
-    virtual QgsAbstractGeometryV2* offsetCurve( double distance, int segments, int joinStyle, double mitreLimit, QString* errorMsg = nullptr ) const = 0;
+    QgsAbstractGeometryV2* offsetCurve( double distance, int segments, int joinStyle, double mitreLimit, QString* errorMsg = nullptr ) const;
 
-  protected:
-    const QgsAbstractGeometryV2* mGeometry;
-
+  private:
+    /**
+     * Private default constructor. Use QgsGeometry::createEngine() instead.
+     */
     QgsGeometryEngine();
+    /**
+     * Creates a geos engine if not present or returns an existing one.
+     */
+    QgsGeos* geosEngine() const;
+
+    const QgsAbstractGeometryV2* mGeometry;
+    int mPrecision;
+
+    mutable QgsGeos* mGeosEngine;
 };
 
-#endif // QGSVECTORTOPOLOGY_H
+#endif // QGSGEOMETRYENGINE_H

--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -124,7 +124,10 @@ class GEOSGeomScopedPtr
 };
 
 QgsGeos::QgsGeos( const QgsAbstractGeometryV2* geometry, double precision )
-    : QgsGeometryEngine( geometry ), mGeos( nullptr ), mGeosPrepared( nullptr ), mPrecision( precision )
+    : mGeometry( geometry )
+    , mGeos( nullptr )
+    , mGeosPrepared( nullptr )
+    , mPrecision( precision )
 {
   cacheGeos();
 }

--- a/src/core/geometry/qgsgeos.h
+++ b/src/core/geometry/qgsgeos.h
@@ -16,7 +16,6 @@ email                : marco.hugentobler at sourcepole dot com
 #ifndef QGSGEOS_H
 #define QGSGEOS_H
 
-#include "qgsgeometryengine.h"
 #include "qgspointv2.h"
 #include <geos_c.h>
 
@@ -27,7 +26,7 @@ class QgsPolygonV2;
  * \note this API is not considered stable and may change for 2.12
  * \note not available in Python bindings
  */
-class CORE_EXPORT QgsGeos: public QgsGeometryEngine
+class CORE_EXPORT QgsGeos
 {
   public:
     /** GEOS geometry engine constructor
@@ -38,37 +37,37 @@ class CORE_EXPORT QgsGeos: public QgsGeometryEngine
     ~QgsGeos();
 
     /** Removes caches*/
-    void geometryChanged() override;
-    void prepareGeometry() override;
+    void geometryChanged();
+    void prepareGeometry();
 
-    QgsAbstractGeometryV2* intersection( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const override;
-    QgsAbstractGeometryV2* difference( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const override;
-    QgsAbstractGeometryV2* combine( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const override;
-    QgsAbstractGeometryV2* combine( const QList< QgsAbstractGeometryV2*>&, QString* errorMsg = nullptr ) const override;
-    QgsAbstractGeometryV2* symDifference( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const override;
-    QgsAbstractGeometryV2* buffer( double distance, int segments, QString* errorMsg = nullptr ) const override;
-    QgsAbstractGeometryV2* buffer( double distance, int segments, int endCapStyle, int joinStyle, double mitreLimit, QString* errorMsg = nullptr ) const override;
-    QgsAbstractGeometryV2* simplify( double tolerance, QString* errorMsg = nullptr ) const override;
-    QgsAbstractGeometryV2* interpolate( double distance, QString* errorMsg = nullptr ) const override;
-    QgsAbstractGeometryV2* envelope( QString* errorMsg = nullptr ) const override;
-    bool centroid( QgsPointV2& pt, QString* errorMsg = nullptr ) const override;
-    bool pointOnSurface( QgsPointV2& pt, QString* errorMsg = nullptr ) const override;
-    QgsAbstractGeometryV2* convexHull( QString* errorMsg = nullptr ) const override;
-    double distance( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const override;
-    bool intersects( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const override;
-    bool touches( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const override;
-    bool crosses( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const override;
-    bool within( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const override;
-    bool overlaps( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const override;
-    bool contains( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const override;
-    bool disjoint( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const override;
-    QString relate( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const override;
-    bool relatePattern( const QgsAbstractGeometryV2& geom, const QString& pattern, QString* errorMsg = nullptr ) const override;
-    double area( QString* errorMsg = nullptr ) const override;
-    double length( QString* errorMsg = nullptr ) const override;
-    bool isValid( QString* errorMsg = nullptr ) const override;
-    bool isEqual( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const override;
-    bool isEmpty( QString* errorMsg = nullptr ) const override;
+    QgsAbstractGeometryV2* intersection( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const;
+    QgsAbstractGeometryV2* difference( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const;
+    QgsAbstractGeometryV2* combine( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const;
+    QgsAbstractGeometryV2* combine( const QList< QgsAbstractGeometryV2*>&, QString* errorMsg = nullptr ) const;
+    QgsAbstractGeometryV2* symDifference( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const;
+    QgsAbstractGeometryV2* buffer( double distance, int segments, QString* errorMsg = nullptr ) const;
+    QgsAbstractGeometryV2* buffer( double distance, int segments, int endCapStyle, int joinStyle, double mitreLimit, QString* errorMsg = nullptr ) const;
+    QgsAbstractGeometryV2* simplify( double tolerance, QString* errorMsg = nullptr ) const;
+    QgsAbstractGeometryV2* interpolate( double distance, QString* errorMsg = nullptr ) const;
+    QgsAbstractGeometryV2* envelope( QString* errorMsg = nullptr ) const;
+    bool centroid( QgsPointV2& pt, QString* errorMsg = nullptr ) const;
+    bool pointOnSurface( QgsPointV2& pt, QString* errorMsg = nullptr ) const;
+    QgsAbstractGeometryV2* convexHull( QString* errorMsg = nullptr ) const;
+    double distance( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const;
+    bool intersects( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const;
+    bool touches( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const;
+    bool crosses( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const;
+    bool within( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const;
+    bool overlaps( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const;
+    bool contains( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const;
+    bool disjoint( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const;
+    QString relate( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const;
+    bool relatePattern( const QgsAbstractGeometryV2& geom, const QString& pattern, QString* errorMsg = nullptr ) const;
+    double area( QString* errorMsg = nullptr ) const;
+    double length( QString* errorMsg = nullptr ) const;
+    bool isValid( QString* errorMsg = nullptr ) const;
+    bool isEqual( const QgsAbstractGeometryV2& geom, QString* errorMsg = nullptr ) const;
+    bool isEmpty( QString* errorMsg = nullptr ) const;
 
     /** Splits this geometry according to a given line.
     @param splitLine the line that splits the geometry
@@ -81,9 +80,9 @@ class CORE_EXPORT QgsGeos: public QgsGeometryEngine
                        QList<QgsAbstractGeometryV2*>& newGeometries,
                        bool topological,
                        QList<QgsPointV2> &topologyTestPoints,
-                       QString* errorMsg = nullptr ) const override;
+                       QString* errorMsg = nullptr ) const;
 
-    QgsAbstractGeometryV2* offsetCurve( double distance, int segments, int joinStyle, double mitreLimit, QString* errorMsg = nullptr ) const override;
+    QgsAbstractGeometryV2* offsetCurve( double distance, int segments, int joinStyle, double mitreLimit, QString* errorMsg = nullptr ) const;
     QgsAbstractGeometryV2* reshapeGeometry( const QgsLineStringV2& reshapeWithLine, int* errorCode, QString* errorMsg = nullptr ) const;
 
     /** Create a geometry from a GEOSGeometry
@@ -97,6 +96,7 @@ class CORE_EXPORT QgsGeos: public QgsGeometryEngine
     static GEOSContextHandle_t getGEOSHandler();
 
   private:
+    const QgsAbstractGeometryV2* mGeometry;
     mutable GEOSGeometry* mGeos;
     const GEOSPreparedGeometry* mGeosPrepared;
     double mPrecision;

--- a/src/plugins/geometry_checker/utils/qgsgeomutils.cpp
+++ b/src/plugins/geometry_checker/utils/qgsgeomutils.cpp
@@ -16,7 +16,7 @@
 
 #include "qgsgeomutils.h"
 #include <qmath.h>
-#include "qgsgeos.h"
+#include "qgsgeometryengine.h"
 #include "qgsgeometryutils.h"
 #include "qgsgeometrycollectionv2.h"
 
@@ -25,7 +25,7 @@ namespace QgsGeomUtils
 
   QgsGeometryEngine* createGeomEngine( QgsAbstractGeometryV2* geometry, double tolerance )
   {
-    return new QgsGeos( geometry, tolerance );
+    return new QgsGeometryEngine( geometry, tolerance );
   }
 
   QgsAbstractGeometryV2* getGeomPart( QgsAbstractGeometryV2* geom, int partIdx )


### PR DESCRIPTION
QgsGeometryEngine acts as a proxy for the backend (library) and is no longer
abstract.
It will create and call QgsGeos methods on request. Other backends may
be implemented in the same way. Users of the engine do not have to know
anything about which library is internally used.

---

I would propose to use this schema for 2.14. It is a flexible approach that allows to add further functionality (qgis implementations) and backends (e.g. sfcgal) whenever required.
