### PR TITLE
Avoid parsing QgsCoordinateReferenceSystem by pointer, returning references

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -18,6 +18,12 @@ This page tries to maintain a list with incompatible changes that happened in pr
 
 \section qgis_api_break_3_0 QGIS 3.0
 
+\subsection qgis_api_break_3_0_QgsMapLayer QgsMapLayer
+
+<ul>
+<li>crs() now returns a QgsCoordinateReferenceSystem object, not a reference. This change has no effect for PyQGIS code.</li>
+</ul>
+
 \subsection qgis_api_break_3_0_QgsVectorLayerImport QgsVectorLayerImport
 
 <ul>

--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -18,11 +18,20 @@ This page tries to maintain a list with incompatible changes that happened in pr
 
 \section qgis_api_break_3_0 QGIS 3.0
 
+\subsection qgis_api_break_3_0_QgsCoordinateTransform QgsCoordinateTransform
+
+<ul>
+<li>sourceCrs() and destCrs() now return a copy instead of a reference to the CRS. This has no effect on PyQGIS code, but c++
+plugins calling these methods will need to be updated.</li>
+</ul>
+
+
 \subsection qgis_api_break_3_0_QgsMapLayer QgsMapLayer
 
 <ul>
 <li>crs() now returns a QgsCoordinateReferenceSystem object, not a reference. This change has no effect for PyQGIS code.</li>
 </ul>
+
 
 \subsection qgis_api_break_3_0_QgsVectorLayerImport QgsVectorLayerImport
 
@@ -33,6 +42,35 @@ pointers makes for more robust, safer code. Use an invalid (default constructed)
 in code which previously passed a null pointer to QgsVectorLayerImport.</li>
 </ul>
 
+\subsection qgis_api_break_3_0_QgsJSONExporter QgsJSONExporter
+
+<ul>
+<li>sourceCrs() now returns a copy instead of a reference to the CRS. This has no effect on PyQGIS code, but c++
+plugins calling this method will need to be updated.</li>
+</ul>
+
+\subsection qgis_api_break_3_0_QgsPointLocator QgsPointLocator
+
+<ul>
+<li>The constructor now takes a reference rather than a pointer to a CRS.  This has no effect on PyQGIS code, but c++
+plugins calling this method will need to be updated.</li>
+<li>destCrs() now returns a copy instead of a reference to the CRS. This has no effect on PyQGIS code, but c++
+plugins calling this method will need to be updated.</li>
+</ul>
+
+\subsection qgis_api_break_3_0_QgsMapSettings QgsMapSettings
+
+<ul>
+<li>destinationCrs() now returns a copy instead of a reference to the CRS. This has no effect on PyQGIS code, but c++
+plugins calling this method will need to be updated.</li>
+</ul>
+
+\subsection qgis_api_break_3_0_QgsGraphBuilderInterface QgsGraphBuilderInterface
+
+<ul>
+<li>destinationCrs() now returns a copy instead of a reference to the CRS. This has no effect on PyQGIS code, but c++
+plugins calling this method will need to be updated.</li>
+</ul>
 
 \section qgis_api_break_2_4 QGIS 2.4
 

--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -16,6 +16,18 @@ with too big impact should be deferred to a major version release.
 
 This page tries to maintain a list with incompatible changes that happened in previous releases.
 
+\section qgis_api_break_3_0 QGIS 3.0
+
+\subsection qgis_api_break_3_0_QgsVectorLayerImport QgsVectorLayerImport
+
+<ul>
+<li>QgsVectorLayerImport now takes references instead of pointers to QgsCoordinateReferenceSystem objects. Since
+QgsCoordinateReferenceSystem is now implicitly shared, using references to QgsCoordinateReferenceSystem rather than
+pointers makes for more robust, safer code. Use an invalid (default constructed) QgsCoordinateReferenceSystem
+in code which previously passed a null pointer to QgsVectorLayerImport.</li>
+</ul>
+
+
 \section qgis_api_break_2_4 QGIS 2.4
 
 \subsection qgis_api_break_mtr Multi-threaded Rendering

--- a/python/analysis/network/qgsgraphbuilderintr.sip
+++ b/python/analysis/network/qgsgraphbuilderintr.sip
@@ -30,7 +30,7 @@ class QgsGraphBuilderInterface
      */
     QgsGraphBuilderInterface( const QgsCoordinateReferenceSystem& crs, bool ctfEnabled = true, double topologyTolerance = 0.0, const QString& ellipsoidID = "WGS84" );
 
-    QgsCoordinateReferenceSystem& destinationCrs();
+    QgsCoordinateReferenceSystem destinationCrs() const;
 
     //! get coordinate transformation enabled
     bool coordinateTransformationEnabled();

--- a/python/core/qgscoordinatetransform.sip
+++ b/python/core/qgscoordinatetransform.sip
@@ -79,13 +79,13 @@ class QgsCoordinateTransform : QObject
      * Get the QgsCoordinateReferenceSystem representation of the layer's coordinate system
      * @return QgsCoordinateReferenceSystem of the layer's coordinate system
      */
-    const QgsCoordinateReferenceSystem& sourceCrs() const;
+    QgsCoordinateReferenceSystem sourceCrs() const;
 
     /*!
      * Get the QgsCoordinateReferenceSystem representation of the map canvas coordinate system
      * @return QgsCoordinateReferenceSystem of the map canvas coordinate system
      */
-    const QgsCoordinateReferenceSystem& destCRS() const;
+    QgsCoordinateReferenceSystem destCRS() const;
 
     /** Transform the point from Source Coordinate System to Destination Coordinate System
      * If the direction is ForwardTransform then coordinates are transformed from layer CS --> map canvas CS,

--- a/python/core/qgsjsonutils.sip
+++ b/python/core/qgsjsonutils.sip
@@ -90,7 +90,7 @@ class QgsJSONExporter
      * correctly automatically reprojected to WGS 84, to match GeoJSON specifications.
      * @see setSourceCrs()
      */
-    const QgsCoordinateReferenceSystem& sourceCrs() const;
+    QgsCoordinateReferenceSystem sourceCrs() const;
 
     /** Sets the list of attributes to include in the JSON exports.
      * @param attributes list of attribute indexes, or an empty list to include all

--- a/python/core/qgsmaplayer.sip
+++ b/python/core/qgsmaplayer.sip
@@ -359,7 +359,7 @@ class QgsMapLayer : QObject
     /** Returns layer's spatial reference system
     @note This was introduced in QGIS 1.4
      */
-    const QgsCoordinateReferenceSystem& crs() const;
+    QgsCoordinateReferenceSystem crs() const;
 
     /** Sets layer's spatial reference system */
     void setCrs( const QgsCoordinateReferenceSystem& srs, bool emitSignal = true );

--- a/python/core/qgsmapsettings.sip
+++ b/python/core/qgsmapsettings.sip
@@ -88,7 +88,7 @@ class QgsMapSettings
     //! sets destination coordinate reference system
     void setDestinationCrs( const QgsCoordinateReferenceSystem& crs );
     //! returns CRS of destination coordinate reference system
-    const QgsCoordinateReferenceSystem& destinationCrs() const;
+    QgsCoordinateReferenceSystem destinationCrs() const;
 
     //! Get units of map's geographical coordinates - used for scale calculation
     QGis::UnitType mapUnits() const;

--- a/python/core/qgspointlocator.sip
+++ b/python/core/qgspointlocator.sip
@@ -19,20 +19,23 @@ class QgsPointLocator : QObject
 %End
 
   public:
+
     /** Construct point locator for a layer.
-     *  @arg destCRS if not null, will do the searches on data reprojected to the given CRS
+     *  @arg destCRS if a valid QgsCoordinateReferenceSystem is passed then the locator will
+     *  do the searches on data reprojected to the given CRS
      *  @arg extent  if not null, will index only a subset of the layer
      */
-    explicit QgsPointLocator( QgsVectorLayer* layer, const QgsCoordinateReferenceSystem* destCRS = 0, const QgsRectangle* extent = 0 );
+    explicit QgsPointLocator( QgsVectorLayer* layer, const QgsCoordinateReferenceSystem& destCRS = QgsCoordinateReferenceSystem(),
+                              const QgsRectangle* extent = nullptr );
 
     ~QgsPointLocator();
 
     //! Get associated layer
     //! @note added in QGIS 2.14
     QgsVectorLayer* layer() const;
-    //! Get destination CRS - may be null if not doing OTF reprojection
+    //! Get destination CRS - may be an invalid QgsCoordinateReferenceSystem if not doing OTF reprojection
     //! @note added in QGIS 2.14
-    const QgsCoordinateReferenceSystem* destCRS() const;
+    QgsCoordinateReferenceSystem destCRS() const;
     //! Get extent of the area point locator covers - if null then it caches the whole layer
     //! @note added in QGIS 2.14
     const QgsRectangle* extent() const;

--- a/python/core/qgsvectorlayerimport.sip
+++ b/python/core/qgsvectorlayerimport.sip
@@ -31,27 +31,50 @@ class QProgressDialog;
       ErrUserCancelled, /*!< User cancelled the import*/
     };
 
-    /** Write contents of vector layer to a different datasource */
+     /**
+     * Writes the contents of vector layer to a different datasource.
+     * @param layer source layer
+     * @param uri URI for destination data source
+     * @param providerKey string key for destination data provider
+     * @param destCRS destination CRS, or an invalid (default constructed) CRS if
+     * not available
+     * @param onlySelected set to true to export only selected features
+     * @param errorMessage if non-null, will be set to any error messages
+     * @param skipAttributeCreation set to true to skip exporting feature attributes
+     * @param options optional provider dataset options
+     * @param progress optional progress dialog to show progress of export
+     * @returns NoError for a successful export, or encountered error
+     */
     static ImportError importLayer( QgsVectorLayer* layer,
                                     const QString& uri,
                                     const QString& providerKey,
-                                    const QgsCoordinateReferenceSystem *destCRS,
+                                    const QgsCoordinateReferenceSystem& destCRS,
                                     bool onlySelected = false,
-                                    QString *errorMessage /Out/ = 0,
+                                    QString *errorMessage /Out/ = nullptr,
                                     bool skipAttributeCreation = false,
-                                    QMap<QString, QVariant> *options = 0,
-                                    QProgressDialog *progress = 0
+                                    QMap<QString, QVariant> *options = nullptr,
+                                    QProgressDialog *progress = nullptr
                                   );
 
-    /** Create a empty layer and add fields to it */
+    /** Constructor for QgsVectorLayerImport.
+     * @param uri URI for destination data source
+     * @param provider string key for destination data provider
+     * @param fields fields to include in created layer
+     * @param geometryType destination geometry type
+     * @param crs desired CRS, or an invalid (default constructed) CRS if
+     * not available
+     * @param overwrite set to true to overwrite any existing data source
+     * @param options optional provider dataset options
+     * @param progress optional progress dialog to show progress of export
+     */
     QgsVectorLayerImport( const QString &uri,
                           const QString &provider,
                           const QgsFields &fields,
                           QGis::WkbType geometryType,
-                          const QgsCoordinateReferenceSystem* crs,
+                          const QgsCoordinateReferenceSystem& crs,
                           bool overwrite = false,
-                          const QMap<QString, QVariant> *options = 0,
-                          QProgressDialog *progress = 0
+                          const QMap<QString, QVariant> *options = nullptr,
+                          QProgressDialog *progress = nullptr
                         );
 
     /** Checks whether there were any errors */

--- a/src/analysis/network/qgsgraphbuilderintr.h
+++ b/src/analysis/network/qgsgraphbuilderintr.h
@@ -56,7 +56,7 @@ class ANALYSIS_EXPORT QgsGraphBuilderInterface
     { }
 
     //! get destinaltion Crs
-    QgsCoordinateReferenceSystem& destinationCrs()
+    QgsCoordinateReferenceSystem destinationCrs() const
     {
       return mCrs;
     }

--- a/src/app/qgsdecorationgrid.cpp
+++ b/src/app/qgsdecorationgrid.cpp
@@ -833,7 +833,7 @@ bool QgsDecorationGrid::getIntervalFromCurrentLayer( double* values )
     return false;
   }
   QgsCoordinateReferenceSystem layerCRS = layer->crs();
-  const QgsCoordinateReferenceSystem& mapCRS =
+  QgsCoordinateReferenceSystem mapCRS =
     QgisApp::instance()->mapCanvas()->mapSettings().destinationCrs();
   // is this the best way to compare CRS? should we also make sure map has OTF enabled?
   // TODO calculate transformed values if necessary

--- a/src/app/qgsidentifyresultsdialog.h
+++ b/src/app/qgsidentifyresultsdialog.h
@@ -68,7 +68,7 @@ class APP_EXPORT QgsIdentifyResultsFeatureItem: public QTreeWidgetItem
     QgsIdentifyResultsFeatureItem( const QgsFields &fields, const QgsFeature &feature, const QgsCoordinateReferenceSystem &crs, const QStringList & strings = QStringList() );
     const QgsFields &fields() const { return mFields; }
     const QgsFeature &feature() const { return mFeature; }
-    const QgsCoordinateReferenceSystem &crs() { return mCrs; }
+    QgsCoordinateReferenceSystem crs() const { return mCrs; }
 
   private:
     QgsFields mFields;

--- a/src/core/qgscoordinatetransform.h
+++ b/src/core/qgscoordinatetransform.h
@@ -113,13 +113,13 @@ class CORE_EXPORT QgsCoordinateTransform : public QObject
      * Get the QgsCoordinateReferenceSystem representation of the layer's coordinate system
      * @return QgsCoordinateReferenceSystem of the layer's coordinate system
      */
-    const QgsCoordinateReferenceSystem& sourceCrs() const { return mSourceCRS; }
+    QgsCoordinateReferenceSystem sourceCrs() const { return mSourceCRS; }
 
     /*!
      * Get the QgsCoordinateReferenceSystem representation of the map canvas coordinate system
      * @return QgsCoordinateReferenceSystem of the map canvas coordinate system
      */
-    const QgsCoordinateReferenceSystem& destCRS() const { return mDestCRS; }
+    QgsCoordinateReferenceSystem destCRS() const { return mDestCRS; }
 
     /** Transform the point from Source Coordinate System to Destination Coordinate System
      * If the direction is ForwardTransform then coordinates are transformed from layer CS --> map canvas CS,

--- a/src/core/qgsjsonutils.cpp
+++ b/src/core/qgsjsonutils.cpp
@@ -58,7 +58,7 @@ void QgsJSONExporter::setSourceCrs( const QgsCoordinateReferenceSystem& crs )
   mTransform.setSourceCrs( mCrs );
 }
 
-const QgsCoordinateReferenceSystem& QgsJSONExporter::sourceCrs() const
+QgsCoordinateReferenceSystem QgsJSONExporter::sourceCrs() const
 {
   return mCrs;
 }

--- a/src/core/qgsjsonutils.h
+++ b/src/core/qgsjsonutils.h
@@ -112,7 +112,7 @@ class CORE_EXPORT QgsJSONExporter
      * correctly automatically reprojected to WGS 84, to match GeoJSON specifications.
      * @see setSourceCrs()
      */
-    const QgsCoordinateReferenceSystem& sourceCrs() const;
+    QgsCoordinateReferenceSystem sourceCrs() const;
 
     /** Sets the list of attributes to include in the JSON exports.
      * @param attributes list of attribute indexes, or an empty list to include all

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -1008,7 +1008,7 @@ void QgsMapLayer::setSubLayerVisibility( const QString& name, bool vis )
   // NOOP
 }
 
-const QgsCoordinateReferenceSystem& QgsMapLayer::crs() const
+QgsCoordinateReferenceSystem QgsMapLayer::crs() const
 {
   return mCRS;
 }

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -378,8 +378,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
     /** Returns layer's spatial reference system
     @note This was introduced in QGIS 1.4
      */
-    //TODO QGIS 3.0 - return QgsCoordinateReferenceSystem object, not reference (since they are implicitly shared)
-    const QgsCoordinateReferenceSystem& crs() const;
+    QgsCoordinateReferenceSystem crs() const;
 
     /** Sets layer's spatial reference system */
     void setCrs( const QgsCoordinateReferenceSystem& srs, bool emitSignal = true );

--- a/src/core/qgsmapsettings.cpp
+++ b/src/core/qgsmapsettings.cpp
@@ -291,7 +291,7 @@ void QgsMapSettings::setDestinationCrs( const QgsCoordinateReferenceSystem& crs 
   mDatumTransformStore.setDestinationCrs( crs );
 }
 
-const QgsCoordinateReferenceSystem& QgsMapSettings::destinationCrs() const
+QgsCoordinateReferenceSystem QgsMapSettings::destinationCrs() const
 {
   return mDestCRS;
 }

--- a/src/core/qgsmapsettings.h
+++ b/src/core/qgsmapsettings.h
@@ -136,7 +136,7 @@ class CORE_EXPORT QgsMapSettings
     //! sets destination coordinate reference system
     void setDestinationCrs( const QgsCoordinateReferenceSystem& crs );
     //! returns CRS of destination coordinate reference system
-    const QgsCoordinateReferenceSystem& destinationCrs() const;
+    QgsCoordinateReferenceSystem destinationCrs() const;
 
     //! Get units of map's geographical coordinates - used for scale calculation
     QGis::UnitType mapUnits() const;

--- a/src/core/qgspointlocator.cpp
+++ b/src/core/qgspointlocator.cpp
@@ -608,7 +608,7 @@ class QgsPointLocator_DumpTree : public SpatialIndex::IQueryStrategy
 ////////////////////////////////////////////////////////////////////////////
 
 
-QgsPointLocator::QgsPointLocator( QgsVectorLayer* layer, const QgsCoordinateReferenceSystem* destCRS, const QgsRectangle* extent )
+QgsPointLocator::QgsPointLocator( QgsVectorLayer* layer, const QgsCoordinateReferenceSystem& destCRS, const QgsRectangle* extent )
     : mStorage( nullptr )
     , mRTree( nullptr )
     , mIsEmptyLayer( false )
@@ -616,9 +616,9 @@ QgsPointLocator::QgsPointLocator( QgsVectorLayer* layer, const QgsCoordinateRefe
     , mLayer( layer )
     , mExtent( nullptr )
 {
-  if ( destCRS )
+  if ( destCRS.isValid() )
   {
-    mTransform = new QgsCoordinateTransform( layer->crs(), *destCRS );
+    mTransform = new QgsCoordinateTransform( layer->crs(), destCRS );
   }
 
   setExtent( extent );
@@ -639,9 +639,9 @@ QgsPointLocator::~QgsPointLocator()
   delete mExtent;
 }
 
-const QgsCoordinateReferenceSystem* QgsPointLocator::destCRS() const
+QgsCoordinateReferenceSystem QgsPointLocator::destCRS() const
 {
-  return mTransform ? &mTransform->destCRS() : nullptr;
+  return mTransform ? mTransform->destCRS() : QgsCoordinateReferenceSystem();
 }
 
 void QgsPointLocator::setExtent( const QgsRectangle* extent )

--- a/src/core/qgspointlocator.h
+++ b/src/core/qgspointlocator.h
@@ -22,9 +22,9 @@ class QgsVectorLayer;
 #include "qgsfeature.h"
 #include "qgspoint.h"
 #include "qgsrectangle.h"
+#include "qgscoordinatereferencesystem.h"
 
 class QgsCoordinateTransform;
-class QgsCoordinateReferenceSystem;
 
 class QgsPointLocator_VisitorNearestVertex;
 class QgsPointLocator_VisitorNearestEdge;
@@ -52,19 +52,21 @@ class CORE_EXPORT QgsPointLocator : public QObject
     Q_OBJECT
   public:
     /** Construct point locator for a layer.
-     *  @arg destCRS if not null, will do the searches on data reprojected to the given CRS
+     *  @arg destCRS if a valid QgsCoordinateReferenceSystem is passed then the locator will
+     *  do the searches on data reprojected to the given CRS
      *  @arg extent  if not null, will index only a subset of the layer
      */
-    explicit QgsPointLocator( QgsVectorLayer* layer, const QgsCoordinateReferenceSystem* destCRS = nullptr, const QgsRectangle* extent = nullptr );
+    explicit QgsPointLocator( QgsVectorLayer* layer, const QgsCoordinateReferenceSystem& destCRS = QgsCoordinateReferenceSystem(),
+                              const QgsRectangle* extent = nullptr );
 
     ~QgsPointLocator();
 
     //! Get associated layer
     //! @note added in QGIS 2.14
     QgsVectorLayer* layer() const { return mLayer; }
-    //! Get destination CRS - may be null if not doing OTF reprojection
+    //! Get destination CRS - may be an invalid QgsCoordinateReferenceSystem if not doing OTF reprojection
     //! @note added in QGIS 2.14
-    const QgsCoordinateReferenceSystem* destCRS() const;
+    QgsCoordinateReferenceSystem destCRS() const;
     //! Get extent of the area point locator covers - if null then it caches the whole layer
     //! @note added in QGIS 2.14
     const QgsRectangle* extent() const { return mExtent; }

--- a/src/core/qgssnappingutils.cpp
+++ b/src/core/qgssnappingutils.cpp
@@ -572,9 +572,9 @@ QString QgsSnappingUtils::dump()
   return msg;
 }
 
-const QgsCoordinateReferenceSystem* QgsSnappingUtils::destCRS()
+QgsCoordinateReferenceSystem QgsSnappingUtils::destCRS() const
 {
-  return mMapSettings.hasCrsTransformEnabled() ? &mMapSettings.destinationCrs() : nullptr;
+  return mMapSettings.hasCrsTransformEnabled() ? mMapSettings.destinationCrs() : QgsCoordinateReferenceSystem();
 }
 
 

--- a/src/core/qgssnappingutils.h
+++ b/src/core/qgssnappingutils.h
@@ -185,8 +185,8 @@ class CORE_EXPORT QgsSnappingUtils : public QObject
     void onLayersWillBeRemoved( const QStringList& layerIds );
 
   private:
-    //! get from map settings pointer to destination CRS - or 0 if projections are disabled
-    const QgsCoordinateReferenceSystem* destCRS();
+    //! Get destination CRS from map settings, or an invalid CRS if projections are disabled
+    QgsCoordinateReferenceSystem destCRS() const;
 
     //! delete all existing locators (e.g. when destination CRS has changed and we need to reindex)
     void clearAllLocators();

--- a/src/core/qgsvectorlayerimport.cpp
+++ b/src/core/qgsvectorlayerimport.cpp
@@ -34,7 +34,7 @@ typedef QgsVectorLayerImport::ImportError createEmptyLayer_t(
   const QString &uri,
   const QgsFields &fields,
   QGis::WkbType geometryType,
-  const QgsCoordinateReferenceSystem *destCRS,
+  const QgsCoordinateReferenceSystem &destCRS,
   bool overwrite,
   QMap<int, int> *oldToNewAttrIdx,
   QString *errorMessage,
@@ -46,7 +46,7 @@ QgsVectorLayerImport::QgsVectorLayerImport( const QString &uri,
     const QString &providerKey,
     const QgsFields& fields,
     QGis::WkbType geometryType,
-    const QgsCoordinateReferenceSystem* crs,
+    const QgsCoordinateReferenceSystem& crs,
     bool overwrite,
     const QMap<QString, QVariant> *options,
     QProgressDialog *progress )
@@ -206,21 +206,21 @@ QgsVectorLayerImport::ImportError
 QgsVectorLayerImport::importLayer( QgsVectorLayer* layer,
                                    const QString& uri,
                                    const QString& providerKey,
-                                   const QgsCoordinateReferenceSystem *destCRS,
+                                   const QgsCoordinateReferenceSystem& destCRS,
                                    bool onlySelected,
                                    QString *errorMessage,
                                    bool skipAttributeCreation,
                                    QMap<QString, QVariant> *options,
                                    QProgressDialog *progress )
 {
-  const QgsCoordinateReferenceSystem* outputCRS;
+  QgsCoordinateReferenceSystem outputCRS;
   QgsCoordinateTransform* ct = nullptr;
   bool shallTransform = false;
 
   if ( !layer )
     return ErrInvalidLayer;
 
-  if ( destCRS && destCRS->isValid() )
+  if ( destCRS.isValid() )
   {
     // This means we should transform
     outputCRS = destCRS;
@@ -229,7 +229,7 @@ QgsVectorLayerImport::importLayer( QgsVectorLayer* layer,
   else
   {
     // This means we shouldn't transform, use source CRS as output (if defined)
-    outputCRS = &layer->crs();
+    outputCRS = layer->crs();
   }
 
 
@@ -314,8 +314,8 @@ QgsVectorLayerImport::importLayer( QgsVectorLayer* layer,
   const QgsFeatureIds& ids = layer->selectedFeaturesIds();
 
   // Create our transform
-  if ( destCRS )
-    ct = new QgsCoordinateTransform( layer->crs(), *destCRS );
+  if ( destCRS.isValid() )
+    ct = new QgsCoordinateTransform( layer->crs(), destCRS );
 
   // Check for failure
   if ( !ct )

--- a/src/core/qgsvectorlayerimport.h
+++ b/src/core/qgsvectorlayerimport.h
@@ -51,11 +51,24 @@ class CORE_EXPORT QgsVectorLayerImport
       ErrUserCancelled, /*!< User cancelled the import*/
     };
 
-    /** Write contents of vector layer to a different datasource */
+    /**
+     * Writes the contents of vector layer to a different datasource.
+     * @param layer source layer
+     * @param uri URI for destination data source
+     * @param providerKey string key for destination data provider
+     * @param destCRS destination CRS, or an invalid (default constructed) CRS if
+     * not available
+     * @param onlySelected set to true to export only selected features
+     * @param errorMessage if non-null, will be set to any error messages
+     * @param skipAttributeCreation set to true to skip exporting feature attributes
+     * @param options optional provider dataset options
+     * @param progress optional progress dialog to show progress of export
+     * @returns NoError for a successful export, or encountered error
+     */
     static ImportError importLayer( QgsVectorLayer* layer,
                                     const QString& uri,
                                     const QString& providerKey,
-                                    const QgsCoordinateReferenceSystem *destCRS,
+                                    const QgsCoordinateReferenceSystem& destCRS,
                                     bool onlySelected = false,
                                     QString *errorMessage = nullptr,
                                     bool skipAttributeCreation = false,
@@ -63,12 +76,22 @@ class CORE_EXPORT QgsVectorLayerImport
                                     QProgressDialog *progress = nullptr
                                   );
 
-    /** Create a empty layer and add fields to it */
+    /** Constructor for QgsVectorLayerImport.
+     * @param uri URI for destination data source
+     * @param provider string key for destination data provider
+     * @param fields fields to include in created layer
+     * @param geometryType destination geometry type
+     * @param crs desired CRS, or an invalid (default constructed) CRS if
+     * not available
+     * @param overwrite set to true to overwrite any existing data source
+     * @param options optional provider dataset options
+     * @param progress optional progress dialog to show progress of export
+     */
     QgsVectorLayerImport( const QString &uri,
                           const QString &provider,
                           const QgsFields &fields,
                           QGis::WkbType geometryType,
-                          const QgsCoordinateReferenceSystem* crs,
+                          const QgsCoordinateReferenceSystem& crs,
                           bool overwrite = false,
                           const QMap<QString, QVariant> *options = nullptr,
                           QProgressDialog *progress = nullptr

--- a/src/gui/qgsnewvectorlayerdialog.cpp
+++ b/src/gui/qgsnewvectorlayerdialog.cpp
@@ -270,14 +270,14 @@ QString QgsNewVectorLayerDialog::runAndCreateLayer( QWidget* parent, QString* pE
     QgsDebugMsg( "ogr provider loaded" );
 
     typedef bool ( *createEmptyDataSourceProc )( const QString&, const QString&, const QString&, QGis::WkbType,
-        const QList< QPair<QString, QString> >&, const QgsCoordinateReferenceSystem * );
+        const QList< QPair<QString, QString> >&, const QgsCoordinateReferenceSystem & );
     createEmptyDataSourceProc createEmptyDataSource = ( createEmptyDataSourceProc ) cast_to_fptr( myLib->resolve( "createEmptyDataSource" ) );
     if ( createEmptyDataSource )
     {
       if ( geometrytype != QGis::WKBUnknown )
       {
         QgsCoordinateReferenceSystem srs = QgsCRSCache::instance()->crsBySrsId( crsId );
-        if ( !createEmptyDataSource( fileName, fileformat, enc, geometrytype, attributes, &srs ) )
+        if ( !createEmptyDataSource( fileName, fileformat, enc, geometrytype, attributes, srs ) )
         {
           return QString::null;
         }

--- a/src/plugins/geometry_checker/ui/qgsgeometrycheckerresulttab.cpp
+++ b/src/plugins/geometry_checker/ui/qgsgeometrycheckerresulttab.cpp
@@ -238,13 +238,13 @@ bool QgsGeometryCheckerResultTab::exportErrorsDo( const QString& file )
   {
     return false;
   }
-  typedef bool ( *createEmptyDataSourceProc )( const QString&, const QString&, const QString&, QGis::WkbType, const QList< QPair<QString, QString> >&, const QgsCoordinateReferenceSystem * );
+  typedef bool ( *createEmptyDataSourceProc )( const QString&, const QString&, const QString&, QGis::WkbType, const QList< QPair<QString, QString> >&, const QgsCoordinateReferenceSystem& );
   createEmptyDataSourceProc createEmptyDataSource = ( createEmptyDataSourceProc ) cast_to_fptr( ogrLib.resolve( "createEmptyDataSource" ) );
   if ( !createEmptyDataSource )
   {
     return false;
   }
-  if ( !createEmptyDataSource( file, "ESRI Shapefile", mFeaturePool->getLayer()->dataProvider()->encoding(), QGis::WKBPoint, attributes, &mFeaturePool->getLayer()->crs() ) )
+  if ( !createEmptyDataSource( file, "ESRI Shapefile", mFeaturePool->getLayer()->dataProvider()->encoding(), QGis::WKBPoint, attributes, mFeaturePool->getLayer()->crs() ) )
   {
     return false;
   }

--- a/src/providers/db2/qgsdb2dataitems.cpp
+++ b/src/providers/db2/qgsdb2dataitems.cpp
@@ -361,7 +361,7 @@ bool QgsDb2ConnectionItem::handleDrop( const QMimeData* data, const QString& toS
 
       QgsVectorLayerImport::ImportError err;
       QString importError;
-      err = QgsVectorLayerImport::importLayer( srcLayer, uri, "DB2", &srcLayer->crs(), false, &importError, false, nullptr, progress );
+      err = QgsVectorLayerImport::importLayer( srcLayer, uri, "DB2", srcLayer->crs(), false, &importError, false, nullptr, progress );
       if ( err == QgsVectorLayerImport::NoError )
       {
         importResults.append( tr( "%1: OK!" ).arg( u.name ) );

--- a/src/providers/db2/qgsdb2provider.cpp
+++ b/src/providers/db2/qgsdb2provider.cpp
@@ -1263,15 +1263,14 @@ bool QgsDb2Provider::changeGeometryValues( const QgsGeometryMap &geometry_map )
   return true;
 }
 
-QgsVectorLayerImport::ImportError QgsDb2Provider::createEmptyLayer(
-  const QString& uri,
-  const QgsFields &fields,
-  QGis::WkbType wkbType,
-  const QgsCoordinateReferenceSystem *srs,
-  bool overwrite,
-  QMap<int, int> *oldToNewAttrIdxMap,
-  QString *errorMessage,
-  const QMap<QString, QVariant> *options )
+QgsVectorLayerImport::ImportError QgsDb2Provider::createEmptyLayer( const QString& uri,
+    const QgsFields &fields,
+    QGis::WkbType wkbType,
+    const QgsCoordinateReferenceSystem& srs,
+    bool overwrite,
+    QMap<int, int> *oldToNewAttrIdxMap,
+    QString *errorMessage,
+    const QMap<QString, QVariant> *options )
 {
   Q_UNUSED( options );
 
@@ -1297,8 +1296,8 @@ QgsVectorLayerImport::ImportError QgsDb2Provider::createEmptyLayer(
   // srs->posgisSrid() seems to return the authority id which is
   // most often the EPSG id.  Hopefully DB2 has defined an SRS using this
   // value as the srid / srs_id.  If not, we are out of luck.
-  QgsDebugMsg( "srs: " + srs->toWkt() );
-  long srid = srs->postgisSrid();
+  QgsDebugMsg( "srs: " + srs.toWkt() );
+  long srid = srs.postgisSrid();
   QgsDebugMsg( QString( "srid: %1" ).arg( srid ) );
   if ( srid >= 0 )
   {
@@ -1740,7 +1739,7 @@ QGISEXTERN QgsVectorLayerImport::ImportError createEmptyLayer(
   const QString& uri,
   const QgsFields &fields,
   QGis::WkbType wkbType,
-  const QgsCoordinateReferenceSystem *srs,
+  const QgsCoordinateReferenceSystem &srs,
   bool overwrite,
   QMap<int, int> *oldToNewAttrIdxMap,
   QString *errorMessage,

--- a/src/providers/db2/qgsdb2provider.h
+++ b/src/providers/db2/qgsdb2provider.h
@@ -143,7 +143,7 @@ class QgsDb2Provider : public QgsVectorDataProvider
       const QString& uri,
       const QgsFields &fields,
       QGis::WkbType wkbType,
-      const QgsCoordinateReferenceSystem *srs,
+      const QgsCoordinateReferenceSystem& srs,
       bool overwrite,
       QMap<int, int> *oldToNewAttrIdxMap,
       QString *errorMessage = nullptr,

--- a/src/providers/mssql/qgsmssqldataitems.cpp
+++ b/src/providers/mssql/qgsmssqldataitems.cpp
@@ -426,7 +426,7 @@ bool QgsMssqlConnectionItem::handleDrop( const QMimeData* data, const QString& t
 
       QgsVectorLayerImport::ImportError err;
       QString importError;
-      err = QgsVectorLayerImport::importLayer( srcLayer, uri, "mssql", &srcLayer->crs(), false, &importError, false, nullptr, progress );
+      err = QgsVectorLayerImport::importLayer( srcLayer, uri, "mssql", srcLayer->crs(), false, &importError, false, nullptr, progress );
       if ( err == QgsVectorLayerImport::NoError )
         importResults.append( tr( "%1: OK!" ).arg( u.name ) );
       else if ( err == QgsVectorLayerImport::ErrUserCancelled )

--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -1650,15 +1650,14 @@ QGis::WkbType QgsMssqlProvider::getWkbType( const QString& geometryType, int dim
 }
 
 
-QgsVectorLayerImport::ImportError QgsMssqlProvider::createEmptyLayer(
-  const QString& uri,
-  const QgsFields &fields,
-  QGis::WkbType wkbType,
-  const QgsCoordinateReferenceSystem *srs,
-  bool overwrite,
-  QMap<int, int> *oldToNewAttrIdxMap,
-  QString *errorMessage,
-  const QMap<QString, QVariant> *options )
+QgsVectorLayerImport::ImportError QgsMssqlProvider::createEmptyLayer( const QString& uri,
+    const QgsFields &fields,
+    QGis::WkbType wkbType,
+    const QgsCoordinateReferenceSystem& srs,
+    bool overwrite,
+    QMap<int, int> *oldToNewAttrIdxMap,
+    QString *errorMessage,
+    const QMap<QString, QVariant> *options )
 {
   Q_UNUSED( options );
 
@@ -1758,23 +1757,23 @@ QgsVectorLayerImport::ImportError QgsMssqlProvider::createEmptyLayer(
 
   // set up spatial reference id
   int srid = 0;
-  if ( srs->isValid() )
+  if ( srs.isValid() )
   {
-    srid = srs->srsid();
+    srid = srs.srsid();
     QString auth_srid = "null";
     QString auth_name = "null";
-    QStringList sl = srs->authid().split( ':' );
+    QStringList sl = srs.authid().split( ':' );
     if ( sl.length() == 2 )
     {
       auth_name = '\'' + sl[0] + '\'';
       auth_srid = sl[1];
     }
     sql = QString( "IF NOT EXISTS (SELECT * FROM spatial_ref_sys WHERE srid=%1) INSERT INTO spatial_ref_sys (srid, auth_name, auth_srid, srtext, proj4text) VALUES (%1, %2, %3, '%4', '%5')" )
-          .arg( srs->srsid() )
+          .arg( srs.srsid() )
           .arg( auth_name,
                 auth_srid,
-                srs->toWkt(),
-                srs->toProj4() );
+                srs.toWkt(),
+                srs.toProj4() );
     if ( !q.exec( sql ) )
     {
       if ( errorMessage )
@@ -1958,7 +1957,7 @@ QGISEXTERN QgsVectorLayerImport::ImportError createEmptyLayer(
   const QString& uri,
   const QgsFields &fields,
   QGis::WkbType wkbType,
-  const QgsCoordinateReferenceSystem *srs,
+  const QgsCoordinateReferenceSystem &srs,
   bool overwrite,
   QMap<int, int> *oldToNewAttrIdxMap,
   QString *errorMessage,

--- a/src/providers/mssql/qgsmssqlprovider.h
+++ b/src/providers/mssql/qgsmssqlprovider.h
@@ -239,7 +239,7 @@ class QgsMssqlProvider : public QgsVectorDataProvider
       const QString& uri,
       const QgsFields &fields,
       QGis::WkbType wkbType,
-      const QgsCoordinateReferenceSystem *srs,
+      const QgsCoordinateReferenceSystem &srs,
       bool overwrite,
       QMap<int, int> *oldToNewAttrIdxMap,
       QString *errorMessage = nullptr,

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -196,15 +196,14 @@ void QgsOgrProvider::repack()
 }
 
 
-QgsVectorLayerImport::ImportError QgsOgrProvider::createEmptyLayer(
-  const QString& uri,
-  const QgsFields &fields,
-  QGis::WkbType wkbType,
-  const QgsCoordinateReferenceSystem *srs,
-  bool overwrite,
-  QMap<int, int> *oldToNewAttrIdxMap,
-  QString *errorMessage,
-  const QMap<QString, QVariant> *options )
+QgsVectorLayerImport::ImportError QgsOgrProvider::createEmptyLayer( const QString& uri,
+    const QgsFields &fields,
+    QGis::WkbType wkbType,
+    const QgsCoordinateReferenceSystem& srs,
+    bool overwrite,
+    QMap<int, int> *oldToNewAttrIdxMap,
+    QString *errorMessage,
+    const QMap<QString, QVariant> *options )
 {
   QString encoding;
   QString driverName = "ESRI Shapefile";
@@ -2438,7 +2437,7 @@ QGISEXTERN bool createEmptyDataSource( const QString &uri,
                                        const QString &encoding,
                                        QGis::WkbType vectortype,
                                        const QList< QPair<QString, QString> > &attributes,
-                                       const QgsCoordinateReferenceSystem *srs = nullptr )
+                                       const QgsCoordinateReferenceSystem& srs = QgsCoordinateReferenceSystem() )
 {
   QgsDebugMsg( QString( "Creating empty vector layer with format: %1" ).arg( format ) );
 
@@ -2493,9 +2492,9 @@ QGISEXTERN bool createEmptyDataSource( const QString &uri,
   OGRSpatialReferenceH reference = nullptr;
 
   QgsCoordinateReferenceSystem mySpatialRefSys;
-  if ( srs )
+  if ( srs.isValid() )
   {
-    mySpatialRefSys = *srs;
+    mySpatialRefSys = srs;
   }
   else
   {
@@ -3335,7 +3334,7 @@ QGISEXTERN QgsVectorLayerImport::ImportError createEmptyLayer(
   const QString& uri,
   const QgsFields &fields,
   QGis::WkbType wkbType,
-  const QgsCoordinateReferenceSystem *srs,
+  const QgsCoordinateReferenceSystem &srs,
   bool overwrite,
   QMap<int, int> *oldToNewAttrIdxMap,
   QString *errorMessage,

--- a/src/providers/ogr/qgsogrprovider.h
+++ b/src/providers/ogr/qgsogrprovider.h
@@ -54,7 +54,7 @@ class QgsOgrProvider : public QgsVectorDataProvider
       const QString& uri,
       const QgsFields &fields,
       QGis::WkbType wkbType,
-      const QgsCoordinateReferenceSystem *srs,
+      const QgsCoordinateReferenceSystem &srs,
       bool overwrite,
       QMap<int, int> *oldToNewAttrIdxMap,
       QString *errorMessage = nullptr,

--- a/src/providers/postgres/qgspostgresdataitems.cpp
+++ b/src/providers/postgres/qgspostgresdataitems.cpp
@@ -233,7 +233,7 @@ bool QgsPGConnectionItem::handleDrop( const QMimeData * data, QString toSchema )
 
       QgsVectorLayerImport::ImportError err;
       QString importError;
-      err = QgsVectorLayerImport::importLayer( srcLayer, uri.uri( false ), "postgres", &srcLayer->crs(), false, &importError, false, nullptr, progress );
+      err = QgsVectorLayerImport::importLayer( srcLayer, uri.uri( false ), "postgres", srcLayer->crs(), false, &importError, false, nullptr, progress );
       if ( err == QgsVectorLayerImport::NoError )
         importResults.append( tr( "%1: OK!" ).arg( u.name ) );
       else if ( err == QgsVectorLayerImport::ErrUserCancelled )

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -3462,15 +3462,14 @@ bool QgsPostgresProvider::convertField( QgsField &field, const QMap<QString, QVa
   return true;
 }
 
-QgsVectorLayerImport::ImportError QgsPostgresProvider::createEmptyLayer(
-  const QString& uri,
-  const QgsFields &fields,
-  QGis::WkbType wkbType,
-  const QgsCoordinateReferenceSystem *srs,
-  bool overwrite,
-  QMap<int, int> *oldToNewAttrIdxMap,
-  QString *errorMessage,
-  const QMap<QString, QVariant> *options )
+QgsVectorLayerImport::ImportError QgsPostgresProvider::createEmptyLayer( const QString& uri,
+    const QgsFields &fields,
+    QGis::WkbType wkbType,
+    const QgsCoordinateReferenceSystem& srs,
+    bool overwrite,
+    QMap<int, int> *oldToNewAttrIdxMap,
+    QString *errorMessage,
+    const QMap<QString, QVariant> *options )
 {
   // populate members from the uri structure
   QgsDataSourceURI dsUri( uri );
@@ -3615,7 +3614,7 @@ QgsVectorLayerImport::ImportError QgsPostgresProvider::createEmptyLayer(
 
     // get geometry type, dim and srid
     int dim = 2;
-    long srid = srs->postgisSrid();
+    long srid = srs.postgisSrid();
 
     QgsPostgresConn::postgisWkbType( wkbType, geometryType, dim );
 
@@ -3854,7 +3853,7 @@ QGISEXTERN QgsVectorLayerImport::ImportError createEmptyLayer(
   const QString& uri,
   const QgsFields &fields,
   QGis::WkbType wkbType,
-  const QgsCoordinateReferenceSystem *srs,
+  const QgsCoordinateReferenceSystem& srs,
   bool overwrite,
   QMap<int, int> *oldToNewAttrIdxMap,
   QString *errorMessage,

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -58,7 +58,7 @@ class QgsPostgresProvider : public QgsVectorDataProvider
       const QString& uri,
       const QgsFields &fields,
       QGis::WkbType wkbType,
-      const QgsCoordinateReferenceSystem *srs,
+      const QgsCoordinateReferenceSystem &srs,
       bool overwrite,
       QMap<int, int> *oldToNewAttrIdxMap,
       QString *errorMessage = nullptr,

--- a/src/providers/spatialite/qgsspatialitedataitems.cpp
+++ b/src/providers/spatialite/qgsspatialitedataitems.cpp
@@ -232,7 +232,7 @@ bool QgsSLConnectionItem::handleDrop( const QMimeData * data, Qt::DropAction )
       QgsDebugMsg( "URI " + destUri.uri() );
       QgsVectorLayerImport::ImportError err;
       QString importError;
-      err = QgsVectorLayerImport::importLayer( srcLayer, destUri.uri(), "spatialite", &srcLayer->crs(), false, &importError, false, nullptr, progress );
+      err = QgsVectorLayerImport::importLayer( srcLayer, destUri.uri(), "spatialite", srcLayer->crs(), false, &importError, false, nullptr, progress );
       if ( err == QgsVectorLayerImport::NoError )
         importResults.append( tr( "%1: OK!" ).arg( u.name ) );
       else if ( err == QgsVectorLayerImport::ErrUserCancelled )

--- a/src/providers/spatialite/qgsspatialiteprovider.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovider.cpp
@@ -93,15 +93,14 @@ bool QgsSpatiaLiteProvider::convertField( QgsField &field )
 
 
 QgsVectorLayerImport::ImportError
-QgsSpatiaLiteProvider::createEmptyLayer(
-  const QString& uri,
-  const QgsFields &fields,
-  QGis::WkbType wkbType,
-  const QgsCoordinateReferenceSystem *srs,
-  bool overwrite,
-  QMap<int, int> *oldToNewAttrIdxMap,
-  QString *errorMessage,
-  const QMap<QString, QVariant> *options )
+QgsSpatiaLiteProvider::createEmptyLayer( const QString& uri,
+    const QgsFields &fields,
+    QGis::WkbType wkbType,
+    const QgsCoordinateReferenceSystem& srs,
+    bool overwrite,
+    QMap<int, int> *oldToNewAttrIdxMap,
+    QString *errorMessage,
+    const QMap<QString, QVariant> *options )
 {
   Q_UNUSED( options );
 
@@ -224,7 +223,7 @@ QgsSpatiaLiteProvider::createEmptyLayer(
 
       // get geometry type, dim and srid
       int dim = 2;
-      long srid = srs->postgisSrid();
+      long srid = srs.postgisSrid();
 
       switch ( wkbType )
       {
@@ -5075,7 +5074,7 @@ QGISEXTERN QgsVectorLayerImport::ImportError createEmptyLayer(
   const QString& uri,
   const QgsFields &fields,
   QGis::WkbType wkbType,
-  const QgsCoordinateReferenceSystem *srs,
+  const QgsCoordinateReferenceSystem& srs,
   bool overwrite,
   QMap<int, int> *oldToNewAttrIdxMap,
   QString *errorMessage,

--- a/src/providers/spatialite/qgsspatialiteprovider.h
+++ b/src/providers/spatialite/qgsspatialiteprovider.h
@@ -59,7 +59,7 @@ class QgsSpatiaLiteProvider: public QgsVectorDataProvider
       const QString& uri,
       const QgsFields &fields,
       QGis::WkbType wkbType,
-      const QgsCoordinateReferenceSystem *srs,
+      const QgsCoordinateReferenceSystem& srs,
       bool overwrite,
       QMap<int, int> *oldToNewAttrIdxMap,
       QString *errorMessage = nullptr,

--- a/src/server/qgsserverprojectparser.cpp
+++ b/src/server/qgsserverprojectparser.cpp
@@ -747,7 +747,7 @@ void QgsServerProjectParser::combineExtentAndCrsOfGroupChildren( QDomElement& gr
 
   QgsConfigParserUtils::appendCRSElementsToLayer( groupElem, doc, combinedCRSSet.toList(), supportedOutputCrsList() );
 
-  const QgsCoordinateReferenceSystem& groupCRS = projectCRS();
+  QgsCoordinateReferenceSystem groupCRS = projectCRS();
   if ( considerMapExtent )
   {
     QgsRectangle mapRect = mapRectangle();
@@ -879,7 +879,7 @@ QgsRectangle QgsServerProjectParser::layerBoundingBoxInProjectCRS( const QDomEle
   }
 
   //get project crs
-  const QgsCoordinateReferenceSystem& projectCrs = projectCRS();
+  QgsCoordinateReferenceSystem projectCrs = projectCRS();
   QgsCoordinateTransform t( layerCrs, projectCrs );
 
   //transform


### PR DESCRIPTION
(this won't build, as it depends on the earlier QGIS 3 PRs I've submitted)

This PR changes all remaining methods which return a reference to a QgsCoordinateReferenceSystem to instead return a copy (since they are implicitly shared). Additionally, all methods which take a QgsCoordinateReferenceSystem pointer have been reworked to take a reference and use invalid CRS objects instead of null pointers.
