### PR TITLE
[FEATURE] widgets constraints

### DIFF
--- a/python/core/qgseditformconfig.sip
+++ b/python/core/qgseditformconfig.sip
@@ -474,7 +474,16 @@ class QgsEditFormConfig : QObject
     /**
      * If set to false, the widget at the given index will be read-only.
      */
-    void setReadOnly(int idx, bool readOnly );
+    void setReadOnly( int idx, bool readOnly = true );
+
+    /**
+     * Returns if the field at fieldidx should be treated as NOT NULL value
+     */
+    bool notNull( int fieldidx) const;
+    /**
+     * Set if the field at fieldidx should be treated as NOT NULL value
+     */
+    void setNotNull( int idx, bool notnull = true );
 
     /**
      * If this returns true, the widget at the given index will receive its label on the previous line

--- a/python/core/qgseditformconfig.sip
+++ b/python/core/qgseditformconfig.sip
@@ -477,6 +477,22 @@ class QgsEditFormConfig : QObject
     void setReadOnly( int idx, bool readOnly = true );
 
     /**
+     * Returns the constraint expression of a specific field
+     * @param idx The index of the field
+     * @return the expression
+     * @note added in QGIS 2.16
+     */
+    QString constraint( int idx ) const;
+
+    /**
+     * Set the constraint expression for a specific field
+     * @param idx the field index
+     * @param str the constraint expression
+     * @note added in QGIS 2.16
+     */
+    void setConstraint( int idx, const QString& str );
+
+    /**
      * Returns if the field at fieldidx should be treated as NOT NULL value
      */
     bool notNull( int fieldidx) const;

--- a/python/core/qgseditformconfig.sip
+++ b/python/core/qgseditformconfig.sip
@@ -482,7 +482,7 @@ class QgsEditFormConfig : QObject
      * @return the expression
      * @note added in QGIS 2.16
      */
-    QString constraint( int idx ) const;
+    QString expression( int idx ) const;
 
     /**
      * Set the constraint expression for a specific field
@@ -490,7 +490,7 @@ class QgsEditFormConfig : QObject
      * @param str the constraint expression
      * @note added in QGIS 2.16
      */
-    void setConstraint( int idx, const QString& str );
+    void setExpression( int idx, const QString& str );
 
     /**
      * Returns if the field at fieldidx should be treated as NOT NULL value

--- a/python/core/qgseditformconfig.sip
+++ b/python/core/qgseditformconfig.sip
@@ -493,6 +493,22 @@ class QgsEditFormConfig : QObject
     void setExpression( int idx, const QString& str );
 
     /**
+     * Returns the constraint expression description of a specific filed.
+     * @param idx The index of the field
+     * @return the expression description
+     * @note added in QGIS 2.16
+     */
+    QString expressionDescription( int idx ) const;
+
+    /**
+     * Set the constraint expression description for a specific field.
+     * @param idx The index of the field
+     * @param descr The description of the expression
+     * @note added in QGIS 2.16
+     */
+    void setExpressionDescription( int idx, const QString &descr );
+
+    /**
      * Returns if the field at fieldidx should be treated as NOT NULL value
      */
     bool notNull( int fieldidx) const;

--- a/python/core/qgsfield.sip
+++ b/python/core/qgsfield.sip
@@ -165,7 +165,7 @@ class QgsField
     /* Raise an exception if the arguments couldn't be parsed. */
     sipNoMethod(sipParseErr, sipName_QgsField, sipName_convertCompatible, doc_QgsField_convertCompatible);
 
-    return NULL;
+    return nullptr;
 %End
 
     //! Allows direct construction of QVariants from fields.

--- a/python/gui/editorwidgets/core/qgseditorwidgetwrapper.sip
+++ b/python/gui/editorwidgets/core/qgseditorwidgetwrapper.sip
@@ -112,8 +112,10 @@ class QgsEditorWidgetWrapper : QgsWidgetWrapper
     void valueChanged( const QVariant& value );
 
     /**
+     * Emit this signal when the constraint status changed.
      * @brief constraintStatusChanged
-     * @param constraint
+     * @param constraint represented as a string
+     * @param err the error represented as a string. Empty if none.
      * @param status
      */
     void constraintStatusChanged( const QString& constraint, const QString& err, bool status );

--- a/python/gui/editorwidgets/core/qgseditorwidgetwrapper.sip
+++ b/python/gui/editorwidgets/core/qgseditorwidgetwrapper.sip
@@ -88,6 +88,21 @@ class QgsEditorWidgetWrapper : QgsWidgetWrapper
      */
     virtual void showIndeterminateState();
 
+    /**
+     * Update constraint.
+     * @param featureContext the feature to use to evaluate the constraint
+     * @note added in QGIS 2.16
+     */
+    void updateConstraint( const QgsFeature &featureContext );
+
+    /**
+     * Get the current constraint status.
+     * @return true if the constraint is valid or if there's not constraint,
+     * false otherwise
+     * @note added in QGIS 2.16
+     */
+    bool isValidConstraint() const;
+
   signals:
     /**
      * Emit this signal, whenever the value changed.
@@ -95,6 +110,13 @@ class QgsEditorWidgetWrapper : QgsWidgetWrapper
      * @param value The new value
      */
     void valueChanged( const QVariant& value );
+
+    /**
+     * @brief constraintStatusChanged
+     * @param constraint
+     * @param status
+     */
+    void constraintStatusChanged( const QString& constraint, const QString& err, bool status );
 
   public slots:
     /**
@@ -162,4 +184,17 @@ class QgsEditorWidgetWrapper : QgsWidgetWrapper
      * Will call the value() method to determine the emitted value
      */
     void valueChanged();
+
+  protected:
+    /**
+     * This should update the widget with a visual cue if a constraint status
+     * changed.
+     *
+     * By default a stylesheet will be applied on the widget that changes the
+     * background color to red.
+     *
+     * This can be overwritten in subclasses to allow individual widgets to
+     * change the visual cue.
+     */
+    virtual void updateConstraintWidgetStatus();
 };

--- a/python/gui/editorwidgets/core/qgseditorwidgetwrapper.sip
+++ b/python/gui/editorwidgets/core/qgseditorwidgetwrapper.sip
@@ -115,6 +115,7 @@ class QgsEditorWidgetWrapper : QgsWidgetWrapper
      * Emit this signal when the constraint status changed.
      * @brief constraintStatusChanged
      * @param constraint represented as a string
+     * @param desc is the constraint description
      * @param err the error represented as a string. Empty if none.
      * @param status
      */

--- a/python/gui/editorwidgets/qgsrelationreferencewidgetwrapper.sip
+++ b/python/gui/editorwidgets/qgsrelationreferencewidgetwrapper.sip
@@ -21,4 +21,18 @@ class QgsRelationReferenceWidgetWrapper : QgsEditorWidgetWrapper
   public slots:
     virtual void setValue( const QVariant& value );
     virtual void setEnabled( bool enabled );
+
+  protected:
+    /**
+     * This should update the widget with a visual cue if a constraint status
+     * changed.
+     *
+     * By default a stylesheet will be applied on the widget that changes the
+     * background color to red.
+     *
+     * This can be overwritten in subclasses to allow individual widgets to
+     * change the visual cue.
+     * @note added in QGIS 2.16
+     */
+    void updateConstraintWidgetStatus();
 };

--- a/src/app/qgsattributetypedialog.cpp
+++ b/src/app/qgsattributetypedialog.cpp
@@ -163,14 +163,24 @@ void QgsAttributeTypeDialog::setWidgetV2Config( const QgsEditorWidgetConfig& con
   mWidgetV2Config = config;
 }
 
-bool QgsAttributeTypeDialog::fieldEditable()
+bool QgsAttributeTypeDialog::fieldEditable() const
 {
   return isFieldEditableCheckBox->isChecked();
 }
 
-bool QgsAttributeTypeDialog::labelOnTop()
+void QgsAttributeTypeDialog::setNotNull( bool notnull )
+{
+  notNullCheckBox->setChecked( notnull );
+}
+
+bool QgsAttributeTypeDialog::labelOnTop() const
 {
   return labelOnTopCheckBox->isChecked();
+}
+
+bool QgsAttributeTypeDialog::notNull() const
+{
+  return notNullCheckBox->isChecked();
 }
 
 void QgsAttributeTypeDialog::setFieldEditable( bool editable )

--- a/src/app/qgsattributetypedialog.cpp
+++ b/src/app/qgsattributetypedialog.cpp
@@ -170,9 +170,9 @@ bool QgsAttributeTypeDialog::fieldEditable() const
   return isFieldEditableCheckBox->isChecked();
 }
 
-void QgsAttributeTypeDialog::setNotNull( bool notnull )
+void QgsAttributeTypeDialog::setNotNull( bool notNull )
 {
-  notNullCheckBox->setChecked( notnull );
+  notNullCheckBox->setChecked( notNull );
 }
 
 bool QgsAttributeTypeDialog::labelOnTop() const

--- a/src/app/qgsattributetypedialog.cpp
+++ b/src/app/qgsattributetypedialog.cpp
@@ -185,12 +185,12 @@ bool QgsAttributeTypeDialog::notNull() const
   return notNullCheckBox->isChecked();
 }
 
-void QgsAttributeTypeDialog::setConstraint( const QString &str )
+void QgsAttributeTypeDialog::setExpression( const QString &str )
 {
   constraintExpression->setField( str );
 }
 
-QString QgsAttributeTypeDialog::constraint() const
+QString QgsAttributeTypeDialog::expression() const
 {
   return constraintExpression->asExpression();
 }

--- a/src/app/qgsattributetypedialog.cpp
+++ b/src/app/qgsattributetypedialog.cpp
@@ -180,6 +180,16 @@ bool QgsAttributeTypeDialog::labelOnTop() const
   return labelOnTopCheckBox->isChecked();
 }
 
+void QgsAttributeTypeDialog::setExpressionDescription( const QString &desc )
+{
+  constraintExpressionDescription->setText( desc );
+}
+
+QString QgsAttributeTypeDialog::expressionDescription()
+{
+  return constraintExpressionDescription->text();
+}
+
 bool QgsAttributeTypeDialog::notNull() const
 {
   return notNullCheckBox->isChecked();

--- a/src/app/qgsattributetypedialog.cpp
+++ b/src/app/qgsattributetypedialog.cpp
@@ -71,6 +71,8 @@ QgsAttributeTypeDialog::QgsAttributeTypeDialog( QgsVectorLayer *vl, int fieldIdx
 
   QSettings settings;
   restoreGeometry( settings.value( "/Windows/QgsAttributeTypeDialog/geometry" ).toByteArray() );
+
+  constraintExpression->setLayer( vl );
 }
 
 QgsAttributeTypeDialog::~QgsAttributeTypeDialog()
@@ -181,6 +183,16 @@ bool QgsAttributeTypeDialog::labelOnTop() const
 bool QgsAttributeTypeDialog::notNull() const
 {
   return notNullCheckBox->isChecked();
+}
+
+void QgsAttributeTypeDialog::setConstraint( const QString &str )
+{
+  constraintExpression->setField( str );
+}
+
+QString QgsAttributeTypeDialog::constraint() const
+{
+  return constraintExpression->asExpression();
 }
 
 void QgsAttributeTypeDialog::setFieldEditable( bool editable )

--- a/src/app/qgsattributetypedialog.h
+++ b/src/app/qgsattributetypedialog.h
@@ -70,6 +70,11 @@ class APP_EXPORT QgsAttributeTypeDialog: public QDialog, private Ui::QgsAttribut
     void setLabelOnTop( bool onTop );
 
     /**
+     * Getter for checkbox for label on top of field
+     */
+    bool labelOnTop() const;
+
+    /**
      * Setter for checkbox for editable state of field
      */
     void setFieldEditable( bool editable );
@@ -77,12 +82,17 @@ class APP_EXPORT QgsAttributeTypeDialog: public QDialog, private Ui::QgsAttribut
     /**
      * Getter for checkbox for editable state of field
      */
-    bool fieldEditable();
+    bool fieldEditable() const;
 
     /**
-     * Getter for checkbox for label on top of field
+     * Getter for checkbox for not null
      */
-    bool labelOnTop();
+    void setNotNull( bool notnull );
+
+    /**
+     * Getter for checkbox for not null
+     */
+    bool notNull() const;
 
   private slots:
     /**

--- a/src/app/qgsattributetypedialog.h
+++ b/src/app/qgsattributetypedialog.h
@@ -85,7 +85,7 @@ class APP_EXPORT QgsAttributeTypeDialog: public QDialog, private Ui::QgsAttribut
     bool fieldEditable() const;
 
     /**
-     * Getter for checkbox for not null
+     * Setter for checkbox for not null
      */
     void setNotNull( bool notNull );
 
@@ -93,6 +93,20 @@ class APP_EXPORT QgsAttributeTypeDialog: public QDialog, private Ui::QgsAttribut
      * Getter for checkbox for not null
      */
     bool notNull() const;
+
+    /*
+     * Setter for constraint expression description
+     * @param desc the expression description
+     * @note added in QGIS 2.16
+     **/
+    void setExpressionDescription( const QString &desc );
+
+    /*
+     * Getter for constraint expression description
+     * @return the expression description
+     * @note added in QGIS 2.16
+     **/
+    QString expressionDescription();
 
     /**
      * Getter for the constraint expression

--- a/src/app/qgsattributetypedialog.h
+++ b/src/app/qgsattributetypedialog.h
@@ -87,7 +87,7 @@ class APP_EXPORT QgsAttributeTypeDialog: public QDialog, private Ui::QgsAttribut
     /**
      * Getter for checkbox for not null
      */
-    void setNotNull( bool notnull );
+    void setNotNull( bool notNull );
 
     /**
      * Getter for checkbox for not null

--- a/src/app/qgsattributetypedialog.h
+++ b/src/app/qgsattributetypedialog.h
@@ -94,6 +94,18 @@ class APP_EXPORT QgsAttributeTypeDialog: public QDialog, private Ui::QgsAttribut
      */
     bool notNull() const;
 
+    /**
+     * Getter for the constraint expression
+     * @note added in QGIS 2.16
+     */
+    QString constraint() const;
+
+    /**
+     * Setter for the constraint expression
+     * @note added in QGIS 2.16
+     */
+    void setConstraint( const QString &str );
+
   private slots:
     /**
      * Slot to handle change of index in combobox to select correct page

--- a/src/app/qgsattributetypedialog.h
+++ b/src/app/qgsattributetypedialog.h
@@ -98,13 +98,13 @@ class APP_EXPORT QgsAttributeTypeDialog: public QDialog, private Ui::QgsAttribut
      * Getter for the constraint expression
      * @note added in QGIS 2.16
      */
-    QString constraint() const;
+    QString expression() const;
 
     /**
      * Setter for the constraint expression
      * @note added in QGIS 2.16
      */
-    void setConstraint( const QString &str );
+    void setExpression( const QString &str );
 
   private slots:
     /**

--- a/src/app/qgsfieldsproperties.cpp
+++ b/src/app/qgsfieldsproperties.cpp
@@ -527,6 +527,7 @@ void QgsFieldsProperties::attributeTypeDialog()
 
   attributeTypeDialog.setFieldEditable( cfg.mEditable );
   attributeTypeDialog.setLabelOnTop( cfg.mLabelOnTop );
+  attributeTypeDialog.setNotNull( cfg.mNotNull );
 
   attributeTypeDialog.setWidgetV2Config( cfg.mEditorWidgetV2Config );
   attributeTypeDialog.setWidgetV2Type( cfg.mEditorWidgetV2Type );
@@ -536,6 +537,7 @@ void QgsFieldsProperties::attributeTypeDialog()
 
   cfg.mEditable = attributeTypeDialog.fieldEditable();
   cfg.mLabelOnTop = attributeTypeDialog.labelOnTop();
+  cfg.mNotNull = attributeTypeDialog.notNull();
 
   cfg.mEditorWidgetV2Type = attributeTypeDialog.editorWidgetV2Type();
   cfg.mEditorWidgetV2Config = attributeTypeDialog.editorWidgetV2Config();
@@ -908,6 +910,7 @@ void QgsFieldsProperties::apply()
 
     mLayer->editFormConfig()->setReadOnly( i, !cfg.mEditable );
     mLayer->editFormConfig()->setLabelOnTop( i, cfg.mLabelOnTop );
+    mLayer->editFormConfig()->setNotNull( i, cfg.mNotNull );
 
     mLayer->editFormConfig()->setWidgetType( idx, cfg.mEditorWidgetV2Type );
     mLayer->editFormConfig()->setWidgetConfig( idx, cfg.mEditorWidgetV2Config );
@@ -974,6 +977,7 @@ QgsFieldsProperties::FieldConfig::FieldConfig()
     : mEditable( true )
     , mEditableEnabled( true )
     , mLabelOnTop( false )
+    , mNotNull( false )
     , mButton( nullptr )
 {
 }
@@ -985,6 +989,7 @@ QgsFieldsProperties::FieldConfig::FieldConfig( QgsVectorLayer* layer, int idx )
   mEditableEnabled = layer->fields().fieldOrigin( idx ) != QgsFields::OriginJoin
                      && layer->fields().fieldOrigin( idx ) != QgsFields::OriginExpression;
   mLabelOnTop = layer->editFormConfig()->labelOnTop( idx );
+  mNotNull = layer->editFormConfig()->notNull( idx );
   mEditorWidgetV2Type = layer->editFormConfig()->widgetType( idx );
   mEditorWidgetV2Config = layer->editFormConfig()->widgetConfig( idx );
 

--- a/src/app/qgsfieldsproperties.cpp
+++ b/src/app/qgsfieldsproperties.cpp
@@ -528,7 +528,7 @@ void QgsFieldsProperties::attributeTypeDialog()
   attributeTypeDialog.setFieldEditable( cfg.mEditable );
   attributeTypeDialog.setLabelOnTop( cfg.mLabelOnTop );
   attributeTypeDialog.setNotNull( cfg.mNotNull );
-  attributeTypeDialog.setConstraint( cfg.mConstraint );
+  attributeTypeDialog.setExpression( cfg.mConstraint );
 
   attributeTypeDialog.setWidgetV2Config( cfg.mEditorWidgetV2Config );
   attributeTypeDialog.setWidgetV2Type( cfg.mEditorWidgetV2Type );
@@ -539,7 +539,7 @@ void QgsFieldsProperties::attributeTypeDialog()
   cfg.mEditable = attributeTypeDialog.fieldEditable();
   cfg.mLabelOnTop = attributeTypeDialog.labelOnTop();
   cfg.mNotNull = attributeTypeDialog.notNull();
-  cfg.mConstraint = attributeTypeDialog.constraint();
+  cfg.mConstraint = attributeTypeDialog.expression();
 
   cfg.mEditorWidgetV2Type = attributeTypeDialog.editorWidgetV2Type();
   cfg.mEditorWidgetV2Config = attributeTypeDialog.editorWidgetV2Config();
@@ -913,7 +913,7 @@ void QgsFieldsProperties::apply()
     mLayer->editFormConfig()->setReadOnly( i, !cfg.mEditable );
     mLayer->editFormConfig()->setLabelOnTop( i, cfg.mLabelOnTop );
     mLayer->editFormConfig()->setNotNull( i, cfg.mNotNull );
-    mLayer->editFormConfig()->setConstraint( i, cfg.mConstraint );
+    mLayer->editFormConfig()->setExpression( i, cfg.mConstraint );
 
     mLayer->editFormConfig()->setWidgetType( idx, cfg.mEditorWidgetV2Type );
     mLayer->editFormConfig()->setWidgetConfig( idx, cfg.mEditorWidgetV2Config );
@@ -993,7 +993,7 @@ QgsFieldsProperties::FieldConfig::FieldConfig( QgsVectorLayer* layer, int idx )
                      && layer->fields().fieldOrigin( idx ) != QgsFields::OriginExpression;
   mLabelOnTop = layer->editFormConfig()->labelOnTop( idx );
   mNotNull = layer->editFormConfig()->notNull( idx );
-  mConstraint = layer->editFormConfig()->constraint( idx );
+  mConstraint = layer->editFormConfig()->expression( idx );
   mEditorWidgetV2Type = layer->editFormConfig()->widgetType( idx );
   mEditorWidgetV2Config = layer->editFormConfig()->widgetConfig( idx );
 

--- a/src/app/qgsfieldsproperties.cpp
+++ b/src/app/qgsfieldsproperties.cpp
@@ -528,6 +528,7 @@ void QgsFieldsProperties::attributeTypeDialog()
   attributeTypeDialog.setFieldEditable( cfg.mEditable );
   attributeTypeDialog.setLabelOnTop( cfg.mLabelOnTop );
   attributeTypeDialog.setNotNull( cfg.mNotNull );
+  attributeTypeDialog.setConstraint( cfg.mConstraint );
 
   attributeTypeDialog.setWidgetV2Config( cfg.mEditorWidgetV2Config );
   attributeTypeDialog.setWidgetV2Type( cfg.mEditorWidgetV2Type );
@@ -538,6 +539,7 @@ void QgsFieldsProperties::attributeTypeDialog()
   cfg.mEditable = attributeTypeDialog.fieldEditable();
   cfg.mLabelOnTop = attributeTypeDialog.labelOnTop();
   cfg.mNotNull = attributeTypeDialog.notNull();
+  cfg.mConstraint = attributeTypeDialog.constraint();
 
   cfg.mEditorWidgetV2Type = attributeTypeDialog.editorWidgetV2Type();
   cfg.mEditorWidgetV2Config = attributeTypeDialog.editorWidgetV2Config();
@@ -911,6 +913,7 @@ void QgsFieldsProperties::apply()
     mLayer->editFormConfig()->setReadOnly( i, !cfg.mEditable );
     mLayer->editFormConfig()->setLabelOnTop( i, cfg.mLabelOnTop );
     mLayer->editFormConfig()->setNotNull( i, cfg.mNotNull );
+    mLayer->editFormConfig()->setConstraint( i, cfg.mConstraint );
 
     mLayer->editFormConfig()->setWidgetType( idx, cfg.mEditorWidgetV2Type );
     mLayer->editFormConfig()->setWidgetConfig( idx, cfg.mEditorWidgetV2Config );
@@ -990,6 +993,7 @@ QgsFieldsProperties::FieldConfig::FieldConfig( QgsVectorLayer* layer, int idx )
                      && layer->fields().fieldOrigin( idx ) != QgsFields::OriginExpression;
   mLabelOnTop = layer->editFormConfig()->labelOnTop( idx );
   mNotNull = layer->editFormConfig()->notNull( idx );
+  mConstraint = layer->editFormConfig()->constraint( idx );
   mEditorWidgetV2Type = layer->editFormConfig()->widgetType( idx );
   mEditorWidgetV2Config = layer->editFormConfig()->widgetConfig( idx );
 

--- a/src/app/qgsfieldsproperties.cpp
+++ b/src/app/qgsfieldsproperties.cpp
@@ -529,6 +529,7 @@ void QgsFieldsProperties::attributeTypeDialog()
   attributeTypeDialog.setLabelOnTop( cfg.mLabelOnTop );
   attributeTypeDialog.setNotNull( cfg.mNotNull );
   attributeTypeDialog.setExpression( cfg.mConstraint );
+  attributeTypeDialog.setExpressionDescription( cfg.mConstraintDescription );
 
   attributeTypeDialog.setWidgetV2Config( cfg.mEditorWidgetV2Config );
   attributeTypeDialog.setWidgetV2Type( cfg.mEditorWidgetV2Type );
@@ -539,6 +540,7 @@ void QgsFieldsProperties::attributeTypeDialog()
   cfg.mEditable = attributeTypeDialog.fieldEditable();
   cfg.mLabelOnTop = attributeTypeDialog.labelOnTop();
   cfg.mNotNull = attributeTypeDialog.notNull();
+  cfg.mConstraintDescription = attributeTypeDialog.expressionDescription();
   cfg.mConstraint = attributeTypeDialog.expression();
 
   cfg.mEditorWidgetV2Type = attributeTypeDialog.editorWidgetV2Type();
@@ -913,6 +915,7 @@ void QgsFieldsProperties::apply()
     mLayer->editFormConfig()->setReadOnly( i, !cfg.mEditable );
     mLayer->editFormConfig()->setLabelOnTop( i, cfg.mLabelOnTop );
     mLayer->editFormConfig()->setNotNull( i, cfg.mNotNull );
+    mLayer->editFormConfig()->setExpressionDescription( i, cfg.mConstraintDescription );
     mLayer->editFormConfig()->setExpression( i, cfg.mConstraint );
 
     mLayer->editFormConfig()->setWidgetType( idx, cfg.mEditorWidgetV2Type );
@@ -981,6 +984,7 @@ QgsFieldsProperties::FieldConfig::FieldConfig()
     , mEditableEnabled( true )
     , mLabelOnTop( false )
     , mNotNull( false )
+    , mConstraintDescription( QString() )
     , mButton( nullptr )
 {
 }
@@ -994,6 +998,7 @@ QgsFieldsProperties::FieldConfig::FieldConfig( QgsVectorLayer* layer, int idx )
   mLabelOnTop = layer->editFormConfig()->labelOnTop( idx );
   mNotNull = layer->editFormConfig()->notNull( idx );
   mConstraint = layer->editFormConfig()->expression( idx );
+  mConstraintDescription = layer->editFormConfig()->expressionDescription( idx );
   mEditorWidgetV2Type = layer->editFormConfig()->widgetType( idx );
   mEditorWidgetV2Config = layer->editFormConfig()->widgetConfig( idx );
 

--- a/src/app/qgsfieldsproperties.h
+++ b/src/app/qgsfieldsproperties.h
@@ -92,6 +92,7 @@ class APP_EXPORT QgsFieldsProperties : public QWidget, private Ui_QgsFieldsPrope
         bool mEditable;
         bool mEditableEnabled;
         bool mLabelOnTop;
+        bool mNotNull;
         QPushButton* mButton;
         QString mEditorWidgetV2Type;
         QMap<QString, QVariant> mEditorWidgetV2Config;

--- a/src/app/qgsfieldsproperties.h
+++ b/src/app/qgsfieldsproperties.h
@@ -93,6 +93,7 @@ class APP_EXPORT QgsFieldsProperties : public QWidget, private Ui_QgsFieldsPrope
         bool mEditableEnabled;
         bool mLabelOnTop;
         bool mNotNull;
+        QString mConstraint;
         QPushButton* mButton;
         QString mEditorWidgetV2Type;
         QMap<QString, QVariant> mEditorWidgetV2Config;

--- a/src/app/qgsfieldsproperties.h
+++ b/src/app/qgsfieldsproperties.h
@@ -94,6 +94,7 @@ class APP_EXPORT QgsFieldsProperties : public QWidget, private Ui_QgsFieldsPrope
         bool mLabelOnTop;
         bool mNotNull;
         QString mConstraint;
+        QString mConstraintDescription;
         QPushButton* mButton;
         QString mEditorWidgetV2Type;
         QMap<QString, QVariant> mEditorWidgetV2Config;

--- a/src/core/qgseditformconfig.cpp
+++ b/src/core/qgseditformconfig.cpp
@@ -119,6 +119,14 @@ bool QgsEditFormConfig::labelOnTop( int idx ) const
     return false;
 }
 
+bool QgsEditFormConfig::notNull( int idx ) const
+{
+  if ( idx >= 0 && idx < mFields.count() )
+    return mNotNull.value( mFields.at( idx ).name(), false );
+  else
+    return false;
+}
+
 void QgsEditFormConfig::setReadOnly( int idx, bool readOnly )
 {
   if ( idx >= 0 && idx < mFields.count() )
@@ -129,6 +137,12 @@ void QgsEditFormConfig::setLabelOnTop( int idx, bool onTop )
 {
   if ( idx >= 0 && idx < mFields.count() )
     mLabelOnTop[ mFields.at( idx ).name()] = onTop;
+}
+
+void QgsEditFormConfig::setNotNull( int idx, bool notnull )
+{
+  if ( idx >= 0 && idx < mFields.count() )
+    mNotNull[ mFields.at( idx ).name()] = notnull;
 }
 
 void QgsEditFormConfig::readXml( const QDomNode& node )
@@ -280,7 +294,6 @@ void QgsEditFormConfig::writeXml( QDomNode& node ) const
   efifpField.appendChild( doc.createTextNode( QgsProject::instance()->writePath( initFilePath() ) ) );
   node.appendChild( efifpField );
 
-
   QDomElement eficField  = doc.createElement( "editforminitcode" );
   eficField.appendChild( doc.createCDATASection( initCode() ) );
   node.appendChild( eficField );
@@ -337,6 +350,7 @@ void QgsEditFormConfig::writeXml( QDomNode& node ) const
     {
       QDomElement widgetElem = doc.createElement( "widget" );
       widgetElem.setAttribute( "name", configIt.key() );
+      // widgetElem.setAttribute( "notNull",  );
 
       QDomElement configElem = doc.createElement( "config" );
       widgetElem.appendChild( configElem );

--- a/src/core/qgseditformconfig.cpp
+++ b/src/core/qgseditformconfig.cpp
@@ -135,6 +135,22 @@ void QgsEditFormConfig::setExpression( int idx, const QString& str )
     mConstraints[ mFields.at( idx ).name()] = str;
 }
 
+QString QgsEditFormConfig::expressionDescription( int idx ) const
+{
+  QString description;
+
+  if ( idx >= 0 && idx < mFields.count() )
+    description = mConstraintsDescription[ mFields.at( idx ).name()];
+
+  return description;
+}
+
+void QgsEditFormConfig::setExpressionDescription( int idx, const QString &descr )
+{
+  if ( idx >= 0 && idx < mFields.count() )
+    mConstraintsDescription[ mFields.at( idx ).name()] = descr;
+}
+
 bool QgsEditFormConfig::notNull( int idx ) const
 {
   if ( idx >= 0 && idx < mFields.count() )

--- a/src/core/qgseditformconfig.cpp
+++ b/src/core/qgseditformconfig.cpp
@@ -119,7 +119,7 @@ bool QgsEditFormConfig::labelOnTop( int idx ) const
     return false;
 }
 
-QString QgsEditFormConfig::constraint( int idx ) const
+QString QgsEditFormConfig::expression( int idx ) const
 {
   QString expr = "";
 
@@ -129,7 +129,7 @@ QString QgsEditFormConfig::constraint( int idx ) const
   return expr;
 }
 
-void QgsEditFormConfig::setConstraint( int idx, const QString& str )
+void QgsEditFormConfig::setExpression( int idx, const QString& str )
 {
   if ( idx >= 0 && idx < mFields.count() )
     mConstraints[ mFields.at( idx ).name()] = str;

--- a/src/core/qgseditformconfig.cpp
+++ b/src/core/qgseditformconfig.cpp
@@ -119,6 +119,22 @@ bool QgsEditFormConfig::labelOnTop( int idx ) const
     return false;
 }
 
+QString QgsEditFormConfig::constraint( int idx ) const
+{
+  QString expr = "";
+
+  if ( idx >= 0 && idx < mFields.count() )
+    expr = mConstraints.value( mFields.at( idx ).name(), "" );
+
+  return expr;
+}
+
+void QgsEditFormConfig::setConstraint( int idx, const QString& str )
+{
+  if ( idx >= 0 && idx < mFields.count() )
+    mConstraints[ mFields.at( idx ).name()] = str;
+}
+
 bool QgsEditFormConfig::notNull( int idx ) const
 {
   if ( idx >= 0 && idx < mFields.count() )

--- a/src/core/qgseditformconfig.cpp
+++ b/src/core/qgseditformconfig.cpp
@@ -121,10 +121,10 @@ bool QgsEditFormConfig::labelOnTop( int idx ) const
 
 QString QgsEditFormConfig::expression( int idx ) const
 {
-  QString expr = "";
+  QString expr;
 
   if ( idx >= 0 && idx < mFields.count() )
-    expr = mConstraints.value( mFields.at( idx ).name(), "" );
+    expr = mConstraints.value( mFields.at( idx ).name(), QString() );
 
   return expr;
 }

--- a/src/core/qgseditformconfig.h
+++ b/src/core/qgseditformconfig.h
@@ -518,7 +518,7 @@ class CORE_EXPORT QgsEditFormConfig : public QObject
      * @return the expression
      * @note added in QGIS 2.16
      */
-    QString constraint( int idx ) const;
+    QString expression( int idx ) const;
 
     /**
      * Set the constraint expression for a specific field
@@ -526,7 +526,7 @@ class CORE_EXPORT QgsEditFormConfig : public QObject
      * @param str the constraint expression
      * @note added in QGIS 2.16
      */
-    void setConstraint( int idx, const QString& str );
+    void setExpression( int idx, const QString& str );
 
     /**
      * Returns if the field at fieldidx should be treated as NOT NULL value

--- a/src/core/qgseditformconfig.h
+++ b/src/core/qgseditformconfig.h
@@ -513,6 +513,15 @@ class CORE_EXPORT QgsEditFormConfig : public QObject
     void setReadOnly( int idx, bool readOnly = true );
 
     /**
+     * Returns if the field at fieldidx should be treated as NOT NULL value
+     */
+    bool notNull( int fieldidx ) const;
+    /**
+     * Set if the field at fieldidx should be treated as NOT NULL value
+     */
+    void setNotNull( int idx, bool notnull = true );
+
+    /**
      * If this returns true, the widget at the given index will receive its label on the previous line
      * while if it returns false, the widget will receive its label on the left hand side.
      * Labeling on top leaves more horizontal space for the widget itself.
@@ -633,6 +642,7 @@ class CORE_EXPORT QgsEditFormConfig : public QObject
 
     QMap< QString, bool> mFieldEditables;
     QMap< QString, bool> mLabelOnTop;
+    QMap< QString, bool> mNotNull;
 
     QMap<QString, QString> mEditorWidgetV2Types;
     QMap<QString, QgsEditorWidgetConfig > mWidgetConfigs;

--- a/src/core/qgseditformconfig.h
+++ b/src/core/qgseditformconfig.h
@@ -484,12 +484,12 @@ class CORE_EXPORT QgsEditFormConfig : public QObject
     QgsEditorWidgetConfig widgetConfig( const QString& widgetName ) const;
 
     /**
-     * Remove the configuration for the editor widget used to represent the field at the given index
-     *
-     * @param fieldIdx  The index of the field
-     *
-     * @return true if successful, false if the field does not exist
-     */
+    * Remove the configuration for the editor widget used to represent the field at the given index
+    *
+    * @param fieldIdx  The index of the field
+    *
+    * @return true if successful, false if the field does not exist
+    */
     bool removeWidgetConfig( int fieldIdx );
 
     /**
@@ -527,6 +527,22 @@ class CORE_EXPORT QgsEditFormConfig : public QObject
      * @note added in QGIS 2.16
      */
     void setExpression( int idx, const QString& str );
+
+    /**
+     * Returns the constraint expression description of a specific filed.
+     * @param idx The index of the field
+     * @return the expression description
+     * @note added in QGIS 2.16
+     */
+    QString expressionDescription( int idx ) const;
+
+    /**
+     * Set the constraint expression description for a specific field.
+     * @param idx The index of the field
+     * @param descr The description of the expression
+     * @note added in QGIS 2.16
+     */
+    void setExpressionDescription( int idx, const QString &descr );
 
     /**
      * Returns if the field at fieldidx should be treated as NOT NULL value
@@ -657,6 +673,7 @@ class CORE_EXPORT QgsEditFormConfig : public QObject
     QList< TabData > mTabs;
 
     QMap< QString, QString> mConstraints;
+    QMap< QString, QString> mConstraintsDescription;
     QMap< QString, bool> mFieldEditables;
     QMap< QString, bool> mLabelOnTop;
     QMap< QString, bool> mNotNull;

--- a/src/core/qgseditformconfig.h
+++ b/src/core/qgseditformconfig.h
@@ -513,6 +513,22 @@ class CORE_EXPORT QgsEditFormConfig : public QObject
     void setReadOnly( int idx, bool readOnly = true );
 
     /**
+     * Returns the constraint expression of a specific field
+     * @param idx The index of the field
+     * @return the expression
+     * @note added in QGIS 2.16
+     */
+    QString constraint( int idx ) const;
+
+    /**
+     * Set the constraint expression for a specific field
+     * @param idx the field index
+     * @param str the constraint expression
+     * @note added in QGIS 2.16
+     */
+    void setConstraint( int idx, const QString& str );
+
+    /**
      * Returns if the field at fieldidx should be treated as NOT NULL value
      */
     bool notNull( int fieldidx ) const;
@@ -640,6 +656,7 @@ class CORE_EXPORT QgsEditFormConfig : public QObject
     /** Map that stores the tab for attributes in the edit form. Key is the tab order and value the tab name*/
     QList< TabData > mTabs;
 
+    QMap< QString, QString> mConstraints;
     QMap< QString, bool> mFieldEditables;
     QMap< QString, bool> mLabelOnTop;
     QMap< QString, bool> mNotNull;

--- a/src/core/qgseditorwidgetconfig.h
+++ b/src/core/qgseditorwidgetconfig.h
@@ -16,6 +16,8 @@
 #include <QString>
 #include <QVariant>
 
+#ifndef QGSEDITORWIDGETCONFIG_H
+#define QGSEDITORWIDGETCONFIG_H
 
 /**
  * Holds a set of configuration parameters for a editor widget wrapper.
@@ -30,4 +32,6 @@
  * You get these passed, for every new widget wrapper.
  */
 
-typedef QMap<QString, QVariant> QgsEditorWidgetConfig;
+typedef QVariantMap QgsEditorWidgetConfig;
+
+#endif // QGSEDITORWIDGETCONFIG_H

--- a/src/core/qgsfeature.cpp
+++ b/src/core/qgsfeature.cpp
@@ -288,6 +288,12 @@ int QgsFeature::fieldNameIndex( const QString& fieldName ) const
   return d->fields.fieldNameIndex( fieldName );
 }
 
+/***************************************************************************
+ * This class is considered CRITICAL and any change MUST be accompanied with
+ * full unit tests in testqgsfeature.cpp.
+ * See details in QEP #17
+ ****************************************************************************/
+
 QDataStream& operator<<( QDataStream& out, const QgsFeature& feature )
 {
   out << feature.id();

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -1105,13 +1105,13 @@ QgsFeatureIterator QgsVectorLayer::getFeatures( const QgsFeatureRequest& request
 }
 
 
-bool QgsVectorLayer::addFeature( QgsFeature& f, bool alsoUpdateExtent )
+bool QgsVectorLayer::addFeature( QgsFeature& feature, bool alsoUpdateExtent )
 {
   Q_UNUSED( alsoUpdateExtent ); // TODO[MD]
   if ( !mValid || !mEditBuffer || !mDataProvider )
     return false;
 
-  bool success = mEditBuffer->addFeature( f );
+  bool success = mEditBuffer->addFeature( feature );
 
   if ( success )
     updateExtents();

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -979,7 +979,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
         @param alsoUpdateExtent If True, will also go to the effort of e.g. updating the extents.
         @return                    True in case of success and False in case of error
      */
-    bool addFeature( QgsFeature& f, bool alsoUpdateExtent = true );
+    bool addFeature( QgsFeature& feature, bool alsoUpdateExtent = true );
 
     /** Updates an existing feature. This method needs to query the datasource
         on every call. Consider using {@link changeAttributeValue()} or

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -975,11 +975,11 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
     QgsFeatureIterator getFeatures( const QgsFeatureRequest& request = QgsFeatureRequest() );
 
     /** Adds a feature
-        @param f feature to add
+        @param feature feature to add
         @param alsoUpdateExtent If True, will also go to the effort of e.g. updating the extents.
         @return                    True in case of success and False in case of error
      */
-    bool addFeature( QgsFeature& f, bool alsoUpdateExtent = true );
+    bool addFeature( QgsFeature& feature, bool alsoUpdateExtent = true );
 
     /** Updates an existing feature. This method needs to query the datasource
         on every call. Consider using {@link changeAttributeValue()} or

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -979,7 +979,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
         @param alsoUpdateExtent If True, will also go to the effort of e.g. updating the extents.
         @return                    True in case of success and False in case of error
      */
-    bool addFeature( QgsFeature& feature, bool alsoUpdateExtent = true );
+    bool addFeature( QgsFeature& f, bool alsoUpdateExtent = true );
 
     /** Updates an existing feature. This method needs to query the datasource
         on every call. Consider using {@link changeAttributeValue()} or

--- a/src/gui/editorwidgets/core/qgseditorwidgetregistry.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetregistry.cpp
@@ -252,7 +252,7 @@ void QgsEditorWidgetRegistry::readMapLayer( QgsMapLayer* mapLayer, const QDomEle
       vectorLayer->editFormConfig()->setReadOnly( idx, ewv2CfgElem.attribute( "fieldEditable", "1" ) != "1" );
       vectorLayer->editFormConfig()->setLabelOnTop( idx, ewv2CfgElem.attribute( "labelOnTop", "0" ) == "1" );
       vectorLayer->editFormConfig()->setNotNull( idx, ewv2CfgElem.attribute( "notNull", "0" ) == "1" );
-      vectorLayer->editFormConfig()->setExpression( idx, ewv2CfgElem.attribute( "constraint", "" ) );
+      vectorLayer->editFormConfig()->setExpression( idx, ewv2CfgElem.attribute( "constraint", QString() ) );
 
       vectorLayer->editFormConfig()->setWidgetConfig( idx, cfg );
     }

--- a/src/gui/editorwidgets/core/qgseditorwidgetregistry.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetregistry.cpp
@@ -252,6 +252,8 @@ void QgsEditorWidgetRegistry::readMapLayer( QgsMapLayer* mapLayer, const QDomEle
       vectorLayer->editFormConfig()->setReadOnly( idx, ewv2CfgElem.attribute( "fieldEditable", "1" ) != "1" );
       vectorLayer->editFormConfig()->setLabelOnTop( idx, ewv2CfgElem.attribute( "labelOnTop", "0" ) == "1" );
       vectorLayer->editFormConfig()->setNotNull( idx, ewv2CfgElem.attribute( "notNull", "0" ) == "1" );
+      vectorLayer->editFormConfig()->setConstraint( idx, ewv2CfgElem.attribute( "constraint", "" ) );
+
       vectorLayer->editFormConfig()->setWidgetConfig( idx, cfg );
     }
     else
@@ -309,6 +311,7 @@ void QgsEditorWidgetRegistry::writeMapLayer( QgsMapLayer* mapLayer, QDomElement&
       ewv2CfgElem.setAttribute( "fieldEditable", !vectorLayer->editFormConfig()->readOnly( idx ) );
       ewv2CfgElem.setAttribute( "labelOnTop", vectorLayer->editFormConfig()->labelOnTop( idx ) );
       ewv2CfgElem.setAttribute( "notNull", vectorLayer->editFormConfig()->notNull( idx ) );
+      ewv2CfgElem.setAttribute( "constraint", vectorLayer->editFormConfig()->constraint( idx ) );
 
       mWidgetFactories[widgetType]->writeConfig( vectorLayer->editFormConfig()->widgetConfig( idx ), ewv2CfgElem, doc, vectorLayer, idx );
 

--- a/src/gui/editorwidgets/core/qgseditorwidgetregistry.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetregistry.cpp
@@ -251,6 +251,7 @@ void QgsEditorWidgetRegistry::readMapLayer( QgsMapLayer* mapLayer, const QDomEle
 
       vectorLayer->editFormConfig()->setReadOnly( idx, ewv2CfgElem.attribute( "fieldEditable", "1" ) != "1" );
       vectorLayer->editFormConfig()->setLabelOnTop( idx, ewv2CfgElem.attribute( "labelOnTop", "0" ) == "1" );
+      vectorLayer->editFormConfig()->setNotNull( idx, ewv2CfgElem.attribute( "notNull", "0" ) == "1" );
       vectorLayer->editFormConfig()->setWidgetConfig( idx, cfg );
     }
     else
@@ -307,6 +308,7 @@ void QgsEditorWidgetRegistry::writeMapLayer( QgsMapLayer* mapLayer, QDomElement&
       QDomElement ewv2CfgElem = doc.createElement( "widgetv2config" );
       ewv2CfgElem.setAttribute( "fieldEditable", !vectorLayer->editFormConfig()->readOnly( idx ) );
       ewv2CfgElem.setAttribute( "labelOnTop", vectorLayer->editFormConfig()->labelOnTop( idx ) );
+      ewv2CfgElem.setAttribute( "notNull", vectorLayer->editFormConfig()->notNull( idx ) );
 
       mWidgetFactories[widgetType]->writeConfig( vectorLayer->editFormConfig()->widgetConfig( idx ), ewv2CfgElem, doc, vectorLayer, idx );
 

--- a/src/gui/editorwidgets/core/qgseditorwidgetregistry.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetregistry.cpp
@@ -252,7 +252,7 @@ void QgsEditorWidgetRegistry::readMapLayer( QgsMapLayer* mapLayer, const QDomEle
       vectorLayer->editFormConfig()->setReadOnly( idx, ewv2CfgElem.attribute( "fieldEditable", "1" ) != "1" );
       vectorLayer->editFormConfig()->setLabelOnTop( idx, ewv2CfgElem.attribute( "labelOnTop", "0" ) == "1" );
       vectorLayer->editFormConfig()->setNotNull( idx, ewv2CfgElem.attribute( "notNull", "0" ) == "1" );
-      vectorLayer->editFormConfig()->setConstraint( idx, ewv2CfgElem.attribute( "constraint", "" ) );
+      vectorLayer->editFormConfig()->setExpression( idx, ewv2CfgElem.attribute( "constraint", "" ) );
 
       vectorLayer->editFormConfig()->setWidgetConfig( idx, cfg );
     }
@@ -311,7 +311,7 @@ void QgsEditorWidgetRegistry::writeMapLayer( QgsMapLayer* mapLayer, QDomElement&
       ewv2CfgElem.setAttribute( "fieldEditable", !vectorLayer->editFormConfig()->readOnly( idx ) );
       ewv2CfgElem.setAttribute( "labelOnTop", vectorLayer->editFormConfig()->labelOnTop( idx ) );
       ewv2CfgElem.setAttribute( "notNull", vectorLayer->editFormConfig()->notNull( idx ) );
-      ewv2CfgElem.setAttribute( "constraint", vectorLayer->editFormConfig()->constraint( idx ) );
+      ewv2CfgElem.setAttribute( "constraint", vectorLayer->editFormConfig()->expression( idx ) );
 
       mWidgetFactories[widgetType]->writeConfig( vectorLayer->editFormConfig()->widgetConfig( idx ), ewv2CfgElem, doc, vectorLayer, idx );
 

--- a/src/gui/editorwidgets/core/qgseditorwidgetregistry.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetregistry.cpp
@@ -253,6 +253,7 @@ void QgsEditorWidgetRegistry::readMapLayer( QgsMapLayer* mapLayer, const QDomEle
       vectorLayer->editFormConfig()->setLabelOnTop( idx, ewv2CfgElem.attribute( "labelOnTop", "0" ) == "1" );
       vectorLayer->editFormConfig()->setNotNull( idx, ewv2CfgElem.attribute( "notNull", "0" ) == "1" );
       vectorLayer->editFormConfig()->setExpression( idx, ewv2CfgElem.attribute( "constraint", QString() ) );
+      vectorLayer->editFormConfig()->setExpressionDescription( idx, ewv2CfgElem.attribute( "constraintDescription", QString() ) );
 
       vectorLayer->editFormConfig()->setWidgetConfig( idx, cfg );
     }
@@ -312,6 +313,7 @@ void QgsEditorWidgetRegistry::writeMapLayer( QgsMapLayer* mapLayer, QDomElement&
       ewv2CfgElem.setAttribute( "labelOnTop", vectorLayer->editFormConfig()->labelOnTop( idx ) );
       ewv2CfgElem.setAttribute( "notNull", vectorLayer->editFormConfig()->notNull( idx ) );
       ewv2CfgElem.setAttribute( "constraint", vectorLayer->editFormConfig()->expression( idx ) );
+      ewv2CfgElem.setAttribute( "constraintDescription", vectorLayer->editFormConfig()->expressionDescription( idx ) );
 
       mWidgetFactories[widgetType]->writeConfig( vectorLayer->editFormConfig()->widgetConfig( idx ), ewv2CfgElem, doc, vectorLayer, idx );
 

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
@@ -24,6 +24,7 @@ QgsEditorWidgetWrapper::QgsEditorWidgetWrapper( QgsVectorLayer* vl, int fieldIdx
     : QgsWidgetWrapper( vl, editor, parent )
     , mFieldIdx( fieldIdx )
 {
+  connect( this, SIGNAL( valueChanged( QVariant ) ), this, SLOT( onValueChanged( QVariant ) ) );
 }
 
 int QgsEditorWidgetWrapper::fieldIdx() const
@@ -61,6 +62,7 @@ void QgsEditorWidgetWrapper::setEnabled( bool enabled )
 void QgsEditorWidgetWrapper::setFeature( const QgsFeature& feature )
 {
   setValue( feature.attribute( mFieldIdx ) );
+  onValueChanged( value() );
 }
 
 void QgsEditorWidgetWrapper::valueChanged( const QString& value )
@@ -91,4 +93,29 @@ void QgsEditorWidgetWrapper::valueChanged( qlonglong value )
 void QgsEditorWidgetWrapper::valueChanged()
 {
   emit valueChanged( value() );
+}
+
+void QgsEditorWidgetWrapper::updateConstraintsOk( bool constraintStatus )
+{
+  if ( constraintStatus )
+  {
+    widget()->setStyleSheet( "" );
+  }
+  else
+  {
+    widget()->setStyleSheet( "QWidget{ background-color: '#dd7777': }" );
+  }
+}
+
+void QgsEditorWidgetWrapper::onValueChanged( const QVariant& value )
+{
+  if ( layer()->editFormConfig()->notNull( mFieldIdx ) )
+  {
+    if ( value.isNull() != mIsNull )
+    {
+      updateConstraintsOk( value.isNull() );
+      emit constraintStatusChanged( "NotNull", !value.isNull() );
+      mIsNull = value.isNull();
+    }
+  }
 }

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
@@ -107,7 +107,7 @@ void QgsEditorWidgetWrapper::updateConstraint( const QgsFeature &ft )
 {
   bool toEmit( false );
   QString errStr( "predicate is True" );
-  QString expression = layer()->editFormConfig()->constraint( mFieldIdx );
+  QString expression = layer()->editFormConfig()->expression( mFieldIdx );
   QVariant value = ft.attribute( mFieldIdx );
 
   if ( ! expression.isEmpty() )

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
@@ -114,6 +114,7 @@ void QgsEditorWidgetWrapper::updateConstraint( const QgsFeature &ft )
   {
     QgsExpressionContext context =
       QgsExpressionContextUtils::createFeatureBasedContext( ft, *ft.fields() );
+    context << QgsExpressionContextUtils::layerScope( layer() );
 
     context.setFeature( ft );
     QgsExpression expr( expression );

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
@@ -98,7 +98,7 @@ void QgsEditorWidgetWrapper::valueChanged()
 void QgsEditorWidgetWrapper::updateConstraintWidgetStatus()
 {
   if ( mValidConstraint )
-    widget()->setStyleSheet( "" );
+    widget()->setStyleSheet( QString() );
   else
     widget()->setStyleSheet( "background-color: #dd7777;" );
 }

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
@@ -108,10 +108,13 @@ void QgsEditorWidgetWrapper::updateConstraint( const QgsFeature &ft )
   bool toEmit( false );
   QString errStr( tr( "predicate is True" ) );
   QString expression = layer()->editFormConfig()->expression( mFieldIdx );
+  QString description;
   QVariant value = ft.attribute( mFieldIdx );
 
   if ( ! expression.isEmpty() )
   {
+    description = layer()->editFormConfig()->expressionDescription( mFieldIdx );
+
     QgsExpressionContext context =
       QgsExpressionContextUtils::createFeatureBasedContext( ft, *ft.fields() );
     context << QgsExpressionContextUtils::layerScope( layer() );
@@ -139,9 +142,13 @@ void QgsEditorWidgetWrapper::updateConstraint( const QgsFeature &ft )
     {
       QString fieldName = ft.fields()->field( mFieldIdx ).name();
       expression = "( " + expression + " ) AND ( " + fieldName + " IS NOT NULL)";
+      description = "( " + description + " ) AND NotNull";
     }
     else
+    {
+      description = "NotNull";
       expression = "NotNull";
+    }
 
     mValidConstraint = mValidConstraint && !value.isNull();
 
@@ -154,7 +161,7 @@ void QgsEditorWidgetWrapper::updateConstraint( const QgsFeature &ft )
   if ( toEmit )
   {
     updateConstraintWidgetStatus();
-    emit constraintStatusChanged( expression, errStr, mValidConstraint );
+    emit constraintStatusChanged( expression, description, errStr, mValidConstraint );
   }
 }
 

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
@@ -106,7 +106,7 @@ void QgsEditorWidgetWrapper::updateConstraintWidgetStatus()
 void QgsEditorWidgetWrapper::updateConstraint( const QgsFeature &ft )
 {
   bool toEmit( false );
-  QString errStr( "predicate is True" );
+  QString errStr( tr( "predicate is True" ) );
   QString expression = layer()->editFormConfig()->expression( mFieldIdx );
   QVariant value = ft.attribute( mFieldIdx );
 
@@ -125,7 +125,7 @@ void QgsEditorWidgetWrapper::updateConstraint( const QgsFeature &ft )
     else if ( expr.hasEvalError() )
       errStr = expr.evalErrorString();
     else if ( ! mValidConstraint )
-      errStr = "predicate is False";
+      errStr = tr( "predicate is False" );
 
     toEmit = true;
   }
@@ -145,7 +145,7 @@ void QgsEditorWidgetWrapper::updateConstraint( const QgsFeature &ft )
     mValidConstraint = mValidConstraint && !value.isNull();
 
     if ( value.isNull() )
-      errStr = "predicate is False";
+      errStr = tr( "predicate is False" );
 
     toEmit = true;
   }

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
@@ -118,6 +118,13 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
      */
     void valueChanged( const QVariant& value );
 
+    /**
+     * @brief constraintStatusChanged
+     * @param constraint
+     * @param status
+     */
+    void constraintStatusChanged( const QString& constraint, bool status );
+
   public slots:
     /**
      * Will be called when the feature changes
@@ -186,7 +193,27 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
     void valueChanged();
 
   private:
+    /**
+     * This should update the widget with a visual cue if a constraint status
+     * changed.
+     *
+     * By default a stylesheet will be applied on the widget that changes the
+     * background color to red.
+     *
+     * This can be overwritten in subclasses to allow individual widgets to
+     * change the visual cue.
+     */
+    virtual void updateConstraintsOk( bool constraintStatus );
+
+  private slots:
+    /**
+     * @brief mFieldIdx
+     */
+    void onValueChanged( const QVariant& value );
+
+  private:
     int mFieldIdx;
+    bool mIsNull;
 };
 
 // We'll use this class inside a QVariant in the widgets properties

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
@@ -223,6 +223,9 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
      */
     virtual void updateConstraintWidgetStatus();
 
+    /**
+     * Boolean storing the current validity of the constraint for this widget.
+     */
     bool mValidConstraint;
 
   private:

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
@@ -137,10 +137,11 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
      * Emit this signal when the constraint status changed.
      * @brief constraintStatusChanged
      * @param constraint represented as a string
+     * @param desc is the constraint description
      * @param err the error represented as a string. Empty if none.
      * @param status
      */
-    void constraintStatusChanged( const QString& constraint, const QString& err, bool status );
+    void constraintStatusChanged( const QString& constraint, const QString &desc, const QString& err, bool status );
 
   public slots:
     /**

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.h
@@ -110,6 +110,21 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
      */
     virtual void showIndeterminateState() {}
 
+    /**
+     * Update constraint.
+     * @param featureContext the feature to use to evaluate the constraint
+     * @note added in QGIS 2.16
+     */
+    void updateConstraint( const QgsFeature &featureContext );
+
+    /**
+     * Get the current constraint status.
+     * @return true if the constraint is valid or if there's not constraint,
+     * false otherwise
+     * @note added in QGIS 2.16
+     */
+    bool isValidConstraint() const;
+
   signals:
     /**
      * Emit this signal, whenever the value changed.
@@ -119,11 +134,13 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
     void valueChanged( const QVariant& value );
 
     /**
+     * Emit this signal when the constraint status changed.
      * @brief constraintStatusChanged
-     * @param constraint
+     * @param constraint represented as a string
+     * @param err the error represented as a string. Empty if none.
      * @param status
      */
-    void constraintStatusChanged( const QString& constraint, bool status );
+    void constraintStatusChanged( const QString& constraint, const QString& err, bool status );
 
   public slots:
     /**
@@ -192,7 +209,7 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
      */
     void valueChanged();
 
-  private:
+  protected:
     /**
      * This should update the widget with a visual cue if a constraint status
      * changed.
@@ -202,18 +219,15 @@ class GUI_EXPORT QgsEditorWidgetWrapper : public QgsWidgetWrapper
      *
      * This can be overwritten in subclasses to allow individual widgets to
      * change the visual cue.
+     * @note added in QGIS 2.16
      */
-    virtual void updateConstraintsOk( bool constraintStatus );
+    virtual void updateConstraintWidgetStatus();
 
-  private slots:
-    /**
-     * @brief mFieldIdx
-     */
-    void onValueChanged( const QVariant& value );
+    bool mValidConstraint;
 
   private:
     int mFieldIdx;
-    bool mIsNull;
+    QgsFeature mFeature;
 };
 
 // We'll use this class inside a QVariant in the widgets properties

--- a/src/gui/editorwidgets/qgscolorwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgscolorwidgetwrapper.cpp
@@ -77,3 +77,8 @@ void QgsColorWidgetWrapper::setValue( const QVariant& value )
   if ( mColorButton )
     mColorButton->setColor( !value.isNull() ? QColor( value.toString() ) : QColor() );
 }
+
+void QgsColorWidgetWrapper::updateConstraintWidgetStatus()
+{
+  // nothing
+}

--- a/src/gui/editorwidgets/qgscolorwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgscolorwidgetwrapper.h
@@ -46,6 +46,8 @@ class GUI_EXPORT  QgsColorWidgetWrapper : public QgsEditorWidgetWrapper
     void setValue( const QVariant& value ) override;
 
   private:
+    void updateConstraintWidgetStatus() override;
+
     QgsColorButtonV2* mColorButton;
 };
 

--- a/src/gui/editorwidgets/qgsexternalresourcewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsexternalresourcewidgetwrapper.cpp
@@ -95,8 +95,9 @@ void QgsExternalResourceWidgetWrapper::initWidget( QWidget* editor )
     {
       fle->setNullValue( QSettings().value( "qgis/nullValue", "NULL" ).toString() );
     }
-    connect( mLineEdit, SIGNAL( textChanged( QString ) ), this, SLOT( valueChanged( QString ) ) );
   }
+  else
+    mLineEdit = editor->findChild<QLineEdit*>();
 
   if ( mQgsWidget )
   {
@@ -138,6 +139,10 @@ void QgsExternalResourceWidgetWrapper::initWidget( QWidget* editor )
       mQgsWidget->fileWidget()->setFilter( config( "FileWidgetFilter" ).toString() );
     }
   }
+
+  if ( mLineEdit )
+    connect( mLineEdit, SIGNAL( textChanged( QString ) ), this, SLOT( valueChanged( QString ) ) );
+
 }
 
 void QgsExternalResourceWidgetWrapper::setValue( const QVariant& value )
@@ -181,4 +186,15 @@ void QgsExternalResourceWidgetWrapper::setEnabled( bool enabled )
 
   if ( mQgsWidget )
     mQgsWidget->setReadOnly( !enabled );
+}
+
+void QgsExternalResourceWidgetWrapper::updateConstraintWidgetStatus()
+{
+  if ( mLineEdit )
+  {
+    if ( mValidConstraint )
+      mLineEdit->setStyleSheet( "" );
+    else
+      mLineEdit->setStyleSheet( "QgsFilterLineEdit { background-color: #dd7777; }" );
+  }
 }

--- a/src/gui/editorwidgets/qgsexternalresourcewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsexternalresourcewidgetwrapper.cpp
@@ -193,7 +193,7 @@ void QgsExternalResourceWidgetWrapper::updateConstraintWidgetStatus()
   if ( mLineEdit )
   {
     if ( mValidConstraint )
-      mLineEdit->setStyleSheet( "" );
+      mLineEdit->setStyleSheet( QString() );
     else
       mLineEdit->setStyleSheet( "QgsFilterLineEdit { background-color: #dd7777; }" );
   }

--- a/src/gui/editorwidgets/qgsexternalresourcewidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsexternalresourcewidgetwrapper.h
@@ -54,6 +54,8 @@ class GUI_EXPORT QgsExternalResourceWidgetWrapper : public QgsEditorWidgetWrappe
     void setEnabled( bool enabled ) override;
 
   private:
+    void updateConstraintWidgetStatus() override;
+
     QLineEdit* mLineEdit;
     QLabel* mLabel;
     QgsExternalResourceWidget* mQgsWidget;

--- a/src/gui/editorwidgets/qgsfilenamewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsfilenamewidgetwrapper.cpp
@@ -157,7 +157,7 @@ void QgsFileNameWidgetWrapper::updateConstraintWidgetStatus()
   if ( mLineEdit )
   {
     if ( mValidConstraint )
-      mLineEdit->setStyleSheet( "" );
+      mLineEdit->setStyleSheet( QString() );
     else
     {
       mLineEdit->setStyleSheet( "QgsFilterLineEdit { background-color: #dd7777; }" );

--- a/src/gui/editorwidgets/qgsfilenamewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsfilenamewidgetwrapper.cpp
@@ -151,3 +151,16 @@ void QgsFileNameWidgetWrapper::selectFileName()
   if ( mLabel )
     mLineEdit->setText( fileName );
 }
+
+void QgsFileNameWidgetWrapper::updateConstraintWidgetStatus()
+{
+  if ( mLineEdit )
+  {
+    if ( mValidConstraint )
+      mLineEdit->setStyleSheet( "" );
+    else
+    {
+      mLineEdit->setStyleSheet( "QgsFilterLineEdit { background-color: #dd7777; }" );
+    }
+  }
+}

--- a/src/gui/editorwidgets/qgsfilenamewidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsfilenamewidgetwrapper.h
@@ -51,6 +51,8 @@ class GUI_EXPORT QgsFileNameWidgetWrapper : public QgsEditorWidgetWrapper
     void setValue( const QVariant& value ) override;
 
   private:
+    void updateConstraintWidgetStatus() override;
+
     QLineEdit* mLineEdit;
     QPushButton* mPushButton;
     QLabel* mLabel;

--- a/src/gui/editorwidgets/qgsphotowidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsphotowidgetwrapper.cpp
@@ -266,3 +266,16 @@ void QgsPhotoWidgetWrapper::setEnabled( bool enabled )
   if ( mButton )
     mButton->setEnabled( enabled );
 }
+
+void QgsPhotoWidgetWrapper::updateConstraintWidgetStatus()
+{
+  if ( mLineEdit )
+  {
+    if ( mValidConstraint )
+      mLineEdit->setStyleSheet( "" );
+    else
+    {
+      mLineEdit->setStyleSheet( "QgsFilterLineEdit { background-color: #dd7777; }" );
+    }
+  }
+}

--- a/src/gui/editorwidgets/qgsphotowidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsphotowidgetwrapper.cpp
@@ -272,7 +272,7 @@ void QgsPhotoWidgetWrapper::updateConstraintWidgetStatus()
   if ( mLineEdit )
   {
     if ( mValidConstraint )
-      mLineEdit->setStyleSheet( "" );
+      mLineEdit->setStyleSheet( QString() );
     else
     {
       mLineEdit->setStyleSheet( "QgsFilterLineEdit { background-color: #dd7777; }" );

--- a/src/gui/editorwidgets/qgsphotowidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsphotowidgetwrapper.h
@@ -65,6 +65,8 @@ class GUI_EXPORT QgsPhotoWidgetWrapper : public QgsEditorWidgetWrapper
     void loadPixmap( const QString& fileName );
 
   private:
+    void updateConstraintWidgetStatus() override;
+
     //! This label is used as a container to display the picture
     QLabel* mPhotoLabel;
     //! This label is used as a container to display a picture that scales with the dialog layout.

--- a/src/gui/editorwidgets/qgsrangewidgetfactory.cpp
+++ b/src/gui/editorwidgets/qgsrangewidgetfactory.cpp
@@ -38,7 +38,7 @@ QgsEditorWidgetConfig QgsRangeWidgetFactory::readConfig( const QDomElement& conf
 {
   Q_UNUSED( layer );
   Q_UNUSED( fieldIdx );
-  QMap<QString, QVariant> cfg;
+  QgsEditorWidgetConfig cfg;
 
   cfg.insert( "Style", configElement.attribute( "Style" ) );
   cfg.insert( "Min", configElement.attribute( "Min" ) );

--- a/src/gui/editorwidgets/qgsrelationreferenceconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferenceconfigdlg.cpp
@@ -55,7 +55,7 @@ QgsRelationReferenceConfigDlg::QgsRelationReferenceConfigDlg( QgsVectorLayer* vl
   }
 }
 
-void QgsRelationReferenceConfigDlg::setConfig( const QMap<QString, QVariant>& config )
+void QgsRelationReferenceConfigDlg::setConfig( const QgsEditorWidgetConfig& config )
 {
   if ( config.contains( "AllowNULL" ) )
   {

--- a/src/gui/editorwidgets/qgsrelationreferencefactory.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencefactory.cpp
@@ -46,7 +46,7 @@ QgsEditorWidgetConfig QgsRelationReferenceFactory::readConfig( const QDomElement
 {
   Q_UNUSED( layer );
   Q_UNUSED( fieldIdx );
-  QMap<QString, QVariant> cfg;
+  QgsEditorWidgetConfig cfg;
 
   cfg.insert( "AllowNULL", configElement.attribute( "AllowNULL" ) == "1" );
   cfg.insert( "OrderByValue", configElement.attribute( "OrderByValue" ) == "1" );

--- a/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
@@ -139,3 +139,14 @@ void QgsRelationReferenceWidgetWrapper::foreignKeyChanged( QVariant value )
   }
   emit valueChanged( value );
 }
+
+void QgsRelationReferenceWidgetWrapper::updateConstraintWidgetStatus()
+{
+  if ( mWidget )
+  {
+    if ( mValidConstraint )
+      mWidget->setStyleSheet( "" );
+    else
+      mWidget->setStyleSheet( ".QComboBox { background-color: #dd7777; }" );
+  }
+}

--- a/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
@@ -145,7 +145,7 @@ void QgsRelationReferenceWidgetWrapper::updateConstraintWidgetStatus()
   if ( mWidget )
   {
     if ( mValidConstraint )
-      mWidget->setStyleSheet( "" );
+      mWidget->setStyleSheet( QString() );
     else
       mWidget->setStyleSheet( ".QComboBox { background-color: #dd7777; }" );
   }

--- a/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.h
@@ -59,6 +59,20 @@ class GUI_EXPORT QgsRelationReferenceWidgetWrapper : public QgsEditorWidgetWrapp
   private slots:
     void foreignKeyChanged( QVariant value );
 
+  protected:
+    /**
+     * This should update the widget with a visual cue if a constraint status
+     * changed.
+     *
+     * By default a stylesheet will be applied on the widget that changes the
+     * background color to red.
+     *
+     * This can be overwritten in subclasses to allow individual widgets to
+     * change the visual cue.
+     * @note added in QGIS 2.16
+     */
+    void updateConstraintWidgetStatus() override;
+
   private:
     QgsRelationReferenceWidget* mWidget;
     QgsMapCanvas* mCanvas;

--- a/src/gui/editorwidgets/qgswebviewwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgswebviewwidgetwrapper.cpp
@@ -194,7 +194,7 @@ void QgsWebViewWidgetWrapper::updateConstraintWidgetStatus()
   if ( mLineEdit )
   {
     if ( mValidConstraint )
-      mLineEdit->setStyleSheet( "" );
+      mLineEdit->setStyleSheet( QString() );
     else
     {
       mLineEdit->setStyleSheet( "QgsFilterLineEdit { background-color: #dd7777; }" );

--- a/src/gui/editorwidgets/qgswebviewwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgswebviewwidgetwrapper.cpp
@@ -188,3 +188,16 @@ void QgsWebViewWidgetWrapper::selectFileName()
   if ( mLineEdit )
     mLineEdit->setText( filePath );
 }
+
+void QgsWebViewWidgetWrapper::updateConstraintWidgetStatus()
+{
+  if ( mLineEdit )
+  {
+    if ( mValidConstraint )
+      mLineEdit->setStyleSheet( "" );
+    else
+    {
+      mLineEdit->setStyleSheet( "QgsFilterLineEdit { background-color: #dd7777; }" );
+    }
+  }
+}

--- a/src/gui/editorwidgets/qgswebviewwidgetwrapper.h
+++ b/src/gui/editorwidgets/qgswebviewwidgetwrapper.h
@@ -53,6 +53,8 @@ class GUI_EXPORT QgsWebViewWidgetWrapper : public QgsEditorWidgetWrapper
     void selectFileName();
 
   private:
+    void updateConstraintWidgetStatus() override;
+
     //! This label is used as a container to display the picture
     QWebView* mWebView;
     //! The line edit containing the path to the picture

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -930,7 +930,7 @@ void QgsAttributeForm::constraintDependencies( QgsEditorWidgetWrapper *w,
       if ( name != ewwName )
       {
         // get expression and referencedColumns
-        QgsExpression expr = eww->layer()->editFormConfig()->constraint( eww->fieldIdx() );
+        QgsExpression expr = eww->layer()->editFormConfig()->expression( eww->fieldIdx() );
 
         Q_FOREACH ( const QString& colName, expr.referencedColumns() )
         {

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -50,7 +50,6 @@ int QgsAttributeForm::sFormCounter = 0;
 QgsAttributeForm::QgsAttributeForm( QgsVectorLayer* vl, const QgsFeature &feature, const QgsAttributeEditorContext &context, QWidget* parent )
     : QWidget( parent )
     , mInvalidConstraintMessageBarItem( nullptr )
-    , mFieldNotInitializedMessageBarItem( nullptr )
     , mLayer( vl )
     , mMessageBar( nullptr )
     , mMultiEditUnsavedMessageBarItem( nullptr )
@@ -83,7 +82,6 @@ QgsAttributeForm::QgsAttributeForm( QgsVectorLayer* vl, const QgsFeature &featur
   connect( vl, SIGNAL( selectionChanged() ), this, SLOT( layerSelectionChanged() ) );
 
   // constraints management
-  displayNullFieldsMessage();
   updateAllConstaints();
 }
 
@@ -760,30 +758,6 @@ bool QgsAttributeForm::currentFormFeature( QgsFeature &feature )
   feature.setAttributes( dst );
 
   return rc;
-}
-
-void QgsAttributeForm::displayNullFieldsMessage()
-{
-  QStringList notInitializedFields;
-  Q_FOREACH ( QgsWidgetWrapper* ww, mWidgets )
-  {
-    QgsEditorWidgetWrapper* eww = qobject_cast<QgsEditorWidgetWrapper*>( ww );
-    if ( eww )
-    {
-      if ( mFeature.attribute( eww->fieldIdx() ).isNull() )
-        notInitializedFields.append( eww->field().name() );
-    }
-  }
-
-  if ( ! notInitializedFields.isEmpty() )
-  {
-    mFieldNotInitializedMessageBarItem =
-      new QgsMessageBarItem( tr( "Some fields are NULL: " ),
-                             notInitializedFields.join( ", " ),
-                             QgsMessageBar::INFO );
-    mMessageBar->pushItem( mFieldNotInitializedMessageBarItem );
-  }
-
 }
 
 void QgsAttributeForm::clearInvalidConstraintsMessage()

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -1144,13 +1144,14 @@ void QgsAttributeForm::init()
         w = formWidget;
         mFormEditorWidgets.insert( idx, formWidget );
         formWidget->createSearchWidgetWrappers( widgetType, idx, widgetConfig, mContext );
+
+        l->setBuddy( eww->widget() );
       }
       else
       {
         w = new QLabel( QString( "<p style=\"color: red; font-style: italic;\">Failed to create widget with type '%1'</p>" ).arg( widgetType ) );
       }
 
-      l->setBuddy( eww->widget() );
 
       if ( w )
         w->setObjectName( field.name() );

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -892,7 +892,7 @@ void QgsAttributeForm::onConstraintStatusChanged( const QString& constraint,
 
   if ( buddy )
   {
-    QString tooltip = "Expression: " + constraint + "\n" + "Constraint: " + err;
+    QString tooltip = tr( "Expression: " ) + constraint + "\n" + tr( "Constraint: " ) + err;
     buddy->setToolTip( tooltip );
 
     if ( !buddy->property( "originalText" ).isValid() )

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -655,6 +655,41 @@ void QgsAttributeForm::onAttributeChanged( const QVariant& value )
       //nothing to do
       break;
   }
+
+  if ( eww->layer()->editFormConfig()->notNull( eww->fieldIdx() ) )
+  {
+    QLabel* buddy = mBuddyMap.value( eww->widget() );
+
+    if ( buddy )
+    {
+      if ( !buddy->property( "originalText" ).isValid() )
+        buddy->setProperty( "originalText", buddy->text() );
+
+      QString text = buddy->property( "originalText" ).toString();
+
+      if ( value.isNull() )
+      {
+        // not good
+#if QT_VERSION >= 0x050000
+        buddy->setText( QString( "%1<font color=\"red\">❌</font>" ).arg( text ) );
+#else
+        buddy->setText( QString( "%1<font color=\"red\">*</font>" ).arg( text ) );
+#endif
+      }
+      else
+      {
+        // good
+#if QT_VERSION >= 0x050000
+        buddy->setText( QString( "%1<font color=\"green\">✔</font>" ).arg( text ) );
+#else
+        buddy->setText( QString( "%1<font color=\"green\">*</font>" ).arg( text ) );
+#endif
+      }
+    }
+  }
+
+
+  emit attributeChanged( eww->field().name(), value );
 }
 
 void QgsAttributeForm::onAttributeAdded( int idx )
@@ -712,6 +747,36 @@ void QgsAttributeForm::onUpdatedFields()
   }
   init();
   setFeature( mFeature );
+}
+
+void QgsAttributeForm::onConstraintStatusChanged( const QString& constraint, bool ok )
+{
+  Q_UNUSED( constraint )
+
+
+  QgsEditorWidgetWrapper* eww = qobject_cast<QgsEditorWidgetWrapper*>( sender() );
+  Q_ASSERT( eww );
+
+  QLabel* buddy = mBuddyMap.value( eww->widget() );
+
+  if ( buddy )
+  {
+    if ( !buddy->property( "originalText" ).isValid() )
+      buddy->setProperty( "originalText", buddy->text() );
+
+    QString text = buddy->property( "originalText" ).toString();
+
+    if ( !ok )
+    {
+      // not good
+      buddy->setText( QString( "%1<font color=\"red\">*</font>" ).arg( text ) );
+    }
+    else
+    {
+      // good
+      buddy->setText( QString( "%1<font color=\"green\">*</font>" ).arg( text ) );
+    }
+  }
 }
 
 void QgsAttributeForm::preventFeatureRefresh()
@@ -899,7 +964,7 @@ void QgsAttributeForm::init()
       bool labelOnTop = mLayer->editFormConfig()->labelOnTop( idx );
 
       // This will also create the widget
-      QWidget *l = new QLabel( fieldName );
+      QLabel *l = new QLabel( fieldName );
       QgsEditorWidgetWrapper* eww = QgsEditorWidgetRegistry::instance()->create( widgetType, mLayer, idx, widgetConfig, nullptr, this, mContext );
 
       QWidget* w = nullptr;
@@ -914,6 +979,11 @@ void QgsAttributeForm::init()
       {
         w = new QLabel( QString( "<p style=\"color: red; font-style: italic;\">Failed to create widget with type '%1'</p>" ).arg( widgetType ) );
       }
+
+      l->setBuddy( w );
+
+      if ( w )
+        w->setObjectName( field.name() );
 
       if ( eww )
         addWidgetWrapper( eww );
@@ -957,6 +1027,7 @@ void QgsAttributeForm::init()
   }
   mButtonBox->setVisible( buttonBoxVisible );
 
+<<<<<<< HEAD
   if ( !mSearchButtonBox )
   {
     mSearchButtonBox = new QWidget();
@@ -1011,7 +1082,7 @@ void QgsAttributeForm::init()
   }
   mSearchButtonBox->setVisible( mMode == SearchMode );
 
-  connectWrappers();
+  afterWidgetInit();
 
   connect( mButtonBox, SIGNAL( accepted() ), this, SLOT( accept() ) );
   connect( mButtonBox, SIGNAL( rejected() ), this, SLOT( resetValues() ) );
@@ -1251,6 +1322,8 @@ QgsAttributeForm::WidgetInfo QgsAttributeForm::createWidgetFromDef( const QgsAtt
             mypLabel->setAlignment( Qt::AlignRight | Qt::AlignVCenter );
           }
 
+          mypLabel->setBuddy( widgetInfo.widget );
+
           if ( widgetInfo.labelOnTop )
           {
             QVBoxLayout* c = new QVBoxLayout();
@@ -1350,7 +1423,7 @@ void QgsAttributeForm::createWrappers()
   }
 }
 
-void QgsAttributeForm::connectWrappers()
+void QgsAttributeForm::afterWidgetInit()
 {
   bool isFirstEww = true;
 
@@ -1367,7 +1440,19 @@ void QgsAttributeForm::connectWrappers()
       }
 
       connect( eww, SIGNAL( valueChanged( const QVariant& ) ), this, SLOT( onAttributeChanged( const QVariant& ) ) );
+      connect( eww, SIGNAL( constraintStatusChanged( QString, bool ) ), this, SLOT( onConstraintStatusChanged( QString, bool ) ) );
     }
+  }
+
+  // Update buddy widget list
+
+  mBuddyMap.clear();
+  QList<QLabel*> labels = findChildren<QLabel*>();
+
+  Q_FOREACH ( QLabel* label, labels )
+  {
+    if ( label->buddy() )
+      mBuddyMap.insert( label->buddy(), label );
   }
 }
 

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -307,9 +307,7 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     void clearInvalidConstraintsMessage();
     void displayInvalidConstraintMessage( const QStringList &invalidFields,
                                           const QStringList &description );
-    void displayNullFieldsMessage();
     QgsMessageBarItem *mInvalidConstraintMessageBarItem;
-    QgsMessageBarItem *mFieldNotInitializedMessageBarItem;
 
     QgsVectorLayer* mLayer;
     QgsFeature mFeature;

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -307,13 +307,13 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     void clearInvalidConstraintsMessage();
     void displayInvalidConstraintMessage( const QStringList &invalidFields,
                                           const QStringList &description );
-    QgsMessageBarItem *mInvalidConstraintMessageBarItem;
 
     QgsVectorLayer* mLayer;
     QgsFeature mFeature;
     QgsMessageBar* mMessageBar;
     QgsMessageBarItem* mMultiEditUnsavedMessageBarItem;
     QgsMessageBarItem* mMultiEditMessageBarItem;
+    QLabel* mInvalidConstraintMessage;
     QList<QgsWidgetWrapper*> mWidgets;
     QgsAttributeEditorContext mContext;
     QDialogButtonBox* mButtonBox;

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -234,7 +234,7 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     void onAttributeAdded( int idx );
     void onAttributeDeleted( int idx );
     void onUpdatedFields();
-    void onConstraintStatusChanged( const QString& constraint, bool ok );
+    void onConstraintStatusChanged( const QString& constraint, const QString& err, bool ok );
 
     void preventFeatureRefresh();
     void synchronizeEnabledState();
@@ -298,6 +298,18 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
 
     QString createFilterExpression() const;
 
+    //! constraints management
+    void updateAllConstaints();
+    void updateConstraints( QgsEditorWidgetWrapper *w );
+    bool currentFormFeature( QgsFeature &feature );
+    bool currentFormValidConstraints( QStringList &invalidFields );
+    void constraintDependencies( QgsEditorWidgetWrapper *w, QList<QgsEditorWidgetWrapper*> &wDeps );
+    void clearInvalidConstraintsMessage();
+    void displayInvalidConstraintMessage( const QStringList &invalidFields );
+    void displayNullFieldsMessage();
+    QgsMessageBarItem *mInvalidConstraintMessageBarItem;
+    QgsMessageBarItem *mFieldNotInitializedMessageBarItem;
+
     QgsVectorLayer* mLayer;
     QgsFeature mFeature;
     QgsMessageBar* mMessageBar;
@@ -336,6 +348,7 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     QMap<QWidget*, QLabel*> mBuddyMap;
 
     friend class TestQgsDualView;
+    friend class TestQgsAttributeForm;
 };
 
 #endif // QGSATTRIBUTEFORM_H

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -234,8 +234,8 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     void onAttributeAdded( int idx );
     void onAttributeDeleted( int idx );
     void onUpdatedFields();
-    void onConstraintStatusChanged( const QString& constraint, const QString& err, bool ok );
-
+    void onConstraintStatusChanged( const QString& constraint,
+                                    const QString &description, const QString& err, bool ok );
     void preventFeatureRefresh();
     void synchronizeEnabledState();
     void layerSelectionChanged();
@@ -302,10 +302,11 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     void updateAllConstaints();
     void updateConstraints( QgsEditorWidgetWrapper *w );
     bool currentFormFeature( QgsFeature &feature );
-    bool currentFormValidConstraints( QStringList &invalidFields );
+    bool currentFormValidConstraints( QStringList &invalidFields, QStringList &descriptions );
     void constraintDependencies( QgsEditorWidgetWrapper *w, QList<QgsEditorWidgetWrapper*> &wDeps );
     void clearInvalidConstraintsMessage();
-    void displayInvalidConstraintMessage( const QStringList &invalidFields );
+    void displayInvalidConstraintMessage( const QStringList &invalidFields,
+                                          const QStringList &description );
     void displayNullFieldsMessage();
     QgsMessageBarItem *mInvalidConstraintMessageBarItem;
     QgsMessageBarItem *mFieldNotInitializedMessageBarItem;

--- a/src/gui/qgsattributeform.h
+++ b/src/gui/qgsattributeform.h
@@ -21,6 +21,7 @@
 #include "qgsattributeeditorcontext.h"
 
 #include <QWidget>
+#include <QLabel>
 #include <QDialogButtonBox>
 
 class QgsAttributeFormInterface;
@@ -233,6 +234,7 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     void onAttributeAdded( int idx );
     void onAttributeDeleted( int idx );
     void onUpdatedFields();
+    void onConstraintStatusChanged( const QString& constraint, bool ok );
 
     void preventFeatureRefresh();
     void synchronizeEnabledState();
@@ -282,7 +284,7 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
      * Called once maximally.
      */
     void createWrappers();
-    void connectWrappers();
+    void afterWidgetInit();
 
     void scanForEqualAttributes( QgsFeatureIterator& fit, QSet< int >& mixedValueFields, QHash< int, QVariant >& fieldSharedValues ) const;
 
@@ -329,6 +331,9 @@ class GUI_EXPORT QgsAttributeForm : public QWidget
     QString mEditCommandMessage;
 
     Mode mMode;
+
+    //! Backlinks widgets to buddies.
+    QMap<QWidget*, QLabel*> mBuddyMap;
 
     friend class TestQgsDualView;
 };

--- a/src/ui/qgsattributetypeedit.ui
+++ b/src/ui/qgsattributetypeedit.ui
@@ -14,17 +14,7 @@
    <string>Edit Widget Properties</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="6" column="1">
-    <widget class="QDialogButtonBox" name="buttonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
-   <item row="2" column="1">
+   <item row="3" column="1">
     <widget class="QStackedWidget" name="stackedWidget"/>
    </item>
    <item row="0" column="1">
@@ -47,8 +37,25 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="0" rowspan="7">
+   <item row="0" column="0" rowspan="8">
     <widget class="QListWidget" name="selectionListWidget"/>
+   </item>
+   <item row="7" column="1">
+    <widget class="QDialogButtonBox" name="buttonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="1">
+    <widget class="QCheckBox" name="notNullCheckBox">
+     <property name="text">
+      <string>Not Null</string>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>

--- a/src/ui/qgsattributetypeedit.ui
+++ b/src/ui/qgsattributetypeedit.ui
@@ -74,6 +74,23 @@
      </item>
     </layout>
    </item>
+   <item row="5" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <property name="bottomMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QLabel" name="label_2">
+       <property name="text">
+        <string>Constraint description</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QLineEdit" name="constraintExpressionDescription"/>
+     </item>
+    </layout>
+   </item>
   </layout>
  </widget>
  <customwidgets>

--- a/src/ui/qgsattributetypeedit.ui
+++ b/src/ui/qgsattributetypeedit.ui
@@ -14,9 +14,6 @@
    <string>Edit Widget Properties</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="3" column="1">
-    <widget class="QStackedWidget" name="stackedWidget"/>
-   </item>
    <item row="0" column="1">
     <widget class="QCheckBox" name="isFieldEditableCheckBox">
      <property name="text">
@@ -37,10 +34,10 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="0" rowspan="8">
+   <item row="0" column="0" rowspan="11">
     <widget class="QListWidget" name="selectionListWidget"/>
    </item>
-   <item row="7" column="1">
+   <item row="10" column="1">
     <widget class="QDialogButtonBox" name="buttonBox">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -50,6 +47,9 @@
      </property>
     </widget>
    </item>
+   <item row="6" column="1">
+    <widget class="QStackedWidget" name="stackedWidget"/>
+   </item>
    <item row="2" column="1">
     <widget class="QCheckBox" name="notNullCheckBox">
      <property name="text">
@@ -57,8 +57,32 @@
      </property>
     </widget>
    </item>
+   <item row="4" column="1">
+    <layout class="QHBoxLayout" name="horizontalLayout_2">
+     <property name="topMargin">
+      <number>0</number>
+     </property>
+     <item>
+      <widget class="QLabel" name="label">
+       <property name="text">
+        <string>Constraint</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QgsFieldExpressionWidget" name="constraintExpression" native="true"/>
+     </item>
+    </layout>
+   </item>
   </layout>
  </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsFieldExpressionWidget</class>
+   <extends>QWidget</extends>
+   <header>qgsfieldexpressionwidget.h</header>
+  </customwidget>
+ </customwidgets>
  <tabstops>
   <tabstop>selectionListWidget</tabstop>
   <tabstop>isFieldEditableCheckBox</tabstop>

--- a/tests/src/gui/CMakeLists.txt
+++ b/tests/src/gui/CMakeLists.txt
@@ -5,7 +5,7 @@ SET (util_SRCS)
 #####################################################
 # Don't forget to include output directory, otherwise
 # the UI file won't be wrapped!
-INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR} 
+INCLUDE_DIRECTORIES(${CMAKE_CURRENT_SOURCE_DIR}
   ${CMAKE_CURRENT_BINARY_DIR}
   ${CMAKE_CURRENT_BINARY_DIR}/../../../src/ui
   ${CMAKE_CURRENT_SOURCE_DIR}/../core #for render checker class
@@ -62,7 +62,7 @@ ENDIF (APPLE)
 #qtests in the executable file list as the moc is
 #directly included in the sources
 #and should not be compiled twice. Trying to include
-#them in will cause an error at build time 
+#them in will cause an error at build time
 #############################################################
 # Tests:
 
@@ -76,7 +76,7 @@ ENDIF (APPLE)
 #ADD_EXECUTABLE(qgis_quickprinttest ${qgis_quickprinttest_SRCS})
 #ADD_DEPENDENCIES(qgis_quickprinttest qgis_quickprinttestmoc)
 #TARGET_LINK_LIBRARIES(qgis_quickprinttest ${QT_LIBRARIES} qgis_core qgis_gui)
-#SET_TARGET_PROPERTIES(qgis_quickprinttest 
+#SET_TARGET_PROPERTIES(qgis_quickprinttest
 #  PROPERTIES INSTALL_RPATH ${QGIS_LIB_DIR}
 #  INSTALL_RPATH_USE_LINK_PATH true)
 #IF (APPLE)
@@ -128,6 +128,7 @@ ADD_QGIS_TEST(zoomtest testqgsmaptoolzoom.cpp)
 #ADD_QGIS_TEST(histogramtest testqgsrasterhistogram.cpp)
 ADD_QGIS_TEST(doublespinbox testqgsdoublespinbox.cpp)
 ADD_QGIS_TEST(dualviewtest testqgsdualview.cpp)
+ADD_QGIS_TEST(attributeformtest testqgsattributeform.cpp)
 ADD_QGIS_TEST(fieldexpressionwidget testqgsfieldexpressionwidget.cpp)
 ADD_QGIS_TEST(filewidget testqgsfilewidget.cpp)
 ADD_QGIS_TEST(focuswatcher testqgsfocuswatcher.cpp)

--- a/tests/src/gui/testqgsattributeform.cpp
+++ b/tests/src/gui/testqgsattributeform.cpp
@@ -81,7 +81,7 @@ void TestQgsAttributeForm::testFieldConstraint()
   QString invalidLabel = "col0<font color=\"red\">*</font>";
 
   // set constraint
-  layer->editFormConfig()->setConstraint( 0, "" );
+  layer->editFormConfig()->setExpression( 0, "" );
 
   // get wrapper
   QgsEditorWidgetWrapper *ww;
@@ -92,7 +92,7 @@ void TestQgsAttributeForm::testFieldConstraint()
   QCOMPARE( label->text(), QString( "col0" ) );
 
   // set a not null constraint
-  layer->editFormConfig()->setConstraint( 0, "col0 is not null" );
+  layer->editFormConfig()->setExpression( 0, "col0 is not null" );
 
   // set value to 1
   ww->setValue( 1 );
@@ -126,10 +126,10 @@ void TestQgsAttributeForm::testFieldMultiConstraints()
   ft.setAttribute( "col3", 3 );
 
   // set constraints for each field
-  layer->editFormConfig()->setConstraint( 0, "" );
-  layer->editFormConfig()->setConstraint( 1, "" );
-  layer->editFormConfig()->setConstraint( 2, "" );
-  layer->editFormConfig()->setConstraint( 3, "" );
+  layer->editFormConfig()->setExpression( 0, "" );
+  layer->editFormConfig()->setExpression( 1, "" );
+  layer->editFormConfig()->setExpression( 2, "" );
+  layer->editFormConfig()->setExpression( 3, "" );
 
   // build a form for this feature
   QgsAttributeForm form( layer );
@@ -160,10 +160,10 @@ void TestQgsAttributeForm::testFieldMultiConstraints()
   QCOMPARE( label3->text(), QString( "col3" ) );
 
   // update constraint
-  layer->editFormConfig()->setConstraint( 0, "col0 < (col1 * col2)" );
-  layer->editFormConfig()->setConstraint( 1, "" );
-  layer->editFormConfig()->setConstraint( 2, "" );
-  layer->editFormConfig()->setConstraint( 3, "col0 = 2" );
+  layer->editFormConfig()->setExpression( 0, "col0 < (col1 * col2)" );
+  layer->editFormConfig()->setExpression( 1, "" );
+  layer->editFormConfig()->setExpression( 2, "" );
+  layer->editFormConfig()->setExpression( 3, "col0 = 2" );
 
   // change value
   ww0->setValue( 2 ); // update col0
@@ -212,7 +212,7 @@ void TestQgsAttributeForm::testOKButtonStatus()
   QSignalSpy spy3( layer, SIGNAL( editingStopped() ) );
 
   // set constraint
-  layer->editFormConfig()->setConstraint( 0, "" );
+  layer->editFormConfig()->setExpression( 0, "" );
 
   // no constraint but layer not editable : OK button disabled
   QCOMPARE( layer->isEditable(), false );
@@ -225,12 +225,12 @@ void TestQgsAttributeForm::testOKButtonStatus()
   QCOMPARE( okButton->isEnabled(), true );
 
   // invalid constraint and editable layer : OK button disabled
-  layer->editFormConfig()->setConstraint( 0, "col0 = 0" );
+  layer->editFormConfig()->setExpression( 0, "col0 = 0" );
   ww->setValue( 1 );
   QCOMPARE( okButton->isEnabled(), false );
 
   // valid constraint and editable layer : OK button enabled
-  layer->editFormConfig()->setConstraint( 0, "col0 = 2" );
+  layer->editFormConfig()->setExpression( 0, "col0 = 2" );
   ww->setValue( 2 );
   QCOMPARE( okButton->isEnabled(), true );
 

--- a/tests/src/gui/testqgsattributeform.cpp
+++ b/tests/src/gui/testqgsattributeform.cpp
@@ -81,7 +81,7 @@ void TestQgsAttributeForm::testFieldConstraint()
   QString invalidLabel = "col0<font color=\"red\">*</font>";
 
   // set constraint
-  layer->editFormConfig()->setExpression( 0, "" );
+  layer->editFormConfig()->setExpression( 0, QString() );
 
   // get wrapper
   QgsEditorWidgetWrapper *ww;
@@ -126,10 +126,10 @@ void TestQgsAttributeForm::testFieldMultiConstraints()
   ft.setAttribute( "col3", 3 );
 
   // set constraints for each field
-  layer->editFormConfig()->setExpression( 0, "" );
-  layer->editFormConfig()->setExpression( 1, "" );
-  layer->editFormConfig()->setExpression( 2, "" );
-  layer->editFormConfig()->setExpression( 3, "" );
+  layer->editFormConfig()->setExpression( 0, QString() );
+  layer->editFormConfig()->setExpression( 1, QString() );
+  layer->editFormConfig()->setExpression( 2, QString() );
+  layer->editFormConfig()->setExpression( 3, QString() );
 
   // build a form for this feature
   QgsAttributeForm form( layer );
@@ -161,8 +161,8 @@ void TestQgsAttributeForm::testFieldMultiConstraints()
 
   // update constraint
   layer->editFormConfig()->setExpression( 0, "col0 < (col1 * col2)" );
-  layer->editFormConfig()->setExpression( 1, "" );
-  layer->editFormConfig()->setExpression( 2, "" );
+  layer->editFormConfig()->setExpression( 1, QString() );
+  layer->editFormConfig()->setExpression( 2, QString() );
   layer->editFormConfig()->setExpression( 3, "col0 = 2" );
 
   // change value
@@ -212,7 +212,7 @@ void TestQgsAttributeForm::testOKButtonStatus()
   QSignalSpy spy3( layer, SIGNAL( editingStopped() ) );
 
   // set constraint
-  layer->editFormConfig()->setExpression( 0, "" );
+  layer->editFormConfig()->setExpression( 0, QString() );
 
   // no constraint but layer not editable : OK button disabled
   QCOMPARE( layer->isEditable(), false );

--- a/tests/src/gui/testqgsattributeform.cpp
+++ b/tests/src/gui/testqgsattributeform.cpp
@@ -1,9 +1,9 @@
 /***************************************************************************
-    testqgsdualview.cpp
+    testqgsattributeform.cpp
      --------------------------------------
     Date                 : 13 05 2016
     Copyright            : (C) 2016 Paul Blottiere
-    Email                : paul.blottiere@oslandia.com
+    Email                : paul dot blottiere at oslandia dot com
  ***************************************************************************
  *                                                                         *
  *   This program is free software; you can redistribute it and/or modify  *

--- a/tests/src/gui/testqgsattributeform.cpp
+++ b/tests/src/gui/testqgsattributeform.cpp
@@ -1,0 +1,245 @@
+/***************************************************************************
+    testqgsdualview.cpp
+     --------------------------------------
+    Date                 : 13 05 2016
+    Copyright            : (C) 2016 Paul Blottiere
+    Email                : paul.blottiere@oslandia.com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+
+#include <QtTest/QtTest>
+#include <QPushButton>
+
+#include <editorwidgets/core/qgseditorwidgetregistry.h>
+#include "qgsattributeform.h"
+#include <qgsapplication.h>
+#include <qgsvectorlayer.h>
+#include "qgsvectordataprovider.h"
+#include <qgsfeature.h>
+
+class TestQgsAttributeForm : public QObject
+{
+    Q_OBJECT
+  public:
+    TestQgsAttributeForm() {}
+
+  private slots:
+    void initTestCase(); // will be called before the first testfunction is executed.
+    void cleanupTestCase(); // will be called after the last testfunction was executed.
+    void init(); // will be called before each testfunction is executed.
+    void cleanup(); // will be called after every testfunction.
+
+    void testFieldConstraint();
+    void testFieldMultiConstraints();
+    void testOKButtonStatus();
+};
+
+void TestQgsAttributeForm::initTestCase()
+{
+  QgsApplication::init();
+  QgsApplication::initQgis();
+  QgsEditorWidgetRegistry::initEditors();
+}
+
+void TestQgsAttributeForm::cleanupTestCase()
+{
+  QgsApplication::exitQgis();
+}
+
+void TestQgsAttributeForm::init()
+{
+}
+
+void TestQgsAttributeForm::cleanup()
+{
+}
+
+void TestQgsAttributeForm::testFieldConstraint()
+{
+  // make a temporary vector layer
+  QString def = "Point?field=col0:integer";
+  QgsVectorLayer* layer = new QgsVectorLayer( def, "test", "memory" );
+
+  // add a feature to the vector layer
+  QgsFeature ft( layer->dataProvider()->fields(), 1 );
+  ft.setAttribute( "col0", 0 );
+
+  // build a form for this feature
+  QgsAttributeForm form( layer );
+  form.setFeature( ft );
+
+  // testing stuff
+  QSignalSpy spy( &form, SIGNAL( attributeChanged( QString, QVariant ) ) );
+  QString validLabel = "col0<font color=\"green\">*</font>";
+  QString invalidLabel = "col0<font color=\"red\">*</font>";
+
+  // set constraint
+  layer->editFormConfig()->setConstraint( 0, "" );
+
+  // get wrapper
+  QgsEditorWidgetWrapper *ww;
+  ww = qobject_cast<QgsEditorWidgetWrapper*>( form.mWidgets[0] );
+
+  // no constraint so we expect a label with just the field name
+  QLabel *label = form.mBuddyMap.value( ww->widget() );
+  QCOMPARE( label->text(), QString( "col0" ) );
+
+  // set a not null constraint
+  layer->editFormConfig()->setConstraint( 0, "col0 is not null" );
+
+  // set value to 1
+  ww->setValue( 1 );
+  QCOMPARE( spy.count(), 2 );
+  QCOMPARE( label->text(), validLabel );
+
+  // set value to null
+  spy.clear();
+  ww->setValue( QVariant() );
+  QCOMPARE( spy.count(), 2 );
+  QCOMPARE( label->text(), invalidLabel );
+
+  // set value to 1
+  spy.clear();
+  ww->setValue( 1 );
+  QCOMPARE( spy.count(), 2 );
+  QCOMPARE( label->text(), validLabel );
+}
+
+void TestQgsAttributeForm::testFieldMultiConstraints()
+{
+  // make a temporary layer to check through
+  QString def = "Point?field=col0:integer&field=col1:integer&field=col2:integer&field=col3:integer";
+  QgsVectorLayer* layer = new QgsVectorLayer( def, "test", "memory" );
+
+  // add features to the vector layer
+  QgsFeature ft( layer->dataProvider()->fields(), 1 );
+  ft.setAttribute( "col0", 0 );
+  ft.setAttribute( "col1", 1 );
+  ft.setAttribute( "col2", 2 );
+  ft.setAttribute( "col3", 3 );
+
+  // set constraints for each field
+  layer->editFormConfig()->setConstraint( 0, "" );
+  layer->editFormConfig()->setConstraint( 1, "" );
+  layer->editFormConfig()->setConstraint( 2, "" );
+  layer->editFormConfig()->setConstraint( 3, "" );
+
+  // build a form for this feature
+  QgsAttributeForm form( layer );
+  form.setFeature( ft );
+
+  // testing stuff
+  QSignalSpy spy( &form, SIGNAL( attributeChanged( QString, QVariant ) ) );
+  QString val = "<font color=\"green\">*</font>";
+  QString inv = "<font color=\"red\">*</font>";
+
+  // get wrappers for each widget
+  QgsEditorWidgetWrapper *ww0, *ww1, *ww2, *ww3;
+  ww0 = qobject_cast<QgsEditorWidgetWrapper*>( form.mWidgets[0] );
+  ww1 = qobject_cast<QgsEditorWidgetWrapper*>( form.mWidgets[1] );
+  ww2 = qobject_cast<QgsEditorWidgetWrapper*>( form.mWidgets[2] );
+  ww3 = qobject_cast<QgsEditorWidgetWrapper*>( form.mWidgets[3] );
+
+  // get label for wrappers
+  QLabel *label0 = form.mBuddyMap.value( ww0->widget() );
+  QLabel *label1 = form.mBuddyMap.value( ww1->widget() );
+  QLabel *label2 = form.mBuddyMap.value( ww2->widget() );
+  QLabel *label3 = form.mBuddyMap.value( ww3->widget() );
+
+  // no constraint so we expect a label with just the field name
+  QCOMPARE( label0->text(), QString( "col0" ) );
+  QCOMPARE( label1->text(), QString( "col1" ) );
+  QCOMPARE( label2->text(), QString( "col2" ) );
+  QCOMPARE( label3->text(), QString( "col3" ) );
+
+  // update constraint
+  layer->editFormConfig()->setConstraint( 0, "col0 < (col1 * col2)" );
+  layer->editFormConfig()->setConstraint( 1, "" );
+  layer->editFormConfig()->setConstraint( 2, "" );
+  layer->editFormConfig()->setConstraint( 3, "col0 = 2" );
+
+  // change value
+  ww0->setValue( 2 ); // update col0
+  QCOMPARE( spy.count(), 2 );
+
+  QCOMPARE( label0->text(), QString( "col0" + inv ) ); // 2 < ( 1 + 2 )
+  QCOMPARE( label1->text(), QString( "col1" ) );
+  QCOMPARE( label2->text(), QString( "col2" ) );
+  QCOMPARE( label3->text(), QString( "col3" + val ) ); // 2 = 2
+
+  // change value
+  spy.clear();
+  ww0->setValue( 1 ); // update col0
+  QCOMPARE( spy.count(), 2 );
+
+  QCOMPARE( label0->text(), QString( "col0" + val ) ); // 1 < ( 1 + 2 )
+  QCOMPARE( label1->text(), QString( "col1" ) );
+  QCOMPARE( label2->text(), QString( "col2" ) );
+  QCOMPARE( label3->text(), QString( "col3" + inv ) ); // 2 = 1
+}
+
+void TestQgsAttributeForm::testOKButtonStatus()
+{
+  // make a temporary vector layer
+  QString def = "Point?field=col0:integer";
+  QgsVectorLayer* layer = new QgsVectorLayer( def, "test", "memory" );
+
+  // add a feature to the vector layer
+  QgsFeature ft( layer->dataProvider()->fields(), 1 );
+  ft.setAttribute( "col0", 0 );
+  ft.setValid( true );
+
+  // build a form for this feature
+  QgsAttributeForm form( layer );
+  form.setFeature( ft );
+
+  QPushButton *okButton = form.mButtonBox->button( QDialogButtonBox::Ok );
+
+  // get wrapper
+  QgsEditorWidgetWrapper *ww;
+  ww = qobject_cast<QgsEditorWidgetWrapper*>( form.mWidgets[0] );
+
+  // testing stuff
+  QSignalSpy spy1( &form, SIGNAL( attributeChanged( QString, QVariant ) ) );
+  QSignalSpy spy2( layer, SIGNAL( editingStarted() ) );
+  QSignalSpy spy3( layer, SIGNAL( editingStopped() ) );
+
+  // set constraint
+  layer->editFormConfig()->setConstraint( 0, "" );
+
+  // no constraint but layer not editable : OK button disabled
+  QCOMPARE( layer->isEditable(), false );
+  QCOMPARE( okButton->isEnabled(), false );
+
+  // no constraint and editable layer : OK button enabled
+  layer->startEditing();
+  QCOMPARE( spy2.count(), 1 );
+  QCOMPARE( layer->isEditable(), true );
+  QCOMPARE( okButton->isEnabled(), true );
+
+  // invalid constraint and editable layer : OK button disabled
+  layer->editFormConfig()->setConstraint( 0, "col0 = 0" );
+  ww->setValue( 1 );
+  QCOMPARE( okButton->isEnabled(), false );
+
+  // valid constraint and editable layer : OK button enabled
+  layer->editFormConfig()->setConstraint( 0, "col0 = 2" );
+  ww->setValue( 2 );
+  QCOMPARE( okButton->isEnabled(), true );
+
+  // valid constraint and not editable layer : OK button disabled
+  layer->rollBack();
+  QCOMPARE( spy3.count(), 1 );
+  QCOMPARE( layer->isEditable(), false );
+  QCOMPARE( okButton->isEnabled(), false );
+}
+
+QTEST_MAIN( TestQgsAttributeForm )
+#include "testqgsattributeform.moc"


### PR DESCRIPTION
Constraints on widgets forms are available :
- a not null checkbox is available for each widget. It's usefull for basics needs
- a QgsExpression field is available for each widget for more advanced needs. Another field of the form can be used within the expression. The feature currently displayed in the form is used to evaluate the expression
- a message bar is displayed at the top of the QgsAttributeForm when a widget has a Null data (info level). It's useful for widgets which can't be represented by such a value (such as the checkbox widget)
- a message bar indicating fields which do not fit constraints is also displayed at the top of the form (warning level)
- the ok button is disabled if some constraints are not honoured
- a tooltip is available for fields with constraints. It describes the current expression to respect and the current status of the evaluation's result (OK, KO, error in expression, ...)
- the background of a widget is red if its constraint is not honoured
- a '*' is displayed next to the label for fields having a constraint. The star is red or green according to the validity of the constraint

Moreover, some unit tests are available.

![constraints](https://cloud.githubusercontent.com/assets/9266424/15364597/5ef12e50-1d1d-11e6-8c1b-16914de2f66d.png)
