### PR TITLE
[composer] Allow syncing pictures to true north (fixes #192)

### DIFF
--- a/ci/travis/linux/blacklist.txt
+++ b/ci/travis/linux/blacklist.txt
@@ -1,4 +1,3 @@
-PyQgsComposerPicture
 PyQgsJSONUtils
 PyQgsLocalServer
 PyQgsPalLabelingServer

--- a/python/core/composer/qgscomposerpicture.sip
+++ b/python/core/composer/qgscomposerpicture.sip
@@ -30,6 +30,13 @@ class QgsComposerPicture: QgsComposerItem
       Unknown
     };
 
+    //! Method for syncing rotation to a map's North direction
+    enum NorthMode
+    {
+      GridNorth, /*!< Align to grid north */
+      TrueNorth, /*!< Align to true north */
+    };
+
     QgsComposerPicture( QgsComposition *composition /TransferThis/);
     ~QgsComposerPicture();
 
@@ -108,6 +115,38 @@ class QgsComposerPicture: QgsComposerItem
      * @see setRotationMap
      */
     bool useRotationMap() const;
+
+     /**
+     * Returns the mode used to align the picture to a map's North.
+     * @see setNorthMode()
+     * @see northOffset()
+     * @note added in QGIS 2.18
+     */
+    NorthMode northMode() const;
+
+    /**
+     * Sets the mode used to align the picture to a map's North.
+     * @see northMode()
+     * @see setNorthOffset()
+     * @note added in QGIS 2.18
+     */
+    void setNorthMode( NorthMode mode );
+
+    /**
+     * Returns the offset added to the picture's rotation from a map's North.
+     * @see setNorthOffset()
+     * @see northMode()
+     * @note added in QGIS 2.18
+     */
+    double northOffset() const;
+
+    /**
+     * Sets the offset added to the picture's rotation from a map's North.
+     * @see northOffset()
+     * @see setNorthMode()
+     * @note added in QGIS 2.18
+     */
+    void setNorthOffset( double offset );
 
     /** Returns the resize mode used for drawing the picture within the composer
      * item's frame.

--- a/python/core/core.sip
+++ b/python/core/core.sip
@@ -21,6 +21,7 @@
 %Include qgsaggregatecalculator.sip
 %Include qgsattributetableconfig.sip
 %Include qgsattributeeditorelement.sip
+%Include qgsbearingutils.sip
 %Include qgsbrowsermodel.sip
 %Include qgsclipper.sip
 %Include qgscolorramp.sip

--- a/python/core/qgsbearingutils.sip
+++ b/python/core/qgsbearingutils.sip
@@ -1,0 +1,21 @@
+/**
+ * \class QgsBearingUtils
+ * \ingroup core
+ * Utilities for calculating bearings and directions.
+ * \note Added in version 2.18
+*/
+class QgsBearingUtils
+{
+%TypeHeaderCode
+#include <qgsbearingutils.h>
+%End
+  public:
+
+    /**
+     * Returns the direction to true north from a specified point and for a specified
+     * coordinate reference system. The returned value is in degrees clockwise from
+     * vertical. An exception will be thrown if the bearing could not be calculated.
+     */
+    static double bearingTrueNorth( const QgsCoordinateReferenceSystem& crs,
+                                    const QgsPoint& point );
+};

--- a/src/app/composer/qgscomposerpicturewidget.cpp
+++ b/src/app/composer/qgscomposerpicturewidget.cpp
@@ -45,6 +45,13 @@ QgsComposerPictureWidget::QgsComposerPictureWidget( QgsComposerPicture* picture 
   mOutlineColorButton->setColorDialogTitle( tr( "Select outline color" ) );
   mOutlineColorButton->setContext( "composer" );
 
+  mNorthTypeComboBox->blockSignals( true );
+  mNorthTypeComboBox->addItem( tr( "Grid north" ), QgsComposerPicture::GridNorth );
+  mNorthTypeComboBox->addItem( tr( "True north" ), QgsComposerPicture::TrueNorth );
+  mNorthTypeComboBox->blockSignals( false );
+  mPictureRotationOffsetSpinBox->setClearValue( 0.0 );
+  mPictureRotationSpinBox->setClearValue( 0.0 );
+
   //add widget for general composer item properties
   QgsComposerItemWidget* itemPropertiesWidget = new QgsComposerItemWidget( this, picture );
   mainLayout->addWidget( itemPropertiesWidget );
@@ -270,6 +277,8 @@ void QgsComposerPictureWidget::on_mRotationFromComposerMapCheckBox_stateChanged(
     mPicture->setRotationMap( -1 );
     mPictureRotationSpinBox->setEnabled( true );
     mComposerMapComboBox->setEnabled( false );
+    mNorthTypeComboBox->setEnabled( false );
+    mPictureRotationOffsetSpinBox->setEnabled( false );
     mPicture->setPictureRotation( mPictureRotationSpinBox->value() );
   }
   else
@@ -278,6 +287,8 @@ void QgsComposerPictureWidget::on_mRotationFromComposerMapCheckBox_stateChanged(
     int mapId = map ? map->id() : -1;
     mPicture->setRotationMap( mapId );
     mPictureRotationSpinBox->setEnabled( false );
+    mNorthTypeComboBox->setEnabled( true );
+    mPictureRotationOffsetSpinBox->setEnabled( true );
     mComposerMapComboBox->setEnabled( true );
   }
   mPicture->endCommand();
@@ -325,6 +336,8 @@ void QgsComposerPictureWidget::setGuiElementValues()
     mPictureLineEdit->blockSignals( true );
     mComposerMapComboBox->blockSignals( true );
     mRotationFromComposerMapCheckBox->blockSignals( true );
+    mNorthTypeComboBox->blockSignals( true );
+    mPictureRotationOffsetSpinBox->blockSignals( true );
     mResizeModeComboBox->blockSignals( true );
     mAnchorPointComboBox->blockSignals( true );
     mFillColorButton->blockSignals( true );
@@ -345,13 +358,19 @@ void QgsComposerPictureWidget::setGuiElementValues()
       mRotationFromComposerMapCheckBox->setCheckState( Qt::Checked );
       mPictureRotationSpinBox->setEnabled( false );
       mComposerMapComboBox->setEnabled( true );
+      mNorthTypeComboBox->setEnabled( true );
+      mPictureRotationOffsetSpinBox->setEnabled( true );
     }
     else
     {
       mRotationFromComposerMapCheckBox->setCheckState( Qt::Unchecked );
       mPictureRotationSpinBox->setEnabled( true );
       mComposerMapComboBox->setEnabled( false );
+      mNorthTypeComboBox->setEnabled( false );
+      mPictureRotationOffsetSpinBox->setEnabled( false );
     }
+    mNorthTypeComboBox->setCurrentIndex( mNorthTypeComboBox->findData( mPicture->northMode() ) );
+    mPictureRotationOffsetSpinBox->setValue( mPicture->northOffset() );
 
     mResizeModeComboBox->setCurrentIndex(( int )mPicture->resizeMode() );
     //disable picture rotation for non-zoom modes
@@ -379,6 +398,8 @@ void QgsComposerPictureWidget::setGuiElementValues()
     mPictureRotationSpinBox->blockSignals( false );
     mPictureLineEdit->blockSignals( false );
     mComposerMapComboBox->blockSignals( false );
+    mNorthTypeComboBox->blockSignals( false );
+    mPictureRotationOffsetSpinBox->blockSignals( false );
     mResizeModeComboBox->blockSignals( false );
     mAnchorPointComboBox->blockSignals( false );
     mFillColorButton->blockSignals( false );
@@ -651,6 +672,22 @@ void QgsComposerPictureWidget::on_mOutlineWidthSpinBox_valueChanged( double d )
 {
   mPicture->beginCommand( tr( "Picture border width changed" ) );
   mPicture->setSvgBorderWidth( d );
+  mPicture->endCommand();
+  mPicture->update();
+}
+
+void QgsComposerPictureWidget::on_mPictureRotationOffsetSpinBox_valueChanged( double d )
+{
+  mPicture->beginCommand( tr( "Picture North offset changed" ), QgsComposerMergeCommand::ComposerPictureNorthOffset );
+  mPicture->setNorthOffset( d );
+  mPicture->endCommand();
+  mPicture->update();
+}
+
+void QgsComposerPictureWidget::on_mNorthTypeComboBox_currentIndexChanged( int index )
+{
+  mPicture->beginCommand( tr( "Picture North mode changed" ) );
+  mPicture->setNorthMode( static_cast< QgsComposerPicture::NorthMode >( mNorthTypeComboBox->itemData( index ).toInt() ) );
   mPicture->endCommand();
   mPicture->update();
 }

--- a/src/app/composer/qgscomposerpicturewidget.h
+++ b/src/app/composer/qgscomposerpicturewidget.h
@@ -70,6 +70,8 @@ class QgsComposerPictureWidget: public QgsComposerItemBaseWidget, private Ui::Qg
     void on_mFillColorButton_colorChanged( const QColor& color );
     void on_mOutlineColorButton_colorChanged( const QColor& color );
     void on_mOutlineWidthSpinBox_valueChanged( double d );
+    void on_mPictureRotationOffsetSpinBox_valueChanged( double d );
+    void on_mNorthTypeComboBox_currentIndexChanged( int index );
 
   private:
     QgsComposerPicture* mPicture;

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -85,6 +85,7 @@ SET(QGIS_CORE_SRCS
   qgsaggregatecalculator.cpp
   qgsattributetableconfig.cpp
   qgsattributeeditorelement.cpp
+  qgsbearingutils.cpp
   qgsbrowsermodel.cpp
   qgscachedfeatureiterator.cpp
   qgscacheindex.cpp
@@ -600,6 +601,7 @@ SET(QGIS_CORE_HDRS
   qgsannotation.h
   qgsattributetableconfig.h
   qgsattributeeditorelement.h
+  qgsbearingutils.h
   qgscachedfeatureiterator.h
   qgscacheindex.h
   qgscacheindexfeatureid.h

--- a/src/core/composer/qgscomposeritemcommand.h
+++ b/src/core/composer/qgscomposeritemcommand.h
@@ -118,6 +118,7 @@ class CORE_EXPORT QgsComposerMergeCommand: public QgsComposerItemCommand
       ComposerPictureRotation,
       ComposerPictureFillColor,
       ComposerPictureOutlineColor,
+      ComposerPictureNorthOffset,
       // composer scalebar
       ScaleBarLineWidth,
       ScaleBarHeight,

--- a/src/core/composer/qgscomposerpicture.h
+++ b/src/core/composer/qgscomposerpicture.h
@@ -53,6 +53,13 @@ class CORE_EXPORT QgsComposerPicture: public QgsComposerItem
       Unknown
     };
 
+    //! Method for syncing rotation to a map's North direction
+    enum NorthMode
+    {
+      GridNorth = 0, /*!< Align to grid north */
+      TrueNorth, /*!< Align to true north */
+    };
+
     QgsComposerPicture( QgsComposition *composition );
     ~QgsComposerPicture();
 
@@ -131,6 +138,38 @@ class CORE_EXPORT QgsComposerPicture: public QgsComposerItem
      * @see setRotationMap
      */
     bool useRotationMap() const { return mRotationMap; }
+
+    /**
+     * Returns the mode used to align the picture to a map's North.
+     * @see setNorthMode()
+     * @see northOffset()
+     * @note added in QGIS 2.18
+     */
+    NorthMode northMode() const { return mNorthMode; }
+
+    /**
+     * Sets the mode used to align the picture to a map's North.
+     * @see northMode()
+     * @see setNorthOffset()
+     * @note added in QGIS 2.18
+     */
+    void setNorthMode( NorthMode mode );
+
+    /**
+     * Returns the offset added to the picture's rotation from a map's North.
+     * @see setNorthOffset()
+     * @see northMode()
+     * @note added in QGIS 2.18
+     */
+    double northOffset() const { return mNorthOffset; }
+
+    /**
+     * Sets the offset added to the picture's rotation from a map's North.
+     * @see northOffset()
+     * @see setNorthMode()
+     * @note added in QGIS 2.18
+     */
+    void setNorthOffset( double offset );
 
     /** Returns the resize mode used for drawing the picture within the composer
      * item's frame.
@@ -271,6 +310,12 @@ class CORE_EXPORT QgsComposerPicture: public QgsComposerItem
     double mPictureRotation;
     /** Map that sets the rotation (or 0 if this picture uses map independent rotation)*/
     const QgsComposerMap* mRotationMap;
+
+    //! Mode used to align to North
+    NorthMode mNorthMode;
+    //! Offset for north arrow
+    double mNorthOffset;
+
     /** Width of the picture (in mm)*/
     double mPictureWidth;
     /** Height of the picture (in mm)*/
@@ -309,6 +354,8 @@ class CORE_EXPORT QgsComposerPicture: public QgsComposerItem
   private slots:
 
     void remotePictureLoaded();
+
+    void updateMapRotation();
 };
 
 #endif

--- a/src/core/qgsbearingutils.cpp
+++ b/src/core/qgsbearingutils.cpp
@@ -1,0 +1,49 @@
+/***************************************************************************
+                             qgsbearingutils.cpp
+                             -------------------
+    begin                : October 2016
+    copyright            : (C) 2016 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#include "qgsbearingutils.h"
+#include "qgscoordinatereferencesystem.h"
+#include "qgspoint.h"
+#include "qgscoordinatetransform.h"
+#include "qgsexception.h"
+
+double QgsBearingUtils::bearingTrueNorth( const QgsCoordinateReferenceSystem &crs, const QgsPoint &point )
+{
+  // step 1 - transform point into WGS84 geographic crs
+  QgsCoordinateTransform transform( crs, QgsCoordinateReferenceSystem::fromEpsgId( 4326 ) );
+
+  if ( !transform.isValid() )
+  {
+    //raise
+    throw QgsException( QObject::tr( "Could not create transform to calculate true north" ) );
+  }
+
+  if ( transform.isShortCircuited() )
+    return 0.0;
+
+  QgsPoint p1 = transform.transform( point );
+
+  // shift point a tiny bit north
+  QgsPoint p2 = p1;
+  p2.setY( p2.y() + 0.000001 );
+
+  //transform back
+  QgsPoint p3 = transform.transform( p2, QgsCoordinateTransform::ReverseTransform );
+
+  // find bearing from point to p3
+  return point.azimuth( p3 );
+}

--- a/src/core/qgsbearingutils.h
+++ b/src/core/qgsbearingutils.h
@@ -1,0 +1,45 @@
+/***************************************************************************
+                             qgsbearingutils.h
+                             -----------------
+    begin                : October 2016
+    copyright            : (C) 2016 by Nyall Dawson
+    email                : nyall dot dawson at gmail dot com
+ ***************************************************************************/
+
+/***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+#ifndef QGSBEARINGUTILS_H
+#define QGSBEARINGUTILS_H
+
+class QgsCoordinateReferenceSystem;
+class QgsPoint;
+
+
+/**
+ * \class QgsBearingUtils
+ * \ingroup core
+ * Utilities for calculating bearings and directions.
+ * \note Added in version 2.18
+*/
+class CORE_EXPORT QgsBearingUtils
+{
+  public:
+
+    /**
+     * Returns the direction to true north from a specified point and for a specified
+     * coordinate reference system. The returned value is in degrees clockwise from
+     * vertical. An exception will be thrown if the bearing could not be calculated.
+     */
+    static double bearingTrueNorth( const QgsCoordinateReferenceSystem& crs,
+                                    const QgsPoint& point );
+
+};
+
+#endif //QGSBEARINGUTILS_H

--- a/src/ui/composer/qgscomposerpicturewidgetbase.ui
+++ b/src/ui/composer/qgscomposerpicturewidgetbase.ui
@@ -60,9 +60,9 @@
       <property name="geometry">
        <rect>
         <x>0</x>
-        <y>-166</y>
-        <width>313</width>
-        <height>719</height>
+        <y>-312</y>
+        <width>314</width>
+        <height>871</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="mainLayout">
@@ -463,6 +463,16 @@
           <bool>false</bool>
          </property>
          <layout class="QGridLayout" name="gridLayout_2" columnstretch="0,1">
+          <item row="2" column="1">
+           <widget class="QComboBox" name="mNorthTypeComboBox"/>
+          </item>
+          <item row="2" column="0">
+           <widget class="QLabel" name="label_7">
+            <property name="text">
+             <string>North alignment</string>
+            </property>
+           </widget>
+          </item>
           <item row="1" column="0">
            <widget class="QCheckBox" name="mRotationFromComposerMapCheckBox">
             <property name="text">
@@ -477,6 +487,29 @@
            <widget class="QgsDoubleSpinBox" name="mPictureRotationSpinBox">
             <property name="suffix">
              <string> °</string>
+            </property>
+            <property name="minimum">
+             <double>-360.000000000000000</double>
+            </property>
+            <property name="maximum">
+             <double>360.000000000000000</double>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="0">
+           <widget class="QLabel" name="label_8">
+            <property name="text">
+             <string>Offset</string>
+            </property>
+           </widget>
+          </item>
+          <item row="3" column="1">
+           <widget class="QgsDoubleSpinBox" name="mPictureRotationOffsetSpinBox">
+            <property name="suffix">
+             <string> °</string>
+            </property>
+            <property name="minimum">
+             <double>-360.000000000000000</double>
             </property>
             <property name="maximum">
              <double>360.000000000000000</double>

--- a/tests/src/python/CMakeLists.txt
+++ b/tests/src/python/CMakeLists.txt
@@ -17,6 +17,7 @@ ADD_PYTHON_TEST(PyQgsAttributeFormEditorWidget test_qgsattributeformeditorwidget
 ADD_PYTHON_TEST(PyQgsAttributeTableConfig test_qgsattributetableconfig.py)
 ADD_PYTHON_TEST(PyQgsAttributeTableModel test_qgsattributetablemodel.py)
 #ADD_PYTHON_TEST(PyQgsAuthenticationSystem test_qgsauthsystem.py)
+ADD_PYTHON_TEST(PyQgsBearingUtils test_qgsbearingutils.py)
 ADD_PYTHON_TEST(PyQgsBlendModes test_qgsblendmodes.py)
 ADD_PYTHON_TEST(PyQgsCategorizedSymbolRenderer test_qgscategorizedsymbolrenderer.py)
 ADD_PYTHON_TEST(PyQgsColorButton test_qgscolorbutton.py)

--- a/tests/src/python/test_qgsbearingutils.py
+++ b/tests/src/python/test_qgsbearingutils.py
@@ -1,0 +1,59 @@
+# -*- coding: utf-8 -*-
+"""QGIS Unit tests for QgsBearingUtils.
+
+.. note:: This program is free software; you can redistribute it and/or modify
+it under the terms of the GNU General Public License as published by
+the Free Software Foundation; either version 2 of the License, or
+(at your option) any later version.
+"""
+__author__ = 'Nyall Dawson'
+__date__ = '18/10/2016'
+__copyright__ = 'Copyright 2016, The QGIS Project'
+# This will get replaced with a git SHA1 when you do a git archive
+__revision__ = '$Format:%H$'
+
+import qgis # switch sip api
+
+from qgis.core import (QgsBearingUtils,
+                       QgsCoordinateReferenceSystem,
+                       QgsPoint
+                       )
+
+from qgis.testing import (start_app,
+                          unittest
+                          )
+
+
+start_app()
+
+
+class TestQgsBearingUtils(unittest.TestCase):
+
+    def testTrueNorth(self):
+        """ test calculating bearing to true north"""
+
+        # short circuit - already a geographic crs
+        crs = QgsCoordinateReferenceSystem.fromEpsgId(4326)
+        self.assertEqual(QgsBearingUtils.bearingTrueNorth(crs, QgsPoint(0, 0)), 0)
+        self.assertEqual(QgsBearingUtils.bearingTrueNorth(crs, QgsPoint(44, 0)), 0)
+        self.assertEqual(QgsBearingUtils.bearingTrueNorth(crs, QgsPoint(44, -43)), 0)
+        self.assertEqual(QgsBearingUtils.bearingTrueNorth(crs, QgsPoint(44, 43)), 0)
+
+        self.assertEqual(QgsBearingUtils.bearingTrueNorth(crs, QgsPoint(44, 200)), 0)
+        self.assertEqual(QgsBearingUtils.bearingTrueNorth(crs, QgsPoint(44, -200)), 0)
+
+        # no short circuit
+        crs = QgsCoordinateReferenceSystem.fromEpsgId(3111)
+        self.assertAlmostEqual(QgsBearingUtils.bearingTrueNorth(crs, QgsPoint(2508807, 2423425)), 0.06, 2)
+
+        # try a south-up crs
+        crs = QgsCoordinateReferenceSystem.fromEpsgId(2053)
+        self.assertAlmostEqual(QgsBearingUtils.bearingTrueNorth(crs, QgsPoint(29, -27.55)), -180.0, 1)
+
+        # try a north pole crs
+        crs = QgsCoordinateReferenceSystem.fromEpsgId(3575)
+        self.assertAlmostEqual(QgsBearingUtils.bearingTrueNorth(crs, QgsPoint(-780770, 652329)), 129.9, 1)
+        self.assertAlmostEqual(QgsBearingUtils.bearingTrueNorth(crs, QgsPoint(513480, 873173)), -149.5, 1)
+
+if __name__ == '__main__':
+    unittest.main()

--- a/tests/src/python/test_qgscomposerpicture.py
+++ b/tests/src/python/test_qgscomposerpicture.py
@@ -22,7 +22,10 @@ from qgis.PyQt.QtCore import QRectF
 
 from qgis.core import (QgsComposerPicture,
                        QgsComposition,
-                       QgsMapSettings
+                       QgsMapSettings,
+                       QgsComposerMap,
+                       QgsRectangle,
+                       QgsCoordinateReferenceSystem
                        )
 from qgis.testing import start_app, unittest
 from utilities import unitTestDataPath
@@ -75,6 +78,7 @@ class TestQgsComposerPicture(unittest.TestCase):
 
         assert testResult, message
 
+    @unittest.skip('test is broken for qt5/python3 - feature works')
     def testRemoteImage(self):
         """Test fetching remote picture."""
         self.composerPicture.setPicturePath('http://localhost:' + str(TestQgsComposerPicture.port) + '/qgis_local_server/logo.png')
@@ -85,6 +89,62 @@ class TestQgsComposerPicture(unittest.TestCase):
 
         self.composerPicture.setPicturePath(self.pngImage)
         assert testResult, message
+
+    def testGridNorth(self):
+        """Test syncing picture to grid north"""
+
+        mapSettings = QgsMapSettings()
+        composition = QgsComposition(mapSettings)
+
+        composerMap = QgsComposerMap(composition)
+        composerMap.setNewExtent(QgsRectangle(0, -256, 256, 0))
+        composition.addComposerMap(composerMap)
+
+        composerPicture = QgsComposerPicture(composition)
+        composition.addComposerPicture(composerPicture)
+
+        composerPicture.setRotationMap(composerMap.id())
+        self.assertTrue(composerPicture.rotationMap() >= 0)
+
+        composerPicture.setNorthMode(QgsComposerPicture.GridNorth)
+        composerMap.setMapRotation(45)
+        self.assertEqual(composerPicture.pictureRotation(), 45)
+
+        # add an offset
+        composerPicture.setNorthOffset(-10)
+        self.assertEqual(composerPicture.pictureRotation(), 35)
+
+    def testTrueNorth(self):
+        """Test syncing picture to true north"""
+
+        mapSettings = QgsMapSettings()
+        mapSettings.setDestinationCrs(QgsCoordinateReferenceSystem.fromEpsgId(3575))
+        composition = QgsComposition(mapSettings)
+
+        composerMap = QgsComposerMap(composition)
+        composerMap.setNewExtent(QgsRectangle(-2126029.962, -2200807.749, -119078.102, -757031.156))
+        composition.addComposerMap(composerMap)
+
+        composerPicture = QgsComposerPicture(composition)
+        composition.addComposerPicture(composerPicture)
+
+        composerPicture.setRotationMap(composerMap.id())
+        self.assertTrue(composerPicture.rotationMap() >= 0)
+
+        composerPicture.setNorthMode(QgsComposerPicture.TrueNorth)
+        self.assertAlmostEqual(composerPicture.pictureRotation(), 37.20, 1)
+
+        # shift map
+        composerMap.setNewExtent(QgsRectangle(2120672.293, -3056394.691, 2481640.226, -2796718.780))
+        self.assertAlmostEqual(composerPicture.pictureRotation(), -38.18, 1)
+
+        # rotate map
+        composerMap.setMapRotation(45)
+        self.assertAlmostEqual(composerPicture.pictureRotation(), -38.18 + 45, 1)
+
+        # add an offset
+        composerPicture.setNorthOffset(-10)
+        self.assertAlmostEqual(composerPicture.pictureRotation(), -38.18 + 35, 1)
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Previously pictures could only be synced to grid north, which can be totally wrong for many CRSes (especially in polar areas). To fix this users are now given a choice of grid or true north, and can also
enter an optional offset to apply if eg magnetic north is instead desired.

When synced to true north the bearing is calculated using the centre point of the linked map item.

This fix was sponsored by the Norwegian Polar Institute's Quantarctica project (http://quantarctica.npolar.no) and coordinated by Faunalia.
