### PR TITLE
[labelling] label all visible parts of a polygon perimeter

### DIFF
--- a/src/core/pal/layer.cpp
+++ b/src/core/pal/layer.cpp
@@ -190,7 +190,7 @@ bool Layer::registerFeature( QgsLabelFeature* lf )
       continue;
     }
 
-    if ( mMode == LabelPerFeature && ( type == GEOS_POLYGON || type == GEOS_LINESTRING ) )
+    if ( mMode == LabelPerFeature && (( type == GEOS_LINESTRING && mArrangement != QgsPalLayerSettings::PerimeterCurved ) || type == GEOS_POLYGON ) )
     {
       if ( type == GEOS_LINESTRING )
         GEOSLength_r( geosctxt, geom, &geom_size );


### PR DESCRIPTION
This addresses an issue with perimeter placement labelling for polygons whereas a polygon perimeter clipped into multiple parts only had one part labelled:
![ok](https://cloud.githubusercontent.com/assets/1728657/17726061/6d9eba68-647a-11e6-8a3a-7f604f409e92.png)
![notok](https://cloud.githubusercontent.com/assets/1728657/17726064/710041d6-647a-11e6-9e04-d9166f99fbc8.png)
_image above shows problem this PR fixes, whereas the left side of the perimeter isn't labelled_

@nyalldawson , as per our discussion 😄 
