### PR TITLE
[FEATURE] add string_to_array() and array_to_string() functions

### DIFF
--- a/resources/function_help/json/array_to_string
+++ b/resources/function_help/json/array_to_string
@@ -1,0 +1,12 @@
+{
+  "name": "array_to_string",
+  "type": "function",
+  "description": "Concatenates array elements into a string separated by a delimiter using and optional string for empty values.",
+  "arguments": [
+    {"arg":"array", "description":"the input array"},
+    {"arg":"delimiter","optional":true,"default":"','","description":"the string delimiter used to separate concatenated array elements"},
+    {"arg":"emptyvalue","optional":true,"default":"''","description":"the optional string to use as replacement to empty values"}],
+  "examples": [ { "expression":"array_to_string(array('1','2','3'),',')", "returns":"'1,2,3'"},
+                { "expression":"array_to_string(array('1','','3'),',','0')", "returns":"'1,0,3'"}
+  ]
+}

--- a/resources/function_help/json/string_to_array
+++ b/resources/function_help/json/string_to_array
@@ -1,0 +1,12 @@
+{
+  "name": "string_to_array",
+  "type": "function",
+  "description": "Splits string into an array using supplied delimiter and optional string for empty values.",
+  "arguments": [
+    {"arg":"string", "description":"the input string"},
+    {"arg":"delimiter","optional":true,"default":"','","description":"the string delimiter used to split the input string"},
+    {"arg":"emptyvalue","optional":true,"default":"''","description":"the optional string to use as replacement to empty values"}],
+  "examples": [ { "expression":"string_to_array('1,2,3',',')", "returns":"array: '1', '2', '3'"},
+                { "expression":"string_to_array('1,,3',',','0')", "returns":"array: '1', '0', '3'"}
+  ]
+}

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -3335,6 +3335,43 @@ static QVariant fcnArrayIntersect( const QVariantList& values, const QgsExpressi
   return QVariant( false );
 }
 
+static QVariant fcnArrayToString( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
+{
+  QVariantList array = getListValue( values.at( 0 ), parent );
+  QString delimiter = getStringValue( values.at( 1 ), parent );
+  QString empty = getStringValue( values.at( 2 ), parent );
+
+  QString str;
+
+  for ( QVariantList::const_iterator it = array.constBegin(); it != array.constEnd(); ++it )
+  {
+    str += ( *it ).toString().isEmpty() == false ? ( *it ).toString() : empty;
+    if ( it != ( array.constEnd() - 1 ) )
+    {
+      str += delimiter;
+    }
+  }
+
+  return QVariant( str );
+}
+
+static QVariant fcnStringToArray( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
+{
+  QString str = getStringValue( values.at( 0 ), parent );
+  QString delimiter = getStringValue( values.at( 1 ), parent );
+  QString empty = getStringValue( values.at( 2 ), parent );
+
+  QStringList list = str.split( delimiter );
+  QVariantList array;
+
+  for ( QStringList::const_iterator it = list.constBegin(); it != list.constEnd(); ++it )
+  {
+    array += ( *it ).isEmpty() == false ? *it : empty;
+  }
+
+  return array;
+}
+
 static QVariant fcnMap( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   QVariantMap result;
@@ -3691,6 +3728,8 @@ const QList<QgsExpression::Function*>& QgsExpression::Functions()
     << new StaticFunction( QStringLiteral( "array_remove_all" ), ParameterList() << Parameter( QStringLiteral( "array" ) ) << Parameter( QStringLiteral( "value" ) ), fcnArrayRemoveAll, QStringLiteral( "Arrays" ) )
     << new StaticFunction( QStringLiteral( "array_cat" ), -1, fcnArrayCat, QStringLiteral( "Arrays" ) )
     << new StaticFunction( QStringLiteral( "array_intersect" ), ParameterList() << Parameter( QStringLiteral( "array1" ) ) << Parameter( QStringLiteral( "array2" ) ), fcnArrayIntersect, QStringLiteral( "Arrays" ) )
+    << new StaticFunction( QStringLiteral( "array_to_string" ), ParameterList() << Parameter( QStringLiteral( "array" ) ) << Parameter( QStringLiteral( "delimiter" ), true, "," ) << Parameter( QStringLiteral( "emptyvalue" ), true, "" ), fcnArrayToString, QStringLiteral( "Arrays" ) )
+    << new StaticFunction( QStringLiteral( "string_to_array" ), ParameterList() << Parameter( QStringLiteral( "string" ) ) << Parameter( QStringLiteral( "delimiter" ), true, "," ) << Parameter( QStringLiteral( "emptyvalue" ), true, "" ), fcnStringToArray, QStringLiteral( "Arrays" ) )
 
     //functions for maps
     << new StaticFunction( QStringLiteral( "map" ), -1, fcnMap, QStringLiteral( "Maps" ) )

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -859,6 +859,9 @@ class TestQgsExpression: public QObject
       QTest::newRow( "concat" ) << "concat('a', 'b', 'c', 'd')" << false << QVariant( "abcd" );
       QTest::newRow( "concat function single" ) << "concat('a')" << false << QVariant( "a" );
       QTest::newRow( "concat function with NULL" ) << "concat(NULL,'a','b')" << false << QVariant( "ab" );
+      QTest::newRow( "array_to_string" ) << "array_to_string(array(1,2,3),',')" << false << QVariant( "1,2,3" );
+      QTest::newRow( "array_to_string with custom empty value" ) << "array_to_string(array(1,'',3),',','*')" << false << QVariant( "1,*,3" );
+      QTest::newRow( "array_to_string fail passing non-array" ) << "array_to_string('non-array',',')" << true << QVariant();
 
       //fuzzy matching
       QTest::newRow( "levenshtein" ) << "levenshtein('kitten','sitting')" << false << QVariant( 3 );
@@ -2180,8 +2183,10 @@ class TestQgsExpression: public QObject
       QCOMPARE( QgsExpression( "array()" ).evaluate( &context ), QVariant( ) );
       builderExpected << "hello";
       QCOMPARE( QgsExpression( "array('hello')" ).evaluate( &context ), QVariant( builderExpected ) );
+      QCOMPARE( QgsExpression( "string_to_array('hello',',')" ).evaluate( &context ), QVariant( builderExpected ) );
       builderExpected << "world";
       QCOMPARE( QgsExpression( "array('hello', 'world')" ).evaluate( &context ), QVariant( builderExpected ) );
+      QCOMPARE( QgsExpression( "string_to_array('hello,world',',')" ).evaluate( &context ), QVariant( builderExpected ) );
 
       QCOMPARE( QgsExpression( "array_length(\"strings\")" ).evaluate( &context ), QVariant( 2 ) );
 


### PR DESCRIPTION
This PR adds a string_to_array() and array_to_string() functions to QGIS' expression engine. Those are basic and useful to array-related functions have. Per QGIS' habit, I named those functions match postgresql.

This allows us to do nice conditional check against TEXT fields. Let's say you have a dataset with a "types" TEXT field which enumerates an array of things served as a comma-separated string, you can now do the following: `if( array_contains( string_to_array( "my_field_name", 'apple' ), 'apple' ), 'the feature has apples', 'the feature doesn't have apples' )`
