### PR TITLE
fix diagram crash (fixes #15575)

### DIFF
--- a/src/core/qgsvectorlayerdiagramprovider.cpp
+++ b/src/core/qgsvectorlayerdiagramprovider.cpp
@@ -229,13 +229,14 @@ QgsLabelFeature* QgsVectorLayerDiagramProvider::registerDiagram( QgsFeature& fea
   }
 
   const GEOSGeometry* geos_geom = nullptr;
-  QScopedPointer<QgsGeometry> preparedGeom;
+  QScopedPointer<QgsGeometry> scopedPreparedGeom;
   if ( QgsPalLabeling::geometryRequiresPreparation( geom, context, mSettings.coordinateTransform(), &extentGeom ) )
   {
-    QgsGeometry preparedGeom = QgsPalLabeling::prepareGeometry( geom, context, mSettings.coordinateTransform(), &extentGeom );
-    if ( preparedGeom.isEmpty() )
+    scopedPreparedGeom.reset( new QgsGeometry( QgsPalLabeling::prepareGeometry( geom, context, mSettings.coordinateTransform(), &extentGeom ) ) );
+    QgsGeometry* preparedGeom = scopedPreparedGeom.data();
+    if ( preparedGeom->isEmpty() )
       return nullptr;
-    geos_geom = preparedGeom.asGeos();
+    geos_geom = preparedGeom->asGeos();
   }
   else
   {


### PR DESCRIPTION
@nyalldawson , this fixes a diagram-related crasher introduced following the QgsGeometry refactoring.

I honestly have _not_ idea what was going on; the fix emulates the way you've handled a QgsGeometry returned from QgsPalLabeling::prepareGeometry in the labelling code).
