### PR TITLE
Fix syntax error on Windows

### DIFF
--- a/src/gui/qgsfilepickerwidget.cpp
+++ b/src/gui/qgsfilepickerwidget.cpp
@@ -280,7 +280,7 @@ QString QgsFilePickerWidget::toUrl( const QString& path ) const
 
   QString urlStr = relativePath( path, false );
   QUrl url = QUrl::fromUserInput( urlStr );
-  if ( !url.isValid() or !url.isLocalFile() )
+  if ( !url.isValid() || !url.isLocalFile() )
   {
     QgsDebugMsg( QString( "URL: %1 is not valid or not a local file !" ).arg( path ) );
     rep =  path;


### PR DESCRIPTION
_C++ operator synonyms_ are disabled on Windows by default (see [this article on MSDN](https://msdn.microsoft.com/en-us/library/34h23df8.aspx#Anchor_9)) , so using `or` in 29752a35974f22bc26d0015fe8d099da1650044f introduced a **syntax error**:

```
QGIS\src\gui\qgsfilepickerwidget.cpp(283) : error C2146: syntax error : missing ')' before identifier 'or'
QGIS\src\gui\qgsfilepickerwidget.cpp(283) : error C2065: 'or' : undeclared identifier
QGIS\src\gui\qgsfilepickerwidget.cpp(283) : error C2143: syntax error : missing ';' before '!'
QGIS\src\gui\qgsfilepickerwidget.cpp(283) : error C2059: syntax error : ')'
QGIS\src\gui\qgsfilepickerwidget.cpp(284) : error C2143: syntax error : missing ';' before '{'
QGIS\src\gui\qgsfilepickerwidget.cpp(284) : warning C4552: '!' : operator has no effect; expected operator with side-effect
```

This PR fixes it by replacing `or` with `||`.

@jef-n
- What do you think of enabling the [/Za option](https://msdn.microsoft.com/en-us/library/0k0w269d.aspx) to disable Microsoft extensions, thereby allowing _C++ operator synonyms_?
- What is the general policy of using _C++ operator synonyms_?
