### PR TITLE
Hillshaderenderer: Add 'multidirectional oblique-weighted' rendering option

### DIFF
--- a/python/core/raster/qgshillshaderenderer.sip
+++ b/python/core/raster/qgshillshaderenderer.sip
@@ -46,6 +46,12 @@ class QgsHillshadeRenderer : QgsRasterRenderer
      */
     double zFactor()  const;
 
+    /**
+     * @brief Is Multi Directional
+     * @return Is Multi Directional
+     */
+    bool multiDirectional() const;
+
 
     /**
      * @brief Set the azimith of the light source.
@@ -64,4 +70,10 @@ class QgsHillshadeRenderer : QgsRasterRenderer
      * @param zfactor The z factor.
      */
     void setZFactor( double zfactor );
+
+    /**
+     * @brief Set Is Multi Directional
+     * @param isMultiDirectional Is multi directional
+     */
+    void setMultiDirectional( bool isMultiDirectional );
 };

--- a/python/gui/raster/qgshillshaderendererwidget.sip
+++ b/python/gui/raster/qgshillshaderendererwidget.sip
@@ -51,6 +51,12 @@ class QgsHillshadeRendererWidget: QgsRasterRendererWidget
      */
     double zFactor()  const;
 
+    /**
+     * @brief multiDirectional
+     * @return multiDirectional
+     */
+    bool multiDirectional() const;
+
   public slots:
     /**
      * @brief Set the altitude of the light source
@@ -69,4 +75,10 @@ class QgsHillshadeRendererWidget: QgsRasterRendererWidget
      * @param zfactor The z factor.
      */
     void setZFactor( double zfactor );
+
+    /**
+     * @brief set MultiDirectional
+     * @param isMultiDirectional
+     */
+    void setMultiDirectional( bool isMultiDirectional);
 };

--- a/src/core/raster/qgshillshaderenderer.h
+++ b/src/core/raster/qgshillshaderenderer.h
@@ -85,6 +85,12 @@ class CORE_EXPORT QgsHillshadeRenderer : public QgsRasterRenderer
     double zFactor()  const { return mZFactor; }
 
     /**
+     * @brief Is Multi Directional
+     * @return Is Multi Directional
+     */
+    bool multiDirectional() const { return mMultiDirectional; }
+
+    /**
      * @brief Set the azimith of the light source.
      * @param azimuth The azimuth of the light source.
      */
@@ -102,11 +108,18 @@ class CORE_EXPORT QgsHillshadeRenderer : public QgsRasterRenderer
      */
     void setZFactor( double zfactor ) { mZFactor = zfactor; }
 
+    /**
+     * @brief Set Is Multi Directional
+     * @param isMultiDirectional Is multi directional
+     */
+    void setMultiDirectional( bool isMultiDirectional ){ mMultiDirectional = isMultiDirectional; }
+
   private:
     int mBand;
     double mZFactor;
     double mLightAngle;
     double mLightAzimuth;
+    bool   mMultiDirectional;
 
     /** Calculates the first order derivative in x-direction according to Horn (1981)*/
     double calcFirstDerX( double x11, double x21, double x31, double x12, double x22, double x32, double x13, double x23, double x33 , double cellsize );

--- a/src/gui/raster/qgshillshaderendererwidget.cpp
+++ b/src/gui/raster/qgshillshaderendererwidget.cpp
@@ -40,6 +40,8 @@ QgsHillshadeRendererWidget::QgsHillshadeRendererWidget( QgsRasterLayer *layer, c
   mZFactor->setValue( 1 );
   mZFactor->setClearValue( 1 );
 
+  mMultiDirection->setChecked( false );
+
   if ( mRasterLayer )
   {
     QgsRasterDataProvider* provider = mRasterLayer->dataProvider();
@@ -63,6 +65,7 @@ QgsHillshadeRendererWidget::QgsHillshadeRendererWidget( QgsRasterLayer *layer, c
   connect( mLightAzimuth, SIGNAL( valueChanged( double ) ), this, SLOT( on_mLightAzimuth_updated( double ) ) );
   connect( mLightAzimuthDial, SIGNAL( valueChanged( int ) ), this, SLOT( on_mLightAzimuthDail_updated( int ) ) );
   connect( mZFactor, SIGNAL( valueChanged( double ) ), this, SIGNAL( widgetChanged() ) );
+  connect( mMultiDirection, SIGNAL( stateChanged( int )), this, SIGNAL( widgetChanged() ) );
 
   QgsBilinearRasterResampler* zoomedInResampler = new QgsBilinearRasterResampler();
   layer->resampleFilter()->setZoomedInResampler( zoomedInResampler );
@@ -91,6 +94,7 @@ QgsRasterRenderer *QgsHillshadeRendererWidget::renderer()
   QgsHillshadeRenderer* renderer = new QgsHillshadeRenderer( provider, band, mLightAzimuth->value(), mLightAngle->value() );
   double value = mZFactor->value();
   renderer->setZFactor( value );
+  renderer->setMultiDirectional( mMultiDirection->checkState() );
   return renderer;
 }
 
@@ -103,6 +107,7 @@ void QgsHillshadeRendererWidget::setFromRenderer( const QgsRasterRenderer *rende
     mLightAngle->setValue( r->altitude() );
     mLightAzimuth->setValue( r->azimuth() );
     mZFactor->setValue( r->zFactor() );
+    mMultiDirection->setChecked( r->multiDirectional() );
   }
 }
 
@@ -119,6 +124,11 @@ void QgsHillshadeRendererWidget::setAzimuth( double azimuth )
 void QgsHillshadeRendererWidget::setZFactor( double zfactor )
 {
   mZFactor->setValue( zfactor );
+}
+
+void QgsHillshadeRendererWidget::setMultiDirectional(bool isMultiDirectional )
+{
+    mMultiDirection->setChecked( isMultiDirectional );
 }
 
 void QgsHillshadeRendererWidget::on_mLightAzimuth_updated( double value )
@@ -152,4 +162,9 @@ double QgsHillshadeRendererWidget::altitude() const
 double QgsHillshadeRendererWidget::zFactor() const
 {
   return mZFactor->value();
+}
+
+bool QgsHillshadeRendererWidget::multiDirectional() const
+{
+    return mMultiDirection->isChecked();
 }

--- a/src/gui/raster/qgshillshaderendererwidget.h
+++ b/src/gui/raster/qgshillshaderendererwidget.h
@@ -77,6 +77,12 @@ class GUI_EXPORT QgsHillshadeRendererWidget: public QgsRasterRendererWidget, pri
      */
     double zFactor()  const;
 
+    /**
+     * @brief multiDirection
+     * @return multiDirection
+     */
+    bool multiDirectional() const;
+
   public slots:
     /**
      * @brief Set the altitude of the light source
@@ -95,6 +101,12 @@ class GUI_EXPORT QgsHillshadeRendererWidget: public QgsRasterRendererWidget, pri
      * @param zfactor The z factor.
      */
     void setZFactor( double zfactor );
+
+    /**
+     * @brief set MultiDirection
+     * @param isMultiDirection
+     */
+    void setMultiDirectional( bool isMultiDirectional);
 
   private slots:
     void on_mLightAzimuth_updated( double value );

--- a/src/ui/raster/qghillshaderendererwidget.ui
+++ b/src/ui/raster/qghillshaderendererwidget.ui
@@ -99,7 +99,7 @@
      </property>
     </widget>
    </item>
-   <item row="4" column="0" colspan="3">
+   <item row="5" column="0" colspan="3">
     <spacer name="verticalSpacer">
      <property name="orientation">
       <enum>Qt::Vertical</enum>
@@ -132,6 +132,20 @@
      </property>
      <property name="value">
       <double>1.000000000000000</double>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="2">
+    <widget class="QCheckBox" name="mMultiDirection">
+     <property name="text">
+      <string/>
+     </property>
+    </widget>
+   </item>
+   <item row="4" column="0">
+    <widget class="QLabel" name="label_5">
+     <property name="text">
+      <string>Multidirectional</string>
      </property>
     </widget>
    </item>


### PR DESCRIPTION
Adds 
- a new rendering method to the hillshaderenderer
- a checkbox to the gui to enable this method instead of the `classic` method
- XML serialization and deserialization

Serialized XML is using an attribute named `multidirection`. This might not be optimal, if we expect more methods to come.
