### PR TITLE
14812, save annotations to project.qgs in creation order

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -1604,14 +1604,19 @@ void QgisApp::showStyleManagerV2()
 void QgisApp::writeAnnotationItemsToProject( QDomDocument& doc )
 {
   QList<QgsAnnotationItem*> items = annotationItems();
-  QList<QgsAnnotationItem*>::const_iterator itemIt = items.constBegin();
-  for ( ; itemIt != items.constEnd(); ++itemIt )
+  QgsAnnotationItem* item;
+  QListIterator<QgsAnnotationItem*> i( items );
+  // save lowermost annotation (at end of list) first
+  i.toBack();
+  while ( i.hasPrevious() )
   {
-    if ( ! *itemIt )
+    item = i.previous();
+
+    if ( ! item )
     {
       continue;
     }
-    ( *itemIt )->writeXML( doc );
+    item->writeXML( doc );
   }
 }
 


### PR DESCRIPTION
(fixes Redmine #14812)

If I create three Text Annotations 'Annotation1', 'Annotation2' and 'Annotation3' and save the project, then the Text Annotations are saved in order 'Annotation3', 'Annotation2', 'Annotation1' in the project.qgs file.

This is because QgsMapCanvas::items() (from parent class QGraphicsView::items()) returns annotation items in "stacking order" with the uppermost item first in the list, and QgisApp::writeAnnotationItemsToProject saves them in this order too.

I changed QgisApp::writeAnnotationItemsToProject to traverse the list of annotations in reverse order -- this logic is already used in method QgsMapCanvas::saveAsImage.

Now the display order of annotations remains the same after projects are saved and loaded.
