### PR TITLE
[processing] ensure that outputs of vector overlay operations are multiparts

### DIFF
--- a/python/plugins/processing/algs/qgis/Clip.py
+++ b/python/plugins/processing/algs/qgis/Clip.py
@@ -67,7 +67,7 @@ class Clip(GeoAlgorithm):
 
         writer = self.getOutputFromName(self.OUTPUT).getVectorWriter(
             source_layer.fields(),
-            source_layer.wkbType(),
+            QgsWkbTypes.multiType(source_layer.wkbType()),
             source_layer.crs())
 
         # first build up a list of clip geometries

--- a/python/plugins/processing/algs/qgis/Difference.py
+++ b/python/plugins/processing/algs/qgis/Difference.py
@@ -69,7 +69,7 @@ class Difference(GeoAlgorithm):
             self.getParameterValue(Difference.OVERLAY))
         ignoreInvalid = self.getParameterValue(Difference.IGNORE_INVALID)
 
-        geomType = layerA.wkbType()
+        geomType = QgsWkbTypes.multiType(layerA.wkbType())
         writer = self.getOutputFromName(
             Difference.OUTPUT).getVectorWriter(layerA.fields(),
                                                geomType,

--- a/python/plugins/processing/algs/qgis/Intersection.py
+++ b/python/plugins/processing/algs/qgis/Intersection.py
@@ -75,7 +75,7 @@ class Intersection(GeoAlgorithm):
         vlayerB = dataobjects.getObjectFromUri(
             self.getParameterValue(self.INPUT2))
 
-        geomType = vlayerA.wkbType()
+        geomType = QgsWkbTypes.multiType(vlayerA.wkbType())
         fields = vector.combineVectorFields(vlayerA, vlayerB)
         writer = self.getOutputFromName(self.OUTPUT).getVectorWriter(fields,
                                                                      geomType, vlayerA.crs())

--- a/python/plugins/processing/algs/qgis/SymmetricalDifference.py
+++ b/python/plugins/processing/algs/qgis/SymmetricalDifference.py
@@ -65,7 +65,7 @@ class SymmetricalDifference(GeoAlgorithm):
         layerB = dataobjects.getObjectFromUri(
             self.getParameterValue(self.OVERLAY))
 
-        geomType = layerA.wkbType()
+        geomType = QgsWkbTypes.multiType(layerA.wkbType())
         fields = vector.combineVectorFields(layerA, layerB)
         writer = self.getOutputFromName(self.OUTPUT).getVectorWriter(
             fields, geomType, layerA.crs())


### PR DESCRIPTION
@volaya , vector overlay operations can often result in multipart geometries. However, the processing algorithm currently doesn't insure outputs are multi{line, polygon} as it simply take the input layer wkbType as the output wkbType.

In cases when the input layer is a non-multi line or polygon, it will lead to errors when writing into a spatialite table, which would create a geometry column of LINE or POLYGON, and subsequently try to insert a MULTILINE or MULTIPOLYGON into it. Alternatively, if you output to a temporary memory layer, it'll be fine except, but the layer - which reports LINE or POLYGON as its type - will contain MULTILINE and MULTIPOLYGON, and create subsequent issues (such as importing the temporary memory layer into a spatialite db via db_manager, etc.)

The solution is to insure that the output type is a multigeometry, as this PR proposes.
