### PR TITLE
Remove duplicate entry of mActionRemove.svg

### DIFF
--- a/images/images.qrc
+++ b/images/images.qrc
@@ -514,7 +514,6 @@
         <file>themes/default/relation.svg</file>
         <file>themes/default/mActionLink.svg</file>
         <file>themes/default/mActionUnlink.svg</file>
-        <file>themes/default/mActionRemove.svg</file>
         <file>flags/mr.png</file>
         <file>flags/bs.png</file>
         <file>flags/ca.png</file>


### PR DESCRIPTION
"mActionRemove.svg" is twice in images.qrc. This simple commit removes this warning.

It comes from this change: https://github.com/qgis/QGIS/commit/6b8130d54d17ca9b6e4e047b6f8da15c3d88a8da
