### PR TITLE
Ctrl zoom

### DIFF
--- a/python/gui/qgsmapcanvas.sip
+++ b/python/gui/qgsmapcanvas.sip
@@ -279,12 +279,6 @@ class QgsMapCanvas : QGraphicsView
     //! set the wheel zoom factor
     void setWheelFactor( double factor );
 
-    //! Zoom in with fixed factor
-    void zoomIn();
-
-    //! Zoom out with fixed factor
-    void zoomOut();
-
     //! Zoom to a specific scale
     void zoomScale( double scale );
 
@@ -465,6 +459,12 @@ class QgsMapCanvas : QGraphicsView
     //! @note added in 2.16
     //! @see scaleLocked()
     void setScaleLocked( bool isLocked );
+
+    //! Zoom in with fixed factor
+    void zoomIn();
+
+    //! Zoom out with fixed factor
+    void zoomOut();
 
   signals:
     /** Let the owner know how far we are with render operations */

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -54,6 +54,7 @@
 #include <QRegExp>
 #include <QRegExpValidator>
 #include <QSettings>
+#include <QShortcut>
 #include <QSpinBox>
 #include <QSplashScreen>
 #ifndef QT_NO_OPENSSL
@@ -935,6 +936,14 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
   mMapCanvas->clearExtentHistory(); // reset zoomnext/zoomlast
   mLastComposerId = 0;
 
+  QAction* zoomAction = new QAction( this );
+  connect( zoomAction, SIGNAL( triggered( bool ) ), mMapCanvas, SLOT( zoomIn() ) );
+  zoomAction->setShortcut( QKeySequence( "Ctrl++" ) );
+  QShortcut* zoomShortCut = new QShortcut( QKeySequence( tr( "Ctrl+=" ) ), this );
+  connect( zoomShortCut, SIGNAL( activated() ), mMapCanvas, SLOT( zoomIn() ) );
+  QAction* zoomOutAction = new QAction( this );
+  connect( zoomOutAction, SIGNAL( triggered( bool ) ), mMapCanvas, SLOT( zoomOut() ) );
+  zoomOutAction->setShortcut( QKeySequence( "Ctrl+-" ) );
 
   // Show a nice tip of the day
   if ( settings.value( QString( "/qgis/showTips%1" ).arg( QGis::QGIS_VERSION_INT / 100 ), true ).toBool() )

--- a/src/gui/qgsmapcanvas.h
+++ b/src/gui/qgsmapcanvas.h
@@ -350,12 +350,6 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     //! set wheel zoom factor (should be greater than 1)
     void setWheelFactor( double factor );
 
-    //! Zoom in with fixed factor
-    void zoomIn();
-
-    //! Zoom out with fixed factor
-    void zoomOut();
-
     //! Zoom to a specific scale
     void zoomScale( double scale );
 
@@ -536,6 +530,12 @@ class GUI_EXPORT QgsMapCanvas : public QGraphicsView
     //! @note added in 2.16
     //! @see scaleLocked()
     void setScaleLocked( bool isLocked );
+
+    //! Zoom in with fixed factor
+    void zoomIn();
+
+    //! Zoom out with fixed factor
+    void zoomOut();
 
   private slots:
     //! called when current maptool is destroyed

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -933,7 +933,7 @@
     <string>Zoom In</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl++</string>
+    <string>Ctrl+Alt++</string>
    </property>
   </action>
   <action name="mActionZoomOut">
@@ -948,7 +948,7 @@
     <string>Zoom Out</string>
    </property>
    <property name="shortcut">
-    <string>Ctrl+-</string>
+    <string>Ctrl+Alt+-</string>
    </property>
   </action>
   <action name="mActionSelectFeatures">


### PR DESCRIPTION
This PR changes the shortcuts to swap to the zoom in/out tool to Ctrl+Alt +/-, and makes Ctrl + and Ctrl - trigger an immediate zoom in/out.

Having Ctrl +/- perform an immediate zoom in/out is standard across almost all apps with a zoom facility, so we should respect that same behavior.

This change also helps bring canvas and composer behavior closer together.

@anitagraser thoughts?
