### PR TITLE
Add null handling to value map edit widget (fixes #15215)

### DIFF
--- a/src/gui/editorwidgets/qgsvaluemapconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapconfigdlg.cpp
@@ -39,6 +39,7 @@ QgsValueMapConfigDlg::QgsValueMapConfigDlg( QgsVectorLayer* vl, int fieldIdx, QW
 QgsEditorWidgetConfig QgsValueMapConfigDlg::config()
 {
   QgsEditorWidgetConfig cfg;
+  QSettings settings;
 
   //store data to map
   for ( int i = 0; i < tableWidget->rowCount() - 1; i++ )
@@ -50,7 +51,7 @@ QgsEditorWidgetConfig QgsValueMapConfigDlg::config()
       continue;
 
     QString ks = ki->text();
-    if (( ks == QString( "NULL" ) ) && !( ki->flags() & Qt::ItemIsEditable ) )
+    if (( ks == settings.value( "qgis/nullValue", "NULL" ).toString() ) && !( ki->flags() & Qt::ItemIsEditable ) )
       ks = "{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}";
 
     if ( !vi || vi->text().isNull() )
@@ -143,6 +144,7 @@ void QgsValueMapConfigDlg::updateMap( const QMap<QString, QVariant> &map, bool i
 
 void QgsValueMapConfigDlg::setRow( int row, const QString value, const QString description )
 {
+  QSettings settings;
   QTableWidgetItem* valueCell;
   QTableWidgetItem* descriptionCell = new QTableWidgetItem( description );
   tableWidget->insertRow( row );
@@ -150,7 +152,7 @@ void QgsValueMapConfigDlg::setRow( int row, const QString value, const QString d
   {
     QFont cellFont;
     cellFont.setItalic( true );
-    valueCell = new QTableWidgetItem( "NULL" );
+    valueCell = new QTableWidgetItem( settings.value( "qgis/nullValue", "NULL" ).toString() );
     valueCell->setFont( cellFont );
     valueCell->setFlags( Qt::ItemIsSelectable | Qt::ItemIsEnabled );
     descriptionCell->setFont( cellFont );

--- a/src/gui/editorwidgets/qgsvaluemapconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapconfigdlg.cpp
@@ -52,7 +52,7 @@ QgsEditorWidgetConfig QgsValueMapConfigDlg::config()
 
     QString ks = ki->text();
     if (( ks == settings.value( "qgis/nullValue", "NULL" ).toString() ) && !( ki->flags() & Qt::ItemIsEditable ) )
-      ks = "{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}";
+      ks = VALUEMAP_NULL_TEXT;
 
     if ( !vi || vi->text().isNull() )
     {
@@ -129,7 +129,7 @@ void QgsValueMapConfigDlg::updateMap( const QMap<QString, QVariant> &map, bool i
 
   if ( insertNull )
   {
-    setRow( row, "{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}", "<NULL>" );
+    setRow( row, VALUEMAP_NULL_TEXT, "<NULL>" );
     ++row;
   }
 
@@ -148,7 +148,7 @@ void QgsValueMapConfigDlg::setRow( int row, const QString value, const QString d
   QTableWidgetItem* valueCell;
   QTableWidgetItem* descriptionCell = new QTableWidgetItem( description );
   tableWidget->insertRow( row );
-  if ( value == QString( "{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}" ) )
+  if ( value == QString( VALUEMAP_NULL_TEXT ) )
   {
     QFont cellFont;
     cellFont.setItalic( true );
@@ -167,7 +167,7 @@ void QgsValueMapConfigDlg::setRow( int row, const QString value, const QString d
 
 void QgsValueMapConfigDlg::addNullButtonPushed()
 {
-  setRow( tableWidget->rowCount() - 1, "{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}", "<NULL>" );
+  setRow( tableWidget->rowCount() - 1, VALUEMAP_NULL_TEXT, "<NULL>" );
 }
 
 void QgsValueMapConfigDlg::loadFromLayerButtonPushed()
@@ -240,7 +240,7 @@ void QgsValueMapConfigDlg::loadFromCSVButtonPushed()
     }
 
     if ( key == settings.value( "qgis/nullValue", "NULL" ).toString() )
-      key = QString( "{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}" );
+      key = QString( VALUEMAP_NULL_TEXT );
 
     map[ key ] = val;
   }

--- a/src/gui/editorwidgets/qgsvaluemapconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapconfigdlg.cpp
@@ -17,6 +17,7 @@
 
 #include "qgsattributetypeloaddialog.h"
 
+#include <QSettings>
 #include <QFileDialog>
 #include <QMessageBox>
 #include <QTextStream>
@@ -77,7 +78,7 @@ void QgsValueMapConfigDlg::setConfig( const QgsEditorWidgetConfig& config )
   for ( QgsEditorWidgetConfig::ConstIterator mit = config.begin(); mit != config.end(); mit++, row++ )
   {
     if ( mit.value().isNull() )
-      setRow( row, mit.key(), QString( "" ) );
+      setRow( row, mit.key(), QString() );
     else
       setRow( row, mit.value().toString(), mit.key() );
   }
@@ -134,7 +135,7 @@ void QgsValueMapConfigDlg::updateMap( const QMap<QString, QVariant> &map, bool i
   for ( QMap<QString, QVariant>::const_iterator mit = map.begin(); mit != map.end(); ++mit, ++row )
   {
     if ( mit.value().isNull() )
-      setRow( row, mit.key(), QString( "" ) );
+      setRow( row, mit.key(), QString() );
     else
       setRow( row, mit.key(), mit.value().toString() );
   }
@@ -178,6 +179,8 @@ void QgsValueMapConfigDlg::loadFromLayerButtonPushed()
 
 void QgsValueMapConfigDlg::loadFromCSVButtonPushed()
 {
+  QSettings settings;
+
   QString fileName = QFileDialog::getOpenFileName( nullptr, tr( "Select a file" ), QDir::homePath() );
   if ( fileName.isNull() )
     return;
@@ -233,6 +236,9 @@ void QgsValueMapConfigDlg::loadFromCSVButtonPushed()
     {
       val = val.mid( 1, val.length() - 2 );
     }
+
+    if ( key == settings.value( "qgis/nullValue", "NULL" ).toString() )
+      key = QString( "{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}" );
 
     map[ key ] = val;
   }

--- a/src/gui/editorwidgets/qgsvaluemapconfigdlg.h
+++ b/src/gui/editorwidgets/qgsvaluemapconfigdlg.h
@@ -20,6 +20,8 @@
 
 #include "qgseditorconfigwidget.h"
 
+#define VALUEMAP_NULL_TEXT "{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}"
+
 /** \ingroup gui
  * \class QgsValueMapConfigDlg
  * \note not available in Python bindings

--- a/src/gui/editorwidgets/qgsvaluemapconfigdlg.h
+++ b/src/gui/editorwidgets/qgsvaluemapconfigdlg.h
@@ -36,8 +36,12 @@ class GUI_EXPORT QgsValueMapConfigDlg : public QgsEditorConfigWidget, private Ui
 
     void updateMap( const QMap<QString, QVariant> &map, bool insertNull );
 
+  private:
+    void setRow( int row, const QString value, const QString description );
+
   private slots:
     void vCellChanged( int row, int column );
+    void addNullButtonPushed();
     void removeSelectedButtonPushed();
     void loadFromLayerButtonPushed();
     void loadFromCSVButtonPushed();

--- a/src/gui/editorwidgets/qgsvaluemapwidgetfactory.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapwidgetfactory.cpp
@@ -86,13 +86,20 @@ QString QgsValueMapWidgetFactory::representValue( QgsVectorLayer* vl, int fieldI
 {
   Q_UNUSED( cache )
 
-  QString v;
+  QString valueInternalText;
+  QString valueDisplayText;
   if ( value.isNull() )
-    v = QSettings().value( "qgis/nullValue", "NULL" ).toString();
+  {
+    valueInternalText = QString( "{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}" );
+    valueDisplayText = QString( "NULL" );
+  }
   else
-    v = value.toString();
+  {
+    valueInternalText = value.toString();
+    valueDisplayText = value.toString();
+  }
 
-  return config.key( v, QVariant( QString( "(%1)" ).arg( vl->fields().at( fieldIdx ).displayString( value ) ) ).toString() );
+  return config.key( valueInternalText, QVariant( QString( "(%1)" ).arg( vl->fields().at( fieldIdx ).displayString( valueDisplayText ) ) ).toString() );
 }
 
 Qt::AlignmentFlag QgsValueMapWidgetFactory::alignmentFlag( QgsVectorLayer* vl, int fieldIdx, const QgsEditorWidgetConfig& config ) const

--- a/src/gui/editorwidgets/qgsvaluemapwidgetfactory.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapwidgetfactory.cpp
@@ -90,17 +90,11 @@ QString QgsValueMapWidgetFactory::representValue( QgsVectorLayer* vl, int fieldI
   QString valueDisplayText;
   QSettings settings;
   if ( value.isNull() )
-  {
     valueInternalText = QString( VALUEMAP_NULL_TEXT );
-    valueDisplayText = settings.value( "qgis/nullValue", "NULL" ).toString();
-  }
   else
-  {
     valueInternalText = value.toString();
-    valueDisplayText = value.toString();
-  }
 
-  return config.key( valueInternalText, QVariant( QString( "(%1)" ).arg( vl->fields().at( fieldIdx ).displayString( valueDisplayText ) ) ).toString() );
+  return config.key( valueInternalText, QVariant( QString( "(%1)" ).arg( vl->fields().at( fieldIdx ).displayString( value ) ) ).toString() );
 }
 
 Qt::AlignmentFlag QgsValueMapWidgetFactory::alignmentFlag( QgsVectorLayer* vl, int fieldIdx, const QgsEditorWidgetConfig& config ) const

--- a/src/gui/editorwidgets/qgsvaluemapwidgetfactory.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapwidgetfactory.cpp
@@ -91,7 +91,7 @@ QString QgsValueMapWidgetFactory::representValue( QgsVectorLayer* vl, int fieldI
   if ( value.isNull() )
   {
     valueInternalText = QString( "{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}" );
-    valueDisplayText = QString( "NULL" );
+    valueDisplayText = settings.value( "qgis/nullValue", "NULL" ).toString();
   }
   else
   {

--- a/src/gui/editorwidgets/qgsvaluemapwidgetfactory.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapwidgetfactory.cpp
@@ -88,9 +88,10 @@ QString QgsValueMapWidgetFactory::representValue( QgsVectorLayer* vl, int fieldI
 
   QString valueInternalText;
   QString valueDisplayText;
+  QSettings settings;
   if ( value.isNull() )
   {
-    valueInternalText = QString( "{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}" );
+    valueInternalText = QString( VALUEMAP_NULL_TEXT );
     valueDisplayText = settings.value( "qgis/nullValue", "NULL" ).toString();
   }
   else

--- a/src/gui/editorwidgets/qgsvaluemapwidgetfactory.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapwidgetfactory.cpp
@@ -20,6 +20,8 @@
 #include "qgsdefaultsearchwidgetwrapper.h"
 #include "qgsvaluemapconfigdlg.h"
 
+#include <QSettings>
+
 QgsValueMapWidgetFactory::QgsValueMapWidgetFactory( const QString& name )
     : QgsEditorWidgetFactory( name )
 {
@@ -82,11 +84,15 @@ void QgsValueMapWidgetFactory::writeConfig( const QgsEditorWidgetConfig& config,
 
 QString QgsValueMapWidgetFactory::representValue( QgsVectorLayer* vl, int fieldIdx, const QgsEditorWidgetConfig& config, const QVariant& cache, const QVariant& value ) const
 {
-  Q_UNUSED( vl )
-  Q_UNUSED( fieldIdx )
   Q_UNUSED( cache )
 
-  return config.key( value, QVariant( QString( "(%1)" ).arg( value.toString() ) ).toString() );
+  QString v;
+  if ( value.isNull() )
+    v = QSettings().value( "qgis/nullValue", "NULL" ).toString();
+  else
+    v = value.toString();
+
+  return config.key( v, QVariant( QString( "(%1)" ).arg( vl->fields().at( fieldIdx ).displayString( value ) ) ).toString() );
 }
 
 Qt::AlignmentFlag QgsValueMapWidgetFactory::alignmentFlag( QgsVectorLayer* vl, int fieldIdx, const QgsEditorWidgetConfig& config ) const

--- a/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.cpp
@@ -15,6 +15,8 @@
 
 #include "qgsvaluemapwidgetwrapper.h"
 
+#include <QSettings>
+
 QgsValueMapWidgetWrapper::QgsValueMapWidgetWrapper( QgsVectorLayer* vl, int fieldIdx, QWidget* editor, QWidget* parent )
     : QgsEditorWidgetWrapper( vl, fieldIdx, editor, parent )
     , mComboBox( nullptr )
@@ -24,10 +26,13 @@ QgsValueMapWidgetWrapper::QgsValueMapWidgetWrapper( QgsVectorLayer* vl, int fiel
 
 QVariant QgsValueMapWidgetWrapper::value() const
 {
-  QVariant v;
+  QString v;
 
   if ( mComboBox )
-    v = mComboBox->itemData( mComboBox->currentIndex() );
+    v = mComboBox->itemData( mComboBox->currentIndex() ).toString();
+
+  if ( v == QSettings().value( "qgis/nullValue", "NULL" ).toString() )
+    return QVariant( field().type() );
 
   return v;
 }
@@ -70,6 +75,12 @@ bool QgsValueMapWidgetWrapper::valid() const
 
 void QgsValueMapWidgetWrapper::setValue( const QVariant& value )
 {
+  QString v;
+  if ( value.isNull() )
+    v = QSettings().value( "qgis/nullValue", "NULL" ).toString();
+  else
+    v = value.toString();
+
   if ( mComboBox )
-    mComboBox->setCurrentIndex( mComboBox->findData( value ) );
+    mComboBox->setCurrentIndex( mComboBox->findData( v ) );
 }

--- a/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.cpp
@@ -31,7 +31,7 @@ QVariant QgsValueMapWidgetWrapper::value() const
   if ( mComboBox )
     v = mComboBox->itemData( mComboBox->currentIndex() );
 
-  if ( v == QSettings().value( "qgis/nullValue", "NULL" ).toString() )
+  if ( v == QString( "{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}" ) )
     v = QVariant( field().type() );
 
   return v;
@@ -77,7 +77,7 @@ void QgsValueMapWidgetWrapper::setValue( const QVariant& value )
 {
   QString v;
   if ( value.isNull() )
-    v = QSettings().value( "qgis/nullValue", "NULL" ).toString();
+    v = QString( "{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}" );
   else
     v = value.toString();
 

--- a/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.cpp
@@ -26,13 +26,13 @@ QgsValueMapWidgetWrapper::QgsValueMapWidgetWrapper( QgsVectorLayer* vl, int fiel
 
 QVariant QgsValueMapWidgetWrapper::value() const
 {
-  QString v;
+  QVariant v;
 
   if ( mComboBox )
-    v = mComboBox->itemData( mComboBox->currentIndex() ).toString();
+    v = mComboBox->itemData( mComboBox->currentIndex() );
 
   if ( v == QSettings().value( "qgis/nullValue", "NULL" ).toString() )
-    return QVariant( field().type() );
+    v = QVariant( field().type() );
 
   return v;
 }

--- a/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapwidgetwrapper.cpp
@@ -14,6 +14,7 @@
  ***************************************************************************/
 
 #include "qgsvaluemapwidgetwrapper.h"
+#include "qgsvaluemapconfigdlg.h"
 
 #include <QSettings>
 
@@ -31,7 +32,7 @@ QVariant QgsValueMapWidgetWrapper::value() const
   if ( mComboBox )
     v = mComboBox->itemData( mComboBox->currentIndex() );
 
-  if ( v == QString( "{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}" ) )
+  if ( v == QString( VALUEMAP_NULL_TEXT ) )
     v = QVariant( field().type() );
 
   return v;
@@ -77,7 +78,7 @@ void QgsValueMapWidgetWrapper::setValue( const QVariant& value )
 {
   QString v;
   if ( value.isNull() )
-    v = QString( "{2839923C-8B7D-419E-B84B-CA2FE9B80EC7}" );
+    v = QString( VALUEMAP_NULL_TEXT );
   else
     v = value.toString();
 

--- a/src/ui/editorwidgets/qgsvaluemapconfigdlgbase.ui
+++ b/src/ui/editorwidgets/qgsvaluemapconfigdlgbase.ui
@@ -14,7 +14,7 @@
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="0" column="0" colspan="3">
+   <item row="0" column="0" colspan="5">
     <widget class="QLabel" name="valueMapLabel">
      <property name="text">
       <string>Combo box with predefined items. Value is stored in the attribute, description is shown in the combo box.</string>
@@ -31,14 +31,7 @@
      </property>
     </widget>
    </item>
-   <item row="1" column="1">
-    <widget class="QPushButton" name="loadFromCSVButton">
-     <property name="text">
-      <string>Load Data from CSV File</string>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="2">
+   <item row="1" column="4">
     <spacer name="horizontalSpacer">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -51,7 +44,7 @@
      </property>
     </spacer>
    </item>
-   <item row="2" column="0" colspan="3">
+   <item row="2" column="0" colspan="5">
     <widget class="QTableWidget" name="tableWidget">
      <column>
       <property name="text">
@@ -65,14 +58,7 @@
      </column>
     </widget>
    </item>
-   <item row="3" column="0">
-    <widget class="QPushButton" name="removeSelectedButton">
-     <property name="text">
-      <string>Remove Selected</string>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="1" colspan="2">
+   <item row="3" column="3" colspan="2">
     <spacer name="horizontalSpacer_2">
      <property name="orientation">
       <enum>Qt::Horizontal</enum>
@@ -84,6 +70,27 @@
       </size>
      </property>
     </spacer>
+   </item>
+   <item row="3" column="0">
+    <widget class="QPushButton" name="addNullButton">
+     <property name="text">
+      <string>Add &quot;NULL&quot; value</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="1">
+    <widget class="QPushButton" name="removeSelectedButton">
+     <property name="text">
+      <string>Remove Selected</string>
+     </property>
+    </widget>
+   </item>
+   <item row="1" column="1">
+    <widget class="QPushButton" name="loadFromCSVButton">
+     <property name="text">
+      <string>Load Data from CSV File</string>
+     </property>
+    </widget>
    </item>
   </layout>
  </widget>


### PR DESCRIPTION
See title. :)

This makes it possible to use the NULL placeholder value in the value map widget, just like in the other editing widgets, so that NULL values can be displayed with an appropriate description, and so that values can be reset to NULL.

I hope this can also be applied to the LTR release 2.14.
