### PR TITLE
Move the options for the QGISSTYLE tool to a separate file

### DIFF
--- a/scripts/astyle.options
+++ b/scripts/astyle.options
@@ -1,0 +1,16 @@
+--preserve-date
+--indent-preprocessor
+--brackets=break
+--convert-tabs
+--indent=spaces=2
+--indent-classes
+--indent-labels
+--indent-namespaces
+--indent-switches
+--one-line=keep-blocks
+--max-instatement-indent=40
+--min-conditional-indent=-1
+--suffix=none
+--pad=oper
+--pad=paren-in
+--unpad=paren

--- a/scripts/astyle.sh
+++ b/scripts/astyle.sh
@@ -53,22 +53,8 @@ set -e
 astyleit()
 {
 	$ASTYLE \
-		--preserve-date \
-		--indent-preprocessor \
-		--brackets=break \
-		--convert-tabs \
-		--indent=spaces=2 \
-		--indent-classes \
-		--indent-labels \
-		--indent-namespaces \
-		--indent-switches \
-		--one-line=keep-blocks \
-		--max-instatement-indent=40 \
-		--min-conditional-indent=-1 \
-		--suffix=none \
-		--pad=oper \
-		--pad=paren-in \
-		--unpad=paren "$1"
+		"--options=$(dirname $0)/astyle.options" \
+		"$1"
 
 	scripts/unify_includes.pl "$1"
 }


### PR DESCRIPTION
This PR allows to call the _QGISSTYLE_ tool with the correct options from outside `astyle.sh`, e.g. from the favorite IDE, even when not using Linux. That can help reduce indentation errors.
