### PR TITLE
Fix creation of features on layers with Z

### DIFF
--- a/python/core/geometry/qgsgeometry.sip
+++ b/python/core/geometry/qgsgeometry.sip
@@ -273,39 +273,58 @@ class QgsGeometry
      */
     double closestSegmentWithContext( const QgsPoint& point, QgsPoint& minDistPoint /Out/, int& afterVertex /Out/ ) const;
 
-    /** Adds a new ring to this geometry. This makes only sense for polygon and multipolygons.
-     @return 0 in case of success (ring added), 1 problem with geometry type, 2 ring not closed,
-     3 ring is not valid geometry, 4 ring not disjoint with existing rings, 5 no polygon found which contained the ring*/
-    int addRing( const QList<QgsPoint>& ring );
+    /** Result codes for addRing().
+     * @note should be replaced in QGIS 3.0 by common codes for all editing operations
+     * @note this is extended by QgsVectorLayer::AddRingResult
+     */
+    enum AddRingResult
+    {
+      AddRingSuccess = 0,       //< Success
+      AddRingWrongFeatureType,  //< Problem with feature type
+      AddRingNotClosed,         //< Ring not closed
+      AddRingNotValid,          //< Ring not valid
+      AddRingCrossing,          //< Ring crosses existing rings
+      AddRingNotInsertable      //< No feature found where ring can be inserted
+    };
 
-    /** Adds a new ring to this geometry. This makes only sense for polygon and multipolygons.
-     @return 0 in case of success (ring added), 1 problem with geometry type, 2 ring not closed,
-     3 ring is not valid geometry, 4 ring not disjoint with existing rings, 5 no polygon found which contained the ring*/
-    int addRing( QgsCurveV2* ring );
+    /** Adds a new ring to this geometry. This makes only sense for polygon and multipolygons. */
+    AddRingResult addRing( const QList<QgsPoint>& ring );
+
+    /** Adds a new ring to this geometry. This makes only sense for polygon and multipolygons. */
+    AddRingResult addRing( QgsCurveV2* ring );
+
+    /** Result codes for addPart().
+     *  @note should be replaced in QGIS 3.0 by common codes for all editing operations
+     */
+    enum AddPartResult
+    {
+      AddPartSuccess,           //< Success
+      AddPartWrongFeatureType,  //< Selected feature is not multipart
+      AddPartNotValid,          //< Ring is not valid geometry
+      AddPartNotDisjoint,       //< New polygon ring not disjoint with exisiting rings
+      AddPartNoFeature,         //< No feature was selected
+      AddPartSeveralFeatures,   //< Several features are selected
+      AddPartNoGeometry         //< Selected geometry not found
+    };
 
     /** Adds a new part to a the geometry.
      * @param points points describing part to add
      * @param geomType default geometry type to create if no existing geometry
-     * @returns 0 in case of success, 1 if not a multipolygon, 2 if ring is not a valid geometry, 3 if new polygon ring
-     * not disjoint with existing polygons of the feature
     */
-    int addPart( const QList<QgsPoint> &points, QGis::GeometryType geomType = QGis::UnknownGeometry );
+    AddPartResult addPart( const QList<QgsPoint> &points, QGis::GeometryType geomType = QGis::UnknownGeometry );
 
     /** Adds a new part to a the geometry.
      * @param points points describing part to add
      * @param geomType default geometry type to create if no existing geometry
-     * @returns 0 in case of success, 1 if not a multipolygon, 2 if ring is not a valid geometry, 3 if new polygon ring
-     * not disjoint with existing polygons of the feature
     */
-    int addPart( const QList<QgsPointV2> &points, QGis::GeometryType geomType = QGis::UnknownGeometry );
+    AddPartResult addPart( const QList<QgsPointV2> &points, QGis::GeometryType geomType = QGis::UnknownGeometry );
 
     /** Adds a new part to this geometry.
      * @param part part to add (ownership is transferred)
      * @param geomType default geometry type to create if no existing geometry
-     * @returns 0 in case of success, 1 if not a multipolygon, 2 if ring is not a valid geometry, 3 if new polygon ring
      * not disjoint with existing polygons of the feature
     */
-    int addPart( QgsAbstractGeometryV2* part /Transfer/, QGis::GeometryType geomType = QGis::UnknownGeometry );
+    AddPartResult addPart( QgsAbstractGeometryV2* part /Transfer/, QGis::GeometryType geomType = QGis::UnknownGeometry );
 
     /** Adds a new island polygon to a multipolygon feature
      @return 0 in case of success, 1 if not a multipolygon, 2 if ring is not a valid geometry, 3 if new polygon ring
@@ -315,11 +334,9 @@ class QgsGeometry
     // int addPart( GEOSGeometry *newPart );
 
     /** Adds a new island polygon to a multipolygon feature
-     @return 0 in case of success, 1 if not a multipolygon, 2 if ring is not a valid geometry, 3 if new polygon ring
-     not disjoint with existing polygons of the feature
      @note available in python bindings as addPartGeometry (added in 2.2)
      */
-    int addPart( const QgsGeometry *newPart /Transfer/ ) /PyName=addPartGeometry/;
+    AddPartResult addPart( const QgsGeometry *newPart /Transfer/ ) /PyName=addPartGeometry/;
 
     /** Translate this geometry by dx, dy
      @return 0 in case of success*/

--- a/python/core/qgsvectorlayer.sip
+++ b/python/core/qgsvectorlayer.sip
@@ -821,46 +821,42 @@ class QgsVectorLayer : QgsMapLayer
      */
     bool deleteSelectedFeatures( int *deletedCount = 0 );
 
+    /** Result codes for addRing().
+     * @note should be replaced in QGIS 3.0 by common codes for all editing operations
+     * @note this is extended from QgsGeometry::AddRingResult
+     */
+    enum AddRingResult
+    {
+      AddRingLayerNotEditable = 6 //< Layer is not editable
+    };
+
     /** Adds a ring to polygon/multipolygon features
      * @param ring ring to add
      * @param featureId if specified, feature ID for feature ring was added to will be stored in this parameter
-     @return
-       0 in case of success,
-       1 problem with feature type,
-       2 ring not closed,
-       3 ring not valid,
-       4 ring crosses existing rings,
-       5 no feature found where ring can be inserted
-       6 layer not editable */
-    int addRing( const QList<QgsPoint>& ring, QgsFeatureId* featureId = 0 );
+     */
+    AddRingResult addRing( const QList<QgsPoint>& ring, QgsFeatureId* featureId = 0 );
 
     /** Adds a ring to polygon/multipolygon features (takes ownership)
      * @param ring ring to add
      * @param featureId if specified, feature ID for feature ring was added to will be stored in this parameter
-            @return
-            0 in case of success
-            1 problem with feature type
-            2 ring not closed
-            6 layer not editable
        @note available in python as addCurvedRing
      */
-    int addRing( QgsCurveV2* ring /Transfer/, QgsFeatureId* featureId = 0 ) /PyName=addCurvedRing/;
+    AddRingResult addRing( QgsCurveV2* ring /Transfer/, QgsFeatureId* featureId = 0 ) /PyName=addCurvedRing/;
 
-    /** Adds a new part polygon to a multipart feature
-     @return
-       0 in case of success,
-       1 if selected feature is not multipart,
-       2 if ring is not a valid geometry,
-       3 if new polygon ring not disjoint with existing rings,
-       4 if no feature was selected,
-       5 if several features are selected,
-       6 if selected geometry not found
-       7 layer not editable
+    /** Result codes for addPart().
+     * @note should be replaced in QGIS 3.0 by common codes for all editing operations
+     * @note extends QgsGeometry::AddPartResult
      */
-    int addPart( const QList<QgsPoint>& ring );
+    enum AddPartResult
+    {
+      AddPartLayerNotEditable = 7   //< Layer not editable
+    };
+
+    /** Adds a new part polygon to a multipart feature */
+    AddPartResult addPart( const QList<QgsPoint>& ring );
 
     //! @note available in python as addCurvedPart
-    int addPart( QgsCurveV2* ring /Transfer/ ) /PyName=addCurvedPart/;
+    AddPartResult addPart( QgsCurveV2* ring /Transfer/ ) /PyName=addCurvedPart/;
 
     /** Translates feature by dx, dy
        @param featureId id of the feature to translate

--- a/python/core/qgsvectorlayereditutils.sip
+++ b/python/core/qgsvectorlayereditutils.sip
@@ -39,25 +39,14 @@ class QgsVectorLayerEditUtils
      * @param targetFeatureIds if specified, only these features will be the candidates for adding a ring. Otherwise
      * all intersecting features are tested and the ring is added to the first valid feature.
      * @param modifiedFeatureId if specified, feature ID for feature that ring was added to will be stored in this parameter
-     @return
-       0 in case of success,
-       1 problem with feature type,
-       2 ring not closed,
-       3 ring not valid,
-       4 ring crosses existing rings,
-       5 no feature found where ring can be inserted*/
-    int addRing( const QList<QgsPoint>& ring, const QgsFeatureIds& targetFeatureIds = QgsFeatureIds(), QgsFeatureId* modifiedFeatureId = 0 );
+     @return a QgsVectorLayer::AddRingResult
+     */
+    QgsVectorLayer::AddRingResult addRing( const QList<QgsPoint>& ring, const QgsFeatureIds& targetFeatureIds = QgsFeatureIds(), QgsFeatureId* modifiedFeatureId = 0 );
 
     /** Adds a new part polygon to a multipart feature
-     @return
-       0 in case of success,
-       1 if selected feature is not multipart,
-       2 if ring is not a valid geometry,
-       3 if new polygon ring not disjoint with existing rings,
-       4 if no feature was selected,
-       5 if several features are selected,
-       6 if selected geometry not found*/
-    int addPart( const QList<QgsPoint>& ring, QgsFeatureId featureId );
+     @return a QgsVectorLayer::AddringResult
+     */
+    QgsVectorLayer::AddPartResult addPart( const QList<QgsPoint>& ring, QgsFeatureId featureId );
 
     /** Translates feature by dx, dy
        @param featureId id of the feature to translate

--- a/python/gui/qgsmaptoolcapture.sip
+++ b/python/gui/qgsmaptoolcapture.sip
@@ -68,6 +68,14 @@ class QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
 
 
   protected:
+    /** Result codes for nextPoint() */
+    enum NextPointResult
+    {
+      NextPointSuccess = 0,          //< No problem
+      NextPointInvalidLayer,         //< The current layer is null or not a vector layer
+      NextPointTransformationFailed  //< The transformation failed
+    };
+
     /** Converts a map point to layer coordinates
         @param mapPoint the point in map coordinates
         @param[inout] layerPoint the point in layer coordinates
@@ -82,12 +90,8 @@ class QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
     /** Converts a map point to layer coordinates
         @param mapPoint the point in map coordinates
         @param[inout] layerPoint the point in layer coordinates
-        @return
-          0 in case of success
-          1 if the current layer is null or not a vector layer
-          2 if the transformation failed
     */
-    int nextPoint( const QgsPointV2& mapPoint, QgsPointV2& layerPoint );
+    NextPointResult nextPoint( const QgsPointV2& mapPoint, QgsPointV2& layerPoint );
 
     /** Converts a point to map coordinates and layer coordinates
         @param p the input point
@@ -105,12 +109,8 @@ class QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
         @param p the input point
         @param[inout] layerPoint the point in layer coordinates
         @param[inout] mapPoint the point in map coordinates
-        @return
-          0 in case of success
-          1 if the current layer is null or not a vector layer
-          2 if the transformation failed
     */
-    int nextPoint( QPoint p, QgsPointV2 &layerPoint, QgsPointV2 &mapPoint );
+    NextPointResult nextPoint( QPoint p, QgsPointV2 &layerPoint, QgsPointV2 &mapPoint );
 
     /** Adds a point to the rubber band (in map coordinates) and to the capture list (in layer coordinates)
      @return 0 in case of success, 1 if current layer is not a vector layer, 2 if coordinate transformation failed*/

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -556,7 +556,7 @@ double QgsGeometry::closestSegmentWithContext(
   return sqrDist;
 }
 
-int QgsGeometry::addRing( const QList<QgsPoint>& ring )
+QgsGeometry::AddRingResult QgsGeometry::addRing( const QList<QgsPoint>& ring )
 {
   detach( true );
 
@@ -568,12 +568,12 @@ int QgsGeometry::addRing( const QList<QgsPoint>& ring )
   return addRing( ringLine );
 }
 
-int QgsGeometry::addRing( QgsCurveV2* ring )
+QgsGeometry::AddRingResult QgsGeometry::addRing( QgsCurveV2* ring )
 {
   if ( !d->geometry )
   {
     delete ring;
-    return 1;
+    return AddRingWrongFeatureType;
   }
 
   detach( true );
@@ -582,14 +582,14 @@ int QgsGeometry::addRing( QgsCurveV2* ring )
   return QgsGeometryEditUtils::addRing( d->geometry, ring );
 }
 
-int QgsGeometry::addPart( const QList<QgsPoint> &points, QGis::GeometryType geomType )
+QgsGeometry::AddPartResult QgsGeometry::addPart( const QList<QgsPoint> &points, QGis::GeometryType geomType )
 {
   QList<QgsPointV2> l;
   convertPointList( points, l );
   return addPart( l, geomType );
 }
 
-int QgsGeometry::addPart( const QList<QgsPointV2> &points, QGis::GeometryType geomType )
+QgsGeometry::AddPartResult QgsGeometry::addPart( const QList<QgsPointV2> &points, QGis::GeometryType geomType )
 {
   QgsAbstractGeometryV2* partGeom = nullptr;
   if ( points.size() == 1 )
@@ -605,7 +605,7 @@ int QgsGeometry::addPart( const QList<QgsPointV2> &points, QGis::GeometryType ge
   return addPart( partGeom, geomType );
 }
 
-int QgsGeometry::addPart( QgsAbstractGeometryV2* part, QGis::GeometryType geomType )
+QgsGeometry::AddPartResult QgsGeometry::addPart( QgsAbstractGeometryV2* part, QGis::GeometryType geomType )
 {
   if ( !d->geometry )
   {
@@ -622,7 +622,7 @@ int QgsGeometry::addPart( QgsAbstractGeometryV2* part, QGis::GeometryType geomTy
         d->geometry = new QgsMultiPolygonV2();
         break;
       default:
-        return 1;
+        return AddPartWrongFeatureType;
     }
   }
   else
@@ -635,21 +635,21 @@ int QgsGeometry::addPart( QgsAbstractGeometryV2* part, QGis::GeometryType geomTy
   return QgsGeometryEditUtils::addPart( d->geometry, part );
 }
 
-int QgsGeometry::addPart( const QgsGeometry *newPart )
+QgsGeometry::AddPartResult QgsGeometry::addPart( const QgsGeometry *newPart )
 {
   if ( !d->geometry || !newPart || !newPart->d || !newPart->d->geometry )
   {
-    return 1;
+    return AddPartWrongFeatureType;
   }
 
   return addPart( newPart->d->geometry->clone() );
 }
 
-int QgsGeometry::addPart( GEOSGeometry *newPart )
+QgsGeometry::AddPartResult QgsGeometry::addPart( GEOSGeometry *newPart )
 {
   if ( !d->geometry || !newPart )
   {
-    return 1;
+    return AddPartWrongFeatureType;
   }
 
   detach( true );

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -317,54 +317,69 @@ class CORE_EXPORT QgsGeometry
      */
     double closestSegmentWithContext( const QgsPoint& point, QgsPoint& minDistPoint, int& afterVertex, double* leftOf = nullptr, double epsilon = DEFAULT_SEGMENT_EPSILON ) const;
 
-    /** Adds a new ring to this geometry. This makes only sense for polygon and multipolygons.
-     @return 0 in case of success (ring added), 1 problem with geometry type, 2 ring not closed,
-     3 ring is not valid geometry, 4 ring not disjoint with existing rings, 5 no polygon found which contained the ring*/
-    int addRing( const QList<QgsPoint>& ring );
+    /** Result codes for addRing().
+     * @note should be replaced in QGIS 3.0 by common codes for all editing operations
+     * @note this is extended by QgsVectorLayer::AddRingResult
+     */
+    enum AddRingResult
+    {
+      AddRingSuccess = 0,       //< Success
+      AddRingWrongFeatureType,  //< Problem with feature type
+      AddRingNotClosed,         //< Ring not closed
+      AddRingNotValid,          //< Ring not valid
+      AddRingCrossing,          //< Ring crosses existing rings
+      AddRingNotInsertable      //< No feature found where ring can be inserted
+    };
 
-    /** Adds a new ring to this geometry. This makes only sense for polygon and multipolygons.
-     @return 0 in case of success (ring added), 1 problem with geometry type, 2 ring not closed,
-     3 ring is not valid geometry, 4 ring not disjoint with existing rings, 5 no polygon found which contained the ring*/
-    int addRing( QgsCurveV2* ring );
+    /** Adds a new ring to this geometry. This makes only sense for polygon and multipolygons. */
+    AddRingResult addRing( const QList<QgsPoint>& ring );
+
+    /** Adds a new ring to this geometry. This makes only sense for polygon and multipolygons. */
+    AddRingResult addRing( QgsCurveV2* ring );
+
+    /** Result codes for addPart().
+     *  @note should be replaced in QGIS 3.0 by common codes for all editing operations
+     */
+    enum AddPartResult
+    {
+      AddPartSuccess,           //< Success
+      AddPartWrongFeatureType,  //< Selected feature is not multipart
+      AddPartNotValid,          //< Ring is not valid geometry
+      AddPartNotDisjoint,       //< New polygon ring not disjoint with exisiting rings
+      AddPartNoFeature,         //< No feature was selected
+      AddPartSeveralFeatures,   //< Several features are selected
+      AddPartNoGeometry         //< Selected geometry not found
+    };
 
     /** Adds a new part to a the geometry.
      * @param points points describing part to add
      * @param geomType default geometry type to create if no existing geometry
-     * @returns 0 in case of success, 1 if not a multipolygon, 2 if ring is not a valid geometry, 3 if new polygon ring
-     * not disjoint with existing polygons of the feature
     */
-    int addPart( const QList<QgsPoint> &points, QGis::GeometryType geomType = QGis::UnknownGeometry );
+    AddPartResult addPart( const QList<QgsPoint> &points, QGis::GeometryType geomType = QGis::UnknownGeometry );
 
     /** Adds a new part to a the geometry.
      * @param points points describing part to add
      * @param geomType default geometry type to create if no existing geometry
-     * @returns 0 in case of success, 1 if not a multipolygon, 2 if ring is not a valid geometry, 3 if new polygon ring
-     * not disjoint with existing polygons of the feature
     */
-    int addPart( const QList<QgsPointV2> &points, QGis::GeometryType geomType = QGis::UnknownGeometry );
+    AddPartResult addPart( const QList<QgsPointV2> &points, QGis::GeometryType geomType = QGis::UnknownGeometry );
 
     /** Adds a new part to this geometry.
      * @param part part to add (ownership is transferred)
      * @param geomType default geometry type to create if no existing geometry
-     * @returns 0 in case of success, 1 if not a multipolygon, 2 if ring is not a valid geometry, 3 if new polygon ring
      * not disjoint with existing polygons of the feature
     */
-    int addPart( QgsAbstractGeometryV2* part, QGis::GeometryType geomType = QGis::UnknownGeometry );
+    AddPartResult addPart( QgsAbstractGeometryV2* part, QGis::GeometryType geomType = QGis::UnknownGeometry );
 
     /** Adds a new island polygon to a multipolygon feature
      * @param newPart part to add. Ownership is NOT transferred.
-     * @return 0 in case of success, 1 if not a multipolygon, 2 if ring is not a valid geometry, 3 if new polygon ring
-     * not disjoint with existing polygons of the feature
      * @note not available in python bindings
      */
-    int addPart( GEOSGeometry *newPart );
+    AddPartResult addPart( GEOSGeometry *newPart );
 
     /** Adds a new island polygon to a multipolygon feature
-     @return 0 in case of success, 1 if not a multipolygon, 2 if ring is not a valid geometry, 3 if new polygon ring
-     not disjoint with existing polygons of the feature
      @note available in python bindings as addPartGeometry (added in 2.2)
      */
-    int addPart( const QgsGeometry *newPart );
+    AddPartResult addPart( const QgsGeometry *newPart );
 
     /** Translate this geometry by dx, dy
      @return 0 in case of success*/

--- a/src/core/geometry/qgsgeometryeditutils.h
+++ b/src/core/geometry/qgsgeometryeditutils.h
@@ -22,6 +22,7 @@ class QgsGeometryEngine;
 class QgsVectorLayer;
 
 #include "qgsfeature.h"
+#include "qgsgeometry.h"
 #include <QMap>
 
 /** \ingroup core
@@ -34,15 +35,11 @@ class QgsVectorLayer;
 class QgsGeometryEditUtils
 {
   public:
-    /** Adds interior ring (taking ownership).
-    @return 0 in case of success (ring added), 1 problem with geometry type, 2 ring not closed,
-    3 ring is not valid geometry, 4 ring not disjoint with existing rings, 5 no polygon found which contained the ring*/
-    static int addRing( QgsAbstractGeometryV2* geom, QgsCurveV2* ring );
+    /** Adds interior ring (taking ownership). */
+    static QgsGeometry::AddRingResult addRing( QgsAbstractGeometryV2* geom, QgsCurveV2* ring );
 
-    /** Adds part to multi type geometry (taking ownership)
-    @return 0 in case of success, 1 if not a multigeometry, 2 if part is not a valid geometry, 3 if new polygon ring
-    not disjoint with existing polygons of the feature*/
-    static int addPart( QgsAbstractGeometryV2* geom, QgsAbstractGeometryV2* part );
+    /** Adds part to multi type geometry (taking ownership) */
+    static QgsGeometry::AddPartResult addPart( QgsAbstractGeometryV2* geom, QgsAbstractGeometryV2* part );
 
     /** Deletes a ring from a geometry.
      * @returns true if delete was successful

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -1072,13 +1072,13 @@ bool QgsVectorLayer::deleteSelectedFeatures( int* deletedCount )
   return deleted == count;
 }
 
-int QgsVectorLayer::addRing( const QList<QgsPoint>& ring, QgsFeatureId* featureId )
+QgsVectorLayer::AddRingResult QgsVectorLayer::addRing( const QList<QgsPoint>& ring, QgsFeatureId* featureId )
 {
   if ( !mValid || !mEditBuffer || !mDataProvider )
-    return 6;
+    return static_cast<AddRingResult>( QgsGeometry::AddRingSuccess );
 
   QgsVectorLayerEditUtils utils( this );
-  int result = 5;
+  int result = QgsGeometry::AddRingNotInsertable;
 
   //first try with selected features
   if ( !mSelectedFeatureIds.isEmpty() )
@@ -1086,36 +1086,36 @@ int QgsVectorLayer::addRing( const QList<QgsPoint>& ring, QgsFeatureId* featureI
     result = utils.addRing( ring, mSelectedFeatureIds, featureId );
   }
 
-  if ( result != 0 )
+  if ( result != QgsGeometry::AddRingSuccess )
   {
     //try with all intersecting features
     result = utils.addRing( ring, QgsFeatureIds(), featureId );
   }
 
-  return result;
+  return static_cast<AddRingResult>( result );
 }
 
-int QgsVectorLayer::addRing( QgsCurveV2* ring, QgsFeatureId* featureId )
+QgsVectorLayer::AddRingResult QgsVectorLayer::addRing( QgsCurveV2* ring, QgsFeatureId* featureId )
 {
   if ( !mValid || !mEditBuffer || !mDataProvider )
   {
     delete ring;
-    return 6;
+    return AddRingLayerNotEditable;
   }
 
   if ( !ring )
   {
-    return 1;
+    return static_cast<AddRingResult>( QgsGeometry::AddRingWrongFeatureType );
   }
 
   if ( !ring->isClosed() )
   {
     delete ring;
-    return 2;
+    return static_cast<AddRingResult>( QgsGeometry::AddRingNotClosed );
   }
 
   QgsVectorLayerEditUtils utils( this );
-  int result = 5;
+  int result = QgsGeometry::AddRingNotInsertable;
 
   //first try with selected features
   if ( !mSelectedFeatureIds.isEmpty() )
@@ -1123,76 +1123,76 @@ int QgsVectorLayer::addRing( QgsCurveV2* ring, QgsFeatureId* featureId )
     result = utils.addRing( static_cast< QgsCurveV2* >( ring->clone() ), mSelectedFeatureIds, featureId );
   }
 
-  if ( result != 0 )
+  if ( result != QgsGeometry::AddRingSuccess )
   {
     //try with all intersecting features
     result = utils.addRing( static_cast< QgsCurveV2* >( ring->clone() ), QgsFeatureIds(), featureId );
   }
 
   delete ring;
-  return result;
+  return static_cast<AddRingResult>( result );
 }
 
-int QgsVectorLayer::addPart( const QList<QgsPoint> &points )
+QgsVectorLayer::AddPartResult QgsVectorLayer::addPart( const QList<QgsPoint> &points )
 {
   if ( !mValid || !mEditBuffer || !mDataProvider )
-    return 7;
+    return AddPartLayerNotEditable;
 
   //number of selected features must be 1
 
   if ( mSelectedFeatureIds.size() < 1 )
   {
     QgsDebugMsg( "Number of selected features <1" );
-    return 4;
+    return static_cast<AddPartResult>( QgsGeometry::AddPartNoFeature );
   }
   else if ( mSelectedFeatureIds.size() > 1 )
   {
     QgsDebugMsg( "Number of selected features >1" );
-    return 5;
+    return static_cast<AddPartResult>( QgsGeometry::AddPartSeveralFeatures );
   }
 
   QgsVectorLayerEditUtils utils( this );
   return utils.addPart( points, *mSelectedFeatureIds.constBegin() );
 }
 
-int QgsVectorLayer::addPart( const QList<QgsPointV2> &points )
+QgsVectorLayer::AddPartResult QgsVectorLayer::addPart( const QList<QgsPointV2> &points )
 {
   if ( !mValid || !mEditBuffer || !mDataProvider )
-    return 7;
+    return AddPartLayerNotEditable;
 
   //number of selected features must be 1
 
   if ( mSelectedFeatureIds.size() < 1 )
   {
     QgsDebugMsg( "Number of selected features <1" );
-    return 4;
+    return static_cast<AddPartResult>( QgsGeometry::AddPartNoFeature );
   }
   else if ( mSelectedFeatureIds.size() > 1 )
   {
     QgsDebugMsg( "Number of selected features >1" );
-    return 5;
+    return static_cast<AddPartResult>( QgsGeometry::AddPartSeveralFeatures );
   }
 
   QgsVectorLayerEditUtils utils( this );
   return utils.addPart( points, *mSelectedFeatureIds.constBegin() );
 }
 
-int QgsVectorLayer::addPart( QgsCurveV2* ring )
+QgsVectorLayer::AddPartResult QgsVectorLayer::addPart( QgsCurveV2* ring )
 {
   if ( !mValid || !mEditBuffer || !mDataProvider )
-    return 7;
+    return AddPartLayerNotEditable;
 
   //number of selected features must be 1
 
   if ( mSelectedFeatureIds.size() < 1 )
   {
     QgsDebugMsg( "Number of selected features <1" );
-    return 4;
+    return static_cast<AddPartResult>( QgsGeometry::AddPartNoFeature );
   }
   else if ( mSelectedFeatureIds.size() > 1 )
   {
     QgsDebugMsg( "Number of selected features >1" );
-    return 5;
+    return static_cast<AddPartResult>( QgsGeometry::AddPartSeveralFeatures );
   }
 
   QgsVectorLayerEditUtils utils( this );

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -937,57 +937,44 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
      */
     bool deleteSelectedFeatures( int *deletedCount = nullptr );
 
+    /** Result codes for addRing().
+     * @note should be replaced in QGIS 3.0 by common codes for all editing operations
+     * @note this is extended from QgsGeometry::AddRingResult
+     */
+    enum AddRingResult
+    {
+      AddRingLayerNotEditable = 6 //< Layer is not editable
+    };
+
     /** Adds a ring to polygon/multipolygon features
      * @param ring ring to add
      * @param featureId if specified, feature ID for feature ring was added to will be stored in this parameter
-     @return
-       0 in case of success,
-       1 problem with feature type,
-       2 ring not closed,
-       3 ring not valid,
-       4 ring crosses existing rings,
-       5 no feature found where ring can be inserted
-       6 layer not editable */
-    int addRing( const QList<QgsPoint>& ring, QgsFeatureId* featureId = nullptr );
+     */
+    AddRingResult addRing( const QList<QgsPoint>& ring, QgsFeatureId* featureId = nullptr );
 
     /** Adds a ring to polygon/multipolygon features (takes ownership)
      * @param ring ring to add
      * @param featureId if specified, feature ID for feature ring was added to will be stored in this parameter
-            @return
-            0 in case of success
-            1 problem with feature type
-            2 ring not closed
-            6 layer not editable
-       @note available in python as addCurvedRing
      */
-    int addRing( QgsCurveV2* ring, QgsFeatureId* featureId = nullptr );
+    AddRingResult addRing( QgsCurveV2* ring, QgsFeatureId* featureId = nullptr );
 
-    /** Adds a new part polygon to a multipart feature
-     @return
-       0 in case of success,
-       1 if selected feature is not multipart,
-       2 if ring is not a valid geometry,
-       3 if new polygon ring not disjoint with existing rings,
-       4 if no feature was selected,
-       5 if several features are selected,
-       6 if selected geometry not found
-       7 layer not editable */
-    int addPart( const QList<QgsPoint>& ring );
+    /** Result codes for addPart().
+     * @note should be replaced in QGIS 3.0 by common codes for all editing operations
+     * @note extends QgsGeometry::AddPartResult
+     */
+    enum AddPartResult
+    {
+      AddPartLayerNotEditable = 7   //< Layer not editable
+    };
 
-    /** Adds a new part polygon to a multipart feature
-     @return
-       0 in case of success,
-       1 if selected feature is not multipart,
-       2 if ring is not a valid geometry,
-       3 if new polygon ring not disjoint with existing rings,
-       4 if no feature was selected,
-       5 if several features are selected,
-       6 if selected geometry not found
-       7 layer not editable */
-    int addPart( const QList<QgsPointV2>& ring );
+    /** Adds a new part polygon to a multipart feature */
+    AddPartResult addPart( const QList<QgsPoint>& ring );
+
+    /** Adds a new part polygon to a multipart feature */
+    AddPartResult addPart( const QList<QgsPointV2>& ring );
 
     //! @note available in python as addCurvedPart
-    int addPart( QgsCurveV2* ring );
+    AddPartResult addPart( QgsCurveV2* ring );
 
     /** Translates feature by dx, dy
        @param featureId id of the feature to translate

--- a/src/core/qgsvectorlayereditutils.h
+++ b/src/core/qgsvectorlayereditutils.h
@@ -68,52 +68,31 @@ class CORE_EXPORT QgsVectorLayerEditUtils
      * @param targetFeatureIds if specified, only these features will be the candidates for adding a ring. Otherwise
      * all intersecting features are tested and the ring is added to the first valid feature.
      * @param modifiedFeatureId if specified, feature ID for feature that ring was added to will be stored in this parameter
-     @return
-       0 in case of success,
-       1 problem with feature type,
-       2 ring not closed,
-       3 ring not valid,
-       4 ring crosses existing rings,
-       5 no feature found where ring can be inserted*/
-    int addRing( const QList<QgsPoint>& ring, const QgsFeatureIds& targetFeatureIds = QgsFeatureIds(), QgsFeatureId* modifiedFeatureId = nullptr );
+     * @return a QgsVectorLayer::AddRingResult
+     */
+    QgsVectorLayer::AddRingResult addRing( const QList<QgsPoint>& ring, const QgsFeatureIds& targetFeatureIds = QgsFeatureIds(), QgsFeatureId* modifiedFeatureId = nullptr );
 
     /** Adds a ring to polygon/multipolygon features
      * @param ring ring to add
      * @param targetFeatureIds if specified, only these features will be the candidates for adding a ring. Otherwise
      * all intersecting features are tested and the ring is added to the first valid feature.
      * @param modifiedFeatureId if specified, feature ID for feature that ring was added to will be stored in this parameter
-         @return
-           0 in case of success,
-           1 problem with feature type,
-           2 ring not closed,
-           3 ring not valid,
-           4 ring crosses existing rings,
-           5 no feature found where ring can be inserted*/
-    int addRing( QgsCurveV2* ring, const QgsFeatureIds& targetFeatureIds = QgsFeatureIds(), QgsFeatureId* modifiedFeatureId = nullptr );
+     * @return a QgsVectorLayer::AddRingResult
+     */
+    QgsVectorLayer::AddRingResult addRing( QgsCurveV2* ring, const QgsFeatureIds& targetFeatureIds = QgsFeatureIds(), QgsFeatureId* modifiedFeatureId = nullptr );
 
     /** Adds a new part polygon to a multipart feature
-     @return
-       0 in case of success,
-       1 if selected feature is not multipart,
-       2 if ring is not a valid geometry,
-       3 if new polygon ring not disjoint with existing rings,
-       4 if no feature was selected,
-       5 if several features are selected,
-       6 if selected geometry not found*/
-    int addPart( const QList<QgsPoint>& ring, QgsFeatureId featureId );
+        @return a QgsVectorLayer::AddPartResult
+    */
+    QgsVectorLayer::AddPartResult addPart( const QList<QgsPoint>& ring, QgsFeatureId featureId );
 
     /** Adds a new part polygon to a multipart feature
-     @return
-       0 in case of success,
-       1 if selected feature is not multipart,
-       2 if ring is not a valid geometry,
-       3 if new polygon ring not disjoint with existing rings,
-       4 if no feature was selected,
-       5 if several features are selected,
-       6 if selected geometry not found*/
-    int addPart( const QList<QgsPointV2>& ring, QgsFeatureId featureId );
+     @return a QgsVectorLayer::AddPartResult
+    */
+    QgsVectorLayer::AddPartResult addPart( const QList<QgsPointV2>& ring, QgsFeatureId featureId );
 
-    int addPart( QgsCurveV2* ring, QgsFeatureId featureId );
+    /** Adds a new part to a curve */
+    QgsVectorLayer::AddPartResult addPart( QgsCurveV2* ring, QgsFeatureId featureId );
 
     /** Translates feature by dx, dy
        @param featureId id of the feature to translate

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -326,13 +326,13 @@ int QgsMapToolCapture::nextPoint( const QgsPoint& mapPoint, QgsPoint& layerPoint
   return r;
 }
 
-int QgsMapToolCapture::nextPoint( const QgsPointV2& mapPoint, QgsPointV2& layerPoint )
+QgsMapToolCapture::NextPointResult QgsMapToolCapture::nextPoint( const QgsPointV2& mapPoint, QgsPointV2& layerPoint )
 {
   QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( mCanvas->currentLayer() );
   if ( !vlayer )
   {
     QgsDebugMsg( "no vector layer" );
-    return 1;
+    return NextPointInvalidLayer;
   }
   try
   {
@@ -347,13 +347,13 @@ int QgsMapToolCapture::nextPoint( const QgsPointV2& mapPoint, QgsPointV2& layerP
   {
     Q_UNUSED( cse );
     QgsDebugMsg( "transformation to layer coordinate failed" );
-    return 2;
+    return NextPointTransformationFailed;
   }
 
-  return 0;
+  return NextPointSuccess;
 }
 
-int QgsMapToolCapture::nextPoint( QPoint p, QgsPointV2 &layerPoint, QgsPointV2 &mapPoint )
+QgsMapToolCapture::NextPointResult QgsMapToolCapture::nextPoint( QPoint p, QgsPointV2 &layerPoint, QgsPointV2 &mapPoint )
 {
   mapPoint = QgsPointV2( toMapCoordinates( p ) );
   return nextPoint( mapPoint, layerPoint );

--- a/src/gui/qgsmaptoolcapture.h
+++ b/src/gui/qgsmaptoolcapture.h
@@ -88,6 +88,14 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
 
 
   protected:
+    /** Result codes for nextPoint() */
+    enum NextPointResult
+    {
+      NextPointSuccess = 0,          //< No problem
+      NextPointInvalidLayer,         //< The current layer is null or not a vector layer
+      NextPointTransformationFailed  //< The transformation failed
+    };
+
     /** Converts a map point to layer coordinates
         @param mapPoint the point in map coordinates
         @param[inout] layerPoint the point in layer coordinates
@@ -102,12 +110,8 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
     /** Converts a map point to layer coordinates
         @param mapPoint the point in map coordinates
         @param[inout] layerPoint the point in layer coordinates
-        @return
-          0 in case of success
-          1 if the current layer is null or not a vector layer
-          2 if the transformation failed
     */
-    int nextPoint( const QgsPointV2& mapPoint, QgsPointV2& layerPoint );
+    NextPointResult nextPoint( const QgsPointV2& mapPoint, QgsPointV2& layerPoint );
 
     /** Converts a point to map coordinates and layer coordinates
         @param p the input point
@@ -130,7 +134,7 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
           1 if the current layer is null or not a vector layer
           2 if the transformation failed
     */
-    int nextPoint( QPoint p, QgsPointV2 &layerPoint, QgsPointV2 &mapPoint );
+    NextPointResult nextPoint( QPoint p, QgsPointV2 &layerPoint, QgsPointV2 &mapPoint );
 
     /** Adds a point to the rubber band (in map coordinates) and to the capture list (in layer coordinates)
      @return 0 in case of success, 1 if current layer is not a vector layer, 2 if coordinate transformation failed*/


### PR DESCRIPTION
When a layer has Z coordinates (postgis for instance), loading, and modification is possible, but creation of new features or new parts is not (new features / parts are 2D only).

This patch makes new features and parts of the correct type so that they can be commited to the underlying layer.

It also make sure the postgres provider exposes the full geometry type with Z / M.
