### PR TITLE
Raster MTR improvements - part one

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -339,6 +339,7 @@ be returned instead of a null pointer if no transformation is required.</li>
 <ul>
 <li>srcDataType() has been renamed to sourceDataType()</li>
 <li>srcInput() has been renamed to sourceInput()</li>
+<li>block() has new "feedback" argument.</li>
 </ul>
 
 \subsection qgis_api_break_3_0_QgsRelation QgsRelation

--- a/python/core/core.sip
+++ b/python/core/core.sip
@@ -53,6 +53,7 @@
 %Include qgsfeaturefilterprovider.sip
 %Include qgsfeatureiterator.sip
 %Include qgsfeaturerequest.sip
+%Include qgsfeedback.sip
 %Include qgsfield.sip
 %Include qgsgeometrysimplifier.sip
 %Include qgsgeometryvalidator.sip

--- a/python/core/qgsfeedback.sip
+++ b/python/core/qgsfeedback.sip
@@ -1,5 +1,6 @@
 
 /** \ingroup core
+ * @note added in QGIS 3.0
  * Base class for feedback objects to be used for cancellation of something running in a worker thread.
  *
  * The class may be used as is or it may be subclassed for extended functionality
@@ -17,7 +18,6 @@
  * subclass and available with QgsMapLayerRenderer::feedback() method. When a map rendering job
  * gets cancelled, the cancel() method is called on the feedback object of all layers.
  *
- * @note added in QGIS 3.0
  */
 class QgsFeedback : QObject
 {

--- a/python/core/qgsfeedback.sip
+++ b/python/core/qgsfeedback.sip
@@ -1,5 +1,6 @@
 
-/** Base class for feedback objects to be used for cancellation of something running in a worker thread.
+/** \ingroup core
+ * Base class for feedback objects to be used for cancellation of something running in a worker thread.
  *
  * The class may be used as is or it may be subclassed for extended functionality
  * for a particular operation (e.g. report progress or pass some data for preview).

--- a/python/core/qgsfeedback.sip
+++ b/python/core/qgsfeedback.sip
@@ -1,0 +1,43 @@
+
+/** Base class for feedback objects to be used for cancellation of something running in a worker thread.
+ *
+ * The class may be used as is or it may be subclassed for extended functionality
+ * for a particular operation (e.g. report progress or pass some data for preview).
+ *
+ * When cancel() is called, the internal code has two options to check for cancellation state:
+ * - if the worker thread uses an event loop (e.g. for network communication), the code can
+ *   make a queued connection to cancelled() signal and handle the cancellation in its slot.
+ * - if the worker thread does not use an event loop, it can poll isCancelled() method regularly
+ *   to see if the operation should be cancelled.
+ *
+ * The class is meant to be created and destroyed in the main thread.
+ *
+ * For map rendering, the object may be created in constructor of a QgsMapLayerRenderer
+ * subclass and available with QgsMapLayerRenderer::feedback() method. When a map rendering job
+ * gets cancelled, the cancel() method is called on the feedback object of all layers.
+ *
+ * @note added in QGIS 3.0
+ */
+class QgsFeedback : QObject
+{
+%TypeHeaderCode
+#include <qgsfeedback.h>
+%End
+
+  public:
+    //! Construct a feedback object
+    QgsFeedback( QObject* parent /TransferThis/ = nullptr );
+
+    virtual ~QgsFeedback();
+
+    //! Tells the internal routines that the current operation should be cancelled. This should be run by the main thread
+    void cancel();
+
+    //! Tells whether the operation has been cancelled already
+    bool isCancelled() const;
+
+  signals:
+    //! Internal routines can connect to this signal if they use event loop
+    void cancelled();
+
+};

--- a/python/core/qgsfeedback.sip
+++ b/python/core/qgsfeedback.sip
@@ -1,8 +1,6 @@
 
 /** \ingroup core
- * @note added in QGIS 3.0
  * Base class for feedback objects to be used for cancellation of something running in a worker thread.
- *
  * The class may be used as is or it may be subclassed for extended functionality
  * for a particular operation (e.g. report progress or pass some data for preview).
  *
@@ -18,6 +16,7 @@
  * subclass and available with QgsMapLayerRenderer::feedback() method. When a map rendering job
  * gets cancelled, the cancel() method is called on the feedback object of all layers.
  *
+ * @note added in QGIS 3.0
  */
 class QgsFeedback : QObject
 {

--- a/python/core/qgsmaplayerrenderer.sip
+++ b/python/core/qgsmaplayerrenderer.sip
@@ -12,6 +12,10 @@ class QgsMapLayerRenderer
     //! Do the rendering (based on data stored in the class)
     virtual bool render() = 0;
 
+    //! Access to feedback object of the layer renderer (may be null)
+    //! @note added in QGIS 3.0
+    virtual QgsFeedback* feedback() const;
+
     //! Return list of errors (problems) that happened during the rendering
     QStringList errors() const;
 

--- a/python/core/raster/qgsbrightnesscontrastfilter.sip
+++ b/python/core/raster/qgsbrightnesscontrastfilter.sip
@@ -15,7 +15,7 @@ class QgsBrightnessContrastFilter : QgsRasterInterface
 
     bool setInput( QgsRasterInterface* input );
 
-    QgsRasterBlock *block( int bandNo, const QgsRectangle &extent, int width, int height );
+    QgsRasterBlock *block( int bandNo, const QgsRectangle &extent, int width, int height, QgsRasterBlockFeedback* feedback = nullptr ) /Factory/;
 
     void setBrightness( int brightness );
     int brightness() const;

--- a/python/core/raster/qgshillshaderenderer.sip
+++ b/python/core/raster/qgshillshaderenderer.sip
@@ -31,7 +31,7 @@ class QgsHillshadeRenderer : QgsRasterRenderer
      */
     static QgsRasterRenderer* create( const QDomElement& elem, QgsRasterInterface* input ) /Factory/;
 
-    QgsRasterBlock *block( int bandNo, const QgsRectangle & extent, int width, int height ) /Factory/;
+    QgsRasterBlock *block( int bandNo, const QgsRectangle & extent, int width, int height, QgsRasterBlockFeedback* feedback = nullptr ) /Factory/;
 
     void writeXml( QDomDocument& doc, QDomElement& parentElem ) const;
 

--- a/python/core/raster/qgshuesaturationfilter.sip
+++ b/python/core/raster/qgshuesaturationfilter.sip
@@ -25,7 +25,7 @@ class QgsHueSaturationFilter : QgsRasterInterface
 
     bool setInput( QgsRasterInterface* input );
 
-    QgsRasterBlock *block( int bandNo, const QgsRectangle &extent, int width, int height );
+    QgsRasterBlock *block( int bandNo, const QgsRectangle &extent, int width, int height, QgsRasterBlockFeedback* feedback = nullptr ) /Factory/;
 
     void setSaturation( int saturation );
     int saturation() const;

--- a/python/core/raster/qgsmultibandcolorrenderer.sip
+++ b/python/core/raster/qgsmultibandcolorrenderer.sip
@@ -12,7 +12,7 @@ class QgsMultiBandColorRenderer: QgsRasterRenderer
 
     static QgsRasterRenderer* create( const QDomElement& elem, QgsRasterDataProvider* provider ) /Factory/;
 
-    QgsRasterBlock* block( int bandNo, const QgsRectangle & extent, int width, int height ) /Factory/;
+    QgsRasterBlock* block( int bandNo, const QgsRectangle & extent, int width, int height, QgsRasterBlockFeedback* feedback = nullptr ) /Factory/;
 
     int redBand() const;
     void setRedBand( int band );

--- a/python/core/raster/qgspalettedrasterrenderer.sip
+++ b/python/core/raster/qgspalettedrasterrenderer.sip
@@ -10,7 +10,7 @@ class QgsPalettedRasterRenderer : QgsRasterRenderer
     virtual QgsPalettedRasterRenderer * clone() const /Factory/;
     static QgsRasterRenderer* create( const QDomElement& elem, QgsRasterInterface* input ) /Factory/;
 
-    QgsRasterBlock *block( int bandNo, const QgsRectangle & extent, int width, int height ) /Factory/;
+    QgsRasterBlock *block( int bandNo, const QgsRectangle & extent, int width, int height, QgsRasterBlockFeedback* feedback = nullptr ) /Factory/;
 
     /** Returns number of colors*/
     int nColors() const;

--- a/python/core/raster/qgsrasterdataprovider.sip
+++ b/python/core/raster/qgsrasterdataprovider.sip
@@ -102,7 +102,7 @@ class QgsRasterDataProvider : QgsDataProvider, QgsRasterInterface
     virtual int ySize() const;
 
     /** Read block of data using given extent and size. */
-    virtual QgsRasterBlock *block( int theBandNo, const QgsRectangle &theExtent, int theWidth, int theHeight ) / Factory /;
+    virtual QgsRasterBlock *block( int theBandNo, const QgsRectangle &theExtent, int theWidth, int theHeight, QgsRasterBlockFeedback* feedback = nullptr ) / Factory /;
 
     /** Return true if source band has no data value */
     virtual bool sourceHasNoDataValue( int bandNo ) const;
@@ -306,7 +306,7 @@ class QgsRasterDataProvider : QgsDataProvider, QgsRasterInterface
     /** Read block of data using give extent and size
      * @note not available in python bindings
      */
-    //virtual void readBlock( int bandNo, QgsRectangle  const & viewExtent, int width, int height, void *data );
+    //virtual void readBlock( int bandNo, QgsRectangle  const & viewExtent, int width, int height, void *data, QgsRasterBlockFeedback* feedback = nullptr );
 
     /** Returns true if user no data contains value */
     bool userNoDataValuesContains( int bandNo, double value ) const;

--- a/python/core/raster/qgsrasterdrawer.sip
+++ b/python/core/raster/qgsrasterdrawer.sip
@@ -13,9 +13,9 @@ class QgsRasterDrawer
      * @param p destination QPainter
      * @param viewPort viewport to render
      * @param theQgsMapToPixel map to pixel convertor
-     * @param ctx render context
+     * @param feedback optional raster feedback object for cancellation/preview. Added in QGIS 3.0.
      */
-    void draw( QPainter* p, QgsRasterViewPort* viewPort, const QgsMapToPixel* theQgsMapToPixel, const QgsRenderContext *ctx = nullptr );
+    void draw( QPainter* p, QgsRasterViewPort* viewPort, const QgsMapToPixel* theQgsMapToPixel, QgsRasterBlockFeedback* feedback = nullptr );
 
   protected:
     /** Draws raster part

--- a/python/core/raster/qgsrasterinterface.sip
+++ b/python/core/raster/qgsrasterinterface.sip
@@ -1,6 +1,8 @@
 
 /** \ingroup core
  * Feedback object tailored for raster block reading.
+ *
+ * @note added in QGIS 3.0
  */
 class QgsRasterBlockFeedback : QgsFeedback
 {

--- a/python/core/raster/qgsrasterinterface.sip
+++ b/python/core/raster/qgsrasterinterface.sip
@@ -1,11 +1,13 @@
 
-/** Feedback object tailored for raster block reading. */
+/** \ingroup core
+ * Feedback object tailored for raster block reading.
+ */
 class QgsRasterBlockFeedback : QgsFeedback
 {
 %TypeHeaderCode
 #include <qgsrasterinterface.h>
 %End
-  // TODO: extend with preview functionality??
+    // TODO: extend with preview functionality??
 };
 
 

--- a/python/core/raster/qgsrasterinterface.sip
+++ b/python/core/raster/qgsrasterinterface.sip
@@ -1,4 +1,14 @@
 
+/** Feedback object tailored for raster block reading. */
+class QgsRasterBlockFeedback : QgsFeedback
+{
+%TypeHeaderCode
+#include <qgsrasterinterface.h>
+%End
+  // TODO: extend with preview functionality??
+};
+
+
 /** Base class for processing modules.
  *
  */
@@ -129,8 +139,9 @@ class QgsRasterInterface
      * @param extent extent of block
      * @param width pixel width of block
      * @param height pixel height of block
+     * @param feedback optional raster feedback object for cancellation/preview. Added in QGIS 3.0.
      */
-    virtual QgsRasterBlock *block( int bandNo, const QgsRectangle &extent, int width, int height ) = 0 /Factory/;
+    virtual QgsRasterBlock *block( int bandNo, const QgsRectangle &extent, int width, int height, QgsRasterBlockFeedback* feedback = nullptr ) = 0 /Factory/;
 
     /** Set input.
       * Returns true if set correctly, false if cannot use that input */

--- a/python/core/raster/qgsrasteriterator.sip
+++ b/python/core/raster/qgsrasteriterator.sip
@@ -12,8 +12,9 @@ class QgsRasterIterator
       @param nCols number of columns
       @param nRows number of rows
       @param extent area to read
+      @param feedback optional raster feedback object for cancellation/preview. Added in QGIS 3.0.
      */
-    void startRasterRead( int bandNumber, int nCols, int nRows, const QgsRectangle& extent );
+    void startRasterRead( int bandNumber, int nCols, int nRows, const QgsRectangle& extent, QgsRasterBlockFeedback* feedback = nullptr );
 
     /** Fetches next part of raster data, caller takes ownership of the block and
        caller should delete the block.

--- a/python/core/raster/qgsrasternuller.sip
+++ b/python/core/raster/qgsrasternuller.sip
@@ -19,7 +19,7 @@ class QgsRasterNuller : QgsRasterInterface
 
     Qgis::DataType dataType( int bandNo ) const;
 
-    QgsRasterBlock *block( int bandNo, const QgsRectangle &extent, int width, int height ) / Factory /;
+    QgsRasterBlock *block( int bandNo, const QgsRectangle &extent, int width, int height, QgsRasterBlockFeedback* feedback = nullptr ) / Factory /;
 
     void setNoData( int bandNo, const QgsRasterRangeList& noData );
 

--- a/python/core/raster/qgsrasterprojector.sip
+++ b/python/core/raster/qgsrasterprojector.sip
@@ -74,7 +74,7 @@ class QgsRasterProjector : QgsRasterInterface
     // Translated precision mode, for use in ComboBox etc.
     static QString precisionLabel( Precision precision );
 
-    QgsRasterBlock *block( int bandNo, const QgsRectangle & extent, int width, int height ) / Factory /;
+    QgsRasterBlock *block( int bandNo, const QgsRectangle & extent, int width, int height, QgsRasterBlockFeedback* feedback = nullptr ) / Factory /;
 
     /** Calculate destination extent and size from source extent and size */
     bool destExtentSize( const QgsRectangle& theSrcExtent, int theSrcXSize, int theSrcYSize,

--- a/python/core/raster/qgsrasterrenderer.sip
+++ b/python/core/raster/qgsrasterrenderer.sip
@@ -38,7 +38,7 @@ class QgsRasterRenderer : QgsRasterInterface
 
     virtual bool setInput( QgsRasterInterface* input );
 
-    virtual QgsRasterBlock *block( int bandNo, const QgsRectangle &extent, int width, int height ) = 0 / Factory /;
+    virtual QgsRasterBlock *block( int bandNo, const QgsRectangle &extent, int width, int height, QgsRasterBlockFeedback* feedback = nullptr ) = 0 / Factory /;
 
     bool usesTransparency() const;
 

--- a/python/core/raster/qgsrasterresamplefilter.sip
+++ b/python/core/raster/qgsrasterresamplefilter.sip
@@ -19,7 +19,7 @@ class QgsRasterResampleFilter : QgsRasterInterface
 
     bool setInput( QgsRasterInterface* input );
 
-    QgsRasterBlock *block( int bandNo, const QgsRectangle &extent, int width, int height ) /Factory/;
+    QgsRasterBlock *block( int bandNo, const QgsRectangle &extent, int width, int height, QgsRasterBlockFeedback* feedback = nullptr ) /Factory/;
 
     /** Set resampler for zoomed in scales. Takes ownership of the object*/
     void setZoomedInResampler( QgsRasterResampler* r /Transfer/ );

--- a/python/core/raster/qgssinglebandcolordatarenderer.sip
+++ b/python/core/raster/qgssinglebandcolordatarenderer.sip
@@ -12,7 +12,7 @@ class QgsSingleBandColorDataRenderer: QgsRasterRenderer
 
     bool setInput( QgsRasterInterface* input );
 
-    QgsRasterBlock* block( int bandNo, const QgsRectangle & extent, int width, int height ) / Factory /;
+    QgsRasterBlock* block( int bandNo, const QgsRectangle & extent, int width, int height, QgsRasterBlockFeedback* feedback = nullptr ) / Factory /;
 
     void writeXml( QDomDocument& doc, QDomElement& parentElem ) const;
 

--- a/python/core/raster/qgssinglebandgrayrenderer.sip
+++ b/python/core/raster/qgssinglebandgrayrenderer.sip
@@ -16,7 +16,7 @@ class QgsSingleBandGrayRenderer: QgsRasterRenderer
 
     static QgsRasterRenderer* create( const QDomElement& elem, QgsRasterDataProvider* provider ) /Factory/;
 
-    QgsRasterBlock *block( int bandNo, const QgsRectangle & extent, int width, int height ) / Factory /;
+    QgsRasterBlock *block( int bandNo, const QgsRectangle & extent, int width, int height, QgsRasterBlockFeedback* feedback = nullptr ) / Factory /;
 
     int grayBand() const;
     void setGrayBand( int band );

--- a/python/core/raster/qgssinglebandpseudocolorrenderer.sip
+++ b/python/core/raster/qgssinglebandpseudocolorrenderer.sip
@@ -11,7 +11,7 @@ class QgsSingleBandPseudoColorRenderer: QgsRasterRenderer
 
     static QgsRasterRenderer* create( const QDomElement& elem, QgsRasterDataProvider* provider ) /Factory/;
 
-    QgsRasterBlock* block( int bandNo, const QgsRectangle & extent, int width, int height ) / Factory /;
+    QgsRasterBlock* block( int bandNo, const QgsRectangle & extent, int width, int height, QgsRasterBlockFeedback* feedback = nullptr ) / Factory /;
 
     /** Takes ownership of the shader*/
     void setShader( QgsRasterShader* shader /Transfer/ );

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -457,6 +457,7 @@ SET(QGIS_CORE_MOC_HDRS
   qgsdataprovider.h
   qgsdbfilterproxymodel.h
   qgseditformconfig.h
+  qgsfeedback.h
   qgsgeometryvalidator.h
   qgsgml.h
   qgsgmlschema.h

--- a/src/core/qgsfeedback.h
+++ b/src/core/qgsfeedback.h
@@ -1,0 +1,73 @@
+/***************************************************************************
+  qgsfeedback.h
+  --------------------------------------
+  Date                 : July 2016
+  Copyright            : (C) 2016 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSFEEDBACK_H
+#define QGSFEEDBACK_H
+
+#include <QObject>
+
+/** Base class for feedback objects to be used for cancellation of something running in a worker thread.
+ *
+ * The class may be used as is or it may be subclassed for extended functionality
+ * for a particular operation (e.g. report progress or pass some data for preview).
+ *
+ * When cancel() is called, the internal code has two options to check for cancellation state:
+ * - if the worker thread uses an event loop (e.g. for network communication), the code can
+ *   make a queued connection to cancelled() signal and handle the cancellation in its slot.
+ * - if the worker thread does not use an event loop, it can poll isCancelled() method regularly
+ *   to see if the operation should be cancelled.
+ *
+ * The class is meant to be created and destroyed in the main thread.
+ *
+ * For map rendering, the object may be created in constructor of a QgsMapLayerRenderer
+ * subclass and available with QgsMapLayerRenderer::feedback() method. When a map rendering job
+ * gets cancelled, the cancel() method is called on the feedback object of all layers.
+ *
+ * @note added in QGIS 3.0
+ */
+class CORE_EXPORT QgsFeedback : public QObject
+{
+    Q_OBJECT
+  public:
+    //! Construct a feedback object
+    QgsFeedback( QObject* parent = nullptr )
+        : QObject( parent )
+        , mCancelled( false )
+    {}
+
+    virtual ~QgsFeedback() {}
+
+    //! Tells the internal routines that the current operation should be cancelled. This should be run by the main thread
+    void cancel()
+    {
+      if ( mCancelled )
+        return;  // only emit the signal once
+      mCancelled = true;
+      emit cancelled();
+    }
+
+    //! Tells whether the operation has been cancelled already
+    bool isCancelled() const { return mCancelled; }
+
+  signals:
+    //! Internal routines can connect to this signal if they use event loop
+    void cancelled();
+
+  private:
+    //! Whether the operation has been cancelled already. False by default.
+    bool mCancelled;
+};
+
+#endif // QGSFEEDBACK_H

--- a/src/core/qgsfeedback.h
+++ b/src/core/qgsfeedback.h
@@ -18,7 +18,8 @@
 
 #include <QObject>
 
-/** Base class for feedback objects to be used for cancellation of something running in a worker thread.
+/** \ingroup core
+ * Base class for feedback objects to be used for cancellation of something running in a worker thread.
  *
  * The class may be used as is or it may be subclassed for extended functionality
  * for a particular operation (e.g. report progress or pass some data for preview).

--- a/src/core/qgsfeedback.h
+++ b/src/core/qgsfeedback.h
@@ -19,6 +19,7 @@
 #include <QObject>
 
 /** \ingroup core
+ * @note added in QGIS 3.0
  * Base class for feedback objects to be used for cancellation of something running in a worker thread.
  *
  * The class may be used as is or it may be subclassed for extended functionality
@@ -36,7 +37,6 @@
  * subclass and available with QgsMapLayerRenderer::feedback() method. When a map rendering job
  * gets cancelled, the cancel() method is called on the feedback object of all layers.
  *
- * @note added in QGIS 3.0
  */
 class CORE_EXPORT QgsFeedback : public QObject
 {

--- a/src/core/qgsfeedback.h
+++ b/src/core/qgsfeedback.h
@@ -19,9 +19,7 @@
 #include <QObject>
 
 /** \ingroup core
- * @note added in QGIS 3.0
  * Base class for feedback objects to be used for cancellation of something running in a worker thread.
- *
  * The class may be used as is or it may be subclassed for extended functionality
  * for a particular operation (e.g. report progress or pass some data for preview).
  *
@@ -37,6 +35,7 @@
  * subclass and available with QgsMapLayerRenderer::feedback() method. When a map rendering job
  * gets cancelled, the cancel() method is called on the feedback object of all layers.
  *
+ * @note added in QGIS 3.0
  */
 class CORE_EXPORT QgsFeedback : public QObject
 {

--- a/src/core/qgsmaplayerrenderer.h
+++ b/src/core/qgsmaplayerrenderer.h
@@ -18,6 +18,8 @@
 
 #include <QStringList>
 
+class QgsFeedback;
+
 /** \ingroup core
  * Base class for utility classes that encapsulate information necessary
  * for rendering of map layers. The rendering is typically done in a background
@@ -48,6 +50,10 @@ class CORE_EXPORT QgsMapLayerRenderer
 
     //! Do the rendering (based on data stored in the class)
     virtual bool render() = 0;
+
+    //! Access to feedback object of the layer renderer (may be null)
+    //! @note added in QGIS 3.0
+    virtual QgsFeedback* feedback() const { return nullptr; }
 
     //! Return list of errors (problems) that happened during the rendering
     QStringList errors() const { return mErrors; }

--- a/src/core/qgsmaprenderercustompainterjob.cpp
+++ b/src/core/qgsmaprenderercustompainterjob.cpp
@@ -15,6 +15,7 @@
 
 #include "qgsmaprenderercustompainterjob.h"
 
+#include "qgsfeedback.h"
 #include "qgslabelingenginev2.h"
 #include "qgslogger.h"
 #include "qgsmaplayerregistry.h"
@@ -124,6 +125,8 @@ void QgsMapRendererCustomPainterJob::cancel()
   for ( LayerRenderJobs::iterator it = mLayerJobs.begin(); it != mLayerJobs.end(); ++it )
   {
     it->context.setRenderingStopped( true );
+    if ( it->renderer->feedback() )
+      it->renderer->feedback()->cancel();
   }
 
   QTime t;

--- a/src/core/qgsmaprendererparalleljob.cpp
+++ b/src/core/qgsmaprendererparalleljob.cpp
@@ -15,6 +15,7 @@
 
 #include "qgsmaprendererparalleljob.h"
 
+#include "qgsfeedback.h"
 #include "qgslabelingenginev2.h"
 #include "qgslogger.h"
 #include "qgsmaplayerrenderer.h"
@@ -91,6 +92,8 @@ void QgsMapRendererParallelJob::cancel()
   for ( LayerRenderJobs::iterator it = mLayerJobs.begin(); it != mLayerJobs.end(); ++it )
   {
     it->context.setRenderingStopped( true );
+    if ( it->renderer->feedback() )
+      it->renderer->feedback()->cancel();
   }
 
   if ( mStatus == RenderingLayers )

--- a/src/core/raster/qgsbrightnesscontrastfilter.cpp
+++ b/src/core/raster/qgsbrightnesscontrastfilter.cpp
@@ -109,7 +109,7 @@ bool QgsBrightnessContrastFilter::setInput( QgsRasterInterface* input )
   return true;
 }
 
-QgsRasterBlock * QgsBrightnessContrastFilter::block( int bandNo, QgsRectangle  const & extent, int width, int height )
+QgsRasterBlock * QgsBrightnessContrastFilter::block( int bandNo, QgsRectangle  const & extent, int width, int height, QgsRasterBlockFeedback* feedback )
 {
   Q_UNUSED( bandNo );
   QgsDebugMsgLevel( QString( "width = %1 height = %2 extent = %3" ).arg( width ).arg( height ).arg( extent.toString() ), 4 );
@@ -122,7 +122,7 @@ QgsRasterBlock * QgsBrightnessContrastFilter::block( int bandNo, QgsRectangle  c
 
   // At this moment we know that we read rendered image
   int bandNumber = 1;
-  QgsRasterBlock *inputBlock = mInput->block( bandNumber, extent, width, height );
+  QgsRasterBlock *inputBlock = mInput->block( bandNumber, extent, width, height, feedback );
   if ( !inputBlock || inputBlock->isEmpty() )
   {
     QgsDebugMsg( "No raster data!" );

--- a/src/core/raster/qgsbrightnesscontrastfilter.h
+++ b/src/core/raster/qgsbrightnesscontrastfilter.h
@@ -39,7 +39,7 @@ class CORE_EXPORT QgsBrightnessContrastFilter : public QgsRasterInterface
 
     bool setInput( QgsRasterInterface* input ) override;
 
-    QgsRasterBlock *block( int bandNo, const QgsRectangle &extent, int width, int height ) override;
+    QgsRasterBlock *block( int bandNo, const QgsRectangle &extent, int width, int height, QgsRasterBlockFeedback* feedback = nullptr ) override;
 
     void setBrightness( int brightness ) { mBrightness = qBound( -255, brightness, 255 ); }
     int brightness() const { return mBrightness; }

--- a/src/core/raster/qgshillshaderenderer.cpp
+++ b/src/core/raster/qgshillshaderenderer.cpp
@@ -83,7 +83,7 @@ void QgsHillshadeRenderer::writeXml( QDomDocument &doc, QDomElement &parentElem 
   parentElem.appendChild( rasterRendererElem );
 }
 
-QgsRasterBlock *QgsHillshadeRenderer::block( int bandNo, const QgsRectangle &extent, int width, int height )
+QgsRasterBlock *QgsHillshadeRenderer::block( int bandNo, const QgsRectangle &extent, int width, int height, QgsRasterBlockFeedback* feedback )
 {
   Q_UNUSED( bandNo );
   QgsRasterBlock *outputBlock = new QgsRasterBlock();
@@ -93,7 +93,7 @@ QgsRasterBlock *QgsHillshadeRenderer::block( int bandNo, const QgsRectangle &ext
     return outputBlock;
   }
 
-  QgsRasterBlock *inputBlock = mInput->block( mBand, extent, width, height );
+  QgsRasterBlock *inputBlock = mInput->block( mBand, extent, width, height, feedback );
 
   if ( !inputBlock || inputBlock->isEmpty() )
   {
@@ -107,7 +107,7 @@ QgsRasterBlock *QgsHillshadeRenderer::block( int bandNo, const QgsRectangle &ext
   if ( mAlphaBand > 0 && mBand != mAlphaBand )
   {
 
-    alphaBlock = mInput->block( mAlphaBand, extent, width, height );
+    alphaBlock = mInput->block( mAlphaBand, extent, width, height, feedback );
     if ( !alphaBlock || alphaBlock->isEmpty() )
     {
       // TODO: better to render without alpha

--- a/src/core/raster/qgshillshaderenderer.h
+++ b/src/core/raster/qgshillshaderenderer.h
@@ -55,7 +55,7 @@ class CORE_EXPORT QgsHillshadeRenderer : public QgsRasterRenderer
 
     void writeXml( QDomDocument& doc, QDomElement& parentElem ) const override;
 
-    QgsRasterBlock *block( int bandNo, QgsRectangle  const & extent, int width, int height ) override;
+    QgsRasterBlock *block( int bandNo, QgsRectangle  const & extent, int width, int height, QgsRasterBlockFeedback* feedback = nullptr ) override;
 
     QList<int> usesBands() const override;
 

--- a/src/core/raster/qgshuesaturationfilter.cpp
+++ b/src/core/raster/qgshuesaturationfilter.cpp
@@ -118,7 +118,7 @@ bool QgsHueSaturationFilter::setInput( QgsRasterInterface* input )
   return true;
 }
 
-QgsRasterBlock * QgsHueSaturationFilter::block( int bandNo, QgsRectangle  const & extent, int width, int height )
+QgsRasterBlock * QgsHueSaturationFilter::block( int bandNo, QgsRectangle  const & extent, int width, int height, QgsRasterBlockFeedback* feedback )
 {
   Q_UNUSED( bandNo );
   QgsDebugMsgLevel( QString( "width = %1 height = %2 extent = %3" ).arg( width ).arg( height ).arg( extent.toString() ), 4 );
@@ -131,7 +131,7 @@ QgsRasterBlock * QgsHueSaturationFilter::block( int bandNo, QgsRectangle  const 
 
   // At this moment we know that we read rendered image
   int bandNumber = 1;
-  QgsRasterBlock *inputBlock = mInput->block( bandNumber, extent, width, height );
+  QgsRasterBlock *inputBlock = mInput->block( bandNumber, extent, width, height, feedback );
   if ( !inputBlock || inputBlock->isEmpty() )
   {
     QgsDebugMsg( "No raster data!" );

--- a/src/core/raster/qgshuesaturationfilter.h
+++ b/src/core/raster/qgshuesaturationfilter.h
@@ -49,7 +49,7 @@ class CORE_EXPORT QgsHueSaturationFilter : public QgsRasterInterface
 
     bool setInput( QgsRasterInterface* input ) override;
 
-    QgsRasterBlock *block( int bandNo, const QgsRectangle &extent, int width, int height ) override;
+    QgsRasterBlock *block( int bandNo, const QgsRectangle &extent, int width, int height, QgsRasterBlockFeedback* feedback = nullptr ) override;
 
     void setSaturation( int saturation );
     int saturation() const { return mSaturation; }

--- a/src/core/raster/qgsmultibandcolorrenderer.cpp
+++ b/src/core/raster/qgsmultibandcolorrenderer.cpp
@@ -130,7 +130,7 @@ QgsRasterRenderer* QgsMultiBandColorRenderer::create( const QDomElement& elem, Q
   return r;
 }
 
-QgsRasterBlock* QgsMultiBandColorRenderer::block( int bandNo, QgsRectangle  const & extent, int width, int height )
+QgsRasterBlock* QgsMultiBandColorRenderer::block( int bandNo, QgsRectangle  const & extent, int width, int height, QgsRasterBlockFeedback* feedback )
 {
   Q_UNUSED( bandNo );
   QgsRasterBlock *outputBlock = new QgsRasterBlock();
@@ -185,7 +185,7 @@ QgsRasterBlock* QgsMultiBandColorRenderer::block( int bandNo, QgsRectangle  cons
   bandIt = bands.constBegin();
   for ( ; bandIt != bands.constEnd(); ++bandIt )
   {
-    bandBlocks[*bandIt] =  mInput->block( *bandIt, extent, width, height );
+    bandBlocks[*bandIt] =  mInput->block( *bandIt, extent, width, height, feedback );
     if ( !bandBlocks[*bandIt] )
     {
       // We should free the alloced mem from block().

--- a/src/core/raster/qgsmultibandcolorrenderer.h
+++ b/src/core/raster/qgsmultibandcolorrenderer.h
@@ -37,7 +37,7 @@ class CORE_EXPORT QgsMultiBandColorRenderer: public QgsRasterRenderer
 
     static QgsRasterRenderer* create( const QDomElement& elem, QgsRasterInterface* input );
 
-    QgsRasterBlock* block( int bandNo, const QgsRectangle & extent, int width, int height ) override;
+    QgsRasterBlock* block( int bandNo, const QgsRectangle & extent, int width, int height, QgsRasterBlockFeedback* feedback = nullptr ) override;
 
     int redBand() const { return mRedBand; }
     void setRedBand( int band ) { mRedBand = band; }

--- a/src/core/raster/qgspalettedrasterrenderer.cpp
+++ b/src/core/raster/qgspalettedrasterrenderer.cpp
@@ -151,7 +151,7 @@ void QgsPalettedRasterRenderer::setLabel( int idx, const QString& label )
   mLabels[idx] = label;
 }
 
-QgsRasterBlock * QgsPalettedRasterRenderer::block( int bandNo, QgsRectangle  const & extent, int width, int height )
+QgsRasterBlock * QgsPalettedRasterRenderer::block( int bandNo, QgsRectangle  const & extent, int width, int height, QgsRasterBlockFeedback* feedback )
 {
   QgsRasterBlock *outputBlock = new QgsRasterBlock();
   if ( !mInput || mNColors == 0 )
@@ -159,7 +159,7 @@ QgsRasterBlock * QgsPalettedRasterRenderer::block( int bandNo, QgsRectangle  con
     return outputBlock;
   }
 
-  QgsRasterBlock *inputBlock = mInput->block( bandNo, extent, width, height );
+  QgsRasterBlock *inputBlock = mInput->block( bandNo, extent, width, height, feedback );
 
   if ( !inputBlock || inputBlock->isEmpty() )
   {
@@ -176,7 +176,7 @@ QgsRasterBlock * QgsPalettedRasterRenderer::block( int bandNo, QgsRectangle  con
 
   if ( mAlphaBand > 0 && mAlphaBand != mBand )
   {
-    alphaBlock = mInput->block( mAlphaBand, extent, width, height );
+    alphaBlock = mInput->block( mAlphaBand, extent, width, height, feedback );
     if ( !alphaBlock || alphaBlock->isEmpty() )
     {
       delete inputBlock;

--- a/src/core/raster/qgspalettedrasterrenderer.h
+++ b/src/core/raster/qgspalettedrasterrenderer.h
@@ -38,7 +38,7 @@ class CORE_EXPORT QgsPalettedRasterRenderer: public QgsRasterRenderer
     QgsPalettedRasterRenderer * clone() const override;
     static QgsRasterRenderer* create( const QDomElement& elem, QgsRasterInterface* input );
 
-    QgsRasterBlock *block( int bandNo, const QgsRectangle & extent, int width, int height ) override;
+    QgsRasterBlock *block( int bandNo, const QgsRectangle & extent, int width, int height, QgsRasterBlockFeedback* feedback = nullptr ) override;
 
     /** Returns number of colors*/
     int nColors() const { return mNColors; }

--- a/src/core/raster/qgsrasterdataprovider.cpp
+++ b/src/core/raster/qgsrasterdataprovider.cpp
@@ -42,7 +42,7 @@ void QgsRasterDataProvider::setUseSourceNoDataValue( int bandNo, bool use )
   mUseSrcNoDataValue[bandNo-1] = use;
 }
 
-QgsRasterBlock * QgsRasterDataProvider::block( int theBandNo, QgsRectangle  const & theExtent, int theWidth, int theHeight )
+QgsRasterBlock * QgsRasterDataProvider::block( int theBandNo, QgsRectangle  const & theExtent, int theWidth, int theHeight, QgsRasterBlockFeedback* feedback )
 {
   QgsDebugMsgLevel( QString( "theBandNo = %1 theWidth = %2 theHeight = %3" ).arg( theBandNo ).arg( theWidth ).arg( theHeight ), 4 );
   QgsDebugMsgLevel( QString( "theExtent = %1" ).arg( theExtent.toString() ), 4 );
@@ -154,7 +154,7 @@ QgsRasterBlock * QgsRasterDataProvider::block( int theBandNo, QgsRectangle  cons
       tmpBlock = new QgsRasterBlock( dataType( theBandNo ), tmpWidth, tmpHeight );
     }
 
-    readBlock( theBandNo, tmpExtent, tmpWidth, tmpHeight, tmpBlock->bits() );
+    readBlock( theBandNo, tmpExtent, tmpWidth, tmpHeight, tmpBlock->bits(), feedback );
 
     int pixelSize = dataTypeSize( theBandNo );
 
@@ -204,7 +204,7 @@ QgsRasterBlock * QgsRasterDataProvider::block( int theBandNo, QgsRectangle  cons
   }
   else
   {
-    readBlock( theBandNo, theExtent, theWidth, theHeight, block->bits() );
+    readBlock( theBandNo, theExtent, theWidth, theHeight, block->bits(), feedback );
   }
 
   // apply scale and offset

--- a/src/core/raster/qgsrasterdataprovider.h
+++ b/src/core/raster/qgsrasterdataprovider.h
@@ -199,7 +199,7 @@ class CORE_EXPORT QgsRasterDataProvider : public QgsDataProvider, public QgsRast
     // TODO: remove or make protected all readBlock working with void*
 
     /** Read block of data using given extent and size. */
-    virtual QgsRasterBlock *block( int theBandNo, const QgsRectangle &theExtent, int theWidth, int theHeight ) override;
+    virtual QgsRasterBlock *block( int theBandNo, const QgsRectangle &theExtent, int theWidth, int theHeight, QgsRasterBlockFeedback* feedback = nullptr ) override;
 
     /** Return true if source band has no data value */
     virtual bool sourceHasNoDataValue( int bandNo ) const { return mSrcHasNoDataValue.value( bandNo -1 ); }
@@ -437,8 +437,8 @@ class CORE_EXPORT QgsRasterDataProvider : public QgsDataProvider, public QgsRast
     /** Read block of data using give extent and size
      * @note not available in python bindings
      */
-    virtual void readBlock( int bandNo, QgsRectangle  const & viewExtent, int width, int height, void *data )
-    { Q_UNUSED( bandNo ); Q_UNUSED( viewExtent ); Q_UNUSED( width ); Q_UNUSED( height ); Q_UNUSED( data ); }
+    virtual void readBlock( int bandNo, QgsRectangle  const & viewExtent, int width, int height, void *data, QgsRasterBlockFeedback* feedback = nullptr )
+    { Q_UNUSED( bandNo ); Q_UNUSED( viewExtent ); Q_UNUSED( width ); Q_UNUSED( height ); Q_UNUSED( data ); Q_UNUSED( feedback ); }
 
     /** Returns true if user no data contains value */
     bool userNoDataValuesContains( int bandNo, double value ) const;

--- a/src/core/raster/qgsrasterdrawer.cpp
+++ b/src/core/raster/qgsrasterdrawer.cpp
@@ -18,6 +18,7 @@
 #include "qgslogger.h"
 #include "qgsrasterblock.h"
 #include "qgsrasterdrawer.h"
+#include "qgsrasterinterface.h"
 #include "qgsrasteriterator.h"
 #include "qgsrasterviewport.h"
 #include "qgsmaptopixel.h"
@@ -30,7 +31,7 @@ QgsRasterDrawer::QgsRasterDrawer( QgsRasterIterator* iterator ): mIterator( iter
 {
 }
 
-void QgsRasterDrawer::draw( QPainter* p, QgsRasterViewPort* viewPort, const QgsMapToPixel* theQgsMapToPixel, const QgsRenderContext* ctx )
+void QgsRasterDrawer::draw( QPainter* p, QgsRasterViewPort* viewPort, const QgsMapToPixel* theQgsMapToPixel, QgsRasterBlockFeedback* feedback )
 {
   QgsDebugMsgLevel( "Entered", 4 );
   if ( !p || !mIterator || !viewPort || !theQgsMapToPixel )
@@ -40,7 +41,7 @@ void QgsRasterDrawer::draw( QPainter* p, QgsRasterViewPort* viewPort, const QgsM
 
   // last pipe filter has only 1 band
   int bandNumber = 1;
-  mIterator->startRasterRead( bandNumber, viewPort->mWidth, viewPort->mHeight, viewPort->mDrawnExtent );
+  mIterator->startRasterRead( bandNumber, viewPort->mWidth, viewPort->mHeight, viewPort->mDrawnExtent, feedback );
 
   //number of cols/rows in output pixels
   int nCols = 0;
@@ -90,7 +91,10 @@ void QgsRasterDrawer::draw( QPainter* p, QgsRasterViewPort* viewPort, const QgsM
     drawImage( p, viewPort, img, topLeftCol, topLeftRow, theQgsMapToPixel );
 
     delete block;
-    if ( ctx && ctx->renderingStopped() )
+
+    // ok this does not matter much anyway as the tile size quite big so most of the time
+    // there would be just one tile for the whole display area, but it won't hurt...
+    if ( feedback && feedback->isCancelled() )
       break;
   }
 }

--- a/src/core/raster/qgsrasterdrawer.h
+++ b/src/core/raster/qgsrasterdrawer.h
@@ -25,6 +25,7 @@ class QImage;
 class QgsMapToPixel;
 class QgsRenderContext;
 struct QgsRasterViewPort;
+class QgsRasterBlockFeedback;
 class QgsRasterIterator;
 
 /** \ingroup core
@@ -39,9 +40,9 @@ class CORE_EXPORT QgsRasterDrawer
      * @param p destination QPainter
      * @param viewPort viewport to render
      * @param theQgsMapToPixel map to pixel converter
-     * @param ctx render context
+     * @param feedback optional raster feedback object for cancellation/preview. Added in QGIS 3.0.
      */
-    void draw( QPainter* p, QgsRasterViewPort* viewPort, const QgsMapToPixel* theQgsMapToPixel, const QgsRenderContext *ctx = nullptr );
+    void draw( QPainter* p, QgsRasterViewPort* viewPort, const QgsMapToPixel* theQgsMapToPixel, QgsRasterBlockFeedback* feedback = nullptr );
 
   protected:
     /** Draws raster part

--- a/src/core/raster/qgsrasterinterface.h
+++ b/src/core/raster/qgsrasterinterface.h
@@ -31,6 +31,8 @@
 
 /** \ingroup core
  * Feedback object tailored for raster block reading.
+ *
+ * @note added in QGIS 3.0
  */
 class CORE_EXPORT QgsRasterBlockFeedback : public QgsFeedback
 {

--- a/src/core/raster/qgsrasterinterface.h
+++ b/src/core/raster/qgsrasterinterface.h
@@ -23,10 +23,18 @@
 #include <QCoreApplication> // for tr()
 #include <QImage>
 
+#include "qgsfeedback.h"
 #include "qgsrasterbandstats.h"
 #include "qgsrasterblock.h"
 #include "qgsrasterhistogram.h"
 #include "qgsrectangle.h"
+
+/** Feedback object tailored for raster block reading. */
+class CORE_EXPORT QgsRasterBlockFeedback : public QgsFeedback
+{
+  // TODO: extend with preview functionality??
+};
+
 
 /** \ingroup core
  * Base class for processing filters like renderers, reprojector, resampler etc.
@@ -108,8 +116,9 @@ class CORE_EXPORT QgsRasterInterface
      * @param extent extent of block
      * @param width pixel width of block
      * @param height pixel height of block
+     * @param feedback optional raster feedback object for cancellation/preview. Added in QGIS 3.0.
      */
-    virtual QgsRasterBlock *block( int bandNo, const QgsRectangle &extent, int width, int height ) = 0;
+    virtual QgsRasterBlock *block( int bandNo, const QgsRectangle &extent, int width, int height, QgsRasterBlockFeedback* feedback = nullptr ) = 0;
 
     /** Set input.
       * Returns true if set correctly, false if cannot use that input */

--- a/src/core/raster/qgsrasterinterface.h
+++ b/src/core/raster/qgsrasterinterface.h
@@ -29,10 +29,12 @@
 #include "qgsrasterhistogram.h"
 #include "qgsrectangle.h"
 
-/** Feedback object tailored for raster block reading. */
+/** \ingroup core
+ * Feedback object tailored for raster block reading.
+ */
 class CORE_EXPORT QgsRasterBlockFeedback : public QgsFeedback
 {
-  // TODO: extend with preview functionality??
+    // TODO: extend with preview functionality??
 };
 
 

--- a/src/core/raster/qgsrasteriterator.cpp
+++ b/src/core/raster/qgsrasteriterator.cpp
@@ -19,12 +19,13 @@
 
 QgsRasterIterator::QgsRasterIterator( QgsRasterInterface* input )
     : mInput( input )
+    , mFeedback( nullptr )
     , mMaximumTileWidth( 2000 )
     , mMaximumTileHeight( 2000 )
 {
 }
 
-void QgsRasterIterator::startRasterRead( int bandNumber, int nCols, int nRows, const QgsRectangle& extent )
+void QgsRasterIterator::startRasterRead( int bandNumber, int nCols, int nRows, const QgsRectangle& extent, QgsRasterBlockFeedback* feedback )
 {
   if ( !mInput )
   {
@@ -32,6 +33,7 @@ void QgsRasterIterator::startRasterRead( int bandNumber, int nCols, int nRows, c
   }
 
   mExtent = extent;
+  mFeedback = feedback;
 
   //remove any previous part on that band
   removePartInfo( bandNumber );
@@ -93,7 +95,7 @@ bool QgsRasterIterator::readNextRasterPart( int bandNumber,
   double ymax = viewPortExtent.yMaximum() - pInfo.currentRow / static_cast< double >( pInfo.nRows ) * viewPortExtent.height();
   QgsRectangle blockRect( xmin, ymin, xmax, ymax );
 
-  *block = mInput->block( bandNumber, blockRect, nCols, nRows );
+  *block = mInput->block( bandNumber, blockRect, nCols, nRows, mFeedback );
   topLeftCol = pInfo.currentCol;
   topLeftRow = pInfo.currentRow;
 

--- a/src/core/raster/qgsrasteriterator.h
+++ b/src/core/raster/qgsrasteriterator.h
@@ -20,6 +20,7 @@
 
 class QgsMapToPixel;
 class QgsRasterBlock;
+class QgsRasterBlockFeedback;
 class QgsRasterInterface;
 class QgsRasterProjector;
 struct QgsRasterViewPort;
@@ -38,8 +39,9 @@ class CORE_EXPORT QgsRasterIterator
       @param nCols number of columns
       @param nRows number of rows
       @param extent area to read
+      @param feedback optional raster feedback object for cancellation/preview. Added in QGIS 3.0.
      */
-    void startRasterRead( int bandNumber, int nCols, int nRows, const QgsRectangle& extent );
+    void startRasterRead( int bandNumber, int nCols, int nRows, const QgsRectangle& extent, QgsRasterBlockFeedback* feedback = nullptr );
 
     /** Fetches next part of raster data, caller takes ownership of the block and
        caller should delete the block.
@@ -79,6 +81,7 @@ class CORE_EXPORT QgsRasterIterator
     QgsRasterInterface* mInput;
     QMap<int, RasterPartInfo> mRasterPartInfos;
     QgsRectangle mExtent;
+    QgsRasterBlockFeedback* mFeedback;
 
     int mMaximumTileWidth;
     int mMaximumTileHeight;

--- a/src/core/raster/qgsrasterlayerrenderer.cpp
+++ b/src/core/raster/qgsrasterlayerrenderer.cpp
@@ -29,8 +29,8 @@ QgsRasterLayerRenderer::QgsRasterLayerRenderer( QgsRasterLayer* layer, QgsRender
     , mRasterViewPort( nullptr )
     , mPipe( nullptr )
     , mContext( rendererContext )
+    , mFeedback( new QgsRasterBlockFeedback() )
 {
-
   mPainter = rendererContext.painter();
   const QgsMapToPixel& theQgsMapToPixel = rendererContext.mapToPixel();
   mMapToPixel = &theQgsMapToPixel;
@@ -181,6 +181,8 @@ QgsRasterLayerRenderer::QgsRasterLayerRenderer( QgsRasterLayer* layer, QgsRender
 
 QgsRasterLayerRenderer::~QgsRasterLayerRenderer()
 {
+  delete mFeedback;
+
   delete mRasterViewPort;
   delete mPipe;
 }
@@ -213,9 +215,14 @@ bool QgsRasterLayerRenderer::render()
   // Drawer to pipe?
   QgsRasterIterator iterator( mPipe->last() );
   QgsRasterDrawer drawer( &iterator );
-  drawer.draw( mPainter, mRasterViewPort, mMapToPixel, &mContext );
+  drawer.draw( mPainter, mRasterViewPort, mMapToPixel, mFeedback );
 
   QgsDebugMsgLevel( QString( "total raster draw time (ms):     %1" ).arg( time.elapsed(), 5 ), 4 );
 
   return true;
+}
+
+QgsFeedback* QgsRasterLayerRenderer::feedback() const
+{
+  return mFeedback;
 }

--- a/src/core/raster/qgsrasterlayerrenderer.h
+++ b/src/core/raster/qgsrasterlayerrenderer.h
@@ -21,6 +21,7 @@
 class QPainter;
 
 class QgsMapToPixel;
+class QgsRasterBlockFeedback;
 class QgsRasterLayer;
 class QgsRasterPipe;
 struct QgsRasterViewPort;
@@ -40,6 +41,8 @@ class QgsRasterLayerRenderer : public QgsMapLayerRenderer
 
     virtual bool render() override;
 
+    virtual QgsFeedback* feedback() const override;
+
   protected:
 
     QPainter* mPainter;
@@ -48,6 +51,8 @@ class QgsRasterLayerRenderer : public QgsMapLayerRenderer
 
     QgsRasterPipe* mPipe;
     QgsRenderContext& mContext;
+
+    QgsRasterBlockFeedback* mFeedback;
 };
 
 #endif // QGSRASTERLAYERRENDERER_H

--- a/src/core/raster/qgsrasternuller.cpp
+++ b/src/core/raster/qgsrasternuller.cpp
@@ -69,7 +69,7 @@ Qgis::DataType QgsRasterNuller::dataType( int bandNo ) const
   return Qgis::UnknownDataType;
 }
 
-QgsRasterBlock * QgsRasterNuller::block( int bandNo, QgsRectangle  const & extent, int width, int height )
+QgsRasterBlock * QgsRasterNuller::block( int bandNo, QgsRectangle  const & extent, int width, int height, QgsRasterBlockFeedback* feedback )
 {
   QgsDebugMsgLevel( "Entered", 4 );
   if ( !mInput )
@@ -77,7 +77,7 @@ QgsRasterBlock * QgsRasterNuller::block( int bandNo, QgsRectangle  const & exten
     return new QgsRasterBlock();
   }
 
-  QgsRasterBlock *inputBlock = mInput->block( bandNo, extent, width, height );
+  QgsRasterBlock *inputBlock = mInput->block( bandNo, extent, width, height, feedback );
   if ( !inputBlock )
   {
     return new QgsRasterBlock();

--- a/src/core/raster/qgsrasternuller.h
+++ b/src/core/raster/qgsrasternuller.h
@@ -44,7 +44,7 @@ class CORE_EXPORT QgsRasterNuller : public QgsRasterInterface
 
     Qgis::DataType dataType( int bandNo ) const override;
 
-    QgsRasterBlock *block( int bandNo, const QgsRectangle &extent, int width, int height ) override;
+    QgsRasterBlock *block( int bandNo, const QgsRectangle &extent, int width, int height, QgsRasterBlockFeedback* feedback = nullptr ) override;
 
     void setNoData( int bandNo, const QgsRasterRangeList& noData );
 

--- a/src/core/raster/qgsrasterpipe.h
+++ b/src/core/raster/qgsrasterpipe.h
@@ -19,9 +19,10 @@
 #define QGSRASTERPIPE_H
 
 #include <QImage>
+#include <QMap>
 #include <QObject>
-#include "qgsrasterinterface.h"
 
+class QgsRasterInterface;
 class QgsRasterRenderer;
 class QgsRasterResampleFilter;
 class QgsBrightnessContrastFilter;

--- a/src/core/raster/qgsrasterprojector.cpp
+++ b/src/core/raster/qgsrasterprojector.cpp
@@ -876,7 +876,7 @@ QString QgsRasterProjector::precisionLabel( Precision precision )
   return "Unknown";
 }
 
-QgsRasterBlock * QgsRasterProjector::block( int bandNo, QgsRectangle  const & extent, int width, int height )
+QgsRasterBlock * QgsRasterProjector::block( int bandNo, QgsRectangle  const & extent, int width, int height, QgsRasterBlockFeedback* feedback )
 {
   QgsDebugMsgLevel( QString( "extent:\n%1" ).arg( extent.toString() ), 4 );
   QgsDebugMsgLevel( QString( "width = %1 height = %2" ).arg( width ).arg( height ), 4 );
@@ -889,7 +889,7 @@ QgsRasterBlock * QgsRasterProjector::block( int bandNo, QgsRectangle  const & ex
   if ( ! mSrcCRS.isValid() || ! mDestCRS.isValid() || mSrcCRS == mDestCRS )
   {
     QgsDebugMsgLevel( "No projection necessary", 4 );
-    return mInput->block( bandNo, extent, width, height );
+    return mInput->block( bandNo, extent, width, height, feedback );
   }
 
   mDestExtent = extent;
@@ -907,7 +907,7 @@ QgsRasterBlock * QgsRasterProjector::block( int bandNo, QgsRectangle  const & ex
     return new QgsRasterBlock();
   }
 
-  QgsRasterBlock *inputBlock = mInput->block( bandNo, srcExtent(), srcCols(), srcRows() );
+  QgsRasterBlock *inputBlock = mInput->block( bandNo, srcExtent(), srcCols(), srcRows(), feedback );
   if ( !inputBlock || inputBlock->isEmpty() )
   {
     QgsDebugMsg( "No raster data!" );

--- a/src/core/raster/qgsrasterprojector.h
+++ b/src/core/raster/qgsrasterprojector.h
@@ -116,7 +116,7 @@ class CORE_EXPORT QgsRasterProjector : public QgsRasterInterface
     // Translated precision mode, for use in ComboBox etc.
     static QString precisionLabel( Precision precision );
 
-    QgsRasterBlock *block( int bandNo, const QgsRectangle & extent, int width, int height ) override;
+    QgsRasterBlock *block( int bandNo, const QgsRectangle & extent, int width, int height, QgsRasterBlockFeedback* feedback = nullptr ) override;
 
     /** Calculate destination extent and size from source extent and size */
     bool destExtentSize( const QgsRectangle& theSrcExtent, int theSrcXSize, int theSrcYSize,

--- a/src/core/raster/qgsrasterrenderer.h
+++ b/src/core/raster/qgsrasterrenderer.h
@@ -68,7 +68,7 @@ class CORE_EXPORT QgsRasterRenderer : public QgsRasterInterface
 
     virtual bool setInput( QgsRasterInterface* input ) override;
 
-    virtual QgsRasterBlock *block( int bandNo, const QgsRectangle &extent, int width, int height ) override = 0;
+    virtual QgsRasterBlock *block( int bandNo, const QgsRectangle &extent, int width, int height, QgsRasterBlockFeedback* feedback = nullptr ) override = 0;
 
     bool usesTransparency() const;
 

--- a/src/core/raster/qgsrasterresamplefilter.cpp
+++ b/src/core/raster/qgsrasterresamplefilter.cpp
@@ -129,7 +129,7 @@ void QgsRasterResampleFilter::setZoomedOutResampler( QgsRasterResampler* r )
   mZoomedOutResampler = r;
 }
 
-QgsRasterBlock * QgsRasterResampleFilter::block( int bandNo, QgsRectangle  const & extent, int width, int height )
+QgsRasterBlock * QgsRasterResampleFilter::block( int bandNo, QgsRectangle  const & extent, int width, int height, QgsRasterBlockFeedback* feedback )
 {
   Q_UNUSED( bandNo );
   QgsDebugMsgLevel( QString( "width = %1 height = %2 extent = %3" ).arg( width ).arg( height ).arg( extent.toString() ), 4 );
@@ -169,7 +169,7 @@ QgsRasterBlock * QgsRasterResampleFilter::block( int bandNo, QgsRectangle  const
   {
     QgsDebugMsgLevel( "No oversampling.", 4 );
     delete outputBlock;
-    return mInput->block( bandNumber, extent, width, height );
+    return mInput->block( bandNumber, extent, width, height, feedback );
   }
 
   //effective oversampling factors are different to global one because of rounding
@@ -181,7 +181,7 @@ QgsRasterBlock * QgsRasterResampleFilter::block( int bandNo, QgsRectangle  const
   int resWidth = width * oversamplingX;
   int resHeight = height * oversamplingY;
 
-  QgsRasterBlock *inputBlock = mInput->block( bandNumber, extent, resWidth, resHeight );
+  QgsRasterBlock *inputBlock = mInput->block( bandNumber, extent, resWidth, resHeight, feedback );
   if ( !inputBlock || inputBlock->isEmpty() )
   {
     QgsDebugMsg( "No raster data!" );

--- a/src/core/raster/qgsrasterresamplefilter.h
+++ b/src/core/raster/qgsrasterresamplefilter.h
@@ -41,7 +41,7 @@ class CORE_EXPORT QgsRasterResampleFilter : public QgsRasterInterface
 
     bool setInput( QgsRasterInterface* input ) override;
 
-    QgsRasterBlock *block( int bandNo, const QgsRectangle &extent, int width, int height ) override;
+    QgsRasterBlock *block( int bandNo, const QgsRectangle &extent, int width, int height, QgsRasterBlockFeedback* feedback = nullptr ) override;
 
     /** Set resampler for zoomed in scales. Takes ownership of the object*/
     void setZoomedInResampler( QgsRasterResampler* r );

--- a/src/core/raster/qgssinglebandcolordatarenderer.cpp
+++ b/src/core/raster/qgssinglebandcolordatarenderer.cpp
@@ -52,7 +52,7 @@ QgsRasterRenderer* QgsSingleBandColorDataRenderer::create( const QDomElement& el
   return r;
 }
 
-QgsRasterBlock* QgsSingleBandColorDataRenderer::block( int bandNo, QgsRectangle  const & extent, int width, int height )
+QgsRasterBlock* QgsSingleBandColorDataRenderer::block( int bandNo, QgsRectangle  const & extent, int width, int height, QgsRasterBlockFeedback* feedback )
 {
   Q_UNUSED( bandNo );
 
@@ -62,7 +62,7 @@ QgsRasterBlock* QgsSingleBandColorDataRenderer::block( int bandNo, QgsRectangle 
     return outputBlock;
   }
 
-  QgsRasterBlock *inputBlock = mInput->block( mBand, extent, width, height );
+  QgsRasterBlock *inputBlock = mInput->block( mBand, extent, width, height, feedback );
   if ( !inputBlock || inputBlock->isEmpty() )
   {
     QgsDebugMsg( "No raster data!" );

--- a/src/core/raster/qgssinglebandcolordatarenderer.h
+++ b/src/core/raster/qgssinglebandcolordatarenderer.h
@@ -36,7 +36,7 @@ class CORE_EXPORT QgsSingleBandColorDataRenderer: public QgsRasterRenderer
 
     bool setInput( QgsRasterInterface* input ) override;
 
-    QgsRasterBlock* block( int bandNo, const QgsRectangle & extent, int width, int height ) override;
+    QgsRasterBlock* block( int bandNo, const QgsRectangle & extent, int width, int height, QgsRasterBlockFeedback* feedback = nullptr ) override;
 
     void writeXml( QDomDocument& doc, QDomElement& parentElem ) const override;
 

--- a/src/core/raster/qgssinglebandgrayrenderer.cpp
+++ b/src/core/raster/qgssinglebandgrayrenderer.cpp
@@ -79,7 +79,7 @@ void QgsSingleBandGrayRenderer::setContrastEnhancement( QgsContrastEnhancement* 
   mContrastEnhancement = ce;
 }
 
-QgsRasterBlock* QgsSingleBandGrayRenderer::block( int bandNo, QgsRectangle  const & extent, int width, int height )
+QgsRasterBlock* QgsSingleBandGrayRenderer::block( int bandNo, QgsRectangle  const & extent, int width, int height, QgsRasterBlockFeedback* feedback )
 {
   Q_UNUSED( bandNo );
   QgsDebugMsgLevel( QString( "width = %1 height = %2" ).arg( width ).arg( height ), 4 );
@@ -90,7 +90,7 @@ QgsRasterBlock* QgsSingleBandGrayRenderer::block( int bandNo, QgsRectangle  cons
     return outputBlock;
   }
 
-  QgsRasterBlock *inputBlock = mInput->block( mGrayBand, extent, width, height );
+  QgsRasterBlock *inputBlock = mInput->block( mGrayBand, extent, width, height, feedback );
   if ( !inputBlock || inputBlock->isEmpty() )
   {
     QgsDebugMsg( "No raster data!" );
@@ -102,7 +102,7 @@ QgsRasterBlock* QgsSingleBandGrayRenderer::block( int bandNo, QgsRectangle  cons
 
   if ( mAlphaBand > 0 && mGrayBand != mAlphaBand )
   {
-    alphaBlock = mInput->block( mAlphaBand, extent, width, height );
+    alphaBlock = mInput->block( mAlphaBand, extent, width, height, feedback );
     if ( !alphaBlock || alphaBlock->isEmpty() )
     {
       // TODO: better to render without alpha

--- a/src/core/raster/qgssinglebandgrayrenderer.h
+++ b/src/core/raster/qgssinglebandgrayrenderer.h
@@ -41,7 +41,7 @@ class CORE_EXPORT QgsSingleBandGrayRenderer: public QgsRasterRenderer
 
     static QgsRasterRenderer* create( const QDomElement& elem, QgsRasterInterface* input );
 
-    QgsRasterBlock *block( int bandNo, QgsRectangle  const & extent, int width, int height ) override;
+    QgsRasterBlock *block( int bandNo, QgsRectangle  const & extent, int width, int height, QgsRasterBlockFeedback* feedback = nullptr ) override;
 
     int grayBand() const { return mGrayBand; }
     void setGrayBand( int band ) { mGrayBand = band; }

--- a/src/core/raster/qgssinglebandpseudocolorrenderer.cpp
+++ b/src/core/raster/qgssinglebandpseudocolorrenderer.cpp
@@ -108,7 +108,7 @@ QgsRasterRenderer* QgsSingleBandPseudoColorRenderer::create( const QDomElement& 
   return r;
 }
 
-QgsRasterBlock* QgsSingleBandPseudoColorRenderer::block( int bandNo, QgsRectangle  const & extent, int width, int height )
+QgsRasterBlock* QgsSingleBandPseudoColorRenderer::block( int bandNo, QgsRectangle  const & extent, int width, int height, QgsRasterBlockFeedback* feedback )
 {
   Q_UNUSED( bandNo );
 
@@ -119,7 +119,7 @@ QgsRasterBlock* QgsSingleBandPseudoColorRenderer::block( int bandNo, QgsRectangl
   }
 
 
-  QgsRasterBlock *inputBlock = mInput->block( mBand, extent, width, height );
+  QgsRasterBlock *inputBlock = mInput->block( mBand, extent, width, height, feedback );
   if ( !inputBlock || inputBlock->isEmpty() )
   {
     QgsDebugMsg( "No raster data!" );
@@ -133,7 +133,7 @@ QgsRasterBlock* QgsSingleBandPseudoColorRenderer::block( int bandNo, QgsRectangl
   QgsRasterBlock *alphaBlock = nullptr;
   if ( mAlphaBand > 0 && mAlphaBand != mBand )
   {
-    alphaBlock = mInput->block( mAlphaBand, extent, width, height );
+    alphaBlock = mInput->block( mAlphaBand, extent, width, height, feedback );
     if ( !alphaBlock || alphaBlock->isEmpty() )
     {
       delete inputBlock;

--- a/src/core/raster/qgssinglebandpseudocolorrenderer.h
+++ b/src/core/raster/qgssinglebandpseudocolorrenderer.h
@@ -36,7 +36,7 @@ class CORE_EXPORT QgsSingleBandPseudoColorRenderer: public QgsRasterRenderer
 
     static QgsRasterRenderer* create( const QDomElement& elem, QgsRasterInterface* input );
 
-    QgsRasterBlock* block( int bandNo, const QgsRectangle & extent, int width, int height ) override;
+    QgsRasterBlock* block( int bandNo, const QgsRectangle & extent, int width, int height, QgsRasterBlockFeedback* feedback = nullptr ) override;
 
     /** Takes ownership of the shader*/
     void setShader( QgsRasterShader* shader );

--- a/src/providers/arcgisrest/qgsamsprovider.cpp
+++ b/src/providers/arcgisrest/qgsamsprovider.cpp
@@ -437,8 +437,10 @@ QgsRasterIdentifyResult QgsAmsProvider::identify( const QgsPoint & thePoint, Qgs
   return QgsRasterIdentifyResult( theFormat, entries );
 }
 
-void QgsAmsProvider::readBlock( int /*bandNo*/, const QgsRectangle & viewExtent, int width, int height, void *data )
+void QgsAmsProvider::readBlock( int /*bandNo*/, const QgsRectangle & viewExtent, int width, int height, void *data, QgsRasterBlockFeedback* feedback )
 {
+  Q_UNUSED( feedback );  // TODO: make use of the feedback object
+
   // TODO: optimize to avoid writing to QImage
   // returned image is actually mCachedImage, no need to delete
   QImage *image = draw( viewExtent, width, height );

--- a/src/providers/arcgisrest/qgsamsprovider.h
+++ b/src/providers/arcgisrest/qgsamsprovider.h
@@ -87,7 +87,7 @@ class QgsAmsProvider : public QgsRasterDataProvider
     QgsRasterIdentifyResult identify( const QgsPoint & thePoint, QgsRaster::IdentifyFormat theFormat, const QgsRectangle &theExtent = QgsRectangle(), int theWidth = 0, int theHeight = 0, int theDpi = 96 ) override;
 
   protected:
-    void readBlock( int bandNo, const QgsRectangle & viewExtent, int width, int height, void *data ) override;
+    void readBlock( int bandNo, const QgsRectangle & viewExtent, int width, int height, void *data, QgsRasterBlockFeedback* feedback = nullptr ) override;
 
   private:
     bool mValid;

--- a/src/providers/gdal/qgsgdalprovider.cpp
+++ b/src/providers/gdal/qgsgdalprovider.cpp
@@ -388,7 +388,7 @@ QImage* QgsGdalProvider::draw( QgsRectangle  const & viewExtent, int pixelWidth,
   return image;
 }
 
-QgsRasterBlock* QgsGdalProvider::block( int theBandNo, const QgsRectangle &theExtent, int theWidth, int theHeight )
+QgsRasterBlock* QgsGdalProvider::block( int theBandNo, const QgsRectangle &theExtent, int theWidth, int theHeight, QgsRasterBlockFeedback* feedback )
 {
   //QgsRasterBlock *block = new QgsRasterBlock( dataType( theBandNo ), theWidth, theHeight, noDataValue( theBandNo ) );
   QgsRasterBlock *block;
@@ -411,7 +411,7 @@ QgsRasterBlock* QgsGdalProvider::block( int theBandNo, const QgsRectangle &theEx
     QRect subRect = QgsRasterBlock::subRect( theExtent, theWidth, theHeight, mExtent );
     block->setIsNoDataExcept( subRect );
   }
-  readBlock( theBandNo, theExtent, theWidth, theHeight, block->bits() );
+  readBlock( theBandNo, theExtent, theWidth, theHeight, block->bits(), feedback );
   // apply scale and offset
   block->applyScaleOffset( bandScale( theBandNo ), bandOffset( theBandNo ) );
   block->applyNoDataValues( userNoDataValues( theBandNo ) );
@@ -435,8 +435,9 @@ void QgsGdalProvider::readBlock( int theBandNo, int xBlock, int yBlock, void *bl
   gdalRasterIO( myGdalBand, GF_Read, xOff, yOff, mXBlockSize, mYBlockSize, block, mXBlockSize, mYBlockSize, ( GDALDataType ) mGdalDataType.at( theBandNo - 1 ), 0, 0 );
 }
 
-void QgsGdalProvider::readBlock( int theBandNo, QgsRectangle  const & theExtent, int thePixelWidth, int thePixelHeight, void *theBlock )
+void QgsGdalProvider::readBlock( int theBandNo, QgsRectangle  const & theExtent, int thePixelWidth, int thePixelHeight, void *theBlock, QgsRasterBlockFeedback* feedback )
 {
+  Q_UNUSED( feedback );  // TODO: use with GDAL 2
   QgsDebugMsg( "thePixelWidth = "  + QString::number( thePixelWidth ) );
   QgsDebugMsg( "thePixelHeight = "  + QString::number( thePixelHeight ) );
   QgsDebugMsg( "theExtent: " + theExtent.toString() );

--- a/src/providers/gdal/qgsgdalprovider.cpp
+++ b/src/providers/gdal/qgsgdalprovider.cpp
@@ -437,7 +437,6 @@ void QgsGdalProvider::readBlock( int theBandNo, int xBlock, int yBlock, void *bl
 
 void QgsGdalProvider::readBlock( int theBandNo, QgsRectangle  const & theExtent, int thePixelWidth, int thePixelHeight, void *theBlock, QgsRasterBlockFeedback* feedback )
 {
-  Q_UNUSED( feedback );  // TODO: use with GDAL 2
   QgsDebugMsg( "thePixelWidth = "  + QString::number( thePixelWidth ) );
   QgsDebugMsg( "thePixelHeight = "  + QString::number( thePixelHeight ) );
   QgsDebugMsg( "theExtent: " + theExtent.toString() );
@@ -608,11 +607,12 @@ void QgsGdalProvider::readBlock( int theBandNo, QgsRectangle  const & theExtent,
   GDALRasterBandH gdalBand = GDALGetRasterBand( mGdalDataset, theBandNo );
   GDALDataType type = ( GDALDataType )mGdalDataType.at( theBandNo - 1 );
   CPLErrorReset();
+
   CPLErr err = gdalRasterIO( gdalBand, GF_Read,
                              srcLeft, srcTop, srcWidth, srcHeight,
                              ( void * )tmpBlock,
                              tmpWidth, tmpHeight, type,
-                             0, 0 );
+                             0, 0, feedback );
 
   if ( err != CPLE_None )
   {

--- a/src/providers/gdal/qgsgdalprovider.h
+++ b/src/providers/gdal/qgsgdalprovider.h
@@ -161,10 +161,10 @@ class QgsGdalProvider : public QgsRasterDataProvider, QgsGdalProviderBase
     QString generateBandName( int theBandNumber ) const override;
 
     /** Reimplemented from QgsRasterDataProvider to bypass second resampling (more efficient for local file based sources)*/
-    QgsRasterBlock *block( int theBandNo, const QgsRectangle &theExtent, int theWidth, int theHeight ) override;
+    QgsRasterBlock *block( int theBandNo, const QgsRectangle &theExtent, int theWidth, int theHeight, QgsRasterBlockFeedback* feedback = nullptr ) override;
 
     void readBlock( int bandNo, int xBlock, int yBlock, void *data ) override;
-    void readBlock( int bandNo, QgsRectangle  const & viewExtent, int width, int height, void *data ) override;
+    void readBlock( int bandNo, QgsRectangle  const & viewExtent, int width, int height, void *data, QgsRasterBlockFeedback* feedback = nullptr ) override;
 
     /** Read band scale for raster value
      * @@note added in 2.3 */

--- a/src/providers/gdal/qgsgdalproviderbase.cpp
+++ b/src/providers/gdal/qgsgdalproviderbase.cpp
@@ -280,7 +280,17 @@ GDALDatasetH QgsGdalProviderBase::gdalOpen( const char *pszFilename, GDALAccess 
   return hDS;
 }
 
-CPLErr QgsGdalProviderBase::gdalRasterIO( GDALRasterBandH hBand, GDALRWFlag eRWFlag, int nXOff, int nYOff, int nXSize, int nYSize, void * pData, int nBufXSize, int nBufYSize, GDALDataType eBufType, int nPixelSpace, int nLineSpace )
+static int CPL_STDCALL _gdalProgressFnWithFeedback( double dfComplete, const char *pszMessage, void *pProgressArg )
+{
+  Q_UNUSED( dfComplete );
+  Q_UNUSED( pszMessage );
+
+  QgsRasterBlockFeedback* feedback = static_cast<QgsRasterBlockFeedback*>( pProgressArg );
+  return !feedback->isCancelled();
+}
+
+
+CPLErr QgsGdalProviderBase::gdalRasterIO( GDALRasterBandH hBand, GDALRWFlag eRWFlag, int nXOff, int nYOff, int nXSize, int nYSize, void * pData, int nBufXSize, int nBufYSize, GDALDataType eBufType, int nPixelSpace, int nLineSpace, QgsRasterBlockFeedback* feedback )
 {
   // See http://hub.qgis.org/issues/8356 and http://trac.osgeo.org/gdal/ticket/5170
 #if GDAL_VERSION_MAJOR == 1 && ( (GDAL_VERSION_MINOR == 9 && GDAL_VERSION_REV <= 2) || (GDAL_VERSION_MINOR == 10 && GDAL_VERSION_REV <= 0) )
@@ -289,7 +299,24 @@ CPLErr QgsGdalProviderBase::gdalRasterIO( GDALRasterBandH hBand, GDALRWFlag eRWF
   QgsDebugMsg( "Disabled VSI_CACHE" );
 #endif
 
+#if GDAL_VERSION_MAJOR >= 2
+  GDALRasterIOExtraArg extra;
+  INIT_RASTERIO_EXTRA_ARG( extra );
+  if ( 0 && feedback )  // disabled!
+  {
+    // Currently the cancellation is disabled... When RasterIO call is cancelled,
+    // GDAL returns CE_Failure with error code = 0 (CPLE_None), however one would
+    // expect to get CPLE_UserInterrupt to clearly identify that the failure was
+    // caused by the cancellation and not that something dodgy is going on.
+    // Are both error codes acceptable?
+    extra.pfnProgress = _gdalProgressFnWithFeedback;
+    extra.pProgressData = ( void* ) feedback;
+  }
+  CPLErr err = GDALRasterIOEx( hBand, eRWFlag, nXOff, nYOff, nXSize, nYSize, pData, nBufXSize, nBufYSize, eBufType, nPixelSpace, nLineSpace, &extra );
+#else
+  Q_UNUSED( feedback );
   CPLErr err = GDALRasterIO( hBand, eRWFlag, nXOff, nYOff, nXSize, nYSize, pData, nBufXSize, nBufYSize, eBufType, nPixelSpace, nLineSpace );
+#endif
 
 #if GDAL_VERSION_MAJOR == 1 && ( (GDAL_VERSION_MINOR == 9 && GDAL_VERSION_REV <= 2) || (GDAL_VERSION_MINOR == 10 && GDAL_VERSION_REV <= 0) )
   CPLSetThreadLocalConfigOption( "VSI_CACHE", pszOldVal );

--- a/src/providers/gdal/qgsgdalproviderbase.cpp
+++ b/src/providers/gdal/qgsgdalproviderbase.cpp
@@ -280,7 +280,7 @@ GDALDatasetH QgsGdalProviderBase::gdalOpen( const char *pszFilename, GDALAccess 
   return hDS;
 }
 
-static int CPL_STDCALL _gdalProgressFnWithFeedback( double dfComplete, const char *pszMessage, void *pProgressArg )
+int CPL_STDCALL _gdalProgressFnWithFeedback( double dfComplete, const char *pszMessage, void *pProgressArg )
 {
   Q_UNUSED( dfComplete );
   Q_UNUSED( pszMessage );

--- a/src/providers/gdal/qgsgdalproviderbase.h
+++ b/src/providers/gdal/qgsgdalproviderbase.h
@@ -49,7 +49,7 @@ class QgsGdalProviderBase
     static GDALDatasetH  gdalOpen( const char *pszFilename, GDALAccess eAccess );
 
     /** Wrapper function for GDALRasterIO to get around possible bugs in GDAL */
-    static CPLErr gdalRasterIO( GDALRasterBandH hBand, GDALRWFlag eRWFlag, int nXOff, int nYOff, int nXSize, int nYSize, void * pData, int nBufXSize, int nBufYSize, GDALDataType eBufType, int nPixelSpace, int nLineSpace );
+    static CPLErr gdalRasterIO( GDALRasterBandH hBand, GDALRWFlag eRWFlag, int nXOff, int nYOff, int nXSize, int nYSize, void * pData, int nBufXSize, int nBufYSize, GDALDataType eBufType, int nPixelSpace, int nLineSpace, QgsRasterBlockFeedback* feedback = nullptr );
 
     /** Wrapper function for GDALRasterIO to get around possible bugs in GDAL */
     static int gdalGetOverviewCount( GDALRasterBandH hBand );

--- a/src/providers/grass/qgsgrassrasterprovider.cpp
+++ b/src/providers/grass/qgsgrassrasterprovider.cpp
@@ -278,8 +278,9 @@ void QgsGrassRasterProvider::readBlock( int bandNo, int xBlock, int yBlock, void
   memcpy( block, data.data(), size );
 }
 
-void QgsGrassRasterProvider::readBlock( int bandNo, QgsRectangle  const & viewExtent, int pixelWidth, int pixelHeight, void *block )
+void QgsGrassRasterProvider::readBlock( int bandNo, QgsRectangle  const & viewExtent, int pixelWidth, int pixelHeight, void *block, QgsRasterBlockFeedback* feedback )
 {
+  Q_UNUSED( feedback );
   QgsDebugMsg( "pixelWidth = "  + QString::number( pixelWidth ) );
   QgsDebugMsg( "pixelHeight = "  + QString::number( pixelHeight ) );
   QgsDebugMsg( "viewExtent: " + viewExtent.toString() );

--- a/src/providers/grass/qgsgrassrasterprovider.h
+++ b/src/providers/grass/qgsgrassrasterprovider.h
@@ -185,7 +185,7 @@ class GRASS_LIB_EXPORT QgsGrassRasterProvider : public QgsRasterDataProvider
     int ySize() const override;
 
     void readBlock( int bandNo, int xBlock, int yBlock, void *data ) override;
-    void readBlock( int bandNo, QgsRectangle  const & viewExtent, int width, int height, void *data ) override;
+    void readBlock( int bandNo, QgsRectangle  const & viewExtent, int width, int height, void *data, QgsRasterBlockFeedback* feedback = nullptr ) override;
 
     QgsRasterBandStats bandStatistics( int theBandNo,
                                        int theStats = QgsRasterBandStats::All,

--- a/src/providers/wcs/qgswcsprovider.cpp
+++ b/src/providers/wcs/qgswcsprovider.cpp
@@ -497,9 +497,8 @@ void QgsWcsProvider::setQueryItem( QUrl &url, const QString& item, const QString
   url.addQueryItem( item, value );
 }
 
-void QgsWcsProvider::readBlock( int bandNo, QgsRectangle  const & viewExtent, int pixelWidth, int pixelHeight, void *block )
+void QgsWcsProvider::readBlock( int bandNo, QgsRectangle  const & viewExtent, int pixelWidth, int pixelHeight, void *block, QgsRasterBlockFeedback* feedback )
 {
-
   // TODO: set block to null values, move that to function and call only if fails
   memset( block, 0, pixelWidth * pixelHeight * QgsRasterBlock::typeSize( dataType( bandNo ) ) );
 
@@ -517,7 +516,7 @@ void QgsWcsProvider::readBlock( int bandNo, QgsRectangle  const & viewExtent, in
        mCachedViewWidth != pixelWidth ||
        mCachedViewHeight != pixelHeight )
   {
-    getCache( bandNo, viewExtent, pixelWidth, pixelHeight );
+    getCache( bandNo, viewExtent, pixelWidth, pixelHeight, QString(), feedback );
   }
 
   if ( mCachedGdalDataset )
@@ -616,7 +615,7 @@ void QgsWcsProvider::readBlock( int bandNo, QgsRectangle  const & viewExtent, in
   }
 }
 
-void QgsWcsProvider::getCache( int bandNo, QgsRectangle  const & viewExtent, int pixelWidth, int pixelHeight, QString crs ) const
+void QgsWcsProvider::getCache( int bandNo, QgsRectangle  const & viewExtent, int pixelWidth, int pixelHeight, QString crs, QgsRasterBlockFeedback* feedback ) const
 {
   Q_UNUSED( bandNo );
   // delete cached data
@@ -769,7 +768,7 @@ void QgsWcsProvider::getCache( int bandNo, QgsRectangle  const & viewExtent, int
 
   emit statusChanged( tr( "Getting map via WCS." ) );
 
-  QgsWcsDownloadHandler handler( url, mAuth, mCacheLoadControl, mCachedData, mCapabilities.version(), mCachedError );
+  QgsWcsDownloadHandler handler( url, mAuth, mCacheLoadControl, mCachedData, mCapabilities.version(), mCachedError, feedback );
   handler.blockingDownload();
 
   QgsDebugMsg( QString( "%1 bytes received" ).arg( mCachedData.size() ) );
@@ -837,7 +836,7 @@ void QgsWcsProvider::readBlock( int theBandNo, int xBlock, int yBlock, void *blo
 
   QgsRectangle extent( xMin, yMin, xMax, yMax );
 
-  readBlock( theBandNo, extent, mXBlockSize, mYBlockSize, block );
+  readBlock( theBandNo, extent, mXBlockSize, mYBlockSize, block, nullptr );
 }
 
 
@@ -1646,7 +1645,7 @@ QGISEXTERN bool isProvider()
 
 int QgsWcsDownloadHandler::sErrors = 0;
 
-QgsWcsDownloadHandler::QgsWcsDownloadHandler( const QUrl& url, QgsWcsAuthorization& auth, QNetworkRequest::CacheLoadControl cacheLoadControl, QByteArray& cachedData, const QString& wcsVersion, QgsError& cachedError )
+QgsWcsDownloadHandler::QgsWcsDownloadHandler( const QUrl& url, QgsWcsAuthorization& auth, QNetworkRequest::CacheLoadControl cacheLoadControl, QByteArray& cachedData, const QString& wcsVersion, QgsError& cachedError, QgsRasterBlockFeedback* feedback )
     : mAuth( auth )
     , mEventLoop( new QEventLoop )
     , mCacheReply( nullptr )
@@ -1667,6 +1666,9 @@ QgsWcsDownloadHandler::QgsWcsDownloadHandler( const QUrl& url, QgsWcsAuthorizati
   mCacheReply = QgsNetworkAccessManager::instance()->get( request );
   connect( mCacheReply, SIGNAL( finished() ), this, SLOT( cacheReplyFinished() ) );
   connect( mCacheReply, SIGNAL( downloadProgress( qint64, qint64 ) ), this, SLOT( cacheReplyProgress( qint64, qint64 ) ) );
+
+  if ( feedback )
+    connect( feedback, SIGNAL( cancelled() ), this, SLOT( cancelled() ), Qt::QueuedConnection );
 }
 
 QgsWcsDownloadHandler::~QgsWcsDownloadHandler()
@@ -1854,30 +1856,34 @@ void QgsWcsDownloadHandler::cacheReplyFinished()
   }
   else
   {
-    // Resend request if AlwaysCache
-    QNetworkRequest request = mCacheReply->request();
-    if ( request.attribute( QNetworkRequest::CacheLoadControlAttribute ).toInt() == QNetworkRequest::AlwaysCache )
+    // report any errors except for the one we have caused by cancelling the request
+    if ( mCacheReply->error() != QNetworkReply::OperationCanceledError )
     {
-      QgsDebugMsg( "Resend request with PreferCache" );
-      request.setAttribute( QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::PreferCache );
+      // Resend request if AlwaysCache
+      QNetworkRequest request = mCacheReply->request();
+      if ( request.attribute( QNetworkRequest::CacheLoadControlAttribute ).toInt() == QNetworkRequest::AlwaysCache )
+      {
+        QgsDebugMsg( "Resend request with PreferCache" );
+        request.setAttribute( QNetworkRequest::CacheLoadControlAttribute, QNetworkRequest::PreferCache );
 
-      mCacheReply->deleteLater();
+        mCacheReply->deleteLater();
 
-      mCacheReply = QgsNetworkAccessManager::instance()->get( request );
-      connect( mCacheReply, SIGNAL( finished() ), this, SLOT( cacheReplyFinished() ), Qt::DirectConnection );
-      connect( mCacheReply, SIGNAL( downloadProgress( qint64, qint64 ) ), this, SLOT( cacheReplyProgress( qint64, qint64 ) ), Qt::DirectConnection );
+        mCacheReply = QgsNetworkAccessManager::instance()->get( request );
+        connect( mCacheReply, SIGNAL( finished() ), this, SLOT( cacheReplyFinished() ), Qt::DirectConnection );
+        connect( mCacheReply, SIGNAL( downloadProgress( qint64, qint64 ) ), this, SLOT( cacheReplyProgress( qint64, qint64 ) ), Qt::DirectConnection );
 
-      return;
-    }
+        return;
+      }
 
-    sErrors++;
-    if ( sErrors < 100 )
-    {
-      QgsMessageLog::logMessage( tr( "Map request failed [error:%1 url:%2]" ).arg( mCacheReply->errorString(), mCacheReply->url().toString() ), tr( "WCS" ) );
-    }
-    else if ( sErrors == 100 )
-    {
-      QgsMessageLog::logMessage( tr( "Not logging more than 100 request errors." ), tr( "WCS" ) );
+      sErrors++;
+      if ( sErrors < 100 )
+      {
+        QgsMessageLog::logMessage( tr( "Map request failed [error:%1 url:%2]" ).arg( mCacheReply->errorString(), mCacheReply->url().toString() ), tr( "WCS" ) );
+      }
+      else if ( sErrors == 100 )
+      {
+        QgsMessageLog::logMessage( tr( "Not logging more than 100 request errors." ), tr( "WCS" ) );
+      }
     }
 
     mCacheReply->deleteLater();
@@ -1892,4 +1898,14 @@ void QgsWcsDownloadHandler::cacheReplyProgress( qint64 bytesReceived, qint64 byt
   Q_UNUSED( bytesReceived );
   Q_UNUSED( bytesTotal );
   QgsDebugMsgLevel( tr( "%1 of %2 bytes of map downloaded." ).arg( bytesReceived ).arg( bytesTotal < 0 ? QString( "unknown number of" ) : QString::number( bytesTotal ) ), 3 );
+}
+
+void QgsWcsDownloadHandler::cancelled()
+{
+  QgsDebugMsg( "Caught cancelled() signal" );
+  if ( mCacheReply )
+  {
+    QgsDebugMsg( "Aborting WCS network request" );
+    mCacheReply->abort();
+  }
 }

--- a/src/providers/wcs/qgswcsprovider.h
+++ b/src/providers/wcs/qgswcsprovider.h
@@ -145,12 +145,12 @@ class QgsWcsProvider : public QgsRasterDataProvider, QgsGdalProviderBase
      */
     QImage *draw( QgsRectangle const &  viewExtent, int pixelWidth, int pixelHeight ) override;
 
-    void readBlock( int bandNo, QgsRectangle  const & viewExtent, int width, int height, void *data ) override;
+    void readBlock( int bandNo, QgsRectangle  const & viewExtent, int width, int height, void *data, QgsRasterBlockFeedback* feedback = nullptr ) override;
 
     void readBlock( int theBandNo, int xBlock, int yBlock, void *block ) override;
 
     /** Download cache */
-    void getCache( int bandNo, QgsRectangle  const & viewExtent, int width, int height, QString crs = "" ) const;
+    void getCache( int bandNo, QgsRectangle  const & viewExtent, int width, int height, QString crs = QString(), QgsRasterBlockFeedback* feedback = nullptr ) const;
 
     virtual QgsRectangle extent() const override;
 
@@ -411,7 +411,7 @@ class QgsWcsDownloadHandler : public QObject
 {
     Q_OBJECT
   public:
-    QgsWcsDownloadHandler( const QUrl& url, QgsWcsAuthorization& auth, QNetworkRequest::CacheLoadControl cacheLoadControl, QByteArray& cachedData, const QString& wcsVersion, QgsError& cachedError );
+    QgsWcsDownloadHandler( const QUrl& url, QgsWcsAuthorization& auth, QNetworkRequest::CacheLoadControl cacheLoadControl, QByteArray& cachedData, const QString& wcsVersion, QgsError& cachedError, QgsRasterBlockFeedback* feedback );
     ~QgsWcsDownloadHandler();
 
     void blockingDownload();
@@ -419,6 +419,7 @@ class QgsWcsDownloadHandler : public QObject
   protected slots:
     void cacheReplyFinished();
     void cacheReplyProgress( qint64, qint64 );
+    void cancelled();
 
   protected:
     void finish() { QMetaObject::invokeMethod( mEventLoop, "quit", Qt::QueuedConnection ); }

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -482,6 +482,11 @@ void QgsWmsProvider::setFormatQueryItem( QUrl &url )
 
 QImage *QgsWmsProvider::draw( QgsRectangle const &viewExtent, int pixelWidth, int pixelHeight )
 {
+  return draw( viewExtent, pixelWidth, pixelHeight, nullptr );
+}
+
+QImage *QgsWmsProvider::draw( QgsRectangle const & viewExtent, int pixelWidth, int pixelHeight, QgsRasterBlockFeedback* feedback )
+{
   QgsDebugMsg( "Entering." );
 
   // Can we reuse the previously cached image?
@@ -581,7 +586,7 @@ QImage *QgsWmsProvider::draw( QgsRectangle const &viewExtent, int pixelWidth, in
 
     emit statusChanged( tr( "Getting map via WMS." ) );
 
-    QgsWmsImageDownloadHandler handler( dataSourceUri(), url, mSettings.authorization(), mCachedImage );
+    QgsWmsImageDownloadHandler handler( dataSourceUri(), url, mSettings.authorization(), mCachedImage, feedback );
     handler.downloadBlocking();
   }
   else
@@ -847,7 +852,7 @@ QImage *QgsWmsProvider::draw( QgsRectangle const &viewExtent, int pixelWidth, in
 
     emit statusChanged( tr( "Getting tiles." ) );
 
-    QgsWmsTiledImageDownloadHandler handler( dataSourceUri(), mSettings.authorization(), mTileReqNo, requests, mCachedImage, mCachedViewExtent, mSettings.mSmoothPixmapTransform );
+    QgsWmsTiledImageDownloadHandler handler( dataSourceUri(), mSettings.authorization(), mTileReqNo, requests, mCachedImage, mCachedViewExtent, mSettings.mSmoothPixmapTransform, feedback );
     handler.downloadBlocking();
 
 
@@ -864,11 +869,11 @@ QImage *QgsWmsProvider::draw( QgsRectangle const &viewExtent, int pixelWidth, in
   return mCachedImage;
 }
 
-void QgsWmsProvider::readBlock( int bandNo, QgsRectangle  const & viewExtent, int pixelWidth, int pixelHeight, void *block )
+void QgsWmsProvider::readBlock( int bandNo, QgsRectangle  const & viewExtent, int pixelWidth, int pixelHeight, void *block, QgsRasterBlockFeedback* feedback )
 {
   Q_UNUSED( bandNo );
   // TODO: optimize to avoid writing to QImage
-  QImage *image = draw( viewExtent, pixelWidth, pixelHeight );
+  QImage *image = draw( viewExtent, pixelWidth, pixelHeight, feedback );
   if ( !image )   // should not happen
   {
     QgsMessageLog::logMessage( tr( "image is NULL" ), tr( "WMS" ) );
@@ -3214,7 +3219,7 @@ QGISEXTERN bool isProvider()
 
 // -----------------
 
-QgsWmsImageDownloadHandler::QgsWmsImageDownloadHandler( const QString& providerUri, const QUrl& url, const QgsWmsAuthorization& auth, QImage* image )
+QgsWmsImageDownloadHandler::QgsWmsImageDownloadHandler( const QString& providerUri, const QUrl& url, const QgsWmsAuthorization& auth, QImage* image, QgsRasterBlockFeedback* feedback )
     : mProviderUri( providerUri )
     , mCachedImage( image )
     , mEventLoop( new QEventLoop )
@@ -3228,6 +3233,8 @@ QgsWmsImageDownloadHandler::QgsWmsImageDownloadHandler( const QString& providerU
 
   Q_ASSERT( mCacheReply->thread() == QThread::currentThread() );
 
+  if ( feedback )
+    connect( feedback, SIGNAL( cancelled() ), this, SLOT( cancelled() ), Qt::QueuedConnection );
 }
 
 QgsWmsImageDownloadHandler::~QgsWmsImageDownloadHandler()
@@ -3321,16 +3328,20 @@ void QgsWmsImageDownloadHandler::cacheReplyFinished()
   }
   else
   {
-    QgsWmsStatistics::Stat& stat = QgsWmsStatistics::statForUri( mProviderUri );
+    // report any errors except for the one we have caused by cancelling the request
+    if ( mCacheReply->error() != QNetworkReply::OperationCanceledError )
+    {
+      QgsWmsStatistics::Stat& stat = QgsWmsStatistics::statForUri( mProviderUri );
 
-    stat.errors++;
-    if ( stat.errors < 100 )
-    {
-      QgsMessageLog::logMessage( tr( "Map request failed [error:%1 url:%2]" ).arg( mCacheReply->errorString(), mCacheReply->url().toString() ), tr( "WMS" ) );
-    }
-    else if ( stat.errors == 100 )
-    {
-      QgsMessageLog::logMessage( tr( "Not logging more than 100 request errors." ), tr( "WMS" ) );
+      stat.errors++;
+      if ( stat.errors < 100 )
+      {
+        QgsMessageLog::logMessage( tr( "Map request failed [error:%1 url:%2]" ).arg( mCacheReply->errorString(), mCacheReply->url().toString() ), tr( "WMS" ) );
+      }
+      else if ( stat.errors == 100 )
+      {
+        QgsMessageLog::logMessage( tr( "Not logging more than 100 request errors." ), tr( "WMS" ) );
+      }
     }
 
     mCacheReply->deleteLater();
@@ -3347,11 +3358,22 @@ void QgsWmsImageDownloadHandler::cacheReplyProgress( qint64 bytesReceived, qint6
   QgsDebugMsg( tr( "%1 of %2 bytes of map downloaded." ).arg( bytesReceived ).arg( bytesTotal < 0 ? QString( "unknown number of" ) : QString::number( bytesTotal ) ) );
 }
 
+void QgsWmsImageDownloadHandler::cancelled()
+{
+  QgsDebugMsg( "Caught cancelled() signal" );
+  if ( mCacheReply )
+  {
+    // abort the reply if it is still active
+    QgsDebugMsg( "Aborting WMS network request" );
+    mCacheReply->abort();
+  }
+}
+
 
 // ----------
 
 
-QgsWmsTiledImageDownloadHandler::QgsWmsTiledImageDownloadHandler( const QString& providerUri, const QgsWmsAuthorization& auth, int tileReqNo, const QList<QgsWmsTiledImageDownloadHandler::TileRequest>& requests, QImage* cachedImage, const QgsRectangle& cachedViewExtent, bool smoothPixmapTransform )
+QgsWmsTiledImageDownloadHandler::QgsWmsTiledImageDownloadHandler( const QString& providerUri, const QgsWmsAuthorization& auth, int tileReqNo, const QList<QgsWmsTiledImageDownloadHandler::TileRequest>& requests, QImage* cachedImage, const QgsRectangle& cachedViewExtent, bool smoothPixmapTransform, QgsRasterBlockFeedback* feedback )
     : mProviderUri( providerUri )
     , mAuth( auth )
     , mCachedImage( cachedImage )
@@ -3376,6 +3398,9 @@ QgsWmsTiledImageDownloadHandler::QgsWmsTiledImageDownloadHandler( const QString&
 
     mReplies << reply;
   }
+
+  if ( feedback )
+    connect( feedback, SIGNAL( cancelled() ), this, SLOT( cancelled() ), Qt::QueuedConnection );
 }
 
 QgsWmsTiledImageDownloadHandler::~QgsWmsTiledImageDownloadHandler()
@@ -3583,10 +3608,14 @@ void QgsWmsTiledImageDownloadHandler::tileReplyFinished()
   }
   else
   {
-    QgsWmsStatistics::Stat& stat = QgsWmsStatistics::statForUri( mProviderUri );
-    stat.errors++;
+    // report any errors except for the one we have caused by cancelling the request
+    if ( reply->error() != QNetworkReply::OperationCanceledError )
+    {
+      QgsWmsStatistics::Stat& stat = QgsWmsStatistics::statForUri( mProviderUri );
+      stat.errors++;
 
-    repeatTileRequest( reply->request() );
+      repeatTileRequest( reply->request() );
+    }
 
     mReplies.removeOne( reply );
     reply->deleteLater();
@@ -3603,6 +3632,16 @@ void QgsWmsTiledImageDownloadHandler::tileReplyFinished()
                       + tr( ", %n errors.", "errors", stat.errors )
                     );
 #endif
+}
+
+void QgsWmsTiledImageDownloadHandler::cancelled()
+{
+  QgsDebugMsg( "Caught cancelled() signal" );
+  Q_FOREACH ( QNetworkReply* reply, mReplies )
+  {
+    QgsDebugMsg( "Aborting tiled network request" );
+    reply->abort();
+  }
 }
 
 

--- a/src/providers/wms/qgswmsprovider.h
+++ b/src/providers/wms/qgswmsprovider.h
@@ -163,7 +163,7 @@ class QgsWmsProvider : public QgsRasterDataProvider
      */
     QImage *draw( QgsRectangle const &  viewExtent, int pixelWidth, int pixelHeight ) override;
 
-    void readBlock( int bandNo, QgsRectangle  const & viewExtent, int width, int height, void *data ) override;
+    void readBlock( int bandNo, QgsRectangle  const & viewExtent, int width, int height, void *data, QgsRasterBlockFeedback* feedback = nullptr ) override;
     //void readBlock( int bandNo, QgsRectangle  const & viewExtent, int width, int height, QgsCoordinateReferenceSystem theSrcCRS, QgsCoordinateReferenceSystem theDestCRS, void *data );
 
     virtual QgsRectangle extent() const override;
@@ -363,6 +363,8 @@ class QgsWmsProvider : public QgsRasterDataProvider
 
   private:
 
+    QImage *draw( QgsRectangle const &  viewExtent, int pixelWidth, int pixelHeight, QgsRasterBlockFeedback* feedback );
+
     /**
      * Try to get best extent for the layer in given CRS. Returns true on success, false otherwise (layer not found, invalid CRS, transform failed)
      */
@@ -561,7 +563,7 @@ class QgsWmsImageDownloadHandler : public QObject
 {
     Q_OBJECT
   public:
-    QgsWmsImageDownloadHandler( const QString& providerUri, const QUrl& url, const QgsWmsAuthorization& auth, QImage* image );
+    QgsWmsImageDownloadHandler( const QString& providerUri, const QUrl& url, const QgsWmsAuthorization& auth, QImage* image, QgsRasterBlockFeedback* feedback );
     ~QgsWmsImageDownloadHandler();
 
     void downloadBlocking();
@@ -569,6 +571,7 @@ class QgsWmsImageDownloadHandler : public QObject
   protected slots:
     void cacheReplyFinished();
     void cacheReplyProgress( qint64 bytesReceived, qint64 bytesTotal );
+    void cancelled();
 
   protected:
     void finish() { QMetaObject::invokeMethod( mEventLoop, "quit", Qt::QueuedConnection ); }
@@ -600,13 +603,14 @@ class QgsWmsTiledImageDownloadHandler : public QObject
       int index;
     };
 
-    QgsWmsTiledImageDownloadHandler( const QString& providerUri, const QgsWmsAuthorization& auth, int reqNo, const QList<TileRequest>& requests, QImage* cachedImage, const QgsRectangle& cachedViewExtent, bool smoothPixmapTransform );
+    QgsWmsTiledImageDownloadHandler( const QString& providerUri, const QgsWmsAuthorization& auth, int reqNo, const QList<TileRequest>& requests, QImage* cachedImage, const QgsRectangle& cachedViewExtent, bool smoothPixmapTransform, QgsRasterBlockFeedback* feedback );
     ~QgsWmsTiledImageDownloadHandler();
 
     void downloadBlocking();
 
   protected slots:
     void tileReplyFinished();
+    void cancelled();
 
   protected:
     /**

--- a/tests/src/python/utilities.py
+++ b/tests/src/python/utilities.py
@@ -545,12 +545,15 @@ class DoxygenParser():
         # test for "added in QGIS xxx" string
         d = e.find('detaileddescription')
         found_version_added = False
-        if d.find('para'):
-            for s in d.find('para').getiterator('simplesect'):
+        for para in d.getiterator('para'):
+            for s in para.getiterator('simplesect'):
                 if s.get('kind') == 'note':
                     for p in s.getiterator('para'):
                         if p.text and p.text.lower().startswith('added in'):
                             found_version_added = True
+                            break
+            if found_version_added:
+                break
 
         return documentable_members, documented_members, undocumented_members, bindable_members, has_brief_description, found_version_added
 


### PR DESCRIPTION
First part of the work to improve rendering of raster layers. With this PR, it is possible to prematurely cancel rendering of raster layers, making it possible to browse the map faster. Especially useful for rasters coming from remote servers.

Raster pipe works with an optional feedback object that can be used to signal cancellation to data providers without having to poll for a "rendering stopped" variable as like with QgsRenderContext. The feedback object may be later used also the other way round - to signal from raster data provider that some data are available and thus a preview of the raster may be produced).

Requires raster data provider support - so far available for WMS, WMTS, WCS.
