### PR TITLE
[renderer] Live hillshade renderer for raster layers

### DIFF
--- a/python/core/core.sip
+++ b/python/core/core.sip
@@ -284,6 +284,7 @@
 %Include raster/qgssinglebandcolordatarenderer.sip
 %Include raster/qgssinglebandgrayrenderer.sip
 %Include raster/qgssinglebandpseudocolorrenderer.sip
+%Include raster/qgshillshaderenderer.sip
 
 %Include symbology-ng/qgscolorbrewerpalette.sip
 %Include symbology-ng/qgscptcityarchive.sip

--- a/python/core/raster/qgshillshaderenderer.sip
+++ b/python/core/raster/qgshillshaderenderer.sip
@@ -1,0 +1,53 @@
+class QgsHillshadeRenderer : QgsRasterRenderer
+{
+%TypeHeaderCode
+    #include "qgshillshaderenderer.h"
+%End
+  public:
+    /** Renderer owns color array*/
+    QgsHillshadeRenderer( QgsRasterInterface* input, int band , double lightAzimuth, double lightAngle );
+
+    ~QgsHillshadeRenderer();
+
+    virtual QgsHillshadeRenderer * clone() const /Factory/;
+
+    static QgsRasterRenderer* create( const QDomElement& elem, QgsRasterInterface* input ) /Factory/;
+
+    QgsRasterBlock *block( int bandNo, const QgsRectangle & extent, int width, int height ) /Factory/;
+
+    void writeXML( QDomDocument& doc, QDomElement& parentElem ) const;
+
+    QList<int> usesBands() const;
+
+    /** Returns the band used by the renderer
+     */
+    int band() const;
+
+    /** Sets the band used by the renderer.
+     * @see band
+     */
+    void setBand( int bandNo );
+
+    /**
+     * @brief The direction of the light over the raster between 0-360
+     * @return The direction of the light over the raster
+     */
+    double Azimuth() const;
+
+    /**
+     * @brief The angle of the light source over the raster
+     * @return The angle of the light source over the raster
+     */
+    double Angle()  const;
+
+    /**
+     * @brief Z Factor
+     * @return Z Factor
+     */
+    double zFactor()  const;
+
+    void setAzimuth( double azimuth );
+    void setAngle( double angle );
+    void setZFactor( double zfactor );
+
+};

--- a/python/gui/gui.sip
+++ b/python/gui/gui.sip
@@ -203,6 +203,7 @@
 %Include raster/qgssinglebandpseudocolorrendererwidget.sip
 %Include raster/qgsrendererrasterpropertieswidget.sip
 %Include raster/qgsrastertransparencywidget.sip
+%Include raster/qgshillshaderendererwidget.sip
 
 %Include symbology-ng/characterwidget.sip
 %Include symbology-ng/qgs25drendererwidget.sip

--- a/python/gui/raster/qgshillshaderendererwidget.sip
+++ b/python/gui/raster/qgshillshaderendererwidget.sip
@@ -1,0 +1,54 @@
+/**
+ * @brief Renderer widget for the hill shade renderer.
+ */
+class QgsHillshadeRendererWidget: QgsRasterRendererWidget
+{
+%TypeHeaderCode
+#include <qgshillshaderendererwidget.h>
+%End
+  public:
+
+    /**
+     * @brief Renderer widget for the hill shade renderer.
+     * @param layer The layer attached for this widget.
+     * @param extent The current extent.
+     */
+    QgsHillshadeRendererWidget( QgsRasterLayer* layer, const QgsRectangle &extent = QgsRectangle() );
+    ~QgsHillshadeRendererWidget();
+
+    /**
+      * Factory method to create the renderer for this type.
+      */
+    static QgsRasterRendererWidget* create( QgsRasterLayer* layer, const QgsRectangle &theExtent ) /Factory/;
+
+    /**
+     * @brief The renderer for the widget.
+     * @return A new renderer for the the config in the widget
+     */
+    QgsRasterRenderer* renderer();
+
+    /**
+     * @brief Set the widget state from the given renderer.
+     * @param r The renderer to take the state from.
+     */
+    void setFromRenderer( const QgsRasterRenderer* r );
+
+  public slots:
+    /**
+     * @brief Set the altitude of the light source
+     * @param altitude The altitude
+     */
+    void setAltitude( double altitude );
+
+    /**
+     * @brief Set the azimith of the light source.
+     * @param azimuth The azimuth of the light source.
+     */
+    void setAzimuth( double azimuth );
+
+    /**
+     * @brief Set the Z factor of the result image.
+     * @param zfactor The z factor.
+     */
+    void setZFactor( double zfactor );
+};

--- a/src/app/qgsrasterlayerproperties.cpp
+++ b/src/app/qgsrasterlayerproperties.cpp
@@ -50,6 +50,7 @@
 #include "qgssinglebandgrayrendererwidget.h"
 #include "qgssinglebandpseudocolorrendererwidget.h"
 #include "qgshuesaturationfilter.h"
+#include "qgshillshaderendererwidget.h"
 
 #include <QTableWidgetItem>
 #include <QHeaderView>
@@ -366,6 +367,7 @@ QgsRasterLayerProperties::QgsRasterLayerProperties( QgsMapLayer* lyr, QgsMapCanv
   QgsRasterRendererRegistry::instance()->insertWidgetFunction( "multibandcolor", QgsMultiBandColorRendererWidget::create );
   QgsRasterRendererRegistry::instance()->insertWidgetFunction( "singlebandpseudocolor", QgsSingleBandPseudoColorRendererWidget::create );
   QgsRasterRendererRegistry::instance()->insertWidgetFunction( "singlebandgray", QgsSingleBandGrayRendererWidget::create );
+  QgsRasterRendererRegistry::instance()->insertWidgetFunction( "hillshade", QgsHillshadeRendererWidget::create );
 
   //fill available renderers into combo box
   QgsRasterRendererRegistryEntry entry;

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -329,6 +329,7 @@ SET(QGIS_CORE_SRCS
   raster/qgssinglebandcolordatarenderer.cpp
   raster/qgssinglebandgrayrenderer.cpp
   raster/qgssinglebandpseudocolorrenderer.cpp
+  raster/qgshillshaderenderer.cpp
 
   geometry/qgsabstractgeometryv2.cpp
   geometry/qgscircularstringv2.cpp
@@ -801,6 +802,7 @@ SET(QGIS_CORE_HDRS
   raster/qgssinglebandcolordatarenderer.h
   raster/qgssinglebandgrayrenderer.h
   raster/qgssinglebandpseudocolorrenderer.h
+  raster/qgshillshaderenderer.h
 
   symbology-ng/qgs25drenderer.h
   symbology-ng/qgscategorizedsymbolrendererv2.h

--- a/src/core/raster/qgshillshaderenderer.cpp
+++ b/src/core/raster/qgshillshaderenderer.cpp
@@ -1,0 +1,249 @@
+#include <QColor>
+
+#include "qgshillshaderenderer.h"
+
+#include "qgsrasterinterface.h"
+#include "qgsrasterblock.h"
+#include "qgsrectangle.h"
+
+
+QgsHillshadeRenderer::QgsHillshadeRenderer( QgsRasterInterface *input, int band, double lightAzimuth, double lightAngle ):
+    QgsRasterRenderer( input, "hillshade" ),
+    mBand( band ),
+    mZFactor( 1 ),
+    mLightAngle( lightAngle ),
+    mLightAzimuth( lightAzimuth )
+{
+
+}
+
+QgsHillshadeRenderer *QgsHillshadeRenderer::clone() const
+{
+  QgsHillshadeRenderer* r = new QgsHillshadeRenderer( nullptr, mBand, mLightAzimuth, mLightAngle );
+  r->setZFactor( mZFactor );
+  return r;
+}
+
+QgsRasterRenderer *QgsHillshadeRenderer::create( const QDomElement &elem, QgsRasterInterface *input )
+{
+  if ( elem.isNull() )
+  {
+    return nullptr;
+  }
+
+  int band = elem.attribute( "band", "0" ).toInt();
+  double azimuth = elem.attribute( "azimuth", "315" ).toDouble();
+  double angle = elem.attribute( "angle", "45" ).toDouble();
+  double zFactor = elem.attribute( "zfactor", "1" ).toDouble();
+  QgsHillshadeRenderer* r = new QgsHillshadeRenderer( input, band, azimuth , angle );
+  r->setZFactor( zFactor );
+  return r;
+}
+
+void QgsHillshadeRenderer::writeXML( QDomDocument &doc, QDomElement &parentElem ) const
+{
+  if ( parentElem.isNull() )
+  {
+    return;
+  }
+
+  QDomElement rasterRendererElem = doc.createElement( "rasterrenderer" );
+  _writeXML( doc, rasterRendererElem );
+
+  rasterRendererElem.setAttribute( "band", mBand );
+  rasterRendererElem.setAttribute( "azimuth", QString::number( mLightAzimuth ) );
+  rasterRendererElem.setAttribute( "angle", QString::number( mLightAngle ) );
+  rasterRendererElem.setAttribute( "zfactor", QString::number( mZFactor ) );
+  parentElem.appendChild( rasterRendererElem );
+}
+
+QgsRasterBlock *QgsHillshadeRenderer::block( int bandNo, const QgsRectangle &extent, int width, int height )
+{
+  Q_UNUSED( bandNo );
+  QgsRasterBlock *outputBlock = new QgsRasterBlock();
+  if ( !mInput )
+  {
+    QgsDebugMsg( "No input raster!" );
+    return outputBlock;
+  }
+
+  QgsRasterBlock *inputBlock = mInput->block( mBand, extent, width, height );
+
+  if ( !inputBlock || inputBlock->isEmpty() )
+  {
+    QgsDebugMsg( "No raster data!" );
+    delete inputBlock;
+    return outputBlock;
+  }
+
+  if ( !outputBlock->reset( QGis::ARGB32_Premultiplied, width, height ) )
+  {
+    delete inputBlock;
+    return outputBlock;
+  }
+
+  double cellxsize = extent.width() / double( width );
+  double cellysize = extent.height() / double( height );
+  double zenith_rad = qMax( 0.0, 90 - mLightAngle ) * M_PI / 180.0;
+  double azimuth_rad = -1 * mLightAzimuth * M_PI / 180.0;
+  double aspect_rad = 0;
+  double coszenith_rad = cos( zenith_rad );
+  double sinzenith_rad = cos( zenith_rad );
+
+  QRgb myDefaultColor = NODATA_COLOR;
+
+  for ( qgssize i = 0; i < ( qgssize )height; i++ )
+  {
+
+    for ( qgssize j = 0; j < ( qgssize )width; j++ )
+    {
+
+      if ( inputBlock->isNoData( i, j ) )
+      {
+        outputBlock->setColor( i, j, myDefaultColor );
+        continue;
+      }
+
+      if ( inputBlock->isNoData( i, j ) )
+      {
+        outputBlock->setColor( i, j, myDefaultColor );
+        continue;
+      }
+
+      qgssize iUp, iDown, jLeft, jRight;
+      if ( i == 0 )
+      {
+        iUp = i;
+        iDown = i + 1;
+      }
+      else if ( i < ( qgssize )height - 1 )
+      {
+        iUp = i - 1;
+        iDown = i + 1;
+      }
+      else
+      {
+        iUp = i - 1;
+        iDown = i;
+      }
+
+      if ( j == 0 )
+      {
+        jLeft = j;
+        jRight = j + 1;
+      }
+      else if ( j < ( qgssize )width - 1 )
+      {
+        jLeft = j - 1;
+        jRight = j + 1;
+      }
+      else
+      {
+        jLeft = j - 1;
+        jRight = j;
+      }
+
+      double x11;
+      double x21;
+      double x31;
+      double x12;
+      double x22; // Working cell
+      double x32;
+      double x13;
+      double x23;
+      double x33;
+
+      // This is center cell. It is not nodata. Use this in place of nodata neighbors
+      x22 = inputBlock->value( i, j );
+
+      x11 = inputBlock->isNoData( iUp, jLeft )  ? x22 : inputBlock->value( iUp, jLeft );
+      x21 = inputBlock->isNoData( i, jLeft )     ? x22 : inputBlock->value( i, jLeft );
+      x31 = inputBlock->isNoData( iDown, jLeft ) ? x22 : inputBlock->value( iDown, jLeft );
+
+      x12 = inputBlock->isNoData( iUp, j )       ? x22 : inputBlock->value( iUp, j );
+      // x22
+      x32 = inputBlock->isNoData( iDown, j )     ? x22 : inputBlock->value( iDown, j );
+
+      x13 = inputBlock->isNoData( iUp, jRight )   ? x22 : inputBlock->value( iUp, jRight );
+      x23 = inputBlock->isNoData( i, jRight )     ? x22 : inputBlock->value( i, jRight );
+      x33 = inputBlock->isNoData( iDown, jRight ) ? x22 : inputBlock->value( iDown, jRight );
+
+      double derX = calcFirstDerX( x11, x21, x31, x12, x22, x32, x13, x23, x33, cellxsize );
+      double derY = calcFirstDerY( x11, x21, x31, x12, x22, x32, x13, x23, x33, cellysize );
+
+      double slope_rad = atan( mZFactor * sqrt( derX * derX + derY * derY ) );
+
+      if ( derX != 0 )
+      {
+        aspect_rad = atan2( derX, -derY );
+        if ( aspect_rad < 0 )
+        {
+          aspect_rad = 2 * M_PI + aspect_rad;
+        }
+      }
+      else if ( derX == 0 )
+      {
+        if ( derY > 0 )
+        {
+          aspect_rad = M_PI / 2;
+        }
+        else if ( derY < 0 )
+        {
+          aspect_rad = 2 * M_PI - M_PI / 2;
+        }
+        else
+        {
+          aspect_rad = aspect_rad;
+        }
+      }
+
+
+      double colorvalue = qMax( 0.0, 255.0 * (( coszenith_rad * cos( slope_rad ) ) +
+                                              ( sinzenith_rad * sin( slope_rad ) * cos( azimuth_rad - aspect_rad ) ) ) );
+
+      outputBlock->setColor( i, j, qRgb( colorvalue, colorvalue, colorvalue ) );
+    }
+  }
+  return outputBlock;
+}
+
+QList<int> QgsHillshadeRenderer::usesBands() const
+{
+  QList<int> bandList;
+  if ( mBand != -1 )
+  {
+    bandList << mBand;
+  }
+  return bandList;
+
+}
+
+void QgsHillshadeRenderer::setBand( int bandNo )
+{
+  if ( bandNo > mInput->bandCount() || bandNo <= 0 )
+  {
+    return;
+  }
+  mBand = bandNo;
+}
+
+double QgsHillshadeRenderer::calcFirstDerX( double x11, double x21, double x31, double x12, double x22, double x32, double x13, double x23, double x33, double cellsize )
+{
+  Q_UNUSED( x12 );
+  Q_UNUSED( x22 );
+  Q_UNUSED( x32 );
+  return (( x13 + x23 + x23 + x33 ) - ( x11 + x21 + x21 + x31 ) ) / ( 8 * cellsize );
+}
+
+double QgsHillshadeRenderer::calcFirstDerY( double x11, double x21, double x31, double x12, double x22, double x32, double x13, double x23, double x33, double cellsize )
+{
+  Q_UNUSED( x22 );
+  Q_UNUSED( x32 );
+  Q_UNUSED( x21 );
+  Q_UNUSED( x23 );
+  return (( x31 + x32 + x32 + x33 ) - ( x11 + x12 + x12 + x13 ) ) / ( 8 * -cellsize );
+}
+
+
+
+

--- a/src/core/raster/qgshillshaderenderer.h
+++ b/src/core/raster/qgshillshaderenderer.h
@@ -1,0 +1,101 @@
+#ifndef QGSHILLSHADERENDERER_H
+#define QGSHILLSHADERENDERER_H
+
+
+#include "qgsrasterrenderer.h"
+
+class QgsRasterBlock;
+class QgsRectangle;
+class QgsRasterInterface;
+
+
+/**
+ * @brief A renderer for generating live hillshade models.
+ */
+class CORE_EXPORT QgsHillshadeRenderer : public QgsRasterRenderer
+{
+  public:
+    /**
+     * @brief A renderer for generating live hillshade models.
+     * @param input The input raster interface
+     * @param band The band in the raster to use
+     * @param lightAzimuth The azimuth of the light source
+     * @param lightAltitude
+     */
+    QgsHillshadeRenderer( QgsRasterInterface* input, int band , double lightAzimuth, double lightAngle );
+
+    QgsHillshadeRenderer * clone() const override;
+
+    /**
+     * @brief Factory method to create a new renderer
+     * @param elem A DOM element to create the renderer from.
+     * @param input The raster input interface.
+     * @return A new QgsHillshadeRenderer.
+     */
+    static QgsRasterRenderer* create( const QDomElement& elem, QgsRasterInterface* input );
+
+    void writeXML( QDomDocument& doc, QDomElement& parentElem ) const override;
+
+    QgsRasterBlock *block( int bandNo, QgsRectangle  const & extent, int width, int height ) override;
+
+    QList<int> usesBands() const override;
+
+    /** Returns the band used by the renderer
+     */
+    int band() const { return mBand; }
+
+    /** Sets the band used by the renderer.
+     * @see band
+     */
+    void setBand( int bandNo );
+
+    /**
+     * @brief The direction of the light over the raster between 0-360
+     * @return The direction of the light over the raster
+     */
+    double Azimuth() const { return mLightAzimuth; }
+
+    /**
+     * @brief The angle of the light source over the raster
+     * @return The angle of the light source over the raster
+     */
+    double Angle()  const { return mLightAngle; }
+
+    /**
+     * @brief Z Factor
+     * @return Z Factor
+     */
+    double zFactor()  const { return mZFactor; }
+
+    /**
+     * @brief Set the azimith of the light source.
+     * @param azimuth The azimuth of the light source.
+     */
+    void setAzimuth( double azimuth ) { mLightAzimuth = azimuth; }
+
+    /**
+     * @brief Set the altitude of the light source
+     * @param altitude The altitude
+     */
+    void setAltitude( double angle ) { mLightAngle = angle; }
+
+    /**
+     * @brief Set the Z factor of the result image.
+     * @param zfactor The z factor.
+     */
+    void setZFactor( double zfactor ) { mZFactor = zfactor; }
+
+  private:
+    int mBand;
+    double mZFactor;
+    double mLightAngle;
+    double mLightAzimuth;
+
+    /** Calculates the first order derivative in x-direction according to Horn (1981)*/
+    double calcFirstDerX( double x11, double x21, double x31, double x12, double x22, double x32, double x13, double x23, double x33 , double cellsize );
+
+    /** Calculates the first order derivative in y-direction according to Horn (1981)*/
+    double calcFirstDerY( double x11, double x21, double x31, double x12, double x22, double x32, double x13, double x23, double x33 , double cellsize );
+};
+
+#endif // QGSHILLSHADERENDERER_H

--- a/src/core/raster/qgsrasterrendererregistry.cpp
+++ b/src/core/raster/qgsrasterrendererregistry.cpp
@@ -21,6 +21,7 @@
 #include "qgssinglebandcolordatarenderer.h"
 #include "qgssinglebandgrayrenderer.h"
 #include "qgssinglebandpseudocolorrenderer.h"
+#include "qgshillshaderenderer.h"
 #include "qgsapplication.h"
 
 #include <QSettings>
@@ -61,6 +62,8 @@ QgsRasterRendererRegistry::QgsRasterRendererRegistry()
                                           QgsSingleBandPseudoColorRenderer::create, nullptr ) );
   insert( QgsRasterRendererRegistryEntry( "singlebandcolordata", QObject::tr( "Singleband color data" ),
                                           QgsSingleBandColorDataRenderer::create, nullptr ) );
+  insert( QgsRasterRendererRegistryEntry( "hillshade", QObject::tr( "Hillshade renderer" ),
+                                          QgsHillshadeRenderer::create, nullptr ) );
 }
 
 void QgsRasterRendererRegistry::insert( const QgsRasterRendererRegistryEntry& entry )

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -8,6 +8,7 @@ SET(QGIS_GUI_SRCS
   raster/qgssinglebandpseudocolorrendererwidget.cpp
   raster/qgsrendererrasterpropertieswidget.cpp
   raster/qgsrastertransparencywidget.cpp
+  raster/qgshillshaderendererwidget.cpp
   raster/qwt5_histogram_item.cpp
 
   symbology-ng/qgs25drendererwidget.cpp
@@ -440,6 +441,7 @@ SET(QGIS_GUI_MOC_HDRS
   raster/qgssinglebandpseudocolorrendererwidget.h
   raster/qgsrendererrasterpropertieswidget.h
   raster/qgsrastertransparencywidget.h
+  raster/qgshillshaderendererwidget.h
 
   symbology-ng/qgs25drendererwidget.h
   symbology-ng/characterwidget.h

--- a/src/gui/raster/qgshillshaderendererwidget.cpp
+++ b/src/gui/raster/qgshillshaderendererwidget.cpp
@@ -1,0 +1,114 @@
+/***************************************************************************
+                         qgssinglebandgrayrendererwidget.h
+                         ---------------------------------
+    begin                : March 2012
+    copyright            : (C) 2012 by Marco Hugentobler
+    email                : marco at sourcepole dot ch
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgshillshaderendererwidget.h"
+#include "qgsrasterlayer.h"
+#include "qgsbilinearrasterresampler.h"
+#include "qgshillshaderenderer.h"
+
+
+QgsHillshadeRendererWidget::QgsHillshadeRendererWidget( QgsRasterLayer *layer, const QgsRectangle &extent )
+    : QgsRasterRendererWidget( layer, extent )
+{
+  setupUi( this );
+
+  mLightAngle->setMaximum( 90 );
+  mLightAzimuth->setMaximum( 360.00 );
+
+  mLightAngle->setValue( 45.00 );
+  mLightAzimuth->setValue( 315.00 );
+  mZFactor->setValue( 1 );
+
+  if ( mRasterLayer )
+  {
+    QgsRasterDataProvider* provider = mRasterLayer->dataProvider();
+    if ( !provider )
+    {
+      return;
+    }
+
+    //fill available bands into combo box
+    int nBands = provider->bandCount();
+    for ( int i = 1; i <= nBands; ++i ) //band numbering seem to start at 1
+    {
+      mBandsCombo->addItem( displayBandName( i ), i );
+    }
+
+  }
+
+  setFromRenderer( layer->renderer() );
+
+  connect( mLightAngle, SIGNAL( valueChanged( double ) ), this, SIGNAL( widgetChanged() ) );
+  connect( mLightAzimuth, SIGNAL( valueChanged( double ) ), this, SIGNAL( widgetChanged() ) );
+  connect( mZFactor, SIGNAL( valueChanged( double ) ), this, SIGNAL( widgetChanged() ) );
+
+  QgsBilinearRasterResampler* zoomedInResampler = new QgsBilinearRasterResampler();
+  layer->resampleFilter()->setZoomedInResampler( zoomedInResampler );
+
+}
+
+QgsHillshadeRendererWidget::~QgsHillshadeRendererWidget()
+{
+
+}
+
+QgsRasterRenderer *QgsHillshadeRendererWidget::renderer()
+{
+  if ( !mRasterLayer )
+  {
+    return nullptr;
+  }
+
+  QgsRasterDataProvider* provider = mRasterLayer->dataProvider();
+  if ( !provider )
+  {
+    return nullptr;
+  }
+
+  int band = mBandsCombo->itemData( mBandsCombo->currentIndex() ).toInt();
+  QgsHillshadeRenderer* renderer = new QgsHillshadeRenderer( provider, band, mLightAzimuth->value(), mLightAngle->value() );
+  double value = mZFactor->value();
+  renderer->setZFactor( value );
+  return renderer;
+}
+
+void QgsHillshadeRendererWidget::setFromRenderer( const QgsRasterRenderer *renderer )
+{
+  const QgsHillshadeRenderer* r = dynamic_cast<const QgsHillshadeRenderer*>( renderer );
+  if ( r )
+  {
+    mBandsCombo->setCurrentIndex( mBandsCombo->findData( r->band() ) );
+    mLightAngle->setValue( r->Angle() );
+    mLightAzimuth->setValue( r->Azimuth() );
+    mZFactor->setValue( r->zFactor() );
+  }
+}
+
+void QgsHillshadeRendererWidget::setAltitude( double altitude )
+{
+  mLightAngle->setValue( altitude );
+}
+
+void QgsHillshadeRendererWidget::setAzimuth( double azimuth )
+{
+  mLightAzimuth->setValue( azimuth );
+}
+
+void QgsHillshadeRendererWidget::setZFactor( double zfactor )
+{
+  mZFactor->setValue( zfactor );
+}

--- a/src/gui/raster/qgshillshaderendererwidget.h
+++ b/src/gui/raster/qgshillshaderendererwidget.h
@@ -1,0 +1,84 @@
+/***************************************************************************
+                         qgshillshaderendererwidget.h
+                         ---------------------------------
+    begin                : May 2016
+    copyright            : (C) 2016 by Nathan Woodrow
+    email                : woodrow dot nathan at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSHILLSHADERENDERERWIDGET_H
+#define QGSHILLSHADERENDERERWIDGET_H
+
+#include "ui_qghillshaderendererwidget.h"
+
+#include <QDoubleSpinBox>
+
+#include "qgsrasterminmaxwidget.h"
+#include "qgsrasterrendererwidget.h"
+
+/**
+ * @brief Renderer widget for the hill shade renderer.
+ */
+class GUI_EXPORT QgsHillshadeRendererWidget: public QgsRasterRendererWidget, private Ui::QgsHillShadeWidget
+{
+    Q_OBJECT
+  public:
+
+    /**
+     * @brief Renderer widget for the hill shade renderer.
+     * @param layer The layer attached for this widget.
+     * @param extent The current extent.
+     */
+    QgsHillshadeRendererWidget( QgsRasterLayer* layer, const QgsRectangle &extent = QgsRectangle() );
+
+    ~QgsHillshadeRendererWidget();
+
+    /**
+      * Factory method to create the renderer for this type.
+      */
+    static QgsRasterRendererWidget* create( QgsRasterLayer* layer, const QgsRectangle &theExtent ) { return new QgsHillshadeRendererWidget( layer, theExtent ); }
+
+    /**
+     * @brief The renderer for the widget.
+     * @return A new renderer for the the config in the widget
+     */
+    QgsRasterRenderer* renderer() override;
+
+    /**
+     * @brief Set the widget state from the given renderer.
+     * @param r The renderer to take the state from.
+     */
+    void setFromRenderer( const QgsRasterRenderer* renderer );
+
+  public slots:
+    /**
+     * @brief Set the altitude of the light source
+     * @param altitude The altitude
+     */
+    void setAltitude( double altitude );
+
+    /**
+     * @brief Set the azimith of the light source.
+     * @param azimuth The azimuth of the light source.
+     */
+    void setAzimuth( double azimuth );
+
+    /**
+     * @brief Set the Z factor of the result image.
+     * @param zfactor The z factor.
+     */
+    void setZFactor( double zfactor );
+};
+
+#endif // QGSSINGLEBANDGRAYRENDERERWIDGET_H
+
+

--- a/src/gui/raster/qgsrendererrasterpropertieswidget.cpp
+++ b/src/gui/raster/qgsrendererrasterpropertieswidget.cpp
@@ -9,6 +9,7 @@
 #include "qgssinglebandpseudocolorrendererwidget.h"
 #include "qgsmultibandcolorrendererwidget.h"
 #include "qgspalettedrendererwidget.h"
+#include "qgshillshaderendererwidget.h"
 
 
 static void _initRendererWidgetFunctions()
@@ -21,6 +22,7 @@ static void _initRendererWidgetFunctions()
   QgsRasterRendererRegistry::instance()->insertWidgetFunction( "multibandcolor", QgsMultiBandColorRendererWidget::create );
   QgsRasterRendererRegistry::instance()->insertWidgetFunction( "singlebandpseudocolor", QgsSingleBandPseudoColorRendererWidget::create );
   QgsRasterRendererRegistry::instance()->insertWidgetFunction( "singlebandgray", QgsSingleBandGrayRendererWidget::create );
+  QgsRasterRendererRegistry::instance()->insertWidgetFunction( "hillshade", QgsHillshadeRendererWidget::create );
 
   initialized = true;
 }

--- a/src/gui/raster/qgssinglebandgrayrendererwidget.h
+++ b/src/gui/raster/qgssinglebandgrayrendererwidget.h
@@ -22,6 +22,7 @@
 #include "qgsrasterrendererwidget.h"
 #include "ui_qgssinglebandgrayrendererwidgetbase.h"
 
+
 class GUI_EXPORT QgsSingleBandGrayRendererWidget: public QgsRasterRendererWidget, private Ui::QgsSingleBandGrayRendererWidgetBase
 {
     Q_OBJECT

--- a/src/ui/raster/qghillshaderendererwidget.ui
+++ b/src/ui/raster/qghillshaderendererwidget.ui
@@ -1,0 +1,124 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsHillShadeWidget</class>
+ <widget class="QWidget" name="QgsHillShadeWidget">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>302</width>
+    <height>541</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Form</string>
+  </property>
+  <layout class="QGridLayout" name="gridLayout">
+   <item row="2" column="1" colspan="2">
+    <layout class="QVBoxLayout" name="verticalLayout">
+     <item>
+      <widget class="QDial" name="mLightAzimuthDial">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+       <property name="maximum">
+        <number>360</number>
+       </property>
+       <property name="value">
+        <number>135</number>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QDoubleSpinBox" name="mLightAzimuth">
+       <property name="sizePolicy">
+        <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+         <horstretch>0</horstretch>
+         <verstretch>0</verstretch>
+        </sizepolicy>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item row="1" column="0" colspan="2">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Altitude (degrees)</string>
+     </property>
+    </widget>
+   </item>
+   <item row="2" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Azimuth (degrees)</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0" colspan="2">
+    <widget class="QLabel" name="label_3">
+     <property name="text">
+      <string>Z Factor</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="2">
+    <widget class="QDoubleSpinBox" name="mLightAngle">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="singleStep">
+      <double>5.000000000000000</double>
+     </property>
+     <property name="value">
+      <double>45.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0" colspan="3">
+    <spacer name="verticalSpacer">
+     <property name="orientation">
+      <enum>Qt::Vertical</enum>
+     </property>
+     <property name="sizeHint" stdset="0">
+      <size>
+       <width>20</width>
+       <height>40</height>
+      </size>
+     </property>
+    </spacer>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label_4">
+     <property name="text">
+      <string>Band</string>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="2">
+    <widget class="QComboBox" name="mBandsCombo"/>
+   </item>
+   <item row="3" column="2">
+    <widget class="QDoubleSpinBox" name="mZFactor">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <property name="value">
+      <double>1.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <resources/>
+ <connections/>
+</ui>


### PR DESCRIPTION
Adds a live hill shade renderer to the raster renderers

![hillshade](https://cloud.githubusercontent.com/assets/381660/15625980/83f259cc-24fc-11e6-90c3-b0b5e52709cb.gif)

**Note:** The hill shade is rendered as grey the above demo has another raster as a overlay with blending mode enabled.
**Note:** The dial isn't connected yet but it will be before merge or just after.

Thanks to Asger Skovbo Petersen (@AsgerPetersen) for the idea and fixes
