### PR TITLE
Fix memory leak of SnappingUtils

### DIFF
--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -1858,6 +1858,11 @@ QgsSnappingUtils* QgsMapCanvas::snappingUtils() const
 
 void QgsMapCanvas::setSnappingUtils( QgsSnappingUtils* utils )
 {
+  if ( mSnappingUtils && mSnappingUtils != utils )
+  {
+    delete mSnappingUtils;
+    mSnappingUtils = nullptr;
+  }
   mSnappingUtils = utils;
 }
 


### PR DESCRIPTION
This pull fixes a possible memory leak in QgsMapCanvas setting a new QgsSnappingUtils object.

[QgsMapCanvas::setSnappingUtils(...)](https://github.com/qgis/QGIS/blob/master/src/gui/qgsmapcanvas.cpp#L1859) does not care of  [mMapCanvas->setSnappingUtils(...)](https://github.com/qgis/QGIS/blob/master/src/app/qgisapp.cpp#L752).
