### PR TITLE
Reword delete button in service connection dialog

### DIFF
--- a/src/ui/qgsowssourceselectbase.ui
+++ b/src/ui/qgsowssourceselectbase.ui
@@ -68,6 +68,9 @@
         <layout class="QHBoxLayout" name="horizontalLayout_3">
          <item>
           <widget class="QPushButton" name="mConnectButton">
+           <property name="toolTip">
+            <string>Connect to selected service</string>
+           </property>
            <property name="enabled">
             <bool>false</bool>
            </property>
@@ -78,6 +81,9 @@
          </item>
          <item>
           <widget class="QPushButton" name="mNewButton">
+           <property name="toolTip">
+            <string>Create a new service connection</string>
+           </property>
            <property name="text">
             <string>&amp;New</string>
            </property>
@@ -85,6 +91,9 @@
          </item>
          <item>
           <widget class="QPushButton" name="mEditButton">
+           <property name="toolTip">
+            <string>Edit selected service connection</string>
+           </property>
            <property name="enabled">
             <bool>false</bool>
            </property>
@@ -95,11 +104,14 @@
          </item>
          <item>
           <widget class="QPushButton" name="mDeleteButton">
+           <property name="toolTip">
+            <string>Remove connection to selected service</string>
+           </property>
            <property name="enabled">
             <bool>false</bool>
            </property>
            <property name="text">
-            <string>Delete</string>
+            <string>Remove</string>
            </property>
           </widget>
          </item>

--- a/src/ui/qgssourceselectdialogbase.ui
+++ b/src/ui/qgssourceselectdialogbase.ui
@@ -24,6 +24,9 @@
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
          <widget class="QPushButton" name="btnConnect">
+          <property name="toolTip">
+           <string>Connect to selected database</string>
+          </property>
           <property name="enabled">
            <bool>false</bool>
           </property>
@@ -34,6 +37,9 @@
         </item>
         <item>
          <widget class="QPushButton" name="btnNew">
+          <property name="toolTip">
+           <string>Create a new database connection</string>
+          </property>
           <property name="text">
            <string>&amp;New</string>
           </property>
@@ -41,6 +47,9 @@
         </item>
         <item>
          <widget class="QPushButton" name="btnEdit">
+          <property name="toolTip">
+           <string>Edit selected database connection</string>
+          </property>
           <property name="enabled">
            <bool>false</bool>
           </property>
@@ -51,6 +60,9 @@
         </item>
         <item>
          <widget class="QPushButton" name="btnDelete">
+          <property name="toolTip">
+           <string>Remove connection to selected database</string>
+          </property>
           <property name="enabled">
            <bool>false</bool>
           </property>

--- a/src/ui/qgswfssourceselectbase.ui
+++ b/src/ui/qgswfssourceselectbase.ui
@@ -53,6 +53,9 @@
        <layout class="QHBoxLayout" name="horizontalLayout">
         <item>
          <widget class="QPushButton" name="btnConnect">
+          <property name="toolTip">
+           <string>Connect to selected service</string>
+          </property>
           <property name="enabled">
            <bool>false</bool>
           </property>
@@ -63,6 +66,9 @@
         </item>
         <item>
          <widget class="QPushButton" name="btnNew">
+          <property name="toolTip">
+           <string>Create a new service connection</string>
+          </property>
           <property name="text">
            <string>&amp;New</string>
           </property>
@@ -70,6 +76,9 @@
         </item>
         <item>
          <widget class="QPushButton" name="btnEdit">
+          <property name="toolTip">
+           <string>Edit selected service connection</string>
+          </property>
           <property name="enabled">
            <bool>false</bool>
           </property>
@@ -80,11 +89,14 @@
         </item>
         <item>
          <widget class="QPushButton" name="btnDelete">
+          <property name="toolTip">
+           <string>Remove connection to selected service</string>
+          </property>
           <property name="enabled">
            <bool>false</bool>
           </property>
           <property name="text">
-           <string>Delete</string>
+           <string>Remove</string>
           </property>
          </widget>
         </item>

--- a/src/ui/qgswmssourceselectbase.ui
+++ b/src/ui/qgswmssourceselectbase.ui
@@ -66,6 +66,9 @@
        </item>
        <item row="1" column="0" colspan="2">
         <widget class="QPushButton" name="btnConnect">
+        <property name="toolTip">
+          <string>Connect to selected service</string>
+         </property>
          <property name="enabled">
           <bool>false</bool>
          </property>
@@ -76,6 +79,9 @@
        </item>
        <item row="1" column="2" colspan="2">
         <widget class="QPushButton" name="btnNew">
+         <property name="toolTip">
+          <string>Create a new service connection</string>
+         </property>
          <property name="text">
           <string>&amp;New</string>
          </property>
@@ -83,6 +89,9 @@
        </item>
        <item row="1" column="4">
         <widget class="QPushButton" name="btnEdit">
+         <property name="toolTip">
+          <string>Edit selected service connection</string>
+         </property>
          <property name="enabled">
           <bool>false</bool>
          </property>
@@ -93,11 +102,14 @@
        </item>
        <item row="1" column="5">
         <widget class="QPushButton" name="btnDelete">
+         <property name="toolTip">
+          <string>Remove connection to selected service</string>
+         </property>
          <property name="enabled">
           <bool>false</bool>
          </property>
          <property name="text">
-          <string>Delete</string>
+          <string>Remove</string>
          </property>
         </widget>
        </item>


### PR DESCRIPTION
This PR aims to have similar button name for all connexion dialog (WMS, WFS, WCS, Oracle, MSSQL, Spatialite and PostGIS).

Similar to c7a4e5a065bdf1c606e5f24d728978f0789cff17

Backport to 2.16 will be great as the above commit is for such release.
