### PR TITLE
Symbol selector dialog: use same terms in the gui

### DIFF
--- a/src/ui/symbollayer/widget_gradientfill.ui
+++ b/src/ui/symbollayer/widget_gradientfill.ui
@@ -14,20 +14,11 @@
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <property name="leftMargin">
-    <number>1</number>
-   </property>
-   <property name="topMargin">
-    <number>1</number>
-   </property>
-   <property name="rightMargin">
-    <number>1</number>
-   </property>
-   <property name="bottomMargin">
-    <number>1</number>
-   </property>
    <property name="horizontalSpacing">
     <number>28</number>
+   </property>
+   <property name="margin">
+    <number>1</number>
    </property>
    <item row="4" column="1">
     <layout class="QHBoxLayout" name="horizontalLayout_5">
@@ -533,7 +524,7 @@
    <item row="7" column="0">
     <widget class="QLabel" name="label_11">
      <property name="text">
-      <string>Angle</string>
+      <string>Rotation</string>
      </property>
     </widget>
    </item>

--- a/src/ui/symbollayer/widget_linepatternfill.ui
+++ b/src/ui/symbollayer/widget_linepatternfill.ui
@@ -23,22 +23,13 @@
    <property name="horizontalSpacing">
     <number>28</number>
    </property>
-   <property name="leftMargin">
-    <number>1</number>
-   </property>
-   <property name="topMargin">
-    <number>1</number>
-   </property>
-   <property name="rightMargin">
-    <number>1</number>
-   </property>
-   <property name="bottomMargin">
+   <property name="margin">
     <number>1</number>
    </property>
    <item row="1" column="0">
-    <widget class="QLabel" name="mAngleLabel">
+    <widget class="QLabel" name="mRotationLabel">
      <property name="text">
-      <string>Angle</string>
+      <string>Rotation</string>
      </property>
     </widget>
    </item>
@@ -162,11 +153,6 @@
  </widget>
  <customwidgets>
   <customwidget>
-   <class>QgsDataDefinedButton</class>
-   <extends>QToolButton</extends>
-   <header>qgsdatadefinedbutton.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
    <header>qgsdoublespinbox.h</header>
@@ -176,6 +162,11 @@
    <extends>QWidget</extends>
    <header>qgsunitselectionwidget.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsDataDefinedButton</class>
+   <extends>QToolButton</extends>
+   <header>qgsdatadefinedbutton.h</header>
   </customwidget>
  </customwidgets>
  <resources/>

--- a/src/ui/symbollayer/widget_simplefill.ui
+++ b/src/ui/symbollayer/widget_simplefill.ui
@@ -31,7 +31,7 @@
    <item row="7" column="0">
     <widget class="QLabel" name="label_5">
      <property name="text">
-      <string>Border width</string>
+      <string>Outline width</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
@@ -117,7 +117,7 @@
         </sizepolicy>
        </property>
        <property name="text">
-        <string>Border</string>
+        <string>Outline</string>
        </property>
        <property name="alignment">
         <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>
@@ -330,7 +330,7 @@
    <item row="4" column="0">
     <widget class="QLabel" name="label_4">
      <property name="text">
-      <string>Border style</string>
+      <string>Outline style</string>
      </property>
      <property name="alignment">
       <set>Qt::AlignLeading|Qt::AlignLeft|Qt::AlignVCenter</set>

--- a/src/ui/symbollayer/widget_simplemarker.ui
+++ b/src/ui/symbollayer/widget_simplemarker.ui
@@ -308,7 +308,7 @@
    <item row="8" column="0">
     <widget class="QLabel" name="label_4">
      <property name="text">
-      <string>Angle</string>
+      <string>Rotation</string>
      </property>
     </widget>
    </item>

--- a/src/ui/symbollayer/widget_svgfill.ui
+++ b/src/ui/symbollayer/widget_svgfill.ui
@@ -143,7 +143,7 @@
      <item row="3" column="0">
       <widget class="QLabel" name="mBorderWidthLabel">
        <property name="text">
-        <string>Border width</string>
+        <string>Outline width</string>
        </property>
       </widget>
      </item>
@@ -336,11 +336,6 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsDataDefinedButton</class>
-   <extends>QToolButton</extends>
-   <header>qgsdatadefinedbutton.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
    <header>qgsdoublespinbox.h</header>
@@ -350,6 +345,11 @@
    <extends>QWidget</extends>
    <header>qgsunitselectionwidget.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsDataDefinedButton</class>
+   <extends>QToolButton</extends>
+   <header>qgsdatadefinedbutton.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/src/ui/symbollayer/widget_svgmarker.ui
+++ b/src/ui/symbollayer/widget_svgmarker.ui
@@ -398,7 +398,7 @@
      <item row="1" column="0">
       <widget class="QLabel" name="label_3">
        <property name="text">
-        <string>Angle</string>
+        <string>Rotation</string>
        </property>
       </widget>
      </item>
@@ -505,11 +505,6 @@
    <container>1</container>
   </customwidget>
   <customwidget>
-   <class>QgsDataDefinedButton</class>
-   <extends>QToolButton</extends>
-   <header>qgsdatadefinedbutton.h</header>
-  </customwidget>
-  <customwidget>
    <class>QgsDoubleSpinBox</class>
    <extends>QDoubleSpinBox</extends>
    <header>qgsdoublespinbox.h</header>
@@ -519,6 +514,11 @@
    <extends>QWidget</extends>
    <header>qgsunitselectionwidget.h</header>
    <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsDataDefinedButton</class>
+   <extends>QToolButton</extends>
+   <header>qgsdatadefinedbutton.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>


### PR DESCRIPTION
Fixes http://hub.qgis.org/issues/14053, using Outline and Rotation where Border and Angle are used
