### PR TITLE
[snapping] fix default advanced mode values for added layers

### DIFF
--- a/src/app/qgssnappingdialog.cpp
+++ b/src/app/qgssnappingdialog.cpp
@@ -310,7 +310,7 @@ void QgsSnappingDialog::addLayer( QgsMapLayer *theMapLayer )
   bool myDockFlag = myQsettings.value( "/qgis/dockSnapping", false ).toBool();
   double defaultSnappingTolerance = myQsettings.value( "/qgis/digitizing/default_snapping_tolerance", 0 ).toDouble();
   int defaultSnappingUnit = myQsettings.value( "/qgis/digitizing/default_snapping_tolerance_unit", QgsTolerance::ProjectUnits ).toInt();
-  QString defaultSnappingString = myQsettings.value( "/qgis/digitizing/default_snap_mode", "to vertex" ).toString();
+  QString defaultSnappingString = myQsettings.value( "/qgis/digitizing/default_snap_mode", "off" ).toString();
 
   int defaultSnappingStringIdx = 0;
   if ( defaultSnappingString == "to vertex" )

--- a/src/core/qgstolerance.h
+++ b/src/core/qgstolerance.h
@@ -34,7 +34,7 @@ class CORE_EXPORT QgsTolerance
     enum UnitType
     {
       /** Layer unit value */
-      LayerUnits = 1,
+      LayerUnits,
       /** Pixels unit of tolerance*/
       Pixels,
       /** Map (project) units. Added in 2.8 */


### PR DESCRIPTION
@wonder-sk , this PR fixes two snapping dialog regressions:
- added layers always activated (irrespective of settings)
- wrong default snapping unit combo box index

This should be backported to the 2.16 branch and master_2.
