### PR TITLE
[Bugfix] offer NULL value in relation reference widget if allowed (fixes #14162)

### DIFF
--- a/src/gui/attributetable/qgsfeaturelistmodel.cpp
+++ b/src/gui/attributetable/qgsfeaturelistmodel.cpp
@@ -61,9 +61,13 @@ QVariant QgsFeatureListModel::data( const QModelIndex &index, int role ) const
     {
       return QSettings().value( "qgis/nullValue", "NULL" ).toString();
     }
-    else
+    else if ( role == QgsAttributeTableModel::FeatureIdRole )
     {
       return QVariant( QVariant::Int );
+    }
+    else
+    {
+      return QVariant( QVariant::Invalid );
     }
   }
 
@@ -122,7 +126,14 @@ QVariant QgsFeatureListModel::data( const QModelIndex &index, int role ) const
 
 Qt::ItemFlags QgsFeatureListModel::flags( const QModelIndex &index ) const
 {
-  return sourceModel()->flags( mapToSource( index ) ) & ~Qt::ItemIsEditable;
+  if ( mInjectNull && index.row() == 0 )
+  {
+    return Qt::ItemIsSelectable | Qt::ItemIsEnabled;
+  }
+  else
+  {
+    return sourceModel()->flags( mapToSource( index ) ) & ~Qt::ItemIsEditable;
+  }
 }
 
 void QgsFeatureListModel::setInjectNull( bool injectNull )

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -234,7 +234,11 @@ void QgsRelationReferenceWidget::setRelationEditable( bool editable )
 
 void QgsRelationReferenceWidget::setForeignKey( const QVariant& value )
 {
-  if ( !value.isValid() || value.isNull() )
+  if ( !value.isValid() )
+  {
+    return;
+  }
+  if ( value.isNull() )
   {
     deleteForeignKey();
     return;
@@ -254,7 +258,6 @@ void QgsRelationReferenceWidget::setForeignKey( const QVariant& value )
 
   if ( !mFeature.isValid() )
   {
-    deleteForeignKey();
     return;
   }
 

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -535,7 +535,8 @@ void QgsRelationReferenceWidget::init()
       }
     }
 
-    mComboBox->setCurrentIndex( mComboBox->findData( mFeature.id(), QgsAttributeTableModel::FeatureIdRole ) );
+    QVariant featId = mFeature.isValid() ? mFeature.id() : QVariant( QVariant::Int );
+    mComboBox->setCurrentIndex( mComboBox->findData( featId, QgsAttributeTableModel::FeatureIdRole ) );
 
     // Only connect after iterating, to have only one iterator on the referenced table at once
     connect( mComboBox, SIGNAL( currentIndexChanged( int ) ), this, SLOT( comboReferenceChanged( int ) ) );


### PR DESCRIPTION
Even if _NULL_ was allowed by checking _Allow NULL value_ in the edit widget configuration dialog, _NULL_ was not offered by the combobox within the _Feature attributes_ dialog (see [Redmine #14162](https://hub.qgis.org/issues/14162)).
