### PR TITLE
[FEATURE] Extra control when smoothing geometries

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -581,6 +581,7 @@ method to determine if a geometry is valid.</li>
 <li>static bool compare( const QgsPolyline& p1, const QgsPolyline& p2, double epsilon ) has been renamed to comparePolylines</li>
 <li>static bool compare( const QgsPolygon& p1, const QgsPolygon& p2, double epsilon ) has been renamed to comparePolygons</li>
 <li>static bool compare( const QgsMultiPolygon& p1, const QgsMultiPolygon& p2, double epsilon ) has been renamed to compareMultiPolygons</li>
+<li>smoothLine and smoothPolygon are no longer public API (use smooth() instead)</li>
 </ul>
 
 \subsection qgis_api_break_3_0_QgsGeometryAnalyzer QgsGeometryAnalyzer

--- a/python/core/geometry/qgsgeometry.sip
+++ b/python/core/geometry/qgsgeometry.sip
@@ -849,14 +849,12 @@ class QgsGeometry
      * @param offset fraction of line to create new vertices along, between 0 and 1.0
      * eg the default value of 0.25 will create new vertices 25% and 75% along each line segment
      * of the geometry for each iteration. Smaller values result in "tighter" smoothing.
+     * @param minimumDistance minimum segment length to apply smoothing to
+     * @param maxAngle maximum angle at node (0-180) at which smoothing will be applied
      * @note added in 2.9
      */
-    QgsGeometry smooth( const unsigned int iterations, const double offset ) const;
-
-    /** Smooths a polygon using the Chaikin algorithm*/
-    QgsPolygon smoothPolygon( const QgsPolygon &polygon, const unsigned int iterations = 1, const double offset = 0.25 ) const;
-    /** Smooths a polyline using the Chaikin algorithm*/
-    QgsPolyline smoothLine( const QgsPolyline &polyline, const unsigned int iterations = 1, const double offset = 0.25 ) const;
+    QgsGeometry smooth( const unsigned int iterations = 1, const double offset = 0.25,
+                        double minimumDistance = -1.0, double maxAngle = 180.0 ) const;
 
     /** Creates and returns a new geometry engine
      */

--- a/python/plugins/processing/algs/help/qgis.yaml
+++ b/python/plugins/processing/algs/help/qgis.yaml
@@ -444,6 +444,15 @@ qgis:singlesidedbuffer: >
 
   The mitre limit parameter is only applicable for mitre join styles, and controls the maximum distance from the buffer to use when creating a mitred join.
 
+qgis:smoothgeometry: >
+  This algorithm smooths the geometries in a line or polygon layer. It creates a new layer with the same features as the ones in the input layer, but with geometries containing a higher number of vertices and corners in the geometries smoothed out.
+
+  The iterations parameter dictates how many smoothing iterations will be applied to each geometry. A higher number of iterations results in smoother geometries with the cost of greater number of nodes in the geometries.
+
+  The offset parameter controls how "tightly" the smoothed geometries follow the original geometries. Smaller values results in a tighter fit, and larger values will create a looser fit.
+
+  The maximum angle parameter can be used to prevent smoothing of nodes with large angles. Any node where the angle of the segments to either side is larger then this will not be smoothed. Eg setting the maximum angle to 90 degrees or lower would preserve right angles in the geometry.
+
 qgis:snappointstogrid: >
   This algorithm modifies the position of points in a vector layer, so they fall in the coordinates of a grid.
 

--- a/python/plugins/processing/tests/testdata/expected/smoothed_lines.gfs
+++ b/python/plugins/processing/tests/testdata/expected/smoothed_lines.gfs
@@ -1,0 +1,15 @@
+<GMLFeatureClassList>
+  <GMLFeatureClass>
+    <Name>smoothed_lines</Name>
+    <ElementPath>smoothed_lines</ElementPath>
+    <GeometryType>2</GeometryType>
+    <SRSName>EPSG:4326</SRSName>
+    <DatasetSpecificInfo>
+      <FeatureCount>7</FeatureCount>
+      <ExtentXMin>-1.00000</ExtentXMin>
+      <ExtentXMax>11.00000</ExtentXMax>
+      <ExtentYMin>-3.00000</ExtentYMin>
+      <ExtentYMax>5.00000</ExtentYMax>
+    </DatasetSpecificInfo>
+  </GMLFeatureClass>
+</GMLFeatureClassList>

--- a/python/plugins/processing/tests/testdata/expected/smoothed_lines.gml
+++ b/python/plugins/processing/tests/testdata/expected/smoothed_lines.gml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation=""
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>-1</gml:X><gml:Y>-3</gml:Y></gml:coord>
+      <gml:coord><gml:X>11</gml:X><gml:Y>5</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                                                                             
+  <gml:featureMember>
+    <ogr:smoothed_lines fid="lines.0">
+      <ogr:geometryProperty><gml:LineString srsName="EPSG:4326"><gml:coordinates>6,2 8.25,2.0 9.0,2.25 9.0,2.75 9.5,3.5 11,5</gml:coordinates></gml:LineString></ogr:geometryProperty>
+    </ogr:smoothed_lines>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:smoothed_lines fid="lines.1">
+      <ogr:geometryProperty><gml:LineString srsName="EPSG:4326"><gml:coordinates>-1,-1 1,-1</gml:coordinates></gml:LineString></ogr:geometryProperty>
+    </ogr:smoothed_lines>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:smoothed_lines fid="lines.2">
+      <ogr:geometryProperty><gml:LineString srsName="EPSG:4326"><gml:coordinates>2,0 2.0,1.5 2.25,2.0 2.75,2.0 3.0,2.25 3,3</gml:coordinates></gml:LineString></ogr:geometryProperty>
+    </ogr:smoothed_lines>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:smoothed_lines fid="lines.3">
+      <ogr:geometryProperty><gml:LineString srsName="EPSG:4326"><gml:coordinates>3,1 5,1</gml:coordinates></gml:LineString></ogr:geometryProperty>
+    </ogr:smoothed_lines>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:smoothed_lines fid="lines.4">
+      <ogr:geometryProperty><gml:LineString srsName="EPSG:4326"><gml:coordinates>7,-3 10,-3</gml:coordinates></gml:LineString></ogr:geometryProperty>
+    </ogr:smoothed_lines>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:smoothed_lines fid="lines.5">
+      <ogr:geometryProperty><gml:LineString srsName="EPSG:4326"><gml:coordinates>6,-3 10,1</gml:coordinates></gml:LineString></ogr:geometryProperty>
+    </ogr:smoothed_lines>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:smoothed_lines fid="lines.6">
+    </ogr:smoothed_lines>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/expected/smoothed_lines_max_angle.gfs
+++ b/python/plugins/processing/tests/testdata/expected/smoothed_lines_max_angle.gfs
@@ -1,0 +1,15 @@
+<GMLFeatureClassList>
+  <GMLFeatureClass>
+    <Name>smoothed_lines_max_angle</Name>
+    <ElementPath>smoothed_lines_max_angle</ElementPath>
+    <GeometryType>2</GeometryType>
+    <SRSName>EPSG:4326</SRSName>
+    <DatasetSpecificInfo>
+      <FeatureCount>7</FeatureCount>
+      <ExtentXMin>-1.00000</ExtentXMin>
+      <ExtentXMax>11.00000</ExtentXMax>
+      <ExtentYMin>-3.00000</ExtentYMin>
+      <ExtentYMax>5.00000</ExtentYMax>
+    </DatasetSpecificInfo>
+  </GMLFeatureClass>
+</GMLFeatureClassList>

--- a/python/plugins/processing/tests/testdata/expected/smoothed_lines_max_angle.gml
+++ b/python/plugins/processing/tests/testdata/expected/smoothed_lines_max_angle.gml
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<ogr:FeatureCollection
+     xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+     xsi:schemaLocation=""
+     xmlns:ogr="http://ogr.maptools.org/"
+     xmlns:gml="http://www.opengis.net/gml">
+  <gml:boundedBy>
+    <gml:Box>
+      <gml:coord><gml:X>-1</gml:X><gml:Y>-3</gml:Y></gml:coord>
+      <gml:coord><gml:X>11</gml:X><gml:Y>5</gml:Y></gml:coord>
+    </gml:Box>
+  </gml:boundedBy>
+                                                                                                                                                             
+  <gml:featureMember>
+    <ogr:smoothed_lines_max_angle fid="lines.0">
+      <ogr:geometryProperty><gml:LineString srsName="EPSG:4326"><gml:coordinates>6,2 9,2 9.0,2.75 9.5,3.5 11,5</gml:coordinates></gml:LineString></ogr:geometryProperty>
+    </ogr:smoothed_lines_max_angle>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:smoothed_lines_max_angle fid="lines.1">
+      <ogr:geometryProperty><gml:LineString srsName="EPSG:4326"><gml:coordinates>-1,-1 1,-1</gml:coordinates></gml:LineString></ogr:geometryProperty>
+    </ogr:smoothed_lines_max_angle>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:smoothed_lines_max_angle fid="lines.2">
+      <ogr:geometryProperty><gml:LineString srsName="EPSG:4326"><gml:coordinates>2,0 2,2 3,2 3,3</gml:coordinates></gml:LineString></ogr:geometryProperty>
+    </ogr:smoothed_lines_max_angle>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:smoothed_lines_max_angle fid="lines.3">
+      <ogr:geometryProperty><gml:LineString srsName="EPSG:4326"><gml:coordinates>3,1 5,1</gml:coordinates></gml:LineString></ogr:geometryProperty>
+    </ogr:smoothed_lines_max_angle>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:smoothed_lines_max_angle fid="lines.4">
+      <ogr:geometryProperty><gml:LineString srsName="EPSG:4326"><gml:coordinates>7,-3 10,-3</gml:coordinates></gml:LineString></ogr:geometryProperty>
+    </ogr:smoothed_lines_max_angle>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:smoothed_lines_max_angle fid="lines.5">
+      <ogr:geometryProperty><gml:LineString srsName="EPSG:4326"><gml:coordinates>6,-3 10,1</gml:coordinates></gml:LineString></ogr:geometryProperty>
+    </ogr:smoothed_lines_max_angle>
+  </gml:featureMember>
+  <gml:featureMember>
+    <ogr:smoothed_lines_max_angle fid="lines.6">
+    </ogr:smoothed_lines_max_angle>
+  </gml:featureMember>
+</ogr:FeatureCollection>

--- a/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
+++ b/python/plugins/processing/tests/testdata/qgis_algorithm_tests.yaml
@@ -965,3 +965,31 @@ tests:
       OUTPUT:
         name: expected/simplify_grid_lines.gml
         type: vector
+
+  - algorithm: qgis:smoothgeometry
+    name: Smooth (lines)
+    params:
+      INPUT_LAYER:
+        name: lines.gml
+        type: vector
+      ITERATIONS: 1
+      MAX_ANGLE: 180.0
+      OFFSET: 0.25
+    results:
+      OUTPUT_LAYER:
+        name: expected/smoothed_lines.gml
+        type: vector
+
+  - algorithm: qgis:smoothgeometry
+    name: Smooth (lines, with max angle)
+    params:
+      INPUT_LAYER:
+        name: lines.gml
+        type: vector
+      ITERATIONS: 1
+      MAX_ANGLE: 60.0
+      OFFSET: 0.25
+    results:
+      OUTPUT_LAYER:
+        name: expected/smoothed_lines_max_angle.gml
+        type: vector

--- a/src/core/geometry/qgsgeometry.h
+++ b/src/core/geometry/qgsgeometry.h
@@ -43,6 +43,7 @@ class QgsVectorLayer;
 class QgsMapToPixel;
 class QPainter;
 class QgsPolygonV2;
+class QgsLineString;
 
 /** Polyline is represented as a vector of points */
 typedef QVector<QgsPoint> QgsPolyline;
@@ -888,14 +889,12 @@ class CORE_EXPORT QgsGeometry
      * @param offset fraction of line to create new vertices along, between 0 and 1.0
      * eg the default value of 0.25 will create new vertices 25% and 75% along each line segment
      * of the geometry for each iteration. Smaller values result in "tighter" smoothing.
+     * @param minimumDistance minimum segment length to apply smoothing to
+     * @param maxAngle maximum angle at node (0-180) at which smoothing will be applied
      * @note added in 2.9
      */
-    QgsGeometry smooth( const unsigned int iterations = 1, const double offset = 0.25 ) const;
-
-    /** Smooths a polygon using the Chaikin algorithm*/
-    QgsPolygon smoothPolygon( const QgsPolygon &polygon, const unsigned int iterations = 1, const double offset = 0.25 ) const;
-    /** Smooths a polyline using the Chaikin algorithm*/
-    QgsPolyline smoothLine( const QgsPolyline &polyline, const unsigned int iterations = 1, const double offset = 0.25 ) const;
+    QgsGeometry smooth( const unsigned int iterations = 1, const double offset = 0.25,
+                        double minimumDistance = -1.0, double maxAngle = 180.0 ) const;
 
     /** Creates and returns a new geometry engine
      */
@@ -941,6 +940,34 @@ class CORE_EXPORT QgsGeometry
     QgsGeometry convertToLine( bool destMultipart ) const;
     /** Try to convert the geometry to a polygon */
     QgsGeometry convertToPolygon( bool destMultipart ) const;
+
+    /** Smooths a polyline using the Chaikin algorithm
+     * @param line line to smooth
+     * @param iterations number of smoothing iterations to run. More iterations results
+     * in a smoother geometry
+     * @param offset fraction of line to create new vertices along, between 0 and 1.0
+     * eg the default value of 0.25 will create new vertices 25% and 75% along each line segment
+     * of the geometry for each iteration. Smaller values result in "tighter" smoothing.
+     * @param minimumDistance minimum segment length to apply smoothing to
+     * @param maxAngle maximum angle at node (0-180) at which smoothing will be applied
+    */
+    QgsLineString* smoothLine( const QgsLineString & line, const unsigned int iterations = 1, const double offset = 0.25,
+                               double minimumDistance = -1, double maxAngle = 180.0 ) const;
+
+    /** Smooths a polygon using the Chaikin algorithm
+     * @param polygon polygon to smooth
+     * @param iterations number of smoothing iterations to run. More iterations results
+     * in a smoother geometry
+     * @param offset fraction of segment to create new vertices along, between 0 and 1.0
+     * eg the default value of 0.25 will create new vertices 25% and 75% along each line segment
+     * of the geometry for each iteration. Smaller values result in "tighter" smoothing.
+     * @param minimumDistance minimum segment length to apply smoothing to
+     * @param maxAngle maximum angle at node (0-180) at which smoothing will be applied
+    */
+    QgsPolygonV2* smoothPolygon( const QgsPolygonV2 &polygon, const unsigned int iterations = 1, const double offset = 0.25,
+                                 double minimumDistance = -1, double maxAngle = 180.0 ) const;
+
+
 }; // class QgsGeometry
 
 Q_DECLARE_METATYPE( QgsGeometry )

--- a/src/core/geometry/qgsgeometryutils.cpp
+++ b/src/core/geometry/qgsgeometryutils.cpp
@@ -824,6 +824,13 @@ double QgsGeometryUtils::lineAngle( double x1, double y1, double x2, double y2 )
   return normalizedAngle( a );
 }
 
+double QgsGeometryUtils::angleBetweenThreePoints( double x1, double y1, double x2, double y2, double x3, double y3 )
+{
+  double angle1 = atan2( y1 - y2, x1 - x2 );
+  double angle2 = atan2( y3 - y2, x3 - x2 );
+  return normalizedAngle( angle1 - angle2 );
+}
+
 double QgsGeometryUtils::linePerpendicularAngle( double x1, double y1, double x2, double y2 )
 {
   double a = lineAngle( x1, y1, x2, y2 );

--- a/src/core/geometry/qgsgeometryutils.h
+++ b/src/core/geometry/qgsgeometryutils.h
@@ -198,6 +198,19 @@ class CORE_EXPORT QgsGeometryUtils
      */
     static double lineAngle( double x1, double y1, double x2, double y2 );
 
+    /** Calculates the angle between the lines AB and BC, where AB and BC described
+     * by points a, b and b, c.
+     * @param x1 x-coordinate of point a
+     * @param y1 y-coordinate of point a
+     * @param x2 x-coordinate of point b
+     * @param y2 y-coordinate of point b
+     * @param x3 x-coordinate of point c
+     * @param y3 y-coordinate of point c
+     * @returns angle between lines in radians. Returned value is undefined if two or more points are equal.
+     */
+    static double angleBetweenThreePoints( double x1, double y1, double x2, double y2,
+                                           double x3, double y3 );
+
     /** Calculates the perpendicular angle to a line joining two points. Returned angle is in radians,
      * clockwise from the north direction.
      * @param x1 x-coordinate of line start

--- a/tests/src/core/testqgsgeometry.cpp
+++ b/tests/src/core/testqgsgeometry.cpp
@@ -3539,6 +3539,45 @@ void TestQgsGeometry::smoothCheck()
   << QgsPoint( 10.0, 7.5 ) << QgsPoint( 12.5, 10.0 ) << QgsPoint( 20.0, 10.0 );
   QVERIFY( QgsGeometry::compare( line, expectedLine ) );
 
+  //linestring, with min distance
+  wkt = "LineString(0 0, 10 0, 10 10, 15 10, 15 20)";
+  geom = QgsGeometry::fromWkt( wkt );
+  result = geom.smooth( 1, 0.25, 6 );
+  line = result.asPolyline();
+  expectedLine.clear();
+  expectedLine << QgsPoint( 0, 0 ) << QgsPoint( 7.5, 0 ) << QgsPoint( 10.0, 2.5 )
+  << QgsPoint( 10.0, 7.5 ) << QgsPoint( 15, 12.5 ) << QgsPoint( 15.0, 20.0 );
+  QVERIFY( QgsGeometry::compare( line, expectedLine ) );
+
+  //linestring, with max angle
+  wkt = "LineString(0 0, 10 0, 15 5, 25 -5, 30 -5 )";
+  geom = QgsGeometry::fromWkt( wkt );
+  result = geom.smooth( 1, 0.25, 0, 50 );
+  line = result.asPolyline();
+  expectedLine.clear();
+  expectedLine << QgsPoint( 0, 0 ) << QgsPoint( 7.5, 0 ) << QgsPoint( 11.25, 1.25 )
+  << QgsPoint( 15.0, 5.0 ) << QgsPoint( 22.5, -2.5 ) << QgsPoint( 26.25, -5 ) << QgsPoint( 30, -5 );
+  QVERIFY( QgsGeometry::compare( line, expectedLine ) );
+
+  //linestring, with max angle, other direction
+  wkt = "LineString( 30 -5, 25 -5, 15 5, 10 0, 0 0 )";
+  geom = QgsGeometry::fromWkt( wkt );
+  result = geom.smooth( 1, 0.25, 0, 50 );
+  line = result.asPolyline();
+  expectedLine.clear();
+  expectedLine << QgsPoint( 30, -5 ) << QgsPoint( 26.25, -5 ) << QgsPoint( 22.5, -2.5 )
+  << QgsPoint( 15.0, 5.0 ) << QgsPoint( 11.25, 1.25 ) << QgsPoint( 7.5, 0 ) << QgsPoint( 0, 0 );
+  QVERIFY( QgsGeometry::compare( line, expectedLine ) );
+
+  //linestring, max angle, first corner sharp
+  wkt = "LineString(0 0, 10 0, 10 10 )";
+  geom = QgsGeometry::fromWkt( wkt );
+  result = geom.smooth( 1, 0.25, 0, 50 );
+  line = result.asPolyline();
+  expectedLine.clear();
+  expectedLine << QgsPoint( 0, 0 ) << QgsPoint( 10, 0 ) << QgsPoint( 10, 10 );
+  QVERIFY( QgsGeometry::compare( line, expectedLine ) );
+
   wkt = "MultiLineString ((0 0, 10 0, 10 10, 20 10),(30 30, 40 30, 40 40, 50 40))";
   geom = QgsGeometry::fromWkt( wkt );
   result = geom.smooth( 1, 0.25 );
@@ -3564,7 +3603,17 @@ void TestQgsGeometry::smoothCheck()
        << QgsPoint( 2.0, 3.5 ) << QgsPoint( 2.0, 2.5 ) << QgsPoint( 2.5, 2.0 ) );
   QVERIFY( QgsGeometry::compare( poly, expectedPolygon ) );
 
-  //multipolygon
+  //polygon with max angle - should be unchanged
+  wkt = "Polygon ((0 0, 10 0, 10 10, 0 10, 0 0))";
+  geom = QgsGeometry::fromWkt( wkt );
+  result = geom.smooth( 1, 0.25, -1, 50 );
+  poly = result.asPolygon();
+  expectedPolygon.clear();
+  expectedPolygon << ( QgsPolyline() << QgsPoint( 0, 0 ) << QgsPoint( 10, 0 ) << QgsPoint( 10.0, 10 )
+                       <<  QgsPoint( 0, 10 ) << QgsPoint( 0, 0 ) );
+  QVERIFY( QgsGeometry::compare( poly, expectedPolygon ) );
+
+  //multipolygon)
   wkt = "MultiPolygon (((0 0, 10 0, 10 10, 0 10, 0 0 )),((2 2, 4 2, 4 4, 2 4, 2 2)))";
   geom = QgsGeometry::fromWkt( wkt );
   result = geom.smooth( 1, 0.1 );

--- a/tests/src/core/testqgsgeometryutils.cpp
+++ b/tests/src/core/testqgsgeometryutils.cpp
@@ -50,6 +50,7 @@ class TestQgsGeometryUtils: public QObject
     void testCircleCenterRadius_data();
     void testCircleCenterRadius();
     void testSqrDistToLine();
+    void testAngleThreePoints();
 };
 
 
@@ -517,6 +518,26 @@ void TestQgsGeometryUtils::testSqrDistToLine()
                    rx, ry, epsilon );
   QGSCOMPARENEAR( sqrDist, 11.83, 0.01 );
 }
+
+void TestQgsGeometryUtils::testAngleThreePoints()
+{
+  QgsPoint p1( 0, 0 );
+  QgsPoint p2( 1, 0 );
+  QgsPoint p3( 1, 1 );
+  QGSCOMPARENEAR( QgsGeometryUtils::angleBetweenThreePoints( p1.x(), p1.y(), p2.x(), p2.y(), p3.x(), p3.y() ), M_PI / 2.0, 0.00000001 );
+  p3 = QgsPoint( 1, -1 );
+  QGSCOMPARENEAR( QgsGeometryUtils::angleBetweenThreePoints( p1.x(), p1.y(), p2.x(), p2.y(), p3.x(), p3.y() ), 3 * M_PI / 2.0, 0.00000001 );
+  p3 = QgsPoint( 2, 0 );
+  QGSCOMPARENEAR( QgsGeometryUtils::angleBetweenThreePoints( p1.x(), p1.y(), p2.x(), p2.y(), p3.x(), p3.y() ), M_PI, 0.00000001 );
+  p3 = QgsPoint( 0, 0 );
+  QGSCOMPARENEAR( QgsGeometryUtils::angleBetweenThreePoints( p1.x(), p1.y(), p2.x(), p2.y(), p3.x(), p3.y() ), 0.0, 0.00000001 );
+  p3 = QgsPoint( 1, 0 );
+  //undefined, but want no crash
+  ( void )QgsGeometryUtils::angleBetweenThreePoints( p1.x(), p1.y(), p2.x(), p2.y(), p3.x(), p3.y() );
+  p2 = QgsPoint( 0, 0 );
+  ( void )QgsGeometryUtils::angleBetweenThreePoints( p1.x(), p1.y(), p2.x(), p2.y(), p3.x(), p3.y() );
+}
+
 
 
 QTEST_MAIN( TestQgsGeometryUtils )


### PR DESCRIPTION
Adds options to QgsGeometry::smooth to not smooth segments shorter than a certain threshold (avoids excessive new vertices) or sharp corners with an angle exceeding a threshold (avoids smoothing intentional sharp corners such as right angles)

Expose the angle threshold to processing smooth algorithm

Also:
- optimise QgsGeometry::smooth for new geometry classes
- Fix smooth does not work with geometries containing Z/M
