### PR TITLE
Revamp QgsActions

### DIFF
--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -322,16 +322,30 @@ QgsAnnotation        {#qgis_api_break_3_0_QgsAnnotation}
 QgsActionManager        {#qgis_api_break_3_0_QgsActionManager}
 ----------------
 
-- doAction() no longer accepts a substitution map. Use expression context variables instead.
-- The doAction() variant which takes a QgsFeature along has been removed. Use the expression context
-variant instead.
-- expandAction() has been removed. Use QgsExpression::replaceExpressionText() instead.
-- setPythonExecute() was removed. Initialize QgsPythonRunner instead.
+- `doAction()` no longer accepts a substitution map. Use expression context
+  variables instead.
+- The `doAction()` variant which takes a QgsFeature along has been removed. Use
+  the expression context variant instead.
+- `expandAction()` has been removed. Use
+  `QgsExpression::replaceExpressionText()` instead.
+- `setPythonExecute()` was removed. Initialize `QgsPythonRunner` instead.
+- `QgsActionManager::listActions()` has been renamed to `QgsActionManager::actions( actionScope )`.
+- `QgsActionManager::removeAction()` takes an actions UUID instead of an index.
+- `QgsActionManager::doAction()` takes an actions UUID instead of an index.
+- `QgsActionManager::writeXml()` no longer takes a QDomDocument. The document is
+  extracted from the layerNode.
+- `QgsActionManager::at()` has been removed. Use `QgsActionManager::action( id )`
+  to get an action by its UUID.
+- `QgsActionManager::defaultAction()` works on a per-scope basis and with UUIDs
+  instead of indexes.
+
 
 QgsAction             {#qgis_api_break_3_0_QgsAction}
 ---------
 
 - `QgsAction::action()` has been renamed to `QgsAction::command()`.
+- `QgsAction::showInAttributeTable()` has been removed. Use
+  `QgsAction::actionScopes()` instead and check for the 'Feature' scope.
 
 
 QgsAdvancedDigitizingDockWidget        {#qgis_api_break_3_0_QgsAdvancedDigitizingDockWidget}

--- a/doc/api_break.dox
+++ b/doc/api_break.dox
@@ -328,6 +328,11 @@ variant instead.
 - expandAction() has been removed. Use QgsExpression::replaceExpressionText() instead.
 - setPythonExecute() was removed. Initialize QgsPythonRunner instead.
 
+QgsAction             {#qgis_api_break_3_0_QgsAction}
+---------
+
+- `QgsAction::action()` has been renamed to `QgsAction::command()`.
+
 
 QgsAdvancedDigitizingDockWidget        {#qgis_api_break_3_0_QgsAdvancedDigitizingDockWidget}
 -------------------------------

--- a/python/core/core.sip
+++ b/python/core/core.sip
@@ -18,6 +18,8 @@
 %Include qgsapplication.sip
 %Include qgsaction.sip
 %Include qgsactionmanager.sip
+%Include qgsactionscope.sip
+%Include qgsactionscoperegistry.sip
 %Include qgsaggregatecalculator.sip
 %Include qgsattributetableconfig.sip
 %Include qgsattributeeditorelement.sip

--- a/python/core/qgsaction.sip
+++ b/python/core/qgsaction.sip
@@ -41,6 +41,20 @@ class QgsAction
     //! The short title is used to label user interface elements like buttons
     QString shortTitle() const;
 
+    /**
+     * Returns a unique id for this action.
+     *
+     * @note Added in QGIS 3.0
+     */
+    QString id() const { return mShortTitle; }
+
+    /**
+     * Returns true if this action was a default constructed one.
+     *
+     * @note Added in QGIS 3.0
+     */
+    bool isValid() const { return !mShortTitle.isNull(); }
+
     //! The path to the icon
     QString iconPath() const;
 
@@ -58,6 +72,20 @@ class QgsAction
 
     //! Checks if the action is runable on the current platform
     bool runable() const;
+
+    /**
+     * Run this action.
+     *
+     * @note Added in QGIS 3.0
+     */
+    void run( QgsVectorLayer* layer, const QgsFeature& feature, const QgsExpressionContext& expressionContext ) const;
+
+    /**
+     * Run this action.
+     *
+     * @note Added in QGIS 3.0
+     */
+    void run( const QgsExpressionContext& expressionContext ) const;
 
     /**
      * The action scopes define where an action will be available.

--- a/python/core/qgsaction.sip
+++ b/python/core/qgsaction.sip
@@ -33,41 +33,7 @@ class QgsAction
       OpenUrl,
     };
 
-    /**
-     * Create a new QgsAction
-     *
-     * @param type          The type of this action
-     * @param description   A human readable description string
-     * @param action        The action text. Its interpretation depends on the type
-     * @param capture       If this is set to true, the output will be captured when an action is run
-     */
-    QgsAction( ActionType type, const QString& description, const QString& action, bool capture );
-
-
-    /**
-     * Create a new QgsAction
-     *
-     * @param type          The type of this action
-     * @param description   A human readable description string
-     * @param action        The action text. Its interpretation depends on the type
-     * @param icon          Path to an icon for this action
-     * @param capture       If this is set to true, the output will be captured when an action is run
-     * @param shortTitle    A short string used to label user interface elements like buttons
-     */
-    QgsAction( ActionType type, const QString& description, const QString& action, const QString& icon, bool capture, const QString& shortTitle = QString() );
-
-    /**
-     * Create a new QgsAction
-     *
-     * @param type                 The type of this action
-     * @param description          A human readable description string
-     * @param action               The action text. Its interpretation depends on the type
-     * @param icon                 Path to an icon for this action
-     * @param capture              If this is set to true, the output will be captured when an action is run
-     * @param showInAttributeTable If this is false, the action will be hidden on the attribute table action widget
-     * @param shortTitle           A short string used to label user interface elements like buttons
-     */
-    QgsAction( ActionType type, const QString& description, const QString& action, const QString& icon, bool capture, bool showInAttributeTable, const QString& shortTitle = QString() );
+    QgsAction( ActionType type, const QString& description, const QString& action, const QString& icon, bool capture, const QString& shortTitle = QString(), const QSet<QString>& actionScopes = QSet<QString>() );
 
     //! The name of the action. This may be a longer description.
     QString name() const;
@@ -81,8 +47,8 @@ class QgsAction
     //! The icon
     QIcon icon() const;
 
-    //! The action
-    QString action() const;
+    //! The command
+    QString command() const;
 
     //! The action type
     ActionType type() const;
@@ -90,9 +56,25 @@ class QgsAction
     //! Whether to capture output for display when this action is run
     bool capture() const;
 
-    //! Whether this action should be shown on the attribute table
-    bool showInAttributeTable() const;
-
-    //! Whether the action is runable on the current platform
+    //! Checks if the action is runable on the current platform
     bool runable() const;
+
+    /**
+     * The action scopes define where an action will be available.
+     * Action scopes may offer additional variables like the clicked
+     * coordinate.
+     *
+     * @see QgsActionScope
+     * @note Added in QGIS 3.0
+     */
+    QSet<QString> actionScopes() const;
+
+    /**
+     * The action scopes define where an action will be available.
+     * Action scopes may offer additional variables like the clicked
+     * coordinate.
+     *
+     * @note Added in QGIS 3.0
+     */
+    void setActionScopes( const QSet<QString>& actionScopes );
 };

--- a/python/core/qgsaction.sip
+++ b/python/core/qgsaction.sip
@@ -33,6 +33,32 @@ class QgsAction
       OpenUrl,
     };
 
+    /**
+     * Default constructor
+     */
+    QgsAction();
+
+    /**
+     * Create a new QgsAction
+     *
+     * @param type          The type of this action
+     * @param description   A human readable description string
+     * @param command       The action text. Its interpretation depends on the type
+     * @param capture       If this is set to true, the output will be captured when an action is run
+     */
+    QgsAction( ActionType type, const QString& description, const QString& command, bool capture = false );
+
+    /**
+     * Create a new QgsAction
+     *
+     * @param type                 The type of this action
+     * @param description          A human readable description string
+     * @param action               The action text. Its interpretation depends on the type
+     * @param icon                 Path to an icon for this action
+     * @param capture              If this is set to true, the output will be captured when an action is run
+     * @param shortTitle           A short string used to label user interface elements like buttons
+     * @param actionScopes         A set of scopes in which this action will be available
+     */
     QgsAction( ActionType type, const QString& description, const QString& action, const QString& icon, bool capture, const QString& shortTitle = QString(), const QSet<QString>& actionScopes = QSet<QString>() );
 
     //! The name of the action. This may be a longer description.
@@ -46,14 +72,14 @@ class QgsAction
      *
      * @note Added in QGIS 3.0
      */
-    QString id() const { return mShortTitle; }
+    QUuid id() const;
 
     /**
      * Returns true if this action was a default constructed one.
      *
      * @note Added in QGIS 3.0
      */
-    bool isValid() const { return !mShortTitle.isNull(); }
+    bool isValid() const;
 
     //! The path to the icon
     QString iconPath() const;
@@ -105,4 +131,20 @@ class QgsAction
      * @note Added in QGIS 3.0
      */
     void setActionScopes( const QSet<QString>& actionScopes );
+
+    /**
+     * Reads an XML definition from actionNode
+     * into this object.
+     *
+     * @note Added in QGIS 3.0
+     */
+    void readXml( const QDomNode& actionNode );
+
+    /**
+     * Appends an XML definition for this action as a new
+     * child node to actionsNode.
+     *
+     * @note Added in QGIS 3.0
+     */
+    void writeXml(QDomNode& actionsNode ) const;
 };

--- a/python/core/qgsactionmanager.sip
+++ b/python/core/qgsactionmanager.sip
@@ -69,7 +69,7 @@ class QgsActionManager
 
     /** Does the action using the expression engine to replace any embedded expressions
      * in the action definition.
-     * @param index action index
+     * @param actionId action id
      * @param feature feature to run action for
      * @param context expression context to evalute expressions under
      */

--- a/python/core/qgsactionmanager.sip
+++ b/python/core/qgsactionmanager.sip
@@ -59,6 +59,13 @@ class QgsActionManager
      */
     void addAction( const QgsAction& action );
 
+    /**
+     * Remove an action by its id.
+     *
+     * @note Added in QGIS 3.0
+     */
+    void removeAction( const QUuid& actionId );
+
     /** Does the given values. defaultValueIndex is the index of the
      *  field to be used if the action has a $currfield placeholder.
      *  @note available in python bindings as doActionFeature
@@ -80,7 +87,7 @@ class QgsActionManager
      * Return a list of actions that are available in the given action scope.
      * If no action scope is provided, all actions will be returned.
      */
-    QList<QgsAction> listActions( const QString& actionScope = QString() ) const;
+    QList<QgsAction> actions( const QString& actionScope = QString() ) const;
 
     //! Return the layer
     QgsVectorLayer* layer() const;

--- a/python/core/qgsactionmanager.sip
+++ b/python/core/qgsactionmanager.sip
@@ -44,7 +44,7 @@ class QgsActionManager
      * any stdout from the process will be captured and displayed in a
      * dialog box.
      */
-    void addAction( QgsAction::ActionType type, const QString& name, const QString& action, bool capture = false );
+    QUuid addAction(QgsAction::ActionType type, const QString& name, const QString& command, bool capture = false );
 
     /** Add an action with the given name and action details.
      * Will happily have duplicate names and actions. If
@@ -52,7 +52,7 @@ class QgsActionManager
      * any stdout from the process will be captured and displayed in a
      * dialog box.
      */
-    void addAction( QgsAction::ActionType type, const QString& name, const QString& action, const QString& icon, bool capture = false );
+    QUuid addAction(QgsAction::ActionType type, const QString& name, const QString& command, const QString& icon, bool capture = false );
 
     /**
      * Add a new action to this list.
@@ -63,9 +63,7 @@ class QgsActionManager
      *  field to be used if the action has a $currfield placeholder.
      *  @note available in python bindings as doActionFeature
      */
-    void doAction( const QString& actionId,
-                   const QgsFeature &feat,
-                   int defaultValueIndex = 0 ) /PyName=doActionFeature/;
+    void doAction(const QUuid& actionId, const QgsFeature& feature, int defaultValueIndex = 0 ) /PyName=doActionFeature/;
 
     /** Does the action using the expression engine to replace any embedded expressions
      * in the action definition.
@@ -73,21 +71,22 @@ class QgsActionManager
      * @param feature feature to run action for
      * @param context expression context to evalute expressions under
      */
-    void doAction( const QString& actionId,
-                   const QgsFeature& feature,
-                   const QgsExpressionContext& context );
+    void doAction( const QUuid& actionId, const QgsFeature& feature, const QgsExpressionContext& context );
 
     //! Removes all actions
     void clearActions();
 
-    //! List all actions
+    /**
+     * Return a list of actions that are available in the given action scope.
+     * If no action scope is provided, all actions will be returned.
+     */
     QList<QgsAction> listActions( const QString& actionScope = QString() ) const;
 
     //! Return the layer
     QgsVectorLayer* layer() const;
 
     //! Writes the actions out in XML format
-    bool writeXml( QDomNode& layer_node, QDomDocument& doc ) const;
+    bool writeXml( QDomNode& layer_node ) const;
 
     //! Reads the actions in in XML format
     bool readXml( const QDomNode& layer_node );
@@ -97,7 +96,7 @@ class QgsActionManager
      *
      * @note Added in QGIS 3.0
      */
-    QgsAction action( const QString& id );
+    QgsAction action( const QUuid& id );
 
     /**
      * Each scope can have a default action. This will be saved in the project
@@ -105,7 +104,7 @@ class QgsActionManager
      *
      * @note Added in QGIS 3.0
      */
-    void setDefaultAction( const QString& actionScope, const QString& actionId );
+    void setDefaultAction( const QString& actionScope, const QUuid& actionId );
 
     /**
      * Each scope can have a default action. This will be saved in the project

--- a/python/core/qgsactionmanager.sip
+++ b/python/core/qgsactionmanager.sip
@@ -59,14 +59,11 @@ class QgsActionManager
      */
     void addAction( const QgsAction& action );
 
-    //! Remove an action at given index
-    void removeAction( int index );
-
     /** Does the given values. defaultValueIndex is the index of the
      *  field to be used if the action has a $currfield placeholder.
      *  @note available in python bindings as doActionFeature
      */
-    void doAction( int index,
+    void doAction( const QString& actionId,
                    const QgsFeature &feat,
                    int defaultValueIndex = 0 ) /PyName=doActionFeature/;
 
@@ -76,7 +73,7 @@ class QgsActionManager
      * @param feature feature to run action for
      * @param context expression context to evalute expressions under
      */
-    void doAction( int index,
+    void doAction( const QString& actionId,
                    const QgsFeature& feature,
                    const QgsExpressionContext& context );
 
@@ -84,7 +81,7 @@ class QgsActionManager
     void clearActions();
 
     //! List all actions
-    QList<QgsAction> listActions() const;
+    QList<QgsAction> listActions( const QString& actionScope = QString() ) const;
 
     //! Return the layer
     QgsVectorLayer* layer() const;
@@ -95,49 +92,27 @@ class QgsActionManager
     //! Reads the actions in in XML format
     bool readXml( const QDomNode& layer_node );
 
-    int size() const;
     /**
-     * Get the action at the specified index.
+     * Get an action by its id.
+     *
+     * @note Added in QGIS 3.0
      */
-    QgsAction at( int idx ) const /Factory/;
-%MethodCode
-  if ( a0 < 0 || a0 >= sipCpp->size() )
-  {
-    PyErr_SetString(PyExc_KeyError, QByteArray::number(a0));
-    sipIsErr = 1;
-  }
-  else
-  {
-    sipRes = new QgsAction( sipCpp->at( a0 ) );
-  }
-%End
+    QgsAction action( const QString& id );
 
     /**
-     * Get the action at the specified index.
+     * Each scope can have a default action. This will be saved in the project
+     * file.
+     *
+     * @note Added in QGIS 3.0
      */
-    QgsAction operator[]( int idx ) const;
-%MethodCode
-  if ( a0 < 0 || a0 >= sipCpp->size() )
-  {
-    PyErr_SetString(PyExc_KeyError, QByteArray::number(a0));
-    sipIsErr = 1;
-  }
-  else
-  {
-    sipRes = new QgsAction( sipCpp->at( a0 ) );
-  }
-%End
+    void setDefaultAction( const QString& actionScope, const QString& actionId );
 
     /**
-     * Returns the index of the default action, or -1 if no default action is available.
-     * @see setDefaultAction()
+     * Each scope can have a default action. This will be saved in the project
+     * file.
+     *
+     * @note Added in QGIS 3.0
      */
-    int defaultAction() const;
+    QgsAction defaultAction( const QString& actionScope );
 
-    /**
-     * Set the index of the default action.
-     * @param actionNumber index of action which should be made the default for the layer
-     * @see defaultAction()
-     */
-    void setDefaultAction( int actionNumber );
 };

--- a/python/core/qgsactionscope.sip
+++ b/python/core/qgsactionscope.sip
@@ -25,11 +25,12 @@
  * <dl>
  *   <dt>Canvas</dt>
  *   <dd>Show for canvas tools. Adds `@clicked_x` and `@clicked_y` in map coordinates.</dd>
- *   <dt>AttributeTable</dt>
- *   <dd>Show in attribute table for each row.</dd>
- *   <dt>FieldSpecific</dt>
- *   <dd>Show on right click in attribute table. Adds `@field_index` and `@field_name`.</dd>
- *   <dt>Selection</dt>
+ *   <dt>Feature</dt>
+ *   <dd>Show in feature specific places like the attribute table or feature
+ *   form.</dd>
+ *   <dt>Field</dt>
+ *   <dd>Show in context menus for individual fields (e.g. attribute table). Adds `@field_index`, `@field_name` and `@field_value`.</dd>
+ *   <dt>Layer</dt>
  *   <dd>Show in attribute table and work on the layer or selection.</dd>
  * </dl>
  *
@@ -43,7 +44,9 @@ class QgsActionScope
 %End
   public:
     /**
-     * Creates a new action scope.
+     * Creates a new invalid action scope.
+     *
+     * @note Added in QGSI 3.0
      */
     explicit QgsActionScope();
 

--- a/python/core/qgsactionscope.sip
+++ b/python/core/qgsactionscope.sip
@@ -1,0 +1,113 @@
+/***************************************************************************
+  qgsactionscope.sip - QgsActionScope
+
+ ---------------------
+ begin                : 1.11.2016
+ copyright            : (C) 2016 by Matthias Kuhn
+ email                : matthias@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+/** \ingroup core
+ * An action scope defines a "place" for an action to be shown and may add
+ * additional expression variables.
+ * Each QgsAction can be available in one or several action scopes.
+ *
+ * Examples:
+ * ---------
+ *
+ * <dl>
+ *   <dt>Canvas</dt>
+ *   <dd>Show for canvas tools. Adds `@clicked_x` and `@clicked_y` in map coordinates.</dd>
+ *   <dt>AttributeTable</dt>
+ *   <dd>Show in attribute table for each row.</dd>
+ *   <dt>FieldSpecific</dt>
+ *   <dd>Show on right click in attribute table. Adds `@field_index` and `@field_name`.</dd>
+ *   <dt>Selection</dt>
+ *   <dd>Show in attribute table and work on the layer or selection.</dd>
+ * </dl>
+ *
+ * @note Added in QGIS 3.0
+ */
+
+class QgsActionScope
+{
+%TypeHeaderCode
+#include "qgsactionscope.h"
+%End
+  public:
+    /**
+     * Creates a new action scope.
+     */
+    explicit QgsActionScope();
+
+    /**
+     * Creates a new action scope.
+     * For details concerning the parameters check the documentation
+     * of the corresponding properties.
+     */
+    explicit QgsActionScope( const QString& id, const QString& title, const QString& description, const QgsExpressionContextScope& expressionContextScope = QgsExpressionContextScope() );
+
+    /**
+     * Compares two action scopes
+     */
+    bool operator==( const QgsActionScope& other ) const;
+
+    /**
+     * An expression scope may offer additional variables for an action scope.
+     * This can be an `field_name` for the attribute which was clicked or
+     * `clicked_x` and `clicked_y` for actions which are available as map canvas clicks.
+     *
+     * @note Added in QGIS 3.0
+     */
+    QgsExpressionContextScope expressionContextScope() const;
+
+    /**
+     * \copydoc expressionContextScope()
+     */
+    void setExpressionContextScope( const QgsExpressionContextScope& expressionContextScope );
+
+    /**
+     * A unique identifier for this action scope.
+     *
+     * @note Added in QGIS 3.0
+     */
+    QString id() const;
+
+    //! \copydoc id()
+    void setId( const QString& id );
+
+    /**
+     * The title is a human readable and translated string that will be
+     * presented to the user in the properties dialog.
+     *
+     * @note Added in QGIS 3.0
+     */
+    QString title() const;
+    //! \copydoc title()
+    void setTitle( const QString& title );
+
+    /**
+     * The description should be a longer description of where actions in this scope
+     * are available. It is not necessary to list the available expression variables
+     * in here, they are extracted automatically from the expressionContextScope().
+     *
+     * @note Added in QGIS 3.0
+     */
+    QString description() const;
+    //! \copydoc description()
+    void setDescription( const QString& description );
+
+    /**
+     * Returns if this scope is valid.
+     *
+     * @note Added in QGIS 3.0
+     */
+    bool isValid() const;
+};

--- a/python/core/qgsactionscoperegistry.sip
+++ b/python/core/qgsactionscoperegistry.sip
@@ -1,0 +1,74 @@
+/***************************************************************************
+  qgsactionscoperegistry.h - QgsActionScopeRegistry
+
+ ---------------------
+ begin                : 1.11.2016
+ copyright            : (C) 2016 by Matthias Kuhn
+ email                : matthias@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+
+/** \ingroup core
+ * The action scope registry is an application wide registry that
+ * contains a list of available action scopes.
+ * Some scopes are available by default, additional ones can be registered
+ * at runtime by plugins or custom applications.
+ *
+ * To get access use the QgsApplication:
+ *
+ * ```
+ * QgsApplication::actionScopeRegistry()
+ * ```
+ *
+ * @note Added in QGIS 3.0
+ */
+class QgsActionScopeRegistry : QObject
+{
+%TypeHeaderCode
+#include "qgsactionscoperegistry.h"
+%End
+
+  public:
+    explicit QgsActionScopeRegistry( QObject* parent = nullptr );
+
+    /**
+     * Get all registered action scopes.
+     */
+    QSet<QgsActionScope> actionScopes() const;
+
+    /**
+     * Register an additional action scope.
+     *
+     * @note Added in QGIS 3.0
+     */
+    void registerActionScope( const QgsActionScope& actionScope );
+
+    /**
+     * Unregister an additional action scope.
+     *
+     * @note Added in QGIS 3.0
+     */
+    void unregisterActionScope( const QgsActionScope& actionScope );
+
+    /**
+     * Get an action scope by its id.
+     *
+     * @note Added in QGIS 3.0
+     */
+    QgsActionScope actionScope( const QString& id );
+
+  signals:
+    /**
+     * Emitted whenever a new action scope is registered or an action scope
+     * is unregistered.
+     *
+     * @note Added in QGIS 3.0
+     */
+    void actionScopesChanged();
+};

--- a/python/core/qgsactionscoperegistry.sip
+++ b/python/core/qgsactionscoperegistry.sip
@@ -35,10 +35,20 @@ class QgsActionScopeRegistry : QObject
 %End
 
   public:
+    /**
+     * Create a new QgsActionScopeRegistry.
+     * QGIS already creates a central registry. You will normally
+     * want to use QgsApplication::actionScopeRegistry() to get acess
+     * to that one instead.
+     *
+     * @note Added in QGIS 3.0
+     */
     explicit QgsActionScopeRegistry( QObject* parent = nullptr );
 
     /**
      * Get all registered action scopes.
+     *
+     * @note Added in QGIS 3.0
      */
     QSet<QgsActionScope> actionScopes() const;
 

--- a/python/core/qgsapplication.sip
+++ b/python/core/qgsapplication.sip
@@ -381,7 +381,7 @@ static void qtgui_UpdatePyArgv(PyObject *argvlist, int argc, char **argv)
     /**
      * Returns the action scope registry.
      *
-     * @Note Added in QGIS 3.0
+     * @note Added in QGIS 3.0
      */
     static QgsActionScopeRegistry* actionScopeRegistry();
 

--- a/python/core/qgsapplication.sip
+++ b/python/core/qgsapplication.sip
@@ -378,6 +378,12 @@ static void qtgui_UpdatePyArgv(PyObject *argvlist, int argc, char **argv)
     //dummy method to workaround sip generation issue issue
     bool x11EventFilter ( XEvent * event );
 %End
+    /**
+     * Returns the action scope registry.
+     *
+     * @Note Added in QGIS 3.0
+     */
+    static QgsActionScopeRegistry* actionScopeRegistry();
 
   public slots:
 

--- a/python/gui/attributetable/qgsattributetablemodel.sip
+++ b/python/gui/attributetable/qgsattributetablemodel.sip
@@ -126,7 +126,7 @@ class QgsAttributeTableModel : QAbstractTableModel
     /**
      * Execute an action
      */
-    void executeAction( int action, const QModelIndex &idx ) const;
+    void executeAction( const QString& action, const QModelIndex &idx ) const;
 
     /**
      * Execute a QgsMapLayerAction

--- a/python/gui/attributetable/qgsdualview.sip
+++ b/python/gui/attributetable/qgsdualview.sip
@@ -229,7 +229,7 @@ class QgsAttributeTableAction : QAction
 %End
 
   public:
-    QgsAttributeTableAction( const QString &name, QgsDualView *dualView, int action, const QModelIndex &fieldIdx );
+    QgsAttributeTableAction( const QString &name, QgsDualView *dualView, const QString& action, const QModelIndex &fieldIdx );
 
   public slots:
     void execute();

--- a/python/gui/attributetable/qgsdualview.sip
+++ b/python/gui/attributetable/qgsdualview.sip
@@ -229,7 +229,7 @@ class QgsAttributeTableAction : QAction
 %End
 
   public:
-    QgsAttributeTableAction( const QString &name, QgsDualView *dualView, const QString& action, const QModelIndex &fieldIdx );
+    QgsAttributeTableAction( const QString& name, QgsDualView* dualView, const QUuid& action, const QModelIndex& fieldIdx );
 
   public slots:
     void execute();

--- a/python/gui/qgsactionmenu.sip
+++ b/python/gui/qgsactionmenu.sip
@@ -19,13 +19,11 @@ class QgsActionMenu : QMenu
     struct ActionData
     {
       ActionData();
-
-      ActionData( int actionId, QgsFeatureId featureId, QgsMapLayer* mapLayer );
-
+      ActionData( const QgsAction& action, QgsFeatureId featureId, QgsMapLayer* mapLayer );
       ActionData( QgsMapLayerAction* action, QgsFeatureId featureId, QgsMapLayer* mapLayer );
 
       QgsActionMenu::ActionType actionType;
-
+      QVariant actionData;
       QgsFeatureId featureId;
       QgsMapLayer* mapLayer;
     };
@@ -38,7 +36,7 @@ class QgsActionMenu : QMenu
      *                 for the lifetime of this object.
      * @param parent   The usual QWidget parent.
      */
-    explicit QgsActionMenu( QgsVectorLayer* layer, const QgsFeature *feature, QWidget *parent /TransferThis/ = 0 );
+    explicit QgsActionMenu( QgsVectorLayer* layer, const QgsFeature& feature, const QString& actionScope, QWidget *parent /TransferThis/ = nullptr );
 
     /**
      * Constructs a new QgsActionMenu
@@ -47,7 +45,7 @@ class QgsActionMenu : QMenu
      * @param fid      The feature id of the feature for which this action will be run.
      * @param parent   The usual QWidget parent.
      */
-    explicit QgsActionMenu( QgsVectorLayer *layer, const QgsFeatureId fid, QWidget *parent /TransferThis/ = 0 );
+    explicit QgsActionMenu( QgsVectorLayer *layer, const QgsFeatureId fid, const QString& actionScope, QWidget *parent /TransferThis/ = nullptr );
 
     /**
      * Destructor
@@ -60,7 +58,7 @@ class QgsActionMenu : QMenu
      * @param feature  A feature. Will not take ownership. It's the callers responsibility to keep the feature
      *                 as long as the menu is displayed and the action is running.
      */
-    void setFeature( QgsFeature* feature );
+    void setFeature( const QgsFeature& feature );
 
   signals:
     void reinit();

--- a/python/gui/qgsactionmenu.sip
+++ b/python/gui/qgsactionmenu.sip
@@ -35,6 +35,7 @@ class QgsActionMenu : QMenu
      * @param feature  The feature that this action will be run upon. Make sure that this feature is available
      *                 for the lifetime of this object.
      * @param parent   The usual QWidget parent.
+     * @param actionScope The action scope this menu will run in
      */
     explicit QgsActionMenu( QgsVectorLayer* layer, const QgsFeature& feature, const QString& actionScope, QWidget *parent /TransferThis/ = nullptr );
 
@@ -44,6 +45,7 @@ class QgsActionMenu : QMenu
      * @param layer    The layer that this action will be run upon.
      * @param fid      The feature id of the feature for which this action will be run.
      * @param parent   The usual QWidget parent.
+     * @param actionScope The action scope this menu will run in
      */
     explicit QgsActionMenu( QgsVectorLayer *layer, const QgsFeatureId fid, const QString& actionScope, QWidget *parent /TransferThis/ = nullptr );
 

--- a/src/app/gps/qgsgpsinformationwidget.cpp
+++ b/src/app/gps/qgsgpsinformationwidget.cpp
@@ -831,7 +831,7 @@ void QgsGPSInformationWidget::on_mBtnCloseFeature_clicked()
     g.fromWkb( buf, size );
     f->setGeometry( g );
 
-    QgsFeatureAction action( tr( "Feature added" ), *f, vlayer, -1, -1, this );
+    QgsFeatureAction action( tr( "Feature added" ), *f, vlayer, QString(), -1, this );
     if ( action.addFeature() )
     {
       if ( mCbxAutoCommit->isChecked() )
@@ -941,7 +941,7 @@ void QgsGPSInformationWidget::on_mBtnCloseFeature_clicked()
       return; //unknown wkbtype
     } // layerWKBType == QgsWkbTypes::Polygon
 
-    QgsFeatureAction action( tr( "Feature added" ), *f, vlayer, -1, -1, this );
+    QgsFeatureAction action( tr( "Feature added" ), *f, vlayer, QString(), -1, this );
     if ( action.addFeature() )
     {
       if ( mCbxAutoCommit->isChecked() )

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -5787,7 +5787,7 @@ void QgisApp::refreshFeatureActions()
   if ( !vlayer )
     return;
 
-  QList<QgsAction> actions = vlayer->actions()->listActions( QStringLiteral( "Canvas" ) );
+  QList<QgsAction> actions = vlayer->actions()->actions( QStringLiteral( "Canvas" ) );
   Q_FOREACH ( const QgsAction& action, actions )
   {
     QAction* qAction = new QAction( action.icon(), action.shortTitle(), mFeatureActionMenu );
@@ -10592,7 +10592,7 @@ void QgisApp::activateDeactivateLayerRelatedActions( QgsMapLayer* layer )
 
     bool isEditable = vlayer->isEditable();
     bool layerHasSelection = vlayer->selectedFeatureCount() > 0;
-    bool layerHasActions = !vlayer->actions()->listActions( QStringLiteral( "Canvas" ) ).isEmpty() || !QgsMapLayerActionRegistry::instance()->mapLayerActions( vlayer ).isEmpty();
+    bool layerHasActions = !vlayer->actions()->actions( QStringLiteral( "Canvas" ) ).isEmpty() || !QgsMapLayerActionRegistry::instance()->mapLayerActions( vlayer ).isEmpty();
 
     mActionLocalHistogramStretch->setEnabled( false );
     mActionFullHistogramStretch->setEnabled( false );
@@ -10873,7 +10873,7 @@ void QgisApp::refreshActionFeatureAction()
   if ( !vlayer )
     return;
 
-  bool layerHasActions = !vlayer->actions()->listActions( QStringLiteral( "Canvas" ) ).isEmpty() || !QgsMapLayerActionRegistry::instance()->mapLayerActions( vlayer ).isEmpty();
+  bool layerHasActions = !vlayer->actions()->actions( QStringLiteral( "Canvas" ) ).isEmpty() || !QgsMapLayerActionRegistry::instance()->mapLayerActions( vlayer ).isEmpty();
   mActionFeatureAction->setEnabled( layerHasActions );
 }
 

--- a/src/app/qgisappinterface.cpp
+++ b/src/app/qgisappinterface.cpp
@@ -633,7 +633,7 @@ bool QgisAppInterface::openFeatureForm( QgsVectorLayer *vlayer, QgsFeature &f, b
   if ( !vlayer )
     return false;
 
-  QgsFeatureAction action( tr( "Attributes changed" ), f, vlayer, -1, -1, QgisApp::instance() );
+  QgsFeatureAction action( tr( "Attributes changed" ), f, vlayer, QString(), -1, QgisApp::instance() );
   if ( vlayer->isEditable() )
   {
     return action.editFeature( showModal );

--- a/src/app/qgsattributeactiondialog.cpp
+++ b/src/app/qgsattributeactiondialog.cpp
@@ -67,7 +67,7 @@ void QgsAttributeActionDialog::init( const QgsActionManager& actions, const QgsA
 
   int i = 0;
   // Populate with our actions.
-  Q_FOREACH ( const QgsAction& action, actions.listActions() )
+  Q_FOREACH ( const QgsAction& action, actions.actions() )
   {
     insertRow( i++, action );
   }

--- a/src/app/qgsattributeactiondialog.h
+++ b/src/app/qgsattributeactiondialog.h
@@ -42,7 +42,7 @@ class APP_EXPORT QgsAttributeActionDialog: public QWidget, private Ui::QgsAttrib
       ShortTitle,
       ActionText,
       Capture,
-      ShowInAttributeTable
+      ActionScopes
     };
 
   public:
@@ -70,7 +70,7 @@ class APP_EXPORT QgsAttributeActionDialog: public QWidget, private Ui::QgsAttrib
 
   private:
     void insertRow( int row, const QgsAction& action );
-    void insertRow( int row, QgsAction::ActionType type, const QString& name, const QString& actionText, const QString& iconPath, bool capture );
+    void insertRow( int row, QgsAction::ActionType type, const QString& name, const QString& actionText, const QString& iconPath, bool capture , const QString& shortTitle, const QSet<QString>& actionScopes );
     void swapRows( int row1, int row2 );
     QgsAction rowToAction( int row ) const;
 

--- a/src/app/qgsattributeactionpropertiesdialog.h
+++ b/src/app/qgsattributeactionpropertiesdialog.h
@@ -22,12 +22,12 @@
 
 #include <QDialog>
 
-class QgsAttributeActionPropertiesDialog: public QDialog, private Ui::QgsAttributeActionPropertiesDialogBase
+class QgsAttributeActionPropertiesDialog: public QDialog, private Ui::QgsAttributeActionPropertiesDialogBase, public QgsExpressionContextGenerator
 {
     Q_OBJECT
 
   public:
-    QgsAttributeActionPropertiesDialog( QgsAction::ActionType type, const QString& description, const QString& shortTitle, const QString& iconPath, const QString& actionText, bool capture, bool showInAttributeTable, QgsVectorLayer* layer, QWidget* parent = nullptr );
+    QgsAttributeActionPropertiesDialog( QgsAction::ActionType type, const QString& description, const QString& shortTitle, const QString& iconPath, const QString& actionText, bool capture, QSet<QString> actionScopes, QgsVectorLayer* layer, QWidget* parent = nullptr );
 
     QgsAttributeActionPropertiesDialog( QgsVectorLayer* layer, QWidget* parent = nullptr );
 
@@ -41,9 +41,11 @@ class QgsAttributeActionPropertiesDialog: public QDialog, private Ui::QgsAttribu
 
     QString actionText() const;
 
-    bool showInAttributeTable() const;
+    QSet<QString> actionScopes() const;
 
     bool capture() const;
+
+    virtual QgsExpressionContext createExpressionContext() const override;
 
   private slots:
     void browse();
@@ -52,7 +54,10 @@ class QgsAttributeActionPropertiesDialog: public QDialog, private Ui::QgsAttribu
     void updateButtons();
 
   private:
+    void init( const QSet<QString>& actionScopes );
+
     QgsVectorLayer* mLayer;
+    QList<QCheckBox*> mActionScopeCheckBoxes;
 };
 
 #endif // QGSATTRIBUTEACTIONPROPERTIESDIALOG_H

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -309,7 +309,7 @@ QgsAttributeTableDialog::QgsAttributeTableDialog( QgsVectorLayer *theLayer, QWid
     mActionSearchForm->setToolTip( tr( "Search is not supported when using custom UI forms" ) );
   }
 
-  QList<QgsAction> actions = mLayer->actions()->listActions( QStringLiteral( "Layer" ) );
+  QList<QgsAction> actions = mLayer->actions()->actions( QStringLiteral( "Layer" ) );
 
   if ( actions.isEmpty() )
   {

--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -309,7 +309,7 @@ QgsAttributeTableDialog::QgsAttributeTableDialog( QgsVectorLayer *theLayer, QWid
     mActionSearchForm->setToolTip( tr( "Search is not supported when using custom UI forms" ) );
   }
 
-  QList<QgsAction> actions = mLayer->actions()->listActions( QStringLiteral( "AttributeTable" ) );
+  QList<QgsAction> actions = mLayer->actions()->listActions( QStringLiteral( "Layer" ) );
 
   if ( actions.isEmpty() )
   {

--- a/src/app/qgsattributetabledialog.h
+++ b/src/app/qgsattributetabledialog.h
@@ -181,6 +181,7 @@ class APP_EXPORT QgsAttributeTableDialog : public QDialog, private Ui::QgsAttrib
     /* replace the search widget with a new one */
     void replaceSearchWidget( QWidget* oldw, QWidget* neww );
 
+    void layerActionTriggered();
   signals:
 
     /**

--- a/src/app/qgsfeatureaction.cpp
+++ b/src/app/qgsfeatureaction.cpp
@@ -66,7 +66,7 @@ QgsAttributeDialog *QgsFeatureAction::newDialog( bool cloneFeature )
   QgsAttributeDialog *dialog = new QgsAttributeDialog( mLayer, f, cloneFeature, parentWidget(), true, context );
   dialog->setWindowFlags( dialog->windowFlags() | Qt::Tool );
 
-  QList<QgsAction> actions = mLayer->actions()->listActions( QStringLiteral( "Feature" ) );
+  QList<QgsAction> actions = mLayer->actions()->actions( QStringLiteral( "Feature" ) );
   if ( !actions.isEmpty() )
   {
     dialog->setContextMenuPolicy( Qt::ActionsContextMenu );

--- a/src/app/qgsfeatureaction.cpp
+++ b/src/app/qgsfeatureaction.cpp
@@ -32,7 +32,7 @@
 #include <QPushButton>
 #include <QSettings>
 
-QgsFeatureAction::QgsFeatureAction( const QString &name, QgsFeature &f, QgsVectorLayer *layer, const QString& actionId, int defaultAttr, QObject *parent )
+QgsFeatureAction::QgsFeatureAction( const QString &name, QgsFeature &f, QgsVectorLayer *layer, const QUuid& actionId, int defaultAttr, QObject *parent )
     : QAction( name, parent )
     , mLayer( layer )
     , mFeature( &f )

--- a/src/app/qgsfeatureaction.cpp
+++ b/src/app/qgsfeatureaction.cpp
@@ -66,7 +66,7 @@ QgsAttributeDialog *QgsFeatureAction::newDialog( bool cloneFeature )
   QgsAttributeDialog *dialog = new QgsAttributeDialog( mLayer, f, cloneFeature, parentWidget(), true, context );
   dialog->setWindowFlags( dialog->windowFlags() | Qt::Tool );
 
-  QList<QgsAction> actions = mLayer->actions()->listActions();
+  QList<QgsAction> actions = mLayer->actions()->listActions( QStringLiteral( "Feature" ) );
   if ( !actions.isEmpty() )
   {
     dialog->setContextMenuPolicy( Qt::ActionsContextMenu );

--- a/src/app/qgsfeatureaction.h
+++ b/src/app/qgsfeatureaction.h
@@ -33,7 +33,7 @@ class APP_EXPORT QgsFeatureAction : public QAction
     Q_OBJECT
 
   public:
-    QgsFeatureAction( const QString &name, QgsFeature &f, QgsVectorLayer *vl, int action = -1, int defaultAttr = -1, QObject *parent = nullptr );
+    QgsFeatureAction( const QString &name, QgsFeature &f, QgsVectorLayer *vl, const QString& actionId = QString(), int defaultAttr = -1, QObject *parent = nullptr );
 
   public slots:
     void execute();
@@ -59,7 +59,7 @@ class APP_EXPORT QgsFeatureAction : public QAction
 
     QgsVectorLayer* mLayer;
     QgsFeature* mFeature;
-    int mAction;
+    QString mActionId;
     int mIdx;
 
     bool mFeatureSaved;

--- a/src/app/qgsfeatureaction.h
+++ b/src/app/qgsfeatureaction.h
@@ -22,6 +22,7 @@
 #include <QList>
 #include <QPair>
 #include <QAction>
+#include <QUuid>
 
 class QgsIdentifyResultsDialog;
 class QgsVectorLayer;
@@ -33,7 +34,7 @@ class APP_EXPORT QgsFeatureAction : public QAction
     Q_OBJECT
 
   public:
-    QgsFeatureAction( const QString &name, QgsFeature &f, QgsVectorLayer *vl, const QString& actionId = QString(), int defaultAttr = -1, QObject *parent = nullptr );
+    QgsFeatureAction( const QString &name, QgsFeature &f, QgsVectorLayer *vl, const QUuid& actionId = QString(), int defaultAttr = -1, QObject *parent = nullptr );
 
   public slots:
     void execute();
@@ -59,7 +60,7 @@ class APP_EXPORT QgsFeatureAction : public QAction
 
     QgsVectorLayer* mLayer;
     QgsFeature* mFeature;
-    QString mActionId;
+    QUuid mActionId;
     int mIdx;
 
     bool mFeatureSaved;

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -428,7 +428,7 @@ void QgsIdentifyResultsDialog::addFeature( QgsVectorLayer *vlayer, const QgsFeat
 
   //get valid QgsMapLayerActions for this layer
   QList< QgsMapLayerAction* > registeredActions = QgsMapLayerActionRegistry::instance()->mapLayerActions( vlayer );
-  QList<QgsAction> actions = vlayer->actions()->listActions( QStringLiteral( "AttributeTableRow" ) );
+  QList<QgsAction> actions = vlayer->actions()->listActions( QStringLiteral( "Feature" ) );
 
   if ( !vlayer->fields().isEmpty() || !actions.isEmpty() || !registeredActions.isEmpty() )
   {
@@ -1040,7 +1040,7 @@ void QgsIdentifyResultsDialog::contextMenuEvent( QContextMenuEvent* event )
 
   if ( featItem && vlayer )
   {
-    QList<QgsAction> actions = vlayer->actions()->listActions( QStringLiteral( "FieldSpecific" ) );
+    QList<QgsAction> actions = vlayer->actions()->listActions( QStringLiteral( "Field" ) );
     if ( !actions.isEmpty() )
     {
       mActionPopup->addSeparator();

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -428,7 +428,7 @@ void QgsIdentifyResultsDialog::addFeature( QgsVectorLayer *vlayer, const QgsFeat
 
   //get valid QgsMapLayerActions for this layer
   QList< QgsMapLayerAction* > registeredActions = QgsMapLayerActionRegistry::instance()->mapLayerActions( vlayer );
-  QList<QgsAction> actions = vlayer->actions()->listActions( QStringLiteral( "Feature" ) );
+  QList<QgsAction> actions = vlayer->actions()->actions( QStringLiteral( "Feature" ) );
 
   if ( !vlayer->fields().isEmpty() || !actions.isEmpty() || !registeredActions.isEmpty() )
   {
@@ -1040,7 +1040,7 @@ void QgsIdentifyResultsDialog::contextMenuEvent( QContextMenuEvent* event )
 
   if ( featItem && vlayer )
   {
-    QList<QgsAction> actions = vlayer->actions()->listActions( QStringLiteral( "Field" ) );
+    QList<QgsAction> actions = vlayer->actions()->actions( QStringLiteral( "Field" ) );
     if ( !actions.isEmpty() )
     {
       mActionPopup->addSeparator();

--- a/src/app/qgsidentifyresultsdialog.h
+++ b/src/app/qgsidentifyresultsdialog.h
@@ -249,7 +249,7 @@ class APP_EXPORT QgsIdentifyResultsDialog: public QDialog, private Ui::QgsIdenti
 
     void highlightFeature( QTreeWidgetItem *item );
 
-    void doAction( QTreeWidgetItem *item, int action );
+    void doAction( QTreeWidgetItem *item, const QString& action );
 
     void doMapLayerAction( QTreeWidgetItem *item, QgsMapLayerAction* action );
 

--- a/src/app/qgsmaptooladdfeature.cpp
+++ b/src/app/qgsmaptooladdfeature.cpp
@@ -49,7 +49,7 @@ QgsMapToolAddFeature::~QgsMapToolAddFeature()
 
 bool QgsMapToolAddFeature::addFeature( QgsVectorLayer *vlayer, QgsFeature *f, bool showModal )
 {
-  QgsFeatureAction *action = new QgsFeatureAction( tr( "add feature" ), *f, vlayer, -1, -1, this );
+  QgsFeatureAction *action = new QgsFeatureAction( tr( "add feature" ), *f, vlayer, QString(), -1, this );
   bool res = action->addFeature( QgsAttributeMap(), showModal );
   if ( showModal )
     delete action;

--- a/src/app/qgsmaptoolfeatureaction.cpp
+++ b/src/app/qgsmaptoolfeatureaction.cpp
@@ -73,7 +73,7 @@ void QgsMapToolFeatureAction::canvasReleaseEvent( QgsMapMouseEvent* e )
   }
 
   QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( layer );
-  if ( vlayer->actions()->size() == 0 && QgsMapLayerActionRegistry::instance()->mapLayerActions( vlayer ).isEmpty() )
+  if ( vlayer->actions()->listActions( QStringLiteral( "Canvas" ) ).isEmpty() && QgsMapLayerActionRegistry::instance()->mapLayerActions( vlayer ).isEmpty() )
   {
     emit messageEmitted( tr( "The active vector layer has no defined actions" ), QgsMessageBar::INFO );
     return;
@@ -100,28 +100,22 @@ bool QgsMapToolFeatureAction::doAction( QgsVectorLayer *layer, int x, int y )
 
   QgsPoint point = mCanvas->getCoordinateTransform()->toMapCoordinates( x, y );
 
-  QgsFeatureList featList;
+  QgsRectangle r;
+
+  // create the search rectangle
+  double searchRadius = searchRadiusMU( mCanvas );
+
+  r.setXMinimum( point.x() - searchRadius );
+  r.setXMaximum( point.x() + searchRadius );
+  r.setYMinimum( point.y() - searchRadius );
+  r.setYMaximum( point.y() + searchRadius );
 
   // toLayerCoordinates will throw an exception for an 'invalid' point.
   // For example, if you project a world map onto a globe using EPSG 2163
   // and then click somewhere off the globe, an exception will be thrown.
   try
   {
-    // create the search rectangle
-    double searchRadius = searchRadiusMU( mCanvas );
-
-    QgsRectangle r;
-    r.setXMinimum( point.x() - searchRadius );
-    r.setXMaximum( point.x() + searchRadius );
-    r.setYMinimum( point.y() - searchRadius );
-    r.setYMaximum( point.y() + searchRadius );
-
     r = toLayerCoordinates( layer, r );
-
-    QgsFeatureIterator fit = layer->getFeatures( QgsFeatureRequest().setFilterRect( r ).setFlags( QgsFeatureRequest::ExactIntersect ) );
-    QgsFeature f;
-    while ( fit.nextFeature( f ) )
-      featList << QgsFeature( f );
   }
   catch ( QgsCsException & cse )
   {
@@ -130,12 +124,13 @@ bool QgsMapToolFeatureAction::doAction( QgsVectorLayer *layer, int x, int y )
     QgsDebugMsg( QString( "Caught CRS exception %1" ).arg( cse.what() ) );
   }
 
-  if ( featList.isEmpty() )
-    return false;
+  QgsAction defaultAction = layer->actions()->defaultAction( QStringLiteral( "Canvas" ) );
 
-  Q_FOREACH ( const QgsFeature& feat, featList )
+  QgsFeatureIterator fit = layer->getFeatures( QgsFeatureRequest().setFilterRect( r ).setFlags( QgsFeatureRequest::ExactIntersect ) );
+  QgsFeature feat;
+  while ( fit.nextFeature( feat ) )
   {
-    if ( layer->actions()->defaultAction() >= 0 )
+    if ( defaultAction.isValid() )
     {
       // define custom substitutions: layer id and clicked coords
       QgsExpressionContext context;
@@ -145,10 +140,10 @@ bool QgsMapToolFeatureAction::doAction( QgsVectorLayer *layer, int x, int y )
       QgsExpressionContextScope* actionScope = new QgsExpressionContextScope();
       actionScope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "click_x" ), point.x(), true ) );
       actionScope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "click_y" ), point.y(), true ) );
+      actionScope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "action_scope" ), QStringLiteral( "Canvas" ), true ) );
       context << actionScope;
 
-      int actionIdx = layer->actions()->defaultAction();
-      layer->actions()->doAction( actionIdx, feat, context );
+      defaultAction.run( layer, feat, context );
     }
     else
     {

--- a/src/app/qgsmaptoolfeatureaction.cpp
+++ b/src/app/qgsmaptoolfeatureaction.cpp
@@ -73,7 +73,7 @@ void QgsMapToolFeatureAction::canvasReleaseEvent( QgsMapMouseEvent* e )
   }
 
   QgsVectorLayer *vlayer = qobject_cast<QgsVectorLayer *>( layer );
-  if ( vlayer->actions()->listActions( QStringLiteral( "Canvas" ) ).isEmpty() && QgsMapLayerActionRegistry::instance()->mapLayerActions( vlayer ).isEmpty() )
+  if ( vlayer->actions()->actions( QStringLiteral( "Canvas" ) ).isEmpty() && QgsMapLayerActionRegistry::instance()->mapLayerActions( vlayer ).isEmpty() )
   {
     emit messageEmitted( tr( "The active vector layer has no defined actions" ), QgsMessageBar::INFO );
     return;

--- a/src/core/CMakeLists.txt
+++ b/src/core/CMakeLists.txt
@@ -81,6 +81,8 @@ SET(QGIS_CORE_SRCS
   qgis.cpp
   qgsapplication.cpp
   qgsaction.cpp
+  qgsactionscope.cpp
+  qgsactionscoperegistry.cpp
   qgsactionmanager.cpp
   qgsaggregatecalculator.cpp
   qgsattributetableconfig.cpp
@@ -450,6 +452,7 @@ ENDIF(NOT MSVC)
 
 SET(QGIS_CORE_MOC_HDRS
   qgsapplication.h
+  qgsactionscoperegistry.h
   qgsbrowsermodel.h
   qgscontexthelp.h
   qgscoordinatereferencesystem.h
@@ -605,6 +608,7 @@ SET(QGIS_CORE_HDRS
 
   qgis.h
   qgsaction.h
+  qgsactionscope.h
   qgsactionmanager.h
   qgsaggregatecalculator.h
   qgsannotation.h

--- a/src/core/qgsaction.cpp
+++ b/src/core/qgsaction.cpp
@@ -91,3 +91,56 @@ void QgsAction::setActionScopes( const QSet<QString>& actionScopes )
 {
   mActionScopes = actionScopes;
 }
+
+void QgsAction::readXml( const QDomNode& actionNode )
+{
+  QDomElement actionElement = actionNode.toElement();
+  QDomNodeList actionScopeNodes = actionElement.elementsByTagName( "actionScope" );
+
+  if ( actionScopeNodes.isEmpty() )
+  {
+    mActionScopes
+    << QStringLiteral( "Canvas" )
+    << QStringLiteral( "Field" )
+    << QStringLiteral( "Feature" );
+  }
+  else
+  {
+    for ( int j = 0; j < actionScopeNodes.length(); ++j )
+    {
+      QDomElement actionScopeElem = actionScopeNodes.item( j ).toElement();
+      mActionScopes << actionScopeElem.attribute( "id" );
+    }
+  }
+
+  mType = static_cast< QgsAction::ActionType >( actionElement.attributeNode( QStringLiteral( "type" ) ).value().toInt() );
+  mDescription = actionElement.attributeNode( QStringLiteral( "name" ) ).value();
+  mCommand = actionElement.attributeNode( QStringLiteral( "action" ) ).value();
+  mIcon = actionElement.attributeNode( QStringLiteral( "icon" ) ).value();
+  mCaptureOutput = actionElement.attributeNode( QStringLiteral( "capture" ) ).value().toInt() != 0;
+  mShortTitle = actionElement.attributeNode( QStringLiteral( "shortTitle" ) ).value();
+  mId = QUuid( actionElement.attributeNode( QStringLiteral( "id" ) ).value() );
+  if ( mId.isNull() )
+    mId = QUuid::createUuid();
+}
+
+void QgsAction::writeXml( QDomNode& actionsNode ) const
+{
+  QDomElement actionSetting = actionsNode.ownerDocument().createElement( QStringLiteral( "actionsetting" ) );
+  actionSetting.setAttribute( QStringLiteral( "type" ), mType );
+  actionSetting.setAttribute( QStringLiteral( "name" ), mDescription );
+  actionSetting.setAttribute( QStringLiteral( "shortTitle" ), mShortTitle );
+  actionSetting.setAttribute( QStringLiteral( "icon" ), mIcon );
+  actionSetting.setAttribute( QStringLiteral( "action" ), mCommand );
+  actionSetting.setAttribute( QStringLiteral( "capture" ), mCaptureOutput );
+  actionSetting.setAttribute( QStringLiteral( "id" ), mId.toString() );
+
+  Q_FOREACH ( const QString& scope, mActionScopes )
+  {
+    QDomElement actionScopeElem = actionsNode.ownerDocument().createElement( "actionScope" );
+    actionScopeElem.setAttribute( "id", scope );
+    actionSetting.appendChild( actionScopeElem );
+  }
+
+  actionsNode.appendChild( actionSetting );
+}

--- a/src/core/qgsaction.cpp
+++ b/src/core/qgsaction.cpp
@@ -16,6 +16,16 @@
 
 #include "qgsaction.h"
 
+#include <QDesktopServices>
+#include <QFileInfo>
+#include <QUrl>
+
+#include "qgspythonrunner.h"
+#include "qgsrunprocess.h"
+#include "qgsexpressioncontext.h"
+#include "qgsvectorlayer.h"
+#include "qgslogger.h"
+
 bool QgsAction::runable() const
 {
   return mType == Generic ||
@@ -29,4 +39,55 @@ bool QgsAction::runable() const
          mType == Unix
 #endif
          ;
+}
+
+void QgsAction::run( QgsVectorLayer* layer, const QgsFeature& feature, const QgsExpressionContext& expressionContext ) const
+{
+  QgsExpressionContext actionContext( expressionContext );
+
+  actionContext << QgsExpressionContextUtils::layerScope( layer );
+  actionContext.setFeature( feature );
+
+  run( actionContext );
+}
+
+void QgsAction::run( const QgsExpressionContext& expressionContext ) const
+{
+  if ( !isValid() )
+  {
+    QgsDebugMsg( "Invalid action cannot be run" );
+    return;
+  }
+
+  QString expandedAction = QgsExpression::replaceExpressionText( mCommand, &expressionContext );
+
+  if ( mType == QgsAction::OpenUrl )
+  {
+    QFileInfo finfo( expandedAction );
+    if ( finfo.exists() && finfo.isFile() )
+      QDesktopServices::openUrl( QUrl::fromLocalFile( expandedAction ) );
+    else
+      QDesktopServices::openUrl( QUrl( expandedAction, QUrl::TolerantMode ) );
+  }
+  else if ( mType == QgsAction::GenericPython )
+  {
+    // TODO: capture output from QgsPythonRunner (like QgsRunProcess does)
+    QgsPythonRunner::run( expandedAction );
+  }
+  else
+  {
+    // The QgsRunProcess instance created by this static function
+    // deletes itself when no longer needed.
+    QgsRunProcess::create( expandedAction, mCaptureOutput );
+  }
+}
+
+QSet<QString> QgsAction::actionScopes() const
+{
+  return mActionScopes;
+}
+
+void QgsAction::setActionScopes( const QSet<QString>& actionScopes )
+{
+  mActionScopes = actionScopes;
 }

--- a/src/core/qgsaction.h
+++ b/src/core/qgsaction.h
@@ -90,8 +90,18 @@ class CORE_EXPORT QgsAction
     //! The short title is used to label user interface elements like buttons
     QString shortTitle() const { return mShortTitle; }
 
+    /**
+     * Returns a unique id for this action.
+     *
+     * @note Added in QGIS 3.0
+     */
     QString id() const { return mShortTitle; }
 
+    /**
+     * Returns true if this action was a default constructed one.
+     *
+     * @note Added in QGIS 3.0
+     */
     bool isValid() const { return !mShortTitle.isNull(); }
 
     //! The path to the icon
@@ -119,12 +129,16 @@ class CORE_EXPORT QgsAction
     bool runable() const;
 
     /**
-     * Run this expression.
+     * Run this action.
+     *
+     * @note Added in QGIS 3.0
      */
     void run( QgsVectorLayer* layer, const QgsFeature& feature, const QgsExpressionContext& expressionContext ) const;
 
     /**
-     * Run this expression.
+     * Run this action.
+     *
+     * @note Added in QGIS 3.0
      */
     void run( const QgsExpressionContext& expressionContext ) const;
 

--- a/src/core/qgsaction.h
+++ b/src/core/qgsaction.h
@@ -20,6 +20,7 @@
 #include <QString>
 #include <QIcon>
 #include <QAction>
+#include <QUuid>
 
 #include "qgsexpressioncontext.h"
 
@@ -53,14 +54,15 @@ class CORE_EXPORT QgsAction
      *
      * @param type          The type of this action
      * @param description   A human readable description string
-     * @param action        The action text. Its interpretation depends on the type
+     * @param command       The action text. Its interpretation depends on the type
      * @param capture       If this is set to true, the output will be captured when an action is run
      */
-    QgsAction( ActionType type, const QString& description, const QString& action, bool capture )
+    QgsAction( ActionType type, const QString& description, const QString& command, bool capture = false )
         : mType( type )
         , mDescription( description )
-        , mCommand( action )
+        , mCommand( command )
         , mCaptureOutput( capture )
+        , mId( QUuid::createUuid() )
     {}
 
     /**
@@ -82,6 +84,7 @@ class CORE_EXPORT QgsAction
         , mCommand( action )
         , mCaptureOutput( capture )
         , mActionScopes( actionScopes )
+        , mId( QUuid::createUuid() )
     {}
 
     //! The name of the action. This may be a longer description.
@@ -95,14 +98,14 @@ class CORE_EXPORT QgsAction
      *
      * @note Added in QGIS 3.0
      */
-    QString id() const { return mShortTitle; }
+    QUuid id() const { return mId; }
 
     /**
      * Returns true if this action was a default constructed one.
      *
      * @note Added in QGIS 3.0
      */
-    bool isValid() const { return !mShortTitle.isNull(); }
+    bool isValid() const { return !mId.isNull(); }
 
     //! The path to the icon
     QString iconPath() const { return mIcon; }
@@ -161,6 +164,22 @@ class CORE_EXPORT QgsAction
      */
     void setActionScopes( const QSet<QString>& actionScopes );
 
+    /**
+     * Reads an XML definition from actionNode
+     * into this object.
+     *
+     * @note Added in QGIS 3.0
+     */
+    void readXml( const QDomNode& actionNode );
+
+    /**
+     * Appends an XML definition for this action as a new
+     * child node to actionsNode.
+     *
+     * @note Added in QGIS 3.0
+     */
+    void writeXml( QDomNode& actionsNode ) const;
+
   private:
     ActionType mType;
     QString mDescription;
@@ -170,6 +189,7 @@ class CORE_EXPORT QgsAction
     bool mCaptureOutput;
     QSet<QString> mActionScopes;
     mutable QSharedPointer<QAction> mAction;
+    QUuid mId;
 };
 
 Q_DECLARE_METATYPE( QgsAction )

--- a/src/core/qgsactionmanager.cpp
+++ b/src/core/qgsactionmanager.cpp
@@ -59,13 +59,27 @@ void QgsActionManager::addAction( const QgsAction& action )
   mActions.append( action );
 }
 
+void QgsActionManager::removeAction( const QUuid& actionId )
+{
+  int i = 0;
+  Q_FOREACH ( const QgsAction& action, mActions )
+  {
+    if ( action.id() == actionId )
+    {
+      mActions.removeAt( i );
+      return;
+    }
+    ++i;
+  }
+}
+
 void QgsActionManager::doAction( const QUuid& actionId, const QgsFeature& feature, int defaultValueIndex )
 {
   QgsExpressionContext context = createExpressionContext();
   QgsExpressionContextScope* actionScope = new QgsExpressionContextScope();
   actionScope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "field_index" ), defaultValueIndex, true ) );
   if ( defaultValueIndex >= 0 && defaultValueIndex < feature.fields().size() )
-    actionScope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "field_name" ), feature.fields().at( defaultValueIndex ), true ) );
+    actionScope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "field_name" ), feature.fields().at( defaultValueIndex ).name(), true ) );
   actionScope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "field_value" ), feature.attribute( defaultValueIndex ), true ) );
   context << actionScope;
   doAction( actionId, feature, context );
@@ -97,7 +111,7 @@ void QgsActionManager::clearActions()
   mActions.clear();
 }
 
-QList<QgsAction> QgsActionManager::listActions( const QString& actionScope ) const
+QList<QgsAction> QgsActionManager::actions( const QString& actionScope ) const
 {
   if ( actionScope.isNull() )
     return mActions;

--- a/src/core/qgsactionmanager.h
+++ b/src/core/qgsactionmanager.h
@@ -51,7 +51,6 @@ class CORE_EXPORT QgsActionManager
     //! Constructor
     QgsActionManager( QgsVectorLayer *layer )
         : mLayer( layer )
-        , mDefaultAction( -1 )
     {}
 
     /** Add an action with the given name and action details.
@@ -142,8 +141,6 @@ class CORE_EXPORT QgsActionManager
     void runAction( const QgsAction &action );
 
     QVariantMap mDefaultActions;
-
-    int mDefaultAction;
 
     QgsExpressionContext createExpressionContext() const;
 };

--- a/src/core/qgsactionmanager.h
+++ b/src/core/qgsactionmanager.h
@@ -74,6 +74,13 @@ class CORE_EXPORT QgsActionManager
      */
     void addAction( const QgsAction& action );
 
+    /**
+     * Remove an action by its id.
+     *
+     * @note Added in QGIS 3.0
+     */
+    void removeAction( const QUuid& actionId );
+
     /** Does the given values. defaultValueIndex is the index of the
      *  field to be used if the action has a $currfield placeholder.
      *  @note available in python bindings as doActionFeature
@@ -94,8 +101,10 @@ class CORE_EXPORT QgsActionManager
     /**
      * Return a list of actions that are available in the given action scope.
      * If no action scope is provided, all actions will be returned.
+     *
+     * @note Added in QGIS 3.0
      */
-    QList<QgsAction> listActions( const QString& actionScope = QString() ) const;
+    QList<QgsAction> actions( const QString& actionScope = QString() ) const;
 
     //! Return the layer
     QgsVectorLayer* layer() const { return mLayer; }

--- a/src/core/qgsactionmanager.h
+++ b/src/core/qgsactionmanager.h
@@ -84,7 +84,7 @@ class CORE_EXPORT QgsActionManager
 
     /** Does the action using the expression engine to replace any embedded expressions
      * in the action definition.
-     * @param index action index
+     * @param actionId action id
      * @param feature feature to run action for
      * @param context expression context to evalute expressions under
      */

--- a/src/core/qgsactionmanager.h
+++ b/src/core/qgsactionmanager.h
@@ -59,7 +59,7 @@ class CORE_EXPORT QgsActionManager
      * any stdout from the process will be captured and displayed in a
      * dialog box.
      */
-    void addAction( QgsAction::ActionType type, const QString& name, const QString& action, bool capture = false );
+    QUuid addAction( QgsAction::ActionType type, const QString& name, const QString& command, bool capture = false );
 
     /** Add an action with the given name and action details.
      * Will happily have duplicate names and actions. If
@@ -67,7 +67,7 @@ class CORE_EXPORT QgsActionManager
      * any stdout from the process will be captured and displayed in a
      * dialog box.
      */
-    void addAction( QgsAction::ActionType type, const QString& name, const QString& action, const QString& icon, bool capture = false );
+    QUuid addAction( QgsAction::ActionType type, const QString& name, const QString& command, const QString& icon, bool capture = false );
 
     /**
      * Add a new action to this list.
@@ -78,9 +78,7 @@ class CORE_EXPORT QgsActionManager
      *  field to be used if the action has a $currfield placeholder.
      *  @note available in python bindings as doActionFeature
      */
-    void doAction( const QString& actionId,
-                   const QgsFeature &feature,
-                   int defaultValueIndex = 0 );
+    void doAction( const QUuid& actionId, const QgsFeature &feature, int defaultValueIndex = 0 );
 
     /** Does the action using the expression engine to replace any embedded expressions
      * in the action definition.
@@ -88,9 +86,7 @@ class CORE_EXPORT QgsActionManager
      * @param feature feature to run action for
      * @param context expression context to evalute expressions under
      */
-    void doAction( const QString& actionId,
-                   const QgsFeature& feature,
-                   const QgsExpressionContext& context );
+    void doAction( const QUuid& actionId, const QgsFeature& feature, const QgsExpressionContext& context );
 
     //! Removes all actions
     void clearActions();
@@ -105,7 +101,7 @@ class CORE_EXPORT QgsActionManager
     QgsVectorLayer* layer() const { return mLayer; }
 
     //! Writes the actions out in XML format
-    bool writeXml( QDomNode& layer_node, QDomDocument& doc ) const;
+    bool writeXml( QDomNode& layer_node ) const;
 
     //! Reads the actions in in XML format
     bool readXml( const QDomNode& layer_node );
@@ -115,7 +111,7 @@ class CORE_EXPORT QgsActionManager
      *
      * @note Added in QGIS 3.0
      */
-    QgsAction action( const QString& id );
+    QgsAction action( const QUuid& id );
 
     /**
      * Each scope can have a default action. This will be saved in the project
@@ -123,7 +119,7 @@ class CORE_EXPORT QgsActionManager
      *
      * @note Added in QGIS 3.0
      */
-    void setDefaultAction( const QString& actionScope, const QString& actionId );
+    void setDefaultAction( const QString& actionScope, const QUuid& actionId );
 
     /**
      * Each scope can have a default action. This will be saved in the project
@@ -140,7 +136,7 @@ class CORE_EXPORT QgsActionManager
 
     void runAction( const QgsAction &action );
 
-    QVariantMap mDefaultActions;
+    QMap<QString, QUuid> mDefaultActions;
 
     QgsExpressionContext createExpressionContext() const;
 };

--- a/src/core/qgsactionscope.cpp
+++ b/src/core/qgsactionscope.cpp
@@ -1,0 +1,90 @@
+/***************************************************************************
+  qgsactionscope.cpp - QgsActionScope
+
+ ---------------------
+ begin                : 1.11.2016
+ copyright            : (C) 2016 by Matthias Kuhn
+ email                : matthias@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include "qgsactionscope.h"
+#include "qgsexpressioncontext.h"
+
+QgsActionScope::QgsActionScope()
+    : mExpressionContextScope( nullptr )
+{
+}
+
+QgsActionScope::QgsActionScope( const QString& id, const QString& title, const QString& description, const QgsExpressionContextScope& expressionContextScope )
+    : mId( id )
+    , mTitle( title )
+    , mDescription( description )
+    , mExpressionContextScope( expressionContextScope )
+{
+}
+
+bool QgsActionScope::operator==( const QgsActionScope& other ) const
+{
+  return other.mId == mId;
+}
+
+QgsExpressionContextScope QgsActionScope::expressionContextScope() const
+{
+  return mExpressionContextScope;
+}
+
+void QgsActionScope::setExpressionContextScope( const QgsExpressionContextScope& expressionContextScope )
+{
+  mExpressionContextScope = expressionContextScope;
+}
+
+QString QgsActionScope::id() const
+{
+  return mId;
+}
+
+void QgsActionScope::setId( const QString& name )
+{
+  mId = name;
+}
+
+bool QgsActionScope::isValid() const
+{
+  return !mId.isNull();
+}
+
+QString QgsActionScope::title() const
+{
+  return mTitle;
+}
+
+void QgsActionScope::setTitle( const QString& title )
+{
+  mTitle = title;
+}
+
+QString QgsActionScope::description() const
+{
+  return mDescription;
+}
+
+void QgsActionScope::setDescription( const QString& description )
+{
+  mDescription = description;
+}
+
+uint qHash( const QgsActionScope& key, uint seed )
+{
+  uint hash = seed;
+
+  hash |= qHash( key.expressionContextScope().variableNames().join( ',' ), seed );
+  hash |= qHash( key.id(), seed );
+
+  return hash;
+}

--- a/src/core/qgsactionscope.h
+++ b/src/core/qgsactionscope.h
@@ -30,15 +30,16 @@
  * <dl>
  *   <dt>Canvas</dt>
  *   <dd>Show for canvas tools. Adds `@clicked_x` and `@clicked_y` in map coordinates.</dd>
- *   <dt>AttributeTable</dt>
- *   <dd>Show in attribute table for each row.</dd>
- *   <dt>FieldSpecific</dt>
+ *   <dt>Feature</dt>
+ *   <dd>Show in feature specific places like the attribute table or feature
+ *   form.</dd>
+ *   <dt>Field</dt>
  *   <dd>Show in context menus for individual fields (e.g. attribute table). Adds `@field_index`, `@field_name` and `@field_value`.</dd>
- *   <dt>Selection</dt>
+ *   <dt>Layer</dt>
  *   <dd>Show in attribute table and work on the layer or selection.</dd>
  * </dl>
  *
- * \since QGIS 3.0
+ * @note Added in QGIS 3.0
  */
 
 class CORE_EXPORT QgsActionScope
@@ -47,6 +48,8 @@ class CORE_EXPORT QgsActionScope
 
     /**
      * Creates a new invalid action scope.
+     *
+     * @note Added in QGSI 3.0
      */
     explicit QgsActionScope();
 

--- a/src/core/qgsactionscope.h
+++ b/src/core/qgsactionscope.h
@@ -1,0 +1,126 @@
+/***************************************************************************
+  qgsactionscope.h - QgsActionScope
+
+ ---------------------
+ begin                : 1.11.2016
+ copyright            : (C) 2016 by Matthias Kuhn
+ email                : matthias@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSACTIONSCOPE_H
+#define QGSACTIONSCOPE_H
+
+#include <QString>
+#include "qgsexpressioncontext.h"
+
+/** \ingroup core
+ * An action scope defines a "place" for an action to be shown and may add
+ * additional expression variables.
+ * Each QgsAction can be available in one or several action scopes.
+ *
+ * Examples:
+ * ---------
+ *
+ * <dl>
+ *   <dt>Canvas</dt>
+ *   <dd>Show for canvas tools. Adds `@clicked_x` and `@clicked_y` in map coordinates.</dd>
+ *   <dt>AttributeTable</dt>
+ *   <dd>Show in attribute table for each row.</dd>
+ *   <dt>FieldSpecific</dt>
+ *   <dd>Show in context menus for individual fields (e.g. attribute table). Adds `@field_index`, `@field_name` and `@field_value`.</dd>
+ *   <dt>Selection</dt>
+ *   <dd>Show in attribute table and work on the layer or selection.</dd>
+ * </dl>
+ *
+ * \since QGIS 3.0
+ */
+
+class CORE_EXPORT QgsActionScope
+{
+  public:
+
+    /**
+     * Creates a new invalid action scope.
+     */
+    explicit QgsActionScope();
+
+    /**
+     * Creates a new action scope.
+     * For details concerning the parameters check the documentation
+     * of the corresponding properties.
+     */
+    explicit QgsActionScope( const QString& id, const QString& title, const QString& description, const QgsExpressionContextScope& expressionContextScope = QgsExpressionContextScope() );
+
+    /**
+     * Compares two action scopes
+     */
+    bool operator==( const QgsActionScope& other ) const;
+
+    /**
+     * An expression scope may offer additional variables for an action scope.
+     * This can be an `field_name` for the attribute which was clicked or
+     * `clicked_x` and `clicked_y` for actions which are available as map canvas clicks.
+     *
+     * @note Added in QGIS 3.0
+     */
+    QgsExpressionContextScope expressionContextScope() const;
+
+    /**
+     * \copydoc expressionContextScope()
+     */
+    void setExpressionContextScope( const QgsExpressionContextScope& expressionContextScope );
+
+    /**
+     * A unique identifier for this action scope.
+     *
+     * @note Added in QGIS 3.0
+     */
+    QString id() const;
+
+    //! \copydoc id()
+    void setId( const QString& id );
+
+    /**
+     * The title is a human readable and translated string that will be
+     * presented to the user in the properties dialog.
+     *
+     * @note Added in QGIS 3.0
+     */
+    QString title() const;
+    //! \copydoc title()
+    void setTitle( const QString& title );
+
+    /**
+     * The description should be a longer description of where actions in this scope
+     * are available. It is not necessary to list the available expression variables
+     * in here, they are extracted automatically from the expressionContextScope().
+     *
+     * @note Added in QGIS 3.0
+     */
+    QString description() const;
+    //! \copydoc description()
+    void setDescription( const QString& description );
+
+    /**
+     * Returns if this scope is valid.
+     *
+     * @note Added in QGIS 3.0
+     */
+    bool isValid() const;
+
+  private:
+    QString mId;
+    QString mTitle;
+    QString mDescription;
+    QgsExpressionContextScope mExpressionContextScope;
+};
+
+CORE_EXPORT uint qHash( const QgsActionScope& key, uint seed = 0 );
+
+#endif // QGSACTIONSCOPE_H

--- a/src/core/qgsactionscoperegistry.cpp
+++ b/src/core/qgsactionscoperegistry.cpp
@@ -28,16 +28,13 @@ QgsActionScopeRegistry::QgsActionScopeRegistry( QObject* parent )
   mActionScopes.insert( QgsActionScope( QStringLiteral( "Canvas" ), tr( "Canvas" ), tr( "Available for the action map tool on the canvas." ), canvasScope ) );
 
   QgsExpressionContextScope fieldScope;
-  fieldScope.addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "current_field" ), QStringLiteral( "[field_value]" ), true ) );
   fieldScope.addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "field_index" ), 0, true ) );
   fieldScope.addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "field_name" ), "[field_name]", true ) );
   fieldScope.addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "field_value" ), "[field_value]", true ) );
-  mActionScopes.insert( QgsActionScope( QStringLiteral( "FieldSpecific" ), tr( "Field Specific" ), tr( "Available for individual fields in the attribute table." ), fieldScope ) );
 
-  mActionScopes.insert( QgsActionScope( QStringLiteral( "AttributeTableRow" ), tr( "Attribute Table Row" ), tr( "Available for individual features (rows) in the attribute table." ) ) );
-  mActionScopes.insert( QgsActionScope( QStringLiteral( "FeatureForm" ), tr( "Feature Form" ), tr( "Available for individual features in their form." ) ) );
-
-  mActionScopes.insert( QgsActionScope( QStringLiteral( "AttributeTable" ), tr( "Attribute Table" ), tr( "Available as layer global action in the attribute table." ) ) );
+  mActionScopes.insert( QgsActionScope( QStringLiteral( "Field" ), tr( "Field Scope" ), tr( "Available for individual fields. For example in the attribute table." ), fieldScope ) );
+  mActionScopes.insert( QgsActionScope( QStringLiteral( "Feature" ), tr( "Feature Scope" ), tr( "Available for individual features. For example on feature forms or per row in the attribute table." ) ) );
+  mActionScopes.insert( QgsActionScope( QStringLiteral( "Layer Scope" ), tr( "Layer Scope" ), tr( "Available as layer global action. For example on top of the attribute table." ) ) );
 }
 
 QSet<QgsActionScope> QgsActionScopeRegistry::actionScopes() const

--- a/src/core/qgsactionscoperegistry.cpp
+++ b/src/core/qgsactionscoperegistry.cpp
@@ -1,0 +1,73 @@
+/***************************************************************************
+  qgsactionscoperegistry.cpp - QgsActionScopeRegistry
+
+ ---------------------
+ begin                : 1.11.2016
+ copyright            : (C) 2016 by Matthias Kuhn
+ email                : matthias@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#include "qgsactionscoperegistry.h"
+
+#include "qgsexpressioncontext.h"
+
+QgsActionScopeRegistry::QgsActionScopeRegistry( QObject* parent )
+    : QObject( parent )
+{
+  // Register some default action scopes:
+
+  QgsExpressionContextScope canvasScope;
+  canvasScope.addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "clicked_x" ), 25, true ) );
+  canvasScope.addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "clicked_y" ), 30, true ) );
+  mActionScopes.insert( QgsActionScope( QStringLiteral( "Canvas" ), tr( "Canvas" ), tr( "Available for the action map tool on the canvas." ), canvasScope ) );
+
+  QgsExpressionContextScope fieldScope;
+  fieldScope.addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "current_field" ), QStringLiteral( "[field_value]" ), true ) );
+  fieldScope.addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "field_index" ), 0, true ) );
+  fieldScope.addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "field_name" ), "[field_name]", true ) );
+  fieldScope.addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "field_value" ), "[field_value]", true ) );
+  mActionScopes.insert( QgsActionScope( QStringLiteral( "FieldSpecific" ), tr( "Field Specific" ), tr( "Available for individual fields in the attribute table." ), fieldScope ) );
+
+  mActionScopes.insert( QgsActionScope( QStringLiteral( "AttributeTableRow" ), tr( "Attribute Table Row" ), tr( "Available for individual features (rows) in the attribute table." ) ) );
+  mActionScopes.insert( QgsActionScope( QStringLiteral( "FeatureForm" ), tr( "Feature Form" ), tr( "Available for individual features in their form." ) ) );
+
+  mActionScopes.insert( QgsActionScope( QStringLiteral( "AttributeTable" ), tr( "Attribute Table" ), tr( "Available as layer global action in the attribute table." ) ) );
+}
+
+QSet<QgsActionScope> QgsActionScopeRegistry::actionScopes() const
+{
+  return mActionScopes;
+}
+
+void QgsActionScopeRegistry::registerActionScope( const QgsActionScope& actionScope )
+{
+  mActionScopes.insert( actionScope );
+
+  emit actionScopesChanged();
+}
+
+void QgsActionScopeRegistry::unregisterActionScope( const QgsActionScope& actionScope )
+{
+  mActionScopes.remove( actionScope );
+
+  emit actionScopesChanged();
+}
+
+QgsActionScope QgsActionScopeRegistry::actionScope( const QString& id )
+{
+  Q_FOREACH ( const QgsActionScope& actionScope, mActionScopes )
+  {
+    if ( actionScope.id() == id )
+    {
+      return actionScope;
+    }
+  }
+
+  return QgsActionScope();
+}

--- a/src/core/qgsactionscoperegistry.h
+++ b/src/core/qgsactionscoperegistry.h
@@ -37,21 +37,24 @@
 class CORE_EXPORT QgsActionScopeRegistry : public QObject
 {
     Q_OBJECT
-    /**
-     * The action scopes which are currently registered and available.
-     *
-     * \read actionScopes()
-     * \notify actionScopesChanged()
-     *
-     * \since QGIS 3.0
-     */
     Q_PROPERTY( QSet<QgsActionScope> actionScopes READ actionScopes NOTIFY actionScopesChanged )
 
   public:
+
+    /**
+     * Create a new QgsActionScopeRegistry.
+     * QGIS already creates a central registry. You will normally
+     * want to use QgsApplication::actionScopeRegistry() to get acess
+     * to that one instead.
+     *
+     * @note Added in QGIS 3.0
+     */
     explicit QgsActionScopeRegistry( QObject* parent = nullptr );
 
     /**
      * Get all registered action scopes.
+     *
+     * @note Added in QGIS 3.0
      */
     QSet<QgsActionScope> actionScopes() const;
 
@@ -69,9 +72,21 @@ class CORE_EXPORT QgsActionScopeRegistry : public QObject
      */
     void unregisterActionScope( const QgsActionScope& actionScope );
 
+    /**
+     * Get an action scope by its id.
+     *
+     * @note Added in QGIS 3.0
+     */
     QgsActionScope actionScope( const QString& id );
 
   signals:
+
+    /**
+     * Emitted whenever a new action scope is registered or an action scope
+     * is unregistered.
+     *
+     * @note Added in QGIS 3.0
+     */
     void actionScopesChanged();
 
   private:

--- a/src/core/qgsactionscoperegistry.h
+++ b/src/core/qgsactionscoperegistry.h
@@ -1,0 +1,81 @@
+/***************************************************************************
+  qgsactionscoperegistry.h - QgsActionScopeRegistry
+
+ ---------------------
+ begin                : 1.11.2016
+ copyright            : (C) 2016 by Matthias Kuhn
+ email                : matthias@opengis.ch
+ ***************************************************************************
+ *                                                                         *
+ *   This program is free software; you can redistribute it and/or modify  *
+ *   it under the terms of the GNU General Public License as published by  *
+ *   the Free Software Foundation; either version 2 of the License, or     *
+ *   (at your option) any later version.                                   *
+ *                                                                         *
+ ***************************************************************************/
+#ifndef QGSACTIONSCOPEREGISTRY_H
+#define QGSACTIONSCOPEREGISTRY_H
+
+#include <QObject>
+#include <QSet>
+#include "qgsactionscope.h"
+
+/** \ingroup core
+ * The action scope registry is an application wide registry that
+ * contains a list of available action scopes.
+ * Some scopes are available by default, additional ones can be registered
+ * at runtime by plugins or custom applications.
+ *
+ * To get access use the QgsApplication:
+ *
+ * ```
+ * QgsApplication::actionScopeRegistry()
+ * ```
+ *
+ * @note Added in QGIS 3.0
+ */
+class CORE_EXPORT QgsActionScopeRegistry : public QObject
+{
+    Q_OBJECT
+    /**
+     * The action scopes which are currently registered and available.
+     *
+     * \read actionScopes()
+     * \notify actionScopesChanged()
+     *
+     * \since QGIS 3.0
+     */
+    Q_PROPERTY( QSet<QgsActionScope> actionScopes READ actionScopes NOTIFY actionScopesChanged )
+
+  public:
+    explicit QgsActionScopeRegistry( QObject* parent = nullptr );
+
+    /**
+     * Get all registered action scopes.
+     */
+    QSet<QgsActionScope> actionScopes() const;
+
+    /**
+     * Register an additional action scope.
+     *
+     * @note Added in QGIS 3.0
+     */
+    void registerActionScope( const QgsActionScope& actionScope );
+
+    /**
+     * Unregister an additional action scope.
+     *
+     * @note Added in QGIS 3.0
+     */
+    void unregisterActionScope( const QgsActionScope& actionScope );
+
+    QgsActionScope actionScope( const QString& id );
+
+  signals:
+    void actionScopesChanged();
+
+  private:
+    QSet<QgsActionScope> mActionScopes;
+};
+
+#endif // QGSACTIONSCOPEREGISTRY_H

--- a/src/core/qgsapplication.cpp
+++ b/src/core/qgsapplication.cpp
@@ -23,6 +23,7 @@
 #include "qgsnetworkaccessmanager.h"
 #include "qgsproviderregistry.h"
 #include "qgsexpression.h"
+#include "qgsactionscoperegistry.h"
 
 #include <QDir>
 #include <QFile>
@@ -102,6 +103,8 @@ QgsApplication::QgsApplication( int & argc, char ** argv, bool GUIenabled, const
     : QApplication( argc, argv, GUIenabled )
 {
   sPlatformName = platformName;
+
+  mActionScopeRegistry = new QgsActionScopeRegistry();
 
   init( customConfigPath ); // init can also be called directly by e.g. unit tests that don't inherit QApplication.
 }
@@ -233,6 +236,12 @@ void QgsApplication::init( QString customConfigPath )
 
 QgsApplication::~QgsApplication()
 {
+  delete mActionScopeRegistry;
+}
+
+QgsApplication* QgsApplication::instance()
+{
+  return qobject_cast<QgsApplication*>( QCoreApplication::instance() );
 }
 
 bool QgsApplication::event( QEvent * event )
@@ -411,7 +420,7 @@ QString QgsApplication::iconPath( const QString& iconFile )
 
 QIcon QgsApplication::getThemeIcon( const QString &theName )
 {
-  QgsApplication* app = qobject_cast<QgsApplication*>( instance() );
+  QgsApplication* app = instance();
   if ( app && app->mIconCache.contains( theName ) )
     return app->mIconCache.value( theName );
 
@@ -1231,6 +1240,11 @@ void QgsApplication::copyPath( const QString& src, const QString& dst )
   {
     QFile::copy( src + QDir::separator() + f, dst + QDir::separator() + f );
   }
+}
+
+QgsActionScopeRegistry* QgsApplication::actionScopeRegistry()
+{
+  return instance()->mActionScopeRegistry;
 }
 
 bool QgsApplication::createDB( QString *errorMessage )

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -376,6 +376,8 @@ class CORE_EXPORT QgsApplication : public QApplication
 
     /**
      * Returns the action scope registry.
+     *
+     * @Note Added in QGIS 3.0
      */
     static QgsActionScopeRegistry* actionScopeRegistry();
 

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -377,7 +377,7 @@ class CORE_EXPORT QgsApplication : public QApplication
     /**
      * Returns the action scope registry.
      *
-     * @Note Added in QGIS 3.0
+     * @note Added in QGIS 3.0
      */
     static QgsActionScopeRegistry* actionScopeRegistry();
 

--- a/src/core/qgsapplication.h
+++ b/src/core/qgsapplication.h
@@ -22,6 +22,8 @@
 #include <qgis.h>
 #include <qgsconfig.h>
 
+class QgsActionScopeRegistry;
+
 /** \ingroup core
  * Extends QApplication to provide access to QGIS specific resources such
  * as theme paths, database paths etc.
@@ -34,12 +36,20 @@ typedef void XEvent;
 class CORE_EXPORT QgsApplication : public QApplication
 {
     Q_OBJECT
+
   public:
     static const char* QGIS_ORGANIZATION_NAME;
     static const char* QGIS_ORGANIZATION_DOMAIN;
     static const char* QGIS_APPLICATION_NAME;
     QgsApplication( int & argc, char ** argv, bool GUIenabled, const QString& customConfigPath = QString(), const QString& platformName = "desktop" );
     virtual ~QgsApplication();
+
+    /**
+     * Returns the singleton instance of the QgsApplication.
+     *
+     * @note Added in QGIS 3.0
+     */
+    static QgsApplication* instance();
 
     /** This method initialises paths etc for QGIS. Called by the ctor or call it manually
         when your app does not extend the QApplication class.
@@ -364,6 +374,11 @@ class CORE_EXPORT QgsApplication : public QApplication
     }
 #endif
 
+    /**
+     * Returns the action scope registry.
+     */
+    static QgsActionScopeRegistry* actionScopeRegistry();
+
   public slots:
 
     /** Causes the application instance to emit the settingsChanged() signal. This should
@@ -429,6 +444,8 @@ class CORE_EXPORT QgsApplication : public QApplication
     static QString sPlatformName;
 
     QMap<QString, QIcon> mIconCache;
+
+    QgsActionScopeRegistry* mActionScopeRegistry;
 };
 
 #endif

--- a/src/core/qgsvectorlayer.cpp
+++ b/src/core/qgsvectorlayer.cpp
@@ -2006,7 +2006,7 @@ bool QgsVectorLayer::writeSymbology( QDomNode& node, QDomDocument& doc, QString&
   node.appendChild( excludeWFSElem );
 
   // add attribute actions
-  mActions->writeXml( node, doc );
+  mActions->writeXml( node );
   mAttributeTableConfig.writeXml( node );
   mEditFormConfig.writeXml( node );
   mConditionalStyles->writeXml( node, doc );

--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -737,7 +737,7 @@ void QgsAttributeTableModel::reload( const QModelIndex &index1, const QModelInde
 }
 
 
-void QgsAttributeTableModel::executeAction( const QString& action, const QModelIndex &idx ) const
+void QgsAttributeTableModel::executeAction( const QUuid& action, const QModelIndex &idx ) const
 {
   QgsFeature f = feature( idx );
   layer()->actions()->doAction( action, f, fieldIdx( idx.column() ) );

--- a/src/gui/attributetable/qgsattributetablemodel.cpp
+++ b/src/gui/attributetable/qgsattributetablemodel.cpp
@@ -737,7 +737,7 @@ void QgsAttributeTableModel::reload( const QModelIndex &index1, const QModelInde
 }
 
 
-void QgsAttributeTableModel::executeAction( int action, const QModelIndex &idx ) const
+void QgsAttributeTableModel::executeAction( const QString& action, const QModelIndex &idx ) const
 {
   QgsFeature f = feature( idx );
   layer()->actions()->doAction( action, f, fieldIdx( idx.column() ) );

--- a/src/gui/attributetable/qgsattributetablemodel.h
+++ b/src/gui/attributetable/qgsattributetablemodel.h
@@ -171,7 +171,7 @@ class GUI_EXPORT QgsAttributeTableModel: public QAbstractTableModel
     /**
      * Execute an action
      */
-    void executeAction( int action, const QModelIndex &idx ) const;
+    void executeAction( const QString& action, const QModelIndex &idx ) const;
 
     /**
      * Execute a QgsMapLayerAction

--- a/src/gui/attributetable/qgsattributetablemodel.h
+++ b/src/gui/attributetable/qgsattributetablemodel.h
@@ -171,7 +171,7 @@ class GUI_EXPORT QgsAttributeTableModel: public QAbstractTableModel
     /**
      * Execute an action
      */
-    void executeAction( const QString& action, const QModelIndex &idx ) const;
+    void executeAction( const QUuid& action, const QModelIndex &idx ) const;
 
     /**
      * Execute a QgsMapLayerAction

--- a/src/gui/attributetable/qgsattributetableview.cpp
+++ b/src/gui/attributetable/qgsattributetableview.cpp
@@ -176,7 +176,7 @@ QWidget* QgsAttributeTableView::createActionWidget( QgsFeatureId fid )
   QAction* defaultAction = nullptr;
 
   // first add user created layer actions
-  QList<QgsAction> actions = mFilterModel->layer()->actions()->listActions( QStringLiteral( "Feature" ) );
+  QList<QgsAction> actions = mFilterModel->layer()->actions()->actions( QStringLiteral( "Feature" ) );
   Q_FOREACH ( const QgsAction& action, actions )
   {
     QString actionTitle = !action.shortTitle().isEmpty() ? action.shortTitle() : action.icon().isNull() ? action.name() : QLatin1String( "" );

--- a/src/gui/attributetable/qgsattributetableview.cpp
+++ b/src/gui/attributetable/qgsattributetableview.cpp
@@ -176,7 +176,7 @@ QWidget* QgsAttributeTableView::createActionWidget( QgsFeatureId fid )
   QAction* defaultAction = nullptr;
 
   // first add user created layer actions
-  QList<QgsAction> actions = mFilterModel->layer()->actions()->listActions( QStringLiteral( "AttributeTableRow" ) );
+  QList<QgsAction> actions = mFilterModel->layer()->actions()->listActions( QStringLiteral( "Feature" ) );
   Q_FOREACH ( const QgsAction& action, actions )
   {
     QString actionTitle = !action.shortTitle().isEmpty() ? action.shortTitle() : action.icon().isNull() ? action.name() : QLatin1String( "" );

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -390,7 +390,7 @@ void QgsDualView::viewWillShowContextMenu( QMenu* menu, const QModelIndex& atInd
   }
 
   //add user-defined actions to context menu
-  QList<QgsAction> actions = mLayerCache->layer()->actions()->listActions( QStringLiteral( "Field" ) );
+  QList<QgsAction> actions = mLayerCache->layer()->actions()->actions( QStringLiteral( "Field" ) );
   if ( !actions.isEmpty() )
   {
     QAction* a = menu->addAction( tr( "Run layer action" ) );

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -390,7 +390,7 @@ void QgsDualView::viewWillShowContextMenu( QMenu* menu, const QModelIndex& atInd
   }
 
   //add user-defined actions to context menu
-  QList<QgsAction> actions = mLayerCache->layer()->actions()->listActions( QStringLiteral( "FieldSpecific" ) );
+  QList<QgsAction> actions = mLayerCache->layer()->actions()->listActions( QStringLiteral( "Field" ) );
   if ( !actions.isEmpty() )
   {
     QAction* a = menu->addAction( tr( "Run layer action" ) );

--- a/src/gui/attributetable/qgsdualview.cpp
+++ b/src/gui/attributetable/qgsdualview.cpp
@@ -390,20 +390,18 @@ void QgsDualView::viewWillShowContextMenu( QMenu* menu, const QModelIndex& atInd
   }
 
   //add user-defined actions to context menu
-  if ( mLayerCache->layer()->actions()->size() != 0 )
+  QList<QgsAction> actions = mLayerCache->layer()->actions()->listActions( QStringLiteral( "FieldSpecific" ) );
+  if ( !actions.isEmpty() )
   {
-
-    QAction *a = menu->addAction( tr( "Run layer action" ) );
+    QAction* a = menu->addAction( tr( "Run layer action" ) );
     a->setEnabled( false );
 
-    for ( int i = 0; i < mLayerCache->layer()->actions()->size(); i++ )
+    Q_FOREACH ( const QgsAction& action, actions )
     {
-      const QgsAction &action = mLayerCache->layer()->actions()->at( i );
-
       if ( !action.runable() )
         continue;
 
-      QgsAttributeTableAction *a = new QgsAttributeTableAction( action.name(), this, i, sourceIndex );
+      QgsAttributeTableAction* a = new QgsAttributeTableAction( action.name(), this, action.id(), sourceIndex );
       menu->addAction( action.name(), a, SLOT( execute() ) );
     }
   }
@@ -424,7 +422,7 @@ void QgsDualView::viewWillShowContextMenu( QMenu* menu, const QModelIndex& atInd
   }
 
   menu->addSeparator();
-  QgsAttributeTableAction *a = new QgsAttributeTableAction( tr( "Open form" ), this, -1, sourceIndex );
+  QgsAttributeTableAction* a = new QgsAttributeTableAction( tr( "Open form" ), this, QString(), sourceIndex );
   menu->addAction( tr( "Open form" ), a, SLOT( featureForm() ) );
 }
 

--- a/src/gui/attributetable/qgsdualview.h
+++ b/src/gui/attributetable/qgsdualview.h
@@ -353,7 +353,7 @@ class GUI_EXPORT QgsAttributeTableAction : public QAction
     Q_OBJECT
 
   public:
-    QgsAttributeTableAction( const QString &name, QgsDualView *dualView, int action, const QModelIndex &fieldIdx )
+    QgsAttributeTableAction( const QString &name, QgsDualView *dualView, const QString& action, const QModelIndex &fieldIdx )
         : QAction( name, dualView )
         , mDualView( dualView )
         , mAction( action )
@@ -366,7 +366,7 @@ class GUI_EXPORT QgsAttributeTableAction : public QAction
 
   private:
     QgsDualView* mDualView;
-    int mAction;
+    QString mAction;
     QModelIndex mFieldIdx;
 };
 

--- a/src/gui/attributetable/qgsdualview.h
+++ b/src/gui/attributetable/qgsdualview.h
@@ -353,6 +353,7 @@ class GUI_EXPORT QgsAttributeTableAction : public QAction
     Q_OBJECT
 
   public:
+
     /**
      * Create a new attribute table action.
      *

--- a/src/gui/attributetable/qgsdualview.h
+++ b/src/gui/attributetable/qgsdualview.h
@@ -353,7 +353,12 @@ class GUI_EXPORT QgsAttributeTableAction : public QAction
     Q_OBJECT
 
   public:
-    QgsAttributeTableAction( const QString &name, QgsDualView *dualView, const QString& action, const QModelIndex &fieldIdx )
+    /**
+     * Create a new attribute table action.
+     *
+     * @note Added in QGIS 3.0
+     */
+    QgsAttributeTableAction( const QString& name, QgsDualView* dualView, const QUuid& action, const QModelIndex& fieldIdx )
         : QAction( name, dualView )
         , mDualView( dualView )
         , mAction( action )
@@ -366,7 +371,7 @@ class GUI_EXPORT QgsAttributeTableAction : public QAction
 
   private:
     QgsDualView* mDualView;
-    QString mAction;
+    QUuid mAction;
     QModelIndex mFieldIdx;
 };
 

--- a/src/gui/attributetable/qgsfeaturelistview.cpp
+++ b/src/gui/attributetable/qgsfeaturelistview.cpp
@@ -317,7 +317,7 @@ void QgsFeatureListView::contextMenuEvent( QContextMenuEvent *event )
   {
     QgsFeature feature = mModel->data( index, QgsFeatureListModel::FeatureRole ).value<QgsFeature>();
 
-    QgsActionMenu* menu = new QgsActionMenu( mModel->layerCache()->layer(), &feature, this );
+    QgsActionMenu* menu = new QgsActionMenu( mModel->layerCache()->layer(), feature, QStringLiteral( "AttributeTableRow" ), this );
     menu->exec( event->globalPos() );
   }
 }

--- a/src/gui/qgsactionmenu.cpp
+++ b/src/gui/qgsactionmenu.cpp
@@ -19,24 +19,21 @@
 #include "qgsactionmanager.h"
 #include "qgsfeatureiterator.h"
 
-QgsActionMenu::QgsActionMenu( QgsVectorLayer* layer, const QgsFeature* feature, QWidget*  parent )
+QgsActionMenu::QgsActionMenu( QgsVectorLayer* layer, const QgsFeature& feature, const QString& actionScope, QWidget*  parent )
     : QMenu( parent )
     , mLayer( layer )
-    , mActions( nullptr )
     , mFeature( feature )
-    , mFeatureId( feature->id() )
-    , mOwnsFeature( false )
+    , mFeatureId( feature.id() )
+    , mActionScope( actionScope )
 {
   init();
 }
 
-QgsActionMenu::QgsActionMenu( QgsVectorLayer* layer, const QgsFeatureId fid, QWidget*  parent )
+QgsActionMenu::QgsActionMenu( QgsVectorLayer* layer, const QgsFeatureId fid, const QString& actionScope, QWidget*  parent )
     : QMenu( parent )
     , mLayer( layer )
-    , mActions( nullptr )
-    , mFeature( nullptr )
     , mFeatureId( fid )
-    , mOwnsFeature( false )
+    , mActionScope( actionScope )
 {
   init();
 }
@@ -50,20 +47,11 @@ void QgsActionMenu::init()
   reloadActions();
 }
 
-const QgsFeature* QgsActionMenu::feature()
+QgsFeature QgsActionMenu::feature()
 {
-  if ( !mFeature || !mFeature->isValid() )
+  if ( !mFeature.isValid() )
   {
-    QgsFeature* feat = new QgsFeature();
-    if ( mActions->layer()->getFeatures( QgsFeatureRequest( mFeatureId ) ).nextFeature( *feat ) )
-    {
-      mFeature = feat;
-      mOwnsFeature = true;
-    }
-    else
-    {
-      delete feat;
-    }
+    mLayer->getFeatures( QgsFeatureRequest( mFeatureId ) ).nextFeature( mFeature );
   }
 
   return mFeature;
@@ -71,23 +59,16 @@ const QgsFeature* QgsActionMenu::feature()
 
 QgsActionMenu::~QgsActionMenu()
 {
-  delete mActions;
-
-  if ( mOwnsFeature )
-    delete mFeature;
 }
 
-void QgsActionMenu::setFeature( QgsFeature* feature )
+void QgsActionMenu::setFeature( const QgsFeature& feature )
 {
-  if ( mOwnsFeature )
-    delete mFeature;
-  mOwnsFeature = false;
   mFeature = feature;
 }
 
 void QgsActionMenu::triggerAction()
 {
-  if ( !feature() )
+  if ( !feature().isValid() )
     return;
 
   QAction* action = qobject_cast<QAction*>( sender() );
@@ -104,12 +85,19 @@ void QgsActionMenu::triggerAction()
 
   if ( data.actionType == MapLayerAction )
   {
-    QgsMapLayerAction* mapLayerAction = data.actionId.action;
-    mapLayerAction->triggerForFeature( data.mapLayer, feature() );
+    QgsMapLayerAction* mapLayerAction = data.actionData.value<QgsMapLayerAction*>();
+    mapLayerAction->triggerForFeature( data.mapLayer, &mFeature );
   }
   else if ( data.actionType == AttributeAction )
   {
-    mActions->doAction( data.actionId.id, *feature() );
+    // define custom substitutions: layer id and clicked coords
+    QgsExpressionContext context = mLayer->createExpressionContext();
+
+    QgsExpressionContextScope* actionScope = new QgsExpressionContextScope();
+    actionScope->addVariable( QgsExpressionContextScope::StaticVariable( QStringLiteral( "action_scope" ), mActionScope, true ) );
+    context << actionScope;
+    QgsAction act = data.actionData.value<QgsAction>();
+    act.run( context );
   }
 }
 
@@ -117,29 +105,26 @@ void QgsActionMenu::reloadActions()
 {
   clear();
 
-  delete mActions;
-  mActions = new QgsActionManager( *mLayer->actions() );
+  mActions = mLayer->actions()->listActions( mActionScope );
 
-  for ( int idx = 0; idx < mActions->size(); ++idx )
+  Q_FOREACH ( const QgsAction& action, mActions )
   {
-    const QgsAction& qaction( mActions->at( idx ) );
-
-    QAction* action = new QAction( qaction.icon(), qaction.name(), this );
-    action->setData( QVariant::fromValue<ActionData>( ActionData( idx, mFeatureId, mLayer ) ) );
-    action->setIcon( qaction.icon() );
+    QAction* qAction = new QAction( action.icon(), action.name(), this );
+    qAction->setData( QVariant::fromValue<ActionData>( ActionData( action, mFeatureId, mLayer ) ) );
+    qAction->setIcon( action.icon() );
 
     // Only enable items on supported platforms
-    if ( !qaction.runable() )
+    if ( !action.runable() )
     {
-      action->setEnabled( false );
-      action->setToolTip( tr( "Not supported on your platform" ) );
+      qAction->setEnabled( false );
+      qAction->setToolTip( tr( "Not supported on your platform" ) );
     }
     else
     {
-      action->setToolTip( qaction.action() );
+      qAction->setToolTip( action.command() );
     }
-    connect( action, SIGNAL( triggered() ), this, SLOT( triggerAction() ) );
-    addAction( action );
+    connect( qAction, &QAction::triggered, this, &QgsActionMenu::triggerAction );
+    addAction( qAction );
   }
 
   QList<QgsMapLayerAction*> mapLayerActions = QgsMapLayerActionRegistry::instance()->mapLayerActions( mLayer, QgsMapLayerAction::SingleFeature );
@@ -152,13 +137,34 @@ void QgsActionMenu::reloadActions()
     for ( int i = 0; i < mapLayerActions.size(); ++i )
     {
       QgsMapLayerAction* qaction = mapLayerActions.at( i );
-      QAction* action = new QAction( qaction->icon(), qaction->text(), this );
-      action->setData( QVariant::fromValue<ActionData>( ActionData( qaction, mFeatureId, mLayer ) ) );
-      addAction( action );
-      connect( action, SIGNAL( triggered() ), this, SLOT( triggerAction() ) );
+      QAction* qAction = new QAction( qaction->icon(), qaction->text(), this );
+      qAction->setData( QVariant::fromValue<ActionData>( ActionData( qaction, mFeatureId, mLayer ) ) );
+      addAction( qAction );
+      connect( qAction, &QAction::triggered, this, &QgsActionMenu::triggerAction );
     }
   }
 
   emit reinit();
 }
 
+
+QgsActionMenu::ActionData::ActionData( QgsMapLayerAction* action, QgsFeatureId featureId, QgsMapLayer* mapLayer )
+    : actionType( MapLayerAction )
+    , actionData( QVariant::fromValue<QgsMapLayerAction*>( action ) )
+    , featureId( featureId )
+    , mapLayer( mapLayer )
+{}
+
+
+QgsActionMenu::ActionData::ActionData( const QgsAction& action, QgsFeatureId featureId, QgsMapLayer* mapLayer )
+    : actionType( AttributeAction )
+    , actionData( QVariant::fromValue<QgsAction>( action ) )
+    , featureId( featureId )
+    , mapLayer( mapLayer )
+{}
+
+QgsActionMenu::ActionData::ActionData()
+    : actionType( Invalid )
+    , featureId( 0 )
+    , mapLayer( nullptr )
+{}

--- a/src/gui/qgsactionmenu.cpp
+++ b/src/gui/qgsactionmenu.cpp
@@ -105,7 +105,7 @@ void QgsActionMenu::reloadActions()
 {
   clear();
 
-  mActions = mLayer->actions()->listActions( mActionScope );
+  mActions = mLayer->actions()->actions( mActionScope );
 
   Q_FOREACH ( const QgsAction& action, mActions )
   {

--- a/src/gui/qgsactionmenu.h
+++ b/src/gui/qgsactionmenu.h
@@ -20,6 +20,7 @@
 #include <QSignalMapper>
 
 #include "qgsfeature.h"
+#include "qgsaction.h"
 
 class QgsMapLayer;
 class QgsMapLayerAction;
@@ -44,37 +45,12 @@ class GUI_EXPORT QgsActionMenu : public QMenu
 
     struct ActionData
     {
-      ActionData()
-          : actionType( Invalid )
-          , actionId( 0 )
-          , featureId( 0 )
-          , mapLayer( nullptr )
-      {}
-
-      ActionData( int actionId, QgsFeatureId featureId, QgsMapLayer* mapLayer )
-          : actionType( AttributeAction )
-          , actionId( actionId )
-          , featureId( featureId )
-          , mapLayer( mapLayer )
-      {}
-
-      ActionData( QgsMapLayerAction* action, QgsFeatureId featureId, QgsMapLayer* mapLayer )
-          : actionType( MapLayerAction )
-          , actionId( action )
-          , featureId( featureId )
-          , mapLayer( mapLayer )
-      {}
+      ActionData();
+      ActionData( const QgsAction& action, QgsFeatureId featureId, QgsMapLayer* mapLayer );
+      ActionData( QgsMapLayerAction* action, QgsFeatureId featureId, QgsMapLayer* mapLayer );
 
       ActionType actionType;
-
-      union aid
-      {
-        aid( int i ) : id( i ) {}
-        aid( QgsMapLayerAction* a ) : action( a ) {}
-        int id;
-        QgsMapLayerAction* action;
-      } actionId;
-
+      QVariant actionData;
       QgsFeatureId featureId;
       QgsMapLayer* mapLayer;
     };
@@ -87,7 +63,7 @@ class GUI_EXPORT QgsActionMenu : public QMenu
      *                 for the lifetime of this object.
      * @param parent   The usual QWidget parent.
      */
-    explicit QgsActionMenu( QgsVectorLayer *layer, const QgsFeature *feature, QWidget *parent = nullptr );
+    explicit QgsActionMenu( QgsVectorLayer* layer, const QgsFeature& feature, const QString& actionScope, QWidget *parent = nullptr );
 
     /**
      * Constructs a new QgsActionMenu
@@ -96,7 +72,7 @@ class GUI_EXPORT QgsActionMenu : public QMenu
      * @param fid      The feature id of the feature for which this action will be run.
      * @param parent   The usual QWidget parent.
      */
-    explicit QgsActionMenu( QgsVectorLayer *layer, const QgsFeatureId fid, QWidget *parent = nullptr );
+    explicit QgsActionMenu( QgsVectorLayer *layer, const QgsFeatureId fid, const QString& actionScope, QWidget *parent = nullptr );
 
     /**
      * Destructor
@@ -109,7 +85,7 @@ class GUI_EXPORT QgsActionMenu : public QMenu
      * @param feature  A feature. Will not take ownership. It's the callers responsibility to keep the feature
      *                 as long as the menu is displayed and the action is running.
      */
-    void setFeature( QgsFeature* feature );
+    void setFeature( const QgsFeature& feature );
 
   private slots:
     void triggerAction();
@@ -120,14 +96,15 @@ class GUI_EXPORT QgsActionMenu : public QMenu
 
   private:
     void init();
-    const QgsFeature* feature();
+    QgsFeature feature();
 
     QgsVectorLayer* mLayer;
-    QgsActionManager* mActions;
-    const QgsFeature* mFeature;
+    QList<QgsAction> mActions;
+    QgsFeature mFeature;
     QgsFeatureId mFeatureId;
-    bool mOwnsFeature;
+    QString mActionScope;
 };
+
 
 Q_DECLARE_METATYPE( QgsActionMenu::ActionData )
 

--- a/src/gui/qgsactionmenu.h
+++ b/src/gui/qgsactionmenu.h
@@ -62,6 +62,7 @@ class GUI_EXPORT QgsActionMenu : public QMenu
      * @param feature  The feature that this action will be run upon. Make sure that this feature is available
      *                 for the lifetime of this object.
      * @param parent   The usual QWidget parent.
+     * @param actionScope The action scope this menu will run in
      */
     explicit QgsActionMenu( QgsVectorLayer* layer, const QgsFeature& feature, const QString& actionScope, QWidget *parent = nullptr );
 
@@ -71,6 +72,7 @@ class GUI_EXPORT QgsActionMenu : public QMenu
      * @param layer    The layer that this action will be run upon.
      * @param fid      The feature id of the feature for which this action will be run.
      * @param parent   The usual QWidget parent.
+     * @param actionScope The action scope this menu will run in
      */
     explicit QgsActionMenu( QgsVectorLayer *layer, const QgsFeatureId fid, const QString& actionScope, QWidget *parent = nullptr );
 
@@ -87,12 +89,12 @@ class GUI_EXPORT QgsActionMenu : public QMenu
      */
     void setFeature( const QgsFeature& feature );
 
+  signals:
+    void reinit();
+
   private slots:
     void triggerAction();
     void reloadActions();
-
-  signals:
-    void reinit();
 
   private:
     void init();

--- a/src/gui/qgsattributedialog.cpp
+++ b/src/gui/qgsattributedialog.cpp
@@ -104,7 +104,7 @@ void QgsAttributeDialog::init( QgsVectorLayer* layer, QgsFeature* feature, const
   connect( buttonBox, SIGNAL( accepted() ), this, SLOT( accept() ) );
   connect( layer, SIGNAL( destroyed() ), this, SLOT( close() ) );
 
-  QgsActionMenu* menu = new QgsActionMenu( layer, &mAttributeForm->feature(), this );
+  QgsActionMenu* menu = new QgsActionMenu( layer, mAttributeForm->feature(), QStringLiteral( "AttributeTableRow" ), this );
   if ( !menu->actions().isEmpty() )
   {
     QMenuBar* menuBar = new QMenuBar( this );

--- a/src/gui/qgsidentifymenu.cpp
+++ b/src/gui/qgsidentifymenu.cpp
@@ -266,7 +266,7 @@ void QgsIdentifyMenu::addVectorLayer( QgsVectorLayer* layer, const QList<QgsMapT
     createMenu = !mCustomActionRegistry.mapLayerActions( layer, QgsMapLayerAction::SingleFeature ).isEmpty();
     if ( !createMenu && mShowFeatureActions )
     {
-      QgsActionMenu* featureActionMenu = new QgsActionMenu( layer, &( results[0].mFeature ), this );
+      QgsActionMenu* featureActionMenu = new QgsActionMenu( layer, results[0].mFeature, QStringLiteral( "AttributeTableRow" ), this );
       createMenu  = !featureActionMenu->actions().isEmpty();
       delete featureActionMenu;
     }
@@ -351,7 +351,7 @@ void QgsIdentifyMenu::addVectorLayer( QgsVectorLayer* layer, const QList<QgsMapT
     QList<QgsMapLayerAction*> customFeatureActions = mCustomActionRegistry.mapLayerActions( layer, QgsMapLayerAction::SingleFeature );
     if ( mShowFeatureActions )
     {
-      featureActionMenu = new QgsActionMenu( layer, result.mFeature.id(), layerMenu );
+      featureActionMenu = new QgsActionMenu( layer, result.mFeature, QStringLiteral( "AttributeTableRow" ), layerMenu );
     }
 
     // feature title

--- a/src/ui/qgsattributeactiondialogbase.ui
+++ b/src/ui/qgsattributeactiondialogbase.ui
@@ -175,7 +175,7 @@
         </column>
         <column>
          <property name="text">
-          <string>Show In Attribute Table</string>
+          <string>Action Scopes</string>
          </property>
         </column>
        </widget>

--- a/src/ui/qgsattributeactionpropertiesdialogbase.ui
+++ b/src/ui/qgsattributeactionpropertiesdialogbase.ui
@@ -14,6 +14,19 @@
    <string>Form</string>
   </property>
   <layout class="QGridLayout" name="gridLayout_2">
+   <item row="1" column="0">
+    <widget class="QLabel" name="textLabel1">
+     <property name="whatsThis">
+      <string>Enter the name of an action here. The name should be unique (qgis will make it unique if necessary).</string>
+     </property>
+     <property name="text">
+      <string>Description</string>
+     </property>
+     <property name="buddy">
+      <cstring>mActionName</cstring>
+     </property>
+    </widget>
+   </item>
    <item row="3" column="1" colspan="3">
     <layout class="QHBoxLayout" name="horizontalLayout_5">
      <item>
@@ -47,7 +60,64 @@
      </item>
     </layout>
    </item>
-   <item row="4" column="0" colspan="4">
+   <item row="6" column="0" colspan="4">
+    <widget class="QDialogButtonBox" name="mButtonBox">
+     <property name="standardButtons">
+      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="0">
+    <widget class="QLabel" name="label">
+     <property name="text">
+      <string>Type</string>
+     </property>
+     <property name="buddy">
+      <cstring>mActionType</cstring>
+     </property>
+    </widget>
+   </item>
+   <item row="0" column="1">
+    <widget class="QComboBox" name="mActionType">
+     <property name="sizePolicy">
+      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
+       <horstretch>0</horstretch>
+       <verstretch>0</verstretch>
+      </sizepolicy>
+     </property>
+     <item>
+      <property name="text">
+       <string>Generic</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Python</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Mac</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Windows</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Unix</string>
+      </property>
+     </item>
+     <item>
+      <property name="text">
+       <string>Open</string>
+      </property>
+     </item>
+    </widget>
+   </item>
+   <item row="5" column="0" colspan="4">
     <widget class="QGroupBox" name="mActionGroupBox">
      <property name="sizePolicy">
       <sizepolicy hsizetype="Preferred" vsizetype="Expanding">
@@ -135,43 +205,6 @@
      </layout>
     </widget>
    </item>
-   <item row="0" column="0">
-    <widget class="QLabel" name="label">
-     <property name="text">
-      <string>Type</string>
-     </property>
-     <property name="buddy">
-      <cstring>mActionType</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="5" column="0" colspan="4">
-    <widget class="QDialogButtonBox" name="mButtonBox">
-     <property name="standardButtons">
-      <set>QDialogButtonBox::Cancel|QDialogButtonBox::Ok</set>
-     </property>
-    </widget>
-   </item>
-   <item row="1" column="0">
-    <widget class="QLabel" name="textLabel1">
-     <property name="whatsThis">
-      <string>Enter the name of an action here. The name should be unique (qgis will make it unique if necessary).</string>
-     </property>
-     <property name="text">
-      <string>Description</string>
-     </property>
-     <property name="buddy">
-      <cstring>mActionName</cstring>
-     </property>
-    </widget>
-   </item>
-   <item row="3" column="0">
-    <widget class="QLabel" name="label_2">
-     <property name="text">
-      <string>Icon</string>
-     </property>
-    </widget>
-   </item>
    <item row="2" column="0">
     <widget class="QLabel" name="label_3">
      <property name="text">
@@ -179,44 +212,11 @@
      </property>
     </widget>
    </item>
-   <item row="0" column="1">
-    <widget class="QComboBox" name="mActionType">
-     <property name="sizePolicy">
-      <sizepolicy hsizetype="Expanding" vsizetype="Fixed">
-       <horstretch>0</horstretch>
-       <verstretch>0</verstretch>
-      </sizepolicy>
+   <item row="2" column="1" colspan="3">
+    <widget class="QLineEdit" name="mShortTitle">
+     <property name="placeholderText">
+      <string>Leave empty to use only icon</string>
      </property>
-     <item>
-      <property name="text">
-       <string>Generic</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Python</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Mac</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Windows</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Unix</string>
-      </property>
-     </item>
-     <item>
-      <property name="text">
-       <string>Open</string>
-      </property>
-     </item>
     </widget>
    </item>
    <item row="0" column="2">
@@ -229,6 +229,13 @@
      </property>
      <property name="text">
       <string>Capture output</string>
+     </property>
+    </widget>
+   </item>
+   <item row="3" column="0">
+    <widget class="QLabel" name="label_2">
+     <property name="text">
+      <string>Icon</string>
      </property>
     </widget>
    </item>
@@ -245,18 +252,12 @@
      </property>
     </widget>
    </item>
-   <item row="2" column="1" colspan="3">
-    <widget class="QLineEdit" name="mShortTitle">
-     <property name="placeholderText">
-      <string>Leave empty to use only icon</string>
+   <item row="4" column="0" colspan="3">
+    <widget class="QGroupBox" name="mActionScopesGroupBox">
+     <property name="title">
+      <string>Action Scopes</string>
      </property>
-    </widget>
-   </item>
-   <item row="0" column="3">
-    <widget class="QCheckBox" name="mShowInAttributeTable">
-     <property name="text">
-      <string>Show in attribute table</string>
-     </property>
+     <layout class="QFormLayout" name="formLayout"/>
     </widget>
    </item>
   </layout>

--- a/src/ui/qgsattributetabledialog.ui
+++ b/src/ui/qgsattributetabledialog.ui
@@ -187,6 +187,8 @@
      <addaction name="mActionOpenFieldCalculator"/>
      <addaction name="separator"/>
      <addaction name="mActionSetStyles"/>
+     <addaction name="separator"/>
+     <addaction name="mActionFeatureActions"/>
     </widget>
    </item>
    <item row="6" column="0">
@@ -611,6 +613,15 @@
    </property>
    <property name="toolTip">
     <string>Conditional formatting</string>
+   </property>
+  </action>
+  <action name="mActionFeatureActions">
+   <property name="icon">
+    <iconset resource="../../images/images.qrc">
+     <normaloff>:/images/themes/default/mAction.svg</normaloff>:/images/themes/default/mAction.svg</iconset>
+   </property>
+   <property name="text">
+    <string>Actions</string>
    </property>
   </action>
  </widget>

--- a/tests/src/python/test_qgsactionmanager.py
+++ b/tests/src/python/test_qgsactionmanager.py
@@ -45,7 +45,7 @@ class TestQgsActionManager(unittest.TestCase):
         self.manager = QgsActionManager(self.layer)
 
         # make a little script to aid in recording action outputs
-        # this is just a little python file which writes out it's arguments to a text file
+        # this is just a little python file which writes out its arguments to a text file
         self.run_script_file = os.path.join(QDir.tempPath(), 'run_action.py')
         with open(self.run_script_file, 'w') as s:
             s.write('import sys\n')
@@ -70,36 +70,29 @@ class TestQgsActionManager(unittest.TestCase):
         """ Test adding actions """
 
         # should be empty to start with
-        self.assertEqual(self.manager.size(), 0)
         self.assertEqual(self.manager.listActions(), [])
 
         # add an action
-        self.manager.addAction(QgsAction.GenericPython, 'test_action', 'i=1')
-        self.assertEqual(self.manager.size(), 1)
+        action1 = QgsAction(QgsAction.GenericPython, 'Test Action', 'i=1')
+        self.manager.addAction(action1)
+        self.assertEqual(len(self.manager.listActions()), 1)
         self.assertEqual(self.manager.listActions()[0].type(), QgsAction.GenericPython)
-        self.assertEqual(self.manager.listActions()[0].name(), 'test_action')
-        self.assertEqual(self.manager.listActions()[0].action(), 'i=1')
-        self.assertEqual(self.manager.at(0).name(), 'test_action')
-        self.assertEqual(self.manager[0].name(), 'test_action')
+        self.assertEqual(self.manager.listActions()[0].name(), 'Test Action')
+        self.assertEqual(self.manager.listActions()[0].command(), 'i=1')
 
         # add another action
-        self.manager.addAction(QgsAction.Windows, 'test_action2', 'i=2')
-        self.assertEqual(self.manager.size(), 2)
-        self.assertEqual(self.manager.listActions()[1].type(), QgsAction.Windows)
-        self.assertEqual(self.manager.listActions()[1].name(), 'test_action2')
-        self.assertEqual(self.manager.listActions()[1].action(), 'i=2')
-        self.assertEqual(self.manager.at(1).name(), 'test_action2')
-        self.assertEqual(self.manager[1].name(), 'test_action2')
+        action2 = QgsAction(QgsAction.Windows, 'Test Action2', 'i=2')
+        self.manager.addAction(action2)
+        self.assertEqual(len(self.manager.listActions()), 2)
+        self.assertEqual(self.manager.action(action2.id()).type(), QgsAction.Windows)
+        self.assertEqual(self.manager.action(action2.id()).name(), 'Test Action2')
+        self.assertEqual(self.manager.action(action2.id()).command(), 'i=2')
 
-        # add a predefined action
-        action = QgsAction(QgsAction.Unix, 'test_action3', 'i=3', False)
-        self.manager.addAction(action)
-        self.assertEqual(self.manager.size(), 3)
-        self.assertEqual(self.manager.listActions()[2].type(), QgsAction.Unix)
-        self.assertEqual(self.manager.listActions()[2].name(), 'test_action3')
-        self.assertEqual(self.manager.listActions()[2].action(), 'i=3')
-        self.assertEqual(self.manager.at(2).name(), 'test_action3')
-        self.assertEqual(self.manager[2].name(), 'test_action3')
+        id3 = self.manager.addAction(QgsAction.Generic, 'Test Action3', 'i=3')
+        self.assertEqual(len(self.manager.listActions()), 3)
+        self.assertEqual(self.manager.action(id3).type(), QgsAction.Generic)
+        self.assertEqual(self.manager.action(id3).name(), 'Test Action3')
+        self.assertEqual(self.manager.action(id3).command(), 'i=3')
 
     def testRemoveActions(self):
         """ test removing actions """
@@ -113,9 +106,9 @@ class TestQgsActionManager(unittest.TestCase):
         self.assertEqual(self.manager.listActions(), [])
 
         # add some actions
-        self.manager.addAction(QgsAction.GenericPython, 'test_action', 'i=1')
-        self.manager.addAction(QgsAction.GenericPython, 'test_action2', 'i=2')
-        self.manager.addAction(QgsAction.GenericPython, 'test_action3', 'i=3')
+        id1 = self.manager.addAction(QgsAction.GenericPython, 'test_action', 'i=1')
+        id2 = self.manager.addAction(QgsAction.GenericPython, 'test_action2', 'i=2')
+        id3 = self.manager.addAction(QgsAction.GenericPython, 'test_action3', 'i=3')
 
         # remove non-existant action
         self.manager.removeAction(5)

--- a/tests/src/python/test_qgsactionmanager.py
+++ b/tests/src/python/test_qgsactionmanager.py
@@ -22,7 +22,7 @@ from qgis.core import (QgsVectorLayer,
                        QgsField,
                        QgsFields
                        )
-from qgis.PyQt.QtCore import QDir, QTemporaryFile
+from qgis.PyQt.QtCore import QDir, QTemporaryFile, QUuid
 
 from qgis.testing import (start_app,
                           unittest
@@ -70,26 +70,26 @@ class TestQgsActionManager(unittest.TestCase):
         """ Test adding actions """
 
         # should be empty to start with
-        self.assertEqual(self.manager.listActions(), [])
+        self.assertEqual(self.manager.actions(), [])
 
         # add an action
         action1 = QgsAction(QgsAction.GenericPython, 'Test Action', 'i=1')
         self.manager.addAction(action1)
-        self.assertEqual(len(self.manager.listActions()), 1)
-        self.assertEqual(self.manager.listActions()[0].type(), QgsAction.GenericPython)
-        self.assertEqual(self.manager.listActions()[0].name(), 'Test Action')
-        self.assertEqual(self.manager.listActions()[0].command(), 'i=1')
+        self.assertEqual(len(self.manager.actions()), 1)
+        self.assertEqual(self.manager.actions()[0].type(), QgsAction.GenericPython)
+        self.assertEqual(self.manager.actions()[0].name(), 'Test Action')
+        self.assertEqual(self.manager.actions()[0].command(), 'i=1')
 
         # add another action
         action2 = QgsAction(QgsAction.Windows, 'Test Action2', 'i=2')
         self.manager.addAction(action2)
-        self.assertEqual(len(self.manager.listActions()), 2)
+        self.assertEqual(len(self.manager.actions()), 2)
         self.assertEqual(self.manager.action(action2.id()).type(), QgsAction.Windows)
         self.assertEqual(self.manager.action(action2.id()).name(), 'Test Action2')
         self.assertEqual(self.manager.action(action2.id()).command(), 'i=2')
 
         id3 = self.manager.addAction(QgsAction.Generic, 'Test Action3', 'i=3')
-        self.assertEqual(len(self.manager.listActions()), 3)
+        self.assertEqual(len(self.manager.actions()), 3)
         self.assertEqual(self.manager.action(id3).type(), QgsAction.Generic)
         self.assertEqual(self.manager.action(id3).name(), 'Test Action3')
         self.assertEqual(self.manager.action(id3).command(), 'i=3')
@@ -102,8 +102,7 @@ class TestQgsActionManager(unittest.TestCase):
 
         # clear the manager and check that it's empty
         self.manager.clearActions()
-        self.assertEqual(self.manager.size(), 0)
-        self.assertEqual(self.manager.listActions(), [])
+        self.assertEqual(self.manager.actions(), [])
 
         # add some actions
         id1 = self.manager.addAction(QgsAction.GenericPython, 'test_action', 'i=1')
@@ -111,66 +110,44 @@ class TestQgsActionManager(unittest.TestCase):
         id3 = self.manager.addAction(QgsAction.GenericPython, 'test_action3', 'i=3')
 
         # remove non-existant action
-        self.manager.removeAction(5)
+        self.manager.removeAction(QUuid.createUuid())
 
         # remove them one by one
-        self.manager.removeAction(1)
-        self.assertEqual(self.manager.size(), 2)
-        self.assertEqual(self.manager.listActions()[0].name(), 'test_action')
-        self.assertEqual(self.manager.listActions()[1].name(), 'test_action3')
-        self.manager.removeAction(0)
-        self.assertEqual(self.manager.size(), 1)
-        self.assertEqual(self.manager.listActions()[0].name(), 'test_action3')
-        self.manager.removeAction(0)
-        self.assertEqual(self.manager.size(), 0)
-
-    def testRetrieveAction(self):
-        """ test retrieving actions """
-        self.manager.clearActions()
-
-        # test that exceptions are thrown when retrieving bad indices
-
-        with self.assertRaises(KeyError):
-            self.manager[0]
-
-        with self.assertRaises(KeyError):
-            self.manager.at(0)
-
-        self.manager.addAction(QgsAction.GenericPython, 'test_action', 'i=1')
-
-        with self.assertRaises(KeyError):
-            self.manager[-1]
-
-        with self.assertRaises(KeyError):
-            self.manager.at(-1)
-
-        with self.assertRaises(KeyError):
-            self.manager[5]
-
-        with self.assertRaises(KeyError):
-            self.manager.at(5)
+        self.manager.removeAction(id2)
+        self.assertEqual(len(self.manager.actions()), 2)
+        self.assertEqual(self.manager.action(id1).name(), 'test_action')
+        self.assertEqual(self.manager.action(id3).name(), 'test_action3')
+        self.manager.removeAction(id1)
+        self.assertEqual(len(self.manager.actions()), 1)
+        self.assertEqual(self.manager.action(id3).name(), 'test_action3')
+        self.manager.removeAction(id3)
+        self.assertEqual(len(self.manager.actions()), 0)
 
     def testDefaultAction(self):
         """ test default action for layer"""
 
         self.manager.clearActions()
-        self.manager.addAction(QgsAction.GenericPython, 'test_action', 'i=1')
-        self.manager.addAction(QgsAction.GenericPython, 'test_action2', 'i=2')
+        action1 = QgsAction(QgsAction.GenericPython, 'test_action', '', 'i=1', False, actionScopes={'Feature'})
+        self.manager.addAction(action1)
+        action2 = QgsAction(QgsAction.GenericPython, 'test_action2', 'i=2')
+        self.manager.addAction(action2)
 
         # initially should be not set
-        self.assertEqual(self.manager.defaultAction(), -1)
+        self.assertFalse(self.manager.defaultAction('Feature').isValid())
 
         # set bad default action
-        self.manager.setDefaultAction(10)
-        self.assertEqual(self.manager.defaultAction(), -1)
+        self.manager.setDefaultAction('Feature', QUuid.createUuid())
+        self.assertFalse(self.manager.defaultAction('Feature').isValid())
 
         # set good default action
-        self.manager.setDefaultAction(1)
-        self.assertEqual(self.manager.defaultAction(), 1)
+        self.manager.setDefaultAction('Feature', action1.id())
+        self.assertTrue(self.manager.defaultAction('Feature').isValid())
+        self.assertEquals(self.manager.defaultAction('Feature').id(), action1.id())
+        self.assertNotEquals(self.manager.defaultAction('Feature').id(), action2.id())
 
         # if default action is removed, should be reset to -1
         self.manager.clearActions()
-        self.assertEqual(self.manager.defaultAction(), -1)
+        self.assertFalse(self.manager.defaultAction('Feature').isValid())
 
     def check_action_result(self, temp_file):
         with open(temp_file, 'r') as result:
@@ -185,7 +162,7 @@ class TestQgsActionManager(unittest.TestCase):
 
         # simple action
         temp_file = self.get_temp_filename()
-        self.manager.addAction(QgsAction.Unix, 'test_action', self.create_action(temp_file, 'test output'))
+        id1 = self.manager.addAction(QgsAction.Unix, 'test_action', self.create_action(temp_file, 'test output'))
 
         fields = QgsFields()
         fields.append(QgsField('my_field'))
@@ -195,28 +172,29 @@ class TestQgsActionManager(unittest.TestCase):
         f.setAttributes([5, 'val'])
 
         c = QgsExpressionContext()
-        self.manager.doAction(0, f, c)
+        self.manager.doAction(id1, f, c)
         time.sleep(0.5)
 
-        self.assertEqual(self.check_action_result(temp_file), 'test output')
+        self.assertEquals(self.check_action_result(temp_file), 'test output')
 
         # action with substitutions
         temp_file = self.get_temp_filename()
-        self.manager.addAction(QgsAction.Unix, 'test_action', self.create_action(temp_file, 'test [% $id %] output [% @layer_name %]'))
-        self.manager.doAction(1, f, c)
+        id2 = self.manager.addAction(QgsAction.Unix, 'test_action', self.create_action(temp_file, 'test [% $id %] output [% @layer_name %]'))
+        self.manager.doAction(id2, f, c)
         time.sleep(0.5)
 
-        self.assertEqual(self.check_action_result(temp_file), 'test 1 output test_layer')
+        self.assertEquals(self.check_action_result(temp_file), 'test 1 output test_layer')
 
         # test doAction using field variant
         temp_file = self.get_temp_filename()
-        self.manager.addAction(QgsAction.Unix, 'test_action', self.create_action(temp_file, 'test [% @current_field %]'))
-        self.manager.doActionFeature(2, f, 0)
+        id3 = self.manager.addAction(QgsAction.Unix, 'test_action',
+                                     self.create_action(temp_file, 'test : [% @field_index %] : [% @field_name %] : [% @field_value%]'))
+        self.manager.doActionFeature(id3, f, 0)
         time.sleep(0.5)
-        self.assertEqual(self.check_action_result(temp_file), 'test 5')
-        self.manager.doActionFeature(2, f, 1)
+        self.assertEquals(self.check_action_result(temp_file), 'test : 0 : my_field : 5')
+        self.manager.doActionFeature(id3, f, 1)
         time.sleep(0.5)
-        self.assertEqual(self.check_action_result(temp_file), 'test val')
+        self.assertEquals(self.check_action_result(temp_file), 'test : 1 : my_other_field : val')
 
 if __name__ == '__main__':
     unittest.main()


### PR DESCRIPTION
Each action can have one or several scopes. They basically define what should be available to properly run the action and therefore where it should be shown.

Some examples:

<dl>
<dt>Field</dt>
<dd>A feature + one active field. (right click on an attribute in the table)</dd>
<dt>Feature</dt> 
<dd>A feature (attribute table row, feature form, identify...)</dd>
<dt>Layer</dt> 
<dd>A layer with no particular feature. The code will probably use all features or the current selection. (attribute table on top, no feature provided in expression context)</dd>
<dt>Canvas</dt> 
<dd>x and y coordinates + possibly a feature (Action Map Tool)</dd>
</dl>


![screenshot from 2016-11-01 14-30-14](https://cloud.githubusercontent.com/assets/588407/19891312/d0a59a86-a03f-11e6-9463-6be87c63b171.png)


![screenshot from 2016-11-01 14-30-29](https://cloud.githubusercontent.com/assets/588407/19891309/cee521a8-a03f-11e6-8c4c-0c6ca118a657.png)

These variables are now also available in the expression editor based on the activated scopes.

Action scopes are in an application wide registry (Implemented compatible https://github.com/qgis/qgis3.0_api/issues/42). It is therefore possible for plugins to register their own scopes. This can be interesting for integrating actions with other apps (QField, LizMap...).

-------------

This is for general feedback and not ready for an in-depth review.

-------------

In a second step I would like to make QgsMapLayerActions available in the same way (https://github.com/qgis/qgis3.0_api/issues/52).