### PR TITLE
Clean up showPanel API. Open dialog if not in dock mode

### DIFF
--- a/python/gui/effects/qgseffectstackpropertieswidget.sip
+++ b/python/gui/effects/qgseffectstackpropertieswidget.sip
@@ -182,13 +182,6 @@ class QgsEffectStackCompactWidget : QgsPanelWidget
      */
     void setPreviewPicture( const QPicture& picture );
 
-    /**
-     * Set the widget in dock mode. In dock mode the widget will emit a signal
-     * to show the effects selector instead of opening a dialog.
-     * @param dockMode True to enable dock mode.
-     */
-    void setDockMode( bool dockMode );
-
   signals:
 
     /** Emitted when the paint effect properties change

--- a/python/gui/qgspanelwidget.sip
+++ b/python/gui/qgspanelwidget.sip
@@ -49,6 +49,27 @@ class QgsPanelWidget : public QWidget
      * @param dockMode True to enable dock mode.
      */
     virtual void setDockMode( bool dockMode );
+
+    /**
+     * Return the dock mode state.
+     * @return True if in dock mode.  If in dock mode the widget
+     * will emit the showPanel signal to handle panel opening
+     * If false it will open dialogs when openPanel is called.
+     */
+    bool dockMode();
+
+    /**
+     * Open a panel or dialog depending on dock mode setting
+     * If dock mode is true this method will emit the showPanel signal
+     * for connected slots to handle the open event.
+     *
+     * If dock mode is false this method will open a dialog
+     * and block the user.
+     *
+     * @param panel The panel widget to open.
+     */
+    void openPanel( QgsPanelWidget* panel );
+
   signals:
 
     /**

--- a/python/gui/symbology-ng/qgsrendererv2propertiesdialog.sip
+++ b/python/gui/symbology-ng/qgsrendererv2propertiesdialog.sip
@@ -24,8 +24,6 @@ class QgsRendererV2PropertiesDialog : QDialog
      */
     void setMapCanvas( QgsMapCanvas* canvas );
 
-    void setDockMode( bool dockMode );
-
   signals:
     /**
      * Emitted when expression context variables on the associated

--- a/python/gui/symbology-ng/qgsrendererv2widget.sip
+++ b/python/gui/symbology-ng/qgsrendererv2widget.sip
@@ -39,13 +39,6 @@ class QgsRendererV2Widget : QgsPanelWidget
      */
     void applyChanges();
 
-    /**
-     * Set the widget in dock mode which tells the widget to emit panel
-     * widgets and not open dialogs
-     * @param dockMode True to enable dock mode.
-     */
-    virtual void setDockMode( bool dockMode);
-
   signals:
     /**
      * Emitted when expression context variables on the associated

--- a/python/gui/symbology-ng/qgssymbolv2selectordialog.sip
+++ b/python/gui/symbology-ng/qgssymbolv2selectordialog.sip
@@ -40,12 +40,6 @@ class QgsSymbolV2SelectorWidget : QgsPanelWidget
      */
     QgsSymbolV2* symbol();
 
-    /**
-     * Set the widget in dock mode which will emit showPanel when a sub widget requests
-     * to show a widget.
-     * @param dockMode True to enable dock mode.
-     */
-    void setDockMode( bool dockMode );
   protected:
     //! Reimplements dialog keyPress event so we can ignore it
     void keyPressEvent( QKeyEvent * event );

--- a/src/gui/effects/qgseffectstackpropertieswidget.cpp
+++ b/src/gui/effects/qgseffectstackpropertieswidget.cpp
@@ -382,7 +382,6 @@ void QgsEffectStackPropertiesDialog::setPreviewPicture( const QPicture &picture 
 
 QgsEffectStackCompactWidget::QgsEffectStackCompactWidget( QWidget *parent , QgsPaintEffect *effect )
     : QgsPanelWidget( parent )
-    , mDockMode( false )
     , mEnabledCheckBox( nullptr )
     , mButton( nullptr )
     , mPreviewPicture( nullptr )
@@ -452,32 +451,14 @@ void QgsEffectStackCompactWidget::showDialog()
     return;
 
   QgsEffectStack* clone = static_cast<QgsEffectStack*>( mStack->clone() );
-  if ( mDockMode )
+  QgsEffectStackPropertiesWidget* widget = new QgsEffectStackPropertiesWidget( clone, nullptr );
+  if ( mPreviewPicture )
   {
-    QgsEffectStackPropertiesWidget* widget = new QgsEffectStackPropertiesWidget( clone, nullptr );
-    if ( mPreviewPicture )
-    {
-      widget->setPreviewPicture( *mPreviewPicture );
-    }
-    connect( widget, SIGNAL( widgetChanged() ), this, SLOT( updateEffectLive() ) );
-    connect( widget, SIGNAL( panelAccepted( QgsPanelWidget* ) ), this, SLOT( updateAcceptWidget( QgsPanelWidget* ) ) );
-    emit showPanel( widget );
+    widget->setPreviewPicture( *mPreviewPicture );
   }
-  else
-  {
-    QgsEffectStackPropertiesDialog dialog( clone, this );
-    if ( mPreviewPicture )
-    {
-      dialog.setPreviewPicture( *mPreviewPicture );
-    }
-    if ( dialog.exec() == QDialog::Accepted )
-    {
-      *mStack = *clone;
-      emit changed();
-    }
-
-    delete clone;
-  }
+  connect( widget, SIGNAL( widgetChanged() ), this, SLOT( updateEffectLive() ) );
+  connect( widget, SIGNAL( panelAccepted( QgsPanelWidget* ) ), this, SLOT( updateAcceptWidget( QgsPanelWidget* ) ) );
+  openPanel( widget );
 }
 
 void QgsEffectStackCompactWidget::enableToggled( bool checked )

--- a/src/gui/effects/qgseffectstackpropertieswidget.h
+++ b/src/gui/effects/qgseffectstackpropertieswidget.h
@@ -219,13 +219,6 @@ class GUI_EXPORT QgsEffectStackCompactWidget: public QgsPanelWidget
      */
     void setPreviewPicture( const QPicture &picture );
 
-    /**
-     * Set the widget in dock mode. In dock mode the widget will emit a signal
-     * to show the effects selector instead of opening a dialog.
-     * @param dockMode True to enable dock mode.
-     */
-    void setDockMode( bool dockMode ) { mDockMode = dockMode; }
-
   signals:
 
     /** Emitted when the paint effect properties change
@@ -242,8 +235,6 @@ class GUI_EXPORT QgsEffectStackCompactWidget: public QgsPanelWidget
     void updateEffectLive();
 
   private:
-    bool mDockMode;
-
     QgsEffectStack* mStack;
     QCheckBox* mEnabledCheckBox;
     QToolButton* mButton;

--- a/src/gui/qgspanelwidget.cpp
+++ b/src/gui/qgspanelwidget.cpp
@@ -14,6 +14,7 @@
  ***************************************************************************/
 #include <QDialogButtonBox>
 #include <QPushButton>
+#include <QDialog>
 
 #include "qgspanelwidget.h"
 #include "qgslogger.h"
@@ -40,6 +41,28 @@ void QgsPanelWidget::connectChildPanel( QgsPanelWidget *panel )
 void QgsPanelWidget::setDockMode( bool dockMode )
 {
   mDockMode = dockMode;
+}
+
+void QgsPanelWidget::openPanel( QgsPanelWidget* panel )
+{
+  if ( mDockMode )
+  {
+    QgsDebugMsg( "DOCK MODE!!" );
+    emit showPanel( panel );
+  }
+  else
+  {
+    // Show the dialog version if no one is connected
+    QDialog* dlg = new QDialog();
+    dlg->setWindowTitle( panel->panelTitle() );
+    dlg->setLayout( new QVBoxLayout() );
+    dlg->layout()->addWidget( panel );
+    QDialogButtonBox* buttonBox = new QDialogButtonBox( QDialogButtonBox::Ok );
+    connect( buttonBox, SIGNAL( accepted() ), dlg, SLOT( accept() ) );
+    dlg->layout()->addWidget( buttonBox );
+    dlg->exec();
+    emit panelAccepted( panel );
+  }
 }
 
 void QgsPanelWidget::acceptPanel()

--- a/src/gui/qgspanelwidget.h
+++ b/src/gui/qgspanelwidget.h
@@ -73,6 +73,26 @@ class GUI_EXPORT QgsPanelWidget : public QWidget
      */
     virtual void setDockMode( bool dockMode );
 
+    /**
+     * Return the dock mode state.
+     * @return True if in dock mode.  If in dock mode the widget
+     * will emit the showPanel signal to handle panel opening
+     * If false it will open dialogs when openPanel is called.
+     */
+    bool dockMode() { return mDockMode; }
+
+    /**
+     * Open a panel or dialog depending on dock mode setting
+     * If dock mode is true this method will emit the showPanel signal
+     * for connected slots to handle the open event.
+     *
+     * If dock mode is false this method will open a dialog
+     * and block the user.
+     *
+     * @param panel The panel widget to open.
+     */
+    void openPanel( QgsPanelWidget* panel );
+
   signals:
 
     /**

--- a/src/gui/symbology-ng/qgscategorizedsymbolrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgscategorizedsymbolrendererv2widget.cpp
@@ -572,12 +572,12 @@ void QgsCategorizedSymbolRendererV2Widget::changeCategorizedSymbol()
 {
   QgsSymbolV2* newSymbol = mCategorizedSymbol->clone();
   QgsSymbolV2SelectorWidget* dlg = new QgsSymbolV2SelectorWidget( newSymbol, mStyle, mLayer, nullptr );
-  dlg->setDockMode( true );
+  dlg->setDockMode( this->dockMode() );
   dlg->setMapCanvas( mMapCanvas );
 
   connect( dlg, SIGNAL( widgetChanged() ), this, SLOT( updateSymbolsFromWidget() ) );
-  connect( dlg, SIGNAL( accepted( QgsPanelWidget* ) ), this, SLOT( cleanUpSymbolSelector( QgsPanelWidget* ) ) );
-  emit showPanel( dlg );
+  connect( dlg, SIGNAL( panelAccepted( QgsPanelWidget* ) ), this, SLOT( cleanUpSymbolSelector( QgsPanelWidget* ) ) );
+  openPanel( dlg );
 }
 
 void QgsCategorizedSymbolRendererV2Widget::updateCategorizedSymbolIcon()
@@ -617,11 +617,11 @@ void QgsCategorizedSymbolRendererV2Widget::changeCategorySymbol()
   }
 
   QgsSymbolV2SelectorWidget* dlg = new QgsSymbolV2SelectorWidget( symbol, mStyle, mLayer, nullptr );
-  dlg->setDockMode( true );
+  dlg->setDockMode( this->dockMode() );
   dlg->setMapCanvas( mMapCanvas );
   connect( dlg, SIGNAL( widgetChanged() ), this, SLOT( updateSymbolsFromWidget() ) );
-  connect( dlg, SIGNAL( accepted( QgsPanelWidget* ) ), this, SLOT( cleanUpSymbolSelector( QgsPanelWidget* ) ) );
-  emit showPanel( dlg );
+  connect( dlg, SIGNAL( panelAccepted( QgsPanelWidget* ) ), this, SLOT( cleanUpSymbolSelector( QgsPanelWidget* ) ) );
+  openPanel( dlg );
 }
 
 static void _createCategories( QgsCategoryList& cats, QList<QVariant>& values, QgsSymbolV2* symbol )

--- a/src/gui/symbology-ng/qgsgraduatedsymbolrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgsgraduatedsymbolrendererv2widget.cpp
@@ -832,7 +832,7 @@ void QgsGraduatedSymbolRendererV2Widget::changeGraduatedSymbol()
 
   connect( dlg, SIGNAL( widgetChanged() ), this, SLOT( updateSymbolsFromWidget() ) );
   connect( dlg, SIGNAL( accepted( QgsPanelWidget* ) ), this, SLOT( cleanUpSymbolSelector( QgsPanelWidget* ) ) );
-  emit showPanel( dlg );
+  openPanel( dlg );
 }
 
 void QgsGraduatedSymbolRendererV2Widget::updateGraduatedSymbolIcon()
@@ -906,12 +906,12 @@ void QgsGraduatedSymbolRendererV2Widget::changeRangeSymbol( int rangeIdx )
 {
   QgsSymbolV2* newSymbol = mRenderer->ranges()[rangeIdx].symbol()->clone();
   QgsSymbolV2SelectorWidget* dlg = new QgsSymbolV2SelectorWidget( newSymbol, mStyle, mLayer, nullptr );
-  dlg->setDockMode( true );
+  dlg->setDockMode( this->dockMode() );
   dlg->setMapCanvas( mMapCanvas );
 
   connect( dlg, SIGNAL( widgetChanged() ), this, SLOT( updateSymbolsFromWidget() ) );
   connect( dlg, SIGNAL( accepted( QgsPanelWidget* ) ), this, SLOT( cleanUpSymbolSelector( QgsPanelWidget* ) ) );
-  emit showPanel( dlg );
+  openPanel( dlg );
 }
 
 void QgsGraduatedSymbolRendererV2Widget::changeRange( int rangeIdx )

--- a/src/gui/symbology-ng/qgslayerpropertieswidget.cpp
+++ b/src/gui/symbology-ng/qgslayerpropertieswidget.cpp
@@ -136,11 +136,8 @@ void QgsLayerPropertiesWidget::setMapCanvas( QgsMapCanvas *canvas )
 
 void QgsLayerPropertiesWidget::setDockMode( bool dockMode )
 {
-  mDockMode = dockMode;
-  if ( dockMode )
-  {
-    mEffectWidget->setDockMode( dockMode );
-  }
+  QgsPanelWidget::setDockMode( dockMode );
+  mEffectWidget->setDockMode( this->dockMode() );
 }
 
 void QgsLayerPropertiesWidget::setExpressionContext( QgsExpressionContext *context )

--- a/src/gui/symbology-ng/qgslayerpropertieswidget.h
+++ b/src/gui/symbology-ng/qgslayerpropertieswidget.h
@@ -58,7 +58,7 @@ class GUI_EXPORT QgsLayerPropertiesWidget : public QgsPanelWidget, private Ui::L
      * widgets and not open dialogs
      * @param dockMode True to enable dock mode.
      */
-    void setDockMode( bool dockMode );
+    virtual void setDockMode( bool dockMode ) override;
 
   public slots:
     void layerTypeChanged();
@@ -92,7 +92,6 @@ class GUI_EXPORT QgsLayerPropertiesWidget : public QgsPanelWidget, private Ui::L
     void reloadLayer();
 
   private:
-    bool mDockMode;
     QgsExpressionContext* mPresetExpressionContext;
     QgsMapCanvas* mMapCanvas;
 

--- a/src/gui/symbology-ng/qgsrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgsrendererv2widget.cpp
@@ -273,11 +273,6 @@ void QgsRendererV2Widget::applyChanges()
   apply();
 }
 
-void QgsRendererV2Widget::setDockMode( bool dockMode )
-{
-  mDockMode = dockMode;
-}
-
 
 
 ////////////

--- a/src/gui/symbology-ng/qgsrendererv2widget.h
+++ b/src/gui/symbology-ng/qgsrendererv2widget.h
@@ -76,14 +76,6 @@ class GUI_EXPORT QgsRendererV2Widget : public QgsPanelWidget
      */
     void applyChanges();
 
-    /**
-     * Set the widget in dock mode which tells the widget to emit panel
-     * widgets and not open dialogs
-     * @param dockMode True to enable dock mode.
-     */
-    virtual void setDockMode( bool dockMode ) override;
-
-
   signals:
     /**
      * Emitted when expression context variables on the associated
@@ -93,7 +85,6 @@ class GUI_EXPORT QgsRendererV2Widget : public QgsPanelWidget
     void layerVariablesChanged();
 
   protected:
-    bool mDockMode;
     QgsVectorLayer* mLayer;
     QgsStyleV2* mStyle;
     QMenu* contextMenu;

--- a/src/gui/symbology-ng/qgssinglesymbolrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgssinglesymbolrendererv2widget.cpp
@@ -90,7 +90,6 @@ void QgsSingleSymbolRendererV2Widget::setMapCanvas( QgsMapCanvas* canvas )
 void QgsSingleSymbolRendererV2Widget::setDockMode( bool dockMode )
 {
   QgsRendererV2Widget::setDockMode( dockMode );
-  mDockMode = dockMode;
   if ( mSelector )
     mSelector->setDockMode( dockMode );
 }

--- a/src/gui/symbology-ng/qgssymbolv2selectordialog.cpp
+++ b/src/gui/symbology-ng/qgssymbolv2selectordialog.cpp
@@ -300,11 +300,6 @@ void QgsSymbolV2SelectorWidget::setMapCanvas( QgsMapCanvas *canvas )
     listWidget->setMapCanvas( canvas );
 }
 
-void QgsSymbolV2SelectorWidget::setDockMode( bool dockMode )
-{
-  mDockMode = dockMode;
-}
-
 void QgsSymbolV2SelectorWidget::loadSymbol( QgsSymbolV2* symbol, SymbolLayerItem* parent )
 {
   SymbolLayerItem* symbolItem = new SymbolLayerItem( symbol );
@@ -419,7 +414,7 @@ void QgsSymbolV2SelectorWidget::layerChanged()
     SymbolLayerItem *parent = static_cast<SymbolLayerItem*>( currentItem->parent() );
     mDataDefineRestorer.reset( new DataDefinedRestorer( parent->symbol(), currentItem->layer() ) );
     QgsLayerPropertiesWidget *layerProp = new QgsLayerPropertiesWidget( currentItem->layer(), parent->symbol(), mVectorLayer );
-    layerProp->setDockMode( mDockMode );
+    layerProp->setDockMode( this->dockMode() );
     layerProp->setExpressionContext( mPresetExpressionContext.data() );
     layerProp->setMapCanvas( mMapCanvas );
     setWidget( layerProp );

--- a/src/gui/symbology-ng/qgssymbolv2selectordialog.h
+++ b/src/gui/symbology-ng/qgssymbolv2selectordialog.h
@@ -128,13 +128,6 @@ class GUI_EXPORT QgsSymbolV2SelectorWidget: public QgsPanelWidget, private Ui::Q
      */
     QgsSymbolV2* symbol() { return mSymbol; }
 
-    /**
-     * Set the widget in dock mode which will emit showPanel when a sub widget requests
-     * to show a widget.
-     * @param dockMode True to enable dock mode.
-     */
-    void setDockMode( bool dockMode );
-
   protected:
 
     /**
@@ -255,7 +248,6 @@ class GUI_EXPORT QgsSymbolV2SelectorWidget: public QgsPanelWidget, private Ui::Q
     QWidget *mPresentWidget;
 
   private:
-    bool mDockMode;
     QScopedPointer<DataDefinedRestorer> mDataDefineRestorer;
     QScopedPointer< QgsExpressionContext > mPresetExpressionContext;
 


### PR DESCRIPTION
Instead of using `emit showPanel` using new method `openPanel` which can open a dialog if dock mode isn't enabled.  Generally cleans up the API for callers so it's a single way to handle opening panels or dialogs.  

This change also makes sure that existing users of the dialog don't have to connect to showPanel in order to handle it.

Opened a PR mainly to check Travis.
