### PR TITLE
[diagram] add unit type setting for outlines (fixes #14614)

### DIFF
--- a/python/core/qgsdiagramrendererv2.sip
+++ b/python/core/qgsdiagramrendererv2.sip
@@ -289,14 +289,13 @@ class QgsDiagramSettings
     //! @note added in 2.10
     QList< QString > categoryLabels;
     QSizeF size; //size
-    SizeType sizeType; //mm or map units
-    /** Line unit index (mm, map units, or pixels)
-     * @note added in 2.16
-     */
+    //! Diagram size unit index (mm, map units, or pixels)
+    QgsSymbolV2::OutputUnit sizeType;
+    //! Diagram size unit scale
+    QgsMapUnitScale sizeScale;
+    //! Line unit index (mm, map units, or pixels)
     QgsSymbolV2::OutputUnit lineSizeType;
-    /** Line unit scale
-     * @note added in 2.16
-     */
+    //! Line unit scale
     QgsMapUnitScale lineSizeScale;
     QColor backgroundColor;
     QColor penColor;

--- a/python/core/qgsdiagramrendererv2.sip
+++ b/python/core/qgsdiagramrendererv2.sip
@@ -290,6 +290,14 @@ class QgsDiagramSettings
     QList< QString > categoryLabels;
     QSizeF size; //size
     SizeType sizeType; //mm or map units
+    /** Line unit index (mm, map units, or pixels)
+     * @note added in 2.16
+     */
+    QgsSymbolV2::OutputUnit lineSizeType;
+    /** Line unit scale
+     * @note added in 2.16
+     */
+    QgsMapUnitScale lineSizeScale;
     QColor backgroundColor;
     QColor penColor;
     double penWidth;

--- a/src/app/qgsdiagramproperties.cpp
+++ b/src/app/qgsdiagramproperties.cpp
@@ -86,6 +86,7 @@ QgsDiagramProperties::QgsDiagramProperties( QgsVectorLayer* layer, QWidget* pare
 
   mDiagramUnitComboBox->insertItem( 0, tr( "mm" ), QgsDiagramSettings::MM );
   mDiagramUnitComboBox->insertItem( 1, tr( "Map units" ), QgsDiagramSettings::MapUnits );
+  mDiagramLineUnitComboBox->setUnits( QgsSymbolV2::OutputUnitList() << QgsSymbolV2::MM << QgsSymbolV2::MapUnit << QgsSymbolV2::Pixel );
 
   QGis::GeometryType layerType = layer->geometryType();
   if ( layerType == QGis::UnknownGeometry || layerType == QGis::NoGeometry )
@@ -193,6 +194,7 @@ QgsDiagramProperties::QgsDiagramProperties( QgsVectorLayer* layer, QWidget* pare
     mDiagramFrame->setEnabled( false );
     mFixedSizeRadio->setChecked( true );
     mDiagramUnitComboBox->setCurrentIndex( mDiagramUnitComboBox->findText( tr( "mm" ) ) );
+    mDiagramLineUnitComboBox->setUnit( QgsSymbolV2::MM );
     mLabelPlacementComboBox->setCurrentIndex( mLabelPlacementComboBox->findText( tr( "x-height" ) ) );
     mDiagramSizeSpinBox->setEnabled( true );
     mDiagramSizeSpinBox->setValue( 15 );
@@ -271,6 +273,8 @@ QgsDiagramProperties::QgsDiagramProperties( QgsVectorLayer* layer, QWidget* pare
       {
         mDiagramUnitComboBox->setCurrentIndex( 1 );
       }
+      mDiagramLineUnitComboBox->setUnit( settingList.at( 0 ).lineSizeType );
+      mDiagramLineUnitComboBox->setMapUnitScale( settingList.at( 0 ).lineSizeScale );
 
       if ( settingList.at( 0 ).labelPlacementMethod == QgsDiagramSettings::Height )
       {
@@ -701,6 +705,8 @@ void QgsDiagramProperties::apply()
   ds.categoryLabels = categoryLabels;
   ds.size = QSizeF( mDiagramSizeSpinBox->value(), mDiagramSizeSpinBox->value() );
   ds.sizeType = static_cast<QgsDiagramSettings::SizeType>( mDiagramUnitComboBox->itemData( mDiagramUnitComboBox->currentIndex() ).toInt() );
+  ds.lineSizeType = mDiagramLineUnitComboBox->unit();
+  ds.lineSizeScale = mDiagramLineUnitComboBox->getMapUnitScale();
   ds.labelPlacementMethod = static_cast<QgsDiagramSettings::LabelPlacementMethod>( mLabelPlacementComboBox->itemData( mLabelPlacementComboBox->currentIndex() ).toInt() );
   ds.scaleByArea = mScaleDependencyComboBox->itemData( mScaleDependencyComboBox->currentIndex() ).toBool();
 

--- a/src/app/qgsdiagramproperties.cpp
+++ b/src/app/qgsdiagramproperties.cpp
@@ -84,8 +84,7 @@ QgsDiagramProperties::QgsDiagramProperties( QgsVectorLayer* layer, QWidget* pare
 
   mMaxValueSpinBox->setShowClearButton( false );
 
-  mDiagramUnitComboBox->insertItem( 0, tr( "mm" ), QgsDiagramSettings::MM );
-  mDiagramUnitComboBox->insertItem( 1, tr( "Map units" ), QgsDiagramSettings::MapUnits );
+  mDiagramUnitComboBox->setUnits( QgsSymbolV2::OutputUnitList() << QgsSymbolV2::MM << QgsSymbolV2::MapUnit << QgsSymbolV2::Pixel );
   mDiagramLineUnitComboBox->setUnits( QgsSymbolV2::OutputUnitList() << QgsSymbolV2::MM << QgsSymbolV2::MapUnit << QgsSymbolV2::Pixel );
 
   QGis::GeometryType layerType = layer->geometryType();
@@ -193,7 +192,7 @@ QgsDiagramProperties::QgsDiagramProperties( QgsVectorLayer* layer, QWidget* pare
     mDiagramTypeFrame->setEnabled( false );
     mDiagramFrame->setEnabled( false );
     mFixedSizeRadio->setChecked( true );
-    mDiagramUnitComboBox->setCurrentIndex( mDiagramUnitComboBox->findText( tr( "mm" ) ) );
+    mDiagramUnitComboBox->setUnit( QgsSymbolV2::MM );
     mDiagramLineUnitComboBox->setUnit( QgsSymbolV2::MM );
     mLabelPlacementComboBox->setCurrentIndex( mLabelPlacementComboBox->findText( tr( "x-height" ) ) );
     mDiagramSizeSpinBox->setEnabled( true );
@@ -265,14 +264,8 @@ QgsDiagramProperties::QgsDiagramProperties( QgsVectorLayer* layer, QWidget* pare
       mScaleRangeWidget->setScaleRange( 1.0 / ( settingList.at( 0 ).maxScaleDenominator > 0 ? settingList.at( 0 ).maxScaleDenominator : layer->maximumScale() ),
                                         1.0 / ( settingList.at( 0 ).minScaleDenominator > 0 ? settingList.at( 0 ).minScaleDenominator : layer->minimumScale() ) );
       mScaleVisibilityGroupBox->setChecked( settingList.at( 0 ).scaleBasedVisibility );
-      if ( settingList.at( 0 ).sizeType == QgsDiagramSettings::MM )
-      {
-        mDiagramUnitComboBox->setCurrentIndex( 0 );
-      }
-      else
-      {
-        mDiagramUnitComboBox->setCurrentIndex( 1 );
-      }
+      mDiagramUnitComboBox->setUnit( settingList.at( 0 ).sizeType );
+      mDiagramUnitComboBox->setMapUnitScale( settingList.at( 0 ).sizeScale );
       mDiagramLineUnitComboBox->setUnit( settingList.at( 0 ).lineSizeType );
       mDiagramLineUnitComboBox->setMapUnitScale( settingList.at( 0 ).lineSizeScale );
 
@@ -704,7 +697,8 @@ void QgsDiagramProperties::apply()
   ds.categoryAttributes = categoryAttributes;
   ds.categoryLabels = categoryLabels;
   ds.size = QSizeF( mDiagramSizeSpinBox->value(), mDiagramSizeSpinBox->value() );
-  ds.sizeType = static_cast<QgsDiagramSettings::SizeType>( mDiagramUnitComboBox->itemData( mDiagramUnitComboBox->currentIndex() ).toInt() );
+  ds.sizeType = mDiagramUnitComboBox->unit();
+  ds.sizeScale = mDiagramUnitComboBox->getMapUnitScale();
   ds.lineSizeType = mDiagramLineUnitComboBox->unit();
   ds.lineSizeScale = mDiagramLineUnitComboBox->getMapUnitScale();
   ds.labelPlacementMethod = static_cast<QgsDiagramSettings::LabelPlacementMethod>( mLabelPlacementComboBox->itemData( mLabelPlacementComboBox->currentIndex() ).toInt() );

--- a/src/core/diagram/qgsdiagram.cpp
+++ b/src/core/diagram/qgsdiagram.cpp
@@ -76,38 +76,24 @@ void QgsDiagram::setPenWidth( QPen& pen, const QgsDiagramSettings& s, const QgsR
 
 QSizeF QgsDiagram::sizePainterUnits( QSizeF size, const QgsDiagramSettings& s, const QgsRenderContext& c )
 {
-  if ( s.sizeType == QgsDiagramSettings::MM )
-  {
-    return QSizeF( size.width() * c.scaleFactor(), size.height() * c.scaleFactor() );
-  }
-  else
-  {
-    return QSizeF( size.width() / c.mapToPixel().mapUnitsPerPixel(), size.height() / c.mapToPixel().mapUnitsPerPixel() );
-  }
+  return QSizeF( QgsSymbolLayerV2Utils::convertToPainterUnits( c, size.width(), s.sizeType, s.sizeScale ), QgsSymbolLayerV2Utils::convertToPainterUnits( c, size.height(), s.sizeType, s.sizeScale ) );
 }
 
 float QgsDiagram::sizePainterUnits( float l, const QgsDiagramSettings& s, const QgsRenderContext& c )
 {
-  if ( s.sizeType == QgsDiagramSettings::MM )
-  {
-    return l * c.scaleFactor();
-  }
-  else
-  {
-    return l / c.mapToPixel().mapUnitsPerPixel();
-  }
+  return QgsSymbolLayerV2Utils::convertToPainterUnits( c, l, s.sizeType, s.sizeScale );
 }
 
 QFont QgsDiagram::scaledFont( const QgsDiagramSettings& s, const QgsRenderContext& c )
 {
   QFont f = s.font;
-  if ( s.sizeType == QgsDiagramSettings::MM )
+  if ( s.sizeType == QgsSymbolV2::MapUnit )
   {
-    f.setPixelSize( s.font.pointSizeF() * 0.376 * c.scaleFactor() );
+    f.setPixelSize( s.font.pointSizeF() / c.mapToPixel().mapUnitsPerPixel() );
   }
   else
   {
-    f.setPixelSize( s.font.pointSizeF() / c.mapToPixel().mapUnitsPerPixel() );
+    f.setPixelSize( s.font.pointSizeF() * 0.376 * c.scaleFactor() );
   }
 
   return f;

--- a/src/core/diagram/qgsdiagram.cpp
+++ b/src/core/diagram/qgsdiagram.cpp
@@ -70,14 +70,7 @@ QgsExpression *QgsDiagram::getExpression( const QString &expression, const QgsEx
 
 void QgsDiagram::setPenWidth( QPen& pen, const QgsDiagramSettings& s, const QgsRenderContext& c )
 {
-  if ( s.sizeType == QgsDiagramSettings::MM )
-  {
-    pen.setWidthF( s.penWidth * c.scaleFactor() );
-  }
-  else
-  {
-    pen.setWidthF( s.penWidth / c.mapToPixel().mapUnitsPerPixel() );
-  }
+  pen.setWidthF( QgsSymbolLayerV2Utils::convertToPainterUnits( c, s.penWidth, s.lineSizeType, s.lineSizeScale ) );
 }
 
 

--- a/src/core/qgsdiagramrendererv2.cpp
+++ b/src/core/qgsdiagramrendererv2.cpp
@@ -181,7 +181,7 @@ void QgsDiagramSettings::readXML( const QDomElement& elem, const QgsVectorLayer*
     scaleBasedVisibility = minScaleDenominator >= 0 && maxScaleDenominator >= 0;
   }
 
-  //mm vs map units
+  //mm vs map units for diagram
   if ( elem.attribute( "sizeType" ) == "MM" )
   {
     sizeType = MM;
@@ -190,6 +190,10 @@ void QgsDiagramSettings::readXML( const QDomElement& elem, const QgsVectorLayer*
   {
     sizeType = MapUnits;
   }
+
+  //mm vs map units for line
+  lineSizeType = QgsSymbolLayerV2Utils::decodeOutputUnit( elem.attribute( "lineSizeType" ) );
+  lineSizeScale = QgsSymbolLayerV2Utils::decodeMapUnitScale( elem.attribute( "lineSizeScale" ) );
 
   //label placement method
   if ( elem.attribute( "labelPlacementMethod" ) == "Height" )
@@ -299,7 +303,7 @@ void QgsDiagramSettings::writeXML( QDomElement& rendererElem, QDomDocument& doc,
   categoryElem.setAttribute( "maxScaleDenominator", QString::number( maxScaleDenominator ) );
   categoryElem.setAttribute( "transparency", QString::number( transparency ) );
 
-  // site type (mm vs. map units)
+  // site type (mm vs. map units) for diagram
   if ( sizeType == MM )
   {
     categoryElem.setAttribute( "sizeType", "MM" );
@@ -308,6 +312,10 @@ void QgsDiagramSettings::writeXML( QDomElement& rendererElem, QDomDocument& doc,
   {
     categoryElem.setAttribute( "sizeType", "MapUnits" );
   }
+
+  // site type (mm vs. map units) for line
+  categoryElem.setAttribute( "lineSizeType", QgsSymbolLayerV2Utils::encodeOutputUnit( lineSizeType ) );
+  categoryElem.setAttribute( "lineSizeScale", QgsSymbolLayerV2Utils::encodeMapUnitScale( lineSizeScale ) );
 
   // label placement method (text diagram)
   if ( labelPlacementMethod == Height )

--- a/src/core/qgsdiagramrendererv2.cpp
+++ b/src/core/qgsdiagramrendererv2.cpp
@@ -181,17 +181,19 @@ void QgsDiagramSettings::readXML( const QDomElement& elem, const QgsVectorLayer*
     scaleBasedVisibility = minScaleDenominator >= 0 && maxScaleDenominator >= 0;
   }
 
-  //mm vs map units for diagram
-  if ( elem.attribute( "sizeType" ) == "MM" )
+  //diagram size unit type and scale
+  if ( elem.attribute( "sizeType" ) == "MapUnits" )
   {
-    sizeType = MM;
+    //compatibility with pre-2.16 project files
+    sizeType = QgsSymbolV2::MapUnit;
   }
   else
   {
-    sizeType = MapUnits;
+    sizeType = QgsSymbolLayerV2Utils::decodeOutputUnit( elem.attribute( "sizeType" ) );
   }
+  sizeScale = QgsSymbolLayerV2Utils::decodeMapUnitScale( elem.attribute( "sizeScale" ) );
 
-  //mm vs map units for line
+  //line width unit type and scale
   lineSizeType = QgsSymbolLayerV2Utils::decodeOutputUnit( elem.attribute( "lineSizeType" ) );
   lineSizeScale = QgsSymbolLayerV2Utils::decodeMapUnitScale( elem.attribute( "lineSizeScale" ) );
 
@@ -303,17 +305,11 @@ void QgsDiagramSettings::writeXML( QDomElement& rendererElem, QDomDocument& doc,
   categoryElem.setAttribute( "maxScaleDenominator", QString::number( maxScaleDenominator ) );
   categoryElem.setAttribute( "transparency", QString::number( transparency ) );
 
-  // site type (mm vs. map units) for diagram
-  if ( sizeType == MM )
-  {
-    categoryElem.setAttribute( "sizeType", "MM" );
-  }
-  else
-  {
-    categoryElem.setAttribute( "sizeType", "MapUnits" );
-  }
+  //diagram size unit type and scale
+  categoryElem.setAttribute( "sizeType", QgsSymbolLayerV2Utils::encodeOutputUnit( sizeType ) );
+  categoryElem.setAttribute( "sizeScale", QgsSymbolLayerV2Utils::encodeMapUnitScale( sizeScale ) );
 
-  // site type (mm vs. map units) for line
+  //line width unit type and scale
   categoryElem.setAttribute( "lineSizeType", QgsSymbolLayerV2Utils::encodeOutputUnit( lineSizeType ) );
   categoryElem.setAttribute( "lineSizeScale", QgsSymbolLayerV2Utils::encodeMapUnitScale( lineSizeScale ) );
 
@@ -425,9 +421,20 @@ QSizeF QgsDiagramRendererV2::sizeMapUnits( const QgsFeature& feature, const QgsR
   }
 
   QSizeF size = diagramSize( feature, c );
-  if ( s.sizeType == QgsDiagramSettings::MM )
+  if ( size.isValid() )
   {
-    convertSizeToMapUnits( size, c );
+    if ( s.sizeType == QgsSymbolV2::MM )
+    {
+      double pixelToMap = c.scaleFactor() * c.mapToPixel().mapUnitsPerPixel();
+      size.rwidth() *= pixelToMap;
+      size.rheight() *= pixelToMap;
+    }
+    else if ( s.sizeType == QgsSymbolV2::Pixel )
+    {
+      double pixelToMap = c.mapToPixel().mapUnitsPerPixel();
+      size.rwidth() *= pixelToMap;
+      size.rheight() *= pixelToMap;
+    }
   }
   return size;
 }

--- a/src/core/qgsdiagramrendererv2.h
+++ b/src/core/qgsdiagramrendererv2.h
@@ -321,7 +321,7 @@ class CORE_EXPORT QgsDiagramSettings
 
     QgsDiagramSettings()
         : enabled( true )
-        , sizeType( MM )
+        , sizeType( QgsSymbolV2::MM )
         , lineSizeType( QgsSymbolV2::MM )
         , penWidth( 0.0 )
         , labelPlacementMethod( QgsDiagramSettings::Height )
@@ -342,7 +342,14 @@ class CORE_EXPORT QgsDiagramSettings
     //! @note added in 2.10
     QList< QString > categoryLabels;
     QSizeF size; //size
-    SizeType sizeType; //mm or map units
+    /** Diagram size unit index (mm, map units, or pixels)
+     * @note added in 2.16
+     */
+    QgsSymbolV2::OutputUnit sizeType;
+    /** Diagram size unit scale
+     * @note added in 2.16
+     */
+    QgsMapUnitScale sizeScale;
     /** Line unit index (mm, map units, or pixels)
      * @note added in 2.16
      */

--- a/src/core/qgsdiagramrendererv2.h
+++ b/src/core/qgsdiagramrendererv2.h
@@ -24,6 +24,7 @@
 
 #include "qgsfeature.h"
 #include "qgsexpressioncontext.h"
+#include "qgssymbollayerv2.h"
 
 class QgsDiagram;
 class QgsDiagramRendererV2;
@@ -321,6 +322,7 @@ class CORE_EXPORT QgsDiagramSettings
     QgsDiagramSettings()
         : enabled( true )
         , sizeType( MM )
+        , lineSizeType( QgsSymbolV2::MM )
         , penWidth( 0.0 )
         , labelPlacementMethod( QgsDiagramSettings::Height )
         , diagramOrientation( QgsDiagramSettings::Up )
@@ -341,6 +343,14 @@ class CORE_EXPORT QgsDiagramSettings
     QList< QString > categoryLabels;
     QSizeF size; //size
     SizeType sizeType; //mm or map units
+    /** Line unit index (mm, map units, or pixels)
+     * @note added in 2.16
+     */
+    QgsSymbolV2::OutputUnit lineSizeType;
+    /** Line unit scale
+     * @note added in 2.16
+     */
+    QgsMapUnitScale lineSizeScale;
     QColor backgroundColor;
     QColor penColor;
     double penWidth;

--- a/src/ui/qgsdiagrampropertiesbase.ui
+++ b/src/ui/qgsdiagrampropertiesbase.ui
@@ -763,13 +763,33 @@
                         </widget>
                        </item>
                        <item row="5" column="0">
+                        <widget class="QLabel" name="mPenWidthLabel">
+                         <property name="text">
+                          <string>Line Unit</string>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="5" column="1">
+                        <widget class="QgsUnitSelectionWidget" name="mDiagramLineUnitComboBox" native="true">
+                         <property name="minimumSize">
+                          <size>
+                           <width>0</width>
+                           <height>0</height>
+                          </size>
+                         </property>
+                         <property name="focusPolicy">
+                          <enum>Qt::StrongFocus</enum>
+                         </property>
+                        </widget>
+                       </item>
+                       <item row="6" column="0">
                         <widget class="QLabel" name="mAngleOffsetLabel">
                          <property name="text">
                           <string>Start angle</string>
                          </property>
                         </widget>
                        </item>
-                       <item row="5" column="1">
+                       <item row="6" column="1">
                         <widget class="QComboBox" name="mAngleOffsetComboBox"/>
                        </item>
                        <item row="3" column="1">
@@ -1839,6 +1859,12 @@
    <extends>QWidget</extends>
    <header>qgsscalerangewidget.h</header>
   </customwidget>
+  <customwidget>
+   <class>QgsUnitSelectionWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsunitselectionwidget.h</header>
+   <container>1</container>
+  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>mEnableDiagramsCheckBox</tabstop>
@@ -1858,6 +1884,7 @@
   <tabstop>mBackgroundColorButton</tabstop>
   <tabstop>mDiagramPenColorButton</tabstop>
   <tabstop>mPenWidthSpinBox</tabstop>
+  <tabstop>mDiagramLineUnitComboBox</tabstop>
   <tabstop>mAngleOffsetComboBox</tabstop>
   <tabstop>mDiagramFontButton</tabstop>
   <tabstop>mShowAllCheckBox</tabstop>

--- a/src/ui/qgsdiagrampropertiesbase.ui
+++ b/src/ui/qgsdiagrampropertiesbase.ui
@@ -702,7 +702,10 @@
                        <item row="1" column="1">
                         <widget class="QgsDoubleSpinBox" name="mBarWidthSpinBox">
                          <property name="minimum">
-                          <double>0.010000000000000</double>
+                          <double>0.00000000000000</double>
+                         </property>
+                         <property name="maximum">
+                          <double>99999999.99000000000</double>
                          </property>
                          <property name="value">
                           <double>5.000000000000000</double>
@@ -1006,7 +1009,17 @@
                    </widget>
                   </item>
                   <item row="0" column="1">
-                   <widget class="QComboBox" name="mDiagramUnitComboBox"/>
+                   <widget class="QgsUnitSelectionWidget" name="mDiagramUnitComboBox" native="true">
+                    <property name="minimumSize">
+                     <size>
+                      <width>0</width>
+                      <height>0</height>
+                     </size>
+                    </property>
+                    <property name="focusPolicy">
+                     <enum>Qt::StrongFocus</enum>
+                    </property>
+                   </widget>
                   </item>
                   <item row="4" column="0">
                    <spacer name="verticalSpacer_3">

--- a/tests/src/core/testqgsdiagram.cpp
+++ b/tests/src/core/testqgsdiagram.cpp
@@ -144,7 +144,7 @@ class TestQgsDiagram : public QObject
       ds.penColor = Qt::green;
       ds.penWidth = .5;
       ds.scaleByArea = true;
-      ds.sizeType = QgsDiagramSettings::MM;
+      ds.sizeType = QgsSymbolV2::MM;
       ds.size = QSizeF( 5, 5 );
       ds.angleOffset = 0;
 
@@ -181,7 +181,7 @@ class TestQgsDiagram : public QObject
       ds.penColor = Qt::green;
       ds.penWidth = .5;
       ds.scaleByArea = true;
-      ds.sizeType = QgsDiagramSettings::MM;
+      ds.sizeType = QgsSymbolV2::MM;
       ds.size = QSizeF( 5, 5 );
       ds.angleOffset = 0;
 


### PR DESCRIPTION
This PR adds a line unit type setting to allow for mm outlines when diagrams' size unit is set to map units.

Before, line size was in map unit:
![error](https://cloud.githubusercontent.com/assets/1728657/14270649/621dda62-fb1a-11e5-9e8b-04408c984d83.png)

With this PR applied, things look much better:
![fixed](https://cloud.githubusercontent.com/assets/1728657/14270659/7a97272e-fb1a-11e5-8bc4-e2525f5842cb.png)
