### PR TITLE
Fix bug in GDALTools Assign Projection

### DIFF
--- a/python/plugins/GdalTools/tools/doProjection.py
+++ b/python/plugins/GdalTools/tools/doProjection.py
@@ -42,7 +42,7 @@ class GdalToolsDialog(QWidget, Ui_Widget, BaseBatchWidget):
         self.iface = iface
 
         self.setupUi(self)
-        BaseBatchWidget.__init__(self, self.iface, "gdalwarp")
+        BaseBatchWidget.__init__(self, self.iface, "gdal_translate")
 
         self.inSelector.setType(self.inSelector.FILE)
 
@@ -112,7 +112,7 @@ class GdalToolsDialog(QWidget, Ui_Widget, BaseBatchWidget):
     def getArguments(self):
         arguments = []
         if self.desiredSRSEdit.text():
-            arguments.append("-t_srs")
+            arguments.append("-a_srs")
             arguments.append(self.desiredSRSEdit.text())
         if self.batchCheck.isChecked():
             return arguments


### PR DESCRIPTION
Assign Projection uses gdalwarp, and this works correctly when a raster has no CRS assigned, however, in the case of a raster with an incorrect CRS assignment, then gdalwarp will reproject the raster instead of simply changing the assigned CRS, propagating the error. Switching the Assign Projection tool to use gdal_translate provides the intended behaviour in all situations.
