### PR TITLE
QgsCoordinateReferenceSystem::setProj4String(): harden validation

### DIFF
--- a/src/core/qgscoordinatereferencesystem.cpp
+++ b/src/core/qgscoordinatereferencesystem.cpp
@@ -899,6 +899,20 @@ void QgsCoordinateReferenceSystem::setProj4String( const QString& theProj4String
   OSRDestroySpatialReference( d->mCRS );
   d->mCRS = OSRNewSpatialReference( nullptr );
   d->mIsValid = OSRImportFromProj4( d->mCRS, theProj4String.trimmed().toLatin1().constData() ) == OGRERR_NONE;
+  // OSRImportFromProj4() may accept strings that are not valid proj.4 strings,
+  // e.g if they lack a +ellps parameter, it will automatically add +ellps=WGS84, but as
+  // we use the original mProj4 with QgsCoordinateTransform, it will fail to initialize
+  // so better detect it now.
+  projPJ theProj = pj_init_plus( theProj4String.trimmed().toLatin1().constData() );
+  if ( !theProj )
+  {
+    QgsDebugMsg( "proj.4 string rejected by pj_init_plus()" );
+    d->mIsValid = false;
+  }
+  else
+  {
+    pj_free( theProj );
+  }
   d->mWkt.clear();
   setMapUnits();
 

--- a/tests/src/core/testqgscoordinatereferencesystem.cpp
+++ b/tests/src/core/testqgscoordinatereferencesystem.cpp
@@ -61,6 +61,7 @@ class TestQgsCoordinateReferenceSystem: public QObject
     void mapUnits();
     void setValidationHint();
     void axisInverted();
+    void createFromProj4Invalid();
   private:
     void debugPrint( QgsCoordinateReferenceSystem &theCrs );
     // these used by createFromESRIWkt()
@@ -486,6 +487,12 @@ void TestQgsCoordinateReferenceSystem::debugPrint(
   {
     QgsDebugMsg( "* Units : degrees" );
   }
+}
+
+void TestQgsCoordinateReferenceSystem::createFromProj4Invalid()
+{
+  QgsCoordinateReferenceSystem myCrs;
+  QVERIFY( !myCrs.createFromProj4( "+proj=longlat +no_defs" ) );
 }
 
 QTEST_MAIN( TestQgsCoordinateReferenceSystem )


### PR DESCRIPTION
OSRImportFromProj4() may accept strings that are not valid proj.4 strings,
e.g if they lack a +ellps parameter, it will automatically add +ellps=WGS84, but as
we use the original mProj4 with QgsCoordinateTransform, it will fail to initialize
so better detect it now.

Fixes #14844
