### PR TITLE
[effect] fix issue with svg marker and antialiasing (fixes #14960)

### DIFF
--- a/src/core/symbology-ng/qgsmarkersymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgsmarkersymbollayerv2.cpp
@@ -2042,6 +2042,7 @@ void QgsSvgMarkerSymbolLayerV2::renderPoint( QPointF point, QgsSymbolV2RenderCon
   }
 
   p->restore();
+  p->setRenderHint( QPainter::Antialiasing );
 }
 
 double QgsSvgMarkerSymbolLayerV2::calculateSize( QgsSymbolV2RenderContext& context, bool& hasDataDefinedSize ) const


### PR DESCRIPTION
Something in the way SVG markers draws its cached picture messes up with effects, disabling antialiasing of paths and polygons after the first SVG marker renderPoint() function is called.

This one line PR fixes the situation reported in issue #14960. 
