### PR TITLE
[Bugfix] Avoid accumulating sub-clauses in QgsOrderByDialog (fixes #14325)

### DIFF
--- a/python/gui/qgsfieldexpressionwidget.sip
+++ b/python/gui/qgsfieldexpressionwidget.sip
@@ -78,7 +78,7 @@ class QgsFieldExpressionWidget : QWidget
     void setLayer( QgsMapLayer* layer );
 
     //! sets the current field or expression in the widget
-    void setField( const QString &fieldName );
+    void setField( const QString &fieldName, bool allowEmptyFieldName = false );
 
   protected slots:
     //! open the expression dialog to edit the current or add a new expression

--- a/src/gui/qgsfieldexpressionwidget.cpp
+++ b/src/gui/qgsfieldexpressionwidget.cpp
@@ -165,9 +165,9 @@ void QgsFieldExpressionWidget::setLayer( QgsVectorLayer *layer )
     connect( mFieldProxyModel->sourceFieldModel()->layer(), SIGNAL( updatedFields() ), SLOT( reloadLayer() ), Qt::UniqueConnection );
 }
 
-void QgsFieldExpressionWidget::setField( const QString &fieldName )
+void QgsFieldExpressionWidget::setField( const QString &fieldName , bool allowEmptyFieldName )
 {
-  if ( fieldName.isEmpty() )
+  if ( !allowEmptyFieldName && fieldName.isEmpty() )
     return;
 
   QModelIndex idx = mFieldProxyModel->sourceFieldModel()->indexFromName( fieldName );

--- a/src/gui/qgsfieldexpressionwidget.h
+++ b/src/gui/qgsfieldexpressionwidget.h
@@ -121,7 +121,7 @@ class GUI_EXPORT QgsFieldExpressionWidget : public QWidget
     void setLayer( QgsMapLayer* layer );
 
     //! sets the current field or expression in the widget
-    void setField( const QString &fieldName );
+    void setField( const QString &fieldName, bool allowEmptyFieldName = false );
 
   protected slots:
     //! open the expression dialog to edit the current or add a new expression

--- a/src/gui/qgsorderbydialog.cpp
+++ b/src/gui/qgsorderbydialog.cpp
@@ -107,7 +107,7 @@ void QgsOrderByDialog::setRow( int row, const QgsFeatureRequest::OrderByClause& 
 {
   QgsFieldExpressionWidget* fieldExpression = new QgsFieldExpressionWidget();
   fieldExpression->setLayer( mLayer );
-  fieldExpression->setField( orderByClause.expression().expression() );
+  fieldExpression->setField( orderByClause.expression().expression(), true );
   connect( fieldExpression, SIGNAL( fieldChanged( QString ) ), this, SLOT( onExpressionChanged( QString ) ) );
 
   QComboBox* ascComboBox = new QComboBox();


### PR DESCRIPTION
When the last sub-clause looses focus and is not empty, a new sub-clause is added. This sub-clause is normally empty, except when the underlying layer has only one field. It contains the fieldname then. This is because `QgsFieldExpressionWidget`
- defaults to the fieldname if only one field is present
- silently ignores requests to set the expression to the empty string

This PR fixes the problem by adding the option to set the expression in `QgsFieldExpressionWidget` to the empty string.
