### PR TITLE
[postgres] Improved handling of DOMAIN type fields

### DIFF
--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -206,5 +206,31 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         self.vl.addFeature(f) # Should not deadlock during an active iteration
         f = next(it)
 
+    def testDomainTypes(self):
+        """Test that domain types are correctly mapped"""
+
+        vl = QgsVectorLayer('%s table="qgis_test"."domains" sql=' % (self.dbconn), "domains", "postgres")
+        self.assertTrue(vl.isValid())
+
+        fields = vl.dataProvider().fields()
+
+        expected = {}
+        expected['fld_var_char_domain'] = {'type': QVariant.String, 'typeName': 'qgis_test.var_char_domain', 'length': -1}
+        expected['fld_var_char_domain_6'] = {'type': QVariant.String, 'typeName': 'qgis_test.var_char_domain_6', 'length': 6}
+        expected['fld_character_domain'] = {'type': QVariant.String, 'typeName': 'qgis_test.character_domain', 'length': 1}
+        expected['fld_character_domain_6'] = {'type': QVariant.String, 'typeName': 'qgis_test.character_domain_6', 'length': 6}
+        expected['fld_char_domain'] = {'type': QVariant.String, 'typeName': 'qgis_test.char_domain', 'length': 1}
+        expected['fld_char_domain_6'] = {'type': QVariant.String, 'typeName': 'qgis_test.char_domain_6', 'length': 6}
+        expected['fld_text_domain'] = {'type': QVariant.String, 'typeName': 'qgis_test.text_domain', 'length': -1}
+        expected['fld_numeric_domain'] = {'type': QVariant.Double, 'typeName': 'qgis_test.numeric_domain', 'length': 10, 'precision': 4}
+
+        for f, e in expected.iteritems():
+            self.assertEqual(fields.at(fields.indexFromName(f)).type(), e['type'])
+            self.assertEqual(fields.at(fields.indexFromName(f)).typeName(), e['typeName'])
+            self.assertEqual(fields.at(fields.indexFromName(f)).length(), e['length'])
+            if 'precision' in e:
+                self.assertEqual(fields.at(fields.indexFromName(f)).precision(), e['precision'])
+
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/testdata/provider/testdata_pg.sql
+++ b/tests/testdata/provider/testdata_pg.sql
@@ -357,3 +357,44 @@ CREATE TABLE qgis_test.oid_serial_table
 );
 
 ALTER TABLE qgis_test.oid_serial_table ALTER COLUMN obj_id SET DEFAULT 'prf_' || nextval('qgis_test.oid_serial');
+
+
+--------------------------------------
+-- Test use of domain types
+--
+
+CREATE DOMAIN qgis_test.var_char_domain
+  AS character varying;
+
+CREATE DOMAIN qgis_test.var_char_domain_6
+  AS character varying(6);
+
+CREATE DOMAIN qgis_test.character_domain
+  AS character;
+
+CREATE DOMAIN qgis_test.character_domain_6
+  AS character(6);
+
+CREATE DOMAIN qgis_test.char_domain
+  AS char;
+
+CREATE DOMAIN qgis_test.char_domain_6
+  AS char(6);
+
+CREATE DOMAIN qgis_test.text_domain
+  AS text;
+
+CREATE DOMAIN qgis_test.numeric_domain
+  AS numeric(10,4);
+
+CREATE TABLE qgis_test.domains
+(
+  fld_var_char_domain qgis_test.var_char_domain,
+  fld_var_char_domain_6 qgis_test.var_char_domain_6,
+  fld_character_domain qgis_test.character_domain,
+  fld_character_domain_6 qgis_test.character_domain_6,
+  fld_char_domain qgis_test.char_domain,
+  fld_char_domain_6 qgis_test.char_domain_6,
+  fld_text_domain qgis_test.text_domain,
+  fld_numeric_domain qgis_test.numeric_domain
+);


### PR DESCRIPTION
- show correct domain type as field type name
- correctly determine length and precision of domain types
- expose bpchar field type as 'character' to users, as postgres only
  uses 'bpchar' internally and refers to bpchar as character in the
  front end
