### PR TITLE
Temporarily hardcode plugins version in url ?qgis=3.0

### DIFF
--- a/python/pyplugin_installer/installer_data.py
+++ b/python/pyplugin_installer/installer_data.py
@@ -236,7 +236,10 @@ class Repositories(QObject):
     def urlParams(self):
         """ return GET parameters to be added to every request """
         v = str(Qgis.QGIS_VERSION_INT)
-        return "?qgis=%d.%d" % (int(v[0]), int(v[1:3]))
+        # TODO: make this proper again after 3.0 release, by uncommenting
+        # the line below and removing the other return line:
+        #return "?qgis=%d.%d" % (int(v[0]), int(v[1:3]))
+        return "?qgis=3.0"
 
     # ----------------------------------------- #
     def setRepositoryData(self, reposName, key, value):


### PR DESCRIPTION
If QGIS 3.0 is actually released this line should be removed.

See: https://lists.osgeo.org/pipermail/qgis-developer/2016-October/045538.html
