### PR TITLE
Moved static vars to functions

### DIFF
--- a/src/server/qgis_map_serv.cpp
+++ b/src/server/qgis_map_serv.cpp
@@ -36,8 +36,7 @@ int fcgi_accept()
 
 int main( int argc, char * argv[] )
 {
-  QgsServer server;
-  server.init( argc, argv );
+  QgsServer server( argc, argv );
   // Starts FCGI loop
   while ( fcgi_accept() >= 0 )
   {

--- a/src/server/qgsserver.cpp
+++ b/src/server/qgsserver.cpp
@@ -57,7 +57,6 @@
 // Static initialisers, default values for fcgi server
 QgsApplication* QgsServer::mQgsApplication = nullptr;
 bool QgsServer::mInitialised = false;
-QString QgsServer::mServerName( "qgis_server" );
 bool QgsServer::mCaptureOutput = false;
 char* QgsServer::mArgv[1];
 int QgsServer::mArgc = 1;
@@ -78,6 +77,13 @@ QgsServer::QgsServer()
 
 QgsServer::~QgsServer()
 {
+}
+
+
+QString& QgsServer::serverName()
+{
+  static QString* name = new QString( "qgis_server" );
+  return *name;
 }
 
 
@@ -296,7 +302,7 @@ bool QgsServer::init()
   {
     return false;
   }
-  mArgv[0] = mServerName.toUtf8().data();
+  mArgv[0] = serverName().toUtf8().data();
   mArgc = 1;
   mCaptureOutput = true;
 #ifdef HAVE_SERVER_PYTHON_PLUGINS

--- a/src/server/qgsserver.h
+++ b/src/server/qgsserver.h
@@ -47,11 +47,16 @@
 class SERVER_EXPORT QgsServer
 {
   public:
+    /**
+     * Standard ctor for CGI/FCGI
+     * @note Not available in Python bindings
+     */
+    QgsServer( int & argc, char ** argv );
+    //! The following is mainly for python bindings, that do not pass argc/argv
     QgsServer();
     ~QgsServer();
+
     /** Server initialization: intialise QGIS ang QT core application.
-     * This method is automatically called by handleRequest if it wasn't
-     * explicitly called before
      * @note Not available in Python bindings
      */
     static bool init( int & argc, char ** argv );
@@ -84,7 +89,7 @@ class SERVER_EXPORT QgsServer
 
     /** Returns a pointer to the server interface */
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
-    QgsServerInterfaceImpl* serverInterface() { return mServerInterface; }
+    QgsServerInterfaceImpl* serverInterface() { return sServerInterface; }
 #endif
 
   private:
@@ -106,21 +111,23 @@ class SERVER_EXPORT QgsServer
     //! Create and return a request handler instance
     static QgsRequestHandler* createRequestHandler( const bool captureOutput = false );
 
-    // Server status
-    static QString mConfigFilePath;
-    static QgsCapabilitiesCache* mCapabilitiesCache;
-    static QgsMapRenderer* mMapRenderer;
-#ifdef HAVE_SERVER_PYTHON_PLUGINS
-    static QgsServerInterfaceImpl* mServerInterface;
-    static bool mInitPython;
-#endif
-    static bool mInitialised;
-    static char* mArgv[1];
-    static int mArgc;
-    static QgsApplication* mQgsApplication;
-    static bool mCaptureOutput;
     // Return the server name
     static QString &serverName();
+
+    // Status
+    static QString sConfigFilePath;
+    static QgsCapabilitiesCache* sCapabilitiesCache;
+    static QgsMapRenderer* sMapRenderer;
+#ifdef HAVE_SERVER_PYTHON_PLUGINS
+    static QgsServerInterfaceImpl* sServerInterface;
+    static bool sInitPython;
+#endif
+    //! Initialization must run once for all servers
+    static bool sInitialised;
+    static char* sArgv[1];
+    static int sArgc;
+    static QgsApplication* sQgsApplication;
+    static bool sCaptureOutput;
 };
 #endif // QGSSERVER_H
 

--- a/src/server/qgsserver.h
+++ b/src/server/qgsserver.h
@@ -115,11 +115,12 @@ class SERVER_EXPORT QgsServer
     static bool mInitPython;
 #endif
     static bool mInitialised;
-    static QString mServerName;
     static char* mArgv[1];
     static int mArgc;
     static QgsApplication* mQgsApplication;
     static bool mCaptureOutput;
+    // Return the server name
+    static QString &serverName();
 };
 #endif // QGSSERVER_H
 

--- a/src/server/qgsserverplugins.cpp
+++ b/src/server/qgsserverplugins.cpp
@@ -26,14 +26,22 @@
 
 #include <QLibrary>
 
+
+// Initialize static members
+QgsPythonUtils* QgsServerPlugins::mPythonUtils;
+
+
 QgsServerPlugins::QgsServerPlugins()
 {
 }
 
+
 // Initialize static members
-QgsPythonUtils* QgsServerPlugins::mPythonUtils;
-// Initialize static members
-QStringList QgsServerPlugins::mServerPlugins;
+QStringList &QgsServerPlugins::serverPlugins()
+{
+  static QStringList* pluginList = new QStringList();
+  return *pluginList;
+}
 
 // This code is mainly borrowed from QGIS desktop Python plugin initialization
 bool QgsServerPlugins::initPlugins( QgsServerInterface *interface )
@@ -101,7 +109,7 @@ bool QgsServerPlugins::initPlugins( QgsServerInterface *interface )
         if ( mPythonUtils->startServerPlugin( pluginName ) )
         {
           atLeastOneEnabled = true;
-          mServerPlugins.append( pluginName );
+          serverPlugins().append( pluginName );
           QgsMessageLog::logMessage( QString( "Server plugin %1 loaded!" ).arg( pluginName ), "Server", QgsMessageLog::INFO );
         }
         else
@@ -117,4 +125,5 @@ bool QgsServerPlugins::initPlugins( QgsServerInterface *interface )
   }
   return mPythonUtils && mPythonUtils->isEnabled() && atLeastOneEnabled;
 }
+
 

--- a/src/server/qgsserverplugins.cpp
+++ b/src/server/qgsserverplugins.cpp
@@ -28,20 +28,20 @@
 
 
 // Initialize static members
-QgsPythonUtils* QgsServerPlugins::mPythonUtils;
+QgsPythonUtils* QgsServerPlugins::sPythonUtils;
 
 
 QgsServerPlugins::QgsServerPlugins()
 {
 }
 
-
-// Initialize static members
+// Construct on first use
 QStringList &QgsServerPlugins::serverPlugins()
 {
   static QStringList* pluginList = new QStringList();
   return *pluginList;
 }
+
 
 // This code is mainly borrowed from QGIS desktop Python plugin initialization
 bool QgsServerPlugins::initPlugins( QgsServerInterface *interface )
@@ -81,10 +81,10 @@ bool QgsServerPlugins::initPlugins( QgsServerInterface *interface )
   }
 
   QgsDebugMsg( "Python support library's instance() symbol resolved." );
-  mPythonUtils = pythonlib_inst();
-  mPythonUtils->initServerPython( interface );
+  sPythonUtils = pythonlib_inst();
+  sPythonUtils->initServerPython( interface );
 
-  if ( mPythonUtils && mPythonUtils->isEnabled() )
+  if ( sPythonUtils && sPythonUtils->isEnabled() )
   {
     QgsDebugMsg( "Python support ENABLED :-)" );
   }
@@ -96,17 +96,17 @@ bool QgsServerPlugins::initPlugins( QgsServerInterface *interface )
 
   //Init plugins: loads a list of installed plugins and filter them
   //for "server" metadata
-  QListIterator<QString> plugins( mPythonUtils->pluginList() );
+  QListIterator<QString> plugins( sPythonUtils->pluginList() );
   bool atLeastOneEnabled = false;
   while ( plugins.hasNext() )
   {
     QString pluginName = plugins.next();
-    QString pluginService = mPythonUtils->getPluginMetadata( pluginName, "server" );
+    QString pluginService = sPythonUtils->getPluginMetadata( pluginName, "server" );
     if ( pluginService == "True" )
     {
-      if ( mPythonUtils->loadPlugin( pluginName ) )
+      if ( sPythonUtils->loadPlugin( pluginName ) )
       {
-        if ( mPythonUtils->startServerPlugin( pluginName ) )
+        if ( sPythonUtils->startServerPlugin( pluginName ) )
         {
           atLeastOneEnabled = true;
           serverPlugins().append( pluginName );
@@ -123,7 +123,7 @@ bool QgsServerPlugins::initPlugins( QgsServerInterface *interface )
       }
     }
   }
-  return mPythonUtils && mPythonUtils->isEnabled() && atLeastOneEnabled;
+  return sPythonUtils && sPythonUtils->isEnabled() && atLeastOneEnabled;
 }
 
 

--- a/src/server/qgsserverplugins.h
+++ b/src/server/qgsserverplugins.h
@@ -37,10 +37,10 @@ class SERVER_EXPORT QgsServerPlugins
      * @return bool true on success
      */
     static bool initPlugins( QgsServerInterface* interface );
-    //! Pointer to QgsPythonUtils
-    static QgsPythonUtils* mPythonUtils;
     //! List of available server plugin names
     static QStringList& serverPlugins();
+    //! Pointer to QgsPythonUtils
+    static QgsPythonUtils* sPythonUtils;
 };
 
 #endif // QGSSERVERPLUGINS_H

--- a/src/server/qgsserverplugins.h
+++ b/src/server/qgsserverplugins.h
@@ -40,7 +40,7 @@ class SERVER_EXPORT QgsServerPlugins
     //! Pointer to QgsPythonUtils
     static QgsPythonUtils* mPythonUtils;
     //! List of available server plugin names
-    static QStringList mServerPlugins;
+    static QStringList& serverPlugins();
 };
 
 #endif // QGSSERVERPLUGINS_H


### PR DESCRIPTION
This is an attempt to fix http://hub.qgis.org/issues/14354, it only partially solves it because the server does not crash anymore when launched from the command line, but still does when running as CGI.
Furthermore, the backtrace in http://hub.qgis.org/issues/14354 indicates a problem with GDAL destructors that are not related with the changes proposed in this patch.
