### PR TITLE
Defer processing of dropped files (backport to master_2)

### DIFF
--- a/src/app/qgisapp.h
+++ b/src/app/qgisapp.h
@@ -1322,6 +1322,9 @@ class APP_EXPORT QgisApp : public QMainWindow, private Ui::MainWindow
     /** Set the layer for the map style dock. Doesn't show the style dock */
     void setMapStyleDockLayer( QgsMapLayer *layer );
 
+    //! Handles processing of dropped mimedata
+    void dropEventTimeout();
+
   signals:
     /** Emitted when a key is pressed and we want non widget sublasses to be able
       to pick up on this (e.g. maplayer) */

--- a/src/core/qgsmimedatautils.h
+++ b/src/core/qgsmimedatautils.h
@@ -55,5 +55,7 @@ class CORE_EXPORT QgsMimeDataUtils
 
 };
 
+Q_DECLARE_METATYPE( QgsMimeDataUtils::UriList );
+
 #endif // QGSMIMEDATAUTILS_H
 


### PR DESCRIPTION
On Windows (and maybe other platforms) Qt locks the dragging application for the duration of dropEvent. This means that dropping large files or projects onto QGIS results in Explorer windows being locked and unresponsive until the entire file/project is loaded.

There does not seem to be any Qt method for releasing this lock early, so instead we return from dropEvent as quickly as possible and defer the actual file loading to a slot which is fired up immediately after dropEvent concludes.

(cherry-picked from bd81edc36f867bd2774acc6bf956802ae8cd2cd7)
