### PR TITLE
[processing] avoid overlapping UI

### DIFF
--- a/python/plugins/processing/gui/ListMultiselectWidget.py
+++ b/python/plugins/processing/gui/ListMultiselectWidget.py
@@ -149,7 +149,7 @@ class ListMultiSelectWidget(QGroupBox):
 
     def _setupUI(self):
         self.setSizePolicy(
-            QSizePolicy.Preferred, QSizePolicy.Ignored)
+            QSizePolicy.Preferred, QSizePolicy.Preferred)
 
         self.setMinimumHeight(180)
 


### PR DESCRIPTION
Super small changes that avoids the overlapping of multi selection widget with other widgets
