### PR TITLE
Add Qt5OpenGL variables to include_directories() & target_link_libraries()

### DIFF
--- a/src/plugins/globe/CMakeLists.txt
+++ b/src/plugins/globe/CMakeLists.txt
@@ -55,6 +55,7 @@ QT4_ADD_RESOURCES(globe_plugin_RCC_SRCS ${globe_plugin_RCCS})
 ADD_LIBRARY (globeplugin MODULE ${globe_plugin_SRCS} ${globe_plugin_MOC_SRCS} ${globe_plugin_RCC_SRCS} ${globe_plugin_UIS_H})
 
 INCLUDE_DIRECTORIES(SYSTEM
+     ${Qt5OpenGL_INCLUDE_DIRS}
      ${OSGEARTH_INCLUDE_DIR}
      ${OSG_INCLUDE_DIR}
      ${GEOS_INCLUDE_DIR}
@@ -82,6 +83,7 @@ TARGET_LINK_LIBRARIES(globeplugin
   qgis_core
   qgis_gui
   ${QT_QTOPENGL_LIBRARY}
+  ${Qt5OpenGL_LIBRARIES}
   ${OSGDB_LIBRARY}
   ${OSGGA_LIBRARY}
   ${OSGUTIL_LIBRARY}


### PR DESCRIPTION
Fixes globe plugin build failure with Qt5 as recently [discussed on the Debian GIS list](https://lists.debian.org/debian-gis/2016/03/msg00007.html).
