### PR TITLE
[Processing][Modeler] Use default value instead of None

### DIFF
--- a/python/plugins/processing/modeler/ModelerAlgorithm.py
+++ b/python/plugins/processing/modeler/ModelerAlgorithm.py
@@ -389,7 +389,7 @@ class ModelerAlgorithm(GeoAlgorithm):
                         iface.messageBar().pushMessage(self.tr("Warning"),
                                                        self.tr("Parameter %s in algorithm %s in the model is run with default value! Edit the model to make sure that this is correct.") % (param.name, alg.name),
                                                        QgsMessageBar.WARNING, 4)
-                    value = None
+                    value = param.default
                 if value is None and isinstance(param, ParameterExtent):
                     value = self.getMinCoveringExtent()
                 # We allow unexistent filepaths, since that allows

--- a/python/plugins/processing/modeler/ModelerParametersDialog.py
+++ b/python/plugins/processing/modeler/ModelerParametersDialog.py
@@ -454,7 +454,7 @@ class ModelerParametersDialog(QDialog):
                 if param.name in alg.params:
                     value = alg.params[param.name]
                 else:
-                    value = None
+                    value = param.default
                 if isinstance(param, (
                         ParameterRaster,
                         ParameterVector,


### PR DESCRIPTION
In Modeler algorithm, when a algorithm's parameter was not defined it's value was set to None.
Before the possibility to defined optional parameters, None value is equal to set value to default one.
Now, it's important to use default value instead of None.
