### PR TITLE
[Processing] Fix TypeError in Zonal Statistics algorithm

### DIFF
--- a/python/plugins/processing/tools/raster.py
+++ b/python/plugins/processing/tools/raster.py
@@ -64,8 +64,14 @@ def scanraster(layer, progress):
 
 
 def mapToPixel(mX, mY, geoTransform):
-    (pX, pY) = gdal.ApplyGeoTransform(
-        gdal.InvGeoTransform(geoTransform)[1], mX, mY)
+    try:
+        # GDAL 1.x
+        (pX, pY) = gdal.ApplyGeoTransform(
+            gdal.InvGeoTransform(geoTransform)[1], mX, mY)
+    except TypeError:
+        # GDAL 2.x
+        (pX, pY) = gdal.ApplyGeoTransform(
+            gdal.InvGeoTransform(geoTransform), mX, mY)
     return (int(pX), int(pY))
 
 


### PR DESCRIPTION
Fixes #14412

Should also fix problems in other algorithms which use mapToPixel: PointsFromLines, PointsFromPolygons, HypsometricCurves

It might be good to include this fix in next 2.14.x release.
