### PR TITLE
[attributetable] add quotes to column name when sorting (fixes #14873)

### DIFF
--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -744,7 +744,7 @@ void QgsAttributeTableModel::prefetchColumnData( int column )
   }
   else
   {
-    prefetchSortData( mLayerCache->layer()->fields().at( mAttributes.at( column ) ).name() );
+    prefetchSortData( QgsExpression::quotedColumnRef( mLayerCache->layer()->fields().at( mAttributes.at( column ) ).name() ) );
   }
 }
 


### PR DESCRIPTION
This fixes a regression introduced in commit d07d9edda6a2c2f7482500ca37b0333353984bd1 . 

@m-kuhn , verified here as fixing the regression.
