### PR TITLE
Sort joins by dependency

### DIFF
--- a/src/core/qgsvectorlayerfeatureiterator.cpp
+++ b/src/core/qgsvectorlayerfeatureiterator.cpp
@@ -588,9 +588,9 @@ void QgsVectorLayerFeatureIterator::prepareFields()
 void QgsVectorLayerFeatureIterator::createOrderedJoinList()
 {
   mOrderedJoinInfoList = mFetchJoinInfo.values();
-  if( mOrderedJoinInfoList.size() < 2 )
+  if ( mOrderedJoinInfoList.size() < 2 )
   {
-      return;
+    return;
   }
 
   QSet<int> resolvedFields; //todo: get provider / virtual fields without joins

--- a/src/core/qgsvectorlayerfeatureiterator.cpp
+++ b/src/core/qgsvectorlayerfeatureiterator.cpp
@@ -559,6 +559,7 @@ void QgsVectorLayerFeatureIterator::prepareFields()
   mPreparedFields.clear();
   mFieldsToPrepare.clear();
   mFetchJoinInfo.clear();
+  mOrderedJoinInfoList.clear();
 
   mExpressionContext.reset( new QgsExpressionContext() );
   mExpressionContext->appendScope( QgsExpressionContextUtils::globalScope() );
@@ -575,6 +576,70 @@ void QgsVectorLayerFeatureIterator::prepareFields()
 
     mPreparedFields << fieldIdx;
     prepareField( fieldIdx );
+  }
+
+  //sort joins by dependency
+  if ( mFetchJoinInfo.size() > 0 )
+  {
+    createOrderedJoinList();
+  }
+}
+
+void QgsVectorLayerFeatureIterator::createOrderedJoinList()
+{
+  mOrderedJoinInfoList = mFetchJoinInfo.values();
+  if( mOrderedJoinInfoList.size() < 2 )
+  {
+      return;
+  }
+
+  QSet<int> resolvedFields; //todo: get provider / virtual fields without joins
+
+  //add all provider fields without joins as resolved fields
+  QList< int >::const_iterator prepFieldIt = mPreparedFields.constBegin();
+  for ( ; prepFieldIt != mPreparedFields.constEnd(); ++prepFieldIt )
+  {
+    if ( mSource->mFields.fieldOrigin( *prepFieldIt ) != QgsFields::OriginJoin )
+    {
+      resolvedFields.insert( *prepFieldIt );
+    }
+  }
+
+  //iterate through the joins. If target field is not yet covered, move the entry to the end of the list
+
+  //some join combinations might not have a resolution at all
+  int maxIterations = ( mOrderedJoinInfoList.size() + 1 ) * mOrderedJoinInfoList.size() / 2.0;
+  int currentIteration = 0;
+
+  for ( int i = 0; i < mOrderedJoinInfoList.size() - 1; ++i )
+  {
+    if ( !resolvedFields.contains( mOrderedJoinInfoList.at( i ).targetField ) )
+    {
+      mOrderedJoinInfoList.append( mOrderedJoinInfoList.at( i ) );
+      mOrderedJoinInfoList.removeAt( i );
+      --i;
+    }
+    else
+    {
+      int offset = mOrderedJoinInfoList.at( i ).indexOffset;
+      int joinField = mOrderedJoinInfoList.at( i ).joinField;
+
+      QgsAttributeList attributes = mOrderedJoinInfoList.at( i ).attributes;
+      QgsAttributeList::const_iterator attIt = attributes.constBegin();
+      for ( ; attIt != attributes.constEnd(); ++attIt )
+      {
+        if ( *attIt != joinField )
+        {
+          resolvedFields.insert( joinField < *attIt ? *attIt + offset - 1 : *attIt + offset );
+        }
+      }
+    }
+
+    ++currentIteration;
+    if ( currentIteration >= maxIterations )
+    {
+      break;
+    }
   }
 }
 
@@ -602,21 +667,18 @@ void QgsVectorLayerFeatureIterator::prepareField( int fieldIdx )
 
 void QgsVectorLayerFeatureIterator::addJoinedAttributes( QgsFeature &f )
 {
-  QMap<const QgsVectorJoinInfo*, FetchJoinInfo>::const_iterator joinIt = mFetchJoinInfo.constBegin();
-  for ( ; joinIt != mFetchJoinInfo.constEnd(); ++joinIt )
+  QList< FetchJoinInfo >::const_iterator joinIt = mOrderedJoinInfoList.constBegin();
+  for ( ; joinIt != mOrderedJoinInfoList.constEnd(); ++joinIt )
   {
-    const FetchJoinInfo& info = joinIt.value();
-    Q_ASSERT( joinIt.key() );
-
-    QVariant targetFieldValue = f.attribute( info.targetField );
+    QVariant targetFieldValue = f.attribute( joinIt->targetField );
     if ( !targetFieldValue.isValid() )
       continue;
 
-    const QHash< QString, QgsAttributes>& memoryCache = info.joinInfo->cachedAttributes;
+    const QHash< QString, QgsAttributes>& memoryCache = joinIt->joinInfo->cachedAttributes;
     if ( memoryCache.isEmpty() )
-      info.addJoinedAttributesDirect( f, targetFieldValue );
+      joinIt->addJoinedAttributesDirect( f, targetFieldValue );
     else
-      info.addJoinedAttributesCached( f, targetFieldValue );
+      joinIt->addJoinedAttributesCached( f, targetFieldValue );
   }
 }
 

--- a/src/core/qgsvectorlayerfeatureiterator.h
+++ b/src/core/qgsvectorlayerfeatureiterator.h
@@ -206,6 +206,9 @@ class CORE_EXPORT QgsVectorLayerFeatureIterator : public QgsAbstractFeatureItera
     QList< int > mPreparedFields;
     QList< int > mFieldsToPrepare;
 
+    /** Join list sorted by dependency*/
+    QList< FetchJoinInfo > mOrderedJoinInfoList;
+
     /**
      * Will always return true. We assume that ordering has been done on provider level already.
      *
@@ -214,6 +217,8 @@ class CORE_EXPORT QgsVectorLayerFeatureIterator : public QgsAbstractFeatureItera
 
     //! returns whether the iterator supports simplify geometries on provider side
     virtual bool providerCanSimplify( QgsSimplifyMethod::MethodType methodType ) const override;
+
+    void createOrderedJoinList();
 };
 
 #endif // QGSVECTORLAYERFEATUREITERATOR_H


### PR DESCRIPTION
Joining several tables together, it happens sometimes that joined fields have NULL values. This is because sometimes the target field has not assigned a value yet if it comes from another join. The pull request solves this issues by sorting the join list in dependency order in prepareFields()
