### PR TITLE
Only enable globe plugin for osgEarth 2.7, it breaks with 2.8.

### DIFF
--- a/debian/rules
+++ b/debian/rules
@@ -53,7 +53,7 @@ QGIS_ABI=$(QGIS_MAJOR).$(QGIS_MINOR).$(QGIS_PATCH)
 GRASS=grass$(subst .,,$(shell pkg-config --modversion grass|cut -d. -f1,2))
 GRASSVER=$(subst .,,$(shell pkg-config --modversion grass|cut -d. -f1))
 
-WITH_GLOBE=$(shell dpkg --compare-versions "$$(dpkg-query -W --showformat='$${Version}' libosgearth-dev)" ge 2.7 && echo 1)
+WITH_GLOBE=$(shell dpkg --compare-versions "$$(dpkg-query -W --showformat='$${Version}' libosgearth-dev)" ge 2.7 && dpkg --compare-versions "$$(dpkg-query -W --showformat='$${Version}' libosgearth-dev)" lt 2.8 && echo 1)
 
 CMAKE_OPTS := \
 	-DBUILDNAME=$(DEB_BUILD_NAME) \


### PR DESCRIPTION
As discussed in [#15536](https://hub.qgis.org/issues/15536) and on [qgis-developer](https://lists.osgeo.org/pipermail/qgis-developer/2016-September/044917.html), the Globe plugin only supports osgEarth 2.7 and breaks with 2.8.

This PR adds an additional version check to ensure that `libosgearth-dev` is less than 2.8.
