### PR TITLE
Don't resize canvas size on widget change

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -10284,10 +10284,10 @@ void QgisApp::refreshActionFeatureAction()
   mActionFeatureAction->setEnabled( layerHasActions );
 }
 
-void QgisApp::resizeEvent(QResizeEvent *event)
+void QgisApp::resizeEvent( QResizeEvent *event )
 {
-    mapCanvas()->updateMapSize();
-
+  Q_UNUSED( event );
+  mapCanvas()->forceResize();
 }
 
 /////////////////////////////////////////////////////////////////

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -10284,6 +10284,12 @@ void QgisApp::refreshActionFeatureAction()
   mActionFeatureAction->setEnabled( layerHasActions );
 }
 
+void QgisApp::resizeEvent(QResizeEvent *event)
+{
+    mapCanvas()->updateMapSize();
+
+}
+
 /////////////////////////////////////////////////////////////////
 //
 //

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -10284,12 +10284,6 @@ void QgisApp::refreshActionFeatureAction()
   mActionFeatureAction->setEnabled( layerHasActions );
 }
 
-void QgisApp::resizeEvent( QResizeEvent *event )
-{
-  Q_UNUSED( event );
-  mapCanvas()->forceResize();
-}
-
 /////////////////////////////////////////////////////////////////
 //
 //

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -678,7 +678,6 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
   protected:
 
-    virtual void resizeEvent( QResizeEvent* event);
     //! Handle state changes (WindowTitleChange)
     virtual void changeEvent( QEvent *event ) override;
     //! Have some control over closing of the application
@@ -1171,7 +1170,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     void labeling();
 
     //! shows the map styling dock
-    void mapStyleDock(bool enabled);
+    void mapStyleDock( bool enabled );
 
     //! diagrams properties
     void diagramProperties();

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -678,6 +678,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
   protected:
 
+    virtual void resizeEvent( QResizeEvent* event);
     //! Handle state changes (WindowTitleChange)
     virtual void changeEvent( QEvent *event ) override;
     //! Have some control over closing of the application

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -194,7 +194,6 @@ QgsMapCanvas::QgsMapCanvas( QWidget * parent, const char *name )
     , mCache( nullptr )
     , mPreviewEffect( nullptr )
     , mSnappingUtils( nullptr )
-    , mFirstResizeDone( false )
     , mExpressionContextScope( tr( "Map Canvas" ) )
 {
   setObjectName( name );
@@ -1353,7 +1352,7 @@ void QgsMapCanvas::mouseReleaseEvent( QMouseEvent* e )
 
 } // mouseReleaseEvent
 
-void QgsMapCanvas::forceResize()
+void QgsMapCanvas::updateMapSize()
 {
   mResizeTimer->start( 500 );
 
@@ -1381,10 +1380,9 @@ void QgsMapCanvas::resizeEvent( QResizeEvent * e )
   QGraphicsView::resizeEvent( e );
 
   QSize size = viewport()->size();
-  QRect current = mScene->sceneRect();
-  if ( current.width() < size.width() || current.height() < size.height() )
+  if ( size.width() > mSettings.outputSize().width() || size.height() > mSettings.outputSize().height() )
   {
-    forceResize();
+    updateMapSize();
   }
   else
   {
@@ -1401,7 +1399,7 @@ void QgsMapCanvas::paintEvent( QPaintEvent *e )
 
 void QgsMapCanvas::showEvent( QShowEvent *e )
 {
-  forceResize();
+  Q_UNUSED( e );
 } // paintEvent
 
 void QgsMapCanvas::updateCanvasItemPositions()

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -194,6 +194,7 @@ QgsMapCanvas::QgsMapCanvas( QWidget * parent, const char *name )
     , mCache( nullptr )
     , mPreviewEffect( nullptr )
     , mSnappingUtils( nullptr )
+    , mFirstResize( false )
     , mExpressionContextScope( tr( "Map Canvas" ) )
 {
   setObjectName( name );
@@ -1352,13 +1353,11 @@ void QgsMapCanvas::mouseReleaseEvent( QMouseEvent* e )
 
 } // mouseReleaseEvent
 
-void QgsMapCanvas::resizeEvent( QResizeEvent * e )
+void QgsMapCanvas::updateMapSize()
 {
-  QGraphicsView::resizeEvent( e );
   mResizeTimer->start( 500 );
 
-  QSize lastSize = viewport()->size();
-
+  QSize lastSize = size();
   mSettings.setOutputSize( lastSize );
   mMapRenderer->setOutputSize( lastSize, mSettings.outputDpi() );
 
@@ -1374,6 +1373,24 @@ void QgsMapCanvas::resizeEvent( QResizeEvent * e )
   //refresh();
 
   emit extentsChanged();
+}
+
+
+void QgsMapCanvas::resizeEvent( QResizeEvent * e )
+{
+  QGraphicsView::resizeEvent( e );
+  QSize lastSize = viewport()->size();
+
+  if ( mFirstResize )
+  {
+      mScene->setSceneRect( QRectF( 0, 0, lastSize.width(), lastSize.height() ) );
+      moveCanvasContents( true );
+      return;
+  }
+
+  updateMapSize();
+
+  mFirstResize = true;
 }
 
 void QgsMapCanvas::paintEvent( QPaintEvent *e )

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -635,9 +635,6 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     //! Overridden resize event
     void resizeEvent( QResizeEvent * e ) override;
 
-    //! Overridden paint event
-    void paintEvent( QPaintEvent * e ) override;
-
     //! Overridden show event
     void showEvent( QShowEvent * e ) override;
 

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -501,6 +501,8 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     //! @note added in 2.8
     static void enableRotation( bool enabled );
 
+    void updateMapSize();
+
   private slots:
     //! called when current maptool is destroyed
     void mapToolDestroyed();
@@ -662,7 +664,7 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     //! Make sure the datum transform store is properly populated
     void updateDatumTransformEntries();
 
-  private:
+private:
     /// this class is non-copyable
     /**
        @note
@@ -737,6 +739,8 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     QgsMapRendererCache* mCache;
 
     QTimer *mResizeTimer;
+
+    bool mFirstResize;
 
     QgsPreviewEffect* mPreviewEffect;
 

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -503,7 +503,7 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
 
     //! Force a resize of the map canvas item
     //! @note added in 2.16
-    void forceResize();
+    void updateMapSize();
 
   private slots:
     //! called when current maptool is destroyed

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -501,7 +501,9 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     //! @note added in 2.8
     static void enableRotation( bool enabled );
 
-    void updateMapSize();
+    //! Force a resize of the map canvas item
+    //! @note added in 2.16
+    void forceResize();
 
   private slots:
     //! called when current maptool is destroyed
@@ -636,6 +638,9 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     //! Overridden paint event
     void paintEvent( QPaintEvent * e ) override;
 
+    //! Overridden show event
+    void showEvent( QShowEvent * e ) override;
+
     //! Overridden drag enter event
     void dragEnterEvent( QDragEnterEvent * e ) override;
 
@@ -664,7 +669,7 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     //! Make sure the datum transform store is properly populated
     void updateDatumTransformEntries();
 
-private:
+  private:
     /// this class is non-copyable
     /**
        @note
@@ -739,8 +744,6 @@ private:
     QgsMapRendererCache* mCache;
 
     QTimer *mResizeTimer;
-
-    bool mFirstResize;
 
     QgsPreviewEffect* mPreviewEffect;
 


### PR DESCRIPTION
A issue I currently have, and really hate, is that when you open any of the panels it will cause a redraw to happen in the canvas.  This is super annoying generally but made worse if the map is complex. Also means that we can't really have auto hide because that would render the map each time a panel hides/shows.  This PR fixes that so that the canvas doesn't re-render on resize.

If the main application window is resized the canvas will still resize as the item needs to be updated, can't really avoid a redraw here as we need new content.

Here is a quick demo:

![anim](https://cloud.githubusercontent.com/assets/381660/14883927/c236f556-0d84-11e6-83fd-49356066b36e.gif)

The code still needs some tweaks. Mainly just hacked in for demo and thoughts?

ping @wonder-sk @nyalldawson 
