### PR TITLE
[FEATURE] Copy attribute cell content in clipboard

### DIFF
--- a/python/gui/attributetable/qgsdualview.sip
+++ b/python/gui/attributetable/qgsdualview.sip
@@ -189,6 +189,12 @@ class QgsDualView : QStackedWidget
      */
     void toggleSearchMode( bool enabled );
 
+    /**
+     * Copy the content of the selected cell in the clipboard.
+     * @note added in QGIS 1.16
+     */
+    void copyCellContent() const;
+
   signals:
     /**
      * Is emitted, whenever the display expression is successfully changed

--- a/src/gui/attributetable/qgsdualview.h
+++ b/src/gui/attributetable/qgsdualview.h
@@ -226,6 +226,12 @@ class GUI_EXPORT QgsDualView : public QStackedWidget, private Ui::QgsDualViewBas
      */
     void toggleSearchMode( bool enabled );
 
+    /**
+     * Copy the content of the selected cell in the clipboard.
+     * @note added in QGIS 1.16
+     */
+    void copyCellContent() const;
+
   signals:
     /**
      * Is emitted, whenever the display expression is successfully changed
@@ -357,5 +363,7 @@ class GUI_EXPORT QgsAttributeTableMapLayerAction : public QAction
     QgsMapLayerAction* mAction;
     QModelIndex mFieldIdx;
 };
+
+Q_DECLARE_METATYPE( QModelIndex );
 
 #endif // QGSDUALVIEW_H


### PR DESCRIPTION
This feature add a way to copy a cell content (whatever the widget type) in the clipboard.  A new item in the contextual menu opened by a right click on a cell is now available : "Copy cell content".

![paste_cell](https://cloud.githubusercontent.com/assets/9266424/15690080/243e6402-2782-11e6-9024-b1ac0f561a3a.png)
