### PR TITLE
[travis] fix grass7 plugin build by adding GRASS_PREFIX7

### DIFF
--- a/ci/travis/linux/install.sh
+++ b/ci/travis/linux/install.sh
@@ -42,6 +42,8 @@ cmake \
       -DCMAKE_PREFIX_PATH=/home/travis/osgeo4travis \
       -DWITH_STAGED_PLUGINS=ON \
       -DWITH_GRASS=ON \
+      -DWITH_GRASS7=ON \
+      -DGRASS_PREFIX7=/home/travis/osgeo4travis/grass-7.0.4 \
       -DSUPPRESS_QT_WARNINGS=ON \
       -DENABLE_MODELTEST=ON \
       -DENABLE_PGTEST=ON \

--- a/src/plugins/grass/qgsgrasseditrenderer.cpp
+++ b/src/plugins/grass/qgsgrasseditrenderer.cpp
@@ -173,7 +173,7 @@ void QgsGrassEditRenderer::stopRender( QgsRenderContext& context )
   mMarkerRenderer->stopRender( context );
 }
 
-QSet<QString> QgsGrassEditRenderer::usedAttributes()
+QSet<QString> QgsGrassEditRenderer::usedAttributes() const
 {
   return mLineRenderer->usedAttributes();
 }

--- a/src/plugins/grass/qgsgrasseditrenderer.h
+++ b/src/plugins/grass/qgsgrasseditrenderer.h
@@ -38,7 +38,7 @@ class QgsGrassEditRenderer : public QgsFeatureRenderer
 
     virtual void stopRender( QgsRenderContext& context ) override;
 
-    virtual QSet<QString> usedAttributes() override;
+    virtual QSet<QString> usedAttributes() const override;
 
     virtual QgsFeatureRenderer* clone() const override;
 


### PR DESCRIPTION
Travis builds should also have WITH_GRASS7=ON to insure the grass renderer symbology (et al) works. 

_Note: this PR should fail as it requires a follow up commit to 3b0486c; I'll add it to the PR after it initially fails to confirm the fix_
