### PR TITLE
Cleanup layer dependency api

### DIFF
--- a/python/core/qgsmaplayer.sip
+++ b/python/core/qgsmaplayer.sip
@@ -677,28 +677,21 @@ class QgsMapLayer : QObject
     void emitStyleChanged();
 
     /**
-     * Sets the list of layers that may modify data/geometries of this layer when modified.
+     * Sets the list of dependencies.
      * @see dependencies()
      *
-     * @param layersIds IDs of the layers that this layer depends on
-     * @returns false if a dependency cycle has been detected (the change dependency set is not changed in that case)
+     * @param layers set of QgsMapLayerDependency. Only user-defined dependencies will be added
+     * @returns false if a dependency cycle has been detected
+     * @note added in QGIS 3.0
      */
-    virtual bool setDataDependencies( const QSet<QString>& layersIds );
-
-    /**
-     * Sets the list of layers that may modify data/geometries of this layer when modified.
-     * @see dependencies()
-     *
-     * @param set of QgsMapLayerDependency. Only user-defined dependencies will be added
-     * @returns false if a dependency cycle has been detected (the change dependency set is not changed in that case)
-     */
-    bool setDataDependencies( const QSet<QgsMapLayerDependency>& layers );
+    virtual bool setDependencies( const QSet<QgsMapLayerDependency>& layers );
 
     /**
      * Gets the list of dependencies. This includes data dependencies set by the user (@see setDataDependencies)
      * as well as dependencies given by the provider
      *
      * @returns a set of QgsMapLayerDependency
+     * @note added in QGIS 3.0
      */
     virtual QSet<QgsMapLayerDependency> dependencies() const;
 
@@ -756,6 +749,11 @@ class QgsMapLayer : QObject
      */
     void configChanged();
 
+    /**
+     * Emitted when dependencies are changed.
+     */
+    void dependenciesChanged();
+
   protected:
     /** Set the extent */
     virtual void setExtent( const QgsRectangle &rect );
@@ -794,5 +792,5 @@ class QgsMapLayer : QObject
     void setError( const QgsError &error );
 
     //! Checks if new change dependency candidates introduce a cycle
-    bool hasDataDependencyCycle( const QSet<QgsMapLayerDependency>& layersIds ) const;
+    bool hasDependencyCycle( const QSet<QgsMapLayerDependency>& layersIds ) const;
 };

--- a/python/core/qgsvectorlayer.sip
+++ b/python/core/qgsvectorlayer.sip
@@ -422,21 +422,21 @@ class QgsVectorLayer : QgsMapLayer
     const QList<QgsVectorJoinInfo> vectorJoins() const;
 
     /**
-     * Sets the list of layers that may modify data/geometries of this layer when modified.
-     * This is meant mainly to declare database triggers between layers.
-     * When one of these layers is modified (feature added/deleted or geometry changed),
-     * dataChanged() will be emitted, allowing users of this layer to refresh / update it.
+     * Sets the list of dependencies.
+     * @see dependencies()
      *
-     * @param layersIds IDs of the layers that this layer depends on
-     * @returns false if a dependency cycle has been detected (the change dependency set is not changed in that case)
+     * @param layers set of QgsMapLayerDependency. Only user-defined dependencies will be added
+     * @returns false if a dependency cycle has been detected
+     * @note added in QGIS 3.0
      */
-    bool setDataDependencies( const QSet<QString>& layersIds );
+    virtual bool setDependencies( const QSet<QgsMapLayerDependency>& layers );
 
     /**
      * Gets the list of dependencies. This includes data dependencies set by the user (@see setDataDependencies)
      * as well as dependencies given by the provider
      *
      * @returns a set of QgsMapLayerDependency
+     * @note added in QGIS 3.0
      */
     virtual QSet<QgsMapLayerDependency> dependencies() const;
 

--- a/src/app/qgsvectorlayerproperties.cpp
+++ b/src/app/qgsvectorlayerproperties.cpp
@@ -580,14 +580,14 @@ void QgsVectorLayerProperties::apply()
   QgsExpressionContextUtils::setLayerVariables( mLayer, mVariableEditor->variablesInActiveScope() );
   updateVariableEditor();
 
-  // save layer dependencies
-  QSet<QString> deps;
+  // save dependencies
+  QSet<QgsMapLayerDependency> deps;
   Q_FOREACH ( const QgsLayerTreeLayer* layer, mLayersDependenciesTreeGroup->findLayers() )
   {
     if ( layer->isVisible() )
-      deps << layer->layerId();
+      deps << QgsMapLayerDependency( layer->layerId() );
   }
-  if ( ! mLayer->setDataDependencies( deps ) )
+  if ( ! mLayer->setDependencies( deps ) )
   {
     QMessageBox::warning( nullptr, tr( "Dependency cycle" ), tr( "This configuration introduces a cycle in data dependencies and will be ignored" ) );
   }

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -1720,7 +1720,7 @@ static bool _depHasCycleDFS( const QgsMapLayer* n, QHash<const QgsMapLayer*, int
   return false;
 }
 
-bool QgsMapLayer::hasDataDependencyCycle( const QSet<QgsMapLayerDependency>& layers ) const
+bool QgsMapLayer::hasDependencyCycle( const QSet<QgsMapLayerDependency>& layers ) const
 {
   QHash<const QgsMapLayer*, int> marks;
   return _depHasCycleDFS( this, marks, this, layers );
@@ -1728,30 +1728,21 @@ bool QgsMapLayer::hasDataDependencyCycle( const QSet<QgsMapLayerDependency>& lay
 
 QSet<QgsMapLayerDependency> QgsMapLayer::dependencies() const
 {
-  return mDataDependencies;
+  return mDependencies;
 }
 
-bool QgsMapLayer::setDataDependencies( const QSet<QString>& layersIds )
+bool QgsMapLayer::setDependencies( const QSet<QgsMapLayerDependency>& oDeps )
 {
   QSet<QgsMapLayerDependency> deps;
-  Q_FOREACH ( QString layerId, layersIds )
+  Q_FOREACH ( const QgsMapLayerDependency& dep, oDeps )
   {
-    deps << QgsMapLayerDependency( layerId );
+    if ( dep.origin() == QgsMapLayerDependency::FromUser )
+      deps << dep;
   }
-  if ( hasDataDependencyCycle( deps ) )
+  if ( hasDependencyCycle( deps ) )
     return false;
 
-  mDataDependencies = deps;
+  mDependencies = deps;
+  emit dependenciesChanged();
   return true;
-}
-
-bool QgsMapLayer::setDataDependencies( const QSet<QgsMapLayerDependency>& layers )
-{
-  QSet<QString> deps;
-  Q_FOREACH ( const QgsMapLayerDependency& dep, layers )
-  {
-    if ( dep.origin() == QgsMapLayerDependency::FromUser && dep.type() == QgsMapLayerDependency::DataDependency )
-      deps << dep.layerId();
-  }
-  return setDataDependencies( deps );
 }

--- a/src/core/qgsmaplayer.h
+++ b/src/core/qgsmaplayer.h
@@ -700,28 +700,21 @@ class CORE_EXPORT QgsMapLayer : public QObject
     void emitStyleChanged();
 
     /**
-     * Sets the list of layers that may modify data/geometries of this layer when modified.
-     * @see dependencies()
-     *
-     * @param layersIds IDs of the layers that this layer depends on
-     * @returns false if a dependency cycle has been detected (the change dependency set is not changed in that case)
-     */
-    virtual bool setDataDependencies( const QSet<QString>& layersIds );
-
-    /**
-     * Sets the list of layers that may modify data/geometries of this layer when modified.
+     * Sets the list of dependencies.
      * @see dependencies()
      *
      * @param layers set of QgsMapLayerDependency. Only user-defined dependencies will be added
-     * @returns false if a dependency cycle has been detected (the change dependency set is not changed in that case)
+     * @returns false if a dependency cycle has been detected
+     * @note added in QGIS 3.0
      */
-    bool setDataDependencies( const QSet<QgsMapLayerDependency>& layers );
+    virtual bool setDependencies( const QSet<QgsMapLayerDependency>& layers );
 
     /**
      * Gets the list of dependencies. This includes data dependencies set by the user (@see setDataDependencies)
      * as well as dependencies given by the provider
      *
      * @returns a set of QgsMapLayerDependency
+     * @note added in QGIS 3.0
      */
     virtual QSet<QgsMapLayerDependency> dependencies() const;
 
@@ -778,6 +771,11 @@ class CORE_EXPORT QgsMapLayer : public QObject
      * to be marked as dirty.
      */
     void configChanged();
+
+    /**
+     * Emitted when dependencies are changed.
+     */
+    void dependenciesChanged();
 
   protected:
     /** Set the extent */
@@ -864,10 +862,10 @@ class CORE_EXPORT QgsMapLayer : public QObject
     QgsError mError;
 
     //! List of layers that may modify this layer on modification
-    QSet<QgsMapLayerDependency> mDataDependencies;
+    QSet<QgsMapLayerDependency> mDependencies;
 
-    //! Checks whether a new set of data dependencies will introduce a cycle
-    bool hasDataDependencyCycle( const QSet<QgsMapLayerDependency>& layers ) const;
+    //! Checks whether a new set of dependencies will introduce a cycle
+    bool hasDependencyCycle( const QSet<QgsMapLayerDependency>& layers ) const;
 
   private:
     /**

--- a/src/core/qgsproject.cpp
+++ b/src/core/qgsproject.cpp
@@ -893,7 +893,7 @@ bool QgsProject::read()
   QMap<QString, QgsMapLayer*> existingMaps = QgsMapLayerRegistry::instance()->mapLayers();
   for ( QMap<QString, QgsMapLayer*>::iterator it = existingMaps.begin(); it != existingMaps.end(); it++ )
   {
-    it.value()->setDataDependencies( it.value()->dependencies() );
+    it.value()->setDependencies( it.value()->dependencies() );
   }
 
   // read the project: used by map canvas and legend
@@ -1001,7 +1001,7 @@ void QgsProject::onMapLayersAdded( const QList<QgsMapLayer*>& layers )
       if ( deps.contains( layer->id() ) )
       {
         // reconnect to change signals
-        it.value()->setDataDependencies( deps );
+        it.value()->setDependencies( deps );
       }
     }
   }

--- a/src/core/qgsvectorlayer.h
+++ b/src/core/qgsvectorlayer.h
@@ -515,21 +515,21 @@ class CORE_EXPORT QgsVectorLayer : public QgsMapLayer, public QgsExpressionConte
     const QList<QgsVectorJoinInfo> vectorJoins() const;
 
     /**
-     * Sets the list of layers that may modify data/geometries of this layer when modified.
-     * This is meant mainly to declare database triggers between layers.
-     * When one of these layers is modified (feature added/deleted or geometry changed),
-     * dataChanged() will be emitted, allowing users of this layer to refresh / update it.
+     * Sets the list of dependencies.
+     * @see dependencies()
      *
-     * @param layersIds IDs of the layers that this layer depends on
-     * @returns false if a dependency cycle has been detected (the change dependency set is not changed in that case)
+     * @param layers set of QgsMapLayerDependency. Only user-defined dependencies will be added
+     * @returns false if a dependency cycle has been detected
+     * @note added in QGIS 3.0
      */
-    bool setDataDependencies( const QSet<QString>& layersIds ) override;
+    virtual bool setDependencies( const QSet<QgsMapLayerDependency>& layers ) override;
 
     /**
      * Gets the list of dependencies. This includes data dependencies set by the user (@see setDataDependencies)
      * as well as dependencies given by the provider
      *
      * @returns a set of QgsMapLayerDependency
+     * @note added in QGIS 3.0
      */
     virtual QSet<QgsMapLayerDependency> dependencies() const override;
 


### PR DESCRIPTION
Following https://github.com/qgis/QGIS/pull/3320 : there is now only one getter and one setter to manipulate dependencies (dependencies() and setDependencies()). A change signal is also emitted.
