### PR TITLE
Default to requesting all attributes for python expression functions

### DIFF
--- a/python/core/__init__.py
+++ b/python/core/__init__.py
@@ -30,7 +30,7 @@ import string
 from qgis._core import *
 
 
-def register_function(function, arg_count, group, usesgeometry=False, **kwargs):
+def register_function(function, arg_count, group, usesgeometry=False, referenced_columns=[QgsFeatureRequest.AllAttributes], **kwargs):
     """
     Register a Python function to be used as a expression function.
 
@@ -59,8 +59,8 @@ def register_function(function, arg_count, group, usesgeometry=False, **kwargs):
     """
     class QgsExpressionFunction(QgsExpression.Function):
 
-        def __init__(self, func, name, args, group, helptext='', usesgeometry=True, expandargs=False):
-            QgsExpression.Function.__init__(self, name, args, group, helptext, usesgeometry)
+        def __init__(self, func, name, args, group, helptext='', usesgeometry=True, referencedColumns=QgsFeatureRequest.AllAttributes, expandargs=False):
+            QgsExpression.Function.__init__(self, name, args, group, helptext, usesgeometry, referencedColumns)
             self.function = func
             self.expandargs = expandargs
 
@@ -100,7 +100,7 @@ def register_function(function, arg_count, group, usesgeometry=False, **kwargs):
 
     function.__name__ = name
     helptext = helptemplate.safe_substitute(name=name, doc=helptext)
-    f = QgsExpressionFunction(function, name, arg_count, group, helptext, usesgeometry, expandargs)
+    f = QgsExpressionFunction(function, name, arg_count, group, helptext, usesgeometry, referenced_columns, expandargs)
 
     # This doesn't really make any sense here but does when used from a decorator context
     # so it can stay.

--- a/tests/src/python/test_qgsexpression.py
+++ b/tests/src/python/test_qgsexpression.py
@@ -16,7 +16,7 @@ import qgis  # NOQA
 
 from qgis.testing import unittest
 from qgis.utils import qgsfunction
-from qgis.core import QgsExpression
+from qgis.core import QgsExpression, QgsFeatureRequest
 
 
 class TestQgsExpressionCustomFunctions(unittest.TestCase):
@@ -45,6 +45,14 @@ class TestQgsExpressionCustomFunctions(unittest.TestCase):
     @qgsfunction(1, 'testing', register=False, usesgeometry=True)
     def geomtest(values, feature, parent):
         pass
+
+    @qgsfunction(args=0, group='testing', register=False)
+    def no_referenced_columns_set(values, feature, parent):
+        return 1
+
+    @qgsfunction(args=0, group='testing', register=False, referenced_columns=['a', 'b'])
+    def referenced_columns_set(values, feature, parent):
+        return 2
 
     def tearDown(self):
         QgsExpression.unregisterFunction('testfun')
@@ -117,6 +125,16 @@ class TestQgsExpressionCustomFunctions(unittest.TestCase):
     def testCanRegisterGeometryFunction(self):
         success = QgsExpression.registerFunction(self.geomtest)
         self.assertTrue(success)
+
+    def testReferencedColumnsNoSet(self):
+        success = QgsExpression.registerFunction(self.no_referenced_columns_set)
+        exp = QgsExpression('no_referenced_columns_set()')
+        self.assertEqual(exp.referencedColumns(), [QgsFeatureRequest.AllAttributes])
+
+    def testReferencedColumnsSet(self):
+        success = QgsExpression.registerFunction(self.referenced_columns_set)
+        exp = QgsExpression('referenced_columns_set()')
+        self.assertEqual(exp.referencedColumns(), ['a', 'b'])
 
     def testCantOverrideBuiltinsWithUnregister(self):
         success = QgsExpression.unregisterFunction("sqrt")


### PR DESCRIPTION
Fix #14985
