### PR TITLE
Fix handling of units for projects, measurement, areas (WIP)

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -125,6 +125,7 @@
 #include "qgsstatusbarcoordinateswidget.h"
 #include "qgsconfigureshortcutsdialog.h"
 #include "qgscoordinatetransform.h"
+#include "qgscoordinateutils.h"
 #include "qgscredentialdialog.h"
 #include "qgscursors.h"
 #include "qgscustomization.h"
@@ -9607,31 +9608,7 @@ void QgisApp::showRotation()
 
 void QgisApp::updateMouseCoordinatePrecision()
 {
-  // Work out what mouse display precision to use. This only needs to
-  // be when the settings change or the zoom level changes. This
-  // function needs to be called every time one of the above happens.
-
-  // Get the display precision from the project settings
-  bool automatic = QgsProject::instance()->readBoolEntry( "PositionPrecision", "/Automatic" );
-  int dp = 0;
-
-  if ( automatic )
-  {
-    // Work out a suitable number of decimal places for the mouse
-    // coordinates with the aim of always having enough decimal places
-    // to show the difference in position between adjacent pixels.
-    // Also avoid taking the log of 0.
-    if ( mapCanvas()->mapUnitsPerPixel() != 0.0 )
-      dp = static_cast<int>( ceil( -1.0 * log10( mapCanvas()->mapUnitsPerPixel() ) ) );
-  }
-  else
-    dp = QgsProject::instance()->readNumEntry( "PositionPrecision", "/DecimalPlaces" );
-
-  // Keep dp sensible
-  if ( dp < 0 )
-    dp = 0;
-
-  mCoordsEdit->setMouseCoordinatesPrecision( dp );
+  mCoordsEdit->setMouseCoordinatesPrecision( QgsCoordinateUtils::calculateCoordinatePrecision( mapCanvas()->mapUnitsPerPixel() ) );
 }
 
 void QgisApp::showStatusMessage( const QString& theMessage )

--- a/src/app/qgsprojectproperties.h
+++ b/src/app/qgsprojectproperties.h
@@ -156,7 +156,7 @@ class APP_EXPORT QgsProjectProperties : public QgsOptionsDialogBase, private Ui:
     /*!
       * If user changes the CRS, set the corresponding map units
       */
-    void setMapUnitsToCurrentProjection();
+    void srIdUpdated();
 
     /* Update ComboBox accorindg to the selected new index
      * Also sets the new selected Ellipsoid. */
@@ -180,6 +180,16 @@ class APP_EXPORT QgsProjectProperties : public QgsOptionsDialogBase, private Ui:
     void refresh();
 
   private:
+
+    //! Formats for displaying coordinates
+    enum CoordinateFormat
+    {
+      DecimalDegrees, /*!< Decimal degrees */
+      DegreesMinutes, /*!< Degrees, decimal minutes */
+      DegreesMinutesSeconds, /*!< Degrees, minutes, seconds */
+      MapUnits, /*! Show coordinates in map units */
+    };
+
     QgsRelationManagerDialog *mRelationManagerDlg;
     QgsMapCanvas* mMapCanvas;
     QgsStyleV2* mStyle;
@@ -230,4 +240,5 @@ class APP_EXPORT QgsProjectProperties : public QgsOptionsDialogBase, private Ui:
 
     static const char * GEO_NONE_DESC;
 
+    void updateGuiForMapUnits( QGis::UnitType units );
 };

--- a/src/app/qgsstatusbarcoordinateswidget.cpp
+++ b/src/app/qgsstatusbarcoordinateswidget.cpp
@@ -225,18 +225,19 @@ void QgsStatusBarCoordinatesWidget::showMouseCoordinates( const QgsPoint & p )
     return;
   }
 
-  if ( mMapCanvas->mapUnits() == QGis::Degrees )
-  {
-    if ( !mMapCanvas->mapSettings().destinationCrs().isValid() )
-      return;
+  QString format = QgsProject::instance()->readEntry( "PositionPrecision", "/DegreeFormat", "D" );
 
-    QgsPoint geo = p;
-    if ( !mMapCanvas->mapSettings().destinationCrs().geographicFlag() )
+  QgsPoint geo = p;
+  if ( format == "DM" || format == "DMS" || format == "D" )
+  {
+    // degrees
+    if ( mMapCanvas->mapSettings().destinationCrs().isValid()
+         && !mMapCanvas->mapSettings().destinationCrs().geographicFlag() )
     {
+      // need to transform to geographic coordinates
       QgsCoordinateTransform ct( mMapCanvas->mapSettings().destinationCrs(), QgsCoordinateReferenceSystem( GEOSRID ) );
       geo = ct.transform( p );
     }
-    QString format = QgsProject::instance()->readEntry( "PositionPrecision", "/DegreeFormat", "D" );
 
     if ( format == "DM" )
       mLineEdit->setText( geo.toDegreesMinutes( mMousePrecisionDecimalPlaces ) );
@@ -247,6 +248,7 @@ void QgsStatusBarCoordinatesWidget::showMouseCoordinates( const QgsPoint & p )
   }
   else
   {
+    // coordinates in map units
     mLineEdit->setText( p.toString( mMousePrecisionDecimalPlaces ) );
   }
 

--- a/src/app/qgsstatusbarcoordinateswidget.cpp
+++ b/src/app/qgsstatusbarcoordinateswidget.cpp
@@ -26,6 +26,7 @@
 #include "qgsapplication.h"
 #include "qgsmapcanvas.h"
 #include "qgsproject.h"
+#include "qgscoordinateutils.h"
 
 
 QgsStatusBarCoordinatesWidget::QgsStatusBarCoordinatesWidget( QWidget *parent )
@@ -225,32 +226,8 @@ void QgsStatusBarCoordinatesWidget::showMouseCoordinates( const QgsPoint & p )
     return;
   }
 
-  QString format = QgsProject::instance()->readEntry( "PositionPrecision", "/DegreeFormat", "D" );
-
-  QgsPoint geo = p;
-  if ( format == "DM" || format == "DMS" || format == "D" )
-  {
-    // degrees
-    if ( mMapCanvas->mapSettings().destinationCrs().isValid()
-         && !mMapCanvas->mapSettings().destinationCrs().geographicFlag() )
-    {
-      // need to transform to geographic coordinates
-      QgsCoordinateTransform ct( mMapCanvas->mapSettings().destinationCrs(), QgsCoordinateReferenceSystem( GEOSRID ) );
-      geo = ct.transform( p );
-    }
-
-    if ( format == "DM" )
-      mLineEdit->setText( geo.toDegreesMinutes( mMousePrecisionDecimalPlaces ) );
-    else if ( format == "DMS" )
-      mLineEdit->setText( geo.toDegreesMinutesSeconds( mMousePrecisionDecimalPlaces ) );
-    else
-      mLineEdit->setText( geo.toString( mMousePrecisionDecimalPlaces ) );
-  }
-  else
-  {
-    // coordinates in map units
-    mLineEdit->setText( p.toString( mMousePrecisionDecimalPlaces ) );
-  }
+  mLineEdit->setText( QgsCoordinateUtils::formatCoordinateForProject( p, mMapCanvas->mapSettings().destinationCrs(),
+                      mMousePrecisionDecimalPlaces ) );
 
   if ( mLineEdit->width() > mLineEdit->minimumWidth() )
   {

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -88,6 +88,7 @@ SET(QGIS_CORE_SRCS
   qgscontexthelp_texts.cpp
   qgscoordinatereferencesystem.cpp
   qgscoordinatetransform.cpp
+  qgscoordinateutils.cpp
   qgscredentials.cpp
   qgscrscache.cpp
   qgsdartmeasurement.cpp
@@ -584,6 +585,7 @@ SET(QGIS_CORE_HDRS
   qgscontexthelp.h
   qgsconditionalstyle.h
   qgscoordinatereferencesystem.h
+  qgscoordinateutils.h
   qgscrscache.h
   qgscsexception.h
   qgsdartmeasurement.h

--- a/src/core/qgscoordinateutils.cpp
+++ b/src/core/qgscoordinateutils.cpp
@@ -1,0 +1,77 @@
+/***************************************************************************
+                             qgscoordinateutils.cpp
+                             ----------------------
+    begin                : February 2016
+    copyright            : (C) 2016 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgscoordinateutils.h"
+#include "qgsproject.h"
+#include "qgis.h"
+
+///@cond NOT_STABLE_API
+
+int QgsCoordinateUtils::calculateCoordinatePrecision( double mapUnitsPerPixel )
+{
+  // Get the display precision from the project settings
+  bool automatic = QgsProject::instance()->readBoolEntry( "PositionPrecision", "/Automatic" );
+  int dp = 0;
+
+  if ( automatic )
+  {
+    // Work out a suitable number of decimal places for the coordinates with the aim of always
+    // having enough decimal places to show the difference in position between adjacent pixels.
+    // Also avoid taking the log of 0.
+    if ( !qgsDoubleNear( mapUnitsPerPixel, 0.0 ) )
+      dp = static_cast<int>( ceil( -1.0 * log10( mapUnitsPerPixel ) ) );
+  }
+  else
+    dp = QgsProject::instance()->readNumEntry( "PositionPrecision", "/DecimalPlaces" );
+
+  // Keep dp sensible
+  if ( dp < 0 )
+    dp = 0;
+
+  return dp;
+}
+
+QString QgsCoordinateUtils::formatCoordinateForProject( const QgsPoint& point, const QgsCoordinateReferenceSystem& destCrs, int precision )
+{
+  QString format = QgsProject::instance()->readEntry( "PositionPrecision", "/DegreeFormat", "D" );
+
+  QgsPoint geo = point;
+  if ( format == "DM" || format == "DMS" || format == "D" )
+  {
+    // degrees
+    if ( destCrs.isValid() && !destCrs.geographicFlag() )
+    {
+      // need to transform to geographic coordinates
+      QgsCoordinateTransform ct( destCrs, QgsCoordinateReferenceSystem( GEOSRID ) );
+      geo = ct.transform( point );
+    }
+
+    if ( format == "DM" )
+      return geo.toDegreesMinutes( precision );
+    else if ( format == "DMS" )
+      return geo.toDegreesMinutesSeconds( precision );
+    else
+      return geo.toString( precision );
+  }
+  else
+  {
+    // coordinates in map units
+    return point.toString( precision );
+  }
+}
+
+///@endcond

--- a/src/core/qgscoordinateutils.h
+++ b/src/core/qgscoordinateutils.h
@@ -1,0 +1,55 @@
+/***************************************************************************
+                             qgscoordinateutils.h
+                             --------------------
+    begin                : February 2016
+    copyright            : (C) 2016 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSCOORDINATEUTILS_H
+#define QGSCOORDINATEUTILS_H
+
+#include "qgscoordinatereferencesystem.h"
+#include "qgspoint.h"
+
+//not stable api - I plan on reworking this when QgsCoordinateFormatter lands in 2.16
+///@cond NOT_STABLE_API
+
+/** \ingroup core
+ * \class QgsCoordinateUtils
+ * \brief Utilities for handling and formatting coordinates
+ * \note added in QGIS 2.14
+ */
+class CORE_EXPORT QgsCoordinateUtils
+{
+  public:
+
+    /** Returns the precision to use for displaying coordinates to the user, respecting
+     * the user's project settings. If the user has set the project to use "automatic"
+     * precision, this function calculates an optimal coordinate precision for a given
+     * map units per pixel by calculating the number of decimal places for the coordinates
+     * with the aim
+     * of always having enough decimal places to show the difference in position
+     * between adjacent pixels.
+     * @param mapUnitsPerPixel number of map units per pixel
+     * @returns optimal number of decimal places for coordinates
+     */
+    static int calculateCoordinatePrecision( double mapUnitsPerPixel );
+
+    static QString formatCoordinateForProject( const QgsPoint& point, const QgsCoordinateReferenceSystem& destCrs, int precision );
+
+};
+
+
+///@endcond
+
+#endif //QGSCOORDINATEUTILS_H

--- a/src/gui/qgsmaptoolidentify.h
+++ b/src/gui/qgsmaptoolidentify.h
@@ -169,12 +169,16 @@ class GUI_EXPORT QgsMapToolIdentify : public QgsMapTool
      */
     void closestVertexAttributes( const QgsAbstractGeometryV2& geometry, QgsVertexId vId, QgsMapLayer *layer, QMap< QString, QString >& derivedAttributes );
 
+    QString formatCoordinate( const QgsPoint& canvasPoint ) const;
+
     // Last point in canvas CRS
     QgsPoint mLastPoint;
 
     double mLastMapUnitsPerPixel;
 
     QgsRectangle mLastExtent;
+
+    int mCoordinatePrecision;
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsMapToolIdentify::LayerType )

--- a/src/ui/qgsprojectpropertiesbase.ui
+++ b/src/ui/qgsprojectpropertiesbase.ui
@@ -42,7 +42,16 @@
        <enum>QFrame::Raised</enum>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_2">
-       <property name="margin">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
         <number>0</number>
        </property>
        <item>
@@ -188,7 +197,16 @@
        <enum>QFrame::Raised</enum>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_3">
-       <property name="margin">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
         <number>0</number>
        </property>
        <item>
@@ -204,7 +222,16 @@
          </property>
          <widget class="QWidget" name="mProjOpts_01">
           <layout class="QVBoxLayout" name="verticalLayout_6">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -220,8 +247,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>696</width>
-                <height>793</height>
+                <width>683</width>
+                <height>779</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_8">
@@ -482,7 +509,7 @@
                 </widget>
                </item>
                <item>
-                <widget class="QgsCollapsibleGroupBox" name="btnGrpMapUnits">
+                <widget class="QgsCollapsibleGroupBox" name="mCoordinateDisplayGroup">
                  <property name="sizePolicy">
                   <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
                    <horstretch>0</horstretch>
@@ -493,141 +520,61 @@
                   <string>Used when CRS transformation is turned off</string>
                  </property>
                  <property name="title">
-                  <string>Canvas units</string>
+                  <string>Coordinate display</string>
                  </property>
                  <property name="syncGroup" stdset="0">
                   <string notr="true">projgeneral</string>
                  </property>
-                 <layout class="QVBoxLayout" name="verticalLayout_19">
-                  <item>
-                   <layout class="QGridLayout" name="gridLayout_2">
-                    <item row="1" column="0">
-                     <spacer name="verticalSpacer_4">
-                      <property name="orientation">
-                       <enum>Qt::Vertical</enum>
-                      </property>
-                      <property name="sizeHint" stdset="0">
-                       <size>
-                        <width>20</width>
-                        <height>0</height>
-                       </size>
-                      </property>
-                     </spacer>
-                    </item>
-                    <item row="0" column="3">
-                     <widget class="QRadioButton" name="radDegrees">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="text">
-                       <string>Degree</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="0" column="2">
-                     <widget class="QRadioButton" name="radNMiles">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="text">
-                       <string>Nautical miles</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="0" column="1">
-                     <widget class="QRadioButton" name="radFeet">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="text">
-                       <string>Feet</string>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="0" column="0">
-                     <widget class="QRadioButton" name="radMeters">
-                      <property name="sizePolicy">
-                       <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                        <horstretch>0</horstretch>
-                        <verstretch>0</verstretch>
-                       </sizepolicy>
-                      </property>
-                      <property name="text">
-                       <string>Meters</string>
-                      </property>
-                      <property name="checked">
-                       <bool>true</bool>
-                      </property>
-                     </widget>
-                    </item>
-                    <item row="0" column="4" rowspan="2">
-                     <widget class="QGroupBox" name="btnGrpDegreeDisplay">
-                      <property name="enabled">
-                       <bool>false</bool>
-                      </property>
-                      <property name="title">
-                       <string>Degree display</string>
-                      </property>
-                      <layout class="QVBoxLayout" name="verticalLayout_20">
-                       <item>
-                        <widget class="QRadioButton" name="radD">
-                         <property name="text">
-                          <string>Decimal degrees</string>
-                         </property>
-                        </widget>
-                       </item>
-                       <item>
-                        <widget class="QRadioButton" name="radDM">
-                         <property name="text">
-                          <string>Degrees, Minutes</string>
-                         </property>
-                        </widget>
-                       </item>
-                       <item>
-                        <widget class="QRadioButton" name="radDMS">
-                         <property name="text">
-                          <string>Degrees, Minutes, Seconds</string>
-                         </property>
-                        </widget>
-                       </item>
-                      </layout>
-                     </widget>
-                    </item>
-                   </layout>
+                 <layout class="QGridLayout" name="gridLayout_18">
+                  <item row="1" column="0">
+                   <widget class="QLabel" name="label_26">
+                    <property name="text">
+                     <string>Precision</string>
+                    </property>
+                   </widget>
                   </item>
-                 </layout>
-                </widget>
-               </item>
-               <item>
-                <widget class="QgsCollapsibleGroupBox" name="btnGrpPrecision">
-                 <property name="title">
-                  <string>Precision</string>
-                 </property>
-                 <property name="syncGroup" stdset="0">
-                  <string notr="true">projgeneral</string>
-                 </property>
-                 <layout class="QGridLayout" name="gridLayout_28">
-                  <item row="0" column="2">
-                   <widget class="QFrame" name="mPrecisionFrame">
-                    <property name="frameShape">
-                     <enum>QFrame::NoFrame</enum>
+                  <item row="0" column="0">
+                   <widget class="QLabel" name="label_25">
+                    <property name="text">
+                     <string>Display coordinates using</string>
                     </property>
-                    <property name="frameShadow">
-                     <enum>QFrame::Raised</enum>
-                    </property>
-                    <layout class="QHBoxLayout" name="horizontalLayout_4">
-                     <property name="margin">
-                      <number>0</number>
-                     </property>
+                   </widget>
+                  </item>
+                  <item row="0" column="1">
+                   <widget class="QComboBox" name="mCoordinateDisplayComboBox"/>
+                  </item>
+                  <item row="1" column="1">
+                   <widget class="QFrame" name="mFramePrecision">
+                    <layout class="QHBoxLayout" name="horizontalLayout_12">
+                     <item>
+                      <widget class="QRadioButton" name="radAutomatic">
+                       <property name="toolTip">
+                        <string>Automatically sets the number of decimal places in the mouse position display</string>
+                       </property>
+                       <property name="whatsThis">
+                        <string>The number of decimal places that are used when displaying the mouse position is automatically set to be enough so that moving the mouse by one pixel gives a change in the position display</string>
+                       </property>
+                       <property name="text">
+                        <string>Automatic</string>
+                       </property>
+                       <property name="checked">
+                        <bool>true</bool>
+                       </property>
+                      </widget>
+                     </item>
+                     <item>
+                      <widget class="QRadioButton" name="radManual">
+                       <property name="toolTip">
+                        <string>Sets the number of decimal places to use for the mouse position display</string>
+                       </property>
+                       <property name="whatsThis">
+                        <string>Sets the number of decimal places to use for the mouse position display</string>
+                       </property>
+                       <property name="text">
+                        <string>Manual</string>
+                       </property>
+                      </widget>
+                     </item>
                      <item>
                       <widget class="QSpinBox" name="spinBoxDP">
                        <property name="toolTip">
@@ -649,41 +596,9 @@
                        <property name="text">
                         <string>decimal places</string>
                        </property>
-                       <property name="buddy">
-                        <cstring>spinBoxDP</cstring>
-                       </property>
                       </widget>
                      </item>
                     </layout>
-                   </widget>
-                  </item>
-                  <item row="0" column="1">
-                   <widget class="QRadioButton" name="radManual">
-                    <property name="toolTip">
-                     <string>Sets the number of decimal places to use for the mouse position display</string>
-                    </property>
-                    <property name="whatsThis">
-                     <string>Sets the number of decimal places to use for the mouse position display</string>
-                    </property>
-                    <property name="text">
-                     <string>Manual</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="0">
-                   <widget class="QRadioButton" name="radAutomatic">
-                    <property name="toolTip">
-                     <string>Automatically sets the number of decimal places in the mouse position display</string>
-                    </property>
-                    <property name="whatsThis">
-                     <string>The number of decimal places that are used when displaying the mouse position is automatically set to be enough so that moving the mouse by one pixel gives a change in the position display</string>
-                    </property>
-                    <property name="text">
-                     <string>Automatic</string>
-                    </property>
-                    <property name="checked">
-                     <bool>true</bool>
-                    </property>
                    </widget>
                   </item>
                  </layout>
@@ -798,7 +713,16 @@
          </widget>
          <widget class="QWidget" name="mProjOpts_02">
           <layout class="QVBoxLayout" name="verticalLayout_5">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -814,7 +738,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>246</width>
+                <width>326</width>
                 <height>46</height>
                </rect>
               </property>
@@ -848,7 +772,16 @@
          </widget>
          <widget class="QWidget" name="mProjOpts_03">
           <layout class="QVBoxLayout" name="verticalLayout_9">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -864,7 +797,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>98</width>
+                <width>133</width>
                 <height>100</height>
                </rect>
               </property>
@@ -920,7 +853,16 @@
          </widget>
          <widget class="QWidget" name="mProjOpts_04">
           <layout class="QVBoxLayout" name="verticalLayout_11">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -936,8 +878,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>311</width>
-                <height>509</height>
+                <width>379</width>
+                <height>582</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_12">
@@ -1336,7 +1278,16 @@
          </widget>
          <widget class="QWidget" name="mProjOpts_05">
           <layout class="QVBoxLayout" name="verticalLayout_14">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -1352,8 +1303,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>399</width>
-                <height>1508</height>
+                <width>663</width>
+                <height>2249</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_13">
@@ -1741,10 +1692,10 @@
                     <property name="checked">
                      <bool>false</bool>
                     </property>
-                    <property name="collapsed">
+                    <property name="collapsed" stdset="0">
                      <bool>false</bool>
                     </property>
-                    <property name="saveCollapsedState">
+                    <property name="saveCollapsedState" stdset="0">
                      <bool>true</bool>
                     </property>
                     <layout class="QGridLayout" name="gridLayout_10">
@@ -1800,10 +1751,10 @@
                     <property name="checked">
                      <bool>false</bool>
                     </property>
-                    <property name="collapsed">
+                    <property name="collapsed" stdset="0">
                      <bool>false</bool>
                     </property>
-                    <property name="saveCollapsedState">
+                    <property name="saveCollapsedState" stdset="0">
                      <bool>true</bool>
                     </property>
                     <layout class="QGridLayout" name="gridLayout">
@@ -2393,7 +2344,16 @@
          </widget>
          <widget class="QWidget" name="mProjOpts_06">
           <layout class="QVBoxLayout" name="verticalLayout_15">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -2409,7 +2369,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>129</width>
+                <width>168</width>
                 <height>46</height>
                </rect>
               </property>
@@ -2446,7 +2406,16 @@
          </widget>
          <widget class="QWidget" name="mTabRelations">
           <layout class="QGridLayout" name="gridLayout_16">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
           </layout>
@@ -2492,7 +2461,16 @@
       <enum>QFrame::Raised</enum>
      </property>
      <layout class="QHBoxLayout" name="horizontalLayout">
-      <property name="margin">
+      <property name="leftMargin">
+       <number>0</number>
+      </property>
+      <property name="topMargin">
+       <number>0</number>
+      </property>
+      <property name="rightMargin">
+       <number>0</number>
+      </property>
+      <property name="bottomMargin">
        <number>0</number>
       </property>
       <item>
@@ -2555,16 +2533,11 @@
   <tabstop>pbnSelectionColor</tabstop>
   <tabstop>pbnCanvasColor</tabstop>
   <tabstop>cbxAbsolutePath</tabstop>
+  <tabstop>mMapTileRenderingCheckBox</tabstop>
   <tabstop>cmbEllipsoid</tabstop>
   <tabstop>leSemiMajor</tabstop>
   <tabstop>leSemiMinor</tabstop>
-  <tabstop>radMeters</tabstop>
-  <tabstop>radFeet</tabstop>
-  <tabstop>radNMiles</tabstop>
-  <tabstop>radDegrees</tabstop>
-  <tabstop>radD</tabstop>
-  <tabstop>radDM</tabstop>
-  <tabstop>radDMS</tabstop>
+  <tabstop>mCoordinateDisplayComboBox</tabstop>
   <tabstop>radAutomatic</tabstop>
   <tabstop>radManual</tabstop>
   <tabstop>spinBoxDP</tabstop>
@@ -2646,6 +2619,17 @@
   <tabstop>mWCSUrlLineEdit</tabstop>
   <tabstop>grpPythonMacros</tabstop>
   <tabstop>scrollArea_6</tabstop>
+  <tabstop>mWMSName</tabstop>
+  <tabstop>mWMSInspire</tabstop>
+  <tabstop>mWMSInspireLanguage</tabstop>
+  <tabstop>mWMSInspireScenario2</tabstop>
+  <tabstop>mWMSInspireTemporalReference</tabstop>
+  <tabstop>mWMSInspireMetadataDate</tabstop>
+  <tabstop>mWMSInspireScenario1</tabstop>
+  <tabstop>mWMSInspireMetadataUrl</tabstop>
+  <tabstop>mWMSInspireMetadataUrlType</tabstop>
+  <tabstop>pbnLaunchOWSChecker</tabstop>
+  <tabstop>teOWSChecker</tabstop>
  </tabstops>
  <resources>
   <include location="../../images/images.qrc"/>


### PR DESCRIPTION
I'm opening this PR early for feedback before I go too far with this approach. It's a WIP to address numerous issues relating to coordinate display, units in project properties, and distance/area measurement issues.

Done so far:
-Remove existing (confusing and totally useless) "canvas units" setting. This setting was supposed to be used a confusing number of totally different uses, eg changing the coordinate display format and changing the default measurement units, but it was so broken it did none of these things except change the coordinate display and it only did that if OTF was off.
- Add a new "coordinate display" section in project settings, which allows choice of format for coordinate display via a combo box (this will also make it easy to add additional custom formats in future), and make this setting work regardless of whether OTF is on or off.
- Respect the coordinate display project setting when showing derived coordinate in identify tool

TODO:
- Add project properties setting for preferred distance/area measurement units, use these for all distance and area measurements (eg in field calculator)
