### PR TITLE
Map Styling dock for consolidated style options (style, labels, diagrams)

### DIFF
--- a/python/gui/qgsfieldexpressionwidget.sip
+++ b/python/gui/qgsfieldexpressionwidget.sip
@@ -84,6 +84,9 @@ class QgsFieldExpressionWidget : QWidget
     //! convenience slot to connect QgsMapLayerComboBox layer signal
     void setLayer( QgsMapLayer* layer );
 
+    //! sets the current row in the widget
+    void setRow( int row );
+
     //! sets the current field or expression in the widget
     void setField( const QString &fieldName );
 

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -94,6 +94,7 @@ SET(QGIS_APP_SRCS
   nodetool/qgsvertexentry.cpp
   nodetool/qgsnodeeditor.cpp
 
+  qgsmapstylingwidget.cpp
   qgsmeasuredialog.cpp
   qgsmeasuretool.cpp
   qgsmergeattributesdialog.cpp
@@ -268,6 +269,7 @@ SET (QGIS_APP_MOC_HDRS
   nodetool/qgsselectedfeature.h
   nodetool/qgsnodeeditor.h
 
+  qgsmapstylingwidget.h
   qgsmeasuredialog.h
   qgsmeasuretool.h
   qgsmergeattributesdialog.h

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -12,8 +12,7 @@
  *   it under the terms of the GNU General Public License as published by  *
  *   the Free Software Foundation; either version 2 of the License, or     *
  *   (at your option) any later version.                                   *
- *                                                                         *
- ***************************************************************************/
+ *                                                                         * ***************************************************************************/
 
 #ifndef QGISAPP_H
 #define QGISAPP_H
@@ -94,6 +93,8 @@ class QgsScaleComboBox;
 class QgsDataItem;
 class QgsTileScaleWidget;
 
+class QgsLabelingWidget;
+class QgsMapStylingWidget;
 class QgsDiagramProperties;
 
 #include <QMainWindow>
@@ -114,6 +115,7 @@ class QgsDiagramProperties;
 #include "qgsmessagebar.h"
 #include "qgsbookmarks.h"
 #include "qgswelcomepageitemsmodel.h"
+
 
 #include "ui_qgisapp.h"
 
@@ -1089,6 +1091,9 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     /** Called when some layer's editing mode was toggled on/off */
     void layerEditStateChanged();
 
+    /** Update the label toolbar buttons */
+    void updateLabelToolButtons();
+
     /** Activates or deactivates actions depending on the current maplayer type.
     Is called from the legend when the current legend item has changed*/
     void activateDeactivateLayerRelatedActions( QgsMapLayer *layer );
@@ -1163,6 +1168,9 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     //! shows label settings dialog (for labeling-ng)
     void labeling();
+
+    //! shows the map styling dock
+    void mapStyleDock();
 
     //! diagrams properties
     void diagramProperties();
@@ -1284,6 +1292,9 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     /** Pushes a layer error to the message bar */
     void onLayerError( const QString& msg );
+
+    /** Set the layer for the map style dock. Doesn't show the style dock */
+    void setMapStyleDockLayer( QgsMapLayer *layer );
 
   signals:
     /** Emitted when a key is pressed and we want non widget sublasses to be able
@@ -1682,6 +1693,8 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     QgsSnappingDialog *mSnappingDialog;
 
     QgsPluginManager *mPluginManager;
+    QDockWidget *mMapStylingDock;
+    QgsMapStylingWidget* mMapStyleWidget;
 
     QgsComposerManager *mComposerManager;
 
@@ -1720,6 +1733,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     QgsMapCanvasTracer* mTracer;
 
     QAction* mActionFilterLegend;
+    QAction* mActionStyleDock;
 
     QgsLegendFilterButton* mLegendExpressionFilterButton;
 

--- a/src/app/qgslabelinggui.h
+++ b/src/app/qgslabelinggui.h
@@ -48,7 +48,14 @@ class APP_EXPORT QgsLabelingGui : public QWidget, private Ui::QgsLabelingGuiBase
 
     void setLabelMode( LabelMode mode );
 
+  signals:
+    void widgetChanged();
+
   public slots:
+    void setLayer( QgsMapLayer* layer );
+    void setDockMode( bool enabled );
+    void connectValueChanged( QList<QWidget*> widgets, const char* slot );
+
     void init();
     void collapseSample( bool collapse );
     void apply();
@@ -121,6 +128,7 @@ class APP_EXPORT QgsLabelingGui : public QWidget, private Ui::QgsLabelingGuiBase
 
     // background reference font
     QFont mRefFont;
+    bool mDockMode;
     int mPreviewSize;
 
     int mMinPixelLimit;

--- a/src/app/qgslabelingwidget.h
+++ b/src/app/qgslabelingwidget.h
@@ -4,11 +4,14 @@
 #include <QWidget>
 
 #include <ui_qgslabelingwidget.h>
+#include <qgspallabeling.h>
 
 class QgsLabelingGui;
 class QgsMapCanvas;
 class QgsRuleBasedLabelingWidget;
+class QgsAbstractVectorLayerLabeling;
 class QgsVectorLayer;
+class QgsMapLayer;
 
 /**
  * Master widget for configuration of labeling of a vector layer
@@ -20,6 +23,8 @@ class QgsLabelingWidget : public QWidget, private Ui::QgsLabelingWidget
     QgsLabelingWidget( QgsVectorLayer* layer, QgsMapCanvas* canvas, QWidget* parent = nullptr );
 
   public slots:
+    void setLayer( QgsMapLayer *layer );
+    void setDockMode( bool enabled );
     //! save config to layer
     void writeSettingsToLayer();
 
@@ -29,6 +34,11 @@ class QgsLabelingWidget : public QWidget, private Ui::QgsLabelingWidget
     //! reload the settings shown in the dialog from the current layer
     void adaptToLayer();
 
+    void resetSettings();
+
+  signals:
+    void widgetChanged();
+
   protected slots:
     void labelModeChanged( int index );
     void showEngineConfigDialog();
@@ -37,7 +47,12 @@ class QgsLabelingWidget : public QWidget, private Ui::QgsLabelingWidget
     QgsVectorLayer* mLayer;
     QgsMapCanvas* mCanvas;
 
+    bool mDockMode;
+
     QWidget* mWidget;
+    QgsLabelingGui* mLabelGui;
+    QgsAbstractVectorLayerLabeling* mOldSettings;
+    QgsPalLayerSettings mOldPalSettings;
 };
 
 #endif // QGSLABELINGWIDGET_H

--- a/src/app/qgsmapstylingwidget.cpp
+++ b/src/app/qgsmapstylingwidget.cpp
@@ -1,0 +1,113 @@
+#include <QLabel>
+#include <QVBoxLayout>
+#include <QHBoxLayout>
+#include <QWidget>
+#include <QSizePolicy>
+
+#include "qgsapplication.h"
+#include "qgslabelingwidget.h"
+#include "qgsmapstylingwidget.h"
+#include "qgsmapcanvas.h"
+#include "qgsmaplayer.h"
+
+QgsMapStylingWidget::QgsMapStylingWidget( QgsMapCanvas* canvas, QWidget *parent ) :
+    QWidget( parent ), mMapCanvas( canvas ), mBlockAutoApply( false ), mCurrentLayer( nullptr )
+{
+  QBoxLayout* layout = new QVBoxLayout();
+  layout->setContentsMargins( 0, 0, 0, 0 );
+  this->setLayout( layout );
+
+  mStackedWidget = new QStackedWidget( this );
+  mMapStyleTabs = new QTabWidget( this );
+  mMapStyleTabs->setDocumentMode( true );
+  mNotSupportedPage = mStackedWidget->addWidget( new QLabel( "Not supported currently" ) );
+  mVectorPage = mStackedWidget->addWidget( mMapStyleTabs );
+
+  layout->addWidget( mStackedWidget );
+  mButtonBox = new QDialogButtonBox( QDialogButtonBox::Reset | QDialogButtonBox::Apply );
+  mLiveApplyCheck = new QCheckBox( "Live update" );
+  mLiveApplyCheck->setChecked( true );
+
+  QHBoxLayout* bottomLayout = new QHBoxLayout( );
+  bottomLayout->addWidget( mButtonBox );
+  bottomLayout->addWidget( mLiveApplyCheck );
+  layout->addLayout( bottomLayout );
+
+  mLabelingWidget = new QgsLabelingWidget( 0, mMapCanvas, this );
+  mLabelingWidget->setDockMode( true );
+  connect( mLabelingWidget, SIGNAL( widgetChanged() ), this, SLOT( autoApply() ) );
+
+  // Only labels for now but styles and diagrams will come later
+//  int styleTabIndex = mMapStyleTabs->addTab( new QWidget(), QgsApplication::getThemeIcon( "propertyicons/symbology.png" ), "Styles" );
+  mLabelTabIndex = mMapStyleTabs->addTab( mLabelingWidget, QgsApplication::getThemeIcon( "labelingSingle.svg" ), "Labeling" );
+//  int diagramTabIndex = mMapStyleTabs->addTab( new QWidget(), QgsApplication::getThemeIcon( "propertyicons/diagram.png" ), "Diagrams" );
+//  mMapStyleTabs->setTabEnabled( styleTabIndex, false );
+//  mMapStyleTabs->setTabEnabled( diagramTabIndex, false );
+  mMapStyleTabs->setCurrentIndex( mLabelTabIndex );
+
+  connect( mLiveApplyCheck, SIGNAL( toggled( bool ) ), mButtonBox->button( QDialogButtonBox::Apply ), SLOT( setDisabled( bool ) ) );
+
+  connect( mButtonBox->button( QDialogButtonBox::Apply ), SIGNAL( clicked() ), this, SLOT( apply() ) );
+  connect( mButtonBox->button( QDialogButtonBox::Reset ), SIGNAL( clicked() ), this, SLOT( resetSettings() ) );
+
+  mButtonBox->button( QDialogButtonBox::Apply )->setEnabled( false );
+  mButtonBox->button( QDialogButtonBox::Reset )->setEnabled( false );
+
+}
+
+void QgsMapStylingWidget::setLayer( QgsMapLayer *layer )
+{
+  if ( !layer )
+    return;
+
+  mBlockAutoApply = true;
+
+  mCurrentLayer = layer;
+
+  if ( layer->type() == QgsMapLayer::VectorLayer )
+  {
+    mStackedWidget->setCurrentIndex( mVectorPage );
+    // TODO Once there is support for more then just labels
+    // we need to add a check for the just the current tab
+    mMapStyleTabs->setCurrentIndex( mLabelTabIndex );
+    mLabelingWidget->setLayer( layer );
+  }
+  else if ( layer->type() == QgsMapLayer::RasterLayer )
+  {
+    mStackedWidget->setCurrentIndex( mNotSupportedPage );
+  }
+  else if ( layer->type() == QgsMapLayer::PluginLayer )
+  {
+    mStackedWidget->setCurrentIndex( mNotSupportedPage );
+  }
+
+  mBlockAutoApply = false;
+
+  mButtonBox->button( QDialogButtonBox::Reset )->setEnabled( false );
+}
+
+void QgsMapStylingWidget::apply()
+{
+  if ( mStackedWidget->currentIndex() == mVectorPage &&
+       mMapStyleTabs->currentIndex() == mLabelTabIndex )
+  {
+    mLabelingWidget->apply();
+    mButtonBox->button( QDialogButtonBox::Reset )->setEnabled( true );
+    emit styleChanged( mCurrentLayer );
+  }
+}
+
+void QgsMapStylingWidget::autoApply()
+{
+  if ( mLiveApplyCheck->isChecked() && !mBlockAutoApply )
+    apply();
+}
+
+void QgsMapStylingWidget::resetSettings()
+{
+  if ( mStackedWidget->currentIndex() == mVectorPage &&
+       mMapStyleTabs->currentIndex() == mLabelTabIndex )
+  {
+    mLabelingWidget->resetSettings();
+  }
+}

--- a/src/app/qgsmapstylingwidget.h
+++ b/src/app/qgsmapstylingwidget.h
@@ -1,0 +1,46 @@
+#ifndef QGSMAPSTYLESDOCK_H
+#define QGSMAPSTYLESDOCK_H
+
+#include <QWidget>
+#include <QTabWidget>
+#include <QStackedWidget>
+#include <QDialogButtonBox>
+#include <QCheckBox>
+
+class QgsLabelingWidget;
+class QgsMapLayer;
+class QgsMapCanvas;
+
+
+class APP_EXPORT QgsMapStylingWidget : public QWidget
+{
+    Q_OBJECT
+  public:
+    explicit QgsMapStylingWidget( QgsMapCanvas *canvas, QWidget *parent = 0 );
+    QgsMapLayer* layer() { return mCurrentLayer; }
+
+  signals:
+    void styleChanged( QgsMapLayer* layer );
+
+  public slots:
+    void setLayer( QgsMapLayer* layer );
+    void apply();
+    void autoApply();
+    void resetSettings();
+
+  private:
+    int mNotSupportedPage;
+    int mVectorPage;
+    int mLabelTabIndex;
+    QgsMapCanvas* mMapCanvas;
+    bool mBlockAutoApply;
+    QgsMapLayer* mCurrentLayer;
+    QStackedWidget* mStackedWidget;
+    QTabWidget *mMapStyleTabs;
+    QgsLabelingWidget *mLabelingWidget;
+    QDialogButtonBox* mButtonBox;
+    QCheckBox* mLiveApplyCheck;
+
+};
+
+#endif // QGSMAPSTYLESDOCK_H

--- a/src/app/qgsrulebasedlabelingwidget.h
+++ b/src/app/qgsrulebasedlabelingwidget.h
@@ -72,26 +72,36 @@ class APP_EXPORT QgsRuleBasedLabelingModel : public QAbstractItemModel
 };
 
 
+class QgsLabelingRulePropsDialog;
+
 
 class QgsRuleBasedLabelingWidget : public QWidget, private Ui::QgsRuleBasedLabelingWidget
 {
     Q_OBJECT
   public:
-    QgsRuleBasedLabelingWidget( QgsVectorLayer* layer, QgsMapCanvas* canvas, QWidget* parent = nullptr );
+    QgsRuleBasedLabelingWidget( QgsVectorLayer* layer, QgsMapCanvas* canvas, QWidget* parent = nullptr, bool dockMode = false );
     ~QgsRuleBasedLabelingWidget();
 
     //! save config to layer
     void writeSettingsToLayer();
+    void setDockMode( bool enabled );
 
   signals:
+    void widgetChanged();
 
   protected slots:
+    void saveRuleEdit();
     void addRule();
+    void saveRule();
+    void rejectRule();
     void editRule();
     void editRule( const QModelIndex& index );
     void removeRule();
     void copy();
     void paste();
+
+  private:
+    void addNewRule( QgsRuleBasedLabeling::Rule* newrule );
 
   protected:
     QgsRuleBasedLabeling::Rule* currentRule();
@@ -102,10 +112,12 @@ class QgsRuleBasedLabelingWidget : public QWidget, private Ui::QgsRuleBasedLabel
 
     QgsRuleBasedLabeling::Rule* mRootRule;
     QgsRuleBasedLabelingModel* mModel;
+    QgsLabelingRulePropsDialog* mRuleProps;
 
     QAction* mCopyAction;
     QAction* mPasteAction;
     QAction* mDeleteAction;
+    bool mDockMode;
 };
 
 
@@ -120,14 +132,29 @@ class APP_EXPORT QgsLabelingRulePropsDialog : public QDialog, private Ui::QgsLab
     Q_OBJECT
 
   public:
-    QgsLabelingRulePropsDialog( QgsRuleBasedLabeling::Rule* rule, QgsVectorLayer* layer, QWidget* parent = nullptr, QgsMapCanvas* mapCanvas = nullptr );
+    enum Mode
+    {
+      Adding,
+      Editing
+    };
+
+    QgsLabelingRulePropsDialog( QgsRuleBasedLabeling::Rule* rule, QgsVectorLayer* layer,
+                                QWidget* parent = nullptr, QgsMapCanvas* mapCanvas = nullptr,
+                                bool dockMode = false );
     ~QgsLabelingRulePropsDialog();
 
     QgsRuleBasedLabeling::Rule* rule() { return mRule; }
 
+    Mode currentMode() { return mCurrentMode; }
+    void setCurrentMode( Mode currentMode ) { mCurrentMode = currentMode; }
+
+  signals:
+    void widgetChanged();
+
   public slots:
     void testFilter();
     void buildExpression();
+    void updateRule();
     void accept() override;
 
   protected:
@@ -138,6 +165,8 @@ class APP_EXPORT QgsLabelingRulePropsDialog : public QDialog, private Ui::QgsLab
     QgsPalLayerSettings* mSettings; // a clone of original settings
 
     QgsMapCanvas* mMapCanvas;
+    bool mDockMode;
+    Mode mCurrentMode;
 };
 
 

--- a/src/gui/qgisgui.cpp
+++ b/src/gui/qgisgui.cpp
@@ -200,5 +200,4 @@ namespace QgisGui
     return QFontDialog::getFont( &ok, initial, nullptr, title );
 #endif
   }
-
 } // end of QgisGui namespace

--- a/src/gui/qgsfieldexpressionwidget.h
+++ b/src/gui/qgsfieldexpressionwidget.h
@@ -127,6 +127,9 @@ class GUI_EXPORT QgsFieldExpressionWidget : public QWidget
     //! convenience slot to connect QgsMapLayerComboBox layer signal
     void setLayer( QgsMapLayer* layer );
 
+    //! sets the current row in the widget
+    void setRow( int row ) { mCombo->setCurrentIndex( row ); }
+
     //! sets the current field or expression in the widget
     void setField( const QString &fieldName );
 

--- a/src/ui/qgslabelingguibase.ui
+++ b/src/ui/qgslabelingguibase.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>640</width>
+    <width>508</width>
     <height>600</height>
    </rect>
   </property>
@@ -14,16 +14,7 @@
    <string>Layer labeling settings</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_8">
-   <property name="leftMargin">
-    <number>0</number>
-   </property>
-   <property name="topMargin">
-    <number>0</number>
-   </property>
-   <property name="rightMargin">
-    <number>0</number>
-   </property>
-   <property name="bottomMargin">
+   <property name="margin">
     <number>0</number>
    </property>
    <property name="verticalSpacing">
@@ -44,16 +35,7 @@
       <enum>QFrame::Raised</enum>
      </property>
      <layout class="QGridLayout" name="gridLayout_23">
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
+      <property name="margin">
        <number>0</number>
       </property>
       <item row="0" column="0">
@@ -112,7 +94,7 @@
               <rect>
                <x>0</x>
                <y>0</y>
-               <width>614</width>
+               <width>487</width>
                <height>300</height>
               </rect>
              </property>
@@ -332,22 +314,110 @@
           <enum>QFrame::Raised</enum>
          </property>
          <layout class="QGridLayout" name="gridLayout_17">
-          <property name="leftMargin">
-           <number>0</number>
-          </property>
-          <property name="topMargin">
-           <number>0</number>
-          </property>
-          <property name="rightMargin">
-           <number>0</number>
-          </property>
-          <property name="bottomMargin">
-           <number>0</number>
-          </property>
           <property name="horizontalSpacing">
            <number>0</number>
           </property>
+          <property name="margin">
+           <number>0</number>
+          </property>
           <item row="0" column="0">
+           <widget class="QTabWidget" name="mOptionsTab">
+            <property name="sizePolicy">
+             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+              <horstretch>0</horstretch>
+              <verstretch>0</verstretch>
+             </sizepolicy>
+            </property>
+            <property name="tabPosition">
+             <enum>QTabWidget::North</enum>
+            </property>
+            <property name="tabShape">
+             <enum>QTabWidget::Rounded</enum>
+            </property>
+            <property name="currentIndex">
+             <number>0</number>
+            </property>
+            <property name="iconSize">
+             <size>
+              <width>20</width>
+              <height>20</height>
+             </size>
+            </property>
+            <property name="elideMode">
+             <enum>Qt::ElideNone</enum>
+            </property>
+            <property name="documentMode">
+             <bool>true</bool>
+            </property>
+            <property name="tabsClosable">
+             <bool>false</bool>
+            </property>
+            <widget class="QWidget" name="textTab">
+             <attribute name="icon">
+              <iconset resource="../../images/images.qrc">
+               <normaloff>:/images/themes/default/mIconFieldText.svg</normaloff>:/images/themes/default/mIconFieldText.svg</iconset>
+             </attribute>
+             <attribute name="title">
+              <string/>
+             </attribute>
+            </widget>
+            <widget class="QWidget" name="tab_2">
+             <attribute name="icon">
+              <iconset resource="../../images/images.qrc">
+               <normaloff>:/images/themes/default/propertyicons/labelformatting.svg</normaloff>:/images/themes/default/propertyicons/labelformatting.svg</iconset>
+             </attribute>
+             <attribute name="title">
+              <string/>
+             </attribute>
+            </widget>
+            <widget class="QWidget" name="tab">
+             <attribute name="icon">
+              <iconset resource="../../images/images.qrc">
+               <normaloff>:/images/themes/default/propertyicons/labelbuffer.svg</normaloff>:/images/themes/default/propertyicons/labelbuffer.svg</iconset>
+             </attribute>
+             <attribute name="title">
+              <string/>
+             </attribute>
+            </widget>
+            <widget class="QWidget" name="tab_3">
+             <attribute name="icon">
+              <iconset resource="../../images/images.qrc">
+               <normaloff>:/images/themes/default/propertyicons/labelbackground.svg</normaloff>:/images/themes/default/propertyicons/labelbackground.svg</iconset>
+             </attribute>
+             <attribute name="title">
+              <string/>
+             </attribute>
+            </widget>
+            <widget class="QWidget" name="tab_4">
+             <attribute name="icon">
+              <iconset resource="../../images/images.qrc">
+               <normaloff>:/images/themes/default/propertyicons/labelshadow.svg</normaloff>:/images/themes/default/propertyicons/labelshadow.svg</iconset>
+             </attribute>
+             <attribute name="title">
+              <string/>
+             </attribute>
+            </widget>
+            <widget class="QWidget" name="widget">
+             <attribute name="icon">
+              <iconset resource="../../images/images.qrc">
+               <normaloff>:/images/themes/default/propertyicons/labelplacement.svg</normaloff>:/images/themes/default/propertyicons/labelplacement.svg</iconset>
+             </attribute>
+             <attribute name="title">
+              <string/>
+             </attribute>
+            </widget>
+            <widget class="QWidget" name="tab_6">
+             <attribute name="icon">
+              <iconset resource="../../images/images.qrc">
+               <normaloff>:/images/themes/default/mIconRenderingEnabled.png</normaloff>:/images/themes/default/mIconRenderingEnabled.png</iconset>
+             </attribute>
+             <attribute name="title">
+              <string/>
+             </attribute>
+            </widget>
+           </widget>
+          </item>
+          <item row="1" column="0">
            <widget class="QSplitter" name="mLabelingOptionsSplitter">
             <property name="orientation">
              <enum>Qt::Horizontal</enum>
@@ -500,7 +570,7 @@
               </sizepolicy>
              </property>
              <property name="frameShape">
-              <enum>QFrame::StyledPanel</enum>
+              <enum>QFrame::NoFrame</enum>
              </property>
              <property name="frameShadow">
               <enum>QFrame::Raised</enum>
@@ -525,28 +595,9 @@
                 </property>
                 <widget class="QWidget" name="mLabelPage_Text">
                  <layout class="QVBoxLayout" name="verticalLayout_6">
-                  <property name="leftMargin">
+                  <property name="margin">
                    <number>0</number>
                   </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                  <item>
-                   <widget class="QLabel" name="label_36">
-                    <property name="styleSheet">
-                     <string notr="true">text-decoration: underline;</string>
-                    </property>
-                    <property name="text">
-                     <string>Text style</string>
-                    </property>
-                   </widget>
-                  </item>
                   <item>
                    <widget class="QScrollArea" name="scrollArea">
                     <property name="frameShape">
@@ -560,8 +611,8 @@
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>594</width>
-                       <height>398</height>
+                       <width>465</width>
+                       <height>385</height>
                       </rect>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_2">
@@ -592,19 +643,10 @@
                          </size>
                         </property>
                         <layout class="QGridLayout" name="gridLayout_6">
-                         <property name="leftMargin">
+                         <property name="margin">
                           <number>0</number>
                          </property>
-                         <property name="topMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="rightMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="bottomMargin">
-                          <number>0</number>
-                         </property>
-                         <item row="9" column="1" colspan="2">
+                         <item row="10" column="1" colspan="2">
                           <layout class="QHBoxLayout" name="horizontalLayout_14">
                            <item>
                             <widget class="QLabel" name="mFontLetterSpacingLabel">
@@ -656,7 +698,7 @@
                            </item>
                           </layout>
                          </item>
-                         <item row="4" column="1">
+                         <item row="5" column="1">
                           <widget class="QgsDoubleSpinBox" name="mFontSizeSpinBox">
                            <property name="sizePolicy">
                             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -681,7 +723,7 @@
                            </property>
                           </widget>
                          </item>
-                         <item row="2" column="0">
+                         <item row="3" column="0">
                           <widget class="QLabel" name="mFontStyleLabel">
                            <property name="sizePolicy">
                             <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
@@ -694,7 +736,7 @@
                            </property>
                           </widget>
                          </item>
-                         <item row="8" column="1">
+                         <item row="9" column="1">
                           <widget class="QComboBox" name="mFontCapitalsComboBox">
                            <property name="enabled">
                             <bool>true</bool>
@@ -716,7 +758,7 @@
                            </property>
                           </widget>
                          </item>
-                         <item row="7" column="0">
+                         <item row="8" column="0">
                           <widget class="QLabel" name="mFontTranspLabel">
                            <property name="enabled">
                             <bool>true</bool>
@@ -726,7 +768,7 @@
                            </property>
                           </widget>
                          </item>
-                         <item row="0" column="0">
+                         <item row="1" column="0">
                           <widget class="QLabel" name="mFontLabel">
                            <property name="sizePolicy">
                             <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
@@ -742,7 +784,7 @@
                            </property>
                           </widget>
                          </item>
-                         <item row="2" column="1">
+                         <item row="3" column="1">
                           <widget class="QComboBox" name="mFontStyleComboBox">
                            <property name="sizePolicy">
                             <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
@@ -770,42 +812,42 @@
                            </property>
                           </widget>
                          </item>
-                         <item row="8" column="2">
+                         <item row="9" column="2">
                           <widget class="QgsDataDefinedButton" name="mFontCaseDDBtn">
                            <property name="text">
                             <string>...</string>
                            </property>
                           </widget>
                          </item>
-                         <item row="5" column="2">
+                         <item row="6" column="2">
                           <widget class="QgsDataDefinedButton" name="mFontUnitsDDBtn">
                            <property name="text">
                             <string>...</string>
                            </property>
                           </widget>
                          </item>
-                         <item row="6" column="2">
+                         <item row="7" column="2">
                           <widget class="QgsDataDefinedButton" name="mFontColorDDBtn">
                            <property name="text">
                             <string>...</string>
                            </property>
                           </widget>
                          </item>
-                         <item row="0" column="2">
+                         <item row="1" column="2">
                           <widget class="QgsDataDefinedButton" name="mFontDDBtn">
                            <property name="text">
                             <string>...</string>
                            </property>
                           </widget>
                          </item>
-                         <item row="7" column="2">
+                         <item row="8" column="2">
                           <widget class="QgsDataDefinedButton" name="mFontTranspDDBtn">
                            <property name="text">
                             <string>...</string>
                            </property>
                           </widget>
                          </item>
-                         <item row="7" column="1">
+                         <item row="8" column="1">
                           <widget class="QFrame" name="frame">
                            <property name="sizePolicy">
                             <sizepolicy hsizetype="Preferred" vsizetype="Maximum">
@@ -814,16 +856,7 @@
                             </sizepolicy>
                            </property>
                            <layout class="QHBoxLayout" name="horizontalLayout_23">
-                            <property name="leftMargin">
-                             <number>0</number>
-                            </property>
-                            <property name="topMargin">
-                             <number>0</number>
-                            </property>
-                            <property name="rightMargin">
-                             <number>0</number>
-                            </property>
-                            <property name="bottomMargin">
+                            <property name="margin">
                              <number>0</number>
                             </property>
                             <item>
@@ -873,7 +906,7 @@
                            </layout>
                           </widget>
                          </item>
-                         <item row="8" column="0">
+                         <item row="9" column="0">
                           <widget class="QLabel" name="mFontCapitalsLabel">
                            <property name="sizePolicy">
                             <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
@@ -886,14 +919,14 @@
                            </property>
                           </widget>
                          </item>
-                         <item row="11" column="2">
+                         <item row="12" column="2">
                           <widget class="QgsDataDefinedButton" name="mFontBlendModeDDBtn">
                            <property name="text">
                             <string>...</string>
                            </property>
                           </widget>
                          </item>
-                         <item row="6" column="0">
+                         <item row="7" column="0">
                           <widget class="QLabel" name="mFontColorLabel">
                            <property name="sizePolicy">
                             <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
@@ -909,21 +942,21 @@
                            </property>
                           </widget>
                          </item>
-                         <item row="4" column="2">
+                         <item row="5" column="2">
                           <widget class="QgsDataDefinedButton" name="mFontSizeDDBtn">
                            <property name="text">
                             <string>...</string>
                            </property>
                           </widget>
                          </item>
-                         <item row="9" column="0">
+                         <item row="10" column="0">
                           <widget class="QLabel" name="label_10">
                            <property name="text">
                             <string>Spacing</string>
                            </property>
                           </widget>
                          </item>
-                         <item row="6" column="1">
+                         <item row="7" column="1">
                           <widget class="QgsColorButtonV2" name="btnTextColor">
                            <property name="sizePolicy">
                             <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
@@ -945,14 +978,14 @@
                            </property>
                           </widget>
                          </item>
-                         <item row="11" column="0">
+                         <item row="12" column="0">
                           <widget class="QLabel" name="labelBlendMode">
                            <property name="text">
                             <string>Blend mode</string>
                            </property>
                           </widget>
                          </item>
-                         <item row="10" column="1" colspan="2">
+                         <item row="11" column="1" colspan="2">
                           <layout class="QHBoxLayout" name="horizontalLayout_15">
                            <item>
                             <widget class="QLabel" name="mFontWordSpacingLabel">
@@ -1004,7 +1037,7 @@
                            </item>
                           </layout>
                          </item>
-                         <item row="3" column="1" colspan="2">
+                         <item row="4" column="1" colspan="2">
                           <layout class="QHBoxLayout" name="horizontalLayout_13">
                            <item>
                             <widget class="QToolButton" name="mFontUnderlineBtn">
@@ -1186,17 +1219,17 @@
                            </item>
                           </layout>
                          </item>
-                         <item row="11" column="1">
+                         <item row="12" column="1">
                           <widget class="QgsBlendModeComboBox" name="comboBlendMode"/>
                          </item>
-                         <item row="2" column="2">
+                         <item row="3" column="2">
                           <widget class="QgsDataDefinedButton" name="mFontStyleDDBtn">
                            <property name="text">
                             <string>...</string>
                            </property>
                           </widget>
                          </item>
-                         <item row="4" column="0">
+                         <item row="5" column="0">
                           <widget class="QLabel" name="mFontSizeLabel">
                            <property name="sizePolicy">
                             <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
@@ -1209,19 +1242,10 @@
                            </property>
                           </widget>
                          </item>
-                         <item row="1" column="1">
+                         <item row="2" column="1">
                           <widget class="QFrame" name="mFontFamilyFrame">
                            <layout class="QHBoxLayout" name="horizontalLayout_5">
-                            <property name="leftMargin">
-                             <number>0</number>
-                            </property>
-                            <property name="topMargin">
-                             <number>0</number>
-                            </property>
-                            <property name="rightMargin">
-                             <number>0</number>
-                            </property>
-                            <property name="bottomMargin">
+                            <property name="margin">
                              <number>0</number>
                             </property>
                             <item>
@@ -1247,15 +1271,31 @@ font-style: italic;</string>
                            </layout>
                           </widget>
                          </item>
-                         <item row="0" column="1">
+                         <item row="1" column="1">
                           <widget class="QFontComboBox" name="mFontFamilyCmbBx">
                            <property name="editable">
                             <bool>false</bool>
                            </property>
                           </widget>
                          </item>
-                         <item row="5" column="1">
+                         <item row="6" column="1">
                           <widget class="QgsUnitSelectionWidget" name="mFontSizeUnitWidget" native="true"/>
+                         </item>
+                         <item row="0" column="0">
+                          <widget class="QLabel" name="mFontLabel_2">
+                           <property name="sizePolicy">
+                            <sizepolicy hsizetype="Preferred" vsizetype="Preferred">
+                             <horstretch>0</horstretch>
+                             <verstretch>0</verstretch>
+                            </sizepolicy>
+                           </property>
+                           <property name="text">
+                            <string>Text</string>
+                           </property>
+                           <property name="alignment">
+                            <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
+                           </property>
+                          </widget>
                          </item>
                         </layout>
                        </widget>
@@ -1281,25 +1321,13 @@ font-style: italic;</string>
                 </widget>
                 <widget class="QWidget" name="mLabelPage_Formatting">
                  <layout class="QVBoxLayout" name="verticalLayout_15">
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
+                  <property name="margin">
                    <number>0</number>
                   </property>
                   <item>
-                   <widget class="QLabel" name="label">
-                    <property name="styleSheet">
-                     <string notr="true">text-decoration: underline;</string>
-                    </property>
+                   <widget class="QLabel" name="label_36">
                     <property name="text">
-                     <string>Text formatting</string>
+                     <string>Formatting</string>
                     </property>
                    </widget>
                   </item>
@@ -1316,8 +1344,8 @@ font-style: italic;</string>
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>594</width>
-                       <height>398</height>
+                       <width>465</width>
+                       <height>366</height>
                       </rect>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_14">
@@ -1500,16 +1528,7 @@ font-style: italic;</string>
                       <item>
                        <widget class="QFrame" name="mDirectSymbolsFrame">
                         <layout class="QGridLayout" name="gridLayout_33">
-                         <property name="leftMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="topMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="rightMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="bottomMargin">
+                         <property name="margin">
                           <number>0</number>
                          </property>
                          <property name="verticalSpacing">
@@ -1575,16 +1594,7 @@ font-style: italic;</string>
                                <property name="spacing">
                                 <number>0</number>
                                </property>
-                               <property name="leftMargin">
-                                <number>0</number>
-                               </property>
-                               <property name="topMargin">
-                                <number>0</number>
-                               </property>
-                               <property name="rightMargin">
-                                <number>0</number>
-                               </property>
-                               <property name="bottomMargin">
+                               <property name="margin">
                                 <number>0</number>
                                </property>
                                <item>
@@ -1686,16 +1696,7 @@ font-style: italic;</string>
                                <property name="spacing">
                                 <number>0</number>
                                </property>
-                               <property name="leftMargin">
-                                <number>0</number>
-                               </property>
-                               <property name="topMargin">
-                                <number>0</number>
-                               </property>
-                               <property name="rightMargin">
-                                <number>0</number>
-                               </property>
-                               <property name="bottomMargin">
+                               <property name="margin">
                                 <number>0</number>
                                </property>
                                <item>
@@ -1740,16 +1741,7 @@ font-style: italic;</string>
                             <item row="2" column="1">
                              <widget class="QFrame" name="mDirectSymbPlacementFrame">
                               <layout class="QHBoxLayout" name="horizontalLayout_17">
-                               <property name="leftMargin">
-                                <number>0</number>
-                               </property>
-                               <property name="topMargin">
-                                <number>0</number>
-                               </property>
-                               <property name="rightMargin">
-                                <number>0</number>
-                               </property>
-                               <property name="bottomMargin">
+                               <property name="margin">
                                 <number>0</number>
                                </property>
                                <item>
@@ -1926,28 +1918,9 @@ font-style: italic;</string>
                 </widget>
                 <widget class="QWidget" name="mLabelPage_Buffer">
                  <layout class="QVBoxLayout" name="verticalLayout_7">
-                  <property name="leftMargin">
+                  <property name="margin">
                    <number>0</number>
                   </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                  <item>
-                   <widget class="QLabel" name="label_4">
-                    <property name="styleSheet">
-                     <string notr="true">text-decoration: underline;</string>
-                    </property>
-                    <property name="text">
-                     <string>Text buffer</string>
-                    </property>
-                   </widget>
-                  </item>
                   <item>
                    <widget class="QScrollArea" name="scrollArea_7">
                     <property name="frameShape">
@@ -1961,8 +1934,8 @@ font-style: italic;</string>
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>594</width>
-                       <height>398</height>
+                       <width>465</width>
+                       <height>385</height>
                       </rect>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_12">
@@ -1980,14 +1953,14 @@ font-style: italic;</string>
                       </property>
                       <item>
                        <layout class="QGridLayout" name="gridLayout_36">
-                        <item row="0" column="1">
+                        <item row="1" column="1">
                          <widget class="QgsDataDefinedButton" name="mBufferDrawDDBtn">
                           <property name="text">
                            <string>...</string>
                           </property>
                          </widget>
                         </item>
-                        <item row="0" column="0">
+                        <item row="1" column="0">
                          <widget class="QCheckBox" name="mBufferDrawChkBx">
                           <property name="sizePolicy">
                            <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
@@ -2000,7 +1973,7 @@ font-style: italic;</string>
                           </property>
                          </widget>
                         </item>
-                        <item row="0" column="2">
+                        <item row="1" column="2">
                          <spacer name="horizontalSpacer_13">
                           <property name="orientation">
                            <enum>Qt::Horizontal</enum>
@@ -2013,7 +1986,7 @@ font-style: italic;</string>
                           </property>
                          </spacer>
                         </item>
-                        <item row="1" column="0" colspan="3">
+                        <item row="2" column="0" colspan="3">
                          <widget class="QFrame" name="mBufferFrame">
                           <layout class="QGridLayout" name="gridLayout_12">
                            <property name="leftMargin">
@@ -2115,16 +2088,7 @@ font-style: italic;</string>
                               </sizepolicy>
                              </property>
                              <layout class="QHBoxLayout" name="horizontalLayout_10">
-                              <property name="leftMargin">
-                               <number>0</number>
-                              </property>
-                              <property name="topMargin">
-                               <number>0</number>
-                              </property>
-                              <property name="rightMargin">
-                               <number>0</number>
-                              </property>
-                              <property name="bottomMargin">
+                              <property name="margin">
                                <number>0</number>
                               </property>
                               <item>
@@ -2282,6 +2246,22 @@ font-style: italic;</string>
                           </layout>
                          </widget>
                         </item>
+                        <item row="0" column="0" colspan="2">
+                         <widget class="QLabel" name="label_37">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="text">
+                           <string>Buffer</string>
+                          </property>
+                          <property name="alignment">
+                           <set>Qt::AlignRight|Qt::AlignTrailing|Qt::AlignVCenter</set>
+                          </property>
+                         </widget>
+                        </item>
                        </layout>
                       </item>
                       <item>
@@ -2305,28 +2285,9 @@ font-style: italic;</string>
                 </widget>
                 <widget class="QWidget" name="mLabelPage_Background">
                  <layout class="QVBoxLayout" name="verticalLayout_20">
-                  <property name="leftMargin">
+                  <property name="margin">
                    <number>0</number>
                   </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                  <item>
-                   <widget class="QLabel" name="label_11">
-                    <property name="styleSheet">
-                     <string notr="true">text-decoration: underline;</string>
-                    </property>
-                    <property name="text">
-                     <string>Background</string>
-                    </property>
-                   </widget>
-                  </item>
                   <item>
                    <widget class="QScrollArea" name="scrollArea_2">
                     <property name="frameShape">
@@ -2340,8 +2301,8 @@ font-style: italic;</string>
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>578</width>
-                       <height>697</height>
+                       <width>448</width>
+                       <height>589</height>
                       </rect>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_21">
@@ -2359,20 +2320,7 @@ font-style: italic;</string>
                       </property>
                       <item>
                        <layout class="QGridLayout" name="gridLayout_37">
-                        <item row="0" column="0">
-                         <widget class="QCheckBox" name="mShapeDrawChkBx">
-                          <property name="sizePolicy">
-                           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                            <horstretch>0</horstretch>
-                            <verstretch>0</verstretch>
-                           </sizepolicy>
-                          </property>
-                          <property name="text">
-                           <string>Draw background</string>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="0" column="2">
+                        <item row="1" column="2">
                          <spacer name="horizontalSpacer_12">
                           <property name="orientation">
                            <enum>Qt::Horizontal</enum>
@@ -2385,14 +2333,27 @@ font-style: italic;</string>
                           </property>
                          </spacer>
                         </item>
-                        <item row="0" column="1">
+                        <item row="1" column="0">
+                         <widget class="QCheckBox" name="mShapeDrawChkBx">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="text">
+                           <string>Draw background</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="1" column="1">
                          <widget class="QgsDataDefinedButton" name="mShapeDrawDDBtn">
                           <property name="text">
                            <string>...</string>
                           </property>
                          </widget>
                         </item>
-                        <item row="1" column="0" colspan="3">
+                        <item row="2" column="0" colspan="3">
                          <widget class="QFrame" name="mShapeFrame">
                           <property name="frameShape">
                            <enum>QFrame::NoFrame</enum>
@@ -2545,16 +2506,7 @@ font-style: italic;</string>
                            <item row="6" column="1" colspan="2">
                             <widget class="QFrame" name="mShapeRotationFrame">
                              <layout class="QHBoxLayout" name="horizontalLayout_36">
-                              <property name="leftMargin">
-                               <number>0</number>
-                              </property>
-                              <property name="topMargin">
-                               <number>0</number>
-                              </property>
-                              <property name="rightMargin">
-                               <number>0</number>
-                              </property>
-                              <property name="bottomMargin">
+                              <property name="margin">
                                <number>0</number>
                               </property>
                              </layout>
@@ -2877,16 +2829,7 @@ font-style: italic;</string>
                            <item row="1" column="1" colspan="2">
                             <widget class="QFrame" name="mShapeSVGPathFrame">
                              <layout class="QHBoxLayout" name="horizontalLayout_26">
-                              <property name="leftMargin">
-                               <number>0</number>
-                              </property>
-                              <property name="topMargin">
-                               <number>0</number>
-                              </property>
-                              <property name="rightMargin">
-                               <number>0</number>
-                              </property>
-                              <property name="bottomMargin">
+                              <property name="margin">
                                <number>0</number>
                               </property>
                               <item>
@@ -3112,6 +3055,13 @@ font-style: italic;</string>
                           </layout>
                          </widget>
                         </item>
+                        <item row="0" column="0">
+                         <widget class="QLabel" name="label_38">
+                          <property name="text">
+                           <string>Background</string>
+                          </property>
+                         </widget>
+                        </item>
                        </layout>
                       </item>
                       <item>
@@ -3135,28 +3085,9 @@ font-style: italic;</string>
                 </widget>
                 <widget class="QWidget" name="mLabelPage_Shadow">
                  <layout class="QVBoxLayout" name="verticalLayout_18">
-                  <property name="leftMargin">
+                  <property name="margin">
                    <number>0</number>
                   </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
-                   <number>0</number>
-                  </property>
-                  <item>
-                   <widget class="QLabel" name="label_37">
-                    <property name="styleSheet">
-                     <string notr="true">text-decoration: underline;</string>
-                    </property>
-                    <property name="text">
-                     <string>Drop shadow</string>
-                    </property>
-                   </widget>
-                  </item>
                   <item>
                    <widget class="QScrollArea" name="scrollArea_8">
                     <property name="frameShape">
@@ -3170,8 +3101,8 @@ font-style: italic;</string>
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>578</width>
-                       <height>424</height>
+                       <width>465</width>
+                       <height>385</height>
                       </rect>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_22">
@@ -3189,20 +3120,7 @@ font-style: italic;</string>
                       </property>
                       <item>
                        <layout class="QGridLayout" name="gridLayout_38">
-                        <item row="0" column="0">
-                         <widget class="QCheckBox" name="mShadowDrawChkBx">
-                          <property name="sizePolicy">
-                           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
-                            <horstretch>0</horstretch>
-                            <verstretch>0</verstretch>
-                           </sizepolicy>
-                          </property>
-                          <property name="text">
-                           <string>Draw drop shadow</string>
-                          </property>
-                         </widget>
-                        </item>
-                        <item row="0" column="2">
+                        <item row="1" column="2">
                          <spacer name="horizontalSpacer_14">
                           <property name="orientation">
                            <enum>Qt::Horizontal</enum>
@@ -3215,14 +3133,27 @@ font-style: italic;</string>
                           </property>
                          </spacer>
                         </item>
-                        <item row="0" column="1">
+                        <item row="1" column="0">
+                         <widget class="QCheckBox" name="mShadowDrawChkBx">
+                          <property name="sizePolicy">
+                           <sizepolicy hsizetype="Maximum" vsizetype="Fixed">
+                            <horstretch>0</horstretch>
+                            <verstretch>0</verstretch>
+                           </sizepolicy>
+                          </property>
+                          <property name="text">
+                           <string>Draw drop shadow</string>
+                          </property>
+                         </widget>
+                        </item>
+                        <item row="1" column="1">
                          <widget class="QgsDataDefinedButton" name="mShadowDrawDDBtn">
                           <property name="text">
                            <string>...</string>
                           </property>
                          </widget>
                         </item>
-                        <item row="1" column="0" colspan="3">
+                        <item row="2" column="0" colspan="3">
                          <widget class="QFrame" name="mShadowFrame">
                           <layout class="QGridLayout" name="gridLayout_7">
                            <property name="leftMargin">
@@ -3602,6 +3533,13 @@ font-style: italic;</string>
                           </layout>
                          </widget>
                         </item>
+                        <item row="0" column="0">
+                         <widget class="QLabel" name="label_39">
+                          <property name="text">
+                           <string>Shadow</string>
+                          </property>
+                         </widget>
+                        </item>
                        </layout>
                       </item>
                       <item>
@@ -3625,22 +3563,16 @@ font-style: italic;</string>
                 </widget>
                 <widget class="QWidget" name="mLabelPage_Placement">
                  <layout class="QVBoxLayout" name="verticalLayout_10">
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
+                  <property name="margin">
                    <number>0</number>
                   </property>
                   <item>
-                   <widget class="QLabel" name="label_38">
-                    <property name="styleSheet">
-                     <string notr="true">text-decoration: underline;</string>
+                   <widget class="QLabel" name="label_43">
+                    <property name="sizePolicy">
+                     <sizepolicy hsizetype="Maximum" vsizetype="Preferred">
+                      <horstretch>0</horstretch>
+                      <verstretch>0</verstretch>
+                     </sizepolicy>
                     </property>
                     <property name="text">
                      <string>Placement</string>
@@ -3660,8 +3592,8 @@ font-style: italic;</string>
                       <rect>
                        <x>0</x>
                        <y>0</y>
-                       <width>578</width>
-                       <height>899</height>
+                       <width>448</width>
+                       <height>758</height>
                       </rect>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_11">
@@ -3692,16 +3624,7 @@ font-style: italic;</string>
                          <enum>QFrame::Sunken</enum>
                         </property>
                         <layout class="QVBoxLayout" name="verticalLayout_9">
-                         <property name="leftMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="topMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="rightMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="bottomMargin">
+                         <property name="margin">
                           <number>0</number>
                          </property>
                          <item>
@@ -3713,20 +3636,11 @@ font-style: italic;</string>
                             <enum>QFrame::Sunken</enum>
                            </property>
                            <property name="currentIndex">
-                            <number>0</number>
+                            <number>1</number>
                            </property>
                            <widget class="QWidget" name="pagePoint">
                             <layout class="QGridLayout" name="gridLayout_13" columnstretch="0,0,0,0">
-                             <property name="leftMargin">
-                              <number>0</number>
-                             </property>
-                             <property name="topMargin">
-                              <number>0</number>
-                             </property>
-                             <property name="rightMargin">
-                              <number>0</number>
-                             </property>
-                             <property name="bottomMargin">
+                             <property name="margin">
                               <number>0</number>
                              </property>
                              <item row="0" column="1">
@@ -3779,16 +3693,7 @@ font-style: italic;</string>
                            </widget>
                            <widget class="QWidget" name="pageLine">
                             <layout class="QGridLayout" name="gridLayout_14">
-                             <property name="leftMargin">
-                              <number>0</number>
-                             </property>
-                             <property name="topMargin">
-                              <number>0</number>
-                             </property>
-                             <property name="rightMargin">
-                              <number>0</number>
-                             </property>
-                             <property name="bottomMargin">
+                             <property name="margin">
                               <number>0</number>
                              </property>
                              <item row="0" column="1">
@@ -3831,16 +3736,7 @@ font-style: italic;</string>
                            </widget>
                            <widget class="QWidget" name="pagePolygon">
                             <layout class="QGridLayout" name="gridLayout_18">
-                             <property name="leftMargin">
-                              <number>0</number>
-                             </property>
-                             <property name="topMargin">
-                              <number>0</number>
-                             </property>
-                             <property name="rightMargin">
-                              <number>0</number>
-                             </property>
-                             <property name="bottomMargin">
+                             <property name="margin">
                               <number>0</number>
                              </property>
                              <item row="0" column="0">
@@ -3924,16 +3820,7 @@ font-style: italic;</string>
                          <enum>QFrame::Raised</enum>
                         </property>
                         <layout class="QGridLayout" name="gridLayout_10">
-                         <property name="leftMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="topMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="rightMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="bottomMargin">
+                         <property name="margin">
                           <number>0</number>
                          </property>
                          <item row="0" column="0">
@@ -4008,16 +3895,7 @@ font-style: italic;</string>
                          <enum>QFrame::Raised</enum>
                         </property>
                         <layout class="QGridLayout" name="gridLayout_25">
-                         <property name="leftMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="topMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="rightMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="bottomMargin">
+                         <property name="margin">
                           <number>0</number>
                          </property>
                          <item row="0" column="0">
@@ -4097,20 +3975,11 @@ font-style: italic;</string>
                          <enum>QFrame::Raised</enum>
                         </property>
                         <layout class="QGridLayout" name="gridLayout_27">
-                         <property name="leftMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="topMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="rightMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="bottomMargin">
-                          <number>0</number>
-                         </property>
                          <property name="verticalSpacing">
                           <number>12</number>
+                         </property>
+                         <property name="margin">
+                          <number>0</number>
                          </property>
                          <item row="0" column="1">
                           <widget class="QgsDoubleSpinBox" name="mLineDistanceSpnBx">
@@ -4176,20 +4045,11 @@ font-style: italic;</string>
                          <enum>QFrame::Raised</enum>
                         </property>
                         <layout class="QGridLayout" name="gridLayout_40">
-                         <property name="leftMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="topMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="rightMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="bottomMargin">
-                          <number>0</number>
-                         </property>
                          <property name="verticalSpacing">
                           <number>12</number>
+                         </property>
+                         <property name="margin">
+                          <number>0</number>
                          </property>
                          <item row="0" column="0">
                           <widget class="QLabel" name="label_42">
@@ -4216,16 +4076,7 @@ font-style: italic;</string>
                       <item>
                        <widget class="QFrame" name="mPlacementQuadrantFrame">
                         <layout class="QGridLayout" name="gridLayout_19">
-                         <property name="leftMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="topMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="rightMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="bottomMargin">
+                         <property name="margin">
                           <number>0</number>
                          </property>
                          <item row="0" column="2">
@@ -4238,16 +4089,7 @@ font-style: italic;</string>
                          <item row="0" column="1" rowspan="3">
                           <widget class="QFrame" name="mPlacementFixedQuadrantFrame">
                            <layout class="QGridLayout" name="gridLayout_3">
-                            <property name="leftMargin">
-                             <number>0</number>
-                            </property>
-                            <property name="topMargin">
-                             <number>0</number>
-                            </property>
-                            <property name="rightMargin">
-                             <number>0</number>
-                            </property>
-                            <property name="bottomMargin">
+                            <property name="margin">
                              <number>0</number>
                             </property>
                             <property name="spacing">
@@ -4503,16 +4345,7 @@ font-style: italic;</string>
                       <item>
                        <widget class="QFrame" name="mPlacementCartographicFrame">
                         <layout class="QGridLayout" name="gridLayout_39">
-                         <property name="leftMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="topMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="rightMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="bottomMargin">
+                         <property name="margin">
                           <number>0</number>
                          </property>
                          <item row="0" column="2">
@@ -4525,16 +4358,7 @@ font-style: italic;</string>
                          <item row="0" column="1" rowspan="2">
                           <widget class="QFrame" name="mPlacementFixedQuadrantFrame_2">
                            <layout class="QGridLayout" name="gridLayout_11">
-                            <property name="leftMargin">
-                             <number>0</number>
-                            </property>
-                            <property name="topMargin">
-                             <number>0</number>
-                            </property>
-                            <property name="rightMargin">
-                             <number>0</number>
-                            </property>
-                            <property name="bottomMargin">
+                            <property name="margin">
                              <number>0</number>
                             </property>
                             <property name="spacing">
@@ -4587,20 +4411,11 @@ font-style: italic;</string>
                          <enum>QFrame::Raised</enum>
                         </property>
                         <layout class="QGridLayout" name="gridLayout_15">
-                         <property name="leftMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="topMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="rightMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="bottomMargin">
-                          <number>0</number>
-                         </property>
                          <property name="verticalSpacing">
                           <number>12</number>
+                         </property>
+                         <property name="margin">
+                          <number>0</number>
                          </property>
                          <item row="0" column="2">
                           <widget class="QgsDoubleSpinBox" name="mPointOffsetYSpinBox">
@@ -4706,16 +4521,7 @@ font-style: italic;</string>
                          <enum>QFrame::Raised</enum>
                         </property>
                         <layout class="QGridLayout" name="gridLayout_26">
-                         <property name="leftMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="topMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="rightMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="bottomMargin">
+                         <property name="margin">
                           <number>0</number>
                          </property>
                          <item row="0" column="0">
@@ -4775,20 +4581,11 @@ font-style: italic;</string>
                          <enum>QFrame::Raised</enum>
                         </property>
                         <layout class="QGridLayout" name="gridLayout_24">
-                         <property name="leftMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="topMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="rightMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="bottomMargin">
-                          <number>0</number>
-                         </property>
                          <property name="verticalSpacing">
                           <number>12</number>
+                         </property>
+                         <property name="margin">
+                          <number>0</number>
                          </property>
                          <item row="0" column="0">
                           <widget class="QLabel" name="label_7">
@@ -4839,20 +4636,11 @@ font-style: italic;</string>
                       <item>
                        <widget class="QFrame" name="mPlacementMaxCharAngleFrame">
                         <layout class="QGridLayout" name="gridLayout_22">
-                         <property name="leftMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="topMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="rightMargin">
-                          <number>0</number>
-                         </property>
-                         <property name="bottomMargin">
-                          <number>0</number>
-                         </property>
                          <property name="verticalSpacing">
                           <number>12</number>
+                         </property>
+                         <property name="margin">
+                          <number>0</number>
                          </property>
                          <item row="1" column="0">
                           <spacer name="horizontalSpacer_19">
@@ -5090,16 +4878,7 @@ font-style: italic;</string>
                          <item row="1" column="1">
                           <widget class="QFrame" name="mCoordAlignmentFrame">
                            <layout class="QHBoxLayout" name="horizontalLayout_27">
-                            <property name="leftMargin">
-                             <number>0</number>
-                            </property>
-                            <property name="topMargin">
-                             <number>0</number>
-                            </property>
-                            <property name="rightMargin">
-                             <number>0</number>
-                            </property>
-                            <property name="bottomMargin">
+                            <property name="margin">
                              <number>0</number>
                             </property>
                             <item>
@@ -5240,23 +5019,11 @@ font-style: italic;</string>
                 </widget>
                 <widget class="QWidget" name="mLabelPage_Rendering">
                  <layout class="QVBoxLayout" name="verticalLayout_13">
-                  <property name="leftMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="topMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="rightMargin">
-                   <number>0</number>
-                  </property>
-                  <property name="bottomMargin">
+                  <property name="margin">
                    <number>0</number>
                   </property>
                   <item>
-                   <widget class="QLabel" name="label_39">
-                    <property name="styleSheet">
-                     <string notr="true">text-decoration: underline;</string>
-                    </property>
+                   <widget class="QLabel" name="label_4">
                     <property name="text">
                      <string>Rendering</string>
                     </property>
@@ -5274,9 +5041,9 @@ font-style: italic;</string>
                      <property name="geometry">
                       <rect>
                        <x>0</x>
-                       <y>-398</y>
-                       <width>578</width>
-                       <height>799</height>
+                       <y>0</y>
+                       <width>448</width>
+                       <height>668</height>
                       </rect>
                      </property>
                      <layout class="QVBoxLayout" name="verticalLayout_8">
@@ -5642,16 +5409,7 @@ font-style: italic;</string>
                             <enum>QFrame::Raised</enum>
                            </property>
                            <layout class="QGridLayout" name="gridLayout_5">
-                            <property name="leftMargin">
-                             <number>0</number>
-                            </property>
-                            <property name="topMargin">
-                             <number>0</number>
-                            </property>
-                            <property name="rightMargin">
-                             <number>0</number>
-                            </property>
-                            <property name="bottomMargin">
+                            <property name="margin">
                              <number>0</number>
                             </property>
                             <property name="verticalSpacing">
@@ -5749,16 +5507,7 @@ font-style: italic;</string>
                          <item>
                           <widget class="QFrame" name="mUpsidedownFrame">
                            <layout class="QGridLayout" name="gridLayout">
-                            <property name="leftMargin">
-                             <number>0</number>
-                            </property>
-                            <property name="topMargin">
-                             <number>0</number>
-                            </property>
-                            <property name="rightMargin">
-                             <number>0</number>
-                            </property>
-                            <property name="bottomMargin">
+                            <property name="margin">
                              <number>0</number>
                             </property>
                             <property name="verticalSpacing">
@@ -5861,16 +5610,7 @@ font-style: italic;</string>
                          <item>
                           <widget class="QFrame" name="mLimitLabelFrame">
                            <layout class="QGridLayout" name="gridLayout_20">
-                            <property name="leftMargin">
-                             <number>0</number>
-                            </property>
-                            <property name="topMargin">
-                             <number>0</number>
-                            </property>
-                            <property name="rightMargin">
-                             <number>0</number>
-                            </property>
-                            <property name="bottomMargin">
+                            <property name="margin">
                              <number>0</number>
                             </property>
                             <property name="verticalSpacing">
@@ -5927,16 +5667,7 @@ font-style: italic;</string>
                          <item>
                           <widget class="QFrame" name="mMinSizeFrame">
                            <layout class="QGridLayout" name="gridLayout_21">
-                            <property name="leftMargin">
-                             <number>0</number>
-                            </property>
-                            <property name="topMargin">
-                             <number>0</number>
-                            </property>
-                            <property name="rightMargin">
-                             <number>0</number>
-                            </property>
-                            <property name="bottomMargin">
+                            <property name="margin">
                              <number>0</number>
                             </property>
                             <property name="verticalSpacing">
@@ -5984,16 +5715,7 @@ font-style: italic;</string>
                             <enum>QFrame::Raised</enum>
                            </property>
                            <layout class="QHBoxLayout" name="horizontalLayout_12">
-                            <property name="leftMargin">
-                             <number>0</number>
-                            </property>
-                            <property name="topMargin">
-                             <number>0</number>
-                            </property>
-                            <property name="rightMargin">
-                             <number>0</number>
-                            </property>
-                            <property name="bottomMargin">
+                            <property name="margin">
                              <number>0</number>
                             </property>
                             <item>
@@ -6065,16 +5787,7 @@ font-style: italic;</string>
                          <item>
                           <widget class="QFrame" name="mObstaclePriorityFrame">
                            <layout class="QHBoxLayout" name="horizontalLayout_18">
-                            <property name="leftMargin">
-                             <number>0</number>
-                            </property>
-                            <property name="topMargin">
-                             <number>0</number>
-                            </property>
-                            <property name="rightMargin">
-                             <number>0</number>
-                            </property>
-                            <property name="bottomMargin">
+                            <property name="margin">
                              <number>0</number>
                             </property>
                             <item>
@@ -6135,16 +5848,7 @@ font-style: italic;</string>
                             <enum>QFrame::Raised</enum>
                            </property>
                            <layout class="QHBoxLayout" name="horizontalLayout_11">
-                            <property name="leftMargin">
-                             <number>0</number>
-                            </property>
-                            <property name="topMargin">
-                             <number>0</number>
-                            </property>
-                            <property name="rightMargin">
-                             <number>0</number>
-                            </property>
-                            <property name="bottomMargin">
+                            <property name="margin">
                              <number>0</number>
                             </property>
                             <item>
@@ -6198,16 +5902,7 @@ font-style: italic;</string>
    <item row="5" column="0">
     <widget class="QFrame" name="frameLabelWith">
      <layout class="QHBoxLayout" name="horizontalLayout_3">
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
+      <property name="margin">
        <number>0</number>
       </property>
       <item>
@@ -6257,10 +5952,21 @@ font-style: italic;</string>
  <layoutdefault spacing="6" margin="11"/>
  <customwidgets>
   <customwidget>
+   <class>QgsCollapsibleGroupBox</class>
+   <extends>QGroupBox</extends>
+   <header>qgscollapsiblegroupbox.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
    <class>QgsColorButtonV2</class>
    <extends>QToolButton</extends>
    <header>qgscolorbuttonv2.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsDataDefinedButton</class>
+   <extends>QToolButton</extends>
+   <header>qgsdatadefinedbutton.h</header>
   </customwidget>
   <customwidget>
    <class>QgsDoubleSpinBox</class>
@@ -6268,21 +5974,15 @@ font-style: italic;</string>
    <header>qgsdoublespinbox.h</header>
   </customwidget>
   <customwidget>
-   <class>QgsSpinBox</class>
-   <extends>QSpinBox</extends>
-   <header>qgsspinbox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsCollapsibleGroupBox</class>
-   <extends>QGroupBox</extends>
-   <header>qgscollapsiblegroupbox.h</header>
-   <container>1</container>
-  </customwidget>
-  <customwidget>
    <class>QgsFieldExpressionWidget</class>
    <extends>QWidget</extends>
    <header>qgsfieldexpressionwidget.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsSpinBox</class>
+   <extends>QSpinBox</extends>
+   <header>qgsspinbox.h</header>
   </customwidget>
   <customwidget>
    <class>QgsUnitSelectionWidget</class>
@@ -6294,11 +5994,6 @@ font-style: italic;</string>
    <class>QgsBlendModeComboBox</class>
    <extends>QComboBox</extends>
    <header>qgsblendmodecombobox.h</header>
-  </customwidget>
-  <customwidget>
-   <class>QgsDataDefinedButton</class>
-   <extends>QToolButton</extends>
-   <header>qgsdatadefinedbutton.h</header>
   </customwidget>
   <customwidget>
    <class>QgsPenJoinStyleComboBox</class>
@@ -6562,6 +6257,22 @@ font-style: italic;</string>
     <hint type="destinationlabel">
      <x>633</x>
      <y>411</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>mOptionsTab</sender>
+   <signal>currentChanged(int)</signal>
+   <receiver>mLabelStackedWidget</receiver>
+   <slot>setCurrentIndex(int)</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>164</x>
+     <y>205</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>689</x>
+     <y>277</y>
     </hint>
    </hints>
   </connection>

--- a/src/ui/qgslabelingrulepropsdialog.ui
+++ b/src/ui/qgslabelingrulepropsdialog.ui
@@ -14,96 +14,124 @@
    <string>Rule properties</string>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
+   <property name="margin">
+    <number>0</number>
+   </property>
    <item>
-    <layout class="QFormLayout" name="formLayout">
-     <property name="fieldGrowthPolicy">
-      <enum>QFormLayout::ExpandingFieldsGrow</enum>
+    <widget class="QScrollArea" name="scrollArea">
+     <property name="frameShape">
+      <enum>QFrame::NoFrame</enum>
      </property>
-     <item row="0" column="0">
-      <widget class="QLabel" name="label_1">
-       <property name="text">
-        <string>Description</string>
+     <property name="widgetResizable">
+      <bool>true</bool>
+     </property>
+     <widget class="QWidget" name="scrollAreaWidgetContents">
+      <property name="geometry">
+       <rect>
+        <x>0</x>
+        <y>0</y>
+        <width>666</width>
+        <height>540</height>
+       </rect>
+      </property>
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <property name="margin">
+        <number>0</number>
        </property>
-      </widget>
-     </item>
-     <item row="0" column="1">
-      <widget class="QLineEdit" name="editDescription"/>
-     </item>
-     <item row="1" column="0">
-      <widget class="QLabel" name="label_5">
-       <property name="text">
-        <string>Filter</string>
-       </property>
-      </widget>
-     </item>
-     <item row="1" column="1">
-      <layout class="QHBoxLayout" name="horizontalLayout">
        <item>
-        <widget class="QLineEdit" name="editFilter"/>
+        <layout class="QFormLayout" name="formLayout">
+         <property name="fieldGrowthPolicy">
+          <enum>QFormLayout::ExpandingFieldsGrow</enum>
+         </property>
+         <item row="0" column="0">
+          <widget class="QLabel" name="label_1">
+           <property name="text">
+            <string>Description</string>
+           </property>
+          </widget>
+         </item>
+         <item row="0" column="1">
+          <widget class="QLineEdit" name="editDescription"/>
+         </item>
+         <item row="1" column="0">
+          <widget class="QLabel" name="label_5">
+           <property name="text">
+            <string>Filter</string>
+           </property>
+          </widget>
+         </item>
+         <item row="1" column="1">
+          <layout class="QHBoxLayout" name="horizontalLayout">
+           <item>
+            <widget class="QLineEdit" name="editFilter"/>
+           </item>
+           <item>
+            <widget class="QPushButton" name="btnExpressionBuilder">
+             <property name="sizePolicy">
+              <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+               <horstretch>0</horstretch>
+               <verstretch>0</verstretch>
+              </sizepolicy>
+             </property>
+             <property name="text">
+              <string>...</string>
+             </property>
+            </widget>
+           </item>
+           <item>
+            <widget class="QPushButton" name="btnTestFilter">
+             <property name="text">
+              <string>Test</string>
+             </property>
+            </widget>
+           </item>
+          </layout>
+         </item>
+        </layout>
        </item>
        <item>
-        <widget class="QPushButton" name="btnExpressionBuilder">
+        <widget class="QGroupBox" name="groupScale">
+         <property name="title">
+          <string>Scale range</string>
+         </property>
+         <property name="checkable">
+          <bool>true</bool>
+         </property>
+         <property name="checked">
+          <bool>false</bool>
+         </property>
+         <layout class="QHBoxLayout" name="horizontalLayout_2">
+          <item>
+           <widget class="QgsScaleRangeWidget" name="mScaleRangeWidget">
+            <property name="toolTip">
+             <string/>
+            </property>
+            <property name="whatsThis">
+             <string/>
+            </property>
+           </widget>
+          </item>
+         </layout>
+        </widget>
+       </item>
+       <item>
+        <widget class="QGroupBox" name="groupSettings">
          <property name="sizePolicy">
-          <sizepolicy hsizetype="Minimum" vsizetype="Fixed">
+          <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
            <horstretch>0</horstretch>
            <verstretch>0</verstretch>
           </sizepolicy>
          </property>
-         <property name="text">
-          <string>...</string>
+         <property name="title">
+          <string>Labels</string>
          </property>
-        </widget>
-       </item>
-       <item>
-        <widget class="QPushButton" name="btnTestFilter">
-         <property name="text">
-          <string>Test</string>
+         <property name="checkable">
+          <bool>true</bool>
          </property>
         </widget>
        </item>
       </layout>
-     </item>
-    </layout>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupScale">
-     <property name="title">
-      <string>Scale range</string>
-     </property>
-     <property name="checkable">
-      <bool>true</bool>
-     </property>
-     <property name="checked">
-      <bool>false</bool>
-     </property>
-     <layout class="QHBoxLayout" name="horizontalLayout_2">
-      <item>
-       <widget class="QgsScaleRangeWidget" name="mScaleRangeWidget" native="true">
-        <property name="toolTip">
-         <string/>
-        </property>
-        <property name="whatsThis">
-         <string/>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item>
-    <widget class="QGroupBox" name="groupSettings">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
-     </property>
-     <property name="title">
-      <string>Labels</string>
-     </property>
-     <property name="checkable">
-      <bool>true</bool>
-     </property>
+     </widget>
     </widget>
    </item>
    <item>
@@ -112,7 +140,7 @@
       <enum>Qt::Horizontal</enum>
      </property>
      <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Save</set>
      </property>
     </widget>
    </item>
@@ -130,8 +158,6 @@
   <tabstop>editFilter</tabstop>
   <tabstop>btnExpressionBuilder</tabstop>
   <tabstop>btnTestFilter</tabstop>
-  <tabstop>groupScale</tabstop>
-  <tabstop>groupSettings</tabstop>
   <tabstop>buttonBox</tabstop>
  </tabstops>
  <resources/>

--- a/src/ui/qgslabelingwidget.ui
+++ b/src/ui/qgslabelingwidget.ui
@@ -97,6 +97,16 @@
    <item>
     <widget class="QStackedWidget" name="mStackedWidget"/>
    </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <property name="spacing">
+      <number>12</number>
+     </property>
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+    </layout>
+   </item>
   </layout>
  </widget>
  <resources>

--- a/src/ui/qgsrulebasedlabelingwidget.ui
+++ b/src/ui/qgsrulebasedlabelingwidget.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>400</width>
-    <height>300</height>
+    <width>457</width>
+    <height>372</height>
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
@@ -15,91 +15,105 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QTreeView" name="viewRules">
-     <property name="contextMenuPolicy">
-      <enum>Qt::ActionsContextMenu</enum>
+    <widget class="QStackedWidget" name="mStackedWidget">
+     <property name="currentIndex">
+      <number>0</number>
      </property>
-     <property name="acceptDrops">
-      <bool>true</bool>
-     </property>
-     <property name="editTriggers">
-      <set>QAbstractItemView::EditKeyPressed|QAbstractItemView::SelectedClicked</set>
-     </property>
-     <property name="dragEnabled">
-      <bool>true</bool>
-     </property>
-     <property name="dragDropMode">
-      <enum>QAbstractItemView::InternalMove</enum>
-     </property>
-     <property name="selectionMode">
-      <enum>QAbstractItemView::ExtendedSelection</enum>
-     </property>
-     <property name="allColumnsShowFocus">
-      <bool>true</bool>
-     </property>
-     <attribute name="headerMinimumSectionSize">
-      <number>100</number>
-     </attribute>
+     <widget class="QWidget" name="rulesPage">
+      <layout class="QVBoxLayout" name="verticalLayout_2">
+       <property name="margin">
+        <number>0</number>
+       </property>
+       <item>
+        <widget class="QTreeView" name="viewRules">
+         <property name="contextMenuPolicy">
+          <enum>Qt::ActionsContextMenu</enum>
+         </property>
+         <property name="acceptDrops">
+          <bool>true</bool>
+         </property>
+         <property name="editTriggers">
+          <set>QAbstractItemView::EditKeyPressed|QAbstractItemView::SelectedClicked</set>
+         </property>
+         <property name="dragEnabled">
+          <bool>true</bool>
+         </property>
+         <property name="dragDropMode">
+          <enum>QAbstractItemView::InternalMove</enum>
+         </property>
+         <property name="selectionMode">
+          <enum>QAbstractItemView::ExtendedSelection</enum>
+         </property>
+         <property name="allColumnsShowFocus">
+          <bool>true</bool>
+         </property>
+         <attribute name="headerMinimumSectionSize">
+          <number>100</number>
+         </attribute>
+        </widget>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="horizontalLayout">
+         <item>
+          <widget class="QPushButton" name="btnAddRule">
+           <property name="toolTip">
+            <string>Add rule</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="icon">
+            <iconset resource="../../images/images.qrc">
+             <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="btnEditRule">
+           <property name="toolTip">
+            <string>Edit rule</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="icon">
+            <iconset resource="../../images/images.qrc">
+             <normaloff>:/images/themes/default/symbologyEdit.png</normaloff>:/images/themes/default/symbologyEdit.png</iconset>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="btnRemoveRule">
+           <property name="toolTip">
+            <string>Remove rule</string>
+           </property>
+           <property name="text">
+            <string/>
+           </property>
+           <property name="icon">
+            <iconset resource="../../images/images.qrc">
+             <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <spacer name="horizontalSpacer">
+           <property name="orientation">
+            <enum>Qt::Horizontal</enum>
+           </property>
+           <property name="sizeHint" stdset="0">
+            <size>
+             <width>40</width>
+             <height>20</height>
+            </size>
+           </property>
+          </spacer>
+         </item>
+        </layout>
+       </item>
+      </layout>
+     </widget>
     </widget>
-   </item>
-   <item>
-    <layout class="QHBoxLayout" name="horizontalLayout">
-     <item>
-      <widget class="QPushButton" name="btnAddRule">
-       <property name="toolTip">
-        <string>Add rule</string>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="icon">
-        <iconset resource="../../images/images.qrc">
-         <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="btnEditRule">
-       <property name="toolTip">
-        <string>Edit rule</string>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="icon">
-        <iconset resource="../../images/images.qrc">
-         <normaloff>:/images/themes/default/symbologyEdit.png</normaloff>:/images/themes/default/symbologyEdit.png</iconset>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <widget class="QPushButton" name="btnRemoveRule">
-       <property name="toolTip">
-        <string>Remove rule</string>
-       </property>
-       <property name="text">
-        <string/>
-       </property>
-       <property name="icon">
-        <iconset resource="../../images/images.qrc">
-         <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-    </layout>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
This is a early preview PR (although it will go to full implementation at some stage soon hopefully) for improving the UX around map styling in QGIS.  Rational for this PR: dialogs suck and I hate having to open and close them.

This PR includes:
- Central Map Styling dock
- Non blocking label options
- **Live** updating of labels in canvas on value changes
- A single entry point for all styling in QGIS - stubbed tabs for Style and Diagrams - and raster styles
- Inlined rule based rendering options

Example image for simple labels:

![image](https://cloud.githubusercontent.com/assets/381660/14232077/3a6ac8fe-f9df-11e5-9083-4a45c08a10de.png)

Using rule based labels:

![image](https://cloud.githubusercontent.com/assets/381660/14232091/d282fc6a-f9df-11e5-9b60-86fc53caa3bc.png)

![image](https://cloud.githubusercontent.com/assets/381660/14232095/e510a18e-f9df-11e5-902d-fab10b7447f2.png)

And a video preview:

https://www.youtube.com/watch?v=dcfIjz360bA&feature=youtu.be

Still a lot to do on this at the moment but currently works well and the instant feedback is fantastic for making maps.

The overall plan is to move the styling options to the style tab, diagrams to the diagrams tab, etc.
