### PR TITLE
Clean up QgsExpressionContext in QgsServer::handleRequest

### DIFF
--- a/src/server/qgsserver.cpp
+++ b/src/server/qgsserver.cpp
@@ -465,6 +465,13 @@ QPair<QByteArray, QByteArray> QgsServer::handleRequest( const QString& queryStri
   int logLevel = QgsServerLogger::instance()->logLevel();
   QTime time; //used for measuring request time if loglevel < 1
   QgsMapLayerRegistry::instance()->removeAllMapLayers();
+
+  // Clean up  Expression Context
+  // because each call to QgsMapLayer::draw add items to QgsExpressionContext scope
+  // list. This prevent the scope list to grow indefinitely and seriously deteriorate
+  // performances and memory in the long run
+  sMapRenderer->rendererContext()->setExpressionContext( QgsExpressionContext() );
+   
   sQgsApplication->processEvents();
   if ( logLevel < 1 )
   {


### PR DESCRIPTION
 Each call to QgsMapLayer::draw add items to QgsExpressionContext scope.
The scope is not cleaned between request and thus the scope list to grow indefinitely. 

Having the list growing indefinitely deteriorate seriously performances in the long run. It also increase the memory footprint but in a less noticiable way.

This behavior has been checked by monitoring reponse time of several ten of thousand identical requests during server long runs.

Not sure it this is the most elegant way of fixing this but it does the job.
