### PR TITLE
qgsmessagebar.pushMessage timeout is not respected in python

### DIFF
--- a/python/gui/qgsmessagebar.sip
+++ b/python/gui/qgsmessagebar.sip
@@ -48,9 +48,9 @@ class QgsMessageBar: QFrame
     static QgsMessageBarItem* createMessage( QWidget *widget, QWidget *parent = 0 ) /Factory/;
 
     //! convenience method for pushing a message to the bar
-    void pushMessage( const QString &text, MessageLevel level = INFO, int duration = 0 );
+    void pushMessage( const QString &text, MessageLevel level = INFO, int duration = 5 );
     //! convenience method for pushing a message with title to the bar
-    void pushMessage( const QString &title, const QString &text, MessageLevel level = INFO, int duration = 0 );
+    void pushMessage( const QString &title, const QString &text, MessageLevel level = INFO, int duration = 5 );
 
     QgsMessageBarItem *currentItem();
 


### PR DESCRIPTION
the default timeout is not respected in python

gui/qgsmessagebar.sip:51:    void pushMessage( const QString &text, MessageLevel level = INFO, int duration = 0 );

https://qgis.org/api/qgsmessagebar_8h_source.html#l00090
void pushMessage( const QString &text, MessageLevel level = INFO, int duration = 5 ) { return pushMessage( QString::null, text, level, duration ); }
