### PR TITLE
[FEATURE] Improved map select tool behaviour

### DIFF
--- a/src/app/qgsmaptoolselect.cpp
+++ b/src/app/qgsmaptoolselect.cpp
@@ -50,8 +50,7 @@ void QgsMapToolSelect::canvasReleaseEvent( QgsMapMouseEvent* e )
   QgsMapToolSelectUtils::expandSelectRectangle( selectRect, vlayer, e->pos() );
   QgsMapToolSelectUtils::setRubberBand( mCanvas, selectRect, &rubberBand );
   QgsGeometry* selectGeom = rubberBand.asGeometry();
-  bool doDifference = e->modifiers() & Qt::ControlModifier;
-  QgsMapToolSelectUtils::setSelectFeatures( mCanvas, selectGeom, false, doDifference, true );
+  QgsMapToolSelectUtils::selectSingleFeature( mCanvas, selectGeom, e );
   delete selectGeom;
   rubberBand.reset( QGis::Polygon );
 }

--- a/src/app/qgsmaptoolselectfreehand.cpp
+++ b/src/app/qgsmaptoolselectfreehand.cpp
@@ -85,9 +85,10 @@ void QgsMapToolSelectFreehand::canvasReleaseEvent( QgsMapMouseEvent* e )
   if ( mRubberBand->numberOfVertices() > 2 )
   {
     QgsGeometry* shapeGeom = mRubberBand->asGeometry();
-    QgsMapToolSelectUtils::setSelectFeatures( mCanvas, shapeGeom,
-        e->modifiers() & Qt::ShiftModifier,
-        e->modifiers() & Qt::ControlModifier, singleSelect );
+    if ( singleSelect )
+      QgsMapToolSelectUtils::selectSingleFeature( mCanvas, shapeGeom, e );
+    else
+      QgsMapToolSelectUtils::selectMultipleFeatures( mCanvas, shapeGeom, e );
     delete shapeGeom;
   }
 

--- a/src/app/qgsmaptoolselectpolygon.cpp
+++ b/src/app/qgsmaptoolselectpolygon.cpp
@@ -54,7 +54,7 @@ void QgsMapToolSelectPolygon::canvasPressEvent( QgsMapMouseEvent* e )
     if ( mRubberBand->numberOfVertices() > 2 )
     {
       QgsGeometry* polygonGeom = mRubberBand->asGeometry();
-      QgsMapToolSelectUtils::setSelectFeatures( mCanvas, polygonGeom, e );
+      QgsMapToolSelectUtils::selectMultipleFeatures( mCanvas, polygonGeom, e );
       delete polygonGeom;
     }
     mRubberBand->reset( QGis::Polygon );

--- a/src/app/qgsmaptoolselectradius.cpp
+++ b/src/app/qgsmaptoolselectradius.cpp
@@ -92,7 +92,7 @@ void QgsMapToolSelectRadius::canvasReleaseEvent( QgsMapMouseEvent* e )
     setRadiusRubberBand( radiusEdge );
   }
   QgsGeometry* radiusGeometry = mRubberBand->asGeometry();
-  QgsMapToolSelectUtils::setSelectFeatures( mCanvas, radiusGeometry, e );
+  QgsMapToolSelectUtils::selectMultipleFeatures( mCanvas, radiusGeometry, e );
   delete radiusGeometry;
   mRubberBand->reset( QGis::Polygon );
   delete mRubberBand;

--- a/src/app/qgsmaptoolselectrectangle.cpp
+++ b/src/app/qgsmaptoolselectrectangle.cpp
@@ -106,11 +106,10 @@ void QgsMapToolSelectFeatures::canvasReleaseEvent( QgsMapMouseEvent* e )
     QgsGeometry* selectGeom = mRubberBand->asGeometry();
     if ( !mDragging )
     {
-      bool doDifference = e->modifiers() & Qt::ControlModifier;
-      QgsMapToolSelectUtils::setSelectFeatures( mCanvas, selectGeom, false, doDifference, true );
+      QgsMapToolSelectUtils::selectSingleFeature( mCanvas, selectGeom, e );
     }
     else
-      QgsMapToolSelectUtils::setSelectFeatures( mCanvas, selectGeom, e );
+      QgsMapToolSelectUtils::selectMultipleFeatures( mCanvas, selectGeom, e );
 
     delete selectGeom;
 

--- a/src/app/qgsmaptoolselectutils.h
+++ b/src/app/qgsmaptoolselectutils.h
@@ -16,6 +16,7 @@ email                : jpalmer at linz dot govt dot nz
 #ifndef QGSMAPTOOLSELECTUTILS_H
 #define QGSMAPTOOLSELECTUTILS_H
 
+#include "qgsvectorlayer.h"
 #include <Qt>
 #include <QRect>
 #include <QPoint>
@@ -31,34 +32,61 @@ class QgsRubberBand;
  */
 namespace QgsMapToolSelectUtils
 {
-  /**
-    Selects the features within currently selected layer.
-    @param canvas The map canvas used to get the current selected vector layer and
+  /** Calculates a list of features matching a selection geometry and flags.
+   * @param canvas the map canvas used to get the current selected vector layer and
     for any required geometry transformations
-    @param selectGeometry The geometry to select the layers features. This geometry
+   * @param selectGeometry the geometry to select the layers features. This geometry
     must be in terms of the canvas coordinate system.
-    @param doContains Features will only be selected if fully contained within
+   * @param doContains features will only be selected if fully contained within
     the selection rubber band (otherwise intersection is enough).
-    @param doDifference Take the symmetric difference of the current selected
-    features and the new features found within the provided selectGeometry.
-    @param singleSelect Only selects the closest feature to the selectGeometry.
-  */
-  void setSelectFeatures( QgsMapCanvas* canvas,
-                          QgsGeometry* selectGeometry,
-                          bool doContains = true,
-                          bool doDifference = false,
-                          bool singleSelect = false );
+   * @param singleSelect only selects the closest feature to the selectGeometry.
+   * @returns list of features which match search geometry and parameters
+   * @note added in QGIS 2.16
+   */
+  QgsFeatureIds getMatchingFeatures( QgsMapCanvas* canvas, QgsGeometry* selectGeometry, bool doContains, bool singleSelect );
 
   /**
-    Select the features within currently selected layer.
-    @param canvas The map canvas used to get the current selected vector layer and
+    Selects the features within currently selected layer.
+    @param canvas the map canvas used to get the current selected vector layer and
     for any required geometry transformations
-    @param selectGeometry The geometry to select the layers features. This geometry
+    @param selectGeometry the geometry to select the layers features. This geometry
+    must be in terms of the canvas coordinate system.
+    @param selectBehaviour behaviour of select (ie replace selection, add to selection)
+    @param doContains features will only be selected if fully contained within
+    the selection rubber band (otherwise intersection is enough).
+    @param singleSelect only selects the closest feature to the selectGeometry.
+    @note added in QGIS 2.16
+  */
+  void setSelectedFeatures( QgsMapCanvas* canvas,
+                            QgsGeometry* selectGeometry,
+                            QgsVectorLayer::SelectBehaviour selectBehaviour = QgsVectorLayer::SetSelection,
+                            bool doContains = true,
+                            bool singleSelect = false );
+
+  /**
+    Selects multiple matching features from within currently selected layer.
+    @param canvas the map canvas used to get the current selected vector layer and
+    for any required geometry transformations
+    @param selectGeometry the geometry to select the layers features. This geometry
     must be in terms of the canvas coordinate system.
     @param e MouseEvents are used to determine the current selection
     operations (add, subtract, contains)
+    @note added in QGIS 2.16
+    @see selectSingleFeature()
   */
-  void setSelectFeatures( QgsMapCanvas* canvas, QgsGeometry* selectGeometry, QMouseEvent * e );
+  void selectMultipleFeatures( QgsMapCanvas* canvas, QgsGeometry* selectGeometry, QMouseEvent * e );
+
+  /**
+    Selects a single feature from within currently selected layer.
+    @param canvas the map canvas used to get the current selected vector layer and
+    for any required geometry transformations
+    @param selectGeometry the geometry to select the layers features. This geometry
+    must be in terms of the canvas coordinate system.
+    @param e MouseEvents are used to determine the current selection
+    operations (add, subtract, contains)
+    @see selectMultipleFeatures()
+  */
+  void selectSingleFeature( QgsMapCanvas* canvas, QgsGeometry* selectGeometry, QMouseEvent * e );
 
   /**
     Get the current selected canvas map layer. Returns nullptr if it is not a vector layer


### PR DESCRIPTION
Implements the improved mouse/key modifier behaviour discussed in:
http://osgeo-org.1560.x6.nabble.com/Key-modifiers-with-selection-tc5239653.html

Specifically,

For click-and-drag selections:
- holding shift = add to selection
- holding ctrl = substract from selection
- holding ctrl+shift = intersect with current selection
- holding alt (can be used with shift/ctrl too) = change from "intersects" to "fully contains" selection mode

For single-click selections:
- holding shift or ctrl = toggle whether feature is selected
  (ie either add to current selection or remove from current selection)

This brings the canvas behaviour into line with other design apps and also with the composer behaviour.

(fix #2666)
