### PR TITLE
[Bugfix] Fix MeasureTool when DestinationCRS changes (fixes #15182)

### DIFF
--- a/src/app/qgsmeasuredialog.cpp
+++ b/src/app/qgsmeasuredialog.cpp
@@ -99,6 +99,7 @@ void QgsMeasureDialog::updateSettings()
   QgsDebugMsg( QString( "Area units: %1" ).arg( QgsUnitTypes::encodeUnit( mAreaUnits ) ) );
   QgsDebugMsg( QString( "Canvas units : %1" ).arg( QgsUnitTypes::encodeUnit( mCanvasUnits ) ) );
 
+  mTable->clear();
   mTotal = 0;
   updateUi();
 }

--- a/src/app/qgsmeasuretool.h
+++ b/src/app/qgsmeasuretool.h
@@ -98,6 +98,9 @@ class APP_EXPORT QgsMeasureTool : public QgsMapTool
     // project projection
     bool mWrongProjectProjection;
 
+    //! Destination CoordinateReferenceSystem used by the MapCanvas
+    QgsCoordinateReferenceSystem mDestinationCrs;
+
     //! Returns the snapped (map) coordinate
     //@param p (pixel) coordinate
     QgsPoint snapPoint( const QPoint& p );

--- a/tests/src/app/testqgsmeasuretool.cpp
+++ b/tests/src/app/testqgsmeasuretool.cpp
@@ -24,6 +24,7 @@
 #include "qgsproject.h"
 #include "qgsmapcanvas.h"
 #include "qgsunittypes.h"
+#include "qgstestutils.h"
 
 /** \ingroup UnitTests
  * This is a unit test for the measure tool
@@ -113,7 +114,7 @@ void TestQgsMeasureTool::testLengthCalculation()
   QString measureString = dlg->editTotal->text();
   double measured = measureString.remove( ',' ).split( ' ' ).at( 0 ).toDouble();
   double expected = 26932.156;
-  QVERIFY( qgsDoubleNear( measured, expected, 0.001 ) );
+  QGSCOMPARENEAR( measured, expected, 0.001 );
 
   // change project length unit, check calculation respects unit
   QgsProject::instance()->writeEntry( "Measurement", "/DistanceUnits", QgsUnitTypes::encodeUnit( QGis::Feet ) );
@@ -130,7 +131,25 @@ void TestQgsMeasureTool::testLengthCalculation()
   measureString = dlg2->editTotal->text();
   measured = measureString.remove( ',' ).split( ' ' ).at( 0 ).toDouble();
   expected = 88360.0918635;
-  QVERIFY( qgsDoubleNear( measured, expected, 0.001 ) );
+  QGSCOMPARENEAR( measured, expected, 0.001 );
+
+  // check new CoordinateReferenceSystem, points must be reprojected to paint them successfully (issue #15182)
+  QgsCoordinateReferenceSystem srs2( 4326, QgsCoordinateReferenceSystem::EpsgCrsId );
+
+  QgsCoordinateTransform ct( srs, srs2 );
+
+  QgsPoint p0 = ct.transform( tool2->points()[0] );
+  QgsPoint p1 = ct.transform( tool2->points()[1] );
+
+  mCanvas->setDestinationCrs( srs2 );
+
+  QgsPoint n0 = tool2->points()[0];
+  QgsPoint n1 = tool2->points()[1];
+
+  QGSCOMPARENEAR( p0.x(), n0.x(), 0.001 );
+  QGSCOMPARENEAR( p0.y(), n0.y(), 0.001 );
+  QGSCOMPARENEAR( p1.x(), n1.x(), 0.001 );
+  QGSCOMPARENEAR( p1.y(), n1.y(), 0.001 );
 }
 
 void TestQgsMeasureTool::testAreaCalculation()
@@ -166,7 +185,7 @@ void TestQgsMeasureTool::testAreaCalculation()
   QString measureString = dlg->editTotal->text();
   double measured = measureString.remove( ',' ).split( ' ' ).at( 0 ).toDouble();
   double expected = 1009089817.0;
-  QVERIFY( qgsDoubleNear( measured, expected, 1.0 ) );
+  QGSCOMPARENEAR( measured, expected, 1.0 );
 
   // change project area unit, check calculation respects unit
   QgsProject::instance()->writeEntry( "Measurement", "/AreaUnits", QgsUnitTypes::encodeUnit( QgsUnitTypes::SquareMiles ) );
@@ -185,7 +204,7 @@ void TestQgsMeasureTool::testAreaCalculation()
   measureString = dlg2->editTotal->text();
   measured = measureString.remove( ',' ).split( ' ' ).at( 0 ).toDouble();
   expected = 389.6117565069;
-  QVERIFY( qgsDoubleNear( measured, expected, 0.001 ) );
+  QGSCOMPARENEAR( measured, expected, 0.001 );
 }
 
 QTEST_MAIN( TestQgsMeasureTool )


### PR DESCRIPTION
MeasureTool fails when the user changes the destination crs of the MapCanvas while the user is digitizing a measure.

The MeasureDialog shows wrong measures and the digitised geometries disappear of the map.

This pull fixes the issue https://hub.qgis.org/issues/15182
