### PR TITLE
Check if the reply is running before timing out

### DIFF
--- a/src/core/qgsnetworkaccessmanager.h
+++ b/src/core/qgsnetworkaccessmanager.h
@@ -110,7 +110,7 @@ class CORE_EXPORT QgsNetworkAccessManager : public QNetworkAccessManager
     void requestSent( QNetworkReply * reply, QObject *sender );
 
   private slots:
-    void abortRequest();
+    void checkRequestTimeout();
 
   protected:
     virtual QNetworkReply *createRequest( QNetworkAccessManager::Operation op, const QNetworkRequest &req, QIODevice *outgoingData = nullptr ) override;


### PR DESCRIPTION
Also fixes a memory leak for timer not being deleted.
This should fix a few reported and unreported issues
with false positive timeout errors.

Fixes: #12243
