### PR TITLE
Fix warning when a QLayout is already present in QgsDualView.

### DIFF
--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -75,7 +75,8 @@ void QgsDualView::init( QgsVectorLayer* layer, QgsMapCanvas* mapCanvas, const Qg
   mTableView->setModel( mFilterModel );
   mFeatureList->setModel( mFeatureListModel );
   mAttributeForm = new QgsAttributeForm( layer, QgsFeature(), mEditorContext );
-  mAttributeEditorScrollArea->setLayout( new QGridLayout() );
+  if ( !mAttributeEditorScrollArea->layout() )
+    mAttributeEditorScrollArea->setLayout( new QGridLayout() );
   mAttributeEditorScrollArea->layout()->addWidget( mAttributeForm );
   mAttributeEditorScrollArea->setWidget( mAttributeForm );
 


### PR DESCRIPTION
Calling `QWidget::setLayout()` on a widget that already has a `QLayout` set, [does nothing](http://doc.qt.io/qt-4.8/qwidget.html#setLayout) but print a warning:

```
Warning: QWidget::setLayout: Attempting to set QLayout "" on QScrollArea "mAttributeEditorScrollArea", which already has a layout
```

Because in this case the layout was created but never deleted, it also resulted in a memory leak.

This PR fixes it by creating and setting the layout only when no layout is set before.

Please note:
I am not sure if calling `QgsDualView::init()` multiple times for the same instance is not an error itself, but it is done in `QgsRelationEditorWidget` by calling [`::updateUi()`](https://github.com/qgis/QGIS/blob/bfad753f37497f46b0a34837447ca1e946ddbca6/src/gui/qgsrelationeditorwidget.cpp#L485-L520) which in turn calls `QgsDualView::init()`.
