### PR TITLE
don't apply loaded style when layer properties dialog is cancelled

### DIFF
--- a/src/app/qgsrasterlayerproperties.cpp
+++ b/src/app/qgsrasterlayerproperties.cpp
@@ -30,7 +30,6 @@
 #include "qgsmapcanvas.h"
 #include "qgsmaplayerregistry.h"
 #include "qgsmaplayerstyleguiutils.h"
-#include "qgsmaplayerstylemanager.h"
 #include "qgsmaprenderer.h"
 #include "qgsmaptoolemitpoint.h"
 #include "qgsmaptopixel.h"
@@ -106,6 +105,8 @@ QgsRasterLayerProperties::QgsRasterLayerProperties( QgsMapLayer* lyr, QgsMapCanv
   connect( lyr->styleManager(), SIGNAL( currentStyleChanged( QString ) ), this, SLOT( syncToLayer() ) );
 
   connect( this, SIGNAL( accepted() ), this, SLOT( apply() ) );
+  connect( this, SIGNAL( rejected() ), this, SLOT( onCancel() ) );
+
   connect( buttonBox->button( QDialogButtonBox::Apply ), SIGNAL( clicked() ), this, SLOT( apply() ) );
 
   connect( mOptionsStackedWidget, SIGNAL( currentChanged( int ) ), this, SLOT( mOptionsStackedWidget_CurrentChanged( int ) ) );
@@ -1713,6 +1714,8 @@ void QgsRasterLayerProperties::loadStyle_clicked()
   if ( !fileName.endsWith( ".qml", Qt::CaseInsensitive ) )
     fileName += ".qml";
 
+  mOldStyle = mRasterLayer->styleManager()->style( mRasterLayer->styleManager()->currentStyle() );
+
   bool defaultLoadedFlag = false;
   QString message = mRasterLayer->loadNamedStyle( fileName, defaultLoadedFlag );
   if ( defaultLoadedFlag )
@@ -1782,4 +1785,16 @@ bool QgsRasterLayerProperties::rasterIsMultiBandColor()
   return mRasterLayer && nullptr != dynamic_cast<QgsMultiBandColorRenderer*>( mRasterLayer->renderer() );
 }
 
-
+void QgsRasterLayerProperties::onCancel()
+{
+  if ( mOldStyle.xmlData() != mRasterLayer->styleManager()->style( mRasterLayer->styleManager()->currentStyle() ).xmlData() )
+  {
+    // need to reset style to previous - style applied directly to the layer (not in apply())
+    QString myMessage;
+    QDomDocument doc( "qgis" );
+    int errorLine, errorColumn;
+    doc.setContent( mOldStyle.xmlData(), false, &myMessage, &errorLine, &errorColumn );
+    mRasterLayer->importNamedStyle( doc, myMessage );
+    syncToLayer();
+  }
+}

--- a/src/app/qgsrasterlayerproperties.h
+++ b/src/app/qgsrasterlayerproperties.h
@@ -25,6 +25,7 @@
 #include "qgsmaptool.h"
 #include "qgscolorrampshader.h"
 #include "qgscontexthelp.h"
+#include "qgsmaplayerstylemanager.h"
 
 class QgsMapLayer;
 class QgsMapCanvas;
@@ -57,6 +58,8 @@ class APP_EXPORT QgsRasterLayerProperties : public QgsOptionsDialogBase, private
     //TODO: Verify that these all need to be public
     /** \brief Applies the settings made in the dialog without closing the box */
     void apply();
+    /** Called when cancel button is pressed */
+    void onCancel();
     /** \brief Slot to update layer display name as original is edited. */
     void on_mLayerOrigNameLineEd_textEdited( const QString& text );
     /** \brief this slot asks the rasterlayer to construct pyramids */
@@ -186,5 +189,9 @@ class APP_EXPORT QgsRasterLayerProperties : public QgsOptionsDialogBase, private
     QgsRasterHistogramWidget* mHistogramWidget;
 
     QVector<bool> mTransparencyToEdited;
+
+    /** Previous layer style. Used to reset style to previous state if new style
+     * was loaded but dialog is cancelled */
+    QgsMapLayerStyle mOldStyle;
 };
 #endif

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -37,7 +37,6 @@
 #include "qgslogger.h"
 #include "qgsmaplayerregistry.h"
 #include "qgsmaplayerstyleguiutils.h"
-#include "qgsmaplayerstylemanager.h"
 #include "qgspluginmetadata.h"
 #include "qgspluginregistry.h"
 #include "qgsproject.h"
@@ -650,6 +649,17 @@ void QgsVectorLayerProperties::onCancel()
 
     mLayer->setSubsetString( mOriginalSubsetSQL );
   }
+
+  if ( mOldStyle.xmlData() != mLayer->styleManager()->style( mLayer->styleManager()->currentStyle() ).xmlData() )
+  {
+    // need to reset style to previous - style applied directly to the layer (not in apply())
+    QString myMessage;
+    QDomDocument doc( "qgis" );
+    int errorLine, errorColumn;
+    doc.setContent( mOldStyle.xmlData(), false, &myMessage, &errorLine, &errorColumn );
+    mLayer->importNamedStyle( doc, myMessage );
+    syncToLayer();
+  }
 }
 
 void QgsVectorLayerProperties::on_pbnQueryBuilder_clicked()
@@ -815,6 +825,8 @@ void QgsVectorLayerProperties::loadStyle_clicked()
   {
     return;
   }
+
+  mOldStyle = mLayer->styleManager()->style( mLayer->styleManager()->currentStyle() );
 
   QString myMessage;
   bool defaultLoadedFlag = false;

--- a/src/app/qgsvectorlayerproperties.h
+++ b/src/app/qgsvectorlayerproperties.h
@@ -30,6 +30,7 @@
 #include "qgsmapcanvas.h"
 #include "qgscontexthelp.h"
 #include "qgsexpressionbuilderdialog.h"
+#include "qgsmaplayerstylemanager.h"
 
 class QgsMapLayer;
 
@@ -188,6 +189,10 @@ class APP_EXPORT QgsVectorLayerProperties : public QgsOptionsDialogBase, private
 
     //! List of joins of a layer at the time of creation of the dialog. Used to return joins to previous state if dialog is cancelled
     QList< QgsVectorJoinInfo > mOldJoins;
+
+    /** Previous layer style. Used to reset style to previous state if new style
+     * was loaded but dialog is cancelled */
+    QgsMapLayerStyle mOldStyle;
 
     void initDiagramTab();
 


### PR DESCRIPTION
When I use "Style" button in the layer properties dialog to load existing style it applied to layer immediately, so pressing Cancel button in the dialog does not revert this operation. This is confusing for some users and it is better to reset style to previous state if Cancel pressed.
