### PR TITLE
[Bugfix] keep feature rendering order settings when changing renderers (fixes #14347)

### DIFF
--- a/src/gui/symbology-ng/qgsrendererv2propertiesdialog.cpp
+++ b/src/gui/symbology-ng/qgsrendererv2propertiesdialog.cpp
@@ -222,7 +222,6 @@ void QgsRendererV2PropertiesDialog::rendererChanged()
     {
       if ( mMapCanvas )
         mActiveWidget->setMapCanvas( mMapCanvas );
-      changeOrderBy( mActiveWidget->renderer()->orderBy(), mActiveWidget->renderer()->orderByEnabled() );
       connect( mActiveWidget, SIGNAL( layerVariablesChanged() ), this, SIGNAL( layerVariablesChanged() ) );
     }
   }


### PR DESCRIPTION
When changing the renderer (e.g. from _single symbol_ to _graduated_), the settings for the _feature rendering order_ are reset to the settings of the layer. Any changes to these settings not yet applied to the layer are lost.

This PR fixes that.
