### PR TITLE
Move profiler instance to QgsApplication

### DIFF
--- a/python/core/qgsapplication.sip
+++ b/python/core/qgsapplication.sip
@@ -92,6 +92,8 @@ static void qtgui_UpdatePyArgv(PyObject *argvlist, int argc, char **argv)
 
     virtual ~QgsApplication();
 
+    static QgsRuntimeProfiler* profiler();
+
     //! Set the FileOpen event receiver
     static void setFileOpenEventReceiver( QObject * receiver );
 

--- a/python/core/qgsruntimeprofiler.sip
+++ b/python/core/qgsruntimeprofiler.sip
@@ -16,13 +16,6 @@ class QgsRuntimeProfiler
      * front of the profile tag set using start.
      * @param name The name of the group.
      */
-    static QgsRuntimeProfiler * instance();
-
-    /**
-     * @brief Begin the group for the profiler. Groups will append {GroupName}/ to the
-     * front of the profile tag set using start.
-     * @param name The name of the group.
-     */
     void beginGroup( const QString& name );
 
     /**

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -587,7 +587,7 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
   }
 
   smInstance = this;
-  profiler = QgsRuntimeProfiler::instance();
+  QgsRuntimeProfiler* profiler = QgsApplication::profiler();
 
   namSetup();
 
@@ -11041,12 +11041,12 @@ void QgisApp::keyPressEvent( QKeyEvent * e )
 
 void QgisApp::startProfile( const QString& name )
 {
-  profiler->start( name );
+  QgsApplication::profiler()->start( name );
 }
 
 void QgisApp::endProfile()
 {
-  profiler->end();
+  QgsApplication::profiler()->end();
 }
 
 void QgisApp::functionProfile( void ( QgisApp::*fnc )(), QgisApp* instance, QString name )

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1379,8 +1379,6 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     void endProfile();
     void functionProfile( void ( QgisApp::*fnc )(), QgisApp *instance, QString name );
 
-    QgsRuntimeProfiler* profiler;
-
     /** This method will open a dialog so the user can select GDAL sublayers to load
      * @returns true if any items were loaded
      */

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -24,6 +24,7 @@
 #include "qgsnetworkaccessmanager.h"
 #include "qgsproviderregistry.h"
 #include "qgsexpression.h"
+#include "qgsruntimeprofiler.h"
 
 #include <QDir>
 #include <QFile>
@@ -65,6 +66,7 @@ QString ABISYM( QgsApplication::mLibraryPath );
 QString ABISYM( QgsApplication::mLibexecPath );
 QString ABISYM( QgsApplication::mThemeName );
 QString ABISYM( QgsApplication::mUIThemeName );
+QgsRuntimeProfiler* ABISYM( QgsApplication::mProfiler );
 QStringList ABISYM( QgsApplication::mDefaultSvgPaths );
 QMap<QString, QString> ABISYM( QgsApplication::mSystemEnvVars );
 QString ABISYM( QgsApplication::mConfigPath );
@@ -300,6 +302,13 @@ bool QgsApplication::notify( QObject * receiver, QEvent * event )
   }
 
   return done;
+}
+
+QgsRuntimeProfiler *QgsApplication::profiler()
+{
+  if ( !ABISYM( mProfiler ) )
+    ABISYM( mProfiler ) = new QgsRuntimeProfiler();
+  return ABISYM( mProfiler );
 }
 
 void QgsApplication::setFileOpenEventReceiver( QObject * receiver )

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -22,6 +22,8 @@
 #include <qgis.h>
 #include <qgsconfig.h>
 
+class QgsRuntimeProfiler;
+
 /** \ingroup core
  * Extends QApplication to provide access to QGIS specific resources such
  * as theme paths, database paths etc.
@@ -54,6 +56,8 @@ class CORE_EXPORT QgsApplication : public QApplication
 
     //! Catch exceptions when sending event to receiver.
     virtual bool notify( QObject * receiver, QEvent * event ) override;
+
+    static QgsRuntimeProfiler* profiler();
 
     //! Set the FileOpen event receiver
     static void setFileOpenEventReceiver( QObject * receiver );
@@ -370,6 +374,7 @@ class CORE_EXPORT QgsApplication : public QApplication
 
   private:
     static void copyPath( const QString& src, const QString& dst );
+    static QgsRuntimeProfiler* ABISYM( mProfiler );
     static QObject* ABISYM( mFileOpenEventReceiver );
     static QStringList ABISYM( mFileOpenEventList );
 

--- a/src/core/qgsruntimeprofiler.cpp
+++ b/src/core/qgsruntimeprofiler.cpp
@@ -2,15 +2,6 @@
 #include "qgslogger.h"
 
 
-QgsRuntimeProfiler* QgsRuntimeProfiler::mInstance = nullptr;
-
-QgsRuntimeProfiler* QgsRuntimeProfiler::instance()
-{
-  if ( !mInstance )
-    mInstance = new QgsRuntimeProfiler();
-  return mInstance;
-}
-
 QgsRuntimeProfiler::QgsRuntimeProfiler()
 {
 

--- a/src/core/qgsruntimeprofiler.h
+++ b/src/core/qgsruntimeprofiler.h
@@ -15,13 +15,6 @@ class CORE_EXPORT QgsRuntimeProfiler
     QgsRuntimeProfiler();
 
     /**
-     * @brief Instance of the run time profiler. To use the main profiler
-     * use this instance.
-     * @return The instance of the run time profiler
-     */
-    static QgsRuntimeProfiler * instance();
-
-    /**
      * @brief Begin the group for the profiler. Groups will append {GroupName}/ to the
      * front of the profile tag set using start.
      * @param name The name of the group.
@@ -64,8 +57,6 @@ class CORE_EXPORT QgsRuntimeProfiler
     double totalTime();
 
   private:
-    static QgsRuntimeProfiler* mInstance;
-
     QString mGroupPrefix;
     QStack<QString> mGroupStack;
     QTime mProfileTime;


### PR DESCRIPTION
Remove the `::instance()` method and move it to QgsApplication for the main profiler instance.  Uses can still make their own just using the class standalone.
