### PR TITLE
[pal] fix repeated labels on curved lines when label width > repeat distance

### DIFF
--- a/src/core/pal/layer.cpp
+++ b/src/core/pal/layer.cpp
@@ -426,6 +426,7 @@ void Layer::chopFeaturesAtRepeatDistance()
     double chopInterval = fpart->repeatDistance();
     if ( chopInterval != 0. && GEOSGeomTypeId_r( geosctxt, geom ) == GEOS_LINESTRING )
     {
+      chopInterval *= ceil( fpart->getLabelWidth() / fpart->repeatDistance() );
 
       double bmin[2], bmax[2];
       fpart->getBoundingBox( bmin, bmax );


### PR DESCRIPTION
When label placement is set to (*) curved and a repeat distance is set, label width that are greater than the repeat distance don't show up at all.

This PR improve (fix?) that scenario by (doubling, tripling, etc.) the repeat distance to provide enough space for label to show while keeping repeat distance interval intact.
