### PR TITLE
[Bugfix] Remove the checkbox 'Control feature rendering order' (fixes #14323)

### DIFF
--- a/src/gui/symbology-ng/qgsrendererv2propertiesdialog.cpp
+++ b/src/gui/symbology-ng/qgsrendererv2propertiesdialog.cpp
@@ -136,19 +136,7 @@ QgsRendererV2PropertiesDialog::QgsRendererV2PropertiesDialog( QgsVectorLayer* la
   // setup slot rendererChanged()
   connect( cboRenderers, SIGNAL( currentIndexChanged( int ) ), this, SLOT( rendererChanged() ) );
   //setup order by
-  if ( mOrderBy.isEmpty() )
-  {
-    btnOrderBy->setEnabled( false );
-    checkboxEnableOrderBy->setChecked( false );
-    lineEditOrderBy->setEnabled( false );
-  }
-  else
-  {
-    checkboxEnableOrderBy->setChecked( true );
-  }
   lineEditOrderBy->setReadOnly( true );
-  connect( checkboxEnableOrderBy, SIGNAL( toggled( bool ) ), btnOrderBy, SLOT( setEnabled( bool ) ) );
-  connect( checkboxEnableOrderBy, SIGNAL( toggled( bool ) ), lineEditOrderBy, SLOT( setEnabled( bool ) ) );
   connect( btnOrderBy, SIGNAL( clicked( bool ) ), this, SLOT( showOrderByDialog() ) );
   lineEditOrderBy->setText( mOrderBy.dump() );
 
@@ -282,7 +270,6 @@ void QgsRendererV2PropertiesDialog::changeOrderBy( const QgsFeatureRequest::Orde
 {
   mOrderBy = orderBy;
   lineEditOrderBy->setText( mOrderBy.dump() );
-  checkboxEnableOrderBy->setChecked( !orderBy.isEmpty() );
 }
 
 

--- a/src/ui/qgsrendererv2propsdialogbase.ui
+++ b/src/ui/qgsrendererv2propsdialogbase.ui
@@ -146,9 +146,9 @@
       <item row="3" column="0" colspan="4">
        <layout class="QHBoxLayout" name="horizontalLayout_3">
         <item>
-         <widget class="QCheckBox" name="checkboxEnableOrderBy">
+         <widget class="QLabel" name="lblFeatureRenderingOrder">
           <property name="text">
-           <string>Control feature rendering order</string>
+           <string>Feature rendering order</string>
           </property>
          </widget>
         </item>


### PR DESCRIPTION
The checkbox _Control feature rendering order_ that is part of #2600 does not have any effect on the rendering. However the UI suggests the user can enable or disable the ordering (see [Redmine #14323](https://hub.qgis.org/issues/14323)).

Therefore the checkbox is removed by this PR.

I know this is not the best solution, because actually having a working checkbox to enable/disable the rendering order is expected by most people (inlcuding me). Please consider this PR a fall-back in case nobody else ( @m-kuhn ? ) comes up with a better solution before the release of QGIS 2.14.

![qgisfeaturerenderingorder](https://cloud.githubusercontent.com/assets/15147421/13159232/fe799044-d690-11e5-917a-65dee1a93f71.PNG)
