### PR TITLE
[gui] better toolbar placement for selection actions

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1843,11 +1843,11 @@ void QgisApp::createToolBars()
   QToolButton *bt = new QToolButton( mAttributesToolBar );
   bt->setPopupMode( QToolButton::MenuButtonPopup );
   QList<QAction*> selectActions;
-  selectActions << mActionDeselectAll << mActionSelectAll
-  << mActionInvertSelection << mActionSelectByExpression;
+  selectActions << mActionSelectByExpression << mActionSelectAll
+  << mActionInvertSelection;
   bt->addActions( selectActions );
-  bt->setDefaultAction( mActionDeselectAll );
-  QAction* selectionAction = mAttributesToolBar->insertWidget( mActionOpenTable, bt );
+  bt->setDefaultAction( mActionSelectByExpression );
+  QAction* selectionAction = mAttributesToolBar->insertWidget( mActionDeselectAll, bt );
 
   // select tool button
 

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -441,6 +441,7 @@
     <bool>true</bool>
    </attribute>
    <addaction name="mActionIdentify"/>
+   <addaction name="mActionDeselectAll"/>
    <addaction name="mActionOpenTable"/>
    <addaction name="mActionOpenFieldCalc"/>
    <addaction name="mActionStatisticalSummary"/>

--- a/src/ui/qgsattributetabledialog.ui
+++ b/src/ui/qgsattributetabledialog.ui
@@ -216,32 +216,6 @@
       </widget>
      </item>
      <item>
-      <widget class="QToolButton" name="mRemoveSelectionButton">
-       <property name="toolTip">
-        <string>Deselect all (Ctrl+Shift+A)</string>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="icon">
-        <iconset resource="../../images/images.qrc">
-         <normaloff>:/images/themes/default/mActionUnselectAttributes.png</normaloff>:/images/themes/default/mActionUnselectAttributes.png</iconset>
-       </property>
-       <property name="iconSize">
-        <size>
-         <width>18</width>
-         <height>18</height>
-        </size>
-       </property>
-       <property name="shortcut">
-        <string>Ctrl+Shift+A</string>
-       </property>
-       <property name="autoRaise">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
       <widget class="QToolButton" name="mSelectAllButton">
        <property name="toolTip">
         <string>Select all (Ctrl+A)</string>
@@ -261,6 +235,58 @@
        </property>
        <property name="shortcut">
         <string>Ctrl+A</string>
+       </property>
+       <property name="autoRaise">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="mInvertSelectionButton">
+       <property name="toolTip">
+        <string>Invert selection (Ctrl+R)</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../../images/images.qrc">
+         <normaloff>:/images/themes/default/mActionInvertSelection.png</normaloff>:/images/themes/default/mActionInvertSelection.png</iconset>
+       </property>
+       <property name="iconSize">
+        <size>
+         <width>18</width>
+         <height>18</height>
+        </size>
+       </property>
+       <property name="shortcut">
+        <string>Ctrl+R</string>
+       </property>
+       <property name="autoRaise">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="mRemoveSelectionButton">
+       <property name="toolTip">
+        <string>Deselect all (Ctrl+Shift+A)</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../../images/images.qrc">
+         <normaloff>:/images/themes/default/mActionUnselectAttributes.png</normaloff>:/images/themes/default/mActionUnselectAttributes.png</iconset>
+       </property>
+       <property name="iconSize">
+        <size>
+         <width>18</width>
+         <height>18</height>
+        </size>
+       </property>
+       <property name="shortcut">
+        <string>Ctrl+Shift+A</string>
        </property>
        <property name="autoRaise">
         <bool>true</bool>
@@ -290,32 +316,6 @@
        </property>
        <property name="checkable">
         <bool>true</bool>
-       </property>
-       <property name="autoRaise">
-        <bool>true</bool>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QToolButton" name="mInvertSelectionButton">
-       <property name="toolTip">
-        <string>Invert selection (Ctrl+R)</string>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="icon">
-        <iconset resource="../../images/images.qrc">
-         <normaloff>:/images/themes/default/mActionInvertSelection.png</normaloff>:/images/themes/default/mActionInvertSelection.png</iconset>
-       </property>
-       <property name="iconSize">
-        <size>
-         <width>18</width>
-         <height>18</height>
-        </size>
-       </property>
-       <property name="shortcut">
-        <string>Ctrl+R</string>
        </property>
        <property name="autoRaise">
         <bool>true</bool>


### PR DESCRIPTION
Even after many years using QGIS, I keep forgetting (and eventually re-discovering) the "Select by Expression..." attribute toolbar action. After giving it some thoughts, I think it's because its placement is hidden within a toolbar pop-up menu which features a deselection icon. 

This PR does - IMHO - improve the placement of selection actions by moving the deselect all action to be its own button, which leaves selection-related actions together (i.e. select all, invert selection, and select by expression)

There are two benefits from this:
1/ it offers a better user experience by having more intuitive / logical action regrouping; and (probably more importantly)
2/ it does a much better job at highlighting a big strength of QGIS, namely its expression engine, in the context of feature selection.

While at it, I've also re-ordered the attribute table window's toolbar selection buttons to follow the same ordering.

Obligatory screenshots below.

Main app toolbar, before:
![nowbizarrelogic](https://cloud.githubusercontent.com/assets/1728657/12864864/5a82ddd2-cccd-11e5-956a-ae54a732264f.png)

Main app toolbar, proposed improvement:
![somelogic](https://cloud.githubusercontent.com/assets/1728657/12864865/60b270aa-cccd-11e5-8040-3ea5f916fb98.png)

Attribute table window toolbar, before:
![attribute-before](https://cloud.githubusercontent.com/assets/1728657/12864924/bea2a4ee-cccf-11e5-9c29-b378579a2992.png)

Attribute table window toolbar, proposed improvement:
![attribute-after](https://cloud.githubusercontent.com/assets/1728657/12864925/c3d1d99e-cccf-11e5-9543-8ce18d6c4236.png)

@anitagraser , @NathanW2 , @nyalldawson , thoughts?
