### PR TITLE
[memorylayer] fix missing datetime field type

### DIFF
--- a/src/providers/memory/qgsmemoryprovider.cpp
+++ b/src/providers/memory/qgsmemoryprovider.cpp
@@ -86,6 +86,7 @@ QgsMemoryProvider::QgsMemoryProvider( const QString& uri )
 
   // date type
   << QgsVectorDataProvider::NativeType( tr( "Date" ), "date", QVariant::Date, -1, -1, -1, -1 )
+  << QgsVectorDataProvider::NativeType( tr( "Date & Time" ), "datetime", QVariant::DateTime, -1, -1, -1, -1 )
 
   // integer types
   << QgsVectorDataProvider::NativeType( tr( "Whole number (smallint - 16bit)" ), "int2", QVariant::Int, -1, -1, 0, 0 )
@@ -106,7 +107,7 @@ QgsMemoryProvider::QgsMemoryProvider( const QString& uri )
   {
     QList<QgsField> attributes;
     QRegExp reFieldDef( "\\:"
-                        "(int|integer|real|double|string|date)" // type
+                        "(int|integer|real|double|string|date|datetime)" // type
                         "(?:\\((\\d+)"                // length
                         "(?:\\,(\\d+))?"                // precision
                         "\\))?"
@@ -142,7 +143,13 @@ QgsMemoryProvider::QgsMemoryProvider( const QString& uri )
         {
           type = QVariant::Date;
           typeName = "date";
-          length = 10;
+          length = -1;
+        }
+        else if ( typeName == "datetime" )
+        {
+          type = QVariant::DateTime;
+          typeName = "datetime";
+          length = -1;
         }
 
         if ( reFieldDef.cap( 2 ) != "" )
@@ -350,6 +357,7 @@ bool QgsMemoryProvider::addAttributes( const QList<QgsField> &attributes )
       case QVariant::Double:
       case QVariant::String:
       case QVariant::Date:
+      case QVariant::DateTime:
       case QVariant::LongLong:
         break;
       default:

--- a/tests/src/python/test_provider_memory.py
+++ b/tests/src/python/test_provider_memory.py
@@ -191,7 +191,9 @@ class TestPyQgsMemoryProvider(TestCase, ProviderTestCase):
         # Add some fields to the layer
         myFields = [QgsField('TestInt', QVariant.Int, 'integer', 2, 0),
                     QgsField('TestDbl', QVariant.Double, 'double', 8, 6),
-                    QgsField('TestString', QVariant.String, 'string', 50, 0)]
+                    QgsField('TestString', QVariant.String, 'string', 50, 0),
+                    QgsField('TestDate', QVariant.Date, 'date'),
+                    QgsField('TestDateTime', QVariant.DateTime, 'datetime')]
         assert myMemoryLayer.startEditing()
         for f in myFields:
             assert myMemoryLayer.addAttribute(f)


### PR DESCRIPTION
The datetime field type is missing from the memory layer provider, breaking pasting of often-used KML layer features into a temporary scratch layer. 

Simple steps to reproduce issue: 
- add a KML file 
- use the selection tool to select a few features from your KML file layer
- try and paste it into a new scratch layer via the Edit -> Paste Features as -> New Temporary Scratch Layer...
- you'll get an error box saying "QDateTime not supported"

This PR fixes this.
