### PR TITLE
[processing] setConfirmOverwrite is gone in pyqt5, use setOption

### DIFF
--- a/python/plugins/processing/gui/OutputSelectionPanel.py
+++ b/python/plugins/processing/gui/OutputSelectionPanel.py
@@ -175,7 +175,7 @@ class OutputSelectionPanel(BASE, WIDGET):
             self, self.tr('Save Spatialite'), path, fileFilter, encoding)
         fileDialog.setFileMode(QFileDialog.AnyFile)
         fileDialog.setAcceptMode(QFileDialog.AcceptSave)
-        fileDialog.setConfirmOverwrite(False)
+        fileDialog.setOption(QFileDialog.DontConfirmOverwrite, True)
 
         if fileDialog.exec_() == QDialog.Accepted:
             files = fileDialog.selectedFiles()
@@ -212,7 +212,7 @@ class OutputSelectionPanel(BASE, WIDGET):
             self, self.tr('Save file'), path, fileFilter, encoding)
         fileDialog.setFileMode(QFileDialog.AnyFile)
         fileDialog.setAcceptMode(QFileDialog.AcceptSave)
-        fileDialog.setConfirmOverwrite(True)
+        fileDialog.setOption(QFileDialog.DontConfirmOverwrite, False)
 
         if fileDialog.exec_() == QDialog.Accepted:
             files = fileDialog.selectedFiles()


### PR DESCRIPTION
@volaya , @alexbruy , a quick processing fix to handle the removal of the setConfirmOverwrite function in PyQt5.
