### PR TITLE
[GDAL provider] Use GDALAutoCreateWarpedVRT() when the dataset has only RPC

### DIFF
--- a/src/providers/gdal/qgsgdalprovider.cpp
+++ b/src/providers/gdal/qgsgdalprovider.cpp
@@ -2503,7 +2503,8 @@ void QgsGdalProvider::initBaseDataset()
              || mGeoTransform[2] != 0.0
              || mGeoTransform[4] != 0.0
              || mGeoTransform[5] > 0.0 ) )
-      || GDALGetGCPCount( mGdalBaseDataset ) > 0 )
+      || GDALGetGCPCount( mGdalBaseDataset ) > 0
+      || GDALGetMetadata( mGdalBaseDataset, "RPC" ) )
   {
     QgsLogger::warning( "Creating Warped VRT." );
 
@@ -2580,7 +2581,16 @@ void QgsGdalProvider::initBaseDataset()
   if ( !crsFromWkt( GDALGetProjectionRef( mGdalDataset ) ) &&
        !crsFromWkt( GDALGetGCPProjection( mGdalDataset ) ) )
   {
-    QgsDebugMsg( "No valid CRS identified" );
+    if ( mGdalBaseDataset != mGdalDataset &&
+         GDALGetMetadata( mGdalBaseDataset, "RPC" ) )
+    {
+      // Warped VRT of RPC is in EPSG:4326
+      mCrs.createFromOgcWmsCrs( "EPSG:4326" );
+    }
+    else
+    {
+      QgsDebugMsg( "No valid CRS identified" );
+    }
   }
 
   //set up the coordinat transform - in the case of raster this is mainly used to convert


### PR DESCRIPTION
This shoud fix the issue reported on https://lists.osgeo.org/pipermail/qgis-developer/2016-May/042553.html
