### PR TITLE
[Processing] Load only providers from processing module when initialising Processing class

### DIFF
--- a/python/plugins/processing/core/Processing.py
+++ b/python/plugins/processing/core/Processing.py
@@ -29,6 +29,7 @@ __revision__ = '$Format:%H$'
 import sys
 import os
 import traceback
+import inspect
 
 from qgis.PyQt.QtCore import Qt, QCoreApplication, QObject, pyqtSignal
 from qgis.PyQt.QtWidgets import QApplication
@@ -144,8 +145,10 @@ class Processing:
         if "model" in [p.getName() for p in Processing.providers]:
             return
         # Add the basic providers
+        processingModuleMembers = [cls for name, cls in inspect.getmembers(sys.modules[__name__])]
         for c in AlgorithmProvider.__subclasses__():
-            Processing.addProvider(c())
+            if c in processingModuleMembers:
+                Processing.addProvider(c())
         # And initialize
         ProcessingConfig.initialize()
         ProcessingConfig.readSettings()


### PR DESCRIPTION
Currently, Processing.initialize() loads providers coming from additional plugins together with the basic ones. This might not be always desirable and also it forces the additional providers to have init function with no parameters. 

This affects 2.16 branch as well.
