### PR TITLE
[Processing] Support postgis service parameter and credentials input

### DIFF
--- a/python/plugins/processing/algs/gdal/ogr2ogrtopostgislist.py
+++ b/python/plugins/processing/algs/gdal/ogr2ogrtopostgislist.py
@@ -39,6 +39,7 @@ from processing.core.parameters import ParameterTableField
 from processing.algs.gdal.GdalAlgorithm import GdalAlgorithm
 from processing.algs.gdal.GdalUtils import GdalUtils
 
+from processing.tools.postgis import uri_from_name, GeoDB
 from processing.tools.system import isWindows
 from processing.tools.vector import ogrConnectionString, ogrLayerName
 
@@ -79,6 +80,10 @@ class Ogr2OgrToPostGisList(GdalAlgorithm):
     PRECISION = 'PRECISION'
     PROMOTETOMULTI = 'PROMOTETOMULTI'
     OPTIONS = 'OPTIONS'
+
+    def __init__(self):
+        GdalAlgorithm.__init__(self)
+        self.processing = False
 
     def dbConnectionNames(self):
         settings = QSettings()
@@ -153,15 +158,18 @@ class Ogr2OgrToPostGisList(GdalAlgorithm):
         self.addParameter(ParameterString(self.OPTIONS,
                                           self.tr('Additional creation options'), '', optional=True))
 
+    def processAlgorithm(self, progress):
+        self.processing = True
+        GdalAlgorithm.processAlgorithm(self, progress)
+        self.processing = False
+
     def getConsoleCommands(self):
         connection = self.DB_CONNECTIONS[self.getParameterValue(self.DATABASE)]
-        settings = QSettings()
-        mySettings = '/PostgreSQL/connections/' + connection
-        dbname = settings.value(mySettings + '/database')
-        user = settings.value(mySettings + '/username')
-        host = settings.value(mySettings + '/host')
-        port = settings.value(mySettings + '/port')
-        password = settings.value(mySettings + '/password')
+        uri = uri_from_name(connection)
+        if self.processing:
+            # to get credentials input when needed
+            uri = GeoDB(uri=uri).uri
+
         inLayer = self.getParameterValue(self.INPUT_LAYER)
         ogrLayer = ogrConnectionString(inLayer)[1:-1]
         ssrs = unicode(self.getParameterValue(self.S_SRS))
@@ -200,17 +208,11 @@ class Ogr2OgrToPostGisList(GdalAlgorithm):
         arguments.append('--config PG_USE_COPY YES')
         arguments.append('-f')
         arguments.append('PostgreSQL')
-        arguments.append('PG:"host=' + host)
-        arguments.append('port=' + port)
-        if len(dbname) > 0:
-            arguments.append('dbname=' + dbname)
-        if len(password) > 0:
-            arguments.append('password=' + password)
-        if len(schema) > 0:
-            arguments.append('active_schema=' + schema)
-        else:
-            arguments.append('active_schema=public')
-        arguments.append('user=' + user + '"')
+        arguments.append('PG:"')
+        for token in uri.connectionInfo(self.processing).split(' '):
+            arguments.append(token)
+        arguments.append('active_schema={}'.format(schema or 'public'))
+        arguments.append('"')
         arguments.append(dimstring)
         arguments.append(ogrLayer)
         arguments.append(ogrLayerName(inLayer))

--- a/python/plugins/processing/algs/qgis/PostGISExecuteSQL.py
+++ b/python/plugins/processing/algs/qgis/PostGISExecuteSQL.py
@@ -46,24 +46,7 @@ class PostGISExecuteSQL(GeoAlgorithm):
 
     def processAlgorithm(self, progress):
         connection = self.getParameterValue(self.DATABASE)
-        settings = QSettings()
-        mySettings = '/PostgreSQL/connections/' + connection
-        try:
-            database = settings.value(mySettings + '/database')
-            username = settings.value(mySettings + '/username')
-            host = settings.value(mySettings + '/host')
-            port = settings.value(mySettings + '/port', type=int)
-            password = settings.value(mySettings + '/password')
-        except Exception as e:
-            raise GeoAlgorithmExecutionException(
-                self.tr('Wrong database connection name: %s' % connection))
-        try:
-            self.db = postgis.GeoDB(host=host, port=port,
-                                    dbname=database, user=username, passwd=password)
-        except postgis.DbError as e:
-            raise GeoAlgorithmExecutionException(
-                self.tr("Couldn't connect to database:\n%s") % unicode(e))
-
+        self.db = postgis.GeoDB.from_name(connection)
         sql = self.getParameterValue(self.SQL).replace('\n', ' ')
         try:
             self.db._exec_sql_and_commit(unicode(sql))

--- a/python/plugins/processing/gui/PostgisTableSelector.py
+++ b/python/plugins/processing/gui/PostgisTableSelector.py
@@ -100,23 +100,10 @@ class ConnectionItem(QTreeWidgetItem):
     def populateSchemas(self):
         if self.childCount() != 0:
             return
-        settings = QSettings()
-        connSettings = '/PostgreSQL/connections/' + self.connection
-        database = settings.value(connSettings + '/database')
-        user = settings.value(connSettings + '/username')
-        host = settings.value(connSettings + '/host')
-        port = settings.value(connSettings + '/port')
-        passwd = settings.value(connSettings + '/password')
-        uri = QgsDataSourceURI()
-        uri.setConnection(host, str(port), database, user, passwd)
-        connInfo = uri.connectionInfo()
-        (success, user, passwd) = QgsCredentials.instance().get(connInfo, None, None)
-        if success:
-            QgsCredentials.instance().put(connInfo, user, passwd)
-            geodb = GeoDB(host, int(port), database, user, passwd)
-            schemas = geodb.list_schemas()
-            for oid, name, owner, perms in schemas:
-                item = QTreeWidgetItem()
-                item.setText(0, name)
-                item.setIcon(0, self.schemaIcon)
-                self.addChild(item)
+        geodb = GeoDB.from_name(self.connection)
+        schemas = geodb.list_schemas()
+        for oid, name, owner, perms in schemas:
+            item = QTreeWidgetItem()
+            item.setText(0, name)
+            item.setIcon(0, self.schemaIcon)
+            self.addChild(item)


### PR DESCRIPTION
- Add helper in `postgis_utils` to create `QgsDataSourceUri` from connection name.
- Call `QgsCredentials` in postgis_utils.GeoDB.__init__` method.

Use this everywhere so :
- service parameter from QSettings is supported.
- credentials came from cache or dialog is shown.
