### PR TITLE
fix transparency in qgsmaprenderer

### DIFF
--- a/src/core/qgsmaprendererjob.cpp
+++ b/src/core/qgsmaprendererjob.cpp
@@ -350,7 +350,7 @@ void QgsMapRendererJob::cleanupJobs( LayerRenderJobs& jobs )
 QImage QgsMapRendererJob::composeImage( const QgsMapSettings& settings, const LayerRenderJobs& jobs )
 {
   QImage image( settings.outputSize(), settings.outputImageFormat() );
-  image.fill( settings.backgroundColor().rgb() );
+  image.fill( settings.backgroundColor().rgba() );
 
   QPainter painter( &image );
 

--- a/src/core/qgsmaprenderersequentialjob.cpp
+++ b/src/core/qgsmaprenderersequentialjob.cpp
@@ -31,6 +31,7 @@ QgsMapRendererSequentialJob::QgsMapRendererSequentialJob( const QgsMapSettings& 
   mImage = QImage( mSettings.outputSize(), mSettings.outputImageFormat() );
   mImage.setDotsPerMeterX( 1000 * settings.outputDpi() / 25.4 );
   mImage.setDotsPerMeterY( 1000 * settings.outputDpi() / 25.4 );
+  mImage.fill( settings.backgroundColor().rgba() );
 }
 
 QgsMapRendererSequentialJob::~QgsMapRendererSequentialJob()

--- a/src/core/qgsmaprenderersequentialjob.cpp
+++ b/src/core/qgsmaprenderersequentialjob.cpp
@@ -31,7 +31,7 @@ QgsMapRendererSequentialJob::QgsMapRendererSequentialJob( const QgsMapSettings& 
   mImage = QImage( mSettings.outputSize(), mSettings.outputImageFormat() );
   mImage.setDotsPerMeterX( 1000 * settings.outputDpi() / 25.4 );
   mImage.setDotsPerMeterY( 1000 * settings.outputDpi() / 25.4 );
-  mImage.fill( settings.backgroundColor().rgba() );
+  mImage.fill( Qt::transparent );
 }
 
 QgsMapRendererSequentialJob::~QgsMapRendererSequentialJob()


### PR DESCRIPTION
QGIS should use `fill()` to fill the image before drawing onto it with QPainter.
If you don't use `fill()` before, you get a lo of noise on the picture like this tile : 
![tile](https://cloud.githubusercontent.com/assets/1609292/12766503/7c319e76-ca04-11e5-9fc5-4b239998579a.png)
