### PR TITLE
Replace connect to 'layerWillBeRemoved' by 'layersWillbeRemoved' in Q…

### DIFF
--- a/src/gui/editorwidgets/core/qgseditorwidgetregistry.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetregistry.cpp
@@ -79,7 +79,7 @@ QgsEditorWidgetRegistry::QgsEditorWidgetRegistry()
   connect( QgsProject::instance(), SIGNAL( readMapLayer( QgsMapLayer*, const QDomElement& ) ), this, SLOT( readMapLayer( QgsMapLayer*, const QDomElement& ) ) );
   // connect( QgsProject::instance(), SIGNAL( writeMapLayer( QgsMapLayer*, QDomElement&, QDomDocument& ) ), this, SLOT( writeMapLayer( QgsMapLayer*, QDomElement&, QDomDocument& ) ) );
 
-  connect( QgsMapLayerRegistry::instance(), SIGNAL( layerWillBeRemoved( QgsMapLayer* ) ), this, SLOT( mapLayerWillBeRemoved( QgsMapLayer* ) ) );
+  connect( QgsMapLayerRegistry::instance(), SIGNAL( layersWillBeRemoved( const QList<QgsMapLayer*>& ) ), this, SLOT( mapLayersWillBeRemoved( const QList<QgsMapLayer*>& ) ) );
   connect( QgsMapLayerRegistry::instance(), SIGNAL( layerWasAdded( QgsMapLayer* ) ), this, SLOT( mapLayerAdded( QgsMapLayer* ) ) );
 }
 
@@ -327,14 +327,16 @@ void QgsEditorWidgetRegistry::writeMapLayer( QgsMapLayer* mapLayer, QDomElement&
   layerElem.appendChild( editTypesNode );
 }
 
-void QgsEditorWidgetRegistry::mapLayerWillBeRemoved( QgsMapLayer* mapLayer )
+void QgsEditorWidgetRegistry::mapLayersWillBeRemoved( const QList<QgsMapLayer*>&  layers )
 {
-  QgsVectorLayer* vl = qobject_cast<QgsVectorLayer*>( mapLayer );
-
-  if ( vl )
+  Q_FOREACH ( QgsMapLayer* layer, layers )
   {
-    disconnect( vl, SIGNAL( readCustomSymbology( const QDomElement&, QString& ) ), this, SLOT( readSymbology( const QDomElement&, QString& ) ) );
-    disconnect( vl, SIGNAL( writeCustomSymbology( QDomElement&, QDomDocument&, QString& ) ), this, SLOT( writeSymbology( QDomElement&, QDomDocument&, QString& ) ) );
+    QgsVectorLayer* vl = qobject_cast<QgsVectorLayer*>( layer );
+    if ( vl )
+    {
+      disconnect( vl, SIGNAL( readCustomSymbology( const QDomElement&, QString& ) ), this, SLOT( readSymbology( const QDomElement&, QString& ) ) );
+      disconnect( vl, SIGNAL( writeCustomSymbology( QDomElement&, QDomDocument&, QString& ) ), this, SLOT( writeSymbology( QDomElement&, QDomDocument&, QString& ) ) );
+    }
   }
 }
 

--- a/src/gui/editorwidgets/core/qgseditorwidgetregistry.h
+++ b/src/gui/editorwidgets/core/qgseditorwidgetregistry.h
@@ -176,9 +176,9 @@ class GUI_EXPORT QgsEditorWidgetRegistry : public QObject
     /**
      * Will disconnect to appropriate signals from map layers to load and save style
      *
-     * @param mapLayer The layer to disconnect
+     * @param layers The list of layers to disconnect
      */
-    void mapLayerWillBeRemoved( QgsMapLayer* mapLayer );
+    void mapLayersWillBeRemoved( const QList<QgsMapLayer*>& layers );
 
     /**
      * Loads layer symbology for the layer that emitted the signal


### PR DESCRIPTION
…gsEditorWidgetRegistry.

QgsEditorWidgetRegistry record every layer added to the QgsMapLayerRegistry by listening to signal 'layerWasAdded'. But layerWillBeRemoved is emitted only for layers owned by
QgsMapLayerRegistry while layersWillBeRemoved is emitted for all layers added to QgsMapLayerRegistry.

In the context of qgi server the layers are not owned by QgsMapLayerRegistry and thus layerWillBeRemoved is never called and connections to layers never released. 
