### PR TITLE
[Bugfix] More comprehensive interface update in symbology (fixes #14224)

### DIFF
--- a/src/app/qgslabelingwidget.cpp
+++ b/src/app/qgslabelingwidget.cpp
@@ -41,6 +41,10 @@ void QgsLabelingWidget::adaptToLayer()
 {
   mLabelModeComboBox->setCurrentIndex( -1 );
 
+  // Delete the widget, so that labelModeChanged() recreates it with
+  // settings loaded from the layer
+  deleteWidget();
+
   // pick the right mode of the layer
   if ( mLayer->labeling() && mLayer->labeling()->type() == "rule-based" )
   {
@@ -107,11 +111,7 @@ void QgsLabelingWidget::labelModeChanged( int index )
 
   // in general case we need to recreate the widget
 
-  if ( mWidget )
-    mStackedWidget->removeWidget( mWidget );
-
-  delete mWidget;
-  mWidget = nullptr;
+  deleteWidget();
 
   if ( index == 2 )
   {
@@ -138,4 +138,13 @@ void QgsLabelingWidget::showEngineConfigDialog()
 {
   QgsLabelEngineConfigDialog dlg( this );
   dlg.exec();
+}
+
+void QgsLabelingWidget::deleteWidget()
+{
+  if ( mWidget )
+    mStackedWidget->removeWidget( mWidget );
+
+  delete mWidget;
+  mWidget = nullptr;
 }

--- a/src/app/qgslabelingwidget.h
+++ b/src/app/qgslabelingwidget.h
@@ -38,6 +38,9 @@ class QgsLabelingWidget : public QWidget, private Ui::QgsLabelingWidget
     QgsMapCanvas* mCanvas;
 
     QWidget* mWidget;
+
+    //! Delete the child widget
+    void deleteWidget();
 };
 
 #endif // QGSLABELINGWIDGET_H


### PR DESCRIPTION
This fixes ~~two bugs~~ this bug:
1. Bug #14224: The labeling widget in the layer properties dialog is not updated (except for the labeling type combobox) when loading a style, so that the labeling settings from the loaded style file are only applied if you press 'cancel' rather than 'ok' in the layer properties dialog.
~~2. When you load a style, it is applied immediately, without the need to press 'ok' or 'apply'. However, the interface is not updated reflected to show this. Thus, currently, if you load a style and then press 'cancel', the loaded style is applied to the layer, but the interface is updated (and the project is marked dirty) only after making another change (such as panning the map).~~ Not necessary anymore because of 25a162c05a2fd95f8e685499a0e403a85edf2646 .
