### PR TITLE
[FEATURE] Make map unit scaling dialog show inline in style dock

### DIFF
--- a/python/gui/qgsunitselectionwidget.sip
+++ b/python/gui/qgsunitselectionwidget.sip
@@ -1,4 +1,63 @@
-/** Dialog allowing the user to choose the minimum and maximum scale of an object in map units */
+/** \class QgsMapUnitScaleWidget
+ * \ingroup gui
+ * A widget which allows the user to choose the minimum and maximum scale of an object in map units
+ * and millimetres. This widget is designed to allow users to edit the properties of a
+ * QgsMapUnitScale object.
+ * \note added in QGIS 3.0
+ * \see QgsMapUnitScaleDialog
+ * \see QgsUnitSelectionWidget
+*/
+class QgsMapUnitScaleWidget : QgsPanelWidget
+{
+%TypeHeaderCode
+#include <qgsunitselectionwidget.h>
+%End
+  public:
+
+    /** Constructor for QgsMapUnitScaleWidget.
+     * @param parent parent widget
+     */
+    QgsMapUnitScaleWidget( QWidget* parent /TransferThis/ = nullptr );
+
+    /** Returns a QgsMapUnitScale representing the settings shown in the
+     * widget.
+     * @see setMapUnitScale()
+     * @see mapUnitScaleChanged()
+     */
+    QgsMapUnitScale mapUnitScale() const;
+
+    /** Updates the widget to reflect the settings from the specified
+     * QgsMapUnitScale object.
+     * @param scale map unit scale to show in widget
+     * @see mapUnitScale()
+     * @see mapUnitScaleChanged()
+     */
+    void setMapUnitScale( const QgsMapUnitScale& scale );
+
+    /** Sets the map canvas associated with the widget. This allows the
+     * widget to retrieve the current map scale from the canvas.
+     * @param canvas map canvas
+     */
+    void setMapCanvas( QgsMapCanvas* canvas );
+
+  signals:
+
+    /** Emitted when the settings in the widget are modified.
+     * @param scale QgsMapUnitScale reflecting new settings from the widget
+     */
+    void mapUnitScaleChanged( const QgsMapUnitScale& scale );
+
+};
+
+
+/** \class QgsMapUnitScaleDialog
+ * \ingroup gui
+ * A dialog which allows the user to choose the minimum and maximum scale of an object in map units
+ * and millimetres. This dialog is designed to allow users to edit the properties of a
+ * QgsMapUnitScale object.
+ * \see QgsMapUnitScaleWidget
+ * \see QgsUnitSelectionWidget
+*/
 class QgsMapUnitScaleDialog : QDialog
 {
 %TypeHeaderCode
@@ -6,11 +65,23 @@ class QgsMapUnitScaleDialog : QDialog
 %End
 
   public:
+
+    /** Constructor for QgsMapUnitScaleDialog.
+     * @param parent parent widget
+     */
     QgsMapUnitScaleDialog( QWidget* parent /TransferThis/ = 0);
 
-    /** Returns the map unit scale */
+    /** Returns a QgsMapUnitScale representing the settings shown in the
+     * dialog.
+     * @see setMapUnitScale()
+     */
     QgsMapUnitScale getMapUnitScale() const;
-    /** Sets the map unit scale */
+
+    /** Updates the dialog to reflect the settings from the specified
+     * QgsMapUnitScale object.
+     * @param scale map unit scale to show in dialog
+     * @see mapUnitScale()
+     */
     void setMapUnitScale( const QgsMapUnitScale& scale );
 
     /** Sets the map canvas associated with the dialog. This allows the dialog to retrieve the current
@@ -22,8 +93,14 @@ class QgsMapUnitScaleDialog : QDialog
 
 };
 
-/** Widget displaying a combobox allowing the user to choose between millimeter and map units
- *  If the user chooses map units,  a button appears allowing the specification of minimum and maximum scale */
+/** \class QgsUnitSelectionWidget
+ * \ingroup gui
+ * A widget displaying a combobox allowing the user to choose between various display units,
+ * such as millimeters or map unit. If the user chooses map units, a button appears allowing
+ * adjustment of minimum and maximum scaling.
+ * \see QgsMapUnitScaleWidget
+ * \see QgsMapUnitScaleDialog
+ */
 class QgsUnitSelectionWidget : QWidget
 {
 %TypeHeaderCode
@@ -31,6 +108,10 @@ class QgsUnitSelectionWidget : QWidget
 %End
 
   public:
+
+    /** Constructor for QgsUnitSelectionWidget.
+     * @param parent parent widget
+     */
     QgsUnitSelectionWidget( QWidget* parent /TransferThis/ = 0 );
 
     /** Sets the units which the user can choose from in the combobox.

--- a/src/gui/qgsunitselectionwidget.h
+++ b/src/gui/qgsunitselectionwidget.h
@@ -19,24 +19,105 @@
 #define QGSUNITSELECTIONWIDGET_H
 
 #include <QWidget>
+#include <QDialog>
+#include "qgspanelwidget.h"
 #include "qgssymbol.h"
 #include "ui_qgsunitselectionwidget.h"
-#include "ui_qgsmapunitscaledialog.h"
+#include "ui_qgsmapunitscalewidgetbase.h"
 
 class QgsMapCanvas;
 
-/** \ingroup gui
- * Dialog allowing the user to choose the minimum and maximum scale of an object in map units */
-class GUI_EXPORT QgsMapUnitScaleDialog : public QDialog, private Ui::QgsMapUnitScaleDialog
+/** \class QgsMapUnitScaleWidget
+ * \ingroup gui
+ * A widget which allows the user to choose the minimum and maximum scale of an object in map units
+ * and millimetres. This widget is designed to allow users to edit the properties of a
+ * QgsMapUnitScale object.
+ * \note added in QGIS 3.0
+ * \see QgsMapUnitScaleDialog
+ * \see QgsUnitSelectionWidget
+*/
+class GUI_EXPORT QgsMapUnitScaleWidget : public QgsPanelWidget, private Ui::QgsMapUnitScaleWidgetBase
 {
     Q_OBJECT
+    Q_PROPERTY( QgsMapUnitScale mapUnitScale READ mapUnitScale WRITE setMapUnitScale NOTIFY mapUnitScaleChanged )
 
   public:
+
+    /** Constructor for QgsMapUnitScaleWidget.
+     * @param parent parent widget
+     */
+    QgsMapUnitScaleWidget( QWidget* parent = nullptr );
+
+    /** Returns a QgsMapUnitScale representing the settings shown in the
+     * widget.
+     * @see setMapUnitScale()
+     * @see mapUnitScaleChanged()
+     */
+    QgsMapUnitScale mapUnitScale() const;
+
+    /** Updates the widget to reflect the settings from the specified
+     * QgsMapUnitScale object.
+     * @param scale map unit scale to show in widget
+     * @see mapUnitScale()
+     * @see mapUnitScaleChanged()
+     */
+    void setMapUnitScale( const QgsMapUnitScale& scale );
+
+    /** Sets the map canvas associated with the widget. This allows the
+     * widget to retrieve the current map scale from the canvas.
+     * @param canvas map canvas
+     */
+    void setMapCanvas( QgsMapCanvas* canvas );
+
+  signals:
+
+    /** Emitted when the settings in the widget are modified.
+     * @param scale QgsMapUnitScale reflecting new settings from the widget
+     */
+    void mapUnitScaleChanged( const QgsMapUnitScale& scale );
+
+  private slots:
+    void configureMinComboBox();
+    void configureMaxComboBox();
+    void settingsChanged();
+
+  private:
+
+    bool mBlockSignals;
+
+};
+
+/** \class QgsMapUnitScaleDialog
+ * \ingroup gui
+ * A dialog which allows the user to choose the minimum and maximum scale of an object in map units
+ * and millimetres. This dialog is designed to allow users to edit the properties of a
+ * QgsMapUnitScale object.
+ * \see QgsMapUnitScaleWidget
+ * \see QgsUnitSelectionWidget
+*/
+class GUI_EXPORT QgsMapUnitScaleDialog : public QDialog
+{
+    Q_OBJECT
+    Q_PROPERTY( QgsMapUnitScale mapUnitScale READ getMapUnitScale WRITE setMapUnitScale )
+
+  public:
+
+    /** Constructor for QgsMapUnitScaleDialog.
+     * @param parent parent widget
+     */
     QgsMapUnitScaleDialog( QWidget* parent = nullptr );
 
-    /** Returns the map unit scale */
+    /** Returns a QgsMapUnitScale representing the settings shown in the
+     * dialog.
+     * @see setMapUnitScale()
+     */
     QgsMapUnitScale getMapUnitScale() const;
-    /** Sets the map unit scale */
+
+    /** Updates the dialog to reflect the settings from the specified
+     * QgsMapUnitScale object.
+     * @param scale map unit scale to show in dialog
+     * @see mapUnitScale()
+     */
     void setMapUnitScale( const QgsMapUnitScale& scale );
 
     /** Sets the map canvas associated with the dialog. This allows the dialog to retrieve the current
@@ -46,24 +127,29 @@ class GUI_EXPORT QgsMapUnitScaleDialog : public QDialog, private Ui::QgsMapUnitS
      */
     void setMapCanvas( QgsMapCanvas* canvas );
 
-  private slots:
-    void configureMinComboBox();
-    void configureMaxComboBox();
+  private:
+
+    QgsMapUnitScaleWidget* mWidget;
 
 };
 
-/** \ingroup gui
- * Widget displaying a combobox allowing the user to choose between millimeter and map units
- *  If the user chooses map units,  a button appears allowing the specification of minimum and maximum scale */
+/** \class QgsUnitSelectionWidget
+ * \ingroup gui
+ * A widget displaying a combobox allowing the user to choose between various display units,
+ * such as millimeters or map unit. If the user chooses map units, a button appears allowing
+ * adjustment of minimum and maximum scaling.
+ * \see QgsMapUnitScaleWidget
+ * \see QgsMapUnitScaleDialog
+ */
 class GUI_EXPORT QgsUnitSelectionWidget : public QWidget, private Ui::QgsUnitSelectionWidget
 {
     Q_OBJECT
 
-  private:
-    QgsMapUnitScaleDialog* mUnitScaleDialog;
-    int mMapUnitIdx;
-
   public:
+
+    /** Constructor for QgsUnitSelectionWidget.
+     * @param parent parent widget
+     */
     QgsUnitSelectionWidget( QWidget* parent = nullptr );
 
     /** Sets the units which the user can choose from in the combobox.
@@ -99,10 +185,10 @@ class GUI_EXPORT QgsUnitSelectionWidget : public QWidget, private Ui::QgsUnitSel
     void setUnit( QgsUnitTypes::RenderUnit unit );
 
     /** Returns the map unit scale */
-    QgsMapUnitScale getMapUnitScale() const { return mUnitScaleDialog->getMapUnitScale(); }
+    QgsMapUnitScale getMapUnitScale() const { return mMapUnitScale; }
 
     /** Sets the map unit scale */
-    void setMapUnitScale( const QgsMapUnitScale& scale ) { mUnitScaleDialog->setMapUnitScale( scale ); }
+    void setMapUnitScale( const QgsMapUnitScale& scale ) { mMapUnitScale = scale; }
 
     /** Sets the map canvas associated with the widget. This allows the widget to retrieve the current
      * map scale from the canvas.
@@ -117,6 +203,12 @@ class GUI_EXPORT QgsUnitSelectionWidget : public QWidget, private Ui::QgsUnitSel
   private slots:
     void showDialog();
     void toggleUnitRangeButton();
+    void widgetChanged( const QgsMapUnitScale& scale );
+
+  private:
+    QgsMapUnitScale mMapUnitScale;
+    int mMapUnitIdx;
+    QgsMapCanvas* mCanvas;
 
 };
 

--- a/src/ui/qgsmapunitscalewidgetbase.ui
+++ b/src/ui/qgsmapunitscalewidgetbase.ui
@@ -1,13 +1,13 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <ui version="4.0">
- <class>QgsMapUnitScaleDialog</class>
- <widget class="QDialog" name="QgsMapUnitScaleDialog">
+ <class>QgsMapUnitScaleWidgetBase</class>
+ <widget class="QgsPanelWidget" name="QgsMapUnitScaleWidgetBase">
   <property name="geometry">
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>443</width>
-    <height>291</height>
+    <width>316</width>
+    <height>276</height>
    </rect>
   </property>
   <property name="windowTitle">
@@ -18,67 +18,19 @@
     <normaloff>:/images/themes/default/mActionOptions.png</normaloff>:/images/themes/default/mActionOptions.png</iconset>
   </property>
   <layout class="QGridLayout" name="gridLayout">
-   <item row="3" column="0" colspan="3">
-    <widget class="QGroupBox" name="groupBox_2">
-     <property name="title">
-      <string>Size range</string>
-     </property>
-     <layout class="QGridLayout" name="gridLayout_3">
-      <item row="1" column="0">
-       <widget class="QCheckBox" name="mCheckBoxMinSize">
-        <property name="text">
-         <string>Minimum size:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="0">
-       <widget class="QCheckBox" name="mCheckBoxMaxSize">
-        <property name="text">
-         <string>Maximum size:</string>
-        </property>
-       </widget>
-      </item>
-      <item row="1" column="1">
-       <widget class="QgsDoubleSpinBox" name="mSpinBoxMinSize">
-        <property name="suffix">
-         <string> mm</string>
-        </property>
-        <property name="maximum">
-         <double>9999999.000000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="2" column="1">
-       <widget class="QgsDoubleSpinBox" name="mSpinBoxMaxSize">
-        <property name="suffix">
-         <string> mm</string>
-        </property>
-        <property name="maximum">
-         <double>999999.000000000000000</double>
-        </property>
-       </widget>
-      </item>
-      <item row="0" column="0" colspan="2">
-       <widget class="QLabel" name="label_2">
-        <property name="text">
-         <string>Scale only within the following size range:</string>
-        </property>
-       </widget>
-      </item>
-     </layout>
-    </widget>
-   </item>
-   <item row="5" column="0" colspan="3">
-    <widget class="QDialogButtonBox" name="mButtonBox">
-     <property name="orientation">
-      <enum>Qt::Horizontal</enum>
-     </property>
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
-   <item row="0" column="0" colspan="3">
+   <property name="leftMargin">
+    <number>3</number>
+   </property>
+   <property name="topMargin">
+    <number>3</number>
+   </property>
+   <property name="rightMargin">
+    <number>3</number>
+   </property>
+   <property name="bottomMargin">
+    <number>3</number>
+   </property>
+   <item row="0" column="0" colspan="2">
     <widget class="QGroupBox" name="groupBox">
      <property name="title">
       <string>Scale range</string>
@@ -138,6 +90,56 @@
      </property>
     </spacer>
    </item>
+   <item row="3" column="0" colspan="2">
+    <widget class="QGroupBox" name="groupBox_2">
+     <property name="title">
+      <string>Size range</string>
+     </property>
+     <layout class="QGridLayout" name="gridLayout_3">
+      <item row="1" column="0">
+       <widget class="QCheckBox" name="mCheckBoxMinSize">
+        <property name="text">
+         <string>Minimum size:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QCheckBox" name="mCheckBoxMaxSize">
+        <property name="text">
+         <string>Maximum size:</string>
+        </property>
+       </widget>
+      </item>
+      <item row="1" column="1">
+       <widget class="QgsDoubleSpinBox" name="mSpinBoxMinSize">
+        <property name="suffix">
+         <string> mm</string>
+        </property>
+        <property name="maximum">
+         <double>9999999.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="1">
+       <widget class="QgsDoubleSpinBox" name="mSpinBoxMaxSize">
+        <property name="suffix">
+         <string> mm</string>
+        </property>
+        <property name="maximum">
+         <double>999999.000000000000000</double>
+        </property>
+       </widget>
+      </item>
+      <item row="0" column="0" colspan="2">
+       <widget class="QLabel" name="label_2">
+        <property name="text">
+         <string>Scale only within the following size range:</string>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
   </layout>
  </widget>
  <customwidgets>
@@ -151,6 +153,11 @@
    <extends>QDoubleSpinBox</extends>
    <header>qgsdoublespinbox.h</header>
   </customwidget>
+  <customwidget>
+   <class>QgsPanelWidget</class>
+   <extends>QWidget</extends>
+   <header>qgspanelwidget.h</header>
+  </customwidget>
  </customwidgets>
  <tabstops>
   <tabstop>mCheckBoxMinScale</tabstop>
@@ -163,38 +170,5 @@
   <tabstop>mSpinBoxMaxSize</tabstop>
  </tabstops>
  <resources/>
- <connections>
-  <connection>
-   <sender>mButtonBox</sender>
-   <signal>accepted()</signal>
-   <receiver>QgsMapUnitScaleDialog</receiver>
-   <slot>accept()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>248</x>
-     <y>254</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>157</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
-  <connection>
-   <sender>mButtonBox</sender>
-   <signal>rejected()</signal>
-   <receiver>QgsMapUnitScaleDialog</receiver>
-   <slot>reject()</slot>
-   <hints>
-    <hint type="sourcelabel">
-     <x>316</x>
-     <y>260</y>
-    </hint>
-    <hint type="destinationlabel">
-     <x>286</x>
-     <y>274</y>
-    </hint>
-   </hints>
-  </connection>
- </connections>
+ <connections/>
 </ui>


### PR DESCRIPTION
This makes the map unit scaling dialog (the dialog which appears when setting a symbol/label size to map units and clicking the spanner icon) show inline in the style dock panel. Much easier for interactively tweaking these settings while being able to zoom in/out of the map and immediately see the result.
