### PR TITLE
[FEATURE] New simplify + smoothing expression functions

### DIFF
--- a/resources/function_help/json/simplify
+++ b/resources/function_help/json/simplify
@@ -1,0 +1,9 @@
+{
+  "name": "simplify",
+  "type": "function",
+  "description":"Simplifies a geometry by removing nodes using a distance based threshold (ie, the Douglas Peucker algorithm). The algorithm preserves large deviations in geometries and reduces the number of vertices in nearly straight segments.",
+  "arguments": [ {"arg":"geometry","description":"a geometry"},
+                 {"arg":"tolerance","description":"maximum deviation from straight segments for points to be removed"} ],
+  "examples": [ { "expression":"geom_to_wkt(simplify(geometry:=geom_from_wkt('LineString(0 0, 5 0.1, 10 0)'),tolerance:=5))", "returns":"'LineString(0 0, 10 0)'"}]
+}
+

--- a/resources/function_help/json/simplify_vw
+++ b/resources/function_help/json/simplify_vw
@@ -1,0 +1,9 @@
+{
+  "name": "simplify_vw",
+  "type": "function",
+  "description":"Simplifies a geometry by removing nodes using an area based threshold (ie, the Visvalingam-Whyatt algorithm). The algorithm removes vertices which create small areas in geometries, eg narrow spikes or nearly straight segments.",
+  "arguments": [ {"arg":"geometry","description":"a geometry"},
+                 {"arg":"tolerance","description":"a measure of the maximum area created by a node for the node to be removed"} ],
+  "examples": [ { "expression":"geom_to_wkt(simplify_vw(geometry:=geom_from_wkt('LineString(0 0, 5 0, 5.01 10, 5.02 0, 10 0)'),tolerance:=5))", "returns":"'LineString(0 0, 10 0)'"}]
+}
+

--- a/resources/function_help/json/smooth
+++ b/resources/function_help/json/smooth
@@ -1,0 +1,12 @@
+{
+  "name": "smooth",
+  "type": "function",
+  "description":"Smooths a geometry by adding extra nodes which round off corners in the geometry.",
+  "arguments": [ {"arg":"geometry","description":"a geometry"},
+                 {"arg":"iterations", "optional":true,"description":"number of smoothing iterations to apply. Larger numbers result in smoother but more complex geometries."},
+                 {"arg":"offset", "optional":true,"description":"value between 0 and 0.5 which controls how tightly the smoothed geometry follow the original geometry. Smaller values result in a tighter smoothing, larger values result in looser smoothing."},
+                 {"arg":"min_length", "optional":true,"description":"minimum length of segments to apply smoothing to. This parameter can be used to avoid placing excessive additional nodes in shorter segments of the geometry."},
+                 {"arg":"max_angle", "optional":true,"description":"maximum angle at node for smoothing to be applied (0-180). By lowering the maximum angle intentionally sharp corners in the geometry can be preserved. For instance, a value of 80 degrees will retain right angles in the geometry."} ],
+  "examples": [ { "expression":"geom_to_wkt(smooth(geometry:=geom_from_wkt('LineString(0 0, 5 0, 5 5)'),iterations:=1,offset:=0.2,min_length:=-1,max_angle:=180))", "returns":"'LineString (0 0, 4 0, 5 1, 5 5)'"}]
+}
+

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -798,6 +798,18 @@ class TestQgsExpression: public QObject
       QTest::newRow( "distance_to_vertex null" ) << "distance_to_vertex(NULL, 0)" << false << QVariant();
       QTest::newRow( "distance_to_vertex point" ) << "distance_to_vertex(geom_from_wkt('POINT(1 2)'),0)" << false << QVariant( 0.0 );
       QTest::newRow( "distance_to_vertex line" ) << "distance_to_vertex(geometry:=geom_from_wkt('LineString(0 0, 10 0, 10 10)'),vertex:=1)" << false << QVariant( 10.0 );
+      QTest::newRow( "simplify not geom" ) << "simplify('g',5)" << true << QVariant();
+      QTest::newRow( "simplify null" ) << "simplify(NULL,5)" << false << QVariant();
+      QTest::newRow( "simplify point" ) << "geom_to_wkt(simplify(geom_from_wkt('POINT(1 2)'),10))" << false << QVariant( "Point (1 2)" );
+      QTest::newRow( "simplify line" ) << "geom_to_wkt(simplify(geometry:=geom_from_wkt('LineString(0 0, 5 0, 10 0)'),tolerance:=5))" << false << QVariant( "LineString (0 0, 10 0)" );
+      QTest::newRow( "simplify_vw not geom" ) << "simplify_vw('g',5)" << true << QVariant();
+      QTest::newRow( "simplify_vw null" ) << "simplify_vw(NULL,5)" << false << QVariant();
+      QTest::newRow( "simplify_vw point" ) << "geom_to_wkt(simplify_vw(geom_from_wkt('POINT(1 2)'),10))" << false << QVariant( "Point (1 2)" );
+      QTest::newRow( "simplify_vw line" ) << "geom_to_wkt(simplify_vw(geometry:=geom_from_wkt('LineString(0 0, 5 0, 5.01 10, 5.02 0, 10 0)'),tolerance:=5))" << false << QVariant( "LineString (0 0, 10 0)" );
+      QTest::newRow( "smooth not geom" ) << "smooth('g',5)" << true << QVariant();
+      QTest::newRow( "smooth null" ) << "smooth(NULL,5)" << false << QVariant();
+      QTest::newRow( "smooth point" ) << "geom_to_wkt(smooth(geom_from_wkt('POINT(1 2)'),10))" << false << QVariant( "Point (1 2)" );
+      QTest::newRow( "smooth line" ) << "geom_to_wkt(smooth(geometry:=geom_from_wkt('LineString(0 0, 5 0, 5 5)'),iterations:=1,offset:=0.2,min_length:=-1,max_angle:=180))" << false << QVariant( "LineString (0 0, 4 0, 5 1, 5 5)" );
 
       // string functions
       QTest::newRow( "lower" ) << "lower('HeLLo')" << false << QVariant( "hello" );


### PR DESCRIPTION
Exposes simplification and smoothing algorithms to expression engine, via:
- simplify(): applies Douglas-Peucker geometry simplification
- simplify_vw(): applies Visvalingam-Whyatt geometry simplification
- smooth(): smoothes a geometry

Carto tip: use smooth along with geometry generators to minimise the typical "GIS" noded look of rendered geometries!
