### PR TITLE
[symbology] add half triangle markers

### DIFF
--- a/python/core/symbology-ng/qgsmarkersymbollayerv2.sip
+++ b/python/core/symbology-ng/qgsmarkersymbollayerv2.sip
@@ -11,7 +11,7 @@ class QgsSimpleMarkerSymbolLayerV2 : QgsMarkerSymbolLayerV2
     * "pentagon", "triangle", "equilateral_triangle", "star", "regular_star", "arrow",
     * "circle", "cross", "cross2", "line", "x", "arrowhead", "filled_arrowhead",
     * "semi_circle", "third_circle", "quarter_circle", "quarter_square", "half_square",
-    * "diagonal_half_square"
+    * "diagonal_half_square", "right_half_triangle", "left_half_triangle"
     * @param color fill color for symbol
     * @param borderColor border color for symbol
     * @param size symbol size (in mm)

--- a/src/core/symbology-ng/qgsellipsesymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgsellipsesymbollayerv2.cpp
@@ -565,6 +565,11 @@ void QgsEllipseSymbolLayerV2::preparePath( const QString& symbolName, QgsSymbolV
   {
     mPainterPath.addEllipse( QRectF( -size.width() / 2.0, -size.height() / 2.0, size.width(), size.height() ) );
   }
+  else if ( symbolName == "semi_circle" )
+  {
+    mPainterPath.arcTo( -size.width() / 2.0, -size.height() / 2.0, size.width(), size.height(), 0, 180 );
+    mPainterPath.lineTo( 0, 0 );
+  }
   else if ( symbolName == "rectangle" )
   {
     mPainterPath.addRect( QRectF( -size.width() / 2.0, -size.height() / 2.0, size.width(), size.height() ) );
@@ -582,6 +587,20 @@ void QgsEllipseSymbolLayerV2::preparePath( const QString& symbolName, QgsSymbolV
     mPainterPath.lineTo( -size.width() / 2.0, size.height() / 2.0 );
     mPainterPath.lineTo( size.width() / 2.0, size.height() / 2.0 );
     mPainterPath.lineTo( 0, -size.height() / 2.0 );
+  }
+  else if ( symbolName == "left_half_triangle" )
+  {
+    mPainterPath.moveTo( 0, size.height() / 2.0 );
+    mPainterPath.lineTo( size.width() / 2.0, size.height() / 2.0 );
+    mPainterPath.lineTo( 0, -size.height() / 2.0 );
+    mPainterPath.lineTo( 0, size.height() / 2.0 );
+  }
+  else if ( symbolName == "right_half_triangle" )
+  {
+    mPainterPath.moveTo( -size.width() / 2.0, size.height() / 2.0 );
+    mPainterPath.lineTo( 0, size.height() / 2.0 );
+    mPainterPath.lineTo( 0, -size.height() / 2.0 );
+    mPainterPath.lineTo( -size.width() / 2.0, size.height() / 2.0 );
   }
 }
 

--- a/src/core/symbology-ng/qgsmarkersymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgsmarkersymbollayerv2.cpp
@@ -384,6 +384,16 @@ bool QgsSimpleMarkerSymbolLayerV2::prepareShape( const QString& name, QPolygonF 
     << QPointF( 0, -1 );
     return true;
   }
+  else if ( name == "left_half_triangle" )
+  {
+    polygon << QPointF( 0, 1 ) << QPointF( 1, 1 ) << QPointF( 0, -1 );
+    return true;
+  }
+  else if ( name == "right_half_triangle" )
+  {
+    polygon << QPointF( -1, 1 ) << QPointF( 0, 1 ) << QPointF( 0, -1 );
+    return true;
+  }
   else if ( name == "star" )
   {
     double sixth = 1.0 / 3;

--- a/src/core/symbology-ng/qgsmarkersymbollayerv2.h
+++ b/src/core/symbology-ng/qgsmarkersymbollayerv2.h
@@ -41,7 +41,7 @@ class CORE_EXPORT QgsSimpleMarkerSymbolLayerV2 : public QgsMarkerSymbolLayerV2
     * "pentagon", "triangle", "equilateral_triangle", "star", "regular_star", "arrow",
     * "circle", "cross", "cross2", "line", "x", "arrowhead", "filled_arrowhead",
     * "semi_circle", "third_circle", "quarter_circle", "quarter_square", "half_square",
-    * "diagonal_half_square"
+    * "diagonal_half_square", "right_half_triangle", "left_half_triangle"
     * @param color fill color for symbol
     * @param borderColor border color for symbol
     * @param size symbol size (in mm)

--- a/src/gui/qgsdatadefinedbutton.cpp
+++ b/src/gui/qgsdatadefinedbutton.cpp
@@ -904,7 +904,8 @@ QString QgsDataDefinedButton::fillStyleDesc()
 
 QString QgsDataDefinedButton::markerStyleDesc()
 {
-  return trString() + QLatin1String( "[<b>circle</b>|<b>rectangle</b>|<b>cross</b>|<b>triangle</b>]" );
+  return trString() + QLatin1String( "[<b>circle</b>|<b>rectangle</b>|<b>cross</b>|<b>triangle"
+                                     "</b>|<b>right_half_triangle</b>|<b>left_half_triangle</b>|<b>semi_circle</b>]" );
 }
 
 QString QgsDataDefinedButton::customDashDesc()

--- a/src/gui/symbology-ng/qgsellipsesymbollayerv2widget.cpp
+++ b/src/gui/symbology-ng/qgsellipsesymbollayerv2widget.cpp
@@ -46,7 +46,7 @@ QgsEllipseSymbolLayerV2Widget::QgsEllipseSymbolLayerV2Widget( const QgsVectorLay
   mRotationSpinBox->setClearValue( 0.0 );
 
   QStringList names;
-  names << "circle" << "rectangle" << "cross" << "triangle";
+  names << "circle" << "rectangle" << "cross" << "triangle" << "right_half_triangle" << "left_half_triangle" << "semi_circle";
   QSize iconSize = mShapeListWidget->iconSize();
 
   Q_FOREACH ( const QString& name, names )

--- a/src/gui/symbology-ng/qgssymbollayerv2widget.cpp
+++ b/src/gui/symbology-ng/qgssymbollayerv2widget.cpp
@@ -442,7 +442,7 @@ QgsSimpleMarkerSymbolLayerV2Widget::QgsSimpleMarkerSymbolLayerV2Widget( const Qg
   QStringList names;
   names << "circle" << "rectangle" << "diamond" << "pentagon" << "cross" << "cross2" << "triangle" << "equilateral_triangle" << "star"
   << "regular_star" << "arrow" << "line" << "arrowhead" << "filled_arrowhead" << "semi_circle" << "third_circle" << "quarter_circle"
-  << "quarter_square" << "half_square" << "diagonal_half_square";
+  << "quarter_square" << "half_square" << "diagonal_half_square" << "right_half_triangle" << "left_half_triangle";
   double markerSize = DEFAULT_POINT_SIZE * 2;
   Q_FOREACH ( const QString& name, names )
   {
@@ -544,7 +544,7 @@ void QgsSimpleMarkerSymbolLayerV2Widget::setSymbolLayer( QgsSymbolLayerV2* layer
                              "<b>star</b>|<b>regular_star</b>|<b>arrow</b>|<b>filled_arrowhead</b>|"
                              "<b>circle</b>|<b>cross</b>|<b>x</b>|"
                              "<b>cross2</b>|<b>line</b>|<b>arrowhead</b>|<b>semi_circle</b>|<b>third_circle</b>|<b>quarter_circle</b>|"
-                             "<b>quarter_square</b>|<b>half_square</b>|<b>diagonal_half_square</b>]" ) );
+                             "<b>quarter_square</b>|<b>half_square</b>|<b>diagonal_half_square</b>|<b>right_half_triangle</b>|<b>left_half_triangle</b>]" ) );
   registerDataDefinedButton( mFillColorDDBtn, "color", QgsDataDefinedButton::String, QgsDataDefinedButton::colorAlphaDesc() );
   registerDataDefinedButton( mBorderColorDDBtn, "color_border", QgsDataDefinedButton::String, QgsDataDefinedButton::colorAlphaDesc() );
   registerDataDefinedButton( mOutlineWidthDDBtn, "outline_width", QgsDataDefinedButton::Double, QgsDataDefinedButton::doublePosDesc() );


### PR DESCRIPTION
This PR adds:
- right/left half triangles to simple markers
- right/left half triangles and semi circle to ellipse markers

As @andreasneumann pointed out in a different PR, half triangles are useful markers to have when building flow symbology:
![half_arrows](https://cloud.githubusercontent.com/assets/1728657/14287741/33fd87a4-fb7e-11e5-8837-0ba484bb44ab.png)
