### PR TITLE
Fix out of bounds array access if nextVertex is called on empty geometry collection

### DIFF
--- a/src/core/geometry/qgsgeometrycollectionv2.cpp
+++ b/src/core/geometry/qgsgeometrycollectionv2.cpp
@@ -374,6 +374,10 @@ bool QgsGeometryCollectionV2::nextVertex( QgsVertexId& id, QgsPointV2& vertex ) 
     id.ring = -1;
     id.vertex = -1;
   }
+  if ( mGeometries.isEmpty() )
+  {
+    return false;
+  }
 
   QgsAbstractGeometryV2* geom = mGeometries.at( id.part );
   if ( geom->nextVertex( id, vertex ) )

--- a/tests/src/core/testqgsgeometry.cpp
+++ b/tests/src/core/testqgsgeometry.cpp
@@ -34,6 +34,7 @@
 #include "qgslinestringv2.h"
 #include "qgspolygonv2.h"
 #include "qgscircularstringv2.h"
+#include "qgsgeometrycollectionv2.h"
 
 //qgs unit test utility class
 #include "qgsrenderchecker.h"
@@ -360,6 +361,9 @@ void TestQgsGeometry::isEmpty()
 
   geom.setGeometry( 0 );
   QVERIFY( geom.isEmpty() );
+
+  QgsGeometryCollectionV2 collection;
+  QVERIFY( collection.isEmpty() );
 }
 
 void TestQgsGeometry::pointV2()


### PR DESCRIPTION
Fixes a geometry checker crash reported in #13535.
