### PR TITLE
[FEATURE] Vector layer save as: offer file/layer overwriting, new layer creation, feature and field appending

### DIFF
--- a/python/core/qgsvectorfilewriter.sip
+++ b/python/core/qgsvectorfilewriter.sip
@@ -132,6 +132,43 @@ class QgsVectorFileWriter
         virtual QVariant convert( int fieldIdxInLayer, const QVariant& value );
     };
 
+    /** Edition capability flags
+      * @note Added in QGIS 3.0 */
+    enum EditionCapability
+    {
+        /** Flag to indicate that a new layer can be added to the dataset */
+        CanAddNewLayer,
+
+        /** Flag to indicate that new features can be added to an existing layer */
+        CanAppendToExistingLayer ,
+
+        /** Flag to indicate that new fields can be added to an existing layer. Imply CanAppendToExistingLayer */
+        CanAddNewFieldsToExistingLayer,
+
+        /** Flag to indicate that an existing layer can be deleted */
+        CanDeleteLayer
+    };
+
+    typedef QFlags<QgsVectorFileWriter::EditionCapability> EditionCapabilities;
+
+    /** Enumeration to describe how to handle existing files
+        @note Added in QGIS 3.0
+     */
+    enum ActionOnExistingFile
+    {
+        /** Create or overwrite file */
+        CreateOrOverwriteFile,
+
+        /** Create or overwrite layer */
+        CreateOrOverwriteLayer,
+
+        /** Append features to existing layer, but do not create new fields */
+        AppendToLayerNoNewFields,
+
+        /** Append features to existing layer, and create new fields if needed */
+        AppendToLayerAddFields
+    };
+
     /** Write contents of vector layer to an (OGR supported) vector formt
      * @param layer layer to write
      * @param fileName file name to write to
@@ -219,6 +256,88 @@ class QgsVectorFileWriter
                                             FieldValueConverter* fieldValueConverter = nullptr
                                           );
 
+
+    /**
+     * Options to pass to writeAsVectorFormat()
+     * @note Added in QGIS 3.0
+     */
+    class SaveVectorOptions
+    {
+      public:
+        /** Constructor */
+        SaveVectorOptions();
+
+        /** Destructor */
+        virtual ~SaveVectorOptions();
+
+        /** OGR driver to use */
+        QString driverName;
+
+        /** Layer name. If let empty, it will be derived from the filename */
+        QString layerName;
+
+        /** Action on existing file  */
+        QgsVectorFileWriter::ActionOnExistingFile actionOnExistingFile;
+
+        /** Encoding to use */
+        QString fileEncoding;
+
+        /** Transform to reproject exported geometries with, or invalid transform
+         * for no transformation */
+        const QgsCoordinateTransform* ct;
+
+        /** Write only selected features of layer */
+        bool onlySelectedFeatures;
+
+        /** List of OGR data source creation options */
+        QStringList datasourceOptions;
+
+        /** List of OGR layer creation options */
+        QStringList layerOptions;
+
+        /** Only write geometries */
+        bool skipAttributeCreation;
+
+        /** Attributes to export (empty means all unless skipAttributeCreation is set) */
+        QgsAttributeList attributes;
+
+        /** Symbology to export */
+        QgsVectorFileWriter::SymbologyExport symbologyExport;
+
+        /** Scale of symbology */
+        double symbologyScale;
+
+        /** If not empty, only features intersecting the extent will be saved */
+        QgsRectangle filterExtent;
+
+        /** Set to a valid geometry type to override the default geometry type for the layer. This parameter
+         * allows for conversion of geometryless tables to null geometries, etc */
+        QgsWKBTypes::Type overrideGeometryType;
+
+        /** Set to true to force creation of multi* geometries */
+        bool forceMulti;
+
+        /** Set to true to include z dimension in output. This option is only valid if overrideGeometryType is set */
+        bool includeZ;
+
+        /** Field value converter */
+        QgsVectorFileWriter::FieldValueConverter* fieldValueConverter;
+    };
+
+    /** Writes a layer out to a vector file.
+     * @param layer source layer to write
+     * @param fileName file name to write to
+     * @param options options.
+     * @param newFilename QString pointer which will contain the new file name created (in case it is different to fileName).
+     * @param errorMessage pointer to buffer fo error message
+     * @note added in 3.0
+     */
+    static WriterError writeAsVectorFormat( QgsVectorLayer* layer,
+                                            const QString& fileName,
+                                            const SaveVectorOptions& options,
+                                            QString *newFilename = nullptr,
+                                            QString *errorMessage = nullptr );
+
     /** Create a new vector file writer */
     QgsVectorFileWriter( const QString& vectorFileName,
                          const QString& fileEncoding,
@@ -292,6 +411,28 @@ class QgsVectorFileWriter
 
     static bool driverMetadata( const QString& driverName, MetaData& driverMetadata );
 
+    /**
+     * Return edition capabilites for an existing dataset name.
+     * @note added in QGIS 3.0
+     */
+    static EditionCapabilities editionCapabilities( const QString& datasetName );
+
+    /**
+     * Returns whether the target layer already exists.
+     * @note added in QGIS 3.0
+     */
+    static bool targetLayerExists( const QString& datasetName,
+                                   const QString& layerName );
+
+    /**
+     * Returns whether there are among the attributes specified some that do not exist yet in the layer
+     * @note added in QGIS 3.0
+     */
+    static bool areThereNewFieldsToCreate( const QString& datasetName,
+                                           const QString& layerName,
+                                           QgsVectorLayer* layer,
+                                           const QgsAttributeList& attributes );
+
   protected:
     //! @note not available in python bindings
     // OGRGeometryH createEmptyGeometry( QGis::WkbType wkbType );
@@ -300,3 +441,5 @@ class QgsVectorFileWriter
 
     QgsVectorFileWriter( const QgsVectorFileWriter& rh );
 };
+
+QFlags<QgsVectorFileWriter::EditionCapability> operator|(QgsVectorFileWriter::EditionCapability f1, QFlags<QgsVectorFileWriter::EditionCapability> f2);

--- a/src/app/ogr/qgsvectorlayersaveasdialog.h
+++ b/src/app/ogr/qgsvectorlayersaveasdialog.h
@@ -45,6 +45,7 @@ class APP_EXPORT QgsVectorLayerSaveAsDialog : public QDialog, private Ui::QgsVec
     QString format() const;
     QString encoding() const;
     QString filename() const;
+    QString layername() const;
     QStringList datasourceOptions() const;
     QStringList layerOptions() const;
     long crs() const;
@@ -99,6 +100,9 @@ class APP_EXPORT QgsVectorLayerSaveAsDialog : public QDialog, private Ui::QgsVec
      */
     void setIncludeZ( bool checked );
 
+    /** Returns creation action */
+    QgsVectorFileWriter::ActionOnExistingFile creationActionOnExistingFile() const;
+
   private slots:
 
     void on_mFormatComboBox_currentIndexChanged( int idx );
@@ -125,6 +129,7 @@ class APP_EXPORT QgsVectorLayerSaveAsDialog : public QDialog, private Ui::QgsVec
     QgsVectorLayer *mLayer;
     bool mAttributeTableItemChangedSlotEnabled;
     bool mReplaceRawFieldValuesStateChangedSlotEnabled;
+    QgsVectorFileWriter::ActionOnExistingFile mActionOnExistingFile;
 };
 
 #endif // QGSVECTORLAYERSAVEASDIALOG_H

--- a/src/core/qgsvectorfilewriter.cpp
+++ b/src/core/qgsvectorfilewriter.cpp
@@ -95,7 +95,8 @@ QgsVectorFileWriter::QgsVectorFileWriter(
     , mFieldValueConverter( nullptr )
 {
   init( theVectorFileName, theFileEncoding, fields, QGis::fromOldWkbType( geometryType ),
-        srs, driverName, datasourceOptions, layerOptions, newFilename, nullptr );
+        srs, driverName, datasourceOptions, layerOptions, newFilename, nullptr,
+        QString(), CreateOrOverwriteFile );
 }
 
 QgsVectorFileWriter::QgsVectorFileWriter( const QString& vectorFileName, const QString& fileEncoding, const QgsFields& fields, QgsWKBTypes::Type geometryType, const QgsCoordinateReferenceSystem* srs, const QString& driverName, const QStringList& datasourceOptions, const QStringList& layerOptions, QString* newFilename, QgsVectorFileWriter::SymbologyExport symbologyExport )
@@ -111,7 +112,8 @@ QgsVectorFileWriter::QgsVectorFileWriter( const QString& vectorFileName, const Q
     , mFieldValueConverter( nullptr )
 {
   init( vectorFileName, fileEncoding, fields, geometryType, srs, driverName,
-        datasourceOptions, layerOptions, newFilename, nullptr );
+        datasourceOptions, layerOptions, newFilename, nullptr,
+        QString(), CreateOrOverwriteFile );
 }
 
 QgsVectorFileWriter::QgsVectorFileWriter( const QString& vectorFileName,
@@ -124,7 +126,9 @@ QgsVectorFileWriter::QgsVectorFileWriter( const QString& vectorFileName,
     const QStringList& layerOptions,
     QString* newFilename,
     QgsVectorFileWriter::SymbologyExport symbologyExport,
-    FieldValueConverter* fieldValueConverter )
+    FieldValueConverter* fieldValueConverter,
+    const QString& layerName,
+    ActionOnExistingFile action )
     : mDS( nullptr )
     , mLayer( nullptr )
     , mOgrRef( nullptr )
@@ -137,7 +141,8 @@ QgsVectorFileWriter::QgsVectorFileWriter( const QString& vectorFileName,
     , mFieldValueConverter( nullptr )
 {
   init( vectorFileName, fileEncoding, fields, geometryType, srs, driverName,
-        datasourceOptions, layerOptions, newFilename, fieldValueConverter );
+        datasourceOptions, layerOptions, newFilename, fieldValueConverter,
+        layerName, action );
 }
 
 void QgsVectorFileWriter::init( QString vectorFileName,
@@ -149,7 +154,9 @@ void QgsVectorFileWriter::init( QString vectorFileName,
                                 QStringList datasourceOptions,
                                 QStringList layerOptions,
                                 QString* newFilename,
-                                FieldValueConverter* fieldValueConverter )
+                                FieldValueConverter* fieldValueConverter,
+                                const QString& layerNameIn,
+                                ActionOnExistingFile action )
 {
   mRenderContext.setRendererScale( mSymbologyScaleDenominator );
 
@@ -237,7 +244,8 @@ void QgsVectorFileWriter::init( QString vectorFileName,
     }
 #endif
 
-    deleteShapeFile( vectorFileName );
+    if ( action == CreateOrOverwriteFile || action == CreateOrOverwriteLayer )
+      deleteShapeFile( vectorFileName );
   }
   else
   {
@@ -260,7 +268,27 @@ void QgsVectorFileWriter::init( QString vectorFileName,
       }
     }
 
-    QFile::remove( vectorFileName );
+    if ( action == CreateOrOverwriteFile )
+    {
+      if ( vectorFileName.endsWith( ".gdb", Qt::CaseInsensitive ) )
+      {
+        QDir dir( vectorFileName );
+        if ( dir.exists() )
+        {
+          QFileInfoList fileList = dir.entryInfoList(
+                                     QDir::NoDotAndDotDot | QDir::System | QDir::Hidden  | QDir::AllDirs | QDir::Files, QDir::DirsFirst );
+          Q_FOREACH ( QFileInfo info, fileList )
+          {
+            QFile::remove( info.absoluteFilePath() );
+          }
+        }
+        QDir().rmdir( vectorFileName );
+      }
+      else
+      {
+        QFile::remove( vectorFileName );
+      }
+    }
   }
 
   if ( metadataFound && !metadata.compulsoryEncoding.isEmpty() )
@@ -285,7 +313,10 @@ void QgsVectorFileWriter::init( QString vectorFileName,
   }
 
   // create the data source
-  mDS = OGR_Dr_CreateDataSource( poDriver, TO8F( vectorFileName ), options );
+  if ( action == CreateOrOverwriteFile )
+    mDS = OGR_Dr_CreateDataSource( poDriver, TO8F( vectorFileName ), options );
+  else
+    mDS = OGROpen( TO8F( vectorFileName ), TRUE, nullptr );
 
   if ( options )
   {
@@ -298,12 +329,47 @@ void QgsVectorFileWriter::init( QString vectorFileName,
   if ( !mDS )
   {
     mError = ErrCreateDataSource;
-    mErrorMessage = QObject::tr( "creation of data source failed (OGR error:%1)" )
-                    .arg( QString::fromUtf8( CPLGetLastErrorMsg() ) );
+    if ( action == CreateOrOverwriteFile )
+      mErrorMessage = QObject::tr( "creation of data source failed (OGR error:%1)" )
+                      .arg( QString::fromUtf8( CPLGetLastErrorMsg() ) );
+    else
+      mErrorMessage = QObject::tr( "opening of data source in update mode failed (OGR error:%1)" )
+                      .arg( QString::fromUtf8( CPLGetLastErrorMsg() ) );
     return;
   }
 
-  QgsDebugMsg( "Created data source" );
+  QString layerName( layerNameIn );
+  if ( layerName.isEmpty() )
+    layerName = QFileInfo( vectorFileName ).baseName();
+
+  if ( action == CreateOrOverwriteLayer )
+  {
+    const int layer_count = OGR_DS_GetLayerCount( mDS );
+    for ( int i = 0; i < layer_count; i++ )
+    {
+      OGRLayerH hLayer = OGR_DS_GetLayer( mDS, i );
+      if ( EQUAL( OGR_L_GetName( hLayer ), TO8F( layerName ) ) )
+      {
+        if ( OGR_DS_DeleteLayer( mDS, i ) != OGRERR_NONE )
+        {
+          mError = ErrCreateLayer;
+          mErrorMessage = QObject::tr( "overwriting of existing layer failed (OGR error:%1)" )
+                          .arg( QString::fromUtf8( CPLGetLastErrorMsg() ) );
+          return;
+        }
+        break;
+      }
+    }
+  }
+
+  if ( action == CreateOrOverwriteFile )
+  {
+    QgsDebugMsg( "Created data source" );
+  }
+  else
+  {
+    QgsDebugMsg( "Opened data source in update mode" );
+  }
 
   // use appropriate codec
   mCodec = QTextCodec::codecForName( fileEncoding.toLocal8Bit().constData() );
@@ -331,7 +397,6 @@ void QgsVectorFileWriter::init( QString vectorFileName,
   }
 
   // datasource created, now create the output layer
-  QString layerName = QFileInfo( vectorFileName ).baseName();
   OGRwkbGeometryType wkbType = ogrTypeFromWkbType( geometryType );
 
   // Remove FEATURE_DATASET layer option (used for ESRI File GDB driver) if its value is not set
@@ -354,7 +419,10 @@ void QgsVectorFileWriter::init( QString vectorFileName,
   // disable encoding conversion of OGR Shapefile layer
   CPLSetConfigOption( "SHAPE_ENCODING", "" );
 
-  mLayer = OGR_DS_CreateLayer( mDS, TO8F( layerName ), mOgrRef, wkbType, options );
+  if ( action == CreateOrOverwriteFile || action == CreateOrOverwriteLayer )
+    mLayer = OGR_DS_CreateLayer( mDS, TO8F( layerName ), mOgrRef, wkbType, options );
+  else
+    mLayer = OGR_DS_GetLayerByName( mDS, TO8F( layerName ) );
 
   if ( options )
   {
@@ -391,8 +459,12 @@ void QgsVectorFileWriter::init( QString vectorFileName,
 
   if ( !mLayer )
   {
-    mErrorMessage = QObject::tr( "creation of layer failed (OGR error:%1)" )
-                    .arg( QString::fromUtf8( CPLGetLastErrorMsg() ) );
+    if ( action == CreateOrOverwriteFile || action == CreateOrOverwriteLayer )
+      mErrorMessage = QObject::tr( "creation of layer failed (OGR error:%1)" )
+                      .arg( QString::fromUtf8( CPLGetLastErrorMsg() ) );
+    else
+      mErrorMessage = QObject::tr( "opening of layer failed (OGR error:%1)" )
+                      .arg( QString::fromUtf8( CPLGetLastErrorMsg() ) );
     mError = ErrCreateLayer;
     return;
   }
@@ -410,17 +482,30 @@ void QgsVectorFileWriter::init( QString vectorFileName,
 
   mFieldValueConverter = fieldValueConverter;
 
-  for ( int fldIdx = 0; fldIdx < fields.count(); ++fldIdx )
+  for ( int fldIdx = 0; ( action == CreateOrOverwriteFile ||
+                          action == CreateOrOverwriteLayer ||
+                          action == AppendToLayerAddFields ) &&
+        fldIdx < fields.count(); ++fldIdx )
   {
     QgsField attrField = fields[fldIdx];
-
-    OGRFieldType ogrType = OFTString; //default to string
 
     if ( fieldValueConverter )
     {
       attrField = fieldValueConverter->fieldDefinition( fields[fldIdx] );
     }
 
+    QString name( attrField.name() );
+    if ( action == AppendToLayerAddFields )
+    {
+      int ogrIdx = OGR_FD_GetFieldIndex( defn, mCodec->fromUnicode( name ) );
+      if ( ogrIdx >= 0 )
+      {
+        mAttrIdxToOgrIdx.insert( fldIdx, ogrIdx );
+        continue;
+      }
+    }
+
+    OGRFieldType ogrType = OFTString; //default to string
     int ogrWidth = attrField.length();
     int ogrPrecision = attrField.precision();
     if ( ogrPrecision > 0 )
@@ -498,8 +583,6 @@ void QgsVectorFileWriter::init( QString vectorFileName,
         mError = ErrAttributeTypeUnsupported;
         return;
     }
-
-    QString name( attrField.name() );
 
     if ( mOgrDriverName == "SQLite" && name.compare( "ogc_fid", Qt::CaseInsensitive ) == 0 )
     {
@@ -592,6 +675,18 @@ void QgsVectorFileWriter::init( QString vectorFileName,
 
     existingIdxs.insert( ogrIdx );
     mAttrIdxToOgrIdx.insert( fldIdx, ogrIdx );
+  }
+
+  if ( action == AppendToLayerNoNewFields )
+  {
+    for ( int fldIdx = 0; fldIdx < fields.count(); ++fldIdx )
+    {
+      QgsField attrField = fields.at( fldIdx );
+      QString name( attrField.name() );
+      int ogrIdx = OGR_FD_GetFieldIndex( defn, mCodec->fromUnicode( name ) );
+      if ( ogrIdx >= 0 )
+        mAttrIdxToOgrIdx.insert( fldIdx, ogrIdx );
+    }
   }
 
   QgsDebugMsg( "Done creating fields" );
@@ -2067,7 +2162,8 @@ void QgsVectorFileWriter::resetMap( const QgsAttributeList &attributes )
   mAttrIdxToOgrIdx.clear();
   for ( int i = 0; i < attributes.size(); i++ )
   {
-    mAttrIdxToOgrIdx.insert( attributes[i], omap[i] );
+    if ( omap.find( i ) != omap.end() )
+      mAttrIdxToOgrIdx.insert( attributes[i], omap[i] );
   }
 }
 
@@ -2158,6 +2254,57 @@ QgsVectorFileWriter::WriterError QgsVectorFileWriter::writeAsVectorFormat( QgsVe
     QgsAttributeList attributes,
     FieldValueConverter* fieldValueConverter )
 {
+  SaveVectorOptions options;
+  options.fileEncoding = fileEncoding;
+  options.ct = ct;
+  options.driverName = driverName;
+  options.onlySelectedFeatures = onlySelected;
+  options.datasourceOptions = datasourceOptions;
+  options.layerOptions = layerOptions;
+  options.skipAttributeCreation = skipAttributeCreation;
+  options.symbologyExport = symbologyExport;
+  options.symbologyScale = symbologyScale;
+  if ( filterExtent )
+    options.filterExtent = *filterExtent;
+  options.overrideGeometryType = overrideGeometryType;
+  options.forceMulti = forceMulti;
+  options.includeZ = includeZ;
+  options.attributes = attributes;
+  options.fieldValueConverter = fieldValueConverter;
+  return writeAsVectorFormat( layer, fileName, options, newFilename, errorMessage );
+}
+
+QgsVectorFileWriter::SaveVectorOptions::SaveVectorOptions()
+    : driverName( "ESRI Shapefile" )
+    , layerName( QString() )
+    , actionOnExistingFile( CreateOrOverwriteFile )
+    , fileEncoding( QString() )
+    , ct( nullptr )
+    , onlySelectedFeatures( false )
+    , datasourceOptions( QStringList() )
+    , layerOptions( QStringList() )
+    , skipAttributeCreation( false )
+    , attributes( QgsAttributeList() )
+    , symbologyExport( NoSymbology )
+    , symbologyScale( 1.0 )
+    , filterExtent( QgsRectangle() )
+    , overrideGeometryType( QgsWKBTypes::Unknown )
+    , forceMulti( false )
+    , fieldValueConverter( nullptr )
+{
+}
+
+QgsVectorFileWriter::SaveVectorOptions::~SaveVectorOptions()
+{
+}
+
+QgsVectorFileWriter::WriterError
+QgsVectorFileWriter::writeAsVectorFormat( QgsVectorLayer* layer,
+    const QString& fileName,
+    const SaveVectorOptions& options,
+    QString *newFilename,
+    QString *errorMessage )
+{
   if ( !layer )
   {
     return ErrInvalidLayer;
@@ -2165,10 +2312,10 @@ QgsVectorFileWriter::WriterError QgsVectorFileWriter::writeAsVectorFormat( QgsVe
 
   bool shallTransform = false;
   const QgsCoordinateReferenceSystem* outputCRS = nullptr;
-  if ( ct )
+  if ( options.ct )
   {
     // This means we should transform
-    outputCRS = &( ct->destCRS() );
+    outputCRS = &( options.ct->destCRS() );
     shallTransform = true;
   }
   else
@@ -2178,18 +2325,19 @@ QgsVectorFileWriter::WriterError QgsVectorFileWriter::writeAsVectorFormat( QgsVe
   }
 
   QgsWKBTypes::Type destWkbType = QGis::fromOldWkbType( layer->wkbType() );
-  if ( overrideGeometryType != QgsWKBTypes::Unknown )
+  if ( options.overrideGeometryType != QgsWKBTypes::Unknown )
   {
-    destWkbType = QgsWKBTypes::flatType( overrideGeometryType );
-    if ( QgsWKBTypes::hasZ( overrideGeometryType ) || includeZ )
+    destWkbType = QgsWKBTypes::flatType( options.overrideGeometryType );
+    if ( QgsWKBTypes::hasZ( options.overrideGeometryType ) || options.includeZ )
       destWkbType = QgsWKBTypes::addZ( destWkbType );
   }
-  if ( forceMulti )
+  if ( options.forceMulti )
   {
     destWkbType = QgsWKBTypes::multiType( destWkbType );
   }
 
-  if ( skipAttributeCreation )
+  QgsAttributeList attributes( options.attributes );
+  if ( options.skipAttributeCreation )
     attributes.clear();
   else if ( attributes.isEmpty() )
   {
@@ -2227,7 +2375,7 @@ QgsVectorFileWriter::WriterError QgsVectorFileWriter::writeAsVectorFormat( QgsVe
     if ( layer->storageType() == "ESRI Shapefile" && !QgsWKBTypes::isMultiType( destWkbType ) )
     {
       QgsFeatureRequest req;
-      if ( onlySelected )
+      if ( options.onlySelectedFeatures )
       {
         req.setFilterFids( layer->selectedFeaturesIds() );
       }
@@ -2261,11 +2409,17 @@ QgsVectorFileWriter::WriterError QgsVectorFileWriter::writeAsVectorFormat( QgsVe
   }
 
   QgsVectorFileWriter* writer =
-    new QgsVectorFileWriter( fileName, fileEncoding, fields, destWkbType,
-                             outputCRS, driverName, datasourceOptions, layerOptions,
-                             newFilename, symbologyExport,
-                             fieldValueConverter );
-  writer->setSymbologyScaleDenominator( symbologyScale );
+    new QgsVectorFileWriter( fileName,
+                             options.fileEncoding, fields, destWkbType,
+                             outputCRS, options.driverName,
+                             options.datasourceOptions,
+                             options.layerOptions,
+                             newFilename,
+                             options.symbologyExport,
+                             options.fieldValueConverter,
+                             options.layerName,
+                             options.actionOnExistingFile );
+  writer->setSymbologyScaleDenominator( options.symbologyScale );
 
   if ( newFilename )
   {
@@ -2298,7 +2452,7 @@ QgsVectorFileWriter::WriterError QgsVectorFileWriter::writeAsVectorFormat( QgsVe
     req.setFlags( QgsFeatureRequest::NoGeometry );
   }
   req.setSubsetOfAttributes( attributes );
-  if ( onlySelected )
+  if ( options.onlySelectedFeatures )
     req.setFilterFids( layer->selectedFeaturesIds() );
   QgsFeatureIterator fit = layer->getFeatures( req );
 
@@ -2314,7 +2468,7 @@ QgsVectorFileWriter::WriterError QgsVectorFileWriter::writeAsVectorFormat( QgsVe
     if ( r->capabilities() & QgsFeatureRendererV2::SymbolLevels
          && r->usingSymbolLevels() )
     {
-      QgsVectorFileWriter::WriterError error = writer->exportFeaturesSymbolLevels( layer, fit, ct, errorMessage );
+      QgsVectorFileWriter::WriterError error = writer->exportFeaturesSymbolLevels( layer, fit, options.ct, errorMessage );
       delete writer;
       return ( error == NoError ) ? NoError : ErrFeatureWriteFailed;
     }
@@ -2324,9 +2478,9 @@ QgsVectorFileWriter::WriterError QgsVectorFileWriter::writeAsVectorFormat( QgsVe
 
   //unit type
   QGis::UnitType mapUnits = layer->crs().mapUnits();
-  if ( ct )
+  if ( options.ct )
   {
-    mapUnits = ct->destCRS().mapUnits();
+    mapUnits = options.ct->destCRS().mapUnits();
   }
 
   writer->startRender( layer );
@@ -2353,7 +2507,7 @@ QgsVectorFileWriter::WriterError QgsVectorFileWriter::writeAsVectorFormat( QgsVe
       {
         if ( fet.geometry() )
         {
-          fet.geometry()->transform( *ct );
+          fet.geometry()->transform( *( options.ct ) );
         }
       }
       catch ( QgsCsException &e )
@@ -2370,10 +2524,10 @@ QgsVectorFileWriter::WriterError QgsVectorFileWriter::writeAsVectorFormat( QgsVe
       }
     }
 
-    if ( fet.constGeometry() && filterExtent && !fet.constGeometry()->intersects( *filterExtent ) )
+    if ( fet.constGeometry() && !options.filterExtent.isNull() && !fet.constGeometry()->intersects( options.filterExtent ) )
       continue;
 
-    if ( attributes.size() < 1 && skipAttributeCreation )
+    if ( attributes.size() < 1 && options.skipAttributeCreation )
     {
       fet.initAttributes( 0 );
     }
@@ -2865,4 +3019,92 @@ void QgsVectorFileWriter::addRendererAttributes( QgsVectorLayer* vl, QgsAttribut
       }
     }
   }
+}
+
+QgsVectorFileWriter::EditionCapabilities QgsVectorFileWriter::editionCapabilities( const QString& datasetName )
+{
+  OGRSFDriverH hDriver = nullptr;
+  OGRDataSourceH hDS = OGROpen( TO8F( datasetName ), TRUE, &hDriver );
+  if ( !hDS )
+    return 0;
+  QString drvName = OGR_Dr_GetName( hDriver );
+  QgsVectorFileWriter::EditionCapabilities caps = 0;
+  if ( OGR_DS_TestCapability( hDS, ODsCCreateLayer ) )
+  {
+    // Shapefile driver returns True for a "foo.shp" dataset name,
+    // creating "bar.shp" new layer, but this would be a bit confusing
+    // for the user, so pretent that it does not support that
+    if ( !( drvName == "ESRI Shapefile" && QFile::exists( datasetName ) ) )
+      caps |= CanAddNewLayer;
+  }
+  if ( OGR_DS_TestCapability( hDS, ODsCDeleteLayer ) )
+  {
+    caps |= CanDeleteLayer;
+  }
+  int layer_count = OGR_DS_GetLayerCount( hDS );
+  if ( layer_count )
+  {
+    OGRLayerH hLayer = OGR_DS_GetLayer( hDS, 0 );
+    if ( hLayer )
+    {
+      if ( OGR_L_TestCapability( hLayer, OLCSequentialWrite ) )
+      {
+        caps |= CanAppendToExistingLayer;
+        if ( OGR_L_TestCapability( hLayer, OLCCreateField ) )
+        {
+          caps |= CanAddNewFieldsToExistingLayer;
+        }
+      }
+    }
+  }
+  OGR_DS_Destroy( hDS );
+  return caps;
+}
+
+bool QgsVectorFileWriter::targetLayerExists( const QString& datasetName,
+    const QString& layerNameIn )
+{
+  OGRSFDriverH hDriver = nullptr;
+  OGRDataSourceH hDS = OGROpen( TO8F( datasetName ), TRUE, &hDriver );
+  if ( !hDS )
+    return false;
+
+  QString layerName( layerNameIn );
+  if ( layerName.isEmpty() )
+    layerName = QFileInfo( datasetName ).baseName();
+
+  bool ret = OGR_DS_GetLayerByName( hDS, TO8F( layerName ) );
+  OGR_DS_Destroy( hDS );
+  return ret;
+}
+
+
+bool QgsVectorFileWriter::areThereNewFieldsToCreate( const QString& datasetName,
+    const QString& layerName,
+    QgsVectorLayer* layer,
+    const QgsAttributeList& attributes )
+{
+  OGRSFDriverH hDriver = nullptr;
+  OGRDataSourceH hDS = OGROpen( TO8F( datasetName ), TRUE, &hDriver );
+  if ( !hDS )
+    return false;
+  OGRLayerH hLayer = OGR_DS_GetLayerByName( hDS, TO8F( layerName ) );
+  if ( !hLayer )
+  {
+    OGR_DS_Destroy( hDS );
+    return false;
+  }
+  bool ret = false;
+  OGRFeatureDefnH defn = OGR_L_GetLayerDefn( hLayer );
+  Q_FOREACH ( int idx, attributes )
+  {
+    QgsField fld = layer->fields().at( idx );
+    if ( OGR_FD_GetFieldIndex( defn, TO8F( fld.name() ) ) < 0 )
+    {
+      ret = true;
+      break;
+    }
+  }
+  OGR_DS_Destroy( hDS );
+  return ret;
 }

--- a/src/ui/qgsvectorlayersaveasdialogbase.ui
+++ b/src/ui/qgsvectorlayersaveasdialogbase.ui
@@ -23,21 +23,21 @@
    <item>
     <widget class="QWidget" name="widget" native="true">
      <layout class="QGridLayout" name="gridLayout_4">
-      <item row="2" column="0">
+      <item row="3" column="0">
        <widget class="QLabel" name="label_3">
         <property name="text">
          <string>CRS</string>
         </property>
        </widget>
       </item>
-      <item row="1" column="1">
+      <item row="1" column="2">
        <widget class="QLineEdit" name="leFilename">
         <property name="enabled">
          <bool>false</bool>
         </property>
        </widget>
       </item>
-      <item row="1" column="2">
+      <item row="1" column="3">
        <widget class="QPushButton" name="browseFilename">
         <property name="enabled">
          <bool>false</bool>
@@ -57,23 +57,40 @@
         </property>
        </widget>
       </item>
-      <item row="0" column="1" colspan="2">
+      <item row="0" column="2" colspan="2">
        <widget class="QComboBox" name="mFormatComboBox"/>
       </item>
       <item row="1" column="0">
        <widget class="QLabel" name="label">
         <property name="text">
-         <string>Save as</string>
+         <string>File name</string>
         </property>
         <property name="buddy">
          <cstring>leFilename</cstring>
         </property>
        </widget>
       </item>
-      <item row="2" column="1" colspan="2">
+      <item row="3" column="2" colspan="2">
        <widget class="QgsProjectionSelectionWidget" name="mCrsSelector" native="true">
         <property name="focusPolicy">
          <enum>Qt::StrongFocus</enum>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="0">
+       <widget class="QLabel" name="label_7">
+        <property name="text">
+         <string>Layer name</string>
+        </property>
+        <property name="buddy">
+         <cstring>leFilename</cstring>
+        </property>
+       </widget>
+      </item>
+      <item row="2" column="2" colspan="2">
+       <widget class="QLineEdit" name="leLayername">
+        <property name="enabled">
+         <bool>false</bool>
         </property>
        </widget>
       </item>
@@ -90,8 +107,8 @@
        <rect>
         <x>0</x>
         <y>0</y>
-        <width>550</width>
-        <height>953</height>
+        <width>557</width>
+        <height>922</height>
        </rect>
       </property>
       <layout class="QVBoxLayout" name="verticalLayout">
@@ -434,6 +451,7 @@
   <tabstop>mFormatComboBox</tabstop>
   <tabstop>leFilename</tabstop>
   <tabstop>browseFilename</tabstop>
+  <tabstop>leLayername</tabstop>
   <tabstop>mCrsSelector</tabstop>
   <tabstop>scrollArea</tabstop>
   <tabstop>mEncodingComboBox</tabstop>


### PR DESCRIPTION
When saving a vector layer into an existing file, depending on the capabilities
of the output driver, the user can now decide whether:
- to overwrite the whole file
- to overwrite only the target layer (layer name is now configurable)
- to append features to the existing target layer
- to append features, add new fields if there are any.

All above is available for drivers like GPKG, SpatiaLite, FileGDB, ...
For drivers like Shapefile, MapInfo .tab, feature append is also available.

Backported from master 688d1a5eba225b07cfbe707b19756683c9a46deb
