### PR TITLE
Fix precision of coordinate display for layer in non-projected CRS

### DIFF
--- a/src/core/qgscoordinateutils.cpp
+++ b/src/core/qgscoordinateutils.cpp
@@ -32,8 +32,11 @@ int QgsCoordinateUtils::calculateCoordinatePrecision( double mapUnitsPerPixel, c
     QString format = QgsProject::instance()->readEntry( "PositionPrecision", "/DegreeFormat", "MU" );
     bool formatGeographic = ( format == "DM" || format == "DMS" || format == "D" );
 
-    // we can only calculate an automatic precision if both map CRS and format are geographic or both not geographic
-    if ( mapCrs.geographicFlag() == formatGeographic )
+    // we can only calculate an automatic precision if one of these is true:
+    // - both map CRS and format are geographic
+    // - both map CRS and format are not geographic
+    // - map CRS is geographic but format is not geographic (i.e. map units)
+    if ( mapCrs.geographicFlag() || !formatGeographic )
     {
       // Work out a suitable number of decimal places for the coordinates with the aim of always
       // having enough decimal places to show the difference in position between adjacent pixels.


### PR DESCRIPTION
This addresses a case where you create a new project and add a layer in WGS84. The display of coordinates is fixed to precision of 2 decimals. One needs to open project properties dialog and click OK to get automatic precision. This is because by default the format is "MU", so this PR allows automatic precision also when format is "MU" while map CRS is geographic.

@nyalldawson Would you mind to have a look?
