### PR TITLE
[processing] resurrect editing of modeler item on double-click

### DIFF
--- a/python/plugins/processing/modeler/ModelerGraphicItem.py
+++ b/python/plugins/processing/modeler/ModelerGraphicItem.py
@@ -132,8 +132,7 @@ class ModelerGraphicItem(QGraphicsItem):
         return rect
 
     def mouseDoubleClickEvent(self, event):
-        pass
-        #self.editElement()
+        self.editElement()
 
     def contextMenuEvent(self, event):
         if isinstance(self.element, ModelerOutput):


### PR DESCRIPTION
@volaya , in Oct. 2014, editing of a modeler item via double left click was disabled due to crashes (commit db0f423). I've re-enabled it in Oct. 2016, and things haven't crashed so far.

Time to resurrect this? :)