### PR TITLE
valgrind: fixed a few memory leaks and errors

### DIFF
--- a/src/core/qgsdataitemproviderregistry.cpp
+++ b/src/core/qgsdataitemproviderregistry.cpp
@@ -58,7 +58,7 @@ QgsDataItemProviderRegistry::QgsDataItemProviderRegistry()
 
   Q_FOREACH ( const QString& key, providersList )
   {
-    QLibrary *library = QgsProviderRegistry::instance()->providerLibrary( key );
+    QScopedPointer<QLibrary> library( QgsProviderRegistry::instance()->providerLibrary( key ) );
     if ( !library )
       continue;
 

--- a/src/core/qgssnappingutils.cpp
+++ b/src/core/qgssnappingutils.cpp
@@ -615,7 +615,7 @@ void QgsSnappingUtils::readConfigFromProject()
        layerIdList.size() != snapToList.size() )
     return;
 
-  if ( !snappingDefinedInProject )
+  if ( layerIdList.isEmpty() || !snappingDefinedInProject || !ok )
     return; // nothing defined in project - use current layer
 
   // Use snapping information from the project

--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -1976,6 +1976,9 @@ void QgsWmsCapabilitiesDownload::capabilitiesReplyFinished()
         }
         else
         {
+          mCapabilitiesReply->deleteLater();
+          mCapabilitiesReply = nullptr;
+
           QNetworkRequest request( toUrl );
           if ( !mAuth.setAuthorization( request ) )
           {
@@ -1987,9 +1990,6 @@ void QgsWmsCapabilitiesDownload::capabilitiesReplyFinished()
           }
           request.setAttribute( QNetworkRequest::CacheLoadControlAttribute, mForceRefresh ? QNetworkRequest::AlwaysNetwork : QNetworkRequest::PreferCache );
           request.setAttribute( QNetworkRequest::CacheSaveControlAttribute, true );
-
-          mCapabilitiesReply->deleteLater();
-          mCapabilitiesReply = nullptr;
 
           QgsDebugMsg( QString( "redirected getcapabilities: %1 forceRefresh=%2" ).arg( redirect.toString() ).arg( mForceRefresh ) );
           mCapabilitiesReply = QgsNetworkAccessManager::instance()->get( request );


### PR DESCRIPTION
The reply handling around QgsNetworkAccessManager is quite complex and
there was a few cases where the reply was not deleted.

In the WMS provider, the usage of QgsNetworkAccessManager was a bit weird.
It's not a good idea to create and delete it that often when there is a
singleton around.
