### PR TITLE
DBManager oracle plugin: strip '"' on unique col

### DIFF
--- a/python/plugins/db_manager/db_plugins/oracle/plugin.py
+++ b/python/plugins/db_manager/db_plugins/oracle/plugin.py
@@ -203,7 +203,7 @@ class ORDatabase(Database):
         uri = self.uri()
         con = self.database().connector
 
-        uri.setDataSource(u"", u"({})".format(sql), geomCol, filter, uniqueCol)
+        uri.setDataSource(u"", u"({})".format(sql), geomCol, filter, uniqueCol.strip(u'"'))
         if avoidSelectById:
             uri.disableSelectAtId(True)
         provider = self.dbplugin().providerName()


### PR DESCRIPTION
For Oracle provider, giving a quoted uniqueColumn in a uri to create a
QgsVectorLayer results in an invalid layer.

To fix it, strip '"' is applied to unique col.
