### PR TITLE
[processing] Fixing issue with 'Eliminate sliver polygons' and fields of type long

### DIFF
--- a/python/plugins/processing/algs/qgis/Eliminate.py
+++ b/python/plugins/processing/algs/qgis/Eliminate.py
@@ -28,7 +28,7 @@ __revision__ = '$Format:%H$'
 import os
 
 from qgis.PyQt.QtGui import QIcon
-from qgis.PyQt.QtCore import QLocale, QDate
+from qgis.PyQt.QtCore import QLocale, QDate, QVariant
 
 from qgis.core import QgsFeatureRequest, QgsFeature, QgsGeometry
 
@@ -113,26 +113,26 @@ class Eliminate(GeoAlgorithm):
             selectType = processLayer.fields()[selectindex].type()
             selectionError = False
 
-            if selectType == 2 or selectType == 4:
+            if selectType == QVariant.Int or selectType == QVariant.LongLong:
                 try:
                     y = int(comparisonvalue)
                 except ValueError:
                     selectionError = True
                     msg = self.tr('Cannot convert "%s" to integer' % unicode(comparisonvalue))
-            elif selectType == 6:
+            elif selectType == QVariant.Double:
                 try:
                     y = float(comparisonvalue)
                 except ValueError:
                     selectionError = True
                     msg = self.tr('Cannot convert "%s" to float' % unicode(comparisonvalue))
-            elif selectType == 10:
+            elif selectType == QVariant.String:
                 # 10: string, boolean
                 try:
                     y = unicode(comparisonvalue)
                 except ValueError:
                     selectionError = True
                     msg = self.tr('Cannot convert "%s" to unicode' % unicode(comparisonvalue))
-            elif selectType == 14:
+            elif selectType == QVariant.Date:
                 # date
                 dateAndFormat = comparisonvalue.split(' ')
 
@@ -157,7 +157,7 @@ class Eliminate(GeoAlgorithm):
                     msg += self.tr('Enter the date and the date format, e.g. "07.26.2011" "MM.dd.yyyy".')
 
             if (comparison == 'begins with' or comparison == 'contains') \
-               and selectType != 10:
+               and selectType != QVariant.String:
                 selectionError = True
                 msg = self.tr('"%s" can only be used with string fields' % comparison)
 
@@ -173,14 +173,14 @@ class Eliminate(GeoAlgorithm):
                     if aValue is None:
                         continue
 
-                    if selectType == 2 or selectType == 4:
+                    if selectType == QVariant.Int or selectType == QVariant.LongLong:
                         x = int(aValue)
-                    elif selectType == 6:
+                    elif selectType == QVariant.Double:
                         x = float(aValue)
-                    elif selectType == 10:
+                    elif selectType == QVariant.String:
                         # 10: string, boolean
                         x = unicode(aValue)
-                    elif selectType == 14:
+                    elif selectType == QVariant.Date:
                         # date
                         x = aValue  # should be date
 

--- a/python/plugins/processing/algs/qgis/Eliminate.py
+++ b/python/plugins/processing/algs/qgis/Eliminate.py
@@ -113,7 +113,7 @@ class Eliminate(GeoAlgorithm):
             selectType = processLayer.fields()[selectindex].type()
             selectionError = False
 
-            if selectType == 2:
+            if selectType == 2 or selectType == 4:
                 try:
                     y = int(comparisonvalue)
                 except ValueError:
@@ -173,7 +173,7 @@ class Eliminate(GeoAlgorithm):
                     if aValue is None:
                         continue
 
-                    if selectType == 2:
+                    if selectType == 2 or selectType == 4:
                         x = int(aValue)
                     elif selectType == 6:
                         x = float(aValue)


### PR DESCRIPTION
With this PR, when the script finds a Long field, it reads its values as `int` (Python knows what to do when an integer is too long).
Fix #15727
