### PR TITLE
BACKPORT: Fixed issue where opening an invalid spatialite db fails and gives and poor warning message

### DIFF
--- a/src/providers/spatialite/qgsspatialitesourceselect.cpp
+++ b/src/providers/spatialite/qgsspatialitesourceselect.cpp
@@ -461,6 +461,10 @@ void QgsSpatiaLiteSourceSelect::on_btnConnect_clicked()
         QMessageBox::critical( this, tr( "SpatiaLite getTableInfo Error" ),
                                tr( "Failure exploring tables from: %1\n\n%2" ).arg( mSqlitePath, errCause ) );
         break;
+      case QgsSpatiaLiteConnection::FailedToCheckMetadata:
+        QMessageBox::critical( this, tr( "SpatiaLite metadata check failed"  ),
+                               tr( "Failure getting table metadata ... is this really a SpatialLite database? %1\n\n%2" ).arg( mSqlitePath, errCause ) );
+        break;
       default:
         QMessageBox::critical( this, tr( "SpatiaLite Error" ),
                                tr( "Unexpected error when working with: %1\n\n%2" ).arg( mSqlitePath, errCause ) );


### PR DESCRIPTION
Fixed issue where opening an invalid spatialite db fails and gives and poor warning message
