### PR TITLE
Show cannot pan WARNING for NULL geometry

### DIFF
--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -1207,7 +1207,15 @@ void QgsMapCanvas::panToSelected( QgsVectorLayer* layer )
 
   QgsRectangle rect = mapSettings().layerExtentToOutputExtent( layer, layer->boundingBoxOfSelected() );
   if ( !rect.isNull() )
-    setCenter( rect.center() );
+    {
+      setCenter( rect.center() );
+    }
+  else
+    {
+      QString errorMessage;
+      errorMessage = tr( "Geometry is NULL" );
+      emit messageEmitted( tr( "Cannot pan to selected feature(s)" ), errorMessage, QgsMessageBar::WARNING );
+    }
 } // panToSelected
 
 void QgsMapCanvas::keyPressEvent( QKeyEvent * e )


### PR DESCRIPTION
Related to https://hub.qgis.org/issues/15122

@m-kuhn Thanks for fixing it!

I also thought of maybe disabling the "Pan to selected" buttons but in that case the user wouldn't know why they're disabled.
