### PR TITLE
[processing] fix missing quotes to field name in refactor fields

### DIFF
--- a/python/plugins/processing/algs/qgis/ui/FieldsMappingPanel.py
+++ b/python/plugins/processing/algs/qgis/ui/FieldsMappingPanel.py
@@ -220,7 +220,7 @@ class FieldsMappingModel(QAbstractTableModel):
                 'type': field.type(),
                 'length': field.length(),
                 'precision': field.precision(),
-                'expression': field.name()}
+                'expression': QgsExpression.quotedColumnRef(field.name())}
 
     def loadLayerFields(self, layer):
         self.beginResetModel()
@@ -292,7 +292,10 @@ class FieldDelegate(QStyledItemDelegate):
 
         elif fieldType == QgsExpression:
             (value, isExpression, isValid) = editor.currentField()
-            model.setData(index, value)
+            if isExpression is True:
+                model.setData(index, value)
+            else:
+                model.setData(index, QgsExpression.quotedColumnRef(value))
 
         else:
             QStyledItemDelegate.setModelData(self, editor, model, index)


### PR DESCRIPTION
ATM, the refactor fields' field mapping panel is broken for field names that are expression functions (for e.g. a field named year is a duplicate of the expression function year()).

This PR fixes the issue by making sure that fields are enclosed in "quotes". 

@volaya , @nyalldawson , does this look good? Works over here.
