### PR TITLE
[FEATURE] Autotransaction mode and transaction groups

### DIFF
--- a/python/core/core.sip
+++ b/python/core/core.sip
@@ -19,6 +19,7 @@
 %Include qgis.sip
 
 %Include qgstransaction.sip
+%Include qgstransactiongroup.sip
 %Include qgsapplication.sip
 %Include qgsattributeaction.sip
 %Include qgsbrowsermodel.sip

--- a/python/core/qgstransaction.sip
+++ b/python/core/qgstransaction.sip
@@ -59,6 +59,11 @@ class QgsTransaction : QObject /Abstract/
     /** Executes sql */
     virtual bool executeSql( const QString& sql, QString& error /Out/ ) = 0;
 
+    /**
+     * Checks if a the provider of a give layer supports transactions.
+     */
+    static bool supportsTransaction( const QgsVectorLayer* layer );
+
   signals:
     /**
      * Emitted after a rollback

--- a/python/core/qgstransactiongroup.sip
+++ b/python/core/qgstransactiongroup.sip
@@ -1,0 +1,56 @@
+/***************************************************************************
+  qgstransactiongroup.h - QgsTransactionGroup
+
+ ---------------------
+ begin                : 15.1.2016
+ copyright            : (C) 2016 by Matthias Kuhn
+ email                : mmatthias@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+class QgsTransactionGroup : QObject
+{
+%TypeHeaderCode
+#include "qgstransactiongroup.h"
+%End
+  public:
+    explicit QgsTransactionGroup( QObject *parent = 0 );
+
+    ~QgsTransactionGroup();
+
+    /**
+     * Add a layer to this transaction group.
+     *
+     * Will return true if it is compatible and has been added.
+     */
+    bool addLayer( QgsVectorLayer* layer );
+
+    /**
+     * Return the connection string used by this transaction group.
+     * Layers need be compatible when added.
+     */
+    QString connString() const;
+
+    /**
+     * Return the provider key used by this transaction group.
+     * Layers need be compatible when added.
+     */
+    QString providerKey() const;
+
+    /**
+     * Returns true if there are no layers in this transaction group.
+     */
+    bool isEmpty() const;
+
+  signals:
+    /**
+     * Will be emitted whenever there is a commit error
+     */
+    void commitError( const QString& msg );
+};

--- a/python/core/qgsvectorlayer.sip
+++ b/python/core/qgsvectorlayer.sip
@@ -1015,14 +1015,6 @@ class QgsVectorLayer : QgsMapLayer
      */
     bool setReadOnly( bool readonly = true );
 
-    /**
-     * Make layer editable.
-     * This starts an edit session on this layer. Changes made in this edit session will not
-     * be made persistent until {@link commitChanges()} is called and can be reverted by calling
-     * {@link rollBack()}.
-     */
-    bool startEditing();
-
     /** Change feature's geometry */
     bool changeGeometry( QgsFeatureId fid, QgsGeometry* geom );
 
@@ -1493,6 +1485,15 @@ class QgsVectorLayer : QgsMapLayer
     /** Check if there is a join with a layer that will be removed */
     void checkJoinLayerRemove( const QString& theLayerId );
 
+    /**
+     * Make layer editable.
+     * This starts an edit session on this layer. Changes made in this edit session will not
+     * be made persistent until {@link commitChanges()} is called and can be reverted by calling
+     * {@link rollBack()}.
+     */
+    bool startEditing();
+
+
   protected slots:
     void invalidateSymbolCountedFlag();
 
@@ -1515,6 +1516,9 @@ class QgsVectorLayer : QgsMapLayer
 
     /** Is emitted, when layer is checked for modifications. Use for last-minute additions */
     void beforeModifiedCheck() const;
+
+    /** Is emitted, before editing on this layer is started */
+    void beforeEditingStarted();
 
     /** Is emitted, when editing on this layer has started*/
     void editingStarted();
@@ -1663,10 +1667,6 @@ class QgsVectorLayer : QgsMapLayer
      */
     void writeCustomSymbology( QDomElement& element, QDomDocument& doc, QString& errorMessage ) const;
 
-  private slots:
-    void onRelationsLoaded();
-    void onJoinedFieldsChanged();
-    void onFeatureDeleted( QgsFeatureId fid );
 
   protected:
     /** Set the extent */

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -64,6 +64,7 @@ class QgsProviderRegistry;
 class QgsPythonUtils;
 class QgsRectangle;
 class QgsSnappingUtils;
+class QgsTransactionGroup;
 class QgsUndoWidget;
 class QgsUserInputDockWidget;
 class QgsVectorLayer;
@@ -670,6 +671,9 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     void refreshActionFeatureAction();
 
     QMenu *panelMenu() { return mPanelMenu; }
+
+    bool autoTransaction() const;
+    void setAutoTransaction( bool state );
 
   protected:
 
@@ -1667,6 +1671,9 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     QgsPluginManager *mPluginManager;
 
     QgsComposerManager *mComposerManager;
+
+    //! map of transaction group: QPair( providerKey, connString ) -> transactionGroup
+    QMap< QPair< QString, QString>, QgsTransactionGroup*> mTransactionGroups;
 
     //! Persistent tile scale slider
     QgsTileScaleWidget *mpTileScaleWidget;

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -591,6 +591,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl ) :
   cbxAddOracleDC->setChecked( mSettings->value( "/qgis/addOracleDC", false ).toBool() );
   cbxCompileExpressions->setChecked( mSettings->value( "/qgis/compileExpressions", true ).toBool() );
   cbxCreateRasterLegendIcons->setChecked( mSettings->value( "/qgis/createRasterLegendIcons", false ).toBool() );
+  cbxAutoTransaction->setChecked( QgisApp::instance()->autoTransaction() );
   cbxCopyWKTGeomFromTable->setChecked( mSettings->value( "/qgis/copyGeometryAsWKT", true ).toBool() );
   leNullValue->setText( mSettings->value( "qgis/nullValue", "NULL" ).toString() );
   cbxIgnoreShapeEncoding->setChecked( mSettings->value( "/qgis/ignoreShapeEncoding", true ).toBool() );
@@ -1141,6 +1142,7 @@ void QgsOptions::saveOptions()
   mSettings->setValue( "/qgis/defaultLegendGraphicResolution", mLegendGraphicResolutionSpinBox->value() );
   bool createRasterLegendIcons = mSettings->value( "/qgis/createRasterLegendIcons", false ).toBool();
   mSettings->setValue( "/qgis/createRasterLegendIcons", cbxCreateRasterLegendIcons->isChecked() );
+  QgisApp::instance()->setAutoTransaction( cbxAutoTransaction->isChecked() );
   mSettings->setValue( "/qgis/copyGeometryAsWKT", cbxCopyWKTGeomFromTable->isChecked() );
   mSettings->setValue( "/qgis/new_layers_visible", chkAddedVisibility->isChecked() );
   mSettings->setValue( "/qgis/enable_anti_aliasing", chkAntiAliasing->isChecked() );

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -190,6 +190,7 @@ SET(QGIS_CORE_SRCS
   qgstolerance.cpp
   qgstracer.cpp
   qgstransaction.cpp
+  qgstransactiongroup.cpp
   qgsvectordataprovider.cpp
   qgsvectorfilewriter.cpp
   qgsvectorlayer.cpp
@@ -459,6 +460,7 @@ SET(QGIS_CORE_MOC_HDRS
   qgssnappingutils.h
   qgstracer.h
   qgstransaction.h
+  qgstransactiongroup.h
   qgsvectordataprovider.h
   qgsvectorlayercache.h
   qgsvectorlayereditbuffer.h

--- a/src/core/qgstransaction.cpp
+++ b/src/core/qgstransaction.cpp
@@ -83,18 +83,12 @@ QgsTransaction::~QgsTransaction()
 
 bool QgsTransaction::addLayer( const QString& layerId )
 {
-  if ( mTransactionActive )
-    return false;
-
   QgsVectorLayer* layer = qobject_cast<QgsVectorLayer*>( QgsMapLayerRegistry::instance()->mapLayer( layerId ) );
   return addLayer( layer );
 }
 
 bool QgsTransaction::addLayer( QgsVectorLayer* layer )
 {
-  if ( mTransactionActive )
-    return false;
-
   if ( !layer )
     return false;
 
@@ -119,6 +113,10 @@ bool QgsTransaction::addLayer( QgsVectorLayer* layer )
   connect( this, SIGNAL( afterRollback() ), layer->dataProvider(), SIGNAL( dataChanged() ) );
   connect( QgsMapLayerRegistry::instance(), SIGNAL( layersWillBeRemoved( QStringList ) ), this, SLOT( onLayersDeleted( QStringList ) ) );
   mLayers.insert( layer );
+
+  if ( mTransactionActive )
+    layer->dataProvider()->setTransaction( this );
+
   return true;
 }
 
@@ -141,14 +139,6 @@ bool QgsTransaction::commit( QString& errorMsg )
   if ( !mTransactionActive )
     return false;
 
-  Q_FOREACH ( QgsVectorLayer* l, mLayers )
-  {
-    if ( !l || l->isEditable() )
-    {
-      return false;
-    }
-  }
-
   if ( !commitTransaction( errorMsg ) )
     return false;
 
@@ -161,14 +151,6 @@ bool QgsTransaction::rollback( QString& errorMsg )
 {
   if ( !mTransactionActive )
     return false;
-
-  Q_FOREACH ( QgsVectorLayer* l, mLayers )
-  {
-    if ( l->isEditable() )
-    {
-      return false;
-    }
-  }
 
   if ( !rollbackTransaction( errorMsg ) )
     return false;

--- a/src/core/qgstransaction.cpp
+++ b/src/core/qgstransaction.cpp
@@ -163,6 +163,15 @@ bool QgsTransaction::rollback( QString& errorMsg )
   return true;
 }
 
+bool QgsTransaction::supportsTransaction( const QgsVectorLayer* layer )
+{
+  QLibrary* lib = QgsProviderRegistry::instance()->providerLibrary( layer->providerType() );
+  if ( !lib )
+    return false;
+
+  return lib->resolve( "createTransaction" );
+}
+
 void QgsTransaction::onLayersDeleted( const QStringList& layerids )
 {
   Q_FOREACH ( const QString& layerid, layerids )

--- a/src/core/qgstransaction.h
+++ b/src/core/qgstransaction.h
@@ -85,6 +85,11 @@ class CORE_EXPORT QgsTransaction : public QObject
     /** Executes sql */
     virtual bool executeSql( const QString& sql, QString& error ) = 0;
 
+    /**
+     * Checks if a the provider of a give layer supports transactions.
+     */
+    static bool supportsTransaction( const QgsVectorLayer* layer );
+
   signals:
     /**
      * Emitted after a rollback

--- a/src/core/qgstransaction.h
+++ b/src/core/qgstransaction.h
@@ -60,10 +60,10 @@ class CORE_EXPORT QgsTransaction : public QObject
 
     virtual ~QgsTransaction();
 
-    /** Add layer to the transaction. The layer must not be in edit mode. The transaction must not be active. */
+    /** Add layer to the transaction. The layer must not be in edit mode.*/
     bool addLayer( const QString& layerId );
 
-    /** Add layer to the transaction. The layer must not be in edit mode. The transaction must not be active. */
+    /** Add layer to the transaction. The layer must not be in edit mode.*/
     bool addLayer( QgsVectorLayer* layer );
 
     /** Begin transaction
@@ -76,10 +76,10 @@ class CORE_EXPORT QgsTransaction : public QObject
      *  Some providers might not honour the statement timeout. */
     bool begin( QString& errorMsg, int statementTimeout = 20 );
 
-    /** Commit transaction. All layers need to be in read-only mode. */
+    /** Commit transaction. */
     bool commit( QString& errorMsg );
 
-    /** Roll back transaction. All layers need to be in read-only mode. */
+    /** Roll back transaction. */
     bool rollback( QString& errorMsg );
 
     /** Executes sql */

--- a/src/core/qgstransactiongroup.cpp
+++ b/src/core/qgstransactiongroup.cpp
@@ -1,0 +1,154 @@
+/***************************************************************************
+  qgstransactiongroup.cpp - QgsTransactionGroup
+
+ ---------------------
+ begin                : 15.1.2016
+ copyright            : (C) 2016 by mku
+ email                : [your-email-here]
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include "qgstransactiongroup.h"
+
+#include "qgstransaction.h"
+#include "qgsvectorlayer.h"
+#include "qgsdatasourceuri.h"
+#include "qgsvectordataprovider.h"
+
+#include <QTimer>
+
+QgsTransactionGroup::QgsTransactionGroup( QObject *parent )
+    : QObject( parent )
+    , mEditingStarting( false )
+    , mEditingStopping( false )
+    , mTransaction( nullptr )
+{
+
+}
+
+QgsTransactionGroup::~QgsTransactionGroup()
+{
+  delete mTransaction;
+}
+
+bool QgsTransactionGroup::addLayer( QgsVectorLayer* layer )
+{
+  if ( !QgsTransaction::supportsTransaction( layer ) )
+    return false;
+
+  QString connString = QgsDataSourceURI( layer->source() ).connectionInfo();
+
+  if ( mConnString.isEmpty() )
+  {
+    mConnString = connString;
+    mProviderKey = layer->providerType();
+  }
+  else if ( mConnString != connString || mProviderKey != layer->providerType() )
+  {
+    return false;
+  }
+
+  mLayers.insert( layer );
+
+  connect( layer, SIGNAL( beforeEditingStarted() ), this, SLOT( onEditingStarted() ) );
+  connect( layer, SIGNAL( layerDeleted() ), this, SLOT( onLayerDeleted() ) );
+
+  return true;
+}
+
+void QgsTransactionGroup::onEditingStarted()
+{
+  if ( mTransaction )
+    return;
+
+  mTransaction = QgsTransaction::create( mConnString, mProviderKey );
+
+  QString errorMsg;
+  mTransaction->begin( errorMsg );
+
+  Q_FOREACH ( QgsVectorLayer* layer, mLayers )
+  {
+    mTransaction->addLayer( layer );
+    layer->startEditing();
+    connect( layer, SIGNAL( beforeCommitChanges() ), this, SLOT( onCommitChanges() ) );
+    connect( layer, SIGNAL( beforeRollBack() ), this, SLOT( onRollback() ) );
+  }
+}
+
+void QgsTransactionGroup::onLayerDeleted()
+{
+  mLayers.remove( qobject_cast<QgsVectorLayer*>( sender() ) );
+}
+
+void QgsTransactionGroup::onCommitChanges()
+{
+  if ( mEditingStopping )
+    return;
+
+  mEditingStopping = true;
+
+  QgsVectorLayer* triggeringLayer = qobject_cast<QgsVectorLayer*>( sender() );
+
+  QString errMsg;
+  if ( mTransaction->commit( errMsg ) )
+  {
+    Q_FOREACH ( QgsVectorLayer* layer, mLayers )
+    {
+      if ( layer != sender() )
+        layer->commitChanges();
+    }
+  }
+  else
+  {
+    emit commitError( errMsg );
+    // Restart editing the calling layer in the next event loop cycle
+    QTimer::singleShot( 0, triggeringLayer, SLOT( startEditing() ) );
+  }
+  mEditingStopping = false;
+}
+
+void QgsTransactionGroup::onRollback()
+{
+  if ( mEditingStopping )
+    return;
+
+  mEditingStopping = true;
+
+  QgsVectorLayer* triggeringLayer = qobject_cast<QgsVectorLayer*>( sender() );
+
+  QString errMsg;
+  if ( mTransaction->rollback( errMsg ) )
+  {
+    Q_FOREACH ( QgsVectorLayer* layer, mLayers )
+    {
+      if ( layer != triggeringLayer )
+        layer->rollBack();
+    }
+  }
+  else
+  {
+    // Restart editing the calling layer in the next event loop cycle
+    QTimer::singleShot( 0, triggeringLayer, SLOT( startEditing() ) );
+  }
+  mEditingStopping = false;
+}
+
+QString QgsTransactionGroup::providerKey() const
+{
+  return mProviderKey;
+}
+
+bool QgsTransactionGroup::isEmpty() const
+{
+  return mLayers.isEmpty();
+}
+
+QString QgsTransactionGroup::connString() const
+{
+  return mConnString;
+}

--- a/src/core/qgstransactiongroup.h
+++ b/src/core/qgstransactiongroup.h
@@ -1,0 +1,81 @@
+/***************************************************************************
+  qgstransactiongroup.h - QgsTransactionGroup
+
+ ---------------------
+ begin                : 15.1.2016
+ copyright            : (C) 2016 by Matthias Kuhn
+ email                : mmatthias@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSTRANSACTIONGROUP_H
+#define QGSTRANSACTIONGROUP_H
+
+#include <QObject>
+#include <QSet>
+
+class QgsVectorLayer;
+class QgsTransaction;
+
+class CORE_EXPORT QgsTransactionGroup : public QObject
+{
+    Q_OBJECT
+  public:
+    explicit QgsTransactionGroup( QObject *parent = 0 );
+
+    ~QgsTransactionGroup();
+
+    /**
+     * Add a layer to this transaction group.
+     *
+     * Will return true if it is compatible and has been added.
+     */
+    bool addLayer( QgsVectorLayer* layer );
+
+    /**
+     * Return the connection string used by this transaction group.
+     * Layers need be compatible when added.
+     */
+    QString connString() const;
+
+    /**
+     * Return the provider key used by this transaction group.
+     * Layers need be compatible when added.
+     */
+    QString providerKey() const;
+
+    /**
+     * Returns true if there are no layers in this transaction group.
+     */
+    bool isEmpty() const;
+
+  signals:
+    /**
+     * Will be emitted whenever there is a commit error
+     */
+    void commitError( const QString& msg );
+
+  private slots:
+    void onEditingStarted();
+    void onLayerDeleted();
+    void onCommitChanges();
+    void onRollback();
+
+  private:
+    bool mEditingStarting;
+    bool mEditingStopping;
+
+    QSet<QgsVectorLayer*> mLayers;
+    //! Only set while a transaction is active
+    QgsTransaction* mTransaction;
+    //! Layers have to be compatible with the connection string
+    QString mConnString;
+    QString mProviderKey;
+};
+
+#endif // QGSTRANSACTIONGROUP_H

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -1313,6 +1313,8 @@ bool QgsVectorLayer::startEditing()
     return false;
   }
 
+  emit beforeEditingStarted();
+
   if ( mDataProvider->transaction() )
   {
     mEditBuffer = new QgsVectorLayerEditPassthrough( this );

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -1140,14 +1140,6 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
      */
     bool setReadOnly( bool readonly = true );
 
-    /**
-     * Make layer editable.
-     * This starts an edit session on this layer. Changes made in this edit session will not
-     * be made persistent until {@link commitChanges()} is called and can be reverted by calling
-     * {@link rollBack()}.
-     */
-    bool startEditing();
-
     /** Change feature's geometry */
     bool changeGeometry( QgsFeatureId fid, QgsGeometry* geom );
 
@@ -1672,6 +1664,15 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
     /** Check if there is a join with a layer that will be removed */
     void checkJoinLayerRemove( const QString& theLayerId );
 
+    /**
+     * Make layer editable.
+     * This starts an edit session on this layer. Changes made in this edit session will not
+     * be made persistent until {@link commitChanges()} is called and can be reverted by calling
+     * {@link rollBack()}.
+     */
+    bool startEditing();
+
+
   protected slots:
     void invalidateSymbolCountedFlag();
 
@@ -1694,6 +1695,9 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
 
     /** Is emitted, when layer is checked for modifications. Use for last-minute additions */
     void beforeModifiedCheck() const;
+
+    /** Is emitted, before editing on this layer is started */
+    void beforeEditingStarted();
 
     /** Is emitted, when editing on this layer has started*/
     void editingStarted();

--- a/src/core/qgsvectorlayereditpassthrough.h
+++ b/src/core/qgsvectorlayereditpassthrough.h
@@ -24,7 +24,7 @@ class CORE_EXPORT QgsVectorLayerEditPassthrough : public QgsVectorLayerEditBuffe
     Q_OBJECT
   public:
     QgsVectorLayerEditPassthrough( QgsVectorLayer* layer ) { L = layer; }
-    bool isModified() const override { return false; }
+    bool isModified() const override { return true; }
     bool addFeature( QgsFeature& f ) override;
     bool addFeatures( QgsFeatureList& features ) override;
     bool deleteFeature( QgsFeatureId fid ) override;

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -45,7 +45,16 @@
        <property name="spacing">
         <number>0</number>
        </property>
-       <property name="margin">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
         <number>0</number>
        </property>
        <item>
@@ -284,17 +293,35 @@
        <enum>QFrame::Raised</enum>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout">
-       <property name="margin">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
         <number>0</number>
        </property>
        <item>
         <widget class="QStackedWidget" name="mOptionsStackedWidget">
          <property name="currentIndex">
-          <number>8</number>
+          <number>2</number>
          </property>
          <widget class="QWidget" name="mOptionsPageGeneral">
           <layout class="QVBoxLayout" name="verticalLayout_3">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -310,8 +337,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>553</width>
-                <height>660</height>
+                <width>581</width>
+                <height>718</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_28">
@@ -932,7 +959,16 @@
          </widget>
          <widget class="QWidget" name="mOptionsPageSystem">
           <layout class="QVBoxLayout" name="verticalLayout_7">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -948,8 +984,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>569</width>
-                <height>1061</height>
+                <width>658</width>
+                <height>1075</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_22">
@@ -1360,7 +1396,16 @@
          </widget>
          <widget class="QWidget" name="mOptionsPageDataSources">
           <layout class="QVBoxLayout" name="verticalLayout_26">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -1376,8 +1421,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>514</width>
-                <height>656</height>
+                <width>952</width>
+                <height>727</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_27">
@@ -1650,6 +1695,13 @@
                     </property>
                    </widget>
                   </item>
+                  <item>
+                   <widget class="QCheckBox" name="cbxAutoTransaction">
+                    <property name="text">
+                     <string>Create transaction groups automatically whenever possible (Experimental)</string>
+                    </property>
+                   </widget>
+                  </item>
                  </layout>
                 </widget>
                </item>
@@ -1723,7 +1775,16 @@
          </widget>
          <widget class="QWidget" name="mOptionsPageRendering">
           <layout class="QVBoxLayout" name="verticalLayout_12">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -1739,8 +1800,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>725</width>
-                <height>790</height>
+                <width>736</width>
+                <height>846</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_29">
@@ -1848,7 +1909,7 @@
                   <item>
                    <widget class="QgsCollapsibleGroupBox" name="mSimplifyDrawingGroupBox">
                     <property name="title">
-                     <string>Enable feature simplification by default for newly added layers</string>
+                     <string>Enable feature si&amp;mplification by default for newly added layers</string>
                     </property>
                     <property name="flat">
                      <bool>true</bool>
@@ -1958,7 +2019,16 @@
                   <string>Rendering quality</string>
                  </property>
                  <layout class="QVBoxLayout" name="_5">
-                  <property name="margin">
+                  <property name="leftMargin">
+                   <number>11</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>11</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>11</number>
+                  </property>
+                  <property name="bottomMargin">
                    <number>11</number>
                   </property>
                   <item>
@@ -1980,7 +2050,16 @@
                   <item>
                    <widget class="QWidget" name="widget" native="true">
                     <layout class="QHBoxLayout" name="horizontalLayout_19">
-                     <property name="margin">
+                     <property name="leftMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="topMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="rightMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="bottomMargin">
                       <number>0</number>
                      </property>
                      <item>
@@ -2064,7 +2143,16 @@
                      <item>
                       <widget class="QWidget" name="widget_3" native="true">
                        <layout class="QHBoxLayout" name="horizontalLayout_22">
-                        <property name="margin">
+                        <property name="leftMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="topMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="rightMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="bottomMargin">
                          <number>0</number>
                         </property>
                         <item>
@@ -2096,7 +2184,16 @@
                      <item>
                       <widget class="QWidget" name="widget_4" native="true">
                        <layout class="QHBoxLayout" name="horizontalLayout_23">
-                        <property name="margin">
+                        <property name="leftMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="topMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="rightMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="bottomMargin">
                          <number>0</number>
                         </property>
                         <item>
@@ -2128,7 +2225,16 @@
                      <item>
                       <widget class="QWidget" name="widget_5" native="true">
                        <layout class="QHBoxLayout" name="horizontalLayout_24">
-                        <property name="margin">
+                        <property name="leftMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="topMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="rightMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="bottomMargin">
                          <number>0</number>
                         </property>
                         <item>
@@ -2167,7 +2273,16 @@
                      <item>
                       <widget class="QWidget" name="widget_6" native="true">
                        <layout class="QHBoxLayout" name="horizontalLayout_25">
-                        <property name="margin">
+                        <property name="leftMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="topMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="rightMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="bottomMargin">
                          <number>0</number>
                         </property>
                         <item>
@@ -2199,7 +2314,16 @@
                      <item>
                       <widget class="QWidget" name="widget_7" native="true">
                        <layout class="QHBoxLayout" name="horizontalLayout_18">
-                        <property name="margin">
+                        <property name="leftMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="topMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="rightMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="bottomMargin">
                          <number>0</number>
                         </property>
                         <item>
@@ -2256,7 +2380,16 @@
                      <item>
                       <widget class="QWidget" name="widget_2" native="true">
                        <layout class="QHBoxLayout" name="horizontalLayout_20">
-                        <property name="margin">
+                        <property name="leftMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="topMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="rightMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="bottomMargin">
                          <number>0</number>
                         </property>
                         <item>
@@ -2362,7 +2495,16 @@
          </widget>
          <widget class="QWidget" name="mOptionsPageColors">
           <layout class="QVBoxLayout" name="verticalLayout_38">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -2378,8 +2520,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>156</width>
-                <height>259</height>
+                <width>168</width>
+                <height>276</height>
                </rect>
               </property>
               <layout class="QHBoxLayout" name="horizontalLayout_46">
@@ -2458,7 +2600,16 @@
          </widget>
          <widget class="QWidget" name="mOptionsPageMapCanvas">
           <layout class="QVBoxLayout" name="verticalLayout_16">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -2474,8 +2625,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>509</width>
-                <height>328</height>
+                <width>521</width>
+                <height>354</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_25">
@@ -2787,7 +2938,16 @@
          </widget>
          <widget class="QWidget" name="mOptionsPageMapTools">
           <layout class="QVBoxLayout" name="verticalLayout_14">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -2803,8 +2963,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>709</width>
-                <height>656</height>
+                <width>678</width>
+                <height>670</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_30">
@@ -2972,7 +3132,7 @@
                   <item row="5" column="1">
                    <widget class="QRadioButton" name="radMeters">
                     <property name="text">
-                     <string>Meters</string>
+                     <string>&amp;Meters</string>
                     </property>
                    </widget>
                   </item>
@@ -3273,7 +3433,16 @@
          </widget>
          <widget class="QWidget" name="mOptionsPageComposer">
           <layout class="QVBoxLayout" name="verticalLayout_36">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -3289,8 +3458,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>629</width>
-                <height>312</height>
+                <width>537</width>
+                <height>321</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_39">
@@ -3469,7 +3638,16 @@
          </widget>
          <widget class="QWidget" name="mOptionsPageDigitizing">
           <layout class="QVBoxLayout" name="verticalLayout_17">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -3484,9 +3662,9 @@
               <property name="geometry">
                <rect>
                 <x>0</x>
-                <y>-66</y>
-                <width>954</width>
-                <height>643</height>
+                <y>0</y>
+                <width>566</width>
+                <height>707</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_31">
@@ -4005,7 +4183,16 @@
          </widget>
          <widget class="QWidget" name="mOptionsPageGDAL">
           <layout class="QVBoxLayout" name="verticalLayout_4">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -4021,8 +4208,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>436</width>
-                <height>368</height>
+                <width>462</width>
+                <height>382</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -4135,7 +4322,16 @@
          </widget>
          <widget class="QWidget" name="mOptionsPageCRS">
           <layout class="QVBoxLayout" name="verticalLayout_18">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -4151,8 +4347,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>527</width>
-                <height>633</height>
+                <width>560</width>
+                <height>681</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_15">
@@ -4194,7 +4390,7 @@
                   <item row="1" column="0">
                    <widget class="QRadioButton" name="radPromptForProjection">
                     <property name="text">
-                     <string>Prompt for &amp;CRS</string>
+                     <string>Pro&amp;mpt for CRS</string>
                     </property>
                    </widget>
                   </item>
@@ -4257,7 +4453,7 @@
                      <string>Automatically enable 'on the fly' reprojection if CRS of a new added layer differ from CRS of layer(s) already present. CRS of present layer(s) will be used.</string>
                     </property>
                     <property name="text">
-                     <string>Automatically enable 'on the fly' reprojection if layers have different CRS</string>
+                     <string>Automatically enable 'on the fly' reprojection if layers ha&amp;ve different CRS</string>
                     </property>
                    </widget>
                   </item>
@@ -4372,7 +4568,16 @@
          </widget>
          <widget class="QWidget" name="mOptionsPageLocale">
           <layout class="QVBoxLayout" name="verticalLayout_19">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -4388,15 +4593,15 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>289</width>
-                <height>222</height>
+                <width>303</width>
+                <height>236</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_32">
                <item>
                 <widget class="QGroupBox" name="grpLocale">
                  <property name="title">
-                  <string>Override system locale</string>
+                  <string>O&amp;verride system locale</string>
                  </property>
                  <property name="checkable">
                   <bool>true</bool>
@@ -4472,7 +4677,16 @@
          </widget>
          <widget class="QWidget" name="mOptionsPageNetwork">
           <layout class="QVBoxLayout" name="verticalLayout_20">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -4488,8 +4702,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>546</width>
-                <height>726</height>
+                <width>552</width>
+                <height>791</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_33">
@@ -4648,7 +4862,7 @@
                <item>
                 <widget class="QgsCollapsibleGroupBox" name="grpProxy">
                  <property name="title">
-                  <string>Use proxy for web access</string>
+                  <string>Use pro&amp;xy for web access</string>
                  </property>
                  <property name="flat">
                   <bool>false</bool>


### PR DESCRIPTION
Introduces transaction groups. Several layers can be part of a transaction group. Edit state is synchronized between them and saving is done on the whole group instead of individual layers.

There is a new option auto-transaction in the settings which will automatically enable this mode on supported layers (postgres currently).
