### PR TITLE
Fix allow clicking on a tags in maptips

### DIFF
--- a/python/gui/qgsmaptip.sip
+++ b/python/gui/qgsmaptip.sip
@@ -3,7 +3,7 @@
  * A maptip is a class to display a tip on a map canvas
  * when a mouse is hovered over a feature.
  */
-class QgsMapTip
+class QgsMapTip: QWidget
 {
 %TypeHeaderCode
 #include <qgsmaptip.h>

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -401,6 +401,7 @@ SET(QGIS_GUI_MOC_HDRS
   qgsmaplayerproxymodel.h
   qgsmaplayerstylemanagerwidget.h
   qgsmapoverviewcanvas.h
+  qgsmaptip.h
   qgsmaptool.h
   qgsmaptooladvanceddigitizing.h
   qgsmaptoolcapture.h

--- a/src/gui/qgsmaptip.cpp
+++ b/src/gui/qgsmaptip.cpp
@@ -26,6 +26,7 @@
 #include <QToolTip>
 #include <QSettings>
 #include <QLabel>
+#include <QDesktopServices>
 #if WITH_QTWEBKIT
 #include <QWebElement>
 #endif
@@ -64,6 +65,13 @@ void QgsMapTip::showMapTip( QgsMapLayer *pLayer,
   delete mWidget;
   mWidget = new QWidget( pMapCanvas );
   mWebView = new QgsWebView( mWidget );
+
+
+#if WITH_QTWEBKIT
+  mWebView->page()->setLinkDelegationPolicy( QWebPage::DelegateAllLinks );//Handle link clicks by yourself
+  mWebView->setContextMenuPolicy( Qt::NoContextMenu ); //No context menu is allowed if you don't need it
+  connect( mWebView, SIGNAL( linkClicked( QUrl ) ), this, SLOT( onLinkClicked( QUrl ) ) );
+#endif
 
   mWebView->page()->settings()->setAttribute(
     QWebSettings::DeveloperExtrasEnabled, true );
@@ -199,4 +207,10 @@ QString QgsMapTip::fetchFeature( QgsMapLayer *layer, QgsPoint &mapPosition, QgsM
   {
     return feature.attribute( idx ).toString();
   }
+}
+
+//This slot handles all clicks
+void QgsMapTip::onLinkClicked( const QUrl &url )
+{
+  QDesktopServices::openUrl( url );
 }

--- a/src/gui/qgsmaptip.h
+++ b/src/gui/qgsmaptip.h
@@ -19,8 +19,12 @@ class QgsMapLayer;
 class QgsMapCanvas;
 class QPoint;
 class QString;
+class QgsPoint;
+class QgsVectorLayer;
 class QgsWebView;
 
+#include <QWidget>
+#include <QUrl>
 #include "qgsfeature.h"
 
 /** \ingroup gui
@@ -42,8 +46,9 @@ class QgsWebView;
  * discourages link rel="stylesheet" in the body, but all browsers allow it.
  * see https://jakearchibald.com/2016/link-in-body/
  */
-class GUI_EXPORT QgsMapTip
+class GUI_EXPORT QgsMapTip: public QWidget
 {
+    Q_OBJECT
   public:
     /** Default constructor
      */
@@ -84,5 +89,7 @@ class GUI_EXPORT QgsMapTip
     QWidget* mWidget;
     QgsWebView* mWebView;
 
+  private slots:
+    void onLinkClicked( const QUrl& url );
 };
 #endif // QGSMAPTIP_H


### PR DESCRIPTION
this is done by listening to the linkClicked signal in the QgsWebView
