### PR TITLE
Add shorthands to get features by fid, fids, rectangle and expression

### DIFF
--- a/python/core/qgsvectorlayer.sip
+++ b/python/core/qgsvectorlayer.sip
@@ -614,6 +614,22 @@ class QgsVectorLayer : QgsMapLayer
      */
     QgsFeatureIterator getFeatures( const QgsFeatureRequest& request = QgsFeatureRequest() );
 
+    /**
+     * Query the provider for features matching a given expression.
+     */
+    QgsFeatureIterator getFeatures( const QString& expression );
+
+    /**
+     * Query the provider for the feature with the given id.
+     * If there is no such feature, the returned feature will be invalid.
+     */
+    QgsFeature getFeature( QgsFeatureId fid );
+
+    /**
+     * Query the provider for the features with the given ids.
+     */
+    QgsFeatureIterator getFeatures( QgsFeatureIds fids );
+
     /** Adds a feature
         @param f feature to add
         @param alsoUpdateExtent If True, will also go to the effort of e.g. updating the extents.

--- a/python/core/qgsvectorlayer.sip
+++ b/python/core/qgsvectorlayer.sip
@@ -615,20 +615,25 @@ class QgsVectorLayer : QgsMapLayer
     QgsFeatureIterator getFeatures( const QgsFeatureRequest& request = QgsFeatureRequest() );
 
     /**
-     * Query the provider for features matching a given expression.
+     * Query the layer for features matching a given expression.
      */
     QgsFeatureIterator getFeatures( const QString& expression );
 
     /**
-     * Query the provider for the feature with the given id.
+     * Query the layer for the feature with the given id.
      * If there is no such feature, the returned feature will be invalid.
      */
     QgsFeature getFeature( QgsFeatureId fid );
 
     /**
-     * Query the provider for the features with the given ids.
+     * Query the layer for the features with the given ids.
      */
     QgsFeatureIterator getFeatures( QgsFeatureIds fids );
+
+    /**
+     * Query the layer for the features which intersect the specified rectangle.
+     */
+    QgsFeatureIterator getFeatures( const QgsRectangle& rectangle );
 
     /** Adds a feature
         @param f feature to add

--- a/python/core/qgsvectorlayercache.sip
+++ b/python/core/qgsvectorlayercache.sip
@@ -90,6 +90,27 @@ class QgsVectorLayerCache : QObject
     QgsFeatureIterator getFeatures( const QgsFeatureRequest& featureRequest = QgsFeatureRequest() );
 
     /**
+     * Query the layer for features matching a given expression.
+     */
+    QgsFeatureIterator getFeatures( const QString& expression );
+
+    /**
+     * Query the layer for the feature with the given id.
+     * If there is no such feature, the returned feature will be invalid.
+     */
+    QgsFeature getFeature( QgsFeatureId fid );
+
+    /**
+     * Query the layer for the features with the given ids.
+     */
+    QgsFeatureIterator getFeatures( QgsFeatureIds fids );
+
+    /**
+     * Query the layer for the features which intersect the specified rectangle.
+     */
+    QgsFeatureIterator getFeatures( const QgsRectangle& rectangle );
+
+    /**
      * Check if a certain feature id is cached.
      * @param  fid The feature id to look for
      * @return True if this id is in the cache

--- a/src/core/qgsfeaturerequest.cpp
+++ b/src/core/qgsfeaturerequest.cpp
@@ -40,6 +40,16 @@ QgsFeatureRequest::QgsFeatureRequest( QgsFeatureId fid )
 {
 }
 
+QgsFeatureRequest::QgsFeatureRequest( QgsFeatureIds fids )
+    : mFilter( FilterFids )
+    , mFilterFids( fids )
+    , mFilterExpression( nullptr )
+    , mFlags( nullptr )
+    , mLimit( -1 )
+{
+
+}
+
 QgsFeatureRequest::QgsFeatureRequest( const QgsRectangle& rect )
     : mFilter( FilterRect )
     , mFilterRect( rect )

--- a/src/core/qgsfeaturerequest.h
+++ b/src/core/qgsfeaturerequest.h
@@ -227,6 +227,8 @@ class CORE_EXPORT QgsFeatureRequest
     QgsFeatureRequest();
     //! construct a request with feature ID filter
     explicit QgsFeatureRequest( QgsFeatureId fid );
+    //! construct a request with feature ID filter
+    explicit QgsFeatureRequest( QgsFeatureIds fids );
     //! construct a request with rectangle filter
     explicit QgsFeatureRequest( const QgsRectangle& rect );
     //! construct a request with a filter expression

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -1109,6 +1109,23 @@ QgsFeatureIterator QgsVectorLayer::getFeatures( const QgsFeatureRequest& request
   return QgsFeatureIterator( new QgsVectorLayerFeatureIterator( new QgsVectorLayerFeatureSource( this ), true, request ) );
 }
 
+QgsFeatureIterator QgsVectorLayer::getFeatures( const QString& expression )
+{
+  return getFeatures( QgsFeatureRequest( expression ) );
+}
+
+QgsFeature QgsVectorLayer::getFeature( QgsFeatureId fid )
+{
+  QgsFeature feature;
+  getFeatures( QgsFeatureRequest( fid ) ).nextFeature( feature );
+  return feature;
+}
+
+QgsFeatureIterator QgsVectorLayer::getFeatures( QgsFeatureIds fids )
+{
+  return getFeatures( QgsFeatureRequest( fids ) );
+}
+
 
 bool QgsVectorLayer::addFeature( QgsFeature& feature, bool alsoUpdateExtent )
 {

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -1109,24 +1109,6 @@ QgsFeatureIterator QgsVectorLayer::getFeatures( const QgsFeatureRequest& request
   return QgsFeatureIterator( new QgsVectorLayerFeatureIterator( new QgsVectorLayerFeatureSource( this ), true, request ) );
 }
 
-QgsFeatureIterator QgsVectorLayer::getFeatures( const QString& expression )
-{
-  return getFeatures( QgsFeatureRequest( expression ) );
-}
-
-QgsFeature QgsVectorLayer::getFeature( QgsFeatureId fid )
-{
-  QgsFeature feature;
-  getFeatures( QgsFeatureRequest( fid ) ).nextFeature( feature );
-  return feature;
-}
-
-QgsFeatureIterator QgsVectorLayer::getFeatures( QgsFeatureIds fids )
-{
-  return getFeatures( QgsFeatureRequest( fids ) );
-}
-
-
 bool QgsVectorLayer::addFeature( QgsFeature& feature, bool alsoUpdateExtent )
 {
   Q_UNUSED( alsoUpdateExtent ); // TODO[MD]

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -985,6 +985,22 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
      */
     QgsFeatureIterator getFeatures( const QgsFeatureRequest& request = QgsFeatureRequest() );
 
+    /**
+     * Query the provider for features matching a given expression.
+     */
+    QgsFeatureIterator getFeatures( const QString& expression );
+
+    /**
+     * Query the provider for the feature with the given id.
+     * If there is no such feature, the returned feature will be invalid.
+     */
+    QgsFeature getFeature( QgsFeatureId fid );
+
+    /**
+     * Query the provider for the features with the given ids.
+     */
+    QgsFeatureIterator getFeatures( QgsFeatureIds fids );
+
     /** Adds a feature
         @param feature feature to add
         @param alsoUpdateExtent If True, will also go to the effort of e.g. updating the extents.

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -986,20 +986,39 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer
     QgsFeatureIterator getFeatures( const QgsFeatureRequest& request = QgsFeatureRequest() );
 
     /**
-     * Query the provider for features matching a given expression.
+     * Query the layer for features matching a given expression.
      */
-    QgsFeatureIterator getFeatures( const QString& expression );
+    inline QgsFeatureIterator getFeatures( const QString& expression )
+    {
+      return getFeatures( QgsFeatureRequest( expression ) );
+    }
 
     /**
-     * Query the provider for the feature with the given id.
+     * Query the layer for the feature with the given id.
      * If there is no such feature, the returned feature will be invalid.
      */
-    QgsFeature getFeature( QgsFeatureId fid );
+    inline QgsFeature getFeature( QgsFeatureId fid )
+    {
+      QgsFeature feature;
+      getFeatures( QgsFeatureRequest( fid ) ).nextFeature( feature );
+      return feature;
+    }
 
     /**
-     * Query the provider for the features with the given ids.
+     * Query the layer for the features with the given ids.
      */
-    QgsFeatureIterator getFeatures( QgsFeatureIds fids );
+    inline QgsFeatureIterator getFeatures( const QgsFeatureIds& fids )
+    {
+      return getFeatures( QgsFeatureRequest( fids ) );
+    }
+
+    /**
+     * Query the layer for the features which intersect the specified rectangle.
+     */
+    inline QgsFeatureIterator getFeatures( const QgsRectangle& rectangle )
+    {
+      return getFeatures( QgsFeatureRequest( rectangle ) );
+    }
 
     /** Adds a feature
         @param feature feature to add

--- a/src/core/qgsvectorlayercache.h
+++ b/src/core/qgsvectorlayercache.h
@@ -156,6 +156,41 @@ class CORE_EXPORT QgsVectorLayerCache : public QObject
     QgsFeatureIterator getFeatures( const QgsFeatureRequest& featureRequest = QgsFeatureRequest() );
 
     /**
+     * Query the layer for features matching a given expression.
+     */
+    inline QgsFeatureIterator getFeatures( const QString& expression )
+    {
+      return getFeatures( QgsFeatureRequest( expression ) );
+    }
+
+    /**
+     * Query the layer for the feature with the given id.
+     * If there is no such feature, the returned feature will be invalid.
+     */
+    inline QgsFeature getFeature( QgsFeatureId fid )
+    {
+      QgsFeature feature;
+      getFeatures( QgsFeatureRequest( fid ) ).nextFeature( feature );
+      return feature;
+    }
+
+    /**
+     * Query the layer for the features with the given ids.
+     */
+    inline QgsFeatureIterator getFeatures( const QgsFeatureIds& fids )
+    {
+      return getFeatures( QgsFeatureRequest( fids ) );
+    }
+
+    /**
+     * Query the layer for the features which intersect the specified rectangle.
+     */
+    inline QgsFeatureIterator getFeatures( const QgsRectangle& rectangle )
+    {
+      return getFeatures( QgsFeatureRequest( rectangle ) );
+    }
+
+    /**
      * Check if a certain feature id is cached.
      * @param  fid The feature id to look for
      * @return True if this id is in the cache


### PR DESCRIPTION
Adds new methods overloads to QgsVectorLayer

```
  getFeatures( expression )
  getFeatures( ids )
  getFeature( id )
```

These three methods to query features are by far the most used ones
and with this patch it is much easier to write and read code.
