### PR TITLE
Support negative short integer primary keys on PostgreSQL

### DIFF
--- a/src/providers/postgres/qgspostgresconn.h
+++ b/src/providers/postgres/qgspostgresconn.h
@@ -49,6 +49,7 @@ enum QgsPostgresPrimaryKeyType
 {
   pktUnknown,
   pktInt,
+  pktInt64,
   pktTid,
   pktOid,
   pktFidMap

--- a/src/providers/postgres/qgspostgresconn.h
+++ b/src/providers/postgres/qgspostgresconn.h
@@ -49,7 +49,7 @@ enum QgsPostgresPrimaryKeyType
 {
   pktUnknown,
   pktInt,
-  pktInt64,
+  pktUint64,
   pktTid,
   pktOid,
   pktFidMap

--- a/src/providers/postgres/qgspostgresfeatureiterator.cpp
+++ b/src/providers/postgres/qgspostgresfeatureiterator.cpp
@@ -581,6 +581,7 @@ bool QgsPostgresFeatureIterator::declareCursor( const QString& whereClause, long
       break;
 
     case pktInt:
+    case pktInt64:
       query += delim + QgsPostgresConn::quotedIdentifier( mSource->mFields.at( mSource->mPrimaryKeyAttrs.at( 0 ) ).name() );
       delim = ',';
       break;
@@ -711,11 +712,16 @@ bool QgsPostgresFeatureIterator::getFeature( QgsPostgresResult &queryResult, int
   {
     case pktOid:
     case pktTid:
-    case pktInt:
       fid = mConn->getBinaryInt( queryResult, row, col++ );
-      if ( mSource->mPrimaryKeyType == pktInt &&
-           ( !subsetOfAttributes || fetchAttributes.contains( mSource->mPrimaryKeyAttrs.at( 0 ) ) ) )
+      break;
+
+    case pktInt:
+    case pktInt64:
+      fid = mConn->getBinaryInt( queryResult, row, col++ );
+      if ( !subsetOfAttributes || fetchAttributes.contains( mSource->mPrimaryKeyAttrs.at( 0 ) ) )
+      {
         feature.setAttribute( mSource->mPrimaryKeyAttrs[0], fid );
+      }
       break;
 
     case pktFidMap:

--- a/src/providers/postgres/qgspostgresfeatureiterator.cpp
+++ b/src/providers/postgres/qgspostgresfeatureiterator.cpp
@@ -581,7 +581,7 @@ bool QgsPostgresFeatureIterator::declareCursor( const QString& whereClause, long
       break;
 
     case pktInt:
-    case pktInt64:
+    case pktUint64:
       query += delim + QgsPostgresConn::quotedIdentifier( mSource->mFields.at( mSource->mPrimaryKeyAttrs.at( 0 ) ).name() );
       delim = ',';
       break;
@@ -716,7 +716,7 @@ bool QgsPostgresFeatureIterator::getFeature( QgsPostgresResult &queryResult, int
       break;
 
     case pktInt:
-    case pktInt64:
+    case pktUint64:
       fid = mConn->getBinaryInt( queryResult, row, col++ );
       if ( !subsetOfAttributes || fetchAttributes.contains( mSource->mPrimaryKeyAttrs.at( 0 ) ) )
       {

--- a/src/providers/postgres/qgspostgresfeatureiterator.cpp
+++ b/src/providers/postgres/qgspostgresfeatureiterator.cpp
@@ -718,13 +718,16 @@ bool QgsPostgresFeatureIterator::getFeature( QgsPostgresResult &queryResult, int
     case pktInt:
     case pktUint64:
       fid = mConn->getBinaryInt( queryResult, row, col++ );
-      if ( mSource->mPrimaryKeyType == pktInt )
-      {
-        fid = QgsPostgresUtils::int32pk_to_fid( fid );
-      }
       if ( !subsetOfAttributes || fetchAttributes.contains( mSource->mPrimaryKeyAttrs.at( 0 ) ) )
       {
         feature.setAttribute( mSource->mPrimaryKeyAttrs[0], fid );
+      }
+      if ( mSource->mPrimaryKeyType == pktInt )
+      {
+        // NOTE: this needs be done _after_ the setAttribute call
+        // above as we want the attribute value to be 1:1 with
+        // database value
+        fid = QgsPostgresUtils::int32pk_to_fid( fid );
       }
       break;
 

--- a/src/providers/postgres/qgspostgresfeatureiterator.cpp
+++ b/src/providers/postgres/qgspostgresfeatureiterator.cpp
@@ -718,6 +718,10 @@ bool QgsPostgresFeatureIterator::getFeature( QgsPostgresResult &queryResult, int
     case pktInt:
     case pktUint64:
       fid = mConn->getBinaryInt( queryResult, row, col++ );
+      if ( mSource->mPrimaryKeyType == pktInt )
+      {
+        fid = QgsPostgresUtils::int32pk_to_fid( fid );
+      }
       if ( !subsetOfAttributes || fetchAttributes.contains( mSource->mPrimaryKeyAttrs.at( 0 ) ) )
       {
         feature.setAttribute( mSource->mPrimaryKeyAttrs[0], fid );

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -42,17 +42,14 @@
 const QString POSTGRES_KEY = "postgres";
 const QString POSTGRES_DESCRIPTION = "PostgreSQL/PostGIS data provider";
 
-// We convert signed 32bit integers to unsigned 64bit integers
-// to support the whole range of int32 values (including negative)
-// See http://hub.qgis.org/issues/14262
-inline uint64_t PKINT2FID( int32_t x )
+inline int64_t PKINT2FID( int32_t x )
 {
-  return static_cast<uint64_t>( x );
+  return QgsPostgresUtils::int32pk_to_fid( x );
 }
 
 inline int32_t FID2PKINT( int64_t x )
 {
-  return static_cast<int32_t>( x );
+  return QgsPostgresUtils::fid_to_int32pk( x );
 }
 
 

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -352,6 +352,17 @@ class QgsPostgresProvider : public QgsVectorDataProvider
      */
     bool parseDomainCheckConstraint( QStringList& enumValues, const QString& attributeName ) const;
 
+    /** Return the type of primary key for a PK field
+     *
+     * @param fld the field to determine PK type of
+     * @return the PrimaryKeyType
+     *
+     * @note that this only makes sense for single-field primary keys,
+     *       whereas multi-field keys always need the pktFidMap
+     *       primary key type.
+     */
+    QgsPostgresPrimaryKeyType pkType( const QgsField& fld ) const;
+
     QgsFields mAttributeFields;
     QString mDataComment;
 

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -502,6 +502,21 @@ class QgsPostgresUtils
                                 QSharedPointer<QgsPostgresSharedData> sharedData );
 
     static QString andWhereClauses( const QString& c1, const QString& c2 );
+
+    static const int64_t int32pk_offset = 4294967296;
+
+    // We shift negative 32bit integers to above the max 32bit
+    // positive integer to support the whole range of int32 values
+    // See http://hub.qgis.org/issues/14262
+    static int64_t int32pk_to_fid( int32_t x )
+    {
+      return x >= 0 ? x : x + int32pk_offset;
+    }
+
+    static int32_t fid_to_int32pk( int64_t x )
+    {
+      return x <= (( int32pk_offset ) / 2.0 ) ? x : -( int32pk_offset - x );
+    }
 };
 
 /** Data shared between provider class and its feature sources. Ideally there should

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -190,7 +190,7 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         # max positive signed 16bit integer
         test(self.dbconn, '(SELECT 32767::int2 i, NULL::geometry(Point) g)', 'i', 32767, 32767)
         # max negative signed 16bit integer
-        test(self.dbconn, '(SELECT -32767::int2 i, NULL::geometry(Point) g)', 'i', -32767, 4294934529)
+        test(self.dbconn, '(SELECT (-32768)::int2 i, NULL::geometry(Point) g)', 'i', -32768, 4294934528)
 
         #### --- INT32 ----
         # zero
@@ -202,7 +202,7 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         # max positive signed 32bit integer
         test(self.dbconn, '(SELECT 2147483647::int4 i, NULL::geometry(Point) g)', 'i', 2147483647, 2147483647)
         # max negative signed 32bit integer
-        test(self.dbconn, '(SELECT -2147483647::int4 i, NULL::geometry(Point) g)', 'i', -2147483647, 2147483649)
+        test(self.dbconn, '(SELECT (-2147483648)::int4 i, NULL::geometry(Point) g)', 'i', -2147483648, 2147483648)
 
         #### --- INT64 (FIDs are always 1 because assigned ex-novo) ----
         # zero
@@ -214,7 +214,7 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         # max positive signed 64bit integer
         test(self.dbconn, '(SELECT 9223372036854775807::int8 i, NULL::geometry(Point) g)', 'i', 9223372036854775807, 1)
         # max negative signed 32bit integer
-        test(self.dbconn, '(SELECT -9223372036854775807::int8 i, NULL::geometry(Point) g)', 'i', -9223372036854775807, 1)
+        test(self.dbconn, '(SELECT (-9223372036854775808)::int8 i, NULL::geometry(Point) g)', 'i', -9223372036854775808, 1)
 
     def testPktIntInsert(self):
         vl = QgsVectorLayer('{} table="qgis_test"."{}" key="pk" sql='.format(self.dbconn, 'bikes_view'), "bikes_view", "postgres")

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -171,9 +171,7 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
             self.assertEqual(count, 1)
         test_query_attribute(self.dbconn, '(SELECT -1::int4 i, NULL::geometry(Point) g)', 'i', -1, 4294967295)
         test_query_attribute(self.dbconn, '(SELECT -2::int2 i, NULL::geometry(Point) g)', 'i', -2, 4294967294)
-        # Unfortunately negative int8 identifiers are still not supported at this moment
-        # TODO: fix expected fidval to be positive !
-        test_query_attribute(self.dbconn, '(SELECT -3::int8 i, NULL::geometry(Point) g)', 'i', -3, -3)
+        test_query_attribute(self.dbconn, '(SELECT -3::int8 i, NULL::geometry(Point) g)', 'i', -3, 1)
 
     def testPktIntInsert(self):
         vl = QgsVectorLayer('{} table="qgis_test"."{}" key="pk" sql='.format(self.dbconn, 'bikes_view'), "bikes_view", "postgres")

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -169,7 +169,7 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
                 self.assertEqual(f.attributes()[att_idx], val)
                 #self.assertEqual(f.id(), val)
             self.assertEqual(count, 1)
-        test_query_attribute(self.dbconn, '(SELECT -1::int4 i, NULL::geometry(Point) g)', 'i', -1, 1)
+        test_query_attribute(self.dbconn, '(SELECT -1::int4 i, NULL::geometry(Point) g)', 'i', -1, 4294967295)
         test_query_attribute(self.dbconn, '(SELECT -1::int2 i, NULL::geometry(Point) g)', 'i', -1, 1)
         test_query_attribute(self.dbconn, '(SELECT -1::int8 i, NULL::geometry(Point) g)', 'i', -1, 1)
         test_query_attribute(self.dbconn, '(SELECT -65535::int8 i, NULL::geometry(Point) g)', 'i', -65535, 1)

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -167,12 +167,13 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
             for f in features:
                 count += 1
                 self.assertEqual(f.attributes()[att_idx], val)
-                #self.assertEqual(f.id(), val)
+                self.assertEqual(f.id(), fidval)
             self.assertEqual(count, 1)
         test_query_attribute(self.dbconn, '(SELECT -1::int4 i, NULL::geometry(Point) g)', 'i', -1, 4294967295)
-        test_query_attribute(self.dbconn, '(SELECT -1::int2 i, NULL::geometry(Point) g)', 'i', -1, 1)
-        test_query_attribute(self.dbconn, '(SELECT -1::int8 i, NULL::geometry(Point) g)', 'i', -1, 1)
-        test_query_attribute(self.dbconn, '(SELECT -65535::int8 i, NULL::geometry(Point) g)', 'i', -65535, 1)
+        test_query_attribute(self.dbconn, '(SELECT -2::int2 i, NULL::geometry(Point) g)', 'i', -2, 4294967294)
+        # Unfortunately negative int8 identifiers are still not supported at this moment
+        # TODO: fix expected fidval to be positive !
+        test_query_attribute(self.dbconn, '(SELECT -3::int8 i, NULL::geometry(Point) g)', 'i', -3, -3)
 
     def testPktIntInsert(self):
         vl = QgsVectorLayer('{} table="qgis_test"."{}" key="pk" sql='.format(self.dbconn, 'bikes_view'), "bikes_view", "postgres")


### PR DESCRIPTION
See http://hub.qgis.org/issues/14262

NOTE: signed int64 keys would still fail

See also https://github.com/qgis/QGIS/pull/2797
