### PR TITLE
Remove column name validation from virtual layers queries

### DIFF
--- a/src/providers/virtual/qgsvirtuallayerqueryparser.cpp
+++ b/src/providers/virtual/qgsvirtuallayerqueryparser.cpp
@@ -93,14 +93,6 @@ namespace QgsVirtualLayerQueryParser
     return defs;
   }
 
-  bool isValidColumnName( const QString& columnName )
-  {
-    // identifier name with possible accents
-    static QRegExp columnNameRx( "[a-zA-Z_\x80-\xFF][a-zA-Z0-9_\x80-\xFF]*" );
-
-    return columnNameRx.exactMatch( columnName );
-  }
-
 // set the type of the column type, given its text representation
   void setColumnDefType( const QString& columnType, ColumnDef& d )
   {
@@ -171,17 +163,6 @@ namespace QgsVirtualLayerQueryParser
       while ( q.step() == SQLITE_ROW )
       {
         QString columnName = q.columnText( 1 );
-
-        if ( !isValidColumnName( columnName ) )
-        {
-          qWarning() << "Invalid name: " << columnName;
-          hasInvalidName = true;
-
-          // add an unnamed column
-          ColumnDef d;
-          tableDef << d;
-          break;
-        }
 
         columns << columnName;
 

--- a/tests/src/python/test_provider_virtual.py
+++ b/tests/src/python/test_provider_virtual.py
@@ -508,10 +508,11 @@ class TestQgsVirtualLayerProvider(unittest.TestCase, ProviderTestCase):
         QgsMapLayerRegistry.instance().addMapLayer(l2)
 
         # unnamed column
-        query = QUrl.toPercentEncoding("SELECT 42")
+        query = QUrl.toPercentEncoding("SELECT count(*)")
         l4 = QgsVectorLayer("?query=%s" % query, "tt", "virtual", False)
-        self.assertEqual(l4.isValid(), False)
-        self.assertEqual("Result column #1 has no name" in l4.dataProvider().error().message(), True)
+        self.assertEqual(l4.isValid(), True)
+        self.assertEqual(l4.dataProvider().fields().at(0).name(), "count(*)")
+        self.assertEqual(l4.dataProvider().fields().at(0).type(), QVariant.Int)
 
     def test_sql_field_types(self):
         query = QUrl.toPercentEncoding("SELECT 42 as t, 'ok'||'ok' as t2, GeomFromText('') as t3, 3.14*2 as t4")


### PR DESCRIPTION
The query already went through the Sqlite query parser. So why not
trusting it? This was in the way of group by queries with count(*)
in the output fields.
