### PR TITLE
Fix saving of the collapsed state for relations

### DIFF
--- a/src/app/qgsattributetabledialog.cpp
+++ b/src/app/qgsattributetabledialog.cpp
@@ -86,6 +86,7 @@ QgsAttributeTableDialog::QgsAttributeTableDialog( QgsVectorLayer *theLayer, QWid
     , mRubberBand( nullptr )
     , mCurrentSearchWidgetWrapper( nullptr )
 {
+  setObjectName( QStringLiteral( "QgsAttributeTableDialog/" ) + theLayer->id() );
   setupUi( this );
 
   Q_FOREACH ( const QgsField& field, mLayer->fields() )

--- a/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidget.cpp
@@ -195,6 +195,7 @@ void QgsRelationReferenceWidget::setRelation( const QgsRelation& relation, bool 
     mReferencedLayer = relation.referencedLayer();
     mReferencedFieldIdx = mReferencedLayer->fields().lookupField( relation.fieldPairs().at( 0 ).second );
     mReferencingFieldIdx = mReferencingLayer->fields().lookupField( relation.fieldPairs().at( 0 ).first );
+    mAttributeEditorFrame->setObjectName( QStringLiteral( "referencing/" ) + relation.name() );
 
     QgsAttributeEditorContext context( mEditorContext, relation, QgsAttributeEditorContext::Single, QgsAttributeEditorContext::Embed );
 

--- a/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrelationreferencewidgetwrapper.cpp
@@ -76,6 +76,7 @@ void QgsRelationReferenceWidgetWrapper::initWidget( QWidget* editor )
       mWidget->setEmbedForm( false );
       mWidget->setReadOnlySelector( false );
       mWidget->setAllowMapIdentification( false );
+      break;
     }
     ctx = ctx->parentContext();
   }

--- a/src/gui/qgsrelationeditorwidget.cpp
+++ b/src/gui/qgsrelationeditorwidget.cpp
@@ -170,8 +170,7 @@ void QgsRelationEditorWidget::setRelationFeature( const QgsRelation& relation, c
     mToggleEditingButton->setEnabled( false );
   }
 
-  setObjectName( mRelation.name() );
-  loadState();
+  setObjectName( QStringLiteral( "referenced/" ) + mRelation.name() );
 
   // If not yet initialized, it is not (yet) visible, so we don't load it to be faster (lazy loading)
   // If it is already initialized, it has been set visible before and the currently shown feature is changing
@@ -240,8 +239,7 @@ void QgsRelationEditorWidget::setRelations( const QgsRelation& relation, const Q
     mToggleEditingButton->setEnabled( false );
   }
 
-  setObjectName( mRelation.name() );
-  loadState();
+  setObjectName( QStringLiteral( "referenced/" ) + mRelation.name() );
 
   updateUi();
 }


### PR DESCRIPTION
In the attribute form, the collapsed state of RelationReference
was not loaded correctly and was interfering with the collapsed
state of the relation editor.

Plus, the state was saved globally for a reference. Meaning that
if a reference was used (through other references) from other
layers, it was sharing the same state.