### PR TITLE
Add global python startup script support in addition to per-user scripts

### DIFF
--- a/python/user.py
+++ b/python/user.py
@@ -55,13 +55,8 @@ def load_user_expressions(path):
 
 userpythonhome = os.path.join(QgsApplication.qgisSettingsDirPath(), "python")
 expressionspath = os.path.join(userpythonhome, "expressions")
-startuppy = os.path.join(userpythonhome, "startup.py")
 
 sys.path.append(userpythonhome)
-
-# exec startup script
-if os.path.exists(startuppy):
-    exec(compile(open(startuppy).read(), startuppy, 'exec'), locals(), globals())
 
 if not os.path.exists(expressionspath):
     os.makedirs(expressionspath)

--- a/src/python/qgspythonutilsimpl.cpp
+++ b/src/python/qgspythonutilsimpl.cpp
@@ -32,6 +32,7 @@
 #include <QMessageBox>
 #include <QStringList>
 #include <QDir>
+#include <QStandardPaths>
 #include <QDebug>
 
 #if (PY_VERSION_HEX < 0x03000000)
@@ -209,6 +210,19 @@ bool QgsPythonUtilsImpl::checkQgisUser()
   return true;
 }
 
+void QgsPythonUtilsImpl::doGlobalImports()
+{
+  QString startupPath = QStandardPaths::locate( QStandardPaths::AppDataLocation, "global_startup.py" );
+  //runString( "if os.path.exists(" + startuppath + "): from global_startup import *\n" );
+  if ( !startupPath.isEmpty() )
+  {
+    runString( "import importlib.util" );
+    runString( QString( "spec = importlib.util.spec_from_file_location('global_startup','%1')" ).arg( startupPath ) );
+    runString( "module = importlib.util.module_from_spec(spec)" );
+    runString( "spec.loader.exec_module(module)" );
+  }
+}
+
 void QgsPythonUtilsImpl::initPython( QgisInterface* interface )
 {
   init();
@@ -224,6 +238,7 @@ void QgsPythonUtilsImpl::initPython( QgisInterface* interface )
     exitPython();
     return;
   }
+  doGlobalImports();
   finish();
 }
 
@@ -249,6 +264,7 @@ void QgsPythonUtilsImpl::initServerPython( QgsServerInterface* interface )
   // This is the other main difference with initInterface() for desktop plugins
   runString( "qgis.utils.initServerInterface(" + QString::number(( unsigned long ) interface ) + ')' );
 
+  doGlobalImports();
   finish();
 }
 

--- a/src/python/qgspythonutilsimpl.h
+++ b/src/python/qgspythonutilsimpl.h
@@ -126,12 +126,11 @@ class QgsPythonUtilsImpl : public QgsPythonUtils
     //@return true if qgis.user could be imported
     bool checkQgisUser();
 
-    //! import global Python code
-    void doGlobalImports();
+    //! import custom user and global Python code (startup scripts)
+    void doCustomImports();
 
     //! cleanup Python context
     void finish();
-
 
     void installErrorHook();
 
@@ -151,6 +150,5 @@ class QgsPythonUtilsImpl : public QgsPythonUtils
     //! flag determining that python support is enabled
     bool mPythonEnabled;
 };
-
 
 #endif

--- a/src/python/qgspythonutilsimpl.h
+++ b/src/python/qgspythonutilsimpl.h
@@ -126,6 +126,9 @@ class QgsPythonUtilsImpl : public QgsPythonUtils
     //@return true if qgis.user could be imported
     bool checkQgisUser();
 
+    //! import global Python code
+    void doGlobalImports();
+
     //! cleanup Python context
     void finish();
 


### PR DESCRIPTION
We already have support for per-user Python startup scripts. This adds support for global startup script for all users. Script file should be called `global_startup.py` and placed in the QGIS Python directory, e.g. `$QGIS_INSTALL_PATH/python/global_startup.py`.

Some use cases: restore/update settings, add connections etc.
