### PR TITLE
Add support for kFreeBSD to GRASS plugin.

### DIFF
--- a/src/plugins/grass/qtermwidget/kpty.cpp
+++ b/src/plugins/grass/qtermwidget/kpty.cpp
@@ -117,7 +117,7 @@ extern "C" {
 # define _NEW_TTY_CTRL
 #endif
 
-#if defined (__FreeBSD__) || defined (__NetBSD__) || defined (__OpenBSD__) || defined (__bsdi__) || defined(__APPLE__) || defined (__DragonFly__)
+#if defined (__FreeBSD__) || defined(__FreeBSD_kernel__) || defined (__NetBSD__) || defined (__OpenBSD__) || defined (__bsdi__) || defined(__APPLE__) || defined (__DragonFly__)
 # define _tcgetattr(fd, ttmode) ioctl(fd, TIOCGETA, (char *)ttmode)
 #else
 # if defined(_HPUX_SOURCE) || defined(__Lynx__) || defined (__CYGWIN__)
@@ -127,7 +127,7 @@ extern "C" {
 # endif
 #endif
 
-#if defined (__FreeBSD__) || defined (__NetBSD__) || defined (__OpenBSD__) || defined (__bsdi__) || defined(__APPLE__) || defined (__DragonFly__)
+#if defined (__FreeBSD__) || defined(__FreeBSD_kernel__) || defined (__NetBSD__) || defined (__OpenBSD__) || defined (__bsdi__) || defined(__APPLE__) || defined (__DragonFly__)
 # define _tcsetattr(fd, ttmode) ioctl(fd, TIOCSETA, (char *)ttmode)
 #else
 # if defined(_HPUX_SOURCE) || defined(__CYGWIN__)


### PR DESCRIPTION
As reported in [Debian Bug #824079](https://bugs.debian.org/824079), builds of qgis on kFreeBSD failed:

``` make
  /«BUILDDIR»/qgis-2.14.2+dfsg/src/plugins/grass/qtermwidget/kpty.cpp: In member function 'bool KPty::tcGetAttr(termios*) const':
  /«BUILDDIR»/qgis-2.14.2+dfsg/src/plugins/grass/qtermwidget/kpty.cpp:126:44: error: 'TCGETS' was not declared in this scope
   #  define _tcgetattr(fd, ttmode) ioctl(fd, TCGETS, (char *)ttmode)
                                              ^
  /«BUILDDIR»/qgis-2.14.2+dfsg/src/plugins/grass/qtermwidget/kpty.cpp:647:12: note: in expansion of macro '_tcgetattr'
       return _tcgetattr(d->masterFd, ttmode) == 0;
              ^
  /«BUILDDIR»/qgis-2.14.2+dfsg/src/plugins/grass/qtermwidget/kpty.cpp: In member function 'bool KPty::tcSetAttr(termios*)':
  /«BUILDDIR»/qgis-2.14.2+dfsg/src/plugins/grass/qtermwidget/kpty.cpp:136:44: error: 'TCSETS' was not declared in this scope
   #  define _tcsetattr(fd, ttmode) ioctl(fd, TCSETS, (char *)ttmode)
                                              ^
  /«BUILDDIR»/qgis-2.14.2+dfsg/src/plugins/grass/qtermwidget/kpty.cpp:654:12: note: in expansion of macro '_tcsetattr'
       return _tcsetattr(d->masterFd, ttmode) == 0;
              ^
```

This is caused by the lack of the GNU/kFreeBSD define in the list of BSD variants to test.

Adding `__FreeBSD_kernel__` as [documented in the kFreeBSD FAQ](https://wiki.debian.org/Debian_GNU/kFreeBSD_FAQ#Q._How_do_I_detect_kfreebsd_with_preprocessor_directives_in_a_C_program.3F) in `src/plugins/grass/qtermwidget/kpty.cpp` resolves the issue.
