### PR TITLE
Remove composer window visibiliy state restoration upon project load (fixes #15495)

### DIFF
--- a/src/app/composer/qgscomposer.cpp
+++ b/src/app/composer/qgscomposer.cpp
@@ -3479,15 +3479,6 @@ void QgsComposer::writeXml( QDomNode& parentNode, QDomDocument& doc )
   }
   mMapsToRestore.clear();
 
-  //store if composer is open or closed
-  if ( isVisible() )
-  {
-    composerElem.setAttribute( "visible", 1 );
-  }
-  else
-  {
-    composerElem.setAttribute( "visible", 0 );
-  }
   parentNode.appendChild( composerElem );
 
   //store composition

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -6606,17 +6606,12 @@ bool QgisApp::loadComposersFromProject( const QDomDocument& doc )
     mPrintComposersMenu->addAction( composer->windowAction() );
 #ifndef Q_OS_MACX
     composer->setWindowState( Qt::WindowMinimized );
-    composer->show();
 #endif
     composer->zoomFull();
     QgsComposerView* composerView = composer->view();
     if ( composerView )
     {
       composerView->updateRulers();
-    }
-    if ( composerNodes.at( i ).toElement().attribute( "visible", "1" ).toInt() < 1 )
-    {
-      composer->close();
     }
     emit composerAdded( composer->view() );
     connect( composer, SIGNAL( composerAdded( QgsComposerView* ) ), this, SIGNAL( composerAdded( QgsComposerView* ) ) );


### PR DESCRIPTION
_Some background first_
To avoid freezing QGIS upon project load, the cache rendering for composer's map items is delayed until a given composer window is opened by the user. 

Due to a bug in Qt 4.8, the QMainWindow showEvent isn't triggered under gnome et cie, which has forced QGIS to use a hack to work around this bug (see http://hub.qgis.org/issues/6085 for more background on this). The hack has all composer windows' state set to Qt::WindowMinimized to allow for the code to trigger the map item cache rendering when a composer window state changes to a non Qt::WindowMinimized state (which is made to happen when you show() the window).

_Problem affecting Qt 5_
Under Qt 4.8, when a window is close()ed, the Qt::WindowMinimized state stays; however, under Qt 5, the window state is reset to Qt::WindowNoState. As a result, under Qt 5, the map item cache would be rendered on project load, freezing the interface for a long duration due to the loadComposersFromProject() function show()ing and subsequently close()ing composer windows if those were not marked as visible when saving the project.

_Solution_
Discussing with @nyalldawson about this, we came to the conclusion that we should simply never show() (and more importantly be forced afterwards to close() ) composer windows on project load, to fix the long freeze on Qt5 (irrespective of whether composer windows are open or not), and also prevent freeze on Qt 4.8 when composer windows were marked as visible while saving a project.

This PR implements the above-mentioned solution.
