### PR TITLE
Rename Style Manager Dialog to Symbol Manager Dialog

### DIFF
--- a/resources/context_help/QgsStyleV2ManagerDialog
+++ b/resources/context_help/QgsStyleV2ManagerDialog
@@ -1,1 +1,1 @@
-<h3>Style Manager</h3>
+<h3>Symbol Manager</h3>

--- a/src/gui/symbology-ng/qgssymbolslistwidget.cpp
+++ b/src/gui/symbology-ng/qgssymbolslistwidget.cpp
@@ -83,7 +83,7 @@ QgsSymbolsListWidget::QgsSymbolsListWidget( QgsSymbolV2* symbol, QgsStyleV2* sty
   connect( viewSymbols->selectionModel(), SIGNAL( currentChanged( const QModelIndex &, const QModelIndex & ) ), this, SLOT( setSymbolFromStyle( const QModelIndex & ) ) );
 
   connect( mStyle, SIGNAL( symbolSaved( QString, QgsSymbolV2* ) ), this, SLOT( symbolAddedToStyle( QString, QgsSymbolV2* ) ) );
-  connect( openStyleManagerButton, SIGNAL( pressed() ), this, SLOT( openStyleManager() ) );
+  connect( openSymbolManagerButton, SIGNAL( pressed() ), this, SLOT( openStyleManager() ) );
 
   lblSymbolName->setText( "" );
   populateSymbolView();

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -1679,7 +1679,7 @@ Ctl (Cmd) increments by 15 deg.</string>
      <normaloff>:/images/themes/default/propertyicons/symbology.png</normaloff>:/images/themes/default/propertyicons/symbology.png</iconset>
    </property>
    <property name="text">
-    <string>Style Manager...</string>
+    <string>Symbol Manager...</string>
    </property>
   </action>
   <action name="mActionShowPythonDialog">

--- a/src/ui/qgsprojectpropertiesbase.ui
+++ b/src/ui/qgsprojectpropertiesbase.ui
@@ -1308,7 +1308,7 @@
                  <item>
                   <widget class="QPushButton" name="pbtnStyleManager">
                    <property name="text">
-                    <string>Style Manager</string>
+                    <string>Symbol Manager</string>
                    </property>
                   </widget>
                  </item>

--- a/src/ui/qgsstylev2managerdialogbase.ui
+++ b/src/ui/qgsstylev2managerdialogbase.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>Style Manager</string>
+   <string>Symbol Manager</string>
   </property>
   <property name="styleSheet">
    <string notr="true">QToolButton { padding-left: 3px; padding-right: 3px; }

--- a/src/ui/symbollayer/widget_symbolslist.ui
+++ b/src/ui/symbollayer/widget_symbolslist.ui
@@ -267,7 +267,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="openStyleManagerButton">
+      <widget class="QPushButton" name="openSymbolManagerButton">
        <property name="text">
         <string>Open Library</string>
        </property>
@@ -405,7 +405,7 @@
   <tabstop>spinWidth</tabstop>
   <tabstop>mWidthDDBtn</tabstop>
   <tabstop>groupsCombo</tabstop>
-  <tabstop>openStyleManagerButton</tabstop>
+  <tabstop>openSymbolManagerButton</tabstop>
   <tabstop>viewSymbols</tabstop>
   <tabstop>btnSaveSymbol</tabstop>
   <tabstop>btnAdvanced</tabstop>


### PR DESCRIPTION
Although the dialog manages symbol (edit, create, import/export), it's imho wrongly named Style Manager instead of Symbol Manager, potentially leading to confusion with layer style (in the documentation at least).
This PR replaces GUI items to display "Symbol Manager" as expected.  It doesn't touch functions name given that I don't know if this could break any compatibility (and to hopefully have it committed into 2.14). I essentially think about:
- QgsStyleV2ManagerDialogBase in src/ui/QgsStyleV2ManagerDialogBase.ui (class and file name) into QgsSymbolManagerDialogBase
- mActionStyleManagerV2 in src/ui/qgisapp.ui into mActionSymbolManager
- openStyleManager function in src/gui/symbology-ng/qgssymbolslistwidget.cpp (and .h) --> openSymbolManager
- pbtnStyleManager --> pbtnSymbolManager in src/ui/qgsprojectpropertiesbase.ui (couldn't find if it is used elsewhere so didn't rename it)

Any other item that should be replaced? 
Are these changes compatible with 2.x or should they be kept for 3.x release?
