### PR TITLE
Fix vector join dialog

### DIFF
--- a/src/app/qgsjoindialog.cpp
+++ b/src/app/qgsjoindialog.cpp
@@ -40,6 +40,7 @@ QgsJoinDialog::QgsJoinDialog( QgsVectorLayer* layer, QList<QgsMapLayer*> already
 
   mTargetFieldComboBox->setLayer( mLayer );
 
+  mJoinLayerComboBox->setFilters( QgsMapLayerProxyModel::VectorLayer );
   mJoinLayerComboBox->setExceptedLayerList( alreadyJoinedLayers );
   connect( mJoinLayerComboBox, SIGNAL( layerChanged( QgsMapLayer* ) ), mJoinFieldComboBox, SLOT( setLayer( QgsMapLayer* ) ) );
   connect( mJoinLayerComboBox, SIGNAL( layerChanged( QgsMapLayer* ) ), this, SLOT( joinedLayerChanged( QgsMapLayer* ) ) );

--- a/src/gui/qgsmaplayerproxymodel.cpp
+++ b/src/gui/qgsmaplayerproxymodel.cpp
@@ -46,7 +46,7 @@ void QgsMapLayerProxyModel::setExceptedLayerList( const QList<QgsMapLayer*>& exc
 
 bool QgsMapLayerProxyModel::filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const
 {
-  if ( mFilters.testFlag( All ) )
+  if ( mFilters.testFlag( All ) && mExceptList.isEmpty() )
     return true;
 
   QModelIndex index = sourceModel()->index( source_row, 0, source_parent );


### PR DESCRIPTION
The vector join dialog is supposed to only offer for joining
- vector layers
- excluding the current layer (no self-joins)
- excluding already joined layers (no double-joins)

But it offered **all layers** instead. This was due to errors in both, `QgsJoinDialog` and `QgsMapLayerProxyModel`. They are fixed by this PR.

![qgisvectorjoinlayers](https://cloud.githubusercontent.com/assets/15147421/12432839/ef66d7ec-befd-11e5-8b34-7103e56f06b2.png)
