### PR TITLE
[Bugfix] Don't use QDialog.exec() for non-modal dialog 'ModelerDialog'

### DIFF
--- a/python/plugins/processing/ProcessingPlugin.py
+++ b/python/plugins/processing/ProcessingPlugin.py
@@ -57,6 +57,7 @@ class ProcessingPlugin:
         Processing.initialize()
 
         self.commander = None
+        self.modelerDialog = None
         self.toolbox = ProcessingToolbox()
         self.iface.addDockWidget(Qt.RightDockWidgetArea, self.toolbox)
         self.toolbox.hide()
@@ -146,11 +147,16 @@ class ProcessingPlugin:
             self.toolbox.show()
 
     def openModeler(self):
-        dlg = ModelerDialog()
-        dlg.show()
-        dlg.exec_()
-        if dlg.update:
+        if self.modelerDialog is None:
+            self.modelerDialog = ModelerDialog()
+            self.modelerDialog.finished.connect(self.finishedModeler)
+        self.modelerDialog.show()
+        self.modelerDialog.activateWindow()
+
+    def finishedModeler(self):
+        if self.modelerDialog.update:
             self.toolbox.updateProvider('model')
+        self.modelerDialog = None
 
     def openResults(self):
         dlg = ResultsDialog()

--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -217,11 +217,11 @@ class ModelerDialog(BASE, WIDGET):
                 QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
 
             if ret == QMessageBox.Yes:
-                evt.accept()
+                super(ModelerDialog, self).closeEvent(evt)
             else:
                 evt.ignore()
         else:
-            evt.accept()
+            super(ModelerDialog, self).closeEvent(evt)
 
     def editHelp(self):
         if self.alg.provider is None:

--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -213,7 +213,7 @@ class ModelerDialog(BASE, WIDGET):
         if self.hasChanged:
             ret = QMessageBox.question(
                 self, self.tr('Unsaved changes'),
-                self.tr('There are unsaved changes in model. Continue?'),
+                self.tr('There are unsaved changes in the model. Close it anyway?'),
                 QMessageBox.Yes | QMessageBox.No, QMessageBox.No)
 
             if ret == QMessageBox.Yes:
@@ -237,8 +237,8 @@ class ModelerDialog(BASE, WIDGET):
     def runModel(self):
         if len(self.alg.algs) == 0:
             QMessageBox.warning(self, self.tr('Empty model'),
-                                self.tr("Model doesn't contains any algorithms and/or "
-                                        "parameters and can't be executed"))
+                                self.tr("The model contains no algorithms and/or "
+                                        "parameters and can't be executed."))
             return
 
         if self.alg.provider is None:
@@ -294,13 +294,13 @@ class ModelerDialog(BASE, WIDGET):
         with codecs.open(filename, 'w', encoding='utf-8') as fout:
             fout.write(text)
         QMessageBox.information(self, self.tr('Model exported'),
-                                self.tr('Model was correctly exported.'))
+                                self.tr('The model was correctly exported.'))
 
     def saveModel(self, saveAs):
         if unicode(self.textGroup.text()).strip() == '' \
                 or unicode(self.textName.text()).strip() == '':
             QMessageBox.warning(
-                self, self.tr('Warning'), self.tr('Please enter group and model names before saving')
+                self, self.tr('Warning'), self.tr('Please enter group and model names before saving.')
             )
             return
         self.alg.name = unicode(self.textName.text())
@@ -335,7 +335,7 @@ class ModelerDialog(BASE, WIDGET):
             fout.close()
             self.update = True
             QMessageBox.information(self, self.tr('Model saved'),
-                                    self.tr('Model was correctly saved.'))
+                                    self.tr('The model was correctly saved.'))
 
             self.hasChanged = False
 


### PR DESCRIPTION
This PR shows the non-modal `ModelerDialog` without using `QDialog::exec()`, thereby avoiding unwanted side-effects like **opening multiple instances of the dialog**.
![qgismultipleprocessingmodelerdialogs](https://cloud.githubusercontent.com/assets/15147421/12538733/d0a8538e-c2e1-11e5-97cf-9facaa6d95be.PNG)

@m-kuhn, @alexbruy 
See the discussion at 51ec2bfba6cd5eeb4bf10588d8b94ee30e7faa4a.
