### PR TITLE
Add missing circular tools in Edit menu

### DIFF
--- a/src/ui/qgisapp.ui
+++ b/src/ui/qgisapp.ui
@@ -272,6 +272,8 @@
     <addaction name="mMenuPasteAs"/>
     <addaction name="separator"/>
     <addaction name="mActionAddFeature"/>
+    <addaction name="mActionCircularStringCurvePoint"/>
+    <addaction name="mActionCircularStringRadius"/>
     <addaction name="mActionMoveFeature"/>
     <addaction name="mActionDeleteSelected"/>
     <addaction name="mActionMultiEditAttributes"/>


### PR DESCRIPTION
Trying to fix http://hub.qgis.org/issues/15211
Wonder if I should connect signals somewhere but unable to find where. :'(

Could be backported once ok
