### PR TITLE
[Bugfix] construct the QgsOrderByDialog with the correct parent

### DIFF
--- a/src/gui/symbology-ng/qgsrendererv2propertiesdialog.cpp
+++ b/src/gui/symbology-ng/qgsrendererv2propertiesdialog.cpp
@@ -268,7 +268,7 @@ void QgsRendererV2PropertiesDialog::onOK()
 
 void QgsRendererV2PropertiesDialog::showOrderByDialog()
 {
-  QgsOrderByDialog dlg( mLayer );
+  QgsOrderByDialog dlg( mLayer, this );
 
   dlg.setOrderBy( mOrderBy );
   if ( dlg.exec() )


### PR DESCRIPTION
This is necessary to ensure proper modal behaviour.

@NathanW2 After #2509 and #2704, are you up to merge my third PR of this kind? :wink: 
