### PR TITLE
Fix joins over several tables

### DIFF
--- a/src/core/qgsvectorlayerfeatureiterator.cpp
+++ b/src/core/qgsvectorlayerfeatureiterator.cpp
@@ -614,7 +614,7 @@ void QgsVectorLayerFeatureIterator::addJoinedAttributes( QgsFeature &f )
     if ( !targetFieldValue.isValid() )
     {
       //try later. Maybe the join depends on other joins
-      if ( f.fields()->fieldOrigin( info.targetField ) != QgsFields::OriginProvider )
+      if ( f.fields().fieldOrigin( info.targetField ) != QgsFields::OriginProvider )
       {
         joinList.push_back( info );
       }


### PR DESCRIPTION
Joining several tables together, it happens sometimes that joined fields have NULL  values. This  is because sometimes the target field has not assigned a value yet if it comes from another join. The pull request solves this issues by moving such joins to the end of a join list and the list is traversed until all the joins are resolved.
