### PR TITLE
- Replaced use of deprecated QgsMapCanvas attribute "mapRenderer" by mapSettings

### DIFF
--- a/python/plugins/MetaSearch/dialogs/maindialog.py
+++ b/python/plugins/MetaSearch/dialogs/maindialog.py
@@ -551,7 +551,7 @@ class MetaSearchDialog(QDialog, BASE_CLASS):
             points = bbox_to_polygon(record.bbox)
             if points is not None:
                 src = QgsCoordinateReferenceSystem(4326)
-                dst = self.map.mapRenderer().destinationCrs()
+                dst = self.map.mapSettings().destinationCrs()
                 geom = QgsGeometry.fromPolygon(points)
                 if src.postgisSrid() != dst.postgisSrid():
                     ctr = QgsCoordinateTransform(src, dst)


### PR DESCRIPTION
This is causing an error with the metasearch core plugin, on QGIS dev 2.99.0-Master
