### PR TITLE
Don't cut the filename if he is relative

### DIFF
--- a/src/core/qgslogger.cpp
+++ b/src/core/qgslogger.cpp
@@ -95,7 +95,7 @@ void QgsLogger::debug( const QString& msg, int debuglevel, const char* file, con
     }
 
 #ifndef _MSC_VER
-    m.prepend( file + sPrefixLength );
+    m.prepend( file + ( file[0] == '/' ? sPrefixLength : 0 ) );
 #else
     m.prepend( file );
 #endif


### PR DESCRIPTION
Actually when I do a build I have some logs like this (for the server but I have the same on desktop):

```
nager.cpp: 377: (setupDefaultProxyAndCache) [0ms] setCacheDirectory: //.qgis2//cache
nager.cpp: 378: (setupDefaultProxyAndCache) [0ms] setMaximumCacheSize: 52428800
nager.cpp: 381: (setupDefaultProxyAndCache) [0ms] cacheDirectory: /.qgis2/cache/
nager.cpp: 382: (setupDefaultProxyAndCache) [0ms] maximumCacheSize: 52428800
...
```
