### PR TITLE
replace exp10 by pow on mac

### DIFF
--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -506,7 +506,7 @@ QImage *QgsWmsProvider::draw( QgsRectangle const &viewExtent, int pixelWidth, in
 static bool _fuzzyContainsRect( const QRectF& r1, const QRectF& r2 )
 {
   double significantDigits = log10( qMax( r1.width(), r1.height() ) );
-  double epsilon = exp10( significantDigits - 5 ); // floats have 6-9 significant digits
+  double epsilon = pow( 10, ( significantDigits - 5 ) ); // floats have 6-9 significant digits
   return r1.contains( r2.adjusted( epsilon, epsilon, -epsilon, -epsilon ) );
 }
 


### PR DESCRIPTION
While I was trying to compile QGIS Master this morning, I got : 

```
[ 56%] Building CXX object src/providers/wms/CMakeFiles/wmsprovider_a.dir/qgswmsprovider.cpp.o
cd /Users/etienne/compil/QGIS/build-debug-master/src/providers/wms && /usr/bin/g++   -DHAS_MOVE_SEMANTICS -DQGISDEBUG=1 -DQT_CORE_LIB -DQT_GUI_LIB -DQT_NETWORK_LIB -DQT_NO_CAST_TO_ASCII -DQT_NO_DEBUG -DQT_SQL_LIB -DQT_SVG_LIB -DQT_WEBKIT_LIB -DQT_XML_LIB -DWITH_QTWEBKIT -isystem /usr/local/Cellar/qt/4.8.7_2/include -iframework /usr/local/Cellar/qt/4.8.7_2/lib -isystem /usr/local/Cellar/qt/4.8.7_2/include/QtSvg -isystem /usr/local/Cellar/qt/4.8.7_2/include/QtWebKit -isystem /usr/local/Cellar/qt/4.8.7_2/include/QtGui -isystem /usr/local/Cellar/qt/4.8.7_2/include/QtXml -isystem /usr/local/Cellar/qt/4.8.7_2/include/QtSql -isystem /usr/local/Cellar/qt/4.8.7_2/include/QtNetwork -isystem /usr/local/Cellar/qt/4.8.7_2/lib/QtCore.framework/Headers -I/Users/etienne/compil/QGIS/build-debug-master -I/Users/etienne/compil/QGIS/src/providers/wms/. -I/Users/etienne/compil/QGIS/src/providers/wms/../../core -I/Users/etienne/compil/QGIS/src/providers/wms/../../core/auth -I/Users/etienne/compil/QGIS/src/providers/wms/../../core/geometry -I/Users/etienne/compil/QGIS/src/providers/wms/../../core/raster -I/Users/etienne/compil/QGIS/src/providers/wms/../../gui -I/Users/etienne/compil/QGIS/src/providers/wms/../../gui/auth -I/Users/etienne/compil/QGIS/build-debug-master/src/providers/wms/../../ui -isystem /usr/local/opt/gdal-20/include -isystem /usr/local/opt/geos/include -isystem /usr/local/Cellar/qt/4.8.7_2/include/QtScript -isystem /usr/local/opt/qca/lib/qca.framework/Headers  -DSPATIALITE_VERSION_GE_4_0_0 -DSPATIALITE_VERSION_G_4_1_1 -DSPATIALITE_HAS_INIT_EX -std=c++11 -Wno-error=c++11-narrowing -Wall -Wextra -Wno-long-long -Wformat-security -Wno-strict-aliasing -Wno-return-type-c-linkage -Wno-overloaded-virtual -Qunused-arguments -O2 -g -DNDEBUG -isysroot /Applications/Xcode.app/Contents/Developer/Platforms/MacOSX.platform/Developer/SDKs/MacOSX10.11.sdk -fvisibility=hidden   -DCORE_EXPORT= -DGUI_EXPORT= -DPYTHON_EXPORT= -DANALYSIS_EXPORT= -DAPP_EXPORT= -DCUSTOMWIDGETS_EXPORT= -DSERVER_EXPORT= -F/usr/local/lib  -o CMakeFiles/wmsprovider_a.dir/qgswmsprovider.cpp.o -c /Users/etienne/compil/QGIS/src/providers/wms/qgswmsprovider.cpp
/Users/etienne/compil/QGIS/src/providers/wms/qgswmsprovider.cpp:509:20: error: use of undeclared identifier 'exp10'
  double epsilon = exp10( significantDigits - 5 ); // floats have 6-9 significant digits
                   ^
1 error generated.
make[2]: *** [src/providers/wms/CMakeFiles/wmsprovider_a.dir/qgswmsprovider.cpp.o] Error 1
make[1]: *** [src/providers/wms/CMakeFiles/wmsprovider_a.dir/all] Error 2
make: *** [all] Error 2
etienne@:~/compil/QGIS/build-debug-master (master) $
```

Related PR from @wonder-sk https://github.com/qgis/QGIS/pull/3473

It seems that exp10 is not present on mac. Replacing exp10 by pow works perfectly.

Can you review @wonder-sk ?
