### PR TITLE
[Processing] Calculate min coverage on execution

### DIFF
--- a/python/plugins/processing/gui/AlgorithmDialog.py
+++ b/python/plugins/processing/gui/AlgorithmDialog.py
@@ -101,19 +101,10 @@ class AlgorithmDialog(AlgorithmDialogBase):
         for param in params:
             if param.hidden:
                 continue
-            if isinstance(param, ParameterExtent):
-                continue
             if not self.setParamValue(
                     param, self.mainWidget.valueItems[param.name]):
                 raise AlgorithmDialogBase.InvalidParameterValue(
                     param, self.mainWidget.valueItems[param.name])
-
-        for param in params:
-            if isinstance(param, ParameterExtent):
-                if not self.setParamValue(
-                        param, self.mainWidget.valueItems[param.name]):
-                    raise AlgorithmDialogBase.InvalidParameterValue(
-                        param, self.mainWidget.valueItems[param.name])
 
         for output in outputs:
             if output.hidden:

--- a/python/plugins/processing/gui/BatchAlgorithmDialog.py
+++ b/python/plugins/processing/gui/BatchAlgorithmDialog.py
@@ -71,27 +71,12 @@ class BatchAlgorithmDialog(AlgorithmDialogBase):
             for param in alg.parameters:
                 if param.hidden:
                     continue
-                if isinstance(param, ParameterExtent):
-                    col += 1
-                    continue
                 widget = self.mainWidget.tblParameters.cellWidget(row, col)
                 if not self.mainWidget.setParamValue(param, widget, alg):
                     self.lblProgress.setText(
                         self.tr('<b>Missing parameter value: %s (row %d)</b>') % (param.description, row + 1))
                     self.algs = None
                     return
-                col += 1
-            col = 0
-            for param in alg.parameters:
-                if param.hidden:
-                    continue
-                if isinstance(param, ParameterExtent):
-                    widget = self.mainWidget.tblParameters.cellWidget(row, col)
-                    if not self.mainWidget.setParamValue(param, widget, alg):
-                        self.lblProgress.setText(
-                            self.tr('<b>Missing parameter value: %s (row %d)</b>') % (param.description, row + 1))
-                        self.algs = None
-                        return
                 col += 1
             for out in alg.outputs:
                 if out.hidden:

--- a/python/plugins/processing/gui/BatchPanel.py
+++ b/python/plugins/processing/gui/BatchPanel.py
@@ -156,7 +156,7 @@ class BatchPanel(BASE, WIDGET):
         elif isinstance(param, ParameterFixedTable):
             item = FixedTablePanel(param)
         elif isinstance(param, ParameterExtent):
-            item = ExtentSelectionPanel(self.parent, self.alg, param.default)
+            item = ExtentSelectionPanel(self.parent, param.default)
         elif isinstance(param, ParameterPoint):
             item = PointSelectionPanel(self.parent, param.default)
         elif isinstance(param, ParameterCrs):
@@ -247,27 +247,12 @@ class BatchPanel(BASE, WIDGET):
             for param in alg.parameters:
                 if param.hidden:
                     continue
-                if isinstance(param, ParameterExtent):
-                    col += 1
-                    continue
                 widget = self.tblParameters.cellWidget(row, col)
                 if not self.setParamValue(param, widget, alg):
                     self.parent.lblProgress.setText(
                         self.tr('<b>Missing parameter value: %s (row %d)</b>') % (param.description, row + 1))
                     return
                 algParams[param.name] = param.getValueAsCommandLineParameter()
-                col += 1
-            col = 0
-            for param in alg.parameters:
-                if param.hidden:
-                    continue
-                if isinstance(param, ParameterExtent):
-                    widget = self.tblParameters.cellWidget(row, col)
-                    if not self.setParamValue(param, widget, alg):
-                        self.parent.lblProgress.setText(
-                            self.tr('<b>Missing parameter value: %s (row %d)</b>') % (param.description, row + 1))
-                        return
-                    algParams[param.name] = unicode(param.value())
                 col += 1
             for out in alg.outputs:
                 if out.hidden:

--- a/python/plugins/processing/modeler/ModelerAlgorithm.py
+++ b/python/plugins/processing/modeler/ModelerAlgorithm.py
@@ -392,8 +392,6 @@ class ModelerAlgorithm(GeoAlgorithm):
                                                        self.tr("Parameter %s in algorithm %s in the model is run with default value! Edit the model to make sure that this is correct.") % (param.name, alg.name),
                                                        QgsMessageBar.WARNING, 4)
                     value = param.default
-                if value is None and isinstance(param, ParameterExtent):
-                    value = self.getMinCoveringExtent()
                 # We allow unexistent filepaths, since that allows
                 # algorithms to skip some conversion routines
                 if not param.setValue(value) and not isinstance(param,
@@ -441,43 +439,6 @@ class ModelerAlgorithm(GeoAlgorithm):
             return self.algs[value.alg].algorithm.getOutputFromName(value.output).value
         else:
             return value
-
-    def getMinCoveringExtent(self):
-        first = True
-        found = False
-        for param in self.parameters:
-            if param.value:
-                if isinstance(param, (ParameterRaster, ParameterVector)):
-                    found = True
-                    if isinstance(param.value, (QgsRasterLayer, QgsVectorLayer)):
-                        layer = param.value
-                    else:
-                        layer = dataobjects.getObjectFromUri(param.value)
-                    self.addToRegion(layer, first)
-                    first = False
-                elif isinstance(param, ParameterMultipleInput):
-                    found = True
-                    layers = param.value.split(';')
-                    for layername in layers:
-                        layer = dataobjects.getObjectFromUri(layername)
-                        self.addToRegion(layer, first)
-                        first = False
-        if found:
-            return ','.join([unicode(v) for v in [self.xmin, self.xmax, self.ymin, self.ymax]])
-        else:
-            return None
-
-    def addToRegion(self, layer, first):
-        if first:
-            self.xmin = layer.extent().xMinimum()
-            self.xmax = layer.extent().xMaximum()
-            self.ymin = layer.extent().yMinimum()
-            self.ymax = layer.extent().yMaximum()
-        else:
-            self.xmin = min(self.xmin, layer.extent().xMinimum())
-            self.xmax = max(self.xmax, layer.extent().xMaximum())
-            self.ymin = min(self.ymin, layer.extent().yMinimum())
-            self.ymax = max(self.ymax, layer.extent().yMaximum())
 
     def processAlgorithm(self, progress):
         executed = []


### PR DESCRIPTION
Here I move the min coverage calculation from the extent selection widget to the execution method of the algorithm.

IMHO calculated extent should not be save anywhere (nor in batch dialog nor in modeler) but only calculated at execution time, so this make sense.

Note that this removes duplicate code : 
- in ModelerAlgorithm and ExtentSelectionPanel for the extent calculation.
- in panel's setParamValue method for get the extent at last.

Note the stats : +65 −138

Merging this will makes me happing for the widget abstraction I'm working on.
