### PR TITLE
Rename QgsEditFormConfig::expression to constraintExpression

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -681,6 +681,10 @@ place of a null pointer.</li>
 <li>widgetType() and widgetConfig() now reflect only the user configured values.
 QgsEditorWidgetRegistry::instance()->findBest() must be used instead.</li>
 <li>widgetType(), widgetConfig(), setWidgetType(), setWidgetConfig() and removeWidgetConfig() now only take a string as first parameter. Access by index has been removed.</li>
+<li>expression() has been renamed to constraintExpression()</li>
+<li>setExpression() has been renamed to setConstraintExpression()</li>
+<li>expressionDescription() has been renamed to constraintDescription()</li>
+<li>setExpressionDesctiption() has been renamed to setConstraintDescription()</li>
 </ul>
 
 \subsection qgis_api_break_3_0_QgsExpression QgsExpression

--- a/python/core/qgseditformconfig.sip
+++ b/python/core/qgseditformconfig.sip
@@ -199,35 +199,49 @@ class QgsEditFormConfig
 
     /**
      * Returns the constraint expression of a specific field
+     *
      * @param idx The index of the field
      * @return the expression
+     *
      * @note added in QGIS 2.16
+     * @note renamed in QGIS 3.0
      */
-    QString expression( int idx ) const;
+    QString constraintExpression( int idx ) const;
 
     /**
      * Set the constraint expression for a specific field
+     *
      * @param idx the field index
-     * @param str the constraint expression
+     * @param expression the constraint expression
+     *
      * @note added in QGIS 2.16
+     * @note renamed in QGIS 3.0
      */
-    void setExpression( int idx, const QString& str );
+    void setConstraintExpression( int idx, const QString& expression );
 
     /**
-     * Returns the constraint expression description of a specific filed.
+     * Returns the constraint expression description of a specific field.
+     *
      * @param idx The index of the field
-     * @return the expression description
+     * @return The expression description. Will be presented
+     *         to the user in case the constraint fails.
+     *
      * @note added in QGIS 2.16
+     * @note renamed in QGIS 3.0
      */
-    QString expressionDescription( int idx ) const;
+    QString constraintDescription( int idx ) const;
 
     /**
      * Set the constraint expression description for a specific field.
+     *
      * @param idx The index of the field
-     * @param descr The description of the expression
+     * @param description The description of the expression. Will be presented
+     *                    to the user in case the constraint fails.
+     *
      * @note added in QGIS 2.16
+     * @note renamed in QGIS 3.0
      */
-    void setExpressionDescription( int idx, const QString &descr );
+    void setContraintDescription( int idx, const QString& description );
 
     /**
      * Returns if the field at fieldidx should be treated as NOT NULL value

--- a/src/app/qgsfieldsproperties.cpp
+++ b/src/app/qgsfieldsproperties.cpp
@@ -949,8 +949,8 @@ void QgsFieldsProperties::apply()
     editFormConfig.setReadOnly( i, !cfg.mEditable );
     editFormConfig.setLabelOnTop( i, cfg.mLabelOnTop );
     editFormConfig.setNotNull( i, cfg.mNotNull );
-    editFormConfig.setExpressionDescription( i, cfg.mConstraintDescription );
-    editFormConfig.setExpression( i, cfg.mConstraint );
+    editFormConfig.setContraintDescription( i, cfg.mConstraintDescription );
+    editFormConfig.setConstraintExpression( i, cfg.mConstraint );
 
     editFormConfig.setWidgetType( name, cfg.mEditorWidgetType );
     editFormConfig.setWidgetConfig( name, cfg.mEditorWidgetConfig );
@@ -1032,8 +1032,8 @@ QgsFieldsProperties::FieldConfig::FieldConfig( QgsVectorLayer* layer, int idx )
                      && layer->fields().fieldOrigin( idx ) != QgsFields::OriginExpression;
   mLabelOnTop = layer->editFormConfig().labelOnTop( idx );
   mNotNull = layer->editFormConfig().notNull( idx );
-  mConstraint = layer->editFormConfig().expression( idx );
-  mConstraintDescription = layer->editFormConfig().expressionDescription( idx );
+  mConstraint = layer->editFormConfig().constraintExpression( idx );
+  mConstraintDescription = layer->editFormConfig().constraintDescription( idx );
   const QgsEditorWidgetSetup setup = QgsEditorWidgetRegistry::instance()->findBest( layer, layer->fields().field( idx ).name() );
   mEditorWidgetType = setup.type();
   mEditorWidgetConfig = setup.config();

--- a/src/core/qgseditformconfig.cpp
+++ b/src/core/qgseditformconfig.cpp
@@ -182,7 +182,7 @@ bool QgsEditFormConfig::labelOnTop( int idx ) const
     return false;
 }
 
-QString QgsEditFormConfig::expression( int idx ) const
+QString QgsEditFormConfig::constraintExpression( int idx ) const
 {
   QString expr;
 
@@ -192,16 +192,16 @@ QString QgsEditFormConfig::expression( int idx ) const
   return expr;
 }
 
-void QgsEditFormConfig::setExpression( int idx, const QString& str )
+void QgsEditFormConfig::setConstraintExpression( int idx, const QString& expression )
 {
   if ( idx >= 0 && idx < d->mFields.count() )
   {
     d.detach();
-    d->mConstraints[ d->mFields.at( idx ).name()] = str;
+    d->mConstraints[ d->mFields.at( idx ).name()] = expression;
   }
 }
 
-QString QgsEditFormConfig::expressionDescription( int idx ) const
+QString QgsEditFormConfig::constraintDescription( int idx ) const
 {
   QString description;
 
@@ -211,7 +211,7 @@ QString QgsEditFormConfig::expressionDescription( int idx ) const
   return description;
 }
 
-void QgsEditFormConfig::setExpressionDescription( int idx, const QString &descr )
+void QgsEditFormConfig::setContraintDescription( int idx, const QString &descr )
 {
   if ( idx >= 0 && idx < d->mFields.count() )
   {

--- a/src/core/qgseditformconfig.h
+++ b/src/core/qgseditformconfig.h
@@ -234,35 +234,49 @@ class CORE_EXPORT QgsEditFormConfig
 
     /**
      * Returns the constraint expression of a specific field
+     *
      * @param idx The index of the field
      * @return the expression
+     *
      * @note added in QGIS 2.16
+     * @note renamed in QGIS 3.0
      */
-    QString expression( int idx ) const;
+    QString constraintExpression( int idx ) const;
 
     /**
      * Set the constraint expression for a specific field
+     *
      * @param idx the field index
-     * @param str the constraint expression
+     * @param expression the constraint expression
+     *
      * @note added in QGIS 2.16
+     * @note renamed in QGIS 3.0
      */
-    void setExpression( int idx, const QString& str );
+    void setConstraintExpression( int idx, const QString& expression );
 
     /**
-     * Returns the constraint expression description of a specific filed.
+     * Returns the constraint expression description of a specific field.
+     *
      * @param idx The index of the field
-     * @return the expression description
+     * @return The expression description. Will be presented
+     *         to the user in case the constraint fails.
+     *
      * @note added in QGIS 2.16
+     * @note renamed in QGIS 3.0
      */
-    QString expressionDescription( int idx ) const;
+    QString constraintDescription( int idx ) const;
 
     /**
      * Set the constraint expression description for a specific field.
+     *
      * @param idx The index of the field
-     * @param descr The description of the expression
+     * @param description The description of the expression. Will be presented
+     *                    to the user in case the constraint fails.
+     *
      * @note added in QGIS 2.16
+     * @note renamed in QGIS 3.0
      */
-    void setExpressionDescription( int idx, const QString &descr );
+    void setContraintDescription( int idx, const QString& description );
 
     /**
      * Returns if the field at fieldidx should be treated as NOT NULL value

--- a/src/gui/editorwidgets/core/qgseditorwidgetregistry.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetregistry.cpp
@@ -264,8 +264,8 @@ void QgsEditorWidgetRegistry::readMapLayer( QgsMapLayer* mapLayer, const QDomEle
       formConfig.setReadOnly( idx, ewv2CfgElem.attribute( "fieldEditable", "1" ) != "1" );
       formConfig.setLabelOnTop( idx, ewv2CfgElem.attribute( "labelOnTop", "0" ) == "1" );
       formConfig.setNotNull( idx, ewv2CfgElem.attribute( "notNull", "0" ) == "1" );
-      formConfig.setExpression( idx, ewv2CfgElem.attribute( "constraint", QString() ) );
-      formConfig.setExpressionDescription( idx, ewv2CfgElem.attribute( "constraintDescription", QString() ) );
+      formConfig.setConstraintExpression( idx, ewv2CfgElem.attribute( "constraint", QString() ) );
+      formConfig.setContraintDescription( idx, ewv2CfgElem.attribute( "constraintDescription", QString() ) );
 
       formConfig.setWidgetConfig( name, cfg );
     }
@@ -320,8 +320,8 @@ void QgsEditorWidgetRegistry::writeMapLayer( QgsMapLayer* mapLayer, QDomElement&
       ewv2CfgElem.setAttribute( "fieldEditable", !vectorLayer->editFormConfig().readOnly( idx ) );
       ewv2CfgElem.setAttribute( "labelOnTop", vectorLayer->editFormConfig().labelOnTop( idx ) );
       ewv2CfgElem.setAttribute( "notNull", vectorLayer->editFormConfig().notNull( idx ) );
-      ewv2CfgElem.setAttribute( "constraint", vectorLayer->editFormConfig().expression( idx ) );
-      ewv2CfgElem.setAttribute( "constraintDescription", vectorLayer->editFormConfig().expressionDescription( idx ) );
+      ewv2CfgElem.setAttribute( "constraint", vectorLayer->editFormConfig().constraintExpression( idx ) );
+      ewv2CfgElem.setAttribute( "constraintDescription", vectorLayer->editFormConfig().constraintDescription( idx ) );
 
       mWidgetFactories[widgetType]->writeConfig( vectorLayer->editFormConfig().widgetConfig( field.name() ), ewv2CfgElem, doc, vectorLayer, idx );
 

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
@@ -109,13 +109,13 @@ void QgsEditorWidgetWrapper::updateConstraint( const QgsFeature &ft )
 {
   bool toEmit( false );
   QString errStr( tr( "predicate is True" ) );
-  QString expression = layer()->editFormConfig().expression( mFieldIdx );
+  QString expression = layer()->editFormConfig().constraintExpression( mFieldIdx );
   QString description;
   QVariant value = ft.attribute( mFieldIdx );
 
   if ( ! expression.isEmpty() )
   {
-    description = layer()->editFormConfig().expressionDescription( mFieldIdx );
+    description = layer()->editFormConfig().constraintDescription( mFieldIdx );
 
     QgsExpressionContext context = layer()->createExpressionContext();
     context.setFeature( ft );

--- a/src/gui/qgsattributeform.cpp
+++ b/src/gui/qgsattributeform.cpp
@@ -835,7 +835,7 @@ bool QgsAttributeForm::currentFormValidConstraints( QStringList &invalidFields,
       {
         invalidFields.append( eww->field().name() );
 
-        QString desc = eww->layer()->editFormConfig().expressionDescription( eww->fieldIdx() );
+        QString desc = eww->layer()->editFormConfig().constraintDescription( eww->fieldIdx() );
         descriptions.append( desc );
 
         valid = false; // continue to get all invalif fields
@@ -952,7 +952,7 @@ QList<QgsEditorWidgetWrapper*> QgsAttributeForm::constraintDependencies( QgsEdit
       if ( name != ewwName )
       {
         // get expression and referencedColumns
-        QgsExpression expr = eww->layer()->editFormConfig().expression( eww->fieldIdx() );
+        QgsExpression expr = eww->layer()->editFormConfig().constraintExpression( eww->fieldIdx() );
 
         Q_FOREACH ( const QString& colName, expr.referencedColumns() )
         {

--- a/tests/src/gui/testqgsattributeform.cpp
+++ b/tests/src/gui/testqgsattributeform.cpp
@@ -84,7 +84,7 @@ void TestQgsAttributeForm::testFieldConstraint()
 
   // set constraint
   QgsEditFormConfig config = layer->editFormConfig();
-  config.setExpression( 0, QString() );
+  config.setConstraintExpression( 0, QString() );
   layer->setEditFormConfig( config );
 
   // get wrapper
@@ -96,7 +96,7 @@ void TestQgsAttributeForm::testFieldConstraint()
   QCOMPARE( label->text(), QString( "col0" ) );
 
   // set a not null constraint
-  config.setExpression( 0, "col0 is not null" );
+  config.setConstraintExpression( 0, "col0 is not null" );
   layer->setEditFormConfig( config );
 
   // set value to 1
@@ -132,10 +132,10 @@ void TestQgsAttributeForm::testFieldMultiConstraints()
 
   // set constraints for each field
   QgsEditFormConfig config = layer->editFormConfig();
-  config.setExpression( 0, QString() );
-  config.setExpression( 1, QString() );
-  config.setExpression( 2, QString() );
-  config.setExpression( 3, QString() );
+  config.setConstraintExpression( 0, QString() );
+  config.setConstraintExpression( 1, QString() );
+  config.setConstraintExpression( 2, QString() );
+  config.setConstraintExpression( 3, QString() );
   layer->setEditFormConfig( config );
 
   // build a form for this feature
@@ -167,10 +167,10 @@ void TestQgsAttributeForm::testFieldMultiConstraints()
   QCOMPARE( label3->text(), QString( "col3" ) );
 
   // update constraint
-  config.setExpression( 0, "col0 < (col1 * col2)" );
-  config.setExpression( 1, QString() );
-  config.setExpression( 2, QString() );
-  config.setExpression( 3, "col0 = 2" );
+  config.setConstraintExpression( 0, "col0 < (col1 * col2)" );
+  config.setConstraintExpression( 1, QString() );
+  config.setConstraintExpression( 2, QString() );
+  config.setConstraintExpression( 3, "col0 = 2" );
   layer->setEditFormConfig( config );
 
   // change value
@@ -206,7 +206,7 @@ void TestQgsAttributeForm::testOKButtonStatus()
 
   // set constraint
   QgsEditFormConfig config = layer->editFormConfig();
-  config.setExpression( 0, QString() );
+  config.setConstraintExpression( 0, QString() );
   layer->setEditFormConfig( config );
 
   // build a form for this feature
@@ -235,13 +235,13 @@ void TestQgsAttributeForm::testOKButtonStatus()
   QCOMPARE( okButton->isEnabled(), true );
 
   // invalid constraint and editable layer : OK button disabled
-  config.setExpression( 0, "col0 = 0" );
+  config.setConstraintExpression( 0, "col0 = 0" );
   layer->setEditFormConfig( config );
   ww->setValue( 1 );
   QCOMPARE( okButton->isEnabled(), false );
 
   // valid constraint and editable layer : OK button enabled
-  config.setExpression( 0, "col0 = 2" );
+  config.setConstraintExpression( 0, "col0 = 2" );
   layer->setEditFormConfig( config );
   ww->setValue( 2 );
   QCOMPARE( okButton->isEnabled(), true );


### PR DESCRIPTION
And QgsEditFormConfig::expressionDescription to constraintDescription.
Because only a verbose API is a good API.
