### PR TITLE
[bugfix] fix crash when right-clicking on geometryless layers

### DIFF
--- a/src/app/qgsapplayertreeviewmenuprovider.cpp
+++ b/src/app/qgsapplayertreeviewmenuprovider.cpp
@@ -148,7 +148,7 @@ QMenu* QgsAppLayerTreeViewMenuProvider::createContextMenu()
         if ( vlayer )
         {
           const QgsSingleSymbolRendererV2* singleRenderer = dynamic_cast< const QgsSingleSymbolRendererV2* >( vlayer->rendererV2() );
-          if ( !singleRenderer && vlayer->rendererV2()->embeddedRenderer() )
+          if ( !singleRenderer && vlayer->rendererV2() && vlayer->rendererV2()->embeddedRenderer() )
           {
             singleRenderer = dynamic_cast< const QgsSingleSymbolRendererV2* >( vlayer->rendererV2()->embeddedRenderer() );
           }


### PR DESCRIPTION
This fixes a crash that was recently introduced on master (commit b32afce), whereas right-clicking on a geometryless layer (e.g., CSV) would kill QGIS.

@nyalldawson , looking good? 
