### PR TITLE
Python unittest.expectedFailure improvements

### DIFF
--- a/tests/src/python/test_qgsappstartup.py
+++ b/tests/src/python/test_qgsappstartup.py
@@ -123,7 +123,6 @@ class TestPyQgsAppStartup(unittest.TestCase):
                                       testFile="qgis.db",
                                       timeOut=270), "config path %s" % p
 
-    @unittest.expectedFailure
     def testPluginPath(self):
         for t in ['test_plugins', 'test plugins', u'test_pluginsé€']:
 

--- a/tests/src/python/test_qgsvectorfilewriter.py
+++ b/tests/src/python/test_qgsvectorfilewriter.py
@@ -172,12 +172,10 @@ class TestQgsVectorLayer(unittest.TestCase):
         assert isinstance(f.attributes()[datetime_idx], QDateTime)
         self.assertEqual(f.attributes()[datetime_idx], QDateTime(QDate(2014, 3, 5), QTime(13, 45, 22)))
 
+    # This test fails on Travis Linux build for unknown reason (probably GDAL version related)
+    @unittest.expectedFailure(os.environ.get('TRAVIS') and 'linux' in platform.system().lower())
     def testWriteShapefileWithZ(self):
         """Check writing geometries with Z dimension to an ESRI shapefile."""
-
-        if os.environ.get('TRAVIS') and 'linux' in platform.system().lower():
-            # This test fails on Travis Linux build for unknown reason (probably GDAL version related)
-            return
 
         #start by saving a memory layer and forcing z
         ml = QgsVectorLayer(


### PR DESCRIPTION
- Raises an `_UnexpectedSuccess` exception if a flagged test succeeds
- Takes a boolean parameter with a condition under which the test is
  expected to fail
  
  ```
  @expectedFailure(time.localtime().tm_year < 2002)
  def my_test(self):
      self.assertTrue(qgisIsInvented())
  ```
