### PR TITLE
Open editor in attribute table on single click

### DIFF
--- a/src/gui/attributetable/qgsattributetableview.cpp
+++ b/src/gui/attributetable/qgsattributetableview.cpp
@@ -57,6 +57,8 @@ QgsAttributeTableView::QgsAttributeTableView( QWidget *parent )
   mTableDelegate = new QgsAttributeTableDelegate( this );
   setItemDelegate( mTableDelegate );
 
+  setEditTriggers( QAbstractItemView::AllEditTriggers );
+
   setSelectionBehavior( QAbstractItemView::SelectRows );
   setSelectionMode( QAbstractItemView::ExtendedSelection );
   setSortingEnabled( true ); // At this point no data is in the model yet, so actually nothing is sorted.


### PR DESCRIPTION
This change makes it so that editor widgets in the attribute table are opened by a single click when the layer is editable. The current behavior is that you have to double click on a cell for the cell to become editable... which is a bit slow and frustrating.

@anitagraser @pcav @NathanW2 and other UX team members... what's your thoughts?
