### PR TITLE
Do not use shared connections from column type thread

### DIFF
--- a/src/providers/postgres/qgscolumntypethread.cpp
+++ b/src/providers/postgres/qgscolumntypethread.cpp
@@ -44,7 +44,8 @@ void QgsGeomColumnTypeThread::stop()
 void QgsGeomColumnTypeThread::run()
 {
   QgsDataSourceURI uri = QgsPostgresConn::connUri( mName );
-  mConn = QgsPostgresConn::connectDb( uri.connectionInfo( false ), true );
+  // We do not want to share connections, not being the main thread
+  mConn = QgsPostgresConn::connectDb( uri.connectionInfo( false ), true, false );
   if ( !mConn )
   {
     QgsDebugMsg( "Connection failed - " + uri.connectionInfo( false ) );


### PR DESCRIPTION
Connections cannot be shared between multiple threads.
Fixes http://hub.qgis.org/issues/13141
