### PR TITLE
Processing - Output tables with no geometry througt OutputVector

### DIFF
--- a/python/plugins/processing/algs/qgis/FieldsMapper.py
+++ b/python/plugins/processing/algs/qgis/FieldsMapper.py
@@ -30,7 +30,7 @@ from qgis.core import QgsField, QgsExpression, QgsExpressionContext, QgsExpressi
 from qgis.utils import iface
 from processing.core.GeoAlgorithm import GeoAlgorithm
 from processing.core.GeoAlgorithmExecutionException import GeoAlgorithmExecutionException
-from processing.core.parameters import ParameterVector
+from processing.core.parameters import ParameterTable
 from processing.core.outputs import OutputVector
 from processing.tools import dataobjects, vector
 
@@ -52,13 +52,15 @@ class FieldsMapper(GeoAlgorithm):
     def defineCharacteristics(self):
         self.name, self.i18n_name = self.trAlgorithm('Refactor fields')
         self.group, self.i18n_group = self.trAlgorithm('Vector table tools')
-        self.addParameter(ParameterVector(self.INPUT_LAYER,
-                                          self.tr('Input layer'),
-                                          [ParameterVector.VECTOR_TYPE_ANY], False))
+        self.addParameter(ParameterTable(self.INPUT_LAYER,
+                                         self.tr('Input layer'),
+                                         False))
         self.addParameter(ParameterFieldsMapping(self.FIELDS_MAPPING,
-                                                 self.tr('Fields mapping'), self.INPUT_LAYER))
+                                                 self.tr('Fields mapping'),
+                                                 self.INPUT_LAYER))
         self.addOutput(OutputVector(self.OUTPUT_LAYER,
-                                    self.tr('Refactored')))
+                                    self.tr('Refactored'),
+                                    base_input=self.INPUT_LAYER))
 
     def processAlgorithm(self, progress):
         layer = self.getParameterValue(self.INPUT_LAYER)
@@ -120,7 +122,9 @@ class FieldsMapper(GeoAlgorithm):
         for current, inFeat in enumerate(features):
             rownum = current + 1
 
-            outFeat.setGeometry(inFeat.geometry())
+            geometry = inFeat.geometry()
+            if geometry is not None:
+                outFeat.setGeometry(geometry)
 
             attrs = []
             for i in xrange(0, len(mapping)):

--- a/python/plugins/processing/algs/qgis/ui/FieldsMapperDialogs.py
+++ b/python/plugins/processing/algs/qgis/ui/FieldsMapperDialogs.py
@@ -56,7 +56,8 @@ class FieldsMapperParametersPanel(ParametersPanel):
             else:
                 items = []
                 self.dependentItems[param.parent] = items
-            items.append(param.name)
+            items.append(param)
+
             parent = self.alg.getParameterFromName(param.parent)
             if isinstance(parent, ParameterVector):
                 layers = dataobjects.getVectorLayers(parent.shapetype)
@@ -76,16 +77,17 @@ class FieldsMapperParametersPanel(ParametersPanel):
         layer = sender.itemData(sender.currentIndex())
         children = self.dependentItems[sender.name]
         for child in children:
-            widget = self.valueItems[child]
+            widget = self.valueItems[child.name]
             if isinstance(widget, FieldsMappingPanel):
                 widget.setLayer(layer)
+        ParametersPanel.updateDependentFields(self)
 
     def somethingDependsOnThisParameter(self, parent):
         for param in self.alg.parameters:
             if isinstance(param, ParameterFieldsMapping):
                 if param.parent == parent.name:
                     return True
-        return False
+        return ParametersPanel.somethingDependsOnThisParameter(self, parent)
 
 
 class FieldsMapperParametersDialog(AlgorithmDialog):

--- a/python/plugins/processing/algs/qgis/ui/FieldsMappingPanel.py
+++ b/python/plugins/processing/algs/qgis/ui/FieldsMappingPanel.py
@@ -463,7 +463,7 @@ class FieldsMappingPanel(BASE, WIDGET):
             self.model.index(end, self.model.columnCount() - 1))
 
     def updateLayerCombo(self):
-        layers = dataobjects.getVectorLayers()
+        layers = dataobjects.getTables()
         layers.sort(key=lambda lay: lay.name())
         for layer in layers:
             self.layerCombo.addItem(layer.name(), layer)

--- a/python/plugins/processing/core/GeoAlgorithm.py
+++ b/python/plugins/processing/core/GeoAlgorithm.py
@@ -354,7 +354,7 @@ class GeoAlgorithm:
                     out.value = out.value + '.' + exts[0]
                 else:
                     ext = out.value[idx + 1:]
-                    if ext not in exts:
+                    if ext not in exts + ['dbf']:
                         out.value = out.value + '.' + exts[0]
 
     def resolveTemporaryOutputs(self):

--- a/python/plugins/processing/gui/OutputSelectionPanel.py
+++ b/python/plugins/processing/gui/OutputSelectionPanel.py
@@ -142,7 +142,9 @@ class OutputSelectionPanel(BASE, WIDGET):
             password = settings.value(mySettings + '/password')
             uri = QgsDataSourceURI()
             uri.setConnection(host, str(port), dbname, user, password)
-            uri.setDataSource(dlg.schema, dlg.table, "the_geom")
+            uri.setDataSource(dlg.schema, dlg.table,
+                              "the_geom" if self.output.hasGeometry() else None)
+
             connInfo = uri.connectionInfo()
             (success, user, passwd) = QgsCredentials.instance().get(connInfo, None, None)
             if success:
@@ -182,7 +184,8 @@ class OutputSelectionPanel(BASE, WIDGET):
 
             uri = QgsDataSourceURI()
             uri.setDatabase(fileName)
-            uri.setDataSource('', self.output.name.lower(), 'the_geom')
+            uri.setDataSource('', self.output.name.lower(),
+                              'the_geom' if self.output.hasGeometry() else None)
             self.leText.setText("spatialite:" + uri.uri())
 
     def saveToMemory(self):


### PR DESCRIPTION
Here I add possibility to create .dbf, .csv, .ods and .xlsx files, memory layers or spatialite/postgis tables without geometry in OutputVector class.

This is very helpful for `Refactor field` algorithm, and possibly for all attributes algorithms in Vector table tools category, as we can process all tables, even if they do not have geometry.

These features were funded by: MEDDE (French Ministry of Sustainable Development)
