### PR TITLE
Use consistant default value of 60000ms for /qgis/networkAndProxy/networkTimeout

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -11089,7 +11089,7 @@ void QgisApp::namSslErrors( QNetworkReply *reply, const QList<QSslError> &errors
     {
       QgsDebugMsg( "Restarting network reply timeout" );
       timer->setSingleShot( true );
-      timer->start( s.value( "/qgis/networkAndProxy/networkTimeout", "20000" ).toInt() );
+      timer->start( s.value( "/qgis/networkAndProxy/networkTimeout", "60000" ).toInt() );
     }
   }
 }

--- a/src/core/qgshttptransaction.cpp
+++ b/src/core/qgshttptransaction.cpp
@@ -58,7 +58,7 @@ QgsHttpTransaction::QgsHttpTransaction( const QString& uri,
   Q_UNUSED( userName );
   Q_UNUSED( password );
   QSettings s;
-  mNetworkTimeoutMsec = s.value( "/qgis/networkAndProxy/networkTimeout", "20000" ).toInt();
+  mNetworkTimeoutMsec = s.value( "/qgis/networkAndProxy/networkTimeout", "60000" ).toInt();
 }
 
 QgsHttpTransaction::QgsHttpTransaction()
@@ -69,7 +69,7 @@ QgsHttpTransaction::QgsHttpTransaction()
     , mWatchdogTimer( nullptr )
 {
   QSettings s;
-  mNetworkTimeoutMsec = s.value( "/qgis/networkAndProxy/networkTimeout", "20000" ).toInt();
+  mNetworkTimeoutMsec = s.value( "/qgis/networkAndProxy/networkTimeout", "60000" ).toInt();
 }
 
 QgsHttpTransaction::~QgsHttpTransaction()

--- a/src/core/qgsnetworkaccessmanager.cpp
+++ b/src/core/qgsnetworkaccessmanager.cpp
@@ -217,7 +217,7 @@ QNetworkReply *QgsNetworkAccessManager::createRequest( QNetworkAccessManager::Op
   timer->setObjectName( "timeoutTimer" );
   connect( timer, SIGNAL( timeout() ), this, SLOT( abortRequest() ) );
   timer->setSingleShot( true );
-  timer->start( s.value( "/qgis/networkAndProxy/networkTimeout", "20000" ).toInt() );
+  timer->start( s.value( "/qgis/networkAndProxy/networkTimeout", "60000" ).toInt() );
 
   connect( reply, SIGNAL( downloadProgress( qint64, qint64 ) ), timer, SLOT( start() ) );
   connect( reply, SIGNAL( uploadProgress( qint64, qint64 ) ), timer, SLOT( start() ) );


### PR DESCRIPTION
Currently there's an inconsistancy between the Options dialog that displays a
default value of 60000ms for network request timeouts, whereas places in the
code use 20000ms. I propose to align on 60000s, since there are occurrences
of network requests, for example big WFS GetFeature requests, that can take
more than 20s to start.
