### PR TITLE
Fix if function example

### DIFF
--- a/resources/function_help/json/if
+++ b/resources/function_help/json/if
@@ -4,10 +4,11 @@
   "description": "Tests a condition and returns a different result depending on the conditional check.",
   "arguments": [
 	{"arg":"condition","description":"the condition which should be checked"},
-	{"arg":"result_when_true","description":"the result which will be returned when the condition is True"},
-	{"arg":"result_when_false","description":"the result which will be returned when the condition is False"}
+	{"arg":"result_when_true","description":"the result which will be returned when the condition returns True or not null value"},
+	{"arg":"result_when_false","description":"the result which will be returned when the condition returns False, zero or empty value"}
   ],
   "examples": [ { "expression":"if( 1, 'One', 'Not One' )", "returns":"'One'"},
-  { "expression":"if( 8, 'One', 'Not One' )", "returns":"'Not One'"}
+  { "expression":"if( 0, 'One', 'Not One' )", "returns":"'Not One'"}
+  { "expression":"if( 8 < 1, 'One', 'Not One' )", "returns":"'Not One'"}
   ]
 }

--- a/resources/function_help/json/if
+++ b/resources/function_help/json/if
@@ -4,11 +4,15 @@
   "description": "Tests a condition and returns a different result depending on the conditional check.",
   "arguments": [
 	{"arg":"condition","description":"the condition which should be checked"},
-	{"arg":"result_when_true","description":"the result which will be returned when the condition returns True or not null value"},
-	{"arg":"result_when_false","description":"the result which will be returned when the condition returns False, zero or empty value"}
+	{"arg":"result_when_true","description":"the result which will be returned when the condition is true or another value that does not convert to false."},
+	{"arg":"result_when_false","description":"the result which will be returned when the condition is false or another value that converts to false like 0 or ''. NULL will also be converted to false."}
   ],
-  "examples": [ { "expression":"if( 1, 'One', 'Not One' )", "returns":"'One'"},
-  { "expression":"if( 0, 'One', 'Not One' )", "returns":"'Not One'"}
-  { "expression":"if( 8 < 1, 'One', 'Not One' )", "returns":"'Not One'"}
+  "examples": [ { "expression":"if( 1+1=2, 'Yes', 'No' )", "returns":"'Yes'"},
+  { "expression":"if( 1+1=3, 'Yes', 'No' )", "returns":"'No'"}
+  { "expression":"if( 5 > 3, 'One', 'Not One' )", "returns":"'One'"}
+  { "expression":"if( '', 'It is true (not empty)', 'It is false (empty)' )", "returns":"'It is false (empty)'"}
+  { "expression":"if( ' ', 'It is true (not empty)', 'It is false (empty)' )", "returns":"'It is true (not empty)'"}
+  { "expression":"if( 0, 'One', 'Zero' )", "returns":"'Zero'"}
+  { "expression":"if( 10, 'One', 'Zero' )", "returns":"'One'"}
   ]
 }


### PR DESCRIPTION
First of all, the example given for the if function `"if( 8, 'One', 'Not One' )", "returns":"'Not One'` is wrong.
Then the concept of what is true or false is not that clear for the common user (e.g, 1 is true, 8 is true, 0 is false...?) so I reword the explanation and add a new example more understandable (a comparison). I let you appreciate what's better.
But the fix should be backported to 2.14.
