### PR TITLE
[DB Manager] Allow lowercase field names for homogenize PostGIS Import

### DIFF
--- a/python/plugins/db_manager/db_plugins/plugin.py
+++ b/python/plugins/db_manager/db_plugins/plugin.py
@@ -552,6 +552,9 @@ class Database(DbItemObject):
     def spatialIndexClause(self, src_table, src_column, dest_table, dest_table_column):
         return None
 
+    def hasLowercaseFieldNamesOption(self):
+        return False
+
 
 class Schema(DbItemObject):
 

--- a/python/plugins/db_manager/db_plugins/postgis/plugin.py
+++ b/python/plugins/db_manager/db_plugins/postgis/plugin.py
@@ -168,6 +168,9 @@ class PGDatabase(Database):
 
         item.runRefreshMaterializedView()
 
+    def hasLowercaseFieldNamesOption(self):
+        return True
+
 
 class PGSchema(Schema):
 

--- a/python/plugins/db_manager/dlg_import_vector.py
+++ b/python/plugins/db_manager/dlg_import_vector.py
@@ -108,6 +108,10 @@ class DlgImportVector(QDialog, Ui_Dialog):
         if not self.chkSpatialIndex.isEnabled():
             self.chkSpatialIndex.setChecked(False)
 
+        self.chkLowercaseFieldNames.setEnabled(self.db.hasLowercaseFieldNamesOption())
+        if not self.chkLowercaseFieldNames.isEnabled():
+            self.chkLowercaseFieldNames.setChecked(False)
+
     def populateLayers(self):
         self.cboInputLayer.clear()
         for index, layer in enumerate(iface.legendInterface().layers()):
@@ -302,13 +306,18 @@ class DlgImportVector(QDialog, Ui_Dialog):
             else:
                 geom = None
 
+            options = {}
+            if self.chkLowercaseFieldNames.isEnabled() and self.chkLowercaseFieldNames.isChecked():
+                pk = pk.lower()
+                if geom:
+                    geom = geom.lower()
+                options['lowercaseFieldNames'] = True
+
             # get output params, update output URI
             self.outUri.setDataSource(schema, table, geom, "", pk)
             uri = self.outUri.uri(False)
 
             providerName = self.db.dbplugin().providerName()
-
-            options = {}
             if self.chkDropTable.isChecked():
                 options['overwrite'] = True
 

--- a/python/plugins/db_manager/ui/DlgImportVector.ui
+++ b/python/plugins/db_manager/ui/DlgImportVector.ui
@@ -253,7 +253,7 @@
         </property>
        </widget>
       </item>
-      <item row="7" column="0" colspan="2">
+      <item row="8" column="0" colspan="2">
        <widget class="QCheckBox" name="chkSpatialIndex">
         <property name="text">
          <string>Create spatial index</string>
@@ -264,6 +264,13 @@
        <widget class="QCheckBox" name="chkDropTable">
         <property name="text">
          <string>Replace destination table (if exists)</string>
+        </property>
+       </widget>
+      </item>
+      <item row="7" column="0">
+       <widget class="QCheckBox" name="chkLowercaseFieldNames">
+        <property name="text">
+         <string>Convert field names to lowercase</string>
         </property>
        </widget>
       </item>


### PR DESCRIPTION
PostGIS provider has an option to lowercase field names. This options is available for user in QGIS algorithm ImportIntoPostGIS and not in DB Mananger.

This commit fix it.
