### PR TITLE
Allow more control over sort order in attribute table

### DIFF
--- a/ci/travis/linux/qt4/script.sh
+++ b/ci/travis/linux/qt4/script.sh
@@ -1,5 +1,5 @@
-export CTEST_PARALLEL_LEVEL=1
 export PYTHONPATH=${HOME}/osgeo4travis/lib/python2.7/site-packages/
+export CTEST_PARALLEL_LEVEL=1
 export PATH=${HOME}/osgeo4travis/bin:${HOME}/osgeo4travis/sbin:${PATH}
 export LD_LIBRARY_PATH=${HOME}/osgeo4travis/lib
 

--- a/ci/travis/linux/qt5/script.sh
+++ b/ci/travis/linux/qt5/script.sh
@@ -1,10 +1,12 @@
 export PYTHONPATH=${HOME}/osgeo4travis/lib/python3.3/site-packages/
 export CTEST_PARALLEL_LEVEL=1
+export PATH=${HOME}/osgeo4travis/bin:${HOME}/osgeo4travis/sbin:${PATH}
+export LD_LIBRARY_PATH=${HOME}/osgeo4travis/lib
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-# ccache -o max_size=150M
-# ccache -o run_second_cpp=true
+ccache -o max_size=150M
+ccache -o run_second_cpp=true
 
 xvfb-run ctest -V -E "$(cat ${DIR}/blacklist.txt | paste -sd '|' -)" -S ./qgis-test-travis.ctest --output-on-failure
 # xvfb-run ctest -V -S ./qgis-test-travis.ctest --output-on-failure

--- a/images/images.qrc
+++ b/images/images.qrc
@@ -583,6 +583,7 @@
         <file>themes/default/multieditMixedValues.svg</file>
         <file>themes/default/multieditSameValues.svg</file>
         <file>themes/default/locked_repeating.svg</file>
+        <file>themes/default/sort.svg</file>
     </qresource>
     <qresource prefix="/images/tips">
         <file alias="symbol_levels.png">qgis_tips/symbol_levels.png</file>

--- a/images/themes/default/sort.svg
+++ b/images/themes/default/sort.svg
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   version="1.1"
+   id="svg5477"
+   viewBox="0 0 4.2333333 4.2333335"
+   height="16"
+   width="16"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="sort.svg">
+  <sodipodi:namedview
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1"
+     objecttolerance="10"
+     gridtolerance="10"
+     guidetolerance="10"
+     inkscape:pageopacity="0"
+     inkscape:pageshadow="2"
+     inkscape:window-width="1920"
+     inkscape:window-height="1016"
+     id="namedview13"
+     showgrid="true"
+     inkscape:zoom="39.333334"
+     inkscape:cx="1.7617969"
+     inkscape:cy="7.4154532"
+     inkscape:window-x="0"
+     inkscape:window-y="27"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg5477">
+    <inkscape:grid
+       type="xygrid"
+       id="grid3341" />
+  </sodipodi:namedview>
+  <defs
+     id="defs5479" />
+  <metadata
+     id="metadata5482">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <path
+     inkscape:connector-curvature="0"
+     style="display:inline;fill:#6d97c4;fill-opacity:1;fill-rule:evenodd;stroke:#415a75;stroke-width:0.19843751;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1;enable-background:new"
+     d="m 2.9088665,3.7628126 -1.0794756,-1.2402344 0.7733851,0 0.2887393,-2.12183447 0.3139285,2.12183447 0.7828981,0 z"
+     id="path2848-7-3-9-4"
+     sodipodi:nodetypes="ccccccc" />
+  <path
+     inkscape:connector-curvature="0"
+     id="path31772"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:medium;line-height:125%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Bold';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:tb-rl;text-anchor:start;fill:#f79191;fill-opacity:1;stroke:#a40000;stroke-width:0.19843751;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 1.2400171,1.4925339 -0.54129826,0 -0.0854208,0.2668105 -0.3479775,0 0.49723917,-1.46451483 0.41271749,0 0.4972392,1.46451483 -0.3479775,0 -0.084522,-0.2668105 m -0.45497826,-0.271715 0.36775916,0 L 0.969368,0.63815188 0.78503884,1.2208189"
+     sodipodi:nodetypes="ccccccccccccc" />
+  <path
+     inkscape:connector-curvature="0"
+     id="path31774"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:medium;line-height:125%;font-family:'DejaVu Sans';-inkscape-font-specification:'DejaVu Sans, Bold';text-align:start;letter-spacing:0px;word-spacing:0px;writing-mode:tb-rl;text-anchor:start;fill:#91bbf7;fill-opacity:1;stroke:#0044a4;stroke-width:0.19843751;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+     d="m 0.40469133,2.2147734 1.12845407,0 0,0.2285545 -0.72023241,0.9505123 0.74091331,0 0,0.285448 -1.16981581,0 0,-0.2285546 0.72023251,-0.9505123 -0.69955167,0 0,-0.2854479"
+     sodipodi:nodetypes="ccccccccccc" />
+</svg>

--- a/python/core/qgsattributetableconfig.sip
+++ b/python/core/qgsattributetableconfig.sip
@@ -104,4 +104,15 @@ class QgsAttributeTableConfig
      * Deserialize to XML on layer load
      */
     void readXml( const QDomNode& node );
+
+    /**
+     * Get the expression used for sorting.
+     */
+    QString sortExpression() const;
+
+    /**
+     * Set the sort expression used for sorting.
+     */
+    void setSortExpression( const QString& sortExpression );
+
 };

--- a/python/gui/attributetable/qgsattributetablefiltermodel.sip
+++ b/python/gui/attributetable/qgsattributetablefiltermodel.sip
@@ -142,6 +142,20 @@ class QgsAttributeTableFilterModel: QSortFilterProxyModel, QgsFeatureModel
      */
     virtual void sort( int column, Qt::SortOrder order = Qt::AscendingOrder );
 
+    /**
+     * Sort by the given expression using the given order.
+     * Prefetches all the data from the layer to speed up sorting.
+     *
+     * @param column The expression which should be used for sorting
+     * @param order  The order ( Qt::AscendingOrder or Qt::DescendingOrder )
+     */
+    void sort( QString expression, Qt::SortOrder order = Qt::AscendingOrder );
+
+    /**
+     * The expression which is used to sort the attribute table.
+     */
+    QString sortExpression() const;
+
     /** Returns the map canvas*/
     QgsMapCanvas* mapCanvas() const;
 

--- a/python/gui/attributetable/qgsattributetablemodel.sip
+++ b/python/gui/attributetable/qgsattributetablemodel.sip
@@ -149,6 +149,19 @@ class QgsAttributeTableModel : QAbstractTableModel
     void prefetchColumnData( int column );
 
     /**
+     * Prefetches the entire data for one expression. Based on this cached information
+     * the sorting can later be done in a performant way.
+     *
+     * @param expression The expression to cache
+     */
+    void prefetchSortData( const QString& expression );
+
+    /**
+     * The expression which was used to fill the sorting cache
+     */
+    QString sortCacheExpression() const;
+
+    /**
      * Set a request that will be used to fill this attribute table model.
      * In contrast to a filter, the request will constrain the data shown without the possibility
      * to dynamically adjust it.
@@ -160,7 +173,7 @@ class QgsAttributeTableModel : QAbstractTableModel
     /**
      * Get the the feature request
      */
-    const QgsFeatureRequest &request() const;
+    const QgsFeatureRequest& request() const;
 
     /**
      * Sets the context in which this table is shown.
@@ -188,7 +201,7 @@ class QgsAttributeTableModel : QAbstractTableModel
      * Empty extra columns to announce from this model.
      * Any extra columns need to be implemented by proxy models in front of this model.
      */
-    void setExtraColumns(int extraColumns);
+    void setExtraColumns( int extraColumns );
 
   public slots:
 
@@ -226,7 +239,7 @@ class QgsAttributeTableModel : QAbstractTableModel
      * Launched when eatures have been deleted
      * @param fids feature ids
      */
-    virtual void featuresDeleted( const QgsFeatureIds& fid );
+    virtual void featuresDeleted( const QgsFeatureIds& fids );
     /**
      * Launched when a feature has been added
      * @param fid feature id

--- a/python/gui/attributetable/qgsdualview.sip
+++ b/python/gui/attributetable/qgsdualview.sip
@@ -115,16 +115,41 @@ class QgsDualView : QStackedWidget
      */
     QgsAttributeTableModel* masterModel() const;
 
+    /**
+     * Set the request
+     *
+     * @param request The request
+     */
     void setRequest( const QgsFeatureRequest& request );
 
+    /**
+     * Set the feature selection model
+     *
+     * @param featureSelectionManager the feature selection model
+     */
     void setFeatureSelectionManager( QgsIFeatureSelectionManager* featureSelectionManager );
 
+    /**
+     * Returns the table view
+     *
+     * @return The table view
+     */
     QgsAttributeTableView* tableView();
     /**
      * Set the attribute table config which should be used to control
      * the appearance of the attribute table.
      */
     void setAttributeTableConfig( const QgsAttributeTableConfig& config );
+
+    /**
+     * Set the expression used for sorting the table and feature list.
+     */
+    void setSortExpression( const QString& sortExpression );
+
+    /**
+     * Get the expression used for sorting the table and feature list.
+     */
+    QString sortExpression() const;
 
   protected:
     /**

--- a/python/gui/qgsexpressionbuilderwidget.sip
+++ b/python/gui/qgsexpressionbuilderwidget.sip
@@ -79,7 +79,7 @@ class QgsExpressionBuilderWidget : QWidget
 %End
 
   public:
-    QgsExpressionBuilderWidget( QWidget *parent /TransferThis/ );
+    QgsExpressionBuilderWidget( QWidget *parent /TransferThis/ = nullptr );
     ~QgsExpressionBuilderWidget();
 
     /** Sets layer in order to get the fields and values

--- a/src/app/qgsattributetabledialog.h
+++ b/src/app/qgsattributetabledialog.h
@@ -154,6 +154,8 @@ class APP_EXPORT QgsAttributeTableDialog : public QDialog, private Ui::QgsAttrib
 
     void on_mHelpButton_clicked() { QgsContextHelp::run( metaObject()->className() ); }
 
+    void on_mSortButton_clicked();
+
     void on_mExpressionSelectButton_clicked();
     void filterColumnChanged( QObject* filterAction );
     void filterExpressionBuilder();

--- a/src/core/qgsattributetableconfig.cpp
+++ b/src/core/qgsattributetableconfig.cpp
@@ -173,6 +173,18 @@ void QgsAttributeTableConfig::readXml( const QDomNode& node )
       }
     }
   }
+
+  mSortExpression = configNode.toElement().attribute( "sortExpression" );
+}
+
+QString QgsAttributeTableConfig::sortExpression() const
+{
+  return mSortExpression;
+}
+
+void QgsAttributeTableConfig::setSortExpression( const QString& sortExpression )
+{
+  mSortExpression = sortExpression;
 }
 
 void QgsAttributeTableConfig::writeXml( QDomNode& node ) const
@@ -181,6 +193,8 @@ void QgsAttributeTableConfig::writeXml( QDomNode& node ) const
 
   QDomElement configElement  = doc.createElement( "attributetableconfig" );
   configElement.setAttribute( "actionWidgetStyle", mActionWidgetStyle == ButtonList ? "buttonList" : "dropDown" );
+
+  configElement.setAttribute( "sortExpression", mSortExpression );
 
   QDomElement columnsElement  = doc.createElement( "columns" );
 

--- a/src/core/qgsattributetableconfig.h
+++ b/src/core/qgsattributetableconfig.h
@@ -110,10 +110,20 @@ class CORE_EXPORT QgsAttributeTableConfig
      */
     void readXml( const QDomNode& node );
 
+    /**
+     * Get the expression used for sorting.
+     */
+    QString sortExpression() const;
+
+    /**
+     * Set the sort expression used for sorting.
+     */
+    void setSortExpression( const QString& sortExpression );
 
   private:
     QVector<ColumnConfig> mColumns;
     ActionWidgetStyle mActionWidgetStyle;
+    QString mSortExpression;
 };
 
 Q_DECLARE_METATYPE( QgsAttributeTableConfig::ColumnConfig )

--- a/src/gui/attributetable/qgsattributetablefiltermodel.cpp
+++ b/src/gui/attributetable/qgsattributetablefiltermodel.cpp
@@ -194,6 +194,20 @@ void QgsAttributeTableFilterModel::setAttributeTableConfig( const QgsAttributeTa
       endResetModel();
     }
   }
+
+  sort( config.sortExpression() );
+}
+
+void QgsAttributeTableFilterModel::sort( QString expression, Qt::SortOrder order )
+{
+  QSortFilterProxyModel::sort( -1 );
+  masterModel()->prefetchSortData( expression );
+  QSortFilterProxyModel::sort( 0, order ) ;
+}
+
+QString QgsAttributeTableFilterModel::sortExpression() const
+{
+  return masterModel()->sortCacheExpression();
 }
 
 void QgsAttributeTableFilterModel::setSelectedOnTop( bool selectedOnTop )

--- a/src/gui/attributetable/qgsattributetablefiltermodel.h
+++ b/src/gui/attributetable/qgsattributetablefiltermodel.h
@@ -178,6 +178,20 @@ class GUI_EXPORT QgsAttributeTableFilterModel: public QSortFilterProxyModel, pub
      */
     virtual void sort( int column, Qt::SortOrder order = Qt::AscendingOrder ) override;
 
+    /**
+     * Sort by the given expression using the given order.
+     * Prefetches all the data from the layer to speed up sorting.
+     *
+     * @param expression The expression which should be used for sorting
+     * @param order      The order ( Qt::AscendingOrder or Qt::DescendingOrder )
+     */
+    void sort( QString expression, Qt::SortOrder order = Qt::AscendingOrder );
+
+    /**
+     * The expression which is used to sort the attribute table.
+     */
+    QString sortExpression() const;
+
     /** Returns the map canvas*/
     QgsMapCanvas* mapCanvas() const { return mCanvas; }
 

--- a/src/gui/attributetable/qgsattributetablemodel.h
+++ b/src/gui/attributetable/qgsattributetablemodel.h
@@ -194,6 +194,19 @@ class GUI_EXPORT QgsAttributeTableModel: public QAbstractTableModel
     void prefetchColumnData( int column );
 
     /**
+     * Prefetches the entire data for one expression. Based on this cached information
+     * the sorting can later be done in a performant way.
+     *
+     * @param expression The expression to cache
+     */
+    void prefetchSortData( const QString& expression );
+
+    /**
+     * The expression which was used to fill the sorting cache
+     */
+    QString sortCacheExpression() const;
+
+    /**
      * Set a request that will be used to fill this attribute table model.
      * In contrast to a filter, the request will constrain the data shown without the possibility
      * to dynamically adjust it.
@@ -335,9 +348,10 @@ class GUI_EXPORT QgsAttributeTableModel: public QAbstractTableModel
     QgsFeatureRequest mFeatureRequest;
 
     /** The currently cached column */
-    int mCachedField;
-    /** Allows caching of one specific column (used for sorting) */
-    QHash<QgsFeatureId, QVariant> mFieldCache;
+    QgsExpression mSortCacheExpression;
+    QgsAttributeList mSortCacheAttributes;
+    /** Allows caching of one value per column (used for sorting) */
+    QHash<QgsFeatureId, QVariant> mSortCache;
 
     /**
      * Holds the bounds of changed cells while an update operation is running

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -196,6 +196,10 @@ void QgsDualView::columnBoxInit()
   {
     mFeatureListPreviewButton->defaultAction()->trigger();
   }
+
+  QAction* sortByPreviewExpression = new QAction( QgsApplication::getThemeIcon( "sort.svg" ), tr( "Sort by preview expression" ), this );
+  connect( sortByPreviewExpression, SIGNAL( triggered( bool ) ), this, SLOT( sortByPreviewExpression() ) );
+  mFeatureListPreviewButton->addAction( sortByPreviewExpression );
 }
 
 void QgsDualView::setView( QgsDualView::ViewMode view )
@@ -439,6 +443,11 @@ void QgsDualView::previewExpressionChanged( const QString& expression )
   mLayerCache->layer()->setDisplayExpression( expression );
 }
 
+void QgsDualView::sortByPreviewExpression()
+{
+  setSortExpression( mFeatureList->displayExpression() );
+}
+
 void QgsDualView::featureFormAttributeChanged()
 {
   mFeatureList->setCurrentFeatureEdited( true );
@@ -468,6 +477,19 @@ void QgsDualView::setFeatureSelectionManager( QgsIFeatureSelectionManager* featu
 void QgsDualView::setAttributeTableConfig( const QgsAttributeTableConfig& config )
 {
   mFilterModel->setAttributeTableConfig( config );
+}
+
+void QgsDualView::setSortExpression( const QString& sortExpression )
+{
+  if ( sortExpression.isNull() )
+    mFilterModel->sort( -1 );
+  else
+    mFilterModel->sort( sortExpression );
+}
+
+QString QgsDualView::sortExpression() const
+{
+  return mFilterModel->sortExpression();
 }
 
 void QgsDualView::progress( int i, bool& cancel )

--- a/src/gui/attributetable/qgsdualview.h
+++ b/src/gui/attributetable/qgsdualview.h
@@ -180,6 +180,16 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
      */
     void setAttributeTableConfig( const QgsAttributeTableConfig& config );
 
+    /**
+     * Set the expression used for sorting the table and feature list.
+     */
+    void setSortExpression( const QString& sortExpression );
+
+    /**
+     * Get the expression used for sorting the table and feature list.
+     */
+    QString sortExpression() const;
+
   protected:
     /**
      * Initializes widgets which depend on the attributes of this layer
@@ -239,6 +249,8 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
     void viewWillShowContextMenu( QMenu* menu, const QModelIndex& atIndex );
 
     void previewExpressionChanged( const QString& expression );
+
+    void sortByPreviewExpression();
 
     /**
      * Will be called whenever the currently shown feature form changes.

--- a/src/gui/qgsexpressionbuilderwidget.h
+++ b/src/gui/qgsexpressionbuilderwidget.h
@@ -118,7 +118,10 @@ class GUI_EXPORT QgsExpressionBuilderWidget : public QWidget, private Ui::QgsExp
 {
     Q_OBJECT
   public:
-    QgsExpressionBuilderWidget( QWidget *parent );
+    /**
+     * Create a new expression builder widget with an optional parent.
+     */
+    QgsExpressionBuilderWidget( QWidget* parent = nullptr );
     ~QgsExpressionBuilderWidget();
 
     /** Sets layer in order to get the fields and values

--- a/src/ui/qgsattributetabledialog.ui
+++ b/src/ui/qgsattributetabledialog.ui
@@ -14,7 +14,16 @@
    <string>Attribute Table</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <property name="margin">
+   <property name="leftMargin">
+    <number>0</number>
+   </property>
+   <property name="topMargin">
+    <number>0</number>
+   </property>
+   <property name="rightMargin">
+    <number>0</number>
+   </property>
+   <property name="bottomMargin">
     <number>0</number>
    </property>
    <property name="spacing">
@@ -567,6 +576,29 @@
       </widget>
      </item>
      <item>
+      <widget class="QToolButton" name="mSortButton">
+       <property name="toolTip">
+        <string>Control the sort order</string>
+       </property>
+       <property name="text">
+        <string>...</string>
+       </property>
+       <property name="icon">
+        <iconset resource="../../images/images.qrc">
+         <normaloff>:/images/themes/default/sort.svg</normaloff>:/images/themes/default/sort.svg</iconset>
+       </property>
+       <property name="iconSize">
+        <size>
+         <width>18</width>
+         <height>18</height>
+        </size>
+       </property>
+       <property name="autoRaise">
+        <bool>true</bool>
+       </property>
+      </widget>
+     </item>
+     <item>
       <spacer name="horizontalSpacer">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
@@ -670,7 +702,16 @@
         <property name="sizeConstraint">
          <enum>QLayout::SetDefaultConstraint</enum>
         </property>
-        <property name="margin">
+        <property name="leftMargin">
+         <number>0</number>
+        </property>
+        <property name="topMargin">
+         <number>0</number>
+        </property>
+        <property name="rightMargin">
+         <number>0</number>
+        </property>
+        <property name="bottomMargin">
          <number>0</number>
         </property>
         <item row="0" column="0">

--- a/tests/src/gui/testqgsdualview.cpp
+++ b/tests/src/gui/testqgsdualview.cpp
@@ -50,6 +50,8 @@ class TestQgsDualView : public QObject
 
     void testSelectAll();
 
+    void testSort();
+
     void testAttributeFormSharedValueScanning();
 
   private:
@@ -139,6 +141,36 @@ void TestQgsDualView::testSelectAll()
   mCanvas->setExtent( QgsRectangle( -110, 40, -100, 48 ) );
   mDualView->mTableView->selectAll();
   QVERIFY( mPointsLayer->selectedFeatureCount() == 1 );
+}
+
+void TestQgsDualView::testSort()
+{
+  mDualView->setSortExpression( "Class" );
+
+  QStringList classes;
+  classes << "B52"
+  << "B52"
+  << "B52"
+  << "B52"
+  << "Biplane"
+  << "Biplane"
+  << "Biplane"
+  << "Biplane"
+  << "Biplane"
+  << "Jet"
+  << "Jet"
+  << "Jet"
+  << "Jet"
+  << "Jet"
+  << "Jet"
+  << "Jet"
+  << "Jet";
+
+  for ( int i = 0; i < classes.length(); ++i )
+  {
+    QModelIndex index = mDualView->tableView()->model()->index( i, 0 );
+    QCOMPARE( mDualView->tableView()->model()->data( index ).toString(), classes.at( i ) );
+  }
 }
 
 void TestQgsDualView::testAttributeFormSharedValueScanning()

--- a/tests/src/python/test_qgsvectorfilewriter.py
+++ b/tests/src/python/test_qgsvectorfilewriter.py
@@ -73,16 +73,16 @@ class TestQgsVectorLayer(unittest.TestCase):
             'test',
             'memory')
 
-        assert self.mMemoryLayer is not None, 'Provider not initialized'
+        self.assertIsNotNone(self.mMemoryLayer, 'Provider not initialized')
         myProvider = self.mMemoryLayer.dataProvider()
-        assert myProvider is not None
+        self.assertIsNotNone(myProvider)
 
         ft = QgsFeature()
         ft.setGeometry(QgsGeometry.fromPoint(QgsPoint(10, 10)))
         ft.setAttributes(['Johny', 20, 0.3])
         myResult, myFeatures = myProvider.addFeatures([ft])
-        assert myResult
-        assert len(myFeatures) > 0
+        self.assertTrue(myResult)
+        self.assertTrue(myFeatures)
 
         writeShape(self.mMemoryLayer, 'writetest.shp')
 
@@ -94,17 +94,16 @@ class TestQgsVectorLayer(unittest.TestCase):
             'test',
             'memory')
 
-        assert ml is not None, 'Provider not initialized'
-        assert ml.isValid(), 'Source layer not valid'
+        self.assertTrue(ml.isValid())
         provider = ml.dataProvider()
-        assert provider is not None
+        self.assertIsNotNone(provider)
 
         ft = QgsFeature()
         ft.setGeometry(QgsGeometry.fromPoint(QgsPoint(10, 10)))
         ft.setAttributes([1, QDate(2014, 3, 5), QTime(13, 45, 22), QDateTime(QDate(2014, 3, 5), QTime(13, 45, 22))])
         res, features = provider.addFeatures([ft])
-        assert res
-        assert len(features) > 0
+        self.assertTrue(res)
+        self.assertTrue(features)
 
         dest_file_name = os.path.join(str(QDir.tempPath()), 'datetime.shp')
         crs = QgsCoordinateReferenceSystem()
@@ -130,15 +129,15 @@ class TestQgsVectorLayer(unittest.TestCase):
         f = next(created_layer.getFeatures(QgsFeatureRequest()))
 
         date_idx = created_layer.fieldNameIndex('date_f')
-        assert isinstance(f.attributes()[date_idx], QDate)
+        self.assertIsInstance(f.attributes()[date_idx], QDate)
         self.assertEqual(f.attributes()[date_idx], QDate(2014, 3, 5))
         time_idx = created_layer.fieldNameIndex('time_f')
         #shapefiles do not support time types
-        assert isinstance(f.attributes()[time_idx], str)
+        self.assertIsInstance(f.attributes()[time_idx], str)
         self.assertEqual(f.attributes()[time_idx], '13:45:22')
         #shapefiles do not support datetime types
         datetime_idx = created_layer.fieldNameIndex('dt_f')
-        assert isinstance(f.attributes()[datetime_idx], str)
+        self.assertIsInstance(f.attributes()[datetime_idx], str)
         self.assertEqual(f.attributes()[datetime_idx], QDateTime(QDate(2014, 3, 5), QTime(13, 45, 22)).toString("yyyy/MM/dd hh:mm:ss.zzz"))
 
     def testDateTimeWriteTabfile(self):
@@ -149,17 +148,17 @@ class TestQgsVectorLayer(unittest.TestCase):
             'test',
             'memory')
 
-        assert ml is not None, 'Provider not initialized'
-        assert ml.isValid(), 'Source layer not valid'
+        self.assertIsNotNone(ml, 'Provider not initialized')
+        self.assertTrue(ml.isValid(), 'Source layer not valid')
         provider = ml.dataProvider()
-        assert provider is not None
+        self.assertIsNotNone(provider)
 
         ft = QgsFeature()
         ft.setGeometry(QgsGeometry.fromPoint(QgsPoint(10, 10)))
         ft.setAttributes([1, QDate(2014, 3, 5), QTime(13, 45, 22), QDateTime(QDate(2014, 3, 5), QTime(13, 45, 22))])
         res, features = provider.addFeatures([ft])
-        assert res
-        assert len(features) > 0
+        self.assertTrue(res)
+        self.assertTrue(features)
 
         dest_file_name = os.path.join(str(QDir.tempPath()), 'datetime.tab')
         crs = QgsCoordinateReferenceSystem()
@@ -183,13 +182,13 @@ class TestQgsVectorLayer(unittest.TestCase):
         f = next(created_layer.getFeatures(QgsFeatureRequest()))
 
         date_idx = created_layer.fieldNameIndex('date_f')
-        assert isinstance(f.attributes()[date_idx], QDate)
+        self.assertIsInstance(f.attributes()[date_idx], QDate)
         self.assertEqual(f.attributes()[date_idx], QDate(2014, 3, 5))
         time_idx = created_layer.fieldNameIndex('time_f')
-        assert isinstance(f.attributes()[time_idx], QTime)
+        self.assertIsInstance(f.attributes()[time_idx], QTime)
         self.assertEqual(f.attributes()[time_idx], QTime(13, 45, 22))
         datetime_idx = created_layer.fieldNameIndex('dt_f')
-        assert isinstance(f.attributes()[datetime_idx], QDateTime)
+        self.assertIsInstance(f.attributes()[datetime_idx], QDateTime)
         self.assertEqual(f.attributes()[datetime_idx], QDateTime(QDate(2014, 3, 5), QTime(13, 45, 22)))
 
     def testWriteShapefileWithZ(self):
@@ -201,17 +200,17 @@ class TestQgsVectorLayer(unittest.TestCase):
             'test',
             'memory')
 
-        assert ml is not None, 'Provider not initialized'
-        assert ml.isValid(), 'Source layer not valid'
+        self.assertIsNotNone(ml, 'Provider not initialized')
+        self.assertTrue(ml.isValid(), 'Source layer not valid')
         provider = ml.dataProvider()
-        assert provider is not None
+        self.assertIsNotNone(provider)
 
         ft = QgsFeature()
         ft.setGeometry(QgsGeometry.fromWkt('PointZ (1 2 3)'))
         ft.setAttributes([1])
         res, features = provider.addFeatures([ft])
-        assert res
-        assert len(features) > 0
+        self.assertTrue(res)
+        self.assertTrue(features)
 
         # check with both a standard PointZ and 25d style Point25D type
         for t in [QgsWKBTypes.PointZ, QgsWKBTypes.Point25D]:
@@ -233,7 +232,7 @@ class TestQgsVectorLayer(unittest.TestCase):
             g = f.geometry()
             wkt = g.exportToWkt()
             expWkt = 'PointZ (1 2 3)'
-            assert compareWkt(expWkt, wkt), "saving geometry with Z failed: mismatch Expected:\n%s\nGot:\n%s\n" % (expWkt, wkt)
+            self.assertTrue(compareWkt(expWkt, wkt), "saving geometry with Z failed: mismatch Expected:\n%s\nGot:\n%s\n" % (expWkt, wkt))
 
             #also try saving out the shapefile version again, as an extra test
             #this tests that saving a layer with z WITHOUT explicitly telling the writer to keep z values,
@@ -254,7 +253,7 @@ class TestQgsVectorLayer(unittest.TestCase):
             f = next(created_layer_from_shp.getFeatures(QgsFeatureRequest()))
             g = f.geometry()
             wkt = g.exportToWkt()
-            assert compareWkt(expWkt, wkt), "saving geometry with Z failed: mismatch Expected:\n%s\nGot:\n%s\n" % (expWkt, wkt)
+            self.assertTrue(compareWkt(expWkt, wkt), "saving geometry with Z failed: mismatch Expected:\n%s\nGot:\n%s\n" % (expWkt, wkt))
 
     def testWriteShapefileWithMultiConversion(self):
         """Check writing geometries to an ESRI shapefile with conversion to multi."""
@@ -263,17 +262,17 @@ class TestQgsVectorLayer(unittest.TestCase):
             'test',
             'memory')
 
-        assert ml is not None, 'Provider not initialized'
-        assert ml.isValid(), 'Source layer not valid'
+        self.assertIsNotNone(ml, 'Provider not initialized')
+        self.assertTrue(ml.isValid(), 'Source layer not valid')
         provider = ml.dataProvider()
-        assert provider is not None
+        self.assertIsNotNone(provider)
 
         ft = QgsFeature()
         ft.setGeometry(QgsGeometry.fromWkt('Point (1 2)'))
         ft.setAttributes([1])
         res, features = provider.addFeatures([ft])
-        assert res
-        assert len(features) > 0
+        self.assertTrue(res)
+        self.assertTrue(features)
 
         dest_file_name = os.path.join(str(QDir.tempPath()), 'to_multi.shp')
         crs = QgsCoordinateReferenceSystem()
@@ -293,7 +292,7 @@ class TestQgsVectorLayer(unittest.TestCase):
         g = f.geometry()
         wkt = g.exportToWkt()
         expWkt = 'MultiPoint ((1 2))'
-        assert compareWkt(expWkt, wkt), "saving geometry with multi conversion failed: mismatch Expected:\n%s\nGot:\n%s\n" % (expWkt, wkt)
+        self.assertTrue(compareWkt(expWkt, wkt), "saving geometry with multi conversion failed: mismatch Expected:\n%s\nGot:\n%s\n" % (expWkt, wkt))
 
     def testWriteShapefileWithAttributeSubsets(self):
         """Tests writing subsets of attributes to files."""
@@ -302,17 +301,17 @@ class TestQgsVectorLayer(unittest.TestCase):
             'test',
             'memory')
 
-        assert ml is not None, 'Provider not initialized'
-        assert ml.isValid(), 'Source layer not valid'
+        self.assertIsNotNone(ml, 'Provider not initialized')
+        self.assertTrue(ml.isValid(), 'Source layer not valid')
         provider = ml.dataProvider()
-        assert provider is not None
+        self.assertIsNotNone(provider)
 
         ft = QgsFeature()
         ft.setGeometry(QgsGeometry.fromWkt('Point (1 2)'))
         ft.setAttributes([1, 11, 12, 13])
         res, features = provider.addFeatures([ft])
-        assert res
-        assert len(features) > 0
+        self.assertTrue(res)
+        self.assertTrue(features)
 
         #first write out with all attributes
         dest_file_name = os.path.join(str(QDir.tempPath()), 'all_attributes.shp')
@@ -376,7 +375,7 @@ class TestQgsVectorLayer(unittest.TestCase):
         g = f.geometry()
         wkt = g.exportToWkt()
         expWkt = 'Point (1 2)'
-        assert compareWkt(expWkt, wkt), "geometry not saved correctly when saving without attributes : mismatch Expected:\n%s\nGot:\n%s\n" % (expWkt, wkt)
+        self.assertTrue(compareWkt(expWkt, wkt), "geometry not saved correctly when saving without attributes : mismatch Expected:\n%s\nGot:\n%s\n" % (expWkt, wkt))
         self.assertEqual(f['FID'], 0)
 
     def testValueConverter(self):
@@ -386,17 +385,17 @@ class TestQgsVectorLayer(unittest.TestCase):
             'test',
             'memory')
 
-        assert ml is not None, 'Provider not initialized'
-        assert ml.isValid(), 'Source layer not valid'
+        self.assertIsNotNone(ml, 'Provider not initialized')
+        self.assertTrue(ml.isValid(), 'Source layer not valid')
         provider = ml.dataProvider()
-        assert provider is not None
+        self.assertIsNotNone(provider)
         self.assertEqual(ml.fields().count(), 3)
 
         ft = QgsFeature()
         ft.setAttributes([1, 'ignored', 3])
         res, features = provider.addFeatures([ft])
-        assert res
-        assert len(features) > 0
+        self.assertTrue(res)
+        self.assertTrue(features)
 
         dest_file_name = os.path.join(str(QDir.tempPath()), 'value_converter.shp')
         converter = TestFieldValueConverter(ml)


### PR DESCRIPTION
- Adds a new button to control the sort order with an arbitrary expression
- Saves the sort order configuration persistently
- Allows disabling sort order (current default, useful for performance issues on large tables)
- Allow setting the display expression as sort order (shortcut action from the form view feature list preview expression  combo box)
