### PR TITLE
[splashscreen] fix pixelated scaling

### DIFF
--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1037,7 +1037,7 @@ int main( int argc, char *argv[] )
   int w = 600 * qApp->desktop()->logicalDpiX() / 96;
   int h = 300 * qApp->desktop()->logicalDpiY() / 96;
 
-  QSplashScreen *mypSplash = new QSplashScreen( myPixmap.scaled( w, h, Qt::KeepAspectRatio ) );
+  QSplashScreen *mypSplash = new QSplashScreen( myPixmap.scaled( w, h, Qt::KeepAspectRatio, Qt::SmoothTransformation ) );
   if ( !myHideSplash && !mySettings.value( "/qgis/hideSplash" ).toBool() )
   {
     //for win and linux we can just automask and png transparency areas will be used


### PR DESCRIPTION
@jef-n , this is a follow up to your commit 9446b20 that improved the splash screen on HiDPI display. The PR insures that the splash screen is scaled down smoothly to avoid pixelated result. 

Current (top) vs. PR (bottom):
![untitled](https://cloud.githubusercontent.com/assets/1728657/16718476/96b2b6cc-474a-11e6-8d06-3fec724d951d.png)

IMO worth committing to 2.16 prior to packaging (if there's a re-packaging taking place due to the unicode string issue fixed yesterday)
