### PR TITLE
[processing] Better method to expose model inputs to expressions

### DIFF
--- a/python/plugins/processing/ProcessingPlugin.py
+++ b/python/plugins/processing/ProcessingPlugin.py
@@ -42,10 +42,17 @@ from processing.gui.ConfigDialog import ConfigDialog
 from processing.gui.ResultsDialog import ResultsDialog
 from processing.gui.CommanderWindow import CommanderWindow
 from processing.modeler.ModelerDialog import ModelerDialog
+from processing.modeler.ModelerAlgorithm import ModelParamFunction
 from processing.tools.system import tempFolder
 from processing.gui.menus import removeMenus, initializeMenus, createMenus
 from processing.core.alglist import algList
 
+from qgis.core import QgsExpression
+
+
+# expression functions must be registered on load, and the function must survive for as long as it can be called
+model_param_function = ModelParamFunction(None)
+QgsExpression.registerFunction(model_param_function)
 
 cmd_folder = os.path.split(inspect.getfile(inspect.currentframe()))[0]
 if cmd_folder not in sys.path:
@@ -142,6 +149,9 @@ class ProcessingPlugin(object):
         self.iface.unregisterMainWindowAction(self.commanderAction)
 
         removeMenus()
+
+        # safely remove expression functions to avoid crash on exit
+        QgsExpression.unregisterFunction('model_param')
 
     def openCommander(self):
         if self.commander is None:

--- a/python/plugins/processing/algs/qgis/ExtractByExpression.py
+++ b/python/plugins/processing/algs/qgis/ExtractByExpression.py
@@ -61,6 +61,9 @@ class ExtractByExpression(GeoAlgorithm):
         else:
             raise GeoAlgorithmExecutionException(expression.parserErrorString())
 
+        context = self.createExpressionContext(layer)
+        req.setExpressionContext(context)
+
         for f in layer.getFeatures(req):
             writer.addFeature(f)
 

--- a/python/plugins/processing/core/GeoAlgorithm.py
+++ b/python/plugins/processing/core/GeoAlgorithm.py
@@ -36,7 +36,7 @@ import copy
 from qgis.PyQt.QtGui import QIcon
 from qgis.PyQt.QtCore import QCoreApplication, QSettings
 
-from qgis.core import QgsVectorLayer, QgsRasterLayer
+from qgis.core import QgsVectorLayer, QgsRasterLayer, QgsExpressionContext, QgsExpressionContextUtils
 
 from processing.core.ProcessingLog import ProcessingLog
 from processing.core.ProcessingConfig import ProcessingConfig
@@ -533,3 +533,17 @@ class GeoAlgorithm(object):
         if context == '':
             context = self.__class__.__name__
         return string, QCoreApplication.translate(context, string)
+
+    def createExpressionContext(self, layer=None):
+
+        context = QgsExpressionContext()
+        context.appendScope(QgsExpressionContextUtils.globalScope())
+        context.appendScope(QgsExpressionContextUtils.projectScope())
+
+        if self.model:
+            context.appendScope(self.model.createExpressionContextScope())
+
+        if layer:
+            context.appendScope(QgsExpressionContextUtils.layerScope(layer))
+
+        return context

--- a/python/plugins/processing/modeler/ModelerAlgorithm.py
+++ b/python/plugins/processing/modeler/ModelerAlgorithm.py
@@ -38,7 +38,7 @@ from qgis.PyQt.QtCore import QCoreApplication, QPointF
 from qgis.PyQt.QtGui import QIcon
 from operator import attrgetter
 
-from qgis.core import QgsRasterLayer, QgsVectorLayer
+from qgis.core import QgsRasterLayer, QgsVectorLayer, QgsExpressionContextScope, QgsScopedExpressionFunction, QgsExpression, NULL
 from qgis.gui import QgsMessageBar
 from qgis.utils import iface
 from processing.core.GeoAlgorithm import GeoAlgorithm
@@ -85,6 +85,32 @@ class ModelerOutput(object):
 
     def todict(self):
         return self.__dict__
+
+
+class ModelParamFunction(QgsScopedExpressionFunction):
+
+    def __init__(self, model):
+        super(ModelParamFunction, self).__init__('model_param', 1, 'Processsing')
+        self.model = model
+
+    def func(self, values, context, parent):
+        if not self.model:
+            return NULL
+
+        param = values[0]
+
+        if param in self.model.inputs:
+            # check by name
+            return self.model.inputs[param].param.value
+        else:
+            # check by description
+            for p, v in self.model.inputs.items():
+                if v.param.description == param:
+                    return v.param.value
+        return NULL
+
+    def clone(self):
+        return ModelParamFunction(self.model)
 
 
 class Algorithm(object):
@@ -637,6 +663,16 @@ class ModelerAlgorithm(GeoAlgorithm):
                         executed.append(alg.name)
 
         return '\n'.join(s)
+
+    parameter_function = None
+
+    def createExpressionContextScope(self):
+        scope = QgsExpressionContextScope()
+        scope.addVariable(QgsExpressionContextScope.StaticVariable('model_name', self.name, True))
+        if not self.parameter_function:
+            self.parameter_function = ModelParamFunction(self)
+        scope.addFunction('model_param', self.parameter_function)
+        return scope
 
 
 def safeName(name):


### PR DESCRIPTION
Processing currently has inconsistent handling of exposing model inputs as variables to expressions, and is not correctly using the design of expression contexts.

This PR refactors how expression contexts are generated within processing, and adds a new scoped expression function 'model_param' which allows you to retrieve the value of a model input at runtime.

Eg:

    model_param('buffer size')

will return the buffer size input value. It also adds a `@model_name` variable, and paves the way for adding many more model specific variables to processing expressions.

This commit only upgrades the Extract by Expression algorithm to use the new way of creating expression contexts, so model_param will only be available for this algorithm at first.