### PR TITLE
[symbology] add semicircle and quarter circle to simple markers

### DIFF
--- a/python/core/symbology-ng/qgsmarkersymbollayerv2.sip
+++ b/python/core/symbology-ng/qgsmarkersymbollayerv2.sip
@@ -9,6 +9,7 @@ class QgsSimpleMarkerSymbolLayerV2 : QgsMarkerSymbolLayerV2
     * @param name symbol name, should be one of "square", "rectangle", "diamond",
     * "pentagon", "triangle", "equilateral_triangle", "star", "regular_star", "arrow",
     *  "circle", "cross", "cross2", "line", "x", "arrowhead", "filled_arrowhead"
+    *  "semi_circle", "third_circle", "quarter_circle"
     * @param color fill color for symbol
     * @param borderColor border color for symbol
     * @param size symbol size (in mm)

--- a/src/core/symbology-ng/qgsmarkersymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgsmarkersymbollayerv2.cpp
@@ -432,6 +432,24 @@ bool QgsSimpleMarkerSymbolLayerV2::preparePath( QString name )
     mPath.addEllipse( QRectF( -1, -1, 2, 2 ) ); // x,y,w,h
     return true;
   }
+  else if ( name == "semi_circle" )
+  {
+    mPath.arcTo( -1, -1, 2, 2, 0, 180 );
+    mPath.lineTo( 0, 0 );
+    return true;
+  }
+  else if ( name == "third_circle" )
+  {
+    mPath.arcTo( -1, -1, 2, 2, 90, 120 );
+    mPath.lineTo( 0, 0 );
+    return true;
+  }
+  else if ( name == "quarter_circle" )
+  {
+    mPath.arcTo( -1, -1, 2, 2, 90, 90 );
+    mPath.lineTo( 0, 0 );
+    return true;
+  }
   else if ( name == "cross" )
   {
     mPath.moveTo( -1, 0 );

--- a/src/core/symbology-ng/qgsmarkersymbollayerv2.h
+++ b/src/core/symbology-ng/qgsmarkersymbollayerv2.h
@@ -38,7 +38,8 @@ class CORE_EXPORT QgsSimpleMarkerSymbolLayerV2 : public QgsMarkerSymbolLayerV2
     /** Constructor for QgsSimpleMarkerSymbolLayerV2.
     * @param name symbol name, should be one of "square", "rectangle", "diamond",
     * "pentagon", "triangle", "equilateral_triangle", "star", "regular_star", "arrow",
-    *  "circle", "cross", "cross2", "line", "x", "arrowhead", "filled_arrowhead"
+    *  "circle", "cross", "cross2", "line", "x", "arrowhead", "filled_arrowhead",
+    *  "semi_circle", "third_circle", "quarter_circle"
     * @param color fill color for symbol
     * @param borderColor border color for symbol
     * @param size symbol size (in mm)

--- a/src/gui/symbology-ng/qgssymbollayerv2widget.cpp
+++ b/src/gui/symbology-ng/qgssymbollayerv2widget.cpp
@@ -440,8 +440,8 @@ QgsSimpleMarkerSymbolLayerV2Widget::QgsSimpleMarkerSymbolLayerV2Widget( const Qg
 
   QSize size = lstNames->iconSize();
   QStringList names;
-  names << "circle" << "rectangle" << "diamond" << "pentagon" << "cross" << "cross2" << "triangle"
-  << "equilateral_triangle" << "star" << "regular_star" << "arrow" << "line" << "arrowhead" << "filled_arrowhead";
+  names << "circle" << "rectangle" << "diamond" << "pentagon" << "cross" << "cross2" << "triangle" << "equilateral_triangle" << "star"
+  << "regular_star" << "arrow" << "line" << "arrowhead" << "filled_arrowhead" << "semi_circle" << "third_circle" << "quarter_circle";
   double markerSize = DEFAULT_POINT_SIZE * 2;
   for ( int i = 0; i < names.count(); ++i )
   {
@@ -541,7 +541,7 @@ void QgsSimpleMarkerSymbolLayerV2Widget::setSymbolLayer( QgsSymbolLayerV2* layer
                              "<b>pentagon</b>|<b>triangle</b>|<b>equilateral_triangle</b>|"
                              "<b>star</b>|<b>regular_star</b>|<b>arrow</b>|<b>filled_arrowhead</b>|"
                              "<b>circle</b>|<b>cross</b>|<b>x</b>|"
-                             "<b>cross2</b>|<b>line</b>|<b>arrowhead</b>]" ) );
+                             "<b>cross2</b>|<b>line</b>|<b>arrowhead</b>|<b>semi_circle</b>|<b>third_circle</b>|<b>quarter_circle</b>]" ) );
   registerDataDefinedButton( mFillColorDDBtn, "color", QgsDataDefinedButton::String, QgsDataDefinedButton::colorAlphaDesc() );
   registerDataDefinedButton( mBorderColorDDBtn, "color_border", QgsDataDefinedButton::String, QgsDataDefinedButton::colorAlphaDesc() );
   registerDataDefinedButton( mOutlineWidthDDBtn, "outline_width", QgsDataDefinedButton::Double, QgsDataDefinedButton::doublePosDesc() );


### PR DESCRIPTION
In a recent project, I had to use semicircle and quarter circles as part of point symbols. While this can be done through SVG marker, I find it's rather useful to have at-hand semicircle and quarter circle markers through simple markers.

![newmarkers](https://cloud.githubusercontent.com/assets/1728657/14243299/e3ebfb9c-fa7e-11e5-9c4f-cf33ba30eeb1.png)
