### PR TITLE
[NEEDS-DOCS] Rename Style tab into Symbology in layer properties dialog

### DIFF
--- a/src/ui/qgsvectorlayerpropertiesbase.ui
+++ b/src/ui/qgsvectorlayerpropertiesbase.ui
@@ -107,10 +107,10 @@
          </item>
          <item>
           <property name="text">
-           <string>Style</string>
+           <string>Symbology</string>
           </property>
           <property name="toolTip">
-           <string>Style</string>
+           <string>Symbology</string>
           </property>
           <property name="icon">
            <iconset resource="../../images/images.qrc">


### PR DESCRIPTION
With the upcoming 3.0, here also comes the time to discuss some GUI texts (a previous misfire at #2765)
`Style` is one of those words that are used in different places with different meanings and, from a doc writer perspective,  doesn't ease explanation (and could puzzle readers/users). This PR renames the Style tab in Layer Properties dialog into `Symbology`, given that it's all about applying symbology to features. Note that this is how it's named in the Layer Styling panel.
