### PR TITLE
	Add 2.5D Renderer

### DIFF
--- a/python/core/core.sip
+++ b/python/core/core.sip
@@ -278,6 +278,7 @@
 %Include symbology-ng/qgscptcityarchive.sip
 %Include symbology-ng/qgsvectorcolorrampv2.sip
 
+%Include symbology-ng/qgs25drenderer.sip
 %Include symbology-ng/qgscategorizedsymbolrendererv2.sip
 %Include symbology-ng/qgsgraduatedsymbolrendererv2.sip
 %Include symbology-ng/qgslegendsymbolitemv2.sip

--- a/python/core/symbology-ng/qgs25drenderer.sip
+++ b/python/core/symbology-ng/qgs25drenderer.sip
@@ -1,0 +1,106 @@
+/***************************************************************************
+  qgs25drenderer.sip - Qgs25DRenderer
+
+ ---------------------
+ begin                : 14.1.2016
+ copyright            : (C) 2016 by Matthias Kuhn
+ email                : matthias@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+class Qgs25DRenderer : QgsFeatureRendererV2
+{
+%TypeHeaderCode
+#include "qgs25drenderer.h"
+%End
+  public:
+    Qgs25DRenderer();
+
+    /**
+     * Create a new 2.5D renderer from XML
+     *
+     * @param element XML information
+     */
+    static QgsFeatureRendererV2* create( QDomElement& element );
+    QDomElement save( QDomDocument& doc );
+
+    void startRender( QgsRenderContext& context, const QgsFields& fields );
+    void stopRender( QgsRenderContext& context );
+
+    QList<QString> usedAttributes();
+    QgsFeatureRendererV2* clone() const;
+
+    virtual QgsSymbolV2* symbolForFeature( QgsFeature& feature, QgsRenderContext& context );
+    virtual QgsSymbolV2List symbols( QgsRenderContext& context );
+
+    /**
+     * Get the field or expression used to determine the height of extrusion
+     */
+    QgsDataDefined height() const;
+    /**
+     * Set the field or expression used to determine the height of extrusion
+     */
+    void setHeight( const QgsDataDefined& height );
+
+    /**
+     * Get the angle for the extrusion effect
+     */
+    int angle() const;
+    /**
+     * Set the angle for the extrusion effect
+     */
+    void setAngle( int angle );
+
+    /**
+     * Get the roof color
+     */
+    QColor roofColor() const;
+
+    /**
+     * Set the roof color
+     */
+    void setRoofColor( const QColor& roofColor );
+
+    /**
+     * Get the wall color
+     */
+    QColor wallColor() const;
+
+    /**
+     * Set the wall color
+     */
+    void setWallColor( const QColor& wallColor );
+
+    /**
+     * Get the shadow's color
+     */
+    QColor shadowColor() const;
+
+    /**
+     * Set the shadow's color
+     */
+    void setShadowColor( const QColor& shadowColor );
+
+    /**
+     * Get the shadow's spread distance in map units
+     */
+    double shadowSpread() const;
+    /**
+     * Set the shadow's spread distance in map units
+     */
+    void setShadowSpread( double shadowSpread );
+
+    /**
+     * Try to convert from an existing renderer. If it is not of the same type
+     * we assume that the internals are not compatible and create a new default
+     * 2.5D renderer.
+     */
+    static Qgs25DRenderer* convertFromRenderer( QgsFeatureRendererV2* renderer );
+
+};

--- a/python/gui/gui.sip
+++ b/python/gui/gui.sip
@@ -194,6 +194,7 @@
 %Include raster/qgssinglebandpseudocolorrendererwidget.sip
 
 %Include symbology-ng/characterwidget.sip
+%Include symbology-ng/qgs25drendererwidget.sip
 %Include symbology-ng/qgsbrushstylecombobox.sip
 %Include symbology-ng/qgscategorizedsymbolrendererv2widget.sip
 %Include symbology-ng/qgscolorrampcombobox.sip

--- a/python/gui/symbology-ng/qgs25drendererwidget.sip
+++ b/python/gui/symbology-ng/qgs25drendererwidget.sip
@@ -1,0 +1,38 @@
+/***************************************************************************
+  qgs25drendererwidget.sip - Qgs25DRendererWidget
+
+ ---------------------
+ begin                : 14.1.2016
+ copyright            : (C) 2016 by Matthias Kuhn
+ email                : matthias@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+class Qgs25DRendererWidget : QgsRendererV2Widget
+{
+%TypeHeaderCode
+#include "qgs25drendererwidget.h"
+%End
+  public:
+    /** Static creation method
+     * @param layer the layer where this renderer is applied
+     * @param style
+     * @param renderer the mask renderer (will take ownership)
+     */
+    static QgsRendererV2Widget* create( QgsVectorLayer* layer, QgsStyleV2* style, QgsFeatureRendererV2* renderer );
+
+    /** Constructor
+     * @param layer the layer where this renderer is applied
+     * @param style
+     * @param renderer the mask renderer (will take ownership)
+     */
+    Qgs25DRendererWidget( QgsVectorLayer* layer, QgsStyleV2* style, QgsFeatureRendererV2* renderer );
+
+    QgsFeatureRendererV2* renderer();
+};

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -30,6 +30,7 @@ SET(QGIS_CORE_SRCS
   symbology-ng/qgsgraduatedsymbolrendererv2.cpp
   symbology-ng/qgsrulebasedrendererv2.cpp
   symbology-ng/qgsheatmaprenderer.cpp
+  symbology-ng/qgs25drenderer.cpp
   symbology-ng/qgsinvertedpolygonrenderer.cpp
   symbology-ng/qgsvectorcolorrampv2.cpp
   symbology-ng/qgscptcityarchive.cpp
@@ -775,6 +776,7 @@ SET(QGIS_CORE_HDRS
   symbology-ng/qgsrulebasedrendererv2.h
   symbology-ng/qgssinglesymbolrendererv2.h
   symbology-ng/qgsheatmaprenderer.h
+  symbology-ng/qgs25drenderer.h
   symbology-ng/qgsinvertedpolygonrenderer.h
   symbology-ng/qgssymbollayerv2.h
   symbology-ng/qgssymbollayerv2registry.h

--- a/src/core/qgsdatadefined.h
+++ b/src/core/qgsdatadefined.h
@@ -63,7 +63,7 @@ class CORE_EXPORT QgsDataDefined
      * @param string field reference or an expression, can be empty
      * @note added in QGIS 2.9
      */
-    explicit QgsDataDefined( const QString& string );
+    QgsDataDefined( const QString& string );
 
     /**
      * Copy constructor. Note that copies of data defined objects with expressions

--- a/src/core/symbology-ng/qgs25drenderer.cpp
+++ b/src/core/symbology-ng/qgs25drenderer.cpp
@@ -1,0 +1,246 @@
+/***************************************************************************
+  qgs25drenderer.cpp - qgs25drenderer
+
+ ---------------------
+ begin                : 14.1.2016
+ copyright            : (C) 2016 by mku
+ email                : [your-email-here]
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include "qgs25drenderer.h"
+#include "qgsgeometrygeneratorsymbollayerv2.h"
+#include "qgsfillsymbollayerv2.h"
+#include "qgspainteffect.h"
+#include "qgseffectstack.h"
+#include "qgsgloweffect.h"
+
+#define ROOF_EXPRESSION \
+  "translate(" \
+  "  $geometry," \
+  "  cos( radians( eval( @qgis_25d_angle ) ) ) * eval( @qgis_25d_height )," \
+  "  sin( radians( eval( @qgis_25d_angle ) ) ) * eval( @qgis_25d_height )" \
+  ")"
+
+#define WALL_EXPRESSION \
+  "extrude(" \
+  "  segments_to_lines( exterior_ring( $geometry ) )," \
+  "  cos( radians( eval( @qgis_25d_angle ) ) ) * eval( @qgis_25d_height )," \
+  "  sin( radians( eval( @qgis_25d_angle ) ) ) * eval( @qgis_25d_height )" \
+  ")"
+
+Qgs25DRenderer::Qgs25DRenderer()
+    : QgsFeatureRendererV2( "25dRenderer" )
+{
+  mSymbol.reset( new QgsFillSymbolV2() );
+
+  mSymbol->deleteSymbolLayer( 0 ); // We never asked for the default layer
+
+  QgsSymbolLayerV2* floor = QgsSimpleFillSymbolLayerV2::create();
+
+  QgsStringMap wallProperties;
+  wallProperties.insert( "geometryModifier", WALL_EXPRESSION );
+  wallProperties.insert( "symbolType", "Fill" );
+  QgsSymbolLayerV2* walls = QgsGeometryGeneratorSymbolLayerV2::create( wallProperties );;
+
+  QgsStringMap roofProperties;
+  roofProperties.insert( "geometryModifier", ROOF_EXPRESSION );
+  roofProperties.insert( "symbolType", "Fill" );
+  QgsSymbolLayerV2* roof = QgsGeometryGeneratorSymbolLayerV2::create( roofProperties );
+
+  mSymbol->appendSymbolLayer( floor );
+  mSymbol->appendSymbolLayer( walls );
+  mSymbol->appendSymbolLayer( roof );
+
+  QgsOuterGlowEffect* glowEffect = new QgsOuterGlowEffect();
+  glowEffect->setBlurLevel( 5 );
+  glowEffect->setSpreadUnit( QgsSymbolV2::MapUnit );
+  floor->setPaintEffect( glowEffect );
+
+  // These methods must only be used after the above initialisation!
+
+  setRoofColor( QColor( "#fdbf6f" ) );
+  setWallColor( QColor( "#777777" ) );
+
+  setShadowSpread( 4 );
+  setShadowColor( QColor( "#1111111" ) );
+
+  setHeight( 20 );
+  setAngle( 40 );
+
+  QgsFeatureRequest::OrderBy orderBy;
+  orderBy << QgsFeatureRequest::OrderByClause(
+    "distance("
+    "  $geometry,"
+    "  translate("
+    "    @map_extent_center,"
+    "    1000 * @map_extent_width * cos( radians( @qgis_25d_angle + 180 ) ),"
+    "    1000 * @map_extent_width * sin( radians( @qgis_25d_angle + 180 ) )"
+    "  )"
+    ")",
+    false );
+
+  setOrderBy( orderBy );
+}
+
+QDomElement Qgs25DRenderer::save( QDomDocument& doc )
+{
+  QDomElement rendererElem = doc.createElement( RENDERER_TAG_NAME );
+
+  rendererElem.setAttribute( "type", "25dRenderer" );
+  rendererElem.setAttribute( "height", mHeight.expressionOrField() );
+  rendererElem.setAttribute( "angle", mAngle );
+
+  QDomElement symbolElem = QgsSymbolLayerV2Utils::saveSymbol( "symbol", mSymbol.data(), doc );
+
+  rendererElem.appendChild( symbolElem );
+
+  return rendererElem;
+}
+
+QgsFeatureRendererV2* Qgs25DRenderer::create( QDomElement& element )
+{
+  Qgs25DRenderer* renderer = new Qgs25DRenderer();
+  renderer->mHeight.setField( element.attribute( "height" ) );
+  renderer->mAngle = element.attribute( "angle", "45" ).toInt();
+
+  return renderer;
+}
+
+void Qgs25DRenderer::startRender( QgsRenderContext& context, const QgsFields& fields )
+{
+  QgsExpressionContextScope* scope = new QgsExpressionContextScope( "2.5D Renderer" );
+  scope->setVariable( "qgis_25d_height", mHeight.field() );
+  scope->setVariable( "qgis_25d_angle", mAngle );
+  context.expressionContext().appendScope( scope );
+  mSymbol->startRender( context, &fields );
+}
+
+void Qgs25DRenderer::stopRender( QgsRenderContext& context )
+{
+  mSymbol->stopRender( context );
+}
+
+QList<QString> Qgs25DRenderer::usedAttributes()
+{
+  return mSymbol->usedAttributes().toList();
+}
+
+QgsFeatureRendererV2* Qgs25DRenderer::clone() const
+{
+  Qgs25DRenderer* c = new Qgs25DRenderer();
+  c->mSymbol.reset( mSymbol->clone() );
+  c->mAngle = mAngle;
+  c->mHeight = mHeight;
+  return c;
+}
+
+QgsSymbolV2*Qgs25DRenderer::symbolForFeature( QgsFeature& feature, QgsRenderContext& context )
+{
+  Q_UNUSED( feature )
+  Q_UNUSED( context )
+  return mSymbol.data();
+}
+
+QgsSymbolV2List Qgs25DRenderer::symbols( QgsRenderContext& context )
+{
+  Q_UNUSED( context );
+  QgsSymbolV2List lst;
+  lst.append( mSymbol.data() );
+  return lst;
+}
+
+QgsDataDefined Qgs25DRenderer::height() const
+{
+  return mHeight;
+}
+
+void Qgs25DRenderer::setHeight( const QgsDataDefined& height )
+{
+  mHeight = height;
+}
+
+int Qgs25DRenderer::angle() const
+{
+  return mAngle;
+}
+
+void Qgs25DRenderer::setAngle( int angle )
+{
+  mAngle = angle;
+}
+
+QgsFillSymbolLayerV2* Qgs25DRenderer::roofLayer() const
+{
+  return static_cast<QgsFillSymbolLayerV2*>( mSymbol->symbolLayer( 2 )->subSymbol()->symbolLayer( 0 ) );
+}
+
+QgsFillSymbolLayerV2* Qgs25DRenderer::wallLayer() const
+{
+  return static_cast<QgsFillSymbolLayerV2*>( mSymbol->symbolLayer( 1 )->subSymbol()->symbolLayer( 0 ) );
+}
+
+QgsOuterGlowEffect* Qgs25DRenderer::glowEffect() const
+{
+  return static_cast<QgsOuterGlowEffect*>( mSymbol->symbolLayer( 0 )->paintEffect() );
+}
+
+QColor Qgs25DRenderer::shadowColor() const
+{
+  return glowEffect()->color();
+}
+
+void Qgs25DRenderer::setShadowColor( const QColor& shadowColor )
+{
+  glowEffect()->setColor( shadowColor );
+}
+
+double Qgs25DRenderer::shadowSpread() const
+{
+  return glowEffect()->spread();
+}
+
+void Qgs25DRenderer::setShadowSpread( double spread )
+{
+  glowEffect()->setSpread( spread );
+}
+
+QColor Qgs25DRenderer::wallColor() const
+{
+  return wallLayer()->fillColor();
+}
+
+void Qgs25DRenderer::setWallColor( const QColor& wallColor )
+{
+  wallLayer()->setFillColor( wallColor );
+  wallLayer()->setOutlineColor( wallColor );
+}
+
+QColor Qgs25DRenderer::roofColor() const
+{
+  return roofLayer()->fillColor();
+}
+
+void Qgs25DRenderer::setRoofColor( const QColor& roofColor )
+{
+  roofLayer()->setFillColor( roofColor );
+  roofLayer()->setOutlineColor( roofColor );
+}
+
+Qgs25DRenderer* Qgs25DRenderer::convertFromRenderer( QgsFeatureRendererV2* renderer )
+{
+  if ( renderer->type() == "25dRenderer" )
+  {
+    return static_cast<Qgs25DRenderer*>( renderer->clone() );
+  }
+  else
+  {
+    return new Qgs25DRenderer();
+  }
+}
+

--- a/src/core/symbology-ng/qgs25drenderer.h
+++ b/src/core/symbology-ng/qgs25drenderer.h
@@ -1,0 +1,122 @@
+/***************************************************************************
+  qgs25drenderer.h - Qgs25DRenderer
+
+ ---------------------
+ begin                : 14.1.2016
+ copyright            : (C) 2016 by Matthias Kuhn
+ email                : matthias@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGS25DRENDERER_H
+#define QGS25DRENDERER_H
+
+#include "qgsrendererv2.h"
+#include "qgsdatadefined.h"
+
+class QgsOuterGlowEffect;
+
+class CORE_EXPORT Qgs25DRenderer : public QgsFeatureRendererV2
+{
+  public:
+    Qgs25DRenderer();
+
+    /**
+     * Create a new 2.5D renderer from XML
+     *
+     * @param element XML information
+     */
+    static QgsFeatureRendererV2* create( QDomElement& element );
+    QDomElement save( QDomDocument& doc ) override;
+
+    void startRender( QgsRenderContext& context, const QgsFields& fields ) override;
+    void stopRender( QgsRenderContext& context ) override;
+
+    QList<QString> usedAttributes() override;
+    QgsFeatureRendererV2* clone() const override;
+
+    virtual QgsSymbolV2* symbolForFeature( QgsFeature& feature, QgsRenderContext& context ) override;
+    virtual QgsSymbolV2List symbols( QgsRenderContext& context ) override;
+
+    /**
+     * Get the field or expression used to determine the height of extrusion
+     */
+    QgsDataDefined height() const;
+    /**
+     * Set the field or expression used to determine the height of extrusion
+     */
+    void setHeight( const QgsDataDefined& height );
+
+    /**
+     * Get the angle for the extrusion effect
+     */
+    int angle() const;
+    /**
+     * Set the angle for the extrusion effect
+     */
+    void setAngle( int angle );
+
+    /**
+     * Get the roof color
+     */
+    QColor roofColor() const;
+
+    /**
+     * Set the roof color
+     */
+    void setRoofColor( const QColor& roofColor );
+
+    /**
+     * Get the wall color
+     */
+    QColor wallColor() const;
+
+    /**
+     * Set the wall color
+     */
+    void setWallColor( const QColor& wallColor );
+
+    /**
+     * Get the shadow's color
+     */
+    QColor shadowColor() const;
+
+    /**
+     * Set the shadow's color
+     */
+    void setShadowColor( const QColor& shadowColor );
+
+    /**
+     * Get the shadow's spread distance in map units
+     */
+    double shadowSpread() const;
+    /**
+     * Set the shadow's spread distance in map units
+     */
+    void setShadowSpread( double shadowSpread );
+
+    /**
+     * Try to convert from an existing renderer. If it is not of the same type
+     * we assume that the internals are not compatible and create a new default
+     * 2.5D renderer.
+     */
+    static Qgs25DRenderer* convertFromRenderer( QgsFeatureRendererV2* renderer );
+
+  private:
+
+    QgsFillSymbolLayerV2* roofLayer() const;
+    QgsFillSymbolLayerV2* wallLayer() const;
+    QgsOuterGlowEffect* glowEffect() const;
+
+    QScopedPointer<QgsSymbolV2> mSymbol;
+
+    QgsDataDefined mHeight;
+    int mAngle;
+};
+
+#endif // QGS25DRENDERER_H

--- a/src/core/symbology-ng/qgsrendererv2registry.cpp
+++ b/src/core/symbology-ng/qgsrendererv2registry.cpp
@@ -22,6 +22,7 @@
 #include "qgspointdisplacementrenderer.h"
 #include "qgsinvertedpolygonrenderer.h"
 #include "qgsheatmaprenderer.h"
+#include "qgs25drenderer.h"
 
 QgsRendererV2Registry::QgsRendererV2Registry()
 {
@@ -55,6 +56,11 @@ QgsRendererV2Registry::QgsRendererV2Registry()
   addRenderer( new QgsRendererV2Metadata( "heatmapRenderer",
                                           QObject::tr( "Heatmap" ),
                                           QgsHeatmapRenderer::create ) );
+
+
+  addRenderer( new QgsRendererV2Metadata( "25dRenderer",
+                                          QObject::tr( "2.5 D" ),
+                                          Qgs25DRenderer::create ) );
 }
 
 QgsRendererV2Registry::~QgsRendererV2Registry()

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -16,6 +16,7 @@ SET(QGIS_GUI_SRCS
   symbology-ng/qgssymbollayerv2widget.cpp
   symbology-ng/qgsrendererv2widget.cpp
   symbology-ng/qgssinglesymbolrendererv2widget.cpp
+  symbology-ng/qgs25drendererwidget.cpp
   symbology-ng/qgscategorizedsymbolrendererv2widget.cpp
   symbology-ng/qgsgraduatedsymbolrendererv2widget.cpp
   symbology-ng/qgsgraduatedhistogramwidget.cpp
@@ -431,6 +432,7 @@ SET(QGIS_GUI_MOC_HDRS
   symbology-ng/qgsrendererv2widget.h
   symbology-ng/qgsrulebasedrendererv2widget.h
   symbology-ng/qgssinglesymbolrendererv2widget.h
+  symbology-ng/qgs25drendererwidget.h
   symbology-ng/qgssmartgroupeditordialog.h
   symbology-ng/qgsstylev2exportimportdialog.h
   symbology-ng/qgsstylev2groupselectiondialog.h

--- a/src/gui/symbology-ng/qgs25drendererwidget.cpp
+++ b/src/gui/symbology-ng/qgs25drendererwidget.cpp
@@ -1,0 +1,72 @@
+/***************************************************************************
+  qgs25drendererwidget.cpp - Qgs25DRendererWidget
+
+ ---------------------
+ begin                : 14.1.2016
+ copyright            : (C) 2016 by mku
+ email                : [your-email-here]
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include "qgs25drendererwidget.h"
+
+Qgs25DRendererWidget::Qgs25DRendererWidget( QgsVectorLayer* layer, QgsStyleV2* style, QgsFeatureRendererV2* renderer )
+    : QgsRendererV2Widget( layer, style )
+    , mRenderer( nullptr )
+{
+  if ( !layer )
+    return;
+
+  // the renderer only applies to point vector layers
+  if ( layer->geometryType() != QGis::Polygon )
+  {
+    //setup blank dialog
+    QGridLayout* layout = new QGridLayout( this );
+    QLabel* label = new QLabel( tr( "The 2.5D renderer only can be used with polygon layers. \n"
+                                    "'%1' is not a polygon layer and cannot be rendered in 2.5D." )
+                                .arg( layer->name() ), this );
+    layout->addWidget( label );
+    return;
+  }
+
+  setupUi( this );
+
+  if ( renderer )
+  {
+    mRenderer = Qgs25DRenderer::convertFromRenderer( renderer );
+  }
+
+  mHeightWidget->setLayer( layer );
+  mHeightWidget->setField( mRenderer->height().expressionOrField() );
+  mAngleWidget->setValue( mRenderer->angle() );
+  mWallColorButton->setColor( mRenderer->wallColor() );
+  mRoofColorButton->setColor( mRenderer->roofColor() );
+
+  connect( mAngleWidget, SIGNAL( valueChanged( int ) ), this, SLOT( updateRenderer() ) );
+  connect( mHeightWidget, SIGNAL( fieldChanged( QString ) ), this, SLOT( updateRenderer() ) );
+  connect( mWallColorButton, SIGNAL( colorChanged( QColor ) ), this, SLOT( updateRenderer() ) );
+  connect( mRoofColorButton, SIGNAL( colorChanged( QColor ) ), this, SLOT( updateRenderer() ) );
+}
+
+QgsFeatureRendererV2* Qgs25DRendererWidget::renderer()
+{
+  return mRenderer;
+}
+
+void Qgs25DRendererWidget::updateRenderer()
+{
+  mRenderer->setHeight( QgsDataDefined( mHeightWidget->currentText() ) );
+  mRenderer->setAngle( mAngleWidget->value() );
+  mRenderer->setRoofColor( mRoofColorButton->color() );
+  mRenderer->setWallColor( mWallColorButton->color() );
+}
+
+QgsRendererV2Widget* Qgs25DRendererWidget::create( QgsVectorLayer* layer, QgsStyleV2* style, QgsFeatureRendererV2* renderer )
+{
+  return new Qgs25DRendererWidget( layer, style, renderer );
+}

--- a/src/gui/symbology-ng/qgs25drendererwidget.h
+++ b/src/gui/symbology-ng/qgs25drendererwidget.h
@@ -1,0 +1,51 @@
+/***************************************************************************
+  qgs25drendererwidget.h - Qgs25DRendererWidget
+
+ ---------------------
+ begin                : 14.1.2016
+ copyright            : (C) 2016 by Matthias Kuhn
+ email                : matthias@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGS25DRENDERERWIDGET_H
+#define QGS25DRENDERERWIDGET_H
+
+#include "ui_qgs25drendererwidgetbase.h"
+#include "qgsrendererv2widget.h"
+#include "qgs25drenderer.h"
+
+class GUI_EXPORT Qgs25DRendererWidget : public QgsRendererV2Widget, Ui::Qgs25DRendererWidgetBase
+{
+    Q_OBJECT
+
+  public:
+    /** Static creation method
+     * @param layer the layer where this renderer is applied
+     * @param style
+     * @param renderer the mask renderer (will take ownership)
+     */
+    static QgsRendererV2Widget* create( QgsVectorLayer* layer, QgsStyleV2* style, QgsFeatureRendererV2* renderer );
+
+    /** Constructor
+     * @param layer the layer where this renderer is applied
+     * @param style
+     * @param renderer the mask renderer (will take ownership)
+     */
+    Qgs25DRendererWidget( QgsVectorLayer* layer, QgsStyleV2* style, QgsFeatureRendererV2* renderer );
+
+    QgsFeatureRendererV2* renderer() override;
+
+  private slots:
+    void updateRenderer();
+
+  private:
+    Qgs25DRenderer* mRenderer;
+};
+
+#endif // QGS25DRENDERERWIDGET_H

--- a/src/gui/symbology-ng/qgscategorizedsymbolrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgscategorizedsymbolrendererv2widget.cpp
@@ -419,6 +419,7 @@ QgsCategorizedSymbolRendererV2Widget::QgsCategorizedSymbolRendererV2Widget( QgsV
   if ( renderer )
   {
     mRenderer = QgsCategorizedSymbolRendererV2::convertFromRenderer( renderer );
+    mRenderer->setOrderBy( renderer->orderBy() );
   }
   if ( !mRenderer )
   {

--- a/src/gui/symbology-ng/qgsgraduatedsymbolrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgsgraduatedsymbolrendererv2widget.cpp
@@ -425,6 +425,7 @@ QgsGraduatedSymbolRendererV2Widget::QgsGraduatedSymbolRendererV2Widget( QgsVecto
   if ( renderer )
   {
     mRenderer = QgsGraduatedSymbolRendererV2::convertFromRenderer( renderer );
+    mRenderer->setOrderBy( renderer->orderBy() );
   }
   if ( !mRenderer )
   {

--- a/src/gui/symbology-ng/qgsrendererv2propertiesdialog.cpp
+++ b/src/gui/symbology-ng/qgsrendererv2propertiesdialog.cpp
@@ -25,8 +25,9 @@
 #include "qgspointdisplacementrendererwidget.h"
 #include "qgsinvertedpolygonrendererwidget.h"
 #include "qgsheatmaprendererwidget.h"
-#include "qgsorderbydialog.h"
+#include "qgs25drendererwidget.h"
 
+#include "qgsorderbydialog.h"
 #include "qgsapplication.h"
 #include "qgslogger.h"
 #include "qgsvectorlayer.h"
@@ -71,6 +72,7 @@ static void _initRendererWidgetFunctions()
   _initRenderer( "pointDisplacement", QgsPointDisplacementRendererWidget::create );
   _initRenderer( "invertedPolygonRenderer", QgsInvertedPolygonRendererWidget::create );
   _initRenderer( "heatmapRenderer", QgsHeatmapRendererWidget::create );
+  _initRenderer( "25dRenderer", Qgs25DRendererWidget::create, "rendererSingleSymbol.png" );
   initialized = true;
 }
 
@@ -186,7 +188,7 @@ void QgsRendererV2PropertiesDialog::rendererChanged()
 
   //Retrieve the previous renderer: from the old active widget if possible, otherwise from the layer
   QgsFeatureRendererV2* oldRenderer;
-  if ( mActiveWidget  && mActiveWidget->renderer() )
+  if ( mActiveWidget && mActiveWidget->renderer() )
   {
     oldRenderer = mActiveWidget->renderer()->clone();
   }
@@ -216,15 +218,18 @@ void QgsRendererV2PropertiesDialog::rendererChanged()
     mActiveWidget = w;
     stackedWidget->addWidget( mActiveWidget );
     stackedWidget->setCurrentWidget( mActiveWidget );
-    if ( mMapCanvas && mActiveWidget->renderer() )
-      mActiveWidget->setMapCanvas( mMapCanvas );
+    if ( mActiveWidget->renderer() )
+    {
+      if ( mMapCanvas )
+        mActiveWidget->setMapCanvas( mMapCanvas );
+      changeOrderBy( mActiveWidget->renderer()->orderBy() );
+    }
   }
   else
   {
     // set default "no edit widget available" page
     stackedWidget->setCurrentWidget( pageNoWidget );
   }
-
 }
 
 void QgsRendererV2PropertiesDialog::apply()
@@ -268,6 +273,13 @@ void QgsRendererV2PropertiesDialog::showOrderByDialog()
     mOrderBy = dlg.orderBy();
     lineEditOrderBy->setText( mOrderBy.dump() );
   }
+}
+
+void QgsRendererV2PropertiesDialog::changeOrderBy( const QgsFeatureRequest::OrderBy& orderBy )
+{
+  mOrderBy = orderBy;
+  lineEditOrderBy->setText( mOrderBy.dump() );
+  checkboxEnableOrderBy->setEnabled( orderBy.isEmpty() );
 }
 
 

--- a/src/gui/symbology-ng/qgsrendererv2propertiesdialog.h
+++ b/src/gui/symbology-ng/qgsrendererv2propertiesdialog.h
@@ -57,6 +57,8 @@ class GUI_EXPORT QgsRendererV2PropertiesDialog : public QDialog, private Ui::Qgs
   private slots:
     void showOrderByDialog();
 
+    void changeOrderBy( const QgsFeatureRequest::OrderBy& orderBy );
+
   protected:
 
     //! Reimplements dialog keyPress event so we can ignore it

--- a/src/gui/symbology-ng/qgssinglesymbolrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgssinglesymbolrendererv2widget.cpp
@@ -39,6 +39,7 @@ QgsSingleSymbolRendererV2Widget::QgsSingleSymbolRendererV2Widget( QgsVectorLayer
   if ( renderer )
   {
     mRenderer = QgsSingleSymbolRendererV2::convertFromRenderer( renderer );
+    mRenderer->setOrderBy( renderer->orderBy() );
   }
   if ( !mRenderer )
   {

--- a/src/ui/symbollayer/qgs25drendererwidgetbase.ui
+++ b/src/ui/symbollayer/qgs25drendererwidgetbase.ui
@@ -1,0 +1,99 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>Qgs25DRendererWidgetBase</class>
+ <widget class="QWidget" name="Qgs25DRendererWidgetBase">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>602</width>
+    <height>395</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QFormLayout" name="formLayout">
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Height</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Angle</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0" colspan="2">
+    <widget class="QGroupBox" name="mAdvancedConfigurationBox">
+     <property name="title">
+      <string>Advanced Configuration</string>
+     </property>
+     <layout class="QFormLayout" name="formLayout_2">
+      <item row="1" column="1">
+       <widget class="QgsColorButtonV2" name="mRoofColorButton">
+        <property name="text">
+         <string>...</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="0">
+       <widget class="QLabel" name="label_3">
+        <property name="text">
+         <string>Roof Color</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_4">
+        <property name="text">
+         <string>Wall Color</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QgsColorButtonV2" name="mWallColorButton">
+        <property name="text">
+         <string>...</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QgsFieldExpressionWidget" name="mHeightWidget" native="true"/>
+   </item>
+   <item row="1" column="1">
+    <widget class="QSpinBox" name="mAngleWidget">
+     <property name="suffix">
+      <string>°</string>
+     </property>
+     <property name="maximum">
+      <number>359</number>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsFieldExpressionWidget</class>
+   <extends>QWidget</extends>
+   <header location="global">qgsfieldexpressionwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsColorButtonV2</class>
+   <extends>QToolButton</extends>
+   <header>qgscolorbuttonv2.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
This adds a configuration interface and renderer that makes it easy to
put all the pieces together which are required to get a 2.5D effect.

It allow for configuring some of the styling and is meant to create an
easy-to-use setup.

Since every part of the system is built around QGIS' internal rendering
and symbology engine, there is much to fine tune. To get all the
possibilities, just change the renderer to a graduated, categorized or
single symbol renderer upon creation and you will find full access to
improve the style to your needs.

Funded by
- Regional Council of Picardy
- ADUGA
- Ville de Nyon
- Wetu GIT cc
