### PR TITLE
Make QgsCoordinateReferenceSystem implicitly shared

### DIFF
--- a/src/analysis/vector/qgsgeometryanalyzer.cpp
+++ b/src/analysis/vector/qgsgeometryanalyzer.cpp
@@ -47,7 +47,7 @@ bool QgsGeometryAnalyzer::simplify( QgsVectorLayer* layer,
   }
 
   QGis::WkbType outputType = dp->geometryType();
-  const QgsCoordinateReferenceSystem crs = layer->crs();
+  QgsCoordinateReferenceSystem crs = layer->crs();
 
   QgsVectorFileWriter vWriter( shapefileName, dp->encoding(), layer->fields(), outputType, &crs );
   QgsFeature currentFeature;
@@ -163,7 +163,7 @@ bool QgsGeometryAnalyzer::centroids( QgsVectorLayer* layer, const QString& shape
   }
 
   QGis::WkbType outputType = QGis::WKBPoint;
-  const QgsCoordinateReferenceSystem crs = layer->crs();
+  QgsCoordinateReferenceSystem crs = layer->crs();
 
   QgsVectorFileWriter vWriter( shapefileName, dp->encoding(), layer->fields(), outputType, &crs );
   QgsFeature currentFeature;
@@ -279,7 +279,7 @@ bool QgsGeometryAnalyzer::extent( QgsVectorLayer* layer,
   }
 
   QGis::WkbType outputType = QGis::WKBPolygon;
-  const QgsCoordinateReferenceSystem crs = layer->crs();
+  QgsCoordinateReferenceSystem crs = layer->crs();
 
   QgsFields fields;
   fields.append( QgsField( QString( "MINX" ), QVariant::Double ) );
@@ -389,7 +389,7 @@ bool QgsGeometryAnalyzer::convexHull( QgsVectorLayer* layer, const QString& shap
   fields.append( QgsField( QString( "PERIM" ), QVariant::Double ) );
 
   QGis::WkbType outputType = QGis::WKBPolygon;
-  const QgsCoordinateReferenceSystem crs = layer->crs();
+  QgsCoordinateReferenceSystem crs = layer->crs();
 
   QgsVectorFileWriter vWriter( shapefileName, dp->encoding(), fields, outputType, &crs );
   QgsFeature currentFeature;
@@ -595,7 +595,7 @@ bool QgsGeometryAnalyzer::dissolve( QgsVectorLayer* layer, const QString& shapef
   }
 
   QGis::WkbType outputType = dp->geometryType();
-  const QgsCoordinateReferenceSystem crs = layer->crs();
+  QgsCoordinateReferenceSystem crs = layer->crs();
 
   QgsVectorFileWriter vWriter( shapefileName, dp->encoding(), layer->fields(), outputType, &crs );
   QgsFeature currentFeature;
@@ -748,7 +748,7 @@ bool QgsGeometryAnalyzer::buffer( QgsVectorLayer* layer, const QString& shapefil
   {
     outputType = QGis::WKBMultiPolygon;
   }
-  const QgsCoordinateReferenceSystem crs = layer->crs();
+  QgsCoordinateReferenceSystem crs = layer->crs();
 
   QgsVectorFileWriter vWriter( shapefileName, dp->encoding(), layer->fields(), outputType, &crs );
   QgsFeature currentFeature;

--- a/src/analysis/vector/qgsoverlayanalyzer.cpp
+++ b/src/analysis/vector/qgsoverlayanalyzer.cpp
@@ -44,7 +44,7 @@ bool QgsOverlayAnalyzer::intersection( QgsVectorLayer* layerA, QgsVectorLayer* l
   }
 
   QGis::WkbType outputType = dpA->geometryType();
-  const QgsCoordinateReferenceSystem crs = layerA->crs();
+  QgsCoordinateReferenceSystem crs = layerA->crs();
   QgsFields fieldsA = layerA->fields();
   QgsFields fieldsB = layerB->fields();
   combineFieldLists( fieldsA, fieldsB );

--- a/src/app/qgsdecorationgrid.cpp
+++ b/src/app/qgsdecorationgrid.cpp
@@ -832,7 +832,7 @@ bool QgsDecorationGrid::getIntervalFromCurrentLayer( double* values )
     QMessageBox::warning( nullptr, tr( "Error" ), tr( "Invalid raster layer" ) );
     return false;
   }
-  const QgsCoordinateReferenceSystem& layerCRS = layer->crs();
+  QgsCoordinateReferenceSystem layerCRS = layer->crs();
   const QgsCoordinateReferenceSystem& mapCRS =
     QgisApp::instance()->mapCanvas()->mapSettings().destinationCrs();
   // is this the best way to compare CRS? should we also make sure map has OTF enabled?

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -612,7 +612,8 @@ SET(QGIS_CORE_HDRS
   qgsconnectionpool.h
   qgscontexthelp.h
   qgsconditionalstyle.h
-  qgscoordinatereferencesystem.h
+  qgscoordinatereferencesystem.h  
+  qgscoordinatereferencesystem_p.h
   qgscoordinateutils.h
   qgscrscache.h
   qgscsexception.h

--- a/src/core/qgscoordinatereferencesystem.h
+++ b/src/core/qgscoordinatereferencesystem.h
@@ -28,6 +28,7 @@
 
 class QDomNode;
 class QDomDocument;
+class QgsCoordinateReferenceSystemPrivate;
 
 // forward declaration for sqlite3
 typedef struct sqlite3 sqlite3;
@@ -46,6 +47,7 @@ typedef void ( *CUSTOM_CRS_VALIDATION )( QgsCoordinateReferenceSystem& );
 
 /** \ingroup core
  * Class for storing a coordinate reference system (CRS)
+ * \note Since QGIS 2.16 QgsCoordinateReferenceSystem objects are implicitly shared.
  */
 class CORE_EXPORT QgsCoordinateReferenceSystem
 {
@@ -58,7 +60,6 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
       EpsgCrsId     // deprecated
     };
 
-    //! Default constructor
     QgsCoordinateReferenceSystem();
 
     ~QgsCoordinateReferenceSystem();
@@ -79,7 +80,7 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      */
     QgsCoordinateReferenceSystem( const long theId, CrsType theType = PostgisCrsId );
 
-    //! copy constructor
+    //! Copy constructor
     QgsCoordinateReferenceSystem( const QgsCoordinateReferenceSystem& srs );
 
     //! Assignment operator
@@ -96,7 +97,7 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
      *
      * \retval false if not given an valid label
      */
-    bool createFromOgcWmsCrs( QString theCrs );
+    bool createFromOgcWmsCrs( const QString& theCrs );
 
     /** Set up this CRS by fetching the appropriate information from the
      * sqlite backend. First the system level read only srs.db will be checked
@@ -443,25 +444,6 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
     // returns the same code as sqlite3_open
     static int openDb( const QString& path, sqlite3 **db, bool readonly = true );
 
-    //!The internal sqlite3 srs.db primary key for this CRS
-    long    mSrsId;
-    //!A textual description of the CRS.
-    QString mDescription;
-    //!The official proj4 acronym for the projection family
-    QString mProjectionAcronym;
-    //!The official proj4 acronym for the ellipoid
-    QString mEllipsoidAcronym;
-    //!Whether this is a geographic or projected coordinate system
-    bool    mGeoFlag;
-    //! The map units
-    QGis::UnitType mMapUnits;
-    //!If available, the Postgis spatial_ref_sys identifier for this CRS (defaults to 0)
-    long    mSRID;
-    //!If available the authority identifier for this CRS
-    QString mAuthId;
-    //! Whether this CRS is properly defined and valid
-    bool mIsValidFlag;
-
     //! Work out the projection units and set the appropriate local variable
     void setMapUnits();
 
@@ -471,20 +453,13 @@ class CORE_EXPORT QgsCoordinateReferenceSystem
     //! Helper for sql-safe value quoting
     static QString quotedValue( QString value );
 
-    OGRSpatialReferenceH mCRS;
-
     bool loadFromDb( const QString& db, const QString& expression, const QString& value );
-
-    QString mValidationHint;
-    mutable QString mWkt;
-    mutable QString mProj4;
 
     static bool loadIDs( QHash<int, QString> &wkts );
     static bool loadWkts( QHash<int, QString> &wkts, const char *filename );
     static bool syncDatumTransform( const QString& dbPath );
 
-    //!Whether this is a coordinate system has inverted axis
-    mutable int mAxisInverted;
+    QExplicitlySharedDataPointer<QgsCoordinateReferenceSystemPrivate> d;
 
     static CUSTOM_CRS_VALIDATION mCustomSrsValidation;
 };

--- a/src/core/qgscoordinatereferencesystem_p.h
+++ b/src/core/qgscoordinatereferencesystem_p.h
@@ -1,0 +1,124 @@
+/***************************************************************************
+                             qgscoordinatereferencesystem_p.h
+
+                             --------------------------------
+    begin                : 2016
+    copyright            : (C) 2016 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSCOORDINATEREFERENCESYSTEM_PRIVATE_H
+#define QGSCOORDINATEREFERENCESYSTEM_PRIVATE_H
+
+/// @cond PRIVATE
+
+//
+//  W A R N I N G
+//  -------------
+//
+// This file is not part of the QGIS API.  It exists purely as an
+// implementation detail.  This header file may change from version to
+// version without notice, or even be removed.
+//
+
+#include "qgscoordinatereferencesystem.h"
+#include <ogr_srs_api.h>
+
+#ifdef DEBUG
+typedef struct OGRSpatialReferenceHS *OGRSpatialReferenceH;
+#else
+typedef void *OGRSpatialReferenceH;
+#endif
+
+class QgsCoordinateReferenceSystemPrivate : public QSharedData
+{
+  public:
+
+    explicit QgsCoordinateReferenceSystemPrivate()
+        : mSrsId( 0 )
+        , mIsGeographic( false )
+        , mMapUnits( QGis::UnknownUnit )
+        , mSRID( 0 )
+        , mIsValid( 0 )
+        , mCRS( OSRNewSpatialReference( nullptr ) )
+        , mAxisInverted( false )
+    {
+    }
+
+    QgsCoordinateReferenceSystemPrivate( const QgsCoordinateReferenceSystemPrivate& other )
+        : QSharedData( other )
+        , mSrsId( other.mSrsId )
+        , mDescription( other.mDescription )
+        , mProjectionAcronym( other.mProjectionAcronym )
+        , mEllipsoidAcronym( other.mEllipsoidAcronym )
+        , mIsGeographic( other.mIsGeographic )
+        , mMapUnits( other.mMapUnits )
+        , mSRID( other.mSRID )
+        , mAuthId( other.mAuthId )
+        , mIsValid( other.mIsValid )
+        , mCRS( OSRNewSpatialReference( nullptr ) )
+        , mValidationHint( other.mValidationHint )
+        , mWkt( other.mWkt )
+        , mProj4( other.mProj4 )
+        , mAxisInverted( other.mAxisInverted )
+    {
+      if ( mIsValid )
+      {
+        mCRS = OSRClone( other.mCRS );
+      }
+    }
+
+    ~QgsCoordinateReferenceSystemPrivate()
+    {
+      OSRDestroySpatialReference( mCRS );
+    }
+
+    //! The internal sqlite3 srs.db primary key for this CRS
+    long mSrsId;
+
+    //! A textual description of the CRS
+    QString mDescription;
+
+    //! The official proj4 acronym for the projection family
+    QString mProjectionAcronym;
+
+    //! The official proj4 acronym for the ellipoid
+    QString mEllipsoidAcronym;
+
+    //! Whether this is a geographic or projected coordinate system
+    bool mIsGeographic;
+
+    //! The map units for the CRS
+    QGis::UnitType mMapUnits;
+
+    //! If available, the Postgis spatial_ref_sys identifier for this CRS (defaults to 0)
+    long mSRID;
+
+    //! If available the authority identifier for this CRS
+    QString mAuthId;
+
+    //! Whether this CRS is properly defined and valid
+    bool mIsValid;
+
+    OGRSpatialReferenceH mCRS;
+
+    QString mValidationHint;
+    mutable QString mWkt;
+    mutable QString mProj4;
+
+    //! Whether this is a coordinate system has inverted axis
+    mutable int mAxisInverted;
+
+};
+
+/// @endcond
+
+#endif //QGSCOORDINATEREFERENCESYSTEM_PRIVATE_H

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -367,6 +367,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
     /** Returns layer's spatial reference system
     @note This was introduced in QGIS 1.4
      */
+    //TODO QGIS 3.0 - return QgsCoordinateReferenceSystem object, not reference (since they are implicitly shared)
     const QgsCoordinateReferenceSystem& crs() const;
 
     /** Sets layer's spatial reference system */
@@ -764,7 +765,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
 
     /** Layer's spatial reference system.
         private to make sure setCrs must be used and layerCrsChanged() is emitted */
-    QgsCoordinateReferenceSystem* mCRS;
+    QgsCoordinateReferenceSystem mCRS;
 
     /** Private copy constructor - QgsMapLayer not copyable */
     QgsMapLayer( QgsMapLayer const & );

--- a/src/core/qgsmaprenderer.h
+++ b/src/core/qgsmaprenderer.h
@@ -456,6 +456,7 @@ class CORE_EXPORT QgsMapRenderer : public QObject
     bool mProjectionsEnabled;
 
     //! destination spatial reference system of the projection
+    // TODO QGIS 3.0 - make object, not pointer
     QgsCoordinateReferenceSystem* mDestCRS;
 
     //! stores array of layers to be rendered (identified by string)

--- a/src/server/qgswcsprojectparser.cpp
+++ b/src/server/qgswcsprojectparser.cpp
@@ -138,7 +138,7 @@ void QgsWCSProjectParser::wcsContentMetadata( QDomElement& parentElement, QDomDo
         layerElem.appendChild( descriptionElem );
 
         //lonLatEnvelope
-        const QgsCoordinateReferenceSystem& layerCrs = layer->crs();
+        QgsCoordinateReferenceSystem layerCrs = layer->crs();
         QgsCoordinateTransform t( layerCrs, QgsCoordinateReferenceSystem( 4326 ) );
         //transform
         QgsRectangle BBox;
@@ -274,7 +274,7 @@ void QgsWCSProjectParser::describeCoverage( const QString& aCoveName, QDomElemen
         layerElem.appendChild( descriptionElem );
 
         //lonLatEnvelope
-        const QgsCoordinateReferenceSystem& layerCrs = rLayer->crs();
+        QgsCoordinateReferenceSystem layerCrs = rLayer->crs();
         QgsCoordinateTransform t( layerCrs, QgsCoordinateReferenceSystem( 4326 ) );
         //transform
         QgsRectangle BBox = rLayer->extent();

--- a/src/server/qgswmsprojectparser.cpp
+++ b/src/server/qgswmsprojectparser.cpp
@@ -1696,7 +1696,7 @@ void QgsWMSProjectParser::addOWSLayers( QDomDocument &doc,
       appendLayerBoundingBoxes( layerElem, doc, currentLayer->extent(), currentLayer->crs() );
       */
       //get project crs
-      const QgsCoordinateReferenceSystem& layerCrs = currentLayer->crs();
+      QgsCoordinateReferenceSystem layerCrs = currentLayer->crs();
       QgsCoordinateTransform t( layerCrs, projectCrs );
 
       //transform

--- a/tests/src/core/testqgscoordinatereferencesystem.cpp
+++ b/tests/src/core/testqgscoordinatereferencesystem.cpp
@@ -126,7 +126,16 @@ void TestQgsCoordinateReferenceSystem::copyCtor()
   QgsCoordinateReferenceSystem myCrs2( myCrs );
   debugPrint( myCrs2 );
   QVERIFY( myCrs2.isValid() );
+  QCOMPARE( myCrs2.authid(), QString( "EPSG:4326" ) );
+
+  //test implicit sharing detachment - modify original
+  myCrs.createFromId( 3111, QgsCoordinateReferenceSystem::EpsgCrsId );
+  QVERIFY( myCrs.isValid() );
+  QCOMPARE( myCrs.authid(), QString( "EPSG:3111" ) );
+  QVERIFY( myCrs2.isValid() );
+  QCOMPARE( myCrs2.authid(), QString( "EPSG:4326" ) );
 }
+
 void TestQgsCoordinateReferenceSystem::assignmentCtor()
 {
   QgsCoordinateReferenceSystem myCrs( GEOSRID,
@@ -134,7 +143,16 @@ void TestQgsCoordinateReferenceSystem::assignmentCtor()
   QgsCoordinateReferenceSystem myCrs2 = myCrs;
   debugPrint( myCrs2 );
   QVERIFY( myCrs2.isValid() );
+  QCOMPARE( myCrs2.authid(), QString( "EPSG:4326" ) );
+
+  //test implicit sharing detachment - modify original
+  myCrs.createFromId( 3111, QgsCoordinateReferenceSystem::EpsgCrsId );
+  QVERIFY( myCrs.isValid() );
+  QCOMPARE( myCrs.authid(), QString( "EPSG:3111" ) );
+  QVERIFY( myCrs2.isValid() );
+  QCOMPARE( myCrs2.authid(), QString( "EPSG:4326" ) );
 }
+
 void TestQgsCoordinateReferenceSystem::createFromId()
 {
   QgsCoordinateReferenceSystem myCrs;


### PR DESCRIPTION
Just as the title says - this PR makes QgsCoordinateReferenceSystem implicitly shared. 

Apart from the benefits that implicit sharing has for PyQGIS devs, my main rationale here is that I'd like to create a new QgsReferencedGeometry class which consists of both a geometry + its corresponding CRS. Given that there may be many of these objects in existence, sharing the CRS will help decrease the memory footprint here.  
