### PR TITLE
fix snapping: do not return a vertex for point layers

### DIFF
--- a/src/core/qgssnappingutils.cpp
+++ b/src/core/qgssnappingutils.cpp
@@ -194,7 +194,7 @@ static void _updateBestMatch( QgsPointLocator::Match& bestMatch, const QgsPoint&
   {
     _replaceIfBetter( bestMatch, loc->nearestVertex( pointMap, tolerance, filter ), tolerance );
   }
-  if ( bestMatch.type() != QgsPointLocator::Vertex && ( type & QgsPointLocator::Edge ) )
+  if ( bestMatch.type() != QgsPointLocator::Vertex && ( loc->layer()->geometryType() != QgsWkbTypes::PointGeometry && type & QgsPointLocator::Edge ) )
   {
     _replaceIfBetter( bestMatch, loc->nearestEdge( pointMap, tolerance, filter ), tolerance );
   }


### PR DESCRIPTION
@wonder-sk not sure if it's the right way to fix this. Let me know your thoughts.

The issue was with advanced digitinzg: we were getting a snapped segment for point layers, with the origin 0,0 as the first point.
