### PR TITLE
[styledock] improve categorized, graduated, and rule-based renderer layouts

### DIFF
--- a/src/ui/qgscategorizedsymbolrendererv2widget.ui
+++ b/src/ui/qgscategorizedsymbolrendererv2widget.ui
@@ -151,8 +151,8 @@
       </widget>
      </item>
      <item>
-      <widget class="QToolButton" name="btnAddCategory">
-       <property name="text">
+      <widget class="QPushButton" name="btnAddCategory">
+       <property name="toolTip">
         <string>Add</string>
        </property>
        <property name="icon">
@@ -162,8 +162,8 @@
       </widget>
      </item>
      <item>
-      <widget class="QToolButton" name="btnDeleteCategories">
-       <property name="text">
+      <widget class="QPushButton" name="btnDeleteCategories">
+       <property name="toolTip">
         <string>Delete</string>
        </property>
        <property name="icon">
@@ -176,10 +176,6 @@
       <widget class="QPushButton" name="btnDeleteAllCategories">
        <property name="text">
         <string>Delete all</string>
-       </property>
-       <property name="icon">
-        <iconset resource="../../images/images.qrc">
-         <normaloff>:/images/themes/default/symbologyRemove.png</normaloff>:/images/themes/default/symbologyRemove.png</iconset>
        </property>
       </widget>
      </item>

--- a/src/ui/qgsgraduatedsymbolrendererv2widget.ui
+++ b/src/ui/qgsgraduatedsymbolrendererv2widget.ui
@@ -308,6 +308,12 @@ Negative rounds to powers of 10</string>
        <string>Classes</string>
       </attribute>
       <layout class="QVBoxLayout" name="verticalLayout">
+       <property name="leftMargin">
+        <number>0</number>
+       </property>
+       <property name="rightMargin">
+        <number>0</number>
+       </property>
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout_5">
          <item>
@@ -379,13 +385,6 @@ Negative rounds to powers of 10</string>
           </widget>
          </item>
          <item>
-          <widget class="QPushButton" name="btnGraduatedClassify">
-           <property name="text">
-            <string>Classify</string>
-           </property>
-          </widget>
-         </item>
-         <item>
           <spacer name="horizontalSpacer_4">
            <property name="orientation">
             <enum>Qt::Horizontal</enum>
@@ -428,8 +427,15 @@ Negative rounds to powers of 10</string>
        <item>
         <layout class="QHBoxLayout" name="horizontalLayout_3">
          <item>
-          <widget class="QToolButton" name="btnGraduatedAdd">
+          <widget class="QPushButton" name="btnGraduatedClassify">
            <property name="text">
+            <string>Classify</string>
+           </property>
+          </widget>
+         </item>
+         <item>
+          <widget class="QPushButton" name="btnGraduatedAdd">
+           <property name="toolTip">
             <string>Add class</string>
            </property>
            <property name="icon">
@@ -439,8 +445,8 @@ Negative rounds to powers of 10</string>
           </widget>
          </item>
          <item>
-          <widget class="QToolButton" name="btnGraduatedDelete">
-           <property name="text">
+          <widget class="QPushButton" name="btnGraduatedDelete">
+           <property name="toolTip">
             <string>Delete</string>
            </property>
            <property name="icon">
@@ -454,20 +460,6 @@ Negative rounds to powers of 10</string>
            <property name="text">
             <string>Delete all</string>
            </property>
-           <property name="icon">
-            <iconset resource="../../images/images.qrc">
-             <normaloff>:/images/themes/default/symbologyRemove.png</normaloff>:/images/themes/default/symbologyRemove.png</iconset>
-           </property>
-          </widget>
-         </item>
-         <item>
-          <widget class="QCheckBox" name="cbxLinkBoundaries">
-           <property name="text">
-            <string>Link class boundaries</string>
-           </property>
-           <property name="checked">
-            <bool>true</bool>
-           </property>
           </widget>
          </item>
          <item>
@@ -477,11 +469,32 @@ Negative rounds to powers of 10</string>
            </property>
            <property name="sizeHint" stdset="0">
             <size>
-             <width>40</width>
+             <width>0</width>
              <height>20</height>
             </size>
            </property>
           </spacer>
+         </item>
+         <item>
+          <widget class="QPushButton" name="btnAdvanced">
+           <property name="text">
+            <string>Advanced</string>
+           </property>
+          </widget>
+         </item>
+        </layout>
+       </item>
+       <item>
+        <layout class="QHBoxLayout" name="_2">
+         <item>
+          <widget class="QCheckBox" name="cbxLinkBoundaries">
+           <property name="text">
+            <string>Link class boundaries</string>
+           </property>
+           <property name="checked">
+            <bool>true</bool>
+           </property>
+          </widget>
          </item>
         </layout>
        </item>
@@ -498,30 +511,6 @@ Negative rounds to powers of 10</string>
       </layout>
      </widget>
     </widget>
-   </item>
-   <item row="6" column="0" colspan="2">
-    <layout class="QHBoxLayout" name="_2">
-     <item>
-      <spacer>
-       <property name="orientation">
-        <enum>Qt::Horizontal</enum>
-       </property>
-       <property name="sizeHint" stdset="0">
-        <size>
-         <width>40</width>
-         <height>20</height>
-        </size>
-       </property>
-      </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="btnAdvanced">
-       <property name="text">
-        <string>Advanced</string>
-       </property>
-      </widget>
-     </item>
-    </layout>
    </item>
   </layout>
  </widget>

--- a/src/ui/qgsrulebasedrendererv2widget.ui
+++ b/src/ui/qgsrulebasedrendererv2widget.ui
@@ -11,18 +11,6 @@
    </rect>
   </property>
   <layout class="QVBoxLayout" name="verticalLayout">
-   <property name="leftMargin">
-    <number>0</number>
-   </property>
-   <property name="topMargin">
-    <number>0</number>
-   </property>
-   <property name="rightMargin">
-    <number>0</number>
-   </property>
-   <property name="bottomMargin">
-    <number>0</number>
-   </property>
    <item>
     <widget class="QTreeView" name="viewRules">
      <property name="contextMenuPolicy">
@@ -71,6 +59,20 @@
       </widget>
      </item>
      <item>
+      <widget class="QPushButton" name="btnRemoveRule">
+       <property name="toolTip">
+        <string>Remove selected rules</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../../images/images.qrc">
+         <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QPushButton" name="btnEditRule">
        <property name="toolTip">
         <string>Edit current rule</string>
@@ -85,19 +87,40 @@
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="btnRemoveRule">
+      <widget class="QPushButton" name="btnCountFeatures">
        <property name="toolTip">
-        <string>Remove selected rules</string>
-       </property>
-       <property name="text">
-        <string/>
+        <string>Count features</string>
        </property>
        <property name="icon">
         <iconset resource="../../images/images.qrc">
-         <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
+        <normaloff>:/images/themes/default/mActionSum.svg</normaloff>:/images/themes/default/mActionSum.svg</iconset>
        </property>
       </widget>
      </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>0</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+     <item>
+      <widget class="QPushButton" name="btnRenderingOrder">
+       <property name="text">
+        <string>Symbol levels...</string>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout2">
      <item>
       <widget class="QPushButton" name="btnRefineRule">
        <property name="enabled">
@@ -121,14 +144,7 @@
       </widget>
      </item>
      <item>
-      <widget class="QPushButton" name="btnCountFeatures">
-       <property name="text">
-        <string>Count features</string>
-       </property>
-      </widget>
-     </item>
-     <item>
-      <spacer name="horizontalSpacer">
+      <spacer name="horizontalSpacer2">
        <property name="orientation">
         <enum>Qt::Horizontal</enum>
        </property>
@@ -139,13 +155,6 @@
         </size>
        </property>
       </spacer>
-     </item>
-     <item>
-      <widget class="QPushButton" name="btnRenderingOrder">
-       <property name="text">
-        <string>Symbol levels...</string>
-       </property>
-      </widget>
      </item>
     </layout>
    </item>


### PR DESCRIPTION
This PR does two things: harmonizes layout across renderers (in terms of QToolButton vs QPushButton, button placement, spacing, etc.), and restructure the layout to allow for it to better shrink its width in the context of the style dock.

Rule-based renderer (before vs. proposed):
![rule](https://cloud.githubusercontent.com/assets/1728657/16401849/ffc040b4-3d11-11e6-8465-116c9c3a76f2.png)
- In terms of horizontal spacing, this was the layout in need of most help
- The count feature string has been replaced with the sum icon to match the composer legend item's button and save space
- The refined selected rules button was moved to its on row
- The [ + ] and [ - ] buttons were paired together to match layout of other renderers

Graduated renderer (before vs. proposed):
![grad](https://cloud.githubusercontent.com/assets/1728657/16401884/478173d2-3d12-11e6-9142-7098038c86c5.png)
- Moved the [ Classify ] button to be to the left of the [ + ] and [ - ] buttons to allow for a narrower width (and harmonize layout with the categorized renderer)
- Moved the [x] link class boundaries to its own row
- Moved the [ Advanced ] button back up (harmonization with categorized renderer)
- Converted the [ + ] and [ - ] buttons into QPushButton (harmonization)
- Removed the icon on the delete all button to reduce visual confusion and save horizontal spacing
- Removed the tab left and rigth margin in the tab widget to harmonize spacing across renderers

Categorized renderer (before vs. proposed):
![cat](https://cloud.githubusercontent.com/assets/1728657/16401924/a68a31c0-3d12-11e6-8ae7-37cd1b42940f.png)
- Converted the [ + ] and [ - ] buttons into QPushButton (harmonization)
- Removed the icon on the delete all button to reduce visual confusion and save horizontal spacing
