### PR TITLE
[FEATURE] Allow expression functions to use named parameters

### DIFF
--- a/python/core/qgsexpression.sip
+++ b/python/core/qgsexpression.sip
@@ -377,6 +377,11 @@ class QgsExpression
         /** The mininum number of parameters this function takes. */
         int minParams() const;
 
+        /** Returns the list of named parameters for the function, if set.
+         * @note added in QGIS 2.16
+        */
+        const QgsExpression::ParameterList& parameters() const;
+
         /** Does this function use a geometry object. */
         bool usesgeometry() const;
 
@@ -646,7 +651,14 @@ class QgsExpression
         */
         void append( QgsExpression::NamedNode* node /Transfer/ );
 
+        /** Returns the number of nodes in the list.
+         */
         int count() const;
+
+        //! Returns true if list contains any named nodes
+        //! @note added in QGIS 2.16
+        bool hasNamedNodes() const;
+
         const QList<QgsExpression::Node*>& list();
 
         //! Returns a list of names for nodes. Unnamed nodes will be indicated by an empty string in the list.

--- a/python/core/qgsexpression.sip
+++ b/python/core/qgsexpression.sip
@@ -304,13 +304,61 @@ class QgsExpression
     // static const char* UnaryOperatorText[];
 
     /**
+      * Represents a single parameter passed to a function.
+      * \note added in QGIS 2.16
+      */
+    class Parameter
+    {
+      public:
+
+        /** Constructor for Parameter.
+         * @param name parameter name, used when named parameter are specified in an expression
+         * @param optional set to true if parameter should be optional
+         * @param defaultValue default value to use for optional parameters
+         */
+        Parameter( const QString& name,
+                   bool optional = false,
+                   const QVariant& defaultValue = QVariant() );
+
+        //! Returns the name of the parameter.
+        QString name() const;
+
+        //! Returns true if the parameter is optional.
+        bool optional() const;
+
+        //! Returns the default value for the parameter.
+        QVariant defaultValue() const;
+
+        bool operator==( const QgsExpression::Parameter& other ) const;
+
+    };
+
+    //! List of parameters, used for function definition
+    typedef QList< QgsExpression::Parameter > ParameterList;
+
+    /**
      * A abstract base class for defining QgsExpression functions.
      */
     class Function
     {
       public:
+
+        //! Constructor for function which uses unnamed parameters
         Function( const QString& fnname,
                   int params,
+                  const QString& group,
+                  const QString& helpText = QString(),
+                  bool usesGeometry = false,
+                  const QStringList& referencedColumns = QStringList(),
+                  bool lazyEval = false,
+                  bool handlesNull = false,
+                  bool isContextual = false );
+
+        /** Constructor for function which uses named parameter list.
+         * @note added in QGIS 2.16
+         */
+        Function( const QString& fnname,
+                  const QgsExpression::ParameterList& params,
                   const QString& group,
                   const QString& helpText = QString(),
                   bool usesGeometry = false,
@@ -322,11 +370,15 @@ class QgsExpression
         virtual ~Function();
 
         /** The name of the function. */
-        QString name();
+        QString name() const;
         /** The number of parameters this function takes. */
-        int params();
+        int params() const;
+
+        /** The mininum number of parameters this function takes. */
+        int minParams() const;
+
         /** Does this function use a geometry object. */
-        bool usesgeometry();
+        bool usesgeometry() const;
 
         /** Returns a list of possible aliases for the function. These include
          * other permissible names for the function, eg deprecated names.
@@ -339,7 +391,7 @@ class QgsExpression
          * rather than the node results when called.  You can use node->eval(parent, feature) to evaluate the node and return the result
          * Functions are non lazy default and will be given the node return value when called
          */
-        bool lazyEval();
+        bool lazyEval() const;
 
         virtual QStringList referencedColumns() const;
 
@@ -349,9 +401,9 @@ class QgsExpression
         bool isContextual() const;
 
         /** The group the function belongs to. */
-        QString group();
+        QString group() const;
         /** The help text for the function. */
-        const QString helptext();
+        const QString helptext() const;
 
         //! @deprecated Use QgsExpressionContext variant instead
         virtual QVariant func( const QVariantList& values, const QgsFeature* f, QgsExpression* parent ) /Deprecated/;
@@ -562,6 +614,25 @@ class QgsExpression
         virtual void accept( QgsExpression::Visitor& v ) const = 0;
     };
 
+    //! Named node
+    //! @note added in QGIS 2.16
+    class NamedNode
+    {
+      public:
+
+        /** Constructor for NamedNode
+         * @param name node name
+         * @param node node
+         */
+        NamedNode( const QString& name, QgsExpression::Node* node );
+
+        //! Node name
+        QString name;
+
+        //! Node
+        QgsExpression::Node* node;
+    };
+
     class NodeList
     {
       public:
@@ -569,8 +640,19 @@ class QgsExpression
         ~NodeList();
         /** Takes ownership of the provided node */
         void append( QgsExpression::Node* node /Transfer/ );
-        int count();
+
+        /** Adds a named node. Takes ownership of the provided node.
+         * @note added in QGIS 2.16
+        */
+        void append( QgsExpression::NamedNode* node /Transfer/ );
+
+        int count() const;
         const QList<QgsExpression::Node*>& list();
+
+        //! Returns a list of names for nodes. Unnamed nodes will be indicated by an empty string in the list.
+        //! @note added in QGIS 2.16
+        QStringList names() const;
+
         /** Creates a deep copy of this list. Ownership is transferred to the caller */
         QgsExpression::NodeList* clone() const;
 
@@ -698,6 +780,9 @@ class QgsExpression
         virtual bool needsGeometry() const;
         virtual void accept( QgsExpression::Visitor& v ) const;
         virtual QgsExpression::Node* clone() const;
+
+        //! Tests whether the provided argument list is valid for the matching function
+        static bool validateParams( int fnIndex, QgsExpression::NodeList* args, QString& error );
     };
 
     class NodeLiteral : QgsExpression::Node

--- a/resources/function_help/json/azimuth
+++ b/resources/function_help/json/azimuth
@@ -1,10 +1,10 @@
 {
   "name": "azimuth",
   "type": "function",
-  "description": "Returns the north-based azimuth as the angle in radians measured clockwise from the vertical on pointA to pointB.",
+  "description": "Returns the north-based azimuth as the angle in radians measured clockwise from the vertical on point_a to point_b.",
   "arguments": [
-    {"arg":"pointA","description":"point geometry"},
-    {"arg":"pointB","description":"point geometry"}
+    {"arg":"point_a","description":"point geometry"},
+    {"arg":"point_b","description":"point geometry"}
   ],
   "examples": [
 	{ "expression":"degrees( azimuth( make_point(25, 45), make_point(75, 100) ) )", "returns":"42.273689"},

--- a/resources/function_help/json/randf
+++ b/resources/function_help/json/randf
@@ -2,7 +2,7 @@
   "name": "randf",
   "type": "function",
   "description": "Returns a random float within the range specified by the minimum and maximum argument (inclusive).",
-  "arguments": [ {"arg":"min","description":"an float representing the smallest possible random number desired"},
-                 {"arg":"max","description":"an float representing the largest possible random number desired"}],
+  "arguments": [ {"arg":"min","optional":true,"default":"0.0","description":"an float representing the smallest possible random number desired"},
+                 {"arg":"max","optional":true,"default":"1.0","description":"an float representing the largest possible random number desired"}],
   "examples": [ { "expression":"randf(1, 10)", "returns":"4.59258286403147"}]
 }

--- a/resources/function_help/json/round
+++ b/resources/function_help/json/round
@@ -3,8 +3,8 @@
   "type": "function",
   "description": "Rounds a number to number of decimal places.",
   "arguments": [
-	{"arg":"decimal","description":"decimal number to be rounded"},
-	{"arg":"places","description":"Optional integer representing number of places to round decimals to. Can be negative."}
+	{"arg":"value","description":"decimal number to be rounded"},
+	{"arg":"places","optional":true,"default":"0","description":"Optional integer representing number of places to round decimals to. Can be negative."}
   ],
   "examples": [
 	{ "expression":"round(1234.567, 2)", "returns":"1234.57"},

--- a/scripts/process_function_template.py
+++ b/scripts/process_function_template.py
@@ -86,11 +86,13 @@ for f in sorted(glob.glob('resources/function_help/json/*')):
 
         if 'arguments' in v:
             for a in v['arguments']:
-                cpp.write("\n              << HelpArg( \"{0}\", tr( \"{1}\" ), {2}, {3} )".format(
+                cpp.write("\n              << HelpArg( \"{0}\", tr( \"{1}\" ), {2}, {3}, {4}, \"{5}\" )".format(
                     a['arg'],
                     a.get('description', ''),
                     "true" if a.get('descOnly', False) else "false",
-                    "true" if a.get('syntaxOnly', False) else "false")
+                    "true" if a.get('syntaxOnly', False) else "false",
+                    "true" if a.get('optional', False) else "false",
+                    a.get('default', ''))
                 )
 
         cpp.write(",\n          /* variableLenArguments */ {0}".format(

--- a/scripts/process_function_template.py
+++ b/scripts/process_function_template.py
@@ -86,7 +86,7 @@ for f in sorted(glob.glob('resources/function_help/json/*')):
 
         if 'arguments' in v:
             for a in v['arguments']:
-                cpp.write("\n              << HelpArg( tr( \"{0}\" ), tr( \"{1}\" ), {2}, {3} )".format(
+                cpp.write("\n              << HelpArg( \"{0}\", tr( \"{1}\" ), {2}, {3} )".format(
                     a['arg'],
                     a.get('description', ''),
                     "true" if a.get('descOnly', False) else "false",

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -2878,10 +2878,10 @@ const QList<QgsExpression::Function*>& QgsExpression::Functions()
     << new StaticFunction( "log", 2, fcnLog, "Math" )
     << new StaticFunction( "round", -1, fcnRound, "Math" )
     << new StaticFunction( "rand", 2, fcnRnd, "Math" )
-    << new StaticFunction( "randf", 2, fcnRndF, "Math" )
+    << new StaticFunction( "randf", ParameterList() << Parameter( "min", true, 0.0 ) << Parameter( "max", true, 1.0 ), fcnRndF, "Math" )
     << new StaticFunction( "max", -1, fcnMax, "Math" )
     << new StaticFunction( "min", -1, fcnMin, "Math" )
-    << new StaticFunction( "clamp", 3, fcnClamp, "Math" )
+    << new StaticFunction( "clamp", ParameterList() << Parameter( "min" ) << Parameter( "value" ) << Parameter( "max" ), fcnClamp, "Math" )
     << new StaticFunction( "scale_linear", 5, fcnLinearScale, "Math" )
     << new StaticFunction( "scale_exp", 6, fcnExpScale, "Math" )
     << new StaticFunction( "floor", 1, fcnFloor, "Math" )
@@ -2915,7 +2915,7 @@ const QList<QgsExpression::Function*>& QgsExpression::Functions()
     << new StaticFunction( "longest_common_substring", 2, fcnLCS, "Fuzzy Matching" )
     << new StaticFunction( "hamming_distance", 2, fcnHamming, "Fuzzy Matching" )
     << new StaticFunction( "soundex", 1, fcnSoundex, "Fuzzy Matching" )
-    << new StaticFunction( "wordwrap", -1, fcnWordwrap, "String" )
+    << new StaticFunction( "wordwrap", ParameterList() << Parameter( "text" ) << Parameter( "length" ) << Parameter( "delimiter", true, " " ), fcnWordwrap, "String" )
     << new StaticFunction( "length", 1, fcnLength, "String" )
     << new StaticFunction( "replace", 3, fcnReplace, "String" )
     << new StaticFunction( "regexp_replace", 3, fcnRegexpReplace, "String" )
@@ -3567,6 +3567,7 @@ QgsExpression::NodeList* QgsExpression::NodeList::clone() const
   {
     nl->mList.append( node->clone() );
   }
+  nl->mNameList = mNameList;
 
   return nl;
 }

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -2860,24 +2860,24 @@ const QList<QgsExpression::Function*>& QgsExpression::Functions()
   if ( gmFunctions.isEmpty() )
   {
     gmFunctions
-    << new StaticFunction( "sqrt", 1, fcnSqrt, "Math" )
-    << new StaticFunction( "radians", 1, fcnRadians, "Math" )
-    << new StaticFunction( "degrees", 1, fcnDegrees, "Math" )
-    << new StaticFunction( "azimuth", 2, fcnAzimuth, "Math" )
-    << new StaticFunction( "abs", 1, fcnAbs, "Math" )
-    << new StaticFunction( "cos", 1, fcnCos, "Math" )
-    << new StaticFunction( "sin", 1, fcnSin, "Math" )
-    << new StaticFunction( "tan", 1, fcnTan, "Math" )
-    << new StaticFunction( "asin", 1, fcnAsin, "Math" )
-    << new StaticFunction( "acos", 1, fcnAcos, "Math" )
-    << new StaticFunction( "atan", 1, fcnAtan, "Math" )
-    << new StaticFunction( "atan2", 2, fcnAtan2, "Math" )
-    << new StaticFunction( "exp", 1, fcnExp, "Math" )
-    << new StaticFunction( "ln", 1, fcnLn, "Math" )
-    << new StaticFunction( "log10", 1, fcnLog10, "Math" )
-    << new StaticFunction( "log", 2, fcnLog, "Math" )
-    << new StaticFunction( "round", -1, fcnRound, "Math" )
-    << new StaticFunction( "rand", 2, fcnRnd, "Math" )
+    << new StaticFunction( "sqrt", ParameterList() << Parameter( "value" ), fcnSqrt, "Math" )
+    << new StaticFunction( "radians", ParameterList() << Parameter( "degrees" ), fcnRadians, "Math" )
+    << new StaticFunction( "degrees", ParameterList() << Parameter( "radians" ), fcnDegrees, "Math" )
+    << new StaticFunction( "azimuth", ParameterList() << Parameter( "point_a" ) << Parameter( "point_b" ), fcnAzimuth, "Math" )
+    << new StaticFunction( "abs", ParameterList() << Parameter( "value" ), fcnAbs, "Math" )
+    << new StaticFunction( "cos", ParameterList() << Parameter( "angle" ), fcnCos, "Math" )
+    << new StaticFunction( "sin", ParameterList() << Parameter( "angle" ), fcnSin, "Math" )
+    << new StaticFunction( "tan", ParameterList() << Parameter( "angle" ), fcnTan, "Math" )
+    << new StaticFunction( "asin", ParameterList() << Parameter( "value" ), fcnAsin, "Math" )
+    << new StaticFunction( "acos", ParameterList() << Parameter( "value" ), fcnAcos, "Math" )
+    << new StaticFunction( "atan", ParameterList() << Parameter( "value" ), fcnAtan, "Math" )
+    << new StaticFunction( "atan2", ParameterList() << Parameter( "dx" ) << Parameter( "dy" ), fcnAtan2, "Math" )
+    << new StaticFunction( "exp", ParameterList() << Parameter( "value" ), fcnExp, "Math" )
+    << new StaticFunction( "ln", ParameterList() << Parameter( "value" ), fcnLn, "Math" )
+    << new StaticFunction( "log10", ParameterList() << Parameter( "value" ), fcnLog10, "Math" )
+    << new StaticFunction( "log", ParameterList() << Parameter( "base" ) << Parameter( "value" ), fcnLog, "Math" )
+    << new StaticFunction( "round", ParameterList() << Parameter( "value" ) << Parameter( "places", true, 0 ), fcnRound, "Math" )
+    << new StaticFunction( "rand", ParameterList() << Parameter( "min" ) << Parameter( "max" ), fcnRnd, "Math" )
     << new StaticFunction( "randf", ParameterList() << Parameter( "min", true, 0.0 ) << Parameter( "max", true, 1.0 ), fcnRndF, "Math" )
     << new StaticFunction( "max", -1, fcnMax, "Math" )
     << new StaticFunction( "min", -1, fcnMin, "Math" )
@@ -4451,7 +4451,10 @@ QString QgsExpression::helptext( QString name )
           helpContents += delim;
           delim = ", ";
           if ( !a.mDescOnly )
-            helpContents += QString( "<span class=\"argument\">%1</span>" ).arg( a.mArg );
+          {
+            helpContents += QString( "<span class=\"argument %1\">%2%3</span>" ).arg( a.mOptional ? "optional" : "", a.mArg,
+                            a.mDefaultVal.isEmpty() ? "" : '=' + a.mDefaultVal );
+          }
         }
 
         if ( v.mVariableLenArguments )

--- a/src/core/qgsexpression.h
+++ b/src/core/qgsexpression.h
@@ -22,6 +22,7 @@
 #include <QList>
 #include <QDomDocument>
 #include <QCoreApplication>
+#include <QSet>
 
 #include "qgis.h"
 #include "qgsunittypes.h"
@@ -424,9 +425,54 @@ class CORE_EXPORT QgsExpression
     //! @note not available in Python bindings
     static const char* UnaryOperatorText[];
 
+    /**
+      * Represents a single parameter passed to a function.
+      * \note added in QGIS 2.16
+      */
+    class CORE_EXPORT Parameter
+    {
+      public:
+
+        /** Constructor for Parameter.
+         * @param name parameter name, used when named parameter are specified in an expression
+         * @param optional set to true if parameter should be optional
+         * @param defaultValue default value to use for optional parameters
+         */
+        Parameter( const QString& name,
+                   bool optional = false,
+                   const QVariant& defaultValue = QVariant() )
+            : mName( name )
+            , mOptional( optional )
+            , mDefaultValue( defaultValue )
+        {}
+
+        //! Returns the name of the parameter.
+        QString name() const { return mName; }
+
+        //! Returns true if the parameter is optional.
+        bool optional() const { return mOptional; }
+
+        //! Returns the default value for the parameter.
+        QVariant defaultValue() const { return mDefaultValue; }
+
+        bool operator==( const Parameter& other ) const
+        {
+          return ( QString::compare( mName, other.mName, Qt::CaseInsensitive ) == 0 );
+        }
+
+      private:
+        QString mName;
+        bool mOptional;
+        QVariant mDefaultValue;
+    };
+
+    //! List of parameters, used for function definition
+    typedef QList< Parameter > ParameterList;
+
+    //! @deprecated will be removed in QGIS 3.0
     typedef QVariant( *FcnEval )( const QVariantList& values, const QgsFeature* f, QgsExpression* parent );
 
-    /** Function definition for evaluation against an expression context
+    /** Function definition for evaluation against an expression context, using a list of values as parameters to the function.
      */
     typedef QVariant( *FcnEvalContext )( const QVariantList& values, const QgsExpressionContext* context, QgsExpression* parent );
 
@@ -436,6 +482,8 @@ class CORE_EXPORT QgsExpression
     class CORE_EXPORT Function
     {
       public:
+
+        //! Constructor for function which uses unnamed parameters
         Function( const QString& fnname,
                   int params,
                   const QString& group,
@@ -454,16 +502,61 @@ class CORE_EXPORT QgsExpression
             , mLazyEval( lazyEval )
             , mHandlesNull( handlesNull )
             , mIsContextual( isContextual )
+        {
+        }
+
+        /** Constructor for function which uses named parameter list.
+         * @note added in QGIS 2.16
+         */
+        Function( const QString& fnname,
+                  const ParameterList& params,
+                  const QString& group,
+                  const QString& helpText = QString(),
+                  bool usesGeometry = false,
+                  const QStringList& referencedColumns = QStringList(),
+                  bool lazyEval = false,
+                  bool handlesNull = false,
+                  bool isContextual = false )
+            : mName( fnname )
+            , mParameterList( params )
+            , mUsesGeometry( usesGeometry )
+            , mGroup( group )
+            , mHelpText( helpText )
+            , mReferencedColumns( referencedColumns )
+            , mLazyEval( lazyEval )
+            , mHandlesNull( handlesNull )
+            , mIsContextual( isContextual )
         {}
 
         virtual ~Function() {}
 
         /** The name of the function. */
-        QString name() { return mName; }
+        QString name() const { return mName; }
+
         /** The number of parameters this function takes. */
-        int params() { return mParams; }
+        int params() const { return mParameterList.isEmpty() ? mParams : mParameterList.count(); }
+
+        /** The mininum number of parameters this function takes. */
+        int minParams() const
+        {
+          if ( mParameterList.isEmpty() )
+            return mParams;
+
+          int min = 0;
+          Q_FOREACH ( const Parameter& param, mParameterList )
+          {
+            if ( !param.optional() )
+              min++;
+          }
+          return min;
+        }
+
+        /** Returns the list of named parameters for the function, if set. */
+        const ParameterList& parameters() const { return mParameterList; }
+
         /** Does this function use a geometry object. */
-        bool usesgeometry() { return mUsesGeometry; }
+        //TODO QGIS 3.0 - rename to usesGeometry()
+        bool usesgeometry() const { return mUsesGeometry; }
 
         /** Returns a list of possible aliases for the function. These include
          * other permissible names for the function, eg deprecated names.
@@ -475,7 +568,7 @@ class CORE_EXPORT QgsExpression
         /** True if this function should use lazy evaluation.  Lazy evaluation functions take QgsExpression::Node objects
          * rather than the node results when called.  You can use node->eval(parent, feature) to evaluate the node and return the result
          * Functions are non lazy default and will be given the node return value when called **/
-        bool lazyEval() { return mLazyEval; }
+        bool lazyEval() const { return mLazyEval; }
 
         virtual QStringList referencedColumns() const { return mReferencedColumns; }
 
@@ -485,9 +578,10 @@ class CORE_EXPORT QgsExpression
         bool isContextual() const { return mIsContextual; }
 
         /** The group the function belongs to. */
-        QString group() { return mGroup; }
+        QString group() const { return mGroup; }
         /** The help text for the function. */
-        const QString helptext() { return mHelpText.isEmpty() ? QgsExpression::helptext( mName ) : mHelpText; }
+        //TODO QGIS 3.0 - rename to helpText()
+        const QString helptext() const { return mHelpText.isEmpty() ? QgsExpression::helptext( mName ) : mHelpText; }
 
         //! @deprecated Use QgsExpressionContext variant instead
         Q_DECL_DEPRECATED virtual QVariant func( const QVariantList&, const QgsFeature*, QgsExpression* );
@@ -515,6 +609,7 @@ class CORE_EXPORT QgsExpression
       private:
         QString mName;
         int mParams;
+        ParameterList mParameterList;
         bool mUsesGeometry;
         QString mGroup;
         QString mHelpText;
@@ -550,10 +645,28 @@ class CORE_EXPORT QgsExpression
 
         virtual ~StaticFunction() {}
 
-        /** Static function for evaluation against a QgsExpressionContext
+        /** Static function for evaluation against a QgsExpressionContext, using an unnamed list of parameter values.
          */
         StaticFunction( const QString& fnname,
                         int params,
+                        FcnEvalContext fcn,
+                        const QString& group,
+                        const QString& helpText = QString(),
+                        bool usesGeometry = false,
+                        const QStringList& referencedColumns = QStringList(),
+                        bool lazyEval = false,
+                        const QStringList& aliases = QStringList(),
+                        bool handlesNull = false )
+            : Function( fnname, params, group, helpText, usesGeometry, referencedColumns, lazyEval, handlesNull )
+            , mFnc( nullptr )
+            , mContextFnc( fcn )
+            , mAliases( aliases )
+        {}
+
+        /** Static function for evaluation against a QgsExpressionContext, using a named list of parameter values.
+         */
+        StaticFunction( const QString& fnname,
+                        const ParameterList& params,
                         FcnEvalContext fcn,
                         const QString& group,
                         const QString& helpText = QString(),
@@ -780,15 +893,52 @@ class CORE_EXPORT QgsExpression
         virtual void accept( Visitor& v ) const = 0;
     };
 
+    //! Named node
+    //! @note added in QGIS 2.16
+    class CORE_EXPORT NamedNode
+    {
+      public:
+
+        /** Constructor for NamedNode
+         * @param name node name
+         * @param node node
+         */
+        NamedNode( const QString& name, Node* node )
+            : name( name )
+            , node( node )
+        {}
+
+        //! Node name
+        QString name;
+
+        //! Node
+        Node* node;
+    };
+
     class CORE_EXPORT NodeList
     {
       public:
-        NodeList() {}
+        NodeList() : mHasNamedNodes( false ) {}
         virtual ~NodeList() { qDeleteAll( mList ); }
         /** Takes ownership of the provided node */
-        void append( Node* node ) { mList.append( node ); }
-        int count() { return mList.count(); }
+        void append( Node* node ) { mList.append( node ); mNameList.append( QString() ); }
+
+        /** Adds a named node. Takes ownership of the provided node.
+         * @note added in QGIS 2.16
+        */
+        void append( NamedNode* node ) { mList.append( node->node ); mNameList.append( node->name.toLower() ); mHasNamedNodes = true; }
+
+        int count() const { return mList.count(); }
+
+        //! Returns true if list contains any named nodes
+        bool hasNamedNodes() const { return mHasNamedNodes; }
+
         QList<Node*> list() { return mList; }
+
+        //! Returns a list of names for nodes. Unnamed nodes will be indicated by an empty string in the list.
+        //! @note added in QGIS 2.16
+        QStringList names() const { return mNameList; }
+
         /** Creates a deep copy of this list. Ownership is transferred to the caller */
         NodeList* clone() const;
 
@@ -796,6 +946,11 @@ class CORE_EXPORT QgsExpression
 
       protected:
         QList<Node*> mList;
+        QStringList mNameList;
+
+      private:
+
+        bool mHasNamedNodes;
     };
 
     class CORE_EXPORT Interval
@@ -928,8 +1083,45 @@ class CORE_EXPORT QgsExpression
     class CORE_EXPORT NodeFunction : public Node
     {
       public:
-        NodeFunction( int fnIndex, NodeList* args ) : mFnIndex( fnIndex ), mArgs( args ) {}
-        //NodeFunction( QString name, NodeList* args ) : mName(name), mArgs(args) {}
+        NodeFunction( int fnIndex, NodeList* args ) : mFnIndex( fnIndex )
+        {
+          const ParameterList& functionParams = Functions()[mFnIndex]->parameters();
+          if ( !args || !args->hasNamedNodes() || functionParams.isEmpty() )
+          {
+            // no named parameters, or function does not support them
+            mArgs = args;
+          }
+          else
+          {
+            mArgs = new NodeList();
+
+            int idx = 0;
+            //first loop through unnamed arguments
+            while ( args->names().at( idx ).isEmpty() )
+            {
+              mArgs->append( args->list().at( idx )->clone() );
+              idx++;
+            }
+
+            //next copy named parameters in order expected by function
+            for ( ; idx < functionParams.count(); ++idx )
+            {
+              int nodeIdx = args->names().indexOf( functionParams.at( idx ).name().toLower() );
+              if ( nodeIdx < 0 )
+              {
+                //parameter not found - insert default value for parameter
+                mArgs->append( new NodeLiteral( functionParams.at( idx ).defaultValue() ) );
+              }
+              else
+              {
+                mArgs->append( args->list().at( nodeIdx )->clone() );
+              }
+            }
+
+            delete args;
+          }
+        }
+
         virtual ~NodeFunction() { delete mArgs; }
 
         int fnIndex() const { return mFnIndex; }
@@ -945,13 +1137,84 @@ class CORE_EXPORT QgsExpression
         virtual void accept( Visitor& v ) const override { v.visit( *this ); }
         virtual Node* clone() const override;
 
+        //! Tests whether the provided argument list is valid for the matching function
+        static bool validateParams( int fnIndex, NodeList* args, QString& error )
+        {
+          if ( !args || !args->hasNamedNodes() )
+            return true;
+
+          const ParameterList& functionParams = Functions()[fnIndex]->parameters();
+          if ( functionParams.isEmpty() )
+          {
+            error = QString( "%1 does not supported named parameters" ).arg( Functions()[fnIndex]->name() );
+            return false;
+          }
+          else
+          {
+            QSet< int > providedArgs;
+            QSet< int > handledArgs;
+            int idx = 0;
+            //first loop through unnamed arguments
+            while ( args->names().at( idx ).isEmpty() )
+            {
+              providedArgs << idx;
+              handledArgs << idx;
+              idx++;
+            }
+
+            //next check named parameters
+            for ( ; idx < functionParams.count(); ++idx )
+            {
+              int nodeIdx = args->names().indexOf( functionParams.at( idx ).name().toLower() );
+              if ( nodeIdx < 0 )
+              {
+                if ( !functionParams.at( idx ).optional() )
+                {
+                  error = QString( "No value specified for parameter '%1' for %2" ).arg( functionParams.at( idx ).name(), Functions()[fnIndex]->name() );
+                  return false;
+                }
+              }
+              else
+              {
+                if ( providedArgs.contains( idx ) )
+                {
+                  error = QString( "Duplicate parameter specified for '%1' for %2" ).arg( functionParams.at( idx ).name(), Functions()[fnIndex]->name() );
+                  return false;
+                }
+              }
+              providedArgs << idx;
+              handledArgs << nodeIdx;
+            }
+
+            //last check for bad names
+            idx = 0;
+            Q_FOREACH ( const QString& name, args->names() )
+            {
+              if ( !name.isEmpty() && !functionParams.contains( name ) )
+              {
+                error = QString( "Invalid parameter name '%1' for %2" ).arg( name, Functions()[fnIndex]->name() );
+                return false;
+              }
+              if ( !name.isEmpty() && !handledArgs.contains( idx ) )
+              {
+                int functionIdx = functionParams.indexOf( name );
+                if ( providedArgs.contains( functionIdx ) )
+                {
+                  error = QString( "Duplicate parameter specified for '%1' for %2" ).arg( functionParams.at( functionIdx ).name(), Functions()[fnIndex]->name() );
+                  return false;
+                }
+              }
+              idx++;
+            }
+
+          }
+          return true;
+        }
+
       protected:
         int mFnIndex;
         NodeList* mArgs;
 
-      private:
-
-        QgsExpression::Function* getFunc() const;
     };
 
     class CORE_EXPORT NodeLiteral : public Node

--- a/src/core/qgsexpression.h
+++ b/src/core/qgsexpression.h
@@ -551,7 +551,9 @@ class CORE_EXPORT QgsExpression
           return min;
         }
 
-        /** Returns the list of named parameters for the function, if set. */
+        /** Returns the list of named parameters for the function, if set.
+         * @note added in QGIS 2.16
+        */
         const ParameterList& parameters() const { return mParameterList; }
 
         /** Does this function use a geometry object. */
@@ -928,9 +930,12 @@ class CORE_EXPORT QgsExpression
         */
         void append( NamedNode* node ) { mList.append( node->node ); mNameList.append( node->name.toLower() ); mHasNamedNodes = true; }
 
+        /** Returns the number of nodes in the list.
+         */
         int count() const { return mList.count(); }
 
         //! Returns true if list contains any named nodes
+        //! @note added in QGIS 2.16
         bool hasNamedNodes() const { return mHasNamedNodes; }
 
         QList<Node*> list() { return mList; }
@@ -1362,17 +1367,22 @@ class CORE_EXPORT QgsExpression
 
     struct HelpArg
     {
-      HelpArg( const QString& arg, const QString& desc, bool descOnly = false, bool syntaxOnly = false )
+      HelpArg( const QString& arg, const QString& desc, bool descOnly = false, bool syntaxOnly = false,
+               bool optional = false, const QString& defaultVal = QString() )
           : mArg( arg )
           , mDescription( desc )
           , mDescOnly( descOnly )
           , mSyntaxOnly( syntaxOnly )
+          , mOptional( optional )
+          , mDefaultVal( defaultVal )
       {}
 
       QString mArg;
       QString mDescription;
       bool mDescOnly;
       bool mSyntaxOnly;
+      bool mOptional;
+      QString mDefaultVal;
     };
 
     struct HelpExample

--- a/src/core/qgsexpressionlexer.ll
+++ b/src/core/qgsexpressionlexer.ll
@@ -79,6 +79,12 @@ static QString stripText(QString text)
   return text;
 }
 
+static QString stripNamedText(QString text)
+{
+  text.remove(":=");
+  return text.trimmed();
+}
+
 static QString stripColumnRef(QString text)
 {
   // strip double quotes on start,end
@@ -109,6 +115,8 @@ column_ref  {col_first}{col_next}*
 deprecated_function "$"[xXyY]_?[aA][tT]
 special_col "$"{column_ref}
 variable "@"{column_ref}
+
+named_node {column_ref}{white}*":="{white}*
 
 col_str_char  "\"\""|[^\"]
 column_ref_quoted  "\""{col_str_char}*"\""
@@ -195,6 +203,8 @@ string      "'"{str_char}*"'"
 {string}  { TEXT_FILTER(stripText); return STRING; }
 
 {deprecated_function} { TEXT; return FUNCTION; }
+
+{named_node} { TEXT_FILTER(stripNamedText); return NAMED_NODE; }
 
 {special_col}        { TEXT; return SPECIAL_COL; }
 

--- a/src/core/qgsexpressionparser.yy
+++ b/src/core/qgsexpressionparser.yy
@@ -77,6 +77,7 @@ struct expression_parser_context
 {
   QgsExpression::Node* node;
   QgsExpression::NodeList* nodelist;
+  QgsExpression::NamedNode* namednode;
   double numberFloat;
   int    numberInt;
   bool   boolVal;
@@ -108,7 +109,7 @@ struct expression_parser_context
 // tokens for conditional expressions
 %token CASE WHEN THEN ELSE END
 
-%token <text> STRING COLUMN_REF FUNCTION SPECIAL_COL VARIABLE
+%token <text> STRING COLUMN_REF FUNCTION SPECIAL_COL VARIABLE NAMED_NODE
 
 %token COMMA
 
@@ -122,6 +123,7 @@ struct expression_parser_context
 %type <nodelist> exp_list
 %type <whenthen> when_then_clause
 %type <whenthenlist> when_then_clauses
+%type <namednode> named_node
 
 // debugging
 %error-verbose
@@ -148,6 +150,7 @@ struct expression_parser_context
 
 %destructor { delete $$; } <node>
 %destructor { delete $$; } <nodelist>
+%destructor { delete $$; } <namednode>
 %destructor { delete $$; } <text>
 %destructor { delete $$; } <whenthen>
 %destructor { delete $$; } <whenthenlist>
@@ -191,10 +194,18 @@ expression:
             delete $3;
             YYERROR;
           }
-          if ( QgsExpression::Functions()[fnIndex]->params() != -1
-               && QgsExpression::Functions()[fnIndex]->params() != $3->count() )
+          QString paramError;
+          if ( !QgsExpression::NodeFunction::validateParams( fnIndex, $3, paramError ) )
           {
-            exp_error(parser_ctx, "Function is called with wrong number of arguments");
+            exp_error( parser_ctx, paramError.toLocal8Bit().constData() );
+            delete $3;
+            YYERROR;
+          }
+          if ( QgsExpression::Functions()[fnIndex]->params() != -1
+               && !( QgsExpression::Functions()[fnIndex]->params() >= $3->count()
+               && QgsExpression::Functions()[fnIndex]->minParams() <= $3->count() ) )
+          {
+            exp_error(parser_ctx, QString( "%1 function is called with wrong number of arguments" ).arg( QgsExpression::Functions()[fnIndex]->name() ).toLocal8Bit().constData() );
             delete $3;
             YYERROR;
           }
@@ -214,7 +225,7 @@ expression:
           }
           if ( QgsExpression::Functions()[fnIndex]->params() != 0 )
           {
-            exp_error(parser_ctx, "Function is called with wrong number of arguments");
+            exp_error(parser_ctx, QString( "%1 function is called with wrong number of arguments" ).arg( QgsExpression::Functions()[fnIndex]->name() ).toLocal8Bit().constData() );
             YYERROR;
           }
           $$ = new QgsExpression::NodeFunction(fnIndex, new QgsExpression::NodeList());
@@ -276,9 +287,27 @@ expression:
     | NULLVALUE                   { $$ = new QgsExpression::NodeLiteral( QVariant() ); }
 ;
 
+named_node:
+    NAMED_NODE expression { $$ = new QgsExpression::NamedNode( *$1, $2 ); delete $1; }
+    ;
+
 exp_list:
-      exp_list COMMA expression { $$ = $1; $1->append($3); }
+      exp_list COMMA expression
+       {
+         if ( $1->hasNamedNodes() )
+         {
+           exp_error(parser_ctx, "All parameters following a named parameter must also be named.");
+           delete $1;
+           YYERROR;
+         }
+         else
+         {
+           $$ = $1; $1->append($3);
+         }
+       }
+    | exp_list COMMA named_node { $$ = $1; $1->append($3); }
     | expression              { $$ = new QgsExpression::NodeList(); $$->append($1); }
+    | named_node              { $$ = new QgsExpression::NodeList(); $$->append($1); }
     ;
 
 when_then_clauses:

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -228,6 +228,65 @@ class TestQgsExpression: public QObject
       QCOMPARE( exp.dump(), dump );
     }
 
+    void named_parameter_data()
+    {
+      //test passing named parameters to functions
+      QTest::addColumn<QString>( "string" );
+      QTest::addColumn<bool>( "parserError" );
+      QTest::addColumn<QString>( "dump" );
+      QTest::addColumn<QVariant>( "result" );
+
+      QTest::newRow( "unsupported" ) << "min( val1:=1, val2:=2, val3:=3 )" << true << "" << QVariant();
+      QTest::newRow( "named params named" ) << "clamp( min:=1, value:=2, max:=3)" << false << "clamp(1, 2, 3)" << QVariant( 2.0 );
+      QTest::newRow( "named params unnamed" ) << "clamp(1,2,3)" << false << "clamp(1, 2, 3)" << QVariant( 2.0 );
+      QTest::newRow( "named params mixed" ) << "clamp( 1, value:=2, max:=3)" << false << "clamp(1, 2, 3)" << QVariant( 2.0 );
+      QTest::newRow( "named params mixed bad" ) << "clamp( 1, value:=2, 3)" << true << "" << QVariant();
+      QTest::newRow( "named params mixed 2" ) << "clamp( 1, 2, max:=3)" << false << "clamp(1, 2, 3)" << QVariant( 2.0 );
+      QTest::newRow( "named params reordered" ) << "clamp( value := 2, max:=3, min:=1)" << false << "clamp(1, 2, 3)" << QVariant( 2.0 );
+      QTest::newRow( "named params mixed case" ) << "clamp( Min:=1, vAlUe:=2,MAX:=3)" << false << "clamp(1, 2, 3)" << QVariant( 2.0 );
+      QTest::newRow( "named params expression node" ) << "clamp( min:=1*2, value:=2+2, max:=3+1+2)" << false << "clamp(1 * 2, 2 + 2, 3 + 1 + 2)" << QVariant( 4.0 );
+      QTest::newRow( "named params bad name" ) << "clamp( min:=1, x:=2, y:=3)" << true << "" << QVariant();
+      QTest::newRow( "named params dupe implied" ) << "clamp( 1, 2, value:= 3, max:=4)" << true << "" << QVariant();
+      QTest::newRow( "named params dupe explicit" ) << "clamp( 1, value := 2, value:= 3, max:=4)" << true << "" << QVariant();
+      QTest::newRow( "named params dupe explicit 2" ) << "clamp( value:=1, value := 2, max:=4)" << true << "" << QVariant();
+      QTest::newRow( "named params non optional omitted" ) << "clamp( min:=1, max:=2)" << true << "" << QVariant();
+      QTest::newRow( "optional parameters specified" ) << "wordwrap( 'testxstring', 5, 'x')" << false << "wordwrap('testxstring', 5, 'x')" << QVariant( "test\nstring" );
+      QTest::newRow( "optional parameters specified named" ) << "wordwrap( text:='testxstring', length:=5, delimiter:='x')" << false << "wordwrap('testxstring', 5, 'x')" << QVariant( "test\nstring" );
+      QTest::newRow( "optional parameters unspecified" ) << "wordwrap( text:='test string', length:=5 )" << false << "wordwrap('test string', 5, ' ')" << QVariant( "test\nstring" );
+      QTest::newRow( "named params dupe explicit 3" ) << "wordwrap( 'test string', 5, length:=6 )" << true << "" << QVariant();
+      QTest::newRow( "named params dupe explicit 4" ) << "wordwrap( text:='test string', length:=5, length:=6 )" << true << "" << QVariant();
+    }
+
+    void named_parameter()
+    {
+      QFETCH( QString, string );
+      QFETCH( bool, parserError );
+      QFETCH( QString, dump );
+      QFETCH( QVariant, result );
+
+      QgsExpression exp( string );
+      QCOMPARE( exp.hasParserError(), parserError );
+      if ( exp.hasParserError() )
+      {
+        //parser error, so no point continuing testing
+        qDebug() << exp.parserErrorString();
+        return;
+      }
+
+      QgsExpressionContext context;
+      Q_ASSERT( exp.prepare( &context ) );
+
+      QVariant res = exp.evaluate();
+      if ( exp.hasEvalError() )
+        qDebug() << exp.evalErrorString();
+      if ( res.type() != result.type() )
+      {
+        qDebug() << "got " << res.typeName() << " instead of " << result.typeName();
+      }
+      QCOMPARE( res, result );
+      QCOMPARE( exp.dump(), dump );
+    }
+
     void evaluation_data()
     {
       QTest::addColumn<QString>( "string" );

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -448,6 +448,7 @@ class TestQgsExpression: public QObject
       QTest::newRow( "min(-16.6,3.5,-2.1)" ) << "min(-16.6,3.5,-2.1)" << false << QVariant( -16.6 );
       QTest::newRow( "min(5,3.5,-2.1)" ) << "min(5,3.5,-2.1)" << false << QVariant( -2.1 );
       QTest::newRow( "clamp(-2,1,5)" ) << "clamp(-2,1,5)" << false << QVariant( 1.0 );
+      QTest::newRow( "clamp(min:=-2,value:=1,max:=5)" ) << "clamp(min:=-2,value:=1,max:=5)" << false << QVariant( 1.0 );
       QTest::newRow( "clamp(-2,-10,5)" ) << "clamp(-2,-10,5)" << false << QVariant( -2.0 );
       QTest::newRow( "clamp(-2,100,5)" ) << "clamp(-2,100,5)" << false << QVariant( 5.0 );
       QTest::newRow( "floor(4.9)" ) << "floor(4.9)" << false << QVariant( 4. );


### PR DESCRIPTION
This commit sets the framework for allowing expression functions to use named parameters. Ie, instead of: 

clamp(1,2,3)

you can use:

clamp( min:=1, value:=2, max:=3)

This also allows arguments to be switched, eg:

clamp( value:=2, max:=3, min:=1)

Additionally, it allows for a more structured definition of function parameters to handle optional arguments and default values for parameters. These are currently being done using a hacky infinite argument list.

I've utilised the postgres ':=' syntax for specifying named arguments to avoid potential collisions which may arise with the equality test if we re-used just the '=' operator alone.

This PR is a proof of concept only (eg incomplete docs, tests and bindings), but I'm after feedback on whether this is the cleanest approach to take.

Basically, all the work is done when either preparing an expression or evaluating it for the first time. A map is built up for translating the specified parameters into the order expected by the function, and replacing any missing parameters with their default values.
