### PR TITLE
[processing] Use unary union in dissolve 

### DIFF
--- a/python/plugins/processing/algs/qgis/Dissolve.py
+++ b/python/plugins/processing/algs/qgis/Dissolve.py
@@ -164,18 +164,11 @@ class Dissolve(GeoAlgorithm):
             for key, value in myDict.items():
                 nElement += 1
                 progress.setPercentage(int(nElement * 100 / nFeat))
-                for i in range(len(value)):
-                    tmpInGeom = value[i]
-
-                    if i == 0:
-                        tmpOutGeom = tmpInGeom
-                    else:
-                        try:
-                            tmpOutGeom = QgsGeometry(
-                                tmpOutGeom.combine(tmpInGeom))
-                        except:
-                            raise GeoAlgorithmExecutionException(
-                                self.tr('Geometry exception while dissolving'))
+                try:
+                    tmpOutGeom = QgsGeometry.unaryUnion(value)
+                except:
+                    raise GeoAlgorithmExecutionException(
+                        self.tr('Geometry exception while dissolving'))
                 outFeat.setGeometry(tmpOutGeom)
                 outFeat.setAttributes(attrDict[key])
                 writer.addFeature(outFeat)


### PR DESCRIPTION
Unary union is much faster for complex or many geometry inputs. Note that this change is only applied when using a field to group results - if accepted I'll make a separate PR for the no-field case
