### PR TITLE
Rewrite pseudocolor render code to improve speed

### DIFF
--- a/python/core/raster/qgscolorrampshader.sip
+++ b/python/core/raster/qgscolorrampshader.sip
@@ -26,11 +26,12 @@ class QgsColorRampShader : QgsRasterShaderFunction
       bool operator<( const QgsColorRampShader::ColorRampItem& other ) const;
     };
 
+    /** Supported methods for color interpolation. */
     enum ColorRamp_TYPE
     {
-      INTERPOLATED,
-      DISCRETE,
-      EXACT
+      INTERPOLATED, //!< Interpolates the color between two class breaks linearly.
+      DISCRETE,     //!< Assigns the color of the higher class for every pixel between two class breaks.
+      EXACT         //!< Assigns the color of the exact matching value in the color ramp item list
     };
 
     /** \brief Get the custom colormap*/
@@ -42,7 +43,9 @@ class QgsColorRampShader : QgsRasterShaderFunction
     /** \brief Get the color ramp type as a string */
     QString colorRampTypeAsQString();
 
-    /** \brief Get the maximum size the color cache can be*/
+    /** \brief Get the maximum size the color cache can be
+     * @deprecated will be removed in QGIS 3.0. Color cache is not used anymore.
+     */
     int maximumColorCacheSize();
 
     /** \brief Set custom colormap */
@@ -54,7 +57,9 @@ class QgsColorRampShader : QgsRasterShaderFunction
     /** \brief Set the color ramp type*/
     void setColorRampType( const QString& theType );
 
-    /** \brief Set the maximum size the color cache can be */
+    /** \brief Set the maximum size the color cache can be
+     * @deprecated will be removed in QGIS 3.0. Color cache is not used anymore.
+     */
     void setMaximumColorCacheSize( int theSize );
 
     /** \brief Generates and new RGB value based on one input value */

--- a/src/core/raster/qgscolorrampshader.cpp
+++ b/src/core/raster/qgscolorrampshader.cpp
@@ -100,7 +100,7 @@ bool QgsColorRampShader::shade( double theValue, int* theReturnRedValue, int* th
       if ( rangeValue > 0 )
       {
         int lutSize = 256; // TODO: test if speed can be increased with a different LUT size
-        mLUTFactor = ( lutSize + 0.0000001 ) / rangeValue; // increase slightly to make sure last LUT category is correct
+        mLUTFactor = ( lutSize - 0.0000001 ) / rangeValue; // decrease slightly to make sure last LUT category is correct
         idx = 0;
         double val;
         mLUT.reserve( lutSize );

--- a/src/core/raster/qgscolorrampshader.cpp
+++ b/src/core/raster/qgscolorrampshader.cpp
@@ -52,7 +52,7 @@ QString QgsColorRampShader::colorRampTypeAsQString()
 
 void QgsColorRampShader::setColorRampItemList( const QList<QgsColorRampShader::ColorRampItem>& theList )
 {
-  mColorRampItemList = theList;
+  mColorRampItemList = theList.toVector();
   // Reset the look up table when the color ramp is changed
   mLUTInitialized = false;
   mLUT.clear();
@@ -236,7 +236,7 @@ bool QgsColorRampShader::shade( double theRedValue, double theGreenValue,
 
 void QgsColorRampShader::legendSymbologyItems( QList< QPair< QString, QColor > >& symbolItems ) const
 {
-  QList<QgsColorRampShader::ColorRampItem>::const_iterator colorRampIt = mColorRampItemList.constBegin();
+  QVector<QgsColorRampShader::ColorRampItem>::const_iterator colorRampIt = mColorRampItemList.constBegin();
   for ( ; colorRampIt != mColorRampItemList.constEnd(); ++colorRampIt )
   {
     symbolItems.push_back( qMakePair( colorRampIt->label, colorRampIt->color ) );

--- a/src/core/raster/qgscolorrampshader.h
+++ b/src/core/raster/qgscolorrampshader.h
@@ -130,7 +130,7 @@ class CORE_EXPORT QgsColorRampShader : public QgsRasterShaderFunction
     /** Maximum size of the color cache. The color cache could eat a ton of
      * memory if you have 32-bit data
      * @deprecated will be removed in QGIS 3.0 */
-    Q_DECL_DEPRECATED int mMaximumColorCacheSize;
+    int mMaximumColorCacheSize;
 
     /** Do not render values out of range */
     bool mClip;

--- a/src/core/raster/qgscolorrampshader.h
+++ b/src/core/raster/qgscolorrampshader.h
@@ -54,11 +54,12 @@ class CORE_EXPORT QgsColorRampShader : public QgsRasterShaderFunction
       bool operator<( const ColorRampItem& other ) const { return value < other.value; }
     };
 
+    /** Supported methods for color interpolation. */
     enum ColorRamp_TYPE
     {
-      INTERPOLATED,
-      DISCRETE,
-      EXACT
+      INTERPOLATED, //!< Interpolates the color between two class breaks linearly.
+      DISCRETE,     //!< Assigns the color of the higher class for every pixel between two class breaks.
+      EXACT         //!< Assigns the color of the exact matching value in the color ramp item list
     };
 
     /** \brief Get the custom colormap*/
@@ -70,8 +71,10 @@ class CORE_EXPORT QgsColorRampShader : public QgsRasterShaderFunction
     /** \brief Get the color ramp type as a string */
     QString colorRampTypeAsQString();
 
-    /** \brief Get the maximum size the color cache can be*/
-    int maximumColorCacheSize() { return mMaximumColorCacheSize; }
+    /** \brief Get the maximum size the color cache can be
+     * @deprecated will be removed in QGIS 3.0. Color cache is not used anymore.
+     */
+    Q_DECL_DEPRECATED int maximumColorCacheSize() { return mMaximumColorCacheSize; }
 
     /** \brief Set custom colormap */
     void setColorRampItemList( const QList<QgsColorRampShader::ColorRampItem>& theList ); //TODO: sort on set
@@ -82,8 +85,10 @@ class CORE_EXPORT QgsColorRampShader : public QgsRasterShaderFunction
     /** \brief Set the color ramp type*/
     void setColorRampType( const QString& theType );
 
-    /** \brief Set the maximum size the color cache can be */
-    void setMaximumColorCacheSize( int theSize ) { mMaximumColorCacheSize = theSize; }
+    /** \brief Set the maximum size the color cache can be
+     * @deprecated will be removed in QGIS 3.0. Color cache is not used anymore.
+     */
+    Q_DECL_DEPRECATED void setMaximumColorCacheSize( int theSize ) { mMaximumColorCacheSize = theSize; }
 
     /** \brief Generates and new RGB value based on one input value */
     bool shade( double, int*, int*, int*, int* ) override;
@@ -105,10 +110,6 @@ class CORE_EXPORT QgsColorRampShader : public QgsRasterShaderFunction
     bool clip() const { return mClip; }
 
   private:
-    /** Current index from which to start searching the color table*/
-    int mCurrentColorRampItemIndex;
-
-    //TODO: Consider pulling this out as a separate class and internally storing as a QMap rather than a QList
     /** This vector holds the information for classification based on values.
      * Each item holds a value, a label and a color. The member
      * mDiscreteClassification holds if one color is applied for all values
@@ -119,27 +120,17 @@ class CORE_EXPORT QgsColorRampShader : public QgsRasterShaderFunction
     /** \brief The color ramp type */
     QgsColorRampShader::ColorRamp_TYPE mColorRampType;
 
-    /** \brief Cache of values that have already been looked up */
-    QMap<double, QColor> mColorCache;
+    /** Look up table to speed up finding the right color.
+      * It is initialized on the first call to shade(). */
+    QList<int> mLUT;
+    double mLUTOffset;
+    double mLUTFactor;
+    bool mLUTInitialized = false;
 
     /** Maximum size of the color cache. The color cache could eat a ton of
-     * memory if you have 32-bit data */
-    int mMaximumColorCacheSize;
-
-    /** Gets the color for a pixel value from the classification vector
-     * mValueClassification. Assigns the color of the lower class for every
-     * pixel between two class breaks.*/
-    bool discreteColor( double, int*, int*, int*, int* );
-
-    /** Gets the color for a pixel value from the classification vector
-     * mValueClassification. Assigns the color of the exact matching value in
-     * the color ramp item list */
-    bool exactColor( double, int*, int*, int*, int* );
-
-    /** Gets the color for a pixel value from the classification vector
-     * mValueClassification. Interpolates the color between two class breaks
-     * linearly.*/
-    bool interpolatedColor( double, int*, int*, int*, int* );
+     * memory if you have 32-bit data
+     * @deprecated will be removed in QGIS 3.0 */
+    Q_DECL_DEPRECATED int mMaximumColorCacheSize;
 
     /** Do not render values out of range */
     bool mClip;

--- a/src/core/raster/qgscolorrampshader.h
+++ b/src/core/raster/qgscolorrampshader.h
@@ -22,7 +22,7 @@ originally part of the larger QgsRasterLayer class
 #define QGSCOLORRAMPSHADER_H
 
 #include <QColor>
-#include <QMap>
+#include <QVector>
 
 #include "qgsrastershaderfunction.h"
 
@@ -63,7 +63,7 @@ class CORE_EXPORT QgsColorRampShader : public QgsRasterShaderFunction
     };
 
     /** \brief Get the custom colormap*/
-    QList<QgsColorRampShader::ColorRampItem> colorRampItemList() const {return mColorRampItemList;}
+    QList<QgsColorRampShader::ColorRampItem> colorRampItemList() const {return mColorRampItemList.toList();}
 
     /** \brief Get the color ramp type */
     QgsColorRampShader::ColorRamp_TYPE colorRampType() const {return mColorRampType;}
@@ -115,14 +115,14 @@ class CORE_EXPORT QgsColorRampShader : public QgsRasterShaderFunction
      * mDiscreteClassification holds if one color is applied for all values
      * between two class breaks (true) or if the item values are (linearly)
      * interpolated for values between the item values (false)*/
-    QList<QgsColorRampShader::ColorRampItem> mColorRampItemList;
+    QVector<QgsColorRampShader::ColorRampItem> mColorRampItemList;
 
     /** \brief The color ramp type */
     QgsColorRampShader::ColorRamp_TYPE mColorRampType;
 
     /** Look up table to speed up finding the right color.
       * It is initialized on the first call to shade(). */
-    QList<int> mLUT;
+    QVector<int> mLUT;
     double mLUTOffset;
     double mLUTFactor;
     bool mLUTInitialized = false;

--- a/src/core/raster/qgscolorrampshader.h
+++ b/src/core/raster/qgscolorrampshader.h
@@ -129,7 +129,7 @@ class CORE_EXPORT QgsColorRampShader : public QgsRasterShaderFunction
 
     /** Maximum size of the color cache. The color cache could eat a ton of
      * memory if you have 32-bit data
-     * @deprecated will be removed in QGIS 3.0 */
+     * TODO QGIS 3: remove this */
     int mMaximumColorCacheSize;
 
     /** Do not render values out of range */


### PR DESCRIPTION
Most of the time was lost in checking the color cache, which for doubles has an almost infinite chance of cache hit misses anyway, so I replaced that by a look up table for the index in the color map.

It is substantially faster now, and the number of color map items doesn't really matter anymore. 

Also fixes http://hub.qgis.org/issues/12581
