### PR TITLE
Launch external browser if CA sslError. Partial fix for #15617

### DIFF
--- a/python/core/auth/qgsauthmanager.sip
+++ b/python/core/auth/qgsauthmanager.sip
@@ -464,6 +464,9 @@ class QgsAuthManager : QObject
     void authDatabaseChanged() const;
 
   public slots:
+    /** Rebuild various SSL authentication caches */
+    bool rebuildSslCaches();
+
     /** Clear all authentication configs from authentication method caches */
     void clearAllCachedConfigs();
 

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -11645,16 +11645,22 @@ void QgisApp::namSslErrors( QNetworkReply *reply, const QList<QSslError> &errors
   dlg->resize( 580, 512 );
   if ( dlg->exec() )
   {
-    if ( reply )
+    if ( reply && !reply->isFinished() )
     {
       QgsDebugMsg( QString( "All SSL errors ignored for %1" ).arg( hostport ) );
       reply->ignoreSslErrors();
     }
   }
+  else
+  {
+    reply->abort();
+    reply->close();
+    reply->deleteLater();
+  }
   dlg->deleteLater();
 
   // restart network request timeout timer
-  if ( reply )
+  if ( reply && !reply->isFinished() )
   {
     QSettings s;
     QTimer *timer = reply->findChild<QTimer *>( "timeoutTimer" );

--- a/src/core/auth/qgsauthmanager.cpp
+++ b/src/core/auth/qgsauthmanager.cpp
@@ -1588,6 +1588,21 @@ bool QgsAuthManager::initSslCaches()
   return res;
 }
 
+bool QgsAuthManager::rebuildSslCaches()
+{
+  // do, incidentally, the same of initSslCaches but it is semantically different!
+  // initSslCaches have to be called only one time, this method can be colled
+  // different times
+  bool res = true;
+  res = res && rebuildCaCertsCache();
+  res = res && rebuildCertTrustCache();
+  res = res && rebuildTrustedCaCertsCache();
+  res = res && rebuildIgnoredSslErrorCache();
+
+  QgsDebugMsg( QString( "rebuild of SSL caches %1" ).arg( res ? "SUCCEEDED" : "FAILED" ) );
+  return res;
+}
+
 bool QgsAuthManager::storeCertIdentity( const QSslCertificate &cert, const QSslKey &key )
 {
   if ( cert.isNull() )

--- a/src/core/auth/qgsauthmanager.h
+++ b/src/core/auth/qgsauthmanager.h
@@ -519,6 +519,11 @@ class CORE_EXPORT QgsAuthManager : public QObject
     void authDatabaseChanged() const;
 
   public slots:
+#ifndef QT_NO_OPENSSL
+    /** Rebuild various SSL authentication caches */
+    bool rebuildSslCaches();
+#endif
+
     /** Clear all authentication configs from authentication method caches */
     void clearAllCachedConfigs();
 

--- a/src/gui/auth/qgsauthsslerrorsdialog.cpp
+++ b/src/gui/auth/qgsauthsslerrorsdialog.cpp
@@ -111,11 +111,13 @@ QgsAuthSslErrorsDialog::QgsAuthSslErrorsDialog( QNetworkReply *reply,
     emit sslErrorsCAtoImport(allowedCaErrors);
 #else
     btnAddCainCAs->setVisible( false );
+    teSslErrorsMessages->setVisible( false );
 #endif // Q_OS_WIN
   }
   else
   {
     btnAddCainCAs->setVisible( false );
+    teSslErrorsMessages->setVisible( false );
     btnChainInfo->setVisible( false );
     btnChainCAs->setVisible( false );
     grpbxSslConfig->setVisible( false );

--- a/src/gui/auth/qgsauthsslerrorsdialog.cpp
+++ b/src/gui/auth/qgsauthsslerrorsdialog.cpp
@@ -18,14 +18,20 @@
 #include "qgsauthsslerrorsdialog.h"
 #include "qgsauthsslconfigwidget.h"
 
+#include <Qt>
+#include <QDesktopServices>
+#include <QMessageBox>
 #include <QDialogButtonBox>
 #include <QFont>
+#include <QColor>
 #include <QPushButton>
 #include <QStyle>
 #include <QToolButton>
+#include <QTimer>
 
 #include "qgsauthmanager.h"
 #include "qgsauthcertutils.h"
+#include "qgsauthguiutils.h"
 #include "qgsauthtrustedcasdialog.h"
 #include "qgscollapsiblegroupbox.h"
 #include "qgslogger.h"
@@ -41,6 +47,7 @@ QgsAuthSslErrorsDialog::QgsAuthSslErrorsDialog( QNetworkReply *reply,
     , mSslErrors( sslErrors )
     , mDigest( digest )
     , mHostPort( hostport )
+    , mUrl( reply->url() )
 {
   if ( mDigest.isEmpty() )
   {
@@ -49,8 +56,8 @@ QgsAuthSslErrorsDialog::QgsAuthSslErrorsDialog( QNetworkReply *reply,
   if ( mHostPort.isEmpty() )
   {
     mHostPort = QString( "%1:%2" )
-                .arg( reply->url().host() )
-                .arg( reply->url().port() != -1 ? reply->url().port() : 443 )
+                .arg( mUrl.host() )
+                .arg( mUrl.port() != -1 ? mUrl.port() : 443 )
                 .trimmed();
   }
 
@@ -81,9 +88,34 @@ QgsAuthSslErrorsDialog::QgsAuthSslErrorsDialog( QNetworkReply *reply,
              this, SLOT( widgetReadyToSaveChanged( bool ) ) );
     wdgtSslConfig->setConfigCheckable( false );
     wdgtSslConfig->certificateGroupBox()->setFlat( true );
+
+#ifdef Q_OS_WIN
+    // in case of a specific set of errors
+    connect( this, SIGNAL( sslErrorsCAtoImport(QList<QSslError>&) ),
+             this, SLOT( widgetAllowAddCAsToKeystore(QList<QSslError>&) ) );
+
+    btnAddCainCAs->setVisible( true );
+    QList<QSslError> allowedCaErrors;
+    Q_FOREACH ( const QSslError &err, mSslErrors )
+    {
+      switch ( err.error() )
+      {
+      case QSslError::UnableToGetLocalIssuerCertificate:
+      case QSslError::CertificateUntrusted:
+        allowedCaErrors.append(err);
+        break;
+      default:
+        break;
+      }
+    }
+    emit sslErrorsCAtoImport(allowedCaErrors);
+#else
+    btnAddCainCAs->setVisible( false );
+#endif // Q_OS_WIN
   }
   else
   {
+    btnAddCainCAs->setVisible( false );
     btnChainInfo->setVisible( false );
     btnChainCAs->setVisible( false );
     grpbxSslConfig->setVisible( false );
@@ -96,6 +128,82 @@ QgsAuthSslErrorsDialog::QgsAuthSslErrorsDialog( QNetworkReply *reply,
 QgsAuthSslErrorsDialog::~QgsAuthSslErrorsDialog()
 {
 }
+
+#ifdef Q_OS_WIN
+void QgsAuthSslErrorsDialog::widgetAllowAddCAsToKeystore( QList<QSslError> &errors )
+{
+  if ( errors.isEmpty() )
+  {
+    btnAddCainCAs->setEnabled( false );
+    btnAddCainCAs->setVisible( false );
+    teSslErrorsMessages->setVisible( false );
+  }
+  else
+  {
+    btnAddCainCAs->setEnabled( true );
+    btnAddCainCAs->setVisible( true );
+
+    // set message related to the error
+    teSslErrorsMessages->setVisible( true );
+    QString msg = QObject::tr("<html>"
+                              "<p align='center'><strong>Certificate Authority unrecognised</strong></p>"
+                              "<br>To import CAs into Windows keystore, click <strong>Open</strong> button below or browse:"
+                              "<br><strong>%1</strong><br>"
+                              "in a Kyestore API capable browser (no Firefox)"
+                              "<br>The <strong>Open</strong> button will open the link with the default browser"
+                              "<br><br>After loaded the web page, <strong>!!! restart QGIS !!!</strong>"
+                              "</html>").arg(QString(mUrl.toString()));
+    teSslErrorsMessages->setHtml(msg);
+
+    QTimer::singleShot(100, this, SLOT(blinkImportCAsButton()));
+  }
+}
+
+void QgsAuthSslErrorsDialog::blinkImportCAsButton()
+{
+  static bool low;
+  QString lowStyleSheet = QString("{color: %1;}").arg(QColor( 0, 0, 0 ).name());
+  QString highStyleSheet = QgsAuthGuiUtils::redTextStyleSheet();
+
+  QString styleSheet;
+  if ( low )
+    styleSheet = lowStyleSheet;
+  else
+    styleSheet = highStyleSheet;
+  btnAddCainCAs->setStyleSheet( styleSheet );
+
+  low = !low;
+  QTimer::singleShot(500, this, SLOT(blinkImportCAsButton()));
+}
+
+void QgsAuthSslErrorsDialog::on_btnAddCainCAs_clicked()
+{
+  if ( !QDesktopServices::openUrl(mUrl) )
+  {
+    QgsDebugMsg( QObject::tr("Cannot open default browser to the linK: %1").arg(QString(mUrl.toString())) );
+  }
+  else
+  {
+    // trigger CA certs rebuild whaiting a time to allow external browser web page load
+    // added two trigger just to be have cache reloaded in case browser lod
+    // web page faster. A second timer in case browser takes time start.
+    // BTW cache reload is affected by this issue: https://hub.qgis.org/issues/15687
+    // so generally speaking rebuildCache could not be useful. I leave reload because
+    // ssl CA issue can be solved later (seems an openssl problem) leaving restart unecessary
+    QTimer::singleShot(3000, QgsAuthManager::instance(), SLOT( rebuildSslCaches() ));
+    QTimer::singleShot(7000, QgsAuthManager::instance(), SLOT( rebuildSslCaches() ));
+
+    // NOTE: a reply.close()/.abort() could be necessary to garantee that new SSL handshake
+    // could accept new CA list. Btw I preferred to avoid reply manipulation in GUI leaving
+    // the responsible to who's created the request. These are the reasons:
+    // 1) avoid side effects when a different workflow is necessary when receiving sslError
+    // 2) GUI wouldn't manage sessions but only get user instruction how to manipulate the session
+
+    // close current GUI
+    reject();
+  }
+}
+#endif // Q_OS_WIN
 
 void QgsAuthSslErrorsDialog::loadUnloadCertificate( bool load )
 {

--- a/src/gui/auth/qgsauthsslerrorsdialog.cpp
+++ b/src/gui/auth/qgsauthsslerrorsdialog.cpp
@@ -91,8 +91,8 @@ QgsAuthSslErrorsDialog::QgsAuthSslErrorsDialog( QNetworkReply *reply,
 
 #ifdef Q_OS_WIN
     // in case of a specific set of errors
-    connect( this, SIGNAL( sslErrorsCAtoImport(QList<QSslError>&) ),
-             this, SLOT( widgetAllowAddCAsToKeystore(QList<QSslError>&) ) );
+    connect( this, SIGNAL( sslErrorsCAtoImport( QList<QSslError>& ) ),
+             this, SLOT( widgetAllowAddCAsToKeystore( QList<QSslError>& ) ) );
 
     btnAddCainCAs->setVisible( true );
     QList<QSslError> allowedCaErrors;
@@ -100,15 +100,15 @@ QgsAuthSslErrorsDialog::QgsAuthSslErrorsDialog( QNetworkReply *reply,
     {
       switch ( err.error() )
       {
-      case QSslError::UnableToGetLocalIssuerCertificate:
-      case QSslError::CertificateUntrusted:
-        allowedCaErrors.append(err);
-        break;
-      default:
-        break;
+        case QSslError::UnableToGetLocalIssuerCertificate:
+        case QSslError::CertificateUntrusted:
+          allowedCaErrors.append( err );
+          break;
+        default:
+          break;
       }
     }
-    emit sslErrorsCAtoImport(allowedCaErrors);
+    emit sslErrorsCAtoImport( allowedCaErrors );
 #else
     btnAddCainCAs->setVisible( false );
     teSslErrorsMessages->setVisible( false );
@@ -147,24 +147,24 @@ void QgsAuthSslErrorsDialog::widgetAllowAddCAsToKeystore( QList<QSslError> &erro
 
     // set message related to the error
     teSslErrorsMessages->setVisible( true );
-    QString msg = QObject::tr("<html>"
-                              "<p align='center'><strong>Certificate Authority unrecognised</strong></p>"
-                              "<br>To import CAs into Windows keystore, click <strong>Open</strong> button below or browse:"
-                              "<br><strong>%1</strong><br>"
-                              "in a Kyestore API capable browser (no Firefox)"
-                              "<br>The <strong>Open</strong> button will open the link with the default browser"
-                              "<br><br>After loaded the web page, <strong>!!! restart QGIS !!!</strong>"
-                              "</html>").arg(QString(mUrl.toString()));
-    teSslErrorsMessages->setHtml(msg);
+    QString msg = QObject::tr( "<html>"
+                               "<p align='center'><strong>Certificate Authority unrecognised</strong></p>"
+                               "<br>To import CAs into Windows keystore, click <strong>Open</strong> button below or browse:"
+                               "<br><strong>%1</strong><br>"
+                               "in a Kyestore API capable browser (no Firefox)"
+                               "<br>The <strong>Open</strong> button will open the link with the default browser"
+                               "<br><br>After loaded the web page, <strong>!!! restart QGIS !!!</strong>"
+                               "</html>" ).arg( QString( mUrl.toString() ) );
+    teSslErrorsMessages->setHtml( msg );
 
-    QTimer::singleShot(100, this, SLOT(blinkImportCAsButton()));
+    QTimer::singleShot( 100, this, SLOT( blinkImportCAsButton() ) );
   }
 }
 
 void QgsAuthSslErrorsDialog::blinkImportCAsButton()
 {
   static bool low;
-  QString lowStyleSheet = QString("{color: %1;}").arg(QColor( 0, 0, 0 ).name());
+  QString lowStyleSheet = QString( "{color: %1;}" ).arg( QColor( 0, 0, 0 ).name() );
   QString highStyleSheet = QgsAuthGuiUtils::redTextStyleSheet();
 
   QString styleSheet;
@@ -175,14 +175,14 @@ void QgsAuthSslErrorsDialog::blinkImportCAsButton()
   btnAddCainCAs->setStyleSheet( styleSheet );
 
   low = !low;
-  QTimer::singleShot(500, this, SLOT(blinkImportCAsButton()));
+  QTimer::singleShot( 500, this, SLOT( blinkImportCAsButton() ) );
 }
 
 void QgsAuthSslErrorsDialog::on_btnAddCainCAs_clicked()
 {
-  if ( !QDesktopServices::openUrl(mUrl) )
+  if ( !QDesktopServices::openUrl( mUrl ) )
   {
-    QgsDebugMsg( QObject::tr("Cannot open default browser to the linK: %1").arg(QString(mUrl.toString())) );
+    QgsDebugMsg( QObject::tr( "Cannot open default browser to the linK: %1" ).arg( QString( mUrl.toString() ) ) );
   }
   else
   {
@@ -192,8 +192,8 @@ void QgsAuthSslErrorsDialog::on_btnAddCainCAs_clicked()
     // BTW cache reload is affected by this issue: https://hub.qgis.org/issues/15687
     // so generally speaking rebuildCache could not be useful. I leave reload because
     // ssl CA issue can be solved later (seems an openssl problem) leaving restart unecessary
-    QTimer::singleShot(3000, QgsAuthManager::instance(), SLOT( rebuildSslCaches() ));
-    QTimer::singleShot(7000, QgsAuthManager::instance(), SLOT( rebuildSslCaches() ));
+    QTimer::singleShot( 3000, QgsAuthManager::instance(), SLOT( rebuildSslCaches() ) );
+    QTimer::singleShot( 7000, QgsAuthManager::instance(), SLOT( rebuildSslCaches() ) );
 
     // NOTE: a reply.close()/.abort() could be necessary to garantee that new SSL handshake
     // could accept new CA list. Btw I preferred to avoid reply manipulation in GUI leaving

--- a/src/gui/auth/qgsauthsslerrorsdialog.h
+++ b/src/gui/auth/qgsauthsslerrorsdialog.h
@@ -20,6 +20,7 @@
 
 #include <QDialog>
 #include <QSslError>
+#include <QUrl>
 #include "ui_qgsauthsslerrorsdialog.h"
 
 class QNetworkReply;
@@ -47,7 +48,6 @@ class GUI_EXPORT QgsAuthSslErrorsDialog : public QDialog, private Ui::QgsAuthSsl
                             const QString &hostport = QString() );
     ~QgsAuthSslErrorsDialog();
 
-
   private slots:
     void loadUnloadCertificate( bool load );
 
@@ -68,6 +68,18 @@ class GUI_EXPORT QgsAuthSslErrorsDialog : public QDialog, private Ui::QgsAuthSsl
 
     void on_grpbxSslErrors_collapsedStateChanged( bool collapsed );
 
+#ifdef Q_OS_WIN
+    void widgetAllowAddCAsToKeystore( QList<QSslError> &errors );
+    void on_btnAddCainCAs_clicked();
+    void blinkImportCAsButton();
+
+  signals:
+    /** Emitted when a set of sslErrors has bee found that need
+        to activate button to import CAs in windows keystore
+        using external browser */
+    void sslErrorsCAtoImport( QList<QSslError> &errors);
+#endif // Q_OS_WIN
+
   private:
     void populateErrorsList();
 
@@ -79,6 +91,8 @@ class GUI_EXPORT QgsAuthSslErrorsDialog : public QDialog, private Ui::QgsAuthSsl
     QList<QSslError> mSslErrors;
     QString mDigest;
     QString mHostPort;
+    QUrl mUrl;
+
 };
 
 #endif // QGSAUTHSSLERRORSDIALOG_H

--- a/src/gui/auth/qgsauthsslerrorsdialog.h
+++ b/src/gui/auth/qgsauthsslerrorsdialog.h
@@ -77,7 +77,7 @@ class GUI_EXPORT QgsAuthSslErrorsDialog : public QDialog, private Ui::QgsAuthSsl
     /** Emitted when a set of sslErrors has bee found that need
         to activate button to import CAs in windows keystore
         using external browser */
-    void sslErrorsCAtoImport( QList<QSslError> &errors);
+    void sslErrorsCAtoImport( QList<QSslError> &errors );
 #endif // Q_OS_WIN
 
   private:

--- a/src/providers/wms/qgswmscapabilities.cpp
+++ b/src/providers/wms/qgswmscapabilities.cpp
@@ -1979,6 +1979,8 @@ void QgsWmsCapabilitiesDownload::abort()
   mIsAborted = true;
   if ( mCapabilitiesReply )
   {
+    mCapabilitiesReply->close();
+    mCapabilitiesReply->abort();
     mCapabilitiesReply->deleteLater();
     mCapabilitiesReply = nullptr;
   }

--- a/src/ui/auth/qgsauthsslerrorsdialog.ui
+++ b/src/ui/auth/qgsauthsslerrorsdialog.ui
@@ -6,7 +6,7 @@
    <rect>
     <x>0</x>
     <y>0</y>
-    <width>617</width>
+    <width>645</width>
     <height>710</height>
    </rect>
   </property>
@@ -109,6 +109,13 @@
         </widget>
        </item>
        <item>
+        <widget class="QTextEdit" name="teSslErrorsMessages">
+         <property name="readOnly">
+          <bool>true</bool>
+         </property>
+        </widget>
+       </item>
+       <item>
         <layout class="QHBoxLayout" name="horizontalLayout">
          <item>
           <spacer name="horizontalSpacer">
@@ -122,6 +129,20 @@
             </size>
            </property>
           </spacer>
+         </item>
+         <item>
+          <widget class="QToolButton" name="btnAddCainCAs">
+           <property name="text">
+            <string>Open</string>
+           </property>
+           <property name="icon">
+            <iconset>
+             <normaloff>:/images/themes/default/mActionAdd.svg</normaloff>:/images/themes/default/mActionAdd.svg</iconset>
+           </property>
+           <property name="toolButtonStyle">
+            <enum>Qt::ToolButtonTextBesideIcon</enum>
+           </property>
+          </widget>
          </item>
          <item>
           <widget class="QToolButton" name="btnChainInfo">
@@ -138,7 +159,7 @@
             <string>Connection certificates</string>
            </property>
            <property name="icon">
-            <iconset resource="../../../images/images.qrc">
+            <iconset>
              <normaloff>:/images/themes/default/propertyicons/metadata.svg</normaloff>:/images/themes/default/propertyicons/metadata.svg</iconset>
            </property>
            <property name="iconSize">
@@ -167,7 +188,7 @@
             <string>Connection trusted CAs</string>
            </property>
            <property name="icon">
-            <iconset resource="../../../images/images.qrc">
+            <iconset>
              <normaloff>:/images/themes/default/propertyicons/metadata.svg</normaloff>:/images/themes/default/propertyicons/metadata.svg</iconset>
            </property>
            <property name="iconSize">
@@ -275,8 +296,6 @@
   <tabstop>btnChainCAs</tabstop>
   <tabstop>grpbxSslConfig</tabstop>
  </tabstops>
- <resources>
-  <include location="../../../images/images.qrc"/>
- </resources>
+ <resources/>
  <connections/>
 </ui>


### PR DESCRIPTION
This PR partially fix: https://hub.qgis.org/issues/15617
"Partially" because due to this issue: https://hub.qgis.org/issues/15687 that I wasn't able to solve and debug, it is not possible to "trasparently" add CAs and a qgis restart will be asked to the user.

This PR is Windows platform specific, and new button and sslError messages are showed only in Win platform.

Due to UX (button and message) modifications the PR will require a new translation round.
