### PR TITLE
Improve the way how fake events are generated in CAD tools

### DIFF
--- a/src/gui/qgsmaptooladvanceddigitizing.cpp
+++ b/src/gui/qgsmaptooladvanceddigitizing.cpp
@@ -15,6 +15,7 @@
 
 #include "qgsmapmouseevent.h"
 #include "qgsmaptooladvanceddigitizing.h"
+#include "qgsmapcanvas.h"
 
 
 QgsMapToolAdvancedDigitizing::QgsMapToolAdvancedDigitizing( QgsMapCanvas* canvas, QgsAdvancedDigitizingDockWidget* cadDockWidget )
@@ -69,9 +70,9 @@ void QgsMapToolAdvancedDigitizing::deactivate()
 
 void QgsMapToolAdvancedDigitizing::cadPointChanged( const QgsPoint& point )
 {
-  QgsMapMouseEvent fakeEvent( mCanvas, QMouseEvent::Move, QPoint( 0, 0 ) );
-  fakeEvent.setMapPoint( point );
-  canvasMoveEvent( &fakeEvent );
+  Q_UNUSED( point );
+  QMouseEvent* ev = new QMouseEvent( QEvent::MouseMove, mCanvas->mouseLastXY(), Qt::NoButton, Qt::NoButton, Qt::NoModifier );
+  qApp->postEvent( mCanvas->viewport(), ev );  // event queue will delete the event when processed
 }
 
 void QgsMapToolAdvancedDigitizing::snap( QgsMapMouseEvent* e )


### PR DESCRIPTION
In my custom tool in python, the generated fake event received in cadCanvasMoveEvent()
was actually QMouseEvent instance instead of QgsMapMouseEvent, suggesting something
dodgy going on behind the scenes. The actual reason was that first argument was
QMouseEvent::Move instead of QEvent::MouseMove (not sure why the cast did not work though)

The new approach seems safer as the event goes through the ordinary event processing
