### PR TITLE
[processing] fix canUseVectorLayer function as well as variable access in AlgorithmDialog

### DIFF
--- a/python/plugins/processing/gui/AlgorithmDialog.py
+++ b/python/plugins/processing/gui/AlgorithmDialog.py
@@ -247,7 +247,7 @@ class AlgorithmDialog(AlgorithmDialogBase):
                     self.resetGUI()
         except AlgorithmDialogBase.InvalidParameterValue as e:
             try:
-                self.buttonBox.accepted.connect(lambda:
+                self.buttonBox.accepted.connect(lambda e=e:
                                                 e.widget.setPalette(QPalette()))
                 palette = e.widget.palette()
                 palette.setColor(QPalette.Base, QColor(255, 255, 0))

--- a/python/plugins/processing/tools/dataobjects.py
+++ b/python/plugins/processing/tools/dataobjects.py
@@ -112,10 +112,11 @@ def getVectorLayers(shapetype=[-1], sorting=True):
 
 
 def canUseVectorLayer(layer, shapetype):
-    if layer.type() == QgsMapLayer.VectorLayer and layer.dataProvider().name() != "grass":
-        if (layer.hasGeometryType() and
-                (shapetype == ALL_TYPES or layer.geometryType() in shapetype)):
-            return True
+    if layer.type() == QgsMapLayer.VectorLayer:
+        if layer.dataProvider().name() != "grass":
+            if (layer.hasGeometryType() and
+                    (shapetype == ALL_TYPES or layer.geometryType() in shapetype)):
+                return True
     return False
 
 


### PR DESCRIPTION
@volaya , @alexbruy , there is a bug in the canUseVectorLayer function, whereas a non-spatial layer (such as .csv file) doesn't have a dataProvider function. When a project's set of layers would contain such a layer, processing would throw a stack error when executing canUseVectorLayer. This PR fixes the issue.
