### PR TITLE
[Bugfix] create vector joins only once for a duplicated layer (fixes #14298)

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -7886,16 +7886,6 @@ void QgisApp::duplicateLayers( const QList<QgsMapLayer *>& lyrList )
       messageBar()->pushMessage( errMsg,
                                  tr( "Cannot copy style to duplicated layer." ),
                                  QgsMessageBar::CRITICAL, messageTimeout() );
-
-    QgsVectorLayer* vLayer = dynamic_cast<QgsVectorLayer*>( selectedLyr );
-    QgsVectorLayer* vDupLayer = dynamic_cast<QgsVectorLayer*>( dupLayer );
-    if ( vLayer && vDupLayer )
-    {
-      Q_FOREACH ( const QgsVectorJoinInfo& join, vLayer->vectorJoins() )
-      {
-        vDupLayer->addJoin( join );
-      }
-    }
   }
 
   dupLayer = nullptr;


### PR DESCRIPTION
Creating the vector joins for a duplicated layer was implemented twice
- first in 9ed180303c8f4172c9c6155e9cb226f79fc734b4
- and again in 57b5eb954ef988489456fcd14b236bb784d150a2

So duplicated layers got every vector join twice (see [Redmine #14298](https://hub.qgis.org/issues/14298)).
