### PR TITLE
processing: fix GRASS7 v.buffer.column

### DIFF
--- a/python/plugins/processing/algs/grass7/description/v.buffer.column.txt
+++ b/python/plugins/processing/algs/grass7/description/v.buffer.column.txt
@@ -1,6 +1,7 @@
 v.buffer
 v.buffer.column - Creates a buffer around features of given type.
 Vector (v.*)
+Hardcoded|layer=1
 ParameterVector|input|Input vector layer|-1|False
 ParameterTableField|column|Name of column to use for buffer distances|input|-1|False
 ParameterNumber|scale|Scaling factor for attribute column values|None|None|1.0


### PR DESCRIPTION
GRASS7 v.buffer (derived from v.buffer2, not from GRASS64 v.buffer) MUST have the "layer" specified when using the parameter "column".
