### PR TITLE
[Bugfix] Fix pin/unpin maptool

### DIFF
--- a/src/app/qgsmaptoollabel.cpp
+++ b/src/app/qgsmaptoollabel.cpp
@@ -689,7 +689,11 @@ QgsMapToolLabel::LabelDetails::LabelDetails( const QgsLabelPosition& p )
   if ( layer && layer->labeling() )
   {
     settings = layer->labeling()->settings( layer, pos.providerID );
-    valid = settings.enabled;
+
+    if ( p.isDiagram )
+      valid = layer->diagramsEnabled();
+    else
+      valid = settings.enabled;
   }
 
   if ( !valid )

--- a/src/app/qgsmaptoolpinlabels.cpp
+++ b/src/app/qgsmaptoolpinlabels.cpp
@@ -239,8 +239,6 @@ void QgsMapToolPinLabels::pinUnpinLabels( const QgsRectangle& ext, QMouseEvent *
   bool toggleUnpinOrPin = e->modifiers() & Qt::ControlModifier;
 
   // get list of all drawn labels from all layers within, or touching, chosen extent
-  bool labelChanged = false;
-
   const QgsLabelingResults* labelingResults = mCanvas->labelingResults();
   if ( !labelingResults )
   {
@@ -250,6 +248,7 @@ void QgsMapToolPinLabels::pinUnpinLabels( const QgsRectangle& ext, QMouseEvent *
 
   QList<QgsLabelPosition> labelPosList = labelingResults->labelsWithinRect( ext );
 
+  bool labelChanged = false;
   QList<QgsLabelPosition>::const_iterator it;
   for ( it = labelPosList.constBegin() ; it != labelPosList.constEnd(); ++it )
   {
@@ -284,7 +283,7 @@ void QgsMapToolPinLabels::pinUnpinLabels( const QgsRectangle& ext, QMouseEvent *
       }
     }
     // pin label
-    if ( !isPinned() && ( !doUnpin || toggleUnpinOrPin ) )
+    else if ( !isPinned() && ( !doUnpin || toggleUnpinOrPin ) )
     {
       // pin label's location, and optionally rotation, to attribute table
       if ( pinUnpinCurrentFeature( true ) )


### PR DESCRIPTION
This PR fixes the below problems:
- the CTL key to toggle the diagrams' pin status doesn't work anymore
- diagrams cannot be pinned/unpinned unless labels are displayed
