### PR TITLE
[FEATURE] "Preset colors" color ramp

### DIFF
--- a/python/core/qgscolorramp.sip
+++ b/python/core/qgscolorramp.sip
@@ -16,6 +16,8 @@ class QgsColorRamp
     sipType = sipType_QgsLimitedRandomColorRamp;
   else if (sipCpp->type() == "randomcolors")
     sipType = sipType_QgsRandomColorRamp;
+  else if (sipCpp->type() == "preset")
+    sipType = sipType_QgsPresetSchemeColorRamp;
   else if (sipCpp->type() == "colorbrewer")
     sipType = sipType_QgsColorBrewerColorRamp;
   else if (sipCpp->type() == "cpt-city")
@@ -283,6 +285,64 @@ class QgsRandomColorRamp : QgsColorRamp
     virtual QgsRandomColorRamp* clone() const /Factory/;
 
     QgsStringMap properties() const;
+};
+
+/** \ingroup core
+ * \class QgsPresetSchemeColorRamp
+ * \brief A scheme based color ramp consisting of a list of predefined colors.
+ * \note added in QGIS 3.0
+ */
+class QgsPresetSchemeColorRamp : QgsColorRamp, QgsColorScheme
+{
+%TypeHeaderCode
+#include <qgscolorramp.h>
+%End
+
+  public:
+
+    /** Constructor for QgsPresetSchemeColorRamp.
+     * @param colors list of colors in ramp
+     */
+    QgsPresetSchemeColorRamp( const QList< QColor >& colors = QList< QColor >() );
+
+    /** Constructor for QgsPresetColorRamp.
+     * @param colors list of named colors in ramp
+     * @note not available in Python bindings - use setColors instead
+     */
+    //QgsPresetSchemeColorRamp( const QgsNamedColorList& colors );
+
+    /** Returns a new QgsPresetSchemeColorRamp color ramp created using the properties encoded in a string
+     * map.
+     * @param properties color ramp properties
+     * @see properties()
+     */
+    static QgsColorRamp* create( const QgsStringMap& properties = QgsStringMap() );
+
+    /** Sets the list of colors used by the ramp.
+     * @param colors list of colors
+     * @see colors()
+     */
+    bool setColors( const QgsNamedColorList& colors, const QString& = QString(), const QColor& = QColor() );
+
+    /** Returns the list of colors used by the ramp.
+     * @see setColors()
+     */
+    QList< QColor > colors() const;
+
+    // QgsColorRamp interface
+    virtual double value( int index ) const;
+    virtual QColor color( double value ) const;
+    virtual QString type() const;
+    virtual QgsPresetSchemeColorRamp* clone() const /Factory/;
+    virtual QgsStringMap properties() const;
+    int count() const;
+
+    // QgsColorScheme interface
+    QString schemeName() const;
+    QgsNamedColorList fetchColors( const QString &context = QString(),
+                                   const QColor &baseColor = QColor() );
+    bool isEditable() const;
+
 };
 
 /** \ingroup core

--- a/python/gui/gui.sip
+++ b/python/gui/gui.sip
@@ -141,6 +141,7 @@
 %Include qgspanelwidgetstack.sip
 %Include qgspixmaplabel.sip
 %Include qgspluginmanagerinterface.sip
+%Include qgspresetcolorrampdialog.sip
 %Include qgsprevieweffect.sip
 %Include qgsprojectbadlayerguihandler.sip
 %Include qgsprojectionselectionwidget.sip

--- a/python/gui/qgscolorschemelist.sip
+++ b/python/gui/qgscolorschemelist.sip
@@ -85,8 +85,9 @@ class QgsColorSchemeModel: QAbstractItemModel
     /** Add a color to the list
      * @param color color to add
      * @param label label for color
+     * @param allowDuplicate set to true to allow duplicate colors to be added (colors which are already present in the list)
      */
-    void addColor( const QColor color, const QString &label = QString() );
+    void addColor( const QColor &color, const QString &label = QString(), bool allowDuplicate = false );
 
     /** Returns whether the color scheme model has been modified
      * @returns true if colors have been modified
@@ -162,11 +163,12 @@ class QgsColorSchemeList: QTreeView
      */
     void removeSelection();
 
-    /** Adds a color to the list
+    /** Add a color to the list
      * @param color color to add
-     * @param label optional label for color
+     * @param label label for color
+     * @param allowDuplicate set to true to allow duplicate colors to be added (colors which are already present in the list)
      */
-    void addColor( const QColor &color, const QString &label = QString() );
+    void addColor( const QColor &color, const QString &label = QString(), bool allowDuplicate = false );
 
     /** Pastes colors from clipboard to the list
      * @see copyColors

--- a/python/gui/qgscompoundcolorwidget.sip
+++ b/python/gui/qgscompoundcolorwidget.sip
@@ -41,6 +41,13 @@ class QgsCompoundColorWidget : QgsPanelWidget
      */
     void setAllowAlpha( const bool allowAlpha );
 
+    /** Sets whether the widget's color has been "discarded" and the selected color should not
+     * be stored in the recent color list.
+     * @param discarded set to true to avoid adding color to recent color list on widget destruction.
+     * @note added in QGIS 3.0
+     */
+    void setDiscarded( bool discarded );
+
   signals:
 
     /** Emitted when the dialog's color changes

--- a/python/gui/qgspresetcolorrampdialog.sip
+++ b/python/gui/qgspresetcolorrampdialog.sip
@@ -1,0 +1,75 @@
+/** \ingroup gui
+ * \class QgsPresetColorRampWidget
+ * A widget which allows users to modify the properties of a QgsPresetSchemeColorRamp.
+ * \note added in QGIS 3.0
+ */
+
+class QgsPresetColorRampWidget : QgsPanelWidget
+{
+%TypeHeaderCode
+#include <qgspresetcolorrampdialog.h>
+%End
+
+  public:
+
+/** Constructor for QgsPresetColorRampWidget.
+     * @param ramp initial ramp to show in dialog
+     * @param parent parent widget
+     */
+    QgsPresetColorRampWidget( const QgsPresetSchemeColorRamp& ramp, QWidget* parent /TransferThis/ = nullptr );
+
+    ~QgsPresetColorRampWidget();
+
+    /** Returns a color ramp representing the current settings from the dialog.
+     * @see setRamp()
+     */
+    QgsPresetSchemeColorRamp ramp() const;
+
+    /** Sets the color ramp to show in the dialog.
+     * @param ramp color ramp
+     * @see ramp()
+     */
+    void setRamp( const QgsPresetSchemeColorRamp& ramp );
+
+  signals:
+
+    //! Emitted when the dialog settings change
+    void changed();
+};
+
+/** \ingroup gui
+ * \class QgsPresetColorRampDialog
+ * A dialog which allows users to modify the properties of a QgsPresetSchemeColorRamp.
+ * \note added in QGIS 3.0
+ */
+
+class QgsPresetColorRampDialog : QDialog
+{
+%TypeHeaderCode
+#include <qgspresetcolorrampdialog.h>
+%End
+
+  public:
+
+    /** Constructor for QgsPresetColorRampDialog.
+     * @param ramp initial ramp to show in dialog
+     * @param parent parent widget
+     */
+    QgsPresetColorRampDialog( const QgsPresetSchemeColorRamp& ramp, QWidget* parent /TransferThis/ = nullptr );
+
+    /** Returns a color ramp representing the current settings from the dialog.
+     * @see setRamp()
+     */
+    QgsPresetSchemeColorRamp ramp() const;
+
+    /** Sets the color ramp to show in the dialog.
+     * @param ramp color ramp
+     * @see ramp()
+     */
+    void setRamp( const QgsPresetSchemeColorRamp& ramp );
+
+  signals:
+
+    //! Emitted when the dialog settings change
+    void changed();
+};

--- a/src/core/qgscolorramp.h
+++ b/src/core/qgscolorramp.h
@@ -19,6 +19,7 @@
 #include <QColor>
 #include <QGradient>
 #include "qgis.h"
+#include "qgscolorscheme.h"
 
 /** \ingroup core
  * \class QgsColorRamp
@@ -378,6 +379,64 @@ class CORE_EXPORT QgsRandomColorRamp: public QgsColorRamp
     int mTotalColorCount;
     QList<QColor> mPrecalculatedColors;
 
+};
+
+
+/** \ingroup core
+ * \class QgsPresetSchemeColorRamp
+ * \brief A scheme based color ramp consisting of a list of predefined colors.
+ * \note added in QGIS 3.0
+ */
+class CORE_EXPORT QgsPresetSchemeColorRamp : public QgsColorRamp, public QgsColorScheme
+{
+  public:
+
+    /** Constructor for QgsPresetSchemeColorRamp.
+     * @param colors list of colors in ramp
+     */
+    QgsPresetSchemeColorRamp( const QList< QColor >& colors = QList< QColor >() );
+
+    /** Constructor for QgsPresetColorRamp.
+     * @param colors list of named colors in ramp
+     * @note not available in Python bindings - use setColors instead
+     */
+    QgsPresetSchemeColorRamp( const QgsNamedColorList& colors );
+
+    /** Returns a new QgsPresetSchemeColorRamp color ramp created using the properties encoded in a string
+     * map.
+     * @param properties color ramp properties
+     * @see properties()
+     */
+    static QgsColorRamp* create( const QgsStringMap& properties = QgsStringMap() );
+
+    /** Sets the list of colors used by the ramp.
+     * @param colors list of colors
+     * @see colors()
+     */
+    bool setColors( const QgsNamedColorList& colors, const QString& = QString(), const QColor& = QColor() ) override { mColors = colors; return true; }
+
+    /** Returns the list of colors used by the ramp.
+     * @see setColors()
+     */
+    QList< QColor > colors() const;
+
+    // QgsColorRamp interface
+    virtual double value( int index ) const override;
+    virtual QColor color( double value ) const override;
+    virtual QString type() const override { return "preset"; }
+    virtual QgsPresetSchemeColorRamp* clone() const override;
+    virtual QgsStringMap properties() const override;
+    int count() const override;
+
+    // QgsColorScheme interface
+    QString schemeName() const override { return "preset"; }
+    QgsNamedColorList fetchColors( const QString &context = QString(),
+                                   const QColor &baseColor = QColor() ) override;
+    bool isEditable() const override { return true; }
+
+  private:
+
+    QgsNamedColorList mColors;
 };
 
 

--- a/src/core/symbology-ng/qgssymbollayerutils.cpp
+++ b/src/core/symbology-ng/qgssymbollayerutils.cpp
@@ -2665,6 +2665,8 @@ QgsColorRamp* QgsSymbolLayerUtils::loadColorRamp( QDomElement& element )
     return QgsColorBrewerColorRamp::create( props );
   else if ( rampType == "cpt-city" )
     return QgsCptCityColorRamp::create( props );
+  else if ( rampType == "preset" )
+    return QgsPresetSchemeColorRamp::create( props );
   else
   {
     QgsDebugMsg( "unknown colorramp type " + rampType );

--- a/src/gui/CMakeLists.txt
+++ b/src/gui/CMakeLists.txt
@@ -279,6 +279,7 @@ SET(QGIS_GUI_SRCS
   qgspanelwidgetstack.cpp
   qgspixmaplabel.cpp
   qgspluginmanagerinterface.cpp
+  qgspresetcolorrampdialog.cpp
   qgsprevieweffect.cpp
   qgsprojectbadlayerguihandler.cpp
   qgsprojectionselectionwidget.cpp
@@ -434,6 +435,7 @@ SET(QGIS_GUI_MOC_HDRS
   qgspanelwidgetstack.h
   qgspixmaplabel.h
   qgspluginmanagerinterface.h
+  qgspresetcolorrampdialog.h
   qgsprevieweffect.h
   qgsprojectbadlayerguihandler.h
   qgsprojectionselectionwidget.h

--- a/src/gui/qgscolorbutton.cpp
+++ b/src/gui/qgscolorbutton.cpp
@@ -101,7 +101,6 @@ void QgsColorButton::showColorDialog()
     colorWidget->setPanelTitle( mColorDialogTitle );
     colorWidget->setAllowAlpha( mAllowAlpha );
     connect( colorWidget, SIGNAL( currentColorChanged( QColor ) ), this, SLOT( setValidTemporaryColor( QColor ) ) );
-    connect( colorWidget, SIGNAL( panelAccepted( QgsPanelWidget* ) ), this, SLOT( panelAccepted( QgsPanelWidget* ) ) );
     panel->openPanel( colorWidget );
     return;
   }
@@ -141,7 +140,6 @@ void QgsColorButton::showColorDialog()
   if ( newColor.isValid() )
   {
     setValidColor( newColor );
-    addRecentColor( newColor );
   }
 
   // reactivate button's window
@@ -375,14 +373,6 @@ void QgsColorButton::setValidTemporaryColor( const QColor& newColor )
   if ( newColor.isValid() )
   {
     setColor( newColor );
-  }
-}
-
-void QgsColorButton::panelAccepted( QgsPanelWidget* widget )
-{
-  if ( QgsCompoundColorWidget* colorWidget = qobject_cast< QgsCompoundColorWidget* >( widget ) )
-  {
-    addRecentColor( colorWidget->color() );
   }
 }
 

--- a/src/gui/qgscolorbutton.h
+++ b/src/gui/qgscolorbutton.h
@@ -425,9 +425,6 @@ class GUI_EXPORT QgsColorButton : public QToolButton
      */
     void setValidTemporaryColor( const QColor& newColor );
 
-    //! Called when a color widget panel is accepted, and adds the final color to the recent colors list
-    void panelAccepted( QgsPanelWidget* widget );
-
     /** Adds a color to the recent colors list
      * @param color to add to recent colors list
      */

--- a/src/gui/qgscolordialog.cpp
+++ b/src/gui/qgscolordialog.cpp
@@ -55,6 +55,7 @@ QgsColorDialog::QgsColorDialog( QWidget *parent, Qt::WindowFlags fl, const QColo
   mColorWidget->setAllowAlpha( true );
 
   connect( mColorWidget, SIGNAL( currentColorChanged( QColor ) ), this, SIGNAL( currentColorChanged( QColor ) ) );
+  connect( this, SIGNAL( rejected() ), this, SLOT( discardColor() ) );
 }
 
 QgsColorDialog::~QgsColorDialog()
@@ -172,6 +173,11 @@ void QgsColorDialog::on_mButtonBox_clicked( QAbstractButton * button )
   {
     setColor( mPreviousColor );
   }
+}
+
+void QgsColorDialog::discardColor()
+{
+  mColorWidget->setDiscarded( true );
 }
 
 void QgsColorDialog::saveSettings()

--- a/src/gui/qgscolordialog.h
+++ b/src/gui/qgscolordialog.h
@@ -111,6 +111,7 @@ class GUI_EXPORT QgsColorDialog : public QDialog, private Ui::QgsColorDialogBase
     void on_mButtonBox_accepted();
     void on_mButtonBox_rejected();
     void on_mButtonBox_clicked( QAbstractButton * button );
+    void discardColor();
 
   private:
 

--- a/src/gui/qgscolorschemelist.cpp
+++ b/src/gui/qgscolorschemelist.cpp
@@ -93,9 +93,9 @@ void QgsColorSchemeList::removeSelection()
   }
 }
 
-void QgsColorSchemeList::addColor( const QColor &color, const QString &label )
+void QgsColorSchemeList::addColor( const QColor &color, const QString &label, bool allowDuplicate )
 {
-  mModel->addColor( color, label );
+  mModel->addColor( color, label, allowDuplicate );
 }
 
 void QgsColorSchemeList::pasteColors()
@@ -647,22 +647,25 @@ bool QgsColorSchemeModel::insertRows( int row, int count, const QModelIndex& par
   return true;
 }
 
-void QgsColorSchemeModel::addColor( const QColor &color, const QString &label )
+void QgsColorSchemeModel::addColor( const QColor &color, const QString &label, bool allowDuplicate )
 {
   if ( !mScheme || !mScheme->isEditable() )
   {
     return;
   }
 
-  //matches existing color? if so, remove it first
-  QPair< QColor, QString > newColor = qMakePair( color, !label.isEmpty() ? label : QgsSymbolLayerUtils::colorToName( color ) );
-  //if color already exists, remove it
-  int existingIndex = mColors.indexOf( newColor );
-  if ( existingIndex >= 0 )
+  if ( !allowDuplicate )
   {
-    beginRemoveRows( QModelIndex(), existingIndex, existingIndex );
-    mColors.removeAt( existingIndex );
-    endRemoveRows();
+    //matches existing color? if so, remove it first
+    QPair< QColor, QString > newColor = qMakePair( color, !label.isEmpty() ? label : QgsSymbolLayerUtils::colorToName( color ) );
+    //if color already exists, remove it
+    int existingIndex = mColors.indexOf( newColor );
+    if ( existingIndex >= 0 )
+    {
+      beginRemoveRows( QModelIndex(), existingIndex, existingIndex );
+      mColors.removeAt( existingIndex );
+      endRemoveRows();
+    }
   }
 
   int row = rowCount();

--- a/src/gui/qgscolorschemelist.cpp
+++ b/src/gui/qgscolorschemelist.cpp
@@ -761,6 +761,7 @@ bool QgsColorSwatchDelegate::editorEvent( QEvent *event, QAbstractItemModel *mod
 
     QColor color = index.model()->data( index, Qt::DisplayRole ).value<QColor>();
 
+#if QT_VERSION >= 0x050000
     QgsPanelWidget* panel = QgsPanelWidget::findParentPanel( qobject_cast< QWidget* >( parent() ) );
     if ( panel && panel->dockMode() )
     {
@@ -772,7 +773,7 @@ bool QgsColorSwatchDelegate::editorEvent( QEvent *event, QAbstractItemModel *mod
       panel->openPanel( colorWidget );
       return true;
     }
-
+#endif
 
     QColor newColor = QgsColorDialog::getColor( color, mParent, tr( "Select color" ), true );
     if ( !newColor.isValid() )
@@ -788,9 +789,11 @@ bool QgsColorSwatchDelegate::editorEvent( QEvent *event, QAbstractItemModel *mod
 
 void QgsColorSwatchDelegate::colorChanged()
 {
+#if QT_VERSION >= 0x050000
   if ( QgsCompoundColorWidget* colorWidget = qobject_cast< QgsCompoundColorWidget* >( sender() ) )
   {
     QModelIndex index = colorWidget->property( "index" ).toModelIndex();
     const_cast< QAbstractItemModel* >( index.model() )->setData( index, colorWidget->color(), Qt::EditRole );
   }
+#endif
 }

--- a/src/gui/qgscolorschemelist.h
+++ b/src/gui/qgscolorschemelist.h
@@ -22,6 +22,7 @@
 #include <QFile>
 
 class QMimeData;
+class QgsPanelWidget;
 
 /** \ingroup gui
  * \class QgsColorSwatchDelegate
@@ -38,6 +39,10 @@ class GUI_EXPORT QgsColorSwatchDelegate : public QAbstractItemDelegate
     void paint( QPainter * painter, const QStyleOptionViewItem & option, const QModelIndex & index ) const override;
     QSize sizeHint( const QStyleOptionViewItem & option, const QModelIndex & index ) const override;
     bool editorEvent( QEvent * event, QAbstractItemModel * model, const QStyleOptionViewItem & option, const QModelIndex & index ) override;
+
+  private slots:
+
+    void colorChanged();
 
   private:
     QWidget* mParent;

--- a/src/gui/qgscolorschemelist.h
+++ b/src/gui/qgscolorschemelist.h
@@ -119,8 +119,9 @@ class GUI_EXPORT QgsColorSchemeModel: public QAbstractItemModel
     /** Add a color to the list
      * @param color color to add
      * @param label label for color
+     * @param allowDuplicate set to true to allow duplicate colors to be added (colors which are already present in the list)
      */
-    void addColor( const QColor &color, const QString &label = QString() );
+    void addColor( const QColor &color, const QString &label = QString(), bool allowDuplicate = false );
 
     /** Returns whether the color scheme model has been modified
      * @returns true if colors have been modified
@@ -210,8 +211,9 @@ class GUI_EXPORT QgsColorSchemeList: public QTreeView
     /** Adds a color to the list
      * @param color color to add
      * @param label optional label for color
+     * @param allowDuplicate set to true to allow duplicate colors to be added, ie colors which already exist in the list
      */
-    void addColor( const QColor &color, const QString &label = QString() );
+    void addColor( const QColor &color, const QString &label = QString(), bool allowDuplicate = false );
 
     /** Pastes colors from clipboard to the list
      * @see copyColors

--- a/src/gui/qgscompoundcolorwidget.cpp
+++ b/src/gui/qgscompoundcolorwidget.cpp
@@ -35,6 +35,7 @@ QgsCompoundColorWidget::QgsCompoundColorWidget( QWidget *parent, const QColor& c
     , mAllowAlpha( true )
     , mLastCustomColorIndex( 0 )
     , mPickingColor( false )
+    , mDiscarded( false )
 {
   setupUi( this );
 
@@ -240,6 +241,10 @@ QgsCompoundColorWidget::QgsCompoundColorWidget( QWidget *parent, const QColor& c
 QgsCompoundColorWidget::~QgsCompoundColorWidget()
 {
   saveSettings();
+  if ( !mDiscarded )
+  {
+    QgsRecentColorScheme::addRecentColor( color() );
+  }
 }
 
 QColor QgsCompoundColorWidget::color() const

--- a/src/gui/qgscompoundcolorwidget.h
+++ b/src/gui/qgscompoundcolorwidget.h
@@ -61,6 +61,13 @@ class GUI_EXPORT QgsCompoundColorWidget : public QgsPanelWidget, private Ui::Qgs
      */
     void setAllowAlpha( const bool allowAlpha );
 
+    /** Sets whether the widget's color has been "discarded" and the selected color should not
+     * be stored in the recent color list.
+     * @param discarded set to true to avoid adding color to recent color list on widget destruction.
+     * @note added in QGIS 3.0
+     */
+    void setDiscarded( bool discarded ) { mDiscarded = discarded; }
+
   signals:
 
     /** Emitted when the dialog's color changes
@@ -124,6 +131,8 @@ class GUI_EXPORT QgsCompoundColorWidget : public QgsPanelWidget, private Ui::Qgs
     int mLastCustomColorIndex;
 
     bool mPickingColor;
+
+    bool mDiscarded;
 
     /** Saves all widget settings
      */

--- a/src/gui/qgspresetcolorrampdialog.cpp
+++ b/src/gui/qgspresetcolorrampdialog.cpp
@@ -1,0 +1,124 @@
+/***************************************************************************
+    qgspresetcolorrampdialog.cpp
+    ----------------------------
+    begin                : September 2016
+    copyright            : (C) 2016 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgspresetcolorrampdialog.h"
+
+#include "qgssymbollayerutils.h"
+#include "qgscolordialog.h"
+#include <QFileDialog>
+#include <QAbstractButton>
+#include <QDialogButtonBox>
+#include <QMessageBox>
+
+QgsPresetColorRampWidget::QgsPresetColorRampWidget( const QgsPresetSchemeColorRamp& ramp, QWidget* parent )
+    : QgsPanelWidget( parent )
+    , mRamp( ramp )
+{
+  setupUi( this );
+  mTreeColors->setScheme( &mRamp );
+
+  connect( mButtonCopyColors, SIGNAL( clicked() ), mTreeColors, SLOT( copyColors() ) );
+  connect( mButtonRemoveColor, SIGNAL( clicked() ), mTreeColors, SLOT( removeSelection() ) );
+  connect( mButtonPasteColors, SIGNAL( clicked() ), mTreeColors, SLOT( pasteColors() ) );
+  connect( mButtonImportColors, SIGNAL( clicked( bool ) ), mTreeColors, SLOT( showImportColorsDialog() ) );
+  connect( mButtonExportColors, SIGNAL( clicked( bool ) ), mTreeColors, SLOT( showExportColorsDialog() ) );
+
+  connect( mTreeColors->model(), SIGNAL( dataChanged( QModelIndex, QModelIndex, QVector<int> ) ), this, SLOT( schemeChanged() ) );
+  connect( mTreeColors->model(), SIGNAL( rowsRemoved( QModelIndex, int, int ) ), this, SLOT( schemeChanged() ) );
+
+  updatePreview();
+}
+
+QgsPresetColorRampWidget::~QgsPresetColorRampWidget()
+{
+}
+
+QgsPresetSchemeColorRamp QgsPresetColorRampWidget::ramp() const
+{
+  return mRamp;
+}
+
+void QgsPresetColorRampWidget::setRamp( const QgsPresetSchemeColorRamp& ramp )
+{
+  mRamp = ramp;
+  mTreeColors->setScheme( &mRamp );
+  updatePreview();
+  emit changed();
+}
+
+void QgsPresetColorRampWidget::updatePreview()
+{
+  QSize size( 300, 40 );
+  lblPreview->setPixmap( QgsSymbolLayerUtils::colorRampPreviewPixmap( &mRamp, size ) );
+}
+
+void QgsPresetColorRampWidget::setColors()
+{
+  updatePreview();
+  emit changed();
+}
+
+void QgsPresetColorRampWidget::on_mButtonAddColor_clicked()
+{
+  if ( dockMode() )
+  {
+    mTreeColors->addColor( QgsRecentColorScheme::lastUsedColor(), QgsSymbolLayerUtils::colorToName( QgsRecentColorScheme::lastUsedColor() ) );
+
+    QgsCompoundColorWidget* colorWidget = new QgsCompoundColorWidget( this, QgsRecentColorScheme::lastUsedColor(), QgsCompoundColorWidget::LayoutVertical );
+    colorWidget->setPanelTitle( tr( "Select Color" ) );
+    colorWidget->setAllowAlpha( true );
+    connect( colorWidget, SIGNAL( currentColorChanged( QColor ) ), this, SLOT( newColorChanged( QColor ) ) );
+    openPanel( colorWidget );
+  }
+  else
+  {
+    QColor newColor = QgsColorDialog::getColor( QColor(), this->parentWidget(), tr( "Select Color" ), true );
+    if ( !newColor.isValid() )
+    {
+      return;
+    }
+    activateWindow();
+
+    mTreeColors->addColor( newColor, QgsSymbolLayerUtils::colorToName( newColor ) );
+  }
+}
+
+void QgsPresetColorRampWidget::schemeChanged()
+{
+  mTreeColors->saveColorsToScheme();
+  updatePreview();
+  emit changed();
+}
+
+void QgsPresetColorRampWidget::newColorChanged( const QColor& color )
+{
+  int row = mTreeColors->model()->rowCount() - 1;
+  QModelIndex colorIndex = mTreeColors->model()->index( row, 0 );
+  mTreeColors->model()->setData( colorIndex, color );
+}
+
+QgsPresetColorRampDialog::QgsPresetColorRampDialog( const QgsPresetSchemeColorRamp& ramp, QWidget* parent )
+    : QDialog( parent )
+{
+  QVBoxLayout* vLayout = new QVBoxLayout();
+  mWidget = new QgsPresetColorRampWidget( ramp );
+  vLayout->addWidget( mWidget );
+  QDialogButtonBox* bbox = new QDialogButtonBox( QDialogButtonBox::Ok | QDialogButtonBox::Cancel, Qt::Horizontal );
+  connect( bbox, SIGNAL( accepted() ), this, SLOT( accept() ) );
+  connect( bbox, SIGNAL( rejected() ), this, SLOT( reject() ) );
+  vLayout->addWidget( bbox );
+  setLayout( vLayout );
+  connect( mWidget, SIGNAL( changed() ), this, SIGNAL( changed() ) );
+}

--- a/src/gui/qgspresetcolorrampdialog.cpp
+++ b/src/gui/qgspresetcolorrampdialog.cpp
@@ -74,7 +74,7 @@ void QgsPresetColorRampWidget::on_mButtonAddColor_clicked()
 {
   if ( dockMode() )
   {
-    mTreeColors->addColor( QgsRecentColorScheme::lastUsedColor(), QgsSymbolLayerUtils::colorToName( QgsRecentColorScheme::lastUsedColor() ) );
+    mTreeColors->addColor( QgsRecentColorScheme::lastUsedColor(), QgsSymbolLayerUtils::colorToName( QgsRecentColorScheme::lastUsedColor() ), true );
 
     QgsCompoundColorWidget* colorWidget = new QgsCompoundColorWidget( this, QgsRecentColorScheme::lastUsedColor(), QgsCompoundColorWidget::LayoutVertical );
     colorWidget->setPanelTitle( tr( "Select Color" ) );

--- a/src/gui/qgspresetcolorrampdialog.h
+++ b/src/gui/qgspresetcolorrampdialog.h
@@ -1,0 +1,114 @@
+/***************************************************************************
+    qgspresetcolorrampdialog.h
+    ---------------------
+    begin                : September 2016
+    copyright            : (C) 2016 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSPRESETCOLORRAMPDIALOG_H
+#define QGSPRESETCOLORRAMPDIALOG_H
+
+#include <QDialog>
+#include "qgspanelwidget.h"
+#include "qgscolorramp.h"
+#include "ui_qgspresetcolorrampwidgetbase.h"
+
+/** \ingroup gui
+ * \class QgsPresetColorRampWidget
+ * A widget which allows users to modify the properties of a QgsPresetSchemeColorRamp.
+ * \note added in QGIS 3.0
+ */
+class GUI_EXPORT QgsPresetColorRampWidget : public QgsPanelWidget, private Ui::QgsPresetColorRampWidgetBase
+{
+    Q_OBJECT
+    Q_PROPERTY( QgsPresetSchemeColorRamp ramp READ ramp WRITE setRamp )
+
+  public:
+
+    /** Constructor for QgsPresetColorRampWidget.
+     * @param ramp initial ramp to show in dialog
+     * @param parent parent widget
+     */
+    QgsPresetColorRampWidget( const QgsPresetSchemeColorRamp& ramp, QWidget* parent = nullptr );
+
+    ~QgsPresetColorRampWidget();
+
+    /** Returns a color ramp representing the current settings from the dialog.
+     * @see setRamp()
+     */
+    QgsPresetSchemeColorRamp ramp() const;
+
+    /** Sets the color ramp to show in the dialog.
+     * @param ramp color ramp
+     * @see ramp()
+     */
+    void setRamp( const QgsPresetSchemeColorRamp& ramp );
+
+  signals:
+
+    //! Emitted when the dialog settings change
+    void changed();
+
+  private slots:
+    void setColors();
+
+    void on_mButtonAddColor_clicked();
+
+    void newColorChanged( const QColor& color );
+    void schemeChanged();
+
+  private:
+
+    void updatePreview();
+    QgsPresetSchemeColorRamp mRamp;
+};
+
+/** \ingroup gui
+ * \class QgsPresetColorRampDialog
+ * A dialog which allows users to modify the properties of a QgsPresetSchemeColorRamp.
+ * \note added in QGIS 3.0
+ */
+class GUI_EXPORT QgsPresetColorRampDialog : public QDialog
+{
+    Q_OBJECT
+    Q_PROPERTY( QgsPresetSchemeColorRamp ramp READ ramp WRITE setRamp )
+
+  public:
+
+    /** Constructor for QgsPresetColorRampDialog.
+     * @param ramp initial ramp to show in dialog
+     * @param parent parent widget
+     */
+    QgsPresetColorRampDialog( const QgsPresetSchemeColorRamp& ramp, QWidget* parent = nullptr );
+
+    /** Returns a color ramp representing the current settings from the dialog.
+     * @see setRamp()
+     */
+    QgsPresetSchemeColorRamp ramp() const { return mWidget->ramp(); }
+
+    /** Sets the color ramp to show in the dialog.
+     * @param ramp color ramp
+     * @see ramp()
+     */
+    void setRamp( const QgsPresetSchemeColorRamp& ramp ) { mWidget->setRamp( ramp ); }
+
+  signals:
+
+    //! Emitted when the dialog settings change
+    void changed();
+
+  private:
+
+    QgsPresetColorRampWidget* mWidget;
+
+};
+
+#endif //QGSPRESETCOLORRAMPDIALOG_H

--- a/src/gui/symbology-ng/qgscolorrampcombobox.cpp
+++ b/src/gui/symbology-ng/qgscolorrampcombobox.cpp
@@ -23,6 +23,7 @@
 #include "qgslimitedrandomcolorrampdialog.h"
 #include "qgscolorbrewercolorrampdialog.h"
 #include "qgscptcitycolorrampdialog.h"
+#include "qgspresetcolorrampdialog.h"
 
 QSize QgsColorRampComboBox::rampIconSize( 50, 16 );
 
@@ -172,6 +173,26 @@ void QgsColorRampComboBox::editSourceRamp()
       }
     }
   }
+  else if ( currentRamp->type() == "preset" )
+  {
+    QgsPresetSchemeColorRamp* presetRamp = static_cast<QgsPresetSchemeColorRamp*>( currentRamp.data() );
+    if ( panelMode )
+    {
+      QgsPresetColorRampWidget* widget = new QgsPresetColorRampWidget( *presetRamp, this );
+      widget->setPanelTitle( tr( "Edit ramp" ) );
+      connect( widget, SIGNAL( changed() ), this, SLOT( rampWidgetUpdated() ) );
+      panel->openPanel( widget );
+    }
+    else
+    {
+      QgsPresetColorRampDialog dlg( *presetRamp, this );
+      if ( dlg.exec() )
+      {
+        setSourceColorRamp( dlg.ramp().clone() );
+        emit sourceRampEdited();
+      }
+    }
+  }
   else if ( currentRamp->type() == "colorbrewer" )
   {
     QgsColorBrewerColorRamp* brewerRamp = static_cast<QgsColorBrewerColorRamp*>( currentRamp.data() );
@@ -224,6 +245,13 @@ void QgsColorRampComboBox::rampWidgetUpdated()
   if ( colorBrewerRampWidget )
   {
     setSourceColorRamp( colorBrewerRampWidget->ramp().clone() );
+    emit sourceRampEdited();
+    return;
+  }
+  QgsPresetColorRampWidget* presetRampWidget = qobject_cast< QgsPresetColorRampWidget* >( sender() );
+  if ( presetRampWidget )
+  {
+    setSourceColorRamp( presetRampWidget->ramp().clone() );
     emit sourceRampEdited();
     return;
   }

--- a/src/gui/symbology-ng/qgsstylemanagerdialog.cpp
+++ b/src/gui/symbology-ng/qgsstylemanagerdialog.cpp
@@ -24,6 +24,7 @@
 #include "qgsgradientcolorrampdialog.h"
 #include "qgslimitedrandomcolorrampdialog.h"
 #include "qgscolorbrewercolorrampdialog.h"
+#include "qgspresetcolorrampdialog.h"
 #include "qgscptcitycolorrampdialog.h"
 #include "qgsstyleexportimportdialog.h"
 #include "qgssmartgroupeditordialog.h"
@@ -133,7 +134,7 @@ QgsStyleManagerDialog::QgsStyleManagerDialog( QgsStyle* style, QWidget* parent )
 
   // Menu for the "Add item" toolbutton when in colorramp mode
   QStringList rampTypes;
-  rampTypes << tr( "Gradient" ) << tr( "Random" ) << tr( "ColorBrewer" );
+  rampTypes << tr( "Gradient" ) << tr( "Random" ) << tr( "ColorBrewer" ) << tr( "Preset colors" );
   rampTypes << tr( "cpt-city" ); // todo, only for rasters?
   mMenuBtnAddItemColorRamp = new QMenu( this );
   Q_FOREACH ( const QString& rampType, rampTypes )
@@ -443,7 +444,7 @@ QString QgsStyleManagerDialog::addColorRampStatic( QWidget* parent, QgsStyle* st
   if ( rampType.isEmpty() )
   {
     QStringList rampTypes;
-    rampTypes << tr( "Gradient" ) << tr( "Random" ) << tr( "ColorBrewer" );
+    rampTypes << tr( "Gradient" ) << tr( "Random" ) << tr( "ColorBrewer" ) << tr( "Preset colors" );
     rampTypes << tr( "cpt-city" ); // todo, only for rasters?
     rampType = QInputDialog::getItem( parent, tr( "Color ramp type" ),
                                       tr( "Please select color ramp type:" ), rampTypes, 0, false, &ok );
@@ -483,6 +484,16 @@ QString QgsStyleManagerDialog::addColorRampStatic( QWidget* parent, QgsStyle* st
     }
     ramp.reset( dlg.ramp().clone() );
     name = dlg.ramp().schemeName() + QString::number( dlg.ramp().colors() );
+  }
+  else if ( rampType == tr( "Preset colors" ) )
+  {
+    QgsPresetColorRampDialog dlg( QgsPresetSchemeColorRamp(), parent );
+    if ( !dlg.exec() )
+    {
+      return QString();
+    }
+    ramp.reset( dlg.ramp().clone() );
+    name = tr( "new preset ramp" );
   }
   else if ( rampType == tr( "cpt-city" ) )
   {
@@ -648,6 +659,16 @@ bool QgsStyleManagerDialog::editColorRamp()
   {
     QgsColorBrewerColorRamp* brewerRamp = static_cast<QgsColorBrewerColorRamp*>( ramp.data() );
     QgsColorBrewerColorRampDialog dlg( *brewerRamp, this );
+    if ( !dlg.exec() )
+    {
+      return false;
+    }
+    ramp.reset( dlg.ramp().clone() );
+  }
+  else if ( ramp->type() == "preset" )
+  {
+    QgsPresetSchemeColorRamp* presetRamp = static_cast<QgsPresetSchemeColorRamp*>( ramp.data() );
+    QgsPresetColorRampDialog dlg( *presetRamp, this );
     if ( !dlg.exec() )
     {
       return false;

--- a/src/ui/qgspresetcolorrampwidgetbase.ui
+++ b/src/ui/qgspresetcolorrampwidgetbase.ui
@@ -1,0 +1,163 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsPresetColorRampWidgetBase</class>
+ <widget class="QgsPanelWidget" name="QgsPresetColorRampWidgetBase">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>232</width>
+    <height>282</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>ColorBrewer ramp</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout" stretch="1,0,0">
+   <item>
+    <widget class="QgsColorSchemeList" name="mTreeColors" native="true"/>
+   </item>
+   <item>
+    <layout class="QHBoxLayout" name="horizontalLayout">
+     <item>
+      <widget class="QToolButton" name="mButtonAddColor">
+       <property name="toolTip">
+        <string>Add color</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../../images/images.qrc">
+         <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="mButtonRemoveColor">
+       <property name="toolTip">
+        <string>Remove color</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../../images/images.qrc">
+         <normaloff>:/images/themes/default/symbologyRemove.svg</normaloff>:/images/themes/default/symbologyRemove.svg</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="mButtonCopyColors">
+       <property name="toolTip">
+        <string>Copy colors</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../../images/images.qrc">
+         <normaloff>:/images/themes/default/mActionCopySelected.png</normaloff>:/images/themes/default/mActionCopySelected.png</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="mButtonPasteColors">
+       <property name="toolTip">
+        <string>Paste colors</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../../images/images.qrc">
+         <normaloff>:/images/themes/default/mActionEditPaste.svg</normaloff>:/images/themes/default/mActionEditPaste.svg</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="mButtonImportColors">
+       <property name="statusTip">
+        <string>Import colors</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../../images/images.qrc">
+         <normaloff>:/images/themes/default/mActionFileOpen.svg</normaloff>:/images/themes/default/mActionFileOpen.svg</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <widget class="QToolButton" name="mButtonExportColors">
+       <property name="toolTip">
+        <string>Export colors</string>
+       </property>
+       <property name="text">
+        <string/>
+       </property>
+       <property name="icon">
+        <iconset resource="../../images/images.qrc">
+         <normaloff>:/images/themes/default/mActionFileSave.svg</normaloff>:/images/themes/default/mActionFileSave.svg</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
+      <spacer name="horizontalSpacer">
+       <property name="orientation">
+        <enum>Qt::Horizontal</enum>
+       </property>
+       <property name="sizeHint" stdset="0">
+        <size>
+         <width>40</width>
+         <height>20</height>
+        </size>
+       </property>
+      </spacer>
+     </item>
+    </layout>
+   </item>
+   <item>
+    <widget class="QGroupBox" name="groupBox">
+     <property name="title">
+      <string>Preview</string>
+     </property>
+     <layout class="QVBoxLayout" name="verticalLayout_2">
+      <item>
+       <widget class="QLabel" name="lblPreview">
+        <property name="frameShape">
+         <enum>QFrame::NoFrame</enum>
+        </property>
+        <property name="text">
+         <string/>
+        </property>
+        <property name="alignment">
+         <set>Qt::AlignCenter</set>
+        </property>
+       </widget>
+      </item>
+     </layout>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <customwidgets>
+  <customwidget>
+   <class>QgsPanelWidget</class>
+   <extends>QWidget</extends>
+   <header>qgspanelwidget.h</header>
+   <container>1</container>
+  </customwidget>
+  <customwidget>
+   <class>QgsColorSchemeList</class>
+   <extends>QWidget</extends>
+   <header location="global">qgscolorschemelist.h</header>
+   <container>1</container>
+  </customwidget>
+ </customwidgets>
+ <resources>
+  <include location="../../images/images.qrc"/>
+ </resources>
+ <connections/>
+</ui>

--- a/tests/src/python/test_qgsvectorcolorramp.py
+++ b/tests/src/python/test_qgsvectorcolorramp.py
@@ -18,7 +18,8 @@ from qgis.core import (QgsGradientColorRamp,
                        QgsGradientStop,
                        QgsLimitedRandomColorRamp,
                        QgsRandomColorRamp,
-                       QgsColorBrewerColorRamp)
+                       QgsColorBrewerColorRamp,
+                       QgsPresetSchemeColorRamp)
 from qgis.PyQt.QtGui import QColor, QGradient
 from qgis.testing import unittest
 
@@ -267,6 +268,47 @@ class PyQgsVectorColorRamp(unittest.TestCase):
             for j in range(10):
                 c = r.color(j * 0.1)
                 self.assertTrue(c.isValid())
+
+    def testQgsPresetSchemeColorRamp(self):
+        # test preset color ramp
+        r = QgsPresetSchemeColorRamp()
+        self.assertEqual(r.type(), 'preset')
+        # should be forced to have at least one color
+        self.assertEqual(r.count(), 1)
+
+        # test getter/setter
+        r = QgsPresetSchemeColorRamp([QColor(255, 0, 0), QColor(0, 255, 0), QColor(0, 0, 255), QColor(0, 0, 0)])
+        self.assertEqual(r.colors(), [QColor(255, 0, 0), QColor(0, 255, 0), QColor(0, 0, 255), QColor(0, 0, 0)])
+        r.setColors([(QColor(255, 0, 0), '1'), (QColor(0, 255, 0), '2')])
+        self.assertEqual(r.colors(), [QColor(255, 0, 0), QColor(0, 255, 0)])
+        self.assertEqual(r.fetchColors(), [(QColor(255, 0, 0), '1'), (QColor(0, 255, 0), '2')])
+
+        # test value
+        r = QgsPresetSchemeColorRamp([QColor(255, 0, 0), QColor(0, 255, 0), QColor(0, 0, 255), QColor(0, 0, 0), QColor(255, 255, 255)])
+        self.assertEqual(r.value(0), 0)
+        self.assertEqual(r.value(1), 0.25)
+        self.assertEqual(r.value(2), 0.5)
+        self.assertEqual(r.value(3), 0.75)
+        self.assertEqual(r.value(4), 1)
+
+        self.assertTrue(not r.color(-1).isValid())
+        self.assertTrue(not r.color(5).isValid())
+
+        # test generated colors
+        for i in range(5):
+            self.assertEqual(r.color(r.value(i)), r.colors()[i])
+
+        # test creating from properties
+        r.setColors([(QColor(255, 0, 0), '1'), (QColor(0, 255, 0), '2')])
+        props = r.properties()
+        fromProps = QgsPresetSchemeColorRamp.create(props)
+        self.assertEqual(fromProps.count(), 2)
+        self.assertEqual(fromProps.fetchColors(), r.fetchColors())
+
+        # test cloning ramp
+        cloned = r.clone()
+        self.assertEqual(cloned.count(), 2)
+        self.assertEqual(cloned.fetchColors(), r.fetchColors())
 
     def testQgsColorBrewerColorRampV2(self):
         # test color brewer color ramps


### PR DESCRIPTION
This allows use of a color ramp consisting of a list of selected colors. Currently there's no way in QGIS to classify a renderer using some list of colors you've previously selected. So you can modify the colors manually after classifying, but that's a pain if you're regularly using the same color scheme.

Basically, it's like the color brewer color ramp options but allowing users to pick their own preset list of colors to use*

(Because Cynthia Brewer isn't the only cartographic color expert!)
