### PR TITLE
[ui] improve virtual layer icon

### DIFF
--- a/images/themes/default/mActionAddVirtualLayer.svg
+++ b/images/themes/default/mActionAddVirtualLayer.svg
@@ -14,8 +14,8 @@
    height="32px"
    id="svg5692"
    version="1.1"
-   inkscape:version="0.48.4 r9939"
-   sodipodi:docname="vlayer.svg"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="mActionAddVirtualLayer.svg"
    inkscape:export-filename="/media/home1/robert/svn/graphics/trunk/toolbar-icons/32x32/layer-vector.png"
    inkscape:export-xdpi="90"
    inkscape:export-ydpi="90">
@@ -26,11 +26,11 @@
     <linearGradient
        id="linearGradient3812">
       <stop
-         style="stop-color:#6e97c4;stop-opacity:1;"
+         style="stop-color:#6e97c4;stop-opacity:1"
          offset="0"
          id="stop3814" />
       <stop
-         style="stop-color:#6e97c4;stop-opacity:0;"
+         style="stop-color:#ecedef;stop-opacity:1"
          offset="1"
          id="stop3816" />
     </linearGradient>
@@ -87,10 +87,10 @@
        inkscape:collect="always"
        xlink:href="#linearGradient3812"
        id="linearGradient3818"
-       x1="37.316311"
-       y1="36.925365"
-       x2="3.1572213"
-       y2="3.1572211"
+       x1="33.051174"
+       y1="35.070534"
+       x2="4.6237812"
+       y2="4.7282839"
        gradientUnits="userSpaceOnUse" />
   </defs>
   <sodipodi:namedview
@@ -101,8 +101,8 @@
      inkscape:pageopacity="0.0"
      inkscape:pageshadow="2"
      inkscape:zoom="15.9375"
-     inkscape:cx="8.4239343"
-     inkscape:cy="11.653661"
+     inkscape:cx="22.387464"
+     inkscape:cy="21.786095"
      inkscape:current-layer="layer2"
      showgrid="true"
      inkscape:grid-bbox="true"
@@ -110,11 +110,11 @@
      borderlayer="false"
      inkscape:window-width="1377"
      inkscape:window-height="807"
-     inkscape:window-x="1932"
+     inkscape:window-x="543"
      inkscape:window-y="134"
      inkscape:window-maximized="0"
      inkscape:snap-global="true"
-     showguides="true"
+     showguides="false"
      inkscape:guide-bbox="true"
      inkscape:snap-object-midpoints="true"
      inkscape:snap-grids="false">
@@ -181,63 +181,62 @@
      inkscape:label="Layer"
      style="display:inline">
     <path
-       inkscape:connector-curvature="0"
-       style="color:#000000;fill:none;stroke:#415a75;stroke-width:1.78710628;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       d="M 3.1572212,3.1572206 11.707585,23.749318 21.110969,3.3492624 28.84278,3.3200046"
-       id="path2960"
-       sodipodi:nodetypes="cccc" />
-    <path
-       sodipodi:type="arc"
-       style="color:#000000;fill:#eeeeec;fill-opacity:1;fill-rule:evenodd;stroke:#415a75;stroke-width:0.78947365;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path2958"
-       sodipodi:cx="3.5"
-       sodipodi:cy="12.5"
-       sodipodi:rx="1"
-       sodipodi:ry="1"
-       d="m 4.5,12.5 a 1,1 0 1 1 -2,0 1,1 0 1 1 2,0 z"
-       transform="matrix(2.263668,0,0,2.263668,-4.7656167,-25.138629)" />
-    <path
-       sodipodi:type="arc"
-       style="color:#000000;fill:#eeeeec;fill-opacity:1;fill-rule:evenodd;stroke:#415a75;stroke-width:1.05263162;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path2958-0"
-       sodipodi:cx="3.5"
-       sodipodi:cy="12.5"
-       sodipodi:rx="1"
-       sodipodi:ry="1"
-       d="m 4.5,12.5 a 1,1 0 1 1 -2,0 1,1 0 1 1 2,0 z"
-       transform="matrix(2.263668,0,0,2.263668,3.8127783,-5.6260389)" />
-    <path
-       sodipodi:type="arc"
-       style="color:#000000;fill:#eeeeec;fill-opacity:1;fill-rule:evenodd;stroke:#415a75;stroke-width:0.78947365;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path2958-9"
-       sodipodi:cx="3.5"
-       sodipodi:cy="12.5"
-       sodipodi:rx="1"
-       sodipodi:ry="1"
-       d="m 4.5,12.5 a 1,1 0 1 1 -2,0 1,1 0 1 1 2,0 z"
-       transform="matrix(2.263668,0,0,2.263668,12.949214,-24.994533)" />
-    <path
-       sodipodi:type="arc"
-       style="color:#000000;fill:#eeeeec;fill-opacity:1;fill-rule:evenodd;stroke:#415a75;stroke-width:0.78947365;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;stroke-dashoffset:0;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       id="path2958-6"
-       sodipodi:cx="3.5"
-       sodipodi:cy="12.5"
-       sodipodi:rx="1"
-       sodipodi:ry="1"
-       d="m 4.5,12.5 a 1,1 0 1 1 -2,0 1,1 0 1 1 2,0 z"
-       transform="matrix(2.263668,0,0,2.263668,20.919941,-24.975845)" />
-    <path
-       style="color:#000000;fill:url(#linearGradient3818);fill-opacity:1;stroke:#2e4e72;stroke-width:1.12999999999999989;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate;fill-rule:nonzero;opacity:1"
-       d="m 4.8072919,3.0420338 22.3854161,0 c 1.042824,0 1.875,0.832177 1.875,1.875001 l 0,22.1971812 c 0,1.042824 -0.832176,1.90625 -1.875,1.90625 l -22.3854161,0 c -1.0428239,0 -1.875,-0.863426 -1.875,-1.90625 l 0,-22.1971812 c 0,-1.042824 0.8321761,-1.875001 1.875,-1.875001 z"
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:url(#linearGradient3818);fill-opacity:1;fill-rule:nonzero;stroke:#2e4e72;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 4.2228977,2.2500001 23.5542053,0 c 1.097272,0 1.972898,0.8809181 1.972898,1.9848207 l 0,23.4972802 c 0,1.103903 -0.875626,2.0179 -1.972898,2.0179 l -23.5542053,0 c -1.0972719,0 -1.9728976,-0.913997 -1.9728976,-2.0179 l 0,-23.4972802 c 0,-1.1039026 0.8756257,-1.9848207 1.9728976,-1.9848207 z"
        id="rect3022"
        inkscape:connector-curvature="0"
        sodipodi:nodetypes="sssssssss" />
     <path
-       style="color:#000000;fill:#ffffff;fill-opacity:1;stroke:none;stroke-width:1.12999999999999989;stroke-miterlimit:4;stroke-opacity:1;stroke-dasharray:none;marker:none;visibility:visible;display:inline;overflow:visible;enable-background:accumulate"
-       d="m 0,0 0,32.0625 32,0 L 32,0 z m 4.7761029,3.0844363 22.3854161,0 c 1.042824,0 1.875,0.8321765 1.875,1.8750003 l 0,22.1971814 c 0,1.042824 -0.832176,1.90625 -1.875,1.90625 l -22.3854161,0 c -1.0428235,0 -1.875,-0.863426 -1.875,-1.90625 l 0,-22.1971814 c 0,-1.0428238 0.8321765,-1.8750003 1.875,-1.8750003 z"
-       id="rect3022"
        inkscape:connector-curvature="0"
-       sodipodi:nodetypes="cccccsssssssss" />
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:none;stroke:#415a75;stroke-width:1.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 3.5,3.5 8,19.999993 9,-19.999993 8,0"
+       id="path2960-4"
+       sodipodi:nodetypes="cccc" />
+    <ellipse
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;fill:#eeeeec;fill-opacity:1;fill-rule:evenodd;stroke:#415a75;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;enable-background:accumulate"
+       id="path2958-0-7"
+       cx="11.5"
+       cy="23.5"
+       rx="2.5"
+       ry="2.5000002" />
+    <path
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="M 6.0636289,2.2912548 5.5843137,5.0039215 4.1568627,6.0392157 2.3757219,6.3169742 2.4303929,3.7618233 3.0383816,2.6780255 4.1660515,2.3925229 Z"
+       id="path4260"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccccc" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#415a75;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="M 4.0898438 2.0605469 C 4.0421282 2.0605469 3.9979945 2.0709358 3.9511719 2.0742188 C 4.5631582 2.2627235 5 2.8187118 5 3.5 C 5 4.340272 4.3402717 5 3.5 5 C 2.8697962 5 2.3421238 4.6279289 2.1171875 4.0878906 L 2.1171875 6.7089844 C 2.5424978 6.8942597 3.0094755 7 3.5 7 C 5.421152 7 7 5.421152 7 3.5 C 7 2.9865124 6.8797066 2.5015157 6.6777344 2.0605469 L 4.0898438 2.0605469 z "
+       id="path2958-0-7-1" />
+    <path
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 18.200809,2.2904666 0.221837,2.3887728 2.628334,1.34429 1.945098,-0.5019608 0.695579,-3.2935206 z"
+       id="path4262"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="cccccc" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#415a75;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="M 17.24218,2.25 C 17.09074,2.6399814 17,3.0589832 17,3.5 17,5.421152 18.57885,7 20.5,7 22.42115,7 24,5.421152 24,3.5 24,3.0589832 23.9073,2.6399814 23.75585,2.25 l -2.41992,0 C 21.73846,2.5164644 22,2.9716687 22,3.5 22,4.340272 21.34027,5 20.5,5 19.65972,5 19,4.340272 19,3.5 19,2.9716501 19.26151,2.5164604 19.66406,2.25 l -2.42188,0 z"
+       id="path2958-0-7-11-0-8"
+       inkscape:connector-curvature="0" />
+    <path
+       style="fill:#eeeeec;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:miter;stroke-opacity:1"
+       d="m 26.61311,2.3091707 0.493428,2.7218555 2.6024,1.0758555 -0.0479,-2.658896 L 29.060168,2.7252231 28.10048,2.3530764 Z"
+       id="path4264"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccc" />
+    <path
+       style="color:#000000;font-style:normal;font-variant:normal;font-weight:normal;font-stretch:normal;font-size:medium;line-height:normal;font-family:sans-serif;text-indent:0;text-align:start;text-decoration:none;text-decoration-line:none;text-decoration-style:solid;text-decoration-color:#000000;letter-spacing:normal;word-spacing:normal;text-transform:none;direction:ltr;block-progression:tb;writing-mode:lr-tb;baseline-shift:baseline;text-anchor:start;white-space:normal;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:#415a75;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1.99999988;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-dashoffset:0;stroke-opacity:1;marker:none;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       d="M 26.24414,2.25 C 26.092767,2.6399031 26,3.0590898 26,3.5 26,5.4211521 27.578848,7 29.5,7 29.58537,7 29.666086,6.980737 29.75,6.974609 l 0,-2 C 29.66863,4.987805 29.58563,5 29.5,5 28.659728,5 28,4.340272 28,3.5 28,3.0528479 28.190749,2.6594042 28.492187,2.3867188 28.270495,2.3008708 28.030728,2.25 27.777344,2.25 l -1.533204,0 z"
+       id="path2958-0-7-11-7-4"
+       inkscape:connector-curvature="0" />
+    <path
+       style="color:#000000;display:inline;overflow:visible;visibility:visible;opacity:1;fill:none;fill-opacity:1;fill-rule:nonzero;stroke:#2e4e72;stroke-width:0.5;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;marker:none;enable-background:accumulate"
+       d="m 4.2228977,2.25 23.5542053,0 c 1.097273,0 1.972898,0.880918 1.972898,1.9848207 l 0,23.4972793 c 0,1.103902 -0.875625,2.0179 -1.972898,2.0179 l -23.5542053,0 c -1.0972719,0 -1.9728976,-0.913998 -1.9728976,-2.0179 l 0,-23.4972793 C 2.2500001,3.130918 3.1256258,2.25 4.2228977,2.25 Z"
+       id="rect3022-4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="sssssssss" />
     <g
        style="display:inline"
        id="g3772">


### PR DESCRIPTION
![untitled](https://cloud.githubusercontent.com/assets/1728657/13099346/ba88ffc4-d563-11e5-9960-74a10d05a609.png)

This PR removes the white outline used in the initial icon to add clipped vector elements. 

Elements also align to the grid, make the icon look sharper.
