### PR TITLE
allow to lock scale to use magnification to zoom in/out

### DIFF
--- a/python/core/qgsmaprenderer.sip
+++ b/python/core/qgsmaprenderer.sip
@@ -184,7 +184,7 @@ class QgsMapRenderer : QObject
     //! sets whether map image will be for overview
     void enableOverviewMode( bool isOverview = true );
 
-    void setOutputSize( QSize size, int dpi );
+    void setOutputSize( QSize size, double dpi );
     void setOutputSize( QSizeF size, double dpi );
 
     //!accessor for output dpi

--- a/python/core/qgsmapsettings.sip
+++ b/python/core/qgsmapsettings.sip
@@ -39,10 +39,15 @@ class QgsMapSettings
     //! Set DPI used for conversion between real world units (e.g. mm) and pixels
     void setOutputDpi( int dpi );
 
-    //! Set the magnification factor.
-    //! @note added in 2.16
-    void setMagnificationFactor( double factor );
-    //! Return the magnification factor.
+
+    /**
+     * @brief setMagnificationFactor set the magnification factor
+     * @param factor the factor of magnification
+     * @note added in 2.16
+     */
+   void setMagnificationFactor( double factor );
+
+   //! Return the magnification factor.
     //! @note added in 2.16
    double magnificationFactor() const;
 

--- a/python/core/qgsmapsettings.sip
+++ b/python/core/qgsmapsettings.sip
@@ -35,9 +35,9 @@ class QgsMapSettings
 
     //! Return DPI used for conversion between real world units (e.g. mm) and pixels
     //! Default value is 96
-    int outputDpi() const;
+    double outputDpi() const;
     //! Set DPI used for conversion between real world units (e.g. mm) and pixels
-    void setOutputDpi( int dpi );
+    void setOutputDpi( double dpi );
 
 
     /**

--- a/python/gui/qgsmapcanvas.sip
+++ b/python/gui/qgsmapcanvas.sip
@@ -279,7 +279,11 @@ class QgsMapCanvas : QGraphicsView
     QgsMapLayer* currentLayer();
 
     //! set wheel action and zoom factor (should be greater than 1)
+    //! @deprecated
     void setWheelAction( WheelAction action, double factor = 2 );
+
+    //! set the wheel zoom factor
+    void setWheelFactor( double factor );
 
     //! Zoom in with fixed factor
     void zoomIn();

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -52,6 +52,7 @@ SET(QGIS_APP_SRCS
   qgssavestyletodbdialog.cpp
   qgsstatusbarcoordinateswidget.cpp
   qgsstatusbarmagnifierwidget.cpp
+  qgsstatusbarscalewidget.cpp
   qgsversioninfo.cpp
   qgswelcomepageitemsmodel.cpp
   qgswelcomepage.cpp
@@ -231,6 +232,7 @@ SET (QGIS_APP_MOC_HDRS
   qgsshortcutsmanager.h
   qgsstatusbarcoordinateswidget.h
   qgsstatusbarmagnifierwidget.h
+  qgsstatusbarscalewidget.h
   qgsversioninfo.h
   qgswelcomepageitemsmodel.h
   qgswelcomepage.h

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -46,6 +46,7 @@ class QgsComposerManager;
 class QgsComposerView;
 class QgsStatusBarCoordinatesWidget;
 class QgsStatusBarMagnifierWidget;
+class QgsStatusBarScaleWidget;
 class QgsContrastEnhancement;
 class QgsCustomLayerOrderWidget;
 class QgsDoubleSpinBox;
@@ -89,8 +90,6 @@ class QgsDecorationItem;
 
 class QgsMessageLogViewer;
 class QgsMessageBar;
-
-class QgsScaleComboBox;
 
 class QgsDataItem;
 class QgsTileScaleWidget;
@@ -736,8 +735,6 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     void saveLastMousePosition( const QgsPoint & );
     //! Slot to show current map scale;
     void showScale( double theScale );
-    //! Slot to handle user scale input;
-    void userScale();
     //! Slot to handle user rotation input;
     //! @note added in 2.8
     void userRotation();
@@ -1589,12 +1586,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     QgsMapTool *mNonEditMapTool;
 
-    //! Widget that will live on the statusbar to display "scale 1:"
-    QLabel *mScaleLabel;
-    //! Widget that will live on the statusbar to display scale value
-    QgsScaleComboBox *mScaleEdit;
-    //! The validator for the mScaleEdit
-    QValidator * mScaleEditValidator;
+    QgsStatusBarScaleWidget* mScaleWidget;
 
     //! zoom widget
     QgsStatusBarMagnifierWidget *mMagnifierWidget;

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -607,11 +607,14 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl )
   mSimplifyMaximumScaleComboBox->setScale( 1.0 / mSettings->value( "/qgis/simplifyMaxScale", 1 ).toFloat() );
 
   // Magnifier
-  doubleSpinBoxMagnifierDefault->setRange( 100, 1000 );
+  double magnifierMin = 100 * mSettings->value( "/qgis/magnifier_factor_min", 0.1 ).toDouble();
+  double magnifierMax = 100 * mSettings->value( "/qgis/magnifier_factor_max", 10 ).toDouble();
+  double magnifierVal = 100 * mSettings->value( "/qgis/magnifier_factor_default", 1.0 ).toDouble();
+  doubleSpinBoxMagnifierDefault->setRange( magnifierMin, magnifierMax );
   doubleSpinBoxMagnifierDefault->setSingleStep( 50 );
   doubleSpinBoxMagnifierDefault->setDecimals( 0 );
   doubleSpinBoxMagnifierDefault->setSuffix( "%" );
-  doubleSpinBoxMagnifierDefault->setValue( mSettings->value( "/qgis/magnifier_level", 100 ).toInt() );
+  doubleSpinBoxMagnifierDefault->setValue( magnifierVal );
 
   // Default local simplification algorithm
   mSimplifyAlgorithmComboBox->addItem( tr( "Distance" ), ( int )QgsVectorSimplifyMethod::Distance );
@@ -731,7 +734,6 @@ QgsOptions::QgsOptions( QWidget *parent, Qt::WindowFlags fl )
   }
   leTemplateFolder->setText( templateDirName );
 
-  cmbWheelAction->setCurrentIndex( mSettings->value( "/qgis/wheel_action", 2 ).toInt() );
   spinZoomFactor->setValue( mSettings->value( "/qgis/zoom_factor", 2 ).toDouble() );
 
   // predefined scales for scale combobox
@@ -1224,7 +1226,7 @@ void QgsOptions::saveOptions()
   mSettings->setValue( "/qgis/simplifyMaxScale", 1.0 / mSimplifyMaximumScaleComboBox->scale() );
 
   // magnification
-  mSettings->setValue( "/qgis/magnifier_level", doubleSpinBoxMagnifierDefault->value() );
+  mSettings->setValue( "/qgis/magnifier_factor_default", doubleSpinBoxMagnifierDefault->value() / 100 );
 
   //curve segmentation
   int segmentationType = mToleranceTypeComboBox->itemData( mToleranceTypeComboBox->currentIndex() ).toInt();
@@ -1341,7 +1343,6 @@ void QgsOptions::saveOptions()
   mSettings->setValue( "/qgis/default_measure_color_green", myColor.green() );
   mSettings->setValue( "/qgis/default_measure_color_blue", myColor.blue() );
 
-  mSettings->setValue( "/qgis/wheel_action", cmbWheelAction->currentIndex() );
   mSettings->setValue( "/qgis/zoom_factor", spinZoomFactor->value() );
 
   //digitizing

--- a/src/app/qgsstatusbarmagnifierwidget.cpp
+++ b/src/app/qgsstatusbarmagnifierwidget.cpp
@@ -17,19 +17,20 @@
 #include <QFont>
 #include <QHBoxLayout>
 #include <QLabel>
+#include <QSettings>
 
 #include <qgsapplication.h>
 #include "qgsstatusbarmagnifierwidget.h"
-#include "qgsmapcanvas.h"
 #include "qgsdoublespinbox.h"
 
-QgsStatusBarMagnifierWidget::QgsStatusBarMagnifierWidget(QgsMapCanvas *canvas, QWidget* parent) :
-    QWidget( parent ),
-    mCanvas( canvas ),
-    mMagnifier( 100 ),
-    mMagnifierMin( 100 ),
-    mMagnifierMax( 1000 )
+QgsStatusBarMagnifierWidget::QgsStatusBarMagnifierWidget( QWidget* parent ) :
+    QWidget( parent )
 {
+  QSettings settings;
+  int minimumFactor = ( int ) 100 * settings.value( "/qgis/magnifier_factor_min", 0.1 ).toDouble();
+  int maximumFactor = ( int ) 100 * settings.value( "/qgis/magnifier_factor_max", 10 ).toDouble();
+  int defaultFactor = ( int ) 100 * settings.value( "/qgis/magnifier_factor_default", 1.0 ).toDouble();
+
   // label
   mLabel = new QLabel( this );
   mLabel->setMinimumWidth( 10 );
@@ -41,17 +42,17 @@ QgsStatusBarMagnifierWidget::QgsStatusBarMagnifierWidget(QgsMapCanvas *canvas, Q
 
   mSpinBox = new QgsDoubleSpinBox( this );
   mSpinBox->setSuffix( "%" );
-  mSpinBox->setClearValue( mMagnifierMin );
   mSpinBox->setKeyboardTracking( false );
   mSpinBox->setMaximumWidth( 120 );
   mSpinBox->setDecimals( 0 );
-  mSpinBox->setRange( mMagnifierMin, mMagnifierMax );
+  mSpinBox->setRange( minimumFactor, maximumFactor );
   mSpinBox->setWrapping( false );
   mSpinBox->setSingleStep( 50 );
   mSpinBox->setToolTip( tr( "Magnifier level" ) );
+  mSpinBox->setClearValueMode( QgsDoubleSpinBox::CustomValue );
+  mSpinBox->setClearValue( defaultFactor );
 
-  connect( mSpinBox, SIGNAL( valueChanged( double ) ), this,
-           SLOT( updateMagnifier() ) );
+  connect( mSpinBox, SIGNAL( valueChanged( double ) ), this, SLOT( setMagnification( double ) ) );
 
   // layout
   mLayout = new QHBoxLayout( this );
@@ -62,17 +63,15 @@ QgsStatusBarMagnifierWidget::QgsStatusBarMagnifierWidget(QgsMapCanvas *canvas, Q
   mLayout->setSpacing( 0 );
 
   setLayout( mLayout );
-
-  updateMagnifier();
 }
 
 QgsStatusBarMagnifierWidget::~QgsStatusBarMagnifierWidget()
 {
 }
 
-double QgsStatusBarMagnifierWidget::magnificationLevel()
+void QgsStatusBarMagnifierWidget::setDefaultFactor( double factor )
 {
-  return mMagnifier;
+  mSpinBox->setClearValue(( int )100*factor );
 }
 
 void QgsStatusBarMagnifierWidget::setFont( const QFont& myFont )
@@ -81,24 +80,12 @@ void QgsStatusBarMagnifierWidget::setFont( const QFont& myFont )
   mSpinBox->setFont( myFont );
 }
 
-bool QgsStatusBarMagnifierWidget::setMagnificationLevel( int level )
+void QgsStatusBarMagnifierWidget::updateMagnification( double factor )
 {
-  bool rc = false;
-
-  if ( level >= mMagnifierMin && level <= mMagnifierMax )
-  {
-    mSpinBox->setValue( level );
-    rc = true;
-  }
-
-  return rc;
+  mSpinBox->setValue( factor * 100 );
 }
 
-void QgsStatusBarMagnifierWidget::updateMagnifier()
+void QgsStatusBarMagnifierWidget::setMagnification( double value )
 {
-  // get current data
-  mMagnifier = mSpinBox->value();
-
-  // update map canvas
-  mCanvas->setMagnificationFactor( mMagnifier / double( mMagnifierMin ) );
+  emit magnificationChanged( value / 100 );
 }

--- a/src/app/qgsstatusbarmagnifierwidget.cpp
+++ b/src/app/qgsstatusbarmagnifierwidget.cpp
@@ -23,8 +23,7 @@
 #include "qgsmapcanvas.h"
 #include "qgsdoublespinbox.h"
 
-QgsStatusBarMagnifierWidget::QgsStatusBarMagnifierWidget( QWidget* parent,
-    QgsMapCanvas *canvas ) :
+QgsStatusBarMagnifierWidget::QgsStatusBarMagnifierWidget(QgsMapCanvas *canvas, QWidget* parent) :
     QWidget( parent ),
     mCanvas( canvas ),
     mMagnifier( 100 ),

--- a/src/app/qgsstatusbarmagnifierwidget.h
+++ b/src/app/qgsstatusbarmagnifierwidget.h
@@ -20,7 +20,6 @@
 class QLabel;
 class QFont;
 class QHBoxLayout;
-class QgsMapCanvas;
 class QgsDoubleSpinBox;
 
 #include <QWidget>
@@ -40,39 +39,36 @@ class APP_EXPORT QgsStatusBarMagnifierWidget : public QWidget
       * @param parent is the parent widget
       * @param canvas the map canvas
       */
-    QgsStatusBarMagnifierWidget( QgsMapCanvas *canvas, QWidget* parent = 0 );
+    QgsStatusBarMagnifierWidget( QWidget* parent = 0 );
 
     /** Destructor */
     virtual ~QgsStatusBarMagnifierWidget();
+
+    void setDefaultFactor( double factor );
 
     /** Set the font of the text
       * @param font the font to use
       */
     void setFont( const QFont& font );
 
-    /** Returns the current magnification level
-      * @return magnification level
-      */
-    double magnificationLevel();
 
-    /** Set the magnification level
-      * @param level the magnification level
-      * @return true if the level is valid, false otherwise
-      */
-    bool setMagnificationLevel( int level );
+  public slots:
+    //! will be triggered from map canvas changes (from mouse wheel, zoom)
+    void updateMagnification( double factor );
+
 
   private slots:
+    //! will be triggered form user input in spin box
+    void setMagnification( double value );
 
-    void updateMagnifier();
+  signals:
+    void magnificationChanged( double factor );
+
 
   private:
-    QgsMapCanvas *mCanvas;
     QHBoxLayout *mLayout;
     QLabel *mLabel;
     QgsDoubleSpinBox *mSpinBox;
-    int mMagnifier;
-    int mMagnifierMin;
-    int mMagnifierMax;
 };
 
 #endif

--- a/src/app/qgsstatusbarmagnifierwidget.h
+++ b/src/app/qgsstatusbarmagnifierwidget.h
@@ -40,7 +40,7 @@ class APP_EXPORT QgsStatusBarMagnifierWidget : public QWidget
       * @param parent is the parent widget
       * @param canvas the map canvas
       */
-    QgsStatusBarMagnifierWidget( QWidget* parent, QgsMapCanvas *canvas );
+    QgsStatusBarMagnifierWidget( QgsMapCanvas *canvas, QWidget* parent = 0 );
 
     /** Destructor */
     virtual ~QgsStatusBarMagnifierWidget();

--- a/src/app/qgsstatusbarscalewidget.cpp
+++ b/src/app/qgsstatusbarscalewidget.cpp
@@ -17,6 +17,7 @@
 #include <QHBoxLayout>
 #include <QLabel>
 #include <QLineEdit>
+#include <QToolButton>
 #include <QValidator>
 
 #include "qgsstatusbarscalewidget.h"
@@ -24,61 +25,75 @@
 #include "qgsmapcanvas.h"
 #include "qgsscalecombobox.h"
 
-QgsStatusBarScaleWidget::QgsStatusBarScaleWidget(QgsMapCanvas *canvas, QWidget *parent)
-    : QWidget(parent)
+QgsStatusBarScaleWidget::QgsStatusBarScaleWidget( QgsMapCanvas *canvas, QWidget *parent )
+    : QWidget( parent )
     , mMapCanvas( canvas )
 {
-    // add a label to show current scale
-    mLabel = new QLabel( QString(), this );
-    mLabel->setObjectName( "mScaleLable" );
-    mLabel->setMinimumWidth( 10 );
-    //mScaleLabel->setMaximumHeight( 20 );
-    mLabel->setMargin( 3 );
-    mLabel->setAlignment( Qt::AlignCenter );
-    mLabel->setFrameStyle( QFrame::NoFrame );
-    mLabel->setText( tr( "Scale" ) );
-    mLabel->setToolTip( tr( "Current map scale" ) );
+  // add a label to show current scale
+  mLabel = new QLabel( QString(), this );
+  mLabel->setObjectName( "mScaleLable" );
+  mLabel->setMinimumWidth( 10 );
+  //mScaleLabel->setMaximumHeight( 20 );
+  mLabel->setMargin( 3 );
+  mLabel->setAlignment( Qt::AlignCenter );
+  mLabel->setFrameStyle( QFrame::NoFrame );
+  mLabel->setText( tr( "Scale" ) );
+  mLabel->setToolTip( tr( "Current map scale" ) );
 
-    mScale = new QgsScaleComboBox( this );
-    mScale->setObjectName( "mScaleEdit" );
-    // seems setFont() change font only for popup not for line edit,
-    // so we need to set font for it separately
-    mScale->setMinimumWidth( 10 );
-    mScale->setContentsMargins( 0, 0, 0, 0 );
-    mScale->setWhatsThis( tr( "Displays the current map scale" ) );
-    mScale->setToolTip( tr( "Current map scale (formatted as x:y)" ) );
+  mScale = new QgsScaleComboBox( this );
+  mScale->setObjectName( "mScaleEdit" );
+  // seems setFont() change font only for popup not for line edit,
+  // so we need to set font for it separately
+  mScale->setMinimumWidth( 10 );
+  mScale->setContentsMargins( 0, 0, 0, 0 );
+  mScale->setWhatsThis( tr( "Displays the current map scale" ) );
+  mScale->setToolTip( tr( "Current map scale (formatted as x:y)" ) );
 
-    // layout
-    mLayout = new QHBoxLayout( this );
-    mLayout->addWidget( mLabel );
-    mLayout->addWidget( mScale );
-    mLayout->setContentsMargins( 0, 0, 0, 0 );
-    mLayout->setAlignment( Qt::AlignRight );
-    mLayout->setSpacing( 0 );
+  mLockButton = new QToolButton( this );
+  mLockButton->setIcon( QIcon( QgsApplication::getThemeIcon( "/locked.svg" ) ) );
+  mLockButton->setToolTip( tr( "Lock the scale to use magnifier to zoom in or out." ) );
+  mLockButton->setCheckable( true );
+  mLockButton->setChecked( false );
 
-    setLayout( mLayout );
+  // layout
+  mLayout = new QHBoxLayout( this );
+  mLayout->addWidget( mLabel );
+  mLayout->addWidget( mScale );
+  mLayout->addWidget( mLockButton );
+  mLayout->setContentsMargins( 0, 0, 0, 0 );
+  mLayout->setAlignment( Qt::AlignRight );
+  mLayout->setSpacing( 0 );
 
-    connect( mScale, SIGNAL( scaleChanged( double ) ), this, SLOT( userScale() ) );
+  setLayout( mLayout );
+
+  connect( mScale, SIGNAL( scaleChanged( double ) ), this, SLOT( userScale() ) );
+
+  connect( mLockButton, SIGNAL( toggled( bool ) ), this, SIGNAL( scaleLockChanged( bool ) ) );
 }
 
 QgsStatusBarScaleWidget::~QgsStatusBarScaleWidget()
 {
 }
 
-void QgsStatusBarScaleWidget::setScale(double scale)
+void QgsStatusBarScaleWidget::setScale( double scale )
 {
-    mScale->setScale(scale);
+  mScale->setScale( scale );
 }
 
-void QgsStatusBarScaleWidget::setFont(const QFont &font)
+bool QgsStatusBarScaleWidget::isLocked()
 {
-    mLabel->setFont( font );
-    mScale->lineEdit()->setFont( font );
+  return mLockButton->isChecked();
 }
 
-void QgsStatusBarScaleWidget::updateScales(const QStringList &scales)
+void QgsStatusBarScaleWidget::setFont( const QFont &font )
 {
-    mScale->updateScales(scales);
+  mLabel->setFont( font );
+  mScale->lineEdit()->setFont( font );
+}
+
+void QgsStatusBarScaleWidget::updateScales( const QStringList &scales )
+{
+  mScale->updateScales( scales );
 }
 
 void QgsStatusBarScaleWidget::userScale()

--- a/src/app/qgsstatusbarscalewidget.cpp
+++ b/src/app/qgsstatusbarscalewidget.cpp
@@ -1,0 +1,88 @@
+/***************************************************************************
+                         qgsstatusbarscalewidget.cpp
+    begin                : May 2016
+    copyright            : (C) 2016 Denis Rouzaud
+    email                : denis.rouzaud@gmail.com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include <QHBoxLayout>
+#include <QLabel>
+#include <QLineEdit>
+#include <QValidator>
+
+#include "qgsstatusbarscalewidget.h"
+
+#include "qgsmapcanvas.h"
+#include "qgsscalecombobox.h"
+
+QgsStatusBarScaleWidget::QgsStatusBarScaleWidget(QgsMapCanvas *canvas, QWidget *parent)
+    : QWidget(parent)
+    , mMapCanvas( canvas )
+{
+    // add a label to show current scale
+    mLabel = new QLabel( QString(), this );
+    mLabel->setObjectName( "mScaleLable" );
+    mLabel->setMinimumWidth( 10 );
+    //mScaleLabel->setMaximumHeight( 20 );
+    mLabel->setMargin( 3 );
+    mLabel->setAlignment( Qt::AlignCenter );
+    mLabel->setFrameStyle( QFrame::NoFrame );
+    mLabel->setText( tr( "Scale" ) );
+    mLabel->setToolTip( tr( "Current map scale" ) );
+
+    mScale = new QgsScaleComboBox( this );
+    mScale->setObjectName( "mScaleEdit" );
+    // seems setFont() change font only for popup not for line edit,
+    // so we need to set font for it separately
+    mScale->setMinimumWidth( 10 );
+    mScale->setContentsMargins( 0, 0, 0, 0 );
+    mScale->setWhatsThis( tr( "Displays the current map scale" ) );
+    mScale->setToolTip( tr( "Current map scale (formatted as x:y)" ) );
+
+    // layout
+    mLayout = new QHBoxLayout( this );
+    mLayout->addWidget( mLabel );
+    mLayout->addWidget( mScale );
+    mLayout->setContentsMargins( 0, 0, 0, 0 );
+    mLayout->setAlignment( Qt::AlignRight );
+    mLayout->setSpacing( 0 );
+
+    setLayout( mLayout );
+
+    connect( mScale, SIGNAL( scaleChanged( double ) ), this, SLOT( userScale() ) );
+}
+
+QgsStatusBarScaleWidget::~QgsStatusBarScaleWidget()
+{
+}
+
+void QgsStatusBarScaleWidget::setScale(double scale)
+{
+    mScale->setScale(scale);
+}
+
+void QgsStatusBarScaleWidget::setFont(const QFont &font)
+{
+    mLabel->setFont( font );
+    mScale->lineEdit()->setFont( font );
+}
+
+void QgsStatusBarScaleWidget::updateScales(const QStringList &scales)
+{
+    mScale->updateScales(scales);
+}
+
+void QgsStatusBarScaleWidget::userScale()
+{
+  // Why has MapCanvas the scale inverted?
+  mMapCanvas->zoomScale( 1.0 / mScale->scale() );
+}

--- a/src/app/qgsstatusbarscalewidget.h
+++ b/src/app/qgsstatusbarscalewidget.h
@@ -1,0 +1,72 @@
+/***************************************************************************
+                         qgsstatusbarscalewidget.h
+    begin                : May 2016
+    copyright            : (C) 2016 Denis Rouzaud
+    email                : denis.rouzaud@gmail.com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSSTATUSBARSCALEWIDGET_H
+#define QGSSTATUSBARSCALEWIDGET_H
+
+class QFont;
+class QHBoxLayout;
+class QLabel;
+class QValidator;
+
+class QgsMapCanvas;
+class QgsScaleComboBox;
+
+
+#include <QWidget>
+
+/**
+  * Widget to define scale of the map canvas.
+  * @note added in 2.16
+  */
+class APP_EXPORT QgsStatusBarScaleWidget : public QWidget
+{
+    Q_OBJECT
+public:
+    explicit QgsStatusBarScaleWidget(QgsMapCanvas* canvas, QWidget *parent = 0);
+
+    /** Destructor */
+    virtual ~QgsStatusBarScaleWidget();
+
+    /**
+     * @brief setScale set the selected scale from double
+     * @param scale
+     */
+    void setScale( double scale );
+
+    /** Set the font of the text
+      * @param font the font to use
+      */
+    void setFont( const QFont& font );
+
+public slots:
+  void updateScales( const QStringList &scales = QStringList() );
+
+private slots:
+    void userScale();
+private:
+    QgsMapCanvas* mMapCanvas;
+    QHBoxLayout *mLayout;
+
+    //! Widget that will live on the statusbar to display "scale 1:"
+    QLabel* mLabel;
+    //! Widget that will live on the statusbar to display scale value
+    QgsScaleComboBox* mScale;
+    //! The validator for the mScaleEdit
+    QValidator* mScaleEditValidator;
+};
+
+#endif // QGSSTATUSBARSCALEWIDGET_H

--- a/src/app/qgsstatusbarscalewidget.h
+++ b/src/app/qgsstatusbarscalewidget.h
@@ -20,6 +20,7 @@
 class QFont;
 class QHBoxLayout;
 class QLabel;
+class QToolButton;
 class QValidator;
 
 class QgsMapCanvas;
@@ -35,8 +36,8 @@ class QgsScaleComboBox;
 class APP_EXPORT QgsStatusBarScaleWidget : public QWidget
 {
     Q_OBJECT
-public:
-    explicit QgsStatusBarScaleWidget(QgsMapCanvas* canvas, QWidget *parent = 0);
+  public:
+    explicit QgsStatusBarScaleWidget( QgsMapCanvas* canvas, QWidget *parent = 0 );
 
     /** Destructor */
     virtual ~QgsStatusBarScaleWidget();
@@ -47,19 +48,30 @@ public:
      */
     void setScale( double scale );
 
+    /**
+     * @brief isLocked check if the scale should be locked to use magnifier instead of scale to zoom in/out
+     * @return True if the scale shall be locked
+     */
+    bool isLocked();
+
     /** Set the font of the text
       * @param font the font to use
       */
     void setFont( const QFont& font );
 
-public slots:
-  void updateScales( const QStringList &scales = QStringList() );
+  public slots:
+    void updateScales( const QStringList &scales = QStringList() );
 
-private slots:
+  private slots:
     void userScale();
-private:
+
+  signals:
+    void scaleLockChanged( bool );
+
+  private:
     QgsMapCanvas* mMapCanvas;
     QHBoxLayout *mLayout;
+    QToolButton* mLockButton;
 
     //! Widget that will live on the statusbar to display "scale 1:"
     QLabel* mLabel;

--- a/src/core/qgsmaprenderer.cpp
+++ b/src/core/qgsmaprenderer.cpp
@@ -138,7 +138,7 @@ double QgsMapRenderer::rotation() const
 }
 
 
-void QgsMapRenderer::setOutputSize( QSize size, int dpi )
+void QgsMapRenderer::setOutputSize( QSize size, double dpi )
 {
   mSize = QSizeF( size.width(), size.height() );
   mScaleCalculator->setDpi( dpi );

--- a/src/core/qgsmaprenderer.h
+++ b/src/core/qgsmaprenderer.h
@@ -247,7 +247,7 @@ class CORE_EXPORT QgsMapRenderer : public QObject
     //! sets whether map image will be for overview
     void enableOverviewMode( bool isOverview = true ) { mOverview = isOverview; }
 
-    void setOutputSize( QSize size, int dpi );
+    void setOutputSize( QSize size, double dpi );
     void setOutputSize( QSizeF size, double dpi );
 
     //!accessor for output dpi

--- a/src/core/qgsmapsettings.cpp
+++ b/src/core/qgsmapsettings.cpp
@@ -59,6 +59,7 @@ QgsMapSettings::QgsMapSettings()
 void QgsMapSettings::setMagnificationFactor( double factor )
 {
   double ratio = mMagnificationFactor / factor;
+
   mMagnificationFactor = factor;
 
   double rot = rotation();
@@ -69,7 +70,9 @@ void QgsMapSettings::setMagnificationFactor( double factor )
 
   mRotation = rot;
   mExtent = ext;
-  mDpi = outputDpi() / ratio;
+  mDpi = mDpi / ratio;
+
+  QgsDebugMsg( QString( "Magnification factor: %1  dpi: %2  ratio: %3" ).arg( factor ).arg( mDpi ).arg( ratio ) );
 
   updateDerived();
 }
@@ -240,7 +243,7 @@ void QgsMapSettings::setOutputSize( QSize size )
 
 int QgsMapSettings::outputDpi() const
 {
-  return mDpi;
+  return ( int )mDpi;
 }
 
 void QgsMapSettings::setOutputDpi( int dpi )

--- a/src/core/qgsmapsettings.cpp
+++ b/src/core/qgsmapsettings.cpp
@@ -241,12 +241,12 @@ void QgsMapSettings::setOutputSize( QSize size )
   updateDerived();
 }
 
-int QgsMapSettings::outputDpi() const
+double QgsMapSettings::outputDpi() const
 {
-  return ( int )mDpi;
+  return mDpi;
 }
 
-void QgsMapSettings::setOutputDpi( int dpi )
+void QgsMapSettings::setOutputDpi( double dpi )
 {
   mDpi = dpi;
 

--- a/src/core/qgsmapsettings.h
+++ b/src/core/qgsmapsettings.h
@@ -83,12 +83,17 @@ class CORE_EXPORT QgsMapSettings
 
     //! Return DPI used for conversion between real world units (e.g. mm) and pixels
     //! Default value is 96
+    //! TODO QGIS 3 return double ?
     int outputDpi() const;
     //! Set DPI used for conversion between real world units (e.g. mm) and pixels
     void setOutputDpi( int dpi );
 
-    //! Set the magnification factor.
-    //! @note added in 2.16
+    /**
+     * @brief setMagnificationFactor set the magnification factor
+     * @param factor the factor of magnification
+     * @param factorChanged defines if it actually changed in the map settings
+     * @note added in 2.16
+     */
     void setMagnificationFactor( double factor );
     //! Return the magnification factor.
     //! @note added in 2.16
@@ -273,7 +278,7 @@ class CORE_EXPORT QgsMapSettings
 
   protected:
 
-    int mDpi;
+    double mDpi;
 
     QSize mSize;
 

--- a/src/core/qgsmapsettings.h
+++ b/src/core/qgsmapsettings.h
@@ -83,10 +83,9 @@ class CORE_EXPORT QgsMapSettings
 
     //! Return DPI used for conversion between real world units (e.g. mm) and pixels
     //! Default value is 96
-    //! TODO QGIS 3 return double ?
-    int outputDpi() const;
+    double outputDpi() const;
     //! Set DPI used for conversion between real world units (e.g. mm) and pixels
-    void setOutputDpi( int dpi );
+    void setOutputDpi( double dpi );
 
     /**
      * @brief setMagnificationFactor set the magnification factor

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -111,6 +111,7 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
 
   public:
 
+    //TODO QGIS 3 remove this
     enum WheelAction { WheelZoom, WheelZoomAndRecenter, WheelZoomToMouseCursor, WheelNothing };
 
     //! Constructor
@@ -118,12 +119,6 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
 
     //! Destructor
     ~QgsMapCanvas();
-
-    //! Sets the factor of magnification to apply to the map canvas. Indeed, we
-    //! increase/decrease the DPI of the map settings according to this factor
-    //! in order to render marker point, labels, ... bigger.
-    //! @note added in 2.16
-    void setMagnificationFactor( double level );
 
     //! Returns the magnification factor
     //! @note added in 2.16
@@ -348,7 +343,11 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     QgsMapLayer* currentLayer();
 
     //! set wheel action and zoom factor (should be greater than 1)
+    //! @deprecated No more options for wheel action
     void setWheelAction( WheelAction action, double factor = 2 );
+
+    //! set wheel zoom factor (should be greater than 1)
+    void setWheelFactor( double factor );
 
     //! Zoom in with fixed factor
     void zoomIn();
@@ -365,6 +364,8 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
 
     //! Zooms in/out with a given center
     void zoomWithCenter( int x, int y, bool zoomIn );
+
+    bool scaleLocked() { return mScaleLocked;}
 
     //! used to determine if anti-aliasing is enabled or not
     void enableAntiAliasing( bool theFlag );
@@ -521,6 +522,15 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     //! @note added in 2.8
     static void enableRotation( bool enabled );
 
+    //! Sets the factor of magnification to apply to the map canvas. Indeed, we
+    //! increase/decrease the DPI of the map settings according to this factor
+    //! in order to render marker point, labels, ... bigger.
+    //! @note added in 2.16
+    void setMagnificationFactor( double factor );
+
+    //! lock the scale, so zooming can be performed using magnication
+    //! @note added in 2.16
+    void setScaleLocked( bool isLocked );
 
   private slots:
     //! called when current maptool is destroyed
@@ -551,6 +561,10 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     //! Emitted when the rotation of the map changes
     //! @note added in 2.8
     void rotationChanged( double );
+
+    //! Emitted when the scale of the map changes
+    //! @note added in 2.16
+    void magnificationChanged( double );
 
     /** Emitted when the canvas has rendered.
      * Passes a pointer to the painter on which the map was drawn. This is
@@ -733,14 +747,8 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     //! Scale factor multiple for default zoom in/out
     double mWheelZoomFactor;
 
-    //! Mouse wheel action
-    WheelAction mWheelAction;
-
     //! Timer that periodically fires while map rendering is in progress to update the visible map
     QTimer mMapUpdateTimer;
-
-    //! magnification factor
-    double mMagnificationFactor;
 
     //! Job that takes care of map rendering in background
     QgsMapRendererQImageJob* mJob;
@@ -767,6 +775,9 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     QgsRectangle imageRect( const QImage& img, const QgsMapSettings& mapSettings );
 
     QgsSnappingUtils* mSnappingUtils;
+
+    //! lock the scale, so zooming can be performed using magnication
+    bool mScaleLocked;
 
     QgsExpressionContextScope mExpressionContextScope;
 

--- a/src/plugins/georeferencer/qgsgeorefplugingui.cpp
+++ b/src/plugins/georeferencer/qgsgeorefplugingui.cpp
@@ -993,9 +993,8 @@ void QgsGeorefPluginGui::createMapCanvas()
            this, SLOT( releasePoint( const QPoint & ) ) );
 
   QSettings s;
-  int action = s.value( "/qgis/wheel_action", 2 ).toInt();
   double zoomFactor = s.value( "/qgis/zoom_factor", 2 ).toDouble();
-  mCanvas->setWheelAction(( QgsMapCanvas::WheelAction ) action, zoomFactor );
+  mCanvas->setWheelFactor( zoomFactor );
 
   mExtentsChangedRecursionGuard = false;
 

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -45,7 +45,16 @@
        <property name="spacing">
         <number>0</number>
        </property>
-       <property name="margin">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
         <number>0</number>
        </property>
        <item>
@@ -284,17 +293,35 @@
        <enum>QFrame::Raised</enum>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout">
-       <property name="margin">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="topMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
+       <property name="bottomMargin">
         <number>0</number>
        </property>
        <item>
         <widget class="QStackedWidget" name="mOptionsStackedWidget">
          <property name="currentIndex">
-          <number>3</number>
+          <number>13</number>
          </property>
          <widget class="QWidget" name="mOptionsPageGeneral">
           <layout class="QVBoxLayout" name="verticalLayout_3">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -310,8 +337,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>611</width>
-                <height>710</height>
+                <width>1230</width>
+                <height>682</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_28">
@@ -982,7 +1009,16 @@
          </widget>
          <widget class="QWidget" name="mOptionsPageSystem">
           <layout class="QVBoxLayout" name="verticalLayout_7">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -998,8 +1034,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>608</width>
-                <height>900</height>
+                <width>610</width>
+                <height>909</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_22">
@@ -1406,7 +1442,16 @@
          </widget>
          <widget class="QWidget" name="mOptionsPageDataSources">
           <layout class="QVBoxLayout" name="verticalLayout_26">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -1422,8 +1467,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>608</width>
-                <height>765</height>
+                <width>610</width>
+                <height>705</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_27">
@@ -1765,7 +1810,16 @@
          </widget>
          <widget class="QWidget" name="mOptionsPageRendering">
           <layout class="QVBoxLayout" name="verticalLayout_12">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -1781,8 +1835,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>623</width>
-                <height>989</height>
+                <width>722</width>
+                <height>1013</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_22">
@@ -1963,12 +2017,12 @@
                      </item>
                      <item row="2" column="1">
                       <widget class="QLabel" name="mSimplifyAlgorithmLabel">
+                       <property name="toolTip">
+                        <string>This algorithm only is applied to simplify on local side</string>
+                       </property>
                        <property name="text">
                         <string>Simplification algorithm: </string>
                        </property>
-                       <property name="toolTip">
-                        <string>This algorithm only is applied to simplify on local side</string>
-                       </property>                          
                        <property name="margin">
                         <number>2</number>
                        </property>
@@ -2049,7 +2103,16 @@
                   <string>Rendering quality</string>
                  </property>
                  <layout class="QVBoxLayout" name="_5">
-                  <property name="margin">
+                  <property name="leftMargin">
+                   <number>11</number>
+                  </property>
+                  <property name="topMargin">
+                   <number>11</number>
+                  </property>
+                  <property name="rightMargin">
+                   <number>11</number>
+                  </property>
+                  <property name="bottomMargin">
                    <number>11</number>
                   </property>
                   <item>
@@ -2100,7 +2163,16 @@
                   <item>
                    <widget class="QWidget" name="widget" native="true">
                     <layout class="QHBoxLayout" name="horizontalLayout_19">
-                     <property name="margin">
+                     <property name="leftMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="topMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="rightMargin">
+                      <number>0</number>
+                     </property>
+                     <property name="bottomMargin">
                       <number>0</number>
                      </property>
                      <item>
@@ -2184,7 +2256,16 @@
                      <item>
                       <widget class="QWidget" name="widget_3" native="true">
                        <layout class="QHBoxLayout" name="horizontalLayout_22">
-                        <property name="margin">
+                        <property name="leftMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="topMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="rightMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="bottomMargin">
                          <number>0</number>
                         </property>
                         <item>
@@ -2216,7 +2297,16 @@
                      <item>
                       <widget class="QWidget" name="widget_4" native="true">
                        <layout class="QHBoxLayout" name="horizontalLayout_23">
-                        <property name="margin">
+                        <property name="leftMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="topMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="rightMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="bottomMargin">
                          <number>0</number>
                         </property>
                         <item>
@@ -2248,7 +2338,16 @@
                      <item>
                       <widget class="QWidget" name="widget_5" native="true">
                        <layout class="QHBoxLayout" name="horizontalLayout_24">
-                        <property name="margin">
+                        <property name="leftMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="topMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="rightMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="bottomMargin">
                          <number>0</number>
                         </property>
                         <item>
@@ -2287,7 +2386,16 @@
                      <item>
                       <widget class="QWidget" name="widget_6" native="true">
                        <layout class="QHBoxLayout" name="horizontalLayout_25">
-                        <property name="margin">
+                        <property name="leftMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="topMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="rightMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="bottomMargin">
                          <number>0</number>
                         </property>
                         <item>
@@ -2319,7 +2427,16 @@
                      <item>
                       <widget class="QWidget" name="widget_7" native="true">
                        <layout class="QHBoxLayout" name="horizontalLayout_18">
-                        <property name="margin">
+                        <property name="leftMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="topMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="rightMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="bottomMargin">
                          <number>0</number>
                         </property>
                         <item>
@@ -2376,7 +2493,16 @@
                      <item>
                       <widget class="QWidget" name="widget_2" native="true">
                        <layout class="QHBoxLayout" name="horizontalLayout_20">
-                        <property name="margin">
+                        <property name="leftMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="topMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="rightMargin">
+                         <number>0</number>
+                        </property>
+                        <property name="bottomMargin">
                          <number>0</number>
                         </property>
                         <item>
@@ -2482,7 +2608,16 @@
          </widget>
          <widget class="QWidget" name="mOptionsPageColors">
           <layout class="QVBoxLayout" name="verticalLayout_38">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -2498,8 +2633,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>120</width>
-                <height>287</height>
+                <width>610</width>
+                <height>592</height>
                </rect>
               </property>
               <layout class="QHBoxLayout" name="horizontalLayout_46">
@@ -2620,7 +2755,16 @@
          </widget>
          <widget class="QWidget" name="mOptionsPageMapCanvas">
           <layout class="QVBoxLayout" name="verticalLayout_16">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -2636,8 +2780,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>475</width>
-                <height>343</height>
+                <width>610</width>
+                <height>592</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_25">
@@ -2949,7 +3093,16 @@
          </widget>
          <widget class="QWidget" name="mOptionsPageMapTools">
           <layout class="QVBoxLayout" name="verticalLayout_14">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -2965,8 +3118,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>622</width>
-                <height>739</height>
+                <width>635</width>
+                <height>663</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_30">
@@ -3228,21 +3381,14 @@
                   <string>Panning and zooming</string>
                  </property>
                  <layout class="QGridLayout" name="_8">
-                  <item row="1" column="0">
+                  <item row="0" column="0">
                    <widget class="QLabel" name="label_3">
                     <property name="text">
                      <string>Zoom factor</string>
                     </property>
                    </widget>
                   </item>
-                  <item row="0" column="0">
-                   <widget class="QLabel" name="label_2">
-                    <property name="text">
-                     <string>Mouse wheel action</string>
-                    </property>
-                   </widget>
-                  </item>
-                  <item row="1" column="1">
+                  <item row="0" column="1">
                    <widget class="QDoubleSpinBox" name="spinZoomFactor">
                     <property name="decimals">
                      <number>1</number>
@@ -3253,30 +3399,6 @@
                     <property name="value">
                      <double>2.000000000000000</double>
                     </property>
-                   </widget>
-                  </item>
-                  <item row="0" column="1">
-                   <widget class="QComboBox" name="cmbWheelAction">
-                    <item>
-                     <property name="text">
-                      <string>Zoom</string>
-                     </property>
-                    </item>
-                    <item>
-                     <property name="text">
-                      <string>Zoom and recenter</string>
-                     </property>
-                    </item>
-                    <item>
-                     <property name="text">
-                      <string>Zoom to mouse cursor</string>
-                     </property>
-                    </item>
-                    <item>
-                     <property name="text">
-                      <string>Nothing</string>
-                     </property>
-                    </item>
                    </widget>
                   </item>
                  </layout>
@@ -3402,7 +3524,16 @@
          </widget>
          <widget class="QWidget" name="mOptionsPageComposer">
           <layout class="QVBoxLayout" name="verticalLayout_36">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -3418,7 +3549,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>514</width>
+                <width>1061</width>
                 <height>605</height>
                </rect>
               </property>
@@ -3662,7 +3793,16 @@
          </widget>
          <widget class="QWidget" name="mOptionsPageDigitizing">
           <layout class="QVBoxLayout" name="verticalLayout_17">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -3678,8 +3818,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>552</width>
-                <height>726</height>
+                <width>610</width>
+                <height>661</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_31">
@@ -4198,7 +4338,16 @@
          </widget>
          <widget class="QWidget" name="mOptionsPageGDAL">
           <layout class="QVBoxLayout" name="verticalLayout_4">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -4214,8 +4363,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>393</width>
-                <height>380</height>
+                <width>610</width>
+                <height>592</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_6">
@@ -4328,7 +4477,16 @@
          </widget>
          <widget class="QWidget" name="mOptionsPageCRS">
           <layout class="QVBoxLayout" name="verticalLayout_18">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -4344,8 +4502,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>467</width>
-                <height>654</height>
+                <width>610</width>
+                <height>659</height>
                </rect>
               </property>
               <layout class="QGridLayout" name="gridLayout_15">
@@ -4565,7 +4723,16 @@
          </widget>
          <widget class="QWidget" name="mOptionsPageLocale">
           <layout class="QVBoxLayout" name="verticalLayout_19">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -4581,8 +4748,8 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>244</width>
-                <height>254</height>
+                <width>610</width>
+                <height>592</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_32">
@@ -4665,7 +4832,16 @@
          </widget>
          <widget class="QWidget" name="mOptionsPageNetwork">
           <layout class="QVBoxLayout" name="verticalLayout_20">
-           <property name="margin">
+           <property name="leftMargin">
+            <number>0</number>
+           </property>
+           <property name="topMargin">
+            <number>0</number>
+           </property>
+           <property name="rightMargin">
+            <number>0</number>
+           </property>
+           <property name="bottomMargin">
             <number>0</number>
            </property>
            <item>
@@ -4681,7 +4857,7 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>469</width>
+                <width>610</width>
                 <height>781</height>
                </rect>
               </property>
@@ -5355,7 +5531,6 @@
   <tabstop>mDistanceUnitsComboBox</tabstop>
   <tabstop>mAreaUnitsComboBox</tabstop>
   <tabstop>mAngleUnitsComboBox</tabstop>
-  <tabstop>cmbWheelAction</tabstop>
   <tabstop>spinZoomFactor</tabstop>
   <tabstop>mListGlobalScales</tabstop>
   <tabstop>pbnAddScale</tabstop>


### PR DESCRIPTION
This allows to lock the scale (by adding a magnet next to scale widget in status bar) so you can zoom in/out by magnification.

This also removes options for mouse wheel behavior and only keeps default (pointer remains at the same geographic location).

Scale widget from the status bar has now its own class (so it removes a few lines from qgisapp).

We had to change the dpi to be a double to avoid rounding errors. @wonder-sk does that sound ok to you? can this be changed in the API for QGIS 3 or should `QgsMapSettings::outputDpi()` always return an int?
