### PR TITLE
Document properties instead of getters and setters

### DIFF
--- a/cmake_templates/Doxyfile.in
+++ b/cmake_templates/Doxyfile.in
@@ -238,7 +238,9 @@ TAB_SIZE               = 2
 # "Side Effects:". You can put \n's in the value part of an alias to insert
 # newlines.
 
-ALIASES                =
+ALIASES                = "read=\par Read:\n" \
+                         "write=\par Write:\n" \
+                         "notify=\par Notify:\n"
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).
 # A mapping has the form "name=value". For example adding "class=itcl::class"

--- a/python/core/qgsproject.sip
+++ b/python/core/qgsproject.sip
@@ -70,61 +70,43 @@ Returns the QgsProject singleton instance
 
     void setFileName( const QString &name );
 %Docstring
- Sets the file name associated with the project. This is the file which contains the project's XML
- representation.
- \param name project file name
-.. seealso:: fileName()
+ \copydoc fileName
 %End
 
     QString fileName() const;
 %Docstring
- Returns the project's file name. This is the file which contains the project's XML
- representation.
-.. seealso:: setFileName()
-.. seealso:: fileInfo()
+ \copydoc fileName
  :rtype: str
 %End
 
     QFileInfo fileInfo() const;
 %Docstring
  Returns QFileInfo object for the project's associated file.
-.. seealso:: fileName()
+.. seealso:: fileName
 .. versionadded:: 2.9
  :rtype: QFileInfo
 %End
 
     QgsCoordinateReferenceSystem crs() const;
 %Docstring
- Returns the project's native coordinate reference system.
-.. versionadded:: 3.0
-.. seealso:: setCrs()
-.. seealso:: ellipsoid()
+ \copydoc crs
  :rtype: QgsCoordinateReferenceSystem
 %End
 
     void setCrs( const QgsCoordinateReferenceSystem &crs );
 %Docstring
- Sets the project's native coordinate reference system.
-.. versionadded:: 3.0
-.. seealso:: crs()
-.. seealso:: setEllipsoid()
+ \copydoc crs
 %End
 
     QString ellipsoid() const;
 %Docstring
- Returns a proj string representing the project's ellipsoid setting, e.g., "WGS84".
-.. seealso:: setEllipsoid()
-.. seealso:: crs()
-.. versionadded:: 3.0
+ \copydoc ellipsoid
  :rtype: str
 %End
 
     void setEllipsoid( const QString &ellipsoid );
 %Docstring
- Sets the project's ellipsoid from a proj string representation, e.g., "WGS84".
-.. seealso:: ellipsoid()
-.. seealso:: setCrs()
-.. versionadded:: 3.0
+ \copydoc ellipsoid
 %End
 
     void clear();
@@ -143,7 +125,7 @@ Returns the QgsProject singleton instance
 
     bool read();
 %Docstring
- Reads the project from its currently associated file (see fileName() ).
+.. seealso:: fileName ).
  :return: true if project file has been read successfully
  :rtype: bool
 %End
@@ -417,6 +399,7 @@ Convenience function to query topological editing status
 
     QgsRelationManager *relationManager() const;
 %Docstring
+ \copydoc relationManager
  :rtype: QgsRelationManager
 %End
 
@@ -445,11 +428,7 @@ Convenience function to query topological editing status
 
     QgsMapThemeCollection *mapThemeCollection();
 %Docstring
- Returns pointer to the project's map theme collection.
-.. versionadded:: 2.12
-.. note::
-
-   renamed in QGIS 3.0, formerly QgsVisibilityPresetCollection
+ \copydoc mapThemeCollection
  :rtype: QgsMapThemeCollection
 %End
 
@@ -463,17 +442,17 @@ Convenience function to query topological editing status
 
     void setNonIdentifiableLayers( const QList<QgsMapLayer *> &layers );
 %Docstring
- Set a list of layers which should not be taken into account on map identification
+ \copydoc nonIdentifiableLayers
 %End
 
     void setNonIdentifiableLayers( const QStringList &layerIds );
 %Docstring
- Set a list of layers which should not be taken into account on map identification
+ \copydoc nonIdentifiableLayers
 %End
 
     QStringList nonIdentifiableLayers() const;
 %Docstring
- Get the list of layers which currently should not be taken into account on map identification
+ \copydoc nonIdentifiableLayers
  :rtype: list of str
 %End
 
@@ -520,25 +499,19 @@ Convenience function to query topological editing status
 
     QgsSnappingConfig snappingConfig() const;
 %Docstring
- The snapping configuration for this project.
-
-.. versionadded:: 3.0
+ \copydoc snappingConfig
  :rtype: QgsSnappingConfig
 %End
 
     QList<QgsVectorLayer *> avoidIntersectionsLayers() const;
 %Docstring
- A list of layers with which intersections should be avoided.
-
-.. versionadded:: 3.0
+ \copydoc avoidIntersectionsLayers()
  :rtype: list of QgsVectorLayer
 %End
 
     void setAvoidIntersectionsLayers( const QList<QgsVectorLayer *> &layers );
 %Docstring
- A list of layers with which intersections should be avoided.
-
-.. versionadded:: 3.0
+ \copydoc avoidIntersectionsLayers()
 %End
 
     QVariantMap customVariables() const;
@@ -830,12 +803,12 @@ emitted when an old project file is read.
 
     void nonIdentifiableLayersChanged( QStringList nonIdentifiableLayers );
 %Docstring
-Emitted when the list of layer which are excluded from map identification changes
+ \copydoc nonIdentifiableLayers
 %End
 
     void fileNameChanged();
 %Docstring
-Emitted when the file name of the project changes
+ \copydoc fileName
 %End
 
     void homePathChanged();
@@ -845,7 +818,7 @@ Emitted when the home path of the project changes
 
     void snappingConfigChanged( const QgsSnappingConfig &config );
 %Docstring
-emitted whenever the configuration for snapping has changed
+ \copydoc snappingConfig
 %End
 
     void customVariablesChanged();
@@ -856,18 +829,12 @@ emitted whenever the configuration for snapping has changed
 
     void crsChanged();
 %Docstring
- Emitted when the CRS of the project has changed.
-
-.. versionadded:: 3.0
+ \copydoc crs
 %End
 
     void ellipsoidChanged( const QString &ellipsoid );
 %Docstring
- Emitted when the project ``ellipsoid`` is changed.
-
-.. versionadded:: 3.0
-.. seealso:: setEllipsoid()
-.. seealso:: ellipsoid()
+ \copydoc ellipsoid
 %End
 
     void transactionGroupsChanged();
@@ -887,13 +854,14 @@ emitted whenever the configuration for snapping has changed
 
     void avoidIntersectionsLayersChanged();
 %Docstring
- Emitted whenever avoidIntersectionsLayers has changed.
-
-.. versionadded:: 3.0
+ \copydoc avoidIntersectionsLayers()
 %End
 
     void mapThemeCollectionChanged();
 %Docstring
+ \copydoc mapThemeCollection
+
+ \note
  Emitted when the map theme collection changes.
  This only happens when the map theme collection is reset.
  Any pointer previously received from mapThemeCollection()
@@ -901,8 +869,6 @@ emitted whenever the configuration for snapping has changed
  You must still connect to signals from the map theme collection
  if you want to be notified about new map themes being added and
  map themes being removed.
-
-.. versionadded:: 3.0
 %End
 
     void labelingEngineSettingsChanged();
@@ -1014,9 +980,7 @@ emitted whenever the configuration for snapping has changed
 
     void setSnappingConfig( const QgsSnappingConfig &snappingConfig );
 %Docstring
- The snapping configuration for this project.
-
-.. versionadded:: 3.0
+ \copydoc snappingConfig
 %End
 
     void setDirty( bool b = true );

--- a/src/core/qgsproject.h
+++ b/src/core/qgsproject.h
@@ -79,6 +79,14 @@ class QgsLabelingEngineSettings;
 class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenerator
 {
     Q_OBJECT
+
+    /**
+     * The list of layers which should not be taken into account on map identification.
+     *
+     * \read nonIdentifiableLayers()
+     * \write setNonIdentifiableLayers()
+     * \notify nonIdentifiableLayersChanged()
+     */
     Q_PROPERTY( QStringList nonIdentifiableLayers READ nonIdentifiableLayers WRITE setNonIdentifiableLayers NOTIFY nonIdentifiableLayersChanged )
 
     /**
@@ -93,12 +101,75 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      * \notify fileNameChanged()
      */
     Q_PROPERTY( QString fileName READ fileName WRITE setFileName NOTIFY fileNameChanged )
+
     Q_PROPERTY( QString homePath READ homePath NOTIFY homePathChanged )
+
+    /**
+     * The project's native coordinate reference system.
+     *
+     * \read crs()
+     * \write setCrs()
+     * \notify crsChanged()
+     *
+     * \since QGIS 3.0
+     *
+     * \see ellipsoid()
+     */
     Q_PROPERTY( QgsCoordinateReferenceSystem crs READ crs WRITE setCrs NOTIFY crsChanged )
+
+    /**
+     * The proj string representing the project's ellipsoid setting, e.g. ``WGS84``.
+     *
+     * \read ellipsoid()
+     * \write setEllipsoid()
+     * \notify ellipsoidChanged()
+     *
+     * \since QGIS 3.0
+     *
+     * \see crs()
+     */
     Q_PROPERTY( QString ellipsoid READ ellipsoid WRITE setEllipsoid NOTIFY ellipsoidChanged )
+
+    /**
+     * The project's map theme collection.
+     * For validity see the notes in \link mapThemeCollectionChanged() \endlink
+     *
+     * \read mapThemeCollection()
+     * \notify mapThemeCollectionChanged()
+     *
+     * \since QGIS 3.0
+     * \note Renamed in QGIS 3.0, formerly ``QgsVisibilityPresetCollection`` (since QGIS 2.12)
+     */
     Q_PROPERTY( QgsMapThemeCollection *mapThemeCollection READ mapThemeCollection NOTIFY mapThemeCollectionChanged )
+
+    /**
+     * The snapping configuration for this project.
+     *
+     * \read snappingConfig()
+     * \write setSnappingConfig()
+     * \notify snappinConfigChanged()
+     *
+     * \since QGIS 3.0
+     */
     Q_PROPERTY( QgsSnappingConfig snappingConfig READ snappingConfig WRITE setSnappingConfig NOTIFY snappingConfigChanged )
+
+    /**
+     * The relation manager keeps track of all the relations which are available
+     * and defined in the project.
+     *
+     * \read relationManager()
+     */
     Q_PROPERTY( QgsRelationManager *relationManager READ relationManager )
+
+    /**
+     * A list of layers with which intersections should be avoided.
+     *
+     * \read avoidIntersectionLayers()
+     * \write setAvoidIntersectionLayers()
+     * \notify avoidIntersectionLayersChanged()
+     *
+     * \since QGIS 3.0
+     */
     Q_PROPERTY( QList<QgsVectorLayer *> avoidIntersectionsLayers READ avoidIntersectionsLayers WRITE setAvoidIntersectionsLayers NOTIFY avoidIntersectionsLayersChanged )
 
   public:
@@ -148,34 +219,22 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     QFileInfo fileInfo() const;
 
     /**
-     * Returns the project's native coordinate reference system.
-     * \since QGIS 3.0
-     * \see setCrs()
-     * \see ellipsoid()
+     * \copydoc crs
      */
     QgsCoordinateReferenceSystem crs() const;
 
     /**
-     * Sets the project's native coordinate reference system.
-     * \since QGIS 3.0
-     * \see crs()
-     * \see setEllipsoid()
+     * \copydoc crs
      */
     void setCrs( const QgsCoordinateReferenceSystem &crs );
 
     /**
-     * Returns a proj string representing the project's ellipsoid setting, e.g., "WGS84".
-     * \see setEllipsoid()
-     * \see crs()
-     * \since QGIS 3.0
+     * \copydoc ellipsoid
      */
     QString ellipsoid() const;
 
     /**
-     * Sets the project's ellipsoid from a proj string representation, e.g., "WGS84".
-     * \see ellipsoid()
-     * \see setCrs()
-     * \since QGIS 3.0
+     * \copydoc ellipsoid
      */
     void setEllipsoid( const QString &ellipsoid );
 
@@ -389,6 +448,9 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
       \returns home path of project (or null QString if not set) */
     QString homePath() const;
 
+    /**
+     * \copydoc relationManager
+     */
     QgsRelationManager *relationManager() const;
 
     /**
@@ -416,9 +478,8 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      */
     QgsLayerTreeRegistryBridge *layerTreeRegistryBridge() const { return mLayerTreeRegistryBridge; }
 
-    /** Returns pointer to the project's map theme collection.
-     * \since QGIS 2.12
-     * \note renamed in QGIS 3.0, formerly QgsVisibilityPresetCollection
+    /**
+     * \copydoc mapThemeCollection
      */
     QgsMapThemeCollection *mapThemeCollection();
 
@@ -435,17 +496,17 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     const QgsAnnotationManager *annotationManager() const SIP_SKIP;
 
     /**
-     * Set a list of layers which should not be taken into account on map identification
+     * \copydoc nonIdentifiableLayers
      */
     void setNonIdentifiableLayers( const QList<QgsMapLayer *> &layers );
 
     /**
-     * Set a list of layers which should not be taken into account on map identification
+     * \copydoc nonIdentifiableLayers
      */
     void setNonIdentifiableLayers( const QStringList &layerIds );
 
     /**
-     * Get the list of layers which currently should not be taken into account on map identification
+     * \copydoc nonIdentifiableLayers
      */
     QStringList nonIdentifiableLayers() const;
 
@@ -497,23 +558,17 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     QgsExpressionContext createExpressionContext() const override;
 
     /**
-     * The snapping configuration for this project.
-     *
-     * \since QGIS 3.0
+     * \copydoc snappingConfig
      */
     QgsSnappingConfig snappingConfig() const;
 
     /**
-     * A list of layers with which intersections should be avoided.
-     *
-     * \since QGIS 3.0
+     * \copydoc avoidIntersectionsLayers()
      */
     QList<QgsVectorLayer *> avoidIntersectionsLayers() const;
 
     /**
-     * A list of layers with which intersections should be avoided.
-     *
-     * \since QGIS 3.0
+     * \copydoc avoidIntersectionsLayers()
      */
     void setAvoidIntersectionsLayers( const QList<QgsVectorLayer *> &layers );
 
@@ -800,7 +855,9 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
 
     void loadingLayer( const QString & );
 
-    //! Emitted when the list of layer which are excluded from map identification changes
+    /**
+     * \copydoc nonIdentifiableLayers
+     */
     void nonIdentifiableLayersChanged( QStringList nonIdentifiableLayers );
 
     /**
@@ -811,27 +868,24 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     //! Emitted when the home path of the project changes
     void homePathChanged();
 
-    //! emitted whenever the configuration for snapping has changed
+    /**
+     * \copydoc snappingConfig
+     */
     void snappingConfigChanged( const QgsSnappingConfig &config );
 
-    /** Emitted whenever the expression variables stored in the project have been changed.
+    /**
+     * Emitted whenever the expression variables stored in the project have been changed.
      * \since QGIS 3.0
      */
     void customVariablesChanged();
 
     /**
-     * Emitted when the CRS of the project has changed.
-     *
-     * \since QGIS 3.0
+     * \copydoc crs
      */
     void crsChanged();
 
     /**
-     * Emitted when the project \a ellipsoid is changed.
-     *
-     * \since QGIS 3.0
-     * \see setEllipsoid()
-     * \see ellipsoid()
+     * \copydoc ellipsoid
      */
     void ellipsoidChanged( const QString &ellipsoid );
 
@@ -851,13 +905,14 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     void topologicalEditingChanged();
 
     /**
-     * Emitted whenever avoidIntersectionsLayers has changed.
-     *
-     * \since QGIS 3.0
+     * \copydoc avoidIntersectionsLayers()
      */
     void avoidIntersectionsLayersChanged();
 
     /**
+     * \copydoc mapThemeCollection
+     *
+     * \note
      * Emitted when the map theme collection changes.
      * This only happens when the map theme collection is reset.
      * Any pointer previously received from mapThemeCollection()
@@ -865,8 +920,6 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      * You must still connect to signals from the map theme collection
      * if you want to be notified about new map themes being added and
      * map themes being removed.
-     *
-     * \since QGIS 3.0
      */
     void mapThemeCollectionChanged();
 
@@ -980,9 +1033,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
   public slots:
 
     /**
-     * The snapping configuration for this project.
-     *
-     * \since QGIS 3.0
+     * \copydoc snappingConfig
      */
     void setSnappingConfig( const QgsSnappingConfig &snappingConfig );
 

--- a/src/core/qgsproject.h
+++ b/src/core/qgsproject.h
@@ -80,6 +80,18 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
 {
     Q_OBJECT
     Q_PROPERTY( QStringList nonIdentifiableLayers READ nonIdentifiableLayers WRITE setNonIdentifiableLayers NOTIFY nonIdentifiableLayersChanged )
+
+    /**
+     * The file name associated with the project.
+     * This is the file which contains the project's XML representation.
+     *
+     * \see fileInfo()
+     * \since QGIS 3.0
+     *
+     * \read fileName()
+     * \write setFileName()
+     * \notify fileNameChanged()
+     */
     Q_PROPERTY( QString fileName READ fileName WRITE setFileName NOTIFY fileNameChanged )
     Q_PROPERTY( QString homePath READ homePath NOTIFY homePathChanged )
     Q_PROPERTY( QgsCoordinateReferenceSystem crs READ crs WRITE setCrs NOTIFY crsChanged )
@@ -119,22 +131,18 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      */
     bool isDirty() const;
 
-    /** Sets the file name associated with the project. This is the file which contains the project's XML
-     * representation.
-     * \param name project file name
-     * \see fileName()
+    /** 
+     * \copydoc fileName
      */
     void setFileName( const QString &name );
 
-    /** Returns the project's file name. This is the file which contains the project's XML
-     * representation.
-     * \see setFileName()
-     * \see fileInfo()
-    */
+    /**
+     * \copydoc fileName
+     */
     QString fileName() const;
 
     /** Returns QFileInfo object for the project's associated file.
-     * \see fileName()
+     * \see fileName
      * \since QGIS 2.9
      */
     QFileInfo fileInfo() const;
@@ -182,7 +190,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      */
     bool read( const QString &filename );
 
-    /** Reads the project from its currently associated file (see fileName() ).
+    /** Reads the project from its currently associated file (\see fileName ).
      * \returns true if project file has been read successfully
      */
     bool read();
@@ -795,7 +803,9 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
     //! Emitted when the list of layer which are excluded from map identification changes
     void nonIdentifiableLayersChanged( QStringList nonIdentifiableLayers );
 
-    //! Emitted when the file name of the project changes
+    /**
+     * \copydoc fileName
+     */
     void fileNameChanged();
 
     //! Emitted when the home path of the project changes

--- a/src/core/qgsproject.h
+++ b/src/core/qgsproject.h
@@ -131,7 +131,7 @@ class CORE_EXPORT QgsProject : public QObject, public QgsExpressionContextGenera
      */
     bool isDirty() const;
 
-    /** 
+    /**
      * \copydoc fileName
      */
     void setFileName( const QString &name );


### PR DESCRIPTION
I find myself often copying documentation from getters to setters (and notification signals) recently. There is often not any additional valuable information in there at all.

I would propose to simplify this and only document properties.

To still have the real names, they can just be listed as follows:

```
    /**
     * The file name associated with the project.
     * This is the file which contains the project's XML representation.
     *
     * \read fileName()
     * \write setFileName()
     * \notify fileNameChanged()
     *
     * \see fileInfo()
     * \since QGIS 3.0
     *
     */
Q_PROPERTY( QString name READ name WRITE setName NOTIFY nameChanged )
```

These will then be listed in the api doc under the title "Properties".

![property](https://cloud.githubusercontent.com/assets/588407/19900094/a3da6d1a-a062-11e6-8ec0-e007b491167e.png)

What's open to decide is what to do with the individual functions.
They could only have a `\see fileName` and nothing else.
Or be totally skipped from the docs `/// @private`. <-- I think Qt does that.
Or have a copy of the doc with `\copydoc fileName`
...