### PR TITLE
fix to support PyQt5 5.7

### DIFF
--- a/python/PyQt/PyQt5/uic/pyuic.py
+++ b/python/PyQt/PyQt5/uic/pyuic.py
@@ -1,1 +1,3 @@
 from PyQt5.uic import pyuic
+if (callable(pyuic.main)):
+    pyuic.main()


### PR DESCRIPTION
@m-kuhn , as of PyQt5 5.7 (offered in Ubuntu's upcoming version 16.10), importing the pyuic module from PyQt5.uic does _not_ run automatically run the pyuic5 ui to python conversion. Instead, the code is put behind a main() function, which needs to be called for it to be executed.

This PR applies a simple fix for us to support PyQt5 pre and post 5.7. Sounds good?
