### PR TITLE
[FEATURE] Allow fields to be renamed

### DIFF
--- a/python/core/qgsvectordataprovider.sip
+++ b/python/core/qgsvectordataprovider.sip
@@ -54,7 +54,9 @@ class QgsVectorDataProvider : QgsDataProvider
       /** Supports joint updates for attributes and geometry
        * Providers supporting this should still define ChangeGeometries | ChangeAttributeValues
        */
-      ChangeFeatures
+      ChangeFeatures,
+      /** Supports renaming attributes (fields). Added in QGIS 2.16 */
+      RenameAttributes,
     };
 
     /** Bitmask of all provider's editing capabilities */
@@ -204,6 +206,14 @@ class QgsVectorDataProvider : QgsDataProvider
      * @return true in case of success and false in case of failure
      */
     virtual bool deleteAttributes( const QSet<int> &attributes );
+
+    /**
+     * Renames existing attributes.
+     * @param renamedAttributes map of attribute index to new attribute name
+     * @return true in case of success and false in case of failure
+     * @note added in QGIS 2.16
+     */
+    virtual bool renameAttributes( const QgsFieldNameMap& renamedAttributes );
 
     /**
      * Changes attribute values of existing features.

--- a/python/core/qgsvectorlayer.sip
+++ b/python/core/qgsvectorlayer.sip
@@ -941,6 +941,13 @@ class QgsVectorLayer : QgsMapLayer
     /** Removes an alias (a display name) for attributes to display in dialogs */
     void remAttributeAlias( int attIndex );
 
+    /** Renames an attribute field  (but does not commit it).
+     * @param attIndex attribute index
+     * @param newName new name of field
+     * @note added in QGIS 2.16
+    */
+    bool renameAttribute( int attIndex, const QString& newName );
+
     /**
      * Adds a tab (for the attribute editor form) holding groups and fields
      *

--- a/python/core/qgsvectorlayereditbuffer.sip
+++ b/python/core/qgsvectorlayereditbuffer.sip
@@ -43,6 +43,12 @@ class QgsVectorLayerEditBuffer : QObject
     /** Delete an attribute field (but does not commit it) */
     virtual bool deleteAttribute( int attr );
 
+    /** Renames an attribute field (but does not commit it)
+     * @param attr attribute index
+     * @param newName new name of field
+     * @note added in QGIS 2.16
+    */
+    virtual bool renameAttribute( int attr, const QString& newName );
 
     /**
       Attempts to commit any changes to disk.  Returns the result of the attempt.
@@ -98,10 +104,25 @@ class QgsVectorLayerEditBuffer : QObject
     void attributeAdded( int idx );
     void attributeDeleted( int idx );
 
+    /** Emitted when an attribute has been renamed
+     * @param idx attribute index
+     * @param newName new attribute name
+     * @note added in QGSI 2.16
+     */
+    void attributeRenamed( int idx, const QString& newName );
+
     /** Signals emitted after committing changes */
     void committedAttributesDeleted( const QString& layerId, const QgsAttributeList& deletedAttributes );
     void committedAttributesAdded( const QString& layerId, const QList<QgsField>& addedAttributes );
     void committedFeaturesAdded( const QString& layerId, const QgsFeatureList& addedFeatures );
+
+    /** Emitted after committing an attribute rename
+     * @param layerId ID of layer
+     * @param renamedAttributes map of field index to new name
+     * @note added in QGIS 2.16
+     */
+    void committedAttributesRenamed( const QString& layerId, const QgsFieldNameMap& renamedAttributes );
+
     void committedFeaturesRemoved( const QString& layerId, const QgsFeatureIds& deletedFeatureIds );
     void committedAttributeValuesChanges( const QString& layerId, const QgsChangedAttributesMap& changedAttributesValues );
     void committedGeometriesChanges( const QString& layerId, const QgsGeometryMap& changedGeometries );

--- a/python/core/qgsvectorlayereditpassthrough.sip
+++ b/python/core/qgsvectorlayereditpassthrough.sip
@@ -14,6 +14,7 @@ class QgsVectorLayerEditPassthrough : QgsVectorLayerEditBuffer
     bool changeAttributeValue( QgsFeatureId fid, int field, const QVariant &newValue, const QVariant &oldValue = QVariant() );
     bool addAttribute( const QgsField &field );
     bool deleteAttribute( int attr );
+    bool renameAttribute( int attr, const QString& newName );
     bool commitChanges( QStringList& commitErrors );
     void rollBack();
 

--- a/python/core/qgsvectorlayerundocommand.sip
+++ b/python/core/qgsvectorlayerundocommand.sip
@@ -1,10 +1,21 @@
+/** \ingroup core
+ * \class QgsVectorLayerUndoCommand
+ * \brief Base class for undo commands within a QgsVectorLayerEditBuffer.
+ */
+
 class QgsVectorLayerUndoCommand : QUndoCommand
 {
 %TypeHeaderCode
 #include "qgsvectorlayerundocommand.h"
 %End
   public:
+
+    /** Constructor for QgsVectorLayerUndoCommand
+     * @param buffer associated edit buffer
+     */
     QgsVectorLayerUndoCommand( QgsVectorLayerEditBuffer *buffer /Transfer/ );
+
+    //! Returns the layer associated with the undo command
     QgsVectorLayer *layer();
     QgsGeometryCache *cache();
 
@@ -13,12 +24,22 @@ class QgsVectorLayerUndoCommand : QUndoCommand
 };
 
 
+/** \ingroup core
+ * \class QgsVectorLayerUndoCommandAddFeature
+ * \brief Undo command for adding a feature to a vector layer.
+ */
+
 class QgsVectorLayerUndoCommandAddFeature : QgsVectorLayerUndoCommand
 {
 %TypeHeaderCode
 #include "qgsvectorlayerundocommand.h"
 %End
   public:
+
+    /** Constructor for QgsVectorLayerUndoCommandAddFeature
+     * @param buffer associated edit buffer
+     * @param f feature to add to layer
+     */
     QgsVectorLayerUndoCommandAddFeature( QgsVectorLayerEditBuffer* buffer /Transfer/, QgsFeature& f );
 
     virtual void undo();
@@ -26,12 +47,22 @@ class QgsVectorLayerUndoCommandAddFeature : QgsVectorLayerUndoCommand
 };
 
 
+/** \ingroup core
+ * \class QgsVectorLayerUndoCommandDeleteFeature
+ * \brief Undo command for deleting a feature from a vector layer.
+ */
+
 class QgsVectorLayerUndoCommandDeleteFeature : QgsVectorLayerUndoCommand
 {
 %TypeHeaderCode
 #include "qgsvectorlayerundocommand.h"
 %End
   public:
+
+    /** Constructor for QgsVectorLayerUndoCommandDeleteFeature
+     * @param buffer associated edit buffer
+     * @param fid feature ID of feature to delete from layer
+     */
     QgsVectorLayerUndoCommandDeleteFeature( QgsVectorLayerEditBuffer* buffer /Transfer/, QgsFeatureId fid );
 
     virtual void undo();
@@ -39,12 +70,23 @@ class QgsVectorLayerUndoCommandDeleteFeature : QgsVectorLayerUndoCommand
 };
 
 
+/** \ingroup core
+ * \class QgsVectorLayerUndoCommandChangeGeometry
+ * \brief Undo command for modifying the geometry of a feature from a vector layer.
+ */
+
 class QgsVectorLayerUndoCommandChangeGeometry : QgsVectorLayerUndoCommand
 {
 %TypeHeaderCode
 #include "qgsvectorlayerundocommand.h"
 %End
   public:
+
+    /** Constructor for QgsVectorLayerUndoCommandChangeGeometry
+     * @param buffer associated edit buffer
+     * @param fid feature ID of feature to modify geometry of
+     * @param newGeom new geometry for feature
+     */
     QgsVectorLayerUndoCommandChangeGeometry( QgsVectorLayerEditBuffer* buffer /Transfer/, QgsFeatureId fid, QgsGeometry* newGeom /Transfer/ );
     ~QgsVectorLayerUndoCommandChangeGeometry();
 
@@ -55,17 +97,35 @@ class QgsVectorLayerUndoCommandChangeGeometry : QgsVectorLayerUndoCommand
 };
 
 
+/** \ingroup core
+ * \class QgsVectorLayerUndoCommandChangeAttribute
+ * \brief Undo command for modifying an attribute of a feature from a vector layer.
+ */
+
 class QgsVectorLayerUndoCommandChangeAttribute : QgsVectorLayerUndoCommand
 {
 %TypeHeaderCode
 #include "qgsvectorlayerundocommand.h"
 %End
   public:
+
+    /** Constructor for QgsVectorLayerUndoCommandChangeAttribute
+     * @param buffer associated edit buffer
+     * @param fid feature ID of feature to modify
+     * @param fieldIndex index of field to modify
+     * @param newValue new value of attribute
+     * @param oldValue previous value of attribute
+     */
     QgsVectorLayerUndoCommandChangeAttribute( QgsVectorLayerEditBuffer* buffer /Transfer/, QgsFeatureId fid, int fieldIndex, const QVariant &newValue, const QVariant &oldValue );
     virtual void undo();
     virtual void redo();
 };
 
+
+/** \ingroup core
+ * \class QgsVectorLayerUndoCommandAddAttribute
+ * \brief Undo command for adding a new attribute to a vector layer.
+ */
 
 class QgsVectorLayerUndoCommandAddAttribute : QgsVectorLayerUndoCommand
 {
@@ -73,6 +133,11 @@ class QgsVectorLayerUndoCommandAddAttribute : QgsVectorLayerUndoCommand
 #include "qgsvectorlayerundocommand.h"
 %End
   public:
+
+    /** Constructor for QgsVectorLayerUndoCommandAddAttribute
+     * @param buffer associated edit buffer
+     * @param field definition of new field to add
+     */
     QgsVectorLayerUndoCommandAddAttribute( QgsVectorLayerEditBuffer* buffer /Transfer/, const QgsField& field );
 
     virtual void undo();
@@ -80,13 +145,49 @@ class QgsVectorLayerUndoCommandAddAttribute : QgsVectorLayerUndoCommand
 };
 
 
+/** \ingroup core
+ * \class QgsVectorLayerUndoCommandDeleteAttribute
+ * \brief Undo command for removing an existing attribute from a vector layer.
+ */
+
 class QgsVectorLayerUndoCommandDeleteAttribute : QgsVectorLayerUndoCommand
 {
 %TypeHeaderCode
 #include "qgsvectorlayerundocommand.h"
 %End
   public:
+
+    /** Constructor for QgsVectorLayerUndoCommandDeleteAttribute
+     * @param buffer associated edit buffer
+     * @param fieldIndex index of field to delete
+     */
     QgsVectorLayerUndoCommandDeleteAttribute( QgsVectorLayerEditBuffer* buffer /Transfer/, int fieldIndex );
+
+    virtual void undo();
+    virtual void redo();
+
+};
+
+
+/** \ingroup core
+ * \class QgsVectorLayerUndoCommandRenameAttribute
+ * \brief Undo command for renaming an existing attribute of a vector layer.
+ * \note added in QGIS 2.16
+ */
+
+class QgsVectorLayerUndoCommandRenameAttribute : QgsVectorLayerUndoCommand
+{
+%TypeHeaderCode
+#include "qgsvectorlayerundocommand.h"
+%End
+  public:
+
+    /** Constructor for QgsVectorLayerUndoCommandRenameAttribute
+     * @param buffer associated edit buffer
+     * @param fieldIndex index of field to rename
+     * @param newName new name for field
+     */
+    QgsVectorLayerUndoCommandRenameAttribute( QgsVectorLayerEditBuffer* buffer /Transfer/, int fieldIndex, const QString& newName );
 
     virtual void undo();
     virtual void redo();

--- a/src/app/qgsfieldsproperties.h
+++ b/src/app/qgsfieldsproperties.h
@@ -214,6 +214,11 @@ class APP_EXPORT QgsFieldsProperties : public QWidget, private Ui_QgsFieldsPrope
     static QMap< QgsVectorLayer::EditType, QString > editTypeMap;
     static void setupEditTypes();
     static QString editTypeButtonText( QgsVectorLayer::EditType type );
+
+  private:
+
+    void updateFieldRenamingStatus();
+
 };
 
 QDataStream& operator<< ( QDataStream& stream, const QgsFieldsProperties::DesignerTreeItemData& data );

--- a/src/core/qgsvectordataprovider.cpp
+++ b/src/core/qgsvectordataprovider.cpp
@@ -81,6 +81,12 @@ bool QgsVectorDataProvider::deleteAttributes( const QgsAttributeIds &attributes 
   return false;
 }
 
+bool QgsVectorDataProvider::renameAttributes( const QgsFieldNameMap& renamedAttributes )
+{
+  Q_UNUSED( renamedAttributes );
+  return false;
+}
+
 bool QgsVectorDataProvider::changeAttributeValues( const QgsChangedAttributesMap &attr_map )
 {
   Q_UNUSED( attr_map );

--- a/src/core/qgsvectordataprovider.h
+++ b/src/core/qgsvectordataprovider.h
@@ -102,12 +102,15 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider
       /** Supports joint updates for attributes and geometry
        * Providers supporting this should still define ChangeGeometries | ChangeAttributeValues
        */
-      ChangeFeatures =                              1 << 18
+      ChangeFeatures =                              1 << 18,
+      /** Supports renaming attributes (fields). Added in QGIS 2.16 */
+      RenameAttributes =                            1 << 19,
     };
 
     /** Bitmask of all provider's editing capabilities */
     const static int EditingCapabilities = AddFeatures | DeleteFeatures |
-                                           ChangeAttributeValues | ChangeGeometries | AddAttributes | DeleteAttributes;
+                                           ChangeAttributeValues | ChangeGeometries | AddAttributes | DeleteAttributes |
+                                           RenameAttributes;
 
     /**
      * Constructor of the vector provider
@@ -253,6 +256,14 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider
      * @return true in case of success and false in case of failure
      */
     virtual bool deleteAttributes( const QgsAttributeIds &attributes );
+
+    /**
+     * Renames existing attributes.
+     * @param renamedAttributes map of attribute index to new attribute name
+     * @return true in case of success and false in case of failure
+     * @note added in QGIS 2.16
+     */
+    virtual bool renameAttributes( const QgsFieldNameMap& renamedAttributes );
 
     /**
      * Changes attribute values of existing features.

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -2360,6 +2360,14 @@ void QgsVectorLayer::remAttributeAlias( int attIndex )
   }
 }
 
+bool QgsVectorLayer::renameAttribute( int attIndex, const QString& newName )
+{
+  if ( !mEditBuffer || !mDataProvider )
+    return false;
+
+  return mEditBuffer->renameAttribute( attIndex, newName );
+}
+
 void QgsVectorLayer::addAttributeAlias( int attIndex, const QString& aliasString )
 {
   if ( attIndex < 0 || attIndex >= fields().count() )

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -1316,6 +1316,13 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
     /** Removes an alias (a display name) for attributes to display in dialogs */
     void remAttributeAlias( int attIndex );
 
+    /** Renames an attribute field  (but does not commit it).
+     * @param attIndex attribute index
+     * @param newName new name of field
+     * @note added in QGIS 2.16
+    */
+    bool renameAttribute( int attIndex, const QString& newName );
+
     /**
      * Adds a tab (for the attribute editor form) holding groups and fields
      *

--- a/src/core/qgsvectorlayereditbuffer.h
+++ b/src/core/qgsvectorlayereditbuffer.h
@@ -69,6 +69,12 @@ class CORE_EXPORT QgsVectorLayerEditBuffer : public QObject
     /** Delete an attribute field (but does not commit it) */
     virtual bool deleteAttribute( int attr );
 
+    /** Renames an attribute field (but does not commit it)
+     * @param attr attribute index
+     * @param newName new name of field
+     * @note added in QGIS 2.16
+    */
+    virtual bool renameAttribute( int attr, const QString& newName );
 
     /**
       Attempts to commit any changes to disk.  Returns the result of the attempt.
@@ -124,9 +130,23 @@ class CORE_EXPORT QgsVectorLayerEditBuffer : public QObject
     void attributeAdded( int idx );
     void attributeDeleted( int idx );
 
+    /** Emitted when an attribute has been renamed
+     * @param idx attribute index
+     * @param newName new attribute name
+     * @note added in QGSI 2.16
+     */
+    void attributeRenamed( int idx, const QString& newName );
+
     /** Signals emitted after committing changes */
     void committedAttributesDeleted( const QString& layerId, const QgsAttributeList& deletedAttributes );
     void committedAttributesAdded( const QString& layerId, const QList<QgsField>& addedAttributes );
+
+    /** Emitted after committing an attribute rename
+     * @param layerId ID of layer
+     * @param renamedAttributes map of field index to new name
+     * @note added in QGIS 2.16
+     */
+    void committedAttributesRenamed( const QString& layerId, const QgsFieldNameMap& renamedAttributes );
     void committedFeaturesAdded( const QString& layerId, const QgsFeatureList& addedFeatures );
     void committedFeaturesRemoved( const QString& layerId, const QgsFeatureIds& deletedFeatureIds );
     void committedAttributeValuesChanges( const QString& layerId, const QgsChangedAttributesMap& changedAttributesValues );
@@ -150,7 +170,6 @@ class CORE_EXPORT QgsVectorLayerEditBuffer : public QObject
     /** Update added and changed features after removal of an attribute */
     void handleAttributeDeleted( int index );
 
-
     /** Updates an index in an attribute map to a new value (for updates of changed attributes) */
     void updateAttributeMapIndex( QgsAttributeMap& attrs, int index, int offset ) const;
 
@@ -167,6 +186,7 @@ class CORE_EXPORT QgsVectorLayerEditBuffer : public QObject
     friend class QgsVectorLayerUndoCommandChangeAttribute;
     friend class QgsVectorLayerUndoCommandAddAttribute;
     friend class QgsVectorLayerUndoCommandDeleteAttribute;
+    friend class QgsVectorLayerUndoCommandRenameAttribute;
 
     /** Deleted feature IDs which are not commited.  Note a feature can be added and then deleted
         again before the change is committed - in that case the added feature would be removed
@@ -185,6 +205,9 @@ class CORE_EXPORT QgsVectorLayerEditBuffer : public QObject
 
     /** Added attributes fields which are not commited */
     QList<QgsField> mAddedAttributes;
+
+    /** Renamed attributes which are not commited. */
+    QgsFieldNameMap mRenamedAttributes;
 
     /** Changed geometries which are not commited. */
     QgsGeometryMap mChangedGeometries;

--- a/src/core/qgsvectorlayereditpassthrough.cpp
+++ b/src/core/qgsvectorlayereditpassthrough.cpp
@@ -133,6 +133,19 @@ bool QgsVectorLayerEditPassthrough::deleteAttribute( int attr )
   return false;
 }
 
+bool QgsVectorLayerEditPassthrough::renameAttribute( int attr, const QString& newName )
+{
+  QgsFieldNameMap map;
+  map[ attr ] = newName;
+  if ( L->dataProvider()->renameAttributes( map ) )
+  {
+    mModified = true;
+    emit attributeRenamed( attr, newName );
+    return true;
+  }
+  return false;
+}
+
 bool QgsVectorLayerEditPassthrough::commitChanges( QStringList& /*commitErrors*/ )
 {
   mModified = false;

--- a/src/core/qgsvectorlayereditpassthrough.h
+++ b/src/core/qgsvectorlayereditpassthrough.h
@@ -33,6 +33,7 @@ class CORE_EXPORT QgsVectorLayerEditPassthrough : public QgsVectorLayerEditBuffe
     bool changeAttributeValue( QgsFeatureId fid, int field, const QVariant &newValue, const QVariant &oldValue = QVariant() ) override;
     bool addAttribute( const QgsField &field ) override;
     bool deleteAttribute( int attr ) override;
+    bool renameAttribute( int attr, const QString& newName ) override;
     bool commitChanges( QStringList& commitErrors ) override;
     void rollBack() override;
 

--- a/src/core/qgsvectorlayerundocommand.h
+++ b/src/core/qgsvectorlayerundocommand.h
@@ -31,14 +31,24 @@ class QgsGeometryCache;
 #include "qgsvectorlayer.h"
 #include "qgsvectorlayereditbuffer.h"
 
+/** \ingroup core
+ * \class QgsVectorLayerUndoCommand
+ * \brief Base class for undo commands within a QgsVectorLayerEditBuffer.
+ */
 
 class CORE_EXPORT QgsVectorLayerUndoCommand : public QUndoCommand
 {
   public:
+
+    /** Constructor for QgsVectorLayerUndoCommand
+     * @param buffer associated edit buffer
+     */
     QgsVectorLayerUndoCommand( QgsVectorLayerEditBuffer *buffer )
         : QUndoCommand()
         , mBuffer( buffer )
     {}
+
+    //! Returns the layer associated with the undo command
     inline QgsVectorLayer *layer() { return mBuffer->L; }
     inline QgsGeometryCache *cache() { return mBuffer->L->cache(); }
 
@@ -46,13 +56,24 @@ class CORE_EXPORT QgsVectorLayerUndoCommand : public QUndoCommand
     virtual bool mergeWith( const QUndoCommand * ) override { return false; }
 
   protected:
+    //! Associated edit buffer
     QgsVectorLayerEditBuffer* mBuffer;
 };
 
 
+/** \ingroup core
+ * \class QgsVectorLayerUndoCommandAddFeature
+ * \brief Undo command for adding a feature to a vector layer.
+ */
+
 class CORE_EXPORT QgsVectorLayerUndoCommandAddFeature : public QgsVectorLayerUndoCommand
 {
   public:
+
+    /** Constructor for QgsVectorLayerUndoCommandAddFeature
+     * @param buffer associated edit buffer
+     * @param f feature to add to layer
+     */
     QgsVectorLayerUndoCommandAddFeature( QgsVectorLayerEditBuffer* buffer, QgsFeature& f );
 
     virtual void undo() override;
@@ -63,9 +84,19 @@ class CORE_EXPORT QgsVectorLayerUndoCommandAddFeature : public QgsVectorLayerUnd
 };
 
 
+/** \ingroup core
+ * \class QgsVectorLayerUndoCommandDeleteFeature
+ * \brief Undo command for deleting a feature from a vector layer.
+ */
+
 class CORE_EXPORT QgsVectorLayerUndoCommandDeleteFeature : public QgsVectorLayerUndoCommand
 {
   public:
+
+    /** Constructor for QgsVectorLayerUndoCommandDeleteFeature
+     * @param buffer associated edit buffer
+     * @param fid feature ID of feature to delete from layer
+     */
     QgsVectorLayerUndoCommandDeleteFeature( QgsVectorLayerEditBuffer* buffer, QgsFeatureId fid );
 
     virtual void undo() override;
@@ -76,10 +107,20 @@ class CORE_EXPORT QgsVectorLayerUndoCommandDeleteFeature : public QgsVectorLayer
     QgsFeature mOldAddedFeature;
 };
 
+/** \ingroup core
+ * \class QgsVectorLayerUndoCommandChangeGeometry
+ * \brief Undo command for modifying the geometry of a feature from a vector layer.
+ */
 
 class CORE_EXPORT QgsVectorLayerUndoCommandChangeGeometry : public QgsVectorLayerUndoCommand
 {
   public:
+
+    /** Constructor for QgsVectorLayerUndoCommandChangeGeometry
+     * @param buffer associated edit buffer
+     * @param fid feature ID of feature to modify geometry of
+     * @param newGeom new geometry for feature
+     */
     QgsVectorLayerUndoCommandChangeGeometry( QgsVectorLayerEditBuffer* buffer, QgsFeatureId fid, QgsGeometry* newGeom );
     ~QgsVectorLayerUndoCommandChangeGeometry();
 
@@ -95,9 +136,22 @@ class CORE_EXPORT QgsVectorLayerUndoCommandChangeGeometry : public QgsVectorLaye
 };
 
 
+/** \ingroup core
+ * \class QgsVectorLayerUndoCommandChangeAttribute
+ * \brief Undo command for modifying an attribute of a feature from a vector layer.
+ */
+
 class CORE_EXPORT QgsVectorLayerUndoCommandChangeAttribute : public QgsVectorLayerUndoCommand
 {
   public:
+
+    /** Constructor for QgsVectorLayerUndoCommandChangeAttribute
+     * @param buffer associated edit buffer
+     * @param fid feature ID of feature to modify
+     * @param fieldIndex index of field to modify
+     * @param newValue new value of attribute
+     * @param oldValue previous value of attribute
+     */
     QgsVectorLayerUndoCommandChangeAttribute( QgsVectorLayerEditBuffer* buffer, QgsFeatureId fid, int fieldIndex, const QVariant &newValue, const QVariant &oldValue );
     virtual void undo() override;
     virtual void redo() override;
@@ -110,10 +164,19 @@ class CORE_EXPORT QgsVectorLayerUndoCommandChangeAttribute : public QgsVectorLay
     bool mFirstChange;
 };
 
+/** \ingroup core
+ * \class QgsVectorLayerUndoCommandAddAttribute
+ * \brief Undo command for adding a new attribute to a vector layer.
+ */
 
 class CORE_EXPORT QgsVectorLayerUndoCommandAddAttribute : public QgsVectorLayerUndoCommand
 {
   public:
+
+    /** Constructor for QgsVectorLayerUndoCommandAddAttribute
+     * @param buffer associated edit buffer
+     * @param field definition of new field to add
+     */
     QgsVectorLayerUndoCommandAddAttribute( QgsVectorLayerEditBuffer* buffer, const QgsField& field );
 
     virtual void undo() override;
@@ -124,10 +187,19 @@ class CORE_EXPORT QgsVectorLayerUndoCommandAddAttribute : public QgsVectorLayerU
     int mFieldIndex;
 };
 
+/** \ingroup core
+ * \class QgsVectorLayerUndoCommandDeleteAttribute
+ * \brief Undo command for removing an existing attribute from a vector layer.
+ */
 
 class CORE_EXPORT QgsVectorLayerUndoCommandDeleteAttribute : public QgsVectorLayerUndoCommand
 {
   public:
+
+    /** Constructor for QgsVectorLayerUndoCommandDeleteAttribute
+     * @param buffer associated edit buffer
+     * @param fieldIndex index of field to delete
+     */
     QgsVectorLayerUndoCommandDeleteAttribute( QgsVectorLayerEditBuffer* buffer, int fieldIndex );
 
     virtual void undo() override;
@@ -141,6 +213,34 @@ class CORE_EXPORT QgsVectorLayerUndoCommandDeleteAttribute : public QgsVectorLay
     QgsEditorWidgetConfig mOldEditorWidgetConfig;
 
     QMap<QgsFeatureId, QVariant> mDeletedValues;
+    QString mOldName;
+};
+
+
+/** \ingroup core
+ * \class QgsVectorLayerUndoCommandRenameAttribute
+ * \brief Undo command for renaming an existing attribute of a vector layer.
+ * \note added in QGIS 2.16
+ */
+
+class CORE_EXPORT QgsVectorLayerUndoCommandRenameAttribute : public QgsVectorLayerUndoCommand
+{
+  public:
+
+    /** Constructor for QgsVectorLayerUndoCommandRenameAttribute
+     * @param buffer associated edit buffer
+     * @param fieldIndex index of field to rename
+     * @param newName new name for field
+     */
+    QgsVectorLayerUndoCommandRenameAttribute( QgsVectorLayerEditBuffer* buffer, int fieldIndex, const QString& newName );
+
+    virtual void undo() override;
+    virtual void redo() override;
+
+  private:
+    int mFieldIndex;
+    QString mOldName;
+    QString mNewName;
 };
 
 

--- a/src/providers/memory/qgsmemoryprovider.cpp
+++ b/src/providers/memory/qgsmemoryprovider.cpp
@@ -375,7 +375,6 @@ bool QgsMemoryProvider::addAttributes( const QList<QgsField> &attributes )
 {
   for ( QList<QgsField>::const_iterator it = attributes.begin(); it != attributes.end(); ++it )
   {
-    // Why are attributes restricted to int,double and string only?
     switch ( it->type() )
     {
       case QVariant::Int:
@@ -402,6 +401,30 @@ bool QgsMemoryProvider::addAttributes( const QList<QgsField> &attributes )
     }
   }
   return true;
+}
+
+bool QgsMemoryProvider::renameAttributes( const QgsFieldNameMap& renamedAttributes )
+{
+  QgsFieldNameMap::const_iterator renameIt = renamedAttributes.constBegin();
+  bool result = true;
+  for ( ; renameIt != renamedAttributes.constEnd(); ++renameIt )
+  {
+    int fieldIndex = renameIt.key();
+    if ( fieldIndex < 0 || fieldIndex >= mFields.count() )
+    {
+      result = false;
+      continue;
+    }
+    if ( mFields.indexFromName( renameIt.value() ) >= 0 )
+    {
+      //field name already in use
+      result = false;
+      continue;
+    }
+
+    mFields[ fieldIndex ].setName( renameIt.value() );
+  }
+  return result;
 }
 
 bool QgsMemoryProvider::deleteAttributes( const QgsAttributeIds& attributes )
@@ -506,7 +529,7 @@ bool QgsMemoryProvider::createSpatialIndex()
 int QgsMemoryProvider::capabilities() const
 {
   return AddFeatures | DeleteFeatures | ChangeGeometries |
-         ChangeAttributeValues | AddAttributes | DeleteAttributes | CreateSpatialIndex |
+         ChangeAttributeValues | AddAttributes | DeleteAttributes | RenameAttributes | CreateSpatialIndex |
          SelectAtId | SelectGeometryAtId | CircularGeometries;
 }
 

--- a/src/providers/memory/qgsmemoryprovider.h
+++ b/src/providers/memory/qgsmemoryprovider.h
@@ -89,6 +89,8 @@ class QgsMemoryProvider : public QgsVectorDataProvider
      */
     virtual bool addAttributes( const QList<QgsField> &attributes ) override;
 
+    virtual bool renameAttributes( const QgsFieldNameMap& renamedAttributes ) override;
+
     /**
      * Deletes existing attributes
      * @param attributes a set containing names of attributes
@@ -131,7 +133,6 @@ class QgsMemoryProvider : public QgsVectorDataProvider
     be prudent to check this value per intended operation.
      */
     virtual int capabilities() const override;
-
 
     /* Implementation of functions from QgsDataProvider */
 

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -1308,6 +1308,48 @@ bool QgsOgrProvider::deleteAttributes( const QgsAttributeIds &attributes )
 #endif
 }
 
+bool QgsOgrProvider::renameAttributes( const QgsFieldNameMap& renamedAttributes )
+{
+  if ( !doInitialActionsForEdition() )
+    return false;
+
+#if defined(GDAL_VERSION_NUM) && GDAL_VERSION_NUM >= 1900
+  QgsFieldNameMap::const_iterator renameIt = renamedAttributes.constBegin();
+  bool result = true;
+  for ( ; renameIt != renamedAttributes.constEnd(); ++renameIt )
+  {
+    int fieldIndex = renameIt.key();
+    if ( fieldIndex < 0 || fieldIndex >= mAttributeFields.count() )
+    {
+      pushError( tr( "Invalid attribute index" ) );
+      result = false;
+      continue;
+    }
+    if ( mAttributeFields.indexFromName( renameIt.value() ) >= 0 )
+    {
+      //field name already in use
+      pushError( tr( "Error renaming field %1: name '%2' already exists" ).arg( fieldIndex ).arg( renameIt.value() ) );
+      result = false;
+      continue;
+    }
+
+    //type does not matter, it will not be used
+    OGRFieldDefnH fld = OGR_Fld_Create( mEncoding->fromUnicode( renameIt.value() ), OFTReal );
+    if ( OGR_L_AlterFieldDefn( ogrLayer, fieldIndex, fld, ALTER_NAME_FLAG ) != OGRERR_NONE )
+    {
+      pushError( tr( "OGR error renaming field %1: %2" ).arg( fieldIndex ).arg( CPLGetLastErrorMsg() ) );
+      result = false;
+    }
+  }
+  loadFields();
+  return result;
+#else
+  Q_UNUSED( attributes );
+  pushError( tr( "Renaming fields is not supported prior to GDAL 1.9.0" ) );
+  return false;
+#endif
+}
+
 
 bool QgsOgrProvider::changeAttributeValues( const QgsChangedAttributesMap &attr_map )
 {
@@ -1715,6 +1757,11 @@ void QgsOgrProvider::computeCapabilities()
     if ( mWriteAccessPossible && OGR_L_TestCapability( ogrLayer, "DeleteField" ) )
     {
       ability |= DeleteAttributes;
+    }
+
+    if ( mWriteAccessPossible && OGR_L_TestCapability( ogrLayer, "AlterFieldDefn" ) )
+    {
+      ability |= RenameAttributes;
     }
 
 #if defined(OLCStringsAsUTF8)

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -1332,14 +1332,26 @@ bool QgsOgrProvider::renameAttributes( const QgsFieldNameMap& renamedAttributes 
       result = false;
       continue;
     }
+    int ogrFieldIndex = fieldIndex;
+    if ( mFirstFieldIsFid )
+    {
+      ogrFieldIndex -= 1;
+      if ( ogrFieldIndex < 0 )
+      {
+        pushError( tr( "Invalid attribute index" ) );
+        result = false;
+        continue;
+      }
+    }
 
     //type does not matter, it will not be used
     OGRFieldDefnH fld = OGR_Fld_Create( mEncoding->fromUnicode( renameIt.value() ), OFTReal );
-    if ( OGR_L_AlterFieldDefn( ogrLayer, fieldIndex, fld, ALTER_NAME_FLAG ) != OGRERR_NONE )
+    if ( OGR_L_AlterFieldDefn( ogrLayer, ogrFieldIndex, fld, ALTER_NAME_FLAG ) != OGRERR_NONE )
     {
       pushError( tr( "OGR error renaming field %1: %2" ).arg( fieldIndex ).arg( CPLGetLastErrorMsg() ) );
       result = false;
     }
+    OGR_Fld_Destroy( fld );
   }
   loadFields();
   return result;

--- a/src/providers/ogr/qgsogrprovider.h
+++ b/src/providers/ogr/qgsogrprovider.h
@@ -137,19 +137,9 @@ class QgsOgrProvider : public QgsVectorDataProvider
     /** Deletes a feature*/
     virtual bool deleteFeatures( const QgsFeatureIds & id ) override;
 
-    /**
-     * Adds new attributes
-     * @param attributes list of new attributes
-     * @return true in case of success and false in case of failure
-     */
     virtual bool addAttributes( const QList<QgsField> &attributes ) override;
-
-    /**
-     * Deletes existing attributes
-     * @param attributes a set containing names of attributes
-     * @return true in case of success and false in case of failure
-     */
     virtual bool deleteAttributes( const QgsAttributeIds &attributes ) override;
+    virtual bool renameAttributes( const QgsFieldNameMap& renamedAttributes ) override;
 
     /** Changes attribute values of existing features */
     virtual bool changeAttributeValues( const QgsChangedAttributesMap &attr_map ) override;

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -1123,7 +1123,7 @@ bool QgsPostgresProvider::hasSufficientPermsAndCapabilities()
       testAccess = connectionRO()->PQexec( sql );
       if ( testAccess.PQresultStatus() == PGRES_TUPLES_OK && testAccess.PQntuples() == 1 )
       {
-        mEnabledCapabilities |= QgsVectorDataProvider::AddAttributes | QgsVectorDataProvider::DeleteAttributes;
+        mEnabledCapabilities |= QgsVectorDataProvider::AddAttributes | QgsVectorDataProvider::DeleteAttributes | QgsVectorDataProvider::RenameAttributes;
       }
     }
   }
@@ -2242,6 +2242,66 @@ bool QgsPostgresProvider::deleteAttributes( const QgsAttributeIds& ids )
   catch ( PGException &e )
   {
     pushError( tr( "PostGIS error while deleting attributes: %1" ).arg( e.errorMessage() ) );
+    conn->rollback();
+    returnvalue = false;
+  }
+
+  loadFields();
+  conn->unlock();
+  return returnvalue;
+}
+
+bool QgsPostgresProvider::renameAttributes( const QgsFieldNameMap& renamedAttributes )
+{
+  if ( mIsQuery )
+    return false;
+
+
+  QString sql = "BEGIN;";
+
+  QgsFieldNameMap::const_iterator renameIt = renamedAttributes.constBegin();
+  bool returnvalue = true;
+  for ( ; renameIt != renamedAttributes.constEnd(); ++renameIt )
+  {
+    int fieldIndex = renameIt.key();
+    if ( fieldIndex < 0 || fieldIndex >= mAttributeFields.count() )
+    {
+      pushError( tr( "Invalid attribute index: %1" ).arg( fieldIndex ) );
+      return false;
+    }
+    if ( mAttributeFields.indexFromName( renameIt.value() ) >= 0 )
+    {
+      //field name already in use
+      pushError( tr( "Error renaming field %1: name '%2' already exists" ).arg( fieldIndex ).arg( renameIt.value() ) );
+      return false;
+    }
+
+    sql += QString( "ALTER TABLE %1 RENAME COLUMN %2 TO %3;" )
+           .arg( mQuery,
+                 quotedIdentifier( mAttributeFields.at( fieldIndex ).name() ),
+                 quotedIdentifier( renameIt.value() ) );
+  }
+  sql += "COMMIT;";
+
+  QgsPostgresConn* conn = connectionRW();
+  if ( !conn )
+  {
+    return false;
+  }
+  conn->lock();
+
+  try
+  {
+    conn->begin();
+    //send sql statement and do error handling
+    QgsPostgresResult result( conn->PQexec( sql ) );
+    if ( result.PQresultStatus() != PGRES_COMMAND_OK )
+      throw PGException( result );
+    returnvalue = conn->commit();
+  }
+  catch ( PGException &e )
+  {
+    pushError( tr( "PostGIS error while renaming attributes: %1" ).arg( e.errorMessage() ) );
     conn->rollback();
     returnvalue = false;
   }

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -197,15 +197,9 @@ class QgsPostgresProvider : public QgsVectorDataProvider
       @return true in case of success and false in case of failure*/
     bool deleteFeatures( const QgsFeatureIds & id ) override;
 
-    /** Adds new attributes
-      @param name map with attribute name as key and type as value
-      @return true in case of success and false in case of failure*/
     bool addAttributes( const QList<QgsField> &attributes ) override;
-
-    /** Deletes existing attributes
-      @param names of the attributes to delete
-      @return true in case of success and false in case of failure*/
     bool deleteAttributes( const QgsAttributeIds &name ) override;
+    virtual bool renameAttributes( const QgsFieldNameMap& renamedAttributes ) override;
 
     /** Changes attribute values of existing features
       @param attr_map a map containing the new attributes. The integer is the feature id,

--- a/tests/src/python/test_provider_shapefile.py
+++ b/tests/src/python/test_provider_shapefile.py
@@ -294,5 +294,51 @@ class TestPyQgsShapefileProvider(unittest.TestCase, ProviderTestCase):
         # And now check that fields are up-to-date
         self.assertEquals(len(vl1.fields()), len(vl2.fields()))
 
+    def testRenameAttributes(self):
+        ''' Test renameAttributes() '''
+
+        tmpdir = tempfile.mkdtemp()
+        self.dirs_to_cleanup.append(tmpdir)
+        srcpath = os.path.join(TEST_DATA_DIR, 'provider')
+        for file in glob.glob(os.path.join(srcpath, 'shapefile.*')):
+            shutil.copy(os.path.join(srcpath, file), tmpdir)
+        datasource = os.path.join(tmpdir, 'shapefile.shp')
+
+        vl = QgsVectorLayer(u'{}|layerid=0'.format(datasource), u'test', u'ogr')
+        provider = vl.dataProvider()
+
+        # bad rename
+        self.assertFalse(provider.renameAttributes({-1: 'not_a_field'}))
+        self.assertFalse(provider.renameAttributes({100: 'not_a_field'}))
+        # already exists
+        self.assertFalse(provider.renameAttributes({2: 'cnt'}))
+
+        # rename one field
+        self.assertTrue(provider.renameAttributes({2: 'newname'}))
+        self.assertEqual(provider.fields().at(2).name(), 'newname')
+        vl.updateFields()
+        fet = next(vl.getFeatures())
+        self.assertEqual(fet.fields()[2].name(), 'newname')
+
+        # rename two fields
+        self.assertTrue(provider.renameAttributes({2: 'newname2', 3: 'another'}))
+        self.assertEqual(provider.fields().at(2).name(), 'newname2')
+        self.assertEqual(provider.fields().at(3).name(), 'another')
+        vl.updateFields()
+        fet = next(vl.getFeatures())
+        self.assertEqual(fet.fields()[2].name(), 'newname2')
+        self.assertEqual(fet.fields()[3].name(), 'another')
+
+        # close file and reopen, then recheck to confirm that changes were saved to file
+        del vl
+        vl = None
+        vl = QgsVectorLayer(u'{}|layerid=0'.format(datasource), u'test', u'ogr')
+        provider = vl.dataProvider()
+        self.assertEqual(provider.fields().at(2).name(), 'newname2')
+        self.assertEqual(provider.fields().at(3).name(), 'another')
+        fet = next(vl.getFeatures())
+        self.assertEqual(fet.fields()[2].name(), 'newname2')
+        self.assertEqual(fet.fields()[3].name(), 'another')
+
 if __name__ == '__main__':
     unittest.main()

--- a/tests/src/python/test_provider_tabfile.py
+++ b/tests/src/python/test_provider_tabfile.py
@@ -13,7 +13,7 @@ __copyright__ = 'Copyright 2016, The QGIS Project'
 __revision__ = '$Format:%H$'
 
 import os
-
+import tempfile
 from qgis.core import QgsVectorLayer, QgsFeatureRequest, QgsVectorDataProvider
 from qgis.PyQt.QtCore import QDate, QTime, QDateTime, QVariant
 from qgis.testing import (
@@ -22,6 +22,9 @@ from qgis.testing import (
 )
 import osgeo.gdal
 from utilities import unitTestDataPath
+import tempfile
+import shutil
+import glob
 
 start_app()
 TEST_DATA_DIR = unitTestDataPath()
@@ -30,6 +33,18 @@ TEST_DATA_DIR = unitTestDataPath()
 
 
 class TestPyQgsTabfileProvider(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        """Run before all tests"""
+        cls.basetestpath = tempfile.mkdtemp()
+        cls.dirs_to_cleanup = [cls.basetestpath]
+
+    @classmethod
+    def tearDownClass(cls):
+        """Run after all tests"""
+        for dirname in cls.dirs_to_cleanup:
+            shutil.rmtree(dirname, True)
 
     def testDateTimeFormats(self):
         # check that date and time formats are correctly interpreted
@@ -74,6 +89,7 @@ class TestPyQgsTabfileProvider(unittest.TestCase):
         self.assertTrue(vl.commitChanges())
         self.assertEquals(vl.dataProvider().property("_debug_open_mode"), "read-only")
         self.assertTrue(vl.dataProvider().isValid())
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/testdata/provider/testdata_pg.sql
+++ b/tests/testdata/provider/testdata_pg.sql
@@ -398,3 +398,17 @@ CREATE TABLE qgis_test.domains
   fld_text_domain qgis_test.text_domain,
   fld_numeric_domain qgis_test.numeric_domain
 );
+
+
+--------------------------------------
+-- Temporary table for testing renaming fields
+--
+
+CREATE TABLE qgis_test.rename_table
+(
+  gid serial NOT NULL,
+  field1 text,
+  field2 text
+);
+
+INSERT INTO qgis_test.rename_table (field1,field2) VALUES ('a','b');


### PR DESCRIPTION
This PR adds support for renaming fields. This is done by double clicking the field name in the fields tab while the layer is in edit mode.

Data provider support has been added for memory layers, postgres and OGR (although OGR support is dependent on the data type and gdal version). 

Attribute renames are added through the edit buffer, so the changes can be rolled back.

@m-kuhn mind reviewing this for me?
