### PR TITLE
MetaSearch: Update LINZ Data Service default URL

### DIFF
--- a/python/plugins/MetaSearch/resources/connections-default.xml
+++ b/python/plugins/MetaSearch/resources/connections-default.xml
@@ -8,7 +8,7 @@
     <csw name="Iceland: National CSW (Iceland Service)" url="http://gatt.lmi.is/geoportal122/csw"/>
     <csw name="Italy: National CSW (Geoportale Nazionale - Servizio di ricerca Italiano)" url="http://www.pcn.minambiente.it/geoportal/csw"/>
     <csw name="Italy: RNDT - Repertorio Nazionale dei Dati Territoriali - Servizio di ricerca" url="http://www.rndt.gov.it/RNDT/CSW"/>
-    <csw name="New Zealand: LINZ Data Service" url="http://data.linz.govt.nz/feeds/csw"/>
+    <csw name="New Zealand: LINZ Data Service" url="https://data.linz.govt.nz/services/csw/"/>
     <csw name="Netherlands: National CSW (Nationaal Georegister)" url="http://www.nationaalgeoregister.nl/geonetwork/srv/eng/csw"/>
     <csw name="Norway: National CSW (Geonorge)" url="http://www.geonorge.no/geonetwork/srv/no/csw"/>
     <csw name="Sweden: National CSW" url="http://www.geodata.se/InspireCswProxy/csw"/>


### PR DESCRIPTION
The existing CSW URL is still supported for backwards compatibility, but `/services/csw/` is the preferred path going forward. They're backed by the same code and results will be identical.

Current url is shown at eg. https://data.linz.govt.nz/layer/767-nz-topo50-maps/webservices/
