### PR TITLE
[Bugfix] Correctly load the labeling-setting to show a plus-sign next to numbers (fixes #13474)

### DIFF
--- a/src/core/qgspallabeling.cpp
+++ b/src/core/qgspallabeling.cpp
@@ -851,7 +851,7 @@ void QgsPalLayerSettings::readFromLayer( QgsVectorLayer* layer )
   placeDirectionSymbol = static_cast< DirectionSymbols >( layer->customProperty( "labeling/placeDirectionSymbol", QVariant( SymbolLeftRight ) ).toUInt() );
   formatNumbers = layer->customProperty( "labeling/formatNumbers" ).toBool();
   decimals = layer->customProperty( "labeling/decimals" ).toInt();
-  plusSign = layer->customProperty( "labeling/plussign" ).toInt();
+  plusSign = layer->customProperty( "labeling/plussign" ).toBool();
 
   // text buffer
   double bufSize = layer->customProperty( "labeling/bufferSize", QVariant( 0.0 ) ).toDouble();


### PR DESCRIPTION
See [Redmine #13474](https://hub.qgis.org/issues/13474).

I am still looking for the ultimate bug that can be fixed by changing only one character :stuck_out_tongue_winking_eye: 
