### PR TITLE
[composer] fix attribute table widget connect warning

### DIFF
--- a/src/app/composer/qgscomposerattributetablewidget.cpp
+++ b/src/app/composer/qgscomposerattributetablewidget.cpp
@@ -66,7 +66,7 @@ QgsComposerAttributeTableWidget::QgsComposerAttributeTableWidget( QgsComposerAtt
 
   mComposerMapComboBox->setComposition( mComposerTable->composition() );
   mComposerMapComboBox->setItemType( QgsComposerItem::ComposerMap );
-  connect( mComposerMapComboBox, SIGNAL( itemChanged( QgsComposerItem* ) ), this, SLOT( composerMapChanged( const QgsComposerItem* ) ) );
+  connect( mComposerMapComboBox, SIGNAL( itemChanged( QgsComposerItem* ) ), this, SLOT( composerMapChanged( QgsComposerItem* ) ) );
 
   mHeaderFontColorButton->setColorDialogTitle( tr( "Select header font color" ) );
   mHeaderFontColorButton->setAllowAlpha( true );
@@ -176,7 +176,7 @@ void QgsComposerAttributeTableWidget::on_mAttributesPushButton_clicked()
   }
 }
 
-void QgsComposerAttributeTableWidget::composerMapChanged( const QgsComposerItem* item )
+void QgsComposerAttributeTableWidget::composerMapChanged( QgsComposerItem* item )
 {
   if ( !mComposerTable )
   {

--- a/src/app/composer/qgscomposerattributetablewidget.h
+++ b/src/app/composer/qgscomposerattributetablewidget.h
@@ -45,7 +45,7 @@ class QgsComposerAttributeTableWidget: public QgsComposerItemBaseWidget, private
   private slots:
     void on_mRefreshPushButton_clicked();
     void on_mAttributesPushButton_clicked();
-    void composerMapChanged( const QgsComposerItem* item );
+    void composerMapChanged( QgsComposerItem* item );
     void on_mMaximumRowsSpinBox_valueChanged( int i );
     void on_mMarginSpinBox_valueChanged( double d );
     void on_mGridStrokeWidthSpinBox_valueChanged( double d );


### PR DESCRIPTION
@nyalldawson , this tiny PR takes care of the following warning thrown by Qt when loading a composer containing attribute table item(s):

```
Warning: QObject::connect: Incompatible sender/receiver arguments
        QgsComposerItemComboBox::itemChanged(QgsComposerItem*) --> QgsComposerAttributeTableWidget::composerMapChanged(const QgsComposerItem*)
```
