### PR TITLE
[Bugfix] Construct the QgsFieldCalculator dialog with the correct parent

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5440,7 +5440,7 @@ void QgisApp::fieldCalculator()
     return;
   }
 
-  QgsFieldCalculator calc( myLayer );
+  QgsFieldCalculator calc( myLayer, this );
   if ( calc.exec() )
   {
     mMapCanvas->refresh();

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -551,7 +551,7 @@ void QgsAttributeTableDialog::on_mOpenFieldCalculator_clicked()
 {
   QgsAttributeTableModel* masterModel = mMainView->masterModel();
 
-  QgsFieldCalculator calc( mLayer );
+  QgsFieldCalculator calc( mLayer, this );
   if ( calc.exec() == QDialog::Accepted )
   {
     int col = masterModel->fieldCol( calc.changedAttributeId() );

--- a/src/app/qgsfieldcalculator.cpp
+++ b/src/app/qgsfieldcalculator.cpp
@@ -27,8 +27,8 @@
 #include <QMessageBox>
 #include <QSettings>
 
-QgsFieldCalculator::QgsFieldCalculator( QgsVectorLayer* vl )
-    : QDialog()
+QgsFieldCalculator::QgsFieldCalculator( QgsVectorLayer* vl, QWidget* parent )
+    : QDialog( parent )
     , mVectorLayer( vl )
     , mAttributeId( -1 )
 {

--- a/src/app/qgsfieldcalculator.h
+++ b/src/app/qgsfieldcalculator.h
@@ -26,7 +26,7 @@ class APP_EXPORT QgsFieldCalculator: public QDialog, private Ui::QgsFieldCalcula
 {
     Q_OBJECT
   public:
-    QgsFieldCalculator( QgsVectorLayer* vl );
+    QgsFieldCalculator( QgsVectorLayer* vl, QWidget* parent = nullptr );
     ~QgsFieldCalculator();
 
     int changedAttributeId() const { return mAttributeId; }

--- a/src/app/qgsfieldsproperties.cpp
+++ b/src/app/qgsfieldsproperties.cpp
@@ -762,7 +762,7 @@ void QgsFieldsProperties::on_mCalculateFieldButton_clicked()
     return;
   }
 
-  QgsFieldCalculator calc( mLayer );
+  QgsFieldCalculator calc( mLayer, this );
   calc.exec();
 }
 


### PR DESCRIPTION
Whenever a `QDialog` is going to be shown as a modal dialog, it is essential to give it the correct `parent`. Otherwise the dialog does not behave correctly, e.g.
- The dialog creates a new button in the task bar.
- Clicking on the parent window will not give focus to the dialog.

This PR fixes that for the `QgsFieldCalculator` dialog.

See also my PR #2509 that fixes the same issue for the `QgsTipGui`.
