### PR TITLE
[Bugfix] Avoid orphaned QgsEditorWidgetConfig (refs #14136)

### DIFF
--- a/python/core/qgseditformconfig.sip
+++ b/python/core/qgseditformconfig.sip
@@ -206,6 +206,24 @@ class QgsEditFormConfig : QObject
     QgsEditorWidgetConfig widgetConfig( const QString& widgetName ) const;
 
     /**
+     * Remove the configuration for the editor widget used to represent the field at the given index
+     *
+     * @param fieldIdx  The index of the field
+     *
+     * @return true if successful, false if the field does not exist
+     */
+    bool removeWidgetConfig( int fieldIdx );
+
+    /**
+     * Remove the configuration for the editor widget used to represent the field with the given name
+     *
+     * @param widgetName The name of the widget. This can be a field name or the name of an additional widget.
+     *
+     * @return true if successful, false if the field does not exist
+     */
+    bool removeWidgetConfig( const QString& widgetName );
+
+    /**
      * This returns true if the field is manually set to read only or if the field
      * does not support editing like joins or virtual fields.
      */

--- a/src/core/qgseditformconfig.cpp
+++ b/src/core/qgseditformconfig.cpp
@@ -72,6 +72,19 @@ void QgsEditFormConfig::setWidgetConfig( const QString& widgetName, const QgsEdi
   mWidgetConfigs[widgetName] = config;
 }
 
+bool QgsEditFormConfig::removeWidgetConfig( const QString &widgetName )
+{
+  return mWidgetConfigs.remove( widgetName ) != 0;
+}
+
+bool QgsEditFormConfig::removeWidgetConfig( int fieldIdx )
+{
+  if ( fieldIdx < 0 || fieldIdx >= mFields.count() )
+    return false;
+
+  return mWidgetConfigs.remove( mFields[fieldIdx].name() );
+}
+
 void QgsEditFormConfig::setUiForm( const QString& ui )
 {
   if ( ui.isEmpty() || ui.isNull() )

--- a/src/core/qgseditformconfig.h
+++ b/src/core/qgseditformconfig.h
@@ -464,6 +464,24 @@ class CORE_EXPORT QgsEditFormConfig : public QObject
     QgsEditorWidgetConfig widgetConfig( const QString& widgetName ) const;
 
     /**
+     * Remove the configuration for the editor widget used to represent the field at the given index
+     *
+     * @param fieldIdx  The index of the field
+     *
+     * @return true if successful, false if the field does not exist
+     */
+    bool removeWidgetConfig( int fieldIdx );
+
+    /**
+     * Remove the configuration for the editor widget used to represent the field with the given name
+     *
+     * @param widgetName The name of the widget. This can be a field name or the name of an additional widget.
+     *
+     * @return true if successful, false if the field does not exist
+     */
+    bool removeWidgetConfig( const QString& widgetName );
+
+    /**
      * This returns true if the field is manually set to read only or if the field
      * does not support editing like joins or virtual fields.
      */

--- a/src/core/qgsvectorlayereditpassthrough.cpp
+++ b/src/core/qgsvectorlayereditpassthrough.cpp
@@ -125,6 +125,7 @@ bool QgsVectorLayerEditPassthrough::deleteAttribute( int attr )
   if ( L->dataProvider()->deleteAttributes( QgsAttributeIds() << attr ) )
   {
     mModified = true;
+    L->editFormConfig()->removeWidgetConfig( attr );
     emit attributeDeleted( attr );
     mModified = true;
     return true;

--- a/src/core/qgsvectorlayerundocommand.cpp
+++ b/src/core/qgsvectorlayerundocommand.cpp
@@ -347,6 +347,7 @@ QgsVectorLayerUndoCommandDeleteAttribute::QgsVectorLayerUndoCommandDeleteAttribu
   QgsFields::FieldOrigin origin = fields.fieldOrigin( mFieldIndex );
   mOriginIndex = fields.fieldOriginIndex( mFieldIndex );
   mProviderField = ( origin == QgsFields::OriginProvider );
+  mOldEditorWidgetConfig = mBuffer->L->editFormConfig()->widgetConfig( mFieldIndex );
 
   if ( !mProviderField )
   {
@@ -401,6 +402,8 @@ void QgsVectorLayerUndoCommandDeleteAttribute::undo()
     }
   }
 
+  mBuffer->L->editFormConfig()->setWidgetConfig( mFieldIndex, mOldEditorWidgetConfig );
+
   emit mBuffer->attributeAdded( mFieldIndex );
 }
 
@@ -417,6 +420,7 @@ void QgsVectorLayerUndoCommandDeleteAttribute::redo()
     mBuffer->mAddedAttributes.removeAt( mOriginIndex ); // removing temporary attribute
   }
 
+  mBuffer->L->editFormConfig()->removeWidgetConfig( mFieldIndex );
   mBuffer->handleAttributeDeleted( mFieldIndex ); // update changed attributes + new features
   mBuffer->updateLayerFields();
   emit mBuffer->attributeDeleted( mFieldIndex );

--- a/src/core/qgsvectorlayerundocommand.h
+++ b/src/core/qgsvectorlayerundocommand.h
@@ -138,6 +138,7 @@ class CORE_EXPORT QgsVectorLayerUndoCommandDeleteAttribute : public QgsVectorLay
     bool mProviderField;
     int mOriginIndex;
     QgsField mOldField;
+    QgsEditorWidgetConfig mOldEditorWidgetConfig;
 
     QMap<QgsFeatureId, QVariant> mDeletedValues;
 };


### PR DESCRIPTION
When removing a field, the accompanying `QgsEditorWidgetConfig` was not removed. Saving the project could produce invalid XML in certain cases.
