### PR TITLE
[ui] add missing icons for no labels and no diagram

### DIFF
--- a/images/images.qrc
+++ b/images/images.qrc
@@ -439,7 +439,8 @@
         <file>themes/default/mMessageLog.svg</file>
         <file>themes/default/mMessageLogRead.svg</file>
         <file>themes/default/north_arrow.png</file>
-        <file>themes/default/pie-chart.png</file>
+        <file>themes/default/diagramNone.svg</file>
+        <file>themes/default/pie-chart.svg</file>
         <file>themes/default/plugin.png</file>
         <file>themes/default/pluginExperimental.png</file>
         <file>themes/default/pluginDeprecated.png</file>
@@ -495,6 +496,7 @@
         <file>themes/default/rendererHeatmapSymbol.svg</file>
         <file>themes/default/renderer25dSymbol.svg</file>
         <file>themes/default/rendererGrassSymbol.svg</file>
+        <file>themes/default/labelingNone.svg</file>
         <file>themes/default/labelingSingle.svg</file>
         <file>themes/default/labelingRuleBased.svg</file>
         <file>themes/default/labelingObstacle.svg</file>

--- a/images/themes/default/diagramNone.svg
+++ b/images/themes/default/diagramNone.svg
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="diagramNone.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="3.959798"
+     inkscape:cx="82.829164"
+     inkscape:cy="-39.990991"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1865"
+     inkscape:window-height="1056"
+     inkscape:window-x="55"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4136"
+       dotted="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <circle
+       style="color:#000000;clip-rule:nonzero;display:inline;overflow:visible;visibility:visible;opacity:1;isolation:auto;mix-blend-mode:normal;color-interpolation:sRGB;color-interpolation-filters:linearRGB;solid-color:#000000;solid-opacity:1;fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:1,1;stroke-dashoffset:0.5;stroke-opacity:0.30980392;color-rendering:auto;image-rendering:auto;shape-rendering:auto;text-rendering:auto;enable-background:accumulate"
+       id="path4239"
+       cx="7.9999995"
+       cy="1044.3622"
+       r="6.5" />
+  </g>
+</svg>

--- a/images/themes/default/labelingNone.svg
+++ b/images/themes/default/labelingNone.svg
@@ -1,0 +1,69 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="labelingNone.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="-0.35957072"
+     inkscape:cy="11.927334"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1865"
+     inkscape:window-height="1056"
+     inkscape:window-x="55"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4136"
+       dotted="true" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <path
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:1;stroke-linecap:butt;stroke-linejoin:miter;stroke-miterlimit:4;stroke-dasharray:1,1;stroke-dashoffset:1.9;stroke-opacity:0.30980392"
+       d="m 1.5,1043.8622 2,-3 11,0 0,7 -11,0 -2,-3 z"
+       id="path4149"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccc" />
+  </g>
+</svg>

--- a/src/app/qgsdiagramproperties.cpp
+++ b/src/app/qgsdiagramproperties.cpp
@@ -66,8 +66,9 @@ QgsDiagramProperties::QgsDiagramProperties( QgsVectorLayer* layer, QWidget* pare
   mDiagramOptionsListWidget->setAttribute( Qt::WA_MacShowFocusRect, false );
 
   mDiagramTypeComboBox->blockSignals( true );
-  mDiagramTypeComboBox->addItem( tr( "No diagrams" ), "None" );
-  QPixmap pix = QgsApplication::getThemePixmap( "pie-chart" );
+  QPixmap pix = QgsApplication::getThemePixmap( "diagramNone" );
+  mDiagramTypeComboBox->addItem( pix, tr( "No diagrams" ), "None" );
+  pix = QgsApplication::getThemePixmap( "pie-chart" );
   mDiagramTypeComboBox->addItem( pix, tr( "Pie chart" ), DIAGRAM_NAME_PIE );
   pix = QgsApplication::getThemePixmap( "text" );
   mDiagramTypeComboBox->addItem( pix, tr( "Text diagram" ), DIAGRAM_NAME_TEXT );

--- a/src/core/symbology-ng/qgsrendererv2registry.cpp
+++ b/src/core/symbology-ng/qgsrendererv2registry.cpp
@@ -29,11 +29,11 @@ QgsRendererV2Registry::QgsRendererV2Registry()
 {
   // add default renderers
   addRenderer( new QgsRendererV2Metadata( "nullSymbol",
-                                          QObject::tr( "No Symbols" ),
+                                          QObject::tr( "No symbols" ),
                                           QgsNullSymbolRenderer::create ) );
 
   addRenderer( new QgsRendererV2Metadata( "singleSymbol",
-                                          QObject::tr( "Single Symbol" ),
+                                          QObject::tr( "Single symbol" ),
                                           QgsSingleSymbolRendererV2::create,
                                           QgsSingleSymbolRendererV2::createFromSld ) );
 
@@ -51,11 +51,11 @@ QgsRendererV2Registry::QgsRendererV2Registry()
                                           QgsRuleBasedRendererV2::createFromSld ) );
 
   addRenderer( new QgsRendererV2Metadata( "pointDisplacement",
-                                          QObject::tr( "Point Displacement" ),
+                                          QObject::tr( "Point displacement" ),
                                           QgsPointDisplacementRenderer::create ) );
 
   addRenderer( new QgsRendererV2Metadata( "invertedPolygonRenderer",
-                                          QObject::tr( "Inverted Polygons" ),
+                                          QObject::tr( "Inverted polygons" ),
                                           QgsInvertedPolygonRenderer::create ) );
 
   addRenderer( new QgsRendererV2Metadata( "heatmapRenderer",

--- a/src/core/symbology-ng/qgsrendererv2registry.cpp
+++ b/src/core/symbology-ng/qgsrendererv2registry.cpp
@@ -28,6 +28,10 @@
 QgsRendererV2Registry::QgsRendererV2Registry()
 {
   // add default renderers
+  addRenderer( new QgsRendererV2Metadata( "nullSymbol",
+                                          QObject::tr( "No Symbols" ),
+                                          QgsNullSymbolRenderer::create ) );
+
   addRenderer( new QgsRendererV2Metadata( "singleSymbol",
                                           QObject::tr( "Single Symbol" ),
                                           QgsSingleSymbolRendererV2::create,
@@ -62,10 +66,6 @@ QgsRendererV2Registry::QgsRendererV2Registry()
   addRenderer( new QgsRendererV2Metadata( "25dRenderer",
                                           QObject::tr( "2.5 D" ),
                                           Qgs25DRenderer::create ) );
-
-  addRenderer( new QgsRendererV2Metadata( "nullSymbol",
-                                          QObject::tr( "No Symbols" ),
-                                          QgsNullSymbolRenderer::create ) );
 }
 
 QgsRendererV2Registry::~QgsRendererV2Registry()

--- a/src/plugins/grass/qgsgrassplugin.cpp
+++ b/src/plugins/grass/qgsgrassplugin.cpp
@@ -294,7 +294,7 @@ void QgsGrassPlugin::initGui()
   if ( !QgsRendererV2Registry::instance()->renderersList().contains( "grassEdit" ) )
   {
     QgsRendererV2Registry::instance()->addRenderer( new QgsRendererV2Metadata( "grassEdit",
-        QObject::tr( "GRASS Edit" ),
+        QObject::tr( "GRASS edit" ),
         QgsGrassEditRenderer::create,
         QIcon( QgsApplication::defaultThemePath() + "rendererGrassSymbol.svg" ),
         QgsGrassEditRendererWidget::create ) );

--- a/src/ui/qgslabelingwidget.ui
+++ b/src/ui/qgslabelingwidget.ui
@@ -25,6 +25,10 @@
         <property name="text">
          <string>No labels</string>
         </property>
+        <property name="icon">
+         <iconset resource="../../images/images.qrc">
+          <normaloff>:/images/themes/default/labelingNone.svg</normaloff>:/images/themes/default/labelingNone.svg</iconset>
+        </property>
        </item>
        <item>
         <property name="text">


### PR DESCRIPTION
(This requires PR #2980 to be merged first)

Adding missing icons for the No labels and No diagram items (inspired by @nyalldawson 's null renderer). It fixes the odd mis-alignment on Ubuntu, and provides an harmonized UX for users:

![zzz2](https://cloud.githubusercontent.com/assets/1728657/14347862/50164e56-fce3-11e5-8389-983a0a5609ba.png)
