### PR TITLE
Make sure files are truncated before writing

### DIFF
--- a/src/analysis/interpolation/qgsgridfilewriter.cpp
+++ b/src/analysis/interpolation/qgsgridfilewriter.cpp
@@ -48,7 +48,7 @@ int QgsGridFileWriter::writeFile( bool showProgressDialog )
 {
   QFile outputFile( mOutputFilePath );
 
-  if ( !outputFile.open( QFile::WriteOnly ) )
+  if ( !outputFile.open( QFile::WriteOnly | QIODevice::Truncate ) )
   {
     return 1;
   }
@@ -111,7 +111,7 @@ int QgsGridFileWriter::writeFile( bool showProgressDialog )
   QFileInfo fi( mOutputFilePath );
   QString fileName = fi.absolutePath() + '/' + fi.completeBaseName() + ".prj";
   QFile prjFile( fileName );
-  if ( !prjFile.open( QFile::WriteOnly ) )
+  if ( !prjFile.open( QFile::WriteOnly | QIODevice::Truncate ) )
   {
     return 1;
   }

--- a/src/analysis/raster/qgsrelief.cpp
+++ b/src/analysis/raster/qgsrelief.cpp
@@ -574,7 +574,7 @@ bool QgsRelief::exportFrequencyDistributionToCsv( const QString& file )
 
   //write out frequency values to csv file for debugging
   QFile outFile( file );
-  if ( !outFile.open( QIODevice::WriteOnly ) )
+  if ( !outFile.open( QIODevice::WriteOnly | QIODevice::Truncate ) )
   {
     return false;
   }

--- a/src/app/composer/qgscomposer.cpp
+++ b/src/app/composer/qgscomposer.cpp
@@ -2877,7 +2877,7 @@ void QgsComposer::exportCompositionAsSVG( QgsComposer::OutputMode mode )
         QFileInfo fi( outputFileName );
         QString currentFileName = i == 0 ? outputFileName : fi.absolutePath() + '/' + fi.baseName() + '_' + QString::number( i + 1 ) + '.' + fi.suffix();
         QFile out( currentFileName );
-        bool openOk = out.open( QIODevice::WriteOnly | QIODevice::Text );
+        bool openOk = out.open( QIODevice::WriteOnly | QIODevice::Text | QIODevice::Truncate );
         if ( !openOk )
         {
           QMessageBox::warning( this, tr( "SVG export error" ),
@@ -3099,7 +3099,7 @@ void QgsComposer::on_mActionSaveAsTemplate_triggered()
   settings.setValue( "UI/lastComposerTemplateDir", saveFileInfo.absolutePath() );
 
   QFile templateFile( saveFileName );
-  if ( !templateFile.open( QIODevice::WriteOnly ) )
+  if ( !templateFile.open( QIODevice::WriteOnly | QIODevice::Truncate ) )
   {
     return;
   }
@@ -4068,7 +4068,7 @@ void QgsComposer::createComposerView()
 void QgsComposer::writeWorldFile( const QString& worldFileName, double a, double b, double c, double d, double e, double f ) const
 {
   QFile worldFile( worldFileName );
-  if ( !worldFile.open( QIODevice::WriteOnly | QIODevice::Text ) )
+  if ( !worldFile.open( QIODevice::WriteOnly | QIODevice::Text | QIODevice::Truncate ) )
   {
     return;
   }

--- a/src/app/main.cpp
+++ b/src/app/main.cpp
@@ -1229,7 +1229,7 @@ int main( int argc, char *argv[] )
     QFile dxfFile;
     if ( dxfOutputFile == "-" )
     {
-      if ( !dxfFile.open( stdout, QIODevice::WriteOnly ) )
+      if ( !dxfFile.open( stdout, QIODevice::WriteOnly | QIODevice::Truncate ) )
       {
         std::cerr << "could not open stdout" << std::endl;
         return 2;

--- a/src/app/qgsbookmarks.cpp
+++ b/src/app/qgsbookmarks.cpp
@@ -372,7 +372,7 @@ void QgsBookmarks::exportToXml()
   }
 
   QFile f( fileName );
-  if ( !f.open( QFile::WriteOnly ) )
+  if ( !f.open( QFile::WriteOnly | QIODevice::Truncate ) )
   {
     f.close();
     return;

--- a/src/app/qgsrasterlayerproperties.cpp
+++ b/src/app/qgsrasterlayerproperties.cpp
@@ -1281,7 +1281,7 @@ void QgsRasterLayerProperties::on_pbnExportTransparentPixelValues_clicked()
     }
 
     QFile myOutputFile( myFileName );
-    if ( myOutputFile.open( QFile::WriteOnly ) )
+    if ( myOutputFile.open( QFile::WriteOnly | QIODevice::Truncate ) )
     {
       QTextStream myOutputStream( &myOutputFile );
       myOutputStream << "# " << tr( "QGIS Generated Transparent Pixel Value Export File" ) << '\n';

--- a/src/app/qgssubstitutionlistwidget.cpp
+++ b/src/app/qgssubstitutionlistwidget.cpp
@@ -107,7 +107,7 @@ void QgsSubstitutionListWidget::on_mButtonExport_clicked()
   doc.appendChild( root );
 
   QFile file( fileName );
-  if ( !file.open( QIODevice::WriteOnly | QIODevice::Text ) )
+  if ( !file.open( QIODevice::WriteOnly | QIODevice::Text | QIODevice::Truncate ) )
   {
     QMessageBox::warning( nullptr, tr( "Export substitutions" ),
                           tr( "Cannot write file %1:\n%2." ).arg( fileName, file.errorString() ),

--- a/src/core/auth/qgsauthcertutils.cpp
+++ b/src/core/auth/qgsauthcertutils.cpp
@@ -253,7 +253,7 @@ QString QgsAuthCertUtils::pemTextToTempFile( const QString &name, const QByteArr
   QFile pemFile( QDir::tempPath() + QDir::separator() + name );
   QString pemFilePath( pemFile.fileName() );
 
-  if ( pemFile.open( QIODevice::WriteOnly ) )
+  if ( pemFile.open( QIODevice::WriteOnly | QIODevice::Truncate ) )
   {
     qint64 bytesWritten = pemFile.write( pemtext );
     if ( bytesWritten == -1 )

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -494,7 +494,7 @@ void QgsApplication::setUITheme( const QString &themeName )
 
   if ( variableInfo.exists() && variablesfile.open( QIODevice::ReadOnly ) )
   {
-    if ( !file.open( QIODevice::ReadOnly ) || !fileout.open( QIODevice::WriteOnly | QIODevice::Text ) )
+    if ( !file.open( QIODevice::ReadOnly ) || !fileout.open( QIODevice::WriteOnly | QIODevice::Text | QIODevice::Truncate ) )
     {
       return;
     }

--- a/src/core/qgsrenderchecker.cpp
+++ b/src/core/qgsrenderchecker.cpp
@@ -230,7 +230,7 @@ bool QgsRenderChecker::runTest( const QString& theTestName,
   //create a world file to go with the image...
 
   QFile wldFile( QDir::tempPath() + '/' + theTestName + "_result.wld" );
-  if ( wldFile.open( QIODevice::WriteOnly ) )
+  if ( wldFile.open( QIODevice::WriteOnly | QIODevice::Truncate ) )
   {
     QgsRectangle r = mMapSettings.extent();
 

--- a/src/core/qgsscaleutils.cpp
+++ b/src/core/qgsscaleutils.cpp
@@ -34,7 +34,7 @@ bool QgsScaleUtils::saveScaleList( const QString &fileName, const QStringList &s
   }
 
   QFile file( fileName );
-  if ( !file.open( QIODevice::WriteOnly | QIODevice::Text ) )
+  if ( !file.open( QIODevice::WriteOnly | QIODevice::Text | QIODevice::Truncate ) )
   {
     errorMessage = QString( "Cannot write file %1:\n%2." ).arg( fileName, file.errorString() );
     return false;

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -363,7 +363,7 @@ void QgsVectorFileWriter::init( QString vectorFileName,
     {
       QString layerName = vectorFileName.left( vectorFileName.indexOf( ".shp", Qt::CaseInsensitive ) );
       QFile prjFile( layerName + ".qpj" );
-      if ( prjFile.open( QIODevice::WriteOnly ) )
+      if ( prjFile.open( QIODevice::WriteOnly  | QIODevice::Truncate ) )
       {
         QTextStream prjStream( &prjFile );
         prjStream << srs.toWkt().toLocal8Bit().constData() << endl;

--- a/src/core/symbology-ng/qgsstyle.cpp
+++ b/src/core/symbology-ng/qgsstyle.cpp
@@ -1388,7 +1388,7 @@ bool QgsStyle::exportXml( const QString& filename )
 
   // save
   QFile f( filename );
-  if ( !f.open( QFile::WriteOnly ) )
+  if ( !f.open( QFile::WriteOnly | QIODevice::Truncate ) )
   {
     mErrorString = "Couldn't open file for writing: " + filename;
     return false;

--- a/src/core/symbology-ng/qgssymbollayerutils.cpp
+++ b/src/core/symbology-ng/qgssymbollayerutils.cpp
@@ -2950,7 +2950,7 @@ QMimeData* QgsSymbolLayerUtils::colorListToMimeData( const QgsNamedColorList& co
 
 bool QgsSymbolLayerUtils::saveColorsToGpl( QFile &file, const QString& paletteName, const QgsNamedColorList& colors )
 {
-  if ( !file.open( QIODevice::ReadWrite ) )
+  if ( !file.open( QIODevice::WriteOnly | QIODevice::Truncate ) )
   {
     return false;
   }

--- a/src/gui/qgsconfigureshortcutsdialog.cpp
+++ b/src/gui/qgsconfigureshortcutsdialog.cpp
@@ -139,7 +139,7 @@ void QgsConfigureShortcutsDialog::saveShortcuts()
   }
 
   QFile file( fileName );
-  if ( !file.open( QIODevice::WriteOnly | QIODevice::Text ) )
+  if ( !file.open( QIODevice::WriteOnly | QIODevice::Text | QIODevice::Truncate ) )
   {
     QMessageBox::warning( this, tr( "Saving shortcuts" ),
                           tr( "Cannot write file %1:\n%2." )

--- a/src/gui/qgsmanageconnectionsdialog.cpp
+++ b/src/gui/qgsmanageconnectionsdialog.cpp
@@ -133,7 +133,7 @@ void QgsManageConnectionsDialog::doExportImport()
     }
 
     QFile file( mFileName );
-    if ( !file.open( QIODevice::WriteOnly | QIODevice::Text ) )
+    if ( !file.open( QIODevice::WriteOnly | QIODevice::Text | QIODevice::Truncate ) )
     {
       QMessageBox::warning( this, tr( "Saving connections" ),
                             tr( "Cannot write file %1:\n%2." )

--- a/src/gui/qgsmapcanvas.cpp
+++ b/src/gui/qgsmapcanvas.cpp
@@ -782,7 +782,7 @@ void QgsMapCanvas::saveAsImage( const QString& theFileName, QPixmap * theQPixmap
   QString myWorldFileName = myInfo.absolutePath() + '/' + myInfo.baseName() + '.'
                             + outputSuffix.at( 0 ) + outputSuffix.at( myInfo.suffix().size() - 1 ) + 'w';
   QFile myWorldFile( myWorldFileName );
-  if ( !myWorldFile.open( QIODevice::WriteOnly ) ) //don't use QIODevice::Text
+  if ( !myWorldFile.open( QIODevice::WriteOnly | QIODevice::Truncate ) ) //don't use QIODevice::Text
   {
     return;
   }

--- a/src/gui/qgssearchquerybuilder.cpp
+++ b/src/gui/qgssearchquerybuilder.cpp
@@ -379,7 +379,7 @@ void QgsSearchQueryBuilder::saveQuery()
   }
 
   QFile saveFile( saveFileName );
-  if ( !saveFile.open( QIODevice::WriteOnly ) )
+  if ( !saveFile.open( QIODevice::WriteOnly | QIODevice::Truncate ) )
   {
     QMessageBox::critical( nullptr, tr( "Error" ), tr( "Could not open file for writing" ) );
     return;

--- a/src/gui/raster/qgsrastertransparencywidget.cpp
+++ b/src/gui/raster/qgsrastertransparencywidget.cpp
@@ -251,7 +251,7 @@ void QgsRasterTransparencyWidget::on_pbnExportTransparentPixelValues_clicked()
     }
 
     QFile myOutputFile( myFileName );
-    if ( myOutputFile.open( QFile::WriteOnly ) )
+    if ( myOutputFile.open( QFile::WriteOnly | QIODevice::Truncate ) )
     {
       QTextStream myOutputStream( &myOutputFile );
       myOutputStream << "# " << tr( "QGIS Generated Transparent Pixel Value Export File" ) << '\n';

--- a/src/gui/raster/qgssinglebandpseudocolorrendererwidget.cpp
+++ b/src/gui/raster/qgssinglebandpseudocolorrendererwidget.cpp
@@ -670,7 +670,7 @@ void QgsSingleBandPseudoColorRendererWidget::on_mExportToFileButton_clicked()
     }
 
     QFile outputFile( fileName );
-    if ( outputFile.open( QFile::WriteOnly ) )
+    if ( outputFile.open( QFile::WriteOnly | QIODevice::Truncate ) )
     {
       QTextStream outputStream( &outputFile );
       outputStream << "# " << tr( "QGIS Generated Color Map Export File" ) << '\n';

--- a/src/plugins/georeferencer/qgsgeorefplugingui.cpp
+++ b/src/plugins/georeferencer/qgsgeorefplugingui.cpp
@@ -1280,7 +1280,7 @@ bool QgsGeorefPluginGui::loadGCPs( /*bool verbose*/ )
 void QgsGeorefPluginGui::saveGCPs()
 {
   QFile pointFile( mGCPpointsFileName );
-  if ( pointFile.open( QIODevice::WriteOnly ) )
+  if ( pointFile.open( QIODevice::WriteOnly | QIODevice::Truncate ) )
   {
     QTextStream points( &pointFile );
     points << "mapX,mapY,pixelX,pixelY,enable" << endl;
@@ -1422,7 +1422,7 @@ bool QgsGeorefPluginGui::writeWorldFile( const QgsPoint& origin, double pixelXSi
 {
   // write the world file
   QFile file( mWorldFileName );
-  if ( !file.open( QIODevice::WriteOnly ) )
+  if ( !file.open( QIODevice::WriteOnly | QIODevice::Truncate ) )
   {
     mMessageBar->pushMessage( tr( "Error" ), tr( "Could not write to %1." ).arg( mWorldFileName ), QgsMessageBar::CRITICAL, messageTimeout() );
     return false;

--- a/src/plugins/grass/qgsgrassmapcalc.cpp
+++ b/src/plugins/grass/qgsgrassmapcalc.cpp
@@ -1052,7 +1052,7 @@ void QgsGrassMapcalc::save()
                  + "/mapcalc/" + mFileName;
 
   QFile out( path );
-  if ( !out.open( QIODevice::WriteOnly ) )
+  if ( !out.open( QIODevice::WriteOnly | QIODevice::Truncate ) )
   {
     QMessageBox::warning( this, tr( "Save mapcalc" ),
                           tr( "Cannot open mapcalc file" ) );

--- a/src/plugins/raster_terrain_analysis/qgsrasterterrainanalysisdialog.cpp
+++ b/src/plugins/raster_terrain_analysis/qgsrasterterrainanalysisdialog.cpp
@@ -249,7 +249,7 @@ void QgsRasterTerrainAnalysisDialog::on_mExportColorsButton_clicked()
   }
 
   QFile outputFile( file );
-  if ( !outputFile.open( QIODevice::WriteOnly ) )
+  if ( !outputFile.open( QIODevice::WriteOnly | QIODevice::Truncate ) )
   {
     return;
   }

--- a/src/providers/gpx/qgsgpxprovider.cpp
+++ b/src/providers/gpx/qgsgpxprovider.cpp
@@ -203,7 +203,7 @@ bool QgsGPXProvider::addFeatures( QgsFeatureList & flist )
 
   // write back to file
   QFile file( mFileName );
-  if ( !file.open( QIODevice::WriteOnly ) )
+  if ( !file.open( QIODevice::WriteOnly | QIODevice::Truncate ) )
     return false;
   QTextStream ostr( &file );
   data->writeXml( ostr );
@@ -391,7 +391,7 @@ bool QgsGPXProvider::deleteFeatures( const QgsFeatureIds & id )
 
   // write back to file
   QFile file( mFileName );
-  if ( !file.open( QIODevice::WriteOnly ) )
+  if ( !file.open( QIODevice::WriteOnly | QIODevice::Truncate ) )
     return false;
   QTextStream ostr( &file );
   data->writeXml( ostr );
@@ -441,7 +441,7 @@ bool QgsGPXProvider::changeAttributeValues( const QgsChangedAttributesMap &attr_
 
   // write back to file
   QFile file( mFileName );
-  if ( !file.open( QIODevice::WriteOnly ) )
+  if ( !file.open( QIODevice::WriteOnly | QIODevice::Truncate ) )
     return false;
   QTextStream ostr( &file );
   data->writeXml( ostr );

--- a/src/providers/ogr/qgsogrdataitems.cpp
+++ b/src/providers/ogr/qgsogrdataitems.cpp
@@ -74,7 +74,7 @@ bool QgsOgrLayerItem::setCrs( QgsCoordinateReferenceSystem crs )
   char* pszOutWkt = nullptr;
   OSRExportToWkt( hSRS, &pszOutWkt );
   QFile prjFile( layerName + ".prj" );
-  if ( prjFile.open( QIODevice::WriteOnly ) )
+  if ( prjFile.open( QIODevice::WriteOnly | QIODevice::Truncate ) )
   {
     QTextStream prjStream( &prjFile );
     prjStream << pszOutWkt << endl;
@@ -90,7 +90,7 @@ bool QgsOgrLayerItem::setCrs( QgsCoordinateReferenceSystem crs )
 
   // save qgis-specific .qpj file (maybe because of better wkt compatibility?)
   QFile qpjFile( layerName + ".qpj" );
-  if ( qpjFile.open( QIODevice::WriteOnly ) )
+  if ( qpjFile.open( QIODevice::WriteOnly | QIODevice::Truncate ) )
   {
     QTextStream qpjStream( &qpjFile );
     qpjStream << wkt.toLocal8Bit().data() << endl;

--- a/src/providers/ogr/qgsogrprovider.cpp
+++ b/src/providers/ogr/qgsogrprovider.cpp
@@ -2663,7 +2663,7 @@ QGISEXTERN bool createEmptyDataSource( const QString &uri,
   {
     QString layerName = uri.left( uri.indexOf( ".shp", Qt::CaseInsensitive ) );
     QFile prjFile( layerName + ".qpj" );
-    if ( prjFile.open( QIODevice::WriteOnly ) )
+    if ( prjFile.open( QIODevice::WriteOnly | QIODevice::Truncate ) )
     {
       QTextStream prjStream( &prjFile );
       prjStream << myWkt.toLocal8Bit().data() << endl;

--- a/src/providers/wcs/qgswcscapabilities.cpp
+++ b/src/providers/wcs/qgswcscapabilities.cpp
@@ -427,7 +427,7 @@ bool QgsWcsCapabilities::parseCapabilitiesDom( QByteArray const &xml, QgsWcsCapa
   QgsDebugMsg( "Entered." );
 #ifdef QGISDEBUG
   QFile file( QDir::tempPath() + "/qgis-wcs-capabilities.xml" );
-  if ( file.open( QIODevice::WriteOnly ) )
+  if ( file.open( QIODevice::WriteOnly | QIODevice::Truncate ) )
   {
     file.write( xml );
     file.close();

--- a/src/providers/wfs/qgswfsfeatureiterator.cpp
+++ b/src/providers/wfs/qgswfsfeatureiterator.cpp
@@ -904,7 +904,7 @@ void QgsWFSFeatureIterator::featureReceivedSynchronous( QVector<QgsWFSFeatureGml
     mWriterFilename = QDir( QgsWFSUtils::acquireCacheDirectory() ).filePath( QString( "iterator_%1_%2.bin" ).arg( thisStr ).arg( mCounter ) );
     QgsDebugMsg( QString( "Transferring feature iterator cache to %1" ).arg( mWriterFilename ) );
     mWriterFile = new QFile( mWriterFilename );
-    if ( !mWriterFile->open( QIODevice::WriteOnly ) )
+    if ( !mWriterFile->open( QIODevice::WriteOnly | QIODevice::Truncate ) )
     {
       QgsDebugMsg( QString( "Cannot open %1 for writing" ).arg( mWriterFilename ) );
       delete mWriterFile;

--- a/src/providers/wfs/qgswfsshareddata.cpp
+++ b/src/providers/wfs/qgswfsshareddata.cpp
@@ -354,7 +354,7 @@ bool QgsWFSSharedData::createCache()
 
     // Copy the in-memory template Spatialite DB into the target DB
     QFile dbFile( mCacheDbname );
-    if ( !dbFile.open( QIODevice::WriteOnly ) )
+    if ( !dbFile.open( QIODevice::WriteOnly | QIODevice::Truncate ) )
     {
       QgsMessageLog::logMessage( tr( "Cannot create temporary SpatiaLite cache" ), tr( "WFS" ) );
       return false;

--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -249,7 +249,7 @@ bool QgsWmsCapabilities::parseCapabilitiesDom( QByteArray const &xml, QgsWmsCapa
 
 #ifdef QGISDEBUG
   QFile file( QDir::tempPath() + "/qgis-wmsprovider-capabilities.xml" );
-  if ( file.open( QIODevice::WriteOnly ) )
+  if ( file.open( QIODevice::WriteOnly | QIODevice::Truncate ) )
   {
     file.write( xml );
     file.close();

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -3835,7 +3835,7 @@ void QgsWmsTiledImageDownloadHandler::tileReplyFinished()
                                    .arg( reply->url().toString() ), tr( "WMS" ) );
 #ifdef QGISDEBUG
         QFile file( QDir::tempPath() + "/broken-image.png" );
-        if ( file.open( QIODevice::WriteOnly ) )
+        if ( file.open( QIODevice::WriteOnly | QIODevice::Truncate ) )
         {
           file.write( text );
           file.close();

--- a/src/server/qgsmsutils.cpp
+++ b/src/server/qgsmsutils.cpp
@@ -70,7 +70,7 @@ QString QgsMSUtils::createTempFilePath()
 int QgsMSUtils::createTextFile( const QString& filePath, const QString& text )
 {
   QFile file( filePath );
-  if ( file.open( QIODevice::WriteOnly | QIODevice::Text ) )
+  if ( file.open( QIODevice::WriteOnly | QIODevice::Text | QIODevice::Truncate ) )
   {
     QTextStream fileStream( &file );
     fileStream << text;

--- a/src/server/qgssoaprequesthandler.cpp
+++ b/src/server/qgssoaprequesthandler.cpp
@@ -768,7 +768,7 @@ int QgsSOAPRequestHandler::setUrlToFile( QImage* img )
     theFile.setFileName( tmpMasDir.absolutePath() + "/" + folderName + "/map.png" );
     uri.append( "/mas_tmp/" + folderName + "/map.png" );
   }
-  if ( !theFile.open( QIODevice::WriteOnly ) )
+  if ( !theFile.open( QIODevice::WriteOnly | QIODevice::Truncate ) )
   {
     QgsDebugMsg( "Error, could not open file" );
     return 4;

--- a/tests/bench/qgsbench.cpp
+++ b/tests/bench/qgsbench.cpp
@@ -335,7 +335,7 @@ QString QgsBench::serialize( const QMap<QString, QVariant>& theMap, int level )
 void QgsBench::saveLog( const QString & fileName )
 {
   QFile file( fileName );
-  if ( !file.open( QIODevice::WriteOnly | QIODevice::Text ) )
+  if ( !file.open( QIODevice::WriteOnly | QIODevice::Text | QIODevice::Truncate ) )
     return;
 
   QTextStream out( &file );

--- a/tests/src/core/testqgis.cpp
+++ b/tests/src/core/testqgis.cpp
@@ -57,7 +57,7 @@ void TestQgis::cleanupTestCase()
 {
   QString myReportFile = QDir::tempPath() + "/qgistest.html";
   QFile myFile( myReportFile );
-  if ( myFile.open( QIODevice::WriteOnly ) )
+  if ( myFile.open( QIODevice::WriteOnly | QIODevice::Truncate ) )
   {
     QTextStream myQTextStream( &myFile );
     myQTextStream << mReport;

--- a/tests/src/core/testqgsauthmanager.cpp
+++ b/tests/src/core/testqgsauthmanager.cpp
@@ -105,7 +105,7 @@ void TestQgsAuthManager::initTestCase()
   // create QGIS_AUTH_PASSWORD_FILE file
   QString passfilepath = mTempDir + "/passfile";
   QFile passfile( passfilepath );
-  if ( passfile.open( QIODevice::WriteOnly | QIODevice::Text ) )
+  if ( passfile.open( QIODevice::WriteOnly | QIODevice::Text | QIODevice::Truncate ) )
   {
     QTextStream fout( &passfile );
     fout << QString( mPass ) << "\r\n";
@@ -149,7 +149,7 @@ void TestQgsAuthManager::cleanupTestCase()
 
   QString myReportFile = QDir::tempPath() + "/qgistest.html";
   QFile myFile( myReportFile );
-  if ( myFile.open( QIODevice::WriteOnly ) )
+  if ( myFile.open( QIODevice::WriteOnly | QIODevice::Truncate ) )
   {
     QTextStream myQTextStream( &myFile );
     myQTextStream << mReport;

--- a/tests/src/providers/testqgswcspublicservers.cpp
+++ b/tests/src/providers/testqgswcspublicservers.cpp
@@ -422,7 +422,7 @@ void TestQgsWcsPublicServers::test()
           {
             uri = myPath + "-gdal.xml";
             QFile myGdalXmlFile( uri );
-            Q_ASSERT( myGdalXmlFile.open( QIODevice::WriteOnly | QIODevice::Text ) );
+            Q_ASSERT( myGdalXmlFile.open( QIODevice::WriteOnly | QIODevice::Text | QIODevice::Truncate ) );
             QTextStream myStream( &myGdalXmlFile );
             myStream << "<WCS_GDAL>\n";
             myStream << "  <ServiceURL>" + serverUrl + '?' + "</ServiceURL>\n";
@@ -519,7 +519,7 @@ void TestQgsWcsPublicServers::test()
 
         QFile myLogFile( myLogPath );
 
-        Q_ASSERT( myLogFile.open( QIODevice::WriteOnly | QIODevice::Text ) );
+        Q_ASSERT( myLogFile.open( QIODevice::WriteOnly | QIODevice::Text | QIODevice::Truncate ) );
         QTextStream myStream( &myLogFile );
         myStream << myLog.join( "\n" );
 
@@ -531,13 +531,13 @@ void TestQgsWcsPublicServers::test()
         QgsDebugMsg( "Coverage not found" );
       }
       QFile myVersionLogFile( myVersionLogPath );
-      Q_ASSERT( myVersionLogFile.open( QIODevice::WriteOnly | QIODevice::Text ) );
+      Q_ASSERT( myVersionLogFile.open( QIODevice::WriteOnly | QIODevice::Text | QIODevice::Truncate ) );
       QTextStream myVersionStream( &myVersionLogFile );
       myVersionStream << myVersionLog.join( "\n" );
       myVersionLogFile.close();
     }
     QFile myServerLogFile( myServerLogPath );
-    Q_ASSERT( myServerLogFile.open( QIODevice::WriteOnly | QIODevice::Text ) );
+    Q_ASSERT( myServerLogFile.open( QIODevice::WriteOnly | QIODevice::Text | QIODevice::Truncate ) );
     QTextStream myServerStream( &myServerLogFile );
     myServerStream << myServerLog.join( "\n" );
     myServerLogFile.close();
@@ -548,7 +548,7 @@ void TestQgsWcsPublicServers::writeReport( const QString& theReport )
 {
   QString myReportFile = mCacheDir.absolutePath() + "/index.html";
   QFile myFile( myReportFile );
-  if ( myFile.open( QIODevice::WriteOnly ) )
+  if ( myFile.open( QIODevice::WriteOnly | QIODevice::Truncate ) )
   {
     QTextStream myStream( &myFile );
     myStream << theReport;


### PR DESCRIPTION
I might be misinterpreting the Qt docs - but I believe there's a lot of cases in master where we should be opening files for writing with the QIODevice::Truncate flag.

I hit an issue today where a file exported from the color list (gpl file) was not being correctly truncated and tracked it down to a missing Truncate flag. But searching through the code I've found lots of other instances were the flag is missing, and am surprised that we haven't seen the consequences of this before...
