### PR TITLE
OWS auth fixes - master_2

### DIFF
--- a/src/core/qgsgml.cpp
+++ b/src/core/qgsgml.cpp
@@ -84,6 +84,20 @@ int QgsGml::getFeatures( const QString& uri, QGis::WkbType* wkbType, QgsRectangl
   }
   QNetworkReply* reply = QgsNetworkAccessManager::instance()->get( request );
 
+  if ( !authcfg.isEmpty() )
+  {
+    if ( !QgsAuthManager::instance()->updateNetworkReply( reply, authcfg ) )
+    {
+      reply->deleteLater();
+      QgsMessageLog::logMessage(
+        tr( "GML Getfeature network reply update failed for authcfg %1" ).arg( authcfg ),
+        tr( "Network" ),
+        QgsMessageLog::CRITICAL
+      );
+      return 1;
+    }
+  }
+
   connect( reply, SIGNAL( finished() ), this, SLOT( setFinished() ) );
   connect( reply, SIGNAL( downloadProgress( qint64, qint64 ) ), this, SLOT( handleProgressEvent( qint64, qint64 ) ) );
 

--- a/src/providers/wcs/qgswcscapabilities.h
+++ b/src/providers/wcs/qgswcscapabilities.h
@@ -162,6 +162,9 @@ class QgsWcsCapabilities : public QObject
     //! set authorization header
     bool setAuthorization( QNetworkRequest &request ) const;
 
+    //! set authorization reply
+    bool setAuthorizationReply( QNetworkReply * reply ) const;
+
     QString version() const { return mCapabilities.version; }
 
     /**

--- a/src/providers/wcs/qgswcsprovider.cpp
+++ b/src/providers/wcs/qgswcsprovider.cpp
@@ -1686,6 +1686,15 @@ QgsWcsDownloadHandler::QgsWcsDownloadHandler( const QUrl& url, QgsWcsAuthorizati
   request.setAttribute( QNetworkRequest::CacheLoadControlAttribute, cacheLoadControl );
 
   mCacheReply = QgsNetworkAccessManager::instance()->get( request );
+  if ( !mAuth.setAuthorizationReply( mCacheReply ) )
+  {
+    mCacheReply->deleteLater();
+    mCacheReply = nullptr;
+    QgsMessageLog::logMessage( tr( "Network reply update failed for authentication config" ),
+                               tr( "WCS" ) );
+    finish();
+    return;
+  }
   connect( mCacheReply, SIGNAL( finished() ), this, SLOT( cacheReplyFinished() ) );
   connect( mCacheReply, SIGNAL( downloadProgress( qint64, qint64 ) ), this, SLOT( cacheReplyProgress( qint64, qint64 ) ) );
 }
@@ -1724,6 +1733,15 @@ void QgsWcsDownloadHandler::cacheReplyFinished()
         return;
       }
       mCacheReply = QgsNetworkAccessManager::instance()->get( request );
+      if ( !mAuth.setAuthorizationReply( mCacheReply ) )
+      {
+        mCacheReply->deleteLater();
+        mCacheReply = nullptr;
+        QgsMessageLog::logMessage( tr( "Network reply update failed for authentication config" ),
+                                   tr( "WCS" ) );
+        finish();
+        return;
+      }
       connect( mCacheReply, SIGNAL( finished() ), this, SLOT( cacheReplyFinished() ) );
       connect( mCacheReply, SIGNAL( downloadProgress( qint64, qint64 ) ), this, SLOT( cacheReplyProgress( qint64, qint64 ) ) );
 
@@ -1891,6 +1909,15 @@ void QgsWcsDownloadHandler::cacheReplyFinished()
         mCacheReply->deleteLater();
 
         mCacheReply = QgsNetworkAccessManager::instance()->get( request );
+        if ( !mAuth.setAuthorizationReply( mCacheReply ) )
+        {
+          mCacheReply->deleteLater();
+          mCacheReply = nullptr;
+          QgsMessageLog::logMessage( tr( "Network reply update failed for authentication config" ),
+                                     tr( "WCS" ) );
+          finish();
+          return;
+        }
         connect( mCacheReply, SIGNAL( finished() ), this, SLOT( cacheReplyFinished() ), Qt::DirectConnection );
         connect( mCacheReply, SIGNAL( downloadProgress( qint64, qint64 ) ), this, SLOT( cacheReplyProgress( qint64, qint64 ) ), Qt::DirectConnection );
 

--- a/src/providers/wcs/qgswcsprovider.h
+++ b/src/providers/wcs/qgswcsprovider.h
@@ -71,6 +71,16 @@ struct QgsWcsAuthorization
     return true;
   }
 
+  //! set authorization reply
+  bool setAuthorizationReply( QNetworkReply * reply ) const
+  {
+    if ( !mAuthCfg.isEmpty() )
+    {
+      return QgsAuthManager::instance()->updateNetworkReply( reply, mAuthCfg );
+    }
+    return true;
+  }
+
   //! Username for basic http authentication
   QString mUserName;
 

--- a/src/providers/wfs/qgswfsdatasourceuri.cpp
+++ b/src/providers/wfs/qgswfsdatasourceuri.cpp
@@ -41,14 +41,19 @@ QgsWFSDataSourceURI::QgsWFSDataSourceURI( const QString& uri )
     QString typeName = url.queryItemValue( QgsWFSConstants::URI_PARAM_TYPENAME );
     QString version = url.queryItemValue( QgsWFSConstants::URI_PARAM_VERSION );
     QString filter = url.queryItemValue( QgsWFSConstants::URI_PARAM_FILTER );
-    mAuth.mUserName = url.queryItemValue( QgsWFSConstants::URI_PARAM_USERNAME );
-    // In QgsDataSourceURI, the "username" param is named "user", check it
-    if ( mAuth.mUserName.isEmpty() )
-    {
-      mAuth.mUserName = url.queryItemValue( QgsWFSConstants::URI_PARAM_USER );
-    }
-    mAuth.mPassword = url.queryItemValue( QgsWFSConstants::URI_PARAM_PASSWORD );
     mAuth.mAuthCfg = url.queryItemValue( QgsWFSConstants::URI_PARAM_AUTHCFG );
+    // NOTE: A defined authcfg overrides any older username/password auth
+    //       Only check for older auth if it is undefined
+    if ( mAuth.mAuthCfg.isEmpty() )
+    {
+      mAuth.mUserName = url.queryItemValue( QgsWFSConstants::URI_PARAM_USERNAME );
+      // In QgsDataSourceURI, the "username" param is named "user", check it
+      if ( mAuth.mUserName.isEmpty() )
+      {
+        mAuth.mUserName = url.queryItemValue( QgsWFSConstants::URI_PARAM_USER );
+      }
+      mAuth.mPassword = url.queryItemValue( QgsWFSConstants::URI_PARAM_PASSWORD );
+    }
 
     // Now remove all stuff that is not the core URL
     url.removeQueryItem( "SERVICE" );
@@ -90,19 +95,24 @@ QgsWFSDataSourceURI::QgsWFSDataSourceURI( const QString& uri )
 const QString QgsWFSDataSourceURI::uri( bool expandAuthConfig ) const
 {
   QgsDataSourceURI theURI( mURI );
-  // Add auth params back into the uri
+  // Add authcfg param back into the uri (must be non-empty value)
   if ( ! mAuth.mAuthCfg.isEmpty() )
   {
     theURI.setAuthConfigId( mAuth.mAuthCfg );
   }
-  if ( ! mAuth.mUserName.isEmpty() )
+  else
   {
-    theURI.setUsername( mAuth.mUserName );
+    // Add any older username/password auth params back in (allow empty values)
+    if ( ! mAuth.mUserName.isNull() )
+    {
+      theURI.setUsername( mAuth.mUserName );
+    }
+    if ( ! mAuth.mPassword.isNull() )
+    {
+      theURI.setPassword( mAuth.mPassword );
+    }
   }
-  if ( ! mAuth.mPassword.isEmpty() )
-  {
-    theURI.setPassword( mAuth.mPassword );
-  }
+  // NOTE: avoid expanding authcfg here; it is handled during network access
   return theURI.uri( expandAuthConfig );
 }
 

--- a/src/providers/wfs/qgswfsdatasourceuri.h
+++ b/src/providers/wfs/qgswfsdatasourceuri.h
@@ -32,7 +32,7 @@ struct QgsWFSAuthorization
       , mAuthCfg( authcfg )
   {}
 
-  //! set authorization header
+  //! update authorization for request
   bool setAuthorization( QNetworkRequest &request ) const
   {
     if ( !mAuthCfg.isEmpty() ) // must be non-empty value
@@ -42,6 +42,16 @@ struct QgsWFSAuthorization
     else if ( !mUserName.isNull() || !mPassword.isNull() ) // allow empty values
     {
       request.setRawHeader( "Authorization", "Basic " + QString( "%1:%2" ).arg( mUserName, mPassword ).toAscii().toBase64() );
+    }
+    return true;
+  }
+
+  //! update authorization for reply
+  bool setAuthorizationReply( QNetworkReply *reply ) const
+  {
+    if ( !mAuthCfg.isEmpty() )
+    {
+      return QgsAuthManager::instance()->updateNetworkReply( reply, mAuthCfg );
     }
     return true;
   }

--- a/src/providers/wfs/qgswfsdatasourceuri.h
+++ b/src/providers/wfs/qgswfsdatasourceuri.h
@@ -35,11 +35,11 @@ struct QgsWFSAuthorization
   //! set authorization header
   bool setAuthorization( QNetworkRequest &request ) const
   {
-    if ( !mAuthCfg.isEmpty() )
+    if ( !mAuthCfg.isEmpty() ) // must be non-empty value
     {
       return QgsAuthManager::instance()->updateNetworkRequest( request, mAuthCfg );
     }
-    else if ( !mUserName.isNull() || !mPassword.isNull() )
+    else if ( !mUserName.isNull() || !mPassword.isNull() ) // allow empty values
     {
       request.setRawHeader( "Authorization", "Basic " + QString( "%1:%2" ).arg( mUserName, mPassword ).toAscii().toBase64() );
     }
@@ -65,8 +65,8 @@ class QgsWFSDataSourceURI
 
     explicit QgsWFSDataSourceURI( const QString& uri );
 
-    /** Return the URI */
-    const QString uri( bool expandAuthConfig = true ) const;
+    /** Return the URI, avoiding expansion of authentication configuration, which is handled during network access */
+    const QString uri( bool expandAuthConfig = false ) const;
 
     /** Return base URL (with SERVICE=WFS parameter if bIncludeServiceWFS=true) */
     QUrl baseURL( bool bIncludeServiceWFS = true ) const;

--- a/src/providers/wfs/qgswfsprovider.cpp
+++ b/src/providers/wfs/qgswfsprovider.cpp
@@ -1101,7 +1101,7 @@ bool QgsWFSProvider::describeFeatureType( QString& geometryAttribute, QgsFields&
 {
   fields.clear();
 
-  QgsWFSDescribeFeatureType describeFeatureType( mShared->mURI.uri( false ) );
+  QgsWFSDescribeFeatureType describeFeatureType( mShared->mURI.uri() );
   if ( !describeFeatureType.requestFeatureType( mShared->mWFSVersion,
        mShared->mURI.typeName() ) )
   {
@@ -1337,7 +1337,7 @@ bool QgsWFSProvider::sendTransactionDocument( const QDomDocument& doc, QDomDocum
     return false;
   }
 
-  QgsWFSTransactionRequest request( mShared->mURI.uri( false ) );
+  QgsWFSTransactionRequest request( mShared->mURI.uri() );
   return request.send( doc, serverResponse );
 }
 
@@ -1440,7 +1440,7 @@ bool QgsWFSProvider::getCapabilities()
 
   if ( mShared->mCaps.version.isEmpty() )
   {
-    QgsWFSCapabilities getCapabilities( mShared->mURI.uri( false ) );
+    QgsWFSCapabilities getCapabilities( mShared->mURI.uri() );
     const bool synchronous = true;
     const bool forceRefresh = false;
     if ( !getCapabilities.requestCapabilities( synchronous, forceRefresh ) )

--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -1956,6 +1956,14 @@ bool QgsWmsCapabilitiesDownload::downloadCapabilities()
   request.setAttribute( QNetworkRequest::CacheSaveControlAttribute, true );
 
   mCapabilitiesReply = QgsNetworkAccessManager::instance()->get( request );
+  if ( !mAuth.setAuthorizationReply( mCapabilitiesReply ) )
+  {
+    mCapabilitiesReply->deleteLater();
+    mCapabilitiesReply = nullptr;
+    mError = tr( "Download of capabilities failed: network reply update failed for authentication config" );
+    QgsMessageLog::logMessage( mError, tr( "WMS" ) );
+    return false;
+  }
   connect( mCapabilitiesReply, SIGNAL( finished() ), this, SLOT( capabilitiesReplyFinished() ), Qt::DirectConnection );
   connect( mCapabilitiesReply, SIGNAL( downloadProgress( qint64, qint64 ) ), this, SLOT( capabilitiesReplyProgress( qint64, qint64 ) ), Qt::DirectConnection );
 
@@ -2022,6 +2030,18 @@ void QgsWmsCapabilitiesDownload::capabilitiesReplyFinished()
 
           QgsDebugMsg( QString( "redirected getcapabilities: %1 forceRefresh=%2" ).arg( redirect.toString() ).arg( mForceRefresh ) );
           mCapabilitiesReply = QgsNetworkAccessManager::instance()->get( request );
+
+          if ( !mAuth.setAuthorizationReply( mCapabilitiesReply ) )
+          {
+            mHttpCapabilitiesResponse.clear();
+            mCapabilitiesReply->deleteLater();
+            mCapabilitiesReply = nullptr;
+            mError = tr( "Download of capabilities failed: network reply update failed for authentication config" );
+            QgsMessageLog::logMessage( mError, tr( "WMS" ) );
+            emit downloadFinished();
+            return;
+          }
+
           connect( mCapabilitiesReply, SIGNAL( finished() ), this, SLOT( capabilitiesReplyFinished() ), Qt::DirectConnection );
           connect( mCapabilitiesReply, SIGNAL( downloadProgress( qint64, qint64 ) ), this, SLOT( capabilitiesReplyProgress( qint64, qint64 ) ), Qt::DirectConnection );
           return;

--- a/src/providers/wms/qgswmscapabilities.h
+++ b/src/providers/wms/qgswmscapabilities.h
@@ -512,6 +512,15 @@ struct QgsWmsAuthorization
     }
     return true;
   }
+  //! set authorization reply
+  bool setAuthorizationReply( QNetworkReply * reply ) const
+  {
+    if ( !mAuthCfg.isEmpty() )
+    {
+      return QgsAuthManager::instance()->updateNetworkReply( reply, mAuthCfg );
+    }
+    return true;
+  }
 
   //! Username for basic http authentication
   QString mUserName;

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -3105,6 +3105,7 @@ void QgsWmsProvider::identifyReplyFinished()
 
       QgsDebugMsg( QString( "redirected getfeatureinfo: %1" ).arg( redirect.toString() ) );
       mIdentifyReply = QgsNetworkAccessManager::instance()->get( QNetworkRequest( redirect.toUrl() ) );
+      mSettings.authorization().setAuthorizationReply( mIdentifyReply );
       mIdentifyReply->setProperty( "eventLoop", QVariant::fromValue( qobject_cast<QObject *>( loop ) ) );
       connect( mIdentifyReply, SIGNAL( finished() ), this, SLOT( identifyReplyFinished() ) );
       return;
@@ -4094,6 +4095,7 @@ QgsWmsLegendDownloadHandler::startUrl( const QUrl& url )
   request.setAttribute( QNetworkRequest::CacheSaveControlAttribute, true );
 
   mReply = mNetworkAccessManager.get( request );
+  mSettings.authorization().setAuthorizationReply( mReply );
   connect( mReply, SIGNAL( error( QNetworkReply::NetworkError ) ), this, SLOT( errored( QNetworkReply::NetworkError ) ) );
   connect( mReply, SIGNAL( finished() ), this, SLOT( finished() ) );
   connect( mReply, SIGNAL( downloadProgress( qint64, qint64 ) ), this, SLOT( progressed( qint64, qint64 ) ) );


### PR DESCRIPTION
Couple of fixes already applied to `release-2_14`, but needed reworked for 2.16+ due to WFS provider refactoring. Passed new local server- and wfs-related unit tests; functionally passed PKI testing for WFS endpoint.

Note: these missing/reinstated reply expansions allow for an OAuth2 auth method plugin (already developed by Boundless).
