### PR TITLE
Remove the extra QgsCoordinateTransform constructors

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -129,6 +129,9 @@ called if changes are made to the CRS database.</li>
 <ul>
 <li>QgsCoordinateTransform is no longer a QObject. readXml, writeXml and initialise are all normal public members now,
 not slots. The invalidTransformInput() signal has been removed.</li>
+<li>The extra QgsCoordinateTransform constructors (those not taking QgsCoordinateReferenceSystem arguments) have been
+removed. Now, QgsCoordinateTransform must be created using an already existing source and destination
+QgsCoordinateReferenceSystem object.</li>
 <li>QgsCoordinateTransform::clone() has been removed. Just use direct copies instead.</li>
 <li>sourceCrs() and destCrs() now return a copy instead of a reference to the CRS. This has no effect on PyQGIS code, but c++
 plugins calling these methods will need to be updated.</li>

--- a/python/core/qgscoordinatetransform.sip
+++ b/python/core/qgscoordinatetransform.sip
@@ -39,28 +39,6 @@ class QgsCoordinateTransform
     QgsCoordinateTransform( const QgsCoordinateReferenceSystem& source,
                             const QgsCoordinateReferenceSystem& destination );
 
-    /** Constructs a QgsCoordinateTransform using CRS ID of source and destination CRS */
-    QgsCoordinateTransform( long sourceSrsId, long destinationSrsId );
-
-    /*!
-     * Constructs a QgsCoordinateTransform using the Well Known Text representation
-     * of the layer and map canvas coordinate systems
-     * @param sourceWkt WKT, typically of the layer's coordinate system
-     * @param destinationWkt WKT, typically of the map canvas coordinate system
-     */
-    QgsCoordinateTransform( const QString& sourceWkt, const QString& destinationWkt );
-
-    /*!
-     * Constructs a QgsCoordinateTransform using a Spatial Reference Id
-     * of the layer and map canvas coordinate system as Wkt
-     * @param sourceSrid Spatial Ref Id of the layer's coordinate system
-     * @param destinationWkt Wkt of the map canvas coordinate system
-     * @param sourceCRSType On of the enum members defined in QgsCoordinateReferenceSystem::CrsType
-     */
-    QgsCoordinateTransform( long sourceSrid,
-                            const QString& destinationWkt,
-                            QgsCoordinateReferenceSystem::CrsType sourceCRSType = QgsCoordinateReferenceSystem::PostgisCrsId );
-
     /*!
      * Returns true if the coordinate transform is valid, ie both the source and destination
      * CRS have been set and are valid.

--- a/src/core/qgscoordinatetransform.cpp
+++ b/src/core/qgscoordinatetransform.cpp
@@ -50,29 +50,6 @@ QgsCoordinateTransform::QgsCoordinateTransform( const QgsCoordinateReferenceSyst
   d = new QgsCoordinateTransformPrivate( source, destination );
 }
 
-QgsCoordinateTransform::QgsCoordinateTransform( long sourceSrsId, long destinationSrsId )
-{
-  d = new QgsCoordinateTransformPrivate( QgsCoordinateReferenceSystem::fromSrsId( sourceSrsId ),
-                                         QgsCoordinateReferenceSystem::fromSrsId( destinationSrsId ) );
-}
-
-QgsCoordinateTransform::QgsCoordinateTransform( const QString& sourceWkt, const QString& destinationWkt )
-{
-  d = new QgsCoordinateTransformPrivate( QgsCoordinateReferenceSystem::fromWkt( sourceWkt ),
-                                         QgsCoordinateReferenceSystem::fromWkt( destinationWkt ) );
-}
-
-
-QgsCoordinateTransform::QgsCoordinateTransform( long sourceSrid,
-    const QString& destinationWkt,
-    QgsCoordinateReferenceSystem::CrsType sourceCrsType )
-{
-  QgsCoordinateReferenceSystem sourceCrs;
-  sourceCrs.createFromId( sourceSrid, sourceCrsType );
-
-  d = new QgsCoordinateTransformPrivate( sourceCrs, QgsCoordinateReferenceSystem::fromWkt( destinationWkt ) );
-}
-
 void QgsCoordinateTransform::setSourceCrs( const QgsCoordinateReferenceSystem& crs )
 {
   d.detach();

--- a/src/core/qgscoordinatetransform.h
+++ b/src/core/qgscoordinatetransform.h
@@ -62,29 +62,6 @@ class CORE_EXPORT QgsCoordinateTransform
     QgsCoordinateTransform( const QgsCoordinateReferenceSystem& source,
                             const QgsCoordinateReferenceSystem& destination );
 
-    /** Constructs a QgsCoordinateTransform using CRS ID of source and destination CRS */
-    QgsCoordinateTransform( long sourceSrsId, long destinationSrsId );
-
-    /*!
-     * Constructs a QgsCoordinateTransform using the Well Known Text representation
-     * of the layer and map canvas coordinate systems
-     * @param sourceWkt WKT, typically of the layer's coordinate system
-     * @param destinationWkt WKT, typically of the map canvas coordinate system
-     */
-    QgsCoordinateTransform( const QString& sourceWkt, const QString& destinationWkt );
-
-    /*!
-     * Constructs a QgsCoordinateTransform using a Spatial Reference Id
-     * of the layer and map canvas coordinate system as Wkt
-     * @param sourceSrid Spatial Ref Id of the layer's coordinate system
-     * @param destinationWkt Wkt of the map canvas coordinate system
-     * @param sourceCrsType On of the enum members defined in QgsCoordinateReferenceSystem::CrsType
-     */
-    QgsCoordinateTransform( long sourceSrid,
-                            const QString& destinationWkt,
-                            QgsCoordinateReferenceSystem::CrsType sourceCrsType = QgsCoordinateReferenceSystem::PostgisCrsId );
-
-
     /*!
      * Returns true if the coordinate transform is valid, ie both the source and destination
      * CRS have been set and are valid.


### PR DESCRIPTION
...and leave only:

QgsCoordinateTransform( const QgsCoordinateReferenceSystem& source,
                        const QgsCoordinateReferenceSystem& destination );

The other constructors were not used in QGIS code, had awkward/confusing API, and no unit tests. I think it makes sense to consolidate this class by removing all these unnecessary constructors.
