### PR TITLE
Add methods to set a datetime for QgsMapSettings and QgsMapCanvas

### DIFF
--- a/python/core/qgsmapsettings.sip
+++ b/python/core/qgsmapsettings.sip
@@ -119,6 +119,22 @@ class QgsMapSettings
     //! Return the calculated scale of the map
     double scale() const;
 
+    /** Sets the current map date and time. This property can be used for maps which alter their appearance
+     * based on a time attribute, such as animated maps.
+     * @param datetime date time property for rendered map
+     * @see dateTime()
+     * @note added in QGIS 2.16
+     */
+    void setDateTime( const QDateTime& datetime );
+
+    /** Returns the current map date and time. This property can be used for maps which alter their appearance
+     * based on a time attribute, such as animated maps.
+     * @returns date time property for rendered map, or an invalid date time if unset
+     * @see setDateTime()
+     * @note added in QGIS 2.16
+     */
+    QDateTime dateTime() const;
+
     /** Sets the expression context. This context is used for all expression evaluation
      * associated with this map settings.
      * @see expressionContext()

--- a/python/core/qgsmapsettings.sip
+++ b/python/core/qgsmapsettings.sip
@@ -119,21 +119,24 @@ class QgsMapSettings
     //! Return the calculated scale of the map
     double scale() const;
 
-    /** Sets the current map date and time. This property can be used for maps which alter their appearance
-     * based on a time attribute, such as animated maps.
-     * @param datetime date time property for rendered map
-     * @see dateTime()
+    /** Sets the current map time value. This time value property can be used for maps which alter their appearance
+     * based on a time attribute, such as animated maps. When set, the property is available via the
+     * \@map_timevalue expression variable.
+     * @param timeValue time value property for rendered map. This can be a date time value (QDateTime), or
+     * any arbitrary value storable in a QVariant.
+     * @see timeValue()
      * @note added in QGIS 2.16
      */
-    void setDateTime( const QDateTime& datetime );
+    void setTimeValue( const QVariant& timeValue );
 
-    /** Returns the current map date and time. This property can be used for maps which alter their appearance
-     * based on a time attribute, such as animated maps.
-     * @returns date time property for rendered map, or an invalid date time if unset
-     * @see setDateTime()
+    /** Returns the current map time value. This time value property can be used for maps which alter their appearance
+     * based on a time attribute, such as animated maps. When set, the property is available via the
+     * \@map_timevalue expression variable.
+     * @returns time value property for rendered map, or an invalid QVariant if unset.
+     * @see setTimeValue()
      * @note added in QGIS 2.16
      */
-    QDateTime dateTime() const;
+    QVariant timeValue() const;
 
     /** Sets the expression context. This context is used for all expression evaluation
      * associated with this map settings.

--- a/python/gui/qgsmapcanvas.sip
+++ b/python/gui/qgsmapcanvas.sip
@@ -148,6 +148,24 @@ class QgsMapCanvas : QGraphicsView
     //! @note added in 2.8
     void setRotation( double degrees );
 
+    /** Sets the current canvas date and time. This property can be used for maps which alter their appearance
+     * based on a time attribute, such as animated maps. When set, the property is available via the
+     * \@map_datetime expression variable.
+     * @param datetime date time property for canvas
+     * @see dateTime()
+     * @note added in QGIS 2.16
+     */
+    void setDateTime( const QDateTime& datetime );
+
+    /** Returns the current canvas date and time. This property can be used for maps which alter their appearance
+     * based on a time attribute, such as animated maps. When set, the property is available via the
+     * \@map_datetime expression variable.
+     * @returns date time property for canvas, or an invalid date time if unset
+     * @see setDateTime()
+     * @note added in QGIS 2.16
+     */
+    QDateTime dateTime() const;
+
     //! Set the center of the map canvas, in geographical coordinates
     //! @note added in 2.8
     void setCenter( const QgsPoint& center );

--- a/python/gui/qgsmapcanvas.sip
+++ b/python/gui/qgsmapcanvas.sip
@@ -148,23 +148,24 @@ class QgsMapCanvas : QGraphicsView
     //! @note added in 2.8
     void setRotation( double degrees );
 
-    /** Sets the current canvas date and time. This property can be used for maps which alter their appearance
+    /** Sets the current canvas time value. This time value property can be used for maps which alter their appearance
      * based on a time attribute, such as animated maps. When set, the property is available via the
-     * \@map_datetime expression variable.
-     * @param datetime date time property for canvas
-     * @see dateTime()
+     * \@map_timevalue expression variable.
+     * @param timeValue time value property for canvas. This can be a date time value (QDateTime), or
+     * any arbitrary value storable in a QVariant.
+     * @see timeValue()
      * @note added in QGIS 2.16
      */
-    void setDateTime( const QDateTime& datetime );
+    void setTimeValue( const QVariant& timeValue );
 
-    /** Returns the current canvas date and time. This property can be used for maps which alter their appearance
+    /** Returns the current canvas time value. This time value property can be used for maps which alter their appearance
      * based on a time attribute, such as animated maps. When set, the property is available via the
-     * \@map_datetime expression variable.
-     * @returns date time property for canvas, or an invalid date time if unset
-     * @see setDateTime()
+     * \@map_timevalue expression variable.
+     * @returns time value property for canvas, or an invalid QVariant if unset.
+     * @see setTimeValue()
      * @note added in QGIS 2.16
      */
-    QDateTime dateTime() const;
+    QVariant timeValue() const;
 
     //! Set the center of the map canvas, in geographical coordinates
     //! @note added in 2.8

--- a/src/core/composer/qgscomposermap.cpp
+++ b/src/core/composer/qgscomposermap.cpp
@@ -2160,7 +2160,7 @@ QgsExpressionContext* QgsComposerMap::createExpressionContext() const
   delete centerPoint;
 
   // NOTE: when QgsComposition::mapSettings is removed this value should be taken from a composition/layout context object
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( "map_datetime", mComposition->mapSettings().dateTime(), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( "map_timevalue", mComposition->mapSettings().timeValue(), true ) );
 
   context->appendScope( scope );
 

--- a/src/core/composer/qgscomposermap.cpp
+++ b/src/core/composer/qgscomposermap.cpp
@@ -2159,6 +2159,9 @@ QgsExpressionContext* QgsComposerMap::createExpressionContext() const
   scope->addVariable( QgsExpressionContextScope::StaticVariable( "map_extent_center", QVariant::fromValue( *centerPoint ), true ) );
   delete centerPoint;
 
+  // NOTE: when QgsComposition::mapSettings is removed this value should be taken from a composition/layout context object
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( "map_datetime", mComposition->mapSettings().dateTime(), true ) );
+
   context->appendScope( scope );
 
   return context;

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -4593,6 +4593,8 @@ void QgsExpression::initVariableHelp()
   gVariableHelpTexts.insert( "map_extent_center", QCoreApplication::translate( "variable_help", "Center of map." ) );
   gVariableHelpTexts.insert( "map_extent_width", QCoreApplication::translate( "variable_help", "Width of map." ) );
   gVariableHelpTexts.insert( "map_extent_height", QCoreApplication::translate( "variable_help", "Height of map." ) );
+  gVariableHelpTexts.insert( "map_datetime", QCoreApplication::translate( "variable_help", "Returns the current map date and time. This variable can be used for maps which alter their appearance"
+                             " based on a time attribute, such as animated maps." ) );
 
   gVariableHelpTexts.insert( "row_number", QCoreApplication::translate( "variable_help", "Stores the number of the current row." ) );
   gVariableHelpTexts.insert( "grid_number", QCoreApplication::translate( "variable_help", "Current grid annotation value." ) );

--- a/src/core/qgsexpressioncontext.cpp
+++ b/src/core/qgsexpressioncontext.cpp
@@ -727,6 +727,7 @@ QgsExpressionContextScope* QgsExpressionContextUtils::mapSettingsScope( const Qg
   QgsGeometry* centerPoint = QgsGeometry::fromPoint( mapSettings.visibleExtent().center() );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( "map_extent_center", QVariant::fromValue( *centerPoint ), true ) );
   delete centerPoint;
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( "map_datetime", mapSettings.dateTime(), true ) );
 
   return scope;
 }

--- a/src/core/qgsexpressioncontext.cpp
+++ b/src/core/qgsexpressioncontext.cpp
@@ -727,7 +727,7 @@ QgsExpressionContextScope* QgsExpressionContextUtils::mapSettingsScope( const Qg
   QgsGeometry* centerPoint = QgsGeometry::fromPoint( mapSettings.visibleExtent().center() );
   scope->addVariable( QgsExpressionContextScope::StaticVariable( "map_extent_center", QVariant::fromValue( *centerPoint ), true ) );
   delete centerPoint;
-  scope->addVariable( QgsExpressionContextScope::StaticVariable( "map_datetime", mapSettings.dateTime(), true ) );
+  scope->addVariable( QgsExpressionContextScope::StaticVariable( "map_timevalue", mapSettings.timeValue(), true ) );
 
   return scope;
 }

--- a/src/core/qgsmapsettings.h
+++ b/src/core/qgsmapsettings.h
@@ -20,6 +20,7 @@
 #include <QImage>
 #include <QSize>
 #include <QStringList>
+#include <QDateTime>
 
 #include "qgscoordinatereferencesystem.h"
 #include "qgsdatumtransformstore.h"
@@ -181,6 +182,24 @@ class CORE_EXPORT QgsMapSettings
      */
     const QgsExpressionContext& expressionContext() const { return mExpressionContext; }
 
+    /** Sets the current map date and time. This property can be used for maps which alter their appearance
+     * based on a time attribute, such as animated maps. When set, the property is available via the
+     * \@map_datetime expression variable.
+     * @param datetime date time property for rendered map
+     * @see dateTime()
+     * @note added in QGIS 2.16
+     */
+    void setDateTime( const QDateTime& datetime ) { mDateTime = datetime; }
+
+    /** Returns the current map date and time. This property can be used for maps which alter their appearance
+     * based on a time attribute, such as animated maps. When set, the property is available via the
+     * \@map_datetime expression variable.
+     * @returns date time property for rendered map, or an invalid date time if unset
+     * @see setDateTime()
+     * @note added in QGIS 2.16
+     */
+    QDateTime dateTime() const { return mDateTime; }
+
     // -- utility functions --
 
     //! @note not available in python bindings
@@ -261,6 +280,8 @@ class CORE_EXPORT QgsMapSettings
     QgsRectangle mExtent;
 
     double mRotation;
+
+    QDateTime mDateTime;
 
     QStringList mLayers;
     QMap<QString, QString> mLayerStyleOverrides;

--- a/src/core/qgsmapsettings.h
+++ b/src/core/qgsmapsettings.h
@@ -182,23 +182,24 @@ class CORE_EXPORT QgsMapSettings
      */
     const QgsExpressionContext& expressionContext() const { return mExpressionContext; }
 
-    /** Sets the current map date and time. This property can be used for maps which alter their appearance
+    /** Sets the current map time value. This time value property can be used for maps which alter their appearance
      * based on a time attribute, such as animated maps. When set, the property is available via the
-     * \@map_datetime expression variable.
-     * @param datetime date time property for rendered map
-     * @see dateTime()
+     * \@map_timevalue expression variable.
+     * @param timeValue time value property for rendered map. This can be a date time value (QDateTime), or
+     * any arbitrary value storable in a QVariant.
+     * @see timeValue()
      * @note added in QGIS 2.16
      */
-    void setDateTime( const QDateTime& datetime ) { mDateTime = datetime; }
+    void setTimeValue( const QVariant& timeValue ) { mTimeValue = timeValue; }
 
-    /** Returns the current map date and time. This property can be used for maps which alter their appearance
+    /** Returns the current map time value. This time value property can be used for maps which alter their appearance
      * based on a time attribute, such as animated maps. When set, the property is available via the
-     * \@map_datetime expression variable.
-     * @returns date time property for rendered map, or an invalid date time if unset
-     * @see setDateTime()
+     * \@map_timevalue expression variable.
+     * @returns time value property for rendered map, or an invalid QVariant if unset.
+     * @see setTimeValue()
      * @note added in QGIS 2.16
      */
-    QDateTime dateTime() const { return mDateTime; }
+    QVariant timeValue() const { return mTimeValue; }
 
     // -- utility functions --
 
@@ -281,7 +282,7 @@ class CORE_EXPORT QgsMapSettings
 
     double mRotation;
 
-    QDateTime mDateTime;
+    QVariant mTimeValue;
 
     QStringList mLayers;
     QMap<QString, QString> mLayerStyleOverrides;

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -958,8 +958,17 @@ void QgsMapCanvas::setRotation( double degrees )
   // notify canvas items of change (needed?)
   updateCanvasItemPositions();
 
-} // setRotation
+}
 
+void QgsMapCanvas::setDateTime( const QDateTime &datetime )
+{
+  mSettings.setDateTime( datetime );
+}
+
+QDateTime QgsMapCanvas::dateTime() const
+{
+  return mSettings.dateTime();
+}
 
 void QgsMapCanvas::updateScale()
 {

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -960,14 +960,14 @@ void QgsMapCanvas::setRotation( double degrees )
 
 }
 
-void QgsMapCanvas::setDateTime( const QDateTime &datetime )
+void QgsMapCanvas::setTimeValue( const QVariant& timeValue )
 {
-  mSettings.setDateTime( datetime );
+  mSettings.setTimeValue( timeValue );
 }
 
-QDateTime QgsMapCanvas::dateTime() const
+QVariant QgsMapCanvas::timeValue() const
 {
-  return mSettings.dateTime();
+  return mSettings.timeValue();
 }
 
 void QgsMapCanvas::updateScale()

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -214,6 +214,24 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     //! @note added in 2.8
     void setRotation( double degrees );
 
+    /** Sets the current canvas date and time. This property can be used for maps which alter their appearance
+     * based on a time attribute, such as animated maps. When set, the property is available via the
+     * \@map_datetime expression variable.
+     * @param datetime date time property for canvas
+     * @see dateTime()
+     * @note added in QGIS 2.16
+     */
+    void setDateTime( const QDateTime& datetime );
+
+    /** Returns the current canvas date and time. This property can be used for maps which alter their appearance
+     * based on a time attribute, such as animated maps. When set, the property is available via the
+     * \@map_datetime expression variable.
+     * @returns date time property for canvas, or an invalid date time if unset
+     * @see setDateTime()
+     * @note added in QGIS 2.16
+     */
+    QDateTime dateTime() const;
+
     //! Set the center of the map canvas, in geographical coordinates
     //! @note added in 2.8
     void setCenter( const QgsPoint& center );

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -214,23 +214,24 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     //! @note added in 2.8
     void setRotation( double degrees );
 
-    /** Sets the current canvas date and time. This property can be used for maps which alter their appearance
+    /** Sets the current canvas time value. This time value property can be used for maps which alter their appearance
      * based on a time attribute, such as animated maps. When set, the property is available via the
-     * \@map_datetime expression variable.
-     * @param datetime date time property for canvas
-     * @see dateTime()
+     * \@map_timevalue expression variable.
+     * @param timeValue time value property for canvas. This can be a date time value (QDateTime), or
+     * any arbitrary value storable in a QVariant.
+     * @see timeValue()
      * @note added in QGIS 2.16
      */
-    void setDateTime( const QDateTime& datetime );
+    void setTimeValue( const QVariant& timeValue );
 
-    /** Returns the current canvas date and time. This property can be used for maps which alter their appearance
+    /** Returns the current canvas time value. This time value property can be used for maps which alter their appearance
      * based on a time attribute, such as animated maps. When set, the property is available via the
-     * \@map_datetime expression variable.
-     * @returns date time property for canvas, or an invalid date time if unset
-     * @see setDateTime()
+     * \@map_timevalue expression variable.
+     * @returns time value property for canvas, or an invalid QVariant if unset.
+     * @see setTimeValue()
      * @note added in QGIS 2.16
      */
-    QDateTime dateTime() const;
+    QVariant timeValue() const;
 
     //! Set the center of the map canvas, in geographical coordinates
     //! @note added in 2.8

--- a/tests/src/core/testqgsexpressioncontext.cpp
+++ b/tests/src/core/testqgsexpressioncontext.cpp
@@ -630,7 +630,7 @@ void TestQgsExpressionContext::mapSettingsScope()
   ms.setRotation( 45 );
   ms.setExtent( QgsRectangle( 0, 500, 1000, 2000 ) );
   ms.setOutputSize( QSize( 10000, 20000 ) );
-  ms.setDateTime( QDateTime( QDate( 1984, 04, 05 ), QTime( 14, 15, 16 ) ) );
+  ms.setTimeValue( QDateTime( QDate( 1984, 04, 05 ), QTime( 14, 15, 16 ) ) );
 
   QScopedPointer<QgsExpressionContextScope> scope( QgsExpressionContextUtils::mapSettingsScope( ms ) );
   QCOMPARE( scope->variable( "map_id" ).toString(), QString( "canvas" ) );
@@ -642,7 +642,7 @@ void TestQgsExpressionContext::mapSettingsScope()
   QgsGeometry center = scope->variable( "map_extent_center" ).value<QgsGeometry>();
   QCOMPARE( center.asQPointF().toPoint(), QPoint( 500, 1250 ) );
 
-  QCOMPARE( scope->variable( "map_datetime" ).toDateTime(), QDateTime( QDate( 1984, 04, 05 ), QTime( 14, 15, 16 ) ) );
+  QCOMPARE( scope->variable( "map_timevalue" ).toDateTime(), QDateTime( QDate( 1984, 04, 05 ), QTime( 14, 15, 16 ) ) );
 }
 
 void TestQgsExpressionContext::featureBasedContext()

--- a/tests/src/core/testqgsexpressioncontext.cpp
+++ b/tests/src/core/testqgsexpressioncontext.cpp
@@ -21,6 +21,7 @@
 #include "qgsapplication.h"
 #include "qgsproject.h"
 #include "qgscolorscheme.h"
+#include "qgsgeometry.h"
 #include <QObject>
 #include <QtTest/QtTest>
 
@@ -46,6 +47,7 @@ class TestQgsExpressionContext : public QObject
     void globalScope();
     void projectScope();
     void layerScope();
+    void mapSettingsScope();
     void featureBasedContext();
 
   private:
@@ -620,6 +622,27 @@ void TestQgsExpressionContext::layerScope()
   QCOMPARE( layerScope->variable( "var1" ).toString(), QString( "val1" ) );
   QCOMPARE( layerScope->variable( "var2" ).toString(), QString( "val2" ) );
   delete layerScope;
+}
+
+void TestQgsExpressionContext::mapSettingsScope()
+{
+  QgsMapSettings ms;
+  ms.setRotation( 45 );
+  ms.setExtent( QgsRectangle( 0, 500, 1000, 2000 ) );
+  ms.setOutputSize( QSize( 10000, 20000 ) );
+  ms.setDateTime( QDateTime( QDate( 1984, 04, 05 ), QTime( 14, 15, 16 ) ) );
+
+  QScopedPointer<QgsExpressionContextScope> scope( QgsExpressionContextUtils::mapSettingsScope( ms ) );
+  QCOMPARE( scope->variable( "map_id" ).toString(), QString( "canvas" ) );
+  QCOMPARE( scope->variable( "map_rotation" ).toInt(), 45 );
+  QCOMPARE( qRound( scope->variable( "map_scale" ).toDouble() / 100 ), qRound( ms.scale() / 100.0 ) );
+  QCOMPARE( scope->variable( "map_extent_width" ).toInt(), 1000 );
+  QCOMPARE( scope->variable( "map_extent_height" ).toInt(), 1500 );
+
+  QgsGeometry center = scope->variable( "map_extent_center" ).value<QgsGeometry>();
+  QCOMPARE( center.asQPointF().toPoint(), QPoint( 500, 1250 ) );
+
+  QCOMPARE( scope->variable( "map_datetime" ).toDateTime(), QDateTime( QDate( 1984, 04, 05 ), QTime( 14, 15, 16 ) ) );
 }
 
 void TestQgsExpressionContext::featureBasedContext()

--- a/tests/src/core/testqgsmapsettings.cpp
+++ b/tests/src/core/testqgsmapsettings.cpp
@@ -32,6 +32,8 @@ class TestQgsMapSettings: public QObject
     void visibleExtent();
     void mapUnitsPerPixel();
     void visiblePolygon();
+    void dateTime();
+
   private:
     QString toString( const QPolygonF& p, int decimalPlaces = 2 ) const;
 };
@@ -144,6 +146,18 @@ void TestQgsMapSettings::visiblePolygon()
   ms.setRotation( -45 );
   QCOMPARE( toString( ms.visiblePolygon() ),
             QString( "32.32 28.03,103.03 -42.67,67.67 -78.03,-3.03 -7.32" ) );
+}
+
+void TestQgsMapSettings::dateTime()
+{
+  QgsMapSettings ms;
+  //default should be no datetime set
+  QVERIFY( !ms.dateTime().isValid() );
+  ms.setDateTime( QDateTime( QDate( 2011, 10, 30 ), QTime( 13, 1, 14 ) ) );
+  QCOMPARE( ms.dateTime(), QDateTime( QDate( 2011, 10, 30 ), QTime( 13, 1, 14 ) ) );
+  //clear date time
+  ms.setDateTime( QDateTime() ) ;
+  QVERIFY( !ms.dateTime().isValid() );
 }
 
 QTEST_MAIN( TestQgsMapSettings )

--- a/tests/src/core/testqgsmapsettings.cpp
+++ b/tests/src/core/testqgsmapsettings.cpp
@@ -32,7 +32,7 @@ class TestQgsMapSettings: public QObject
     void visibleExtent();
     void mapUnitsPerPixel();
     void visiblePolygon();
-    void dateTime();
+    void timeValue();
 
   private:
     QString toString( const QPolygonF& p, int decimalPlaces = 2 ) const;
@@ -148,16 +148,16 @@ void TestQgsMapSettings::visiblePolygon()
             QString( "32.32 28.03,103.03 -42.67,67.67 -78.03,-3.03 -7.32" ) );
 }
 
-void TestQgsMapSettings::dateTime()
+void TestQgsMapSettings::timeValue()
 {
   QgsMapSettings ms;
   //default should be no datetime set
-  QVERIFY( !ms.dateTime().isValid() );
-  ms.setDateTime( QDateTime( QDate( 2011, 10, 30 ), QTime( 13, 1, 14 ) ) );
-  QCOMPARE( ms.dateTime(), QDateTime( QDate( 2011, 10, 30 ), QTime( 13, 1, 14 ) ) );
+  QVERIFY( !ms.timeValue().isValid() );
+  ms.setTimeValue( QDateTime( QDate( 2011, 10, 30 ), QTime( 13, 1, 14 ) ) );
+  QCOMPARE( ms.timeValue().toDateTime(), QDateTime( QDate( 2011, 10, 30 ), QTime( 13, 1, 14 ) ) );
   //clear date time
-  ms.setDateTime( QDateTime() ) ;
-  QVERIFY( !ms.dateTime().isValid() );
+  ms.setTimeValue( QVariant() ) ;
+  QVERIFY( !ms.timeValue().isValid() );
 }
 
 QTEST_MAIN( TestQgsMapSettings )

--- a/tests/src/gui/testqgsmapcanvas.cpp
+++ b/tests/src/gui/testqgsmapcanvas.cpp
@@ -43,6 +43,7 @@ class TestQgsMapCanvas : public QObject
 
     void testMapRendererInteraction();
     void testPanByKeyboard();
+    void datetime();
 
   private:
     QgsMapCanvas* mCanvas;
@@ -152,6 +153,21 @@ void TestQgsMapCanvas::testPanByKeyboard()
     }
     QVERIFY( mCanvas->extent() == originalExtent );
   }
+}
+
+void TestQgsMapCanvas::datetime()
+{
+  //default should be no datetime set (also check canvas' mapsettings)
+  QVERIFY( !mCanvas->dateTime().isValid() );
+  QVERIFY( !mCanvas->mapSettings().dateTime().isValid() );
+  mCanvas->setDateTime( QDateTime( QDate( 2011, 10, 30 ), QTime( 13, 1, 14 ) ) );
+  QCOMPARE( mCanvas->dateTime(), QDateTime( QDate( 2011, 10, 30 ), QTime( 13, 1, 14 ) ) );
+  //check that datetime has been correctly set in mapsettings
+  QCOMPARE( mCanvas->mapSettings().dateTime(), QDateTime( QDate( 2011, 10, 30 ), QTime( 13, 1, 14 ) ) );
+  //clear date time
+  mCanvas->setDateTime( QDateTime() ) ;
+  QVERIFY( !mCanvas->dateTime().isValid() );
+  QVERIFY( !mCanvas->mapSettings().dateTime().isValid() );
 }
 
 

--- a/tests/src/gui/testqgsmapcanvas.cpp
+++ b/tests/src/gui/testqgsmapcanvas.cpp
@@ -43,7 +43,7 @@ class TestQgsMapCanvas : public QObject
 
     void testMapRendererInteraction();
     void testPanByKeyboard();
-    void datetime();
+    void timeValue();
 
   private:
     QgsMapCanvas* mCanvas;
@@ -155,19 +155,19 @@ void TestQgsMapCanvas::testPanByKeyboard()
   }
 }
 
-void TestQgsMapCanvas::datetime()
+void TestQgsMapCanvas::timeValue()
 {
-  //default should be no datetime set (also check canvas' mapsettings)
-  QVERIFY( !mCanvas->dateTime().isValid() );
-  QVERIFY( !mCanvas->mapSettings().dateTime().isValid() );
-  mCanvas->setDateTime( QDateTime( QDate( 2011, 10, 30 ), QTime( 13, 1, 14 ) ) );
-  QCOMPARE( mCanvas->dateTime(), QDateTime( QDate( 2011, 10, 30 ), QTime( 13, 1, 14 ) ) );
+  //default should be no timevalue set (also check canvas' mapsettings)
+  QVERIFY( !mCanvas->timeValue().isValid() );
+  QVERIFY( !mCanvas->mapSettings().timeValue().isValid() );
+  mCanvas->setTimeValue( QDateTime( QDate( 2011, 10, 30 ), QTime( 13, 1, 14 ) ) );
+  QCOMPARE( mCanvas->timeValue().toDateTime(), QDateTime( QDate( 2011, 10, 30 ), QTime( 13, 1, 14 ) ) );
   //check that datetime has been correctly set in mapsettings
-  QCOMPARE( mCanvas->mapSettings().dateTime(), QDateTime( QDate( 2011, 10, 30 ), QTime( 13, 1, 14 ) ) );
+  QCOMPARE( mCanvas->mapSettings().timeValue().toDateTime(), QDateTime( QDate( 2011, 10, 30 ), QTime( 13, 1, 14 ) ) );
   //clear date time
-  mCanvas->setDateTime( QDateTime() ) ;
-  QVERIFY( !mCanvas->dateTime().isValid() );
-  QVERIFY( !mCanvas->mapSettings().dateTime().isValid() );
+  mCanvas->setTimeValue( QVariant() ) ;
+  QVERIFY( !mCanvas->timeValue().isValid() );
+  QVERIFY( !mCanvas->mapSettings().timeValue().isValid() );
 }
 
 


### PR DESCRIPTION
When set, the datetime will be accessible via the @map_datetime expression variable.

This is baby steps towards moving parts of Time Manager functionality to core. The intention is that Time Manager (and other animation/time based plugins) can call these methods to set the desired date and time for the the map render. Users can then use data defined styling to alter the appearance of symbols based on the @map_datetime variable (ie, as a generic replacement for Time Manager's animation_datetime() function). 

Note that this PR does not handle other features from Time Manager, such as filtering of features, etc. It just provides a standardised way of setting a map date time for styling.
