### PR TITLE
[qt5 tests] Workaround unpredictable composertable tests

### DIFF
--- a/ci/travis/linux/qt5/blacklist.txt
+++ b/ci/travis/linux/qt5/blacklist.txt
@@ -12,6 +12,4 @@ PyQgsSpatialiteProvider
 PyQgsVirtualLayerDefinition
 PyQgsVirtualLayerProvider
 qgis_composermapgridtest
-qgis_composertabletest
-qgis_composertablev2test
 qgis_composerutils

--- a/tests/src/core/testqgscomposertable.cpp
+++ b/tests/src/core/testqgscomposertable.cpp
@@ -297,14 +297,10 @@ void TestQgsComposerTable::attributeTableSetAttributes()
 
   //get header labels and compare
   QMap<int, QString> headerMap = mComposerAttributeTable->headerLabels();
-  QMap<int, QString>::const_iterator headerIt = headerMap.constBegin();
-  QString expected;
-  QString evaluated;
-  for ( ; headerIt != headerMap.constEnd(); ++headerIt )
+
+  Q_FOREACH ( const QString& expected, expectedHeaders )
   {
-    evaluated = headerIt.value();
-    expected = expectedHeaders.at( headerIt.key() );
-    QCOMPARE( evaluated, expected );
+    QVERIFY( headerMap.values().contains( expected ) );
   }
 
   QList<QStringList> expectedRows;

--- a/tests/src/core/testqgscomposertablev2.cpp
+++ b/tests/src/core/testqgscomposertablev2.cpp
@@ -266,14 +266,10 @@ void TestQgsComposerTableV2::attributeTableSetAttributes()
 
   //get header labels and compare
   QMap<int, QString> headerMap = mComposerAttributeTable->headerLabels();
-  QMap<int, QString>::const_iterator headerIt = headerMap.constBegin();
-  QString expected;
-  QString evaluated;
-  for ( ; headerIt != headerMap.constEnd(); ++headerIt )
+
+  Q_FOREACH ( const QString& expected, expectedHeaders )
   {
-    evaluated = headerIt.value();
-    expected = expectedHeaders.at( headerIt.key() );
-    QCOMPARE( evaluated, expected );
+    QVERIFY( headerMap.values().contains( expected ) );
   }
 
   QList<QStringList> expectedRows;


### PR DESCRIPTION
QgsComposerAttributeTable::setDisplayAttributes takes a QSet<int> of attributes
to display. The tests previously expected that the attributes are displayed in a
specific order which cannot be guaranteed by a QSet. And apparantly Qt5 behaves
differently.

For flexibility it would be good to add another method which takes a
QVector<int> (or a QStringList to be less fragile to changes in the database
structure).
