### PR TITLE
Debian packaging improvements

### DIFF
--- a/debian/control.in
+++ b/debian/control.in
@@ -64,7 +64,8 @@ Build-Depends:
  spawn-fcgi, lighttpd, poppler-utils, locales, qt4-doc-html,
  libqt4-sql-sqlite, python-psycopg2
 Build-Conflicts: libqgis-dev, qgis-dev
-#sid stretch jessie vivid wily xenial#Standards-Version: 3.9.6
+#sid stretch xenial#Standards-Version: 3.9.7
+#jessie vivid wily#Standards-Version: 3.9.6
 #wheezy#Standards-Version: 3.9.3
 #precise trusty#Standards-Version: 3.8.4
 #sid stretch jessie#X-Python-Version: >= 2.7, << 2.8

--- a/debian/control.in
+++ b/debian/control.in
@@ -407,6 +407,7 @@ Depends:
  gdal-bin,
  python-gdal,
  python-matplotlib,
+ python-shapely,
  libqgis-customwidgets,
  ${misc:Depends}
 XB-Python-Version: ${python:Versions}

--- a/debian/copyright
+++ b/debian/copyright
@@ -89,7 +89,6 @@ Copyright:                   Carl Anderson
                        2014, Radoslaw Guzinski <rmgu@dhi-gras.com>
        2004-2006, 2009-2015, Radim Blazek <blazek@itc.it>
                   2004-2015, Marco Hugentobler <marco@sourcepole.ch>
-       2008-2012, 2014-2015, Jürgen E. Fischer <jef@norbit.de>
                   2009-2015, Alexander Bruy <alexander.bruy@gmail.com>
                   2012-2015, The QGIS Project
                   2012-2015, Larry Shaffer <lshaffer@boundlessgeo.com>
@@ -111,6 +110,7 @@ Copyright:                   Carl Anderson
                  2008, 2015, Stéphane Brunner <stephane.brunner@camptocamp.org>
       2005, 2012, 2014-2016, Hugo Mercier <hugo.mercier@oslandia.com>
                   2005-2016, Martin Dobias <wonder.sk@gmail.com>
+       2008-2012, 2014-2016, Jürgen E. Fischer <jef@norbit.de>
                   2012-2016, Denis Rouzaud <denis.rouzaud@gmail.com>
                   2012-2016, Matthias Kuhn <matthias@opengis.ch>
                   2012-2016, Victor Olaya <volayaf@gmail.com>
@@ -249,6 +249,7 @@ License: GPL-2+
 
 Files: src/app/gps/qwtpolar-0.1/*
  src/app/gps/qwtpolar-1.0/*
+ src/app/gps/qwtpolar-1.1.1/*
 Copyright: 2008, Uwe Rathmann
 Comment: This library is free software; you can redistribute it and/or
  modify it under the terms of the Qwt License, Version 1.0
@@ -468,30 +469,23 @@ Files: cmake/FindIconv.cmake
 Copyright: 2009, Juergen E. Fischer <jef at norbit dot de>
 License: BSD-3-Clause
 
-Files: cmake/FindLibPython.py
- cmake/FindPyQt4.cmake
- cmake/FindPyQt4.py
- cmake/FindPyQt5.cmake
- cmake/FindPyQt5.py
- cmake/FindSIP.py
-Copyright: 2007, Simon Edwards <simon@simonzone.com>
-License: BSD-3-Clause
-
 Files: cmake/FindOSGEARTH.cmake
 Copyright: 2011-2013, Pirmin Kalberer
                 2011, Jürgen E. Fischer <jef at norbit.de>
                 2013, William Kyngesburye
 License: BSD-3-Clause
 
-Files: cmake/FindPyQt4.cmake
-Copyright: 2007-2008, Simon Edwards <simon@simonzone.com>
-License: BSD-3-Clause
-
-Files: cmake/FindPythonLibrary.cmake
+Files: cmake/FindLibPython.py
+ cmake/FindPyQt4.cmake
+ cmake/FindPyQt4.py
+ cmake/FindPyQt5.cmake
+ cmake/FindPyQt5.py
+ cmake/FindPythonLibrary.cmake
  cmake/FindSIP.cmake
+ cmake/FindSIP.py
  cmake/PythonMacros.cmake
  cmake/SIPMacros.cmake
-Copyright: 2007, Simon Edwards <simon@simonzone.com>
+Copyright: 2007-2008, Simon Edwards <simon@simonzone.com>
 License: BSD-3-Clause
 
 Files: cmake/FindQCA.cmake

--- a/debian/rules
+++ b/debian/rules
@@ -7,6 +7,9 @@
 # This has to be exported to make some magic below work.
 export DH_OPTIONS
 
+# Enable hardening build flags
+export DEB_BUILD_MAINT_OPTIONS=hardening=+all
+
 # These are used for cross-compiling and for saving the configure script
 # from having to guess our platform (since we know it already)
 DEB_HOST_GNU_TYPE   ?= $(shell dpkg-architecture -qDEB_HOST_GNU_TYPE)

--- a/debian/rules
+++ b/debian/rules
@@ -251,6 +251,35 @@ endif
 override_dh_auto_install:
 	dh_auto_install
 
+	# remove unwanted files
+	$(RM) $(CURDIR)/debian/tmp/usr/share/qgis/doc/api/installdox
+	$(RM) $(CURDIR)/debian/tmp/usr/share/qgis/doc/api/html/jquery.js
+	$(RM) $(CURDIR)/debian/tmp/usr/share/qgis/doc/api/jquery.js
+
+	# replace leaflet and jquery urls
+	perl -i -p \
+		-e 's#http://.*/leaflet.css#leaflet/leaflet.css#;s#http://.*/leaflet.js#leaflet/leaflet.js#;s#http://.*/jquery-.*.min.js#jquery-min.js#' \
+		$(CURDIR)/debian/tmp/usr/share/qgis/doc/developersmap.html
+
+	# Use /usr/bin/python2.7 explicitly for Python Policy compliance
+	perl -i -pe 's=#!/usr/bin/env python=#!/usr/bin/python2.7=;' $$(find debian/tmp -name "*.py")
+
+	# Don't include a copy of the world.tif also included in osgearth-data
+	$(RM) $(CURDIR)/debian/tmp/usr/share/qgis/globe/world.tif
+
+	# remove extra license files
+	-find $(CURDIR)/debian/tmp/usr/share/qgis/resources/cpt-city-qgis-min/ -name COPYING.xml -delete
+	$(RM) $(CURDIR)/debian/tmp/usr/share/qgis/doc/LICENSE
+	$(RM) $(CURDIR)/debian/tmp/usr/share/qgis/python/plugins/db_manager/LICENSE
+	$(RM) $(CURDIR)/debian/tmp/usr/share/qgis/python/plugins/MetaSearch/LICENSE.txt
+
+	# Man pages are installed by dh_installman
+	$(RM) $(CURDIR)/debian/tmp/usr/man/man1/qgis.1
+	$(RM) $(CURDIR)/debian/tmp/usr/man/man1/qbrowser.1
+
+	# Don't ship srs.db, automatically updated in postinst with crssync
+	mv $(CURDIR)/debian/tmp/usr/share/qgis/resources/srs.db $(CURDIR)/debian/tmp/usr/share/qgis/resources/srs-template.db
+
 	# Install menu pixmap
 	install -o root -g root -d $(CURDIR)/debian/tmp/usr/share/pixmaps
 	install -o root -g root -m 644 $(CURDIR)/images/icons/qgis_icon.svg $(CURDIR)/debian/tmp/usr/share/pixmaps/qgis.svg
@@ -306,34 +335,6 @@ override_dh_auto_install:
 	install -o root -g root -m 755 $(CURDIR)/debian/qgis.sh $(CURDIR)/debian/qgis/usr/bin/qbrowser
 
 override_dh_install:
-	# Don't ship srs.db, automatically updated in postinst with crssync
-	mv $(CURDIR)/debian/tmp/usr/share/qgis/resources/srs.db $(CURDIR)/debian/tmp/usr/share/qgis/resources/srs-template.db
-
-	perl -i -pe 's=#!/usr/bin/env python=#!/usr/bin/python2.7=;' $$(find debian/tmp -name "*.py")
-
-	# remove unwanted files
-	$(RM) $(CURDIR)/debian/tmp/usr/share/qgis/doc/api/installdox
-	$(RM) $(CURDIR)/debian/tmp/usr/share/qgis/doc/api/html/jquery.js
-	$(RM) $(CURDIR)/debian/tmp/usr/share/qgis/doc/api/jquery.js
-
-	# replace leaflet and jquery urls
-	perl -i -p \
-		-e 's#http://.*/leaflet.css#leaflet/leaflet.css#;s#http://.*/leaflet.js#leaflet/leaflet.js#;s#http://.*/jquery-.*.min.js#jquery-min.js#' \
-		$(CURDIR)/debian/tmp/usr/share/qgis/doc/developersmap.html
-
-	# Don't include a copy of the world.tif also included in osgearth-data
-	$(RM) $(CURDIR)/debian/tmp/usr/share/qgis/globe/world.tif
-
-	# remove extra license files
-	-find $(CURDIR)/debian/tmp/usr/share/qgis/resources/cpt-city-qgis-min/ -name COPYING.xml -delete
-	$(RM) $(CURDIR)/debian/tmp/usr/share/qgis/doc/LICENSE
-	$(RM) $(CURDIR)/debian/tmp/usr/share/qgis/python/plugins/db_manager/LICENSE
-	$(RM) $(CURDIR)/debian/tmp/usr/share/qgis/python/plugins/MetaSearch/LICENSE.txt
-
-	# Man pages are installed by dh_installman
-	$(RM) $(CURDIR)/debian/tmp/usr/man/man1/qgis.1
-	$(RM) $(CURDIR)/debian/tmp/usr/man/man1/qbrowser.1
-
 	dh_install --autodest --list-missing
 
 override_dh_installchangelogs:

--- a/debian/upstream/metadata
+++ b/debian/upstream/metadata
@@ -1,10 +1,10 @@
 ---
-Bug-Database: http://hub.qgis.org/projects/quantum-gis/issues
-Bug-Submit: http://hub.qgis.org/projects/quantum-gis/issues/new
+Bug-Database: https://hub.qgis.org/projects/quantum-gis/issues
+Bug-Submit: https://hub.qgis.org/projects/quantum-gis/issues/new
 Contact: qgis-developer@lists.osgeo.org
-Donation: http://qgis.org/en/site/getinvolved/donations.html
+Donation: https://qgis.org/en/site/getinvolved/donations.html
 Name: QGIS
 Registration: https://www2.osgeo.org/cgi-bin/ldap_create_user.py
 Repository: https://github.com/qgis/QGIS.git
 Repository-Browse: https://github.com/qgis/QGIS
-Screenshots: http://qgis.org/en/site/about/screenshots.html
+Screenshots: https://qgis.org/en/site/about/screenshots.html

--- a/resources/context_help/QgsDelimitedTextSourceSelect
+++ b/resources/context_help/QgsDelimitedTextSourceSelect
@@ -221,7 +221,7 @@ Each attribute also has a data type, one of string (text), integer, longlong,
 or real number.
 The data type is inferred from the content of the fields - if every non blank value
 is a valid integer then the type is integer, otherwise if it is a valid long long
-nubmer then the type is longlong, otherwise if it is a valid real
+number then the type is longlong, otherwise if it is a valid real
 number then the type is real, otherwise the type is string.  Note that this is
 based on the content of the fields - quoting fields does not change the way they
 are interpreted.

--- a/scripts/spelling.dat
+++ b/scripts/spelling.dat
@@ -300,6 +300,7 @@ nescessary:necessary
 nessessary:necessary
 noticable:noticeable
 notications:notifications
+nubmer:number
 o'caml:OCaml
 occured:occurred
 occurence:occurrence

--- a/src/providers/wcs/qgswcsprovider.cpp
+++ b/src/providers/wcs/qgswcsprovider.cpp
@@ -185,7 +185,7 @@ QgsWcsProvider::QgsWcsProvider( QString const &uri )
     return;
   }
 
-  // Get small piece of coverage to find GDAL data type and nubmer of bands
+  // Get small piece of coverage to find GDAL data type and number of bands
   int bandNo = 0; // All bands
   int width;
   int height;


### PR DESCRIPTION
Forwarding some changes triggered by the 2.14.1 release:
- A spelling error fix (nubmer -> number)
- Standards-Version bump to 3.9.7 for sid, stretch & xenial (initially forwarded in #2818)
- Copyright file update:
  - Update copyright years for Jürgen E. Fischer
  - Add license & copyright for qwtpolar-1.1.1
  - Group CMake files by Simon Edwards
- Enable all hardening buildflags (adds ld -z now & -fPIE -pie)
- Move all post installation changes to dh_auto_install override
