### PR TITLE
astyle.sh: make it not touch unmodified files

### DIFF
--- a/scripts/astyle.sh
+++ b/scripts/astyle.sh
@@ -56,7 +56,11 @@ set -e
 
 astyleit() {
 	$ASTYLE --options="$ASTYLEOPTS" "$1"
-	scripts/unify_includes.pl "$1"
+	modified=$1.unify_includes_modified
+	cp "$1" "$modified"
+	scripts/unify_includes.pl "$modified"
+	diff "$f" "$modified" >/dev/null || mv "$modified" "$1"
+	rm -f "$modified"
 }
 
 for f in "$@"; do
@@ -103,6 +107,10 @@ for f in "$@"; do
 		echo "removed BOM from $f"
 	fi
 
-	flip -ub "$f"
+	modified=$f.flip_modified
+	cp "$f" "$modified"
+	flip -ub "$modified"
+	diff "$f" "$modified" >/dev/null || mv "$modified" "$f"
+	rm -f "$modified"
 	eval "$cmd '$f'"
 done

--- a/scripts/astyle.sh
+++ b/scripts/astyle.sh
@@ -59,7 +59,7 @@ astyleit() {
 	modified=$1.unify_includes_modified
 	cp "$1" "$modified"
 	scripts/unify_includes.pl "$modified"
-	diff "$f" "$modified" >/dev/null || mv "$modified" "$1"
+	diff "$1" "$modified" >/dev/null || mv "$modified" "$1"
 	rm -f "$modified"
 }
 


### PR DESCRIPTION
Currently astyle.sh will rewrite files, even if no change are made.
This causes some editors (for example kate) to believe that the file
has been changed even if it is not the case. Letting the timestamp
untouched is not enough. So make 'flip' and 'unify_includes.pl'
operate on copies, and move the copies as the original file if
differences are found.
