### PR TITLE
[BUGFIX] QDialogProgress used in QgsVectorLayer::countSymbolFeatures

### DIFF
--- a/python/core/qgsvectorlayer.sip
+++ b/python/core/qgsvectorlayer.sip
@@ -1687,6 +1687,13 @@ class QgsVectorLayer : QgsMapLayer
      */
     void writeCustomSymbology( QDomElement& element, QDomDocument& doc, QString& errorMessage ) const;
 
+    /** Is emitted, when count symbol features has started*/
+    void countSymbolFeaturesStarted( long featureCount );
+    /** Is emitted, when count symbol features changed */
+    void countSymbolFeaturesChanged( long featureCounted );
+    /** Is emitted, when count symbol features ended */
+    void countSymbolFeaturesStopped( long featureCounted );
+
 
   protected:
     /** Set the extent */

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -701,6 +701,9 @@ long QgsVectorLayer::featureCount( QgsSymbolV2* symbol )
 
 bool QgsVectorLayer::countSymbolFeatures( bool showProgress )
 {
+  // Do not change the method signature
+  // and do not break API
+  Q_UNUSED( showProgress )
   if ( mSymbolFeatureCounted )
     return true;
 
@@ -730,12 +733,6 @@ bool QgsVectorLayer::countSymbolFeatures( bool showProgress )
     mSymbolFeatureCountMap.insert( symbolIt->second, 0 );
   }
 
-  long nFeatures = featureCount();
-  QProgressDialog progressDialog( tr( "Updating feature count for layer %1" ).arg( name() ), tr( "Abort" ), 0, nFeatures );
-  progressDialog.setWindowTitle( tr( "QGIS" ) );
-  progressDialog.setWindowModality( Qt::WindowModal );
-  int featuresCounted = 0;
-
   QgsFeatureIterator fit = getFeatures( QgsFeatureRequest().setFlags( QgsFeatureRequest::NoGeometry ) );
 
   // Renderer (rule based) may depend on context scale, with scale is ignored if 0
@@ -756,28 +753,8 @@ bool QgsVectorLayer::countSymbolFeatures( bool showProgress )
     {
       mSymbolFeatureCountMap[*symbolIt] += 1;
     }
-    ++featuresCounted;
-
-    if ( showProgress )
-    {
-      if ( featuresCounted % 50 == 0 )
-      {
-        if ( featuresCounted > nFeatures ) //sometimes the feature count is not correct
-        {
-          progressDialog.setMaximum( 0 );
-        }
-        progressDialog.setValue( featuresCounted );
-        if ( progressDialog.wasCanceled() )
-        {
-          mSymbolFeatureCountMap.clear();
-          mRendererV2->stopRender( renderContext );
-          return false;
-        }
-      }
-    }
   }
   mRendererV2->stopRender( renderContext );
-  progressDialog.setValue( nFeatures );
   mSymbolFeatureCounted = true;
   return true;
 }

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -701,9 +701,6 @@ long QgsVectorLayer::featureCount( QgsSymbolV2* symbol )
 
 bool QgsVectorLayer::countSymbolFeatures( bool showProgress )
 {
-  // Do not change the method signature
-  // and do not break API
-  Q_UNUSED( showProgress )
   if ( mSymbolFeatureCounted )
     return true;
 
@@ -733,6 +730,10 @@ bool QgsVectorLayer::countSymbolFeatures( bool showProgress )
     mSymbolFeatureCountMap.insert( symbolIt->second, 0 );
   }
 
+  long nFeatures = featureCount();
+  emit countSymbolFeaturesStarted( nFeatures );
+  int featuresCounted = 0;
+
   QgsFeatureIterator fit = getFeatures( QgsFeatureRequest().setFlags( QgsFeatureRequest::NoGeometry ) );
 
   // Renderer (rule based) may depend on context scale, with scale is ignored if 0
@@ -753,8 +754,18 @@ bool QgsVectorLayer::countSymbolFeatures( bool showProgress )
     {
       mSymbolFeatureCountMap[*symbolIt] += 1;
     }
+    ++featuresCounted;
+
+    if ( showProgress )
+    {
+      if ( featuresCounted % 50 == 0 )
+      {
+        emit countSymbolFeaturesStarted( featuresCounted );
+      }
+    }
   }
   mRendererV2->stopRender( renderContext );
+  emit countSymbolFeaturesStarted( featuresCounted );
   mSymbolFeatureCounted = true;
   return true;
 }

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -1881,6 +1881,13 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
      */
     void writeCustomSymbology( QDomElement& element, QDomDocument& doc, QString& errorMessage ) const;
 
+    /** Is emitted, when count symbol features has started*/
+    void countSymbolFeaturesStarted( long featureCount );
+    /** Is emitted, when count symbol features changed */
+    void countSymbolFeaturesChanged( long featureCounted );
+    /** Is emitted, when count symbol features ended */
+    void countSymbolFeaturesStopped( long featureCounted );
+
   private slots:
     void onJoinedFieldsChanged();
     void onFeatureDeleted( QgsFeatureId fid );


### PR DESCRIPTION
Folliwing the vector feature counts moved to vector layer commit 038acbc76083dae3fd29795b9e73d97cd92c3d3a fixes 6237, QDialogProcess is used in QgsVectorLayer::countSymbolFeatures. But no GUI tools has to be hardcoded in core.

QgsVectorLayer::countSymbolFeatures has a parameter showProgress with defaut value to True.

The method countSymbolFeatures is used in QgsLegendModel and QgsMapLayerLegend without parameter.

To fix it, it simply removes the use of QDialogProgress but keep showProgress parameter to not change the method signature and not break API.

Fixes #14272
