### PR TITLE
Geom snapper fixes

### DIFF
--- a/src/plugins/geometry_snapper/qgsgeometrysnapper.cpp
+++ b/src/plugins/geometry_snapper/qgsgeometrysnapper.cpp
@@ -49,11 +49,13 @@ QgsGeometrySnapper::QgsGeometrySnapper( QgsVectorLayer *adjustLayer, QgsVectorLa
 
 QFuture<void> QgsGeometrySnapper::processFeatures()
 {
+  emit progressRangeChanged( 0, mFeatures.size() );
   return QtConcurrent::map( mFeatures, ProcessFeatureWrapper( this ) );
 }
 
 void QgsGeometrySnapper::processFeature( QgsFeatureId id )
 {
+  emit progressStep();
   // Get current feature
   QgsFeature feature;
   if ( !getFeature( mAdjustLayer, mAdjustLayerMutex, id, feature ) )

--- a/src/plugins/geometry_snapper/qgsgeometrysnapper.h
+++ b/src/plugins/geometry_snapper/qgsgeometrysnapper.h
@@ -35,6 +35,10 @@ class QgsGeometrySnapper : public QObject
     QFuture<void> processFeatures();
     const QStringList& getErrors() const { return mErrors; }
 
+  signals:
+    void progressRangeChanged( int min, int max );
+    void progressStep();
+
   private:
     struct ProcessFeatureWrapper
     {

--- a/src/plugins/geometry_snapper/qgsgeometrysnapperdialog.cpp
+++ b/src/plugins/geometry_snapper/qgsgeometrysnapperdialog.cpp
@@ -280,8 +280,6 @@ void QgsGeometrySnapperDialog::run()
   /** Run **/
   QEventLoop evLoop;
   QFutureWatcher<void> futureWatcher;
-  connect( &futureWatcher, SIGNAL( progressRangeChanged( int, int ) ), progressBar, SLOT( setRange( int, int ) ) );
-  connect( &futureWatcher, SIGNAL( progressValueChanged( int ) ), progressBar, SLOT( setValue( int ) ) );
   connect( &futureWatcher, SIGNAL( finished() ), &evLoop, SLOT( quit() ) );
   connect( buttonBox->button( QDialogButtonBox::Abort ), SIGNAL( clicked() ), &futureWatcher, SLOT( cancel() ) );
 
@@ -294,6 +292,8 @@ void QgsGeometrySnapperDialog::run()
   widgetInputs->setEnabled( false );
 
   QgsGeometrySnapper snapper( layer, referenceLayer, selectedOnly, doubleSpinBoxMaxDistance->value(), &mIface->mapCanvas()->mapSettings() );
+  connect( &snapper, SIGNAL( progressRangeChanged( int, int ) ), progressBar, SLOT( setRange( int, int ) ) );
+  connect( &snapper, SIGNAL( progressStep() ), this, SLOT( progressStep() ) );
   futureWatcher.setFuture( snapper.processFeatures() );
   evLoop.exec();
 
@@ -315,5 +315,10 @@ void QgsGeometrySnapperDialog::run()
     QMessageBox::warning( this, tr( "Errors occurred" ), tr( "<p>The following errors occurred:</p><ul><li>%1</li></ul>" ).arg( snapper.getErrors().join( "</li><li>" ) ) );
   }
   hide() ;
+}
+
+void QgsGeometrySnapperDialog::progressStep()
+{
+  progressBar->setValue( progressBar->value() + 1 );
 }
 

--- a/src/plugins/geometry_snapper/qgsgeometrysnapperdialog.h
+++ b/src/plugins/geometry_snapper/qgsgeometrysnapperdialog.h
@@ -46,6 +46,7 @@ class QgsGeometrySnapperDialog: public QDialog, private Ui::QgsGeometrySnapperDi
     void updateLayers();
     void validateInput();
     void selectOutputFile();
+    void progressStep();
 };
 
 #endif // QGS_GEOMETRY_SNAPPER_DIALOG_H

--- a/src/plugins/geometry_snapper/qgssnapindex.cpp
+++ b/src/plugins/geometry_snapper/qgssnapindex.cpp
@@ -309,7 +309,7 @@ void QgsSnapIndex::addGeometry( const QgsAbstractGeometryV2* geom )
 {
   for ( int iPart = 0, nParts = geom->partCount(); iPart < nParts; ++iPart )
   {
-    for ( int iRing = 0, nRings = geom->ringCount( iRing ); iRing < nRings; ++iRing )
+    for ( int iRing = 0, nRings = geom->ringCount( iPart ); iRing < nRings; ++iRing )
     {
       for ( int iVert = 0, nVerts = geom->vertexCount( iPart, iRing ) - 1; iVert < nVerts; ++iVert )
       {


### PR DESCRIPTION
Some geometry snapper fixes:
- Progress bar did not work
- Typo resulted in snapper misbehaving (or crashing) with certain geometries
