### PR TITLE
[ogr] Read GPX elevation values as geometry Z values

### DIFF
--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -3073,6 +3073,7 @@ void QgsOgrProvider::open( OpenMode mode )
   QgsDebugMsg( "mLayerName: " + mLayerName );
   QgsDebugMsg( "mSubsetString: " + mSubsetString );
   CPLSetConfigOption( "OGR_ORGANIZE_POLYGONS", "ONLY_CCW" );  // "SKIP" returns MULTIPOLYGONs for multiringed POLYGONs
+  CPLSetConfigOption( "GPX_ELE_AS_25D", "YES" );  // use GPX elevation as z values
 
   if ( mFilePath.startsWith( "MySQL:" ) && !mLayerName.isEmpty() && !mFilePath.endsWith( ",tables=" + mLayerName ) )
   {

--- a/tests/src/python/test_provider_ogr.py
+++ b/tests/src/python/test_provider_ogr.py
@@ -116,6 +116,25 @@ class PyQgsOGRProvider(unittest.TestCase):
         self.assertEqual(len(vl.dataProvider().subLayers()), 1)
         self.assertEqual(vl.dataProvider().subLayers()[0], '0:testMixOfLineStringCompoundCurve:5:CompoundCurve')
 
+    def testGpxElevation(self):
+        # GPX without elevation data
+        datasource = os.path.join(TEST_DATA_DIR, 'noelev.gpx')
+        vl = QgsVectorLayer(u'{}|layername=routes'.format(datasource), u'test', u'ogr')
+        self.assertTrue(vl.isValid())
+        f = next(vl.getFeatures())
+        self.assertEqual(f.constGeometry().geometry().wkbType(), QgsWKBTypes.LineString)
+
+        # GPX with elevation data
+        datasource = os.path.join(TEST_DATA_DIR, 'elev.gpx')
+        vl = QgsVectorLayer(u'{}|layername=routes'.format(datasource), u'test', u'ogr')
+        self.assertTrue(vl.isValid())
+        f = next(vl.getFeatures())
+        #not sure why this next line fails - wkb type exported by OGR_G_ExportToWkb is corrupt
+        #self.assertEqual(f.constGeometry().geometry().wkbType(), QgsWKBTypes.LineStringZ )
+        self.assertEqual(f.constGeometry().geometry().pointN(0).z(), 1)
+        self.assertEqual(f.constGeometry().geometry().pointN(1).z(), 2)
+        self.assertEqual(f.constGeometry().geometry().pointN(2).z(), 3)
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/tests/testdata/elev.gpx
+++ b/tests/testdata/elev.gpx
@@ -1,0 +1,15 @@
+<?xml version="1.0"?>
+<gpx version="1.1" creator="GDAL 1.11.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.topografix.com/GPX/1/1" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
+<metadata><bounds minlat="56.134840267383296" minlon="-3.877982991747363" maxlat="56.135514185147493" maxlon="-3.852565020533009"/></metadata>                  
+<rte>
+  <rtept lat="56.134840267383296" lon="-3.877982991747363">
+    <ele>1</ele>
+  </rtept>
+  <rtept lat="56.134933668432737" lon="-3.865962243986197">
+    <ele>2</ele>
+  </rtept>
+  <rtept lat="56.135514185147493" lon="-3.852565020533009">
+    <ele>3</ele>
+  </rtept>
+</rte>
+</gpx>

--- a/tests/testdata/noelev.gpx
+++ b/tests/testdata/noelev.gpx
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<gpx version="1.1" creator="GDAL 1.11.3" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns="http://www.topografix.com/GPX/1/1" xsi:schemaLocation="http://www.topografix.com/GPX/1/1 http://www.topografix.com/GPX/1/1/gpx.xsd">
+<metadata><bounds minlat="56.134840267383240" minlon="-3.877982991747359" maxlat="56.135514185147436" maxlon="-3.852565020533005"/></metadata>                  
+<rte>
+  <rtept lat="56.13484026738324" lon="-3.877982991747359">
+  </rtept>
+  <rtept lat="56.13493366843268" lon="-3.865962243986193">
+  </rtept>
+  <rtept lat="56.135514185147436" lon="-3.852565020533005">
+  </rtept>
+</rte>
+</gpx>


### PR DESCRIPTION
@rouault mind taking a look at this? I noticed that elevation values weren't read by QGIS while investigating http://hub.qgis.org/issues/14702 and I believe this is the fix.

However, the WKB type of the geometries seems messed up, and I think it may be an OGR issue. See the comment https://github.com/qgis/QGIS/compare/master...nyalldawson:gpx_elev?expand=1#diff-a7986217f22008f8bf3a9b9f8a65060bR132
