### PR TITLE
Deprecate QgsPostgresConn::connectDb

### DIFF
--- a/src/providers/postgres/qgspostgresconn.h
+++ b/src/providers/postgres/qgspostgresconn.h
@@ -187,11 +187,13 @@ class QgsPostgresConn : public QObject
 
   public:
     /*
-     * \param shared allow using a shared connection. Should never be
+     * @param shared allow using a shared connection. Should never be
      *        called from a thread other than the main one.
      *        An assertion guards against such programmatic error.
+     *
+     *  @deprecated Use QgsPostgresConnPool
      */
-    static QgsPostgresConn *connectDb( const QString &connInfo, bool readOnly, bool shared = true, bool transaction = false );
+    Q_DECL_DEPRECATED static QgsPostgresConn *connectDb( const QString &connInfo, bool readOnly, bool shared = true, bool transaction = false );
 
     void ref() { ++mRef; }
     void unref();

--- a/src/providers/postgres/qgspostgresconnpool.h
+++ b/src/providers/postgres/qgspostgresconnpool.h
@@ -27,7 +27,9 @@ inline QString qgsConnectionPool_ConnectionToName( QgsPostgresConn *c )
 
 inline void qgsConnectionPool_ConnectionCreate( const QString &connInfo, QgsPostgresConn *&c )
 {
+  Q_NOWARN_DEPRECATED_PUSH
   c = QgsPostgresConn::connectDb( connInfo, true, false );
+  Q_NOWARN_DEPRECATED_POP
 }
 
 inline void qgsConnectionPool_ConnectionDestroy( QgsPostgresConn *c )

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -147,7 +147,9 @@ QgsPostgresProvider::QgsPostgresProvider( QString const &uri )
     return;
   }
 
+  Q_NOWARN_DEPRECATED_PUSH
   mConnectionRO = QgsPostgresConn::connectDb( mUri.connectionInfo( false ), true );
+  Q_NOWARN_DEPRECATED_POP
   if ( !mConnectionRO )
   {
     return;
@@ -300,7 +302,9 @@ QgsPostgresConn *QgsPostgresProvider::connectionRW()
   }
   else if ( !mConnectionRW )
   {
+    Q_NOWARN_DEPRECATED_PUSH
     mConnectionRW = QgsPostgresConn::connectDb( mUri.connectionInfo( false ), false );
+    Q_NOWARN_DEPRECATED_POP
   }
   return mConnectionRW;
 }
@@ -3675,7 +3679,9 @@ QgsVectorLayerExporter::ExportError QgsPostgresProvider::createEmptyLayer( const
   QgsDebugMsg( QString( "Table name is: %1" ).arg( tableName ) );
 
   // create the table
+  Q_NOWARN_DEPRECATED_PUSH
   QgsPostgresConn *conn = QgsPostgresConn::connectDb( dsUri.connectionInfo( false ), false );
+  Q_NOWARN_DEPRECATED_POP
   if ( !conn )
   {
     if ( errorMessage )
@@ -4317,7 +4323,9 @@ QGISEXTERN bool deleteLayer( const QString &uri, QString &errCause )
   }
   schemaTableName += QgsPostgresConn::quotedIdentifier( tableName );
 
+  Q_NOWARN_DEPRECATED_PUSH
   QgsPostgresConn *conn = QgsPostgresConn::connectDb( dsUri.connectionInfo( false ), false );
+  Q_NOWARN_DEPRECATED_POP
   if ( !conn )
   {
     errCause = QObject::tr( "Connection to database failed" );
@@ -4383,7 +4391,9 @@ QGISEXTERN bool deleteSchema( const QString &schema, const QgsDataSourceUri &uri
 
   QString schemaName = QgsPostgresConn::quotedIdentifier( schema );
 
+  Q_NOWARN_DEPRECATED_PUSH
   QgsPostgresConn *conn = QgsPostgresConn::connectDb( uri.connectionInfo( false ), false );
+  Q_NOWARN_DEPRECATED_POP
   if ( !conn )
   {
     errCause = QObject::tr( "Connection to database failed" );
@@ -4414,7 +4424,9 @@ QGISEXTERN bool saveStyle( const QString &uri, const QString &qmlStyle, const QS
 {
   QgsDataSourceUri dsUri( uri );
 
+  Q_NOWARN_DEPRECATED_PUSH
   QgsPostgresConn *conn = QgsPostgresConn::connectDb( dsUri.connectionInfo( false ), false );
+  Q_NOWARN_DEPRECATED_POP
   if ( !conn )
   {
     errCause = QObject::tr( "Connection to database failed" );
@@ -4559,7 +4571,9 @@ QGISEXTERN QString loadStyle( const QString &uri, QString &errCause )
 {
   QgsDataSourceUri dsUri( uri );
 
+  Q_NOWARN_DEPRECATED_PUSH
   QgsPostgresConn *conn = QgsPostgresConn::connectDb( dsUri.connectionInfo( false ), false );
+  Q_NOWARN_DEPRECATED_POP
   if ( !conn )
   {
     errCause = QObject::tr( "Connection to database failed" );
@@ -4597,7 +4611,9 @@ QGISEXTERN int listStyles( const QString &uri, QStringList &ids, QStringList &na
 {
   QgsDataSourceUri dsUri( uri );
 
+  Q_NOWARN_DEPRECATED_PUSH
   QgsPostgresConn *conn = QgsPostgresConn::connectDb( dsUri.connectionInfo( false ), false );
+  Q_NOWARN_DEPRECATED_POP
   if ( !conn )
   {
     errCause = QObject::tr( "Connection to database failed using username: %1" ).arg( dsUri.username() );
@@ -4667,7 +4683,9 @@ QGISEXTERN bool deleteStyleById( const QString &uri, QString styleId, QString &e
   QgsDataSourceUri dsUri( uri );
   bool deleted;
 
+  Q_NOWARN_DEPRECATED_PUSH
   QgsPostgresConn *conn = QgsPostgresConn::connectDb( dsUri.connectionInfo( false ), false );
+  Q_NOWARN_DEPRECATED_POP
   if ( !conn )
   {
     errCause = QObject::tr( "Connection to database failed using username: %1" ).arg( dsUri.username() );


### PR DESCRIPTION
Rebased version of #2689 and added security measure to abort on misuse of shared connection API.
