### PR TITLE
Add buttons to manage rows in Feature Order control dialog

### DIFF
--- a/src/ui/qgsorderbydialogbase.ui
+++ b/src/ui/qgsorderbydialogbase.ui
@@ -43,9 +43,116 @@
      </column>
     </widget>
    </item>
+   <item row="0" column="1">
+    <widget class="QWidget" name="mOrderTreeButtonFrame" native="true">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Minimum" vsizetype="Preferred">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="maximumSize">
+      <size>
+       <width>30</width>
+       <height>16777215</height>
+      </size>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout">
+      <property name="spacing">
+       <number>6</number>
+      </property>
+      <property name="margin">
+       <number>0</number>
+      </property>
+      <item>
+       <spacer name="verticalSpacer_1">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeType">
+         <enum>QSizePolicy::Fixed</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>20</width>
+          <height>20</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+      <item>
+       <widget class="QToolButton" name="mAddNewOrderButton">
+        <property name="text">
+         <string>+</string>
+        </property>
+        <property name="icon">
+         <iconset>
+          <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QToolButton" name="mRemoveOrderButton">
+        <property name="text">
+         <string>-</string>
+        </property>
+        <property name="icon">
+         <iconset>
+          <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QToolButton" name="mMoveUpItem">
+        <property name="text">
+         <string>^</string>
+        </property>
+        <property name="icon">
+         <iconset>
+          <normaloff>:/images/themes/default/mActionArrowUp.png</normaloff>:/images/themes/default/mActionArrowUp.png</iconset>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <widget class="QToolButton" name="mMoveDownItem">
+        <property name="text">
+         <string>v</string>
+        </property>
+        <property name="icon">
+         <iconset>
+          <normaloff>:/images/themes/default/mActionArrowDown.png</normaloff>:/images/themes/default/mActionArrowDown.png</iconset>
+        </property>
+       </widget>
+      </item>
+      <item>
+       <spacer name="verticalSpacer_2">
+        <property name="orientation">
+         <enum>Qt::Vertical</enum>
+        </property>
+        <property name="sizeHint" stdset="0">
+         <size>
+          <width>5</width>
+          <height>176</height>
+         </size>
+        </property>
+       </spacer>
+      </item>
+     </layout>
+    </widget>
+   </item>
   </layout>
  </widget>
- <resources/>
+ <tabstops>
+  <tabstop>buttonBox</tabstop>
+  <tabstop>mOrderByTableWidget</tabstop>
+  <tabstop>mAddNewOrderButton</tabstop>
+  <tabstop>mRemoveOrderButton</tabstop>
+  <tabstop>mMoveUpItem</tabstop>
+  <tabstop>mMoveDownItem</tabstop>
+ </tabstops>
+ <resources>
+  <include location="../../images/images.qrc"/>
+ </resources>
  <connections>
   <connection>
    <sender>buttonBox</sender>


### PR DESCRIPTION
The dialog to define feature order during rendering is somehow weird. It doesn't follow the way all other dialogs manipulate rows (attibute table in composer, add symbol layers, adding scales...):
- it adds a new and empty row as soon as the previous is filled
- it doesn't allow reordering rows, which imho makes the dialog hard to use, given that you need to fill all rows again if you'd like to (re)move the first row.

This PR doesn't fix the issues above :(. I don't have enough skills to fix this in a reasonable period. It just proposes the UI to use to reach the goal. If someone want to take it and do the rest, it'd be nice. Thanks!
![control order](https://cloud.githubusercontent.com/assets/7983394/14938061/e74b8132-0f18-11e6-86ee-ab4b72a021fe.png)
