### PR TITLE
[processing] add date, datetime, time fields to memory output

### DIFF
--- a/python/plugins/processing/tools/vector.py
+++ b/python/plugins/processing/tools/vector.py
@@ -67,7 +67,10 @@ TYPE_MAP = {
 TYPE_MAP_MEMORY_LAYER = {
     QVariant.String: "string",
     QVariant.Double: "double",
-    QVariant.Int: "integer"
+    QVariant.Int: "integer",
+    QVariant.Date: "date",
+    QVariant.DateTime: "datetime",
+    QVariant.Time: "time"
 }
 
 TYPE_MAP_POSTGIS_LAYER = {


### PR DESCRIPTION
This PR adds date ,datetime, and time field support to the memory vector writer.

@alexbruy , this fixes the issue I filed a few days ago  (http://hub.qgis.org/issues/14163). 

@nyalldawson , I don't have a postgis environment setup on my machine, so couldn't add the postgresql-specific field mapping.
