### PR TITLE
rename "snapping mode" option

### DIFF
--- a/src/ui/qgssnappingdialogbase.ui
+++ b/src/ui/qgssnappingdialogbase.ui
@@ -19,7 +19,7 @@
      <item>
       <widget class="QLabel" name="label">
        <property name="text">
-        <string>Snapping mode</string>
+        <string>Layer selection</string>
        </property>
       </widget>
      </item>


### PR DESCRIPTION
Fix [#14828](http://hub.qgis.org/issues/14828) 
When comes the time to document the Snapping Options dialog, it's quite difficult to find the right words;  "Snapping mode" is used as well as for:
- the **to-snap-to layer selection** mode : `Current layer`, `All layers`, `Advanced`
- and **the way to snap to** that layer: `To vertex`, `To segment`, `To vertex and segment`, `Off` as described in the Digitizing tab of Settings --> Options menu.
