### PR TITLE
Processing:warp - only add -te_srs if GDAL>=2.0

### DIFF
--- a/python/plugins/processing/algs/gdal/warp.py
+++ b/python/plugins/processing/algs/gdal/warp.py
@@ -176,9 +176,10 @@ class warp(GdalAlgorithm):
         if rastext:
             arguments.extend(rastext)
 
-        if rastext and len(rastext_crs) > 0:
-            arguments.append('-te_srs')
-            arguments.append(rastext_crs)
+        if GdalUtils.version() > 2000000:
+            if rastext and len(rastext_crs) > 0:
+                arguments.append('-te_srs')
+                arguments.append(rastext_crs)
 
         if extra and len(extra) > 0:
             arguments.append(extra)


### PR DESCRIPTION
Fixes error with Processing:warp on > 2.14 with GDAL < 2.0:

```
Uncaught error while executing algorithm 
Traceback (most recent call last): 
  File "/usr/share/qgis/python/plugins/processing/core/GeoAlgorithm.py", line 203, in execute 
    self.processAlgorithm(progress) 
  File "/usr/share/qgis/python/plugins/processing/algs/gdal/GdalAlgorithm.py", line 51, in processAlgorithm 
    commands = self.getConsoleCommands() 
  File "/usr/share/qgis/python/plugins/processing/algs/gdal/warp.py", line 179, in getConsoleCommands 
    if rastext and len(rastext_crs) > 0: 
TypeError: object of type 'NoneType' has no len() 
```
