### PR TITLE
[expression] support collection of geometry in the aggregate() function

### DIFF
--- a/python/core/geometry/qgsgeometry.sip
+++ b/python/core/geometry/qgsgeometry.sip
@@ -80,6 +80,8 @@ class QgsGeometry
     static QgsGeometry fromMultiPolygon( const QgsMultiPolygon& multipoly );
     /** Creates a new geometry from a QgsRectangle */
     static QgsGeometry fromRect( const QgsRectangle& rect );
+    /** Creates a new multipart geometry from a list of QgsGeometry objects*/
+    static QgsGeometry collectGeometry( const QList< QgsGeometry >& geometries );
 
     /**
      * Set the geometry, feeding in a geometry in GEOS format.

--- a/python/core/qgsaggregatecalculator.sip
+++ b/python/core/qgsaggregatecalculator.sip
@@ -38,6 +38,7 @@ class QgsAggregateCalculator
       StringMinimumLength, //!< Minimum length of string (string fields only)
       StringMaximumLength, //!< Maximum length of string (string fields only)
       StringConcatenate, //! Concatenate values with a joining string (string fields only). Specify the delimiter using setDelimiter().
+      GeometryCollect, //! Create a multipart geometry from aggregated geometries
     };
 
     //! A bundle of parameters controlling aggregate calculation

--- a/resources/function_help/json/aggregate
+++ b/resources/function_help/json/aggregate
@@ -4,7 +4,7 @@
   "description": "Returns an aggregate value calculated using features from another layer.",
   "arguments": [
 	{"arg":"layer", "description":"a string, representing either a layer name or layer ID"},
-	{"arg":"aggregate", "description":"a string corresponding to the aggregate to calculate. Valid options are:<br /><ul><li>count</li><li>count_distinct</li><li>count_missing</li><li>min</li><li>max</li><li>sum</li><li>mean</li><li>median</li><li>stdev</li><li>stdevsample</li><li>range</li><li>minority</li><li>majority</li><li>q1: first quartile</li><li>q3: third quartile</li><li>iqr: inter quartile range</li><li>min_length: minimum string length</li><li>max_length: maximum string length</li><li>concatenate: join strings with a concatenator</li></ul>"},
+	{"arg":"aggregate", "description":"a string corresponding to the aggregate to calculate. Valid options are:<br /><ul><li>count</li><li>count_distinct</li><li>count_missing</li><li>min</li><li>max</li><li>sum</li><li>mean</li><li>median</li><li>stdev</li><li>stdevsample</li><li>range</li><li>minority</li><li>majority</li><li>q1: first quartile</li><li>q3: third quartile</li><li>iqr: inter quartile range</li><li>min_length: minimum string length</li><li>max_length: maximum string length</li><li>concatenate: join strings with a concatenator</li><li>collect: create an aggregated multipart geometry</li></ul>"},
 	{"arg":"calculation", "description":"sub expression or field name to aggregate"},
 	{"arg":"filter", "optional":true, "description":"optional filter expression to limit the features used for calculating the aggregate"},
 	{"arg":"concatenator", "optional":true, "description":"optional string to use to join values for 'concatenate' aggregate"}

--- a/resources/function_help/json/collect
+++ b/resources/function_help/json/collect
@@ -1,0 +1,13 @@
+{
+  "name": "collect",
+  "type": "function",
+  "description": "Returns the multipart geometry of aggregated geometries from an expression",
+  "arguments": [
+	{"arg":"expression", "description":"geometry expression to aggregate"},
+	{"arg":"group_by", "optional":true, "description":"optional expression to use to group aggregate calculations"},
+	{"arg":"filter", "optional":true, "description":"optional expression to use to filter features used to calculate aggregate"}
+  ],
+  "examples": [
+	{ "expression":"collect( $geometry )", "returns":"multipart geometry of aggregated geometries"}
+  ]
+}

--- a/src/core/geometry/qgsgeometry.cpp
+++ b/src/core/geometry/qgsgeometry.cpp
@@ -239,6 +239,27 @@ QgsGeometry QgsGeometry::fromRect( const QgsRectangle& rect )
   return fromPolygon( polygon );
 }
 
+QgsGeometry QgsGeometry::collectGeometry( const QList< QgsGeometry >& geometries )
+{
+  QgsGeometry collected;
+
+  QList< QgsGeometry >::const_iterator git = geometries.constBegin();
+  for ( ; git != geometries.constEnd(); ++git )
+  {
+    if ( collected.isEmpty() )
+    {
+      collected = QgsGeometry( *git );
+      collected.convertToMultiType();
+    }
+    else
+    {
+      QgsGeometry part = QgsGeometry( *git );
+      collected.addPart( &part );
+    }
+  }
+  return collected;
+}
+
 void QgsGeometry::fromWkb( unsigned char *wkb, int length )
 {
   detach( false );

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -132,6 +132,8 @@ class CORE_EXPORT QgsGeometry
     static QgsGeometry fromMultiPolygon( const QgsMultiPolygon& multipoly );
     /** Creates a new geometry from a QgsRectangle */
     static QgsGeometry fromRect( const QgsRectangle& rect );
+    /** Creates a new multipart geometry from a list of QgsGeometry objects*/
+    static QgsGeometry collectGeometry( const QList< QgsGeometry >& geometries );
 
     /**
      * Set the geometry, feeding in a geometry in GEOS format.

--- a/src/core/qgsaggregatecalculator.h
+++ b/src/core/qgsaggregatecalculator.h
@@ -64,6 +64,7 @@ class CORE_EXPORT QgsAggregateCalculator
       StringMinimumLength, //!< Minimum length of string (string fields only)
       StringMaximumLength, //!< Maximum length of string (string fields only)
       StringConcatenate, //! Concatenate values with a joining string (string fields only). Specify the delimiter using setDelimiter().
+      GeometryCollect //! Create a multipart geometry from aggregated geometries
     };
 
     //! A bundle of parameters controlling aggregate calculation
@@ -160,6 +161,7 @@ class CORE_EXPORT QgsAggregateCalculator
 
     static QVariant calculateDateTimeAggregate( QgsFeatureIterator& fit, int attr, QgsExpression* expression,
         QgsExpressionContext* context, QgsDateTimeStatisticalSummary::Statistic stat );
+    static QVariant calculateGeometryAggregate( QgsFeatureIterator& fit, QgsExpression* expression, QgsExpressionContext* context );
 
     static QVariant calculate( Aggregate aggregate, QgsFeatureIterator& fit, QVariant::Type resultType,
                                int attr, QgsExpression* expression,

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -945,6 +945,11 @@ static QVariant fcnAggregateMaxLength( const QVariantList& values, const QgsExpr
   return fcnAggregateGeneric( QgsAggregateCalculator::StringMaximumLength, values, QgsAggregateCalculator::AggregateParameters(), context, parent );
 }
 
+static QVariant fcnAggregateCollectGeometry( const QVariantList& values, const QgsExpressionContext* context, QgsExpression *parent )
+{
+  return fcnAggregateGeneric( QgsAggregateCalculator::GeometryCollect, values, QgsAggregateCalculator::AggregateParameters(), context, parent );
+}
+
 static QVariant fcnAggregateStringConcat( const QVariantList& values, const QgsExpressionContext* context, QgsExpression *parent )
 {
   QgsAggregateCalculator::AggregateParameters parameters;
@@ -3150,7 +3155,7 @@ const QStringList& QgsExpression::BuiltinFunctions()
     << "aggregate" << "relation_aggregate" << "count" << "count_distinct"
     << "count_missing" << "minimum" << "maximum" << "sum" << "mean"
     << "median" << "stdev" << "range" << "minority" << "majority"
-    << "q1" << "q3" << "iqr" << "min_length" << "max_length" << "concatenate"
+    << "q1" << "q3" << "iqr" << "min_length" << "max_length" << "collect" << "concatenate"
     << "attribute" << "var" << "layer_property"
     << "$id" << "$scale" << "_specialcol_";
   }
@@ -3214,7 +3219,7 @@ const QList<QgsExpression::Function*>& QgsExpression::Functions()
     << new StaticFunction( "coalesce", -1, fcnCoalesce, "Conditionals", QString(), false, QStringList(), false, QStringList(), true )
     << new StaticFunction( "if", 3, fcnIf, "Conditionals", QString(), False, QStringList(), true )
     << new StaticFunction( "aggregate", ParameterList() << Parameter( "layer" ) << Parameter( "aggregate" ) << Parameter( "expression" )
-                           << Parameter( "filter", true ) << Parameter( "concatenator", true ), fcnAggregate, "Aggregates", QString(), False, QStringList(), true )
+                           << Parameter( "filter", true ) << Parameter( "concatenator", true ), fcnAggregate, "Aggregates", QString(), false, QStringList(), true )
     << new StaticFunction( "relation_aggregate", ParameterList() << Parameter( "relation" ) << Parameter( "aggregate" ) << Parameter( "expression" ) << Parameter( "concatenator", true ),
                            fcnAggregateRelation, "Aggregates", QString(), False, QStringList( QgsFeatureRequest::AllAttributes ), true )
 
@@ -3235,6 +3240,7 @@ const QList<QgsExpression::Function*>& QgsExpression::Functions()
     << new StaticFunction( "iqr", aggParams, fcnAggregateIQR, "Aggregates", QString(), False, QStringList(), true )
     << new StaticFunction( "min_length", aggParams, fcnAggregateMinLength, "Aggregates", QString(), False, QStringList(), true )
     << new StaticFunction( "max_length", aggParams, fcnAggregateMaxLength, "Aggregates", QString(), False, QStringList(), true )
+    << new StaticFunction( "collect", aggParams, fcnAggregateCollectGeometry, "Aggregates", QString(), False, QStringList(), true )
     << new StaticFunction( "concatenate", aggParams << Parameter( "concatenator", true ), fcnAggregateStringConcat, "Aggregates", QString(), False, QStringList(), true )
 
     << new StaticFunction( "regexp_match", 2, fcnRegexpMatch, "Conditionals" )

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -116,26 +116,32 @@ class TestQgsExpression: public QObject
       mAggregatesLayer = new QgsVectorLayer( "Point?field=col1:integer&field=col2:string&field=col3:integer", "aggregate_layer", "memory" );
       QVERIFY( mAggregatesLayer->isValid() );
       QgsFeature af1( mAggregatesLayer->dataProvider()->fields(), 1 );
+      af1.setGeometry( QgsGeometry::fromPoint( QgsPoint( 0, 0 ) ) );
       af1.setAttribute( "col1", 4 );
       af1.setAttribute( "col2", "test" );
       af1.setAttribute( "col3", 2 );
       QgsFeature af2( mAggregatesLayer->dataProvider()->fields(), 2 );
+      af2.setGeometry( QgsGeometry::fromPoint( QgsPoint( 1, 0 ) ) );
       af2.setAttribute( "col1", 2 );
       af2.setAttribute( "col2", QVariant( QVariant::String ) );
       af2.setAttribute( "col3", 1 );
       QgsFeature af3( mAggregatesLayer->dataProvider()->fields(), 3 );
+      af3.setGeometry( QgsGeometry::fromPoint( QgsPoint( 2, 0 ) ) );
       af3.setAttribute( "col1", 3 );
       af3.setAttribute( "col2", "test333" );
       af3.setAttribute( "col3", 2 );
       QgsFeature af4( mAggregatesLayer->dataProvider()->fields(), 4 );
+      af4.setGeometry( QgsGeometry::fromPoint( QgsPoint( 3, 0 ) ) );
       af4.setAttribute( "col1", 2 );
       af4.setAttribute( "col2", "test4" );
       af4.setAttribute( "col3", 2 );
       QgsFeature af5( mAggregatesLayer->dataProvider()->fields(), 5 );
+      af5.setGeometry( QgsGeometry::fromPoint( QgsPoint( 4, 0 ) ) );
       af5.setAttribute( "col1", 5 );
       af5.setAttribute( "col2", QVariant( QVariant::String ) );
       af5.setAttribute( "col3", 3 );
       QgsFeature af6( mAggregatesLayer->dataProvider()->fields(), 6 );
+      af6.setGeometry( QgsGeometry::fromPoint( QgsPoint( 5, 0 ) ) );
       af6.setAttribute( "col1", 8 );
       af6.setAttribute( "col2", "test4" );
       af6.setAttribute( "col3", 3 );
@@ -1213,6 +1219,8 @@ class TestQgsExpression: public QObject
       QTest::newRow( "string aggregate 2" ) << "aggregate('test','min_length',\"col2\")" << false << QVariant( 5 );
       QTest::newRow( "string concatenate" ) << "aggregate('test','concatenate',\"col2\",concatenator:=' , ')" << false << QVariant( "test1 , test2 , test3 , test4" );
 
+      QTest::newRow( "geometry collect" ) << "geom_to_wkt(aggregate('aggregate_layer','collect',$geometry))" << false << QVariant( QString( "MultiPoint ((0 0),(1 0),(2 0),(3 0),(4 0),(5 0))" ) );
+
       QTest::newRow( "sub expression" ) << "aggregate('test','sum',\"col1\" * 2)" << false << QVariant( 65 * 2 );
       QTest::newRow( "bad sub expression" ) << "aggregate('test','sum',\"xcvxcv\" * 2)" << true << QVariant();
 
@@ -1288,6 +1296,8 @@ class TestQgsExpression: public QObject
       QTest::newRow( "min_length" ) << "min_length(\"col2\")" << false << QVariant( 0 );
       QTest::newRow( "max_length" ) << "max_length(\"col2\")" << false << QVariant( 7 );
       QTest::newRow( "concatenate" ) << "concatenate(\"col2\",concatenator:=',')" << false << QVariant( "test,,test333,test4,,test4" );
+
+      QTest::newRow( "geometry collect" ) << "geom_to_wkt(collect($geometry))" << false << QVariant( QString( "MultiPoint ((0 0),(1 0),(2 0),(3 0),(4 0),(5 0))" ) );
 
       QTest::newRow( "bad expression" ) << "sum(\"xcvxcvcol1\")" << true << QVariant();
       QTest::newRow( "aggregate named" ) << "sum(expression:=\"col1\")" << false << QVariant( 24.0 );

--- a/tests/src/python/test_qgsgeometry.py
+++ b/tests/src/python/test_qgsgeometry.py
@@ -1346,6 +1346,45 @@ class TestQgsGeometry(unittest.TestCase):
         line = QgsGeometry.fromPolyline(points)
         assert line.boundingBox().isNull()
 
+    def testCollectGeometry(self):
+        # collect points
+        geometries = [QgsGeometry.fromPoint(QgsPoint(0, 0)), QgsGeometry.fromPoint(QgsPoint(1, 1))]
+        geometry = QgsGeometry.collectGeometry(geometries)
+        expwkt = "MultiPoint ((0 0), (1 1))"
+        wkt = geometry.exportToWkt()
+        assert compareWkt(expwkt, wkt), "Expected:\n%s\nGot:\n%s\n" % (expwkt, wkt)
+
+        # collect lines
+        points = [
+            [QgsPoint(0, 0), QgsPoint(1, 0)],
+            [QgsPoint(2, 0), QgsPoint(3, 0)]
+        ]
+        geometries = [QgsGeometry.fromPolyline(points[0]), QgsGeometry.fromPolyline(points[1])]
+        geometry = QgsGeometry.collectGeometry(geometries)
+        expwkt = "MultiLineString ((0 0, 1 0), (2 0, 3 0))"
+        wkt = geometry.exportToWkt()
+        assert compareWkt(expwkt, wkt), "Expected:\n%s\nGot:\n%s\n" % (expwkt, wkt)
+
+        # collect polygons
+        points = [
+            [[QgsPoint(0, 0), QgsPoint(1, 0), QgsPoint(1, 1), QgsPoint(0, 1), QgsPoint(0, 0)]],
+            [[QgsPoint(2, 0), QgsPoint(3, 0), QgsPoint(3, 1), QgsPoint(2, 1), QgsPoint(2, 0)]]
+        ]
+        geometries = [QgsGeometry.fromPolygon(points[0]), QgsGeometry.fromPolygon(points[1])]
+        geometry = QgsGeometry.collectGeometry(geometries)
+        expwkt = "MultiPolygon (((0 0, 1 0, 1 1, 0 1, 0 0)),((2 0, 3 0, 3 1, 2 1, 2 0)))"
+        wkt = geometry.exportToWkt()
+        assert compareWkt(expwkt, wkt), "Expected:\n%s\nGot:\n%s\n" % (expwkt, wkt)
+
+        # test empty list
+        geometries = []
+        geometry = QgsGeometry.collectGeometry(geometries)
+        assert geometry.isEmpty(), "Expected geometry to be empty"
+
+        # check that the resulting geometry is multi
+        geometry = QgsGeometry.collectGeometry([QgsGeometry.fromWkt('Point (0 0)')])
+        assert geometry.isMultipart(), "Expected collected geometry to be multipart"
+
     def testAddPart(self):
         # add a part to a multipoint
         points = [QgsPoint(0, 0), QgsPoint(1, 0)]


### PR DESCRIPTION
This PR adds a "collect" geometry method to the aggregate() function to allow for the creation a multipart geometry representing the sum of aggregated geometries. 

This opens the door to all sorts of interesting expression-based geometry manipulation and checks / rules. For e.g., creating a rule-based symbology that highlights in green concessions (i.e. polygons) intersecting a flight path:
![aggregate](https://cloud.githubusercontent.com/assets/1728657/17846347/283355f0-6872-11e6-821b-230decaf4989.png)
_the rule used to color the polygons in green is: intersects($geometry,aggregate('flight_path_layer','collect',$geometry))_

@nyalldawson , how does this look?
