### PR TITLE
Hillshaderenderer: Rename in dropdown, remove code setting resampling

### DIFF
--- a/src/core/raster/qgsrasterrendererregistry.cpp
+++ b/src/core/raster/qgsrasterrendererregistry.cpp
@@ -62,7 +62,7 @@ QgsRasterRendererRegistry::QgsRasterRendererRegistry()
                                           QgsSingleBandPseudoColorRenderer::create, nullptr ) );
   insert( QgsRasterRendererRegistryEntry( "singlebandcolordata", QObject::tr( "Singleband color data" ),
                                           QgsSingleBandColorDataRenderer::create, nullptr ) );
-  insert( QgsRasterRendererRegistryEntry( "hillshade", QObject::tr( "Hillshade renderer" ),
+  insert( QgsRasterRendererRegistryEntry( "hillshade", QObject::tr( "Hillshade" ),
                                           QgsHillshadeRenderer::create, nullptr ) );
 }
 

--- a/src/gui/raster/qgshillshaderendererwidget.cpp
+++ b/src/gui/raster/qgshillshaderendererwidget.cpp
@@ -66,10 +66,6 @@ QgsHillshadeRendererWidget::QgsHillshadeRendererWidget( QgsRasterLayer *layer, c
   connect( mLightAzimuthDial, SIGNAL( valueChanged( int ) ), this, SLOT( on_mLightAzimuthDail_updated( int ) ) );
   connect( mZFactor, SIGNAL( valueChanged( double ) ), this, SIGNAL( widgetChanged() ) );
   connect( mMultiDirection, SIGNAL( toggled( bool ) ), this, SIGNAL( widgetChanged() ) );
-
-  QgsBilinearRasterResampler* zoomedInResampler = new QgsBilinearRasterResampler();
-  layer->resampleFilter()->setZoomedInResampler( zoomedInResampler );
-
 }
 
 QgsHillshadeRendererWidget::~QgsHillshadeRendererWidget()


### PR DESCRIPTION
This PR renames the hillshaderenderer to "Hillshade" in the "Render type" drop down. Before it was called "Hillshade renderer". The usage of "renderer" here is not in line with the other options:
![image](https://cloud.githubusercontent.com/assets/1392735/16381858/b1b15de2-3c7e-11e6-9491-ff5b4b42a7e8.png)

Furthermore the PR removes code which tries to set resampling for the hillshade renderer. The removed code sets the resampling for the layer meaning that once the hillshade renderer has been initialised the new resampling method will also apply to other renderers using that layer. I think this is surprising and unwanted behaviour.
