### PR TITLE
Scale based layer visibility cosmetics

### DIFF
--- a/python/core/layertree/qgslayertreemodel.sip
+++ b/python/core/layertree/qgslayertreemodel.sip
@@ -230,6 +230,7 @@ class QgsLayerTreeModel : QAbstractItemModel
 
     //! emit dataChanged() for layer tree node items
     void recursivelyEmitDataChanged( const QModelIndex& index = QModelIndex() );
+    void refreshScaleBasedLayers( const QModelIndex& index = QModelIndex() );
 
     static const QIcon& iconGroup();
 

--- a/python/core/qgis.sip
+++ b/python/core/qgis.sip
@@ -235,6 +235,12 @@ class QGis
     /** Default highlight line/outline minimum width in mm.
      *  @note added in 2.3 */
     static double DEFAULT_HIGHLIGHT_MIN_WIDTH_MM;
+
+    /** Fudge factor used to compare two scales. The code is often going from scale to scale
+     *  denominator. So it looses precision and, when a limit is inclusive, can lead to errors.
+     *  To avoid that, use this factor instead of using <= or >=.
+     * @note added in 2.15*/
+    static double SCALE_PRECISION;
 };
 
 

--- a/python/core/qgslabel.sip
+++ b/python/core/qgslabel.sip
@@ -106,6 +106,9 @@ class QgsLabel
     void setScaleBasedVisibility( bool theVisibilityFlag );
     bool scaleBasedVisibility() const;
 
+    /** Return true if the label is visible at the given scale */
+    bool isInScaleRange( double scale ) const;
+
   private:
     QgsLabel (); // pretend that constructor is private for now
     QgsLabel( const QgsLabel& rh );

--- a/python/core/qgsmaplayer.sip
+++ b/python/core/qgsmaplayer.sip
@@ -492,6 +492,11 @@ class QgsMapLayer : QObject
      */
     QgsMapLayerStyleManager* styleManager() const;
 
+    /**
+     * @returns true if the layer is visible at the given scale.
+     */
+    bool isInScaleRange( double scale ) const;
+
     /** Returns the minimum scale denominator at which the layer is visible.
      * Scale based visibility is only used if hasScaleBasedVisibility is true.
      * @returns minimum scale denominator at which the layer will render

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -7938,6 +7938,31 @@ void QgisApp::setLayerScaleVisibility()
   delete dlg;
 }
 
+void QgisApp::zoomToLayerScale()
+{
+  if ( !mLayerTreeView )
+    return;
+
+  QList<QgsMapLayer*> layers = mLayerTreeView->selectedLayers();
+
+  if ( layers.length() < 1 )
+    return;
+
+  QgsMapLayer* layer = mLayerTreeView->currentLayer();
+  if ( layer && layer->hasScaleBasedVisibility() )
+  {
+    const double scale = mMapCanvas->scale();
+    if ( scale > layer->maximumScale() )
+    {
+      mMapCanvas->zoomScale( layer->maximumScale() * QGis::SCALE_PRECISION );
+    }
+    else if ( scale <= layer->minimumScale() )
+    {
+      mMapCanvas->zoomScale( layer->minimumScale() );
+    }
+  }
+}
+
 void QgisApp::setLayerCRS()
 {
   if ( !( mLayerTreeView && mLayerTreeView->currentLayer() ) )

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -744,6 +744,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     void duplicateLayers( const QList<QgsMapLayer *>& lyrList = QList<QgsMapLayer *>() );
     //! Set Scale visibility of selected layers
     void setLayerScaleVisibility();
+    void zoomToLayerScale();
     //! Set CRS of a layer
     void setLayerCRS();
     //! Assign layer CRS to project

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -11,6 +11,7 @@
 #include "qgslayertreemodel.h"
 #include "qgslayertreemodellegendnode.h"
 #include "qgslayertreeviewdefaultactions.h"
+#include "qgsmapcanvas.h"
 #include "qgsmaplayerstyleguiutils.h"
 #include "qgsmaplayerregistry.h"
 #include "qgsproject.h"
@@ -104,6 +105,9 @@ QMenu* QgsAppLayerTreeViewMenuProvider::createContextMenu()
       {
         // set layer scale visibility
         menu->addAction( tr( "&Set Layer Scale Visibility" ), QgisApp::instance(), SLOT( setLayerScaleVisibility() ) );
+
+        if ( !vlayer->isInScaleRange( mCanvas->scale() ) )
+          menu->addAction( tr( "&Zoom to Layer Scale" ), QgisApp::instance(), SLOT( zoomToLayerScale() ) );
 
         // set layer crs
         menu->addAction( QgsApplication::getThemeIcon( "/mActionSetCRS.png" ), tr( "&Set Layer CRS" ), QgisApp::instance(), SLOT( setLayerCRS() ) );

--- a/src/core/dxf/qgsdxfexport.cpp
+++ b/src/core/dxf/qgsdxfexport.cpp
@@ -4109,11 +4109,10 @@ bool QgsDxfExport::layerIsScaleBasedVisible( const QgsMapLayer* layer ) const
   if ( !layer )
     return false;
 
-  if ( mSymbologyExport == QgsDxfExport::NoSymbology || !layer->hasScaleBasedVisibility() )
+  if ( mSymbologyExport == QgsDxfExport::NoSymbology )
     return true;
 
-  return layer->minimumScale() < mSymbologyScaleDenominator &&
-         layer->maximumScale() > mSymbologyScaleDenominator;
+  return layer->isInScaleRange( mSymbologyScaleDenominator );
 }
 
 QString QgsDxfExport::layerName( const QString &id, const QgsFeature &f ) const

--- a/src/core/layertree/qgslayertreemodel.h
+++ b/src/core/layertree/qgslayertreemodel.h
@@ -254,6 +254,8 @@ class CORE_EXPORT QgsLayerTreeModel : public QAbstractItemModel
 
     //! emit dataChanged() for layer tree node items
     void recursivelyEmitDataChanged( const QModelIndex& index = QModelIndex() );
+    //! emit dataChanged() for scale dependent layers
+    void refreshScaleBasedLayers( const QModelIndex& index = QModelIndex() );
 
     static const QIcon& iconGroup();
 

--- a/src/core/qgis.cpp
+++ b/src/core/qgis.cpp
@@ -87,6 +87,8 @@ double QGis::DEFAULT_HIGHLIGHT_BUFFER_MM = 0.5;
 
 double QGis::DEFAULT_HIGHLIGHT_MIN_WIDTH_MM = 1.0;
 
+double QGis::SCALE_PRECISION = 0.9999999999;
+
 // description strings for units
 // Order must match enum indices
 const char* QGis::qgisUnitTypes[] =

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -246,6 +246,12 @@ class CORE_EXPORT QGis
      *  @note added in 2.3 */
     static double DEFAULT_HIGHLIGHT_MIN_WIDTH_MM;
 
+    /** Fudge factor used to compare two scales. The code is often going from scale to scale
+     *  denominator. So it looses precision and, when a limit is inclusive, can lead to errors.
+     *  To avoid that, use this factor instead of using <= or >=.
+     * @note added in 2.15*/
+    static double SCALE_PRECISION;
+
   private:
     // String representation of unit types (set in qgis.cpp)
     static const char *qgisUnitTypes[];

--- a/src/core/qgslabel.cpp
+++ b/src/core/qgslabel.cpp
@@ -1414,3 +1414,9 @@ float QgsLabel::maxScale() const
 {
   return mMaxScale;
 }
+
+bool QgsLabel::isInScaleRange( double scale ) const
+{
+  return !mScaleBasedVisibility ||
+         ( mMinScale * QGis::SCALE_PRECISION < scale && scale * QGis::SCALE_PRECISION < mMaxScale );
+}

--- a/src/core/qgslabel.h
+++ b/src/core/qgslabel.h
@@ -146,6 +146,9 @@ class CORE_EXPORT QgsLabel
     void setScaleBasedVisibility( bool theVisibilityFlag );
     bool scaleBasedVisibility() const;
 
+    /** Return true if the label is visible at the given scale */
+    bool isInScaleRange( double scale ) const;
+
   private:
     /** Does the actual rendering of a label at the given point */
     void renderLabel( QgsRenderContext &renderContext, QgsPoint point,

--- a/src/core/qgsmaphittest.cpp
+++ b/src/core/qgsmaphittest.cpp
@@ -59,7 +59,7 @@ void QgsMapHitTest::run()
 
     if ( !mOnlyExpressions )
     {
-      if ( vl->hasScaleBasedVisibility() && ( mSettings.scale() < vl->minimumScale() || mSettings.scale() > vl->maximumScale() ) )
+      if ( !vl->isInScaleRange( mSettings.scale() ) )
       {
         mHitTest[vl] = SymbolV2Set(); // no symbols -> will not be shown
         mHitTestRuleKey[vl] = SymbolV2Set();

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -925,6 +925,10 @@ void QgsMapLayer::connectNotify( const char * signal )
 } //  QgsMapLayer::connectNotify
 #endif
 
+bool QgsMapLayer::isInScaleRange( double scale ) const
+{
+  return !mScaleBasedVisibility || ( mMinScale * QGis::SCALE_PRECISION < scale && scale < mMaxScale );
+}
 
 void QgsMapLayer::toggleScaleBasedVisibility( bool theVisibilityFlag )
 {

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -511,6 +511,11 @@ class CORE_EXPORT QgsMapLayer : public QObject
      */
     QgsMapLayerStyleManager* styleManager() const;
 
+    /**
+     * @returns true if the layer is visible at the given scale.
+     */
+    bool isInScaleRange( double scale ) const;
+
     /** Returns the minimum scale denominator at which the layer is visible.
      * Scale based visibility is only used if hasScaleBasedVisibility is true.
      * @returns minimum scale denominator at which the layer will render

--- a/src/core/qgsmaprenderer.cpp
+++ b/src/core/qgsmaprenderer.cpp
@@ -394,7 +394,7 @@ void QgsMapRenderer::render( QPainter* painter, double* forceWidthScale )
       mypContextPainter->setCompositionMode( ml->blendMode() );
     }
 
-    if ( !ml->hasScaleBasedVisibility() || ( ml->minimumScale() <= mScale && mScale < ml->maximumScale() ) || mOverview )
+    if ( ml->isInScaleRange( mScale ) || mOverview )
     {
       connect( ml, SIGNAL( drawingProgress( int, int ) ), this, SLOT( onDrawingProgress( int, int ) ) );
 
@@ -584,7 +584,7 @@ void QgsMapRenderer::render( QPainter* painter, double* forceWidthScale )
       {
         // only make labels if the layer is visible
         // after scale dep viewing settings are checked
-        if ( !ml->hasScaleBasedVisibility() || ( ml->minimumScale() < mScale && mScale < ml->maximumScale() ) )
+        if ( ml->isInScaleRange( mScale ) )
         {
           bool split = false;
 

--- a/src/core/qgsmaprenderercustompainterjob.cpp
+++ b/src/core/qgsmaprenderercustompainterjob.cpp
@@ -332,7 +332,7 @@ void QgsMapRendererJob::drawOldLabeling( const QgsMapSettings& settings, QgsRend
 
     // only make labels if the layer is visible
     // after scale dep viewing settings are checked
-    if ( ml->hasScaleBasedVisibility() && ( settings.scale() < ml->minimumScale() || settings.scale() > ml->maximumScale() ) )
+    if ( !ml->isInScaleRange( settings.scale() ) )
       continue;
 
     const QgsCoordinateTransform* ct = nullptr;

--- a/src/core/qgsmaprendererjob.cpp
+++ b/src/core/qgsmaprendererjob.cpp
@@ -207,7 +207,7 @@ LayerRenderJobs QgsMapRendererJob::prepareJobs( QPainter* painter, QgsPalLabelin
                  .arg( ml->blendMode() )
                );
 
-    if ( ml->hasScaleBasedVisibility() && ( mSettings.scale() < ml->minimumScale() || mSettings.scale() > ml->maximumScale() ) ) //|| mOverview )
+    if ( !ml->isInScaleRange( mSettings.scale() ) ) //|| mOverview )
     {
       QgsDebugMsg( "Layer not rendered because it is not within the defined visibility scale range" );
       continue;

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -320,9 +320,7 @@ void QgsVectorLayer::drawLabels( QgsRenderContext& rendererContext )
   QgsDebugMsg( "Starting draw of labels: " + id() );
 
   if ( mRendererV2 && mLabelOn && mLabel &&
-       ( !mLabel->scaleBasedVisibility() ||
-         ( mLabel->minScale() <= rendererContext.rendererScale() &&
-           rendererContext.rendererScale() <= mLabel->maxScale() ) ) )
+       mLabel->isInScaleRange( rendererContext.rendererScale() ) )
   {
     QgsAttributeList attributes;
     Q_FOREACH ( const QString& attrName, mRendererV2->usedAttributes() )

--- a/src/gui/attributetable/qgsattributetablefiltermodel.cpp
+++ b/src/gui/attributetable/qgsattributetablefiltermodel.cpp
@@ -245,9 +245,7 @@ void QgsAttributeTableFilterModel::generateListOfVisibleFeatures()
   }
 
   const QgsMapSettings& ms = mCanvas->mapSettings();
-  if ( layer()->hasScaleBasedVisibility() &&
-       ( layer()->minimumScale() > ms.scale() ||
-         layer()->maximumScale() <= ms.scale() ) )
+  if ( !layer()->isInScaleRange( ms.scale() ) )
   {
     QgsDebugMsg( "Out of scale limits" );
   }

--- a/src/gui/qgsmaptoolidentify.cpp
+++ b/src/gui/qgsmaptoolidentify.cpp
@@ -200,9 +200,7 @@ bool QgsMapToolIdentify::identifyVectorLayer( QList<IdentifyResult> *results, Qg
   if ( !layer || !layer->hasGeometryType() )
     return false;
 
-  if ( layer->hasScaleBasedVisibility() &&
-       ( layer->minimumScale() > mCanvas->mapSettings().scale() ||
-         layer->maximumScale() <= mCanvas->mapSettings().scale() ) )
+  if ( !layer->isInScaleRange( mCanvas->mapSettings().scale() ) )
   {
     QgsDebugMsg( "Out of scale limits" );
     return false;


### PR DESCRIPTION
Made layers/labels visibility more consistent.
Make out of range layers greyed out in the tree.
Add a menu entry to zoom to a layer's scale range.
