### PR TITLE
[Bugfix] #14611 Polyline rendering when line layer draws effects

### DIFF
--- a/src/core/composer/qgscomposerpolyline.cpp
+++ b/src/core/composer/qgscomposerpolyline.cpp
@@ -121,6 +121,9 @@ void QgsComposerPolyline::_draw( QPainter *painter )
   mPolylineStyleSymbol->renderPolyline( t.map( mPolygon ), nullptr, context );
   mPolylineStyleSymbol->stopRender( context );
   painter->scale( dotsPerMM, dotsPerMM );
+
+  // transparent background
+  setBackgroundColor( QColor( 0, 0, 0, 0 ) );
 }
 
 void QgsComposerPolyline::_readXMLStyle( const QDomElement &elmt )


### PR DESCRIPTION
@nirvn, @nyalldawson  A transparent background is set by default for polyline items.
