### PR TITLE
[FEATURE] array support for the replace() expression function

### DIFF
--- a/resources/function_help/json/replace
+++ b/resources/function_help/json/replace
@@ -1,10 +1,12 @@
 {
   "name": "replace",
   "type": "function",
-  "description": "Returns a string with the the supplied string replaced.",
+  "description": "Returns a string with the supplied string or array of strings replaced by a string or an array of strings.",
   "arguments": [ {"arg":"string","description":"the input string"},
-                 {"arg":"before","description":"the string to replace"},
-                 {"arg":"after","description":"the string to use as a replacement"}],
-  "examples": [ { "expression":"replace('QGIS SHOULD ROCK','SHOULD','DOES')", "returns":"'QGIS DOES ROCK'"}
+                 {"arg":"before","description":"the string or array of strings to replace"},
+                 {"arg":"after","description":"the string or array of strings to use as a replacement"}],
+  "examples": [ { "expression":"replace('QGIS SHOULD ROCK','SHOULD','DOES')", "returns":"'QGIS DOES ROCK'"},
+                { "expression":"replace('QGIS ABC',array('A','B','C'),array('X','Y','Z'))", "returns":"'QGIS XYZ'"},
+                { "expression":"replace('QGIS',array('Q','S'),'')", "returns":"'GI'"}
   ]
 }

--- a/resources/function_help/json/replace
+++ b/resources/function_help/json/replace
@@ -1,12 +1,20 @@
 {
   "name": "replace",
   "type": "function",
-  "description": "Returns a string with the supplied string or array of strings replaced by a string or an array of strings.",
-  "arguments": [ {"arg":"string","description":"the input string"},
-                 {"arg":"before","description":"the string or array of strings to replace"},
-                 {"arg":"after","description":"the string or array of strings to use as a replacement"}],
-  "examples": [ { "expression":"replace('QGIS SHOULD ROCK','SHOULD','DOES')", "returns":"'QGIS DOES ROCK'"},
-                { "expression":"replace('QGIS ABC',array('A','B','C'),array('X','Y','Z'))", "returns":"'QGIS XYZ'"},
-                { "expression":"replace('QGIS',array('Q','S'),'')", "returns":"'GI'"}
-  ]
+  "description": "Returns a string with the supplied string, array, or map of strings replaced.",
+  "variants": [
+  { "variant": "String & array variant",
+      "variant_description": "Returns a string with the supplied string or array of strings replaced by a string or an array of strings.",
+      "arguments": [ {"arg":"string","description":"the input string"},
+                     {"arg":"before","description":"the string or array of strings to replace"},
+                     {"arg":"after","description":"the string or array of strings to use as a replacement"}],
+      "examples": [ { "expression":"replace('QGIS SHOULD ROCK','SHOULD','DOES')", "returns":"'QGIS DOES ROCK'"},
+                    { "expression":"replace('QGIS ABC',array('A','B','C'),array('X','Y','Z'))", "returns":"'QGIS XYZ'"},
+                    { "expression":"replace('QGIS',array('Q','S'),'')", "returns":"'GI'"} ] },
+  { "variant": "Map variant",
+      "variant_description": "Returns a string with the supplied map keys replaced by paired values.",
+      "arguments": [ {"arg":"string","description":"the input string"},
+                     {"arg":"map","description":"the map containing keys and values"} ],
+      "examples": [ { "expression":"replace('APP SHOULD ROCK',map('APP','QGIS','SHOULD','DOES'))", "returns":"'QGIS DOES ROCK'"} ]
+  }]
 }

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -1215,9 +1215,41 @@ static QVariant fcnLength( const QVariantList& values, const QgsExpressionContex
 static QVariant fcnReplace( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   QString str = getStringValue( values.at( 0 ), parent );
-  QString before = getStringValue( values.at( 1 ), parent );
-  QString after = getStringValue( values.at( 2 ), parent );
-  return QVariant( str.replace( before, after ) );
+  QVariantList before;
+  QVariantList after;
+  bool isSingleReplacement = false;
+
+  if ( values.at( 1 ).type() != QVariant::List && values.at( 2 ).type() != QVariant::StringList )
+  {
+    before = QVariantList() << getStringValue( values.at( 1 ), parent );
+  }
+  else
+  {
+    before = getListValue( values.at( 1 ), parent );
+  }
+
+  if ( values.at( 2 ).type() != QVariant::List && values.at( 2 ).type() != QVariant::StringList )
+  {
+    after = QVariantList() << getStringValue( values.at( 2 ), parent );
+    isSingleReplacement = true;
+  }
+  else
+  {
+    after = getListValue( values.at( 2 ), parent );
+  }
+
+  if ( !isSingleReplacement && before.length() != after.length() )
+  {
+    parent->setEvalErrorString( QObject::tr( "Invalid pair of array, length not identical" ) );
+    return QVariant();
+  }
+
+  for ( int i = 0; i < before.length(); i++ )
+  {
+    str = str.replace( before.at( i ).toString(), after.at( isSingleReplacement ? 0 : i ).toString() );
+  }
+
+  return QVariant( str );
 }
 static QVariant fcnRegexpReplace( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -825,6 +825,7 @@ class TestQgsExpression: public QObject
       QTest::newRow( "replace (array replaced by string)" ) << "replace('12345', array('2','4'), '')" << false << QVariant( "135" );
       QTest::newRow( "replace (unbalanced array, before > after)" ) << "replace('12345', array('1','2','3'), array('6','7'))" << true << QVariant();
       QTest::newRow( "replace (unbalanced array, before < after)" ) << "replace('12345', array('1','2'), array('6','7','8'))" << true << QVariant();
+      QTest::newRow( "replace (map)" ) << "replace('APP SHOULD ROCK',map('APP','QGIS','SHOULD','DOES'))" << false << QVariant( "QGIS DOES ROCK" );
       QTest::newRow( "regexp_replace" ) << "regexp_replace('HeLLo','[eL]+', '-')" << false << QVariant( "H-o" );
       QTest::newRow( "regexp_replace greedy" ) << "regexp_replace('HeLLo','(?<=H).*L', '-')" << false << QVariant( "H-o" );
       QTest::newRow( "regexp_replace non greedy" ) << "regexp_replace('HeLLo','(?<=H).*?L', '-')" << false << QVariant( "H-Lo" );

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -821,6 +821,10 @@ class TestQgsExpression: public QObject
       QTest::newRow( "upper" ) << "upper('HeLLo')" << false << QVariant( "HELLO" );
       QTest::newRow( "length" ) << "length('HeLLo')" << false << QVariant( 5 );
       QTest::newRow( "replace" ) << "replace('HeLLo', 'LL', 'xx')" << false << QVariant( "Hexxo" );
+      QTest::newRow( "replace (array replaced by array)" ) << "replace('321', array('1','2','3'), array('7','8','9'))" << false << QVariant( "987" );
+      QTest::newRow( "replace (array replaced by string)" ) << "replace('12345', array('2','4'), '')" << false << QVariant( "135" );
+      QTest::newRow( "replace (unbalanced array, before > after)" ) << "replace('12345', array('1','2','3'), array('6','7'))" << true << QVariant();
+      QTest::newRow( "replace (unbalanced array, before < after)" ) << "replace('12345', array('1','2'), array('6','7','8'))" << true << QVariant();
       QTest::newRow( "regexp_replace" ) << "regexp_replace('HeLLo','[eL]+', '-')" << false << QVariant( "H-o" );
       QTest::newRow( "regexp_replace greedy" ) << "regexp_replace('HeLLo','(?<=H).*L', '-')" << false << QVariant( "H-o" );
       QTest::newRow( "regexp_replace non greedy" ) << "regexp_replace('HeLLo','(?<=H).*?L', '-')" << false << QVariant( "H-Lo" );


### PR DESCRIPTION
Simple replace() expression function upgrade making use of the (extremely cool) recent array support addition.

This new string function allows you to modify a string by replacing matching array of strings with either an array of strings or a single string replacement. It can clean up expression that relies in a cascade of replace() calls (i.e. replace(replace(replace(‘boring’)))) .

For e.g., a simple expression to convert numbers from latin to Khmer: 

`replace(my_number,array(‘1’,‘2’,‘3’,‘4’,‘5’,‘6’,‘7’,‘8’,‘9’,’0’),array(‘១’,‘២’,‘៣’,‘៤’,‘៥’,‘៦’,‘៧’,‘៨’,‘៩’,’០’))`

Going from 10 replace() to a single replace() is a nice win.
