### PR TITLE
Fix offline editing

### DIFF
--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -1994,7 +1994,7 @@ bool QgsVectorLayer::readSymbology( const QDomNode& node, QString& errorMessage 
 
   mConditionalStyles->readXml( node );
 
-  readCustomProperties( node );
+  readCustomProperties( node, "variable" );
 
   return true;
 }


### PR DESCRIPTION
We cannot just restore all layer properties, offline editing relies on some not
being copied.
