### PR TITLE
[db manager] non-spatial import & spatialite error reporting fixes

### DIFF
--- a/python/plugins/db_manager/db_plugins/spatialite/connector.py
+++ b/python/plugins/db_manager/db_plugins/spatialite/connector.py
@@ -31,6 +31,7 @@ from ..connector import DBConnector
 from ..plugin import ConnectionError, DbError, Table
 
 from qgis.utils import spatialite_connect
+import sqlite3 as sqlite
 
 
 def classFactory():

--- a/python/plugins/db_manager/dlg_export_vector.py
+++ b/python/plugins/db_manager/dlg_export_vector.py
@@ -163,7 +163,7 @@ class DlgExportVector(QDialog, Ui_Dialog):
             if self.chkDropTable.isChecked():
                 options['overwrite'] = True
 
-            outCrs = None
+            outCrs = QgsCoordinateReferenceSystem
             if self.chkTargetSrid.isEnabled() and self.chkTargetSrid.isChecked():
                 targetSrid = int(self.editTargetSrid.text())
                 outCrs = QgsCoordinateReferenceSystem(targetSrid)

--- a/python/plugins/db_manager/dlg_export_vector.py
+++ b/python/plugins/db_manager/dlg_export_vector.py
@@ -163,7 +163,7 @@ class DlgExportVector(QDialog, Ui_Dialog):
             if self.chkDropTable.isChecked():
                 options['overwrite'] = True
 
-            outCrs = QgsCoordinateReferenceSystem
+            outCrs = QgsCoordinateReferenceSystem()
             if self.chkTargetSrid.isEnabled() and self.chkTargetSrid.isChecked():
                 targetSrid = int(self.editTargetSrid.text())
                 outCrs = QgsCoordinateReferenceSystem(targetSrid)

--- a/python/plugins/db_manager/dlg_import_vector.py
+++ b/python/plugins/db_manager/dlg_import_vector.py
@@ -315,7 +315,7 @@ class DlgImportVector(QDialog, Ui_Dialog):
             if self.chkSinglePart.isEnabled() and self.chkSinglePart.isChecked():
                 options['forceSinglePartGeometryType'] = True
 
-            outCrs = None
+            outCrs = QgsCoordinateReferenceSystem()
             if self.chkTargetSrid.isEnabled() and self.chkTargetSrid.isChecked():
                 targetSrid = int(self.editTargetSrid.text())
                 outCrs = QgsCoordinateReferenceSystem(targetSrid)


### PR DESCRIPTION
@nyalldawson , can you review this? The first commit is linked to your improvements of QgsCoordinateReferenceSystem.

The second commit fix spatialite error reporting following our use of qgis.utils' spatialite_connect method.
