### PR TITLE
Make QgsVectorLayer::geometryType() invokable

### DIFF
--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -824,7 +824,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
     void setRendererV2( QgsFeatureRendererV2* r );
 
     /** Returns point, line or polygon */
-    QGis::GeometryType geometryType() const;
+    Q_INVOKABLE QGis::GeometryType geometryType() const;
 
     /** Returns true if this is a geometry layer and false in case of NoGeometry (table only) or UnknownGeometry */
     bool hasGeometryType() const;


### PR DESCRIPTION
This makes the `QgsVectorLayer::geometryType()` method `Q_INVOKABLE` by QML applications.
This mainly adds information to the meta object produced by the MOC and allows using this function directly from QML.

I plan to add more of these while developing QField, this will make it a lot easier to build QML applications based on the QGIS libraries.

So this pull request is mainly a test balloon to check if there's any objection to this plan in general.

Adding more `Q_PROPERTY`'s is on the same page.
