### PR TITLE
[FEATURE] add array_distinct() function

### DIFF
--- a/resources/function_help/json/array_distinct
+++ b/resources/function_help/json/array_distinct
@@ -1,0 +1,9 @@
+{
+  "name": "array_distinct",
+  "type": "function",
+  "description": "Returns an array containing distinct values of the given array.",
+  "arguments": [
+    {"arg":"array","description":"an array"}],
+  "examples": [ { "expression":"array_distinct(array(1,2,3,2,1))", "returns":"array: 1,2,3"}
+  ]
+}

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -3404,6 +3404,24 @@ static QVariant fcnArrayIntersect( const QVariantList& values, const QgsExpressi
   return QVariant( false );
 }
 
+
+static QVariant fcnArrayDistinct( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
+{
+  QVariantList array = getListValue( values.at( 0 ), parent );
+
+  QVariantList distinct;
+
+  for ( QVariantList::const_iterator it = array.constBegin(); it != array.constEnd(); ++it )
+  {
+    if ( !distinct.contains( *it ) )
+    {
+      distinct += ( *it );
+    }
+  }
+
+  return distinct;
+}
+
 static QVariant fcnArrayToString( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
 {
   QVariantList array = getListValue( values.at( 0 ), parent );
@@ -3872,6 +3890,7 @@ const QList<QgsExpression::Function*>& QgsExpression::Functions()
     << new StaticFunction( QStringLiteral( "array_remove_all" ), ParameterList() << Parameter( QStringLiteral( "array" ) ) << Parameter( QStringLiteral( "value" ) ), fcnArrayRemoveAll, QStringLiteral( "Arrays" ) )
     << new StaticFunction( QStringLiteral( "array_cat" ), -1, fcnArrayCat, QStringLiteral( "Arrays" ) )
     << new StaticFunction( QStringLiteral( "array_intersect" ), ParameterList() << Parameter( QStringLiteral( "array1" ) ) << Parameter( QStringLiteral( "array2" ) ), fcnArrayIntersect, QStringLiteral( "Arrays" ) )
+    << new StaticFunction( QStringLiteral( "array_distinct" ), 1, fcnArrayDistinct, QStringLiteral( "Arrays" ) )
     << new StaticFunction( QStringLiteral( "array_to_string" ), ParameterList() << Parameter( QStringLiteral( "array" ) ) << Parameter( QStringLiteral( "delimiter" ), true, "," ) << Parameter( QStringLiteral( "emptyvalue" ), true, "" ), fcnArrayToString, QStringLiteral( "Arrays" ) )
     << new StaticFunction( QStringLiteral( "string_to_array" ), ParameterList() << Parameter( QStringLiteral( "string" ) ) << Parameter( QStringLiteral( "delimiter" ), true, "," ) << Parameter( QStringLiteral( "emptyvalue" ), true, "" ), fcnStringToArray, QStringLiteral( "Arrays" ) )
 

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -862,6 +862,8 @@ class TestQgsExpression: public QObject
       QTest::newRow( "array_to_string" ) << "array_to_string(array(1,2,3),',')" << false << QVariant( "1,2,3" );
       QTest::newRow( "array_to_string with custom empty value" ) << "array_to_string(array(1,'',3),',','*')" << false << QVariant( "1,*,3" );
       QTest::newRow( "array_to_string fail passing non-array" ) << "array_to_string('non-array',',')" << true << QVariant();
+      QTest::newRow( "array_unique" ) << "array_to_string(array_distinct(array('hello','world','world','hello')))" << false << QVariant( "hello,world" );
+      QTest::newRow( "array_unique fail passing non-array" ) << "array_distinct('non-array')" << true << QVariant();
 
       //fuzzy matching
       QTest::newRow( "levenshtein" ) << "levenshtein('kitten','sitting')" << false << QVariant( 3 );


### PR DESCRIPTION
This PR introduces another array function to the expression engine: `array_distinct()`. It's a tiny yet pretty useful function. 

For e.g., when used alongside the `concatenate()` function, users can quickly get a list of unique values:

```
array_distinct(string_to_array(concatenate("string_field", concatenator:=',')))
```
