### PR TITLE
[symbology] add a filled cross simple marker

### DIFF
--- a/python/core/symbology-ng/qgsmarkersymbollayerv2.sip
+++ b/python/core/symbology-ng/qgsmarkersymbollayerv2.sip
@@ -8,8 +8,8 @@ class QgsSimpleMarkerSymbolLayerV2 : QgsMarkerSymbolLayerV2
 
     /** Constructor for QgsSimpleMarkerSymbolLayerV2.
     * @param name symbol name, should be one of "square", "rectangle", "diamond",
-    * "pentagon", "triangle", "equilateral_triangle", "star", "arrow",
-    * "circle", "cross", "cross2", "line", "x", "arrowhead", "filled_arrowhead",
+    * "pentagon", "hexagon", "triangle", "equilateral_triangle", "star", "arrow",
+    * "circle", "cross", "cross_fill", "cross2", "line", "x", "arrowhead", "filled_arrowhead",
     * "semi_circle", "third_circle", "quarter_circle", "quarter_square", "half_square",
     * "diagonal_half_square", "right_half_triangle", "left_half_triangle"
     * @param color fill color for symbol

--- a/src/core/symbology-ng/qgsellipsesymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgsellipsesymbollayerv2.cpp
@@ -379,6 +379,9 @@ QgsEllipseSymbolLayerV2* QgsEllipseSymbolLayerV2::clone() const
   m->setSymbolHeightMapUnitScale( mSymbolHeightMapUnitScale );
   m->setOutlineWidthUnit( mOutlineWidthUnit );
   m->setOutlineWidthMapUnitScale( mOutlineWidthMapUnitScale );
+  m->setAngle( mAngle );
+  m->setHorizontalAnchorPoint( mHorizontalAnchorPoint );
+  m->setVerticalAnchorPoint( mVerticalAnchorPoint );
 
   copyDataDefinedProperties( m );
   copyPaintEffect( m );

--- a/src/core/symbology-ng/qgsmarkersymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgsmarkersymbollayerv2.cpp
@@ -372,6 +372,12 @@ bool QgsSimpleMarkerSymbolLayerV2::prepareShape( const QString& name, QPolygonF 
     << QPointF( 0, -1 );
     return true;
   }
+  else if ( name == "hexagon" )
+  {
+    polygon << QPointF( -1, 0.5 ) << QPointF( 0, 1 ) << QPointF( 1, 0.5 )
+    << QPointF( 1, -0.5 ) << QPointF( 0, -1 ) << QPointF( -1, -0.5 );
+    return true;
+  }
   else if ( name == "triangle" )
   {
     polygon << QPointF( -1, 1 ) << QPointF( 1, 1 ) << QPointF( 0, -1 );
@@ -467,6 +473,23 @@ bool QgsSimpleMarkerSymbolLayerV2::preparePath( QString name )
     mPath.lineTo( 1, 0 ); // horizontal
     mPath.moveTo( 0, -1 );
     mPath.lineTo( 0, 1 ); // vertical
+    return true;
+  }
+  else if ( name == "cross_fill" )
+  {
+    mPath.moveTo( -1, -0.2 );
+    mPath.lineTo( -1, 0.2 );
+    mPath.lineTo( -0.2, 0.2 );
+    mPath.lineTo( -0.2, 1 );
+    mPath.lineTo( 0.2, 1 );
+    mPath.lineTo( 0.2, 0.2 );
+    mPath.lineTo( 1, 0.2 );
+    mPath.lineTo( 1, -0.2 );
+    mPath.lineTo( 0.2, -0.2 );
+    mPath.lineTo( 0.2, -1 );
+    mPath.lineTo( -0.2, -1 );
+    mPath.lineTo( -0.2, -0.2 );
+    mPath.lineTo( -1, -0.2 );
     return true;
   }
   else if ( name == "x" || name == "cross2" )

--- a/src/core/symbology-ng/qgsmarkersymbollayerv2.h
+++ b/src/core/symbology-ng/qgsmarkersymbollayerv2.h
@@ -38,8 +38,8 @@ class CORE_EXPORT QgsSimpleMarkerSymbolLayerV2 : public QgsMarkerSymbolLayerV2
 
     /** Constructor for QgsSimpleMarkerSymbolLayerV2.
     * @param name symbol name, should be one of "square", "rectangle", "diamond",
-    * "pentagon", "triangle", "equilateral_triangle", "star", "arrow",
-    * "circle", "cross", "cross2", "line", "x", "arrowhead", "filled_arrowhead",
+    * "pentagon", "hexagon", "triangle", "equilateral_triangle", "star", "arrow",
+    * "circle", "cross", "cross_fill", "cross2", "line", "x", "arrowhead", "filled_arrowhead",
     * "semi_circle", "third_circle", "quarter_circle", "quarter_square", "half_square",
     * "diagonal_half_square", "right_half_triangle", "left_half_triangle"
     * @param color fill color for symbol

--- a/src/gui/symbology-ng/qgssymbollayerv2widget.cpp
+++ b/src/gui/symbology-ng/qgssymbollayerv2widget.cpp
@@ -440,8 +440,8 @@ QgsSimpleMarkerSymbolLayerV2Widget::QgsSimpleMarkerSymbolLayerV2Widget( const Qg
 
   QSize size = lstNames->iconSize();
   QStringList names;
-  names << "circle" << "rectangle" << "diamond" << "pentagon" << "cross" << "cross2" << "triangle" << "equilateral_triangle" << "star"
-  << "arrow" << "line" << "arrowhead" << "filled_arrowhead" << "semi_circle" << "third_circle" << "quarter_circle"
+  names << "circle" << "rectangle" << "diamond" << "pentagon" << "hexagon" << "cross" << "cross_fill" << "triangle" << "equilateral_triangle"
+  << "star" << "arrow" << "line" << "arrowhead" << "cross2" << "filled_arrowhead" << "semi_circle" << "third_circle" << "quarter_circle"
   << "quarter_square" << "half_square" << "diagonal_half_square" << "right_half_triangle" << "left_half_triangle";
   double markerSize = DEFAULT_POINT_SIZE * 2;
   Q_FOREACH ( const QString& name, names )
@@ -540,10 +540,10 @@ void QgsSimpleMarkerSymbolLayerV2Widget::setSymbolLayer( QgsSymbolLayerV2* layer
   mVerticalAnchorComboBox->blockSignals( false );
 
   registerDataDefinedButton( mNameDDBtn, "name", QgsDataDefinedButton::String, tr( "string " ) + QLatin1String( "[<b>square</b>|<b>rectangle</b>|<b>diamond</b>|"
-                             "<b>pentagon</b>|<b>triangle</b>|<b>equilateral_triangle</b>|"
+                             "<b>pentagon</b>|<b>hexagon</b>|<b>triangle</b>|<b>equilateral_triangle</b>|"
                              "<b>star</b>|<b>arrow</b>|<b>filled_arrowhead</b>|"
-                             "<b>circle</b>|<b>cross</b>|<b>x</b>|"
-                             "<b>cross2</b>|<b>line</b>|<b>arrowhead</b>|<b>semi_circle</b>|<b>third_circle</b>|<b>quarter_circle</b>|"
+                             "<b>circle</b>|<b>cross</b>|<b>cross_fill</b>|<b>x</b>|"
+                             "<b>line</b>|<b>arrowhead</b>|<b>cross2</b>|<b>semi_circle</b>|<b>third_circle</b>|<b>quarter_circle</b>|"
                              "<b>quarter_square</b>|<b>half_square</b>|<b>diagonal_half_square</b>|<b>right_half_triangle</b>|<b>left_half_triangle</b>]" ) );
   registerDataDefinedButton( mFillColorDDBtn, "color", QgsDataDefinedButton::String, QgsDataDefinedButton::colorAlphaDesc() );
   registerDataDefinedButton( mBorderColorDDBtn, "color_border", QgsDataDefinedButton::String, QgsDataDefinedButton::colorAlphaDesc() );


### PR DESCRIPTION
A picture is worth a thousand words:
![untitled](https://cloud.githubusercontent.com/assets/1728657/14453931/df43e688-00c1-11e6-8596-56665efe04a6.png)

Until now, to be able to have a filled cross marker symbol, users had to rely on two cross layers on top of one another. This makes a quite frequently used symbol much simpler to create.

@nyalldawson whenever you have a minute. Cheers. 
