### PR TITLE
Wait for server ready (and times out) before starting the tests

### DIFF
--- a/ci/travis/linux/script.sh
+++ b/ci/travis/linux/script.sh
@@ -21,5 +21,5 @@ export CCACHE_TEMPDIR=/tmp
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 
-xvfb-run ctest -V -E "qgis_openstreetmaptest|qgis_wcsprovidertest|PyQgsWFSProviderGUI|qgis_ziplayertest|qgis_ogcutilstest|PyQgsServerWFST|$(cat ${DIR}/blacklist.txt | paste -sd '|' -)" -S ./qgis-test-travis.ctest --output-on-failure
+xvfb-run ctest -V -E "qgis_openstreetmaptest|qgis_wcsprovidertest|PyQgsWFSProviderGUI|qgis_ziplayertest|qgis_ogcutilstest|$(cat ${DIR}/blacklist.txt | paste -sd '|' -)" -S ./qgis-test-travis.ctest --output-on-failure
 # xvfb-run ctest -V -E "qgis_openstreetmaptest|qgis_wcsprovidertest" -S ./qgis-test-travis.ctest --output-on-failure

--- a/tests/src/python/qgis_wrapped_server.py
+++ b/tests/src/python/qgis_wrapped_server.py
@@ -3,7 +3,8 @@
 QGIS Server HTTP wrapper
 
 This script launches a QGIS Server listening on port 8081 or on the port
-specified on the environment variable QGIS_SERVER_DEFAULT_PORT
+specified on the environment variable QGIS_SERVER_PORT
+QGIS_SERVER_HOST (defaults to 127.0.0.1)
 
 For testing purposes, HTTP Basic can be enabled by setting the following
 environment variables:
@@ -36,10 +37,8 @@ from http.server import BaseHTTPRequestHandler, HTTPServer
 from qgis.core import QgsApplication
 from qgis.server import QgsServer
 
-try:
-    QGIS_SERVER_DEFAULT_PORT = int(os.environ['QGIS_SERVER_DEFAULT_PORT'])
-except KeyError:
-    QGIS_SERVER_DEFAULT_PORT = 8081
+QGIS_SERVER_PORT = int(os.environ.get('QGIS_SERVER_PORT', '8081'))
+QGIS_SERVER_HOST = os.environ.get('QGIS_SERVER_HOST', '127.0.0.1')
 
 qgs_app = QgsApplication([], False)
 qgs_server = QgsServer()
@@ -101,9 +100,9 @@ class Handler(BaseHTTPRequestHandler):
 
 
 if __name__ == '__main__':
-    server = HTTPServer(('localhost', QGIS_SERVER_DEFAULT_PORT), Handler)
-    print('Starting server on localhost:%s, use <Ctrl-C> to stop' %
-          QGIS_SERVER_DEFAULT_PORT)
+    print('Starting server on %s:%s, use <Ctrl-C> to stop' %
+          (QGIS_SERVER_HOST, QGIS_SERVER_PORT))
+    server = HTTPServer((QGIS_SERVER_HOST, QGIS_SERVER_PORT), Handler)
 
     def signal_handler(signal, frame):
         global qgs_app

--- a/tests/src/python/test_authmanager_endpoint.py
+++ b/tests/src/python/test_authmanager_endpoint.py
@@ -33,7 +33,7 @@ from time import sleep
 from urllib.parse import quote
 from shutil import rmtree
 
-from utilities import unitTestDataPath
+from utilities import unitTestDataPath, waitServer
 from qgis.core import (
     QgsAuthManager,
     QgsAuthMethodConfig,
@@ -92,12 +92,12 @@ class TestAuthManager(unittest.TestCase):
         os.environ['QGIS_SERVER_HTTP_BASIC_AUTH'] = '1'
         os.environ['QGIS_SERVER_USERNAME'] = cls.username
         os.environ['QGIS_SERVER_PASSWORD'] = cls.password
-        os.environ['QGIS_SERVER_DEFAULT_PORT'] = str(cls.port)
+        os.environ['QGIS_SERVER_PORT'] = str(cls.port)
         server_path = os.path.dirname(os.path.realpath(__file__)) + \
             '/qgis_wrapped_server.py'
         cls.server = subprocess.Popen([sys.executable, server_path],
                                       env=os.environ)
-        sleep(2)
+        assert waitServer('http://127.0.0.1:%s' % cls.port), "Server is not responding!"
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/src/python/test_offline_editing_wfs.py
+++ b/tests/src/python/test_offline_editing_wfs.py
@@ -35,7 +35,7 @@ import subprocess
 from shutil import copytree, rmtree
 import tempfile
 from time import sleep
-from utilities import unitTestDataPath
+from utilities import unitTestDataPath, waitServer
 from qgis.core import QgsVectorLayer
 
 from qgis.testing import (
@@ -85,7 +85,7 @@ class TestWFST(unittest.TestCase, OfflineTestBase):
                 pass
         # Clear all test layers
         cls._clearLayer(cls._getLayer('test_point'))
-        os.environ['QGIS_SERVER_DEFAULT_PORT'] = str(cls.port)
+        os.environ['QGIS_SERVER_PORT'] = str(cls.port)
         cls.server_path = os.path.dirname(os.path.realpath(__file__)) + \
             '/qgis_wrapped_server.py'
 
@@ -99,7 +99,7 @@ class TestWFST(unittest.TestCase, OfflineTestBase):
         self.server = subprocess.Popen([sys.executable, self.server_path],
                                        env=os.environ)
         # Wait for the server process to start
-        sleep(2)
+        assert waitServer('http://127.0.0.1:%s' % self.port), "Server is not responding!"
         self._setUp()
 
     def tearDown(self):

--- a/tests/src/python/test_qgsserver_wfst.py
+++ b/tests/src/python/test_qgsserver_wfst.py
@@ -41,7 +41,7 @@ import subprocess
 from shutil import copytree, rmtree
 import tempfile
 from time import sleep
-from utilities import unitTestDataPath
+from utilities import unitTestDataPath, waitServer
 from qgis.core import (
     QgsVectorLayer,
     QgsFeature,
@@ -94,12 +94,12 @@ class TestWFST(unittest.TestCase):
         # Clear all test layers
         for ln in ['test_point', 'test_polygon', 'test_linestring']:
             cls._clearLayer(ln)
-        os.environ['QGIS_SERVER_DEFAULT_PORT'] = str(cls.port)
+        os.environ['QGIS_SERVER_PORT'] = str(cls.port)
         server_path = os.path.dirname(os.path.realpath(__file__)) + \
             '/qgis_wrapped_server.py'
         cls.server = subprocess.Popen([sys.executable, server_path],
                                       env=os.environ)
-        sleep(2)
+        assert waitServer('http://127.0.0.1:%s' % cls.port), "Server is not responding!"
 
     @classmethod
     def tearDownClass(cls):

--- a/tests/src/python/utilities.py
+++ b/tests/src/python/utilities.py
@@ -18,6 +18,11 @@ import sys
 import glob
 import platform
 import tempfile
+try:
+    from urllib2 import urlopen, HTTPError
+except ImportError:
+    from urllib.request import urlopen, HTTPError
+
 
 from qgis.PyQt.QtCore import QDir
 
@@ -828,3 +833,22 @@ class DoxygenParser():
             if doc is not None and list(doc):
                 return True
         return False
+
+
+def waitServer(url, timeout=10):
+    """ Wait for a server to be online and to respond
+        HTTP errors are ignored
+        @param timeout: in seconds
+        @return: True of False
+    """
+    from time import time as now
+    end = now() + timeout
+    while True:
+        try:
+            urlopen(url, timeout=1)
+            return True
+        except HTTPError:
+            return True
+        except Exception as e:
+            if now() > end:
+                return False


### PR DESCRIPTION
This eliminates timing errors "Connection refused" if the test starts before the server is ready to accept connections. 
