### PR TITLE
referencedColumns returns QSet<QString> instead of QStringList

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -710,6 +710,9 @@ version instead.</li>
 <li>helptext() has been renamed to helpText()</li>
 <li>isValid() has been renamed to checkExpression()</li>
 <li>acceptVisitor() has been removed</li>
+<li>QgsExpression::referencedColumns() returns QSet<QString> instead of QStringList</li>
+<li>QgsExpression::Node::referencedColumns() returns QSet<QString> instead of QStringList</li>
+<li>QgsExpression::Function::referencedColumns() returns QSet<QString> instead of QStringList</li>
 </ul>
 
 \subsection qgis_api_break_3_0_QgsFeature QgsFeature
@@ -1482,6 +1485,8 @@ optional property map passing down layer level properties to the SLD encoders. I
 <code>scaleMinDenom</code> and <code>scaleMaxDenom</code> properties.</li>
 <li>The RotationField capabitity was removed. This is now handled using data defined rotation at a symbol layer level</li>
 <li>setScaleMethodToSymbol was removed. This is now handled using data defined scaling at a symbol layer level</li>
+<li>setScaleMethodToSymbol was removed. This is now handled using data defined scaling at a symbol layer level</li>
+<li>usedAttributes is now a const method and returns QSet<QString> instead of QStringList</li>
 </ul>
 
 

--- a/python/core/qgsdatadefined.sip
+++ b/python/core/qgsdatadefined.sip
@@ -128,7 +128,7 @@ class QgsDataDefined
      * @param context expression context, used for preparing the expression if required
      * @note added in QGIS 2.12
      */
-    QStringList referencedColumns( const QgsExpressionContext& context = QgsExpressionContext() );
+    QSet<QString> referencedColumns( const QgsExpressionContext& context = QgsExpressionContext() );
 
     /**
      * Get the field which this QgsDataDefined represents. Be aware that this may return

--- a/python/core/qgsexpression.sip
+++ b/python/core/qgsexpression.sip
@@ -51,7 +51,7 @@ class QgsExpression
      *
      * TODO QGIS3: Return QSet<QString>
      */
-    QStringList referencedColumns() const;
+    QSet<QString> referencedColumns() const;
 
     /**
      * Return a list of field name indexes obtained from the provided fields.
@@ -301,7 +301,7 @@ class QgsExpression
                   const QString& group,
                   const QString& helpText = QString(),
                   bool usesGeometry = false,
-                  const QStringList& referencedColumns = QStringList(),
+                  const QSet<QString>& referencedColumns = QSet<QString>(),
                   bool lazyEval = false,
                   bool handlesNull = false,
                   bool isContextual = false );
@@ -314,7 +314,7 @@ class QgsExpression
                   const QString& group,
                   const QString& helpText = QString(),
                   bool usesGeometry = false,
-                  const QStringList& referencedColumns = QStringList(),
+                  const QSet<QString>& referencedColumns = QSet<QString>(),
                   bool lazyEval = false,
                   bool handlesNull = false,
                   bool isContextual = false );
@@ -350,7 +350,7 @@ class QgsExpression
          */
         bool lazyEval() const;
 
-        virtual QStringList referencedColumns() const;
+        virtual QSet<QString> referencedColumns() const;
 
         /** Returns whether the function is only available if provided by a QgsExpressionContext object.
          * @note added in QGIS 2.12
@@ -517,7 +517,7 @@ class QgsExpression
          *
          * @return A list of columns required to evaluate this expression
          */
-        virtual QStringList referencedColumns() const = 0;
+        virtual QSet<QString> referencedColumns() const = 0;
 
         /**
          * Abstract virtual method which returns if the geometry is required to evaluate
@@ -596,7 +596,7 @@ class QgsExpression
         virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context );
         virtual QString dump() const;
 
-        virtual QStringList referencedColumns() const;
+        virtual QSet<QString> referencedColumns() const;
         virtual bool needsGeometry() const;
         virtual QgsExpression::Node* clone() const;
     };
@@ -616,7 +616,7 @@ class QgsExpression
         virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context );
         virtual QString dump() const;
 
-        virtual QStringList referencedColumns() const;
+        virtual QSet<QString> referencedColumns() const;
         virtual bool needsGeometry() const;
         virtual QgsExpression::Node* clone() const;
 
@@ -650,7 +650,7 @@ class QgsExpression
         virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context );
         virtual QString dump() const;
 
-        virtual QStringList referencedColumns() const;
+        virtual QSet<QString> referencedColumns() const;
         virtual bool needsGeometry() const;
         virtual QgsExpression::Node* clone() const;
     };
@@ -670,7 +670,7 @@ class QgsExpression
         virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context );
         virtual QString dump() const;
 
-        virtual QStringList referencedColumns() const;
+        virtual QSet<QString> referencedColumns() const;
         virtual bool needsGeometry() const;
         virtual QgsExpression::Node* clone() const;
 
@@ -692,7 +692,7 @@ class QgsExpression
         virtual QString dump() const;
         virtual QgsExpression::Node* clone() const;
 
-        virtual QStringList referencedColumns() const;
+        virtual QSet<QString> referencedColumns() const;
         virtual bool needsGeometry() const;
     };
 
@@ -709,7 +709,7 @@ class QgsExpression
         virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context );
         virtual QString dump() const;
 
-        virtual QStringList referencedColumns() const;
+        virtual QSet<QString> referencedColumns() const;
         virtual bool needsGeometry() const;
 
         virtual QgsExpression::Node* clone() const;
@@ -741,7 +741,7 @@ class QgsExpression
         virtual bool prepare( QgsExpression* parent, const QgsExpressionContext* context );
         virtual QString dump() const;
 
-        virtual QStringList referencedColumns() const;
+        virtual QSet<QString> referencedColumns() const;
         virtual bool needsGeometry() const;
         virtual QgsExpression::Node* clone() const;
     };

--- a/python/core/qgsexpressioncontext.sip
+++ b/python/core/qgsexpressioncontext.sip
@@ -17,7 +17,7 @@ class QgsScopedExpressionFunction : QgsExpression::Function
                                  const QString& group,
                                  const QString& helpText = QString(),
                                  bool usesGeometry = false,
-                                 const QStringList& referencedColumns = QStringList(),
+                                 const QSet<QString>& referencedColumns = QSet<QString>(),
                                  bool lazyEval = false,
                                  bool handlesNull = false,
                                  bool isContextual = true );

--- a/python/core/qgspallabeling.sip
+++ b/python/core/qgspallabeling.sip
@@ -122,14 +122,14 @@ class QgsLabelingEngineInterface
     //! clears data defined objects from PAL layer settings for a registered layer
     virtual void clearActiveLayer( const QString& layerID ) = 0;
     //! called when starting rendering of a layer
-    virtual int prepareLayer( QgsVectorLayer* layer, QStringList& attrNames, QgsRenderContext& ctx ) = 0;
+    virtual int prepareLayer( QgsVectorLayer* layer, QSet<QString>& attrNames, QgsRenderContext& ctx ) = 0;
     //! adds a diagram layer to the labeling engine
     //! @note added in QGIS 2.12
-    virtual int prepareDiagramLayer( QgsVectorLayer *layer, QStringList &attrNames, QgsRenderContext &ctx );
+    virtual int prepareDiagramLayer( QgsVectorLayer *layer, QSet<QString>& attrNames, QgsRenderContext& ctx );
     //! called for every feature
-    virtual void registerFeature( const QString &layerID, QgsFeature &feat, QgsRenderContext &context ) = 0;
+    virtual void registerFeature( const QString &layerID, QgsFeature& feat, QgsRenderContext& context ) = 0;
     //! called for every diagram feature
-    virtual void registerDiagramFeature( const QString &layerID, QgsFeature &feat, QgsRenderContext &context );
+    virtual void registerDiagramFeature( const QString& layerID, QgsFeature& feat, QgsRenderContext& context );
     //! called when the map is drawn and labels should be placed
     virtual void drawLabeling( QgsRenderContext& context ) = 0;
     //! called when we're done with rendering
@@ -915,10 +915,10 @@ class QgsPalLabeling : QgsLabelingEngineInterface
     //! clears data defined objects from PAL layer settings for a registered layer
     virtual void clearActiveLayer( const QString& layerID );
     //! hook called when drawing layer before issuing select()
-    virtual int prepareLayer( QgsVectorLayer* layer, QStringList &attrNames, QgsRenderContext& ctx );
+    virtual int prepareLayer( QgsVectorLayer* layer, QSet<QString>& attrNames, QgsRenderContext& ctx );
     //! adds a diagram layer to the labeling engine
     //! @note added in QGIS 2.12
-    virtual int prepareDiagramLayer( QgsVectorLayer* layer, QStringList& attrNames, QgsRenderContext& ctx );
+    virtual int prepareDiagramLayer( QgsVectorLayer* layer, QSet<QString>& attrNames, QgsRenderContext& ctx );
 
     /** Register a feature for labelling.
      * @param layerID string identifying layer associated with label

--- a/python/core/symbology-ng/qgs25drenderer.sip
+++ b/python/core/symbology-ng/qgs25drenderer.sip
@@ -33,7 +33,7 @@ class Qgs25DRenderer : QgsFeatureRenderer
     void startRender( QgsRenderContext& context, const QgsFields& fields );
     void stopRender( QgsRenderContext& context );
 
-    QList<QString> usedAttributes();
+    QSet<QString> usedAttributes() const;
     QgsFeatureRenderer* clone() const;
 
     virtual QgsSymbol* symbolForFeature( QgsFeature& feature, QgsRenderContext& context );

--- a/python/core/symbology-ng/qgscategorizedsymbolrenderer.sip
+++ b/python/core/symbology-ng/qgscategorizedsymbolrenderer.sip
@@ -59,7 +59,7 @@ class QgsCategorizedSymbolRenderer : QgsFeatureRenderer
 
     virtual void stopRender( QgsRenderContext& context );
 
-    virtual QList<QString> usedAttributes();
+    virtual QSet<QString> usedAttributes() const;
 
     virtual QString dump() const;
 

--- a/python/core/symbology-ng/qgsgraduatedsymbolrenderer.sip
+++ b/python/core/symbology-ng/qgsgraduatedsymbolrenderer.sip
@@ -102,7 +102,7 @@ class QgsGraduatedSymbolRenderer : QgsFeatureRenderer
 
     virtual void stopRender( QgsRenderContext& context );
 
-    virtual QList<QString> usedAttributes();
+    virtual QSet<QString> usedAttributes() const;
 
     virtual QString dump() const;
 

--- a/python/core/symbology-ng/qgsheatmaprenderer.sip
+++ b/python/core/symbology-ng/qgsheatmaprenderer.sip
@@ -18,7 +18,7 @@ class QgsHeatmapRenderer : QgsFeatureRenderer
     //! @note symbol2 in python bindings
     virtual QgsSymbolList symbols( QgsRenderContext& context );
     virtual QString dump() const;
-    virtual QList<QString> usedAttributes();
+    virtual QSet<QString> usedAttributes() const;
     static QgsFeatureRenderer* create( QDomElement& element ) /Factory/;
     virtual QDomElement save( QDomDocument& doc );
     static QgsHeatmapRenderer* convertFromRenderer( const QgsFeatureRenderer* renderer ) /Factory/;

--- a/python/core/symbology-ng/qgsinvertedpolygonrenderer.sip
+++ b/python/core/symbology-ng/qgsinvertedpolygonrenderer.sip
@@ -39,7 +39,7 @@ class QgsInvertedPolygonRenderer : QgsFeatureRenderer
     virtual QString dump() const;
 
     /** Proxy that will call this method on the embedded renderer. */
-    virtual QList<QString> usedAttributes();
+    virtual QSet<QString> usedAttributes() const;
     /** Proxy that will call this method on the embedded renderer. */
     virtual QgsFeatureRenderer::Capabilities capabilities();
     /** Proxy that will call this method on the embedded renderer.

--- a/python/core/symbology-ng/qgsnullsymbolrenderer.sip
+++ b/python/core/symbology-ng/qgsnullsymbolrenderer.sip
@@ -24,7 +24,7 @@ class QgsNullSymbolRenderer : QgsFeatureRenderer
     virtual void stopRender( QgsRenderContext& context );
     virtual bool willRenderFeature( QgsFeature& feat, QgsRenderContext& context );
 
-    virtual QList<QString> usedAttributes();
+    virtual QSet<QString> usedAttributes() const;
     virtual QString dump() const;
     virtual QgsFeatureRenderer* clone() const /Factory/;
     virtual QgsSymbolList symbols( QgsRenderContext& context );

--- a/python/core/symbology-ng/qgspointclusterrenderer.sip
+++ b/python/core/symbology-ng/qgspointclusterrenderer.sip
@@ -16,7 +16,7 @@ class QgsPointClusterRenderer : QgsPointDistanceRenderer
     virtual void startRender( QgsRenderContext& context, const QgsFields& fields );
     void stopRender( QgsRenderContext& context );
     QDomElement save( QDomDocument& doc );
-    virtual QList<QString> usedAttributes();
+    virtual QSet<QString> usedAttributes() const;
 
     //! Create a renderer from XML element
     static QgsFeatureRenderer* create( QDomElement& symbologyElem ) /Factory/;

--- a/python/core/symbology-ng/qgspointdisplacementrenderer.sip
+++ b/python/core/symbology-ng/qgspointdisplacementrenderer.sip
@@ -26,7 +26,7 @@ class QgsPointDisplacementRenderer : QgsPointDistanceRenderer
     virtual void startRender( QgsRenderContext& context, const QgsFields& fields );
     void stopRender( QgsRenderContext& context );
     QDomElement save( QDomDocument& doc );
-    virtual QList<QString> usedAttributes();
+    virtual QSet<QString> usedAttributes() const;
 
     //! Create a renderer from XML element
     static QgsFeatureRenderer* create( QDomElement& symbologyElem ) /Factory/;

--- a/python/core/symbology-ng/qgspointdistancerenderer.sip
+++ b/python/core/symbology-ng/qgspointdistancerenderer.sip
@@ -50,7 +50,7 @@ class QgsPointDistanceRenderer : QgsFeatureRenderer
 
     virtual void toSld( QDomDocument& doc, QDomElement &element, QgsStringMap props = QgsStringMap() ) const;
     bool renderFeature( QgsFeature& feature, QgsRenderContext& context, int layer = -1, bool selected = false, bool drawVertexMarker = false );
-    virtual QList<QString> usedAttributes();
+    virtual QSet<QString> usedAttributes() const;
     virtual Capabilities capabilities();
     virtual QgsSymbolList symbols( QgsRenderContext& context );
     virtual QgsSymbol* symbolForFeature( QgsFeature& feature, QgsRenderContext& context );

--- a/python/core/symbology-ng/qgsrenderer.sip
+++ b/python/core/symbology-ng/qgsrenderer.sip
@@ -119,10 +119,8 @@ class QgsFeatureRenderer
 
     /**
      * Returns a set of attributes required for this renderer.
-     *
-     * TODO QGIS3: Change QList to QSet
      */
-    virtual QList<QString> usedAttributes() = 0;
+    virtual QSet<QString> usedAttributes() const = 0;
 
     /**
      * Returns true if this renderer requires the geometry to apply the filter.

--- a/python/core/symbology-ng/qgsrulebasedrenderer.sip
+++ b/python/core/symbology-ng/qgsrulebasedrenderer.sip
@@ -340,7 +340,7 @@ class QgsRuleBasedRenderer : QgsFeatureRenderer
 
     virtual QString filter( const QgsFields& fields = QgsFields() );
 
-    virtual QList<QString> usedAttributes();
+    virtual QSet<QString> usedAttributes() const;
 
     virtual bool filterNeedsGeometry() const;
 

--- a/python/core/symbology-ng/qgssinglesymbolrenderer.sip
+++ b/python/core/symbology-ng/qgssinglesymbolrenderer.sip
@@ -19,7 +19,7 @@ class QgsSingleSymbolRenderer : QgsFeatureRenderer
 
     virtual void stopRender( QgsRenderContext& context );
 
-    virtual QList<QString> usedAttributes();
+    virtual QSet<QString> usedAttributes() const;
 
     QgsSymbol* symbol() const;
     void setSymbol( QgsSymbol* s /Transfer/ );

--- a/src/core/dxf/qgsdxfexport.cpp
+++ b/src/core/dxf/qgsdxfexport.cpp
@@ -965,12 +965,11 @@ void QgsDxfExport::writeEntities()
     }
     renderer->startRender( ctx, vl->fields() );
 
-    QStringList attributes = renderer->usedAttributes();
+    QSet<QString> attributes = renderer->usedAttributes();
     if ( vl->fields().exists( layerIt->second ) )
     {
       QString layerAttr = vl->fields().at( layerIt->second ).name();
-      if ( !attributes.contains( layerAttr ) )
-        attributes << layerAttr;
+      attributes << layerAttr;
     }
 
     const QgsAbstractVectorLayerLabeling *labeling = vl->labeling();
@@ -1106,7 +1105,7 @@ void QgsDxfExport::writeEntitiesSymbolLevels( QgsVectorLayer* layer )
   {
     req.setFlags( QgsFeatureRequest::NoGeometry );
   }
-  req.setSubsetOfAttributes( QStringList( renderer->usedAttributes() ), layer->fields() );
+  req.setSubsetOfAttributes( renderer->usedAttributes(), layer->fields() );
   req.setFilterRect( mMapSettings.mapToLayerCoordinates( layer, mExtent ) );
 
   QgsFeatureIterator fit = layer->getFeatures( req );

--- a/src/core/qgsaggregatecalculator.cpp
+++ b/src/core/qgsaggregatecalculator.cpp
@@ -71,9 +71,9 @@ QVariant QgsAggregateCalculator::calculate( QgsAggregateCalculator::Aggregate ag
     }
   }
 
-  QStringList lst;
+  QSet<QString> lst;
   if ( expression.isNull() )
-    lst.append( fieldOrExpression );
+    lst.insert( fieldOrExpression );
   else
     lst = expression->referencedColumns();
 

--- a/src/core/qgsdatadefined.cpp
+++ b/src/core/qgsdatadefined.cpp
@@ -187,7 +187,7 @@ QgsExpression *QgsDataDefined::expression()
   return d->expression;
 }
 
-QStringList QgsDataDefined::referencedColumns( const QgsExpressionContext& context )
+QSet<QString> QgsDataDefined::referencedColumns( const QgsExpressionContext& context )
 {
   if ( !d->exprRefColumns.isEmpty() )
   {

--- a/src/core/qgsdatadefined.h
+++ b/src/core/qgsdatadefined.h
@@ -154,7 +154,7 @@ class CORE_EXPORT QgsDataDefined
      * @param context expression context, used for preparing the expression if required
      * @note added in QGIS 2.12
      */
-    QStringList referencedColumns( const QgsExpressionContext& context = QgsExpressionContext() );
+    QSet<QString> referencedColumns( const QgsExpressionContext& context = QgsExpressionContext() );
 
     /**
      * Get the field which this QgsDataDefined represents. Be aware that this may return

--- a/src/core/qgsdatadefined_p.h
+++ b/src/core/qgsdatadefined_p.h
@@ -80,7 +80,7 @@ class QgsDataDefinedPrivate : public QSharedData
     QString field;
 
     bool expressionPrepared;
-    QStringList exprRefColumns;
+    QSet<QString> exprRefColumns;
 };
 
 /// @endcond

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -3427,43 +3427,43 @@ const QList<QgsExpression::Function*>& QgsExpression::Functions()
     << new StaticFunction( "scale_exp", 6, fcnExpScale, "Math" )
     << new StaticFunction( "floor", 1, fcnFloor, "Math" )
     << new StaticFunction( "ceil", 1, fcnCeil, "Math" )
-    << new StaticFunction( "pi", 0, fcnPi, "Math", QString(), false, QStringList(), false, QStringList() << "$pi" )
-    << new StaticFunction( "to_int", 1, fcnToInt, "Conversions", QString(), false, QStringList(), false, QStringList() << "toint" )
-    << new StaticFunction( "to_real", 1, fcnToReal, "Conversions", QString(), false, QStringList(), false, QStringList() << "toreal" )
-    << new StaticFunction( "to_string", 1, fcnToString, "Conversions", QString(), false, QStringList(), false, QStringList() << "tostring" )
-    << new StaticFunction( "to_datetime", 1, fcnToDateTime, "Conversions", QString(), false, QStringList(), false, QStringList() << "todatetime" )
-    << new StaticFunction( "to_date", 1, fcnToDate, "Conversions", QString(), false, QStringList(), false, QStringList() << "todate" )
-    << new StaticFunction( "to_time", 1, fcnToTime, "Conversions", QString(), false, QStringList(), false, QStringList() << "totime" )
-    << new StaticFunction( "to_interval", 1, fcnToInterval, "Conversions", QString(), false, QStringList(), false, QStringList() << "tointerval" )
-    << new StaticFunction( "coalesce", -1, fcnCoalesce, "Conditionals", QString(), false, QStringList(), false, QStringList(), true )
-    << new StaticFunction( "if", 3, fcnIf, "Conditionals", QString(), False, QStringList(), true )
+    << new StaticFunction( "pi", 0, fcnPi, "Math", QString(), false, QSet<QString>(), false, QStringList() << "$pi" )
+    << new StaticFunction( "to_int", 1, fcnToInt, "Conversions", QString(), false, QSet<QString>(), false, QStringList() << "toint" )
+    << new StaticFunction( "to_real", 1, fcnToReal, "Conversions", QString(), false, QSet<QString>(), false, QStringList() << "toreal" )
+    << new StaticFunction( "to_string", 1, fcnToString, "Conversions", QString(), false, QSet<QString>(), false, QStringList() << "tostring" )
+    << new StaticFunction( "to_datetime", 1, fcnToDateTime, "Conversions", QString(), false, QSet<QString>(), false, QStringList() << "todatetime" )
+    << new StaticFunction( "to_date", 1, fcnToDate, "Conversions", QString(), false, QSet<QString>(), false, QStringList() << "todate" )
+    << new StaticFunction( "to_time", 1, fcnToTime, "Conversions", QString(), false, QSet<QString>(), false, QStringList() << "totime" )
+    << new StaticFunction( "to_interval", 1, fcnToInterval, "Conversions", QString(), false, QSet<QString>(), false, QStringList() << "tointerval" )
+    << new StaticFunction( "coalesce", -1, fcnCoalesce, "Conditionals", QString(), false, QSet<QString>(), false, QStringList(), true )
+    << new StaticFunction( "if", 3, fcnIf, "Conditionals", QString(), False, QSet<QString>(), true )
     << new StaticFunction( "aggregate", ParameterList() << Parameter( "layer" ) << Parameter( "aggregate" ) << Parameter( "expression" )
-                           << Parameter( "filter", true ) << Parameter( "concatenator", true ), fcnAggregate, "Aggregates", QString(), false, QStringList(), true )
+                           << Parameter( "filter", true ) << Parameter( "concatenator", true ), fcnAggregate, "Aggregates", QString(), false, QSet<QString>(), true )
     << new StaticFunction( "relation_aggregate", ParameterList() << Parameter( "relation" ) << Parameter( "aggregate" ) << Parameter( "expression" ) << Parameter( "concatenator", true ),
-                           fcnAggregateRelation, "Aggregates", QString(), False, QStringList( QgsFeatureRequest::AllAttributes ), true )
+                           fcnAggregateRelation, "Aggregates", QString(), False, QSet<QString>() << QgsFeatureRequest::AllAttributes, true )
 
-    << new StaticFunction( "count", aggParams, fcnAggregateCount, "Aggregates", QString(), False, QStringList(), true )
-    << new StaticFunction( "count_distinct", aggParams, fcnAggregateCountDistinct, "Aggregates", QString(), False, QStringList(), true )
-    << new StaticFunction( "count_missing", aggParams, fcnAggregateCountMissing, "Aggregates", QString(), False, QStringList(), true )
-    << new StaticFunction( "minimum", aggParams, fcnAggregateMin, "Aggregates", QString(), False, QStringList(), true )
-    << new StaticFunction( "maximum", aggParams, fcnAggregateMax, "Aggregates", QString(), False, QStringList(), true )
-    << new StaticFunction( "sum", aggParams, fcnAggregateSum, "Aggregates", QString(), False, QStringList(), true )
-    << new StaticFunction( "mean", aggParams, fcnAggregateMean, "Aggregates", QString(), False, QStringList(), true )
-    << new StaticFunction( "median", aggParams, fcnAggregateMedian, "Aggregates", QString(), False, QStringList(), true )
-    << new StaticFunction( "stdev", aggParams, fcnAggregateStdev, "Aggregates", QString(), False, QStringList(), true )
-    << new StaticFunction( "range", aggParams, fcnAggregateRange, "Aggregates", QString(), False, QStringList(), true )
-    << new StaticFunction( "minority", aggParams, fcnAggregateMinority, "Aggregates", QString(), False, QStringList(), true )
-    << new StaticFunction( "majority", aggParams, fcnAggregateMajority, "Aggregates", QString(), False, QStringList(), true )
-    << new StaticFunction( "q1", aggParams, fcnAggregateQ1, "Aggregates", QString(), False, QStringList(), true )
-    << new StaticFunction( "q3", aggParams, fcnAggregateQ3, "Aggregates", QString(), False, QStringList(), true )
-    << new StaticFunction( "iqr", aggParams, fcnAggregateIQR, "Aggregates", QString(), False, QStringList(), true )
-    << new StaticFunction( "min_length", aggParams, fcnAggregateMinLength, "Aggregates", QString(), False, QStringList(), true )
-    << new StaticFunction( "max_length", aggParams, fcnAggregateMaxLength, "Aggregates", QString(), False, QStringList(), true )
-    << new StaticFunction( "collect", aggParams, fcnAggregateCollectGeometry, "Aggregates", QString(), False, QStringList(), true )
-    << new StaticFunction( "concatenate", aggParams << Parameter( "concatenator", true ), fcnAggregateStringConcat, "Aggregates", QString(), False, QStringList(), true )
+    << new StaticFunction( "count", aggParams, fcnAggregateCount, "Aggregates", QString(), False, QSet<QString>(), true )
+    << new StaticFunction( "count_distinct", aggParams, fcnAggregateCountDistinct, "Aggregates", QString(), False, QSet<QString>(), true )
+    << new StaticFunction( "count_missing", aggParams, fcnAggregateCountMissing, "Aggregates", QString(), False, QSet<QString>(), true )
+    << new StaticFunction( "minimum", aggParams, fcnAggregateMin, "Aggregates", QString(), False, QSet<QString>(), true )
+    << new StaticFunction( "maximum", aggParams, fcnAggregateMax, "Aggregates", QString(), False, QSet<QString>(), true )
+    << new StaticFunction( "sum", aggParams, fcnAggregateSum, "Aggregates", QString(), False, QSet<QString>(), true )
+    << new StaticFunction( "mean", aggParams, fcnAggregateMean, "Aggregates", QString(), False, QSet<QString>(), true )
+    << new StaticFunction( "median", aggParams, fcnAggregateMedian, "Aggregates", QString(), False, QSet<QString>(), true )
+    << new StaticFunction( "stdev", aggParams, fcnAggregateStdev, "Aggregates", QString(), False, QSet<QString>(), true )
+    << new StaticFunction( "range", aggParams, fcnAggregateRange, "Aggregates", QString(), False, QSet<QString>(), true )
+    << new StaticFunction( "minority", aggParams, fcnAggregateMinority, "Aggregates", QString(), False, QSet<QString>(), true )
+    << new StaticFunction( "majority", aggParams, fcnAggregateMajority, "Aggregates", QString(), False, QSet<QString>(), true )
+    << new StaticFunction( "q1", aggParams, fcnAggregateQ1, "Aggregates", QString(), False, QSet<QString>(), true )
+    << new StaticFunction( "q3", aggParams, fcnAggregateQ3, "Aggregates", QString(), False, QSet<QString>(), true )
+    << new StaticFunction( "iqr", aggParams, fcnAggregateIQR, "Aggregates", QString(), False, QSet<QString>(), true )
+    << new StaticFunction( "min_length", aggParams, fcnAggregateMinLength, "Aggregates", QString(), False, QSet<QString>(), true )
+    << new StaticFunction( "max_length", aggParams, fcnAggregateMaxLength, "Aggregates", QString(), False, QSet<QString>(), true )
+    << new StaticFunction( "collect", aggParams, fcnAggregateCollectGeometry, "Aggregates", QString(), False, QSet<QString>(), true )
+    << new StaticFunction( "concatenate", aggParams << Parameter( "concatenator", true ), fcnAggregateStringConcat, "Aggregates", QString(), False, QSet<QString>(), true )
 
     << new StaticFunction( "regexp_match", 2, fcnRegexpMatch, "Conditionals" )
-    << new StaticFunction( "now", 0, fcnNow, "Date and Time", QString(), false, QStringList(), false, QStringList() << "$now" )
+    << new StaticFunction( "now", 0, fcnNow, "Date and Time", QString(), false, QSet<QString>(), false, QStringList() << "$now" )
     << new StaticFunction( "age", 2, fcnAge, "Date and Time" )
     << new StaticFunction( "year", 1, fcnYear, "Date and Time" )
     << new StaticFunction( "month", 1, fcnMonth, "Date and Time" )
@@ -3488,7 +3488,7 @@ const QList<QgsExpression::Function*>& QgsExpression::Functions()
     << new StaticFunction( "regexp_replace", 3, fcnRegexpReplace, "String" )
     << new StaticFunction( "regexp_substr", 2, fcnRegexpSubstr, "String" )
     << new StaticFunction( "substr", 3, fcnSubstr, "String" )
-    << new StaticFunction( "concat", -1, fcnConcat, "String", QString(), false, QStringList(), false, QStringList(), true )
+    << new StaticFunction( "concat", -1, fcnConcat, "String", QString(), false, QSet<QString>(), false, QStringList(), true )
     << new StaticFunction( "strpos", 2, fcnStrpos, "String" )
     << new StaticFunction( "left", 2, fcnLeft, "String" )
     << new StaticFunction( "right", 2, fcnRight, "String" )
@@ -3531,16 +3531,16 @@ const QList<QgsExpression::Function*>& QgsExpression::Functions()
     << new StaticFunction( "make_point_m", 3, fcnMakePointM, "GeometryGroup" )
     << new StaticFunction( "make_line", -1, fcnMakeLine, "GeometryGroup" )
     << new StaticFunction( "make_polygon", -1, fcnMakePolygon, "GeometryGroup" )
-    << new StaticFunction( "$x_at", 1, fcnXat, "GeometryGroup", QString(), true, QStringList(), false, QStringList() << "xat" << "x_at" )
-    << new StaticFunction( "$y_at", 1, fcnYat, "GeometryGroup", QString(), true, QStringList(), false, QStringList() << "yat" << "y_at" )
-    << new StaticFunction( "x_min", 1, fcnXMin, "GeometryGroup", QString(), false, QStringList(), false, QStringList() << "xmin" )
-    << new StaticFunction( "x_max", 1, fcnXMax, "GeometryGroup", QString(), false, QStringList(), false, QStringList() << "xmax" )
-    << new StaticFunction( "y_min", 1, fcnYMin, "GeometryGroup", QString(), false, QStringList(), false, QStringList() << "ymin" )
-    << new StaticFunction( "y_max", 1, fcnYMax, "GeometryGroup", QString(), false, QStringList(), false, QStringList() << "ymax" )
-    << new StaticFunction( "geom_from_wkt", 1, fcnGeomFromWKT, "GeometryGroup", QString(), false, QStringList(), false, QStringList() << "geomFromWKT" )
-    << new StaticFunction( "geom_from_gml", 1, fcnGeomFromGML, "GeometryGroup", QString(), false, QStringList(), false, QStringList() << "geomFromGML" )
+    << new StaticFunction( "$x_at", 1, fcnXat, "GeometryGroup", QString(), true, QSet<QString>(), false, QStringList() << "xat" << "x_at" )
+    << new StaticFunction( "$y_at", 1, fcnYat, "GeometryGroup", QString(), true, QSet<QString>(), false, QStringList() << "yat" << "y_at" )
+    << new StaticFunction( "x_min", 1, fcnXMin, "GeometryGroup", QString(), false, QSet<QString>(), false, QStringList() << "xmin" )
+    << new StaticFunction( "x_max", 1, fcnXMax, "GeometryGroup", QString(), false, QSet<QString>(), false, QStringList() << "xmax" )
+    << new StaticFunction( "y_min", 1, fcnYMin, "GeometryGroup", QString(), false, QSet<QString>(), false, QStringList() << "ymin" )
+    << new StaticFunction( "y_max", 1, fcnYMax, "GeometryGroup", QString(), false, QSet<QString>(), false, QStringList() << "ymax" )
+    << new StaticFunction( "geom_from_wkt", 1, fcnGeomFromWKT, "GeometryGroup", QString(), false, QSet<QString>(), false, QStringList() << "geomFromWKT" )
+    << new StaticFunction( "geom_from_gml", 1, fcnGeomFromGML, "GeometryGroup", QString(), false, QSet<QString>(), false, QStringList() << "geomFromGML" )
     << new StaticFunction( "relate", -1, fcnRelate, "GeometryGroup" )
-    << new StaticFunction( "intersects_bbox", 2, fcnBbox, "GeometryGroup", QString(), false, QStringList(), false, QStringList() << "bbox" )
+    << new StaticFunction( "intersects_bbox", 2, fcnBbox, "GeometryGroup", QString(), false, QSet<QString>(), false, QStringList() << "bbox" )
     << new StaticFunction( "disjoint", 2, fcnDisjoint, "GeometryGroup" )
     << new StaticFunction( "intersects", 2, fcnIntersects, "GeometryGroup" )
     << new StaticFunction( "touches", 2, fcnTouches, "GeometryGroup" )
@@ -3584,14 +3584,14 @@ const QList<QgsExpression::Function*>& QgsExpression::Functions()
     << new StaticFunction( "bounds_width", 1, fcnBoundsWidth, "GeometryGroup" )
     << new StaticFunction( "bounds_height", 1, fcnBoundsHeight, "GeometryGroup" )
     << new StaticFunction( "is_closed", 1, fcnIsClosed, "GeometryGroup" )
-    << new StaticFunction( "convex_hull", 1, fcnConvexHull, "GeometryGroup", QString(), false, QStringList(), false, QStringList() << "convexHull" )
+    << new StaticFunction( "convex_hull", 1, fcnConvexHull, "GeometryGroup", QString(), false, QSet<QString>(), false, QStringList() << "convexHull" )
     << new StaticFunction( "difference", 2, fcnDifference, "GeometryGroup" )
     << new StaticFunction( "distance", 2, fcnDistance, "GeometryGroup" )
     << new StaticFunction( "intersection", 2, fcnIntersection, "GeometryGroup" )
-    << new StaticFunction( "sym_difference", 2, fcnSymDifference, "GeometryGroup", QString(), false, QStringList(), false, QStringList() << "symDifference" )
+    << new StaticFunction( "sym_difference", 2, fcnSymDifference, "GeometryGroup", QString(), false, QSet<QString>(), false, QStringList() << "symDifference" )
     << new StaticFunction( "combine", 2, fcnCombine, "GeometryGroup" )
     << new StaticFunction( "union", 2, fcnCombine, "GeometryGroup" )
-    << new StaticFunction( "geom_to_wkt", -1, fcnGeomToWKT, "GeometryGroup", QString(), false, QStringList(), false, QStringList() << "geomToWKT" )
+    << new StaticFunction( "geom_to_wkt", -1, fcnGeomToWKT, "GeometryGroup", QString(), false, QSet<QString>(), false, QStringList() << "geomToWKT" )
     << new StaticFunction( "geometry", 1, fcnGetGeometry, "GeometryGroup", QString(), true )
     << new StaticFunction( "transform", 3, fcnTransformGeometry, "GeometryGroup" )
     << new StaticFunction( "extrude", 3, fcnExtrude, "GeometryGroup", QString() )
@@ -3610,16 +3610,16 @@ const QList<QgsExpression::Function*>& QgsExpression::Functions()
                            << Parameter( "vertex" ), fcnDistanceToVertex, "GeometryGroup" )
     << new StaticFunction( "$id", 0, fcnFeatureId, "Record" )
     << new StaticFunction( "$currentfeature", 0, fcnFeature, "Record" )
-    << new StaticFunction( "uuid", 0, fcnUuid, "Record", QString(), false, QStringList(), false, QStringList() << "$uuid" )
-    << new StaticFunction( "get_feature", 3, fcnGetFeature, "Record", QString(), false, QStringList(), false, QStringList() << "getFeature" )
+    << new StaticFunction( "uuid", 0, fcnUuid, "Record", QString(), false, QSet<QString>(), false, QStringList() << "$uuid" )
+    << new StaticFunction( "get_feature", 3, fcnGetFeature, "Record", QString(), false, QSet<QString>(), false, QStringList() << "getFeature" )
     << new StaticFunction( "layer_property", 2, fcnGetLayerProperty, "General" )
     << new StaticFunction( "var", 1, fcnGetVariable, "General" )
 
     //return all attributes string for referencedColumns - this is caught by
     // QgsFeatureRequest::setSubsetOfAttributes and causes all attributes to be fetched by the
     // feature request
-    << new StaticFunction( "eval", 1, fcnEval, "General", QString(), true, QStringList( QgsFeatureRequest::AllAttributes ) )
-    << new StaticFunction( "attribute", 2, fcnAttribute, "Record", QString(), false, QStringList( QgsFeatureRequest::AllAttributes ) )
+    << new StaticFunction( "eval", 1, fcnEval, "General", QString(), true, QSet<QString>() << QgsFeatureRequest::AllAttributes )
+    << new StaticFunction( "attribute", 2, fcnAttribute, "Record", QString(), false, QSet<QString>() << QgsFeatureRequest::AllAttributes )
 
     // functions for arrays
     << new StaticFunction( "array", -1, fcnArray, "Arrays" )
@@ -3800,28 +3800,12 @@ bool QgsExpression::hasParserError() const { return !d->mParserErrorString.isNul
 
 QString QgsExpression::parserErrorString() const { return d->mParserErrorString; }
 
-QStringList QgsExpression::referencedColumns() const
+QSet<QString> QgsExpression::referencedColumns() const
 {
   if ( !d->mRootNode )
-    return QStringList();
+    return QSet<QString>();
 
-  QStringList columns = d->mRootNode->referencedColumns();
-
-  // filter out duplicates
-  for ( int i = 0; i < columns.count(); i++ )
-  {
-    QString col = columns.at( i );
-    for ( int j = i + 1; j < columns.count(); j++ )
-    {
-      if ( QString::compare( col, columns[j], Qt::CaseInsensitive ) == 0 )
-      {
-        // this column is repeated: remove it!
-        columns.removeAt( j-- );
-      }
-    }
-  }
-
-  return columns;
+  return d->mRootNode->referencedColumns();
 }
 
 bool QgsExpression::NodeInOperator::needsGeometry() const
@@ -3837,10 +3821,10 @@ QSet<int> QgsExpression::referencedAttributeIndexes( const QgsFields& fields ) c
   if ( !d->mRootNode )
     return QSet<int>();
 
-  QStringList referencedFields = d->mRootNode->referencedColumns();
+  const QSet<QString> referencedFields = d->mRootNode->referencedColumns();
   QSet<int> referencedIndexes;
 
-  Q_FOREACH ( const QString& fieldName, referencedFields )
+for ( const QString& fieldName : referencedFields )
   {
     if ( fieldName == QgsFeatureRequest::AllAttributes )
     {
@@ -4618,7 +4602,7 @@ QString QgsExpression::NodeBinaryOperator::dump() const
   return fmt.arg( mOpLeft->dump(), BinaryOperatorText[mOp], rdump );
 }
 
-QStringList QgsExpression::NodeBinaryOperator::referencedColumns() const
+QSet<QString> QgsExpression::NodeBinaryOperator::referencedColumns() const
 {
   return mOpLeft->referencedColumns() + mOpRight->referencedColumns();
 }
@@ -4626,11 +4610,6 @@ QStringList QgsExpression::NodeBinaryOperator::referencedColumns() const
 bool QgsExpression::NodeBinaryOperator::needsGeometry() const
 {
   return mOpLeft->needsGeometry() || mOpRight->needsGeometry();
-}
-
-void QgsExpression::NodeBinaryOperator::accept( QgsExpression::Visitor& v ) const
-{
-  v.visit( *this );
 }
 
 QgsExpression::Node* QgsExpression::NodeBinaryOperator::clone() const
@@ -4812,10 +4791,10 @@ QString QgsExpression::NodeFunction::dump() const
     return QString( "%1(%2)" ).arg( fd->name(), mArgs ? mArgs->dump() : QString() ); // function
 }
 
-QStringList QgsExpression::NodeFunction::referencedColumns() const
+QSet<QString> QgsExpression::NodeFunction::referencedColumns() const
 {
   Function* fd = Functions()[mFnIndex];
-  QStringList functionColumns = fd->referencedColumns();
+  QSet<QString> functionColumns = fd->referencedColumns();
 
   if ( !mArgs )
   {
@@ -4825,11 +4804,10 @@ QStringList QgsExpression::NodeFunction::referencedColumns() const
 
   Q_FOREACH ( Node* n, mArgs->list() )
   {
-    functionColumns.append( n->referencedColumns() );
+    functionColumns.unite( n->referencedColumns() );
   }
 
-  //remove duplicates and return
-  return functionColumns.toSet().toList();
+  return functionColumns;
 }
 
 bool QgsExpression::NodeFunction::needsGeometry() const
@@ -5078,9 +5056,9 @@ QString QgsExpression::NodeCondition::dump() const
   return msg;
 }
 
-QStringList QgsExpression::NodeCondition::referencedColumns() const
+QSet<QString> QgsExpression::NodeCondition::referencedColumns() const
 {
-  QStringList lst;
+  QSet<QString> lst;
   Q_FOREACH ( WhenThen* cond, mConditions )
   {
     lst += cond->mWhenExp->referencedColumns() + cond->mThenExp->referencedColumns();
@@ -5449,11 +5427,11 @@ const QgsExpression::Node* QgsExpression::rootNode() const
   return d->mRootNode;
 }
 
-QStringList QgsExpression::NodeInOperator::referencedColumns() const
+QSet<QString> QgsExpression::NodeInOperator::referencedColumns() const
 {
-  QStringList lst( mNode->referencedColumns() );
+  QSet<QString> lst( mNode->referencedColumns() );
   Q_FOREACH ( const Node* n, mList->list() )
-    lst.append( n->referencedColumns() );
+    lst.unite( n->referencedColumns() );
   return lst;
 }
 

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -3824,6 +3824,14 @@ QStringList QgsExpression::referencedColumns() const
   return columns;
 }
 
+bool QgsExpression::NodeInOperator::needsGeometry() const
+{
+  bool needs = false;
+  Q_FOREACH ( Node* n, mList->list() )
+    needs |= n->needsGeometry();
+  return needs;
+}
+
 QSet<int> QgsExpression::referencedAttributeIndexes( const QgsFields& fields ) const
 {
   if ( !d->mRootNode )
@@ -4055,6 +4063,13 @@ double QgsExpression::evaluateToDouble( const QString &text, const double fallba
 
 ///////////////////////////////////////////////
 // nodes
+
+void QgsExpression::NodeList::append( QgsExpression::NamedNode* node )
+{
+  mList.append( node->node );
+  mNameList.append( node->name.toLower() );
+  mHasNamedNodes = true;
+}
 
 QgsExpression::NodeList* QgsExpression::NodeList::clone() const
 {
@@ -4603,6 +4618,21 @@ QString QgsExpression::NodeBinaryOperator::dump() const
   return fmt.arg( mOpLeft->dump(), BinaryOperatorText[mOp], rdump );
 }
 
+QStringList QgsExpression::NodeBinaryOperator::referencedColumns() const
+{
+  return mOpLeft->referencedColumns() + mOpRight->referencedColumns();
+}
+
+bool QgsExpression::NodeBinaryOperator::needsGeometry() const
+{
+  return mOpLeft->needsGeometry() || mOpRight->needsGeometry();
+}
+
+void QgsExpression::NodeBinaryOperator::accept( QgsExpression::Visitor& v ) const
+{
+  v.visit( *this );
+}
+
 QgsExpression::Node* QgsExpression::NodeBinaryOperator::clone() const
 {
   return new NodeBinaryOperator( mOp, mOpLeft->clone(), mOpRight->clone() );
@@ -4718,6 +4748,46 @@ QVariant QgsExpression::NodeFunction::eval( QgsExpression *parent, const QgsExpr
   return res;
 }
 
+QgsExpression::NodeFunction::NodeFunction( int fnIndex, QgsExpression::NodeList* args )
+    : mFnIndex( fnIndex )
+{
+  const ParameterList& functionParams = Functions()[mFnIndex]->parameters();
+  if ( !args || functionParams.isEmpty() )
+  {
+    // no parameters, or function does not support them
+    mArgs = args;
+  }
+  else
+  {
+    mArgs = new NodeList();
+
+    int idx = 0;
+    //first loop through unnamed arguments
+    while ( idx < args->names().size() && args->names().at( idx ).isEmpty() )
+    {
+      mArgs->append( args->list().at( idx )->clone() );
+      idx++;
+    }
+
+    //next copy named parameters in order expected by function
+    for ( ; idx < functionParams.count(); ++idx )
+    {
+      int nodeIdx = args->names().indexOf( functionParams.at( idx ).name().toLower() );
+      if ( nodeIdx < 0 )
+      {
+        //parameter not found - insert default value for parameter
+        mArgs->append( new NodeLiteral( functionParams.at( idx ).defaultValue() ) );
+      }
+      else
+      {
+        mArgs->append( args->list().at( nodeIdx )->clone() );
+      }
+    }
+
+    delete args;
+  }
+}
+
 bool QgsExpression::NodeFunction::prepare( QgsExpression *parent, const QgsExpressionContext *context )
 {
   Function* fd = Functions()[mFnIndex];
@@ -4762,9 +4832,93 @@ QStringList QgsExpression::NodeFunction::referencedColumns() const
   return functionColumns.toSet().toList();
 }
 
+bool QgsExpression::NodeFunction::needsGeometry() const
+{
+  bool needs = Functions()[mFnIndex]->usesGeometry();
+  if ( mArgs )
+  {
+    Q_FOREACH ( Node* n, mArgs->list() )
+      needs |= n->needsGeometry();
+  }
+  return needs;
+}
+
 QgsExpression::Node* QgsExpression::NodeFunction::clone() const
 {
   return new NodeFunction( mFnIndex, mArgs ? mArgs->clone() : nullptr );
+}
+
+bool QgsExpression::NodeFunction::validateParams( int fnIndex, QgsExpression::NodeList* args, QString& error )
+{
+  if ( !args || !args->hasNamedNodes() )
+    return true;
+
+  const ParameterList& functionParams = Functions()[fnIndex]->parameters();
+  if ( functionParams.isEmpty() )
+  {
+    error = QString( "%1 does not supported named parameters" ).arg( Functions()[fnIndex]->name() );
+    return false;
+  }
+  else
+  {
+    QSet< int > providedArgs;
+    QSet< int > handledArgs;
+    int idx = 0;
+    //first loop through unnamed arguments
+    while ( args->names().at( idx ).isEmpty() )
+    {
+      providedArgs << idx;
+      handledArgs << idx;
+      idx++;
+    }
+
+    //next check named parameters
+    for ( ; idx < functionParams.count(); ++idx )
+    {
+      int nodeIdx = args->names().indexOf( functionParams.at( idx ).name().toLower() );
+      if ( nodeIdx < 0 )
+      {
+        if ( !functionParams.at( idx ).optional() )
+        {
+          error = QString( "No value specified for parameter '%1' for %2" ).arg( functionParams.at( idx ).name(), Functions()[fnIndex]->name() );
+          return false;
+        }
+      }
+      else
+      {
+        if ( providedArgs.contains( idx ) )
+        {
+          error = QString( "Duplicate parameter specified for '%1' for %2" ).arg( functionParams.at( idx ).name(), Functions()[fnIndex]->name() );
+          return false;
+        }
+      }
+      providedArgs << idx;
+      handledArgs << nodeIdx;
+    }
+
+    //last check for bad names
+    idx = 0;
+    Q_FOREACH ( const QString& name, args->names() )
+    {
+      if ( !name.isEmpty() && !functionParams.contains( name ) )
+      {
+        error = QString( "Invalid parameter name '%1' for %2" ).arg( name, Functions()[fnIndex]->name() );
+        return false;
+      }
+      if ( !name.isEmpty() && !handledArgs.contains( idx ) )
+      {
+        int functionIdx = functionParams.indexOf( name );
+        if ( providedArgs.contains( functionIdx ) )
+        {
+          error = QString( "Duplicate parameter specified for '%1' for %2" ).arg( functionParams.at( functionIdx ).name(), Functions()[fnIndex]->name() );
+          return false;
+        }
+      }
+      idx++;
+    }
+
+  }
+  return true;
 }
 
 //
@@ -5293,4 +5447,20 @@ QString QgsExpression::formatPreviewString( const QVariant& value )
 const QgsExpression::Node* QgsExpression::rootNode() const
 {
   return d->mRootNode;
+}
+
+QStringList QgsExpression::NodeInOperator::referencedColumns() const
+{
+  QStringList lst( mNode->referencedColumns() );
+  Q_FOREACH ( const Node* n, mList->list() )
+    lst.append( n->referencedColumns() );
+  return lst;
+}
+
+bool QgsExpression::Function::operator==( const QgsExpression::Function& other ) const
+{
+  if ( QString::compare( mName, other.mName, Qt::CaseInsensitive ) == 0 )
+    return true;
+
+  return false;
 }

--- a/src/core/qgsexpression.h
+++ b/src/core/qgsexpression.h
@@ -183,7 +183,7 @@ class CORE_EXPORT QgsExpression
      *
      * TODO QGIS3: Return QSet<QString>
      */
-    QStringList referencedColumns() const;
+    QSet<QString> referencedColumns() const;
 
     /**
      * Return a list of field name indexes obtained from the provided fields.
@@ -451,7 +451,7 @@ class CORE_EXPORT QgsExpression
                   const QString& group,
                   const QString& helpText = QString(),
                   bool usesGeometry = false,
-                  const QStringList& referencedColumns = QStringList(),
+                  const QSet<QString>& referencedColumns = QSet<QString>(),
                   bool lazyEval = false,
                   bool handlesNull = false,
                   bool isContextual = false )
@@ -475,7 +475,7 @@ class CORE_EXPORT QgsExpression
                   const QString& group,
                   const QString& helpText = QString(),
                   bool usesGeometry = false,
-                  const QStringList& referencedColumns = QStringList(),
+                  const QSet<QString>& referencedColumns = QSet<QString>(),
                   bool lazyEval = false,
                   bool handlesNull = false,
                   bool isContextual = false )
@@ -534,7 +534,7 @@ class CORE_EXPORT QgsExpression
          * Functions are non lazy default and will be given the node return value when called **/
         bool lazyEval() const { return mLazyEval; }
 
-        virtual QStringList referencedColumns() const { return mReferencedColumns; }
+        virtual QSet<QString> referencedColumns() const { return mReferencedColumns; }
 
         /** Returns whether the function is only available if provided by a QgsExpressionContext object.
          * @note added in QGIS 2.12
@@ -566,7 +566,7 @@ class CORE_EXPORT QgsExpression
         bool mUsesGeometry;
         QString mGroup;
         QString mHelpText;
-        QStringList mReferencedColumns;
+        QSet<QString> mReferencedColumns;
         bool mLazyEval;
         bool mHandlesNull;
         bool mIsContextual; //if true function is only available through an expression context
@@ -588,7 +588,7 @@ class CORE_EXPORT QgsExpression
                         const QString& group,
                         const QString& helpText = QString(),
                         bool usesGeometry = false,
-                        const QStringList& referencedColumns = QStringList(),
+                        const QSet<QString>& referencedColumns = QSet<QString>(),
                         bool lazyEval = false,
                         const QStringList& aliases = QStringList(),
                         bool handlesNull = false )
@@ -605,7 +605,7 @@ class CORE_EXPORT QgsExpression
                         const QString& group,
                         const QString& helpText = QString(),
                         bool usesGeometry = false,
-                        const QStringList& referencedColumns = QStringList(),
+                        const QSet<QString>& referencedColumns = QSet<QString>(),
                         bool lazyEval = false,
                         const QStringList& aliases = QStringList(),
                         bool handlesNull = false )
@@ -775,7 +775,7 @@ class CORE_EXPORT QgsExpression
          *
          * @return A list of columns required to evaluate this expression
          */
-        virtual QStringList referencedColumns() const = 0;
+        virtual QSet<QString> referencedColumns() const = 0;
 
         /**
          * Abstract virtual method which returns if the geometry is required to evaluate
@@ -873,7 +873,7 @@ class CORE_EXPORT QgsExpression
         virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context ) override;
         virtual QString dump() const override;
 
-        virtual QStringList referencedColumns() const override { return mOperand->referencedColumns(); }
+        virtual QSet<QString> referencedColumns() const override { return mOperand->referencedColumns(); }
         virtual bool needsGeometry() const override { return mOperand->needsGeometry(); }
         virtual Node* clone() const override;
 
@@ -903,7 +903,7 @@ class CORE_EXPORT QgsExpression
         virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context ) override;
         virtual QString dump() const override;
 
-        virtual QStringList referencedColumns() const override;
+        virtual QSet<QString> referencedColumns() const override;
         virtual bool needsGeometry() const override;
         virtual Node* clone() const override;
 
@@ -947,7 +947,7 @@ class CORE_EXPORT QgsExpression
         virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context ) override;
         virtual QString dump() const override;
 
-        virtual QStringList referencedColumns() const override;
+        virtual QSet<QString> referencedColumns() const override;
         virtual bool needsGeometry() const override;
         virtual Node* clone() const override;
 
@@ -974,7 +974,7 @@ class CORE_EXPORT QgsExpression
         virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context ) override;
         virtual QString dump() const override;
 
-        virtual QStringList referencedColumns() const override;
+        virtual QSet<QString> referencedColumns() const override;
         virtual bool needsGeometry() const override;
         virtual Node* clone() const override;
 
@@ -1004,7 +1004,7 @@ class CORE_EXPORT QgsExpression
         virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context ) override;
         virtual QString dump() const override;
 
-        virtual QStringList referencedColumns() const override { return QStringList(); }
+        virtual QSet<QString> referencedColumns() const override { return QSet<QString>(); }
         virtual bool needsGeometry() const override { return false; }
         virtual Node* clone() const override;
 
@@ -1030,7 +1030,7 @@ class CORE_EXPORT QgsExpression
         virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context ) override;
         virtual QString dump() const override;
 
-        virtual QStringList referencedColumns() const override { return QStringList( mName ); }
+        virtual QSet<QString> referencedColumns() const override { return QSet<QString>() << mName; }
         virtual bool needsGeometry() const override { return false; }
 
         virtual Node* clone() const override;
@@ -1081,7 +1081,7 @@ class CORE_EXPORT QgsExpression
         virtual bool prepare( QgsExpression* parent, const QgsExpressionContext* context ) override;
         virtual QString dump() const override;
 
-        virtual QStringList referencedColumns() const override;
+        virtual QSet<QString> referencedColumns() const override;
         virtual bool needsGeometry() const override;
         virtual Node* clone() const override;
 

--- a/src/core/qgsexpression.h
+++ b/src/core/qgsexpression.h
@@ -555,13 +555,7 @@ class CORE_EXPORT QgsExpression
          */
         virtual QVariant func( const QVariantList& values, const QgsExpressionContext* context, QgsExpression* parent ) = 0;
 
-        bool operator==( const Function& other ) const
-        {
-          if ( QString::compare( mName, other.mName, Qt::CaseInsensitive ) == 0 )
-            return true;
-
-          return false;
-        }
+        bool operator==( const Function& other ) const;
 
         virtual bool handlesNull() const { return mHandlesNull; }
 
@@ -830,7 +824,7 @@ class CORE_EXPORT QgsExpression
         /** Adds a named node. Takes ownership of the provided node.
          * @note added in QGIS 2.16
         */
-        void append( NamedNode* node ) { mList.append( node->node ); mNameList.append( node->name.toLower() ); mHasNamedNodes = true; }
+        void append( NamedNode* node );
 
         /** Returns the number of nodes in the list.
          */
@@ -909,8 +903,8 @@ class CORE_EXPORT QgsExpression
         virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context ) override;
         virtual QString dump() const override;
 
-        virtual QStringList referencedColumns() const override { return mOpLeft->referencedColumns() + mOpRight->referencedColumns(); }
-        virtual bool needsGeometry() const override { return mOpLeft->needsGeometry() || mOpRight->needsGeometry(); }
+        virtual QStringList referencedColumns() const override;
+        virtual bool needsGeometry() const override;
         virtual Node* clone() const override;
 
         int precedence() const;
@@ -953,8 +947,8 @@ class CORE_EXPORT QgsExpression
         virtual QVariant eval( QgsExpression* parent, const QgsExpressionContext* context ) override;
         virtual QString dump() const override;
 
-        virtual QStringList referencedColumns() const override { QStringList lst( mNode->referencedColumns() ); Q_FOREACH ( const Node* n, mList->list() ) lst.append( n->referencedColumns() ); return lst; }
-        virtual bool needsGeometry() const override { bool needs = false; Q_FOREACH ( Node* n, mList->list() ) needs |= n->needsGeometry(); return needs; }
+        virtual QStringList referencedColumns() const override;
+        virtual bool needsGeometry() const override;
         virtual Node* clone() const override;
 
       protected:
@@ -968,44 +962,7 @@ class CORE_EXPORT QgsExpression
     class CORE_EXPORT NodeFunction : public Node
     {
       public:
-        NodeFunction( int fnIndex, NodeList* args ) : mFnIndex( fnIndex )
-        {
-          const ParameterList& functionParams = Functions()[mFnIndex]->parameters();
-          if ( !args || functionParams.isEmpty() )
-          {
-            // no parameters, or function does not support them
-            mArgs = args;
-          }
-          else
-          {
-            mArgs = new NodeList();
-
-            int idx = 0;
-            //first loop through unnamed arguments
-            while ( idx < args->names().size() && args->names().at( idx ).isEmpty() )
-            {
-              mArgs->append( args->list().at( idx )->clone() );
-              idx++;
-            }
-
-            //next copy named parameters in order expected by function
-            for ( ; idx < functionParams.count(); ++idx )
-            {
-              int nodeIdx = args->names().indexOf( functionParams.at( idx ).name().toLower() );
-              if ( nodeIdx < 0 )
-              {
-                //parameter not found - insert default value for parameter
-                mArgs->append( new NodeLiteral( functionParams.at( idx ).defaultValue() ) );
-              }
-              else
-              {
-                mArgs->append( args->list().at( nodeIdx )->clone() );
-              }
-            }
-
-            delete args;
-          }
-        }
+        NodeFunction( int fnIndex, NodeList* args );
 
         virtual ~NodeFunction() { delete mArgs; }
 
@@ -1018,82 +975,11 @@ class CORE_EXPORT QgsExpression
         virtual QString dump() const override;
 
         virtual QStringList referencedColumns() const override;
-        virtual bool needsGeometry() const override { bool needs = Functions()[mFnIndex]->usesGeometry(); if ( mArgs ) { Q_FOREACH ( Node* n, mArgs->list() ) needs |= n->needsGeometry(); } return needs; }
+        virtual bool needsGeometry() const override;
         virtual Node* clone() const override;
 
         //! Tests whether the provided argument list is valid for the matching function
-        static bool validateParams( int fnIndex, NodeList* args, QString& error )
-        {
-          if ( !args || !args->hasNamedNodes() )
-            return true;
-
-          const ParameterList& functionParams = Functions()[fnIndex]->parameters();
-          if ( functionParams.isEmpty() )
-          {
-            error = QString( "%1 does not supported named parameters" ).arg( Functions()[fnIndex]->name() );
-            return false;
-          }
-          else
-          {
-            QSet< int > providedArgs;
-            QSet< int > handledArgs;
-            int idx = 0;
-            //first loop through unnamed arguments
-            while ( args->names().at( idx ).isEmpty() )
-            {
-              providedArgs << idx;
-              handledArgs << idx;
-              idx++;
-            }
-
-            //next check named parameters
-            for ( ; idx < functionParams.count(); ++idx )
-            {
-              int nodeIdx = args->names().indexOf( functionParams.at( idx ).name().toLower() );
-              if ( nodeIdx < 0 )
-              {
-                if ( !functionParams.at( idx ).optional() )
-                {
-                  error = QString( "No value specified for parameter '%1' for %2" ).arg( functionParams.at( idx ).name(), Functions()[fnIndex]->name() );
-                  return false;
-                }
-              }
-              else
-              {
-                if ( providedArgs.contains( idx ) )
-                {
-                  error = QString( "Duplicate parameter specified for '%1' for %2" ).arg( functionParams.at( idx ).name(), Functions()[fnIndex]->name() );
-                  return false;
-                }
-              }
-              providedArgs << idx;
-              handledArgs << nodeIdx;
-            }
-
-            //last check for bad names
-            idx = 0;
-            Q_FOREACH ( const QString& name, args->names() )
-            {
-              if ( !name.isEmpty() && !functionParams.contains( name ) )
-              {
-                error = QString( "Invalid parameter name '%1' for %2" ).arg( name, Functions()[fnIndex]->name() );
-                return false;
-              }
-              if ( !name.isEmpty() && !handledArgs.contains( idx ) )
-              {
-                int functionIdx = functionParams.indexOf( name );
-                if ( providedArgs.contains( functionIdx ) )
-                {
-                  error = QString( "Duplicate parameter specified for '%1' for %2" ).arg( functionParams.at( functionIdx ).name(), Functions()[fnIndex]->name() );
-                  return false;
-                }
-              }
-              idx++;
-            }
-
-          }
-          return true;
-        }
+        static bool validateParams( int fnIndex, NodeList* args, QString& error );
 
       protected:
         int mFnIndex;
@@ -1332,6 +1218,8 @@ class CORE_EXPORT QgsExpression
 
     friend class QgsOgcUtils;
 };
+
+
 
 Q_DECLARE_METATYPE( QgsExpression::Node* )
 

--- a/src/core/qgsexpressioncontext.h
+++ b/src/core/qgsexpressioncontext.h
@@ -41,12 +41,17 @@ class QgsSymbol;
 class CORE_EXPORT QgsScopedExpressionFunction : public QgsExpression::Function
 {
   public:
+    /**
+     * Create a new QgsScopedExpressionFunction
+     *
+     * @note Added in QGIS 2.12
+     */
     QgsScopedExpressionFunction( const QString& fnname,
                                  int params,
                                  const QString& group,
                                  const QString& helpText = QString(),
                                  bool usesGeometry = false,
-                                 const QStringList& referencedColumns = QStringList(),
+                                 const QSet<QString>& referencedColumns = QSet<QString>(),
                                  bool lazyEval = false,
                                  bool handlesNull = false,
                                  bool isContextual = true )

--- a/src/core/qgsfeaturerequest.cpp
+++ b/src/core/qgsfeaturerequest.cpp
@@ -216,6 +216,27 @@ QgsFeatureRequest& QgsFeatureRequest::setSubsetOfAttributes( const QStringList& 
   return *this;
 }
 
+QgsFeatureRequest& QgsFeatureRequest::setSubsetOfAttributes( const QSet<QString>& attrNames, const QgsFields& fields )
+{
+  if ( attrNames.contains( QgsFeatureRequest::AllAttributes ) )
+  {
+    //attribute string list contains the all attributes flag, so we must fetch all attributes
+    return *this;
+  }
+
+  mFlags |= SubsetOfAttributes;
+  mAttrs.clear();
+
+  Q_FOREACH ( const QString& attrName, attrNames )
+  {
+    int attrNum = fields.lookupField( attrName );
+    if ( attrNum != -1 && !mAttrs.contains( attrNum ) )
+      mAttrs.append( attrNum );
+  }
+
+  return *this;
+}
+
 QgsFeatureRequest& QgsFeatureRequest::setSimplifyMethod( const QgsSimplifyMethod& simplifyMethod )
 {
   mSimplifyMethod = simplifyMethod;
@@ -387,7 +408,7 @@ QSet<QString> QgsFeatureRequest::OrderBy::usedAttributes() const
   {
     const OrderByClause& clause = *it;
 
-    usedAttributes.unite( clause.expression().referencedColumns().toSet() );
+    usedAttributes.unite( clause.expression().referencedColumns() );
   }
 
   return usedAttributes;

--- a/src/core/qgsfeaturerequest.h
+++ b/src/core/qgsfeaturerequest.h
@@ -377,6 +377,9 @@ class CORE_EXPORT QgsFeatureRequest
     //! Set a subset of attributes by names that will be fetched
     QgsFeatureRequest& setSubsetOfAttributes( const QStringList& attrNames, const QgsFields& fields );
 
+    //! Set a subset of attributes by names that will be fetched
+    QgsFeatureRequest& setSubsetOfAttributes( const QSet<QString>& attrNames, const QgsFields& fields );
+
     //! Set a simplification method for geometries that will be fetched
     //! @note added in 2.2
     QgsFeatureRequest& setSimplifyMethod( const QgsSimplifyMethod& simplifyMethod );

--- a/src/core/qgspallabeling.cpp
+++ b/src/core/qgspallabeling.cpp
@@ -3946,7 +3946,7 @@ void QgsPalLabeling::clearActiveLayer( const QString &layerID )
 }
 
 
-int QgsPalLabeling::prepareLayer( QgsVectorLayer* layer, QStringList& attrNames, QgsRenderContext& ctx )
+int QgsPalLabeling::prepareLayer( QgsVectorLayer* layer, QSet<QString>& attrNames, QgsRenderContext& ctx )
 {
   if ( !willUseLayer( layer ) )
   {
@@ -3974,7 +3974,7 @@ int QgsPalLabeling::prepareLayer( QgsVectorLayer* layer, QStringList& attrNames,
   return 1; // init successful
 }
 
-int QgsPalLabeling::prepareDiagramLayer( QgsVectorLayer* layer, QStringList& attrNames, QgsRenderContext& ctx )
+int QgsPalLabeling::prepareDiagramLayer( QgsVectorLayer* layer, QSet<QString>& attrNames, QgsRenderContext& ctx )
 {
   QgsVectorLayerDiagramProvider* dp = new QgsVectorLayerDiagramProvider( layer, false );
   // need to be added before calling prepare() - uses map settings from engine

--- a/src/core/qgspallabeling.h
+++ b/src/core/qgspallabeling.h
@@ -135,11 +135,11 @@ class CORE_EXPORT QgsLabelingEngineInterface
     //! clears data defined objects from PAL layer settings for a registered layer
     virtual void clearActiveLayer( const QString& layerID ) = 0;
     //! called when starting rendering of a layer
-    virtual int prepareLayer( QgsVectorLayer* layer, QStringList& attrNames, QgsRenderContext& ctx ) = 0;
+    virtual int prepareLayer( QgsVectorLayer* layer, QSet<QString>& attrNames, QgsRenderContext& ctx ) = 0;
 
     //! adds a diagram layer to the labeling engine
     //! @note added in QGIS 2.12
-    virtual int prepareDiagramLayer( QgsVectorLayer *layer, QStringList &attrNames, QgsRenderContext &ctx )
+    virtual int prepareDiagramLayer( QgsVectorLayer *layer, QSet<QString>& attrNames, QgsRenderContext &ctx )
     { Q_UNUSED( layer ); Q_UNUSED( attrNames ); Q_UNUSED( ctx ); return 0; }
 
     //! called for every feature
@@ -1037,10 +1037,10 @@ class CORE_EXPORT QgsPalLabeling : public QgsLabelingEngineInterface
     //! clears data defined objects from PAL layer settings for a registered layer
     virtual void clearActiveLayer( const QString& layerID ) override;
     //! hook called when drawing layer before issuing select()
-    virtual int prepareLayer( QgsVectorLayer* layer, QStringList &attrNames, QgsRenderContext& ctx ) override;
+    virtual int prepareLayer( QgsVectorLayer* layer, QSet<QString>& attrNames, QgsRenderContext& ctx ) override;
     //! adds a diagram layer to the labeling engine
     //! @note added in QGIS 2.12
-    virtual int prepareDiagramLayer( QgsVectorLayer* layer, QStringList& attrNames, QgsRenderContext& ctx ) override;
+    virtual int prepareDiagramLayer( QgsVectorLayer* layer, QSet<QString>& attrNames, QgsRenderContext& ctx ) override;
 
     /** Register a feature for labelling.
      * @param layerID string identifying layer associated with label

--- a/src/core/qgsrulebasedlabeling.cpp
+++ b/src/core/qgsrulebasedlabeling.cpp
@@ -32,7 +32,7 @@ QgsVectorLayerLabelProvider *QgsRuleBasedLabelProvider::createProvider( QgsVecto
   return new QgsVectorLayerLabelProvider( layer, providerId, withFeatureLoop, settings );
 }
 
-bool QgsRuleBasedLabelProvider::prepare( const QgsRenderContext& context, QStringList& attributeNames )
+bool QgsRuleBasedLabelProvider::prepare( const QgsRenderContext& context, QSet<QString>& attributeNames )
 {
   Q_FOREACH ( QgsVectorLayerLabelProvider* provider, mSubProviders )
     provider->setEngine( mEngine );
@@ -264,7 +264,7 @@ void QgsRuleBasedLabeling::Rule::createSubProviders( QgsVectorLayer* layer, QgsR
   }
 }
 
-void QgsRuleBasedLabeling::Rule::prepare( const QgsRenderContext& context, QStringList& attributeNames, QgsRuleBasedLabeling::RuleToProviderMap& subProviders )
+void QgsRuleBasedLabeling::Rule::prepare( const QgsRenderContext& context, QSet<QString>& attributeNames, QgsRuleBasedLabeling::RuleToProviderMap& subProviders )
 {
   if ( mSettings )
   {
@@ -278,7 +278,7 @@ void QgsRuleBasedLabeling::Rule::prepare( const QgsRenderContext& context, QStri
 
   if ( mFilter )
   {
-    attributeNames << mFilter->referencedColumns();
+    attributeNames.unite( mFilter->referencedColumns() );
     mFilter->prepare( &context.expressionContext() );
   }
 

--- a/src/core/qgsrulebasedlabeling.h
+++ b/src/core/qgsrulebasedlabeling.h
@@ -238,7 +238,7 @@ class CORE_EXPORT QgsRuleBasedLabeling : public QgsAbstractVectorLayerLabeling
         void subProviderIds( QStringList& list ) const;
 
         //! call prepare() on sub-providers and populate attributeNames
-        void prepare( const QgsRenderContext& context, QStringList& attributeNames, RuleToProviderMap& subProviders );
+        void prepare( const QgsRenderContext& context, QSet<QString>& attributeNames, RuleToProviderMap& subProviders );
 
         //! register individual features
         RegisterResult registerFeature( QgsFeature& feature, QgsRenderContext& context, RuleToProviderMap& subProviders, QgsGeometry* obstacleGeometry = nullptr );
@@ -330,7 +330,7 @@ class CORE_EXPORT QgsRuleBasedLabelProvider : public QgsVectorLayerLabelProvider
 
     // reimplemented
 
-    virtual bool prepare( const QgsRenderContext& context, QStringList& attributeNames ) override;
+    virtual bool prepare( const QgsRenderContext& context, QSet<QString>& attributeNames ) override;
 
     virtual void registerFeature( QgsFeature& feature, QgsRenderContext& context, QgsGeometry* obstacleGeometry = nullptr ) override;
 

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -2863,13 +2863,13 @@ void QgsVectorFileWriter::addRendererAttributes( QgsVectorLayer* vl, QgsAttribut
   QgsFeatureRenderer* renderer = symbologyRenderer( vl );
   if ( renderer )
   {
-    QList<QString> rendererAttributes = renderer->usedAttributes();
-    for ( int i = 0; i < rendererAttributes.size(); ++i )
+    const QSet<QString> rendererAttributes = renderer->usedAttributes();
+  for ( const QString& attr : rendererAttributes )
     {
-      int index = vl->fields().lookupField( rendererAttributes.at( i ) );
+      int index = vl->fields().lookupField( attr );
       if ( index != -1 )
       {
-        attList.push_back( vl->fields().lookupField( rendererAttributes.at( i ) ) );
+        attList.append( index );
       }
     }
   }

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -3306,9 +3306,9 @@ QList<QVariant> QgsVectorLayer::getValues( const QString &fieldOrExpression, boo
   }
 
   QgsFeature f;
-  QStringList lst;
+  QSet<QString> lst;
   if ( expression.isNull() )
-    lst.append( fieldOrExpression );
+    lst.insert( fieldOrExpression );
   else
     lst = expression->referencedColumns();
 

--- a/src/core/qgsvectorlayerdiagramprovider.cpp
+++ b/src/core/qgsvectorlayerdiagramprovider.cpp
@@ -87,7 +87,7 @@ QList<QgsLabelFeature*> QgsVectorLayerDiagramProvider::labelFeatures( QgsRenderC
     return mFeatures;
   }
 
-  QStringList attributeNames;
+  QSet<QString> attributeNames;
   if ( !prepare( context, attributeNames ) )
     return QList<QgsLabelFeature*>();
 
@@ -155,7 +155,7 @@ void QgsVectorLayerDiagramProvider::drawLabel( QgsRenderContext& context, pal::L
 }
 
 
-bool QgsVectorLayerDiagramProvider::prepare( const QgsRenderContext& context, QStringList& attributeNames )
+bool QgsVectorLayerDiagramProvider::prepare( const QgsRenderContext& context, QSet<QString>& attributeNames )
 {
   QgsDiagramLayerSettings& s2 = mSettings;
   const QgsMapSettings& mapSettings = mEngine->mapSettings();
@@ -177,11 +177,7 @@ bool QgsVectorLayerDiagramProvider::prepare( const QgsRenderContext& context, QS
   s2.setRenderer( mDiagRenderer );
 
   //add attributes needed by the diagram renderer
-  Q_FOREACH ( const QString& field, s2.referencedFields( context.expressionContext(), mFields ) )
-  {
-    if ( !attributeNames.contains( field ) )
-      attributeNames << field;
-  }
+  attributeNames.unite( s2.referencedFields( context.expressionContext(), mFields ) );
 
   return true;
 }

--- a/src/core/qgsvectorlayerdiagramprovider.h
+++ b/src/core/qgsvectorlayerdiagramprovider.h
@@ -85,7 +85,7 @@ class CORE_EXPORT QgsVectorLayerDiagramProvider : public QgsAbstractLabelProvide
      * @param attributeNames list of attribute names to which additional required attributes shall be added
      * @return Whether the preparation was successful - if not, the provider shall not be used
      */
-    virtual bool prepare( const QgsRenderContext& context, QStringList& attributeNames );
+    virtual bool prepare( const QgsRenderContext& context, QSet<QString>& attributeNames );
 
     /**
      * Register a feature for labeling as one or more QgsLabelFeature objects stored into mFeatures

--- a/src/core/qgsvectorlayerlabelprovider.cpp
+++ b/src/core/qgsvectorlayerlabelprovider.cpp
@@ -128,7 +128,7 @@ QgsVectorLayerLabelProvider::~QgsVectorLayerLabelProvider()
 }
 
 
-bool QgsVectorLayerLabelProvider::prepare( const QgsRenderContext& context, QStringList& attributeNames )
+bool QgsVectorLayerLabelProvider::prepare( const QgsRenderContext& context, QSet<QString>& attributeNames )
 {
   QgsPalLayerSettings& lyr = mSettings;
   const QgsMapSettings& mapSettings = mEngine->mapSettings();
@@ -178,12 +178,12 @@ bool QgsVectorLayerLabelProvider::prepare( const QgsRenderContext& context, QStr
       Q_FOREACH ( const QString& name, exp->referencedColumns() )
       {
         QgsDebugMsgLevel( "REFERENCED COLUMN = " + name, 4 );
-        attributeNames.append( name );
+        attributeNames.insert( name );
       }
     }
     else
     {
-      attributeNames.append( lyr.fieldName );
+      attributeNames.insert( lyr.fieldName );
     }
 
     // add field indices of data defined expression or field
@@ -198,12 +198,12 @@ bool QgsVectorLayerLabelProvider::prepare( const QgsRenderContext& context, QStr
 
       // this will return columns for expressions or field name, depending upon what is set to be used
       // this also prepares any expressions, too
-      QStringList cols = dd->referencedColumns( context.expressionContext() );
+      QSet<QString> cols = dd->referencedColumns( context.expressionContext() );
 
       //QgsDebugMsgLevel( QString( "Data defined referenced columns:" ) + cols.join( "," ), 4 );
       Q_FOREACH ( const QString& name, cols )
       {
-        attributeNames.append( name );
+        attributeNames.insert( name );
       }
     }
   }
@@ -258,7 +258,7 @@ QList<QgsLabelFeature*> QgsVectorLayerLabelProvider::labelFeatures( QgsRenderCon
     return mLabels;
   }
 
-  QStringList attrNames;
+  QSet<QString> attrNames;
   if ( !prepare( ctx, attrNames ) )
     return QList<QgsLabelFeature*>();
 

--- a/src/core/qgsvectorlayerlabelprovider.h
+++ b/src/core/qgsvectorlayerlabelprovider.h
@@ -66,7 +66,7 @@ class CORE_EXPORT QgsVectorLayerLabelProvider : public QgsAbstractLabelProvider
      * @param attributeNames list of attribute names to which additional required attributes shall be added
      * @return Whether the preparation was successful - if not, the provider shall not be used
      */
-    virtual bool prepare( const QgsRenderContext& context, QStringList& attributeNames );
+    virtual bool prepare( const QgsRenderContext& context, QSet<QString>& attributeNames );
 
     /**
      * Register a feature for labeling as one or more QgsLabelFeature objects stored into mLabels

--- a/src/core/qgsvectorlayerrenderer.cpp
+++ b/src/core/qgsvectorlayerrenderer.cpp
@@ -534,7 +534,7 @@ void QgsVectorLayerRenderer::stopRenderer( QgsSingleSymbolRenderer* selRenderer 
 
 
 
-void QgsVectorLayerRenderer::prepareLabeling( QgsVectorLayer* layer, QStringList& attributeNames )
+void QgsVectorLayerRenderer::prepareLabeling( QgsVectorLayer* layer, QSet<QString>& attributeNames )
 {
   if ( !mContext.labelingEngine() )
   {
@@ -591,7 +591,7 @@ void QgsVectorLayerRenderer::prepareLabeling( QgsVectorLayer* layer, QStringList
   }
 }
 
-void QgsVectorLayerRenderer::prepareDiagrams( QgsVectorLayer* layer, QStringList& attributeNames )
+void QgsVectorLayerRenderer::prepareDiagrams( QgsVectorLayer* layer, QSet<QString>& attributeNames )
 {
   if ( !mContext.labelingEngine() )
   {

--- a/src/core/qgsvectorlayerrenderer.h
+++ b/src/core/qgsvectorlayerrenderer.h
@@ -82,8 +82,8 @@ class QgsVectorLayerRenderer : public QgsMapLayerRenderer
       @param layer diagram layer
       @param attributeNames attributes needed for labeling and diagrams will be added to the list
      */
-    void prepareLabeling( QgsVectorLayer* layer, QStringList& attributeNames );
-    void prepareDiagrams( QgsVectorLayer* layer, QStringList& attributeNames );
+    void prepareLabeling( QgsVectorLayer* layer, QSet<QString>& attributeNames );
+    void prepareDiagrams( QgsVectorLayer* layer, QSet<QString>& attributeNames );
 
     /** Draw layer with renderer V2. QgsFeatureRenderer::startRender() needs to be called before using this method
      */
@@ -122,7 +122,7 @@ class QgsVectorLayerRenderer : public QgsMapLayerRenderer
 
     QgsWkbTypes::GeometryType mGeometryType;
 
-    QStringList mAttrNames;
+    QSet<QString> mAttrNames;
 
     //! used with old labeling engine (QgsPalLabeling): whether labeling is enabled
     bool mLabeling;

--- a/src/core/symbology-ng/qgs25drenderer.cpp
+++ b/src/core/symbology-ng/qgs25drenderer.cpp
@@ -146,9 +146,9 @@ void Qgs25DRenderer::stopRender( QgsRenderContext& context )
   mSymbol->stopRender( context );
 }
 
-QList<QString> Qgs25DRenderer::usedAttributes()
+QSet<QString> Qgs25DRenderer::usedAttributes() const
 {
-  return mSymbol->usedAttributes().toList();
+  return mSymbol->usedAttributes();
 }
 
 QgsFeatureRenderer* Qgs25DRenderer::clone() const

--- a/src/core/symbology-ng/qgs25drenderer.h
+++ b/src/core/symbology-ng/qgs25drenderer.h
@@ -39,7 +39,7 @@ class CORE_EXPORT Qgs25DRenderer : public QgsFeatureRenderer
     void startRender( QgsRenderContext& context, const QgsFields& fields ) override;
     void stopRender( QgsRenderContext& context ) override;
 
-    QList<QString> usedAttributes() override;
+    QSet<QString> usedAttributes() const override;
     QgsFeatureRenderer* clone() const override;
 
     virtual QgsSymbol* symbolForFeature( QgsFeature& feature, QgsRenderContext& context ) override;

--- a/src/core/symbology-ng/qgscategorizedsymbolrenderer.cpp
+++ b/src/core/symbology-ng/qgscategorizedsymbolrenderer.cpp
@@ -430,7 +430,7 @@ void QgsCategorizedSymbolRenderer::stopRender( QgsRenderContext& context )
   mExpression.reset();
 }
 
-QList<QString> QgsCategorizedSymbolRenderer::usedAttributes()
+QSet<QString> QgsCategorizedSymbolRenderer::usedAttributes() const
 {
   QSet<QString> attributes;
 
@@ -442,7 +442,7 @@ QList<QString> QgsCategorizedSymbolRenderer::usedAttributes()
 
   QgsExpression testExpr( mAttrName );
   if ( !testExpr.hasParserError() )
-    attributes.unite( testExpr.referencedColumns().toSet() );
+    attributes.unite( testExpr.referencedColumns() );
 
   QgsCategoryList::const_iterator catIt = mCategories.constBegin();
   for ( ; catIt != mCategories.constEnd(); ++catIt )
@@ -453,7 +453,7 @@ QList<QString> QgsCategorizedSymbolRenderer::usedAttributes()
       attributes.unite( catSymbol->usedAttributes() );
     }
   }
-  return attributes.toList();
+  return attributes;
 }
 
 QString QgsCategorizedSymbolRenderer::dump() const

--- a/src/core/symbology-ng/qgscategorizedsymbolrenderer.h
+++ b/src/core/symbology-ng/qgscategorizedsymbolrenderer.h
@@ -86,7 +86,7 @@ class CORE_EXPORT QgsCategorizedSymbolRenderer : public QgsFeatureRenderer
     virtual QgsSymbol* originalSymbolForFeature( QgsFeature& feature, QgsRenderContext& context ) override;
     virtual void startRender( QgsRenderContext& context, const QgsFields& fields ) override;
     virtual void stopRender( QgsRenderContext& context ) override;
-    virtual QList<QString> usedAttributes() override;
+    virtual QSet<QString> usedAttributes() const override;
     virtual QString dump() const override;
     virtual QgsCategorizedSymbolRenderer* clone() const override;
     virtual void toSld( QDomDocument& doc, QDomElement &element, QgsStringMap props = QgsStringMap() ) const override;

--- a/src/core/symbology-ng/qgsgeometrygeneratorsymbollayer.cpp
+++ b/src/core/symbology-ng/qgsgeometrygeneratorsymbollayer.cpp
@@ -178,7 +178,7 @@ bool QgsGeometryGeneratorSymbolLayer::setSubSymbol( QgsSymbol* symbol )
 
 QSet<QString> QgsGeometryGeneratorSymbolLayer::usedAttributes() const
 {
-  return mSymbol->usedAttributes() + mExpression->referencedColumns().toSet();
+  return mSymbol->usedAttributes() + mExpression->referencedColumns();
 }
 
 bool QgsGeometryGeneratorSymbolLayer::isCompatibleWithSymbol( QgsSymbol* symbol ) const

--- a/src/core/symbology-ng/qgsgraduatedsymbolrenderer.cpp
+++ b/src/core/symbology-ng/qgsgraduatedsymbolrenderer.cpp
@@ -412,7 +412,7 @@ void QgsGraduatedSymbolRenderer::stopRender( QgsRenderContext& context )
   }
 }
 
-QList<QString> QgsGraduatedSymbolRenderer::usedAttributes()
+QSet<QString> QgsGraduatedSymbolRenderer::usedAttributes() const
 {
   QSet<QString> attributes;
 
@@ -424,7 +424,7 @@ QList<QString> QgsGraduatedSymbolRenderer::usedAttributes()
 
   QgsExpression testExpr( mAttrName );
   if ( !testExpr.hasParserError() )
-    attributes.unite( testExpr.referencedColumns().toSet() );
+    attributes.unite( testExpr.referencedColumns() );
 
   QgsRangeList::const_iterator range_it = mRanges.constBegin();
   for ( ; range_it != mRanges.constEnd(); ++range_it )
@@ -435,7 +435,7 @@ QList<QString> QgsGraduatedSymbolRenderer::usedAttributes()
       attributes.unite( symbol->usedAttributes() );
     }
   }
-  return attributes.toList();
+  return attributes;
 }
 
 bool QgsGraduatedSymbolRenderer::updateRangeSymbol( int rangeIndex, QgsSymbol* symbol )

--- a/src/core/symbology-ng/qgsgraduatedsymbolrenderer.h
+++ b/src/core/symbology-ng/qgsgraduatedsymbolrenderer.h
@@ -140,7 +140,7 @@ class CORE_EXPORT QgsGraduatedSymbolRenderer : public QgsFeatureRenderer
     virtual QgsSymbol* originalSymbolForFeature( QgsFeature& feature, QgsRenderContext &context ) override;
     virtual void startRender( QgsRenderContext& context, const QgsFields& fields ) override;
     virtual void stopRender( QgsRenderContext& context ) override;
-    virtual QList<QString> usedAttributes() override;
+    virtual QSet<QString> usedAttributes() const override;
     virtual QString dump() const override;
     virtual QgsGraduatedSymbolRenderer* clone() const override;
     virtual void toSld( QDomDocument& doc, QDomElement &element, QgsStringMap props = QgsStringMap() ) const override;

--- a/src/core/symbology-ng/qgsheatmaprenderer.cpp
+++ b/src/core/symbology-ng/qgsheatmaprenderer.cpp
@@ -384,7 +384,7 @@ QgsSymbolList QgsHeatmapRenderer::symbols( QgsRenderContext& )
   return QgsSymbolList();
 }
 
-QList<QString> QgsHeatmapRenderer::usedAttributes()
+QSet<QString> QgsHeatmapRenderer::usedAttributes() const
 {
   QSet<QString> attributes;
 
@@ -396,9 +396,9 @@ QList<QString> QgsHeatmapRenderer::usedAttributes()
 
   QgsExpression testExpr( mWeightExpressionString );
   if ( !testExpr.hasParserError() )
-    attributes.unite( testExpr.referencedColumns().toSet() );
+    attributes.unite( testExpr.referencedColumns() );
 
-  return attributes.toList();
+  return attributes;
 }
 
 QgsHeatmapRenderer* QgsHeatmapRenderer::convertFromRenderer( const QgsFeatureRenderer *renderer )

--- a/src/core/symbology-ng/qgsheatmaprenderer.h
+++ b/src/core/symbology-ng/qgsheatmaprenderer.h
@@ -46,7 +46,7 @@ class CORE_EXPORT QgsHeatmapRenderer : public QgsFeatureRenderer
     //! @note symbol2 in python bindings
     virtual QgsSymbolList symbols( QgsRenderContext &context ) override;
     virtual QString dump() const override;
-    virtual QList<QString> usedAttributes() override;
+    virtual QSet<QString> usedAttributes() const override;
     static QgsFeatureRenderer* create( QDomElement& element );
     virtual QDomElement save( QDomDocument& doc ) override;
     static QgsHeatmapRenderer* convertFromRenderer( const QgsFeatureRenderer* renderer );

--- a/src/core/symbology-ng/qgsinvertedpolygonrenderer.cpp
+++ b/src/core/symbology-ng/qgsinvertedpolygonrenderer.cpp
@@ -464,11 +464,11 @@ QgsFeatureRenderer::Capabilities QgsInvertedPolygonRenderer::capabilities()
   return mSubRenderer->capabilities();
 }
 
-QList<QString> QgsInvertedPolygonRenderer::usedAttributes()
+QSet<QString> QgsInvertedPolygonRenderer::usedAttributes() const
 {
   if ( !mSubRenderer )
   {
-    return QList<QString>();
+    return QSet<QString>();
   }
   return mSubRenderer->usedAttributes();
 }

--- a/src/core/symbology-ng/qgsinvertedpolygonrenderer.h
+++ b/src/core/symbology-ng/qgsinvertedpolygonrenderer.h
@@ -71,7 +71,7 @@ class CORE_EXPORT QgsInvertedPolygonRenderer : public QgsFeatureRenderer
     virtual QString dump() const override;
 
     /** Proxy that will call this method on the embedded renderer. */
-    virtual QList<QString> usedAttributes() override;
+    virtual QSet<QString> usedAttributes() const override;
     /** Proxy that will call this method on the embedded renderer. */
     virtual Capabilities capabilities() override;
     /** Proxy that will call this method on the embedded renderer.

--- a/src/core/symbology-ng/qgsnullsymbolrenderer.cpp
+++ b/src/core/symbology-ng/qgsnullsymbolrenderer.cpp
@@ -84,9 +84,9 @@ bool QgsNullSymbolRenderer::willRenderFeature( QgsFeature&, QgsRenderContext& )
   return true;
 }
 
-QList<QString> QgsNullSymbolRenderer::usedAttributes()
+QSet<QString> QgsNullSymbolRenderer::usedAttributes() const
 {
-  return QList<QString>();
+  return QSet<QString>();
 }
 
 QString QgsNullSymbolRenderer::dump() const

--- a/src/core/symbology-ng/qgsnullsymbolrenderer.h
+++ b/src/core/symbology-ng/qgsnullsymbolrenderer.h
@@ -42,7 +42,7 @@ class CORE_EXPORT QgsNullSymbolRenderer : public QgsFeatureRenderer
     virtual void stopRender( QgsRenderContext& context ) override;
     virtual bool willRenderFeature( QgsFeature& feat, QgsRenderContext& context ) override;
 
-    virtual QList<QString> usedAttributes() override;
+    virtual QSet<QString> usedAttributes() const override;
     virtual QString dump() const override;
     virtual QgsFeatureRenderer* clone() const override;
     virtual QgsSymbolList symbols( QgsRenderContext& context ) override;

--- a/src/core/symbology-ng/qgspointclusterrenderer.cpp
+++ b/src/core/symbology-ng/qgspointclusterrenderer.cpp
@@ -157,11 +157,11 @@ QDomElement QgsPointClusterRenderer::save( QDomDocument& doc )
   return rendererElement;
 }
 
-QList<QString> QgsPointClusterRenderer::usedAttributes()
+QSet<QString> QgsPointClusterRenderer::usedAttributes() const
 {
-  QList<QString> attr = QgsPointDistanceRenderer::usedAttributes();
+  QSet<QString> attr = QgsPointDistanceRenderer::usedAttributes();
   if ( mClusterSymbol )
-    attr.append( mClusterSymbol->usedAttributes().toList() );
+    attr.unite( mClusterSymbol->usedAttributes() );
   return attr;
 }
 

--- a/src/core/symbology-ng/qgspointclusterrenderer.h
+++ b/src/core/symbology-ng/qgspointclusterrenderer.h
@@ -35,7 +35,7 @@ class CORE_EXPORT QgsPointClusterRenderer: public QgsPointDistanceRenderer
     virtual void startRender( QgsRenderContext& context, const QgsFields& fields ) override;
     void stopRender( QgsRenderContext& context ) override;
     QDomElement save( QDomDocument& doc ) override;
-    virtual QList<QString> usedAttributes() override;
+    virtual QSet<QString> usedAttributes() const override;
 
     //! Creates a renderer from XML element
     static QgsFeatureRenderer* create( QDomElement& symbologyElem );

--- a/src/core/symbology-ng/qgspointdisplacementrenderer.cpp
+++ b/src/core/symbology-ng/qgspointdisplacementrenderer.cpp
@@ -215,11 +215,11 @@ QDomElement QgsPointDisplacementRenderer::save( QDomDocument& doc )
   return rendererElement;
 }
 
-QList<QString> QgsPointDisplacementRenderer::usedAttributes()
+QSet<QString> QgsPointDisplacementRenderer::usedAttributes() const
 {
-  QList<QString> attr = QgsPointDistanceRenderer::usedAttributes();
+  QSet<QString> attr = QgsPointDistanceRenderer::usedAttributes();
   if ( mCenterSymbol )
-    attr.append( mCenterSymbol->usedAttributes().toList() );
+    attr.unite( mCenterSymbol->usedAttributes() );
   return attr;
 }
 

--- a/src/core/symbology-ng/qgspointdisplacementrenderer.h
+++ b/src/core/symbology-ng/qgspointdisplacementrenderer.h
@@ -45,7 +45,7 @@ class CORE_EXPORT QgsPointDisplacementRenderer: public QgsPointDistanceRenderer
     virtual void startRender( QgsRenderContext& context, const QgsFields& fields ) override;
     void stopRender( QgsRenderContext& context ) override;
     QDomElement save( QDomDocument& doc ) override;
-    virtual QList<QString> usedAttributes() override;
+    virtual QSet<QString> usedAttributes() const override;
 
     //! Create a renderer from XML element
     static QgsFeatureRenderer* create( QDomElement& symbologyElem );

--- a/src/core/symbology-ng/qgspointdistancerenderer.cpp
+++ b/src/core/symbology-ng/qgspointdistancerenderer.cpp
@@ -204,12 +204,12 @@ QString QgsPointDistanceRenderer::filter( const QgsFields& fields )
     return mRenderer->filter( fields );
 }
 
-QList<QString> QgsPointDistanceRenderer::usedAttributes()
+QSet<QString> QgsPointDistanceRenderer::usedAttributes() const
 {
-  QList<QString> attributeList;
+  QSet<QString> attributeList;
   if ( !mLabelAttributeName.isEmpty() )
   {
-    attributeList.push_back( mLabelAttributeName );
+    attributeList.insert( mLabelAttributeName );
   }
   if ( mRenderer )
   {

--- a/src/core/symbology-ng/qgspointdistancerenderer.h
+++ b/src/core/symbology-ng/qgspointdistancerenderer.h
@@ -76,7 +76,7 @@ class CORE_EXPORT QgsPointDistanceRenderer: public QgsFeatureRenderer
 
     virtual void toSld( QDomDocument& doc, QDomElement &element, QgsStringMap props = QgsStringMap() ) const override;
     bool renderFeature( QgsFeature& feature, QgsRenderContext& context, int layer = -1, bool selected = false, bool drawVertexMarker = false ) override;
-    virtual QList<QString> usedAttributes() override;
+    virtual QSet<QString> usedAttributes() const override;
     virtual Capabilities capabilities() override;
     virtual QgsSymbolList symbols( QgsRenderContext& context ) override;
     virtual QgsSymbol* symbolForFeature( QgsFeature& feature, QgsRenderContext& context ) override;

--- a/src/core/symbology-ng/qgsrenderer.h
+++ b/src/core/symbology-ng/qgsrenderer.h
@@ -148,8 +148,7 @@ class CORE_EXPORT QgsFeatureRenderer
      *
      * @return A set of attributes
      */
-    // TODO QGIS3: Change QList to QSet
-    virtual QList<QString> usedAttributes() = 0;
+    virtual QSet<QString> usedAttributes() const = 0;
 
     /**
      * Returns true if this renderer requires the geometry to apply the filter.

--- a/src/core/symbology-ng/qgsrulebasedrenderer.cpp
+++ b/src/core/symbology-ng/qgsrulebasedrenderer.cpp
@@ -185,7 +185,7 @@ QSet<QString> QgsRuleBasedRenderer::Rule::usedAttributes() const
   // attributes needed by this rule
   QSet<QString> attrs;
   if ( mFilter )
-    attrs.unite( mFilter->referencedColumns().toSet() );
+    attrs.unite( mFilter->referencedColumns() );
   if ( mSymbol )
     attrs.unite( mSymbol->usedAttributes() );
 
@@ -910,10 +910,9 @@ QString QgsRuleBasedRenderer::filter( const QgsFields& )
   return mFilter;
 }
 
-QList<QString> QgsRuleBasedRenderer::usedAttributes()
+QSet<QString> QgsRuleBasedRenderer::usedAttributes() const
 {
-  QSet<QString> attrs = mRootRule->usedAttributes();
-  return attrs.toList();
+  return mRootRule->usedAttributes();
 }
 
 bool QgsRuleBasedRenderer::filterNeedsGeometry() const

--- a/src/core/symbology-ng/qgsrulebasedrenderer.h
+++ b/src/core/symbology-ng/qgsrulebasedrenderer.h
@@ -421,7 +421,7 @@ class CORE_EXPORT QgsRuleBasedRenderer : public QgsFeatureRenderer
 
     virtual QString filter( const QgsFields& fields = QgsFields() ) override;
 
-    virtual QList<QString> usedAttributes() override;
+    virtual QSet<QString> usedAttributes() const override;
 
     virtual bool filterNeedsGeometry() const override;
 

--- a/src/core/symbology-ng/qgssinglesymbolrenderer.cpp
+++ b/src/core/symbology-ng/qgssinglesymbolrenderer.cpp
@@ -72,11 +72,12 @@ void QgsSingleSymbolRenderer::stopRender( QgsRenderContext& context )
   mSymbol->stopRender( context );
 }
 
-QList<QString> QgsSingleSymbolRenderer::usedAttributes()
+QSet<QString> QgsSingleSymbolRenderer::usedAttributes() const
 {
   QSet<QString> attributes;
-  if ( mSymbol.data() ) attributes.unite( mSymbol->usedAttributes() );
-  return attributes.toList();
+  if ( mSymbol.data() )
+    attributes.unite( mSymbol->usedAttributes() );
+  return attributes;
 }
 
 QgsSymbol* QgsSingleSymbolRenderer::symbol() const

--- a/src/core/symbology-ng/qgssinglesymbolrenderer.h
+++ b/src/core/symbology-ng/qgssinglesymbolrenderer.h
@@ -36,7 +36,7 @@ class CORE_EXPORT QgsSingleSymbolRenderer : public QgsFeatureRenderer
     virtual QgsSymbol* originalSymbolForFeature( QgsFeature& feature, QgsRenderContext& context ) override;
     virtual void startRender( QgsRenderContext& context, const QgsFields& fields ) override;
     virtual void stopRender( QgsRenderContext& context ) override;
-    virtual QList<QString> usedAttributes() override;
+    virtual QSet<QString> usedAttributes() const override;
 
     QgsSymbol* symbol() const;
     void setSymbol( QgsSymbol* s );

--- a/src/core/symbology-ng/qgssymbollayer.cpp
+++ b/src/core/symbology-ng/qgssymbollayer.cpp
@@ -303,18 +303,18 @@ bool QgsSymbolLayer::isCompatibleWithSymbol( QgsSymbol* symbol ) const
 
 QSet<QString> QgsSymbolLayer::usedAttributes() const
 {
-  QStringList columns;
+  QSet<QString> columns;
 
   QMap< QString, QgsDataDefined* >::const_iterator ddIt = mDataDefinedProperties.constBegin();
   for ( ; ddIt != mDataDefinedProperties.constEnd(); ++ddIt )
   {
     if ( ddIt.value() && ddIt.value()->isActive() )
     {
-      columns.append( ddIt.value()->referencedColumns() );
+      columns.unite( ddIt.value()->referencedColumns() );
     }
   }
 
-  return columns.toSet();
+  return columns;
 }
 
 void QgsSymbolLayer::saveDataDefinedProperties( QgsStringMap& stringMap ) const

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -518,7 +518,7 @@ void QgsRelationReferenceWidget::init()
 
     QgsExpression exp( mReferencedLayer->displayExpression() );
 
-    requestedAttrs += exp.referencedColumns().toSet();
+    requestedAttrs += exp.referencedColumns();
     requestedAttrs << mRelation.fieldPairs().at( 0 ).second;
 
     QgsAttributeList attributes;
@@ -527,7 +527,7 @@ void QgsRelationReferenceWidget::init()
 
     layerCache->setCacheSubsetOfAttributes( attributes );
     mMasterModel = new QgsAttributeTableModel( layerCache );
-    mMasterModel->setRequest( QgsFeatureRequest().setFlags( QgsFeatureRequest::NoGeometry ).setSubsetOfAttributes( requestedAttrs.toList(), mReferencedLayer->fields() ) );
+    mMasterModel->setRequest( QgsFeatureRequest().setFlags( QgsFeatureRequest::NoGeometry ).setSubsetOfAttributes( requestedAttrs, mReferencedLayer->fields() ) );
     mFilterModel = new QgsAttributeTableFilterModel( mCanvas, mMasterModel, mMasterModel );
     mFeatureListModel = new QgsFeatureListModel( mFilterModel, this );
     mFeatureListModel->setDisplayExpression( mReferencedLayer->displayExpression() );

--- a/src/gui/symbology-ng/qgssizescalewidget.cpp
+++ b/src/gui/symbology-ng/qgssizescalewidget.cpp
@@ -277,7 +277,7 @@ void QgsSizeScaleWidget::computeFromLayerTriggered()
   if ( ! expression.prepare( &context ) )
     return;
 
-  QStringList lst( expression.referencedColumns() );
+  QSet<QString> lst( expression.referencedColumns() );
 
   QgsFeatureIterator fit = mLayer->getFeatures(
                              QgsFeatureRequest().setFlags( expression.needsGeometry()

--- a/tests/src/core/testqgsdatadefined.cpp
+++ b/tests/src/core/testqgsdatadefined.cpp
@@ -273,20 +273,20 @@ void TestQgsDataDefined::referencedColumns()
   dd.setActive( true );
   dd.setUseExpression( true );
 
-  QStringList cols = dd.referencedColumns();
+  QSet<QString> cols = dd.referencedColumns();
   QVERIFY( cols.isEmpty() );
 
   //set as expression
   dd.setExpressionString( "1+col1+col2" );
   cols = dd.referencedColumns();
-  QCOMPARE( cols.length(), 2 );
+  QCOMPARE( cols.size(), 2 );
   QVERIFY( cols.contains( QString( "col1" ) ) );
   QVERIFY( cols.contains( QString( "col2" ) ) );
 
   //alter expression and check that referenced columns is updated
   dd.setExpressionString( "1+col1+col2+col3" );
   cols = dd.referencedColumns();
-  QCOMPARE( cols.length(), 3 );
+  QCOMPARE( cols.size(), 3 );
   QVERIFY( cols.contains( QString( "col1" ) ) );
   QVERIFY( cols.contains( QString( "col2" ) ) );
   QVERIFY( cols.contains( QString( "col3" ) ) );
@@ -298,13 +298,13 @@ void TestQgsDataDefined::referencedColumns()
 
   dd.setField( "field" );
   cols = dd.referencedColumns();
-  QCOMPARE( cols.length(), 1 );
+  QCOMPARE( cols.size(), 1 );
   QVERIFY( cols.contains( QString( "field" ) ) );
 
   //switch back to expression
   dd.setUseExpression( true );
   cols = dd.referencedColumns();
-  QCOMPARE( cols.length(), 3 );
+  QCOMPARE( cols.size(), 3 );
   QVERIFY( cols.contains( QString( "col1" ) ) );
   QVERIFY( cols.contains( QString( "col2" ) ) );
   QVERIFY( cols.contains( QString( "col3" ) ) );

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -1494,7 +1494,7 @@ class TestQgsExpression: public QObject
       expectedCols << "foo" << "bar" << "ppp" << "qqq" << "rrr";
       QgsExpression exp( "length(Bar || FOO) = 4 or foo + sqrt(bar) > 0 or case when ppp then qqq else rrr end" );
       QCOMPARE( exp.hasParserError(), false );
-      QStringList refCols = exp.referencedColumns();
+      QSet<QString> refCols = exp.referencedColumns();
       // make sure we have lower case
       QSet<QString> refColsSet;
       Q_FOREACH ( const QString& col, refCols )
@@ -1507,7 +1507,7 @@ class TestQgsExpression: public QObject
     {
       QgsExpression exp( "attribute($currentfeature,'test')" );
       QCOMPARE( exp.hasParserError(), false );
-      QStringList refCols = exp.referencedColumns();
+      QSet<QString> refCols = exp.referencedColumns();
       // make sure we get the all attributes flag
       bool allAttributesFlag = refCols.contains( QgsFeatureRequest::AllAttributes );
       QCOMPARE( allAttributesFlag, true );

--- a/tests/src/core/testqgslabelingengine.cpp
+++ b/tests/src/core/testqgslabelingengine.cpp
@@ -437,7 +437,7 @@ void TestQgsLabelingEngine::testSubstitutions()
   mapSettings.setLayers( QStringList() << vl->id() );
   mapSettings.setOutputDpi( 96 );
   QgsRenderContext context = QgsRenderContext::fromMapSettings( mapSettings );
-  QStringList attributes;
+  QSet<QString> attributes;
   QgsLabelingEngine engine;
   engine.setMapSettings( mapSettings );
   engine.addProvider( provider );
@@ -469,7 +469,7 @@ void TestQgsLabelingEngine::testCapitalization()
   mapSettings.setLayers( QStringList() << vl->id() );
   mapSettings.setOutputDpi( 96 );
   QgsRenderContext context = QgsRenderContext::fromMapSettings( mapSettings );
-  QStringList attributes;
+  QSet<QString> attributes;
   QgsLabelingEngine engine;
   engine.setMapSettings( mapSettings );
 

--- a/tests/src/python/test_qgsexpression.py
+++ b/tests/src/python/test_qgsexpression.py
@@ -129,7 +129,8 @@ class TestQgsExpressionCustomFunctions(unittest.TestCase):
     def testReferencedColumnsNoSet(self):
         success = QgsExpression.registerFunction(self.no_referenced_columns_set)
         exp = QgsExpression('no_referenced_columns_set()')
-        self.assertEqual(exp.referencedColumns(), [QgsFeatureRequest.AllAttributes])
+        self.assertEqual(exp.referencedColumns(),
+                         {QgsFeatureRequest.AllAttributes})
 
     def testReferencedColumnsSet(self):
         success = QgsExpression.registerFunction(self.referenced_columns_set)


### PR DESCRIPTION
The order of the elements is irrelevant and duplicate elements are unwanted. It
is therefore a perfect candidate for a set instead of a list. This prevents
filtering for duplicate by (more performant) builtin methods of QSet.
