### PR TITLE
Fix extension removal in exportVectorLayer

### DIFF
--- a/python/plugins/processing/algs/grass/GrassAlgorithm.py
+++ b/python/plugins/processing/algs/grass/GrassAlgorithm.py
@@ -465,7 +465,7 @@ class GrassAlgorithm(GeoAlgorithm):
         snap = self.getParameterValue(self.GRASS_SNAP_TOLERANCE_PARAMETER)
         command += ' snap=' + unicode(snap)
         command += ' dsn="%s"' % os.path.dirname(filename)
-        command += ' layer="%s"' % os.path.splitext(os.path.basename(filename)[:-4])[0]
+        command += ' layer="%s"' % os.path.basename(filename)[:-4]
         command += ' output=' + destFilename
         command += ' --overwrite -o'
         return command


### PR DESCRIPTION
Taking the [:-4] slice from basename and splitext() try to do the same thing. Usually splitext() was failing silently, but if you're using the iterating function of processing, you can have filenames like [timestamp].[sequenceno].shp, which makes it cut off the sequencenumber and makes the OGR import fail.

I've left only the [:-4] slice because we check whether the file ends with .shp above anyway. This is also the way the grass7 file does it.
