### PR TITLE
Const correctness for numerous data provider methods

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -16,6 +16,24 @@ with too big impact should be deferred to a major version release.
 
 This page tries to maintain a list with incompatible changes that happened in previous releases.
 
+\section qgis_api_break_3_0 QGIS 3.0
+
+
+\subsection qgis_api_break_3_0_DataProviders Data Providers
+
+<ul>
+<li>Many methods in QgsDataProvider, QgsVectorDataProvider and QgsRasterDataProvider have been made const-correct.
+This has no effect on PyQGIS code, but c++ code implementing third-party providers will need to update the
+signatures of these methods to match. Affected methods are:
+<ul>
+<li>QgsDataProvider: crs(), extent(), isValid(), supportsSubsetString(), subsetString()</li>
+<li>QgsVectorDataProvider: getFeatures(), minimumValue(), maximumValue(), uniqueValues(), enumValues(), defaultValue(),
+attributeIndexes(), pkAttributeIndexes(), isSaveAndLoadStyleToDBSupported()</li>
+<li>QgsRasterInterface: extent()</li>
+</ul
+</li>
+</ul>
+
 \section qgis_api_break_2_4 QGIS 2.4
 
 \subsection qgis_api_break_mtr Multi-threaded Rendering

--- a/python/core/qgsdataprovider.sip
+++ b/python/core/qgsdataprovider.sip
@@ -54,12 +54,11 @@ class QgsDataProvider : QObject
     virtual ~QgsDataProvider();
 
 
-    /** Get the QgsCoordinateReferenceSystem for this layer
-     * @note Must be reimplemented by each provider.
-     * If the provider isn't capable of returning
-     * its projection an empty srs will be return, ti will return 0
+    /* Returns the coordinate system for the data source.
+     * If the provider isn't capable of returning its projection then an invalid
+     * QgsCoordinateReferenceSystem will be returned.
      */
-    virtual QgsCoordinateReferenceSystem crs() = 0;
+    virtual QgsCoordinateReferenceSystem crs() const = 0;
 
 
     /**
@@ -82,21 +81,21 @@ class QgsDataProvider : QObject
 
 
     /**
-     * Get the extent of the layer
+     * Returns the extent of the layer.
      * @return QgsRectangle containing the extent of the layer
      */
-    virtual QgsRectangle extent() = 0;
+    virtual QgsRectangle extent() const = 0;
 
 
     /**
      * Returns true if this is a valid layer. It is up to individual providers
-     * to determine what constitutes a valid layer
+     * to determine what constitutes a valid layer.
      */
-    virtual bool isValid() = 0;
+    virtual bool isValid() const = 0;
 
 
     /**
-     * Update the extents of the layer. Not implemented by default
+     * Update the extents of the layer. Not implemented by default.
      */
     virtual void updateExtents();
 
@@ -109,8 +108,8 @@ class QgsDataProvider : QObject
      */
     virtual bool setSubsetString( const QString& subset, bool updateFeatureCount = true );
 
-    /** Provider supports setting of subset strings */
-    virtual bool supportsSubsetString();
+    /** Returns true if the provider supports setting of subset strings. */
+    virtual bool supportsSubsetString() const;
 
     /**
      * Returns the subset definition string (typically sql) currently in
@@ -118,7 +117,7 @@ class QgsDataProvider : QObject
      * Must be overridden in the dataprovider, otherwise returns a null
      * QString.
      */
-    virtual QString subsetString();
+    virtual QString subsetString() const;
 
 
     /**

--- a/python/core/qgsvectordataprovider.sip
+++ b/python/core/qgsvectordataprovider.sip
@@ -98,8 +98,10 @@ class QgsVectorDataProvider : QgsDataProvider
 
     /**
      * Query the provider for features specified in request.
+     * @param request feature request describing parameters of features to return
+     * @returns iterator for matching features from provider
      */
-    virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest& request = QgsFeatureRequest() ) = 0;
+    virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest& request = QgsFeatureRequest() ) const = 0;
 
     /**
      * Get feature type.
@@ -134,7 +136,7 @@ class QgsVectorDataProvider : QgsDataProvider
      * and maximal values. If provider has facilities to retrieve minimal
      * value directly, override this function.
      */
-    virtual QVariant minimumValue( int index );
+    virtual QVariant minimumValue( int index ) const;
 
     /**
      * Returns the maximum value of an attribute
@@ -144,7 +146,7 @@ class QgsVectorDataProvider : QgsDataProvider
      * and maximal values. If provider has facilities to retrieve maximal
      * value directly, override this function.
      */
-    virtual QVariant maximumValue( int index );
+    virtual QVariant maximumValue( int index ) const;
 
     /**
      * Return unique values of an attribute
@@ -154,7 +156,7 @@ class QgsVectorDataProvider : QgsDataProvider
      *
      * Default implementation simply iterates the features
      */
-    virtual void uniqueValues( int index, QList<QVariant> &uniqueValues /Out/, int limit = -1 );
+    virtual void uniqueValues( int index, QList<QVariant> &uniqueValues /Out/, int limit = -1 ) const;
 
     /** Calculates an aggregated value from the layer's features. The base implementation does nothing,
      * but subclasses can override this method to handoff calculation of aggregates to the provider.
@@ -170,7 +172,7 @@ class QgsVectorDataProvider : QgsDataProvider
                                 int index,
                                 const QgsAggregateCalculator::AggregateParameters& parameters,
                                 QgsExpressionContext* context,
-                                bool& ok );
+                                bool& ok ) const;
 
     /**
      * Returns the possible enum values of an attribute. Returns an empty stringlist if a provider does not support enum types
@@ -178,7 +180,7 @@ class QgsVectorDataProvider : QgsDataProvider
      * @param index the index of the attribute
      * @param enumList reference to the list to fill
      */
-    virtual void enumValues( int index, QStringList& enumList /Out/ );
+    virtual void enumValues( int index, QStringList& enumList /Out/ ) const;
 
     /**
      * Adds a list of features
@@ -236,7 +238,7 @@ class QgsVectorDataProvider : QgsDataProvider
     /**
      * Returns the default value for field specified by @c fieldId
      */
-    virtual QVariant defaultValue( int fieldId );
+    virtual QVariant defaultValue( int fieldId ) const;
 
     /**
      * Changes geometries of existing features
@@ -291,12 +293,12 @@ class QgsVectorDataProvider : QgsDataProvider
     /**
      * Return list of indexes to fetch all attributes in nextFeature()
      */
-    virtual QList<int> attributeIndexes();
+    virtual QList<int> attributeIndexes() const;
 
     /**
      * Return list of indexes of fields that make up the primary key
      */
-    virtual QList<int> pkAttributeIndexes();
+    virtual QList<int> pkAttributeIndexes() const;
 
     /**
      * Return list of indexes to names for QgsPalLabeling fix
@@ -333,12 +335,12 @@ class QgsVectorDataProvider : QgsDataProvider
     virtual bool doesStrictFeatureTypeCheck() const;
 
     /** Returns a list of available encodings */
-    static const QStringList &availableEncodings();
+    static QStringList availableEncodings();
 
     /**
      * Provider has errors to report
      */
-    bool hasErrors();
+    bool hasErrors() const;
 
     /**
      * Clear recorded errors
@@ -348,14 +350,14 @@ class QgsVectorDataProvider : QgsDataProvider
     /**
      * Get recorded errors
      */
-    QStringList errors();
+    QStringList errors() const;
 
 
     /**
      * It returns false by default.
      * Must be implemented by providers that support saving and loading styles to db returning true
      */
-    virtual bool isSaveAndLoadStyleToDBSupported();
+    virtual bool isSaveAndLoadStyleToDBSupported() const;
 
     static QVariant convertValue( QVariant::Type type, const QString& value );
 
@@ -384,7 +386,9 @@ class QgsVectorDataProvider : QgsDataProvider
 
   protected:
     void clearMinMaxCache();
-    void fillMinMaxCache();
+
+    //! Populates the cache of minimum and maximum attribute values.
+    void fillMinMaxCache() const;
 
     void pushError( const QString& msg );
 

--- a/python/core/raster/qgsrasterdataprovider.sip
+++ b/python/core/raster/qgsrasterdataprovider.sip
@@ -64,7 +64,7 @@ class QgsRasterDataProvider : QgsDataProvider, QgsRasterInterface
     /** Get the extent of the data source.
      * @return QgsRectangle containing the extent of the layer
      */
-    virtual QgsRectangle extent() = 0;
+    virtual QgsRectangle extent() const = 0;
 
     /** Returns data type for the band specified by number */
     virtual QGis::DataType dataType( int bandNo ) const = 0;
@@ -295,7 +295,7 @@ class QgsRasterDataProvider : QgsDataProvider, QgsRasterInterface
     /** Emit a message to be displayed on status bar, usually used by network providers (WMS,WCS)
      * @note added in 2.14
      */
-    void statusChanged( const QString& );
+    void statusChanged( const QString& ) const;
 
   protected:
     /** Read block of data

--- a/python/core/raster/qgsrasterinterface.sip
+++ b/python/core/raster/qgsrasterinterface.sip
@@ -104,7 +104,7 @@ class QgsRasterInterface
      * Get the extent of the interface.
      * @return QgsRectangle containing the extent of the layer
      */
-    virtual QgsRectangle extent();
+    virtual QgsRectangle extent() const;
 
     int dataTypeSize( int bandNo );
 

--- a/src/core/qgsdataprovider.h
+++ b/src/core/qgsdataprovider.h
@@ -84,12 +84,11 @@ class CORE_EXPORT QgsDataProvider : public QObject
     virtual ~QgsDataProvider() {}
 
 
-    /** Get the QgsCoordinateReferenceSystem for this layer
-     * @note Must be reimplemented by each provider.
-     * If the provider isn't capable of returning
-     * its projection an empty srs will be return, ti will return 0
+    /** Returns the coordinate system for the data source.
+     * If the provider isn't capable of returning its projection then an invalid
+     * QgsCoordinateReferenceSystem will be returned.
      */
-    virtual QgsCoordinateReferenceSystem crs() = 0;
+    virtual QgsCoordinateReferenceSystem crs() const = 0;
 
 
     /**
@@ -126,21 +125,21 @@ class CORE_EXPORT QgsDataProvider : public QObject
 
 
     /**
-     * Get the extent of the layer
+     * Returns the extent of the layer
      * @return QgsRectangle containing the extent of the layer
      */
-    virtual QgsRectangle extent() = 0;
+    virtual QgsRectangle extent() const = 0;
 
 
     /**
      * Returns true if this is a valid layer. It is up to individual providers
-     * to determine what constitutes a valid layer
+     * to determine what constitutes a valid layer.
      */
-    virtual bool isValid() = 0;
+    virtual bool isValid() const = 0;
 
 
     /**
-     * Update the extents of the layer. Not implemented by default
+     * Update the extents of the layer. Not implemented by default.
      */
     virtual void updateExtents()
     {
@@ -163,8 +162,9 @@ class CORE_EXPORT QgsDataProvider : public QObject
     }
 
 
-    /** Provider supports setting of subset strings */
-    virtual bool supportsSubsetString() { return false; }
+    /** Returns true if the provider supports setting of subset strings.
+    */
+    virtual bool supportsSubsetString() const { return false; }
 
     /**
      * Returns the subset definition string (typically sql) currently in
@@ -172,7 +172,7 @@ class CORE_EXPORT QgsDataProvider : public QObject
      * Must be overridden in the dataprovider, otherwise returns a null
      * QString.
      */
-    virtual QString subsetString()
+    virtual QString subsetString() const
     {
       return QString::null;
     }

--- a/src/core/qgsvectordataprovider.cpp
+++ b/src/core/qgsvectordataprovider.cpp
@@ -93,7 +93,7 @@ bool QgsVectorDataProvider::changeAttributeValues( const QgsChangedAttributesMap
   return false;
 }
 
-QVariant QgsVectorDataProvider::defaultValue( int fieldId )
+QVariant QgsVectorDataProvider::defaultValue( int fieldId ) const
 {
   Q_UNUSED( fieldId );
   return QVariant();
@@ -278,7 +278,7 @@ QMap<QString, int> QgsVectorDataProvider::fieldNameMap() const
   return resultMap;
 }
 
-QgsAttributeList QgsVectorDataProvider::attributeIndexes()
+QgsAttributeList QgsVectorDataProvider::attributeIndexes() const
 {
   return fields().allAttributesList();
 }
@@ -356,7 +356,7 @@ bool QgsVectorDataProvider::supportedType( const QgsField &field ) const
   return false;
 }
 
-QVariant QgsVectorDataProvider::minimumValue( int index )
+QVariant QgsVectorDataProvider::minimumValue( int index ) const
 {
   if ( index < 0 || index >= fields().count() )
   {
@@ -372,7 +372,7 @@ QVariant QgsVectorDataProvider::minimumValue( int index )
   return mCacheMinValues[index];
 }
 
-QVariant QgsVectorDataProvider::maximumValue( int index )
+QVariant QgsVectorDataProvider::maximumValue( int index ) const
 {
   if ( index < 0 || index >= fields().count() )
   {
@@ -388,7 +388,7 @@ QVariant QgsVectorDataProvider::maximumValue( int index )
   return mCacheMaxValues[index];
 }
 
-void QgsVectorDataProvider::uniqueValues( int index, QList<QVariant> &values, int limit )
+void QgsVectorDataProvider::uniqueValues( int index, QList<QVariant> &values, int limit ) const
 {
   QgsFeature f;
   QgsAttributeList keys;
@@ -412,7 +412,7 @@ void QgsVectorDataProvider::uniqueValues( int index, QList<QVariant> &values, in
 }
 
 QVariant QgsVectorDataProvider::aggregate( QgsAggregateCalculator::Aggregate aggregate, int index,
-    const QgsAggregateCalculator::AggregateParameters& parameters, QgsExpressionContext* context, bool& ok )
+    const QgsAggregateCalculator::AggregateParameters& parameters, QgsExpressionContext* context, bool& ok ) const
 {
   //base implementation does nothing
   Q_UNUSED( aggregate );
@@ -429,7 +429,7 @@ void QgsVectorDataProvider::clearMinMaxCache()
   mCacheMinMaxDirty = true;
 }
 
-void QgsVectorDataProvider::fillMinMaxCache()
+void QgsVectorDataProvider::fillMinMaxCache() const
 {
   if ( !mCacheMinMaxDirty )
     return;
@@ -530,7 +530,7 @@ static bool _compareEncodings( const QString& s1, const QString& s2 )
   return s1.toLower() < s2.toLower();
 }
 
-const QStringList &QgsVectorDataProvider::availableEncodings()
+QStringList QgsVectorDataProvider::availableEncodings()
 {
   if ( smEncodings.isEmpty() )
   {
@@ -598,12 +598,12 @@ void QgsVectorDataProvider::clearErrors()
   mErrors.clear();
 }
 
-bool QgsVectorDataProvider::hasErrors()
+bool QgsVectorDataProvider::hasErrors() const
 {
   return !mErrors.isEmpty();
 }
 
-QStringList QgsVectorDataProvider::errors()
+QStringList QgsVectorDataProvider::errors() const
 {
   return mErrors;
 }

--- a/src/core/qgsvectordataprovider.h
+++ b/src/core/qgsvectordataprovider.h
@@ -148,8 +148,10 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider
 
     /**
      * Query the provider for features specified in request.
+     * @param request feature request describing parameters of features to return
+     * @returns iterator for matching features from provider
      */
-    virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest& request = QgsFeatureRequest() ) = 0;
+    virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest& request = QgsFeatureRequest() ) const = 0;
 
     /**
      * Get feature type.
@@ -185,7 +187,7 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider
      * and maximal values. If provider has facilities to retrieve minimal
      * value directly, override this function.
      */
-    virtual QVariant minimumValue( int index );
+    virtual QVariant minimumValue( int index ) const;
 
     /**
      * Returns the maximum value of an attribute
@@ -195,7 +197,7 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider
      * and maximal values. If provider has facilities to retrieve maximal
      * value directly, override this function.
      */
-    virtual QVariant maximumValue( int index );
+    virtual QVariant maximumValue( int index ) const;
 
     /**
      * Return unique values of an attribute
@@ -205,7 +207,7 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider
      *
      * Default implementation simply iterates the features
      */
-    virtual void uniqueValues( int index, QList<QVariant> &uniqueValues, int limit = -1 );
+    virtual void uniqueValues( int index, QList<QVariant> &uniqueValues, int limit = -1 ) const;
 
     /** Calculates an aggregated value from the layer's features. The base implementation does nothing,
      * but subclasses can override this method to handoff calculation of aggregates to the provider.
@@ -221,7 +223,7 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider
                                 int index,
                                 const QgsAggregateCalculator::AggregateParameters& parameters,
                                 QgsExpressionContext* context,
-                                bool& ok );
+                                bool& ok ) const;
 
     /**
      * Returns the possible enum values of an attribute. Returns an empty stringlist if a provider does not support enum types
@@ -229,7 +231,7 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider
      * @param index the index of the attribute
      * @param enumList reference to the list to fill
      */
-    virtual void enumValues( int index, QStringList& enumList ) { Q_UNUSED( index ); enumList.clear(); }
+    virtual void enumValues( int index, QStringList& enumList ) const { Q_UNUSED( index ); enumList.clear(); }
 
     /**
      * Adds a list of features
@@ -287,7 +289,7 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider
     /**
      * Returns the default value for field specified by @c fieldId
      */
-    virtual QVariant defaultValue( int fieldId );
+    virtual QVariant defaultValue( int fieldId ) const;
 
     /**
      * Changes geometries of existing features
@@ -342,12 +344,12 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider
     /**
      * Return list of indexes to fetch all attributes in nextFeature()
      */
-    virtual QgsAttributeList attributeIndexes();
+    virtual QgsAttributeList attributeIndexes() const;
 
     /**
      * Return list of indexes of fields that make up the primary key
      */
-    virtual QgsAttributeList pkAttributeIndexes() { return QgsAttributeList(); }
+    virtual QgsAttributeList pkAttributeIndexes() const { return QgsAttributeList(); }
 
     /**
      * Return list of indexes to names for QgsPalLabeling fix
@@ -392,12 +394,12 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider
     virtual bool doesStrictFeatureTypeCheck() const { return true;}
 
     /** Returns a list of available encodings */
-    static const QStringList &availableEncodings();
+    static QStringList availableEncodings();
 
     /**
      * Provider has errors to report
      */
-    bool hasErrors();
+    bool hasErrors() const;
 
     /**
      * Clear recorded errors
@@ -407,14 +409,14 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider
     /**
      * Get recorded errors
      */
-    QStringList errors();
+    QStringList errors() const;
 
 
     /**
      * It returns false by default.
      * Must be implemented by providers that support saving and loading styles to db returning true
      */
-    virtual bool isSaveAndLoadStyleToDBSupported() { return false; }
+    virtual bool isSaveAndLoadStyleToDBSupported() const { return false; }
 
     static QVariant convertValue( QVariant::Type type, const QString& value );
 
@@ -446,10 +448,12 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider
 
   protected:
     void clearMinMaxCache();
-    void fillMinMaxCache();
 
-    bool mCacheMinMaxDirty;
-    QMap<int, QVariant> mCacheMinValues, mCacheMaxValues;
+    //! Populates the cache of minimum and maximum attribute values.
+    void fillMinMaxCache() const;
+
+    mutable bool mCacheMinMaxDirty;
+    mutable QMap<int, QVariant> mCacheMinValues, mCacheMaxValues;
 
     /** Encoding */
     QTextCodec* mEncoding;

--- a/src/core/raster/qgsrasterdataprovider.h
+++ b/src/core/raster/qgsrasterdataprovider.h
@@ -108,10 +108,7 @@ class CORE_EXPORT QgsRasterDataProvider : public QgsDataProvider, public QgsRast
      */
     virtual QImage* draw( const QgsRectangle & viewExtent, int pixelWidth, int pixelHeight ) = 0;
 
-    /** Get the extent of the data source.
-     * @return QgsRectangle containing the extent of the layer
-     */
-    virtual QgsRectangle extent() override = 0;
+    virtual QgsRectangle extent() const override = 0;
 
     /** Returns data type for the band specified by number */
     virtual QGis::DataType dataType( int bandNo ) const override = 0;
@@ -434,7 +431,7 @@ class CORE_EXPORT QgsRasterDataProvider : public QgsDataProvider, public QgsRast
     /** Emit a message to be displayed on status bar, usually used by network providers (WMS,WCS)
      * @note added in 2.14
      */
-    void statusChanged( const QString& );
+    void statusChanged( const QString& ) const;
 
   protected:
     /** Read block of data
@@ -484,7 +481,7 @@ class CORE_EXPORT QgsRasterDataProvider : public QgsDataProvider, public QgsRast
      *  for each band, indexed from 0 */
     QList< QgsRasterRangeList > mUserNoDataValue;
 
-    QgsRectangle mExtent;
+    mutable QgsRectangle mExtent;
 
     static QStringList mPyramidResamplingListGdal;
     static QgsStringMap mPyramidResamplingMapGdal;

--- a/src/core/raster/qgsrasterinterface.h
+++ b/src/core/raster/qgsrasterinterface.h
@@ -81,7 +81,7 @@ class CORE_EXPORT QgsRasterInterface
      * Get the extent of the interface.
      * @return QgsRectangle containing the extent of the layer
      */
-    virtual QgsRectangle extent() { return mInput ? mInput->extent() : QgsRectangle(); }
+    virtual QgsRectangle extent() const { return mInput ? mInput->extent() : QgsRectangle(); }
 
     int dataTypeSize( int bandNo ) { return QgsRasterBlock::typeSize( dataType( bandNo ) ); }
 

--- a/src/providers/arcgisrest/qgsafsprovider.cpp
+++ b/src/providers/arcgisrest/qgsafsprovider.cpp
@@ -150,7 +150,7 @@ QgsAbstractFeatureSource* QgsAfsProvider::featureSource() const
   return new QgsAfsFeatureSource( this );
 }
 
-QgsFeatureIterator QgsAfsProvider::getFeatures( const QgsFeatureRequest& request )
+QgsFeatureIterator QgsAfsProvider::getFeatures( const QgsFeatureRequest& request ) const
 {
   return new QgsAfsFeatureIterator( new QgsAfsFeatureSource( this ), true, request );
 }

--- a/src/providers/arcgisrest/qgsafsprovider.h
+++ b/src/providers/arcgisrest/qgsafsprovider.h
@@ -40,7 +40,7 @@ class QgsAfsProvider : public QgsVectorDataProvider
     /* Inherited from QgsVectorDataProvider */
     QgsAbstractFeatureSource* featureSource() const override;
     QString storageType() const override { return "ESRI ArcGIS Feature Server"; }
-    QgsFeatureIterator getFeatures( const QgsFeatureRequest& request = QgsFeatureRequest() ) override;
+    QgsFeatureIterator getFeatures( const QgsFeatureRequest& request = QgsFeatureRequest() ) const override;
     QGis::WkbType geometryType() const override { return static_cast<QGis::WkbType>( mGeometryType ); }
     long featureCount() const override { return mObjectIds.size(); }
     const QgsFields &fields() const override { return mFields; }
@@ -53,14 +53,14 @@ class QgsAfsProvider : public QgsVectorDataProvider
     bool changeGeometryValues( QgsGeometryMap & geometry_map ) override{ return false; }
     */
     int capabilities() const override { return QgsVectorDataProvider::NoCapabilities; }
-    QgsAttributeList pkAttributeIndexes() override { return QgsAttributeList() << mObjectIdFieldIdx; }
+    QgsAttributeList pkAttributeIndexes() const override { return QgsAttributeList() << mObjectIdFieldIdx; }
     QgsAttrPalIndexNameHash palAttributeIndexNames() const override { return QgsAttrPalIndexNameHash(); }
 
     /* Inherited from QgsDataProvider */
-    QgsCoordinateReferenceSystem crs() override { return mSourceCRS; }
+    QgsCoordinateReferenceSystem crs() const override { return mSourceCRS; }
     void setDataSourceUri( const QString & uri ) override;
-    QgsRectangle extent() override { return mExtent; }
-    bool isValid() override { return mValid; }
+    QgsRectangle extent() const override { return mExtent; }
+    bool isValid() const override { return mValid; }
     /* Read only for the moment
     void updateExtents() override{}
     */

--- a/src/providers/arcgisrest/qgsamsprovider.h
+++ b/src/providers/arcgisrest/qgsamsprovider.h
@@ -56,10 +56,10 @@ class QgsAmsProvider : public QgsRasterDataProvider
     QgsAmsProvider( const QString & uri );
 
     /* Inherited from QgsDataProvider */
-    bool isValid() override { return mValid; }
+    bool isValid() const override { return mValid; }
     QString name() const override { return "mapserver"; }
     QString description() const override { return "ArcGIS MapServer data provider"; }
-    QgsCoordinateReferenceSystem crs() override { return mCrs; }
+    QgsCoordinateReferenceSystem crs() const override { return mCrs; }
     uint subLayerCount() const override { return mSubLayers.size(); }
     QStringList subLayers() const override { return mSubLayers; }
     QStringList subLayerStyles() const override;
@@ -72,7 +72,7 @@ class QgsAmsProvider : public QgsRasterDataProvider
     int capabilities() const override { return Identify | IdentifyText | IdentifyFeature; }
 
     /* Inherited from QgsRasterDataProvider */
-    QgsRectangle extent() override { return mExtent; }
+    QgsRectangle extent() const override { return mExtent; }
     QString lastErrorTitle() override { return mErrorTitle; }
     QString lastError() override { return mError; }
     QGis::DataType dataType( int /*bandNo*/ ) const override { return QGis::ARGB32; }

--- a/src/providers/db2/qgsdb2provider.cpp
+++ b/src/providers/db2/qgsdb2provider.cpp
@@ -449,7 +449,7 @@ QgsAbstractFeatureSource* QgsDb2Provider::featureSource() const
   return new QgsDb2FeatureSource( this );
 }
 
-QgsFeatureIterator QgsDb2Provider::getFeatures( const QgsFeatureRequest& request )
+QgsFeatureIterator QgsDb2Provider::getFeatures( const QgsFeatureRequest& request ) const
 {
   if ( !mValid )
   {
@@ -499,7 +499,7 @@ const QgsFields &QgsDb2Provider::fields() const
   return mAttributeFields;
 }
 
-QgsCoordinateReferenceSystem QgsDb2Provider::crs()
+QgsCoordinateReferenceSystem QgsDb2Provider::crs() const
 {
   if ( !mCrs.isValid() && mSRId > 0 )
   {
@@ -527,7 +527,7 @@ QgsCoordinateReferenceSystem QgsDb2Provider::crs()
 }
 
 // update the extent for this layer
-void QgsDb2Provider::updateStatistics()
+void QgsDb2Provider::updateStatistics() const
 {
   // get features to calculate the statistics
   QString statement;
@@ -618,7 +618,7 @@ void QgsDb2Provider::updateStatistics()
   }
 }
 
-QgsRectangle QgsDb2Provider::extent()
+QgsRectangle QgsDb2Provider::extent() const
 {
   QgsDebugMsg( QString( "entering; mExtent: %1" ).arg( mExtent.toString() ) );
   if ( mExtent.isEmpty() )
@@ -626,12 +626,12 @@ QgsRectangle QgsDb2Provider::extent()
   return mExtent;
 }
 
-bool QgsDb2Provider::isValid()
+bool QgsDb2Provider::isValid() const
 {
   return true; //DB2 only has valid geometries
 }
 
-QString QgsDb2Provider::subsetString()
+QString QgsDb2Provider::subsetString() const
 {
   return mSqlWhereClause;
 }

--- a/src/providers/db2/qgsdb2provider.h
+++ b/src/providers/db2/qgsdb2provider.h
@@ -51,11 +51,7 @@ class QgsDb2Provider : public QgsVectorDataProvider
 
     virtual QgsAbstractFeatureSource* featureSource() const override;
 
-    /**
-     * Get feature iterator.
-     * @return QgsFeatureIterator to iterate features.
-     */
-    virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest& request = QgsFeatureRequest() ) override;
+    virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest& request = QgsFeatureRequest() ) const override;
 
     /**
      * Get feature type.
@@ -72,7 +68,7 @@ class QgsDb2Provider : public QgsVectorDataProvider
     /**
      * Update the extent for this layer.
      */
-    void updateStatistics();
+    void updateStatistics() const;
 
     /**
      * Return a map of indexes with field names for this layer.
@@ -80,29 +76,17 @@ class QgsDb2Provider : public QgsVectorDataProvider
      */
     virtual const QgsFields &fields() const override;
 
-    virtual QgsCoordinateReferenceSystem crs() override;
-
-    /**
-     * Return the extent for this data layer.
-     */
-    virtual QgsRectangle extent() override;
-
-    /**
-     * Returns true if this is a valid data source.
-     */
-    virtual bool isValid() override;
-
-    /**
-     * Accessor for SQL WHERE clause used to limit dataset.
-     */
-    QString subsetString() override;
+    virtual QgsCoordinateReferenceSystem crs() const override;
+    virtual QgsRectangle extent() const override;
+    virtual bool isValid() const override;
+    QString subsetString() const override;
 
     /**
      * Mutator for SQL WHERE clause used to limit dataset size.
      */
     bool setSubsetString( const QString& theSQL, bool updateFeatureCount = true ) override;
 
-    virtual bool supportsSubsetString() override { return true; }
+    virtual bool supportsSubsetString() const override { return true; }
 
     /** Return a provider name
 
@@ -168,19 +152,19 @@ class QgsDb2Provider : public QgsVectorDataProvider
 
     QgsFields mAttributeFields; //fields
     QMap<int, QVariant> mDefaultValues;
-    QgsRectangle mExtent; //layer extent
+    mutable QgsRectangle mExtent; //layer extent
     bool mValid;
     bool mUseEstimatedMetadata;
     bool mSkipFailures;
     long mNumberFeatures;
     QString mFidColName;
     QString mExtents;
-    long mSRId;
-    int  mEnvironment;
-    QString mSrsName;
-    QString mGeometryColName, mGeometryColType;
+    mutable long mSRId;
+    mutable int  mEnvironment;
+    mutable QString mSrsName;
+    mutable QString mGeometryColName, mGeometryColType;
     QString mLastError; //string containing the last reported error message
-    QgsCoordinateReferenceSystem mCrs; //coordinate reference system
+    mutable QgsCoordinateReferenceSystem mCrs; //coordinate reference system
     QGis::WkbType mWkbType;
     QSqlQuery mQuery; //current SQL query
     QString mConnInfo; // full connection information

--- a/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
@@ -285,14 +285,14 @@ QStringList QgsDelimitedTextProvider::readCsvtFieldTypes( const QString& filenam
 
 }
 
-void QgsDelimitedTextProvider::resetCachedSubset()
+void QgsDelimitedTextProvider::resetCachedSubset() const
 {
   mCachedSubsetString = QString();
   mCachedUseSubsetIndex = false;
   mCachedUseSpatialIndex = false;
 }
 
-void QgsDelimitedTextProvider::resetIndexes()
+void QgsDelimitedTextProvider::resetIndexes() const
 {
   resetCachedSubset();
   mUseSubsetIndex = false;
@@ -721,7 +721,7 @@ void QgsDelimitedTextProvider::scanFile( bool buildIndexes )
 // rescanFile.  Called if something has changed file definition, such as
 // selecting a subset, the file has been changed by another program, etc
 
-void QgsDelimitedTextProvider::rescanFile()
+void QgsDelimitedTextProvider::rescanFile() const
 {
   mRescanRequired = false;
   resetIndexes();
@@ -906,7 +906,7 @@ QString QgsDelimitedTextProvider::storageType() const
   return "Delimited text file";
 }
 
-QgsFeatureIterator QgsDelimitedTextProvider::getFeatures( const QgsFeatureRequest& request )
+QgsFeatureIterator QgsDelimitedTextProvider::getFeatures( const QgsFeatureRequest& request ) const
 {
   // If the file has become invalid, rescan to check that it is still invalid.
   //
@@ -915,7 +915,7 @@ QgsFeatureIterator QgsDelimitedTextProvider::getFeatures( const QgsFeatureReques
   return QgsFeatureIterator( new QgsDelimitedTextFeatureIterator( new QgsDelimitedTextFeatureSource( this ), true, request ) );
 }
 
-void QgsDelimitedTextProvider::clearInvalidLines()
+void QgsDelimitedTextProvider::clearInvalidLines() const
 {
   mInvalidLines.clear();
   mNExtraInvalidLines = 0;
@@ -942,7 +942,7 @@ void QgsDelimitedTextProvider::recordInvalidLine( const QString& message )
   }
 }
 
-void QgsDelimitedTextProvider::reportErrors( const QStringList& messages, bool showDialog )
+void QgsDelimitedTextProvider::reportErrors( const QStringList& messages, bool showDialog ) const
 {
   if ( !mInvalidLines.isEmpty() || ! messages.isEmpty() )
   {
@@ -1110,11 +1110,10 @@ void QgsDelimitedTextProvider::onFileUpdated()
   }
 }
 
-
-// Return the extent of the layer
-QgsRectangle QgsDelimitedTextProvider::extent()
+QgsRectangle QgsDelimitedTextProvider::extent() const
 {
-  if ( mRescanRequired ) rescanFile();
+  if ( mRescanRequired )
+    rescanFile();
   return mExtent;
 }
 
@@ -1141,7 +1140,7 @@ const QgsFields & QgsDelimitedTextProvider::fields() const
   return attributeFields;
 }
 
-bool QgsDelimitedTextProvider::isValid()
+bool QgsDelimitedTextProvider::isValid() const
 {
   return mLayerValid;
 }
@@ -1152,7 +1151,7 @@ int QgsDelimitedTextProvider::capabilities() const
 }
 
 
-QgsCoordinateReferenceSystem QgsDelimitedTextProvider::crs()
+QgsCoordinateReferenceSystem QgsDelimitedTextProvider::crs() const
 {
   return mCrs;
 }

--- a/src/providers/delimitedtext/qgsdelimitedtextprovider.h
+++ b/src/providers/delimitedtext/qgsdelimitedtextprovider.h
@@ -87,7 +87,7 @@ class QgsDelimitedTextProvider : public QgsVectorDataProvider
      */
     virtual QString storageType() const override;
 
-    virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest& request ) override;
+    virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest& request ) const override;
 
     /**
      * Get feature type.
@@ -148,35 +148,19 @@ class QgsDelimitedTextProvider : public QgsVectorDataProvider
      */
     QString description() const override;
 
-    /**
-     * Return the extent for this data layer
-     */
-    virtual QgsRectangle extent() override;
+    virtual QgsRectangle extent() const override;
+    bool isValid() const override;
 
-    /**
-     * Returns true if this is a valid delimited file
-     */
-    bool isValid() override;
-
-    virtual QgsCoordinateReferenceSystem crs() override;
+    virtual QgsCoordinateReferenceSystem crs() const override;
     /**
      * Set the subset string used to create a subset of features in
      * the layer.
      */
     virtual bool setSubsetString( const QString& subset, bool updateFeatureCount = true ) override;
 
-    /**
-     * provider supports setting of subset strings
-     */
-    virtual bool supportsSubsetString() override { return true; }
+    virtual bool supportsSubsetString() const override { return true; }
 
-    /**
-     * Returns the subset definition string (typically sql) currently in
-     * use by the layer and used by the provider to limit the feature set.
-     * Must be overridden in the dataprovider, otherwise returns a null
-     * QString.
-     */
-    virtual QString subsetString() override
+    virtual QString subsetString() const override
     {
       return mSubsetString;
     }
@@ -216,12 +200,14 @@ class QgsDelimitedTextProvider : public QgsVectorDataProvider
   private:
 
     void scanFile( bool buildIndexes );
-    void rescanFile();
-    void resetCachedSubset();
-    void resetIndexes();
-    void clearInvalidLines();
+
+    //some of these methods const, as they need to be called from const methods such as extent()
+    void rescanFile() const;
+    void resetCachedSubset() const;
+    void resetIndexes() const;
+    void clearInvalidLines() const;
     void recordInvalidLine( const QString& message );
-    void reportErrors( const QStringList& messages = QStringList(), bool showDialog = false );
+    void reportErrors( const QStringList& messages = QStringList(), bool showDialog = false ) const;
     static bool recordIsEmpty( QStringList &record );
     void setUriParameter( const QString& parameter, const QString& value );
 
@@ -234,14 +220,14 @@ class QgsDelimitedTextProvider : public QgsVectorDataProvider
     bool mLayerValid;
     // mValid defines whether the layer is currently valid (may differ from
     // mLayerValid if the file has been rewritten)
-    bool mValid;
+    mutable bool mValid;
 
     //! Text file
     QgsDelimitedTextFile *mFile;
 
     // Fields
     GeomRepresentationType mGeomRep;
-    QList<int> attributeColumns;
+    mutable QList<int> attributeColumns;
     QgsFields attributeFields;
 
     int mFieldCount;  // Note: this includes field count for wkt field
@@ -249,41 +235,41 @@ class QgsDelimitedTextProvider : public QgsVectorDataProvider
     QString mXFieldName;
     QString mYFieldName;
 
-    int mXFieldIndex;
-    int mYFieldIndex;
-    int mWktFieldIndex;
+    mutable int mXFieldIndex;
+    mutable int mYFieldIndex;
+    mutable int mWktFieldIndex;
 
     // mWktPrefix regexp is used to clean up
     // prefixes sometimes used for WKT (postgis EWKT, informix SRID)
     bool mWktHasPrefix;
 
     //! Layer extent
-    QgsRectangle mExtent;
+    mutable QgsRectangle mExtent;
 
     int mGeomType;
 
-    long mNumberFeatures;
+    mutable long mNumberFeatures;
     int mSkipLines;
     QString mDecimalPoint;
     bool mXyDms;
 
     QString mSubsetString;
-    QString mCachedSubsetString;
+    mutable QString mCachedSubsetString;
     QgsExpression *mSubsetExpression;
     bool mBuildSubsetIndex;
-    QList<quintptr> mSubsetIndex;
-    bool mUseSubsetIndex;
-    bool mCachedUseSubsetIndex;
+    mutable QList<quintptr> mSubsetIndex;
+    mutable bool mUseSubsetIndex;
+    mutable bool mCachedUseSubsetIndex;
 
     //! Storage for any lines in the file that couldn't be loaded
     int mMaxInvalidLines;
-    int mNExtraInvalidLines;
-    QStringList mInvalidLines;
+    mutable int mNExtraInvalidLines;
+    mutable QStringList mInvalidLines;
     //! Only want to show the invalid lines once to the user
     bool mShowInvalidLines;
 
     //! Record file updates, flags rescan required
-    bool mRescanRequired;
+    mutable bool mRescanRequired;
 
     // Coordinate reference sytem
     QgsCoordinateReferenceSystem mCrs;
@@ -293,9 +279,9 @@ class QgsDelimitedTextProvider : public QgsVectorDataProvider
 
     // Spatial index
     bool mBuildSpatialIndex;
-    bool mUseSpatialIndex;
-    bool mCachedUseSpatialIndex;
-    QgsSpatialIndex *mSpatialIndex;
+    mutable bool mUseSpatialIndex;
+    mutable bool mCachedUseSpatialIndex;
+    mutable QgsSpatialIndex *mSpatialIndex;
 
     friend class QgsDelimitedTextFeatureIterator;
     friend class QgsDelimitedTextFeatureSource;

--- a/src/providers/gdal/qgsgdalprovider.cpp
+++ b/src/providers/gdal/qgsgdalprovider.cpp
@@ -874,12 +874,12 @@ QList<QgsColorRampShader::ColorRampItem> QgsGdalProvider::colorTable( int theBan
   return QgsGdalProviderBase::colorTable( mGdalDataset, theBandNumber );
 }
 
-QgsCoordinateReferenceSystem QgsGdalProvider::crs()
+QgsCoordinateReferenceSystem QgsGdalProvider::crs() const
 {
   return mCrs;
 }
 
-QgsRectangle QgsGdalProvider::extent()
+QgsRectangle QgsGdalProvider::extent() const
 {
   //TODO
   //mExtent = QgsGdal::extent( mGisdbase, mLocation, mMapset, mMapName, QgsGdal::Raster );
@@ -1190,7 +1190,7 @@ int QgsGdalProvider::colorInterpretation( int theBandNo ) const
   return colorInterpretationFromGdal( GDALGetRasterColorInterpretation( myGdalBand ) );
 }
 
-bool QgsGdalProvider::isValid()
+bool QgsGdalProvider::isValid() const
 {
   QgsDebugMsg( QString( "valid = %1" ).arg( mValid ) );
   return mValid;

--- a/src/providers/gdal/qgsgdalprovider.h
+++ b/src/providers/gdal/qgsgdalprovider.h
@@ -109,20 +109,11 @@ class QgsGdalProvider : public QgsRasterDataProvider, QgsGdalProviderBase
      */
     QString description() const override;
 
-    /** Get the QgsCoordinateReferenceSystem for this layer
-     * @note Must be reimplemented by each provider.
-     * If the provider isn't capable of returning
-     * its projection an empty srs will be return, ti will return 0
-     */
-    virtual QgsCoordinateReferenceSystem crs() override;
+    virtual QgsCoordinateReferenceSystem crs() const override;
 
-    /** Return the extent for this data layer
-     */
-    virtual QgsRectangle extent() override;
+    virtual QgsRectangle extent() const override;
 
-    /** Returns true if layer is valid
-     */
-    bool isValid() override;
+    bool isValid() const override;
 
     QgsRasterIdentifyResult identify( const QgsPoint & thePoint, QgsRaster::IdentifyFormat theFormat, const QgsRectangle &theExtent = QgsRectangle(), int theWidth = 0, int theHeight = 0, int theDpi = 96 ) override;
 

--- a/src/providers/gpx/qgsgpxprovider.cpp
+++ b/src/providers/gpx/qgsgpxprovider.cpp
@@ -135,7 +135,7 @@ int QgsGPXProvider::capabilities() const
 
 
 // Return the extent of the layer
-QgsRectangle QgsGPXProvider::extent()
+QgsRectangle QgsGPXProvider::extent() const
 {
   return data->getExtent();
 }
@@ -178,13 +178,13 @@ const QgsFields& QgsGPXProvider::fields() const
 
 
 
-bool QgsGPXProvider::isValid()
+bool QgsGPXProvider::isValid() const
 {
   return mValid;
 }
 
 
-QgsFeatureIterator QgsGPXProvider::getFeatures( const QgsFeatureRequest& request )
+QgsFeatureIterator QgsGPXProvider::getFeatures( const QgsFeatureRequest& request ) const
 {
   return QgsFeatureIterator( new QgsGPXFeatureIterator( new QgsGPXFeatureSource( this ), true, request ) );
 }
@@ -515,7 +515,7 @@ void QgsGPXProvider::changeAttributeValues( QgsGPSObject& obj, const QgsAttribut
 }
 
 
-QVariant QgsGPXProvider::defaultValue( int fieldId )
+QVariant QgsGPXProvider::defaultValue( int fieldId ) const
 {
   if ( fieldId == SrcAttr )
     return tr( "Digitized in QGIS" );
@@ -535,7 +535,7 @@ QString QgsGPXProvider::description() const
   return GPX_DESCRIPTION;
 } // QgsGPXProvider::description()
 
-QgsCoordinateReferenceSystem QgsGPXProvider::crs()
+QgsCoordinateReferenceSystem QgsGPXProvider::crs() const
 {
   return QgsCoordinateReferenceSystem( GEOSRID, QgsCoordinateReferenceSystem::PostgisCrsId ); // use WGS84
 }

--- a/src/providers/gpx/qgsgpxprovider.h
+++ b/src/providers/gpx/qgsgpxprovider.h
@@ -55,7 +55,7 @@ class QgsGPXProvider : public QgsVectorDataProvider
      */
     virtual QString storageType() const override;
 
-    virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest& request ) override;
+    virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest& request ) const override;
 
     /**
      * Get feature type.
@@ -96,21 +96,13 @@ class QgsGPXProvider : public QgsVectorDataProvider
 
     virtual int capabilities() const override;
 
-    /**
-     * Returns the default value for field specified by @c fieldId
-     */
-    virtual QVariant defaultValue( int fieldId ) override;
+    virtual QVariant defaultValue( int fieldId ) const override;
 
 
     /* Functions inherited from QgsDataProvider */
 
-    /** Return the extent for this data layer
-     */
-    virtual QgsRectangle extent() override;
-
-    /** Returns true if this is a valid delimited file
-     */
-    virtual bool isValid() override;
+    virtual QgsRectangle extent() const override;
+    virtual bool isValid() const override;
 
     /** Return a provider name */
     virtual QString name() const override;
@@ -118,7 +110,7 @@ class QgsGPXProvider : public QgsVectorDataProvider
     /** Return description */
     virtual QString description() const override;
 
-    virtual QgsCoordinateReferenceSystem crs() override;
+    virtual QgsCoordinateReferenceSystem crs() const override;
 
 
     /* new functions */

--- a/src/providers/grass/qgsgrassprovider.cpp
+++ b/src/providers/grass/qgsgrassprovider.cpp
@@ -414,7 +414,7 @@ QString QgsGrassProvider::storageType() const
 
 
 
-QgsFeatureIterator QgsGrassProvider::getFeatures( const QgsFeatureRequest& request )
+QgsFeatureIterator QgsGrassProvider::getFeatures( const QgsFeatureRequest& request ) const
 {
   if ( !mValid )
   {
@@ -429,7 +429,7 @@ QgsFeatureIterator QgsGrassProvider::getFeatures( const QgsFeatureRequest& reque
   return QgsFeatureIterator( iterator );
 }
 
-QgsRectangle QgsGrassProvider::extent()
+QgsRectangle QgsGrassProvider::extent() const
 {
   if ( isValid() )
   {
@@ -478,7 +478,7 @@ int QgsGrassProvider::keyField()
   return mLayer->keyColumn();
 }
 
-QVariant QgsGrassProvider::minimumValue( int index )
+QVariant QgsGrassProvider::minimumValue( int index ) const
 {
   if ( isValid() )
   {
@@ -497,14 +497,14 @@ QVariant QgsGrassProvider::maxValue( int index )
   return QVariant();
 }
 
-bool QgsGrassProvider::isValid()
+bool QgsGrassProvider::isValid() const
 {
   bool valid = mValid && mLayer && mLayer->map() && mLayer->map()->map();
   QgsDebugMsg( QString( "valid = %1" ).arg( valid ) );
   return valid;
 }
 
-QgsCoordinateReferenceSystem QgsGrassProvider::crs()
+QgsCoordinateReferenceSystem QgsGrassProvider::crs() const
 {
   QString error;
   return QgsGrass::crs( mGrassObject.gisdbase(), mGrassObject.location(), error );
@@ -655,7 +655,7 @@ bool QgsGrassProvider::closeEdit( bool newMap, QgsVectorLayer *vectorLayer )
   return false;
 }
 
-void QgsGrassProvider::ensureUpdated()
+void QgsGrassProvider::ensureUpdated() const
 {
   // TODO
 #if 0
@@ -2064,13 +2064,13 @@ QgsGrassVectorMapLayer * QgsGrassProvider::openLayer() const
   return mLayer->map()->openLayer( mLayerField );
 }
 
-struct Map_info * QgsGrassProvider::map()
-{
-  Q_ASSERT( mLayer );
-  Q_ASSERT( mLayer->map() );
-  Q_ASSERT( mLayer->map()->map() );
-  return mLayer->map()->map();
-}
+struct Map_info * QgsGrassProvider::map() const
+  {
+    Q_ASSERT( mLayer );
+    Q_ASSERT( mLayer->map() );
+    Q_ASSERT( mLayer->map()->map() );
+    return mLayer->map()->map();
+  }
 
 void QgsGrassProvider::setMapset()
 {

--- a/src/providers/grass/qgsgrassprovider.h
+++ b/src/providers/grass/qgsgrassprovider.h
@@ -72,7 +72,7 @@ class GRASS_LIB_EXPORT QgsGrassProvider : public QgsVectorDataProvider
       */
     virtual QString storageType() const override;
 
-    virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest& request ) override;
+    virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest& request ) const override;
 
     /**
      * Get the feature type as defined in WkbType (qgis.h).
@@ -86,10 +86,7 @@ class GRASS_LIB_EXPORT QgsGrassProvider : public QgsVectorDataProvider
      */
     long featureCount() const override;
 
-
-    /** Return the extent for this data layer
-     */
-    virtual QgsRectangle extent() override;
+    virtual QgsRectangle extent() const override;
 
     /**
      * Get the field information for the layer
@@ -102,9 +99,7 @@ class GRASS_LIB_EXPORT QgsGrassProvider : public QgsVectorDataProvider
     /** Restart reading features from previous select operation */
     void rewind();
 
-    /** Returns the minimum value of an attributs
-     *  @param index the index of the attribute */
-    QVariant minimumValue( int index ) override;
+    QVariant minimumValue( int index ) const override;
 
     /** Returns the maximum value of an attributs
      *  @param index the index of the attribute */
@@ -119,11 +114,9 @@ class GRASS_LIB_EXPORT QgsGrassProvider : public QgsVectorDataProvider
     /** Load info (mNumberFeatures, mCidxFieldIndex, mCidxFieldNumCats)  from map */
     void loadMapInfo();
 
-    /** Returns true if this is a valid layer
-     */
-    bool isValid() override;
+    bool isValid() const override;
 
-    QgsCoordinateReferenceSystem crs() override;
+    QgsCoordinateReferenceSystem crs() const override;
 
     // ----------------------------------- New edit --------------------------------
     // Changes are written during editing.
@@ -406,7 +399,7 @@ class GRASS_LIB_EXPORT QgsGrassProvider : public QgsVectorDataProvider
     QgsGrassVectorMapLayer *openLayer() const;
 
   private:
-    struct Map_info * map();
+    struct Map_info * map() const;
     void setMapset();
     bool openLayer();
     // update topo symbol of new features
@@ -443,7 +436,7 @@ class GRASS_LIB_EXPORT QgsGrassProvider : public QgsVectorDataProvider
     static char *attribute( int layerId, int cat, int column );
 
     /** Check if provider is outdated and update if necessary */
-    void ensureUpdated();
+    void ensureUpdated() const;
 
     /** Check if layer is topology layer TOPO_POINT, TOPO_NODE, TOPO_LINE */
     bool isTopoType() const;

--- a/src/providers/grass/qgsgrassrasterprovider.cpp
+++ b/src/providers/grass/qgsgrassrasterprovider.cpp
@@ -426,12 +426,12 @@ QList<QgsColorRampShader::ColorRampItem> QgsGrassRasterProvider::colorTable( int
   return ct;
 }
 
-QgsCoordinateReferenceSystem QgsGrassRasterProvider::crs()
+QgsCoordinateReferenceSystem QgsGrassRasterProvider::crs() const
 {
   return mCrs;
 }
 
-QgsRectangle QgsGrassRasterProvider::extent()
+QgsRectangle QgsGrassRasterProvider::extent() const
 {
   // The extend can change of course so we get always fresh, to avoid running always the module
   // we should save mExtent and mLastModified and check if the map was modified
@@ -570,7 +570,7 @@ QString QgsGrassRasterProvider::metadata()
   return myMetadata;
 }
 
-bool QgsGrassRasterProvider::isValid()
+bool QgsGrassRasterProvider::isValid() const
 {
   return mValid;
 }

--- a/src/providers/grass/qgsgrassrasterprovider.h
+++ b/src/providers/grass/qgsgrassrasterprovider.h
@@ -133,20 +133,13 @@ class GRASS_LIB_EXPORT QgsGrassRasterProvider : public QgsRasterDataProvider
      */
     QString description() const override;
 
-    /** Get the QgsCoordinateReferenceSystem for this layer
-     * @note Must be reimplemented by each provider.
-     * If the provider isn't capable of returning
-     * its projection an empty srs will be return, ti will return 0
-     */
-    virtual QgsCoordinateReferenceSystem crs() override;
+    virtual QgsCoordinateReferenceSystem crs() const override;
 
     /** Return the extent for this data layer
      */
-    virtual QgsRectangle extent() override;
+    virtual QgsRectangle extent() const override;
 
-    /** Returns true if layer is valid
-     */
-    bool isValid() override;
+    bool isValid() const override;
 
     QgsRasterIdentifyResult identify( const QgsPoint & thePoint, QgsRaster::IdentifyFormat theFormat, const QgsRectangle &theExtent = QgsRectangle(), int theWidth = 0, int theHeight = 0, int theDpi = 96 ) override;
 

--- a/src/providers/memory/qgsmemoryprovider.cpp
+++ b/src/providers/memory/qgsmemoryprovider.cpp
@@ -277,13 +277,13 @@ QString QgsMemoryProvider::storageType() const
   return "Memory storage";
 }
 
-QgsFeatureIterator QgsMemoryProvider::getFeatures( const QgsFeatureRequest& request )
+QgsFeatureIterator QgsMemoryProvider::getFeatures( const QgsFeatureRequest& request ) const
 {
   return QgsFeatureIterator( new QgsMemoryFeatureIterator( new QgsMemoryFeatureSource( this ), true, request ) );
 }
 
 
-QgsRectangle QgsMemoryProvider::extent()
+QgsRectangle QgsMemoryProvider::extent() const
 {
   return mExtent;
 }
@@ -314,12 +314,12 @@ const QgsFields & QgsMemoryProvider::fields() const
   return mFields;
 }
 
-bool QgsMemoryProvider::isValid()
+bool QgsMemoryProvider::isValid() const
 {
   return ( mWkbType != QGis::WKBUnknown );
 }
 
-QgsCoordinateReferenceSystem QgsMemoryProvider::crs()
+QgsCoordinateReferenceSystem QgsMemoryProvider::crs() const
 {
   // TODO: make provider projection-aware
   return mCrs; // return default CRS
@@ -488,7 +488,7 @@ bool QgsMemoryProvider::changeGeometryValues( const QgsGeometryMap &geometry_map
   return true;
 }
 
-QString QgsMemoryProvider::subsetString()
+QString QgsMemoryProvider::subsetString() const
 {
   return mSubsetString;
 }

--- a/src/providers/memory/qgsmemoryprovider.h
+++ b/src/providers/memory/qgsmemoryprovider.h
@@ -47,7 +47,7 @@ class QgsMemoryProvider : public QgsVectorDataProvider
      */
     virtual QString storageType() const override;
 
-    virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest& request ) override;
+    virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest& request ) const override;
 
     /**
      * Get feature type.
@@ -113,13 +113,12 @@ class QgsMemoryProvider : public QgsVectorDataProvider
      */
     virtual bool changeGeometryValues( const QgsGeometryMap & geometry_map ) override;
 
-    /** Accessor for sql where clause used to limit dataset */
-    QString subsetString() override;
+    QString subsetString() const override;
 
     /** Mutator for sql where clause used to limit dataset size */
     bool setSubsetString( const QString& theSQL, bool updateFeatureCount = true ) override;
 
-    virtual bool supportsSubsetString() override { return true; }
+    virtual bool supportsSubsetString() const override { return true; }
 
     /**
      * Creates a spatial index
@@ -146,17 +145,10 @@ class QgsMemoryProvider : public QgsVectorDataProvider
      */
     QString description() const override;
 
-    /**
-     * Return the extent for this data layer
-     */
-    virtual QgsRectangle extent() override;
+    virtual QgsRectangle extent() const override;
+    bool isValid() const override;
 
-    /**
-     * Returns true if this is a valid provider
-     */
-    bool isValid() override;
-
-    virtual QgsCoordinateReferenceSystem crs() override;
+    virtual QgsCoordinateReferenceSystem crs() const override;
 
   protected:
 

--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -187,7 +187,7 @@ QgsAbstractFeatureSource* QgsMssqlProvider::featureSource() const
   return new QgsMssqlFeatureSource( this );
 }
 
-QgsFeatureIterator QgsMssqlProvider::getFeatures( const QgsFeatureRequest& request )
+QgsFeatureIterator QgsMssqlProvider::getFeatures( const QgsFeatureRequest& request ) const
 {
   if ( !mValid )
   {
@@ -502,7 +502,7 @@ QString QgsMssqlProvider::quotedValue( const QVariant& value )
   }
 }
 
-QVariant QgsMssqlProvider::defaultValue( int fieldId )
+QVariant QgsMssqlProvider::defaultValue( int fieldId ) const
 {
   if ( mDefaultValues.contains( fieldId ) )
     return mDefaultValues[fieldId];
@@ -516,7 +516,7 @@ QString QgsMssqlProvider::storageType() const
 }
 
 // Returns the minimum value of an attribute
-QVariant QgsMssqlProvider::minimumValue( int index )
+QVariant QgsMssqlProvider::minimumValue( int index ) const
 {
   // get the field name
   QgsField fld = mAttributeFields.at( index );
@@ -547,7 +547,7 @@ QVariant QgsMssqlProvider::minimumValue( int index )
 }
 
 // Returns the maximum value of an attribute
-QVariant QgsMssqlProvider::maximumValue( int index )
+QVariant QgsMssqlProvider::maximumValue( int index ) const
 {
   // get the field name
   QgsField fld = mAttributeFields.at( index );
@@ -578,7 +578,7 @@ QVariant QgsMssqlProvider::maximumValue( int index )
 }
 
 // Returns the list of unique values of an attribute
-void QgsMssqlProvider::uniqueValues( int index, QList<QVariant> &uniqueValues, int limit )
+void QgsMssqlProvider::uniqueValues( int index, QList<QVariant> &uniqueValues, int limit ) const
 {
   uniqueValues.clear();
 
@@ -621,7 +621,7 @@ void QgsMssqlProvider::uniqueValues( int index, QList<QVariant> &uniqueValues, i
 
 
 // update the extent, wkb type and srid for this layer
-void QgsMssqlProvider::UpdateStatistics( bool estimate )
+void QgsMssqlProvider::UpdateStatistics( bool estimate ) const
 {
   if ( mGeometryColName.isEmpty() )
     return;
@@ -730,7 +730,7 @@ void QgsMssqlProvider::UpdateStatistics( bool estimate )
 }
 
 // Return the extent of the layer
-QgsRectangle QgsMssqlProvider::extent()
+QgsRectangle QgsMssqlProvider::extent() const
 {
   if ( mExtent.isEmpty() )
     UpdateStatistics( mUseEstimatedMetadata );
@@ -783,7 +783,7 @@ const QgsFields & QgsMssqlProvider::fields() const
   return mAttributeFields;
 }
 
-bool QgsMssqlProvider::isValid()
+bool QgsMssqlProvider::isValid() const
 {
   return mValid;
 }
@@ -1396,7 +1396,7 @@ bool QgsMssqlProvider::createAttributeIndex( int field )
   return true;
 }
 
-QgsCoordinateReferenceSystem QgsMssqlProvider::crs()
+QgsCoordinateReferenceSystem QgsMssqlProvider::crs() const
 {
   if ( !mCrs.isValid() && mSRId > 0 )
   {
@@ -1433,7 +1433,7 @@ QgsCoordinateReferenceSystem QgsMssqlProvider::crs()
   return mCrs;
 }
 
-QString QgsMssqlProvider::subsetString()
+QString QgsMssqlProvider::subsetString() const
 {
   return mSqlWhereClause;
 }

--- a/src/providers/mssql/qgsmssqlprovider.h
+++ b/src/providers/mssql/qgsmssqlprovider.h
@@ -73,42 +73,10 @@ class QgsMssqlProvider : public QgsVectorDataProvider
      * it knows about in some way before it hands them off to the provider.
      */
     virtual QStringList subLayers() const override;
-
-    /**
-     * Returns the minimum value of an attribute
-     * @param index the index of the attribute
-     *
-     * Default implementation walks all numeric attributes and caches minimal
-     * and maximal values. If provider has facilities to retrieve minimal
-     * value directly, override this function.
-     */
-    virtual QVariant minimumValue( int index ) override;
-
-    /**
-     * Returns the maximum value of an attribute
-     * @param index the index of the attribute
-     *
-     * Default implementation walks all numeric attributes and caches minimal
-     * and maximal values. If provider has facilities to retrieve maximal
-     * value directly, override this function.
-     */
-    virtual QVariant maximumValue( int index ) override;
-
-    /**
-     * Return unique values of an attribute
-     * @param index the index of the attribute
-     * @param uniqueValues values reference to the list to fill
-     * @param limit maxmum number of the values to return
-     *
-     * Default implementation simply iterates the features
-     */
-    virtual void uniqueValues( int index, QList<QVariant> &uniqueValues, int limit = -1 ) override;
-
-    /**
-     * Get feature iterator.
-     * @return QgsFeatureIterator to iterate features
-     */
-    virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest& request ) override;
+    virtual QVariant minimumValue( int index ) const override;
+    virtual QVariant maximumValue( int index ) const override;
+    virtual void uniqueValues( int index, QList<QVariant> &uniqueValues, int limit = -1 ) const override;
+    virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest& request ) const override;
 
     /**
      * Get feature type.
@@ -123,7 +91,7 @@ class QgsMssqlProvider : public QgsVectorDataProvider
     virtual long featureCount() const override;
 
     /** Update the extent, feature count, wkb type and srid for this layer */
-    void UpdateStatistics( bool estimate );
+    void UpdateStatistics( bool estimate ) const;
 
     /**
      * Return a map of indexes with field names for this layer
@@ -131,13 +99,12 @@ class QgsMssqlProvider : public QgsVectorDataProvider
      */
     virtual const QgsFields & fields() const override;
 
-    /** Accessor for sql where clause used to limit dataset */
-    QString subsetString() override;
+    QString subsetString() const override;
 
     /** Mutator for sql where clause used to limit dataset size */
     bool setSubsetString( const QString& theSQL, bool updateFeatureCount = true ) override;
 
-    virtual bool supportsSubsetString() override { return true; }
+    virtual bool supportsSubsetString() const override { return true; }
 
     /** Returns a bitmask containing the supported capabilities
         Note, some capabilities may change depending on whether
@@ -176,20 +143,11 @@ class QgsMssqlProvider : public QgsVectorDataProvider
      */
     QString description() const override;
 
-    /**
-     * Return the extent for this data layer
-     */
-    virtual QgsRectangle extent() override;
+    virtual QgsRectangle extent() const override;
 
-    /**
-     * Returns true if this is a valid data source
-     */
-    bool isValid() override;
+    bool isValid() const override;
 
-    /**
-     * It returns true. Saving style to db is supported by this provider
-     */
-    virtual bool isSaveAndLoadStyleToDBSupported() override { return true; }
+    virtual bool isSaveAndLoadStyleToDBSupported() const override { return true; }
 
     /** Writes a list of features to the database*/
     virtual bool addFeatures( QgsFeatureList & flist ) override;
@@ -231,8 +189,7 @@ class QgsMssqlProvider : public QgsVectorDataProvider
     /** Convert values to quoted values for database work **/
     static QString quotedValue( const QVariant& value );
 
-    /** Returns the default value for field specified by @c fieldId */
-    QVariant defaultValue( int fieldId ) override;
+    QVariant defaultValue( int fieldId ) const override;
 
     /** Import a vector layer into the database */
     static QgsVectorLayerImport::ImportError createEmptyLayer(
@@ -246,7 +203,7 @@ class QgsMssqlProvider : public QgsVectorDataProvider
       const QMap<QString, QVariant> *options = nullptr
     );
 
-    virtual QgsCoordinateReferenceSystem crs() override;
+    virtual QgsCoordinateReferenceSystem crs() const override;
 
   protected:
     /** Loads fields from input file to member attributeFields */
@@ -260,10 +217,10 @@ class QgsMssqlProvider : public QgsVectorDataProvider
     QgsFields mAttributeFields;
     QMap<int, QVariant> mDefaultValues;
 
-    QgsMssqlGeometryParser mParser;
+    mutable QgsMssqlGeometryParser mParser;
 
     //! Layer extent
-    QgsRectangle mExtent;
+    mutable QgsRectangle mExtent;
 
     bool mValid;
 
@@ -273,7 +230,7 @@ class QgsMssqlProvider : public QgsVectorDataProvider
 
     long mNumberFeatures;
     QString mFidColName;
-    long mSRId;
+    mutable long mSRId;
     QString mGeometryColName;
     QString mGeometryColType;
 
@@ -281,9 +238,9 @@ class QgsMssqlProvider : public QgsVectorDataProvider
     QString mLastError;
 
     // Coordinate reference sytem
-    QgsCoordinateReferenceSystem mCrs;
+    mutable QgsCoordinateReferenceSystem mCrs;
 
-    QGis::WkbType mWkbType;
+    mutable QGis::WkbType mWkbType;
 
     // The database object
     QSqlDatabase mDatabase;

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -475,7 +475,7 @@ bool QgsOgrProvider::setSubsetString( const QString& theSQL, bool updateFeatureC
   return true;
 }
 
-QString QgsOgrProvider::subsetString()
+QString QgsOgrProvider::subsetString() const
 {
   return mSubsetString;
 }
@@ -932,7 +932,7 @@ void QgsOgrProviderUtils::setRelevantFields( OGRLayerH ogrLayer, int fieldCount,
 #endif
 }
 
-QgsFeatureIterator QgsOgrProvider::getFeatures( const QgsFeatureRequest& request )
+QgsFeatureIterator QgsOgrProvider::getFeatures( const QgsFeatureRequest& request ) const
 {
   return QgsFeatureIterator( new QgsOgrFeatureIterator( static_cast<QgsOgrFeatureSource*>( featureSource() ), true, request ) );
 }
@@ -954,7 +954,7 @@ unsigned char * QgsOgrProvider::getGeometryPointer( OGRFeatureH fet )
 }
 
 
-QgsRectangle QgsOgrProvider::extent()
+QgsRectangle QgsOgrProvider::extent() const
 {
   if ( !mExtent )
   {
@@ -1044,7 +1044,7 @@ const QgsFields & QgsOgrProvider::fields() const
 //TODO - add sanity check for shape file layers, to include cheking to
 //       see if the .shp, .dbf, .shx files are all present and the layer
 //       actually has features
-bool QgsOgrProvider::isValid()
+bool QgsOgrProvider::isValid() const
 {
   return mValid;
 }
@@ -2666,7 +2666,7 @@ QGISEXTERN bool createEmptyDataSource( const QString &uri,
   return true;
 }
 
-QgsCoordinateReferenceSystem QgsOgrProvider::crs()
+QgsCoordinateReferenceSystem QgsOgrProvider::crs() const
 {
   QgsDebugMsg( "Entering." );
 
@@ -2721,7 +2721,7 @@ QgsCoordinateReferenceSystem QgsOgrProvider::crs()
   return srs;
 }
 
-void QgsOgrProvider::uniqueValues( int index, QList<QVariant> &uniqueValues, int limit )
+void QgsOgrProvider::uniqueValues( int index, QList<QVariant> &uniqueValues, int limit ) const
 {
   uniqueValues.clear();
 
@@ -2770,7 +2770,7 @@ void QgsOgrProvider::uniqueValues( int index, QList<QVariant> &uniqueValues, int
 #endif
 }
 
-QVariant QgsOgrProvider::minimumValue( int index )
+QVariant QgsOgrProvider::minimumValue( int index ) const
 {
   if ( !mValid || index < 0 || index >= mAttributeFields.count() )
   {
@@ -2809,7 +2809,7 @@ QVariant QgsOgrProvider::minimumValue( int index )
   return value;
 }
 
-QVariant QgsOgrProvider::maximumValue( int index )
+QVariant QgsOgrProvider::maximumValue( int index ) const
 {
   if ( !mValid || index < 0 || index >= mAttributeFields.count() )
   {

--- a/src/providers/ogr/qgsogrprovider.h
+++ b/src/providers/ogr/qgsogrprovider.h
@@ -74,7 +74,7 @@ class QgsOgrProvider : public QgsVectorDataProvider
 
     virtual QgsAbstractFeatureSource* featureSource() const override;
 
-    virtual QgsCoordinateReferenceSystem crs() override;
+    virtual QgsCoordinateReferenceSystem crs() const override;
 
     /**
      * Sub-layers handled by this provider, in order from bottom to top
@@ -89,12 +89,11 @@ class QgsOgrProvider : public QgsVectorDataProvider
      */
     virtual QString storageType() const override;
 
-    virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest& request ) override;
+    virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest& request ) const override;
 
-    /** Accessor for sql where clause used to limit dataset */
-    virtual QString subsetString() override;
+    virtual QString subsetString() const override;
 
-    virtual bool supportsSubsetString() override { return true; }
+    virtual bool supportsSubsetString() const override { return true; }
 
     /** Mutator for sql where clause used to limit dataset size */
     virtual bool setSubsetString( const QString& theSQL, bool updateFeatureCount = true ) override;
@@ -123,9 +122,7 @@ class QgsOgrProvider : public QgsVectorDataProvider
      */
     virtual const QgsFields & fields() const override;
 
-    /** Return the extent for this data layer
-     */
-    virtual QgsRectangle extent() override;
+    virtual QgsRectangle extent() const override;
 
     /** Update the extents
      */
@@ -188,23 +185,23 @@ class QgsOgrProvider : public QgsVectorDataProvider
 
     /** Returns true if this is a valid shapefile
      */
-    bool isValid() override;
+    bool isValid() const override;
 
     /** Returns the minimum value of an attribute
      *  @param index the index of the attribute
      */
-    QVariant minimumValue( int index ) override;
+    QVariant minimumValue( int index ) const override;
 
     /** Returns the maximum value of an attribute
      *  @param index the index of the attribute
      */
-    QVariant maximumValue( int index ) override;
+    QVariant maximumValue( int index ) const override;
 
     /** Return the unique values of an attribute
      *  @param index the index of the attribute
      *  @param values reference to the list of unique values
      */
-    virtual void uniqueValues( int index, QList<QVariant> &uniqueValues, int limit = -1 ) override;
+    virtual void uniqueValues( int index, QList<QVariant> &uniqueValues, int limit = -1 ) const override;
 
     /** Return a provider name
      *
@@ -301,11 +298,11 @@ class QgsOgrProvider : public QgsVectorDataProvider
     QgsFields mAttributeFields;
     bool mFirstFieldIsFid;
     OGRDataSourceH ogrDataSource;
-    OGREnvelope* mExtent;
+    mutable OGREnvelope* mExtent;
 
     /** This member variable receives the same value as extent_
      in the method QgsOgrProvider::extent(). The purpose is to prevent a memory leak*/
-    QgsRectangle mExtentRect;
+    mutable QgsRectangle mExtentRect;
     OGRLayerH ogrLayer;
     OGRLayerH ogrOrigLayer;
 

--- a/src/providers/ows/qgsowsprovider.h
+++ b/src/providers/ows/qgsowsprovider.h
@@ -56,11 +56,11 @@ class QgsOwsProvider : public QgsDataProvider
 
     QString description() const override;
 
-    QgsCoordinateReferenceSystem crs() override { return QgsCoordinateReferenceSystem(); }
+    QgsCoordinateReferenceSystem crs() const override { return QgsCoordinateReferenceSystem(); }
 
-    QgsRectangle extent() override { return QgsRectangle(); }
+    QgsRectangle extent() const override { return QgsRectangle(); }
 
-    bool isValid() override { return false; }
+    bool isValid() const override { return false; }
 };
 
 #endif // QGSOWSPROVIDER_H

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -402,7 +402,7 @@ static bool operator<( const QVariant &a, const QVariant &b )
 }
 #endif
 
-QgsFeatureIterator QgsPostgresProvider::getFeatures( const QgsFeatureRequest& request )
+QgsFeatureIterator QgsPostgresProvider::getFeatures( const QgsFeatureRequest& request ) const
 {
   if ( !mValid )
   {
@@ -1489,7 +1489,7 @@ bool QgsPostgresProvider::uniqueData( const QString& quotedColNames )
 }
 
 // Returns the minimum value of an attribute
-QVariant QgsPostgresProvider::minimumValue( int index )
+QVariant QgsPostgresProvider::minimumValue( int index ) const
 {
   try
   {
@@ -1516,7 +1516,7 @@ QVariant QgsPostgresProvider::minimumValue( int index )
 }
 
 // Returns the list of unique values of an attribute
-void QgsPostgresProvider::uniqueValues( int index, QList<QVariant> &uniqueValues, int limit )
+void QgsPostgresProvider::uniqueValues( int index, QList<QVariant> &uniqueValues, int limit ) const
 {
   uniqueValues.clear();
 
@@ -1554,7 +1554,7 @@ void QgsPostgresProvider::uniqueValues( int index, QList<QVariant> &uniqueValues
   }
 }
 
-void QgsPostgresProvider::enumValues( int index, QStringList& enumList )
+void QgsPostgresProvider::enumValues( int index, QStringList& enumList ) const
 {
   enumList.clear();
 
@@ -1664,7 +1664,7 @@ bool QgsPostgresProvider::parseDomainCheckConstraint( QStringList& enumValues, c
 }
 
 // Returns the maximum value of an attribute
-QVariant QgsPostgresProvider::maximumValue( int index )
+QVariant QgsPostgresProvider::maximumValue( int index ) const
 {
   try
   {
@@ -1692,12 +1692,12 @@ QVariant QgsPostgresProvider::maximumValue( int index )
 }
 
 
-bool QgsPostgresProvider::isValid()
+bool QgsPostgresProvider::isValid() const
 {
   return mValid;
 }
 
-QVariant QgsPostgresProvider::defaultValue( int fieldId )
+QVariant QgsPostgresProvider::defaultValue( int fieldId ) const
 {
   QVariant defVal = mDefaultValues.value( fieldId, QString::null );
 
@@ -2821,7 +2821,7 @@ bool QgsPostgresProvider::changeFeatures( const QgsChangedAttributesMap &attr_ma
   return returnvalue;
 }
 
-QgsAttributeList QgsPostgresProvider::attributeIndexes()
+QgsAttributeList QgsPostgresProvider::attributeIndexes() const
 {
   QgsAttributeList lst;
   lst.reserve( mAttributeFields.count() );
@@ -2920,7 +2920,7 @@ long QgsPostgresProvider::featureCount() const
   return num;
 }
 
-QgsRectangle QgsPostgresProvider::extent()
+QgsRectangle QgsPostgresProvider::extent() const
 {
   if ( mGeometryColumn.isNull() )
     return QgsRectangle();
@@ -3738,7 +3738,7 @@ QgsVectorLayerImport::ImportError QgsPostgresProvider::createEmptyLayer(
   return QgsVectorLayerImport::NoError;
 }
 
-QgsCoordinateReferenceSystem QgsPostgresProvider::crs()
+QgsCoordinateReferenceSystem QgsPostgresProvider::crs() const
 {
   QgsCoordinateReferenceSystem srs;
   int srid = mRequestedSrid.isEmpty() ? mDetectedSrid.toInt() : mRequestedSrid.toInt();
@@ -3752,7 +3752,7 @@ QgsCoordinateReferenceSystem QgsPostgresProvider::crs()
   return srs;
 }
 
-QString QgsPostgresProvider::subsetString()
+QString QgsPostgresProvider::subsetString() const
 {
   return mSqlWhereClause;
 }

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -83,14 +83,9 @@ class QgsPostgresProvider : public QgsVectorDataProvider
       */
     virtual QString storageType() const override;
 
-    /** Get the QgsCoordinateReferenceSystem for this layer
-     * @note Must be reimplemented by each provider.
-     * If the provider isn't capable of returning
-     * its projection an empty srs will be returned
-     */
-    virtual QgsCoordinateReferenceSystem crs() override;
+    virtual QgsCoordinateReferenceSystem crs() const override;
 
-    virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest& request ) override;
+    virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest& request ) const override;
 
     /** Get the feature type. This corresponds to
      * WKBPoint,
@@ -124,9 +119,7 @@ class QgsPostgresProvider : public QgsVectorDataProvider
      */
     void setExtent( QgsRectangle& newExtent );
 
-    /** Return the extent for this data layer
-     */
-    virtual QgsRectangle extent() override;
+    virtual QgsRectangle extent() const override;
 
     /** Update the extent
      */
@@ -152,40 +145,15 @@ class QgsPostgresProvider : public QgsVectorDataProvider
      */
     QString dataComment() const override;
 
-    /** Returns the minimum value of an attribute
-     *  @param index the index of the attribute */
-    QVariant minimumValue( int index ) override;
-
-    /** Returns the maximum value of an attribute
-     *  @param index the index of the attribute */
-    QVariant maximumValue( int index ) override;
-
-    /** Return the unique values of an attribute
-     *  @param index the index of the attribute
-     *  @param values reference to the list of unique values */
-    virtual void uniqueValues( int index, QList<QVariant> &uniqueValues, int limit = -1 ) override;
-
-    /** Returns the possible enum values of an attribute. Returns an empty stringlist if a provider does not support enum types
-      or if the given attribute is not an enum type.
-     * @param index the index of the attribute
-     * @param enumList reference to the list to fill */
-    virtual void enumValues( int index, QStringList& enumList ) override;
-
-    /** Returns true if layer is valid
-     */
-    bool isValid() override;
-
-    /**
-     * It returns true. Saving style to db is supported by this provider
-     */
-    virtual bool isSaveAndLoadStyleToDBSupported() override { return true; }
-
-    QgsAttributeList attributeIndexes() override;
-
-    QgsAttributeList pkAttributeIndexes() override { return mPrimaryKeyAttrs; }
-
-    /** Returns the default value for field specified by @c fieldId */
-    QVariant defaultValue( int fieldId ) override;
+    QVariant minimumValue( int index ) const override;
+    QVariant maximumValue( int index ) const override;
+    virtual void uniqueValues( int index, QList<QVariant> &uniqueValues, int limit = -1 ) const override;
+    virtual void enumValues( int index, QStringList& enumList ) const override;
+    bool isValid() const override;
+    virtual bool isSaveAndLoadStyleToDBSupported() const override { return true; }
+    QgsAttributeList attributeIndexes() const override;
+    QgsAttributeList pkAttributeIndexes() const override { return mPrimaryKeyAttrs; }
+    QVariant defaultValue( int fieldId ) const override;
 
     /** Adds a list of features
       @return true in case of success and false in case of failure*/
@@ -230,13 +198,12 @@ class QgsPostgresProvider : public QgsVectorDataProvider
     //! Get the table name associated with this provider instance
     QString getTableName();
 
-    /** Accessor for sql where clause used to limit dataset */
-    QString subsetString() override;
+    QString subsetString() const override;
 
     /** Mutator for sql where clause used to limit dataset size */
     bool setSubsetString( const QString& theSQL, bool updateFeatureCount = true ) override;
 
-    virtual bool supportsSubsetString() override { return true; }
+    virtual bool supportsSubsetString() const override { return true; }
 
     /** Returns a bitmask containing the supported capabilities*/
     int capabilities() const override;
@@ -413,7 +380,7 @@ class QgsPostgresProvider : public QgsVectorDataProvider
     QString mPrimaryKeyDefault;
 
     QString mGeometryColumn;          //! name of the geometry column
-    QgsRectangle mLayerExtent;        //! Rectangle that contains the extent (bounding box) of the layer
+    mutable QgsRectangle mLayerExtent;        //! Rectangle that contains the extent (bounding box) of the layer
 
     QGis::WkbType mDetectedGeomType;  //! geometry type detected in the database
     bool mForce2d;                    //! geometry type needs to be forced to 2d (eg. ZM)

--- a/src/providers/spatialite/qgsspatialiteprovider.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovider.cpp
@@ -978,7 +978,7 @@ QString QgsSpatiaLiteProvider::storageType() const
   return "SQLite database with SpatiaLite extension";
 }
 
-QgsFeatureIterator QgsSpatiaLiteProvider::getFeatures( const QgsFeatureRequest& request )
+QgsFeatureIterator QgsSpatiaLiteProvider::getFeatures( const QgsFeatureRequest& request ) const
 {
   if ( !mValid )
   {
@@ -3256,7 +3256,7 @@ int QgsSpatiaLiteProvider::computeMultiWKB3Dsize( const unsigned char *p_in, int
   return size;
 }
 
-QString QgsSpatiaLiteProvider::subsetString()
+QString QgsSpatiaLiteProvider::subsetString() const
 {
   return mSubsetString;
 }
@@ -3292,7 +3292,7 @@ bool QgsSpatiaLiteProvider::setSubsetString( const QString& theSQL, bool updateF
 }
 
 
-QgsRectangle QgsSpatiaLiteProvider::extent()
+QgsRectangle QgsSpatiaLiteProvider::extent() const
 {
   return mLayerExtent;
 }
@@ -3325,7 +3325,7 @@ long QgsSpatiaLiteProvider::featureCount() const
 }
 
 
-QgsCoordinateReferenceSystem QgsSpatiaLiteProvider::crs()
+QgsCoordinateReferenceSystem QgsSpatiaLiteProvider::crs() const
 {
   QgsCoordinateReferenceSystem srs = QgsCRSCache::instance()->crsByOgcWmsCrs( mAuthId );
   if ( !srs.isValid() )
@@ -3348,7 +3348,7 @@ QgsCoordinateReferenceSystem QgsSpatiaLiteProvider::crs()
 }
 
 
-bool QgsSpatiaLiteProvider::isValid()
+bool QgsSpatiaLiteProvider::isValid() const
 {
   return mValid;
 }
@@ -3371,7 +3371,7 @@ const QgsFields& QgsSpatiaLiteProvider::fields() const
 }
 
 // Returns the minimum value of an attribute
-QVariant QgsSpatiaLiteProvider::minimumValue( int index )
+QVariant QgsSpatiaLiteProvider::minimumValue( int index ) const
 {
   int ret;
   int i;
@@ -3434,7 +3434,7 @@ QVariant QgsSpatiaLiteProvider::minimumValue( int index )
 }
 
 // Returns the maximum value of an attribute
-QVariant QgsSpatiaLiteProvider::maximumValue( int index )
+QVariant QgsSpatiaLiteProvider::maximumValue( int index ) const
 {
   int ret;
   int i;
@@ -3498,7 +3498,7 @@ QVariant QgsSpatiaLiteProvider::maximumValue( int index )
 }
 
 // Returns the list of unique values of an attribute
-void QgsSpatiaLiteProvider::uniqueValues( int index, QList < QVariant > &uniqueValues, int limit )
+void QgsSpatiaLiteProvider::uniqueValues( int index, QList < QVariant > &uniqueValues, int limit ) const
 {
   sqlite3_stmt *stmt = nullptr;
   QString sql;
@@ -5246,7 +5246,7 @@ QGISEXTERN bool deleteLayer( const QString& dbPath, const QString& tableName, QS
   return true;
 }
 
-QgsAttributeList QgsSpatiaLiteProvider::pkAttributeIndexes()
+QgsAttributeList QgsSpatiaLiteProvider::pkAttributeIndexes() const
 {
   return mPrimaryKeyAttrs;
 }

--- a/src/providers/spatialite/qgsspatialiteprovider.h
+++ b/src/providers/spatialite/qgsspatialiteprovider.h
@@ -85,17 +85,16 @@ class QgsSpatiaLiteProvider: public QgsVectorDataProvider
      * If the provider isn't capable of returning
      * its projection an empty srs will be return, ti will return 0
      */
-    virtual QgsCoordinateReferenceSystem crs() override;
+    virtual QgsCoordinateReferenceSystem crs() const override;
 
-    virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest& request ) override;
+    virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest& request ) const override;
 
-    /** Accessor for sql where clause used to limit dataset */
-    virtual QString subsetString() override;
+    virtual QString subsetString() const override;
 
     /** Mutator for sql where clause used to limit dataset size */
     virtual bool setSubsetString( const QString& theSQL, bool updateFeatureCount = true ) override;
 
-    virtual bool supportsSubsetString() override { return true; }
+    virtual bool supportsSubsetString() const override { return true; }
 
     /** Get the feature type. This corresponds to
      * WKBPoint,
@@ -119,9 +118,7 @@ class QgsSpatiaLiteProvider: public QgsVectorDataProvider
      */
     long featureCount() const override;
 
-    /** Return the extent for this data layer
-     */
-    virtual QgsRectangle extent() override;
+    virtual QgsRectangle extent() const override;
 
     /** Update the extent for this data layer
      */
@@ -133,27 +130,12 @@ class QgsSpatiaLiteProvider: public QgsVectorDataProvider
       */
     const QgsFields & fields() const override;
 
-    /** Returns the minimum value of an attribute
-     *  @param index the index of the attribute */
-    QVariant minimumValue( int index ) override;
+    QVariant minimumValue( int index ) const override;
+    QVariant maximumValue( int index ) const override;
+    virtual void uniqueValues( int index, QList < QVariant > &uniqueValues, int limit = -1 ) const override;
 
-    /** Returns the maximum value of an attribute
-     *  @param index the index of the attribute */
-    QVariant maximumValue( int index ) override;
-
-    /** Return the unique values of an attribute
-     *  @param index the index of the attribute
-     *  @param values reference to the list of unique values
-     *  @param limit maximum number of values */
-    virtual void uniqueValues( int index, QList < QVariant > &uniqueValues, int limit = -1 ) override;
-
-    /** Returns true if layer is valid
-     */
-    bool isValid() override;
-
-    /** Describes if provider has save and load style support
-       @return true in case saving style to db is supported by this provider*/
-    virtual bool isSaveAndLoadStyleToDBSupported() override { return true; }
+    bool isValid() const override;
+    virtual bool isSaveAndLoadStyleToDBSupported() const override { return true; }
 
     /** Adds a list of features
       @return true in case of success and false in case of failure*/
@@ -226,11 +208,7 @@ class QgsSpatiaLiteProvider: public QgsVectorDataProvider
      *
      */
     QString description() const override;
-
-    /**
-     * Return list of indexes of fields that make up the primary key
-     */
-    QgsAttributeList pkAttributeIndexes() override;
+    QgsAttributeList pkAttributeIndexes() const override;
 
     void invalidateConnections( const QString& connection ) override;
 

--- a/src/providers/virtual/qgsvirtuallayerprovider.cpp
+++ b/src/providers/virtual/qgsvirtuallayerprovider.cpp
@@ -475,17 +475,17 @@ QString QgsVirtualLayerProvider::storageType() const
   return "No storage per se, view data from other data sources";
 }
 
-QgsCoordinateReferenceSystem QgsVirtualLayerProvider::crs()
+QgsCoordinateReferenceSystem QgsVirtualLayerProvider::crs() const
 {
   return mCrs;
 }
 
-QgsFeatureIterator QgsVirtualLayerProvider::getFeatures( const QgsFeatureRequest& request )
+QgsFeatureIterator QgsVirtualLayerProvider::getFeatures( const QgsFeatureRequest& request ) const
 {
   return QgsFeatureIterator( new QgsVirtualLayerFeatureIterator( new QgsVirtualLayerFeatureSource( this ), false, request ) );
 }
 
-QString QgsVirtualLayerProvider::subsetString()
+QString QgsVirtualLayerProvider::subsetString() const
 {
   return mSubset;
 }
@@ -514,7 +514,7 @@ long QgsVirtualLayerProvider::featureCount() const
   return mFeatureCount;
 }
 
-QgsRectangle QgsVirtualLayerProvider::extent()
+QgsRectangle QgsVirtualLayerProvider::extent() const
 {
   if ( !mCachedStatistics )
   {
@@ -558,7 +558,7 @@ const QgsFields & QgsVirtualLayerProvider::fields() const
   return mDefinition.fields();
 }
 
-bool QgsVirtualLayerProvider::isValid()
+bool QgsVirtualLayerProvider::isValid() const
 {
   return mValid;
 }
@@ -582,7 +582,7 @@ QString QgsVirtualLayerProvider::description() const
   return VIRTUAL_LAYER_DESCRIPTION;
 }
 
-QgsAttributeList QgsVirtualLayerProvider::pkAttributeIndexes()
+QgsAttributeList QgsVirtualLayerProvider::pkAttributeIndexes() const
 {
   if ( !mDefinition.uid().isNull() )
   {

--- a/src/providers/virtual/qgsvirtuallayerprovider.h
+++ b/src/providers/virtual/qgsvirtuallayerprovider.h
@@ -44,11 +44,9 @@ class QgsVirtualLayerProvider: public QgsVectorDataProvider
     /** Returns the permanent storage type for this layer as a friendly name */
     virtual QString storageType() const override;
 
-    /** Get the QgsCoordinateReferenceSystem for this layer */
-    virtual QgsCoordinateReferenceSystem crs() override;
+    virtual QgsCoordinateReferenceSystem crs() const override;
 
-    /** Access features through an iterator */
-    virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest& request ) override;
+    virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest& request ) const override;
 
     /** Get the feature geometry type */
     QGis::WkbType geometryType() const override;
@@ -56,17 +54,14 @@ class QgsVirtualLayerProvider: public QgsVectorDataProvider
     /** Get the number of features in the layer */
     long featureCount() const override;
 
-    /** Return the extent for this data layer */
-    virtual QgsRectangle extent() override;
+    virtual QgsRectangle extent() const override;
 
-    /** Accessor for sql where clause used to limit dataset */
-    virtual QString subsetString() override;
+    virtual QString subsetString() const override;
 
     /** Set the subset string used to create a subset of features in the layer (WHERE clause) */
     virtual bool setSubsetString( const QString& subset, bool updateFeatureCount = true ) override;
 
-    /** Provider supports setting of subset strings */
-    virtual bool supportsSubsetString() override { return true; }
+    virtual bool supportsSubsetString() const override { return true; }
 
     /**
      * Get the field information for the layer
@@ -74,8 +69,7 @@ class QgsVirtualLayerProvider: public QgsVectorDataProvider
      */
     const QgsFields & fields() const override;
 
-    /** Returns true if layer is valid */
-    bool isValid() override;
+    bool isValid() const override;
 
     /** Returns a bitmask containing the supported capabilities*/
     int capabilities() const override;
@@ -86,8 +80,7 @@ class QgsVirtualLayerProvider: public QgsVectorDataProvider
     /** Return description  */
     QString description() const override;
 
-    /** Return list of indexes of fields that make up the primary key */
-    QgsAttributeList pkAttributeIndexes() override;
+    QgsAttributeList pkAttributeIndexes() const override;
 
     /** Get the list of layer ids on which this layer depends */
     QSet<QString> layerDependencies() const override;

--- a/src/providers/wcs/qgswcsprovider.cpp
+++ b/src/providers/wcs/qgswcsprovider.cpp
@@ -502,7 +502,7 @@ void QgsWcsProvider::setCoverageCrs( QString const & crs )
   }
 }
 
-void QgsWcsProvider::setQueryItem( QUrl &url, const QString& item, const QString& value )
+void QgsWcsProvider::setQueryItem( QUrl &url, const QString& item, const QString& value ) const
 {
   url.removeQueryItem( item );
   url.addQueryItem( item, value );
@@ -627,7 +627,7 @@ void QgsWcsProvider::readBlock( int bandNo, QgsRectangle  const & viewExtent, in
   }
 }
 
-void QgsWcsProvider::getCache( int bandNo, QgsRectangle  const & viewExtent, int pixelWidth, int pixelHeight, QString crs )
+void QgsWcsProvider::getCache( int bandNo, QgsRectangle  const & viewExtent, int pixelWidth, int pixelHeight, QString crs ) const
 {
   Q_UNUSED( bandNo );
   // delete cached data
@@ -892,7 +892,7 @@ int QgsWcsProvider::yBlockSize() const
 int QgsWcsProvider::xSize() const { return mWidth; }
 int QgsWcsProvider::ySize() const { return mHeight; }
 
-void QgsWcsProvider::clearCache()
+void QgsWcsProvider::clearCache() const
 {
   if ( mCachedGdalDataset )
   {
@@ -1049,7 +1049,7 @@ void QgsWcsProvider::parseServiceException( QDomElement const & e, const QString
 
 
 
-QgsRectangle QgsWcsProvider::extent()
+QgsRectangle QgsWcsProvider::extent() const
 {
   if ( mExtentDirty )
   {
@@ -1062,7 +1062,7 @@ QgsRectangle QgsWcsProvider::extent()
   return mCoverageExtent;
 }
 
-bool QgsWcsProvider::isValid()
+bool QgsWcsProvider::isValid() const
 {
   return mValid;
 }
@@ -1073,7 +1073,7 @@ QString QgsWcsProvider::wcsVersion()
   return mCapabilities.version();
 }
 
-bool QgsWcsProvider::calculateExtent()
+bool QgsWcsProvider::calculateExtent() const
 {
 
   // Make sure we know what extents are available
@@ -1533,7 +1533,7 @@ QgsRasterIdentifyResult QgsWcsProvider::identify( const QgsPoint & thePoint, Qgs
   return QgsRasterIdentifyResult( QgsRaster::IdentifyFormatValue, results );
 }
 
-QgsCoordinateReferenceSystem QgsWcsProvider::crs()
+QgsCoordinateReferenceSystem QgsWcsProvider::crs() const
 {
   return mCrs;
 }

--- a/src/providers/wcs/qgswcsprovider.h
+++ b/src/providers/wcs/qgswcsprovider.h
@@ -109,12 +109,7 @@ class QgsWcsProvider : public QgsRasterDataProvider, QgsGdalProviderBase
 
     QgsWcsProvider * clone() const override;
 
-    /** Get the QgsCoordinateReferenceSystem for this layer
-     * @note Must be reimplemented by each provider.
-     * If the provider isn't capable of returning
-     * its projection an empty srs will be return, ti will return 0
-     */
-    virtual QgsCoordinateReferenceSystem crs() override;
+    virtual QgsCoordinateReferenceSystem crs() const override;
 
     /**
      * Get the coverage format used in the transfer from the WCS server
@@ -154,15 +149,11 @@ class QgsWcsProvider : public QgsRasterDataProvider, QgsGdalProviderBase
     void readBlock( int theBandNo, int xBlock, int yBlock, void *block ) override;
 
     /** Download cache */
-    void getCache( int bandNo, QgsRectangle  const & viewExtent, int width, int height, QString crs = "" );
+    void getCache( int bandNo, QgsRectangle  const & viewExtent, int width, int height, QString crs = "" ) const;
 
-    /** Return the extent for this data layer
-     */
-    virtual QgsRectangle extent() override;
+    virtual QgsRectangle extent() const override;
 
-    /** Returns true if layer is valid
-     */
-    bool isValid() override;
+    bool isValid() const override;
 
     /** Returns the base url
      */
@@ -223,7 +214,7 @@ class QgsWcsProvider : public QgsRasterDataProvider, QgsGdalProviderBase
      * \retval false if the capabilities document could not be retrieved or parsed -
      *         see lastError() for more info
      */
-    bool calculateExtent();
+    bool calculateExtent() const;
 
     /**
      * \brief Check for parameters in the uri,
@@ -245,10 +236,10 @@ class QgsWcsProvider : public QgsRasterDataProvider, QgsGdalProviderBase
     QString coverageMetadata( const QgsWcsCoverageSummary& c );
 
     //! remove query item and replace it with a new value
-    void setQueryItem( QUrl &url, const QString& key, const QString& value );
+    void setQueryItem( QUrl &url, const QString& key, const QString& value ) const;
 
     //! Release cache resources
-    void clearCache();
+    void clearCache() const;
 
     //! Create html cell (used by metadata)
     QString htmlCell( const QString &text );
@@ -286,7 +277,7 @@ class QgsWcsProvider : public QgsRasterDataProvider, QgsGdalProviderBase
     QString mSrid;
 
     /** Rectangle that contains the extent (bounding box) of the layer */
-    QgsRectangle mCoverageExtent;
+    mutable QgsRectangle mCoverageExtent;
 
     /** Coverage width, may be 0 if it could not be found in DescribeCoverage */
     int mWidth;
@@ -339,27 +330,27 @@ class QgsWcsProvider : public QgsRasterDataProvider, QgsGdalProviderBase
     QString mCoverageCrs;
 
     /** Cached data */
-    QByteArray mCachedData;
+    mutable QByteArray mCachedData;
 
     /** Name of memory file for cached data */
     QString mCachedMemFilename;
 
 #if defined(GDAL_VERSION_NUM) && GDAL_VERSION_NUM >= 1800
-    VSILFILE * mCachedMemFile;
+    mutable VSILFILE * mCachedMemFile;
 #else
-    FILE * mCachedMemFile;
+    mutable FILE * mCachedMemFile;
 #endif
 
     /** Pointer to cached GDAL dataset */
-    GDALDatasetH mCachedGdalDataset;
+    mutable GDALDatasetH mCachedGdalDataset;
 
     /** Current cache error last getCache() error. */
-    QgsError mCachedError;
+    mutable QgsError mCachedError;
 
     /** The previous parameters to draw(). */
-    QgsRectangle mCachedViewExtent;
-    int mCachedViewWidth;
-    int mCachedViewHeight;
+    mutable QgsRectangle mCachedViewExtent;
+    mutable int mCachedViewWidth;
+    mutable int mCachedViewHeight;
 
     /** Maximum width and height of getmap requests */
     int mMaxWidth;
@@ -376,10 +367,10 @@ class QgsWcsProvider : public QgsRasterDataProvider, QgsGdalProviderBase
     QString mErrorFormat;
 
     //! A QgsCoordinateTransform is used for transformation of WCS layer extents
-    QgsCoordinateTransform *mCoordinateTransform;
+    mutable QgsCoordinateTransform *mCoordinateTransform;
 
     //! See if calculateExtents() needs to be called before extent() returns useful data
-    bool mExtentDirty;
+    mutable bool mExtentDirty;
 
     //! Base URL for WCS GetFeatureInfo requests
     QString mGetFeatureInfoUrlBase;
@@ -394,7 +385,7 @@ class QgsWcsProvider : public QgsRasterDataProvider, QgsGdalProviderBase
     int mErrors;
 
     //! http authorization details
-    QgsWcsAuthorization mAuth;
+    mutable QgsWcsAuthorization mAuth;
 
     //! whether to use hrefs from GetCapabilities (default) or
     // the given base urls for GetMap and GetFeatureInfo

--- a/src/providers/wfs/qgswfsprovider.cpp
+++ b/src/providers/wfs/qgswfsprovider.cpp
@@ -649,7 +649,7 @@ void QgsWFSProvider::featureReceivedAnalyzeOneFeature( QVector<QgsWFSFeatureGmlI
   }
 }
 
-QString QgsWFSProvider::subsetString()
+QString QgsWFSProvider::subsetString() const
 {
   return mSubsetString;
 }
@@ -734,12 +734,12 @@ QString QgsWFSProvider::geometryAttribute() const
   return mShared->mGeometryAttribute;
 }
 
-QgsCoordinateReferenceSystem QgsWFSProvider::crs()
+QgsCoordinateReferenceSystem QgsWFSProvider::crs() const
 {
   return mShared->mSourceCRS;
 }
 
-QgsRectangle QgsWFSProvider::extent()
+QgsRectangle QgsWFSProvider::extent() const
 {
   // Some servers return completely buggy extent in their capabilities response
   // so mix it with the extent actually got from the downloaded features
@@ -766,12 +766,12 @@ QgsRectangle QgsWFSProvider::extent()
   return computedExtent;
 }
 
-bool QgsWFSProvider::isValid()
+bool QgsWFSProvider::isValid() const
 {
   return mValid;
 }
 
-QgsFeatureIterator QgsWFSProvider::getFeatures( const QgsFeatureRequest& request )
+QgsFeatureIterator QgsWFSProvider::getFeatures( const QgsFeatureRequest& request ) const
 {
   return QgsFeatureIterator( new QgsWFSFeatureIterator( new QgsWFSFeatureSource( this ), true, request ) );
 }

--- a/src/providers/wfs/qgswfsprovider.h
+++ b/src/providers/wfs/qgswfsprovider.h
@@ -69,27 +69,26 @@ class QgsWFSProvider : public QgsVectorDataProvider
 
     virtual QgsAbstractFeatureSource* featureSource() const override;
 
-    QgsFeatureIterator getFeatures( const QgsFeatureRequest& request = QgsFeatureRequest() ) override;
+    QgsFeatureIterator getFeatures( const QgsFeatureRequest& request = QgsFeatureRequest() ) const override;
 
     QGis::WkbType geometryType() const override;
     long featureCount() const override;
 
     const QgsFields& fields() const override;
 
-    virtual QgsCoordinateReferenceSystem crs() override;
+    virtual QgsCoordinateReferenceSystem crs() const override;
 
-    /** Accessor for sql where clause used to limit dataset */
-    virtual QString subsetString() override;
+    virtual QString subsetString() const override;
 
     /** Mutator for sql where clause used to limit dataset size */
     virtual bool setSubsetString( const QString& theSQL, bool updateFeatureCount = true ) override;
 
-    virtual bool supportsSubsetString() override { return true; }
+    virtual bool supportsSubsetString() const override { return true; }
 
     /* Inherited from QgsDataProvider */
 
-    QgsRectangle extent() override;
-    bool isValid() override;
+    QgsRectangle extent() const override;
+    bool isValid() const override;
     QString name() const override;
     QString description() const override;
 

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -959,7 +959,7 @@ static const QgsWmsLayerProperty* _findNestedLayerProperty( const QString& layer
 }
 
 
-bool QgsWmsProvider::extentForNonTiledLayer( const QString& layerName, const QString& crs, QgsRectangle& extent )
+bool QgsWmsProvider::extentForNonTiledLayer( const QString& layerName, const QString& crs, QgsRectangle& extent ) const
 {
   const QgsWmsLayerProperty* layerProperty = nullptr;
   Q_FOREACH ( const QgsWmsLayerProperty& toplevelLayer, mCaps.mCapabilities.capability.layers )
@@ -1176,7 +1176,7 @@ void QgsWmsProvider::parseServiceException( QDomElement const & e, QString& erro
   QgsDebugMsg( QString( "exiting with composed error message '%1'." ).arg( errorText ) );
 }
 
-QgsRectangle QgsWmsProvider::extent()
+QgsRectangle QgsWmsProvider::extent() const
 {
   if ( mExtentDirty )
   {
@@ -1189,7 +1189,7 @@ QgsRectangle QgsWmsProvider::extent()
   return mLayerExtent;
 }
 
-bool QgsWmsProvider::isValid()
+bool QgsWmsProvider::isValid() const
 {
   return mValid;
 }
@@ -1213,7 +1213,7 @@ QStringList QgsWmsProvider::subLayerStyles() const
   return mSettings.mActiveSubStyles;
 }
 
-bool QgsWmsProvider::calculateExtent()
+bool QgsWmsProvider::calculateExtent() const
 {
   //! \todo Make this handle non-geographic CRSs (e.g. floor plans) as per WMS spec
 
@@ -2854,7 +2854,7 @@ void QgsWmsProvider::identifyReplyFinished()
 }
 
 
-QgsCoordinateReferenceSystem QgsWmsProvider::crs()
+QgsCoordinateReferenceSystem QgsWmsProvider::crs() const
 {
   return mCrs;
 }

--- a/src/providers/wms/qgswmsprovider.h
+++ b/src/providers/wms/qgswmsprovider.h
@@ -127,13 +127,7 @@ class QgsWmsProvider : public QgsRasterDataProvider
 
     QgsWmsProvider * clone() const override;
 
-
-    /** Get the QgsCoordinateReferenceSystem for this layer
-     * @note Must be reimplemented by each provider.
-     * If the provider isn't capable of returning
-     * its projection an empty srs will be return, ti will return 0
-     */
-    virtual QgsCoordinateReferenceSystem crs() override;
+    virtual QgsCoordinateReferenceSystem crs() const override;
 
     /**
      * Reorder the list of WMS layer names to be rendered by this server
@@ -171,14 +165,9 @@ class QgsWmsProvider : public QgsRasterDataProvider
     void readBlock( int bandNo, QgsRectangle  const & viewExtent, int width, int height, void *data ) override;
     //void readBlock( int bandNo, QgsRectangle  const & viewExtent, int width, int height, QgsCoordinateReferenceSystem theSrcCRS, QgsCoordinateReferenceSystem theDestCRS, void *data );
 
+    virtual QgsRectangle extent() const override;
 
-    /** Return the extent for this data layer
-     */
-    virtual QgsRectangle extent() override;
-
-    /** Returns true if layer is valid
-     */
-    bool isValid() override;
+    bool isValid() const override;
 
 #if 0
     /** Returns true if layer has tile set profiles
@@ -376,7 +365,7 @@ class QgsWmsProvider : public QgsRasterDataProvider
     /**
      * Try to get best extent for the layer in given CRS. Returns true on success, false otherwise (layer not found, invalid CRS, transform failed)
      */
-    bool extentForNonTiledLayer( const QString& layerName, const QString& crs, QgsRectangle& extent );
+    bool extentForNonTiledLayer( const QString& layerName, const QString& crs, QgsRectangle& extent ) const;
 
     // case insensitive attribute value lookup
     static QString nodeAttribute( const QDomElement &e, const QString& name, const QString& defValue = QString::null );
@@ -419,7 +408,7 @@ class QgsWmsProvider : public QgsRasterDataProvider
      * \retval false if the capabilities document could not be retrieved or parsed -
      *         see lastError() for more info
      */
-    bool calculateExtent();
+    bool calculateExtent() const;
 
     /* \brief Bounding box in WMS format
      *
@@ -465,7 +454,7 @@ class QgsWmsProvider : public QgsRasterDataProvider
     /**
      * Rectangle that contains the extent (bounding box) of the layer
      */
-    QgsRectangle mLayerExtent;
+    mutable QgsRectangle mLayerExtent;
 
     /**
      * GetLegendGraphic of the WMS (raw)
@@ -544,7 +533,7 @@ class QgsWmsProvider : public QgsRasterDataProvider
     QgsCoordinateTransform *mCoordinateTransform;
 
     //! See if calculateExtents() needs to be called before extent() returns useful data
-    bool mExtentDirty;
+    mutable bool mExtentDirty;
 
     QString mServiceMetadataURL;
 


### PR DESCRIPTION
This PR marks numerous QgsDataProvider, QgsVectorDataProvider and QgsRasterLayer methods correctly as const.

It partly addresses https://github.com/qgis/qgis3.0_api/issues/48

Note that many individual data provider members have been marked as mutable as a consequence - I think this is acceptable, as it's semantically correct. These methods _should_ be marked const, and it's valid to make any cached variables which are altered as a result mutable. 
