### PR TITLE
[processing] Rework centroid algorithm to handle non-polygon layers

### DIFF
--- a/python/plugins/processing/algs/help/qgis.yaml
+++ b/python/plugins/processing/algs/help/qgis.yaml
@@ -44,6 +44,11 @@ qgis:buildvirtualvector: >
 
   The output virtual layer will not be open in the current project.
 
+qgis:centroids: >
+  This algorithm creates a new point layer, with points representing the centroid of the geometries in an input layer.
+
+  The attributes associated to each point in the output layer are the same ones associated to the original features.
+
 qgis:checkvalidity:
   This algorithm performs a validity check on the geometries of a vector layer.
 
@@ -305,6 +310,8 @@ qgis:polygoncentroids: >
   This algorithm creates a new point layer, with points representing the centroid of polygons of an input layer.
 
   The attributes associated to each point in the output layer are the same ones associated to the original polygon.
+
+  NOTE: This algorithm is deprecated and the generic "centroids" algorithm (which works for line and multi geometry layers) should be used instead.
 
 
 qgis:polygonfromlayerextent: >

--- a/python/plugins/processing/algs/qgis/QGISAlgorithmProvider.py
+++ b/python/plugins/processing/algs/qgis/QGISAlgorithmProvider.py
@@ -151,6 +151,7 @@ from .BoundingBox import BoundingBox
 from .Boundary import Boundary
 from .PointOnSurface import PointOnSurface
 from .OffsetLine import OffsetLine
+from .PolygonCentroids import PolygonCentroids
 
 pluginPath = os.path.normpath(os.path.join(
     os.path.split(os.path.dirname(__file__))[0], os.pardir))
@@ -204,7 +205,7 @@ class QGISAlgorithmProvider(AlgorithmProvider):
                         RectanglesOvalsDiamondsVariable(),
                         RectanglesOvalsDiamondsFixed(), MergeLines(),
                         BoundingBox(), Boundary(), PointOnSurface(),
-                        OffsetLine()
+                        OffsetLine(), PolygonCentroids()
                         ]
 
         if hasMatplotlib:

--- a/python/plugins/processing/gui/menus.py
+++ b/python/plugins/processing/gui/menus.py
@@ -52,7 +52,7 @@ defaultMenuEntries.update({'qgis:convexhull': geoprocessingToolsMenu,
 geometryToolsMenu = vectorMenu + "/" + Processing.tr('G&eometry Tools')
 defaultMenuEntries.update({'qgis:checkvalidity': geometryToolsMenu,
                            'qgis:exportaddgeometrycolumns': geometryToolsMenu,
-                           'qgis:polygoncentroids': geometryToolsMenu,
+                           'qgis:centroids': geometryToolsMenu,
                            'qgis:delaunaytriangulation': geometryToolsMenu,
                            'qgis:voronoipolygons': geometryToolsMenu,
                            'qgis:simplifygeometries': geometryToolsMenu,

--- a/python/plugins/processing/tests/testdata/expected/centroid_lines.gfs
+++ b/python/plugins/processing/tests/testdata/expected/centroid_lines.gfs
@@ -1,0 +1,15 @@
+<GMLFeatureClassList>
+  <GMLFeatureClass>
+    <Name>centroid_lines</Name>
+    <ElementPath>centroid_lines</ElementPath>
+    <GeometryType>1</GeometryType>
+    <SRSName>EPSG:4326</SRSName>
+    <DatasetSpecificInfo>
+      <FeatureCount>7</FeatureCount>
+      <ExtentXMin>0.00000</ExtentXMin>
+      <ExtentXMax>8.75520</ExtentXMax>
+      <ExtentYMin>-3.00000</ExtentYMin>
+      <ExtentYMax>2.90165</ExtentYMax>
+    </DatasetSpecificInfo>
+  </GMLFeatureClass>
+</GMLFeatureClassList>

--- a/python/plugins/processing/tests/testdata/expected/centroid_lines.gml
+++ b/python/plugins/processing/tests/testdata/expected/centroid_lines.gml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation=""
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>0</gml:X><gml:Y>-3</gml:Y></gml:coord>
+      <gml:coord><gml:X>8.755203820042828</gml:X><gml:Y>2.901650429449553</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                                               
+  <gml:featureMember>
+    <ogr:centroid_lines fid="lines.0">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>8.755203820042828,2.901650429449553</gml:coordinates></gml:Point></ogr:geometryProperty>
+    </ogr:centroid_lines>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:centroid_lines fid="lines.1">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>0,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+    </ogr:centroid_lines>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:centroid_lines fid="lines.2">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>2.375,1.625</gml:coordinates></gml:Point></ogr:geometryProperty>
+    </ogr:centroid_lines>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:centroid_lines fid="lines.3">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>4,1</gml:coordinates></gml:Point></ogr:geometryProperty>
+    </ogr:centroid_lines>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:centroid_lines fid="lines.4">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>8.5,-3.0</gml:coordinates></gml:Point></ogr:geometryProperty>
+    </ogr:centroid_lines>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:centroid_lines fid="lines.5">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>8,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+    </ogr:centroid_lines>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:centroid_lines fid="lines.6">
+    </ogr:centroid_lines>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/centroid_multilines.gfs
+++ b/python/plugins/processing/tests/testdata/expected/centroid_multilines.gfs
@@ -1,0 +1,15 @@
+<GMLFeatureClassList>
+  <GMLFeatureClass>
+    <Name>centroid_multilines</Name>
+    <ElementPath>centroid_multilines</ElementPath>
+    <GeometryType>1</GeometryType>
+    <SRSName>EPSG:4326</SRSName>
+    <DatasetSpecificInfo>
+      <FeatureCount>4</FeatureCount>
+      <ExtentXMin>0.00000</ExtentXMin>
+      <ExtentXMax>4.41936</ExtentXMax>
+      <ExtentYMin>-1.00000</ExtentYMin>
+      <ExtentYMax>2.68756</ExtentYMax>
+    </DatasetSpecificInfo>
+  </GMLFeatureClass>
+</GMLFeatureClassList>

--- a/python/plugins/processing/tests/testdata/expected/centroid_multilines.gml
+++ b/python/plugins/processing/tests/testdata/expected/centroid_multilines.gml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation=""
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>0</gml:X><gml:Y>-1</gml:Y></gml:coord>
+      <gml:coord><gml:X>4.41935638121706</gml:X><gml:Y>2.687560818469874</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                                                
+  <gml:featureMember>
+    <ogr:centroid_multilines fid="lines.1">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>0,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+    </ogr:centroid_multilines>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:centroid_multilines fid="lines.2">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>4.41935638121706,1.293104104489945</gml:coordinates></gml:Point></ogr:geometryProperty>
+    </ogr:centroid_multilines>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:centroid_multilines fid="lines.3">
+    </ogr:centroid_multilines>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:centroid_multilines fid="lines.4">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3.423678244400056,2.687560818469874</gml:coordinates></gml:Point></ogr:geometryProperty>
+    </ogr:centroid_multilines>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/centroid_multipoint.gfs
+++ b/python/plugins/processing/tests/testdata/expected/centroid_multipoint.gfs
@@ -1,0 +1,19 @@
+<GMLFeatureClassList>
+  <GMLFeatureClass>
+    <Name>centroid_multipoint</Name>
+    <ElementPath>centroid_multipoint</ElementPath>
+    <SRSName>EPSG:4326</SRSName>
+    <DatasetSpecificInfo>
+      <FeatureCount>5</FeatureCount>
+      <ExtentXMin>2.00000</ExtentXMin>
+      <ExtentXMax>4.50000</ExtentXMax>
+      <ExtentYMin>-3.00000</ExtentYMin>
+      <ExtentYMax>2.00000</ExtentYMax>
+    </DatasetSpecificInfo>
+    <PropertyDefn>
+      <Name>d</Name>
+      <ElementPath>d</ElementPath>
+      <Type>Integer</Type>
+    </PropertyDefn>
+  </GMLFeatureClass>
+</GMLFeatureClassList>

--- a/python/plugins/processing/tests/testdata/expected/centroid_multipoint.gml
+++ b/python/plugins/processing/tests/testdata/expected/centroid_multipoint.gml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation=""
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>2</gml:X><gml:Y>-3</gml:Y></gml:coord>
+      <gml:coord><gml:X>4.5</gml:X><gml:Y>2</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                                                                             
+  <gml:featureMember>
+    <ogr:centroid_multipoint fid="points.9">
+      <ogr:d>5</ogr:d>
+    </ogr:centroid_multipoint>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:centroid_multipoint fid="points.0">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>2,2</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:d>1</ogr:d>
+    </ogr:centroid_multipoint>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:centroid_multipoint fid="points.3">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>4.5,1.5</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:d>2</ogr:d>
+    </ogr:centroid_multipoint>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:centroid_multipoint fid="points.5">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>4,-3</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:d>3</ogr:d>
+    </ogr:centroid_multipoint>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:centroid_multipoint fid="points.7">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3.5,-1.0</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:d>4</ogr:d>
+    </ogr:centroid_multipoint>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/centroid_multipolys.gfs
+++ b/python/plugins/processing/tests/testdata/expected/centroid_multipolys.gfs
@@ -1,0 +1,31 @@
+<GMLFeatureClassList>
+  <GMLFeatureClass>
+    <Name>centroid_multipolys</Name>
+    <ElementPath>centroid_multipolys</ElementPath>
+    <GeometryType>1</GeometryType>
+    <SRSName>EPSG:4326</SRSName>
+    <DatasetSpecificInfo>
+      <FeatureCount>4</FeatureCount>
+      <ExtentXMin>0.50000</ExtentXMin>
+      <ExtentXMax>7.68889</ExtentXMax>
+      <ExtentYMin>0.50000</ExtentYMin>
+      <ExtentYMax>2.91111</ExtentYMax>
+    </DatasetSpecificInfo>
+    <PropertyDefn>
+      <Name>Bname</Name>
+      <ElementPath>Bname</ElementPath>
+      <Type>String</Type>
+      <Width>4</Width>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>Bintval</Name>
+      <ElementPath>Bintval</ElementPath>
+      <Type>Integer</Type>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>Bfloatval</Name>
+      <ElementPath>Bfloatval</ElementPath>
+      <Type>Real</Type>
+    </PropertyDefn>
+  </GMLFeatureClass>
+</GMLFeatureClassList>

--- a/python/plugins/processing/tests/testdata/expected/centroid_multipolys.gml
+++ b/python/plugins/processing/tests/testdata/expected/centroid_multipolys.gml
@@ -1,0 +1,42 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation=""
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>0.5</gml:X><gml:Y>0.5</gml:Y></gml:coord>
+      <gml:coord><gml:X>7.688888888888888</gml:X><gml:Y>2.911111111111111</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                                            
+  <gml:featureMember>
+    <ogr:centroid_multipolys fid="multipolys.0">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3.166666666666667,1.833333333333333</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:Bname>Test</ogr:Bname>
+      <ogr:Bintval>1</ogr:Bintval>
+      <ogr:Bfloatval>0.123</ogr:Bfloatval>
+    </ogr:centroid_multipolys>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:centroid_multipolys fid="multipolys.1">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>7.688888888888888,2.911111111111111</gml:coordinates></gml:Point></ogr:geometryProperty>
+    </ogr:centroid_multipolys>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:centroid_multipolys fid="multipolys.2">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>0.5,0.5</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:Bname>Test</ogr:Bname>
+      <ogr:Bintval>2</ogr:Bintval>
+      <ogr:Bfloatval>-0.123</ogr:Bfloatval>
+    </ogr:centroid_multipolys>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:centroid_multipolys fid="multipolys.3">
+      <ogr:Bname>Test</ogr:Bname>
+      <ogr:Bintval>3</ogr:Bintval>
+      <ogr:Bfloatval>0</ogr:Bfloatval>
+    </ogr:centroid_multipolys>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/centroid_points.gfs
+++ b/python/plugins/processing/tests/testdata/expected/centroid_points.gfs
@@ -1,0 +1,15 @@
+<GMLFeatureClassList>
+  <GMLFeatureClass>
+    <Name>centroid_points</Name>
+    <ElementPath>centroid_points</ElementPath>
+    <GeometryType>1</GeometryType>
+    <SRSName>EPSG:4326</SRSName>
+    <DatasetSpecificInfo>
+      <FeatureCount>9</FeatureCount>
+      <ExtentXMin>0.00000</ExtentXMin>
+      <ExtentXMax>8.00000</ExtentXMax>
+      <ExtentYMin>-5.00000</ExtentYMin>
+      <ExtentYMax>3.00000</ExtentYMax>
+    </DatasetSpecificInfo>
+  </GMLFeatureClass>
+</GMLFeatureClassList>

--- a/python/plugins/processing/tests/testdata/expected/centroid_points.gml
+++ b/python/plugins/processing/tests/testdata/expected/centroid_points.gml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation=""
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>0</gml:X><gml:Y>-5</gml:Y></gml:coord>
+      <gml:coord><gml:X>8</gml:X><gml:Y>3</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                                                                               
+  <gml:featureMember>
+    <ogr:centroid_points fid="points.0">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>1,1</gml:coordinates></gml:Point></ogr:geometryProperty>
+    </ogr:centroid_points>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:centroid_points fid="points.1">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>3,3</gml:coordinates></gml:Point></ogr:geometryProperty>
+    </ogr:centroid_points>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:centroid_points fid="points.2">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>2,2</gml:coordinates></gml:Point></ogr:geometryProperty>
+    </ogr:centroid_points>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:centroid_points fid="points.3">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>5,2</gml:coordinates></gml:Point></ogr:geometryProperty>
+    </ogr:centroid_points>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:centroid_points fid="points.4">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>4,1</gml:coordinates></gml:Point></ogr:geometryProperty>
+    </ogr:centroid_points>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:centroid_points fid="points.5">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>0,-5</gml:coordinates></gml:Point></ogr:geometryProperty>
+    </ogr:centroid_points>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:centroid_points fid="points.6">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>8,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+    </ogr:centroid_points>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:centroid_points fid="points.7">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>7,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+    </ogr:centroid_points>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:centroid_points fid="points.8">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>0,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+    </ogr:centroid_points>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/centroid_polys.gfs
+++ b/python/plugins/processing/tests/testdata/expected/centroid_polys.gfs
@@ -1,0 +1,31 @@
+<GMLFeatureClassList>
+  <GMLFeatureClass>
+    <Name>centroid_polys</Name>
+    <ElementPath>centroid_polys</ElementPath>
+    <GeometryType>1</GeometryType>
+    <SRSName>EPSG:4326</SRSName>
+    <DatasetSpecificInfo>
+      <FeatureCount>6</FeatureCount>
+      <ExtentXMin>0.65385</ExtentXMin>
+      <ExtentXMax>8.00000</ExtentXMax>
+      <ExtentYMin>-1.00000</ExtentYMin>
+      <ExtentYMax>5.50000</ExtentYMax>
+    </DatasetSpecificInfo>
+    <PropertyDefn>
+      <Name>name</Name>
+      <ElementPath>name</ElementPath>
+      <Type>String</Type>
+      <Width>5</Width>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>intval</Name>
+      <ElementPath>intval</ElementPath>
+      <Type>Integer</Type>
+    </PropertyDefn>
+    <PropertyDefn>
+      <Name>floatval</Name>
+      <ElementPath>floatval</ElementPath>
+      <Type>Real</Type>
+    </PropertyDefn>
+  </GMLFeatureClass>
+</GMLFeatureClassList>

--- a/python/plugins/processing/tests/testdata/expected/centroid_polys.gml
+++ b/python/plugins/processing/tests/testdata/expected/centroid_polys.gml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation=""
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>0.6538461538461539</gml:X><gml:Y>-1</gml:Y></gml:coord>
+      <gml:coord><gml:X>8</gml:X><gml:Y>5.5</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                                                            
+  <gml:featureMember>
+    <ogr:centroid_polys fid="polys.0">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>0.653846153846154,1.115384615384615</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:name>aaaaa</ogr:name>
+      <ogr:intval>33</ogr:intval>
+      <ogr:floatval>44.123456</ogr:floatval>
+    </ogr:centroid_polys>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:centroid_polys fid="polys.1">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>5.0,4.333333333333333</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:name>Aaaaa</ogr:name>
+      <ogr:intval>-33</ogr:intval>
+      <ogr:floatval>0</ogr:floatval>
+    </ogr:centroid_polys>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:centroid_polys fid="polys.2">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>2.5,5.5</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:name>bbaaa</ogr:name>
+      <ogr:floatval>0.123</ogr:floatval>
+    </ogr:centroid_polys>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:centroid_polys fid="polys.3">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>8,-1</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:name>ASDF</ogr:name>
+      <ogr:intval>0</ogr:intval>
+    </ogr:centroid_polys>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:centroid_polys fid="polys.4">
+      <ogr:intval>120</ogr:intval>
+      <ogr:floatval>-100291.43213</ogr:floatval>
+    </ogr:centroid_polys>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:centroid_polys fid="polys.5">
+      <ogr:geometryProperty><gml:Point srsName="EPSG:4326"><gml:coordinates>4.080459770114943,-0.218390804597701</gml:coordinates></gml:Point></ogr:geometryProperty>
+      <ogr:name>elim</ogr:name>
+      <ogr:intval>2</ogr:intval>
+      <ogr:floatval>3.33</ogr:floatval>
+    </ogr:centroid_polys>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
@@ -743,3 +743,69 @@ tests:
         name: expected/buffer_lines_square.gml
         type: vector
 
+  - algorithm: qgis:centroids
+    name: Test (qgis:centroids)
+    params:
+      INPUT_LAYER:
+        name: lines.gml
+        type: vector
+    results:
+      OUTPUT_LAYER:
+        name: expected/centroid_lines.gml
+        type: vector
+
+  - algorithm: qgis:centroids
+    name: Test (qgis:centroids)
+    params:
+      INPUT_LAYER:
+        name: multilines.gml
+        type: vector
+    results:
+      OUTPUT_LAYER:
+        name: expected/centroid_multilines.gml
+        type: vector
+
+  - algorithm: qgis:centroids
+    name: Test (qgis:centroids)
+    params:
+      INPUT_LAYER:
+        name: multipoints.gml
+        type: vector
+    results:
+      OUTPUT_LAYER:
+        name: expected/centroid_multipoint.gml
+        type: vector
+
+  - algorithm: qgis:centroids
+    name: Test (qgis:centroids)
+    params:
+      INPUT_LAYER:
+        name: multipolys.gml
+        type: vector
+    results:
+      OUTPUT_LAYER:
+        name: expected/centroid_multipolys.gml
+        type: vector
+
+  - algorithm: qgis:centroids
+    name: Test (qgis:centroids)
+    params:
+      INPUT_LAYER:
+        name: points.gml
+        type: vector
+    results:
+      OUTPUT_LAYER:
+        name: expected/centroid_points.gml
+        type: vector
+
+  - algorithm: qgis:centroids
+    name: Test (qgis:centroids)
+    params:
+      INPUT_LAYER:
+        name: polys.gml
+        type: vector
+    results:
+      OUTPUT_LAYER:
+        name: expected/centroid_polys.gml
+        type: vector
+  


### PR DESCRIPTION
The existing polygoncentroids algorithm has been deprecated (and hidden from the toolbox), and a new, generic centroids algorithm added which works with lines and multipoints.

I've gone with the add new algorithm + deprecate old approach since I'd like to backport this to master_2. For the master branch we could potentially delete the polygoncentroids algorithm (if we're ok with breaking existing models)
