### PR TITLE
Make QgsVectorDataProvider::fillMinMaxCache() handle LongLong

### DIFF
--- a/src/core/qgsvectordataprovider.cpp
+++ b/src/core/qgsvectordataprovider.cpp
@@ -18,6 +18,7 @@
 
 #include <cfloat> // for DBL_MAX
 #include <climits>
+#include <limits>
 
 #include "qgsvectordataprovider.h"
 #include "qgsfeature.h"
@@ -393,6 +394,11 @@ void QgsVectorDataProvider::fillMinMaxCache()
       mCacheMinValues[i] = QVariant( INT_MAX );
       mCacheMaxValues[i] = QVariant( INT_MIN );
     }
+    else if ( flds[i].type() == QVariant::LongLong )
+    {
+      mCacheMinValues[i] = QVariant( std::numeric_limits<qlonglong>::max() );
+      mCacheMaxValues[i] = QVariant( std::numeric_limits<qlonglong>::min() );
+    }
     else if ( flds[i].type() == QVariant::Double )
     {
       mCacheMinValues[i] = QVariant( DBL_MAX );
@@ -425,6 +431,14 @@ void QgsVectorDataProvider::fillMinMaxCache()
         if ( value < mCacheMinValues[*it].toInt() )
           mCacheMinValues[*it] = value;
         if ( value > mCacheMaxValues[*it].toInt() )
+          mCacheMaxValues[*it] = value;
+      }
+      else if ( flds[*it].type() == QVariant::LongLong )
+      {
+        qlonglong value = varValue.toLongLong();
+        if ( value < mCacheMinValues[*it].toLongLong() )
+          mCacheMinValues[*it] = value;
+        if ( value > mCacheMaxValues[*it].toLongLong() )
           mCacheMaxValues[*it] = value;
       }
       else if ( flds[*it].type() == QVariant::Double )

--- a/tests/src/python/test_provider_memory.py
+++ b/tests/src/python/test_provider_memory.py
@@ -271,7 +271,7 @@ class TestPyQgsMemoryProviderIndexed(unittest.TestCase, ProviderTestCase):
     def setUpClass(cls):
         """Run before all tests"""
         # Create test layer
-        cls.vl = QgsVectorLayer(u'Point?crs=epsg:4326&index=yes&field=pk:integer&field=cnt:integer&field=name:string(0)&field=name2:string(0)&field=num_char:string&key=pk',
+        cls.vl = QgsVectorLayer(u'Point?crs=epsg:4326&index=yes&field=pk:integer&field=cnt:int8&field=name:string(0)&field=name2:string(0)&field=num_char:string&key=pk',
                                 u'test', u'memory')
         assert (cls.vl.isValid())
         cls.provider = cls.vl.dataProvider()


### PR DESCRIPTION
The code currently fallbacks to dealing with LongLong fields as
strings, which breaks the ProviderTestCase testMinValue() and
testMaxValue() tests, if we change the definition of the tests
of the memory provider to use a int8 field for the cnt field.
# 
## FAIL: testMaxValue (**main**.TestPyQgsMemoryProviderIndexed)

Traceback (most recent call last):
  File "/home/even/qgis-git/Quantum-GIS.clean/tests/src/python/providertestbase.py", line 349, in testMaxValue
    self.assertEqual(self.provider.maximumValue(1), 400)
AssertionError: u'400' != 400
# 
## FAIL: testMinValue (**main**.TestPyQgsMemoryProviderIndexed)

Traceback (most recent call last):
  File "/home/even/qgis-git/Quantum-GIS.clean/tests/src/python/providertestbase.py", line 345, in testMinValue
    self.assertEqual(self.provider.minimumValue(1), -200)
AssertionError: u'-200' != -200
