### PR TITLE
Remove mention of "panning" in the title as the frame is only about z…

### DIFF
--- a/src/ui/qgsoptionsbase.ui
+++ b/src/ui/qgsoptionsbase.ui
@@ -3362,7 +3362,7 @@
                <item>
                 <widget class="QgsCollapsibleGroupBox" name="groupBox_10">
                  <property name="title">
-                  <string>Panning and zooming</string>
+                  <string>Zooming</string>
                  </property>
                  <layout class="QGridLayout" name="_8">
                   <item row="0" column="0">


### PR DESCRIPTION
…ooming

Unless the "zoom factor" option in the frame applies also to panning (or an upcoming option will refer to it), mentioning panning in the title sounds erroneous.
The other option that refered to panning has been removed from 2.14 to 2.16.
