### PR TITLE
Data dependency between layers + snapping fix

### DIFF
--- a/ci/travis/linux/qt5/blacklist.txt
+++ b/ci/travis/linux/qt5/blacklist.txt
@@ -9,6 +9,7 @@ PyQgsSipCoverage
 PyQgsSpatialiteProvider
 PyQgsVirtualLayerDefinition
 PyQgsVirtualLayerProvider
+PyQgsLayerDependencies
 qgis_composermapgridtest
 qgis_composerutils
 ProcessingGrass7AlgorithmsImageryTest

--- a/images/images.qrc
+++ b/images/images.qrc
@@ -665,6 +665,7 @@
         <file>themes/default/mActionAddAfsLayer.svg</file>
         <file>themes/default/mIconFormSelect.svg</file>
         <file>themes/default/mActionMultiEdit.svg</file>
+        <file>themes/default/dependencies.svg</file>
     </qresource>
     <qresource prefix="/images/tips">
         <file alias="symbol_levels.png">qgis_tips/symbol_levels.png</file>

--- a/images/themes/default/dependencies.svg
+++ b/images/themes/default/dependencies.svg
@@ -1,0 +1,151 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<!-- Created with Inkscape (http://www.inkscape.org/) -->
+
+<svg
+   xmlns:dc="http://purl.org/dc/elements/1.1/"
+   xmlns:cc="http://creativecommons.org/ns#"
+   xmlns:rdf="http://www.w3.org/1999/02/22-rdf-syntax-ns#"
+   xmlns:svg="http://www.w3.org/2000/svg"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:xlink="http://www.w3.org/1999/xlink"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   width="16"
+   height="16"
+   viewBox="0 0 16 16"
+   id="svg2"
+   version="1.1"
+   inkscape:version="0.91 r13725"
+   sodipodi:docname="sync_views.svg">
+  <defs
+     id="defs4">
+    <linearGradient
+       inkscape:collect="always"
+       id="linearGradient4158">
+      <stop
+         style="stop-color:#0000ff;stop-opacity:1"
+         offset="0"
+         id="stop4160" />
+      <stop
+         style="stop-color:#0000a9;stop-opacity:1"
+         offset="1"
+         id="stop4162" />
+    </linearGradient>
+    <marker
+       inkscape:stockid="Arrow2Mend"
+       orient="auto"
+       refY="0.0"
+       refX="0.0"
+       id="Arrow2Mend"
+       style="overflow:visible;"
+       inkscape:isstock="true">
+      <path
+         id="path4171"
+         style="fill-rule:evenodd;stroke-width:0.625;stroke-linejoin:round;stroke:#000000;stroke-opacity:1;fill:#000000;fill-opacity:1"
+         d="M 8.7185878,4.0337352 L -2.2072895,0.016013256 L 8.7185884,-4.0017078 C 6.9730900,-1.6296469 6.9831476,1.6157441 8.7185878,4.0337352 z "
+         transform="scale(0.6) rotate(180) translate(0,0)" />
+    </marker>
+    <marker
+       inkscape:stockid="Arrow2Mend"
+       orient="auto"
+       refY="0"
+       refX="0"
+       id="Arrow2Mend-8"
+       style="overflow:visible"
+       inkscape:isstock="true">
+      <path
+         inkscape:connector-curvature="0"
+         id="path4171-2"
+         style="fill:#000000;fill-opacity:1;fill-rule:evenodd;stroke:#000000;stroke-width:0.625;stroke-linejoin:round;stroke-opacity:1"
+         d="M 8.7185878,4.0337352 -2.2072895,0.01601326 8.7185884,-4.0017078 c -1.7454984,2.3720609 -1.7354408,5.6174519 -6e-7,8.035443 z"
+         transform="scale(-0.6,-0.6)" />
+    </marker>
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4158"
+       id="radialGradient4178"
+       cx="7.9999766"
+       cy="1040.8622"
+       fx="7.9999766"
+       fy="1040.8622"
+       r="6.9999766"
+       gradientTransform="matrix(1,0,0,0.49999621,0,520.43504)"
+       gradientUnits="userSpaceOnUse" />
+    <radialGradient
+       inkscape:collect="always"
+       xlink:href="#linearGradient4158"
+       id="radialGradient4178-3"
+       cx="7.9999766"
+       cy="1040.8622"
+       fx="7.9999766"
+       fy="1040.8622"
+       r="6.9999766"
+       gradientTransform="matrix(-1,0,0,0.49999621,16,527.43502)"
+       gradientUnits="userSpaceOnUse" />
+  </defs>
+  <sodipodi:namedview
+     id="base"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageopacity="0.0"
+     inkscape:pageshadow="2"
+     inkscape:zoom="18.5"
+     inkscape:cx="0.59568033"
+     inkscape:cy="10.721345"
+     inkscape:document-units="px"
+     inkscape:current-layer="layer1"
+     showgrid="true"
+     units="px"
+     inkscape:snap-bbox="true"
+     inkscape:bbox-paths="true"
+     inkscape:bbox-nodes="true"
+     inkscape:snap-bbox-edge-midpoints="true"
+     inkscape:snap-bbox-midpoints="true"
+     inkscape:object-paths="true"
+     inkscape:snap-intersection-paths="true"
+     inkscape:object-nodes="true"
+     inkscape:snap-smooth-nodes="true"
+     inkscape:window-width="1600"
+     inkscape:window-height="829"
+     inkscape:window-x="0"
+     inkscape:window-y="0"
+     inkscape:window-maximized="1">
+    <inkscape:grid
+       type="xygrid"
+       id="grid4136" />
+  </sodipodi:namedview>
+  <metadata
+     id="metadata7">
+    <rdf:RDF>
+      <cc:Work
+         rdf:about="">
+        <dc:format>image/svg+xml</dc:format>
+        <dc:type
+           rdf:resource="http://purl.org/dc/dcmitype/StillImage" />
+        <dc:title />
+      </cc:Work>
+    </rdf:RDF>
+  </metadata>
+  <g
+     inkscape:label="Layer 1"
+     inkscape:groupmode="layer"
+     id="layer1"
+     transform="translate(0,-1036.3622)">
+    <g
+       id="g4865">
+      <path
+         style="fill:url(#radialGradient4178);fill-opacity:1;fill-rule:evenodd;stroke:#0000a9;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 1.5,1040.8622 0,1 8,0 0,2 5,-3 -5,-3 0,2 -8,0 z"
+         id="path4156"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccc" />
+      <path
+         style="fill:url(#radialGradient4178-3);fill-opacity:1;fill-rule:evenodd;stroke:#0000a9;stroke-width:0.5;stroke-linecap:round;stroke-linejoin:round;stroke-miterlimit:4;stroke-dasharray:none;stroke-opacity:1"
+         d="m 14.5,1047.8622 0,1 -7.9999996,0 0,2 -5,-3 5,-3 0,2 7.9999996,0 z"
+         id="path4156-7"
+         inkscape:connector-curvature="0"
+         sodipodi:nodetypes="ccccccccc" />
+    </g>
+  </g>
+</svg>

--- a/python/core/core.sip
+++ b/python/core/core.sip
@@ -80,6 +80,7 @@
 %Include qgslogger.sip
 %Include qgsmaphittest.sip
 %Include qgsmaplayer.sip
+%Include qgsmaplayerdependency.sip
 %Include qgsmaplayerlegend.sip
 %Include qgsmaplayermodel.sip
 %Include qgsmaplayerproxymodel.sip

--- a/python/core/qgsmaplayer.sip
+++ b/python/core/qgsmaplayer.sip
@@ -678,7 +678,7 @@ class QgsMapLayer : QObject
 
     /**
      * Sets the list of layers that may modify data/geometries of this layer when modified.
-     * @see dataDependencies
+     * @see dependencies()
      *
      * @param layersIds IDs of the layers that this layer depends on
      * @returns false if a dependency cycle has been detected (the change dependency set is not changed in that case)
@@ -686,12 +686,21 @@ class QgsMapLayer : QObject
     virtual bool setDataDependencies( const QSet<QString>& layersIds );
 
     /**
-     * Gets the list of layers that may modify data/geometries of this layer when modified.
-     * @see setDataDependencies
+     * Sets the list of layers that may modify data/geometries of this layer when modified.
+     * @see dependencies()
      *
-     * @returns IDs of the layers that this layer depends on
+     * @param set of QgsMapLayerDependency. Only user-defined dependencies will be added
+     * @returns false if a dependency cycle has been detected (the change dependency set is not changed in that case)
      */
-    virtual QSet<QString> dataDependencies() const;
+    bool setDataDependencies( const QSet<QgsMapLayerDependency>& layers );
+
+    /**
+     * Gets the list of dependencies. This includes data dependencies set by the user (@see setDataDependencies)
+     * as well as dependencies given by the provider
+     *
+     * @returns a set of QgsMapLayerDependency
+     */
+    virtual QSet<QgsMapLayerDependency> dependencies() const;
 
   signals:
 
@@ -785,5 +794,5 @@ class QgsMapLayer : QObject
     void setError( const QgsError &error );
 
     //! Checks if new change dependency candidates introduce a cycle
-    bool hasDataDependencyCycle( const QSet<QString>& layersIds ) const;
+    bool hasDataDependencyCycle( const QSet<QgsMapLayerDependency>& layersIds ) const;
 };

--- a/python/core/qgsmaplayer.sip
+++ b/python/core/qgsmaplayer.sip
@@ -676,6 +676,23 @@ class QgsMapLayer : QObject
      */
     void emitStyleChanged();
 
+    /**
+     * Sets the list of layers that may modify data/geometries of this layer when modified.
+     * @see dataDependencies
+     *
+     * @param layersIds IDs of the layers that this layer depends on
+     * @returns false if a dependency cycle has been detected (the change dependency set is not changed in that case)
+     */
+    virtual bool setDataDependencies( const QSet<QString>& layersIds );
+
+    /**
+     * Gets the list of layers that may modify data/geometries of this layer when modified.
+     * @see setDataDependencies
+     *
+     * @returns IDs of the layers that this layer depends on
+     */
+    virtual QSet<QString> dataDependencies() const;
+
   signals:
 
     /** Emit a signal with status (e.g. to be caught by QgisApp and display a msg on status bar) */
@@ -766,4 +783,7 @@ class QgsMapLayer : QObject
     void appendError( const QgsErrorMessage &error );
     /** Set error message */
     void setError( const QgsError &error );
+
+    //! Checks if new change dependency candidates introduce a cycle
+    bool hasDataDependencyCycle( const QSet<QString>& layersIds ) const;
 };

--- a/python/core/qgsmaplayerdependency.sip
+++ b/python/core/qgsmaplayerdependency.sip
@@ -1,0 +1,36 @@
+class QgsMapLayerDependency
+{
+%TypeHeaderCode
+#include "qgsmaplayerdependency.h"
+%End
+ public:
+  //! Type of dependency
+  enum Type
+  {
+    PresenceDependency = 1, // The layer must be already present (in the registry) for this dependency to be resolved
+    DataDependency     = 2  // The layer may be invalidated by data changes on another layer
+  };
+
+  //! Origin of the dependency
+  enum Origin
+  {
+    FromProvider = 0,  // Dependency given by the provider, the user cannot change it
+    FromUser     = 1   // Dependency given by the user
+  };
+
+  //! Standard constructor
+  QgsMapLayerDependency( QString layerId, Type type = DataDependency, Origin origin = FromUser );
+
+  //! Return the dependency type
+  Type type() const;
+
+  //! Return the dependency origin
+  Origin origin() const;
+
+  //! Return the ID of the layer this dependency depends on
+  QString layerId() const;
+
+  bool operator==( const QgsMapLayerDependency& other ) const;
+};
+
+

--- a/python/core/qgsvectordataprovider.sip
+++ b/python/core/qgsvectordataprovider.sip
@@ -368,7 +368,7 @@ class QgsVectorDataProvider : QgsDataProvider
     /**
      * Get the list of layer ids on which this layer depends. This in particular determines the order of layer loading.
      */
-    virtual QSet<QString> layerDependencies() const;
+    virtual QSet<QgsMapLayerDependency> dependencies() const;
 
   signals:
     /** Signals an error in this provider */

--- a/python/core/qgsvectorlayer.sip
+++ b/python/core/qgsvectorlayer.sip
@@ -422,9 +422,29 @@ class QgsVectorLayer : QgsMapLayer
     const QList<QgsVectorJoinInfo> vectorJoins() const;
 
     /**
-     * Get the list of layer ids on which this layer depends. This in particular determines the order of layer loading.
+     * Gets the list of layer ids on which this layer depends, as returned by the provider.
+     * This in particular determines the order of layer loading.
      */
     virtual QSet<QString> layerDependencies() const;
+
+    /**
+     * Sets the list of layers that may modify data/geometries of this layer when modified.
+     * This is meant mainly to declare database triggers between layers.
+     * When one of these layers is modified (feature added/deleted or geometry changed),
+     * dataChanged() will be emitted, allowing users of this layer to refresh / update it.
+     *
+     * @param layersIds IDs of the layers that this layer depends on
+     * @returns false if a dependency cycle has been detected (the change dependency set is not changed in that case)
+     */
+    bool setDataDependencies( const QSet<QString>& layersIds );
+
+    /**
+     * Gets the list of layers that may modify data/geometries of this layer when modified.
+     * @see setDataDependencies
+     *
+     * @returns IDs of the layers that this layer depends on
+     */
+    QSet<QString> dataDependencies() const;
 
     /**
      * Add a new field which is calculated by the expression specified

--- a/python/core/qgsvectorlayer.sip
+++ b/python/core/qgsvectorlayer.sip
@@ -422,12 +422,6 @@ class QgsVectorLayer : QgsMapLayer
     const QList<QgsVectorJoinInfo> vectorJoins() const;
 
     /**
-     * Gets the list of layer ids on which this layer depends, as returned by the provider.
-     * This in particular determines the order of layer loading.
-     */
-    virtual QSet<QString> layerDependencies() const;
-
-    /**
      * Sets the list of layers that may modify data/geometries of this layer when modified.
      * This is meant mainly to declare database triggers between layers.
      * When one of these layers is modified (feature added/deleted or geometry changed),
@@ -439,12 +433,12 @@ class QgsVectorLayer : QgsMapLayer
     bool setDataDependencies( const QSet<QString>& layersIds );
 
     /**
-     * Gets the list of layers that may modify data/geometries of this layer when modified.
-     * @see setDataDependencies
+     * Gets the list of dependencies. This includes data dependencies set by the user (@see setDataDependencies)
+     * as well as dependencies given by the provider
      *
-     * @returns IDs of the layers that this layer depends on
+     * @returns a set of QgsMapLayerDependency
      */
-    QSet<QString> dataDependencies() const;
+    virtual QSet<QgsMapLayerDependency> dependencies() const;
 
     /**
      * Add a new field which is calculated by the expression specified

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -52,6 +52,7 @@
 #include "qgsdatasourceuri.h"
 #include "qgsrenderer.h"
 #include "qgsexpressioncontext.h"
+#include "layertree/qgslayertreelayer.h"
 
 #include <QMessageBox>
 #include <QDir>
@@ -291,6 +292,23 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
 
   QString title = QString( tr( "Layer Properties - %1" ) ).arg( mLayer->name() );
   restoreOptionsBaseUi( title );
+
+  mLayersDependenciesTreeGroup.reset( QgsProject::instance()->layerTreeRoot()->clone() );
+  QgsLayerTreeLayer* layer = mLayersDependenciesTreeGroup->findLayer( mLayer->id() );
+  layer->parent()->takeChild( layer );
+  mLayersDependenciesTreeModel.reset( new QgsLayerTreeModel( mLayersDependenciesTreeGroup.data() ) );
+  // use visibility as selection
+  mLayersDependenciesTreeModel->setFlag( QgsLayerTreeModel::AllowNodeChangeVisibility );
+
+  mLayersDependenciesTreeGroup->setVisible( Qt::Unchecked );
+
+  QSet<QString> dependencySources = mLayer->dataDependencies();
+  Q_FOREACH ( QgsLayerTreeLayer* layer, mLayersDependenciesTreeGroup->findLayers() )
+  {
+    layer->setVisible( dependencySources.contains( layer->layerId() ) ? Qt::Checked : Qt::Unchecked );
+  }
+
+  mLayersDependenciesTreeView->setModel( mLayersDependenciesTreeModel.data() );
 } // QgsVectorLayerProperties ctor
 
 
@@ -557,6 +575,18 @@ void QgsVectorLayerProperties::apply()
   //save variables
   QgsExpressionContextUtils::setLayerVariables( mLayer, mVariableEditor->variablesInActiveScope() );
   updateVariableEditor();
+
+  // save layer dependencies
+  QSet<QString> deps;
+  Q_FOREACH ( const QgsLayerTreeLayer* layer, mLayersDependenciesTreeGroup->findLayers() )
+  {
+    if ( layer->isVisible() )
+      deps << layer->layerId();
+  }
+  if ( ! mLayer->setDataDependencies( deps ) )
+  {
+    QMessageBox::warning( nullptr, tr( "Dependency cycle" ), tr( "This configuration introduces a cycle in data dependencies and will be ignored" ) );
+  }
 
   // update symbology
   emit refreshLegend( mLayer->id() );

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -302,7 +302,11 @@ QgsVectorLayerProperties::QgsVectorLayerProperties(
 
   mLayersDependenciesTreeGroup->setVisible( Qt::Unchecked );
 
-  QSet<QString> dependencySources = mLayer->dataDependencies();
+  QSet<QString> dependencySources;
+  Q_FOREACH ( const QgsMapLayerDependency& dep, mLayer->dependencies() )
+  {
+    dependencySources << dep.layerId();
+  }
   Q_FOREACH ( QgsLayerTreeLayer* layer, mLayersDependenciesTreeGroup->findLayers() )
   {
     layer->setVisible( dependencySources.contains( layer->layerId() ) ? Qt::Checked : Qt::Unchecked );

--- a/src/app/qgsvectorlayerproperties.h
+++ b/src/app/qgsvectorlayerproperties.h
@@ -25,6 +25,8 @@
 #include "qgscontexthelp.h"
 #include "qgsmaplayerstylemanager.h"
 #include "qgsvectorlayer.h"
+#include "layertree/qgslayertreemodel.h"
+#include "layertree/qgslayertreegroup.h"
 
 class QgsMapLayer;
 
@@ -192,6 +194,9 @@ class APP_EXPORT QgsVectorLayerProperties : public QgsOptionsDialogBase, private
     QgsExpressionContext mContext;
 
     QgsExpressionContext createExpressionContext() const override;
+
+    QScopedPointer<QgsLayerTreeGroup> mLayersDependenciesTreeGroup;
+    QScopedPointer<QgsLayerTreeModel> mLayersDependenciesTreeModel;
 
   private slots:
     void openPanel( QgsPanelWidget* panel );

--- a/src/core/qgslayerdefinition.cpp
+++ b/src/core/qgslayerdefinition.cpp
@@ -111,6 +111,22 @@ bool QgsLayerDefinition::loadLayerDefinition( QDomDocument doc, QgsLayerTreeGrou
         joinNode.toElement().setAttribute( "joinLayerId", newid );
       }
     }
+
+    // change IDs of dependencies
+    QDomNodeList dataDeps = doc.elementsByTagName( "dataDependencies" );
+    for ( int i = 0; i < dataDeps.size(); i++ )
+    {
+      QDomNodeList layers = dataDeps.at( i ).childNodes();
+      for ( int j = 0; j < layers.size(); j++ )
+      {
+        QDomElement elt = layers.at( j ).toElement();
+        if ( elt.attribute( "id" ) == oldid )
+        {
+          elt.setAttribute( "id", newid );
+        }
+      }
+    }
+
   }
 
   QDomElement layerTreeElem = doc.documentElement().firstChildElement( "layer-tree-group" );

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -698,6 +698,23 @@ class CORE_EXPORT QgsMapLayer : public QObject
      */
     void emitStyleChanged();
 
+    /**
+     * Sets the list of layers that may modify data/geometries of this layer when modified.
+     * @see dataDependencies
+     *
+     * @param layersIds IDs of the layers that this layer depends on
+     * @returns false if a dependency cycle has been detected (the change dependency set is not changed in that case)
+     */
+    virtual bool setDataDependencies( const QSet<QString>& layersIds );
+
+    /**
+     * Gets the list of layers that may modify data/geometries of this layer when modified.
+     * @see setDataDependencies
+     *
+     * @returns IDs of the layers that this layer depends on
+     */
+    virtual QSet<QString> dataDependencies() const;
+
   signals:
 
     /** Emit a signal with status (e.g. to be caught by QgisApp and display a msg on status bar) */
@@ -835,6 +852,12 @@ class CORE_EXPORT QgsMapLayer : public QObject
 
     /** \brief Error */
     QgsError mError;
+
+    //! List of layers that may modify this layer on modification
+    QSet<QString> mDataDependencies;
+
+    //! Checks whether a new set of data dependencies will introduce a cycle
+    bool hasDataDependencyCycle( const QSet<QString>& layersIds ) const;
 
   private:
     /**

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -32,6 +32,7 @@
 #include "qgsrectangle.h"
 #include "qgscoordinatereferencesystem.h"
 #include "qgsrendercontext.h"
+#include "qgsmaplayerdependency.h"
 
 class QgsMapLayerLegend;
 class QgsMapLayerRenderer;
@@ -700,7 +701,7 @@ class CORE_EXPORT QgsMapLayer : public QObject
 
     /**
      * Sets the list of layers that may modify data/geometries of this layer when modified.
-     * @see dataDependencies
+     * @see dependencies()
      *
      * @param layersIds IDs of the layers that this layer depends on
      * @returns false if a dependency cycle has been detected (the change dependency set is not changed in that case)
@@ -708,12 +709,21 @@ class CORE_EXPORT QgsMapLayer : public QObject
     virtual bool setDataDependencies( const QSet<QString>& layersIds );
 
     /**
-     * Gets the list of layers that may modify data/geometries of this layer when modified.
-     * @see setDataDependencies
+     * Sets the list of layers that may modify data/geometries of this layer when modified.
+     * @see dependencies()
      *
-     * @returns IDs of the layers that this layer depends on
+     * @param layers set of QgsMapLayerDependency. Only user-defined dependencies will be added
+     * @returns false if a dependency cycle has been detected (the change dependency set is not changed in that case)
      */
-    virtual QSet<QString> dataDependencies() const;
+    bool setDataDependencies( const QSet<QgsMapLayerDependency>& layers );
+
+    /**
+     * Gets the list of dependencies. This includes data dependencies set by the user (@see setDataDependencies)
+     * as well as dependencies given by the provider
+     *
+     * @returns a set of QgsMapLayerDependency
+     */
+    virtual QSet<QgsMapLayerDependency> dependencies() const;
 
   signals:
 
@@ -854,10 +864,10 @@ class CORE_EXPORT QgsMapLayer : public QObject
     QgsError mError;
 
     //! List of layers that may modify this layer on modification
-    QSet<QString> mDataDependencies;
+    QSet<QgsMapLayerDependency> mDataDependencies;
 
     //! Checks whether a new set of data dependencies will introduce a cycle
-    bool hasDataDependencyCycle( const QSet<QString>& layersIds ) const;
+    bool hasDataDependencyCycle( const QSet<QgsMapLayerDependency>& layers ) const;
 
   private:
     /**

--- a/src/core/qgsmaplayerdependency.h
+++ b/src/core/qgsmaplayerdependency.h
@@ -1,0 +1,85 @@
+
+/***************************************************************************
+                          qgsmaplayerdependency.h  -  description
+                             -------------------
+    begin                : September 2016
+    copyright            : (C) 2016 by Hugo Mercier
+    email                : hugo dot mercier at oslandia dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSMAPLAYERDEPENDENCY_H
+#define QGSMAPLAYERDEPENDENCY_H
+
+#include <QString>
+
+/** \ingroup core
+ * This class models dependencies with or between map layers.
+ * A dependency is defined by a layer ID, a type and an origin.
+ * The two combinations of type/origin that are currently supported are:
+ *  - PresenceDependency && FromProvider: virtual layers for instance which may depend on other layers already loaded to work
+ *  - DataDependency && FromUser: dependencies given by the user, mainly to represent database triggers
+ *
+ * @note added in QGIS 3.0
+ */
+class CORE_EXPORT QgsMapLayerDependency
+{
+  public:
+    //! Type of dependency
+    enum Type
+    {
+      PresenceDependency = 1, //< The layer must be already present (in the registry) for this dependency to be resolved
+      DataDependency     = 2  //< The layer may be invalidated by data changes on another layer
+    };
+
+    //! Origin of the dependency
+    enum Origin
+    {
+      FromProvider = 0,  //< Dependency given by the provider, the user cannot change it
+      FromUser     = 1   //< Dependency given by the user
+    };
+
+    //! Standard constructor
+    QgsMapLayerDependency( QString layerId, Type type = DataDependency, Origin origin = FromUser ) :
+        mType( type ),
+        mOrigin( origin ),
+        mLayerId( layerId )
+    {}
+
+    //! Return the dependency type
+    Type type() const { return mType; }
+
+    //! Return the dependency origin
+    Origin origin() const { return mOrigin; }
+
+    //! Return the ID of the layer this dependency depends on
+    QString layerId() const { return mLayerId; }
+
+    //! Comparison operator
+    bool operator==( const QgsMapLayerDependency& other ) const
+    {
+      return layerId() == other.layerId() && origin() == other.origin() && type() == other.type();
+    }
+  private:
+    Type mType;
+    Origin mOrigin;
+    QString mLayerId;
+};
+
+/**
+ * global qHash function for QgsMapLayerDependency, so that it can be used in a QSet
+ */
+inline uint qHash( const QgsMapLayerDependency& dep )
+{
+  return qHash( dep.layerId() ) + dep.origin() + dep.type();
+}
+
+#endif

--- a/src/core/qgspointlocator.cpp
+++ b/src/core/qgspointlocator.cpp
@@ -629,6 +629,7 @@ QgsPointLocator::QgsPointLocator( QgsVectorLayer* layer, const QgsCoordinateRefe
   connect( mLayer, SIGNAL( featureAdded( QgsFeatureId ) ), this, SLOT( onFeatureAdded( QgsFeatureId ) ) );
   connect( mLayer, SIGNAL( featureDeleted( QgsFeatureId ) ), this, SLOT( onFeatureDeleted( QgsFeatureId ) ) );
   connect( mLayer, SIGNAL( geometryChanged( QgsFeatureId, const QgsGeometry& ) ), this, SLOT( onGeometryChanged( QgsFeatureId, const QgsGeometry& ) ) );
+  connect( mLayer, SIGNAL( dataChanged() ), this, SLOT( destroyIndex() ) );
 }
 
 

--- a/src/core/qgspointlocator.h
+++ b/src/core/qgspointlocator.h
@@ -207,8 +207,8 @@ class CORE_EXPORT QgsPointLocator : public QObject
 
   protected:
     bool rebuildIndex( int maxFeaturesToIndex = -1 );
+  protected slots:
     void destroyIndex();
-
   private slots:
     void onFeatureAdded( QgsFeatureId fid );
     void onFeatureDeleted( QgsFeatureId fid );

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -889,6 +889,12 @@ bool QgsProject::read()
   mVisibilityPresetCollection.reset( new QgsMapThemeCollection() );
   mVisibilityPresetCollection->readXml( *doc );
 
+  // reassign change dependencies now that all layers are loaded
+  QMap<QString, QgsMapLayer*> existingMaps = QgsMapLayerRegistry::instance()->mapLayers();
+  for ( QMap<QString, QgsMapLayer*>::iterator it = existingMaps.begin(); it != existingMaps.end(); it++ )
+  {
+    it.value()->setDataDependencies( it.value()->dataDependencies() );
+  }
 
   // read the project: used by map canvas and legend
   emit readProject( *doc );
@@ -957,6 +963,8 @@ QgsExpressionContext QgsProject::createExpressionContext() const
 
 void QgsProject::onMapLayersAdded( const QList<QgsMapLayer*>& layers )
 {
+  QMap<QString, QgsMapLayer*> existingMaps = QgsMapLayerRegistry::instance()->mapLayers();
+
   Q_FOREACH ( QgsMapLayer* layer, layers )
   {
     QgsVectorLayer* vlayer = qobject_cast<QgsVectorLayer*>( layer );
@@ -985,6 +993,17 @@ void QgsProject::onMapLayersAdded( const QList<QgsMapLayer*>& layers )
     }
 
     connect( layer, SIGNAL( configChanged() ), this, SLOT( setDirty() ) );
+
+    // check if we have to update connections for layers with dependencies
+    for ( QMap<QString, QgsMapLayer*>::iterator it = existingMaps.begin(); it != existingMaps.end(); it++ )
+    {
+      QSet<QString> deps = it.value()->dataDependencies();
+      if ( deps.contains( layer->id() ) )
+      {
+        // reconnect to change signals
+        it.value()->setDataDependencies( deps );
+      }
+    }
   }
 }
 

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -893,7 +893,7 @@ bool QgsProject::read()
   QMap<QString, QgsMapLayer*> existingMaps = QgsMapLayerRegistry::instance()->mapLayers();
   for ( QMap<QString, QgsMapLayer*>::iterator it = existingMaps.begin(); it != existingMaps.end(); it++ )
   {
-    it.value()->setDataDependencies( it.value()->dataDependencies() );
+    it.value()->setDataDependencies( it.value()->dependencies() );
   }
 
   // read the project: used by map canvas and legend
@@ -997,7 +997,7 @@ void QgsProject::onMapLayersAdded( const QList<QgsMapLayer*>& layers )
     // check if we have to update connections for layers with dependencies
     for ( QMap<QString, QgsMapLayer*>::iterator it = existingMaps.begin(); it != existingMaps.end(); it++ )
     {
-      QSet<QString> deps = it.value()->dataDependencies();
+      QSet<QgsMapLayerDependency> deps = it.value()->dependencies();
       if ( deps.contains( layer->id() ) )
       {
         // reconnect to change signals

--- a/src/core/qgsvectordataprovider.cpp
+++ b/src/core/qgsvectordataprovider.cpp
@@ -613,9 +613,9 @@ void QgsVectorDataProvider::pushError( const QString& msg )
   emit raiseError( msg );
 }
 
-QSet<QString> QgsVectorDataProvider::layerDependencies() const
+QSet<QgsMapLayerDependency> QgsVectorDataProvider::dependencies() const
 {
-  return QSet<QString>();
+  return QSet<QgsMapLayerDependency>();
 }
 
 QgsGeometry* QgsVectorDataProvider::convertToProviderType( const QgsGeometry& geom ) const

--- a/src/core/qgsvectordataprovider.h
+++ b/src/core/qgsvectordataprovider.h
@@ -27,6 +27,7 @@ class QTextCodec;
 #include "qgsdataprovider.h"
 #include "qgsfeature.h"
 #include "qgsaggregatecalculator.h"
+#include "qgsmaplayerdependency.h"
 
 typedef QList<int> QgsAttributeList;
 typedef QSet<int> QgsAttributeIds;
@@ -428,7 +429,7 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider
     /**
      * Get the list of layer ids on which this layer depends. This in particular determines the order of layer loading.
      */
-    virtual QSet<QString> layerDependencies() const;
+    virtual QSet<QgsMapLayerDependency> dependencies() const;
 
   signals:
     /** Signals an error in this provider */

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -515,9 +515,29 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     const QList<QgsVectorJoinInfo> vectorJoins() const;
 
     /**
-     * Get the list of layer ids on which this layer depends. This in particular determines the order of layer loading.
+     * Gets the list of layer ids on which this layer depends, as returned by the provider.
+     * This in particular determines the order of layer loading.
      */
     virtual QSet<QString> layerDependencies() const;
+
+    /**
+     * Sets the list of layers that may modify data/geometries of this layer when modified.
+     * This is meant mainly to declare database triggers between layers.
+     * When one of these layers is modified (feature added/deleted or geometry changed),
+     * dataChanged() will be emitted, allowing users of this layer to refresh / update it.
+     *
+     * @param layersIds IDs of the layers that this layer depends on
+     * @returns false if a dependency cycle has been detected (the change dependency set is not changed in that case)
+     */
+    bool setDataDependencies( const QSet<QString>& layersIds ) override;
+
+    /**
+     * Gets the list of layers that may modify data/geometries of this layer when modified.
+     * @see setDataDependencies
+     *
+     * @returns IDs of the layers that this layer depends on
+     */
+    QSet<QString> dataDependencies() const override;
 
     /**
      * Add a new field which is calculated by the expression specified

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -515,12 +515,6 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     const QList<QgsVectorJoinInfo> vectorJoins() const;
 
     /**
-     * Gets the list of layer ids on which this layer depends, as returned by the provider.
-     * This in particular determines the order of layer loading.
-     */
-    virtual QSet<QString> layerDependencies() const;
-
-    /**
      * Sets the list of layers that may modify data/geometries of this layer when modified.
      * This is meant mainly to declare database triggers between layers.
      * When one of these layers is modified (feature added/deleted or geometry changed),
@@ -532,12 +526,12 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     bool setDataDependencies( const QSet<QString>& layersIds ) override;
 
     /**
-     * Gets the list of layers that may modify data/geometries of this layer when modified.
-     * @see setDataDependencies
+     * Gets the list of dependencies. This includes data dependencies set by the user (@see setDataDependencies)
+     * as well as dependencies given by the provider
      *
-     * @returns IDs of the layers that this layer depends on
+     * @returns a set of QgsMapLayerDependency
      */
-    QSet<QString> dataDependencies() const override;
+    virtual QSet<QgsMapLayerDependency> dependencies() const override;
 
     /**
      * Add a new field which is calculated by the expression specified

--- a/src/providers/virtual/qgsvirtuallayerprovider.cpp
+++ b/src/providers/virtual/qgsvirtuallayerprovider.cpp
@@ -601,13 +601,13 @@ QgsAttributeList QgsVirtualLayerProvider::pkAttributeIndexes() const
   return QgsAttributeList();
 }
 
-QSet<QString> QgsVirtualLayerProvider::layerDependencies() const
+QSet<QgsMapLayerDependency> QgsVirtualLayerProvider::dependencies() const
 {
-  QSet<QString> deps;
+  QSet<QgsMapLayerDependency> deps;
   Q_FOREACH ( const QgsVirtualLayerDefinition::SourceLayer& l, mDefinition.sourceLayers() )
   {
     if ( l.isReferenced() )
-      deps << l.reference();
+      deps << QgsMapLayerDependency( l.reference(), QgsMapLayerDependency::PresenceDependency, QgsMapLayerDependency::FromProvider );
   }
   return deps;
 }

--- a/src/providers/virtual/qgsvirtuallayerprovider.h
+++ b/src/providers/virtual/qgsvirtuallayerprovider.h
@@ -79,7 +79,7 @@ class QgsVirtualLayerProvider: public QgsVectorDataProvider
     QgsAttributeList pkAttributeIndexes() const override;
 
     /** Get the list of layer ids on which this layer depends */
-    QSet<QString> layerDependencies() const override;
+    QSet<QgsMapLayerDependency> dependencies() const override;
 
   private:
 

--- a/src/ui/qgsvectorlayerpropertiesbase.ui
+++ b/src/ui/qgsvectorlayerpropertiesbase.ui
@@ -46,16 +46,7 @@
        <enum>QFrame::Raised</enum>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_2">
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
+       <property name="margin">
         <number>0</number>
        </property>
        <item>
@@ -231,6 +222,15 @@
             <normaloff>:/images/themes/default/legend.svg</normaloff>:/images/themes/default/legend.svg</iconset>
           </property>
          </item>
+         <item>
+          <property name="text">
+           <string>Data dependencies</string>
+          </property>
+          <property name="icon">
+           <iconset resource="../../images/images.qrc">
+            <normaloff>:/images/themes/default/dependencies.svg</normaloff>:/images/themes/default/dependencies.svg</iconset>
+          </property>
+         </item>
         </widget>
        </item>
       </layout>
@@ -249,16 +249,7 @@
        <enum>QFrame::Raised</enum>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout_3">
-       <property name="leftMargin">
-        <number>0</number>
-       </property>
-       <property name="topMargin">
-        <number>0</number>
-       </property>
-       <property name="rightMargin">
-        <number>0</number>
-       </property>
-       <property name="bottomMargin">
+       <property name="margin">
         <number>0</number>
        </property>
        <item>
@@ -274,16 +265,7 @@
          </property>
          <widget class="QWidget" name="mOptsPage_General">
           <layout class="QVBoxLayout" name="verticalLayout_14">
-           <property name="leftMargin">
-            <number>0</number>
-           </property>
-           <property name="topMargin">
-            <number>0</number>
-           </property>
-           <property name="rightMargin">
-            <number>0</number>
-           </property>
-           <property name="bottomMargin">
+           <property name="margin">
             <number>0</number>
            </property>
            <item>
@@ -304,16 +286,7 @@
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_13">
-               <property name="leftMargin">
-                <number>0</number>
-               </property>
-               <property name="topMargin">
-                <number>0</number>
-               </property>
-               <property name="rightMargin">
-                <number>0</number>
-               </property>
-               <property name="bottomMargin">
+               <property name="margin">
                 <number>0</number>
                </property>
                <item>
@@ -335,16 +308,7 @@
                   <item row="5" column="0">
                    <widget class="QFrame" name="mDataSourceEncodingFrame">
                     <layout class="QHBoxLayout" name="horizontalLayout_4">
-                     <property name="leftMargin">
-                      <number>0</number>
-                     </property>
-                     <property name="topMargin">
-                      <number>0</number>
-                     </property>
-                     <property name="rightMargin">
-                      <number>0</number>
-                     </property>
-                     <property name="bottomMargin">
+                     <property name="margin">
                       <number>0</number>
                      </property>
                     </layout>
@@ -572,16 +536,7 @@
          </widget>
          <widget class="QWidget" name="mOptsPage_Style">
           <layout class="QVBoxLayout" name="verticalLayout_11">
-           <property name="leftMargin">
-            <number>0</number>
-           </property>
-           <property name="topMargin">
-            <number>0</number>
-           </property>
-           <property name="rightMargin">
-            <number>0</number>
-           </property>
-           <property name="bottomMargin">
+           <property name="margin">
             <number>0</number>
            </property>
            <item>
@@ -597,21 +552,12 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>100</width>
-                <height>30</height>
+                <width>730</width>
+                <height>537</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_18">
-               <property name="leftMargin">
-                <number>0</number>
-               </property>
-               <property name="topMargin">
-                <number>0</number>
-               </property>
-               <property name="rightMargin">
-                <number>0</number>
-               </property>
-               <property name="bottomMargin">
+               <property name="margin">
                 <number>0</number>
                </property>
                <item>
@@ -641,16 +587,7 @@
          </widget>
          <widget class="QWidget" name="mOptsPage_Labels">
           <layout class="QVBoxLayout" name="verticalLayout_12">
-           <property name="leftMargin">
-            <number>0</number>
-           </property>
-           <property name="topMargin">
-            <number>0</number>
-           </property>
-           <property name="rightMargin">
-            <number>0</number>
-           </property>
-           <property name="bottomMargin">
+           <property name="margin">
             <number>0</number>
            </property>
            <item>
@@ -673,16 +610,7 @@
          </widget>
          <widget class="QWidget" name="mOptsPage_Fields">
           <layout class="QVBoxLayout" name="verticalLayout_15">
-           <property name="leftMargin">
-            <number>0</number>
-           </property>
-           <property name="topMargin">
-            <number>0</number>
-           </property>
-           <property name="rightMargin">
-            <number>0</number>
-           </property>
-           <property name="bottomMargin">
+           <property name="margin">
             <number>0</number>
            </property>
            <item>
@@ -698,21 +626,12 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>100</width>
-                <height>30</height>
+                <width>730</width>
+                <height>537</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_20">
-               <property name="leftMargin">
-                <number>0</number>
-               </property>
-               <property name="topMargin">
-                <number>0</number>
-               </property>
-               <property name="rightMargin">
-                <number>0</number>
-               </property>
-               <property name="bottomMargin">
+               <property name="margin">
                 <number>0</number>
                </property>
                <item>
@@ -733,16 +652,7 @@
          </widget>
          <widget class="QWidget" name="mOptsPage_Rendering">
           <layout class="QVBoxLayout" name="verticalLayout_19">
-           <property name="leftMargin">
-            <number>0</number>
-           </property>
-           <property name="topMargin">
-            <number>0</number>
-           </property>
-           <property name="rightMargin">
-            <number>0</number>
-           </property>
-           <property name="bottomMargin">
+           <property name="margin">
             <number>0</number>
            </property>
            <item>
@@ -908,16 +818,7 @@
          </widget>
          <widget class="QWidget" name="mOptsPage_Display">
           <layout class="QVBoxLayout" name="verticalLayout_25">
-           <property name="leftMargin">
-            <number>0</number>
-           </property>
-           <property name="topMargin">
-            <number>0</number>
-           </property>
-           <property name="rightMargin">
-            <number>0</number>
-           </property>
-           <property name="bottomMargin">
+           <property name="margin">
             <number>0</number>
            </property>
            <item>
@@ -1003,16 +904,7 @@
          </widget>
          <widget class="QWidget" name="mOptsPage_Actions">
           <layout class="QVBoxLayout" name="verticalLayout_16">
-           <property name="leftMargin">
-            <number>0</number>
-           </property>
-           <property name="topMargin">
-            <number>0</number>
-           </property>
-           <property name="rightMargin">
-            <number>0</number>
-           </property>
-           <property name="bottomMargin">
+           <property name="margin">
             <number>0</number>
            </property>
            <item>
@@ -1028,21 +920,12 @@
                <rect>
                 <x>0</x>
                 <y>0</y>
-                <width>100</width>
-                <height>30</height>
+                <width>730</width>
+                <height>537</height>
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_21">
-               <property name="leftMargin">
-                <number>0</number>
-               </property>
-               <property name="topMargin">
-                <number>0</number>
-               </property>
-               <property name="rightMargin">
-                <number>0</number>
-               </property>
-               <property name="bottomMargin">
+               <property name="margin">
                 <number>0</number>
                </property>
                <item>
@@ -1069,16 +952,7 @@
          </widget>
          <widget class="QWidget" name="mOptsPage_Joins">
           <layout class="QVBoxLayout" name="verticalLayout_17">
-           <property name="leftMargin">
-            <number>0</number>
-           </property>
-           <property name="topMargin">
-            <number>0</number>
-           </property>
-           <property name="rightMargin">
-            <number>0</number>
-           </property>
-           <property name="bottomMargin">
+           <property name="margin">
             <number>0</number>
            </property>
            <item>
@@ -1099,16 +973,7 @@
                </rect>
               </property>
               <layout class="QVBoxLayout" name="verticalLayout_23">
-               <property name="leftMargin">
-                <number>0</number>
-               </property>
-               <property name="topMargin">
-                <number>0</number>
-               </property>
-               <property name="rightMargin">
-                <number>0</number>
-               </property>
-               <property name="bottomMargin">
+               <property name="margin">
                 <number>0</number>
                </property>
                <item>
@@ -1206,16 +1071,7 @@
          </widget>
          <widget class="QWidget" name="mOptsPage_Diagrams">
           <layout class="QVBoxLayout" name="verticalLayout_10">
-           <property name="leftMargin">
-            <number>0</number>
-           </property>
-           <property name="topMargin">
-            <number>0</number>
-           </property>
-           <property name="rightMargin">
-            <number>0</number>
-           </property>
-           <property name="bottomMargin">
+           <property name="margin">
             <number>0</number>
            </property>
            <item>
@@ -1238,16 +1094,7 @@
          </widget>
          <widget class="QWidget" name="mOptsPage_Metadata">
           <layout class="QVBoxLayout" name="verticalLayout_7">
-           <property name="leftMargin">
-            <number>0</number>
-           </property>
-           <property name="topMargin">
-            <number>0</number>
-           </property>
-           <property name="rightMargin">
-            <number>0</number>
-           </property>
-           <property name="bottomMargin">
+           <property name="margin">
             <number>0</number>
            </property>
            <item>
@@ -1702,6 +1549,46 @@
            </item>
           </layout>
          </widget>
+         <widget class="QWidget" name="mOptsPage_DataDependencies">
+          <layout class="QVBoxLayout" name="verticalLayout_29">
+           <item>
+            <widget class="QgsCollapsibleGroupBox" name="groupBox_5">
+             <property name="title">
+              <string>Data dependencies</string>
+             </property>
+             <layout class="QVBoxLayout" name="verticalLayout_24">
+              <item>
+               <widget class="QLabel" name="label">
+                <property name="text">
+                 <string>Data of this layer may be updated by data change on one of these layers :</string>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <widget class="QgsLayerTreeView" name="mLayersDependenciesTreeView">
+                <property name="enabled">
+                 <bool>true</bool>
+                </property>
+               </widget>
+              </item>
+              <item>
+               <spacer name="verticalSpacer_4">
+                <property name="orientation">
+                 <enum>Qt::Vertical</enum>
+                </property>
+                <property name="sizeHint" stdset="0">
+                 <size>
+                  <width>20</width>
+                  <height>40</height>
+                 </size>
+                </property>
+               </spacer>
+              </item>
+             </layout>
+            </widget>
+           </item>
+          </layout>
+         </widget>
         </widget>
        </item>
       </layout>
@@ -1723,16 +1610,7 @@
       <enum>QFrame::Raised</enum>
      </property>
      <layout class="QGridLayout" name="gridLayout_btnbox">
-      <property name="leftMargin">
-       <number>0</number>
-      </property>
-      <property name="topMargin">
-       <number>0</number>
-      </property>
-      <property name="rightMargin">
-       <number>0</number>
-      </property>
-      <property name="bottomMargin">
+      <property name="margin">
        <number>0</number>
       </property>
       <item row="2" column="1" colspan="4">
@@ -1795,6 +1673,9 @@
    <extends>QFrame</extends>
    <header>qgscodeeditorhtml.h</header>
    <container>1</container>
+   <class>QgsLayerTreeView</class>
+   <extends>QTreeView</extends>
+   <header>qgslayertreeview.h</header>
   </customwidget>
  </customwidgets>
  <tabstops>

--- a/tests/src/python/CMakeLists.txt
+++ b/tests/src/python/CMakeLists.txt
@@ -108,6 +108,7 @@ ADD_PYTHON_TEST(PyQgsLayerDefinition test_qgslayerdefinition.py)
 ADD_PYTHON_TEST(PyQgsWFSProvider test_provider_wfs.py)
 ADD_PYTHON_TEST(PyQgsWFSProviderGUI test_provider_wfs_gui.py)
 ADD_PYTHON_TEST(PyQgsConsole test_console.py)
+ADD_PYTHON_TEST(PyQgsLayerDependencies test_layer_dependencies.py)
 
 IF (NOT WIN32)
   ADD_PYTHON_TEST(PyQgsLogger test_qgslogger.py)

--- a/tests/src/python/test_layer_dependencies.py
+++ b/tests/src/python/test_layer_dependencies.py
@@ -1,0 +1,259 @@
+# -*- coding: utf-8 -*-
+"""QGIS Unit tests for QgsSnappingUtils (complement to C++-based tests)
+
+.. note:: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+"""
+__author__ = 'Hugo Mercier'
+__date__ = '12/07/2016'
+__copyright__ = 'Copyright 2016, The QGIS Project'
+# This will get replaced with a git SHA1 when you do a git archive
+__revision__ = '$Format:%H$'
+
+import qgis  # NOQA
+import os
+
+from qgis.core import (QgsMapLayerRegistry,
+                       QgsVectorLayer,
+                       QgsMapSettings,
+                       QgsSnappingUtils,
+                       QgsPointLocator,
+                       QgsTolerance,
+                       QgsRectangle,
+                       QgsPoint,
+                       QgsFeature,
+                       QgsGeometry,
+                       QgsProject,
+                       QgsLayerDefinition
+                       )
+
+from qgis.testing import start_app, unittest
+from utilities import unitTestDataPath
+
+from qgis.PyQt.QtCore import QSize, QPoint
+
+import tempfile
+
+try:
+    from pyspatialite import dbapi2 as sqlite3
+except ImportError:
+    print("You should install pyspatialite to run the tests")
+    raise ImportError
+
+# Convenience instances in case you may need them
+start_app()
+
+
+class TestLayerDependencies(unittest.TestCase):
+
+    @classmethod
+    def setUpClass(cls):
+        """Run before all tests"""
+
+        # create a temp spatialite db with a trigger
+        fo = tempfile.NamedTemporaryFile()
+        fn = fo.name
+        fo.close()
+        cls.fn = fn
+        con = sqlite3.connect(fn)
+        cur = con.cursor()
+        cur.execute("SELECT InitSpatialMetadata(1)")
+        cur.execute("create table node(id integer primary key autoincrement);")
+        cur.execute("select AddGeometryColumn('node', 'geom', 4326, 'POINT');")
+        cur.execute("create table section(id integer primary key autoincrement, node1 integer, node2 integer);")
+        cur.execute("select AddGeometryColumn('section', 'geom', 4326, 'LINESTRING');")
+        cur.execute("create trigger add_nodes after insert on section begin insert into node (geom) values (st_startpoint(NEW.geom)); insert into node (geom) values (st_endpoint(NEW.geom)); end;")
+        cur.execute("insert into node (geom) values (geomfromtext('point(0 0)', 4326));")
+        cur.execute("insert into node (geom) values (geomfromtext('point(1 0)', 4326));")
+        cur.execute("create table node2(id integer primary key autoincrement);")
+        cur.execute("select AddGeometryColumn('node2', 'geom', 4326, 'POINT');")
+        cur.execute("create trigger add_nodes2 after insert on node begin insert into node2 (geom) values (st_translate(NEW.geom, 0.2, 0, 0)); end;")
+        con.commit()
+        con.close()
+
+        cls.pointsLayer = QgsVectorLayer("dbname='%s' table=\"node\" (geom) sql=" % fn, "points", "spatialite")
+        assert (cls.pointsLayer.isValid())
+        cls.linesLayer = QgsVectorLayer("dbname='%s' table=\"section\" (geom) sql=" % fn, "lines", "spatialite")
+        assert (cls.linesLayer.isValid())
+        cls.pointsLayer2 = QgsVectorLayer("dbname='%s' table=\"node2\" (geom) sql=" % fn, "_points2", "spatialite")
+        assert (cls.pointsLayer2.isValid())
+        QgsMapLayerRegistry.instance().addMapLayers([cls.pointsLayer, cls.linesLayer, cls.pointsLayer2])
+
+        # save the project file
+        fo = tempfile.NamedTemporaryFile()
+        fn = fo.name
+        fo.close()
+        cls.projectFile = fn
+        QgsProject.instance().setFileName(cls.projectFile)
+        QgsProject.instance().write()
+
+    @classmethod
+    def tearDownClass(cls):
+        """Run after all tests"""
+        pass
+
+    def setUp(self):
+        """Run before each test."""
+        pass
+
+    def tearDown(self):
+        """Run after each test."""
+        pass
+
+    def test_resetSnappingIndex(self):
+        self.pointsLayer.setDataDependencies([])
+        self.linesLayer.setDataDependencies([])
+        self.pointsLayer2.setDataDependencies([])
+
+        ms = QgsMapSettings()
+        ms.setOutputSize(QSize(100, 100))
+        ms.setExtent(QgsRectangle(0, 0, 1, 1))
+        self.assertTrue(ms.hasValidSettings())
+
+        u = QgsSnappingUtils()
+        u.setMapSettings(ms)
+        u.setSnapToMapMode(QgsSnappingUtils.SnapAdvanced)
+        layers = [QgsSnappingUtils.LayerConfig(self.pointsLayer, QgsPointLocator.Vertex, 20, QgsTolerance.Pixels)]
+        u.setLayers(layers)
+
+        m = u.snapToMap(QPoint(95, 100))
+        self.assertTrue(m.isValid())
+        self.assertTrue(m.hasVertex())
+        self.assertEqual(m.point(), QgsPoint(1, 0))
+
+        f = QgsFeature(self.linesLayer.fields())
+        f.setFeatureId(1)
+        geom = QgsGeometry.fromWkt("LINESTRING(0 0,1 1)")
+        f.setGeometry(geom)
+        self.linesLayer.startEditing()
+        self.linesLayer.addFeatures([f])
+        self.linesLayer.commitChanges()
+
+        l1 = len([f for f in self.pointsLayer.getFeatures()])
+        self.assertEqual(l1, 4)
+        m = u.snapToMap(QPoint(95, 0))
+        # snapping not updated
+        self.assertEqual(m.isValid(), False)
+
+        # set layer dependencies
+        self.pointsLayer.setDataDependencies([self.linesLayer.id()])
+        # add another line
+        f = QgsFeature(self.linesLayer.fields())
+        f.setFeatureId(2)
+        geom = QgsGeometry.fromWkt("LINESTRING(0 0,0.5 0.5)")
+        f.setGeometry(geom)
+        self.linesLayer.startEditing()
+        self.linesLayer.addFeatures([f])
+        self.linesLayer.commitChanges()
+        # check the snapped point is ok
+        m = u.snapToMap(QPoint(45, 50))
+        self.assertTrue(m.isValid())
+        self.assertTrue(m.hasVertex())
+        self.assertEqual(m.point(), QgsPoint(0.5, 0.5))
+        self.pointsLayer.setDataDependencies([])
+
+        # test chained layer dependencies A -> B -> C
+        layers = [QgsSnappingUtils.LayerConfig(self.pointsLayer, QgsPointLocator.Vertex, 20, QgsTolerance.Pixels),
+                  QgsSnappingUtils.LayerConfig(self.pointsLayer2, QgsPointLocator.Vertex, 20, QgsTolerance.Pixels)
+                  ]
+        u.setLayers(layers)
+        self.pointsLayer.setDataDependencies([self.linesLayer.id()])
+        self.pointsLayer2.setDataDependencies([self.pointsLayer.id()])
+        # add another line
+        f = QgsFeature(self.linesLayer.fields())
+        f.setFeatureId(3)
+        geom = QgsGeometry.fromWkt("LINESTRING(0 0.2,0.5 0.8)")
+        f.setGeometry(geom)
+        self.linesLayer.startEditing()
+        self.linesLayer.addFeatures([f])
+        self.linesLayer.commitChanges()
+        # check the second snapped point is ok
+        m = u.snapToMap(QPoint(75, 100 - 80))
+        self.assertTrue(m.isValid())
+        self.assertTrue(m.hasVertex())
+        self.assertEqual(m.point(), QgsPoint(0.7, 0.8))
+        self.pointsLayer.setDataDependencies([])
+        self.pointsLayer2.setDataDependencies([])
+
+    def test_cycleDetection(self):
+        self.assertTrue(self.pointsLayer.setDataDependencies([self.linesLayer.id()]))
+        self.assertFalse(self.linesLayer.setDataDependencies([self.pointsLayer.id()]))
+        self.pointsLayer.setDataDependencies([])
+        self.linesLayer.setDataDependencies([])
+
+    def test_layerDefinitionRewriteId(self):
+        tmpfile = os.path.join(tempfile.tempdir, "test.qlr")
+
+        ltr = QgsProject.instance().layerTreeRoot()
+
+        self.pointsLayer.setDataDependencies([self.linesLayer.id()])
+
+        QgsLayerDefinition.exportLayerDefinition(tmpfile, [ltr])
+
+        grp = ltr.addGroup("imported")
+        QgsLayerDefinition.loadLayerDefinition(tmpfile, grp)
+
+        newPointsLayer = None
+        newLinesLayer = None
+        for l in grp.findLayers():
+            if l.layerId().startswith('points'):
+                newPointsLayer = l.layer()
+            elif l.layerId().startswith('lines'):
+                newLinesLayer = l.layer()
+        self.assertFalse(newPointsLayer is None)
+        self.assertFalse(newLinesLayer is None)
+        self.assertTrue(newLinesLayer.id() in newPointsLayer.dataDependencies())
+
+        self.pointsLayer.setDataDependencies([])
+
+    def test_signalConnection(self):
+        # remove all layers
+        QgsMapLayerRegistry.instance().removeAllMapLayers()
+        # set dependencies and add back layers
+        self.pointsLayer = QgsVectorLayer("dbname='%s' table=\"node\" (geom) sql=" % self.fn, "points", "spatialite")
+        assert (self.pointsLayer.isValid())
+        self.linesLayer = QgsVectorLayer("dbname='%s' table=\"section\" (geom) sql=" % self.fn, "lines", "spatialite")
+        assert (self.linesLayer.isValid())
+        self.pointsLayer2 = QgsVectorLayer("dbname='%s' table=\"node2\" (geom) sql=" % self.fn, "_points2", "spatialite")
+        assert (self.pointsLayer2.isValid())
+        self.pointsLayer.setDataDependencies([self.linesLayer.id()])
+        self.pointsLayer2.setDataDependencies([self.pointsLayer.id()])
+        # this should update connections between layers
+        QgsMapLayerRegistry.instance().addMapLayers([self.pointsLayer])
+        QgsMapLayerRegistry.instance().addMapLayers([self.linesLayer])
+        QgsMapLayerRegistry.instance().addMapLayers([self.pointsLayer2])
+
+        ms = QgsMapSettings()
+        ms.setOutputSize(QSize(100, 100))
+        ms.setExtent(QgsRectangle(0, 0, 1, 1))
+        self.assertTrue(ms.hasValidSettings())
+
+        u = QgsSnappingUtils()
+        u.setMapSettings(ms)
+        u.setSnapToMapMode(QgsSnappingUtils.SnapAdvanced)
+        layers = [QgsSnappingUtils.LayerConfig(self.pointsLayer, QgsPointLocator.Vertex, 20, QgsTolerance.Pixels),
+                  QgsSnappingUtils.LayerConfig(self.pointsLayer2, QgsPointLocator.Vertex, 20, QgsTolerance.Pixels)
+                  ]
+        u.setLayers(layers)
+        # add another line
+        f = QgsFeature(self.linesLayer.fields())
+        f.setFeatureId(4)
+        geom = QgsGeometry.fromWkt("LINESTRING(0.5 0.2,0.6 0)")
+        f.setGeometry(geom)
+        self.linesLayer.startEditing()
+        self.linesLayer.addFeatures([f])
+        self.linesLayer.commitChanges()
+        # check the second snapped point is ok
+        m = u.snapToMap(QPoint(75, 100 - 0))
+        self.assertTrue(m.isValid())
+        self.assertTrue(m.hasVertex())
+        self.assertEqual(m.point(), QgsPoint(0.8, 0.0))
+
+        self.pointsLayer.setDataDependencies([])
+        self.pointsLayer2.setDataDependencies([])
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/src/python/test_layer_dependencies.py
+++ b/tests/src/python/test_layer_dependencies.py
@@ -135,6 +135,7 @@ class TestLayerDependencies(unittest.TestCase):
         self.assertEqual(l1, 4)
         m = u.snapToMap(QPoint(95, 0))
         # snapping not updated
+        self.pointsLayer.setDataDependencies([])
         self.assertEqual(m.isValid(), False)
 
         # set layer dependencies
@@ -204,7 +205,7 @@ class TestLayerDependencies(unittest.TestCase):
                 newLinesLayer = l.layer()
         self.assertFalse(newPointsLayer is None)
         self.assertFalse(newLinesLayer is None)
-        self.assertTrue(newLinesLayer.id() in newPointsLayer.dataDependencies())
+        self.assertTrue(newLinesLayer.id() in [dep.layerId() for dep in newPointsLayer.dependencies()])
 
         self.pointsLayer.setDataDependencies([])
 

--- a/tests/src/python/test_provider_virtual.py
+++ b/tests/src/python/test_provider_virtual.py
@@ -677,18 +677,18 @@ class TestQgsVirtualLayerProvider(unittest.TestCase, ProviderTestCase):
         self.assertEqual(l2.isValid(), True)
         QgsMapLayerRegistry.instance().addMapLayer(l2)
 
-        self.assertEqual(len(l2.layerDependencies()), 1)
-        self.assertEqual(l2.layerDependencies()[0].startswith('france_parts'), True)
+        self.assertEqual(len(l2.dependencies()), 1)
+        self.assertEqual(l2.dependencies()[0].layerId().startswith('france_parts'), True)
 
         query = QUrl.toPercentEncoding("SELECT t1.objectid, t2.name_0 FROM france_parts as t1, aa as t2")
         l3 = QgsVectorLayer("?query=%s" % query, "bb", "virtual", False)
         self.assertEqual(l3.isValid(), True)
         QgsMapLayerRegistry.instance().addMapLayer(l3)
 
-        self.assertEqual(len(l2.layerDependencies()), 1)
-        self.assertEqual(l2.layerDependencies()[0].startswith('france_parts'), True)
+        self.assertEqual(len(l2.dependencies()), 1)
+        self.assertEqual(l2.dependencies()[0].layerId().startswith('france_parts'), True)
 
-        self.assertEqual(len(l3.layerDependencies()), 2)
+        self.assertEqual(len(l3.dependencies()), 2)
 
         temp = os.path.join(tempfile.gettempdir(), "qgstestproject.qgs")
 


### PR DESCRIPTION
Following #3306, this patch adds a way for the user to declare data dependencies between layers, where data of a layer may be modified when other layers are modified.

Dependencies are declared thanks to new methods on QgsProject. Layers are registered for modification signals (featureAdded / featureDelete / geometryChanged) and will trigger dataChanged()

Other parts of the code that should know which caches to update can connect to the dataChanged signal. This is done for the snapping on QgsPointLocator

UI side, there is a new tab in the vector layer property that allows to select which layers depends on which others.
