### PR TITLE
Fix auto conf of QgsRangeWidgetWrapper

### DIFF
--- a/src/gui/editorwidgets/qgsdatetimeeditconfig.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeeditconfig.cpp
@@ -15,6 +15,7 @@
 
 #include "qgsdatetimeeditconfig.h"
 #include "qgsdatetimeeditfactory.h"
+#include "qgsvectorlayer.h"
 
 QgsDateTimeEditConfig::QgsDateTimeEditConfig( QgsVectorLayer* vl, int fieldIdx, QWidget* parent )
     : QgsEditorConfigWidget( vl, fieldIdx, parent )
@@ -119,9 +120,26 @@ QgsEditorWidgetConfig QgsDateTimeEditConfig::config()
 }
 
 
+QString QgsDateTimeEditConfig::defaultFormat( const QVariant::Type type )
+{
+  switch ( type )
+  {
+    case QVariant::DateTime:
+      return QGSDATETIMEEDIT_DATETIMEFORMAT;
+      break;
+    case QVariant::Time:
+      return QGSDATETIMEEDIT_TIMEFORMAT;
+      break;
+    default:
+      return QGSDATETIMEEDIT_DATEFORMAT;
+  }
+}
+
+
 void QgsDateTimeEditConfig::setConfig( const QgsEditorWidgetConfig &config )
 {
-  const QString fieldFormat = config.value( "field_format", QGSDATETIMEEDIT_DATEFORMAT ).toString();
+  const QgsField fieldDef = layer()->fields().at( field() );
+  const QString fieldFormat = config.value( "field_format", defaultFormat( fieldDef.type() ) ).toString();
   mFieldFormatEdit->setText( fieldFormat );
 
   if ( fieldFormat == QGSDATETIMEEDIT_DATEFORMAT )
@@ -133,7 +151,7 @@ void QgsDateTimeEditConfig::setConfig( const QgsEditorWidgetConfig &config )
   else
     mFieldFormatComboBox->setCurrentIndex( 3 );
 
-  QString displayFormat = config.value( "display_format", QGSDATETIMEEDIT_DATEFORMAT ).toString();
+  QString displayFormat = config.value( "display_format", defaultFormat( fieldDef.type() ) ).toString();
   mDisplayFormatEdit->setText( displayFormat );
   if ( displayFormat == mFieldFormatEdit->text() )
   {

--- a/src/gui/editorwidgets/qgsdatetimeeditconfig.h
+++ b/src/gui/editorwidgets/qgsdatetimeeditconfig.h
@@ -41,6 +41,13 @@ class GUI_EXPORT QgsDateTimeEditConfig : public QgsEditorConfigWidget, private U
   public:
     QgsEditorWidgetConfig config() override;
     void setConfig( const QgsEditorWidgetConfig &config ) override;
+
+    /**
+     * Get the default format in fonction of the type
+     * @param type the field type
+     * @return the date/time format
+     */
+    static QString defaultFormat( const QVariant::Type type );
 };
 
 #endif // QGSDATETIMEEDITCONFIG_H

--- a/src/gui/editorwidgets/qgsdatetimeeditfactory.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeeditfactory.cpp
@@ -81,8 +81,9 @@ QString QgsDateTimeEditFactory::representValue( QgsVectorLayer* vl, int fieldIdx
     return settings.value( "qgis/nullValue", "NULL" ).toString();
   }
 
-  const QString displayFormat = config.value( "display_format", QGSDATETIMEEDIT_DATEFORMAT ).toString();
-  const QString fieldFormat = config.value( "field_format", QGSDATETIMEEDIT_DATEFORMAT ).toString();
+  const QgsField field = vl->fields().at( fieldIdx );
+  const QString displayFormat = config.value( "display_format", QgsDateTimeEditConfig::defaultFormat( field.type() ) ).toString();
+  const QString fieldFormat = config.value( "field_format", QgsDateTimeEditConfig::defaultFormat( field.type() ) ).toString();
 
   QDateTime date = QDateTime::fromString( value.toString(), fieldFormat );
 
@@ -120,7 +121,7 @@ unsigned int QgsDateTimeEditFactory::fieldScore( const QgsVectorLayer* vl, int f
   const QgsField field = vl->fields().field( fieldIdx );
   const QVariant::Type type = field.type();
   const QgsEditorWidgetConfig config = vl->editFormConfig().widgetConfig( field.name() );
-  if ( type == QVariant::DateTime || config.contains( "field_format" ) )
+  if ( type == QVariant::DateTime || type == QVariant::Date || type == QVariant::Time || config.contains( "field_format" ) )
   {
     return 20;
   }

--- a/src/gui/editorwidgets/qgsdatetimeeditwrapper.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeeditwrapper.cpp
@@ -18,6 +18,7 @@
 #include "qgsmessagelog.h"
 #include "qgslogger.h"
 #include "qgsdatetimeedit.h"
+#include "qgsdatetimeeditconfig.h"
 
 #include <QDateTimeEdit>
 #include <QDateEdit>
@@ -62,7 +63,7 @@ void QgsDateTimeEditWrapper::initWidget( QWidget *editor )
     return;
   }
 
-  const QString displayFormat = config( "display_format", QGSDATETIMEEDIT_DATEFORMAT ).toString();
+  const QString displayFormat = config( "display_format", QgsDateTimeEditConfig::defaultFormat( field().type() ) ).toString();
   mQDateTimeEdit->setDisplayFormat( displayFormat );
 
   const bool calendar = config( "calendar_popup", false ).toBool();
@@ -110,7 +111,7 @@ void QgsDateTimeEditWrapper::showIndeterminateState()
 
 void QgsDateTimeEditWrapper::dateTimeChanged( const QDateTime& dateTime )
 {
-  const QString fieldFormat = config( "field_format", QGSDATETIMEEDIT_DATEFORMAT ).toString();
+  const QString fieldFormat = config( "field_format", QgsDateTimeEditConfig::defaultFormat( field().type() ) ).toString();
   emit valueChanged( dateTime.toString( fieldFormat ) );
 }
 
@@ -131,7 +132,7 @@ QVariant QgsDateTimeEditWrapper::value() const
     }
   }
 
-  const QString fieldFormat = config( "field_format", QGSDATETIMEEDIT_DATEFORMAT ).toString();
+  const QString fieldFormat = config( "field_format", QgsDateTimeEditConfig::defaultFormat( field().type() ) ).toString();
 
   if ( mQgsDateTimeEdit )
   {
@@ -148,7 +149,7 @@ void QgsDateTimeEditWrapper::setValue( const QVariant &value )
   if ( !mQDateTimeEdit )
     return;
 
-  const QString fieldFormat = config( "field_format", QGSDATETIMEEDIT_DATEFORMAT ).toString();
+  const QString fieldFormat = config( "field_format", QgsDateTimeEditConfig::defaultFormat( field().type() ) ).toString();
   const QDateTime date = field().type() == QVariant::DateTime ? value.toDateTime() : QDateTime::fromString( value.toString(), fieldFormat );
 
   if ( mQgsDateTimeEdit )

--- a/src/gui/editorwidgets/qgsdatetimesearchwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsdatetimesearchwidgetwrapper.cpp
@@ -20,6 +20,7 @@
 #include "qgsvectorlayer.h"
 #include "qgsdatetimeedit.h"
 #include "qcalendarwidget.h"
+#include "qgsdatetimeeditconfig.h"
 
 #include <QSettings>
 
@@ -45,7 +46,7 @@ QVariant QgsDateTimeSearchWidgetWrapper::value() const
   if ( ! mDateTimeEdit )
     return QDateTime();
 
-  const QString fieldFormat = config( "field_format", QGSDATETIMEEDIT_DATEFORMAT ).toString();
+  const QString fieldFormat = config( "field_format", QgsDateTimeEditConfig::defaultFormat( layer()->fields().at( mFieldIdx ).type() ) ).toString();
   return mDateTimeEdit->dateTime().toString( fieldFormat );
 }
 
@@ -151,7 +152,7 @@ void QgsDateTimeSearchWidgetWrapper::initWidget( QWidget* editor )
   {
     mDateTimeEdit->setAllowNull( false );
 
-    const QString displayFormat = config( "display_format", QGSDATETIMEEDIT_DATEFORMAT ).toString();
+    const QString displayFormat = config( "display_format", QgsDateTimeEditConfig::defaultFormat( layer()->fields().at( mFieldIdx ).type() ) ).toString();
     mDateTimeEdit->setDisplayFormat( displayFormat );
 
     const bool calendar = config( "calendar_popup", false ).toBool();

--- a/src/gui/editorwidgets/qgsrangeconfigdlg.cpp
+++ b/src/gui/editorwidgets/qgsrangeconfigdlg.cpp
@@ -100,12 +100,12 @@ QgsEditorWidgetConfig QgsRangeConfigDlg::config()
 
 void QgsRangeConfigDlg::setConfig( const QgsEditorWidgetConfig& config )
 {
-  minimumDoubleSpinBox->setValue( config.value( "Min", 0.0 ).toDouble() );
-  maximumDoubleSpinBox->setValue( config.value( "Max", 5.0 ).toDouble() );
+  minimumDoubleSpinBox->setValue( config.value( "Min", -std::numeric_limits<double>::max() ).toDouble() );
+  maximumDoubleSpinBox->setValue( config.value( "Max", std::numeric_limits<double>::max() ).toDouble() );
   stepDoubleSpinBox->setValue( config.value( "Step", 1.0 ).toDouble() );
 
-  minimumSpinBox->setValue( config.value( "Min", 0 ).toInt() );
-  maximumSpinBox->setValue( config.value( "Max", 5 ).toInt() );
+  minimumSpinBox->setValue( config.value( "Min", std::numeric_limits<int>::min() ).toInt() );
+  maximumSpinBox->setValue( config.value( "Max", std::numeric_limits<int>::max() ).toInt() );
   stepSpinBox->setValue( config.value( "Step", 1 ).toInt() );
 
   rangeWidget->setCurrentIndex( rangeWidget->findData( config.value( "Style", "SpinBox" ) ) );

--- a/src/gui/editorwidgets/qgsrangewidgetfactory.cpp
+++ b/src/gui/editorwidgets/qgsrangewidgetfactory.cpp
@@ -73,7 +73,10 @@ void QgsRangeWidgetFactory::writeConfig( const QgsEditorWidgetConfig& config, QD
 
 unsigned int QgsRangeWidgetFactory::fieldScore( const QgsVectorLayer* vl, int fieldIdx ) const
 {
-  return vl->fields().at( fieldIdx ).isNumeric() ? 20 : 0;
+  const QgsField field = vl->fields().at( fieldIdx );
+  if ( field.type() == QVariant::Int || field.type() == QVariant::Double ) return 20;
+  if ( field.isNumeric() ) return 5; // widgets used support only signed 32bits (int) and double
+  return 0;
 }
 
 QMap<const char*, int> QgsRangeWidgetFactory::supportedWidgetTypes()

--- a/src/gui/editorwidgets/qgsrangewidgetwrapper.h
+++ b/src/gui/editorwidgets/qgsrangewidgetwrapper.h
@@ -21,6 +21,7 @@
 #include <QSpinBox>
 #include <QDoubleSpinBox>
 
+class QAbstractSlider;
 class QSlider;
 class QDial;
 class QgsSlider;

--- a/src/ui/editorwidgets/qgsrangeconfigdlgbase.ui
+++ b/src/ui/editorwidgets/qgsrangeconfigdlgbase.ui
@@ -93,10 +93,13 @@
        <item row="0" column="1">
         <widget class="QSpinBox" name="minimumSpinBox">
          <property name="minimum">
-          <number>-999999999</number>
+          <number>−2147483648</number>
          </property>
          <property name="maximum">
-          <number>999999999</number>
+          <number>2147483647</number>
+         </property>
+         <property name="value">
+          <number>−2147483648</number>
          </property>
         </widget>
        </item>
@@ -110,13 +113,13 @@
        <item row="1" column="1">
         <widget class="QSpinBox" name="maximumSpinBox">
          <property name="minimum">
-          <number>-999999999</number>
+          <number>−2147483648</number>
          </property>
          <property name="maximum">
-          <number>999999999</number>
+          <number>2147483647</number>
          </property>
          <property name="value">
-          <number>5</number>
+          <number>2147483647</number>
          </property>
         </widget>
        </item>
@@ -130,7 +133,7 @@
        <item row="2" column="1">
         <widget class="QSpinBox" name="stepSpinBox">
          <property name="maximum">
-          <number>999999999</number>
+          <number>2147483647</number>
          </property>
          <property name="value">
           <number>1</number>
@@ -168,30 +171,33 @@
        <item row="0" column="1">
         <widget class="QDoubleSpinBox" name="minimumDoubleSpinBox">
          <property name="minimum">
-          <double>-999999999.990000009536743</double>
+          <double>-1.79769e+308</double>
          </property>
          <property name="maximum">
-          <double>999999999.990000009536743</double>
+          <double>1.79769e+308</double>
+         </property>
+         <property name="value">
+          <double>-1.79769e+308</double>
          </property>
         </widget>
        </item>
        <item row="1" column="1">
         <widget class="QDoubleSpinBox" name="maximumDoubleSpinBox">
          <property name="minimum">
-          <double>-999999999.990000009536743</double>
+          <double>-1.79769e+308</double>
          </property>
          <property name="maximum">
-          <double>999999999.990000009536743</double>
+          <double>1.79769e+308</double>
          </property>
          <property name="value">
-          <double>5.000000000000000</double>
+          <double>1.79769e+308</double>
          </property>
         </widget>
        </item>
        <item row="2" column="1">
         <widget class="QDoubleSpinBox" name="stepDoubleSpinBox">
          <property name="maximum">
-          <double>999999999.990000009536743</double>
+          <double>1.79769e+308</double>
          </property>
          <property name="value">
           <double>1.000000000000000</double>

--- a/tests/src/gui/testqgseditorwidgetregistry.cpp
+++ b/tests/src/gui/testqgseditorwidgetregistry.cpp
@@ -68,6 +68,11 @@ class TestQgsEditorWidgetRegistry: public QObject
       checkSimple( "integer", "Range" );
     }
 
+    void longLongType()
+    {
+      checkSimple( "int8", "TextEdit" ); // no current widget supports 64 bit integers => default to TextEdit
+    }
+
     void doubleType()
     {
       checkSimple( "double", "Range" );


### PR DESCRIPTION
The default range was 0..100, made it to min..max of the type.
QgsRangeWidgetWrapper is auto selected only for Int and Double QVariants,
now. The used widgets don't support 64 bits and Uint ranges.
