### PR TITLE
[postgres] Avoid deadlocks in transactional editing

### DIFF
--- a/src/providers/postgres/qgspostgresfeatureiterator.h
+++ b/src/providers/postgres/qgspostgresfeatureiterator.h
@@ -126,6 +126,9 @@ class QgsPostgresFeatureIterator : public QgsAbstractFeatureIteratorFromSource<Q
 
     virtual bool prepareOrderBy( const QList<QgsFeatureRequest::OrderByClause> &orderBys ) override;
 
+    inline void lock();
+    inline void unlock();
+
     bool mExpressionCompiled;
     bool mOrderByCompiled;
     bool mLastFetch;


### PR DESCRIPTION
Can currently be triggered by using the field calculator to update a selection.
While an iterator is active and the connection is locked, an update statement
waits unsuccessfully for the same (locked) connection.

This commit only locks the connection while an iterator is actually fetching
data and not for its entire lifetime.
