### PR TITLE
[SERVER] Fix encoding of query string for bindings

### DIFF
--- a/src/server/qgsserver.cpp
+++ b/src/server/qgsserver.cpp
@@ -441,9 +441,9 @@ bool QgsServer::init( int & argc, char ** argv )
 void QgsServer::putenv( const QString &var, const QString &val )
 {
 #ifdef _MSC_VER
-  _putenv_s( var.toUtf8().data(), val.toUtf8().data() );
+  _putenv_s( var.toStdString().c_str(), val.toStdString().c_str() );
 #else
-  setenv( var.toUtf8().data(), val.toUtf8().data(), 1 );
+  setenv( var.toStdString().c_str(), val.toStdString().c_str(), 1 );
 #endif
 }
 


### PR DESCRIPTION
Fix an error when passing utf-8 chars in the query string
from python bindings

Adds a test for GetLegendGraphics
