### PR TITLE
New method for calculating geometry boundary

### DIFF
--- a/python/core/geometry/qgsabstractgeometryv2.sip
+++ b/python/core/geometry/qgsabstractgeometryv2.sip
@@ -130,6 +130,13 @@ class QgsAbstractGeometryV2
      */
     bool isMeasure() const;
 
+    /** Returns the closure of the combinatorial boundary of the geometry (ie the topological boundary of the geometry).
+     * For instance, a polygon geometry will have a boundary consisting of the linestrings for each ring in the polygon.
+     * @returns boundary for geometry. May be null for some geometry types.
+     * @note added in QGIS 3.0
+     */
+    virtual QgsAbstractGeometryV2* boundary() const = 0;
+
     //import
 
     /** Sets the geometry from a WKB string.

--- a/python/core/geometry/qgscurvepolygonv2.sip
+++ b/python/core/geometry/qgscurvepolygonv2.sip
@@ -29,6 +29,8 @@ class QgsCurvePolygonV2: public QgsSurfaceV2
     virtual double area() const;
     virtual double perimeter() const;
     QgsPolygonV2* surfaceToPolygon() const;
+    virtual QgsAbstractGeometryV2* boundary() const /Factory/;
+
 
     //curve polygon interface
     int numInteriorRings() const;

--- a/python/core/geometry/qgscurvev2.sip
+++ b/python/core/geometry/qgscurvev2.sip
@@ -75,6 +75,8 @@ class QgsCurveV2: public QgsAbstractGeometryV2
      */
     virtual QgsCurveV2* reversed() const = 0 /Factory/;
 
+    virtual QgsAbstractGeometryV2* boundary() const /Factory/;
+
     /** Returns a geometry without curves. Caller takes ownership
     * @param tolerance segmentation tolerance
     * @param toleranceType maximum segmentation angle or maximum difference between approximation and curve*/

--- a/python/core/geometry/qgsgeometrycollectionv2.sip
+++ b/python/core/geometry/qgsgeometrycollectionv2.sip
@@ -30,6 +30,7 @@ class QgsGeometryCollectionV2: public QgsAbstractGeometryV2
     virtual int dimension() const;
     virtual QString geometryType() const;
     virtual void clear();
+    virtual QgsAbstractGeometryV2* boundary() const /Factory/;
 
     /** Adds a geometry and takes ownership. Returns true in case of success.*/
     virtual bool addGeometry( QgsAbstractGeometryV2* g /Transfer/ );

--- a/python/core/geometry/qgsmulticurvev2.sip
+++ b/python/core/geometry/qgsmulticurvev2.sip
@@ -26,4 +26,6 @@ class QgsMultiCurveV2: public QgsGeometryCollectionV2
      * @note added in QGIS 2.14
      */
     QgsMultiCurveV2* reversed() const /Factory/;
+
+    virtual QgsAbstractGeometryV2* boundary() const /Factory/;
 };

--- a/python/core/geometry/qgsmultipointv2.sip
+++ b/python/core/geometry/qgsmultipointv2.sip
@@ -20,6 +20,8 @@ class QgsMultiPointV2: public QgsGeometryCollectionV2
     /** Adds a geometry and takes ownership. Returns true in case of success*/
     virtual bool addGeometry( QgsAbstractGeometryV2* g );
 
+    virtual QgsAbstractGeometryV2* boundary() const /Factory/;
+
   protected:
 
     virtual bool wktOmitChildType() const;

--- a/python/core/geometry/qgsmultipolygonv2.sip
+++ b/python/core/geometry/qgsmultipolygonv2.sip
@@ -24,6 +24,8 @@ class QgsMultiPolygonV2: public QgsMultiSurfaceV2
     @return the converted geometry. Caller takes ownership*/
     QgsAbstractGeometryV2* toCurveType() const /Factory/;
 
+    virtual QgsAbstractGeometryV2* boundary() const /Factory/;
+
   protected:
 
     virtual bool wktOmitChildType() const;

--- a/python/core/geometry/qgsmultisurfacev2.sip
+++ b/python/core/geometry/qgsmultisurfacev2.sip
@@ -20,6 +20,8 @@ class QgsMultiSurfaceV2: public QgsGeometryCollectionV2
     /** Adds a geometry and takes ownership. Returns true in case of success*/
     virtual bool addGeometry( QgsAbstractGeometryV2* g );
 
+    virtual QgsAbstractGeometryV2* boundary() const /Factory/;
+
     /** Returns a geometry without curves. Caller takes ownership*/
     QgsAbstractGeometryV2* segmentize() const /Factory/;
 };

--- a/python/core/geometry/qgspointv2.sip
+++ b/python/core/geometry/qgspointv2.sip
@@ -157,6 +157,7 @@ class QgsPointV2: public QgsAbstractGeometryV2
                     bool transformZ = false );
     void transform( const QTransform& t );
     virtual QList< QList< QList< QgsPointV2 > > > coordinateSequence() const;
+    virtual QgsAbstractGeometryV2* boundary() const /Factory/;
 
     //low-level editing
     virtual bool insertVertex( QgsVertexId position, const QgsPointV2& vertex );

--- a/python/core/geometry/qgspolygonv2.sip
+++ b/python/core/geometry/qgspolygonv2.sip
@@ -35,4 +35,5 @@ class QgsPolygonV2: public QgsCurvePolygonV2
     //overridden to handle LineString25D rings
     virtual void setExteriorRing( QgsCurveV2* ring /Transfer/ );
 
+    virtual QgsAbstractGeometryV2* boundary() const /Factory/;
 };

--- a/resources/function_help/json/boundary
+++ b/resources/function_help/json/boundary
@@ -1,0 +1,8 @@
+{
+  "name": "boundary",
+  "type": "function",
+  "description":"Returns the closure of the combinatorial boundary of the geometry (ie the topological boundary of the geometry). For instance, a polygon geometry will have a boundary consisting of the linestrings for each ring in the polygon. Some geometry types do not have a defined boundary, eg points or geometry collections, and will return null.",
+  "arguments": [ {"arg":"geometry","description":"a geometry"} ],
+  "examples": [ { "expression":"geom_to_wkt(boundary(geom_from_wkt('Polygon((1 1, 0 0, -1 1, 1 1))')))", "returns":"'LineString(1 1,0 0,-1 1,1 1)'"}]
+}
+

--- a/src/core/geometry/qgsabstractgeometryv2.h
+++ b/src/core/geometry/qgsabstractgeometryv2.h
@@ -111,9 +111,15 @@ class CORE_EXPORT QgsAbstractGeometryV2
     virtual bool isValid() const = 0;
     virtual QgsMultiPointV2* locateAlong() const = 0;
     virtual QgsMultiCurveV2* locateBetween() const = 0;
-    virtual QgsCurveV2* boundary() const = 0;
     virtual QgsRectangle envelope() const = 0;
 #endif
+
+    /** Returns the closure of the combinatorial boundary of the geometry (ie the topological boundary of the geometry).
+     * For instance, a polygon geometry will have a boundary consisting of the linestrings for each ring in the polygon.
+     * @returns boundary for geometry. May be null for some geometry types.
+     * @note added in QGIS 3.0
+     */
+    virtual QgsAbstractGeometryV2* boundary() const = 0;
 
     //import
 

--- a/src/core/geometry/qgscurvepolygonv2.cpp
+++ b/src/core/geometry/qgscurvepolygonv2.cpp
@@ -23,6 +23,7 @@
 #include "qgslinestringv2.h"
 #include "qgspolygonv2.h"
 #include "qgswkbptr.h"
+#include "qgsmulticurvev2.h"
 #include <QPainter>
 #include <QPainterPath>
 
@@ -418,6 +419,25 @@ QgsPolygonV2* QgsCurvePolygonV2::surfaceToPolygon() const
   }
   polygon->setInteriorRings( interiors );
   return polygon;
+}
+
+QgsAbstractGeometryV2* QgsCurvePolygonV2::boundary() const
+{
+  if ( mInteriorRings.isEmpty() )
+  {
+    return mExteriorRing->clone();
+  }
+  else
+  {
+    QgsMultiCurveV2* multiCurve = new QgsMultiCurveV2();
+    multiCurve->addGeometry( mExteriorRing->clone() );
+    int nInteriorRings = mInteriorRings.size();
+    for ( int i = 0; i < nInteriorRings; ++i )
+    {
+      multiCurve->addGeometry( mInteriorRings.at( i )->clone() );
+    }
+    return multiCurve;
+  }
 }
 
 QgsPolygonV2* QgsCurvePolygonV2::toPolygon( double tolerance, SegmentationToleranceType toleranceType ) const

--- a/src/core/geometry/qgscurvepolygonv2.h
+++ b/src/core/geometry/qgscurvepolygonv2.h
@@ -55,6 +55,7 @@ class CORE_EXPORT QgsCurvePolygonV2: public QgsSurfaceV2
     virtual double area() const override;
     virtual double perimeter() const override;
     QgsPolygonV2* surfaceToPolygon() const override;
+    virtual QgsAbstractGeometryV2* boundary() const override;
 
     //curve polygon interface
     int numInteriorRings() const;

--- a/src/core/geometry/qgscurvev2.cpp
+++ b/src/core/geometry/qgscurvev2.cpp
@@ -18,6 +18,7 @@
 #include "qgscurvev2.h"
 #include "qgslinestringv2.h"
 #include "qgspointv2.h"
+#include "qgsmultipointv2.h"
 
 QgsCurveV2::QgsCurveV2(): QgsAbstractGeometryV2()
 {}
@@ -78,6 +79,20 @@ bool QgsCurveV2::nextVertex( QgsVertexId& id, QgsPointV2& vertex ) const
     ++id.vertex;
   }
   return pointAt( id.vertex, vertex, id.type );
+}
+
+QgsAbstractGeometryV2* QgsCurveV2::boundary() const
+{
+  if ( isEmpty() )
+    return nullptr;
+
+  if ( isClosed() )
+    return nullptr;
+
+  QgsMultiPointV2* multiPoint = new QgsMultiPointV2();
+  multiPoint->addGeometry( new QgsPointV2( startPoint() ) );
+  multiPoint->addGeometry( new QgsPointV2( endPoint() ) );
+  return multiPoint;
 }
 
 QgsCurveV2* QgsCurveV2::segmentize( double tolerance, SegmentationToleranceType toleranceType ) const

--- a/src/core/geometry/qgscurvev2.h
+++ b/src/core/geometry/qgscurvev2.h
@@ -102,6 +102,8 @@ class CORE_EXPORT QgsCurveV2: public QgsAbstractGeometryV2
      */
     virtual QgsCurveV2* reversed() const = 0;
 
+    virtual QgsAbstractGeometryV2* boundary() const override;
+
     /** Returns a geometry without curves. Caller takes ownership
      * @param tolerance segmentation tolerance
      * @param toleranceType maximum segmentation angle or maximum difference between approximation and curve*/

--- a/src/core/geometry/qgsgeometrycollectionv2.cpp
+++ b/src/core/geometry/qgsgeometrycollectionv2.cpp
@@ -75,6 +75,11 @@ void QgsGeometryCollectionV2::clear()
   clearCache(); //set bounding box invalid
 }
 
+QgsAbstractGeometryV2*QgsGeometryCollectionV2::boundary() const
+{
+  return nullptr;
+}
+
 int QgsGeometryCollectionV2::numGeometries() const
 {
   return mGeometries.size();

--- a/src/core/geometry/qgsgeometrycollectionv2.h
+++ b/src/core/geometry/qgsgeometrycollectionv2.h
@@ -54,6 +54,7 @@ class CORE_EXPORT QgsGeometryCollectionV2: public QgsAbstractGeometryV2
     virtual int dimension() const override;
     virtual QString geometryType() const override { return "GeometryCollection"; }
     virtual void clear() override;
+    virtual QgsAbstractGeometryV2* boundary() const override;
 
     /** Adds a geometry and takes ownership. Returns true in case of success.*/
     virtual bool addGeometry( QgsAbstractGeometryV2* g );

--- a/src/core/geometry/qgsmulticurvev2.cpp
+++ b/src/core/geometry/qgsmulticurvev2.cpp
@@ -20,6 +20,7 @@ email                : marco.hugentobler at sourcepole dot com
 #include "qgscompoundcurvev2.h"
 #include "qgsgeometryutils.h"
 #include "qgslinestringv2.h"
+#include "qgsmultipointv2.h"
 
 QgsMultiCurveV2::QgsMultiCurveV2()
     : QgsGeometryCollectionV2()
@@ -124,4 +125,26 @@ QgsMultiCurveV2* QgsMultiCurveV2::reversed() const
     }
   }
   return reversedMultiCurve;
+}
+
+QgsAbstractGeometryV2* QgsMultiCurveV2::boundary() const
+{
+  QgsMultiPointV2* multiPoint = new QgsMultiPointV2();
+  for ( int i = 0; i < mGeometries.size(); ++i )
+  {
+    if ( QgsCurveV2* curve = dynamic_cast<QgsCurveV2*>( mGeometries.at( i ) ) )
+    {
+      if ( !curve->isClosed() )
+      {
+        multiPoint->addGeometry( new QgsPointV2( curve->startPoint() ) );
+        multiPoint->addGeometry( new QgsPointV2( curve->endPoint() ) );
+      }
+    }
+  }
+  if ( multiPoint->numGeometries() == 0 )
+  {
+    delete multiPoint;
+    return nullptr;
+  }
+  return multiPoint;
 }

--- a/src/core/geometry/qgsmulticurvev2.h
+++ b/src/core/geometry/qgsmulticurvev2.h
@@ -47,6 +47,9 @@ class CORE_EXPORT QgsMultiCurveV2: public QgsGeometryCollectionV2
      * @note added in QGIS 2.14
      */
     QgsMultiCurveV2* reversed() const;
+
+    virtual QgsAbstractGeometryV2* boundary() const override;
+
 };
 
 #endif // QGSMULTICURVEV2_H

--- a/src/core/geometry/qgsmultilinestringv2.cpp
+++ b/src/core/geometry/qgsmultilinestringv2.cpp
@@ -118,3 +118,4 @@ QgsAbstractGeometryV2* QgsMultiLineStringV2::toCurveType() const
   }
   return multiCurve;
 }
+

--- a/src/core/geometry/qgsmultipointv2.cpp
+++ b/src/core/geometry/qgsmultipointv2.cpp
@@ -105,3 +105,8 @@ bool QgsMultiPointV2::addGeometry( QgsAbstractGeometryV2* g )
   setZMTypeFromSubGeometry( g, QgsWKBTypes::MultiPoint );
   return QgsGeometryCollectionV2::addGeometry( g );
 }
+
+QgsAbstractGeometryV2* QgsMultiPointV2::boundary() const
+{
+  return nullptr;
+}

--- a/src/core/geometry/qgsmultipointv2.h
+++ b/src/core/geometry/qgsmultipointv2.h
@@ -44,6 +44,8 @@ class CORE_EXPORT QgsMultiPointV2: public QgsGeometryCollectionV2
     /** Adds a geometry and takes ownership. Returns true in case of success*/
     virtual bool addGeometry( QgsAbstractGeometryV2* g ) override;
 
+    virtual QgsAbstractGeometryV2* boundary() const override;
+
   protected:
 
     virtual bool wktOmitChildType() const override { return true; }

--- a/src/core/geometry/qgsmultipolygonv2.h
+++ b/src/core/geometry/qgsmultipolygonv2.h
@@ -40,13 +40,14 @@ class CORE_EXPORT QgsMultiPolygonV2: public QgsMultiSurfaceV2
     QDomElement asGML3( QDomDocument& doc, int precision = 17, const QString& ns = "gml" ) const override;
     QString asJSON( int precision = 17 ) const override;
 
-
     /** Adds a geometry and takes ownership. Returns true in case of success*/
     virtual bool addGeometry( QgsAbstractGeometryV2* g ) override;
 
     /** Returns the geometry converted to the more generic curve type QgsMultiSurfaceV2
     @return the converted geometry. Caller takes ownership*/
     QgsAbstractGeometryV2* toCurveType() const override;
+
+    virtual QgsAbstractGeometryV2* boundary() const override;
 
   protected:
 

--- a/src/core/geometry/qgsmultisurfacev2.cpp
+++ b/src/core/geometry/qgsmultisurfacev2.cpp
@@ -21,6 +21,7 @@ email                : marco.hugentobler at sourcepole dot com
 #include "qgslinestringv2.h"
 #include "qgspolygonv2.h"
 #include "qgscurvepolygonv2.h"
+#include "qgsmulticurvev2.h"
 
 QgsMultiSurfaceV2::QgsMultiSurfaceV2()
     : QgsGeometryCollectionV2()
@@ -131,4 +132,22 @@ bool QgsMultiSurfaceV2::addGeometry( QgsAbstractGeometryV2* g )
 
   setZMTypeFromSubGeometry( g, QgsWKBTypes::MultiSurface );
   return QgsGeometryCollectionV2::addGeometry( g );
+}
+
+QgsAbstractGeometryV2* QgsMultiSurfaceV2::boundary() const
+{
+  QgsMultiCurveV2* multiCurve = new QgsMultiCurveV2();
+  for ( int i = 0; i < mGeometries.size(); ++i )
+  {
+    if ( QgsSurfaceV2* surface = dynamic_cast<QgsSurfaceV2*>( mGeometries.at( i ) ) )
+    {
+      multiCurve->addGeometry( surface->boundary() );
+    }
+  }
+  if ( multiCurve->numGeometries() == 0 )
+  {
+    delete multiCurve;
+    return nullptr;
+  }
+  return multiCurve;
 }

--- a/src/core/geometry/qgsmultisurfacev2.h
+++ b/src/core/geometry/qgsmultisurfacev2.h
@@ -43,6 +43,8 @@ class CORE_EXPORT QgsMultiSurfaceV2: public QgsGeometryCollectionV2
 
     /** Adds a geometry and takes ownership. Returns true in case of success*/
     virtual bool addGeometry( QgsAbstractGeometryV2* g ) override;
+
+    virtual QgsAbstractGeometryV2* boundary() const override;
 };
 
 #endif // QGSMULTISURFACEV2_H

--- a/src/core/geometry/qgspointv2.cpp
+++ b/src/core/geometry/qgspointv2.cpp
@@ -281,6 +281,11 @@ QgsCoordinateSequenceV2 QgsPointV2::coordinateSequence() const
   return cs;
 }
 
+QgsAbstractGeometryV2* QgsPointV2::boundary() const
+{
+  return nullptr;
+}
+
 /***************************************************************************
  * This class is considered CRITICAL and any change MUST be accompanied with
  * full unit tests.

--- a/src/core/geometry/qgspointv2.h
+++ b/src/core/geometry/qgspointv2.h
@@ -170,6 +170,7 @@ class CORE_EXPORT QgsPointV2: public QgsAbstractGeometryV2
                     bool transformZ = false ) override;
     void transform( const QTransform& t ) override;
     virtual QgsCoordinateSequenceV2 coordinateSequence() const override;
+    virtual QgsAbstractGeometryV2* boundary() const override;
 
     //low-level editing
     virtual bool insertVertex( QgsVertexId position, const QgsPointV2& vertex ) override { Q_UNUSED( position ); Q_UNUSED( vertex ); return false; }

--- a/src/core/geometry/qgspolygonv2.cpp
+++ b/src/core/geometry/qgspolygonv2.cpp
@@ -19,6 +19,7 @@
 #include "qgsapplication.h"
 #include "qgsgeometryutils.h"
 #include "qgslinestringv2.h"
+#include "qgsmultilinestringv2.h"
 #include "qgswkbptr.h"
 
 QgsPolygonV2::QgsPolygonV2()
@@ -240,6 +241,28 @@ void QgsPolygonV2::setExteriorRing( QgsCurveV2* ring )
   }
 
   clearCache();
+}
+
+QgsAbstractGeometryV2* QgsPolygonV2::boundary() const
+{
+  if ( !mExteriorRing )
+    return nullptr;
+
+  if ( mInteriorRings.isEmpty() )
+  {
+    return mExteriorRing->clone();
+  }
+  else
+  {
+    QgsMultiLineStringV2* multiLine = new QgsMultiLineStringV2();
+    multiLine->addGeometry( mExteriorRing->clone() );
+    int nInteriorRings = mInteriorRings.size();
+    for ( int i = 0; i < nInteriorRings; ++i )
+    {
+      multiLine->addGeometry( mInteriorRings.at( i )->clone() );
+    }
+    return multiLine;
+  }
 }
 
 QgsPolygonV2* QgsPolygonV2::surfaceToPolygon() const

--- a/src/core/geometry/qgspolygonv2.h
+++ b/src/core/geometry/qgspolygonv2.h
@@ -59,5 +59,7 @@ class CORE_EXPORT QgsPolygonV2: public QgsCurvePolygonV2
     //overridden to handle LineString25D rings
     virtual void setExteriorRing( QgsCurveV2* ring ) override;
 
+    virtual QgsAbstractGeometryV2* boundary() const override;
+
 };
 #endif // QGSPOLYGONV2_H

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -1825,6 +1825,20 @@ static QVariant fcnGeometryN( const QVariantList& values, const QgsExpressionCon
   return result;
 }
 
+static QVariant fcnBoundary( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
+{
+  QgsGeometry geom = getGeometry( values.at( 0 ), parent );
+
+  if ( geom.isEmpty() )
+    return QVariant();
+
+  QgsAbstractGeometryV2* boundary = geom.geometry()->boundary();
+  if ( !boundary )
+    return QVariant();
+
+  return QVariant::fromValue( QgsGeometry( boundary ) );
+}
+
 static QVariant fcnMakePoint( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   if ( values.count() < 2 || values.count() > 4 )
@@ -3173,6 +3187,7 @@ const QStringList& QgsExpression::BuiltinFunctions()
     << "disjoint" << "intersects" << "touches" << "crosses" << "contains"
     << "relate"
     << "overlaps" << "within" << "buffer" << "centroid" << "bounds" << "reverse" << "exterior_ring"
+    << "boundary"
     << "bounds_width" << "bounds_height" << "is_closed" << "convex_hull" << "difference"
     << "distance" << "intersection" << "sym_difference" << "combine"
     << "extrude" << "azimuth" <<  "project" << "closest_point" << "shortest_line"
@@ -3364,6 +3379,7 @@ const QList<QgsExpression::Function*>& QgsExpression::Functions()
     << new StaticFunction( "exterior_ring", 1, fcnExteriorRing, "GeometryGroup" )
     << new StaticFunction( "interior_ring_n", 2, fcnInteriorRingN, "GeometryGroup" )
     << new StaticFunction( "geometry_n", 2, fcnGeometryN, "GeometryGroup" )
+    << new StaticFunction( "boundary", ParameterList() << Parameter( "geometry" ), fcnBoundary, "GeometryGroup" )
     << new StaticFunction( "bounds", 1, fcnBounds, "GeometryGroup" )
     << new StaticFunction( "num_points", 1, fcnGeomNumPoints, "GeometryGroup" )
     << new StaticFunction( "num_interior_rings", 1, fcnGeomNumInteriorRings, "GeometryGroup" )

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -667,6 +667,11 @@ class TestQgsExpression: public QObject
       QTest::newRow( "geometry_n collection" ) << "geom_to_wkt(geometry_n(geom_from_wkt('GEOMETRYCOLLECTION(POINT(0 1), POINT(0 0), POINT(1 0), POINT(1 1))'),3))" << false << QVariant( QString( "Point (1 0)" ) );
       QTest::newRow( "geometry_n collection bad index 1" ) << "geometry_n(geom_from_wkt('GEOMETRYCOLLECTION(POINT(0 1), POINT(0 0), POINT(1 0), POINT(1 1))'),0)" << false << QVariant();
       QTest::newRow( "geometry_n collection bad index 2" ) << "geometry_n(geom_from_wkt('GEOMETRYCOLLECTION(POINT(0 1), POINT(0 0), POINT(1 0), POINT(1 1))'),5)" << false << QVariant();
+      QTest::newRow( "boundary not geom" ) << "boundary('g')" << true << QVariant();
+      QTest::newRow( "boundary null" ) << "boundary(NULL)" << false << QVariant();
+      QTest::newRow( "boundary point" ) << "boundary(geom_from_wkt('POINT(1 2)'))" << false << QVariant();
+      QTest::newRow( "boundary polygon" ) << "geom_to_wkt(boundary(geometry:=geom_from_wkt('POLYGON((-1 -1, 4 0, 4 2, 0 2, -1 -1))')))" << false << QVariant( "LineString (-1 -1, 4 0, 4 2, 0 2, -1 -1)" );
+      QTest::newRow( "boundary line" ) << "geom_to_wkt(boundary(geom_from_wkt('LINESTRING(0 0, 1 1, 2 2)')))" << false << QVariant( "MultiPoint ((0 0),(2 2))" );
       QTest::newRow( "start_point point" ) << "geom_to_wkt(start_point(geom_from_wkt('POINT(2 0)')))" << false << QVariant( "Point (2 0)" );
       QTest::newRow( "start_point multipoint" ) << "geom_to_wkt(start_point(geom_from_wkt('MULTIPOINT((3 3), (1 1), (2 2))')))" << false << QVariant( "Point (3 3)" );
       QTest::newRow( "start_point line" ) << "geom_to_wkt(start_point(geom_from_wkt('LINESTRING(4 1, 1 1, 2 2)')))" << false << QVariant( "Point (4 1)" );


### PR DESCRIPTION
Similar to the Postgis st_boundary or GEOS GEOSBoundary_r function - this will return the topological boundary of a geometry.

Having it implemented in QGIS' geometry engine avoids the need to call GEOS methods to calculate this, and the expense associated with translating to/from GEOS -> QgsAbstractGeometryV2. Plus, this implementation works correctly with curved geometries.
