### PR TITLE
Enable switch-enum warning on Travis

### DIFF
--- a/ci/travis/linux/install.sh
+++ b/ci/travis/linux/install.sh
@@ -1,7 +1,7 @@
 mkdir build
 cd build
 
-CLANG_WARNINGS="-Wimplicit-fallthrough"
+CLANG_WARNINGS="-Wimplicit-fallthrough -Wswitch-enum"
 
 cmake -DWITH_SERVER=ON \
       -DWITH_STAGED_PLUGINS=ON \

--- a/src/analysis/interpolation/qgsinterpolator.cpp
+++ b/src/analysis/interpolation/qgsinterpolator.cpp
@@ -325,6 +325,18 @@ int QgsInterpolator::addVerticesToCache( const QgsGeometry *geom, bool zCoord, d
       break;
     }
 #endif //0
+
+    case QGis::WKBPolygon:
+    case QGis::WKBPolygon25D:
+    case QGis::WKBMultiPoint:
+    case QGis::WKBMultiPoint25D:
+    case QGis::WKBMultiLineString:
+    case QGis::WKBMultiLineString25D:
+    case QGis::WKBMultiPolygon:
+    case QGis::WKBMultiPolygon25D:
+
+    case QGis::WKBUnknown:
+    case QGis::WKBNoGeometry:
     default:
       break;
   }

--- a/src/analysis/interpolation/qgstininterpolator.cpp
+++ b/src/analysis/interpolation/qgstininterpolator.cpp
@@ -428,6 +428,8 @@ int QgsTINInterpolator::insertData( QgsFeature* f, bool zCoord, int attr, InputT
       }
       break;
     }
+    case QGis::WKBUnknown:
+    case QGis::WKBNoGeometry:
     default:
       //should not happen...
       break;

--- a/src/analysis/raster/qgsrastercalcnode.cpp
+++ b/src/analysis/raster/qgsrastercalcnode.cpp
@@ -223,6 +223,7 @@ bool QgsRasterCalcNode::calculate( QMap<QString, QgsRasterBlock* >& rasterData, 
       case opLOG10:
         leftMatrix.log10();
         break;
+      case opNONE:
       default:
         return false;
     }

--- a/src/app/composer/qgscomposermapwidget.cpp
+++ b/src/app/composer/qgscomposermapwidget.cpp
@@ -739,6 +739,9 @@ void QgsComposerMapWidget::toggleAtlasScalingOptionsByLayerType()
       mAtlasMarginRadio->setEnabled( false );
       mAtlasPredefinedScaleRadio->setEnabled( false );
       break;
+    case QGis::WKBUnknown:
+    case QGis::WKBLineString:
+    case QGis::WKBPolygon:
     default:
       //Not a point layer, so enable changes to fixed scale control
       mAtlasMarginRadio->setEnabled( true );
@@ -1468,6 +1471,7 @@ void QgsComposerMapWidget::setGridItems( const QgsComposerMapGrid* grid )
       mFrameStyleComboBox->setCurrentIndex( 5 );
       toggleFrameControls( true, false, false );
       break;
+    case QgsComposerMapGrid::NoFrame:
     default:
       mFrameStyleComboBox->setCurrentIndex( 0 );
       toggleFrameControls( false, false, false );

--- a/src/app/qgslabelpropertydialog.cpp
+++ b/src/app/qgslabelpropertydialog.cpp
@@ -108,6 +108,8 @@ void QgsLabelPropertyDialog::init( const QString& layerId, int featureId, const 
           case QVariant::LongLong:
             mLabelTextLineEdit->setValidator( new QIntValidator( this ) );
             break;
+
+          CASE_UNUSUAL_QVARIANT_TYPES:
           default:
             break;
         }

--- a/src/app/qgsvariantdelegate.cpp
+++ b/src/app/qgsvariantdelegate.cpp
@@ -42,6 +42,7 @@
 #include <QDateTime>
 
 #include "qgsvariantdelegate.h"
+#include "qgis.h"
 
 QgsVariantDelegate::QgsVariantDelegate( QObject* parent )
     : QItemDelegate( parent )
@@ -143,6 +144,47 @@ QWidget* QgsVariantDelegate::createEditor( QWidget* parent,
     case QVariant::ULongLong:
       regExp = mUnsignedIntegerExp;
       break;
+
+    case QVariant::String:
+    case QVariant::Invalid:
+    case QVariant::Map:
+    case QVariant::StringList:
+    case QVariant::List:
+    case QVariant::BitArray:
+    case QVariant::Url:
+    case QVariant::Locale:
+    case QVariant::RectF:
+    case QVariant::SizeF:
+    case QVariant::Line:
+    case QVariant::LineF:
+    case QVariant::PointF:
+    case QVariant::RegExp:
+    case QVariant::Hash:
+    case QVariant::EasingCurve:
+    case QVariant::Font:
+    case QVariant::Pixmap:
+    case QVariant::Brush:
+    case QVariant::Palette:
+    case QVariant::Icon:
+    case QVariant::Image:
+    case QVariant::Polygon:
+    case QVariant::Region:
+    case QVariant::Bitmap:
+    case QVariant::Cursor:
+    case QVariant::SizePolicy:
+    case QVariant::KeySequence:
+    case QVariant::Pen:
+    case QVariant::TextLength:
+    case QVariant::TextFormat:
+    case QVariant::Matrix:
+    case QVariant::Transform:
+    case QVariant::Matrix4x4:
+    case QVariant::Vector2D:
+    case QVariant::Vector3D:
+    case QVariant::Vector4D:
+    case QVariant::Quaternion:
+    case QVariant::LastType:
+    case QVariant::UserType:
     default:
       ;
   }
@@ -235,6 +277,44 @@ void QgsVariantDelegate::setModelData( QWidget* editor, QAbstractItemModel* mode
       value = time;
     }
     break;
+
+    case QVariant::Invalid:
+    case QVariant::Bool:
+    case QVariant::Int:
+    case QVariant::BitArray:
+    case QVariant::Url:
+    case QVariant::Locale:
+    case QVariant::RectF:
+    case QVariant::SizeF:
+    case QVariant::Line:
+    case QVariant::LineF:
+    case QVariant::PointF:
+    case QVariant::RegExp:
+    case QVariant::Hash:
+    case QVariant::EasingCurve:
+    case QVariant::Font:
+    case QVariant::Pixmap:
+    case QVariant::Brush:
+    case QVariant::Palette:
+    case QVariant::Icon:
+    case QVariant::Image:
+    case QVariant::Polygon:
+    case QVariant::Region:
+    case QVariant::Bitmap:
+    case QVariant::Cursor:
+    case QVariant::SizePolicy:
+    case QVariant::KeySequence:
+    case QVariant::Pen:
+    case QVariant::TextLength:
+    case QVariant::TextFormat:
+    case QVariant::Matrix:
+    case QVariant::Transform:
+    case QVariant::Matrix4x4:
+    case QVariant::Vector2D:
+    case QVariant::Vector3D:
+    case QVariant::Vector4D:
+    case QVariant::Quaternion:
+    case QVariant::LastType:
     default:
       value = text;
       value.convert( QgsVariantDelegate::type( originalValue ) );
@@ -266,6 +346,45 @@ bool QgsVariantDelegate::isSupportedType( QVariant::Type type )
     case QVariant::UInt:
     case QVariant::ULongLong:
       return true;
+
+    case QVariant::Invalid:
+    case QVariant::Map:
+    case QVariant::List:
+    case QVariant::BitArray:
+    case QVariant::Url:
+    case QVariant::Locale:
+    case QVariant::RectF:
+    case QVariant::SizeF:
+    case QVariant::Line:
+    case QVariant::LineF:
+    case QVariant::PointF:
+    case QVariant::RegExp:
+    case QVariant::Hash:
+    case QVariant::EasingCurve:
+    case QVariant::Font:
+    case QVariant::Pixmap:
+    case QVariant::Brush:
+    case QVariant::Palette:
+    case QVariant::Icon:
+    case QVariant::Image:
+    case QVariant::Polygon:
+    case QVariant::Region:
+    case QVariant::Bitmap:
+    case QVariant::Cursor:
+    case QVariant::SizePolicy:
+    case QVariant::KeySequence:
+    case QVariant::Pen:
+    case QVariant::TextLength:
+    case QVariant::TextFormat:
+    case QVariant::Matrix:
+    case QVariant::Transform:
+    case QVariant::Matrix4x4:
+    case QVariant::Vector2D:
+    case QVariant::Vector3D:
+    case QVariant::Vector4D:
+    case QVariant::Quaternion:
+    case QVariant::LastType:
+    case QVariant::UserType:
     default:
       return false;
   }
@@ -319,6 +438,44 @@ QString QgsVariantDelegate::displayText( const QVariant& value )
       return value.toStringList().join( "," );
     case QVariant::Time:
       return value.toTime().toString( Qt::ISODate );
+
+    case QVariant::Map:
+    case QVariant::List:
+    case QVariant::BitArray:
+    case QVariant::Url:
+    case QVariant::Locale:
+    case QVariant::RectF:
+    case QVariant::SizeF:
+    case QVariant::Line:
+    case QVariant::LineF:
+    case QVariant::PointF:
+    case QVariant::RegExp:
+    case QVariant::Hash:
+    case QVariant::EasingCurve:
+    case QVariant::Font:
+    case QVariant::Pixmap:
+    case QVariant::Brush:
+    case QVariant::Palette:
+    case QVariant::Icon:
+    case QVariant::Image:
+    case QVariant::Polygon:
+    case QVariant::Region:
+    case QVariant::Bitmap:
+    case QVariant::Cursor:
+    case QVariant::SizePolicy:
+    case QVariant::KeySequence:
+    case QVariant::Pen:
+    case QVariant::TextLength:
+    case QVariant::TextFormat:
+    case QVariant::Matrix:
+    case QVariant::Transform:
+    case QVariant::Matrix4x4:
+    case QVariant::Vector2D:
+    case QVariant::Vector3D:
+    case QVariant::Vector4D:
+    case QVariant::Quaternion:
+    case QVariant::LastType:
+    case QVariant::UserType:
     default:
       break;
   }

--- a/src/core/auth/qgsauthcertutils.cpp
+++ b/src/core/auth/qgsauthcertutils.cpp
@@ -42,6 +42,8 @@ QString QgsAuthCertUtils::getSslProtocolName( QSsl::SslProtocol protocol )
       return QObject::tr( "SslV3" );
     case QSsl::SslV2:
       return QObject::tr( "SslV2" );
+    case QSsl::UnknownProtocol:
+    case QSsl::AnyProtocol:
     default:
       return QString();
   }
@@ -392,6 +394,7 @@ QString QgsAuthCertUtils::getCertTrustName( QgsAuthCertUtils::CertTrustPolicy tr
       return QObject::tr( "Trusted" );
     case Untrusted:
       return QObject::tr( "Untrusted" );
+    case NoPolicy:
     default:
       return QString();
   }
@@ -523,6 +526,7 @@ QString QgsAuthCertUtils::qcaSignatureAlgorithm( QCA::SignatureAlgorithm algorit
     case QCA::EMSA3_SHA512:
       return QObject::tr( "SHA512, with EMSA3" );
 #endif
+    case QCA::SignatureUnknown:
     default:
       return QObject::tr( "Unknown (possibly Elliptic Curve)" );
   }

--- a/src/core/auth/qgsauthmanager.cpp
+++ b/src/core/auth/qgsauthmanager.cpp
@@ -2766,6 +2766,7 @@ void QgsAuthManager::writeToConsole( const QString &message,
     case QgsAuthManager::CRITICAL:
       msg += "ERROR: ";
       break;
+    case QgsAuthManager::INFO:
     default:
       break;
   }

--- a/src/core/composer/qgsatlascomposition.cpp
+++ b/src/core/composer/qgsatlascomposition.cpp
@@ -537,6 +537,17 @@ void QgsAtlasComposition::prepareMap( QgsComposerMap* map )
     case QGis::WKBMultiPoint25D:
       isPointLayer = true;
       break;
+
+    case QGis::WKBUnknown:
+    case QGis::WKBLineString:
+    case QGis::WKBLineString25D:
+    case QGis::WKBPolygon:
+    case QGis::WKBPolygon25D:
+    case QGis::WKBMultiLineString:
+    case QGis::WKBMultiLineString25D:
+    case QGis::WKBMultiPolygon:
+    case QGis::WKBMultiPolygon25D:
+    case QGis::WKBNoGeometry:
     default:
       isPointLayer = false;
       break;

--- a/src/core/composer/qgscomposerattributetable.cpp
+++ b/src/core/composer/qgscomposerattributetable.cpp
@@ -78,6 +78,16 @@ bool QgsComposerAttributeTableCompare::operator()( const QgsAttributeMap& m1, co
         less = v1.toTime() < v2.toTime();
         break;
 
+      case QVariant::String:
+      case QVariant::Invalid:
+      case QVariant::Bool:
+      case QVariant::Char:
+      case QVariant::Map:
+      case QVariant::List:
+      case QVariant::StringList:
+      case QVariant::ByteArray:
+      case QVariant::UserType:
+      CASE_UNUSUAL_QVARIANT_TYPES:
       default:
         //use locale aware compare for strings
         less = v1.toString().localeAwareCompare( v2.toString() ) < 0;

--- a/src/core/composer/qgscomposerattributetablemodel.cpp
+++ b/src/core/composer/qgscomposerattributetablemodel.cpp
@@ -105,12 +105,22 @@ QVariant QgsComposerAttributeTableColumnModel::data( const QModelIndex &index, i
         switch ( column->hAlignment() )
         {
           case Qt::AlignHCenter:
+          case Qt::AlignCenter:
             switch ( column->vAlignment() )
             {
               case Qt::AlignTop:
+              case Qt::AlignVertical_Mask:
                 return tr( "Top center" );
               case Qt::AlignBottom:
                 return tr( "Bottom center" );
+              case Qt::AlignLeft:
+              case Qt::AlignRight:
+              case Qt::AlignHCenter:
+              case Qt::AlignJustify:
+              case Qt::AlignAbsolute:
+              case Qt::AlignHorizontal_Mask:
+              case Qt::AlignVCenter:
+              case Qt::AlignCenter:
               default:
                 return tr( "Middle center" );
             }
@@ -118,20 +128,45 @@ QVariant QgsComposerAttributeTableColumnModel::data( const QModelIndex &index, i
             switch ( column->vAlignment() )
             {
               case Qt::AlignTop:
+              case Qt::AlignVertical_Mask:
                 return tr( "Top right" );
               case Qt::AlignBottom:
                 return tr( "Bottom right" );
+              case Qt::AlignLeft:
+              case Qt::AlignRight:
+              case Qt::AlignHCenter:
+              case Qt::AlignJustify:
+              case Qt::AlignAbsolute:
+              case Qt::AlignHorizontal_Mask:
+              case Qt::AlignVCenter:
+              case Qt::AlignCenter:
               default:
                 return tr( "Middle right" );
             }
           case Qt::AlignLeft:
+          case Qt::AlignJustify:
+          case Qt::AlignAbsolute:
+          case Qt::AlignHorizontal_Mask:
+          case Qt::AlignTop:
+          case Qt::AlignBottom:
+          case Qt::AlignVCenter:
+          case Qt::AlignVertical_Mask:
           default:
             switch ( column->vAlignment() )
             {
               case Qt::AlignTop:
+              case Qt::AlignVertical_Mask:
                 return tr( "Top left" );
               case Qt::AlignBottom:
                 return tr( "Bottom left" );
+              case Qt::AlignLeft:
+              case Qt::AlignRight:
+              case Qt::AlignHCenter:
+              case Qt::AlignJustify:
+              case Qt::AlignAbsolute:
+              case Qt::AlignHorizontal_Mask:
+              case Qt::AlignVCenter:
+              case Qt::AlignCenter:
               default:
                 return tr( "Middle left" );
             }

--- a/src/core/composer/qgscomposerattributetablemodelv2.cpp
+++ b/src/core/composer/qgscomposerattributetablemodelv2.cpp
@@ -105,12 +105,22 @@ QVariant QgsComposerAttributeTableColumnModelV2::data( const QModelIndex &index,
         switch ( column->hAlignment() )
         {
           case Qt::AlignHCenter:
+          case Qt::AlignCenter:
             switch ( column->vAlignment() )
             {
               case Qt::AlignTop:
+              case Qt::AlignVertical_Mask:
                 return tr( "Top center" );
               case Qt::AlignBottom:
                 return tr( "Bottom center" );
+              case Qt::AlignLeft:
+              case Qt::AlignRight:
+              case Qt::AlignHCenter:
+              case Qt::AlignJustify:
+              case Qt::AlignAbsolute:
+              case Qt::AlignHorizontal_Mask:
+              case Qt::AlignVCenter:
+              case Qt::AlignCenter:
               default:
                 return tr( "Middle center" );
             }
@@ -118,20 +128,45 @@ QVariant QgsComposerAttributeTableColumnModelV2::data( const QModelIndex &index,
             switch ( column->vAlignment() )
             {
               case Qt::AlignTop:
+              case Qt::AlignVertical_Mask:
                 return tr( "Top right" );
               case Qt::AlignBottom:
                 return tr( "Bottom right" );
+              case Qt::AlignLeft:
+              case Qt::AlignRight:
+              case Qt::AlignHCenter:
+              case Qt::AlignJustify:
+              case Qt::AlignAbsolute:
+              case Qt::AlignHorizontal_Mask:
+              case Qt::AlignVCenter:
+              case Qt::AlignCenter:
               default:
                 return tr( "Middle right" );
             }
           case Qt::AlignLeft:
+          case Qt::AlignJustify:
+          case Qt::AlignAbsolute:
+          case Qt::AlignHorizontal_Mask:
+          case Qt::AlignTop:
+          case Qt::AlignBottom:
+          case Qt::AlignVCenter:
+          case Qt::AlignVertical_Mask:
           default:
             switch ( column->vAlignment() )
             {
               case Qt::AlignTop:
+              case Qt::AlignVertical_Mask:
                 return tr( "Top left" );
               case Qt::AlignBottom:
                 return tr( "Bottom left" );
+              case Qt::AlignLeft:
+              case Qt::AlignRight:
+              case Qt::AlignHCenter:
+              case Qt::AlignJustify:
+              case Qt::AlignAbsolute:
+              case Qt::AlignHorizontal_Mask:
+              case Qt::AlignVCenter:
+              case Qt::AlignCenter:
               default:
                 return tr( "Middle left" );
             }

--- a/src/core/composer/qgscomposerattributetablev2.cpp
+++ b/src/core/composer/qgscomposerattributetablev2.cpp
@@ -83,6 +83,16 @@ bool QgsComposerAttributeTableCompareV2::operator()( const QgsComposerTableRow& 
         less = v1.toTime() < v2.toTime();
         break;
 
+      case QVariant::String:
+      case QVariant::Bool:
+      case QVariant::Char:
+      case QVariant::Invalid:
+      case QVariant::Map:
+      case QVariant::List:
+      case QVariant::StringList:
+      case QVariant::ByteArray:
+      case QVariant::UserType:
+      CASE_UNUSUAL_QVARIANT_TYPES:
       default:
         //use locale aware compare for strings
         less = v1.toString().localeAwareCompare( v2.toString() ) < 0;

--- a/src/core/composer/qgscomposermap.cpp
+++ b/src/core/composer/qgscomposermap.cpp
@@ -1856,6 +1856,7 @@ void QgsComposerMap::setGridAnnotationDirection( GridAnnotationDirection d, QgsC
     case QgsComposerMap::BoundaryDirection:
       gridDirection = QgsComposerMapGrid::BoundaryDirection;
       break;
+    case QgsComposerMap::HorizontalAndVertical:
     default:
       gridDirection = QgsComposerMapGrid::Horizontal;
   }

--- a/src/core/composer/qgscomposermousehandles.cpp
+++ b/src/core/composer/qgscomposermousehandles.cpp
@@ -782,6 +782,9 @@ QSizeF QgsComposerMouseHandles::calcCursorEdgeOffset( QPointF cursorPos )
     case QgsComposerMouseHandles::ResizeLeftDown:
       return QSizeF( sceneMousePos.x(), sceneMousePos.y() - rect().height() );
 
+    case MoveItem:
+    case SelectItem:
+    case NoAction:
     default:
       return QSizeF( 0, 0 );
   }

--- a/src/core/composer/qgslegendmodel.cpp
+++ b/src/core/composer/qgslegendmodel.cpp
@@ -591,6 +591,7 @@ void QgsLegendModel::addLayer( QgsMapLayer* theMapLayer, double scaleDenominator
     case QgsMapLayer::RasterLayer:
       addRasterLayerItems( layerItem, theMapLayer );
       break;
+    case QgsMapLayer::PluginLayer:
     default:
       break;
   }

--- a/src/core/dxf/qgsdxfexport.cpp
+++ b/src/core/dxf/qgsdxfexport.cpp
@@ -4064,6 +4064,7 @@ QString QgsDxfExport::lineNameFromPenStyle( Qt::PenStyle style )
   switch ( style )
   {
     case Qt::DashLine:
+    case Qt::CustomDashLine:
       return "DASH";
     case Qt::DotLine:
       return "DOT";
@@ -4072,6 +4073,8 @@ QString QgsDxfExport::lineNameFromPenStyle( Qt::PenStyle style )
     case Qt::DashDotDotLine:
       return "DASHDOTDOT";
     case Qt::SolidLine:
+    case Qt::NoPen:
+    case Qt::MPenStyle:
     default:
       return "CONTINUOUS";
   }

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -616,6 +616,8 @@ int QgsGeometry::addPart( QgsAbstractGeometryV2* part, QGis::GeometryType geomTy
       case QGis::Polygon:
         d->geometry = new QgsMultiPolygonV2();
         break;
+      case QGis::UnknownGeometry:
+      case QGis::NoGeometry:
       default:
         return 1;
     }
@@ -917,6 +919,8 @@ QgsGeometry* QgsGeometry::convertToType( QGis::GeometryType destType, bool destM
     case QGis::Polygon:
       return convertToPolygon( destMultipart );
 
+    case QGis::UnknownGeometry:
+    case QGis::NoGeometry:
     default:
       return nullptr;
   }
@@ -1917,6 +1921,7 @@ QgsGeometry* QgsGeometry::smooth( const unsigned int iterations, const double of
     }
 
     case QGis::WKBUnknown:
+    case QGis::WKBNoGeometry:
     default:
       return new QgsGeometry( *this );
   }
@@ -2062,6 +2067,8 @@ QgsGeometry* QgsGeometry::convertToPoint( bool destMultipart ) const
       }
     }
 
+    case QGis::UnknownGeometry:
+    case QGis::NoGeometry:
     default:
       return nullptr;
   }
@@ -2169,6 +2176,8 @@ QgsGeometry* QgsGeometry::convertToLine( bool destMultipart ) const
       return nullptr;
     }
 
+    case QGis::UnknownGeometry:
+    case QGis::NoGeometry:
     default:
       return nullptr;
   }
@@ -2288,6 +2297,8 @@ QgsGeometry* QgsGeometry::convertToPolygon( bool destMultipart ) const
       return nullptr;
     }
 
+    case QGis::UnknownGeometry:
+    case QGis::NoGeometry:
     default:
       return nullptr;
   }

--- a/src/core/geometry/qgsgeometryfactory.cpp
+++ b/src/core/geometry/qgsgeometryfactory.cpp
@@ -209,33 +209,77 @@ QgsLineStringV2* QgsGeometryFactory::linestringFromPolyline( const QgsPolyline& 
 
 QgsAbstractGeometryV2* QgsGeometryFactory::geomFromWkbType( QgsWKBTypes::Type t )
 {
-  QgsWKBTypes::Type type = QgsWKBTypes::flatType( t );
-  switch ( type )
+  switch ( t )
   {
     case QgsWKBTypes::Point:
+    case QgsWKBTypes::PointZ:
+    case QgsWKBTypes::PointM:
+    case QgsWKBTypes::PointZM:
+    case QgsWKBTypes::Point25D:
       return new QgsPointV2();
     case QgsWKBTypes::LineString:
+    case QgsWKBTypes::LineStringZ:
+    case QgsWKBTypes::LineStringM:
+    case QgsWKBTypes::LineStringZM:
+    case QgsWKBTypes::LineString25D:
       return new QgsLineStringV2();
     case QgsWKBTypes::CircularString:
+    case QgsWKBTypes::CircularStringZ:
+    case QgsWKBTypes::CircularStringM:
+    case QgsWKBTypes::CircularStringZM:
       return new QgsCircularStringV2();
     case QgsWKBTypes::CompoundCurve:
+    case QgsWKBTypes::CompoundCurveZ:
+    case QgsWKBTypes::CompoundCurveM:
+    case QgsWKBTypes::CompoundCurveZM:
       return new QgsCompoundCurveV2();
     case QgsWKBTypes::Polygon:
+    case QgsWKBTypes::PolygonZ:
+    case QgsWKBTypes::PolygonM:
+    case QgsWKBTypes::PolygonZM:
+    case QgsWKBTypes::Polygon25D:
       return new QgsPolygonV2();
     case QgsWKBTypes::CurvePolygon:
+    case QgsWKBTypes::CurvePolygonZ:
+    case QgsWKBTypes::CurvePolygonM:
+    case QgsWKBTypes::CurvePolygonZM:
       return new QgsCurvePolygonV2();
     case QgsWKBTypes::MultiLineString:
+    case QgsWKBTypes::MultiLineStringZ:
+    case QgsWKBTypes::MultiLineStringM:
+    case QgsWKBTypes::MultiLineStringZM:
+    case QgsWKBTypes::MultiLineString25D:
       return new QgsMultiLineStringV2();
     case QgsWKBTypes::MultiPolygon:
+    case QgsWKBTypes::MultiPolygonZ:
+    case QgsWKBTypes::MultiPolygonM:
+    case QgsWKBTypes::MultiPolygonZM:
+    case QgsWKBTypes::MultiPolygon25D:
       return new QgsMultiPolygonV2();
     case QgsWKBTypes::MultiPoint:
+    case QgsWKBTypes::MultiPointZ:
+    case QgsWKBTypes::MultiPointM:
+    case QgsWKBTypes::MultiPointZM:
+    case QgsWKBTypes::MultiPoint25D:
       return new QgsMultiPointV2();
     case QgsWKBTypes::MultiCurve:
+    case QgsWKBTypes::MultiCurveZ:
+    case QgsWKBTypes::MultiCurveM:
+    case QgsWKBTypes::MultiCurveZM:
       return new QgsMultiCurveV2();
     case QgsWKBTypes::MultiSurface:
+    case QgsWKBTypes::MultiSurfaceZ:
+    case QgsWKBTypes::MultiSurfaceM:
+    case QgsWKBTypes::MultiSurfaceZM:
       return new QgsMultiSurfaceV2();
     case QgsWKBTypes::GeometryCollection:
+    case QgsWKBTypes::GeometryCollectionZ:
+    case QgsWKBTypes::GeometryCollectionM:
+    case QgsWKBTypes::GeometryCollectionZM:
       return new QgsGeometryCollectionV2();
+
+    case QgsWKBTypes::Unknown:
+    case QgsWKBTypes::NoGeometry:
     default:
       return nullptr;
   }

--- a/src/core/geometry/qgspointv2.cpp
+++ b/src/core/geometry/qgspointv2.cpp
@@ -407,6 +407,58 @@ bool QgsPointV2::convertTo( QgsWKBTypes::Type type )
     case QgsWKBTypes::PointZM:
       mWkbType = type;
       return true;
+
+    case QgsWKBTypes::Unknown:
+    case QgsWKBTypes::LineString:
+    case QgsWKBTypes::LineStringZ:
+    case QgsWKBTypes::LineStringM:
+    case QgsWKBTypes::LineStringZM:
+    case QgsWKBTypes::LineString25D:
+    case QgsWKBTypes::Polygon:
+    case QgsWKBTypes::PolygonZ:
+    case QgsWKBTypes::PolygonM:
+    case QgsWKBTypes::PolygonZM:
+    case QgsWKBTypes::Polygon25D:
+    case QgsWKBTypes::MultiPoint:
+    case QgsWKBTypes::MultiPointZ:
+    case QgsWKBTypes::MultiPointM:
+    case QgsWKBTypes::MultiPointZM:
+    case QgsWKBTypes::MultiPoint25D:
+    case QgsWKBTypes::MultiLineString:
+    case QgsWKBTypes::MultiLineStringZ:
+    case QgsWKBTypes::MultiLineStringM:
+    case QgsWKBTypes::MultiLineStringZM:
+    case QgsWKBTypes::MultiLineString25D:
+    case QgsWKBTypes::MultiPolygon:
+    case QgsWKBTypes::MultiPolygonZ:
+    case QgsWKBTypes::MultiPolygonM:
+    case QgsWKBTypes::MultiPolygonZM:
+    case QgsWKBTypes::MultiPolygon25D:
+    case QgsWKBTypes::GeometryCollection:
+    case QgsWKBTypes::GeometryCollectionZ:
+    case QgsWKBTypes::GeometryCollectionM:
+    case QgsWKBTypes::GeometryCollectionZM:
+    case QgsWKBTypes::CircularString:
+    case QgsWKBTypes::CircularStringZ:
+    case QgsWKBTypes::CircularStringM:
+    case QgsWKBTypes::CircularStringZM:
+    case QgsWKBTypes::CompoundCurve:
+    case QgsWKBTypes::CompoundCurveZ:
+    case QgsWKBTypes::CompoundCurveM:
+    case QgsWKBTypes::CompoundCurveZM:
+    case QgsWKBTypes::CurvePolygon:
+    case QgsWKBTypes::CurvePolygonZ:
+    case QgsWKBTypes::CurvePolygonM:
+    case QgsWKBTypes::CurvePolygonZM:
+    case QgsWKBTypes::MultiSurface:
+    case QgsWKBTypes::MultiSurfaceZ:
+    case QgsWKBTypes::MultiSurfaceM:
+    case QgsWKBTypes::MultiSurfaceZM:
+    case QgsWKBTypes::MultiCurve:
+    case QgsWKBTypes::MultiCurveZ:
+    case QgsWKBTypes::MultiCurveM:
+    case QgsWKBTypes::MultiCurveZM:
+    case QgsWKBTypes::NoGeometry:
     default:
       break;
   }

--- a/src/core/geometry/qgspolygonv2.cpp
+++ b/src/core/geometry/qgspolygonv2.cpp
@@ -100,7 +100,16 @@ bool QgsPolygonV2::fromWkb( const unsigned char* wkb )
     case QgsWKBTypes::Polygon25D:
       ringType = QgsWKBTypes::LineString25D;
       break;
+
+    case QgsWKBTypes::Polygon:
+
+    case QgsWKBTypes::Unknown:
+    case QgsWKBTypes::Point:
+    case QgsWKBTypes::LineString:
+    case QgsWKBTypes::MultiPoint:
+    case QgsWKBTypes::MultiLineString:
     default:
+
       ringType = QgsWKBTypes::LineString;
       break;
   }

--- a/src/core/geometry/qgswkbtypes.h
+++ b/src/core/geometry/qgswkbtypes.h
@@ -508,8 +508,37 @@ class CORE_EXPORT QgsWKBTypes
         case Polygon25D:
           return false;
 
-        default:
+        case MultiPoint:
+        case MultiLineString:
+        case MultiPolygon:
+        case GeometryCollection:
+        case MultiCurve:
+        case MultiSurface:
+        case MultiPointZ:
+        case MultiLineStringZ:
+        case MultiPolygonZ:
+        case GeometryCollectionZ:
+        case MultiCurveZ:
+        case MultiSurfaceZ:
+        case MultiPointM:
+        case MultiLineStringM:
+        case MultiPolygonM:
+        case GeometryCollectionM:
+        case MultiCurveM:
+        case MultiSurfaceM:
+        case MultiPointZM:
+        case MultiLineStringZM:
+        case MultiPolygonZM:
+        case GeometryCollectionZM:
+        case MultiCurveZM:
+        case MultiSurfaceZM:
+        case MultiPoint25D:
+        case MultiLineString25D:
+        case MultiPolygon25D:
           return true;
+
+        default:
+          return false;
 
       }
     }
@@ -528,6 +557,57 @@ class CORE_EXPORT QgsWKBTypes
         case MultiSurface:
           return true;
 
+        case Unknown:
+        case Point:
+        case LineString:
+        case Polygon:
+        case MultiPoint:
+        case MultiLineString:
+        case MultiPolygon:
+        case GeometryCollection:
+        case NoGeometry:
+        case PointZ:
+        case LineStringZ:
+        case PolygonZ:
+        case MultiPointZ:
+        case MultiLineStringZ:
+        case MultiPolygonZ:
+        case GeometryCollectionZ:
+        case CircularStringZ:
+        case CompoundCurveZ:
+        case CurvePolygonZ:
+        case MultiCurveZ:
+        case MultiSurfaceZ:
+        case PointM:
+        case LineStringM:
+        case PolygonM:
+        case MultiPointM:
+        case MultiLineStringM:
+        case MultiPolygonM:
+        case GeometryCollectionM:
+        case CircularStringM:
+        case CompoundCurveM:
+        case CurvePolygonM:
+        case MultiCurveM:
+        case MultiSurfaceM:
+        case PointZM:
+        case LineStringZM:
+        case PolygonZM:
+        case MultiPointZM:
+        case MultiLineStringZM:
+        case MultiPolygonZM:
+        case GeometryCollectionZM:
+        case CircularStringZM:
+        case CompoundCurveZM:
+        case CurvePolygonZM:
+        case MultiCurveZM:
+        case MultiSurfaceZM:
+        case Point25D:
+        case LineString25D:
+        case Polygon25D:
+        case MultiPoint25D:
+        case MultiLineString25D:
+        case MultiPolygon25D:
         default:
           return false;
       }
@@ -548,6 +628,9 @@ class CORE_EXPORT QgsWKBTypes
           return 1;
         case PolygonGeometry:
           return 2;
+        case PointGeometry:
+        case UnknownGeometry:
+        case NullGeometry:
         default: //point, no geometry, unknown geometry
           return 0;
       }
@@ -689,6 +772,32 @@ class CORE_EXPORT QgsWKBTypes
         case MultiPolygon25D:
           return true;
 
+        case Unknown:
+        case Point:
+        case LineString:
+        case Polygon:
+        case MultiPoint:
+        case MultiLineString:
+        case MultiPolygon:
+        case GeometryCollection:
+        case CircularString:
+        case CompoundCurve:
+        case CurvePolygon:
+        case MultiCurve:
+        case MultiSurface:
+        case NoGeometry:
+        case PointM:
+        case LineStringM:
+        case PolygonM:
+        case MultiPointM:
+        case MultiLineStringM:
+        case MultiPolygonM:
+        case GeometryCollectionM:
+        case CircularStringM:
+        case CompoundCurveM:
+        case CurvePolygonM:
+        case MultiCurveM:
+        case MultiSurfaceM:
         default:
           return false;
 
@@ -730,6 +839,38 @@ class CORE_EXPORT QgsWKBTypes
         case MultiSurfaceZM:
           return true;
 
+        case Unknown:
+        case Point:
+        case LineString:
+        case Polygon:
+        case MultiPoint:
+        case MultiLineString:
+        case MultiPolygon:
+        case GeometryCollection:
+        case CircularString:
+        case CompoundCurve:
+        case CurvePolygon:
+        case MultiCurve:
+        case MultiSurface:
+        case NoGeometry:
+        case PointZ:
+        case LineStringZ:
+        case PolygonZ:
+        case MultiPointZ:
+        case MultiLineStringZ:
+        case MultiPolygonZ:
+        case GeometryCollectionZ:
+        case CircularStringZ:
+        case CompoundCurveZ:
+        case CurvePolygonZ:
+        case MultiCurveZ:
+        case MultiSurfaceZ:
+        case Point25D:
+        case LineString25D:
+        case Polygon25D:
+        case MultiPoint25D:
+        case MultiLineString25D:
+        case MultiPolygon25D:
         default:
           return false;
 

--- a/src/core/gps/qextserialport/posix_qextserialport.cpp
+++ b/src/core/gps/qextserialport/posix_qextserialport.cpp
@@ -88,6 +88,24 @@ void QextSerialPort::setBaudRate(BaudRateType baudRate)
                 Settings.BaudRate=BAUD115200;
                 break;
 
+            case BAUD50:
+            case BAUD75:
+            case BAUD110:
+            case BAUD134:
+            case BAUD150:
+            case BAUD200:
+            case BAUD300:
+            case BAUD600:
+            case BAUD1200:
+            case BAUD1800:
+            case BAUD2400:
+            case BAUD4800:
+            case BAUD9600:
+            case BAUD19200:
+            case BAUD38400:
+            case BAUD57600:
+            case BAUD115200:
+
             default:
                 Settings.BaudRate=baudRate;
                 break;

--- a/src/core/pal/feature.cpp
+++ b/src/core/pal/feature.cpp
@@ -1337,6 +1337,11 @@ int FeaturePart::createCandidates( QList< LabelPosition*>& lPos,
           case QgsPalLayerSettings::Line:
             createCandidatesAlongLine( lPos, mapShape );
             break;
+
+          case QgsPalLayerSettings::Horizontal:
+          case QgsPalLayerSettings::Free:
+          case QgsPalLayerSettings::Curved:
+          case QgsPalLayerSettings::OrderedPositionsAroundPoint:
           default:
             createCandidatesForPolygon( lPos, mapShape );
             break;

--- a/src/core/pal/problem.cpp
+++ b/src/core/pal/problem.cpp
@@ -485,6 +485,8 @@ void Problem::popmusic()
       case POPMUSIC_CHAIN :
         delta = popmusic_chain( current );
         break;
+      case CHAIN:
+      case FALP:
       default:
         delete[] ok;
         delete[] parts;

--- a/src/core/qgis.cpp
+++ b/src/core/qgis.cpp
@@ -171,6 +171,11 @@ QGis::WkbType QGis::fromNewWkbType( QgsWKBTypes::Type type )
       return QGis::WKBMultiLineString25D;
     case QgsWKBTypes::MultiPolygonZ:
       return QGis::WKBMultiPolygon25D;
+
+
+    case QgsWKBTypes::Unknown:
+      return QGis::WKBUnknown;
+
     default:
       break;
   }
@@ -280,6 +285,18 @@ bool qgsVariantLessThan( const QVariant& lhs, const QVariant& rhs )
       return lhs.toTime() < rhs.toTime();
     case QVariant::DateTime:
       return lhs.toDateTime() < rhs.toDateTime();
+    case QVariant::Bool:
+      return !lhs.toBool();
+
+    case QVariant::String:
+    case QVariant::Map:
+    case QVariant::List:
+    case QVariant::StringList:
+    case QVariant::Invalid:
+    case QVariant::UserType:
+    case QVariant::ByteArray:
+    CASE_UNUSUAL_QVARIANT_TYPES:
+
     default:
       return QString::localeAwareCompare( lhs.toString(), rhs.toString() ) < 0;
   }
@@ -323,6 +340,17 @@ QGis::WkbType QGis::singleType( QGis::WkbType type )
       return WKBLineString25D;
     case WKBMultiPolygon25D:
       return WKBPolygon25D;
+
+    case WKBUnknown:
+    case WKBPoint:
+    case WKBLineString:
+    case WKBPolygon:
+    case WKBNoGeometry:
+    case WKBPoint25D:
+    case WKBLineString25D:
+    case WKBPolygon25D:
+      return type;
+
     default:
       return fromNewWkbType( QgsWKBTypes::singleType( fromOldWkbType( type ) ) );
   }
@@ -344,6 +372,16 @@ QGis::WkbType QGis::multiType( QGis::WkbType type )
       return WKBMultiLineString25D;
     case WKBPolygon25D:
       return WKBMultiPolygon25D;
+    case WKBUnknown:
+      return WKBUnknown;
+    case WKBMultiPoint:
+    case WKBMultiPoint25D:
+    case WKBMultiLineString:
+    case WKBMultiLineString25D:
+    case WKBMultiPolygon:
+    case WKBMultiPolygon25D:
+    case WKBNoGeometry:
+      return type;
     default:
       return fromNewWkbType( QgsWKBTypes::multiType( fromOldWkbType( type ) ) );
   }
@@ -365,6 +403,17 @@ QGis::WkbType QGis::flatType( QGis::WkbType type )
       return WKBMultiLineString;
     case WKBMultiPolygon25D:
       return WKBMultiPolygon;
+    case WKBUnknown:
+      return WKBUnknown;
+    case WKBPoint:
+    case WKBLineString:
+    case WKBPolygon:
+    case WKBMultiPoint:
+    case WKBMultiLineString:
+    case WKBMultiPolygon:
+    case WKBNoGeometry:
+      return type;
+
     default:
       return fromNewWkbType( QgsWKBTypes::flatType( fromOldWkbType( type ) ) );
   }

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -430,3 +430,43 @@ typedef unsigned long long qgssize;
 #else
 #define FALLTHROUGH
 #endif
+
+#define CASE_UNUSUAL_QVARIANT_TYPES \
+  case QVariant::BitArray: \
+  case QVariant::Url: \
+  case QVariant::Locale: \
+  case QVariant::Rect: \
+  case QVariant::RectF: \
+  case QVariant::Size: \
+  case QVariant::SizeF: \
+  case QVariant::Line: \
+  case QVariant::LineF: \
+  case QVariant::Point: \
+  case QVariant::PointF: \
+  case QVariant::RegExp: \
+  case QVariant::Hash: \
+  case QVariant::EasingCurve: \
+  case QVariant::Font: \
+  case QVariant::Pixmap: \
+  case QVariant::Brush: \
+  case QVariant::Color: \
+  case QVariant::Palette: \
+  case QVariant::Icon: \
+  case QVariant::Image: \
+  case QVariant::Polygon: \
+  case QVariant::Region: \
+  case QVariant::Bitmap: \
+  case QVariant::Cursor: \
+  case QVariant::SizePolicy: \
+  case QVariant::KeySequence: \
+  case QVariant::Pen: \
+  case QVariant::TextLength: \
+  case QVariant::TextFormat: \
+  case QVariant::Matrix: \
+  case QVariant::Transform: \
+  case QVariant::Matrix4x4: \
+  case QVariant::Vector2D: \
+  case QVariant::Vector3D: \
+  case QVariant::Vector4D: \
+  case QVariant::Quaternion: \
+  case QVariant::LastType

--- a/src/core/qgscachedfeatureiterator.cpp
+++ b/src/core/qgscachedfeatureiterator.cpp
@@ -41,6 +41,9 @@ QgsCachedFeatureIterator::QgsCachedFeatureIterator( QgsVectorLayerCache *vlCache
       mFeatureIds = QgsFeatureIds() << featureRequest.filterFid();
       break;
 
+    case QgsFeatureRequest::FilterNone:
+    case QgsFeatureRequest::FilterRect:
+    case QgsFeatureRequest::FilterExpression:
     default:
       mFeatureIds = mVectorLayerCache->mCache.keys().toSet();
       break;

--- a/src/core/qgsdataitem.cpp
+++ b/src/core/qgsdataitem.cpp
@@ -701,6 +701,10 @@ QgsLayerItem::QgsLayerItem( QgsDataItem* parent, const QString& name, const QStr
     case Raster:
       mIconName = "/mIconRaster.svg";
       break;
+    case NoType:
+    case Database:
+    case Table:
+    case Plugin:
     default:
       mIconName = "/mIconLayer.png";
       break;

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -3130,6 +3130,8 @@ QString QgsExpression::quotedValue( const QVariant& value, QVariant::Type type )
     case QVariant::Int:
     case QVariant::LongLong:
     case QVariant::Double:
+    case QVariant::UInt:
+    case QVariant::ULongLong:
       return value.toString();
 
     case QVariant::Bool:
@@ -3137,6 +3139,18 @@ QString QgsExpression::quotedValue( const QVariant& value, QVariant::Type type )
 
     default:
     case QVariant::String:
+    case QVariant::Date:
+    case QVariant::Time:
+    case QVariant::DateTime:
+    case QVariant::Invalid:
+    case QVariant::Char:
+    case QVariant::Map:
+    case QVariant::List:
+    case QVariant::StringList:
+    case QVariant::ByteArray:
+    case QVariant::UserType:
+    CASE_UNUSUAL_QVARIANT_TYPES:
+
       return quotedString( value.toString() );
   }
 
@@ -3815,6 +3829,23 @@ bool QgsExpression::NodeBinaryOperator::compare( double diff )
       return diff <= 0;
     case boGE:
       return diff >= 0;
+    case boOr:
+    case boAnd:
+    case boRegexp:
+    case boLike:
+    case boNotLike:
+    case boILike:
+    case boNotILike:
+    case boIs:
+    case boIsNot:
+    case boPlus:
+    case boMinus:
+    case boMul:
+    case boDiv:
+    case boIntDiv:
+    case boMod:
+    case boPow:
+    case boConcat:
     default:
       Q_ASSERT( false );
       return false;
@@ -3835,6 +3866,25 @@ int QgsExpression::NodeBinaryOperator::computeInt( int x, int y )
       return x / y;
     case boMod:
       return x % y;
+    case boOr:
+    case boAnd:
+    case boEQ:
+    case boNE:
+    case boLE:
+    case boGE:
+    case boLT:
+    case boGT:
+    case boRegexp:
+    case boLike:
+    case boNotLike:
+    case boILike:
+    case boNotILike:
+    case boIs:
+    case boIsNot:
+    case boIntDiv:
+    case boPow:
+    case boConcat:
+
     default:
       Q_ASSERT( false );
       return 0;
@@ -3849,6 +3899,27 @@ QDateTime QgsExpression::NodeBinaryOperator::computeDateTimeFromInterval( const 
       return d.addSecs( i->seconds() );
     case boMinus:
       return d.addSecs( -i->seconds() );
+    case boOr:
+    case boAnd:
+    case boEQ:
+    case boNE:
+    case boLE:
+    case boGE:
+    case boLT:
+    case boGT:
+    case boRegexp:
+    case boLike:
+    case boNotLike:
+    case boILike:
+    case boNotILike:
+    case boIs:
+    case boIsNot:
+    case boMul:
+    case boDiv:
+    case boIntDiv:
+    case boMod:
+    case boPow:
+    case boConcat:
     default:
       Q_ASSERT( false );
       return QDateTime();
@@ -3869,6 +3940,24 @@ double QgsExpression::NodeBinaryOperator::computeDouble( double x, double y )
       return x / y;
     case boMod:
       return fmod( x, y );
+    case boOr:
+    case boAnd:
+    case boEQ:
+    case boNE:
+    case boLE:
+    case boGE:
+    case boLT:
+    case boGT:
+    case boRegexp:
+    case boLike:
+    case boNotLike:
+    case boILike:
+    case boNotILike:
+    case boIs:
+    case boIsNot:
+    case boIntDiv:
+    case boPow:
+    case boConcat:
     default:
       Q_ASSERT( false );
       return 0;
@@ -4180,6 +4269,21 @@ QString QgsExpression::NodeLiteral::dump() const
       return quotedString( mValue.toString() );
     case QVariant::Bool:
       return mValue.toBool() ? "TRUE" : "FALSE";
+
+    case QVariant::Invalid:
+    case QVariant::UInt:
+    case QVariant::LongLong:
+    case QVariant::ULongLong:
+    case QVariant::Char:
+    case QVariant::Map:
+    case QVariant::StringList:
+    case QVariant::List:
+    case QVariant::Date:
+    case QVariant::Time:
+    case QVariant::DateTime:
+    case QVariant::ByteArray:
+    case QVariant::UserType:
+    CASE_UNUSUAL_QVARIANT_TYPES:
     default:
       return tr( "[unsupported type;%1; value:%2]" ).arg( mValue.typeName(), mValue.toString() );
   }

--- a/src/core/qgsexpressionsorter.h
+++ b/src/core/qgsexpressionsorter.h
@@ -103,6 +103,15 @@ class QgsExpressionSorter
             else
               return v1.toBool();
 
+          case QVariant::Invalid:
+          CASE_UNUSUAL_QVARIANT_TYPES:
+          case QVariant::Char:
+          case QVariant::Map:
+          case QVariant::List:
+          case QVariant::String:
+          case QVariant::StringList:
+          case QVariant::ByteArray:
+          case QVariant::UserType:
           default:
             if ( 0 == v1.toString().localeAwareCompare( v2.toString() ) )
               continue;

--- a/src/core/qgsfeatureiterator.cpp
+++ b/src/core/qgsfeatureiterator.cpp
@@ -72,6 +72,9 @@ bool QgsAbstractFeatureIterator::nextFeature( QgsFeature& f )
         dataOk = nextFeatureFilterFids( f );
         break;
 
+      case QgsFeatureRequest::FilterNone:
+      case QgsFeatureRequest::FilterRect:
+      case QgsFeatureRequest::FilterFid:
       default:
         dataOk = fetchFeature( f );
         break;

--- a/src/core/qgsgml.cpp
+++ b/src/core/qgsgml.cpp
@@ -583,6 +583,22 @@ void QgsGml::setAttribute( const QString& name, const QString& value )
       case QVariant::LongLong:
         var = QVariant( value.toLongLong() );
         break;
+
+      case QVariant::String:
+      case QVariant::Invalid:
+      case QVariant::Bool:
+      case QVariant::UInt:
+      case QVariant::ULongLong:
+      case QVariant::Char:
+      case QVariant::Map:
+      case QVariant::List:
+      case QVariant::StringList:
+      case QVariant::ByteArray:
+      case QVariant::Date:
+      case QVariant::Time:
+      case QVariant::DateTime:
+      case QVariant::UserType:
+      CASE_UNUSUAL_QVARIANT_TYPES:
       default: //string type is default
         var = QVariant( value );
         break;

--- a/src/core/qgslabel.cpp
+++ b/src/core/qgslabel.cpp
@@ -555,6 +555,8 @@ void QgsLabel::labelPoint( std::vector<labelpoint>& points, QgsFeature & feature
       }
     }
     break;
+    case QGis::WKBUnknown:
+    case QGis::WKBNoGeometry:
     default:
       QgsDebugMsg( "Unknown geometry type of " + QString::number( wkbType ) );
   }
@@ -697,6 +699,14 @@ const unsigned char* QgsLabel::labelPoint( labelpoint& point, const unsigned cha
     }
     break;
 
+    case QGis::WKBUnknown:
+    case QGis::WKBMultiPoint:
+    case QGis::WKBMultiLineString:
+    case QGis::WKBMultiPolygon:
+    case QGis::WKBNoGeometry:
+    case QGis::WKBMultiPoint25D:
+    case QGis::WKBMultiLineString25D:
+    case QGis::WKBMultiPolygon25D:
     default:
       // To get here is a bug because our caller should be filtering
       // on wkb type.

--- a/src/core/qgslegendrenderer.cpp
+++ b/src/core/qgslegendrenderer.cpp
@@ -375,6 +375,7 @@ QSizeF QgsLegendRenderer::drawTitle( QPainter* painter, QPointF point, Qt::Align
   switch ( halignment )
   {
     case Qt::AlignHCenter:
+    case Qt::AlignCenter:
       textBoxWidth = ( qMin( static_cast< double >( point.x() ), legendWidth - point.x() ) - mSettings.boxSpace() ) * 2.0;
       textBoxLeft = point.x() - textBoxWidth / 2.;
       break;
@@ -383,6 +384,13 @@ QSizeF QgsLegendRenderer::drawTitle( QPainter* painter, QPointF point, Qt::Align
       textBoxWidth = point.x() - mSettings.boxSpace();
       break;
     case Qt::AlignLeft:
+    case Qt::AlignJustify:
+    case Qt::AlignAbsolute:
+    case Qt::AlignHorizontal_Mask:
+    case Qt::AlignTop:
+    case Qt::AlignBottom:
+    case Qt::AlignVCenter:
+    case Qt::AlignVertical_Mask:
     default:
       textBoxLeft = point.x();
       textBoxWidth = legendWidth - point.x() - mSettings.boxSpace();
@@ -618,6 +626,10 @@ void QgsLegendRenderer::setNodeLegendStyle( QgsLayerTreeNode* node, QgsComposerL
     case QgsComposerLegendStyle::Subgroup:
       str = "subgroup";
       break;
+    case QgsComposerLegendStyle::Undefined:
+    case QgsComposerLegendStyle::Title:
+    case QgsComposerLegendStyle::Symbol:
+    case QgsComposerLegendStyle::SymbolLabel:
     default:
       break; // nothing
   }

--- a/src/core/qgsmaprenderer.cpp
+++ b/src/core/qgsmaprenderer.cpp
@@ -1238,6 +1238,15 @@ QgsMapRenderer::BlendMode QgsMapRenderer::getBlendModeEnum( QPainter::Compositio
       return QgsMapRenderer::BlendDestinationAtop;
     case QPainter::CompositionMode_Xor:
       return QgsMapRenderer::BlendXor;
+    case QPainter::RasterOp_SourceOrDestination:
+    case QPainter::RasterOp_SourceAndDestination:
+    case QPainter::RasterOp_SourceXorDestination:
+    case QPainter::RasterOp_NotSourceAndNotDestination:
+    case QPainter::RasterOp_NotSourceOrNotDestination:
+    case QPainter::RasterOp_NotSourceXorDestination:
+    case QPainter::RasterOp_NotSource:
+    case QPainter::RasterOp_NotSourceAndDestination:
+    case QPainter::RasterOp_SourceAndNotDestination:
     default:
       QgsDebugMsg( QString( "Composition mode %1 mapped to Normal" ).arg( blendMode ) );
       return QgsMapRenderer::BlendNormal;

--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -514,6 +514,14 @@ QgsVectorLayer* QgsOfflineEditing::copyVectorLayer( QgsVectorLayer* layer, sqlit
       case QGis::WKBMultiPolygon:
         geomType = "MULTIPOLYGON";
         break;
+      case QGis::WKBUnknown:
+      case QGis::WKBNoGeometry:
+      case QGis::WKBPoint25D:
+      case QGis::WKBLineString25D:
+      case QGis::WKBPolygon25D:
+      case QGis::WKBMultiPoint25D:
+      case QGis::WKBMultiLineString25D:
+      case QGis::WKBMultiPolygon25D:
       default:
         showWarning( tr( "QGIS wkbType %1 not supported" ).arg( layer->wkbType() ) );
         break;

--- a/src/core/qgsogcutils.cpp
+++ b/src/core/qgsogcutils.cpp
@@ -1092,6 +1092,16 @@ QDomElement QgsOgcUtils::geometryToGML( const QgsGeometry* geometry, QDomDocumen
       case QGis::WKBMultiPoint:
         baseCoordElem = doc.createElement( "gml:pos" );
         break;
+      case QGis::WKBUnknown:
+      case QGis::WKBLineString:
+      case QGis::WKBPolygon:
+      case QGis::WKBMultiLineString:
+      case QGis::WKBMultiPolygon:
+      case QGis::WKBNoGeometry:
+      case QGis::WKBLineString25D:
+      case QGis::WKBPolygon25D:
+      case QGis::WKBMultiLineString25D:
+      case QGis::WKBMultiPolygon25D:
       default:
         baseCoordElem = doc.createElement( "gml:posList" );
         break;
@@ -1360,6 +1370,8 @@ QDomElement QgsOgcUtils::geometryToGML( const QgsGeometry* geometry, QDomDocumen
       }
       return multiPolygonElem;
     }
+    case QGis::WKBUnknown:
+    case QGis::WKBNoGeometry:
     default:
       return QDomElement();
   }
@@ -1943,6 +1955,7 @@ QDomElement QgsOgcUtils::expressionNodeToOgcFilter( const QgsExpression::Node* n
     case QgsExpression::ntColumnRef:
       return expressionColumnRefToOgcFilter( static_cast<const QgsExpression::NodeColumnRef*>( node ), doc, errorMessage );
 
+    case QgsExpression::ntCondition:
     default:
       errorMessage = QString( "Node type not supported: %1" ).arg( node->nodeType() );
       return QDomElement();
@@ -2069,10 +2082,27 @@ QDomElement QgsOgcUtils::expressionLiteralToOgcFilter( const QgsExpression::Node
     case QVariant::Double:
       value = QString::number( node->value().toDouble() );
       break;
+    case QVariant::LongLong:
+      value = QString::number( node->value().toLongLong() );
+      break;
     case QVariant::String:
+    case QVariant::Char:
       value = node->value().toString();
       break;
 
+    case QVariant::Invalid:
+    case QVariant::Bool:
+    case QVariant::UInt:
+    case QVariant::ULongLong:
+    case QVariant::Map:
+    case QVariant::StringList:
+    case QVariant::List:
+    case QVariant::Date:
+    case QVariant::Time:
+    case QVariant::DateTime:
+    case QVariant::ByteArray:
+    case QVariant::UserType:
+    CASE_UNUSUAL_QVARIANT_TYPES:
     default:
       errorMessage = QString( "Literal type not supported: %1" ).arg( node->value().type() );
       return QDomElement();

--- a/src/core/qgspointlocator.cpp
+++ b/src/core/qgspointlocator.cpp
@@ -492,6 +492,7 @@ static QgsPointLocator::MatchList _geometrySegmentsInRect( QgsGeometry* geom, co
     }
 
     case QGis::WKBUnknown:
+    case QGis::WKBNoGeometry:
     default:
       return lst;
   } // switch (wkbType)

--- a/src/core/qgsprojectproperty.cpp
+++ b/src/core/qgsprojectproperty.cpp
@@ -211,6 +211,35 @@ bool QgsPropertyValue::readXML( QDomNode & keyNode )
         value_ = QVariant(subkeyElement.text()).toULongLong();
         break;
       */
+    case QVariant::LongLong:
+    case QVariant::ULongLong:
+    case QVariant::Char:
+    case QVariant::Date:
+    case QVariant::Time:
+    case QVariant::DateTime:
+    case QVariant::Url:
+    case QVariant::Locale:
+    case QVariant::RectF:
+    case QVariant::SizeF:
+    case QVariant::Line:
+    case QVariant::LineF:
+    case QVariant::PointF:
+    case QVariant::RegExp:
+    case QVariant::Hash:
+    case QVariant::EasingCurve:
+    case QVariant::Icon:
+    case QVariant::SizePolicy:
+    case QVariant::TextLength:
+    case QVariant::TextFormat:
+    case QVariant::Matrix:
+    case QVariant::Transform:
+    case QVariant::Matrix4x4:
+    case QVariant::Vector2D:
+    case QVariant::Vector3D:
+    case QVariant::Vector4D:
+    case QVariant::Quaternion:
+    case QVariant::UserType:
+    case QVariant::LastType:
     default :
       QgsDebugMsg( QString( "unsupported value type %1 .. not propertly translated to QVariant" ).arg( typeString ) );
   }

--- a/src/core/qgsscalecalculator.cpp
+++ b/src/core/qgsscalecalculator.cpp
@@ -71,6 +71,7 @@ double QgsScaleCalculator::calculate( const QgsRectangle &mapExtent, int canvasW
 
     default:
     case QGis::Degrees:
+    case QGis::UnknownUnit:
       // degrees require conversion to meters first
       conversionFactor = 39.3700787;
       delta = calculateGeographicDistance( mapExtent );

--- a/src/core/qgssqlexpressioncompiler.cpp
+++ b/src/core/qgssqlexpressioncompiler.cpp
@@ -62,6 +62,20 @@ QString QgsSqlExpressionCompiler::quotedValue( const QVariant& value, bool& ok )
 
     default:
     case QVariant::String:
+    case QVariant::Invalid:
+    case QVariant::UInt:
+    case QVariant::ULongLong:
+    case QVariant::Char:
+    case QVariant::Map:
+    case QVariant::List:
+    case QVariant::StringList:
+    case QVariant::Date:
+    case QVariant::Time:
+    case QVariant::DateTime:
+    case QVariant::ByteArray:
+    CASE_UNUSUAL_QVARIANT_TYPES:
+    case QVariant::UserType:
+
       QString v = value.toString();
       v.replace( '\'', "''" );
       if ( v.contains( '\\' ) )

--- a/src/core/qgsunittypes.cpp
+++ b/src/core/qgsunittypes.cpp
@@ -214,6 +214,7 @@ QString QgsUnitTypes::encodeUnit( QgsSymbolV2::OutputUnit unit )
       return "Pixel";
     case QgsSymbolV2::Percentage:
       return "Percentage";
+    case QgsSymbolV2::Mixed:
     default:
       return "MM";
   }

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -404,6 +404,17 @@ void QgsVectorFileWriter::init( QString vectorFileName, QString fileEncoding, co
         ogrType = OFTDateTime;
         break;
 
+      case QVariant::Invalid:
+      case QVariant::Bool:
+      case QVariant::UInt:
+      case QVariant::ULongLong:
+      case QVariant::Char:
+      case QVariant::Map:
+      case QVariant::List:
+      case QVariant::StringList:
+      case QVariant::ByteArray:
+      case QVariant::UserType:
+      CASE_UNUSUAL_QVARIANT_TYPES:
       default:
         //assert(0 && "invalid variant type!");
         mErrorMessage = QObject::tr( "unsupported type for field %1" )
@@ -1817,6 +1828,15 @@ OGRFeatureH QgsVectorFileWriter::createFeature( QgsFeature& feature )
         break;
       case QVariant::Invalid:
         break;
+
+      case QVariant::Bool:
+      case QVariant::Char:
+      case QVariant::Map:
+      case QVariant::List:
+      case QVariant::StringList:
+      case QVariant::ByteArray:
+      case QVariant::UserType:
+      CASE_UNUSUAL_QVARIANT_TYPES:
       default:
         mErrorMessage = QObject::tr( "Invalid variant type for field %1[%2]: received %3 with type %4" )
                         .arg( mFields.at( fldIdx ).name() )

--- a/src/core/qgsvectorlayereditutils.cpp
+++ b/src/core/qgsvectorlayereditutils.cpp
@@ -657,6 +657,13 @@ int QgsVectorLayerEditUtils::addTopologicalPoints( const QgsGeometry* geom )
       }
       break;
     }
+
+    case QGis::WKBPoint:
+    case QGis::WKBPoint25D:
+    case QGis::WKBMultiPoint:
+    case QGis::WKBMultiPoint25D:
+    case QGis::WKBNoGeometry:
+    case QGis::WKBUnknown:
     default:
       break;
   }

--- a/src/core/qgsvectorlayerfeatureiterator.cpp
+++ b/src/core/qgsvectorlayerfeatureiterator.cpp
@@ -23,6 +23,7 @@
 #include "qgsvectorlayer.h"
 #include "qgsvectorlayerjoinbuffer.h"
 #include "qgsexpressioncontext.h"
+#include "qgis.h"
 
 QgsVectorLayerFeatureSource::QgsVectorLayerFeatureSource( QgsVectorLayer *layer )
 {
@@ -701,8 +702,22 @@ void QgsVectorLayerFeatureIterator::FetchJoinInfo::addJoinedAttributesDirect( Qg
       case QVariant::Double:
         break;
 
-      default:
       case QVariant::String:
+      case QVariant::Invalid:
+      case QVariant::Bool:
+      case QVariant::UInt:
+      case QVariant::ULongLong:
+      case QVariant::Char:
+      case QVariant::Map:
+      case QVariant::List:
+      case QVariant::StringList:
+      case QVariant::ByteArray:
+      case QVariant::Date:
+      case QVariant::Time:
+      case QVariant::DateTime:
+      case QVariant::UserType:
+      default:
+      CASE_UNUSUAL_QVARIANT_TYPES:
         v.replace( '\'', "''" );
         v.prepend( '\'' ).append( '\'' );
         break;

--- a/src/core/qgsvectorlayerimport.cpp
+++ b/src/core/qgsvectorlayerimport.cpp
@@ -276,6 +276,15 @@ QgsVectorLayerImport::importLayer( QgsVectorLayer* layer,
         case QGis::WKBPolygon25D:
           wkbType = QGis::WKBMultiPolygon25D;
           break;
+
+        case QGis::WKBMultiPoint:
+        case QGis::WKBMultiPoint25D:
+        case QGis::WKBMultiLineString:
+        case QGis::WKBMultiLineString25D:
+        case QGis::WKBMultiPolygon:
+        case QGis::WKBMultiPolygon25D:
+        case QGis::WKBUnknown:
+        case QGis::WKBNoGeometry:
         default:
           break;
       }

--- a/src/core/raster/qgscontrastenhancement.cpp
+++ b/src/core/raster/qgscontrastenhancement.cpp
@@ -260,6 +260,7 @@ void QgsContrastEnhancement::setContrastEnhancementAlgorithm( ContrastEnhancemen
     case UserDefinedEnhancement :
       //Do nothing
       break;
+    case NoEnhancement:
     default:
       delete mContrastEnhancementFunction;
       mContrastEnhancementFunction = new QgsContrastEnhancementFunction( mRasterDataType, mMinimumValue, mMaximumValue );

--- a/src/core/raster/qgsraster.cpp
+++ b/src/core/raster/qgsraster.cpp
@@ -27,6 +27,7 @@ QString QgsRaster::contrastEnhancementLimitsAsString( ContrastEnhancementLimits 
       return "StdDev";
     case QgsRaster::ContrastEnhancementCumulativeCut:
       return "CumulativeCut";
+    case QgsRaster::ContrastEnhancementNone:
     default:
       break;
   }
@@ -66,6 +67,14 @@ double QgsRaster::representableValue( double value, QGis::DataType dataType )
       return static_cast<qint32>( value );
     case QGis::Float32:
       return static_cast<float>( value );
+    case QGis::UnknownDataType:
+    case QGis::Float64:
+    case QGis::CInt16:
+    case QGis::CInt32:
+    case QGis::CFloat32:
+    case QGis::CFloat64:
+    case QGis::ARGB32:
+    case QGis::ARGB32_Premultiplied:
     default:
       break;
   }

--- a/src/core/raster/qgsrasterblock.cpp
+++ b/src/core/raster/qgsrasterblock.cpp
@@ -264,6 +264,13 @@ QGis::DataType QgsRasterBlock::typeWithNoDataValue( QGis::DataType dataType, dou
       *noDataValue = std::numeric_limits<double>::max() * -1.0;
       newDataType = QGis::Float64;
       break;
+    case QGis::UnknownDataType:
+    case QGis::CInt16:
+    case QGis::CInt32:
+    case QGis::CFloat32:
+    case QGis::CFloat64:
+    case QGis::ARGB32:
+    case QGis::ARGB32_Premultiplied:
     default:
       QgsDebugMsg( QString( "Unknown data type %1" ).arg( dataType ) );
       return QGis::UnknownDataType;
@@ -888,6 +895,13 @@ QByteArray QgsRasterBlock::valueBytes( QGis::DataType theDataType, double theVal
       d = static_cast< double >( theValue );
       memcpy( data, &d, size );
       break;
+    case QGis::UnknownDataType:
+    case QGis::CInt16:
+    case QGis::CInt32:
+    case QGis::CFloat32:
+    case QGis::CFloat64:
+    case QGis::ARGB32:
+    case QGis::ARGB32_Premultiplied:
     default:
       QgsDebugMsg( "Data type is not supported" );
   }

--- a/src/core/raster/qgsrasterblock.h
+++ b/src/core/raster/qgsrasterblock.h
@@ -446,6 +446,13 @@ inline double QgsRasterBlock::readValue( void *data, QGis::DataType type, qgssiz
     case QGis::Float64:
       return static_cast< double >(( static_cast< double * >( data ) )[index] );
       break;
+    case QGis::UnknownDataType:
+    case QGis::CInt16:
+    case QGis::CInt32:
+    case QGis::CFloat32:
+    case QGis::CFloat64:
+    case QGis::ARGB32:
+    case QGis::ARGB32_Premultiplied:
     default:
       QgsDebugMsg( QString( "Data type %1 is not supported" ).arg( type ) );
       break;
@@ -481,6 +488,13 @@ inline void QgsRasterBlock::writeValue( void *data, QGis::DataType type, qgssize
     case QGis::Float64:
       ( static_cast< double * >( data ) )[index] = value;
       break;
+    case QGis::UnknownDataType:
+    case QGis::CInt16:
+    case QGis::CInt32:
+    case QGis::CFloat32:
+    case QGis::CFloat64:
+    case QGis::ARGB32:
+    case QGis::ARGB32_Premultiplied:
     default:
       QgsDebugMsg( QString( "Data type %1 is not supported" ).arg( type ) );
       break;

--- a/src/core/raster/qgsrasterdataprovider.cpp
+++ b/src/core/raster/qgsrasterdataprovider.cpp
@@ -458,6 +458,7 @@ QString QgsRasterDataProvider::identifyFormatName( QgsRaster::IdentifyFormat for
       return "Html";
     case QgsRaster::IdentifyFormatFeature:
       return "Feature";
+    case QgsRaster::IdentifyFormatUndefined:
     default:
       return "Undefined";
   }
@@ -475,6 +476,7 @@ QString QgsRasterDataProvider::identifyFormatLabel( QgsRaster::IdentifyFormat fo
       return tr( "Html" );
     case QgsRaster::IdentifyFormatFeature:
       return tr( "Feature" );
+    case QgsRaster::IdentifyFormatUndefined:
     default:
       return "Undefined";
   }
@@ -501,6 +503,7 @@ QgsRasterInterface::Capability QgsRasterDataProvider::identifyFormatToCapability
       return IdentifyHtml;
     case QgsRaster::IdentifyFormatFeature:
       return IdentifyFeature;
+    case QgsRaster::IdentifyFormatUndefined:
     default:
       return NoCapabilities;
   }

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -384,6 +384,9 @@ QString QgsRasterLayer::metadata()
     case QGis::CFloat64:
       myMetadata += tr( "CFloat64 - Complex Float64 " );
       break;
+    case QGis::UnknownDataType:
+    case QGis::ARGB32:
+    case QGis::ARGB32_Premultiplied:
     default:
       myMetadata += tr( "Could not determine raster data type." );
   }

--- a/src/core/raster/qgsrasterrendererregistry.cpp
+++ b/src/core/raster/qgsrasterrendererregistry.cpp
@@ -199,6 +199,11 @@ QgsRasterRenderer* QgsRasterRendererRegistry::defaultRendererForDrawingStyle( Qg
       renderer = new QgsSingleBandColorDataRenderer( provider, 1 );
       break;
     }
+    case QgsRaster::UndefinedDrawingStyle:
+    case QgsRaster::PalettedSingleBandGray:
+    case QgsRaster::PalettedSingleBandPseudoColor:
+    case QgsRaster::PalettedMultiBandColor:
+    case QgsRaster::MultiBandSingleBandPseudoColor:
     default:
       return nullptr;
   }

--- a/src/core/symbology-ng/qgsgeometrygeneratorsymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgsgeometrygeneratorsymbollayerv2.cpp
@@ -132,6 +132,8 @@ QgsStringMap QgsGeometryGeneratorSymbolLayerV2::properties() const
     case QgsSymbolV2::Line:
       props.insert( "SymbolType", "Line" );
       break;
+    case QgsSymbolV2::Fill:
+    case QgsSymbolV2::Hybrid:
     default:
       props.insert( "SymbolType", "Fill" );
       break;
@@ -167,6 +169,7 @@ bool QgsGeometryGeneratorSymbolLayerV2::setSubSymbol( QgsSymbolV2* symbol )
       mFillSymbol = static_cast<QgsFillSymbolV2*>( symbol );
       break;
 
+    case QgsSymbolV2::Hybrid:
     default:
       break;
   }

--- a/src/core/symbology-ng/qgslinesymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgslinesymbollayerv2.cpp
@@ -1403,6 +1403,7 @@ void QgsMarkerLineSymbolLayerV2::toSld( QDomDocument &doc, QDomElement &element,
         // no way to get line/polygon's vertices, use a VendorOption
         symbolizerElem.appendChild( QgsSymbolLayerV2Utils::createVendorOptionElement( doc, "placement", "points" ) );
         break;
+      case Interval:
       default:
         gap = QString::number( mInterval );
         break;

--- a/src/core/symbology-ng/qgsrulebasedrendererv2.cpp
+++ b/src/core/symbology-ng/qgsrulebasedrendererv2.cpp
@@ -808,6 +808,8 @@ QgsRuleBasedRendererV2::Rule* QgsRuleBasedRendererV2::Rule::createFromSld( QDomE
         symbol = new QgsMarkerSymbolV2( layers );
         break;
 
+      case QGis::UnknownGeometry:
+      case QGis::NoGeometry:
       default:
         QgsDebugMsg( QString( "invalid geometry type: found %1" ).arg( geomType ) );
         return nullptr;
@@ -1411,6 +1413,8 @@ void QgsRuleBasedRendererV2::convertToDataDefinedSymbology( QgsSymbolV2* symbol,
         }
       }
       break;
+    case QgsSymbolV2::Fill:
+    case QgsSymbolV2::Hybrid:
     default:
       break;
   }

--- a/src/core/symbology-ng/qgssinglesymbolrendererv2.cpp
+++ b/src/core/symbology-ng/qgssinglesymbolrendererv2.cpp
@@ -346,6 +346,8 @@ QgsFeatureRendererV2* QgsSingleSymbolRendererV2::createFromSld( QDomElement& ele
       symbol = new QgsMarkerSymbolV2( layers );
       break;
 
+    case QGis::UnknownGeometry:
+    case QGis::NoGeometry:
     default:
       QgsDebugMsg( QString( "invalid geometry type: found %1" ).arg( geomType ) );
       return nullptr;

--- a/src/core/symbology-ng/qgsstylev2.cpp
+++ b/src/core/symbology-ng/qgsstylev2.cpp
@@ -765,6 +765,9 @@ bool QgsStyleV2::group( StyleEntity type, const QString& name, int groupid )
       query = sqlite3_mprintf( "UPDATE colorramp SET groupid=%d WHERE name='%q'", groupid, name.toUtf8().constData() );
       break;
 
+    case GroupEntity:
+    case TagEntity:
+    case SmartgroupEntity:
     default:
       QgsDebugMsg( "Wrong entity value. cannot apply group" );
       return false;

--- a/src/core/symbology-ng/qgssymbollayerv2utils.cpp
+++ b/src/core/symbology-ng/qgssymbollayerv2utils.cpp
@@ -145,6 +145,8 @@ QString QgsSymbolLayerV2Utils::encodePenStyle( Qt::PenStyle style )
       return "dash dot";
     case Qt::DashDotDotLine:
       return "dash dot dot";
+    case Qt::CustomDashLine:
+    case Qt::MPenStyle:
     default:
       return "???";
   }
@@ -168,9 +170,11 @@ QString QgsSymbolLayerV2Utils::encodePenJoinStyle( Qt::PenJoinStyle style )
     case Qt::BevelJoin:
       return "bevel";
     case Qt::MiterJoin:
+    case Qt::SvgMiterJoin:
       return "miter";
     case Qt::RoundJoin:
       return "round";
+    case Qt::MPenJoinStyle:
     default:
       return "???";
   }
@@ -191,9 +195,11 @@ QString QgsSymbolLayerV2Utils::encodeSldLineJoinStyle( Qt::PenJoinStyle style )
     case Qt::BevelJoin:
       return "bevel";
     case Qt::MiterJoin:
+    case Qt::SvgMiterJoin:
       return "mitre";
     case Qt::RoundJoin:
       return "round";
+    case Qt::MPenJoinStyle:
     default:
       return "";
   }
@@ -217,6 +223,7 @@ QString QgsSymbolLayerV2Utils::encodePenCapStyle( Qt::PenCapStyle style )
       return "flat";
     case Qt::RoundCap:
       return "round";
+    case Qt::MPenCapStyle:
     default:
       return "???";
   }
@@ -240,6 +247,7 @@ QString QgsSymbolLayerV2Utils::encodeSldLineCapStyle( Qt::PenCapStyle style )
       return "butt";
     case Qt::RoundCap:
       return "round";
+    case Qt::MPenCapStyle:
     default:
       return "";
   }
@@ -287,6 +295,10 @@ QString QgsSymbolLayerV2Utils::encodeBrushStyle( Qt::BrushStyle style )
       return "dense7";
     case Qt::NoBrush :
       return "no";
+    case Qt::LinearGradientPattern:
+    case Qt::RadialGradientPattern:
+    case Qt::ConicalGradientPattern:
+    case Qt::TexturePattern:
     default:
       return "???";
   }
@@ -344,6 +356,7 @@ QString QgsSymbolLayerV2Utils::encodeSldBrushStyle( Qt::BrushStyle style )
     case Qt::Dense7Pattern:
       return QString( "brush://%1" ).arg( encodeBrushStyle( style ) );
 
+    case Qt::NoBrush:
     default:
       return QString();
   }
@@ -1037,6 +1050,7 @@ static QString _nameForSymbolType( QgsSymbolV2::SymbolType type )
       return "marker";
     case QgsSymbolV2::Fill:
       return "fill";
+    case QgsSymbolV2::Hybrid:
     default:
       return "";
   }
@@ -1135,6 +1149,8 @@ bool QgsSymbolLayerV2Utils::createSymbolLayerV2ListFromSld( QDomElement& element
 
           break;
 
+        case QGis::UnknownGeometry:
+        case QGis::NoGeometry:
         default:
           break;
       }
@@ -1171,6 +1187,8 @@ bool QgsSymbolLayerV2Utils::createSymbolLayerV2ListFromSld( QDomElement& element
 
           break;
 
+        case QGis::UnknownGeometry:
+        case QGis::NoGeometry:
         default:
           break;
       }
@@ -1227,6 +1245,8 @@ bool QgsSymbolLayerV2Utils::createSymbolLayerV2ListFromSld( QDomElement& element
           convertPolygonSymbolizerToPointMarker( element, layers );
           break;
 
+        case QGis::UnknownGeometry:
+        case QGis::NoGeometry:
         default:
           break;
       }
@@ -1783,6 +1803,10 @@ void QgsSymbolLayerV2Utils::fillToSld( QDomDocument &doc, QDomElement &element, 
       patternName = encodeSldBrushStyle( brushStyle );
       break;
 
+    case Qt::LinearGradientPattern:
+    case Qt::RadialGradientPattern:
+    case Qt::ConicalGradientPattern:
+    case Qt::TexturePattern:
     default:
       element.appendChild( doc.createComment( QString( "Qt::BrushStyle '%1'' not supported yet" ).arg( brushStyle ) ) );
       return;
@@ -1905,6 +1929,7 @@ void QgsSymbolLayerV2Utils::lineToSld( QDomDocument &doc, QDomElement &element,
       pattern = customDashPattern;
       break;
 
+    case Qt::MPenStyle:
     default:
       element.appendChild( doc.createComment( QString( "Qt::BrushStyle '%1'' not supported yet" ).arg( penStyle ) ) );
       return;
@@ -2438,6 +2463,7 @@ QString QgsSymbolLayerV2Utils::ogrFeatureStylePen( double width, double mmScaleF
       penStyle.append( 'r' );
       break;
     case Qt::FlatCap:
+    case Qt::MPenCapStyle:
     default:
       penStyle.append( 'b' );
   }
@@ -2453,6 +2479,8 @@ QString QgsSymbolLayerV2Utils::ogrFeatureStylePen( double width, double mmScaleF
       penStyle.append( 'r' );
       break;
     case Qt::MiterJoin:
+    case Qt::SvgMiterJoin:
+    case Qt::MPenJoinStyle:
     default:
       penStyle.append( 'm' );
   }

--- a/src/core/symbology-ng/qgssymbologyv2conversion.cpp
+++ b/src/core/symbology-ng/qgssymbologyv2conversion.cpp
@@ -180,6 +180,8 @@ static QgsSymbolV2* readOldSymbol( const QDomNode& synode, QGis::GeometryType ge
       return new QgsFillSymbolV2( layers );
     }
 
+    case QGis::UnknownGeometry:
+    case QGis::NoGeometry:
     default:
       return nullptr;
   }

--- a/src/core/symbology-ng/qgssymbolv2.cpp
+++ b/src/core/symbology-ng/qgssymbolv2.cpp
@@ -319,11 +319,12 @@ QgsSymbolV2* QgsSymbolV2::defaultSymbol( QGis::GeometryType geomType )
     case QGis::Polygon :
       defaultSymbol = QgsProject::instance()->readEntry( "DefaultStyles", "/Fill", "" );
       break;
+    case QGis::UnknownGeometry:
+    case QGis::NoGeometry:
     default:
-      defaultSymbol = "";
       break;
   }
-  if ( defaultSymbol != "" )
+  if ( !defaultSymbol.isEmpty() )
     s = QgsStyleV2::defaultStyle()->symbol( defaultSymbol );
 
   // if no default found for this type, get global default (as previously)
@@ -340,6 +341,8 @@ QgsSymbolV2* QgsSymbolV2::defaultSymbol( QGis::GeometryType geomType )
       case QGis::Polygon:
         s = new QgsFillSymbolV2();
         break;
+      case QGis::UnknownGeometry:
+      case QGis::NoGeometry:
       default:
         QgsDebugMsg( "unknown layer's geometry type" );
         return nullptr;
@@ -350,7 +353,7 @@ QgsSymbolV2* QgsSymbolV2::defaultSymbol( QGis::GeometryType geomType )
   s->setAlpha( QgsProject::instance()->readDoubleEntry( "DefaultStyles", "/AlphaInt", 255 ) / 255.0 );
 
   // set random color, it project prefs allow
-  if ( defaultSymbol == "" ||
+  if ( defaultSymbol.isEmpty() ||
        QgsProject::instance()->readBoolEntry( "DefaultStyles", "/RandomColors", true ) )
   {
     s->setColor( QColor::fromHsv( qrand() % 360, 64 + qrand() % 192, 128 + qrand() % 128 ) );
@@ -601,6 +604,7 @@ QString QgsSymbolV2::dump() const
     case QgsSymbolV2::Fill:
       t = "FILL";
       break;
+    case QgsSymbolV2::Hybrid:
     default:
       Q_ASSERT( 0 && "unknown symbol type" );
   }
@@ -721,9 +725,12 @@ void QgsSymbolV2::renderFeature( const QgsFeature& feature, QgsRenderContext& co
     mSymbolRenderContext->expressionContextScope()->setVariable( QgsExpressionContext::EXPR_GEOMETRY_PART_NUM, 1 );
   }
 
-  switch ( QgsWKBTypes::flatType( segmentizedGeometry->geometry()->wkbType() ) )
+  switch ( segmentizedGeometry->geometry()->wkbType() )
   {
     case QgsWKBTypes::Point:
+    case QgsWKBTypes::PointZ:
+    case QgsWKBTypes::PointM:
+    case QgsWKBTypes::PointZM:
     {
       QPointF pt;
       if ( mType != QgsSymbolV2::Marker )
@@ -747,6 +754,9 @@ void QgsSymbolV2::renderFeature( const QgsFeature& feature, QgsRenderContext& co
     }
     break;
     case QgsWKBTypes::LineString:
+    case QgsWKBTypes::LineStringZ:
+    case QgsWKBTypes::LineStringM:
+    case QgsWKBTypes::LineStringZM:
     {
       QPolygonF pts;
       if ( mType != QgsSymbolV2::Line )
@@ -759,6 +769,9 @@ void QgsSymbolV2::renderFeature( const QgsFeature& feature, QgsRenderContext& co
     }
     break;
     case QgsWKBTypes::Polygon:
+    case QgsWKBTypes::PolygonZ:
+    case QgsWKBTypes::PolygonM:
+    case QgsWKBTypes::PolygonZM:
     {
       QPolygonF pts;
       QList<QPolygonF> holes;
@@ -773,6 +786,9 @@ void QgsSymbolV2::renderFeature( const QgsFeature& feature, QgsRenderContext& co
     break;
 
     case QgsWKBTypes::MultiPoint:
+    case QgsWKBTypes::MultiPointZ:
+    case QgsWKBTypes::MultiPointM:
+    case QgsWKBTypes::MultiPointZM:
     {
       QPointF pt;
 
@@ -796,7 +812,13 @@ void QgsSymbolV2::renderFeature( const QgsFeature& feature, QgsRenderContext& co
     break;
 
     case QgsWKBTypes::MultiCurve:
+    case QgsWKBTypes::MultiCurveZ:
+    case QgsWKBTypes::MultiCurveM:
+    case QgsWKBTypes::MultiCurveZM:
     case QgsWKBTypes::MultiLineString:
+    case QgsWKBTypes::MultiLineStringZ:
+    case QgsWKBTypes::MultiLineStringM:
+    case QgsWKBTypes::MultiLineStringZM:
     {
       QPolygonF pts;
 
@@ -828,7 +850,13 @@ void QgsSymbolV2::renderFeature( const QgsFeature& feature, QgsRenderContext& co
     break;
 
     case QgsWKBTypes::MultiSurface:
+    case QgsWKBTypes::MultiSurfaceZ:
+    case QgsWKBTypes::MultiSurfaceM:
+    case QgsWKBTypes::MultiSurfaceZM:
     case QgsWKBTypes::MultiPolygon:
+    case QgsWKBTypes::MultiPolygonZ:
+    case QgsWKBTypes::MultiPolygonM:
+    case QgsWKBTypes::MultiPolygonZM:
     {
       if ( mType != QgsSymbolV2::Fill )
       {

--- a/src/gui/attributetable/qgsattributetablefiltermodel.cpp
+++ b/src/gui/attributetable/qgsattributetablefiltermodel.cpp
@@ -86,6 +86,16 @@ bool QgsAttributeTableFilterModel::lessThan( const QModelIndex &left, const QMod
     case QVariant::DateTime:
       return leftData.toDateTime() < rightData.toDateTime();
 
+    case QVariant::String:
+    case QVariant::Invalid:
+    case QVariant::Bool:
+    case QVariant::Char:
+    case QVariant::Map:
+    case QVariant::List:
+    case QVariant::StringList:
+    case QVariant::ByteArray:
+    case QVariant::UserType:
+    CASE_UNUSUAL_QVARIANT_TYPES:
     default:
       return leftData.toString().localeAwareCompare( rightData.toString() ) < 0;
   }

--- a/src/gui/attributetable/qgsattributetableview.cpp
+++ b/src/gui/attributetable/qgsattributetableview.cpp
@@ -72,18 +72,13 @@ bool QgsAttributeTableView::eventFilter( QObject *object, QEvent *event )
 {
   if ( object == verticalHeader()->viewport() )
   {
-    switch ( event->type() )
+    if ( event->type() == QEvent::MouseButtonPress )
     {
-      case QEvent::MouseButtonPress:
-        mFeatureSelectionModel->enableSync( false );
-        break;
-
-      case QEvent::MouseButtonRelease:
-        mFeatureSelectionModel->enableSync( true );
-        break;
-
-      default:
-        break;
+      mFeatureSelectionModel->enableSync( false );
+    }
+    else if ( event->type() == QEvent::MouseButtonRelease )
+    {
+      mFeatureSelectionModel->enableSync( true );
     }
   }
   return false;

--- a/src/gui/auth/qgsauthauthoritieseditor.cpp
+++ b/src/gui/auth/qgsauthauthoritieseditor.cpp
@@ -410,6 +410,8 @@ void QgsAuthAuthoritiesEditor::checkSelection()
         iscert = true;
         isdbcert = true;
         break;
+      case QgsAuthAuthoritiesEditor::Section:
+      case QgsAuthAuthoritiesEditor::OrgName:
       default:
         break;
     }
@@ -432,6 +434,9 @@ void QgsAuthAuthoritiesEditor::handleDoubleClick( QTreeWidgetItem *item, int col
     case QgsAuthAuthoritiesEditor::OrgName:
       iscert = false;
       break;
+    case QgsAuthAuthoritiesEditor::RootCaCert:
+    case QgsAuthAuthoritiesEditor::FileCaCert:
+    case QgsAuthAuthoritiesEditor::DbCaCert:
     default:
       break;
   }

--- a/src/gui/auth/qgsauthcerttrustpolicycombobox.cpp
+++ b/src/gui/auth/qgsauthcerttrustpolicycombobox.cpp
@@ -101,6 +101,7 @@ void QgsAuthCertTrustPolicyComboBox::highlightCurrentIndex( int indx )
       ss = QgsAuthGuiUtils::redTextStyleSheet( "QComboBox:open" ) + "\nQComboBox:!open{}";
       break;
     case QgsAuthCertUtils::DefaultTrust:
+    case QgsAuthCertUtils::NoPolicy:
     default:
       break;
   }

--- a/src/gui/auth/qgsauthidentitieseditor.cpp
+++ b/src/gui/auth/qgsauthidentitieseditor.cpp
@@ -262,6 +262,8 @@ void QgsAuthIdentitiesEditor::checkSelection()
       case QgsAuthIdentitiesEditor::CertIdentity:
         iscert = true;
         break;
+      case QgsAuthIdentitiesEditor::Section:
+      case QgsAuthIdentitiesEditor::OrgName:
       default:
         break;
     }
@@ -284,6 +286,7 @@ void QgsAuthIdentitiesEditor::handleDoubleClick( QTreeWidgetItem *item, int col 
     case QgsAuthIdentitiesEditor::OrgName:
       iscert = false;
       break;
+    case QgsAuthIdentitiesEditor::CertIdentity:
     default:
       break;
   }

--- a/src/gui/auth/qgsauthserverseditor.cpp
+++ b/src/gui/auth/qgsauthserverseditor.cpp
@@ -241,6 +241,8 @@ void QgsAuthServersEditor::checkSelection()
       case QgsAuthServersEditor::ServerConfig :
         isconfig = true;
         break;
+      case QgsAuthServersEditor::Section:
+      case QgsAuthServersEditor::OrgName:
       default:
         break;
     }
@@ -263,6 +265,7 @@ void QgsAuthServersEditor::handleDoubleClick( QTreeWidgetItem *item, int col )
     case QgsAuthServersEditor::OrgName:
       isconfig = false;
       break;
+    case QgsAuthServersEditor::ServerConfig:
     default:
       break;
   }

--- a/src/gui/auth/qgsauthsslerrorsdialog.cpp
+++ b/src/gui/auth/qgsauthsslerrorsdialog.cpp
@@ -165,23 +165,22 @@ void QgsAuthSslErrorsDialog::clearCertificateConfig()
 void QgsAuthSslErrorsDialog::on_buttonBox_clicked( QAbstractButton *button )
 {
   QDialogButtonBox::StandardButton btnenum( buttonBox->standardButton( button ) );
-  switch ( btnenum )
+  if ( btnenum ==  QDialogButtonBox::Ignore )
   {
-    case QDialogButtonBox::Ignore:
-      QgsAuthManager::instance()->updateIgnoredSslErrorsCache(
-        QString( "%1:%2" ).arg( mDigest, mHostPort ),
-        mSslErrors );
-      accept();
-      break;
-    case QDialogButtonBox::Save:
-      // save config and ignore errors
-      wdgtSslConfig->saveSslCertConfig();
-      accept();
-      break;
-    case QDialogButtonBox::Abort:
-    default:
-      reject();
-      break;
+    QgsAuthManager::instance()->updateIgnoredSslErrorsCache(
+      QString( "%1:%2" ).arg( mDigest, mHostPort ),
+      mSslErrors );
+    accept();
+  }
+  else if ( btnenum == QDialogButtonBox::Save )
+  {
+    // save config and ignore errors
+    wdgtSslConfig->saveSslCertConfig();
+    accept();
+  }
+  else
+  {
+    reject();
   }
 }
 

--- a/src/gui/auth/qgsauthtrustedcasdialog.cpp
+++ b/src/gui/auth/qgsauthtrustedcasdialog.cpp
@@ -258,6 +258,8 @@ void QgsAuthTrustedCAsDialog::checkSelection()
       case QgsAuthTrustedCAsDialog::CaCert:
         iscert = true;
         break;
+      case QgsAuthTrustedCAsDialog::Section:
+      case QgsAuthTrustedCAsDialog::OrgName:
       default:
         break;
     }
@@ -279,6 +281,7 @@ void QgsAuthTrustedCAsDialog::handleDoubleClick( QTreeWidgetItem *item, int col 
     case QgsAuthTrustedCAsDialog::OrgName:
       iscert = false;
       break;
+    case QgsAuthTrustedCAsDialog::CaCert:
     default:
       break;
   }

--- a/src/gui/editorwidgets/qgsrangeconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsrangeconfigdlg.cpp
@@ -44,6 +44,21 @@ QgsRangeConfigDlg::QgsRangeConfigDlg( QgsVectorLayer* vl, int fieldIdx, QWidget 
       break;
     }
 
+    case QVariant::String:
+    case QVariant::Invalid:
+    case QVariant::Bool:
+    case QVariant::UInt:
+    case QVariant::ULongLong:
+    case QVariant::Char:
+    case QVariant::Map:
+    case QVariant::List:
+    case QVariant::StringList:
+    case QVariant::ByteArray:
+    case QVariant::Date:
+    case QVariant::Time:
+    case QVariant::DateTime:
+    case QVariant::UserType:
+    CASE_UNUSUAL_QVARIANT_TYPES:
     default:
       text = tr( "Attribute has no integer or real type, therefore range is not usable." );
       break;
@@ -73,6 +88,21 @@ QgsEditorWidgetConfig QgsRangeConfigDlg::config()
       cfg.insert( "Step", stepDoubleSpinBox->value() );
       break;
 
+    case QVariant::String:
+    case QVariant::Invalid:
+    case QVariant::Bool:
+    case QVariant::UInt:
+    case QVariant::ULongLong:
+    case QVariant::Char:
+    case QVariant::Map:
+    case QVariant::List:
+    case QVariant::StringList:
+    case QVariant::ByteArray:
+    case QVariant::Date:
+    case QVariant::Time:
+    case QVariant::DateTime:
+    case QVariant::UserType:
+    CASE_UNUSUAL_QVARIANT_TYPES:
     default:
       break;
   }

--- a/src/gui/editorwidgets/qgsrangewidgetfactory.cpp
+++ b/src/gui/editorwidgets/qgsrangewidgetfactory.cpp
@@ -80,6 +80,21 @@ bool QgsRangeWidgetFactory::isFieldSupported( QgsVectorLayer* vl, int fieldIdx )
     case QVariant::Int:
       return true;
 
+    case QVariant::String:
+    case QVariant::Invalid:
+    case QVariant::Bool:
+    case QVariant::UInt:
+    case QVariant::ULongLong:
+    case QVariant::Char:
+    case QVariant::Map:
+    case QVariant::List:
+    case QVariant::StringList:
+    case QVariant::ByteArray:
+    case QVariant::Date:
+    case QVariant::Time:
+    case QVariant::DateTime:
+    case QVariant::UserType:
+    CASE_UNUSUAL_QVARIANT_TYPES:
     default:
       return false;
   }

--- a/src/gui/editorwidgets/qgsrangewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrangewidgetwrapper.cpp
@@ -46,20 +46,17 @@ QWidget* QgsRangeWidgetWrapper::createWidget( QWidget* parent )
   else
   {
     QgsDebugMsg( QString( "%1" ).arg(( int )layer()->fields().at( fieldIdx() ).type() ) );
-    switch ( layer()->fields().at( fieldIdx() ).type() )
+    if ( layer()->fields().at( fieldIdx() ).type()  == QVariant::Double )
     {
-      case QVariant::Double:
-      {
-        editor = new QgsDoubleSpinBox( parent );
-        break;
-      }
-      case QVariant::Int:
-      case QVariant::LongLong:
-      default:
-        editor = new QgsSpinBox( parent );
-        break;
+      editor = new QgsDoubleSpinBox( parent );
+
+    }
+    else
+    {
+      editor = new QgsSpinBox( parent );
     }
   }
+
 
   return editor;
 }

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -45,6 +45,22 @@ bool orderByLessThan( const QgsRelationReferenceWidget::ValueRelationItem& p1
     case QVariant::Double:
       return p1.first.toDouble() < p2.first.toDouble();
 
+    case QVariant::Int:
+    case QVariant::Invalid:
+    case QVariant::Bool:
+    case QVariant::UInt:
+    case QVariant::LongLong:
+    case QVariant::ULongLong:
+    case QVariant::Char:
+    case QVariant::Map:
+    case QVariant::List:
+    case QVariant::StringList:
+    case QVariant::ByteArray:
+    case QVariant::Date:
+    case QVariant::Time:
+    case QVariant::DateTime:
+    case QVariant::UserType:
+    CASE_UNUSUAL_QVARIANT_TYPES:
     default:
       return p1.first.toInt() < p2.first.toInt();
   }

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
@@ -35,6 +35,22 @@ bool QgsValueRelationWidgetWrapper::orderByKeyLessThan( const QgsValueRelationWi
     case QVariant::Double:
       return p1.first.toDouble() < p2.first.toDouble();
 
+    case QVariant::Int:
+    case QVariant::Invalid:
+    case QVariant::Bool:
+    case QVariant::UInt:
+    case QVariant::LongLong:
+    case QVariant::ULongLong:
+    case QVariant::Char:
+    case QVariant::Map:
+    case QVariant::List:
+    case QVariant::StringList:
+    case QVariant::ByteArray:
+    case QVariant::Date:
+    case QVariant::Time:
+    case QVariant::DateTime:
+    case QVariant::UserType:
+    CASE_UNUSUAL_QVARIANT_TYPES:
     default:
       return p1.first.toInt() < p2.first.toInt();
   }

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -800,6 +800,7 @@ QWidget* QgsAttributeForm::createWidgetFromDef( const QgsAttributeEditorElement 
       break;
     }
 
+    case QgsAttributeEditorElement::AeTypeInvalid:
     default:
       QgsDebugMsg( "Unknown attribute editor widget type encountered..." );
       break;

--- a/src/gui/qgscolorwidgets.cpp
+++ b/src/gui/qgscolorwidgets.cpp
@@ -97,6 +97,7 @@ int QgsColorWidget::componentValue( const QgsColorWidget::ColorComponent compone
       return mCurrentColor.value();
     case QgsColorWidget::Alpha:
       return mCurrentColor.alpha();
+    case QgsColorWidget::Multiple:
     default:
       return -1;
   }
@@ -170,6 +171,7 @@ void QgsColorWidget::alterColor( QColor& color, const QgsColorWidget::ColorCompo
     case QgsColorWidget::Alpha:
       color.setAlpha( clippedValue );
       return;
+    case QgsColorWidget::Multiple:
     default:
       return;
   }
@@ -326,6 +328,7 @@ void QgsColorWidget::setComponentValue( const int value )
       }
       mCurrentColor.setAlpha( valueClipped );
       break;
+    case QgsColorWidget::Multiple:
     default:
       return;
   }
@@ -911,6 +914,8 @@ QgsColorWidget::ColorComponent QgsColorBox::yComponent() const
     case QgsColorWidget:: Saturation:
     case QgsColorWidget:: Value:
       return  QgsColorWidget::Hue;
+    case QgsColorWidget::Multiple:
+    case QgsColorWidget::Alpha:
     default:
       //should not occur
       return QgsColorWidget::Red;
@@ -936,6 +941,8 @@ QgsColorWidget::ColorComponent QgsColorBox::xComponent() const
       return QgsColorWidget:: Value;
     case QgsColorWidget:: Value:
       return  QgsColorWidget::Saturation;
+    case QgsColorWidget::Multiple:
+    case QgsColorWidget::Alpha:
     default:
       //should not occur
       return QgsColorWidget::Red;

--- a/src/gui/qgscomposerview.cpp
+++ b/src/gui/qgscomposerview.cpp
@@ -123,6 +123,8 @@ void QgsComposerView::setCurrentTool( QgsComposerView::Tool t )
       viewport()->setCursor( defaultCursorForTool( mCurrentTool ) );
       break;
     }
+    case QgsComposerView::Select:
+    case QgsComposerView::MoveItemContent:
     default:
     {
       //not using pan tool, composer items can change cursor
@@ -954,6 +956,8 @@ void QgsComposerView::mouseReleaseEvent( QMouseEvent* e )
         emit actionFinished();
       }
       break;
+    case AddScalebar:
+    case Pan:
     default:
       break;
   }
@@ -1057,6 +1061,9 @@ void QgsComposerView::mouseMoveEvent( QMouseEvent* e )
         }
         break;
       }
+      case AddScalebar:
+      case Pan:
+      case Zoom:
       default:
         break;
     }
@@ -1644,6 +1651,8 @@ void QgsComposerView::wheelZoom( QWheelEvent * event )
       break;
     }
 
+    case QgsMapCanvas::WheelZoom:
+    case QgsMapCanvas::WheelNothing:
     default:
       break;
   }

--- a/src/gui/qgsdatadefinedbutton.cpp
+++ b/src/gui/qgsdatadefinedbutton.cpp
@@ -188,6 +188,20 @@ void QgsDataDefinedButton::init( const QgsVectorLayer* vl,
           fieldType = tr( "double" );
           break;
         case QVariant::Invalid:
+        case QVariant::Bool:
+        case QVariant::UInt:
+        case QVariant::LongLong:
+        case QVariant::ULongLong:
+        case QVariant::Char:
+        case QVariant::Map:
+        case QVariant::List:
+        case QVariant::StringList:
+        case QVariant::ByteArray:
+        case QVariant::Date:
+        case QVariant::Time:
+        case QVariant::DateTime:
+        case QVariant::UserType:
+        CASE_UNUSUAL_QVARIANT_TYPES:
         default:
           fieldMatch = true; // field type is unknown
           fieldType = tr( "unknown type" );

--- a/src/gui/qgsfieldvalidator.cpp
+++ b/src/gui/qgsfieldvalidator.cpp
@@ -28,6 +28,7 @@
 #include "qgslogger.h"
 #include "qgslonglongvalidator.h"
 #include "qgsfield.h"
+#include "qgis.h"
 
 QgsFieldValidator::QgsFieldValidator( QObject *parent, const QgsField &field, const QString& defaultValue, const QString& dateFormat )
     : QValidator( parent )
@@ -79,6 +80,21 @@ QgsFieldValidator::QgsFieldValidator( QObject *parent, const QgsField &field, co
       mValidator = new QgsLongLongValidator( parent );
       break;
 
+    case QVariant::String:
+    case QVariant::Invalid:
+    case QVariant::Bool:
+    case QVariant::UInt:
+    case QVariant::ULongLong:
+    case QVariant::Char:
+    case QVariant::Map:
+    case QVariant::List:
+    case QVariant::StringList:
+    case QVariant::ByteArray:
+    case QVariant::Date:
+    case QVariant::Time:
+    case QVariant::DateTime:
+    case QVariant::UserType:
+    CASE_UNUSUAL_QVARIANT_TYPES:
     default:
       mValidator = nullptr;
   }

--- a/src/gui/qgshighlight.cpp
+++ b/src/gui/qgshighlight.cpp
@@ -338,6 +338,7 @@ void QgsHighlight::paint( QPainter* p )
       break;
 
       case QGis::WKBUnknown:
+      case QGis::WKBNoGeometry:
       default:
         return;
     }

--- a/src/gui/qgsidentifymenu.cpp
+++ b/src/gui/qgsidentifymenu.cpp
@@ -319,6 +319,8 @@ void QgsIdentifyMenu::addVectorLayer( QgsVectorLayer* layer, const QList<QgsMapT
       case QGis::Polygon:
         layerAction->setIcon( QgsApplication::getThemeIcon( "/mIconPolygonLayer.png" ) );
         break;
+      case QGis::UnknownGeometry:
+      case QGis::NoGeometry:
       default:
         break;
     }

--- a/src/gui/qgsmapcanvastracer.cpp
+++ b/src/gui/qgsmapcanvastracer.cpp
@@ -61,6 +61,9 @@ void QgsMapCanvasTracer::reportError( QgsTracer::PathError err, bool addingVerte
       message = tr( "Disabled - there are too many features displayed. Try zooming in or disable some layers." );
       break;
     case ErrNone:
+    case ErrPoint1:
+    case ErrPoint2:
+    case ErrNoPath:
     default:
       break;
   }

--- a/src/gui/qgsmaplayermodel.cpp
+++ b/src/gui/qgsmaplayermodel.cpp
@@ -196,12 +196,14 @@ QVariant QgsMapLayerModel::data( const QModelIndex &index, int role ) const
             {
               return QgsLayerItem::iconTable();
             }
+            case QGis::UnknownGeometry:
             default:
             {
               return QIcon();
             }
           }
         }
+        case QgsMapLayer::PluginLayer:
         default:
         {
           return QIcon();

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -129,6 +129,8 @@ void QgsMapToolCapture::currentLayerChanged( QgsMapLayer *layer )
     case QGis::Polygon:
       mCaptureMode = CapturePolygon;
       break;
+    case QGis::UnknownGeometry:
+    case QGis::NoGeometry:
     default:
       mCaptureMode = CaptureNone;
       break;

--- a/src/gui/qgsmessagebaritem.cpp
+++ b/src/gui/qgsmessagebaritem.cpp
@@ -114,6 +114,7 @@ void QgsMessageBarItem::writeContent()
       case QgsMessageBar::SUCCESS:
         msgIcon = QString( "/mIconSuccess.png" );
         break;
+      case QgsMessageBar::INFO:
       default:
         break;
     }

--- a/src/gui/qgsnewmemorylayerdialog.cpp
+++ b/src/gui/qgsnewmemorylayerdialog.cpp
@@ -63,6 +63,14 @@ QgsVectorLayer *QgsNewMemoryLayerDialog::runAndCreateLayer( QWidget *parent )
     case QGis::WKBNoGeometry:
       geomType = "none";
       break;
+
+    case QGis::WKBUnknown:
+    case QGis::WKBPoint25D:
+    case QGis::WKBLineString25D:
+    case QGis::WKBPolygon25D:
+    case QGis::WKBMultiPoint25D:
+    case QGis::WKBMultiLineString25D:
+    case QGis::WKBMultiPolygon25D:
     default:
       geomType = "point";
   }

--- a/src/gui/qgsprevieweffect.cpp
+++ b/src/gui/qgsprevieweffect.cpp
@@ -124,6 +124,8 @@ QRgb QgsPreviewEffect::simulateColorBlindness( QRgb& originalColor, QgsPreviewEf
     case PreviewDeuteranope:
       simulateDeuteranopeLMS( L, M, S );
       break;
+    case PreviewGrayscale:
+    case PreviewMono:
     default:
       break;
   }

--- a/src/gui/qgsprojectbadlayerguihandler.cpp
+++ b/src/gui/qgsprojectbadlayerguihandler.cpp
@@ -161,6 +161,7 @@ QgsProjectBadLayerGuiHandler::ProviderType QgsProjectBadLayerGuiHandler::provide
       // physical files
       return IS_FILE;
 
+    case IS_BOGUS:
     default:
       QgsDebugMsg( "unknown ``type'' attribute" );
   }
@@ -212,6 +213,7 @@ bool QgsProjectBadLayerGuiHandler::findMissingFile( QString const & fileFilters,
 
       break;
     }
+    case IS_BOGUS:
     default:
       QgsDebugMsg( "unable to determine data type" );
       return false;

--- a/src/gui/qgsrasterlayersaveasdialog.cpp
+++ b/src/gui/qgsrasterlayersaveasdialog.cpp
@@ -556,6 +556,19 @@ void QgsRasterLayerSaveAsDialog::addNoDataRow( double min, double max )
           valueString = QgsRasterBlock::printValue( value );
         }
         break;
+
+      case QGis::UnknownDataType:
+      case QGis::Byte:
+      case QGis::UInt16:
+      case QGis::Int16:
+      case QGis::UInt32:
+      case QGis::Int32:
+      case QGis::CInt16:
+      case QGis::CInt32:
+      case QGis::CFloat32:
+      case QGis::CFloat64:
+      case QGis::ARGB32:
+      case QGis::ARGB32_Premultiplied:
       default:
         lineEdit->setValidator( new QIntValidator( nullptr ) );
         if ( !qIsNaN( value ) )

--- a/src/gui/qgsrubberband.cpp
+++ b/src/gui/qgsrubberband.cpp
@@ -415,6 +415,7 @@ void QgsRubberBand::addGeometry( const QgsGeometry* geom, QgsVectorLayer* layer 
     break;
 
     case QGis::WKBUnknown:
+    case QGis::WKBNoGeometry:
     default:
       return;
   }
@@ -516,6 +517,8 @@ void QgsRubberBand::paint( QPainter* p )
         break;
 
         case QGis::Line:
+        case QGis::UnknownGeometry:
+        case QGis::NoGeometry:
         default:
         {
           p->drawPolyline( pts );
@@ -654,6 +657,8 @@ QgsGeometry *QgsRubberBand::asGeometry()
     }
 
     case QGis::Line:
+    case QGis::UnknownGeometry:
+    case QGis::NoGeometry:
     default:
     {
       if ( !mPoints.isEmpty() )

--- a/src/gui/symbology-ng/qgscategorizedsymbolrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgscategorizedsymbolrendererv2widget.cpp
@@ -185,6 +185,23 @@ bool QgsCategorizedSymbolRendererV2Model::setData( const QModelIndex & index, co
         case QVariant::Double:
           val = value.toDouble();
           break;
+
+        case QVariant::String:
+        case QVariant::Invalid:
+        case QVariant::Bool:
+        case QVariant::UInt:
+        case QVariant::LongLong:
+        case QVariant::ULongLong:
+        case QVariant::Char:
+        case QVariant::Map:
+        case QVariant::List:
+        case QVariant::StringList:
+        case QVariant::ByteArray:
+        case QVariant::Date:
+        case QVariant::Time:
+        case QVariant::DateTime:
+        case QVariant::UserType:
+        CASE_UNUSUAL_QVARIANT_TYPES:
         default:
           val = value.toString();
           break;

--- a/src/gui/symbology-ng/qgsgraduatedhistogramwidget.cpp
+++ b/src/gui/symbology-ng/qgsgraduatedhistogramwidget.cpp
@@ -194,28 +194,21 @@ bool QgsGraduatedHistogramEventFilter::eventFilter( QObject *object, QEvent *eve
   if ( !mPlot->isEnabled() )
     return QObject::eventFilter( object, event );
 
-  switch ( event->type() )
+  if ( event->type() == QEvent::MouseButtonPress )
   {
-    case QEvent::MouseButtonPress:
+    const QMouseEvent* mouseEvent = static_cast<QMouseEvent* >( event );
+    if ( mouseEvent->button() == Qt::LeftButton )
     {
-      const QMouseEvent* mouseEvent = static_cast<QMouseEvent* >( event );
-      if ( mouseEvent->button() == Qt::LeftButton )
-      {
-        emit mousePress( posToValue( mouseEvent->pos() ) );
-      }
-      break;
+      emit mousePress( posToValue( mouseEvent->pos() ) );
     }
-    case QEvent::MouseButtonRelease:
+  }
+  else if ( event->type() == QEvent::MouseButtonRelease )
+  {
+    const QMouseEvent* mouseEvent = static_cast<QMouseEvent* >( event );
+    if ( mouseEvent->button() == Qt::LeftButton )
     {
-      const QMouseEvent* mouseEvent = static_cast<QMouseEvent* >( event );
-      if ( mouseEvent->button() == Qt::LeftButton )
-      {
-        emit mouseRelease( posToValue( mouseEvent->pos() ) );
-      }
-      break;
+      emit mouseRelease( posToValue( mouseEvent->pos() ) );
     }
-    default:
-      break;
   }
 
   return QObject::eventFilter( object, event );

--- a/src/gui/symbology-ng/qgssymbolv2selectordialog.cpp
+++ b/src/gui/symbology-ng/qgssymbolv2selectordialog.cpp
@@ -186,6 +186,7 @@ class SymbolLayerItem : public QStandardItem
               return QCoreApplication::translate( "SymbolLayerItem", "Fill", nullptr, QCoreApplication::UnicodeUTF8 );
             case QgsSymbolV2::Line   :
               return QCoreApplication::translate( "SymbolLayerItem", "Line", nullptr, QCoreApplication::UnicodeUTF8 );
+            case QgsSymbolV2::Hybrid:
             default:
               return "Symbol";
           }

--- a/src/plugins/georeferencer/qgsgeorefconfigdialog.cpp
+++ b/src/plugins/georeferencer/qgsgeorefconfigdialog.cpp
@@ -65,14 +65,8 @@ QgsGeorefConfigDialog::~QgsGeorefConfigDialog()
 void QgsGeorefConfigDialog::changeEvent( QEvent *e )
 {
   QDialog::changeEvent( e );
-  switch ( e->type() )
-  {
-    case QEvent::LanguageChange:
-      retranslateUi( this );
-      break;
-    default:
-      break;
-  }
+  if ( e->type() == QEvent::LanguageChange )
+    retranslateUi( this );
 }
 
 void QgsGeorefConfigDialog::on_buttonBox_accepted()

--- a/src/plugins/georeferencer/qgsgeorefplugingui.cpp
+++ b/src/plugins/georeferencer/qgsgeorefplugingui.cpp
@@ -401,6 +401,9 @@ void QgsGeorefPluginGui::generateGDALScript()
       }
     }
     FALLTHROUGH;
+    case QgsGeorefTransform::Linear:
+    case QgsGeorefTransform::Helmert:
+    case QgsGeorefTransform::Projective:
     default:
       mMessageBar->pushMessage( tr( "Invalid Transform" ), tr( "GDAL scripting is not supported for %1 transformation." )
                                 .arg( convertTransformEnumToString( mTransformParam ) )
@@ -2043,6 +2046,7 @@ QString QgsGeorefPluginGui::convertTransformEnumToString( QgsGeorefTransform::Tr
       return tr( "Thin plate spline (TPS)" );
     case QgsGeorefTransform::Projective:
       return tr( "Projective" );
+    case QgsGeorefTransform::InvalidTransform:
     default:
       return tr( "Not set" );
   }

--- a/src/plugins/georeferencer/qgsgeoreftransform.cpp
+++ b/src/plugins/georeferencer/qgsgeoreftransform.cpp
@@ -252,6 +252,7 @@ QgsGeorefTransformInterface *QgsGeorefTransform::createImplementation( Transform
       return new QgsGDALGeorefTransform( true, 0 );
     case Projective:
       return new QgsProjectiveGeorefTransform;
+    case InvalidTransform:
     default:
       return nullptr;
   }

--- a/src/plugins/georeferencer/qgstransformsettingsdialog.cpp
+++ b/src/plugins/georeferencer/qgstransformsettingsdialog.cpp
@@ -143,13 +143,9 @@ void QgsTransformSettingsDialog::resetSettings()
 void QgsTransformSettingsDialog::changeEvent( QEvent *e )
 {
   QDialog::changeEvent( e );
-  switch ( e->type() )
+  if ( e->type() == QEvent::LanguageChange )
   {
-    case QEvent::LanguageChange:
-      retranslateUi( this );
-      break;
-    default:
-      break;
+    retranslateUi( this );
   }
 }
 

--- a/src/plugins/grass/qtermwidget/TerminalDisplay.cpp
+++ b/src/plugins/grass/qtermwidget/TerminalDisplay.cpp
@@ -2700,6 +2700,8 @@ QVariant TerminalDisplay::inputMethodQuery( Qt::InputMethodQuery query ) const
         case Qt::ImCurrentSelection:
                 return QString();
             break;
+        case Qt::ImMaximumTextLength:
+        case Qt::ImAnchorPosition:
         default:
             break;
     }
@@ -2760,17 +2762,13 @@ bool TerminalDisplay::handleShortcutOverrideEvent(QKeyEvent* keyEvent)
 bool TerminalDisplay::event(QEvent* event)
 {
   bool eventHandled = false;
-  switch (event->type())
+  if ( event->type() == QEvent::ShortcutOverride )
   {
-    case QEvent::ShortcutOverride:
         eventHandled = handleShortcutOverrideEvent((QKeyEvent*)event);
-        break;
-    case QEvent::PaletteChange:
-    case QEvent::ApplicationPaletteChange:
+  }
+  else if ( event->type() == QEvent::PaletteChange || event->type() == QEvent::ApplicationPaletteChange )
+  {
         _scrollBar->setPalette( QApplication::palette() );
-        break;
-    default:
-        break;
   }
   return eventHandled ? true : QWidget::event(event);
 }
@@ -3078,9 +3076,7 @@ bool AutoScrollHandler::eventFilter(QObject* watched,QEvent* event)
     Q_UNUSED( watched );
 
     QMouseEvent* mouseEvent = (QMouseEvent*)event;
-    switch (event->type())
-    {
-        case QEvent::MouseMove:
+    if (event->type() == QEvent::MouseMove )
         {
             bool mouseInWidget = widget()->rect().contains(mouseEvent->pos());
 
@@ -3095,18 +3091,16 @@ bool AutoScrollHandler::eventFilter(QObject* watched,QEvent* event)
                 if (!_timerId && (mouseEvent->buttons() & Qt::LeftButton))
                     _timerId = startTimer(100);
             }
-                break;
+
         }
-        case QEvent::MouseButtonRelease:
+    else if ( event->type() == QEvent::MouseButtonRelease )
+    {
             if (_timerId && (mouseEvent->buttons() & ~Qt::LeftButton))
             {
                 killTimer(_timerId);
                 _timerId = 0;
             }
-        break;
-        default:
-        break;
-    };
+   }
 
     return false;
 }

--- a/src/plugins/grass/qtermwidget/kprocess.cpp
+++ b/src/plugins/grass/qtermwidget/kprocess.cpp
@@ -140,6 +140,9 @@ void KProcess::setOutputChannelMode(OutputChannelMode mode)
     case OnlyStderrChannel:
         connect(this, SIGNAL(readyReadStandardOutput()), SLOT(_k_forwardStdout()));
         break;
+    case SeparateChannels:
+    case MergedChannels:
+    case ForwardedChannels:
     default:
         QProcess::setProcessChannelMode((ProcessChannelMode)mode);
         return;

--- a/src/plugins/heatmap/heatmap.cpp
+++ b/src/plugins/heatmap/heatmap.cpp
@@ -433,6 +433,7 @@ double Heatmap::uniformKernel( const double distance, const int bandwidth, const
       // Derived from Wand and Jones (1995), p. 175
       return k * ( 0.5 / ( double )bandwidth );
     }
+    case Raw:
     default:
       return 1.0;
   }
@@ -450,6 +451,7 @@ double Heatmap::quarticKernel( const double distance, const int bandwidth, const
       // Derived from Wand and Jones (1995), p. 175
       return k * ( 15. / 16. ) * pow( 1. - pow( distance / ( double )bandwidth, 2 ), 2 );
     }
+    case Raw:
     default:
       return pow( 1. - pow( distance / ( double )bandwidth, 2 ), 2 );
   }
@@ -467,6 +469,7 @@ double Heatmap::triweightKernel( const double distance, const int bandwidth, con
       // Derived from Wand and Jones (1995), p. 175
       return k * ( 35. / 32. ) * pow( 1. - pow( distance / ( double )bandwidth, 2 ), 3 );
     }
+    case Raw:
     default:
       return pow( 1. - pow( distance / ( double )bandwidth, 2 ), 3 );
   }
@@ -484,6 +487,7 @@ double Heatmap::epanechnikovKernel( const double distance, const int bandwidth, 
       // Derived from Wand and Jones (1995), p. 175
       return k * ( 3. / 4. ) * ( 1. - pow( distance / ( double )bandwidth, 2 ) );
     }
+    case Raw:
     default:
       return ( 1. - pow( distance / ( double )bandwidth, 2 ) );
   }
@@ -511,6 +515,7 @@ double Heatmap::triangularKernel( const double distance, const int bandwidth, co
         return ( 1. - ( 1. - mDecay ) * ( distance / ( double )bandwidth ) );
       }
     }
+    case Raw:
     default:
       return ( 1. - ( 1. - mDecay ) * ( distance / ( double )bandwidth ) );
   }

--- a/src/plugins/spatialquery/qgsspatialquery.cpp
+++ b/src/plugins/spatialquery/qgsspatialquery.cpp
@@ -154,6 +154,8 @@ short int QgsSpatialQuery::dimensionGeometry( QGis::GeometryType geomType )
     case QGis::Polygon:
       dimGeom = 2;
       break;
+    case QGis::UnknownGeometry:
+    case QGis::NoGeometry:
     default:
       Q_ASSERT( 0 );
       break;

--- a/src/plugins/spatialquery/qgsspatialquerydialog.cpp
+++ b/src/plugins/spatialquery/qgsspatialquerydialog.cpp
@@ -787,6 +787,9 @@ void QgsSpatialQueryDialog::on_bbMain_clicked( QAbstractButton * button )
     case QDialogButtonBox::RejectRole:
       reject();
       break;
+    case QDialogButtonBox::InvalidRole:
+    case QDialogButtonBox::AcceptRole:
+    case QDialogButtonBox::ActionRole:
     default:
       return;
   }

--- a/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.cpp
@@ -459,6 +459,14 @@ void QgsDelimitedTextFeatureIterator::fetchAttribute( QgsFeature& feature, int f
       }
       break;
     }
+
+    case QVariant::Invalid:
+    case QVariant::Bool:
+    case QVariant::UInt:
+    case QVariant::LongLong:
+    case QVariant::ULongLong:
+    case QVariant::Char:
+    CASE_UNUSUAL_QVARIANT_TYPES:
     default:
       val = QVariant( value );
       break;

--- a/src/providers/grass/qgsgrass.cpp
+++ b/src/providers/grass/qgsgrass.cpp
@@ -2439,6 +2439,8 @@ void QgsGrass::createTable( dbDriver *driver, const QString tableName, const Qgs
       case QVariant::String:
         typeName = QString( "varchar (%1)" ).arg( field.length() );
         break;
+
+      CASE_UNUSUAL_QVARIANT_TYPES:
       default:
         typeName = QString( "varchar (%1)" ).arg( field.length() > 0 ? field.length() : 255 );
     }
@@ -2494,6 +2496,8 @@ void QgsGrass::insertRow( dbDriver *driver, const QString tableName,
       case QVariant::DateTime:
         valueString = attribute.toDateTime().toString( Qt::ISODate );
         break;
+
+      CASE_UNUSUAL_QVARIANT_TYPES:
       default:
         valueString = attribute.toString();
     }

--- a/src/providers/grass/qgsgrassvectormaplayer.cpp
+++ b/src/providers/grass/qgsgrassvectormaplayer.cpp
@@ -409,6 +409,7 @@ QString QgsGrassVectorMapLayer::quotedValue( QVariant value )
 
     default:
     case QVariant::String:
+    CASE_UNUSUAL_QVARIANT_TYPES:
       QString v = value.toString();
       v.replace( "'", "''" );
       if ( v.contains( "\\" ) )

--- a/src/providers/memory/qgsmemoryprovider.cpp
+++ b/src/providers/memory/qgsmemoryprovider.cpp
@@ -22,6 +22,7 @@
 #include "qgslogger.h"
 #include "qgsspatialindex.h"
 #include "qgscoordinatereferencesystem.h"
+#include "qgis.h"
 
 #include <QUrl>
 #include <QRegExp>
@@ -379,6 +380,18 @@ bool QgsMemoryProvider::addAttributes( const QList<QgsField> &attributes )
       case QVariant::DateTime:
       case QVariant::LongLong:
         break;
+
+      case QVariant::Invalid:
+      case QVariant::Bool:
+      case QVariant::UInt:
+      case QVariant::ULongLong:
+      case QVariant::Char:
+      case QVariant::Map:
+      case QVariant::List:
+      case QVariant::StringList:
+      case QVariant::ByteArray:
+      case QVariant::UserType:
+      CASE_UNUSUAL_QVARIANT_TYPES:
       default:
         QgsDebugMsg( "Field type not supported: " + it->typeName() );
         continue;

--- a/src/providers/mssql/qgsmssqldataitems.cpp
+++ b/src/providers/mssql/qgsmssqldataitems.cpp
@@ -576,6 +576,9 @@ QgsMssqlLayerItem* QgsMssqlSchemaItem::addLayer( const QgsMssqlLayerProperty& la
     case QGis::WKBMultiPolygon25D:
       layerType = QgsLayerItem::Polygon;
       break;
+
+    case QGis::WKBUnknown:
+    case QGis::WKBNoGeometry:
     default:
       if ( layerProperty.type == "NONE" && layerProperty.geometryColName.isEmpty() )
       {

--- a/src/providers/mssql/qgsmssqlexpressioncompiler.cpp
+++ b/src/providers/mssql/qgsmssqlexpressioncompiler.cpp
@@ -47,6 +47,12 @@ QgsSqlExpressionCompiler::Result QgsMssqlExpressionCompiler::compileNode( const 
         result = QString( "%1 + %2" ).arg( op1, op2 );
         return result1 == Partial || result2 == Partial ? Partial : Complete;
 
+      case QgsExpression::boOr:
+      case QgsExpression::boAnd:
+      case QgsExpression::boEQ:
+      case QgsExpression::boNE:
+      case QgsExpression::boLE:
+      case QgsExpression::boGE:
       default:
         break;
     }
@@ -67,13 +73,13 @@ QString QgsMssqlExpressionCompiler::quotedValue( const QVariant& value, bool& ok
     return QString();
   }
 
-  switch ( value.type() )
+  if ( value.type() == QVariant::Bool )
   {
-    case QVariant::Bool:
-      //no boolean literal support in mssql, so fake it
-      return value.toBool() ? "(1=1)" : "(1=0)";
-
-    default:
-      return QgsSqlExpressionCompiler::quotedValue( value, ok );
+    //no boolean literal support in mssql, so fake it
+    return value.toBool() ? "(1=1)" : "(1=0)";
+  }
+  else
+  {
+    return QgsSqlExpressionCompiler::quotedValue( value, ok );
   }
 }

--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -1528,6 +1528,13 @@ bool QgsMssqlProvider::convertField( QgsField &field )
       }
       break;
 
+    case QVariant::Invalid:
+    case QVariant::Bool:
+    case QVariant::UInt:
+    case QVariant::ULongLong:
+    case QVariant::Char:
+    case QVariant::Map:
+    CASE_UNUSUAL_QVARIANT_TYPES:
     default:
       return false;
   }

--- a/src/providers/ogr/qgsogrdataitems.cpp
+++ b/src/providers/ogr/qgsogrdataitems.cpp
@@ -155,6 +155,9 @@ static QgsOgrLayerItem* dataItemForLayer( QgsDataItem* parentItem, QString name,
     case wkbMultiPolygon25D:
       layerType = QgsLayerItem::Polygon;
       break;
+
+    case wkbLinearRing:
+    case wkbGeometryCollection25D:
     default:
       break;
   }

--- a/src/providers/ogr/qgsogrexpressioncompiler.cpp
+++ b/src/providers/ogr/qgsogrexpressioncompiler.cpp
@@ -66,6 +66,14 @@ QgsSqlExpressionCompiler::Result QgsOgrExpressionCompiler::compileNode( const Qg
         case QgsExpression::boRegexp:
           return Fail; //not supported by OGR
 
+        case QgsExpression::boOr:
+        case QgsExpression::boAnd:
+        case QgsExpression::boEQ:
+        case QgsExpression::boNE:
+        case QgsExpression::boLE:
+        case QgsExpression::boGE:
+        case QgsExpression::boLT:
+        case QgsExpression::boGT:
         default:
           //fallback to default handling
           return QgsSqlExpressionCompiler::compileNode( node, result );

--- a/src/providers/ogr/qgsogrfeatureiterator.cpp
+++ b/src/providers/ogr/qgsogrfeatureiterator.cpp
@@ -308,6 +308,19 @@ void QgsOgrFeatureIterator::getFeatureAttribute( OGRFeatureH ogrFet, QgsFeature 
           value = QDateTime( QDate( year, month, day ), QTime( hour, minute, second ) );
       }
       break;
+
+      case QVariant::Invalid:
+      case QVariant::Bool:
+      case QVariant::UInt:
+      case QVariant::LongLong:
+      case QVariant::ULongLong:
+      case QVariant::Char:
+      case QVariant::Map:
+      case QVariant::List:
+      case QVariant::StringList:
+      case QVariant::ByteArray:
+      case QVariant::UserType:
+      CASE_UNUSUAL_QVARIANT_TYPES:
       default:
         assert( 0 && "unsupported field type" );
     }

--- a/src/providers/postgres/qgspostgresconn.cpp
+++ b/src/providers/postgres/qgspostgresconn.cpp
@@ -944,8 +944,10 @@ QString QgsPostgresConn::quotedValue( const QVariant& value )
     case QVariant::Bool:
       return value.toBool() ? "TRUE" : "FALSE";
 
+
     default:
     case QVariant::String:
+    CASE_UNUSUAL_QVARIANT_TYPES:
       QString v = value.toString();
       v.replace( '\'', "''" );
       if ( v.contains( '\\' ) )

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -360,6 +360,7 @@ static bool operator<( const QVariant &a, const QVariant &b )
       case QVariant::ULongLong:
         return a.toULongLong() < b.toULongLong();
 
+      CASE_UNUSUAL_QVARIANT_TYPES:
       default:
         break;
     }
@@ -3273,6 +3274,7 @@ bool QgsPostgresProvider::convertField( QgsField &field, const QMap<QString, QVa
       fieldPrec = -1;
       break;
 
+    CASE_UNUSUAL_QVARIANT_TYPES:
     default:
       return false;
   }

--- a/src/providers/spatialite/qgsspatialitedataitems.cpp
+++ b/src/providers/spatialite/qgsspatialitedataitems.cpp
@@ -129,9 +129,12 @@ QVector<QgsDataItem*> QgsSLConnectionItem::createChildren()
       case QgsSpatiaLiteConnection::FailedToGetTables:
         msg = tr( "Failed to get list of tables" );
         break;
+      case QgsSpatiaLiteConnection::NoError:
+        break;
       default:
         msg = tr( "Unknown error" );
         break;
+
     }
     QString msgDetails = connection.errorMessage();
     if ( !msgDetails.isEmpty() )

--- a/src/providers/spatialite/qgsspatialiteexpressioncompiler.cpp
+++ b/src/providers/spatialite/qgsspatialiteexpressioncompiler.cpp
@@ -70,8 +70,10 @@ QString QgsSpatiaLiteExpressionCompiler::quotedValue( const QVariant& value, boo
       //SQLite has no boolean literals
       return value.toBool() ? "1" : "0";
 
-    default:
     case QVariant::String:
+    CASE_UNUSUAL_QVARIANT_TYPES:
+    default:
+
       QString v = value.toString();
       v.replace( '\'', "''" );
       if ( v.contains( '\\' ) )

--- a/src/providers/spatialite/qgsspatialiteprovider.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovider.cpp
@@ -83,6 +83,13 @@ bool QgsSpatiaLiteProvider::convertField( QgsField &field )
       }
       break;
 
+    case QVariant::Invalid:
+    case QVariant::Bool:
+    case QVariant::UInt:
+    case QVariant::ULongLong:
+    case QVariant::Char:
+    case QVariant::Map:
+    CASE_UNUSUAL_QVARIANT_TYPES:
     default:
       return false;
   }

--- a/src/providers/virtual/qgsvirtuallayersqlitemodule.cpp
+++ b/src/providers/virtual/qgsvirtuallayersqlitemodule.cpp
@@ -211,6 +211,7 @@ private:
           typeName = "real";
           break;
         case QVariant::String:
+        CASE_UNUSUAL_QVARIANT_TYPES:
         default:
           typeName = "text";
           break;
@@ -688,6 +689,8 @@ int vtableColumn( sqlite3_vtab_cursor *cursor, sqlite3_context* ctxt, int idx )
       case QVariant::Double:
         sqlite3_result_double( ctxt, v.toDouble() );
         break;
+
+      CASE_UNUSUAL_QVARIANT_TYPES:
       default:
       {
         sqlite3_result_text( ctxt, v.toString().toUtf8(), -1, SQLITE_TRANSIENT );
@@ -798,6 +801,8 @@ void qgisFunctionWrapper( sqlite3_context* ctxt, int nArgs, sqlite3_value** args
     case QVariant::Double:
       sqlite3_result_double( ctxt, ret.toDouble() );
       break;
+
+    CASE_UNUSUAL_QVARIANT_TYPES:
     case QVariant::String:
     {
       QByteArray ba( ret.toByteArray() );

--- a/src/providers/wcs/qgswcsprovider.cpp
+++ b/src/providers/wcs/qgswcsprovider.cpp
@@ -1422,6 +1422,9 @@ QgsRasterIdentifyResult QgsWcsProvider::identify( const QgsPoint & thePoint, Qgs
           // max length of degree of latitude on pole is 111694 m
           xRes = 1e-8;
           break;
+
+        case QGis::UnknownUnit:
+        case QGis::NauticalMiles:
         default:
           xRes = 0.001; // expecting meters
       }

--- a/src/providers/wfs/qgswfssourceselect.cpp
+++ b/src/providers/wfs/qgswfssourceselect.cpp
@@ -212,8 +212,13 @@ void QgsWFSSourceSelect::capabilitiesReplyFinished()
       case QgsWFSCapabilities::ServerExceptionError:
         title = tr( "Server Exception" );
         break;
+
+      case QgsWFSCapabilities::WFSVersionNotSupported:
       default:
-        tr( "Error" );
+        title = tr( "Error" );
+        break;
+
+      case QgsWFSCapabilities::NoError:
         break;
     }
     // handle errors

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -2096,6 +2096,9 @@ QgsRasterIdentifyResult QgsWmsProvider::identify( const QgsPoint & thePoint, Qgs
           // max length of degree of latitude on pole is 111694 m
           xRes = 1e-8;
           break;
+
+        case QGis::UnknownUnit:
+        case QGis::NauticalMiles:
         default:
           xRes = 0.001; // expecting meters
       }

--- a/src/server/qgswfsprojectparser.cpp
+++ b/src/server/qgswfsprojectparser.cpp
@@ -431,6 +431,9 @@ void QgsWFSProjectParser::describeFeatureType( const QString& aTypeName, QDomEle
             case QGis::WKBMultiPolygon:
               geomElem.setAttribute( "type", "gml:MultiPolygonPropertyType" );
               break;
+
+            case QGis::WKBNoGeometry:
+            case QGis::WKBUnknown:
             default:
               geomElem.setAttribute( "type", "gml:GeometryPropertyType" );
               break;

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -846,6 +846,8 @@ class TestQgsExpression: public QObject
           }
           break;
         }
+
+      CASE_UNUSUAL_QVARIANT_TYPES:
         default:
           Q_ASSERT( false ); // should never happen
       }


### PR DESCRIPTION
Not ready for merging yet, but seeking feedback prior to doing more work on this.

This change forces explicit use of all values from an enum when switching over it.

eg, instead of 

```
switch ( layer->geometryType() )
{
  case QGis::Polygon:
      ...
  case QGis::LineString:
      ...
  default:
    break;
}
```

you'd have to do:

```
switch ( layer->geometryType() )
{
  case QGis::Polygon:
      ...
  case QGis::LineString:
      ...

  case QGis::Point:
  case QGis::NoGeometry:
  case QGis::UnknownGeometry:
  default:
    break;
}
```

or travis would throw a warning and your build will fail.

*_Why??
*_

Because I honestly believe this will help us write less buggy and more future-proof code. It's has a number of advantages:
- forces you to think about ALL the possible values a switch should handle. For example, there's lots of cases throughout the code where we switch on the result of QVariant::type(). I think a lot of these are missing handling for a lot of common types - eg missing QVariant::LongLong handling, missing Date/Time/DateTime handling, etc. By having to consider all the possible values to switch over, it's possible that special handling can be added for these as required or they can be merged into other case value blocks, rather then the default block
- forces you to cover all the times an enum is switched over when adding a new value to an existing enum. It prevents bugs caused by the newly added value falling through to the default handler, when it should be specially handled.
- in some cases, it makes code more readable. You can see ALL the values an enum can take when modifying code, and decide how they all should be handled. Eg, maybe it's trivial to add handling for 25D geometry types to a switch, but without seeing that it's a possible value it gets neglected.

Disadvantages:
- Makes some switch statements very verbose (eg when switching over QgsWKBTypes or QVariant::Type values). For this reason I've added the CASE_UNUSUAL_QVARIANT_TYPES macro to at least help avoid some of this bloat.
- If you're not building with clang and can't locally enable this warning, you'll have to push your branch and get the report from Travis to see where this warning is being thrown.

Working through this has already revealed a few bugs/things we could improve. 

Also, it turns out we have about 10 different methods for sorting QVariant values scattered through different classes. We really should condense all these down into the one ultimate method in qgsVariantLessThan.

Thoughts??
