### PR TITLE
More consistency in icon use

### DIFF
--- a/python/plugins/processing/algs/qgis/ui/FieldsMappingPanel.py
+++ b/python/plugins/processing/algs/qgis/ui/FieldsMappingPanel.py
@@ -313,7 +313,7 @@ class FieldsMappingPanel(BASE, WIDGET):
         self.addButton.setIcon(
             QIcon(':/images/themes/default/mActionAdd.svg'))
         self.deleteButton.setIcon(
-            QIcon(':/images/themes/default/mActionRemove.svg'))
+            QIcon(':/images/themes/default/mActionDeleteSelected.svg'))
         self.upButton.setIcon(
             QIcon(':/images/themes/default/mActionArrowUp.png'))
         self.downButton.setIcon(

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -62,7 +62,7 @@ QgsRelationEditorWidget::QgsRelationEditorWidget( QWidget* parent )
   buttonLayout->addWidget( mAddFeatureButton );
   // delete feature
   mDeleteFeatureButton = new QToolButton( this );
-  mDeleteFeatureButton->setIcon( QgsApplication::getThemeIcon( "/mActionRemove.svg" ) );
+  mDeleteFeatureButton->setIcon( QgsApplication::getThemeIcon( "/mActionDeleteSelected.svg" ) );
   mDeleteFeatureButton->setText( tr( "Delete feature" ) );
   mDeleteFeatureButton->setObjectName( "mDeleteFeatureButton" );
   buttonLayout->addWidget( mDeleteFeatureButton );


### PR DESCRIPTION
The icon used in almost all dialogs for feature deletion is mActionDeleteSelected and no longer mActionRemove
