### PR TITLE
Fix qml icons in debian, eventually...

### DIFF
--- a/debian/mime/application/x-qgis-layer-settings.desktop
+++ b/debian/mime/application/x-qgis-layer-settings.desktop
@@ -6,3 +6,4 @@ Comment=QGIS layer settings
 Comment[de]=QGIS Layer Einstellungen
 Icon=qgis-qml-mime
 Patterns=*.qml;
+Name[en_US]=x-qgis-layer-settings.desktop

--- a/rpm/sources/qgis-mime.xml
+++ b/rpm/sources/qgis-mime.xml
@@ -19,6 +19,7 @@
     <comment xml:lang="de">QGIS-Layereinstellungen</comment>
     <sub-class-of type="application/xml"/>
     <magic priority="50">
+    <icon name="qgis-qml"/>
       <match type="string" offset="0" value="&lt;!DOCTYPE qgis">
         <match type="string" offset="0:256" value="&lt;qgis version"/>
       </match>


### PR DESCRIPTION
QML file type Icon is not working in Ubuntu. I'm not sure why. So this tries to make all files exactlylike the ones for QLR and QPT (which works).

@jef-n Can you please review it? Thanks
