### PR TITLE
[DbManager] Fix the 'MoveToSchema' functionality (fixes #14219)

### DIFF
--- a/python/plugins/db_manager/db_plugins/plugin.py
+++ b/python/plugins/db_manager/db_plugins/plugin.py
@@ -463,7 +463,7 @@ class Database(DbItemObject):
 
     def prepareMenuMoveTableToSchemaActionSlot(self, item, menu, mainWindow):
         """ populate menu with schemas """
-        slot = lambda x: lambda: mainWindow.invokeCallback(self.moveTableToSchemaActionSlot, [x])
+        slot = lambda x: lambda: mainWindow.invokeCallback(self.moveTableToSchemaActionSlot, x)
 
         menu.clear()
         for schema in self.schemas():


### PR DESCRIPTION
The regression occurred in 80a13e38526d7c7e6cc4869170818b66955e6517. See [Redmine #14219](https://hub.qgis.org/issues/14219). @brushtyler Can you have a quick look at this?

@nyalldawson
A bugfix with only two characters, so even better than #2716. Still hunting the single character bugfix :stuck_out_tongue_winking_eye: Oh, and I do know that instead of changing `[x]`to `x` changing it to `*[x]` would have worked, too. But I'd consider that cheating. 
