### PR TITLE
Remove reference to renamed QgsAdvancedDigitizingDock in API doc

### DIFF
--- a/python/gui/qgsadvanceddigitizingcanvasitem.sip
+++ b/python/gui/qgsadvanceddigitizingcanvasitem.sip
@@ -1,5 +1,5 @@
 /**
- * @brief The QgsAdvancedDigitizingCanvasItem class draws the graphical elements of the CAD tools (@see QgsAdvancedDigitizingDock) on the map canvas.
+ * @brief The QgsAdvancedDigitizingCanvasItem class draws the graphical elements of the CAD tools (@see QgsAdvancedDigitizingDockWidget) on the map canvas.
  */
 
 class QgsAdvancedDigitizingCanvasItem : QgsMapCanvasItem

--- a/python/gui/qgsadvanceddigitizingdockwidget.sip
+++ b/python/gui/qgsadvanceddigitizingdockwidget.sip
@@ -1,5 +1,5 @@
 /***************************************************************************
-    qgsadvanceddigitizingdock.h  -  dock for CAD tools
+    qgsadvanceddigitizingdockwidget.h  -  dock for CAD tools
     ----------------------
     begin                : October 2014
     copyright            : (C) Denis Rouzaud
@@ -15,7 +15,7 @@
 
 
 /**
- * @brief The QgsAdvancedDigitizingDock class is a dockable widget
+ * @brief The QgsAdvancedDigitizingDockWidget class is a dockable widget
  * used to handle the CAD tools on top of a selection of map tools.
  * It handles both the UI and the constraints. Constraints are applied
  * by implemeting filters called from QgsMapToolAdvancedDigitizing.

--- a/src/gui/qgsadvanceddigitizingcanvasitem.h
+++ b/src/gui/qgsadvanceddigitizingcanvasitem.h
@@ -23,7 +23,7 @@
 class QgsAdvancedDigitizingDockWidget;
 
 /**
- * @brief The QgsAdvancedDigitizingCanvasItem class draws the graphical elements of the CAD tools (@see QgsAdvancedDigitizingDock) on the map canvas.
+ * @brief The QgsAdvancedDigitizingCanvasItem class draws the graphical elements of the CAD tools (@see QgsAdvancedDigitizingDockWidget) on the map canvas.
  */
 class GUI_EXPORT QgsAdvancedDigitizingCanvasItem : public QgsMapCanvasItem
 {

--- a/src/gui/qgsadvanceddigitizingdockwidget.h
+++ b/src/gui/qgsadvanceddigitizingdockwidget.h
@@ -1,5 +1,5 @@
 /***************************************************************************
-    qgsadvanceddigitizingdock.h  -  dock for CAD tools
+    qgsadvanceddigitizingdockwidget.h  -  dock for CAD tools
     ----------------------
     begin                : October 2014
     copyright            : (C) Denis Rouzaud
@@ -36,7 +36,7 @@ static const double SoftConstraintTolerancePixel = 15;
 static const double SoftConstraintToleranceDegrees = 10;
 
 /**
- * @brief The QgsAdvancedDigitizingDock class is a dockable widget
+ * @brief The QgsAdvancedDigitizingDockWidget class is a dockable widget
  * used to handle the CAD tools on top of a selection of map tools.
  * It handles both the UI and the constraints. Constraints are applied
  * by implemeting filters called from QgsMapToolAdvancedDigitizing.


### PR DESCRIPTION
Remaining references to `QgsAdvancedDigitizingDock` has been replaced with `QgsAdvancedDigitizingDockWidget` and `qgsadvanceddigitizingdock` with `qgsadvanceddigitizingdockwidget.h`. For this 2nd case, it was only in the comments (see commit for confirmation).
