### PR TITLE
Consolidate all QVariant sort methods to use qgsVariantLessThan

### DIFF
--- a/python/core/qgis.sip
+++ b/python/core/qgis.sip
@@ -243,6 +243,17 @@ class QGis
     static double SCALE_PRECISION;
 };
 
+//! Compares two QVariant values and returns whether the first is less than the second.
+//! Useful for sorting lists of variants, correctly handling sorting of the various
+//! QVariant data types (such as strings, numeric values, dates and times)
+//! @see qgsVariantGreaterThan()
+bool qgsVariantLessThan( const QVariant& lhs, const QVariant& rhs );
+
+//! Compares two QVariant values and returns whether the first is greater than the second.
+//! Useful for sorting lists of variants, correctly handling sorting of the various
+//! QVariant data types (such as strings, numeric values, dates and times)
+//! @see qgsVariantLessThan()
+bool qgsVariantGreaterThan( const QVariant& lhs, const QVariant& rhs );
 
 /** Wkt string that represents a geographic coord sys
  * @note added to replace GEOWkt

--- a/src/core/composer/qgsatlascomposition.cpp
+++ b/src/core/composer/qgsatlascomposition.cpp
@@ -166,23 +166,10 @@ class FieldSorter
 
     bool operator()( const QPair< QgsFeatureId, QString > & id1, const QPair< QgsFeatureId, QString >& id2 )
     {
-      bool result = true;
-
-      if ( mKeys[ id1.first ].type() == QVariant::Int )
-      {
-        result = mKeys[ id1.first ].toInt() < mKeys[ id2.first ].toInt();
-      }
-      else if ( mKeys[ id1.first ].type() == QVariant::Double )
-      {
-        result = mKeys[ id1.first ].toDouble() < mKeys[ id2.first ].toDouble();
-      }
-      else if ( mKeys[ id1.first ].type() == QVariant::String )
-      {
-        result = ( QString::localeAwareCompare( mKeys[ id1.first ].toString(), mKeys[ id2.first ].toString() ) < 0 );
-      }
-
-      return mAscending ? result : !result;
+      return mAscending ? qgsVariantLessThan( mKeys.value( id1.first ), mKeys.value( id2.first ) )
+             : qgsVariantGreaterThan( mKeys.value( id1.first ), mKeys.value( id2.first ) );
     }
+
   private:
     QgsAtlasComposition::SorterKeys& mKeys;
     bool mAscending;

--- a/src/core/composer/qgscomposerattributetable.cpp
+++ b/src/core/composer/qgscomposerattributetable.cpp
@@ -32,60 +32,8 @@ QgsComposerAttributeTableCompare::QgsComposerAttributeTableCompare()
 
 bool QgsComposerAttributeTableCompare::operator()( const QgsAttributeMap& m1, const QgsAttributeMap& m2 )
 {
-  QVariant v1 = m1[mCurrentSortColumn];
-  QVariant v2 = m2[mCurrentSortColumn];
-
-  bool less = false;
-
-  //sort null values first
-  if ( v1.isNull() && v2.isNull() )
-  {
-    less = false;
-  }
-  else if ( v1.isNull() )
-  {
-    less = true;
-  }
-  else if ( v2.isNull() )
-  {
-    less = false;
-  }
-  else
-  {
-    //otherwise sort by converting to corresponding type and comparing
-    switch ( v1.type() )
-    {
-      case QVariant::Int:
-      case QVariant::UInt:
-      case QVariant::LongLong:
-      case QVariant::ULongLong:
-        less = v1.toLongLong() < v2.toLongLong();
-        break;
-
-      case QVariant::Double:
-        less = v1.toDouble() < v2.toDouble();
-        break;
-
-      case QVariant::Date:
-        less = v1.toDate() < v2.toDate();
-        break;
-
-      case QVariant::DateTime:
-        less = v1.toDateTime() < v2.toDateTime();
-        break;
-
-      case QVariant::Time:
-        less = v1.toTime() < v2.toTime();
-        break;
-
-      default:
-        //use locale aware compare for strings
-        less = v1.toString().localeAwareCompare( v2.toString() ) < 0;
-        break;
-    }
-  }
-
-  return ( mAscending ? less : !less );
+  return ( mAscending ? qgsVariantLessThan( m1[mCurrentSortColumn], m2[mCurrentSortColumn] )
+           : qgsVariantGreaterThan( m1[mCurrentSortColumn], m2[mCurrentSortColumn] ) );
 }
 
 

--- a/src/core/composer/qgscomposerattributetablev2.cpp
+++ b/src/core/composer/qgscomposerattributetablev2.cpp
@@ -37,60 +37,8 @@ QgsComposerAttributeTableCompareV2::QgsComposerAttributeTableCompareV2()
 
 bool QgsComposerAttributeTableCompareV2::operator()( const QgsComposerTableRow& m1, const QgsComposerTableRow& m2 )
 {
-  QVariant v1 = m1[mCurrentSortColumn];
-  QVariant v2 = m2[mCurrentSortColumn];
-
-  bool less = false;
-
-  //sort null values first
-  if ( v1.isNull() && v2.isNull() )
-  {
-    less = false;
-  }
-  else if ( v1.isNull() )
-  {
-    less = true;
-  }
-  else if ( v2.isNull() )
-  {
-    less = false;
-  }
-  else
-  {
-    //otherwise sort by converting to corresponding type and comparing
-    switch ( v1.type() )
-    {
-      case QVariant::Int:
-      case QVariant::UInt:
-      case QVariant::LongLong:
-      case QVariant::ULongLong:
-        less = v1.toLongLong() < v2.toLongLong();
-        break;
-
-      case QVariant::Double:
-        less = v1.toDouble() < v2.toDouble();
-        break;
-
-      case QVariant::Date:
-        less = v1.toDate() < v2.toDate();
-        break;
-
-      case QVariant::DateTime:
-        less = v1.toDateTime() < v2.toDateTime();
-        break;
-
-      case QVariant::Time:
-        less = v1.toTime() < v2.toTime();
-        break;
-
-      default:
-        //use locale aware compare for strings
-        less = v1.toString().localeAwareCompare( v2.toString() ) < 0;
-        break;
-    }
-  }
-
-  return ( mAscending ? less : !less );
+  return ( mAscending ? qgsVariantLessThan( m1[mCurrentSortColumn], m2[mCurrentSortColumn] )
+           : qgsVariantGreaterThan( m1[mCurrentSortColumn], m2[mCurrentSortColumn] ) );
 }
 
 //

--- a/src/core/qgis.cpp
+++ b/src/core/qgis.cpp
@@ -262,6 +262,14 @@ void qgsFree( void *ptr )
 
 bool qgsVariantLessThan( const QVariant& lhs, const QVariant& rhs )
 {
+  // invalid < NULL < any value
+  if ( !lhs.isValid() )
+    return rhs.isValid();
+  else if ( lhs.isNull() )
+    return rhs.isValid() && !rhs.isNull();
+  else if ( !rhs.isValid() || rhs.isNull() )
+    return false;
+
   switch ( lhs.type() )
   {
     case QVariant::Int:
@@ -282,6 +290,39 @@ bool qgsVariantLessThan( const QVariant& lhs, const QVariant& rhs )
       return lhs.toTime() < rhs.toTime();
     case QVariant::DateTime:
       return lhs.toDateTime() < rhs.toDateTime();
+    case QVariant::Bool:
+      return lhs.toBool() < rhs.toBool();
+
+    case QVariant::List:
+    {
+      const QList<QVariant> &lhsl = lhs.toList();
+      const QList<QVariant> &rhsl = rhs.toList();
+
+      int i, n = qMin( lhsl.size(), rhsl.size() );
+      for ( i = 0; i < n && lhsl[i].type() == rhsl[i].type() && lhsl[i].isNull() == rhsl[i].isNull() && lhsl[i] == rhsl[i]; i++ )
+        ;
+
+      if ( i == n )
+        return lhsl.size() < rhsl.size();
+      else
+        return qgsVariantLessThan( lhsl[i], rhsl[i] );
+    }
+
+    case QVariant::StringList:
+    {
+      const QStringList &lhsl = lhs.toStringList();
+      const QStringList &rhsl = rhs.toStringList();
+
+      int i, n = qMin( lhsl.size(), rhsl.size() );
+      for ( i = 0; i < n && lhsl[i] == rhsl[i]; i++ )
+        ;
+
+      if ( i == n )
+        return lhsl.size() < rhsl.size();
+      else
+        return lhsl[i] < rhsl[i];
+    }
+
     default:
       return QString::localeAwareCompare( lhs.toString(), rhs.toString() ) < 0;
   }

--- a/src/core/qgis.h
+++ b/src/core/qgis.h
@@ -330,9 +330,9 @@ template<class Object> inline QgsSignalBlocker<Object> whileBlocking( Object* ob
   return QgsSignalBlocker<Object>( object );
 }
 
-//
-// return a string representation of a double
-//
+//! Returns a string representation of a double
+//! @param a double value
+//! @param precision number of decimal places to retain
 inline QString qgsDoubleToString( double a, int precision = 17 )
 {
   if ( precision )
@@ -341,18 +341,17 @@ inline QString qgsDoubleToString( double a, int precision = 17 )
     return QString::number( a, 'f', precision );
 }
 
-//
-// compare two doubles (but allow some difference)
-//
+//! Compare two doubles (but allow some difference)
+//! @param a first double
+//! @param b second double
+//! @param epsilon maximum difference allowable between doubles
 inline bool qgsDoubleNear( double a, double b, double epsilon = 4 * DBL_EPSILON )
 {
   const double diff = a - b;
   return diff > -epsilon && diff <= epsilon;
 }
 
-//
-// compare two doubles using specified number of significant digits
-//
+//! Compare two doubles using specified number of significant digits
 inline bool qgsDoubleNearSig( double a, double b, int significantDigits = 10 )
 {
   // The most simple would be to print numbers as %.xe and compare as strings
@@ -368,17 +367,23 @@ inline bool qgsDoubleNearSig( double a, double b, int significantDigits = 10 )
          qRound( ar * pow( 10.0, significantDigits ) ) == qRound( br * pow( 10.0, significantDigits ) );
 }
 
-//
-// a round function which returns a double to guard against overflows
-//
+//! A round function which returns a double to guard against overflows
 inline double qgsRound( double x )
 {
   return x < 0.0 ? std::ceil( x - 0.5 ) : std::floor( x + 0.5 );
 }
 
-bool qgsVariantLessThan( const QVariant& lhs, const QVariant& rhs );
+//! Compares two QVariant values and returns whether the first is less than the second.
+//! Useful for sorting lists of variants, correctly handling sorting of the various
+//! QVariant data types (such as strings, numeric values, dates and times)
+//! @see qgsVariantGreaterThan()
+CORE_EXPORT bool qgsVariantLessThan( const QVariant& lhs, const QVariant& rhs );
 
-bool qgsVariantGreaterThan( const QVariant& lhs, const QVariant& rhs );
+//! Compares two QVariant values and returns whether the first is greater than the second.
+//! Useful for sorting lists of variants, correctly handling sorting of the various
+//! QVariant data types (such as strings, numeric values, dates and times)
+//! @see qgsVariantLessThan()
+CORE_EXPORT bool qgsVariantGreaterThan( const QVariant& lhs, const QVariant& rhs );
 
 CORE_EXPORT QString qgsVsiPrefix( const QString& path );
 

--- a/src/core/symbology-ng/qgssymbollayerv2utils.cpp
+++ b/src/core/symbology-ng/qgssymbollayerv2utils.cpp
@@ -3642,40 +3642,6 @@ void QgsSymbolLayerV2Utils::premultiplyColor( QColor &rgb, int alpha )
   }
 }
 
-#if 0
-static bool _QVariantLessThan( const QVariant& lhs, const QVariant& rhs )
-{
-  switch ( lhs.type() )
-  {
-    case QVariant::Int:
-      return lhs.toInt() < rhs.toInt();
-    case QVariant::UInt:
-      return lhs.toUInt() < rhs.toUInt();
-    case QVariant::LongLong:
-      return lhs.toLongLong() < rhs.toLongLong();
-    case QVariant::ULongLong:
-      return lhs.toULongLong() < rhs.toULongLong();
-    case QVariant::Double:
-      return lhs.toDouble() < rhs.toDouble();
-    case QVariant::Char:
-      return lhs.toChar() < rhs.toChar();
-    case QVariant::Date:
-      return lhs.toDate() < rhs.toDate();
-    case QVariant::Time:
-      return lhs.toTime() < rhs.toTime();
-    case QVariant::DateTime:
-      return lhs.toDateTime() < rhs.toDateTime();
-    default:
-      return QString::localeAwareCompare( lhs.toString(), rhs.toString() ) < 0;
-  }
-}
-
-static bool _QVariantGreaterThan( const QVariant& lhs, const QVariant& rhs )
-{
-  return ! _QVariantLessThan( lhs, rhs );
-}
-#endif
-
 void QgsSymbolLayerV2Utils::sortVariantList( QList<QVariant>& list, Qt::SortOrder order )
 {
   if ( order == Qt::AscendingOrder )

--- a/src/gui/attributetable/qgsattributetablefiltermodel.cpp
+++ b/src/gui/attributetable/qgsattributetablefiltermodel.cpp
@@ -15,6 +15,7 @@
 
 #include <QItemSelectionModel>
 
+#include "qgis.h"
 #include "qgsattributetablefiltermodel.h"
 #include "qgsattributetablemodel.h"
 #include "qgsvectorlayer.h"
@@ -56,39 +57,8 @@ bool QgsAttributeTableFilterModel::lessThan( const QModelIndex &left, const QMod
     }
   }
 
-
-  QVariant leftData = left.data( QgsAttributeTableModel::SortRole );
-  QVariant rightData = right.data( QgsAttributeTableModel::SortRole );
-
-  if ( leftData.isNull() )
-    return true;
-
-  if ( rightData.isNull() )
-    return false;
-
-  switch ( leftData.type() )
-  {
-    case QVariant::Int:
-    case QVariant::UInt:
-    case QVariant::LongLong:
-    case QVariant::ULongLong:
-      return leftData.toLongLong() < rightData.toLongLong();
-
-    case QVariant::Double:
-      return leftData.toDouble() < rightData.toDouble();
-
-    case QVariant::Date:
-      return leftData.toDate() < rightData.toDate();
-
-    case QVariant::Time:
-      return leftData.toTime() < rightData.toTime();
-
-    case QVariant::DateTime:
-      return leftData.toDateTime() < rightData.toDateTime();
-
-    default:
-      return leftData.toString().localeAwareCompare( rightData.toString() ) < 0;
-  }
+  return qgsVariantLessThan( left.data( QgsAttributeTableModel::SortRole ),
+                             right.data( QgsAttributeTableModel::SortRole ) );
 }
 
 void QgsAttributeTableFilterModel::sort( int column, Qt::SortOrder order )

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -34,22 +34,6 @@
 #include "qgsvectorlayer.h"
 #include "qgsattributetablemodel.h"
 
-bool orderByLessThan( const QgsRelationReferenceWidget::ValueRelationItem& p1
-                      , const QgsRelationReferenceWidget::ValueRelationItem& p2 )
-{
-  switch ( p1.first.type() )
-  {
-    case QVariant::String:
-      return p1.first.toString() < p2.first.toString();
-
-    case QVariant::Double:
-      return p1.first.toDouble() < p2.first.toDouble();
-
-    default:
-      return p1.first.toInt() < p2.first.toInt();
-  }
-}
-
 QgsRelationReferenceWidget::QgsRelationReferenceWidget( QWidget* parent )
     : QWidget( parent )
     , mEditorContext( QgsAttributeEditorContext() )

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetwrapper.cpp
@@ -15,6 +15,7 @@
 
 #include "qgsvaluerelationwidgetwrapper.h"
 
+#include "qgis.h"
 #include "qgsfield.h"
 #include "qgsmaplayerregistry.h"
 #include "qgsvaluerelationwidgetfactory.h"
@@ -27,23 +28,13 @@
 bool QgsValueRelationWidgetWrapper::orderByKeyLessThan( const QgsValueRelationWidgetWrapper::ValueRelationItem& p1
     , const QgsValueRelationWidgetWrapper::ValueRelationItem& p2 )
 {
-  switch ( p1.first.type() )
-  {
-    case QVariant::String:
-      return p1.first.toString() < p2.first.toString();
-
-    case QVariant::Double:
-      return p1.first.toDouble() < p2.first.toDouble();
-
-    default:
-      return p1.first.toInt() < p2.first.toInt();
-  }
+  return qgsVariantLessThan( p1.first, p2.first );
 }
 
 bool QgsValueRelationWidgetWrapper::orderByValueLessThan( const QgsValueRelationWidgetWrapper::ValueRelationItem& p1
     , const QgsValueRelationWidgetWrapper::ValueRelationItem& p2 )
 {
-  return p1.second < p2.second;
+  return qgsVariantLessThan( p1.second, p2.second );
 }
 
 QgsValueRelationWidgetWrapper::QgsValueRelationWidgetWrapper( QgsVectorLayer* vl, int fieldIdx, QWidget* editor, QWidget* parent )

--- a/tests/src/core/testqgis.cpp
+++ b/tests/src/core/testqgis.cpp
@@ -39,6 +39,8 @@ class TestQGis : public QObject
     void doubleToString();
     void qgsround();
     void signalBlocker();
+    void qVariantCompare_data();
+    void qVariantCompare();
 
   private:
     QString mReport;
@@ -223,6 +225,73 @@ void TestQGis::signalBlocker()
   whileBlocking( checkbox.data() )->setChecked( true );
   QVERIFY( checkbox->signalsBlocked() );
 }
+
+void TestQGis::qVariantCompare_data()
+{
+  QTest::addColumn<QVariant>( "lhs" );
+  QTest::addColumn<QVariant>( "rhs" );
+  QTest::addColumn<bool>( "lessThan" );
+  QTest::addColumn<bool>( "greaterThan" );
+
+  QTest::newRow( "invalid to value" ) << QVariant() << QVariant( 2 ) << true << false;
+  QTest::newRow( "invalid to value 2" ) << QVariant( 2 ) << QVariant() << false << true;
+  QTest::newRow( "invalid to null" ) << QVariant() << QVariant( QVariant::String ) << true << false;
+  QTest::newRow( "invalid to null2 " ) << QVariant( QVariant::String ) << QVariant() << false << true;
+  QTest::newRow( "null to value" ) <<  QVariant( QVariant::String ) << QVariant( "a" ) << true << false;
+  QTest::newRow( "null to value 2" ) << QVariant( "a" ) << QVariant( QVariant::String ) << false << true;
+
+  QTest::newRow( "int" ) << QVariant( 1 ) << QVariant( 2 ) << true << false;
+  QTest::newRow( "int 2" ) << QVariant( 1 ) << QVariant( -2 ) << false << true;
+  QTest::newRow( "int 3" ) << QVariant( 0 ) << QVariant( 1 ) << true << false;
+  QTest::newRow( "uint" ) << QVariant( 1u ) << QVariant( 2u ) << true << false;
+  QTest::newRow( "uint 2" ) << QVariant( 2u ) << QVariant( 0u ) << false << true;
+  QTest::newRow( "long long" ) << QVariant( 1LL ) << QVariant( 2LL ) << true << false;
+  QTest::newRow( "long long 2" ) << QVariant( 1LL ) << QVariant( -2LL ) << false << true;
+  QTest::newRow( "long long 3" ) << QVariant( 0LL ) << QVariant( 1LL ) << true << false;
+  QTest::newRow( "ulong long" ) << QVariant( 1uLL ) << QVariant( 2uLL ) << true << false;
+  QTest::newRow( "ulong long 2" ) << QVariant( 2uLL ) << QVariant( 0uLL ) << false << true;
+  QTest::newRow( "double" ) << QVariant( 1.5 ) << QVariant( 2.5 ) << true << false;
+  QTest::newRow( "double 2" ) << QVariant( 1.5 ) << QVariant( -2.5 ) << false << true;
+  QTest::newRow( "double 3" ) << QVariant( 0.5 ) << QVariant( 1.5 ) << true << false;
+  QTest::newRow( "char" ) << QVariant( 'b' ) << QVariant( 'x' ) << true << false;
+  QTest::newRow( "char 2" ) << QVariant( 'x' ) << QVariant( 'b' ) << false << true;
+  QTest::newRow( "date" ) << QVariant( QDate( 2000, 5, 6 ) ) << QVariant( QDate( 2000, 8, 6 ) ) << true << false;
+  QTest::newRow( "date 2" ) << QVariant( QDate( 2000, 8, 6 ) ) << QVariant( QDate( 2000, 5, 6 ) ) << false << true;
+  QTest::newRow( "time" ) << QVariant( QTime( 13, 5, 6 ) ) << QVariant( QTime( 13, 8, 6 ) ) << true << false;
+  QTest::newRow( "time 2" ) << QVariant( QTime( 18, 8, 6 ) ) << QVariant( QTime( 13, 5, 6 ) ) << false << true;
+  QTest::newRow( "datetime" ) << QVariant( QDateTime( QDate( 2000, 5, 6 ), QTime( 13, 5, 6 ) ) ) << QVariant( QDateTime( QDate( 2000, 8, 6 ), QTime( 13, 5, 6 ) ) ) << true << false;
+  QTest::newRow( "datetime 2" ) << QVariant( QDateTime( QDate( 2000, 8, 6 ), QTime( 13, 5, 6 ) ) ) << QVariant( QDateTime( QDate( 2000, 5, 6 ), QTime( 13, 5, 6 ) ) ) << false << true;
+  QTest::newRow( "datetime 3" ) << QVariant( QDateTime( QDate( 2000, 5, 6 ), QTime( 13, 5, 6 ) ) ) << QVariant( QDateTime( QDate( 2000, 5, 6 ), QTime( 13, 9, 6 ) ) ) << true << false;
+  QTest::newRow( "datetime 4" ) << QVariant( QDateTime( QDate( 2000, 5, 6 ), QTime( 13, 9, 6 ) ) ) << QVariant( QDateTime( QDate( 2000, 5, 6 ), QTime( 13, 5, 6 ) ) ) << false << true;
+  QTest::newRow( "bool" ) << QVariant( false ) << QVariant( true ) << true << false;
+  QTest::newRow( "bool 2" ) << QVariant( true ) << QVariant( false ) << false << true;
+  QTest::newRow( "qvariantlist" ) << QVariant( QVariantList() << QVariant( 5 ) ) << QVariant( QVariantList() << QVariant( 9 ) ) << true << false;
+  QTest::newRow( "qvariantlist 2" ) << QVariant( QVariantList() << QVariant( 9 ) ) << QVariant( QVariantList() << QVariant( 5 ) ) << false << true;
+  QTest::newRow( "qvariantlist 3" ) << QVariant( QVariantList() << QVariant( 5 ) << QVariant( 3 ) ) << QVariant( QVariantList() << QVariant( 5 ) << QVariant( 6 ) ) << true << false;
+  QTest::newRow( "qvariantlist 4" ) << QVariant( QVariant( QVariantList() << QVariant( 5 ) << QVariant( 6 ) ) ) << QVariant( QVariantList() << QVariant( 5 ) << QVariant( 3 ) ) << false << true;
+  QTest::newRow( "qvariantlist 5" ) << QVariant( QVariantList() << QVariant( 5 ) ) << QVariant( QVariantList() << QVariant( 5 ) << QVariant( 6 ) ) << true << false;
+  QTest::newRow( "qvariantlist 5" ) << QVariant( QVariantList() << QVariant( 5 ) << QVariant( 6 ) ) << QVariant( QVariantList() << QVariant( 5 ) ) << false << true;
+  QTest::newRow( "qstringlist" ) << QVariant( QStringList() << "aa" ) << QVariant( QStringList() << "bb" ) << true << false;
+  QTest::newRow( "qstringlist 2" ) << QVariant( QStringList() << "bb" ) << QVariant( QStringList() << "aa" ) << false << true;
+  QTest::newRow( "qstringlist 3" ) << QVariant( QStringList() << "aa" << "cc" ) << QVariant( QStringList() << "aa" << "xx" ) << true << false;
+  QTest::newRow( "qstringlist 4" ) << QVariant( QStringList() << "aa" << "xx" ) << QVariant( QStringList() << "aa" << "cc" ) << false << true;
+  QTest::newRow( "qstringlist 5" ) << QVariant( QStringList() << "aa" ) << QVariant( QStringList() << "aa" << "xx" ) << true << false;
+  QTest::newRow( "qstringlist 6" ) << QVariant( QStringList() << "aa" << "xx" ) << QVariant( QStringList() << "aa" ) << false << true;
+  QTest::newRow( "string" ) << QVariant( "a b c" ) << QVariant( "d e f" ) << true << false;
+  QTest::newRow( "string 2" ) << QVariant( "d e f" ) << QVariant( "a b c" ) << false << true;
+}
+
+void TestQGis::qVariantCompare()
+{
+  QFETCH( QVariant, lhs );
+  QFETCH( QVariant, rhs );
+  QFETCH( bool, lessThan );
+  QFETCH( bool, greaterThan );
+
+  QCOMPARE( qgsVariantLessThan( lhs, rhs ), lessThan );
+  QCOMPARE( qgsVariantGreaterThan( lhs, rhs ), greaterThan );
+}
+
 
 QTEST_MAIN( TestQGis )
 #include "testqgis.moc"


### PR DESCRIPTION
Instead of multiple methods for sorting lists of QVariants this consolidates them all into a single ultimate one - qgsVariantLessThan (and qgsVariantGreaterThan).

I've copied the best bits from each individual sort implementation into this method, and added a bunch of unit tests.

This should fix #14671, which was caused by a QVariant sort implementation not handling longlong types.
