### PR TITLE
[dbmanager] Fixes #13712

### DIFF
--- a/python/plugins/db_manager/db_model.py
+++ b/python/plugins/db_manager/db_model.py
@@ -559,7 +559,7 @@ class DBModel(QAbstractItemModel):
                         uri = QgsDataSourceURI()
                         uri.setDatabase(filename)
                         item.getItemData().addConnection(conn_name, uri)
-                        item.itemChanged.emit(item)
+                        item.itemChanged.emit()
                         added += 1
                         continue
 

--- a/python/plugins/db_manager/db_plugins/spatialite/connector.py
+++ b/python/plugins/db_manager/db_plugins/spatialite/connector.py
@@ -57,14 +57,20 @@ class SpatiaLiteDBConnector(DBConnector):
 
     @classmethod
     def isValidDatabase(self, path):
-        if not QFile.exists(path):
+        """Checks if a file is a valid sqlite database
+           http://stackoverflow.com/a/15355790
+        """
+        from os.path import isfile, getsize
+
+        if not isfile(path):
             return False
-        try:
-            conn = sqlite.connect(path)
-        except self.connection_error_types():
+        if getsize(path) < 100:
             return False
-        conn.close()
-        return True
+
+        with open(path, 'rb') as fd:
+            header = fd.read(100)
+
+        return header[:16] == 'SQLite format 3\x00'
 
     def _checkSpatial(self):
         """ check if it's a valid spatialite db """


### PR DESCRIPTION
A part the `TypeError: TreeItem.itemChanged[] signal has 0 argument(s) but 1 provided`, it seems that the `isValidDatabase(path)` method not work as expected. Any file is considered as a valid sqlite database creating a new connection (by `conn = sqlite.connect(path)`) when drag and drop a file in tree model.

I found a different approach to check if the file is a valid database, much the same as shown in this [discussion](http://stackoverflow.com/a/15355790).

@brushtyler could you take a look at this change, please.

refs: [#13712](http://hub.qgis.org/issues/13712)

_Note: maybe requires some change for python3_
