### PR TITLE
Default datum transform for Server

### DIFF
--- a/python/core/qgsdatumtransformstore.sip
+++ b/python/core/qgsdatumtransformstore.sip
@@ -19,6 +19,8 @@ class QgsDatumTransformStore
 
     void addEntry( const QString& layerId, const QString& srcAuthId, const QString& destAuthId, int srcDatumTransform, int destDatumTransform );
 
+    /** Tests if the store has an entry for the map layer
+    @param layer the layer*/
     bool hasEntryForLayer( const QgsMapLayer* layer ) const;
 
     /** Will return transform from layer's CRS to current destination CRS.

--- a/python/core/qgsdatumtransformstore.sip
+++ b/python/core/qgsdatumtransformstore.sip
@@ -19,7 +19,7 @@ class QgsDatumTransformStore
 
     void addEntry( const QString& layerId, const QString& srcAuthId, const QString& destAuthId, int srcDatumTransform, int destDatumTransform );
 
-    bool hasEntryForLayer( QgsMapLayer* layer ) const;
+    bool hasEntryForLayer( const QgsMapLayer* layer ) const;
 
     /** Will return transform from layer's CRS to current destination CRS.
      *  Will emit datumTransformInfoRequested signal if the layer has no entry.

--- a/python/core/qgsmaprendererjob.sip
+++ b/python/core/qgsmaprendererjob.sip
@@ -97,6 +97,12 @@ class QgsMapRendererJob : QObject
      */
     const QgsMapSettings& mapSettings() const;
 
+    /** Sets feature filter provider
+    @param p the filter provider*/
+    void setFeatureFilterProvider( const QgsFeatureFilterProvider* p );
+    /** Returns the feature filter provider*/
+    const QgsFeatureFilterProvider* featureFilterProvider() const;
+
   signals:
 
     //! emitted when asynchronous rendering is finished (or canceled).

--- a/python/core/qgsmapsettings.sip
+++ b/python/core/qgsmapsettings.sip
@@ -8,7 +8,6 @@ class QgsMapSettings
   public:
     QgsMapSettings();
     QgsMapSettings( const QgsMapSettings& other );
-    QgsMapSettings& operator=( const QgsMapSettings& other );
 
     //! Return geographical coordinates of the rectangle that should be rendered.
     //! The actual visible extent used for rendering could be slightly different

--- a/python/core/qgsmapsettings.sip
+++ b/python/core/qgsmapsettings.sip
@@ -7,6 +7,8 @@ class QgsMapSettings
 
   public:
     QgsMapSettings();
+    QgsMapSettings( const QgsMapSettings& other );
+    QgsMapSettings& operator=( const QgsMapSettings& other );
 
     //! Return geographical coordinates of the rectangle that should be rendered.
     //! The actual visible extent used for rendering could be slightly different
@@ -203,6 +205,12 @@ class QgsMapSettings
     void readXML( QDomNode& theNode );
 
     void writeXML( QDomNode& theNode, QDomDocument& theDoc );
+
+    /** Updates datum transformation for layer
+        @param ml the map layer
+        @param srcAuthId id for source layer
+        @param destAuthId id for dest layer*/
+    void getDatumTransformInfo( const QgsMapLayer* ml, const QString& srcAuthId, const QString& destAuthId );
 
   protected:
 

--- a/python/core/qgsmapsettings.sip
+++ b/python/core/qgsmapsettings.sip
@@ -7,6 +7,8 @@ class QgsMapSettings: QObject
 
   public:
     QgsMapSettings();
+    /** The copy constructor
+    @param other the other settings*/
     QgsMapSettings( const QgsMapSettings& other );
 
     //! Return geographical coordinates of the rectangle that should be rendered.

--- a/python/core/qgsmapsettings.sip
+++ b/python/core/qgsmapsettings.sip
@@ -1,5 +1,5 @@
 
-class QgsMapSettings
+class QgsMapSettings: QObject
 {
 %TypeHeaderCode
 #include <qgsmapsettings.h>

--- a/python/server/qgswmsconfigparser.sip
+++ b/python/server/qgswmsconfigparser.sip
@@ -103,6 +103,8 @@ class QgsWMSConfigParser
    /** Creates a print composition, usually for a GetPrint request. Replaces map and label parameters*/
     QgsComposition* createPrintComposition( const QString& composerTemplate, QgsMapRenderer* mapRenderer, const QMap< QString, QString >& parameterMap, QStringList& highlightLayers ) const;
 
+    QgsComposition* createPrintComposition( const QString& composerTemplate, const QgsMapSettings* mapSettings, const QMap< QString, QString >& parameterMap, QStringList& highlightLayers ) const;
+
     /** Creates a composition from the project file (probably delegated to the fallback parser)*/
     //virtual QgsComposition* initComposition( const QString& composerTemplate, QgsMapRenderer* mapRenderer, QList< QgsComposerMap*>& mapList /Out/, QList< QgsComposerLegend* >& legendList /Out/, QList< QgsComposerLabel* >& labelList /Out/, QList<const QgsComposerHtml *>& htmlFrameList /Out/ ) const = 0;
 

--- a/python/server/qgswmsconfigparser.sip
+++ b/python/server/qgswmsconfigparser.sip
@@ -101,13 +101,32 @@ class QgsWMSConfigParser
     QgsComposition* createPrintComposition( const QString& composerTemplate, QgsMapRenderer* mapRenderer, const QMap< QString, QString >& parameterMap ) const;
 
    /** Creates a print composition, usually for a GetPrint request. Replaces map and label parameters*/
-    QgsComposition* createPrintComposition( const QString& composerTemplate, QgsMapRenderer* mapRenderer, const QMap< QString, QString >& parameterMap, QStringList& highlightLayers ) const;
+    QgsComposition* createPrintComposition( const QString& composerTemplate, QgsMapRenderer* mapRenderer, const QMap< QString, QString >& parameterMap, QStringList& highlightLayers /Out/ ) const;
 
-    /** Creates a print composition, usually for a GetPrint request. Replaces map and label parameters*/
-    QgsComposition* createPrintComposition( const QString& composerTemplate, const QgsMapSettings* mapSettings, const QMap< QString, QString >& parameterMap, QStringList& highlightLayers ) const;
+    /** Creates a print composition (usually for a GetPrint request
+        @param composerTemplate the template
+        @param mapSettings the map settings
+        @param parameterMap the request parameter / values
+        @param highlightLayers list of highlight layers is returned
+     */
+    QgsComposition* createPrintComposition( const QString& composerTemplate, const QgsMapSettings* mapSettings, const QMap< QString, QString >& parameterMap, QStringList& highlightLayers /Out/ ) const;
 
-    /** Creates a composition from the project file (probably delegated to the fallback parser)*/
-    //virtual QgsComposition* initComposition( const QString& composerTemplate, QgsMapRenderer* mapRenderer, QList< QgsComposerMap*>& mapList /Out/, QList< QgsComposerLegend* >& legendList /Out/, QList< QgsComposerLabel* >& labelList /Out/, QList<const QgsComposerHtml *>& htmlFrameList /Out/ ) const = 0;
+    /** Creates a composition from the project file (probably delegated to the fallback parser)
+    @param composerTemplate the composer template
+    @param mapRenderer the map renderer
+    @param mapList out: list of composer maps
+    @param legendList out: list of legends
+    @param labelList out: list of labels
+    @param htmlFrameList out: list of frames*/
+    virtual QgsComposition* initComposition( const QString& composerTemplate, QgsMapRenderer* mapRenderer, QList< QgsComposerMap*>& mapList /Out/, QList< QgsComposerLegend* >& legendList /Out/, QList< QgsComposerLabel* >& labelList /Out/, QList<const QgsComposerHtml *>& htmlFrameList /Out/  ) const = 0;
+    /** Creates a composition from the project file (probably delegated to the fallback parser)
+    @param composerTemplate the composer template
+    @param mapSettings the map settings
+    @param mapList out: list of composer maps
+    @param legendList out: list of legends
+    @param labelList out: list of labels
+    @param htmlFrameList out: list of frames*/
+    virtual QgsComposition* initComposition( const QString& composerTemplate, const QgsMapSettings* mapSettings, QList< QgsComposerMap*>& mapList /Out/, QList< QgsComposerLegend* >& legendList /Out/, QList< QgsComposerLabel* >& labelList /Out/, QList<const QgsComposerHtml *>& htmlFrameList /Out/ ) const = 0;
 
     /** Adds print capabilities to xml document. ParentElem usually is the <Capabilities> element*/
     virtual void printCapabilities( QDomElement& parentElement, QDomDocument& doc ) const = 0;

--- a/python/server/qgswmsconfigparser.sip
+++ b/python/server/qgswmsconfigparser.sip
@@ -103,6 +103,7 @@ class QgsWMSConfigParser
    /** Creates a print composition, usually for a GetPrint request. Replaces map and label parameters*/
     QgsComposition* createPrintComposition( const QString& composerTemplate, QgsMapRenderer* mapRenderer, const QMap< QString, QString >& parameterMap, QStringList& highlightLayers ) const;
 
+    /** Creates a print composition, usually for a GetPrint request. Replaces map and label parameters*/
     QgsComposition* createPrintComposition( const QString& composerTemplate, const QgsMapSettings* mapSettings, const QMap< QString, QString >& parameterMap, QStringList& highlightLayers ) const;
 
     /** Creates a composition from the project file (probably delegated to the fallback parser)*/

--- a/python/server/qgswmserver.sip
+++ b/python/server/qgswmserver.sip
@@ -60,6 +60,12 @@ class QgsWMSServer: public QgsOWSServer
         QgsConfigParser, QgsCapabilitiesCache and QgsMapRenderer*/
     QgsWMSServer( const QString& configFilePath, QMap<QString, QString> &parameters, QgsWMSConfigParser* cp, QgsRequestHandler* rh,
                   QgsMapRenderer* renderer, QgsCapabilitiesCache* capCache, const QgsAccessControl* accessControl );
+
+    /** Constructor. Does _NOT_ take ownership of
+        QgsConfigParser, QgsCapabilitiesCache and QgsMapSettings*/
+    QgsWMSServer( const QString& configFilePath, QMap<QString, QString> &parameters, QgsWMSConfigParser* cp, QgsRequestHandler* rh,
+                  QgsMapSettings* renderer, QgsCapabilitiesCache* capCache, const QgsAccessControl* accessControl );
+
     ~QgsWMSServer();
 
     void executeRequest() override;

--- a/python/server/qgswmsprojectparser.sip
+++ b/python/server/qgswmsprojectparser.sip
@@ -54,8 +54,22 @@ class QgsWMSProjectParser : public QgsWMSConfigParser
     double imageQuality() const  /*override*/ ;
     int WMSPrecision() const  /*override*/ ;
 
-    //printing
-    //QgsComposition* initComposition( const QString& composerTemplate, QgsMapRenderer* mapRenderer, QList< QgsComposerMap* >& mapList, //QList< QgsComposerLegend* >& legendList, QList< QgsComposerLabel* >& labelList, QList<const QgsComposerHtml *>& htmlFrameList ) const  /*override*/ ;
+    /** Creates a composition from the project file (probably delegated to the fallback parser)
+    @param composerTemplate the composer template
+    @param mapRenderer the map renderer
+    @param mapList out: list of composer maps
+    @param legendList out: list of legends
+    @param labelList out: list of labels
+    @param htmlFrameList out: list of frames*/
+    virtual QgsComposition* initComposition( const QString& composerTemplate, QgsMapRenderer* mapRenderer, QList< QgsComposerMap*>& mapList /Out/, QList< QgsComposerLegend* >& legendList /Out/, QList< QgsComposerLabel* >& labelList /Out/, QList<const QgsComposerHtml *>& htmlFrameList /Out/  ) const;
+    /** Creates a composition from the project file (probably delegated to the fallback parser)
+    @param composerTemplate the composer template
+    @param mapSettings the map settings
+    @param mapList out: list of composer maps
+    @param legendList out: list of legends
+    @param labelList out: list of labels
+    @param htmlFrameList out: list of frames*/
+    virtual QgsComposition* initComposition( const QString& composerTemplate, const QgsMapSettings* mapSettings, QList< QgsComposerMap*>& mapList /Out/, QList< QgsComposerLegend* >& legendList /Out/, QList< QgsComposerLabel* >& labelList /Out/, QList<const QgsComposerHtml *>& htmlFrameList /Out/ ) const;
 
     void printCapabilities( QDomElement& parentElement, QDomDocument& doc ) const  /*override*/ ;
 

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -455,6 +455,7 @@ SET(QGIS_CORE_MOC_HDRS
   qgsmaprendererjob.h
   qgsmaprendererparalleljob.h
   qgsmaprenderersequentialjob.h
+  qgsmapsettings.h
   qgsmessagelog.h
   qgsmessageoutput.h
   qgsnetworkaccessmanager.h

--- a/src/core/qgsdatumtransformstore.cpp
+++ b/src/core/qgsdatumtransformstore.cpp
@@ -45,7 +45,7 @@ void QgsDatumTransformStore::addEntry( const QString& layerId, const QString& sr
   mEntries.insert( layerId, lt );
 }
 
-bool QgsDatumTransformStore::hasEntryForLayer( QgsMapLayer* layer ) const
+bool QgsDatumTransformStore::hasEntryForLayer( const QgsMapLayer* layer ) const
 {
   return mEntries.contains( layer->id() );
 }
@@ -71,6 +71,16 @@ const QgsCoordinateTransform* QgsDatumTransformStore::transformation( QgsMapLaye
   else
   {
     return QgsCoordinateTransformCache::instance()->transform( srcAuthId, dstAuthId );
+  }
+}
+
+void QgsDatumTransformStore::entries( QList< QPair< QString, Entry> >& list ) const
+{
+  list.clear();
+  QHash< QString, Entry >::const_iterator it = mEntries.constBegin();
+  for ( ; it != mEntries.constEnd(); ++it )
+  {
+    list.append( qMakePair( it.key(), it.value() ) );
   }
 }
 

--- a/src/core/qgsdatumtransformstore.h
+++ b/src/core/qgsdatumtransformstore.h
@@ -49,6 +49,8 @@ class CORE_EXPORT QgsDatumTransformStore
 
     void addEntry( const QString& layerId, const QString& srcAuthId, const QString& destAuthId, int srcDatumTransform, int destDatumTransform );
 
+    /** Tests if the store has an entry for the map layer
+    @param layer the layer*/
     bool hasEntryForLayer( const QgsMapLayer* layer ) const;
 
     /** Will return transform from layer's CRS to current destination CRS.

--- a/src/core/qgsdatumtransformstore.h
+++ b/src/core/qgsdatumtransformstore.h
@@ -32,25 +32,6 @@ class QDomElement;
 class CORE_EXPORT QgsDatumTransformStore
 {
   public:
-    explicit QgsDatumTransformStore( const QgsCoordinateReferenceSystem& destCrs );
-
-    void clear();
-
-    void setDestinationCrs( const QgsCoordinateReferenceSystem& destCrs );
-
-    void addEntry( const QString& layerId, const QString& srcAuthId, const QString& destAuthId, int srcDatumTransform, int destDatumTransform );
-
-    bool hasEntryForLayer( QgsMapLayer* layer ) const;
-
-    /** Will return transform from layer's CRS to current destination CRS.
-     *  Will emit datumTransformInfoRequested signal if the layer has no entry.
-     *  Returns an instance from QgsCoordinateTransformCache
-     */
-    const QgsCoordinateTransform* transformation( QgsMapLayer* layer ) const;
-
-    void readXML( const QDomNode& parentNode );
-
-    void writeXML( QDomNode& parentNode, QDomDocument& theDoc ) const;
 
     struct Entry
     {
@@ -59,6 +40,30 @@ class CORE_EXPORT QgsDatumTransformStore
       int srcDatumTransform; //-1 if unknown or not specified
       int destDatumTransform;
     };
+
+    explicit QgsDatumTransformStore( const QgsCoordinateReferenceSystem& destCrs );
+
+    void clear();
+
+    void setDestinationCrs( const QgsCoordinateReferenceSystem& destCrs );
+
+    void addEntry( const QString& layerId, const QString& srcAuthId, const QString& destAuthId, int srcDatumTransform, int destDatumTransform );
+
+    bool hasEntryForLayer( const QgsMapLayer* layer ) const;
+
+    /** Will return transform from layer's CRS to current destination CRS.
+     *  Will emit datumTransformInfoRequested signal if the layer has no entry.
+     *  Returns an instance from QgsCoordinateTransformCache
+     */
+    const QgsCoordinateTransform* transformation( QgsMapLayer* layer ) const;
+
+    void entries( QList< QPair< QString, Entry> >& list ) const;
+
+    void readXML( const QDomNode& parentNode );
+
+    void writeXML( QDomNode& parentNode, QDomDocument& theDoc ) const;
+
+
 
   protected:
     QgsCoordinateReferenceSystem mDestCRS;

--- a/src/core/qgsdatumtransformstore.h
+++ b/src/core/qgsdatumtransformstore.h
@@ -57,6 +57,9 @@ class CORE_EXPORT QgsDatumTransformStore
      */
     const QgsCoordinateTransform* transformation( QgsMapLayer* layer ) const;
 
+    /** Returns the entry in the store
+        @param list entries will be appended to the list
+        @note not available in python bindings*/
     void entries( QList< QPair< QString, Entry> >& list ) const;
 
     void readXML( const QDomNode& parentNode );

--- a/src/core/qgsmaprendererjob.cpp
+++ b/src/core/qgsmaprendererjob.cpp
@@ -22,6 +22,7 @@
 #include <QSettings>
 
 #include "qgscrscache.h"
+#include "qgsfeaturefilterprovider.h"
 #include "qgslogger.h"
 #include "qgsrendercontext.h"
 #include "qgsmaplayer.h"
@@ -38,6 +39,7 @@ QgsMapRendererJob::QgsMapRendererJob( const QgsMapSettings& settings )
     : mSettings( settings )
     , mCache( nullptr )
     , mRenderingTime( 0 )
+    , mFeatureFilterProvider( 0 )
 {
 }
 
@@ -254,6 +256,11 @@ LayerRenderJobs QgsMapRendererJob::prepareJobs( QPainter* painter, QgsPalLabelin
     job.context.setLabelingEngineV2( labelingEngine2 );
     job.context.setCoordinateTransform( ct );
     job.context.setExtent( r1 );
+
+    if ( mFeatureFilterProvider )
+    {
+      job.context.setFeatureFilterProvider( mFeatureFilterProvider );
+    }
 
     // if we can use the cache, let's do it and avoid rendering!
     if ( mCache && !mCache->cacheImage( ml->id() ).isNull() )

--- a/src/core/qgsmaprendererjob.h
+++ b/src/core/qgsmaprendererjob.h
@@ -136,7 +136,10 @@ class CORE_EXPORT QgsMapRendererJob : public QObject
      */
     const QgsMapSettings& mapSettings() const;
 
+    /** Sets feature filter provider
+    @param p the filter provider*/
     void setFeatureFilterProvider( const QgsFeatureFilterProvider* p ) { mFeatureFilterProvider = p; }
+    /** Returns the feature filter provider*/
     const QgsFeatureFilterProvider* featureFilterProvider() const { return mFeatureFilterProvider; }
 
   signals:

--- a/src/core/qgsmaprendererjob.h
+++ b/src/core/qgsmaprendererjob.h
@@ -29,6 +29,7 @@
 
 #include "qgsgeometrycache.h"
 
+class QgsFeatureFilterProvider;
 class QgsLabelingEngineV2;
 class QgsLabelingResults;
 class QgsMapLayerRenderer;
@@ -135,6 +136,9 @@ class CORE_EXPORT QgsMapRendererJob : public QObject
      */
     const QgsMapSettings& mapSettings() const;
 
+    void setFeatureFilterProvider( const QgsFeatureFilterProvider* p ) { mFeatureFilterProvider = p; }
+    const QgsFeatureFilterProvider* featureFilterProvider() const { return mFeatureFilterProvider; }
+
   signals:
 
     //! emitted when asynchronous rendering is finished (or canceled).
@@ -183,6 +187,8 @@ class CORE_EXPORT QgsMapRendererJob : public QObject
 
     QTime mRenderingStart;
     int mRenderingTime;
+
+    const QgsFeatureFilterProvider* mFeatureFilterProvider;
 };
 
 

--- a/src/core/qgsmapsettings.cpp
+++ b/src/core/qgsmapsettings.cpp
@@ -708,7 +708,29 @@ void QgsMapSettings::getDatumTransformInfo( const QgsMapLayer* ml, const QString
     return;
   }
 
-  //check if default datum transformation available
+  //check if default datum transformation is available in environment variable
+  const char* envChar = getenv( "DEFAULT_DATUM_TRANSFORM" );
+  if ( envChar )
+  {
+    QString envString( envChar );
+    QStringList transformSplit = envString.split( ";" );
+    for ( int i = 0; i < transformSplit.size(); ++i )
+    {
+      QStringList slashSplit = transformSplit.at( i ).split( "/" );
+      if ( slashSplit.size() < 4 )
+      {
+        continue;
+      }
+
+      if ( slashSplit.at( 0 ) == srcAuthId && slashSplit.at( 1 ) == destAuthId )
+      {
+        datumTransformStore().addEntry( ml->id(), srcAuthId, destAuthId, slashSplit.at( 2 ).toInt(), slashSplit.at( 3 ).toInt() );
+        return;
+      }
+    }
+  }
+
+  //check if default datum transformation is available in settings
   QSettings s;
   QString settingsString = "/Projections/" + srcAuthId + "//" + destAuthId;
   QVariant defaultSrcTransform = s.value( settingsString + "_srcTransform" );

--- a/src/core/qgsmapsettings.cpp
+++ b/src/core/qgsmapsettings.cpp
@@ -24,14 +24,17 @@
 #include "qgsmessagelog.h"
 #include "qgsmaplayer.h"
 #include "qgsmaplayerregistry.h"
+#include "qgsvectorlayer.h"
 #include "qgsxmlutils.h"
+
+#include <QSettings>
 
 
 Q_GUI_EXPORT extern int qt_defaultDpiX();
 
 
 QgsMapSettings::QgsMapSettings()
-    : mDpi( qt_defaultDpiX() ) // DPI that will be used by default for QImage instances
+    : QObject(), mDpi( qt_defaultDpiX() ) // DPI that will be used by default for QImage instances
     , mSize( QSize( 0, 0 ) )
     , mExtent()
     , mRotation( 0.0 )
@@ -53,6 +56,35 @@ QgsMapSettings::QgsMapSettings()
   setMapUnits( QGis::Degrees );
 }
 
+QgsMapSettings::QgsMapSettings( const QgsMapSettings& other ): QObject(), mDatumTransformStore( mDestCRS )
+{
+  *this = other;
+}
+
+QgsMapSettings& QgsMapSettings::operator=( const QgsMapSettings & other )
+{
+  mDpi = other.mDpi;
+  mSize = other.mSize;
+  mExtent = other.mExtent;
+  mRotation = other.mRotation;
+  mLayers = other.mLayers;
+  mLayerStyleOverrides = other.mLayerStyleOverrides;
+  mExpressionContext = other.mExpressionContext;
+  mProjectionsEnabled = other.mProjectionsEnabled;
+  mDestCRS = other.mDestCRS;
+  mDatumTransformStore = other.mDatumTransformStore;
+  mBackgroundColor = other.mBackgroundColor;
+  mSelectionColor = other.mSelectionColor;
+  mFlags = other.mFlags;
+  mImageFormat = other.mImageFormat;
+  mValid = other.mValid;
+  mVisibleExtent = other.mVisibleExtent;
+  mMapUnitsPerPixel = other.mMapUnitsPerPixel;
+  mScale = other.mScale;
+  mScaleCalculator = other.mScaleCalculator;
+  mMapToPixel = other.mMapToPixel;
+  return *this;
+}
 
 QgsRectangle QgsMapSettings::extent() const
 {
@@ -229,6 +261,7 @@ QStringList QgsMapSettings::layers() const
 void QgsMapSettings::setLayers( const QStringList& layers )
 {
   mLayers = layers;
+  updateDatumTransformEntries();
 }
 
 QMap<QString, QString> QgsMapSettings::layerStyleOverrides() const
@@ -244,6 +277,7 @@ void QgsMapSettings::setLayerStyleOverrides( const QMap<QString, QString>& overr
 void QgsMapSettings::setCrsTransformEnabled( bool enabled )
 {
   mProjectionsEnabled = enabled;
+  updateDatumTransformEntries();
 }
 
 bool QgsMapSettings::hasCrsTransformEnabled() const
@@ -256,6 +290,7 @@ void QgsMapSettings::setDestinationCrs( const QgsCoordinateReferenceSystem& crs 
 {
   mDestCRS = crs;
   mDatumTransformStore.setDestinationCrs( crs );
+  updateDatumTransformEntries();
 }
 
 const QgsCoordinateReferenceSystem& QgsMapSettings::destinationCrs() const
@@ -640,4 +675,58 @@ void QgsMapSettings::writeXML( QDomNode& theNode, QDomDocument& theDoc )
   theNode.appendChild( renderMapTileElem );
 
   mDatumTransformStore.writeXML( theNode, theDoc );
+}
+
+void QgsMapSettings::updateDatumTransformEntries()
+{
+  if ( !hasCrsTransformEnabled() )
+    return;
+
+  QString destAuthId = destinationCrs().authid();
+  Q_FOREACH ( const QString& layerID, layers() )
+  {
+    QgsMapLayer* layer = QgsMapLayerRegistry::instance()->mapLayer( layerID );
+    if ( !layer )
+      continue;
+
+    QgsVectorLayer *vl = qobject_cast<QgsVectorLayer *>( layer );
+    if ( vl && vl->geometryType() == QGis::NoGeometry )
+      continue;
+
+    // if there are more options, ask the user which datum transform to use
+    if ( !datumTransformStore().hasEntryForLayer( layer ) )
+    {
+      getDatumTransformInfo( layer, layer->crs().authid(), destAuthId );
+    }
+  }
+}
+
+void QgsMapSettings::getDatumTransformInfo( const QgsMapLayer* ml, const QString& srcAuthId, const QString& destAuthId )
+{
+  if ( !ml )
+  {
+    return;
+  }
+
+  //check if default datum transformation available
+  QSettings s;
+  QString settingsString = "/Projections/" + srcAuthId + "//" + destAuthId;
+  QVariant defaultSrcTransform = s.value( settingsString + "_srcTransform" );
+  QVariant defaultDestTransform = s.value( settingsString + "_destTransform" );
+  if ( defaultSrcTransform.isValid() && defaultDestTransform.isValid() )
+  {
+    datumTransformStore().addEntry( ml->id(), srcAuthId, destAuthId, defaultSrcTransform.toInt(), defaultDestTransform.toInt() );
+    return;
+  }
+
+  if ( s.value( "/Projections/showDatumTransformDialog", false ).toBool() )
+  {
+    //QgsMapCanvas brings a dialog to ask for the datum transformation
+    emit datumTransformationRequested( ml, srcAuthId, destAuthId );
+  }
+
+  if ( !datumTransformStore().hasEntryForLayer( ml ) )
+  {
+    datumTransformStore().addEntry( ml->id(), srcAuthId, destAuthId, -1, -1 );
+  }
 }

--- a/src/core/qgsmapsettings.h
+++ b/src/core/qgsmapsettings.h
@@ -18,6 +18,7 @@
 
 #include <QColor>
 #include <QImage>
+#include <QObject>
 #include <QSize>
 #include <QStringList>
 
@@ -50,10 +51,13 @@ class QgsMapLayer;
  *
  * @note added in 2.4
  */
-class CORE_EXPORT QgsMapSettings
+class CORE_EXPORT QgsMapSettings: public QObject
 {
+    Q_OBJECT
   public:
     QgsMapSettings();
+    QgsMapSettings( const QgsMapSettings& other );
+    QgsMapSettings& operator=( const QgsMapSettings& other );
 
     //! Return geographical coordinates of the rectangle that should be rendered.
     //! The actual visible extent used for rendering could be slightly different
@@ -252,6 +256,8 @@ class CORE_EXPORT QgsMapSettings
 
     void writeXML( QDomNode& theNode, QDomDocument& theDoc );
 
+    void getDatumTransformInfo( const QgsMapLayer* ml, const QString& srcAuthId, const QString& destAuthId );
+
   protected:
 
     int mDpi;
@@ -289,6 +295,11 @@ class CORE_EXPORT QgsMapSettings
     QgsMapToPixel mMapToPixel;
 
     void updateDerived();
+
+    void updateDatumTransformEntries();
+
+  signals:
+    void datumTransformationRequested( const QgsMapLayer* ml, const QString& srcAuthId, const QString& destAuthId );
 };
 
 Q_DECLARE_OPERATORS_FOR_FLAGS( QgsMapSettings::Flags )

--- a/src/core/qgsmapsettings.h
+++ b/src/core/qgsmapsettings.h
@@ -56,7 +56,12 @@ class CORE_EXPORT QgsMapSettings: public QObject
     Q_OBJECT
   public:
     QgsMapSettings();
+    /** The copy constructor
+    @param other the other settings*/
     QgsMapSettings( const QgsMapSettings& other );
+    /** Assignment operator
+    @param other the other settings
+    @note not available in python bindings*/
     QgsMapSettings& operator=( const QgsMapSettings& other );
 
     //! Return geographical coordinates of the rectangle that should be rendered.

--- a/src/core/qgsmapsettings.h
+++ b/src/core/qgsmapsettings.h
@@ -256,6 +256,10 @@ class CORE_EXPORT QgsMapSettings: public QObject
 
     void writeXML( QDomNode& theNode, QDomDocument& theDoc );
 
+    /** Updates datum transformation for layer
+        @param ml the map layer
+        @param srcAuthId id for source layer
+        @param destAuthId id for dest layer*/
     void getDatumTransformInfo( const QgsMapLayer* ml, const QString& srcAuthId, const QString& destAuthId );
 
   protected:

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -757,7 +757,6 @@ void QgsMapCanvas::askDatumTransform( const QgsMapLayer* ml, const QString& srcA
     }
 
     mSettings.datumTransformStore().addEntry( ml->id(), srcAuthId, destAuthId, srcTransform, destTransform );
-    //mMapRenderer->addLayerCoordinateTransform( ml->id(), srcAuthId, destAuthId, srcTransform, destTransform );
 
     if ( d.rememberSelection() )
     {

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -110,8 +110,36 @@ QgsMapCanvasRendererSync::QgsMapCanvasRendererSync( QgsMapCanvas* canvas, QgsMap
   connect( mRenderer, SIGNAL( destinationSrsChanged() ), this, SLOT( onDestCrsR2C() ) );
 
   connect( mCanvas, SIGNAL( layersChanged() ), this, SLOT( onLayersC2R() ) );
+
+  //sync datum transform with mMapRenderer
+  connect( mCanvas, SIGNAL( hasCrsTransformEnabledChanged( bool ) ), this, SLOT( syncDatumTransforms() ) );
+  connect( mCanvas, SIGNAL( destinationCrsChanged() ), this, SLOT( syncDatumTransforms() ) );
+  connect( mCanvas, SIGNAL( layersChanged() ), this, SLOT( syncDatumTransforms() ) );
+
   // TODO: layers R2C ? (should not happen!)
 
+}
+
+void QgsMapCanvasRendererSync::syncDatumTransforms()
+{
+  if ( !mRenderer || !mCanvas )
+  {
+    return;
+  }
+
+  mRenderer->clearLayerCoordinateTransforms();
+
+  const QgsMapSettings& settings = mCanvas->mapSettings();
+  const QgsDatumTransformStore& transformStore = settings.datumTransformStore();
+
+  QList<QPair< QString, QgsDatumTransformStore::Entry> > entryList;
+  transformStore.entries( entryList );
+
+  QList<QPair< QString, QgsDatumTransformStore::Entry> >::const_iterator entryIt = entryList.constBegin();
+  for ( ; entryIt != entryList.constEnd(); ++entryIt )
+  {
+    mRenderer->addLayerCoordinateTransform( entryIt->first, entryIt->second.srcAuthId, entryIt->second.destAuthId, entryIt->second.srcDatumTransform, entryIt->second.destDatumTransform );
+  }
 }
 
 void QgsMapCanvasRendererSync::onExtentC2R()
@@ -232,6 +260,7 @@ QgsMapCanvas::QgsMapCanvas( QWidget * parent, const char *name )
            this, SLOT( readProject( const QDomDocument & ) ) );
   connect( QgsProject::instance(), SIGNAL( writeProject( QDomDocument & ) ),
            this, SLOT( writeProject( QDomDocument & ) ) );
+  connect( &mSettings, SIGNAL( datumTransformationRequested( const QgsMapLayer*, const QString&, const QString& ) ), this, SLOT( askDatumTransform( const QgsMapLayer*, const QString&, const QString& ) ) );
 
   mSettings.setFlag( QgsMapSettings::DrawEditingInfo );
   mSettings.setFlag( QgsMapSettings::UseRenderingOptimization );
@@ -448,8 +477,6 @@ void QgsMapCanvas::setLayerSet( QList<QgsMapCanvasLayer> &layers )
       }
     }
 
-    updateDatumTransformEntries();
-
     QgsDebugMsg( "Layers have changed, refreshing" );
     emit layersChanged();
 
@@ -506,9 +533,6 @@ void QgsMapCanvas::setCrsTransformEnabled( bool enabled )
     return;
 
   mSettings.setCrsTransformEnabled( enabled );
-
-  updateDatumTransformEntries();
-
   refresh();
 
   emit hasCrsTransformEnabledChanged( enabled );
@@ -546,9 +570,6 @@ void QgsMapCanvas::setDestinationCrs( const QgsCoordinateReferenceSystem &crs )
   }
 
   mSettings.setDestinationCrs( crs );
-
-  updateDatumTransformEntries();
-
   emit destinationCrsChanged();
 }
 
@@ -701,6 +722,49 @@ void QgsMapCanvas::refreshMap()
   mMapUpdateTimer.start();
 
   emit renderStarting();
+}
+
+void QgsMapCanvas::askDatumTransform( const QgsMapLayer* ml, const QString& srcAuthId, const QString& destAuthId )
+{
+  QSettings s;
+  QString settingsString = "/Projections/" + srcAuthId + "//" + destAuthId;
+
+  const QgsCoordinateReferenceSystem& srcCRS = QgsCRSCache::instance()->crsByAuthId( srcAuthId );
+  const QgsCoordinateReferenceSystem& destCRS = QgsCRSCache::instance()->crsByAuthId( destAuthId );
+
+  //get list of datum transforms
+  QList< QList< int > > dt = QgsCoordinateTransform::datumTransformations( srcCRS, destCRS );
+  if ( dt.size() < 2 )
+  {
+    return;
+  }
+
+  //if several possibilities:  present dialog
+  QgsDatumTransformDialog d( ml->name(), dt );
+  d.setDatumTransformInfo( srcCRS.authid(), destCRS.authid() );
+  if ( d.exec() == QDialog::Accepted )
+  {
+    int srcTransform = -1;
+    int destTransform = -1;
+    QList<int> t = d.selectedDatumTransform();
+    if ( !t.isEmpty() )
+    {
+      srcTransform = t.at( 0 );
+    }
+    if ( t.size() > 1 )
+    {
+      destTransform = t.at( 1 );
+    }
+
+    mSettings.datumTransformStore().addEntry( ml->id(), srcAuthId, destAuthId, srcTransform, destTransform );
+    //mMapRenderer->addLayerCoordinateTransform( ml->id(), srcAuthId, destAuthId, srcTransform, destTransform );
+
+    if ( d.rememberSelection() )
+    {
+      s.setValue( settingsString + "_srcTransform", srcTransform );
+      s.setValue( settingsString + "_destTransform", destTransform );
+    }
+  }
 }
 
 
@@ -1630,8 +1694,7 @@ void QgsMapCanvas::layerCrsChange()
   QObject *theSender = sender();
   QgsMapLayer *layer = qobject_cast<QgsMapLayer *>( theSender );
   QString destAuthId = mSettings.destinationCrs().authid();
-  getDatumTransformInfo( layer, layer->crs().authid(), destAuthId );
-
+  mSettings.getDatumTransformInfo( layer, layer->crs().authid(), destAuthId );
 } // layerCrsChange
 
 
@@ -1717,6 +1780,12 @@ void QgsMapCanvas::connectNotify( const char * signal )
 
 void QgsMapCanvas::updateDatumTransformEntries()
 {
+  //mSettings.updateDatumTransformEntries(); ?
+}
+
+#if 0
+void QgsMapCanvas::updateDatumTransformEntries()
+{
   if ( !mSettings.hasCrsTransformEnabled() )
     return;
 
@@ -1736,6 +1805,7 @@ void QgsMapCanvas::updateDatumTransformEntries()
       getDatumTransformInfo( layer, layer->crs().authid(), destAuthId );
   }
 }
+#endif //0
 
 
 
@@ -1890,73 +1960,9 @@ void QgsMapCanvas::writeProject( QDomDocument & doc )
   // TODO: store only units, extent, projections, dest CRS
 }
 
-/** Ask user which datum transform to use*/
 void QgsMapCanvas::getDatumTransformInfo( const QgsMapLayer* ml, const QString& srcAuthId, const QString& destAuthId )
 {
-  if ( !ml )
-  {
-    return;
-  }
-
-  //check if default datum transformation available
-  QSettings s;
-  QString settingsString = "/Projections/" + srcAuthId + "//" + destAuthId;
-  QVariant defaultSrcTransform = s.value( settingsString + "_srcTransform" );
-  QVariant defaultDestTransform = s.value( settingsString + "_destTransform" );
-  if ( defaultSrcTransform.isValid() && defaultDestTransform.isValid() )
-  {
-    mSettings.datumTransformStore().addEntry( ml->id(), srcAuthId, destAuthId, defaultSrcTransform.toInt(), defaultDestTransform.toInt() );
-    mMapRenderer->addLayerCoordinateTransform( ml->id(), srcAuthId, destAuthId, defaultSrcTransform.toInt(), defaultDestTransform.toInt() );
-    return;
-  }
-
-  const QgsCoordinateReferenceSystem& srcCRS = QgsCRSCache::instance()->crsByAuthId( srcAuthId );
-  const QgsCoordinateReferenceSystem& destCRS = QgsCRSCache::instance()->crsByAuthId( destAuthId );
-
-  if ( !s.value( "/Projections/showDatumTransformDialog", false ).toBool() )
-  {
-    // just use the default transform
-    mSettings.datumTransformStore().addEntry( ml->id(), srcAuthId, destAuthId, -1, -1 );
-    mMapRenderer->addLayerCoordinateTransform( ml->id(), srcAuthId, destAuthId, -1, -1 );
-    return;
-  }
-
-  //get list of datum transforms
-  QList< QList< int > > dt = QgsCoordinateTransform::datumTransformations( srcCRS, destCRS );
-  if ( dt.size() < 2 )
-  {
-    return;
-  }
-
-  //if several possibilities:  present dialog
-  QgsDatumTransformDialog d( ml->name(), dt );
-  d.setDatumTransformInfo( srcCRS.authid(), destCRS.authid() );
-  if ( d.exec() == QDialog::Accepted )
-  {
-    int srcTransform = -1;
-    int destTransform = -1;
-    QList<int> t = d.selectedDatumTransform();
-    if ( !t.isEmpty() )
-    {
-      srcTransform = t.at( 0 );
-    }
-    if ( t.size() > 1 )
-    {
-      destTransform = t.at( 1 );
-    }
-    mSettings.datumTransformStore().addEntry( ml->id(), srcAuthId, destAuthId, srcTransform, destTransform );
-    mMapRenderer->addLayerCoordinateTransform( ml->id(), srcAuthId, destAuthId, srcTransform, destTransform );
-    if ( d.rememberSelection() )
-    {
-      s.setValue( settingsString + "_srcTransform", srcTransform );
-      s.setValue( settingsString + "_destTransform", destTransform );
-    }
-  }
-  else
-  {
-    mSettings.datumTransformStore().addEntry( ml->id(), srcAuthId, destAuthId, -1, -1 );
-    mMapRenderer->addLayerCoordinateTransform( ml->id(), srcAuthId, destAuthId, -1, -1 );
-  }
+  mSettings.getDatumTransformInfo( ml, srcAuthId, destAuthId );
 }
 
 void QgsMapCanvas::zoomByFactor( double scaleFactor, const QgsPoint* center )

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -512,6 +512,8 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
 
     void refreshMap();
 
+    void askDatumTransform( const QgsMapLayer* ml, const QString& srcAuthId, const QString& destAuthId );
+
   signals:
     /** Let the owner know how far we are with render operations */
     //! @deprecated since 2.4 - already unused in 2.0 anyway
@@ -659,8 +661,10 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
      */
     void connectNotify( const char * signal ) override;
 #endif
+
     //! Make sure the datum transform store is properly populated
     void updateDatumTransformEntries();
+
 
   private:
     /// this class is non-copyable
@@ -785,6 +789,8 @@ class QgsMapCanvasRendererSync : public QObject
     void onDestCrsR2C();
 
     void onLayersC2R();
+
+    void syncDatumTransforms();
 
   protected:
     QgsMapCanvas* mCanvas;

--- a/src/server/qgsserver.cpp
+++ b/src/server/qgsserver.cpp
@@ -34,6 +34,7 @@
 #include "qgswfsserver.h"
 #include "qgswcsserver.h"
 #include "qgsmapserviceexception.h"
+#include "qgsmapsettings.h"
 #include "qgspallabeling.h"
 #include "qgsnetworkaccessmanager.h"
 #include "qgsmaplayerregistry.h"
@@ -62,6 +63,7 @@
 QString* QgsServer::sConfigFilePath = nullptr;
 QgsCapabilitiesCache* QgsServer::sCapabilitiesCache = nullptr;
 QgsMapRenderer* QgsServer::sMapRenderer = nullptr;
+QgsMapSettings* QgsServer::sMapSettings = nullptr;
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
 QgsServerInterfaceImpl*QgsServer::sServerInterface = nullptr;
 bool QgsServer::sInitPython = true;
@@ -410,6 +412,7 @@ bool QgsServer::init( int & argc, char ** argv )
   //create cache for capabilities XML
   sCapabilitiesCache = new QgsCapabilitiesCache();
   sMapRenderer =  new QgsMapRenderer;
+  sMapSettings = new QgsMapSettings();
   sMapRenderer->setLabelingEngine( new QgsPalLabeling() );
 
 #ifdef ENABLE_MS_TESTS
@@ -612,7 +615,7 @@ QPair<QByteArray, QByteArray> QgsServer::handleRequest( const QString& queryStri
           , parameterMap
           , p
           , theRequestHandler.data()
-          , sMapRenderer
+          , sMapSettings
           , sCapabilitiesCache
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
           , accessControl

--- a/src/server/qgsserver.h
+++ b/src/server/qgsserver.h
@@ -40,6 +40,7 @@
 #include "qgsserverinterfaceimpl.h"
 #endif
 
+class QgsMapSettings;
 
 /** \ingroup server
  * The QgsServer class provides OGC web services.
@@ -118,6 +119,7 @@ class SERVER_EXPORT QgsServer
     static QString* sConfigFilePath;
     static QgsCapabilitiesCache* sCapabilitiesCache;
     static QgsMapRenderer* sMapRenderer;
+    static QgsMapSettings* sMapSettings;
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
     static QgsServerInterfaceImpl* sServerInterface;
     static bool sInitPython;

--- a/src/server/qgsserver.h
+++ b/src/server/qgsserver.h
@@ -94,6 +94,12 @@ class SERVER_EXPORT QgsServer
 #endif
 
   private:
+
+    void saveEnvVars();
+
+    /** Saves environment variable into mEnvironmentVariables if defined*/
+    void saveEnvVar( const QString& variableName );
+
     // All functions that where previously in the main file are now
     // static methods of this class
     static QString configPath( const QString& defaultConfigPath,
@@ -130,6 +136,9 @@ class SERVER_EXPORT QgsServer
     static int sArgc;
     static QgsApplication* sQgsApplication;
     static bool sCaptureOutput;
+
+    /** Pass important environment variables to the fcgi processes*/
+    QHash< QString, QString > mEnvironmentVariables;
 };
 #endif // QGSSERVER_H
 

--- a/src/server/qgsserverprojectparser.cpp
+++ b/src/server/qgsserverprojectparser.cpp
@@ -78,6 +78,7 @@ QgsServerProjectParser::QgsServerProjectParser( QDomDocument* xmlDoc, const QStr
   if ( !mProjectPath.isEmpty() )
   {
     QgsProject::instance()->setFileName( mProjectPath );
+    QgsProject::instance()->read();
   }
 }
 

--- a/src/server/qgssldconfigparser.cpp
+++ b/src/server/qgssldconfigparser.cpp
@@ -735,6 +735,15 @@ QgsComposition* QgsSLDConfigParser::initComposition( const QString& composerTemp
   return nullptr;
 }
 
+QgsComposition* QgsSLDConfigParser::initComposition( const QString& composerTemplate, const QgsMapSettings* mapSettings, QList< QgsComposerMap*>& mapList, QList< QgsComposerLegend* >& legendList, QList< QgsComposerLabel* >& labelList, QList<const QgsComposerHtml *>& htmlFrameList ) const
+{
+  if ( mFallbackParser )
+  {
+    return mFallbackParser->initComposition( composerTemplate, mapSettings, mapList, legendList, labelList, htmlFrameList );
+  }
+  return nullptr;
+}
+
 void QgsSLDConfigParser::printCapabilities( QDomElement& parentElement, QDomDocument& doc ) const
 {
   if ( mFallbackParser )

--- a/src/server/qgssldconfigparser.h
+++ b/src/server/qgssldconfigparser.h
@@ -117,6 +117,9 @@ class QgsSLDConfigParser : public QgsWMSConfigParser
     /** Creates a composition from the project file (probably delegated to the fallback parser)*/
     QgsComposition* initComposition( const QString& composerTemplate, QgsMapRenderer* mapRenderer, QList< QgsComposerMap*>& mapList, QList< QgsComposerLegend* >& legendList, QList< QgsComposerLabel* >& labelList, QList<const QgsComposerHtml *>& htmlFrameList ) const override;
 
+    /** Creates a composition from the project file (probably delegated to the fallback parser)*/
+    QgsComposition* initComposition( const QString& composerTemplate, const QgsMapSettings* mapSettings, QList< QgsComposerMap*>& mapList, QList< QgsComposerLegend* >& legendList, QList< QgsComposerLabel* >& labelList, QList<const QgsComposerHtml *>& htmlFrameList ) const override;
+
     /** Adds print capabilities to xml document. ParentElem usually is the <Capabilities> element*/
     void printCapabilities( QDomElement& parentElement, QDomDocument& doc ) const override;
 

--- a/src/server/qgssldconfigparser.h
+++ b/src/server/qgssldconfigparser.h
@@ -114,10 +114,22 @@ class QgsSLDConfigParser : public QgsWMSConfigParser
     /** Creates a print composition, usually for a GetPrint request. Replaces map and label parameters*/
     QgsComposition* createPrintComposition( const QString& composerTemplate, QgsMapRenderer* mapRenderer, const QMap< QString, QString >& parameterMap, QStringList& highlightLayers ) const;
 
-    /** Creates a composition from the project file (probably delegated to the fallback parser)*/
+    /** Creates a composition from the project file (probably delegated to the fallback parser)
+    @param composerTemplate the composer template
+    @param mapRenderer the map renderer
+    @param mapList out: list of composer maps
+    @param legendList out: list of legends
+    @param labelList out: list of labels
+    @param htmlFrameList out: list of frames*/
     QgsComposition* initComposition( const QString& composerTemplate, QgsMapRenderer* mapRenderer, QList< QgsComposerMap*>& mapList, QList< QgsComposerLegend* >& legendList, QList< QgsComposerLabel* >& labelList, QList<const QgsComposerHtml *>& htmlFrameList ) const override;
 
-    /** Creates a composition from the project file (probably delegated to the fallback parser)*/
+    /** Creates a composition from the project file (probably delegated to the fallback parser)
+    @param composerTemplate the composer template
+    @param mapSettings the map settings
+    @param mapList out: list of composer maps
+    @param legendList out: list of legends
+    @param labelList out: list of labels
+    @param htmlFrameList out: list of frames*/
     QgsComposition* initComposition( const QString& composerTemplate, const QgsMapSettings* mapSettings, QList< QgsComposerMap*>& mapList, QList< QgsComposerLegend* >& legendList, QList< QgsComposerLabel* >& labelList, QList<const QgsComposerHtml *>& htmlFrameList ) const override;
 
     /** Adds print capabilities to xml document. ParentElem usually is the <Capabilities> element*/

--- a/src/server/qgswmsconfigparser.cpp
+++ b/src/server/qgswmsconfigparser.cpp
@@ -45,27 +45,14 @@ QgsWMSConfigParser::~QgsWMSConfigParser()
 
 }
 
-QgsComposition* QgsWMSConfigParser::createPrintComposition( const QString& composerTemplate, QgsMapSettings* mapSettings, const QMap< QString, QString >& parameterMap, QStringList& highlightLayers ) const
-{
-  return 0; //todo: fixme
-}
-
-QgsComposition* QgsWMSConfigParser::createPrintComposition( const QString& composerTemplate, QgsMapRenderer* mapRenderer, const QMap< QString, QString >& parameterMap ) const
-{
-  QStringList highlightLayers;
-  return createPrintComposition( composerTemplate, mapRenderer, parameterMap, highlightLayers );
-}
-
-
-
-QgsComposition* QgsWMSConfigParser::createPrintComposition( const QString& composerTemplate, QgsMapRenderer* mapRenderer, const QMap< QString, QString >& parameterMap, QStringList& highlightLayers ) const
+QgsComposition* QgsWMSConfigParser::createPrintComposition( const QString& composerTemplate, const QgsMapSettings* mapSettings, const QMap< QString, QString >& parameterMap, QStringList& highlightLayers ) const
 {
   QList<QgsComposerMap*> composerMaps;
   QList<QgsComposerLegend*> composerLegends;
   QList<QgsComposerLabel*> composerLabels;
   QList<const QgsComposerHtml*> composerHtmls;
 
-  QgsComposition* c = initComposition( composerTemplate, mapRenderer, composerMaps, composerLegends, composerLabels, composerHtmls );
+  QgsComposition* c = initComposition( composerTemplate, mapSettings, composerMaps, composerLegends, composerLabels, composerHtmls );
   if ( !c )
   {
     return nullptr;
@@ -120,7 +107,7 @@ QgsComposition* QgsWMSConfigParser::createPrintComposition( const QString& compo
 
     //Change x- and y- of extent for WMS 1.3.0 if axis inverted
     QString version = parameterMap.value( "VERSION" );
-    if ( version == "1.3.0" && mapRenderer && mapRenderer->destinationCrs().axisInverted() )
+    if ( version == "1.3.0" && mapSettings && mapSettings->destinationCrs().axisInverted() )
     {
       r.invert();
     }
@@ -217,8 +204,8 @@ QgsComposition* QgsWMSConfigParser::createPrintComposition( const QString& compo
     currentMap->grid()->setIntervalX( parameterMap.value( mapId + ":GRID_INTERVAL_X" ).toDouble() );
     currentMap->grid()->setIntervalY( parameterMap.value( mapId + ":GRID_INTERVAL_Y" ).toDouble() );
   }
-//update legend
-// if it has an auto-update model
+  //update legend
+  // if it has an auto-update model
   Q_FOREACH ( QgsComposerLegend* currentLegend, composerLegends )
   {
     if ( !currentLegend )
@@ -244,7 +231,7 @@ QgsComposition* QgsWMSConfigParser::createPrintComposition( const QString& compo
     }
   }
 
-//replace label text
+  //replace label text
   Q_FOREACH ( QgsComposerLabel *currentLabel, composerLabels )
   {
     QString title = parameterMap.value( currentLabel->id().toUpper() );
@@ -264,7 +251,7 @@ QgsComposition* QgsWMSConfigParser::createPrintComposition( const QString& compo
     currentLabel->setText( title );
   }
 
-//replace html url
+  //replace html url
   Q_FOREACH ( const QgsComposerHtml *currentHtml, composerHtmls )
   {
     QgsComposerHtml * html = const_cast<QgsComposerHtml *>( currentHtml );
@@ -294,6 +281,25 @@ QgsComposition* QgsWMSConfigParser::createPrintComposition( const QString& compo
   }
 
   return c;
+}
+
+QgsComposition* QgsWMSConfigParser::createPrintComposition( const QString& composerTemplate, QgsMapRenderer* mapRenderer, const QMap< QString, QString >& parameterMap ) const
+{
+  QStringList highlightLayers;
+  return createPrintComposition( composerTemplate, mapRenderer, parameterMap, highlightLayers );
+}
+
+
+
+QgsComposition* QgsWMSConfigParser::createPrintComposition( const QString& composerTemplate, QgsMapRenderer* mapRenderer, const QMap< QString, QString >& parameterMap, QStringList& highlightLayers ) const
+{
+  if ( !mapRenderer )
+  {
+    return 0;
+  }
+
+  const QgsMapSettings& mapSettings = mapRenderer->mapSettings();
+  return createPrintComposition( composerTemplate, &mapSettings, parameterMap, highlightLayers );
 }
 
 QStringList QgsWMSConfigParser::addHighlightLayers( const QMap<QString, QString>& parameterMap, QStringList& layerSet, const QString& parameterPrefix )

--- a/src/server/qgswmsconfigparser.cpp
+++ b/src/server/qgswmsconfigparser.cpp
@@ -45,11 +45,18 @@ QgsWMSConfigParser::~QgsWMSConfigParser()
 
 }
 
+QgsComposition* QgsWMSConfigParser::createPrintComposition( const QString& composerTemplate, QgsMapSettings* mapSettings, const QMap< QString, QString >& parameterMap, QStringList& highlightLayers ) const
+{
+  return 0; //todo: fixme
+}
+
 QgsComposition* QgsWMSConfigParser::createPrintComposition( const QString& composerTemplate, QgsMapRenderer* mapRenderer, const QMap< QString, QString >& parameterMap ) const
 {
   QStringList highlightLayers;
   return createPrintComposition( composerTemplate, mapRenderer, parameterMap, highlightLayers );
 }
+
+
 
 QgsComposition* QgsWMSConfigParser::createPrintComposition( const QString& composerTemplate, QgsMapRenderer* mapRenderer, const QMap< QString, QString >& parameterMap, QStringList& highlightLayers ) const
 {

--- a/src/server/qgswmsconfigparser.h
+++ b/src/server/qgswmsconfigparser.h
@@ -119,6 +119,9 @@ class SERVER_EXPORT QgsWMSConfigParser
     /** Creates a print composition, usually for a GetPrint request. Replaces map and label parameters*/
     QgsComposition* createPrintComposition( const QString& composerTemplate, QgsMapRenderer* mapRenderer, const QMap< QString, QString >& parameterMap, QStringList& highlightLayers ) const;
 
+    QgsComposition* createPrintComposition( const QString& composerTemplate, QgsMapSettings* mapSettings, const QMap< QString, QString >& parameterMap, QStringList& highlightLayers ) const;
+
+
     /** Creates a composition from the project file (probably delegated to the fallback parser)*/
     virtual QgsComposition* initComposition( const QString& composerTemplate, QgsMapRenderer* mapRenderer, QList< QgsComposerMap*>& mapList, QList< QgsComposerLegend* >& legendList, QList< QgsComposerLabel* >& labelList, QList<const QgsComposerHtml *>& htmlFrameList ) const = 0;
 

--- a/src/server/qgswmsconfigparser.h
+++ b/src/server/qgswmsconfigparser.h
@@ -119,12 +119,30 @@ class SERVER_EXPORT QgsWMSConfigParser
     /** Creates a print composition, usually for a GetPrint request. Replaces map and label parameters*/
     QgsComposition* createPrintComposition( const QString& composerTemplate, QgsMapRenderer* mapRenderer, const QMap< QString, QString >& parameterMap, QStringList& highlightLayers ) const;
 
+    /** Creates a print composition (usually for a GetPrint request
+        @param composerTemplate the template
+        @param mapSettings the map settings
+        @param parameterMap the request parameter / values
+        @param highlightLayers list of highlight layers is returned
+     */
     QgsComposition* createPrintComposition( const QString& composerTemplate, const QgsMapSettings* mapSettings, const QMap< QString, QString >& parameterMap, QStringList& highlightLayers ) const;
 
 
-    /** Creates a composition from the project file (probably delegated to the fallback parser)*/
+    /** Creates a composition from the project file (probably delegated to the fallback parser)
+    @param composerTemplate the composer template
+    @param mapRenderer the map renderer
+    @param mapList out: list of composer maps
+    @param legendList out: list of legends
+    @param labelList out: list of labels
+    @param htmlFrameList out: list of frames*/
     virtual QgsComposition* initComposition( const QString& composerTemplate, QgsMapRenderer* mapRenderer, QList< QgsComposerMap*>& mapList, QList< QgsComposerLegend* >& legendList, QList< QgsComposerLabel* >& labelList, QList<const QgsComposerHtml *>& htmlFrameList ) const = 0;
-
+    /** Creates a composition from the project file (probably delegated to the fallback parser)
+    @param composerTemplate the composer template
+    @param mapSettings the map settings
+    @param mapList out: list of composer maps
+    @param legendList out: list of legends
+    @param labelList out: list of labels
+    @param htmlFrameList out: list of frames*/
     virtual QgsComposition* initComposition( const QString& composerTemplate, const QgsMapSettings* mapSettings, QList< QgsComposerMap*>& mapList, QList< QgsComposerLegend* >& legendList, QList< QgsComposerLabel* >& labelList, QList<const QgsComposerHtml *>& htmlFrameList ) const = 0;
 
     /** Adds print capabilities to xml document. ParentElem usually is the <Capabilities> element*/

--- a/src/server/qgswmsconfigparser.h
+++ b/src/server/qgswmsconfigparser.h
@@ -119,11 +119,13 @@ class SERVER_EXPORT QgsWMSConfigParser
     /** Creates a print composition, usually for a GetPrint request. Replaces map and label parameters*/
     QgsComposition* createPrintComposition( const QString& composerTemplate, QgsMapRenderer* mapRenderer, const QMap< QString, QString >& parameterMap, QStringList& highlightLayers ) const;
 
-    QgsComposition* createPrintComposition( const QString& composerTemplate, QgsMapSettings* mapSettings, const QMap< QString, QString >& parameterMap, QStringList& highlightLayers ) const;
+    QgsComposition* createPrintComposition( const QString& composerTemplate, const QgsMapSettings* mapSettings, const QMap< QString, QString >& parameterMap, QStringList& highlightLayers ) const;
 
 
     /** Creates a composition from the project file (probably delegated to the fallback parser)*/
     virtual QgsComposition* initComposition( const QString& composerTemplate, QgsMapRenderer* mapRenderer, QList< QgsComposerMap*>& mapList, QList< QgsComposerLegend* >& legendList, QList< QgsComposerLabel* >& labelList, QList<const QgsComposerHtml *>& htmlFrameList ) const = 0;
+
+    virtual QgsComposition* initComposition( const QString& composerTemplate, const QgsMapSettings* mapSettings, QList< QgsComposerMap*>& mapList, QList< QgsComposerLegend* >& legendList, QList< QgsComposerLabel* >& labelList, QList<const QgsComposerHtml *>& htmlFrameList ) const = 0;
 
     /** Adds print capabilities to xml document. ParentElem usually is the <Capabilities> element*/
     virtual void printCapabilities( QDomElement& parentElement, QDomDocument& doc ) const = 0;

--- a/src/server/qgswmsprojectparser.cpp
+++ b/src/server/qgswmsprojectparser.cpp
@@ -471,6 +471,22 @@ bool QgsWMSProjectParser::WMSInspireActivated() const
 
 QgsComposition* QgsWMSProjectParser::initComposition( const QString& composerTemplate, QgsMapRenderer* mapRenderer, QList< QgsComposerMap* >& mapList, QList< QgsComposerLegend* >& legendList, QList< QgsComposerLabel* >& labelList, QList<const QgsComposerHtml *>& htmlList ) const
 {
+  if ( !mapRenderer )
+  {
+    return 0;
+  }
+
+  const QgsMapSettings& mapSettings = mapRenderer->mapSettings();
+  return initComposition( composerTemplate, &mapSettings, mapList, legendList, labelList, htmlList );
+}
+
+QgsComposition* QgsWMSProjectParser::initComposition( const QString& composerTemplate, const QgsMapSettings* mapSettings, QList< QgsComposerMap* >& mapList, QList< QgsComposerLegend* >& legendList, QList< QgsComposerLabel* >& labelList, QList<const QgsComposerHtml *>& htmlList ) const
+{
+  if ( !mapSettings )
+  {
+    return 0;
+  }
+
   //Create composition from xml
   QDomElement composerElem = composerByName( composerTemplate );
   if ( composerElem.isNull() )
@@ -484,7 +500,7 @@ QgsComposition* QgsWMSProjectParser::initComposition( const QString& composerTem
     return nullptr;
   }
 
-  QgsComposition* composition = new QgsComposition( mapRenderer->mapSettings() ); //set resolution, paper size from composer element attributes
+  QgsComposition* composition = new QgsComposition( *mapSettings ); //set resolution, paper size from composer element attributes
   if ( !composition->readXML( compositionElem, *( mProjectParser->xmlDocument() ) ) )
   {
     delete composition;

--- a/src/server/qgswmsprojectparser.h
+++ b/src/server/qgswmsprojectparser.h
@@ -72,9 +72,22 @@ class SERVER_EXPORT QgsWMSProjectParser : public QgsWMSConfigParser
     bool WMSInspireActivated() const override;
     void inspireCapabilities( QDomElement& parentElement, QDomDocument& doc ) const override;
 
-    //printing
+    /** Creates a composition from the project file (probably delegated to the fallback parser)
+    @param composerTemplate the composer template
+    @param mapRenderer the map renderer
+    @param mapList out: list of composer maps
+    @param legendList out: list of legends
+    @param labelList out: list of labels
+    @param htmlFrameList out: list of frames*/
     QgsComposition* initComposition( const QString& composerTemplate, QgsMapRenderer* mapRenderer, QList< QgsComposerMap* >& mapList, QList< QgsComposerLegend* >& legendList, QList< QgsComposerLabel* >& labelList, QList<const QgsComposerHtml *>& htmlFrameList ) const override;
 
+    /** Creates a composition from the project file (probably delegated to the fallback parser)
+    @param composerTemplate the composer template
+    @param mapSettings the map settings
+    @param mapList out: list of composer maps
+    @param legendList out: list of legends
+    @param labelList out: list of labels
+    @param htmlFrameList out: list of frames*/
     QgsComposition* initComposition( const QString& composerTemplate, const QgsMapSettings* mapSettings, QList< QgsComposerMap* >& mapList, QList< QgsComposerLegend* >& legendList, QList< QgsComposerLabel* >& labelList, QList<const QgsComposerHtml *>& htmlFrameList ) const override;
 
 

--- a/src/server/qgswmsprojectparser.h
+++ b/src/server/qgswmsprojectparser.h
@@ -74,6 +74,10 @@ class SERVER_EXPORT QgsWMSProjectParser : public QgsWMSConfigParser
 
     //printing
     QgsComposition* initComposition( const QString& composerTemplate, QgsMapRenderer* mapRenderer, QList< QgsComposerMap* >& mapList, QList< QgsComposerLegend* >& legendList, QList< QgsComposerLabel* >& labelList, QList<const QgsComposerHtml *>& htmlFrameList ) const override;
+
+    QgsComposition* initComposition( const QString& composerTemplate, const QgsMapSettings* mapSettings, QList< QgsComposerMap* >& mapList, QList< QgsComposerLegend* >& legendList, QList< QgsComposerLabel* >& labelList, QList<const QgsComposerHtml *>& htmlFrameList ) const override;
+
+
     void printCapabilities( QDomElement& parentElement, QDomDocument& doc ) const override;
 
     //todo: fixme

--- a/tests/src/python/test_qgsserver_accesscontrol.py
+++ b/tests/src/python/test_qgsserver_accesscontrol.py
@@ -1424,9 +1424,9 @@ class TestQgsServerAccessControl(unittest.TestCase):
         control.setRenderedImage(temp_image)
         if max_size_diff.isValid():
             control.setSizeTolerance(max_size_diff.width(), max_size_diff.height())
-        return control.compareImages(control_image), control.report()
+        return control.compareImages(control_image, max_diff), control.report()
 
-    def _img_diff_error(self, response, headers, image, max_diff=10, max_size_diff=QSize()):
+    def _img_diff_error(self, response, headers, image, max_diff=250, max_size_diff=QSize()):
         self.assertEquals(
             headers.get("Content-Type"), "image/png",
             "Content type is wrong: %s" % headers.get("Content-Type"))


### PR DESCRIPTION
(First travis test)

This PR adds the possibility to set default datum transformations for QGIS server (from environment variable or from QSettings). To achieve this, the following changes have been made:
- Reading of default datum transformation has been moved from QgsMapCanvas (gui) to QgsMapSettings (core) such that it can also be used by the server. If a dialog is needed (for the desktop case), a signal is sent from QgsMapSettings to QgsMapCanvas
- The server code has been changed from QgsMapRenderer to use the newer QgsMapRenderJob / QgsMapSettings classes
