### PR TITLE
Add check to make sure minScale<=maxScale.

### DIFF
--- a/python/gui/qgsscalecombobox.sip
+++ b/python/gui/qgsscalecombobox.sip
@@ -17,9 +17,11 @@ class QgsScaleComboBox : QComboBox
     //! Function to set the selected scale from text
     bool setScaleString( const QString& scaleTxt );
     //! Function to read the selected scale as double
-    double scale();
+    double scale() const;
     //! Function to set the selected scale from double
     void setScale( double scale );
+    //! Function to read the min scale
+    double minScale() const;
 
     //! Helper function to convert a double to scale string
     // Performs rounding, so an exact representation is not to
@@ -30,10 +32,12 @@ class QgsScaleComboBox : QComboBox
 
   signals:
     //! Signal is emitted when *user* has finished editing/selecting a new scale.
-    void scaleChanged();
+    void scaleChanged( double scale );
 
   public slots:
     void updateScales( const QStringList &scales = QStringList() );
+    //! Function to set the min scale
+    void setMinScale( double scale );
 
   protected:
     void showPopup();

--- a/python/gui/qgsscalewidget.sip
+++ b/python/gui/qgsscalewidget.sip
@@ -26,9 +26,11 @@ class QgsScaleWidget : QWidget
     //! Function to set the selected scale from text
     bool setScaleString( const QString& scaleTxt );
     //! Function to read the selected scale as double
-    double scale();
+    double scale() const;
     //! Function to set the selected scale from double
     void setScale( double scale );
+    //! Function to read the min scale
+    double minScale() const;
 
     //! Helper function to convert a double to scale string
     // Performs rounding, so an exact representation is not to
@@ -43,9 +45,12 @@ class QgsScaleWidget : QWidget
     //! assign the current scale from the map canvas
     void setScaleFromCanvas();
 
+    //! Function to set the min scale
+    void setMinScale( double scale );
+
   signals:
     //! Signal is emitted when *user* has finished editing/selecting a new scale.
-    void scaleChanged();
+    void scaleChanged( double scale );
 
 
 };

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2057,7 +2057,7 @@ void QgisApp::createStatusBar()
   mScaleEdit->setToolTip( tr( "Current map scale (formatted as x:y)" ) );
 
   statusBar()->addPermanentWidget( mScaleEdit, 0 );
-  connect( mScaleEdit, SIGNAL( scaleChanged() ), this, SLOT( userScale() ) );
+  connect( mScaleEdit, SIGNAL( scaleChanged( double ) ), this, SLOT( userScale() ) );
 
   if ( QgsMapCanvas::rotationEnabled() )
   {

--- a/src/gui/qgsscalecombobox.h
+++ b/src/gui/qgsscalecombobox.h
@@ -36,9 +36,11 @@ class GUI_EXPORT QgsScaleComboBox : public QComboBox
     //! Function to set the selected scale from text
     bool setScaleString( const QString& scaleTxt );
     //! Function to read the selected scale as double
-    double scale();
+    double scale() const;
     //! Function to set the selected scale from double
     void setScale( double scale );
+    //! Function to read the min scale
+    double minScale() const { return mMinScale; }
 
     //! Helper function to convert a double to scale string
     // Performs rounding, so an exact representation is not to
@@ -49,10 +51,12 @@ class GUI_EXPORT QgsScaleComboBox : public QComboBox
 
   signals:
     //! Signal is emitted when *user* has finished editing/selecting a new scale.
-    void scaleChanged();
+    void scaleChanged( double scale );
 
   public slots:
     void updateScales( const QStringList &scales = QStringList() );
+    //! Function to set the min scale
+    void setMinScale( double scale );
 
   protected:
     void showPopup() override;
@@ -62,6 +66,7 @@ class GUI_EXPORT QgsScaleComboBox : public QComboBox
 
   private:
     double mScale;
+    double mMinScale;
 };
 
 #endif // QGSSCALECOMBOBOX_H

--- a/src/gui/qgsscalerangewidget.cpp
+++ b/src/gui/qgsscalerangewidget.cpp
@@ -43,6 +43,7 @@ QgsScaleRangeWidget::QgsScaleRangeWidget( QWidget *parent )
 
   mMinimumScaleWidget = new QgsScaleWidget( this );
   mMaximumScaleWidget = new QgsScaleWidget( this );
+  connect( mMinimumScaleWidget, SIGNAL( scaleChanged( double ) ), mMaximumScaleWidget, SLOT( setMinScale( double ) ) );
   mMinimumScaleWidget->setShowCurrentScaleButton( true );
   mMaximumScaleWidget->setShowCurrentScaleButton( true );
   reloadProjectScales();

--- a/src/gui/qgsscalewidget.cpp
+++ b/src/gui/qgsscalewidget.cpp
@@ -37,7 +37,7 @@ QgsScaleWidget::QgsScaleWidget( QWidget *parent )
   layout->addWidget( mCurrentScaleButton );
   mCurrentScaleButton->hide();
 
-  connect( mScaleComboBox, SIGNAL( scaleChanged() ), this, SIGNAL( scaleChanged() ) );
+  connect( mScaleComboBox, SIGNAL( scaleChanged( double ) ), this, SIGNAL( scaleChanged( double ) ) );
   connect( mCurrentScaleButton, SIGNAL( clicked() ), this, SLOT( setScaleFromCanvas() ) );
 }
 

--- a/src/gui/qgsscalewidget.h
+++ b/src/gui/qgsscalewidget.h
@@ -32,6 +32,8 @@ class GUI_EXPORT QgsScaleWidget : public QWidget
 {
     Q_OBJECT
     Q_PROPERTY( bool showCurrentScaleButton READ showCurrentScaleButton WRITE setShowCurrentScaleButton )
+    Q_PROPERTY( bool scale READ scale WRITE setScale NOTIFY scaleChanged )
+    Q_PROPERTY( bool minScale READ minScale WRITE setMinScale )
 
   public:
     explicit QgsScaleWidget( QWidget *parent = nullptr );
@@ -51,9 +53,11 @@ class GUI_EXPORT QgsScaleWidget : public QWidget
     //! Function to set the selected scale from text
     bool setScaleString( const QString& scaleTxt ) { return mScaleComboBox->setScaleString( scaleTxt ); }
     //! Function to read the selected scale as double
-    double scale() { return mScaleComboBox->scale();}
+    double scale() const { return mScaleComboBox->scale();}
     //! Function to set the selected scale from double
     void setScale( double scale ) { return mScaleComboBox->setScale( scale ); }
+    //! Function to read the min scale
+    double minScale() const { return mScaleComboBox->minScale(); }
 
     //! Helper function to convert a double to scale string
     // Performs rounding, so an exact representation is not to
@@ -68,9 +72,12 @@ class GUI_EXPORT QgsScaleWidget : public QWidget
     //! assign the current scale from the map canvas
     void setScaleFromCanvas();
 
+    //! Function to set the min scale
+    void setMinScale( double scale ) { mScaleComboBox->setMinScale( scale ); }
+
   signals:
     //! Signal is emitted when *user* has finished editing/selecting a new scale.
-    void scaleChanged();
+    void scaleChanged( double scale );
 
   private:
     QgsScaleComboBox* mScaleComboBox;

--- a/src/gui/qgsunitselectionwidget.cpp
+++ b/src/gui/qgsunitselectionwidget.cpp
@@ -28,8 +28,9 @@ QgsMapUnitScaleDialog::QgsMapUnitScaleDialog( QWidget* parent )
   mSpinBoxMaxSize->setShowClearButton( false );
   connect( mCheckBoxMinScale, SIGNAL( toggled( bool ) ), this, SLOT( configureMinComboBox() ) );
   connect( mCheckBoxMaxScale, SIGNAL( toggled( bool ) ), this, SLOT( configureMaxComboBox() ) );
-  connect( mComboBoxMinScale, SIGNAL( scaleChanged() ), this, SLOT( configureMaxComboBox() ) );
-  connect( mComboBoxMaxScale, SIGNAL( scaleChanged() ), this, SLOT( configureMinComboBox() ) );
+  connect( mComboBoxMinScale, SIGNAL( scaleChanged( double ) ), this, SLOT( configureMaxComboBox() ) );
+  connect( mComboBoxMinScale, SIGNAL( scaleChanged( double ) ), mComboBoxMaxScale, SLOT( setMinScale( double ) ) );
+  connect( mComboBoxMaxScale, SIGNAL( scaleChanged( double ) ), this, SLOT( configureMinComboBox() ) );
 
   connect( mCheckBoxMinSize, SIGNAL( toggled( bool ) ), mSpinBoxMinSize, SLOT( setEnabled( bool ) ) );
   connect( mCheckBoxMaxSize, SIGNAL( toggled( bool ) ), mSpinBoxMaxSize, SLOT( setEnabled( bool ) ) );


### PR DESCRIPTION
Those two fields are present in the vector layer properties. It
was possible to set a minScale bigger than the maxScale.
Now, the maxScale is forced to minScale if the user tries to
set it to a lower value.
