### PR TITLE
[Bugfix] Always hide the welcome screen when the first project is loaded

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -4143,6 +4143,7 @@ void QgisApp::fileOpenAfterLaunch()
   if ( mProjOpen == 0 ) // welcome page
   {
     connect( this, SIGNAL( newProject() ), this, SLOT( showMapCanvas() ) );
+    connect( this, SIGNAL( projectRead() ), this, SLOT( showMapCanvas() ) );
     return;
   }
   if ( mProjOpen == 1 && !mRecentProjects.isEmpty() ) // most recent project


### PR DESCRIPTION
After starting QGIS, when a **project with no visible layers** was loaded, the welcome screen would still be shown.

This PR makes the welcome screen go away even in that admittedly exceptional case.
