### PR TITLE
change QgsAbstractGeometryV2::coordinateSequence() to return a

### DIFF
--- a/python/core/geometry/qgsabstractgeometryv2.sip
+++ b/python/core/geometry/qgsabstractgeometryv2.sip
@@ -221,9 +221,9 @@ class QgsAbstractGeometryV2
     virtual bool nextVertex( QgsVertexId& id, QgsPointV2& vertex ) const = 0;
 
     /** Retrieves the sequence of geometries, rings and nodes.
-     * @param coord destination for coordinate sequence.
+     * @return coordinate sequence
      */
-    virtual void coordinateSequence( QList< QList< QList< QgsPointV2 > > >& coord /Out/ ) const = 0;
+    virtual QList< QList< QList< QgsPointV2 > > > coordinateSequence() const = 0;
 
     /** Returns the number of nodes contained in the geometry
      */

--- a/python/core/geometry/qgscircularstringv2.sip
+++ b/python/core/geometry/qgscircularstringv2.sip
@@ -82,7 +82,7 @@ class QgsCircularStringV2: public QgsCurveV2
     /**
      * @copydoc QgsCurveV2::pointAt()
      */
-    bool pointAt( int i, QgsPointV2& vertex, QgsVertexId::VertexType& type ) const;
+    bool pointAt( int node, QgsPointV2& point, QgsVertexId::VertexType& type ) const;
 
     /**
      * @copydoc QgsCurveV2::sumUpArea()

--- a/python/core/geometry/qgscurvepolygonv2.sip
+++ b/python/core/geometry/qgscurvepolygonv2.sip
@@ -64,7 +64,7 @@ class QgsCurvePolygonV2: public QgsSurfaceV2
     virtual bool moveVertex( QgsVertexId position, const QgsPointV2& newPos );
     virtual bool deleteVertex( QgsVertexId position );
 
-    virtual void coordinateSequence( QList< QList< QList< QgsPointV2 > > >& coord /Out/ ) const;
+    virtual QList< QList< QList< QgsPointV2 > > > coordinateSequence() const;
     double closestSegment( const QgsPointV2& pt, QgsPointV2& segmentPt,  QgsVertexId& vertexAfter, bool* leftOf, double epsilon ) const;
     bool nextVertex( QgsVertexId& id, QgsPointV2& vertex ) const;
 

--- a/python/core/geometry/qgscurvev2.sip
+++ b/python/core/geometry/qgscurvev2.sip
@@ -57,7 +57,7 @@ class QgsCurveV2: public QgsAbstractGeometryV2
      */
     virtual void sumUpArea( double& sum ) const = 0;
 
-    virtual void coordinateSequence( QList< QList< QList< QgsPointV2 > > >& coord /Out/ ) const;
+    virtual QList< QList< QList< QgsPointV2 > > > coordinateSequence() const;
     virtual bool nextVertex( QgsVertexId& id, QgsPointV2& vertex ) const;
 
     /** Returns the point and vertex id of a point within the curve.
@@ -76,8 +76,8 @@ class QgsCurveV2: public QgsAbstractGeometryV2
     /** Returns a geometry without curves. Caller takes ownership*/
     virtual QgsCurveV2* segmentize() const /Factory/;
 
-    virtual int vertexCount(int part = 0, int ring = 0) const;
-    virtual int ringCount(int part = 0) const;
+    virtual int vertexCount( int part = 0, int ring = 0 ) const;
+    virtual int ringCount( int part = 0 ) const;
     virtual int partCount() const;
     virtual QgsPointV2 vertexAt( QgsVertexId id ) const;
 

--- a/python/core/geometry/qgsgeometry.sip
+++ b/python/core/geometry/qgsgeometry.sip
@@ -279,11 +279,13 @@ class QgsGeometry
     /** Adds a new ring to this geometry. This makes only sense for polygon and multipolygons.
      @return 0 in case of success (ring added), 1 problem with geometry type, 2 ring not closed,
      3 ring is not valid geometry, 4 ring not disjoint with existing rings, 5 no polygon found which contained the ring*/
+    // TODO QGIS 3.0 returns an enum instead of a magic constant
     int addRing( const QList<QgsPoint>& ring );
 
     /** Adds a new ring to this geometry. This makes only sense for polygon and multipolygons.
      @return 0 in case of success (ring added), 1 problem with geometry type, 2 ring not closed,
      3 ring is not valid geometry, 4 ring not disjoint with existing rings, 5 no polygon found which contained the ring*/
+    // TODO QGIS 3.0 returns an enum instead of a magic constant
     int addRing( QgsCurveV2* ring );
 
     /** Adds a new part to a the geometry.
@@ -292,6 +294,7 @@ class QgsGeometry
      * @returns 0 in case of success, 1 if not a multipolygon, 2 if ring is not a valid geometry, 3 if new polygon ring
      * not disjoint with existing polygons of the feature
      */
+    // TODO QGIS 3.0 returns an enum instead of a magic constant
     int addPart( const QList<QgsPoint> &points, QGis::GeometryType geomType = QGis::UnknownGeometry );
 
     /** Adds a new part to a the geometry.
@@ -300,6 +303,7 @@ class QgsGeometry
      * @returns 0 in case of success, 1 if not a multipolygon, 2 if ring is not a valid geometry, 3 if new polygon ring
      * not disjoint with existing polygons of the feature
      */
+    // TODO QGIS 3.0 returns an enum instead of a magic constant
     int addPart( const QList<QgsPointV2> &points, QGis::GeometryType geomType = QGis::UnknownGeometry );
 
     /** Adds a new part to this geometry.
@@ -308,6 +312,7 @@ class QgsGeometry
      * @returns 0 in case of success, 1 if not a multipolygon, 2 if ring is not a valid geometry, 3 if new polygon ring
      * not disjoint with existing polygons of the feature
      */
+    // TODO QGIS 3.0 returns an enum instead of a magic constant
     int addPart( QgsAbstractGeometryV2* part /Transfer/, QGis::GeometryType geomType = QGis::UnknownGeometry );
 
     /** Adds a new island polygon to a multipolygon feature
@@ -316,6 +321,7 @@ class QgsGeometry
      * not disjoint with existing polygons of the feature
      * @note not available in python bindings
      */
+    // TODO QGIS 3.0 returns an enum instead of a magic constant
     // int addPart( GEOSGeometry *newPart );
 
     /** Adds a new island polygon to a multipolygon feature
@@ -323,6 +329,7 @@ class QgsGeometry
      not disjoint with existing polygons of the feature
      @note available in python bindings as addPartGeometry (added in 2.2)
      */
+    // TODO QGIS 3.0 returns an enum instead of a magic constant
     int addPart( const QgsGeometry *newPart /Transfer/ ) /PyName=addPartGeometry/;
 
     /** Translate this geometry by dx, dy
@@ -351,6 +358,7 @@ class QgsGeometry
     @param topological true if topological editing is enabled
     @param[out] topologyTestPoints points that need to be tested for topological completeness in the dataset
     @return 0 in case of success, 1 if geometry has not been split, error else*/
+    // TODO QGIS 3.0 returns an enum instead of a magic constant
     int splitGeometry( const QList<QgsPoint>& splitLine,
                        QList<QgsGeometry*>&newGeometries /Out/,
                        bool topological,

--- a/python/core/geometry/qgsgeometrycollectionv2.sip
+++ b/python/core/geometry/qgsgeometrycollectionv2.sip
@@ -68,7 +68,7 @@ class QgsGeometryCollectionV2: public QgsAbstractGeometryV2
 
     virtual QgsRectangle boundingBox() const;
 
-    virtual void coordinateSequence( QList< QList< QList< QgsPointV2 > > >& coord /Out/ ) const;
+    virtual QList< QList< QList< QgsPointV2 > > > coordinateSequence() const;
     virtual double closestSegment( const QgsPointV2& pt, QgsPointV2& segmentPt,  QgsVertexId& vertexAfter, bool* leftOf, double epsilon ) const;
     bool nextVertex( QgsVertexId& id, QgsPointV2& vertex ) const;
 

--- a/python/core/geometry/qgspointv2.sip
+++ b/python/core/geometry/qgspointv2.sip
@@ -155,7 +155,7 @@ class QgsPointV2: public QgsAbstractGeometryV2
     void draw( QPainter& p ) const;
     void transform( const QgsCoordinateTransform& ct, QgsCoordinateTransform::TransformDirection d = QgsCoordinateTransform::ForwardTransform );
     void transform( const QTransform& t );
-    virtual void coordinateSequence( QList< QList< QList< QgsPointV2 > > >& coord /Out/ ) const;
+    virtual QList< QList< QList< QgsPointV2 > > > coordinateSequence() const;
 
     //low-level editing
     virtual bool insertVertex( QgsVertexId position, const QgsPointV2& vertex );

--- a/python/core/qgsvectorlayereditutils.sip
+++ b/python/core/qgsvectorlayereditutils.sip
@@ -54,6 +54,7 @@ class QgsVectorLayerEditUtils
      *   4 ring crosses existing rings,
      *   5 no feature found where ring can be inserted
      */
+    // TODO QGIS 3.0 returns an enum instead of a magic constant
     int addRing( const QList<QgsPoint>& ring, const QgsFeatureIds& targetFeatureIds = QgsFeatureIds(), QgsFeatureId* modifiedFeatureId = 0 );
 
     /** Adds a ring to polygon/multipolygon features
@@ -70,6 +71,7 @@ class QgsVectorLayerEditUtils
      *  5 no feature found where ring can be inserted
      * @note available in python bindings as addCurvedRing
      */
+    // TODO QGIS 3.0 returns an enum instead of a magic constant
     int addRing( QgsCurveV2* ring, const QgsFeatureIds& targetFeatureIds = QgsFeatureIds(), QgsFeatureId* modifiedFeatureId = nullptr ) /PyName=addCurvedRing/;
 
     /** Adds a new part polygon to a multipart feature
@@ -82,6 +84,7 @@ class QgsVectorLayerEditUtils
      *  5 if several features are selected,
      *  6 if selected geometry not found
      */
+    // TODO QGIS 3.0 returns an enum instead of a magic constant
     int addPart( const QList<QgsPoint>& ring, QgsFeatureId featureId );
 
     /** Adds a new part polygon to a multipart feature
@@ -95,9 +98,11 @@ class QgsVectorLayerEditUtils
      *  6 if selected geometry not found
      * @note available in python bindings as addPartV2
      */
+    // TODO QGIS 3.0 returns an enum instead of a magic constant
     int addPart( const QList<QgsPointV2>& ring, QgsFeatureId featureId ) /PyName=addPartV2/;
 
     // @note available in python bindings as addCurvedPart
+    // TODO QGIS 3.0 returns an enum instead of a magic constant
     int addPart( QgsCurveV2* ring, QgsFeatureId featureId ) /PyName=addCurvedPart/;
 
     /** Translates feature by dx, dy
@@ -115,6 +120,7 @@ class QgsVectorLayerEditUtils
      *   0 in case of success,
      *   4 if there is a selection but no feature split
      */
+    // TODO QGIS 3.0 returns an enum instead of a magic constant
     int splitParts( const QList<QgsPoint>& splitLine, bool topologicalEditing = false );
 
     /** Splits features cut by the given line
@@ -124,6 +130,7 @@ class QgsVectorLayerEditUtils
      *   0 in case of success,
      *   4 if there is a selection but no feature split
      */
+    // TODO QGIS 3.0 returns an enum instead of a magic constant
     int splitFeatures( const QList<QgsPoint>& splitLine, bool topologicalEditing = false );
 
     /** Adds topological points for every vertex of the geometry.

--- a/src/app/qgsmaptooladdcircularstring.cpp
+++ b/src/app/qgsmaptooladdcircularstring.cpp
@@ -161,7 +161,7 @@ void QgsMapToolAddCircularString::activate()
             mTempRubberBand->show();
           }
           QgsCircularStringV2* c = new QgsCircularStringV2();
-          QList< QgsPointV2 > rubberBandPoints = mPoints;
+          QgsPointSequenceV2 rubberBandPoints = mPoints;
           rubberBandPoints.append( QgsPointV2( mapPoint ) );
           c->setPoints( rubberBandPoints );
           mTempRubberBand->setGeometry( c );
@@ -208,7 +208,7 @@ void QgsMapToolAddCircularString::updateCenterPointRubberBand( const QgsPointV2&
 
   //create circular string
   QgsCircularStringV2* cs = new QgsCircularStringV2();
-  QList< QgsPointV2 > csPoints;
+  QgsPointSequenceV2 csPoints;
   csPoints.append( mPoints.at( mPoints.size() - 2 ) );
   csPoints.append( mPoints.at( mPoints.size() - 1 ) );
   csPoints.append( pt );

--- a/src/app/qgsmaptooladdcircularstring.h
+++ b/src/app/qgsmaptooladdcircularstring.h
@@ -45,7 +45,7 @@ class QgsMapToolAddCircularString: public QgsMapToolCapture
      * */
     QgsMapToolCapture* mParentTool;
     /** Circular string points (in map coordinates)*/
-    QList< QgsPointV2 > mPoints;
+    QgsPointSequenceV2 mPoints;
     //! The rubberband to show the already completed circular strings
     QgsGeometryRubberBand* mRubberBand;
     //! The rubberband to show the circular string currently working on

--- a/src/app/qgsmaptooladdpart.cpp
+++ b/src/app/qgsmaptooladdpart.cpp
@@ -85,7 +85,7 @@ void QgsMapToolAddPart::cadCanvasReleaseEvent( QgsMapMouseEvent * e )
       }
 
       vlayer->beginEditCommand( tr( "Part added" ) );
-      errorCode = vlayer->addPart( QList<QgsPointV2>() << layerPoint );
+      errorCode = vlayer->addPart( QgsPointSequenceV2() << layerPoint );
     }
     break;
 

--- a/src/app/qgsmaptoolcircularstringcurvepoint.cpp
+++ b/src/app/qgsmaptoolcircularstringcurvepoint.cpp
@@ -52,7 +52,7 @@ void QgsMapToolCircularStringCurvePoint::cadCanvasReleaseEvent( QgsMapMouseEvent
       }
 
       QgsCircularStringV2* c = new QgsCircularStringV2();
-      QList< QgsPointV2 > rubberBandPoints = mPoints.mid( mPoints.size() - 1 - ( mPoints.size() + 1 ) % 2 );
+      QgsPointSequenceV2 rubberBandPoints = mPoints.mid( mPoints.size() - 1 - ( mPoints.size() + 1 ) % 2 );
       rubberBandPoints.append( mapPoint );
       c->setPoints( rubberBandPoints );
       mTempRubberBand->setGeometry( c );
@@ -66,7 +66,7 @@ void QgsMapToolCircularStringCurvePoint::cadCanvasReleaseEvent( QgsMapMouseEvent
       }
 
       QgsCircularStringV2* c = new QgsCircularStringV2();
-      QList< QgsPointV2 > rubberBandPoints = mPoints;
+      QgsPointSequenceV2 rubberBandPoints = mPoints;
       rubberBandPoints.append( mapPoint );
       c->setPoints( rubberBandPoints );
       mRubberBand->setGeometry( c );

--- a/src/app/qgsmaptoolcircularstringradius.cpp
+++ b/src/app/qgsmaptoolcircularstringradius.cpp
@@ -122,7 +122,7 @@ void QgsMapToolCircularStringRadius::recalculateRubberBand()
 
 void QgsMapToolCircularStringRadius::recalculateTempRubberBand( const QgsPoint& mousePosition )
 {
-  QList<QgsPointV2> rubberBandPoints;
+  QgsPointSequenceV2 rubberBandPoints;
   if ( !( mPoints.size() % 2 ) )
   {
     //recalculate midpoint on circle segment

--- a/src/core/geometry/qgsabstractgeometryv2.cpp
+++ b/src/core/geometry/qgsabstractgeometryv2.cpp
@@ -137,18 +137,13 @@ QgsRectangle QgsAbstractGeometryV2::calculateBoundingBox() const
 
 int QgsAbstractGeometryV2::nCoordinates() const
 {
-  QList< QList< QList< QgsPointV2 > > > coordinates;
-  coordinateSequence( coordinates );
   int nCoords = 0;
 
-  QList< QList< QList< QgsPointV2 > > >::const_iterator partIt = coordinates.constBegin();
-  for ( ; partIt != coordinates.constEnd(); ++partIt )
+  Q_FOREACH ( const QgsRingSequenceV2 &r, coordinateSequence() )
   {
-    const QList< QList< QgsPointV2 > >& part = *partIt;
-    QList< QList< QgsPointV2 > >::const_iterator ringIt = part.constBegin();
-    for ( ; ringIt != part.constEnd(); ++ringIt )
+    Q_FOREACH ( const QgsPointSequenceV2 &p, r )
     {
-      nCoords += ringIt->size();
+      nCoords += p.size();
     }
   }
 

--- a/src/core/geometry/qgsabstractgeometryv2.h
+++ b/src/core/geometry/qgsabstractgeometryv2.h
@@ -32,6 +32,9 @@ class QgsPointV2;
 struct QgsVertexId;
 class QPainter;
 
+typedef QList< QgsPointV2 > QgsPointSequenceV2;
+typedef QList< QgsPointSequenceV2 > QgsRingSequenceV2;
+typedef QList< QgsRingSequenceV2 > QgsCoordinateSequenceV2;
 
 /** \ingroup core
  * \class QgsAbstractGeometryV2
@@ -204,9 +207,9 @@ class CORE_EXPORT QgsAbstractGeometryV2
     virtual bool nextVertex( QgsVertexId& id, QgsPointV2& vertex ) const = 0;
 
     /** Retrieves the sequence of geometries, rings and nodes.
-     * @param coord destination for coordinate sequence.
+     * @return coordinate sequence
      */
-    virtual void coordinateSequence( QList< QList< QList< QgsPointV2 > > >& coord ) const = 0;
+    virtual QgsCoordinateSequenceV2 coordinateSequence() const = 0;
 
     /** Returns the number of nodes contained in the geometry
      */

--- a/src/core/geometry/qgscircularstringv2.cpp
+++ b/src/core/geometry/qgscircularstringv2.cpp
@@ -118,8 +118,8 @@ QgsRectangle QgsCircularStringV2::segmentBoundingBox( const QgsPointV2& pt1, con
   QgsRectangle bbox( pt1.x(), pt1.y(), pt1.x(), pt1.y() );
   bbox.combineExtentWith( pt3.x(), pt3.y() );
 
-  QList<QgsPointV2> compassPoints = compassPointsOnSegment( p1Angle, p2Angle, p3Angle, centerX, centerY, radius );
-  QList<QgsPointV2>::const_iterator cpIt = compassPoints.constBegin();
+  QgsPointSequenceV2 compassPoints = compassPointsOnSegment( p1Angle, p2Angle, p3Angle, centerX, centerY, radius );
+  QgsPointSequenceV2::const_iterator cpIt = compassPoints.constBegin();
   for ( ; cpIt != compassPoints.constEnd(); ++cpIt )
   {
     bbox.combineExtentWith( cpIt->x(), cpIt->y() );
@@ -127,9 +127,9 @@ QgsRectangle QgsCircularStringV2::segmentBoundingBox( const QgsPointV2& pt1, con
   return bbox;
 }
 
-QList<QgsPointV2> QgsCircularStringV2::compassPointsOnSegment( double p1Angle, double p2Angle, double p3Angle, double centerX, double centerY, double radius )
+QgsPointSequenceV2 QgsCircularStringV2::compassPointsOnSegment( double p1Angle, double p2Angle, double p3Angle, double centerX, double centerY, double radius )
 {
-  QList<QgsPointV2> pointList;
+  QgsPointSequenceV2 pointList;
 
   QgsPointV2 nPoint( centerX, centerY + radius );
   QgsPointV2 ePoint( centerX + radius, centerY );
@@ -274,7 +274,7 @@ unsigned char* QgsCircularStringV2::asWkb( int& binarySize ) const
   QgsWkbPtr wkb( geomPtr, binarySize );
   wkb << static_cast<char>( QgsApplication::endian() );
   wkb << static_cast<quint32>( wkbType() );
-  QList<QgsPointV2> pts;
+  QgsPointSequenceV2 pts;
   points( pts );
   QgsGeometryUtils::pointsToWKB( wkb, pts, is3D(), isMeasure() );
   return geomPtr;
@@ -283,7 +283,7 @@ unsigned char* QgsCircularStringV2::asWkb( int& binarySize ) const
 QString QgsCircularStringV2::asWkt( int precision ) const
 {
   QString wkt = wktTypeStr() + ' ';
-  QList<QgsPointV2> pts;
+  QgsPointSequenceV2 pts;
   points( pts );
   wkt += QgsGeometryUtils::pointsToWKT( pts, precision, is3D(), isMeasure() );
   return wkt;
@@ -300,7 +300,7 @@ QDomElement QgsCircularStringV2::asGML2( QDomDocument& doc, int precision, const
 
 QDomElement QgsCircularStringV2::asGML3( QDomDocument& doc, int precision, const QString& ns ) const
 {
-  QList<QgsPointV2> pts;
+  QgsPointSequenceV2 pts;
   points( pts );
 
   QDomElement elemCurve = doc.createElementNS( ns, "Curve" );
@@ -354,7 +354,7 @@ QgsPointV2 QgsCircularStringV2::endPoint() const
 QgsLineStringV2* QgsCircularStringV2::curveToLine() const
 {
   QgsLineStringV2* line = new QgsLineStringV2();
-  QList<QgsPointV2> points;
+  QgsPointSequenceV2 points;
   int nPoints = numPoints();
 
   for ( int i = 0; i < ( nPoints - 2 ) ; i += 2 )
@@ -408,7 +408,7 @@ QgsPointV2 QgsCircularStringV2::pointN( int i ) const
   return QgsPointV2( t, x, y, z, m );
 }
 
-void QgsCircularStringV2::points( QList<QgsPointV2>& pts ) const
+void QgsCircularStringV2::points( QgsPointSequenceV2 &pts ) const
 {
   pts.clear();
   int nPts = numPoints();
@@ -418,7 +418,7 @@ void QgsCircularStringV2::points( QList<QgsPointV2>& pts ) const
   }
 }
 
-void QgsCircularStringV2::setPoints( const QList<QgsPointV2>& points )
+void QgsCircularStringV2::setPoints( const QgsPointSequenceV2 &points )
 {
   clearCache();
 
@@ -473,7 +473,7 @@ void QgsCircularStringV2::setPoints( const QList<QgsPointV2>& points )
   }
 }
 
-void QgsCircularStringV2::segmentize( const QgsPointV2& p1, const QgsPointV2& p2, const QgsPointV2& p3, QList<QgsPointV2>& points ) const
+void QgsCircularStringV2::segmentize( const QgsPointV2& p1, const QgsPointV2& p2, const QgsPointV2& p3, QgsPointSequenceV2 &points ) const
 {
   //adapted code from postgis
   double radius = 0;
@@ -670,7 +670,7 @@ void QgsCircularStringV2::addToPainterPath( QPainterPath& path ) const
 
   for ( int i = 0; i < ( nPoints - 2 ) ; i += 2 )
   {
-    QList<QgsPointV2> pt;
+    QgsPointSequenceV2 pt;
     segmentize( QgsPointV2( mX[i], mY[i] ), QgsPointV2( mX[i + 1], mY[i + 1] ), QgsPointV2( mX[i + 2], mY[i + 2] ), pt );
     for ( int j = 1; j < pt.size(); ++j )
     {

--- a/src/core/geometry/qgscircularstringv2.h
+++ b/src/core/geometry/qgscircularstringv2.h
@@ -60,11 +60,11 @@ class CORE_EXPORT QgsCircularStringV2: public QgsCurveV2
     /**
      * @copydoc QgsCurveV2::points()
      */
-    void points( QList<QgsPointV2>& pts ) const override;
+    void points( QgsPointSequenceV2 &pts ) const override;
 
     /** Sets the circular string's points
      */
-    void setPoints( const QList<QgsPointV2>& points );
+    void setPoints( const QgsPointSequenceV2 &points );
 
     /**
      * @copydoc QgsAbstractGeometryV2::length()
@@ -143,13 +143,13 @@ class CORE_EXPORT QgsCircularStringV2: public QgsCurveV2
     QVector<double> mM;
 
     //helper methods for curveToLine
-    void segmentize( const QgsPointV2& p1, const QgsPointV2& p2, const QgsPointV2& p3, QList<QgsPointV2>& points ) const;
+    void segmentize( const QgsPointV2& p1, const QgsPointV2& p2, const QgsPointV2& p3, QgsPointSequenceV2 &points ) const;
     int segmentSide( const QgsPointV2& pt1, const QgsPointV2& pt3, const QgsPointV2& pt2 ) const;
     double interpolateArc( double angle, double a1, double a2, double a3, double zm1, double zm2, double zm3 ) const;
     static void arcTo( QPainterPath& path, QPointF pt1, QPointF pt2, QPointF pt3 );
     //bounding box of a single segment
     static QgsRectangle segmentBoundingBox( const QgsPointV2& pt1, const QgsPointV2& pt2, const QgsPointV2& pt3 );
-    static QList<QgsPointV2> compassPointsOnSegment( double p1Angle, double p2Angle, double p3Angle, double centerX, double centerY, double radius );
+    static QgsPointSequenceV2 compassPointsOnSegment( double p1Angle, double p2Angle, double p3Angle, double centerX, double centerY, double radius );
     static double closestPointOnArc( double x1, double y1, double x2, double y2, double x3, double y3,
                                      const QgsPointV2& pt, QgsPointV2& segmentPt,  QgsVertexId& vertexAfter, bool* leftOf, double epsilon );
     void insertVertexBetween( int after, int before, int pointOnCircle );

--- a/src/core/geometry/qgscompoundcurvev2.cpp
+++ b/src/core/geometry/qgscompoundcurvev2.cpp
@@ -263,7 +263,7 @@ QDomElement QgsCompoundCurveV2::asGML3( QDomDocument& doc, int precision, const 
   {
     if ( dynamic_cast<const QgsLineStringV2*>( curve ) )
     {
-      QList<QgsPointV2> pts;
+      QgsPointSequenceV2 pts;
       curve->points( pts );
 
       QDomElement elemLineStringSegment = doc.createElementNS( ns, "LineStringSegment" );
@@ -272,7 +272,7 @@ QDomElement QgsCompoundCurveV2::asGML3( QDomDocument& doc, int precision, const 
     }
     else if ( dynamic_cast<const QgsCircularStringV2*>( curve ) )
     {
-      QList<QgsPointV2> pts;
+      QgsPointSequenceV2 pts;
       curve->points( pts );
 
       QDomElement elemArcString = doc.createElementNS( ns, "ArcString" );
@@ -322,7 +322,7 @@ QgsPointV2 QgsCompoundCurveV2::endPoint() const
   return mCurves.at( mCurves.size() - 1 )->endPoint();
 }
 
-void QgsCompoundCurveV2::points( QList<QgsPointV2>& pts ) const
+void QgsCompoundCurveV2::points( QgsPointSequenceV2 &pts ) const
 {
   pts.clear();
   if ( mCurves.size() < 1 )
@@ -333,7 +333,7 @@ void QgsCompoundCurveV2::points( QList<QgsPointV2>& pts ) const
   mCurves[0]->points( pts );
   for ( int i = 1; i < mCurves.size(); ++i )
   {
-    QList<QgsPointV2> pList;
+    QgsPointSequenceV2 pList;
     mCurves[i]->points( pList );
     pList.removeFirst(); //first vertex already added in previous line
     pts.append( pList );

--- a/src/core/geometry/qgscompoundcurvev2.h
+++ b/src/core/geometry/qgscompoundcurvev2.h
@@ -56,7 +56,7 @@ class CORE_EXPORT QgsCompoundCurveV2: public QgsCurveV2
     virtual double length() const override;
     virtual QgsPointV2 startPoint() const override;
     virtual QgsPointV2 endPoint() const override;
-    virtual void points( QList<QgsPointV2>& pts ) const override;
+    virtual void points( QgsPointSequenceV2 &pts ) const override;
     virtual int numPoints() const override;
     virtual QgsLineStringV2* curveToLine() const override;
 

--- a/src/core/geometry/qgscurvepolygonv2.h
+++ b/src/core/geometry/qgscurvepolygonv2.h
@@ -90,7 +90,7 @@ class CORE_EXPORT QgsCurvePolygonV2: public QgsSurfaceV2
     virtual bool moveVertex( QgsVertexId position, const QgsPointV2& newPos ) override;
     virtual bool deleteVertex( QgsVertexId position ) override;
 
-    virtual void coordinateSequence( QList< QList< QList< QgsPointV2 > > >& coord ) const override;
+    virtual QgsCoordinateSequenceV2 coordinateSequence() const override;
     double closestSegment( const QgsPointV2& pt, QgsPointV2& segmentPt,  QgsVertexId& vertexAfter, bool* leftOf, double epsilon ) const override;
     bool nextVertex( QgsVertexId& id, QgsPointV2& vertex ) const override;
 

--- a/src/core/geometry/qgscurvev2.cpp
+++ b/src/core/geometry/qgscurvev2.cpp
@@ -42,14 +42,16 @@ bool QgsCurveV2::isRing() const
   return ( isClosed() && numPoints() >= 4 );
 }
 
-void QgsCurveV2::coordinateSequence( QList< QList< QList< QgsPointV2 > > >& coord ) const
+QgsCoordinateSequenceV2 QgsCurveV2::coordinateSequence() const
 {
-  coord.clear();
-  QList<QgsPointV2> pts;
-  points( pts );
-  QList< QList<QgsPointV2> > ptsList;
-  ptsList.append( pts );
-  coord.append( ptsList );
+  if ( !mCoordinateSequence.isEmpty() )
+    return mCoordinateSequence;
+
+  mCoordinateSequence.append( QgsRingSequenceV2() );
+  mCoordinateSequence.back().append( QgsPointSequenceV2() );
+  points( mCoordinateSequence.back().back() );
+
+  return mCoordinateSequence;
 }
 
 bool QgsCurveV2::nextVertex( QgsVertexId& id, QgsPointV2& vertex ) const

--- a/src/core/geometry/qgscurvev2.h
+++ b/src/core/geometry/qgscurvev2.h
@@ -74,7 +74,7 @@ class CORE_EXPORT QgsCurveV2: public QgsAbstractGeometryV2
 
     /** Returns a list of points within the curve.
      */
-    virtual void points( QList<QgsPointV2>& pt ) const = 0;
+    virtual void points( QgsPointSequenceV2 &pt ) const = 0;
 
     /** Returns the number of points in the curve.
      */
@@ -85,7 +85,7 @@ class CORE_EXPORT QgsCurveV2: public QgsAbstractGeometryV2
      */
     virtual void sumUpArea( double& sum ) const = 0;
 
-    virtual void coordinateSequence( QList< QList< QList< QgsPointV2 > > >& coord ) const override;
+    virtual QgsCoordinateSequenceV2 coordinateSequence() const override;
     virtual bool nextVertex( QgsVertexId& id, QgsPointV2& vertex ) const override;
 
     /** Returns the point and vertex id of a point within the curve.
@@ -104,8 +104,8 @@ class CORE_EXPORT QgsCurveV2: public QgsAbstractGeometryV2
     /** Returns a geometry without curves. Caller takes ownership*/
     QgsCurveV2* segmentize() const override;
 
-    virtual int vertexCount( int /*part*/ = 0, int /*ring*/ = 0 ) const override { return numPoints(); }
-    virtual int ringCount( int /*part*/ = 0 ) const override { return numPoints() > 0 ? 1 : 0; }
+    virtual int vertexCount( int part = 0, int ring = 0 ) const override { Q_UNUSED( part );  Q_UNUSED( ring ); return numPoints(); }
+    virtual int ringCount( int part = 0 ) const override { Q_UNUSED( part ); return numPoints() > 0 ? 1 : 0; }
     virtual int partCount() const override { return numPoints() > 0 ? 1 : 0; }
     virtual QgsPointV2 vertexAt( QgsVertexId id ) const override;
 
@@ -113,11 +113,12 @@ class CORE_EXPORT QgsCurveV2: public QgsAbstractGeometryV2
 
   protected:
 
-    virtual void clearCache() const override { mBoundingBox = QgsRectangle(); QgsAbstractGeometryV2::clearCache(); }
+    virtual void clearCache() const override { mBoundingBox = QgsRectangle(); mCoordinateSequence.clear(); QgsAbstractGeometryV2::clearCache(); }
 
   private:
 
     mutable QgsRectangle mBoundingBox;
+    mutable QgsCoordinateSequenceV2 mCoordinateSequence;
 };
 
 #endif // QGSCURVEV2_H

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -346,7 +346,7 @@ class CORE_EXPORT QgsGeometry
      * not disjoint with existing polygons of the feature
      */
     // TODO QGIS 3.0 returns an enum instead of a magic constant
-    int addPart( const QList<QgsPointV2> &points, QGis::GeometryType geomType = QGis::UnknownGeometry );
+    int addPart( const QgsPointSequenceV2 &points, QGis::GeometryType geomType = QGis::UnknownGeometry );
 
     /** Adds a new part to this geometry.
      * @param part part to add (ownership is transferred)
@@ -794,13 +794,13 @@ class CORE_EXPORT QgsGeometry
      * @param input list of QgsPoint objects to be upgraded
      * @param output destination for list of points converted to QgsPointV2
      */
-    static void convertPointList( const QList<QgsPoint>& input, QList<QgsPointV2>& output );
+    static void convertPointList( const QList<QgsPoint> &input, QgsPointSequenceV2 &output );
 
     /** Downgrades a point list from QgsPointV2 to QgsPoint
      * @param input list of QgsPointV2 objects to be downgraded
      * @param output destination for list of points converted to QgsPoint
      */
-    static void convertPointList( const QList<QgsPointV2>& input, QList<QgsPoint>& output );
+    static void convertPointList( const QgsPointSequenceV2 &input, QList<QgsPoint> &output );
 
   private:
 
@@ -809,7 +809,7 @@ class CORE_EXPORT QgsGeometry
     void detach( bool cloneGeom = true ); //make sure mGeometry only referenced from this instance
     void removeWkbGeos();
 
-    static void convertToPolyline( const QList<QgsPointV2>& input, QgsPolyline& output );
+    static void convertToPolyline( const QgsPointSequenceV2 &input, QgsPolyline& output );
     static void convertPolygon( const QgsPolygonV2& input, QgsPolygon& output );
 
     /** Try to convert the geometry to a point */

--- a/src/core/geometry/qgsgeometrycollectionv2.cpp
+++ b/src/core/geometry/qgsgeometrycollectionv2.cpp
@@ -341,20 +341,24 @@ QgsRectangle QgsGeometryCollectionV2::calculateBoundingBox() const
   return bbox;
 }
 
-void QgsGeometryCollectionV2::coordinateSequence( QList< QList< QList< QgsPointV2 > > >& coord ) const
+QgsCoordinateSequenceV2 QgsGeometryCollectionV2::coordinateSequence() const
 {
-  coord.clear();
+  if ( !mCoordinateSequence.isEmpty() )
+    return mCoordinateSequence;
+
   QVector< QgsAbstractGeometryV2* >::const_iterator geomIt = mGeometries.constBegin();
   for ( ; geomIt != mGeometries.constEnd(); ++geomIt )
   {
-    QList< QList< QList< QgsPointV2 > > > geomCoords;
-    ( *geomIt )->coordinateSequence( geomCoords );
-    QList< QList< QList< QgsPointV2 > > >::const_iterator cIt = geomCoords.constBegin();
+    QgsCoordinateSequenceV2 geomCoords = ( *geomIt )->coordinateSequence();
+
+    QgsCoordinateSequenceV2::const_iterator cIt = geomCoords.constBegin();
     for ( ; cIt != geomCoords.constEnd(); ++cIt )
     {
-      coord.push_back( *cIt );
+      mCoordinateSequence.push_back( *cIt );
     }
   }
+
+  return mCoordinateSequence;
 }
 
 double QgsGeometryCollectionV2::closestSegment( const QgsPointV2& pt, QgsPointV2& segmentPt,  QgsVertexId& vertexAfter, bool* leftOf, double epsilon ) const

--- a/src/core/geometry/qgsgeometrycollectionv2.h
+++ b/src/core/geometry/qgsgeometrycollectionv2.h
@@ -92,7 +92,7 @@ class CORE_EXPORT QgsGeometryCollectionV2: public QgsAbstractGeometryV2
 
     virtual QgsRectangle boundingBox() const override;
 
-    virtual void coordinateSequence( QList< QList< QList< QgsPointV2 > > >& coord ) const override;
+    virtual QgsCoordinateSequenceV2 coordinateSequence() const override;
     virtual double closestSegment( const QgsPointV2& pt, QgsPointV2& segmentPt,  QgsVertexId& vertexAfter, bool* leftOf, double epsilon ) const override;
     bool nextVertex( QgsVertexId& id, QgsPointV2& vertex ) const override;
 
@@ -139,11 +139,12 @@ class CORE_EXPORT QgsGeometryCollectionV2: public QgsAbstractGeometryV2
     bool fromCollectionWkt( const QString &wkt, const QList<QgsAbstractGeometryV2*>& subtypes, const QString& defaultChildWkbType = QString() );
 
     virtual QgsRectangle calculateBoundingBox() const override;
-    virtual void clearCache() const override { mBoundingBox = QgsRectangle(); QgsAbstractGeometryV2::clearCache(); }
+    virtual void clearCache() const override { mBoundingBox = QgsRectangle(); mCoordinateSequence.clear(); QgsAbstractGeometryV2::clearCache(); }
 
   private:
 
     mutable QgsRectangle mBoundingBox;
+    mutable QgsCoordinateSequenceV2 mCoordinateSequence;
 };
 
 #endif // QGSGEOMETRYCOLLECTIONV2_H

--- a/src/core/geometry/qgsgeometryengine.h
+++ b/src/core/geometry/qgsgeometryengine.h
@@ -88,7 +88,7 @@ class CORE_EXPORT QgsGeometryEngine
     virtual int splitGeometry( const QgsLineStringV2& splitLine,
                                QList<QgsAbstractGeometryV2*>& newGeometries,
                                bool topological,
-                               QList<QgsPointV2> &topologyTestPoints, QString* errorMsg = nullptr ) const
+                               QgsPointSequenceV2 &topologyTestPoints, QString* errorMsg = nullptr ) const
     {
       Q_UNUSED( splitLine );
       Q_UNUSED( newGeometries );

--- a/src/core/geometry/qgsgeometryfactory.cpp
+++ b/src/core/geometry/qgsgeometryfactory.cpp
@@ -207,7 +207,7 @@ QgsLineStringV2* QgsGeometryFactory::linestringFromPolyline( const QgsPolyline& 
 {
   QgsLineStringV2* line = new QgsLineStringV2();
 
-  QList<QgsPointV2> points;
+  QgsPointSequenceV2 points;
   QgsPolyline::const_iterator it = polyline.constBegin();
   for ( ; it != polyline.constEnd(); ++it )
   {

--- a/src/core/geometry/qgsgeometryutils.cpp
+++ b/src/core/geometry/qgsgeometryutils.cpp
@@ -92,22 +92,23 @@ QgsPointV2 QgsGeometryUtils::closestVertex( const QgsAbstractGeometryV2& geom, c
 void QgsGeometryUtils::adjacentVertices( const QgsAbstractGeometryV2& geom, QgsVertexId atVertex, QgsVertexId& beforeVertex, QgsVertexId& afterVertex )
 {
   bool polygonType = ( geom.dimension()  == 2 );
-  QList< QList< QList< QgsPointV2 > > > coords;
-  geom.coordinateSequence( coords );
+
+  QgsCoordinateSequenceV2 coords = geom.coordinateSequence();
 
   //get feature
   if ( coords.size() <= atVertex.part )
   {
     return; //error, no such feature
   }
-  const QList< QList< QgsPointV2 > >& part = coords.at( atVertex.part );
+
+  const QgsRingSequenceV2 &part = coords.at( atVertex.part );
 
   //get ring
   if ( part.size() <= atVertex.ring )
   {
     return; //error, no such ring
   }
-  const QList< QgsPointV2 >& ring = part.at( atVertex.ring );
+  const QgsPointSequenceV2 &ring = part.at( atVertex.ring );
   if ( ring.size() <= atVertex.vertex )
   {
     return;
@@ -522,10 +523,10 @@ double QgsGeometryUtils::circleTangentDirection( const QgsPointV2& tangentPoint,
   }
 }
 
-QList<QgsPointV2> QgsGeometryUtils::pointsFromWKT( const QString &wktCoordinateList, bool is3D, bool isMeasure )
+QgsPointSequenceV2 QgsGeometryUtils::pointsFromWKT( const QString &wktCoordinateList, bool is3D, bool isMeasure )
 {
   int dim = 2 + is3D + isMeasure;
-  QList<QgsPointV2> points;
+  QgsPointSequenceV2 points;
   QStringList coordList = wktCoordinateList.split( ',', QString::SkipEmptyParts );
 
   //first scan through for extra unexpected dimensions
@@ -589,7 +590,7 @@ QList<QgsPointV2> QgsGeometryUtils::pointsFromWKT( const QString &wktCoordinateL
   return points;
 }
 
-void QgsGeometryUtils::pointsToWKB( QgsWkbPtr& wkb, const QList<QgsPointV2> &points, bool is3D, bool isMeasure )
+void QgsGeometryUtils::pointsToWKB( QgsWkbPtr& wkb, const QgsPointSequenceV2 &points, bool is3D, bool isMeasure )
 {
   wkb << static_cast<quint32>( points.size() );
   Q_FOREACH ( const QgsPointV2& point, points )
@@ -606,7 +607,7 @@ void QgsGeometryUtils::pointsToWKB( QgsWkbPtr& wkb, const QList<QgsPointV2> &poi
   }
 }
 
-QString QgsGeometryUtils::pointsToWKT( const QList<QgsPointV2>& points, int precision, bool is3D, bool isMeasure )
+QString QgsGeometryUtils::pointsToWKT( const QgsPointSequenceV2 &points, int precision, bool is3D, bool isMeasure )
 {
   QString wkt = "(";
   Q_FOREACH ( const QgsPointV2& p, points )
@@ -625,7 +626,7 @@ QString QgsGeometryUtils::pointsToWKT( const QList<QgsPointV2>& points, int prec
   return wkt;
 }
 
-QDomElement QgsGeometryUtils::pointsToGML2( const QList<QgsPointV2>& points, QDomDocument& doc, int precision, const QString &ns )
+QDomElement QgsGeometryUtils::pointsToGML2( const QgsPointSequenceV2 &points, QDomDocument& doc, int precision, const QString &ns )
 {
   QDomElement elemCoordinates = doc.createElementNS( ns, "coordinates" );
 
@@ -641,7 +642,7 @@ QDomElement QgsGeometryUtils::pointsToGML2( const QList<QgsPointV2>& points, QDo
   return elemCoordinates;
 }
 
-QDomElement QgsGeometryUtils::pointsToGML3( const QList<QgsPointV2>& points, QDomDocument& doc, int precision, const QString &ns, bool is3D )
+QDomElement QgsGeometryUtils::pointsToGML3( const QgsPointSequenceV2 &points, QDomDocument& doc, int precision, const QString &ns, bool is3D )
 {
   QDomElement elemPosList = doc.createElementNS( ns, "posList" );
   elemPosList.setAttribute( "srsDimension", is3D ? 3 : 2 );
@@ -660,7 +661,7 @@ QDomElement QgsGeometryUtils::pointsToGML3( const QList<QgsPointV2>& points, QDo
   return elemPosList;
 }
 
-QString QgsGeometryUtils::pointsToJSON( const QList<QgsPointV2>& points, int precision )
+QString QgsGeometryUtils::pointsToJSON( const QgsPointSequenceV2 &points, int precision )
 {
   QString json = "[ ";
   Q_FOREACH ( const QgsPointV2& p, points )

--- a/src/core/geometry/qgsgeometryutils.h
+++ b/src/core/geometry/qgsgeometryutils.h
@@ -148,17 +148,17 @@ class CORE_EXPORT QgsGeometryUtils
 
     /** Returns a list of points contained in a WKT string.
      */
-    static QList<QgsPointV2> pointsFromWKT( const QString& wktCoordinateList, bool is3D, bool isMeasure );
+    static QgsPointSequenceV2 pointsFromWKT( const QString& wktCoordinateList, bool is3D, bool isMeasure );
     /** Returns a LinearRing { uint32 numPoints; Point points[numPoints]; } */
-    static void pointsToWKB( QgsWkbPtr &wkb, const QList<QgsPointV2>& points, bool is3D, bool isMeasure );
+    static void pointsToWKB( QgsWkbPtr &wkb, const QgsPointSequenceV2 &points, bool is3D, bool isMeasure );
     /** Returns a WKT coordinate list */
-    static QString pointsToWKT( const QList<QgsPointV2>& points, int precision, bool is3D, bool isMeasure );
+    static QString pointsToWKT( const QgsPointSequenceV2 &points, int precision, bool is3D, bool isMeasure );
     /** Returns a gml::coordinates DOM element */
-    static QDomElement pointsToGML2( const QList<QgsPointV2>& points, QDomDocument &doc, int precision, const QString& ns );
+    static QDomElement pointsToGML2( const QgsPointSequenceV2 &points, QDomDocument &doc, int precision, const QString& ns );
     /** Returns a gml::posList DOM element */
-    static QDomElement pointsToGML3( const QList<QgsPointV2>& points, QDomDocument &doc, int precision, const QString& ns, bool is3D );
+    static QDomElement pointsToGML3( const QgsPointSequenceV2 &points, QDomDocument &doc, int precision, const QString& ns, bool is3D );
     /** Returns a geoJSON coordinates string */
-    static QString pointsToJSON( const QList<QgsPointV2>& points, int precision );
+    static QString pointsToJSON( const QgsPointSequenceV2 &points, int precision );
 
     /** Ensures that an angle is in the range 0 <= angle < 2 pi.
      * @param angle angle in radians

--- a/src/core/geometry/qgsgeos.cpp
+++ b/src/core/geometry/qgsgeos.cpp
@@ -378,7 +378,7 @@ double QgsGeos::length( QString* errorMsg ) const
 int QgsGeos::splitGeometry( const QgsLineStringV2& splitLine,
                             QList<QgsAbstractGeometryV2*>&newGeometries,
                             bool topological,
-                            QList<QgsPointV2> &topologyTestPoints,
+                            QgsPointSequenceV2 &topologyTestPoints,
                             QString* errorMsg ) const
 {
 
@@ -457,7 +457,7 @@ int QgsGeos::splitGeometry( const QgsLineStringV2& splitLine,
 
 
 
-int QgsGeos::topologicalTestPointsSplit( const GEOSGeometry* splitLine, QList<QgsPointV2>& testPoints, QString* errorMsg ) const
+int QgsGeos::topologicalTestPointsSplit( const GEOSGeometry* splitLine, QgsPointSequenceV2 &testPoints, QString* errorMsg ) const
 {
   //Find out the intersection points between splitLineGeos and this geometry.
   //These points need to be tested for topological correctness by the calling function
@@ -983,7 +983,7 @@ QgsPolygonV2* QgsGeos::fromGeosPolygon( const GEOSGeometry* geos )
 
 QgsLineStringV2* QgsGeos::sequenceToLinestring( const GEOSGeometry* geos, bool hasZ, bool hasM )
 {
-  QList<QgsPointV2> pts;
+  QgsPointSequenceV2 pts;
   const GEOSCoordSequence* cs = GEOSGeom_getCoordSeq_r( geosinit.ctxt, geos );
   unsigned int nPoints;
   GEOSCoordSeq_getSize_r( geosinit.ctxt, cs, &nPoints );

--- a/src/core/geometry/qgsgeos.h
+++ b/src/core/geometry/qgsgeos.h
@@ -81,7 +81,7 @@ class CORE_EXPORT QgsGeos: public QgsGeometryEngine
     int splitGeometry( const QgsLineStringV2& splitLine,
                        QList<QgsAbstractGeometryV2*>& newGeometries,
                        bool topological,
-                       QList<QgsPointV2> &topologyTestPoints,
+                       QgsPointSequenceV2 &topologyTestPoints,
                        QString* errorMsg = nullptr ) const override;
 
     QgsAbstractGeometryV2* offsetCurve( double distance, int segments, int joinStyle, double mitreLimit, QString* errorMsg = nullptr ) const override;
@@ -152,7 +152,7 @@ class CORE_EXPORT QgsGeos: public QgsGeometryEngine
     static GEOSGeometry* createGeosPolygon( const QgsAbstractGeometryV2* poly, double precision );
 
     //utils for geometry split
-    int topologicalTestPointsSplit( const GEOSGeometry* splitLine, QList<QgsPointV2>& testPoints, QString* errorMsg = nullptr ) const;
+    int topologicalTestPointsSplit( const GEOSGeometry* splitLine, QgsPointSequenceV2 &testPoints, QString* errorMsg = nullptr ) const;
     GEOSGeometry* linePointDifference( GEOSGeometry* GEOSsplitPoint ) const;
     int splitLinearGeometry( GEOSGeometry* splitLine, QList<QgsAbstractGeometryV2*>& newGeometries ) const;
     int splitPolygonGeometry( GEOSGeometry* splitLine, QList<QgsAbstractGeometryV2*>& newGeometries ) const;

--- a/src/core/geometry/qgslinestringv2.cpp
+++ b/src/core/geometry/qgslinestringv2.cpp
@@ -171,7 +171,7 @@ unsigned char* QgsLineStringV2::asWkb( int& binarySize ) const
   QgsWkbPtr wkb( geomPtr, binarySize );
   wkb << static_cast<char>( QgsApplication::endian() );
   wkb << static_cast<quint32>( wkbType() );
-  QList<QgsPointV2> pts;
+  QgsPointSequenceV2 pts;
   points( pts );
   QgsGeometryUtils::pointsToWKB( wkb, pts, is3D(), isMeasure() );
   return geomPtr;
@@ -186,7 +186,7 @@ unsigned char* QgsLineStringV2::asWkb( int& binarySize ) const
 QString QgsLineStringV2::asWkt( int precision ) const
 {
   QString wkt = wktTypeStr() + ' ';
-  QList<QgsPointV2> pts;
+  QgsPointSequenceV2 pts;
   points( pts );
   wkt += QgsGeometryUtils::pointsToWKT( pts, precision, is3D(), isMeasure() );
   return wkt;
@@ -194,7 +194,7 @@ QString QgsLineStringV2::asWkt( int precision ) const
 
 QDomElement QgsLineStringV2::asGML2( QDomDocument& doc, int precision, const QString& ns ) const
 {
-  QList<QgsPointV2> pts;
+  QgsPointSequenceV2 pts;
   points( pts );
 
   QDomElement elemLineString = doc.createElementNS( ns, "LineString" );
@@ -205,7 +205,7 @@ QDomElement QgsLineStringV2::asGML2( QDomDocument& doc, int precision, const QSt
 
 QDomElement QgsLineStringV2::asGML3( QDomDocument& doc, int precision, const QString& ns ) const
 {
-  QList<QgsPointV2> pts;
+  QgsPointSequenceV2 pts;
   points( pts );
 
   QDomElement elemCurve = doc.createElementNS( ns, "Curve" );
@@ -220,7 +220,7 @@ QDomElement QgsLineStringV2::asGML3( QDomDocument& doc, int precision, const QSt
 
 QString QgsLineStringV2::asJSON( int precision ) const
 {
-  QList<QgsPointV2> pts;
+  QgsPointSequenceV2 pts;
   points( pts );
 
   return "{\"type\": \"LineString\", \"coordinates\": " + QgsGeometryUtils::pointsToJSON( pts, precision ) + '}';
@@ -393,7 +393,7 @@ void QgsLineStringV2::setMAt( int index, double m )
  * See details in QEP #17
  ****************************************************************************/
 
-void QgsLineStringV2::points( QList<QgsPointV2>& pts ) const
+void QgsLineStringV2::points( QgsPointSequenceV2 &pts ) const
 {
   pts.clear();
   int nPoints = numPoints();
@@ -403,7 +403,7 @@ void QgsLineStringV2::points( QList<QgsPointV2>& pts ) const
   }
 }
 
-void QgsLineStringV2::setPoints( const QList<QgsPointV2>& points )
+void QgsLineStringV2::setPoints( const QgsPointSequenceV2 &points )
 {
   clearCache(); //set bounding box invalid
 

--- a/src/core/geometry/qgslinestringv2.h
+++ b/src/core/geometry/qgslinestringv2.h
@@ -113,7 +113,7 @@ class CORE_EXPORT QgsLineStringV2: public QgsCurveV2
      * inherit the dimensionality of the first point in the list.
      * @param points new points for line string. If empty, line string will be cleared.
      */
-    void setPoints( const QList<QgsPointV2>& points );
+    void setPoints( const QgsPointSequenceV2 &points );
 
     /** Appends the contents of another line string to the end of this line string.
      * @param line line to append. Ownership is not transferred.
@@ -156,7 +156,7 @@ class CORE_EXPORT QgsLineStringV2: public QgsCurveV2
     virtual QgsLineStringV2* curveToLine() const override;
 
     int numPoints() const override;
-    void points( QList<QgsPointV2>& pt ) const override;
+    void points( QgsPointSequenceV2 &pt ) const override;
 
     void draw( QPainter& p ) const override;
 

--- a/src/core/geometry/qgsmulticurvev2.cpp
+++ b/src/core/geometry/qgsmulticurvev2.cpp
@@ -81,7 +81,7 @@ QString QgsMultiCurveV2::asJSON( int precision ) const
     if ( dynamic_cast<const QgsCurveV2*>( geom ) )
     {
       QgsLineStringV2* lineString = static_cast<const QgsCurveV2*>( geom )->curveToLine();
-      QList<QgsPointV2> pts;
+      QgsPointSequenceV2 pts;
       lineString->points( pts );
       json += QgsGeometryUtils::pointsToJSON( pts, precision ) + ", ";
       delete lineString;

--- a/src/core/geometry/qgsmultilinestringv2.cpp
+++ b/src/core/geometry/qgsmultilinestringv2.cpp
@@ -77,7 +77,7 @@ QString QgsMultiLineStringV2::asJSON( int precision ) const
     if ( dynamic_cast<const QgsCurveV2*>( geom ) )
     {
       const QgsLineStringV2* lineString = static_cast<const QgsLineStringV2*>( geom );
-      QList<QgsPointV2> pts;
+      QgsPointSequenceV2 pts;
       lineString->points( pts );
       json += QgsGeometryUtils::pointsToJSON( pts, precision ) + ", ";
     }

--- a/src/core/geometry/qgsmultipointv2.cpp
+++ b/src/core/geometry/qgsmultipointv2.cpp
@@ -75,7 +75,7 @@ QString QgsMultiPointV2::asJSON( int precision ) const
 {
   QString json = "{\"type\": \"MultiPoint\", \"coordinates\": ";
 
-  QList<QgsPointV2> pts;
+  QgsPointSequenceV2 pts;
   Q_FOREACH ( const QgsAbstractGeometryV2 *geom, mGeometries )
   {
     if ( dynamic_cast<const QgsPointV2*>( geom ) )

--- a/src/core/geometry/qgsmultipolygonv2.cpp
+++ b/src/core/geometry/qgsmultipolygonv2.cpp
@@ -77,7 +77,7 @@ QString QgsMultiPolygonV2::asJSON( int precision ) const
       const QgsPolygonV2* polygon = static_cast<const QgsPolygonV2*>( geom );
 
       QgsLineStringV2* exteriorLineString = polygon->exteriorRing()->curveToLine();
-      QList<QgsPointV2> exteriorPts;
+      QgsPointSequenceV2 exteriorPts;
       exteriorLineString->points( exteriorPts );
       json += QgsGeometryUtils::pointsToJSON( exteriorPts, precision ) + ", ";
       delete exteriorLineString;
@@ -85,7 +85,7 @@ QString QgsMultiPolygonV2::asJSON( int precision ) const
       for ( int i = 0, n = polygon->numInteriorRings(); i < n; ++i )
       {
         QgsLineStringV2* interiorLineString = polygon->interiorRing( i )->curveToLine();
-        QList<QgsPointV2> interiorPts;
+        QgsPointSequenceV2 interiorPts;
         interiorLineString->points( interiorPts );
         json += QgsGeometryUtils::pointsToJSON( interiorPts, precision ) + ", ";
         delete interiorLineString;

--- a/src/core/geometry/qgsmultisurfacev2.cpp
+++ b/src/core/geometry/qgsmultisurfacev2.cpp
@@ -84,7 +84,7 @@ QString QgsMultiSurfaceV2::asJSON( int precision ) const
       QgsPolygonV2* polygon = static_cast<const QgsSurfaceV2*>( geom )->surfaceToPolygon();
 
       QgsLineStringV2* exteriorLineString = polygon->exteriorRing()->curveToLine();
-      QList<QgsPointV2> exteriorPts;
+      QgsPointSequenceV2 exteriorPts;
       exteriorLineString->points( exteriorPts );
       json += QgsGeometryUtils::pointsToJSON( exteriorPts, precision ) + ", ";
       delete exteriorLineString;
@@ -92,7 +92,7 @@ QString QgsMultiSurfaceV2::asJSON( int precision ) const
       for ( int i = 0, n = polygon->numInteriorRings(); i < n; ++i )
       {
         QgsLineStringV2* interiorLineString = polygon->interiorRing( i )->curveToLine();
-        QList<QgsPointV2> interiorPts;
+        QgsPointSequenceV2 interiorPts;
         interiorLineString->points( interiorPts );
         json += QgsGeometryUtils::pointsToJSON( interiorPts, precision ) + ", ";
         delete interiorLineString;

--- a/src/core/geometry/qgspointv2.cpp
+++ b/src/core/geometry/qgspointv2.cpp
@@ -264,12 +264,14 @@ void QgsPointV2::transform( const QgsCoordinateTransform& ct, QgsCoordinateTrans
   ct.transformInPlace( mX, mY, mZ, d );
 }
 
-void QgsPointV2::coordinateSequence( QList< QList< QList< QgsPointV2 > > >& coord ) const
+QgsCoordinateSequenceV2 QgsPointV2::coordinateSequence() const
 {
-  coord.clear();
-  QList< QList< QgsPointV2 > > featureCoord;
-  featureCoord.append( QList< QgsPointV2 >() << QgsPointV2( *this ) );
-  coord.append( featureCoord );
+  QgsCoordinateSequenceV2 cs;
+
+  cs.append( QgsRingSequenceV2() );
+  cs.back().append( QgsPointSequenceV2() << QgsPointV2( *this ) );
+
+  return cs;
 }
 
 /***************************************************************************

--- a/src/core/geometry/qgspointv2.h
+++ b/src/core/geometry/qgspointv2.h
@@ -167,7 +167,7 @@ class CORE_EXPORT QgsPointV2: public QgsAbstractGeometryV2
     void draw( QPainter& p ) const override;
     void transform( const QgsCoordinateTransform& ct, QgsCoordinateTransform::TransformDirection d = QgsCoordinateTransform::ForwardTransform ) override;
     void transform( const QTransform& t ) override;
-    virtual void coordinateSequence( QList< QList< QList< QgsPointV2 > > >& coord ) const override;
+    virtual QgsCoordinateSequenceV2 coordinateSequence() const override;
 
     //low-level editing
     virtual bool insertVertex( QgsVertexId position, const QgsPointV2& vertex ) override { Q_UNUSED( position ); Q_UNUSED( vertex ); return false; }

--- a/src/core/geometry/qgspolygonv2.cpp
+++ b/src/core/geometry/qgspolygonv2.cpp
@@ -155,13 +155,13 @@ unsigned char* QgsPolygonV2::asWkb( int& binarySize ) const
   wkb << static_cast<quint32>(( nullptr != mExteriorRing ) + mInteriorRings.size() );
   if ( mExteriorRing )
   {
-    QList<QgsPointV2> pts;
+    QgsPointSequenceV2 pts;
     mExteriorRing->points( pts );
     QgsGeometryUtils::pointsToWKB( wkb, pts, mExteriorRing->is3D(), mExteriorRing->isMeasure() );
   }
   Q_FOREACH ( const QgsCurveV2* curve, mInteriorRings )
   {
-    QList<QgsPointV2> pts;
+    QgsPointSequenceV2 pts;
     curve->points( pts );
     QgsGeometryUtils::pointsToWKB( wkb, pts, curve->is3D(), curve->isMeasure() );
   }

--- a/src/core/geometry/qgssurfacev2.h
+++ b/src/core/geometry/qgssurfacev2.h
@@ -42,10 +42,9 @@ class CORE_EXPORT QgsSurfaceV2: public QgsAbstractGeometryV2
 
   protected:
 
-    virtual void clearCache() const override { mBoundingBox = QgsRectangle(); QgsAbstractGeometryV2::clearCache(); }
+    virtual void clearCache() const override { mBoundingBox = QgsRectangle(); mCoordinateSequence.clear(); QgsAbstractGeometryV2::clearCache(); }
 
-  private:
-
+    mutable QgsCoordinateSequenceV2 mCoordinateSequence;
     mutable QgsRectangle mBoundingBox;
 };
 

--- a/src/core/qgsdistancearea.cpp
+++ b/src/core/qgsdistancearea.cpp
@@ -442,7 +442,7 @@ double QgsDistanceArea::measureLine( const QgsCurveV2* curve ) const
     return 0.0;
   }
 
-  QList<QgsPointV2> linePointsV2;
+  QgsPointSequenceV2 linePointsV2;
   QList<QgsPoint> linePoints;
   curve->points( linePointsV2 );
   QgsGeometry::convertPointList( linePointsV2, linePoints );
@@ -646,7 +646,7 @@ double QgsDistanceArea::measurePolygon( const QgsCurveV2* curve ) const
     return 0.0;
   }
 
-  QList<QgsPointV2> linePointsV2;
+  QgsPointSequenceV2 linePointsV2;
   curve->points( linePointsV2 );
   QList<QgsPoint> linePoints;
   QgsGeometry::convertPointList( linePointsV2, linePoints );

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -1411,12 +1411,9 @@ static QVariant fcnNodesToPoints( const QVariantList& values, const QgsExpressio
 
   QgsMultiPointV2* mp = new QgsMultiPointV2();
 
-  QList< QList< QList< QgsPointV2 > > > coords;
-  geom.geometry()->coordinateSequence( coords );
-
-  Q_FOREACH ( const QList< QList< QgsPointV2 > >& part, coords )
+  Q_FOREACH ( const QgsRingSequenceV2 &part, geom.geometry()->coordinateSequence() )
   {
-    Q_FOREACH ( const QList< QgsPointV2 >& ring, part )
+    Q_FOREACH ( const QgsPointSequenceV2 &ring, part )
     {
       bool skipLast = false;
       if ( ignoreClosing && ring.count() > 2 && ring.first() == ring.last() )
@@ -1450,7 +1447,7 @@ static QVariant fcnSegmentsToLines( const QVariantList& values, const QgsExpress
     for ( int i = 0; i < line->numPoints() - 1; ++i )
     {
       QgsLineStringV2* segment = new QgsLineStringV2();
-      segment->setPoints( QList<QgsPointV2>()
+      segment->setPoints( QgsPointSequenceV2()
                           << line->pointN( i )
                           << line->pointN( i + 1 ) );
       ml->addGeometry( segment );

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -1155,7 +1155,7 @@ int QgsVectorLayer::addPart( const QList<QgsPoint> &points )
   return utils.addPart( points, *mSelectedFeatureIds.constBegin() );
 }
 
-int QgsVectorLayer::addPart( const QList<QgsPointV2> &points )
+int QgsVectorLayer::addPart( const QgsPointSequenceV2 &points )
 {
   if ( !mValid || !mEditBuffer || !mDataProvider )
     return 7;

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -68,6 +68,7 @@ class QgsPointV2;
 
 typedef QList<int> QgsAttributeList;
 typedef QSet<int> QgsAttributeIds;
+typedef QList<QgsPointV2> QgsPointSequenceV2;
 
 
 struct CORE_EXPORT QgsVectorJoinInfo
@@ -996,7 +997,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
      * @note available in python bindings as addPartV2
      */
     // TODO QGIS 3.0 returns an enum instead of a magic constant
-    int addPart( const QList<QgsPointV2>& ring );
+    int addPart( const QgsPointSequenceV2 &ring );
 
     //! @note available in python as addCurvedPart
     int addPart( QgsCurveV2* ring );

--- a/src/core/qgsvectorlayereditutils.cpp
+++ b/src/core/qgsvectorlayereditutils.cpp
@@ -122,7 +122,7 @@ QgsVectorLayer::EditResult QgsVectorLayerEditUtils::deleteVertexV2( QgsFeatureId
 int QgsVectorLayerEditUtils::addRing( const QList<QgsPoint>& ring, const QgsFeatureIds& targetFeatureIds, QgsFeatureId* modifiedFeatureId )
 {
   QgsLineStringV2* ringLine = new QgsLineStringV2();
-  QList< QgsPointV2 > ringPoints;
+  QgsPointSequenceV2 ringPoints;
   QList<QgsPoint>::const_iterator ringIt = ring.constBegin();
   for ( ; ringIt != ring.constEnd(); ++ringIt )
   {
@@ -181,7 +181,7 @@ int QgsVectorLayerEditUtils::addRing( QgsCurveV2* ring, const QgsFeatureIds& tar
 
 int QgsVectorLayerEditUtils::addPart( const QList<QgsPoint> &points, QgsFeatureId featureId )
 {
-  QList<QgsPointV2> l;
+  QgsPointSequenceV2 l;
   for ( QList<QgsPoint>::const_iterator it = points.constBegin(); it != points.constEnd(); ++it )
   {
     l <<  QgsPointV2( *it );
@@ -189,7 +189,7 @@ int QgsVectorLayerEditUtils::addPart( const QList<QgsPoint> &points, QgsFeatureI
   return addPart( l, featureId );
 }
 
-int QgsVectorLayerEditUtils::addPart( const QList<QgsPointV2> &points, QgsFeatureId featureId )
+int QgsVectorLayerEditUtils::addPart( const QgsPointSequenceV2 &points, QgsFeatureId featureId )
 {
   if ( !L->hasGeometryType() )
     return 6;

--- a/src/core/qgsvectorlayereditutils.h
+++ b/src/core/qgsvectorlayereditutils.h
@@ -121,7 +121,7 @@ class CORE_EXPORT QgsVectorLayerEditUtils
      * @note available in python bindings as addPartV2
      */
     // TODO QGIS 3.0 returns an enum instead of a magic constant
-    int addPart( const QList<QgsPointV2>& ring, QgsFeatureId featureId );
+    int addPart( const QgsPointSequenceV2 &ring, QgsFeatureId featureId );
 
     // @note available in python bindings as addCurvedPart
     // TODO QGIS 3.0 returns an enum instead of a magic constant

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -233,7 +233,7 @@ bool QgsMapToolCapture::tracingAddVertex( const QgsPoint& point )
     return false; // ignore the vertex - can't find path to the end point!
 
   // transform points
-  QList<QgsPointV2> layerPoints;
+  QgsPointSequenceV2 layerPoints;
   QgsPointV2 lp; // in layer coords
   for ( int i = 1; i < points.count(); ++i )
   {
@@ -479,10 +479,10 @@ int QgsMapToolCapture::addCurve( QgsCurveV2* c )
   }
 
   QgsLineStringV2* lineString = c->curveToLine();
-  QList<QgsPointV2> linePoints;
+  QgsPointSequenceV2 linePoints;
   lineString->points( linePoints );
   delete lineString;
-  QList<QgsPointV2>::const_iterator ptIt = linePoints.constBegin();
+  QgsPointSequenceV2::const_iterator ptIt = linePoints.constBegin();
   for ( ; ptIt != linePoints.constEnd(); ++ptIt )
   {
     mRubberBand->addPoint( QgsPoint( ptIt->x(), ptIt->y() ) );
@@ -715,7 +715,7 @@ int QgsMapToolCapture::size()
 
 QList<QgsPoint> QgsMapToolCapture::points()
 {
-  QList<QgsPointV2> pts;
+  QgsPointSequenceV2 pts;
   QList<QgsPoint> points;
   mCaptureCurve.points( pts );
   QgsGeometry::convertPointList( pts, points );
@@ -724,7 +724,7 @@ QList<QgsPoint> QgsMapToolCapture::points()
 
 void QgsMapToolCapture::setPoints( const QList<QgsPoint>& pointList )
 {
-  QList<QgsPointV2> pts;
+  QgsPointSequenceV2 pts;
   QgsGeometry::convertPointList( pointList, pts );
 
   QgsLineStringV2* line = new QgsLineStringV2();

--- a/src/plugins/geometry_checker/checks/qgsgeometryselfintersectioncheck.cpp
+++ b/src/plugins/geometry_checker/checks/qgsgeometryselfintersectioncheck.cpp
@@ -126,7 +126,7 @@ void QgsGeometrySelfIntersectionCheck::fixError( QgsGeometryCheckError* error, i
   else if ( method == ToMultiObject || method == ToSingleObjects )
   {
     // Extract rings
-    QList<QgsPointV2> ring1, ring2;
+    QgsPointSequenceV2 ring1, ring2;
     bool ring1EndsWithS = false;
     bool ring2EndsWithS = false;
     for ( int i = 0; i < nVerts; ++i )

--- a/src/providers/grass/qgsgrassvectormap.cpp
+++ b/src/providers/grass/qgsgrassvectormap.cpp
@@ -641,7 +641,7 @@ QgsAbstractGeometryV2 * QgsGrassVectorMap::lineGeometry( int id )
     return 0;
   }
 
-  QList<QgsPointV2> pointList;
+  QgsPointSequenceV2 pointList;
   pointList.reserve( points->n_points );
   for ( int i = 0; i < points->n_points; i++ )
   {
@@ -693,7 +693,7 @@ QgsAbstractGeometryV2 * QgsGrassVectorMap::areaGeometry( int id )
   QgsGrass::lock();
   Vect_get_area_points( mMap, id, points );
 
-  QList<QgsPointV2> pointList;
+  QgsPointSequenceV2 pointList;
   pointList.reserve( points->n_points );
   for ( int i = 0; i < points->n_points; i++ )
   {

--- a/tests/src/core/testqgsgeometry.cpp
+++ b/tests/src/core/testqgsgeometry.cpp
@@ -615,9 +615,8 @@ void TestQgsGeometry::pointV2()
   QVERIFY( p17 == QgsPointV2( QgsWKBTypes::PointZM, 20, 60, 30, 40 ) );
 
   //coordinateSequence
-  QList< QList< QList< QgsPointV2 > > > coord;
   QgsPointV2 p18( QgsWKBTypes::PointZM, 1.0, 2.0, 3.0, 4.0 );
-  p18.coordinateSequence( coord );
+  QgsCoordinateSequenceV2 coord = p18.coordinateSequence();
   QCOMPARE( coord.count(), 1 );
   QCOMPARE( coord.at( 0 ).count(), 1 );
   QCOMPARE( coord.at( 0 ).at( 0 ).count(), 1 );
@@ -871,7 +870,7 @@ void TestQgsGeometry::lineStringV2()
 
   //setPoints
   QgsLineStringV2 l8;
-  l8.setPoints( QList< QgsPointV2 >() << QgsPointV2( 1, 2 ) << QgsPointV2( 2, 3 ) << QgsPointV2( 3, 4 ) );
+  l8.setPoints( QgsPointSequenceV2() << QgsPointV2( 1, 2 ) << QgsPointV2( 2, 3 ) << QgsPointV2( 3, 4 ) );
   QVERIFY( !l8.isEmpty() );
   QCOMPARE( l8.numPoints(), 3 );
   QCOMPARE( l8.vertexCount(), 3 );
@@ -884,7 +883,7 @@ void TestQgsGeometry::lineStringV2()
   QVERIFY( !l8.hasCurvedSegments() );
 
   //setPoints with empty list, should clear linestring
-  l8.setPoints( QList< QgsPointV2 >() );
+  l8.setPoints( QgsPointSequenceV2() );
   QVERIFY( l8.isEmpty() );
   QCOMPARE( l8.numPoints(), 0 );
   QCOMPARE( l8.vertexCount(), 0 );
@@ -894,14 +893,14 @@ void TestQgsGeometry::lineStringV2()
   QCOMPARE( l8.wkbType(), QgsWKBTypes::Unknown );
 
   //setPoints with z
-  l8.setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZ, 1, 2, 3 ) << QgsPointV2( QgsWKBTypes::PointZ, 2, 3, 4 ) );
+  l8.setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZ, 1, 2, 3 ) << QgsPointV2( QgsWKBTypes::PointZ, 2, 3, 4 ) );
   QCOMPARE( l8.numPoints(), 2 );
   QVERIFY( l8.is3D() );
   QVERIFY( !l8.isMeasure() );
   QCOMPARE( l8.wkbType(), QgsWKBTypes::LineStringZ );
 
   //setPoints with 25d
-  l8.setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::Point25D, 1, 2, 4 ) << QgsPointV2( QgsWKBTypes::Point25D, 2, 3, 4 ) );
+  l8.setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::Point25D, 1, 2, 4 ) << QgsPointV2( QgsWKBTypes::Point25D, 2, 3, 4 ) );
   QCOMPARE( l8.numPoints(), 2 );
   QVERIFY( l8.is3D() );
   QVERIFY( !l8.isMeasure() );
@@ -909,21 +908,21 @@ void TestQgsGeometry::lineStringV2()
   QCOMPARE( l8.pointN( 0 ), QgsPointV2( QgsWKBTypes::Point25D, 1, 2, 4 ) );
 
   //setPoints with m
-  l8.setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointM, 1, 2, 0, 3 ) << QgsPointV2( QgsWKBTypes::PointM, 2, 3, 0, 4 ) );
+  l8.setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointM, 1, 2, 0, 3 ) << QgsPointV2( QgsWKBTypes::PointM, 2, 3, 0, 4 ) );
   QCOMPARE( l8.numPoints(), 2 );
   QVERIFY( !l8.is3D() );
   QVERIFY( l8.isMeasure() );
   QCOMPARE( l8.wkbType(), QgsWKBTypes::LineStringM );
 
   //setPoints with zm
-  l8.setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZM, 1, 2, 4, 5 ) << QgsPointV2( QgsWKBTypes::PointZM, 2, 3, 4, 5 ) );
+  l8.setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZM, 1, 2, 4, 5 ) << QgsPointV2( QgsWKBTypes::PointZM, 2, 3, 4, 5 ) );
   QCOMPARE( l8.numPoints(), 2 );
   QVERIFY( l8.is3D() );
   QVERIFY( l8.isMeasure() );
   QCOMPARE( l8.wkbType(), QgsWKBTypes::LineStringZM );
 
   //setPoints with MIXED dimensionality of points
-  l8.setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZM, 1, 2, 4, 5 ) << QgsPointV2( QgsWKBTypes::PointM, 2, 3, 0, 5 ) );
+  l8.setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZM, 1, 2, 4, 5 ) << QgsPointV2( QgsWKBTypes::PointM, 2, 3, 0, 5 ) );
   QCOMPARE( l8.numPoints(), 2 );
   QVERIFY( l8.is3D() );
   QVERIFY( l8.isMeasure() );
@@ -939,7 +938,7 @@ void TestQgsGeometry::lineStringV2()
 
   //test getters/setters
   QgsLineStringV2 l9;
-  l9.setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZM, 1, 2, 3, 4 )
+  l9.setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZM, 1, 2, 3, 4 )
                 << QgsPointV2( QgsWKBTypes::PointZM, 11, 12, 13, 14 )
                 << QgsPointV2( QgsWKBTypes::PointZM, 21, 22, 23, 24 ) );
   QCOMPARE( l9.xAt( 0 ), 1.0 );
@@ -995,7 +994,7 @@ void TestQgsGeometry::lineStringV2()
   l9.setMAt( 11, 54.0 ); //out of range
 
   //check zAt/setZAt with non-3d linestring
-  l9.setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointM, 1, 2, 0, 4 )
+  l9.setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointM, 1, 2, 0, 4 )
                 << QgsPointV2( QgsWKBTypes::PointM, 11, 12, 0, 14 )
                 << QgsPointV2( QgsWKBTypes::PointM, 21, 22, 0, 24 ) );
 
@@ -1006,7 +1005,7 @@ void TestQgsGeometry::lineStringV2()
   l9.setZAt( 1, 63.0 );
 
   //check mAt/setMAt with non-measure linestring
-  l9.setPoints( QList< QgsPointV2 >() << QgsPointV2( 1, 2 )
+  l9.setPoints( QgsPointSequenceV2() << QgsPointV2( 1, 2 )
                 << QgsPointV2( 11, 12 )
                 << QgsPointV2( 21, 22 ) );
 
@@ -1025,7 +1024,7 @@ void TestQgsGeometry::lineStringV2()
   QCOMPARE( l10.numPoints(), 0 );
 
   QScopedPointer<QgsLineStringV2> toAppend( new QgsLineStringV2() );
-  toAppend->setPoints( QList< QgsPointV2 >() << QgsPointV2( 1, 2 )
+  toAppend->setPoints( QgsPointSequenceV2() << QgsPointV2( 1, 2 )
                        << QgsPointV2( 11, 12 )
                        << QgsPointV2( 21, 22 ) );
   l10.append( toAppend.data() );
@@ -1043,7 +1042,7 @@ void TestQgsGeometry::lineStringV2()
 
   //add more points
   toAppend.reset( new QgsLineStringV2() );
-  toAppend->setPoints( QList< QgsPointV2 >() << QgsPointV2( 31, 32 )
+  toAppend->setPoints( QgsPointSequenceV2() << QgsPointV2( 31, 32 )
                        << QgsPointV2( 41, 42 )
                        << QgsPointV2( 51, 52 ) );
   l10.append( toAppend.data() );
@@ -1059,7 +1058,7 @@ void TestQgsGeometry::lineStringV2()
   //check dimensionality is inherited from append line if initially empty
   l10.clear();
   toAppend.reset( new QgsLineStringV2() );
-  toAppend->setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZM, 31, 32, 33, 34 )
+  toAppend->setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZM, 31, 32, 33, 34 )
                        << QgsPointV2( QgsWKBTypes::PointZM, 41, 42, 43 , 44 )
                        << QgsPointV2( QgsWKBTypes::PointZM, 51, 52, 53, 54 ) );
   l10.append( toAppend.data() );
@@ -1079,7 +1078,7 @@ void TestQgsGeometry::lineStringV2()
   QVERIFY( !l10.is3D() );
   QCOMPARE( l10.wkbType(), QgsWKBTypes::LineString );
   toAppend.reset( new QgsLineStringV2() );
-  toAppend->setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZM, 31, 32, 33, 34 )
+  toAppend->setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZM, 31, 32, 33, 34 )
                        << QgsPointV2( QgsWKBTypes::PointZM, 41, 42, 43 , 44 )
                        << QgsPointV2( QgsWKBTypes::PointZM, 51, 52, 53, 54 ) );
   l10.append( toAppend.data() );
@@ -1096,7 +1095,7 @@ void TestQgsGeometry::lineStringV2()
   QVERIFY( l10.isMeasure() );
   QCOMPARE( l10.wkbType(), QgsWKBTypes::LineStringZM );
   toAppend.reset( new QgsLineStringV2() );
-  toAppend->setPoints( QList< QgsPointV2 >() << QgsPointV2( 31, 32 )
+  toAppend->setPoints( QgsPointSequenceV2() << QgsPointV2( 31, 32 )
                        << QgsPointV2( 41, 42 )
                        << QgsPointV2( 51, 52 ) );
   l10.append( toAppend.data() );
@@ -1109,7 +1108,7 @@ void TestQgsGeometry::lineStringV2()
   //25d append
   l10.clear();
   toAppend.reset( new QgsLineStringV2() );
-  toAppend->setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::Point25D, 31, 32, 33 )
+  toAppend->setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::Point25D, 31, 32, 33 )
                        << QgsPointV2( QgsWKBTypes::Point25D, 41, 42, 43 ) );
   l10.append( toAppend.data() );
   QVERIFY( l10.is3D() );
@@ -1118,7 +1117,7 @@ void TestQgsGeometry::lineStringV2()
   QCOMPARE( l10.pointN( 0 ), QgsPointV2( QgsWKBTypes::Point25D, 31, 32, 33 ) );
   QCOMPARE( l10.pointN( 1 ), QgsPointV2( QgsWKBTypes::Point25D, 41, 42, 43 ) );
   l10.clear();
-  l10.setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::Point25D, 11, 12, 33 ) );
+  l10.setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::Point25D, 11, 12, 33 ) );
   QCOMPARE( l10.wkbType(), QgsWKBTypes::LineString25D );
   l10.append( toAppend.data() );
   QVERIFY( l10.is3D() );
@@ -1132,7 +1131,7 @@ void TestQgsGeometry::lineStringV2()
   //Make sure there are not duplicit points except start and end point
   l10.clear();
   toAppend.reset( new QgsLineStringV2() );
-  toAppend->setPoints( QList< QgsPointV2 >()
+  toAppend->setPoints( QgsPointSequenceV2()
                        << QgsPointV2( 1, 1 )
                        << QgsPointV2( 5, 5 )
                        << QgsPointV2( 10, 1 ) );
@@ -1140,7 +1139,7 @@ void TestQgsGeometry::lineStringV2()
   QCOMPARE( l10.numPoints(), 3 );
   QCOMPARE( l10.vertexCount(), 3 );
   toAppend.reset( new QgsLineStringV2() );
-  toAppend->setPoints( QList< QgsPointV2 >()
+  toAppend->setPoints( QgsPointSequenceV2()
                        << QgsPointV2( 10, 1 )
                        << QgsPointV2( 1, 1 ) );
   l10.append( toAppend.data() );
@@ -1169,23 +1168,23 @@ void TestQgsGeometry::lineStringV2()
   QVERIFY( !( e1 == e2 ) ); //different coordinates
   QVERIFY( e1 != e2 );
   QgsLineStringV2 e3;
-  e3.setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZ, 1, 2, 0 )
+  e3.setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZ, 1, 2, 0 )
                 << QgsPointV2( QgsWKBTypes::PointZ, 1 / 3.0, 4 / 3.0, 0 )
                 << QgsPointV2( QgsWKBTypes::PointZ, 7, 8, 0 ) );
   QVERIFY( !( e1 == e3 ) ); //different dimension
   QVERIFY( e1 != e3 );
   QgsLineStringV2 e4;
-  e4.setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZ, 1, 2, 2 )
+  e4.setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZ, 1, 2, 2 )
                 << QgsPointV2( QgsWKBTypes::PointZ, 1 / 3.0, 4 / 3.0, 3 )
                 << QgsPointV2( QgsWKBTypes::PointZ, 7, 8, 4 ) );
   QVERIFY( !( e3 == e4 ) ); //different z coordinates
   QVERIFY( e3 != e4 );
   QgsLineStringV2 e5;
-  e5.setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointM, 1, 2, 0, 1 )
+  e5.setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointM, 1, 2, 0, 1 )
                 << QgsPointV2( QgsWKBTypes::PointM, 1 / 3.0, 4 / 3.0, 0, 2 )
                 << QgsPointV2( QgsWKBTypes::PointM, 7, 8, 0, 3 ) );
   QgsLineStringV2 e6;
-  e6.setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointM, 1, 2, 0, 11 )
+  e6.setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointM, 1, 2, 0, 11 )
                 << QgsPointV2( QgsWKBTypes::PointM, 1 / 3.0, 4 / 3.0, 0, 12 )
                 << QgsPointV2( QgsWKBTypes::PointM, 7, 8, 0, 13 ) );
   QVERIFY( !( e5 == e6 ) ); //different m values
@@ -1194,7 +1193,7 @@ void TestQgsGeometry::lineStringV2()
   //close/isClosed
   QgsLineStringV2 l11;
   QVERIFY( !l11.isClosed() );
-  l11.setPoints( QList< QgsPointV2 >() << QgsPointV2( 1, 2 )
+  l11.setPoints( QgsPointSequenceV2() << QgsPointV2( 1, 2 )
                  << QgsPointV2( 11, 2 )
                  << QgsPointV2( 11, 22 )
                  << QgsPointV2( 1, 22 ) );
@@ -1218,7 +1217,7 @@ void TestQgsGeometry::lineStringV2()
   QCOMPARE( l11.numPoints(), 5 );
   QCOMPARE( l11.pointN( 4 ), QgsPointV2( 1, 2 ) );
   //test that m values aren't considered when testing for closedness
-  l11.setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointM, 1, 2, 0, 3 )
+  l11.setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointM, 1, 2, 0, 3 )
                  << QgsPointV2( QgsWKBTypes::PointM, 11, 2, 0, 4 )
                  << QgsPointV2( QgsWKBTypes::PointM, 11, 22, 0, 5 )
                  << QgsPointV2( QgsWKBTypes::PointM, 1, 2, 0, 6 ) );
@@ -1226,7 +1225,7 @@ void TestQgsGeometry::lineStringV2()
 
   //close with z and m
   QgsLineStringV2 l12;
-  l12.setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZM, 1, 2, 3, 4 )
+  l12.setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZM, 1, 2, 3, 4 )
                  << QgsPointV2( QgsWKBTypes::PointZM, 11, 2, 11, 14 )
                  << QgsPointV2( QgsWKBTypes::PointZM, 11, 22, 21, 24 )
                  << QgsPointV2( QgsWKBTypes::PointZM, 1, 22, 31, 34 ) );
@@ -1236,7 +1235,7 @@ void TestQgsGeometry::lineStringV2()
 
   //polygonf
   QgsLineStringV2 l13;
-  l13.setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZM, 1, 2, 3, 4 )
+  l13.setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZM, 1, 2, 3, 4 )
                  << QgsPointV2( QgsWKBTypes::PointZM, 11, 2, 11, 14 )
                  << QgsPointV2( QgsWKBTypes::PointZM, 11, 22, 21, 24 )
                  << QgsPointV2( QgsWKBTypes::PointZM, 1, 22, 31, 34 ) );
@@ -1255,7 +1254,7 @@ void TestQgsGeometry::lineStringV2()
   // clone tests. At the same time, check segmentize as the result should
   // be equal to a clone for LineStrings
   QgsLineStringV2 l14;
-  l14.setPoints( QList< QgsPointV2 >() << QgsPointV2( 1, 2 )
+  l14.setPoints( QgsPointSequenceV2() << QgsPointV2( 1, 2 )
                  << QgsPointV2( 11, 2 )
                  << QgsPointV2( 11, 22 )
                  << QgsPointV2( 1, 22 ) );
@@ -1282,7 +1281,7 @@ void TestQgsGeometry::lineStringV2()
   QCOMPARE( segmentized->pointN( 3 ), l14.pointN( 3 ) );
 
   //clone with Z/M
-  l14.setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZM, 1, 2, 3, 4 )
+  l14.setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZM, 1, 2, 3, 4 )
                  << QgsPointV2( QgsWKBTypes::PointZM, 11, 2, 11, 14 )
                  << QgsPointV2( QgsWKBTypes::PointZM, 11, 22, 21, 24 )
                  << QgsPointV2( QgsWKBTypes::PointZM, 1, 22, 31, 34 ) );
@@ -1322,7 +1321,7 @@ void TestQgsGeometry::lineStringV2()
 
   //to/from WKB
   QgsLineStringV2 l15;
-  l15.setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZM, 1, 2, 3, 4 )
+  l15.setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZM, 1, 2, 3, 4 )
                  << QgsPointV2( QgsWKBTypes::PointZM, 11, 2, 11, 14 )
                  << QgsPointV2( QgsWKBTypes::PointZM, 11, 22, 21, 24 )
                  << QgsPointV2( QgsWKBTypes::PointZM, 1, 22, 31, 34 ) );
@@ -1359,7 +1358,7 @@ void TestQgsGeometry::lineStringV2()
 
   //to/from WKT
   QgsLineStringV2 l17;
-  l17.setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZM, 1, 2, 3, 4 )
+  l17.setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZM, 1, 2, 3, 4 )
                  << QgsPointV2( QgsWKBTypes::PointZM, 11, 2, 11, 14 )
                  << QgsPointV2( QgsWKBTypes::PointZM, 11, 22, 21, 24 )
                  << QgsPointV2( QgsWKBTypes::PointZM, 1, 22, 31, 34 ) );
@@ -1387,11 +1386,11 @@ void TestQgsGeometry::lineStringV2()
 
   //asGML2
   QgsLineStringV2 exportLine;
-  exportLine.setPoints( QList< QgsPointV2 >() << QgsPointV2( 31, 32 )
+  exportLine.setPoints( QgsPointSequenceV2() << QgsPointV2( 31, 32 )
                         << QgsPointV2( 41, 42 )
                         << QgsPointV2( 51, 52 ) );
   QgsLineStringV2 exportLineFloat;
-  exportLineFloat.setPoints( QList< QgsPointV2 >() << QgsPointV2( 1 / 3.0, 2 / 3.0 )
+  exportLineFloat.setPoints( QgsPointSequenceV2() << QgsPointV2( 1 / 3.0, 2 / 3.0 )
                              << QgsPointV2( 1 + 1 / 3.0, 1 + 2 / 3.0 )
                              << QgsPointV2( 2 + 1 / 3.0, 2 + 2 / 3.0 ) );
   QDomDocument doc( "gml" );
@@ -1415,7 +1414,7 @@ void TestQgsGeometry::lineStringV2()
   //length
   QgsLineStringV2 l19;
   QCOMPARE( l19.length(), 0.0 );
-  l19.setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZM, 1, 1, 2, 3 )
+  l19.setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZM, 1, 1, 2, 3 )
                  << QgsPointV2( QgsWKBTypes::PointZM, 1, 10, 4, 5 )
                  << QgsPointV2( QgsWKBTypes::PointZM, 15, 10, 6, 7 ) );
   QCOMPARE( l19.length(), 23.0 );
@@ -1432,7 +1431,7 @@ void TestQgsGeometry::lineStringV2()
   QCOMPARE( l19.endPoint(), QgsPointV2() );
 
   //curveToLine - no segmentation required, so should return a clone
-  l19.setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZM, 1, 1, 2, 3 )
+  l19.setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZM, 1, 1, 2, 3 )
                  << QgsPointV2( QgsWKBTypes::PointZM, 1, 10, 4, 5 )
                  << QgsPointV2( QgsWKBTypes::PointZM, 15, 10, 6, 7 ) );
   segmentized.reset( l19.curveToLine() );
@@ -1446,10 +1445,10 @@ void TestQgsGeometry::lineStringV2()
 
   // points
   QgsLineStringV2 l20;
-  QList< QgsPointV2 > points;
+  QgsPointSequenceV2 points;
   l20.points( points );
   QVERIFY( l20.isEmpty() );
-  l20.setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZM, 1, 1, 2, 3 )
+  l20.setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZM, 1, 1, 2, 3 )
                  << QgsPointV2( QgsWKBTypes::PointZM, 1, 10, 4, 5 )
                  << QgsPointV2( QgsWKBTypes::PointZM, 15, 10, 6, 7 ) );
   l20.points( points );
@@ -1467,7 +1466,7 @@ void TestQgsGeometry::lineStringV2()
 
   // 2d CRS transform
   QgsLineStringV2 l21;
-  l21.setPoints( QList< QgsPointV2 >() << QgsPointV2( 6374985, -3626584 )
+  l21.setPoints( QgsPointSequenceV2() << QgsPointV2( 6374985, -3626584 )
                  << QgsPointV2( 6474985, -3526584 ) );
   l21.transform( tr, QgsCoordinateTransform::ForwardTransform );
   QVERIFY( qgsDoubleNear( l21.pointN( 0 ).x(), 175.771, 0.001 ) );
@@ -1481,7 +1480,7 @@ void TestQgsGeometry::lineStringV2()
 
   //3d CRS transform
   QgsLineStringV2 l22;
-  l22.setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZM, 6374985, -3626584, 1, 2 )
+  l22.setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZM, 6374985, -3626584, 1, 2 )
                  << QgsPointV2( QgsWKBTypes::PointZM, 6474985, -3526584, 3, 4 ) );
   l22.transform( tr, QgsCoordinateTransform::ForwardTransform );
   QVERIFY( qgsDoubleNear( l22.pointN( 0 ).x(), 175.771, 0.001 ) );
@@ -1507,7 +1506,7 @@ void TestQgsGeometry::lineStringV2()
   //QTransform transform
   QTransform qtr = QTransform::fromScale( 2, 3 );
   QgsLineStringV2 l23;
-  l23.setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZM, 1, 2, 3, 4 )
+  l23.setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZM, 1, 2, 3, 4 )
                  << QgsPointV2( QgsWKBTypes::PointZM, 11, 12, 13, 14 ) );
   l23.transform( qtr );
   QCOMPARE( l23.pointN( 0 ), QgsPointV2( QgsWKBTypes::PointZM, 2, 6, 3, 4 ) );
@@ -1535,7 +1534,7 @@ void TestQgsGeometry::lineStringV2()
   QCOMPARE( l24.pointN( 0 ), QgsPointV2( QgsWKBTypes::PointZM, 6.0, 7.0, 1.0, 2.0 ) );
 
   //2d line
-  l24.setPoints( QList< QgsPointV2 >() << QgsPointV2( 1, 2 )
+  l24.setPoints( QgsPointSequenceV2() << QgsPointV2( 1, 2 )
                  << QgsPointV2( 11, 12 ) << QgsPointV2( 21, 22 ) );
   QVERIFY( l24.insertVertex( QgsVertexId( 0, 0, 0 ), QgsPointV2( 6.0, 7.0 ) ) );
   QCOMPARE( l24.numPoints(), 4 );
@@ -1564,7 +1563,7 @@ void TestQgsGeometry::lineStringV2()
   QCOMPARE( l24.numPoints(), 7 );
 
   //insert 4d vertex in 4d line
-  l24.setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZM, 1, 1, 2, 3 )
+  l24.setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZM, 1, 1, 2, 3 )
                  << QgsPointV2( QgsWKBTypes::PointZM, 1, 10, 4, 5 )
                  << QgsPointV2( QgsWKBTypes::PointZM, 15, 10, 6, 7 ) );
   QVERIFY( l24.insertVertex( QgsVertexId( 0, 0, 0 ), QgsPointV2( QgsWKBTypes::PointZM, 11, 12, 13, 14 ) ) );
@@ -1578,7 +1577,7 @@ void TestQgsGeometry::lineStringV2()
   QCOMPARE( l24.pointN( 1 ), QgsPointV2( QgsWKBTypes::PointZM, 101, 102, 0, 0 ) );
 
   //insert 4d vertex in 2d line
-  l24.setPoints( QList< QgsPointV2 >() << QgsPointV2( 1, 2 )
+  l24.setPoints( QgsPointSequenceV2() << QgsPointV2( 1, 2 )
                  << QgsPointV2( 11, 12 ) << QgsPointV2( 21, 22 ) );
   QVERIFY( l24.insertVertex( QgsVertexId( 0, 0, 0 ), QgsPointV2( QgsWKBTypes::PointZM, 101, 102, 103, 104 ) ) );
   QCOMPARE( l24.numPoints(), 4 );
@@ -1599,7 +1598,7 @@ void TestQgsGeometry::lineStringV2()
   QVERIFY( l25.isEmpty() );
 
   //valid line
-  l25.setPoints( QList< QgsPointV2 >() << QgsPointV2( 1, 2 )
+  l25.setPoints( QgsPointSequenceV2() << QgsPointV2( 1, 2 )
                  << QgsPointV2( 11, 12 ) << QgsPointV2( 21, 22 ) );
   QVERIFY( l25.moveVertex( QgsVertexId( 0, 0, 0 ), QgsPointV2( 6.0, 7.0 ) ) );
   QVERIFY( l25.moveVertex( QgsVertexId( 0, 0, 1 ), QgsPointV2( 16.0, 17.0 ) ) );
@@ -1616,7 +1615,7 @@ void TestQgsGeometry::lineStringV2()
   QCOMPARE( l25.pointN( 2 ), QgsPointV2( 26.0, 27.0 ) );
 
   //move 4d point in 4d line
-  l25.setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZM, 1, 1, 2, 3 )
+  l25.setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZM, 1, 1, 2, 3 )
                  << QgsPointV2( QgsWKBTypes::PointZM, 1, 10, 4, 5 )
                  << QgsPointV2( QgsWKBTypes::PointZM, 15, 10, 6, 7 ) );
   QVERIFY( l25.moveVertex( QgsVertexId( 0, 0, 1 ), QgsPointV2( QgsWKBTypes::PointZM, 6, 7, 12, 13 ) ) );
@@ -1627,7 +1626,7 @@ void TestQgsGeometry::lineStringV2()
   QCOMPARE( l25.pointN( 1 ), QgsPointV2( QgsWKBTypes::PointZM, 34, 35, 12, 13 ) );
 
   //move 4d point in 2d line
-  l25.setPoints( QList< QgsPointV2 >() << QgsPointV2( 1, 2 )
+  l25.setPoints( QgsPointSequenceV2() << QgsPointV2( 1, 2 )
                  << QgsPointV2( 11, 12 ) << QgsPointV2( 21, 22 ) );
   QVERIFY( l25.moveVertex( QgsVertexId( 0, 0, 0 ), QgsPointV2( QgsWKBTypes::PointZM, 3, 4, 2, 3 ) ) );
   QCOMPARE( l25.pointN( 0 ), QgsPointV2( 3, 4 ) );
@@ -1641,7 +1640,7 @@ void TestQgsGeometry::lineStringV2()
   QVERIFY( l26.isEmpty() );
 
   //valid line
-  l26.setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZM, 1, 2, 2, 3 )
+  l26.setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZM, 1, 2, 2, 3 )
                  << QgsPointV2( QgsWKBTypes::PointZM, 11, 12, 4, 5 )
                  << QgsPointV2( QgsWKBTypes::PointZM, 21, 22, 6, 7 ) );
   //out of range vertices
@@ -1663,7 +1662,7 @@ void TestQgsGeometry::lineStringV2()
   QgsLineStringV2 l27;
   QScopedPointer< QgsLineStringV2 > reversed( l27.reversed() );
   QVERIFY( reversed->isEmpty() );
-  l27.setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZM, 1, 2, 2, 3 )
+  l27.setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZM, 1, 2, 2, 3 )
                  << QgsPointV2( QgsWKBTypes::PointZM, 11, 12, 4, 5 )
                  << QgsPointV2( QgsWKBTypes::PointZM, 21, 22, 6, 7 ) );
   reversed.reset( l27.reversed() );
@@ -1685,7 +1684,7 @@ void TestQgsGeometry::lineStringV2()
   QVERIFY( l28.addZValue() );
   QCOMPARE( l28.wkbType(), QgsWKBTypes::LineStringZ );
   //2d line
-  l28.setPoints( QList< QgsPointV2 >() << QgsPointV2( 1, 2 ) << QgsPointV2( 11, 12 ) );
+  l28.setPoints( QgsPointSequenceV2() << QgsPointV2( 1, 2 ) << QgsPointV2( 11, 12 ) );
   QVERIFY( l28.addZValue( 2 ) );
   QVERIFY( l28.is3D() );
   QCOMPARE( l28.wkbType(), QgsWKBTypes::LineStringZ );
@@ -1695,7 +1694,7 @@ void TestQgsGeometry::lineStringV2()
   QCOMPARE( l28.pointN( 0 ), QgsPointV2( QgsWKBTypes::PointZ, 1, 2, 2 ) );
   QCOMPARE( l28.pointN( 1 ), QgsPointV2( QgsWKBTypes::PointZ, 11, 12, 2 ) );
   //linestring with m
-  l28.setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointM, 1, 2, 0, 3 ) << QgsPointV2( QgsWKBTypes::PointM, 11, 12, 0, 4 ) );
+  l28.setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointM, 1, 2, 0, 3 ) << QgsPointV2( QgsWKBTypes::PointM, 11, 12, 0, 4 ) );
   QVERIFY( l28.addZValue( 5 ) );
   QVERIFY( l28.is3D() );
   QVERIFY( l28.isMeasure() );
@@ -1703,7 +1702,7 @@ void TestQgsGeometry::lineStringV2()
   QCOMPARE( l28.pointN( 0 ), QgsPointV2( QgsWKBTypes::PointZM, 1, 2, 5, 3 ) );
   QCOMPARE( l28.pointN( 1 ), QgsPointV2( QgsWKBTypes::PointZM, 11, 12, 5, 4 ) );
   //linestring25d
-  l28.setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::Point25D, 1, 2, 3 ) << QgsPointV2( QgsWKBTypes::Point25D, 11, 12, 4 ) );
+  l28.setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::Point25D, 1, 2, 3 ) << QgsPointV2( QgsWKBTypes::Point25D, 11, 12, 4 ) );
   QCOMPARE( l28.wkbType(), QgsWKBTypes::LineString25D );
   QVERIFY( !l28.addZValue( 5 ) );
   QCOMPARE( l28.wkbType(), QgsWKBTypes::LineString25D );
@@ -1720,7 +1719,7 @@ void TestQgsGeometry::lineStringV2()
   QVERIFY( l29.addMValue() );
   QCOMPARE( l29.wkbType(), QgsWKBTypes::LineStringM );
   //2d line
-  l29.setPoints( QList< QgsPointV2 >() << QgsPointV2( 1, 2 ) << QgsPointV2( 11, 12 ) );
+  l29.setPoints( QgsPointSequenceV2() << QgsPointV2( 1, 2 ) << QgsPointV2( 11, 12 ) );
   QVERIFY( l29.addMValue( 2 ) );
   QVERIFY( !l29.is3D() );
   QVERIFY( l29.isMeasure() );
@@ -1731,7 +1730,7 @@ void TestQgsGeometry::lineStringV2()
   QCOMPARE( l29.pointN( 0 ), QgsPointV2( QgsWKBTypes::PointM, 1, 2, 0, 2 ) );
   QCOMPARE( l29.pointN( 1 ), QgsPointV2( QgsWKBTypes::PointM, 11, 12, 0, 2 ) );
   //linestring with z
-  l29.setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZ, 1, 2, 3 ) << QgsPointV2( QgsWKBTypes::PointZ, 11, 12, 4 ) );
+  l29.setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZ, 1, 2, 3 ) << QgsPointV2( QgsWKBTypes::PointZ, 11, 12, 4 ) );
   QVERIFY( l29.addMValue( 5 ) );
   QVERIFY( l29.is3D() );
   QVERIFY( l29.isMeasure() );
@@ -1739,7 +1738,7 @@ void TestQgsGeometry::lineStringV2()
   QCOMPARE( l29.pointN( 0 ), QgsPointV2( QgsWKBTypes::PointZM, 1, 2, 3, 5 ) );
   QCOMPARE( l29.pointN( 1 ), QgsPointV2( QgsWKBTypes::PointZM, 11, 12, 4, 5 ) );
   //linestring25d, should become LineStringZM
-  l29.setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::Point25D, 1, 2, 3 ) << QgsPointV2( QgsWKBTypes::Point25D, 11, 12, 4 ) );
+  l29.setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::Point25D, 1, 2, 3 ) << QgsPointV2( QgsWKBTypes::Point25D, 11, 12, 4 ) );
   QCOMPARE( l29.wkbType(), QgsWKBTypes::LineString25D );
   QVERIFY( l29.addMValue( 5 ) );
   QVERIFY( l29.is3D() );
@@ -1752,7 +1751,7 @@ void TestQgsGeometry::lineStringV2()
   //dropZValue
   QgsLineStringV2 l28d;
   QVERIFY( !l28d.dropZValue() );
-  l28d.setPoints( QList< QgsPointV2 >() << QgsPointV2( 1, 2 ) << QgsPointV2( 11, 12 ) );
+  l28d.setPoints( QgsPointSequenceV2() << QgsPointV2( 1, 2 ) << QgsPointV2( 11, 12 ) );
   QVERIFY( !l28d.dropZValue() );
   l28d.addZValue( 1.0 );
   QCOMPARE( l28d.wkbType(), QgsWKBTypes::LineStringZ );
@@ -1764,7 +1763,7 @@ void TestQgsGeometry::lineStringV2()
   QCOMPARE( l28d.pointN( 1 ), QgsPointV2( QgsWKBTypes::Point, 11, 12 ) );
   QVERIFY( !l28d.dropZValue() ); //already dropped
   //linestring with m
-  l28d.setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZM, 1, 2, 3, 4 ) << QgsPointV2( QgsWKBTypes::PointZM, 11, 12, 3, 4 ) );
+  l28d.setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZM, 1, 2, 3, 4 ) << QgsPointV2( QgsWKBTypes::PointZM, 11, 12, 3, 4 ) );
   QVERIFY( l28d.dropZValue() );
   QVERIFY( !l28d.is3D() );
   QVERIFY( l28d.isMeasure() );
@@ -1772,7 +1771,7 @@ void TestQgsGeometry::lineStringV2()
   QCOMPARE( l28d.pointN( 0 ), QgsPointV2( QgsWKBTypes::PointM, 1, 2, 0, 4 ) );
   QCOMPARE( l28d.pointN( 1 ), QgsPointV2( QgsWKBTypes::PointM, 11, 12, 0, 4 ) );
   //linestring25d
-  l28d.setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::Point25D, 1, 2, 3 ) << QgsPointV2( QgsWKBTypes::Point25D, 11, 12, 4 ) );
+  l28d.setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::Point25D, 1, 2, 3 ) << QgsPointV2( QgsWKBTypes::Point25D, 11, 12, 4 ) );
   QCOMPARE( l28d.wkbType(), QgsWKBTypes::LineString25D );
   QVERIFY( l28d.dropZValue() );
   QCOMPARE( l28d.wkbType(), QgsWKBTypes::LineString );
@@ -1780,7 +1779,7 @@ void TestQgsGeometry::lineStringV2()
   QCOMPARE( l28d.pointN( 1 ), QgsPointV2( QgsWKBTypes::Point, 11, 12 ) );
 
   //dropMValue
-  l28d.setPoints( QList< QgsPointV2 >() << QgsPointV2( 1, 2 ) << QgsPointV2( 11, 12 ) );
+  l28d.setPoints( QgsPointSequenceV2() << QgsPointV2( 1, 2 ) << QgsPointV2( 11, 12 ) );
   QVERIFY( !l28d.dropMValue() );
   l28d.addMValue( 1.0 );
   QCOMPARE( l28d.wkbType(), QgsWKBTypes::LineStringM );
@@ -1792,7 +1791,7 @@ void TestQgsGeometry::lineStringV2()
   QCOMPARE( l28d.pointN( 1 ), QgsPointV2( QgsWKBTypes::Point, 11, 12 ) );
   QVERIFY( !l28d.dropMValue() ); //already dropped
   //linestring with z
-  l28d.setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZM, 1, 2, 3, 4 ) << QgsPointV2( QgsWKBTypes::PointZM, 11, 12, 3, 4 ) );
+  l28d.setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZM, 1, 2, 3, 4 ) << QgsPointV2( QgsWKBTypes::PointZM, 11, 12, 3, 4 ) );
   QVERIFY( l28d.dropMValue() );
   QVERIFY( !l28d.isMeasure() );
   QVERIFY( l28d.is3D() );
@@ -1801,7 +1800,7 @@ void TestQgsGeometry::lineStringV2()
   QCOMPARE( l28d.pointN( 1 ), QgsPointV2( QgsWKBTypes::PointZ, 11, 12, 3, 0 ) );
 
   //convertTo
-  l28d.setPoints( QList< QgsPointV2 >() << QgsPointV2( 1, 2 ) << QgsPointV2( 11, 12 ) );
+  l28d.setPoints( QgsPointSequenceV2() << QgsPointV2( 1, 2 ) << QgsPointV2( 11, 12 ) );
   QVERIFY( l28d.convertTo( QgsWKBTypes::LineString ) );
   QCOMPARE( l28d.wkbType(), QgsWKBTypes::LineString );
   QVERIFY( l28d.convertTo( QgsWKBTypes::LineStringZ ) );
@@ -1826,24 +1825,23 @@ void TestQgsGeometry::lineStringV2()
   //isRing
   QgsLineStringV2 l30;
   QVERIFY( !l30.isRing() );
-  l30.setPoints( QList< QgsPointV2 >() << QgsPointV2( 1, 2 ) << QgsPointV2( 11, 12 ) << QgsPointV2( 1, 2 ) );
+  l30.setPoints( QgsPointSequenceV2() << QgsPointV2( 1, 2 ) << QgsPointV2( 11, 12 ) << QgsPointV2( 1, 2 ) );
   QVERIFY( !l30.isRing() ); //<4 points
-  l30.setPoints( QList< QgsPointV2 >() << QgsPointV2( 1, 2 ) << QgsPointV2( 11, 12 ) << QgsPointV2( 21, 22 ) << QgsPointV2( 31, 32 ) );
+  l30.setPoints( QgsPointSequenceV2() << QgsPointV2( 1, 2 ) << QgsPointV2( 11, 12 ) << QgsPointV2( 21, 22 ) << QgsPointV2( 31, 32 ) );
   QVERIFY( !l30.isRing() ); //not closed
-  l30.setPoints( QList< QgsPointV2 >() << QgsPointV2( 1, 2 ) << QgsPointV2( 11, 12 ) << QgsPointV2( 21, 22 ) << QgsPointV2( 1, 2 ) );
+  l30.setPoints( QgsPointSequenceV2() << QgsPointV2( 1, 2 ) << QgsPointV2( 11, 12 ) << QgsPointV2( 21, 22 ) << QgsPointV2( 1, 2 ) );
   QVERIFY( l30.isRing() );
 
   //coordinateSequence
   QgsLineStringV2 l31;
-  QList< QList< QList< QgsPointV2 > > > coords;
-  l31.coordinateSequence( coords );
+  QgsCoordinateSequenceV2 coords = l31.coordinateSequence();
   QCOMPARE( coords.count(), 1 );
   QCOMPARE( coords.at( 0 ).count(), 1 );
   QVERIFY( coords.at( 0 ).at( 0 ).isEmpty() );
-  l31.setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZM, 1, 2, 2, 3 )
+  l31.setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZM, 1, 2, 2, 3 )
                  << QgsPointV2( QgsWKBTypes::PointZM, 11, 12, 4, 5 )
                  << QgsPointV2( QgsWKBTypes::PointZM, 21, 22, 6, 7 ) );
-  l31.coordinateSequence( coords );
+  coords = l31.coordinateSequence();
   QCOMPARE( coords.count(), 1 );
   QCOMPARE( coords.at( 0 ).count(), 1 );
   QCOMPARE( coords.at( 0 ).at( 0 ).count(), 3 );
@@ -1862,7 +1860,7 @@ void TestQgsGeometry::lineStringV2()
   v = QgsVertexId( 0, 0, 10 );
   QVERIFY( !l32.nextVertex( v, p ) );
   //LineString
-  l32.setPoints( QList< QgsPointV2 >() << QgsPointV2( 1, 2 ) << QgsPointV2( 11, 12 ) );
+  l32.setPoints( QgsPointSequenceV2() << QgsPointV2( 1, 2 ) << QgsPointV2( 11, 12 ) );
   v = QgsVertexId( 0, 0, 2 ); //out of range
   QVERIFY( !l32.nextVertex( v, p ) );
   v = QgsVertexId( 0, 0, -5 );
@@ -1885,7 +1883,7 @@ void TestQgsGeometry::lineStringV2()
   QCOMPARE( p, QgsPointV2( 11, 12 ) );
 
   //LineStringZ
-  l32.setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZ, 1, 2, 3 ) << QgsPointV2( QgsWKBTypes::PointZ, 11, 12, 13 ) );
+  l32.setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZ, 1, 2, 3 ) << QgsPointV2( QgsWKBTypes::PointZ, 11, 12, 13 ) );
   v = QgsVertexId( 0, 0, -1 );
   QVERIFY( l32.nextVertex( v, p ) );
   QCOMPARE( v, QgsVertexId( 0, 0, 0 ) );
@@ -1895,7 +1893,7 @@ void TestQgsGeometry::lineStringV2()
   QCOMPARE( p, QgsPointV2( QgsWKBTypes::PointZ, 11, 12, 13 ) );
   QVERIFY( !l32.nextVertex( v, p ) );
   //LineStringM
-  l32.setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointM, 1, 2, 0, 4 ) << QgsPointV2( QgsWKBTypes::PointM, 11, 12, 0, 14 ) );
+  l32.setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointM, 1, 2, 0, 4 ) << QgsPointV2( QgsWKBTypes::PointM, 11, 12, 0, 14 ) );
   v = QgsVertexId( 0, 0, -1 );
   QVERIFY( l32.nextVertex( v, p ) );
   QCOMPARE( v, QgsVertexId( 0, 0, 0 ) );
@@ -1905,7 +1903,7 @@ void TestQgsGeometry::lineStringV2()
   QCOMPARE( p, QgsPointV2( QgsWKBTypes::PointM, 11, 12, 0, 14 ) );
   QVERIFY( !l32.nextVertex( v, p ) );
   //LineStringZM
-  l32.setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZM, 1, 2, 3, 4 ) << QgsPointV2( QgsWKBTypes::PointZM, 11, 12, 13, 14 ) );
+  l32.setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZM, 1, 2, 3, 4 ) << QgsPointV2( QgsWKBTypes::PointZM, 11, 12, 13, 14 ) );
   v = QgsVertexId( 0, 0, -1 );
   QVERIFY( l32.nextVertex( v, p ) );
   QCOMPARE( v, QgsVertexId( 0, 0, 0 ) );
@@ -1915,7 +1913,7 @@ void TestQgsGeometry::lineStringV2()
   QCOMPARE( p, QgsPointV2( QgsWKBTypes::PointZM, 11, 12, 13, 14 ) );
   QVERIFY( !l32.nextVertex( v, p ) );
   //LineString25D
-  l32.setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::Point25D, 1, 2, 3 ) << QgsPointV2( QgsWKBTypes::Point25D, 11, 12, 13 ) );
+  l32.setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::Point25D, 1, 2, 3 ) << QgsPointV2( QgsWKBTypes::Point25D, 11, 12, 13 ) );
   v = QgsVertexId( 0, 0, -1 );
   QVERIFY( l32.nextVertex( v, p ) );
   QCOMPARE( v, QgsVertexId( 0, 0, 0 ) );
@@ -1933,7 +1931,7 @@ void TestQgsGeometry::lineStringV2()
   QVERIFY( !l33.pointAt( -10, p, type ) );
   QVERIFY( !l33.pointAt( 10, p, type ) );
   //LineString
-  l33.setPoints( QList< QgsPointV2 >() << QgsPointV2( 1, 2 ) << QgsPointV2( 11, 12 ) );
+  l33.setPoints( QgsPointSequenceV2() << QgsPointV2( 1, 2 ) << QgsPointV2( 11, 12 ) );
   l33.vertexAt( QgsVertexId( 0, 0, -10 ) );
   l33.vertexAt( QgsVertexId( 0, 0, 10 ) ); //out of bounds, check for no crash
   QCOMPARE( l33.vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPointV2( 1, 2 ) );
@@ -1947,7 +1945,7 @@ void TestQgsGeometry::lineStringV2()
   QCOMPARE( p, QgsPointV2( 11, 12 ) );
   QCOMPARE( type, QgsVertexId::SegmentVertex );
   //LineStringZ
-  l33.setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZ, 1, 2, 3 ) << QgsPointV2( QgsWKBTypes::PointZ, 11, 12, 13 ) );
+  l33.setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZ, 1, 2, 3 ) << QgsPointV2( QgsWKBTypes::PointZ, 11, 12, 13 ) );
   QCOMPARE( l33.vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPointV2( QgsWKBTypes::PointZ, 1, 2, 3 ) );
   QCOMPARE( l33.vertexAt( QgsVertexId( 0, 0, 1 ) ), QgsPointV2( QgsWKBTypes::PointZ, 11, 12, 13 ) );
   QVERIFY( l33.pointAt( 0, p, type ) );
@@ -1957,7 +1955,7 @@ void TestQgsGeometry::lineStringV2()
   QCOMPARE( p, QgsPointV2( QgsWKBTypes::PointZ, 11, 12, 13 ) );
   QCOMPARE( type, QgsVertexId::SegmentVertex );
   //LineStringM
-  l33.setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointM, 1, 2, 0, 4 ) << QgsPointV2( QgsWKBTypes::PointM, 11, 12, 0, 14 ) );
+  l33.setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointM, 1, 2, 0, 4 ) << QgsPointV2( QgsWKBTypes::PointM, 11, 12, 0, 14 ) );
   QCOMPARE( l33.vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPointV2( QgsWKBTypes::PointM, 1, 2, 0, 4 ) );
   QCOMPARE( l33.vertexAt( QgsVertexId( 0, 0, 1 ) ), QgsPointV2( QgsWKBTypes::PointM, 11, 12, 0, 14 ) );
   QVERIFY( l33.pointAt( 0, p, type ) );
@@ -1967,7 +1965,7 @@ void TestQgsGeometry::lineStringV2()
   QCOMPARE( p, QgsPointV2( QgsWKBTypes::PointM, 11, 12, 0, 14 ) );
   QCOMPARE( type, QgsVertexId::SegmentVertex );
   //LineStringZM
-  l33.setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZM, 1, 2, 3, 4 ) << QgsPointV2( QgsWKBTypes::PointZM, 11, 12, 13, 14 ) );
+  l33.setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZM, 1, 2, 3, 4 ) << QgsPointV2( QgsWKBTypes::PointZM, 11, 12, 13, 14 ) );
   QCOMPARE( l33.vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPointV2( QgsWKBTypes::PointZM, 1, 2, 3, 4 ) );
   QCOMPARE( l33.vertexAt( QgsVertexId( 0, 0, 1 ) ), QgsPointV2( QgsWKBTypes::PointZM, 11, 12, 13, 14 ) );
   QVERIFY( l33.pointAt( 0, p, type ) );
@@ -1977,7 +1975,7 @@ void TestQgsGeometry::lineStringV2()
   QCOMPARE( p, QgsPointV2( QgsWKBTypes::PointZM, 11, 12, 13, 14 ) );
   QCOMPARE( type, QgsVertexId::SegmentVertex );
   //LineString25D
-  l33.setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::Point25D, 1, 2, 3 ) << QgsPointV2( QgsWKBTypes::Point25D, 11, 12, 13 ) );
+  l33.setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::Point25D, 1, 2, 3 ) << QgsPointV2( QgsWKBTypes::Point25D, 11, 12, 13 ) );
   QCOMPARE( l33.vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPointV2( QgsWKBTypes::Point25D, 1, 2, 3 ) );
   QCOMPARE( l33.vertexAt( QgsVertexId( 0, 0, 1 ) ), QgsPointV2( QgsWKBTypes::Point25D, 11, 12, 13 ) );
   QVERIFY( l33.pointAt( 0, p, type ) );
@@ -1990,28 +1988,28 @@ void TestQgsGeometry::lineStringV2()
   //centroid
   QgsLineStringV2 l34;
   QCOMPARE( l34.centroid(), QgsPointV2() );
-  l34.setPoints( QList< QgsPointV2 >() << QgsPointV2( 5, 10 ) );
+  l34.setPoints( QgsPointSequenceV2() << QgsPointV2( 5, 10 ) );
   QCOMPARE( l34.centroid(), QgsPointV2( 5, 10 ) );
-  l34.setPoints( QList< QgsPointV2 >() << QgsPointV2( 0, 0 ) << QgsPointV2( 20, 10 ) );
+  l34.setPoints( QgsPointSequenceV2() << QgsPointV2( 0, 0 ) << QgsPointV2( 20, 10 ) );
   QCOMPARE( l34.centroid(), QgsPointV2( 10, 5 ) );
-  l34.setPoints( QList< QgsPointV2 >() << QgsPointV2( 0, 0 ) << QgsPointV2( 0, 9 ) << QgsPointV2( 2, 9 ) << QgsPointV2( 2, 0 ) );
+  l34.setPoints( QgsPointSequenceV2() << QgsPointV2( 0, 0 ) << QgsPointV2( 0, 9 ) << QgsPointV2( 2, 9 ) << QgsPointV2( 2, 0 ) );
   QCOMPARE( l34.centroid(), QgsPointV2( 1, 4.95 ) );
   //linestring with 0 length segment
-  l34.setPoints( QList< QgsPointV2 >() << QgsPointV2( 0, 0 ) << QgsPointV2( 0, 9 ) << QgsPointV2( 2, 9 ) << QgsPointV2( 2, 9 ) << QgsPointV2( 2, 0 ) );
+  l34.setPoints( QgsPointSequenceV2() << QgsPointV2( 0, 0 ) << QgsPointV2( 0, 9 ) << QgsPointV2( 2, 9 ) << QgsPointV2( 2, 9 ) << QgsPointV2( 2, 0 ) );
   QCOMPARE( l34.centroid(), QgsPointV2( 1, 4.95 ) );
   //linestring with 0 total length segment
-  l34.setPoints( QList< QgsPointV2 >() << QgsPointV2( 5, 4 ) << QgsPointV2( 5, 4 ) << QgsPointV2( 5, 4 ) );
+  l34.setPoints( QgsPointSequenceV2() << QgsPointV2( 5, 4 ) << QgsPointV2( 5, 4 ) << QgsPointV2( 5, 4 ) );
   QCOMPARE( l34.centroid(), QgsPointV2( 5, 4 ) );
 
   //closest segment
   QgsLineStringV2 l35;
   bool leftOf = false;
   ( void )l35.closestSegment( QgsPointV2( 1, 2 ), p, v, 0, 0 ); //empty line, just want no crash
-  l35.setPoints( QList< QgsPointV2 >() << QgsPointV2( 5, 10 ) );
+  l35.setPoints( QgsPointSequenceV2() << QgsPointV2( 5, 10 ) );
   QVERIFY( qgsDoubleNear( l35.closestSegment( QgsPointV2( 5, 10 ), p, v, 0, 0 ), 0 ) );
   QCOMPARE( p, QgsPointV2( 5, 10 ) );
   QCOMPARE( v, QgsVertexId( 0, 0, 1 ) );
-  l35.setPoints( QList< QgsPointV2 >() << QgsPointV2( 5, 10 ) << QgsPointV2( 10, 10 ) );
+  l35.setPoints( QgsPointSequenceV2() << QgsPointV2( 5, 10 ) << QgsPointV2( 10, 10 ) );
   QVERIFY( qgsDoubleNear( l35.closestSegment( QgsPointV2( 4, 11 ), p, v, &leftOf, 0 ), 2.0 ) );
   QCOMPARE( p, QgsPointV2( 5, 10 ) );
   QCOMPARE( v, QgsVertexId( 0, 0, 1 ) );
@@ -2028,7 +2026,7 @@ void TestQgsGeometry::lineStringV2()
   QCOMPARE( p, QgsPointV2( 10, 10 ) );
   QCOMPARE( v, QgsVertexId( 0, 0, 1 ) );
   QCOMPARE( leftOf, false );
-  l35.setPoints( QList< QgsPointV2 >() << QgsPointV2( 5, 10 )
+  l35.setPoints( QgsPointSequenceV2() << QgsPointV2( 5, 10 )
                  << QgsPointV2( 10, 10 )
                  << QgsPointV2( 10, 15 ) );
   QVERIFY( qgsDoubleNear( l35.closestSegment( QgsPointV2( 11, 12 ), p, v, &leftOf, 0 ), 1.0 ) );
@@ -2041,25 +2039,25 @@ void TestQgsGeometry::lineStringV2()
   double area = 1.0; //sumUpArea adds to area, so start with non-zero value
   l36.sumUpArea( area );
   QCOMPARE( area, 1.0 );
-  l36.setPoints( QList< QgsPointV2 >() << QgsPointV2( 5, 10 ) );
+  l36.setPoints( QgsPointSequenceV2() << QgsPointV2( 5, 10 ) );
   l36.sumUpArea( area );
   QCOMPARE( area, 1.0 );
-  l36.setPoints( QList< QgsPointV2 >() << QgsPointV2( 5, 10 ) << QgsPointV2( 10, 10 ) );
+  l36.setPoints( QgsPointSequenceV2() << QgsPointV2( 5, 10 ) << QgsPointV2( 10, 10 ) );
   l36.sumUpArea( area );
   QCOMPARE( area, 1.0 );
-  l36.setPoints( QList< QgsPointV2 >() << QgsPointV2( 0, 0 ) << QgsPointV2( 2, 0 ) << QgsPointV2( 2, 2 ) );
+  l36.setPoints( QgsPointSequenceV2() << QgsPointV2( 0, 0 ) << QgsPointV2( 2, 0 ) << QgsPointV2( 2, 2 ) );
   l36.sumUpArea( area );
   QVERIFY( qgsDoubleNear( area, 3.0 ) );
-  l36.setPoints( QList< QgsPointV2 >() << QgsPointV2( 0, 0 ) << QgsPointV2( 2, 0 ) << QgsPointV2( 2, 2 ) << QgsPointV2( 0, 2 ) );
+  l36.setPoints( QgsPointSequenceV2() << QgsPointV2( 0, 0 ) << QgsPointV2( 2, 0 ) << QgsPointV2( 2, 2 ) << QgsPointV2( 0, 2 ) );
   l36.sumUpArea( area );
   QVERIFY( qgsDoubleNear( area, 7.0 ) );
 
   //boundingBox - test that bounding box is updated after every modification to the line string
   QgsLineStringV2 l37;
   QVERIFY( l37.boundingBox().isNull() );
-  l37.setPoints( QList< QgsPointV2 >() << QgsPointV2( 5, 10 ) << QgsPointV2( 10, 15 ) );
+  l37.setPoints( QgsPointSequenceV2() << QgsPointV2( 5, 10 ) << QgsPointV2( 10, 15 ) );
   QCOMPARE( l37.boundingBox(), QgsRectangle( 5, 10, 10, 15 ) );
-  l37.setPoints( QList< QgsPointV2 >() << QgsPointV2( -5, -10 ) << QgsPointV2( -6, -10 ) << QgsPointV2( -5.5, -9 ) );
+  l37.setPoints( QgsPointSequenceV2() << QgsPointV2( -5, -10 ) << QgsPointV2( -6, -10 ) << QgsPointV2( -5.5, -9 ) );
   QCOMPARE( l37.boundingBox(), QgsRectangle( -6, -10, -5, -9 ) );
   //setXAt
   l37.setXAt( 2, -4 );
@@ -2069,14 +2067,14 @@ void TestQgsGeometry::lineStringV2()
   QCOMPARE( l37.boundingBox(), QgsRectangle( -6, -15, -4, -9 ) );
   //append
   toAppend.reset( new QgsLineStringV2() );
-  toAppend->setPoints( QList< QgsPointV2 >() << QgsPointV2( 1, 2 ) << QgsPointV2( 4, 0 ) );
+  toAppend->setPoints( QgsPointSequenceV2() << QgsPointV2( 1, 2 ) << QgsPointV2( 4, 0 ) );
   l37.append( toAppend.data() );
   QCOMPARE( l37.boundingBox(), QgsRectangle( -6, -15, 4, 2 ) );
   l37.addVertex( QgsPointV2( 6, 3 ) );
   QCOMPARE( l37.boundingBox(), QgsRectangle( -6, -15, 6, 3 ) );
   l37.clear();
   QVERIFY( l37.boundingBox().isNull() );
-  l37.setPoints( QList< QgsPointV2 >() << QgsPointV2( 5, 10 ) << QgsPointV2( 10, 15 ) );
+  l37.setPoints( QgsPointSequenceV2() << QgsPointV2( 5, 10 ) << QgsPointV2( 10, 15 ) );
   wkb = toAppend->asWkb( size );
   l37.fromWkb( QgsConstWkbPtr( wkb, size ) );
   delete[] wkb;
@@ -2095,26 +2093,26 @@ void TestQgsGeometry::lineStringV2()
   QgsLineStringV2 l38;
   ( void )l38.vertexAngle( QgsVertexId() ); //just want no crash
   ( void )l38.vertexAngle( QgsVertexId( 0, 0, 0 ) ); //just want no crash
-  l38.setPoints( QList< QgsPointV2 >() << QgsPointV2( 0, 0 ) );
+  l38.setPoints( QgsPointSequenceV2() << QgsPointV2( 0, 0 ) );
   ( void )l38.vertexAngle( QgsVertexId( 0, 0, 0 ) ); //just want no crash, any answer is meaningless
-  l38.setPoints( QList< QgsPointV2 >() << QgsPointV2( 0, 0 ) << QgsPointV2( 1, 0 ) );
+  l38.setPoints( QgsPointSequenceV2() << QgsPointV2( 0, 0 ) << QgsPointV2( 1, 0 ) );
   QVERIFY( qgsDoubleNear( l38.vertexAngle( QgsVertexId( 0, 0, 0 ) ), 1.5708, 0.0001 ) );
   QVERIFY( qgsDoubleNear( l38.vertexAngle( QgsVertexId( 0, 0, 1 ) ), 1.5708, 0.0001 ) );
   ( void )l38.vertexAngle( QgsVertexId( 0, 0, 2 ) ); //no crash
-  l38.setPoints( QList< QgsPointV2 >() << QgsPointV2( 0, 0 ) << QgsPointV2( 0, 1 ) );
+  l38.setPoints( QgsPointSequenceV2() << QgsPointV2( 0, 0 ) << QgsPointV2( 0, 1 ) );
   QVERIFY( qgsDoubleNear( l38.vertexAngle( QgsVertexId( 0, 0, 0 ) ), 0.0 ) );
   QVERIFY( qgsDoubleNear( l38.vertexAngle( QgsVertexId( 0, 0, 1 ) ), 0.0 ) );
-  l38.setPoints( QList< QgsPointV2 >() << QgsPointV2( 1, 0 ) << QgsPointV2( 0, 0 ) );
+  l38.setPoints( QgsPointSequenceV2() << QgsPointV2( 1, 0 ) << QgsPointV2( 0, 0 ) );
   QVERIFY( qgsDoubleNear( l38.vertexAngle( QgsVertexId( 0, 0, 0 ) ), 4.71239, 0.0001 ) );
   QVERIFY( qgsDoubleNear( l38.vertexAngle( QgsVertexId( 0, 0, 1 ) ), 4.71239, 0.0001 ) );
-  l38.setPoints( QList< QgsPointV2 >() << QgsPointV2( 0, 1 ) << QgsPointV2( 0, 0 ) );
+  l38.setPoints( QgsPointSequenceV2() << QgsPointV2( 0, 1 ) << QgsPointV2( 0, 0 ) );
   QVERIFY( qgsDoubleNear( l38.vertexAngle( QgsVertexId( 0, 0, 0 ) ), 3.1416, 0.0001 ) );
   QVERIFY( qgsDoubleNear( l38.vertexAngle( QgsVertexId( 0, 0, 1 ) ), 3.1416, 0.0001 ) );
-  l38.setPoints( QList< QgsPointV2 >() << QgsPointV2( 0, 0 ) << QgsPointV2( 1, 0 ) << QgsPointV2( 1, 1 ) );
+  l38.setPoints( QgsPointSequenceV2() << QgsPointV2( 0, 0 ) << QgsPointV2( 1, 0 ) << QgsPointV2( 1, 1 ) );
   QVERIFY( qgsDoubleNear( l38.vertexAngle( QgsVertexId( 0, 0, 0 ) ), 1.5708, 0.0001 ) );
   QVERIFY( qgsDoubleNear( l38.vertexAngle( QgsVertexId( 0, 0, 1 ) ), 0.7854, 0.0001 ) );
   QVERIFY( qgsDoubleNear( l38.vertexAngle( QgsVertexId( 0, 0, 2 ) ), 0.0, 0.0001 ) );
-  l38.setPoints( QList< QgsPointV2 >() << QgsPointV2( 0, 0 ) << QgsPointV2( 0.5, 0 ) << QgsPointV2( 1, 0 )
+  l38.setPoints( QgsPointSequenceV2() << QgsPointV2( 0, 0 ) << QgsPointV2( 0.5, 0 ) << QgsPointV2( 1, 0 )
                  << QgsPointV2( 2, 1 ) << QgsPointV2( 1, 2 ) << QgsPointV2( 0, 2 ) );
   ( void )l38.vertexAngle( QgsVertexId( 0, 0, 20 ) );
   QVERIFY( qgsDoubleNear( l38.vertexAngle( QgsVertexId( 0, 0, 0 ) ), 1.5708, 0.0001 ) );
@@ -2174,7 +2172,7 @@ void TestQgsGeometry::polygonV2()
 
   //valid exterior ring
   ext = new QgsLineStringV2();
-  ext->setPoints( QList< QgsPointV2 >() << QgsPointV2( 0, 0 ) << QgsPointV2( 0, 10 ) << QgsPointV2( 10, 10 )
+  ext->setPoints( QgsPointSequenceV2() << QgsPointV2( 0, 0 ) << QgsPointV2( 0, 10 ) << QgsPointV2( 10, 10 )
                   << QgsPointV2( 10, 0 ) << QgsPointV2( 0, 0 ) );
   p1.setExteriorRing( ext );
   QVERIFY( !p1.isEmpty() );
@@ -2199,7 +2197,7 @@ void TestQgsGeometry::polygonV2()
 
   //test that a non closed exterior ring will be automatically closed
   ext = new QgsLineStringV2();
-  ext->setPoints( QList< QgsPointV2 >() << QgsPointV2( 0, 0 ) << QgsPointV2( 0, 10 ) << QgsPointV2( 10, 10 )
+  ext->setPoints( QgsPointSequenceV2() << QgsPointV2( 0, 0 ) << QgsPointV2( 0, 10 ) << QgsPointV2( 10, 10 )
                   << QgsPointV2( 10, 0 ) );
   QVERIFY( !ext->isClosed() );
   p1.setExteriorRing( ext );
@@ -2210,7 +2208,7 @@ void TestQgsGeometry::polygonV2()
   //initial setting of exterior ring should set z/m type
   QgsPolygonV2 p2;
   ext = new QgsLineStringV2();
-  ext->setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZ, 0, 0, 1 )
+  ext->setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZ, 0, 0, 1 )
                   << QgsPointV2( QgsWKBTypes::PointZ, 0, 10, 2 ) << QgsPointV2( QgsWKBTypes::PointZ, 10, 10, 3 )
                   << QgsPointV2( QgsWKBTypes::PointZ, 10, 0, 4 ) << QgsPointV2( QgsWKBTypes::PointZ, 0, 0, 1 ) );
   p2.setExteriorRing( ext );
@@ -2222,7 +2220,7 @@ void TestQgsGeometry::polygonV2()
   QCOMPARE( *( static_cast< const QgsLineStringV2* >( p2.exteriorRing() ) ), *ext );
   QgsPolygonV2 p3;
   ext = new QgsLineStringV2();
-  ext->setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointM, 0, 0, 0, 1 )
+  ext->setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointM, 0, 0, 0, 1 )
                   << QgsPointV2( QgsWKBTypes::PointM, 0, 10, 0, 2 ) << QgsPointV2( QgsWKBTypes::PointM, 10, 10, 0, 3 )
                   << QgsPointV2( QgsWKBTypes::PointM, 10, 0, 0, 4 ) << QgsPointV2( QgsWKBTypes::PointM, 0, 0, 0, 1 ) );
   p3.setExteriorRing( ext );
@@ -2233,7 +2231,7 @@ void TestQgsGeometry::polygonV2()
   QCOMPARE( *( static_cast< const QgsLineStringV2* >( p3.exteriorRing() ) ), *ext );
   QgsPolygonV2 p4;
   ext = new QgsLineStringV2();
-  ext->setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZM, 0, 0, 2, 1 )
+  ext->setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZM, 0, 0, 2, 1 )
                   << QgsPointV2( QgsWKBTypes::PointZM, 0, 10, 3, 2 ) << QgsPointV2( QgsWKBTypes::PointZM, 10, 10, 5, 3 )
                   << QgsPointV2( QgsWKBTypes::PointZM, 10, 0, 0, 4 ) << QgsPointV2( QgsWKBTypes::PointZM, 0, 0, 2, 1 ) );
   p4.setExteriorRing( ext );
@@ -2244,7 +2242,7 @@ void TestQgsGeometry::polygonV2()
   QCOMPARE( *( static_cast< const QgsLineStringV2* >( p4.exteriorRing() ) ), *ext );
   QgsPolygonV2 p5;
   ext = new QgsLineStringV2();
-  ext->setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::Point25D, 0, 0, 1 )
+  ext->setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::Point25D, 0, 0, 1 )
                   << QgsPointV2( QgsWKBTypes::Point25D, 0, 10, 2 ) << QgsPointV2( QgsWKBTypes::Point25D, 10, 10, 3 )
                   << QgsPointV2( QgsWKBTypes::Point25D, 10, 0, 4 ) << QgsPointV2( QgsWKBTypes::Point25D, 0, 0, 1 ) );
   p5.setExteriorRing( ext );
@@ -2256,7 +2254,7 @@ void TestQgsGeometry::polygonV2()
 
   //setting curved exterior ring should be segmentized
   QgsCircularStringV2* circularRing = new QgsCircularStringV2();
-  circularRing->setPoints( QList< QgsPointV2 >() << QgsPointV2( 0, 0 ) << QgsPointV2( 0, 10 ) << QgsPointV2( 10, 10 )
+  circularRing->setPoints( QgsPointSequenceV2() << QgsPointV2( 0, 0 ) << QgsPointV2( 0, 10 ) << QgsPointV2( 10, 10 )
                            << QgsPointV2( 10, 0 ) << QgsPointV2( 0, 0 ) );
   QVERIFY( circularRing->hasCurvedSegments() );
   p5.setExteriorRing( circularRing );
@@ -2266,7 +2264,7 @@ void TestQgsGeometry::polygonV2()
   //addInteriorRing
   QgsPolygonV2 p6;
   ext = new QgsLineStringV2();
-  ext->setPoints( QList< QgsPointV2 >() << QgsPointV2( 0, 0 ) << QgsPointV2( 0, 10 ) << QgsPointV2( 10, 10 )
+  ext->setPoints( QgsPointSequenceV2() << QgsPointV2( 0, 0 ) << QgsPointV2( 0, 10 ) << QgsPointV2( 10, 10 )
                   << QgsPointV2( 10, 0 ) << QgsPointV2( 0, 0 ) );
   p6.setExteriorRing( ext );
   //empty ring
@@ -2276,7 +2274,7 @@ void TestQgsGeometry::polygonV2()
   p6.addInteriorRing( 0 );
   QCOMPARE( p6.numInteriorRings(), 0 );
   QgsLineStringV2* ring = new QgsLineStringV2();
-  ring->setPoints( QList< QgsPointV2 >() << QgsPointV2( 1, 1 ) << QgsPointV2( 1, 9 ) << QgsPointV2( 9, 9 )
+  ring->setPoints( QgsPointSequenceV2() << QgsPointV2( 1, 1 ) << QgsPointV2( 1, 9 ) << QgsPointV2( 9, 9 )
                    << QgsPointV2( 9, 1 ) << QgsPointV2( 1, 1 ) );
   p6.addInteriorRing( ring );
   QCOMPARE( p6.numInteriorRings(), 1 );
@@ -2285,7 +2283,7 @@ void TestQgsGeometry::polygonV2()
 
   //add non-closed interior ring, should be closed automatically
   ring = new QgsLineStringV2();
-  ring->setPoints( QList< QgsPointV2 >() << QgsPointV2( 0.1, 0.1 ) << QgsPointV2( 0.1, 0.9 ) << QgsPointV2( 0.9, 0.9 )
+  ring->setPoints( QgsPointSequenceV2() << QgsPointV2( 0.1, 0.1 ) << QgsPointV2( 0.1, 0.9 ) << QgsPointV2( 0.9, 0.9 )
                    << QgsPointV2( 0.9, 0.1 ) );
   QVERIFY( !ring->isClosed() );
   p6.addInteriorRing( ring );
@@ -2294,7 +2292,7 @@ void TestQgsGeometry::polygonV2()
 
   //try adding an interior ring with z to a 2d polygon, z should be dropped
   ring = new QgsLineStringV2();
-  ring->setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZ, 0.1, 0.1, 1 )
+  ring->setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZ, 0.1, 0.1, 1 )
                    << QgsPointV2( QgsWKBTypes::PointZ, 0.1, 0.2, 2 ) << QgsPointV2( QgsWKBTypes::PointZ, 0.2, 0.2, 3 )
                    << QgsPointV2( QgsWKBTypes::PointZ, 0.2, 0.1, 4 ) << QgsPointV2( QgsWKBTypes::PointZ, 0.1, 0.1, 1 ) );
   p6.addInteriorRing( ring );
@@ -2309,7 +2307,7 @@ void TestQgsGeometry::polygonV2()
 
   //try adding an interior ring with m to a 2d polygon, m should be dropped
   ring = new QgsLineStringV2();
-  ring->setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointM, 0.1, 0.1, 0, 1 )
+  ring->setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointM, 0.1, 0.1, 0, 1 )
                    << QgsPointV2( QgsWKBTypes::PointM, 0.1, 0.2, 0, 2 ) << QgsPointV2( QgsWKBTypes::PointM, 0.2, 0.2, 0, 3 )
                    << QgsPointV2( QgsWKBTypes::PointM, 0.2, 0.1, 0, 4 ) << QgsPointV2( QgsWKBTypes::PointM, 0.1, 0.1, 0, 1 ) );
   p6.addInteriorRing( ring );
@@ -2325,7 +2323,7 @@ void TestQgsGeometry::polygonV2()
   //addInteriorRing without z/m to PolygonZM
   QgsPolygonV2 p6b;
   ext = new QgsLineStringV2();
-  ext->setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZM, 0, 0, 1 )
+  ext->setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZM, 0, 0, 1 )
                   << QgsPointV2( QgsWKBTypes::PointZM, 0, 10, 2 ) << QgsPointV2( QgsWKBTypes::PointZM, 10, 10, 3 )
                   << QgsPointV2( QgsWKBTypes::PointZM, 10, 0, 4 ) << QgsPointV2( QgsWKBTypes::PointZM, 0, 0, 1 ) );
   p6b.setExteriorRing( ext );
@@ -2334,7 +2332,7 @@ void TestQgsGeometry::polygonV2()
   QCOMPARE( p6b.wkbType(), QgsWKBTypes::PolygonZM );
   //ring has no z
   ring = new QgsLineStringV2();
-  ring->setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointM, 1, 1, 0, 2 ) << QgsPointV2( QgsWKBTypes::PointM, 1, 9 ) << QgsPointV2( QgsWKBTypes::PointM, 9, 9 )
+  ring->setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointM, 1, 1, 0, 2 ) << QgsPointV2( QgsWKBTypes::PointM, 1, 9 ) << QgsPointV2( QgsWKBTypes::PointM, 9, 9 )
                    << QgsPointV2( QgsWKBTypes::PointM, 9, 1 ) << QgsPointV2( QgsWKBTypes::PointM, 1, 1 ) );
   p6b.addInteriorRing( ring );
   QVERIFY( p6b.interiorRing( 0 ) );
@@ -2344,7 +2342,7 @@ void TestQgsGeometry::polygonV2()
   QCOMPARE( p6b.interiorRing( 0 )->vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPointV2( QgsWKBTypes::PointZM, 1, 1, 0, 2 ) );
   //ring has no m
   ring = new QgsLineStringV2();
-  ring->setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZ, 0.1, 0.1, 1 )
+  ring->setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZ, 0.1, 0.1, 1 )
                    << QgsPointV2( QgsWKBTypes::PointZ, 0.1, 0.2, 2 ) << QgsPointV2( QgsWKBTypes::PointZ, 0.2, 0.2, 3 )
                    << QgsPointV2( QgsWKBTypes::PointZ, 0.2, 0.1, 4 ) << QgsPointV2( QgsWKBTypes::PointZ, 0.1, 0.1, 1 ) );
   p6b.addInteriorRing( ring );
@@ -2356,7 +2354,7 @@ void TestQgsGeometry::polygonV2()
   //test handling of 25D rings/polygons
   QgsPolygonV2 p6c;
   ext = new QgsLineStringV2();
-  ext->setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::Point25D, 0, 0, 1 )
+  ext->setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::Point25D, 0, 0, 1 )
                   << QgsPointV2( QgsWKBTypes::Point25D, 0, 10, 2 ) << QgsPointV2( QgsWKBTypes::Point25D, 10, 10, 3 )
                   << QgsPointV2( QgsWKBTypes::Point25D, 10, 0, 4 ) << QgsPointV2( QgsWKBTypes::Point25D, 0, 0, 1 ) );
   p6c.setExteriorRing( ext );
@@ -2365,7 +2363,7 @@ void TestQgsGeometry::polygonV2()
   QCOMPARE( p6c.wkbType(), QgsWKBTypes::Polygon25D );
   //adding a LineStringZ, should become LineString25D
   ring = new QgsLineStringV2();
-  ring->setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZ, 0.1, 0.1, 1 )
+  ring->setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZ, 0.1, 0.1, 1 )
                    << QgsPointV2( QgsWKBTypes::PointZ, 0.1, 0.2, 2 ) << QgsPointV2( QgsWKBTypes::PointZ, 0.2, 0.2, 3 )
                    << QgsPointV2( QgsWKBTypes::PointZ, 0.2, 0.1, 4 ) << QgsPointV2( QgsWKBTypes::PointZ, 0.1, 0.1, 1 ) );
   QCOMPARE( ring->wkbType(), QgsWKBTypes::LineStringZ );
@@ -2377,7 +2375,7 @@ void TestQgsGeometry::polygonV2()
   QCOMPARE( p6c.interiorRing( 0 )->vertexAt( QgsVertexId( 0, 0, 0 ) ), QgsPointV2( QgsWKBTypes::Point25D, 0.1, 0.1, 1 ) );
   //add a LineStringM, should become LineString25D
   ring = new QgsLineStringV2();
-  ring->setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointM, 0.1, 0.1, 0, 1 )
+  ring->setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointM, 0.1, 0.1, 0, 1 )
                    << QgsPointV2( QgsWKBTypes::PointM, 0.1, 0.2, 0, 2 ) << QgsPointV2( QgsWKBTypes::PointM, 0.2, 0.2, 0, 3 )
                    << QgsPointV2( QgsWKBTypes::PointM, 0.2, 0.1, 0, 4 ) << QgsPointV2( QgsWKBTypes::PointM, 0.1, 0.1, 0, 1 ) );
   QCOMPARE( ring->wkbType(), QgsWKBTypes::LineStringM );
@@ -2390,7 +2388,7 @@ void TestQgsGeometry::polygonV2()
 
   //add curved ring to polygon
   circularRing = new QgsCircularStringV2();
-  circularRing->setPoints( QList< QgsPointV2 >() << QgsPointV2( 0, 0 ) << QgsPointV2( 0, 10 ) << QgsPointV2( 10, 10 )
+  circularRing->setPoints( QgsPointSequenceV2() << QgsPointV2( 0, 0 ) << QgsPointV2( 0, 10 ) << QgsPointV2( 10, 10 )
                            << QgsPointV2( 10, 0 ) << QgsPointV2( 0, 0 ) );
   QVERIFY( circularRing->hasCurvedSegments() );
   p6c.addInteriorRing( circularRing );
@@ -2403,23 +2401,23 @@ void TestQgsGeometry::polygonV2()
   //set interior rings
   QgsPolygonV2 p7;
   ext = new QgsLineStringV2();
-  ext->setPoints( QList< QgsPointV2 >() << QgsPointV2( 0, 0 ) << QgsPointV2( 0, 10 ) << QgsPointV2( 10, 10 )
+  ext->setPoints( QgsPointSequenceV2() << QgsPointV2( 0, 0 ) << QgsPointV2( 0, 10 ) << QgsPointV2( 10, 10 )
                   << QgsPointV2( 10, 0 ) << QgsPointV2( 0, 0 ) );
   p7.setExteriorRing( ext );
   //add a list of rings with mixed types
   QList< QgsCurveV2* > rings;
   rings << new QgsLineStringV2();
-  static_cast< QgsLineStringV2*>( rings[0] )->setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZ, 0.1, 0.1, 1 )
+  static_cast< QgsLineStringV2*>( rings[0] )->setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZ, 0.1, 0.1, 1 )
       << QgsPointV2( QgsWKBTypes::PointZ, 0.1, 0.2, 2 ) << QgsPointV2( QgsWKBTypes::PointZ, 0.2, 0.2, 3 )
       << QgsPointV2( QgsWKBTypes::PointZ, 0.2, 0.1, 4 ) << QgsPointV2( QgsWKBTypes::PointZ, 0.1, 0.1, 1 ) );
   rings << new QgsLineStringV2();
-  static_cast< QgsLineStringV2*>( rings[1] )->setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointM, 0.3, 0.3, 0, 1 )
+  static_cast< QgsLineStringV2*>( rings[1] )->setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointM, 0.3, 0.3, 0, 1 )
       << QgsPointV2( QgsWKBTypes::PointM, 0.3, 0.4, 0, 2 ) << QgsPointV2( QgsWKBTypes::PointM, 0.4, 0.4, 0, 3 )
       << QgsPointV2( QgsWKBTypes::PointM, 0.4, 0.3, 0, 4 ) << QgsPointV2( QgsWKBTypes::PointM, 0.3, 0.3, 0, 1 ) );
   //throw an empty ring in too
   rings << 0;
   rings << new QgsCircularStringV2();
-  static_cast< QgsCircularStringV2*>( rings[3] )->setPoints( QList< QgsPointV2 >() << QgsPointV2( 0, 0 ) << QgsPointV2( 0, 10 ) << QgsPointV2( 10, 10 )
+  static_cast< QgsCircularStringV2*>( rings[3] )->setPoints( QgsPointSequenceV2() << QgsPointV2( 0, 0 ) << QgsPointV2( 0, 10 ) << QgsPointV2( 10, 10 )
       << QgsPointV2( 10, 0 ) << QgsPointV2( 0, 0 ) );
   p7.setInteriorRings( rings );
   QCOMPARE( p7.numInteriorRings(), 3 );
@@ -2441,7 +2439,7 @@ void TestQgsGeometry::polygonV2()
   //set rings with existing
   rings.clear();
   rings << new QgsLineStringV2();
-  static_cast< QgsLineStringV2*>( rings[0] )->setPoints( QList< QgsPointV2 >() << QgsPointV2( 0.8, 0.8 )
+  static_cast< QgsLineStringV2*>( rings[0] )->setPoints( QgsPointSequenceV2() << QgsPointV2( 0.8, 0.8 )
       << QgsPointV2( 0.8, 0.9 ) << QgsPointV2( 0.9, 0.9 )
       << QgsPointV2( 0.9, 0.8 ) << QgsPointV2( 0.8, 0.8 ) );
   p7.setInteriorRings( rings );
@@ -2458,16 +2456,16 @@ void TestQgsGeometry::polygonV2()
   //change dimensionality of interior rings using setExteriorRing
   QgsPolygonV2 p7a;
   ext = new QgsLineStringV2();
-  ext->setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZ, 0, 0, 1 ) << QgsPointV2( QgsWKBTypes::PointZ, 0, 10, 2 )
+  ext->setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZ, 0, 0, 1 ) << QgsPointV2( QgsWKBTypes::PointZ, 0, 10, 2 )
                   << QgsPointV2( QgsWKBTypes::PointZ, 10, 10, 1 ) << QgsPointV2( QgsWKBTypes::PointZ, 10, 0, 3 ) << QgsPointV2( QgsWKBTypes::PointZ, 0, 0, 1 ) );
   p7a.setExteriorRing( ext );
   rings.clear();
   rings << new QgsLineStringV2();
-  static_cast< QgsLineStringV2*>( rings[0] )->setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZ, 0.1, 0.1, 1 )
+  static_cast< QgsLineStringV2*>( rings[0] )->setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZ, 0.1, 0.1, 1 )
       << QgsPointV2( QgsWKBTypes::PointZ, 0.1, 0.2, 2 ) << QgsPointV2( QgsWKBTypes::PointZ, 0.2, 0.2, 3 )
       << QgsPointV2( QgsWKBTypes::PointZ, 0.2, 0.1, 4 ) << QgsPointV2( QgsWKBTypes::PointZ, 0.1, 0.1, 1 ) );
   rings << new QgsLineStringV2();
-  static_cast< QgsLineStringV2*>( rings[1] )->setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZ, 0.3, 0.3, 1 )
+  static_cast< QgsLineStringV2*>( rings[1] )->setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZ, 0.3, 0.3, 1 )
       << QgsPointV2( QgsWKBTypes::PointZ, 0.3, 0.4, 2 ) << QgsPointV2( QgsWKBTypes::PointZ, 0.4, 0.4, 3 )
       << QgsPointV2( QgsWKBTypes::PointZ, 0.4, 0.3, 4 ) << QgsPointV2( QgsWKBTypes::PointZ, 0.3, 0.3,  1 ) );
   p7a.setInteriorRings( rings );
@@ -2479,7 +2477,7 @@ void TestQgsGeometry::polygonV2()
   QVERIFY( !p7a.interiorRing( 1 )->isMeasure() );
   //reset exterior ring to 2d
   ext = new QgsLineStringV2();
-  ext->setPoints( QList< QgsPointV2 >() << QgsPointV2( 0, 0 ) << QgsPointV2( 0, 10 )
+  ext->setPoints( QgsPointSequenceV2() << QgsPointV2( 0, 0 ) << QgsPointV2( 0, 10 )
                   << QgsPointV2( 10, 10 ) << QgsPointV2( 10, 0 ) << QgsPointV2( 0, 0 ) );
   p7a.setExteriorRing( ext );
   QVERIFY( !p7a.is3D() );
@@ -2487,7 +2485,7 @@ void TestQgsGeometry::polygonV2()
   QVERIFY( !p7a.interiorRing( 1 )->is3D() );
   //reset exterior ring to LineStringM
   ext = new QgsLineStringV2();
-  ext->setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointM, 0, 0 ) << QgsPointV2( QgsWKBTypes::PointM, 0, 10 )
+  ext->setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointM, 0, 0 ) << QgsPointV2( QgsWKBTypes::PointM, 0, 10 )
                   << QgsPointV2( QgsWKBTypes::PointM, 10, 10 ) << QgsPointV2( QgsWKBTypes::PointM, 10, 0 ) << QgsPointV2( QgsWKBTypes::PointM, 0, 0 ) );
   p7a.setExteriorRing( ext );
   QVERIFY( p7a.isMeasure() );
@@ -2495,7 +2493,7 @@ void TestQgsGeometry::polygonV2()
   QVERIFY( p7a.interiorRing( 1 )->isMeasure() );
   //25D exterior ring
   ext = new QgsLineStringV2();
-  ext->setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::Point25D, 0, 0 ) << QgsPointV2( QgsWKBTypes::Point25D, 0, 10 )
+  ext->setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::Point25D, 0, 0 ) << QgsPointV2( QgsWKBTypes::Point25D, 0, 10 )
                   << QgsPointV2( QgsWKBTypes::Point25D, 10, 10 ) << QgsPointV2( QgsWKBTypes::Point25D, 10, 0 ) << QgsPointV2( QgsWKBTypes::Point25D, 0, 0 ) );
   p7a.setExteriorRing( ext );
   QVERIFY( p7a.is3D() );
@@ -2511,22 +2509,22 @@ void TestQgsGeometry::polygonV2()
   //removeInteriorRing
   QgsPolygonV2 p8;
   ext = new QgsLineStringV2();
-  ext->setPoints( QList< QgsPointV2 >() << QgsPointV2( 0, 0 ) << QgsPointV2( 0, 10 ) << QgsPointV2( 10, 10 )
+  ext->setPoints( QgsPointSequenceV2() << QgsPointV2( 0, 0 ) << QgsPointV2( 0, 10 ) << QgsPointV2( 10, 10 )
                   << QgsPointV2( 10, 0 ) << QgsPointV2( 0, 0 ) );
   p8.setExteriorRing( ext );
   QVERIFY( !p8.removeInteriorRing( -1 ) );
   QVERIFY( !p8.removeInteriorRing( 0 ) );
   rings.clear();
   rings << new QgsLineStringV2();
-  static_cast< QgsLineStringV2*>( rings[0] )->setPoints( QList< QgsPointV2 >() << QgsPointV2( 0.1, 0.1 )
+  static_cast< QgsLineStringV2*>( rings[0] )->setPoints( QgsPointSequenceV2() << QgsPointV2( 0.1, 0.1 )
       << QgsPointV2( 0.1, 0.2 ) << QgsPointV2( 0.2, 0.2 )
       << QgsPointV2( 0.2, 0.1 ) << QgsPointV2( 0.1, 0.1 ) );
   rings << new QgsLineStringV2();
-  static_cast< QgsLineStringV2*>( rings[1] )->setPoints( QList< QgsPointV2 >() << QgsPointV2( 0.3, 0.3 )
+  static_cast< QgsLineStringV2*>( rings[1] )->setPoints( QgsPointSequenceV2() << QgsPointV2( 0.3, 0.3 )
       << QgsPointV2( 0.3, 0.4 ) << QgsPointV2( 0.4, 0.4 )
       << QgsPointV2( 0.4, 0.3 ) << QgsPointV2( 0.3, 0.3 ) );
   rings << new QgsLineStringV2();
-  static_cast< QgsLineStringV2*>( rings[2] )->setPoints( QList< QgsPointV2 >() << QgsPointV2( 0.8, 0.8 )
+  static_cast< QgsLineStringV2*>( rings[2] )->setPoints( QgsPointSequenceV2() << QgsPointV2( 0.8, 0.8 )
       << QgsPointV2( 0.8, 0.9 ) << QgsPointV2( 0.9, 0.9 )
       << QgsPointV2( 0.9, 0.8 ) << QgsPointV2( 0.8, 0.8 ) );
   p8.setInteriorRings( rings );
@@ -2545,12 +2543,12 @@ void TestQgsGeometry::polygonV2()
   //clear
   QgsPolygonV2 p9;
   ext = new QgsLineStringV2();
-  ext->setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZ, 0, 0, 1 )
+  ext->setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZ, 0, 0, 1 )
                   << QgsPointV2( QgsWKBTypes::PointZ, 0, 10, 2 ) << QgsPointV2( QgsWKBTypes::PointZ, 10, 10, 3 )
                   << QgsPointV2( QgsWKBTypes::PointZ, 10, 0, 4 ) << QgsPointV2( QgsWKBTypes::PointZ, 0, 0, 1 ) );
   p9.setExteriorRing( ext );
   ring = new QgsLineStringV2();
-  ring->setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZ, 1, 1, 1 )
+  ring->setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZ, 1, 1, 1 )
                    << QgsPointV2( QgsWKBTypes::PointZ, 1, 9, 2 ) << QgsPointV2( QgsWKBTypes::PointZ, 9, 9, 3 )
                    << QgsPointV2( QgsWKBTypes::PointZ, 9, 1, 4 ) << QgsPointV2( QgsWKBTypes::PointZ, 1, 1, 1 ) );
   p9.addInteriorRing( ring );
@@ -2571,25 +2569,25 @@ void TestQgsGeometry::polygonV2()
   QVERIFY( p10 == p10b );
   QVERIFY( !( p10 != p10b ) );
   ext = new QgsLineStringV2();
-  ext->setPoints( QList< QgsPointV2 >() << QgsPointV2( 0, 0 ) << QgsPointV2( 0, 10 ) << QgsPointV2( 10, 10 )
+  ext->setPoints( QgsPointSequenceV2() << QgsPointV2( 0, 0 ) << QgsPointV2( 0, 10 ) << QgsPointV2( 10, 10 )
                   << QgsPointV2( 10, 0 ) << QgsPointV2( 0, 0 ) );
   p10.setExteriorRing( ext );
   QVERIFY( !( p10 == p10b ) );
   QVERIFY( p10 != p10b );
   ext = new QgsLineStringV2();
-  ext->setPoints( QList< QgsPointV2 >() << QgsPointV2( 0, 0 ) << QgsPointV2( 0, 10 ) << QgsPointV2( 10, 10 )
+  ext->setPoints( QgsPointSequenceV2() << QgsPointV2( 0, 0 ) << QgsPointV2( 0, 10 ) << QgsPointV2( 10, 10 )
                   << QgsPointV2( 10, 0 ) << QgsPointV2( 0, 0 ) );
   p10b.setExteriorRing( ext );
   QVERIFY( p10 == p10b );
   QVERIFY( !( p10 != p10b ) );
   ext = new QgsLineStringV2();
-  ext->setPoints( QList< QgsPointV2 >() << QgsPointV2( 0, 0 ) << QgsPointV2( 0, 9 ) << QgsPointV2( 9, 9 )
+  ext->setPoints( QgsPointSequenceV2() << QgsPointV2( 0, 0 ) << QgsPointV2( 0, 9 ) << QgsPointV2( 9, 9 )
                   << QgsPointV2( 9, 0 ) << QgsPointV2( 0, 0 ) );
   p10b.setExteriorRing( ext );
   QVERIFY( !( p10 == p10b ) );
   QVERIFY( p10 != p10b );
   ext = new QgsLineStringV2();
-  ext->setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZ, 0, 0, 1 ) << QgsPointV2( QgsWKBTypes::PointZ, 0, 10, 2 )
+  ext->setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZ, 0, 0, 1 ) << QgsPointV2( QgsWKBTypes::PointZ, 0, 10, 2 )
                   << QgsPointV2( QgsWKBTypes::PointZ, 10, 10, 3 ) << QgsPointV2( QgsWKBTypes::PointZ, 10, 0, 4 ) << QgsPointV2( QgsWKBTypes::PointZ, 0, 0, 1 ) );
   p10b.setExteriorRing( ext );
   QVERIFY( !( p10 == p10b ) );
@@ -2598,14 +2596,14 @@ void TestQgsGeometry::polygonV2()
   QVERIFY( p10 == p10b );
   QVERIFY( !( p10 != p10b ) );
   ring = new QgsLineStringV2();
-  ring->setPoints( QList< QgsPointV2 >() << QgsPointV2( 1, 1 )
+  ring->setPoints( QgsPointSequenceV2() << QgsPointV2( 1, 1 )
                    << QgsPointV2( 1, 9 ) << QgsPointV2( 9, 9 )
                    << QgsPointV2( 9, 1 ) << QgsPointV2( 1, 1 ) );
   p10.addInteriorRing( ring );
   QVERIFY( !( p10 == p10b ) );
   QVERIFY( p10 != p10b );
   ring = new QgsLineStringV2();
-  ring->setPoints( QList< QgsPointV2 >() << QgsPointV2( 2, 1 )
+  ring->setPoints( QgsPointSequenceV2() << QgsPointV2( 2, 1 )
                    << QgsPointV2( 2, 9 ) << QgsPointV2( 9, 9 )
                    << QgsPointV2( 9, 1 ) << QgsPointV2( 2, 1 ) );
   p10b.addInteriorRing( ring );
@@ -2622,12 +2620,12 @@ void TestQgsGeometry::polygonV2()
   QScopedPointer< QgsPolygonV2 >cloned( p11.clone() );
   QCOMPARE( p11, *cloned );
   ext = new QgsLineStringV2();
-  ext->setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZM, 0, 0, 1, 5 )
+  ext->setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZM, 0, 0, 1, 5 )
                   << QgsPointV2( QgsWKBTypes::PointZM, 0, 10, 2, 6 ) << QgsPointV2( QgsWKBTypes::PointZM, 10, 10, 3, 7 )
                   << QgsPointV2( QgsWKBTypes::PointZM, 10, 0, 4, 8 ) << QgsPointV2( QgsWKBTypes::PointZM, 0, 0, 1, 9 ) );
   p11.setExteriorRing( ext );
   ring = new QgsLineStringV2();
-  ring->setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZM, 1, 1, 1, 2 )
+  ring->setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZM, 1, 1, 1, 2 )
                    << QgsPointV2( QgsWKBTypes::PointZM, 1, 9, 2, 3 ) << QgsPointV2( QgsWKBTypes::PointZM, 9, 9, 3, 6 )
                    << QgsPointV2( QgsWKBTypes::PointZM, 9, 1, 4, 4 ) << QgsPointV2( QgsWKBTypes::PointZM, 1, 1, 1, 7 ) );
   p11.addInteriorRing( ring );
@@ -2639,12 +2637,12 @@ void TestQgsGeometry::polygonV2()
   QgsPolygonV2 p13( p12 );
   QCOMPARE( p12, p13 );
   ext = new QgsLineStringV2();
-  ext->setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZM, 0, 0, 1, 5 )
+  ext->setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZM, 0, 0, 1, 5 )
                   << QgsPointV2( QgsWKBTypes::PointZM, 0, 10, 2, 6 ) << QgsPointV2( QgsWKBTypes::PointZM, 10, 10, 3, 7 )
                   << QgsPointV2( QgsWKBTypes::PointZM, 10, 0, 4, 8 ) << QgsPointV2( QgsWKBTypes::PointZM, 0, 0, 1, 9 ) );
   p12.setExteriorRing( ext );
   ring = new QgsLineStringV2();
-  ring->setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZM, 1, 1, 1, 2 )
+  ring->setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZM, 1, 1, 1, 2 )
                    << QgsPointV2( QgsWKBTypes::PointZM, 1, 9, 2, 3 ) << QgsPointV2( QgsWKBTypes::PointZM, 9, 9, 3, 6 )
                    << QgsPointV2( QgsWKBTypes::PointZM, 9, 1, 4, 4 ) << QgsPointV2( QgsWKBTypes::PointZM, 1, 1, 1, 7 ) );
   p12.addInteriorRing( ring );
@@ -2665,12 +2663,12 @@ void TestQgsGeometry::polygonV2()
   //to/fromWKB
   QgsPolygonV2 p16;
   ext = new QgsLineStringV2();
-  ext->setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::Point, 0, 0 )
+  ext->setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::Point, 0, 0 )
                   << QgsPointV2( QgsWKBTypes::Point, 0, 10 ) << QgsPointV2( QgsWKBTypes::Point, 10, 10 )
                   << QgsPointV2( QgsWKBTypes::Point, 10, 0 ) << QgsPointV2( QgsWKBTypes::Point, 0, 0 ) );
   p16.setExteriorRing( ext );
   ring = new QgsLineStringV2();
-  ring->setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::Point, 1, 1 )
+  ring->setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::Point, 1, 1 )
                    << QgsPointV2( QgsWKBTypes::Point, 1, 9 ) << QgsPointV2( QgsWKBTypes::Point, 9, 9 )
                    << QgsPointV2( QgsWKBTypes::Point, 9, 1 ) << QgsPointV2( QgsWKBTypes::Point, 1, 1 ) );
   p16.addInteriorRing( ring );
@@ -2686,12 +2684,12 @@ void TestQgsGeometry::polygonV2()
   p16.clear();
   p17.clear();
   ext = new QgsLineStringV2();
-  ext->setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZ, 0, 0, 1 )
+  ext->setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZ, 0, 0, 1 )
                   << QgsPointV2( QgsWKBTypes::PointZ, 0, 10, 2 ) << QgsPointV2( QgsWKBTypes::PointZ, 10, 10, 3 )
                   << QgsPointV2( QgsWKBTypes::PointZ, 10, 0, 4 ) << QgsPointV2( QgsWKBTypes::PointZ, 0, 0, 1 ) );
   p16.setExteriorRing( ext );
   ring = new QgsLineStringV2();
-  ring->setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZ, 1, 1, 1 )
+  ring->setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZ, 1, 1, 1 )
                    << QgsPointV2( QgsWKBTypes::PointZ, 1, 9, 2 ) << QgsPointV2( QgsWKBTypes::PointZ, 9, 9, 3 )
                    << QgsPointV2( QgsWKBTypes::PointZ, 9, 1, 4 ) << QgsPointV2( QgsWKBTypes::PointZ, 1, 1, 1 ) );
   p16.addInteriorRing( ring );
@@ -2706,12 +2704,12 @@ void TestQgsGeometry::polygonV2()
   p16.clear();
   p17.clear();
   ext = new QgsLineStringV2();
-  ext->setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointM, 0, 0, 0, 1 )
+  ext->setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointM, 0, 0, 0, 1 )
                   << QgsPointV2( QgsWKBTypes::PointM, 0, 10,  0, 2 ) << QgsPointV2( QgsWKBTypes::PointM, 10, 10, 0, 3 )
                   << QgsPointV2( QgsWKBTypes::PointM, 10, 0,  0, 4 ) << QgsPointV2( QgsWKBTypes::PointM, 0, 0, 0, 1 ) );
   p16.setExteriorRing( ext );
   ring = new QgsLineStringV2();
-  ring->setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointM, 1, 1, 0, 1 )
+  ring->setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointM, 1, 1, 0, 1 )
                    << QgsPointV2( QgsWKBTypes::PointM, 1, 9, 0, 2 ) << QgsPointV2( QgsWKBTypes::PointM, 9, 9, 0, 3 )
                    << QgsPointV2( QgsWKBTypes::PointM, 9, 1, 0, 4 ) << QgsPointV2( QgsWKBTypes::PointM, 1, 1, 0, 1 ) );
   p16.addInteriorRing( ring );
@@ -2726,12 +2724,12 @@ void TestQgsGeometry::polygonV2()
   p16.clear();
   p17.clear();
   ext = new QgsLineStringV2();
-  ext->setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZM, 0, 0, 1, 5 )
+  ext->setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZM, 0, 0, 1, 5 )
                   << QgsPointV2( QgsWKBTypes::PointZM, 0, 10, 2, 6 ) << QgsPointV2( QgsWKBTypes::PointZM, 10, 10, 3, 7 )
                   << QgsPointV2( QgsWKBTypes::PointZM, 10, 0, 4, 8 ) << QgsPointV2( QgsWKBTypes::PointZM, 0, 0, 1, 9 ) );
   p16.setExteriorRing( ext );
   ring = new QgsLineStringV2();
-  ring->setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZM, 1, 1, 1, 2 )
+  ring->setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZM, 1, 1, 1, 2 )
                    << QgsPointV2( QgsWKBTypes::PointZM, 1, 9, 2, 3 ) << QgsPointV2( QgsWKBTypes::PointZM, 9, 9, 3, 6 )
                    << QgsPointV2( QgsWKBTypes::PointZM, 9, 1, 4, 4 ) << QgsPointV2( QgsWKBTypes::PointZM, 1, 1, 1, 7 ) );
   p16.addInteriorRing( ring );
@@ -2746,12 +2744,12 @@ void TestQgsGeometry::polygonV2()
   p16.clear();
   p17.clear();
   ext = new QgsLineStringV2();
-  ext->setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::Point25D, 0, 0, 1 )
+  ext->setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::Point25D, 0, 0, 1 )
                   << QgsPointV2( QgsWKBTypes::Point25D, 0, 10, 2 ) << QgsPointV2( QgsWKBTypes::Point25D, 10, 10, 3 )
                   << QgsPointV2( QgsWKBTypes::Point25D, 10, 0, 4 ) << QgsPointV2( QgsWKBTypes::Point25D, 0, 0, 1 ) );
   p16.setExteriorRing( ext );
   ring = new QgsLineStringV2();
-  ring->setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::Point25D, 1, 1, 1 )
+  ring->setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::Point25D, 1, 1, 1 )
                    << QgsPointV2( QgsWKBTypes::Point25D, 1, 9, 2 ) << QgsPointV2( QgsWKBTypes::Point25D, 9, 9, 3 )
                    << QgsPointV2( QgsWKBTypes::Point25D, 9, 1, 4 ) << QgsPointV2( QgsWKBTypes::Point25D, 1, 1, 1 ) );
   p16.addInteriorRing( ring );
@@ -2778,12 +2776,12 @@ void TestQgsGeometry::polygonV2()
   //to/from WKT
   QgsPolygonV2 p18;
   ext = new QgsLineStringV2();
-  ext->setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZM, 0, 0, 1, 5 )
+  ext->setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZM, 0, 0, 1, 5 )
                   << QgsPointV2( QgsWKBTypes::PointZM, 0, 10, 2, 6 ) << QgsPointV2( QgsWKBTypes::PointZM, 10, 10, 3, 7 )
                   << QgsPointV2( QgsWKBTypes::PointZM, 10, 0, 4, 8 ) << QgsPointV2( QgsWKBTypes::PointZM, 0, 0, 1, 9 ) );
   p18.setExteriorRing( ext );
   ring = new QgsLineStringV2();
-  ring->setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::PointZM, 1, 1, 1, 2 )
+  ring->setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::PointZM, 1, 1, 1, 2 )
                    << QgsPointV2( QgsWKBTypes::PointZM, 1, 9, 2, 3 ) << QgsPointV2( QgsWKBTypes::PointZM, 9, 9, 3, 6 )
                    << QgsPointV2( QgsWKBTypes::PointZM, 9, 1, 4, 4 ) << QgsPointV2( QgsWKBTypes::PointZM, 1, 1, 1, 7 ) );
   p18.addInteriorRing( ring );
@@ -2806,12 +2804,12 @@ void TestQgsGeometry::polygonV2()
   //as JSON
   QgsPolygonV2 exportPolygon;
   ext = new QgsLineStringV2();
-  ext->setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::Point, 0, 0 )
+  ext->setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::Point, 0, 0 )
                   << QgsPointV2( QgsWKBTypes::Point, 0, 10 ) << QgsPointV2( QgsWKBTypes::Point, 10, 10 )
                   << QgsPointV2( QgsWKBTypes::Point, 10, 0 ) << QgsPointV2( QgsWKBTypes::Point, 0, 0 ) );
   exportPolygon.setExteriorRing( ext );
   ring = new QgsLineStringV2();
-  ring->setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::Point, 1, 1 )
+  ring->setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::Point, 1, 1 )
                    << QgsPointV2( QgsWKBTypes::Point, 1, 9 ) << QgsPointV2( QgsWKBTypes::Point, 9, 9 )
                    << QgsPointV2( QgsWKBTypes::Point, 9, 1 ) << QgsPointV2( QgsWKBTypes::Point, 1, 1 ) );
   exportPolygon.addInteriorRing( ring );
@@ -2821,12 +2819,12 @@ void TestQgsGeometry::polygonV2()
 
   QgsPolygonV2 exportPolygonFloat;
   ext = new QgsLineStringV2();
-  ext->setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::Point, 10 / 9.0, 10 / 9.0 )
+  ext->setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::Point, 10 / 9.0, 10 / 9.0 )
                   << QgsPointV2( QgsWKBTypes::Point, 10 / 9.0, 100 / 9.0 ) << QgsPointV2( QgsWKBTypes::Point, 100 / 9.0, 100 / 9.0 )
                   << QgsPointV2( QgsWKBTypes::Point, 100 / 9.0, 10 / 9.0 ) << QgsPointV2( QgsWKBTypes::Point, 10 / 9.0, 10 / 9.0 ) );
   exportPolygonFloat.setExteriorRing( ext );
   ring = new QgsLineStringV2();
-  ring->setPoints( QList< QgsPointV2 >() << QgsPointV2( QgsWKBTypes::Point, 2 / 3.0, 2 / 3.0 )
+  ring->setPoints( QgsPointSequenceV2() << QgsPointV2( QgsWKBTypes::Point, 2 / 3.0, 2 / 3.0 )
                    << QgsPointV2( QgsWKBTypes::Point, 2 / 3.0, 4 / 3.0 ) << QgsPointV2( QgsWKBTypes::Point, 4 / 3.0, 4 / 3.0 )
                    << QgsPointV2( QgsWKBTypes::Point, 4 / 3.0, 2 / 3.0 ) << QgsPointV2( QgsWKBTypes::Point, 2 / 3.0, 2 / 3.0 ) );
   exportPolygonFloat.addInteriorRing( ring );


### PR DESCRIPTION
implicitly shared copy of an internal cache instead of recreating the coordinate sequence again and again.

Improves performance of the nodetool on large features a lot (refs [#13963](http://hub.qgis.org/issues/13963))

Also introduce Qgs(Coordinate|Ring|Point)SequenceV2 typedefs.
