### PR TITLE
Rename arrow item to line

### DIFF
--- a/src/app/composer/qgscomposerarrowwidget.cpp
+++ b/src/app/composer/qgscomposerarrowwidget.cpp
@@ -29,8 +29,8 @@ QgsComposerArrowWidget::QgsComposerArrowWidget( QgsComposerArrow* arrow ): QgsCo
 {
   setupUi( this );
   mRadioButtonGroup = new QButtonGroup( this );
-  mRadioButtonGroup->addButton( mDefaultMarkerRadioButton );
   mRadioButtonGroup->addButton( mNoMarkerRadioButton );
+  mRadioButtonGroup->addButton( mDefaultMarkerRadioButton );
   mRadioButtonGroup->addButton( mSvgMarkerRadioButton );
   mRadioButtonGroup->setExclusive( true );
 

--- a/src/core/composer/qgscomposerarrow.cpp
+++ b/src/core/composer/qgscomposerarrow.cpp
@@ -31,7 +31,7 @@ QgsComposerArrow::QgsComposerArrow( QgsComposition* c )
     , mStopPoint( 0, 0 )
     , mStartXIdx( 0 )
     , mStartYIdx( 0 )
-    , mMarkerMode( DefaultMarker )
+    , mMarkerMode( NoMarker )
     , mArrowHeadOutlineWidth( 1.0 )
     , mArrowHeadOutlineColor( Qt::black )
     , mArrowHeadFillColor( Qt::black )
@@ -45,7 +45,7 @@ QgsComposerArrow::QgsComposerArrow( QPointF startPoint, QPointF stopPoint, QgsCo
     : QgsComposerItem( c )
     , mStartPoint( startPoint )
     , mStopPoint( stopPoint )
-    , mMarkerMode( DefaultMarker )
+    , mMarkerMode( NoMarker )
     , mArrowHeadOutlineWidth( 1.0 )
     , mArrowHeadOutlineColor( Qt::black )
     , mArrowHeadFillColor( Qt::black )
@@ -65,7 +65,7 @@ QgsComposerArrow::~QgsComposerArrow()
 
 void QgsComposerArrow::init()
 {
-  setArrowHeadWidth( 4 );
+  setArrowHeadWidth( 0 );
   mPen.setColor( mArrowHeadOutlineColor );
   mPen.setWidthF( 1 );
   mBrush.setColor( mArrowHeadFillColor );

--- a/src/core/composer/qgscomposerarrow.h
+++ b/src/core/composer/qgscomposerarrow.h
@@ -238,7 +238,7 @@ class CORE_EXPORT QgsComposerArrow: public QgsComposerItem
     QString mStartMarkerFile;
     /** Path to the end marker file*/
     QString mEndMarkerFile;
-    /** Default marker, no marker or svg marker*/
+    /** No marker, simple marker or svg marker*/
     MarkerMode mMarkerMode;
 
     double mArrowHeadOutlineWidth;

--- a/src/core/composer/qgscomposeritem.cpp
+++ b/src/core/composer/qgscomposeritem.cpp
@@ -1441,7 +1441,7 @@ QString QgsComposerItem::displayName() const
   switch ( type() )
   {
     case ComposerArrow:
-      return tr( "<arrow>" );
+      return tr( "<line>" );
     case ComposerItemGroup:
       return tr( "<group>" );
     case ComposerLabel:

--- a/src/ui/composer/qgscomposerarrowwidgetbase.ui
+++ b/src/ui/composer/qgscomposerarrowwidgetbase.ui
@@ -32,7 +32,7 @@
       <string notr="true">padding: 2px; font-weight: bold; background-color: rgb(200, 200, 200);</string>
      </property>
      <property name="text">
-      <string>Arrow</string>
+      <string>Line</string>
      </property>
     </widget>
    </item>
@@ -94,16 +94,16 @@
           <item row="0" column="0" colspan="2">
            <layout class="QHBoxLayout" name="horizontalLayout_3">
             <item>
-             <widget class="QRadioButton" name="mDefaultMarkerRadioButton">
+             <widget class="QRadioButton" name="mNoMarkerRadioButton">
               <property name="text">
-               <string>Default</string>
+               <string>None</string>
               </property>
              </widget>
             </item>
             <item>
-             <widget class="QRadioButton" name="mNoMarkerRadioButton">
+             <widget class="QRadioButton" name="mDefaultMarkerRadioButton">
               <property name="text">
-               <string>None</string>
+               <string>Simple Arrow</string>
               </property>
              </widget>
             </item>
@@ -295,8 +295,8 @@
   <tabstop>groupBox</tabstop>
   <tabstop>mLineStyleButton</tabstop>
   <tabstop>mArrowMarkersGroupBox</tabstop>
-  <tabstop>mDefaultMarkerRadioButton</tabstop>
   <tabstop>mNoMarkerRadioButton</tabstop>
+  <tabstop>mDefaultMarkerRadioButton</tabstop>
   <tabstop>mSvgMarkerRadioButton</tabstop>
   <tabstop>mArrowHeadOutlineColorButton</tabstop>
   <tabstop>mArrowHeadFillColorButton</tabstop>

--- a/src/ui/composer/qgscomposerbase.ui
+++ b/src/ui/composer/qgscomposerbase.ui
@@ -595,10 +595,10 @@
     <bool>true</bool>
    </property>
    <property name="text">
-    <string>Add Arro&amp;w</string>
+    <string>Add Line</string>
    </property>
    <property name="toolTip">
-    <string>Add arrow</string>
+    <string>Add line</string>
    </property>
   </action>
   <action name="mActionAddTable">


### PR DESCRIPTION
Given that the icons have been reworked, i think it might be worth fixing the arrow item, renaming it line item. I therfore use no marker as default option for line item and rename "Default marker " to "simple marker".

This PR is not expected to be merged as is. I'm not a dev so surely miss some changes (especially how to set a width for the arrow when switching to simple marker. It's just a draft that expects to draw the attention of some experienced dev on this issue.
@nyalldawson ?
