### PR TITLE
[symbology] add diamond ellipse marker

### DIFF
--- a/src/core/symbology-ng/qgsellipsesymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgsellipsesymbollayerv2.cpp
@@ -367,6 +367,8 @@ QgsEllipseSymbolLayerV2* QgsEllipseSymbolLayerV2::clone() const
   m->setSymbolWidth( mSymbolWidth );
   m->setSymbolHeight( mSymbolHeight );
   m->setOutlineStyle( mOutlineStyle );
+  m->setOffset( mOffset );
+  m->setOffsetUnit( mOffsetUnit );
   m->setOffsetMapUnitScale( mOffsetMapUnitScale );
   m->setOutlineStyle( mOutlineStyle );
   m->setPenJoinStyle( mPenJoinStyle );

--- a/src/core/symbology-ng/qgsellipsesymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgsellipsesymbollayerv2.cpp
@@ -597,6 +597,14 @@ void QgsEllipseSymbolLayerV2::preparePath( const QString& symbolName, QgsSymbolV
   {
     mPainterPath.addRect( QRectF( -size.width() / 2.0, -size.height() / 2.0, size.width(), size.height() ) );
   }
+  else if ( symbolName == "diamond" )
+  {
+    mPainterPath.moveTo( -size.width() / 2.0, 0 );
+    mPainterPath.lineTo( 0, size.height() / 2.0 );
+    mPainterPath.lineTo( size.width() / 2.0, 0 );
+    mPainterPath.lineTo( 0, -size.height() / 2.0 );
+    mPainterPath.lineTo( -size.width() / 2.0, 0 );
+  }
   else if ( symbolName == "cross" )
   {
     mPainterPath.moveTo( 0, -size.height() / 2.0 );

--- a/src/gui/qgsdatadefinedbutton.cpp
+++ b/src/gui/qgsdatadefinedbutton.cpp
@@ -896,7 +896,7 @@ QString QgsDataDefinedButton::fillStyleDesc()
 
 QString QgsDataDefinedButton::markerStyleDesc()
 {
-  return trString() + QLatin1String( "[<b>circle</b>|<b>rectangle</b>|<b>cross</b>|<b>triangle"
+  return trString() + QLatin1String( "[<b>circle</b>|<b>rectangle</b>|<b>diamond</b>|<b>cross</b>|<b>triangle"
                                      "</b>|<b>right_half_triangle</b>|<b>left_half_triangle</b>|<b>semi_circle</b>]" );
 }
 

--- a/src/gui/symbology-ng/qgsellipsesymbollayerv2widget.cpp
+++ b/src/gui/symbology-ng/qgsellipsesymbollayerv2widget.cpp
@@ -46,7 +46,7 @@ QgsEllipseSymbolLayerV2Widget::QgsEllipseSymbolLayerV2Widget( const QgsVectorLay
   mRotationSpinBox->setClearValue( 0.0 );
 
   QStringList names;
-  names << "circle" << "rectangle" << "cross" << "triangle" << "right_half_triangle" << "left_half_triangle" << "semi_circle";
+  names << "circle" << "rectangle" << "diamond" << "cross" << "triangle" << "right_half_triangle" << "left_half_triangle" << "semi_circle";
   QSize iconSize = mShapeListWidget->iconSize();
 
   Q_FOREACH ( const QString& name, names )


### PR DESCRIPTION
This PR adds a missing-in-action ellipse marker so far: the diamond. It's a basic shape that's useful to have and can't be replicated by rotating other shapes.

This opens the door to some cool symbols when paired with other shapes recently added, such as:
![diamond-ellipse](https://cloud.githubusercontent.com/assets/1728657/14492957/e893d2de-01ac-11e6-9b9a-438cdb383906.png)
_This little demo uses a field to color the cube symbol, and uses the darker() expression function to darken the diamond ellipse._

@nyalldawson , this cube symbol revealed one more issue with ellipse cloning: offset settings not being cloned. I've fixed the issue as a separate commit so you can backport to 2.14. It should be the last of such fix, hopefully :smile: 
