### PR TITLE
[processing] fix missing argument when calling getMinCoveringExtent()

### DIFF
--- a/python/plugins/processing/core/parameters.py
+++ b/python/plugins/processing/core/parameters.py
@@ -403,7 +403,7 @@ class ParameterExtent(Parameter):
 
     def evaluate(self, alg):
         if self.optional and not bool(self.value):
-            self.value = self.getMinCoveringExtent()
+            self.value = self.getMinCoveringExtent(alg)
 
     def getMinCoveringExtent(self, alg):
         first = True


### PR DESCRIPTION
@volaya , this PR fixes a small issue which prevents grass7 algorithms from running by adding a missing argument when calling getMinCoveringExtent() function.
