### PR TITLE
[Bugfix] correctly check/uncheck 'Control feature rendering order' (fixes #14274)

### DIFF
--- a/src/gui/symbology-ng/qgsrendererv2propertiesdialog.cpp
+++ b/src/gui/symbology-ng/qgsrendererv2propertiesdialog.cpp
@@ -282,7 +282,7 @@ void QgsRendererV2PropertiesDialog::changeOrderBy( const QgsFeatureRequest::Orde
 {
   mOrderBy = orderBy;
   lineEditOrderBy->setText( mOrderBy.dump() );
-  checkboxEnableOrderBy->setChecked( orderBy.isEmpty() );
+  checkboxEnableOrderBy->setChecked( !orderBy.isEmpty() );
 }
 
 


### PR DESCRIPTION
The logic to automatically check/uncheck the _Control feature rendering order_ is currently inverted. The checkbox is unchecked when an order-by clause is defined and checked when none is defined.

@nyalldawson Here I finally got the ultimate one-character-bugfix :sunglasses: 

But actually automatically checking/unchecking the checkbox is a bug itself, isn't it?
