### PR TITLE
If a dependent layer is redrawn, then also redraw child layer

### DIFF
--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -4139,6 +4139,7 @@ bool QgsVectorLayer::setDependencies( const QSet<QgsMapLayerDependency>& oDeps )
     disconnect( lyr, SIGNAL( featureDeleted( QgsFeatureId ) ), this, SIGNAL( dataChanged() ) );
     disconnect( lyr, SIGNAL( geometryChanged( QgsFeatureId, const QgsGeometry& ) ), this, SIGNAL( dataChanged() ) );
     disconnect( lyr, SIGNAL( dataChanged() ), this, SIGNAL( dataChanged() ) );
+    disconnect( lyr, SIGNAL( repaintRequested() ), this, SLOT( triggerRepaint() ) );
   }
 
   // assign new dependencies
@@ -4158,6 +4159,7 @@ bool QgsVectorLayer::setDependencies( const QSet<QgsMapLayerDependency>& oDeps )
     connect( lyr, SIGNAL( featureDeleted( QgsFeatureId ) ), this, SIGNAL( dataChanged() ) );
     connect( lyr, SIGNAL( geometryChanged( QgsFeatureId, const QgsGeometry& ) ), this, SIGNAL( dataChanged() ) );
     connect( lyr, SIGNAL( dataChanged() ), this, SIGNAL( dataChanged() ) );
+    connect( lyr, SIGNAL( repaintRequested() ), this, SLOT( triggerRepaint() ) );
   }
 
   // if new layers are present, emit a data change


### PR DESCRIPTION
If a layer has a dependency on another layer, then trigger a redraw for the dependant layer whenever the other layer is redrawn.

@mhugo What do you think? Does this make sense to you?
