### PR TITLE
treat PostgreSQL's "json" field type as string

### DIFF
--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -894,6 +894,7 @@ bool QgsPostgresProvider::loadFields()
                 fieldTypeName == "ltree" ||
                 fieldTypeName == "uuid" ||
                 fieldTypeName == "xml" ||
+                fieldTypeName == "json" ||
                 fieldTypeName.startsWith( "time" ) ||
                 fieldTypeName.startsWith( "date" ) )
       {


### PR DESCRIPTION
Similar to #1890
