### PR TITLE
Fix refine current rule not working when symbol widgets are not used in the style dock

### DIFF
--- a/python/gui/qgspanelwidget.sip
+++ b/python/gui/qgspanelwidget.sip
@@ -89,6 +89,9 @@ class QgsPanelWidget : public QWidget
      * @param panel The panel widget that was accepted.
      * @note This argument is normally raised with emit panelAccepted(this)
      * so that callers can retrive the widget easier in calling code.
+     * @note this is emitted only when this panel is accepted, and is not emitted for
+     * child panels. Eg, if this panel opens a second stacked panel, then this panel
+     * will not emit panelAccepted when the second panel is accepted.
      */
     void panelAccepted( QgsPanelWidget* panel );
 

--- a/src/core/symbology-ng/qgscategorizedsymbolrenderer.cpp
+++ b/src/core/symbology-ng/qgscategorizedsymbolrenderer.cpp
@@ -161,7 +161,7 @@ QgsCategorizedSymbolRenderer::QgsCategorizedSymbolRenderer( const QString& attrN
   //trigger a detachment and copy of mCategories BUT that same method CAN be used to modify a symbol in place
   Q_FOREACH ( const QgsRendererCategory& cat, categories )
   {
-    if ( cat.symbol() )
+    if ( !cat.symbol() )
     {
       QgsDebugMsg( "invalid symbol in a category! ignoring..." );
     }

--- a/src/gui/qgspanelwidget.cpp
+++ b/src/gui/qgspanelwidget.cpp
@@ -84,7 +84,7 @@ void QgsPanelWidget::openPanel( QgsPanelWidget* panel )
     dlg->layout()->addWidget( buttonBox );
     dlg->exec();
     settings.setValue( key, dlg->saveGeometry() );
-    emit panelAccepted( panel );
+    panel->acceptPanel();
   }
 }
 

--- a/src/gui/qgspanelwidget.h
+++ b/src/gui/qgspanelwidget.h
@@ -108,6 +108,9 @@ class GUI_EXPORT QgsPanelWidget : public QWidget
      * @param panel The panel widget that was accepted.
      * @note This argument is normally raised with emit panelAccepted(this)
      * so that callers can retrive the widget easier in calling code.
+     * @note this is emitted only when this panel is accepted, and is not emitted for
+     * child panels. Eg, if this panel opens a second stacked panel, then this panel
+     * will not emit panelAccepted when the second panel is accepted.
      */
     void panelAccepted( QgsPanelWidget* panel );
 


### PR DESCRIPTION
Fixes #15373 - refine current rule not working when symbol widgets are not used in the style dock

This fixes a behavioural difference when new panels are opened in a QgsPanelWidget when in docked/undocked mode. When in docked mode, the newly opened panel will emit panelAccepted
when it is accepted. But for undocked mode, the parent panel was emitting the panelAccepted signal and so the connection to update the renderer was never triggered. Now both docked/undocked panels will always emit panelAccepted ONLY from the newly opened panel itself.

This also fixes memory leaks as the clean up code was never run in undocked mode.

I've updated the docs to clarify this behaviour.
