### PR TITLE
[processing] fix broken modeler under pyqt5/python3 (fixes #15734)

### DIFF
--- a/python/plugins/processing/gui/EditRenderingStylesDialog.py
+++ b/python/plugins/processing/gui/EditRenderingStylesDialog.py
@@ -50,7 +50,7 @@ class EditRenderingStylesDialog(BASE, WIDGET):
 
         self.alg = alg.getCopy()
 
-        self.tblStyles.horizontalHeader().setResizeMode(QHeaderView.Stretch)
+        self.tblStyles.horizontalHeader().setSectionResizeMode(QHeaderView.Stretch)
         self.setWindowTitle(self.alg.name)
 
         self.valueItems = {}

--- a/python/plugins/processing/modeler/ModelerAlgorithm.py
+++ b/python/plugins/processing/modeler/ModelerAlgorithm.py
@@ -237,7 +237,7 @@ class ModelerAlgorithm(GeoAlgorithm):
         newone.provider = self.provider
 
         newone.algs = {}
-        for algname, alg in self.algs.iteritems():
+        for algname, alg in self.algs.items():
             newone.algs[algname] = Algorithm()
             newone.algs[algname].__dict__.update(copy.deepcopy(alg.todict()))
         newone.inputs = copy.deepcopy(self.inputs)

--- a/python/plugins/processing/modeler/ModelerArrowItem.py
+++ b/python/plugins/processing/modeler/ModelerArrowItem.py
@@ -57,7 +57,7 @@ class ModelerArrowItem(QGraphicsPathItem):
 
     def __init__(self, startItem, startIndex, endItem, endIndex,
                  parent=None, scene=None):
-        super(ModelerArrowItem, self).__init__(parent, scene)
+        super(ModelerArrowItem, self).__init__(parent)
         self.arrowHead = QPolygonF()
         self.endIndex = endIndex
         self.startIndex = startIndex

--- a/python/plugins/processing/modeler/ModelerGraphicItem.py
+++ b/python/plugins/processing/modeler/ModelerGraphicItem.py
@@ -43,7 +43,7 @@ class ModelerGraphicItem(QGraphicsItem):
     BOX_WIDTH = 200
 
     def __init__(self, element, model):
-        super(ModelerGraphicItem, self).__init__(None, None)
+        super(ModelerGraphicItem, self).__init__(None)
         self.model = model
         self.element = element
         if isinstance(element, ModelerParameter):
@@ -337,7 +337,7 @@ class FlatButtonGraphicItem(QGraphicsItem):
     HEIGHT = 16
 
     def __init__(self, icon, position, action):
-        super(FlatButtonGraphicItem, self).__init__(None, None)
+        super(FlatButtonGraphicItem, self).__init__(None)
         self.setAcceptHoverEvents(True)
         self.setFlag(QGraphicsItem.ItemIsMovable, False)
         self.pixmap = icon.pixmap(self.WIDTH, self.HEIGHT,


### PR DESCRIPTION
This PR resurrects processing's graphical modeler, currently broken when running under pyqt5 & python3.

@volaya , @alexbruy , this fixes http://hub.qgis.org/issues/15734 .
