### PR TITLE
Keep numeric fields type, length and precision in postgresql provider

### DIFF
--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -3336,16 +3336,16 @@ bool QgsPostgresProvider::convertField( QgsField &field, const QMap<QString, QVa
       break;
 
     case QVariant::Double:
-      if ( fieldSize > 18 )
+      if ( fieldPrec > 0 )
       {
         fieldType = "numeric";
-        fieldSize = -1;
       }
       else
       {
         fieldType = "float8";
+        fieldSize = -1;
+        fieldPrec = -1;
       }
-      fieldPrec = -1;
       break;
 
     default:


### PR DESCRIPTION
For now,  on table creation, PostgreSQL / PostGIS provider do not create numeric/float fields with expected type, length and precision.

Here, I change this behavior to keep original field type, length and precision, as given to the createEmptyLayer method.

For exemple, using DBManager when importing layers to PostGIS, new table fields now have same type, length and precision as source fields.
