### PR TITLE
[Postgres] Remove the temporary SSL files only when they were created

### DIFF
--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -208,19 +208,19 @@ QgsPostgresConn::QgsPostgresConn( const QString& conninfo, bool readOnly, bool s
 
   mConn = PQconnectdb( expandedConnectionInfo.toLocal8Bit() );  // use what is set based on locale; after connecting, use Utf8
 
-  // remove temporary cert/key/CA
+  // remove temporary cert/key/CA if they exist
   QgsDataSourceURI expandedUri( expandedConnectionInfo );
-  QString sslCertFile = expandedUri.param( "sslcert" );
-  sslCertFile.remove( "'" );
-  QFile::remove( sslCertFile );
-
-  QString sslKeyFile = expandedUri.param( "sslkey" );
-  sslKeyFile.remove( "'" );
-  QFile::remove( sslKeyFile );
-
-  QString sslCAFile = expandedUri.param( "sslrootcert" );
-  sslCAFile.remove( "'" );
-  QFile::remove( sslCAFile );
+  QStringList parameters;
+  parameters << "sslcert" << "sslkey" << "sslrootcert";
+  Q_FOREACH ( const QString& param, parameters )
+  {
+    if ( expandedUri.hasParam( param ) )
+    {
+      QString fileName = expandedUri.param( param );
+      fileName.remove( "'" );
+      QFile::remove( fileName );
+    }
+  }
 
   // check the connection status
   if ( PQstatus() != CONNECTION_OK )


### PR DESCRIPTION
When not using a certificate based authentication method, the following warnings were thrown when connecting to a PostgreSQL database:

```
Warning: QFile::remove: Empty or null file name
Warning: QFile::remove: Empty or null file name
Warning: QFile::remove: Empty or null file name
```

This PR fixes it by only removing the files when they were created and also deduplicates the code to do it.

(follow-up to #2674)
