### PR TITLE
[processing] tiny fix for python3 support

### DIFF
--- a/python/plugins/processing/tools/vector.py
+++ b/python/plugins/processing/tools/vector.py
@@ -31,7 +31,10 @@ import os
 import csv
 import uuid
 import codecs
-import cStringIO
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
 
 import psycopg2
 


### PR DESCRIPTION
When running processing under a Qt5 + Python3 setup, I get an error when trying to import the cStringIO. This PR applies a solution advertised on stack exchange (http://stackoverflow.com/questions/11914472/stringio-in-python3).
