### PR TITLE
Add bound-checking QgsAbstractGeometry::fromWkb and WkbPtr

### DIFF
--- a/src/core/geometry/qgsabstractgeometryv2.h
+++ b/src/core/geometry/qgsabstractgeometryv2.h
@@ -112,9 +112,18 @@ class CORE_EXPORT QgsAbstractGeometryV2
     //import
 
     /** Sets the geometry from a WKB string.
+     * @deprecated, use the version taking a length
+     */
+    Q_DECL_DEPRECATED bool fromWkb( const unsigned char * wkb )
+    {
+      return fromWkb( wkb,
+                      std::numeric_limits<unsigned char *>::max() - wkb );
+    }
+
+    /** Sets the geometry from a WKB string.
      * @see fromWkt
      */
-    virtual bool fromWkb( const unsigned char * wkb ) = 0;
+    virtual bool fromWkb( const unsigned char * wkb, int length ) = 0;
 
     /** Sets the geometry from a WKT string.
      * @see fromWkb

--- a/src/core/geometry/qgscircularstringv2.cpp
+++ b/src/core/geometry/qgscircularstringv2.cpp
@@ -206,14 +206,14 @@ QList<QgsPointV2> QgsCircularStringV2::compassPointsOnSegment( double p1Angle, d
   return pointList;
 }
 
-bool QgsCircularStringV2::fromWkb( const unsigned char* wkb )
+bool QgsCircularStringV2::fromWkb( const unsigned char* wkb, int length )
 {
   if ( !wkb )
   {
     return false;
   }
 
-  QgsConstWkbPtr wkbPtr( wkb );
+  QgsConstWkbPtr wkbPtr( wkb, length );
   QgsWKBTypes::Type type = wkbPtr.readHeader();
   if ( QgsWKBTypes::flatType( type ) != QgsWKBTypes::CircularString )
   {
@@ -272,7 +272,7 @@ unsigned char* QgsCircularStringV2::asWkb( int& binarySize ) const
 {
   binarySize = wkbSize();
   unsigned char* geomPtr = new unsigned char[binarySize];
-  QgsWkbPtr wkb( geomPtr );
+  QgsWkbPtr wkb( geomPtr, binarySize );
   wkb << static_cast<char>( QgsApplication::endian() );
   wkb << static_cast<quint32>( wkbType() );
   QList<QgsPointV2> pts;

--- a/src/core/geometry/qgscircularstringv2.h
+++ b/src/core/geometry/qgscircularstringv2.h
@@ -43,7 +43,7 @@ class CORE_EXPORT QgsCircularStringV2: public QgsCurveV2
 
     virtual QgsRectangle calculateBoundingBox() const override;
 
-    virtual bool fromWkb( const unsigned char * wkb ) override;
+    virtual bool fromWkb( const unsigned char * wkb, int length ) override;
     virtual bool fromWkt( const QString& wkt ) override;
 
     int wkbSize() const override;

--- a/src/core/geometry/qgscompoundcurvev2.cpp
+++ b/src/core/geometry/qgscompoundcurvev2.cpp
@@ -98,7 +98,7 @@ QgsRectangle QgsCompoundCurveV2::calculateBoundingBox() const
   return bbox;
 }
 
-bool QgsCompoundCurveV2::fromWkb( const unsigned char* wkb )
+bool QgsCompoundCurveV2::fromWkb( const unsigned char* wkb, int length )
 {
   clear();
   if ( !wkb )
@@ -106,7 +106,7 @@ bool QgsCompoundCurveV2::fromWkb( const unsigned char* wkb )
     return false;
   }
 
-  QgsConstWkbPtr wkbPtr( wkb );
+  QgsConstWkbPtr wkbPtr( wkb, length );
   QgsWKBTypes::Type type = wkbPtr.readHeader();
   if ( QgsWKBTypes::flatType( type ) != QgsWKBTypes::CompoundCurve )
   {
@@ -136,7 +136,7 @@ bool QgsCompoundCurveV2::fromWkb( const unsigned char* wkb )
     {
       return false;
     }
-    currentCurve->fromWkb( wkbPtr );
+    currentCurve->fromWkb( wkbPtr, wkbPtr.bytesLeft() );
     currentCurveSize = currentCurve->wkbSize();
     mCurves.append( currentCurve );
     wkbPtr += currentCurveSize;
@@ -209,7 +209,7 @@ unsigned char* QgsCompoundCurveV2::asWkb( int& binarySize ) const
 {
   binarySize = wkbSize();
   unsigned char* geomPtr = new unsigned char[binarySize];
-  QgsWkbPtr wkb( geomPtr );
+  QgsWkbPtr wkb( geomPtr, binarySize );
   wkb << static_cast<char>( QgsApplication::endian() );
   wkb << static_cast<quint32>( wkbType() );
   wkb << static_cast<quint32>( mCurves.size() );

--- a/src/core/geometry/qgscompoundcurvev2.h
+++ b/src/core/geometry/qgscompoundcurvev2.h
@@ -44,7 +44,7 @@ class CORE_EXPORT QgsCompoundCurveV2: public QgsCurveV2
 
     virtual QgsRectangle calculateBoundingBox() const override;
 
-    virtual bool fromWkb( const unsigned char* wkb ) override;
+    virtual bool fromWkb( const unsigned char* wkb, int length ) override;
     virtual bool fromWkt( const QString& wkt ) override;
 
     int wkbSize() const override;

--- a/src/core/geometry/qgscurvepolygonv2.cpp
+++ b/src/core/geometry/qgscurvepolygonv2.cpp
@@ -82,14 +82,14 @@ void QgsCurvePolygonV2::clear()
 }
 
 
-bool QgsCurvePolygonV2::fromWkb( const unsigned char* wkb )
+bool QgsCurvePolygonV2::fromWkb( const unsigned char* wkb, int length )
 {
   clear();
   if ( !wkb )
   {
     return false;
   }
-  QgsConstWkbPtr wkbPtr( wkb );
+  QgsConstWkbPtr wkbPtr( wkb, length );
   QgsWKBTypes::Type type = wkbPtr.readHeader();
   if ( QgsWKBTypes::flatType( type ) != QgsWKBTypes::CurvePolygon )
   {
@@ -125,7 +125,7 @@ bool QgsCurvePolygonV2::fromWkb( const unsigned char* wkb )
     {
       return false;
     }
-    currentCurve->fromWkb( wkbPtr );
+    currentCurve->fromWkb( wkbPtr, wkbPtr.bytesLeft() );
     currentCurveSize = currentCurve->wkbSize();
     if ( i == 0 )
     {
@@ -233,7 +233,7 @@ unsigned char* QgsCurvePolygonV2::asWkb( int& binarySize ) const
 {
   binarySize = wkbSize();
   unsigned char* geomPtr = new unsigned char[binarySize];
-  QgsWkbPtr wkb( geomPtr );
+  QgsWkbPtr wkb( geomPtr, binarySize );
   wkb << static_cast<char>( QgsApplication::endian() );
   wkb << static_cast<quint32>( wkbType() );
   wkb << static_cast<quint32>(( nullptr != mExteriorRing ) + mInteriorRings.size() );

--- a/src/core/geometry/qgscurvepolygonv2.h
+++ b/src/core/geometry/qgscurvepolygonv2.h
@@ -43,7 +43,7 @@ class CORE_EXPORT QgsCurvePolygonV2: public QgsSurfaceV2
 
 
     virtual QgsRectangle calculateBoundingBox() const override;
-    virtual bool fromWkb( const unsigned char* wkb ) override;
+    virtual bool fromWkb( const unsigned char* wkb, int length ) override;
     virtual bool fromWkt( const QString& wkt ) override;
 
     int wkbSize() const override;

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -235,8 +235,6 @@ QgsGeometry* QgsGeometry::fromRect( const QgsRectangle& rect )
 
 void QgsGeometry::fromWkb( unsigned char *wkb, int length )
 {
-  Q_UNUSED( length );
-
   detach( false );
 
   if ( d->geometry )
@@ -244,7 +242,7 @@ void QgsGeometry::fromWkb( unsigned char *wkb, int length )
     delete d->geometry;
     removeWkbGeos();
   }
-  d->geometry = QgsGeometryFactory::geomFromWkb( wkb );
+  d->geometry = QgsGeometryFactory::geomFromWkb( wkb, length );
   d->mWkb = wkb;
   d->mWkbSize = length;
 }

--- a/src/core/geometry/qgsgeometrycollectionv2.cpp
+++ b/src/core/geometry/qgsgeometrycollectionv2.cpp
@@ -179,13 +179,13 @@ void QgsGeometryCollectionV2::draw( QPainter& p ) const
   }
 }
 
-bool QgsGeometryCollectionV2::fromWkb( const unsigned char * wkb )
+bool QgsGeometryCollectionV2::fromWkb( const unsigned char * wkb, int length )
 {
   if ( !wkb )
   {
     return false;
   }
-  QgsConstWkbPtr wkbPtr( wkb + 1 );
+  QgsConstWkbPtr wkbPtr( wkb + 1, length - 1 );
   //type
   wkbPtr >> mWkbType;
   int nGeometries = 0;
@@ -194,7 +194,7 @@ bool QgsGeometryCollectionV2::fromWkb( const unsigned char * wkb )
   QList<QgsAbstractGeometryV2*> geometryList;
   for ( int i = 0; i < nGeometries; ++i )
   {
-    QgsAbstractGeometryV2* geom = QgsGeometryFactory::geomFromWkb( wkbPtr );
+    QgsAbstractGeometryV2* geom = QgsGeometryFactory::geomFromWkb( wkbPtr, wkbPtr.bytesLeft() );
     if ( geom )
     {
       geometryList.append( geom );
@@ -237,7 +237,7 @@ unsigned char* QgsGeometryCollectionV2::asWkb( int& binarySize ) const
 {
   binarySize = wkbSize();
   unsigned char* geomPtr = new unsigned char[binarySize];
-  QgsWkbPtr wkb( geomPtr );
+  QgsWkbPtr wkb( geomPtr, binarySize );
   wkb << static_cast<char>( QgsApplication::endian() );
   wkb << static_cast<quint32>( wkbType() );
   wkb << static_cast<quint32>( mGeometries.size() );

--- a/src/core/geometry/qgsgeometrycollectionv2.h
+++ b/src/core/geometry/qgsgeometrycollectionv2.h
@@ -81,7 +81,7 @@ class CORE_EXPORT QgsGeometryCollectionV2: public QgsAbstractGeometryV2
 #endif
     virtual void draw( QPainter& p ) const override;
 
-    bool fromWkb( const unsigned char * wkb ) override;
+    bool fromWkb( const unsigned char * wkb, int length ) override;
     virtual bool fromWkt( const QString& wkt ) override;
     int wkbSize() const override;
     unsigned char* asWkb( int& binarySize ) const override;

--- a/src/core/geometry/qgsgeometryfactory.cpp
+++ b/src/core/geometry/qgsgeometryfactory.cpp
@@ -29,7 +29,7 @@
 #include "qgsmultisurfacev2.h"
 #include "qgswkbtypes.h"
 
-QgsAbstractGeometryV2* QgsGeometryFactory::geomFromWkb( const unsigned char* wkb )
+QgsAbstractGeometryV2* QgsGeometryFactory::geomFromWkb( const unsigned char* wkb, int length )
 {
   if ( !wkb )
   {
@@ -45,7 +45,7 @@ QgsAbstractGeometryV2* QgsGeometryFactory::geomFromWkb( const unsigned char* wkb
 
   if ( geom )
   {
-    geom->fromWkb( wkb );
+    geom->fromWkb( wkb, length );
   }
   return geom;
 }

--- a/src/core/geometry/qgsgeometryfactory.h
+++ b/src/core/geometry/qgsgeometryfactory.h
@@ -45,7 +45,7 @@ class CORE_EXPORT QgsGeometryFactory
   public:
     /** Construct geometry from a WKB string.
      */
-    static QgsAbstractGeometryV2* geomFromWkb( const unsigned char* wkb );
+    static QgsAbstractGeometryV2* geomFromWkb( const unsigned char* wkb, int length );
 
     /** Construct geometry from a WKT string.
      */

--- a/src/core/geometry/qgslinestringv2.cpp
+++ b/src/core/geometry/qgslinestringv2.cpp
@@ -89,13 +89,13 @@ void QgsLineStringV2::clear()
   mBoundingBox = QgsRectangle();
 }
 
-bool QgsLineStringV2::fromWkb( const unsigned char* wkb )
+bool QgsLineStringV2::fromWkb( const unsigned char* wkb, int length )
 {
   if ( !wkb )
   {
     return false;
   }
-  QgsConstWkbPtr wkbPtr( wkb );
+  QgsConstWkbPtr wkbPtr( wkb, length );
   QgsWKBTypes::Type type = wkbPtr.readHeader();
   if ( QgsWKBTypes::flatType( type ) != QgsWKBTypes::LineString )
   {
@@ -143,7 +143,7 @@ unsigned char* QgsLineStringV2::asWkb( int& binarySize ) const
 {
   binarySize = wkbSize();
   unsigned char* geomPtr = new unsigned char[binarySize];
-  QgsWkbPtr wkb( geomPtr );
+  QgsWkbPtr wkb( geomPtr, binarySize );
   wkb << static_cast<char>( QgsApplication::endian() );
   wkb << static_cast<quint32>( wkbType() );
   QList<QgsPointV2> pts;

--- a/src/core/geometry/qgslinestringv2.h
+++ b/src/core/geometry/qgslinestringv2.h
@@ -139,7 +139,7 @@ class CORE_EXPORT QgsLineStringV2: public QgsCurveV2
     virtual QgsLineStringV2* clone() const override;
     virtual void clear() override;
 
-    virtual bool fromWkb( const unsigned char* wkb ) override;
+    virtual bool fromWkb( const unsigned char* wkb, int length ) override;
     virtual bool fromWkt( const QString& wkt ) override;
 
     int wkbSize() const override;

--- a/src/core/geometry/qgspointv2.cpp
+++ b/src/core/geometry/qgspointv2.cpp
@@ -96,9 +96,9 @@ QgsPointV2 *QgsPointV2::clone() const
   return new QgsPointV2( *this );
 }
 
-bool QgsPointV2::fromWkb( const unsigned char* wkb )
+bool QgsPointV2::fromWkb( const unsigned char* wkb, int length )
 {
-  QgsConstWkbPtr wkbPtr( wkb );
+  QgsConstWkbPtr wkbPtr( wkb, length );
   QgsWKBTypes::Type type = wkbPtr.readHeader();
   if ( QgsWKBTypes::flatType( type ) != QgsWKBTypes::Point )
   {
@@ -183,7 +183,7 @@ unsigned char* QgsPointV2::asWkb( int& binarySize ) const
 {
   binarySize = wkbSize();
   unsigned char* geomPtr = new unsigned char[binarySize];
-  QgsWkbPtr wkb( geomPtr );
+  QgsWkbPtr wkb( geomPtr, binarySize );
   wkb << static_cast<char>( QgsApplication::endian() );
   wkb << static_cast<quint32>( wkbType() );
   wkb << mX << mY;

--- a/src/core/geometry/qgspointv2.h
+++ b/src/core/geometry/qgspointv2.h
@@ -155,7 +155,7 @@ class CORE_EXPORT QgsPointV2: public QgsAbstractGeometryV2
     virtual int dimension() const override { return 0; }
     virtual QgsPointV2* clone() const override;
     void clear() override;
-    virtual bool fromWkb( const unsigned char* wkb ) override;
+    virtual bool fromWkb( const unsigned char* wkb, int length ) override;
     virtual bool fromWkt( const QString& wkt ) override;
     int wkbSize() const override;
     unsigned char* asWkb( int& binarySize ) const override;

--- a/src/core/geometry/qgspolygonv2.cpp
+++ b/src/core/geometry/qgspolygonv2.cpp
@@ -69,7 +69,7 @@ QgsPolygonV2* QgsPolygonV2::clone() const
   return new QgsPolygonV2( *this );
 }
 
-bool QgsPolygonV2::fromWkb( const unsigned char* wkb )
+bool QgsPolygonV2::fromWkb( const unsigned char* wkb, int length )
 {
   clear();
   if ( !wkb )
@@ -77,7 +77,7 @@ bool QgsPolygonV2::fromWkb( const unsigned char* wkb )
     return false;
   }
 
-  QgsConstWkbPtr wkbPtr( wkb );
+  QgsConstWkbPtr wkbPtr( wkb, length );
   QgsWKBTypes::Type type = wkbPtr.readHeader();
   if ( QgsWKBTypes::flatType( type ) != QgsWKBTypes::Polygon )
   {
@@ -149,7 +149,7 @@ unsigned char* QgsPolygonV2::asWkb( int& binarySize ) const
 {
   binarySize = wkbSize();
   unsigned char* geomPtr = new unsigned char[binarySize];
-  QgsWkbPtr wkb( geomPtr );
+  QgsWkbPtr wkb( geomPtr, binarySize );
   wkb << static_cast<char>( QgsApplication::endian() );
   wkb << static_cast<quint32>( wkbType() );
   wkb << static_cast<quint32>(( nullptr != mExteriorRing ) + mInteriorRings.size() );

--- a/src/core/geometry/qgspolygonv2.h
+++ b/src/core/geometry/qgspolygonv2.h
@@ -37,7 +37,7 @@ class CORE_EXPORT QgsPolygonV2: public QgsCurvePolygonV2
     virtual QString geometryType() const override { return "Polygon"; }
     virtual QgsPolygonV2* clone() const override;
 
-    virtual bool fromWkb( const unsigned char* wkb ) override;
+    virtual bool fromWkb( const unsigned char* wkb, int length ) override;
 
     int wkbSize() const override;
     unsigned char* asWkb( int& binarySize ) const override;

--- a/src/core/geometry/qgswkbptr.cpp
+++ b/src/core/geometry/qgswkbptr.cpp
@@ -14,9 +14,17 @@
  ***************************************************************************/
 #include "qgswkbptr.h"
 
+// @deprecated
 QgsConstWkbPtr::QgsConstWkbPtr( const unsigned char *p ): mEndianSwap( false )
 {
   mP = const_cast< unsigned char * >( p );
+  mE = std::numeric_limits<unsigned char *>::max();
+}
+
+QgsConstWkbPtr::QgsConstWkbPtr( const unsigned char *p, unsigned int l ): mEndianSwap( false )
+{
+  mP = const_cast< unsigned char * >( p );
+  mE = mP + l;
 }
 
 QgsWKBTypes::Type QgsConstWkbPtr::readHeader() const

--- a/src/core/qgsdistancearea.cpp
+++ b/src/core/qgsdistancearea.cpp
@@ -529,7 +529,8 @@ double QgsDistanceArea::measureLine( const QgsPoint& p1, const QgsPoint& p2, QGi
 }
 
 
-const unsigned char *QgsDistanceArea::measurePolygon( const unsigned char* feature, double* area, double* perimeter, bool hasZptr ) const
+const unsigned char *
+QgsDistanceArea::measurePolygon( const unsigned char* feature, double* area, double* perimeter, bool hasZptr ) const
 {
   if ( !feature )
   {

--- a/src/core/qgspointlocator.cpp
+++ b/src/core/qgspointlocator.cpp
@@ -313,7 +313,7 @@ static QgsPointLocator::MatchList _geometrySegmentsInRect( QgsGeometry* geom, co
 
   _CohenSutherland cs( rect );
 
-  QgsWkbPtr wkbPtr( wkb + 1 );
+  QgsWkbPtr wkbPtr( wkb + 1, geom->wkbSize() - 1 );
   QGis::WkbType wkbType;
   wkbPtr >> wkbType;
 


### PR DESCRIPTION
Keeps old methods as deprecated.
This is unfinished.

The aim is fixing the test in #2722 with the new code.

Current problem is with adding the deprecated wrappers: trying to avoid to duplicate the wrapper in all levels of the inheritance hierarchy but SIP seems to be not happy with that:

```
/usr/src/qgis/build/master/python/core/sip_corepart0.cpp:34066:40: error: no matching function for call to ‘sipQgsPolygonV2::fromWkb(const unsigned char*&)’
```

Do I just have to re-generate sip bindings ?
