### PR TITLE
Processing plugin OTB improvements

### DIFF
--- a/python/plugins/processing/algs/otb/OTBAlgorithmProvider.py
+++ b/python/plugins/processing/algs/otb/OTBAlgorithmProvider.py
@@ -86,16 +86,14 @@ class OTBAlgorithmProvider(AlgorithmProvider):
 
     def initializeSettings(self):
         AlgorithmProvider.initializeSettings(self)
-        if OTBUtils.findOtbPath() is None:
-            ProcessingConfig.addSetting(Setting(self.getDescription(),
-                                                OTBUtils.OTB_FOLDER,
-                                                self.tr("OTB command line tools folder"), OTBUtils.otbPath(),
-                                                valuetype=Setting.FOLDER))
-        if OTBUtils.findOtbLibPath() is None:
-            ProcessingConfig.addSetting(Setting(self.getDescription(),
-                                                OTBUtils.OTB_LIB_FOLDER,
-                                                self.tr("OTB applications folder"), OTBUtils.otbLibPath(),
-                                                valuetype=Setting.FOLDER))
+        ProcessingConfig.addSetting(Setting(self.getDescription(),
+                                            OTBUtils.OTB_FOLDER,
+                                            self.tr("OTB command line tools folder"), OTBUtils.findOtbPath(),
+                                            valuetype=Setting.FOLDER))
+        ProcessingConfig.addSetting(Setting(self.getDescription(),
+                                            OTBUtils.OTB_LIB_FOLDER,
+                                            self.tr("OTB applications folder"), OTBUtils.findOtbLibPath(),
+                                            valuetype=Setting.FOLDER))
         ProcessingConfig.addSetting(Setting(self.getDescription(),
                                             OTBUtils.OTB_SRTM_FOLDER,
                                             self.tr("SRTM tiles folder"), OTBUtils.otbSRTMPath(),

--- a/python/plugins/processing/algs/otb/OTBUtils.py
+++ b/python/plugins/processing/algs/otb/OTBUtils.py
@@ -49,7 +49,7 @@ OTB_GEOID_FILE = "OTB_GEOID_FILE"
 
 
 def findOtbPath():
-    folder = None
+    folder = ""
     #try to configure the path automatically
     if isMac():
         testfolder = os.path.join(unicode(QgsApplication.prefixPath()), "bin")
@@ -72,14 +72,14 @@ def findOtbPath():
 
 
 def otbPath():
-    folder = findOtbPath()
+    folder = ProcessingConfig.getSetting(OTB_FOLDER)
     if folder is None:
-        folder = ProcessingConfig.getSetting(OTB_FOLDER)
+        folder = ""
     return folder
 
 
 def findOtbLibPath():
-    folder = None
+    folder = ""
     #try to configure the path automatically
     if isMac():
         testfolder = os.path.join(unicode(QgsApplication.prefixPath()), "lib/otb/applications")
@@ -101,9 +101,9 @@ def findOtbLibPath():
 
 
 def otbLibPath():
-    folder = findOtbLibPath()
+    folder = ProcessingConfig.getSetting(OTB_LIB_FOLDER)
     if folder is None:
-        folder = ProcessingConfig.getSetting(OTB_LIB_FOLDER)
+        folder = ""
     return folder
 
 

--- a/python/plugins/processing/algs/otb/OTBUtils.py
+++ b/python/plugins/processing/algs/otb/OTBUtils.py
@@ -135,7 +135,7 @@ def getInstalledVersion(runOtb=False):
     if _installedVersionFound and not runOtb:
         return _installedVersion
 
-    if otbPath() is None:
+    if otbPath() is None or otbLibPath() is None:
         _installedVersionFound = False
         return None
     commands = [os.path.join(otbPath(), "otbcli_Smoothing")]


### PR DESCRIPTION
These two patches enable selecting a custom OTB installation for the processing plugin, which currently is impossible if a system OTB is found. Tested on debian. I can test on windows in a few days using a nightly build if it is merged.
