### PR TITLE
[FEATURE] New map tool for interactively setting point symbol offset

### DIFF
--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -74,6 +74,8 @@ SET(QGIS_APP_SRCS
   qgsmaptoolmovefeature.cpp
   qgsmaptoolmovelabel.cpp
   qgsmaptooloffsetcurve.cpp
+  qgsmaptooloffsetpointsymbol.cpp
+  qgsmaptoolpointsymbol.cpp
   qgsmaptoolreshape.cpp
   qgsmaptoolrotatefeature.cpp
   qgsmaptoolrotatelabel.cpp
@@ -100,6 +102,7 @@ SET(QGIS_APP_SRCS
   qgsmeasuretool.cpp
   qgsmergeattributesdialog.cpp
   qgsoptions.cpp
+  qgspointmarkeritem.cpp
   qgspointrotationitem.cpp
   qgspluginmetadata.cpp
   qgspluginregistry.cpp
@@ -250,6 +253,8 @@ SET (QGIS_APP_MOC_HDRS
   qgsmaptoolmovelabel.h
   qgsmaptoollabel.h
   qgsmaptooloffsetcurve.h
+  qgsmaptooloffsetpointsymbol.h
+  qgsmaptoolpointsymbol.h
   qgsmaptoolreshape.h
   qgsmaptoolrotatefeature.h
   qgsmaptoolrotatelabel.h

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -293,6 +293,7 @@
 #include "qgsmaptoolmovefeature.h"
 #include "qgsmaptoolrotatefeature.h"
 #include "qgsmaptooloffsetcurve.h"
+#include "qgsmaptooloffsetpointsymbol.h"
 #include "qgsmaptoolpan.h"
 #include "qgsmaptoolselect.h"
 #include "qgsmaptoolselectrectangle.h"
@@ -1115,6 +1116,7 @@ QgisApp::~QgisApp()
   delete mMapTools.mRotateFeature;
   delete mMapTools.mRotateLabel;
   delete mMapTools.mRotatePointSymbolsTool;
+  delete mMapTools.mOffsetPointSymbolTool;
   delete mMapTools.mSelectFreehand;
   delete mMapTools.mSelectPolygon;
   delete mMapTools.mSelectRadius;
@@ -1396,6 +1398,7 @@ void QgisApp::createActions()
   connect( mActionMultiEditAttributes, SIGNAL( triggered() ), this, SLOT( modifyAttributesOfSelectedFeatures() ) );
   connect( mActionNodeTool, SIGNAL( triggered() ), this, SLOT( nodeTool() ) );
   connect( mActionRotatePointSymbols, SIGNAL( triggered() ), this, SLOT( rotatePointSymbols() ) );
+  connect( mActionOffsetPointSymbol, SIGNAL( triggered() ), this, SLOT( offsetPointSymbol() ) );
   connect( mActionSnappingOptions, SIGNAL( triggered() ), this, SLOT( snappingOptions() ) );
   connect( mActionOffsetCurve, SIGNAL( triggered() ), this, SLOT( offsetCurve() ) );
 
@@ -1681,6 +1684,7 @@ void QgisApp::createActionGroups()
   mMapToolGroup->addAction( mActionMergeFeatureAttributes );
   mMapToolGroup->addAction( mActionNodeTool );
   mMapToolGroup->addAction( mActionRotatePointSymbols );
+  mMapToolGroup->addAction( mActionOffsetPointSymbol );
 
   mMapToolGroup->addAction( mActionPinLabels );
   mMapToolGroup->addAction( mActionShowHideLabels );
@@ -2328,6 +2332,7 @@ void QgisApp::setTheme( const QString& theThemeName )
   mActionOffsetCurve->setIcon( QgsApplication::getThemeIcon( "/mActionOffsetCurve.png" ) );
   mActionMergeFeatureAttributes->setIcon( QgsApplication::getThemeIcon( "/mActionMergeFeatureAttributes.png" ) );
   mActionRotatePointSymbols->setIcon( QgsApplication::getThemeIcon( "mActionRotatePointSymbols.png" ) );
+  mActionOffsetPointSymbol->setIcon( QgsApplication::getThemeIcon( "mActionRotatePointSymbols.png" ) );
   mActionZoomIn->setIcon( QgsApplication::getThemeIcon( "/mActionZoomIn.svg" ) );
   mActionZoomOut->setIcon( QgsApplication::getThemeIcon( "/mActionZoomOut.svg" ) );
   mActionZoomFullExtent->setIcon( QgsApplication::getThemeIcon( "/mActionZoomFullExtent.svg" ) );
@@ -2591,6 +2596,8 @@ void QgisApp::createCanvasTools()
   mMapTools.mNodeTool->setAction( mActionNodeTool );
   mMapTools.mRotatePointSymbolsTool = new QgsMapToolRotatePointSymbols( mMapCanvas );
   mMapTools.mRotatePointSymbolsTool->setAction( mActionRotatePointSymbols );
+  mMapTools.mOffsetPointSymbolTool = new QgsMapToolOffsetPointSymbol( mMapCanvas );
+  mMapTools.mOffsetPointSymbolTool->setAction( mActionOffsetPointSymbol );
 
   mMapTools.mPinLabels = new QgsMapToolPinLabels( mMapCanvas );
   mMapTools.mPinLabels->setAction( mActionPinLabels );
@@ -6754,6 +6761,11 @@ void QgisApp::rotatePointSymbols()
   mMapCanvas->setMapTool( mMapTools.mRotatePointSymbolsTool );
 }
 
+void QgisApp::offsetPointSymbol()
+{
+  mMapCanvas->setMapTool( mMapTools.mOffsetPointSymbolTool );
+}
+
 void QgisApp::snappingOptions()
 {
   mSnappingDialog->show();
@@ -10023,6 +10035,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer* layer )
     mActionMergeFeatureAttributes->setEnabled( false );
     mActionMultiEditAttributes->setEnabled( false );
     mActionRotatePointSymbols->setEnabled( false );
+    mActionOffsetPointSymbol->setEnabled( false );
     mActionEnableTracing->setEnabled( false );
 
     mActionPinLabels->setEnabled( false );
@@ -10166,6 +10179,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer* layer )
         mActionSimplifyFeature->setEnabled( false );
         mActionDeleteRing->setEnabled( false );
         mActionRotatePointSymbols->setEnabled( false );
+        mActionOffsetPointSymbol->setEnabled( false );
         mActionOffsetCurve->setEnabled( false );
 
         if ( isEditable && canChangeAttributes )
@@ -10173,6 +10187,10 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer* layer )
           if ( QgsMapToolRotatePointSymbols::layerIsRotatable( vlayer ) )
           {
             mActionRotatePointSymbols->setEnabled( true );
+          }
+          if ( QgsMapToolOffsetPointSymbol::layerIsOffsetable( vlayer ) )
+          {
+            mActionOffsetPointSymbol->setEnabled( true );
           }
         }
       }
@@ -10287,6 +10305,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer* layer )
     mActionCutFeatures->setEnabled( false );
     mActionPasteFeatures->setEnabled( false );
     mActionRotatePointSymbols->setEnabled( false );
+    mActionOffsetPointSymbol->setEnabled( false );
     mActionDeletePart->setEnabled( false );
     mActionDeleteRing->setEnabled( false );
     mActionSimplifyFeature->setEnabled( false );

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1040,6 +1040,8 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     void nodeTool();
     //! activates the rotate points tool
     void rotatePointSymbols();
+    //! activates the offset point symbol tool
+    void offsetPointSymbol();
     //! shows the snapping Options
     void snappingOptions();
 
@@ -1569,6 +1571,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
         QgsMapTool *mDeletePart;
         QgsMapTool *mNodeTool;
         QgsMapTool *mRotatePointSymbolsTool;
+        QgsMapTool *mOffsetPointSymbolTool;
         QgsMapTool *mAnnotation;
         QgsMapTool *mFormAnnotation;
         QgsMapTool *mHtmlAnnotation;

--- a/src/app/qgsmaptooloffsetpointsymbol.cpp
+++ b/src/app/qgsmaptooloffsetpointsymbol.cpp
@@ -1,0 +1,262 @@
+/***************************************************************************
+    qgsmaptooloffsetpointsymbol.h
+    -----------------------------
+    begin                : April 2016
+    copyright            : (C) 2016 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsmaptooloffsetpointsymbol.h"
+#include "qgsapplication.h"
+#include "qgsmapcanvas.h"
+#include "qgspointmarkeritem.h"
+#include "qgsrendererv2.h"
+#include "qgssnappingutils.h"
+#include "qgssymbolv2.h"
+#include "qgsvectorlayer.h"
+#include "qgssymbollayerv2.h"
+#include "qgsdatadefined.h"
+#include "qgisapp.h"
+
+#include <QGraphicsPixmapItem>
+#include <QMouseEvent>
+
+QgsMapToolOffsetPointSymbol::QgsMapToolOffsetPointSymbol( QgsMapCanvas* canvas )
+    : QgsMapToolPointSymbol( canvas )
+    , mOffsetting( false )
+    , mOffsetItem( nullptr )
+    , mSymbolRotation( 0.0 )
+{}
+
+QgsMapToolOffsetPointSymbol::~QgsMapToolOffsetPointSymbol()
+{
+  delete mOffsetItem;
+}
+
+bool QgsMapToolOffsetPointSymbol::layerIsOffsetable( QgsMapLayer* ml )
+{
+  if ( !ml )
+  {
+    return false;
+  }
+
+  //a vector layer
+  QgsVectorLayer* vLayer = qobject_cast<QgsVectorLayer *>( ml );
+  if ( !vLayer )
+  {
+    return false;
+  }
+
+  //does it have point or multipoint type?
+  if ( vLayer->geometryType() != QGis::Point )
+  {
+    return false;
+  }
+
+  //we consider all point layers as offsetable, as data defined offset can be set on a per
+  //symbol/feature basis
+  return true;
+}
+
+void QgsMapToolOffsetPointSymbol::canvasPressEvent( QgsMapMouseEvent* e )
+{
+  mMarkerSymbol.reset( nullptr );
+  mClickedPoint = e->mapPoint();
+  mSymbolRotation = 0.0;
+  QgsMapToolPointSymbol::canvasPressEvent( e );
+}
+
+void QgsMapToolOffsetPointSymbol::canvasPressOnFeature( QgsMapMouseEvent *e, const QgsFeature &feature, const QgsPoint &snappedPoint )
+{
+  Q_UNUSED( e );
+  mClickedFeature = feature;
+  createPreviewItem( mMarkerSymbol.data() );
+  mOffsetItem->setPointLocation( snappedPoint );
+  updateOffsetPreviewItem( mClickedPoint, mClickedPoint );
+  mOffsetting = true;
+}
+
+bool QgsMapToolOffsetPointSymbol::checkSymbolCompatibility( QgsMarkerSymbolV2* markerSymbol, QgsRenderContext &context )
+{
+  bool ok = false;
+
+  Q_FOREACH ( QgsSymbolLayerV2* layer, markerSymbol->symbolLayers() )
+  {
+    if ( !layer->hasDataDefinedProperty( "offset" ) )
+      continue;
+
+    if ( layer->getDataDefinedProperty( "offset" )->useExpression() )
+      continue;
+
+    ok = true;
+    if ( mMarkerSymbol.isNull() )
+    {
+      double symbolRotation = markerSymbol->angle();
+      if ( layer->hasDataDefinedProperty( "angle" ) )
+      {
+        QString rotationExp = layer->getDataDefinedProperty( "angle" )->expressionOrField();
+        QgsExpression exp( rotationExp );
+        QVariant val = exp.evaluate( &context.expressionContext() );
+        bool convertOk = false;
+        double rotation = val.toDouble( &convertOk );
+        if ( convertOk )
+          symbolRotation = rotation;
+      }
+
+      mSymbolRotation = symbolRotation;
+      mMarkerSymbol.reset( markerSymbol->clone() );
+    }
+  }
+  return ok;
+}
+
+void QgsMapToolOffsetPointSymbol::noCompatibleSymbols()
+{
+  emit messageEmitted( tr( "The selected point does not have an offset attribute set." ), QgsMessageBar::CRITICAL );
+}
+
+void QgsMapToolOffsetPointSymbol::canvasMoveEvent( QgsMapMouseEvent* e )
+{
+  if ( !mOffsetting )
+  {
+    return;
+  }
+
+  updateOffsetPreviewItem( mClickedPoint, e->mapPoint() );
+}
+
+void QgsMapToolOffsetPointSymbol::canvasReleaseEvent( QgsMapMouseEvent* e )
+{
+  Q_UNUSED( e );
+
+  if ( mOffsetting && mActiveLayer )
+  {
+    QMap<int, QVariant> attrs = calculateNewOffsetAttributes( mClickedPoint, e->mapPoint() );
+    mActiveLayer->beginEditCommand( tr( "Offset symbol" ) );
+    bool offsetSuccess = true;
+
+    //write offset to attributes
+    QMap<int, QVariant>::const_iterator it = attrs.constBegin();
+    for ( ; it != attrs.constEnd(); ++it )
+    {
+      if ( !mActiveLayer->changeAttributeValue( mFeatureNumber, it.key(), it.value() ) )
+      {
+        offsetSuccess = false;
+      }
+    }
+
+    if ( offsetSuccess )
+    {
+      mActiveLayer->endEditCommand();
+    }
+    else
+    {
+      mActiveLayer->destroyEditCommand();
+    }
+  }
+  mOffsetting = false;
+  delete mOffsetItem;
+  mOffsetItem = nullptr;
+  mCanvas->refresh();
+}
+
+void QgsMapToolOffsetPointSymbol::createPreviewItem( QgsMarkerSymbolV2* markerSymbol )
+{
+  delete mOffsetItem;
+  mOffsetItem = nullptr;
+
+  if ( !mCanvas )
+  {
+    return;
+  }
+
+  mOffsetItem = new QgsPointMarkerItem( mCanvas );
+  mOffsetItem->setTransparency( 0.3 );
+  mOffsetItem->setSymbol( markerSymbol->clone() );
+}
+
+QMap<int, QVariant> QgsMapToolOffsetPointSymbol::calculateNewOffsetAttributes( const QgsPoint& startPoint, const QgsPoint& endPoint ) const
+{
+  QMap<int, QVariant> newAttrValues;
+  Q_FOREACH ( QgsSymbolLayerV2* layer, mMarkerSymbol->symbolLayers() )
+  {
+    if ( !layer->hasDataDefinedProperty( "offset" ) )
+      continue;
+
+    if ( layer->getDataDefinedProperty( "offset" )->useExpression() )
+      continue;
+
+    QgsMarkerSymbolLayerV2* ml = dynamic_cast< QgsMarkerSymbolLayerV2* >( layer );
+    if ( !ml )
+      continue;
+
+    QPointF offset = calculateOffset( startPoint, endPoint, ml->offsetUnit() );
+    int fieldIdx = mActiveLayer->fields().indexFromName( layer->getDataDefinedProperty( "offset" )->field() );
+    if ( fieldIdx >= 0 )
+      newAttrValues[ fieldIdx ] = QgsSymbolLayerV2Utils::encodePoint( offset );
+  }
+  return newAttrValues;
+}
+
+void QgsMapToolOffsetPointSymbol::updateOffsetPreviewItem( const QgsPoint& startPoint, const QgsPoint& endPoint )
+{
+  if ( !mOffsetItem )
+    return;
+
+  QgsFeature f = mClickedFeature;
+  QMap<int, QVariant> attrs = calculateNewOffsetAttributes( startPoint, endPoint );
+  QMap<int, QVariant>::const_iterator it = attrs.constBegin();
+  for ( ; it != attrs.constEnd(); ++it )
+  {
+    f.setAttribute( it.key(), it.value() );
+  }
+
+  mOffsetItem->setFeature( f );
+  mOffsetItem->updateSize();
+}
+
+QPointF QgsMapToolOffsetPointSymbol::calculateOffset( const QgsPoint& startPoint, const QgsPoint& endPoint, QgsSymbolV2::OutputUnit unit ) const
+{
+  double dx = endPoint.x() - startPoint.x();
+  double dy = -( endPoint.y() - startPoint.y() );
+
+  double factor = 1.0;
+
+  switch ( unit )
+  {
+    case QgsSymbolV2::MM:
+      factor = 25.4 / mCanvas->mapSettings().outputDpi() / mCanvas->mapSettings().mapUnitsPerPixel() ;
+      break;
+
+    case QgsSymbolV2::Pixel:
+      factor = 1.0 / mCanvas->mapSettings().mapUnitsPerPixel();
+      break;
+
+    case QgsSymbolV2::MapUnit:
+      factor = 1.0;
+      break;
+
+    case QgsSymbolV2::Mixed:
+    case QgsSymbolV2::Percentage:
+      //no sensible value
+      factor = 1.0;
+      break;
+  }
+
+  return rotatedOffset( QPointF( dx * factor, dy * factor ), mSymbolRotation );
+}
+
+QPointF QgsMapToolOffsetPointSymbol::rotatedOffset( QPointF offset, double angle ) const
+{
+  angle = DEG2RAD( 360 - angle );
+  double c = cos( angle ), s = sin( angle );
+  return QPointF( offset.x() * c - offset.y() * s, offset.x() * s + offset.y() * c );
+}
+

--- a/src/app/qgsmaptooloffsetpointsymbol.h
+++ b/src/app/qgsmaptooloffsetpointsymbol.h
@@ -1,0 +1,93 @@
+/***************************************************************************
+    qgsmaptooloffsetpointsymbol.h
+    -----------------------------
+    begin                : April 2016
+    copyright            : (C) 2016 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSMAPTOOLOFFSETPOINTSYMBOL_H
+#define QGSMAPTOOLOFFSETPOINTSYMBOL_H
+
+#include "qgsmaptoolpointsymbol.h"
+#include "qgssymbolv2.h"
+
+class QgsMarkerSymbolV2;
+class QgsPointMarkerItem;
+
+/** \ingroup app
+ * \class QgsMapToolOffsetPointSymbol
+ * \brief A class that allows interactive manipulation of the offset field(s) for point layers.
+ */
+
+class APP_EXPORT QgsMapToolOffsetPointSymbol: public QgsMapToolPointSymbol
+{
+    Q_OBJECT
+
+  public:
+    QgsMapToolOffsetPointSymbol( QgsMapCanvas* canvas );
+    ~QgsMapToolOffsetPointSymbol();
+
+    void canvasPressEvent( QgsMapMouseEvent* e ) override;
+    void canvasMoveEvent( QgsMapMouseEvent* e ) override;
+    void canvasReleaseEvent( QgsMapMouseEvent* e ) override;
+
+    /** Returns true if the symbols of a map layer can be offset. This means the layer
+     *  is a vector layer, has type point or multipoint and has at least one offset attribute in the renderer.
+    */
+    static bool layerIsOffsetable( QgsMapLayer* ml );
+
+  protected:
+
+    virtual void canvasPressOnFeature( QgsMapMouseEvent* e, const QgsFeature& feature, const QgsPoint& snappedPoint ) override;
+    virtual bool checkSymbolCompatibility( QgsMarkerSymbolV2* markerSymbol, QgsRenderContext& context ) override;
+    virtual void noCompatibleSymbols() override;
+
+  private:
+
+    //! True when user is dragging to offset a point
+    bool mOffsetting;
+
+    //! Item that previews the offset during mouse move
+    QgsPointMarkerItem* mOffsetItem;
+
+    //! Clone of first found marker symbol for feature with offset attribute set
+    QScopedPointer< QgsMarkerSymbolV2 > mMarkerSymbol;
+
+    //! Feature which was clicked on
+    QgsFeature mClickedFeature;
+
+    //! Point in map units where click originated
+    QgsPoint mClickedPoint;
+
+    //! Stores the symbol rotation so that offset can be adjusted to account for rotation
+    double mSymbolRotation;
+
+    //! Create item with the point symbol for a specific feature. This will be used to show the offset to the user.
+    void createPreviewItem( QgsMarkerSymbolV2 *markerSymbol );
+
+    //! Calculates the new values for offset attributes, respecting the symbol's offset units
+    //! @note start and end point are in map units
+    QMap< int, QVariant > calculateNewOffsetAttributes( const QgsPoint& startPoint, const QgsPoint& endPoint ) const;
+
+    /** Updates the preview item to reflect a new offset.
+     * @note start and end points are in map units
+     */
+    void updateOffsetPreviewItem( const QgsPoint& startPoint, const QgsPoint& endPoint );
+
+    //! Calculates the required offset from the start to end points, in the specified unit
+    //! @note start and end points are in map units
+    QPointF calculateOffset( const QgsPoint& startPoint, const QgsPoint& endPoint, QgsSymbolV2::OutputUnit unit ) const;
+
+    //! Adjusts the calculated offset to account for the symbol's rotation
+    QPointF rotatedOffset( QPointF offset, double angle ) const;
+};
+
+#endif // QGSMAPTOOLOFFSETPOINTSYMBOL_H

--- a/src/app/qgsmaptoolpointsymbol.cpp
+++ b/src/app/qgsmaptoolpointsymbol.cpp
@@ -1,0 +1,108 @@
+/***************************************************************************
+    qgsmaptoolpointsymbol.cpp
+    -------------------------
+    begin                : April 2016
+    copyright            : (C) 2016 by Marco Hugentobler, Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsmaptoolpointsymbol.h"
+#include "qgsrendererv2.h"
+#include "qgsvectorlayer.h"
+#include "qgsmapcanvas.h"
+
+#include <QMouseEvent>
+
+QgsMapToolPointSymbol::QgsMapToolPointSymbol( QgsMapCanvas* canvas )
+    : QgsMapToolEdit( canvas )
+    , mActiveLayer( nullptr )
+    , mFeatureNumber( -1 )
+{}
+
+void QgsMapToolPointSymbol::canvasPressEvent( QgsMapMouseEvent* e )
+{
+  if ( !mCanvas )
+  {
+    return;
+  }
+
+  mActiveLayer = currentVectorLayer();
+  if ( !mActiveLayer )
+  {
+    notifyNotVectorLayer();
+    return;
+  }
+
+  if ( !mActiveLayer->isEditable() )
+  {
+    notifyNotEditableLayer();
+    return;
+  }
+
+  if ( mActiveLayer->geometryType() != QGis::Point )
+  {
+    return;
+  }
+
+  //find the closest feature to the pressed position
+  QgsPointLocator::Match m = mCanvas->snappingUtils()->snapToCurrentLayer( e->pos(), QgsPointLocator::Vertex );
+  if ( !m.isValid() )
+  {
+    emit messageEmitted( tr( "No point feature was detected at the clicked position. Please click closer to the feature or enhance the search tolerance under Settings->Options->Digitizing->Search radius for vertex edits" ), QgsMessageBar::CRITICAL );
+    return; //error during snapping
+  }
+
+  mFeatureNumber = m.featureId();
+  mSnappedPoint = toCanvasCoordinates( m.point() );
+
+  QgsFeature feature;
+  if ( !mActiveLayer->getFeatures( QgsFeatureRequest().setFilterFid( mFeatureNumber ) ).nextFeature( feature ) )
+  {
+    return;
+  }
+
+  //check whether selected feature has a modifiable symbol
+  QgsFeatureRendererV2* renderer = mActiveLayer->rendererV2();
+  if ( !renderer )
+    return;
+  QgsRenderContext context = QgsRenderContext::fromMapSettings( mCanvas->mapSettings() );
+  context.expressionContext() << QgsExpressionContextUtils::layerScope( mActiveLayer );
+  context.expressionContext().setFeature( feature );
+  renderer->startRender( context, mActiveLayer->fields() );
+
+  //test whether symbol is compatible with map tool
+  bool hasCompatibleSymbol = false;
+  if ( renderer->capabilities() & QgsFeatureRendererV2::MoreSymbolsPerFeature )
+  {
+    //could be multiple symbols for this feature, so check them all
+    Q_FOREACH ( QgsSymbolV2* s, renderer->originalSymbolsForFeature( feature, context ) )
+    {
+      if ( s && s->type() == QgsSymbolV2::Marker )
+      {
+        hasCompatibleSymbol = hasCompatibleSymbol || checkSymbolCompatibility( static_cast< QgsMarkerSymbolV2* >( s ), context );
+      }
+    }
+  }
+  else
+  {
+    QgsSymbolV2* s = renderer->originalSymbolForFeature( feature, context );
+    if ( s && s->type() == QgsSymbolV2::Marker )
+    {
+      hasCompatibleSymbol = hasCompatibleSymbol || checkSymbolCompatibility( static_cast< QgsMarkerSymbolV2* >( s ), context );
+    }
+  }
+
+  renderer->stopRender( context );
+  if ( hasCompatibleSymbol )
+    canvasPressOnFeature( e, feature, m.point() );
+  else
+    noCompatibleSymbols();
+}
+

--- a/src/app/qgsmaptoolpointsymbol.h
+++ b/src/app/qgsmaptoolpointsymbol.h
@@ -1,0 +1,55 @@
+/***************************************************************************
+    qgsmaptoolpointsymbol.h
+    -----------------------
+    begin                : April 2016
+    copyright            : (C) 2016 by Marco Hugentobler, Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSMAPTOOLPOINTSYMBOL_H
+#define QGSMAPTOOLPOINTSYMBOL_H
+
+#include "qgsmaptooledit.h"
+#include "qgsfeature.h"
+
+class QgsMarkerSymbolV2;
+
+/** \ingroup app
+ * \class QgsMapToolPointSymbol
+ * \brief An abstract base class that allows interactive manipulation of the symbols for point layers. Handles
+ * snapping the mouse press to a feature, and detecting whether the clicked feature has symbology which is
+ * compatible with the map tool.
+ */
+class APP_EXPORT QgsMapToolPointSymbol: public QgsMapToolEdit
+{
+    Q_OBJECT
+
+  public:
+    QgsMapToolPointSymbol( QgsMapCanvas* canvas );
+
+    void canvasPressEvent( QgsMapMouseEvent* e ) override;
+    bool isEditTool() override { return true; }
+
+  protected:
+    QgsVectorLayer* mActiveLayer;
+    QgsFeatureId mFeatureNumber;
+
+    /** Screen coordinate of the snaped feature*/
+    QPoint mSnappedPoint;
+
+    virtual void canvasPressOnFeature( QgsMapMouseEvent* e, const QgsFeature& feature, const QgsPoint& snappedPoint ) = 0;
+
+    virtual bool checkSymbolCompatibility( QgsMarkerSymbolV2* markerSymbol, QgsRenderContext& context ) = 0;
+
+    virtual void noCompatibleSymbols() {}
+
+};
+
+#endif // QGSMAPTOOLPOINTSYMBOL_H

--- a/src/app/qgsmaptoolrotatepointsymbols.cpp
+++ b/src/app/qgsmaptoolrotatepointsymbols.cpp
@@ -28,17 +28,13 @@
 #include <QMouseEvent>
 
 QgsMapToolRotatePointSymbols::QgsMapToolRotatePointSymbols( QgsMapCanvas* canvas )
-    : QgsMapToolEdit( canvas )
-    , mActiveLayer( nullptr )
-    , mFeatureNumber( 0 )
+    : QgsMapToolPointSymbol( canvas )
     , mCurrentMouseAzimut( 0.0 )
     , mCurrentRotationFeature( 0.0 )
     , mRotating( false )
     , mRotationItem( nullptr )
     , mCtrlPressed( false )
-{
-
-}
+{}
 
 QgsMapToolRotatePointSymbols::~QgsMapToolRotatePointSymbols()
 {
@@ -72,112 +68,49 @@ bool QgsMapToolRotatePointSymbols::layerIsRotatable( QgsMapLayer* ml )
 
 void QgsMapToolRotatePointSymbols::canvasPressEvent( QgsMapMouseEvent* e )
 {
-  if ( !mCanvas )
-  {
-    return;
-  }
-
-  mActiveLayer = currentVectorLayer();
-  if ( !mActiveLayer )
-  {
-    notifyNotVectorLayer();
-    return;
-  }
-
-  if ( !mActiveLayer->isEditable() )
-  {
-    notifyNotEditableLayer();
-    return;
-  }
-
-  if ( mActiveLayer->geometryType() != QGis::Point )
-  {
-    return;
-  }
-
-  //find the closest feature to the pressed position
-  QgsPointLocator::Match m = mCanvas->snappingUtils()->snapToCurrentLayer( e->pos(), QgsPointLocator::Vertex );
-  if ( !m.isValid() )
-  {
-    emit messageEmitted( tr( "No point feature was detected at the clicked position. Please click closer to the feature or enhance the search tolerance under Settings->Options->Digitizing->Search radius for vertex edits" ), QgsMessageBar::CRITICAL );
-    return; //error during snapping
-  }
-
-  mFeatureNumber = m.featureId();
   mCurrentRotationAttributes.clear();
-  mSnappedPoint = toCanvasCoordinates( m.point() );
+  mMarkerSymbol.reset( nullptr );
+  QgsMapToolPointSymbol::canvasPressEvent( e );
+}
 
-  QgsFeature pointFeature;
-  if ( !mActiveLayer->getFeatures( QgsFeatureRequest().setFlags( QgsFeatureRequest::NoGeometry ).setFilterFid( mFeatureNumber ) ).nextFeature( pointFeature ) )
-  {
-    return;
-  }
-
-  //check whether selected feature has a rotatable symbol
-  QgsFeatureRendererV2* renderer = mActiveLayer->rendererV2();
-  if ( !renderer )
-    return;
-  QgsRenderContext context = QgsRenderContext::fromMapSettings( mCanvas->mapSettings() );
-  context.expressionContext() << QgsExpressionContextUtils::layerScope( mActiveLayer );
-  context.expressionContext().setFeature( pointFeature );
-  renderer->startRender( context, mActiveLayer->fields() );
-
-  //find all rotation fields used by renderer for feature
-  QgsMarkerSymbolV2* markerSymbol = nullptr;
-  if ( renderer->capabilities() & QgsFeatureRendererV2::MoreSymbolsPerFeature )
-  {
-    //could be multiple symbols for this feature, so check them all
-    Q_FOREACH ( QgsSymbolV2* s, renderer->originalSymbolsForFeature( pointFeature, context ) )
-    {
-      if ( s && s->type() == QgsSymbolV2::Marker )
-      {
-        markerSymbol = static_cast< QgsMarkerSymbolV2* >( s );
-        QString rotationField = ( markerSymbol->dataDefinedAngle().isActive() && !markerSymbol->dataDefinedAngle().useExpression() ) ?
-                                markerSymbol->dataDefinedAngle().field() : QString();
-        if ( !rotationField.isEmpty() )
-        {
-          int fieldIndex = mActiveLayer->fields().indexFromName( rotationField );
-          if ( !mCurrentRotationAttributes.contains( fieldIndex ) )
-            mCurrentRotationAttributes << fieldIndex;
-        }
-      }
-    }
-  }
-  else
-  {
-    QgsSymbolV2* s = renderer->originalSymbolForFeature( pointFeature, context );
-    if ( s && s->type() == QgsSymbolV2::Marker )
-    {
-      markerSymbol = static_cast< QgsMarkerSymbolV2* >( s );
-      QString rotationField = ( markerSymbol->dataDefinedAngle().isActive() && !markerSymbol->dataDefinedAngle().useExpression() ) ?
-                              markerSymbol->dataDefinedAngle().field() : QString();
-      if ( !rotationField.isEmpty() )
-        mCurrentRotationAttributes << mActiveLayer->fields().indexFromName( rotationField );
-    }
-  }
-
-  if ( mCurrentRotationAttributes.isEmpty() )
-  {
-    emit messageEmitted( tr( "The selected point does not have a rotation attribute." ), QgsMessageBar::CRITICAL );
-    return;
-  }
-
+void QgsMapToolRotatePointSymbols::canvasPressOnFeature( QgsMapMouseEvent *e, const QgsFeature &feature, const QgsPoint &snappedPoint )
+{
   //find out initial arrow direction
-  QVariant attrVal = pointFeature.attribute( mCurrentRotationAttributes.at( 0 ) );
+  QVariant attrVal = feature.attribute( mCurrentRotationAttributes.toList().at( 0 ) );
   if ( !attrVal.isValid() )
   {
     return;
   }
 
   mCurrentRotationFeature = attrVal.toDouble();
-  createPixmapItem( markerSymbol );
+  createPixmapItem( mMarkerSymbol.data() );
   if ( mRotationItem )
   {
-    mRotationItem->setPointLocation( m.point() );
+    mRotationItem->setPointLocation( snappedPoint );
   }
   mCurrentMouseAzimut = calculateAzimut( e->pos() );
   setPixmapItemRotation(( int )( mCurrentMouseAzimut ) );
   mRotating = true;
+}
+
+bool QgsMapToolRotatePointSymbols::checkSymbolCompatibility( QgsMarkerSymbolV2* markerSymbol, QgsRenderContext& )
+{
+  bool ok = false;
+  if ( markerSymbol->dataDefinedAngle().isActive() && !markerSymbol->dataDefinedAngle().useExpression() )
+  {
+    mCurrentRotationAttributes << mActiveLayer->fields().indexFromName( markerSymbol->dataDefinedAngle().field() );
+    ok = true;
+    if ( mMarkerSymbol.isNull() )
+    {
+      mMarkerSymbol.reset( markerSymbol->clone() );
+    }
+  }
+  return ok;
+}
+
+void QgsMapToolRotatePointSymbols::noCompatibleSymbols()
+{
+  emit messageEmitted( tr( "The selected point does not have a rotation attribute set." ), QgsMessageBar::CRITICAL );
 }
 
 void QgsMapToolRotatePointSymbols::canvasMoveEvent( QgsMapMouseEvent* e )
@@ -245,7 +178,7 @@ void QgsMapToolRotatePointSymbols::canvasReleaseEvent( QgsMapMouseEvent* e )
       rotation = ( int )mCurrentRotationFeature;
     }
 
-    QList<int>::const_iterator it = mCurrentRotationAttributes.constBegin();
+    QSet<int>::const_iterator it = mCurrentRotationAttributes.constBegin();
     for ( ; it != mCurrentRotationAttributes.constEnd(); ++it )
     {
       if ( !mActiveLayer->changeAttributeValue( mFeatureNumber, *it, rotation ) )

--- a/src/app/qgsmaptoolrotatepointsymbols.h
+++ b/src/app/qgsmaptoolrotatepointsymbols.h
@@ -16,14 +16,17 @@
 #ifndef QGSMAPTOOLROTATEPOINTSYMBOLS_H
 #define QGSMAPTOOLROTATEPOINTSYMBOLS_H
 
-#include "qgsmaptooledit.h"
-#include "qgsfeature.h"
+#include "qgsmaptoolpointsymbol.h"
 
 class QgsPointRotationItem;
 class QgsMarkerSymbolV2;
 
-/** A class that allows interactive manipulation the value of the rotation field(s) for point layers*/
-class APP_EXPORT QgsMapToolRotatePointSymbols: public QgsMapToolEdit
+/** \ingroup app
+ * \class QgsMapToolRotatePointSymbols
+ * \brief A class that allows interactive manipulation the value of the rotation field(s) for point layers.
+ */
+
+class APP_EXPORT QgsMapToolRotatePointSymbols: public QgsMapToolPointSymbol
 {
     Q_OBJECT
 
@@ -35,27 +38,30 @@ class APP_EXPORT QgsMapToolRotatePointSymbols: public QgsMapToolEdit
     void canvasMoveEvent( QgsMapMouseEvent* e ) override;
     void canvasReleaseEvent( QgsMapMouseEvent* e ) override;
 
-    bool isEditTool() override {return true;}
-
     /** Returns true if the symbols of a maplayer can be rotated. This means the layer
       is a vector layer, has type point or multipoint and has at least one rotation attribute in the renderer*/
     static bool layerIsRotatable( QgsMapLayer* ml );
 
+  protected:
+
+    virtual void canvasPressOnFeature( QgsMapMouseEvent* e, const QgsFeature& feature, const QgsPoint& snappedPoint ) override;
+    virtual bool checkSymbolCompatibility( QgsMarkerSymbolV2* markerSymbol, QgsRenderContext& context ) override;
+    virtual void noCompatibleSymbols() override;
+
   private:
-    QgsVectorLayer* mActiveLayer;
-    QgsFeatureId mFeatureNumber;
+
     /** Last azimut between mouse and edited point*/
     double mCurrentMouseAzimut;
     /** Last feature rotation*/
     double mCurrentRotationFeature;
     bool mRotating;
-    QList<int> mCurrentRotationAttributes;
-    /** Screen coordinate of the snaped feature*/
-    QPoint mSnappedPoint;
+    QSet<int> mCurrentRotationAttributes;
     /** Item that displays rotation during mouse move*/
     QgsPointRotationItem* mRotationItem;
     /** True if ctrl was pressed during the last mouse move event*/
     bool mCtrlPressed;
+    //! Clone of first found marker symbol for feature with rotation attribute set
+    QScopedPointer< QgsMarkerSymbolV2 > mMarkerSymbol;
 
     void drawArrow( double azimut ) const;
     /** Calculates the azimut between mousePos and mSnappedPoint*/
@@ -66,6 +72,7 @@ class APP_EXPORT QgsMapToolRotatePointSymbols: public QgsMapToolEdit
     void setPixmapItemRotation( double rotation );
     /** Rounds value to 15 degree integer (used if ctrl pressed)*/
     static int roundTo15Degrees( double n );
+
 };
 
 #endif // QGSMAPTOOLROTATEPOINTSYMBOLS_H

--- a/src/app/qgspointmarkeritem.cpp
+++ b/src/app/qgspointmarkeritem.cpp
@@ -1,0 +1,124 @@
+/***************************************************************************
+    qgspointmarkeritem.cpp
+    ----------------------
+    begin                : April 2016
+    copyright            : (C) 2016 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgspointmarkeritem.h"
+#include "qgssymbolv2.h"
+#include "qgsmapcanvas.h"
+#include "qgsmapsettings.h"
+#include <QPainter>
+#include <cmath>
+
+QgsPointMarkerItem::QgsPointMarkerItem( QgsMapCanvas* canvas )
+    : QgsMapCanvasItem( canvas )
+    , mOpacityEffect( new QgsDrawSourceEffect() )
+{
+  setCacheMode( QGraphicsItem::ItemCoordinateCache );
+}
+
+QgsRenderContext QgsPointMarkerItem::renderContext( QPainter* painter )
+{
+  QgsExpressionContext context;
+  context << QgsExpressionContextUtils::globalScope()
+  << QgsExpressionContextUtils::projectScope()
+  << QgsExpressionContextUtils::atlasScope( nullptr );
+  if ( mMapCanvas )
+  {
+    context << QgsExpressionContextUtils::mapSettingsScope( mMapCanvas->mapSettings() )
+    << new QgsExpressionContextScope( mMapCanvas->expressionContextScope() );
+  }
+  else
+  {
+    context << QgsExpressionContextUtils::mapSettingsScope( QgsMapSettings() );
+  }
+  //context << QgsExpressionContextUtils::layerScope( mLayer );
+  context.setFeature( mFeature );
+
+  //setup render context
+  QgsMapSettings ms = mMapCanvas->mapSettings();
+  ms.setExpressionContext( context );
+  QgsRenderContext rc = QgsRenderContext::fromMapSettings( ms );
+  rc.setPainter( painter );
+
+  return rc;
+}
+
+void QgsPointMarkerItem::paint( QPainter * painter )
+{
+  if ( !painter )
+  {
+    return;
+  }
+
+  QgsRenderContext rc = renderContext( painter );
+
+  bool useEffect = !qgsDoubleNear( mOpacityEffect->transparency(), 0.0 );
+  if ( useEffect )
+  {
+    //use a paint effect to reduce opacity. If we directly set the opacity on the painter, then the symbol will NOT
+    //be correctly "flattened" and parts of the symbol which should be obscured will show through
+    mOpacityEffect->begin( rc );
+  }
+
+  mMarkerSymbol->startRender( rc, mFeature.fields() );
+  mMarkerSymbol->renderPoint( mLocation - pos(), &mFeature, rc );
+  mMarkerSymbol->stopRender( rc );
+
+  if ( useEffect )
+  {
+    mOpacityEffect->end( rc );
+  }
+}
+
+void QgsPointMarkerItem::setPointLocation( const QgsPoint& p )
+{
+  mLocation = toCanvasCoordinates( p );
+}
+
+void QgsPointMarkerItem::setSymbol( QgsMarkerSymbolV2 *symbol )
+{
+  mMarkerSymbol.reset( symbol );
+}
+
+QgsMarkerSymbolV2*QgsPointMarkerItem::symbol()
+{
+  return mMarkerSymbol.data();
+}
+
+void QgsPointMarkerItem::setFeature( const QgsFeature& feature )
+{
+  mFeature = feature;
+}
+
+void QgsPointMarkerItem::updateSize()
+{
+  QgsRenderContext rc = renderContext( nullptr );
+  mMarkerSymbol->startRender( rc, mFeature.fields() );
+  QRectF bounds =  mMarkerSymbol->bounds( mLocation, rc, mFeature );
+  mMarkerSymbol->stopRender( rc );
+  QgsRectangle r( mMapCanvas->mapSettings().mapToPixel().toMapCoordinates( bounds.x(), bounds.y() ),
+                  mMapCanvas->mapSettings().mapToPixel().toMapCoordinates( bounds.x() + bounds.width() * 2, bounds.y() + bounds.height() * 2 ) );
+  setRect( r );
+}
+
+void QgsPointMarkerItem::setTransparency( double transparency )
+{
+  mOpacityEffect->setTransparency( transparency );
+}
+
+double QgsPointMarkerItem::transparency() const
+{
+  return mOpacityEffect->transparency();
+}
+

--- a/src/app/qgspointmarkeritem.h
+++ b/src/app/qgspointmarkeritem.h
@@ -1,0 +1,100 @@
+/***************************************************************************
+    qgspointmarkeritem.h
+    --------------------
+    begin                : April 2016
+    copyright            : (C) 2016 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSPOINTMARKERITEM_H
+#define QGSPOINTMARKERITEM_H
+
+#include "qgsmapcanvasitem.h"
+#include "qgsfeature.h"
+#include "effects/qgspainteffect.h"
+#include <QFontMetricsF>
+#include <QPixmap>
+
+class QgsMarkerSymbolV2;
+
+/** \ingroup app
+ * \class QgsPointMarkerItem
+ * \brief An item that shows a point marker symbol centered on a map location.
+ */
+
+class APP_EXPORT QgsPointMarkerItem: public QgsMapCanvasItem
+{
+  public:
+
+    QgsPointMarkerItem( QgsMapCanvas* canvas = nullptr );
+
+    void paint( QPainter * painter ) override;
+
+    /** Sets the center point of the marker symbol (in map coordinates)
+     * @param p center point
+    */
+    void setPointLocation( const QgsPoint& p );
+
+    /** Sets the marker symbol to use for rendering the point. Note - you may need to call
+     * updateSize() after setting the symbol.
+     * @param symbol marker symbol. Ownership is transferred to item.
+     * @see symbol()
+     * @see updateSize()
+     */
+    void setSymbol( QgsMarkerSymbolV2* symbol );
+
+    /** Returns the marker symbol used for rendering the point.
+     * @see setSymbol()
+     */
+    QgsMarkerSymbolV2* symbol();
+
+    /** Sets the feature used for rendering the marker symbol. The feature's attributes
+     * may affect the rendered symbol if data defined overrides are in place.
+     * @param feature feature for symbol
+     * @see feature()
+     * @see updateSize()
+     */
+    void setFeature( const QgsFeature& feature );
+
+    /** Returns the feature used for rendering the marker symbol.
+     * @see setFeature()
+     */
+    QgsFeature feature() const { return mFeature; }
+
+    /** Must be called after setting the symbol or feature and when the symbol's size may
+     * have changed.
+     */
+    void updateSize();
+
+    /** Sets the transparency for the marker.
+     * @param transparency double between 0 and 1 inclusive, where 0 is fully opaque
+     * and 1 is fully transparent
+     * @see transparency()
+     */
+    void setTransparency( double transparency );
+
+    /** Returns the transparency for the marker.
+     * @returns transparency value between 0 and 1 inclusive, where 0 is fully opaque
+     * and 1 is fully transparent
+     * @see setTransparency()
+     */
+    double transparency() const;
+
+  private:
+
+    QgsFeature mFeature;
+    QScopedPointer< QgsMarkerSymbolV2 > mMarkerSymbol;
+    QPointF mLocation;
+    QScopedPointer< QgsDrawSourceEffect > mOpacityEffect;
+
+    QgsRenderContext renderContext( QPainter* painter );
+};
+
+#endif // QGSPOINTMARKERITEM_H

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -288,6 +288,7 @@
     <addaction name="mActionMergeFeatureAttributes"/>
     <addaction name="mActionNodeTool"/>
     <addaction name="mActionRotatePointSymbols"/>
+    <addaction name="mActionOffsetPointSymbol"/>
    </widget>
    <addaction name="mProjectMenu"/>
    <addaction name="mEditMenu"/>
@@ -404,6 +405,7 @@
    <addaction name="mActionMergeFeatures"/>
    <addaction name="mActionMergeFeatureAttributes"/>
    <addaction name="mActionRotatePointSymbols"/>
+   <addaction name="mActionOffsetPointSymbol"/>
   </widget>
   <widget class="QToolBar" name="mMapNavToolBar">
    <property name="windowTitle">
@@ -894,6 +896,18 @@
    </property>
    <property name="text">
     <string>Rotate Point Symbols</string>
+   </property>
+  </action>
+  <action name="mActionOffsetPointSymbol">
+   <property name="checkable">
+    <bool>true</bool>
+   </property>
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mActionRotatePointSymbols.png</normaloff>:/images/themes/default/mActionRotatePointSymbols.png</iconset>
+   </property>
+   <property name="text">
+    <string>Offset Point Symbol</string>
    </property>
   </action>
   <action name="mActionSnappingOptions">


### PR DESCRIPTION
Allows for setting a point's offset if it is bound to a field using data defined overrides (fix #14738)

Handles conversion of offset to correct units (ie map units, mm or pixels). Also handles points with data defined rotation correctly.

Ignore the placeholder icon for now!

Here's a live demo - https://www.youtube.com/watch?v=1mO3eKUAMRQ&feature=youtu.be , also showing using geometry generators in a unique way ;)

Sponsored by North Road
