### PR TITLE
Add an interface class for annotations, remove some hacks

### DIFF
--- a/python/core/core.sip
+++ b/python/core/core.sip
@@ -18,6 +18,7 @@
 
 %Include qgis.sip
 
+%Include qgsannotation.sip
 %Include qgsapplication.sip
 %Include qgsaction.sip
 %Include qgsactionmanager.sip

--- a/python/core/qgsannotation.sip
+++ b/python/core/qgsannotation.sip
@@ -1,0 +1,58 @@
+/** \ingroup core
+ * \class QgsAnnotation
+ * \note added in QGIS 3.0
+ *
+ *  An interface for annotation type items.
+ */
+
+class QgsAnnotation
+{
+%TypeHeaderCode
+#include <qgsannotation.h>
+%End
+  public:
+
+    //! Returns true if the annotation should be shown.
+    virtual bool showItem() const = 0;
+
+    /** Returns true if the annotation is attached to a fixed map position, or
+     * false if the annotation uses a position relative to the current map
+     * extent.
+     * @see mapPosition()
+     * @see relativePositon()
+     */
+    //TODO QGIS 3 - rename to hasFixedMapPosition()
+    virtual bool mapPositionFixed() const = 0;
+
+    /** Returns the map position of the annotation, if it is attached to a fixed map
+     * position.
+     * @see mapPositionFixed()
+     * @see mapPositionCrs()
+     */
+    virtual QgsPoint mapPosition() const;
+
+    /** Returns the CRS of the map position, or an invalid CRS if the annotation does
+     * not have a fixed map position.
+    */
+    virtual QgsCoordinateReferenceSystem mapPositionCrs() const;
+
+    /** Returns the relative position of the annotation, if it is not attached to a fixed map
+     * position. The coordinates in the return point should be between 0 and 1, and represent
+     * the relative percentage for the position compared to the map width and height.
+     * @see mapPositionFixed()
+     */
+    virtual QPointF relativePosition() const;
+
+    /** Returns a scaling factor which should be applied to painters before rendering
+     * the item.
+     */
+    virtual double scaleFactor() const = 0;
+
+    //! deprecated - do not use
+    // TODO QGIS 3.0 - remove
+    virtual void setItemData( int role, const QVariant& value ) = 0;
+
+    //! Paint the annotation to a destination painter
+    virtual void paint( QPainter * painter, const QStyleOptionGraphicsItem * option, QWidget * widget = nullptr ) = 0;
+
+};

--- a/python/core/qgsannotation.sip
+++ b/python/core/qgsannotation.sip
@@ -2,7 +2,13 @@
  * \class QgsAnnotation
  * \note added in QGIS 3.0
  *
- *  An interface for annotation type items.
+ * \brief An interface for annotation items which are drawn over a map.
+ *
+ * QgsAnnotation is an interface class for map annotation items. These annotations can be
+ * drawn within a map, and have either a fixed map position (retrieved using mapPosition())
+ * or are placed relative to the map's frame (retrieved using relativePosition()).
+ * Annotations with a fixed map position also have a corresponding
+ * QgsCoordinateReferenceSystem, which can be determined by calling mapPositionCrs().
  */
 
 class QgsAnnotation

--- a/python/gui/qgsannotationitem.sip
+++ b/python/gui/qgsannotationitem.sip
@@ -8,7 +8,7 @@
 #include "qgstextannotationitem.h"
 %End
 
-class QgsAnnotationItem: QgsMapCanvasItem
+class QgsAnnotationItem: QgsMapCanvasItem, QgsAnnotation
 {
 %TypeHeaderCode
 #include <qgsannotationitem.h>
@@ -66,6 +66,12 @@ class QgsAnnotationItem: QgsMapCanvasItem
     virtual void setMapPosition( const QgsPoint& pos );
     QgsPoint mapPosition() const;
 
+    virtual QPointF relativePosition() const;
+
+    virtual double scaleFactor() const;
+
+    virtual bool showItem() const;
+
     /** Sets the CRS of the map position.
       @param crs the CRS to set */
     virtual void setMapPositionCrs( const QgsCoordinateReferenceSystem& crs );
@@ -97,18 +103,28 @@ class QgsAnnotationItem: QgsMapCanvasItem
     void _writeXml( QDomDocument& doc, QDomElement& itemElem ) const;
     void _readXml( const QDomDocument& doc, const QDomElement& annotationElem );
 
+    virtual void setItemData( int role, const QVariant& value );
+    virtual void paint( QPainter * painter, const QStyleOptionGraphicsItem * option, QWidget * widget = nullptr );
+    void paint( QPainter* painter );
+
   protected:
     void updateBoundingRect();
     /** Check where to attach the balloon connection between frame and map point*/
     void updateBalloon();
 
-    void drawFrame( QPainter* p );
-    void drawMarkerSymbol( QPainter* p );
-    void drawSelectionBoxes( QPainter* p );
+    //! Draws the annotation frame to a destination painter
+    void drawFrame( QPainter* p ) const;
+
+    //! Draws the map position marker symbol to a destination painter
+    void drawMarkerSymbol( QPainter* p ) const;
+
+    //! Draws selection handles around the item
+    void drawSelectionBoxes( QPainter* p ) const;
+
     /** Returns frame width in painter units*/
     //double scaledFrameWidth( QPainter* p) const;
     /** Gets the frame line (0 is the top line, 1 right, 2 bottom, 3 left)*/
-    QLineF segment( int index );
+    QLineF segment( int index ) const;
     /** Returns a point on the line from startPoint to directionPoint that is a certain distance away from the starting point*/
     QPointF pointOnLineWithDistance( QPointF startPoint, QPointF directionPoint, double distance ) const;
     /** Returns the symbol size scaled in (mapcanvas) pixels. Used for the counding rect calculation*/

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -603,6 +603,7 @@ SET(QGIS_CORE_HDRS
   qgis.h
   qgsaction.h
   qgsaggregatecalculator.h
+  qgsannotation.h
   qgsattributetableconfig.h
   qgsattributeaction.h
   qgscachedfeatureiterator.h

--- a/src/core/composer/qgscomposermap.h
+++ b/src/core/composer/qgscomposermap.h
@@ -36,6 +36,7 @@ class QPainter;
 class QgsFillSymbolV2;
 class QgsLineSymbolV2;
 class QgsVectorLayer;
+class QgsAnnotation;
 
 /** \ingroup core
  *  \class QgsComposerMap
@@ -968,8 +969,8 @@ class CORE_EXPORT QgsComposerMap : public QgsComposerItem
     void transformShift( double& xShift, double& yShift ) const;
 
     void drawCanvasItems( QPainter* painter, const QStyleOptionGraphicsItem* itemStyle );
-    void drawCanvasItem( QGraphicsItem* item, QPainter* painter, const QStyleOptionGraphicsItem* itemStyle );
-    QPointF composerMapPosForItem( const QGraphicsItem* item ) const;
+    void drawCanvasItem( const QgsAnnotation* item, QPainter* painter, const QStyleOptionGraphicsItem* itemStyle );
+    QPointF composerMapPosForItem( const QgsAnnotation* item ) const;
 
     enum PartType
     {

--- a/src/core/qgsannotation.h
+++ b/src/core/qgsannotation.h
@@ -28,7 +28,13 @@ class QStyleOptionGraphicsItem;
  * \class QgsAnnotation
  * \note added in QGIS 3.0
  *
- *  An interface for annotation type items.
+ * \brief An interface for annotation items which are drawn over a map.
+ *
+ * QgsAnnotation is an interface class for map annotation items. These annotations can be
+ * drawn within a map, and have either a fixed map position (retrieved using mapPosition())
+ * or are placed relative to the map's frame (retrieved using relativePosition()).
+ * Annotations with a fixed map position also have a corresponding
+ * QgsCoordinateReferenceSystem, which can be determined by calling mapPositionCrs().
  */
 
 class CORE_EXPORT QgsAnnotation

--- a/src/core/qgsannotation.h
+++ b/src/core/qgsannotation.h
@@ -1,0 +1,84 @@
+/***************************************************************************
+                             qgsannotation.h
+                             ---------------
+    begin                : July 2016
+    copyright            : (C) 2016 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSANNOTATION_H
+#define QGSANNOTATION_H
+
+#include "qgspoint.h"
+#include "qgscoordinatereferencesystem.h"
+
+class QPainter;
+class QStyleOptionGraphicsItem;
+
+/** \ingroup core
+ * \class QgsAnnotation
+ * \note added in QGIS 3.0
+ *
+ *  An interface for annotation type items.
+ */
+
+class CORE_EXPORT QgsAnnotation
+{
+  public:
+
+    //! Returns true if the annotation should be shown.
+    virtual bool showItem() const = 0;
+
+    /** Returns true if the annotation is attached to a fixed map position, or
+     * false if the annotation uses a position relative to the current map
+     * extent.
+     * @see mapPosition()
+     * @see relativePositon()
+     */
+    //TODO QGIS 3 - rename to hasFixedMapPosition()
+    virtual bool mapPositionFixed() const = 0;
+
+    /** Returns the map position of the annotation, if it is attached to a fixed map
+     * position.
+     * @see mapPositionFixed()
+     * @see mapPositionCrs()
+     */
+    virtual QgsPoint mapPosition() const { return QgsPoint(); }
+
+    /** Returns the CRS of the map position, or an invalid CRS if the annotation does
+     * not have a fixed map position.
+    */
+    virtual QgsCoordinateReferenceSystem mapPositionCrs() const { return QgsCoordinateReferenceSystem(); }
+
+    /** Returns the relative position of the annotation, if it is not attached to a fixed map
+     * position. The coordinates in the return point should be between 0 and 1, and represent
+     * the relative percentage for the position compared to the map width and height.
+     * @see mapPositionFixed()
+     */
+    virtual QPointF relativePosition() const { return QPointF(); }
+
+    /** Returns a scaling factor which should be applied to painters before rendering
+     * the item.
+     */
+    virtual double scaleFactor() const = 0;
+
+    //! deprecated - do not use
+    // TODO QGIS 3.0 - remove
+    virtual void setItemData( int role, const QVariant& value ) = 0;
+
+    //! Paint the annotation to a destination painter
+    virtual void paint( QPainter * painter, const QStyleOptionGraphicsItem * option, QWidget * widget = nullptr ) = 0;
+
+
+};
+
+#endif // QGSANNOTATION_H

--- a/src/gui/qgsannotationitem.h
+++ b/src/gui/qgsannotationitem.h
@@ -20,6 +20,7 @@
 
 #include "qgsmapcanvasitem.h"
 #include "qgscoordinatereferencesystem.h"
+#include "qgsannotation.h"
 
 class QDomDocument;
 class QDomElement;
@@ -30,7 +31,8 @@ class QgsMarkerSymbolV2;
 /** \ingroup gui
  * An annotation item can be either placed either on screen corrdinates or on map coordinates.
   It may reference a feature and displays that associatiation with a balloon like appearance*/
-class GUI_EXPORT QgsAnnotationItem: public QgsMapCanvasItem
+
+class GUI_EXPORT QgsAnnotationItem: public QgsMapCanvasItem, public QgsAnnotation
 {
   public:
     enum MouseMoveAction
@@ -65,16 +67,22 @@ class GUI_EXPORT QgsAnnotationItem: public QgsMapCanvasItem
 
     //setters and getters
     void setMapPositionFixed( bool fixed );
-    bool mapPositionFixed() const { return mMapPositionFixed; }
+    bool mapPositionFixed() const override { return mMapPositionFixed; }
 
     virtual void setMapPosition( const QgsPoint& pos );
-    QgsPoint mapPosition() const { return mMapPosition; }
+    QgsPoint mapPosition() const override { return mMapPosition; }
+
+    virtual QPointF relativePosition() const override;
+
+    virtual double scaleFactor() const override;
+
+    virtual bool showItem() const override { return isVisible(); }
 
     /** Sets the CRS of the map position.
       @param crs the CRS to set */
     virtual void setMapPositionCrs( const QgsCoordinateReferenceSystem& crs );
     /** Returns the CRS of the map position.*/
-    QgsCoordinateReferenceSystem mapPositionCrs() const { return mMapPositionCrs; }
+    QgsCoordinateReferenceSystem mapPositionCrs() const override { return mMapPositionCrs; }
 
     void setFrameSize( QSizeF size );
     QSizeF frameSize() const { return mFrameSize; }
@@ -100,6 +108,12 @@ class GUI_EXPORT QgsAnnotationItem: public QgsMapCanvasItem
 
     void _writeXml( QDomDocument& doc, QDomElement& itemElem ) const;
     void _readXml( const QDomDocument& doc, const QDomElement& annotationElem );
+
+    virtual void setItemData( int role, const QVariant& value ) override;
+
+    virtual void paint( QPainter * painter, const QStyleOptionGraphicsItem * option, QWidget * widget = nullptr ) override;
+
+    void paint( QPainter* painter ) override;
 
   protected:
     /** True: the item stays at the same map position, False: the item stays on same screen position*/
@@ -136,13 +150,19 @@ class GUI_EXPORT QgsAnnotationItem: public QgsMapCanvasItem
     /** Check where to attach the balloon connection between frame and map point*/
     void updateBalloon();
 
-    void drawFrame( QPainter* p );
-    void drawMarkerSymbol( QPainter* p );
-    void drawSelectionBoxes( QPainter* p );
+    //! Draws the annotation frame to a destination painter
+    void drawFrame( QPainter* p ) const;
+
+    //! Draws the map position marker symbol to a destination painter
+    void drawMarkerSymbol( QPainter* p ) const;
+
+    //! Draws selection handles around the item
+    void drawSelectionBoxes( QPainter* p ) const;
+
     /** Returns frame width in painter units*/
     //double scaledFrameWidth( QPainter* p) const;
     /** Gets the frame line (0 is the top line, 1 right, 2 bottom, 3 left)*/
-    QLineF segment( int index );
+    QLineF segment( int index ) const;
     /** Returns a point on the line from startPoint to directionPoint that is a certain distance away from the starting point*/
     QPointF pointOnLineWithDistance( QPointF startPoint, QPointF directionPoint, double distance ) const;
     /** Returns the symbol size scaled in (mapcanvas) pixels. Used for the counding rect calculation*/


### PR DESCRIPTION
This PR adds a new interface class QgsAnnotation in core, and allows for removal of a bunch of hacks in QgsComposerMap which try to work out the position of annotations based on their scene position.

This is a minimal change so that it maintains 2.x API and can be backported to 2.14 (and remove the stench of 72b53b980bf48a77e3fdce5dce9729af3698ca25 )

After this I'm planning on expanding this interface so that a few more annotation hacks can be removed and the dependancy that QgsComposerMap has on QgsMapCanvas can be killed, but that's not possible without breaking API.

So consider this a first step...
