### PR TITLE
[Bugfix] Remove FEATURE_DATASET option if not set (Redmine #13824)

### DIFF
--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -284,10 +284,10 @@ void QgsVectorFileWriter::init( QString vectorFileName, QString fileEncoding, co
   OGRwkbGeometryType wkbType = static_cast<OGRwkbGeometryType>( geometryType );
 
   // Remove FEATURE_DATASET layer option (used for ESRI File GDB driver) if its value is not set
-  int optIndex = layOptions.indexOf("FEATURE_DATASET=");
+  int optIndex = layerOptions.indexOf("FEATURE_DATASET=");
   if ( optIndex != -1 )
   {
-    layOptions.removeAt(optIndex);
+    layerOptions.removeAt(optIndex);
   }
   
   if ( !layerOptions.isEmpty() )

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -284,12 +284,12 @@ void QgsVectorFileWriter::init( QString vectorFileName, QString fileEncoding, co
   OGRwkbGeometryType wkbType = static_cast<OGRwkbGeometryType>( geometryType );
 
   // Remove FEATURE_DATASET layer option (used for ESRI File GDB driver) if its value is not set
-  int optIndex = layerOptions.indexOf("FEATURE_DATASET=");
+  int optIndex = layerOptions.indexOf( "FEATURE_DATASET=" );
   if ( optIndex != -1 )
   {
-    layerOptions.removeAt(optIndex);
+    layerOptions.removeAt( optIndex );
   }
-  
+
   if ( !layerOptions.isEmpty() )
   {
     options = new char *[ layerOptions.size()+1 ];

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -283,6 +283,13 @@ void QgsVectorFileWriter::init( QString vectorFileName, QString fileEncoding, co
   QString layerName = QFileInfo( vectorFileName ).baseName();
   OGRwkbGeometryType wkbType = static_cast<OGRwkbGeometryType>( geometryType );
 
+  // Remove FEATURE_DATASET layer option (used for ESRI File GDB driver) if its value is not set
+  int optIndex = layOptions.indexOf("FEATURE_DATASET=");
+  if ( optIndex != -1 )
+  {
+    layOptions.removeAt(optIndex);
+  }
+  
   if ( !layerOptions.isEmpty() )
   {
     options = new char *[ layerOptions.size()+1 ];


### PR DESCRIPTION
I believe that this will fix the bug as described, however I do not have the capability to compile and test this code.

I am not 100% certain of the string to search for, specifically, whether the default empty string value will be retained on the right of the equals sign ("FEATURE_DATASET=" vs "FEATURE_DATASET=""""", the proposed value is based on examples in the surrounding code, assuming that nothing is recorded to the right of the '=' if no value was entered by the user.
