### PR TITLE
[labelling] always label all parts when placement is set to perimeter

### DIFF
--- a/src/core/qgsvectorlayerlabelprovider.cpp
+++ b/src/core/qgsvectorlayerlabelprovider.cpp
@@ -95,6 +95,12 @@ QgsVectorLayerLabelProvider::QgsVectorLayerLabelProvider( const QgsPalLayerSetti
 
 void QgsVectorLayerLabelProvider::init()
 {
+  if ( mLayerGeometryType == QgsWkbTypes::GeometryType::PolygonGeometry &&
+       ( mSettings.placement == QgsPalLayerSettings::Placement::Line  || mSettings.placement == QgsPalLayerSettings::Placement::PerimeterCurved ) )
+  {
+    mSettings.labelPerPart = true;
+  }
+
   mPlacement = mSettings.placement;
   mLinePlacementFlags = mSettings.placementFlags;
   mFlags = Flags();


### PR DESCRIPTION
(See #3403 for more background on this)

This PR insures that labels are shown on all parts of a polygon perimeter, irrespective of whether [x] label all parts is set so that a single-part perimeter broken into two (or more) parts are all labelled. 

@nyalldawson , as per our discussion, I've changed the way I approached it to insure it works both for perimeter and curved perimeter.
