### PR TITLE
[processing] Fix add script from file.

### DIFF
--- a/python/plugins/processing/script/AddScriptFromFileAction.py
+++ b/python/plugins/processing/script/AddScriptFromFileAction.py
@@ -65,7 +65,7 @@ class AddScriptFromFileAction(ToolboxAction):
                                     self.tr('Error reading script', 'AddScriptFromFileAction'),
                                     self.tr('The selected file does not contain a valid script', 'AddScriptFromFileAction'))
                 return
-            destFilename = os.path.join(ScriptUtils.scriptsFolder(), os.path.basename(filename))
+            destFilename = os.path.join(ScriptUtils.defaultScriptsFolder(), os.path.basename(filename))
             with open(destFilename, 'w') as f:
                 f.write(script.script)
             algList.reloadProvider('script')


### PR DESCRIPTION
In QGIS 2.16 and master, adding script from file will throw this error:
![processing_bug](https://cloud.githubusercontent.com/assets/992519/16913302/b05382ba-4ce9-11e6-96e1-3aa9c3c6da42.png)

There was changes lately that it supports multiple folders. I guess this needs to also be cherrypicked to 2.16?

cc @volaya @alexbruy 
