### PR TITLE
Minor refactor of QgsDiagramLayerSettings

### DIFF
--- a/python/core/qgsdiagramrendererv2.sip
+++ b/python/core/qgsdiagramrendererv2.sip
@@ -1,8 +1,17 @@
-struct QgsDiagramLayerSettings
+/** \ingroup core
+ * \class QgsDiagramLayerSettings
+ * \brief Stores the settings for rendering of all diagrams for a layer.
+ *
+ * QgsDiagramSettings stores the settings related to rendering the individual diagrams themselves, while
+ * QgsDiagramLayerSettings stores settings which control how ALL diagrams within a layer are rendered.
+ */
+
+class QgsDiagramLayerSettings
 {
 %TypeHeaderCode
 #include <qgsdiagramrendererv2.h>
 %End
+
   public:
     //avoid inclusion of QgsPalLabeling
     enum Placement
@@ -15,6 +24,7 @@ struct QgsDiagramLayerSettings
       Free // Polygon
     };
 
+    //! Line placement flags for controlling line based placements
     enum LinePlacementFlags
     {
       OnLine,
@@ -24,36 +34,226 @@ struct QgsDiagramLayerSettings
     };
 
     QgsDiagramLayerSettings();
+
+    //! Copy constructor
     QgsDiagramLayerSettings( const QgsDiagramLayerSettings& rh );
 
     ~QgsDiagramLayerSettings();
 
-    //pal placement properties
+    /** Returns the diagram placement.
+     * @see setPlacement()
+     * @note added in QGIS 2.16
+     */
+    //TODO QGIS 3.0 - rename getter to placement()
+    Placement getPlacement() const;
+
+    /** Sets the diagram placement.
+     * @param value placement value
+     * @see getPlacement()
+     * @note added in QGIS 2.16
+     */
+    void setPlacement( Placement value );
+
+    //! Diagram placement
+    //TODO QGIS 3.0 - make private, rename to mPlacement
     Placement placement;
+
+    /** Returns the diagram placement flags. These are only used if the diagram placement
+     * is set to a line type.
+     * @see setLinePlacementFlags()
+     * @note added in QGIS 2.16
+     */
+    unsigned int linePlacementFlags() const;
+
+    /** Sets the the diagram placement flags. These are only used if the diagram placement
+     * is set to a line type.
+     * @param value placement value
+     * @see getPlacement()
+     * @note added in QGIS 2.16
+     */
+    void setLinePlacementFlags( unsigned int flags );
+
+    //! Diagram placement flags
+    // TODO QGIS 3.0 - make private, rename to mPlacementFlags, use QFlags
     unsigned int placementFlags;
-    int priority; // 0 = low, 10 = high
+
+    /** Returns the diagram priority.
+     * @returns diagram priority, where 0 = low and 10 = high
+     * @note placement priority is shared with labeling, so diagrams with a high priority may displace labels
+     * and vice-versa
+     * @see setPriority()
+     * @note added in QGIS 2.16
+     */
+    //TODO QGIS 3.0 - rename getter to priority()
+    int getPriority() const;
+
+    /** Sets the diagram priority.
+     * @param value priority, where 0 = low and 10 = high
+     * @see getPriority()
+     * @note added in QGIS 2.16
+     */
+    void setPriority( int value );
+
+    //! Placement priority, where 0 = low and 10 = high
+    //! @note placement priority is shared with labeling, so diagrams with a high priority may displace labels
+    //! and vice-versa
+    // TODO QGIS 3.0 - make private, rename to mPriority
+    int priority;
+
+    /** Returns the diagram z-index. Diagrams (or labels) with a higher z-index are drawn over diagrams
+     * with a lower z-index.
+     * @note z-index ordering is shared with labeling, so diagrams with a high z-index may be drawn over labels
+     * with a low z-index and vice-versa
+     * @see setZIndex()
+     * @note added in QGIS 2.16
+     */
+    //TODO QGIS 3.0 - rename getter to zIndex()
+    double getZIndex() const;
+
+    /** Sets the diagram z-index. Diagrams (or labels) with a higher z-index are drawn over diagrams
+     * with a lower z-index.
+     * @param index diagram z-index
+     * @see getZIndex()
+     * @note added in QGIS 2.16
+     */
+    void setZIndex( double index );
 
     //! Z-index of diagrams, where diagrams with a higher z-index are drawn on top of diagrams with a lower z-index
+    // TODO QGIS 3.0 - rename to mZIndex, make private
     double zIndex;
 
-    bool obstacle; // whether it's an obstacle
-    double dist; // distance from the feature (in mm)
-    QgsDiagramRendererV2* renderer; // if any renderer is assigned, it is owned by this class
+    /** Returns whether the feature associated with a diagram acts as an obstacle for other labels or diagrams.
+     * @see setIsObstacle()
+     * @note added in QGIS 2.16
+     */
+    bool isObstacle() const;
 
-    //assigned when layer gets prepared
-    const QgsCoordinateTransform* ct;
+    /** Sets whether the feature associated with a diagram acts as an obstacle for other labels or diagrams.
+     * @param isObstacle set to true for feature to act as obstacle
+     * @see isObstacle()
+     * @note added in QGIS 2.16
+     */
+    void setIsObstacle( bool isObstacle );
+
+    //! Whether associated feature acts as an obstacle for other labels or diagrams
+    // TODO QGIS 3.0 - rename to mObstacle, make private
+    bool obstacle;
+
+    /** Returns the distance between the diagram and the feature (in mm).
+     * @see setDistance()
+     * @note added in QGIS 2.16
+     */
+    double distance() const;
+
+    /** Sets the distance between the diagram and the feature.
+     * @param distance distance in mm
+     * @see distance()
+     * @note added in QGIS 2.16
+     */
+    void setDistance( double distance );
+
+    //! Distance between diagram and the feature (in mm)
+    // TODO QGIS 3.0 - make private, rename to mDistance
+    double dist;
+
+    /** Returns the diagram renderer associated with the layer.
+     * @see setRenderer()
+     * @note added in QGIS 2.16
+     */
+    // TODO QGIS 3.0 - rename to renderer()
+    QgsDiagramRendererV2* getRenderer();
+
+    /** Returns the diagram renderer associated with the layer.
+     * @see setRenderer()
+     * @note added in QGIS 2.16
+     */
+    // TODO QGIS 3.0 - rename to renderer()
+    //const QgsDiagramRendererV2* getRenderer() const;
+
+    /** Sets the diagram renderer associated with the layer.
+     * @param diagramRenderer diagram renderer. Ownership is transferred to the object.
+     * @see getRenderer()
+     * @note added in QGIS 2.16
+     */
+    void setRenderer( QgsDiagramRendererV2* diagramRenderer /Transfer/ );
+
+    //! Associated diagram renderer. Owned by this object.
+    // TODO QGIS 3.0 - make private, rename to mRenderer
+    QgsDiagramRendererV2* renderer;
+
+    /** Returns the coordinate transform associated with the layer.
+     * @see setCoordinateTransform()
+     * @note added in QGIS 2.16
+     */
+    QgsCoordinateTransform* coordinateTransform();
+
+    /** Returns the coordinate transform associated with the layer.
+     * @see setCoordinateTransform()
+     * @note added in QGIS 2.16
+     */
+    //const QgsCoordinateTransform* coordinateTransform() const;
+
+    /** Sets the coordinate transform associated with the layer.
+     * @param transform coordinate transform. Ownership is transferred to the object.
+     * @see coordinateTransform()
+     * @note added in QGIS 2.16
+     */
+    void setCoordinateTransform( QgsCoordinateTransform* transform /Transfer/ );
+
+    //! Associated coordinate transform. Owned by this object.
+    // TODO QGIS 3.0 - make private, rename to mCt
+    QgsCoordinateTransform* ct;
+
+    //! @deprecated will be removed in QGIS 3.0
     const QgsMapToPixel* xform;
+
+    //! @deprecated will be removed in QGIS 3.0
     QgsFields fields;
 
-    int xPosColumn; //attribute index for x coordinate (or -1 if position not data defined)
-    int yPosColumn;//attribute index for y coordinate (or -1 if position not data defined)
+    //! Attribute index for x coordinate (or -1 if position not data defined)
+    int xPosColumn;
+
+    //! Attribute index for y coordinate (or -1 if position not data defined)
+    int yPosColumn;
+
+    /** Returns whether the layer should show all diagrams, including overlapping diagrams
+     * @see setShowAllDiagrams()
+     * @note added in QGIS 2.16
+     */
+    bool showAllDiagrams() const;
+
+    /** Sets whether the layer should show all diagrams, including overlapping diagrams
+     * @param showAllDiagrams set to true to show all diagrams
+     * @see showAllDiagrams()
+     * @note added in QGIS 2.16
+     */
+    void setShowAllDiagrams( bool showAllDiagrams );
+
+    //! Whether to show all diagrams, including overlapping diagrams
+    // TODO QGIS 3.0 - make private, rename to mShowAll
     bool showAll;
 
     void readXML( const QDomElement& elem, const QgsVectorLayer* layer );
     void writeXML( QDomElement& layerElem, QDomDocument& doc, const QgsVectorLayer* layer ) const;
+
+    /** Returns the set of any fields referenced by the layer's diagrams.
+     * @param context expression context the diagrams will be drawn using
+     * @param fields layer fields
+     * @note added in QGIS 2.16
+     */
+    //TODO QGIS 3.0 - remove need for fields parameter
+    QSet< QString > referencedFields( const QgsExpressionContext& context = QgsExpressionContext(), const QgsFields& fields = QgsFields() ) const;
+
 };
 
-//diagram settings for rendering
+/** \ingroup core
+ * \class QgsDiagramSettings
+ * \brief Stores the settings for rendering a single diagram.
+ *
+ * QgsDiagramSettings stores the settings related to rendering the individual diagrams themselves, while
+ * QgsDiagramLayerSettings stores settings which control how ALL diagrams within a layer are rendered.
+ */
+
 class QgsDiagramSettings
 {
 %TypeHeaderCode
@@ -136,7 +336,12 @@ class QgsDiagramInterpolationSettings
     bool classificationAttributeIsExpression;
 };
 
-/** Returns diagram settings for a feature*/
+
+/** \ingroup core
+ * \class QgsDiagramRendererV2
+ * \brief Evaluates and returns the diagram settings relating to a diagram for a specific feature.
+ */
+
 class QgsDiagramRendererV2
 {
 %TypeHeaderCode
@@ -152,12 +357,20 @@ class QgsDiagramRendererV2
     virtual QgsDiagramRendererV2* clone() const = 0 /Factory/;
 
     /** Returns size of the diagram for a feature in map units. Returns an invalid QSizeF in case of error*/
-    virtual QSizeF sizeMapUnits( const QgsFeature& feature, const QgsRenderContext& c );
+    virtual QSizeF sizeMapUnits( const QgsFeature& feature, const QgsRenderContext& c ) const;
 
     virtual QString rendererName() const = 0;
 
     /** Returns attribute indices needed for diagram rendering*/
     virtual QList<QString> diagramAttributes() const = 0;
+
+    /** Returns the set of any fields required for diagram rendering
+     * @param context expression context the diagrams will be drawn using
+     * @param fields layer fields
+     * @note added in QGIS 2.16
+     */
+    //TODO QGIS 3.0 - remove need for fields parameter
+    virtual QSet< QString > referencedFields( const QgsExpressionContext& context = QgsExpressionContext(), const QgsFields& fields = QgsFields() ) const;
 
     void renderDiagram( const QgsFeature& feature, QgsRenderContext& c, QPointF pos );
 
@@ -183,10 +396,10 @@ class QgsDiagramRendererV2
      * @param c render context
      * @param s out: diagram settings for the feature
      */
-    virtual bool diagramSettings( const QgsFeature &feature, const QgsRenderContext& c, QgsDiagramSettings& s ) = 0;
+    virtual bool diagramSettings( const QgsFeature &feature, const QgsRenderContext& c, QgsDiagramSettings& s ) const = 0;
 
     /** Returns size of the diagram (in painter units) or an invalid size in case of error*/
-    virtual QSizeF diagramSize( const QgsFeature& features, const QgsRenderContext& c ) = 0;
+    virtual QSizeF diagramSize( const QgsFeature& features, const QgsRenderContext& c ) const = 0;
 
     /** Converts size from mm to map units*/
     void convertSizeToMapUnits( QSizeF& size, const QgsRenderContext& context ) const;
@@ -226,9 +439,9 @@ class QgsSingleCategoryDiagramRenderer : QgsDiagramRendererV2
     virtual QList< QgsLayerTreeModelLegendNode* > legendItems( QgsLayerTreeLayer* nodeLayer ) const /Factory/;
 
   protected:
-    bool diagramSettings( const QgsFeature &feature, const QgsRenderContext& c, QgsDiagramSettings& s );
+    bool diagramSettings( const QgsFeature &feature, const QgsRenderContext& c, QgsDiagramSettings& s ) const;
 
-    QSizeF diagramSize( const QgsFeature&, const QgsRenderContext& c );
+    QSizeF diagramSize( const QgsFeature&, const QgsRenderContext& c ) const;
 };
 
 class QgsLinearlyInterpolatedDiagramRenderer : QgsDiagramRendererV2
@@ -249,6 +462,8 @@ class QgsLinearlyInterpolatedDiagramRenderer : QgsDiagramRendererV2
     void setDiagramSettings( const QgsDiagramSettings& s );
 
     QList<QString> diagramAttributes() const;
+
+    virtual QSet< QString > referencedFields( const QgsExpressionContext& context = QgsExpressionContext(), const QgsFields& fields = QgsFields() ) const;
 
     QString rendererName() const;
 
@@ -279,7 +494,7 @@ class QgsLinearlyInterpolatedDiagramRenderer : QgsDiagramRendererV2
     virtual QList< QgsLayerTreeModelLegendNode* > legendItems( QgsLayerTreeLayer* nodeLayer ) const /Factory/;
 
   protected:
-    bool diagramSettings( const QgsFeature &feature, const QgsRenderContext& c, QgsDiagramSettings& s );
+    bool diagramSettings( const QgsFeature &feature, const QgsRenderContext& c, QgsDiagramSettings& s ) const;
 
-    QSizeF diagramSize( const QgsFeature&, const QgsRenderContext& c );
+    QSizeF diagramSize( const QgsFeature&, const QgsRenderContext& c ) const;
 };

--- a/src/app/qgsdiagramproperties.cpp
+++ b/src/app/qgsdiagramproperties.cpp
@@ -366,24 +366,24 @@ QgsDiagramProperties::QgsDiagramProperties( QgsVectorLayer* layer, QWidget* pare
     const QgsDiagramLayerSettings *dls = layer->diagramLayerSettings();
     if ( dls )
     {
-      mDiagramDistanceSpinBox->setValue( dls->dist );
-      mPrioritySlider->setValue( dls->priority );
-      mZIndexSpinBox->setValue( dls->zIndex );
+      mDiagramDistanceSpinBox->setValue( dls->distance() );
+      mPrioritySlider->setValue( dls->getPriority() );
+      mZIndexSpinBox->setValue( dls->getZIndex() );
       mDataDefinedXComboBox->setCurrentIndex( mDataDefinedXComboBox->findData( dls->xPosColumn ) );
       mDataDefinedYComboBox->setCurrentIndex( mDataDefinedYComboBox->findData( dls->yPosColumn ) );
       if ( dls->xPosColumn != -1 || dls->yPosColumn != -1 )
       {
         mDataDefinedPositionGroupBox->setChecked( true );
       }
-      mPlacementComboBox->setCurrentIndex( mPlacementComboBox->findData( dls->placement ) );
+      mPlacementComboBox->setCurrentIndex( mPlacementComboBox->findData( dls->getPlacement() ) );
 
-      chkLineAbove->setChecked( dls->placementFlags & QgsDiagramLayerSettings::AboveLine );
-      chkLineBelow->setChecked( dls->placementFlags & QgsDiagramLayerSettings::BelowLine );
-      chkLineOn->setChecked( dls->placementFlags & QgsDiagramLayerSettings::OnLine );
-      if ( !( dls->placementFlags & QgsDiagramLayerSettings::MapOrientation ) )
+      chkLineAbove->setChecked( dls->linePlacementFlags() & QgsDiagramLayerSettings::AboveLine );
+      chkLineBelow->setChecked( dls->linePlacementFlags() & QgsDiagramLayerSettings::BelowLine );
+      chkLineOn->setChecked( dls->linePlacementFlags() & QgsDiagramLayerSettings::OnLine );
+      if ( !( dls->linePlacementFlags() & QgsDiagramLayerSettings::MapOrientation ) )
         chkLineOrientationDependent->setChecked( true );
 
-      mShowAllCheckBox->setChecked( dls->showAll );
+      mShowAllCheckBox->setChecked( dls->showAllDiagrams() );
     }
 
     if ( dr->diagram() )
@@ -762,10 +762,10 @@ void QgsDiagramProperties::apply()
   }
 
   QgsDiagramLayerSettings dls;
-  dls.dist = mDiagramDistanceSpinBox->value();
-  dls.priority = mPrioritySlider->value();
-  dls.zIndex = mZIndexSpinBox->value();
-  dls.showAll = mShowAllCheckBox->isChecked();
+  dls.setDistance( mDiagramDistanceSpinBox->value() );
+  dls.setPriority( mPrioritySlider->value() );
+  dls.setZIndex( mZIndexSpinBox->value() );
+  dls.setShowAllDiagrams( mShowAllCheckBox->isChecked() );
   if ( mDataDefinedPositionGroupBox->isChecked() )
   {
     dls.xPosColumn = mDataDefinedXComboBox->itemData( mDataDefinedXComboBox->currentIndex() ).toInt();
@@ -776,16 +776,18 @@ void QgsDiagramProperties::apply()
     dls.xPosColumn = -1;
     dls.yPosColumn = -1;
   }
-  dls.placement = ( QgsDiagramLayerSettings::Placement )mPlacementComboBox->itemData( mPlacementComboBox->currentIndex() ).toInt();
-  dls.placementFlags = ( QgsDiagramLayerSettings::LinePlacementFlags )0;
+  dls.setPlacement(( QgsDiagramLayerSettings::Placement )mPlacementComboBox->itemData( mPlacementComboBox->currentIndex() ).toInt() );
+
+  unsigned int flags = 0;
   if ( chkLineAbove->isChecked() )
-    dls.placementFlags |= QgsDiagramLayerSettings::AboveLine;
+    flags |= QgsDiagramLayerSettings::AboveLine;
   if ( chkLineBelow->isChecked() )
-    dls.placementFlags |= QgsDiagramLayerSettings::BelowLine;
+    flags |= QgsDiagramLayerSettings::BelowLine;
   if ( chkLineOn->isChecked() )
-    dls.placementFlags |= QgsDiagramLayerSettings::OnLine;
+    flags |= QgsDiagramLayerSettings::OnLine;
   if ( ! chkLineOrientationDependent->isChecked() )
-    dls.placementFlags |= QgsDiagramLayerSettings::MapOrientation;
+    flags |= QgsDiagramLayerSettings::MapOrientation;
+  dls.setLinePlacementFlags( flags );
 
   mLayer->setDiagramLayerSettings( dls );
 }

--- a/src/core/qgsdiagramrendererv2.h
+++ b/src/core/qgsdiagramrendererv2.h
@@ -23,6 +23,7 @@
 #include <QDomDocument>
 
 #include "qgsfeature.h"
+#include "qgsexpressioncontext.h"
 
 class QgsDiagram;
 class QgsDiagramRendererV2;
@@ -37,9 +38,18 @@ class QgsLayerTreeLayer;
 
 namespace pal { class Layer; }
 
+/** \ingroup core
+ * \class QgsDiagramLayerSettings
+ * \brief Stores the settings for rendering of all diagrams for a layer.
+ *
+ * QgsDiagramSettings stores the settings related to rendering the individual diagrams themselves, while
+ * QgsDiagramLayerSettings stores settings which control how ALL diagrams within a layer are rendered.
+ */
+
 class CORE_EXPORT QgsDiagramLayerSettings
 {
   public:
+
     //avoid inclusion of QgsPalLabeling
     enum Placement
     {
@@ -51,6 +61,7 @@ class CORE_EXPORT QgsDiagramLayerSettings
       Free // Polygon
     };
 
+    //! Line placement flags for controlling line based placements
     enum LinePlacementFlags
     {
       OnLine    = 1,
@@ -60,38 +71,229 @@ class CORE_EXPORT QgsDiagramLayerSettings
     };
 
     QgsDiagramLayerSettings();
+
+    //! Copy constructor
     QgsDiagramLayerSettings( const QgsDiagramLayerSettings& rh );
+
     QgsDiagramLayerSettings& operator=( const QgsDiagramLayerSettings& rh );
 
     ~QgsDiagramLayerSettings();
 
-    //pal placement properties
+    /** Returns the diagram placement.
+     * @see setPlacement()
+     * @note added in QGIS 2.16
+     */
+    //TODO QGIS 3.0 - rename getter to placement()
+    Placement getPlacement() const { return placement; }
+
+    /** Sets the diagram placement.
+     * @param value placement value
+     * @see getPlacement()
+     * @note added in QGIS 2.16
+     */
+    void setPlacement( Placement value ) { placement = value; }
+
+    //! Diagram placement
+    //TODO QGIS 3.0 - make private, rename to mPlacement
     Placement placement;
+
+    /** Returns the diagram placement flags. These are only used if the diagram placement
+     * is set to a line type.
+     * @see setLinePlacementFlags()
+     * @note added in QGIS 2.16
+     */
+    unsigned int linePlacementFlags() const { return placementFlags; }
+
+    /** Sets the the diagram placement flags. These are only used if the diagram placement
+     * is set to a line type.
+     * @param value placement value
+     * @see getPlacement()
+     * @note added in QGIS 2.16
+     */
+    void setLinePlacementFlags( unsigned int flags ) { placementFlags = flags; }
+
+    //! Diagram placement flags
+    // TODO QGIS 3.0 - make private, rename to mPlacementFlags, use QFlags
     unsigned int placementFlags;
-    int priority; // 0 = low, 10 = high
+
+    /** Returns the diagram priority.
+     * @returns diagram priority, where 0 = low and 10 = high
+     * @note placement priority is shared with labeling, so diagrams with a high priority may displace labels
+     * and vice-versa
+     * @see setPriority()
+     * @note added in QGIS 2.16
+     */
+    //TODO QGIS 3.0 - rename getter to priority()
+    int getPriority() const { return priority; }
+
+    /** Sets the diagram priority.
+     * @param value priority, where 0 = low and 10 = high
+     * @see getPriority()
+     * @note added in QGIS 2.16
+     */
+    void setPriority( int value ) { priority = value; }
+
+    //! Placement priority, where 0 = low and 10 = high
+    //! @note placement priority is shared with labeling, so diagrams with a high priority may displace labels
+    //! and vice-versa
+    // TODO QGIS 3.0 - make private, rename to mPriority
+    int priority;
+
+    /** Returns the diagram z-index. Diagrams (or labels) with a higher z-index are drawn over diagrams
+     * with a lower z-index.
+     * @note z-index ordering is shared with labeling, so diagrams with a high z-index may be drawn over labels
+     * with a low z-index and vice-versa
+     * @see setZIndex()
+     * @note added in QGIS 2.16
+     */
+    //TODO QGIS 3.0 - rename getter to zIndex()
+    double getZIndex() const { return zIndex; }
+
+    /** Sets the diagram z-index. Diagrams (or labels) with a higher z-index are drawn over diagrams
+     * with a lower z-index.
+     * @param index diagram z-index
+     * @see getZIndex()
+     * @note added in QGIS 2.16
+     */
+    void setZIndex( double index ) { zIndex = index; }
 
     //! Z-index of diagrams, where diagrams with a higher z-index are drawn on top of diagrams with a lower z-index
+    // TODO QGIS 3.0 - rename to mZIndex, make private
     double zIndex;
 
-    bool obstacle; // whether it's an obstacle
-    double dist; // distance from the feature (in mm)
-    QgsDiagramRendererV2* renderer; // if any renderer is assigned, it is owned by this class
 
-    //assigned when layer gets prepared
-    const QgsCoordinateTransform* ct;
-    const QgsMapToPixel* xform;
-    QgsFields fields;
+    /** Returns whether the feature associated with a diagram acts as an obstacle for other labels or diagrams.
+     * @see setIsObstacle()
+     * @note added in QGIS 2.16
+     */
+    bool isObstacle() const { return obstacle; }
 
-    int xPosColumn; //attribute index for x coordinate (or -1 if position not data defined)
-    int yPosColumn;//attribute index for y coordinate (or -1 if position not data defined)
+    /** Sets whether the feature associated with a diagram acts as an obstacle for other labels or diagrams.
+     * @param isObstacle set to true for feature to act as obstacle
+     * @see isObstacle()
+     * @note added in QGIS 2.16
+     */
+    void setIsObstacle( bool isObstacle ) { obstacle = isObstacle; }
+
+    //! Whether associated feature acts as an obstacle for other labels or diagrams
+    // TODO QGIS 3.0 - rename to mObstacle, make private
+    bool obstacle;
+
+    /** Returns the distance between the diagram and the feature (in mm).
+     * @see setDistance()
+     * @note added in QGIS 2.16
+     */
+    double distance() const { return dist; }
+
+    /** Sets the distance between the diagram and the feature.
+     * @param distance distance in mm
+     * @see distance()
+     * @note added in QGIS 2.16
+     */
+    void setDistance( double distance ) { dist = distance; }
+
+    //! Distance between diagram and the feature (in mm)
+    // TODO QGIS 3.0 - make private, rename to mDistance
+    double dist;
+
+    /** Returns the diagram renderer associated with the layer.
+     * @see setRenderer()
+     * @note added in QGIS 2.16
+     */
+    // TODO QGIS 3.0 - rename to renderer()
+    QgsDiagramRendererV2* getRenderer() { return renderer; }
+
+    /** Returns the diagram renderer associated with the layer.
+     * @see setRenderer()
+     * @note added in QGIS 2.16
+     */
+    // TODO QGIS 3.0 - rename to renderer()
+    const QgsDiagramRendererV2* getRenderer() const { return renderer; }
+
+    /** Sets the diagram renderer associated with the layer.
+     * @param diagramRenderer diagram renderer. Ownership is transferred to the object.
+     * @see getRenderer()
+     * @note added in QGIS 2.16
+     */
+    void setRenderer( QgsDiagramRendererV2* diagramRenderer );
+
+    //! Associated diagram renderer. Owned by this object.
+    // TODO QGIS 3.0 - make private, rename to mRenderer
+    QgsDiagramRendererV2* renderer;
+
+    /** Returns the coordinate transform associated with the layer.
+     * @see setCoordinateTransform()
+     * @note added in QGIS 2.16
+     */
+    QgsCoordinateTransform* coordinateTransform() { return ct; }
+
+    /** Returns the coordinate transform associated with the layer.
+     * @see setCoordinateTransform()
+     * @note added in QGIS 2.16
+     */
+    const QgsCoordinateTransform* coordinateTransform() const { return ct; }
+
+    /** Sets the coordinate transform associated with the layer.
+     * @param transform coordinate transform. Ownership is transferred to the object.
+     * @see coordinateTransform()
+     * @note added in QGIS 2.16
+     */
+    void setCoordinateTransform( QgsCoordinateTransform* transform );
+
+    //! Associated coordinate transform. Owned by this object.
+    // TODO QGIS 3.0 - make private, rename to mCt
+    QgsCoordinateTransform* ct;
+
+    //! @deprecated will be removed in QGIS 3.0
+    Q_DECL_DEPRECATED const QgsMapToPixel* xform;
+
+    //! @deprecated will be removed in QGIS 3.0
+    Q_DECL_DEPRECATED QgsFields fields;
+
+    //! Attribute index for x coordinate (or -1 if position not data defined)
+    int xPosColumn;
+
+    //! Attribute index for y coordinate (or -1 if position not data defined)
+    int yPosColumn;
+
+    /** Returns whether the layer should show all diagrams, including overlapping diagrams
+     * @see setShowAllDiagrams()
+     * @note added in QGIS 2.16
+     */
+    bool showAllDiagrams() const { return showAll; }
+
+    /** Sets whether the layer should show all diagrams, including overlapping diagrams
+     * @param showAllDiagrams set to true to show all diagrams
+     * @see showAllDiagrams()
+     * @note added in QGIS 2.16
+     */
+    void setShowAllDiagrams( bool showAllDiagrams ) { showAll = showAllDiagrams; }
+
+    //! Whether to show all diagrams, including overlapping diagrams
+    // TODO QGIS 3.0 - make private, rename to mShowAll
     bool showAll;
 
     void readXML( const QDomElement& elem, const QgsVectorLayer* layer );
     void writeXML( QDomElement& layerElem, QDomDocument& doc, const QgsVectorLayer* layer ) const;
 
+    /** Returns the set of any fields referenced by the layer's diagrams.
+     * @param context expression context the diagrams will be drawn using
+     * @param fields layer fields
+     * @note added in QGIS 2.16
+     */
+    //TODO QGIS 3.0 - remove need for fields parameter
+    QSet< QString > referencedFields( const QgsExpressionContext& context = QgsExpressionContext(), const QgsFields& fields = QgsFields() ) const;
+
 };
 
-//diagram settings for rendering
+/** \ingroup core
+ * \class QgsDiagramSettings
+ * \brief Stores the settings for rendering a single diagram.
+ *
+ * QgsDiagramSettings stores the settings related to rendering the individual diagrams themselves, while
+ * QgsDiagramLayerSettings stores settings which control how ALL diagrams within a layer are rendered.
+ */
+
 class CORE_EXPORT QgsDiagramSettings
 {
   public:
@@ -176,13 +378,21 @@ class CORE_EXPORT QgsDiagramInterpolationSettings
     QSizeF upperSize;
     double lowerValue;
     double upperValue;
+
     /** Index of the classification attribute*/
+    //TODO QGIS 3.0 - don't store index, store field name
     int classificationAttribute;
+
     QString classificationAttributeExpression;
     bool classificationAttributeIsExpression;
 };
 
-/** Returns diagram settings for a feature*/
+
+/** \ingroup core
+ * \class QgsDiagramRendererV2
+ * \brief Evaluates and returns the diagram settings relating to a diagram for a specific feature.
+ */
+
 class CORE_EXPORT QgsDiagramRendererV2
 {
   public:
@@ -195,14 +405,22 @@ class CORE_EXPORT QgsDiagramRendererV2
     virtual QgsDiagramRendererV2* clone() const = 0;
 
     /** Returns size of the diagram for a feature in map units. Returns an invalid QSizeF in case of error*/
-    virtual QSizeF sizeMapUnits( const QgsFeature& feature, const QgsRenderContext& c );
+    virtual QSizeF sizeMapUnits( const QgsFeature& feature, const QgsRenderContext& c ) const;
 
     virtual QString rendererName() const = 0;
 
     /** Returns attribute indices needed for diagram rendering*/
     virtual QList<QString> diagramAttributes() const = 0;
 
-    void renderDiagram( const QgsFeature& feature, QgsRenderContext& c, QPointF pos );
+    /** Returns the set of any fields required for diagram rendering
+     * @param context expression context the diagrams will be drawn using
+     * @param fields layer fields
+     * @note added in QGIS 2.16
+     */
+    //TODO QGIS 3.0 - remove need for fields parameter
+    virtual QSet< QString > referencedFields( const QgsExpressionContext& context = QgsExpressionContext(), const QgsFields& fields = QgsFields() ) const;
+
+    void renderDiagram( const QgsFeature& feature, QgsRenderContext& c, QPointF pos ) const;
 
     void setDiagram( QgsDiagram* d );
     QgsDiagram* diagram() const { return mDiagram; }
@@ -227,10 +445,10 @@ class CORE_EXPORT QgsDiagramRendererV2
      * @param c render context
      * @param s out: diagram settings for the feature
      */
-    virtual bool diagramSettings( const QgsFeature &feature, const QgsRenderContext& c, QgsDiagramSettings& s ) = 0;
+    virtual bool diagramSettings( const QgsFeature &feature, const QgsRenderContext& c, QgsDiagramSettings& s ) const = 0;
 
     /** Returns size of the diagram (in painter units) or an invalid size in case of error*/
-    virtual QSizeF diagramSize( const QgsFeature& features, const QgsRenderContext& c ) = 0;
+    virtual QSizeF diagramSize( const QgsFeature& features, const QgsRenderContext& c ) const = 0;
 
     /** Converts size from mm to map units*/
     void convertSizeToMapUnits( QSizeF& size, const QgsRenderContext& context ) const;
@@ -269,9 +487,9 @@ class CORE_EXPORT QgsSingleCategoryDiagramRenderer : public QgsDiagramRendererV2
     QList< QgsLayerTreeModelLegendNode* > legendItems( QgsLayerTreeLayer* nodeLayer ) const override;
 
   protected:
-    bool diagramSettings( const QgsFeature &feature, const QgsRenderContext& c, QgsDiagramSettings& s ) override;
+    bool diagramSettings( const QgsFeature &feature, const QgsRenderContext& c, QgsDiagramSettings& s ) const override;
 
-    QSizeF diagramSize( const QgsFeature&, const QgsRenderContext& c ) override;
+    QSizeF diagramSize( const QgsFeature&, const QgsRenderContext& c ) const override;
 
   private:
     QgsDiagramSettings mSettings;
@@ -291,6 +509,8 @@ class CORE_EXPORT QgsLinearlyInterpolatedDiagramRenderer : public QgsDiagramRend
     void setDiagramSettings( const QgsDiagramSettings& s ) { mSettings = s; }
 
     QList<QString> diagramAttributes() const override;
+
+    virtual QSet< QString > referencedFields( const QgsExpressionContext& context = QgsExpressionContext(), const QgsFields& fields = QgsFields() ) const override;
 
     QString rendererName() const override { return "LinearlyInterpolated"; }
 
@@ -321,9 +541,9 @@ class CORE_EXPORT QgsLinearlyInterpolatedDiagramRenderer : public QgsDiagramRend
     QList< QgsLayerTreeModelLegendNode* > legendItems( QgsLayerTreeLayer* nodeLayer ) const override;
 
   protected:
-    bool diagramSettings( const QgsFeature &feature, const QgsRenderContext& c, QgsDiagramSettings& s ) override;
+    bool diagramSettings( const QgsFeature &feature, const QgsRenderContext& c, QgsDiagramSettings& s ) const override;
 
-    QSizeF diagramSize( const QgsFeature&, const QgsRenderContext& c ) override;
+    QSizeF diagramSize( const QgsFeature&, const QgsRenderContext& c ) const override;
 
   private:
     QgsDiagramSettings mSettings;

--- a/tests/src/core/testqgsdiagram.cpp
+++ b/tests/src/core/testqgsdiagram.cpp
@@ -159,8 +159,8 @@ class TestQgsDiagram : public QObject
       mPointsLayer->setDiagramRenderer( dr );
 
       QgsDiagramLayerSettings dls = QgsDiagramLayerSettings();
-      dls.placement = QgsDiagramLayerSettings::OverPoint;
-      dls.showAll = true;
+      dls.setPlacement( QgsDiagramLayerSettings::OverPoint );
+      dls.setShowAllDiagrams( true );
       mPointsLayer->setDiagramLayerSettings( dls );
 
       QVERIFY( imageCheck( "piediagram" ) );
@@ -196,8 +196,8 @@ class TestQgsDiagram : public QObject
       dr->setDiagramSettings( ds );
 
       QgsDiagramLayerSettings dls = QgsDiagramLayerSettings();
-      dls.placement = QgsDiagramLayerSettings::OverPoint;
-      dls.showAll = true;
+      dls.setPlacement( QgsDiagramLayerSettings::OverPoint );
+      dls.setShowAllDiagrams( true );
       // dls.setRenderer( dr );
 
       mPointsLayer->setDiagramRenderer( dr );


### PR DESCRIPTION
- add public getters and setters for variables, will make variables private in QGIS 3.0
- avoid some memory leaks and potential crashes
- move calculation of referenced fields to diagram classes, out of QgsVectorLayerDiagramProvider
- add a bunch of docs
