### PR TITLE
[vector export] better default for kml altitudemode

### DIFF
--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -1077,10 +1077,10 @@ QMap<QString, QgsVectorFileWriter::MetaData> QgsVectorFileWriter::initMetaData()
                            QObject::tr( "Allows you to specify the AltitudeMode to use for KML geometries. "
                                         "This will only affect 3D geometries and must be one of the valid KML options." ),
                            QStringList()
-                           << "relativeToGround"
                            << "clampToGround"
+                           << "relativeToGround"
                            << "absolute",
-                           "relativeToGround" // Default value
+                           "clampToGround" // Default value
                          ) );
 
   driverMetadata.insert( "KML",


### PR DESCRIPTION
Google Earth's default altitude mode for new features is "clamp to ground", which must users expect. However, when QGIS exports a vector layer to KML, it sets the altitude mode to "relative to ground" (and no altitude value, which sets it to zero). It results in polygons and lines drawn below elevated ground and can confuse users.

An exported polygon set to relative to ground (QGIS default):
![relative](https://cloud.githubusercontent.com/assets/1728657/12409941/2b168bc2-bea2-11e5-8d13-d73926e61e30.jpg)

An exported polygon set to clamp to ground (Google Earth default, and proposed new default for QGIS):
![clamped](https://cloud.githubusercontent.com/assets/1728657/12409944/320d91aa-bea2-11e5-8447-04358a96a2b6.jpg)

This PR changes the default to clamp to ground, to be more user-friendly and behave like Google Earth.

@nyalldawson , @jef-n , I consider this 2-line change a behavior fix, can it be merged amid the freeze? It's very, very safe :smile: 
