### PR TITLE
[symbology] prevent creation of a zero width/height line pattern image (fixes #15728)

### DIFF
--- a/src/core/symbology-ng/qgsfillsymbollayer.cpp
+++ b/src/core/symbology-ng/qgsfillsymbollayer.cpp
@@ -2654,7 +2654,8 @@ void QgsLinePatternFillSymbolLayer::applyPattern( const QgsSymbolRenderContext& 
   width += 2 * xBuffer;
   height += 2 * yBuffer;
 
-  if ( width > 10000 || height > 10000 ) //protect symbol layer from eating too much memory
+  //protect from zero width/height image and symbol layer from eating too much memory
+  if ( width > 10000 || height > 10000 || width == 0 || height == 0 )
   {
     return;
   }


### PR DESCRIPTION
This PR fixes line fill pattern symbology trying to create a QImage with 0 width and/or height, which can happen when the line distance value is represented as map units and the canvas' scale is zoomed out enough.

This fixes #15728 (http://hub.qgis.org/issues/15728).
