### PR TITLE
[composer] fix html label stylesheet's margin (fixes #15290)

### DIFF
--- a/src/core/composer/qgscomposerlabel.cpp
+++ b/src/core/composer/qgscomposerlabel.cpp
@@ -644,7 +644,7 @@ void QgsComposerLabel::itemShiftAdjustSize( double newWidth, double newHeight, d
 QUrl QgsComposerLabel::createStylesheetUrl() const
 {
   QString stylesheet;
-  stylesheet += QString( "body { margin: %1 %2;" ).arg( qMax( mMarginX * mHtmlUnitsToMM, 0.0 ) ).arg( qMax( mMarginY * mHtmlUnitsToMM, 0.0 ) );
+  stylesheet += QString( "body { margin: %1 %2;" ).arg( qMax( mMarginY * mHtmlUnitsToMM, 0.0 ) ).arg( qMax( mMarginX * mHtmlUnitsToMM, 0.0 ) );
   stylesheet += QgsFontUtils::asCSS( mFont, 0.352778 * mHtmlUnitsToMM );
   stylesheet += QString( "color: %1;" ).arg( mFontColor.name() );
   stylesheet += QString( "text-align: %1; }" ).arg( mHAlignment == Qt::AlignLeft ? "left" : mHAlignment == Qt::AlignRight ? "right" : "center" );


### PR DESCRIPTION
Margins for html-enabled label items are inverted due to a small issue in the stylesheet creation process whereas mMarginX and mMarginY are served in the wrong order.

@nyalldawson , this affects the newly-released 2.16.0 as well as master. It'll need to be backported to the 2.16 branch (as well as master_2 ?)
