### PR TITLE
OWS auth fixes - master

### DIFF
--- a/src/core/qgsgml.cpp
+++ b/src/core/qgsgml.cpp
@@ -83,6 +83,20 @@ int QgsGml::getFeatures( const QString& uri, QgsWkbTypes::Type* wkbType, QgsRect
   }
   QNetworkReply* reply = QgsNetworkAccessManager::instance()->get( request );
 
+  if ( !authcfg.isEmpty() )
+  {
+    if ( !QgsAuthManager::instance()->updateNetworkReply( reply, authcfg ) )
+    {
+      reply->deleteLater();
+      QgsMessageLog::logMessage(
+        tr( "GML Getfeature network reply update failed for authcfg %1" ).arg( authcfg ),
+        tr( "Network" ),
+        QgsMessageLog::CRITICAL
+      );
+      return 1;
+    }
+  }
+
   connect( reply, SIGNAL( finished() ), this, SLOT( setFinished() ) );
   connect( reply, SIGNAL( downloadProgress( qint64, qint64 ) ), this, SLOT( handleProgressEvent( qint64, qint64 ) ) );
 

--- a/src/providers/wcs/qgswcscapabilities.cpp
+++ b/src/providers/wcs/qgswcscapabilities.cpp
@@ -157,6 +157,14 @@ bool QgsWcsCapabilities::sendRequest( QString const & url )
 
   QgsDebugMsg( QString( "getcapabilities: %1" ).arg( url ) );
   mCapabilitiesReply = QgsNetworkAccessManager::instance()->get( request );
+  if ( !setAuthorizationReply( mCapabilitiesReply ) )
+  {
+    mCapabilitiesReply->deleteLater();
+    mCapabilitiesReply = nullptr;
+    mError = tr( "Download of capabilities failed: network reply update failed for authentication config" );
+    QgsMessageLog::logMessage( mError, tr( "WCS" ) );
+    return false;
+  }
 
   connect( mCapabilitiesReply, SIGNAL( finished() ), this, SLOT( capabilitiesReplyFinished() ) );
   connect( mCapabilitiesReply, SIGNAL( downloadProgress( qint64, qint64 ) ), this, SLOT( capabilitiesReplyProgress( qint64, qint64 ) ) );
@@ -367,6 +375,15 @@ void QgsWcsCapabilities::capabilitiesReplyFinished()
       mCapabilitiesReply->deleteLater();
       QgsDebugMsg( QString( "redirected getcapabilities: %1" ).arg( redirect.toString() ) );
       mCapabilitiesReply = QgsNetworkAccessManager::instance()->get( request );
+      if ( !setAuthorizationReply( mCapabilitiesReply ) )
+      {
+        mCapabilitiesResponse.clear();
+        mCapabilitiesReply->deleteLater();
+        mCapabilitiesReply = nullptr;
+        mError = tr( "Download of capabilities failed: network reply update failed for authentication config" );
+        QgsMessageLog::logMessage( mError, tr( "WCS" ) );
+        return;
+      }
 
       connect( mCapabilitiesReply, SIGNAL( finished() ), this, SLOT( capabilitiesReplyFinished() ) );
       connect( mCapabilitiesReply, SIGNAL( downloadProgress( qint64, qint64 ) ), this, SLOT( capabilitiesReplyProgress( qint64, qint64 ) ) );
@@ -393,6 +410,15 @@ void QgsWcsCapabilities::capabilitiesReplyFinished()
       mCapabilitiesReply->deleteLater();
 
       mCapabilitiesReply = QgsNetworkAccessManager::instance()->get( request );
+      if ( !setAuthorizationReply( mCapabilitiesReply ) )
+      {
+        mCapabilitiesResponse.clear();
+        mCapabilitiesReply->deleteLater();
+        mCapabilitiesReply = nullptr;
+        mError = tr( "Download of capabilities failed: network reply update failed for authentication config" );
+        QgsMessageLog::logMessage( mError, tr( "WCS" ) );
+        return;
+      }
       connect( mCapabilitiesReply, SIGNAL( finished() ), this, SLOT( capabilitiesReplyFinished() ) );
       connect( mCapabilitiesReply, SIGNAL( downloadProgress( qint64, qint64 ) ), this, SLOT( capabilitiesReplyProgress( qint64, qint64 ) ) );
       return;
@@ -1174,6 +1200,15 @@ bool QgsWcsCapabilities::setAuthorization( QNetworkRequest &request ) const
   {
     QgsDebugMsg( "setAuthorization " + mUri.param( "username" ) );
     request.setRawHeader( "Authorization", "Basic " + QString( "%1:%2" ).arg( mUri.param( "username" ), mUri.param( "password" ) ).toLatin1().toBase64() );
+  }
+  return true;
+}
+
+bool QgsWcsCapabilities::setAuthorizationReply( QNetworkReply *reply ) const
+{
+  if ( mUri.hasParam( "authcfg" ) && !mUri.param( "authcfg" ).isEmpty() )
+  {
+    return QgsAuthManager::instance()->updateNetworkReply( reply, mUri.param( "authcfg" ) );
   }
   return true;
 }

--- a/src/providers/wcs/qgswcscapabilities.h
+++ b/src/providers/wcs/qgswcscapabilities.h
@@ -162,6 +162,9 @@ class QgsWcsCapabilities : public QObject
     //! set authorization header
     bool setAuthorization( QNetworkRequest &request ) const;
 
+    //! set authorization reply
+    bool setAuthorizationReply( QNetworkReply * reply ) const;
+
     QString version() const { return mCapabilities.version; }
 
     /**

--- a/src/providers/wcs/qgswcsprovider.cpp
+++ b/src/providers/wcs/qgswcsprovider.cpp
@@ -1663,6 +1663,15 @@ QgsWcsDownloadHandler::QgsWcsDownloadHandler( const QUrl& url, QgsWcsAuthorizati
   request.setAttribute( QNetworkRequest::CacheLoadControlAttribute, cacheLoadControl );
 
   mCacheReply = QgsNetworkAccessManager::instance()->get( request );
+  if ( !mAuth.setAuthorizationReply( mCacheReply ) )
+  {
+    mCacheReply->deleteLater();
+    mCacheReply = nullptr;
+    QgsMessageLog::logMessage( tr( "Network reply update failed for authentication config" ),
+                               tr( "WCS" ) );
+    finish();
+    return;
+  }
   connect( mCacheReply, SIGNAL( finished() ), this, SLOT( cacheReplyFinished() ) );
   connect( mCacheReply, SIGNAL( downloadProgress( qint64, qint64 ) ), this, SLOT( cacheReplyProgress( qint64, qint64 ) ) );
 
@@ -1701,6 +1710,15 @@ void QgsWcsDownloadHandler::cacheReplyFinished()
         return;
       }
       mCacheReply = QgsNetworkAccessManager::instance()->get( request );
+      if ( !mAuth.setAuthorizationReply( mCacheReply ) )
+      {
+        mCacheReply->deleteLater();
+        mCacheReply = nullptr;
+        QgsMessageLog::logMessage( tr( "Network reply update failed for authentication config" ),
+                                   tr( "WCS" ) );
+        finish();
+        return;
+      }
       connect( mCacheReply, SIGNAL( finished() ), this, SLOT( cacheReplyFinished() ) );
       connect( mCacheReply, SIGNAL( downloadProgress( qint64, qint64 ) ), this, SLOT( cacheReplyProgress( qint64, qint64 ) ) );
 
@@ -1868,6 +1886,15 @@ void QgsWcsDownloadHandler::cacheReplyFinished()
         mCacheReply->deleteLater();
 
         mCacheReply = QgsNetworkAccessManager::instance()->get( request );
+        if ( !mAuth.setAuthorizationReply( mCacheReply ) )
+        {
+          mCacheReply->deleteLater();
+          mCacheReply = nullptr;
+          QgsMessageLog::logMessage( tr( "Network reply update failed for authentication config" ),
+                                     tr( "WCS" ) );
+          finish();
+          return;
+        }
         connect( mCacheReply, SIGNAL( finished() ), this, SLOT( cacheReplyFinished() ), Qt::DirectConnection );
         connect( mCacheReply, SIGNAL( downloadProgress( qint64, qint64 ) ), this, SLOT( cacheReplyProgress( qint64, qint64 ) ), Qt::DirectConnection );
 

--- a/src/providers/wcs/qgswcsprovider.h
+++ b/src/providers/wcs/qgswcsprovider.h
@@ -72,6 +72,16 @@ struct QgsWcsAuthorization
     return true;
   }
 
+  //! set authorization reply
+  bool setAuthorizationReply( QNetworkReply * reply ) const
+  {
+    if ( !mAuthCfg.isEmpty() )
+    {
+      return QgsAuthManager::instance()->updateNetworkReply( reply, mAuthCfg );
+    }
+    return true;
+  }
+
   //! Username for basic http authentication
   QString mUserName;
 

--- a/src/providers/wfs/qgswfsdatasourceuri.h
+++ b/src/providers/wfs/qgswfsdatasourceuri.h
@@ -32,7 +32,7 @@ struct QgsWFSAuthorization
       , mAuthCfg( authcfg )
   {}
 
-  //! set authorization header
+  //! update authorization for request
   bool setAuthorization( QNetworkRequest &request ) const
   {
     if ( !mAuthCfg.isEmpty() ) // must be non-empty value
@@ -42,6 +42,16 @@ struct QgsWFSAuthorization
     else if ( !mUserName.isNull() || !mPassword.isNull() ) // allow empty values
     {
       request.setRawHeader( "Authorization", "Basic " + QString( "%1:%2" ).arg( mUserName, mPassword ).toLatin1().toBase64() );
+    }
+    return true;
+  }
+
+  //! update authorization for reply
+  bool setAuthorizationReply( QNetworkReply *reply ) const
+  {
+    if ( !mAuthCfg.isEmpty() )
+    {
+      return QgsAuthManager::instance()->updateNetworkReply( reply, mAuthCfg );
     }
     return true;
   }

--- a/src/providers/wfs/qgswfsdatasourceuri.h
+++ b/src/providers/wfs/qgswfsdatasourceuri.h
@@ -35,11 +35,11 @@ struct QgsWFSAuthorization
   //! set authorization header
   bool setAuthorization( QNetworkRequest &request ) const
   {
-    if ( !mAuthCfg.isEmpty() )
+    if ( !mAuthCfg.isEmpty() ) // must be non-empty value
     {
       return QgsAuthManager::instance()->updateNetworkRequest( request, mAuthCfg );
     }
-    else if ( !mUserName.isNull() || !mPassword.isNull() )
+    else if ( !mUserName.isNull() || !mPassword.isNull() ) // allow empty values
     {
       request.setRawHeader( "Authorization", "Basic " + QString( "%1:%2" ).arg( mUserName, mPassword ).toLatin1().toBase64() );
     }
@@ -65,8 +65,8 @@ class QgsWFSDataSourceURI
 
     explicit QgsWFSDataSourceURI( const QString& uri );
 
-    /** Return the URI */
-    const QString uri( bool expandAuthConfig = true ) const;
+    /** Return the URI, avoiding expansion of authentication configuration, which is handled during network access */
+    const QString uri( bool expandAuthConfig = false ) const;
 
     /** Return base URL (with SERVICE=WFS parameter if bIncludeServiceWFS=true) */
     QUrl baseURL( bool bIncludeServiceWFS = true ) const;

--- a/src/providers/wfs/qgswfsprovider.cpp
+++ b/src/providers/wfs/qgswfsprovider.cpp
@@ -1104,7 +1104,7 @@ bool QgsWFSProvider::describeFeatureType( QString& geometryAttribute, QgsFields&
 {
   fields.clear();
 
-  QgsWFSDescribeFeatureType describeFeatureType( mShared->mURI.uri( false ) );
+  QgsWFSDescribeFeatureType describeFeatureType( mShared->mURI.uri() );
   if ( !describeFeatureType.requestFeatureType( mShared->mWFSVersion,
        mShared->mURI.typeName() ) )
   {
@@ -1340,7 +1340,7 @@ bool QgsWFSProvider::sendTransactionDocument( const QDomDocument& doc, QDomDocum
     return false;
   }
 
-  QgsWFSTransactionRequest request( mShared->mURI.uri( false ) );
+  QgsWFSTransactionRequest request( mShared->mURI.uri() );
   return request.send( doc, serverResponse );
 }
 
@@ -1443,7 +1443,7 @@ bool QgsWFSProvider::getCapabilities()
 
   if ( mShared->mCaps.version.isEmpty() )
   {
-    QgsWfsCapabilities getCapabilities( mShared->mURI.uri( false ) );
+    QgsWfsCapabilities getCapabilities( mShared->mURI.uri() );
     const bool synchronous = true;
     const bool forceRefresh = false;
     if ( !getCapabilities.requestCapabilities( synchronous, forceRefresh ) )

--- a/src/providers/wfs/qgswfsrequest.cpp
+++ b/src/providers/wfs/qgswfsrequest.cpp
@@ -116,6 +116,13 @@ bool QgsWfsRequest::sendGET( const QUrl& url, bool synchronous, bool forceRefres
   }
 
   mReply = QgsNetworkAccessManager::instance()->get( request );
+  if ( !mUri.auth().setAuthorizationReply( mReply ) )
+  {
+    mErrorCode = QgsWfsRequest::NetworkError;
+    mErrorMessage = errorMessageFailedAuth();
+    QgsMessageLog::logMessage( mErrorMessage, tr( "WFS" ) );
+    return false;
+  }
   connect( mReply, SIGNAL( finished() ), this, SLOT( replyFinished() ) );
   connect( mReply, SIGNAL( downloadProgress( qint64, qint64 ) ), this, SLOT( replyProgress( qint64, qint64 ) ) );
 
@@ -160,6 +167,13 @@ bool QgsWfsRequest::sendPOST( const QUrl& url, const QString& contentTypeHeader,
   request.setHeader( QNetworkRequest::ContentTypeHeader, contentTypeHeader );
 
   mReply = QgsNetworkAccessManager::instance()->post( request, data );
+  if ( !mUri.auth().setAuthorizationReply( mReply ) )
+  {
+    mErrorCode = QgsWfsRequest::NetworkError;
+    mErrorMessage = errorMessageFailedAuth();
+    QgsMessageLog::logMessage( mErrorMessage, tr( "WFS" ) );
+    return false;
+  }
   connect( mReply, SIGNAL( finished() ), this, SLOT( replyFinished() ) );
   connect( mReply, SIGNAL( downloadProgress( qint64, qint64 ) ), this, SLOT( replyProgress( qint64, qint64 ) ) );
 
@@ -243,6 +257,15 @@ void QgsWfsRequest::replyFinished()
 
           QgsDebugMsg( QString( "redirected: %1 forceRefresh=%2" ).arg( redirect.toString() ).arg( mForceRefresh ) );
           mReply = QgsNetworkAccessManager::instance()->get( request );
+          if ( !mUri.auth().setAuthorizationReply( mReply ) )
+          {
+            mResponse.clear();
+            mErrorMessage = errorMessageFailedAuth();
+            mErrorCode = QgsWfsRequest::NetworkError;
+            QgsMessageLog::logMessage( mErrorMessage, tr( "WFS" ) );
+            emit downloadFinished();
+            return;
+          }
           connect( mReply, SIGNAL( finished() ), this, SLOT( replyFinished() ) );
           connect( mReply, SIGNAL( downloadProgress( qint64, qint64 ) ), this, SLOT( replyProgress( qint64, qint64 ) ) );
           return;

--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -1955,6 +1955,14 @@ bool QgsWmsCapabilitiesDownload::downloadCapabilities()
   request.setAttribute( QNetworkRequest::CacheSaveControlAttribute, true );
 
   mCapabilitiesReply = QgsNetworkAccessManager::instance()->get( request );
+  if ( !mAuth.setAuthorizationReply( mCapabilitiesReply ) )
+  {
+    mCapabilitiesReply->deleteLater();
+    mCapabilitiesReply = nullptr;
+    mError = tr( "Download of capabilities failed: network reply update failed for authentication config" );
+    QgsMessageLog::logMessage( mError, tr( "WMS" ) );
+    return false;
+  }
   connect( mCapabilitiesReply, SIGNAL( finished() ), this, SLOT( capabilitiesReplyFinished() ), Qt::DirectConnection );
   connect( mCapabilitiesReply, SIGNAL( downloadProgress( qint64, qint64 ) ), this, SLOT( capabilitiesReplyProgress( qint64, qint64 ) ), Qt::DirectConnection );
 
@@ -2021,6 +2029,18 @@ void QgsWmsCapabilitiesDownload::capabilitiesReplyFinished()
 
           QgsDebugMsg( QString( "redirected getcapabilities: %1 forceRefresh=%2" ).arg( redirect.toString() ).arg( mForceRefresh ) );
           mCapabilitiesReply = QgsNetworkAccessManager::instance()->get( request );
+
+          if ( !mAuth.setAuthorizationReply( mCapabilitiesReply ) )
+          {
+            mHttpCapabilitiesResponse.clear();
+            mCapabilitiesReply->deleteLater();
+            mCapabilitiesReply = nullptr;
+            mError = tr( "Download of capabilities failed: network reply update failed for authentication config" );
+            QgsMessageLog::logMessage( mError, tr( "WMS" ) );
+            emit downloadFinished();
+            return;
+          }
+
           connect( mCapabilitiesReply, SIGNAL( finished() ), this, SLOT( capabilitiesReplyFinished() ), Qt::DirectConnection );
           connect( mCapabilitiesReply, SIGNAL( downloadProgress( qint64, qint64 ) ), this, SLOT( capabilitiesReplyProgress( qint64, qint64 ) ), Qt::DirectConnection );
           return;

--- a/src/providers/wms/qgswmscapabilities.h
+++ b/src/providers/wms/qgswmscapabilities.h
@@ -512,6 +512,15 @@ struct QgsWmsAuthorization
     }
     return true;
   }
+  //! set authorization reply
+  bool setAuthorizationReply( QNetworkReply * reply ) const
+  {
+    if ( !mAuthCfg.isEmpty() )
+    {
+      return QgsAuthManager::instance()->updateNetworkReply( reply, mAuthCfg );
+    }
+    return true;
+  }
 
   //! Username for basic http authentication
   QString mUserName;

--- a/src/providers/wms/qgswmsprovider.cpp
+++ b/src/providers/wms/qgswmsprovider.cpp
@@ -3110,6 +3110,7 @@ void QgsWmsProvider::identifyReplyFinished()
 
       QgsDebugMsg( QString( "redirected getfeatureinfo: %1" ).arg( redirect.toString() ) );
       mIdentifyReply = QgsNetworkAccessManager::instance()->get( QNetworkRequest( redirect.toUrl() ) );
+      mSettings.authorization().setAuthorizationReply( mIdentifyReply );
       mIdentifyReply->setProperty( "eventLoop", QVariant::fromValue( qobject_cast<QObject *>( loop ) ) );
       connect( mIdentifyReply, SIGNAL( finished() ), this, SLOT( identifyReplyFinished() ) );
       return;
@@ -4100,6 +4101,7 @@ QgsWmsLegendDownloadHandler::startUrl( const QUrl& url )
   request.setAttribute( QNetworkRequest::CacheSaveControlAttribute, true );
 
   mReply = mNetworkAccessManager.get( request );
+  mSettings.authorization().setAuthorizationReply( mReply );
   connect( mReply, SIGNAL( error( QNetworkReply::NetworkError ) ), this, SLOT( errored( QNetworkReply::NetworkError ) ) );
   connect( mReply, SIGNAL( finished() ), this, SLOT( finished() ) );
   connect( mReply, SIGNAL( downloadProgress( qint64, qint64 ) ), this, SLOT( progressed( qint64, qint64 ) ) );


### PR DESCRIPTION
Couple of fixes already applied to `release-2_14`, but needed reworked for 2.16+ and `master` due to WFS provider refactoring.

Note: these missing/reinstated reply expansions allow for an OAuth2 auth method plugin (already developed by Boundless).
