### PR TITLE
Speed up inserting features into memory layers by ~65%

### DIFF
--- a/src/providers/memory/qgsmemoryprovider.cpp
+++ b/src/providers/memory/qgsmemoryprovider.cpp
@@ -301,15 +301,14 @@ bool QgsMemoryProvider::addFeatures( QgsFeatureList & flist )
   // TODO: sanity checks of fields and geometries
   for ( QgsFeatureList::iterator it = flist.begin(); it != flist.end(); ++it )
   {
-    mFeatures[mNextFeatureId] = *it;
-    QgsFeature& newfeat = mFeatures[mNextFeatureId];
-    newfeat.setFeatureId( mNextFeatureId );
-    newfeat.setValid( true );
     it->setFeatureId( mNextFeatureId );
+    it->setValid( true );
+
+    mFeatures.insert( mNextFeatureId, *it );
 
     // update spatial index
     if ( mSpatialIndex )
-      mSpatialIndex->insertFeature( newfeat );
+      mSpatialIndex->insertFeature( *it );
 
     mNextFeatureId++;
   }


### PR DESCRIPTION
By avoiding unnecessary map lookups (insert feature, then retrieve from map and modify in place) and instead just modify the feature before inserting into qmap.

wheee!

