### PR TITLE
[Processing] bugfix: intersection QGIS algorithm

### DIFF
--- a/python/plugins/processing/algs/qgis/Intersection.py
+++ b/python/plugins/processing/algs/qgis/Intersection.py
@@ -96,8 +96,10 @@ class Intersection(GeoAlgorithm):
                     int_geom = QgsGeometry(geom.intersection(tmpGeom))
                     if int_geom.wkbType() == QgsWkbTypes.Unknown or QgsWkbTypes.flatType(int_geom.geometry().wkbType()) == QgsWkbTypes.GeometryCollection:
                         int_com = geom.combine(tmpGeom)
-                        int_sym = geom.symDifference(tmpGeom)
-                        int_geom = QgsGeometry(int_com.difference(int_sym))
+                        int_geom = QgsGeometry()
+                        if int_com:
+                            int_sym = geom.symDifference(tmpGeom)
+                            int_geom = QgsGeometry(int_com.difference(int_sym))
                     if int_geom.isGeosEmpty() or not int_geom.isGeosValid():
                         ProcessingLog.addToLog(ProcessingLog.LOG_ERROR,
                                                self.tr('GEOS geoprocessing error: One or '


### PR DESCRIPTION
fixing this by testing int_com.

```
Traceback (most recent call last):
File "C:/PROGRA~1/QGIS2~1.17/apps/qgis/./python/plugins\processing\core\GeoAlgorithm.py", line 203, in execute
self.processAlgorithm(progress)
File "C:/PROGRA~1/QGIS2~1.17/apps/qgis/./python/plugins\processing\algs\qgis\Intersection.py", line 100, in processAlgorithm
int_geom = QgsGeometry(int_com.difference(int_sym))
```

AttributeError: 'NoneType' object has no attribute 'difference'
