### PR TITLE
Fixes to GrassUtils and Grass7Utils (mostly cherry-picked jef-n)

### DIFF
--- a/python/plugins/processing/algs/grass/GrassUtils.py
+++ b/python/plugins/processing/algs/grass/GrassUtils.py
@@ -91,11 +91,14 @@ class GrassUtils:
             folder = None
         if folder is None:
             if isWindows():
-                testfolder = os.path.dirname(QgsApplication.prefixPath())
+                if "OSGEO4W_ROOT" in environ:
+                    testfolder = os.path.join(unicode(environ['OSGEO4W_ROOT']), "apps", "grass")
+                else:
+                    testfolder = unicode(QgsApplication.prefixPath())
                 testfolder = os.path.join(testfolder, 'grass')
                 if os.path.isdir(testfolder):
                     for subfolder in os.listdir(testfolder):
-                        if subfolder.startswith('grass'):
+                        if subfolder.startswith('grass-6'):
                             folder = os.path.join(testfolder, subfolder)
                             break
             else:

--- a/python/plugins/processing/algs/grass/GrassUtils.py
+++ b/python/plugins/processing/algs/grass/GrassUtils.py
@@ -92,7 +92,7 @@ class GrassUtils:
         if folder is None:
             if isWindows():
                 if "OSGEO4W_ROOT" in os.environ:
-                    testfolder = os.path.join(unicode(os.environ['OSGEO4W_ROOT']), "apps", "grass")
+                    testfolder = os.path.join(unicode(os.environ['OSGEO4W_ROOT']), "apps")
                 else:
                     testfolder = unicode(QgsApplication.prefixPath())
                 testfolder = os.path.join(testfolder, 'grass')

--- a/python/plugins/processing/algs/grass/GrassUtils.py
+++ b/python/plugins/processing/algs/grass/GrassUtils.py
@@ -113,10 +113,10 @@ class GrassUtils:
         folder = ProcessingConfig.getSetting(GrassUtils.GRASS_WIN_SHELL) or ''
         if not os.path.exists(folder):
             folder = None
-        if folder is None:
+        if folder is None and GrassUtils.grassPath():
             folder = os.path.dirname(unicode(QgsApplication.prefixPath()))
             folder = os.path.join(folder, 'msys')
-        return folder
+        return folder or ''
 
     @staticmethod
     def grassDescriptionPath():

--- a/python/plugins/processing/algs/grass/GrassUtils.py
+++ b/python/plugins/processing/algs/grass/GrassUtils.py
@@ -91,8 +91,8 @@ class GrassUtils:
             folder = None
         if folder is None:
             if isWindows():
-                if "OSGEO4W_ROOT" in environ:
-                    testfolder = os.path.join(unicode(environ['OSGEO4W_ROOT']), "apps", "grass")
+                if "OSGEO4W_ROOT" in os.environ:
+                    testfolder = os.path.join(unicode(os.environ['OSGEO4W_ROOT']), "apps", "grass")
                 else:
                     testfolder = unicode(QgsApplication.prefixPath())
                 testfolder = os.path.join(testfolder, 'grass')

--- a/python/plugins/processing/algs/grass7/Grass7Utils.py
+++ b/python/plugins/processing/algs/grass7/Grass7Utils.py
@@ -89,7 +89,7 @@ class Grass7Utils:
         if folder is None:
             if isWindows():
                 if "OSGEO4W_ROOT" in os.environ:
-                    testfolder = os.path.join(unicode(os.environ['OSGEO4W_ROOT']), "apps", "grass")
+                    testfolder = os.path.join(unicode(os.environ['OSGEO4W_ROOT']), "apps")
                 else:
                     testfolder = unicode(QgsApplication.prefixPath())
                 testfolder = os.path.join(testfolder, 'grass')
@@ -103,7 +103,7 @@ class Grass7Utils:
                 if not os.path.isdir(folder):
                     folder = '/Applications/GRASS-7.0.app/Contents/MacOS'
 
-        return folder
+        return folder or ''
 
     @staticmethod
     def grassDescriptionPath():

--- a/python/plugins/processing/algs/grass7/Grass7Utils.py
+++ b/python/plugins/processing/algs/grass7/Grass7Utils.py
@@ -88,7 +88,10 @@ class Grass7Utils:
             folder = None
         if folder is None:
             if isWindows():
-                testfolder = os.path.dirname(unicode(QgsApplication.prefixPath()))
+                if "OSGEO4W_ROOT" in environ:
+                    testfolder = os.path.join(unicode(environ['OSGEO4W_ROOT']), "apps", "grass")
+                else:
+                    testfolder = unicode(QgsApplication.prefixPath())
                 testfolder = os.path.join(testfolder, 'grass')
                 if os.path.isdir(testfolder):
                     for subfolder in os.listdir(testfolder):

--- a/python/plugins/processing/algs/grass7/Grass7Utils.py
+++ b/python/plugins/processing/algs/grass7/Grass7Utils.py
@@ -88,8 +88,8 @@ class Grass7Utils:
             folder = None
         if folder is None:
             if isWindows():
-                if "OSGEO4W_ROOT" in environ:
-                    testfolder = os.path.join(unicode(environ['OSGEO4W_ROOT']), "apps", "grass")
+                if "OSGEO4W_ROOT" in os.environ:
+                    testfolder = os.path.join(unicode(os.environ['OSGEO4W_ROOT']), "apps", "grass")
                 else:
                     testfolder = unicode(QgsApplication.prefixPath())
                 testfolder = os.path.join(testfolder, 'grass')


### PR DESCRIPTION
This PR adds @jef-n's fixes to `GrassUtils` and `Grass7Utils` from master and adds an additional fix to `grassWinShell` (commit [e94c24d9f6cf3b9d148c1cbeca1246643434bfb1](https://github.com/qgis/QGIS/commit/e94c24d9f6cf3b9d148c1cbeca1246643434bfb1)).

The issue with `grassWinShell` was that the GRASS 7 path was used for GRASS 6 and msys path set, even when msys directory did not exist.
