### PR TITLE
Do not pollute expression context when rendering

### DIFF
--- a/python/core/symbology-ng/qgspointdisplacementrenderer.sip
+++ b/python/core/symbology-ng/qgspointdisplacementrenderer.sip
@@ -69,7 +69,7 @@ class QgsPointDisplacementRenderer : QgsFeatureRendererV2
     QString labelAttributeName() const;
 
     void setEmbeddedRenderer( QgsFeatureRendererV2* r /Transfer/ );
-    QgsFeatureRendererV2* embeddedRenderer();
+    const QgsFeatureRendererV2* embeddedRenderer() const;
 
     virtual void setLegendSymbolItem( const QString& key, QgsSymbolV2* symbol );
 

--- a/src/core/qgsvectorlayerrenderer.cpp
+++ b/src/core/qgsvectorlayerrenderer.cpp
@@ -41,7 +41,7 @@
 // - passing of cache to QgsVectorLayer
 
 
-QgsVectorLayerRenderer::QgsVectorLayerRenderer( QgsVectorLayer* layer, QgsRenderContext& context )
+QgsVectorLayerRenderer::QgsVectorLayerRenderer( QgsVectorLayer* layer, const QgsRenderContext& context )
     : QgsMapLayerRenderer( layer->id() )
     , mContext( context )
     , mInterruptionChecker( context )

--- a/src/core/qgsvectorlayerrenderer.h
+++ b/src/core/qgsvectorlayerrenderer.h
@@ -66,6 +66,12 @@ class QgsVectorLayerRendererInterruptionChecker: public QgsInterruptionChecker
 class QgsVectorLayerRenderer : public QgsMapLayerRenderer
 {
   public:
+    /**
+     * Create a new renderer for a vector layer.
+     * 
+     * @param layer The layer to be rendered.
+     * @param context Contains additional information about the rendering environment.
+     */
     QgsVectorLayerRenderer( QgsVectorLayer* layer, const QgsRenderContext& context );
     ~QgsVectorLayerRenderer();
 

--- a/src/core/qgsvectorlayerrenderer.h
+++ b/src/core/qgsvectorlayerrenderer.h
@@ -17,7 +17,6 @@
 #define QGSVECTORLAYERRENDERER_H
 
 class QgsFeatureRendererV2;
-class QgsRenderContext;
 class QgsVectorLayer;
 class QgsVectorLayerFeatureSource;
 
@@ -40,6 +39,7 @@ typedef QList<int> QgsAttributeList;
 #include "qgsvectorsimplifymethod.h"
 
 #include "qgsmaplayerrenderer.h"
+#include "qgsrendercontext.h"
 
 class QgsVectorLayerLabelProvider;
 class QgsVectorLayerDiagramProvider;
@@ -66,7 +66,7 @@ class QgsVectorLayerRendererInterruptionChecker: public QgsInterruptionChecker
 class QgsVectorLayerRenderer : public QgsMapLayerRenderer
 {
   public:
-    QgsVectorLayerRenderer( QgsVectorLayer* layer, QgsRenderContext& context );
+    QgsVectorLayerRenderer( QgsVectorLayer* layer, const QgsRenderContext& context );
     ~QgsVectorLayerRenderer();
 
     virtual bool render() override;
@@ -98,7 +98,7 @@ class QgsVectorLayerRenderer : public QgsMapLayerRenderer
 
   protected:
 
-    QgsRenderContext& mContext;
+    QgsRenderContext mContext;
 
     QgsVectorLayerRendererInterruptionChecker mInterruptionChecker;
 

--- a/src/server/qgsserver.cpp
+++ b/src/server/qgsserver.cpp
@@ -473,13 +473,6 @@ QPair<QByteArray, QByteArray> QgsServer::handleRequest( const QString& queryStri
   int logLevel = QgsServerLogger::instance()->logLevel();
   QTime time; //used for measuring request time if loglevel < 1
   QgsMapLayerRegistry::instance()->removeAllMapLayers();
-
-  // Clean up  Expression Context
-  // because each call to QgsMapLayer::draw add items to QgsExpressionContext scope
-  // list. This prevent the scope list to grow indefinitely and seriously deteriorate
-  // performances and memory in the long run
-  sMapRenderer->rendererContext()->setExpressionContext( QgsExpressionContext() );
-   
   sQgsApplication->processEvents();
   if ( logLevel < 1 )
   {


### PR DESCRIPTION
The `QgsRenderContext` is currently passed as reference (r/w) to `QgsVectorLayerRenderer`. The later one adds new scope(s) to the context. (See https://github.com/qgis/QGIS/commit/5c3aa51e80887de6ff76682a42814041bb32cd5b for side-effects)

This pull request proposes to pass a copy instead of a reference of the context to the renderer, so any changes to it will happen on the copy and leave the "master" context unaffected.
