### PR TITLE
QgsVectorDataProvider::Capability improvements

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -198,12 +198,15 @@ attributeIndexes(), pkAttributeIndexes(), isSaveAndLoadStyleToDBSupported()</li>
 <li>QgsGroupWMSDataDialo has been renamed to QgsGroupWmsDataDialog</li>
 </ul>
 
-\subsection qgis_api_break_3_0_DataProviders Data Providers
+\subsection qgis_api_break_3_0_QgsVectorDataProvider QgsVectorDataProvider
 
 <ul>
 <li>QgsVectorDataProvider::fields() now returns a copy, rather than a const reference. Since QgsFields
 objects are implicitly shared, returning a copy helps simplify and make code more robust. This change
 only affects third party c++ providers, and does not affect PyQGIS scripts.</li>
+<li>The SaveAsShapefile, SelectGeometryAtId, RandomSelectGeometryAtId and SequentialSelectGeometryAtId
+capabilities have been removed, as they were unused and had no effect.</li>
+<li>capabilities() now returns a typesafe QgsVectorDataProvider::Capabilities object, not an integer.</li>
 </ul>
 
 \subsection qgis_api_break_3_0_QgsLabelingEngineInterface QgsLabelingEngineInterface

--- a/python/core/qgsvectordataprovider.sip
+++ b/python/core/qgsvectordataprovider.sip
@@ -25,20 +25,12 @@ class QgsVectorDataProvider : QgsDataProvider
       AddAttributes,
       /** Allows deletion of attributes (fields) */
       DeleteAttributes,
-      /** DEPRECATED - do not use */
-      SaveAsShapefile,
       /** Allows creation of spatial index */
       CreateSpatialIndex,
       /** Fast access to features using their ID */
       SelectAtId,
       /** Allows modifications of geometries */
       ChangeGeometries,
-      /** DEPRECATED - do not use */
-      SelectGeometryAtId,
-      /** DEPRECATED - do not use */
-      RandomSelectGeometryAtId,
-      /** DEPRECATED - do not use */
-      SequentialSelectGeometryAtId,
       /** DEPRECATED - do not use */
       CreateAttributeIndex,
       /** Allows user to select encoding */
@@ -58,6 +50,7 @@ class QgsVectorDataProvider : QgsDataProvider
       /** Supports renaming attributes (fields). Added in QGIS 2.16 */
       RenameAttributes,
     };
+    typedef QFlags<QgsVectorDataProvider::Capability> Capabilities;
 
     /** Bitmask of all provider's editing capabilities */
     static const int EditingCapabilities;
@@ -257,11 +250,11 @@ class QgsVectorDataProvider : QgsDataProvider
     virtual bool createAttributeIndex( int field );
 
     /** Returns a bitmask containing the supported capabilities
-        Note, some capabilities may change depending on whether
+        @note, some capabilities may change depending on whether
         a spatial filter is active on this provider, so it may
         be prudent to check this value per intended operation.
      */
-    virtual int capabilities() const;
+    virtual Capabilities capabilities() const;
 
     /**
      *  Returns the above in friendly format.
@@ -394,3 +387,5 @@ class QgsVectorDataProvider : QgsDataProvider
     @return the converted geometry or nullptr if no conversion was necessary or possible*/
     QgsGeometry* convertToProviderType( const QgsGeometry* geom ) const /Factory/;
 };
+
+QFlags<QgsVectorDataProvider::Capability> operator|(QgsVectorDataProvider::Capability f1, QFlags<QgsVectorDataProvider::Capability> f2);

--- a/src/core/qgsvectordataprovider.cpp
+++ b/src/core/qgsvectordataprovider.cpp
@@ -124,7 +124,7 @@ bool QgsVectorDataProvider::createAttributeIndex( int field )
   return true;
 }
 
-int QgsVectorDataProvider::capabilities() const
+QgsVectorDataProvider::Capabilities QgsVectorDataProvider::capabilities() const
 {
   return QgsVectorDataProvider::NoCapabilities;
 }

--- a/src/core/qgsvectordataprovider.h
+++ b/src/core/qgsvectordataprovider.h
@@ -71,24 +71,16 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider
       AddAttributes =                               1 <<  3,
       /** Allows deletion of attributes (fields) */
       DeleteAttributes =                            1 <<  4,
-      /** DEPRECATED - do not use */
-      SaveAsShapefile =                             1 <<  5,
       /** Allows creation of spatial index */
       CreateSpatialIndex =                          1 <<  6,
       /** Fast access to features using their ID */
       SelectAtId =                                  1 <<  7,
       /** Allows modifications of geometries */
       ChangeGeometries =                            1 <<  8,
-      /** DEPRECATED - do not use */
-      SelectGeometryAtId =                          1 <<  9,
-      /** DEPRECATED - do not use */
-      RandomSelectGeometryAtId =                    1 << 10,
-      /** DEPRECATED - do not use */
-      SequentialSelectGeometryAtId =                1 << 11,
-      /** DEPRECATED - do not use */
-      CreateAttributeIndex =                        1 << 12,
       /** Allows user to select encoding */
       SelectEncoding =                              1 << 13,
+      /** DEPRECATED - do not use */
+      CreateAttributeIndex =                        1 << 12,
       /** Supports simplification of geometries on provider side according to a distance tolerance */
       SimplifyGeometries =                          1 << 14,
       /** Supports topological simplification of geometries on provider side according to a distance tolerance */
@@ -104,6 +96,8 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider
       /** Supports renaming attributes (fields). Added in QGIS 2.16 */
       RenameAttributes =                            1 << 19,
     };
+
+    Q_DECLARE_FLAGS( Capabilities, Capability )
 
     /** Bitmask of all provider's editing capabilities */
     const static int EditingCapabilities = AddFeatures | DeleteFeatures |
@@ -304,12 +298,12 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider
     /** Create an attribute index on the datasource*/
     virtual bool createAttributeIndex( int field );
 
-    /** Returns a bitmask containing the supported capabilities
-        Note, some capabilities may change depending on whether
+    /** Returns flags containing the supported capabilities
+        @note, some capabilities may change depending on whether
         a spatial filter is active on this provider, so it may
         be prudent to check this value per intended operation.
      */
-    virtual int capabilities() const;
+    virtual Capabilities capabilities() const;
 
     /**
      *  Returns the above in friendly format.
@@ -483,6 +477,8 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider
     virtual void setTransaction( QgsTransaction* /*transaction*/ ) {}
 
 };
+
+Q_DECLARE_OPERATORS_FOR_FLAGS( QgsVectorDataProvider::Capabilities )
 
 
 #endif

--- a/src/providers/arcgisrest/qgsafsprovider.h
+++ b/src/providers/arcgisrest/qgsafsprovider.h
@@ -53,7 +53,7 @@ class QgsAfsProvider : public QgsVectorDataProvider
     bool changeAttributeValues( const QgsChangedAttributesMap &attr_map ) override{ return false; }
     bool changeGeometryValues( QgsGeometryMap & geometry_map ) override{ return false; }
     */
-    int capabilities() const override { return QgsVectorDataProvider::NoCapabilities; }
+    QgsVectorDataProvider::Capabilities capabilities() const override { return QgsVectorDataProvider::NoCapabilities; }
     QgsAttributeList pkAttributeIndexes() const override { return QgsAttributeList() << mObjectIdFieldIdx; }
     QgsAttrPalIndexNameHash palAttributeIndexNames() const override { return QgsAttrPalIndexNameHash(); }
 

--- a/src/providers/db2/qgsdb2provider.cpp
+++ b/src/providers/db2/qgsdb2provider.cpp
@@ -1180,9 +1180,9 @@ bool QgsDb2Provider::addFeatures( QgsFeatureList & flist )
   return true;
 }
 
-int QgsDb2Provider::capabilities() const
+QgsVectorDataProvider::Capabilities QgsDb2Provider::capabilities() const
 {
-  int cap = AddFeatures;
+  QgsVectorDataProvider::Capabilities cap = AddFeatures;
   bool hasGeom = false;
   if ( !mGeometryColName.isEmpty() )
   {
@@ -1195,7 +1195,7 @@ int QgsDb2Provider::capabilities() const
   else
   {
     if ( hasGeom )
-      cap |= ChangeGeometries | QgsVectorDataProvider::SelectGeometryAtId;
+      cap |= ChangeGeometries;
 
     return cap | DeleteFeatures | ChangeAttributeValues |
            QgsVectorDataProvider::SelectAtId;

--- a/src/providers/db2/qgsdb2provider.h
+++ b/src/providers/db2/qgsdb2provider.h
@@ -106,7 +106,7 @@ class QgsDb2Provider : public QgsVectorDataProvider
         a spatial filter is active on this provider, so it may
         be prudent to check this value per intended operation.
      */
-    virtual int capabilities() const override;
+    virtual QgsVectorDataProvider::Capabilities capabilities() const override;
 
     /** Writes a list of features to the database*/
     virtual bool addFeatures( QgsFeatureList & flist ) override;

--- a/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextprovider.cpp
@@ -1145,7 +1145,7 @@ bool QgsDelimitedTextProvider::isValid() const
   return mLayerValid;
 }
 
-int QgsDelimitedTextProvider::capabilities() const
+QgsVectorDataProvider::Capabilities QgsDelimitedTextProvider::capabilities() const
 {
   return SelectAtId | CreateSpatialIndex | CircularGeometries;
 }

--- a/src/providers/delimitedtext/qgsdelimitedtextprovider.h
+++ b/src/providers/delimitedtext/qgsdelimitedtextprovider.h
@@ -109,7 +109,7 @@ class QgsDelimitedTextProvider : public QgsVectorDataProvider
      * a spatial filter is active on this provider, so it may
      * be prudent to check this value per intended operation.
      */
-    virtual int capabilities() const override;
+    virtual QgsVectorDataProvider::Capabilities capabilities() const override;
 
     /** Creates a spatial index on the data
      * @return indexCreated  Returns true if a spatial index is created

--- a/src/providers/gpx/qgsgpxprovider.cpp
+++ b/src/providers/gpx/qgsgpxprovider.cpp
@@ -125,7 +125,7 @@ QString QgsGPXProvider::storageType() const
   return tr( "GPS eXchange file" );
 }
 
-int QgsGPXProvider::capabilities() const
+QgsVectorDataProvider::Capabilities QgsGPXProvider::capabilities() const
 {
   return QgsVectorDataProvider::AddFeatures |
          QgsVectorDataProvider::DeleteFeatures |

--- a/src/providers/gpx/qgsgpxprovider.h
+++ b/src/providers/gpx/qgsgpxprovider.h
@@ -91,7 +91,7 @@ class QgsGPXProvider : public QgsVectorDataProvider
      */
     virtual bool changeAttributeValues( const QgsChangedAttributesMap & attr_map ) override;
 
-    virtual int capabilities() const override;
+    virtual QgsVectorDataProvider::Capabilities capabilities() const override;
 
     virtual QVariant defaultValue( int fieldId ) const override;
 

--- a/src/providers/grass/qgsgrassprovider.cpp
+++ b/src/providers/grass/qgsgrassprovider.cpp
@@ -293,7 +293,7 @@ QgsGrassProvider::~QgsGrassProvider()
   }
 }
 
-int QgsGrassProvider::capabilities() const
+QgsVectorDataProvider::Capabilities QgsGrassProvider::capabilities() const
 {
   // Because of bug in GRASS https://trac.osgeo.org/grass/ticket/2775 it is not possible
   // close db drivers in random order on Unix and probably Mac -> disable editing if another layer is edited

--- a/src/providers/grass/qgsgrassprovider.h
+++ b/src/providers/grass/qgsgrassprovider.h
@@ -63,7 +63,7 @@ class GRASS_LIB_EXPORT QgsGrassProvider : public QgsVectorDataProvider
 
     virtual ~QgsGrassProvider();
 
-    virtual int capabilities() const override;
+    virtual QgsVectorDataProvider::Capabilities capabilities() const override;
 
     virtual QgsAbstractFeatureSource* featureSource() const override;
 

--- a/src/providers/memory/qgsmemoryprovider.cpp
+++ b/src/providers/memory/qgsmemoryprovider.cpp
@@ -526,11 +526,11 @@ bool QgsMemoryProvider::createSpatialIndex()
   return true;
 }
 
-int QgsMemoryProvider::capabilities() const
+QgsVectorDataProvider::Capabilities QgsMemoryProvider::capabilities() const
 {
   return AddFeatures | DeleteFeatures | ChangeGeometries |
          ChangeAttributeValues | AddAttributes | DeleteAttributes | RenameAttributes | CreateSpatialIndex |
-         SelectAtId | SelectGeometryAtId | CircularGeometries;
+         SelectAtId | CircularGeometries;
 }
 
 

--- a/src/providers/memory/qgsmemoryprovider.h
+++ b/src/providers/memory/qgsmemoryprovider.h
@@ -126,7 +126,7 @@ class QgsMemoryProvider : public QgsVectorDataProvider
     a spatial filter is active on this provider, so it may
     be prudent to check this value per intended operation.
      */
-    virtual int capabilities() const override;
+    virtual QgsVectorDataProvider::Capabilities capabilities() const override;
 
     /* Implementation of functions from QgsDataProvider */
 

--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -1311,9 +1311,9 @@ bool QgsMssqlProvider::deleteFeatures( const QgsFeatureIds & id )
   return true;
 }
 
-int QgsMssqlProvider::capabilities() const
+QgsVectorDataProvider::Capabilities QgsMssqlProvider::capabilities() const
 {
-  int cap = CreateAttributeIndex | AddFeatures | AddAttributes;
+  QgsVectorDataProvider::Capabilities cap = CreateAttributeIndex | AddFeatures | AddAttributes;
   bool hasGeom = false;
   if ( !mGeometryColName.isEmpty() )
   {
@@ -1326,7 +1326,7 @@ int QgsMssqlProvider::capabilities() const
   else
   {
     if ( hasGeom )
-      cap |= ChangeGeometries | QgsVectorDataProvider::SelectGeometryAtId;
+      cap |= ChangeGeometries;
 
     return cap | DeleteFeatures | ChangeAttributeValues | DeleteAttributes |
            QgsVectorDataProvider::SelectAtId;

--- a/src/providers/mssql/qgsmssqlprovider.h
+++ b/src/providers/mssql/qgsmssqlprovider.h
@@ -108,7 +108,7 @@ class QgsMssqlProvider : public QgsVectorDataProvider
         a spatial filter is active on this provider, so it may
         be prudent to check this value per intended operation.
      */
-    virtual int capabilities() const override;
+    virtual QgsVectorDataProvider::Capabilities capabilities() const override;
 
 
     /* Implementation of functions from QgsDataProvider */

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -1739,14 +1739,14 @@ bool QgsOgrProvider::doInitialActionsForEdition()
   return true;
 }
 
-int QgsOgrProvider::capabilities() const
+QgsVectorDataProvider::Capabilities QgsOgrProvider::capabilities() const
 {
   return mCapabilities;
 }
 
 void QgsOgrProvider::computeCapabilities()
 {
-  int ability = 0;
+  QgsVectorDataProvider::Capabilities ability = 0;
 
   // collect abilities reported by OGR
   if ( ogrLayer )
@@ -1764,7 +1764,7 @@ void QgsOgrProvider::computeCapabilities()
       //       (vs read from disk every time) based on this setting.
     {
       // the latter flag is here just for compatibility
-      ability |= QgsVectorDataProvider::SelectAtId | QgsVectorDataProvider::SelectGeometryAtId;
+      ability |= QgsVectorDataProvider::SelectAtId;
     }
 
     if ( mWriteAccessPossible && OGR_L_TestCapability( ogrLayer, "SequentialWrite" ) )

--- a/src/providers/ogr/qgsogrprovider.h
+++ b/src/providers/ogr/qgsogrprovider.h
@@ -154,7 +154,7 @@ class QgsOgrProvider : public QgsVectorDataProvider
         be prudent to check this value per intended operation.
         See the OGRLayer::TestCapability API for details.
       */
-    virtual int capabilities() const override;
+    virtual QgsVectorDataProvider::Capabilities capabilities() const override;
 
     virtual void setEncoding( const QString& e ) override;
 
@@ -369,7 +369,7 @@ class QgsOgrProvider : public QgsVectorDataProvider
 
     void computeCapabilities();
 
-    int mCapabilities;
+    QgsVectorDataProvider::Capabilities mCapabilities;
 
     bool doInitialActionsForEdition();
 };

--- a/src/providers/oracle/qgsoracleprovider.cpp
+++ b/src/providers/oracle/qgsoracleprovider.cpp
@@ -764,7 +764,7 @@ bool QgsOracleProvider::hasSufficientPermsAndCapabilities()
 {
   QgsDebugMsg( "Checking for permissions on the relation" );
 
-  mEnabledCapabilities = QgsVectorDataProvider::SelectAtId | QgsVectorDataProvider::SelectGeometryAtId;
+  mEnabledCapabilities = QgsVectorDataProvider::SelectAtId;
 
   QSqlQuery qry( *mConnection );
   if ( !mIsQuery )
@@ -2064,7 +2064,7 @@ bool QgsOracleProvider::changeGeometryValues( const QgsGeometryMap &geometry_map
   return returnvalue;
 }
 
-int QgsOracleProvider::capabilities() const
+QgsVectorDataProvider::Capabilities QgsOracleProvider::capabilities() const
 {
   return mEnabledCapabilities;
 }

--- a/src/providers/oracle/qgsoracleprovider.h
+++ b/src/providers/oracle/qgsoracleprovider.h
@@ -240,7 +240,7 @@ class QgsOracleProvider : public QgsVectorDataProvider
     virtual bool supportsSubsetString() const override { return true; }
 
     /** Returns a bitmask containing the supported capabilities*/
-    int capabilities() const override;
+    QgsVectorDataProvider::Capabilities capabilities() const override;
 
     /** Return a provider name
      *
@@ -350,7 +350,7 @@ class QgsOracleProvider : public QgsVectorDataProvider
     mutable QgsRectangle mLayerExtent; //! Rectangle that contains the extent (bounding box) of the layer
     mutable long mFeaturesCounted;     //! Number of features in the layer
     int mSrid;                         //! srid of column
-    int mEnabledCapabilities;          //! capabilities of layer
+    QgsVectorDataProvider::Capabilities mEnabledCapabilities;          //! capabilities of layer
 
     Qgis::WkbType mDetectedGeomType;   //! geometry type detected in the database
     Qgis::WkbType mRequestedGeomType;  //! geometry type requested in the uri

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -1085,7 +1085,7 @@ bool QgsPostgresProvider::hasSufficientPermsAndCapabilities()
     // the latter flag is here just for compatibility
     if ( !mSelectAtIdDisabled )
     {
-      mEnabledCapabilities = QgsVectorDataProvider::SelectAtId | QgsVectorDataProvider::SelectGeometryAtId;
+      mEnabledCapabilities = QgsVectorDataProvider::SelectAtId;
     }
 
     if ( !inRecovery )
@@ -1210,7 +1210,7 @@ bool QgsPostgresProvider::hasSufficientPermsAndCapabilities()
 
     if ( !mSelectAtIdDisabled )
     {
-      mEnabledCapabilities = QgsVectorDataProvider::SelectAtId | QgsVectorDataProvider::SelectGeometryAtId;
+      mEnabledCapabilities = QgsVectorDataProvider::SelectAtId;
     }
   }
 
@@ -2830,7 +2830,7 @@ QgsAttributeList QgsPostgresProvider::attributeIndexes() const
   return lst;
 }
 
-int QgsPostgresProvider::capabilities() const
+QgsVectorDataProvider::Capabilities QgsPostgresProvider::capabilities() const
 {
   return mEnabledCapabilities;
 }

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -203,7 +203,7 @@ class QgsPostgresProvider : public QgsVectorDataProvider
     virtual bool supportsSubsetString() const override { return true; }
 
     /** Returns a bitmask containing the supported capabilities*/
-    int capabilities() const override;
+    QgsVectorDataProvider::Capabilities capabilities() const override;
 
     /** The Postgres provider does its own transforms so we return
      * true for the following three functions to indicate that transforms
@@ -430,7 +430,7 @@ class QgsPostgresProvider : public QgsVectorDataProvider
     // A function that determines if the given columns contain unique entries
     bool uniqueData( const QString& quotedColNames );
 
-    int mEnabledCapabilities;
+    QgsVectorDataProvider::Capabilities mEnabledCapabilities;
 
     void appendGeomParam( const QgsGeometry *geom, QStringList &param ) const;
     void appendPkParams( QgsFeatureId fid, QStringList &param ) const;

--- a/src/providers/spatialite/qgsspatialiteprovider.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovider.cpp
@@ -509,7 +509,7 @@ QgsSpatiaLiteProvider::QgsSpatiaLiteProvider( QString const &uri )
     closeDb();
     return;
   }
-  mEnabledCapabilities = mPrimaryKey.isEmpty() ? 0 : ( QgsVectorDataProvider::SelectAtId | QgsVectorDataProvider::SelectGeometryAtId );
+  mEnabledCapabilities = mPrimaryKey.isEmpty() ? QgsVectorDataProvider::Capabilities() : ( QgsVectorDataProvider::SelectAtId );
   if (( mTableBased || mViewBased ) &&  !mReadOnly )
   {
     // enabling editing only for Tables [excluding Views and VirtualShapes]
@@ -612,12 +612,10 @@ void QgsSpatiaLiteProvider::updatePrimaryKeyCapabilities()
   if ( mPrimaryKey.isEmpty() )
   {
     mEnabledCapabilities &= ~QgsVectorDataProvider::SelectAtId;
-    mEnabledCapabilities &= ~QgsVectorDataProvider::SelectGeometryAtId;
   }
   else
   {
     mEnabledCapabilities |= QgsVectorDataProvider::SelectAtId;
-    mEnabledCapabilities |= QgsVectorDataProvider::SelectGeometryAtId;
   }
 }
 
@@ -4148,7 +4146,7 @@ abort:
   return false;
 }
 
-int QgsSpatiaLiteProvider::capabilities() const
+QgsVectorDataProvider::Capabilities QgsSpatiaLiteProvider::capabilities() const
 {
   return mEnabledCapabilities;
 }

--- a/src/providers/spatialite/qgsspatialiteprovider.h
+++ b/src/providers/spatialite/qgsspatialiteprovider.h
@@ -163,7 +163,7 @@ class QgsSpatiaLiteProvider: public QgsVectorDataProvider
     bool changeGeometryValues( const QgsGeometryMap &geometry_map ) override;
 
     /** Returns a bitmask containing the supported capabilities*/
-    int capabilities() const override;
+    QgsVectorDataProvider::Capabilities capabilities() const override;
 
     /** The SpatiaLite provider does its own transforms so we return
      * true for the following three functions to indicate that transforms
@@ -368,7 +368,7 @@ class QgsSpatiaLiteProvider: public QgsVectorDataProvider
     //! this Geometry is supported by an MBR cache spatial index
     bool mSpatialIndexMbrCache;
 
-    int mEnabledCapabilities;
+    QgsVectorDataProvider::Capabilities mEnabledCapabilities;
 
     const QgsField &field( int index ) const;
 

--- a/src/providers/virtual/qgsvirtuallayerprovider.cpp
+++ b/src/providers/virtual/qgsvirtuallayerprovider.cpp
@@ -563,11 +563,11 @@ bool QgsVirtualLayerProvider::isValid() const
   return mValid;
 }
 
-int QgsVirtualLayerProvider::capabilities() const
+QgsVectorDataProvider::Capabilities QgsVirtualLayerProvider::capabilities() const
 {
   if ( !mDefinition.uid().isNull() )
   {
-    return SelectAtId | SelectGeometryAtId;
+    return SelectAtId;
   }
   return 0;
 }

--- a/src/providers/virtual/qgsvirtuallayerprovider.h
+++ b/src/providers/virtual/qgsvirtuallayerprovider.h
@@ -68,7 +68,7 @@ class QgsVirtualLayerProvider: public QgsVectorDataProvider
     bool isValid() const override;
 
     /** Returns a bitmask containing the supported capabilities*/
-    int capabilities() const override;
+    QgsVectorDataProvider::Capabilities capabilities() const override;
 
     /** Return the provider name */
     QString name() const override;

--- a/src/providers/wfs/qgswfsprovider.cpp
+++ b/src/providers/wfs/qgswfsprovider.cpp
@@ -1309,7 +1309,7 @@ QString QgsWFSProvider::description() const
   return TEXT_PROVIDER_DESCRIPTION;
 }
 
-int QgsWFSProvider::capabilities() const
+QgsVectorDataProvider::Capabilities QgsWFSProvider::capabilities() const
 {
   return mCapabilities;
 }

--- a/src/providers/wfs/qgswfsprovider.h
+++ b/src/providers/wfs/qgswfsprovider.h
@@ -92,7 +92,7 @@ class QgsWFSProvider : public QgsVectorDataProvider
     QString name() const override;
     QString description() const override;
 
-    virtual int capabilities() const override;
+    virtual QgsVectorDataProvider::Capabilities capabilities() const override;
 
     /* new functions */
 
@@ -161,7 +161,7 @@ class QgsWFSProvider : public QgsVectorDataProvider
     /** Namespace URL of the server (comes from DescribeFeatureDocument)*/
     QString mApplicationNamespace;
     /** Server capabilities for this layer (generated from capabilities document)*/
-    int mCapabilities;
+    QgsVectorDataProvider::Capabilities mCapabilities;
     /** Fields of this typename. Might be different from mShared->mFields in case of SELECT */
     QgsFields mThisTypenameFields;
 

--- a/tests/src/python/test_provider_wfs.py
+++ b/tests/src/python/test_provider_wfs.py
@@ -557,10 +557,10 @@ class TestPyQgsWFSProvider(unittest.TestCase, ProviderTestCase):
         assert vl.isValid()
 
         self.assertEqual(vl.dataProvider().capabilities(),
-                         QgsVectorDataProvider.AddFeatures +
-                         QgsVectorDataProvider.ChangeAttributeValues +
-                         QgsVectorDataProvider.ChangeGeometries +
-                         QgsVectorDataProvider.DeleteFeatures +
+                         QgsVectorDataProvider.AddFeatures |
+                         QgsVectorDataProvider.ChangeAttributeValues |
+                         QgsVectorDataProvider.ChangeGeometries |
+                         QgsVectorDataProvider.DeleteFeatures |
                          QgsVectorDataProvider.SelectAtId)
 
         (ret, _) = vl.dataProvider().addFeatures([QgsFeature()])


### PR DESCRIPTION
- Remove some deprecated capabilities
- Also make capabilities() return a QFlags QgsVectorDataProvider::Capabilities, rather than an integer
  value (for type safety)
