### PR TITLE
[Processing][Rscripts] Use temp script filename

### DIFF
--- a/python/plugins/processing/algs/r/RUtils.py
+++ b/python/plugins/processing/algs/r/RUtils.py
@@ -45,6 +45,8 @@ class RUtils(object):
     R_USE64 = 'R_USE64'
     R_LIBS_USER = 'R_LIBS_USER'
 
+    rscriptfilename = userFolder() + os.sep + 'processing_script.r'
+
     @staticmethod
     def RFolder():
         folder = ProcessingConfig.getSetting(RUtils.R_FOLDER)
@@ -108,7 +110,7 @@ class RUtils(object):
 
     @staticmethod
     def getRScriptFilename():
-        return userFolder() + os.sep + 'processing_script.r'
+        return RUtils.rscriptfilename
 
     @staticmethod
     def getConsoleOutputFilename():
@@ -116,6 +118,9 @@ class RUtils(object):
 
     @staticmethod
     def executeRAlgorithm(alg, progress):
+        # generate new R script file name in a temp folder
+        RUtils.rscriptfilename = getTempFilenameInTempFolder('processing_script.r')
+        # run commands
         RUtils.verboseCommands = alg.getVerboseCommands()
         RUtils.createRScriptFromRCommands(alg.getFullSetOfRCommands())
         if isWindows():


### PR DESCRIPTION
The build RScript is stored in the User folder, so the script is erased at each RAlgorithm execute.
Server side or for debugging this could be a problem.
So processing_script.r will be stored in temp folder.
