### PR TITLE
Fix postgres pkey map in Qt5 (fixes #15223)

### DIFF
--- a/src/providers/postgres/qgspostgresfeatureiterator.cpp
+++ b/src/providers/postgres/qgspostgresfeatureiterator.cpp
@@ -733,7 +733,7 @@ bool QgsPostgresFeatureIterator::getFeature( QgsPostgresResult &queryResult, int
 
     case pktFidMap:
     {
-      QList<QVariant> primaryKeyVals;
+      QVariantList primaryKeyVals;
 
       Q_FOREACH ( int idx, mSource->mPrimaryKeyAttrs )
       {
@@ -748,7 +748,7 @@ bool QgsPostgresFeatureIterator::getFeature( QgsPostgresResult &queryResult, int
         col++;
       }
 
-      fid = mSource->mShared->lookupFid( QVariant( primaryKeyVals ) );
+      fid = mSource->mShared->lookupFid( primaryKeyVals );
 
     }
     break;

--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -403,6 +403,17 @@ static bool operator<( const QVariant &a, const QVariant &b )
 }
 #endif
 
+#if QT_VERSION >= 0x050000 && QT_VERSION < 0x050600
+#include <algorithm>
+template <typename T>
+bool operator<( const QList<T> &lhs, const QList<T> &rhs )
+{
+  return std::lexicographical_compare( lhs.begin(), lhs.end(),
+                                       rhs.begin(), rhs.end() );
+}
+#endif
+
+
 QgsFeatureIterator QgsPostgresProvider::getFeatures( const QgsFeatureRequest& request ) const
 {
   if ( !mValid )

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -508,10 +508,10 @@ class QgsPostgresSharedData
     void ensureFeaturesCountedAtLeast( long fetched );
 
     // FID lookups
-    QgsFeatureId lookupFid( const QVariant &v ); // lookup existing mapping or add a new one
-    QVariant removeFid( QgsFeatureId fid );
-    void insertFid( QgsFeatureId fid, const QVariant& k );
-    QVariant lookupKey( QgsFeatureId featureId );
+    QgsFeatureId lookupFid( const QVariantList& v ); // lookup existing mapping or add a new one
+    QVariantList removeFid( QgsFeatureId fid );
+    void insertFid( QgsFeatureId fid, const QVariantList& k );
+    QVariantList lookupKey( QgsFeatureId featureId );
 
   protected:
     QMutex mMutex; //!< Access to all data members is guarded by the mutex
@@ -519,8 +519,8 @@ class QgsPostgresSharedData
     long mFeaturesCounted;    //! Number of features in the layer
 
     QgsFeatureId mFidCounter;                    // next feature id if map is used
-    QMap<QVariant, QgsFeatureId> mKeyToFid;      // map key values to feature id
-    QMap<QgsFeatureId, QVariant> mFidToKey;      // map feature back to fea
+    QMap<QVariantList, QgsFeatureId> mKeyToFid;      // map key values to feature id
+    QMap<QgsFeatureId, QVariantList> mFidToKey;      // map feature id back to key values
 };
 
 #endif


### PR DESCRIPTION
Switching from QVariant to QVariantList solves the underlying Qt5 issue:
- comparison of QVariantList objects works fine
- comparison of QVariantList objects wrapped in QVariant does not work

For Qt4 we have our own QVariant comparison operator in postgres provider that handles QVariantList correctly, but in Qt5 the QVariant comparison is given.

The extra wrapping of QVariantList into another QVariant seems unnecessary anyway, so we may as well save a tiny bit of memory and cpu

Needs someone to test properly on qt4/qt5... maybe @3nids ? :-)

cc @nyalldawson 
