### PR TITLE
Fix floating point inaccuracies when digitizing (to fix bug #13745)

### DIFF
--- a/python/gui/qgsmapmouseevent.sip
+++ b/python/gui/qgsmapmouseevent.sip
@@ -79,6 +79,13 @@ class QgsMapMouseEvent : QMouseEvent
     QgsPoint mapPoint() const;
 
     /**
+      * Returns the matching data from the most recently snapped point.
+      * @return the snapping data structure
+      * @note added in 2.14
+      */
+    QgsPointLocator::Match mapPointMatch() const;
+
+    /**
      * Set the (snapped) point this event points to in map coordinates.
      * The point in pixel coordinates will be calculated accordingly.
      *

--- a/python/gui/qgsmaptoolcapture.sip
+++ b/python/gui/qgsmaptoolcapture.sip
@@ -112,9 +112,21 @@ class QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
     */
     int nextPoint( QPoint p, QgsPointV2 &layerPoint, QgsPointV2 &mapPoint );
 
+    /** Fetches the original point from the source layer if it has the same
+     * CRS as the current layer.
+     * @return 0 in case of success, 1 if not applicable (CRS mismatch), 2 in case of failure
+     * @note added in 2.14 */
+    int fetchLayerPoint( QgsPointLocator::Match match, QgsPointV2& layerPoint );
+
     /** Adds a point to the rubber band (in map coordinates) and to the capture list (in layer coordinates)
      @return 0 in case of success, 1 if current layer is not a vector layer, 2 if coordinate transformation failed*/
     int addVertex( const QgsPoint& point );
+
+    /** Variant to supply more information in the case of snapping
+     @param mapPoint The vertex to add in map coordinates
+     @param match Data about the snapping match. Can be an invalid match, if point not snapped.
+     @note added in 2.14 */
+    int addVertex( const QgsPoint& mapPoint, QgsPointLocator::Match match );
 
     /** Removes the last vertex from mRubberBand and mCaptureList*/
     void undo();

--- a/src/app/qgsmaptooladdfeature.cpp
+++ b/src/app/qgsmaptooladdfeature.cpp
@@ -113,7 +113,17 @@ void QgsMapToolAddFeature::cadCanvasReleaseEvent( QgsMapMouseEvent* e )
     QgsPoint savePoint; //point in layer coordinates
     try
     {
-      savePoint = toLayerCoordinates( vlayer, e->mapPoint() );
+      QgsPointV2 fetchPoint;
+      int res;
+      res = fetchLayerPoint( e->mapPointMatch(), fetchPoint );
+      if ( res == 0 )
+      {
+        savePoint = QgsPoint( fetchPoint.x(), fetchPoint.y() );
+      }
+      else
+      {
+        savePoint = toLayerCoordinates( vlayer, e->mapPoint() );
+      }
       QgsDebugMsg( "savePoint = " + savePoint.toString() );
     }
     catch ( QgsCsException &cse )
@@ -184,7 +194,7 @@ void QgsMapToolAddFeature::cadCanvasReleaseEvent( QgsMapMouseEvent* e )
     //add point to list and to rubber band
     if ( e->button() == Qt::LeftButton )
     {
-      int error = addVertex( e->mapPoint() );
+      int error = addVertex( e->mapPoint(), e->mapPointMatch() );
       if ( error == 1 )
       {
         //current layer is not a vector layer

--- a/src/app/qgsmaptooladdpart.cpp
+++ b/src/app/qgsmaptooladdpart.cpp
@@ -95,7 +95,7 @@ void QgsMapToolAddPart::cadCanvasReleaseEvent( QgsMapMouseEvent * e )
       //add point to list and to rubber band
       if ( e->button() == Qt::LeftButton )
       {
-        int error = addVertex( e->mapPoint() );
+        int error = addVertex( e->mapPoint(), e->mapPointMatch() );
         if ( error == 1 )
         {
           QgsDebugMsg( "current layer is not a vector layer" );

--- a/src/app/qgsmaptooladdring.cpp
+++ b/src/app/qgsmaptooladdring.cpp
@@ -58,7 +58,7 @@ void QgsMapToolAddRing::cadCanvasReleaseEvent( QgsMapMouseEvent * e )
   //add point to list and to rubber band
   if ( e->button() == Qt::LeftButton )
   {
-    int error = addVertex( e->mapPoint() );
+    int error = addVertex( e->mapPoint(), e->mapPointMatch() );
     if ( error == 1 )
     {
       //current layer is not a vector layer

--- a/src/app/qgsmaptoolreshape.cpp
+++ b/src/app/qgsmaptoolreshape.cpp
@@ -50,7 +50,7 @@ void QgsMapToolReshape::cadCanvasReleaseEvent( QgsMapMouseEvent * e )
   //add point to list and to rubber band
   if ( e->button() == Qt::LeftButton )
   {
-    int error = addVertex( e->mapPoint() );
+    int error = addVertex( e->mapPoint(), e->mapPointMatch() );
     if ( error == 1 )
     {
       //current layer is not a vector layer

--- a/src/app/qgsmaptoolsplitfeatures.cpp
+++ b/src/app/qgsmaptoolsplitfeatures.cpp
@@ -67,7 +67,7 @@ void QgsMapToolSplitFeatures::cadCanvasReleaseEvent( QgsMapMouseEvent * e )
       }
     }
 
-    int error = addVertex( e->mapPoint() );
+    int error = addVertex( e->mapPoint(), e->mapPointMatch() );
     if ( error == 1 )
     {
       //current layer is not a vector layer

--- a/src/gui/qgsmapmouseevent.h
+++ b/src/gui/qgsmapmouseevent.h
@@ -94,6 +94,13 @@ class GUI_EXPORT QgsMapMouseEvent : public QMouseEvent
     inline QgsPoint mapPoint() const { return mMapPoint; }
 
     /**
+      * Returns the matching data from the most recently snapped point.
+      * @return the snapping data structure
+      * @note added in 2.14
+      */
+    QgsPointLocator::Match mapPointMatch() const { return mSnapMatch; }
+
+    /**
      * Set the (snapped) point this event points to in map coordinates.
      * The point in pixel coordinates will be calculated accordingly.
      *

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -367,7 +367,41 @@ int QgsMapToolCapture::nextPoint( QPoint p, QgsPoint &layerPoint, QgsPoint &mapP
   Q_NOWARN_DEPRECATED_POP
 }
 
+int QgsMapToolCapture::fetchLayerPoint( QgsPointLocator::Match match , QgsPointV2 &layerPoint )
+{
+  QgsVectorLayer* vlayer = qobject_cast<QgsVectorLayer *>( mCanvas->currentLayer() );
+  QgsVectorLayer* sourceLayer = match.layer();
+  if ( match.isValid() && match.hasVertex() && sourceLayer &&
+       ( sourceLayer->crs() == vlayer->crs() ) )
+  {
+    QgsFeature f;
+    QgsFeatureRequest request;
+    QgsPoint foundPoint;
+    request.setFilterFid( match.featureId() );
+    bool fetched = match.layer()->getFeatures( request ).nextFeature( f );
+    if ( fetched )
+    {
+      foundPoint = f.geometry()->vertexAt( match.vertexIndex() );
+      layerPoint = QgsPointV2( foundPoint.x(), foundPoint.y() );
+      return 0;
+    }
+    else
+    {
+      return 2;
+    }
+  }
+  else
+  {
+    return 1;
+  }
+}
+
 int QgsMapToolCapture::addVertex( const QgsPoint& point )
+{
+  return addVertex( point, QgsPointLocator::Match() );
+}
+
+int QgsMapToolCapture::addVertex( const QgsPoint& point, QgsPointLocator::Match match )
 {
   if ( mode() == CaptureNone )
   {
@@ -377,10 +411,14 @@ int QgsMapToolCapture::addVertex( const QgsPoint& point )
 
   int res;
   QgsPointV2 layerPoint;
-  res = nextPoint( QgsPointV2( point ), layerPoint );
+  res = fetchLayerPoint( match, layerPoint );
   if ( res != 0 )
   {
-    return res;
+    res = nextPoint( QgsPointV2( point ), layerPoint );
+    if ( res != 0 )
+    {
+      return res;
+    }
   }
 
   if ( !mRubberBand )

--- a/src/gui/qgsmaptoolcapture.h
+++ b/src/gui/qgsmaptoolcapture.h
@@ -22,6 +22,7 @@
 #include "qgspoint.h"
 #include "qgsgeometry.h"
 #include "qgslayertreeview.h"
+#include "qgspointlocator.h"
 
 #include <QPoint>
 #include <QList>
@@ -132,9 +133,21 @@ class GUI_EXPORT QgsMapToolCapture : public QgsMapToolAdvancedDigitizing
     */
     int nextPoint( QPoint p, QgsPointV2 &layerPoint, QgsPointV2 &mapPoint );
 
+    /** Fetches the original point from the source layer if it has the same
+     * CRS as the current layer.
+     * @return 0 in case of success, 1 if not applicable (CRS mismatch), 2 in case of failure
+     * @note added in 2.14 */
+    int fetchLayerPoint( QgsPointLocator::Match match, QgsPointV2& layerPoint );
+
     /** Adds a point to the rubber band (in map coordinates) and to the capture list (in layer coordinates)
      @return 0 in case of success, 1 if current layer is not a vector layer, 2 if coordinate transformation failed*/
     int addVertex( const QgsPoint& point );
+
+    /** Variant to supply more information in the case of snapping
+     @param mapPoint The vertex to add in map coordinates
+     @param match Data about the snapping match. Can be an invalid match, if point not snapped.
+     @note added in 2.14 */
+    int addVertex( const QgsPoint& mapPoint, QgsPointLocator::Match match );
 
     /** Removes the last vertex from mRubberBand and mCaptureList*/
     void undo();


### PR DESCRIPTION
Second try after #2434.

~~By putting the code in QgsMapToolCapture::nextPoint(), both the snapping function and the tracing function benefit from it.~~

I make this PR now so that anyone can take a look already (and @wonder-sk, so that you can see whether I understood your suggestion correctly), but it is not yet finished. For example:
- ~~Unit test?~~
- [x] Code for adding single points
- ~~Tracer~~
