### PR TITLE
QgsMapLayer, QgsVectorLayer, QgsRasterLayer const correct + cleanups

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -26,7 +26,7 @@ This page tries to maintain a list with incompatible changes that happened in pr
 <li>toggleScaleBasedVisibility() was replaced by setScaleBasedVisibility()</li>
 <li>lastErrorTitle(), lastError(), cacheImage(), onCacheImageDelete(), clearCacheImage() and the signals drawingProgress(),
 screenUpdateRequested() were removed. These members have had no effect for a number of QGIS 2.x releases.</li>
-<li>extent(), styleURI(), exportNamedStyle(), exportSldStyle(), writeXml() were made const. This has no effect on PyQGIS code, but c++ code implementing derived layer classes will need to update the signatures of these methods to match.</li>
+<li>extent(), styleURI(), exportNamedStyle(), exportSldStyle(), writeXml(), metadata() were made const. This has no effect on PyQGIS code, but c++ code implementing derived layer classes will need to update the signatures of these methods to match.</li>
 <li>The lyrname parameter in the QgsMapLayer constructor was renamed to 'name'.</li>
 <li>The vis parameter in setSubLayerVisibility was renamed to 'visible'.</li>
 <li>theResultFlag parameter in loadDefaultStyle and saveDefaultStyle were renamed to resultFlag.</li>

--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -29,6 +29,15 @@ screenUpdateRequested() were removed. These members have had no effect for a num
 
 </ul>
 
+\subsection qgis_api_break_3_0_QgsVectorLayerEditBuffer QgsVectorLayerEditBuffer
+
+<ul>
+<li>The addedFeatures(), changedAttributeValues(), deletedAttributeIds(), addedAttributes(), changedGeometries()
+and deletedFeatureIds() functions now return values, not references. This has no effect on PyQGIS code, but c++
+plugins calling these methods will need to be updated.</li>
+</ul>
+
+
 
 \section qgis_api_break_2_4 QGIS 2.4
 

--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -37,8 +37,12 @@ screenUpdateRequested() were removed. These members have had no effect for a num
 <li>theError parameter in appendError() and setError() were renamed to 'error'.</li>
 </ul>
 
-</ul>
+\subsection qgis_api_break_3_0_QgsVectorLayer QgsVectorLayer
 
+<ul>
+<li>commitErrors() now returns an object, rather than a reference. This has no effect on PyQGIS code.</li>
+<li>subsetString() was made const. This has no effect on PyQGIS code, but c++ code implementing derived layer classes will need to update the signature of this method to match.</li>
+</ul>
 
 \subsection qgis_api_break_3_0_QgsVectorLayerEditBuffer QgsVectorLayerEditBuffer
 

--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -16,6 +16,20 @@ with too big impact should be deferred to a major version release.
 
 This page tries to maintain a list with incompatible changes that happened in previous releases.
 
+\section qgis_api_break_3_0 QGIS 3.0
+
+
+\subsection qgis_api_break_3_0_QgsMapLayer QgsMapLayer
+
+<ul>
+<li>setLayerName() was removed, use setName() instead. The layerNameChanged() signal has been replaced by nameChanged().</li>
+<li>toggleScaleBasedVisibility() was replaced by setScaleBasedVisibility()</li>
+<li>lastErrorTitle(), lastError(), cacheImage(), onCacheImageDelete(), clearCacheImage() and the signals drawingProgress(),
+screenUpdateRequested() were removed. These members have had no effect for a number of QGIS 2.x releases.</li>
+
+</ul>
+
+
 \section qgis_api_break_2_4 QGIS 2.4
 
 \subsection qgis_api_break_mtr Multi-threaded Rendering

--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -26,8 +26,19 @@ This page tries to maintain a list with incompatible changes that happened in pr
 <li>toggleScaleBasedVisibility() was replaced by setScaleBasedVisibility()</li>
 <li>lastErrorTitle(), lastError(), cacheImage(), onCacheImageDelete(), clearCacheImage() and the signals drawingProgress(),
 screenUpdateRequested() were removed. These members have had no effect for a number of QGIS 2.x releases.</li>
+<li>extent(), styleURI(), exportNamedStyle(), exportSldStyle(), writeXml() were made const. This has no effect on PyQGIS code, but c++ code implementing derived layer classes will need to update the signatures of these methods to match.</li>
+<li>The lyrname parameter in the QgsMapLayer constructor was renamed to 'name'.</li>
+<li>The vis parameter in setSubLayerVisibility was renamed to 'visible'.</li>
+<li>theResultFlag parameter in loadDefaultStyle and saveDefaultStyle were renamed to resultFlag.</li>
+<li>theURI, theResultFlag parameters in loadNamedStyle, saveNamedStyle, saveSldStyle and loadSldStyle were renamed to uri, resultFlag.</li>
+<li>theURI parameter in loadNamedStyleFromDb was renamed to uri.</li>
+<li>theMinScale and theMaxScale parameters in setMinimumScale and setMaximumScale were renamed to scale</li>
+<li>The layerCrsChanged() signal was renamed to crsChanged()</li>
+<li>theError parameter in appendError() and setError() were renamed to 'error'.</li>
+</ul>
 
 </ul>
+
 
 \subsection qgis_api_break_3_0_QgsVectorLayerEditBuffer QgsVectorLayerEditBuffer
 
@@ -36,7 +47,6 @@ screenUpdateRequested() were removed. These members have had no effect for a num
 and deletedFeatureIds() functions now return values, not references. This has no effect on PyQGIS code, but c++
 plugins calling these methods will need to be updated.</li>
 </ul>
-
 
 
 \section qgis_api_break_2_4 QGIS 2.4

--- a/python/core/qgsaggregatecalculator.sip
+++ b/python/core/qgsaggregatecalculator.sip
@@ -60,11 +60,11 @@ class QgsAggregateCalculator
     /** Constructor for QgsAggregateCalculator.
      * @param layer vector layer to calculate aggregate from
      */
-    QgsAggregateCalculator( QgsVectorLayer* layer );
+    QgsAggregateCalculator( const QgsVectorLayer* layer );
 
     /** Returns the associated vector layer.
      */
-    QgsVectorLayer* layer() const;
+    const QgsVectorLayer* layer() const;
 
     /** Sets all aggregate parameters from a parameter bundle.
      * @param parameters aggregate parameters

--- a/python/core/qgsmaplayer.sip
+++ b/python/core/qgsmaplayer.sip
@@ -61,11 +61,6 @@ class QgsMapLayer : QObject
     /** Get this layer's unique ID, this ID is used to access this layer from map layer registry */
     QString id() const;
 
-    /** Set the display name of the layer
-     * @param name New name for the layer
-     */
-    void setLayerName( const QString & name ) /Deprecated/;
-
     /**
      * Set the display name of the layer
      * @param name New name for the layer
@@ -343,13 +338,6 @@ class QgsMapLayer : QObject
     /** Remove a custom property from layer. Properties are stored in a map and saved in project file. */
     void removeCustomProperty( const QString& key );
 
-
-    //! @deprecated since 2.4 - returns empty string
-    virtual QString lastErrorTitle() /Deprecated/;
-
-    //! @deprecated since 2.4 - returns empty string
-    virtual QString lastError() /Deprecated/;
-
     /** Get current status error. This error describes some principal problem
      *  for which layer cannot work and thus is not valid. It is not last error
      *  after accessing data by draw() etc.
@@ -507,13 +495,6 @@ class QgsMapLayer : QObject
     void setLegendUrlFormat( const QString& legendUrlFormat );
     QString legendUrlFormat() const;
 
-    /** @deprecated since 2.4 - returns nullptr */
-    QImage *cacheImage() /Deprecated/;
-    /** @deprecated since 2.4 - caches listen to repaintRequested() signal to invalidate the cached image */
-    void setCacheImage( QImage * thepImage /Transfer/ ) /Deprecated/;
-    /** @deprecated since 2.4 - does nothing */
-    virtual void onCacheImageDelete() /Deprecated/;
-
     /**
      * Assign a legend controller to the map layer. The object will be responsible for providing legend items.
      * @param legend Takes ownership of the object. Can be null pointer
@@ -602,16 +583,6 @@ class QgsMapLayer : QObject
      */
     void setScaleBasedVisibility( const bool enabled );
 
-    /** Accessor for the scale based visilibility flag
-     * @deprecated use setScaleBasedVisibility instead
-     */
-    void toggleScaleBasedVisibility( bool theVisibilityFlag ) /Deprecated/;
-
-    /** Clear cached image
-     *  @deprecated in 2.4 - use triggerRepaint() - caches automatically listen to repaintRequested() signal to invalidate the cached image
-     */
-    void clearCacheImage() /Deprecated/;
-
     /**
      * Will advice the map canvas (and any other interested party) that this layer requires to be repainted.
      * Will emit a repaintRequested() signal.
@@ -633,16 +604,8 @@ class QgsMapLayer : QObject
 
   signals:
 
-    //! @deprecated in 2.4 - not emitted anymore
-    void drawingProgress( int theProgress, int theTotalSteps );
-
     /** Emit a signal with status (e.g. to be caught by QgisApp and display a msg on status bar) */
     void statusChanged( const QString& theStatus );
-
-    /** Emit a signal that the layer name has been changed
-     * @deprecated since 2.16 use nameChanged() instead
-     */
-    void layerNameChanged();
 
     /**
      * Emitted when the name has been changed
@@ -658,9 +621,6 @@ class QgsMapLayer : QObject
      * and any view showing the rendered layer should refresh itself.
      */
     void repaintRequested();
-
-    //! \note Deprecated in 2.4 and not emitted anymore
-    void screenUpdateRequested();
 
     /** This is used to send a request that any mapcanvas using this layer update its extents */
     void recalculateExtents();

--- a/python/core/qgsmaplayer.sip
+++ b/python/core/qgsmaplayer.sip
@@ -650,7 +650,7 @@ class QgsMapLayer : QObject
     void triggerRepaint();
 
     /** \brief Obtain Metadata for this layer */
-    virtual QString metadata();
+    virtual QString metadata() const;
 
     /** Time stamp of data source in the moment when data/metadata were loaded by provider */
     virtual QDateTime timestamp() const;

--- a/python/core/qgsmaplayer.sip
+++ b/python/core/qgsmaplayer.sip
@@ -35,7 +35,8 @@ class QgsMapLayer : QObject
 %End
 
   public:
-    /** Layers enum defining the types of layers that can be added to a map */
+
+    //! Types of layers that can be added to a map
     enum LayerType
     {
       VectorLayer,
@@ -43,179 +44,224 @@ class QgsMapLayer : QObject
       PluginLayer
     };
 
-    /** Constructor
-     * @param type Type of layer as defined in QgsMapLayer::LayerType enum
-     * @param lyrname Display Name of the layer
+    /** Constructor for QgsMapLayer
+     * @param type layer type
+     * @param name display name for the layer
      * @param source datasource of layer
      */
-    QgsMapLayer( QgsMapLayer::LayerType type = QgsMapLayer::VectorLayer, const QString& lyrname = QString::null, const QString& source = QString::null );
+    QgsMapLayer( QgsMapLayer::LayerType type = VectorLayer, const QString& name = QString::null, const QString& source = QString::null );
 
-    /** Destructor */
     virtual ~QgsMapLayer();
 
-    /** Get the type of the layer
-     * @return Integer matching a value in the QgsMapLayer::LayerType enum
+    /** Returns the type of the layer.
      */
     QgsMapLayer::LayerType type() const;
 
-    /** Get this layer's unique ID, this ID is used to access this layer from map layer registry */
+    /** Returns the layer's unique ID, which is used to access this layer from QgsMapLayerRegistry. */
     QString id() const;
 
     /**
      * Set the display name of the layer
-     * @param name New name for the layer
-     *
+     * @param name new name for the layer
      * @note added in 2.16
+     * @see name()
      */
     void setName( const QString& name );
 
-    /** Get the display name of the layer
+    /** Returns the display name of the layer.
      * @return the layer name
+     * @see setName()
      */
     QString name() const;
 
-    /** Get the original name of the layer
+    /** Returns the original name of the layer.
      * @return the original layer name
      */
     QString originalName() const;
 
-    /** Set the short name of the layer
-     *  used by QGIS Server to identify the layer
+    /** Sets the short name of the layer
+     *  used by QGIS Server to identify the layer.
      * @return the layer short name
+     * @see shortName()
      */
     void setShortName( const QString& shortName );
-    /** Get the short name of the layer
-     *  used by QGIS Server to identify the layer
+
+    /** Returns the short name of the layer
+     *  used by QGIS Server to identify the layer.
      * @return the layer short name
+     * @see setShortName()
      */
     QString shortName() const;
 
-    /** Set the title of the layer
-     *  used by QGIS Server in GetCapabilities request
+    /** Sets the title of the layer
+     *  used by QGIS Server in GetCapabilities request.
      * @return the layer title
+     * @see title()
      */
     void setTitle( const QString& title );
-    /** Get the title of the layer
-     *  used by QGIS Server in GetCapabilities request
+
+    /** Returns the title of the layer
+     *  used by QGIS Server in GetCapabilities request.
      * @return the layer title
+     * @see setTitle()
      */
     QString title() const;
 
-    /** Set the abstract of the layer
-     *  used by QGIS Server in GetCapabilities request
+    /** Sets the abstract of the layer
+     *  used by QGIS Server in GetCapabilities request.
      * @return the layer abstract
+     * @see abstract()
      */
     void setAbstract( const QString& abstract );
-    /** Get the abstract of the layer
-     *  used by QGIS Server in GetCapabilities request
+
+    /** Returns the abstract of the layer
+     *  used by QGIS Server in GetCapabilities request.
      * @return the layer abstract
+     * @see setAbstract()
      */
     QString abstract() const;
 
-    /** Set the keyword list of the layer
-     *  used by QGIS Server in GetCapabilities request
+    /** Sets the keyword list of the layer
+     *  used by QGIS Server in GetCapabilities request.
      * @return the layer keyword list
+     * @see keywordList()
      */
     void setKeywordList( const QString& keywords );
-    /** Get the keyword list of the layer
-     *  used by QGIS Server in GetCapabilities request
+
+    /** Returns the keyword list of the layer
+     *  used by QGIS Server in GetCapabilities request.
      * @return the layer keyword list
+     * @see setKeywordList()
      */
     QString keywordList() const;
 
     /* Layer dataUrl information */
-    /** Set the DataUrl of the layer
-     *  used by QGIS Server in GetCapabilities request
-     *  DataUrl is a a link to the underlying data represented by a particular layer
+
+    /** Sets the DataUrl of the layer
+     *  used by QGIS Server in GetCapabilities request.
+     *  DataUrl is a a link to the underlying data represented by a particular layer.
      * @return the layer DataUrl
+     * @see dataUrl()
      */
     void setDataUrl( const QString& dataUrl );
-    /** Get the DataUrl of the layer
-     *  used by QGIS Server in GetCapabilities request
-     *  DataUrl is a a link to the underlying data represented by a particular layer
+
+    /** Returns the DataUrl of the layer
+     *  used by QGIS Server in GetCapabilities request.
+     *  DataUrl is a a link to the underlying data represented by a particular layer.
      * @return the layer DataUrl
+     * @see setDataUrl()
      */
     QString dataUrl() const;
-    /** Set the DataUrl format of the layer
-     *  used by QGIS Server in GetCapabilities request
-     *  DataUrl is a a link to the underlying data represented by a particular layer
+
+    /** Sets the DataUrl format of the layer
+     *  used by QGIS Server in GetCapabilities request.
+     *  DataUrl is a a link to the underlying data represented by a particular layer.
      * @return the layer DataUrl format
+     * @see dataUrlFormat()
      */
     void setDataUrlFormat( const QString& dataUrlFormat );
-    /** Get the DataUrl format of the layer
-     *  used by QGIS Server in GetCapabilities request
-     *  DataUrl is a a link to the underlying data represented by a particular layer
+
+    /** Returns the DataUrl format of the layer
+     *  used by QGIS Server in GetCapabilities request.
+     *  DataUrl is a a link to the underlying data represented by a particular layer.
      * @return the layer DataUrl format
+     * @see setDataUrlFormat()
      */
     QString dataUrlFormat() const;
 
     /* Layer attribution information */
-    /** Set the attribution of the layer
-     *  used by QGIS Server in GetCapabilities request
-     *  Attribution indicates the provider of a Layer or collection of Layers.
+
+    /** Sets the attribution of the layer
+     *  used by QGIS Server in GetCapabilities request.
+     *  Attribution indicates the provider of a layer or collection of layers.
      * @return the layer attribution
+     * @see attribution()
      */
     void setAttribution( const QString& attrib );
-    /** Get the attribution of the layer
-     *  used by QGIS Server in GetCapabilities request
-     *  Attribution indicates the provider of a Layer or collection of Layers.
+
+    /** Returns the attribution of the layer
+     *  used by QGIS Server in GetCapabilities request.
+     *  Attribution indicates the provider of a layer or collection of layers.
      * @return the layer attribution
+     * @see setAttribution()
      */
     QString attribution() const;
-    /** Set the attribution URL of the layer
-     *  used by QGIS Server in GetCapabilities request
-     *  Attribution indicates the provider of a Layer or collection of Layers.
+
+    /** Sets the attribution URL of the layer
+     *  used by QGIS Server in GetCapabilities request.
+     *  Attribution indicates the provider of a layer or collection of layers.
      * @return the layer attribution URL
+     * @see attributionUrl()
      */
     void setAttributionUrl( const QString& attribUrl );
-    /** Get the attribution URL of the layer
-     *  used by QGIS Server in GetCapabilities request
-     *  Attribution indicates the provider of a Layer or collection of Layers.
+
+    /** Returns the attribution URL of the layer
+     *  used by QGIS Server in GetCapabilities request.
+     *  Attribution indicates the provider of a layer or collection of layers.
      * @return the layer attribution URL
+     * @see setAttributionUrl()
      */
     QString attributionUrl() const;
 
     /* Layer metadataUrl information */
-    /** Set the metadata URL of the layer
-     *  used by QGIS Server in GetCapabilities request
+
+    /** Sets the metadata URL of the layer
+     *  used by QGIS Server in GetCapabilities request.
      *  MetadataUrl is a a link to the detailed, standardized metadata about the data.
      * @return the layer metadata URL
+     * @see metadataUrl()
      */
     void setMetadataUrl( const QString& metaUrl );
-    /** Get the metadata URL of the layer
-     *  used by QGIS Server in GetCapabilities request
+
+    /** Returns the metadata URL of the layer
+     *  used by QGIS Server in GetCapabilities request.
      *  MetadataUrl is a a link to the detailed, standardized metadata about the data.
      * @return the layer metadata URL
+     * @see setMetadataUrl()
      */
     QString metadataUrl() const;
+
     /** Set the metadata type of the layer
      *  used by QGIS Server in GetCapabilities request
      *  MetadataUrlType indicates the standard to which the metadata complies.
      * @return the layer metadata type
+     * @see metadataUrlType()
      */
     void setMetadataUrlType( const QString& metaUrlType );
-    /** Get the metadata type of the layer
-     *  used by QGIS Server in GetCapabilities request
+
+    /** Returns the metadata type of the layer
+     *  used by QGIS Server in GetCapabilities request.
      *  MetadataUrlType indicates the standard to which the metadata complies.
      * @return the layer metadata type
+     * @see setMetadataUrlType()
      */
     QString metadataUrlType() const;
-    /** Set the metadata format of the layer
-     *  used by QGIS Server in GetCapabilities request
+
+    /** Sets the metadata format of the layer
+     *  used by QGIS Server in GetCapabilities request.
      *  MetadataUrlType indicates how the metadata is structured.
      * @return the layer metadata format
+     * @see metadataUrlFormat()
      */
     void setMetadataUrlFormat( const QString& metaUrlFormat );
-    /** Get the metadata format of the layer
-     *  used by QGIS Server in GetCapabilities request
+
+    /** Returns the metadata format of the layer
+     *  used by QGIS Server in GetCapabilities request.
      *  MetadataUrlType indicates how the metadata is structured.
      * @return the layer metadata format
+     * @see setMetadataUrlFormat()
      */
     QString metadataUrlFormat() const;
 
-    /** Set the blending mode used for rendering a layer */
+    /** Set the blending mode used for rendering a layer.
+     * @param blendMode new blending mode
+     * @see blendMode()
+    */
     void setBlendMode( QPainter::CompositionMode blendMode );
-    /** Returns the current blending mode for a layer */
+
+    /** Returns the current blending mode for a layer.
+     * @see setBlendMode()
+    */
     QPainter::CompositionMode blendMode() const;
 
     /** Returns if this layer is read only. */
@@ -243,22 +289,26 @@ class QgsMapLayer : QObject
      */
     virtual void drawLabels( QgsRenderContext& rendererContext );
 
-    /** Return the extent of the layer */
-    virtual QgsRectangle extent();
+    /** Returns the extent of the layer. */
+    virtual QgsRectangle extent() const;
 
     /** Return the status of the layer. An invalid layer is one which has a bad datasource
-     * or other problem. Child classes set this flag when intialized
-     * @return True if the layer is valid and can be accessed
+     * or other problem. Child classes set this flag when initialized.
+     * @return true if the layer is valid and can be accessed
      */
-    bool isValid();
+    bool isValid() const;
 
     /** Gets a version of the internal layer definition that has sensitive
       *  bits removed (for example, the password). This function should
       * be used when displaying the source name for general viewing.
+      * @see source()
      */
     QString publicSource() const;
 
-    /** Returns the source for the layer */
+    /** Returns the source for the layer. This source may contain usernames, passwords
+     * and other sensitive information.
+     * @see publicSource()
+     */
     QString source() const;
 
     /**
@@ -268,15 +318,18 @@ class QgsMapLayer : QObject
     virtual QStringList subLayers() const;
 
     /**
-     * Reorders the *previously selected* sublayers of this layer from bottom to top
-     * (Useful for providers that manage their own layers, such as WMS)
+     * Reorders the *previously selected* sublayers of this layer from bottom to top.
+     * (Useful for providers that manage their own layers, such as WMS).
      */
     virtual void setLayerOrder( const QStringList &layers );
 
-    /** Set the visibility of the given sublayer name */
-    virtual void setSubLayerVisibility( const QString& name, bool vis );
+    /** Set the visibility of the given sublayer name.
+     * @param name sublayer name
+     * @param visible sublayer visibility
+    */
+    virtual void setSubLayerVisibility( const QString& name, bool visible );
 
-    /** True if the layer can be edited */
+    /** Returns true if the layer can be edited. */
     virtual bool isEditable() const;
 
     /** Returns true if the layer is considered a spatial layer, ie it has some form of geometry associated with it.
@@ -300,7 +353,6 @@ class QgsMapLayer : QObject
      */
     bool readLayerXML( const QDomElement& layerElement );
 
-
     /** Stores state in Dom node
      * @param layerElement is a Dom element corresponding to ``maplayer'' tag
      * @param document is a the dom document being written
@@ -317,7 +369,7 @@ class QgsMapLayer : QObject
      *
      * @returns true if successful
      */
-    bool writeLayerXML( QDomElement& layerElement, QDomDocument& document, const QString& relativeBasePath = QString::null );
+    bool writeLayerXML( QDomElement& layerElement, QDomDocument& document, const QString& relativeBasePath = QString::null ) const;
 
     /** Returns the given layer as a layer definition document
      *  Layer definitions store the data source as well as styling and custom properties.
@@ -331,11 +383,18 @@ class QgsMapLayer : QObject
     static QList<QgsMapLayer*> fromLayerDefinition( QDomDocument& document, bool addToRegistry = false, bool addToLegend = false );
     static QList<QgsMapLayer*> fromLayerDefinitionFile( const QString &qlrfile );
 
-    /** Set a custom property for layer. Properties are stored in a map and saved in project file. */
+    /** Set a custom property for layer. Properties are stored in a map and saved in project file.
+     * @see customProperty()
+     * @see removeCustomProperty()
+     */
     void setCustomProperty( const QString& key, const QVariant& value );
-    /** Read a custom property from layer. Properties are stored in a map and saved in project file. */
+    /** Read a custom property from layer. Properties are stored in a map and saved in project file.
+     * @see setCustomProperty()
+    */
     QVariant customProperty( const QString& value, const QVariant& defaultValue = QVariant() ) const;
-    /** Remove a custom property from layer. Properties are stored in a map and saved in project file. */
+    /** Remove a custom property from layer. Properties are stored in a map and saved in project file.
+     * @see setCustomProperty()
+     */
     void removeCustomProperty( const QString& key );
 
     /** Get current status error. This error describes some principal problem
@@ -344,7 +403,7 @@ class QgsMapLayer : QObject
      */
     virtual QgsError error() const;
 
-    /** Returns layer's spatial reference system
+    /** Returns the layer's spatial reference system.
     @note This was introduced in QGIS 1.4
      */
     const QgsCoordinateReferenceSystem& crs() const;
@@ -361,34 +420,34 @@ class QgsMapLayer : QObject
      * @return a QString with the style file name
      * @see also loadNamedStyle () and saveNamedStyle ();
      */
-    virtual QString styleURI();
+    virtual QString styleURI() const;
 
     /** Retrieve the default style for this layer if one
      * exists (either as a .qml file on disk or as a
      * record in the users style table in their personal qgis.db)
-     * @param theResultFlag a reference to a flag that will be set to false if
+     * @param resultFlag a reference to a flag that will be set to false if
      * we did not manage to load the default style.
      * @return a QString with any status messages
      * @see also loadNamedStyle ();
      */
-    virtual QString loadDefaultStyle( bool & theResultFlag /Out/ );
+    virtual QString loadDefaultStyle( bool & resultFlag /Out/ );
 
     /** Retrieve a named style for this layer if one
      * exists (either as a .qml file on disk or as a
      * record in the users style table in their personal qgis.db)
-     * @param theURI - the file name or other URI for the
+     * @param uri - the file name or other URI for the
      * style file. First an attempt will be made to see if this
      * is a file and load that, if that fails the qgis.db styles
      * table will be consulted to see if there is a style who's
      * key matches the URI.
-     * @param theResultFlag a reference to a flag that will be set to false if
+     * @param resultFlag a reference to a flag that will be set to false if
      * we did not manage to load the default style.
      * @return a QString with any status messages
      * @see also loadDefaultStyle ();
      */
-    virtual QString loadNamedStyle( const QString &theURI, bool &theResultFlag /Out/ );
+    virtual QString loadNamedStyle( const QString& uri, bool &resultFlag /Out/ );
 
-    virtual bool loadNamedStyleFromDb( const QString &db, const QString &theURI, QString &qml /Out/ );
+    virtual bool loadNamedStyleFromDb( const QString &db, const QString &uri, QString &qml /Out/ );
 
     /**
      * Import the properties of this layer from a QDomDocument
@@ -406,8 +465,7 @@ class QgsMapLayer : QObject
      * @param errorMsg this QString will be initialized on error
      * during the execution of writeSymbology
      */
-    virtual void exportNamedStyle( QDomDocument &doc, QString &errorMsg );
-
+    virtual void exportNamedStyle( QDomDocument &doc, QString &errorMsg ) const;
 
     /**
      * Export the properties of this layer as SLD style in a QDomDocument
@@ -415,35 +473,35 @@ class QgsMapLayer : QObject
      * @param errorMsg this QString will be initialized on error
      * during the execution of writeSymbology
      */
-    virtual void exportSldStyle( QDomDocument &doc, QString &errorMsg );
+    virtual void exportSldStyle( QDomDocument &doc, QString &errorMsg ) const;
 
     /** Save the properties of this layer as the default style
      * (either as a .qml file on disk or as a
      * record in the users style table in their personal qgis.db)
-     * @param theResultFlag a reference to a flag that will be set to false if
+     * @param resultFlag a reference to a flag that will be set to false if
      * we did not manage to save the default style.
      * @return a QString with any status messages
      * @sa loadNamedStyle() and @see saveNamedStyle()
      */
-    virtual QString saveDefaultStyle( bool & theResultFlag /Out/ );
+    virtual QString saveDefaultStyle( bool & resultFlag /Out/ );
 
     /** Save the properties of this layer as a named style
      * (either as a .qml file on disk or as a
      * record in the users style table in their personal qgis.db)
-     * @param theURI the file name or other URI for the
+     * @param uri the file name or other URI for the
      * style file. First an attempt will be made to see if this
      * is a file and save to that, if that fails the qgis.db styles
      * table will be used to create a style entry who's
      * key matches the URI.
-     * @param theResultFlag a reference to a flag that will be set to false if
+     * @param resultFlag a reference to a flag that will be set to false if
      * we did not manage to save the default style.
      * @return a QString with any status messages
      * @sa saveDefaultStyle()
      */
-    virtual QString saveNamedStyle( const QString &theURI, bool &theResultFlag /Out/ );
+    virtual QString saveNamedStyle( const QString &uri, bool &resultFlag /Out/ );
 
-    virtual QString saveSldStyle( const QString &theURI, bool &theResultFlag );
-    virtual QString loadSldStyle( const QString &theURI, bool &theResultFlag );
+    virtual QString saveSldStyle( const QString &uri, bool &resultFlag ) const;
+    virtual QString loadSldStyle( const QString &uri, bool &resultFlag );
 
     virtual bool readSld( const QDomNode &node, QString &errorMessage );
 
@@ -559,21 +617,21 @@ class QgsMapLayer : QObject
 
     /** Sets the minimum scale denominator at which the layer will be visible.
      * Scale based visibility is only used if setScaleBasedVisibility is set to true.
-     * @param theMinScale minimum scale denominator at which the layer should render
+     * @param scale minimum scale denominator at which the layer should render
      * @see minimumScale
      * @see setMaximumScale
      * @see setScaleBasedVisibility
      */
-    void setMinimumScale( double theMinScale );
+    void setMinimumScale( double scale );
 
     /** Sets the maximum scale denominator at which the layer will be visible.
      * Scale based visibility is only used if setScaleBasedVisibility is set to true.
-     * @param theMaxScale maximum scale denominator at which the layer should render
+     * @param scale maximum scale denominator at which the layer should render
      * @see maximumScale
      * @see setMinimumScale
      * @see setScaleBasedVisibility
      */
-    void setMaximumScale( double theMaxScale );
+    void setMaximumScale( double scale );
 
     /** Sets whether scale based visibility is enabled for the layer.
      * @param enabled set to true to enable scale based visibility
@@ -605,7 +663,7 @@ class QgsMapLayer : QObject
   signals:
 
     /** Emit a signal with status (e.g. to be caught by QgisApp and display a msg on status bar) */
-    void statusChanged( const QString& theStatus );
+    void statusChanged( const QString& status );
 
     /**
      * Emitted when the name has been changed
@@ -615,7 +673,7 @@ class QgsMapLayer : QObject
     void nameChanged();
 
     /** Emit a signal that layer's CRS has been reset */
-    void layerCrsChanged();
+    void crsChanged();
 
     /** By emitting this signal the layer tells that either appearance or content have been changed
      * and any view showing the rendered layer should refresh itself.
@@ -623,7 +681,7 @@ class QgsMapLayer : QObject
     void repaintRequested();
 
     /** This is used to send a request that any mapcanvas using this layer update its extents */
-    void recalculateExtents();
+    void recalculateExtents() const;
 
     /** Data of layer changed */
     void dataChanged();
@@ -671,7 +729,7 @@ class QgsMapLayer : QObject
     /** Called by writeLayerXML(), used by children to write state specific to them to
      *  project files.
      */
-    virtual bool writeXml( QDomNode & layer_node, QDomDocument & document );
+    virtual bool writeXml( QDomNode & layer_node, QDomDocument & document ) const;
 
 
     /** Read custom properties from project file.
@@ -689,7 +747,7 @@ class QgsMapLayer : QObject
 
 
     /** Add error message */
-    void appendError( const QgsErrorMessage & theMessage );
+    void appendError( const QgsErrorMessage &error );
     /** Set error message */
-    void setError( const QgsError & theError );
+    void setError( const QgsError &error );
 };

--- a/python/core/qgsrelationmanager.sip
+++ b/python/core/qgsrelationmanager.sip
@@ -79,7 +79,7 @@ class QgsRelationManager : QObject
      *
      * @return A list of relations matching the given layer and fieldIdx.
      */
-    QList<QgsRelation> referencingRelations( QgsVectorLayer *layer = 0, int fieldIdx = -2 ) const;
+    QList<QgsRelation> referencingRelations( const QgsVectorLayer *layer = 0, int fieldIdx = -2 ) const;
 
     /**
      * Get all relations where this layer is the referenced part (i.e. the parent table with the primary key being referenced from another layer).

--- a/python/core/qgsvectorlayer.sip
+++ b/python/core/qgsvectorlayer.sip
@@ -472,7 +472,7 @@ class QgsVectorLayer : QgsMapLayer
     /** Write vector layer specific state to project file Dom node.
      * @note Called by QgsMapLayer::writeXML().
      */
-    virtual bool writeXml( QDomNode & layer_node, QDomDocument & doc );
+    virtual bool writeXml( QDomNode & layer_node, QDomDocument & doc ) const;
 
     /**
      * Save named and sld style of the layer to the style table in the db.
@@ -610,9 +610,11 @@ class QgsVectorLayer : QgsMapLayer
     virtual QString subsetString();
 
     /**
-     * Query the provider for features specified in request.
+      * Query the layer for features specified in request.
+      * @param request feature request describing parameters of features to return
+      * @returns iterator for matching features from provider
      */
-    QgsFeatureIterator getFeatures( const QgsFeatureRequest& request = QgsFeatureRequest() );
+    QgsFeatureIterator getFeatures( const QgsFeatureRequest& request = QgsFeatureRequest() ) const;
 
     /** Adds a feature
         @param f feature to add
@@ -853,7 +855,7 @@ class QgsVectorLayer : QgsMapLayer
     void drawLabels( QgsRenderContext& rendererContext ) /Deprecated/;
 
     /** Return the extent of the layer */
-    QgsRectangle extent();
+    QgsRectangle extent() const;
 
     /**
      * Returns the list of fields of this layer.
@@ -1315,7 +1317,7 @@ class QgsVectorLayer : QgsMapLayer
     void updateFields();
 
     /** Caches joined attributes if required (and not already done) */
-    void createJoinCaches();
+    void createJoinCaches() const;
 
     /** Returns unique values for column
      * @param index column index for attribute

--- a/python/core/qgsvectorlayer.sip
+++ b/python/core/qgsvectorlayer.sip
@@ -207,7 +207,7 @@ class QgsVectorLayer : QgsMapLayer
      *
      *  @return The expression which will be used to preview features for this layer
      */
-    const QString displayExpression();
+    QString displayExpression() const;
 
     /** Returns the data provider */
     QgsVectorDataProvider* dataProvider();
@@ -269,7 +269,7 @@ class QgsVectorLayer : QgsMapLayer
      *
      * @note added in 2.9
      */
-    const QString expressionField( int index );
+    QString expressionField( int index ) const;
 
     /**
      * Changes the expression used to define an expression based (virtual) field
@@ -297,7 +297,7 @@ class QgsVectorLayer : QgsMapLayer
      *
      * @return See description
      */
-    int selectedFeatureCount();
+    int selectedFeatureCount() const;
 
     /**
      * Select features found within the search rectangle (in layer's coordinates)
@@ -364,7 +364,7 @@ class QgsVectorLayer : QgsMapLayer
     void selectAll();
 
     /** Get all feature Ids */
-    QgsFeatureIds allFeatureIds();
+    QgsFeatureIds allFeatureIds() const;
 
     /**
      * Invert selection of features found within the search rectangle (in layer's coordinates)
@@ -383,7 +383,7 @@ class QgsVectorLayer : QgsMapLayer
      * @see    selectedFeaturesIds()
      * @see    selectedFeaturesIterator() which is more memory friendly when handling large selections
      */
-    QgsFeatureList selectedFeatures();
+    QgsFeatureList selectedFeatures() const;
 
     /**
      * Get an iterator of the selected features
@@ -396,7 +396,7 @@ class QgsVectorLayer : QgsMapLayer
      * @see    selectedFeaturesIds()
      * @see    selectedFeatures()
      */
-    QgsFeatureIterator selectedFeaturesIterator( QgsFeatureRequest request = QgsFeatureRequest() );
+    QgsFeatureIterator selectedFeaturesIterator( QgsFeatureRequest request = QgsFeatureRequest() ) const;
 
     /**
      * Return reference to identifiers of selected features
@@ -417,7 +417,7 @@ class QgsVectorLayer : QgsMapLayer
     void setSelectedFeatures( const QgsFeatureIds &ids ) /Deprecated/;
 
     /** Returns the bounding box of the selected features. If there is no selection, QgsRectangle(0,0,0,0) is returned */
-    QgsRectangle boundingBoxOfSelected();
+    QgsRectangle boundingBoxOfSelected() const;
 
     /** Returns whether the layer contains labels which are enabled and should be drawn.
      * @return true if layer contains enabled labels
@@ -573,7 +573,7 @@ class QgsVectorLayer : QgsMapLayer
      * @param symbol the symbol
      * @return number of features rendered by symbol or -1 if failed or counts are not available
      */
-    long featureCount( QgsSymbolV2* symbol );
+    long featureCount( QgsSymbolV2* symbol ) const;
 
     /**
      * Update the data source of the layer. The layer's renderer and legend will be preserved only
@@ -607,7 +607,7 @@ class QgsVectorLayer : QgsMapLayer
      * Get the string (typically sql) used to define a subset of the layer
      * @return The subset string or QString::null if not implemented by the provider
      */
-    virtual QString subsetString();
+    virtual QString subsetString() const;
 
     /**
       * Query the layer for features specified in request.
@@ -1085,7 +1085,7 @@ class QgsVectorLayer : QgsMapLayer
      * that the user has some chance of repairing the damage cleanly.
      */
     bool commitChanges();
-    const QStringList &commitErrors();
+    QStringList commitErrors() const;
 
     /** Stop editing and discard the edits
      * @param deleteBuffer whether to delete editing buffer
@@ -1235,7 +1235,7 @@ class QgsVectorLayer : QgsMapLayer
     RangeData range( int idx ) /Deprecated/;
 
     /** Access value relation widget data */
-    ValueRelationData valueRelation( int idx );
+    ValueRelationData valueRelation( int idx ) const;
 
     /**
      * Get relations, where the foreign key is on this layer
@@ -1243,7 +1243,7 @@ class QgsVectorLayer : QgsMapLayer
      * @param idx Only get relations, where idx forms part of the foreign key
      * @return A list of relations
      */
-    QList<QgsRelation> referencingRelations( int idx );
+    QList<QgsRelation> referencingRelations( int idx ) const;
 
     /**
      * Access date format
@@ -1324,13 +1324,13 @@ class QgsVectorLayer : QgsMapLayer
      * @param uniqueValues out: result list
      * @param limit maximum number of values to return (-1 if unlimited)
      */
-    void uniqueValues( int index, QList<QVariant> &uniqueValues /Out/, int limit = -1 );
+    void uniqueValues( int index, QList<QVariant> &uniqueValues /Out/, int limit = -1 ) const;
 
     /** Returns minimum value for an attribute column or invalid variant in case of error */
-    QVariant minimumValue( int index );
+    QVariant minimumValue( int index ) const;
 
     /** Returns maximum value for an attribute column or invalid variant in case of error */
-    QVariant maximumValue( int index );
+    QVariant maximumValue( int index ) const;
 
     /** Calculates an aggregated value from the layer's features.
      * @param aggregate aggregate to calculate
@@ -1345,7 +1345,7 @@ class QgsVectorLayer : QgsMapLayer
                         const QString& fieldOrExpression,
                         const QgsAggregateCalculator::AggregateParameters& parameters = QgsAggregateCalculator::AggregateParameters(),
                         QgsExpressionContext* context = nullptr,
-                        bool* ok = nullptr );
+                        bool* ok = nullptr ) const;
 
     /** Fetches all values from a specified field name or expression.
      * @param fieldOrExpression field name or an expression string
@@ -1355,7 +1355,7 @@ class QgsVectorLayer : QgsMapLayer
      * @note added in QGIS 2.9
      * @see getDoubleValues
      */
-    QList< QVariant > getValues( const QString &fieldOrExpression, bool &ok, bool selectedOnly = false );
+    QList< QVariant > getValues( const QString &fieldOrExpression, bool &ok, bool selectedOnly = false ) const;
 
     /** Fetches all double values from a specified field name or expression. Null values or
      * invalid expression results are skipped.
@@ -1367,7 +1367,7 @@ class QgsVectorLayer : QgsMapLayer
      * @note added in QGIS 2.9
      * @see getValues
      */
-    QList< double > getDoubleValues( const QString &fieldOrExpression, bool &ok, bool selectedOnly = false, int* nullCount = 0 );
+    QList< double > getDoubleValues( const QString &fieldOrExpression, bool &ok, bool selectedOnly = false, int* nullCount = 0 ) const;
 
     /** Set the blending mode used for rendering each feature */
     void setFeatureBlendMode( QPainter::CompositionMode blendMode );

--- a/python/core/qgsvectorlayer.sip
+++ b/python/core/qgsvectorlayer.sip
@@ -1379,7 +1379,7 @@ class QgsVectorLayer : QgsMapLayer
     /** Returns the current transparency for the vector layer */
     int layerTransparency() const;
 
-    QString metadata();
+    QString metadata() const;
 
     /** @note not available in python bindings */
     // inline QgsGeometryCache* cache();

--- a/python/core/qgsvectorlayereditbuffer.sip
+++ b/python/core/qgsvectorlayereditbuffer.sip
@@ -70,24 +70,42 @@ class QgsVectorLayerEditBuffer : QObject
     /** Stop editing and discard the edits */
     virtual void rollBack();
 
+    /** Returns a map of new features which are not committed. */
+    QgsFeatureMap addedFeatures() const;
 
+    /** Returns true if the specified feature ID has been added but not committed.
+     * @param id feature ID
+     * @note added in QGIS 3.0
+     */
+    bool featureIsAdded( QgsFeatureId id ) const;
 
-    /** New features which are not commited. */
-    const QgsFeatureMap& addedFeatures();
+    /** Returns a map of features with changed attributes values which are not committed */
+    QgsChangedAttributesMap changedAttributeValues() const;
 
-    /** Changed attributes values which are not commited */
-    const QgsChangedAttributesMap& changedAttributeValues();
+    /** Returns true if the specified feature ID has had an attribute changed but not committed.
+     * @param id feature ID
+     * @note added in QGIS 3.0
+     */
+    bool featureHasAttributeChanges( QgsFeatureId id ) const;
 
-    /** Deleted attributes fields which are not commited. The list is kept sorted. */
-    const QgsAttributeList& deletedAttributeIds();
+    /** Returns a list of deleted attributes fields which are not committed. The list is kept sorted. */
+    QgsAttributeList deletedAttributeIds() const;
 
-    /** Added attributes fields which are not commited */
-    const QList<QgsField>& addedAttributes();
+    /** Returns a list of added attributes fields which are not committed */
+    QList<QgsField> addedAttributes() const;
 
-    /** Changed geometries which are not commited. */
-    const QgsGeometryMap& changedGeometries();
+    /** Returns a map of features with changed geometries which are not committed. */
+    QgsGeometryMap changedGeometries() const;
 
-    const QgsFeatureIds deletedFeatureIds();
+    /** Returns true if the specified feature ID has had its geometry changed but not committed.
+     * @param id feature ID
+     * @note added in QGIS 3.0
+     */
+    bool featureHasGeometryChange( QgsFeatureId id ) const;
+
+    /** Returns a list of deleted feature IDs which are not committed. */
+    QgsFeatureIds deletedFeatureIds() const;
+
     //QString dumpEditBuffer();
 
   protected slots:
@@ -131,10 +149,10 @@ class QgsVectorLayerEditBuffer : QObject
 
     void updateFields( QgsFields& fields );
 
-    /** Update feature with uncommited geometry updates */
+    /** Update feature with uncommitted geometry updates */
     void updateFeatureGeometry( QgsFeature &f );
 
-    /** Update feature with uncommited attribute updates */
+    /** Update feature with uncommitted attribute updates */
     void updateChangedAttributes( QgsFeature &f );
 
     /** Update added and changed features after addition of an attribute */

--- a/python/core/raster/qgsrasterlayer.sip
+++ b/python/core/raster/qgsrasterlayer.sip
@@ -247,6 +247,6 @@ class QgsRasterLayer : QgsMapLayer
     bool writeStyle(QDomNode &node, QDomDocument &doc, QString &errorMessage) const;
 
     /** \brief Write layer specific state to project file Dom node */
-    bool writeXml( QDomNode & layer_node, QDomDocument & doc );
+    bool writeXml( QDomNode & layer_node, QDomDocument & doc ) const;
 };
 

--- a/python/core/raster/qgsrasterlayer.sip
+++ b/python/core/raster/qgsrasterlayer.sip
@@ -115,7 +115,7 @@ class QgsRasterLayer : QgsMapLayer
     int bandCount() const;
 
     /** \brief Get the name of a band given its number  */
-    const  QString bandName( int theBandNoInt );
+    QString bandName( int theBandNoInt ) const;
 
     /** Returns the data provider */
     QgsRasterDataProvider* dataProvider();
@@ -147,7 +147,7 @@ class QgsRasterLayer : QgsMapLayer
     virtual bool isSpatial() const;
 
     /** \brief Obtain GDAL Metadata for this layer */
-    QString metadata();
+    QString metadata() const;
 
     /** \brief Get an 100x100 pixmap of the color palette. If the layer has no palette a white pixmap will be returned */
     QPixmap paletteAsPixmap( int theBandNumber = 1 );

--- a/python/plugins/processing/gui/Postprocessing.py
+++ b/python/plugins/processing/gui/Postprocessing.py
@@ -62,7 +62,7 @@ def handleAlgorithmResults(alg, progress=None, showResults=True):
         if isinstance(out, (OutputRaster, OutputVector, OutputTable)):
             try:
                 if hasattr(out, "layer") and out.layer is not None:
-                    out.layer.setLayerName(out.description)
+                    out.layer.setName(out.description)
                     QgsMapLayerRegistry.instance().addMapLayers([out.layer])
                 else:
                     if ProcessingConfig.getSetting(

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -392,7 +392,7 @@ void QgsIdentifyResultsDialog::addFeature( QgsVectorLayer *vlayer, const QgsFeat
     lstResults->addTopLevelItem( layItem );
 
     connect( vlayer, SIGNAL( layerDeleted() ), this, SLOT( layerDestroyed() ) );
-    connect( vlayer, SIGNAL( layerCrsChanged() ), this, SLOT( layerDestroyed() ) );
+    connect( vlayer, SIGNAL( crsChanged() ), this, SLOT( layerDestroyed() ) );
     connect( vlayer, SIGNAL( featureDeleted( QgsFeatureId ) ), this, SLOT( featureDeleted( QgsFeatureId ) ) );
     connect( vlayer, SIGNAL( attributeValueChanged( QgsFeatureId, int, const QVariant & ) ),
              this, SLOT( attributeValueChanged( QgsFeatureId, int, const QVariant & ) ) );
@@ -720,7 +720,7 @@ void QgsIdentifyResultsDialog::addFeature( QgsRasterLayer *layer,
     }
 
     connect( layer, SIGNAL( destroyed() ), this, SLOT( layerDestroyed() ) );
-    connect( layer, SIGNAL( layerCrsChanged() ), this, SLOT( layerDestroyed() ) );
+    connect( layer, SIGNAL( crsChanged() ), this, SLOT( layerDestroyed() ) );
   }
   // Set/reset getFeatureInfoUrl (currently only available for Feature, so it may change if format changes)
   layItem->setData( 0, GetFeatureInfoUrlRole, params.value( "getFeatureInfoUrl" ) );

--- a/src/core/qgsaggregatecalculator.cpp
+++ b/src/core/qgsaggregatecalculator.cpp
@@ -23,13 +23,13 @@
 
 
 
-QgsAggregateCalculator::QgsAggregateCalculator( QgsVectorLayer* layer )
+QgsAggregateCalculator::QgsAggregateCalculator( const QgsVectorLayer* layer )
     : mLayer( layer )
 {
 
 }
 
-QgsVectorLayer*QgsAggregateCalculator::layer() const
+const QgsVectorLayer* QgsAggregateCalculator::layer() const
 {
   return mLayer;
 }

--- a/src/core/qgsaggregatecalculator.h
+++ b/src/core/qgsaggregatecalculator.h
@@ -86,11 +86,11 @@ class CORE_EXPORT QgsAggregateCalculator
     /** Constructor for QgsAggregateCalculator.
      * @param layer vector layer to calculate aggregate from
      */
-    QgsAggregateCalculator( QgsVectorLayer* layer );
+    QgsAggregateCalculator( const QgsVectorLayer* layer );
 
     /** Returns the associated vector layer.
      */
-    QgsVectorLayer* layer() const;
+    const QgsVectorLayer* layer() const;
 
     /** Sets all aggregate parameters from a parameter bundle.
      * @param parameters aggregate parameters
@@ -140,7 +140,7 @@ class CORE_EXPORT QgsAggregateCalculator
   private:
 
     //! Source layer
-    QgsVectorLayer* mLayer;
+    const QgsVectorLayer* mLayer;
 
     //! Filter expression, or empty for no filter
     QString mFilterExpression;

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -84,8 +84,6 @@ QgsMapLayer::QgsMapLayer( QgsMapLayer::LayerType type,
   mMinScale = 0;
   mMaxScale = 100000000;
   mScaleBasedVisibility = false;
-
-  connect( this, SIGNAL( nameChanged() ), this, SIGNAL( layerNameChanged() ) );
 }
 
 QgsMapLayer::~QgsMapLayer()
@@ -103,11 +101,6 @@ QgsMapLayer::LayerType QgsMapLayer::type() const
 QString QgsMapLayer::id() const
 {
   return mID;
-}
-
-void QgsMapLayer::setLayerName( const QString & name )
-{
-  setName( name );
 }
 
 void QgsMapLayer::setName( const QString& name )
@@ -930,17 +923,6 @@ void QgsMapLayer::invalidTransformInput()
   // TODO: emit a signal - it will be used to update legend
 }
 
-
-QString QgsMapLayer::lastErrorTitle()
-{
-  return QString();
-}
-
-QString QgsMapLayer::lastError()
-{
-  return QString();
-}
-
 #if 0
 void QgsMapLayer::connectNotify( const char * signal )
 {
@@ -952,11 +934,6 @@ void QgsMapLayer::connectNotify( const char * signal )
 bool QgsMapLayer::isInScaleRange( double scale ) const
 {
   return !mScaleBasedVisibility || ( mMinScale * QGis::SCALE_PRECISION < scale && scale < mMaxScale );
-}
-
-void QgsMapLayer::toggleScaleBasedVisibility( bool theVisibilityFlag )
-{
-  setScaleBasedVisibility( theVisibilityFlag );
 }
 
 bool QgsMapLayer::hasScaleBasedVisibility() const
@@ -1669,11 +1646,6 @@ void QgsMapLayer::setValid( bool valid )
   mValid = valid;
 }
 
-void QgsMapLayer::setCacheImage( QImage * )
-{
-  emit repaintRequested();
-}
-
 void QgsMapLayer::setLegend( QgsMapLayerLegend* legend )
 {
   if ( legend == mLegend )
@@ -1696,11 +1668,6 @@ QgsMapLayerLegend*QgsMapLayer::legend() const
 QgsMapLayerStyleManager* QgsMapLayer::styleManager() const
 {
   return mStyleManager;
-}
-
-void QgsMapLayer::clearCacheImage()
-{
-  emit repaintRequested();
 }
 
 void QgsMapLayer::triggerRepaint()

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -1672,7 +1672,7 @@ void QgsMapLayer::triggerRepaint()
   emit repaintRequested();
 }
 
-QString QgsMapLayer::metadata()
+QString QgsMapLayer::metadata() const
 {
   return QString();
 }

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -135,7 +135,7 @@ QString QgsMapLayer::source() const
   return mDataSource;
 }
 
-QgsRectangle QgsMapLayer::extent()
+QgsRectangle QgsMapLayer::extent() const
 {
   return mExtent;
 }
@@ -528,7 +528,7 @@ bool QgsMapLayer::readXml( const QDomNode& layer_node )
 
 
 
-bool QgsMapLayer::writeLayerXML( QDomElement& layerElement, QDomDocument& document, const QString& relativeBasePath )
+bool QgsMapLayer::writeLayerXML( QDomElement& layerElement, QDomDocument& document, const QString& relativeBasePath ) const
 {
   // use scale dependent visibility flag
   layerElement.setAttribute( "hasScaleBasedVisibilityFlag", hasScaleBasedVisibility() ? 1 : 0 );
@@ -552,7 +552,7 @@ bool QgsMapLayer::writeLayerXML( QDomElement& layerElement, QDomDocument& docume
 
   QString src = source();
 
-  QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( this );
+  const QgsVectorLayer *vlayer = qobject_cast<const QgsVectorLayer *>( this );
   // TODO: what about postgres, mysql and others, they should not go through writePath()
   if ( vlayer && vlayer->providerType() == "spatialite" )
   {
@@ -591,7 +591,7 @@ bool QgsMapLayer::writeLayerXML( QDomElement& layerElement, QDomDocument& docume
 
     if ( !vlayer )
     {
-      QgsRasterLayer *rlayer = qobject_cast<QgsRasterLayer *>( this );
+      const QgsRasterLayer *rlayer = qobject_cast<const QgsRasterLayer *>( this );
       // Update path for subdataset
       if ( rlayer && rlayer->providerType() == "gdal" )
       {
@@ -869,7 +869,7 @@ QList<QgsMapLayer *> QgsMapLayer::fromLayerDefinitionFile( const QString &qlrfil
 }
 
 
-bool QgsMapLayer::writeXml( QDomNode & layer_node, QDomDocument & document )
+bool QgsMapLayer::writeXml( QDomNode & layer_node, QDomDocument & document ) const
 {
   Q_UNUSED( layer_node );
   Q_UNUSED( document );
@@ -908,10 +908,7 @@ void QgsMapLayer::writeStyleManager( QDomNode& layerNode, QDomDocument& doc ) co
   }
 }
 
-
-
-
-bool QgsMapLayer::isValid()
+bool QgsMapLayer::isValid() const
 {
   return mValid;
 }
@@ -941,9 +938,9 @@ bool QgsMapLayer::hasScaleBasedVisibility() const
   return mScaleBasedVisibility;
 }
 
-void QgsMapLayer::setMinimumScale( double theMinScale )
+void QgsMapLayer::setMinimumScale( double scale )
 {
-  mMinScale = theMinScale;
+  mMinScale = scale;
 }
 
 double QgsMapLayer::minimumScale() const
@@ -952,9 +949,9 @@ double QgsMapLayer::minimumScale() const
 }
 
 
-void QgsMapLayer::setMaximumScale( double theMaxScale )
+void QgsMapLayer::setMaximumScale( double scale )
 {
-  mMaxScale = theMaxScale;
+  mMaxScale = scale;
 }
 
 void QgsMapLayer::setScaleBasedVisibility( const bool enabled )
@@ -1001,7 +998,7 @@ void QgsMapLayer::setCrs( const QgsCoordinateReferenceSystem& srs, bool emitSign
   }
 
   if ( emitSignal )
-    emit layerCrsChanged();
+    emit crsChanged();
 }
 
 QString QgsMapLayer::capitaliseLayerName( const QString& name )
@@ -1019,7 +1016,7 @@ QString QgsMapLayer::capitaliseLayerName( const QString& name )
   return layerName;
 }
 
-QString QgsMapLayer::styleURI()
+QString QgsMapLayer::styleURI() const
 {
   QString myURI = publicSource();
 
@@ -1071,14 +1068,14 @@ QString QgsMapLayer::styleURI()
   return key;
 }
 
-QString QgsMapLayer::loadDefaultStyle( bool & theResultFlag )
+QString QgsMapLayer::loadDefaultStyle( bool & resultFlag )
 {
-  return loadNamedStyle( styleURI(), theResultFlag );
+  return loadNamedStyle( styleURI(), resultFlag );
 }
 
-bool QgsMapLayer::loadNamedStyleFromDb( const QString &db, const QString &theURI, QString &qml )
+bool QgsMapLayer::loadNamedStyleFromDb( const QString &db, const QString &uri, QString &qml )
 {
-  QgsDebugMsg( QString( "db = %1 uri = %2" ).arg( db, theURI ) );
+  QgsDebugMsg( QString( "db = %1 uri = %2" ).arg( db, uri ) );
 
   bool theResultFlag = false;
 
@@ -1088,7 +1085,7 @@ bool QgsMapLayer::loadNamedStyleFromDb( const QString &db, const QString &theURI
   const char *myTail;
   int myResult;
 
-  QgsDebugMsg( QString( "Trying to load style for \"%1\" from \"%2\"" ).arg( theURI, db ) );
+  QgsDebugMsg( QString( "Trying to load style for \"%1\" from \"%2\"" ).arg( uri, db ) );
 
   if ( db.isEmpty() || !QFile( db ).exists() )
     return false;
@@ -1103,7 +1100,7 @@ bool QgsMapLayer::loadNamedStyleFromDb( const QString &db, const QString &theURI
   myResult = sqlite3_prepare( myDatabase, mySql.toUtf8().data(), mySql.toUtf8().length(), &myPreparedStatement, &myTail );
   if ( myResult == SQLITE_OK )
   {
-    QByteArray param = theURI.toUtf8();
+    QByteArray param = uri.toUtf8();
 
     if ( sqlite3_bind_text( myPreparedStatement, 1, param.data(), param.length(), SQLITE_STATIC ) == SQLITE_OK &&
          sqlite3_step( myPreparedStatement ) == SQLITE_ROW )
@@ -1121,11 +1118,11 @@ bool QgsMapLayer::loadNamedStyleFromDb( const QString &db, const QString &theURI
 }
 
 
-QString QgsMapLayer::loadNamedStyle( const QString &theURI, bool &theResultFlag )
+QString QgsMapLayer::loadNamedStyle( const QString &uri, bool &resultFlag )
 {
-  QgsDebugMsg( QString( "uri = %1 myURI = %2" ).arg( theURI, publicSource() ) );
+  QgsDebugMsg( QString( "uri = %1 myURI = %2" ).arg( uri, publicSource() ) );
 
-  theResultFlag = false;
+  resultFlag = false;
 
   QDomDocument myDocument( "qgis" );
 
@@ -1133,12 +1130,12 @@ QString QgsMapLayer::loadNamedStyle( const QString &theURI, bool &theResultFlag 
   int line, column;
   QString myErrorMessage;
 
-  QFile myFile( theURI );
+  QFile myFile( uri );
   if ( myFile.open( QFile::ReadOnly ) )
   {
     // read file
-    theResultFlag = myDocument.setContent( &myFile, &myErrorMessage, &line, &column );
-    if ( !theResultFlag )
+    resultFlag = myDocument.setContent( &myFile, &myErrorMessage, &line, &column );
+    if ( !resultFlag )
       myErrorMessage = tr( "%1 at line %2 column %3" ).arg( myErrorMessage ).arg( line ).arg( column );
     myFile.close();
   }
@@ -1148,12 +1145,12 @@ QString QgsMapLayer::loadNamedStyle( const QString &theURI, bool &theResultFlag 
     QgsDebugMsg( QString( "project fileName: %1" ).arg( project.absoluteFilePath() ) );
 
     QString qml;
-    if ( loadNamedStyleFromDb( QDir( QgsApplication::qgisSettingsDirPath() ).absoluteFilePath( "qgis.qmldb" ), theURI, qml ) ||
-         ( project.exists() && loadNamedStyleFromDb( project.absoluteDir().absoluteFilePath( project.baseName() + ".qmldb" ), theURI, qml ) ) ||
-         loadNamedStyleFromDb( QDir( QgsApplication::pkgDataPath() ).absoluteFilePath( "resources/qgis.qmldb" ), theURI, qml ) )
+    if ( loadNamedStyleFromDb( QDir( QgsApplication::qgisSettingsDirPath() ).absoluteFilePath( "qgis.qmldb" ), uri, qml ) ||
+         ( project.exists() && loadNamedStyleFromDb( project.absoluteDir().absoluteFilePath( project.baseName() + ".qmldb" ), uri, qml ) ) ||
+         loadNamedStyleFromDb( QDir( QgsApplication::pkgDataPath() ).absoluteFilePath( "resources/qgis.qmldb" ), uri, qml ) )
     {
-      theResultFlag = myDocument.setContent( qml, &myErrorMessage, &line, &column );
-      if ( !theResultFlag )
+      resultFlag = myDocument.setContent( qml, &myErrorMessage, &line, &column );
+      if ( !resultFlag )
       {
         myErrorMessage = tr( "%1 at line %2 column %3" ).arg( myErrorMessage ).arg( line ).arg( column );
       }
@@ -1164,14 +1161,14 @@ QString QgsMapLayer::loadNamedStyle( const QString &theURI, bool &theResultFlag 
     }
   }
 
-  if ( !theResultFlag )
+  if ( !resultFlag )
   {
     return myErrorMessage;
   }
 
-  theResultFlag = importNamedStyle( myDocument, myErrorMessage );
-  if ( !theResultFlag )
-    myErrorMessage = tr( "Loading style file %1 failed because:\n%2" ).arg( theURI, myErrorMessage );
+  resultFlag = importNamedStyle( myDocument, myErrorMessage );
+  if ( !resultFlag )
+    myErrorMessage = tr( "Loading style file %1 failed because:\n%2" ).arg( uri, myErrorMessage );
 
   return myErrorMessage;
 }
@@ -1199,7 +1196,7 @@ bool QgsMapLayer::importNamedStyle( QDomDocument& myDocument, QString& myErrorMe
   //Test for matching geometry type on vector layers when applying, if geometry type is given in the style
   if ( type() == QgsMapLayer::VectorLayer && !myRoot.firstChildElement( "layerGeometryType" ).isNull() )
   {
-    QgsVectorLayer *vl = static_cast<QgsVectorLayer*>( this );
+    QgsVectorLayer *vl = qobject_cast<QgsVectorLayer*>( this );
     int importLayerGeometryType = myRoot.firstChildElement( "layerGeometryType" ).text().toInt();
     if ( vl->geometryType() != importLayerGeometryType )
     {
@@ -1228,7 +1225,7 @@ bool QgsMapLayer::importNamedStyle( QDomDocument& myDocument, QString& myErrorMe
   return readSymbology( myRoot, myErrorMessage );
 }
 
-void QgsMapLayer::exportNamedStyle( QDomDocument &doc, QString &errorMsg )
+void QgsMapLayer::exportNamedStyle( QDomDocument &doc, QString &errorMsg ) const
 {
   QDomImplementation DomImplementation;
   QDomDocumentType documentType = DomImplementation.createDocumentType( "qgis", "http://mrcc.com/qgis.dtd", "SYSTEM" );
@@ -1263,7 +1260,7 @@ void QgsMapLayer::exportNamedStyle( QDomDocument &doc, QString &errorMsg )
   if ( type() == QgsMapLayer::VectorLayer )
   {
     //Getting the selectionLayer geometry
-    QgsVectorLayer *vl = static_cast<QgsVectorLayer*>( this );
+    const QgsVectorLayer *vl = qobject_cast<const QgsVectorLayer*>( this );
     QString geoType = QString::number( vl->geometryType() );
 
     //Adding geometryinformation
@@ -1277,12 +1274,12 @@ void QgsMapLayer::exportNamedStyle( QDomDocument &doc, QString &errorMsg )
   doc = myDocument;
 }
 
-QString QgsMapLayer::saveDefaultStyle( bool & theResultFlag )
+QString QgsMapLayer::saveDefaultStyle( bool & resultFlag )
 {
-  return saveNamedStyle( styleURI(), theResultFlag );
+  return saveNamedStyle( styleURI(), resultFlag );
 }
 
-QString QgsMapLayer::saveNamedStyle( const QString &theURI, bool &theResultFlag )
+QString QgsMapLayer::saveNamedStyle( const QString &uri, bool &resultFlag )
 {
   QString myErrorMessage;
   QDomDocument myDocument;
@@ -1296,24 +1293,24 @@ QString QgsMapLayer::saveNamedStyle( const QString &theURI, bool &theResultFlag 
   QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( this );
   if ( vlayer && vlayer->providerType() == "ogr" )
   {
-    QStringList theURIParts = theURI.split( '|' );
+    QStringList theURIParts = uri.split( '|' );
     filename = theURIParts[0];
   }
   else if ( vlayer && vlayer->providerType() == "gpx" )
   {
-    QStringList theURIParts = theURI.split( '?' );
+    QStringList theURIParts = uri.split( '?' );
     filename = theURIParts[0];
   }
   else if ( vlayer && vlayer->providerType() == "delimitedtext" )
   {
-    filename = QUrl::fromEncoded( theURI.toAscii() ).toLocalFile();
+    filename = QUrl::fromEncoded( uri.toAscii() ).toLocalFile();
     // toLocalFile() returns an empty string if theURI is a plain Windows-path, e.g. "C:/style.qml"
     if ( filename.isEmpty() )
-      filename = theURI;
+      filename = uri;
   }
   else
   {
-    filename = theURI;
+    filename = uri;
   }
 
   QFileInfo myFileInfo( filename );
@@ -1335,12 +1332,12 @@ QString QgsMapLayer::saveNamedStyle( const QString &theURI, bool &theResultFlag 
       // save as utf-8 with 2 spaces for indents
       myDocument.save( myFileStream, 2 );
       myFile.close();
-      theResultFlag = true;
+      resultFlag = true;
       return tr( "Created default style file as %1" ).arg( myFileName );
     }
     else
     {
-      theResultFlag = false;
+      resultFlag = false;
       return tr( "ERROR: Failed to created default style file as %1. Check file permissions and retry." ).arg( myFileName );
     }
   }
@@ -1360,7 +1357,7 @@ QString QgsMapLayer::saveNamedStyle( const QString &theURI, bool &theResultFlag 
       return tr( "User database could not be opened." );
     }
 
-    QByteArray param0 = theURI.toUtf8();
+    QByteArray param0 = uri.toUtf8();
     QByteArray param1 = qml.toUtf8();
 
     QString mySql = "create table if not exists tbl_styles(style varchar primary key,qml varchar)";
@@ -1371,7 +1368,7 @@ QString QgsMapLayer::saveNamedStyle( const QString &theURI, bool &theResultFlag 
       {
         sqlite3_finalize( myPreparedStatement );
         sqlite3_close( myDatabase );
-        theResultFlag = false;
+        resultFlag = false;
         return tr( "The style table could not be created." );
       }
     }
@@ -1386,14 +1383,14 @@ QString QgsMapLayer::saveNamedStyle( const QString &theURI, bool &theResultFlag 
            sqlite3_bind_text( myPreparedStatement, 2, param1.data(), param1.length(), SQLITE_STATIC ) == SQLITE_OK &&
            sqlite3_step( myPreparedStatement ) == SQLITE_DONE )
       {
-        theResultFlag = true;
-        myErrorMessage = tr( "The style %1 was saved to database" ).arg( theURI );
+        resultFlag = true;
+        myErrorMessage = tr( "The style %1 was saved to database" ).arg( uri );
       }
     }
 
     sqlite3_finalize( myPreparedStatement );
 
-    if ( !theResultFlag )
+    if ( !resultFlag )
     {
       QString mySql = "update tbl_styles set qml=? where style=?";
       myResult = sqlite3_prepare( myDatabase, mySql.toUtf8().data(), mySql.toUtf8().length(), &myPreparedStatement, &myTail );
@@ -1403,19 +1400,19 @@ QString QgsMapLayer::saveNamedStyle( const QString &theURI, bool &theResultFlag 
              sqlite3_bind_text( myPreparedStatement, 1, param1.data(), param1.length(), SQLITE_STATIC ) == SQLITE_OK &&
              sqlite3_step( myPreparedStatement ) == SQLITE_DONE )
         {
-          theResultFlag = true;
-          myErrorMessage = tr( "The style %1 was updated in the database." ).arg( theURI );
+          resultFlag = true;
+          myErrorMessage = tr( "The style %1 was updated in the database." ).arg( uri );
         }
         else
         {
-          theResultFlag = false;
-          myErrorMessage = tr( "The style %1 could not be updated in the database." ).arg( theURI );
+          resultFlag = false;
+          myErrorMessage = tr( "The style %1 could not be updated in the database." ).arg( uri );
         }
       }
       else
       {
-        theResultFlag = false;
-        myErrorMessage = tr( "The style %1 could not be inserted into database." ).arg( theURI );
+        resultFlag = false;
+        myErrorMessage = tr( "The style %1 could not be inserted into database." ).arg( uri );
       }
 
       sqlite3_finalize( myPreparedStatement );
@@ -1427,7 +1424,7 @@ QString QgsMapLayer::saveNamedStyle( const QString &theURI, bool &theResultFlag 
   return myErrorMessage;
 }
 
-void QgsMapLayer::exportSldStyle( QDomDocument &doc, QString &errorMsg )
+void QgsMapLayer::exportSldStyle( QDomDocument &doc, QString &errorMsg ) const
 {
   QDomDocument myDocument = QDomDocument();
 
@@ -1449,7 +1446,7 @@ void QgsMapLayer::exportSldStyle( QDomDocument &doc, QString &errorMsg )
   QDomElement namedLayerNode = myDocument.createElement( "NamedLayer" );
   root.appendChild( namedLayerNode );
 
-  QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( this );
+  const QgsVectorLayer *vlayer = qobject_cast<const QgsVectorLayer *>( this );
   if ( !vlayer )
   {
     errorMsg = tr( "Could not save symbology because:\n%1" )
@@ -1466,41 +1463,41 @@ void QgsMapLayer::exportSldStyle( QDomDocument &doc, QString &errorMsg )
   doc = myDocument;
 }
 
-QString QgsMapLayer::saveSldStyle( const QString &theURI, bool &theResultFlag )
+QString QgsMapLayer::saveSldStyle( const QString &uri, bool &resultFlag ) const
 {
   QString errorMsg;
   QDomDocument myDocument;
   exportSldStyle( myDocument, errorMsg );
   if ( !errorMsg.isNull() )
   {
-    theResultFlag = false;
+    resultFlag = false;
     return errorMsg;
   }
-  QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( this );
+  const QgsVectorLayer *vlayer = qobject_cast<const QgsVectorLayer *>( this );
 
   // check if the uri is a file or ends with .sld,
   // which indicates that it should become one
   QString filename;
   if ( vlayer->providerType() == "ogr" )
   {
-    QStringList theURIParts = theURI.split( '|' );
+    QStringList theURIParts = uri.split( '|' );
     filename = theURIParts[0];
   }
   else if ( vlayer->providerType() == "gpx" )
   {
-    QStringList theURIParts = theURI.split( '?' );
+    QStringList theURIParts = uri.split( '?' );
     filename = theURIParts[0];
   }
   else if ( vlayer->providerType() == "delimitedtext" )
   {
-    filename = QUrl::fromEncoded( theURI.toAscii() ).toLocalFile();
+    filename = QUrl::fromEncoded( uri.toAscii() ).toLocalFile();
     // toLocalFile() returns an empty string if theURI is a plain Windows-path, e.g. "C:/style.qml"
     if ( filename.isEmpty() )
-      filename = theURI;
+      filename = uri;
   }
   else
   {
-    filename = theURI;
+    filename = uri;
   }
 
   QFileInfo myFileInfo( filename );
@@ -1522,20 +1519,20 @@ QString QgsMapLayer::saveSldStyle( const QString &theURI, bool &theResultFlag )
       // save as utf-8 with 2 spaces for indents
       myDocument.save( myFileStream, 2 );
       myFile.close();
-      theResultFlag = true;
+      resultFlag = true;
       return tr( "Created default style file as %1" ).arg( myFileName );
     }
   }
 
-  theResultFlag = false;
+  resultFlag = false;
   return tr( "ERROR: Failed to created SLD style file as %1. Check file permissions and retry." ).arg( filename );
 }
 
-QString QgsMapLayer::loadSldStyle( const QString &theURI, bool &theResultFlag )
+QString QgsMapLayer::loadSldStyle( const QString &uri, bool &resultFlag )
 {
   QgsDebugMsg( "Entered." );
 
-  theResultFlag = false;
+  resultFlag = false;
 
   QDomDocument myDocument;
 
@@ -1543,21 +1540,21 @@ QString QgsMapLayer::loadSldStyle( const QString &theURI, bool &theResultFlag )
   int line, column;
   QString myErrorMessage;
 
-  QFile myFile( theURI );
+  QFile myFile( uri );
   if ( myFile.open( QFile::ReadOnly ) )
   {
     // read file
-    theResultFlag = myDocument.setContent( &myFile, true, &myErrorMessage, &line, &column );
-    if ( !theResultFlag )
+    resultFlag = myDocument.setContent( &myFile, true, &myErrorMessage, &line, &column );
+    if ( !resultFlag )
       myErrorMessage = tr( "%1 at line %2 column %3" ).arg( myErrorMessage ).arg( line ).arg( column );
     myFile.close();
   }
   else
   {
-    myErrorMessage = tr( "Unable to open file %1" ).arg( theURI );
+    myErrorMessage = tr( "Unable to open file %1" ).arg( uri );
   }
 
-  if ( !theResultFlag )
+  if ( !resultFlag )
   {
     return myErrorMessage;
   }
@@ -1566,8 +1563,8 @@ QString QgsMapLayer::loadSldStyle( const QString &theURI, bool &theResultFlag )
   QDomElement myRoot = myDocument.firstChildElement( "StyledLayerDescriptor" );
   if ( myRoot.isNull() )
   {
-    myErrorMessage = QString( "Error: StyledLayerDescriptor element not found in %1" ).arg( theURI );
-    theResultFlag = false;
+    myErrorMessage = QString( "Error: StyledLayerDescriptor element not found in %1" ).arg( uri );
+    resultFlag = false;
     return myErrorMessage;
   }
 
@@ -1577,15 +1574,15 @@ QString QgsMapLayer::loadSldStyle( const QString &theURI, bool &theResultFlag )
   if ( namedLayerElem.isNull() )
   {
     myErrorMessage = QLatin1String( "Info: NamedLayer element not found." );
-    theResultFlag = false;
+    resultFlag = false;
     return myErrorMessage;
   }
 
   QString errorMsg;
-  theResultFlag = readSld( namedLayerElem, errorMsg );
-  if ( !theResultFlag )
+  resultFlag = readSld( namedLayerElem, errorMsg );
+  if ( !resultFlag )
   {
-    myErrorMessage = tr( "Loading style file %1 failed because:\n%2" ).arg( theURI, errorMsg );
+    myErrorMessage = tr( "Loading style file %1 failed because:\n%2" ).arg( uri, errorMsg );
     return myErrorMessage;
   }
 

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -53,7 +53,8 @@ class CORE_EXPORT QgsMapLayer : public QObject
     Q_PROPERTY( QString name READ name WRITE setName NOTIFY nameChanged )
 
   public:
-    /** Layers enum defining the types of layers that can be added to a map */
+
+    //! Types of layers that can be added to a map
     enum LayerType
     {
       VectorLayer,
@@ -61,179 +62,224 @@ class CORE_EXPORT QgsMapLayer : public QObject
       PluginLayer
     };
 
-    /** Constructor
-     * @param type Type of layer as defined in QgsMapLayer::LayerType enum
-     * @param lyrname Display Name of the layer
+    /** Constructor for QgsMapLayer
+     * @param type layer type
+     * @param name display name for the layer
      * @param source datasource of layer
      */
-    QgsMapLayer( QgsMapLayer::LayerType type = VectorLayer, const QString& lyrname = QString::null, const QString& source = QString::null );
+    QgsMapLayer( QgsMapLayer::LayerType type = VectorLayer, const QString& name = QString::null, const QString& source = QString::null );
 
-    /** Destructor */
     virtual ~QgsMapLayer();
 
-    /** Get the type of the layer
-     * @return Integer matching a value in the QgsMapLayer::LayerType enum
+    /** Returns the type of the layer.
      */
     QgsMapLayer::LayerType type() const;
 
-    /** Get this layer's unique ID, this ID is used to access this layer from map layer registry */
+    /** Returns the layer's unique ID, which is used to access this layer from QgsMapLayerRegistry. */
     QString id() const;
 
     /**
      * Set the display name of the layer
-     * @param name New name for the layer
-     *
+     * @param name new name for the layer
      * @note added in 2.16
+     * @see name()
      */
     void setName( const QString& name );
 
-    /** Get the display name of the layer
+    /** Returns the display name of the layer.
      * @return the layer name
+     * @see setName()
      */
     QString name() const;
 
-    /** Get the original name of the layer
+    /** Returns the original name of the layer.
      * @return the original layer name
      */
     QString originalName() const { return mLayerOrigName; }
 
-    /** Set the short name of the layer
-     *  used by QGIS Server to identify the layer
+    /** Sets the short name of the layer
+     *  used by QGIS Server to identify the layer.
      * @return the layer short name
+     * @see shortName()
      */
     void setShortName( const QString& shortName ) { mShortName = shortName; }
-    /** Get the short name of the layer
-     *  used by QGIS Server to identify the layer
+
+    /** Returns the short name of the layer
+     *  used by QGIS Server to identify the layer.
      * @return the layer short name
+     * @see setShortName()
      */
     QString shortName() const { return mShortName; }
 
-    /** Set the title of the layer
-     *  used by QGIS Server in GetCapabilities request
+    /** Sets the title of the layer
+     *  used by QGIS Server in GetCapabilities request.
      * @return the layer title
+     * @see title()
      */
     void setTitle( const QString& title ) { mTitle = title; }
-    /** Get the title of the layer
-     *  used by QGIS Server in GetCapabilities request
+
+    /** Returns the title of the layer
+     *  used by QGIS Server in GetCapabilities request.
      * @return the layer title
+     * @see setTitle()
      */
     QString title() const { return mTitle; }
 
-    /** Set the abstract of the layer
-     *  used by QGIS Server in GetCapabilities request
+    /** Sets the abstract of the layer
+     *  used by QGIS Server in GetCapabilities request.
      * @return the layer abstract
+     * @see abstract()
      */
     void setAbstract( const QString& abstract ) { mAbstract = abstract; }
-    /** Get the abstract of the layer
-     *  used by QGIS Server in GetCapabilities request
+
+    /** Returns the abstract of the layer
+     *  used by QGIS Server in GetCapabilities request.
      * @return the layer abstract
+     * @see setAbstract()
      */
     QString abstract() const { return mAbstract; }
 
-    /** Set the keyword list of the layer
-     *  used by QGIS Server in GetCapabilities request
+    /** Sets the keyword list of the layer
+     *  used by QGIS Server in GetCapabilities request.
      * @return the layer keyword list
+     * @see keywordList()
      */
     void setKeywordList( const QString& keywords ) { mKeywordList = keywords; }
-    /** Get the keyword list of the layer
-     *  used by QGIS Server in GetCapabilities request
+
+    /** Returns the keyword list of the layer
+     *  used by QGIS Server in GetCapabilities request.
      * @return the layer keyword list
+     * @see setKeywordList()
      */
     QString keywordList() const { return mKeywordList; }
 
     /* Layer dataUrl information */
-    /** Set the DataUrl of the layer
-     *  used by QGIS Server in GetCapabilities request
-     *  DataUrl is a a link to the underlying data represented by a particular layer
+
+    /** Sets the DataUrl of the layer
+     *  used by QGIS Server in GetCapabilities request.
+     *  DataUrl is a a link to the underlying data represented by a particular layer.
      * @return the layer DataUrl
+     * @see dataUrl()
      */
     void setDataUrl( const QString& dataUrl ) { mDataUrl = dataUrl; }
-    /** Get the DataUrl of the layer
-     *  used by QGIS Server in GetCapabilities request
-     *  DataUrl is a a link to the underlying data represented by a particular layer
+
+    /** Returns the DataUrl of the layer
+     *  used by QGIS Server in GetCapabilities request.
+     *  DataUrl is a a link to the underlying data represented by a particular layer.
      * @return the layer DataUrl
+     * @see setDataUrl()
      */
     QString dataUrl() const { return mDataUrl; }
-    /** Set the DataUrl format of the layer
-     *  used by QGIS Server in GetCapabilities request
-     *  DataUrl is a a link to the underlying data represented by a particular layer
+
+    /** Sets the DataUrl format of the layer
+     *  used by QGIS Server in GetCapabilities request.
+     *  DataUrl is a a link to the underlying data represented by a particular layer.
      * @return the layer DataUrl format
+     * @see dataUrlFormat()
      */
     void setDataUrlFormat( const QString& dataUrlFormat ) { mDataUrlFormat = dataUrlFormat; }
-    /** Get the DataUrl format of the layer
-     *  used by QGIS Server in GetCapabilities request
-     *  DataUrl is a a link to the underlying data represented by a particular layer
+
+    /** Returns the DataUrl format of the layer
+     *  used by QGIS Server in GetCapabilities request.
+     *  DataUrl is a a link to the underlying data represented by a particular layer.
      * @return the layer DataUrl format
+     * @see setDataUrlFormat()
      */
     QString dataUrlFormat() const { return mDataUrlFormat; }
 
     /* Layer attribution information */
-    /** Set the attribution of the layer
-     *  used by QGIS Server in GetCapabilities request
-     *  Attribution indicates the provider of a Layer or collection of Layers.
+
+    /** Sets the attribution of the layer
+     *  used by QGIS Server in GetCapabilities request.
+     *  Attribution indicates the provider of a layer or collection of layers.
      * @return the layer attribution
+     * @see attribution()
      */
     void setAttribution( const QString& attrib ) { mAttribution = attrib; }
-    /** Get the attribution of the layer
-     *  used by QGIS Server in GetCapabilities request
-     *  Attribution indicates the provider of a Layer or collection of Layers.
+
+    /** Returns the attribution of the layer
+     *  used by QGIS Server in GetCapabilities request.
+     *  Attribution indicates the provider of a layer or collection of layers.
      * @return the layer attribution
+     * @see setAttribution()
      */
     QString attribution() const { return mAttribution; }
-    /** Set the attribution URL of the layer
-     *  used by QGIS Server in GetCapabilities request
-     *  Attribution indicates the provider of a Layer or collection of Layers.
+
+    /** Sets the attribution URL of the layer
+     *  used by QGIS Server in GetCapabilities request.
+     *  Attribution indicates the provider of a layer or collection of layers.
      * @return the layer attribution URL
+     * @see attributionUrl()
      */
     void setAttributionUrl( const QString& attribUrl ) { mAttributionUrl = attribUrl; }
-    /** Get the attribution URL of the layer
-     *  used by QGIS Server in GetCapabilities request
-     *  Attribution indicates the provider of a Layer or collection of Layers.
+
+    /** Returns the attribution URL of the layer
+     *  used by QGIS Server in GetCapabilities request.
+     *  Attribution indicates the provider of a layer or collection of layers.
      * @return the layer attribution URL
+     * @see setAttributionUrl()
      */
     QString attributionUrl() const { return mAttributionUrl; }
 
     /* Layer metadataUrl information */
-    /** Set the metadata URL of the layer
-     *  used by QGIS Server in GetCapabilities request
+
+    /** Sets the metadata URL of the layer
+     *  used by QGIS Server in GetCapabilities request.
      *  MetadataUrl is a a link to the detailed, standardized metadata about the data.
      * @return the layer metadata URL
+     * @see metadataUrl()
      */
     void setMetadataUrl( const QString& metaUrl ) { mMetadataUrl = metaUrl; }
-    /** Get the metadata URL of the layer
-     *  used by QGIS Server in GetCapabilities request
+
+    /** Returns the metadata URL of the layer
+     *  used by QGIS Server in GetCapabilities request.
      *  MetadataUrl is a a link to the detailed, standardized metadata about the data.
      * @return the layer metadata URL
+     * @see setMetadataUrl()
      */
     QString metadataUrl() const { return mMetadataUrl; }
+
     /** Set the metadata type of the layer
      *  used by QGIS Server in GetCapabilities request
      *  MetadataUrlType indicates the standard to which the metadata complies.
      * @return the layer metadata type
+     * @see metadataUrlType()
      */
     void setMetadataUrlType( const QString& metaUrlType ) { mMetadataUrlType = metaUrlType; }
-    /** Get the metadata type of the layer
-     *  used by QGIS Server in GetCapabilities request
+
+    /** Returns the metadata type of the layer
+     *  used by QGIS Server in GetCapabilities request.
      *  MetadataUrlType indicates the standard to which the metadata complies.
      * @return the layer metadata type
+     * @see setMetadataUrlType()
      */
     QString metadataUrlType() const { return mMetadataUrlType; }
-    /** Set the metadata format of the layer
-     *  used by QGIS Server in GetCapabilities request
+
+    /** Sets the metadata format of the layer
+     *  used by QGIS Server in GetCapabilities request.
      *  MetadataUrlType indicates how the metadata is structured.
      * @return the layer metadata format
+     * @see metadataUrlFormat()
      */
     void setMetadataUrlFormat( const QString& metaUrlFormat ) { mMetadataUrlFormat = metaUrlFormat; }
-    /** Get the metadata format of the layer
-     *  used by QGIS Server in GetCapabilities request
+
+    /** Returns the metadata format of the layer
+     *  used by QGIS Server in GetCapabilities request.
      *  MetadataUrlType indicates how the metadata is structured.
      * @return the layer metadata format
+     * @see setMetadataUrlFormat()
      */
     QString metadataUrlFormat() const { return mMetadataUrlFormat; }
 
-    /** Set the blending mode used for rendering a layer */
+    /** Set the blending mode used for rendering a layer.
+     * @param blendMode new blending mode
+     * @see blendMode()
+    */
     void setBlendMode( QPainter::CompositionMode blendMode );
-    /** Returns the current blending mode for a layer */
+
+    /** Returns the current blending mode for a layer.
+     * @see setBlendMode()
+    */
     QPainter::CompositionMode blendMode() const;
 
     /** Returns if this layer is read only. */
@@ -261,40 +307,47 @@ class CORE_EXPORT QgsMapLayer : public QObject
      */
     virtual void drawLabels( QgsRenderContext& rendererContext );
 
-    /** Return the extent of the layer */
-    virtual QgsRectangle extent();
+    /** Returns the extent of the layer. */
+    virtual QgsRectangle extent() const;
 
     /** Return the status of the layer. An invalid layer is one which has a bad datasource
-     * or other problem. Child classes set this flag when intialized
-     * @return True if the layer is valid and can be accessed
+     * or other problem. Child classes set this flag when initialized.
+     * @return true if the layer is valid and can be accessed
      */
-    bool isValid();
+    bool isValid() const;
 
     /** Gets a version of the internal layer definition that has sensitive
       *  bits removed (for example, the password). This function should
       * be used when displaying the source name for general viewing.
+      * @see source()
      */
     QString publicSource() const;
 
-    /** Returns the source for the layer */
+    /** Returns the source for the layer. This source may contain usernames, passwords
+     * and other sensitive information.
+     * @see publicSource()
+     */
     QString source() const;
 
     /**
-     * Returns the sublayers of this layer
-     * (Useful for providers that manage their own layers, such as WMS)
+     * Returns the sublayers of this layer.
+     * (Useful for providers that manage their own layers, such as WMS).
      */
     virtual QStringList subLayers() const;
 
     /**
-     * Reorders the *previously selected* sublayers of this layer from bottom to top
-     * (Useful for providers that manage their own layers, such as WMS)
+     * Reorders the *previously selected* sublayers of this layer from bottom to top.
+     * (Useful for providers that manage their own layers, such as WMS).
      */
     virtual void setLayerOrder( const QStringList &layers );
 
-    /** Set the visibility of the given sublayer name */
-    virtual void setSubLayerVisibility( const QString& name, bool vis );
+    /** Set the visibility of the given sublayer name.
+     * @param name sublayer name
+     * @param visible sublayer visibility
+    */
+    virtual void setSubLayerVisibility( const QString& name, bool visible );
 
-    /** True if the layer can be edited */
+    /** Returns true if the layer can be edited. */
     virtual bool isEditable() const;
 
     /** Returns true if the layer is considered a spatial layer, ie it has some form of geometry associated with it.
@@ -335,7 +388,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
      *
      * @returns true if successful
      */
-    bool writeLayerXML( QDomElement& layerElement, QDomDocument& document, const QString& relativeBasePath = QString::null );
+    bool writeLayerXML( QDomElement& layerElement, QDomDocument& document, const QString& relativeBasePath = QString::null ) const;
 
     /** Returns the given layer as a layer definition document
      *  Layer definitions store the data source as well as styling and custom properties.
@@ -349,11 +402,18 @@ class CORE_EXPORT QgsMapLayer : public QObject
     static QList<QgsMapLayer*> fromLayerDefinition( QDomDocument& document, bool addToRegistry = false, bool addToLegend = false );
     static QList<QgsMapLayer*> fromLayerDefinitionFile( const QString &qlrfile );
 
-    /** Set a custom property for layer. Properties are stored in a map and saved in project file. */
+    /** Set a custom property for layer. Properties are stored in a map and saved in project file.
+     * @see customProperty()
+     * @see removeCustomProperty()
+     */
     void setCustomProperty( const QString& key, const QVariant& value );
-    /** Read a custom property from layer. Properties are stored in a map and saved in project file. */
+    /** Read a custom property from layer. Properties are stored in a map and saved in project file.
+     * @see setCustomProperty()
+    */
     QVariant customProperty( const QString& value, const QVariant& defaultValue = QVariant() ) const;
-    /** Remove a custom property from layer. Properties are stored in a map and saved in project file. */
+    /** Remove a custom property from layer. Properties are stored in a map and saved in project file.
+     * @see setCustomProperty()
+     */
     void removeCustomProperty( const QString& key );
 
     /** Get current status error. This error describes some principal problem
@@ -362,7 +422,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
      */
     virtual QgsError error() const { return mError; }
 
-    /** Returns layer's spatial reference system
+    /** Returns the layer's spatial reference system.
     @note This was introduced in QGIS 1.4
      */
     //TODO QGIS 3.0 - return QgsCoordinateReferenceSystem object, not reference (since they are implicitly shared)
@@ -380,34 +440,34 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * @return a QString with the style file name
      * @see also loadNamedStyle () and saveNamedStyle ();
      */
-    virtual QString styleURI();
+    virtual QString styleURI() const;
 
     /** Retrieve the default style for this layer if one
      * exists (either as a .qml file on disk or as a
      * record in the users style table in their personal qgis.db)
-     * @param theResultFlag a reference to a flag that will be set to false if
+     * @param resultFlag a reference to a flag that will be set to false if
      * we did not manage to load the default style.
      * @return a QString with any status messages
      * @see also loadNamedStyle ();
      */
-    virtual QString loadDefaultStyle( bool & theResultFlag );
+    virtual QString loadDefaultStyle( bool & resultFlag );
 
     /** Retrieve a named style for this layer if one
      * exists (either as a .qml file on disk or as a
      * record in the users style table in their personal qgis.db)
-     * @param theURI - the file name or other URI for the
+     * @param uri - the file name or other URI for the
      * style file. First an attempt will be made to see if this
      * is a file and load that, if that fails the qgis.db styles
      * table will be consulted to see if there is a style who's
      * key matches the URI.
-     * @param theResultFlag a reference to a flag that will be set to false if
+     * @param resultFlag a reference to a flag that will be set to false if
      * we did not manage to load the default style.
      * @return a QString with any status messages
      * @see also loadDefaultStyle ();
      */
-    virtual QString loadNamedStyle( const QString &theURI, bool &theResultFlag );
+    virtual QString loadNamedStyle( const QString& uri, bool &resultFlag );
 
-    virtual bool loadNamedStyleFromDb( const QString &db, const QString &theURI, QString &qml );
+    virtual bool loadNamedStyleFromDb( const QString &db, const QString &uri, QString &qml );
 
     /**
      * Import the properties of this layer from a QDomDocument
@@ -425,7 +485,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * @param errorMsg this QString will be initialized on error
      * during the execution of writeSymbology
      */
-    virtual void exportNamedStyle( QDomDocument &doc, QString &errorMsg );
+    virtual void exportNamedStyle( QDomDocument &doc, QString &errorMsg ) const;
 
 
     /**
@@ -434,35 +494,35 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * @param errorMsg this QString will be initialized on error
      * during the execution of writeSymbology
      */
-    virtual void exportSldStyle( QDomDocument &doc, QString &errorMsg );
+    virtual void exportSldStyle( QDomDocument &doc, QString &errorMsg ) const;
 
     /** Save the properties of this layer as the default style
      * (either as a .qml file on disk or as a
      * record in the users style table in their personal qgis.db)
-     * @param theResultFlag a reference to a flag that will be set to false if
+     * @param resultFlag a reference to a flag that will be set to false if
      * we did not manage to save the default style.
      * @return a QString with any status messages
      * @sa loadNamedStyle() and @see saveNamedStyle()
      */
-    virtual QString saveDefaultStyle( bool & theResultFlag );
+    virtual QString saveDefaultStyle( bool & resultFlag );
 
     /** Save the properties of this layer as a named style
      * (either as a .qml file on disk or as a
      * record in the users style table in their personal qgis.db)
-     * @param theURI the file name or other URI for the
+     * @param uri the file name or other URI for the
      * style file. First an attempt will be made to see if this
      * is a file and save to that, if that fails the qgis.db styles
      * table will be used to create a style entry who's
      * key matches the URI.
-     * @param theResultFlag a reference to a flag that will be set to false if
+     * @param resultFlag a reference to a flag that will be set to false if
      * we did not manage to save the default style.
      * @return a QString with any status messages
      * @sa saveDefaultStyle()
      */
-    virtual QString saveNamedStyle( const QString &theURI, bool &theResultFlag );
+    virtual QString saveNamedStyle( const QString &uri, bool &resultFlag );
 
-    virtual QString saveSldStyle( const QString &theURI, bool &theResultFlag );
-    virtual QString loadSldStyle( const QString &theURI, bool &theResultFlag );
+    virtual QString saveSldStyle( const QString &uri, bool &resultFlag ) const;
+    virtual QString loadSldStyle( const QString &uri, bool &resultFlag );
 
     virtual bool readSld( const QDomNode &node, QString &errorMessage )
     { Q_UNUSED( node ); errorMessage = QString( "Layer type %1 not supported" ).arg( type() ); return false; }
@@ -581,21 +641,21 @@ class CORE_EXPORT QgsMapLayer : public QObject
 
     /** Sets the minimum scale denominator at which the layer will be visible.
      * Scale based visibility is only used if setScaleBasedVisibility is set to true.
-     * @param theMinScale minimum scale denominator at which the layer should render
+     * @param scale minimum scale denominator at which the layer should render
      * @see minimumScale
      * @see setMaximumScale
      * @see setScaleBasedVisibility
      */
-    void setMinimumScale( double theMinScale );
+    void setMinimumScale( double scale );
 
     /** Sets the maximum scale denominator at which the layer will be visible.
      * Scale based visibility is only used if setScaleBasedVisibility is set to true.
-     * @param theMaxScale maximum scale denominator at which the layer should render
+     * @param scale maximum scale denominator at which the layer should render
      * @see maximumScale
      * @see setMinimumScale
      * @see setScaleBasedVisibility
      */
-    void setMaximumScale( double theMaxScale );
+    void setMaximumScale( double scale );
 
     /** Sets whether scale based visibility is enabled for the layer.
      * @param enabled set to true to enable scale based visibility
@@ -627,7 +687,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
   signals:
 
     /** Emit a signal with status (e.g. to be caught by QgisApp and display a msg on status bar) */
-    void statusChanged( const QString& theStatus );
+    void statusChanged( const QString& status );
 
     /**
      * Emitted when the name has been changed
@@ -637,7 +697,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
     void nameChanged();
 
     /** Emit a signal that layer's CRS has been reset */
-    void layerCrsChanged();
+    void crsChanged();
 
     /** By emitting this signal the layer tells that either appearance or content have been changed
      * and any view showing the rendered layer should refresh itself.
@@ -645,7 +705,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
     void repaintRequested();
 
     /** This is used to send a request that any mapcanvas using this layer update its extents */
-    void recalculateExtents();
+    void recalculateExtents() const;
 
     /** Data of layer changed */
     void dataChanged();
@@ -693,7 +753,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
     /** Called by writeLayerXML(), used by children to write state specific to them to
      *  project files.
      */
-    virtual bool writeXml( QDomNode & layer_node, QDomDocument & document );
+    virtual bool writeXml( QDomNode & layer_node, QDomDocument & document ) const;
 
 
     /** Read custom properties from project file.
@@ -715,12 +775,12 @@ class CORE_EXPORT QgsMapLayer : public QObject
 #endif
 
     /** Add error message */
-    void appendError( const QgsErrorMessage & theMessage ) { mError.append( theMessage );}
+    void appendError( const QgsErrorMessage & error ) { mError.append( error );}
     /** Set error message */
-    void setError( const QgsError & theError ) { mError = theError;}
+    void setError( const QgsError & error ) { mError = error;}
 
     /** Extent of the layer */
-    QgsRectangle mExtent;
+    mutable QgsRectangle mExtent;
 
     /** Indicates if the layer is valid and can be drawn */
     bool mValid;
@@ -770,7 +830,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
     virtual bool isReadOnly() const { return true; }
 
     /** Layer's spatial reference system.
-        private to make sure setCrs must be used and layerCrsChanged() is emitted */
+        private to make sure setCrs must be used and crsChanged() is emitted */
     QgsCoordinateReferenceSystem mCRS;
 
     /** Private copy constructor - QgsMapLayer not copyable */

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -79,12 +79,6 @@ class CORE_EXPORT QgsMapLayer : public QObject
     /** Get this layer's unique ID, this ID is used to access this layer from map layer registry */
     QString id() const;
 
-    /** Set the display name of the layer
-     * @param name New name for the layer
-     * @deprecated Since 2.16, use setName instead
-     */
-    Q_DECL_DEPRECATED void setLayerName( const QString & name );
-
     /**
      * Set the display name of the layer
      * @param name New name for the layer
@@ -362,13 +356,6 @@ class CORE_EXPORT QgsMapLayer : public QObject
     /** Remove a custom property from layer. Properties are stored in a map and saved in project file. */
     void removeCustomProperty( const QString& key );
 
-
-    //! @deprecated since 2.4 - returns empty string
-    Q_DECL_DEPRECATED virtual QString lastErrorTitle();
-
-    //! @deprecated since 2.4 - returns empty string
-    Q_DECL_DEPRECATED virtual QString lastError();
-
     /** Get current status error. This error describes some principal problem
      *  for which layer cannot work and thus is not valid. It is not last error
      *  after accessing data by draw() etc.
@@ -530,13 +517,6 @@ class CORE_EXPORT QgsMapLayer : public QObject
     void setLegendUrlFormat( const QString& legendUrlFormat ) { mLegendUrlFormat = legendUrlFormat; }
     QString legendUrlFormat() const { return mLegendUrlFormat; }
 
-    /** @deprecated since 2.4 - returns nullptr */
-    Q_DECL_DEPRECATED QImage *cacheImage() { return nullptr; }
-    /** @deprecated since 2.4 - caches listen to repaintRequested() signal to invalidate the cached image */
-    Q_DECL_DEPRECATED void setCacheImage( QImage * );
-    /** @deprecated since 2.4 - does nothing */
-    Q_DECL_DEPRECATED virtual void onCacheImageDelete() {}
-
     /**
      * Assign a legend controller to the map layer. The object will be responsible for providing legend items.
      * @param legend Takes ownership of the object. Can be null pointer
@@ -625,16 +605,6 @@ class CORE_EXPORT QgsMapLayer : public QObject
      */
     void setScaleBasedVisibility( const bool enabled );
 
-    /** Accessor for the scale based visilibility flag
-     * @deprecated use setScaleBasedVisibility instead
-     */
-    Q_DECL_DEPRECATED void toggleScaleBasedVisibility( bool theVisibilityFlag );
-
-    /** Clear cached image
-     *  @deprecated in 2.4 - use triggerRepaint() - caches automatically listen to repaintRequested() signal to invalidate the cached image
-     */
-    Q_DECL_DEPRECATED void clearCacheImage();
-
     /**
      * Will advice the map canvas (and any other interested party) that this layer requires to be repainted.
      * Will emit a repaintRequested() signal.
@@ -656,16 +626,8 @@ class CORE_EXPORT QgsMapLayer : public QObject
 
   signals:
 
-    //! @deprecated in 2.4 - not emitted anymore
-    Q_DECL_DEPRECATED void drawingProgress( int theProgress, int theTotalSteps );
-
     /** Emit a signal with status (e.g. to be caught by QgisApp and display a msg on status bar) */
     void statusChanged( const QString& theStatus );
-
-    /** Emit a signal that the layer name has been changed
-     * @deprecated since 2.16 use nameChanged() instead
-     */
-    Q_DECL_DEPRECATED void layerNameChanged();
 
     /**
      * Emitted when the name has been changed
@@ -681,9 +643,6 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * and any view showing the rendered layer should refresh itself.
      */
     void repaintRequested();
-
-    //! \note Deprecated in 2.4 and not emitted anymore
-    void screenUpdateRequested();
 
     /** This is used to send a request that any mapcanvas using this layer update its extents */
     void recalculateExtents();

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -674,7 +674,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
     void triggerRepaint();
 
     /** \brief Obtain Metadata for this layer */
-    virtual QString metadata();
+    virtual QString metadata() const;
 
     /** Time stamp of data source in the moment when data/metadata were loaded by provider */
     virtual QDateTime timestamp() const { return QDateTime() ; }

--- a/src/core/qgsrelationmanager.cpp
+++ b/src/core/qgsrelationmanager.cpp
@@ -93,7 +93,7 @@ void QgsRelationManager::clear()
   emit changed();
 }
 
-QList<QgsRelation> QgsRelationManager::referencingRelations( QgsVectorLayer* layer, int fieldIdx ) const
+QList<QgsRelation> QgsRelationManager::referencingRelations( const QgsVectorLayer* layer, int fieldIdx ) const
 {
   if ( !layer )
   {

--- a/src/core/qgsrelationmanager.h
+++ b/src/core/qgsrelationmanager.h
@@ -106,7 +106,7 @@ class CORE_EXPORT QgsRelationManager : public QObject
      *
      * @return A list of relations matching the given layer and fieldIdx.
      */
-    QList<QgsRelation> referencingRelations( QgsVectorLayer *layer = nullptr, int fieldIdx = -2 ) const;
+    QList<QgsRelation> referencingRelations( const QgsVectorLayer* layer = nullptr, int fieldIdx = -2 ) const;
 
     /**
      * Get all relations where this layer is the referenced part (i.e. the parent table with the primary key being referenced from another layer).

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -964,7 +964,7 @@ void QgsVectorLayer::setExtent( const QgsRectangle &r )
   mValidExtent = true;
 }
 
-QgsRectangle QgsVectorLayer::extent()
+QgsRectangle QgsVectorLayer::extent() const
 {
   QgsRectangle rect;
   rect.setMinimal();
@@ -980,7 +980,8 @@ QgsRectangle QgsVectorLayer::extent()
     // show the extent
     QgsDebugMsg( "Extent of layer: " + mbr.toString() );
     // store the extent
-    setExtent( mbr );
+    mValidExtent = true;
+    mExtent = mbr;
 
     mLazyExtent = false;
   }
@@ -1042,7 +1043,8 @@ QgsRectangle QgsVectorLayer::extent()
     rect = QgsRectangle(); // use rectangle with zero coordinates
   }
 
-  setExtent( rect );
+  mValidExtent = true;
+  mExtent = rect;
 
   // Send this (hopefully) up the chain to the map canvas
   emit recalculateExtents();
@@ -1101,7 +1103,7 @@ QgsConditionalLayerStyles* QgsVectorLayer::conditionalStyles() const
   return mConditionalStyles;
 }
 
-QgsFeatureIterator QgsVectorLayer::getFeatures( const QgsFeatureRequest& request )
+QgsFeatureIterator QgsVectorLayer::getFeatures( const QgsFeatureRequest& request ) const
 {
   if ( !mValid || !mDataProvider )
     return QgsFeatureIterator();
@@ -1828,7 +1830,7 @@ bool QgsVectorLayer::setDataProvider( QString const & provider )
 
 /* virtual */
 bool QgsVectorLayer::writeXml( QDomNode & layer_node,
-                               QDomDocument & document )
+                               QDomDocument & document ) const
 {
   // first get the layer element so that we can append the type attribute
 
@@ -3122,7 +3124,7 @@ void QgsVectorLayer::updateFields()
 }
 
 
-void QgsVectorLayer::createJoinCaches()
+void QgsVectorLayer::createJoinCaches() const
 {
   if ( mJoinBuffer->containsJoins() )
   {

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -3760,7 +3760,7 @@ void QgsVectorLayer::setDiagramLayerSettings( const QgsDiagramLayerSettings& s )
   *mDiagramLayerSettings = s;
 }
 
-QString QgsVectorLayer::metadata()
+QString QgsVectorLayer::metadata() const
 {
   QString myMetadata = "<html><body>";
 

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -581,7 +581,7 @@ void QgsVectorLayer::selectAll()
   selectByIds( allFeatureIds() );
 }
 
-QgsFeatureIds QgsVectorLayer::allFeatureIds()
+QgsFeatureIds QgsVectorLayer::allFeatureIds() const
 {
   QgsFeatureIterator fit = getFeatures( QgsFeatureRequest()
                                         .setFlags( QgsFeatureRequest::NoGeometry )
@@ -695,7 +695,7 @@ QGis::WkbType QgsVectorLayer::wkbType() const
   return mWkbType;
 }
 
-QgsRectangle QgsVectorLayer::boundingBoxOfSelected()
+QgsRectangle QgsVectorLayer::boundingBoxOfSelected() const
 {
   if ( !mValid || mSelectedFeatureIds.isEmpty() ) //no selected features
   {
@@ -781,7 +781,7 @@ bool QgsVectorLayer::diagramsEnabled() const
   return false;
 }
 
-long QgsVectorLayer::featureCount( QgsSymbolV2* symbol )
+long QgsVectorLayer::featureCount( QgsSymbolV2* symbol ) const
 {
   if ( !mSymbolFeatureCounted )
     return -1;
@@ -1052,7 +1052,7 @@ QgsRectangle QgsVectorLayer::extent() const
   return rect;
 }
 
-QString QgsVectorLayer::subsetString()
+QString QgsVectorLayer::subsetString() const
 {
   if ( !mValid || !mDataProvider )
   {
@@ -2545,7 +2545,7 @@ bool QgsVectorLayer::commitChanges()
   return success;
 }
 
-const QStringList &QgsVectorLayer::commitErrors()
+QStringList QgsVectorLayer::commitErrors() const
 {
   return mCommitErrors;
 }
@@ -2601,7 +2601,7 @@ void QgsVectorLayer::setSelectedFeatures( const QgsFeatureIds& ids )
   selectByIds( ids, SetSelection );
 }
 
-int QgsVectorLayer::selectedFeatureCount()
+int QgsVectorLayer::selectedFeatureCount() const
 {
   return mSelectedFeatureIds.size();
 }
@@ -2611,7 +2611,7 @@ const QgsFeatureIds& QgsVectorLayer::selectedFeaturesIds() const
   return mSelectedFeatureIds;
 }
 
-QgsFeatureList QgsVectorLayer::selectedFeatures()
+QgsFeatureList QgsVectorLayer::selectedFeatures() const
 {
   QgsFeatureList features;
   QgsFeature f;
@@ -2639,7 +2639,7 @@ QgsFeatureList QgsVectorLayer::selectedFeatures()
   return features;
 }
 
-QgsFeatureIterator QgsVectorLayer::selectedFeaturesIterator( QgsFeatureRequest request )
+QgsFeatureIterator QgsVectorLayer::selectedFeaturesIterator( QgsFeatureRequest request ) const
 {
   if ( mSelectedFeatureIds.isEmpty() )
     return QgsFeatureIterator();
@@ -2855,7 +2855,7 @@ void QgsVectorLayer::setDisplayExpression( const QString &displayExpression )
   mDisplayExpression = displayExpression;
 }
 
-const QString QgsVectorLayer::displayExpression()
+QString QgsVectorLayer::displayExpression() const
 {
   return mDisplayExpression;
 }
@@ -3084,7 +3084,7 @@ void QgsVectorLayer::removeExpressionField( int index )
   emit attributeDeleted( index );
 }
 
-QString QgsVectorLayer::expressionField( int index )
+QString QgsVectorLayer::expressionField( int index ) const
 {
   int oi = mUpdatedFields.fieldOriginIndex( index );
   return mExpressionFieldBuffer->expressions().value( oi ).expression;
@@ -3132,7 +3132,7 @@ void QgsVectorLayer::createJoinCaches() const
   }
 }
 
-void QgsVectorLayer::uniqueValues( int index, QList<QVariant> &uniqueValues, int limit )
+void QgsVectorLayer::uniqueValues( int index, QList<QVariant> &uniqueValues, int limit ) const
 {
   uniqueValues.clear();
   if ( !mDataProvider )
@@ -3221,7 +3221,7 @@ void QgsVectorLayer::uniqueValues( int index, QList<QVariant> &uniqueValues, int
   Q_ASSERT_X( false, "QgsVectorLayer::uniqueValues()", "Unknown source of the field!" );
 }
 
-QVariant QgsVectorLayer::minimumValue( int index )
+QVariant QgsVectorLayer::minimumValue( int index ) const
 {
   if ( !mDataProvider )
   {
@@ -3281,7 +3281,7 @@ QVariant QgsVectorLayer::minimumValue( int index )
   return QVariant();
 }
 
-QVariant QgsVectorLayer::maximumValue( int index )
+QVariant QgsVectorLayer::maximumValue( int index ) const
 {
   if ( !mDataProvider )
   {
@@ -3339,7 +3339,7 @@ QVariant QgsVectorLayer::maximumValue( int index )
 }
 
 QVariant QgsVectorLayer::aggregate( QgsAggregateCalculator::Aggregate aggregate, const QString& fieldOrExpression,
-                                    const QgsAggregateCalculator::AggregateParameters& parameters, QgsExpressionContext* context, bool* ok )
+                                    const QgsAggregateCalculator::AggregateParameters& parameters, QgsExpressionContext* context, bool* ok ) const
 {
   if ( ok )
     *ok = false;
@@ -3376,7 +3376,7 @@ QVariant QgsVectorLayer::aggregate( QgsAggregateCalculator::Aggregate aggregate,
   return c.calculate( aggregate, fieldOrExpression, context, ok );
 }
 
-QList<QVariant> QgsVectorLayer::getValues( const QString &fieldOrExpression, bool& ok, bool selectedOnly )
+QList<QVariant> QgsVectorLayer::getValues( const QString &fieldOrExpression, bool& ok, bool selectedOnly ) const
 {
   QList<QVariant> values;
 
@@ -3441,7 +3441,7 @@ QList<QVariant> QgsVectorLayer::getValues( const QString &fieldOrExpression, boo
   return values;
 }
 
-QList<double> QgsVectorLayer::getDoubleValues( const QString &fieldOrExpression, bool& ok, bool selectedOnly, int* nullCount )
+QList<double> QgsVectorLayer::getDoubleValues( const QString &fieldOrExpression, bool& ok, bool selectedOnly, int* nullCount ) const
 {
   QList<double> values;
 
@@ -4034,7 +4034,7 @@ void QgsVectorLayer::onFeatureDeleted( QgsFeatureId fid )
   emit featureDeleted( fid );
 }
 
-QgsVectorLayer::ValueRelationData QgsVectorLayer::valueRelation( int idx )
+QgsVectorLayer::ValueRelationData QgsVectorLayer::valueRelation( int idx ) const
 {
   if ( mEditFormConfig->widgetType( idx ) == "ValueRelation" )
   {
@@ -4055,7 +4055,7 @@ QgsVectorLayer::ValueRelationData QgsVectorLayer::valueRelation( int idx )
   }
 }
 
-QList<QgsRelation> QgsVectorLayer::referencingRelations( int idx )
+QList<QgsRelation> QgsVectorLayer::referencingRelations( int idx ) const
 {
   return QgsProject::instance()->relationManager()->referencingRelations( this, idx );
 }

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -1772,7 +1772,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
     /** Returns the current transparency for the vector layer */
     int layerTransparency() const;
 
-    QString metadata() override;
+    QString metadata() const override;
 
     /** @note not available in python bindings */
     inline QgsGeometryCache* cache() { return mCache; }

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -572,7 +572,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
      *
      *  @return The expression which will be used to preview features for this layer
      */
-    const QString displayExpression();
+    QString displayExpression() const;
 
     /** Returns the data provider */
     QgsVectorDataProvider* dataProvider();
@@ -634,7 +634,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
      *
      * @note added in 2.9
      */
-    QString expressionField( int index );
+    QString expressionField( int index ) const;
 
     /**
      * Changes the expression used to define an expression based (virtual) field
@@ -668,7 +668,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
      *
      * @return See description
      */
-    int selectedFeatureCount();
+    int selectedFeatureCount() const;
 
     /**
      * Select features found within the search rectangle (in layer's coordinates)
@@ -735,7 +735,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
     void selectAll();
 
     /** Get all feature Ids */
-    QgsFeatureIds allFeatureIds();
+    QgsFeatureIds allFeatureIds() const;
 
     /**
      * Invert selection of features found within the search rectangle (in layer's coordinates)
@@ -754,7 +754,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
      * @see    selectedFeaturesIds()
      * @see    selectedFeaturesIterator() which is more memory friendly when handling large selections
      */
-    QgsFeatureList selectedFeatures();
+    QgsFeatureList selectedFeatures() const;
 
     /**
      * Get an iterator of the selected features
@@ -767,7 +767,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
      * @see    selectedFeaturesIds()
      * @see    selectedFeatures()
      */
-    QgsFeatureIterator selectedFeaturesIterator( QgsFeatureRequest request = QgsFeatureRequest() );
+    QgsFeatureIterator selectedFeaturesIterator( QgsFeatureRequest request = QgsFeatureRequest() ) const;
 
     /**
      * Return reference to identifiers of selected features
@@ -788,7 +788,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
     Q_DECL_DEPRECATED void setSelectedFeatures( const QgsFeatureIds &ids );
 
     /** Returns the bounding box of the selected features. If there is no selection, QgsRectangle(0,0,0,0) is returned */
-    QgsRectangle boundingBoxOfSelected();
+    QgsRectangle boundingBoxOfSelected() const;
 
     /** Returns whether the layer contains labels which are enabled and should be drawn.
      * @return true if layer contains enabled labels
@@ -944,7 +944,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
      * @param symbol the symbol
      * @return number of features rendered by symbol or -1 if failed or counts are not available
      */
-    long featureCount( QgsSymbolV2* symbol );
+    long featureCount( QgsSymbolV2* symbol ) const;
 
     /**
      * Update the data source of the layer. The layer's renderer and legend will be preserved only
@@ -978,7 +978,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
      * Get the string (typically sql) used to define a subset of the layer
      * @return The subset string or QString::null if not implemented by the provider
      */
-    virtual QString subsetString();
+    virtual QString subsetString() const;
 
     /**
      * Query the layer for features specified in request.
@@ -1474,7 +1474,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
      * that the user has some chance of repairing the damage cleanly.
      */
     bool commitChanges();
-    const QStringList &commitErrors();
+    QStringList commitErrors() const;
 
     /** Stop editing and discard the edits
      * @param deleteBuffer whether to delete editing buffer
@@ -1624,7 +1624,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
     Q_DECL_DEPRECATED RangeData range( int idx );
 
     /** Access value relation widget data */
-    ValueRelationData valueRelation( int idx );
+    ValueRelationData valueRelation( int idx ) const;
 
     /**
      * Get relations, where the foreign key is on this layer
@@ -1632,7 +1632,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
      * @param idx Only get relations, where idx forms part of the foreign key
      * @return A list of relations
      */
-    QList<QgsRelation> referencingRelations( int idx );
+    QList<QgsRelation> referencingRelations( int idx ) const;
 
     /**
      * Access date format
@@ -1717,13 +1717,13 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
      * @param uniqueValues out: result list
      * @param limit maximum number of values to return (-1 if unlimited)
      */
-    void uniqueValues( int index, QList<QVariant> &uniqueValues, int limit = -1 );
+    void uniqueValues( int index, QList<QVariant> &uniqueValues, int limit = -1 ) const;
 
     /** Returns minimum value for an attribute column or invalid variant in case of error */
-    QVariant minimumValue( int index );
+    QVariant minimumValue( int index ) const;
 
     /** Returns maximum value for an attribute column or invalid variant in case of error */
-    QVariant maximumValue( int index );
+    QVariant maximumValue( int index ) const;
 
     /** Calculates an aggregated value from the layer's features.
      * @param aggregate aggregate to calculate
@@ -1738,7 +1738,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
                         const QString& fieldOrExpression,
                         const QgsAggregateCalculator::AggregateParameters& parameters = QgsAggregateCalculator::AggregateParameters(),
                         QgsExpressionContext* context = nullptr,
-                        bool* ok = nullptr );
+                        bool* ok = nullptr ) const;
 
     /** Fetches all values from a specified field name or expression.
      * @param fieldOrExpression field name or an expression string
@@ -1748,7 +1748,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
      * @note added in QGIS 2.9
      * @see getDoubleValues
      */
-    QList< QVariant > getValues( const QString &fieldOrExpression, bool &ok, bool selectedOnly = false );
+    QList< QVariant > getValues( const QString &fieldOrExpression, bool &ok, bool selectedOnly = false ) const;
 
     /** Fetches all double values from a specified field name or expression. Null values or
      * invalid expression results are skipped.
@@ -1760,7 +1760,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
      * @note added in QGIS 2.9
      * @see getValues
      */
-    QList< double > getDoubleValues( const QString &fieldOrExpression, bool &ok, bool selectedOnly = false, int* nullCount = nullptr );
+    QList< double > getDoubleValues( const QString &fieldOrExpression, bool &ok, bool selectedOnly = false, int* nullCount = nullptr ) const;
 
     /** Set the blending mode used for rendering each feature */
     void setFeatureBlendMode( QPainter::CompositionMode blendMode );

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -843,7 +843,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
     /** Write vector layer specific state to project file Dom node.
      * @note Called by QgsMapLayer::writeXML().
      */
-    virtual bool writeXml( QDomNode & layer_node, QDomDocument & doc ) override;
+    virtual bool writeXml( QDomNode & layer_node, QDomDocument & doc ) const override;
 
     /**
      * Save named and sld style of the layer to the style table in the db.
@@ -981,9 +981,11 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
     virtual QString subsetString();
 
     /**
-     * Query the provider for features specified in request.
+     * Query the layer for features specified in request.
+     * @param request feature request describing parameters of features to return
+     * @returns iterator for matching features from provider
      */
-    QgsFeatureIterator getFeatures( const QgsFeatureRequest& request = QgsFeatureRequest() );
+    QgsFeatureIterator getFeatures( const QgsFeatureRequest& request = QgsFeatureRequest() ) const;
 
     /** Adds a feature
         @param feature feature to add
@@ -1235,8 +1237,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
      */
     Q_DECL_DEPRECATED void drawLabels( QgsRenderContext& rendererContext ) override;
 
-    /** Return the extent of the layer */
-    QgsRectangle extent() override;
+    QgsRectangle extent() const override;
 
     /**
      * Returns the list of fields of this layer.
@@ -1675,6 +1676,9 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
     //! Buffer with uncommitted editing operations. Only valid after editing has been turned on.
     QgsVectorLayerEditBuffer* editBuffer() { return mEditBuffer; }
 
+    //! Buffer with uncommitted editing operations. Only valid after editing has been turned on.
+    const QgsVectorLayerEditBuffer* editBuffer() const { return mEditBuffer; }
+
     /**
      * Create edit command for undo/redo operations
      * @param text text which is to be displayed in undo window
@@ -1705,7 +1709,8 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
     void updateFields();
 
     /** Caches joined attributes if required (and not already done) */
-    void createJoinCaches();
+    // marked as const as these are just caches, and need to be created from const accessors
+    void createJoinCaches() const;
 
     /** Returns unique values for column
      * @param index column index for attribute
@@ -2218,8 +2223,8 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
     //stores infos about diagram placement (placement type, priority, position distance)
     QgsDiagramLayerSettings *mDiagramLayerSettings;
 
-    bool mValidExtent;
-    bool mLazyExtent;
+    mutable bool mValidExtent;
+    mutable bool mLazyExtent;
 
     // Features in renderer classes counted
     bool mSymbolFeatureCounted;
@@ -2234,7 +2239,7 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
 
     QgsAttributeTableConfig mAttributeTableConfig;
 
-    QMutex mFeatureSourceConstructorMutex;
+    mutable QMutex mFeatureSourceConstructorMutex;
 
     friend class QgsVectorLayerFeatureSource;
 };

--- a/src/core/qgsvectorlayereditbuffer.h
+++ b/src/core/qgsvectorlayereditbuffer.h
@@ -99,24 +99,42 @@ class CORE_EXPORT QgsVectorLayerEditBuffer : public QObject
     /** Stop editing and discard the edits */
     virtual void rollBack();
 
+    /** Returns a map of new features which are not committed. */
+    QgsFeatureMap addedFeatures() const { return mAddedFeatures; }
 
+    /** Returns true if the specified feature ID has been added but not committed.
+     * @param id feature ID
+     * @note added in QGIS 3.0
+     */
+    bool featureIsAdded( QgsFeatureId id ) const { return mAddedFeatures.contains( id ); }
 
-    /** New features which are not commited. */
-    inline const QgsFeatureMap& addedFeatures() { return mAddedFeatures; }
+    /** Returns a map of features with changed attributes values which are not committed */
+    QgsChangedAttributesMap changedAttributeValues() const { return mChangedAttributeValues; }
 
-    /** Changed attributes values which are not commited */
-    inline const QgsChangedAttributesMap& changedAttributeValues() { return mChangedAttributeValues; }
+    /** Returns true if the specified feature ID has had an attribute changed but not committed.
+     * @param id feature ID
+     * @note added in QGIS 3.0
+     */
+    bool featureHasAttributeChanges( QgsFeatureId id ) const { return mChangedAttributeValues.contains( id ); }
 
-    /** Deleted attributes fields which are not commited. The list is kept sorted. */
-    inline const QgsAttributeList& deletedAttributeIds() { return mDeletedAttributeIds; }
+    /** Returns a list of deleted attributes fields which are not committed. The list is kept sorted. */
+    QgsAttributeList deletedAttributeIds() const { return mDeletedAttributeIds; }
 
-    /** Added attributes fields which are not commited */
-    inline const QList<QgsField>& addedAttributes() { return mAddedAttributes; }
+    /** Returns a list of added attributes fields which are not committed */
+    QList<QgsField> addedAttributes() const { return mAddedAttributes; }
 
-    /** Changed geometries which are not commited. */
-    inline const QgsGeometryMap& changedGeometries() { return mChangedGeometries; }
+    /** Returns a map of features with changed geometries which are not committed. */
+    QgsGeometryMap changedGeometries() const { return mChangedGeometries; }
 
-    inline const QgsFeatureIds deletedFeatureIds() { return mDeletedFeatureIds; }
+    /** Returns true if the specified feature ID has had its geometry changed but not committed.
+     * @param id feature ID
+     * @note added in QGIS 3.0
+     */
+    bool featureHasGeometryChange( QgsFeatureId id ) const { return mChangedGeometries.contains( id ); }
+
+    /** Returns a list of deleted feature IDs which are not committed. */
+    QgsFeatureIds deletedFeatureIds() const { return mDeletedFeatureIds; }
+
     //QString dumpEditBuffer();
 
   protected slots:
@@ -161,10 +179,10 @@ class CORE_EXPORT QgsVectorLayerEditBuffer : public QObject
 
     void updateFields( QgsFields& fields );
 
-    /** Update feature with uncommited geometry updates */
+    /** Update feature with uncommitted geometry updates */
     void updateFeatureGeometry( QgsFeature &f );
 
-    /** Update feature with uncommited attribute updates */
+    /** Update feature with uncommitted attribute updates */
     void updateChangedAttributes( QgsFeature &f );
 
     /** Update added and changed features after addition of an attribute */
@@ -191,29 +209,31 @@ class CORE_EXPORT QgsVectorLayerEditBuffer : public QObject
     friend class QgsVectorLayerUndoCommandDeleteAttribute;
     friend class QgsVectorLayerUndoCommandRenameAttribute;
 
-    /** Deleted feature IDs which are not commited.  Note a feature can be added and then deleted
+    /** Deleted feature IDs which are not committed.  Note a feature can be added and then deleted
         again before the change is committed - in that case the added feature would be removed
         from mAddedFeatures only and *not* entered here.
      */
     QgsFeatureIds mDeletedFeatureIds;
 
-    /** New features which are not commited. */
+    /** New features which are not committed. */
     QgsFeatureMap mAddedFeatures;
 
-    /** Changed attributes values which are not commited */
+    /** Changed attributes values which are not committed */
     QgsChangedAttributesMap mChangedAttributeValues;
 
-    /** Deleted attributes fields which are not commited. The list is kept sorted. */
+    /** Deleted attributes fields which are not committed. The list is kept sorted. */
     QgsAttributeList mDeletedAttributeIds;
 
-    /** Added attributes fields which are not commited */
+    /** Added attributes fields which are not committed */
     QList<QgsField> mAddedAttributes;
 
-    /** Renamed attributes which are not commited. */
+    /** Renamed attributes which are not committed. */
     QgsFieldNameMap mRenamedAttributes;
 
-    /** Changed geometries which are not commited. */
+    /** Changed geometries which are not committed. */
     QgsGeometryMap mChangedGeometries;
+
+    friend class QgsGrassProvider; //GRASS provider totally abuses the edit buffer
 };
 
 #endif // QGSVECTORLAYEREDITBUFFER_H

--- a/src/core/qgsvectorlayerfeatureiterator.cpp
+++ b/src/core/qgsvectorlayerfeatureiterator.cpp
@@ -26,7 +26,7 @@
 #include "qgsdistancearea.h"
 #include "qgsproject.h"
 
-QgsVectorLayerFeatureSource::QgsVectorLayerFeatureSource( QgsVectorLayer *layer )
+QgsVectorLayerFeatureSource::QgsVectorLayerFeatureSource( const QgsVectorLayer* layer )
     : mCrsId( 0 )
 {
   QMutexLocker locker( &layer->mFeatureSourceConstructorMutex );

--- a/src/core/qgsvectorlayerfeatureiterator.h
+++ b/src/core/qgsvectorlayerfeatureiterator.h
@@ -37,7 +37,7 @@ class QgsVectorLayerFeatureIterator;
 class QgsVectorLayerFeatureSource : public QgsAbstractFeatureSource
 {
   public:
-    explicit QgsVectorLayerFeatureSource( QgsVectorLayer* layer );
+    explicit QgsVectorLayerFeatureSource( const QgsVectorLayer* layer );
     ~QgsVectorLayerFeatureSource();
 
     virtual QgsFeatureIterator getFeatures( const QgsFeatureRequest& request ) override;

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -1502,7 +1502,7 @@ bool QgsRasterLayer::writeStyle( QDomNode &node, QDomDocument &doc, QString &err
  *  @note Called by QgsMapLayer::writeXML().
  */
 bool QgsRasterLayer::writeXml( QDomNode & layer_node,
-                               QDomDocument & document )
+                               QDomDocument & document ) const
 {
   // first get the layer element so that we can append the type attribute
 

--- a/src/core/raster/qgsrasterlayer.cpp
+++ b/src/core/raster/qgsrasterlayer.cpp
@@ -219,7 +219,7 @@ int QgsRasterLayer::bandCount() const
   return mDataProvider->bandCount();
 }
 
-const QString QgsRasterLayer::bandName( int theBandNo )
+QString QgsRasterLayer::bandName( int theBandNo ) const
 {
   return dataProvider()->generateBandName( theBandNo );
 }
@@ -316,8 +316,9 @@ QgsLegendColorList QgsRasterLayer::legendSymbologyItems() const
   return symbolList;
 }
 
-QString QgsRasterLayer::metadata()
+QString QgsRasterLayer::metadata() const
 {
+  QgsRasterDataProvider* provider = const_cast< QgsRasterDataProvider* >( mDataProvider );
   QString myMetadata;
   myMetadata += "<p class=\"glossy\">" + tr( "Driver" ) + "</p>\n";
   myMetadata += "<p>";
@@ -442,7 +443,7 @@ QString QgsRasterLayer::metadata()
     myMetadata += "</p>\n";
 
     //check if full stats for this layer have already been collected
-    if ( !dataProvider()->hasStatistics( myIteratorInt ) )  //not collected
+    if ( !provider->hasStatistics( myIteratorInt ) )  //not collected
     {
       QgsDebugMsgLevel( ".....no", 4 );
 
@@ -457,7 +458,7 @@ QString QgsRasterLayer::metadata()
     {
       QgsDebugMsgLevel( ".....yes", 4 );
 
-      QgsRasterBandStats myRasterBandStats = dataProvider()->bandStatistics( myIteratorInt );
+      QgsRasterBandStats myRasterBandStats = provider->bandStatistics( myIteratorInt );
       //Min Val
       myMetadata += "<p>";
       myMetadata += tr( "Min Val" );

--- a/src/core/raster/qgsrasterlayer.h
+++ b/src/core/raster/qgsrasterlayer.h
@@ -251,7 +251,7 @@ class CORE_EXPORT QgsRasterLayer : public QgsMapLayer
     int bandCount() const;
 
     /** \brief Get the name of a band given its number  */
-    const  QString bandName( int theBandNoInt );
+    QString bandName( int theBandNoInt ) const;
 
     /** Returns the data provider */
     QgsRasterDataProvider* dataProvider();
@@ -283,7 +283,7 @@ class CORE_EXPORT QgsRasterLayer : public QgsMapLayer
     virtual bool isSpatial() const override { return true; }
 
     /** \brief Obtain GDAL Metadata for this layer */
-    QString metadata() override;
+    QString metadata() const override;
 
     /** \brief Get an 100x100 pixmap of the color palette. If the layer has no palette a white pixmap will be returned */
     QPixmap paletteAsPixmap( int theBandNumber = 1 );

--- a/src/core/raster/qgsrasterlayer.h
+++ b/src/core/raster/qgsrasterlayer.h
@@ -378,7 +378,7 @@ class CORE_EXPORT QgsRasterLayer : public QgsMapLayer
     bool writeStyle( QDomNode &node, QDomDocument &doc, QString &errorMessage ) const override;
 
     /** \brief Write layer specific state to project file Dom node */
-    bool writeXml( QDomNode & layer_node, QDomDocument & doc ) override;
+    bool writeXml( QDomNode & layer_node, QDomDocument & doc ) const override;
 
   private:
     /** \brief Initialize default values */

--- a/src/gui/attributetable/qgsattributetablefiltermodel.cpp
+++ b/src/gui/attributetable/qgsattributetablefiltermodel.cpp
@@ -324,11 +324,18 @@ bool QgsAttributeTableFilterModel::filterAcceptsRow( int sourceRow, const QModel
       QgsVectorLayerEditBuffer* editBuffer = layer()->editBuffer();
       if ( editBuffer )
       {
-        const QList<QgsFeatureId> addedFeatures = editBuffer->addedFeatures().keys();
-        const QList<QgsFeatureId> changedFeatures = editBuffer->changedAttributeValues().keys();
-        const QList<QgsFeatureId> changedGeometries = editBuffer->changedGeometries().keys();
-        const QgsFeatureId fid = masterModel()->rowToId( sourceRow );
-        return addedFeatures.contains( fid ) || changedFeatures.contains( fid ) || changedGeometries.contains( fid );
+        QgsFeatureId fid = masterModel()->rowToId( sourceRow );
+
+        if ( editBuffer->featureIsAdded( fid ) )
+          return true;
+
+        if ( editBuffer->featureHasAttributeChanges( fid ) )
+          return true;
+
+        if ( editBuffer->featureHasGeometryChange( fid ) )
+          return true;
+
+        return false;
       }
       return false;
     }

--- a/src/gui/attributetable/qgsfeaturelistmodel.cpp
+++ b/src/gui/attributetable/qgsfeaturelistmodel.cpp
@@ -111,14 +111,11 @@ QVariant QgsFeatureListModel::data( const QModelIndex &index, int role ) const
 
     if ( editBuffer )
     {
-      const QList<QgsFeatureId> addedFeatures = editBuffer->addedFeatures().keys();
-      const QList<QgsFeatureId> changedFeatures = editBuffer->changedAttributeValues().keys();
-
-      if ( addedFeatures.contains( feat.id() ) )
+      if ( editBuffer->featureIsAdded( feat.id() ) )
       {
         featInfo.isNew = true;
       }
-      if ( changedFeatures.contains( feat.id() ) )
+      if ( editBuffer->featureHasAttributeChanges( feat.id() ) )
       {
         featInfo.isEdited = true;
       }

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -462,7 +462,7 @@ void QgsMapCanvas::setLayerSet( QList<QgsMapCanvasLayer> &layers )
       if ( !currentLayer )
         continue;
       disconnect( currentLayer, SIGNAL( repaintRequested() ), this, SLOT( refresh() ) );
-      disconnect( currentLayer, SIGNAL( layerCrsChanged() ), this, SLOT( layerCrsChange() ) );
+      disconnect( currentLayer, SIGNAL( crsChanged() ), this, SLOT( layerCrsChange() ) );
       QgsVectorLayer *isVectLyr = qobject_cast<QgsVectorLayer *>( currentLayer );
       if ( isVectLyr )
       {
@@ -480,7 +480,7 @@ void QgsMapCanvas::setLayerSet( QList<QgsMapCanvasLayer> &layers )
       if ( !currentLayer )
         continue;
       connect( currentLayer, SIGNAL( repaintRequested() ), this, SLOT( refresh() ) );
-      connect( currentLayer, SIGNAL( layerCrsChanged() ), this, SLOT( layerCrsChange() ) );
+      connect( currentLayer, SIGNAL( crsChanged() ), this, SLOT( layerCrsChange() ) );
       QgsVectorLayer *isVectLyr = qobject_cast<QgsVectorLayer *>( currentLayer );
       if ( isVectLyr )
       {

--- a/src/providers/grass/qgsgrassprovider.cpp
+++ b/src/providers/grass/qgsgrassprovider.cpp
@@ -1219,7 +1219,7 @@ void QgsGrassProvider::onFeatureAdded( QgsFeatureId fid )
     }
     // geometry
     const QgsAbstractGeometryV2 *geometry = 0;
-    if ( !mEditBuffer->addedFeatures().contains( fid ) )
+    if ( !mEditBuffer->featureIsAdded( fid ) )
     {
 #ifdef QGISDEBUG
       QgsDebugMsg( "the feature is missing in buffer addedFeatures :" );
@@ -1248,7 +1248,7 @@ void QgsGrassProvider::onFeatureAdded( QgsFeatureId fid )
 
     setPoints( mPoints, geometry );
 
-    QgsFeatureMap& addedFeatures = const_cast<QgsFeatureMap&>( mEditBuffer->addedFeatures() );
+    QgsFeatureMap& addedFeatures = mEditBuffer->mAddedFeatures;
 
     // change polygon to linestring
     QgsWKBTypes::Type wkbType = QgsWKBTypes::flatType( geometry->wkbType() );
@@ -1271,7 +1271,7 @@ void QgsGrassProvider::onFeatureAdded( QgsFeatureId fid )
       // resetting fid probably is not possible because it is stored in undo commands and used in buffer maps
 
       // It may be that user manualy entered cat value
-      QgsFeatureMap& addedFeatures = const_cast<QgsFeatureMap&>( mEditBuffer->addedFeatures() );
+      QgsFeatureMap& addedFeatures = mEditBuffer->mAddedFeatures;
       QgsFeature& feature = addedFeatures[fid];
       int catIndex = feature.fields()->indexFromName( mLayer->keyColumnName() );
       if ( catIndex != -1 )
@@ -1721,7 +1721,7 @@ void QgsGrassProvider::onAttributeValueChanged( QgsFeatureId fid, int idx, const
   {
     QgsDebugMsg( "changing attributes in different layer is not allowed" );
     // reset the value
-    QgsChangedAttributesMap &changedAttributes = const_cast<QgsChangedAttributesMap &>( mEditBuffer->changedAttributeValues() );
+    QgsChangedAttributesMap &changedAttributes = mEditBuffer->mChangedAttributeValues;
     if ( idx == mLayer->keyColumn() )
     {
       // should not happen because cat field is not editable
@@ -1923,7 +1923,7 @@ void QgsGrassProvider::setAddedFeaturesSymbol()
   {
     return;
   }
-  QgsFeatureMap& features = const_cast<QgsFeatureMap&>( mEditBuffer->addedFeatures() );
+  QgsFeatureMap& features = mEditBuffer->mAddedFeatures;
   Q_FOREACH ( QgsFeatureId fid, features.keys() )
   {
     QgsFeature feature = features[fid];


### PR DESCRIPTION
(This won't build, as it depends on #3291 )

This PR implements some clean ups for the various map layer classes. Changes include:
- removal of deprecated methods from QgsMapLayer
- make QgsVectorLayerEditBuffer const correct
- make a bunch of QgsVectorLayer methods const correct, including getFeatures() is now const (see https://github.com/qgis/qgis3.0_api/issues/48 )

With the exception of the removed deprecated members, these changes have minimal impact on PyQGIS code and are mostly motivated by the cleanups they will allow to core code. C++ plugins and custom layer types will be affected due to the modified virtual signatures.
