### PR TITLE
Various fixes for virtual layers

### DIFF
--- a/python/plugins/db_manager/db_plugins/vlayers/data_model.py
+++ b/python/plugins/db_manager/db_plugins/vlayers/data_model.py
@@ -26,7 +26,7 @@ from .plugin import LVectorTable
 from ..plugin import DbError
 
 from PyQt.QtCore import QUrl, QTime, QTemporaryFile
-from qgis.core import QGis, QgsVectorLayer
+from qgis.core import QGis, QgsVectorLayer, QgsWKBTypes
 
 
 class LTableDataModel(TableDataModel):
@@ -46,7 +46,13 @@ class LTableDataModel(TableDataModel):
         # populate self.resdata
         self.resdata = []
         for f in self.layer.getFeatures():
-            self.resdata.append(f.attributes())
+            a = f.attributes()
+            # add the geometry type
+            if f.geometry():
+                a.append(QgsWKBTypes.displayString(QGis.fromOldWkbType(f.geometry().wkbType())))
+            else:
+                a.append('None')
+            self.resdata.append(a)
 
         self.fetchedFrom = 0
         self.fetchedCount = len(self.resdata)

--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -249,6 +249,11 @@ QMenu* QgsAppLayerTreeViewMenuProvider::createContextMenu()
 
       if ( mView->selectedNodes( true ).count() >= 2 )
         menu->addAction( actions->actionGroupSelected( menu ) );
+
+      if ( layer && layer->type() == QgsMapLayer::VectorLayer && static_cast<QgsVectorLayer*>( layer )->providerType() == "virtual" )
+      {
+        menu->addAction( tr( "Edit virtual layer settings" ), QgisApp::instance(), SLOT( addVirtualLayer() ) );
+      }
     }
 
   }

--- a/src/providers/virtual/qgsvirtuallayerprovider.cpp
+++ b/src/providers/virtual/qgsvirtuallayerprovider.cpp
@@ -237,7 +237,7 @@ bool QgsVirtualLayerProvider::createIt()
           continue;
 
         const QgsVectorLayer* vl = static_cast<const QgsVectorLayer*>( l );
-        if (( vl->name() == tname ) || ( vl->id() == tname ) )
+        if ( ( vl->name() == tname ) || ( vl->name().toLower() == tname.toLower() ) || ( vl->id() == tname ) )
         {
           mDefinition.addSource( tname, vl->id() );
           found = true;

--- a/src/providers/virtual/qgsvirtuallayerprovider.cpp
+++ b/src/providers/virtual/qgsvirtuallayerprovider.cpp
@@ -237,7 +237,7 @@ bool QgsVirtualLayerProvider::createIt()
           continue;
 
         const QgsVectorLayer* vl = static_cast<const QgsVectorLayer*>( l );
-        if ( ( vl->name() == tname ) || ( vl->name().toLower() == tname.toLower() ) || ( vl->id() == tname ) )
+        if (( vl->name() == tname ) || ( vl->name().toLower() == tname.toLower() ) || ( vl->id() == tname ) )
         {
           mDefinition.addSource( tname, vl->id() );
           found = true;

--- a/src/providers/virtual/qgsvirtuallayersourceselectbase.ui
+++ b/src/providers/virtual/qgsvirtuallayersourceselectbase.ui
@@ -50,12 +50,16 @@
      <property name="title">
       <string>Embedded layers</string>
      </property>
-     <property name="collapsed">
-      <bool>true</bool>
+     <property name="collapsed" stdset="0">
+      <bool>false</bool>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_4">
       <item>
        <widget class="QTableWidget" name="mLayersTable">
+        <property name="toolTip">
+         <string>Embedded layers can be added to have SQL queries with layers that are independent from layers loaded by the current QGIS project.
+In particular, saving a virtual layer with embedded layers to a QLR file can be done to reuse its definition in another project.</string>
+        </property>
         <property name="selectionMode">
          <enum>QAbstractItemView::SingleSelection</enum>
         </property>
@@ -161,9 +165,8 @@
       <item>
        <widget class="QgsCodeEditorSQL" name="mQueryEdit" native="true">
         <property name="toolTip">
-         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the SQL query editor.&lt;/p&gt;&lt;p&gt;Virtual layers rely on SQLite and Spatialite. Any functions from SQLite or Spatialite can then be used in the query.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Special comments:&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Because it is not always possible to autodetect the data type of each column in a query, special comments can be used in the query to force a specific type.&lt;/p&gt;&lt;p&gt;Special comments must be placed on the right of a column name and have the form &lt;tt&gt;/*:type*/&lt;/tt&gt; where type can be any of &lt;span style=&quot; font-style:italic;&quot;&gt;int&lt;/span&gt;, &lt;span style=&quot; font-style:italic;&quot;&gt;real&lt;/span&gt; or &lt;span style=&quot; font-style:italic;&quot;&gt;text&lt;/span&gt;. They can also be used to specify the type and SRID of the geometry column with the following syntax: &lt;tt&gt;/*:gtype:srid*/&lt;/tt&gt; where &lt;span style=&quot; font-style:italic;&quot;&gt;gtype&lt;/span&gt; can be &lt;span style=&quot; font-style:italic;&quot;&gt;point&lt;/span&gt;, &lt;span style=&quot; font-style:italic;&quot;&gt;linestring&lt;/span&gt; or &lt;span style=&quot; font-style:italic;&quot;&gt;polygon&lt;/span&gt; (with an optional &lt;span style=&quot; font-style:italic;&quot;&gt;multi&lt;/span&gt; prefix) and &lt;span style=&quot; font-style:italic;&quot;&gt;srid&lt;/span&gt; is an integer identifier.&lt;/p&gt;&lt;p&gt;Example:&lt;/p&gt;&lt;p&gt;&lt;tt&gt;SELECT id + 1 as id /*:int*/, ST_Centroid(geometry) as geom /*:point:4326*/ FROM tab&lt;/tt&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
+         <string>&lt;html&gt;&lt;head/&gt;&lt;body&gt;&lt;p&gt;This is the SQL query editor. You can edit here an SQL query refering to any existing vector layers or embedded layers.&lt;/p&gt;&lt;p&gt;Virtual layers rely on SQLite and Spatialite. Any functions from SQLite or Spatialite can then be used in the query. To add or access geometries of a table, you can use &quot;tablename.geometry&quot;, regardless of original geometry column's name.&lt;/p&gt;&lt;p&gt;&lt;span style=&quot; font-weight:600;&quot;&gt;Special comments:&lt;/span&gt;&lt;/p&gt;&lt;p&gt;Because it is not always possible to autodetect the data type of each column in a query, special comments can be used in the query to force a specific type.&lt;/p&gt;&lt;p&gt;Special comments must be placed on the right of a column name and have the form &lt;tt&gt;/*:type*/&lt;/tt&gt; where type can be any of &lt;span style=&quot; font-style:italic;&quot;&gt;int&lt;/span&gt;, &lt;span style=&quot; font-style:italic;&quot;&gt;real&lt;/span&gt; or &lt;span style=&quot; font-style:italic;&quot;&gt;text&lt;/span&gt;. They can also be used to specify the type and SRID of the geometry column with the following syntax: &lt;tt&gt;/*:gtype:srid*/&lt;/tt&gt; where &lt;span style=&quot; font-style:italic;&quot;&gt;gtype&lt;/span&gt; can be &lt;span style=&quot; font-style:italic;&quot;&gt;point&lt;/span&gt;, &lt;span style=&quot; font-style:italic;&quot;&gt;linestring&lt;/span&gt; or &lt;span style=&quot; font-style:italic;&quot;&gt;polygon&lt;/span&gt; (with an optional &lt;span style=&quot; font-style:italic;&quot;&gt;multi&lt;/span&gt; prefix) and &lt;span style=&quot; font-style:italic;&quot;&gt;srid&lt;/span&gt; is an integer identifier.&lt;/p&gt;&lt;p&gt;Example:&lt;/p&gt;&lt;p&gt;&lt;tt&gt;SELECT id + 1 as id /*:int*/, ST_Centroid(geometry) as geom /*:point:4326*/ FROM tab&lt;/tt&gt;&lt;/p&gt;&lt;/body&gt;&lt;/html&gt;</string>
         </property>
-        <zorder>mEmbeddedlLayersGroup</zorder>
        </widget>
       </item>
      </layout>
@@ -195,7 +198,7 @@
      <property name="title">
       <string>Geometry</string>
      </property>
-     <property name="collapsed">
+     <property name="collapsed" stdset="0">
       <bool>true</bool>
      </property>
      <layout class="QVBoxLayout" name="verticalLayout_3">

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -2233,10 +2233,10 @@ Acts on currently active editable layer</string>
      <normaloff>:/images/themes/default/mActionAddVirtualLayer.svg</normaloff>:/images/themes/default/mActionAddVirtualLayer.svg</iconset>
    </property>
    <property name="text">
-    <string>Add Virtual Layer...</string>
+    <string>Add/Edit Virtual Layer...</string>
    </property>
    <property name="toolTip">
-    <string>Add Virtual Layer</string>
+    <string>Add/Edit Virtual Layer</string>
    </property>
   </action>
   <action name="mActionPasteAsNewVector">


### PR DESCRIPTION
- Better tooltips in the UI
- Icon text changed from "Add Virtual layer" to "Add/Edit"
- Case insensitive search of table names
- Add a right click action to edit the virtual layer settings
- Fixes http://hub.qgis.org/issues/14404

About the right click action, it is hardcoded in QgsAppLayerTreeViewMenuProvider. Is it ok or is there a way for providers to declare specific context menu actions ?
