### PR TITLE
Add == and != operator to QgsFeature and add QML bindings

### DIFF
--- a/python/core/qgsfeature.sip
+++ b/python/core/qgsfeature.sip
@@ -239,13 +239,19 @@ class QgsFeature
      * @returns feature ID
      * @see setFeatureId
      */
-    qint64 id() const;
+    QgsFeatureId id() const;
 
     /** Sets the feature ID for this feature.
      * @param id feature id
      * @see id
      */
-    void setFeatureId( qint64 id );
+    void setFeatureId( QgsFeatureId id );
+
+    /** Sets the feature ID for this feature.
+     * @param id feature id
+     * @see id
+     */
+    void setId( QgsFeatureId id );
 
     /** Returns the feature's attributes.
      * @link attributes @endlink method.

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -454,6 +454,7 @@ SET(QGIS_CORE_MOC_HDRS
   qgsdataprovider.h
   qgsdbfilterproxymodel.h
   qgseditformconfig.h
+  qgsfeature.h
   qgsfeedback.h
   qgsfield.h
   qgsgeometryvalidator.h
@@ -640,7 +641,6 @@ SET(QGIS_CORE_HDRS
   qgsexpressioncontext.h
   qgsexpressioncontextgenerator.h
   qgsexpressionfieldbuffer.h
-  qgsfeature.h
   qgsfeature_p.h
   qgsfeatureiterator.h
   qgsfeaturerequest.h

--- a/src/core/qgsfeature.cpp
+++ b/src/core/qgsfeature.cpp
@@ -41,15 +41,35 @@ QgsFeature::QgsFeature( const QgsFields &fields, QgsFeatureId id )
   initAttributes( d->fields.count() );
 }
 
-QgsFeature::QgsFeature( QgsFeature const & rhs )
+QgsFeature::QgsFeature( const QgsFeature& rhs )
     : d( rhs.d )
 {
 }
 
-QgsFeature & QgsFeature::operator=( QgsFeature const & rhs )
+QgsFeature & QgsFeature::operator=( const QgsFeature & rhs )
 {
   d = rhs.d;
   return *this;
+}
+
+bool QgsFeature::operator ==( const QgsFeature& other ) const
+{
+  if ( d == other.d )
+    return true;
+
+  if ( d->fid == other.d->fid
+       && d->valid == other.d->valid
+       && d->fields == other.d->fields
+       && d->attributes == other.d->attributes
+       && d->geometry.equals( other.d->geometry ) )
+    return true;
+
+  return false;
+}
+
+bool QgsFeature::operator!=( const QgsFeature& other ) const
+{
+  return !( *this == other );
 }
 
 QgsFeature::~QgsFeature()
@@ -85,6 +105,21 @@ QgsGeometry QgsFeature::geometry() const
  ****************************************************************************/
 
 void QgsFeature::setFeatureId( QgsFeatureId id )
+{
+  if ( id == d->fid )
+    return;
+
+  d.detach();
+  d->fid = id;
+}
+
+/***************************************************************************
+ * This class is considered CRITICAL and any change MUST be accompanied with
+ * full unit tests in testqgsfeature.cpp.
+ * See details in QEP #17
+ ****************************************************************************/
+
+void QgsFeature::setId( QgsFeatureId id )
 {
   if ( id == d->fid )
     return;

--- a/src/core/qgsfeature.h
+++ b/src/core/qgsfeature.h
@@ -24,10 +24,11 @@ email                : sherman at mrcc.com
 #include <QSet>
 #include <QExplicitlySharedDataPointer>
 
+#include "qgsfield.h"
+
 class QgsGeometry;
 class QgsRectangle;
 class QgsFeature;
-class QgsFields;
 class QgsFeaturePrivate;
 
 // feature id class (currently 64 bit)
@@ -123,6 +124,12 @@ class QgsField;
  */
 class CORE_EXPORT QgsFeature
 {
+    Q_GADGET
+
+    Q_PROPERTY( QgsFeatureId id READ id WRITE setId )
+    Q_PROPERTY( QgsAttributes attributes READ attributes WRITE setAttributes )
+    Q_PROPERTY( QgsFields fields READ fields WRITE setFields )
+
   public:
 
     /** Constructor for QgsFeature
@@ -144,6 +151,17 @@ class CORE_EXPORT QgsFeature
      */
     QgsFeature & operator=( QgsFeature const & rhs );
 
+    /**
+     * Compares two features
+     */
+    bool operator==( const QgsFeature& other ) const;
+
+    /**
+     * Compares two features
+     */
+    bool operator!=( const QgsFeature& other ) const;
+
+
     //! Destructor
     virtual ~QgsFeature();
 
@@ -158,6 +176,12 @@ class CORE_EXPORT QgsFeature
      * @see id
      */
     void setFeatureId( QgsFeatureId id );
+
+    /** Sets the feature ID for this feature.
+     * @param id feature id
+     * @see id
+     */
+    void setId( QgsFeatureId id );
 
     /** Returns the feature's attributes.
      * @link attributes @endlink method.

--- a/tests/src/core/testqgsfeature.cpp
+++ b/tests/src/core/testqgsfeature.cpp
@@ -41,6 +41,7 @@ class TestQgsFeature: public QObject
     void geometry();
     void asVariant(); //test conversion to and from a QVariant
     void fields();
+    void equality();
     void attributeUsingField();
     void dataStream();
 
@@ -357,6 +358,81 @@ void TestQgsFeature::fields()
   QCOMPARE( copy.fieldNameIndex( "bad" ), -1 );
   QCOMPARE( copy.fieldNameIndex( "field1" ), 0 );
   QCOMPARE( copy.fieldNameIndex( "field2" ), 1 );
+}
+
+void TestQgsFeature::equality()
+{
+
+  QgsFeature feature;
+  feature.setFields( mFields, true );
+  feature.setAttribute( 0, QString( "attr1" ) );
+  feature.setAttribute( 1, QString( "attr2" ) );
+  feature.setAttribute( 2, QString( "attr3" ) );
+  feature.setValid( true );
+  feature.setId( 1 );
+  feature.setGeometry( QgsGeometry( new QgsPointV2( 1, 2 ) ) );
+
+  QgsFeature feature2 = feature;
+  QVERIFY( feature == feature2 );
+
+  feature2.setAttribute( 0, "attr1" );
+  QVERIFY( feature == feature2 );
+
+  feature2.setAttribute( 1, 1 );
+  QVERIFY( feature != feature2 );
+
+  QgsFeature feature3;
+  feature3.setFields( mFields, true );
+  feature3.setAttribute( 0, QString( "attr1" ) );
+  feature3.setAttribute( 1, QString( "attr2" ) );
+  feature3.setAttribute( 2, QString( "attr3" ) );
+  feature3.setValid( true );
+  feature3.setId( 1 );
+  feature3.setGeometry( QgsGeometry( new QgsPointV2( 1, 2 ) ) );
+  QVERIFY( feature == feature3 );
+
+  QgsFeature feature4;
+  feature4.setFields( mFields, true );
+  feature4.setAttribute( 0, 1 );
+  feature4.setAttribute( 1, 2 );
+  feature4.setAttribute( 2, 3 );
+  feature4.setValid( true );
+  feature4.setId( 1 );
+  feature4.setGeometry( QgsGeometry( new QgsPointV2( 1, 2 ) ) );
+  QVERIFY( feature != feature4 );
+
+  QgsFeature feature5;
+  feature5.setFields( mFields, true );
+  feature5.setAttribute( 0, QString( "attr1" ) );
+  feature5.setAttribute( 1, QString( "attr2" ) );
+  feature5.setAttribute( 2, QString( "attr3" ) );
+  feature5.setValid( false );
+  feature5.setId( 1 );
+  feature5.setGeometry( QgsGeometry( new QgsPointV2( 1, 2 ) ) );
+
+  QVERIFY( feature != feature5 );
+
+  QgsFeature feature6;
+  feature6.setFields( mFields, true );
+  feature6.setAttribute( 0, QString( "attr1" ) );
+  feature6.setAttribute( 1, QString( "attr2" ) );
+  feature6.setAttribute( 2, QString( "attr3" ) );
+  feature6.setValid( true );
+  feature6.setId( 2 );
+  feature6.setGeometry( QgsGeometry( new QgsPointV2( 1, 2 ) ) );
+
+  QVERIFY( feature != feature6 );
+
+  QgsFeature feature7;
+  feature7.setFields( mFields, true );
+  feature7.setAttribute( 0, QString( "attr1" ) );
+  feature7.setAttribute( 1, QString( "attr2" ) );
+  feature7.setAttribute( 2, QString( "attr3" ) );
+  feature7.setValid( true );
+  feature7.setId( 1 );
+  feature7.setGeometry( QgsGeometry( new QgsPointV2( 1, 3 ) ) );
+
+  QVERIFY( feature != feature7 );
 }
 
 void TestQgsFeature::attributeUsingField()


### PR DESCRIPTION
Also adds a `QgsFeature::setId()` method that is aligned with `QgsFeature::id()` (as opposed to the old `QgsFeature::setFeatureId()`)
