### PR TITLE
[delimitertext] fix watcher check ignored and harmful watcher created for iterator (fixes #15558)

### DIFF
--- a/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextfeatureiterator.cpp
@@ -500,8 +500,16 @@ QgsDelimitedTextFeatureSource::QgsDelimitedTextFeatureSource( const QgsDelimited
     , mXyDms( p->mXyDms )
     , attributeColumns( p->attributeColumns )
 {
+  QUrl url = p->mFile->url();
+
+  // make sure watcher not created when using iterator (e.g. for rendering, see issue #15558)
+  if ( url.hasQueryItem( "watchFile" ) )
+  {
+    url.removeQueryItem( "watchFile" );
+  }
+
   mFile = new QgsDelimitedTextFile();
-  mFile->setFromUrl( p->mFile->url() );
+  mFile->setFromUrl( url );
 
   mExpressionContext << QgsExpressionContextUtils::globalScope()
   << QgsExpressionContextUtils::projectScope();

--- a/src/providers/delimitedtext/qgsdelimitedtextfile.cpp
+++ b/src/providers/delimitedtext/qgsdelimitedtextfile.cpp
@@ -35,7 +35,7 @@ QgsDelimitedTextFile::QgsDelimitedTextFile( const QString& url )
     , mEncoding( "UTF-8" )
     , mFile( nullptr )
     , mStream( nullptr )
-    , mUseWatcher( true )
+    , mUseWatcher( false )
     , mWatcher( nullptr )
     , mDefinitionValid( false )
     , mUseHeader( true )
@@ -158,9 +158,9 @@ bool QgsDelimitedTextFile::setFromUrl( const QUrl &url )
   }
 
   //
-  if ( url.hasQueryItem( "useWatcher" ) )
+  if ( url.hasQueryItem( "watchFile" ) )
   {
-    mUseWatcher = ! url.queryItemValue( "useWatcher" ).toUpper().startsWith( 'N' );
+    mUseWatcher = url.queryItemValue( "watchFile" ).toUpper().startsWith( 'Y' );
   }
 
   // The default type is csv, to be consistent with the
@@ -269,9 +269,9 @@ QUrl QgsDelimitedTextFile::url()
     url.addQueryItem( "encoding", mEncoding );
   }
 
-  if ( !mUseWatcher )
+  if ( mUseWatcher )
   {
-    url.addQueryItem( "useWatcher", "no" );
+    url.addQueryItem( "watchFile", "yes" );
   }
 
   url.addQueryItem( "type", type() );


### PR DESCRIPTION
This PR fixes two issues:
- the [ x ] watch file setting was ignored (always on) as the code checked for the wrong query item
- more importantly, a watcher was always created while creating the provider iterator, resulting in a QSocketNotice error on Qt5 (and possibly leading to a crasher, see PR #3473)

@ccrook , I believe you are responsible for this provider. Does this look good to you? Thanks.
