### PR TITLE
API to allow drag'n'drop of custom browser items

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -434,6 +434,12 @@ be returned instead of a null pointer if no transformation is required.</li>
 plugins calling this method will need to be updated.</li>
 </ul>
 
+\subsection qgis_api_break_3_0_QgsMimeDataUtils QgsMimeDataUtils
+
+<ul>
+<li>Constructor taking QgsLayerItem argument has been removed. Use QgsDataItem::mimeUri() instead.</li>
+</ul>
+
 \subsection qgis_api_break_3_0_QgsOSMElement QgsOSMElement
 
 <ul>

--- a/python/core/qgsdataitem.sip
+++ b/python/core/qgsdataitem.sip
@@ -135,6 +135,21 @@ class QgsDataItem : QObject
      */
     virtual bool handleDrop( const QMimeData * /*data*/, Qt::DropAction /*action*/ );
 
+    /** Returns true if the item may be dragged.
+     * Default implementation returns false.
+     * A draggable item has to implement mimeUri() that will be used to pass data.
+     * @see mimeUri()
+     * @note added in 3.0
+     */
+    virtual bool hasDragEnabled() const;
+
+    /** Return mime URI for the data item.
+     * Items that return valid URI will be returned in mime data when dragging a selection from browser model.
+     * @see hasDragEnabled()
+     * @note added in 3.0
+     */
+    virtual QgsMimeDataUtils::Uri mimeUri() const;
+
     enum Capability
     {
       NoCapabilities,
@@ -262,26 +277,30 @@ class QgsLayerItem : QgsDataItem
 
     virtual bool equal( const QgsDataItem *other );
 
+    virtual bool hasDragEnabled() const;
+
+    virtual QgsMimeDataUtils::Uri mimeUri() const;
+
     // --- New virtual methods for layer item derived classes ---
 
     // Returns QgsMapLayer::LayerType
-    QgsMapLayer::LayerType mapLayerType();
+    QgsMapLayer::LayerType mapLayerType() const;
 
     // Returns layer uri or empty string if layer cannot be created
-    QString uri();
+    QString uri() const;
 
     // Returns provider key
-    QString providerKey();
+    QString providerKey() const;
 
     /** Returns the supported CRS
      *  @note Added in 2.8
      */
-    QStringList supportedCrs();
+    QStringList supportedCrs() const;
 
     /** Returns the supported formats
      *  @note Added in 2.8
      */
-    QStringList supportedFormats();
+    QStringList supportedFormats() const;
 
     /** Returns comments of the layer
      * @note added in 2.12
@@ -389,6 +408,7 @@ class QgsProjectItem : QgsDataItem
     QgsProjectItem( QgsDataItem* parent, const QString& name, const QString& path );
     ~QgsProjectItem();
 
+    virtual bool hasDragEnabled() const;
 };
 
 /**

--- a/python/core/qgsmimedatautils.sip
+++ b/python/core/qgsmimedatautils.sip
@@ -7,14 +7,27 @@ class QgsMimeDataUtils
 
     struct Uri
     {
-      Uri( QgsLayerItem* layer );
-      Uri( QString& encData );
+      //! Constructs invalid URI
+      Uri();
+      //! Constructs URI from encoded data
+      explicit Uri( QString& encData );
 
+      //! Returns whether the object contains valid data
+      //! @note added in 3.0
+      bool isValid() const;
+
+      //! Returns encoded representation of the object
       QString data() const;
 
+      //! Type of URI. Recognized types: "vector" / "raster" / "plugin" / "custom"
       QString layerType;
+      //! For "vector" / "raster" type: provider id.
+      //! For "plugin" type: plugin layer type name.
+      //! For "custom" type: key of its QgsCustomDropHandler
       QString providerKey;
+      //! Human readable name to be used e.g. in layer tree
       QString name;
+      //! Identifier of the data source recognized by its providerKey
       QString uri;
       QStringList supportedCrs;
       QStringList supportedFormats;

--- a/python/gui/gui.sip
+++ b/python/gui/gui.sip
@@ -57,6 +57,7 @@
 %Include qgscompoundcolorwidget.sip
 %Include qgsconfigureshortcutsdialog.sip
 %Include qgscredentialdialog.sip
+%Include qgscustomdrophandler.sip
 %Include qgsdatadefinedbutton.sip
 %Include qgsdetaileditemdata.sip
 %Include qgsdetaileditemdelegate.sip

--- a/python/gui/qgisinterface.sip
+++ b/python/gui/qgisinterface.sip
@@ -292,6 +292,18 @@ class QgisInterface : QObject
     */
     virtual void unregisterMapLayerConfigWidgetFactory( QgsMapLayerConfigWidgetFactory* factory ) = 0;
 
+    /** Register a new custom drop handler.
+     * @note added in QGIS 3.0
+     * @note Ownership of the factory is not transferred, and the factory must
+     *       be unregistered when plugin is unloaded.
+     * @see unregisterCustomDropHandler() */
+    virtual void registerCustomDropHandler( QgsCustomDropHandler* handler ) = 0;
+
+    /** Unregister a previously registered custom drop handler.
+     * @note added in QGIS 3.0
+     * @see registerCustomDropHandler() */
+    virtual void unregisterCustomDropHandler( QgsCustomDropHandler* handler ) = 0;
+
     // @todo is this deprecated in favour of QgsContextHelp?
     /** Open a url in the users browser. By default the QGIS doc directory is used
      * as the base for the URL. To open a URL that is not relative to the installed

--- a/python/gui/qgscustomdrophandler.sip
+++ b/python/gui/qgscustomdrophandler.sip
@@ -1,0 +1,21 @@
+/** \ingroup gui
+ * Abstract base class that may be implemented to handle new types of data to be dropped in QGIS.
+ * Implementations will be used when a QgsMimeDataUtils::Uri has layerType equal to "custom",
+ * and the providerKey is equal to key() returned by the implementation.
+ * @note added in QGIS 3.0
+ */
+class QgsCustomDropHandler
+{
+%TypeHeaderCode
+#include <qgscustomdrophandler.h>
+%End
+
+  public:
+    virtual ~QgsCustomDropHandler();
+
+    //! Type of custom URI recognized by the handler
+    virtual QString key() const = 0;
+
+    //! Method called from QGIS after a drop event with custom URI known by the handler
+    virtual void handleDrop( const QgsMimeDataUtils::Uri& uri ) const = 0;
+};

--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -44,6 +44,7 @@ class QgsClipboard;
 class QgsComposer;
 class QgsComposerManager;
 class QgsComposerView;
+class QgsCustomDropHandler;
 class QgsStatusBarCoordinatesWidget;
 class QgsStatusBarMagnifierWidget;
 class QgsStatusBarScaleWidget;
@@ -120,6 +121,7 @@ class QgsDiagramProperties;
 #include "qgsfeature.h"
 #include "qgspoint.h"
 #include "qgsmessagebar.h"
+#include "qgsmimedatautils.h"
 #include "qgswelcomepageitemsmodel.h"
 #include "qgsraster.h"
 
@@ -513,6 +515,15 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
 
     /** Unregister a previously registered tab in the layer properties dialog */
     void unregisterMapLayerPropertiesFactory( QgsMapLayerConfigWidgetFactory* factory );
+
+    /** Register a new custom drop handler. */
+    void registerCustomDropHandler( QgsCustomDropHandler* handler );
+
+    /** Unregister a previously registered custom drop handler. */
+    void unregisterCustomDropHandler( QgsCustomDropHandler* handler );
+
+    /** Process the list of URIs that have been dropped in QGIS */
+    void handleDropUriList( const QgsMimeDataUtils::UriList& lst );
 
   public slots:
     void layerTreeViewDoubleClicked( const QModelIndex& index );
@@ -1772,6 +1783,8 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     QgsSnappingUtils* mSnappingUtils;
 
     QList<QgsMapLayerConfigWidgetFactory*> mMapLayerPanelFactories;
+
+    QList<QgsCustomDropHandler*> mCustomDropHandlers;
 
     QDateTime mProjectLastModified;
 

--- a/src/app/qgisappinterface.cpp
+++ b/src/app/qgisappinterface.cpp
@@ -485,6 +485,16 @@ void QgisAppInterface::unregisterMapLayerConfigWidgetFactory( QgsMapLayerConfigW
   qgis->unregisterMapLayerPropertiesFactory( factory );
 }
 
+void QgisAppInterface::registerCustomDropHandler( QgsCustomDropHandler *handler )
+{
+  qgis->registerCustomDropHandler( handler );
+}
+
+void QgisAppInterface::unregisterCustomDropHandler( QgsCustomDropHandler *handler )
+{
+  qgis->unregisterCustomDropHandler( handler );
+}
+
 //! Menus
 Q_DECL_DEPRECATED QMenu *QgisAppInterface::fileMenu() { return qgis->projectMenu(); }
 QMenu *QgisAppInterface::projectMenu() { return qgis->projectMenu(); }

--- a/src/app/qgisappinterface.h
+++ b/src/app/qgisappinterface.h
@@ -301,6 +301,18 @@ class APP_EXPORT QgisAppInterface : public QgisInterface
     */
     virtual void unregisterMapLayerConfigWidgetFactory( QgsMapLayerConfigWidgetFactory* factory ) override;
 
+    /** Register a new custom drop handler.
+     * @note added in QGIS 3.0
+     * @note Ownership of the factory is not transferred, and the factory must
+     *       be unregistered when plugin is unloaded.
+     * @see unregisterCustomDropHandler() */
+    virtual void registerCustomDropHandler( QgsCustomDropHandler* handler ) override;
+
+    /** Unregister a previously registered custom drop handler.
+     * @note added in QGIS 3.0
+     * @see registerCustomDropHandler() */
+    virtual void unregisterCustomDropHandler( QgsCustomDropHandler* handler ) override;
+
     /** Accessors for inserting items into menus and toolbars.
      * An item can be inserted before any existing action.
      */

--- a/src/app/qgsbrowserdockwidget.cpp
+++ b/src/app/qgsbrowserdockwidget.cpp
@@ -516,26 +516,9 @@ void QgsBrowserDockWidget::addLayer( QgsLayerItem *layerItem )
   if ( !layerItem )
     return;
 
-  QString uri = QgisApp::instance()->crsAndFormatAdjustedLayerUri( layerItem->uri(), layerItem->supportedCrs(), layerItem->supportedFormats() );
-  if ( uri.isEmpty() )
-    return;
-
-  QgsMapLayer::LayerType type = layerItem->mapLayerType();
-  QString providerKey = layerItem->providerKey();
-
-  QgsDebugMsg( providerKey + " : " + uri );
-  if ( type == QgsMapLayer::VectorLayer )
-  {
-    QgisApp::instance()->addVectorLayer( uri, layerItem->layerName(), providerKey );
-  }
-  if ( type == QgsMapLayer::RasterLayer )
-  {
-    QgisApp::instance()->addRasterLayer( uri, layerItem->layerName(), providerKey );
-  }
-  if ( type == QgsMapLayer::PluginLayer )
-  {
-    QgisApp::instance()->addPluginLayer( uri, layerItem->layerName(), providerKey );
-  }
+  QgsMimeDataUtils::UriList list;
+  list << layerItem->mimeUri();
+  QgisApp::instance()->handleDropUriList( list );
 }
 
 void QgsBrowserDockWidget::addLayerAtIndex( const QModelIndex& index )

--- a/src/core/qgsbrowsermodel.cpp
+++ b/src/core/qgsbrowsermodel.cpp
@@ -186,10 +186,9 @@ Qt::ItemFlags QgsBrowserModel::flags( const QModelIndex & index ) const
   Qt::ItemFlags flags = Qt::ItemIsEnabled | Qt::ItemIsSelectable;
 
   QgsDataItem* ptr = reinterpret_cast< QgsDataItem* >( index.internalPointer() );
-  if ( ptr->type() == QgsDataItem::Layer || ptr->type() == QgsDataItem::Project )
-  {
+  if ( ptr->hasDragEnabled() )
     flags |= Qt::ItemIsDragEnabled;
-  }
+
   if ( ptr->acceptDrop() )
     flags |= Qt::ItemIsDropEnabled;
   return flags;
@@ -461,9 +460,9 @@ QMimeData * QgsBrowserModel::mimeData( const QModelIndexList &indexes ) const
         return mimeData;
       }
 
-      if ( ptr->type() != QgsDataItem::Layer ) continue;
-      QgsLayerItem *layer = static_cast< QgsLayerItem* >( ptr );
-      lst.append( QgsMimeDataUtils::Uri( layer ) );
+      QgsMimeDataUtils::Uri uri = ptr->mimeUri();
+      if ( uri.isValid() )
+          lst.append( uri );
     }
   }
   return QgsMimeDataUtils::encodeUriList( lst );

--- a/src/core/qgsbrowsermodel.cpp
+++ b/src/core/qgsbrowsermodel.cpp
@@ -462,7 +462,7 @@ QMimeData * QgsBrowserModel::mimeData( const QModelIndexList &indexes ) const
 
       QgsMimeDataUtils::Uri uri = ptr->mimeUri();
       if ( uri.isValid() )
-          lst.append( uri );
+        lst.append( uri );
     }
   }
   return QgsMimeDataUtils::encodeUriList( lst );

--- a/src/core/qgsdataitem.cpp
+++ b/src/core/qgsdataitem.cpp
@@ -670,7 +670,7 @@ QgsLayerItem::QgsLayerItem( QgsDataItem* parent, const QString& name, const QStr
   }
 }
 
-QgsMapLayer::LayerType QgsLayerItem::mapLayerType()
+QgsMapLayer::LayerType QgsLayerItem::mapLayerType() const
 {
   if ( mLayerType == QgsLayerItem::Raster )
     return QgsMapLayer::RasterLayer;
@@ -692,6 +692,33 @@ bool QgsLayerItem::equal( const QgsDataItem *other )
     return false;
 
   return ( mPath == o->mPath && mName == o->mName && mUri == o->mUri && mProviderKey == o->mProviderKey );
+}
+
+QgsMimeDataUtils::Uri QgsLayerItem::mimeUri() const
+{
+  QgsMimeDataUtils::Uri u;
+
+  switch ( mapLayerType() )
+  {
+    case QgsMapLayer::VectorLayer:
+      u.layerType = "vector";
+      break;
+    case QgsMapLayer::RasterLayer:
+      u.layerType = "raster";
+      break;
+    case QgsMapLayer::PluginLayer:
+      u.layerType = "plugin";
+      break;
+    default:
+      return u;  // invalid URI
+  }
+
+  u.providerKey = providerKey();
+  u.name = layerName();
+  u.uri = uri();
+  u.supportedCrs = supportedCrs();
+  u.supportedFormats = supportedFormats();
+  return u;
 }
 
 // ---------------------------------------------------------------------

--- a/src/core/qgsdataitem.h
+++ b/src/core/qgsdataitem.h
@@ -30,6 +30,7 @@
 
 #include "qgsmaplayer.h"
 #include "qgscoordinatereferencesystem.h"
+#include "qgsmimedatautils.h"
 
 class QgsDataProvider;
 class QgsDataItem;
@@ -160,6 +161,21 @@ class CORE_EXPORT QgsDataItem : public QObject
      * @see acceptDrop()
      */
     virtual bool handleDrop( const QMimeData * /*data*/, Qt::DropAction /*action*/ ) { return false; }
+
+    /** Returns true if the item may be dragged.
+     * Default implementation returns false.
+     * A draggable item has to implement mimeUri() that will be used to pass data.
+     * @see mimeUri()
+     * @note added in 3.0
+     */
+    virtual bool hasDragEnabled() const { return false; }
+
+    /** Return mime URI for the data item.
+     * Items that return valid URI will be returned in mime data when dragging a selection from browser model.
+     * @see hasDragEnabled()
+     * @note added in 3.0
+     */
+    virtual QgsMimeDataUtils::Uri mimeUri() const { return QgsMimeDataUtils::Uri(); }
 
     enum Capability
     {
@@ -314,26 +330,30 @@ class CORE_EXPORT QgsLayerItem : public QgsDataItem
 
     virtual bool equal( const QgsDataItem *other ) override;
 
+    virtual bool hasDragEnabled() const override { return true; }
+
+    virtual QgsMimeDataUtils::Uri mimeUri() const override;
+
     // --- New virtual methods for layer item derived classes ---
 
     /** Returns QgsMapLayer::LayerType */
-    QgsMapLayer::LayerType mapLayerType();
+    QgsMapLayer::LayerType mapLayerType() const;
 
     /** Returns layer uri or empty string if layer cannot be created */
-    QString uri() { return mUri; }
+    QString uri() const { return mUri; }
 
     /** Returns provider key */
-    QString providerKey() { return mProviderKey; }
+    QString providerKey() const { return mProviderKey; }
 
     /** Returns the supported CRS
      *  @note Added in 2.8
      */
-    QStringList supportedCrs() { return mSupportedCRS; }
+    QStringList supportedCrs() const { return mSupportedCRS; }
 
     /** Returns the supported formats
      *  @note Added in 2.8
      */
-    QStringList supportedFormats() { return mSupportFormats; }
+    QStringList supportedFormats() const { return mSupportFormats; }
 
     /** Returns comments of the layer
      * @note added in 2.12
@@ -451,6 +471,8 @@ class CORE_EXPORT QgsProjectItem : public QgsDataItem
      */
     QgsProjectItem( QgsDataItem* parent, const QString& name, const QString& path );
     ~QgsProjectItem();
+
+    virtual bool hasDragEnabled() const override { return true; }
 
 };
 

--- a/src/core/qgsmimedatautils.cpp
+++ b/src/core/qgsmimedatautils.cpp
@@ -21,25 +21,9 @@
 
 static const char* QGIS_URILIST_MIMETYPE = "application/x-vnd.qgis.qgis.uri";
 
-QgsMimeDataUtils::Uri::Uri( QgsLayerItem* layerItem )
-    : providerKey( layerItem->providerKey() )
-    , name( layerItem->layerName() )
-    , uri( layerItem->uri() )
-    , supportedCrs( layerItem->supportedCrs() )
-    , supportedFormats( layerItem->supportedFormats() )
+
+QgsMimeDataUtils::Uri::Uri()
 {
-  switch ( layerItem->mapLayerType() )
-  {
-    case QgsMapLayer::VectorLayer:
-      layerType = "vector";
-      break;
-    case QgsMapLayer::RasterLayer:
-      layerType = "raster";
-      break;
-    case QgsMapLayer::PluginLayer:
-      layerType = "plugin";
-      break;
-  }
 }
 
 QgsMimeDataUtils::Uri::Uri( QString& encData )

--- a/src/core/qgsmimedatautils.h
+++ b/src/core/qgsmimedatautils.h
@@ -29,14 +29,27 @@ class CORE_EXPORT QgsMimeDataUtils
 
     struct CORE_EXPORT Uri
     {
-      Uri( QgsLayerItem* layer );
-      Uri( QString& encData );
+      //! Constructs invalid URI
+      Uri();
+      //! Constructs URI from encoded data
+      explicit Uri( QString& encData );
 
+      //! Returns whether the object contains valid data
+      //! @note added in 3.0
+      bool isValid() const { return !layerType.isEmpty(); }
+
+      //! Returns encoded representation of the object
       QString data() const;
 
+      //! Type of URI. Recognized types: "vector" / "raster" / "plugin" / "custom"
       QString layerType;
+      //! For "vector" / "raster" type: provider id.
+      //! For "plugin" type: plugin layer type name.
+      //! For "custom" type: key of its QgsCustomDropHandler
       QString providerKey;
+      //! Human readable name to be used e.g. in layer tree
       QString name;
+      //! Identifier of the data source recognized by its providerKey
       QString uri;
       QStringList supportedCrs;
       QStringList supportedFormats;

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -194,6 +194,7 @@ SET(QGIS_GUI_SRCS
   qgsconfigureshortcutsdialog.cpp
   qgscredentialdialog.cpp
   qgscursors.cpp
+  qgscustomdrophandler.cpp
   qgsdatadefinedbutton.cpp
   qgsdatumtransformdialog.cpp
   qgsdetaileditemdata.cpp
@@ -619,6 +620,7 @@ SET(QGIS_GUI_HDRS
   qgsattributeforminterface.h
   qgsattributeformlegacyinterface.h
   qgscursors.h
+  qgscustomdrophandler.h
   qgsdetaileditemdata.h
   qgsexpressionbuilderdialog.h
   qgsfiledropedit.h

--- a/src/gui/qgisinterface.h
+++ b/src/gui/qgisinterface.h
@@ -28,6 +28,7 @@ class QWidget;
 class QgsAdvancedDigitizingDockWidget;
 class QgsAttributeDialog;
 class QgsComposerView;
+class QgsCustomDropHandler;
 class QgsFeature;
 class QgsLayerTreeMapCanvasBridge;
 class QgsLayerTreeView;
@@ -341,6 +342,18 @@ class GUI_EXPORT QgisInterface : public QObject
      * @see registerMapLayerPropertiesFactory()
     */
     virtual void unregisterMapLayerConfigWidgetFactory( QgsMapLayerConfigWidgetFactory* factory ) = 0;
+
+    /** Register a new custom drop handler.
+     * @note added in QGIS 3.0
+     * @note Ownership of the factory is not transferred, and the factory must
+     *       be unregistered when plugin is unloaded.
+     * @see unregisterCustomDropHandler() */
+    virtual void registerCustomDropHandler( QgsCustomDropHandler* handler ) = 0;
+
+    /** Unregister a previously registered custom drop handler.
+     * @note added in QGIS 3.0
+     * @see registerCustomDropHandler() */
+    virtual void unregisterCustomDropHandler( QgsCustomDropHandler* handler ) = 0;
 
     // @todo is this deprecated in favour of QgsContextHelp?
     /** Open a url in the users browser. By default the QGIS doc directory is used

--- a/src/gui/qgscustomdrophandler.cpp
+++ b/src/gui/qgscustomdrophandler.cpp
@@ -1,0 +1,20 @@
+/***************************************************************************
+    qgscustomdrophandler.cpp
+    ---------------------
+    begin                : August 2016
+    copyright            : (C) 2016 by Martin Dobias
+    email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgscustomdrophandler.h"
+
+QgsCustomDropHandler::~QgsCustomDropHandler()
+{
+}

--- a/src/gui/qgscustomdrophandler.h
+++ b/src/gui/qgscustomdrophandler.h
@@ -20,6 +20,8 @@
 
 /** \ingroup gui
  * Abstract base class that may be implemented to handle new types of data to be dropped in QGIS.
+ * Implementations will be used when a QgsMimeDataUtils::Uri has layerType equal to "custom",
+ * and the providerKey is equal to key() returned by the implementation.
  * @note added in QGIS 3.0
  */
 class GUI_EXPORT QgsCustomDropHandler

--- a/src/gui/qgscustomdrophandler.h
+++ b/src/gui/qgscustomdrophandler.h
@@ -1,0 +1,37 @@
+/***************************************************************************
+    qgscustomdrophandler.h
+    ---------------------
+    begin                : August 2016
+    copyright            : (C) 2016 by Martin Dobias
+    email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSCUSTOMDROPHANDLER_H
+#define QGSCUSTOMDROPHANDLER_H
+
+#include "qgsmimedatautils.h"
+
+/** \ingroup gui
+ * Abstract base class that may be implemented to handle new types of data to be dropped in QGIS.
+ * @note added in QGIS 3.0
+ */
+class GUI_EXPORT QgsCustomDropHandler
+{
+  public:
+    virtual ~QgsCustomDropHandler();
+
+    //! Type of custom URI recognized by the handler
+    virtual QString key() const = 0;
+
+    //! Method called from QGIS after a drop event with custom URI known by the handler
+    virtual void handleDrop( const QgsMimeDataUtils::Uri& uri ) const = 0;
+};
+
+#endif // QGSCUSTOMDROPHANDLER_H


### PR DESCRIPTION
QgsDataItem implementations may provide hasDragEnabled(), mimeUri() and QgsCustomDropHandler implementation to deal with drop of custom items.
