### PR TITLE
Fix import of shapefiles to postgres - regression introduced in 5abdfcb

### DIFF
--- a/src/providers/postgres/qgspostgresprovider.cpp
+++ b/src/providers/postgres/qgspostgresprovider.cpp
@@ -3546,6 +3546,9 @@ QgsVectorLayerImport::ImportError QgsPostgresProvider::createEmptyLayer(
         fldIdx = -1; // it is incremented in the for loop, i.e. restarts at 0
       }
     }
+
+    pkList = QStringList( primaryKey );
+    pkType = QStringList( "serial" );
   }
   else
   {

--- a/tests/src/python/test_provider_postgres.py
+++ b/tests/src/python/test_provider_postgres.py
@@ -374,7 +374,7 @@ class TestPyQgsPostgresProvider(unittest.TestCase, ProviderTestCase):
                 self.assertEquals(oflds.size(), flds.size() + 1)
                 self.assertEquals(oflds[0].name(), kfnames[0])
                 for i in range(flds.size()):
-                    self.assertEqual(oflds[i+1].name(), flds[i].name())
+                    self.assertEqual(oflds[i + 1].name(), flds[i].name())
             else:
                 # pkey was given, no extra field generated
                 self.assertEquals(oflds.size(), flds.size())


### PR DESCRIPTION
This is to fix master_2 - import with browser dock fails completely if no primary keys are explicitly specified
