### PR TITLE
[UI] Make title of QgsNewVectorLayerDialog consistent

### DIFF
--- a/src/gui/qgsnewvectorlayerdialog.cpp
+++ b/src/gui/qgsnewvectorlayerdialog.cpp
@@ -53,6 +53,7 @@ QgsNewVectorLayerDialog::QgsNewVectorLayerDialog( QWidget *parent, const Qt::Win
   mFileFormatComboBox->addItem( tr( "ESRI Shapefile" ), "ESRI Shapefile" );
 #if 0
   // Disabled until provider properly supports editing the created file formats
+  // When enabling this, adapt the window-title of the dialog and the title of all actions showing this dialog.
   mFileFormatComboBox->addItem( tr( "Comma Separated Value" ), "Comma Separated Value" );
   mFileFormatComboBox->addItem( tr( "GML" ), "GML" );
   mFileFormatComboBox->addItem( tr( "Mapinfo File" ), "Mapinfo File" );

--- a/src/ui/qgsnewvectorlayerdialogbase.ui
+++ b/src/ui/qgsnewvectorlayerdialogbase.ui
@@ -11,7 +11,7 @@
    </rect>
   </property>
   <property name="windowTitle">
-   <string>New Vector Layer</string>
+   <string>New Shapefile Layer</string>
   </property>
   <property name="modal">
    <bool>true</bool>


### PR DESCRIPTION
At the moment, only ESRI-Shapefiles can be created by the `QgsNewVectorLayerDialog`, however the dialog title is _New **Vector** Layer_. Two UI inconsistencies follow from that:
- The actions that show the dialog have the caption _New **Shapefile** Layer_.
- The format selector is hidden in the dialog so it is unclear to the user what format the newly created vector layer will be in.

This PR fixes it by changing the title of the dialog to _New Shapefile Layer_. It also adds a remark to change the title and the caption of all affected actions once the dialog can create vector layers in different formats.

An alternative would be:
- Change the captions of the actions to _New Vector Layer_.
- Show (and probably disable) the format combo box instead of hiding it.
  The benefits here would be to avoid another UI change once more formats are supported.

_Edit: Emphasize on showing the format combobox and leave disabling it as an option._
