### PR TITLE
[FEATURE] Move feature now benefits from Advanced Digitizing

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -261,6 +261,12 @@ variant instead.</li>
 <li>expandAction() has been removed. Use QgsExpression::replaceExpressionText() instead.</li>
 </ul>
 
+\subsection qgis_api_break_3_0_QgsAdvancedDigitizingDockWidget QgsAdvancedDigitizingDockWidget
+
+<ul>
+<li>canvasReleaseEvent takes now QgsAdvancedDigitizingDockWidget::CaptureMode as second argument.</li>
+</ul>
+
 \subsection qgis_api_break_3_0_QgsAtlasComposition QgsAtlasComposition
 
 <ul>

--- a/python/gui/qgsadvanceddigitizingdockwidget.sip
+++ b/python/gui/qgsadvanceddigitizingdockwidget.sip
@@ -50,6 +50,16 @@ class QgsAdvancedDigitizingDockWidget : QDockWidget
     };
 
     /**
+     * Determines if the dock has to record one, two or many points.
+     */
+    enum CaptureMode
+    {
+      SinglePoint, //!< Capture a single point (e.g. for point digitizing)
+      TwoPoints,   //!< Capture two points (e.g. for translation)
+      ManyPoints   //!< Capture many points (e.g. line or polygon digitizing)
+    };
+
+    /**
      * @brief The CadConstraint is an abstract class for all basic constraints (angle/distance/x/y).
      * It contains all values (locked, value, relative) and pointers to corresponding widgets.
      * @note Relative is not mandatory since it is not used for distance.
@@ -169,10 +179,10 @@ class QgsAdvancedDigitizingDockWidget : QDockWidget
      * Will react on a canvas release event
      *
      * @param e A mouse event (may be modified)
-     * @param captureSegment Capture segments?
+     * @param mode determines if the dock has to record one, two or many points.
      * @return  If the event is hidden (construction mode hides events from the maptool)
      */
-    bool canvasReleaseEvent( QgsMapMouseEvent* e , bool captureSegment );
+    bool canvasReleaseEvent( QgsMapMouseEvent* e , CaptureMode mode );
     /**
      * Will react on a canvas move event
      *

--- a/python/gui/qgsadvanceddigitizingdockwidget.sip
+++ b/python/gui/qgsadvanceddigitizingdockwidget.sip
@@ -52,11 +52,11 @@ class QgsAdvancedDigitizingDockWidget : QDockWidget
     /**
      * Determines if the dock has to record one, two or many points.
      */
-    enum CaptureMode
+    enum AdvancedDigitizingMode
     {
       SinglePoint, //!< Capture a single point (e.g. for point digitizing)
       TwoPoints,   //!< Capture two points (e.g. for translation)
-      ManyPoints   //!< Capture many points (e.g. line or polygon digitizing)
+      ManyPoints   //!< Capture two or more points (e.g. line or polygon digitizing)
     };
 
     /**
@@ -182,7 +182,7 @@ class QgsAdvancedDigitizingDockWidget : QDockWidget
      * @param mode determines if the dock has to record one, two or many points.
      * @return  If the event is hidden (construction mode hides events from the maptool)
      */
-    bool canvasReleaseEvent( QgsMapMouseEvent* e , CaptureMode mode );
+    bool canvasReleaseEvent( QgsMapMouseEvent* e, AdvancedDigitizingMode mode );
     /**
      * Will react on a canvas move event
      *

--- a/python/gui/qgsmaptooladvanceddigitizing.sip
+++ b/python/gui/qgsmaptooladvanceddigitizing.sip
@@ -32,6 +32,7 @@ class QgsMapToolAdvancedDigitizing : QgsMapToolEdit
     {
       CaptureNone,    //!< Do not capture
       CapturePoint,   //!< Capture points
+      CaptureSegment, //!< Capture a segment (i.e. 2 points)
       CaptureLine,    //!< Capture lines
       CapturePolygon  //!< Capture polygons
     };

--- a/src/app/qgsmaptoolmovefeature.h
+++ b/src/app/qgsmaptoolmovefeature.h
@@ -16,21 +16,19 @@
 #ifndef QGSMAPTOOLMOVEFEATURE_H
 #define QGSMAPTOOLMOVEFEATURE_H
 
-#include "qgsmaptooledit.h"
+#include "qgsmaptooladvanceddigitizing.h"
 
 /** Map tool for translating feature position by mouse drag*/
-class APP_EXPORT QgsMapToolMoveFeature: public QgsMapToolEdit
+class APP_EXPORT QgsMapToolMoveFeature: public QgsMapToolAdvancedDigitizing
 {
     Q_OBJECT
   public:
     QgsMapToolMoveFeature( QgsMapCanvas* canvas );
     virtual ~QgsMapToolMoveFeature();
 
-    virtual void canvasMoveEvent( QgsMapMouseEvent* e ) override;
+    virtual void cadCanvasMoveEvent( QgsMapMouseEvent* e ) override;
 
-    virtual void canvasPressEvent( QgsMapMouseEvent* e ) override;
-
-    virtual void canvasReleaseEvent( QgsMapMouseEvent* e ) override;
+    virtual void cadCanvasReleaseEvent( QgsMapMouseEvent* e ) override;
 
     //! called when map tool is being deactivated
     void deactivate() override;
@@ -44,6 +42,9 @@ class APP_EXPORT QgsMapToolMoveFeature: public QgsMapToolEdit
 
     /** Id of moved feature*/
     QgsFeatureIds mMovedFeatures;
+
+    QPoint mPressPos;
+
 };
 
 #endif

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -900,7 +900,7 @@ bool QgsAdvancedDigitizingDockWidget::canvasPressEvent( QgsMapMouseEvent* e )
   return mCadEnabled && mConstructionMode;
 }
 
-bool QgsAdvancedDigitizingDockWidget::canvasReleaseEvent( QgsMapMouseEvent* e, bool captureSegment )
+bool QgsAdvancedDigitizingDockWidget::canvasReleaseEvent( QgsMapMouseEvent* e, CaptureMode mode )
 {
   if ( !mCadEnabled )
     return false;
@@ -932,8 +932,8 @@ bool QgsAdvancedDigitizingDockWidget::canvasReleaseEvent( QgsMapMouseEvent* e, b
 
   if ( e->button() == Qt::LeftButton )
   {
-    // stop digitizing if not intermediate point and if line or polygon
-    if ( !mConstructionMode && !captureSegment )
+    // stop digitizing if not intermediate point and enough points are recorded with respect to the mode
+    if ( !mConstructionMode && ( mode == SinglePoint || ( mode == TwoPoints && mCadPointList.count() > 2 ) ) )
     {
       clearPoints();
     }

--- a/src/gui/qgsadvanceddigitizingdockwidget.cpp
+++ b/src/gui/qgsadvanceddigitizingdockwidget.cpp
@@ -900,7 +900,7 @@ bool QgsAdvancedDigitizingDockWidget::canvasPressEvent( QgsMapMouseEvent* e )
   return mCadEnabled && mConstructionMode;
 }
 
-bool QgsAdvancedDigitizingDockWidget::canvasReleaseEvent( QgsMapMouseEvent* e, CaptureMode mode )
+bool QgsAdvancedDigitizingDockWidget::canvasReleaseEvent( QgsMapMouseEvent* e, AdvancedDigitizingMode mode )
 {
   if ( !mCadEnabled )
     return false;

--- a/src/gui/qgsadvanceddigitizingdockwidget.h
+++ b/src/gui/qgsadvanceddigitizingdockwidget.h
@@ -70,6 +70,16 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
       Parallel       //!< Parallel
     };
 
+    /**
+     * Determines if the dock has to record one, two or many points.
+     */
+    enum CaptureMode
+    {
+      SinglePoint, //!< Capture a single point (e.g. for point digitizing)
+      TwoPoints,   //!< Capture two points (e.g. for translation)
+      ManyPoints   //!< Capture many points (e.g. line or polygon digitizing)
+    };
+
     /** \ingroup gui
      * @brief The CadConstraint is an abstract class for all basic constraints (angle/distance/x/y).
      * It contains all values (locked, value, relative) and pointers to corresponding widgets.
@@ -209,10 +219,10 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
      * Will react on a canvas release event
      *
      * @param e A mouse event (may be modified)
-     * @param captureSegment Capture segments?
+     * @param mode determines if the dock has to record one, two or many points.
      * @return  If the event is hidden (construction mode hides events from the maptool)
      */
-    bool canvasReleaseEvent( QgsMapMouseEvent* e , bool captureSegment );
+    bool canvasReleaseEvent( QgsMapMouseEvent* e , CaptureMode mode );
     /**
      * Will react on a canvas move event
      *

--- a/src/gui/qgsadvanceddigitizingdockwidget.h
+++ b/src/gui/qgsadvanceddigitizingdockwidget.h
@@ -73,11 +73,11 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
     /**
      * Determines if the dock has to record one, two or many points.
      */
-    enum CaptureMode
+    enum AdvancedDigitizingMode
     {
       SinglePoint, //!< Capture a single point (e.g. for point digitizing)
       TwoPoints,   //!< Capture two points (e.g. for translation)
-      ManyPoints   //!< Capture many points (e.g. line or polygon digitizing)
+      ManyPoints   //!< Capture two or more points (e.g. line or polygon digitizing)
     };
 
     /** \ingroup gui
@@ -222,7 +222,7 @@ class GUI_EXPORT QgsAdvancedDigitizingDockWidget : public QgsDockWidget, private
      * @param mode determines if the dock has to record one, two or many points.
      * @return  If the event is hidden (construction mode hides events from the maptool)
      */
-    bool canvasReleaseEvent( QgsMapMouseEvent* e , CaptureMode mode );
+    bool canvasReleaseEvent( QgsMapMouseEvent* e, AdvancedDigitizingMode mode );
     /**
      * Will react on a canvas move event
      *

--- a/src/gui/qgsmaptooladvanceddigitizing.cpp
+++ b/src/gui/qgsmaptooladvanceddigitizing.cpp
@@ -44,7 +44,7 @@ void QgsMapToolAdvancedDigitizing::canvasReleaseEvent( QgsMapMouseEvent* e )
 {
   snap( e );
 
-  QgsAdvancedDigitizingDockWidget::CaptureMode dockMode;
+  QgsAdvancedDigitizingDockWidget::AdvancedDigitizingMode dockMode;
   switch ( mCaptureMode )
   {
     case CaptureLine:

--- a/src/gui/qgsmaptooladvanceddigitizing.cpp
+++ b/src/gui/qgsmaptooladvanceddigitizing.cpp
@@ -43,7 +43,23 @@ void QgsMapToolAdvancedDigitizing::canvasPressEvent( QgsMapMouseEvent* e )
 void QgsMapToolAdvancedDigitizing::canvasReleaseEvent( QgsMapMouseEvent* e )
 {
   snap( e );
-  if ( !mCadDockWidget->canvasReleaseEvent( e, mCaptureMode == CaptureLine || mCaptureMode == CapturePolygon ) )
+
+  QgsAdvancedDigitizingDockWidget::CaptureMode dockMode;
+  switch ( mCaptureMode )
+  {
+    case CaptureLine:
+    case CapturePolygon:
+      dockMode = QgsAdvancedDigitizingDockWidget::ManyPoints;
+      break;
+    case CaptureSegment:
+      dockMode = QgsAdvancedDigitizingDockWidget::TwoPoints;
+      break;
+    default:
+      dockMode = QgsAdvancedDigitizingDockWidget::SinglePoint;
+      break;
+  }
+
+  if ( !mCadDockWidget->canvasReleaseEvent( e, dockMode ) )
     cadCanvasReleaseEvent( e );
 }
 

--- a/src/gui/qgsmaptooladvanceddigitizing.h
+++ b/src/gui/qgsmaptooladvanceddigitizing.h
@@ -39,6 +39,7 @@ class GUI_EXPORT QgsMapToolAdvancedDigitizing : public QgsMapToolEdit
     {
       CaptureNone,    //!< Do not capture
       CapturePoint,   //!< Capture points
+      CaptureSegment, //!< Capture a segment (i.e. 2 points)
       CaptureLine,    //!< Capture lines
       CapturePolygon  //!< Capture polygons
     };
@@ -85,6 +86,7 @@ class GUI_EXPORT QgsMapToolAdvancedDigitizing : public QgsMapToolEdit
     virtual void deactivate() override;
 
     QgsAdvancedDigitizingDockWidget* cadDockWidget() const { return mCadDockWidget; }
+
 
   protected:
     /**

--- a/src/gui/qgsmaptoolcapture.cpp
+++ b/src/gui/qgsmaptoolcapture.cpp
@@ -659,8 +659,9 @@ void QgsMapToolCapture::validateGeometry()
     case CaptureNone:
     case CapturePoint:
       return;
+    case CaptureSegment:
     case CaptureLine:
-      if ( size() < 2 )
+      if ( size() < 2  || ( mCaptureMode == CaptureSegment && size() > 2 ) )
         return;
       g.reset( new QgsGeometry( mCaptureCurve.curveToLine() ) );
       break;


### PR DESCRIPTION
QgsMapToolMoveFeature now inherits QgsMapToolAdvancedDigitizing
this allows to specify distance, angles, complex and multiple moves at once
it is now a click and click operation (similarly to the rotate feature map tool): so it can be cancelled once enabled with the right click

see demo video: https://youtu.be/VaDMLT5bB90
(lines going to 0,0 in the video is an issue from the snapping which should be solved in #3377)
