### PR TITLE
Port composer item configuration widgets to inline dock

### DIFF
--- a/python/core/composer/qgscomposeritemcommand.sip
+++ b/python/core/composer/qgscomposeritemcommand.sip
@@ -49,9 +49,14 @@ class QgsComposerMergeCommand : QgsComposerItemCommand
       //composer label
       ComposerLabelSetText,
       ComposerLabelSetId,
+      ComposerLabelFontColor,
       //composer map
       ComposerMapRotation,
       ComposerMapAnnotationDistance,
+      ComposerMapGridFramePenColor,
+      ComposerMapGridFrameFill1Color,
+      ComposerMapGridFrameFill2Color,
+      ComposerMapGridAnnotationFontColor,
       //composer legend
       ComposerLegendText,
       LegendColumnCount,
@@ -69,8 +74,12 @@ class QgsComposerMergeCommand : QgsComposerItemCommand
       LegendBoxSpace,
       LegendColumnSpace,
       LegendRasterBorderWidth,
+      LegendFontColor,
+      LegendRasterBorderColor,
       //composer picture
       ComposerPictureRotation,
+      ComposerPictureFillColor,
+      ComposerPictureOutlineColor,
       // composer scalebar
       ScaleBarLineWidth,
       ScaleBarHeight,
@@ -81,6 +90,10 @@ class QgsComposerMergeCommand : QgsComposerItemCommand
       ScaleBarMapUnitsSegment,
       ScaleBarLabelBarSize,
       ScaleBarBoxContentSpace,
+      ScaleBarFontColor,
+      ScaleBarFillColor,
+      ScaleBarFill2Color,
+      ScaleBarStrokeColor,
       // composer table
       TableMaximumFeatures,
       TableMargin,
@@ -90,9 +103,13 @@ class QgsComposerMergeCommand : QgsComposerItemCommand
       ShapeOutlineWidth,
       //composer arrow
       ArrowOutlineWidth,
+      ArrowHeadFillColor,
+      ArrowHeadOutlineColor,
       ArrowHeadWidth,
       //item
       ItemOutlineWidth,
+      ItemOutlineColor,
+      ItemBackgroundColor,
       ItemMove,
       ItemRotation,
       ItemTransparency,

--- a/python/core/composer/qgscomposermultiframecommand.sip
+++ b/python/core/composer/qgscomposermultiframecommand.sip
@@ -49,7 +49,11 @@ class QgsComposerMultiFrameMergeCommand: QgsComposerMultiFrameCommand
       TableMaximumFeatures,
       TableMargin,
       TableGridStrokeWidth,
-      TableCellStyle
+      TableCellStyle,
+      TableHeaderFontColor,
+      TableContentFontColor,
+      TableGridColor,
+      TableBackgroundColor,
     };
 
     QgsComposerMultiFrameMergeCommand( Context c, QgsComposerMultiFrame* multiFrame, const QString& text );

--- a/src/app/composer/qgscomposer.h
+++ b/src/app/composer/qgscomposer.h
@@ -18,6 +18,7 @@
 #define QGSCOMPOSER_H
 #include "ui_qgscomposerbase.h"
 
+#include "qgspanelwidget.h"
 class QgisApp;
 class QgsComposerArrow;
 class QgsComposerPolygon;
@@ -44,6 +45,7 @@ class QgsDockWidget;
 class QgsMapLayer;
 class QgsFeature;
 class QgsVectorLayer;
+class QgsPanelWidgetStack;
 
 class QGridLayout;
 class QDomNode;
@@ -568,7 +570,7 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
     QSizeGrip *mSizeGrip;
 
     //! To know which item to show if selection changes
-    QMap<QgsComposerItem*, QWidget*> mItemWidgetMap;
+    QMap<QgsComposerItem*, QgsPanelWidget*> mItemWidgetMap;
 
     //! Window menu action to select this window
     QAction *mWindowAction;
@@ -597,6 +599,7 @@ class QgsComposer: public QMainWindow, private Ui::QgsComposerBase
     QMap< QgsComposerMap*, int > mMapsToRestore;
 
     QgsDockWidget* mItemDock;
+    QgsPanelWidgetStack* mItemPropertiesStack;
     QgsDockWidget* mUndoDock;
     QgsDockWidget* mGeneralDock;
     QgsDockWidget* mAtlasDock;

--- a/src/app/composer/qgscomposerarrowwidget.cpp
+++ b/src/app/composer/qgscomposerarrowwidget.cpp
@@ -28,6 +28,7 @@
 QgsComposerArrowWidget::QgsComposerArrowWidget( QgsComposerArrow* arrow ): QgsComposerItemBaseWidget( nullptr, arrow ), mArrow( arrow )
 {
   setupUi( this );
+  setPanelTitle( tr( "Arrow properties" ) );
   mRadioButtonGroup = new QButtonGroup( this );
   mRadioButtonGroup->addButton( mDefaultMarkerRadioButton );
   mRadioButtonGroup->addButton( mNoMarkerRadioButton );

--- a/src/app/composer/qgscomposerarrowwidget.cpp
+++ b/src/app/composer/qgscomposerarrowwidget.cpp
@@ -99,7 +99,7 @@ void QgsComposerArrowWidget::on_mArrowHeadFillColorButton_colorChanged( const QC
     return;
   }
 
-  mArrow->beginCommand( tr( "Arrow head fill color" ) );
+  mArrow->beginCommand( tr( "Arrow head fill color" ), QgsComposerMergeCommand::ArrowHeadFillColor );
   mArrow->setArrowHeadFillColor( newColor );
   mArrow->update();
   mArrow->endCommand();
@@ -112,7 +112,7 @@ void QgsComposerArrowWidget::on_mArrowHeadOutlineColorButton_colorChanged( const
     return;
   }
 
-  mArrow->beginCommand( tr( "Arrow head outline color" ) );
+  mArrow->beginCommand( tr( "Arrow head outline color" ), QgsComposerMergeCommand::ArrowHeadOutlineColor );
   mArrow->setArrowHeadOutlineColor( newColor );
   mArrow->update();
   mArrow->endCommand();

--- a/src/app/composer/qgscomposerattributetablewidget.cpp
+++ b/src/app/composer/qgscomposerattributetablewidget.cpp
@@ -269,7 +269,7 @@ void QgsComposerAttributeTableWidget::on_mHeaderFontColorButton_colorChanged( co
   QgsComposition* composition = mComposerTable->composition();
   if ( composition )
   {
-    composition->beginMultiFrameCommand( mComposerTable, tr( "Table header font color" ) );
+    composition->beginMultiFrameCommand( mComposerTable, tr( "Table header font color" ), QgsComposerMultiFrameMergeCommand::TableHeaderFontColor );
   }
   mComposerTable->setHeaderFontColor( newColor );
   if ( composition )
@@ -310,7 +310,7 @@ void QgsComposerAttributeTableWidget::on_mContentFontColorButton_colorChanged( c
   QgsComposition* composition = mComposerTable->composition();
   if ( composition )
   {
-    composition->beginMultiFrameCommand( mComposerTable, tr( "Table content font color" ) );
+    composition->beginMultiFrameCommand( mComposerTable, tr( "Table content font color" ), QgsComposerMultiFrameMergeCommand::TableContentFontColor );
   }
   mComposerTable->setContentFontColor( newColor );
   if ( composition )
@@ -348,7 +348,7 @@ void QgsComposerAttributeTableWidget::on_mGridColorButton_colorChanged( const QC
   QgsComposition* composition = mComposerTable->composition();
   if ( composition )
   {
-    composition->beginMultiFrameCommand( mComposerTable, tr( "Table grid color" ) );
+    composition->beginMultiFrameCommand( mComposerTable, tr( "Table grid color" ), QgsComposerMultiFrameMergeCommand::TableGridColor );
   }
   mComposerTable->setGridColor( newColor );
   if ( composition )
@@ -386,7 +386,7 @@ void QgsComposerAttributeTableWidget::on_mBackgroundColorButton_colorChanged( co
   QgsComposition* composition = mComposerTable->composition();
   if ( composition )
   {
-    composition->beginMultiFrameCommand( mComposerTable, tr( "Table background color" ) );
+    composition->beginMultiFrameCommand( mComposerTable, tr( "Table background color" ), QgsComposerMultiFrameMergeCommand::TableBackgroundColor );
   }
   mComposerTable->setBackgroundColor( newColor );
   if ( composition )

--- a/src/app/composer/qgscomposerattributetablewidget.cpp
+++ b/src/app/composer/qgscomposerattributetablewidget.cpp
@@ -39,6 +39,7 @@ QgsComposerAttributeTableWidget::QgsComposerAttributeTableWidget( QgsComposerAtt
     , mFrame( frame )
 {
   setupUi( this );
+  setPanelTitle( tr( "Table properties" ) );
 
   blockAllSignals( true );
 

--- a/src/app/composer/qgscomposerhtmlwidget.cpp
+++ b/src/app/composer/qgscomposerhtmlwidget.cpp
@@ -31,6 +31,7 @@ QgsComposerHtmlWidget::QgsComposerHtmlWidget( QgsComposerHtml* html, QgsComposer
     , mFrame( frame )
 {
   setupUi( this );
+  setPanelTitle( tr( "HTML properties" ) );
 
   //setup html editor
   mHtmlEditor = new QgsCodeEditorHTML( this );

--- a/src/app/composer/qgscomposeritemwidget.cpp
+++ b/src/app/composer/qgscomposeritemwidget.cpp
@@ -210,7 +210,7 @@ void QgsComposerItemWidget::on_mFrameColorButton_colorChanged( const QColor& new
   {
     return;
   }
-  mItem->beginCommand( tr( "Frame color changed" ) );
+  mItem->beginCommand( tr( "Frame color changed" ), QgsComposerMergeCommand::ItemOutlineColor );
   mItem->setFrameOutlineColor( newFrameColor );
   mItem->update();
   mItem->endCommand();
@@ -230,7 +230,7 @@ void QgsComposerItemWidget::on_mBackgroundColorButton_colorChanged( const QColor
   {
     return;
   }
-  mItem->beginCommand( tr( "Background color changed" ) );
+  mItem->beginCommand( tr( "Background color changed" ), QgsComposerMergeCommand::ItemBackgroundColor );
   mItem->setBackgroundColor( newBackgroundColor );
 
   //if the item is a composer map, we need to regenerate the map image

--- a/src/app/composer/qgscomposeritemwidget.cpp
+++ b/src/app/composer/qgscomposeritemwidget.cpp
@@ -30,18 +30,20 @@
 
 //QgsComposerItemBaseWidget
 
-QgsComposerItemBaseWidget::QgsComposerItemBaseWidget( QWidget* parent, QgsComposerObject *composerObject ): QWidget( parent ), mComposerObject( composerObject )
+QgsComposerConfigObject::QgsComposerConfigObject( QWidget* parent, QgsComposerObject *composerObject )
+    : QObject( parent )
+    , mComposerObject( composerObject )
 {
   connect( atlasComposition(), SIGNAL( coverageLayerChanged( QgsVectorLayer* ) ),
            this, SLOT( updateDataDefinedButtons() ) );
   connect( atlasComposition(), SIGNAL( toggled( bool ) ), this, SLOT( updateDataDefinedButtons() ) );
 }
 
-QgsComposerItemBaseWidget::~QgsComposerItemBaseWidget()
+QgsComposerConfigObject::~QgsComposerConfigObject()
 {
 }
 
-void QgsComposerItemBaseWidget::updateDataDefinedProperty()
+void QgsComposerConfigObject::updateDataDefinedProperty()
 {
   //match data defined button to item's data defined property
   QgsDataDefinedButton* ddButton = dynamic_cast<QgsDataDefinedButton*>( sender() );
@@ -64,7 +66,7 @@ void QgsComposerItemBaseWidget::updateDataDefinedProperty()
   mComposerObject->refreshDataDefinedProperty( property );
 }
 
-void QgsComposerItemBaseWidget::updateDataDefinedButtons()
+void QgsComposerConfigObject::updateDataDefinedButtons()
 {
   Q_FOREACH ( QgsDataDefinedButton* button, findChildren< QgsDataDefinedButton* >() )
   {
@@ -72,7 +74,7 @@ void QgsComposerItemBaseWidget::updateDataDefinedButtons()
   }
 }
 
-void QgsComposerItemBaseWidget::setDataDefinedProperty( const QgsDataDefinedButton *ddBtn, QgsComposerObject::DataDefinedProperty p )
+void QgsComposerConfigObject::setDataDefinedProperty( const QgsDataDefinedButton *ddBtn, QgsComposerObject::DataDefinedProperty p )
 {
   if ( !mComposerObject )
   {
@@ -83,7 +85,7 @@ void QgsComposerItemBaseWidget::setDataDefinedProperty( const QgsDataDefinedButt
   mComposerObject->setDataDefinedProperty( p, map.value( "active" ).toInt(), map.value( "useexpr" ).toInt(), map.value( "expression" ), map.value( "field" ) );
 }
 
-void QgsComposerItemBaseWidget::registerDataDefinedButton( QgsDataDefinedButton* button, QgsComposerObject::DataDefinedProperty property,
+void QgsComposerConfigObject::registerDataDefinedButton( QgsDataDefinedButton* button, QgsComposerObject::DataDefinedProperty property,
     QgsDataDefinedButton::DataType type, const QString& description )
 {
   button->blockSignals( true );
@@ -98,7 +100,7 @@ void QgsComposerItemBaseWidget::registerDataDefinedButton( QgsDataDefinedButton*
   button->blockSignals( false );
 }
 
-QgsAtlasComposition* QgsComposerItemBaseWidget::atlasComposition() const
+QgsAtlasComposition* QgsComposerConfigObject::atlasComposition() const
 {
   if ( !mComposerObject )
   {
@@ -115,7 +117,7 @@ QgsAtlasComposition* QgsComposerItemBaseWidget::atlasComposition() const
   return &composition->atlasComposition();
 }
 
-QgsVectorLayer* QgsComposerItemBaseWidget::atlasCoverageLayer() const
+QgsVectorLayer* QgsComposerConfigObject::atlasCoverageLayer() const
 {
   QgsAtlasComposition* atlasMap = atlasComposition();
 
@@ -140,8 +142,9 @@ void QgsComposerItemWidget::updateVariables()
 }
 
 QgsComposerItemWidget::QgsComposerItemWidget( QWidget* parent, QgsComposerItem* item )
-    : QgsComposerItemBaseWidget( parent, item )
+    : QWidget( parent )
     , mItem( item )
+    , mConfigObject( new QgsComposerConfigObject( this, item ) )
     , mFreezeXPosSpin( false )
     , mFreezeYPosSpin( false )
     , mFreezeWidthSpin( false )
@@ -182,18 +185,6 @@ QgsComposerItemWidget::QgsComposerItemWidget( QWidget* parent, QgsComposerItem* 
   connect( QgsProject::instance(), SIGNAL( variablesChanged() ), this, SLOT( updateVariables() ) );
   if ( mItem->composition() )
     connect( mItem->composition(), SIGNAL( variablesChanged() ), this, SLOT( updateVariables() ) );
-}
-
-QgsComposerItemWidget::QgsComposerItemWidget()
-    : QgsComposerItemBaseWidget( nullptr, nullptr )
-    , mItem( nullptr )
-    , mFreezeXPosSpin( false )
-    , mFreezeYPosSpin( false )
-    , mFreezeWidthSpin( false )
-    , mFreezeHeightSpin( false )
-    , mFreezePageSpin( false )
-{
-
 }
 
 QgsComposerItemWidget::~QgsComposerItemWidget()
@@ -552,22 +543,22 @@ void QgsComposerItemWidget::setValuesForGuiNonPositionElements()
 
 void QgsComposerItemWidget::populateDataDefinedButtons()
 {
-  registerDataDefinedButton( mXPositionDDBtn, QgsComposerObject::PositionX,
-                             QgsDataDefinedButton::AnyType, QgsDataDefinedButton::doubleDesc() );
-  registerDataDefinedButton( mYPositionDDBtn, QgsComposerObject::PositionY,
-                             QgsDataDefinedButton::AnyType, QgsDataDefinedButton::doubleDesc() );
-  registerDataDefinedButton( mWidthDDBtn, QgsComposerObject::ItemWidth,
-                             QgsDataDefinedButton::AnyType, QgsDataDefinedButton::doubleDesc() );
-  registerDataDefinedButton( mHeightDDBtn, QgsComposerObject::ItemHeight,
-                             QgsDataDefinedButton::AnyType, QgsDataDefinedButton::doubleDesc() );
-  registerDataDefinedButton( mItemRotationDDBtn, QgsComposerObject::ItemRotation,
-                             QgsDataDefinedButton::AnyType, QgsDataDefinedButton::double180RotDesc() );
-  registerDataDefinedButton( mTransparencyDDBtn, QgsComposerObject::Transparency,
-                             QgsDataDefinedButton::AnyType, QgsDataDefinedButton::intTranspDesc() );
-  registerDataDefinedButton( mBlendModeDDBtn, QgsComposerObject::BlendMode,
-                             QgsDataDefinedButton::String, QgsDataDefinedButton::blendModesDesc() );
-  registerDataDefinedButton( mExcludePrintsDDBtn, QgsComposerObject::ExcludeFromExports,
-                             QgsDataDefinedButton::String, QgsDataDefinedButton::boolDesc() );
+  mConfigObject->registerDataDefinedButton( mXPositionDDBtn, QgsComposerObject::PositionX,
+      QgsDataDefinedButton::AnyType, QgsDataDefinedButton::doubleDesc() );
+  mConfigObject->registerDataDefinedButton( mYPositionDDBtn, QgsComposerObject::PositionY,
+      QgsDataDefinedButton::AnyType, QgsDataDefinedButton::doubleDesc() );
+  mConfigObject->registerDataDefinedButton( mWidthDDBtn, QgsComposerObject::ItemWidth,
+      QgsDataDefinedButton::AnyType, QgsDataDefinedButton::doubleDesc() );
+  mConfigObject->registerDataDefinedButton( mHeightDDBtn, QgsComposerObject::ItemHeight,
+      QgsDataDefinedButton::AnyType, QgsDataDefinedButton::doubleDesc() );
+  mConfigObject->registerDataDefinedButton( mItemRotationDDBtn, QgsComposerObject::ItemRotation,
+      QgsDataDefinedButton::AnyType, QgsDataDefinedButton::double180RotDesc() );
+  mConfigObject->registerDataDefinedButton( mTransparencyDDBtn, QgsComposerObject::Transparency,
+      QgsDataDefinedButton::AnyType, QgsDataDefinedButton::intTranspDesc() );
+  mConfigObject->registerDataDefinedButton( mBlendModeDDBtn, QgsComposerObject::BlendMode,
+      QgsDataDefinedButton::String, QgsDataDefinedButton::blendModesDesc() );
+  mConfigObject->registerDataDefinedButton( mExcludePrintsDDBtn, QgsComposerObject::ExcludeFromExports,
+      QgsDataDefinedButton::String, QgsDataDefinedButton::boolDesc() );
 }
 
 void QgsComposerItemWidget::setValuesForGuiElements()
@@ -785,4 +776,26 @@ void QgsComposerItemWidget::on_mExcludeFromPrintsCheckBox_toggled( bool checked 
     mItem->setExcludeFromExports( checked );
     mItem->endCommand();
   }
+}
+
+QgsComposerItemBaseWidget::QgsComposerItemBaseWidget( QWidget* parent, QgsComposerObject* composerObject )
+    : QgsPanelWidget( parent )
+    , mConfigObject( new QgsComposerConfigObject( this, composerObject ) )
+{
+
+}
+
+void QgsComposerItemBaseWidget::registerDataDefinedButton( QgsDataDefinedButton* button, QgsComposerObject::DataDefinedProperty property, QgsDataDefinedButton::DataType type, const QString& description )
+{
+  mConfigObject->registerDataDefinedButton( button, property, type, description );
+}
+
+QgsVectorLayer* QgsComposerItemBaseWidget::atlasCoverageLayer() const
+{
+  return mConfigObject->atlasCoverageLayer();
+}
+
+QgsAtlasComposition* QgsComposerItemBaseWidget::atlasComposition() const
+{
+  return mConfigObject->atlasComposition();
 }

--- a/src/app/composer/qgscomposerlabelwidget.cpp
+++ b/src/app/composer/qgscomposerlabelwidget.cpp
@@ -29,6 +29,7 @@
 QgsComposerLabelWidget::QgsComposerLabelWidget( QgsComposerLabel* label ): QgsComposerItemBaseWidget( nullptr, label ), mComposerLabel( label )
 {
   setupUi( this );
+  setPanelTitle( tr( "Label properties" ) );
 
   //add widget for general composer item properties
   QgsComposerItemWidget* itemPropertiesWidget = new QgsComposerItemWidget( this, label );

--- a/src/app/composer/qgscomposerlabelwidget.cpp
+++ b/src/app/composer/qgscomposerlabelwidget.cpp
@@ -125,7 +125,7 @@ void QgsComposerLabelWidget::on_mFontColorButton_colorChanged( const QColor &new
     return;
   }
 
-  mComposerLabel->beginCommand( tr( "Label color changed" ) );
+  mComposerLabel->beginCommand( tr( "Label color changed" ), QgsComposerMergeCommand::ComposerLabelFontColor );
   mComposerLabel->setFontColor( newLabelColor );
   mComposerLabel->update();
   mComposerLabel->endCommand();

--- a/src/app/composer/qgscomposerlegendwidget.cpp
+++ b/src/app/composer/qgscomposerlegendwidget.cpp
@@ -47,6 +47,7 @@ QgsComposerLegendWidget::QgsComposerLegendWidget( QgsComposerLegend* legend )
     , mLegend( legend )
 {
   setupUi( this );
+  setPanelTitle( tr( "Legend properties" ) );
 
   // setup icons
   mAddToolButton->setIcon( QIcon( QgsApplication::iconPath( "symbologyAdd.svg" ) ) );

--- a/src/app/composer/qgscomposerlegendwidget.cpp
+++ b/src/app/composer/qgscomposerlegendwidget.cpp
@@ -406,7 +406,7 @@ void QgsComposerLegendWidget::on_mFontColorButton_colorChanged( const QColor& ne
     return;
   }
 
-  mLegend->beginCommand( tr( "Legend font color changed" ) );
+  mLegend->beginCommand( tr( "Legend font color changed" ), QgsComposerMergeCommand::LegendFontColor );
   mLegend->setFontColor( newFontColor );
   mLegend->update();
   mLegend->endCommand();
@@ -624,7 +624,7 @@ void QgsComposerLegendWidget::on_mRasterBorderColorButton_colorChanged( const QC
     return;
   }
 
-  mLegend->beginCommand( tr( "Legend raster border color" ) );
+  mLegend->beginCommand( tr( "Legend raster border color" ), QgsComposerMergeCommand::LegendRasterBorderColor );
   mLegend->setRasterBorderColor( newColor );
   mLegend->update();
   mLegend->endCommand();

--- a/src/app/composer/qgscomposermapwidget.cpp
+++ b/src/app/composer/qgscomposermapwidget.cpp
@@ -1730,7 +1730,7 @@ void QgsComposerMapWidget::on_mGridFramePenColorButton_colorChanged( const QColo
     return;
   }
 
-  mComposerMap->beginCommand( tr( "Grid frame color changed" ) );
+  mComposerMap->beginCommand( tr( "Grid frame color changed" ), QgsComposerMergeCommand::ComposerMapGridFramePenColor );
   grid->setFramePenColor( newColor );
   mComposerMap->update();
   mComposerMap->endCommand();
@@ -1744,7 +1744,7 @@ void QgsComposerMapWidget::on_mGridFrameFill1ColorButton_colorChanged( const QCo
     return;
   }
 
-  mComposerMap->beginCommand( tr( "Grid frame first fill color changed" ) );
+  mComposerMap->beginCommand( tr( "Grid frame first fill color changed" ), QgsComposerMergeCommand::ComposerMapGridFrameFill1Color );
   grid->setFrameFillColor1( newColor );
   mComposerMap->update();
   mComposerMap->endCommand();
@@ -1758,7 +1758,7 @@ void QgsComposerMapWidget::on_mGridFrameFill2ColorButton_colorChanged( const QCo
     return;
   }
 
-  mComposerMap->beginCommand( tr( "Grid frame second fill color changed" ) );
+  mComposerMap->beginCommand( tr( "Grid frame second fill color changed" ), QgsComposerMergeCommand::ComposerMapGridFrameFill2Color );
   grid->setFrameFillColor2( newColor );
   mComposerMap->update();
   mComposerMap->endCommand();
@@ -2077,7 +2077,7 @@ void QgsComposerMapWidget::on_mAnnotationFontColorButton_colorChanged( const QCo
     return;
   }
 
-  mComposerMap->beginCommand( tr( "Annotation color changed" ) );
+  mComposerMap->beginCommand( tr( "Annotation color changed" ), QgsComposerMergeCommand::ComposerMapGridAnnotationFontColor );
   grid->setAnnotationFontColor( color );
   mComposerMap->update();
   mComposerMap->endCommand();

--- a/src/app/composer/qgscomposermapwidget.cpp
+++ b/src/app/composer/qgscomposermapwidget.cpp
@@ -48,6 +48,7 @@ QgsComposerMapWidget::QgsComposerMapWidget( QgsComposerMap* composerMap )
     , mComposerMap( composerMap )
 {
   setupUi( this );
+  setPanelTitle( tr( "Map properties" ) );
 
   //add widget for general composer item properties
   QgsComposerItemWidget* itemPropertiesWidget = new QgsComposerItemWidget( this, composerMap );

--- a/src/app/composer/qgscomposerpicturewidget.cpp
+++ b/src/app/composer/qgscomposerpicturewidget.cpp
@@ -633,7 +633,7 @@ void QgsComposerPictureWidget::loadPicturePreviews( bool collapsed )
 
 void QgsComposerPictureWidget::on_mFillColorButton_colorChanged( const QColor& color )
 {
-  mPicture->beginCommand( tr( "Picture fill color changed" ) );
+  mPicture->beginCommand( tr( "Picture fill color changed" ), QgsComposerMergeCommand::ComposerPictureFillColor );
   mPicture->setSvgFillColor( color );
   mPicture->endCommand();
   mPicture->update();
@@ -641,7 +641,7 @@ void QgsComposerPictureWidget::on_mFillColorButton_colorChanged( const QColor& c
 
 void QgsComposerPictureWidget::on_mOutlineColorButton_colorChanged( const QColor& color )
 {
-  mPicture->beginCommand( tr( "Picture border color changed" ) );
+  mPicture->beginCommand( tr( "Picture border color changed" ), QgsComposerMergeCommand::ComposerPictureOutlineColor );
   mPicture->setSvgBorderColor( color );
   mPicture->endCommand();
   mPicture->update();

--- a/src/app/composer/qgscomposerpicturewidget.cpp
+++ b/src/app/composer/qgscomposerpicturewidget.cpp
@@ -36,6 +36,7 @@
 QgsComposerPictureWidget::QgsComposerPictureWidget( QgsComposerPicture* picture ): QgsComposerItemBaseWidget( nullptr, picture ), mPicture( picture ), mPreviewsLoaded( false )
 {
   setupUi( this );
+  setPanelTitle( tr( "Picture properties" ) );
 
   mFillColorButton->setAllowAlpha( true );
   mFillColorButton->setColorDialogTitle( tr( "Select fill color" ) );

--- a/src/app/composer/qgscomposerpolygonwidget.cpp
+++ b/src/app/composer/qgscomposerpolygonwidget.cpp
@@ -26,6 +26,7 @@ QgsComposerPolygonWidget::QgsComposerPolygonWidget( QgsComposerPolygon* composer
     , mComposerPolygon( composerPolygon )
 {
   setupUi( this );
+  setPanelTitle( tr( "Polygon properties" ) );
 
   //add widget for general composer item properties
   QgsComposerItemWidget* itemPropertiesWidget = new QgsComposerItemWidget( this, composerPolygon );

--- a/src/app/composer/qgscomposerpolylinewidget.cpp
+++ b/src/app/composer/qgscomposerpolylinewidget.cpp
@@ -26,6 +26,7 @@ QgsComposerPolylineWidget::QgsComposerPolylineWidget( QgsComposerPolyline* compo
     , mComposerPolyline( composerPolyline )
 {
   setupUi( this );
+  setPanelTitle( tr( "Polyline properties" ) );
 
   //add widget for general composer item properties
   QgsComposerItemWidget* itemPropertiesWidget = new QgsComposerItemWidget( this, composerPolyline );

--- a/src/app/composer/qgscomposerscalebarwidget.cpp
+++ b/src/app/composer/qgscomposerscalebarwidget.cpp
@@ -27,6 +27,8 @@
 QgsComposerScaleBarWidget::QgsComposerScaleBarWidget( QgsComposerScaleBar* scaleBar ): QgsComposerItemBaseWidget( nullptr, scaleBar ), mComposerScaleBar( scaleBar )
 {
   setupUi( this );
+  setPanelTitle( tr( "Scalebar properties" ) );
+
   connectUpdateSignal();
 
   //add widget for general composer item properties

--- a/src/app/composer/qgscomposerscalebarwidget.cpp
+++ b/src/app/composer/qgscomposerscalebarwidget.cpp
@@ -263,7 +263,7 @@ void QgsComposerScaleBarWidget::on_mFontColorButton_colorChanged( const QColor& 
     return;
   }
 
-  mComposerScaleBar->beginCommand( tr( "Scalebar font color changed" ) );
+  mComposerScaleBar->beginCommand( tr( "Scalebar font color changed" ), QgsComposerMergeCommand::ScaleBarFontColor );
   disconnectUpdateSignal();
   mComposerScaleBar->setFontColor( newColor );
   mComposerScaleBar->update();
@@ -278,7 +278,7 @@ void QgsComposerScaleBarWidget::on_mFillColorButton_colorChanged( const QColor& 
     return;
   }
 
-  mComposerScaleBar->beginCommand( tr( "Scalebar color changed" ) );
+  mComposerScaleBar->beginCommand( tr( "Scalebar color changed" ), QgsComposerMergeCommand::ScaleBarFillColor );
   disconnectUpdateSignal();
   QBrush newBrush = mComposerScaleBar->brush();
   newBrush.setColor( newColor );
@@ -295,7 +295,7 @@ void QgsComposerScaleBarWidget::on_mFillColor2Button_colorChanged( const QColor 
     return;
   }
 
-  mComposerScaleBar->beginCommand( tr( "Scalebar secondary color changed" ) );
+  mComposerScaleBar->beginCommand( tr( "Scalebar secondary color changed" ), QgsComposerMergeCommand::ScaleBarFill2Color );
   disconnectUpdateSignal();
   QBrush newBrush = mComposerScaleBar->brush2();
   newBrush.setColor( newColor );
@@ -312,7 +312,7 @@ void QgsComposerScaleBarWidget::on_mStrokeColorButton_colorChanged( const QColor
     return;
   }
 
-  mComposerScaleBar->beginCommand( tr( "Scalebar line color changed" ) );
+  mComposerScaleBar->beginCommand( tr( "Scalebar line color changed" ), QgsComposerMergeCommand::ScaleBarStrokeColor );
   disconnectUpdateSignal();
   QPen newPen = mComposerScaleBar->pen();
   newPen.setColor( newColor );

--- a/src/app/composer/qgscomposershapewidget.cpp
+++ b/src/app/composer/qgscomposershapewidget.cpp
@@ -27,6 +27,7 @@
 QgsComposerShapeWidget::QgsComposerShapeWidget( QgsComposerShape* composerShape ): QgsComposerItemBaseWidget( nullptr, composerShape ), mComposerShape( composerShape )
 {
   setupUi( this );
+  setPanelTitle( tr( "Shape properties" ) );
 
   //add widget for general composer item properties
   QgsComposerItemWidget* itemPropertiesWidget = new QgsComposerItemWidget( this, composerShape );
@@ -109,19 +110,18 @@ void QgsComposerShapeWidget::on_mShapeStyleButton_clicked()
 
   QgsFillSymbol* newSymbol = mComposerShape->shapeStyleSymbol()->clone();
   QgsExpressionContext context = mComposerShape->createExpressionContext();
-  QgsSymbolSelectorDialog d( newSymbol, QgsStyle::defaultStyle(), coverageLayer, this );
+
+
+
+  QgsSymbolSelectorWidget* d = new QgsSymbolSelectorWidget( newSymbol, QgsStyle::defaultStyle(), coverageLayer, nullptr );
   QgsSymbolWidgetContext symbolContext;
   symbolContext.setExpressionContext( &context );
-  d.setContext( symbolContext );
+  d->setContext( symbolContext );
 
-  if ( d.exec() == QDialog::Accepted )
-  {
-    mComposerShape->beginCommand( tr( "Shape style changed" ) );
-    mComposerShape->setShapeStyleSymbol( newSymbol );
-    updateShapeStyle();
-    mComposerShape->endCommand();
-  }
-  delete newSymbol;
+  connect( d, SIGNAL( widgetChanged() ), this, SLOT( updateSymbolFromWidget() ) );
+  connect( d, SIGNAL( panelAccepted( QgsPanelWidget* ) ), this, SLOT( cleanUpSymbolSelector( QgsPanelWidget* ) ) );
+  openPanel( d );
+  mComposerShape->beginCommand( tr( "Shape style changed" ) );
 }
 
 void QgsComposerShapeWidget::updateShapeStyle()
@@ -180,6 +180,23 @@ void QgsComposerShapeWidget::toggleRadiusSpin( const QString& shapeText )
   {
     mCornerRadiusSpinBox->setEnabled( false );
   }
+}
+
+void QgsComposerShapeWidget::updateSymbolFromWidget()
+{
+  QgsSymbolSelectorWidget* w = qobject_cast<QgsSymbolSelectorWidget*>( sender() );
+  mComposerShape->setShapeStyleSymbol( dynamic_cast< QgsFillSymbol* >( w->symbol() ) );
+}
+
+void QgsComposerShapeWidget::cleanUpSymbolSelector( QgsPanelWidget* container )
+{
+  QgsSymbolSelectorWidget* w = qobject_cast<QgsSymbolSelectorWidget*>( container );
+  if ( !w )
+    return;
+
+  delete w->symbol();
+  updateShapeStyle();
+  mComposerShape->endCommand();
 }
 
 

--- a/src/app/composer/qgscomposershapewidget.h
+++ b/src/app/composer/qgscomposershapewidget.h
@@ -49,6 +49,8 @@ class QgsComposerShapeWidget: public QgsComposerItemBaseWidget, private Ui::QgsC
 
     /** Enables or disables the rounded radius spin box based on shape type*/
     void toggleRadiusSpin( const QString& shapeText );
+    void updateSymbolFromWidget();
+    void cleanUpSymbolSelector( QgsPanelWidget* container );
 };
 
 #endif // QGSCOMPOSERSHAPEWIDGET_H

--- a/src/core/composer/qgscomposeritemcommand.h
+++ b/src/core/composer/qgscomposeritemcommand.h
@@ -87,9 +87,14 @@ class CORE_EXPORT QgsComposerMergeCommand: public QgsComposerItemCommand
       //composer label
       ComposerLabelSetText,
       ComposerLabelSetId,
+      ComposerLabelFontColor,
       //composer map
       ComposerMapRotation,
       ComposerMapAnnotationDistance,
+      ComposerMapGridFramePenColor,
+      ComposerMapGridFrameFill1Color,
+      ComposerMapGridFrameFill2Color,
+      ComposerMapGridAnnotationFontColor,
       //composer legend
       ComposerLegendText,
       LegendColumnCount,
@@ -107,8 +112,12 @@ class CORE_EXPORT QgsComposerMergeCommand: public QgsComposerItemCommand
       LegendBoxSpace,
       LegendColumnSpace,
       LegendRasterBorderWidth,
+      LegendFontColor,
+      LegendRasterBorderColor,
       //composer picture
       ComposerPictureRotation,
+      ComposerPictureFillColor,
+      ComposerPictureOutlineColor,
       // composer scalebar
       ScaleBarLineWidth,
       ScaleBarHeight,
@@ -119,6 +128,10 @@ class CORE_EXPORT QgsComposerMergeCommand: public QgsComposerItemCommand
       ScaleBarMapUnitsSegment,
       ScaleBarLabelBarSize,
       ScaleBarBoxContentSpace,
+      ScaleBarFontColor,
+      ScaleBarFillColor,
+      ScaleBarFill2Color,
+      ScaleBarStrokeColor,
       // composer table
       TableMaximumFeatures,
       TableMargin,
@@ -128,9 +141,13 @@ class CORE_EXPORT QgsComposerMergeCommand: public QgsComposerItemCommand
       ShapeOutlineWidth,
       //composer arrow
       ArrowOutlineWidth,
+      ArrowHeadFillColor,
+      ArrowHeadOutlineColor,
       ArrowHeadWidth,
       //item
       ItemOutlineWidth,
+      ItemOutlineColor,
+      ItemBackgroundColor,
       ItemMove,
       ItemRotation,
       ItemTransparency,

--- a/src/core/composer/qgscomposermultiframecommand.h
+++ b/src/core/composer/qgscomposermultiframecommand.h
@@ -78,7 +78,11 @@ class CORE_EXPORT QgsComposerMultiFrameMergeCommand: public QgsComposerMultiFram
       TableMaximumFeatures,
       TableMargin,
       TableGridStrokeWidth,
-      TableCellStyle
+      TableCellStyle,
+      TableHeaderFontColor,
+      TableContentFontColor,
+      TableGridColor,
+      TableBackgroundColor,
     };
 
     QgsComposerMultiFrameMergeCommand( Context c, QgsComposerMultiFrame* multiFrame, const QString& text );


### PR DESCRIPTION
This PR brings the wonder of the stacked panel approach from the live styling dock across to composer item configuration. It avoids annoying modal dialogs for things like color changes and lets you see the results instantly.

I think this could be a good solution to the UI bloat which composer item properties are suffering from. Eg we could put things like grid configuration into a separate inline panel which only shows on demand.
