### PR TITLE
[gui] better toolbar placement for selection actions

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1843,11 +1843,11 @@ void QgisApp::createToolBars()
   QToolButton *bt = new QToolButton( mAttributesToolBar );
   bt->setPopupMode( QToolButton::MenuButtonPopup );
   QList<QAction*> selectActions;
-  selectActions << mActionDeselectAll << mActionSelectAll
-  << mActionInvertSelection << mActionSelectByExpression;
+  selectActions << mActionSelectByExpression << mActionSelectAll
+  << mActionInvertSelection;
   bt->addActions( selectActions );
-  bt->setDefaultAction( mActionDeselectAll );
-  QAction* selectionAction = mAttributesToolBar->insertWidget( mActionOpenTable, bt );
+  bt->setDefaultAction( mActionSelectByExpression );
+  QAction* selectionAction = mAttributesToolBar->insertWidget( mActionDeselectAll, bt );
 
   // select tool button
 

--- a/src/core/qgsconnectionpool.h
+++ b/src/core/qgsconnectionpool.h
@@ -128,15 +128,22 @@ class QgsConnectionPoolGroup
     {
       connMutex.lock();
       acquiredConns.removeAll( conn );
-      Item i;
-      i.c = conn;
-      i.lastUsedTime = QTime::currentTime();
-      conns.push( i );
-
-      if ( !expirationTimer->isActive() )
+      if ( !qgsConnectionPool_ConnectionIsValid( conn ) )
       {
-        // will call the slot directly or queue the call (if the object lives in a different thread)
-        QMetaObject::invokeMethod( expirationTimer->parent(), "startExpirationTimer" );
+        qgsConnectionPool_ConnectionDestroy( conn );
+      }
+      else
+      {
+        Item i;
+        i.c = conn;
+        i.lastUsedTime = QTime::currentTime();
+        conns.push( i );
+
+        if ( !expirationTimer->isActive() )
+        {
+          // will call the slot directly or queue the call (if the object lives in a different thread)
+          QMetaObject::invokeMethod( expirationTimer->parent(), "startExpirationTimer" );
+        }
       }
 
       connMutex.unlock();

--- a/src/core/qgsconnectionpool.h
+++ b/src/core/qgsconnectionpool.h
@@ -156,8 +156,9 @@ class QgsConnectionPoolGroup
       connMutex.lock();
       Q_FOREACH ( Item i, conns )
       {
-        qgsConnectionPool_InvalidateConnection( i.c );
+        qgsConnectionPool_ConnectionDestroy( i.c );
       }
+      conns.clear();
       Q_FOREACH ( T c, acquiredConns )
         qgsConnectionPool_InvalidateConnection( c );
       connMutex.unlock();

--- a/src/providers/ogr/qgsogrconnpool.h
+++ b/src/providers/ogr/qgsogrconnpool.h
@@ -146,16 +146,6 @@ class QgsOgrConnPool : public QgsConnectionPool<QgsOgrConn*, QgsOgrConnPoolGroup
       mMutex.unlock();
     }
 
-    static void refS( const QString &connInfo )
-    {
-      instance()->ref( connInfo );
-    }
-
-    static void unrefS( const QString &connInfo )
-    {
-      instance()->unref( connInfo );
-    }
-
   protected:
     Q_DISABLE_COPY( QgsOgrConnPool )
 

--- a/src/providers/ogr/qgsogrconnpool.h
+++ b/src/providers/ogr/qgsogrconnpool.h
@@ -105,6 +105,15 @@ class QgsOgrConnPool : public QgsConnectionPool<QgsOgrConn*, QgsOgrConnPoolGroup
     //
     static void cleanupInstance();
 
+    /**
+     * @brief Increases the reference count on the connection pool for the specified connection.
+     * @param connInfo The connection string.
+     * @note
+     *     Any user of the connection pool needs to increase the reference count
+     *     before it acquires any connections and decrease the reference count after
+     *     releasing all acquired connections to ensure that all open OGR handles
+     *     are freed when and only when no one is using the pool anymore.
+     */
     void ref( const QString& connInfo )
     {
       mMutex.lock();
@@ -115,6 +124,10 @@ class QgsOgrConnPool : public QgsConnectionPool<QgsOgrConn*, QgsOgrConnPoolGroup
       mMutex.unlock();
     }
 
+    /**
+     * @brief Decrease the reference count on the connection pool for the specified connection.
+     * @param connInfo The connection string.
+     */
     void unref( const QString& connInfo )
     {
       mMutex.lock();

--- a/src/providers/ogr/qgsogrfeatureiterator.cpp
+++ b/src/providers/ogr/qgsogrfeatureiterator.cpp
@@ -404,12 +404,12 @@ QgsOgrFeatureSource::QgsOgrFeatureSource( const QgsOgrProvider* p )
   mFields = p->mAttributeFields;
   mDriverName = p->ogrDriverName;
   mOgrGeometryTypeFilter = wkbFlatten( p->mOgrGeometryTypeFilter );
-  QgsOgrConnPool::refS( mFilePath );
+  QgsOgrConnPool::instance()->ref( mFilePath );
 }
 
 QgsOgrFeatureSource::~QgsOgrFeatureSource()
 {
-  QgsOgrConnPool::unrefS( mFilePath );
+  QgsOgrConnPool::instance()->unref( mFilePath );
 }
 
 QgsFeatureIterator QgsOgrFeatureSource::getFeatures( const QgsFeatureRequest& request )

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -374,7 +374,7 @@ QgsOgrProvider::QgsOgrProvider( QString const & uri )
     << QgsVectorDataProvider::NativeType( tr( "Date & Time" ), "datetime", QVariant::DateTime );
   }
 
-  QgsOgrConnPool::refS( mFilePath );
+  QgsOgrConnPool::instance()->ref( mFilePath );
 }
 
 QgsOgrProvider::~QgsOgrProvider()
@@ -2590,7 +2590,7 @@ QString QgsOgrUtils::quotedValue( const QVariant& value )
 bool QgsOgrProvider::syncToDisc()
 {
   //for shapefiles, remove spatial index files and create a new index
-  QgsOgrConnPool::unrefS( mFilePath );
+  QgsOgrConnPool::instance()->unref( mFilePath );
   bool shapeIndex = false;
   if ( ogrDriverName == "ESRI Shapefile" )
   {
@@ -2621,7 +2621,7 @@ bool QgsOgrProvider::syncToDisc()
 
   mShapefileMayBeCorrupted = false;
 
-  QgsOgrConnPool::refS( mFilePath );
+  QgsOgrConnPool::instance()->ref( mFilePath );
   if ( shapeIndex )
   {
     return createSpatialIndex();
@@ -2834,7 +2834,7 @@ void QgsOgrProvider::close()
 
   updateExtents();
 
-  QgsOgrConnPool::unrefS( mFilePath );
+  QgsOgrConnPool::instance()->unref( mFilePath );
 }
 
 // ---------------------------------------------------------------------------

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -441,6 +441,7 @@
     <bool>true</bool>
    </attribute>
    <addaction name="mActionIdentify"/>
+   <addaction name="mActionDeselectAll"/>
    <addaction name="mActionOpenTable"/>
    <addaction name="mActionOpenFieldCalc"/>
    <addaction name="mActionStatisticalSummary"/>

--- a/src/ui/qgsattributetabledialog.ui
+++ b/src/ui/qgsattributetabledialog.ui
@@ -216,32 +216,6 @@
       </widget>
      </item>
      <item>
-      <widget class="QToolButton" name="mRemoveSelectionButton">
-       <property name="toolTip">
-        <string>Deselect all (Ctrl+Shift+A)</string>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="icon">
-        <iconset resource="../../images/images.qrc">
-         <normaloff>:/images/themes/default/mActionUnselectAttributes.png</normaloff>:/images/themes/default/mActionUnselectAttributes.png</iconset>
-       </property>
-       <property name="iconSize">
-        <size>
-         <width>18</width>
-         <height>18</height>
-        </size>
-       </property>
-       <property name="shortcut">
-        <string>Ctrl+Shift+A</string>
-       </property>
-       <property name="autoRaise">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
       <widget class="QToolButton" name="mSelectAllButton">
        <property name="toolTip">
         <string>Select all (Ctrl+A)</string>
@@ -261,6 +235,58 @@
        </property>
        <property name="shortcut">
         <string>Ctrl+A</string>
+       </property>
+       <property name="autoRaise">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="mInvertSelectionButton">
+       <property name="toolTip">
+        <string>Invert selection (Ctrl+R)</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../../images/images.qrc">
+         <normaloff>:/images/themes/default/mActionInvertSelection.png</normaloff>:/images/themes/default/mActionInvertSelection.png</iconset>
+       </property>
+       <property name="iconSize">
+        <size>
+         <width>18</width>
+         <height>18</height>
+        </size>
+       </property>
+       <property name="shortcut">
+        <string>Ctrl+R</string>
+       </property>
+       <property name="autoRaise">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="mRemoveSelectionButton">
+       <property name="toolTip">
+        <string>Deselect all (Ctrl+Shift+A)</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../../images/images.qrc">
+         <normaloff>:/images/themes/default/mActionUnselectAttributes.png</normaloff>:/images/themes/default/mActionUnselectAttributes.png</iconset>
+       </property>
+       <property name="iconSize">
+        <size>
+         <width>18</width>
+         <height>18</height>
+        </size>
+       </property>
+       <property name="shortcut">
+        <string>Ctrl+Shift+A</string>
        </property>
        <property name="autoRaise">
         <bool>true</bool>
@@ -290,32 +316,6 @@
        </property>
        <property name="checkable">
         <bool>true</bool>
-       </property>
-       <property name="autoRaise">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QToolButton" name="mInvertSelectionButton">
-       <property name="toolTip">
-        <string>Invert selection (Ctrl+R)</string>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="icon">
-        <iconset resource="../../images/images.qrc">
-         <normaloff>:/images/themes/default/mActionInvertSelection.png</normaloff>:/images/themes/default/mActionInvertSelection.png</iconset>
-       </property>
-       <property name="iconSize">
-        <size>
-         <width>18</width>
-         <height>18</height>
-        </size>
-       </property>
-       <property name="shortcut">
-        <string>Ctrl+R</string>
        </property>
        <property name="autoRaise">
         <bool>true</bool>

--- a/tests/src/analysis/testqgsvectoranalyzer.cpp
+++ b/tests/src/analysis/testqgsvectoranalyzer.cpp
@@ -86,6 +86,9 @@ void  TestQgsVectorAnalyzer::initTestCase()
 }
 void  TestQgsVectorAnalyzer::cleanupTestCase()
 {
+  delete mpLineLayer;
+  delete mpPolyLayer;
+  delete mpPointLayer;
   QgsApplication::exitQgis();
 }
 void  TestQgsVectorAnalyzer::init()


### PR DESCRIPTION
Even after many years using QGIS, I keep forgetting (and eventually re-discovering) the "Select by Expression..." attribute toolbar action. After giving it some thoughts, I think it's because its placement is hidden within a toolbar pop-up menu which features a deselection icon. 

This PR is - IMHO - improves the placement of selection actions by moving the deselect all action to be its own button, which leaves selection-related actions together (i.e. select all, invert selection, and select by expression)

There are two benefits from this:
1/ it offers a better user experience by having more intuitive / logical action regrouping; and (probably more importantly)
2/ it does a much better job at highlighting a big strength of QGIS, namely its expression engine, in the context of feature selection.

Obligatory screenshots below.

Before:
![nowbizarrelogic](https://cloud.githubusercontent.com/assets/1728657/12864864/5a82ddd2-cccd-11e5-956a-ae54a732264f.png)

Proposed improvement:
![somelogic](https://cloud.githubusercontent.com/assets/1728657/12864865/60b270aa-cccd-11e5-8040-3ea5f916fb98.png)
