### PR TITLE
Support for rendering HTML based labels

### DIFF
--- a/src/app/qgslabelinggui.cpp
+++ b/src/app/qgslabelinggui.cpp
@@ -333,6 +333,7 @@ void QgsLabelingGui::init()
 
   // set the current field or add the current expression to the bottom of the list
   mFieldExpressionWidget->setField( lyr.fieldName );
+  mRenderAsHTML->setChecked( lyr.renderAsHTML );
 
   // populate placement options
   mCentroidRadioWhole->setChecked( lyr.centroidWhole );
@@ -630,6 +631,7 @@ QgsPalLayerSettings QgsLabelingGui::layerSettings()
 
   lyr.enabled = ( mMode == Labels || mMode == ObstaclesOnly );
   lyr.drawLabels = ( mMode == Labels );
+  lyr.renderAsHTML = mRenderAsHTML->isChecked();
 
   bool isExpression;
   lyr.fieldName = mFieldExpressionWidget->currentField( &isExpression );

--- a/src/core/qgspallabeling.cpp
+++ b/src/core/qgspallabeling.cpp
@@ -118,6 +118,7 @@ QgsPalLayerSettings::QgsPalLayerSettings()
   drawLabels = true;
   isExpression = false;
   fieldIndex = 0;
+  renderAsHTML = false;
 
   // text style
   textFont = QApplication::font();
@@ -805,6 +806,7 @@ void QgsPalLayerSettings::readFromLayer( QgsVectorLayer* layer )
 
   // text style
   fieldName = layer->customProperty( "labeling/fieldName" ).toString();
+  renderAsHTML = layer->customProperty( "labeling/renderAsHTML" ).toBool();
   isExpression = layer->customProperty( "labeling/isExpression" ).toBool();
   QFont appFont = QApplication::font();
   mTextFontFamily = layer->customProperty( "labeling/fontFamily", QVariant( appFont.family() ) ).toString();
@@ -1024,6 +1026,7 @@ void QgsPalLayerSettings::writeToLayer( QgsVectorLayer* layer )
 
   // text style
   layer->setCustomProperty( "labeling/fieldName", fieldName );
+  layer->setCustomProperty( "labeling/renderAsHTML", renderAsHTML );
   layer->setCustomProperty( "labeling/isExpression", isExpression );
   layer->setCustomProperty( "labeling/fontFamily", textFont.family() );
   layer->setCustomProperty( "labeling/namedStyle", QgsFontUtils::untranslateNamedStyle( textNamedStyle ) );
@@ -1915,13 +1918,13 @@ void QgsPalLayerSettings::calculateLabelSize( const QFontMetricsF* fm, QString t
   if ( renderAsHTML )
   {
     QTextDocument doc;
+    doc.setDocumentMargin( 0 );
     doc.setHtml( text );
-    h += doc.size().height();
-    w += doc.size().width();
+    h = doc.size().height();
+    w = doc.size().width();
   }
   else
   {
-
     QStringList multiLineSplit = QgsPalLabeling::splitToLines( text, wrapchr );
     int lines = multiLineSplit.size();
 

--- a/src/core/qgspallabeling.h
+++ b/src/core/qgspallabeling.h
@@ -356,6 +356,8 @@ class CORE_EXPORT QgsPalLayerSettings
       */
     bool isExpression;
 
+    bool renderAsHTML;
+
     /** Returns the QgsExpression for this label settings.
       */
     QgsExpression* getLabelExpression();

--- a/src/core/qgsvectorlayerlabelprovider.cpp
+++ b/src/core/qgsvectorlayerlabelprovider.cpp
@@ -32,8 +32,9 @@
 
 #include <QPicture>
 #include <QTextDocument>
-#include <QWebPage>
-#include <QWebFrame>
+#include <QAbstractTextDocumentLayout>
+#include <QSize>
+
 
 using namespace pal;
 
@@ -635,8 +636,6 @@ void QgsVectorLayerLabelProvider::drawLabelPrivate( pal::LabelPosition* label, Q
       }
     }
 
-    tmpLyr.renderAsHTML = true;
-
     //QgsDebugMsgLevel( "drawLabel " + txt, 4 );
     QStringList multiLineList;
     if ( tmpLyr.renderAsHTML )
@@ -732,6 +731,7 @@ void QgsVectorLayerLabelProvider::drawLabelPrivate( pal::LabelPosition* label, Q
       }
       else
       {
+        QTextDocument doc;
         // draw label's text, QPainterPath method
         // store text's drawing in QPicture for drop shadow call
         QPicture textPict;
@@ -743,8 +743,9 @@ void QgsVectorLayerLabelProvider::drawLabelPrivate( pal::LabelPosition* label, Q
         if ( tmpLyr.renderAsHTML )
         {
           QTextDocument doc;
+          doc.setDocumentMargin(0);
           doc.setHtml( component.text() );
-          doc.drawContents( &textp );
+          doc.drawContents( &textp);
         }
         else
         {
@@ -783,7 +784,13 @@ void QgsVectorLayerLabelProvider::drawLabelPrivate( pal::LabelPosition* label, Q
         {
           // draw outlined text
           _fixQPictureDPI( painter );
-          painter->drawPicture( 0, 0, textPict );
+          int y = 0;
+          if ( tmpLyr.renderAsHTML )
+            {
+                painter->translate( QPointF( 0, 0 - doc.size().height() ) );
+                y -= doc.size().height();
+            }
+          painter->drawPicture( 0, y, textPict );
         }
         else
         {

--- a/src/ui/qgslabelingguibase.ui
+++ b/src/ui/qgslabelingguibase.ui
@@ -112,7 +112,7 @@
               <rect>
                <x>0</x>
                <y>0</y>
-               <width>614</width>
+               <width>619</width>
                <height>300</height>
               </rect>
              </property>
@@ -560,8 +560,8 @@
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>594</width>
-                       <height>398</height>
+                       <width>591</width>
+                       <height>420</height>
                       </rect>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -604,7 +604,83 @@
                          <property name="bottomMargin">
                           <number>0</number>
                          </property>
-                         <item row="9" column="1" colspan="2">
+                         <item row="8" column="0">
+                          <widget class="QLabel" name="mFontTranspLabel">
+                           <property name="enabled">
+                            <bool>true</bool>
+                           </property>
+                           <property name="text">
+                            <string>Transparency</string>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="9" column="1">
+                          <widget class="QComboBox" name="mFontCapitalsComboBox">
+                           <property name="enabled">
+                            <bool>true</bool>
+                           </property>
+                           <property name="sizePolicy">
+                            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                             <horstretch>0</horstretch>
+                             <verstretch>0</verstretch>
+                            </sizepolicy>
+                           </property>
+                           <property name="maximumSize">
+                            <size>
+                             <width>16777215</width>
+                             <height>16777215</height>
+                            </size>
+                           </property>
+                           <property name="toolTip">
+                            <string>Capitalization style of text</string>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="1" column="0">
+                          <widget class="QLabel" name="mFontLabel">
+                           <property name="sizePolicy">
+                            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                             <horstretch>0</horstretch>
+                             <verstretch>0</verstretch>
+                            </sizepolicy>
+                           </property>
+                           <property name="text">
+                            <string>Font</string>
+                           </property>
+                           <property name="alignment">
+                            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="3" column="1">
+                          <widget class="QComboBox" name="mFontStyleComboBox">
+                           <property name="sizePolicy">
+                            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                             <horstretch>0</horstretch>
+                             <verstretch>0</verstretch>
+                            </sizepolicy>
+                           </property>
+                           <property name="minimumSize">
+                            <size>
+                             <width>0</width>
+                             <height>0</height>
+                            </size>
+                           </property>
+                           <property name="maximumSize">
+                            <size>
+                             <width>16777215</width>
+                             <height>16777215</height>
+                            </size>
+                           </property>
+                           <property name="toolTip">
+                            <string>Available typeface styles</string>
+                           </property>
+                           <property name="sizeAdjustPolicy">
+                            <enum>QComboBox::AdjustToContentsOnFirstShow</enum>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="10" column="1" colspan="2">
                           <layout class="QHBoxLayout" name="horizontalLayout_14">
                            <item>
                             <widget class="QLabel" name="mFontLetterSpacingLabel">
@@ -656,7 +732,20 @@
                            </item>
                           </layout>
                          </item>
-                         <item row="4" column="1">
+                         <item row="3" column="0">
+                          <widget class="QLabel" name="mFontStyleLabel">
+                           <property name="sizePolicy">
+                            <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                             <horstretch>0</horstretch>
+                             <verstretch>0</verstretch>
+                            </sizepolicy>
+                           </property>
+                           <property name="text">
+                            <string>Style</string>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="5" column="1">
                           <widget class="QgsDoubleSpinBox" name="mFontSizeSpinBox">
                            <property name="sizePolicy">
                             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -681,131 +770,67 @@
                            </property>
                           </widget>
                          </item>
-                         <item row="2" column="0">
-                          <widget class="QLabel" name="mFontStyleLabel">
-                           <property name="sizePolicy">
-                            <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
-                             <horstretch>0</horstretch>
-                             <verstretch>0</verstretch>
-                            </sizepolicy>
-                           </property>
-                           <property name="text">
-                            <string>Style</string>
-                           </property>
-                          </widget>
-                         </item>
-                         <item row="8" column="1">
-                          <widget class="QComboBox" name="mFontCapitalsComboBox">
-                           <property name="enabled">
-                            <bool>true</bool>
-                           </property>
-                           <property name="sizePolicy">
-                            <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
-                             <horstretch>0</horstretch>
-                             <verstretch>0</verstretch>
-                            </sizepolicy>
-                           </property>
-                           <property name="maximumSize">
-                            <size>
-                             <width>16777215</width>
-                             <height>16777215</height>
-                            </size>
-                           </property>
-                           <property name="toolTip">
-                            <string>Capitalization style of text</string>
-                           </property>
-                          </widget>
-                         </item>
-                         <item row="7" column="0">
-                          <widget class="QLabel" name="mFontTranspLabel">
-                           <property name="enabled">
-                            <bool>true</bool>
-                           </property>
-                           <property name="text">
-                            <string>Transparency</string>
-                           </property>
-                          </widget>
-                         </item>
-                         <item row="0" column="0">
-                          <widget class="QLabel" name="mFontLabel">
-                           <property name="sizePolicy">
-                            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
-                             <horstretch>0</horstretch>
-                             <verstretch>0</verstretch>
-                            </sizepolicy>
-                           </property>
-                           <property name="text">
-                            <string>Font</string>
-                           </property>
-                           <property name="alignment">
-                            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-                           </property>
-                          </widget>
-                         </item>
                          <item row="2" column="1">
-                          <widget class="QComboBox" name="mFontStyleComboBox">
+                          <widget class="QFrame" name="mFontFamilyFrame">
+                           <layout class="QHBoxLayout" name="horizontalLayout_5">
+                            <property name="leftMargin">
+                             <number>0</number>
+                            </property>
+                            <property name="topMargin">
+                             <number>0</number>
+                            </property>
+                            <property name="rightMargin">
+                             <number>0</number>
+                            </property>
+                            <property name="bottomMargin">
+                             <number>0</number>
+                            </property>
+                            <item>
+                             <widget class="QLabel" name="mFontMissingLabel">
+                              <property name="sizePolicy">
+                               <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+                                <horstretch>0</horstretch>
+                                <verstretch>0</verstretch>
+                               </sizepolicy>
+                              </property>
+                              <property name="styleSheet">
+                               <string notr="true">color: #990000;
+font-style: italic;</string>
+                              </property>
+                              <property name="text">
+                               <string>Font is missing.</string>
+                              </property>
+                              <property name="alignment">
+                               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+                              </property>
+                             </widget>
+                            </item>
+                           </layout>
+                          </widget>
+                         </item>
+                         <item row="7" column="1">
+                          <widget class="QgsColorButtonV2" name="btnTextColor">
                            <property name="sizePolicy">
-                            <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+                            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
                              <horstretch>0</horstretch>
                              <verstretch>0</verstretch>
                             </sizepolicy>
                            </property>
                            <property name="minimumSize">
                             <size>
-                             <width>0</width>
+                             <width>120</width>
                              <height>0</height>
                             </size>
                            </property>
                            <property name="maximumSize">
                             <size>
-                             <width>16777215</width>
+                             <width>120</width>
                              <height>16777215</height>
                             </size>
                            </property>
-                           <property name="toolTip">
-                            <string>Available typeface styles</string>
-                           </property>
-                           <property name="sizeAdjustPolicy">
-                            <enum>QComboBox::AdjustToContentsOnFirstShow</enum>
-                           </property>
                           </widget>
                          </item>
-                         <item row="8" column="2">
-                          <widget class="QgsDataDefinedButton" name="mFontCaseDDBtn">
-                           <property name="text">
-                            <string>...</string>
-                           </property>
-                          </widget>
-                         </item>
-                         <item row="5" column="2">
-                          <widget class="QgsDataDefinedButton" name="mFontUnitsDDBtn">
-                           <property name="text">
-                            <string>...</string>
-                           </property>
-                          </widget>
-                         </item>
-                         <item row="6" column="2">
-                          <widget class="QgsDataDefinedButton" name="mFontColorDDBtn">
-                           <property name="text">
-                            <string>...</string>
-                           </property>
-                          </widget>
-                         </item>
-                         <item row="0" column="2">
-                          <widget class="QgsDataDefinedButton" name="mFontDDBtn">
-                           <property name="text">
-                            <string>...</string>
-                           </property>
-                          </widget>
-                         </item>
-                         <item row="7" column="2">
-                          <widget class="QgsDataDefinedButton" name="mFontTranspDDBtn">
-                           <property name="text">
-                            <string>...</string>
-                           </property>
-                          </widget>
-                         </item>
-                         <item row="7" column="1">
+                         <item row="8" column="1">
                           <widget class="QFrame" name="frame">
                            <property name="sizePolicy">
                             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
@@ -873,7 +898,45 @@
                            </layout>
                           </widget>
                          </item>
-                         <item row="8" column="0">
+                         <item row="6" column="1">
+                          <widget class="QgsUnitSelectionWidget" name="mFontSizeUnitWidget" native="true"/>
+                         </item>
+                         <item row="7" column="2">
+                          <widget class="QgsDataDefinedButton" name="mFontColorDDBtn">
+                           <property name="text">
+                            <string>...</string>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="1" column="2">
+                          <widget class="QgsDataDefinedButton" name="mFontDDBtn">
+                           <property name="text">
+                            <string>...</string>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="8" column="2">
+                          <widget class="QgsDataDefinedButton" name="mFontTranspDDBtn">
+                           <property name="text">
+                            <string>...</string>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="9" column="2">
+                          <widget class="QgsDataDefinedButton" name="mFontCaseDDBtn">
+                           <property name="text">
+                            <string>...</string>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="6" column="2">
+                          <widget class="QgsDataDefinedButton" name="mFontUnitsDDBtn">
+                           <property name="text">
+                            <string>...</string>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="9" column="0">
                           <widget class="QLabel" name="mFontCapitalsLabel">
                            <property name="sizePolicy">
                             <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
@@ -886,14 +949,28 @@
                            </property>
                           </widget>
                          </item>
-                         <item row="11" column="2">
+                         <item row="12" column="2">
                           <widget class="QgsDataDefinedButton" name="mFontBlendModeDDBtn">
                            <property name="text">
                             <string>...</string>
                            </property>
                           </widget>
                          </item>
-                         <item row="6" column="0">
+                         <item row="10" column="0">
+                          <widget class="QLabel" name="label_10">
+                           <property name="text">
+                            <string>Spacing</string>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="5" column="2">
+                          <widget class="QgsDataDefinedButton" name="mFontSizeDDBtn">
+                           <property name="text">
+                            <string>...</string>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="7" column="0">
                           <widget class="QLabel" name="mFontColorLabel">
                            <property name="sizePolicy">
                             <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
@@ -909,50 +986,14 @@
                            </property>
                           </widget>
                          </item>
-                         <item row="4" column="2">
-                          <widget class="QgsDataDefinedButton" name="mFontSizeDDBtn">
-                           <property name="text">
-                            <string>...</string>
-                           </property>
-                          </widget>
-                         </item>
-                         <item row="9" column="0">
-                          <widget class="QLabel" name="label_10">
-                           <property name="text">
-                            <string>Spacing</string>
-                           </property>
-                          </widget>
-                         </item>
-                         <item row="6" column="1">
-                          <widget class="QgsColorButtonV2" name="btnTextColor">
-                           <property name="sizePolicy">
-                            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
-                             <horstretch>0</horstretch>
-                             <verstretch>0</verstretch>
-                            </sizepolicy>
-                           </property>
-                           <property name="minimumSize">
-                            <size>
-                             <width>120</width>
-                             <height>0</height>
-                            </size>
-                           </property>
-                           <property name="maximumSize">
-                            <size>
-                             <width>120</width>
-                             <height>16777215</height>
-                            </size>
-                           </property>
-                          </widget>
-                         </item>
-                         <item row="11" column="0">
+                         <item row="12" column="0">
                           <widget class="QLabel" name="labelBlendMode">
                            <property name="text">
                             <string>Blend mode</string>
                            </property>
                           </widget>
                          </item>
-                         <item row="10" column="1" colspan="2">
+                         <item row="11" column="1" colspan="2">
                           <layout class="QHBoxLayout" name="horizontalLayout_15">
                            <item>
                             <widget class="QLabel" name="mFontWordSpacingLabel">
@@ -1004,7 +1045,17 @@
                            </item>
                           </layout>
                          </item>
-                         <item row="3" column="1" colspan="2">
+                         <item row="12" column="1">
+                          <widget class="QgsBlendModeComboBox" name="comboBlendMode"/>
+                         </item>
+                         <item row="3" column="2">
+                          <widget class="QgsDataDefinedButton" name="mFontStyleDDBtn">
+                           <property name="text">
+                            <string>...</string>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="4" column="1" colspan="2">
                           <layout class="QHBoxLayout" name="horizontalLayout_13">
                            <item>
                             <widget class="QToolButton" name="mFontUnderlineBtn">
@@ -1186,17 +1237,7 @@
                            </item>
                           </layout>
                          </item>
-                         <item row="11" column="1">
-                          <widget class="QgsBlendModeComboBox" name="comboBlendMode"/>
-                         </item>
-                         <item row="2" column="2">
-                          <widget class="QgsDataDefinedButton" name="mFontStyleDDBtn">
-                           <property name="text">
-                            <string>...</string>
-                           </property>
-                          </widget>
-                         </item>
-                         <item row="4" column="0">
+                         <item row="5" column="0">
                           <widget class="QLabel" name="mFontSizeLabel">
                            <property name="sizePolicy">
                             <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
@@ -1210,52 +1251,25 @@
                           </widget>
                          </item>
                          <item row="1" column="1">
-                          <widget class="QFrame" name="mFontFamilyFrame">
-                           <layout class="QHBoxLayout" name="horizontalLayout_5">
-                            <property name="leftMargin">
-                             <number>0</number>
-                            </property>
-                            <property name="topMargin">
-                             <number>0</number>
-                            </property>
-                            <property name="rightMargin">
-                             <number>0</number>
-                            </property>
-                            <property name="bottomMargin">
-                             <number>0</number>
-                            </property>
-                            <item>
-                             <widget class="QLabel" name="mFontMissingLabel">
-                              <property name="sizePolicy">
-                               <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
-                                <horstretch>0</horstretch>
-                                <verstretch>0</verstretch>
-                               </sizepolicy>
-                              </property>
-                              <property name="styleSheet">
-                               <string notr="true">color: #990000;
-font-style: italic;</string>
-                              </property>
-                              <property name="text">
-                               <string>Font is missing.</string>
-                              </property>
-                              <property name="alignment">
-                               <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
-                              </property>
-                             </widget>
-                            </item>
-                           </layout>
-                          </widget>
-                         </item>
-                         <item row="0" column="1">
                           <widget class="QFontComboBox" name="mFontFamilyCmbBx">
                            <property name="editable">
                             <bool>false</bool>
                            </property>
                           </widget>
                          </item>
-                         <item row="5" column="1">
-                          <widget class="QgsUnitSelectionWidget" name="mFontSizeUnitWidget" native="true"/>
+                         <item row="0" column="0">
+                          <widget class="QLabel" name="label_43">
+                           <property name="text">
+                            <string>HTML Labels</string>
+                           </property>
+                          </widget>
+                         </item>
+                         <item row="0" column="1">
+                          <widget class="QCheckBox" name="mRenderAsHTML">
+                           <property name="text">
+                            <string/>
+                           </property>
+                          </widget>
                          </item>
                         </layout>
                        </widget>
@@ -1316,8 +1330,8 @@ font-style: italic;</string>
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>594</width>
-                       <height>398</height>
+                       <width>293</width>
+                       <height>315</height>
                       </rect>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_14">
@@ -1961,8 +1975,8 @@ font-style: italic;</string>
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>594</width>
-                       <height>398</height>
+                       <width>251</width>
+                       <height>210</height>
                       </rect>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_12">
@@ -2340,8 +2354,8 @@ font-style: italic;</string>
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>578</width>
-                       <height>697</height>
+                       <width>372</width>
+                       <height>570</height>
                       </rect>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_21">
@@ -3170,8 +3184,8 @@ font-style: italic;</string>
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>578</width>
-                       <height>424</height>
+                       <width>281</width>
+                       <height>352</height>
                       </rect>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_22">
@@ -3660,8 +3674,8 @@ font-style: italic;</string>
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>578</width>
-                       <height>899</height>
+                       <width>307</width>
+                       <height>758</height>
                       </rect>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_11">
@@ -5274,9 +5288,9 @@ font-style: italic;</string>
                      <property name="geometry">
                       <rect>
                        <x>0</x>
-                       <y>-398</y>
-                       <width>578</width>
-                       <height>799</height>
+                       <y>0</y>
+                       <width>302</width>
+                       <height>668</height>
                       </rect>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_8">


### PR DESCRIPTION
This PR adds support for reading HTML based labels

![image](https://cloud.githubusercontent.com/assets/381660/13425319/b8d7249c-dff1-11e5-9476-9ef13d98d23c.png)

Opened for review

Things to complete:

[ ] Tests
[X] Fix position 
[ ] Disable options not supported with HTML labels
