### PR TITLE
[map themes] fix composer signal name

### DIFF
--- a/src/app/composer/qgscomposermapwidget.cpp
+++ b/src/app/composer/qgscomposermapwidget.cpp
@@ -67,9 +67,9 @@ QgsComposerMapWidget::QgsComposerMapWidget( QgsComposerMap* composerMap )
   // follow preset combo
   mFollowVisibilityPresetCombo->setModel( new QStringListModel( mFollowVisibilityPresetCombo ) );
   connect( mFollowVisibilityPresetCombo, SIGNAL( currentIndexChanged( int ) ), this, SLOT( followVisibilityPresetSelected( int ) ) );
-  connect( QgsProject::instance()->mapThemeCollection(), SIGNAL( presetsChanged() ),
-           this, SLOT( onPresetsChanged() ) );
-  onPresetsChanged();
+  connect( QgsProject::instance()->mapThemeCollection(), SIGNAL( mapThemesChanged() ),
+           this, SLOT( onMapThemesChanged() ) );
+  onMapThemesChanged();
 
   // keep layers from preset button
   QMenu* menuKeepLayers = new QMenu( this );
@@ -213,7 +213,7 @@ void QgsComposerMapWidget::keepLayersVisibilityPresetSelected()
   }
 }
 
-void QgsComposerMapWidget::onPresetsChanged()
+void QgsComposerMapWidget::onMapThemesChanged()
 {
   if ( QStringListModel* model = qobject_cast<QStringListModel*>( mFollowVisibilityPresetCombo->model() ) )
   {

--- a/src/app/composer/qgscomposermapwidget.h
+++ b/src/app/composer/qgscomposermapwidget.h
@@ -116,7 +116,7 @@ class QgsComposerMapWidget: public QgsComposerItemBaseWidget, private Ui::QgsCom
     void followVisibilityPresetSelected( int currentIndex );
     void keepLayersVisibilityPresetSelected();
 
-    void onPresetsChanged();
+    void onMapThemesChanged();
 
     void updateOverviewFrameStyleFromWidget();
     void cleanUpOverviewFrameStyleSelector( QgsPanelWidget* container );


### PR DESCRIPTION
@m-kuhn , one more map themes signal needed renaming, this PR fixes it. This gets rid of the following warning:

```
Warning: QObject::connect: No such signal QgsMapThemeCollection::presetsChanged()
Warning: QObject::connect:  (receiver name: 'QgsComposerMapWidgetBase')
```

BTW, it could be useful to have an additional travis test that looks at warning outputs when launching QGIS, which would fail if such warnings show up.
