### PR TITLE
[gui] improve scale widget layout to save space

### DIFF
--- a/src/gui/qgsscalerangewidget.cpp
+++ b/src/gui/qgsscalerangewidget.cpp
@@ -25,12 +25,12 @@ QgsScaleRangeWidget::QgsScaleRangeWidget( QWidget *parent )
   mLayout = new QGridLayout( this );
   mLayout->setContentsMargins( 0, 0, 0, 0 );
 
-  QLabel* minLbl = new QLabel( tr( "Minimum\n(exclusive)" ), this );
+  QLabel* minLbl = new QLabel( tr( "Minimum (exclusive)" ), this );
   minLbl->setWordWrap( true );
   minLbl->setAlignment( Qt::AlignTop );
   minLbl->setToolTip( tr( "Minimum scale, i.e. maximum scale denominator. "
                           "This limit is exclusive, that means the layer will not be displayed on this scale." ) );
-  QLabel* maxLbl = new QLabel( tr( "Maximum\n(inclusive)" ), this );
+  QLabel* maxLbl = new QLabel( tr( "Maximum (inclusive)" ), this );
   maxLbl->setWordWrap( true );
   maxLbl->setAlignment( Qt::AlignTop );
   maxLbl->setToolTip( tr( "Maximum scale, i.e. minimum scale denominator. "
@@ -51,19 +51,17 @@ QgsScaleRangeWidget::QgsScaleRangeWidget( QWidget *parent )
   mMinimumScaleWidget->setScale( 1.0 / 100000 );
   mMaximumScaleWidget->setScale( 1.0 / 1000 );
 
-  mLayout->addWidget( minLbl, 0, 0, 2, 1 );
-  mLayout->addWidget( mMinimumScaleIconLabel, 0, 1 );
-  mLayout->addWidget( mMinimumScaleWidget, 0, 2 );
-  mLayout->addWidget( maxLbl, 0, 3, 2, 1 );
-  mLayout->addWidget( mMaximumScaleIconLabel, 0, 4 );
-  mLayout->addWidget( mMaximumScaleWidget, 0, 5 );
+  mLayout->addWidget( minLbl, 0, 0, 1, 2 );
+  mLayout->addWidget( mMinimumScaleIconLabel, 1, 0 );
+  mLayout->addWidget( mMinimumScaleWidget, 1, 1 );
+  mLayout->addWidget( maxLbl, 0, 2, 1, 2 );
+  mLayout->addWidget( mMaximumScaleIconLabel, 1, 2 );
+  mLayout->addWidget( mMaximumScaleWidget, 1, 3 );
 
   mLayout->setColumnStretch( 0, 0 );
-  mLayout->setColumnStretch( 1, 0 );
-  mLayout->setColumnStretch( 2, 3 );
-  mLayout->setColumnStretch( 3, 0 );
-  mLayout->setColumnStretch( 4, 0 );
-  mLayout->setColumnStretch( 5, 3 );
+  mLayout->setColumnStretch( 1, 3 );
+  mLayout->setColumnStretch( 2, 0 );
+  mLayout->setColumnStretch( 3, 3 );
 
   connect( mMinimumScaleWidget, SIGNAL( scaleChanged( double ) ), this, SLOT( emitRangeChanged() ) );
   connect( mMaximumScaleWidget, SIGNAL( scaleChanged( double ) ), this, SLOT( emitRangeChanged() ) );


### PR DESCRIPTION
The scale widget layout currently takes _a lot_ of horizontal space, which doesn't play nicely with the style dock:
![untitled2](https://cloud.githubusercontent.com/assets/1728657/16375909/f9f1ad06-3c87-11e6-94d9-496eda922af0.png)

This PR improves things by moving the label to the top of the combo box:
![untitled](https://cloud.githubusercontent.com/assets/1728657/16375913/fd573dee-3c87-11e6-926c-c2f14828694a.png)
