### PR TITLE
[BUGFIX] Emit layerWillBeRemoved like layersWillBeRemoved

### DIFF
--- a/src/core/qgsmaplayerregistry.cpp
+++ b/src/core/qgsmaplayerregistry.cpp
@@ -144,10 +144,10 @@ void QgsMapLayerRegistry::removeMapLayers( const QList<QgsMapLayer*>& layers )
       continue;
 
     QString myId( lyr->id() );
+    emit layerWillBeRemoved( myId );
+    emit layerWillBeRemoved( lyr );
     if ( mOwnedLayers.contains( lyr ) )
     {
-      emit layerWillBeRemoved( myId );
-      emit layerWillBeRemoved( lyr );
       delete lyr;
       mOwnedLayers.remove( lyr );
     }


### PR DESCRIPTION
The signal layerWillBeremoved is only emitted when the layer is owned by QgsMapLayerRegistry.

To fix it just move the emitted layerWilBeRemoved out of the scope of layers owned by QgsMapLayerRegistry.
