### PR TITLE
Curved labels improved

### DIFF
--- a/src/core/gps/gmath.c
+++ b/src/core/gps/gmath.c
@@ -31,6 +31,8 @@
 #include <math.h>
 #include <float.h>
 
+double remainder(double X, double Y) { return fmod(X, Y); }
+
 /**
  * \fn nmea_degree2radian
  * \brief Convert degree to radian

--- a/src/core/pal/feature.cpp
+++ b/src/core/pal/feature.cpp
@@ -879,6 +879,13 @@ LabelPosition* FeaturePart::curvedPlacementAtOffset( PointSet* path_positions, d
       delete slp;
       return nullptr;
     }
+    // Shift the character downwards since the draw position is specified at the baseline
+    // and we're calculating the mean line here
+    double dist = 0.9 * li->label_height / 2;
+    if (orientation < 0)
+        dist = -dist;
+    start_x += dist * cos(angle + M_PI_2);
+    start_y -= dist * sin(angle + M_PI_2);
 
     double render_angle = angle;
 
@@ -1042,11 +1049,11 @@ int FeaturePart::createCurvedCandidatesAlongLine( QList< LabelPosition* >& lPos,
       double angle_avg = atan2( sin_avg / li->char_num, cos_avg / li->char_num );
       // displacement
       if (( !reversed && ( flags & FLAG_ABOVE_LINE ) ) || ( reversed && ( flags & FLAG_BELOW_LINE ) ) )
-        positions.append( _createCurvedCandidate( slp, angle_avg, mLF->distLabel() ) );
+        positions.append( _createCurvedCandidate( slp, angle_avg, mLF->distLabel() + li->label_height / 2 ) );
       if ( flags & FLAG_ON_LINE )
-        positions.append( _createCurvedCandidate( slp, angle_avg, -li->label_height / 2 ) );
+        positions.append( _createCurvedCandidate( slp, angle_avg, 0 ) );
       if (( !reversed && ( flags & FLAG_BELOW_LINE ) ) || ( reversed && ( flags & FLAG_ABOVE_LINE ) ) )
-        positions.append( _createCurvedCandidate( slp, angle_avg, -li->label_height - mLF->distLabel() ) );
+        positions.append( _createCurvedCandidate( slp, angle_avg, -li->label_height / 2 - mLF->distLabel() ) );
 
       // delete original candidate
       delete slp;

--- a/src/core/pal/feature.cpp
+++ b/src/core/pal/feature.cpp
@@ -879,13 +879,6 @@ LabelPosition* FeaturePart::curvedPlacementAtOffset( PointSet* path_positions, d
       delete slp;
       return nullptr;
     }
-    // Shift the character downwards since the draw position is specified at the baseline
-    // and we're calculating the mean line here
-    double dist = 0.9 * li->label_height / 2;
-    if (orientation < 0)
-        dist = -dist;
-    start_x += dist * cos(angle + M_PI_2);
-    start_y -= dist * sin(angle + M_PI_2);
 
     double render_angle = angle;
 
@@ -1049,11 +1042,11 @@ int FeaturePart::createCurvedCandidatesAlongLine( QList< LabelPosition* >& lPos,
       double angle_avg = atan2( sin_avg / li->char_num, cos_avg / li->char_num );
       // displacement
       if (( !reversed && ( flags & FLAG_ABOVE_LINE ) ) || ( reversed && ( flags & FLAG_BELOW_LINE ) ) )
-        positions.append( _createCurvedCandidate( slp, angle_avg, mLF->distLabel() + li->label_height / 2 ) );
+        positions.append( _createCurvedCandidate( slp, angle_avg, mLF->distLabel() ) );
       if ( flags & FLAG_ON_LINE )
-        positions.append( _createCurvedCandidate( slp, angle_avg, 0 ) );
+        positions.append( _createCurvedCandidate( slp, angle_avg, -li->label_height / 2 ) );
       if (( !reversed && ( flags & FLAG_BELOW_LINE ) ) || ( reversed && ( flags & FLAG_ABOVE_LINE ) ) )
-        positions.append( _createCurvedCandidate( slp, angle_avg, -li->label_height / 2 - mLF->distLabel() ) );
+        positions.append( _createCurvedCandidate( slp, angle_avg, -li->label_height - mLF->distLabel() ) );
 
       // delete original candidate
       delete slp;

--- a/src/core/qgspallabeling.cpp
+++ b/src/core/qgspallabeling.cpp
@@ -2517,7 +2517,8 @@ void QgsPalLayerSettings::registerFeature( QgsFeature& f, QgsRenderContext &cont
   }
 
   GEOSGeometry* geos_geom_clone;
-  if ( GEOSGeomTypeId_r( QgsGeometry::getGEOSHandler(), geos_geom ) == GEOS_POLYGON && repeatDistance > 0 && placement == Line )
+  GEOSGeomTypes geomType = (GEOSGeomTypes) GEOSGeomTypeId_r( QgsGeometry::getGEOSHandler(), geos_geom );
+  if ( (geomType == GEOS_POLYGON || geomType == GEOS_MULTIPOLYGON) && repeatDistance > 0 && placement == Line )
   {
     geos_geom_clone = GEOSBoundary_r( QgsGeometry::getGEOSHandler(), geos_geom );
   }


### PR DESCRIPTION
Curved labels are now effectively rotated at the character mean line in stead of the base line. This means there is less overlap if the label is angled upwards and less extra space if the label is angled downwards.
