### PR TITLE
Make qgis_fieldtest all Qt 5.X compatible

### DIFF
--- a/ci/travis/linux/qt5/blacklist.txt
+++ b/ci/travis/linux/qt5/blacklist.txt
@@ -24,4 +24,3 @@ qgis_composermapgridtest
 qgis_composertabletest
 qgis_composertablev2test
 qgis_composerutils
-qgis_fieldtest

--- a/tests/src/core/testqgsfield.cpp
+++ b/tests/src/core/testqgsfield.cpp
@@ -217,11 +217,10 @@ void TestQgsField::convertCompatible()
   QVERIFY( stringField.convertCompatible( nullInt ) );
   QCOMPARE( nullInt.type(), QVariant::String );
   QVERIFY( nullInt.isNull() );
-  QVariant doubleVar( 9.7 );
+  QVariant doubleVar( 1.25 );
   QVERIFY( stringField.convertCompatible( doubleVar ) );
   QCOMPARE( doubleVar.type(), QVariant::String );
-  // Should be fixed in Qt 5.7: https://bugreports.qt.io/browse/QTBUG-47192
-  QCOMPARE( doubleVar, QVariant( "9.7" ) );
+  QCOMPARE( doubleVar, QVariant( "1.25" ) );
   QVariant nullDouble = QVariant( QVariant::Double );
   QVERIFY( stringField.convertCompatible( nullDouble ) );
   QCOMPARE( nullDouble.type(), QVariant::String );
@@ -246,10 +245,10 @@ void TestQgsField::convertCompatible()
   QVERIFY( doubleField.convertCompatible( nullInt ) );
   QCOMPARE( nullInt.type(), QVariant::Double );
   QVERIFY( nullInt.isNull() );
-  doubleVar = QVariant( 9.7 );
+  doubleVar = QVariant( 1.25 );
   QVERIFY( doubleField.convertCompatible( doubleVar ) );
   QCOMPARE( doubleVar.type(), QVariant::Double );
-  QCOMPARE( doubleVar, QVariant( 9.7 ) );
+  QCOMPARE( doubleVar, QVariant( 1.25 ) );
   nullDouble = QVariant( QVariant::Double );
   QVERIFY( doubleField.convertCompatible( nullDouble ) );
   QCOMPARE( nullDouble.type(), QVariant::Double );


### PR DESCRIPTION
In https://codereview.qt-project.org/#/c/99815/ implemented in QT 5.5,
doubles are converted to strings using '%.17g', so short decimal values
might be expanded to long strings depending on their values.
https://wiki.qt.io/New_Features_in_Qt_5.7 has a logic to avoid this, but
if we select carefully the double to have both an exact binary and decimal
representation, that can work will all versions.

$ python -c "print('%.17g' % 9.7)"
9.6999999999999993

$ python -c "print('%.17g' % 1.25)"
1.25
