### PR TITLE
Update label

### DIFF
--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -686,7 +686,7 @@
                     <item>
                      <widget class="QCheckBox" name="cbxCanvasRotation">
                       <property name="text">
-                       <string>Experimental canvas rotation support (restart required)</string>
+                       <string>Canvas rotation support (restart required)</string>
                       </property>
                      </widget>
                     </item>


### PR DESCRIPTION
Given that the canvas rotation is in QGIS for many releases, it may be time to remove the "experimental" attribute in the label
