### PR TITLE
Fix python3 pyspatialite import

### DIFF
--- a/python/ext-libs/pyspatialite/lib/dbapi2.py
+++ b/python/ext-libs/pyspatialite/lib/dbapi2.py
@@ -50,7 +50,10 @@ def TimestampFromTicks(ticks):
 version_info = tuple([int(x) for x in version.split(".")])
 sqlite_version_info = tuple([int(x) for x in sqlite_version.split(".")])
 
-Binary = buffer
+# buffer is no longer supported is python 3
+# memoryview fit 2.7 and 3+
+# see https://docs.python.org/2/c-api/buffer.html
+Binary = memoryview
 
 def register_adapters_and_converters():
     def adapt_date(val):

--- a/python/ext-libs/pyspatialite/src/module.c
+++ b/python/ext-libs/pyspatialite/src/module.c
@@ -329,7 +329,11 @@ static struct PyModuleDef _sqlite3module = {
 };
 #endif
 
+#if PY_MAJOR_VERSION < 3
 PyMODINIT_FUNC init_spatialite(void)
+#else
+PyMODINIT_FUNC PyInit__spatialite(void)
+#endif
 {
     PyObject *module, *dict;
     PyObject *tmp_obj;


### PR DESCRIPTION
pyspatialite is broken under python 3.5+:
- The entry point of the c module does does not follow the python 3 specs - see https://docs.python.org/3/extending/building.html - and pyspatialite import fails with the following error:

```
ImportError: dynamic module does not define module export function (PyInit__spatialite)
```
- `buffer()` is removed in python3 in favor of `memoryview` - see https://docs.python.org/2/c-api/buffer.html.  `memoryview` works in 2.7 and support the object implementing buffer protocol. I did not see any explicit reference to `buffer()` in the qgis ( `buffer` is aliased as `Binary` in `dbapi2.py`) but I cannot speak for plugins.
