### PR TITLE
QgsFields cleanup

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -271,6 +271,12 @@ None will need to be modified, as the method will return an empty geometry if th
 <li>The method capabilities() returns QgsFeatureRendererV2::Capabilities flags instead of an integer. The two are binary compatible.
 </ul>
 
+\subsection qgis_api_break_3_0_QgsFields QgsFields
+
+<ul>
+<li>All const methods which return a field from QgsFields now return a QgsField value, not a reference.</li>
+</ul>
+
 \subsection qgis_api_break_3_0_QgsGeometry QgsGeometry
 
 <ul>

--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -233,6 +233,13 @@ instead.</li>
 be returned in place of a null pointer.</li>
 </ul>
 
+\subsection qgis_api_break_3_0_QgsDiagram QgsDiagram
+
+<ul>
+<li>The deprecated getExpression( const QString& expression, const QgsFields* fields ) method has been removed.
+Use the variant which accepts an expression context instead.</li>
+</ul>
+
 \subsection qgis_api_break_3_0_QgsDiagramLayerSettings QgsDiagramLayerSettings
 
 <ul>
@@ -255,6 +262,7 @@ a feature has a geometry is now done using the new hasGeometry() method. Any cod
 None will need to be modified, as the method will return an empty geometry if the feature has no geometry.</b></li>
 <li>The temporary constGeometry() method has been removed. Use geometry() instead.</li>
 <li>setFields( const QgsFields*, bool ) has been removed, use setFields( const QgsFields&, bool ) instead.</li>
+<li>fields() no longer returns a pointer, but instead a QgsFields value.</li>
 </ul>
 
 \subsection qgis_api_break_3_0_QgsFeatureRendererV2 QgsFeatureRendererV2
@@ -523,6 +531,21 @@ be returned instead of a null pointer if no transformation is required.</li>
 <li>The OutputUnit enum, including QgsSymbolV2::MM, QgsSymbolV2::MapUnit, QgsSymbolV2::Mixed, QgsSymbolV2::Pixel and QgsSymbolV2::Percentage has been moved to QgsUnitTypes
 and renamed to RenderUnit. QgsSymbolV2::OutputUnitList was renamed to QgsUnitTypes::RenderUnitList. All methods which previously accepted QgsSymbolV2::OutputUnit
 parameters or QgsSymbolV2::OutputUnitList parameters now take QgsUnitTypes::RenderUnit or QgsUnitTypes::RenderUnitList parameters respectively.</li>
+<li>startRender() now accepts a QgsFields reference, not a pointer.</li>
+</ul>
+
+\subsection qgis_api_break_3_0_QgsSymbolLayerV2 QgsSymbolLayerV2
+
+<ul>
+<li>The deprecated prepareExpressions( const QgsFields* fields, double scale = -1.0 ) method has been removed. Use
+the variant which takes QgsSymbolV2RenderContext instead.</li>
+</ul>
+
+\subsection qgis_api_break_3_0_QgsSymbolV2RenderContext QgsSymbolV2RenderContext
+
+<ul>
+<li>The constructor now accepts a QgsFields reference, not a pointer.</li>
+<li>fields() now returns a QgsFields value, not a pointer.</li>
 </ul>
 
 \subsection qgis_api_break_3_0_QgsSymbolLayerV2Utils QgsSymbolLayerV2Utils

--- a/python/core/diagram/qgsdiagram.sip
+++ b/python/core/diagram/qgsdiagram.sip
@@ -11,9 +11,6 @@ class QgsDiagram
 
     void clearCache();
 
-    //! @deprecated use QgsExpressionContext variant instead
-    QgsExpression* getExpression( const QString& expression, const QgsFields* fields ) /Deprecated/;
-
     /** Returns a prepared expression for the specified context.
      * @param expression expression string
      * @param context expression context

--- a/python/core/qgsfeature.sip
+++ b/python/core/qgsfeature.sip
@@ -361,9 +361,8 @@ class QgsFeature
 
     /** Returns the field map associated with the feature.
      * @see setFields
-     * TODO: QGIS 3 - return value, not pointer
      */
-    const QgsFields* fields() const;
+    QgsFields fields() const;
 
     /** Insert a value into attribute. Returns false if attribute name could not be converted to index.
      *  Field map must be associated using @link setFields @endlink before this method can be used.

--- a/python/core/qgsfield.sip
+++ b/python/core/qgsfield.sip
@@ -262,7 +262,7 @@ class QgsFields
 %End
 
     //! Get field at particular index (must be in range 0..N-1)
-    const QgsField& at( int i ) const /Factory/;
+    QgsField at( int i ) const /Factory/;
 %MethodCode
   if ( a0 < 0 || a0 >= sipCpp->count() )
   {
@@ -276,7 +276,7 @@ class QgsFields
 %End
 
     //! Get field at particular index (must be in range 0..N-1)
-    const QgsField& field( int fieldIdx ) const /Factory/;
+    QgsField field( int fieldIdx ) const /Factory/;
 %MethodCode
   if ( a0 < 0 || a0 >= sipCpp->count() )
   {
@@ -290,7 +290,7 @@ class QgsFields
 %End
 
     //! Get field at particular index (must be in range 0..N-1)
-    const QgsField& field( const QString& name ) const /Factory/;
+    QgsField field( const QString& name ) const /Factory/;
 %MethodCode
   int fieldIdx = sipCpp->indexFromName(*a0);
   if (fieldIdx == -1)

--- a/python/core/symbology-ng/qgssymbollayerv2.sip
+++ b/python/core/symbology-ng/qgssymbollayerv2.sip
@@ -303,14 +303,6 @@ class QgsSymbolLayerV2
 
     /** Prepares all data defined property expressions for evaluation. This should
      * be called prior to evaluating data defined properties.
-     * @param fields associated layer fields
-     * @param scale map scale
-     * @deprecated use variant which takes QgsSymbolV2RenderContext instead
-     */
-    virtual void prepareExpressions( const QgsFields* fields, double scale = -1.0 ) /Deprecated/;
-
-    /** Prepares all data defined property expressions for evaluation. This should
-     * be called prior to evaluating data defined properties.
      * @param context symbol render context
      * @note added in QGIS 2.12
      */

--- a/python/core/symbology-ng/qgssymbolv2.sip
+++ b/python/core/symbology-ng/qgssymbolv2.sip
@@ -110,7 +110,21 @@ class QgsSymbolV2
     //! delete layer at specified index and set a new one
     bool changeSymbolLayer( int index, QgsSymbolLayerV2 *layer /Transfer/ );
 
+    /** Begins the rendering process for the symbol. This must be called before renderFeature(),
+     * and should be followed by a call to stopRender().
+     * @param context render context which symbol will be drawn using
+     * @param fields fields for features to be rendered (usually the associated
+     * vector layer's fields). Required for correct calculation of data defined
+     * overrides.
+     * @see stopRender()
+     */
     void startRender( QgsRenderContext& context, const QgsFields& fields = QgsFields() );
+
+    /** Ends the rendering process. This should be called after rendering all desired features.
+     * @param context render context, must match the context specified when startRender()
+     * was called.
+     * @see startRender()
+     */
     void stopRender( QgsRenderContext& context );
 
     void setColor( const QColor& color );
@@ -205,7 +219,8 @@ class QgsSymbolV2
     const QgsVectorLayer* layer() const;
 
     /**
-     * Render a feature.
+     * Render a feature. Before calling this the startRender() method should be called to initialise
+     * the rendering process. After rendering all features stopRender() must be called.
      */
     void renderFeature( const QgsFeature& feature, QgsRenderContext& context, int layer = -1, bool selected = false, bool drawVertexMarker = false, int currentVertexMarkerType = 0, int currentVertexMarkerSize = 0 );
 

--- a/python/core/symbology-ng/qgssymbolv2.sip
+++ b/python/core/symbology-ng/qgssymbolv2.sip
@@ -110,7 +110,7 @@ class QgsSymbolV2
     //! delete layer at specified index and set a new one
     bool changeSymbolLayer( int index, QgsSymbolLayerV2 *layer /Transfer/ );
 
-    void startRender( QgsRenderContext& context, const QgsFields* fields = 0 );
+    void startRender( QgsRenderContext& context, const QgsFields& fields = QgsFields() );
     void stopRender( QgsRenderContext& context );
 
     void setColor( const QColor& color );
@@ -292,7 +292,7 @@ class QgsSymbolV2RenderContext
      * @param fields
      * @param mapUnitScale
      */
-    QgsSymbolV2RenderContext( QgsRenderContext& c, QgsUnitTypes::RenderUnit u, qreal alpha = 1.0, bool selected = false, int renderHints = 0, const QgsFeature* f = 0, const QgsFields* fields = 0, const QgsMapUnitScale& mapUnitScale = QgsMapUnitScale() );
+    QgsSymbolV2RenderContext( QgsRenderContext& c, QgsUnitTypes::RenderUnit u, qreal alpha = 1.0, bool selected = false, int renderHints = 0, const QgsFeature* f = 0, const QgsFields& fields = QgsFields(), const QgsMapUnitScale& mapUnitScale = QgsMapUnitScale() );
     ~QgsSymbolV2RenderContext();
 
     QgsRenderContext& renderContext();
@@ -333,7 +333,7 @@ class QgsSymbolV2RenderContext
     //! to allow symbols with data-defined properties prepare the expressions
     //! (other times fields() returns null)
     //! @note added in 2.4
-    const QgsFields* fields() const;
+    QgsFields fields() const;
 
     /** Part count of current geometry
      * @note added in QGIS 2.16

--- a/src/analysis/vector/qgsoverlayanalyzer.cpp
+++ b/src/analysis/vector/qgsoverlayanalyzer.cpp
@@ -192,7 +192,7 @@ void QgsOverlayAnalyzer::combineFieldLists( QgsFields& fieldListA, const QgsFiel
 
   for ( int idx = 0; idx < fieldListB.count(); ++idx )
   {
-    QgsField field = fieldListB[idx];
+    QgsField field = fieldListB.at( idx );
     int count = 0;
     while ( names.contains( field.name() ) )
     {

--- a/src/app/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/app/ogr/qgsvectorlayersaveasdialog.cpp
@@ -271,7 +271,7 @@ void QgsVectorLayerSaveAsDialog::on_mFormatComboBox_currentIndexChanged( int idx
 
     for ( int i = 0; i < mLayer->fields().size(); ++i )
     {
-      const QgsField &fld = mLayer->fields().at( i );
+      QgsField fld = mLayer->fields().at( i );
       Qt::ItemFlags flags = mLayer->providerType() != "oracle" || !fld.typeName().contains( "SDO_GEOMETRY" ) ? Qt::ItemIsEnabled : Qt::NoItemFlags;
       QTableWidgetItem *item;
       item = new QTableWidgetItem( fld.name() );

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -6848,7 +6848,7 @@ void QgisApp::mergeAttributesOfSelectedFeatures()
         continue;
 
       QVariant val = merged.at( i );
-      const QgsField &fld( vl->fields().at( i ) );
+      QgsField fld( vl->fields().at( i ) );
       bool isDefaultValue = vl->fields().fieldOrigin( i ) == QgsFields::OriginProvider &&
                             vl->dataProvider() &&
                             vl->dataProvider()->defaultValue( vl->fields().fieldOriginIndex( i ) ) == val;

--- a/src/app/qgsdecorationgrid.cpp
+++ b/src/app/qgsdecorationgrid.cpp
@@ -232,7 +232,7 @@ void QgsDecorationGrid::render( QPainter * p )
 
     QgsRenderContext context = QgsRenderContext::fromMapSettings( QgisApp::instance()->mapCanvas()->mapSettings() );
     context.setPainter( p );
-    mLineSymbol->startRender( context, nullptr );
+    mLineSymbol->startRender( context );
 
     for ( ; vIt != verticalLines.constEnd(); ++vIt )
     {
@@ -310,7 +310,7 @@ void QgsDecorationGrid::render( QPainter * p )
 
     QgsRenderContext context = QgsRenderContext::fromMapSettings( QgisApp::instance()->mapCanvas()->mapSettings() );
     context.setPainter( p );
-    mMarkerSymbol->startRender( context, nullptr );
+    mMarkerSymbol->startRender( context );
 
     QPointF intersectionPoint;
     for ( ; vIt != verticalLines.constEnd(); ++vIt )

--- a/src/app/qgsdelattrdialog.cpp
+++ b/src/app/qgsdelattrdialog.cpp
@@ -34,7 +34,7 @@ QgsDelAttrDialog::QgsDelAttrDialog( const QgsVectorLayer* vl )
     const QgsFields& layerAttributes = vl->fields();
     for ( int idx = 0; idx < layerAttributes.count(); ++idx )
     {
-      QListWidgetItem* item = new QListWidgetItem( layerAttributes[idx].name(), listBox2 );
+      QListWidgetItem* item = new QListWidgetItem( layerAttributes.at( idx ).name(), listBox2 );
       switch ( vl->fields().fieldOrigin( idx ) )
       {
         case QgsFields::OriginExpression:

--- a/src/app/qgsdiagramproperties.cpp
+++ b/src/app/qgsdiagramproperties.cpp
@@ -184,14 +184,14 @@ QgsDiagramProperties::QgsDiagramProperties( QgsVectorLayer* layer,
   for ( int idx = 0; idx < layerFields.count(); ++idx )
   {
     QTreeWidgetItem *newItem = new QTreeWidgetItem( mAttributesTreeWidget );
-    QString name = QString( "\"%1\"" ).arg( layerFields[idx].name() );
+    QString name = QString( "\"%1\"" ).arg( layerFields.at( idx ).name() );
     newItem->setText( 0, name );
     newItem->setData( 0, Qt::UserRole, name );
     newItem->setFlags( newItem->flags() & ~Qt::ItemIsDropEnabled );
 
-    mDataDefinedXComboBox->addItem( layerFields[idx].name(), idx );
-    mDataDefinedYComboBox->addItem( layerFields[idx].name(), idx );
-    mDataDefinedVisibilityComboBox->addItem( layerFields[idx].name(), idx );
+    mDataDefinedXComboBox->addItem( layerFields.at( idx ).name(), idx );
+    mDataDefinedYComboBox->addItem( layerFields.at( idx ).name(), idx );
+    mDataDefinedVisibilityComboBox->addItem( layerFields.at( idx ).name(), idx );
   }
 
   const QgsDiagramRendererV2* dr = layer->diagramRenderer();

--- a/src/app/qgsfieldcalculator.cpp
+++ b/src/app/qgsfieldcalculator.cpp
@@ -234,7 +234,7 @@ void QgsFieldCalculator::accept()
 
       for ( int idx = 0; idx < fields.count(); ++idx )
       {
-        if ( fields[idx].name() == mOutputFieldNameLineEdit->text() )
+        if ( fields.at( idx ).name() == mOutputFieldNameLineEdit->text() )
         {
           mAttributeId = idx;
           break;

--- a/src/app/qgsfieldsproperties.cpp
+++ b/src/app/qgsfieldsproperties.cpp
@@ -576,7 +576,7 @@ void QgsFieldsProperties::attributeAdded( int idx )
   const QgsFields &fields = mLayer->fields();
   int row = mFieldsList->rowCount();
   mFieldsList->insertRow( row );
-  setRow( row, idx, fields[idx] );
+  setRow( row, idx, fields.at( idx ) );
   mFieldsList->setCurrentCell( row, idx );
 
   for ( int i = idx + 1; i < mIndexedWidgets.count(); i++ )

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -493,7 +493,7 @@ void QgsIdentifyResultsDialog::addFeature( QgsVectorLayer *vlayer, const QgsFeat
     featItem->addChild( attrItem );
 
     attrItem->setData( 0, Qt::DisplayRole, vlayer->attributeDisplayName( i ) );
-    attrItem->setData( 0, Qt::UserRole, fields[i].name() );
+    attrItem->setData( 0, Qt::UserRole, fields.at( i ).name() );
     attrItem->setData( 0, Qt::UserRole + 1, i );
 
     attrItem->setData( 1, Qt::UserRole, value );
@@ -515,7 +515,7 @@ void QgsIdentifyResultsDialog::addFeature( QgsVectorLayer *vlayer, const QgsFeat
       attrItem->treeWidget()->setItemWidget( attrItem, 1, nullptr );
     }
 
-    if ( fields[i].name() == vlayer->displayField() )
+    if ( fields.at( i ).name() == vlayer->displayField() )
     {
       featItem->setText( 0, attrItem->text( 0 ) );
       featItem->setText( 1, attrItem->text( 1 ) );
@@ -560,11 +560,11 @@ void QgsIdentifyResultsDialog::addFeature( QgsVectorLayer *vlayer, const QgsFeat
     tblResults->setItem( j, 1, item );
 
     item = new QTableWidgetItem( QString::number( i ) );
-    if ( fields[i].name() == vlayer->displayField() )
+    if ( fields.at( i ).name() == vlayer->displayField() )
       item->setData( Qt::DisplayRole, vlayer->attributeDisplayName( i ) + " *" );
     else
       item->setData( Qt::DisplayRole, vlayer->attributeDisplayName( i ) );
-    item->setData( Qt::UserRole, fields[i].name() );
+    item->setData( Qt::UserRole, fields.at( i ).name() );
     item->setData( Qt::UserRole + 1, i );
     tblResults->setItem( j, 2, item );
 
@@ -765,7 +765,7 @@ void QgsIdentifyResultsDialog::addFeature( QgsRasterLayer *layer,
 
       QTreeWidgetItem *attrItem = new QTreeWidgetItem( QStringList() << QString::number( i ) << attrs.at( i ).toString() );
 
-      attrItem->setData( 0, Qt::DisplayRole, fields[i].name() );
+      attrItem->setData( 0, Qt::DisplayRole, fields.at( i ).name() );
 
       QVariant value = attrs.at( i );
       attrItem->setData( 1, Qt::DisplayRole, value );
@@ -1188,7 +1188,7 @@ void QgsIdentifyResultsDialog::doAction( QTreeWidgetItem *item, int action )
     const QgsFields& fields = layer->fields();
     for ( int fldIdx = 0; fldIdx < fields.count(); ++fldIdx )
     {
-      if ( fields[fldIdx].name() == fieldName )
+      if ( fields.at( fldIdx ).name() == fieldName )
       {
         idx = fldIdx;
         break;
@@ -1741,7 +1741,7 @@ void QgsIdentifyResultsDialog::copyFeatureAttributes()
       if ( attrIdx < 0 || attrIdx >= fields.count() )
         continue;
 
-      text += QString( "%1: %2\n" ).arg( fields[attrIdx].name(), it.value().toString() );
+      text += QString( "%1: %2\n" ).arg( fields.at( attrIdx ).name(), it.value().toString() );
     }
   }
   else if ( rlayer )

--- a/src/app/qgslabelpropertydialog.cpp
+++ b/src/app/qgslabelpropertydialog.cpp
@@ -103,7 +103,7 @@ void QgsLabelPropertyDialog::init( const QString& layerId, const QString& provid
       {
         mLabelTextLineEdit->setText( attributeValues.at( mCurLabelField ).toString() );
         const QgsFields& layerFields = vlayer->fields();
-        switch ( layerFields[mCurLabelField].type() )
+        switch ( layerFields.at( mCurLabelField ).type() )
         {
           case QVariant::Double:
             mLabelTextLineEdit->setValidator( new QDoubleValidator( this ) );

--- a/src/app/qgsmergeattributesdialog.cpp
+++ b/src/app/qgsmergeattributesdialog.cpp
@@ -358,7 +358,7 @@ QVariant QgsMergeAttributesDialog::calcStatistic( int col, QgsStatisticalSummary
 
   if ( values.isEmpty() )
   {
-    return QVariant( mVectorLayer->fields()[col].type() );
+    return QVariant( mVectorLayer->fields().at( col ).type() );
   }
 
   summary.calculate( values );

--- a/src/core/composer/qgscomposerattributetable.cpp
+++ b/src/core/composer/qgscomposerattributetable.cpp
@@ -241,7 +241,7 @@ void QgsComposerAttributeTable::setDisplayAttributes( const QSet<int>& attr, boo
       }
       QString currentAlias = mVectorLayer->attributeDisplayName( attrIdx );
       QgsComposerTableColumn* col = new QgsComposerTableColumn;
-      col->setAttribute( fields[attrIdx].name() );
+      col->setAttribute( fields.at( attrIdx ).name() );
       col->setHeading( currentAlias );
       mColumns.append( col );
     }
@@ -652,7 +652,7 @@ bool QgsComposerAttributeTable::readXml( const QDomElement& itemElem, const QDom
       //find corresponding column
       Q_FOREACH ( QgsComposerTableColumn* column, mColumns )
       {
-        if ( column->attribute() == fields[attribute].name() )
+        if ( column->attribute() == fields.at( attribute ).name() )
         {
           column->setSortByRank( i + 1 );
           column->setSortOrder( order );

--- a/src/core/composer/qgscomposerattributetablev2.cpp
+++ b/src/core/composer/qgscomposerattributetablev2.cpp
@@ -338,7 +338,7 @@ void QgsComposerAttributeTableV2::setDisplayAttributes( const QSet<int>& attr, b
       }
       QString currentAlias = source->attributeDisplayName( attrIdx );
       QgsComposerTableColumn* col = new QgsComposerTableColumn;
-      col->setAttribute( fields[attrIdx].name() );
+      col->setAttribute( fields.at( attrIdx ).name() );
       col->setHeading( currentAlias );
       mColumns.append( col );
     }

--- a/src/core/diagram/qgsdiagram.cpp
+++ b/src/core/diagram/qgsdiagram.cpp
@@ -45,19 +45,6 @@ void QgsDiagram::clearCache()
   mExpressions.clear();
 }
 
-QgsExpression* QgsDiagram::getExpression( const QString& expression, const QgsFields* fields )
-{
-  Q_NOWARN_DEPRECATED_PUSH
-  if ( !mExpressions.contains( expression ) )
-  {
-    QgsExpression* expr = new QgsExpression( expression );
-    expr->prepare( *fields );
-    mExpressions[expression] = expr;
-  }
-  return mExpressions[expression];
-  Q_NOWARN_DEPRECATED_POP
-}
-
 QgsExpression *QgsDiagram::getExpression( const QString &expression, const QgsExpressionContext &context )
 {
   if ( !mExpressions.contains( expression ) )

--- a/src/core/diagram/qgsdiagram.h
+++ b/src/core/diagram/qgsdiagram.h
@@ -42,9 +42,6 @@ class CORE_EXPORT QgsDiagram
 
     void clearCache();
 
-    //! @deprecated use QgsExpressionContext variant instead
-    Q_DECL_DEPRECATED QgsExpression* getExpression( const QString& expression, const QgsFields* fields );
-
     /** Returns a prepared expression for the specified context.
      * @param expression expression string
      * @param context expression context

--- a/src/core/diagram/qgshistogramdiagram.cpp
+++ b/src/core/diagram/qgshistogramdiagram.cpp
@@ -50,8 +50,8 @@ QSizeF QgsHistogramDiagram::diagramSize( const QgsFeature& feature, const QgsRen
 
   QgsExpressionContext expressionContext = c.expressionContext();
   expressionContext.setFeature( feature );
-  if ( feature.fields() )
-    expressionContext.setFields( *feature.fields() );
+  if ( !feature.fields().isEmpty() )
+    expressionContext.setFields( feature.fields() );
 
   Q_FOREACH ( const QString& cat, s.categoryAttributes )
   {
@@ -147,8 +147,8 @@ void QgsHistogramDiagram::renderDiagram( const QgsFeature& feature, QgsRenderCon
 
   QgsExpressionContext expressionContext = c.expressionContext();
   expressionContext.setFeature( feature );
-  if ( feature.fields() )
-    expressionContext.setFields( *feature.fields() );
+  if ( !feature.fields().isEmpty() )
+    expressionContext.setFields( feature.fields() );
 
   Q_FOREACH ( const QString& cat, s.categoryAttributes )
   {

--- a/src/core/diagram/qgspiediagram.cpp
+++ b/src/core/diagram/qgspiediagram.cpp
@@ -43,8 +43,8 @@ QSizeF QgsPieDiagram::diagramSize( const QgsFeature& feature, const QgsRenderCon
   if ( is.classificationAttributeIsExpression )
   {
     QgsExpressionContext expressionContext = c.expressionContext();
-    if ( feature.fields() )
-      expressionContext.setFields( *feature.fields() );
+    if ( !feature.fields().isEmpty() )
+      expressionContext.setFields( feature.fields() );
     expressionContext.setFeature( feature );
 
     QgsExpression* expression = getExpression( is.classificationAttributeExpression, expressionContext );
@@ -94,8 +94,8 @@ void QgsPieDiagram::renderDiagram( const QgsFeature& feature, QgsRenderContext& 
 
   QgsExpressionContext expressionContext = c.expressionContext();
   expressionContext.setFeature( feature );
-  if ( feature.fields() )
-    expressionContext.setFields( *feature.fields() );
+  if ( !feature.fields().isEmpty() )
+    expressionContext.setFields( feature.fields() );
 
   QList<QString>::const_iterator catIt = s.categoryAttributes.constBegin();
   for ( ; catIt != s.categoryAttributes.constEnd(); ++catIt )

--- a/src/core/diagram/qgstextdiagram.cpp
+++ b/src/core/diagram/qgstextdiagram.cpp
@@ -40,8 +40,8 @@ QSizeF QgsTextDiagram::diagramSize( const QgsFeature& feature, const QgsRenderCo
 {
   QgsExpressionContext expressionContext = c.expressionContext();
   expressionContext.setFeature( feature );
-  if ( feature.fields() )
-    expressionContext.setFields( *feature.fields() );
+  if ( !feature.fields().isEmpty() )
+    expressionContext.setFields( feature.fields() );
 
   QVariant attrVal;
   if ( is.classificationAttributeIsExpression )
@@ -198,8 +198,8 @@ void QgsTextDiagram::renderDiagram( const QgsFeature& feature, QgsRenderContext&
 
   QgsExpressionContext expressionContext = c.expressionContext();
   expressionContext.setFeature( feature );
-  if ( feature.fields() )
-    expressionContext.setFields( *feature.fields() );
+  if ( !feature.fields().isEmpty() )
+    expressionContext.setFields( feature.fields() );
 
   for ( int i = 0; i < textPositions.size(); ++i )
   {

--- a/src/core/qgsactionmanager.cpp
+++ b/src/core/qgsactionmanager.cpp
@@ -210,13 +210,13 @@ QString QgsActionManager::expandAction( QString action, const QgsAttributeMap &a
       switch ( i )
       {
         case 0:
-          to_replace = "[%" + fields[attrIdx].name() + ']';
+          to_replace = "[%" + fields.at( attrIdx ).name() + ']';
           break;
         case 1:
           to_replace = "[%" + mLayer->attributeDisplayName( attrIdx ) + ']';
           break;
         case 2:
-          to_replace = '%' + fields[attrIdx].name();
+          to_replace = '%' + fields.at( attrIdx ).name();
           break;
         case 3:
           to_replace = '%' + mLayer->attributeDisplayName( attrIdx );

--- a/src/core/qgsfeature.cpp
+++ b/src/core/qgsfeature.cpp
@@ -134,9 +134,9 @@ void QgsFeature::setFields( const QgsFields &fields, bool init )
   }
 }
 
-const QgsFields *QgsFeature::fields() const
+QgsFields QgsFeature::fields() const
 {
-  return &( d->fields );
+  return d->fields;
 }
 
 /***************************************************************************

--- a/src/core/qgsfeature.h
+++ b/src/core/qgsfeature.h
@@ -308,9 +308,8 @@ class CORE_EXPORT QgsFeature
 
     /** Returns the field map associated with the feature.
      * @see setFields
-     * TODO: QGIS 3 - return value, not pointer
      */
-    const QgsFields* fields() const;
+    QgsFields fields() const;
 
     /** Insert a value into attribute. Returns false if attribute name could not be converted to index.
      *  Field map must be associated using @link setFields @endlink before this method can be used.

--- a/src/core/qgsfield.cpp
+++ b/src/core/qgsfield.cpp
@@ -382,17 +382,17 @@ QgsField &QgsFields::operator[]( int i )
   return d->fields[i].field;
 }
 
-const QgsField &QgsFields::at( int i ) const
+QgsField QgsFields::at( int i ) const
 {
   return d->fields[i].field;
 }
 
-const QgsField &QgsFields::field( int fieldIdx ) const
+QgsField QgsFields::field( int fieldIdx ) const
 {
   return d->fields[fieldIdx].field;
 }
 
-const QgsField &QgsFields::field( const QString &name ) const
+QgsField QgsFields::field( const QString &name ) const
 {
   return d->fields[ indexFromName( name )].field;
 }
@@ -403,7 +403,7 @@ const QgsField &QgsFields::field( const QString &name ) const
  * See details in QEP #17
  ****************************************************************************/
 
-const QgsField &QgsFields::operator[]( int i ) const
+QgsField QgsFields::operator[]( int i ) const
 {
   return d->fields[i].field;
 }

--- a/src/core/qgsfield.h
+++ b/src/core/qgsfield.h
@@ -255,15 +255,15 @@ class CORE_EXPORT QgsFields
     bool exists( int i ) const;
 
     //! Get field at particular index (must be in range 0..N-1)
-    const QgsField& operator[]( int i ) const;
+    QgsField operator[]( int i ) const;
     //! Get field at particular index (must be in range 0..N-1)
     QgsField& operator[]( int i );
     //! Get field at particular index (must be in range 0..N-1)
-    const QgsField& at( int i ) const;
+    QgsField at( int i ) const;
     //! Get field at particular index (must be in range 0..N-1)
-    const QgsField& field( int fieldIdx ) const;
-    //! Get field at particular index (must be in range 0..N-1)
-    const QgsField& field( const QString& name ) const;
+    QgsField field( int fieldIdx ) const;
+    //! Get field with matching name
+    QgsField field( const QString& name ) const;
 
     //! Get field's origin (value from an enumeration)
     FieldOrigin fieldOrigin( int fieldIdx ) const;

--- a/src/core/qgsgml.cpp
+++ b/src/core/qgsgml.cpp
@@ -294,7 +294,7 @@ QgsGmlStreamingParser::QgsGmlStreamingParser( const QString& typeName,
   mThematicAttributes.clear();
   for ( int i = 0; i < fields.size(); i++ )
   {
-    mThematicAttributes.insert( fields[i].name(), qMakePair( i, fields[i] ) );
+    mThematicAttributes.insert( fields.at( i ).name(), qMakePair( i, fields.at( i ) ) );
   }
 
   mEndian = QgsApplication::endian();
@@ -355,13 +355,13 @@ QgsGmlStreamingParser::QgsGmlStreamingParser( const QList<LayerProperties>& laye
   mThematicAttributes.clear();
   for ( int i = 0; i < fields.size(); i++ )
   {
-    QMap< QString, QPair<QString, QString> >::const_iterator att_it = mapFieldNameToSrcLayerNameFieldName.constFind( fields[i].name() );
+    QMap< QString, QPair<QString, QString> >::const_iterator att_it = mapFieldNameToSrcLayerNameFieldName.constFind( fields.at( i ).name() );
     if ( att_it != mapFieldNameToSrcLayerNameFieldName.constEnd() )
     {
       if ( mLayerProperties.size() == 1 )
-        mThematicAttributes.insert( att_it.value().second, qMakePair( i, fields[i] ) );
+        mThematicAttributes.insert( att_it.value().second, qMakePair( i, fields.at( i ) ) );
       else
-        mThematicAttributes.insert( stripNS( att_it.value().first ) + "|" + att_it.value().second, qMakePair( i, fields[i] ) );
+        mThematicAttributes.insert( stripNS( att_it.value().first ) + "|" + att_it.value().second, qMakePair( i, fields.at( i ) ) );
     }
   }
   bool alreadyFoundGeometry = false;

--- a/src/core/qgsjsonutils.cpp
+++ b/src/core/qgsjsonutils.cpp
@@ -116,9 +116,9 @@ QString QgsJSONExporter::exportFeature( const QgsFeature& feature, const QVarian
 
     if ( mIncludeAttributes )
     {
-      const QgsFields* fields = feature.fields();
+      QgsFields fields = feature.fields();
 
-      for ( int i = 0; i < fields->count(); ++i )
+      for ( int i = 0; i < fields.count(); ++i )
       {
         if (( !mAttributeIndexes.isEmpty() && !mAttributeIndexes.contains( i ) ) || mExcludedAttributeIndexes.contains( i ) )
           continue;
@@ -127,7 +127,7 @@ QString QgsJSONExporter::exportFeature( const QgsFeature& feature, const QVarian
           properties += ",\n";
         QVariant val =  feature.attributes().at( i );
 
-        properties += QString( "      \"%1\":%2" ).arg( fields->at( i ).name(), QgsJSONUtils::encodeValue( val ) );
+        properties += QString( "      \"%1\":%2" ).arg( fields.at( i ).name(), QgsJSONUtils::encodeValue( val ) );
 
         ++attributeCounter;
       }
@@ -296,15 +296,15 @@ QString QgsJSONUtils::encodeValue( const QVariant &value )
 
 QString QgsJSONUtils::exportAttributes( const QgsFeature& feature )
 {
-  const QgsFields* fields = feature.fields();
+  QgsFields fields = feature.fields();
   QString attrs;
-  for ( int i = 0; i < fields->count(); ++i )
+  for ( int i = 0; i < fields.count(); ++i )
   {
     if ( i > 0 )
       attrs += ",\n";
 
     QVariant val = feature.attributes().at( i );
-    attrs += encodeValue( fields->at( i ).name() ) + ':' + encodeValue( val );
+    attrs += encodeValue( fields.at( i ).name() ) + ':' + encodeValue( val );
   }
   return attrs.prepend( '{' ).append( '}' );
 }

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -2174,7 +2174,7 @@ QgsVectorFileWriter::WriterError QgsVectorFileWriter::writeAsVectorFormat( QgsVe
   {
     Q_FOREACH ( int idx, layer->attributeList() )
     {
-      const QgsField &fld = layer->fields()[idx];
+      QgsField fld = layer->fields().at( idx );
       if ( layer->providerType() == "oracle" && fld.typeName().contains( "SDO_GEOMETRY" ) )
         continue;
       attributes.append( idx );
@@ -2186,7 +2186,7 @@ QgsVectorFileWriter::WriterError QgsVectorFileWriter::writeAsVectorFormat( QgsVe
   {
     Q_FOREACH ( int attrIdx, attributes )
     {
-      fields.append( layer->fields()[attrIdx] );
+      fields.append( layer->fields().at( attrIdx ) );
     }
   }
 

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -398,13 +398,13 @@ void QgsVectorFileWriter::init( QString vectorFileName,
 
   for ( int fldIdx = 0; fldIdx < fields.count(); ++fldIdx )
   {
-    QgsField attrField = fields[fldIdx];
+    QgsField attrField = fields.at( fldIdx );
 
     OGRFieldType ogrType = OFTString; //default to string
 
     if ( fieldValueConverter )
     {
-      attrField = fieldValueConverter->fieldDefinition( fields[fldIdx] );
+      attrField = fieldValueConverter->fieldDefinition( fields.at( fldIdx ) );
     }
 
     int ogrWidth = attrField.length();
@@ -489,7 +489,7 @@ void QgsVectorFileWriter::init( QString vectorFileName,
         name = QString( "ogc_fid%1" ).arg( i );
 
         int j;
-        for ( j = 0; j < fields.size() && name.compare( fields[j].name(), Qt::CaseInsensitive ) != 0; j++ )
+        for ( j = 0; j < fields.size() && name.compare( fields.at( j ).name(), Qt::CaseInsensitive ) != 0; j++ )
           ;
 
         if ( j == fields.size() )

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -3757,7 +3757,7 @@ QString QgsVectorLayer::metadata() const
   const QgsFields& myFields = pendingFields();
   for ( int i = 0, n = myFields.size(); i < n; ++i )
   {
-    const QgsField& myField = fields[i];
+    QgsField myField = fields.at( i );
 
     myMetadata += "<tr><td>";
     myMetadata += myField.name();

--- a/src/core/qgsvectorlayereditbuffer.cpp
+++ b/src/core/qgsvectorlayereditbuffer.cpp
@@ -418,8 +418,8 @@ bool QgsVectorLayerEditBuffer::commitChanges( QStringList& commitErrors )
 
     for ( int i = 0; i < qMin( oldFields.count(), newFields.count() ); ++i )
     {
-      const QgsField& oldField = oldFields.at( i );
-      const QgsField& newField = newFields.at( i );
+      QgsField oldField = oldFields.at( i );
+      QgsField newField = newFields.at( i );
       if ( attributeChangesOk && oldField != newField )
       {
         commitErrors

--- a/src/core/symbology-ng/qgs25drenderer.cpp
+++ b/src/core/symbology-ng/qgs25drenderer.cpp
@@ -138,7 +138,7 @@ QgsFeatureRendererV2* Qgs25DRenderer::create( QDomElement& element )
 
 void Qgs25DRenderer::startRender( QgsRenderContext& context, const QgsFields& fields )
 {
-  mSymbol->startRender( context, &fields );
+  mSymbol->startRender( context, fields );
 }
 
 void Qgs25DRenderer::stopRender( QgsRenderContext& context )

--- a/src/core/symbology-ng/qgscategorizedsymbolrendererv2.cpp
+++ b/src/core/symbology-ng/qgscategorizedsymbolrendererv2.cpp
@@ -431,14 +431,14 @@ void QgsCategorizedSymbolRendererV2::startRender( QgsRenderContext& context, con
 
   Q_FOREACH ( const QgsRendererCategoryV2& cat, mCategories )
   {
-    cat.symbol()->startRender( context, &fields );
+    cat.symbol()->startRender( context, fields );
 
     if ( mRotation.data() || mSizeScale.data() )
     {
       QgsSymbolV2* tempSymbol = cat.symbol()->clone();
       tempSymbol->setRenderHints(( mRotation.data() ? QgsSymbolV2::DataDefinedRotation : 0 ) |
                                  ( mSizeScale.data() ? QgsSymbolV2::DataDefinedSizeScale : 0 ) );
-      tempSymbol->startRender( context, &fields );
+      tempSymbol->startRender( context, fields );
       mTempSymbols[ cat.symbol()] = tempSymbol;
     }
   }

--- a/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.cpp
+++ b/src/core/symbology-ng/qgsgraduatedsymbolrendererv2.cpp
@@ -424,14 +424,14 @@ void QgsGraduatedSymbolRendererV2::startRender( QgsRenderContext& context, const
     if ( !range.symbol() )
       continue;
 
-    range.symbol()->startRender( context, &fields );
+    range.symbol()->startRender( context, fields );
 
     if ( mRotation.data() || mSizeScale.data() )
     {
       QgsSymbolV2* tempSymbol = range.symbol()->clone();
       tempSymbol->setRenderHints(( mRotation.data() ? QgsSymbolV2::DataDefinedRotation : 0 ) |
                                  ( mSizeScale.data() ? QgsSymbolV2::DataDefinedSizeScale : 0 ) );
-      tempSymbol->startRender( context, &fields );
+      tempSymbol->startRender( context, fields );
       mTempSymbols[ range.symbol()] = tempSymbol;
     }
   }

--- a/src/core/symbology-ng/qgspointdisplacementrenderer.cpp
+++ b/src/core/symbology-ng/qgspointdisplacementrenderer.cpp
@@ -364,7 +364,7 @@ void QgsPointDisplacementRenderer::startRender( QgsRenderContext& context, const
 
   if ( mCenterSymbol )
   {
-    mCenterSymbol->startRender( context, &fields );
+    mCenterSymbol->startRender( context, fields );
   }
   return;
 }

--- a/src/core/symbology-ng/qgsrulebasedrendererv2.cpp
+++ b/src/core/symbology-ng/qgsrulebasedrendererv2.cpp
@@ -447,7 +447,7 @@ bool QgsRuleBasedRendererV2::Rule::startRender( QgsRenderContext& context, const
   if ( mFilter )
     mFilter->prepare( &context.expressionContext() );
   if ( mSymbol )
-    mSymbol->startRender( context, &fields );
+    mSymbol->startRender( context, fields );
 
   // init children
   // build temporary list of active rules (usable with this scale)

--- a/src/core/symbology-ng/qgssinglesymbolrendererv2.cpp
+++ b/src/core/symbology-ng/qgssinglesymbolrendererv2.cpp
@@ -87,7 +87,7 @@ void QgsSingleSymbolRendererV2::startRender( QgsRenderContext& context, const Qg
   if ( !mSymbol.data() )
     return;
 
-  mSymbol->startRender( context, &fields );
+  mSymbol->startRender( context, fields );
 
   if ( mRotation.data() || mSizeScale.data() )
   {
@@ -101,7 +101,7 @@ void QgsSingleSymbolRendererV2::startRender( QgsRenderContext& context, const Qg
       hints |= QgsSymbolV2::DataDefinedSizeScale;
     mTempSymbol->setRenderHints( hints );
 
-    mTempSymbol->startRender( context, &fields );
+    mTempSymbol->startRender( context, fields );
 
     if ( mSymbol->type() == QgsSymbolV2::Marker )
     {

--- a/src/core/symbology-ng/qgssymbollayerv2.cpp
+++ b/src/core/symbology-ng/qgssymbollayerv2.cpp
@@ -335,38 +335,6 @@ QgsSymbolLayerV2::QgsSymbolLayerV2( QgsSymbolV2::SymbolType type, bool locked )
   mPaintEffect->setEnabled( false );
 }
 
-void QgsSymbolLayerV2::prepareExpressions( const QgsFields* fields, double scale )
-{
-  QMap< QString, QgsDataDefined* >::const_iterator it = mDataDefinedProperties.constBegin();
-  for ( ; it != mDataDefinedProperties.constEnd(); ++it )
-  {
-    if ( it.value() )
-    {
-      QMap<QString, QVariant> params;
-      if ( scale > 0 )
-      {
-        params.insert( "scale", scale );
-      }
-      it.value()->setExpressionParams( params );
-
-      if ( fields )
-      {
-        it.value()->prepareExpression( QgsExpressionContextUtils::createFeatureBasedContext( QgsFeature(), *fields ) );
-      }
-      else
-      {
-        it.value()->prepareExpression();
-      }
-    }
-  }
-
-  if ( fields )
-  {
-    //QgsFields is implicitly shared, so it's cheap to make a copy
-    mFields = *fields;
-  }
-}
-
 void QgsSymbolLayerV2::prepareExpressions( const QgsSymbolV2RenderContext& context )
 {
   QMap< QString, QgsDataDefined* >::const_iterator it = mDataDefinedProperties.constBegin();
@@ -384,10 +352,10 @@ void QgsSymbolLayerV2::prepareExpressions( const QgsSymbolV2RenderContext& conte
     }
   }
 
-  if ( context.fields() )
+  if ( !context.fields().isEmpty() )
   {
     //QgsFields is implicitly shared, so it's cheap to make a copy
-    mFields = *context.fields();
+    mFields = context.fields();
   }
 }
 

--- a/src/core/symbology-ng/qgssymbollayerv2.h
+++ b/src/core/symbology-ng/qgssymbollayerv2.h
@@ -313,14 +313,6 @@ class CORE_EXPORT QgsSymbolLayerV2
 
     /** Prepares all data defined property expressions for evaluation. This should
      * be called prior to evaluating data defined properties.
-     * @param fields associated layer fields
-     * @param scale map scale
-     * @deprecated use variant which takes QgsSymbolV2RenderContext instead
-     */
-    Q_DECL_DEPRECATED virtual void prepareExpressions( const QgsFields* fields, double scale = -1.0 );
-
-    /** Prepares all data defined property expressions for evaluation. This should
-     * be called prior to evaluating data defined properties.
      * @param context symbol render context
      * @note added in QGIS 2.12
      */

--- a/src/core/symbology-ng/qgssymbollayerv2utils.cpp
+++ b/src/core/symbology-ng/qgssymbollayerv2utils.cpp
@@ -599,7 +599,7 @@ QPicture QgsSymbolLayerV2Utils::symbolLayerPreviewPicture( QgsSymbolLayerV2* lay
   painter.setRenderHint( QPainter::Antialiasing );
   QgsRenderContext renderContext = createRenderContext( &painter );
   renderContext.setForceVectorOutput( true );
-  QgsSymbolV2RenderContext symbolContext( renderContext, units, 1.0, false, 0, nullptr, nullptr, scale );
+  QgsSymbolV2RenderContext symbolContext( renderContext, units, 1.0, false, 0, nullptr, QgsFields(), scale );
   layer->drawPreviewIcon( symbolContext, size );
   painter.end();
   return picture;
@@ -613,7 +613,7 @@ QIcon QgsSymbolLayerV2Utils::symbolLayerPreviewIcon( QgsSymbolLayerV2* layer, Qg
   painter.begin( &pixmap );
   painter.setRenderHint( QPainter::Antialiasing );
   QgsRenderContext renderContext = createRenderContext( &painter );
-  QgsSymbolV2RenderContext symbolContext( renderContext, u, 1.0, false, 0, nullptr, nullptr, scale );
+  QgsSymbolV2RenderContext symbolContext( renderContext, u, 1.0, false, 0, nullptr, QgsFields(), scale );
   layer->drawPreviewIcon( symbolContext, size );
   painter.end();
   return QIcon( pixmap );

--- a/src/core/symbology-ng/qgssymbolv2.cpp
+++ b/src/core/symbology-ng/qgssymbolv2.cpp
@@ -443,7 +443,7 @@ bool QgsSymbolV2::changeSymbolLayer( int index, QgsSymbolLayerV2* layer )
 }
 
 
-void QgsSymbolV2::startRender( QgsRenderContext& context, const QgsFields* fields )
+void QgsSymbolV2::startRender( QgsRenderContext& context, const QgsFields& fields )
 {
   delete mSymbolRenderContext;
   mSymbolRenderContext = new QgsSymbolV2RenderContext( context, outputUnit(), mAlpha, false, mRenderHints, nullptr, fields, mapUnitScale() );
@@ -497,7 +497,7 @@ void QgsSymbolV2::drawPreviewIcon( QPainter* painter, QSize size, QgsRenderConte
 {
   QgsRenderContext context = customContext ? *customContext : QgsSymbolLayerV2Utils::createRenderContext( painter );
   context.setForceVectorOutput( true );
-  QgsSymbolV2RenderContext symbolContext( context, outputUnit(), mAlpha, false, mRenderHints, nullptr, nullptr, mapUnitScale() );
+  QgsSymbolV2RenderContext symbolContext( context, outputUnit(), mAlpha, false, mRenderHints, nullptr, QgsFields(), mapUnitScale() );
 
   Q_FOREACH ( QgsSymbolLayerV2* layer, mLayers )
   {
@@ -1024,7 +1024,7 @@ void QgsSymbolV2::renderVertexMarker( QPointF pt, QgsRenderContext& context, int
 ////////////////////
 
 
-QgsSymbolV2RenderContext::QgsSymbolV2RenderContext( QgsRenderContext& c, QgsUnitTypes::RenderUnit u, qreal alpha, bool selected, int renderHints, const QgsFeature* f, const QgsFields* fields, const QgsMapUnitScale& mapUnitScale )
+QgsSymbolV2RenderContext::QgsSymbolV2RenderContext( QgsRenderContext& c, QgsUnitTypes::RenderUnit u, qreal alpha, bool selected, int renderHints, const QgsFeature* f, const QgsFields& fields, const QgsMapUnitScale& mapUnitScale )
     : mRenderContext( c )
     , mExpressionContextScope( nullptr )
     , mOutputUnit( u )
@@ -1472,7 +1472,7 @@ void QgsMarkerSymbolV2::renderPointUsingLayer( QgsMarkerSymbolLayerV2* layer, QP
 
 void QgsMarkerSymbolV2::renderPoint( QPointF point, const QgsFeature* f, QgsRenderContext& context, int layerIdx, bool selected )
 {
-  QgsSymbolV2RenderContext symbolContext( context, outputUnit(), mAlpha, selected, mRenderHints, f, nullptr, mapUnitScale() );
+  QgsSymbolV2RenderContext symbolContext( context, outputUnit(), mAlpha, selected, mRenderHints, f, QgsFields(), mapUnitScale() );
   symbolContext.setGeometryPartCount( symbolRenderContext()->geometryPartCount() );
   symbolContext.setGeometryPartNum( symbolRenderContext()->geometryPartNum() );
 
@@ -1680,7 +1680,7 @@ void QgsLineSymbolV2::renderPolyline( const QPolygonF& points, const QgsFeature*
 {
   //save old painter
   QPainter* renderPainter = context.painter();
-  QgsSymbolV2RenderContext symbolContext( context, outputUnit(), mAlpha, selected, mRenderHints, f, nullptr, mapUnitScale() );
+  QgsSymbolV2RenderContext symbolContext( context, outputUnit(), mAlpha, selected, mRenderHints, f, QgsFields(), mapUnitScale() );
   symbolContext.setGeometryPartCount( symbolRenderContext()->geometryPartCount() );
   symbolContext.setGeometryPartNum( symbolRenderContext()->geometryPartNum() );
 
@@ -1759,7 +1759,7 @@ QgsFillSymbolV2::QgsFillSymbolV2( const QgsSymbolLayerV2List& layers )
 
 void QgsFillSymbolV2::renderPolygon( const QPolygonF& points, QList<QPolygonF>* rings, const QgsFeature* f, QgsRenderContext& context, int layerIdx, bool selected )
 {
-  QgsSymbolV2RenderContext symbolContext( context, outputUnit(), mAlpha, selected, mRenderHints, f, nullptr, mapUnitScale() );
+  QgsSymbolV2RenderContext symbolContext( context, outputUnit(), mAlpha, selected, mRenderHints, f, QgsFields(), mapUnitScale() );
   symbolContext.setGeometryPartCount( symbolRenderContext()->geometryPartCount() );
   symbolContext.setGeometryPartNum( symbolRenderContext()->geometryPartNum() );
 

--- a/src/core/symbology-ng/qgssymbolv2.h
+++ b/src/core/symbology-ng/qgssymbolv2.h
@@ -22,6 +22,7 @@
 #include "qgsmapunitscale.h"
 #include "qgspointv2.h"
 #include "qgsfeature.h"
+#include "qgsfield.h"
 
 class QColor;
 class QImage;
@@ -148,7 +149,7 @@ class CORE_EXPORT QgsSymbolV2
     //! delete layer at specified index and set a new one
     bool changeSymbolLayer( int index, QgsSymbolLayerV2 *layer );
 
-    void startRender( QgsRenderContext& context, const QgsFields* fields = nullptr );
+    void startRender( QgsRenderContext& context, const QgsFields& fields = QgsFields() );
     void stopRender( QgsRenderContext& context );
 
     void setColor( const QColor& color );
@@ -359,7 +360,7 @@ class CORE_EXPORT QgsSymbolV2RenderContext
      * @param fields
      * @param mapUnitScale
      */
-    QgsSymbolV2RenderContext( QgsRenderContext& c, QgsUnitTypes::RenderUnit u, qreal alpha = 1.0, bool selected = false, int renderHints = 0, const QgsFeature* f = nullptr, const QgsFields* fields = nullptr, const QgsMapUnitScale& mapUnitScale = QgsMapUnitScale() );
+    QgsSymbolV2RenderContext( QgsRenderContext& c, QgsUnitTypes::RenderUnit u, qreal alpha = 1.0, bool selected = false, int renderHints = 0, const QgsFeature* f = nullptr, const QgsFields& fields = QgsFields(), const QgsMapUnitScale& mapUnitScale = QgsMapUnitScale() );
     ~QgsSymbolV2RenderContext();
 
     QgsRenderContext& renderContext() { return mRenderContext; }
@@ -400,7 +401,7 @@ class CORE_EXPORT QgsSymbolV2RenderContext
     //! to allow symbols with data-defined properties prepare the expressions
     //! (other times fields() returns null)
     //! @note added in 2.4
-    const QgsFields* fields() const { return mFields; }
+    QgsFields fields() const { return mFields; }
 
     /** Part count of current geometry
      * @note added in QGIS 2.16
@@ -450,7 +451,7 @@ class CORE_EXPORT QgsSymbolV2RenderContext
     bool mSelected;
     int mRenderHints;
     const QgsFeature* mFeature; //current feature
-    const QgsFields* mFields;
+    QgsFields mFields;
     int mGeometryPartCount;
     int mGeometryPartNum;
 

--- a/src/core/symbology-ng/qgssymbolv2.h
+++ b/src/core/symbology-ng/qgssymbolv2.h
@@ -149,7 +149,21 @@ class CORE_EXPORT QgsSymbolV2
     //! delete layer at specified index and set a new one
     bool changeSymbolLayer( int index, QgsSymbolLayerV2 *layer );
 
+    /** Begins the rendering process for the symbol. This must be called before renderFeature(),
+     * and should be followed by a call to stopRender().
+     * @param context render context which symbol will be drawn using
+     * @param fields fields for features to be rendered (usually the associated
+     * vector layer's fields). Required for correct calculation of data defined
+     * overrides.
+     * @see stopRender()
+     */
     void startRender( QgsRenderContext& context, const QgsFields& fields = QgsFields() );
+
+    /** Ends the rendering process. This should be called after rendering all desired features.
+     * @param context render context, must match the context specified when startRender()
+     * was called.
+     * @see startRender()
+     */
     void stopRender( QgsRenderContext& context );
 
     void setColor( const QColor& color );
@@ -244,7 +258,8 @@ class CORE_EXPORT QgsSymbolV2
     const QgsVectorLayer* layer() const { return mLayer; }
 
     /**
-     * Render a feature.
+     * Render a feature. Before calling this the startRender() method should be called to initialise
+     * the rendering process. After rendering all features stopRender() must be called.
      */
     void renderFeature( const QgsFeature& feature, QgsRenderContext& context, int layer = -1, bool selected = false, bool drawVertexMarker = false, int currentVertexMarkerType = 0, int currentVertexMarkerSize = 0 );
 

--- a/src/core/symbology-ng/qgsvectorfieldsymbollayer.cpp
+++ b/src/core/symbology-ng/qgsvectorfieldsymbollayer.cpp
@@ -210,11 +210,11 @@ void QgsVectorFieldSymbolLayer::startRender( QgsSymbolV2RenderContext& context )
     mLineSymbol->startRender( context.renderContext(), context.fields() );
   }
 
-  const QgsFields* fields = context.fields();
-  if ( fields )
+  QgsFields fields = context.fields();
+  if ( !fields.isEmpty() )
   {
-    mXIndex = fields->fieldNameIndex( mXAttribute );
-    mYIndex = fields->fieldNameIndex( mYAttribute );
+    mXIndex = fields.fieldNameIndex( mXAttribute );
+    mYIndex = fields.fieldNameIndex( mYAttribute );
   }
   else
   {

--- a/src/gui/editorwidgets/core/qgseditorwidgetregistry.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetregistry.cpp
@@ -296,7 +296,7 @@ void QgsEditorWidgetRegistry::writeMapLayer( QgsMapLayer* mapLayer, QDomElement&
   QgsFields fields = vectorLayer->fields();
   for ( int idx = 0; idx < fields.count(); ++idx )
   {
-    const QgsField &field = fields.at( idx );
+    QgsField field = fields.at( idx );
     const QString& widgetType = vectorLayer->editFormConfig()->widgetType( idx );
     if ( !mWidgetFactories.contains( widgetType ) )
     {

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
@@ -118,7 +118,7 @@ void QgsEditorWidgetWrapper::updateConstraint( const QgsFeature &ft )
     description = layer()->editFormConfig()->expressionDescription( mFieldIdx );
 
     QgsExpressionContext context =
-      QgsExpressionContextUtils::createFeatureBasedContext( ft, *ft.fields() );
+      QgsExpressionContextUtils::createFeatureBasedContext( ft, ft.fields() );
     context << QgsExpressionContextUtils::layerScope( layer() );
 
     context.setFeature( ft );
@@ -142,7 +142,7 @@ void QgsEditorWidgetWrapper::updateConstraint( const QgsFeature &ft )
   {
     if ( !expression.isEmpty() )
     {
-      QString fieldName = ft.fields()->field( mFieldIdx ).name();
+      QString fieldName = ft.fields().field( mFieldIdx ).name();
       expression = "( " + expression + " ) AND ( " + fieldName + " IS NOT NULL)";
       description = "( " + description + " ) AND NotNull";
     }

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -869,7 +869,7 @@ void QgsAttributeForm::onUpdatedFields()
     QgsAttributes attrs( layer()->fields().size() );
     for ( int i = 0; i < layer()->fields().size(); i++ )
     {
-      int idx = mFeature.fields()->indexFromName( layer()->fields().at( i ).name() );
+      int idx = mFeature.fields().indexFromName( layer()->fields().at( i ).name() );
       if ( idx != -1 )
       {
         attrs[i] = mFeature.attributes().at( idx );

--- a/src/gui/qgsquerybuilder.cpp
+++ b/src/gui/qgsquerybuilder.cpp
@@ -77,7 +77,7 @@ void QgsQueryBuilder::populateFields()
       // only consider native fields
       continue;
     }
-    QStandardItem *myItem = new QStandardItem( fields[idx].name() );
+    QStandardItem *myItem = new QStandardItem( fields.at( idx ).name() );
     myItem->setData( idx );
     myItem->setEditable( false );
     mModelFields->insertRow( mModelFields->rowCount(), myItem );

--- a/src/gui/qgssearchquerybuilder.cpp
+++ b/src/gui/qgssearchquerybuilder.cpp
@@ -77,7 +77,7 @@ void QgsSearchQueryBuilder::populateFields()
   const QgsFields& fields = mLayer->fields();
   for ( int idx = 0; idx < fields.count(); ++idx )
   {
-    QString fieldName = fields[idx].name();
+    QString fieldName = fields.at( idx ).name();
     mFieldMap[fieldName] = idx;
     QStandardItem *myItem = new QStandardItem( fieldName );
     myItem->setEditable( false );

--- a/src/providers/db2/qgsdb2featureiterator.cpp
+++ b/src/providers/db2/qgsdb2featureiterator.cpp
@@ -338,7 +338,7 @@ bool QgsDb2FeatureIterator::fetchFeature( QgsFeature& feature )
         {
           v = QVariant( v.toString() );
         }
-        const QgsField &fld = mSource->mFields.at( mAttributesToFetch.at( i ) );
+        QgsField fld = mSource->mFields.at( mAttributesToFetch.at( i ) );
 //        QgsDebugMsg( QString( "v.type: %1; fld.type: %2" ).arg( v.type() ).arg( fld.type() ) );
         if ( v.type() != fld.type() )
         {

--- a/src/providers/db2/qgsdb2provider.cpp
+++ b/src/providers/db2/qgsdb2provider.cpp
@@ -1332,7 +1332,7 @@ QgsVectorLayerImport::ImportError QgsDb2Provider::createEmptyLayer( const QStrin
     QString pk = primaryKey = "QGS_FID";
     for ( int i = 0; i < fieldCount; ++i )
     {
-      if ( fields[i].name() == primaryKey )
+      if ( fields.at( i ).name() == primaryKey )
       {
         // it already exists, try again with a new name
         primaryKey = QString( "%1_%2" ).arg( pk ).arg( index++ );
@@ -1345,10 +1345,10 @@ QgsVectorLayerImport::ImportError QgsDb2Provider::createEmptyLayer( const QStrin
     // search for the passed field
     for ( int i = 0; i < fieldCount; ++i )
     {
-      if ( fields[i].name() == primaryKey )
+      if ( fields.at( i ).name() == primaryKey )
       {
         // found, get the field type
-        QgsField fld = fields[i];
+        QgsField fld = fields.at( i );
         if ( convertField( fld ) )
         {
           primaryKeyType = fld.typeName();

--- a/src/providers/grass/qgsgrassprovider.cpp
+++ b/src/providers/grass/qgsgrassprovider.cpp
@@ -1268,7 +1268,7 @@ void QgsGrassProvider::onFeatureAdded( QgsFeatureId fid )
       // It may be that user manualy entered cat value
       QgsFeatureMap& addedFeatures = mEditBuffer->mAddedFeatures;
       QgsFeature& feature = addedFeatures[fid];
-      int catIndex = feature.fields()->indexFromName( mLayer->keyColumnName() );
+      int catIndex = feature.fields().indexFromName( mLayer->keyColumnName() );
       if ( catIndex != -1 )
       {
         QVariant userCatVariant = feature.attributes().value( catIndex );

--- a/src/providers/grass/qgsgrassvectormaplayer.cpp
+++ b/src/providers/grass/qgsgrassvectormaplayer.cpp
@@ -838,12 +838,12 @@ void QgsGrassVectorMapLayer::insertAttributes( int cat, const QgsFeature &featur
     cacheValues << QVariant();
   }
 
-  if ( feature.fields() )
+  if ( !feature.fields().isEmpty() )
   {
     // append feature attributes if not null
-    for ( int i = 0; i < feature.fields()->size(); i++ )
+    for ( int i = 0; i < feature.fields().size(); i++ )
     {
-      QString name = feature.fields()->at( i ).name();
+      QString name = feature.fields().at( i ).name();
       QVariant valueVariant = feature.attributes().value( i );
 
       if ( name != QgsGrassVectorMap::topoSymbolFieldName() )
@@ -940,7 +940,7 @@ void QgsGrassVectorMapLayer::updateAttributes( int cat, QgsFeature &feature, QSt
     error = tr( "Table does not exist" );
     return;
   }
-  if ( !feature.isValid() || !feature.fields() )
+  if ( !feature.isValid() || feature.fields().isEmpty() )
   {
     error = tr( "Feature invalid" );
     return;
@@ -949,9 +949,9 @@ void QgsGrassVectorMapLayer::updateAttributes( int cat, QgsFeature &feature, QSt
   QStringList updates;
   QMap<int, QVariant> cacheUpdates;
   // append feature attributes if not null
-  for ( int i = 0; i < feature.fields()->size(); i++ )
+  for ( int i = 0; i < feature.fields().size(); i++ )
   {
-    QString name = feature.fields()->at( i ).name();
+    QString name = feature.fields().at( i ).name();
     if ( name == mFieldInfo->key )
     {
       continue;

--- a/src/providers/memory/qgsmemoryprovider.cpp
+++ b/src/providers/memory/qgsmemoryprovider.cpp
@@ -262,7 +262,7 @@ QString QgsMemoryProvider::dataSourceUri( bool expandAuthConfig ) const
   QgsAttributeList attrs = const_cast<QgsMemoryProvider *>( this )->attributeIndexes();
   for ( int i = 0; i < attrs.size(); i++ )
   {
-    QgsField field = mFields[attrs[i]];
+    QgsField field = mFields.at( attrs[i] );
     QString fieldDef = field.name();
     fieldDef.append( QString( ":%2(%3,%4)" ).arg( field.typeName() ).arg( field.length() ).arg( field.precision() ) );
     uri.addQueryItem( "field", fieldDef );

--- a/src/providers/mssql/qgsmssqlfeatureiterator.cpp
+++ b/src/providers/mssql/qgsmssqlfeatureiterator.cpp
@@ -300,7 +300,7 @@ bool QgsMssqlFeatureIterator::fetchFeature( QgsFeature& feature )
     for ( int i = 0; i < mAttributesToFetch.count(); i++ )
     {
       QVariant v = mQuery->value( i );
-      const QgsField &fld = mSource->mFields.at( mAttributesToFetch.at( i ) );
+      QgsField fld = mSource->mFields.at( mAttributesToFetch.at( i ) );
       if ( v.type() != fld.type() )
         v = QgsVectorDataProvider::convertValue( fld.type(), v.toString() );
       feature.setAttribute( mAttributesToFetch.at( i ), v );

--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -1669,7 +1669,7 @@ QgsVectorLayerImport::ImportError QgsMssqlProvider::createEmptyLayer( const QStr
     QString pk = primaryKey = "qgs_fid";
     for ( int i = 0, n = fields.size(); i < n; ++i )
     {
-      if ( fields[i].name() == primaryKey )
+      if ( fields.at( i ).name() == primaryKey )
       {
         // it already exists, try again with a new name
         primaryKey = QString( "%1_%2" ).arg( pk ).arg( index++ );
@@ -1682,10 +1682,10 @@ QgsVectorLayerImport::ImportError QgsMssqlProvider::createEmptyLayer( const QStr
     // search for the passed field
     for ( int i = 0, n = fields.size(); i < n; ++i )
     {
-      if ( fields[i].name() == primaryKey )
+      if ( fields.at( i ).name() == primaryKey )
       {
         // found, get the field type
-        QgsField fld = fields[i];
+        QgsField fld = fields.at( i );
         if ( convertField( fld ) )
         {
           primaryKeyType = fld.typeName();
@@ -1830,7 +1830,7 @@ QgsVectorLayerImport::ImportError QgsMssqlProvider::createEmptyLayer( const QStr
     QList<QgsField> flist;
     for ( int i = 0, n = fields.size(); i < n; ++i )
     {
-      QgsField fld = fields[i];
+      QgsField fld = fields.at( i );
       if ( oldToNewAttrIdxMap && fld.name() == primaryKey )
       {
         oldToNewAttrIdxMap->insert( fields.fieldNameIndex( fld.name() ), 0 );

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -2726,7 +2726,7 @@ void QgsOgrProvider::uniqueValues( int index, QList<QVariant> &uniqueValues, int
   if ( !mValid || index < 0 || index >= mAttributeFields.count() )
     return;
 
-  const QgsField& fld = mAttributeFields.at( index );
+  QgsField fld = mAttributeFields.at( index );
   if ( fld.name().isNull() )
   {
     return; //not a provider field
@@ -2774,7 +2774,7 @@ QVariant QgsOgrProvider::minimumValue( int index ) const
   {
     return QVariant();
   }
-  const QgsField& fld = mAttributeFields.at( index );
+  QgsField fld = mAttributeFields.at( index );
 
   // Don't quote column name (see https://trac.osgeo.org/gdal/ticket/5799#comment:9)
   QByteArray sql = "SELECT MIN(" + mEncoding->fromUnicode( fld.name() );
@@ -2813,7 +2813,7 @@ QVariant QgsOgrProvider::maximumValue( int index ) const
   {
     return QVariant();
   }
-  const QgsField& fld = mAttributeFields.at( index );
+  QgsField fld = mAttributeFields.at( index );
 
   // Don't quote column name (see https://trac.osgeo.org/gdal/ticket/5799#comment:9)
   QByteArray sql = "SELECT MAX(" + mEncoding->fromUnicode( fld.name() );

--- a/src/providers/oracle/qgsoraclefeatureiterator.cpp
+++ b/src/providers/oracle/qgsoraclefeatureiterator.cpp
@@ -337,7 +337,7 @@ bool QgsOracleFeatureIterator::fetchFeature( QgsFeature& feature )
         {
           Q_FOREACH ( int idx, mSource->mPrimaryKeyAttrs )
           {
-            const QgsField &fld = mSource->mFields[idx];
+            QgsField fld = mSource->mFields.at( idx );
 
             QVariant v = mQry.value( col );
             if ( v.type() != fld.type() )
@@ -373,7 +373,7 @@ bool QgsOracleFeatureIterator::fetchFeature( QgsFeature& feature )
       if ( mSource->mPrimaryKeyAttrs.contains( idx ) )
         continue;
 
-      const QgsField &fld = mSource->mFields[idx];
+      QgsField fld = mSource->mFields.at( idx );
 
       QVariant v = mQry.value( col );
       if ( fld.type() == QVariant::ByteArray && fld.typeName().endsWith( ".SDO_GEOMETRY" ) )

--- a/src/providers/oracle/qgsoraclefeatureiterator.cpp
+++ b/src/providers/oracle/qgsoraclefeatureiterator.cpp
@@ -452,14 +452,14 @@ bool QgsOracleFeatureIterator::openQuery( QString whereClause, bool showLog )
         break;
 
       case pktInt:
-        query += delim + QgsOracleProvider::quotedIdentifier( mSource->mFields[ mSource->mPrimaryKeyAttrs[0] ].name() );
+        query += delim + QgsOracleProvider::quotedIdentifier( mSource->mFields.at( mSource->mPrimaryKeyAttrs[0] ).name() );
         delim = ",";
         break;
 
       case pktFidMap:
         Q_FOREACH ( int idx, mSource->mPrimaryKeyAttrs )
         {
-          query += delim + mConnection->fieldExpression( mSource->mFields[idx] );
+          query += delim + mConnection->fieldExpression( mSource->mFields.at( idx ) );
           delim = ",";
         }
         break;
@@ -475,7 +475,7 @@ bool QgsOracleFeatureIterator::openQuery( QString whereClause, bool showLog )
       if ( mSource->mPrimaryKeyAttrs.contains( idx ) )
         continue;
 
-      query += delim + mConnection->fieldExpression( mSource->mFields[idx] );
+      query += delim + mConnection->fieldExpression( mSource->mFields.at( idx ) );
     }
 
     query += QString( " FROM %1 \"FEATUREREQUEST\"" ).arg( mSource->mQuery );

--- a/src/providers/oracle/qgsoracleprovider.cpp
+++ b/src/providers/oracle/qgsoracleprovider.cpp
@@ -338,7 +338,7 @@ QString QgsOracleProvider::pkParamWhereClause() const
       for ( int i = 0; i < mPrimaryKeyAttrs.size(); i++ )
       {
         int idx = mPrimaryKeyAttrs[i];
-        const QgsField &fld = field( idx );
+        QgsField fld = field( idx );
 
         whereClause += delim + QString( "%1=?" ).arg( mConnection->fieldExpression( fld ) );
         delim = " AND ";
@@ -435,7 +435,7 @@ QString QgsOracleUtils::whereClause( QgsFeatureId featureId, const QgsFields& fi
           for ( int i = 0; i < primaryKeyAttrs.size(); i++ )
           {
             int idx = primaryKeyAttrs[i];
-            const QgsField &fld = fields[ idx ];
+            QgsField fld = fields.at( idx );
 
             whereClause += delim + QString( "%1=%2" ).arg( QgsOracleConn::fieldExpression( fld ) ).arg( QgsOracleConn::quotedValue( pkVals[i], fld.type() ) );
             delim = " AND ";
@@ -504,7 +504,7 @@ QgsWkbTypes::Type QgsOracleProvider::wkbType() const
   return mRequestedGeomType != QgsWkbTypes::Unknown ? mRequestedGeomType : mDetectedGeomType;
 }
 
-const QgsField &QgsOracleProvider::field( int index ) const
+QgsField QgsOracleProvider::field( int index ) const
 {
   if ( index < 0 || index >= mAttributeFields.size() )
   {
@@ -512,7 +512,7 @@ const QgsField &QgsOracleProvider::field( int index ) const
     throw OracleFieldNotFound();
   }
 
-  return mAttributeFields[ index ];
+  return mAttributeFields.at( index );
 }
 
 QgsFeatureIterator QgsOracleProvider::getFeatures( const QgsFeatureRequest& request ) const
@@ -900,7 +900,7 @@ bool QgsOracleProvider::determinePrimaryKey()
         return false;
       }
 
-      const QgsField &fld = mAttributeFields.at( idx );
+      QgsField fld = mAttributeFields.at( idx );
 
       if ( isInt &&
            fld.type() != QVariant::Int &&
@@ -937,7 +937,7 @@ bool QgsOracleProvider::determinePrimaryKey()
 
         if ( idx >= 0 )
         {
-          const QgsField &fld = mAttributeFields.at( idx );
+          QgsField fld = mAttributeFields.at( idx );
 
           if ( mUseEstimatedMetadata || uniqueData( mQuery, primaryKey ) )
           {
@@ -1027,7 +1027,7 @@ QVariant QgsOracleProvider::minimumValue( int index ) const
   try
   {
     // get the field name
-    const QgsField &fld = field( index );
+    QgsField fld = field( index );
     QString sql = QString( "SELECT min(%1) FROM %2" )
                   .arg( quotedIdentifier( fld.name() ) )
                   .arg( mQuery );
@@ -1070,7 +1070,7 @@ void QgsOracleProvider::uniqueValues( int index, QList<QVariant> &uniqueValues, 
   try
   {
     // get the field name
-    const QgsField &fld = field( index );
+    QgsField fld = field( index );
     QString sql = QString( "SELECT DISTINCT %1 FROM %2" )
                   .arg( quotedIdentifier( fld.name() ) )
                   .arg( mQuery );
@@ -1117,7 +1117,7 @@ QVariant QgsOracleProvider::maximumValue( int index ) const
   try
   {
     // get the field name
-    const QgsField &fld = field( index );
+    QgsField fld = field( index );
     QString sql = QString( "SELECT max(%1) FROM %2" )
                   .arg( quotedIdentifier( fld.name() ) )
                   .arg( mQuery );
@@ -1227,7 +1227,7 @@ bool QgsOracleProvider::addFeatures( QgsFeatureList &flist )
 
       Q_FOREACH ( int idx, mPrimaryKeyAttrs )
       {
-        const QgsField &fld = field( idx );
+        QgsField fld = field( idx );
         insert += delim + quotedIdentifier( fld.name() );
         keys += kdelim + quotedIdentifier( fld.name() );
         values += delim + "?";
@@ -1256,7 +1256,7 @@ bool QgsOracleProvider::addFeatures( QgsFeatureList &flist )
       if ( fieldId.contains( idx ) )
         continue;
 
-      const QgsField &fld = mAttributeFields[idx];
+      QgsField fld = mAttributeFields.at( idx );
 
       QgsDebugMsgLevel( "Checking field against: " + fld.name(), 4 );
 
@@ -1339,7 +1339,7 @@ bool QgsOracleProvider::addFeatures( QgsFeatureList &flist )
         QString v;
         if ( !value.isValid() )
         {
-          const QgsField &fld = field( fieldId[i] );
+          QgsField fld = field( fieldId[i] );
           v = paramValue( defaultValues[i], defaultValues[i] );
           features->setAttribute( fieldId[i], convertValue( fld.type(), v ) );
         }
@@ -1349,7 +1349,7 @@ bool QgsOracleProvider::addFeatures( QgsFeatureList &flist )
 
           if ( v != value.toString() )
           {
-            const QgsField &fld = field( fieldId[i] );
+            QgsField fld = field( fieldId[i] );
             features->setAttribute( fieldId[i], convertValue( fld.type(), v ) );
           }
         }
@@ -1375,7 +1375,7 @@ bool QgsOracleProvider::addFeatures( QgsFeatureList &flist )
         int col = 0;
         Q_FOREACH ( int idx, mPrimaryKeyAttrs )
         {
-          const QgsField &fld = field( idx );
+          QgsField fld = field( idx );
 
           QVariant v = getfid.value( col++ );
           if ( v.type() != fld.type() )
@@ -1590,7 +1590,7 @@ bool QgsOracleProvider::deleteAttributes( const QgsAttributeIds& ids )
 
     Q_FOREACH ( int id, idsList )
     {
-      const QgsField &fld = mAttributeFields.at( id );
+      QgsField fld = mAttributeFields.at( id );
 
       QString sql = QString( "ALTER TABLE %1 DROP COLUMN %2" )
                     .arg( mQuery )
@@ -1751,7 +1751,7 @@ bool QgsOracleProvider::changeAttributeValues( const QgsChangedAttributesMap &at
       {
         try
         {
-          const QgsField &fld = field( siter.key() );
+          QgsField fld = field( siter.key() );
 
           pkChanged = pkChanged || mPrimaryKeyAttrs.contains( siter.key() );
 

--- a/src/providers/oracle/qgsoracleprovider.cpp
+++ b/src/providers/oracle/qgsoracleprovider.cpp
@@ -181,7 +181,7 @@ QgsOracleProvider::QgsOracleProvider( QString const & uri )
       Q_FOREACH ( int idx, mPrimaryKeyAttrs )
       {
         Q_ASSERT( idx >= 0 && idx < mAttributeFields.size() );
-        key += delim + mAttributeFields[ idx ].name();
+        key += delim + mAttributeFields.at( idx ).name();
         delim = ",";
       }
     }
@@ -416,7 +416,7 @@ QString QgsOracleUtils::whereClause( QgsFeatureId featureId, const QgsFields& fi
   {
     case pktInt:
       Q_ASSERT( primaryKeyAttrs.size() == 1 );
-      whereClause = QString( "%1=%2" ).arg( QgsOracleConn::quotedIdentifier( fields[ primaryKeyAttrs[0] ].name() ) ).arg( featureId );
+      whereClause = QString( "%1=%2" ).arg( QgsOracleConn::quotedIdentifier( fields.at( primaryKeyAttrs[0] ).name() ) ).arg( featureId );
       break;
 
     case pktRowId:
@@ -966,9 +966,9 @@ bool QgsOracleProvider::determinePrimaryKey()
     int idx = fieldNameIndex( mUri.keyColumn() );
 
     if ( idx >= 0 && (
-           mAttributeFields[idx].type() == QVariant::Int ||
-           mAttributeFields[idx].type() == QVariant::LongLong ||
-           mAttributeFields[idx].type() == QVariant::Double
+           mAttributeFields.at( idx ).type() == QVariant::Int ||
+           mAttributeFields.at( idx ).type() == QVariant::LongLong ||
+           mAttributeFields.at( idx ).type() == QVariant::Double
          ) )
     {
       if ( mUseEstimatedMetadata || uniqueData( mQuery, primaryKey ) )
@@ -1299,7 +1299,7 @@ bool QgsOracleProvider::addFeatures( QgsFeatureList &flist )
         }
         else
         {
-          values += delim + quotedValue( v, mAttributeFields[idx].type() );
+          values += delim + quotedValue( v, mAttributeFields.at( idx ).type() );
         }
       }
       else
@@ -2091,7 +2091,7 @@ bool QgsOracleProvider::setSubsetString( const QString& theSQL, bool updateFeatu
   }
   qry.finish();
 
-  if ( mPrimaryKeyType == pktInt && !uniqueData( mQuery, mAttributeFields[ mPrimaryKeyAttrs[0] ].name() ) )
+  if ( mPrimaryKeyType == pktInt && !uniqueData( mQuery, mAttributeFields.at( mPrimaryKeyAttrs[0] ).name() ) )
   {
     mSqlWhereClause = prevWhere;
     return false;
@@ -2649,7 +2649,7 @@ QgsVectorLayerImport::ImportError QgsOracleProvider::createEmptyLayer(
     int idx = fields.indexFromName( primaryKey );
     if ( idx >= 0 )
     {
-      QgsField fld = fields[idx];
+      QgsField fld = fields.at( idx );
       if ( convertField( fld ) )
       {
         primaryKeyType = fld.typeName();
@@ -2856,7 +2856,7 @@ QgsVectorLayerImport::ImportError QgsOracleProvider::createEmptyLayer(
     QList<QgsField> launderedFields;
     for ( int i = 0; i < fields.size(); i++ )
     {
-      QgsField fld = fields[i];
+      QgsField fld = fields.at( i );
 
       QString name = fld.name().left( 30 ).toUpper();
 

--- a/src/providers/oracle/qgsoracleprovider.h
+++ b/src/providers/oracle/qgsoracleprovider.h
@@ -292,7 +292,7 @@ class QgsOracleProvider : public QgsVectorDataProvider
 
     bool hasSufficientPermsAndCapabilities();
 
-    const QgsField &field( int index ) const;
+    QgsField field( int index ) const;
 
     /** Load the field list
      */

--- a/src/providers/postgres/qgspostgresfeatureiterator.cpp
+++ b/src/providers/postgres/qgspostgresfeatureiterator.cpp
@@ -737,7 +737,7 @@ bool QgsPostgresFeatureIterator::getFeature( QgsPostgresResult &queryResult, int
 
       Q_FOREACH ( int idx, mSource->mPrimaryKeyAttrs )
       {
-        const QgsField &fld = mSource->mFields.at( idx );
+        QgsField fld = mSource->mFields.at( idx );
 
         QVariant v = QgsPostgresProvider::convertValue( fld.type(), queryResult.PQgetvalue( row, col ) );
         primaryKeyVals << v;

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -544,12 +544,12 @@ QString QgsPostgresUtils::whereClause( QgsFeatureId featureId, const QgsFields& 
 
     case pktInt:
       Q_ASSERT( pkAttrs.size() == 1 );
-      whereClause = QString( "%1=%2" ).arg( QgsPostgresConn::quotedIdentifier( fields[ pkAttrs[0] ].name() ) ).arg( FID2PKINT( featureId ) );
+      whereClause = QString( "%1=%2" ).arg( QgsPostgresConn::quotedIdentifier( fields.at( pkAttrs[0] ).name() ) ).arg( FID2PKINT( featureId ) );
       break;
 
     case pktUint64:
       Q_ASSERT( pkAttrs.size() == 1 );
-      whereClause = QString( "%1=%2" ).arg( QgsPostgresConn::quotedIdentifier( fields[ pkAttrs[0] ].name() ) ).arg( featureId );
+      whereClause = QString( "%1=%2" ).arg( QgsPostgresConn::quotedIdentifier( fields.at( pkAttrs[0] ).name() ) ).arg( featureId );
       break;
 
     case pktFidMap:
@@ -565,7 +565,7 @@ QString QgsPostgresUtils::whereClause( QgsFeatureId featureId, const QgsFields& 
         for ( int i = 0; i < pkAttrs.size(); i++ )
         {
           int idx = pkAttrs[i];
-          QgsField fld = fields[ idx ];
+          QgsField fld = fields.at( idx );
 
           whereClause += delim + conn->fieldExpression( fld );
           if ( pkVals[i].isNull() )
@@ -607,7 +607,7 @@ QString QgsPostgresUtils::whereClause( const QgsFeatureIds& featureIds, const Qg
       if ( !featureIds.isEmpty() )
       {
         QString delim;
-        expr = QString( "%1 IN (" ).arg(( pkType == pktOid ? "oid" : QgsPostgresConn::quotedIdentifier( fields[ pkAttrs[0] ].name() ) ) );
+        expr = QString( "%1 IN (" ).arg(( pkType == pktOid ? "oid" : QgsPostgresConn::quotedIdentifier( fields.at( pkAttrs[0] ).name() ) ) );
 
         Q_FOREACH ( const QgsFeatureId featureId, featureIds )
         {
@@ -3489,7 +3489,7 @@ QgsVectorLayerImport::ImportError QgsPostgresProvider::createEmptyLayer( const Q
     QString pk = primaryKey = "id";
     for ( int fldIdx = 0; fldIdx < fields.count(); ++fldIdx )
     {
-      if ( fields[fldIdx].name() == primaryKey )
+      if ( fields.at( fldIdx ).name() == primaryKey )
       {
         // it already exists, try again with a new name
         primaryKey = QString( "%1_%2" ).arg( pk ).arg( index++ );
@@ -3502,10 +3502,10 @@ QgsVectorLayerImport::ImportError QgsPostgresProvider::createEmptyLayer( const Q
     // search for the passed field
     for ( int fldIdx = 0; fldIdx < fields.count(); ++fldIdx )
     {
-      if ( fields[fldIdx].name() == primaryKey )
+      if ( fields.at( fldIdx ).name() == primaryKey )
       {
         // found, get the field type
-        QgsField fld = fields[fldIdx];
+        QgsField fld = fields.at( fldIdx );
         if ( convertField( fld, options ) )
         {
           primaryKeyType = fld.typeName();
@@ -3658,7 +3658,7 @@ QgsVectorLayerImport::ImportError QgsPostgresProvider::createEmptyLayer( const Q
     QList<QgsField> flist;
     for ( int fldIdx = 0; fldIdx < fields.count(); ++fldIdx )
     {
-      QgsField fld = fields[fldIdx];
+      QgsField fld = fields.at( fldIdx );
 
       if ( fld.name() == geometryColumn )
       {

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -444,7 +444,7 @@ QString QgsPostgresProvider::pkParamWhereClause( int offset, const char *alias )
       for ( int i = 0; i < mPrimaryKeyAttrs.size(); i++ )
       {
         int idx = mPrimaryKeyAttrs[i];
-        const QgsField &fld = field( idx );
+        QgsField fld = field( idx );
 
         whereClause += delim + QString( "%3%1=$%2" ).arg( connectionRO()->fieldExpression( fld ) ).arg( offset++ ).arg( aliased );
         delim = " AND ";
@@ -565,7 +565,7 @@ QString QgsPostgresUtils::whereClause( QgsFeatureId featureId, const QgsFields& 
         for ( int i = 0; i < pkAttrs.size(); i++ )
         {
           int idx = pkAttrs[i];
-          const QgsField &fld = fields[ idx ];
+          QgsField fld = fields[ idx ];
 
           whereClause += delim + conn->fieldExpression( fld );
           if ( pkVals[i].isNull() )
@@ -691,7 +691,7 @@ QgsWkbTypes::Type QgsPostgresProvider::wkbType() const
   return mRequestedGeomType != QgsWkbTypes::Unknown ? mRequestedGeomType : mDetectedGeomType;
 }
 
-const QgsField &QgsPostgresProvider::field( int index ) const
+QgsField QgsPostgresProvider::field( int index ) const
 {
   if ( index < 0 || index >= mAttributeFields.count() )
   {
@@ -699,7 +699,7 @@ const QgsField &QgsPostgresProvider::field( int index ) const
     throw PGFieldNotFound();
   }
 
-  return mAttributeFields[index];
+  return mAttributeFields.at( index );
 }
 
 QgsFields QgsPostgresProvider::fields() const
@@ -1350,7 +1350,7 @@ bool QgsPostgresProvider::determinePrimaryKey()
           QgsDebugMsg( "Skipping " + name );
           continue;
         }
-        const QgsField& fld = mAttributeFields.at( idx );
+        QgsField fld = mAttributeFields.at( idx );
 
         // Always use pktFidMap for multi-field keys
         mPrimaryKeyType = i ? pktFidMap : pkType( fld );
@@ -1448,7 +1448,7 @@ void QgsPostgresProvider::determinePrimaryKeyFromUriKeyColumn()
         mPrimaryKeyType = pktFidMap; // Map by default
         if ( mPrimaryKeyAttrs.size() == 1 )
         {
-          const QgsField& fld = mAttributeFields.at( 0 );
+          QgsField fld = mAttributeFields.at( 0 );
           mPrimaryKeyType = pkType( fld );
         }
       }
@@ -1493,7 +1493,7 @@ QVariant QgsPostgresProvider::minimumValue( int index ) const
   try
   {
     // get the field name
-    const QgsField &fld = field( index );
+    QgsField fld = field( index );
     QString sql = QString( "SELECT min(%1) AS %1 FROM %2" )
                   .arg( quotedIdentifier( fld.name() ),
                         mQuery );
@@ -1522,7 +1522,7 @@ void QgsPostgresProvider::uniqueValues( int index, QList<QVariant> &uniqueValues
   try
   {
     // get the field name
-    const QgsField &fld = field( index );
+    QgsField fld = field( index );
     QString sql = QString( "SELECT DISTINCT %1 FROM %2" )
                   .arg( quotedIdentifier( fld.name() ),
                         mQuery );
@@ -1668,7 +1668,7 @@ QVariant QgsPostgresProvider::maximumValue( int index ) const
   try
   {
     // get the field name
-    const QgsField &fld = field( index );
+    QgsField fld = field( index );
     QString sql = QString( "SELECT max(%1) AS %1 FROM %2" )
                   .arg( quotedIdentifier( fld.name() ),
                         mQuery );
@@ -1702,7 +1702,7 @@ QVariant QgsPostgresProvider::defaultValue( int fieldId ) const
 
   if ( providerProperty( EvaluateDefaultValues, false ).toBool() && !defVal.isNull() )
   {
-    const QgsField& fld = field( fieldId );
+    QgsField fld = field( fieldId );
 
     QgsPostgresResult res( connectionRO()->PQexec( QString( "SELECT %1" ).arg( defVal.toString() ) ) );
 
@@ -2003,7 +2003,7 @@ bool QgsPostgresProvider::addFeatures( QgsFeatureList &flist )
         QString v;
         if ( value.isNull() )
         {
-          const QgsField &fld = field( attrIdx );
+          QgsField fld = field( attrIdx );
           v = paramValue( defaultValues[ i ], defaultValues[ i ] );
           features->setAttribute( attrIdx, convertValue( fld.type(), v ) );
         }
@@ -2013,7 +2013,7 @@ bool QgsPostgresProvider::addFeatures( QgsFeatureList &flist )
 
           if ( v != value.toString() )
           {
-            const QgsField &fld = field( attrIdx );
+            QgsField fld = field( attrIdx );
             features->setAttribute( attrIdx, convertValue( fld.type(), v ) );
           }
         }

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -294,7 +294,7 @@ class QgsPostgresProvider : public QgsVectorDataProvider
 
     bool hasSufficientPermsAndCapabilities();
 
-    const QgsField &field( int index ) const;
+    QgsField field( int index ) const;
 
     /** Load the field list
      */

--- a/src/providers/spatialite/qgsspatialiteprovider.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovider.cpp
@@ -3381,7 +3381,7 @@ QVariant QgsSpatiaLiteProvider::minimumValue( int index ) const
   try
   {
     // get the field name
-    const QgsField& fld = field( index );
+    QgsField fld = field( index );
 
     sql = QString( "SELECT Min(%1) FROM %2" ).arg( quotedIdentifier( fld.name() ), mQuery );
 
@@ -3444,7 +3444,7 @@ QVariant QgsSpatiaLiteProvider::maximumValue( int index ) const
   try
   {
     // get the field name
-    const QgsField & fld = field( index );
+    QgsField fld = field( index );
 
     sql = QString( "SELECT Max(%1) FROM %2" ).arg( quotedIdentifier( fld.name() ), mQuery );
 
@@ -3506,7 +3506,7 @@ void QgsSpatiaLiteProvider::uniqueValues( int index, QList < QVariant > &uniqueV
   {
     return; //invalid field
   }
-  const QgsField& fld = mAttributeFields.at( index );
+  QgsField fld = mAttributeFields.at( index );
 
   sql = QString( "SELECT DISTINCT %1 FROM %2" ).arg( quotedIdentifier( fld.name() ), mQuery );
 
@@ -3971,7 +3971,7 @@ bool QgsSpatiaLiteProvider::changeAttributeValues( const QgsChangedAttributesMap
       // Loop over all changed attributes
       try
       {
-        const QgsField& fld = field( siter.key() );
+        QgsField fld = field( siter.key() );
         const QVariant& val = siter.value();
 
         if ( !first )
@@ -4995,7 +4995,7 @@ error:
   return false;
 }
 
-const QgsField & QgsSpatiaLiteProvider::field( int index ) const
+QgsField QgsSpatiaLiteProvider::field( int index ) const
 {
   if ( index < 0 || index >= mAttributeFields.count() )
   {
@@ -5003,7 +5003,7 @@ const QgsField & QgsSpatiaLiteProvider::field( int index ) const
     throw SLFieldNotFound();
   }
 
-  return mAttributeFields[index];
+  return mAttributeFields.at( index );
 }
 
 void QgsSpatiaLiteProvider::invalidateConnections( const QString& connection )

--- a/src/providers/spatialite/qgsspatialiteprovider.cpp
+++ b/src/providers/spatialite/qgsspatialiteprovider.cpp
@@ -144,7 +144,7 @@ QgsSpatiaLiteProvider::createEmptyLayer( const QString& uri,
       QString pk = primaryKey = "pk";
       for ( int fldIdx = 0; fldIdx < fields.count(); ++fldIdx )
       {
-        if ( fields[fldIdx].name() == primaryKey )
+        if ( fields.at( fldIdx ).name() == primaryKey )
         {
           // it already exists, try again with a new name
           primaryKey = QString( "%1_%2" ).arg( pk ).arg( index++ );
@@ -157,10 +157,10 @@ QgsSpatiaLiteProvider::createEmptyLayer( const QString& uri,
       // search for the passed field
       for ( int fldIdx = 0; fldIdx < fields.count(); ++fldIdx )
       {
-        if ( fields[fldIdx].name() == primaryKey )
+        if ( fields.at( fldIdx ).name() == primaryKey )
         {
           // found, get the field type
-          QgsField fld = fields[fldIdx];
+          QgsField fld = fields.at( fldIdx );
           if ( convertField( fld ) )
           {
             primaryKeyType = fld.typeName();
@@ -357,7 +357,7 @@ QgsSpatiaLiteProvider::createEmptyLayer( const QString& uri,
     QList<QgsField> flist;
     for ( int fldIdx = 0; fldIdx < fields.count(); ++fldIdx )
     {
-      QgsField fld = fields[fldIdx];
+      QgsField fld = fields.at( fldIdx );
       if ( fld.name() == primaryKey )
         continue;
 

--- a/src/providers/spatialite/qgsspatialiteprovider.h
+++ b/src/providers/spatialite/qgsspatialiteprovider.h
@@ -370,7 +370,7 @@ class QgsSpatiaLiteProvider: public QgsVectorDataProvider
 
     QgsVectorDataProvider::Capabilities mEnabledCapabilities;
 
-    const QgsField &field( int index ) const;
+    QgsField field( int index ) const;
 
     //! SpatiaLite version string
     QString mSpatialiteVersionInfo;

--- a/src/providers/wfs/qgswfsfeatureiterator.cpp
+++ b/src/providers/wfs/qgswfsfeatureiterator.cpp
@@ -955,7 +955,7 @@ bool QgsWFSFeatureIterator::fetchFeature( QgsFeature& f )
 
     if ( !mShared->mGeometryAttribute.isEmpty() && mFetchGeometry )
     {
-      int idx = cachedFeature.fields()->indexFromName( QgsWFSConstants::FIELD_HEXWKB_GEOM );
+      int idx = cachedFeature.fields().indexFromName( QgsWFSConstants::FIELD_HEXWKB_GEOM );
       Q_ASSERT( idx >= 0 );
 
       const QVariant &v = cachedFeature.attributes().value( idx );
@@ -1183,7 +1183,7 @@ void QgsWFSFeatureIterator::copyFeature( const QgsFeature& srcFeature, QgsFeatur
   {
     Q_FOREACH ( int i, mSubSetAttributes )
     {
-      int idx = srcFeature.fields()->indexFromName( fields.at( i ).name() );
+      int idx = srcFeature.fields().indexFromName( fields.at( i ).name() );
       if ( idx >= 0 )
       {
         const QVariant &v = srcFeature.attributes().value( idx );
@@ -1200,7 +1200,7 @@ void QgsWFSFeatureIterator::copyFeature( const QgsFeature& srcFeature, QgsFeatur
   {
     for ( int i = 0; i < fields.size(); i++ )
     {
-      int idx = srcFeature.fields()->indexFromName( fields.at( i ).name() );
+      int idx = srcFeature.fields().indexFromName( fields.at( i ).name() );
       if ( idx >= 0 )
       {
         const QVariant &v = srcFeature.attributes().value( idx );

--- a/src/providers/wfs/qgswfsprovider.cpp
+++ b/src/providers/wfs/qgswfsprovider.cpp
@@ -530,7 +530,7 @@ bool QgsWFSProvider::processSQL( const QString& sqlString, QString& errorMsg, QS
         const QgsFields tableFields = mapTypenameToFields[columnTableTypename];
         for ( int i = 0; i < tableFields.size();i++ )
         {
-          const QgsField& srcField = tableFields[i];
+          QgsField srcField = tableFields.at( i );
           QString fieldName( srcField.name() );
           // If several tables selected, prefix by table name
           if ( typenameList.size() > 1 )
@@ -562,7 +562,7 @@ bool QgsWFSProvider::processSQL( const QString& sqlString, QString& errorMsg, QS
           const QgsFields tableFields = mapTypenameToFields[typeName];
           for ( int i = 0; i < tableFields.size();i++ )
           {
-            const QgsField& srcField = tableFields[i];
+            QgsField srcField = tableFields.at( i );
             QString fieldName( srcField.name() );
             // If several tables selected, prefix by table name
             if ( typenameList.size() > 1 )

--- a/src/providers/wfs/qgswfsprovider.cpp
+++ b/src/providers/wfs/qgswfsprovider.cpp
@@ -618,9 +618,9 @@ bool QgsWFSProvider::processSQL( const QString& sqlString, QString& errorMsg, QS
         return false;
       }
 
-      QgsField field( fieldName, tableFields[idx].type(), tableFields[idx].typeName() );
+      QgsField field( fieldName, tableFields.at( idx ).type(), tableFields.at( idx ).typeName() );
       mapFieldNameToSrcLayerNameFieldName[ field.name()] =
-        QPair<QString, QString>( columnTableTypename, tableFields[idx].name() );
+        QPair<QString, QString>( columnTableTypename, tableFields.at( idx ).name() );
       mShared->mFields.append( field );
     }
   }

--- a/src/server/qgsserverprojectparser.cpp
+++ b/src/server/qgsserverprojectparser.cpp
@@ -789,7 +789,7 @@ void QgsServerProjectParser::addLayerProjectSettings( QDomElement& layerElem, QD
     const QgsFields& layerFields = vLayer->pendingFields();
     for ( int idx = 0; idx < layerFields.count(); ++idx )
     {
-      const QgsField& field = layerFields.at( idx );
+      QgsField field = layerFields.at( idx );
       if ( excludedAttributes.contains( field.name() ) )
       {
         continue;

--- a/src/server/qgswfsprojectparser.cpp
+++ b/src/server/qgswfsprojectparser.cpp
@@ -465,7 +465,7 @@ void QgsWfsProjectParser::describeFeatureType( const QString& aTypeName, QDomEle
           //xsd:element
           QDomElement attElem = doc.createElement( "element"/*xsd:element*/ );
           attElem.setAttribute( "name", attributeName );
-          QVariant::Type attributeType = fields[idx].type();
+          QVariant::Type attributeType = fields.at( idx ).type();
           if ( attributeType == QVariant::Int )
             attElem.setAttribute( "type", "integer" );
           else if ( attributeType == QVariant::LongLong )

--- a/src/server/qgswfsserver.cpp
+++ b/src/server/qgswfsserver.cpp
@@ -1603,7 +1603,7 @@ QDomDocument QgsWfsServer::transaction( const QString& requestBody )
               {
                 continue;
               }
-              const QgsField& field = fields.at( fieldMapIt.value() );
+              QgsField field = fields.at( fieldMapIt.value() );
               if ( field.type() == 2 )
                 layer->changeAttributeValue( *fidIt, fieldMapIt.value(), it.value().toInt( &conversionSuccess ) );
               else if ( field.type() == 6 )
@@ -1740,7 +1740,7 @@ QDomDocument QgsWfsServer::transaction( const QString& requestBody )
                   {
                     continue;
                   }
-                  const QgsField& field = fields.at( fieldMapIt.value() );
+                  QgsField field = fields.at( fieldMapIt.value() );
                   QString attrValue = currentAttributeElement.text();
                   int attrType = field.type();
                   QgsMessageLog::logMessage( QString( "attr: name=%1 idx=%2 value=%3" ).arg( attrName ).arg( fieldMapIt.value() ).arg( attrValue ) );

--- a/src/server/qgswfsserver.cpp
+++ b/src/server/qgswfsserver.cpp
@@ -1896,16 +1896,16 @@ QString QgsWfsServer::createFeatureGeoJSON( QgsFeature* feat, int prec, QgsCoord
     }
   }
 
-  const QgsFields* fields = feat->fields();
+  QgsFields fields = feat->fields();
   QgsAttributeList attrsToExport;
   for ( int i = 0; i < attrIndexes.count(); ++i )
   {
     int idx = attrIndexes[i];
-    if ( idx >= fields->count() )
+    if ( idx >= fields.count() )
     {
       continue;
     }
-    QString attributeName = fields->at( idx ).name();
+    QString attributeName = fields.at( idx ).name();
     //skip attribute if it is excluded from WFS publication
     if ( excludedAttributes.contains( attributeName ) )
     {
@@ -1972,15 +1972,15 @@ QDomElement QgsWfsServer::createFeatureGML2( QgsFeature* feat, QDomDocument& doc
 
   //read all attribute values from the feature
   QgsAttributes featureAttributes = feat->attributes();
-  const QgsFields* fields = feat->fields();
+  QgsFields fields = feat->fields();
   for ( int i = 0; i < attrIndexes.count(); ++i )
   {
     int idx = attrIndexes[i];
-    if ( idx >= fields->count() )
+    if ( idx >= fields.count() )
     {
       continue;
     }
-    QString attributeName = fields->at( idx ).name();
+    QString attributeName = fields.at( idx ).name();
     //skip attribute if it is excluded from WFS publication
     if ( excludedAttributes.contains( attributeName ) )
     {
@@ -2047,15 +2047,15 @@ QDomElement QgsWfsServer::createFeatureGML3( QgsFeature* feat, QDomDocument& doc
 
   //read all attribute values from the feature
   QgsAttributes featureAttributes = feat->attributes();
-  const QgsFields* fields = feat->fields();
+  QgsFields fields = feat->fields();
   for ( int i = 0; i < attrIndexes.count(); ++i )
   {
     int idx = attrIndexes[i];
-    if ( idx >= fields->count() )
+    if ( idx >= fields.count() )
     {
       continue;
     }
-    QString attributeName = fields->at( idx ).name();
+    QString attributeName = fields.at( idx ).name();
     //skip attribute if it is excluded from WFS publication
     if ( excludedAttributes.contains( attributeName ) )
     {

--- a/src/server/qgswmsserver.cpp
+++ b/src/server/qgswmsserver.cpp
@@ -3273,10 +3273,10 @@ QDomElement QgsWmsServer::createFeatureGML(
 
   //read all allowed attribute values from the feature
   QgsAttributes featureAttributes = feat->attributes();
-  const QgsFields* fields = feat->fields();
-  for ( int i = 0; i < fields->count(); ++i )
+  QgsFields fields = feat->fields();
+  for ( int i = 0; i < fields.count(); ++i )
   {
-    QString attributeName = fields->at( i ).name();
+    QString attributeName = fields.at( i ).name();
     //skip attribute if it is explicitly excluded from WMS publication
     if ( layer && layer->excludeAttributesWms().contains( attributeName ) )
     {

--- a/src/server/qgswmsserver.cpp
+++ b/src/server/qgswmsserver.cpp
@@ -2305,13 +2305,13 @@ int QgsWmsServer::featureInfoFromVectorLayer( QgsVectorLayer* layer,
       for ( int i = 0; i < featureAttributes.count(); ++i )
       {
         //skip attribute if it is explicitly excluded from WMS publication
-        if ( excludedAttributes.contains( fields[i].name() ) )
+        if ( excludedAttributes.contains( fields.at( i ).name() ) )
         {
           continue;
         }
 #ifdef HAVE_SERVER_PYTHON_PLUGINS
         //skip attribute if it is excluded by access control
-        if ( !attributes.contains( fields[i].name() ) )
+        if ( !attributes.contains( fields.at( i ).name() ) )
         {
           continue;
         }

--- a/tests/src/core/testqgsfeature.cpp
+++ b/tests/src/core/testqgsfeature.cpp
@@ -130,7 +130,7 @@ void TestQgsFeature::create()
 
   QgsFeature featureFromFieldsId( mFields, 1001LL );
   QCOMPARE( featureFromFieldsId.id(), 1001LL );
-  QCOMPARE( *featureFromFieldsId.fields(), mFields );
+  QCOMPARE( featureFromFieldsId.fields(), mFields );
   QCOMPARE( featureFromFieldsId.isValid(), false );
   //should be 3 invalid attributes
   QCOMPARE( featureFromFieldsId.attributes().count(), 3 );
@@ -303,24 +303,24 @@ void TestQgsFeature::asVariant()
   QgsFeature fromVar = qvariant_cast<QgsFeature>( var );
   //QCOMPARE( fromVar, original );
   QCOMPARE( fromVar.id(), original.id() );
-  QCOMPARE( *fromVar.fields(), *original.fields() );
+  QCOMPARE( fromVar.fields(), original.fields() );
 }
 
 void TestQgsFeature::fields()
 {
   QgsFeature original;
-  QVERIFY( original.fields()->isEmpty() );
+  QVERIFY( original.fields().isEmpty() );
   original.setFields( mFields );
-  QCOMPARE( *original.fields(), mFields );
+  QCOMPARE( original.fields(), mFields );
   QgsFeature copy( original );
-  QCOMPARE( *copy.fields(), *original.fields() );
+  QCOMPARE( copy.fields(), original.fields() );
 
   //test detach
   QgsFields newFields( mFields );
   newFields.remove( 2 );
   copy.setFields( newFields );
-  QCOMPARE( *copy.fields(), newFields );
-  QCOMPARE( *original.fields(), mFields );
+  QCOMPARE( copy.fields(), newFields );
+  QCOMPARE( original.fields(), mFields );
 
   //test that no init leaves attributes
   copy = original;
@@ -329,7 +329,7 @@ void TestQgsFeature::fields()
   copy.setAttribute( 1, 2 );
   copy.setAttribute( 2, 3 );
   copy.setFields( mFields, false );
-  QCOMPARE( *copy.fields(), mFields );
+  QCOMPARE( copy.fields(), mFields );
   //should be 3 invalid attributes
   QCOMPARE( copy.attributes().count(), 3 );
   QCOMPARE( copy.attributes().at( 0 ).toInt(), 1 );
@@ -343,7 +343,7 @@ void TestQgsFeature::fields()
   copy.setAttribute( 1, 2 );
   copy.setAttribute( 2, 3 );
   copy.setFields( mFields, true );
-  QCOMPARE( *copy.fields(), mFields );
+  QCOMPARE( copy.fields(), mFields );
   //should be 3 invalid attributes
   QCOMPARE( copy.attributes().count(), 3 );
   Q_FOREACH ( const QVariant& a, copy.attributes() )

--- a/tests/src/gui/testqgsdualview.cpp
+++ b/tests/src/gui/testqgsdualview.cpp
@@ -111,7 +111,7 @@ void TestQgsDualView::testColumnHeaders()
 {
   for ( int i = 0; i < mPointsLayer->fields().count(); ++i )
   {
-    const QgsField& fld = mPointsLayer->fields().at( i );
+    QgsField fld = mPointsLayer->fields().at( i );
     QCOMPARE( mDualView->tableView()->model()->headerData( i, Qt::Horizontal ).toString(), fld.name() );
   }
 }
@@ -123,7 +123,7 @@ void TestQgsDualView::testData()
 
   for ( int i = 0; i < mPointsLayer->fields().count(); ++i )
   {
-    const QgsField& fld = mPointsLayer->fields().at( i );
+    QgsField fld = mPointsLayer->fields().at( i );
 
     QModelIndex index = mDualView->tableView()->model()->index( 0, i );
     QCOMPARE( mDualView->tableView()->model()->data( index ).toString(), fld.displayString( feature.attribute( i ) ) );

--- a/tests/src/providers/grass/testqgsgrassprovider.cpp
+++ b/tests/src/providers/grass/testqgsgrassprovider.cpp
@@ -1112,7 +1112,7 @@ bool TestQgsGrassProvider::setAttributes( QgsFeature & feature, const QMap<QStri
   bool attributesSet = true;
   Q_FOREACH ( const QString fieldName, attributes.keys() )
   {
-    int index = feature.fields()->indexFromName( fieldName );
+    int index = feature.fields().indexFromName( fieldName );
     if ( index < 0 )
     {
       attributesSet = false;
@@ -1501,26 +1501,26 @@ bool TestQgsGrassProvider::equal( QgsFeature feature, QgsFeature expectedFeature
   }
   // GRASS feature has always additional cat field
   QSet<int> indexes;
-  for ( int i = 0; i < feature.fields()->size(); i++ )
+  for ( int i = 0; i < feature.fields().size(); i++ )
   {
-    QString name = feature.fields()->at( i ).name();
+    QString name = feature.fields().at( i ).name();
     if ( name == "cat" ) // skip cat
     {
       continue;
     }
     indexes << i;
   }
-  for ( int i = 0; i < expectedFeature.fields()->size(); i++ )
+  for ( int i = 0; i < expectedFeature.fields().size(); i++ )
   {
-    QString name = expectedFeature.fields()->at( i ).name();
-    int index = feature.fields()->indexFromName( name );
+    QString name = expectedFeature.fields().at( i ).name();
+    int index = feature.fields().indexFromName( name );
     if ( index < 0 )
     {
       // not found
       QStringList names;
-      for ( int j = 0; j < feature.fields()->size(); j++ )
+      for ( int j = 0; j < feature.fields().size(); j++ )
       {
-        names << feature.fields()->at( j ).name();
+        names << feature.fields().at( j ).name();
       }
       reportRow( QString( "Attribute %1 not found, feature attributes: %2" ).arg( name, names.join( "," ) ) );
       return false;
@@ -1539,7 +1539,7 @@ bool TestQgsGrassProvider::equal( QgsFeature feature, QgsFeature expectedFeature
     QStringList names;
     Q_FOREACH ( int i, indexes )
     {
-      names << feature.fields()->at( i ).name();
+      names << feature.fields().at( i ).name();
     }
     reportRow( QString( "feature has %1 unexpected attributes: %2" ).arg( indexes.size() ).arg( names.join( "," ) ) );
     return false;


### PR DESCRIPTION
- QgsFeature::fields() returns a value, not a pointer 
- QgsFields returns QgsField value instead of const references

Both done because QgsFields/QgsField are implicitly shared, and to avoid potential leaks/lifetime issues.
