### PR TITLE
Fix snapping for layers with triggers

### DIFF
--- a/python/core/qgssnappingutils.sip
+++ b/python/core/qgssnappingutils.sip
@@ -89,6 +89,11 @@ class QgsSnappingUtils : QObject
     /** Query layers used for snapping */
     QList<QgsSnappingUtils::LayerConfig> layers() const;
 
+    /** Set layers which have side effects, i.e. which may create or modify geometries in other layers */
+    void setSideEffectLayers( const QVector<QgsVectorLayer*>& layers );
+    /** Query layers with side effects */
+    QVector<QgsVectorLayer*> sideEffectLayers() const;
+
     /** Set whether to consider intersections of nearby segments for snapping */
     void setSnapOnIntersections( bool enabled );
     /** Query whether to consider intersections of nearby segments for snapping */

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -591,7 +591,6 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
     , mpTileScaleWidget( nullptr )
     , mpGpsWidget( nullptr )
     , mTracer( nullptr )
-    , mSnappingUtils( nullptr )
     , mProjectLastModified()
     , mWelcomePage( nullptr )
     , mCentralContainer( nullptr )
@@ -748,10 +747,10 @@ QgisApp::QgisApp( QSplashScreen *splash, bool restorePlugins, bool skipVersionCh
   endProfile();
 
   startProfile( "Snapping utils" );
-  mSnappingUtils = new QgsMapCanvasSnappingUtils( mMapCanvas, this );
-  mMapCanvas->setSnappingUtils( mSnappingUtils );
-  connect( QgsProject::instance(), SIGNAL( snapSettingsChanged() ), mSnappingUtils, SLOT( readConfigFromProject() ) );
-  connect( this, SIGNAL( projectRead() ), mSnappingUtils, SLOT( readConfigFromProject() ) );
+  mSnappingUtils.reset( new QgsMapCanvasSnappingUtils( mMapCanvas, this ) );
+  mMapCanvas->setSnappingUtils( mSnappingUtils.data() );
+  connect( QgsProject::instance(), SIGNAL( snapSettingsChanged() ), mSnappingUtils.data(), SLOT( readConfigFromProject() ) );
+  connect( this, SIGNAL( projectRead() ), mSnappingUtils.data(), SLOT( readConfigFromProject() ) );
   endProfile();
 
   functionProfile( &QgisApp::createActions, this, "Create actions" );

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1770,7 +1770,7 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     QgsLegendFilterButton* mLegendExpressionFilterButton;
 
-    QgsSnappingUtils* mSnappingUtils;
+    QScopedPointer<QgsSnappingUtils> mSnappingUtils;
 
     QList<QgsMapLayerConfigWidgetFactory*> mMapLayerPanelFactories;
 

--- a/src/core/qgssnappingutils.h
+++ b/src/core/qgssnappingutils.h
@@ -155,6 +155,11 @@ class CORE_EXPORT QgsSnappingUtils : public QObject
     /** Query layers used for snapping */
     QList<LayerConfig> layers() const { return mLayers; }
 
+    /** Set layers which have side effects, i.e. which may create or modify geometries in other layers */
+    void setSideEffectLayers( const QVector<QgsVectorLayer*>& layers );
+    /** Query layers with side effects */
+    QVector<QgsVectorLayer*> sideEffectLayers() const { return mSideEffectLayers; }
+
     /** Set whether to consider intersections of nearby segments for snapping */
     void setSnapOnIntersections( bool enabled );
     /** Query whether to consider intersections of nearby segments for snapping */
@@ -184,12 +189,12 @@ class CORE_EXPORT QgsSnappingUtils : public QObject
   private slots:
     void onLayersWillBeRemoved( const QStringList& layerIds );
 
+    //! delete all existing locators (e.g. when destination CRS has changed and we need to reindex)
+    void clearAllLocators();
+
   private:
     //! get from map settings pointer to destination CRS - or 0 if projections are disabled
     const QgsCoordinateReferenceSystem* destCRS();
-
-    //! delete all existing locators (e.g. when destination CRS has changed and we need to reindex)
-    void clearAllLocators();
 
     //! return a locator (temporary or not) according to the indexing strategy
     QgsPointLocator* locatorForLayerUsingStrategy( QgsVectorLayer* vl, const QgsPoint& pointMap, double tolerance );
@@ -239,6 +244,9 @@ class CORE_EXPORT QgsSnappingUtils : public QObject
 
     //! internal flag that an indexing process is going on. Prevents starting two processes in parallel.
     bool mIsIndexing;
+
+    //! side effect layers, i.e. layers that may create/modify geometries in other layers
+    QVector<QgsVectorLayer*> mSideEffectLayers;
 };
 
 

--- a/src/ui/qgssnappingdialogbase.ui
+++ b/src/ui/qgssnappingdialogbase.ui
@@ -6,8 +6,8 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>798</width>
-    <height>290</height>
+    <width>1021</width>
+    <height>288</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -66,7 +66,7 @@
    <item>
     <widget class="QStackedWidget" name="mStackedWidget">
      <property name="currentIndex">
-      <number>0</number>
+      <number>1</number>
      </property>
      <widget class="QWidget" name="page">
       <layout class="QGridLayout" name="gridLayout_3">
@@ -205,6 +205,14 @@
           </property>
           <property name="textAlignment">
            <set>AlignLeft|AlignVCenter</set>
+          </property>
+         </column>
+         <column>
+          <property name="text">
+           <string>Has side effects</string>
+          </property>
+          <property name="toolTip">
+           <string>Reset the snapping index when the layer is modified (useful if geometries in other layers are computed from geometries of this layer with database triggers)</string>
           </property>
          </column>
         </widget>

--- a/tests/src/python/CMakeLists.txt
+++ b/tests/src/python/CMakeLists.txt
@@ -101,6 +101,7 @@ ADD_PYTHON_TEST(PyQgsLayerDefinition test_qgslayerdefinition.py)
 ADD_PYTHON_TEST(PyQgsWFSProvider test_provider_wfs.py)
 ADD_PYTHON_TEST(PyQgsWFSProviderGUI test_provider_wfs_gui.py)
 ADD_PYTHON_TEST(PyQgsConsole test_console.py)
+ADD_PYTHON_TEST(PyQgsSnappingUtils test_qgssnappingutils.py)
 
 IF (NOT WIN32)
   ADD_PYTHON_TEST(PyQgsLogger test_qgslogger.py)

--- a/tests/src/python/test_qgssnappingutils.py
+++ b/tests/src/python/test_qgssnappingutils.py
@@ -1,0 +1,138 @@
+# -*- coding: utf-8 -*-
+"""QGIS Unit tests for QgsSnappingUtils (complement to C++-based tests)
+
+.. note:: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+"""
+__author__ = 'Hugo Mercier'
+__date__ = '12/07/2016'
+__copyright__ = 'Copyright 2016, The QGIS Project'
+# This will get replaced with a git SHA1 when you do a git archive
+__revision__ = '$Format:%H$'
+
+import qgis  # NOQA
+import os
+
+from qgis.core import (QgsMapLayerRegistry,
+                       QgsVectorLayer,
+                       QgsMapSettings,
+                       QgsSnappingUtils,
+                       QgsPointLocator,
+                       QgsTolerance,
+                       QgsRectangle,
+                       QgsPoint,
+                       QgsFeature,
+                       QgsGeometry
+                       )
+
+from qgis.testing import start_app, unittest
+from utilities import unitTestDataPath
+
+from qgis.PyQt.QtCore import QSize, QPoint
+
+import tempfile
+
+try:
+    from pyspatialite import dbapi2 as sqlite3
+except ImportError:
+    print("You should install pyspatialite to run the tests")
+    raise ImportError
+
+# Convenience instances in case you may need them
+start_app()
+
+
+class TestQgsSnappingUtils(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        """Run before all tests"""
+
+        # create a temp spatialite db with a trigger
+        fo = tempfile.NamedTemporaryFile()
+        fn = fo.name
+        fo.close()
+        print fn
+        con = sqlite3.connect(fn)
+        cur = con.cursor()
+        cur.execute("SELECT InitSpatialMetadata(1)")
+        cur.execute("create table node(id integer primary key autoincrement);")
+        cur.execute("select AddGeometryColumn('node', 'geom', 4326, 'POINT');")
+        cur.execute("create table section(id integer primary key autoincrement, node1 integer, node2 integer);")
+        cur.execute("select AddGeometryColumn('section', 'geom', 4326, 'LINESTRING');")
+        cur.execute("create trigger add_nodes after insert on section begin insert into node (geom) values (st_startpoint(NEW.geom)); insert into node (geom) values (st_endpoint(NEW.geom)); end;")
+        cur.execute("insert into node (geom) values (geomfromtext('point(0 0)', 4326));")
+        cur.execute("insert into node (geom) values (geomfromtext('point(1 0)', 4326));")
+        con.commit()
+        con.close()
+
+        cls.pointsLayer = QgsVectorLayer("dbname='%s' table=\"node\" (geom) sql=" % fn, "points", "spatialite")
+        assert (cls.pointsLayer.isValid())
+        cls.linesLayer = QgsVectorLayer("dbname='%s' table=\"section\" (geom) sql=" % fn, "points", "spatialite")
+        assert (cls.linesLayer.isValid())
+        QgsMapLayerRegistry.instance().addMapLayers([cls.pointsLayer, cls.linesLayer])
+
+    @classmethod
+    def tearDownClass(cls):
+        """Run after all tests"""
+        pass
+
+    def setUp(self):
+        """Run before each test."""
+        pass
+
+    def tearDown(self):
+        """Run after each test."""
+        pass
+
+    def test_resetSnappingIndex(self):
+        ms = QgsMapSettings()
+        ms.setOutputSize(QSize(100, 100))
+        ms.setExtent(QgsRectangle(0, 0, 1, 1))
+        self.assertTrue(ms.hasValidSettings())
+
+        u = QgsSnappingUtils()
+        u.setMapSettings(ms)
+        u.setSnapToMapMode(QgsSnappingUtils.SnapAdvanced)
+        layers = [QgsSnappingUtils.LayerConfig(self.pointsLayer, QgsPointLocator.Vertex, 20, QgsTolerance.Pixels)]
+        u.setLayers(layers)
+
+        m = u.snapToMap(QPoint(95, 100))
+        self.assertTrue(m.isValid())
+        self.assertTrue(m.hasVertex())
+        self.assertEqual(m.point(), QgsPoint(1, 0))
+
+        f = QgsFeature(self.linesLayer.fields())
+        f.setFeatureId(1)
+        geom = QgsGeometry.fromWkt("LINESTRING(0 0,1 1)")
+        f.setGeometry(geom)
+        self.linesLayer.startEditing()
+        self.linesLayer.addFeatures([f])
+        self.linesLayer.commitChanges()
+
+        l1 = len([f for f in self.pointsLayer.getFeatures()])
+        self.assertEqual(l1, 4)
+        m = u.snapToMap(QPoint(95, 0))
+        # snapping not updated
+        self.assertEqual(m.isValid(), False)
+
+        # set side effect layers
+        u.setSideEffectLayers([self.linesLayer])
+        # add another line
+        f = QgsFeature(self.linesLayer.fields())
+        f.setFeatureId(2)
+        geom = QgsGeometry.fromWkt("LINESTRING(0 0,0.5 0.5)")
+        f.setGeometry(geom)
+        self.linesLayer.startEditing()
+        self.linesLayer.addFeatures([f])
+        self.linesLayer.commitChanges()
+
+        m = u.snapToMap(QPoint(45, 50))
+        self.assertTrue(m.isValid())
+        self.assertTrue(m.hasVertex())
+        self.assertEqual(m.point(), QgsPoint(0.5, 0.5))
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
When using snapping options with layers that have triggers in a db that creates or modify geometries in other layers, qgis is not notified of such changes and the snapping "cache" is not cleared. It gives very strange results where the snapping can't see new geometries or resolve to geometries that are not there anymore.

This patch allows the user to declare some layers as having "side effects". Any modification to these layers will reset all the snapping cache.

I am still wondering if this has to be a new option and exposed to the user. The alternative would be to always reset snapping cache whenever a geometry is changed on any layers. There might be slight performance issues, but only when a new geometry is added or modified, which is probably acceptable. Any opinion ?
