### PR TITLE
QgsVectorLayerRenderer::drawRendererV2(): make it cancellable in all …

### DIFF
--- a/src/core/qgsvectorlayerrenderer.cpp
+++ b/src/core/qgsvectorlayerrenderer.cpp
@@ -295,14 +295,14 @@ void QgsVectorLayerRenderer::drawRendererV2( QgsFeatureIterator& fit )
   {
     try
     {
-      if ( !fet.constGeometry() )
-        continue; // skip features without geometry
-
       if ( mContext.renderingStopped() )
       {
         QgsDebugMsg( QString( "Drawing of vector layer %1 cancelled." ).arg( layerID() ) );
         break;
       }
+
+      if ( !fet.constGeometry() )
+        continue; // skip features without geometry
 
       mContext.expressionContext().setFeature( fet );
 


### PR DESCRIPTION
…situations

Currently the mContext.renderingStopped() check is done only if the feature
has a geometry. Which makes it possible to have really really long loops if
a long series of features without geometries are returned by the feature iterator.
This is perhaps not something that can happen in practice, but I hit that issue
when prototyping my WFS asynchronous feature downloading that currently only returns
dummy features. QGIS was completely blocked due to the iterator returning infinite
geometry-less features.
