### PR TITLE
[Processing] Do not set "None" value in batch panel string widgets

### DIFF
--- a/python/plugins/processing/gui/BatchPanel.py
+++ b/python/plugins/processing/gui/BatchPanel.py
@@ -170,10 +170,11 @@ class BatchPanel(BASE, WIDGET):
             self.tblParameters.setColumnWidth(col, width)
         else:
             item = QLineEdit()
-            try:
-                item.setText(unicode(param.default))
-            except:
-                pass
+            if param.default is not None:
+                try:
+                    item.setText(unicode(param.default))
+                except:
+                    pass
 
         return item
 


### PR DESCRIPTION
For now, when I open an batch algorithm dialog, all string widget without default values are filled with "None". Here I fix that.
