### PR TITLE
QgsCoordinateTransform::transformCoords(): do not convert elevations to radians

### DIFF
--- a/src/core/qgscoordinatetransform.cpp
+++ b/src/core/qgscoordinatetransform.cpp
@@ -668,7 +668,6 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
     {
       x[i] *= DEG_TO_RAD;
       y[i] *= DEG_TO_RAD;
-      z[i] *= DEG_TO_RAD;
     }
 
   }
@@ -736,7 +735,6 @@ void QgsCoordinateTransform::transformCoords( int numPoints, double *x, double *
     {
       x[i] *= RAD_TO_DEG;
       y[i] *= RAD_TO_DEG;
-      z[i] *= RAD_TO_DEG;
     }
   }
 #ifdef COORDINATE_TRANSFORM_VERBOSE

--- a/tests/src/core/testqgsgeometry.cpp
+++ b/tests/src/core/testqgsgeometry.cpp
@@ -606,7 +606,7 @@ void TestQgsGeometry::pointV2()
   p16.transform( tr, QgsCoordinateTransform::ForwardTransform );
   QVERIFY( qgsDoubleNear( p16.x(), 175.771, 0.001 ) );
   QVERIFY( qgsDoubleNear( p16.y(), -39.722, 0.001 ) );
-  QVERIFY( qgsDoubleNear( p16.z(), 57.2958, 0.001 ) );
+  QVERIFY( qgsDoubleNear( p16.z(), 1.0, 0.001 ) );
   QCOMPARE( p16.m(), 2.0 );
   p16.transform( tr, QgsCoordinateTransform::ReverseTransform );
   QVERIFY( qgsDoubleNear( p16.x(), 6374985, 1 ) );
@@ -1491,11 +1491,11 @@ void TestQgsGeometry::lineStringV2()
   l22.transform( tr, QgsCoordinateTransform::ForwardTransform );
   QVERIFY( qgsDoubleNear( l22.pointN( 0 ).x(), 175.771, 0.001 ) );
   QVERIFY( qgsDoubleNear( l22.pointN( 0 ).y(), -39.722, 0.001 ) );
-  QVERIFY( qgsDoubleNear( l22.pointN( 0 ).z(), 57.2958, 0.001 ) );
+  QVERIFY( qgsDoubleNear( l22.pointN( 0 ).z(), 1.0, 0.001 ) );
   QCOMPARE( l22.pointN( 0 ).m(), 2.0 );
   QVERIFY( qgsDoubleNear( l22.pointN( 1 ).x(), 176.959, 0.001 ) );
   QVERIFY( qgsDoubleNear( l22.pointN( 1 ).y(), -38.798, 0.001 ) );
-  QVERIFY( qgsDoubleNear( l22.pointN( 1 ).z(), 171.887, 0.001 ) );
+  QVERIFY( qgsDoubleNear( l22.pointN( 1 ).z(), 3.0, 0.001 ) );
   QCOMPARE( l22.pointN( 1 ).m(), 4.0 );
 
   //reverse transform


### PR DESCRIPTION
Fixes #14702
