### PR TITLE
[Bugfix] Make the flag 'All' actually contain all types of layers

### DIFF
--- a/src/gui/qgsmaplayerproxymodel.h
+++ b/src/gui/qgsmaplayerproxymodel.h
@@ -40,7 +40,7 @@ class GUI_EXPORT QgsMapLayerProxyModel : public QSortFilterProxyModel
       HasGeometry = PointLayer | LineLayer | PolygonLayer,
       VectorLayer = NoGeometry | HasGeometry,
       PluginLayer = 32,
-      All = RasterLayer | PolygonLayer | PluginLayer
+      All = RasterLayer | VectorLayer | PluginLayer
     };
     Q_DECLARE_FLAGS( Filters, Filter )
 


### PR DESCRIPTION
When using the filter flag `QgsMapLayerProxyModel::All`only raster-, polygon- and plugin-layers were selected. Other types of vector-layers (point-, line- or geometryless layers) were ignored.

This PR fixes that.
