### PR TITLE
Fix indentation in src/app/qgisapp.cpp

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -7746,7 +7746,7 @@ void QgisApp::removeLayer()
   }
 
   bool promptConfirmation = QSettings().value( "qgis/askToDeleteLayers", true ).toBool();
-  bool shiftHeld = QApplication::queryKeyboardModifiers().testFlag(Qt::ShiftModifier);
+  bool shiftHeld = QApplication::queryKeyboardModifiers().testFlag( Qt::ShiftModifier );
   //display a warning
   if ( !shiftHeld && promptConfirmation && QMessageBox::warning( this, tr( "Remove layers and groups" ), tr( "Remove %n legend entries?", "number of legend items to remove", selectedNodes.count() ), QMessageBox::Ok | QMessageBox::Cancel ) == QMessageBox::Cancel )
   {


### PR DESCRIPTION
The indentation error was added in
https://github.com/qgis/QGIS/commit/d732d845f1303dc6374efe0facfe4bea0d528d91
but went unnoticed in the Travis builds after merge in master.

However my working branch rebased on top of master detected the issue whereas
I never modified this file...
https://travis-ci.org/rouault/Quantum-GIS/jobs/119308048

There must be some shortcoming or subtelty in the working of scripts/verify-indentation.sh
