### PR TITLE
Add support for GNU/Hurd to GRASS plugin qtermwidget/kpty.cpp.

### DIFF
--- a/src/plugins/grass/qtermwidget/kpty.cpp
+++ b/src/plugins/grass/qtermwidget/kpty.cpp
@@ -120,7 +120,7 @@ extern "C" {
 #if defined (__FreeBSD__) || defined(__FreeBSD_kernel__) || defined (__NetBSD__) || defined (__OpenBSD__) || defined (__bsdi__) || defined(__APPLE__) || defined (__DragonFly__)
 # define _tcgetattr(fd, ttmode) ioctl(fd, TIOCGETA, (char *)ttmode)
 #else
-# if defined(_HPUX_SOURCE) || defined(__Lynx__) || defined (__CYGWIN__)
+# if defined(_HPUX_SOURCE) || defined(__Lynx__) || defined (__CYGWIN__) || defined(__GNU__)
 #  define _tcgetattr(fd, ttmode) tcgetattr(fd, ttmode)
 # else
 #  define _tcgetattr(fd, ttmode) ioctl(fd, TCGETS, (char *)ttmode)
@@ -130,7 +130,7 @@ extern "C" {
 #if defined (__FreeBSD__) || defined(__FreeBSD_kernel__) || defined (__NetBSD__) || defined (__OpenBSD__) || defined (__bsdi__) || defined(__APPLE__) || defined (__DragonFly__)
 # define _tcsetattr(fd, ttmode) ioctl(fd, TIOCSETA, (char *)ttmode)
 #else
-# if defined(_HPUX_SOURCE) || defined(__CYGWIN__)
+# if defined(_HPUX_SOURCE) || defined(__CYGWIN__) || defined(__GNU__)
 #  define _tcsetattr(fd, ttmode) tcsetattr(fd, TCSANOW, ttmode)
 # else
 #  define _tcsetattr(fd, ttmode) ioctl(fd, TCSETS, (char *)ttmode)


### PR DESCRIPTION
This is a follow-up to #3068.

The GNU/Hurd porting guidelines document the following:

> Missing termio.h
> 
> Change it to use termios.h (check for it properly with autoconf HAVE_TERMIOS_H or the **GLIBC** macro)
> 
> Also, change calls to ioctl(fd, TCGETS, ...) and ioctl(fd, TCSETS, ...) with tcgetattr(fd, ...) and tcsetattr(fd, ...).

https://www.gnu.org/software/hurd/hurd/porting/guidelines.html#Missing_termio_h_tt_

These changes for Hurd have also been included upstream via: https://github.com/lxde/qtermwidget/pull/69
The kFreeBSD related changes were merged earlier via: https://github.com/lxde/qtermwidget/pull/68
