### PR TITLE
Bugfix for #13527 - missing commas in GeoJSON response from server (WFS GetFeature)

### DIFF
--- a/src/server/qgswfsserver.cpp
+++ b/src/server/qgswfsserver.cpp
@@ -414,6 +414,7 @@ int QgsWFSServer::getFeature( QgsRequestHandler& request, const QString& format 
   long startIndex = 0;
   long featureCounter = 0;
   int layerPrec = 8;
+  long featCounter = 0;
 
   QgsExpressionContext expressionContext;
   expressionContext << QgsExpressionContextUtils::globalScope()
@@ -424,7 +425,6 @@ int QgsWFSServer::getFeature( QgsRequestHandler& request, const QString& format 
   if ( doc.setContent( mParameters.value( "REQUEST_BODY" ), true, &errorMsg ) )
   {
     QDomElement docElem = doc.documentElement();
-
     if ( docElem.hasAttribute( "maxFeatures" ) )
       maxFeatures = docElem.attribute( "maxFeatures" ).toLong();
     if ( docElem.hasAttribute( "startIndex" ) )
@@ -564,7 +564,6 @@ int QgsWFSServer::getFeature( QgsRequestHandler& request, const QString& format 
 
         QgsFeatureIterator fit = layer->getFeatures( fReq );
 
-        long featCounter = 0;
         QDomNodeList filterNodes = queryElem.elementsByTagName( "Filter" );
         if ( !filterNodes.isEmpty() )
         {
@@ -932,7 +931,6 @@ int QgsWFSServer::getFeature( QgsRequestHandler& request, const QString& format 
                         searchRect.yMaximum() + 1. / pow( 10., layerPrec ) );
       layerCrs = layer->crs();
 
-      long featCounter = 0;
       if ( featureIdOk )
       {
         Q_FOREACH ( const QString &fidStr, featureIdList )


### PR DESCRIPTION
This is a simple fix for bug #13527 - missing commas in GeoJSON between features from different layers.
Maybe somebody with a better knowledge of qgis WFS server sources could check the code in QgsWFSServer::getFeature method and fix this bug better. There is two very similar variables - 'featureCounter' and 'featCounter'. In my fix, I have changed the position of 'featCounter' initialization and removed it's reseting to 0 for each layer. Now it is very similar to 'featureCounter' (slight difference is in their incrementation), so maybe just one variable is really needed.
