### PR TITLE
[Spatialite] Fix crash on iterator closing if connection failed.

### DIFF
--- a/src/providers/spatialite/qgsspatialitefeatureiterator.cpp
+++ b/src/providers/spatialite/qgsspatialitefeatureiterator.cpp
@@ -235,10 +235,16 @@ bool QgsSpatiaLiteFeatureIterator::rewind()
 
 bool QgsSpatiaLiteFeatureIterator::close()
 {
-  if ( !mHandle )
+  if ( mClosed )
     return false;
 
   iteratorClosed();
+
+  if ( !mHandle )
+  {
+    mClosed = true;
+    return false;
+  }
 
   if ( sqliteStatement )
   {

--- a/tests/src/python/test_provider_spatialite.py
+++ b/tests/src/python/test_provider_spatialite.py
@@ -15,6 +15,7 @@ __revision__ = '$Format:%H$'
 import qgis  # NOQA
 
 import os
+import shutil
 import tempfile
 
 from qgis.core import QgsVectorLayer, QgsPoint, QgsFeature
@@ -201,6 +202,16 @@ class TestQgsSpatialiteProvider(unittest.TestCase, ProviderTestCase):
         fields = [f.name() for f in l.dataProvider().fields()]
         assert('Geometry' not in fields)
 
+    def test_invalid_iterator(self):
+        """ Test invalid iterator """
+        corrupt_dbname = self.dbname + '.corrupt'
+        shutil.copy(self.dbname, corrupt_dbname)
+        layer = QgsVectorLayer("dbname=%s table=test_pg (geometry)" % corrupt_dbname, "test_pg", "spatialite")
+        # Corrupt the database
+        open(corrupt_dbname, 'wb').write('')
+        layer.getFeatures()
+        layer = None
+        os.unlink(corrupt_dbname)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
If an iterator fails to open the spatialite database (mHandle == nullptr
in QgsSpatiaLiteFeatureIterator::QgsSpatiaLiteFeatureIterator() ),
a crash will occur at the destruction of the QgsSpatiaLiteFeatureSource,
due to the iterator not being removed from the list of active iterators.

Currently QgsSpatiaLiteFeatureIterator::close() does not call
iteratorClosed() if mHandle is invalid, which later causes
QgsAbstractFeatureSource::~QgsAbstractFeatureSource() to try calling
the close() method of a now defunct iterator.

If not applying the patch, the added test case crashes with:

177: src/providers/spatialite/qgsspatialiteconnection.cpp: 736: (openDb) [1ms] New sqlite connection for /tmp/test.sqlite.corrupt
177: src/providers/spatialite/qgsspatialiteconnection.cpp: 750: (openDb) [1ms] Failure while connecting to: /tmp/test.sqlite.corrupt
177:
177: invalid metadata tables
177: src/core/qgsfeaturerequest.cpp: 259: (~QgsAbstractFeatureSource) [0ms] closing active iterator
177: CMake Error at PyQgsSpatialiteProvider.cmake:22 (MESSAGE):
177:   Test failed: Segmentation fault
