### PR TITLE
Cast each child of QgsAnnotationItem in SIP bindings for Python

### DIFF
--- a/python/gui/qgsannotationitem.sip
+++ b/python/gui/qgsannotationitem.sip
@@ -1,10 +1,32 @@
-/** An annotation item can be either placed either on screen corrdinates or on map coordinates.
-  It may reference a feature and displays that associatiation with a balloon like appearance*/
+/** An annotation item can be either placed either on screen coordinates or on map coordinates.
+  It may reference a feature and displays that association with a balloon like appearance*/
+
+%ModuleCode
+#include "qgsformannotationitem.h"
+#include "qgshtmlannotationitem.h"
+#include "qgssvgannotationitem.h"
+#include "qgstextannotationitem.h"
+%End
+
 class QgsAnnotationItem: QgsMapCanvasItem
 {
 %TypeHeaderCode
 #include <qgsannotationitem.h>
 %End
+
+%ConvertToSubClassCode
+  if (dynamic_cast<QgsFormAnnotationItem*>(sipCpp) )
+    sipType = sipType_QgsFormAnnotationItem;
+  else if (dynamic_cast<QgsHtmlAnnotationItem*>(sipCpp) )
+    sipType = sipType_QgsHtmlAnnotationItem;
+  else if (dynamic_cast<QgsSvgAnnotationItem*>(sipCpp) )
+    sipType = sipType_QgsSvgAnnotationItem;
+  else if (dynamic_cast<QgsTextAnnotationItem*>(sipCpp) )
+    sipType = sipType_QgsTextAnnotationItem;
+  else
+    sipType = 0;
+%End
+
 
   public:
     enum MouseMoveAction


### PR DESCRIPTION
There was no cast in [`QgsAnnotationItem`](https://qgis.org/api/classQgsAnnotationItem.html) children in SIP bindings.

To reproduce the issue before the commit, create a text annotation or a svg annotation through the GUI.

Then, in QGIS Python console, run `iface.mapCanvas().items()`, you will see that the return list does not reference the `QgsTextAnnotationItem` or `QgsSvgAnnotationItem` types.

Remove the annotation to confirm, it was in these items that the `QgsTextAnnotationItem` or `QgsSvgAnnotationItem` have been added.

Repeat the process with the proposed patch to see the types now appear when running `iface.mapCanvas().items()`
