### PR TITLE
Geomchecker fixes

### DIFF
--- a/src/core/geometry/qgsabstractgeometryv2.cpp
+++ b/src/core/geometry/qgsabstractgeometryv2.cpp
@@ -174,6 +174,7 @@ QgsPointV2 QgsAbstractGeometryV2::centroid() const
   double A = 0.;
   double Cx = 0.;
   double Cy = 0.;
+  QgsPointV2 v0 = vertexAt( QgsVertexId( 0, 0, 0 ) );
   int i = 0, j = 1;
   if ( vertexAt( QgsVertexId( 0, 0, 0 ) ) != vertexAt( QgsVertexId( 0, 0, n - 1 ) ) )
   {
@@ -184,6 +185,10 @@ QgsPointV2 QgsAbstractGeometryV2::centroid() const
   {
     QgsPointV2 vi = vertexAt( QgsVertexId( 0, 0, i ) );
     QgsPointV2 vj = vertexAt( QgsVertexId( 0, 0, j ) );
+    vi.rx() -= v0.x();
+    vi.ry() -= v0.y();
+    vj.rx() -= v0.x();
+    vj.ry() -= v0.y();
     double d = vi.x() * vj.y() - vj.x() * vi.y();
     A += d;
     Cx += ( vi.x() + vj.x() ) * d;
@@ -203,7 +208,7 @@ QgsPointV2 QgsAbstractGeometryV2::centroid() const
   }
   else
   {
-    return QgsPointV2( Cx / ( 3. * A ), Cy / ( 3. * A ) );
+    return QgsPointV2( v0.x() + Cx / ( 3. * A ), v0.y() + Cy / ( 3. * A ) );
   }
 }
 

--- a/src/plugins/geometry_checker/ui/qgsgeometrycheckerdialog.cpp
+++ b/src/plugins/geometry_checker/ui/qgsgeometrycheckerdialog.cpp
@@ -70,7 +70,7 @@ void QgsGeometryCheckerDialog::onCheckerFinished( bool successful )
   {
     mTabWidget->setTabEnabled( 1, true );
     mTabWidget->setCurrentIndex( 1 );
-    static_cast<QgsGeometryCheckerResultTab*>( mTabWidget->widget( 1 ) )->showCheckMessages();
+    static_cast<QgsGeometryCheckerResultTab*>( mTabWidget->widget( 1 ) )->finalize();
   }
 }
 

--- a/src/plugins/geometry_checker/ui/qgsgeometrycheckerresulttab.cpp
+++ b/src/plugins/geometry_checker/ui/qgsgeometrycheckerresulttab.cpp
@@ -76,7 +76,9 @@ QgsGeometryCheckerResultTab::QgsGeometryCheckerResultTab( QgisInterface* iface, 
 
   ui.progressBarFixErrors->setVisible( false );
   ui.tableWidgetErrors->horizontalHeader()->setSortIndicator( 0, Qt::AscendingOrder );
+  // Not sure why, but this is needed...
   ui.tableWidgetErrors->setSortingEnabled( true );
+  ui.tableWidgetErrors->setSortingEnabled( false );
 }
 
 QgsGeometryCheckerResultTab::~QgsGeometryCheckerResultTab()
@@ -88,8 +90,9 @@ QgsGeometryCheckerResultTab::~QgsGeometryCheckerResultTab()
   qDeleteAll( mCurrentRubberBands );
 }
 
-void QgsGeometryCheckerResultTab::showCheckMessages()
+void QgsGeometryCheckerResultTab::finalize()
 {
+  ui.tableWidgetErrors->setSortingEnabled( true );
   if ( !mChecker->getMessages().isEmpty() )
   {
     QDialog dialog;
@@ -107,11 +110,6 @@ void QgsGeometryCheckerResultTab::showCheckMessages()
 
 void QgsGeometryCheckerResultTab::addError( QgsGeometryCheckError *error )
 {
-  // Disable sorting to prevent crashes: if i.e. sorting by col 0, as soon as the item(row, 0)
-  // is set, the row is potentially moved due to sorting, and subsequent item(row, col) reference wrong
-  // item
-  ui.tableWidgetErrors->setSortingEnabled( false );
-
   int row = ui.tableWidgetErrors->rowCount();
   int prec = 7 - std::floor( qMax( 0., std::log10( qMax( error->location().x(), error->location().y() ) ) ) );
   QString posStr = QString( "%1, %2" ).arg( error->location().x(), 0, 'f', prec ).arg( error->location().y(), 0, 'f', prec );
@@ -144,8 +142,6 @@ void QgsGeometryCheckerResultTab::addError( QgsGeometryCheckError *error )
   ui.labelErrorCount->setText( tr( "Total errors: %1, fixed errors: %2" ).arg( mErrorCount ).arg( mFixedCount ) );
   mStatistics.newErrors.insert( error );
   mErrorMap.insert( error, QPersistentModelIndex( ui.tableWidgetErrors->model()->index( row, 0 ) ) );
-
-  ui.tableWidgetErrors->setSortingEnabled( true );
 }
 
 void QgsGeometryCheckerResultTab::updateError( QgsGeometryCheckError *error, bool statusChanged )

--- a/src/plugins/geometry_checker/ui/qgsgeometrycheckerresulttab.h
+++ b/src/plugins/geometry_checker/ui/qgsgeometrycheckerresulttab.h
@@ -34,7 +34,7 @@ class QgsGeometryCheckerResultTab : public QWidget
   public:
     QgsGeometryCheckerResultTab( QgisInterface* iface, QgsGeometryChecker* checker, QgsFeaturePool *featurePool, QTabWidget *tabWidget, QWidget* parent = nullptr );
     ~QgsGeometryCheckerResultTab();
-    void showCheckMessages();
+    void finalize();
     bool isCloseable() const { return mCloseable; }
 
     static QString sSettingsGroup;


### PR DESCRIPTION
- Speed up listing of geometry checker results by not sorting every time a result is added to the table widget
- Improve numerical stability of QgsAbstractGeometryV2::centroid by shifting coordinates to origin
