### PR TITLE
[style dock] vectorize undo & redo button, create history symbol

### DIFF
--- a/images/images.qrc
+++ b/images/images.qrc
@@ -228,6 +228,7 @@
         <file>themes/default/mActionHideAllLayers.png</file>
         <file>themes/default/mActionHideAllLayers.svg</file>
         <file>themes/default/mActionHideSelectedLayers.png</file>
+        <file>themes/default/mActionHistory.svg</file>
         <file>themes/default/mActionIdentify.svg</file>
         <file>themes/default/mActionIncreaseBrightness.svg</file>
         <file>themes/default/mActionIncreaseContrast.svg</file>
@@ -277,6 +278,7 @@
         <file>themes/default/mActionPropertyItem.svg</file>
         <file>themes/default/mActionQgisHomePage.png</file>
         <file>themes/default/mActionRaiseItems.png</file>
+        <file>themes/default/mActionRedo.svg</file>
         <file>themes/default/mActionRedo.png</file>
         <file>themes/default/mActionRefresh.png</file>
         <file>themes/default/mActionRemove.png</file>
@@ -330,6 +332,7 @@
         <file>themes/default/mActionToggleEditing.svg</file>
         <file>themes/default/mActionTouch.svg</file>
         <file>themes/default/mActionTouch2.png</file>
+        <file>themes/default/mActionUndo.svg</file>
         <file>themes/default/mActionUndo.png</file>
         <file>themes/default/mActionUngroupItems.png</file>
         <file>themes/default/mActionUnselectAttributes.png</file>

--- a/images/themes/default/mActionHistory.svg
+++ b/images/themes/default/mActionHistory.svg
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="48"
+   height="48"
+   viewBox="0 0 48 48"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="mActionHistory.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="1.4142136"
+     inkscape:cx="-46.753063"
+     inkscape:cy="25.741222"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1865"
+     inkscape:window-height="1056"
+     inkscape:window-x="55"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:snap-grids="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4147" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1004.3622)">
+    <g
+       id="g4305"
+       transform="translate(-4.133807,2.1078)">
+      <path
+         sodipodi:nodetypes="ccccccccccc"
+         inkscape:connector-curvature="0"
+         id="path4168-1"
+         d="m 25.516169,1006.7544 8.117652,10.1471 -8.117652,10.1471 0,-6.7648 -6.76471,0 c -3.644141,3.5268 -1.313608,6.7648 2.705884,6.7648 l 0,2.7058 c -4.610598,0 -10.823536,-1.78 -10.823536,-10.147 0,-2.8469 2.334451,-6.0883 8.117652,-6.0883 l 6.76471,0 z"
+         style="fill:#8cbe8c;fill-opacity:1;fill-rule:evenodd;stroke:#639563;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ccsscsscccc"
+         inkscape:connector-curvature="0"
+         id="path4168-9"
+         d="m 25.721525,1007.1138 0,6.7647 -6.76471,0 c -5.7832,0 -8.117652,3.2413 -8.117652,6.0882 0,3.9412 1.38666,6.4068 3.326863,7.9274 -1.195391,-1.5221 -1.973921,-3.6341 -1.973921,-6.5745 0,-4.1454 1.881458,-6.0882 8.117652,-6.0882 l 5.891021,0 c 0.635041,0 0.873689,-0.3905 0.873689,-0.8616 l 0,-5.5649 z"
+         style="fill:#afd5c1;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+      <path
+         sodipodi:nodetypes="ccccccccccc"
+         inkscape:connector-curvature="0"
+         id="path4168-4-5"
+         d="m 25.516169,1006.7544 8.117652,10.1471 -8.117652,10.1471 0,-6.7648 -6.76471,0 c -3.644141,3.5268 -1.313608,6.7648 2.705884,6.7648 l 0,2.7058 c -4.610598,0 -10.823536,-1.78 -10.823536,-10.147 0,-2.8469 2.334451,-6.0883 8.117652,-6.0883 l 6.76471,0 z"
+         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#639563;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+    </g>
+    <g
+       id="g4310"
+       transform="translate(-4.889719,1.3896)">
+      <path
+         sodipodi:nodetypes="ccccccccccc"
+         inkscape:connector-curvature="0"
+         id="path4168-7"
+         d="m 33.507357,1022.4726 -8.117652,10.1471 8.117652,10.1471 0,-6.7647 6.76471,0 c 3.644141,3.5267 1.313608,6.7647 -2.705884,6.7647 l 0,2.7058 c 4.610597,0 10.823536,-1.78 10.823536,-10.147 0,-2.8469 -2.334452,-6.0882 -8.117652,-6.0882 l -6.76471,0 z"
+         style="fill:#e37e39;fill-opacity:1;fill-rule:evenodd;stroke:#bc9377;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:0" />
+      <path
+         sodipodi:nodetypes="ccccccccccccccccc"
+         inkscape:connector-curvature="0"
+         id="path4168-3-1"
+         d="m 25.552688,1032.6354 7.277349,9.9145 0,-3.0441 -6.76471,-8.4559 z m 8.6303,1.7968 0,1.353 5.411768,0 c 1.826167,1.7673 2.149414,3.4603 1.514131,4.7115 1.978023,-1.1372 2.466233,-3.5217 -0.161189,-6.0645 z m 11.555498,7.2509 c -2.178903,1.708 -5.057547,2.2197 -7.496672,2.2197 l 0,-1.4904 c -0.423239,0.087 -0.874656,0.1375 -1.352942,0.1375 l 0,2.7059 c 2.990104,0 6.643383,-0.7642 8.849614,-3.5727 z"
+         style="fill:#f2c990;fill-opacity:1;fill-rule:evenodd;stroke:#bc0077;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:0" />
+      <path
+         sodipodi:nodetypes="ccccccccccc"
+         inkscape:connector-curvature="0"
+         id="path4168-4-1"
+         d="m 33.507357,1022.4726 -8.117652,10.1471 8.117652,10.1471 0,-6.7647 6.76471,0 c 3.644141,3.5267 1.313608,6.7647 -2.705884,6.7647 l 0,2.7058 c 4.610597,0 10.823536,-1.78 10.823536,-10.147 0,-2.8469 -2.334452,-6.0882 -8.117652,-6.0882 l -6.76471,0 z"
+         style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#d06935;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1" />
+    </g>
+  </g>
+</svg>

--- a/images/themes/default/mActionRedo.svg
+++ b/images/themes/default/mActionRedo.svg
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="mActionRedo.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="3.959798"
+     inkscape:cx="-14.827045"
+     inkscape:cy="20.472455"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1865"
+     inkscape:window-height="1056"
+     inkscape:window-x="55"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:snap-grids="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4147" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title></dc:title>
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1028.3622)">
+    <path
+       style="fill:#8cbe8c;fill-opacity:1;fill-rule:evenodd;stroke:#639563;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+       d="m 14.5,1031.8622 6,7.5 -6,7.5 0,-5 -5,0 c -2.693494,2.6067 -0.970927,5 2,5 l 0,2 c -3.407831,0 -8,-1.3157 -8,-7.5 0,-2.1042 1.725463,-4.5 6,-4.5 l 5,0 z"
+       id="path4168"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccc" />
+    <path
+       style="fill:#afd5c1;fill-opacity:1;fill-rule:evenodd;stroke:none;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+       d="m 14.651785,1032.1278 0,5 -5.0000001,0 c -4.2745369,0 -5.9999999,2.3958 -5.9999999,4.5 0,2.9131 1.024922,4.7355 2.458984,5.8594 -0.883549,-1.125 -1.458984,-2.6861 -1.458984,-4.8594 0,-3.064 1.390642,-4.5 6,-4.5 l 4.35423,0 c 0.469378,0 0.64577,-0.2886 0.64577,-0.6368 l 0,-4.1132 z"
+       id="path4168-9"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccsscsscccc" />
+    <path
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#639563;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+       d="m 14.5,1031.8622 6,7.5 -6,7.5 0,-5 -5,0 c -2.693494,2.6067 -0.970927,5 2,5 l 0,2 c -3.407831,0 -8,-1.3157 -8,-7.5 0,-2.1042 1.725463,-4.5 6,-4.5 l 5,0 z"
+       id="path4168-4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccc" />
+  </g>
+</svg>

--- a/images/themes/default/mActionUndo.svg
+++ b/images/themes/default/mActionUndo.svg
@@ -1,0 +1,81 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="24"
+   height="24"
+   viewBox="0 0 24 24"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="mActionUndo.svg">
+  <defs
+     id="defs4" />
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="22.627417"
+     inkscape:cx="8.2285623"
+     inkscape:cy="4.0327929"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:window-width="1865"
+     inkscape:window-height="1056"
+     inkscape:window-x="55"
+     inkscape:window-y="24"
+     inkscape:window-maximized="1"
+     inkscape:snap-grids="false">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4147" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1028.3622)">
+    <path
+       style="fill:#e37e39;fill-opacity:1;fill-rule:evenodd;stroke:#bc9377;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:0"
+       d="m 9.499986,1031.8622 -6,7.5 6,7.5 0,-5 5,0 c 2.693494,2.6067 0.970927,5 -2,5 l 0,2 c 3.407831,0 8,-1.3157 8,-7.5 0,-2.1042 -1.725463,-4.5 -6,-4.5 l -5,0 z"
+       id="path4168"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccc" />
+    <path
+       style="fill:#f2c990;fill-opacity:1;fill-rule:evenodd;stroke:#bc0077;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:0"
+       d="m 3.64389,1039.4245 5.3554685,7.2774 0,-2.25 -4.9999998,-6.25 z m 6.3554747,1.2774 0,1 4.0000003,0 c 1.349775,1.3063 1.588697,2.5576 1.11914,3.4824 1.462016,-0.8405 1.822867,-2.603 -0.11914,-4.4824 z m 8.5410153,5.3593 c -1.610492,1.2625 -3.738184,1.6407 -5.541015,1.6407 l 0,-1.1016 c -0.312828,0.064 -0.646484,0.1016 -1,0.1016 l 0,2 c 2.210076,0 4.910324,-0.5648 6.541015,-2.6407 z"
+       id="path4168-3"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccccccccc" />
+    <path
+       style="fill:none;fill-opacity:1;fill-rule:evenodd;stroke:#d06935;stroke-width:1px;stroke-linecap:butt;stroke-linejoin:round;stroke-opacity:1"
+       d="m 9.499986,1031.8622 -6,7.5 6,7.5 0,-5 5,0 c 2.693494,2.6067 0.970927,5 -2,5 l 0,2 c 3.407831,0 8,-1.3157 8,-7.5 0,-2.1042 -1.725463,-4.5 -6,-4.5 l -5,0 z"
+       id="path4168-4"
+       inkscape:connector-curvature="0"
+       sodipodi:nodetypes="ccccccccccc" />
+  </g>
+</svg>

--- a/src/app/composer/qgscomposer.cpp
+++ b/src/app/composer/qgscomposer.cpp
@@ -719,8 +719,8 @@ void QgsComposer::setupTheme()
   mActionZoomActual->setIcon( QgsApplication::getThemeIcon( "/mActionZoomActual.svg" ) );
   mActionMouseZoom->setIcon( QgsApplication::getThemeIcon( "/mActionZoomToArea.svg" ) );
   mActionRefreshView->setIcon( QgsApplication::getThemeIcon( "/mActionDraw.svg" ) );
-  mActionUndo->setIcon( QgsApplication::getThemeIcon( "/mActionUndo.png" ) );
-  mActionRedo->setIcon( QgsApplication::getThemeIcon( "/mActionRedo.png" ) );
+  mActionUndo->setIcon( QgsApplication::getThemeIcon( "/mActionUndo.svg" ) );
+  mActionRedo->setIcon( QgsApplication::getThemeIcon( "/mActionRedo.svg" ) );
   mActionAddImage->setIcon( QgsApplication::getThemeIcon( "/mActionAddImage.svg" ) );
   mActionAddNewMap->setIcon( QgsApplication::getThemeIcon( "/mActionAddMap.svg" ) );
   mActionAddNewLabel->setIcon( QgsApplication::getThemeIcon( "/mActionLabel.svg" ) );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -2514,8 +2514,8 @@ void QgisApp::setTheme( const QString& theThemeName )
   mActionDeleteSelected->setIcon( QgsApplication::getThemeIcon( "/mActionDeleteSelected.svg" ) );
   mActionNodeTool->setIcon( QgsApplication::getThemeIcon( "/mActionNodeTool.png" ) );
   mActionSimplifyFeature->setIcon( QgsApplication::getThemeIcon( "/mActionSimplify.png" ) );
-  mActionUndo->setIcon( QgsApplication::getThemeIcon( "/mActionUndo.png" ) );
-  mActionRedo->setIcon( QgsApplication::getThemeIcon( "/mActionRedo.png" ) );
+  mActionUndo->setIcon( QgsApplication::getThemeIcon( "/mActionUndo.svg" ) );
+  mActionRedo->setIcon( QgsApplication::getThemeIcon( "/mActionRedo.svg" ) );
   mActionAddRing->setIcon( QgsApplication::getThemeIcon( "/mActionAddRing.png" ) );
   mActionFillRing->setIcon( QgsApplication::getThemeIcon( "/mActionFillRing.svg" ) );
   mActionAddPart->setIcon( QgsApplication::getThemeIcon( "/mActionAddPart.png" ) );

--- a/src/app/qgsmapstylingwidget.cpp
+++ b/src/app/qgsmapstylingwidget.cpp
@@ -134,7 +134,7 @@ void QgsMapStylingWidget::setLayer( QgsMapLayer *layer )
       QgsDebugMsg( QString( "ROW IS %1" ).arg( row ) );
     }
   }
-  mOptionsListWidget->addItem( new QListWidgetItem( QgsApplication::getThemeIcon( "mIconTreeView.png" ), "" ) );
+  mOptionsListWidget->addItem( new QListWidgetItem( QgsApplication::getThemeIcon( "mActionHistory.svg" ), "" ) );
 
   if ( sameLayerType )
   {

--- a/src/app/qgsrasterlayerproperties.cpp
+++ b/src/app/qgsrasterlayerproperties.cpp
@@ -428,7 +428,7 @@ QgsRasterLayerProperties::QgsRasterLayerProperties( QgsMapLayer* lyr, QgsMapCanv
                        mOptStackedWidget->indexOf( mOptsPage_Style ) );
   }
 
-  mResetColorRenderingBtn->setIcon( QgsApplication::getThemeIcon( "/mActionUndo.png" ) );
+  mResetColorRenderingBtn->setIcon( QgsApplication::getThemeIcon( "/mActionUndo.svg" ) );
 
   QString title = QString( tr( "Layer Properties - %1" ) ).arg( lyr->name() );
   restoreOptionsBaseUi( title );

--- a/src/app/qgsundowidget.cpp
+++ b/src/app/qgsundowidget.cpp
@@ -185,13 +185,13 @@ void QgsUndoWidget::setupUi( QWidget *UndoWidget )
 
   undoButton = new QPushButton( dockWidgetContents );
   undoButton->setObjectName( QString::fromUtf8( "undoButton" ) );
-  undoButton->setIcon( QgsApplication::getThemeIcon( "mActionUndo.png" ) );
+  undoButton->setIcon( QgsApplication::getThemeIcon( "mActionUndo.svg" ) );
 
   gridLayout->addWidget( undoButton, 1, 0, 1, 1 );
 
   redoButton = new QPushButton( dockWidgetContents );
   redoButton->setObjectName( QString::fromUtf8( "redoButton" ) );
-  redoButton->setIcon( QgsApplication::getThemeIcon( "mActionRedo.png" ) );
+  redoButton->setIcon( QgsApplication::getThemeIcon( "mActionRedo.svg" ) );
 
   gridLayout->addWidget( redoButton, 1, 1, 1, 1 );
 

--- a/src/ui/composer/qgscomposerbase.ui
+++ b/src/ui/composer/qgscomposerbase.ui
@@ -638,7 +638,7 @@
   <action name="mActionUndo">
    <property name="icon">
     <iconset>
-     <normalon>:/images/themes/default/mActionUndo.png</normalon>
+     <normalon>:/images/themes/default/mActionUndo.svg</normalon>
     </iconset>
    </property>
    <property name="text">
@@ -654,7 +654,7 @@
   <action name="mActionRedo">
    <property name="icon">
     <iconset resource="../../../images/images.qrc">
-     <normaloff>:/images/themes/default/mActionRedo.png</normaloff>:/images/themes/default/mActionRedo.png</iconset>
+     <normaloff>:/images/themes/default/mActionRedo.svg</normaloff>:/images/themes/default/mActionRedo.svg</iconset>
    </property>
    <property name="text">
     <string>&amp;Redo</string>

--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -663,7 +663,7 @@
   <action name="mActionUndo">
    <property name="icon">
     <iconset resource="../../images/images.qrc">
-     <normaloff>:/images/themes/default/mActionUndo.png</normaloff>:/images/themes/default/mActionUndo.png</iconset>
+     <normaloff>:/images/themes/default/mActionUndo.svg</normaloff>:/images/themes/default/mActionUndo.svg</iconset>
    </property>
    <property name="text">
     <string>&amp;Undo</string>
@@ -675,7 +675,7 @@
   <action name="mActionRedo">
    <property name="icon">
     <iconset resource="../../images/images.qrc">
-     <normaloff>:/images/themes/default/mActionRedo.png</normaloff>:/images/themes/default/mActionRedo.png</iconset>
+     <normaloff>:/images/themes/default/mActionRedo.svg</normaloff>:/images/themes/default/mActionRedo.svg</iconset>
    </property>
    <property name="text">
     <string>&amp;Redo</string>

--- a/src/ui/qgslabelingguibase.ui
+++ b/src/ui/qgslabelingguibase.ui
@@ -204,7 +204,7 @@
               </property>
               <property name="icon">
                <iconset resource="../../images/images.qrc">
-                <normaloff>:/images/themes/default/mActionUndo.png</normaloff>:/images/themes/default/mActionUndo.png</iconset>
+                <normaloff>:/images/themes/default/mActionUndo.svg</normaloff>:/images/themes/default/mActionUndo.svg</iconset>
               </property>
              </widget>
             </item>

--- a/src/ui/qgsmapstylingwidgetbase.ui
+++ b/src/ui/qgsmapstylingwidgetbase.ui
@@ -53,7 +53,7 @@
            </property>
            <property name="icon">
             <iconset resource="../../images/images.qrc">
-             <normaloff>:/images/themes/default/mActionUndo.png</normaloff>:/images/themes/default/mActionUndo.png</iconset>
+             <normaloff>:/images/themes/default/mActionUndo.svg</normaloff>:/images/themes/default/mActionUndo.svg</iconset>
            </property>
           </widget>
          </item>
@@ -64,7 +64,7 @@
            </property>
            <property name="icon">
             <iconset resource="../../images/images.qrc">
-             <normaloff>:/images/themes/default/mActionRedo.png</normaloff>:/images/themes/default/mActionRedo.png</iconset>
+             <normaloff>:/images/themes/default/mActionRedo.svg</normaloff>:/images/themes/default/mActionRedo.svg</iconset>
            </property>
           </widget>
          </item>
@@ -75,18 +75,10 @@
            </property>
            <property name="sizeHint" stdset="0">
             <size>
-             <width>40</width>
              <height>20</height>
             </size>
            </property>
           </spacer>
-         </item>
-         <item>
-          <widget class="QDialogButtonBox" name="mButtonBox">
-           <property name="standardButtons">
-            <set>QDialogButtonBox::Apply</set>
-           </property>
-          </widget>
          </item>
          <item>
           <widget class="QCheckBox" name="mLiveApplyCheck">
@@ -98,6 +90,19 @@
            </property>
            <property name="autoRepeat">
             <bool>false</bool>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QDialogButtonBox" name="mButtonBox">
+           <property name="sizePolicy">
+            <sizepolicy hsizetype="Fixed" vsizetype="Fixed">
+             <horstretch>0</horstretch>
+             <verstretch>0</verstretch>
+            </sizepolicy>
+           </property>
+           <property name="standardButtons">
+            <set>QDialogButtonBox::Apply</set>
            </property>
           </widget>
          </item>

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -904,7 +904,7 @@
                       </property>
                       <property name="icon">
                        <iconset resource="../../images/images.qrc">
-                        <normaloff>:/images/themes/default/mActionUndo.png</normaloff>:/images/themes/default/mActionUndo.png</iconset>
+                        <normaloff>:/images/themes/default/mActionUndo.svg</normaloff>:/images/themes/default/mActionUndo.svg</iconset>
                       </property>
                      </widget>
                     </item>
@@ -1202,7 +1202,7 @@
                     </property>
                     <property name="icon">
                      <iconset resource="../../images/images.qrc">
-                      <normaloff>:/images/themes/default/mActionUndo.png</normaloff>:/images/themes/default/mActionUndo.png</iconset>
+                      <normaloff>:/images/themes/default/mActionUndo.svg</normaloff>:/images/themes/default/mActionUndo.svg</iconset>
                     </property>
                    </widget>
                   </item>
@@ -3443,7 +3443,7 @@
                       </property>
                       <property name="icon">
                        <iconset resource="../../images/images.qrc">
-                        <normaloff>:/images/themes/default/mActionUndo.png</normaloff>:/images/themes/default/mActionUndo.png</iconset>
+                        <normaloff>:/images/themes/default/mActionUndo.svg</normaloff>:/images/themes/default/mActionUndo.svg</iconset>
                       </property>
                      </widget>
                     </item>
@@ -5011,7 +5011,7 @@
                     </property>
                     <property name="icon">
                      <iconset resource="../../images/images.qrc">
-                      <normaloff>:/images/themes/default/mActionUndo.png</normaloff>:/images/themes/default/mActionUndo.png</iconset>
+                      <normaloff>:/images/themes/default/mActionUndo.svg</normaloff>:/images/themes/default/mActionUndo.svg</iconset>
                     </property>
                    </widget>
                   </item>

--- a/src/ui/qgsrasterlayerpropertiesbase.ui
+++ b/src/ui/qgsrasterlayerpropertiesbase.ui
@@ -827,7 +827,7 @@
                     </property>
                     <property name="icon">
                      <iconset resource="../../images/images.qrc">
-                      <normaloff>:/images/themes/default/mActionUndo.png</normaloff>:/images/themes/default/mActionUndo.png</iconset>
+                      <normaloff>:/images/themes/default/mActionUndo.svg</normaloff>:/images/themes/default/mActionUndo.svg</iconset>
                     </property>
                     <property name="toolButtonStyle">
                      <enum>Qt::ToolButtonTextBesideIcon</enum>

--- a/src/ui/qgsrendererrasterpropswidgetbase.ui
+++ b/src/ui/qgsrendererrasterpropswidgetbase.ui
@@ -364,7 +364,7 @@
           </property>
           <property name="icon">
            <iconset resource="../../images/images.qrc">
-            <normaloff>:/images/themes/default/mActionUndo.png</normaloff>:/images/themes/default/mActionUndo.png</iconset>
+            <normaloff>:/images/themes/default/mActionUndo.svg</normaloff>:/images/themes/default/mActionUndo.svg</iconset>
           </property>
           <property name="toolButtonStyle">
            <enum>Qt::ToolButtonTextBesideIcon</enum>


### PR DESCRIPTION
The PR does the following:
- vectorize the undo / redo icon, and update icons throughout QGIS to use those
- change the undo arrow color to be orange to give a better visual cue, and follow standard established by Inkscape, Gimp, etc. 
- create an history icon, and have the style dock make use of it

The image worth a thousand words:
![untitled](https://cloud.githubusercontent.com/assets/1728657/15917475/4cc493d2-2e27-11e6-8ccf-cc6c6f5eafbc.png)
