### PR TITLE
Remove QgsColorDialog, rename QgsColorDialogV2 to QgsColorDialog

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -43,7 +43,9 @@ This page tries to maintain a list with incompatible changes that happened in pr
 \subsection qgis_api_break_3_0_removed_classes Removed Classes
 
 <ul>
-<li>QgsColorbutton was removed. QgsColorButtonV2 has now been renamed to QgsColorButton. Hence, QgsColorButtonV2 does not exist anymore.
+<li>QgsColorbutton was removed. QgsColorButtonV2 has now been renamed to QgsColorButton. Hence, QgsColorButtonV2 does not exist anymore.</li>
+<li>QgsColorDialog was removed, and QgsColorDialogV2 was renamed to QgsColorDialog. Hence, QgsColorButtonV2 does not exist anymore.
+All the functionality from the old QgsColorDialog has been moved to the new class.</li>
 <li>QgsCRSCache was removed. QgsCoordinateReferenceSystem now internally uses a cache for CRS creation,
 so there is no longer a need for the separate cache class. Code which previously called QgsCRSCache::updateCRSCache()
 should now call QgsCoordinateReferenceSystem::invalidateCache() and QgsCoordinateTransformCache::instance()->invalidateCrs( authid ).</li>

--- a/python/gui/qgscolordialog.sip
+++ b/python/gui/qgscolordialog.sip
@@ -1,42 +1,12 @@
 
 /** \ingroup gui
  * \class QgsColorDialog
- * A dialog for selecting a color
- */
-
-class QgsColorDialog : QObject
-{
-%TypeHeaderCode
-#include <qgscolordialog.h>
-%End
-  public:
-    QgsColorDialog();
-    ~QgsColorDialog();
-
-    /** Return a color selection from a QColorDialog, with live updating of interim selections.
-     * @param initialColor The initial color of the selection dialog.
-     * @param updateObject The receiver object of the live updating.
-     * @param updateSlot The receiver object's slot for live updating (e.g. SLOT( setValidColor( const QColor& ) ) ).
-     * @param parent Parent widget. Usually 0 is best for native system color dialogs.
-     * @param title The title of the QColorDialog.
-     * @param options ColorDialogOptions passed to QColorDialog.
-     * @return Selected color on accepted() or initialColor on rejected().
-     */
-    static QColor getLiveColor( const QColor& initialColor, QObject* updateObject, const char* updateSlot,
-                                QWidget* parent = 0,
-                                const QString& title = "",
-                                const QColorDialog::ColorDialogOptions& options = 0 );
-};
-
-
-/** \ingroup gui
- * \class QgsColorDialogV2
  * A custom QGIS dialog for selecting a color. Has many improvements over the standard Qt color picker dialog, including
  * hue wheel supports, color swatches, and a color sampler.
  * \note Added in version 2.5
  */
 
-class QgsColorDialogV2 : QDialog
+class QgsColorDialog : QDialog
 {
 %TypeHeaderCode
 #include <qgscolordialog.h>
@@ -49,10 +19,10 @@ class QgsColorDialogV2 : QDialog
      * @param fl window flags
      * @param color initial color for dialog
      */
-    QgsColorDialogV2( QWidget *parent /TransferThis/ = 0, const Qt::WindowFlags& fl = QgisGui::ModalDialogFlags,
+    QgsColorDialog( QWidget *parent /TransferThis/ = 0, const Qt::WindowFlags& fl = QgisGui::ModalDialogFlags,
                       const QColor& color = QColor() );
 
-    ~QgsColorDialogV2();
+    ~QgsColorDialog();
 
     /** Returns the current color for the dialog
      * @returns dialog color

--- a/src/app/qgsdiagramproperties.cpp
+++ b/src/app/qgsdiagramproperties.cpp
@@ -609,7 +609,7 @@ void QgsDiagramProperties::on_mDiagramAttributesTreeWidget_itemDoubleClicked( QT
 {
   if ( column == 1 ) //change color
   {
-    QColor newColor = QgsColorDialogV2::getColor( item->background( 1 ).color(), nullptr );
+    QColor newColor = QgsColorDialog::getColor( item->background( 1 ).color(), nullptr );
     if ( newColor.isValid() )
     {
       item->setBackground( 1, QBrush( newColor ) );

--- a/src/app/qgsoptions.cpp
+++ b/src/app/qgsoptions.cpp
@@ -2152,7 +2152,7 @@ void QgsOptions::saveDefaultDatumTransformations()
 
 void QgsOptions::on_mButtonAddColor_clicked()
 {
-  QColor newColor = QgsColorDialogV2::getColor( QColor(), this->parentWidget(), tr( "Select color" ), true );
+  QColor newColor = QgsColorDialog::getColor( QColor(), this->parentWidget(), tr( "Select color" ), true );
   if ( !newColor.isValid() )
   {
     return;

--- a/src/app/qgsprojectproperties.cpp
+++ b/src/app/qgsprojectproperties.cpp
@@ -2020,7 +2020,7 @@ void QgsProjectProperties::projectionSelectorInitialized()
 
 void QgsProjectProperties::on_mButtonAddColor_clicked()
 {
-  QColor newColor = QgsColorDialogV2::getColor( QColor(), this->parentWidget(), tr( "Select Color" ), true );
+  QColor newColor = QgsColorDialog::getColor( QColor(), this->parentWidget(), tr( "Select Color" ), true );
   if ( !newColor.isValid() )
   {
     return;

--- a/src/gui/qgscolorbutton.cpp
+++ b/src/gui/qgscolorbutton.cpp
@@ -97,35 +97,25 @@ void QgsColorButton::showColorDialog()
   QColor newColor;
   QSettings settings;
 
-  //using native color dialogs?
-  bool useNative = settings.value( "/qgis/native_color_dialogs", false ).toBool();
-
-  if ( useNative )
+  if ( mAcceptLiveUpdates && settings.value( "/qgis/live_color_dialogs", false ).toBool() )
   {
-    // use native o/s dialogs
-    if ( mAcceptLiveUpdates && settings.value( "/qgis/live_color_dialogs", false ).toBool() )
-    {
-      newColor = QgsColorDialog::getLiveColor(
-                   color(), this, SLOT( setValidColor( const QColor& ) ),
-                   this->parentWidget(), mColorDialogTitle, mAllowAlpha ? QColorDialog::ShowAlphaChannel : ( QColorDialog::ColorDialogOption )0 );
-    }
-    else
-    {
-      newColor = QColorDialog::getColor( color(), this->parentWidget(), mColorDialogTitle, mAllowAlpha ? QColorDialog::ShowAlphaChannel : ( QColorDialog::ColorDialogOption )0 );
-    }
+    // live updating dialog - QgsColorDialog will automatically use native dialog if option is set
+    newColor = QgsColorDialog::getLiveColor(
+                 color(), this, SLOT( setValidColor( const QColor& ) ),
+                 this, mColorDialogTitle, mAllowAlpha );
   }
   else
   {
-    //use QGIS style color dialogs
-    if ( mAcceptLiveUpdates && settings.value( "/qgis/live_color_dialogs", false ).toBool() )
+    // not using live updating dialog - first check if we need to use the limited native dialogs
+    bool useNative = settings.value( "/qgis/native_color_dialogs", false ).toBool();
+    if ( useNative )
     {
-      newColor = QgsColorDialogV2::getLiveColor(
-                   color(), this, SLOT( setValidColor( const QColor& ) ),
-                   this->parentWidget(), mColorDialogTitle, mAllowAlpha );
+      // why would anyone want this? who knows.... maybe the limited nature of native dialogs helps ease the transition for MapInfo users?
+      newColor = QColorDialog::getColor( color(), this, mColorDialogTitle, mAllowAlpha ? QColorDialog::ShowAlphaChannel : ( QColorDialog::ColorDialogOption )0 );
     }
     else
     {
-      QgsColorDialogV2 dialog( this, 0, color() );
+      QgsColorDialog dialog( this, 0, color() );
       dialog.setTitle( mColorDialogTitle );
       dialog.setAllowAlpha( mAllowAlpha );
 

--- a/src/gui/qgscolordialog.cpp
+++ b/src/gui/qgscolordialog.cpp
@@ -30,43 +30,7 @@
 #include <QMouseEvent>
 #include <QInputDialog>
 
-QgsColorDialog::QgsColorDialog()
-{
-}
-
-QgsColorDialog::~QgsColorDialog()
-{
-}
-
-QColor QgsColorDialog::getLiveColor( const QColor& initialColor, QObject* updateObject, const char* updateSlot,
-                                     QWidget* parent,
-                                     const QString& title,
-                                     const QColorDialog::ColorDialogOptions& options )
-{
-  QColor returnColor( initialColor );
-  QColorDialog* liveDialog = new QColorDialog( initialColor, parent );
-  liveDialog->setWindowTitle( title.isEmpty() ? tr( "Select Color" ) : title );
-  liveDialog->setOptions( options );
-
-  connect( liveDialog, SIGNAL( currentColorChanged( const QColor& ) ),
-           updateObject, updateSlot );
-
-  if ( liveDialog->exec() )
-  {
-    returnColor = liveDialog->currentColor();
-  }
-  delete liveDialog;
-  liveDialog = nullptr;
-
-  return returnColor;
-}
-
-
-//
-// QgsColorDialogV2
-//
-
-QgsColorDialogV2::QgsColorDialogV2( QWidget *parent, Qt::WindowFlags fl, const QColor& color )
+QgsColorDialog::QgsColorDialog( QWidget *parent, Qt::WindowFlags fl, const QColor& color )
     : QDialog( parent, fl )
     , mPreviousColor( color )
     , mAllowAlpha( true )
@@ -93,51 +57,73 @@ QgsColorDialogV2::QgsColorDialogV2( QWidget *parent, Qt::WindowFlags fl, const Q
   connect( mColorWidget, SIGNAL( currentColorChanged( QColor ) ), this, SIGNAL( currentColorChanged( QColor ) ) );
 }
 
-QgsColorDialogV2::~QgsColorDialogV2()
+QgsColorDialog::~QgsColorDialog()
 {
 
 }
 
-QColor QgsColorDialogV2::color() const
+QColor QgsColorDialog::color() const
 {
   return mColorWidget->color();
 }
 
-void QgsColorDialogV2::setTitle( const QString& title )
+void QgsColorDialog::setTitle( const QString& title )
 {
   setWindowTitle( title.isEmpty() ? tr( "Select Color" ) : title );
 }
 
-void QgsColorDialogV2::setAllowAlpha( const bool allowAlpha )
+void QgsColorDialog::setAllowAlpha( const bool allowAlpha )
 {
   mAllowAlpha = allowAlpha;
   mColorWidget->setAllowAlpha( allowAlpha );
 }
 
-QColor QgsColorDialogV2::getLiveColor( const QColor &initialColor, QObject *updateObject, const char *updateSlot, QWidget *parent, const QString &title, const bool allowAlpha )
+QColor QgsColorDialog::getLiveColor( const QColor &initialColor, QObject *updateObject, const char *updateSlot, QWidget *parent, const QString &title, const bool allowAlpha )
 {
   QColor returnColor( initialColor );
-  QgsColorDialogV2* liveDialog = new QgsColorDialogV2( parent, 0, initialColor );
-  liveDialog->setWindowTitle( title.isEmpty() ? tr( "Select Color" ) : title );
-  if ( !allowAlpha )
-  {
-    liveDialog->setAllowAlpha( false );
-  }
 
-  connect( liveDialog, SIGNAL( currentColorChanged( const QColor& ) ),
-           updateObject, updateSlot );
+  QSettings settings;
 
-  if ( liveDialog->exec() )
+  //using native color dialogs?
+  bool useNative = settings.value( "/qgis/native_color_dialogs", false ).toBool();
+  if ( useNative )
   {
-    returnColor = liveDialog->color();
+    QColorDialog* liveDialog = new QColorDialog( initialColor, parent );
+    liveDialog->setWindowTitle( title.isEmpty() ? tr( "Select Color" ) : title );
+    liveDialog->setOptions( allowAlpha ? QColorDialog::ShowAlphaChannel : ( QColorDialog::ColorDialogOption )0 );
+
+    connect( liveDialog, SIGNAL( currentColorChanged( const QColor& ) ),
+             updateObject, updateSlot );
+
+    if ( liveDialog->exec() )
+    {
+      returnColor = liveDialog->currentColor();
+    }
+    delete liveDialog;
   }
-  delete liveDialog;
-  liveDialog = nullptr;
+  else
+  {
+    QgsColorDialog* liveDialog = new QgsColorDialog( parent, 0, initialColor );
+    liveDialog->setWindowTitle( title.isEmpty() ? tr( "Select Color" ) : title );
+    if ( !allowAlpha )
+    {
+      liveDialog->setAllowAlpha( false );
+    }
+
+    connect( liveDialog, SIGNAL( currentColorChanged( const QColor& ) ),
+             updateObject, updateSlot );
+
+    if ( liveDialog->exec() )
+    {
+      returnColor = liveDialog->color();
+    }
+    delete liveDialog;
+  }
 
   return returnColor;
 }
 
-QColor QgsColorDialogV2::getColor( const QColor &initialColor, QWidget *parent, const QString &title, const bool allowAlpha )
+QColor QgsColorDialog::getColor( const QColor &initialColor, QWidget *parent, const QString &title, const bool allowAlpha )
 {
   QString dialogTitle = title.isEmpty() ? tr( "Select Color" ) : title;
 
@@ -150,7 +136,7 @@ QColor QgsColorDialogV2::getColor( const QColor &initialColor, QWidget *parent, 
   }
   else
   {
-    QgsColorDialogV2* dialog = new QgsColorDialogV2( parent, 0, initialColor );
+    QgsColorDialog* dialog = new QgsColorDialog( parent, 0, initialColor );
     dialog->setWindowTitle( dialogTitle );
     dialog->setAllowAlpha( allowAlpha );
 
@@ -168,19 +154,19 @@ QColor QgsColorDialogV2::getColor( const QColor &initialColor, QWidget *parent, 
   }
 }
 
-void QgsColorDialogV2::on_mButtonBox_accepted()
+void QgsColorDialog::on_mButtonBox_accepted()
 {
   saveSettings();
   accept();
 }
 
-void QgsColorDialogV2::on_mButtonBox_rejected()
+void QgsColorDialog::on_mButtonBox_rejected()
 {
   saveSettings();
   reject();
 }
 
-void QgsColorDialogV2::on_mButtonBox_clicked( QAbstractButton * button )
+void QgsColorDialog::on_mButtonBox_clicked( QAbstractButton * button )
 {
   if ( mButtonBox->buttonRole( button ) == QDialogButtonBox::ResetRole && mPreviousColor.isValid() )
   {
@@ -188,13 +174,13 @@ void QgsColorDialogV2::on_mButtonBox_clicked( QAbstractButton * button )
   }
 }
 
-void QgsColorDialogV2::saveSettings()
+void QgsColorDialog::saveSettings()
 {
   QSettings settings;
   settings.setValue( "/Windows/ColorDialog/geometry", saveGeometry() );
 }
 
-void QgsColorDialogV2::setColor( const QColor &color )
+void QgsColorDialog::setColor( const QColor &color )
 {
   if ( !color.isValid() )
   {
@@ -212,7 +198,7 @@ void QgsColorDialogV2::setColor( const QColor &color )
   emit currentColorChanged( fixedColor );
 }
 
-void QgsColorDialogV2::closeEvent( QCloseEvent *e )
+void QgsColorDialog::closeEvent( QCloseEvent *e )
 {
   saveSettings();
   QDialog::closeEvent( e );

--- a/src/gui/qgscolordialog.h
+++ b/src/gui/qgscolordialog.h
@@ -24,41 +24,12 @@ class QColor;
 
 /** \ingroup gui
  * \class QgsColorDialog
- * A native operating system dialog for selecting a color
- */
-
-class GUI_EXPORT QgsColorDialog : public QObject
-{
-    Q_OBJECT
-
-  public:
-    QgsColorDialog();
-    ~QgsColorDialog();
-
-    /** Return a color selection from a QColorDialog, with live updating of interim selections.
-     * @param initialColor The initial color of the selection dialog.
-     * @param updateObject The receiver object of the live updating.
-     * @param updateSlot The receiver object's slot for live updating (e.g. SLOT( setValidColor( const QColor& ) ) ).
-     * @param parent Parent widget. Usually 0 is best for native system color dialogs.
-     * @param title The title of the QColorDialog.
-     * @param options ColorDialogOptions passed to QColorDialog.
-     * @return Selected color on accepted() or initialColor on rejected().
-     */
-    static QColor getLiveColor( const QColor& initialColor, QObject* updateObject, const char* updateSlot,
-                                QWidget* parent = nullptr,
-                                const QString& title = "",
-                                const QColorDialog::ColorDialogOptions& options = 0 );
-};
-
-
-/** \ingroup gui
- * \class QgsColorDialogV2
  * A custom QGIS dialog for selecting a color. Has many improvements over the standard Qt color picker dialog, including
  * hue wheel supports, color swatches, and a color sampler.
  * \note Added in version 2.5
  */
 
-class GUI_EXPORT QgsColorDialogV2 : public QDialog, private Ui::QgsColorDialogBase
+class GUI_EXPORT QgsColorDialog : public QDialog, private Ui::QgsColorDialogBase
 {
 
     Q_OBJECT
@@ -70,10 +41,10 @@ class GUI_EXPORT QgsColorDialogV2 : public QDialog, private Ui::QgsColorDialogBa
      * @param fl window flags
      * @param color initial color for dialog
      */
-    QgsColorDialogV2( QWidget *parent = nullptr, Qt::WindowFlags fl = QgisGui::ModalDialogFlags,
-                      const QColor& color = QColor() );
+    QgsColorDialog( QWidget *parent = nullptr, Qt::WindowFlags fl = QgisGui::ModalDialogFlags,
+                    const QColor& color = QColor() );
 
-    ~QgsColorDialogV2();
+    ~QgsColorDialog();
 
     /** Returns the current color for the dialog
      * @returns dialog color

--- a/src/gui/qgscolorschemelist.cpp
+++ b/src/gui/qgscolorschemelist.cpp
@@ -699,7 +699,7 @@ bool QgsColorSwatchDelegate::editorEvent( QEvent *event, QAbstractItemModel *mod
       return false;
     }
     QColor color = index.model()->data( index, Qt::DisplayRole ).value<QColor>();
-    QColor newColor = QgsColorDialogV2::getColor( color, mParent, tr( "Select color" ), true );
+    QColor newColor = QgsColorDialog::getColor( color, mParent, tr( "Select color" ), true );
     if ( !newColor.isValid() )
     {
       return false;

--- a/src/gui/raster/qgspalettedrendererwidget.cpp
+++ b/src/gui/raster/qgspalettedrendererwidget.cpp
@@ -75,7 +75,7 @@ void QgsPalettedRendererWidget::on_mTreeWidget_itemDoubleClicked( QTreeWidgetIte
   if ( column == 1 && item ) //change item color
   {
     item->setFlags( Qt::ItemIsEnabled | Qt::ItemIsSelectable );
-    QColor c = QgsColorDialogV2::getColor( item->background( column ).color(), nullptr );
+    QColor c = QgsColorDialog::getColor( item->background( column ).color(), nullptr );
     if ( c.isValid() )
     {
       item->setBackground( column, QBrush( c ) );

--- a/src/gui/raster/qgssinglebandpseudocolorrendererwidget.cpp
+++ b/src/gui/raster/qgssinglebandpseudocolorrendererwidget.cpp
@@ -733,7 +733,7 @@ void QgsSingleBandPseudoColorRendererWidget::on_mColormapTreeWidget_itemDoubleCl
   if ( column == ColorColumn )
   {
     item->setFlags( Qt::ItemIsEnabled | Qt::ItemIsSelectable );
-    QColor newColor = QgsColorDialogV2::getColor( item->background( column ).color(), this, "Change color", true );
+    QColor newColor = QgsColorDialog::getColor( item->background( column ).color(), this, "Change color", true );
     if ( newColor.isValid() )
     {
       item->setBackground( ColorColumn, QBrush( newColor ) );

--- a/src/gui/symbology-ng/qgsrendererv2widget.cpp
+++ b/src/gui/symbology-ng/qgsrendererv2widget.cpp
@@ -80,7 +80,7 @@ void QgsRendererV2Widget::changeSymbolColor()
   if ( !firstSymbol )
     return;
 
-  QColor color = QgsColorDialogV2::getColor( firstSymbol->color(), this, "Change Symbol Color", true );
+  QColor color = QgsColorDialog::getColor( firstSymbol->color(), this, "Change Symbol Color", true );
   if ( color.isValid() )
   {
     Q_FOREACH ( QgsSymbol* symbol, symbolList )


### PR DESCRIPTION
The last bits of missing functionality (handling native dialogs and live updates) were ported across.
