### PR TITLE
Add auto-discovery of relations for PostgresQL and SpatiaLite

### DIFF
--- a/python/core/qgsrelation.sip
+++ b/python/core/qgsrelation.sip
@@ -172,6 +172,12 @@ class QgsRelation
     QString id() const;
 
     /**
+     * Generate a (project-wide) unique id for this relation
+     * @note added in QGIS 3.0
+     */
+    void generateId();
+
+    /**
      * Access the referencing (child) layer's id
      * This is the layer which has the field(s) which point to another layer
      *
@@ -240,6 +246,15 @@ class QgsRelation
      * @return true if the relation is valid
      */
     bool isValid() const;
+
+    /**
+     * Compares the two QgsRelation, ignoring the name and the ID.
+     *
+     * @param other The other relation
+     * @return true if they are similar
+     * @note added in QGIS 3.0
+     */
+    bool hasEqualDefinition( const QgsRelation& other ) const;
 
   protected:
     /**

--- a/python/core/qgsrelationmanager.sip
+++ b/python/core/qgsrelationmanager.sip
@@ -90,6 +90,16 @@ class QgsRelationManager : QObject
      */
     QList<QgsRelation> referencedRelations( QgsVectorLayer *layer = 0 ) const;
 
+    /**
+     * Discover all the relations available from the current layers.
+     *
+     * @param existingRelations the existing relations to filter them out
+     * @param layers the current layers
+     * @return the list of discovered relations
+     * @note added in QGIS 3.0
+     */
+    static QList<QgsRelation> discoverRelations( const QList<QgsRelation>& existingRelations, const QList<QgsVectorLayer*>& layers );
+
   signals:
     /** This signal is emitted when the relations were loaded after reading a project */
     void relationsLoaded();

--- a/python/core/qgsvectordataprovider.sip
+++ b/python/core/qgsvectordataprovider.sip
@@ -371,6 +371,15 @@ class QgsVectorDataProvider : QgsDataProvider
      */
     virtual QSet<QgsMapLayerDependency> dependencies() const;
 
+    /**
+     * Discover the available relations with the given layers.
+     * @param self the layer using this data provider.
+     * @param layers the other layers.
+     * @return the list of N-1 relations from this provider.
+     * @note added in QGIS 3.0
+     */
+    virtual QList<QgsRelation> discoverRelations( const QgsVectorLayer* self, const QList<QgsVectorLayer*>& layers ) const;
+
   signals:
     /** Signals an error in this provider */
     void raiseError( const QString& msg );

--- a/src/app/CMakeLists.txt
+++ b/src/app/CMakeLists.txt
@@ -28,6 +28,7 @@ SET(QGIS_APP_SRCS
   qgsdecorationscalebardialog.cpp
   qgsdecorationgrid.cpp
   qgsdecorationgriddialog.cpp
+  qgsdiscoverrelationsdlg.cpp
   qgsdxfexportdialog.cpp
   qgsformannotationdialog.cpp
   qgsguivectorlayertools.cpp
@@ -207,6 +208,7 @@ SET (QGIS_APP_MOC_HDRS
   qgsdecorationgriddialog.h
   qgsdelattrdialog.h
   qgsdiagramproperties.h
+  qgsdiscoverrelationsdlg.h
   qgsdisplayangle.h
   qgsdxfexportdialog.h
   qgsfeatureaction.h

--- a/src/app/qgsdiscoverrelationsdlg.cpp
+++ b/src/app/qgsdiscoverrelationsdlg.cpp
@@ -1,0 +1,61 @@
+/***************************************************************************
+    qgsdiscoverrelationsdlg.cpp
+    ---------------------
+    begin                : September 2016
+    copyright            : (C) 2016 by Patrick Valsecchi
+    email                : patrick dot valsecchi at camptocamp dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include "qgsdiscoverrelationsdlg.h"
+#include "qgsvectorlayer.h"
+#include "qgsrelationmanager.h"
+
+#include <QPushButton>
+
+QgsDiscoverRelationsDlg::QgsDiscoverRelationsDlg( const QList<QgsRelation>& existingRelations, const QList<QgsVectorLayer*>& layers, QWidget *parent )
+    : QDialog( parent )
+    , mLayers( layers )
+{
+  setupUi( this );
+
+  mButtonBox->button( QDialogButtonBox::Ok )->setEnabled( false );
+  connect( mRelationsTable->selectionModel(), &QItemSelectionModel::selectionChanged, this, &QgsDiscoverRelationsDlg::onSelectionChanged );
+
+  mFoundRelations = QgsRelationManager::discoverRelations( existingRelations, layers );
+  Q_FOREACH ( const QgsRelation& relation, mFoundRelations ) addRelation( relation );
+
+  mRelationsTable->resizeColumnsToContents();
+
+}
+
+void QgsDiscoverRelationsDlg::addRelation( const QgsRelation &rel )
+{
+  const int row = mRelationsTable->rowCount();
+  mRelationsTable->insertRow( row );
+  mRelationsTable->setItem( row, 0, new QTableWidgetItem( rel.name() ) );
+  mRelationsTable->setItem( row, 1, new QTableWidgetItem( rel.referencingLayer()->name() ) );
+  mRelationsTable->setItem( row, 2, new QTableWidgetItem( rel.fieldPairs().at( 0 ).referencingField() ) );
+  mRelationsTable->setItem( row, 3, new QTableWidgetItem( rel.referencedLayer()->name() ) );
+  mRelationsTable->setItem( row, 4, new QTableWidgetItem( rel.fieldPairs().at( 0 ).referencedField() ) );
+}
+
+QList<QgsRelation> QgsDiscoverRelationsDlg::relations() const
+{
+  QList<QgsRelation> result;
+  Q_FOREACH ( const QModelIndex& row, mRelationsTable->selectionModel()->selectedRows() )
+  {
+    result.append( mFoundRelations.at( row.row() ) );
+  }
+  return result;
+}
+
+void QgsDiscoverRelationsDlg::onSelectionChanged()
+{
+  mButtonBox->button( QDialogButtonBox::Ok )->setEnabled( mRelationsTable->selectionModel()->hasSelection() );
+}

--- a/src/app/qgsdiscoverrelationsdlg.h
+++ b/src/app/qgsdiscoverrelationsdlg.h
@@ -1,0 +1,53 @@
+/***************************************************************************
+    qgsdiscoverrelationsdlg.h
+    ---------------------
+    begin                : September 2016
+    copyright            : (C) 2016 by Patrick Valsecchi
+    email                : patrick dot valsecchi at camptocamp dot com
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSDISCOVERRELATIONSDLG_H
+#define QGSDISCOVERRELATIONSDLG_H
+
+#include <QDialog>
+#include "ui_qgsdiscoverrelationsdlgbase.h"
+#include "qgsrelation.h"
+
+class QgsRelationManager;
+class QgsVectorLayer;
+
+/**
+ * Shows the list of relations discovered from the providers.
+ *
+ * The user can select some of them to add them to his project.
+ */
+class APP_EXPORT QgsDiscoverRelationsDlg : public QDialog, private Ui::QgsDiscoverRelationsDlgBase
+{
+    Q_OBJECT
+
+  public:
+    explicit QgsDiscoverRelationsDlg( const QList<QgsRelation>& existingRelations, const QList<QgsVectorLayer*>& layers, QWidget *parent = nullptr );
+
+    /**
+     * Get the selected relations.
+     */
+    QList<QgsRelation> relations() const;
+
+  private slots:
+    void onSelectionChanged();
+
+  private:
+    QList<QgsVectorLayer*> mLayers;
+    QList<QgsRelation> mFoundRelations;
+
+    void addRelation( const QgsRelation &rel );
+
+};
+
+#endif // QGSDISCOVERRELATIONSDLG_H

--- a/src/app/qgsrelationmanagerdialog.cpp
+++ b/src/app/qgsrelationmanagerdialog.cpp
@@ -13,6 +13,7 @@
  *                                                                         *
  ***************************************************************************/
 
+#include "qgsdiscoverrelationsdlg.h"
 #include "qgsrelationadddlg.h"
 #include "qgsrelationmanagerdialog.h"
 #include "qgsrelationmanager.h"
@@ -46,6 +47,7 @@ void QgsRelationManagerDialog::setLayers( const QList< QgsVectorLayer* >& layers
 
 void QgsRelationManagerDialog::addRelation( const QgsRelation &rel )
 {
+  mRelationsTable->setSortingEnabled( false );
   int row = mRelationsTable->rowCount();
   mRelationsTable->insertRow( row );
 
@@ -53,7 +55,6 @@ void QgsRelationManagerDialog::addRelation( const QgsRelation &rel )
   // Save relation in first column's item
   item->setData( Qt::UserRole, QVariant::fromValue<QgsRelation>( rel ) );
   mRelationsTable->setItem( row, 0, item );
-
 
   item = new QTableWidgetItem( rel.referencingLayer()->name() );
   item->setFlags( Qt::ItemIsEditable );
@@ -74,6 +75,7 @@ void QgsRelationManagerDialog::addRelation( const QgsRelation &rel )
   item = new QTableWidgetItem( rel.id() );
   item->setFlags( Qt::ItemIsEditable );
   mRelationsTable->setItem( row, 5, item );
+  mRelationsTable->setSortingEnabled( true );
 }
 
 void QgsRelationManagerDialog::on_mBtnAddRelation_clicked()
@@ -115,6 +117,18 @@ void QgsRelationManagerDialog::on_mBtnAddRelation_clicked()
     relation.setRelationName( addDlg.relationName() );
 
     addRelation( relation );
+  }
+}
+
+void QgsRelationManagerDialog::on_mBtnDiscoverRelations_clicked()
+{
+  QgsDiscoverRelationsDlg discoverDlg( relations(), mLayers, this );
+  if ( discoverDlg.exec() )
+  {
+    Q_FOREACH ( const QgsRelation& relation, discoverDlg.relations() )
+    {
+      addRelation( relation );
+    }
   }
 }
 

--- a/src/app/qgsrelationmanagerdialog.h
+++ b/src/app/qgsrelationmanagerdialog.h
@@ -39,6 +39,7 @@ class APP_EXPORT QgsRelationManagerDialog : public QWidget, private Ui::QgsRelat
 
   public slots:
     void on_mBtnAddRelation_clicked();
+    void on_mBtnDiscoverRelations_clicked();
     void on_mBtnRemoveRelation_clicked();
 
   private:

--- a/src/core/qgsrelation.cpp
+++ b/src/core/qgsrelation.cpp
@@ -248,6 +248,16 @@ QString QgsRelation::id() const
   return mRelationId;
 }
 
+void QgsRelation::generateId()
+{
+  mRelationId = QString( "%1_%2_%3_%4" )
+                .arg( referencingLayerId(),
+                      mFieldPairs.at( 0 ).referencingField(),
+                      referencedLayerId(),
+                      mFieldPairs.at( 0 ).referencedField() );
+  updateRelationStatus();
+}
+
 QString QgsRelation::referencingLayerId() const
 {
   return mReferencingLayerId;
@@ -299,6 +309,11 @@ QgsAttributeList QgsRelation::referencingFields() const
 bool QgsRelation::isValid() const
 {
   return mValid;
+}
+
+bool QgsRelation::hasEqualDefinition( const QgsRelation& other ) const
+{
+  return mReferencedLayerId == other.mReferencedLayerId && mReferencingLayerId == other.mReferencingLayerId && mFieldPairs == other.mFieldPairs;
 }
 
 void QgsRelation::updateRelationStatus()

--- a/src/core/qgsrelation.h
+++ b/src/core/qgsrelation.h
@@ -57,6 +57,8 @@ class CORE_EXPORT QgsRelation
         QString referencingField() const { return first; }
         //! Get the name of the referenced (parent) field
         QString referencedField() const { return second; }
+
+        bool operator==( const FieldPair& other ) const { return first == other.first && second == other.second; }
     };
 
     /**
@@ -211,6 +213,12 @@ class CORE_EXPORT QgsRelation
     QString id() const;
 
     /**
+     * Generate a (project-wide) unique id for this relation
+     * @note added in QGIS 3.0
+     */
+    void generateId();
+
+    /**
      * Access the referencing (child) layer's id
      * This is the layer which has the field(s) which point to another layer
      *
@@ -271,6 +279,15 @@ class CORE_EXPORT QgsRelation
      * @return true if the relation is valid
      */
     bool isValid() const;
+
+    /**
+     * Compares the two QgsRelation, ignoring the name and the ID.
+     *
+     * @param other The other relation
+     * @return true if they are similar
+     * @note added in QGIS 3.0
+     */
+    bool hasEqualDefinition( const QgsRelation& other ) const;
 
   protected:
     /**

--- a/src/core/qgsrelationmanager.cpp
+++ b/src/core/qgsrelationmanager.cpp
@@ -19,6 +19,7 @@
 #include "qgslogger.h"
 #include "qgsmaplayerregistry.h"
 #include "qgsproject.h"
+#include "qgsvectordataprovider.h"
 #include "qgsvectorlayer.h"
 
 QgsRelationManager::QgsRelationManager( QgsProject* project )
@@ -216,4 +217,29 @@ void QgsRelationManager::layersRemoved( const QStringList& layers )
   {
     emit changed();
   }
+}
+
+static bool hasRelationWithEqualDefinition( const QList<QgsRelation>& existingRelations, const QgsRelation& relation )
+{
+  Q_FOREACH ( const QgsRelation& cur, existingRelations )
+  {
+    if ( cur.hasEqualDefinition( relation ) ) return true;
+  }
+  return false;
+}
+
+QList<QgsRelation> QgsRelationManager::discoverRelations( const QList<QgsRelation>& existingRelations, const QList<QgsVectorLayer*>& layers )
+{
+  QList<QgsRelation> result;
+  Q_FOREACH ( const QgsVectorLayer* layer, layers )
+  {
+    Q_FOREACH ( const QgsRelation& relation, layer->dataProvider()->discoverRelations( layer, layers ) )
+    {
+      if ( !hasRelationWithEqualDefinition( existingRelations, relation ) )
+      {
+        result.append( relation );
+      }
+    }
+  }
+  return result;
 }

--- a/src/core/qgsrelationmanager.h
+++ b/src/core/qgsrelationmanager.h
@@ -117,6 +117,16 @@ class CORE_EXPORT QgsRelationManager : public QObject
      */
     QList<QgsRelation> referencedRelations( QgsVectorLayer *layer = nullptr ) const;
 
+    /**
+     * Discover all the relations available from the current layers.
+     *
+     * @param existingRelations the existing relations to filter them out
+     * @param layers the current layers
+     * @return the list of discovered relations
+     * @note added in QGIS 3.0
+     */
+    static QList<QgsRelation> discoverRelations( const QList<QgsRelation>& existingRelations, const QList<QgsVectorLayer*>& layers );
+
   signals:
     /** This signal is emitted when the relations were loaded after reading a project */
     void relationsLoaded();

--- a/src/core/qgsvectordataprovider.cpp
+++ b/src/core/qgsvectordataprovider.cpp
@@ -718,3 +718,8 @@ QgsGeometry* QgsVectorDataProvider::convertToProviderType( const QgsGeometry& ge
 }
 
 QStringList QgsVectorDataProvider::smEncodings;
+
+QList<QgsRelation> QgsVectorDataProvider::discoverRelations( const QgsVectorLayer*, const QList<QgsVectorLayer*>& ) const
+{
+  return QList<QgsRelation>();
+}

--- a/src/core/qgsvectordataprovider.h
+++ b/src/core/qgsvectordataprovider.h
@@ -28,6 +28,7 @@ class QTextCodec;
 #include "qgsfeature.h"
 #include "qgsaggregatecalculator.h"
 #include "qgsmaplayerdependency.h"
+#include "qgsrelation.h"
 
 typedef QList<int> QgsAttributeList;
 typedef QSet<int> QgsAttributeIds;
@@ -432,6 +433,15 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider
      * Get the list of layer ids on which this layer depends. This in particular determines the order of layer loading.
      */
     virtual QSet<QgsMapLayerDependency> dependencies() const;
+
+    /**
+     * Discover the available relations with the given layers.
+     * @param self the layer using this data provider.
+     * @param layers the other layers.
+     * @return the list of N-1 relations from this provider.
+     * @note added in QGIS 3.0
+     */
+    virtual QList<QgsRelation> discoverRelations( const QgsVectorLayer* self, const QList<QgsVectorLayer*>& layers ) const;
 
   signals:
     /** Signals an error in this provider */

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -258,6 +258,8 @@ class QgsPostgresProvider : public QgsVectorDataProvider
      */
     static QVariant convertValue( QVariant::Type type, QVariant::Type subType, const QString& value );
 
+    virtual QList<QgsRelation> discoverRelations( const QgsVectorLayer* self, const QList<QgsVectorLayer*>& layers ) const override;
+
   signals:
     /**
      *   This is emitted whenever the worker thread has fully calculated the
@@ -339,6 +341,11 @@ class QgsPostgresProvider : public QgsVectorDataProvider
      *       primary key type.
      */
     QgsPostgresPrimaryKeyType pkType( const QgsField& fld ) const;
+
+    /**
+     * Search all the layers using the given table.
+     */
+    static QList<QgsVectorLayer*> searchLayers( const QList<QgsVectorLayer*>& layers, const QString& connectionInfo, const QString& schema, const QString& tableName );
 
     QgsFields mAttributeFields;
     QString mDataComment;

--- a/src/providers/spatialite/qgsspatialiteprovider.h
+++ b/src/providers/spatialite/qgsspatialiteprovider.h
@@ -209,6 +209,8 @@ class QgsSpatiaLiteProvider: public QgsVectorDataProvider
 
     void invalidateConnections( const QString& connection ) override;
 
+    QList<QgsRelation> discoverRelations( const QgsVectorLayer* self, const QList<QgsVectorLayer*>& layers ) const override;
+
     // static functions
     static void convertToGeosWKB( const unsigned char *blob, int blob_size,
                                   unsigned char **wkb, int *geom_size );
@@ -290,6 +292,11 @@ class QgsSpatiaLiteProvider: public QgsVectorDataProvider
 
     //! get SpatiaLite version string
     QString spatialiteVersion();
+
+    /**
+     * Search all the layers using the given table.
+     */
+    static QList<QgsVectorLayer*> searchLayers( const QList<QgsVectorLayer*>& layers, const QString& connectionInfo, const QString& tableName );
 
     QgsFields mAttributeFields;
 

--- a/src/ui/qgsdiscoverrelationsdlgbase.ui
+++ b/src/ui/qgsdiscoverrelationsdlgbase.ui
@@ -1,0 +1,117 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<ui version="4.0">
+ <class>QgsDiscoverRelationsDlgBase</class>
+ <widget class="QDialog" name="QgsDiscoverRelationsDlgBase">
+  <property name="geometry">
+   <rect>
+    <x>0</x>
+    <y>0</y>
+    <width>700</width>
+    <height>267</height>
+   </rect>
+  </property>
+  <property name="windowTitle">
+   <string>Discover relations</string>
+  </property>
+  <layout class="QVBoxLayout" name="verticalLayout">
+   <item>
+    <widget class="QTableWidget" name="mRelationsTable">
+     <property name="editTriggers">
+      <set>QAbstractItemView::NoEditTriggers</set>
+     </property>
+     <property name="selectionMode">
+      <enum>QAbstractItemView::MultiSelection</enum>
+     </property>
+     <property name="selectionBehavior">
+      <enum>QAbstractItemView::SelectRows</enum>
+     </property>
+     <property name="sortingEnabled">
+      <bool>true</bool>
+     </property>
+     <attribute name="horizontalHeaderStretchLastSection">
+      <bool>true</bool>
+     </attribute>
+     <attribute name="verticalHeaderVisible">
+      <bool>false</bool>
+     </attribute>
+     <attribute name="verticalHeaderShowSortIndicator" stdset="0">
+      <bool>true</bool>
+     </attribute>
+     <column>
+      <property name="text">
+       <string>Name</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Referencing Layer</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Referencing Field</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Referenced Layer</string>
+      </property>
+     </column>
+     <column>
+      <property name="text">
+       <string>Referenced Field</string>
+      </property>
+     </column>
+    </widget>
+   </item>
+   <item>
+    <widget class="QDialogButtonBox" name="mButtonBox">
+     <property name="orientation">
+      <enum>Qt::Horizontal</enum>
+     </property>
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+  </layout>
+ </widget>
+ <tabstops>
+  <tabstop>mButtonBox</tabstop>
+ </tabstops>
+ <resources/>
+ <connections>
+  <connection>
+   <sender>mButtonBox</sender>
+   <signal>accepted()</signal>
+   <receiver>QgsDiscoverRelationsDlgBase</receiver>
+   <slot>accept()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>248</x>
+     <y>254</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>157</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+  <connection>
+   <sender>mButtonBox</sender>
+   <signal>rejected()</signal>
+   <receiver>QgsDiscoverRelationsDlgBase</receiver>
+   <slot>reject()</slot>
+   <hints>
+    <hint type="sourcelabel">
+     <x>316</x>
+     <y>260</y>
+    </hint>
+    <hint type="destinationlabel">
+     <x>286</x>
+     <y>274</y>
+    </hint>
+   </hints>
+  </connection>
+ </connections>
+</ui>

--- a/src/ui/qgsrelationmanagerdialogbase.ui
+++ b/src/ui/qgsrelationmanagerdialogbase.ui
@@ -84,6 +84,17 @@
       </widget>
      </item>
      <item>
+      <widget class="QPushButton" name="mBtnDiscoverRelations">
+       <property name="text">
+        <string>Discover Relations</string>
+       </property>
+       <property name="icon">
+        <iconset resource="../../images/images.qrc">
+         <normaloff>:/images/themes/default/symbologyAdd.svg</normaloff>:/images/themes/default/symbologyAdd.svg</iconset>
+       </property>
+      </widget>
+     </item>
+     <item>
       <widget class="QPushButton" name="mBtnRemoveRelation">
        <property name="text">
         <string>Remove Relation</string>


### PR DESCRIPTION
Fixed the add relation functionnality: the table is sorted. When the code
was setting the sorted column, the row was sorted and the other columns it was
setting were set on the wrong row.
