### PR TITLE
Expose server interfaces methods to python for clearing server cache

### DIFF
--- a/python/server/qgsserverinterface.sip
+++ b/python/server/qgsserverinterface.sip
@@ -64,6 +64,11 @@ class QgsServerInterface
     virtual QString configFilePath() = 0;
     /** Set the config file path */
     virtual void setConfigFilePath( const QString& configFilePath) = 0;
+    /** Remove entry from config cache */
+    virtual void removeConfigCacheEntry( const QString& path ) = 0;
+    /** Remove entry from layer cache */
+    virtual void removeProjectLayers( const QString& path ) = 0;
+
 
 private:
     /** Constructor */

--- a/src/server/qgsconfigcache.cpp
+++ b/src/server/qgsconfigcache.cpp
@@ -207,3 +207,10 @@ void QgsConfigCache::removeChangedEntry( const QString& path )
 
   mFileSystemWatcher.removePath( path );
 }
+
+
+void QgsConfigCache::removeEntry( const QString& path )
+{
+   removeChangedEntry( path );
+}
+

--- a/src/server/qgsconfigcache.h
+++ b/src/server/qgsconfigcache.h
@@ -61,6 +61,8 @@ class SERVER_EXPORT QgsConfigCache : public QObject
       , const QMap<QString, QString>& parameterMap = ( QMap< QString, QString >() )
     );
 
+    void removeEntry( const QString& path );
+
   private:
     QgsConfigCache();
 

--- a/src/server/qgsmslayercache.cpp
+++ b/src/server/qgsmslayercache.cpp
@@ -226,3 +226,9 @@ void QgsMSLayerCache::logCacheContents() const
     QgsMessageLog::logMessage( "Url: " + it.value().url + " Layer name: " + it.value().layerPointer->name() + " Project: " + it.value().configFile, "Server", QgsMessageLog::INFO );
   }
 }
+
+
+void QgsMSLayerCache::removeProjectLayers( const QString& path )
+{
+    removeProjectFileLayers( path );
+}

--- a/src/server/qgsmslayercache.h
+++ b/src/server/qgsmslayercache.h
@@ -73,6 +73,9 @@ class QgsMSLayerCache: public QObject
     //for debugging
     void logCacheContents() const;
 
+    /** Expose method for use in server interface */
+    void removeProjectLayers( const QString& path );
+
   protected:
     /** Protected singleton constructor*/
     QgsMSLayerCache();

--- a/src/server/qgsserverinterface.h
+++ b/src/server/qgsserverinterface.h
@@ -111,6 +111,21 @@ class SERVER_EXPORT QgsServerInterface
      */
     virtual void setConfigFilePath( const QString& configFilePath ) = 0;
 
+    /** 
+     * Remove entry from config cache 
+     * @param path the path of the file to remove 
+     */
+    virtual void removeConfigCacheEntry( const QString& path ) = 0; 
+
+    /** 
+     * Remove entries from layer cache 
+     * @param path the path of the project which own the layers to be removed
+     */
+    virtual void removeProjectLayers( const QString& path ) = 0; 
+
+
+
+
   private:
     QString mConfigFilePath;
 };

--- a/src/server/qgsserverinterfaceimpl.cpp
+++ b/src/server/qgsserverinterfaceimpl.cpp
@@ -18,7 +18,8 @@
 
 
 #include "qgsserverinterfaceimpl.h"
-
+#include "qgsconfigcache.h"
+#include "qgsmslayercache.h"
 
 /** Constructor */
 QgsServerInterfaceImpl::QgsServerInterfaceImpl( QgsCapabilitiesCache* capCache )
@@ -72,3 +73,17 @@ void QgsServerInterfaceImpl::registerAccessControl( QgsAccessControlFilter* acce
 {
   mAccessControls->registerAccessControl( accessControl, priority );
 }
+
+
+void QgsServerInterfaceImpl::removeConfigCacheEntry( const QString& path )
+{
+    QgsConfigCache::instance()->removeEntry( path );
+}
+
+void QgsServerInterfaceImpl::removeProjectLayers( const QString& path )
+{
+    QgsMSLayerCache::instance()->removeProjectLayers( path );
+}
+
+
+

--- a/src/server/qgsserverinterfaceimpl.h
+++ b/src/server/qgsserverinterfaceimpl.h
@@ -61,6 +61,8 @@ class QgsServerInterfaceImpl : public QgsServerInterface
     QString configFilePath() override { return mConfigFilePath; }
     void setConfigFilePath( const QString& configFilePath ) override;
     void setFilters( QgsServerFiltersMap *filters ) override;
+    void removeConfigCacheEntry( const QString& path ) override; 
+    void removeProjectLayers( const QString& path ) override; 
 
   private:
 


### PR DESCRIPTION
In some situations, it may be interesting to force removing layers cache in python scripts. 
The use case we have faced was the fact the we use nfs mounted directories for storing projects and  inotify does not detect changes on files on nfs mounts. Delegating file watching to python was a quick win.
