### PR TITLE
[BUGFIX] [Processing] Fix updateDependentFields

### DIFF
--- a/python/plugins/processing/gui/ParametersPanel.py
+++ b/python/plugins/processing/gui/ParametersPanel.py
@@ -453,10 +453,10 @@ class ParametersPanel(BASE, WIDGET):
             if isinstance(child, ParameterTableField):
                 widget = self.valueItems[child.name]
                 widget.clear()
-                if self.alg.getParameterFromName(child).optional:
+                if self.alg.getParameterFromName(child.name).optional:
                     widget.addItem(self.tr('[not set]'))
                 widget.addItems(self.getFields(layer,
-                                               self.alg.getParameterFromName(child).datatype))
+                                               self.alg.getParameterFromName(child.name).datatype))
             if isinstance(child, OutputVector):
                 child.base_layer = layer
 


### PR DESCRIPTION
This is a fixup for afbe914.
To support geometryless tables though OutputVector in processing GUI, I've changed the ParametersPanel.dependentItems content from parameter's names to parameter object instances.
I've forgotten some related changes.
