### PR TITLE
[Spatialite] Use correct free function for sqlite3_bind_blob of geome…

### DIFF
--- a/src/providers/spatialite/qgsspatialiteprovider.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovider.cpp
@@ -3594,6 +3594,11 @@ QString QgsSpatiaLiteProvider::geomParam() const
   return geometry;
 }
 
+static void deleteWkbBlob( void* wkbBlob )
+{
+  delete[]( char* )wkbBlob;
+}
+
 bool QgsSpatiaLiteProvider::addFeatures( QgsFeatureList & flist )
 {
   sqlite3_stmt *stmt = nullptr;
@@ -3677,7 +3682,7 @@ bool QgsSpatiaLiteProvider::addFeatures( QgsFeatureList & flist )
             if ( !wkb )
               sqlite3_bind_null( stmt, ++ia );
             else
-              sqlite3_bind_blob( stmt, ++ia, wkb, wkb_size, free );
+              sqlite3_bind_blob( stmt, ++ia, wkb, wkb_size, deleteWkbBlob );
           }
         }
 
@@ -4070,7 +4075,7 @@ bool QgsSpatiaLiteProvider::changeGeometryValues( const QgsGeometryMap &geometry
     if ( !wkb )
       sqlite3_bind_null( stmt, 1 );
     else
-      sqlite3_bind_blob( stmt, 1, wkb, wkb_size, free );
+      sqlite3_bind_blob( stmt, 1, wkb, wkb_size, deleteWkbBlob );
     sqlite3_bind_int64( stmt, 2, FID_TO_NUMBER( iter.key() ) );
 
     // performing actual row update


### PR DESCRIPTION
…tries

Currently sqlite3_bind_blob() uses free() as the free function of WKB
blobs returned by convertFromGeosWKB(). But those are allocated with
new[] and should consequently be freed with delete[].

Spotted by Valgrind:
==4014== Mismatched free() / delete / delete []
==4014==    at 0x4C287BE: free (vg_replace_malloc.c:446)
==4014==    by 0xE42E481: sqlite3VdbeMemReleaseExternal (sqlite3.c:57237)
==4014==    by 0xE42E4E3: sqlite3VdbeMemRelease (sqlite3.c:57252)
==4014==    by 0xE42EC3E: releaseMemArray (sqlite3.c:59208)
==4014==    by 0xE42ED1E: sqlite3VdbeDeleteObject (sqlite3.c:60561)
==4014==    by 0xE46A6DB: sqlite3VdbeFinalize (sqlite3.c:60528)
==4014==    by 0xE46A916: sqlite3_finalize (sqlite3.c:61431)
==4014==    by 0x7FB23958: QgsSpatiaLiteProvider::addFeatures(QList<QgsFeature>&) (qgsspatialiteprovider.cpp:3752)
==4014==  Address 0x8e2a8b30 is 0 bytes inside a block of size 94 alloc'd
==4014==    at 0x4C29520: operator new[](unsigned long) (vg_replace_malloc.c:363)
==4014==    by 0x7FB1B964: QgsSpatiaLiteProvider::convertFromGeosWKB(unsigned char const_, int, unsigned char__, int_, int) (qgsspatialiteprovider.cpp:1341)
==4014==    by 0x7FB234B5: QgsSpatiaLiteProvider::addFeatures(QList<QgsFeature>&) (qgsspatialiteprovider.cpp:3676)
