### PR TITLE
allow zooming to multiple features by their ID

### DIFF
--- a/python/gui/qgsmapcanvas.sip
+++ b/python/gui/qgsmapcanvas.sip
@@ -168,10 +168,10 @@ class QgsMapCanvas : QGraphicsView
       @param layer optionally specify different than current layer */
     void zoomToSelected( QgsVectorLayer* layer = NULL );
 
-    /** Set canvas extent to the bounding box of a feature
+    /** Set canvas extent to the bounding box of a set of features
         @param layer the vector layer
-        @param id the feature id*/
-    void zoomToFeatureId( QgsVectorLayer* layer, QgsFeatureId id );
+        @param ids the feature ids*/
+    void zoomToFeatureIds( QgsVectorLayer* layer, const QgsFeatureIds& ids );
 
     /** Pan to the selected features of current (vector) layer keeping same extent. */
     void panToSelected( QgsVectorLayer* layer = NULL );

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -409,11 +409,12 @@ void QgsDualView::zoomToCurrentFeature()
     return;
   }
 
-  QgsFeatureId id = mFilterModel->rowToId( currentIndex );
+  QgsFeatureIds ids;
+  ids.insert( mFilterModel->rowToId( currentIndex ) );
   QgsMapCanvas* canvas = mFilterModel->mapCanvas();
   if ( canvas )
   {
-    canvas->zoomToFeatureId( mLayerCache->layer(), id );
+    canvas->zoomToFeatureIds( mLayerCache->layer(), ids );
   }
 }
 

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -238,10 +238,10 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
       @param layer optionally specify different than current layer */
     void zoomToSelected( QgsVectorLayer* layer = nullptr );
 
-    /** Set canvas extent to the bounding box of a feature
+    /** Set canvas extent to the bounding box of a set of features
         @param layer the vector layer
-        @param id the feature id*/
-    void zoomToFeatureId( QgsVectorLayer* layer, QgsFeatureId id );
+        @param ids the feature ids*/
+    void zoomToFeatureIds( QgsVectorLayer* layer, const QgsFeatureIds& ids );
 
     /** Pan to the selected features of current (vector) layer keeping same extent. */
     void panToSelected( QgsVectorLayer* layer = nullptr );


### PR DESCRIPTION
This PR changes `QgsMapCanvas::zoomToFeatureId()` to `QgsMapCanvas::zoomToFeatureIds()` accepting multiple IDs instead of just one.

It is an addition to @mhugent's PR #2619. It opens the newly introduced function to a wider range of applications, e.g. functions like:
- zoom to all features overlapping the current feature
- zoom to all features touching the convex hull of the current feature
- or a totally different use case where a plugin needs to zoom to a set of features
