### PR TITLE
add supportPython3 option to plugin metadata, and disable incompatible plugins

### DIFF
--- a/python/pyplugin_installer/installer_data.py
+++ b/python/pyplugin_installer/installer_data.py
@@ -450,6 +450,9 @@ class Repositories(QObject):
                         "library": "",
                         "readonly": False
                     }
+                    supportPython3 = pluginNodes.item(i).firstChildElement("support_python3").text().strip()
+                    if not supportPython3:
+                        supportPython3 = False
                     qgisMinimumVersion = pluginNodes.item(i).firstChildElement("qgis_minimum_version").text().strip()
                     if not qgisMinimumVersion:
                         qgisMinimumVersion = "2"
@@ -458,7 +461,7 @@ class Repositories(QObject):
                         qgisMaximumVersion = qgisMinimumVersion[0] + ".99"
                     #if compatible, add the plugin to the list
                     if not pluginNodes.item(i).firstChildElement("disabled").text().strip().upper() in ["TRUE", "YES"]:
-                        if isCompatible(QGis.QGIS_VERSION, qgisMinimumVersion, qgisMaximumVersion):
+                        if isCompatible(QGis.QGIS_VERSION, qgisMinimumVersion, qgisMaximumVersion, supportPython3):
                             #add the plugin to the cache
                             plugins.addFromRepository(plugin)
                 self.mRepositories[reposName]["state"] = 2
@@ -599,6 +602,9 @@ class Plugins(QObject):
             version = normalizeVersion(pluginMetadata("version"))
 
         if version:
+            supportPython3 = pluginMetadata("supportPython3").strip()
+            if not supportPython3:
+                supportPython3 = False
             qgisMinimumVersion = pluginMetadata("qgisMinimumVersion").strip()
             if not qgisMinimumVersion:
                 qgisMinimumVersion = "0"
@@ -606,7 +612,7 @@ class Plugins(QObject):
             if not qgisMaximumVersion:
                 qgisMaximumVersion = qgisMinimumVersion[0] + ".99"
             #if compatible, add the plugin to the list
-            if not isCompatible(QGis.QGIS_VERSION, qgisMinimumVersion, qgisMaximumVersion):
+            if not isCompatible(QGis.QGIS_VERSION, qgisMinimumVersion, qgisMaximumVersion, supportPython3):
                 error = "incompatible"
                 errorDetails = "%s - %s" % (qgisMinimumVersion, qgisMaximumVersion)
             elif testLoad:

--- a/python/pyplugin_installer/installer_data.py
+++ b/python/pyplugin_installer/installer_data.py
@@ -450,9 +450,19 @@ class Repositories(QObject):
                         "library": "",
                         "readonly": False
                     }
-                    supportPython3 = pluginNodes.item(i).firstChildElement("support_python3").text().strip()
-                    if not supportPython3:
-                        supportPython3 = False
+
+					supportPython2 = pluginNodes.item(i).firstChildElement("supportPython2").text().strip()
+					supportPython3 = pluginNodes.item(i).firstChildElement("supportPython3").text().strip()
+					# python3 support is False by default
+					# python2 support is True by default, but False by default if python3 is supported
+					if not supportPython3:
+						supportPython3 = False
+					else:
+						if not supportPython2:
+							supportPython2 = False
+					if not supportPython2:
+						supportPython2 = True
+
                     qgisMinimumVersion = pluginNodes.item(i).firstChildElement("qgis_minimum_version").text().strip()
                     if not qgisMinimumVersion:
                         qgisMinimumVersion = "2"
@@ -461,7 +471,7 @@ class Repositories(QObject):
                         qgisMaximumVersion = qgisMinimumVersion[0] + ".99"
                     #if compatible, add the plugin to the list
                     if not pluginNodes.item(i).firstChildElement("disabled").text().strip().upper() in ["TRUE", "YES"]:
-                        if isCompatible(QGis.QGIS_VERSION, qgisMinimumVersion, qgisMaximumVersion, supportPython3):
+                        if isCompatible(QGis.QGIS_VERSION, qgisMinimumVersion, qgisMaximumVersion, supportPython2, supportPython3):
                             #add the plugin to the cache
                             plugins.addFromRepository(plugin)
                 self.mRepositories[reposName]["state"] = 2
@@ -602,9 +612,18 @@ class Plugins(QObject):
             version = normalizeVersion(pluginMetadata("version"))
 
         if version:
+            supportPython2 = pluginMetadata("supportPython2").strip()
             supportPython3 = pluginMetadata("supportPython3").strip()
+            # python3 support is False by default
+            # python2 support is True by default, but False by default if python3 is supported
             if not supportPython3:
                 supportPython3 = False
+            else:
+				if not supportPython2:
+					supportPython2 = False
+			if not supportPython2:
+				supportPython2 = True
+
             qgisMinimumVersion = pluginMetadata("qgisMinimumVersion").strip()
             if not qgisMinimumVersion:
                 qgisMinimumVersion = "0"
@@ -612,7 +631,7 @@ class Plugins(QObject):
             if not qgisMaximumVersion:
                 qgisMaximumVersion = qgisMinimumVersion[0] + ".99"
             #if compatible, add the plugin to the list
-            if not isCompatible(QGis.QGIS_VERSION, qgisMinimumVersion, qgisMaximumVersion, supportPython3):
+            if not isCompatible(QGis.QGIS_VERSION, qgisMinimumVersion, qgisMaximumVersion, supportPython2, supportPython3):
                 error = "incompatible"
                 errorDetails = "%s - %s" % (qgisMinimumVersion, qgisMaximumVersion)
             elif testLoad:

--- a/python/pyplugin_installer/version_compare.py
+++ b/python/pyplugin_installer/version_compare.py
@@ -171,7 +171,7 @@ def splitVersion(s):
     return l
 
 
-def isCompatible(curVer, minVer, maxVer, supportPython3=False):
+def isCompatible(curVer, minVer, maxVer, supportPython2=True, supportPython3=False):
     """ Compare current QGIS version with qgisMinVersion and qgisMaxVersion """
 
     if not minVer or not curVer or not maxVer:
@@ -196,5 +196,11 @@ def isCompatible(curVer, minVer, maxVer, supportPython3=False):
     minVer = "%04d%04d%04d" % (int(minVer[0]), int(minVer[1]), int(minVer[2]))
     maxVer = "%04d%04d%04d" % (int(maxVer[0]), int(maxVer[1]), int(maxVer[2]))
     curVer = "%04d%04d%04d" % (int(curVer[0]), int(curVer[1]), int(curVer[2]))
+    
+    if ( sys.version_info[0] < 3 and not supportPython2 )
+		return False
+		
+    if ( sys.version_info[0] == 3 and not supportPython3 )
+		return False
 
-    return (minVer <= curVer and maxVer >= curVer and (supportPython3 or sys.version_info[0] < 3))
+    return minVer <= curVer and maxVer >= curVer

--- a/python/pyplugin_installer/version_compare.py
+++ b/python/pyplugin_installer/version_compare.py
@@ -47,6 +47,7 @@ ALPHA, BETA, RC, PREVIEW and TRUNK which make the version number lower.
 """
 
 import re
+import sys
 
 # ------------------------------------------------------------------------ #
 
@@ -170,7 +171,7 @@ def splitVersion(s):
     return l
 
 
-def isCompatible(curVer, minVer, maxVer):
+def isCompatible(curVer, minVer, maxVer, supportPython3=False):
     """ Compare current QGIS version with qgisMinVersion and qgisMaxVersion """
 
     if not minVer or not curVer or not maxVer:
@@ -196,4 +197,4 @@ def isCompatible(curVer, minVer, maxVer):
     maxVer = "%04d%04d%04d" % (int(maxVer[0]), int(maxVer[1]), int(maxVer[2]))
     curVer = "%04d%04d%04d" % (int(curVer[0]), int(curVer[1]), int(curVer[2]))
 
-    return (minVer <= curVer and maxVer >= curVer)
+    return (minVer <= curVer and maxVer >= curVer and (supportPython3 or sys.version_info[0] < 3))


### PR DESCRIPTION
Here is an idea on how to support existing plugins while running QGIS built with Qt5/Py3.

The idea is to have a new tag that tells if the plugin supports Python 3 or not, which would be false by default.

I suppose this would require the update of the plugin repository website code, but I don't have access to it.

Any opinion @m-kuhn @borysiasty @NathanW2 ?
