### PR TITLE
Fix editor widgets default behaviors.

### DIFF
--- a/python/gui/editorwidgets/core/qgseditorwidgetfactory.sip
+++ b/python/gui/editorwidgets/core/qgseditorwidgetfactory.sip
@@ -189,4 +189,16 @@ class QgsEditorWidgetFactory
      * @see supportsField( QgsVectorLayer* vl, fieldIdx )
      */
     virtual unsigned int fieldScore( const QgsVectorLayer* vl, int fieldIdx ) const;
+
+  protected:
+
+    /**
+     * Copy the given config element to a XML attribute.
+     */
+    static void config2xml( const QgsEditorWidgetConfig& config, QDomElement& configElement, const QString& fieldName );
+
+    /**
+     * Copy the given XML attribute to the configuration element.
+     */
+    static void xml2config( const QDomElement& configElement, QgsEditorWidgetConfig& config, const QString& fieldName );
 };

--- a/src/gui/editorwidgets/core/qgseditorwidgetfactory.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetfactory.cpp
@@ -123,3 +123,27 @@ unsigned int QgsEditorWidgetFactory::fieldScore( const QgsVectorLayer* vl, int f
   return 5;
 }
 
+void QgsEditorWidgetFactory::config2xml( const QgsEditorWidgetConfig& config, QDomElement& configElement, const QString& fieldName )
+{
+  const QVariant value = config.value( fieldName );
+  if ( value.isValid() )
+  {
+    if ( value.type() == QVariant::Bool )
+    {
+      configElement.setAttribute( fieldName, value.toBool() ? "1" : "0" );
+    }
+    else
+    {
+      configElement.setAttribute( fieldName, value.toString() );
+    }
+  }
+}
+
+void QgsEditorWidgetFactory::xml2config( const QDomElement& configElement, QgsEditorWidgetConfig& config, const QString& fieldName )
+{
+  const QString value = configElement.attribute( fieldName );
+  if ( !value.isNull() )
+  {
+    config.insert( fieldName, value );
+  }
+}

--- a/src/gui/editorwidgets/core/qgseditorwidgetfactory.h
+++ b/src/gui/editorwidgets/core/qgseditorwidgetfactory.h
@@ -207,6 +207,18 @@ class GUI_EXPORT QgsEditorWidgetFactory
      */
     virtual unsigned int fieldScore( const QgsVectorLayer* vl, int fieldIdx ) const;
 
+  protected:
+
+    /**
+     * Copy the given config element to a XML attribute.
+     */
+    static void config2xml( const QgsEditorWidgetConfig& config, QDomElement& configElement, const QString& fieldName );
+
+    /**
+     * Copy the given XML attribute to the configuration element.
+     */
+    static void xml2config( const QDomElement& configElement, QgsEditorWidgetConfig& config, const QString& fieldName );
+
   private:
     QString mName;
 };

--- a/src/gui/editorwidgets/qgscheckboxwidgetfactory.cpp
+++ b/src/gui/editorwidgets/qgscheckboxwidgetfactory.cpp
@@ -45,8 +45,8 @@ QgsEditorWidgetConfig QgsCheckboxWidgetFactory::readConfig( const QDomElement& c
 
   QgsEditorWidgetConfig cfg;
 
-  cfg.insert( QStringLiteral( "CheckedState" ), configElement.attribute( QStringLiteral( "CheckedState" ) ) );
-  cfg.insert( QStringLiteral( "UncheckedState" ), configElement.attribute( QStringLiteral( "UncheckedState" ) ) );
+  xml2config( configElement, cfg, QStringLiteral( "CheckedState" ) );
+  xml2config( configElement, cfg, QStringLiteral( "UncheckedState" ) );
 
   return cfg;
 }
@@ -57,8 +57,8 @@ void QgsCheckboxWidgetFactory::writeConfig( const QgsEditorWidgetConfig& config,
   Q_UNUSED( layer )
   Q_UNUSED( fieldIdx )
 
-  configElement.setAttribute( QStringLiteral( "CheckedState" ), config.value( QStringLiteral( "CheckedState" ), "1" ).toString() );
-  configElement.setAttribute( QStringLiteral( "UncheckedState" ), config.value( QStringLiteral( "UncheckedState" ), "0" ).toString() );
+  config2xml( config, configElement, QStringLiteral( "CheckedState" ) );
+  config2xml( config, configElement, QStringLiteral( "UncheckedState" ) );
 }
 
 QHash<const char*, int> QgsCheckboxWidgetFactory::supportedWidgetTypes()

--- a/src/gui/editorwidgets/qgsdatetimeeditfactory.cpp
+++ b/src/gui/editorwidgets/qgsdatetimeeditfactory.cpp
@@ -47,10 +47,10 @@ QgsEditorWidgetConfig QgsDateTimeEditFactory::readConfig( const QDomElement& con
   Q_UNUSED( fieldIdx );
   QgsEditorWidgetConfig cfg;
 
-  cfg.insert( QStringLiteral( "field_format" ), configElement.attribute( QStringLiteral( "field_format" ) ) );
-  cfg.insert( QStringLiteral( "display_format" ), configElement.attribute( QStringLiteral( "display_format" ) ) );
-  cfg.insert( QStringLiteral( "calendar_popup" ), configElement.attribute( QStringLiteral( "calendar_popup" ) ) == QLatin1String( "1" ) );
-  cfg.insert( QStringLiteral( "allow_null" ), configElement.attribute( QStringLiteral( "allow_null" ) ) == QLatin1String( "1" ) );
+  xml2config( configElement, cfg, QStringLiteral( "field_format" ) );
+  xml2config( configElement, cfg, QStringLiteral( "display_format" ) );
+  xml2config( configElement, cfg, QStringLiteral( "calendar_popup" ) );
+  xml2config( configElement, cfg, QStringLiteral( "allow_null" ) );
 
   return cfg;
 }
@@ -61,10 +61,10 @@ void QgsDateTimeEditFactory::writeConfig( const QgsEditorWidgetConfig& config, Q
   Q_UNUSED( layer );
   Q_UNUSED( fieldIdx );
 
-  configElement.setAttribute( QStringLiteral( "field_format" ), config[QStringLiteral( "field_format" )].toString() );
-  configElement.setAttribute( QStringLiteral( "display_format" ), config[QStringLiteral( "display_format" )].toString() );
-  configElement.setAttribute( QStringLiteral( "calendar_popup" ), config[QStringLiteral( "calendar_popup" )].toBool() );
-  configElement.setAttribute( QStringLiteral( "allow_null" ), config[QStringLiteral( "allow_null" )].toBool() );
+  config2xml( config, configElement, QStringLiteral( "field_format" ) );
+  config2xml( config, configElement, QStringLiteral( "display_format" ) );
+  config2xml( config, configElement, QStringLiteral( "calendar_popup" ) );
+  config2xml( config, configElement, QStringLiteral( "allow_null" ) );
 }
 
 QString QgsDateTimeEditFactory::representValue( QgsVectorLayer* vl, int fieldIdx, const QgsEditorWidgetConfig& config, const QVariant& cache, const QVariant& value ) const

--- a/src/gui/editorwidgets/qgsexternalresourcewidgetfactory.cpp
+++ b/src/gui/editorwidgets/qgsexternalresourcewidgetfactory.cpp
@@ -40,36 +40,17 @@ void QgsExternalResourceWidgetFactory::writeConfig( const QgsEditorWidgetConfig&
   Q_UNUSED( layer )
   Q_UNUSED( fieldIdx )
 
-  configElement.setAttribute( QStringLiteral( "FileWidget" ), config.value( QStringLiteral( "FileWidget" ), true ).toBool() );
-  configElement.setAttribute( QStringLiteral( "FileWidgetButton" ), config.value( QStringLiteral( "FileWidgetButton" ), true ).toBool() );
-
-
-  // Non mandatory options are not saved into project file (to save some space).
-  if ( config.contains( QStringLiteral( "UseLink" ) ) )
-    configElement.setAttribute( QStringLiteral( "UseLink" ), config.value( QStringLiteral( "UseLink" ) ).toBool() );
-
-  if ( config.contains( QStringLiteral( "FullUrl" ) ) )
-    configElement.setAttribute( QStringLiteral( "FullUrl" ), config.value( QStringLiteral( "FullUrl" ) ).toBool() );
-
-  if ( config.contains( QStringLiteral( "DefaultRoot" ) ) )
-    configElement.setAttribute( QStringLiteral( "DefaultRoot" ), config.value( QStringLiteral( "DefaultRoot" ) ).toString() );
-
-  if ( config.contains( QStringLiteral( "RelativeStorage" ) ) )
-    configElement.setAttribute( QStringLiteral( "RelativeStorage" ) , config.value( QStringLiteral( "RelativeStorage" ) ).toString() );
-
-  if ( config.contains( QStringLiteral( "DocumentViewer" ) ) )
-    configElement.setAttribute( QStringLiteral( "DocumentViewer" ), config.value( QStringLiteral( "DocumentViewer" ) ).toInt() );
-
-  if ( config.contains( QStringLiteral( "DocumentViewerWidth" ) ) )
-    configElement.setAttribute( QStringLiteral( "DocumentViewerWidth" ), config.value( QStringLiteral( "DocumentViewerWidth" ) ).toInt() );
-
-  if ( config.contains( QStringLiteral( "DocumentViewerHeight" ) ) )
-    configElement.setAttribute( QStringLiteral( "DocumentViewerHeight" ), config.value( QStringLiteral( "DocumentViewerHeight" ) ).toInt() );
-
-  if ( config.contains( QStringLiteral( "FileWidgetFilter" ) ) )
-    configElement.setAttribute( QStringLiteral( "FileWidgetFilter" ), config.value( QStringLiteral( "FileWidgetFilter" ) ).toString() );
-
-  configElement.setAttribute( QStringLiteral( "StorageMode" ), config.value( QStringLiteral( "StorageMode" ) ).toString() );
+  config2xml( config, configElement, QStringLiteral( "FileWidget" ) );
+  config2xml( config, configElement, QStringLiteral( "FileWidgetButton" ) );
+  config2xml( config, configElement, QStringLiteral( "UseLink" ) );
+  config2xml( config, configElement, QStringLiteral( "FullUrl" ) );
+  config2xml( config, configElement, QStringLiteral( "DefaultRoot" ) );
+  config2xml( config, configElement, QStringLiteral( "RelativeStorage" ) );
+  config2xml( config, configElement, QStringLiteral( "DocumentViewer" ) );
+  config2xml( config, configElement, QStringLiteral( "DocumentViewerWidth" ) );
+  config2xml( config, configElement, QStringLiteral( "DocumentViewerHeight" ) );
+  config2xml( config, configElement, QStringLiteral( "FileWidgetFilter" ) );
+  config2xml( config, configElement, QStringLiteral( "StorageMode" ) );
 }
 
 QgsEditorWidgetConfig QgsExternalResourceWidgetFactory::readConfig( const QDomElement& configElement, QgsVectorLayer* layer, int fieldIdx )
@@ -79,42 +60,22 @@ QgsEditorWidgetConfig QgsExternalResourceWidgetFactory::readConfig( const QDomEl
 
   QgsEditorWidgetConfig cfg;
 
-  if ( configElement.hasAttribute( QStringLiteral( "FileWidgetButton" ) ) )
-    cfg.insert( QStringLiteral( "FileWidgetButton" ), configElement.attribute( QStringLiteral( "FileWidgetButton" ) ) == QLatin1String( "1" ) );
-
-  if ( configElement.hasAttribute( QStringLiteral( "FileWidget" ) ) )
-    cfg.insert( QStringLiteral( "FileWidget" ), configElement.attribute( QStringLiteral( "FileWidget" ) ) == QLatin1String( "1" ) );
-
-  if ( configElement.hasAttribute( QStringLiteral( "UseLink" ) ) )
-    cfg.insert( QStringLiteral( "UseLink" ), configElement.attribute( QStringLiteral( "UseLink" ) ) == QLatin1String( "1" ) );
-
-  if ( configElement.hasAttribute( QStringLiteral( "FullUrl" ) ) )
-    cfg.insert( QStringLiteral( "FullUrl" ), configElement.attribute( QStringLiteral( "FullUrl" ) ) == QLatin1String( "1" ) );
-
-  if ( configElement.hasAttribute( QStringLiteral( "DefaultRoot" ) ) )
-    cfg.insert( QStringLiteral( "DefaultRoot" ), configElement.attribute( QStringLiteral( "DefaultRoot" ) ) );
-
+  xml2config( configElement, cfg, QStringLiteral( "FileWidget" ) );
+  xml2config( configElement, cfg, QStringLiteral( "FileWidgetButton" ) );
+  xml2config( configElement, cfg, QStringLiteral( "UseLink" ) );
+  xml2config( configElement, cfg, QStringLiteral( "FullUrl" ) );
+  xml2config( configElement, cfg, QStringLiteral( "DefaultRoot" ) );
   if ( configElement.hasAttribute( QStringLiteral( "RelativeStorage" ) ) )
   {
     if (( configElement.attribute( QStringLiteral( "RelativeStorage" ) ).toInt() == QgsFileWidget::RelativeDefaultPath && configElement.hasAttribute( QStringLiteral( "DefaultRoot" ) ) ) ||
         configElement.attribute( QStringLiteral( "RelativeStorage" ) ).toInt() == QgsFileWidget::RelativeProject )
-      cfg.insert( QStringLiteral( "RelativeStorage" ) , configElement.attribute( QStringLiteral( "RelativeStorage" ) ).toInt() );
+      xml2config( configElement, cfg, QStringLiteral( "RelativeStorage" ) );
   }
-
-  if ( configElement.hasAttribute( QStringLiteral( "DocumentViewer" ) ) )
-    cfg.insert( QStringLiteral( "DocumentViewer" ), configElement.attribute( QStringLiteral( "DocumentViewer" ) ) );
-
-  if ( configElement.hasAttribute( QStringLiteral( "DocumentViewerWidth" ) ) )
-    cfg.insert( QStringLiteral( "DocumentViewerWidth" ), configElement.attribute( QStringLiteral( "DocumentViewerWidth" ) ) );
-
-  if ( configElement.hasAttribute( QStringLiteral( "DocumentViewerHeight" ) ) )
-    cfg.insert( QStringLiteral( "DocumentViewerHeight" ), configElement.attribute( QStringLiteral( "DocumentViewerHeight" ) ) );
-
-  if ( configElement.hasAttribute( QStringLiteral( "FileWidgetFilter" ) ) )
-    cfg.insert( QStringLiteral( "FileWidgetFilter" ), configElement.attribute( QStringLiteral( "FileWidgetFilter" ) ) );
-
-
-  cfg.insert( QStringLiteral( "StorageMode" ), configElement.attribute( QStringLiteral( "StorageMode" ), QStringLiteral( "Files" ) ) );
+  xml2config( configElement, cfg, QStringLiteral( "DocumentViewer" ) );
+  xml2config( configElement, cfg, QStringLiteral( "DocumentViewerWidth" ) );
+  xml2config( configElement, cfg, QStringLiteral( "DocumentViewerHeight" ) );
+  xml2config( configElement, cfg, QStringLiteral( "FileWidgetFilter" ) );
+  xml2config( configElement, cfg, QStringLiteral( "StorageMode" ) );
 
   return cfg;
 }

--- a/src/gui/editorwidgets/qgsphotowidgetfactory.cpp
+++ b/src/gui/editorwidgets/qgsphotowidgetfactory.cpp
@@ -41,8 +41,8 @@ QgsEditorWidgetConfig QgsPhotoWidgetFactory::readConfig( const QDomElement& conf
 
   QgsEditorWidgetConfig cfg;
 
-  cfg.insert( QStringLiteral( "Height" ), configElement.attribute( QStringLiteral( "Height" ), 0 ).toInt() );
-  cfg.insert( QStringLiteral( "Width" ), configElement.attribute( QStringLiteral( "Width" ), 0 ).toInt() );
+  xml2config( configElement, cfg, QStringLiteral( "Height" ) );
+  xml2config( configElement, cfg, QStringLiteral( "Width" ) );
 
   return cfg;
 }
@@ -53,6 +53,6 @@ void QgsPhotoWidgetFactory::writeConfig( const QgsEditorWidgetConfig& config, QD
   Q_UNUSED( layer )
   Q_UNUSED( fieldIdx )
 
-  configElement.setAttribute( QStringLiteral( "Height" ), config.value( QStringLiteral( "Height" ), 0 ).toString() );
-  configElement.setAttribute( QStringLiteral( "Width" ), config.value( QStringLiteral( "Width" ), 0 ).toString() );
+  config2xml( config, configElement, QStringLiteral( "Height" ) );
+  config2xml( config, configElement, QStringLiteral( "Width" ) );
 }

--- a/src/gui/editorwidgets/qgsrangewidgetfactory.cpp
+++ b/src/gui/editorwidgets/qgsrangewidgetfactory.cpp
@@ -40,16 +40,12 @@ QgsEditorWidgetConfig QgsRangeWidgetFactory::readConfig( const QDomElement& conf
   Q_UNUSED( fieldIdx );
   QgsEditorWidgetConfig cfg;
 
-  cfg.insert( QStringLiteral( "Style" ), configElement.attribute( QStringLiteral( "Style" ) ) );
-  cfg.insert( QStringLiteral( "Min" ), configElement.attribute( QStringLiteral( "Min" ) ) );
-  cfg.insert( QStringLiteral( "Max" ), configElement.attribute( QStringLiteral( "Max" ) ) );
-  cfg.insert( QStringLiteral( "Step" ), configElement.attribute( QStringLiteral( "Step" ) ) );
-  cfg.insert( QStringLiteral( "AllowNull" ), configElement.attribute( QStringLiteral( "AllowNull" ) ) == QLatin1String( "1" ) );
-
-  if ( configElement.hasAttribute( QStringLiteral( "Suffix" ) ) )
-  {
-    cfg.insert( QStringLiteral( "Suffix" ), configElement.attribute( QStringLiteral( "Suffix" ) ) );
-  }
+  xml2config( configElement, cfg, QStringLiteral( "Style" ) );
+  xml2config( configElement, cfg, QStringLiteral( "Min" ) );
+  xml2config( configElement, cfg, QStringLiteral( "Max" ) );
+  xml2config( configElement, cfg, QStringLiteral( "Step" ) );
+  xml2config( configElement, cfg, QStringLiteral( "AllowNull" ) );
+  xml2config( configElement, cfg, QStringLiteral( "Suffix" ) );
 
   return cfg;
 }
@@ -60,15 +56,12 @@ void QgsRangeWidgetFactory::writeConfig( const QgsEditorWidgetConfig& config, QD
   Q_UNUSED( layer );
   Q_UNUSED( fieldIdx );
 
-  configElement.setAttribute( QStringLiteral( "Style" ), config[QStringLiteral( "Style" )].toString() );
-  configElement.setAttribute( QStringLiteral( "Min" ), config[QStringLiteral( "Min" )].toString() );
-  configElement.setAttribute( QStringLiteral( "Max" ), config[QStringLiteral( "Max" )].toString() );
-  configElement.setAttribute( QStringLiteral( "Step" ), config[QStringLiteral( "Step" )].toString() );
-  configElement.setAttribute( QStringLiteral( "AllowNull" ), config[QStringLiteral( "AllowNull" )].toBool() );
-  if ( config.contains( QStringLiteral( "Suffix" ) ) )
-  {
-    configElement.setAttribute( QStringLiteral( "Suffix" ), config[QStringLiteral( "Suffix" )].toString() );
-  }
+  config2xml( config, configElement, QStringLiteral( "Style" ) );
+  config2xml( config, configElement, QStringLiteral( "Min" ) );
+  config2xml( config, configElement, QStringLiteral( "Max" ) );
+  config2xml( config, configElement, QStringLiteral( "Step" ) );
+  config2xml( config, configElement, QStringLiteral( "AllowNull" ) );
+  config2xml( config, configElement, QStringLiteral( "Suffix" ) );
 }
 
 unsigned int QgsRangeWidgetFactory::fieldScore( const QgsVectorLayer* vl, int fieldIdx ) const

--- a/src/gui/editorwidgets/qgsrelationreferencefactory.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencefactory.cpp
@@ -53,13 +53,13 @@ QgsEditorWidgetConfig QgsRelationReferenceFactory::readConfig( const QDomElement
   Q_UNUSED( fieldIdx );
   QgsEditorWidgetConfig cfg;
 
-  cfg.insert( QStringLiteral( "AllowNULL" ), configElement.attribute( QStringLiteral( "AllowNULL" ) ) == QLatin1String( "1" ) );
-  cfg.insert( QStringLiteral( "OrderByValue" ), configElement.attribute( QStringLiteral( "OrderByValue" ) ) == QLatin1String( "1" ) );
-  cfg.insert( QStringLiteral( "ShowForm" ), configElement.attribute( QStringLiteral( "ShowForm" ) ) == QLatin1String( "1" ) );
-  cfg.insert( QStringLiteral( "Relation" ), configElement.attribute( QStringLiteral( "Relation" ) ) );
-  cfg.insert( QStringLiteral( "MapIdentification" ), configElement.attribute( QStringLiteral( "MapIdentification" ) ) == QLatin1String( "1" ) );
-  cfg.insert( QStringLiteral( "ReadOnly" ), configElement.attribute( QStringLiteral( "ReadOnly" ) ) == QLatin1String( "1" ) );
-  cfg.insert( QStringLiteral( "AllowAddFeatures" ), configElement.attribute( QStringLiteral( "AllowAddFeatures" ) ) == QLatin1String( "1" ) );
+  xml2config( configElement, cfg, QStringLiteral( "AllowNULL" ) );
+  xml2config( configElement, cfg, QStringLiteral( "OrderByValue" ) );
+  xml2config( configElement, cfg, QStringLiteral( "ShowForm" ) );
+  xml2config( configElement, cfg, QStringLiteral( "Relation" ) );
+  xml2config( configElement, cfg, QStringLiteral( "MapIdentification" ) );
+  xml2config( configElement, cfg, QStringLiteral( "ReadOnly" ) );
+  xml2config( configElement, cfg, QStringLiteral( "AllowAddFeatures" ) );
 
   QDomNode filterNode = configElement.elementsByTagName( QStringLiteral( "FilterFields" ) ).at( 0 );
   if ( !filterNode.isNull() )
@@ -74,7 +74,7 @@ QgsEditorWidgetConfig QgsRelationReferenceFactory::readConfig( const QDomElement
     }
     cfg.insert( QStringLiteral( "FilterFields" ), filterFields );
 
-    cfg.insert( QStringLiteral( "ChainFilters" ), filterNode.toElement().attribute( QStringLiteral( "ChainFilters" ) ) == QLatin1String( "1" ) );
+    xml2config( configElement, cfg , QStringLiteral( "ChainFilters" ) );
   }
   return cfg;
 }
@@ -85,13 +85,13 @@ void QgsRelationReferenceFactory::writeConfig( const QgsEditorWidgetConfig& conf
   Q_UNUSED( layer );
   Q_UNUSED( fieldIdx );
 
-  configElement.setAttribute( QStringLiteral( "AllowNULL" ), config[QStringLiteral( "AllowNULL" )].toBool() );
-  configElement.setAttribute( QStringLiteral( "OrderByValue" ), config[QStringLiteral( "OrderByValue" )].toBool() );
-  configElement.setAttribute( QStringLiteral( "ShowForm" ), config[QStringLiteral( "ShowForm" )].toBool() );
-  configElement.setAttribute( QStringLiteral( "Relation" ), config[QStringLiteral( "Relation" )].toString() );
-  configElement.setAttribute( QStringLiteral( "MapIdentification" ), config[QStringLiteral( "MapIdentification" )].toBool() );
-  configElement.setAttribute( QStringLiteral( "ReadOnly" ), config[QStringLiteral( "ReadOnly" )].toBool() );
-  configElement.setAttribute( QStringLiteral( "AllowAddFeatures" ), config[QStringLiteral( "AllowAddFeatures" )].toBool() );
+  config2xml( config, configElement, QStringLiteral( "AllowNULL" ) );
+  config2xml( config, configElement, QStringLiteral( "OrderByValue" ) );
+  config2xml( config, configElement, QStringLiteral( "ShowForm" ) );
+  config2xml( config, configElement, QStringLiteral( "Relation" ) );
+  config2xml( config, configElement, QStringLiteral( "MapIdentification" ) );
+  config2xml( config, configElement, QStringLiteral( "ReadOnly" ) );
+  config2xml( config, configElement, QStringLiteral( "AllowAddFeatures" ) );
 
   if ( config.contains( QStringLiteral( "FilterFields" ) ) )
   {
@@ -105,7 +105,7 @@ void QgsRelationReferenceFactory::writeConfig( const QgsEditorWidgetConfig& conf
     }
     configElement.appendChild( filterFields );
 
-    filterFields.setAttribute( QStringLiteral( "ChainFilters" ), config[QStringLiteral( "ChainFilters" )].toBool() );
+    config2xml( config, configElement, QStringLiteral( "ChainFilters" ) );
   }
 }
 

--- a/src/gui/editorwidgets/qgstexteditwidgetfactory.cpp
+++ b/src/gui/editorwidgets/qgstexteditwidgetfactory.cpp
@@ -46,8 +46,8 @@ void QgsTextEditWidgetFactory::writeConfig( const QgsEditorWidgetConfig& config,
   Q_UNUSED( layer )
   Q_UNUSED( fieldIdx )
 
-  configElement.setAttribute( QStringLiteral( "IsMultiline" ), config.value( QStringLiteral( "IsMultiline" ), false ).toBool() );
-  configElement.setAttribute( QStringLiteral( "UseHtml" ), config.value( QStringLiteral( "UseHtml" ), false ).toBool() );
+  config2xml( config, configElement, QStringLiteral( "IsMultiline" ) );
+  config2xml( config, configElement, QStringLiteral( "UseHtml" ) );
 }
 
 QgsEditorWidgetConfig QgsTextEditWidgetFactory::readConfig( const QDomElement& configElement, QgsVectorLayer* layer, int fieldIdx )
@@ -57,8 +57,8 @@ QgsEditorWidgetConfig QgsTextEditWidgetFactory::readConfig( const QDomElement& c
 
   QgsEditorWidgetConfig cfg;
 
-  cfg.insert( QStringLiteral( "IsMultiline" ), configElement.attribute( QStringLiteral( "IsMultiline" ), QStringLiteral( "0" ) ) == QLatin1String( "1" ) );
-  cfg.insert( QStringLiteral( "UseHtml" ), configElement.attribute( QStringLiteral( "UseHtml" ), QStringLiteral( "0" ) ) == QLatin1String( "1" ) );
+  xml2config( configElement, cfg, QStringLiteral( "IsMultiline" ) );
+  xml2config( configElement, cfg, QStringLiteral( "UseHtml" ) );
 
   return cfg;
 }

--- a/src/gui/editorwidgets/qgsuniquevaluewidgetfactory.cpp
+++ b/src/gui/editorwidgets/qgsuniquevaluewidgetfactory.cpp
@@ -41,7 +41,7 @@ QgsEditorWidgetConfig QgsUniqueValueWidgetFactory::readConfig( const QDomElement
 
   QgsEditorWidgetConfig cfg;
 
-  cfg.insert( QStringLiteral( "Editable" ), configElement.attribute( QStringLiteral( "Editable" ), QStringLiteral( "0" ) ) == QLatin1String( "1" ) );
+  xml2config( configElement, cfg, QStringLiteral( "Editable" ) );
 
   return cfg;
 }
@@ -51,5 +51,5 @@ void QgsUniqueValueWidgetFactory::writeConfig( const QgsEditorWidgetConfig& conf
   Q_UNUSED( doc )
   Q_UNUSED( layer )
   Q_UNUSED( fieldIdx )
-  configElement.setAttribute( QStringLiteral( "Editable" ), config.value( QStringLiteral( "Editable" ), false ).toBool() );
+  config2xml( config, configElement, QStringLiteral( "Editable" ) );
 }

--- a/src/gui/editorwidgets/qgsvaluerelationwidgetfactory.cpp
+++ b/src/gui/editorwidgets/qgsvaluerelationwidgetfactory.cpp
@@ -52,14 +52,14 @@ QgsEditorWidgetConfig QgsValueRelationWidgetFactory::readConfig( const QDomEleme
 
   QgsEditorWidgetConfig cfg;
 
-  cfg.insert( QStringLiteral( "Layer" ), configElement.attribute( QStringLiteral( "Layer" ) ) );
-  cfg.insert( QStringLiteral( "Key" ), configElement.attribute( QStringLiteral( "Key" ) ) );
-  cfg.insert( QStringLiteral( "Value" ), configElement.attribute( QStringLiteral( "Value" ) ) );
-  cfg.insert( QStringLiteral( "FilterExpression" ), configElement.attribute( QStringLiteral( "FilterExpression" ) ) );
-  cfg.insert( QStringLiteral( "OrderByValue" ), configElement.attribute( QStringLiteral( "OrderByValue" ) ) );
-  cfg.insert( QStringLiteral( "AllowMulti" ), configElement.attribute( QStringLiteral( "AllowMulti" ) ) );
-  cfg.insert( QStringLiteral( "AllowNull" ), configElement.attribute( QStringLiteral( "AllowNull" ) ) );
-  cfg.insert( QStringLiteral( "UseCompleter" ), configElement.attribute( QStringLiteral( "UseCompleter" ) ) );
+  xml2config( configElement, cfg, QStringLiteral( "Layer" ) );
+  xml2config( configElement, cfg, QStringLiteral( "Key" ) );
+  xml2config( configElement, cfg, QStringLiteral( "Value" ) );
+  xml2config( configElement, cfg, QStringLiteral( "FilterExpression" ) );
+  xml2config( configElement, cfg, QStringLiteral( "OrderByValue" ) );
+  xml2config( configElement, cfg, QStringLiteral( "AllowMulti" ) );
+  xml2config( configElement, cfg, QStringLiteral( "AllowNull" ) );
+  xml2config( configElement, cfg, QStringLiteral( "UseCompleter" ) );
 
   return cfg;
 }
@@ -70,14 +70,14 @@ void QgsValueRelationWidgetFactory::writeConfig( const QgsEditorWidgetConfig& co
   Q_UNUSED( layer )
   Q_UNUSED( fieldIdx )
 
-  configElement.setAttribute( QStringLiteral( "Layer" ), config.value( QStringLiteral( "Layer" ) ).toString() );
-  configElement.setAttribute( QStringLiteral( "Key" ), config.value( QStringLiteral( "Key" ) ).toString() );
-  configElement.setAttribute( QStringLiteral( "Value" ), config.value( QStringLiteral( "Value" ) ).toString() );
-  configElement.setAttribute( QStringLiteral( "FilterExpression" ), config.value( QStringLiteral( "FilterExpression" ) ).toString() );
-  configElement.setAttribute( QStringLiteral( "OrderByValue" ), config.value( QStringLiteral( "OrderByValue" ) ).toBool() );
-  configElement.setAttribute( QStringLiteral( "AllowMulti" ), config.value( QStringLiteral( "AllowMulti" ) ).toBool() );
-  configElement.setAttribute( QStringLiteral( "AllowNull" ), config.value( QStringLiteral( "AllowNull" ) ).toBool() );
-  configElement.setAttribute( QStringLiteral( "UseCompleter" ), config.value( QStringLiteral( "UseCompleter" ) ).toBool() );
+  config2xml( config, configElement, QStringLiteral( "Layer" ) );
+  config2xml( config, configElement, QStringLiteral( "Key" ) );
+  config2xml( config, configElement, QStringLiteral( "Value" ) );
+  config2xml( config, configElement, QStringLiteral( "FilterExpression" ) );
+  config2xml( config, configElement, QStringLiteral( "OrderByValue" ) );
+  config2xml( config, configElement, QStringLiteral( "AllowMulti" ) );
+  config2xml( config, configElement, QStringLiteral( "AllowNull" ) );
+  config2xml( config, configElement, QStringLiteral( "UseCompleter" ) );
 }
 
 QString QgsValueRelationWidgetFactory::representValue( QgsVectorLayer* vl, int fieldIdx, const QgsEditorWidgetConfig& config, const QVariant& cache, const QVariant& value ) const

--- a/src/gui/editorwidgets/qgswebviewwidgetfactory.cpp
+++ b/src/gui/editorwidgets/qgswebviewwidgetfactory.cpp
@@ -41,8 +41,8 @@ QgsEditorWidgetConfig QgsWebViewWidgetFactory::readConfig( const QDomElement& co
 
   QgsEditorWidgetConfig cfg;
 
-  cfg.insert( QStringLiteral( "Height" ), configElement.attribute( QStringLiteral( "Height" ), 0 ).toInt() );
-  cfg.insert( QStringLiteral( "Width" ), configElement.attribute( QStringLiteral( "Width" ), 0 ).toInt() );
+  xml2config( configElement, cfg, QStringLiteral( "Height" ) );
+  xml2config( configElement, cfg, QStringLiteral( "Width" ) );
 
   return cfg;
 }
@@ -53,6 +53,6 @@ void QgsWebViewWidgetFactory::writeConfig( const QgsEditorWidgetConfig& config, 
   Q_UNUSED( layer )
   Q_UNUSED( fieldIdx )
 
-  configElement.setAttribute( QStringLiteral( "Height" ), config.value( QStringLiteral( "Height" ), 0 ).toString() );
-  configElement.setAttribute( QStringLiteral( "Width" ), config.value( QStringLiteral( "Width" ), 0 ).toString() );
+  config2xml( config, configElement, QStringLiteral( "Height" ) );
+  config2xml( config, configElement, QStringLiteral( "Width" ) );
 }


### PR DESCRIPTION
When the user opens the layers properties, leaves the default
fields definition as is and saves the project, the fields were saved
with empty configuration values.

I've fixed all the editor widget types that are potentially used
without configuration.
