### PR TITLE
Disable old labelling on Qt5 travis builds

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -668,6 +668,11 @@ IF (UNIX AND NOT APPLE)
   SET (QGIS_MANUAL_DIR  ${CMAKE_INSTALL_PREFIX}/${QGIS_MANUAL_SUBDIR})
 ENDIF (UNIX AND NOT APPLE)
 
+SET (DISABLE_DEPRECATED ${ENABLE_QT5} CACHE BOOL "If set to true, it will disable deprecated functionality to prepare for the next generation of QGIS")
+IF (DISABLE_DEPRECATED)
+  ADD_DEFINITIONS(-DQGIS_DISABLE_DEPRECATED)
+ENDIF (DISABLE_DEPRECATED)
+
 
 #############################################################
 # Python build dependency

--- a/ci/travis/linux/qt5/install.sh
+++ b/ci/travis/linux/qt5/install.sh
@@ -35,6 +35,7 @@ cmake \
       -DWITH_SERVER=ON \
       -DENABLE_QT5=ON \
       -DENABLE_PYTHON3=ON \
+      -DDISABLE_DEPRECATED=ON \
       -DPORT_PLUGINS=ON \
       -DCXX_EXTRA_FLAGS="$CLANG_WARNINGS" \
       ..

--- a/ci/travis/linux/qt5/script.sh
+++ b/ci/travis/linux/qt5/script.sh
@@ -3,5 +3,5 @@ export CTEST_PARALLEL_LEVEL=1
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-xvfb-run ctest -V -E "$(cat ${DIR}/blacklist.txt | paste -sd '|' -)" -S ./qgis-test-travis.ctest --output-on-failure
-# xvfb-run ctest -V -S ./qgis-test-travis.ctest --output-on-failure
+# xvfb-run ctest -V -E "$(cat ${DIR}/blacklist.txt | paste -sd '|' -)" -S ./qgis-test-travis.ctest --output-on-failure
+xvfb-run ctest -V -S ./qgis-test-travis.ctest --output-on-failure

--- a/src/core/qgsmaprenderercustompainterjob.cpp
+++ b/src/core/qgsmaprenderercustompainterjob.cpp
@@ -293,9 +293,10 @@ void QgsMapRendererJob::drawLabeling( const QgsMapSettings& settings, QgsRenderC
   renderContext.setPainter( painter );
   renderContext.setLabelingEngine( labelingEngine );
 
+#if !defined(QGIS_DISABLE_DEPRECATED)
   // old labeling - to be removed at some point...
   drawOldLabeling( settings, renderContext );
-
+#endif
   drawNewLabeling( settings, renderContext, labelingEngine );
 
   if ( labelingEngine2 )


### PR DESCRIPTION
Adds a new cmake flag `DISABLE_DEPRECATED` which is used on the Qt5/Python3 builds to be one step closer to the next major version of QGIS.

It should also help to run some renderer tests which have been affected by a deadlock on the qt5/python3 CI.
