### PR TITLE
[Plugin Manager] Fix font size (issue #15302)

### DIFF
--- a/src/app/pluginmanager/qgspluginmanager.cpp
+++ b/src/app/pluginmanager/qgspluginmanager.cpp
@@ -617,7 +617,7 @@ void QgsPluginManager::showPluginDetails( QStandardItem * item )
           "    padding:0px;"
           "    margin:0px;"
           "    font-family:verdana;"
-          "    font-size: 1.1em;"
+          "    font-size: 10pt;"
           "  }"
           "  div#votes {"
           "    width:360px;"
@@ -1133,11 +1133,11 @@ void QgsPluginManager::setCurrentTab( int idx )
     if ( it != mTabDescriptions.constEnd() )
     {
       tabInfoHTML += "<style>"
-                     "body, table {"
-                     "margin:4px;"
-                     "font-family:verdana;"
-                     "font-size: 12px;"
-                     "}"
+                     "  body, p {"
+                     "      margin: 2px;"
+                     "      font-family: verdana;"
+                     "      font-size: 10pt;"
+                     "  }"
                      "</style>";
       // tabInfoHTML += "<style>" + QgsApplication::reportStyleSheet() + "</style>";
       tabInfoHTML += it.value();


### PR DESCRIPTION
@jef-n, some time ago you changed the font size in the Plugin Manager:

https://github.com/qgis/QGIS/commit/010a850f5046

I believe it was an optimisation for the non-QtWebkit version on a high resolution display, but unfortunately it causes super huge fonts in the QtWebkit version, at least in KDE and Windows, on laptop resolutions. See http://hub.qgis.org/issues/15302.

I'd made the font size fixed in points, what _should be_ :) device independent and always readable, but could you please confirm the 10pt also works on the setup where you found the 1.1em appropriate?

Here is how it looks at mine, quite consistent with QtWebkit and without:

![pluman-qtwebkit](https://cloud.githubusercontent.com/assets/1000043/19341787/48394b08-912f-11e6-8952-13537ce3503f.png)

![pluman-nonqtwebkit](https://cloud.githubusercontent.com/assets/1000043/19341788/4cbc5508-912f-11e6-97f9-0adbc59d7c28.png)
