### PR TITLE
Fix installation path of scalable icons.

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -332,9 +332,9 @@ override_dh_auto_install:
 		install -o root -g root -m 644 $(CURDIR)/debian/qbrowser-icon$${size}.png $(CURDIR)/debian/tmp/usr/share/icons/hicolor/$${size}/apps/qbrowser.png ; \
 	done
 	
-	install -o root -g root -d $(CURDIR)/debian/tmp/usr/share/icons/scalable/apps
-	install -o root -g root -m 644 $(CURDIR)/images/icons/qgis_icon.svg $(CURDIR)/debian/tmp/usr/share/icons/scalable/apps/qgis.svg
-	install -o root -g root -m 644 $(CURDIR)/images/icons/qbrowser_icon.svg $(CURDIR)/debian/tmp/usr/share/icons/scalable/apps/qbrowser.svg
+	install -o root -g root -d $(CURDIR)/debian/tmp/usr/share/icons/hicolor/scalable/apps
+	install -o root -g root -m 644 $(CURDIR)/images/icons/qgis_icon.svg $(CURDIR)/debian/tmp/usr/share/icons/hicolor/scalable/apps/qgis.svg
+	install -o root -g root -m 644 $(CURDIR)/images/icons/qbrowser_icon.svg $(CURDIR)/debian/tmp/usr/share/icons/hicolor/scalable/apps/qbrowser.svg
 
 	# Install desktop files
 	install -o root -g root -d $(CURDIR)/debian/tmp/usr/share/applications


### PR DESCRIPTION
As reported by Jeremy Bicha in [Debian Bug #830638](https://bugs.debian.org/830638):

> I noticed that qgis installs 2 icons in the wrong directory:
> /usr/share/icons/scalable/apps/qbrowser.svg
> /usr/share/icons/scalable/apps/qgis.svg
> 
> It should be:
> /usr/share/icons/hicolor/scalable/apps/qbrowser.svg
> /usr/share/icons/hicolor/scalable/apps/qgis.svg
> 
> I'm attaching a patch to fix this.
> 
> Thanks,
> Jeremy Bicha
