### PR TITLE
[processing] fix modeleter mouse wheel zoom under qt5

### DIFF
--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -111,7 +111,7 @@ class ModelerDialog(BASE, WIDGET):
         def _wheelEvent(event):
             self.view.setTransformationAnchor(QGraphicsView.AnchorUnderMouse)
             factor = 1.05
-            if event.delta() > 0:
+            if event.angleDelta().y() > 0:
                 factor = 1 / factor
             self.view.scale(factor, factor)
             self.repaintModel()


### PR DESCRIPTION
@volaya , @alexbruy , Qt5 removed the QMouseWheel delta() function, which broke processing modeler's mouse wheel zoom in/out. 
