### PR TITLE
use same icons as in other dialogs for this task

### DIFF
--- a/python/plugins/processing/algs/qgis/ui/FieldsMappingPanel.py
+++ b/python/plugins/processing/algs/qgis/ui/FieldsMappingPanel.py
@@ -311,9 +311,9 @@ class FieldsMappingPanel(BASE, WIDGET):
         self.setupUi(self)
 
         self.addButton.setIcon(
-            QIcon(':/images/themes/default/mActionAdd.svg'))
+            QIcon(':/images/themes/default/mActionNewAttribute.png'))
         self.deleteButton.setIcon(
-            QIcon(':/images/themes/default/mActionDeleteSelected.svg'))
+            QIcon(':/images/themes/default/mActionDeleteAttribute.svg'))
         self.upButton.setIcon(
             QIcon(':/images/themes/default/mActionArrowUp.png'))
         self.downButton.setIcon(

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -56,7 +56,7 @@ QgsRelationEditorWidget::QgsRelationEditorWidget( QWidget* parent )
   buttonLayout->addWidget( mSaveEditsButton );
   // add feature
   mAddFeatureButton = new QToolButton( this );
-  mAddFeatureButton->setIcon( QgsApplication::getThemeIcon( "/mActionAdd.svg" ) );
+  mAddFeatureButton->setIcon( QgsApplication::getThemeIcon( "/mActionNewTableRow.png" ) );
   mAddFeatureButton->setText( tr( "Add feature" ) );
   mAddFeatureButton->setObjectName( "mAddFeatureButton" );
   buttonLayout->addWidget( mAddFeatureButton );


### PR DESCRIPTION
Actually, instead of using mActionAdd ![mactionadd](https://cloud.githubusercontent.com/assets/7983394/15123819/b3fb7c42-1625-11e6-8611-179778ad70cc.png) as "Add field" and "Add feature" icons or 
![mactiondeleteselected](https://github.com/qgis/QGIS/blob/master/images/themes/default/mActionDeleteSelected.png) for "Delete attribute", should be used [mActionNewAttribute](https://github.com/qgis/QGIS/blob/master/images/themes/default/mActionNewAttribute.png) ![mactionnewattribute](https://cloud.githubusercontent.com/assets/7983394/15124253/8d9fc024-1627-11e6-894b-20e2e5f332b1.png)
, [mActionNewTableRow](https://github.com/qgis/QGIS/blob/master/images/themes/default/mActionNewTableRow.png) ![mactionnewtablerow](https://cloud.githubusercontent.com/assets/7983394/15124118/0d0633b2-1627-11e6-82c0-e7780f690bc9.png) and [mActionDeleteAttribute](https://github.com/qgis/QGIS/blob/master/images/themes/default/mActionDeleteAttribute.png)
![mactiondeleteattribute](https://cloud.githubusercontent.com/assets/7983394/15124131/19524944-1627-11e6-9d7f-f99ccec4e817.png)  as used in Edit toolbar and attribute table
