### PR TITLE
ReadOnly vector layers, NonIdentifyableLayers

### DIFF
--- a/python/console/console_editor.py
+++ b/python/console/console_editor.py
@@ -18,7 +18,6 @@ email                : lrssvtml (at) gmail (dot) com
  ***************************************************************************/
 Some portions of code were taken from https://code.google.com/p/pydee/
 """
-
 from PyQt.QtCore import Qt, QObject, QEvent, QSettings, QCoreApplication, QFileInfo, QSize
 from PyQt.QtGui import QFont, QFontMetrics, QColor, QKeySequence, QCursor
 from PyQt.QtWidgets import QShortcut, QMenu, QApplication, QWidget, QGridLayout, QSpacerItem, QSizePolicy, QFileDialog, QTabWidget, QTreeWidgetItem, QFrame, QLabel, QToolButton, QMessageBox
@@ -48,7 +47,7 @@ class KeyFilter(QObject):
         self.window = window
         self.tab = tab
         self._handlers = {}
-        for shortcut, handler in KeyFilter.SHORTCUTS.iteritems():
+        for shortcut, handler in KeyFilter.SHORTCUTS.items():
             modifiers = shortcut[0]
             if not isinstance(modifiers, list):
                 modifiers = [modifiers]
@@ -266,7 +265,7 @@ class Editor(QsciScintilla):
         else:
             apiPath = self.settings.value("pythonConsole/userAPI", [])
             for i in range(0, len(apiPath)):
-                self.api.load(unicode(apiPath[i]))
+                self.api.load(apiPath[i])
             self.api.prepare()
             self.lexer.setAPIs(self.api)
 
@@ -418,19 +417,23 @@ class Editor(QsciScintilla):
             self.parent.pc.objectListButton.setChecked(True)
 
     def codepad(self):
-        import urllib2
-        import urllib
+        import urllib.request
+        import urllib.error
+        import urllib.parse
+        import urllib.request
+        import urllib.parse
+        import urllib.error
         listText = self.selectedText().split('\n')
         getCmd = []
         for strLine in listText:
-            getCmd.append(unicode(strLine))
+            getCmd.append(strLine)
         pasteText = u"\n".join(getCmd)
         url = 'http://codepad.org'
         values = {'lang': 'Python',
                   'code': pasteText,
                   'submit': 'Submit'}
         try:
-            response = urllib2.urlopen(url, urllib.urlencode(values))
+            response = urllib.request.urlopen(url, urllib.parse.urlencode(values))
             url = response.read()
             for href in url.split("</a>"):
                 if "Link:" in href:
@@ -443,9 +446,9 @@ class Editor(QsciScintilla):
                 QApplication.clipboard().setText(link)
                 msgText = QCoreApplication.translate('PythonConsole', 'URL copied to clipboard.')
                 self.parent.pc.callWidgetMessageBarEditor(msgText, 0, True)
-        except urllib2.URLError as e:
+        except urllib.error.URLError as e:
             msgText = QCoreApplication.translate('PythonConsole', 'Connection error: ')
-            self.parent.pc.callWidgetMessageBarEditor(msgText + str(e.args), 0, True)
+            self.parent.pc.callWidgetMessageBarEditor(msgText + e.args, 0, True)
 
     def hideEditor(self):
         self.parent.pc.splitterObj.hide()
@@ -506,10 +509,10 @@ class Editor(QsciScintilla):
         try:
             ## set creationflags for running command without shell window
             if sys.platform.startswith('win'):
-                p = subprocess.Popen(['python', unicode(filename)], shell=False, stdin=subprocess.PIPE,
+                p = subprocess.Popen(['python', filename], shell=False, stdin=subprocess.PIPE,
                                      stderr=subprocess.PIPE, stdout=subprocess.PIPE, creationflags=0x08000000)
             else:
-                p = subprocess.Popen(['python', unicode(filename)], shell=False, stdin=subprocess.PIPE,
+                p = subprocess.Popen(['python', filename], shell=False, stdin=subprocess.PIPE,
                                      stderr=subprocess.PIPE, stdout=subprocess.PIPE)
             out, _traceback = p.communicate()
 
@@ -529,15 +532,15 @@ class Editor(QsciScintilla):
                 file = file + tmpFileTr
             if _traceback:
                 msgTraceTr = QCoreApplication.translate('PythonConsole', '## Script error: {0}').format(file)
-                print "## %s" % datetime.datetime.now()
-                print unicode(msgTraceTr)
+                print("## {}".format(datetime.datetime.now()))
+                print(msgTraceTr)
                 sys.stderr.write(_traceback)
                 p.stderr.close()
             else:
                 msgSuccessTr = QCoreApplication.translate('PythonConsole',
                                                           '## Script executed successfully: {0}').format(file)
-                print "## %s" % datetime.datetime.now()
-                print unicode(msgSuccessTr)
+                print("## {}".format(datetime.datetime.now()))
+                print(msgSuccessTr)
                 sys.stdout.write(out)
                 p.stdout.close()
             del p
@@ -547,10 +550,10 @@ class Editor(QsciScintilla):
             IOErrorTr = QCoreApplication.translate('PythonConsole',
                                                    'Cannot execute file {0}. Error: {1}\n').format(filename,
                                                                                                    error.strerror)
-            print '## Error: ' + IOErrorTr
+            print('## Error: ' + IOErrorTr)
         except:
             s = traceback.format_exc()
-            print '## Error: '
+            print('## Error: ')
             sys.stderr.write(s)
 
     def runScriptCode(self):
@@ -602,7 +605,7 @@ class Editor(QsciScintilla):
         eline = None
         ecolumn = 0
         edescr = ''
-        source = unicode(self.text())
+        source = self.text()
         try:
             if not filename:
                 filename = self.parent.tw.currentWidget().path
@@ -611,7 +614,7 @@ class Editor(QsciScintilla):
                 source = source.encode('utf-8')
             if isinstance(filename, type(u"")):
                 filename = filename.encode('utf-8')
-            compile(source, str(filename), 'exec')
+            compile(source, filename, 'exec')
         except SyntaxError as detail:
             eline = detail.lineno and detail.lineno or 1
             ecolumn = detail.offset and detail.offset or 1
@@ -644,7 +647,7 @@ class Editor(QsciScintilla):
             return True
 
     def keyPressEvent(self, e):
-        t = unicode(e.text())
+        t = e.text()
         startLine, _, endLine, endPos = self.getSelection()
         line, pos = self.getCursorPosition()
         self.autoCloseBracket = self.settings.value("pythonConsole/autoCloseBracketEditor", False, type=bool)
@@ -761,7 +764,7 @@ class EditorTab(QWidget):
 
     def loadFile(self, filename, modified):
         self.newEditor.lastModified = QFileInfo(filename).lastModified()
-        fn = codecs.open(unicode(filename), "rb", encoding='utf-8')
+        fn = codecs.open(filename, "rb", encoding='utf-8')
         txt = fn.read()
         fn.close()
         QApplication.setOverrideCursor(QCursor(Qt.WaitCursor))
@@ -779,10 +782,10 @@ class EditorTab(QWidget):
         if self.path is None:
             saveTr = QCoreApplication.translate('PythonConsole',
                                                 'Python Console: Save file')
-            self.path = str(QFileDialog().getSaveFileName(self,
-                                                          saveTr,
-                                                          self.tw.tabText(index) + '.py',
-                                                          "Script file (*.py)"))
+            self.path = QFileDialog().getSaveFileName(self,
+                                                      saveTr,
+                                                      self.tw.tabText(index) + '.py',
+                                                      "Script file (*.py)")
             # If the user didn't select a file, abort the save operation
             if len(self.path) == 0:
                 self.path = None
@@ -792,7 +795,7 @@ class EditorTab(QWidget):
                                                  'Script was correctly saved.')
             self.pc.callWidgetMessageBarEditor(msgText, 0, True)
         # Rename the original file, if it exists
-        path = unicode(self.path)
+        path = self.path
         overwrite = QFileInfo(path).exists()
         if overwrite:
             try:
@@ -979,7 +982,7 @@ class EditorTabWidget(QTabWidget):
     def closeOthers(self):
         idx = self.idx
         countTab = self.count()
-        for i in range(countTab - 1, idx, -1) + range(idx - 1, -1, -1):
+        for i in list(range(countTab - 1, idx, -1)) + list(range(idx - 1, -1, -1)):
             self._removeTab(i)
 
     def closeAll(self):
@@ -1009,14 +1012,14 @@ class EditorTabWidget(QTabWidget):
         if filename:
             readOnly = not QFileInfo(filename).isWritable()
             try:
-                fn = codecs.open(unicode(filename), "rb", encoding='utf-8')
+                fn = codecs.open(filename, "rb", encoding='utf-8')
                 fn.read()
                 fn.close()
             except IOError as error:
                 IOErrorTr = QCoreApplication.translate('PythonConsole',
                                                        'The file {0} could not be opened. Error: {1}\n').format(filename,
                                                                                                                 error.strerror)
-                print '## Error: '
+                print('## Error: ')
                 sys.stderr.write(IOErrorTr)
                 return
 
@@ -1028,7 +1031,7 @@ class EditorTabWidget(QTabWidget):
         self.addTab(self.tab, self.iconTab, tabName + ' (ro)' if readOnly else tabName)
         self.setCurrentWidget(self.tab)
         if filename:
-            self.setTabToolTip(self.currentIndex(), unicode(filename))
+            self.setTabToolTip(self.currentIndex(), filename)
         else:
             self.setTabToolTip(self.currentIndex(), tabName)
 
@@ -1108,14 +1111,14 @@ class EditorTabWidget(QTabWidget):
 
     def restoreTabs(self):
         for script in self.restoreTabList:
-            pathFile = unicode(script)
+            pathFile = script
             if QFileInfo(pathFile).exists():
                 tabName = pathFile.split('/')[-1]
                 self.newTabEditor(tabName, pathFile)
             else:
                 errOnRestore = QCoreApplication.translate("PythonConsole",
                                                           "Unable to restore the file: \n{0}\n").format(pathFile)
-                print '## Error: '
+                print('## Error: ')
                 s = errOnRestore
                 sys.stderr.write(s)
                 self.parent.updateTabListScript(pathFile, action='remove')
@@ -1150,7 +1153,7 @@ class EditorTabWidget(QTabWidget):
             tabWidget = self.widget(tab)
         if tabWidget:
             if tabWidget.path:
-                pathFile, file = os.path.split(unicode(tabWidget.path))
+                pathFile, file = os.path.split(tabWidget.path)
                 module, ext = os.path.splitext(file)
                 found = False
                 if pathFile not in sys.path:
@@ -1161,8 +1164,8 @@ class EditorTabWidget(QTabWidget):
                     dictObject = {}
                     readModule = pyclbr.readmodule(module)
                     readModuleFunction = pyclbr.readmodule_ex(module)
-                    for name, class_data in sorted(readModule.items(), key=lambda x: x[1].lineno):
-                        if os.path.normpath(str(class_data.file)) == os.path.normpath(str(tabWidget.path)):
+                    for name, class_data in sorted(list(readModule.items()), key=lambda x: x[1].lineno):
+                        if os.path.normpath(class_data.file) == os.path.normpath(tabWidget.path):
                             superClassName = []
                             for superClass in class_data.super:
                                 if superClass == 'object':
@@ -1181,11 +1184,11 @@ class EditorTabWidget(QTabWidget):
                                 classItem.setToolTip(0, name)
                             if sys.platform.startswith('win'):
                                 classItem.setSizeHint(0, QSize(18, 18))
-                            classItem.setText(1, str(class_data.lineno))
+                            classItem.setText(1, class_data.lineno)
                             iconClass = QgsApplication.getThemeIcon("console/iconClassTreeWidgetConsole.png")
                             classItem.setIcon(0, iconClass)
                             dictObject[name] = class_data.lineno
-                            for meth, lineno in sorted(class_data.methods.items(), key=itemgetter(1)):
+                            for meth, lineno in sorted(list(class_data.methods.items()), key=itemgetter(1)):
                                 methodItem = QTreeWidgetItem()
                                 methodItem.setText(0, meth + ' ')
                                 methodItem.setText(1, str(lineno))
@@ -1197,9 +1200,9 @@ class EditorTabWidget(QTabWidget):
                                 classItem.addChild(methodItem)
                                 dictObject[meth] = lineno
                             self.parent.listClassMethod.addTopLevelItem(classItem)
-                    for func_name, data in sorted(readModuleFunction.items(), key=lambda x: x[1].lineno):
+                    for func_name, data in sorted(list(readModuleFunction.items()), key=lambda x: x[1].lineno):
                         if isinstance(data, pyclbr.Function) and \
-                           os.path.normpath(str(data.file)) == os.path.normpath(str(tabWidget.path)):
+                           os.path.normpath(data.file) == os.path.normpath(tabWidget.path):
                             funcItem = QTreeWidgetItem()
                             funcItem.setText(0, func_name + ' ')
                             funcItem.setText(1, str(data.lineno))

--- a/python/console/console_sci.py
+++ b/python/console/console_sci.py
@@ -321,11 +321,11 @@ class ShellScintilla(QsciScintilla, code.InteractiveInterpreter):
     def readHistoryFile(self):
         fileExist = QFile.exists(_historyFile)
         if fileExist:
-            rH = codecs.open(_historyFile, 'r', encoding='utf-8')
-            for line in rH:
-                if line != "\n":
-                    l = line.rstrip('\n')
-                    self.updateHistory(l)
+            with codecs.open(_historyFile, 'r', encoding='utf-8') as rH:
+                for line in rH:
+                    if line != "\n":
+                        l = line.rstrip('\n')
+                        self.updateHistory(l)
         else:
             return
 

--- a/python/core/qgsmaplayer.sip
+++ b/python/core/qgsmaplayer.sip
@@ -215,6 +215,9 @@ class QgsMapLayer : QObject
     /** Returns the current blending mode for a layer */
     QPainter::CompositionMode blendMode() const;
 
+    /** Returns if this layer is read only. */
+    bool readOnly() const;
+
     /** Synchronises with changes in the datasource
         */
     virtual void reload();

--- a/python/core/qgsproject.sip
+++ b/python/core/qgsproject.sip
@@ -281,6 +281,21 @@ class QgsProject : QObject
      */
     QgsVisibilityPresetCollection* visibilityPresetCollection();
 
+    /**
+     * Set a list of layers which should not be taken into account on map identification
+     */
+    void setNonIdentifiableLayers( QList<QgsMapLayer*> layers );
+
+    /**
+     * Set a list of layers which should not be taken into account on map identification
+     */
+    void setNonIdentifiableLayers( const QStringList& layerIds );
+
+    /**
+     * Get the list of layers which currently should not be taken into account on map identification
+     */
+    QStringList nonIdentifiableLayers() const;
+
   protected:
 
     /** Set error message from read/write operation
@@ -344,6 +359,9 @@ class QgsProject : QObject
     void loadingLayer( const QString& );
 
     void snapSettingsChanged();
+
+    //! Emitted when the list of layer which are excluded from map identification changes
+    void nonIdentifiableLayersChanged( QStringList nonIdentifiableLayers );
 
   private:
 

--- a/python/gui/gui.sip
+++ b/python/gui/gui.sip
@@ -143,6 +143,7 @@
 %Include qgsslider.sip
 %Include qgssublayersdialog.sip
 %Include qgssvgannotationitem.sip
+%Include qgstablewidgetitem.sip
 %Include qgstextannotationitem.sip
 %Include qgsunitselectionwidget.sip
 %Include qgsuserinputdockwidget.sip

--- a/python/gui/qgsmaplayerproxymodel.sip
+++ b/python/gui/qgsmaplayerproxymodel.sip
@@ -45,7 +45,13 @@ class QgsMapLayerProxyModel : QSortFilterProxyModel
 
     //! offer the possibility to except some layers to be listed
     void setExceptedLayerList( const QList<QgsMapLayer*>& exceptList );
+    //! Get the list of maplayers which are excluded from the list
     QList<QgsMapLayer*> exceptedLayerList();
+
+    //! Set the list of maplayer ids which are excluded from the list
+    void setExceptedLayerIds( const QStringList& ids );
+    //! Get the list of maplayer ids which are excluded from the list
+    QStringList exceptedLayerIds() const;
 
     // QSortFilterProxyModel interface
   public:

--- a/python/gui/qgsmaplayerproxymodel.sip
+++ b/python/gui/qgsmaplayerproxymodel.sip
@@ -20,6 +20,7 @@ class QgsMapLayerProxyModel : QSortFilterProxyModel
       HasGeometry,
       VectorLayer,
       PluginLayer,
+      WritableLayer,
       All
     };
     typedef QFlags<QgsMapLayerProxyModel::Filter> Filters;

--- a/python/gui/qgstablewidgetitem.sip
+++ b/python/gui/qgstablewidgetitem.sip
@@ -1,0 +1,37 @@
+/***************************************************************************
+  qgstablewidgetitem.sip - QgsTableWidgetItem
+
+ ---------------------
+ begin                : 27.3.2016
+ copyright            : (C) 2016 by Matthias Kuhn, OPENGIS.ch
+ email                : matthias@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+class QgsTableWidgetItem : QTableWidgetItem
+{
+%TypeHeaderCode
+#include "qgstablewidgetitem.h"
+%End
+
+  public:
+    QgsTableWidgetItem();
+    QgsTableWidgetItem( const QString& text );
+
+    /**
+     * Set the role by which the items should be sorted.
+     * By default this will be set to Qt::DisplayRole
+     */
+    void setSortRole(  int role );
+    /**
+     * Get the role by which the items should be sorted.
+     * By default this will be Qt::DisplayRole
+     */
+    int sortRole() const;
+};

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -7247,7 +7247,7 @@ bool QgisApp::toggleEditing( QgsMapLayer *layer, bool allowCancel )
   if ( vlayer->isModified() || ( tg && tg->layers().contains( vlayer ) && tg->modified() ) )
     isModified  = true;
 
-  if ( !vlayer->isEditable() && !vlayer->isReadOnly() )
+  if ( !vlayer->isEditable() && !vlayer->readOnly() )
   {
     if ( !( vlayer->dataProvider()->capabilities() & QgsVectorDataProvider::EditingCapabilities ) )
     {
@@ -10011,7 +10011,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer* layer )
 
       mActionLayerSubsetString->setEnabled( !isEditable && dprovider->supportsSubsetString() );
 
-      mActionToggleEditing->setEnabled( canSupportEditing && !vlayer->isReadOnly() );
+      mActionToggleEditing->setEnabled( canSupportEditing && !vlayer->readOnly() );
       mActionToggleEditing->setChecked( canSupportEditing && isEditable );
       mActionSaveLayerEdits->setEnabled( canSupportEditing && isEditable && vlayer->isModified() );
       mUndoWidget->dockContents()->setEnabled( canSupportEditing && isEditable );

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -193,7 +193,7 @@ QgsAttributeTableDialog::QgsAttributeTableDialog( QgsVectorLayer *theLayer, QWid
   mToggleEditingButton->blockSignals( true );
   mToggleEditingButton->setCheckable( true );
   mToggleEditingButton->setChecked( mLayer->isEditable() );
-  mToggleEditingButton->setEnabled(( canChangeAttributes || canDeleteFeatures || canAddAttributes || canDeleteAttributes || canAddFeatures ) && !mLayer->isReadOnly() );
+  mToggleEditingButton->setEnabled(( canChangeAttributes || canDeleteFeatures || canAddAttributes || canDeleteAttributes || canAddFeatures ) && !mLayer->readOnly() );
   mToggleEditingButton->blockSignals( false );
 
   mSaveEditsButton->setEnabled( mToggleEditingButton->isEnabled() && mLayer->isEditable() );

--- a/src/app/qgsfieldsproperties.cpp
+++ b/src/app/qgsfieldsproperties.cpp
@@ -672,7 +672,7 @@ void QgsFieldsProperties::updateButtons()
 {
   int cap = mLayer->dataProvider()->capabilities();
 
-  mToggleEditingButton->setEnabled(( cap & QgsVectorDataProvider::ChangeAttributeValues ) && !mLayer->isReadOnly() );
+  mToggleEditingButton->setEnabled(( cap & QgsVectorDataProvider::ChangeAttributeValues ) && !mLayer->readOnly() );
 
   if ( mLayer->isEditable() )
   {

--- a/src/app/qgsguivectorlayertools.cpp
+++ b/src/app/qgsguivectorlayertools.cpp
@@ -56,7 +56,7 @@ bool QgsGuiVectorLayerTools::startEditing( QgsVectorLayer* layer ) const
 
   bool res = true;
 
-  if ( !layer->isEditable() && !layer->isReadOnly() )
+  if ( !layer->isEditable() && !layer->readOnly() )
   {
     if ( !( layer->dataProvider()->capabilities() & QgsVectorDataProvider::EditingCapabilities ) )
     {

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -228,7 +228,7 @@ QgsProjectProperties::QgsProjectProperties( QgsMapCanvas* mapCanvas, QWidget *pa
 
   QgsMapLayer* currentLayer = nullptr;
 
-  QStringList noIdentifyLayerIdList = QgsProject::instance()->readListEntry( "Identify", "/disabledLayers" );
+  QStringList noIdentifyLayerIdList = QgsProject::instance()->nonIdentifiableLayers();
 
   const QMap<QString, QgsMapLayer*> &mapLayers = QgsMapLayerRegistry::instance()->mapLayers();
 
@@ -888,7 +888,7 @@ void QgsProjectProperties::apply()
     }
   }
 
-  QgsProject::instance()->writeEntry( "Identify", "/disabledLayers", noIdentifyLayerList );
+  QgsProject::instance()->setNonIdentifiableLayers( noIdentifyLayerList );
 
   QgsProject::instance()->writeEntry( "WMSServiceCapabilities", "/", grpOWSServiceCapabilities->isChecked() );
   QgsProject::instance()->writeEntry( "WMSServiceTitle", "/", mWMSTitle->text() );

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -231,6 +231,9 @@ class CORE_EXPORT QgsMapLayer : public QObject
     /** Returns the current blending mode for a layer */
     QPainter::CompositionMode blendMode() const;
 
+    /** Returns if this layer is read only. */
+    bool readOnly() const { return isReadOnly(); }
+
     /** Synchronises with changes in the datasource
         */
     virtual void reload() {}
@@ -735,6 +738,12 @@ class CORE_EXPORT QgsMapLayer : public QObject
     QgsError mError;
 
   private:
+    /**
+     * This method returns true by default but can be overwritten to specify
+     * that a certain layer is writable.
+     */
+    virtual bool isReadOnly() const { return true; }
+
     /** Layer's spatial reference system.
         private to make sure setCrs must be used and layerCrsChanged() is emitted */
     QgsCoordinateReferenceSystem* mCRS;

--- a/src/core/qgsproject.h
+++ b/src/core/qgsproject.h
@@ -70,6 +70,7 @@ class QgsVisibilityPresetCollection;
 class CORE_EXPORT QgsProject : public QObject
 {
     Q_OBJECT
+    Q_PROPERTY( QStringList nonIdentifiableLayers READ nonIdentifiableLayers WRITE setNonIdentifiableLayers NOTIFY nonIdentifiableLayersChanged )
 
   public:
 
@@ -327,8 +328,22 @@ class CORE_EXPORT QgsProject : public QObject
      */
     QgsVisibilityPresetCollection* visibilityPresetCollection();
 
-  protected:
+    /**
+     * Set a list of layers which should not be taken into account on map identification
+     */
+    void setNonIdentifiableLayers( QList<QgsMapLayer*> layers );
 
+    /**
+     * Set a list of layers which should not be taken into account on map identification
+     */
+    void setNonIdentifiableLayers( const QStringList& layerIds );
+
+    /**
+     * Get the list of layers which currently should not be taken into account on map identification
+     */
+    QStringList nonIdentifiableLayers() const;
+
+  protected:
     /** Set error message from read/write operation
      * @note not available in Python bindings
      */
@@ -391,6 +406,9 @@ class CORE_EXPORT QgsProject : public QObject
 
     void snapSettingsChanged();
 
+    //! Emitted when the list of layer which are excluded from map identification changes
+    void nonIdentifiableLayersChanged( QStringList nonIdentifiableLayers );
+
   private:
 
     QgsProject(); // private 'cause it's a singleton
@@ -426,7 +444,6 @@ class CORE_EXPORT QgsProject : public QObject
     QgsLayerTreeRegistryBridge* mLayerTreeRegistryBridge;
 
     QScopedPointer<QgsVisibilityPresetCollection> mVisibilityPresetCollection;
-
 }; // QgsProject
 
 

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -1421,6 +1421,10 @@ bool QgsVectorLayer::readXml( const QDomNode& layer_node )
     return false;
   }
 
+  QDomElement mapLayerNode = layer_node.toElement();
+  if ( mapLayerNode.attribute( "readOnly", "0" ).toInt() == 1 )
+    mReadOnly = true;
+
   QDomElement pkeyElem = pkeyNode.toElement();
   if ( !pkeyElem.isNull() )
   {
@@ -1641,6 +1645,9 @@ bool QgsVectorLayer::writeXml( QDomNode & layer_node,
     provider.appendChild( providerText );
     layer_node.appendChild( provider );
   }
+
+  // save readonly state
+  mapLayerNode.setAttribute( "readOnly", mReadOnly );
 
   // save preview expression
   QDomElement prevExpElem = document.createElement( "previewExpression" );

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -379,7 +379,7 @@ protected:
  *
  * Provider to display vector data in a GRASS GIS layer.
  *
- * TODO QGIS3: Remove virtual from non-inherited methods (like isModified, isReadOnly)
+ * TODO QGIS3: Remove virtual from non-inherited methods (like isModified)
  */
 
 
@@ -1090,8 +1090,14 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
 
     virtual bool isSpatial() const override;
 
-    /** Returns true if the provider is in read-only mode */
-    virtual bool isReadOnly() const;
+    /**
+     * Returns true if the provider is in read-only mode
+     *
+     * @deprecated Use readOnly() instead. Will be made private with QGIS 3
+     *
+     * TODO QGIS3: make private
+     */
+    Q_DECL_DEPRECATED virtual bool isReadOnly() const override;
 
     /** Returns true if the provider has been modified since the last commit */
     virtual bool isModified() const;

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -267,6 +267,7 @@ SET(QGIS_GUI_SRCS
   qgsslider.cpp
   qgssublayersdialog.cpp
   qgssvgannotationitem.cpp
+  qgstablewidgetitem.cpp
   qgstextannotationitem.cpp
   qgsunitselectionwidget.cpp
   qgsuserinputdockwidget.cpp
@@ -575,6 +576,7 @@ SET(QGIS_GUI_HDRS
   qgsnumericsortlistviewitem.h
   qgsrubberband.h
   qgssvgannotationitem.h
+  qgstablewidgetitem.h
   qgstextannotationitem.h
   qgsuserinputdockwidget.h
   qgsvectorlayertools.h

--- a/src/gui/qgsmaplayerproxymodel.cpp
+++ b/src/gui/qgsmaplayerproxymodel.cpp
@@ -84,6 +84,11 @@ bool QgsMapLayerProxyModel::filterAcceptsRow( int source_row, const QModelIndex 
   if ( mExceptList.contains( layer ) )
     return false;
 
+  QgsVectorLayer* vl = qobject_cast<QgsVectorLayer*>( layer );
+
+  if ( mFilters.testFlag( WritableLayer ) && layer->readOnly() )
+    return false;
+
   // layer type
   if (( mFilters.testFlag( RasterLayer ) && layer->type() == QgsMapLayer::RasterLayer ) ||
       ( mFilters.testFlag( VectorLayer ) && layer->type() == QgsMapLayer::VectorLayer ) ||
@@ -98,7 +103,6 @@ bool QgsMapLayerProxyModel::filterAcceptsRow( int source_row, const QModelIndex 
                         mFilters.testFlag( HasGeometry );
   if ( detectGeometry && layer->type() == QgsMapLayer::VectorLayer )
   {
-    QgsVectorLayer* vl = dynamic_cast<QgsVectorLayer*>( layer );
     if ( vl )
     {
       if ( mFilters.testFlag( HasGeometry ) && vl->hasGeometryType() )

--- a/src/gui/qgsmaplayerproxymodel.cpp
+++ b/src/gui/qgsmaplayerproxymodel.cpp
@@ -16,6 +16,7 @@
 #include "qgsmaplayerproxymodel.h"
 #include "qgsmaplayermodel.h"
 #include "qgsmaplayer.h"
+#include "qgsmaplayerregistry.h"
 #include "qgsvectorlayer.h"
 
 QgsMapLayerProxyModel::QgsMapLayerProxyModel( QObject *parent )
@@ -40,8 +41,34 @@ QgsMapLayerProxyModel *QgsMapLayerProxyModel::setFilters( const Filters& filters
 
 void QgsMapLayerProxyModel::setExceptedLayerList( const QList<QgsMapLayer*>& exceptList )
 {
+  if ( mExceptList == exceptList )
+    return;
+
   mExceptList = exceptList;
   invalidateFilter();
+}
+
+void QgsMapLayerProxyModel::setExceptedLayerIds( const QStringList& ids )
+{
+  mExceptList.clear();
+
+  Q_FOREACH ( const QString& id, ids )
+  {
+    QgsMapLayer* l = QgsMapLayerRegistry::instance()->mapLayer( id );
+    if ( l )
+      mExceptList << l;
+  }
+  invalidateFilter();
+}
+
+QStringList QgsMapLayerProxyModel::exceptedLayerIds() const
+{
+  QStringList lst;
+
+  Q_FOREACH ( QgsMapLayer* l, mExceptList )
+    lst << l->id();
+
+  return lst;
 }
 
 bool QgsMapLayerProxyModel::filterAcceptsRow( int source_row, const QModelIndex &source_parent ) const

--- a/src/gui/qgsmaplayerproxymodel.h
+++ b/src/gui/qgsmaplayerproxymodel.h
@@ -17,6 +17,7 @@
 #define QGSMAPLAYERPROXYMODEL_H
 
 #include <QSortFilterProxyModel>
+#include <QStringList>
 
 class QgsMapLayerModel;
 class QgsMapLayer;
@@ -31,6 +32,8 @@ class GUI_EXPORT QgsMapLayerProxyModel : public QSortFilterProxyModel
     Q_FLAGS( Filters )
 
     Q_PROPERTY( QgsMapLayerProxyModel::Filters filters READ filters WRITE setFilters )
+    Q_PROPERTY( QList<QgsMapLayer*> exceptedLayerList READ exceptedLayerList WRITE setExceptedLayerList )
+    Q_PROPERTY( QStringList exceptedLayerIds READ exceptedLayerIds WRITE setExceptedLayerIds )
 
   public:
     enum Filter
@@ -68,7 +71,13 @@ class GUI_EXPORT QgsMapLayerProxyModel : public QSortFilterProxyModel
 
     //! offer the possibility to except some layers to be listed
     void setExceptedLayerList( const QList<QgsMapLayer*>& exceptList );
+    //! Get the list of maplayers which are excluded from the list
     QList<QgsMapLayer*> exceptedLayerList() {return mExceptList;}
+
+    //! Set the list of maplayer ids which are excluded from the list
+    void setExceptedLayerIds( const QStringList& ids );
+    //! Get the list of maplayer ids which are excluded from the list
+    QStringList exceptedLayerIds() const;
 
   private:
     Filters mFilters;

--- a/src/gui/qgsmaplayerproxymodel.h
+++ b/src/gui/qgsmaplayerproxymodel.h
@@ -46,6 +46,7 @@ class GUI_EXPORT QgsMapLayerProxyModel : public QSortFilterProxyModel
       HasGeometry = PointLayer | LineLayer | PolygonLayer,
       VectorLayer = NoGeometry | HasGeometry,
       PluginLayer = 32,
+      WritableLayer = 64,
       All = RasterLayer | VectorLayer | PluginLayer
     };
     Q_DECLARE_FLAGS( Filters, Filter )

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -146,7 +146,7 @@ void QgsRelationEditorWidget::setRelationFeature( const QgsRelation& relation, c
   QgsVectorLayer* lyr = relation.referencingLayer();
 
   bool canChangeAttributes = lyr->dataProvider()->capabilities() & QgsVectorDataProvider::ChangeAttributeValues;
-  if ( canChangeAttributes && !lyr->isReadOnly() )
+  if ( canChangeAttributes && !lyr->readOnly() )
   {
     mToggleEditingButton->setEnabled( true );
     updateButtons();
@@ -205,7 +205,7 @@ void QgsRelationEditorWidget::setRelations( const QgsRelation& relation, const Q
   QgsVectorLayer* lyr = relation.referencingLayer();
 
   bool canChangeAttributes = lyr->dataProvider()->capabilities() & QgsVectorDataProvider::ChangeAttributeValues;
-  if ( canChangeAttributes && !lyr->isReadOnly() )
+  if ( canChangeAttributes && !lyr->readOnly() )
   {
     mToggleEditingButton->setEnabled( true );
     updateButtons();

--- a/src/gui/qgstablewidgetitem.cpp
+++ b/src/gui/qgstablewidgetitem.cpp
@@ -39,5 +39,9 @@ int QgsTableWidgetItem::sortRole() const
 
 bool QgsTableWidgetItem::operator<( const QTableWidgetItem& other ) const
 {
+#if QT_VERSION < 0x050000
+  return data( mSortRole ).toString() < other.data( mSortRole ).toString();
+#else
   return data( mSortRole ) < other.data( mSortRole );
+#endif
 }

--- a/src/gui/qgstablewidgetitem.cpp
+++ b/src/gui/qgstablewidgetitem.cpp
@@ -1,0 +1,43 @@
+/***************************************************************************
+  qgstablewidgetitem.cpp - QgsTableWidgetItem
+
+ ---------------------
+ begin                : 27.3.2016
+ copyright            : (C) 2016 by Matthias Kuhn, OPENGIS.ch
+ email                : matthias@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include "qgstablewidgetitem.h"
+
+QgsTableWidgetItem::QgsTableWidgetItem()
+    : QTableWidgetItem()
+    , mSortRole( Qt::DisplayRole )
+{
+}
+
+QgsTableWidgetItem::QgsTableWidgetItem( const QString& text )
+    : QTableWidgetItem( text )
+    , mSortRole( Qt::DisplayRole )
+{
+}
+
+void QgsTableWidgetItem::setSortRole( int role )
+{
+  mSortRole = role;
+}
+
+int QgsTableWidgetItem::sortRole() const
+{
+  return mSortRole;
+}
+
+bool QgsTableWidgetItem::operator<( const QTableWidgetItem& other ) const
+{
+  return data( mSortRole ) < other.data( mSortRole );
+}

--- a/src/gui/qgstablewidgetitem.h
+++ b/src/gui/qgstablewidgetitem.h
@@ -26,6 +26,9 @@ class GUI_EXPORT QgsTableWidgetItem : public QTableWidgetItem
 {
   public:
     QgsTableWidgetItem();
+    /**
+     * Creates a new table widget item with the specified text.
+     */
     QgsTableWidgetItem( const QString& text );
 
 

--- a/src/gui/qgstablewidgetitem.h
+++ b/src/gui/qgstablewidgetitem.h
@@ -1,0 +1,49 @@
+/***************************************************************************
+  qgstablewidgetitem.h - QgsTableWidgetItem
+
+ ---------------------
+ begin                : 27.3.2016
+ copyright            : (C) 2016 by Matthias Kuhn, OPENGIS.ch
+ email                : matthias@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSTABLEWIDGETITEM_H
+#define QGSTABLEWIDGETITEM_H
+
+#include <QTableWidget>
+
+/**
+ * This can be used like a regular QTableWidgetItem with the difference that a
+ * specific role can be set to sort.
+ */
+class GUI_EXPORT QgsTableWidgetItem : public QTableWidgetItem
+{
+  public:
+    QgsTableWidgetItem();
+    QgsTableWidgetItem( const QString& text );
+
+
+    /**
+     * Set the role by which the items should be sorted.
+     * By default this will be set to Qt::DisplayRole
+     */
+    void setSortRole( int role );
+    /**
+     * Get the role by which the items should be sorted.
+     * By default this will be Qt::DisplayRole
+     */
+    int sortRole() const;
+
+    bool operator <( const QTableWidgetItem& other ) const override;
+
+  private:
+    int mSortRole;
+};
+
+#endif // QGSTABLEWIDGETITEM_H

--- a/src/ui/qgsprojectpropertiesbase.ui
+++ b/src/ui/qgsprojectpropertiesbase.ui
@@ -218,7 +218,7 @@
           </sizepolicy>
          </property>
          <property name="currentIndex">
-          <number>0</number>
+          <number>2</number>
          </property>
          <widget class="QWidget" name="mProjOpts_01">
           <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -248,7 +248,7 @@
                 <x>0</x>
                 <y>0</y>
                 <width>683</width>
-                <height>779</height>
+                <height>776</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_8">
@@ -749,8 +749,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>326</width>
-                <height>46</height>
+                <width>683</width>
+                <height>776</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_7">
@@ -808,8 +808,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>133</width>
-                <height>100</height>
+                <width>683</width>
+                <height>776</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_10">
@@ -851,6 +851,11 @@
                       <string>Identifiable</string>
                      </property>
                     </column>
+                    <column>
+                     <property name="text">
+                      <string>Read Only</string>
+                     </property>
+                    </column>
                    </widget>
                   </item>
                  </layout>
@@ -889,8 +894,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>379</width>
-                <height>582</height>
+                <width>381</width>
+                <height>607</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_12">
@@ -1314,8 +1319,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>663</width>
-                <height>2249</height>
+                <width>642</width>
+                <height>2374</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_13">
@@ -2380,7 +2385,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>168</width>
+                <width>166</width>
                 <height>46</height>
                </rect>
               </property>


### PR DESCRIPTION
Vector Layers can already be set to readonly via API calls. There were two problems with this which are solved with this PR
- ReadOnly state is now persisted in the project file
- ReadOnly state can now be controlled from the project properties

Then there are some other changes for non-identifyable layers which previously have been managed by directly writing to the project. This is now centralized as a standarized API.
