### PR TITLE
add quotes to field name is the rendering order settings dialog

### DIFF
--- a/src/gui/qgsorderbydialog.cpp
+++ b/src/gui/qgsorderbydialog.cpp
@@ -58,6 +58,7 @@ QgsFeatureRequest::OrderBy QgsOrderByDialog::orderBy()
   for ( int i = 0; i < mOrderByTableWidget->rowCount(); ++i )
   {
     QString expressionText = static_cast<QgsFieldExpressionWidget*>( mOrderByTableWidget->cellWidget( i, 0 ) )->currentText();
+    bool isExpression = static_cast<QgsFieldExpressionWidget*>( mOrderByTableWidget->cellWidget( i, 0 ) )->isExpression();
 
     if ( ! expressionText.isEmpty() )
     {
@@ -70,6 +71,9 @@ QgsFeatureRequest::OrderBy QgsOrderByDialog::orderBy()
       int nullsFirstIndex = static_cast<QComboBox*>( mOrderByTableWidget->cellWidget( i, 2 ) )->currentIndex();
       if ( nullsFirstIndex == 1 )
         nullsFirst = true;
+
+      if ( !isExpression )
+        expressionText = QgsExpression::quotedColumnRef( expressionText );
 
       QgsFeatureRequest::OrderByClause orderByClause( expressionText, asc, nullsFirst );
 


### PR DESCRIPTION
This PR fixes #15203 whereas feature rendering order would fail if the ordering was set to a field name that matches an expression engine function name (e.g. field name YEAR and expression function year()).

@m-kuhn , @nyalldawson , this is the third round for such fix during this dev cycle :smile:
