### PR TITLE
[style dock] use a QLineEntry for layer title

### DIFF
--- a/src/app/qgsmapstylingwidget.cpp
+++ b/src/app/qgsmapstylingwidget.cpp
@@ -62,7 +62,7 @@ void QgsMapStylingWidget::setLayer( QgsMapLayer *layer )
 {
   if ( !layer || !layer->isSpatial() )
   {
-    mLayerTitleLabel->clear();
+    mLayerTitle->setText( QString() );
     mStackedWidget->setCurrentIndex( mNotSupportedPage );
     return;
   }
@@ -177,7 +177,7 @@ void QgsMapStylingWidget::updateCurrentWidgetLayer()
 
   mUndoWidget->setUndoStack( layer->undoStackStyles() );
 
-  mLayerTitleLabel->setText( layer->name() );
+  mLayerTitle->setText( layer->name() );
 
   if ( layer->type() == QgsMapLayer::VectorLayer )
   {

--- a/src/ui/qgsmapstylingwidgetbase.ui
+++ b/src/ui/qgsmapstylingwidgetbase.ui
@@ -154,24 +154,18 @@
        <item row="0" column="0" colspan="2">
         <layout class="QHBoxLayout" name="horizontalLayout">
          <item>
-          <widget class="QLabel" name="mLayerTitleLabel">
+          <widget class="QLabel" name="textLabel">
            <property name="text">
-            <string/>
+            <string>Layer name</string>
            </property>
           </widget>
          </item>
          <item>
-          <spacer name="horizontalSpacer">
-           <property name="orientation">
-            <enum>Qt::Horizontal</enum>
+          <widget class="QLineEdit" name="mLayerTitle">
+           <property name="readOnly">
+            <bool>true</bool>
            </property>
-           <property name="sizeHint" stdset="0">
-            <size>
-             <width>40</width>
-             <height>20</height>
-            </size>
-           </property>
-          </spacer>
+          </widget>
          </item>
          <item>
           <widget class="QCheckBox" name="mLiveApplyCheck">


### PR DESCRIPTION
@NathanW2 this fixes one big UX issue I've had with the style dock, whereas the panel's width would grow to unreasonable length for layers with long names. For e.g., days ago, I opened a NASA MODIS product, with a file name that looked like: "MVC341A1-201602938-BUUL-2019340-20393920019283-LEVEL1 Layer 0 QA Z", which had my dock go full width of available canvas space :)

Relying on a QLineEntry prevents overly long no-wrappeable labels, and as a bonus allows users to copy the value if needed.
