### PR TITLE
Rename File Toolbar into Project Toolbar

### DIFF
--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -310,10 +310,10 @@
   </widget>
   <widget class="QToolBar" name="mFileToolBar">
    <property name="windowTitle">
-    <string>File Toolbar</string>
+    <string>Project Toolbar</string>
    </property>
    <property name="toolTip">
-    <string>File Toolbar</string>
+    <string>Project Toolbar</string>
    </property>
    <attribute name="toolBarArea">
     <enum>TopToolBarArea</enum>


### PR DESCRIPTION
The "File" menu has been removed a while ago and replaced by "Project" menu afaics. The tools in the so called "File Toolbar" are actually on "Project Toolbar" so, for consistency...
I don't rename the object itself (mFileToolbar) to avoid breaking anything (might be for 3.0?).
