### PR TITLE
Add handling of null value in value map to search widget

### DIFF
--- a/src/gui/editorwidgets/qgsvaluemapsearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapsearchwidgetwrapper.cpp
@@ -96,12 +96,6 @@ QString QgsValueMapSearchWidgetWrapper::createExpression( QgsSearchWidgetWrapper
 
   QString currentKey = mComboBox->itemData( mComboBox->currentIndex() ).toString();
 
-  if ( currentKey == QString( VALUEMAP_NULL_TEXT ) )
-    if ( flags & EqualTo )
-      return fieldName + " IS NULL";
-  if ( flags & NotEqualTo )
-    return fieldName + " IS NOT NULL";
-
   switch ( fldType )
   {
     case QVariant::Int:
@@ -152,7 +146,8 @@ void QgsValueMapSearchWidgetWrapper::initWidget( QWidget* editor )
 
     while ( it != cfg.constEnd() )
     {
-      mComboBox->addItem( it.key(), it.value() );
+      if ( it.value() != QString( VALUEMAP_NULL_TEXT ) )
+        mComboBox->addItem( it.key(), it.value() );
       ++it;
     }
     connect( mComboBox, SIGNAL( currentIndexChanged( int ) ), this, SLOT( comboBoxIndexChanged( int ) ) );

--- a/src/gui/editorwidgets/qgsvaluemapsearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsvaluemapsearchwidgetwrapper.cpp
@@ -15,6 +15,7 @@
 
 #include "qgsvaluemapsearchwidgetwrapper.h"
 #include "qgstexteditconfigdlg.h"
+#include "qgsvaluemapconfigdlg.h"
 
 #include "qgsfield.h"
 #include "qgsfieldvalidator.h"
@@ -94,6 +95,12 @@ QString QgsValueMapSearchWidgetWrapper::createExpression( QgsSearchWidgetWrapper
     return fieldName + " IS NOT NULL";
 
   QString currentKey = mComboBox->itemData( mComboBox->currentIndex() ).toString();
+
+  if ( currentKey == QString( VALUEMAP_NULL_TEXT ) )
+    if ( flags & EqualTo )
+      return fieldName + " IS NULL";
+  if ( flags & NotEqualTo )
+    return fieldName + " IS NOT NULL";
 
   switch ( fldType )
   {


### PR DESCRIPTION
I mainly developed my previous PR #3274 against version 2.14 so I forgot to take care of the new (in 2.16) widget for the attribute table search function.

I'm not entirely sure about the solution in this PR, because this new search function also has its own handling of null values. Should a null value in the value map perhaps be hidden in the search widget? Should the value map search widget perhaps not support the IsNull and IsNotNull flags? Or maybe it is ok to have both ways leading to the same result?
