### PR TITLE
QgsPanelWidget API improvement

### DIFF
--- a/src/gui/qgspanelwidget.cpp
+++ b/src/gui/qgspanelwidget.cpp
@@ -62,6 +62,9 @@ QgsPanelWidget*QgsPanelWidget::findParentPanel( QWidget* widget )
 
 void QgsPanelWidget::openPanel( QgsPanelWidget* panel )
 {
+  //panel dock mode inherits from this panel
+  panel->setDockMode( dockMode() );
+
   if ( mDockMode )
   {
     emit showPanel( panel );


### PR DESCRIPTION
When a panel widget opens a new panel, the new panel should inherit the dock mode of the previous panel.

I can't see any reason why a docked panel should open a new panel in a non docked mode, and having this happen automatically (without the need to manually set dock mode) seems a bit friendlier.
