### PR TITLE
append extension to output filename (fix #14077)

### DIFF
--- a/src/plugins/geometry_checker/ui/qgsgeometrycheckersetuptab.cpp
+++ b/src/plugins/geometry_checker/ui/qgsgeometrycheckersetuptab.cpp
@@ -161,6 +161,17 @@ void QgsGeometryCheckerSetupTab::selectOutputFile()
         filename += QString( ".%1" ).arg( mdata.ext );
       }
     }
+    else
+    {
+      int start, stop;
+      start = selectedFilter.indexOf( "." );
+      stop = selectedFilter.indexOf( " ", start );
+      QString ext = selectedFilter.mid( start, stop - start );
+      if ( !filename.endsWith( ext ) )
+      {
+        filename += ext;
+      }
+    }
     ui.lineEditOutput->setText( filename );
   }
 }


### PR DESCRIPTION
Seems some OGR drivers does not report extension via metadata, in
such case we extract it from selected filter string
