### PR TITLE
[processing] remove console error message when optional otb provider not installed

### DIFF
--- a/python/plugins/processing/algs/otb/OTBAlgorithmProvider.py
+++ b/python/plugins/processing/algs/otb/OTBAlgorithmProvider.py
@@ -61,8 +61,6 @@ class OTBAlgorithmProvider(AlgorithmProvider):
 
         version = OTBUtils.getInstalledVersion(True)
         if version is None:
-            ProcessingLog.addToLog(ProcessingLog.LOG_ERROR,
-                                   self.tr('Problem with OTB installation: OTB was not found or is not correctly installed'))
             return
 
         folder = OTBUtils.compatibleDescriptionPath(version)


### PR DESCRIPTION
ATM, processing always throws an error message in the console upon QGIS launch when OTB - an optional provider - is not installed/found. 

This behavior results in effectively rendering the status bar console "you've got messages" icon notification useless.

This PR simply removes the error message, as a/ OTB not present is not an error per say, and b/ the absence of OTB algorithms in the processing toolbox list does a better job at indicating OTB was not found :smile: