### PR TITLE
[processing] Add a reset menus button

### DIFF
--- a/python/plugins/processing/gui/ConfigDialog.py
+++ b/python/plugins/processing/gui/ConfigDialog.py
@@ -42,6 +42,7 @@ from qgis.PyQt.QtWidgets import (QFileDialog,
                                  QHBoxLayout,
                                  QComboBox)
 from qgis.PyQt.QtGui import (QIcon,
+                             QPushButton,
                              QStandardItemModel,
                              QStandardItem)
 
@@ -55,7 +56,7 @@ from processing.core.ProcessingConfig import (ProcessingConfig,
                                               Setting)
 from processing.core.Processing import Processing
 from processing.gui.DirectorySelectorDialog import DirectorySelectorDialog
-from processing.gui.menus import updateMenus
+from processing.gui.menus import defaultMenuEntries, updateMenus
 from processing.gui.menus import menusSettingsGroup
 
 
@@ -198,6 +199,16 @@ class ConfigDialog(BASE, WIDGET):
 
         rootItem.insertRow(0, [menusItem, emptyItem])
 
+        button = QPushButton(self.tr('Reset to defaults'))
+        button.clicked.connect(self.resetMenusToDefaults)
+        layout = QHBoxLayout()
+        layout.setContentsMargins(0, 0, 0, 0)
+        layout.addWidget(button)
+        layout.addStretch()
+        widget = QWidget()
+        widget.setLayout(layout)
+        self.tree.setIndexWidget(emptyItem.index(), widget)
+
         providers = Processing.providers
         for provider in providers:
             providerDescription = provider.getDescription()
@@ -239,6 +250,15 @@ class ConfigDialog(BASE, WIDGET):
 
         self.tree.sortByColumn(0, Qt.AscendingOrder)
         self.adjustColumns()
+
+    def resetMenusToDefaults(self):
+        providers = Processing.providers
+        for provider in providers:
+            for alg in provider.algs:
+                d = defaultMenuEntries.get(alg.commandLineName(), "")
+                setting = ProcessingConfig.settings["MENU_" + alg.commandLineName()]
+                item = self.items[setting]
+                item.setData(d, Qt.EditRole)
 
     def accept(self):
         for setting in self.items.keys():

--- a/python/plugins/processing/gui/ConfigDialog.py
+++ b/python/plugins/processing/gui/ConfigDialog.py
@@ -190,7 +190,7 @@ class ConfigDialog(BASE, WIDGET):
         """
         Filter 'Menus' items
         """
-        menusItem = QStandardItem(self.tr('Menus (requires restart)'))
+        menusItem = QStandardItem(self.tr('Menus'))
         icon = QIcon(os.path.join(pluginPath, 'images', 'menu.png'))
         menusItem.setIcon(icon)
         menusItem.setEditable(False)

--- a/python/plugins/processing/gui/menus.py
+++ b/python/plugins/processing/gui/menus.py
@@ -1,4 +1,5 @@
 import os
+from qgis.PyQt.QtCore import QCoreApplication
 from qgis.PyQt.QtWidgets import QAction, QMenu
 from PyQt4.QtGui import QIcon
 from processing.core.alglist import algList
@@ -127,6 +128,7 @@ def initializeMenus():
 
 def updateMenus():
     removeMenus()
+    QCoreApplication.processEvents()
     createMenus()
 
 


### PR DESCRIPTION
- Add a button to reset processing menus to defaults in processing configuration dialog.
  
  Note that in 2.16 release, french users got 2 vector menus due to an error in translations.
  - In QGIS main application : Vect&or => &Vecteur
  - In processing plugin : Vect&or => Vect&eur
  
  So this would be very useful for french users to merge the processing vector menu into main QGIS application vector menu.
  Fix : https://hub.qgis.org/issues/14535
- Also fix the updateMenus method.
  Fix : https://hub.qgis.org/issues/15118
  And remove "require restart" as it is not the case.

Once this is merged, I will fix the translation in Transifex.
