### PR TITLE
Small correction of documenation in qgspointlocator.h

### DIFF
--- a/src/core/qgspointlocator.h
+++ b/src/core/qgspointlocator.h
@@ -184,7 +184,7 @@ class CORE_EXPORT QgsPointLocator : public QObject
     //! Find nearest vertex to the specified point - up to distance specified by tolerance
     //! Optional filter may discard unwanted matches.
     Match nearestVertex( const QgsPoint& point, double tolerance, MatchFilter* filter = nullptr );
-    //! Find nearest edges to the specified point - up to distance specified by tolerance
+    //! Find nearest edge to the specified point - up to distance specified by tolerance
     //! Optional filter may discard unwanted matches.
     Match nearestEdge( const QgsPoint& point, double tolerance, MatchFilter* filter = nullptr );
     //! Find edges within a specified recangle


### PR DESCRIPTION
A very small but important change to the comments/API documentation. The nearestEdge method does not return multiple edges but only one edge.
