### PR TITLE
[styledock] open via double click action legend setting

### DIFF
--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -463,6 +463,9 @@ void QgisApp::layerTreeViewDoubleClicked( const QModelIndex& index )
     case 1:
       QgisApp::instance()->attributeTable();
       break;
+    case 2:
+      mapStyleDock( true );
+      break;
     default:
       break;
   }

--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -2919,6 +2919,11 @@
                         <string>Open attribute table</string>
                        </property>
                       </item>
+                      <item>
+                       <property name="text">
+                        <string>Open map styling dock</string>
+                       </property>
+                      </item>
                      </widget>
                     </item>
                    </layout>


### PR DESCRIPTION
The style dock is too nice not to add the possibility to assign it to the legend's double click action:
![untitled](https://cloud.githubusercontent.com/assets/1728657/16185643/930ef8ca-36ef-11e6-9ad6-82a399c2abf3.png)

This PR doesn't mess with the default action, which is still assigned to opening the layer's properties window.
