### PR TITLE
[BUGFIX] QgsGeometry exportToGeoJSON return 'null' for null Geometry

### DIFF
--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -928,7 +928,7 @@ QString QgsGeometry::exportToGeoJSON( int precision ) const
 {
   if ( !d->geometry )
   {
-    return QString();
+    return QString( "null" );
   }
   return d->geometry->asJSON( precision );
 }

--- a/tests/src/core/testqgsgeometry.cpp
+++ b/tests/src/core/testqgsgeometry.cpp
@@ -3311,6 +3311,12 @@ void TestQgsGeometry::exportToGeoJSON()
   obtained = geom->exportToGeoJSON();
   geojson = "{\"type\": \"MultiPolygon\", \"coordinates\": [[[ [0, 0], [10, 0], [10, 10], [0, 10], [0, 0]]], [[ [2, 2], [4, 2], [4, 4], [2, 4], [2, 2]]]] }";
   QCOMPARE( obtained, geojson );
+
+  // no geometry
+  QgsGeometry nullGeom( nullptr );
+  obtained = nullGeom.exportToGeoJSON();
+  geojson = "null";
+  QCOMPARE( obtained, geojson );
 }
 
 bool TestQgsGeometry::renderCheck( const QString& theTestName, const QString& theComment, int mismatchCount )


### PR DESCRIPTION
Needed for QGIS Server WFS
