### PR TITLE
fix build under NDK

### DIFF
--- a/src/gui/qgsmaptooltouch.h
+++ b/src/gui/qgsmaptooltouch.h
@@ -48,7 +48,7 @@ class GUI_EXPORT QgsMapToolTouch : public QgsMapTool
     //! Overridden Mouse double click event.
     virtual void canvasDoubleClickEvent( QgsMapMouseEvent* e ) override;
 
-    virtual bool isTransient() override { return true; }
+    Q_DECL_DEPRECATED virtual bool isTransient() const override { return true; }
 
     bool gestureEvent( QGestureEvent *event ) override;
 


### PR DESCRIPTION
this fixes:
QgsMapToolTouch::isTransient()' marked override, but does not override virtual bool isTransient() override { return true; }

@m-kuhn I discovered this when building with NDK r10e which is the one we suggest for OSGEO4A
