### PR TITLE
[processing] Add SHAPE_ENCODING parameter in GDAL "to postgis" algorithms

### DIFF
--- a/python/plugins/processing/algs/gdal/ogr2ogrtabletopostgislist.py
+++ b/python/plugins/processing/algs/gdal/ogr2ogrtabletopostgislist.py
@@ -44,6 +44,7 @@ class Ogr2OgrTableToPostGisList(GdalAlgorithm):
 
     DATABASE = 'DATABASE'
     INPUT_LAYER = 'INPUT_LAYER'
+    SHAPE_ENCODING = 'SHAPE_ENCODING'
     HOST = 'HOST'
     PORT = 'PORT'
     USER = 'USER'
@@ -76,6 +77,8 @@ class Ogr2OgrTableToPostGisList(GdalAlgorithm):
                                              self.tr('Database (connection name)'), self.DB_CONNECTIONS))
         self.addParameter(ParameterTable(self.INPUT_LAYER,
                                          self.tr('Input layer')))
+        self.addParameter(ParameterString(self.SHAPE_ENCODING,
+                                          self.tr('Shape encoding'), "", optional=True))
         self.addParameter(ParameterString(self.SCHEMA,
                                           self.tr('Schema name'), 'public', optional=True))
         self.addParameter(ParameterString(self.TABLE,
@@ -120,6 +123,7 @@ class Ogr2OgrTableToPostGisList(GdalAlgorithm):
         password = settings.value(mySettings + '/password')
         inLayer = self.getParameterValue(self.INPUT_LAYER)
         ogrLayer = ogrConnectionString(inLayer)[1:-1]
+        shapeEncoding = self.getParameterValue(self.SHAPE_ENCODING)
         schema = unicode(self.getParameterValue(self.SCHEMA))
         table = unicode(self.getParameterValue(self.TABLE))
         pk = unicode(self.getParameterValue(self.PK))
@@ -140,6 +144,10 @@ class Ogr2OgrTableToPostGisList(GdalAlgorithm):
         arguments = []
         arguments.append('-progress')
         arguments.append('--config PG_USE_COPY YES')
+        if len(shapeEncoding) > 0:
+            arguments.append('--config')
+            arguments.append('SHAPE_ENCODING')
+            arguments.append('"' + shapeEncoding + '"')
         arguments.append('-f')
         arguments.append('PostgreSQL')
         arguments.append('PG:"host=')

--- a/python/plugins/processing/algs/gdal/ogr2ogrtopostgis.py
+++ b/python/plugins/processing/algs/gdal/ogr2ogrtopostgis.py
@@ -43,6 +43,7 @@ from processing.tools.vector import ogrConnectionString, ogrLayerName
 class Ogr2OgrToPostGis(GdalAlgorithm):
 
     INPUT_LAYER = 'INPUT_LAYER'
+    SHAPE_ENCODING = 'SHAPE_ENCODING'
     GTYPE = 'GTYPE'
     GEOMTYPE = ['', 'NONE', 'GEOMETRY', 'POINT', 'LINESTRING', 'POLYGON', 'GEOMETRYCOLLECTION', 'MULTIPOINT', 'MULTIPOLYGON', 'MULTILINESTRING']
     S_SRS = 'S_SRS'
@@ -81,6 +82,8 @@ class Ogr2OgrToPostGis(GdalAlgorithm):
         self.group, self.i18n_group = self.trAlgorithm('[OGR] Miscellaneous')
         self.addParameter(ParameterVector(self.INPUT_LAYER,
                                           self.tr('Input layer'), [ParameterVector.VECTOR_TYPE_ANY], False))
+        self.addParameter(ParameterString(self.SHAPE_ENCODING,
+                                          self.tr('Shape encoding'), "", optional=True))
         self.addParameter(ParameterSelection(self.GTYPE,
                                              self.tr('Output geometry type'), self.GEOMTYPE, 0))
         self.addParameter(ParameterCrs(self.A_SRS,
@@ -153,6 +156,7 @@ class Ogr2OgrToPostGis(GdalAlgorithm):
     def getConsoleCommands(self):
         inLayer = self.getParameterValue(self.INPUT_LAYER)
         ogrLayer = ogrConnectionString(inLayer)[1:-1]
+        shapeEncoding = self.getParameterValue(self.SHAPE_ENCODING)
         ssrs = unicode(self.getParameterValue(self.S_SRS))
         tsrs = unicode(self.getParameterValue(self.T_SRS))
         asrs = unicode(self.getParameterValue(self.A_SRS))
@@ -192,6 +196,10 @@ class Ogr2OgrToPostGis(GdalAlgorithm):
         arguments = []
         arguments.append('-progress')
         arguments.append('--config PG_USE_COPY YES')
+        if len(shapeEncoding) > 0:
+            arguments.append('--config')
+            arguments.append('SHAPE_ENCODING')
+            arguments.append('"' + shapeEncoding + '"')
         arguments.append('-f')
         arguments.append('PostgreSQL')
         arguments.append('PG:"host=' + host)

--- a/python/plugins/processing/algs/gdal/ogr2ogrtopostgislist.py
+++ b/python/plugins/processing/algs/gdal/ogr2ogrtopostgislist.py
@@ -47,6 +47,7 @@ class Ogr2OgrToPostGisList(GdalAlgorithm):
 
     DATABASE = 'DATABASE'
     INPUT_LAYER = 'INPUT_LAYER'
+    SHAPE_ENCODING = 'SHAPE_ENCODING'
     GTYPE = 'GTYPE'
     GEOMTYPE = ['', 'NONE', 'GEOMETRY', 'POINT', 'LINESTRING', 'POLYGON', 'GEOMETRYCOLLECTION', 'MULTIPOINT', 'MULTIPOLYGON', 'MULTILINESTRING']
     S_SRS = 'S_SRS'
@@ -93,6 +94,8 @@ class Ogr2OgrToPostGisList(GdalAlgorithm):
                                              self.tr('Database (connection name)'), self.DB_CONNECTIONS))
         self.addParameter(ParameterVector(self.INPUT_LAYER,
                                           self.tr('Input layer'), [ParameterVector.VECTOR_TYPE_ANY], False))
+        self.addParameter(ParameterString(self.SHAPE_ENCODING,
+                                          self.tr('Shape encoding'), "", optional=True))
         self.addParameter(ParameterSelection(self.GTYPE,
                                              self.tr('Output geometry type'), self.GEOMTYPE, 0))
         self.addParameter(ParameterCrs(self.A_SRS,
@@ -164,6 +167,7 @@ class Ogr2OgrToPostGisList(GdalAlgorithm):
         password = settings.value(mySettings + '/password')
         inLayer = self.getParameterValue(self.INPUT_LAYER)
         ogrLayer = ogrConnectionString(inLayer)[1:-1]
+        shapeEncoding = self.getParameterValue(self.SHAPE_ENCODING)
         ssrs = unicode(self.getParameterValue(self.S_SRS))
         tsrs = unicode(self.getParameterValue(self.T_SRS))
         asrs = unicode(self.getParameterValue(self.A_SRS))
@@ -198,6 +202,10 @@ class Ogr2OgrToPostGisList(GdalAlgorithm):
         arguments = []
         arguments.append('-progress')
         arguments.append('--config PG_USE_COPY YES')
+        if len(shapeEncoding) > 0:
+            arguments.append('--config')
+            arguments.append('SHAPE_ENCODING')
+            arguments.append('"' + shapeEncoding + '"')
         arguments.append('-f')
         arguments.append('PostgreSQL')
         arguments.append('PG:"host=' + host)


### PR DESCRIPTION
In GDAL algorithms, if the input layer is a shapefile and no selection is set on the layer, the source shapefile is used. In other case, a new temporary shapefile should be created with encoding get from in QSettings.value('/UI/encoding', 'System'). 
Qt encoding names are not the same as GDAL / OGR ones.
GDAL / OGR supported encoding should depend on GDAL version, distro, compilation options.

It seems difficult to propose a default value of list of values here. Best choice seems to give the user a chance to set the shape encoding if he encounter an error and he knows what is the source file encoding.
