### PR TITLE
Have a capabilities cache per hostname

### DIFF
--- a/src/server/qgswmsserver.cpp
+++ b/src/server/qgswmsserver.cpp
@@ -159,6 +159,7 @@ void QgsWMSServer::executeRequest()
   {
     QStringList cacheKeyList;
     cacheKeyList << ( getProjectSettings ? "projectSettings" : version );
+    cacheKeyList << getenv( "SERVER_NAME" );
     bool cache = true;
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
     cache = mAccessControl->fillCacheKey( cacheKeyList );


### PR DESCRIPTION
Actually if I get
http://127.0.0.1/qgis?REQUEST=GetCapabilities&VERSION=1.1.0&SERVICE=WFS
then
http://localhost/qgis?REQUEST=GetCapabilities&VERSION=1.1.0&SERVICE=WFS
the onlineResource will be wrong in the second request...
