### PR TITLE
[Bugfix] Improve version check (refs #14022)

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -119,6 +119,7 @@ void usage( std::string const & appName )
             << "\t[--project projectfile]\tload the given QGIS project\n"
             << "\t[--extent xmin,ymin,xmax,ymax]\tset initial map extent\n"
             << "\t[--nologo]\thide splash screen\n"
+            << "\t[--noversioncheck]\tdon't check for new version of QGIS at startup"
             << "\t[--noplugins]\tdon't restore plugins on startup\n"
             << "\t[--nocustomization]\tdon't apply GUI customization\n"
             << "\t[--customizationfile]\tuse the given ini file as GUI customization\n"
@@ -476,6 +477,7 @@ int main( int argc, char *argv[] )
   int mySnapshotHeight = 600;
 
   bool myHideSplash = false;
+  bool mySkipVersionCheck = false;
 #if defined(ANDROID)
   QgsDebugMsg( QString( "Android: Splash hidden" ) );
   myHideSplash = true;
@@ -542,6 +544,10 @@ int main( int argc, char *argv[] )
       else if ( arg == "--nologo" || arg == "-n" )
       {
         myHideSplash = true;
+      }
+      else if ( arg == "--noversioncheck" || arg == "-V" )
+      {
+        mySkipVersionCheck = true;
       }
       else if ( arg == "--noplugins" || arg == "-P" )
       {
@@ -1032,7 +1038,7 @@ int main( int argc, char *argv[] )
   // this should be done in QgsApplication::init() but it doesn't know the settings dir.
   QgsApplication::setMaxThreads( QSettings().value( "/qgis/max_threads", -1 ).toInt() );
 
-  QgisApp *qgis = new QgisApp( mypSplash, myRestorePlugins ); // "QgisApp" used to find canonical instance
+  QgisApp *qgis = new QgisApp( mypSplash, myRestorePlugins, mySkipVersionCheck ); // "QgisApp" used to find canonical instance
   qgis->setObjectName( "QgisApp" );
 
   myApp.connect(

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -531,7 +531,7 @@ static bool cmpByText_( QAction* a, QAction* b )
 QgisApp *QgisApp::smInstance = nullptr;
 
 // constructor starts here
-QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, QWidget * parent, Qt::WindowFlags fl )
+QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCheck, QWidget * parent, Qt::WindowFlags fl )
     : QMainWindow( parent, fl )
     , mNonEditMapTool( nullptr )
     , mScaleLabel( nullptr )
@@ -639,7 +639,7 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, QWidget * parent, 
   // what type of project to auto-open
   mProjOpen = settings.value( "/qgis/projOpenAtLaunch", 0 ).toInt();
 
-  mWelcomePage = new QgsWelcomePage;
+  mWelcomePage = new QgsWelcomePage( skipVersionCheck );
 
   mCentralContainer = new QStackedWidget;
   mCentralContainer->insertWidget( 0, mMapCanvas );

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -134,7 +134,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     Q_OBJECT
   public:
     //! Constructor
-    QgisApp( QSplashScreen *splash, bool restorePlugins = true, QWidget *parent = nullptr, Qt::WindowFlags fl = Qt::Window );
+    QgisApp( QSplashScreen *splash, bool restorePlugins = true, bool skipVersionCheck = false, QWidget *parent = nullptr, Qt::WindowFlags fl = Qt::Window );
     //! Constructor for unit tests
     QgisApp();
     //! Destructor

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -590,6 +590,7 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl ) :
   mLegendGroupsBoldChkBx->setChecked( mSettings->value( "/qgis/legendGroupsBold", false ).toBool() );
   cbxHideSplash->setChecked( mSettings->value( "/qgis/hideSplash", false ).toBool() );
   cbxShowTips->setChecked( mSettings->value( QString( "/qgis/showTips%1" ).arg( QGis::QGIS_VERSION_INT / 100 ), true ).toBool() );
+  cbxCheckVersion->setChecked( mSettings->value( "/qgis/checkVersion", true ).toBool() );
   cbxAttributeTableDocked->setChecked( mSettings->value( "/qgis/dockAttributeTable", false ).toBool() );
   cbxSnappingOptionsDocked->setChecked( mSettings->value( "/qgis/dockSnapping", false ).toBool() );
   cbxAddPostgisDC->setChecked( mSettings->value( "/qgis/addPostgisDC", false ).toBool() );
@@ -1131,6 +1132,7 @@ void QgsOptions::saveOptions()
   mSettings->setValue( "/qgis/legendGroupsBold", mLegendGroupsBoldChkBx->isChecked() );
   mSettings->setValue( "/qgis/hideSplash", cbxHideSplash->isChecked() );
   mSettings->setValue( QString( "/qgis/showTips%1" ).arg( QGis::QGIS_VERSION_INT / 100 ), cbxShowTips->isChecked() );
+  mSettings->setValue( "/qgis/checkVersion", cbxCheckVersion->isChecked() );
   mSettings->setValue( "/qgis/dockAttributeTable", cbxAttributeTableDocked->isChecked() );
   mSettings->setValue( "/qgis/attributeTableBehaviour", cmbAttrTableBehaviour->itemData( cmbAttrTableBehaviour->currentIndex() ) );
   mSettings->setValue( "/qgis/attributeTableRowCache", spinBoxAttrTableRowCache->value() );

--- a/src/app/qgsversioninfo.cpp
+++ b/src/app/qgsversioninfo.cpp
@@ -78,7 +78,7 @@ void QgsVersionInfo::versionReplyFinished()
       mErrorString = tr( "Connection refused - server may be down" );
       break;
     case QNetworkReply::HostNotFoundError:
-      mErrorString = tr( "The host name qgis.org could not be resolved. Check your DNS settings or contact your system administrator." );
+      mErrorString = tr( "The host name %1 could not be resolved. Check your DNS settings or contact your system administrator." ).arg( reply->request().url().host() );
       break;
     case QNetworkReply::NoError:
       mErrorString = "";

--- a/src/app/qgswelcomepage.cpp
+++ b/src/app/qgswelcomepage.cpp
@@ -24,7 +24,7 @@
 #include <QListView>
 #include <QSettings>
 
-QgsWelcomePage::QgsWelcomePage( QWidget* parent )
+QgsWelcomePage::QgsWelcomePage( bool skipVersionCheck, QWidget* parent )
     : QWidget( parent )
 {
   QSettings settings;
@@ -60,7 +60,7 @@ QgsWelcomePage::QgsWelcomePage( QWidget* parent )
   mVersionInformation->setVisible( false );
 
   mVersionInfo = new QgsVersionInfo();
-  if ( !QgsApplication::isRunningFromBuildDir() && settings.value( "/qgis/checkVersion", true ).toBool() )
+  if ( !QgsApplication::isRunningFromBuildDir() && settings.value( "/qgis/checkVersion", true ).toBool() && !skipVersionCheck )
   {
     connect( mVersionInfo, SIGNAL( versionInfoAvailable() ), this, SLOT( versionInfoReceived() ) );
     mVersionInfo->checkVersion();

--- a/src/app/qgswelcomepage.cpp
+++ b/src/app/qgswelcomepage.cpp
@@ -27,6 +27,8 @@
 QgsWelcomePage::QgsWelcomePage( QWidget* parent )
     : QWidget( parent )
 {
+  QSettings settings;
+
   QVBoxLayout* mainLayout = new QVBoxLayout;
   mainLayout->setMargin( 0 );
   setLayout( mainLayout );
@@ -58,7 +60,7 @@ QgsWelcomePage::QgsWelcomePage( QWidget* parent )
   mVersionInformation->setVisible( false );
 
   mVersionInfo = new QgsVersionInfo();
-  if ( !QgsApplication::isRunningFromBuildDir() )
+  if ( !QgsApplication::isRunningFromBuildDir() && settings.value( "/qgis/checkVersion", true ).toBool() )
   {
     connect( mVersionInfo, SIGNAL( versionInfoAvailable() ), this, SLOT( versionInfoReceived() ) );
     mVersionInfo->checkVersion();

--- a/src/app/qgswelcomepage.h
+++ b/src/app/qgswelcomepage.h
@@ -28,7 +28,7 @@ class QgsWelcomePage : public QWidget
     Q_OBJECT
 
   public:
-    explicit QgsWelcomePage( QWidget* parent = nullptr );
+    explicit QgsWelcomePage( bool skipVersionCheck = false, QWidget* parent = nullptr );
 
     ~QgsWelcomePage();
 

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -619,8 +619,34 @@
                     </item>
                     <item>
                      <widget class="QCheckBox" name="cbxShowTips">
+                      <property name="sizePolicy">
+                       <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                        <horstretch>0</horstretch>
+                        <verstretch>0</verstretch>
+                       </sizepolicy>
+                      </property>
                       <property name="text">
                        <string>Show tips at start up</string>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="Line" name="line_2">
+                      <property name="minimumSize">
+                       <size>
+                        <width>12</width>
+                        <height>0</height>
+                       </size>
+                      </property>
+                      <property name="orientation">
+                       <enum>Qt::Vertical</enum>
+                      </property>
+                     </widget>
+                    </item>
+                    <item>
+                     <widget class="QCheckBox" name="cbxCheckVersion">
+                      <property name="text">
+                       <string>Check QGIS version at startup</string>
                       </property>
                      </widget>
                     </item>


### PR DESCRIPTION
- Added a setting to the options dialog to allow disabling the version check at QGIS startup (see [Redmine #14022](https://hub.qgis.org/issues/14022)). The default is _true_, so the check is performend unless the user decides otherwise.
- Improved the error message in case the host name for the version check could not be resolved: Now the actual host name is reported, instead of the hardcoded `qgis.org`, which is not even the correct host name since 764c649842f542984e87b0732ca84dc0354d0836.
- Added a command line option (`--noversioncheck` or `-V`) to skip the version check (as suggested by @nyalldawson).

![qgischeckversion](https://cloud.githubusercontent.com/assets/15147421/13035364/b39c3364-d34e-11e5-81fc-28b6d8051b31.PNG)

_Edit: Added new command line option._
