### PR TITLE
Guard against possible crash by using destroyed QgsMapRendererCustomPainterJob

### DIFF
--- a/src/core/qgsmaprendererparalleljob.cpp
+++ b/src/core/qgsmaprendererparalleljob.cpp
@@ -75,6 +75,14 @@ void QgsMapRendererParallelJob::start()
   }
 
   mLayerJobs = prepareJobs( nullptr, mLabelingEngine, mLabelingEngineV2 );
+  // prepareJobs calls mapLayer->createMapRenderer may involve cloning a RasterDataProvider,
+  // whose constructor may need to download some data (i.e. WMS, AMS) and doing so runs a
+  // QEventLoop waiting for the network request to complete. If unluckily someone calls
+  // mapCanvas->refresh() while this is happening, QgsMapRendererCustomPainterJob::cancel is
+  // called, deleting the QgsMapRendererCustomPainterJob while this function is running.
+  // Hence we need to check whether the job is still active before proceeding
+  if ( !isActive() )
+    return;
 
   QgsDebugMsg( QString( "QThreadPool max thread count is %1" ).arg( QThreadPool::globalInstance()->maxThreadCount() ) );
 


### PR DESCRIPTION
See comment in commit for details. In particular when suffering from slow connection speed, qgis can crash when rendering raster layers which run an event loop in the provider constructor (i.e. when fetching  data via network).
