### PR TITLE
[DBManager]  replace pyspatialite with pysqlite

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -48,7 +48,6 @@ matrix:
             - python-numpy
             - python-pip
             - python-psycopg2
-            - python-pysqlite2
             - python-qscintilla2
             - python-qt4-dev
             - python-qt4-sql

--- a/.travis.yml
+++ b/.travis.yml
@@ -48,6 +48,7 @@ matrix:
             - python-numpy
             - python-pip
             - python-psycopg2
+            - python-pysqlite2
             - python-qscintilla2
             - python-qt4-dev
             - python-qt4-sql

--- a/ci/travis/linux/qt4/before_install.sh
+++ b/ci/travis/linux/qt4/before_install.sh
@@ -6,4 +6,4 @@ curl -L https://github.com/opengisch/osgeo4travis/archive/qt4bin.tar.gz | tar -x
 curl -L https://cmake.org/files/v3.5/cmake-3.5.0-Linux-x86_64.tar.gz | tar --strip-components=1 -zxC /home/travis/osgeo4travis
 
 popd
-pip install --user autopep8 nose2 pyyaml mock future
+pip install --user autopep8 nose2 pyyaml mock future pysqlite

--- a/ci/travis/linux/qt5/before_install.sh
+++ b/ci/travis/linux/qt5/before_install.sh
@@ -13,4 +13,4 @@ curl -L https://github.com/opengisch/osgeo4travis/archive/qt5bin.tar.gz | tar -x
 curl -L https://cmake.org/files/v3.5/cmake-3.5.0-Linux-x86_64.tar.gz | tar --strip-components=1 -zxC /home/travis/osgeo4travis
 popd
 
-pip install psycopg2 numpy nose2 pyyaml mock future
+pip install psycopg2 numpy nose2 pyyaml mock future pysqlite

--- a/ci/travis/linux/qt5/blacklist.txt
+++ b/ci/travis/linux/qt5/blacklist.txt
@@ -12,9 +12,7 @@ PyQgsServer
 PyQgsServerAccessControl
 PyQgsShapefileProvider
 PyQgsSipCoverage
-PyQgsSpatialiteProvider
 PyQgsVirtualLayerDefinition
-PyQgsVirtualLayerProvider
 qgis_composermapgridtest
 qgis_composertabletest
 qgis_composertablev2test

--- a/ci/travis/osx/before_install.sh
+++ b/ci/travis/osx/before_install.sh
@@ -18,4 +18,4 @@ mkdir -p ${HOME}/Library/Python/2.7/lib/python/site-packages
 echo 'import site; site.addsitedir("/usr/local/lib/python2.7/site-packages")' >> ${HOME}/Library/Python/2.7/lib/python/site-packages/homebrew.pth
 
 # Needed for Processing
-pip install psycopg2 numpy nose2 pyyaml mock future
+pip install psycopg2 numpy nose2 pyyaml mock future pysqlite

--- a/python/plugins/db_manager/README
+++ b/python/plugins/db_manager/README
@@ -5,7 +5,7 @@ It allows showing the DBs contents and run query on them.
 
 In this moment DB Manager supports the following DBMS backends:
 - PostgreSQL/PostGIS through the psycopg2 pymodule
-- SQLite/SpatiaLite using the pyspatialite pymodule
+- SQLite/SpatiaLite using the pysqlite pymodule
 - Oracle Spatial using PyQt QtSql module
 
 For more info about the project, see at the wiki page:

--- a/python/plugins/db_manager/db_plugins/spatialite/connector.py
+++ b/python/plugins/db_manager/db_plugins/spatialite/connector.py
@@ -19,6 +19,7 @@ email                : brush.tyler@gmail.com
  *                                                                         *
  ***************************************************************************/
 """
+import os
 
 from qgis.PyQt.QtCore import QFile
 from qgis.PyQt.QtWidgets import QApplication
@@ -26,7 +27,7 @@ from qgis.PyQt.QtWidgets import QApplication
 from ..connector import DBConnector
 from ..plugin import ConnectionError, DbError, Table
 
-from pyspatialite import dbapi2 as sqlite
+from pysqlite2 import dbapi2 as sqlite
 
 
 def classFactory():
@@ -44,7 +45,14 @@ class SpatiaLiteDBConnector(DBConnector):
 
         try:
             self.connection = sqlite.connect(self._connectionInfo())
-
+            self.connection.enable_load_extension(True)
+            c = self._get_cursor()
+            if os.name == 'nt':
+                sql = "SELECT load_extension('spatialite4.dll')"
+            else:
+                sql = "SELECT load_extension('libspatialite')"
+            self._execute(c, sql)
+            c.close()
         except self.connection_error_types() as e:
             raise ConnectionError(e)
 

--- a/tests/src/python/test_qgsissue7244.py
+++ b/tests/src/python/test_qgsissue7244.py
@@ -20,7 +20,11 @@ from qgis.core import QgsPoint, QgsVectorLayer
 
 from qgis.testing import start_app, unittest
 
-from pyspatialite import dbapi2 as sqlite3
+try:
+    from pysqlite2 import dbapi2 as sqlite
+except ImportError:
+    print("You should install pysqlite to run the tests")
+    raise ImportError
 
 # Convenience instances in case you may need them
 start_app()
@@ -38,8 +42,17 @@ class TestQgsSpatialiteProvider(unittest.TestCase):
         # create test db
         if os.path.exists("test.sqlite"):
             os.remove("test.sqlite")
-        con = sqlite3.connect("test.sqlite", isolation_level=None)
+        con = sqlite.connect("test.sqlite", isolation_level=None)
         cur = con.cursor()
+
+        # load spatialite extension
+        if os.name == 'nt':
+            sql = "SELECT load_extension('spatialite4.dll')"
+        else:
+            sql = "SELECT load_extension('libspatialite')"
+        cur.execute(sql)
+        con.enable_load_extension(False)
+
         cur.execute("BEGIN")
         sql = "SELECT InitSpatialMetadata()"
         cur.execute(sql)


### PR DESCRIPTION
Pyspatialite does not support SpatiaLite 4.x. Pysqlite module is much more widely used and now it is possible to load spatial extensions via SQLite's load_extension() mechanism without issues.

See also old discussion in the SpatiaLite mailing list https://groups.google.com/forum/#!topic/spatialite-users/iTOGhiBi83E
