### PR TITLE
[processing] Import vector in Eliminate.py to avoid error (QGIS v2.14.8)

### DIFF
--- a/python/plugins/processing/algs/qgis/Eliminate.py
+++ b/python/plugins/processing/algs/qgis/Eliminate.py
@@ -37,7 +37,7 @@ from processing.core.parameters import ParameterTableField
 from processing.core.parameters import ParameterString
 from processing.core.parameters import ParameterSelection
 from processing.core.outputs import OutputVector
-from processing.tools import dataobjects
+from processing.tools import dataobjects, vector
 
 
 class Eliminate(GeoAlgorithm):


### PR DESCRIPTION
It seems that line 95 was added by a cherry pick commit without importing `vector`.
