### PR TITLE
[processing] Fixed UI bug with invalid button width.

### DIFF
--- a/python/plugins/processing/modeler/ModelerParametersDialog.py
+++ b/python/plugins/processing/modeler/ModelerParametersDialog.py
@@ -125,10 +125,12 @@ class ModelerParametersDialog(QDialog):
             if param.isAdvanced:
                 self.advancedButton = QPushButton()
                 self.advancedButton.setText(self.tr('Show advanced parameters'))
-                self.advancedButton.setMaximumWidth(150)
                 self.advancedButton.clicked.connect(
                     self.showAdvancedParametersClicked)
-                self.verticalLayout.addWidget(self.advancedButton)
+                advancedButtonHLayout = QHBoxLayout()
+                advancedButtonHLayout.addWidget(self.advancedButton)
+                advancedButtonHLayout.addStretch()
+                self.verticalLayout.addLayout(advancedButtonHLayout)
                 break
         for param in self._alg.parameters:
             if param.hidden:


### PR DESCRIPTION
Hello!

I just found small uI glitch with button (the width is too small to display text correctly).
Some screens (before and after attached).

Best regards,
Kirill Abramov.

![qgis_modeler_bug](https://cloud.githubusercontent.com/assets/7783792/14033595/a6ece134-f22c-11e5-9db6-61e6b21e329f.png)
![qgis_modeler_bug_fix](https://cloud.githubusercontent.com/assets/7783792/14033596/a708f0b8-f22c-11e5-8d3b-8b5e89b9c764.png)
