### PR TITLE
Fix bogus precision/scale in PostgreSQL for double values

### DIFF
--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -3421,16 +3421,16 @@ bool QgsPostgresProvider::convertField( QgsField &field, const QMap<QString, QVa
     }
 
     case QVariant::Double:
-      if ( fieldPrec > 0 )
+      if ( fieldSize > 18 )
       {
         fieldType = "numeric";
+        fieldSize = -1;
       }
       else
       {
         fieldType = "float8";
-        fieldSize = -1;
-        fieldPrec = -1;
       }
+      fieldPrec = -1;
       break;
 
     default:

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -14,11 +14,15 @@ __copyright__ = 'Copyright 2015, The QGIS Project'
 __revision__ = '$Format:%H$'
 
 import qgis  # NOQA
+import psycopg2
 
 import os
 
 from qgis.core import (
+    QgsGeometry,
+    QgsPoint,
     QgsVectorLayer,
+    QgsVectorLayerImport,
     QgsFeatureRequest,
     QgsFeature,
     QgsTransactionGroup,
@@ -50,10 +54,19 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
         assert cls.poly_vl.isValid()
         cls.poly_provider = cls.poly_vl.dataProvider()
         QgsEditorWidgetRegistry.instance().initEditors()
+        cls.con = psycopg2.connect(cls.dbconn)
 
     @classmethod
     def tearDownClass(cls):
         """Run after all tests"""
+
+    def execSQLCommand(self, sql):
+        self.assertTrue(self.con)
+        cur = self.con.cursor()
+        self.assertTrue(cur)
+        cur.execute(sql)
+        cur.close()
+        self.con.commit()
 
     def enableCompiler(self):
         QSettings().setValue('/qgis/compileExpressions', True)
@@ -454,6 +467,29 @@ class TestPyQgsPostgresProviderCompoundKey(unittest.TestCase, ProviderTestCase):
     def partiallyCompiledFilters(self):
         return set([])
 
+    # See http://hub.qgis.org/issues/15188
+    def testNumericPrecision(self):
+        uri = 'point?field=f1:int'
+        uri += '&field=f2:double(6,4)'
+        uri += '&field=f3:string(20)'
+        lyr = QgsVectorLayer(uri, "x", "memory")
+        self.assertTrue(lyr.isValid())
+        f = QgsFeature(lyr.fields())
+        f['f1'] = 1
+        f['f2'] = 123.456
+        f['f3'] = '12345678.90123456789'
+        lyr.dataProvider().addFeatures([f])
+        uri = '%s table="qgis_test"."b18155" (g) key=\'f1\'' % (self.dbconn)
+        self.execSQLCommand('DROP TABLE IF EXISTS qgis_test.b18155')
+        err = QgsVectorLayerImport.importLayer(lyr, uri, "postgres", lyr.crs())
+        self.assertEqual(err[0], QgsVectorLayerImport.NoError,
+                         'unexpected import error {0}'.format(err))
+        lyr = QgsVectorLayer(uri, "y", "postgres")
+        self.assertTrue(lyr.isValid())
+        f = next(lyr.getFeatures())
+        self.assertEqual(f['f1'], 1)
+        self.assertEqual(f['f2'], 123.456)
+        self.assertEqual(f['f3'], '12345678.90123456789')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
This reverts commit 92f71b696ca93c792ae5602ed82863fcef0e5006,
which broke import of legit shapefiles by assuming wrong
semantic for the non-constraining QgsField length/precision
attributes.

Closes #15188

Includes test
