### PR TITLE
[gui] improve load min/max widget UI/UX

### DIFF
--- a/src/gui/raster/qgsmultibandcolorrendererwidget.cpp
+++ b/src/gui/raster/qgsmultibandcolorrendererwidget.cpp
@@ -37,7 +37,10 @@ QgsMultiBandColorRendererWidget::QgsMultiBandColorRendererWidget( QgsRasterLayer
     mMinMaxWidget = new QgsRasterMinMaxWidget( layer, this );
     mMinMaxWidget->setExtent( extent );
     mMinMaxWidget->setMapCanvas( mCanvas );
-    layout()->addWidget( mMinMaxWidget );
+    QHBoxLayout *layout = new QHBoxLayout();
+    layout->setContentsMargins( 0, 0, 0, 0 );
+    mMinMaxContainerWidget->setLayout( layout );
+    layout->addWidget( mMinMaxWidget );
     connect( mMinMaxWidget, SIGNAL( load( int, double, double, int ) ),
              this, SLOT( loadMinMax( int, double, double, int ) ) );
 

--- a/src/gui/raster/qgsrasterminmaxwidget.cpp
+++ b/src/gui/raster/qgsrasterminmaxwidget.cpp
@@ -64,7 +64,7 @@ QgsMapCanvas* QgsRasterMinMaxWidget::mapCanvas()
 
 QgsRectangle QgsRasterMinMaxWidget::extent()
 {
-  if ( !mCurrentExtentRadioButton->isChecked() )
+  if ( !cbxClipExtent->isChecked() )
     return QgsRectangle();
 
   if ( mLayer && mCanvas )
@@ -91,7 +91,7 @@ void QgsRasterMinMaxWidget::on_mLoadPushButton_clicked()
     double myMax = std::numeric_limits<double>::quiet_NaN();
 
     QgsRectangle myExtent = extent(); // empty == full
-    if ( mCurrentExtentRadioButton->isChecked() )
+    if ( cbxClipExtent->isChecked() )
     {
       origin |= QgsRasterRenderer::MinMaxSubExtent;
     }
@@ -102,7 +102,7 @@ void QgsRasterMinMaxWidget::on_mLoadPushButton_clicked()
     QgsDebugMsg( QString( "myExtent.isEmpty() = %1" ).arg( myExtent.isEmpty() ) );
 
     int mySampleSize = sampleSize(); // 0 == exact
-    if ( mEstimateRadioButton->isChecked() )
+    if ( cboAccuracy->currentIndex() == 0 )
     {
       origin |= QgsRasterRenderer::MinMaxEstimated;
     }

--- a/src/gui/raster/qgsrasterminmaxwidget.h
+++ b/src/gui/raster/qgsrasterminmaxwidget.h
@@ -62,7 +62,7 @@ class GUI_EXPORT QgsRasterMinMaxWidget: public QWidget, private Ui::QgsRasterMin
     QgsRectangle extent();
 
     /** Return the selected sample size. */
-    int sampleSize() { return mEstimateRadioButton->isChecked() ? 250000 : 0; }
+    int sampleSize() { return cboAccuracy->currentIndex() == 0 ? 250000 : 0; }
 
     // Load programmaticaly with current values
     void load() { on_mLoadPushButton_clicked(); }

--- a/src/ui/qgsmultibandcolorrendererwidgetbase.ui
+++ b/src/ui/qgsmultibandcolorrendererwidgetbase.ui
@@ -156,7 +156,7 @@ enhancement</string>
        </property>
       </widget>
      </item>
-     <item row="3" column="4">
+     <item row="3" column="2">
       <widget class="QLineEdit" name="mGreenMinLineEdit">
        <property name="maxLength">
         <number>16</number>
@@ -209,7 +209,7 @@ enhancement</string>
        </property>
       </widget>
      </item>
-     <item row="3" column="2">
+     <item row="3" column="4">
       <widget class="QLineEdit" name="mGreenMaxLineEdit">
        <property name="maxLength">
         <number>16</number>
@@ -217,6 +217,9 @@ enhancement</string>
       </widget>
      </item>
     </layout>
+   </item>
+   <item row="4" column="0" colspan="5"> 
+    <widget class="QWidget" name="mMinMaxContainerWidget" native="true"/>
    </item>
   </layout>
  </widget>

--- a/src/ui/qgsrasterminmaxwidgetbase.ui
+++ b/src/ui/qgsrasterminmaxwidgetbase.ui
@@ -27,26 +27,23 @@
     <number>0</number>
    </property>
    <item>
-    <widget class="QGroupBox" name="mLoadMinMaxValuesGroupBox">
+    <widget class="QgsCollapsibleGroupBox" name="mLoadMinMaxValuesGroupBox">
      <property name="title">
       <string>Load min/max values</string>
      </property>
      <property name="flat">
       <bool>true</bool>
      </property>
+     <property name="checkable">
+      <bool>false</bool>
+     </property>
+     <property name="collapsed" stdset="0">
+      <bool>true</bool>
+     </property>
+     <property name="saveCollapsedState" stdset="0">
+      <bool>false</bool>
+     </property>
      <layout class="QVBoxLayout" name="verticalLayout_4">
-      <property name="leftMargin">
-       <number>6</number>
-      </property>
-      <property name="topMargin">
-       <number>6</number>
-      </property>
-      <property name="rightMargin">
-       <number>6</number>
-      </property>
-      <property name="bottomMargin">
-       <number>6</number>
-      </property>
       <item>
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
@@ -174,121 +171,68 @@ standard deviation ×</string>
         </item>
        </layout>
       </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_2">
-        <property name="spacing">
-         <number>3</number>
+      
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_1">
+       <item>
+        <widget class="QPushButton" name="mLoadPushButton">
+         <property name="text">
+          <string>Load</string>
+         </property>
+        </widget>
+       </item>
+       <item>
+        <spacer name="horizontalSpacer_7">
+         <property name="orientation">
+          <enum>Qt::Horizontal</enum>
+         </property>
+         <property name="sizeHint" stdset="0">
+          <size>
+           <width>0</width>
+           <height>20</height>
+          </size>
+         </property>
+        </spacer>
+       </item>
+     <item>
+      <widget class="QLabel" name="mColorInterpolationLabel_2">
+       <property name="text">
+        <string>Accuracy</string>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QComboBox" name="cboAccuracy">
+       <item>
+        <property name="text">
+         <string>Estimate (faster)</string>
         </property>
-        <item>
-         <widget class="QGroupBox" name="mExtentGroupBox">
-          <layout class="QVBoxLayout" name="verticalLayout_2">
-           <property name="leftMargin">
-            <number>0</number>
-           </property>
-           <property name="topMargin">
-            <number>0</number>
-           </property>
-           <property name="rightMargin">
-            <number>0</number>
-           </property>
-           <property name="bottomMargin">
-            <number>0</number>
-           </property>
-           <item>
-            <widget class="QLabel" name="label_3">
-             <property name="text">
-              <string>Extent</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QRadioButton" name="mFullExtentRadioButton">
-             <property name="text">
-              <string>Full</string>
-             </property>
-             <property name="checked">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QRadioButton" name="mCurrentExtentRadioButton">
-             <property name="text">
-              <string>Current</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-        <item>
-         <widget class="QGroupBox" name="mAccuracyGroupBox">
-          <layout class="QVBoxLayout" name="verticalLayout">
-           <property name="leftMargin">
-            <number>0</number>
-           </property>
-           <property name="topMargin">
-            <number>0</number>
-           </property>
-           <property name="rightMargin">
-            <number>0</number>
-           </property>
-           <property name="bottomMargin">
-            <number>0</number>
-           </property>
-           <item>
-            <widget class="QLabel" name="label_5">
-             <property name="text">
-              <string>Accuracy</string>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QRadioButton" name="mEstimateRadioButton">
-             <property name="text">
-              <string>Estimate (faster)</string>
-             </property>
-             <property name="checked">
-              <bool>true</bool>
-             </property>
-            </widget>
-           </item>
-           <item>
-            <widget class="QRadioButton" name="mActualRadioButton">
-             <property name="text">
-              <string>Actual (slower)</string>
-             </property>
-            </widget>
-           </item>
-          </layout>
-         </widget>
-        </item>
-       </layout>
-      </item>
-      <item>
-       <layout class="QHBoxLayout" name="horizontalLayout_4">
-        <item>
-         <spacer name="horizontalSpacer_5">
-          <property name="orientation">
-           <enum>Qt::Horizontal</enum>
-          </property>
-          <property name="sizeHint" stdset="0">
-           <size>
-            <width>0</width>
-            <height>20</height>
-           </size>
-          </property>
-         </spacer>
-        </item>
-        <item>
-         <widget class="QPushButton" name="mLoadPushButton">
-          <property name="text">
-           <string>Load</string>
-          </property>
-         </widget>
-        </item>
-       </layout>
-      </item>
+       </item>
+       <item>
+        <property name="text">
+         <string>Actual (slower)</string>
+        </property>
+       </item>
+      </widget>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout_6">
+     <item>
+      <widget class="QCheckBox" name="cbxClipExtent">
+       <property name="text">
+        <string>Clip extent to canvas</string>
+       </property>
+       <property name="checked">
+        <bool>false</bool>
+       </property>
+      </widget>
+     </item>
+    </layout>
+   </item> 
+   
+   
      </layout>
     </widget>
    </item>

--- a/src/ui/qgsrendererrasterpropswidgetbase.ui
+++ b/src/ui/qgsrendererrasterpropswidgetbase.ui
@@ -360,19 +360,6 @@
          <item row="6" column="2" colspan="3">
           <layout class="QHBoxLayout" name="horizontalLayout_13">
            <item>
-            <spacer name="horizontalSpacer_3">
-             <property name="orientation">
-              <enum>Qt::Horizontal</enum>
-             </property>
-             <property name="sizeHint" stdset="0">
-              <size>
-               <width>40</width>
-               <height>20</height>
-              </size>
-             </property>
-            </spacer>
-           </item>
-           <item>
             <widget class="QToolButton" name="mResetColorRenderingBtn">
              <property name="toolTip">
               <string>Reset all color rendering options to default</string>
@@ -436,6 +423,19 @@
      </layout>
     </widget>
    </item>
+           <item row="7">
+            <spacer name="verticalSpacer">
+             <property name="orientation">
+              <enum>Qt::Vertical</enum>
+             </property>
+             <property name="sizeHint" stdset="0">
+              <size>
+               <width>0</width>
+               <height>0</height>
+              </size>
+             </property>
+            </spacer>
+           </item>
   </layout>
  </widget>
  <customwidgets>

--- a/src/ui/qgssinglebandpseudocolorrendererwidgetbase.ui
+++ b/src/ui/qgssinglebandpseudocolorrendererwidgetbase.ui
@@ -26,7 +26,7 @@
    <property name="bottomMargin">
     <number>3</number>
    </property>
-   <item row="3" column="1" colspan="4">
+   <item row="4" column="1" colspan="4">
     <layout class="QHBoxLayout" name="horizontalLayout_2">
      <item>
       <widget class="QgsColorRampComboBox" name="mColorRampComboBox"/>
@@ -47,7 +47,7 @@
      </item>
     </layout>
    </item>
-   <item row="3" column="0">
+   <item row="4" column="0">
     <widget class="QLabel" name="mColorInterpolationLabel_2">
      <property name="text">
       <string>Color</string>
@@ -70,7 +70,7 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="1" colspan="4">
+   <item row="3" column="1" colspan="4">
     <widget class="QComboBox" name="mColorInterpolationComboBox"/>
    </item>
    <item row="0" column="0">
@@ -96,14 +96,14 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="0">
+   <item row="3" column="0">
     <widget class="QLabel" name="mColorInterpolationLabel">
      <property name="text">
       <string>Interpolation</string>
      </property>
     </widget>
    </item>
-   <item row="8" column="0" colspan="5">
+   <item row="9" column="0" colspan="5">
     <layout class="QHBoxLayout" name="horizontalLayout_3">
      <item>
       <widget class="QPushButton" name="mClassifyButton">
@@ -182,7 +182,7 @@
      </item>
     </layout>
    </item>
-   <item row="5" column="0">
+   <item row="6" column="0">
     <widget class="QLabel" name="label_2">
      <property name="text">
       <string>Min / max 
@@ -190,7 +190,7 @@ origin:</string>
      </property>
     </widget>
    </item>
-   <item row="5" column="1" colspan="4">
+   <item row="6" column="1" colspan="4">
     <widget class="QLabel" name="mMinMaxOriginLabel">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Preferred">
@@ -203,7 +203,7 @@ origin:</string>
      </property>
     </widget>
    </item>
-   <item row="9" column="0" colspan="5">
+   <item row="10" column="0" colspan="5">
     <widget class="QCheckBox" name="mClipCheckBox">
      <property name="toolTip">
       <string>If checked, any pixels with a value out of range will not be rendered</string>
@@ -216,7 +216,7 @@ origin:</string>
    <item row="1" column="2">
     <widget class="QLineEdit" name="mMinLineEdit"/>
    </item>
-   <item row="7" column="0" colspan="5">
+   <item row="8" column="0" colspan="5">
     <layout class="QHBoxLayout" name="horizontalLayout_5">
      <item>
       <widget class="QLabel" name="mClassificationModeLabel">
@@ -269,10 +269,10 @@ origin:</string>
      </item>
     </layout>
    </item>
-   <item row="11" column="0" colspan="5">
+   <item row="2" column="0" colspan="5">
     <widget class="QWidget" name="mMinMaxContainerWidget" native="true"/>
    </item>
-   <item row="6" column="0" colspan="5">
+   <item row="7" column="0" colspan="5">
     <widget class="QTreeWidget" name="mColormapTreeWidget">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Expanding" vsizetype="Expanding">
@@ -312,14 +312,14 @@ origin:</string>
      </column>
     </widget>
    </item>
-   <item row="4" column="1" colspan="4">
+   <item row="5" column="1" colspan="4">
     <widget class="QLineEdit" name="mUnitLineEdit">
      <property name="toolTip">
       <string>Unit suffix</string>
      </property>
     </widget>
    </item>
-   <item row="4" column="0">
+   <item row="5" column="0">
     <widget class="QLabel" name="mUnitLabel">
      <property name="text">
       <string>Label unit


### PR DESCRIPTION
_(See PR #3249 for background discussion)_

This PR improves the raster min/max widget layout and attempts to improve the user experience by embedding it in a more logical location.

This PR proposes that we collapse the min/max widget by default, which allows us to then place the widget next to its associated band(s) in a more complex setting layout (such as the singleband pseudo color).

Collapsed:
![c](https://cloud.githubusercontent.com/assets/1728657/16439581/21771b6a-3de4-11e6-84e0-8f18322dbd06.png)

Expanded:
![o](https://cloud.githubusercontent.com/assets/1728657/16439582/2519cb64-3de4-11e6-9078-17de39adedc6.png)

In terms of layout changes, we gained lots of vertical space by moving away from radio boxes and instead using a checkbox for the extent (which was a binary choice anyways) and a combo box for accuracy (which could eventually host more than fast estimate and slow actual options).

@nyalldawson , @pcav , What do you think of this? 
