### PR TITLE
Preview of tiled layers (WMTS) + support XYZ tile layers

### DIFF
--- a/python/core/qgsmapsettings.sip
+++ b/python/core/qgsmapsettings.sip
@@ -116,7 +116,8 @@ class QgsMapSettings
       UseRenderingOptimization,   //!< Enable vector simplification and other rendering optimizations
       DrawSelection,              //!< Whether vector selections should be shown in the rendered map
       DrawSymbolBounds,           //!< Draw bounds of symbols (for debugging/testing)
-      RenderMapTile               //!< Draw map such that there are no problems between adjacent tiles
+      RenderMapTile,              //!< Draw map such that there are no problems between adjacent tiles
+      RenderPartialOutput,        //!< Whether to make extra effort to update map image with partially rendered layers (better for interactive map canvas). Added in QGIS 3.0
     };
     typedef QFlags<QgsMapSettings::Flag> Flags;
 

--- a/python/core/qgsrendercontext.sip
+++ b/python/core/qgsrendercontext.sip
@@ -23,6 +23,7 @@ class QgsRenderContext
       DrawSymbolBounds,         //!< Draw bounds of symbols (for debugging/testing)
       RenderMapTile,            //!< Draw map such that there are no problems between adjacent tiles
       Antialiasing,             //!< Use antialiasing while drawing
+      RenderPartialOutput,      //!< Whether to make extra effort to update map image with partially rendered layers (better for interactive map canvas). Added in QGIS 3.0
     };
     typedef QFlags<QgsRenderContext::Flag> Flags;
 

--- a/python/core/raster/qgsrasterinterface.sip
+++ b/python/core/raster/qgsrasterinterface.sip
@@ -9,7 +9,21 @@ class QgsRasterBlockFeedback : QgsFeedback
 %TypeHeaderCode
 #include <qgsrasterinterface.h>
 %End
-    // TODO: extend with preview functionality??
+
+  public:
+    //! construct a new raster block feedback object
+    QgsRasterBlockFeedback( QObject* parent = nullptr );
+
+    //! whether the raster provider should return only data that are already available
+    //! without waiting for full result
+    bool preview_only;
+
+    //! whether our painter is drawing to a temporary image used just by this layer
+    bool render_partial_output;
+
+    //! may be emitted by raster data provider to indicate that some partial data are available
+    //! and a new preview image may be produced
+    virtual void onNewData();
 };
 
 

--- a/python/core/raster/qgsrasterinterface.sip
+++ b/python/core/raster/qgsrasterinterface.sip
@@ -11,19 +11,28 @@ class QgsRasterBlockFeedback : QgsFeedback
 %End
 
   public:
-    //! construct a new raster block feedback object
+    //! Construct a new raster block feedback object
     QgsRasterBlockFeedback( QObject* parent = nullptr );
 
-    //! whether the raster provider should return only data that are already available
-    //! without waiting for full result
-    bool preview_only;
-
-    //! whether our painter is drawing to a temporary image used just by this layer
-    bool render_partial_output;
-
-    //! may be emitted by raster data provider to indicate that some partial data are available
+    //! May be emitted by raster data provider to indicate that some partial data are available
     //! and a new preview image may be produced
     virtual void onNewData();
+
+    //! Whether the raster provider should return only data that are already available
+    //! without waiting for full result. By default this flag is not enabled.
+    //! @see setPreviewOnly()
+    bool isPreviewOnly() const;
+    //! set flag whether the block request is for preview purposes only
+    //! @see isPreviewOnly()
+    void setPreviewOnly( bool preview );
+
+    //! Whether our painter is drawing to a temporary image used just by this layer
+    //! @see setRenderPartialOutput()
+    bool renderPartialOutput() const;
+    //! Set whether our painter is drawing to a temporary image used just by this layer
+    //! @see renderPartialOutput()
+    void setRenderPartialOutput( bool enable );
+
 };
 
 

--- a/python/core/raster/qgsrasterinterface.sip
+++ b/python/core/raster/qgsrasterinterface.sip
@@ -256,5 +256,10 @@ class QgsRasterInterface
                          int theStats = QgsRasterBandStats::All,
                          const QgsRectangle & theExtent = QgsRectangle(),
                          int theBinCount = 0 );
+
+  private:
+    QgsRasterInterface(const QgsRasterInterface &);
+    QgsRasterInterface &operator=(const QgsRasterInterface &);
+
 };
 

--- a/python/core/raster/qgsrasterprojector.sip
+++ b/python/core/raster/qgsrasterprojector.sip
@@ -1,6 +1,10 @@
 
-/** Raster projector */
-
+/** \ingroup core
+ * \brief QgsRasterProjector implements approximate projection support for
+ * it calculates grid of points in source CRS for target CRS + extent
+ * which are used to calculate affine transformation matrices.
+ * \class QgsRasterProjector
+ */
 class QgsRasterProjector : QgsRasterInterface
 {
 %TypeHeaderCode
@@ -18,33 +22,6 @@ class QgsRasterProjector : QgsRasterInterface
       Exact,   //!< Exact, precise but slow
     };
 
-    /** \brief QgsRasterProjector implements approximate projection support for
-     * it calculates grid of points in source CRS for target CRS + extent
-     * which are used to calculate affine transformation matrices.
-     */
-
-    QgsRasterProjector( const QgsCoordinateReferenceSystem& theSrcCRS,
-                        const QgsCoordinateReferenceSystem& theDestCRS,
-                        int theSrcDatumTransform,
-                        int theDestDatumTransform,
-                        const QgsRectangle& theDestExtent,
-                        int theDestRows, int theDestCols,
-                        double theMaxSrcXRes, double theMaxSrcYRes,
-                        const QgsRectangle& theExtent
-                      );
-
-    QgsRasterProjector( const QgsCoordinateReferenceSystem& theSrcCRS,
-                        const QgsCoordinateReferenceSystem& theDestCRS,
-                        const QgsRectangle& theDestExtent,
-                        int theDestRows, int theDestCols,
-                        double theMaxSrcXRes, double theMaxSrcYRes,
-                        const QgsRectangle& theExtent
-                      );
-    QgsRasterProjector( const QgsCoordinateReferenceSystem& theSrcCRS,
-                        const QgsCoordinateReferenceSystem& theDestCRS,
-                        double theMaxSrcXRes, double theMaxSrcYRes,
-                        const QgsRectangle& theExtent
-                      );
     QgsRasterProjector();
 
     /** \brief The destructor */

--- a/python/core/raster/qgsrasterprojector.sip
+++ b/python/core/raster/qgsrasterprojector.sip
@@ -43,9 +43,6 @@ class QgsRasterProjector : QgsRasterInterface
     /** \brief Get destination CRS */
     QgsCoordinateReferenceSystem destinationCrs() const;
 
-    /** \brief set maximum source resolution */
-    void setMaxSrcRes( double theMaxSrcXRes, double theMaxSrcYRes );
-
     Precision precision() const;
     void setPrecision( Precision precision );
     // Translated precision mode, for use in ComboBox etc.

--- a/src/app/qgslayerstylingwidget.cpp
+++ b/src/app/qgslayerstylingwidget.cpp
@@ -38,6 +38,7 @@
 #include "qgsrenderer.h"
 #include "qgsrendererregistry.h"
 #include "qgsmaplayerregistry.h"
+#include "qgsrasterdataprovider.h"
 #include "qgsrasterlayer.h"
 #include "qgsmaplayerconfigwidget.h"
 #include "qgsmaplayerstylemanagerwidget.h"
@@ -171,10 +172,14 @@ void QgsLayerStylingWidget::setLayer( QgsMapLayer *layer )
     transparencyItem->setToolTip( tr( "Transparency" ) );
     transparencyItem->setData( Qt::UserRole, RasterTransparency );
     mOptionsListWidget->addItem( transparencyItem );
-    QListWidgetItem* histogramItem = new QListWidgetItem( QgsApplication::getThemeIcon( "propertyicons/histogram.png" ), QString() );
-    histogramItem->setData( Qt::UserRole, RasterHistogram );
-    mOptionsListWidget->addItem( histogramItem );
-    histogramItem->setToolTip( tr( "Histogram" ) );
+
+    if ( static_cast<QgsRasterLayer*>( layer )->dataProvider()->capabilities() & QgsRasterDataProvider::Size )
+    {
+      QListWidgetItem* histogramItem = new QListWidgetItem( QgsApplication::getThemeIcon( "propertyicons/histogram.png" ), QString() );
+      histogramItem->setData( Qt::UserRole, RasterHistogram );
+      mOptionsListWidget->addItem( histogramItem );
+      histogramItem->setToolTip( tr( "Histogram" ) );
+    }
   }
 
   Q_FOREACH ( QgsMapLayerConfigWidgetFactory* factory, mPageFactories )
@@ -392,21 +397,24 @@ void QgsLayerStylingWidget::updateCurrentWidgetLayer()
       }
       case 2: // Histogram
       {
-        if ( mRasterStyleWidget )
+        if ( rlayer->dataProvider()->capabilities() & QgsRasterDataProvider::Size )
         {
-          mRasterStyleWidget->deleteLater();
-          delete mRasterStyleWidget;
+          if ( mRasterStyleWidget )
+          {
+            mRasterStyleWidget->deleteLater();
+            delete mRasterStyleWidget;
+          }
+          mRasterStyleWidget = new QgsRendererRasterPropertiesWidget( rlayer, mMapCanvas, mWidgetStack );
+          mRasterStyleWidget->syncToLayer( rlayer );
+          connect( mRasterStyleWidget, SIGNAL( widgetChanged() ), this, SLOT( autoApply() ) );
+
+          QgsRasterHistogramWidget* widget = new QgsRasterHistogramWidget( rlayer, mWidgetStack );
+          connect( widget, SIGNAL( widgetChanged() ), this, SLOT( autoApply() ) );
+          QString name = mRasterStyleWidget->currentRenderWidget()->renderer()->type();
+          widget->setRendererWidget( name, mRasterStyleWidget->currentRenderWidget() );
+
+          mWidgetStack->addMainPanel( widget );
         }
-        mRasterStyleWidget = new QgsRendererRasterPropertiesWidget( rlayer, mMapCanvas, mWidgetStack );
-        mRasterStyleWidget->syncToLayer( rlayer );
-        connect( mRasterStyleWidget, SIGNAL( widgetChanged() ), this, SLOT( autoApply() ) );
-
-        QgsRasterHistogramWidget* widget = new QgsRasterHistogramWidget( rlayer, mWidgetStack );
-        connect( widget, SIGNAL( widgetChanged() ), this, SLOT( autoApply() ) );
-        QString name = mRasterStyleWidget->currentRenderWidget()->renderer()->type();
-        widget->setRendererWidget( name, mRasterStyleWidget->currentRenderWidget() );
-
-        mWidgetStack->addMainPanel( widget );
         break;
       }
       default:

--- a/src/core/qgsmaplayer.cpp
+++ b/src/core/qgsmaplayer.cpp
@@ -234,7 +234,9 @@ bool QgsMapLayer::readLayerXml( const QDomElement& layerElement )
     // This is modified version of old QgsWmsProvider::parseUri
     // The new format has always params crs,format,layers,styles and that params
     // should not appear in old format url -> use them to identify version
-    if ( !mDataSource.contains( "crs=" ) && !mDataSource.contains( "format=" ) )
+    // XYZ tile layers do not need to contain crs,format params, but they have type=xyz
+    if ( !mDataSource.contains( "type=" ) &&
+         !mDataSource.contains( "crs=" ) && !mDataSource.contains( "format=" ) )
     {
       QgsDebugMsg( "Old WMS URI format detected -> converting to new format" );
       QgsDataSourceUri uri;

--- a/src/core/qgsmaprenderercustompainterjob.cpp
+++ b/src/core/qgsmaprenderercustompainterjob.cpp
@@ -333,6 +333,12 @@ bool QgsMapRendererJob::needTemporaryImage( QgsMapLayer* ml )
       return true;
     }
   }
+  else if ( ml->type() == QgsMapLayer::RasterLayer )
+  {
+    // preview of intermediate raster rendering results requires a temporary output image
+    if ( mSettings.testFlag( QgsMapSettings::RenderPartialOutput ) )
+      return true;
+  }
 
   return false;
 }

--- a/src/core/qgsmapsettings.h
+++ b/src/core/qgsmapsettings.h
@@ -164,7 +164,8 @@ class CORE_EXPORT QgsMapSettings
       UseRenderingOptimization = 0x20,  //!< Enable vector simplification and other rendering optimizations
       DrawSelection            = 0x40,  //!< Whether vector selections should be shown in the rendered map
       DrawSymbolBounds         = 0x80,  //!< Draw bounds of symbols (for debugging/testing)
-      RenderMapTile            = 0x100  //!< Draw map such that there are no problems between adjacent tiles
+      RenderMapTile            = 0x100, //!< Draw map such that there are no problems between adjacent tiles
+      RenderPartialOutput      = 0x200, //!< Whether to make extra effort to update map image with partially rendered layers (better for interactive map canvas). Added in QGIS 3.0
       // TODO: ignore scale-based visibility (overview)
     };
     Q_DECLARE_FLAGS( Flags, Flag )

--- a/src/core/qgsrendercontext.cpp
+++ b/src/core/qgsrendercontext.cpp
@@ -129,6 +129,7 @@ QgsRenderContext QgsRenderContext::fromMapSettings( const QgsMapSettings& mapSet
   ctx.setFlag( DrawSymbolBounds, mapSettings.testFlag( QgsMapSettings::DrawSymbolBounds ) );
   ctx.setFlag( RenderMapTile, mapSettings.testFlag( QgsMapSettings::RenderMapTile ) );
   ctx.setFlag( Antialiasing, mapSettings.testFlag( QgsMapSettings::Antialiasing ) );
+  ctx.setFlag( RenderPartialOutput, mapSettings.testFlag( QgsMapSettings::RenderPartialOutput ) );
   ctx.setRasterScaleFactor( 1.0 );
   ctx.setScaleFactor( mapSettings.outputDpi() / 25.4 ); // = pixels per mm
   ctx.setRendererScale( mapSettings.scale() );

--- a/src/core/qgsrendercontext.h
+++ b/src/core/qgsrendercontext.h
@@ -65,6 +65,7 @@ class CORE_EXPORT QgsRenderContext
       DrawSymbolBounds         = 0x20,  //!< Draw bounds of symbols (for debugging/testing)
       RenderMapTile            = 0x40,  //!< Draw map such that there are no problems between adjacent tiles
       Antialiasing             = 0x80,  //!< Use antialiasing while drawing
+      RenderPartialOutput      = 0x100, //!< Whether to make extra effort to update map image with partially rendered layers (better for interactive map canvas). Added in QGIS 3.0
     };
     Q_DECLARE_FLAGS( Flags, Flag )
 

--- a/src/core/raster/qgsrasterdrawer.cpp
+++ b/src/core/raster/qgsrasterdrawer.cpp
@@ -88,7 +88,7 @@ void QgsRasterDrawer::draw( QPainter* p, QgsRasterViewPort* viewPort, const QgsM
       }
     }
 
-    if ( feedback && feedback->render_partial_output )
+    if ( feedback && feedback->renderPartialOutput() )
     {
       // there could have been partial preview written before
       // so overwrite anything with the resulting image.

--- a/src/core/raster/qgsrasterdrawer.cpp
+++ b/src/core/raster/qgsrasterdrawer.cpp
@@ -88,9 +88,19 @@ void QgsRasterDrawer::draw( QPainter* p, QgsRasterViewPort* viewPort, const QgsM
       }
     }
 
+    if ( feedback && feedback->render_partial_output )
+    {
+      // there could have been partial preview written before
+      // so overwrite anything with the resulting image.
+      // (we are guaranteed to have a temporary image for this layer, see QgsMapRendererJob::needTemporaryImage)
+      p->setCompositionMode( QPainter::CompositionMode_Source );
+    }
+
     drawImage( p, viewPort, img, topLeftCol, topLeftRow, theQgsMapToPixel );
 
     delete block;
+
+    p->setCompositionMode( QPainter::CompositionMode_SourceOver );  // go back to the default composition mode
 
     // ok this does not matter much anyway as the tile size quite big so most of the time
     // there would be just one tile for the whole display area, but it won't hurt...

--- a/src/core/raster/qgsrasterinterface.h
+++ b/src/core/raster/qgsrasterinterface.h
@@ -270,6 +270,9 @@ class CORE_EXPORT QgsRasterInterface
                          int theStats = QgsRasterBandStats::All,
                          const QgsRectangle & theExtent = QgsRectangle(),
                          int theBinCount = 0 );
+
+  private:
+    Q_DISABLE_COPY( QgsRasterInterface )   // there is clone() for copying
 };
 
 #endif

--- a/src/core/raster/qgsrasterinterface.h
+++ b/src/core/raster/qgsrasterinterface.h
@@ -37,6 +37,7 @@
 class CORE_EXPORT QgsRasterBlockFeedback : public QgsFeedback
 {
   public:
+    //! construct a new raster block feedback object
     QgsRasterBlockFeedback( QObject* parent = nullptr ) : QgsFeedback( parent ), preview_only( false ), render_partial_output( false ) {}
 
     //! whether the raster provider should return only data that are already available

--- a/src/core/raster/qgsrasterinterface.h
+++ b/src/core/raster/qgsrasterinterface.h
@@ -37,19 +37,35 @@
 class CORE_EXPORT QgsRasterBlockFeedback : public QgsFeedback
 {
   public:
-    //! construct a new raster block feedback object
-    QgsRasterBlockFeedback( QObject* parent = nullptr ) : QgsFeedback( parent ), preview_only( false ), render_partial_output( false ) {}
+    //! Construct a new raster block feedback object
+    QgsRasterBlockFeedback( QObject* parent = nullptr ) : QgsFeedback( parent ), mPreviewOnly( false ), mRenderPartialOutput( false ) {}
 
-    //! whether the raster provider should return only data that are already available
-    //! without waiting for full result
-    bool preview_only;
-
-    //! whether our painter is drawing to a temporary image used just by this layer
-    bool render_partial_output;
-
-    //! may be emitted by raster data provider to indicate that some partial data are available
+    //! May be emitted by raster data provider to indicate that some partial data are available
     //! and a new preview image may be produced
     virtual void onNewData() {}
+
+    //! Whether the raster provider should return only data that are already available
+    //! without waiting for full result. By default this flag is not enabled.
+    //! @see setPreviewOnly()
+    bool isPreviewOnly() const { return mPreviewOnly; }
+    //! set flag whether the block request is for preview purposes only
+    //! @see isPreviewOnly()
+    void setPreviewOnly( bool preview ) { mPreviewOnly = preview; }
+
+    //! Whether our painter is drawing to a temporary image used just by this layer
+    //! @see setRenderPartialOutput()
+    bool renderPartialOutput() const { return mRenderPartialOutput; }
+    //! Set whether our painter is drawing to a temporary image used just by this layer
+    //! @see renderPartialOutput()
+    void setRenderPartialOutput( bool enable ) { mRenderPartialOutput = enable; }
+
+  private:
+    //! Whether the raster provider should return only data that are already available
+    //! without waiting for full result
+    bool mPreviewOnly;
+
+    //! Whether our painter is drawing to a temporary image used just by this layer
+    bool mRenderPartialOutput;
 };
 
 

--- a/src/core/raster/qgsrasterinterface.h
+++ b/src/core/raster/qgsrasterinterface.h
@@ -36,7 +36,16 @@
  */
 class CORE_EXPORT QgsRasterBlockFeedback : public QgsFeedback
 {
-    // TODO: extend with preview functionality??
+  public:
+    QgsRasterBlockFeedback( QObject* parent = nullptr ) : QgsFeedback( parent ), preview_only( false ) {}
+
+    //! whether the raster provider should return only data that are already available
+    //! without waiting for full result
+    bool preview_only;
+
+    //! may be emitted by raster data provider to indicate that some partial data are available
+    //! and a new preview image may be produced
+    virtual void onNewData() {}
 };
 
 

--- a/src/core/raster/qgsrasterinterface.h
+++ b/src/core/raster/qgsrasterinterface.h
@@ -37,11 +37,14 @@
 class CORE_EXPORT QgsRasterBlockFeedback : public QgsFeedback
 {
   public:
-    QgsRasterBlockFeedback( QObject* parent = nullptr ) : QgsFeedback( parent ), preview_only( false ) {}
+    QgsRasterBlockFeedback( QObject* parent = nullptr ) : QgsFeedback( parent ), preview_only( false ), render_partial_output( false ) {}
 
     //! whether the raster provider should return only data that are already available
     //! without waiting for full result
     bool preview_only;
+
+    //! whether our painter is drawing to a temporary image used just by this layer
+    bool render_partial_output;
 
     //! may be emitted by raster data provider to indicate that some partial data are available
     //! and a new preview image may be produced

--- a/src/core/raster/qgsrasterlayerrenderer.cpp
+++ b/src/core/raster/qgsrasterlayerrenderer.cpp
@@ -241,7 +241,7 @@ void QgsRasterLayerRenderer::Feedback::onNewData()
 
   // update only once upon a time
   // (preview itself takes some time)
-  if ( mLastPreview.msecsTo( QTime::currentTime() ) < mMinimalPreviewInterval )
+  if ( mLastPreview.isValid() && mLastPreview.msecsTo( QTime::currentTime() ) < mMinimalPreviewInterval )
     return;
 
   // TODO: update only the area that got new data

--- a/src/core/raster/qgsrasterlayerrenderer.cpp
+++ b/src/core/raster/qgsrasterlayerrenderer.cpp
@@ -236,8 +236,6 @@ QgsRasterLayerRenderer::Feedback::Feedback( QgsRasterLayerRenderer *r )
 
 void QgsRasterLayerRenderer::Feedback::onNewData()
 {
-  qDebug( "\nGOT NEW DATA!\n" );
-
   if ( !renderPartialOutput() )
     return;  // we were not asked for partial renders and we may not have a temporary image for overwriting...
 
@@ -248,7 +246,7 @@ void QgsRasterLayerRenderer::Feedback::onNewData()
 
   // TODO: update only the area that got new data
 
-  qDebug( "new raster preview! %d", mLastPreview.msecsTo( QTime::currentTime() ) );
+  QgsDebugMsg( QString( "new raster preview! %1" ).arg( mLastPreview.msecsTo( QTime::currentTime() ) ) );
   QTime t;
   t.start();
   QgsRasterBlockFeedback feedback;
@@ -257,6 +255,6 @@ void QgsRasterLayerRenderer::Feedback::onNewData()
   QgsRasterIterator iterator( mR->mPipe->last() );
   QgsRasterDrawer drawer( &iterator );
   drawer.draw( mR->mPainter, mR->mRasterViewPort, mR->mMapToPixel, &feedback );
-  qDebug( "PREVIEW TOOK %d ms", t.elapsed() );
+  QgsDebugMsg( QString( "total raster preview time: %1 ms" ).arg( t.elapsed() ) );
   mLastPreview = QTime::currentTime();
 }

--- a/src/core/raster/qgsrasterlayerrenderer.cpp
+++ b/src/core/raster/qgsrasterlayerrenderer.cpp
@@ -29,7 +29,7 @@ QgsRasterLayerRenderer::QgsRasterLayerRenderer( QgsRasterLayer* layer, QgsRender
     , mRasterViewPort( nullptr )
     , mPipe( nullptr )
     , mContext( rendererContext )
-    , mFeedback( new MyFeedback( this ) )
+    , mFeedback( new Feedback( this ) )
 {
   mPainter = rendererContext.painter();
   const QgsMapToPixel& theQgsMapToPixel = rendererContext.mapToPixel();
@@ -227,14 +227,14 @@ QgsFeedback* QgsRasterLayerRenderer::feedback() const
   return mFeedback;
 }
 
-MyFeedback::MyFeedback( QgsRasterLayerRenderer *r )
+QgsRasterLayerRenderer::Feedback::Feedback( QgsRasterLayerRenderer *r )
     : mR( r )
     , mMinimalPreviewInterval( 250 )
 {
   render_partial_output = r->mContext.testFlag( QgsRenderContext::RenderPartialOutput );
 }
 
-void MyFeedback::onNewData()
+void QgsRasterLayerRenderer::Feedback::onNewData()
 {
   qDebug( "\nGOT NEW DATA!\n" );
 

--- a/src/core/raster/qgsrasterlayerrenderer.cpp
+++ b/src/core/raster/qgsrasterlayerrenderer.cpp
@@ -231,22 +231,29 @@ MyFeedback::MyFeedback( QgsRasterLayerRenderer *r )
     : mR( r )
     , mMinimalPreviewInterval( 250 )
 {
+  render_partial_output = r->mContext.testFlag( QgsRenderContext::RenderPartialOutput );
 }
 
 void MyFeedback::onNewData()
 {
   qDebug( "\nGOT NEW DATA!\n" );
 
+  if ( !render_partial_output )
+    return;  // we were not asked for partial renders and we may not have a temporary image for overwriting...
+
   // update only once upon a time
   // (preview itself takes some time)
   if ( mLastPreview.msecsTo( QTime::currentTime() ) < mMinimalPreviewInterval )
     return;
+
+  // TODO: update only the area that got new data
 
   qDebug( "new raster preview! %d", mLastPreview.msecsTo( QTime::currentTime() ) );
   QTime t;
   t.start();
   QgsRasterBlockFeedback feedback;
   feedback.preview_only = true;
+  feedback.render_partial_output = true;
   QgsRasterIterator iterator( mR->mPipe->last() );
   QgsRasterDrawer drawer( &iterator );
   drawer.draw( mR->mPainter, mR->mRasterViewPort, mR->mMapToPixel, &feedback );

--- a/src/core/raster/qgsrasterlayerrenderer.cpp
+++ b/src/core/raster/qgsrasterlayerrenderer.cpp
@@ -231,14 +231,14 @@ QgsRasterLayerRenderer::Feedback::Feedback( QgsRasterLayerRenderer *r )
     : mR( r )
     , mMinimalPreviewInterval( 250 )
 {
-  render_partial_output = r->mContext.testFlag( QgsRenderContext::RenderPartialOutput );
+  setRenderPartialOutput( r->mContext.testFlag( QgsRenderContext::RenderPartialOutput ) );
 }
 
 void QgsRasterLayerRenderer::Feedback::onNewData()
 {
   qDebug( "\nGOT NEW DATA!\n" );
 
-  if ( !render_partial_output )
+  if ( !renderPartialOutput() )
     return;  // we were not asked for partial renders and we may not have a temporary image for overwriting...
 
   // update only once upon a time
@@ -252,8 +252,8 @@ void QgsRasterLayerRenderer::Feedback::onNewData()
   QTime t;
   t.start();
   QgsRasterBlockFeedback feedback;
-  feedback.preview_only = true;
-  feedback.render_partial_output = true;
+  feedback.setPreviewOnly( true );
+  feedback.setRenderPartialOutput( true );
   QgsRasterIterator iterator( mR->mPipe->last() );
   QgsRasterDrawer drawer( &iterator );
   drawer.draw( mR->mPainter, mR->mRasterViewPort, mR->mMapToPixel, &feedback );

--- a/src/core/raster/qgsrasterlayerrenderer.h
+++ b/src/core/raster/qgsrasterlayerrenderer.h
@@ -31,18 +31,6 @@ class QgsRasterLayerRenderer;
 
 #include "qgsrasterinterface.h"
 
-class MyFeedback : public QgsRasterBlockFeedback
-{
-  public:
-    explicit MyFeedback( QgsRasterLayerRenderer* r );
-
-    virtual void onNewData() override;
-  private:
-    QgsRasterLayerRenderer* mR;
-    int mMinimalPreviewInterval;  //!< in miliseconds
-    QTime mLastPreview;
-};
-
 
 /** \ingroup core
  * Implementation of threaded rendering for raster layers.
@@ -69,8 +57,22 @@ class QgsRasterLayerRenderer : public QgsMapLayerRenderer
     QgsRasterPipe* mPipe;
     QgsRenderContext& mContext;
 
-    MyFeedback* mFeedback;
-    friend class MyFeedback;
+    //! Specific feedback class to provide preview of raster layer rendering.
+    class Feedback : public QgsRasterBlockFeedback
+    {
+      public:
+        explicit Feedback( QgsRasterLayerRenderer* r );
+
+        //! when notified of new data in data provider it launches a preview draw of the raster
+        virtual void onNewData() override;
+      private:
+        QgsRasterLayerRenderer* mR;   //!< parent renderer instance
+        int mMinimalPreviewInterval;  //!< in miliseconds
+        QTime mLastPreview;           //!< when last preview has been generated
+    };
+
+    //! feedback class for cancellation and preview generation
+    Feedback* mFeedback;
 };
 
 

--- a/src/core/raster/qgsrasterlayerrenderer.h
+++ b/src/core/raster/qgsrasterlayerrenderer.h
@@ -27,6 +27,23 @@ class QgsRasterPipe;
 struct QgsRasterViewPort;
 class QgsRenderContext;
 
+class QgsRasterLayerRenderer;
+
+#include "qgsrasterinterface.h"
+
+class MyFeedback : public QgsRasterBlockFeedback
+{
+  public:
+    explicit MyFeedback( QgsRasterLayerRenderer* r );
+
+    virtual void onNewData() override;
+  private:
+    QgsRasterLayerRenderer* mR;
+    int mMinimalPreviewInterval;  //!< in miliseconds
+    QTime mLastPreview;
+};
+
+
 /** \ingroup core
  * Implementation of threaded rendering for raster layers.
  *
@@ -52,7 +69,9 @@ class QgsRasterLayerRenderer : public QgsMapLayerRenderer
     QgsRasterPipe* mPipe;
     QgsRenderContext& mContext;
 
-    QgsRasterBlockFeedback* mFeedback;
+    MyFeedback* mFeedback;
+    friend class MyFeedback;
 };
+
 
 #endif // QGSRASTERLAYERRENDERER_H

--- a/src/core/raster/qgsrasterlayerrenderer.h
+++ b/src/core/raster/qgsrasterlayerrenderer.h
@@ -57,10 +57,15 @@ class QgsRasterLayerRenderer : public QgsMapLayerRenderer
     QgsRasterPipe* mPipe;
     QgsRenderContext& mContext;
 
-    //! Specific feedback class to provide preview of raster layer rendering.
+    /** \ingroup core
+     * Specific internal feedback class to provide preview of raster layer rendering.
+     * @note added in 3.0
+     * @note not available in Python bindings
+     */
     class Feedback : public QgsRasterBlockFeedback
     {
       public:
+        //! Create feedback object based on our layer renderer
         explicit Feedback( QgsRasterLayerRenderer* r );
 
         //! when notified of new data in data provider it launches a preview draw of the raster

--- a/src/core/raster/qgsrasterprojector.cpp
+++ b/src/core/raster/qgsrasterprojector.cpp
@@ -23,98 +23,14 @@
 #include "qgscoordinatetransform.h"
 #include "qgscsexception.h"
 
-QgsRasterProjector::QgsRasterProjector(
-  const QgsCoordinateReferenceSystem& theSrcCRS,
-  const QgsCoordinateReferenceSystem& theDestCRS,
-  int theSrcDatumTransform,
-  int theDestDatumTransform,
-  const QgsRectangle& theDestExtent,
-  int theDestRows, int theDestCols,
-  double theMaxSrcXRes, double theMaxSrcYRes,
-  const QgsRectangle& theExtent )
-    : QgsRasterInterface( nullptr )
-    , mSrcCRS( theSrcCRS )
-    , mDestCRS( theDestCRS )
-    , mSrcDatumTransform( theSrcDatumTransform )
-    , mDestDatumTransform( theDestDatumTransform )
-    , mDestExtent( theDestExtent )
-    , mExtent( theExtent )
-    , mDestRows( theDestRows ), mDestCols( theDestCols )
-    , pHelperTop( nullptr ), pHelperBottom( nullptr )
-    , mMaxSrcXRes( theMaxSrcXRes ), mMaxSrcYRes( theMaxSrcYRes )
-    , mPrecision( Approximate )
-    , mApproximate( true )
-{
-  QgsDebugMsgLevel( "Entered", 4 );
-  QgsDebugMsgLevel( "theDestExtent = " + theDestExtent.toString(), 4 );
 
-  calc();
-}
-
-QgsRasterProjector::QgsRasterProjector(
-  const QgsCoordinateReferenceSystem& theSrcCRS,
-  const QgsCoordinateReferenceSystem& theDestCRS,
-  const QgsRectangle& theDestExtent,
-  int theDestRows, int theDestCols,
-  double theMaxSrcXRes, double theMaxSrcYRes,
-  const QgsRectangle& theExtent )
-    : QgsRasterInterface( nullptr )
-    , mSrcCRS( theSrcCRS )
-    , mDestCRS( theDestCRS )
-    , mSrcDatumTransform( -1 )
-    , mDestDatumTransform( -1 )
-    , mDestExtent( theDestExtent )
-    , mExtent( theExtent )
-    , mDestRows( theDestRows ), mDestCols( theDestCols )
-    , pHelperTop( nullptr ), pHelperBottom( nullptr )
-    , mMaxSrcXRes( theMaxSrcXRes ), mMaxSrcYRes( theMaxSrcYRes )
-    , mPrecision( Approximate )
-    , mApproximate( false )
-{
-  QgsDebugMsgLevel( "Entered", 4 );
-  QgsDebugMsgLevel( "theDestExtent = " + theDestExtent.toString(), 4 );
-
-  calc();
-}
-
-QgsRasterProjector::QgsRasterProjector(
-  const QgsCoordinateReferenceSystem& theSrcCRS,
-  const QgsCoordinateReferenceSystem& theDestCRS,
-  double theMaxSrcXRes, double theMaxSrcYRes,
-  const QgsRectangle& theExtent )
-    : QgsRasterInterface( nullptr )
-    , mSrcCRS( theSrcCRS )
-    , mDestCRS( theDestCRS )
-    , mSrcDatumTransform( -1 )
-    , mDestDatumTransform( -1 )
-    , mExtent( theExtent )
-    , mDestRows( 0 )
-    , mDestCols( 0 )
-    , mDestXRes( 0.0 )
-    , mDestYRes( 0.0 )
-    , mSrcRows( 0 )
-    , mSrcCols( 0 )
-    , mSrcXRes( 0.0 )
-    , mSrcYRes( 0.0 )
-    , mDestRowsPerMatrixRow( 0.0 )
-    , mDestColsPerMatrixCol( 0.0 )
-    , pHelperTop( nullptr ), pHelperBottom( nullptr )
-    , mHelperTopRow( 0 )
-    , mCPCols( 0 )
-    , mCPRows( 0 )
-    , mSqrTolerance( 0.0 )
-    , mMaxSrcXRes( theMaxSrcXRes )
-    , mMaxSrcYRes( theMaxSrcYRes )
-    , mPrecision( Approximate )
-    , mApproximate( false )
-{
-  QgsDebugMsgLevel( "Entered", 4 );
-}
 
 QgsRasterProjector::QgsRasterProjector()
     : QgsRasterInterface( nullptr )
     , mSrcDatumTransform( -1 )
     , mDestDatumTransform( -1 )
+    , mPrecision( Approximate )
+    , mApproximate( false )
     , mDestRows( 0 )
     , mDestCols( 0 )
     , mDestXRes( 0.0 )
@@ -133,64 +49,22 @@ QgsRasterProjector::QgsRasterProjector()
     , mSqrTolerance( 0.0 )
     , mMaxSrcXRes( 0 )
     , mMaxSrcYRes( 0 )
-    , mPrecision( Approximate )
-    , mApproximate( false )
 {
   QgsDebugMsgLevel( "Entered", 4 );
 }
 
-QgsRasterProjector::QgsRasterProjector( const QgsRasterProjector &projector )
-    : QgsRasterInterface( nullptr )
-    , pHelperTop( nullptr )
-    , pHelperBottom( nullptr )
-    , mHelperTopRow( 0 )
-    , mCPCols( 0 )
-    , mCPRows( 0 )
-    , mSqrTolerance( 0 )
-    , mApproximate( false )
-{
-  mSrcCRS = projector.mSrcCRS;
-  mDestCRS = projector.mDestCRS;
-  mSrcDatumTransform = projector.mSrcDatumTransform;
-  mDestDatumTransform = projector.mDestDatumTransform;
-  mMaxSrcXRes = projector.mMaxSrcXRes;
-  mMaxSrcYRes = projector.mMaxSrcYRes;
-  mExtent = projector.mExtent;
-  mDestRows = projector.mDestRows;
-  mDestCols = projector.mDestCols;
-  mDestXRes = projector.mDestXRes;
-  mDestYRes = projector.mDestYRes;
-  mSrcRows = projector.mSrcRows;
-  mSrcCols = projector.mSrcCols;
-  mSrcXRes = projector.mSrcXRes;
-  mSrcYRes = projector.mSrcYRes;
-  mDestRowsPerMatrixRow = projector.mDestRowsPerMatrixRow;
-  mDestColsPerMatrixCol = projector.mDestColsPerMatrixCol;
-  mPrecision = projector.mPrecision;
-}
-
-QgsRasterProjector & QgsRasterProjector::operator=( const QgsRasterProjector & projector )
-{
-  if ( &projector != this )
-  {
-    mSrcCRS = projector.mSrcCRS;
-    mDestCRS = projector.mDestCRS;
-    mSrcDatumTransform = projector.mSrcDatumTransform;
-    mDestDatumTransform = projector.mDestDatumTransform;
-    mMaxSrcXRes = projector.mMaxSrcXRes;
-    mMaxSrcYRes = projector.mMaxSrcYRes;
-    mExtent = projector.mExtent;
-    mPrecision = projector.mPrecision;
-  }
-  return *this;
-}
 
 QgsRasterProjector* QgsRasterProjector::clone() const
 {
   QgsDebugMsgLevel( "Entered", 4 );
-  QgsRasterProjector * projector = new QgsRasterProjector( mSrcCRS, mDestCRS, mMaxSrcXRes, mMaxSrcYRes, mExtent );
+  QgsRasterProjector * projector = new QgsRasterProjector;
+  projector->mSrcCRS = mSrcCRS;
+  projector->mDestCRS = mDestCRS;
   projector->mSrcDatumTransform = mSrcDatumTransform;
   projector->mDestDatumTransform = mDestDatumTransform;
+  projector->mMaxSrcXRes = mMaxSrcXRes;
+  projector->mMaxSrcYRes = mMaxSrcYRes;
+  projector->mExtent = mExtent;
   projector->mPrecision = mPrecision;
   return projector;
 }
@@ -897,17 +771,17 @@ QgsRasterBlock * QgsRasterProjector::block( int bandNo, QgsRectangle  const & ex
   mDestCols = width;
   calc();
 
-  QgsDebugMsgLevel( QString( "srcExtent:\n%1" ).arg( srcExtent().toString() ), 4 );
-  QgsDebugMsgLevel( QString( "srcCols = %1 srcRows = %2" ).arg( srcCols() ).arg( srcRows() ), 4 );
+  QgsDebugMsgLevel( QString( "srcExtent:\n%1" ).arg( mSrcExtent.toString() ), 4 );
+  QgsDebugMsgLevel( QString( "srcCols = %1 srcRows = %2" ).arg( mSrcCols ).arg( mSrcRows ), 4 );
 
   // If we zoom out too much, projector srcRows / srcCols maybe 0, which can cause problems in providers
-  if ( srcRows() <= 0 || srcCols() <= 0 )
+  if ( mSrcRows <= 0 || mSrcCols <= 0 )
   {
     QgsDebugMsgLevel( "Zero srcRows or srcCols", 4 );
     return new QgsRasterBlock();
   }
 
-  QgsRasterBlock *inputBlock = mInput->block( bandNo, srcExtent(), srcCols(), srcRows(), feedback );
+  QgsRasterBlock *inputBlock = mInput->block( bandNo, mSrcExtent, mSrcCols, mSrcRows, feedback );
   if ( !inputBlock || inputBlock->isEmpty() )
   {
     QgsDebugMsg( "No raster data!" );

--- a/src/core/raster/qgsrasterprojector.cpp
+++ b/src/core/raster/qgsrasterprojector.cpp
@@ -64,6 +64,10 @@ Qgis::DataType QgsRasterProjector::dataType( int bandNo ) const
   return Qgis::UnknownDataType;
 }
 
+
+/// @cond PRIVATE
+
+
 void QgsRasterProjector::setCrs( const QgsCoordinateReferenceSystem & theSrcCRS, const QgsCoordinateReferenceSystem & theDestCRS, int srcDatumTransform, int destDatumTransform )
 {
   mSrcCRS = theSrcCRS;
@@ -725,6 +729,9 @@ bool ProjectorData::checkRows( const QgsCoordinateTransform& ct )
   }
   return true;
 }
+
+/// @endcond
+
 
 QString QgsRasterProjector::precisionLabel( Precision precision )
 {

--- a/src/core/raster/qgsrasterprojector.h
+++ b/src/core/raster/qgsrasterprojector.h
@@ -36,6 +36,9 @@ class QgsPoint;
 class QgsCoordinateTransform;
 
 /** \ingroup core
+ * \brief QgsRasterProjector implements approximate projection support for
+ * it calculates grid of points in source CRS for target CRS + extent
+ * which are used to calculate affine transformation matrices.
  * \class QgsRasterProjector
  */
 class CORE_EXPORT QgsRasterProjector : public QgsRasterInterface
@@ -50,43 +53,10 @@ class CORE_EXPORT QgsRasterProjector : public QgsRasterInterface
       Exact = 1,   //!< Exact, precise but slow
     };
 
-    /** \brief QgsRasterProjector implements approximate projection support for
-     * it calculates grid of points in source CRS for target CRS + extent
-     * which are used to calculate affine transformation matrices.
-     */
-
-    QgsRasterProjector( const QgsCoordinateReferenceSystem& theSrcCRS,
-                        const QgsCoordinateReferenceSystem& theDestCRS,
-                        int theSrcDatumTransform,
-                        int theDestDatumTransform,
-                        const QgsRectangle& theDestExtent,
-                        int theDestRows, int theDestCols,
-                        double theMaxSrcXRes, double theMaxSrcYRes,
-                        const QgsRectangle& theExtent
-                      );
-
-    QgsRasterProjector( const QgsCoordinateReferenceSystem& theSrcCRS,
-                        const QgsCoordinateReferenceSystem& theDestCRS,
-                        const QgsRectangle& theDestExtent,
-                        int theDestRows, int theDestCols,
-                        double theMaxSrcXRes, double theMaxSrcYRes,
-                        const QgsRectangle& theExtent
-                      );
-    QgsRasterProjector( const QgsCoordinateReferenceSystem& theSrcCRS,
-                        const QgsCoordinateReferenceSystem& theDestCRS,
-                        double theMaxSrcXRes, double theMaxSrcYRes,
-                        const QgsRectangle& theExtent
-                      );
     QgsRasterProjector();
-    /** \brief Copy constructor */
-    // To avoid synthesized which fails on copy of QgsCoordinateTransform
-    // (QObject child) in Python bindings
-    QgsRasterProjector( const QgsRasterProjector &projector );
 
     /** \brief The destructor */
     ~QgsRasterProjector();
-
-    QgsRasterProjector & operator=( const QgsRasterProjector &projector );
 
     QgsRasterProjector *clone() const override;
 
@@ -128,23 +98,12 @@ class CORE_EXPORT QgsRasterProjector : public QgsRasterInterface
                             QgsRectangle& theDestExtent, int& theDestXSize, int& theDestYSize );
 
   private:
-    /** Get source extent */
-    QgsRectangle srcExtent() { return mSrcExtent; }
-
-    /** Get/set source width/height */
-    int srcRows() { return mSrcRows; }
-    int srcCols() { return mSrcCols; }
-    void setSrcRows( int theRows ) { mSrcRows = theRows; mSrcXRes = mSrcExtent.height() / mSrcRows; }
-    void setSrcCols( int theCols ) { mSrcCols = theCols; mSrcYRes = mSrcExtent.width() / mSrcCols; }
 
     /** \brief Get source row and column indexes for current source extent and resolution
         If source pixel is outside source extent theSrcRow and theSrcCol are left unchanged.
         @return true if inside source
      */
     bool srcRowCol( int theDestRow, int theDestCol, int *theSrcRow, int *theSrcCol, const QgsCoordinateTransform& ct );
-
-    int dstRows() const { return mDestRows; }
-    int dstCols() const { return mDestCols; }
 
     /** \brief get destination point for _current_ destination position */
     void destPointOnCPMatrix( int theRow, int theCol, double *theX, double *theY );
@@ -215,6 +174,16 @@ class CORE_EXPORT QgsRasterProjector : public QgsRasterInterface
     /** Destination datum transformation id (or -1 if none) */
     int mDestDatumTransform;
 
+    /** Requested precision */
+    Precision mPrecision;
+
+    /** Use approximation (requested precision is Approximate and it is possible to calculate
+     *  an approximation matrix with a sufficient precision) */
+    bool mApproximate;
+
+
+
+
     /** Destination extent */
     QgsRectangle mDestExtent;
 
@@ -284,12 +253,6 @@ class CORE_EXPORT QgsRasterProjector : public QgsRasterInterface
     double mMaxSrcXRes;
     double mMaxSrcYRes;
 
-    /** Requested precision */
-    Precision mPrecision;
-
-    /** Use approximation (requested precision is Approximate and it is possible to calculate
-     *  an approximation matrix with a sufficient precision) */
-    bool mApproximate;
 };
 
 #endif

--- a/src/core/raster/qgsrasterprojector.h
+++ b/src/core/raster/qgsrasterprojector.h
@@ -74,13 +74,6 @@ class CORE_EXPORT QgsRasterProjector : public QgsRasterInterface
     /** \brief Get destination CRS */
     QgsCoordinateReferenceSystem destinationCrs() const { return mDestCRS; }
 
-    /** \brief set maximum source resolution */
-    void setMaxSrcRes( double theMaxSrcXRes, double theMaxSrcYRes )
-    {
-      mMaxSrcXRes = theMaxSrcXRes;
-      mMaxSrcYRes = theMaxSrcYRes;
-    }
-
     Precision precision() const { return mPrecision; }
     void setPrecision( Precision precision ) { mPrecision = precision; }
     // Translated precision mode, for use in ComboBox etc.
@@ -99,12 +92,48 @@ class CORE_EXPORT QgsRasterProjector : public QgsRasterInterface
 
   private:
 
+    /** Source CRS */
+    QgsCoordinateReferenceSystem mSrcCRS;
+
+    /** Destination CRS */
+    QgsCoordinateReferenceSystem mDestCRS;
+
+    /** Source datum transformation id (or -1 if none) */
+    int mSrcDatumTransform;
+
+    /** Destination datum transformation id (or -1 if none) */
+    int mDestDatumTransform;
+
+    /** Requested precision */
+    Precision mPrecision;
+
+};
+
+/// @cond PRIVATE
+
+/**
+ * Internal class for reprojection of rasters - either exact or approximate.
+ * QgsRasterProjector creates it and then keeps calling srcRowCol() to get source pixel position
+ * for every destination pixel position.
+ */
+class ProjectorData
+{
+  public:
+    /** Initialize reprojector and calculate matrix */
+    ProjectorData( const QgsRectangle &extent, int width, int height, QgsRasterInterface *input, const QgsCoordinateTransform &inverseCt, QgsRasterProjector::Precision precision );
+    ~ProjectorData();
+
     /** \brief Get source row and column indexes for current source extent and resolution
         If source pixel is outside source extent theSrcRow and theSrcCol are left unchanged.
         @return true if inside source
      */
-    bool srcRowCol( int theDestRow, int theDestCol, int *theSrcRow, int *theSrcCol, const QgsCoordinateTransform& ct );
+    bool srcRowCol( int theDestRow, int theDestCol, int *theSrcRow, int *theSrcCol );
 
+    QgsRectangle srcExtent() const { return mSrcExtent; }
+    int srcRows() const { return mSrcRows; }
+    int srcCols() const { return mSrcCols; }
+
+  private:
     /** \brief get destination point for _current_ destination position */
     void destPointOnCPMatrix( int theRow, int theCol, double *theX, double *theY );
 
@@ -112,17 +141,11 @@ class CORE_EXPORT QgsRasterProjector : public QgsRasterInterface
     int matrixRow( int theDestRow );
     int matrixCol( int theDestCol );
 
-    /** \brief get destination point for _current_ matrix position */
-    QgsPoint srcPoint( int theRow, int theCol );
-
     /** \brief Get precise source row and column indexes for current source extent and resolution */
-    inline bool preciseSrcRowCol( int theDestRow, int theDestCol, int *theSrcRow, int *theSrcCol, const QgsCoordinateTransform& ct );
+    inline bool preciseSrcRowCol( int theDestRow, int theDestCol, int *theSrcRow, int *theSrcCol );
 
     /** \brief Get approximate source row and column indexes for current source extent and resolution */
     inline bool approximateSrcRowCol( int theDestRow, int theDestCol, int *theSrcRow, int *theSrcCol );
-
-    /** \brief Calculate matrix */
-    void calc();
 
     /** \brief insert rows to matrix */
     void insertRows( const QgsCoordinateTransform& ct );
@@ -162,27 +185,12 @@ class CORE_EXPORT QgsRasterProjector : public QgsRasterInterface
     /** Get mCPMatrix as string */
     QString cpToString();
 
-    /** Source CRS */
-    QgsCoordinateReferenceSystem mSrcCRS;
-
-    /** Destination CRS */
-    QgsCoordinateReferenceSystem mDestCRS;
-
-    /** Source datum transformation id (or -1 if none) */
-    int mSrcDatumTransform;
-
-    /** Destination datum transformation id (or -1 if none) */
-    int mDestDatumTransform;
-
-    /** Requested precision */
-    Precision mPrecision;
-
     /** Use approximation (requested precision is Approximate and it is possible to calculate
      *  an approximation matrix with a sufficient precision) */
     bool mApproximate;
 
-
-
+    /** Transformation from destination CRS to source CRS */
+    QgsCoordinateTransform* mInverseCt;
 
     /** Destination extent */
     QgsRectangle mDestExtent;
@@ -254,6 +262,8 @@ class CORE_EXPORT QgsRasterProjector : public QgsRasterInterface
     double mMaxSrcYRes;
 
 };
+
+/// @endcond
 
 #endif
 

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -143,6 +143,7 @@ QgsMapCanvas::QgsMapCanvas( QWidget * parent )
 
   mSettings.setFlag( QgsMapSettings::DrawEditingInfo );
   mSettings.setFlag( QgsMapSettings::UseRenderingOptimization );
+  mSettings.setFlag( QgsMapSettings::RenderPartialOutput );
 
   //segmentation parameters
   QSettings settings;

--- a/src/gui/raster/qgsrastertransparencywidget.cpp
+++ b/src/gui/raster/qgsrastertransparencywidget.cpp
@@ -76,6 +76,13 @@ void QgsRasterTransparencyWidget::syncToLayer()
   QgsRasterRenderer* renderer = mRasterLayer->renderer();
   if ( provider )
   {
+    if ( provider->dataType( 1 ) == Qgis::ARGB32
+         || provider->dataType( 1 ) == Qgis::ARGB32_Premultiplied )
+    {
+      gboxNoDataValue->setEnabled( false );
+      gboxCustomTransparency->setEnabled( false );
+    }
+
     cboxTransparencyBand->addItem( tr( "None" ), -1 );
     int nBands = provider->bandCount();
     QString bandName;

--- a/src/providers/wms/CMakeLists.txt
+++ b/src/providers/wms/CMakeLists.txt
@@ -9,6 +9,7 @@ SET (WMS_SRCS
   qgswmssourceselect.cpp
   qgswmsconnection.cpp
   qgswmsdataitems.cpp
+  qgstilecache.cpp
   qgstilescalewidget.cpp
   qgswmtsdimensions.cpp
   qgsxyzconnection.cpp

--- a/src/providers/wms/CMakeLists.txt
+++ b/src/providers/wms/CMakeLists.txt
@@ -11,6 +11,7 @@ SET (WMS_SRCS
   qgswmsdataitems.cpp
   qgstilescalewidget.cpp
   qgswmtsdimensions.cpp
+  qgsxyzconnection.cpp
 )
 SET (WMS_MOC_HDRS
   qgswmscapabilities.h

--- a/src/providers/wms/qgstilecache.cpp
+++ b/src/providers/wms/qgstilecache.cpp
@@ -1,0 +1,57 @@
+/***************************************************************************
+  qgstilecache.h
+  --------------------------------------
+  Date                 : September 2016
+  Copyright            : (C) 2016 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgstilecache.h"
+
+#include "qgsnetworkaccessmanager.h"
+
+#include <QAbstractNetworkCache>
+#include <QImage>
+
+QCache<QUrl, QImage> QgsTileCache::sTileCache( 256 );
+QMutex QgsTileCache::sTileCacheMutex;
+
+
+void QgsTileCache::insertTile( const QUrl& url, const QImage& image )
+{
+  QMutexLocker locker( &sTileCacheMutex );
+  sTileCache.insert( url, new QImage( image ) );
+}
+
+bool QgsTileCache::tile( const QUrl& url, QImage& image )
+{
+  QMutexLocker locker( &sTileCacheMutex );
+  if ( QImage* i = sTileCache.object( url ) )
+  {
+    image = *i;
+    return true;
+  }
+  else if ( QgsNetworkAccessManager::instance()->cache()->metaData( url ).isValid() )
+  {
+    if ( QIODevice* data = QgsNetworkAccessManager::instance()->cache()->data( url ) )
+    {
+      QByteArray imageData = data->readAll();
+      delete data;
+
+      image = QImage::fromData( imageData );
+
+      // cache it as well (mutex is already locked)
+      sTileCache.insert( url, new QImage( image ) );
+
+      return true;
+    }
+  }
+  return false;
+}

--- a/src/providers/wms/qgstilecache.h
+++ b/src/providers/wms/qgstilecache.h
@@ -1,0 +1,56 @@
+/***************************************************************************
+  qgstilecache.h
+  --------------------------------------
+  Date                 : September 2016
+  Copyright            : (C) 2016 by Martin Dobias
+  Email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSTILECACHE_H
+#define QGSTILECACHE_H
+
+
+#include <QCache>
+#include <QMutex>
+
+class QImage;
+class QUrl;
+
+/** A simple tile cache implementation. Tiles are cached according to their URL.
+ * There is a small in-memory cache and a secondary caching in the local disk.
+ * The in-memory cache is there to save CPU time otherwise wasted to read and
+ * uncompress data saved on the disk.
+ *
+ * The class is thread safe (its methods can be called from any thread).
+ */
+class QgsTileCache
+{
+  public:
+
+    //! Add a tile image with given URL to the cache
+    static void insertTile( const QUrl& url, const QImage& image );
+
+    //! Try to access a tile and load it into "image" argument
+    //! @returns true if the tile exists in the cache
+    static bool tile( const QUrl& url, QImage& image );
+
+    //! how many tiles are stored in the in-memory cache
+    static int totalCost() { return sTileCache.totalCost(); }
+    //! how many tiles can be stored in the in-memory cache
+    static int maxCost() { return sTileCache.maxCost(); }
+
+  private:
+    //! in-memory cache
+    static QCache<QUrl, QImage> sTileCache;
+    //! mutex to protect the in-memory cache
+    static QMutex sTileCacheMutex;
+};
+
+#endif // QGSTILECACHE_H

--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -2151,3 +2151,15 @@ const QgsWmtsTileMatrix* QgsWmtsTileMatrixSet::findNearestResolution( double vre
 
   return &it.value();
 }
+
+const QgsWmtsTileMatrix *QgsWmtsTileMatrixSet::findOtherResolution( double tres, int offset ) const
+{
+  QMap<double, QgsWmtsTileMatrix>::const_iterator it = tileMatrices.constFind( tres );
+  if ( it == tileMatrices.constEnd() )
+    return nullptr;
+  it += offset;
+  if ( it == tileMatrices.constEnd() )
+    return nullptr;
+
+  return &it.value();
+}

--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -2157,9 +2157,25 @@ const QgsWmtsTileMatrix *QgsWmtsTileMatrixSet::findOtherResolution( double tres,
   QMap<double, QgsWmtsTileMatrix>::const_iterator it = tileMatrices.constFind( tres );
   if ( it == tileMatrices.constEnd() )
     return nullptr;
-  it += offset;
-  if ( it == tileMatrices.constEnd() )
-    return nullptr;
+  while ( 1 )
+  {
+    if ( offset > 0 )
+    {
+      ++it;
+      --offset;
+    }
+    else if ( offset < 0 )
+    {
+      if ( it == tileMatrices.constBegin() )
+        return nullptr;
+      --it;
+      ++offset;
+    }
+    else
+      break;
 
+    if ( it == tileMatrices.constEnd() )
+      return nullptr;
+  }
   return &it.value();
 }

--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -40,6 +40,37 @@ bool QgsWmsSettings::parseUri( const QString& uriString )
   QgsDataSourceUri uri;
   uri.setEncodedUri( uriString );
 
+  mXyz = false;  // assume WMS / WMTS
+
+  if ( uri.param( "type" ) == "xyz" )
+  {
+    // for XYZ tiles most of the things do not apply
+    mTiled = true;
+    mXyz = true;
+    mTileDimensionValues.clear();
+    mTileMatrixSetId = "tms0";
+    mMaxWidth = 0;
+    mMaxHeight = 0;
+    mHttpUri = uri.param( "url" );
+    mBaseUrl = mHttpUri;
+    mAuth.mUserName.clear();
+    mAuth.mPassword.clear();
+    mAuth.mReferer.clear();
+    mAuth.mAuthCfg.clear();
+    mIgnoreGetMapUrl = false;
+    mIgnoreGetFeatureInfoUrl = false;
+    mSmoothPixmapTransform = false;
+    mDpiMode = dpiNone; // does not matter what we set here
+    mActiveSubLayers = QStringList( "xyz" );  // just a placeholder to have one sub-layer
+    mActiveSubStyles = QStringList( "xyz" );  // just a placeholder to have one sub-style
+    mActiveSubLayerVisibility.clear();
+    mFeatureCount = 0;
+    mImageMimeType.clear();
+    mCrsId = "EPSG:3857";
+    mEnableContextualLegend = false;
+    return true;
+  }
+
   mTiled = false;
   mTileDimensionValues.clear();
 

--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -1258,6 +1258,7 @@ void QgsWmsCapabilities::parseTileSetProfile( QDomElement const &e )
     m.matrixWidth  = ceil( l.boundingBoxes.at( 0 ).box.width() / m.tileWidth / r );
     m.matrixHeight = ceil( l.boundingBoxes.at( 0 ).box.height() / m.tileHeight / r );
     m.topLeft = QgsPoint( l.boundingBoxes.at( 0 ).box.xMinimum(), l.boundingBoxes.at( 0 ).box.yMinimum() + m.matrixHeight * m.tileHeight * r );
+    m.tres = r;
     ms.tileMatrices.insert( r, m );
     i++;
   }
@@ -1340,17 +1341,19 @@ void QgsWmsCapabilities::parseWMTSContents( QDomElement const &e )
       m.matrixWidth  = e1.firstChildElement( "MatrixWidth" ).text().toInt();
       m.matrixHeight = e1.firstChildElement( "MatrixHeight" ).text().toInt();
 
-      double res = m.scaleDenom * 0.00028 / metersPerUnit;
+      // the magic number below is "standardized rendering pixel size" defined
+      // in WMTS (and WMS 1.3) standard, being 0.28 pixel
+      m.tres = m.scaleDenom * 0.00028 / metersPerUnit;
 
       QgsDebugMsg( QString( " %1: scale=%2 res=%3 tile=%4x%5 matrix=%6x%7 topLeft=%8" )
                    .arg( m.identifier )
-                   .arg( m.scaleDenom ).arg( res )
+                   .arg( m.scaleDenom ).arg( m.tres )
                    .arg( m.tileWidth ).arg( m.tileHeight )
                    .arg( m.matrixWidth ).arg( m.matrixHeight )
                    .arg( m.topLeft.toString() )
                  );
 
-      s.tileMatrices.insert( res, m );
+      s.tileMatrices.insert( m.tres, m );
     }
 
     mTileMatrixSets.insert( s.identifier, s );
@@ -1797,6 +1800,8 @@ bool QgsWmsCapabilities::detectTileLayerBoundingBox( QgsWmtsTileLayer& l )
 
   const QgsWmtsTileMatrix& tm = *tmIt;
   double metersPerUnit = QgsUnitTypes::fromUnitToUnitFactor( crs.mapUnits(), QgsUnitTypes::DistanceMeters );
+  // the magic number below is "standardized rendering pixel size" defined
+  // in WMTS (and WMS 1.3) standard, being 0.28 pixel
   double res = tm.scaleDenom * 0.00028 / metersPerUnit;
   QgsPoint bottomRight( tm.topLeft.x() + res * tm.tileWidth * tm.matrixWidth,
                         tm.topLeft.y() - res * tm.tileHeight * tm.matrixHeight );
@@ -2048,4 +2053,70 @@ void QgsWmsCapabilitiesDownload::capabilitiesReplyFinished()
   }
 
   emit downloadFinished();
+}
+
+QRectF QgsWmtsTileMatrix::tileRect( int col, int row ) const
+{
+  double twMap = tileWidth * tres;
+  double thMap = tileHeight * tres;
+  return QRectF( topLeft.x() + col * twMap, topLeft.y() - ( row + 1 ) * thMap, twMap, thMap );
+}
+
+QgsRectangle QgsWmtsTileMatrix::tileBBox( int col, int row ) const
+{
+  double twMap = tileWidth * tres;
+  double thMap = tileHeight * tres;
+  return QgsRectangle(
+           topLeft.x() +         col * twMap,
+           topLeft.y() - ( row + 1 ) * thMap,
+           topLeft.x() + ( col + 1 ) * twMap,
+           topLeft.y() -         row * thMap );
+}
+
+void QgsWmtsTileMatrix::viewExtentIntersection( const QgsRectangle &viewExtent, const QgsWmtsTileMatrixLimits* tml, int &col0, int &row0, int &col1, int &row1 ) const
+{
+  double twMap = tileWidth * tres;
+  double thMap = tileHeight * tres;
+
+  int minTileCol = 0;
+  int maxTileCol = matrixWidth - 1;
+  int minTileRow = 0;
+  int maxTileRow = matrixHeight - 1;
+
+  if ( tml )
+  {
+    minTileCol = tml->minTileCol;
+    maxTileCol = tml->maxTileCol;
+    minTileRow = tml->minTileRow;
+    maxTileRow = tml->maxTileRow;
+    //QgsDebugMsg( QString( "%1 %2: TileMatrixLimits col %3-%4 row %5-%6" )
+    //             .arg( tileMatrixSet->identifier, identifier )
+    //             .arg( minTileCol ).arg( maxTileCol )
+    //             .arg( minTileRow ).arg( maxTileRow ) );
+  }
+
+  col0 = qBound( minTileCol, ( int ) floor(( viewExtent.xMinimum() - topLeft.x() ) / twMap ), maxTileCol );
+  row0 = qBound( minTileRow, ( int ) floor(( topLeft.y() - viewExtent.yMaximum() ) / thMap ), maxTileRow );
+  col1 = qBound( minTileCol, ( int ) floor(( viewExtent.xMaximum() - topLeft.x() ) / twMap ), maxTileCol );
+  row1 = qBound( minTileRow, ( int ) floor(( topLeft.y() - viewExtent.yMinimum() ) / thMap ), maxTileRow );
+}
+
+const QgsWmtsTileMatrix* QgsWmtsTileMatrixSet::findNearestResolution( double vres ) const
+{
+  QMap<double, QgsWmtsTileMatrix>::const_iterator prev, it = tileMatrices.constBegin();
+  while ( it != tileMatrices.constEnd() && it.key() < vres )
+  {
+    //QgsDebugMsg( QString( "res:%1 >= %2" ).arg( it.key() ).arg( vres ) );
+    prev = it;
+    ++it;
+  }
+
+  if ( it == tileMatrices.constEnd() ||
+       ( it != tileMatrices.constBegin() && vres - prev.key() < it.key() - vres ) )
+  {
+    //QgsDebugMsg( "back to previous res" );
+    it = prev;
+  }
+
+  return &it.value();
 }

--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -59,7 +59,7 @@ bool QgsWmsSettings::parseUri( const QString& uriString )
     mAuth.mAuthCfg.clear();
     mIgnoreGetMapUrl = false;
     mIgnoreGetFeatureInfoUrl = false;
-    mSmoothPixmapTransform = false;
+    mSmoothPixmapTransform = true;
     mDpiMode = dpiNone; // does not matter what we set here
     mActiveSubLayers = QStringList( "xyz" );  // just a placeholder to have one sub-layer
     mActiveSubStyles = QStringList( "xyz" );  // just a placeholder to have one sub-style

--- a/src/providers/wms/qgswmscapabilities.h
+++ b/src/providers/wms/qgswmscapabilities.h
@@ -308,17 +308,33 @@ struct QgsWmtsTheme
   ~QgsWmtsTheme() { delete subTheme; }
 };
 
+struct QgsWmtsTileMatrixLimits;
+
 struct QgsWmtsTileMatrix
 {
   QString identifier;
   QString title, abstract;
   QStringList keywords;
   double scaleDenom;
-  QgsPoint topLeft;
-  int tileWidth;
-  int tileHeight;
-  int matrixWidth;
-  int matrixHeight;
+  QgsPoint topLeft;  //!< top-left corner of the tile matrix in map units
+  int tileWidth;     //!< width of a tile in pixels
+  int tileHeight;    //!< height of a tile in pixels
+  int matrixWidth;   //!< number of tiles horizontally
+  int matrixHeight;  //!< number of tiles vertically
+  double tres;       //!< pixel span in map units
+
+  //! Returns extent of a tile in map coordinates.
+  //! (same function as tileBBox() but returns QRectF instead of QgsRectangle)
+  QRectF tileRect( int col, int row ) const;
+
+  //! Returns extent of a tile in map coordinates
+  //! (same function as tileRect() but returns QgsRectangle instead of QRectF)
+  QgsRectangle tileBBox( int col, int row ) const;
+
+  //! Returns range of tiles that intersects with the view extent
+  //! (tml may be null)
+  void viewExtentIntersection( const QgsRectangle& viewExtent, const QgsWmtsTileMatrixLimits* tml, int& col0, int& row0, int& col1, int& row1 ) const;
+
 };
 
 struct QgsWmtsTileMatrixSet
@@ -329,6 +345,9 @@ struct QgsWmtsTileMatrixSet
   QString crs;
   QString wkScaleSet;
   QMap<double, QgsWmtsTileMatrix> tileMatrices;
+
+  //! Returns closest tile resolution to the requested one. (resolution = width [map units] / with [pixels])
+  const QgsWmtsTileMatrix* findNearestResolution( double vres ) const;
 };
 
 enum QgsTileMode { WMTS, WMSC };

--- a/src/providers/wms/qgswmscapabilities.h
+++ b/src/providers/wms/qgswmscapabilities.h
@@ -350,6 +350,9 @@ struct QgsWmtsTileMatrixSet
 
   //! Returns closest tile resolution to the requested one. (resolution = width [map units] / with [pixels])
   const QgsWmtsTileMatrix* findNearestResolution( double vres ) const;
+
+  //! Return tile matrix for other near resolution from given tres (positive offset = lower resolution tiles)
+  const QgsWmtsTileMatrix* findOtherResolution( double tres, int offset ) const;
 };
 
 enum QgsTileMode { WMTS, WMSC, XYZ };

--- a/src/providers/wms/qgswmscapabilities.h
+++ b/src/providers/wms/qgswmscapabilities.h
@@ -339,18 +339,20 @@ struct QgsWmtsTileMatrix
 
 struct QgsWmtsTileMatrixSet
 {
-  QString identifier;
-  QString title, abstract;
-  QStringList keywords;
-  QString crs;
-  QString wkScaleSet;
+  QString identifier;   //!< tile matrix set identifier
+  QString title;        //!< human readable tile matrix set name
+  QString abstract;     //!< brief description of the tile matrix set
+  QStringList keywords; //!< list of words/phrases to describe the dataset
+  QString crs;          //!< CRS of the tile matrix set
+  QString wkScaleSet;   //!< optional reference to a well-known scale set
+  //! available tile matrixes (key = pixel span in map units)
   QMap<double, QgsWmtsTileMatrix> tileMatrices;
 
   //! Returns closest tile resolution to the requested one. (resolution = width [map units] / with [pixels])
   const QgsWmtsTileMatrix* findNearestResolution( double vres ) const;
 };
 
-enum QgsTileMode { WMTS, WMSC };
+enum QgsTileMode { WMTS, WMSC, XYZ };
 
 struct QgsWmtsTileMatrixLimits
 {
@@ -382,16 +384,22 @@ struct QgsWmtsStyle
   QList<QgsWmtsLegendURL> legendURLs;
 };
 
+/**
+ * In case of multi-dimensional data, the service metadata can describe their multi-
+ * dimensionality and tiles can be requested at specific values in these dimensions.
+ * Examples of dimensions are Time, Elevation and Band.
+ */
 struct QgsWmtsDimension
 {
-  QString identifier;
-  QString title, abstract;
-  QStringList keywords;
-  QString UOM;
-  QString unitSymbol;
-  QString defaultValue;
-  bool current;
-  QStringList values;
+  QString identifier;   //!< name of the dimensional axis
+  QString title;        //!< human readable name
+  QString abstract;     //!< brief description of the dimension
+  QStringList keywords; //!< list of words/phrases to describe the dataset
+  QString UOM;          //!< units of measure of dimensional axis
+  QString unitSymbol;   //!< symbol of the units
+  QString defaultValue; //!< default value to be used if value is not specified in request
+  bool current;         //!< indicates whether temporal data are normally kept current
+  QStringList values;   //!< available values for this dimension
 };
 
 struct QgsWmtsTileLayer
@@ -404,6 +412,7 @@ struct QgsWmtsTileLayer
   QStringList formats;
   QStringList infoFormats;
   QString defaultStyle;
+  //! available dimensions (optional, for multi-dimensional data)
   QHash<QString, QgsWmtsDimension> dimensions;
   QHash<QString, QgsWmtsStyle> styles;
   QHash<QString, QgsWmtsTileMatrixSetLink> setLinks;
@@ -532,7 +541,11 @@ class QgsWmsSettings
 
     //! layer is tiled, tile layer and active matrix set
     bool                    mTiled;
+    //! whether we actually work with XYZ tiles instead of WMS / WMTS
+    bool mXyz;
+    //! chosen values for dimensions in case of multi-dimensional data (key=dim id, value=dim value)
     QHash<QString, QString>  mTileDimensionValues;
+    //! name of the chosen tile matrix set
     QString                 mTileMatrixSetId;
 
     /**

--- a/src/providers/wms/qgswmsdataitems.cpp
+++ b/src/providers/wms/qgswmsdataitems.cpp
@@ -16,12 +16,16 @@
 
 #include "qgslogger.h"
 
+#include "qgsdataitemproviderregistry.h"
 #include "qgsdatasourceuri.h"
 #include "qgswmscapabilities.h"
 #include "qgswmsconnection.h"
 #include "qgswmssourceselect.h"
 #include "qgsnewhttpconnection.h"
 #include "qgstilescalewidget.h"
+#include "qgsxyzconnection.h"
+
+#include <QInputDialog>
 
 // ---------------------------------------------------------------------------
 QgsWMSConnectionItem::QgsWMSConnectionItem( QgsDataItem* parent, QString name, QString path, QString uri )
@@ -416,6 +420,10 @@ void QgsWMSRootItem::newConnection()
 QGISEXTERN void registerGui( QMainWindow *mainWindow )
 {
   QgsTileScaleWidget::showTileScale( mainWindow );
+
+  // with dataItem(...) at provider level we can only have one root item,
+  // so we have a data item provider for XYZ tile layers
+  QgsDataItemProviderRegistry::instance()->addProvider( new QgsXyzTileDataItemProvider );
 }
 
 QGISEXTERN QgsWMSSourceSelect * selectWidget( QWidget * parent, Qt::WindowFlags fl )
@@ -450,3 +458,81 @@ QGISEXTERN QgsDataItem * dataItem( QString thePath, QgsDataItem* parentItem )
   return nullptr;
 }
 
+
+// ---------------------------------------------------------------------------
+
+
+QgsXyzTileRootItem::QgsXyzTileRootItem( QgsDataItem *parent, QString name, QString path )
+    : QgsDataCollectionItem( parent, name, path )
+{
+  mCapabilities |= Fast;
+  mIconName = "mIconWms.svg";
+  populate();
+}
+
+QVector<QgsDataItem *> QgsXyzTileRootItem::createChildren()
+{
+  QVector<QgsDataItem*> connections;
+  Q_FOREACH ( const QString& connName, QgsXyzConnectionUtils::connectionList() )
+  {
+    QgsXyzConnection connection( QgsXyzConnectionUtils::connection( connName ) );
+    QgsDataItem * conn = new QgsXyzLayerItem( this, connName, mPath + '/' + connName, connection.encodedUri() );
+    connections.append( conn );
+  }
+  return connections;
+}
+
+QList<QAction *> QgsXyzTileRootItem::actions()
+{
+  QAction* actionNew = new QAction( tr( "New Connection..." ), this );
+  connect( actionNew, SIGNAL( triggered() ), this, SLOT( newConnection() ) );
+  return QList<QAction*>() << actionNew;
+}
+
+void QgsXyzTileRootItem::newConnection()
+{
+  QString url = QInputDialog::getText( nullptr, tr( "New XYZ tile layer" ),
+                                       tr( "Please enter XYZ tile layer URL. {x}, {y}, {z} will be replaced by actual tile coordinates." ) );
+  if ( url.isEmpty() )
+    return;
+
+  QString name = QInputDialog::getText( nullptr, tr( "New XYZ tile layer" ),
+                                        tr( "Please enter name of the tile layer:" ) );
+  if ( name.isEmpty() )
+    return;
+
+  QgsXyzConnection conn;
+  conn.name = name;
+  conn.url = url;
+  QgsXyzConnectionUtils::addConnection( conn );
+
+  refresh();
+}
+
+
+// ---------------------------------------------------------------------------
+
+
+QgsXyzLayerItem::QgsXyzLayerItem( QgsDataItem *parent, QString name, QString path, const QString &encodedUri )
+    : QgsLayerItem( parent, name, path, encodedUri, QgsLayerItem::Raster, "wms" )
+{
+  setState( Populated );
+}
+
+QList<QAction *> QgsXyzLayerItem::actions()
+{
+  QList<QAction*> lst = QgsLayerItem::actions();
+
+  QAction* actionDelete = new QAction( tr( "Delete" ), this );
+  connect( actionDelete, SIGNAL( triggered() ), this, SLOT( deleteConnection() ) );
+  lst << actionDelete;
+
+  return lst;
+}
+
+void QgsXyzLayerItem::deleteConnection()
+{
+  QgsXyzConnectionUtils::deleteConnection( mName );
+
+  mParent->refresh();
+}

--- a/src/providers/wms/qgswmsdataitems.cpp
+++ b/src/providers/wms/qgswmsdataitems.cpp
@@ -420,10 +420,6 @@ void QgsWMSRootItem::newConnection()
 QGISEXTERN void registerGui( QMainWindow *mainWindow )
 {
   QgsTileScaleWidget::showTileScale( mainWindow );
-
-  // with dataItem(...) at provider level we can only have one root item,
-  // so we have a data item provider for XYZ tile layers
-  QgsDataItemProviderRegistry::instance()->addProvider( new QgsXyzTileDataItemProvider );
 }
 
 QGISEXTERN QgsWMSSourceSelect * selectWidget( QWidget * parent, Qt::WindowFlags fl )
@@ -431,12 +427,8 @@ QGISEXTERN QgsWMSSourceSelect * selectWidget( QWidget * parent, Qt::WindowFlags 
   return new QgsWMSSourceSelect( parent, fl );
 }
 
-QGISEXTERN int dataCapabilities()
-{
-  return  QgsDataProvider::Net;
-}
 
-QGISEXTERN QgsDataItem * dataItem( QString thePath, QgsDataItem* parentItem )
+QgsDataItem* QgsWmsDataItemProvider::createDataItem( const QString& thePath, QgsDataItem *parentItem )
 {
   QgsDebugMsg( "thePath = " + thePath );
   if ( thePath.isEmpty() )
@@ -458,6 +450,12 @@ QGISEXTERN QgsDataItem * dataItem( QString thePath, QgsDataItem* parentItem )
   return nullptr;
 }
 
+QGISEXTERN QList<QgsDataItemProvider*> dataItemProviders()
+{
+  return QList<QgsDataItemProvider*>()
+         << new QgsWmsDataItemProvider
+         << new QgsXyzTileDataItemProvider;
+}
 
 // ---------------------------------------------------------------------------
 

--- a/src/providers/wms/qgswmsdataitems.h
+++ b/src/providers/wms/qgswmsdataitems.h
@@ -106,6 +106,19 @@ class QgsWMSRootItem : public QgsDataCollectionItem
     void newConnection();
 };
 
+
+//! Provider for WMS root data item
+class QgsWmsDataItemProvider : public QgsDataItemProvider
+{
+  public:
+    virtual QString name() override { return "WMS"; }
+
+    virtual int capabilities() override { return QgsDataProvider::Net; }
+
+    virtual QgsDataItem* createDataItem( const QString& path, QgsDataItem* parentItem ) override;
+};
+
+
 //! Root item for XYZ tile layers
 class QgsXyzTileRootItem : public QgsDataCollectionItem
 {

--- a/src/providers/wms/qgswmsdataitems.h
+++ b/src/providers/wms/qgswmsdataitems.h
@@ -16,6 +16,7 @@
 #define QGSWMSDATAITEMS_H
 
 #include "qgsdataitem.h"
+#include "qgsdataitemprovider.h"
 #include "qgsdatasourceuri.h"
 #include "qgswmsprovider.h"
 
@@ -104,5 +105,51 @@ class QgsWMSRootItem : public QgsDataCollectionItem
 
     void newConnection();
 };
+
+//! Root item for XYZ tile layers
+class QgsXyzTileRootItem : public QgsDataCollectionItem
+{
+    Q_OBJECT
+  public:
+    QgsXyzTileRootItem( QgsDataItem* parent, QString name, QString path );
+
+    QVector<QgsDataItem*> createChildren() override;
+
+    virtual QList<QAction*> actions() override;
+
+  private slots:
+    void newConnection();
+};
+
+//! Item implementation for XYZ tile layers
+class QgsXyzLayerItem : public QgsLayerItem
+{
+    Q_OBJECT
+  public:
+    QgsXyzLayerItem( QgsDataItem* parent, QString name, QString path, const QString& encodedUri );
+
+    virtual QList<QAction*> actions() override;
+
+  public slots:
+    void deleteConnection();
+};
+
+
+//! Provider for XYZ root data item
+class QgsXyzTileDataItemProvider : public QgsDataItemProvider
+{
+  public:
+    virtual QString name() override { return "XYZ Tiles"; }
+
+    virtual int capabilities() override { return QgsDataProvider::Net; }
+
+    virtual QgsDataItem* createDataItem( const QString& path, QgsDataItem* parentItem ) override
+    {
+      if ( path.isEmpty() )
+        return new QgsXyzTileRootItem( parentItem, "Tile Server (XYZ)", "xyz:" );
+      return nullptr;
+    }
+};
+
 
 #endif // QGSWMSDATAITEMS_H

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -780,7 +780,7 @@ QImage *QgsWmsProvider::draw( QgsRectangle const & viewExtent, int pixelWidth, i
 
     // draw other res tiles if preview
     QPainter p( image );
-    if ( feedback && feedback->preview_only && missing.count() > 0 )
+    if ( feedback && feedback->isPreviewOnly() && missing.count() > 0 )
     {
       // some tiles are still missing, so let's see if we have any cached tiles
       // from lower or higher resolution available to give the user a bit of context
@@ -825,14 +825,14 @@ QImage *QgsWmsProvider::draw( QgsRectangle const & viewExtent, int pixelWidth, i
         p.setRenderHint( QPainter::SmoothPixmapTransform, true );
       p.drawImage( ti.rect, ti.img );
 
-      if ( feedback && feedback->preview_only )
+      if ( feedback && feedback->isPreviewOnly() )
         _drawDebugRect( p, ti.rect, Qt::green );
     }
     p.end();
 
     int t2 = t.elapsed() - t1;
 
-    if ( feedback && feedback->preview_only )
+    if ( feedback && feedback->isPreviewOnly() )
     {
       qDebug( "PREVIEW - CACHED: %d / MISSING: %d", tileImages.count(), requests.count() - tileImages.count() );
       qDebug( "PREVIEW - TIME: this res %d ms | other res %d ms | TOTAL %d ms", t0 + t2, t1, t0 + t1 + t2 );
@@ -840,7 +840,7 @@ QImage *QgsWmsProvider::draw( QgsRectangle const & viewExtent, int pixelWidth, i
     else if ( !requestsFinal.isEmpty() )
     {
       // let the feedback object know about the tiles we have already
-      if ( feedback && feedback->render_partial_output )
+      if ( feedback && feedback->renderPartialOutput() )
         feedback->onNewData();
 
       // order tile requests according to the distance from view center
@@ -3908,7 +3908,7 @@ void QgsWmsTiledImageDownloadHandler::tileReplyFinished()
   }
   else
   {
-    if ( !( mFeedback && mFeedback->preview_only ) )
+    if ( !( mFeedback && mFeedback->isPreviewOnly() ) )
     {
       // report any errors except for the one we have caused by cancelling the request
       if ( reply->error() != QNetworkReply::OperationCanceledError )

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -566,9 +566,9 @@ QImage *QgsWmsProvider::draw( QgsRectangle const & viewExtent, int pixelWidth, i
     mTileReqNo++;
 
     double vres = viewExtent.width() / pixelWidth;
-    double tres = vres;
 
     const QgsWmtsTileMatrix *tm = nullptr;
+    QScopedPointer<QgsWmtsTileMatrix> tempTm;
     enum QgsTileMode tileMode;
 
     if ( mSettings.mTiled )
@@ -577,38 +577,22 @@ QImage *QgsWmsProvider::draw( QgsRectangle const & viewExtent, int pixelWidth, i
       Q_ASSERT( mTileMatrixSet );
       Q_ASSERT( !mTileMatrixSet->tileMatrices.isEmpty() );
 
-      QMap<double, QgsWmtsTileMatrix> &m =  mTileMatrixSet->tileMatrices;
-
       // find nearest resolution
-      QMap<double, QgsWmtsTileMatrix>::const_iterator prev, it = m.constBegin();
-      while ( it != m.constEnd() && it.key() < vres )
-      {
-        QgsDebugMsg( QString( "res:%1 >= %2" ).arg( it.key() ).arg( vres ) );
-        prev = it;
-        ++it;
-      }
-
-      if ( it == m.constEnd() ||
-           ( it != m.constBegin() && vres - prev.key() < it.key() - vres ) )
-      {
-        QgsDebugMsg( "back to previous res" );
-        it = prev;
-      }
-
-      tres = it.key();
-      tm = &it.value();
+      tm = mTileMatrixSet->findNearestResolution( vres );
+      Q_ASSERT( tm );
 
       tileMode = mTileLayer->tileMode;
     }
     else if ( mSettings.mMaxWidth != 0 && mSettings.mMaxHeight != 0 )
     {
-      static QgsWmtsTileMatrix tempTm;
-      tempTm.topLeft      = QgsPoint( mLayerExtent.xMinimum(), mLayerExtent.yMaximum() );
-      tempTm.tileWidth    = mSettings.mMaxWidth;
-      tempTm.tileHeight   = mSettings.mMaxHeight;
-      tempTm.matrixWidth  = ceil( mLayerExtent.width() / mSettings.mMaxWidth / vres );
-      tempTm.matrixHeight = ceil( mLayerExtent.height() / mSettings.mMaxHeight / vres );
-      tm = &tempTm;
+      tempTm.reset( new QgsWmtsTileMatrix );
+      tempTm->topLeft      = QgsPoint( mLayerExtent.xMinimum(), mLayerExtent.yMaximum() );
+      tempTm->tileWidth    = mSettings.mMaxWidth;
+      tempTm->tileHeight   = mSettings.mMaxHeight;
+      tempTm->matrixWidth  = ceil( mLayerExtent.width() / mSettings.mMaxWidth / vres );
+      tempTm->matrixHeight = ceil( mLayerExtent.height() / mSettings.mMaxHeight / vres );
+      tempTm->tres = vres;
+      tm = tempTm.data();
 
       tileMode = WMSC;
     }
@@ -634,43 +618,24 @@ QImage *QgsWmsProvider::draw( QgsRectangle const & viewExtent, int pixelWidth, i
                );
 
     QgsDebugMsg( QString( "tile matrix %1,%2 res:%3 tilesize:%4x%5 matrixsize:%6x%7 id:%8" )
-                 .arg( tm->topLeft.x() ).arg( tm->topLeft.y() ).arg( tres )
+                 .arg( tm->topLeft.x() ).arg( tm->topLeft.y() ).arg( tm->tres )
                  .arg( tm->tileWidth ).arg( tm->tileHeight )
                  .arg( tm->matrixWidth ).arg( tm->matrixHeight )
                  .arg( tm->identifier )
                );
 
-    // calculate tile coordinates
-    double twMap = tm->tileWidth * tres;
-    double thMap = tm->tileHeight * tres;
-    QgsDebugMsg( QString( "tile map size: %1,%2" ).arg( qgsDoubleToString( twMap ), qgsDoubleToString( thMap ) ) );
-
-    int minTileCol = 0;
-    int maxTileCol = tm->matrixWidth - 1;
-    int minTileRow = 0;
-    int maxTileRow = tm->matrixHeight - 1;
-
+    const QgsWmtsTileMatrixLimits *tml = nullptr;
 
     if ( mTileLayer &&
          mTileLayer->setLinks.contains( mTileMatrixSet->identifier ) &&
          mTileLayer->setLinks[ mTileMatrixSet->identifier ].limits.contains( tm->identifier ) )
     {
-      const QgsWmtsTileMatrixLimits &tml = mTileLayer->setLinks[ mTileMatrixSet->identifier ].limits[ tm->identifier ];
-      minTileCol = tml.minTileCol;
-      maxTileCol = tml.maxTileCol;
-      minTileRow = tml.minTileRow;
-      maxTileRow = tml.maxTileRow;
-      QgsDebugMsg( QString( "%1 %2: TileMatrixLimits col %3-%4 row %5-%6" )
-                   .arg( mTileMatrixSet->identifier,
-                         tm->identifier )
-                   .arg( minTileCol ).arg( maxTileCol )
-                   .arg( minTileRow ).arg( maxTileRow ) );
+      tml = &mTileLayer->setLinks[ mTileMatrixSet->identifier ].limits[ tm->identifier ];
     }
 
-    int col0 = qBound( minTileCol, ( int ) floor(( viewExtent.xMinimum() - tm->topLeft.x() ) / twMap ), maxTileCol );
-    int row0 = qBound( minTileRow, ( int ) floor(( tm->topLeft.y() - viewExtent.yMaximum() ) / thMap ), maxTileRow );
-    int col1 = qBound( minTileCol, ( int ) floor(( viewExtent.xMaximum() - tm->topLeft.x() ) / twMap ), maxTileCol );
-    int row1 = qBound( minTileRow, ( int ) floor(( tm->topLeft.y() - viewExtent.yMinimum() ) / thMap ), maxTileRow );
+    // calculate tile coordinates
+    int col0, col1, row0, row1;
+    tm->viewExtentIntersection( viewExtent, tml, col0, row0, col1, row1 );
 
 #if QGISDEBUG
     int n = ( col1 - col0 + 1 ) * ( row1 - row0 + 1 );
@@ -728,17 +693,17 @@ QImage *QgsWmsProvider::draw( QgsRectangle const & viewExtent, int pixelWidth, i
         {
           for ( int col = col0; col <= col1; col++ )
           {
+            QgsRectangle bbox( tm->tileBBox( col, row ) );
             QString turl;
             turl += url.toString();
             turl += QString( changeXY ? "&BBOX=%2,%1,%4,%3" : "&BBOX=%1,%2,%3,%4" )
-                    .arg( qgsDoubleToString( tm->topLeft.x() +         col * twMap /* + twMap * 0.001 */ ),
-                          qgsDoubleToString( tm->topLeft.y() - ( row + 1 ) * thMap /* - thMap * 0.001 */ ),
-                          qgsDoubleToString( tm->topLeft.x() + ( col + 1 ) * twMap /* - twMap * 0.001 */ ),
-                          qgsDoubleToString( tm->topLeft.y() -         row * thMap /* + thMap * 0.001 */ ) );
+                    .arg( qgsDoubleToString( bbox.xMinimum() ),
+                          qgsDoubleToString( bbox.yMinimum() ),
+                          qgsDoubleToString( bbox.xMaximum() ),
+                          qgsDoubleToString( bbox.yMaximum() ) );
 
             QgsDebugMsg( QString( "tileRequest %1 %2/%3 (%4,%5): %6" ).arg( mTileReqNo ).arg( i++ ).arg( n ).arg( row ).arg( col ).arg( turl ) );
-            QRectF rect( tm->topLeft.x() + col * twMap, tm->topLeft.y() - ( row + 1 ) * thMap, twMap, thMap );
-            requests << QgsWmsTiledImageDownloadHandler::TileRequest( turl, rect, i );
+            requests << QgsWmsTiledImageDownloadHandler::TileRequest( turl, tm->tileRect( col, row ), i );
           }
         }
       }
@@ -779,8 +744,7 @@ QImage *QgsWmsProvider::draw( QgsRectangle const & viewExtent, int pixelWidth, i
               turl += QString( "&TILEROW=%1&TILECOL=%2" ).arg( row ).arg( col );
 
               QgsDebugMsg( QString( "tileRequest %1 %2/%3 (%4,%5): %6" ).arg( mTileReqNo ).arg( i++ ).arg( n ).arg( row ).arg( col ).arg( turl ) );
-              QRectF rect( tm->topLeft.x() + col * twMap, tm->topLeft.y() - ( row + 1 ) * thMap, twMap, thMap );
-              requests << QgsWmsTiledImageDownloadHandler::TileRequest( turl, rect, i );
+              requests << QgsWmsTiledImageDownloadHandler::TileRequest( turl, tm->tileRect( col, row ), i );
             }
           }
         }
@@ -810,8 +774,7 @@ QImage *QgsWmsProvider::draw( QgsRectangle const & viewExtent, int pixelWidth, i
 
               if ( feedback && !feedback->preview_only )
                 QgsDebugMsg( QString( "tileRequest %1 %2/%3 (%4,%5): %6" ).arg( mTileReqNo ).arg( i++ ).arg( n ).arg( row ).arg( col ).arg( turl ) );
-              QRectF rect( tm->topLeft.x() + col * twMap, tm->topLeft.y() - ( row + 1 ) * thMap, twMap, thMap );
-              requests << QgsWmsTiledImageDownloadHandler::TileRequest( turl, rect, i );
+              requests << QgsWmsTiledImageDownloadHandler::TileRequest( turl, tm->tileRect( col, row ), i );
             }
           }
         }

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -831,6 +831,7 @@ QImage *QgsWmsProvider::draw( QgsRectangle const & viewExtent, int pixelWidth, i
     p.end();
 
     int t2 = t.elapsed() - t1;
+    Q_UNUSED( t2 ); // only used in debug build
 
     if ( feedback && feedback->isPreviewOnly() )
     {

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -85,11 +85,7 @@ QgsWmsProvider::QgsWmsProvider( QString const& uri, const QgsWmsCapabilities* ca
     , mGetLegendGraphicImage()
     , mGetLegendGraphicScale( 0.0 )
     , mImageCrs( DEFAULT_LATLON_CRS )
-    , mCachedImage( nullptr )
     , mIdentifyReply( nullptr )
-    , mCachedViewExtent( 0 )
-    , mCachedViewWidth( 0 )
-    , mCachedViewHeight( 0 )
     , mExtentDirty( true )
     , mTileReqNo( 0 )
     , mTileLayer( nullptr )
@@ -170,13 +166,6 @@ QString QgsWmsProvider::prepareUri( QString uri )
 QgsWmsProvider::~QgsWmsProvider()
 {
   QgsDebugMsg( "deconstructing." );
-
-  // Dispose of any cached image as created by draw()
-  if ( mCachedImage )
-  {
-    delete mCachedImage;
-    mCachedImage = nullptr;
-  }
 }
 
 QgsWmsProvider* QgsWmsProvider::clone() const
@@ -484,26 +473,13 @@ QImage *QgsWmsProvider::draw( QgsRectangle const &viewExtent, int pixelWidth, in
   return draw( viewExtent, pixelWidth, pixelHeight, nullptr );
 }
 
+#include <QCache>
+static QCache<QUrl, QImage> sTileCache;
+static QMutex sTileCacheMutex;
+
 QImage *QgsWmsProvider::draw( QgsRectangle const & viewExtent, int pixelWidth, int pixelHeight, QgsRasterBlockFeedback* feedback )
 {
   QgsDebugMsg( "Entering." );
-
-  // Can we reuse the previously cached image?
-  if ( mCachedImage &&
-       mCachedViewExtent == viewExtent &&
-       mCachedViewWidth == pixelWidth &&
-       mCachedViewHeight == pixelHeight )
-  {
-    return mCachedImage;
-  }
-
-  // delete cached image and create network request(s) to fill it
-  if ( mCachedImage )
-  {
-    delete mCachedImage;
-    mCachedImage = nullptr;
-  }
-
 
   bool changeXY = mCaps.shouldInvertAxisOrientation( mImageCrs );
 
@@ -511,11 +487,8 @@ QImage *QgsWmsProvider::draw( QgsRectangle const & viewExtent, int pixelWidth, i
 
   QString bbox = toParamValue( viewExtent, changeXY );
 
-  mCachedImage = new QImage( pixelWidth, pixelHeight, QImage::Format_ARGB32 );
-  mCachedImage->fill( 0 );
-  mCachedViewExtent = viewExtent;
-  mCachedViewWidth = pixelWidth;
-  mCachedViewHeight = pixelHeight;
+  QImage* image = new QImage( pixelWidth, pixelHeight, QImage::Format_ARGB32 );
+  image->fill( 0 );
 
   if ( !mSettings.mTiled && mSettings.mMaxWidth == 0 && mSettings.mMaxHeight == 0 )
   {
@@ -585,7 +558,7 @@ QImage *QgsWmsProvider::draw( QgsRectangle const & viewExtent, int pixelWidth, i
 
     emit statusChanged( tr( "Getting map via WMS." ) );
 
-    QgsWmsImageDownloadHandler handler( dataSourceUri(), url, mSettings.authorization(), mCachedImage, feedback );
+    QgsWmsImageDownloadHandler handler( dataSourceUri(), url, mSettings.authorization(), image, feedback );
     handler.downloadBlocking();
   }
   else
@@ -642,7 +615,7 @@ QImage *QgsWmsProvider::draw( QgsRectangle const & viewExtent, int pixelWidth, i
     else
     {
       QgsDebugMsg( "empty tile size" );
-      return mCachedImage;
+      return image;
     }
 
     QgsDebugMsg( QString( "layer extent: %1,%2 %3x%4" )
@@ -705,7 +678,7 @@ QImage *QgsWmsProvider::draw( QgsRectangle const & viewExtent, int pixelWidth, i
     if ( n > 100 )
     {
       emit statusChanged( QString( "current view would need %1 tiles. tile request per draw limited to 100." ).arg( n ) );
-      return mCachedImage;
+      return image;
     }
 #endif
 
@@ -835,7 +808,8 @@ QImage *QgsWmsProvider::draw( QgsRectangle const & viewExtent, int pixelWidth, i
               turl.replace( "{tilerow}", QString::number( row ), Qt::CaseInsensitive );
               turl.replace( "{tilecol}", QString::number( col ), Qt::CaseInsensitive );
 
-              QgsDebugMsg( QString( "tileRequest %1 %2/%3 (%4,%5): %6" ).arg( mTileReqNo ).arg( i++ ).arg( n ).arg( row ).arg( col ).arg( turl ) );
+              if ( feedback && !feedback->preview_only )
+                QgsDebugMsg( QString( "tileRequest %1 %2/%3 (%4,%5): %6" ).arg( mTileReqNo ).arg( i++ ).arg( n ).arg( row ).arg( col ).arg( turl ) );
               QRectF rect( tm->topLeft.x() + col * twMap, tm->topLeft.y() - ( row + 1 ) * thMap, twMap, thMap );
               requests << QgsWmsTiledImageDownloadHandler::TileRequest( turl, rect, i );
             }
@@ -846,13 +820,78 @@ QImage *QgsWmsProvider::draw( QgsRectangle const & viewExtent, int pixelWidth, i
 
       default:
         QgsDebugMsg( QString( "unexpected tile mode %1" ).arg( mTileLayer->tileMode ) );
-        return mCachedImage;
+        return image;
     }
 
     emit statusChanged( tr( "Getting tiles." ) );
 
-    QgsWmsTiledImageDownloadHandler handler( dataSourceUri(), mSettings.authorization(), mTileReqNo, requests, mCachedImage, mCachedViewExtent, mSettings.mSmoothPixmapTransform, feedback );
-    handler.downloadBlocking();
+    QTime t;
+    t.start();
+    int memCached = 0, diskCached = 0;
+    QList<QgsWmsTiledImageDownloadHandler::TileRequest> requestsFinal;
+    Q_FOREACH ( const QgsWmsTiledImageDownloadHandler::TileRequest& r, requests )
+    {
+      QImage localImage;
+
+      sTileCacheMutex.lock();
+      if ( QImage* i = sTileCache.object( r.url ) )
+      {
+        localImage = *i;
+        memCached++;
+      }
+      else if ( QgsNetworkAccessManager::instance()->cache()->metaData( r.url ).isValid() )
+      {
+        if ( QIODevice* data = QgsNetworkAccessManager::instance()->cache()->data( r.url ) )
+        {
+          QByteArray imageData = data->readAll();
+          delete data;
+
+          localImage = QImage::fromData( imageData );
+
+          // cache it as well (mutex is already locked)
+          sTileCache.insert( r.url, new QImage( localImage ) );
+
+          diskCached++;
+        }
+      }
+      sTileCacheMutex.unlock();
+
+      // draw the tile directly if possible
+      if ( !localImage.isNull() )
+      {
+        double cr = viewExtent.width() / image->width();
+
+        QRectF dst(( r.rect.left() - viewExtent.xMinimum() ) / cr,
+                   ( viewExtent.yMaximum() - r.rect.bottom() ) / cr,
+                   r.rect.width() / cr,
+                   r.rect.height() / cr );
+
+        QPainter p( image );
+        if ( mSettings.mSmoothPixmapTransform )
+          p.setRenderHint( QPainter::SmoothPixmapTransform, true );
+        p.drawImage( dst, localImage );
+      }
+      else
+      {
+        // need to make a request
+        requestsFinal << r;
+      }
+    }
+
+    if ( feedback && feedback->preview_only )
+    {
+      qDebug( "PREVIEW - MEM CACHED: %d / DISK CACHED: %d / MISSING: %d", memCached, diskCached, requests.count() - memCached - diskCached );
+      qDebug( "PREVIEW - SPENT IN WMTS PROVIDER: %d ms", t.elapsed() );
+    }
+    else if ( !requestsFinal.isEmpty() )
+    {
+      // let the feedback object know about the tiles we have already
+      if ( feedback && memCached + diskCached > 0 )
+        feedback->onNewData();
+
+      QgsWmsTiledImageDownloadHandler handler( dataSourceUri(), mSettings.authorization(), mTileReqNo, requestsFinal, image, viewExtent, mSettings.mSmoothPixmapTransform, feedback );
+      handler.downloadBlocking();
+    }
 
 
 #if 0
@@ -865,7 +904,7 @@ QImage *QgsWmsProvider::draw( QgsRectangle const & viewExtent, int pixelWidth, i
 #endif
   }
 
-  return mCachedImage;
+  return image;
 }
 
 void QgsWmsProvider::readBlock( int bandNo, QgsRectangle  const & viewExtent, int pixelWidth, int pixelHeight, void *block, QgsRasterBlockFeedback* feedback )
@@ -885,6 +924,7 @@ void QgsWmsProvider::readBlock( int bandNo, QgsRectangle  const & viewExtent, in
   if ( myExpectedSize != myImageSize )   // should not happen
   {
     QgsMessageLog::logMessage( tr( "unexpected image size" ), tr( "WMS" ) );
+    delete image;
     return;
   }
 
@@ -894,8 +934,8 @@ void QgsWmsProvider::readBlock( int bandNo, QgsRectangle  const & viewExtent, in
     // If image is too large, ptr can be NULL
     memcpy( block, ptr, myExpectedSize );
   }
-  // do not delete the image, it is handled by draw()
-  //delete image;
+
+  delete image;
 }
 
 
@@ -2895,8 +2935,6 @@ QString  QgsWmsProvider::description() const
 
 void QgsWmsProvider::reloadData()
 {
-  delete mCachedImage;
-  mCachedImage = nullptr;
 }
 
 
@@ -3376,14 +3414,15 @@ void QgsWmsImageDownloadHandler::cancelled()
 // ----------
 
 
-QgsWmsTiledImageDownloadHandler::QgsWmsTiledImageDownloadHandler( const QString& providerUri, const QgsWmsAuthorization& auth, int tileReqNo, const QList<QgsWmsTiledImageDownloadHandler::TileRequest>& requests, QImage* cachedImage, const QgsRectangle& cachedViewExtent, bool smoothPixmapTransform, QgsRasterBlockFeedback* feedback )
+QgsWmsTiledImageDownloadHandler::QgsWmsTiledImageDownloadHandler( const QString& providerUri, const QgsWmsAuthorization& auth, int tileReqNo, const QList<QgsWmsTiledImageDownloadHandler::TileRequest>& requests, QImage* image, const QgsRectangle& viewExtent, bool smoothPixmapTransform, QgsRasterBlockFeedback* feedback )
     : mProviderUri( providerUri )
     , mAuth( auth )
-    , mCachedImage( cachedImage )
-    , mCachedViewExtent( cachedViewExtent )
+    , mImage( image )
+    , mViewExtent( viewExtent )
     , mEventLoop( new QEventLoop )
     , mTileReqNo( tileReqNo )
     , mSmoothPixmapTransform( smoothPixmapTransform )
+    , mFeedback( feedback )
 {
   Q_FOREACH ( const TileRequest& r, requests )
   {
@@ -3562,10 +3601,10 @@ void QgsWmsTiledImageDownloadHandler::tileReplyFinished()
     // only take results from current request number
     if ( mTileReqNo == tileReqNo )
     {
-      double cr = mCachedViewExtent.width() / mCachedImage->width();
+      double cr = mViewExtent.width() / mImage->width();
 
-      QRectF dst(( r.left() - mCachedViewExtent.xMinimum() ) / cr,
-                 ( mCachedViewExtent.yMaximum() - r.bottom() ) / cr,
+      QRectF dst(( r.left() - mViewExtent.xMinimum() ) / cr,
+                 ( mViewExtent.yMaximum() - r.bottom() ) / cr,
                  r.width() / cr,
                  r.height() / cr );
 
@@ -3575,7 +3614,7 @@ void QgsWmsTiledImageDownloadHandler::tileReplyFinished()
 
       if ( !myLocalImage.isNull() )
       {
-        QPainter p( mCachedImage );
+        QPainter p( mImage );
         if ( mSmoothPixmapTransform )
           p.setRenderHint( QPainter::SmoothPixmapTransform, true );
         p.drawImage( dst, myLocalImage );
@@ -3588,6 +3627,13 @@ void QgsWmsTiledImageDownloadHandler::tileReplyFinished()
                     .arg( r.right() ).arg( r.top() )
                     .arg( r.width() ).arg( r.height() ) );
 #endif
+
+        sTileCacheMutex.lock();
+        sTileCache.insert( reply->url(), new QImage( myLocalImage ) );
+        sTileCacheMutex.unlock();
+
+        if ( mFeedback )
+          mFeedback->onNewData();
       }
       else
       {
@@ -3611,13 +3657,16 @@ void QgsWmsTiledImageDownloadHandler::tileReplyFinished()
   }
   else
   {
-    // report any errors except for the one we have caused by cancelling the request
-    if ( reply->error() != QNetworkReply::OperationCanceledError )
+    if ( !( mFeedback && mFeedback->preview_only ) )
     {
-      QgsWmsStatistics::Stat& stat = QgsWmsStatistics::statForUri( mProviderUri );
-      stat.errors++;
+      // report any errors except for the one we have caused by cancelling the request
+      if ( reply->error() != QNetworkReply::OperationCanceledError )
+      {
+        QgsWmsStatistics::Stat& stat = QgsWmsStatistics::statForUri( mProviderUri );
+        stat.errors++;
 
-      repeatTileRequest( reply->request() );
+        repeatTileRequest( reply->request() );
+      }
     }
 
     mReplies.removeOne( reply );

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -834,8 +834,8 @@ QImage *QgsWmsProvider::draw( QgsRectangle const & viewExtent, int pixelWidth, i
 
     if ( feedback && feedback->isPreviewOnly() )
     {
-      qDebug( "PREVIEW - CACHED: %d / MISSING: %d", tileImages.count(), requests.count() - tileImages.count() );
-      qDebug( "PREVIEW - TIME: this res %d ms | other res %d ms | TOTAL %d ms", t0 + t2, t1, t0 + t1 + t2 );
+      QgsDebugMsg( QString( "PREVIEW - CACHED: %1 / MISSING: %2" ).arg( tileImages.count() ).arg( requests.count() - tileImages.count() ) );
+      QgsDebugMsg( QString( "PREVIEW - TIME: this res %1 ms | other res %2 ms | TOTAL %3 ms" ).arg( t0 + t2 ).arg( t1 ).arg( t0 + t1 + t2 ) );
     }
     else if ( !requestsFinal.isEmpty() )
     {
@@ -852,7 +852,7 @@ QImage *QgsWmsProvider::draw( QgsRectangle const & viewExtent, int pixelWidth, i
       handler.downloadBlocking();
     }
 
-    qDebug( "TILE CACHE total: %d / %d ", QgsTileCache::totalCost(), QgsTileCache::maxCost() );
+    QgsDebugMsg( QString( "TILE CACHE total: %1 / %2" ).arg( QgsTileCache::totalCost() ).arg( QgsTileCache::maxCost() ) );
 
 #if 0
     const QgsWmsStatistics::Stat& stat = QgsWmsStatistics::statForUri( dataSourceUri() );

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -710,9 +710,9 @@ QImage *QgsWmsProvider::draw( QgsRectangle const & viewExtent, int pixelWidth, i
 #if QGISDEBUG
     int n = ( col1 - col0 + 1 ) * ( row1 - row0 + 1 );
     QgsDebugMsg( QString( "tile number: %1x%2 = %3" ).arg( col1 - col0 + 1 ).arg( row1 - row0 + 1 ).arg( n ) );
-    if ( n > 100 )
+    if ( n > 256 )
     {
-      emit statusChanged( QString( "current view would need %1 tiles. tile request per draw limited to 100." ).arg( n ) );
+      emit statusChanged( QString( "current view would need %1 tiles. tile request per draw limited to 256." ).arg( n ) );
       return image;
     }
 #endif

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -3337,7 +3337,18 @@ QgsWmsImageDownloadHandler::QgsWmsImageDownloadHandler( const QString& providerU
     : mProviderUri( providerUri )
     , mCachedImage( image )
     , mEventLoop( new QEventLoop )
+    , mFeedback( feedback )
 {
+  if ( feedback )
+  {
+    connect( feedback, SIGNAL( cancelled() ), this, SLOT( cancelled() ), Qt::QueuedConnection );
+
+    // rendering could have been cancelled before we started to listen to cancelled() signal
+    // so let's check before doing the download and maybe quit prematurely
+    if ( feedback->isCancelled() )
+      return;
+  }
+
   QNetworkRequest request( url );
   auth.setAuthorization( request );
   request.setAttribute( QNetworkRequest::CacheSaveControlAttribute, true );
@@ -3346,9 +3357,6 @@ QgsWmsImageDownloadHandler::QgsWmsImageDownloadHandler( const QString& providerU
   connect( mCacheReply, SIGNAL( downloadProgress( qint64, qint64 ) ), this, SLOT( cacheReplyProgress( qint64, qint64 ) ) );
 
   Q_ASSERT( mCacheReply->thread() == QThread::currentThread() );
-
-  if ( feedback )
-    connect( feedback, SIGNAL( cancelled() ), this, SLOT( cancelled() ), Qt::QueuedConnection );
 }
 
 QgsWmsImageDownloadHandler::~QgsWmsImageDownloadHandler()
@@ -3358,6 +3366,9 @@ QgsWmsImageDownloadHandler::~QgsWmsImageDownloadHandler()
 
 void QgsWmsImageDownloadHandler::downloadBlocking()
 {
+  if ( mFeedback && mFeedback->isCancelled() )
+    return; // nothing to do
+
   mEventLoop->exec( QEventLoop::ExcludeUserInputEvents );
 
   Q_ASSERT( !mCacheReply );
@@ -3497,6 +3508,16 @@ QgsWmsTiledImageDownloadHandler::QgsWmsTiledImageDownloadHandler( const QString&
     , mSmoothPixmapTransform( smoothPixmapTransform )
     , mFeedback( feedback )
 {
+  if ( feedback )
+  {
+    connect( feedback, SIGNAL( cancelled() ), this, SLOT( cancelled() ), Qt::QueuedConnection );
+
+    // rendering could have been cancelled before we started to listen to cancelled() signal
+    // so let's check before doing the download and maybe quit prematurely
+    if ( feedback->isCancelled() )
+      return;
+  }
+
   Q_FOREACH ( const TileRequest& r, requests )
   {
     QNetworkRequest request( r.url );
@@ -3513,9 +3534,6 @@ QgsWmsTiledImageDownloadHandler::QgsWmsTiledImageDownloadHandler( const QString&
 
     mReplies << reply;
   }
-
-  if ( feedback )
-    connect( feedback, SIGNAL( cancelled() ), this, SLOT( cancelled() ), Qt::QueuedConnection );
 }
 
 QgsWmsTiledImageDownloadHandler::~QgsWmsTiledImageDownloadHandler()
@@ -3525,6 +3543,9 @@ QgsWmsTiledImageDownloadHandler::~QgsWmsTiledImageDownloadHandler()
 
 void QgsWmsTiledImageDownloadHandler::downloadBlocking()
 {
+  if ( mFeedback && mFeedback->isCancelled() )
+    return; // nothing to do
+
   mEventLoop->exec( QEventLoop::ExcludeUserInputEvents );
 
   Q_ASSERT( mReplies.isEmpty() );

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -79,6 +79,18 @@ static QString DEFAULT_LATLON_CRS = "CRS:84";
 
 QMap<QString, QgsWmsStatistics::Stat> QgsWmsStatistics::sData;
 
+//! a helper class for ordering tile requests according to the distance from view center
+struct LessThanTileRequest
+{
+  QgsPoint center;
+  bool operator()( const QgsWmsTiledImageDownloadHandler::TileRequest &req1, const QgsWmsTiledImageDownloadHandler::TileRequest &req2 )
+  {
+    QPointF p1 = req1.rect.center();
+    QPointF p2 = req2.rect.center();
+    return center.distance( p1.x(), p1.y() ) < center.distance( p2.x(), p2.y() );
+  }
+};
+
 
 QgsWmsProvider::QgsWmsProvider( QString const& uri, const QgsWmsCapabilities* capabilities )
     : QgsRasterDataProvider( uri )
@@ -886,6 +898,11 @@ QImage *QgsWmsProvider::draw( QgsRectangle const & viewExtent, int pixelWidth, i
       // let the feedback object know about the tiles we have already
       if ( feedback && memCached + diskCached > 0 )
         feedback->onNewData();
+
+      // order tile requests according to the distance from view center
+      LessThanTileRequest cmp;
+      cmp.center = viewExtent.center();
+      qSort( requestsFinal.begin(), requestsFinal.end(), cmp );
 
       QgsWmsTiledImageDownloadHandler handler( dataSourceUri(), mSettings.authorization(), mTileReqNo, requestsFinal, image, viewExtent, mSettings.mSmoothPixmapTransform, feedback );
       handler.downloadBlocking();

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -83,11 +83,14 @@ QMap<QString, QgsWmsStatistics::Stat> QgsWmsStatistics::sData;
 struct LessThanTileRequest
 {
   QgsPoint center;
-  bool operator()( const QgsWmsTiledImageDownloadHandler::TileRequest &req1, const QgsWmsTiledImageDownloadHandler::TileRequest &req2 )
+  bool operator()( const QgsWmsProvider::TileRequest &req1, const QgsWmsProvider::TileRequest &req2 )
   {
     QPointF p1 = req1.rect.center();
     QPointF p2 = req2.rect.center();
-    return center.distance( p1.x(), p1.y() ) < center.distance( p2.x(), p2.y() );
+    // using chessboard distance (loading order more natural than euclidean/manhattan distance)
+    double d1 = qMax( qAbs( center.x() - p1.x() ), qAbs( center.y() - p1.y() ) );
+    double d2 = qMax( qAbs( center.x() - p2.x() ), qAbs( center.y() - p2.y() ) );
+    return d1 < d2;
   }
 };
 
@@ -506,78 +509,14 @@ QImage *QgsWmsProvider::draw( QgsRectangle const & viewExtent, int pixelWidth, i
 {
   QgsDebugMsg( "Entering." );
 
-  bool changeXY = mCaps.shouldInvertAxisOrientation( mImageCrs );
-
   // compose the URL query string for the WMS server.
-
-  QString bbox = toParamValue( viewExtent, changeXY );
 
   QImage* image = new QImage( pixelWidth, pixelHeight, QImage::Format_ARGB32 );
   image->fill( 0 );
 
   if ( !mSettings.mTiled && mSettings.mMaxWidth == 0 && mSettings.mMaxHeight == 0 )
   {
-    // Calculate active layers that are also visible.
-
-    QgsDebugMsg( "Active layer list of "  + mSettings.mActiveSubLayers.join( ", " )
-                 + " and style list of "  + mSettings.mActiveSubStyles.join( ", " ) );
-
-    QStringList visibleLayers = QStringList();
-    QStringList visibleStyles = QStringList();
-
-    QStringList::const_iterator it2  = mSettings.mActiveSubStyles.constBegin();
-
-    for ( QStringList::const_iterator it = mSettings.mActiveSubLayers.constBegin();
-          it != mSettings.mActiveSubLayers.constEnd();
-          ++it )
-    {
-      if ( mActiveSubLayerVisibility.constFind( *it ).value() )
-      {
-        visibleLayers += *it;
-        visibleStyles += *it2;
-      }
-
-      ++it2;
-    }
-
-    QString layers = visibleLayers.join( "," );
-    layers = layers.isNull() ? "" : layers;
-    QString styles = visibleStyles.join( "," );
-    styles = styles.isNull() ? "" : styles;
-
-    QgsDebugMsg( "Visible layer list of " + layers + " and style list of " + styles );
-
-    QUrl url( mSettings.mIgnoreGetMapUrl ? mSettings.mBaseUrl : getMapUrl() );
-    setQueryItem( url, "SERVICE", "WMS" );
-    setQueryItem( url, "VERSION", mCaps.mCapabilities.version );
-    setQueryItem( url, "REQUEST", "GetMap" );
-    setQueryItem( url, "BBOX", bbox );
-    setSRSQueryItem( url );
-    setQueryItem( url, "WIDTH", QString::number( pixelWidth ) );
-    setQueryItem( url, "HEIGHT", QString::number( pixelHeight ) );
-    setQueryItem( url, "LAYERS", layers );
-    setQueryItem( url, "STYLES", styles );
-    setFormatQueryItem( url );
-
-    if ( mDpi != -1 )
-    {
-      if ( mSettings.mDpiMode & dpiQGIS )
-        setQueryItem( url, "DPI", QString::number( mDpi ) );
-      if ( mSettings.mDpiMode & dpiUMN )
-        setQueryItem( url, "MAP_RESOLUTION", QString::number( mDpi ) );
-      if ( mSettings.mDpiMode & dpiGeoServer )
-        setQueryItem( url, "FORMAT_OPTIONS", QString( "dpi:%1" ).arg( mDpi ) );
-    }
-
-    //MH: jpeg does not support transparency and some servers complain if jpg and transparent=true
-    if ( mSettings.mImageMimeType == "image/x-jpegorpng" ||
-         ( !mSettings.mImageMimeType.contains( "jpeg", Qt::CaseInsensitive ) &&
-           !mSettings.mImageMimeType.contains( "jpg", Qt::CaseInsensitive ) ) )
-    {
-      setQueryItem( url, "TRANSPARENT", "TRUE" );  // some servers giving error for 'true' (lowercase)
-    }
-
-    QgsDebugMsg( QString( "getmap: %1" ).arg( url.toString() ) );
+    QUrl url = createRequestUrlWMS( viewExtent, pixelWidth, pixelHeight );
 
     // cache some details for if the user wants to do an identifyAsHtml() later
 
@@ -672,161 +611,29 @@ QImage *QgsWmsProvider::draw( QgsRectangle const & viewExtent, int pixelWidth, i
     }
 #endif
 
-    QList<QgsWmsTiledImageDownloadHandler::TileRequest> requests;
+    TilePositions tiles;
+    for ( int row = row0; row <= row1; row++ )
+    {
+      for ( int col = col0; col <= col1; col++ )
+      {
+        tiles << TilePosition( row, col );
+      }
+    }
 
+    TileRequests requests;
     switch ( tileMode )
     {
       case WMSC:
-      {
-        // add WMS request
-        QUrl url( mSettings.mIgnoreGetMapUrl ? mSettings.mBaseUrl : getMapUrl() );
-        setQueryItem( url, "SERVICE", "WMS" );
-        setQueryItem( url, "VERSION", mCaps.mCapabilities.version );
-        setQueryItem( url, "REQUEST", "GetMap" );
-        setQueryItem( url, "WIDTH", QString::number( tm->tileWidth ) );
-        setQueryItem( url, "HEIGHT", QString::number( tm->tileHeight ) );
-        setQueryItem( url, "LAYERS", mSettings.mActiveSubLayers.join( "," ) );
-        setQueryItem( url, "STYLES", mSettings.mActiveSubStyles.join( "," ) );
-        setFormatQueryItem( url );
-
-        setSRSQueryItem( url );
-
-        if ( mSettings.mTiled )
-        {
-          setQueryItem( url, "TILED", "true" );
-        }
-
-        if ( mDpi != -1 )
-        {
-          if ( mSettings.mDpiMode & dpiQGIS )
-            setQueryItem( url, "DPI", QString::number( mDpi ) );
-          if ( mSettings.mDpiMode & dpiUMN )
-            setQueryItem( url, "MAP_RESOLUTION", QString::number( mDpi ) );
-          if ( mSettings.mDpiMode & dpiGeoServer )
-            setQueryItem( url, "FORMAT_OPTIONS", QString( "dpi:%1" ).arg( mDpi ) );
-        }
-
-        if ( mSettings.mImageMimeType == "image/x-jpegorpng" ||
-             ( !mSettings.mImageMimeType.contains( "jpeg", Qt::CaseInsensitive ) &&
-               !mSettings.mImageMimeType.contains( "jpg", Qt::CaseInsensitive ) ) )
-        {
-          setQueryItem( url, "TRANSPARENT", "TRUE" );  // some servers giving error for 'true' (lowercase)
-        }
-
-        int i = 0;
-        for ( int row = row0; row <= row1; row++ )
-        {
-          for ( int col = col0; col <= col1; col++ )
-          {
-            QgsRectangle bbox( tm->tileBBox( col, row ) );
-            QString turl;
-            turl += url.toString();
-            turl += QString( changeXY ? "&BBOX=%2,%1,%4,%3" : "&BBOX=%1,%2,%3,%4" )
-                    .arg( qgsDoubleToString( bbox.xMinimum() ),
-                          qgsDoubleToString( bbox.yMinimum() ),
-                          qgsDoubleToString( bbox.xMaximum() ),
-                          qgsDoubleToString( bbox.yMaximum() ) );
-
-            QgsDebugMsg( QString( "tileRequest %1 %2/%3 (%4,%5): %6" ).arg( mTileReqNo ).arg( i++ ).arg( n ).arg( row ).arg( col ).arg( turl ) );
-            requests << QgsWmsTiledImageDownloadHandler::TileRequest( turl, tm->tileRect( col, row ), i );
-          }
-        }
-      }
-      break;
+        createTileRequestsWMSC( tm, tiles, requests );
+        break;
 
       case WMTS:
-      {
-        if ( !getTileUrl().isNull() )
-        {
-          // KVP
-          QUrl url( mSettings.mIgnoreGetMapUrl ? mSettings.mBaseUrl : getTileUrl() );
-
-          // compose static request arguments.
-          setQueryItem( url, "SERVICE", "WMTS" );
-          setQueryItem( url, "REQUEST", "GetTile" );
-          setQueryItem( url, "VERSION", mCaps.mCapabilities.version );
-          setQueryItem( url, "LAYER", mSettings.mActiveSubLayers[0] );
-          setQueryItem( url, "STYLE", mSettings.mActiveSubStyles[0] );
-          setQueryItem( url, "FORMAT", mSettings.mImageMimeType );
-          setQueryItem( url, "TILEMATRIXSET", mTileMatrixSet->identifier );
-          setQueryItem( url, "TILEMATRIX", tm->identifier );
-
-          for ( QHash<QString, QString>::const_iterator it = mSettings.mTileDimensionValues.constBegin(); it != mSettings.mTileDimensionValues.constEnd(); ++it )
-          {
-            setQueryItem( url, it.key(), it.value() );
-          }
-
-          url.removeQueryItem( "TILEROW" );
-          url.removeQueryItem( "TILECOL" );
-
-          int i = 0;
-          for ( int row = row0; row <= row1; row++ )
-          {
-            for ( int col = col0; col <= col1; col++ )
-            {
-              QString turl;
-              turl += url.toString();
-              turl += QString( "&TILEROW=%1&TILECOL=%2" ).arg( row ).arg( col );
-
-              QgsDebugMsg( QString( "tileRequest %1 %2/%3 (%4,%5): %6" ).arg( mTileReqNo ).arg( i++ ).arg( n ).arg( row ).arg( col ).arg( turl ) );
-              requests << QgsWmsTiledImageDownloadHandler::TileRequest( turl, tm->tileRect( col, row ), i );
-            }
-          }
-        }
-        else
-        {
-          // REST
-          QString url = mTileLayer->getTileURLs[ mSettings.mImageMimeType ];
-
-          url.replace( "{layer}", mSettings.mActiveSubLayers[0], Qt::CaseInsensitive );
-          url.replace( "{style}", mSettings.mActiveSubStyles[0], Qt::CaseInsensitive );
-          url.replace( "{tilematrixset}", mTileMatrixSet->identifier, Qt::CaseInsensitive );
-          url.replace( "{tilematrix}", tm->identifier, Qt::CaseInsensitive );
-
-          for ( QHash<QString, QString>::const_iterator it = mSettings.mTileDimensionValues.constBegin(); it != mSettings.mTileDimensionValues.constEnd(); ++it )
-          {
-            url.replace( "{" + it.key() + "}", it.value(), Qt::CaseInsensitive );
-          }
-
-          int i = 0;
-          for ( int row = row0; row <= row1; row++ )
-          {
-            for ( int col = col0; col <= col1; col++ )
-            {
-              QString turl( url );
-              turl.replace( "{tilerow}", QString::number( row ), Qt::CaseInsensitive );
-              turl.replace( "{tilecol}", QString::number( col ), Qt::CaseInsensitive );
-
-              if ( feedback && !feedback->preview_only )
-                QgsDebugMsg( QString( "tileRequest %1 %2/%3 (%4,%5): %6" ).arg( mTileReqNo ).arg( i++ ).arg( n ).arg( row ).arg( col ).arg( turl ) );
-              requests << QgsWmsTiledImageDownloadHandler::TileRequest( turl, tm->tileRect( col, row ), i );
-            }
-          }
-        }
-      }
-      break;
+        createTileRequestsWMTS( tm, tiles, requests );
+        break;
 
       case XYZ:
-      {
-        QString url = mSettings.mBaseUrl;
-        int z = tm->identifier.toInt();
-        int i = 0;
-        for ( int row = row0; row <= row1; row++ )
-        {
-          for ( int col = col0; col <= col1; col++ )
-          {
-            QString turl( url );
-            turl.replace( "{x}", QString::number( col ), Qt::CaseInsensitive );
-            turl.replace( "{y}", QString::number( row ), Qt::CaseInsensitive );
-            turl.replace( "{z}", QString::number( z ), Qt::CaseInsensitive );
-
-            if ( feedback && !feedback->preview_only )
-              QgsDebugMsg( QString( "tileRequest %1 %2/%3 (%4,%5): %6" ).arg( mTileReqNo ).arg( i++ ).arg( n ).arg( row ).arg( col ).arg( turl ) );
-            requests << QgsWmsTiledImageDownloadHandler::TileRequest( turl, tm->tileRect( col, row ), i );
-          }
-        }
-      }
-      break;
+        createTileRequestsXYZ( tm, tiles, requests );
+        break;
 
       default:
         QgsDebugMsg( QString( "unexpected tile mode %1" ).arg( mTileLayer->tileMode ) );
@@ -838,8 +645,8 @@ QImage *QgsWmsProvider::draw( QgsRectangle const & viewExtent, int pixelWidth, i
     QTime t;
     t.start();
     int memCached = 0, diskCached = 0;
-    QList<QgsWmsTiledImageDownloadHandler::TileRequest> requestsFinal;
-    Q_FOREACH ( const QgsWmsTiledImageDownloadHandler::TileRequest& r, requests )
+    TileRequests requestsFinal;
+    Q_FOREACH ( const TileRequest& r, requests )
     {
       QImage localImage;
 
@@ -951,6 +758,220 @@ void QgsWmsProvider::readBlock( int bandNo, QgsRectangle  const & viewExtent, in
   }
 
   delete image;
+}
+
+QUrl QgsWmsProvider::createRequestUrlWMS( const QgsRectangle& viewExtent, int pixelWidth, int pixelHeight )
+{
+  // Calculate active layers that are also visible.
+
+  bool changeXY = mCaps.shouldInvertAxisOrientation( mImageCrs );
+
+  QgsDebugMsg( "Active layer list of "  + mSettings.mActiveSubLayers.join( ", " )
+               + " and style list of "  + mSettings.mActiveSubStyles.join( ", " ) );
+
+  QStringList visibleLayers = QStringList();
+  QStringList visibleStyles = QStringList();
+
+  QStringList::const_iterator it2  = mSettings.mActiveSubStyles.constBegin();
+
+  for ( QStringList::const_iterator it = mSettings.mActiveSubLayers.constBegin();
+        it != mSettings.mActiveSubLayers.constEnd();
+        ++it )
+  {
+    if ( mActiveSubLayerVisibility.constFind( *it ).value() )
+    {
+      visibleLayers += *it;
+      visibleStyles += *it2;
+    }
+
+    ++it2;
+  }
+
+  QString layers = visibleLayers.join( "," );
+  layers = layers.isNull() ? "" : layers;
+  QString styles = visibleStyles.join( "," );
+  styles = styles.isNull() ? "" : styles;
+
+  QgsDebugMsg( "Visible layer list of " + layers + " and style list of " + styles );
+
+  QString bbox = toParamValue( viewExtent, changeXY );
+
+  QUrl url( mSettings.mIgnoreGetMapUrl ? mSettings.mBaseUrl : getMapUrl() );
+  setQueryItem( url, "SERVICE", "WMS" );
+  setQueryItem( url, "VERSION", mCaps.mCapabilities.version );
+  setQueryItem( url, "REQUEST", "GetMap" );
+  setQueryItem( url, "BBOX", bbox );
+  setSRSQueryItem( url );
+  setQueryItem( url, "WIDTH", QString::number( pixelWidth ) );
+  setQueryItem( url, "HEIGHT", QString::number( pixelHeight ) );
+  setQueryItem( url, "LAYERS", layers );
+  setQueryItem( url, "STYLES", styles );
+  setFormatQueryItem( url );
+
+  if ( mDpi != -1 )
+  {
+    if ( mSettings.mDpiMode & dpiQGIS )
+      setQueryItem( url, "DPI", QString::number( mDpi ) );
+    if ( mSettings.mDpiMode & dpiUMN )
+      setQueryItem( url, "MAP_RESOLUTION", QString::number( mDpi ) );
+    if ( mSettings.mDpiMode & dpiGeoServer )
+      setQueryItem( url, "FORMAT_OPTIONS", QString( "dpi:%1" ).arg( mDpi ) );
+  }
+
+  //MH: jpeg does not support transparency and some servers complain if jpg and transparent=true
+  if ( mSettings.mImageMimeType == "image/x-jpegorpng" ||
+       ( !mSettings.mImageMimeType.contains( "jpeg", Qt::CaseInsensitive ) &&
+         !mSettings.mImageMimeType.contains( "jpg", Qt::CaseInsensitive ) ) )
+  {
+    setQueryItem( url, "TRANSPARENT", "TRUE" );  // some servers giving error for 'true' (lowercase)
+  }
+
+  QgsDebugMsg( QString( "getmap: %1" ).arg( url.toString() ) );
+  return url;
+}
+
+
+void QgsWmsProvider::createTileRequestsWMSC( const QgsWmtsTileMatrix* tm, const QgsWmsProvider::TilePositions& tiles, QgsWmsProvider::TileRequests& requests )
+{
+  bool changeXY = mCaps.shouldInvertAxisOrientation( mImageCrs );
+
+  // add WMS request
+  QUrl url( mSettings.mIgnoreGetMapUrl ? mSettings.mBaseUrl : getMapUrl() );
+  setQueryItem( url, "SERVICE", "WMS" );
+  setQueryItem( url, "VERSION", mCaps.mCapabilities.version );
+  setQueryItem( url, "REQUEST", "GetMap" );
+  setQueryItem( url, "LAYERS", mSettings.mActiveSubLayers.join( "," ) );
+  setQueryItem( url, "STYLES", mSettings.mActiveSubStyles.join( "," ) );
+  setQueryItem( url, "WIDTH", QString::number( tm->tileWidth ) );
+  setQueryItem( url, "HEIGHT", QString::number( tm->tileHeight ) );
+  setFormatQueryItem( url );
+
+  setSRSQueryItem( url );
+
+  if ( mSettings.mTiled )
+  {
+    setQueryItem( url, "TILED", "true" );
+  }
+
+  if ( mDpi != -1 )
+  {
+    if ( mSettings.mDpiMode & dpiQGIS )
+      setQueryItem( url, "DPI", QString::number( mDpi ) );
+    if ( mSettings.mDpiMode & dpiUMN )
+      setQueryItem( url, "MAP_RESOLUTION", QString::number( mDpi ) );
+    if ( mSettings.mDpiMode & dpiGeoServer )
+      setQueryItem( url, "FORMAT_OPTIONS", QString( "dpi:%1" ).arg( mDpi ) );
+  }
+
+  if ( mSettings.mImageMimeType == "image/x-jpegorpng" ||
+       ( !mSettings.mImageMimeType.contains( "jpeg", Qt::CaseInsensitive ) &&
+         !mSettings.mImageMimeType.contains( "jpg", Qt::CaseInsensitive ) ) )
+  {
+    setQueryItem( url, "TRANSPARENT", "TRUE" );  // some servers giving error for 'true' (lowercase)
+  }
+
+  int i = 0;
+  Q_FOREACH ( const TilePosition& tile, tiles )
+  {
+    QgsRectangle bbox( tm->tileBBox( tile.col, tile.row ) );
+    QString turl;
+    turl += url.toString();
+    turl += QString( changeXY ? "&BBOX=%2,%1,%4,%3" : "&BBOX=%1,%2,%3,%4" )
+            .arg( qgsDoubleToString( bbox.xMinimum() ),
+                  qgsDoubleToString( bbox.yMinimum() ),
+                  qgsDoubleToString( bbox.xMaximum() ),
+                  qgsDoubleToString( bbox.yMaximum() ) );
+
+    QgsDebugMsg( QString( "tileRequest %1 %2/%3 (%4,%5): %6" ).arg( mTileReqNo ).arg( i ).arg( tiles.count() ).arg( tile.row ).arg( tile.col ).arg( turl ) );
+    requests << TileRequest( turl, tm->tileRect( tile.col, tile.row ), i );
+    ++i;
+  }
+}
+
+
+void QgsWmsProvider::createTileRequestsWMTS( const QgsWmtsTileMatrix* tm, const QgsWmsProvider::TilePositions& tiles, QgsWmsProvider::TileRequests& requests )
+{
+  if ( !getTileUrl().isNull() )
+  {
+    // KVP
+    QUrl url( mSettings.mIgnoreGetMapUrl ? mSettings.mBaseUrl : getTileUrl() );
+
+    // compose static request arguments.
+    setQueryItem( url, "SERVICE", "WMTS" );
+    setQueryItem( url, "REQUEST", "GetTile" );
+    setQueryItem( url, "VERSION", mCaps.mCapabilities.version );
+    setQueryItem( url, "LAYER", mSettings.mActiveSubLayers[0] );
+    setQueryItem( url, "STYLE", mSettings.mActiveSubStyles[0] );
+    setQueryItem( url, "FORMAT", mSettings.mImageMimeType );
+    setQueryItem( url, "TILEMATRIXSET", mTileMatrixSet->identifier );
+    setQueryItem( url, "TILEMATRIX", tm->identifier );
+
+    for ( QHash<QString, QString>::const_iterator it = mSettings.mTileDimensionValues.constBegin(); it != mSettings.mTileDimensionValues.constEnd(); ++it )
+    {
+      setQueryItem( url, it.key(), it.value() );
+    }
+
+    url.removeQueryItem( "TILEROW" );
+    url.removeQueryItem( "TILECOL" );
+
+    int i = 0;
+    Q_FOREACH ( const TilePosition& tile, tiles )
+    {
+      QString turl;
+      turl += url.toString();
+      turl += QString( "&TILEROW=%1&TILECOL=%2" ).arg( tile.row ).arg( tile.col );
+
+      QgsDebugMsg( QString( "tileRequest %1 %2/%3 (%4,%5): %6" ).arg( mTileReqNo ).arg( i ).arg( tiles.count() ).arg( tile.row ).arg( tile.col ).arg( turl ) );
+      requests << TileRequest( turl, tm->tileRect( tile.col, tile.row ), i );
+      ++i;
+    }
+  }
+  else
+  {
+    // REST
+    QString url = mTileLayer->getTileURLs[ mSettings.mImageMimeType ];
+
+    url.replace( "{layer}", mSettings.mActiveSubLayers[0], Qt::CaseInsensitive );
+    url.replace( "{style}", mSettings.mActiveSubStyles[0], Qt::CaseInsensitive );
+    url.replace( "{tilematrixset}", mTileMatrixSet->identifier, Qt::CaseInsensitive );
+    url.replace( "{tilematrix}", tm->identifier, Qt::CaseInsensitive );
+
+    for ( QHash<QString, QString>::const_iterator it = mSettings.mTileDimensionValues.constBegin(); it != mSettings.mTileDimensionValues.constEnd(); ++it )
+    {
+      url.replace( "{" + it.key() + "}", it.value(), Qt::CaseInsensitive );
+    }
+
+    int i = 0;
+    Q_FOREACH ( const TilePosition& tile, tiles )
+    {
+      QString turl( url );
+      turl.replace( "{tilerow}", QString::number( tile.row ), Qt::CaseInsensitive );
+      turl.replace( "{tilecol}", QString::number( tile.col ), Qt::CaseInsensitive );
+
+      QgsDebugMsgLevel( QString( "tileRequest %1 %2/%3 (%4,%5): %6" ).arg( mTileReqNo ).arg( i ).arg( tiles.count() ).arg( tile.row ).arg( tile.col ).arg( turl ), 2 );
+      requests << TileRequest( turl, tm->tileRect( tile.col, tile.row ), i );
+      ++i;
+    }
+  }
+}
+
+
+void QgsWmsProvider::createTileRequestsXYZ( const QgsWmtsTileMatrix* tm, const QgsWmsProvider::TilePositions& tiles, QgsWmsProvider::TileRequests& requests )
+{
+  int z = tm->identifier.toInt();
+  QString url = mSettings.mBaseUrl;
+  int i = 0;
+  Q_FOREACH ( const TilePosition& tile, tiles )
+  {
+    ++i;
+    QString turl( url );
+    turl.replace( "{x}", QString::number( tile.col ), Qt::CaseInsensitive );
+    turl.replace( "{y}", QString::number( tile.row ), Qt::CaseInsensitive );
+    turl.replace( "{z}", QString::number( z ), Qt::CaseInsensitive );
+
+    QgsDebugMsgLevel( QString( "tileRequest %1 %2/%3 (%4,%5): %6" ).arg( mTileReqNo ).arg( i ).arg( tiles.count() ).arg( tile.row ).arg( tile.col ).arg( turl ), 2 );
+    requests << TileRequest( turl, tm->tileRect( tile.col, tile.row ), i );
+  }
 }
 
 
@@ -3498,7 +3519,7 @@ void QgsWmsImageDownloadHandler::cancelled()
 // ----------
 
 
-QgsWmsTiledImageDownloadHandler::QgsWmsTiledImageDownloadHandler( const QString& providerUri, const QgsWmsAuthorization& auth, int tileReqNo, const QList<QgsWmsTiledImageDownloadHandler::TileRequest>& requests, QImage* image, const QgsRectangle& viewExtent, bool smoothPixmapTransform, QgsRasterBlockFeedback* feedback )
+QgsWmsTiledImageDownloadHandler::QgsWmsTiledImageDownloadHandler( const QString& providerUri, const QgsWmsAuthorization& auth, int tileReqNo, const QgsWmsProvider::TileRequests& requests, QImage* image, const QgsRectangle& viewExtent, bool smoothPixmapTransform, QgsRasterBlockFeedback* feedback )
     : mProviderUri( providerUri )
     , mAuth( auth )
     , mImage( image )
@@ -3518,7 +3539,7 @@ QgsWmsTiledImageDownloadHandler::QgsWmsTiledImageDownloadHandler( const QString&
       return;
   }
 
-  Q_FOREACH ( const TileRequest& r, requests )
+  Q_FOREACH ( const QgsWmsProvider::TileRequest& r, requests )
   {
     QNetworkRequest request( r.url );
     auth.setAuthorization( request );

--- a/src/providers/wms/qgswmsprovider.h
+++ b/src/providers/wms/qgswmsprovider.h
@@ -348,6 +348,20 @@ class QgsWmsProvider : public QgsRasterDataProvider
      */
     static QString prepareUri( QString uri );
 
+    //! Helper struct for tile requests
+    struct TileRequest
+    {
+      TileRequest( const QUrl& u, const QRectF& r, int i )
+          : url( u )
+          , rect( r )
+          , index( i )
+      {}
+      QUrl url;
+      QRectF rect;
+      int index;
+    };
+    typedef QList<TileRequest> TileRequests;
+
   signals:
 
     /** \brief emit a signal to notify of a progress event */
@@ -426,6 +440,20 @@ class QgsWmsProvider : public QgsRasterDataProvider
     void setSRSQueryItem( QUrl& url );
 
   private:
+
+    //! Tile identifier within a tile source
+    typedef struct TilePosition
+    {
+      TilePosition( int r, int c ): row( r ), col( c ) {}
+      int row;
+      int col;
+    } TilePosition;
+    typedef QList<TilePosition> TilePositions;
+
+    QUrl createRequestUrlWMS( const QgsRectangle& viewExtent, int pixelWidth, int pixelHeight );
+    void createTileRequestsWMSC( const QgsWmtsTileMatrix* tm, const QgsWmsProvider::TilePositions& tiles, QgsWmsProvider::TileRequests& requests );
+    void createTileRequestsWMTS( const QgsWmtsTileMatrix* tm, const QgsWmsProvider::TilePositions& tiles, QgsWmsProvider::TileRequests& requests );
+    void createTileRequestsXYZ( const QgsWmtsTileMatrix* tm, const QgsWmsProvider::TilePositions& tiles, QgsWmsProvider::TileRequests& requests );
 
     /** Return the full url to request legend graphic
      * The visibleExtent isi only used if provider supports contextual
@@ -582,19 +610,7 @@ class QgsWmsTiledImageDownloadHandler : public QObject
     Q_OBJECT
   public:
 
-    struct TileRequest
-    {
-      TileRequest( const QUrl& u, const QRectF& r, int i )
-          : url( u )
-          , rect( r )
-          , index( i )
-      {}
-      QUrl url;
-      QRectF rect;
-      int index;
-    };
-
-    QgsWmsTiledImageDownloadHandler( const QString& providerUri, const QgsWmsAuthorization& auth, int reqNo, const QList<TileRequest>& requests, QImage* image, const QgsRectangle& viewExtent, bool smoothPixmapTransform, QgsRasterBlockFeedback* feedback );
+    QgsWmsTiledImageDownloadHandler( const QString& providerUri, const QgsWmsAuthorization& auth, int reqNo, const QgsWmsProvider::TileRequests& requests, QImage* image, const QgsRectangle& viewExtent, bool smoothPixmapTransform, QgsRasterBlockFeedback* feedback );
     ~QgsWmsTiledImageDownloadHandler();
 
     void downloadBlocking();

--- a/src/providers/wms/qgswmsprovider.h
+++ b/src/providers/wms/qgswmsprovider.h
@@ -571,6 +571,8 @@ class QgsWmsImageDownloadHandler : public QObject
     QImage* mCachedImage;
 
     QEventLoop* mEventLoop;
+
+    QgsRasterBlockFeedback* mFeedback;
 };
 
 

--- a/src/providers/wms/qgswmsprovider.h
+++ b/src/providers/wms/qgswmsprovider.h
@@ -362,6 +362,16 @@ class QgsWmsProvider : public QgsRasterDataProvider
     };
     typedef QList<TileRequest> TileRequests;
 
+    //! Tile identifier within a tile source
+    typedef struct TilePosition
+    {
+      TilePosition( int r, int c ): row( r ), col( c ) {}
+      bool operator==( const TilePosition& other ) const { return row == other.row && col == other.col; }
+      int row;
+      int col;
+    } TilePosition;
+    typedef QList<TilePosition> TilePositions;
+
   signals:
 
     /** \brief emit a signal to notify of a progress event */
@@ -441,19 +451,20 @@ class QgsWmsProvider : public QgsRasterDataProvider
 
   private:
 
-    //! Tile identifier within a tile source
-    typedef struct TilePosition
-    {
-      TilePosition( int r, int c ): row( r ), col( c ) {}
-      int row;
-      int col;
-    } TilePosition;
-    typedef QList<TilePosition> TilePositions;
-
     QUrl createRequestUrlWMS( const QgsRectangle& viewExtent, int pixelWidth, int pixelHeight );
     void createTileRequestsWMSC( const QgsWmtsTileMatrix* tm, const QgsWmsProvider::TilePositions& tiles, QgsWmsProvider::TileRequests& requests );
     void createTileRequestsWMTS( const QgsWmtsTileMatrix* tm, const QgsWmsProvider::TilePositions& tiles, QgsWmsProvider::TileRequests& requests );
     void createTileRequestsXYZ( const QgsWmtsTileMatrix* tm, const QgsWmsProvider::TilePositions& tiles, QgsWmsProvider::TileRequests& requests );
+
+    //! Helper structure to store a cached tile image with its rectangle
+    typedef struct TileImage
+    {
+      TileImage( QRectF r, QImage i ): rect( r ), img( i ) {}
+      QRectF rect; //!< destination rectangle for a tile (in screen coordinates)
+      QImage img;  //!< cached tile to be drawn
+    } TileImage;
+    //! Get tiles from a different resolution to cover the missing areas
+    void fetchOtherResTiles( QgsTileMode tileMode, const QgsRectangle& viewExtent, int imageWidth, QList<QRectF>& missing, double tres, int resOffset, QList<TileImage> &otherResTiles );
 
     /** Return the full url to request legend graphic
      * The visibleExtent isi only used if provider supports contextual

--- a/src/providers/wms/qgswmsprovider.h
+++ b/src/providers/wms/qgswmsprovider.h
@@ -489,13 +489,6 @@ class QgsWmsProvider : public QgsRasterDataProvider
     QString mImageCrs;
 
     /**
-     * The previously retrieved image from the WMS server.
-     * This can be reused if draw() is called consecutively
-     * with the same parameters.
-     */
-    QImage *mCachedImage;
-
-    /**
      * The reply to the capabilities request
      */
     QNetworkReply *mIdentifyReply;
@@ -509,13 +502,6 @@ class QgsWmsProvider : public QgsRasterDataProvider
 
     // TODO: better
     QString mIdentifyResultXsd;
-
-    /**
-     * The previous parameters to draw().
-     */
-    QgsRectangle mCachedViewExtent;
-    int mCachedViewWidth;
-    int mCachedViewHeight;
 
     /**
      * The error caption associated with the last WMS error.
@@ -603,7 +589,7 @@ class QgsWmsTiledImageDownloadHandler : public QObject
       int index;
     };
 
-    QgsWmsTiledImageDownloadHandler( const QString& providerUri, const QgsWmsAuthorization& auth, int reqNo, const QList<TileRequest>& requests, QImage* cachedImage, const QgsRectangle& cachedViewExtent, bool smoothPixmapTransform, QgsRasterBlockFeedback* feedback );
+    QgsWmsTiledImageDownloadHandler( const QString& providerUri, const QgsWmsAuthorization& auth, int reqNo, const QList<TileRequest>& requests, QImage* image, const QgsRectangle& viewExtent, bool smoothPixmapTransform, QgsRasterBlockFeedback* feedback );
     ~QgsWmsTiledImageDownloadHandler();
 
     void downloadBlocking();
@@ -628,8 +614,8 @@ class QgsWmsTiledImageDownloadHandler : public QObject
 
     QgsWmsAuthorization mAuth;
 
-    QImage* mCachedImage;
-    QgsRectangle mCachedViewExtent;
+    QImage* mImage;
+    QgsRectangle mViewExtent;
 
     QEventLoop* mEventLoop;
 
@@ -638,6 +624,8 @@ class QgsWmsTiledImageDownloadHandler : public QObject
 
     //! Running tile requests
     QList<QNetworkReply*> mReplies;
+
+    QgsRasterBlockFeedback* mFeedback;
 };
 
 

--- a/src/providers/wms/qgswmsprovider.h
+++ b/src/providers/wms/qgswmsprovider.h
@@ -363,6 +363,9 @@ class QgsWmsProvider : public QgsRasterDataProvider
 
   private:
 
+    //! In case of XYZ tile layer, setup capabilities from its URI
+    void setupXyzCapabilities( const QString& uri );
+
     QImage *draw( QgsRectangle const &  viewExtent, int pixelWidth, int pixelHeight, QgsRasterBlockFeedback* feedback );
 
     /**

--- a/src/providers/wms/qgsxyzconnection.cpp
+++ b/src/providers/wms/qgsxyzconnection.cpp
@@ -1,0 +1,59 @@
+/***************************************************************************
+    qgsxyzconnection.h
+    ---------------------
+    begin                : August 2016
+    copyright            : (C) 2016 by Martin Dobias
+    email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsxyzconnection.h"
+
+#include "qgsdatasourceuri.h"
+
+#include <QSettings>
+
+QString QgsXyzConnection::encodedUri() const
+{
+  QgsDataSourceUri uri;
+  uri.setParam( "type", "xyz" );
+  uri.setParam( "url", url );
+  return uri.encodedUri();
+}
+
+QStringList QgsXyzConnectionUtils::connectionList()
+{
+  QSettings settings;
+  settings.beginGroup( "/Qgis/connections-xyz" );
+  return settings.childGroups();
+}
+
+QgsXyzConnection QgsXyzConnectionUtils::connection( const QString &name )
+{
+  QSettings settings;
+  settings.beginGroup( "/Qgis/connections-xyz/" + name );
+
+  QgsXyzConnection conn;
+  conn.name = name;
+  conn.url = settings.value( "url" ).toString();
+  return conn;
+}
+
+void QgsXyzConnectionUtils::deleteConnection( const QString& name )
+{
+  QSettings settings;
+  settings.remove( "/Qgis/connections-xyz/" + name );
+}
+
+void QgsXyzConnectionUtils::addConnection( const QgsXyzConnection &conn )
+{
+  QSettings settings;
+  settings.beginGroup( "/Qgis/connections-xyz/" + conn.name );
+  settings.setValue( "url", conn.url );
+}

--- a/src/providers/wms/qgsxyzconnection.h
+++ b/src/providers/wms/qgsxyzconnection.h
@@ -1,0 +1,47 @@
+/***************************************************************************
+    qgsxyzconnection.h
+    ---------------------
+    begin                : August 2016
+    copyright            : (C) 2016 by Martin Dobias
+    email                : wonder dot sk at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSXYZCONNECTION_H
+#define QGSXYZCONNECTION_H
+
+#include <QStringList>
+
+struct QgsXyzConnection
+{
+  QString name;
+  QString url;
+
+  QString encodedUri() const;
+};
+
+/** Utility class for handling list of connections to XYZ tile layers */
+class QgsXyzConnectionUtils
+{
+  public:
+    //! Returns list of existing connections
+    static QStringList connectionList();
+
+    //! Returns connection details
+    static QgsXyzConnection connection( const QString& name );
+
+    //! Removes a connection from the list
+    static void deleteConnection( const QString& name );
+
+    //! Adds a new connection to the list
+    static void addConnection( const QgsXyzConnection& conn );
+};
+
+
+#endif // QGSXYZCONNECTION_H


### PR DESCRIPTION
This introduces live preview when rendering WMTS layers - as soon as individual tiles are loaded, they are shown in map canvas... no need to wait with a blank map until all tiles are fully downloaded. Additionally, if there are already locally cached tiles of other zoom levels, they may be used in the preview while the tiles with best matching zoom level are being downloaded. This greatly improves the user experience when working with WMTS layers.

Additionally, I have added native support for XYZ tile layers into WMS provider (based on existing implementation of WMTS tiling). This allows loading of various new raster tile sources (e.g. OpenStreetMap tiles) that were before available only with QuickMapServices or OpenLayers plugins. To use XYZ tile layers, open the browser dock in QGIS and look for "Tile Servers (XYZ)" root entry. Right-clicking will open a menu to add connections. For example for OpenStreetMap the URL would be `http://c.tile.openstreetmap.org/{z}/{x}/{y}.png`

The work on WMTS live preview has been funded by Land Information New Zealand.

The work on XYZ tile layers has been funded by Lutra Consulting.
