### PR TITLE
[styledock] reduce height of vector layer rendering section

### DIFF
--- a/src/gui/symbology-ng/qgsrendererv2propertiesdialog.cpp
+++ b/src/gui/symbology-ng/qgsrendererv2propertiesdialog.cpp
@@ -118,7 +118,6 @@ QgsRendererV2PropertiesDialog::QgsRendererV2PropertiesDialog( QgsVectorLayer* la
 
   connect( cboRenderers, SIGNAL( currentIndexChanged( int ) ), this, SLOT( rendererChanged() ) );
   connect( checkboxEnableOrderBy, SIGNAL( toggled( bool ) ), btnOrderBy, SLOT( setEnabled( bool ) ) );
-  connect( checkboxEnableOrderBy, SIGNAL( toggled( bool ) ), lineEditOrderBy, SLOT( setEnabled( bool ) ) );
   connect( btnOrderBy, SIGNAL( clicked( bool ) ), this, SLOT( showOrderByDialog() ) );
 
   syncToLayer();
@@ -127,7 +126,6 @@ QgsRendererV2PropertiesDialog::QgsRendererV2PropertiesDialog( QgsVectorLayer* la
   widgets << mLayerTransparencySpnBx
   << cboRenderers
   << checkboxEnableOrderBy
-  << lineEditOrderBy
   << mBlendModeComboBox
   << mFeatureBlendComboBox
   << mEffectWidget;
@@ -348,8 +346,6 @@ void QgsRendererV2PropertiesDialog::syncToLayer()
     mOrderBy = mLayer->rendererV2()->orderBy();
   }
 
-  lineEditOrderBy->setText( mOrderBy.dump() );
-
   // setup slot rendererChanged()
   //setup order by
   if ( mLayer->rendererV2() &&
@@ -361,9 +357,7 @@ void QgsRendererV2PropertiesDialog::syncToLayer()
   {
     btnOrderBy->setEnabled( false );
     checkboxEnableOrderBy->setChecked( false );
-    lineEditOrderBy->setEnabled( false );
   }
-  lineEditOrderBy->setReadOnly( true );
 
   if ( mLayer->rendererV2() )
   {
@@ -387,14 +381,12 @@ void QgsRendererV2PropertiesDialog::showOrderByDialog()
   if ( dlg.exec() )
   {
     mOrderBy = dlg.orderBy();
-    lineEditOrderBy->setText( mOrderBy.dump() );
   }
 }
 
 void QgsRendererV2PropertiesDialog::changeOrderBy( const QgsFeatureRequest::OrderBy& orderBy, bool orderByEnabled )
 {
   mOrderBy = orderBy;
-  lineEditOrderBy->setText( mOrderBy.dump() );
   checkboxEnableOrderBy->setChecked( orderByEnabled );
 }
 

--- a/src/ui/qgsrendererv2propsdialogbase.ui
+++ b/src/ui/qgsrendererv2propsdialogbase.ui
@@ -163,7 +163,7 @@
              <widget class="QgsBlendModeComboBox" name="mBlendModeComboBox"/>
             </item>
             <item row="4" column="0" colspan="4">
-             <layout class="QVBoxLayout" name="verticalLayout_3">
+             <layout class="QHBoxLayout" name="horizontalLayout_3">
               <item>
                <widget class="QCheckBox" name="checkboxEnableOrderBy">
                 <property name="text">
@@ -172,25 +172,15 @@
                </widget>
               </item>
               <item>
-               <layout class="QHBoxLayout" name="horizontalLayout_3">
-                <property name="topMargin">
-                 <number>0</number>
+               <widget class="QToolButton" name="btnOrderBy">
+                <property name="icon">
+                 <iconset resource="../../images/images.qrc">
+                  <normaloff>:/images/themes/default/sort.svg</normaloff>:/images/themes/default/sort.svg</iconset>
                 </property>
-                <item>
-                 <widget class="QLineEdit" name="lineEditOrderBy">
-                  <property name="readOnly">
-                   <bool>true</bool>
-                  </property>
-                 </widget>
-                </item>
-                <item>
-                 <widget class="QToolButton" name="btnOrderBy">
-                  <property name="text">
-                   <string>...</string>
-                  </property>
-                 </widget>
-                </item>
-               </layout>
+                <property name="text">
+                 <string>...</string>
+                </property>
+               </widget>
               </item>
              </layout>
             </item>


### PR DESCRIPTION
As discussed and agreed upon in PR #3247 , this PR removes the read-only feature ordering text box to save vertical space in the vector's layer rendering section:
![untitled](https://cloud.githubusercontent.com/assets/1728657/16549441/a9f0cc32-41c9-11e6-8489-e4c3b6a3c33f.png)

It also synchronizes the UI to match effects.
