### PR TITLE
[FEATURE] Vector layer save as: offer file/layer overwriting, new layer creation, feature and field appending

### DIFF
--- a/python/core/qgsvectorfilewriter.sip
+++ b/python/core/qgsvectorfilewriter.sip
@@ -132,6 +132,43 @@ class QgsVectorFileWriter
         virtual QVariant convert( int fieldIdxInLayer, const QVariant& value );
     };
 
+    /** Edition capability flags
+      * @note Added in QGIS 3.0 */
+    enum EditionCapability
+    {
+        /** Flag to indicate that a new layer can be added to the dataset */
+        CanAddNewLayer,
+
+        /** Flag to indicate that new features can be added to an existing layer */
+        CanAppendToExistingLayer ,
+
+        /** Flag to indicate that new fields can be added to an existing layer. Imply CanAppendToExistingLayer */
+        CanAddNewFieldsToExistingLayer,
+
+        /** Flag to indicate that an existing layer can be deleted */
+        CanDeleteLayer
+    };
+
+    typedef QFlags<QgsVectorFileWriter::EditionCapability> EditionCapabilities;
+
+    /** Enumeration to describe how to handle existing files
+        @note Added in QGIS 3.0
+     */
+    enum ActionOnExistingFile
+    {
+        /** Create or overwrite file */
+        CreateOrOverwriteFile,
+
+        /** Create or overwrite layer */
+        CreateOrOverwriteLayer,
+
+        /** Append features to existing layer, but do not create new fields */
+        AppendToLayerNoNewFields,
+
+        /** Append features to existing layer, and create new fields if needed */
+        AppendToLayerAddFields
+    };
+
     /** Write contents of vector layer to an (OGR supported) vector formt
      * @param layer layer to write
      * @param fileName file name to write to
@@ -220,6 +257,88 @@ class QgsVectorFileWriter
                                             FieldValueConverter* fieldValueConverter = nullptr
                                           );
 
+
+    /**
+     * Options to pass to writeAsVectorFormat()
+     * @note Added in QGIS 3.0
+     */
+    class SaveVectorOptions
+    {
+      public:
+        /** Constructor */
+        SaveVectorOptions();
+
+        /** Destructor */
+        virtual ~SaveVectorOptions();
+
+        /** OGR driver to use */
+        QString driverName;
+
+        /** Layer name. If let empty, it will be derived from the filename */
+        QString layerName;
+
+        /** Action on existing file  */
+        QgsVectorFileWriter::ActionOnExistingFile actionOnExistingFile;
+
+        /** Encoding to use */
+        QString fileEncoding;
+
+        /** Transform to reproject exported geometries with, or invalid transform
+         * for no transformation */
+        QgsCoordinateTransform ct;
+
+        /** Write only selected features of layer */
+        bool onlySelectedFeatures;
+
+        /** List of OGR data source creation options */
+        QStringList datasourceOptions;
+
+        /** List of OGR layer creation options */
+        QStringList layerOptions;
+
+        /** Only write geometries */
+        bool skipAttributeCreation;
+
+        /** Attributes to export (empty means all unless skipAttributeCreation is set) */
+        QgsAttributeList attributes;
+
+        /** Symbology to export */
+        QgsVectorFileWriter::SymbologyExport symbologyExport;
+
+        /** Scale of symbology */
+        double symbologyScale;
+
+        /** If not empty, only features intersecting the extent will be saved */
+        QgsRectangle filterExtent;
+
+        /** Set to a valid geometry type to override the default geometry type for the layer. This parameter
+         * allows for conversion of geometryless tables to null geometries, etc */
+        QgsWkbTypes::Type overrideGeometryType;
+
+        /** Set to true to force creation of multi* geometries */
+        bool forceMulti;
+
+        /** Set to true to include z dimension in output. This option is only valid if overrideGeometryType is set */
+        bool includeZ;
+
+        /** Field value converter */
+        QgsVectorFileWriter::FieldValueConverter* fieldValueConverter;
+    };
+
+    /** Writes a layer out to a vector file.
+     * @param layer source layer to write
+     * @param fileName file name to write to
+     * @param options options.
+     * @param newFilename QString pointer which will contain the new file name created (in case it is different to fileName).
+     * @param errorMessage pointer to buffer fo error message
+     * @note added in 3.0
+     */
+    static WriterError writeAsVectorFormat( QgsVectorLayer* layer,
+                                            const QString& fileName,
+                                            const SaveVectorOptions& options,
+                                            QString *newFilename = nullptr,
+                                            QString *errorMessage = nullptr );
+
     /** Create a new vector file writer */
     QgsVectorFileWriter( const QString& vectorFileName,
                          const QString& fileEncoding,
@@ -294,6 +413,27 @@ class QgsVectorFileWriter
      */
     static QStringList defaultLayerOptions( const QString& driverName );
 
+    /**
+     * Return edition capabilites for an existing dataset name.
+     * @note added in QGIS 3.0
+     */
+    static EditionCapabilities editionCapabilities( const QString& datasetName );
+
+    /**
+     * Returns whether the target layer already exists.
+     * @note added in QGIS 3.0
+     */
+    static bool targetLayerExists( const QString& datasetName,
+                                   const QString& layerName );
+
+    /**
+     * Returns whether there are among the attributes specified some that do not exist yet in the layer
+     * @note added in QGIS 3.0
+     */
+    static bool areThereNewFieldsToCreate( const QString& datasetName,
+                                           const QString& layerName,
+                                           QgsVectorLayer* layer,
+                                           const QgsAttributeList& attributes );
   protected:
     //! @note not available in python bindings
     // OGRGeometryH createEmptyGeometry( QgsWkbTypes::Type wkbType );
@@ -302,3 +442,5 @@ class QgsVectorFileWriter
 
     QgsVectorFileWriter( const QgsVectorFileWriter& rh );
 };
+
+QFlags<QgsVectorFileWriter::EditionCapability> operator|(QgsVectorFileWriter::EditionCapability f1, QFlags<QgsVectorFileWriter::EditionCapability> f2);

--- a/src/app/ogr/qgsvectorlayersaveasdialog.cpp
+++ b/src/app/ogr/qgsvectorlayersaveasdialog.cpp
@@ -23,6 +23,7 @@
 #include "qgseditorwidgetfactory.h"
 #include "qgseditorwidgetregistry.h"
 
+#include <QMessageBox>
 #include <QSettings>
 #include <QFileDialog>
 #include <QTextCodec>
@@ -37,6 +38,7 @@ QgsVectorLayerSaveAsDialog::QgsVectorLayerSaveAsDialog( long srsid, QWidget* par
     , mLayer( 0 )
     , mAttributeTableItemChangedSlotEnabled( true )
     , mReplaceRawFieldValuesStateChangedSlotEnabled( true )
+    , mActionOnExistingFile( QgsVectorFileWriter::CreateOrOverwriteFile )
 {
   setup();
 }
@@ -46,6 +48,7 @@ QgsVectorLayerSaveAsDialog::QgsVectorLayerSaveAsDialog( QgsVectorLayer *layer, i
     , mLayer( layer )
     , mAttributeTableItemChangedSlotEnabled( true )
     , mReplaceRawFieldValuesStateChangedSlotEnabled( true )
+    , mActionOnExistingFile( QgsVectorFileWriter::CreateOrOverwriteFile )
 {
   if ( layer )
   {
@@ -210,6 +213,121 @@ QgsVectorLayerSaveAsDialog::~QgsVectorLayerSaveAsDialog()
 
 void QgsVectorLayerSaveAsDialog::accept()
 {
+  if ( QFile::exists( filename() ) )
+  {
+    QgsVectorFileWriter::EditionCapabilities caps =
+      QgsVectorFileWriter::editionCapabilities( filename() );
+    bool layerExists = QgsVectorFileWriter::targetLayerExists( filename(),
+                       layername() );
+    if ( layerExists )
+    {
+      if ( !( caps & QgsVectorFileWriter::CanAppendToExistingLayer ) &&
+           ( caps & QgsVectorFileWriter::CanDeleteLayer ) &&
+           ( caps & QgsVectorFileWriter::CanAddNewLayer ) )
+      {
+        QMessageBox msgBox;
+        msgBox.setIcon( QMessageBox::Question );
+        msgBox.setWindowTitle( tr( "The layer already exists" ) );
+        msgBox.setText( tr( "Do you want to overwrite the whole file or overwrite the layer?" ) );
+        QPushButton *overwriteFileButton = msgBox.addButton( tr( "Overwrite file" ), QMessageBox::ActionRole );
+        QPushButton *overwriteLayerButton = msgBox.addButton( tr( "Overwrite layer" ), QMessageBox::ActionRole );
+        msgBox.setStandardButtons( QMessageBox::Cancel );
+        msgBox.setDefaultButton( QMessageBox::Cancel );
+        int ret = msgBox.exec();
+        if ( ret == QMessageBox::Cancel )
+          return;
+        if ( msgBox.clickedButton() == overwriteFileButton )
+          mActionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteFile;
+        else if ( msgBox.clickedButton() == overwriteLayerButton )
+          mActionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteLayer;
+      }
+      else if ( !( caps & QgsVectorFileWriter::CanAppendToExistingLayer ) )
+      {
+        if ( QMessageBox::question( this,
+                                    tr( "The file already exists" ),
+                                    tr( "Do you want to overwrite the existing file?" ) ) == QMessageBox::NoButton )
+        {
+          return;
+        }
+        mActionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteFile;
+      }
+      else if (( caps & QgsVectorFileWriter::CanDeleteLayer ) &&
+               ( caps & QgsVectorFileWriter::CanAddNewLayer ) )
+      {
+        QMessageBox msgBox;
+        msgBox.setIcon( QMessageBox::Question );
+        msgBox.setWindowTitle( tr( "The layer already exists" ) );
+        msgBox.setText( tr( "Do you want to overwrite the whole file, overwrite the layer or append features to the layer?" ) );
+        QPushButton *overwriteFileButton = msgBox.addButton( tr( "Overwrite file" ), QMessageBox::ActionRole );
+        QPushButton *overwriteLayerButton = msgBox.addButton( tr( "Overwrite layer" ), QMessageBox::ActionRole );
+        QPushButton *appendToLayerButton = msgBox.addButton( tr( "Append to layer" ), QMessageBox::ActionRole );
+        msgBox.setStandardButtons( QMessageBox::Cancel );
+        msgBox.setDefaultButton( QMessageBox::Cancel );
+        int ret = msgBox.exec();
+        if ( ret == QMessageBox::Cancel )
+          return;
+        if ( msgBox.clickedButton() == overwriteFileButton )
+          mActionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteFile;
+        else if ( msgBox.clickedButton() == overwriteLayerButton )
+          mActionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteLayer;
+        else if ( msgBox.clickedButton() == appendToLayerButton )
+          mActionOnExistingFile = QgsVectorFileWriter::AppendToLayerNoNewFields;
+      }
+      else
+      {
+        QMessageBox msgBox;
+        msgBox.setIcon( QMessageBox::Question );
+        msgBox.setWindowTitle( tr( "The layer already exists" ) );
+        msgBox.setText( tr( "Do you want to overwrite the whole file or append features to the layer?" ) );
+        QPushButton *overwriteFileButton = msgBox.addButton( tr( "Overwrite file" ), QMessageBox::ActionRole );
+        QPushButton *appendToLayerButton = msgBox.addButton( tr( "Append to layer" ), QMessageBox::ActionRole );
+        msgBox.setStandardButtons( QMessageBox::Cancel );
+        msgBox.setDefaultButton( QMessageBox::Cancel );
+        int ret = msgBox.exec();
+        if ( ret == QMessageBox::Cancel )
+          return;
+        if ( msgBox.clickedButton() == overwriteFileButton )
+          mActionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteFile;
+        else if ( msgBox.clickedButton() == appendToLayerButton )
+          mActionOnExistingFile = QgsVectorFileWriter::AppendToLayerNoNewFields;
+      }
+
+      if ( mActionOnExistingFile == QgsVectorFileWriter::AppendToLayerNoNewFields )
+      {
+        if ( QgsVectorFileWriter::areThereNewFieldsToCreate( filename(),
+             layername(),
+             mLayer,
+             selectedAttributes() ) )
+        {
+          if ( QMessageBox::question( this,
+                                      tr( "The existing layer has different fields" ),
+                                      tr( "Do you want to add the missing fields to the layer?" ) ) == QMessageBox::Yes )
+          {
+            mActionOnExistingFile = QgsVectorFileWriter::AppendToLayerAddFields;
+          }
+        }
+      }
+
+    }
+    else
+    {
+      if (( caps & QgsVectorFileWriter::CanAddNewLayer ) )
+      {
+        mActionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteLayer;
+      }
+      else
+      {
+        if ( QMessageBox::question( this,
+                                    tr( "The file already exists" ),
+                                    tr( "Do you want to overwrite the existing file?" ) ) == QMessageBox::NoButton )
+        {
+          return;
+        }
+        mActionOnExistingFile = QgsVectorFileWriter::CreateOrOverwriteFile;
+      }
+    }
+  }
+
   QSettings settings;
   settings.setValue( "/UI/lastVectorFileFilterDir", QFileInfo( filename() ).absolutePath() );
   settings.setValue( "/UI/lastVectorFormat", format() );
@@ -226,12 +344,13 @@ void QgsVectorLayerSaveAsDialog::on_mFormatComboBox_currentIndexChanged( int idx
   bool selectAllFields = true;
   bool fieldsAsDisplayedValues = false;
 
-  if ( format() == "KML" )
+  const QString sFormat( format() );
+  if ( sFormat == "KML" )
   {
     mAttributesSelection->setEnabled( true );
     selectAllFields = false;
   }
-  else if ( format() == "DXF" )
+  else if ( sFormat == "DXF" )
   {
     mAttributesSelection->setEnabled( false );
     selectAllFields = false;
@@ -239,7 +358,23 @@ void QgsVectorLayerSaveAsDialog::on_mFormatComboBox_currentIndexChanged( int idx
   else
   {
     mAttributesSelection->setEnabled( true );
-    fieldsAsDisplayedValues = ( format() == "CSV" || format() == "XLS" || format() == "XLSX" || format() == "ODS" );
+    fieldsAsDisplayedValues = ( sFormat == "CSV" || sFormat == "XLS" || sFormat == "XLSX" || sFormat == "ODS" );
+  }
+
+  leLayername->setEnabled( sFormat == "KML" ||
+                           sFormat == "GPKG" ||
+                           sFormat == "XLSX" ||
+                           sFormat == "ODS" ||
+                           sFormat == "FileGDB" ||
+                           sFormat == "SQLite" ||
+                           sFormat == "SpatiaLite" );
+  if ( !leLayername->isEnabled() )
+    leLayername->setText( QString() );
+  else if ( leLayername->text().isEmpty() &&
+            !leFilename->text().isEmpty() )
+  {
+    QString layerName = QFileInfo( leFilename->text() ).baseName();
+    leLayername->setText( layerName ) ;
   }
 
   if ( mLayer )
@@ -485,7 +620,14 @@ void QgsVectorLayerSaveAsDialog::on_mAttributeTable_itemChanged( QTableWidgetIte
 
 void QgsVectorLayerSaveAsDialog::on_leFilename_textChanged( const QString& text )
 {
-  buttonBox->button( QDialogButtonBox::Ok )->setEnabled( QFileInfo( text ).absoluteDir().exists() );
+  buttonBox->button( QDialogButtonBox::Ok )->setEnabled(
+    !text.isEmpty() && QFileInfo( text ).absoluteDir().exists() );
+
+  if ( leLayername->isEnabled() )
+  {
+    QString layerName = QFileInfo( text ).baseName();
+    leLayername->setText( layerName );
+  }
 }
 
 void QgsVectorLayerSaveAsDialog::on_browseFilename_clicked()
@@ -493,7 +635,7 @@ void QgsVectorLayerSaveAsDialog::on_browseFilename_clicked()
   QSettings settings;
   QString dirName = leFilename->text().isEmpty() ? settings.value( "/UI/lastVectorFileFilterDir", QDir::homePath() ).toString() : leFilename->text();
   QString filterString = QgsVectorFileWriter::filterForDriver( format() );
-  QString outputFile = QFileDialog::getSaveFileName( nullptr, tr( "Save layer as..." ), dirName, filterString );
+  QString outputFile = QFileDialog::getSaveFileName( nullptr, tr( "Save layer as..." ), dirName, filterString, nullptr, QFileDialog::DontConfirmOverwrite );
   if ( !outputFile.isNull() )
   {
     leFilename->setText( outputFile );
@@ -509,6 +651,11 @@ void QgsVectorLayerSaveAsDialog::on_mCrsSelector_crsChanged( const QgsCoordinate
 QString QgsVectorLayerSaveAsDialog::filename() const
 {
   return leFilename->text();
+}
+
+QString QgsVectorLayerSaveAsDialog::layername() const
+{
+  return leLayername->text();
 }
 
 QString QgsVectorLayerSaveAsDialog::encoding() const
@@ -611,7 +758,7 @@ QStringList QgsVectorLayerSaveAsDialog::layerOptions() const
         case QgsVectorFileWriter::String:
         {
           QLineEdit* le = mLayerOptionsGroupBox->findChild<QLineEdit*>( it.key() );
-          if ( le )
+          if ( le && !le->text().isEmpty() )
             options << QString( "%1=%2" ).arg( it.key(), le->text() );
           break;
         }
@@ -728,6 +875,11 @@ void QgsVectorLayerSaveAsDialog::setForceMulti( bool checked )
 bool QgsVectorLayerSaveAsDialog::includeZ() const
 {
   return mIncludeZCheckBox->isChecked();
+}
+
+QgsVectorFileWriter::ActionOnExistingFile QgsVectorLayerSaveAsDialog::creationActionOnExistingFile() const
+{
+  return mActionOnExistingFile;
 }
 
 void QgsVectorLayerSaveAsDialog::setIncludeZ( bool checked )

--- a/src/app/ogr/qgsvectorlayersaveasdialog.h
+++ b/src/app/ogr/qgsvectorlayersaveasdialog.h
@@ -48,6 +48,7 @@ class APP_EXPORT QgsVectorLayerSaveAsDialog : public QDialog, private Ui::QgsVec
     QString format() const;
     QString encoding() const;
     QString filename() const;
+    QString layername() const;
     QStringList datasourceOptions() const;
     QStringList layerOptions() const;
     long crs() const;
@@ -100,6 +101,9 @@ class APP_EXPORT QgsVectorLayerSaveAsDialog : public QDialog, private Ui::QgsVec
      */
     void setIncludeZ( bool checked );
 
+    /** Returns creation action */
+    QgsVectorFileWriter::ActionOnExistingFile creationActionOnExistingFile() const;
+
   private slots:
 
     void on_mFormatComboBox_currentIndexChanged( int idx );
@@ -126,6 +130,7 @@ class APP_EXPORT QgsVectorLayerSaveAsDialog : public QDialog, private Ui::QgsVec
     QgsVectorLayer *mLayer;
     bool mAttributeTableItemChangedSlotEnabled;
     bool mReplaceRawFieldValuesStateChangedSlotEnabled;
+    QgsVectorFileWriter::ActionOnExistingFile mActionOnExistingFile;
 };
 
 #endif // QGSVECTORLAYERSAVEASDIALOG_H

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -3521,7 +3521,11 @@ bool QgisApp::addVectorLayers( const QStringList &theLayerQStringList, const QSt
     QString base;
     if ( dataSourceType == "file" )
     {
-      QFileInfo fi( src );
+      QString srcWithoutLayername( src );
+      int posPipe = srcWithoutLayername.indexOf( '|' );
+      if ( posPipe >= 0 )
+        srcWithoutLayername.resize( posPipe );
+      QFileInfo fi( srcWithoutLayername );
       base = fi.completeBaseName();
 
       // if needed prompt for zipitem layers
@@ -6228,22 +6232,29 @@ void QgisApp::saveAsVectorFileGeneral( QgsVectorLayer* vlayer, bool symbologyOpt
     // No need to use the converter if there is nothing to convert
     if ( !dialog->attributesAsDisplayedValues().isEmpty() )
       converterPtr = &converter;
+
+    QgsVectorFileWriter::SaveVectorOptions options;
+    options.driverName = format;
+    options.layerName = dialog->layername();
+    options.actionOnExistingFile = dialog->creationActionOnExistingFile();
+    options.fileEncoding = encoding;
+    options.ct = ct;
+    options.onlySelectedFeatures = dialog->onlySelected();
+    options.datasourceOptions = datasourceOptions;
+    options.layerOptions = dialog->layerOptions();
+    options.skipAttributeCreation = dialog->selectedAttributes().isEmpty();
+    options.symbologyExport = static_cast< QgsVectorFileWriter::SymbologyExport >( dialog->symbologyExport() );
+    options.symbologyScale = dialog->scaleDenominator();
+    if ( dialog->hasFilterExtent() )
+      options.filterExtent = filterExtent;
+    options.overrideGeometryType = autoGeometryType ? QgsWkbTypes::Unknown : forcedGeometryType;
+    options.forceMulti = dialog->forceMulti();
+    options.includeZ = dialog->includeZ();
+    options.attributes = dialog->selectedAttributes();
+    options.fieldValueConverter = converterPtr;
+
     error = QgsVectorFileWriter::writeAsVectorFormat(
-              vlayer, vectorFilename, encoding, ct, format,
-              dialog->onlySelected(),
-              &errorMessage,
-              datasourceOptions, dialog->layerOptions(),
-              dialog->selectedAttributes().isEmpty(),
-              &newFilename,
-              static_cast< QgsVectorFileWriter::SymbologyExport >( dialog->symbologyExport() ),
-              dialog->scaleDenominator(),
-              dialog->hasFilterExtent() ? &filterExtent : nullptr,
-              autoGeometryType ? QgsWkbTypes::Unknown : forcedGeometryType,
-              dialog->forceMulti(),
-              dialog->includeZ(),
-              dialog->selectedAttributes(),
-              converterPtr
-            );
+              vlayer, vectorFilename, options, &newFilename, &errorMessage );
 
     QApplication::restoreOverrideCursor();
 
@@ -6251,7 +6262,10 @@ void QgisApp::saveAsVectorFileGeneral( QgsVectorLayer* vlayer, bool symbologyOpt
     {
       if ( dialog->addToCanvas() )
       {
-        addVectorLayers( QStringList( newFilename ), encoding, "file" );
+        QString uri( newFilename );
+        if ( !dialog->layername().isEmpty() )
+          uri += "|layername=" + dialog->layername();
+        addVectorLayers( QStringList( uri ), encoding, "file" );
       }
       emit layerSavedAs( vlayer, vectorFilename );
       messageBar()->pushMessage( tr( "Saving done" ),

--- a/src/core/qgsvectorfilewriter.h
+++ b/src/core/qgsvectorfilewriter.h
@@ -199,6 +199,45 @@ class CORE_EXPORT QgsVectorFileWriter
         virtual QVariant convert( int fieldIdxInLayer, const QVariant& value );
     };
 
+    /** Edition capability flags
+      * @note Added in QGIS 3.0 */
+    enum EditionCapability
+    {
+      /** Flag to indicate that a new layer can be added to the dataset */
+      CanAddNewLayer                 = 1 << 0,
+
+      /** Flag to indicate that new features can be added to an existing layer */
+      CanAppendToExistingLayer       = 1 << 1,
+
+      /** Flag to indicate that new fields can be added to an existing layer. Imply CanAppendToExistingLayer */
+      CanAddNewFieldsToExistingLayer = 1 << 2,
+
+      /** Flag to indicate that an existing layer can be deleted */
+      CanDeleteLayer                 = 1 << 3
+    };
+
+    /** Combination of CanAddNewLayer, CanAppendToExistingLayer, CanAddNewFieldsToExistingLayer or CanDeleteLayer
+      * @note Added in QGIS 3.0 */
+    Q_DECLARE_FLAGS( EditionCapabilities, EditionCapability )
+
+    /** Enumeration to describe how to handle existing files
+        @note Added in QGIS 3.0
+     */
+    typedef enum
+    {
+      /** Create or overwrite file */
+      CreateOrOverwriteFile,
+
+      /** Create or overwrite layer */
+      CreateOrOverwriteLayer,
+
+      /** Append features to existing layer, but do not create new fields */
+      AppendToLayerNoNewFields,
+
+      /** Append features to existing layer, and create new fields if needed */
+      AppendToLayerAddFields
+    } ActionOnExistingFile;
+
     /** Write contents of vector layer to an (OGR supported) vector formt
      * @param layer layer to write
      * @param fileName file name to write to
@@ -287,6 +326,88 @@ class CORE_EXPORT QgsVectorFileWriter
                                             FieldValueConverter* fieldValueConverter = nullptr
                                           );
 
+
+    /** \ingroup core
+     * Options to pass to writeAsVectorFormat()
+     * @note Added in QGIS 3.0
+     */
+    class CORE_EXPORT SaveVectorOptions
+    {
+      public:
+        /** Constructor */
+        SaveVectorOptions();
+
+        /** Destructor */
+        virtual ~SaveVectorOptions();
+
+        /** OGR driver to use */
+        QString driverName;
+
+        /** Layer name. If let empty, it will be derived from the filename */
+        QString layerName;
+
+        /** Action on existing file  */
+        ActionOnExistingFile actionOnExistingFile;
+
+        /** Encoding to use */
+        QString fileEncoding;
+
+        /** Transform to reproject exported geometries with, or invalid transform
+         * for no transformation */
+        QgsCoordinateTransform ct;
+
+        /** Write only selected features of layer */
+        bool onlySelectedFeatures;
+
+        /** List of OGR data source creation options */
+        QStringList datasourceOptions;
+
+        /** List of OGR layer creation options */
+        QStringList layerOptions;
+
+        /** Only write geometries */
+        bool skipAttributeCreation;
+
+        /** Attributes to export (empty means all unless skipAttributeCreation is set) */
+        QgsAttributeList attributes;
+
+        /** Symbology to export */
+        SymbologyExport symbologyExport;
+
+        /** Scale of symbology */
+        double symbologyScale;
+
+        /** If not empty, only features intersecting the extent will be saved */
+        QgsRectangle filterExtent;
+
+        /** Set to a valid geometry type to override the default geometry type for the layer. This parameter
+         * allows for conversion of geometryless tables to null geometries, etc */
+        QgsWkbTypes::Type overrideGeometryType;
+
+        /** Set to true to force creation of multi* geometries */
+        bool forceMulti;
+
+        /** Set to true to include z dimension in output. This option is only valid if overrideGeometryType is set */
+        bool includeZ;
+
+        /** Field value converter */
+        FieldValueConverter* fieldValueConverter;
+    };
+
+    /** Writes a layer out to a vector file.
+     * @param layer source layer to write
+     * @param fileName file name to write to
+     * @param options options.
+     * @param newFilename QString pointer which will contain the new file name created (in case it is different to fileName).
+     * @param errorMessage pointer to buffer fo error message
+     * @note added in 3.0
+     */
+    static WriterError writeAsVectorFormat( QgsVectorLayer* layer,
+                                            const QString& fileName,
+                                            const SaveVectorOptions& options,
+                                            QString *newFilename = nullptr,
+                                            QString *errorMessage = nullptr );
+
     /** Create a new vector file writer */
     QgsVectorFileWriter( const QString& vectorFileName,
                          const QString& fileEncoding,
@@ -369,6 +490,28 @@ class CORE_EXPORT QgsVectorFileWriter
      */
     static OGRwkbGeometryType ogrTypeFromWkbType( QgsWkbTypes::Type type );
 
+    /**
+     * Return edition capabilites for an existing dataset name.
+     * @note added in QGIS 3.0
+     */
+    static EditionCapabilities editionCapabilities( const QString& datasetName );
+
+    /**
+     * Returns whether the target layer already exists.
+     * @note added in QGIS 3.0
+     */
+    static bool targetLayerExists( const QString& datasetName,
+                                   const QString& layerName );
+
+    /**
+     * Returns whether there are among the attributes specified some that do not exist yet in the layer
+     * @note added in QGIS 3.0
+     */
+    static bool areThereNewFieldsToCreate( const QString& datasetName,
+                                           const QString& layerName,
+                                           QgsVectorLayer* layer,
+                                           const QgsAttributeList& attributes );
+
   protected:
     //! @note not available in python bindings
     OGRGeometryH createEmptyGeometry( QgsWkbTypes::Type wkbType );
@@ -420,6 +563,8 @@ class CORE_EXPORT QgsVectorFileWriter
      * @param newFilename potentially modified file name (output parameter)
      * @param symbologyExport symbology to export
      * @param fieldValueConverter field value converter (added in QGIS 2.16)
+     * @param layerName layer name. If let empty, it will be derived from the filename (added in QGIS 3.0)
+     * @param action action on existing file (added in QGIS 3.0)
      */
     QgsVectorFileWriter( const QString& vectorFileName,
                          const QString& fileEncoding,
@@ -431,14 +576,18 @@ class CORE_EXPORT QgsVectorFileWriter
                          const QStringList &layerOptions,
                          QString *newFilename,
                          SymbologyExport symbologyExport,
-                         FieldValueConverter* fieldValueConverter
+                         FieldValueConverter* fieldValueConverter,
+                         const QString& layerName,
+                         ActionOnExistingFile action
                        );
 
     void init( QString vectorFileName, QString fileEncoding, const QgsFields& fields,
                QgsWkbTypes::Type geometryType, QgsCoordinateReferenceSystem srs,
                const QString& driverName, QStringList datasourceOptions,
                QStringList layerOptions, QString* newFilename,
-               FieldValueConverter* fieldValueConverter );
+               FieldValueConverter* fieldValueConverter,
+               const QString& layerName,
+               ActionOnExistingFile action );
     void resetMap( const QgsAttributeList &attributes );
 
     QgsRenderContext mRenderContext;
@@ -466,5 +615,7 @@ class CORE_EXPORT QgsVectorFileWriter
     //! Concatenates a list of options using their default values
     static QStringList concatenateOptions( const QMap<QString, Option*>& options );
 };
+
+Q_DECLARE_OPERATORS_FOR_FLAGS( QgsVectorFileWriter::EditionCapabilities )
 
 #endif

--- a/src/ui/qgsvectorlayersaveasdialogbase.ui
+++ b/src/ui/qgsvectorlayersaveasdialogbase.ui
@@ -23,21 +23,21 @@
    <item>
     <widget class="QWidget" name="widget" native="true">
      <layout class="QGridLayout" name="gridLayout_4">
-      <item row="2" column="0">
+      <item row="3" column="0">
        <widget class="QLabel" name="label_3">
         <property name="text">
          <string>CRS</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
+      <item row="1" column="2">
        <widget class="QLineEdit" name="leFilename">
         <property name="enabled">
          <bool>false</bool>
         </property>
        </widget>
       </item>
-      <item row="1" column="2">
+      <item row="1" column="3">
        <widget class="QPushButton" name="browseFilename">
         <property name="enabled">
          <bool>false</bool>
@@ -57,23 +57,40 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="1" colspan="2">
+      <item row="0" column="2" colspan="2">
        <widget class="QComboBox" name="mFormatComboBox"/>
       </item>
       <item row="1" column="0">
        <widget class="QLabel" name="label">
         <property name="text">
-         <string>Save as</string>
+         <string>File name</string>
         </property>
         <property name="buddy">
          <cstring>leFilename</cstring>
         </property>
        </widget>
       </item>
-      <item row="2" column="1" colspan="2">
+      <item row="3" column="2" colspan="2">
        <widget class="QgsProjectionSelectionWidget" name="mCrsSelector" native="true">
         <property name="focusPolicy">
          <enum>Qt::StrongFocus</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_7">
+        <property name="text">
+         <string>Layer name</string>
+        </property>
+        <property name="buddy">
+         <cstring>leFilename</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="2" colspan="2">
+       <widget class="QLineEdit" name="leLayername">
+        <property name="enabled">
+         <bool>false</bool>
         </property>
        </widget>
       </item>
@@ -90,8 +107,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>550</width>
-        <height>953</height>
+        <width>557</width>
+        <height>922</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout">
@@ -434,6 +451,7 @@
   <tabstop>mFormatComboBox</tabstop>
   <tabstop>leFilename</tabstop>
   <tabstop>browseFilename</tabstop>
+  <tabstop>leLayername</tabstop>
   <tabstop>mCrsSelector</tabstop>
   <tabstop>scrollArea</tabstop>
   <tabstop>mEncodingComboBox</tabstop>

--- a/tests/src/python/test_qgsvectorfilewriter.py
+++ b/tests/src/python/test_qgsvectorfilewriter.py
@@ -29,6 +29,7 @@ from qgis.core import (QgsVectorLayer,
 from qgis.PyQt.QtCore import QDate, QTime, QDateTime, QVariant, QDir
 import os
 import osgeo.gdal
+from osgeo import gdal, ogr
 import platform
 from qgis.testing import start_app, unittest
 from utilities import writeShape, compareWkt
@@ -485,6 +486,177 @@ class TestQgsVectorLayer(unittest.TestCase):
         options = QgsVectorFileWriter.defaultLayerOptions('GML')
         self.assertEqual(options, [])
 
+    def testOverwriteLayer(self):
+        """Tests writing a layer with a field value converter."""
+
+        ml = QgsVectorLayer('Point?field=firstfield:int', 'test', 'memory')
+        provider = ml.dataProvider()
+
+        ft = QgsFeature()
+        ft.setAttributes([1])
+        provider.addFeatures([ft])
+
+        options = QgsVectorFileWriter.SaveVectorOptions()
+        options.driverName = 'GPKG'
+        options.layerName = 'test'
+        filename = '/vsimem/out.gpkg'
+        write_result = QgsVectorFileWriter.writeAsVectorFormat(
+            ml,
+            filename,
+            options)
+        self.assertEqual(write_result, QgsVectorFileWriter.NoError)
+
+        ds = ogr.Open(filename, update=1)
+        lyr = ds.GetLayerByName('test')
+        self.assertIsNotNone(lyr)
+        f = lyr.GetNextFeature()
+        self.assertEqual(f['firstfield'], 1)
+        ds.CreateLayer('another_layer')
+        del f
+        del lyr
+        del ds
+
+        caps = QgsVectorFileWriter.editionCapabilities(filename)
+        self.assertTrue((caps & QgsVectorFileWriter.CanAddNewLayer))
+        self.assertTrue((caps & QgsVectorFileWriter.CanAppendToExistingLayer))
+        self.assertTrue((caps & QgsVectorFileWriter.CanAddNewFieldsToExistingLayer))
+        self.assertTrue((caps & QgsVectorFileWriter.CanDeleteLayer))
+
+        self.assertTrue(QgsVectorFileWriter.targetLayerExists(filename, 'test'))
+
+        self.assertFalse(QgsVectorFileWriter.areThereNewFieldsToCreate(filename, 'test', ml, [0]))
+
+        # Test CreateOrOverwriteLayer
+        ml = QgsVectorLayer('Point?field=firstfield:int', 'test', 'memory')
+        provider = ml.dataProvider()
+
+        ft = QgsFeature()
+        ft.setAttributes([2])
+        provider.addFeatures([ft])
+
+        options = QgsVectorFileWriter.SaveVectorOptions()
+        options.driverName = 'GPKG'
+        options.layerName = 'test'
+        options.actionOnExistingFile = QgsVectorFileWriter.CreateOrOverwriteLayer
+        filename = '/vsimem/out.gpkg'
+        write_result = QgsVectorFileWriter.writeAsVectorFormat(
+            ml,
+            filename,
+            options)
+        self.assertEqual(write_result, QgsVectorFileWriter.NoError)
+
+        ds = ogr.Open(filename)
+        lyr = ds.GetLayerByName('test')
+        self.assertIsNotNone(lyr)
+        f = lyr.GetNextFeature()
+        self.assertEqual(f['firstfield'], 2)
+        # another_layer should still exist
+        self.assertIsNotNone(ds.GetLayerByName('another_layer'))
+        del f
+        del lyr
+        del ds
+
+        # Test CreateOrOverwriteFile
+        ml = QgsVectorLayer('Point?field=firstfield:int', 'test', 'memory')
+        provider = ml.dataProvider()
+
+        ft = QgsFeature()
+        ft.setAttributes([3])
+        provider.addFeatures([ft])
+
+        options = QgsVectorFileWriter.SaveVectorOptions()
+        options.driverName = 'GPKG'
+        options.layerName = 'test'
+        filename = '/vsimem/out.gpkg'
+        write_result = QgsVectorFileWriter.writeAsVectorFormat(
+            ml,
+            filename,
+            options)
+        self.assertEqual(write_result, QgsVectorFileWriter.NoError)
+
+        ds = ogr.Open(filename)
+        lyr = ds.GetLayerByName('test')
+        self.assertIsNotNone(lyr)
+        f = lyr.GetNextFeature()
+        self.assertEqual(f['firstfield'], 3)
+        # another_layer should no longer exist
+        self.assertIsNone(ds.GetLayerByName('another_layer'))
+        del f
+        del lyr
+        del ds
+
+        # Test AppendToLayerNoNewFields
+        ml = QgsVectorLayer('Point?field=firstfield:int&field=secondfield:int', 'test', 'memory')
+        provider = ml.dataProvider()
+
+        ft = QgsFeature()
+        ft.setAttributes([4, -10])
+        provider.addFeatures([ft])
+
+        self.assertTrue(QgsVectorFileWriter.areThereNewFieldsToCreate(filename, 'test', ml, [0, 1]))
+
+        options = QgsVectorFileWriter.SaveVectorOptions()
+        options.driverName = 'GPKG'
+        options.layerName = 'test'
+        options.actionOnExistingFile = QgsVectorFileWriter.AppendToLayerNoNewFields
+        filename = '/vsimem/out.gpkg'
+        write_result = QgsVectorFileWriter.writeAsVectorFormat(
+            ml,
+            filename,
+            options)
+        self.assertEqual(write_result, QgsVectorFileWriter.NoError)
+
+        ds = ogr.Open(filename)
+        lyr = ds.GetLayerByName('test')
+        self.assertEqual(lyr.GetLayerDefn().GetFieldCount(), 1)
+        self.assertIsNotNone(lyr)
+        f = lyr.GetNextFeature()
+        self.assertEqual(f['firstfield'], 3)
+        f = lyr.GetNextFeature()
+        self.assertEqual(f['firstfield'], 4)
+        del f
+        del lyr
+        del ds
+
+        # Test AppendToLayerAddFields
+        ml = QgsVectorLayer('Point?field=firstfield:int&field=secondfield:int', 'test', 'memory')
+        provider = ml.dataProvider()
+
+        ft = QgsFeature()
+        ft.setAttributes([5, -1])
+        provider.addFeatures([ft])
+
+        self.assertTrue(QgsVectorFileWriter.areThereNewFieldsToCreate(filename, 'test', ml, [0, 1]))
+
+        options = QgsVectorFileWriter.SaveVectorOptions()
+        options.driverName = 'GPKG'
+        options.layerName = 'test'
+        options.actionOnExistingFile = QgsVectorFileWriter.AppendToLayerAddFields
+        filename = '/vsimem/out.gpkg'
+        write_result = QgsVectorFileWriter.writeAsVectorFormat(
+            ml,
+            filename,
+            options)
+        self.assertEqual(write_result, QgsVectorFileWriter.NoError)
+
+        ds = ogr.Open(filename)
+        lyr = ds.GetLayerByName('test')
+        self.assertEqual(lyr.GetLayerDefn().GetFieldCount(), 2)
+        self.assertIsNotNone(lyr)
+        f = lyr.GetNextFeature()
+        self.assertEqual(f['firstfield'], 3)
+        self.assertFalse(f.IsFieldSet('secondfield'))
+        f = lyr.GetNextFeature()
+        self.assertEqual(f['firstfield'], 4)
+        self.assertFalse(f.IsFieldSet('secondfield'))
+        f = lyr.GetNextFeature()
+        self.assertEqual(f['firstfield'], 5)
+        self.assertEqual(f['secondfield'], -1)
+        del f
+        del lyr
+        del ds
+
+        gdal.Unlink(filename)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
When saving a vector layer into an existing file, depending on the capabilities
of the output driver, the user can now decide whether:
- to overwrite the whole file
- to overwrite only the target layer (layer name is now configurable)
- to append features to the existing target layer
- to append features, add new fields if there are any.

Works for drivers like GPKG, SpatiaLite, FileGDB, ...
