### PR TITLE
Change some wording in QgsQueryBuilder API documentation

### DIFF
--- a/src/gui/qgsquerybuilder.h
+++ b/src/gui/qgsquerybuilder.h
@@ -31,7 +31,7 @@ class QgsVectorLayer;
  * \brief Query Builder for layers.
  *
  * The query builder allows interactive creation of a SQL for limiting the
- * features displayed in a database layer.  The fields in the table are
+ * features displayed in a vector layer.  The fields in the table are
  * displayed and sample values (or all values) can be viewed to aid in
  * constructing the query. A test function returns the number of features that
  * will be returned.
@@ -80,7 +80,7 @@ class GUI_EXPORT QgsQueryBuilder : public QDialog, private Ui::QgsQueryBuilderBa
 
     void on_buttonBox_helpRequested() { QgsContextHelp::run( metaObject()->className() ); }
 
-    /** Test the constructed sql statement to see if the database likes it.
+    /** Test the constructed sql statement to see if the vector layer data provider likes it.
      * The number of rows that would be returned is displayed in a message box.
      * The test uses a "select count(*) from ..." query to test the SQL
      * statement.


### PR DESCRIPTION
We don't need a database but a vector layer although we can use SQL, hence, the small rewording.
