### PR TITLE
Export parametric SVG, will fallback symbols for the systems that cannot understand them

### DIFF
--- a/python/core/symbology-ng/qgssymbollayerutils.sip
+++ b/python/core/symbology-ng/qgssymbollayerutils.sip
@@ -501,4 +501,20 @@ class QgsSymbolLayerUtils
       */
     static void mergeScaleDependencies( int mScaleMinDenom, int mScaleMaxDenom, QgsStringMap& props );
 
+    /**
+     * Encodes a reference to a parametric SVG into SLD, as a succession of parametric SVG using URL parameters,
+     * a fallback SVG without parameters, and a final fallback as a mark with the right colors and outline for systems
+     * that cannot do SVG at all
+     * @note added in 3.0
+     */
+    static void parametricSvgToSld( QDomDocument &doc, QDomElement &graphicElem,
+                                    const QString& path,
+                                    const QColor& fillColor, double size, const QColor& outlineColor, double outlineWidth );
+
+    /**
+     * Encodes a reference to a parametric SVG into a path with parameters according to the SVG Parameters spec
+     * @note added in 3.0
+     */
+    static QString getSvgParametricPath( const QString& basePath, const QColor& fillColor, const QColor& borderColor, double borderWidth );
+
 };

--- a/src/core/symbology-ng/qgsfillsymbollayer.cpp
+++ b/src/core/symbology-ng/qgsfillsymbollayer.cpp
@@ -2083,20 +2083,16 @@ void QgsSVGFillSymbolLayer::toSld( QDomDocument &doc, QDomElement &element, cons
 
   if ( !mSvgFilePath.isEmpty() )
   {
-    double partternWidth = QgsSymbolLayerUtils::rescaleUom( mPatternWidth, mPatternWidthUnit, props );
-    QgsSymbolLayerUtils::externalGraphicToSld( doc, graphicElem, mSvgFilePath, QStringLiteral( "image/svg+xml" ), mColor, partternWidth );
+    // encode a parametric SVG reference
+    double patternWidth = QgsSymbolLayerUtils::rescaleUom( mPatternWidth, mPatternWidthUnit, props );
+    double outlineWidth = QgsSymbolLayerUtils::rescaleUom( mSvgOutlineWidth, mSvgOutlineWidthUnit, props );
+    QgsSymbolLayerUtils::parametricSvgToSld( doc, graphicElem, mSvgFilePath, mColor, patternWidth, mSvgOutlineColor, outlineWidth );
   }
   else
   {
     // TODO: create svg from data
     // <se:InlineContent>
     symbolizerElem.appendChild( doc.createComment( QStringLiteral( "SVG from data not implemented yet" ) ) );
-  }
-
-  if ( mSvgOutlineColor.isValid() || mSvgOutlineWidth >= 0 )
-  {
-    double svgOutlineWidth = QgsSymbolLayerUtils::rescaleUom( mSvgOutlineWidth, mSvgOutlineWidthUnit, props );
-    QgsSymbolLayerUtils::lineToSld( doc, graphicElem, Qt::SolidLine, mSvgOutlineColor, svgOutlineWidth );
   }
 
   // <Rotation>

--- a/src/core/symbology-ng/qgsmarkersymbollayer.cpp
+++ b/src/core/symbology-ng/qgsmarkersymbollayer.cpp
@@ -2194,8 +2194,10 @@ void QgsSvgMarkerSymbolLayer::writeSldMarker( QDomDocument &doc, QDomElement &el
   QDomElement graphicElem = doc.createElement( QStringLiteral( "se:Graphic" ) );
   element.appendChild( graphicElem );
 
+  // encode a parametric SVG reference
   double size = QgsSymbolLayerUtils::rescaleUom( mSize, mSizeUnit, props );
-  QgsSymbolLayerUtils::externalGraphicToSld( doc, graphicElem, mPath, QStringLiteral( "image/svg+xml" ), mColor, size );
+  double outlineWidth = QgsSymbolLayerUtils::rescaleUom( mOutlineWidth, mOutlineWidthUnit, props );
+  QgsSymbolLayerUtils::parametricSvgToSld( doc, graphicElem, mPath, mColor, size, mOutlineColor, outlineWidth );
 
   // <Rotation>
   QString angleFunc;

--- a/src/core/symbology-ng/qgssymbollayerutils.h
+++ b/src/core/symbology-ng/qgssymbollayerutils.h
@@ -587,6 +587,22 @@ class CORE_EXPORT QgsSymbolLayerUtils
       */
     static void mergeScaleDependencies( int mScaleMinDenom, int mScaleMaxDenom, QgsStringMap& props );
 
+    /**
+     * Encodes a reference to a parametric SVG into SLD, as a succession of parametric SVG using URL parameters,
+     * a fallback SVG without parameters, and a final fallback as a mark with the right colors and outline for systems
+     * that cannot do SVG at all
+     * @note added in 3.0
+     */
+    static void parametricSvgToSld( QDomDocument &doc, QDomElement &graphicElem,
+                                    const QString& path,
+                                    const QColor& fillColor, double size, const QColor& outlineColor, double outlineWidth );
+
+    /**
+     * Encodes a reference to a parametric SVG into a path with parameters according to the SVG Parameters spec
+     * @note added in 3.0
+     */
+    static QString getSvgParametricPath( const QString& basePath, const QColor& fillColor, const QColor& borderColor, double borderWidth );
+
 };
 
 class QPolygonF;


### PR DESCRIPTION
This pull request makes the SVG parameters explicit, but at the same time leverages SLD fallback symbol support to add a non parametric SVG fallback, as well as a simple mark with the right color and outline for systems that cannot deal with SVG, or lack the symbol on their file system.