### PR TITLE
Revert "Keep numeric fields type, length and precision in postgresql …

### DIFF
--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -3440,16 +3440,16 @@ bool QgsPostgresProvider::convertField( QgsField &field, const QMap<QString, QVa
       break;
 
     case QVariant::Double:
-      if ( fieldPrec > 0 )
+      if ( fieldSize > 18 )
       {
         fieldType = "numeric";
+        fieldSize = -1;
       }
       else
       {
         fieldType = "float8";
-        fieldSize = -1;
-        fieldPrec = -1;
       }
+      fieldPrec = -1;
       break;
 
     default:


### PR DESCRIPTION
…provider"

This reverts commit 92f71b696ca93c792ae5602ed82863fcef0e5006.

That commit broke import of legit shapefiles by assuming wrong
semantic for the non-constraining QgsField length/precision attributes.

Closes http://hub.qgis.org/issues/15188
