### PR TITLE
[Bugfix] Fix position and scale when on-the-fly CRS transformation is disabled (fixes #15183)

### DIFF
--- a/src/core/qgstestutils.h
+++ b/src/core/qgstestutils.h
@@ -32,5 +32,16 @@
     QVERIFY( qgsDoubleNear( value, expected, epsilon ) ); \
   }
 
+#define QGSCOMPARENEARPOINT(point1,point2,epsilon) { \
+    QGSCOMPARENEAR( point1.x(), point2.x(), epsilon ); \
+    QGSCOMPARENEAR( point1.y(), point2.y(), epsilon ); \
+  }
+
+#define QGSCOMPARENEARRECTANGLE(rectangle1,rectangle2,epsilon) { \
+    QGSCOMPARENEAR( rectangle1.xMinimum(), rectangle2.xMinimum(), epsilon ); \
+    QGSCOMPARENEAR( rectangle1.xMaximum(), rectangle2.xMaximum(), epsilon ); \
+    QGSCOMPARENEAR( rectangle1.yMinimum(), rectangle2.yMinimum(), epsilon ); \
+    QGSCOMPARENEAR( rectangle1.yMaximum(), rectangle2.yMaximum(), epsilon ); \
+  }
 
 #endif // QGSTESTUTILS_H

--- a/tests/src/gui/testprojectionissues.cpp
+++ b/tests/src/gui/testprojectionissues.cpp
@@ -23,6 +23,7 @@
 #include "qgsrasterlayer.h"
 #include <QObject>
 #include <QtTest/QtTest>
+#include "qgstestutils.h"
 
 class TestProjectionIssues : public QObject
 {
@@ -39,6 +40,7 @@ class TestProjectionIssues : public QObject
     void init();// will be called before each testfunction is executed.
     void cleanup();// will be called after every testfunction.
     void issue5895();// test for #5895
+    void issue15183();// test for #15183
 
   private:
     QgsRasterLayer* mRasterLayer;
@@ -107,6 +109,29 @@ void TestProjectionIssues::issue5895()
   QgsRectangle largeExtent( -610861, 5101721, 2523921, 6795055 );
   mMapCanvas->setExtent( largeExtent );
   mMapCanvas->zoomByFactor( 2.0 ); // Zoom out. This should exceed the transform limits.
+}
+
+void TestProjectionIssues::issue15183()
+{
+  QgsRectangle largeExtent( -610861, 5101721, 2523921, 6795055 );
+  mMapCanvas->setExtent( largeExtent );
+
+  // Set to CRS's
+  QgsCoordinateReferenceSystem sourceCRS;
+  sourceCRS = mMapCanvas->mapSettings().destinationCrs();
+  QgsCoordinateReferenceSystem targetCRS;
+  targetCRS.createFromId( 4326, QgsCoordinateReferenceSystem::EpsgCrsId );
+
+  QgsCoordinateTransform ct( sourceCRS, targetCRS );
+  QgsRectangle initialExtent = ct.transformBoundingBox( mMapCanvas->extent() );
+
+  mMapCanvas->setCrsTransformEnabled( false );
+  mMapCanvas->setDestinationCrs( targetCRS );
+
+  QgsRectangle currentExtent = mMapCanvas->extent();
+
+  // Compare center
+  QGSCOMPARENEARPOINT( initialExtent.center(), currentExtent.center(), 0.00001 );
 }
 
 QTEST_MAIN( TestProjectionIssues )


### PR DESCRIPTION
When the user disables the on-the-fly CRS transformation, the map is not centered to the new transformed position and the scale gets wrong.

This pull fixes the issue https://hub.qgis.org/issues/15183
