### PR TITLE
add parameter to GRASS 64/70 r.slope.aspect to allow use region resolution

### DIFF
--- a/python/plugins/processing/algs/grass/description/r.aspect.txt
+++ b/python/plugins/processing/algs/grass/description/r.aspect.txt
@@ -3,6 +3,7 @@ r.aspect - Generates raster maps of aspect from a elevation raster map.
 Raster (r.*)
 ParameterRaster|elevation|Elevation|False
 ParameterSelection|prec|Data type|float;double;int
+ParameterBoolean|-a|Do not align the current region to the elevation layer|True
 ParameterNumber|zfactor|Multiplicative factor to convert elevation units to meters|None|None|1.0
 ParameterNumber|min_slp_allowed|Minimum slope val. (in percent) for which aspect is computed|None|None|0.0
 OutputRaster|aspect|Aspect

--- a/python/plugins/processing/algs/grass/description/r.slope.aspect.txt
+++ b/python/plugins/processing/algs/grass/description/r.slope.aspect.txt
@@ -4,6 +4,7 @@ Raster (r.*)
 ParameterRaster|elevation|Elevation|False
 ParameterSelection|format|Format for reporting the slope|degrees;percent
 ParameterSelection|prec|Type of output aspect and slope layer|float;double;int
+ParameterBoolean|-a|Do not align the current region to the elevation layer|True
 ParameterNumber|zfactor|Multiplicative factor to convert elevation units to meters|None|None|1.0
 ParameterNumber|min_slp_allowed|Minimum slope val. (in percent) for which aspect is computed|None|None|0.0
 OutputRaster|slope|Slope

--- a/python/plugins/processing/algs/grass/description/r.slope.txt
+++ b/python/plugins/processing/algs/grass/description/r.slope.txt
@@ -4,6 +4,7 @@ Raster (r.*)
 ParameterRaster|elevation|Name of elevation raster map|False
 ParameterSelection|format|Format for reporting the slope|degrees;percent
 ParameterSelection|prec|Type of output aspect and slope maps|float;double;int
+ParameterBoolean|-a|Do not align the current region to the elevation layer|True
 ParameterNumber|zfactor|Multiplicative factor to convert elevation units to meters|None|None|1.0
 ParameterNumber|min_slp_allowed|Minimum slope val. (in percent) for which aspect is computed|None|None|0.0
 ParameterBoolean|-a|Do not align the current region to the elevation layer|True

--- a/python/plugins/processing/algs/grass7/description/r.aspect.txt
+++ b/python/plugins/processing/algs/grass7/description/r.aspect.txt
@@ -2,7 +2,8 @@ r.slope.aspect
 r.aspect - Generates raster maps of aspect from a elevation raster map.
 Raster (r.*)
 ParameterRaster|elevation|Elevation|False
-ParameterSelection|precision|Data type|CELL;FCELL;DCELL
+ParameterSelection|precision|Data type|FCELL;CELL;DCELL
+ParameterBoolean|-a|Do not align the current region to the elevation layer|True
 ParameterNumber|zfactor|Multiplicative factor to convert elevation units to meters|None|None|1.0
 ParameterNumber|min_slope|Minimum slope val. (in percent) for which aspect is computed|None|None|0.0
 OutputRaster|aspect|Aspect

--- a/python/plugins/processing/algs/grass7/description/r.slope.aspect.txt
+++ b/python/plugins/processing/algs/grass7/description/r.slope.aspect.txt
@@ -3,7 +3,8 @@ Generates raster layers of slope, aspect, curvatures and partial derivatives fro
 Raster (r.*)
 ParameterRaster|elevation|Elevation|False
 ParameterSelection|format|Format for reporting the slope|degrees;percent
-ParameterSelection|precision|Type of output aspect and slope layer|CELL;FCELL;DCELL
+ParameterSelection|precision|Type of output aspect and slope layer|FCELL;CELL;DCELL
+ParameterBoolean|-a|Do not align the current region to the elevation layer|True
 ParameterNumber|zscale|Multiplicative factor to convert elevation units to meters|None|None|1.0
 ParameterNumber|min_slope|Minimum slope val. (in percent) for which aspect is computed|None|None|0.0
 OutputRaster|slope|Slope

--- a/python/plugins/processing/algs/grass7/description/r.slope.txt
+++ b/python/plugins/processing/algs/grass7/description/r.slope.txt
@@ -2,7 +2,8 @@ r.slope.aspect
 r.slope - Generates raster maps of slope from a elevation raster map.
 Raster (r.*)
 ParameterRaster|elevation|Elevation|False
-ParameterSelection|precision|Data type|CELL;FCELL;DCELL
+ParameterSelection|precision|Data type|FCELL;CELL;DCELL
+ParameterBoolean|-a|Do not align the current region to the elevation layer|True
 ParameterNumber|zfactor|Multiplicative factor to convert elevation units to meters|None|None|1.0
 ParameterNumber|min_slope|Minimum slope val. (in percent) for which aspect is computed|None|None|0.0
 OutputRaster|slope|Slope


### PR DESCRIPTION
from GRASS man pages for r.slope.aspect

"To ensure that the raster elevation map layer is not inappropriately resampled, the settings for the current region are modified slightly (for the execution of the program only): the resolution is set to match the resolution of the elevation map and the edges of the region (i.e. the north, south, east and west) are shifted, if necessary, to line up along edges of the nearest cells in the elevation map. If the user really wants the elevation map resampled to the current region resolution, the -a flag should be specified. "

This PR adds also a better output type for GRASS7.
