### PR TITLE
Fix PyQgsServer test on GDAL >= 2.0 and fix handling of longlong types

### DIFF
--- a/src/server/qgswfsprojectparser.cpp
+++ b/src/server/qgswfsprojectparser.cpp
@@ -468,6 +468,8 @@ void QgsWFSProjectParser::describeFeatureType( const QString& aTypeName, QDomEle
           QVariant::Type attributeType = fields[idx].type();
           if ( attributeType == QVariant::Int )
             attElem.setAttribute( "type", "integer" );
+          else if ( attributeType == QVariant::LongLong )
+            attElem.setAttribute( "type", "long" );
           else if ( attributeType == QVariant::Double )
             attElem.setAttribute( "type", "double" );
           else if ( attributeType == QVariant::Bool )

--- a/tests/src/python/test_qgsserver.py
+++ b/tests/src/python/test_qgsserver.py
@@ -21,6 +21,7 @@ from qgis.server import QgsServer
 from qgis.core import QgsMessageLog
 from qgis.testing import unittest
 from utilities import unitTestDataPath
+import osgeo.gdal
 
 # Strip path and content length because path may vary
 RE_STRIP_PATH = r'MAP=[^&]+|Content-Length: \d+'
@@ -163,6 +164,11 @@ class TestQgsServer(unittest.TestCase):
         """
         response = re.sub(RE_STRIP_PATH, '', response)
         expected = re.sub(RE_STRIP_PATH, '', expected)
+
+        # for older GDAL versions (<2.0), id field will be integer type
+        if int(osgeo.gdal.VersionInfo()[:1]) < 2:
+            expected = expected.replace('typeName="Integer64" precision="0" length="10" editType="TextEdit" type="qlonglong"', 'typeName="Integer" precision="0" length="10" editType="TextEdit" type="int"')
+
         self.assertEqual(response, expected, msg="request %s failed.\n Query: %s\n Expected:\n%s\n\n Response:\n%s" % (query_string, request, expected, response))
 
     def test_project_wms(self):
@@ -240,10 +246,15 @@ class TestQgsServer(unittest.TestCase):
         """
         response = re.sub(RE_STRIP_PATH, '', response)
         expected = re.sub(RE_STRIP_PATH, '', expected)
+
+        # for older GDAL versions (<2.0), id field will be integer type
+        if int(osgeo.gdal.VersionInfo()[:1]) < 2:
+            expected = expected.replace('<element type="long" name="id"/>', '<element type="integer" name="id"/>')
+
         self.assertEqual(response, expected, msg="request %s failed.\n Query: %s\n Expected:\n%s\n\n Response:\n%s" % (query_string, request, expected, response))
 
     def test_project_wfs(self):
-        """Test some WMS request"""
+        """Test some WFS request"""
         for request in ('GetCapabilities', 'DescribeFeatureType'):
             self.wfs_request_compare(request)
 

--- a/tests/testdata/qgis_server/getprojectsettings.txt
+++ b/tests/testdata/qgis_server/getprojectsettings.txt
@@ -150,7 +150,7 @@ Content-Type: text/xml; charset=utf-8
     </Style>
     <TreeName>testlayer èé</TreeName>
     <Attributes>
-     <Attribute typeName="Integer" precision="0" length="10" editType="TextEdit" type="int" comment="" name="id"/>
+     <Attribute typeName="Integer64" precision="0" length="10" editType="TextEdit" type="qlonglong" comment="" name="id"/>
      <Attribute typeName="String" precision="0" length="10" editType="TextEdit" type="QString" comment="" name="name"/>
      <Attribute typeName="String" precision="0" length="13" editType="TextEdit" type="QString" comment="" name="utf8nameè"/>
     </Attributes>

--- a/tests/testdata/qgis_server/wfs_describefeaturetype.txt
+++ b/tests/testdata/qgis_server/wfs_describefeaturetype.txt
@@ -9,7 +9,7 @@ Content-Type: text/xml; charset=utf-8
    <extension base="gml:AbstractFeatureType">
     <sequence>
      <element minOccurs="0" maxOccurs="1" type="gml:GeometryPropertyType" name="geometry"/>
-     <element type="integer" name="id"/>
+     <element type="long" name="id"/>
      <element type="string" name="name"/>
      <element type="string" name="utf8nameè"/>
     </sequence>


### PR DESCRIPTION
With GDAL >= 2.0 feature IDs are longlongs, not int. This updates the server test to handle this.

Also includes a fix for handling of longlong types in wfs_describefeaturetype
