### PR TITLE
[FEATURE] Expression variables relating to QGIS environment

### DIFF
--- a/python/core/qgsapplication.sip
+++ b/python/core/qgsapplication.sip
@@ -228,8 +228,32 @@ static void qtgui_UpdatePyArgv(PyObject *argvlist, int argc, char **argv)
     //! Returns the path to user's style.
     static QString userStyleV2Path();
 
-    //! Returns the short name regular exprecience for line edit validator
+    //! Returns the short name regular expression for line edit validator
     static QRegExp shortNameRegExp();
+
+    /** Returns the user's operating system login account name.
+     * @note added in QGIS 2.14
+     * @see userFullName()
+     */
+    static QString userLoginName();
+
+    /** Returns the user's operating system login account full display name.
+     * @note added in QGIS 2.14
+     * @see userLoginName()
+     */
+    static QString userFullName();
+
+    /** Returns a string name of the operating system QGIS is running on.
+     * @note added in QGIS 2.14
+     * @see platform()
+     */
+    static QString osName();
+
+    /** Returns the QGIS platform name, eg "desktop" or "server".
+     * @note added in QGIS 2.14
+     * @see osName()
+     */
+    static QString platform();
 
     //! Returns the path to user's themes folder
     static QString userThemesFolder();

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -190,8 +190,32 @@ class CORE_EXPORT QgsApplication : public QApplication
     //! Returns the path to user's style.
     static QString userStyleV2Path();
 
-    //! Returns the short name regular exprecience for line edit validator
+    //! Returns the short name regular expression for line edit validator
     static QRegExp shortNameRegExp();
+
+    /** Returns the user's operating system login account name.
+     * @note added in QGIS 2.14
+     * @see userFullName()
+     */
+    static QString userLoginName();
+
+    /** Returns the user's operating system login account full display name.
+     * @note added in QGIS 2.14
+     * @see userLoginName()
+     */
+    static QString userFullName();
+
+    /** Returns a string name of the operating system QGIS is running on.
+     * @note added in QGIS 2.14
+     * @see platform()
+     */
+    static QString osName();
+
+    /** Returns the QGIS platform name, eg "desktop" or "server".
+     * @note added in QGIS 2.14
+     * @see osName()
+     */
+    static QString platform();
 
     //! Returns the path to user's themes folder
     static QString userThemesFolder();
@@ -378,6 +402,12 @@ class CORE_EXPORT QgsApplication : public QApplication
     /**
      * @note added in 2.12 */
     static QString ABISYM( mAuthDbDirPath );
+
+    static QString sUserName;
+    static QString sUserFullName;
+    static QString sPlatformName;
+
+    friend class QgsServer; //to modify sPlatformName
 };
 
 #endif

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -4407,6 +4407,10 @@ void QgsExpression::initVariableHelp()
   gVariableHelpTexts.insert( "qgis_version", QCoreApplication::translate( "variable_help", "Current QGIS version string." ) );
   gVariableHelpTexts.insert( "qgis_version_no", QCoreApplication::translate( "variable_help", "Current QGIS version number." ) );
   gVariableHelpTexts.insert( "qgis_release_name", QCoreApplication::translate( "variable_help", "Current QGIS release name." ) );
+  gVariableHelpTexts.insert( "qgis_os_name", QCoreApplication::translate( "variable_help", "Operating system name, eg 'windows', 'linux' or 'osx'." ) );
+  gVariableHelpTexts.insert( "qgis_platform", QCoreApplication::translate( "variable_help", "QGIS platform, eg 'desktop' or 'server'." ) );
+  gVariableHelpTexts.insert( "user_account_name", QCoreApplication::translate( "variable_help", "Current user's operating system account name." ) );
+  gVariableHelpTexts.insert( "user_full_name", QCoreApplication::translate( "variable_help", "Current user's operating system user name (if available)." ) );
 
   //project variables
   gVariableHelpTexts.insert( "project_title", QCoreApplication::translate( "variable_help", "Title of current project." ) );

--- a/src/core/qgsexpressioncontext.cpp
+++ b/src/core/qgsexpressioncontext.cpp
@@ -25,6 +25,7 @@
 #include "qgscomposition.h"
 #include "qgscomposeritem.h"
 #include "qgsatlascomposition.h"
+#include "qgsapplication.h"
 #include <QSettings>
 #include <QDir>
 
@@ -465,6 +466,10 @@ QgsExpressionContextScope* QgsExpressionContextUtils::globalScope()
   scope->addVariable( QgsExpressionContextScope::StaticVariable( "qgis_version", QGis::QGIS_VERSION, true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( "qgis_version_no", QGis::QGIS_VERSION_INT, true ) );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( "qgis_release_name", QGis::QGIS_RELEASE_NAME, true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( "qgis_platform", QgsApplication::platform(), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( "qgis_os_name", QgsApplication::osName(), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( "user_account_name", QgsApplication::userLoginName(), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( "user_full_name", QgsApplication::userFullName(), true ) );
 
   return scope;
 }

--- a/src/server/qgsserver.cpp
+++ b/src/server/qgsserver.cpp
@@ -331,6 +331,7 @@ bool QgsServer::init( int & argc, char ** argv )
   }
 
   mQgsApplication = new QgsApplication( argc, argv, getenv( "DISPLAY" ) );
+  mQgsApplication->sPlatformName = "server";
 
   QCoreApplication::setOrganizationName( QgsApplication::QGIS_ORGANIZATION_NAME );
   QCoreApplication::setOrganizationDomain( QgsApplication::QGIS_ORGANIZATION_DOMAIN );

--- a/tests/src/core/testqgsapplication.cpp
+++ b/tests/src/core/testqgsapplication.cpp
@@ -29,6 +29,11 @@ class TestQgsApplication: public QObject
     void checkGdalSkip();
     void initTestCase();
     void cleanupTestCase();
+
+    void accountName();
+    void osName();
+    void platformName();
+
   private:
     QString getQgisPath();
 };
@@ -48,6 +53,34 @@ void TestQgsApplication::initTestCase()
 void TestQgsApplication::cleanupTestCase()
 {
   QgsApplication::exitQgis();
+}
+
+void TestQgsApplication::accountName()
+{
+  QString loginName = QgsApplication::userLoginName();
+  qDebug() << QString( "Got login name: '%1'" ).arg( loginName );
+  QVERIFY( !loginName.isEmpty() );
+  //test cached return works correctly
+  QCOMPARE( loginName, QgsApplication::userLoginName() );
+
+  //can't test contents, as it can be validly empty (eg on Travis). Just testing that we don't crash
+  QString fullName = QgsApplication::userFullName();
+  qDebug() << QString( "Got full name: '%1'" ).arg( fullName );
+  //test cached return works correctly
+  QCOMPARE( fullName, QgsApplication::userFullName() );
+}
+
+void TestQgsApplication::osName()
+{
+  // can't test expected result, so just check for non-empty result
+  qDebug() << QString( "Got OS name: '%1'" ).arg( QgsApplication::osName() );
+  QVERIFY( !QgsApplication::osName().isEmpty() );
+}
+
+void TestQgsApplication::platformName()
+{
+  // test will always be run under desktop platform
+  QCOMPARE( QgsApplication::platform(), QString( "desktop" ) );
 }
 
 void TestQgsApplication::checkPaths()

--- a/tests/src/core/testqgsexpressioncontext.cpp
+++ b/tests/src/core/testqgsexpressioncontext.cpp
@@ -488,10 +488,18 @@ void TestQgsExpressionContext::globalScope()
   QgsExpression expVersion( "var('qgis_version')" );
   QgsExpression expVersionNo( "var('qgis_version_no')" );
   QgsExpression expReleaseName( "var('qgis_release_name')" );
+  QgsExpression expAccountName( "var('user_account_name')" );
+  QgsExpression expUserFullName( "var('user_full_name')" );
+  QgsExpression expOsName( "var('qgis_os_name')" );
+  QgsExpression expPlatform( "var('qgis_platform')" );
 
   QCOMPARE( expVersion.evaluate( &context ).toString(), QString( QGis::QGIS_VERSION ) );
   QCOMPARE( expVersionNo.evaluate( &context ).toInt(), QGis::QGIS_VERSION_INT );
   QCOMPARE( expReleaseName.evaluate( &context ).toString(), QString( QGis::QGIS_RELEASE_NAME ) );
+  QCOMPARE( expAccountName.evaluate( &context ).toString(), QgsApplication::userLoginName() );
+  QCOMPARE( expUserFullName.evaluate( &context ).toString(), QgsApplication::userFullName() );
+  QCOMPARE( expOsName.evaluate( &context ).toString(), QgsApplication::osName() );
+  QCOMPARE( expPlatform.evaluate( &context ).toString(), QgsApplication::platform() );
 
   //test setGlobalVariables
   QgsStringMap vars;


### PR DESCRIPTION
New variables for:
- @qgis_os_name: eg 'linux','windows' or 'osx'
- @qgis_platform: eg 'desktop' or 'server'
- @user_account_name: current user's operating system account name
- @user_full_name: current user's name from os account (if available)
