### PR TITLE
[Bugfix] Fix MeasureTool when DestinationCRS changes (2)

### DIFF
--- a/src/app/qgsmeasuretool.cpp
+++ b/src/app/qgsmeasuretool.cpp
@@ -168,6 +168,11 @@ void QgsMeasureTool::updateSettings()
     mRubberBand->addPoint( mPoints.last() );
     mDialog->addPoint( mPoints.last() );
   }
+  if ( mRubberBand->size() > 0 )
+  {
+    mRubberBand->setVisible( true );
+    mRubberBandPoints->setVisible( true );
+  }
 }
 
 //////////////////////////


### PR DESCRIPTION
This pull is a followup of the another merged pull https://github.com/qgis/QGIS/pull/3262

It fixes the issue detected by @nyalldawson in https://github.com/qgis/QGIS/pull/3262#issuecomment-230642198
