### PR TITLE
[FEATURE] Allow web map style shift-drag zoom

### DIFF
--- a/python/gui/qgsmaptool.sip
+++ b/python/gui/qgsmaptool.sip
@@ -38,6 +38,7 @@ class QgsMapTool : QObject
                                If it does, the tool can be operated once and then a previous map
                                tool automatically restored. */
       EditTool, /*!< Map tool is an edit tool, which can only be used when layer is editable*/
+      AllowZoomRect, /*!< Allow zooming by rectangle (by holding shift and dragging) while the tool is active*/
     };
     typedef QFlags<QgsMapTool::Flag> Flags;
 
@@ -183,3 +184,6 @@ class QgsMapTool : QObject
 
 
 };
+
+
+QFlags<QgsMapTool::Flag> operator|(QgsMapTool::Flag f1, QFlags<QgsMapTool::Flag> f2);

--- a/python/gui/qgsmaptool.sip
+++ b/python/gui/qgsmaptool.sip
@@ -30,6 +30,22 @@ class QgsMapTool : QObject
 
   public:
 
+    //! Enumeration of flags that adjust the way the map tool operates
+    //! @note added in QGIS 2.16
+    enum Flag
+    {
+      Transient, /*!< Indicates that this map tool performs a transient (one-off) operation.
+                               If it does, the tool can be operated once and then a previous map
+                               tool automatically restored. */
+      EditTool, /*!< Map tool is an edit tool, which can only be used when layer is editable*/
+    };
+    typedef QFlags<QgsMapTool::Flag> Flags;
+
+    /** Returns the flags for the map tool.
+     * @note added in QGIS 2.16
+     */
+    virtual Flags flags() const;
+
     //! virtual destructor
     virtual ~QgsMapTool();
 
@@ -85,13 +101,16 @@ class QgsMapTool : QObject
 
     /** Check whether this MapTool performs a zoom or pan operation.
      * If it does, we will be able to perform the zoom  and then
-     * resume operations with the original / previously used tool.*/
-    virtual bool isTransient();
+     * resume operations with the original / previously used tool.
+     * @deprecated use flags() instead
+    */
+    virtual bool isTransient() const /Deprecated/;
 
     /** Check whether this MapTool performs an edit operation.
-     * If it does, we will deactivate it when editing is turned off
+     * If it does, we will deactivate it when editing is turned off.
+     * @deprecated use flags() instead
      */
-    virtual bool isEditTool();
+    virtual bool isEditTool() const /Deprecated/;
 
     //! called when set as currently active map tool
     virtual void activate();

--- a/python/gui/qgsmaptooledit.sip
+++ b/python/gui/qgsmaptooledit.sip
@@ -25,11 +25,7 @@ class QgsMapToolEdit: QgsMapTool
     QgsMapToolEdit( QgsMapCanvas* canvas );
     virtual ~QgsMapToolEdit();
 
-    /**
-     * Is this an edit tool?
-     * @return  Of course it is or you would not be inheriting from it.
-     */
-    virtual bool isEditTool();
+    virtual Flags flags() const;
 
   protected:
 

--- a/python/gui/qgsmaptoolemitpoint.sip
+++ b/python/gui/qgsmaptoolemitpoint.sip
@@ -9,6 +9,8 @@ class QgsMapToolEmitPoint : QgsMapTool
     //! constructor
     QgsMapToolEmitPoint( QgsMapCanvas* canvas );
 
+    virtual Flags flags() const;
+
     //! Overridden mouse move event
     virtual void canvasMoveEvent( QgsMapMouseEvent * e );
 

--- a/python/gui/qgsmaptoolidentify.sip
+++ b/python/gui/qgsmaptoolidentify.sip
@@ -47,6 +47,8 @@ class QgsMapToolIdentify : QgsMapTool
 
     virtual ~QgsMapToolIdentify();
 
+    virtual Flags flags() const;
+
     //! Overridden mouse move event
     virtual void canvasMoveEvent( QgsMapMouseEvent * e );
 

--- a/python/gui/qgsmaptoolpan.sip
+++ b/python/gui/qgsmaptoolpan.sip
@@ -9,6 +9,8 @@ class QgsMapToolPan : QgsMapTool
     //! constructor
     QgsMapToolPan( QgsMapCanvas* canvas );
 
+    virtual Flags flags() const;
+
     //! Mouse press event
     virtual void canvasPressEvent( QgsMapMouseEvent* e );
 
@@ -18,6 +20,5 @@ class QgsMapToolPan : QgsMapTool
     //! Overridden mouse release event
     virtual void canvasReleaseEvent( QgsMapMouseEvent* e );
 
-    virtual bool isTransient();
 };
 

--- a/python/gui/qgsmaptoolzoom.sip
+++ b/python/gui/qgsmaptoolzoom.sip
@@ -11,6 +11,8 @@ class QgsMapToolZoom : QgsMapTool
 
     ~QgsMapToolZoom();
 
+    virtual Flags flags() const;
+
     //! Overridden mouse move event
     virtual void canvasMoveEvent( QgsMapMouseEvent* e );
 
@@ -19,9 +21,6 @@ class QgsMapToolZoom : QgsMapTool
 
     //! Overridden mouse release event
     virtual void canvasReleaseEvent( QgsMapMouseEvent* e );
-
-    //! indicates whether we're zooming in or out
-    virtual bool isTransient();
 
     //! Flag to indicate a map canvas drag operation is taking place
     virtual void deactivate();

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -9753,7 +9753,7 @@ void QgisApp::mapToolChanged( QgsMapTool *newTool, QgsMapTool *oldTool )
 
   if ( newTool )
   {
-    if ( !newTool->isEditTool() )
+    if ( !( newTool->flags() & QgsMapTool::EditTool ) )
     {
       mNonEditMapTool = newTool;
     }
@@ -10195,7 +10195,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer* layer )
     mActionFeatureAction->setEnabled( layerHasActions );
 
     if ( !isEditable && mMapCanvas && mMapCanvas->mapTool()
-         && mMapCanvas->mapTool()->isEditTool() && !mSaveRollbackInProgress )
+         && ( mMapCanvas->mapTool()->flags() & QgsMapTool::EditTool ) && !mSaveRollbackInProgress )
     {
       mMapCanvas->setMapTool( mNonEditMapTool );
     }

--- a/src/app/qgsmaptoolfeatureaction.h
+++ b/src/app/qgsmaptoolfeatureaction.h
@@ -36,6 +36,8 @@ class APP_EXPORT QgsMapToolFeatureAction : public QgsMapTool
 
     ~QgsMapToolFeatureAction();
 
+    virtual Flags flags() const override { return QgsMapTool::AllowZoomRect; }
+
     //! Overridden mouse move event
     virtual void canvasMoveEvent( QgsMapMouseEvent* e ) override;
 

--- a/src/app/qgsmaptoolmeasureangle.h
+++ b/src/app/qgsmaptoolmeasureangle.h
@@ -31,7 +31,9 @@ class APP_EXPORT QgsMapToolMeasureAngle: public QgsMapTool
     QgsMapToolMeasureAngle( QgsMapCanvas* canvas );
     ~QgsMapToolMeasureAngle();
 
-    //! Mouse move event for overridingqgs
+    virtual Flags flags() const override { return QgsMapTool::AllowZoomRect; }
+
+    //! Mouse move event for overriding
     void canvasMoveEvent( QgsMapMouseEvent* e ) override;
 
     //! Mouse release event for overriding

--- a/src/app/qgsmaptoolpointsymbol.h
+++ b/src/app/qgsmaptoolpointsymbol.h
@@ -34,8 +34,9 @@ class APP_EXPORT QgsMapToolPointSymbol: public QgsMapToolEdit
   public:
     QgsMapToolPointSymbol( QgsMapCanvas* canvas );
 
+    virtual Flags flags() const { return QgsMapTool::EditTool; }
+
     void canvasPressEvent( QgsMapMouseEvent* e ) override;
-    bool isEditTool() override { return true; }
 
   protected:
     QgsVectorLayer* mActiveLayer;

--- a/src/app/qgsmaptoolpointsymbol.h
+++ b/src/app/qgsmaptoolpointsymbol.h
@@ -34,7 +34,7 @@ class APP_EXPORT QgsMapToolPointSymbol: public QgsMapToolEdit
   public:
     QgsMapToolPointSymbol( QgsMapCanvas* canvas );
 
-    virtual Flags flags() const { return QgsMapTool::EditTool; }
+    virtual Flags flags() const override { return QgsMapTool::EditTool; }
 
     void canvasPressEvent( QgsMapMouseEvent* e ) override;
 

--- a/src/app/qgsmeasuretool.h
+++ b/src/app/qgsmeasuretool.h
@@ -36,6 +36,8 @@ class APP_EXPORT QgsMeasureTool : public QgsMapTool
 
     ~QgsMeasureTool();
 
+    virtual Flags flags() const override { return QgsMapTool::AllowZoomRect; }
+
     //! returns whether measuring distance or area
     bool measureArea() { return mMeasureArea; }
 

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -1365,12 +1365,15 @@ void QgsMapCanvas::endZoomRect( QPoint pos )
   mZoomRubberBand.reset( nullptr );
   QApplication::restoreOverrideCursor();
 
-  if ( mZoomRect.topLeft() == mZoomRect.bottomRight() )
-    return;
-
   // store the rectangle
   mZoomRect.setRight( pos.x() );
   mZoomRect.setBottom( pos.y() );
+
+  if ( mZoomRect.width() < 5 && mZoomRect.height() < 5 )
+  {
+    //probably a mistake - would result in huge zoom!
+    return;
+  }
 
   //account for bottom right -> top left dragging
   mZoomRect = mZoomRect.normalized();

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -1386,7 +1386,7 @@ void QgsMapCanvas::mouseReleaseEvent( QMouseEvent* e )
     if ( mMapTool )
     {
       // right button was pressed in zoom tool? return to previous non zoom tool
-      if ( e->button() == Qt::RightButton && mMapTool->isTransient() )
+      if ( e->button() == Qt::RightButton && mMapTool->flags() & QgsMapTool::Transient )
       {
         QgsDebugMsg( "Right click in map tool zoom or pan, last tool is " +
                      QString( mLastNonZoomMapTool ? "not null." : "null." ) );
@@ -1395,7 +1395,8 @@ void QgsMapCanvas::mouseReleaseEvent( QMouseEvent* e )
 
         // change to older non-zoom tool
         if ( mLastNonZoomMapTool
-             && ( !mLastNonZoomMapTool->isEditTool() || ( vlayer && vlayer->isEditable() ) ) )
+             && ( !( mLastNonZoomMapTool->flags() & QgsMapTool::EditTool )
+                  || ( vlayer && vlayer->isEditable() ) ) )
         {
           QgsMapTool* t = mLastNonZoomMapTool;
           mLastNonZoomMapTool = nullptr;
@@ -1601,7 +1602,8 @@ void QgsMapCanvas::setMapTool( QgsMapTool* tool )
     mMapTool->deactivate();
   }
 
-  if ( tool->isTransient() && mMapTool && !mMapTool->isTransient() )
+  if (( tool->flags() & QgsMapTool::Transient )
+      && mMapTool && !( mMapTool->flags() & QgsMapTool::Transient ) )
   {
     // if zoom or pan tool will be active, save old tool
     // to bring it back on right click

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -803,13 +803,13 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
 
     /** Starts zooming via rectangle
      * @param pos start position for rectangle
-     * @node added in QGIS 2.16
+     * @note added in QGIS 2.16
      */
     void beginZoomRect( QPoint pos );
 
     /** Ends zooming via rectangle
      * @param pos end position for rectangle
-     * @node added in QGIS 2.16
+     * @note added in QGIS 2.16
      */
     void endZoomRect( QPoint pos );
 

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -65,6 +65,7 @@ class QgsMapCanvasMap;
 class QgsMapOverviewCanvas;
 class QgsMapTool;
 class QgsSnappingUtils;
+class QgsRubberBand;
 
 /** \ingroup gui
   * A class that stores visibility and presence in overview flags together
@@ -785,9 +786,32 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
 
     QgsExpressionContextScope mExpressionContextScope;
 
+    //! Stores zoom rect
+    QRect mZoomRect;
+
+    //! Flag to indicate a zoom by rectangle operation is taking place
+    bool mZoomDragging;
+
+    //! Zoom by rectangle rubber band
+    QScopedPointer< QgsRubberBand > mZoomRubberBand;
+
+    QCursor mZoomCursor;
+
     //! Force a resize of the map canvas item
     //! @note added in 2.16
     void updateMapSize();
+
+    /** Starts zooming via rectangle
+     * @param pos start position for rectangle
+     * @node added in QGIS 2.16
+     */
+    void beginZoomRect( QPoint pos );
+
+    /** Ends zooming via rectangle
+     * @param pos end position for rectangle
+     * @node added in QGIS 2.16
+     */
+    void endZoomRect( QPoint pos );
 
     friend class TestQgsMapCanvas;
 

--- a/src/gui/qgsmaptool.cpp
+++ b/src/gui/qgsmaptool.cpp
@@ -189,14 +189,14 @@ void QgsMapTool::renderComplete()
 {
 }
 
-bool QgsMapTool::isTransient()
+bool QgsMapTool::isTransient() const
 {
-  return false;
+  return flags() & Transient;
 }
 
-bool QgsMapTool::isEditTool()
+bool QgsMapTool::isEditTool() const
 {
-  return false;
+  return flags() & EditTool;
 }
 
 QgsMapCanvas* QgsMapTool::canvas()

--- a/src/gui/qgsmaptool.h
+++ b/src/gui/qgsmaptool.h
@@ -62,6 +62,7 @@ class GUI_EXPORT QgsMapTool : public QObject
                                If it does, the tool can be operated once and then a previous map
                                tool automatically restored. */
       EditTool = 1 << 2, /*!< Map tool is an edit tool, which can only be used when layer is editable*/
+      AllowZoomRect = 1 << 3, /*!< Allow zooming by rectangle (by holding shift and dragging) while the tool is active*/
     };
     Q_DECLARE_FLAGS( Flags, Flag )
 
@@ -224,6 +225,9 @@ class GUI_EXPORT QgsMapTool : public QObject
 
     //! translated name of the map tool
     QString mToolName;
+
 };
+
+Q_DECLARE_OPERATORS_FOR_FLAGS( QgsMapTool::Flags )
 
 #endif

--- a/src/gui/qgsmaptool.h
+++ b/src/gui/qgsmaptool.h
@@ -54,6 +54,22 @@ class GUI_EXPORT QgsMapTool : public QObject
 
   public:
 
+    //! Enumeration of flags that adjust the way the map tool operates
+    //! @note added in QGIS 2.16
+    enum Flag
+    {
+      Transient = 1 << 1, /*!< Indicates that this map tool performs a transient (one-off) operation.
+                               If it does, the tool can be operated once and then a previous map
+                               tool automatically restored. */
+      EditTool = 1 << 2, /*!< Map tool is an edit tool, which can only be used when layer is editable*/
+    };
+    Q_DECLARE_FLAGS( Flags, Flag )
+
+    /** Returns the flags for the map tool.
+     * @note added in QGIS 2.16
+     */
+    virtual Flags flags() const { return Flags(); }
+
     //! virtual destructor
     virtual ~QgsMapTool();
 
@@ -87,7 +103,6 @@ class GUI_EXPORT QgsMapTool : public QObject
     //! @deprecated since 2.4 - not called anymore - map tools must not directly depend on rendering progress
     Q_DECL_DEPRECATED virtual void renderComplete();
 
-
     /** Use this to associate a QAction to this maptool. Then when the setMapTool
      * method of mapcanvas is called the action state will be set to on.
      * Usually this will cause e.g. a toolbutton to appear pressed in and
@@ -109,13 +124,16 @@ class GUI_EXPORT QgsMapTool : public QObject
 
     /** Check whether this MapTool performs a zoom or pan operation.
      * If it does, we will be able to perform the zoom  and then
-     * resume operations with the original / previously used tool.*/
-    virtual bool isTransient();
+     * resume operations with the original / previously used tool.
+     * @deprecated use flags() instead
+    */
+    Q_DECL_DEPRECATED virtual bool isTransient() const;
 
     /** Check whether this MapTool performs an edit operation.
-     * If it does, we will deactivate it when editing is turned off
+     * If it does, we will deactivate it when editing is turned off.
+     * @deprecated use flags() instead
      */
-    virtual bool isEditTool();
+    Q_DECL_DEPRECATED virtual bool isEditTool() const;
 
     //! called when set as currently active map tool
     virtual void activate();

--- a/src/gui/qgsmaptooledit.h
+++ b/src/gui/qgsmaptooledit.h
@@ -33,11 +33,7 @@ class GUI_EXPORT QgsMapToolEdit: public QgsMapTool
     QgsMapToolEdit( QgsMapCanvas* canvas );
     virtual ~QgsMapToolEdit();
 
-    /**
-     * Is this an edit tool?
-     * @return  Of course it is or you would not be inheriting from it.
-     */
-    virtual bool isEditTool() override { return true; }
+    virtual Flags flags() const { return QgsMapTool::EditTool; }
 
   protected:
 

--- a/src/gui/qgsmaptooledit.h
+++ b/src/gui/qgsmaptooledit.h
@@ -33,7 +33,7 @@ class GUI_EXPORT QgsMapToolEdit: public QgsMapTool
     QgsMapToolEdit( QgsMapCanvas* canvas );
     virtual ~QgsMapToolEdit();
 
-    virtual Flags flags() const { return QgsMapTool::EditTool; }
+    virtual Flags flags() const override { return QgsMapTool::EditTool; }
 
   protected:
 

--- a/src/gui/qgsmaptoolemitpoint.h
+++ b/src/gui/qgsmaptoolemitpoint.h
@@ -34,6 +34,8 @@ class GUI_EXPORT QgsMapToolEmitPoint : public QgsMapTool
     //! constructor
     QgsMapToolEmitPoint( QgsMapCanvas* canvas );
 
+    virtual Flags flags() const override { return QgsMapTool::AllowZoomRect; }
+
     //! Overridden mouse move event
     virtual void canvasMoveEvent( QgsMapMouseEvent* e ) override;
 

--- a/src/gui/qgsmaptoolidentify.h
+++ b/src/gui/qgsmaptoolidentify.h
@@ -92,6 +92,8 @@ class GUI_EXPORT QgsMapToolIdentify : public QgsMapTool
 
     virtual ~QgsMapToolIdentify();
 
+    virtual Flags flags() const override { return QgsMapTool::AllowZoomRect; }
+
     //! Overridden mouse move event
     virtual void canvasMoveEvent( QgsMapMouseEvent* e ) override;
 

--- a/src/gui/qgsmaptoolpan.h
+++ b/src/gui/qgsmaptoolpan.h
@@ -32,6 +32,8 @@ class GUI_EXPORT QgsMapToolPan : public QgsMapTool
     //! constructor
     QgsMapToolPan( QgsMapCanvas* canvas );
 
+    virtual Flags flags() const { return QgsMapTool::Transient; }
+
     //! Mouse press event
     virtual void canvasPressEvent( QgsMapMouseEvent* e ) override;
 
@@ -40,8 +42,6 @@ class GUI_EXPORT QgsMapToolPan : public QgsMapTool
 
     //! Overridden mouse release event
     virtual void canvasReleaseEvent( QgsMapMouseEvent* e ) override;
-
-    virtual bool isTransient() override { return true; }
 
   private:
 

--- a/src/gui/qgsmaptoolpan.h
+++ b/src/gui/qgsmaptoolpan.h
@@ -32,7 +32,7 @@ class GUI_EXPORT QgsMapToolPan : public QgsMapTool
     //! constructor
     QgsMapToolPan( QgsMapCanvas* canvas );
 
-    virtual Flags flags() const { return QgsMapTool::Transient; }
+    virtual Flags flags() const override { return QgsMapTool::Transient | QgsMapTool::AllowZoomRect; }
 
     //! Mouse press event
     virtual void canvasPressEvent( QgsMapMouseEvent* e ) override;

--- a/src/gui/qgsmaptoolzoom.h
+++ b/src/gui/qgsmaptoolzoom.h
@@ -35,6 +35,8 @@ class GUI_EXPORT QgsMapToolZoom : public QgsMapTool
 
     ~QgsMapToolZoom();
 
+    virtual Flags flags() const { return QgsMapTool::Transient; }
+
     //! Overridden mouse move event
     virtual void canvasMoveEvent( QgsMapMouseEvent* e ) override;
 
@@ -44,10 +46,6 @@ class GUI_EXPORT QgsMapToolZoom : public QgsMapTool
     //! Overridden mouse release event
     virtual void canvasReleaseEvent( QgsMapMouseEvent* e ) override;
 
-    //! indicates whether we're zooming in or out
-    virtual bool isTransient() override { return true; }
-
-    //! Flag to indicate a map canvas drag operation is taking place
     virtual void deactivate() override;
 
   protected:

--- a/src/gui/qgsmaptoolzoom.h
+++ b/src/gui/qgsmaptoolzoom.h
@@ -35,7 +35,7 @@ class GUI_EXPORT QgsMapToolZoom : public QgsMapTool
 
     ~QgsMapToolZoom();
 
-    virtual Flags flags() const { return QgsMapTool::Transient; }
+    virtual Flags flags() const override { return QgsMapTool::Transient; }
 
     //! Overridden mouse move event
     virtual void canvasMoveEvent( QgsMapMouseEvent* e ) override;

--- a/tests/src/gui/testqgsmapcanvas.cpp
+++ b/tests/src/gui/testqgsmapcanvas.cpp
@@ -34,6 +34,17 @@ namespace QTest
   }
 }
 
+inline bool qgsDoubleNearDebug( double a, double b, double epsilon = 4 * DBL_EPSILON )
+{
+  if ( !qgsDoubleNear( a, b, epsilon ) )
+  {
+    qDebug( "Expecting %f got %f (diff %f > %f)", a, b, qAbs( a - b ), epsilon );
+    return false;
+  }
+  return true;
+}
+
+
 class QgsMapToolTest : public QgsMapTool
 {
   public:
@@ -429,8 +440,8 @@ void TestQgsMapCanvas::testShiftZoom()
                    Qt::LeftButton, Qt::LeftButton, Qt::ShiftModifier );
   mCanvas->mouseReleaseEvent( &e );
 
-  QVERIFY( qgsDoubleNear( mCanvas->extent().width(), originalWidth / 2.0, 0.1 ) );
-  QVERIFY( qgsDoubleNear( mCanvas->extent().height(), originalHeight / 2.0, 0.1 ) );
+  QVERIFY( qgsDoubleNearDebug( mCanvas->extent().width(), originalWidth / 2.0, 0.1 ) );
+  QVERIFY( qgsDoubleNearDebug( mCanvas->extent().height(), originalHeight / 2.0, 0.1 ) );
 
   //reset
   mCanvas->setExtent( QgsRectangle( 0, 0, 10, 10 ) );
@@ -446,8 +457,8 @@ void TestQgsMapCanvas::testShiftZoom()
                    Qt::LeftButton, Qt::LeftButton, Qt::ShiftModifier );
   mCanvas->mouseReleaseEvent( &e );
 
-  QVERIFY( qgsDoubleNear( mCanvas->extent().width(), originalWidth, 0.0001 ) );
-  QVERIFY( qgsDoubleNear( mCanvas->extent().height(), originalHeight, 0.0001 ) );
+  QVERIFY( qgsDoubleNearDebug( mCanvas->extent().width(), originalWidth, 0.0001 ) );
+  QVERIFY( qgsDoubleNearDebug( mCanvas->extent().height(), originalHeight, 0.0001 ) );
 
   //reset
   mCanvas->setExtent( QgsRectangle( 0, 0, 10, 10 ) );
@@ -466,8 +477,8 @@ void TestQgsMapCanvas::testShiftZoom()
                    Qt::LeftButton, Qt::LeftButton, Qt::ShiftModifier );
   mCanvas->mouseReleaseEvent( &e );
 
-  QVERIFY( qgsDoubleNear( mCanvas->extent().width(), originalWidth, 0.00001 ) );
-  QVERIFY( qgsDoubleNear( mCanvas->extent().height(), originalHeight, 0.00001 ) );
+  QVERIFY( qgsDoubleNearDebug( mCanvas->extent().width(), originalWidth, 0.00001 ) );
+  QVERIFY( qgsDoubleNearDebug( mCanvas->extent().height(), originalHeight, 0.00001 ) );
 }
 
 QTEST_MAIN( TestQgsMapCanvas )

--- a/tests/src/gui/testqgsmapcanvas.cpp
+++ b/tests/src/gui/testqgsmapcanvas.cpp
@@ -22,6 +22,7 @@
 #include <qgsmaplayerregistry.h>
 #include <qgsrenderchecker.h>
 #include <qgsvectordataprovider.h>
+#include <qgsmaptoolpan.h>
 
 namespace QTest
 {
@@ -32,6 +33,13 @@ namespace QTest
     return qstrdup( ba.data() );
   }
 }
+
+class QgsMapToolTest : public QgsMapTool
+{
+  public:
+    QgsMapToolTest( QgsMapCanvas* canvas ) : QgsMapTool( canvas ) {}
+
+};
 
 class TestQgsMapCanvas : public QObject
 {
@@ -51,6 +59,7 @@ class TestQgsMapCanvas : public QObject
     void testMagnificationExtent();
     void testMagnificationScale();
     void testZoomByWheel();
+    void testShiftZoom();
 
   private:
     QgsMapCanvas* mCanvas;
@@ -393,6 +402,72 @@ void TestQgsMapCanvas::testZoomByWheel()
   mCanvas->wheelEvent( &e );
   QVERIFY( qgsDoubleNear( mCanvas->extent().width(), originalWidth, 0.1 ) );
   QVERIFY( qgsDoubleNear( mCanvas->extent().height(), originalHeight, 0.1 ) );
+}
+
+void TestQgsMapCanvas::testShiftZoom()
+{
+  mCanvas->setExtent( QgsRectangle( 0, 0, 10, 10 ) );
+  QgsRectangle initialExtent = mCanvas->extent();
+  double originalWidth = initialExtent.width();
+  double originalHeight = initialExtent.height();
+
+  QPoint startPos = QPoint( mCanvas->width() / 4, mCanvas->height() / 4 );
+  QPoint endPos = QPoint( mCanvas->width() * 3 / 4.0, mCanvas->height() * 3 / 4.0 );
+
+  QgsMapToolPan panTool( mCanvas );
+
+  // start by testing a tool with shift-zoom enabled
+  mCanvas->setMapTool( &panTool );
+
+  QMouseEvent e( QMouseEvent::MouseButtonPress, startPos,
+                 Qt::LeftButton, Qt::LeftButton, Qt::ShiftModifier );
+  mCanvas->mousePressEvent( &e );
+  e = QMouseEvent( QMouseEvent::MouseMove, endPos,
+                   Qt::LeftButton, Qt::LeftButton, Qt::ShiftModifier );
+  mCanvas->mouseMoveEvent( &e );
+  e = QMouseEvent( QMouseEvent::MouseButtonRelease, endPos,
+                   Qt::LeftButton, Qt::LeftButton, Qt::ShiftModifier );
+  mCanvas->mouseReleaseEvent( &e );
+
+  QVERIFY( qgsDoubleNear( mCanvas->extent().width(), originalWidth / 2.0, 0.1 ) );
+  QVERIFY( qgsDoubleNear( mCanvas->extent().height(), originalHeight / 2.0, 0.1 ) );
+
+  //reset
+  mCanvas->setExtent( QgsRectangle( 0, 0, 10, 10 ) );
+
+  //test that a shift-click (no movement) will not zoom
+  e = QMouseEvent( QMouseEvent::MouseButtonPress, startPos,
+                   Qt::LeftButton, Qt::LeftButton, Qt::ShiftModifier );
+  mCanvas->mousePressEvent( &e );
+  e = QMouseEvent( QMouseEvent::MouseMove, startPos,
+                   Qt::LeftButton, Qt::LeftButton, Qt::ShiftModifier );
+  mCanvas->mouseMoveEvent( &e );
+  e = QMouseEvent( QMouseEvent::MouseButtonRelease, startPos,
+                   Qt::LeftButton, Qt::LeftButton, Qt::ShiftModifier );
+  mCanvas->mouseReleaseEvent( &e );
+
+  QVERIFY( qgsDoubleNear( mCanvas->extent().width(), originalWidth, 0.0001 ) );
+  QVERIFY( qgsDoubleNear( mCanvas->extent().height(), originalHeight, 0.0001 ) );
+
+  //reset
+  mCanvas->setExtent( QgsRectangle( 0, 0, 10, 10 ) );
+
+  //test with map tool which does not have shift-zoom enabled
+  QgsMapToolTest mapTool( mCanvas );
+  mCanvas->setMapTool( &mapTool );
+
+  e = QMouseEvent( QMouseEvent::MouseButtonPress, startPos,
+                   Qt::LeftButton, Qt::LeftButton, Qt::ShiftModifier );
+  mCanvas->mousePressEvent( &e );
+  e = QMouseEvent( QMouseEvent::MouseMove, endPos,
+                   Qt::LeftButton, Qt::LeftButton, Qt::ShiftModifier );
+  mCanvas->mouseMoveEvent( &e );
+  e = QMouseEvent( QMouseEvent::MouseButtonRelease, endPos,
+                   Qt::LeftButton, Qt::LeftButton, Qt::ShiftModifier );
+  mCanvas->mouseReleaseEvent( &e );
+
+  QVERIFY( qgsDoubleNear( mCanvas->extent().width(), originalWidth, 0.00001 ) );
+  QVERIFY( qgsDoubleNear( mCanvas->extent().height(), originalHeight, 0.00001 ) );
 }
 
 QTEST_MAIN( TestQgsMapCanvas )

--- a/tests/src/gui/testqgsmapcanvas.cpp
+++ b/tests/src/gui/testqgsmapcanvas.cpp
@@ -440,8 +440,8 @@ void TestQgsMapCanvas::testShiftZoom()
                    Qt::LeftButton, Qt::LeftButton, Qt::ShiftModifier );
   mCanvas->mouseReleaseEvent( &e );
 
-  QVERIFY( qgsDoubleNearDebug( mCanvas->extent().width(), originalWidth / 2.0, 0.1 ) );
-  QVERIFY( qgsDoubleNearDebug( mCanvas->extent().height(), originalHeight / 2.0, 0.1 ) );
+  QVERIFY( qgsDoubleNearDebug( mCanvas->extent().width(), originalWidth / 2.0, 0.2 ) );
+  QVERIFY( qgsDoubleNearDebug( mCanvas->extent().height(), originalHeight / 2.0, 0.2 ) );
 
   //reset
   mCanvas->setExtent( QgsRectangle( 0, 0, 10, 10 ) );


### PR DESCRIPTION
When certain map tools are active, you can hold down shift and drag a rectangle on the map to zoom to that area. This is enabled for the map tools which are not selection tools (since they use shift for adding to selection), and edit tools.
