### PR TITLE
[FEATURE][processing] New input type for expressions

### DIFF
--- a/python/plugins/processing/algs/qgis/ExtractByExpression.py
+++ b/python/plugins/processing/algs/qgis/ExtractByExpression.py
@@ -30,7 +30,7 @@ from processing.core.GeoAlgorithmExecutionException import GeoAlgorithmExecution
 from processing.core.parameters import ParameterVector
 from processing.core.outputs import OutputVector
 from processing.core.GeoAlgorithm import GeoAlgorithm
-from processing.core.parameters import ParameterString
+from processing.core.parameters import ParameterString, ParameterExpression
 from processing.tools import dataobjects
 
 
@@ -46,8 +46,8 @@ class ExtractByExpression(GeoAlgorithm):
 
         self.addParameter(ParameterVector(self.INPUT,
                                           self.tr('Input Layer')))
-        self.addParameter(ParameterString(self.EXPRESSION,
-                                          self.tr("Expression")))
+        self.addParameter(ParameterExpression(self.EXPRESSION,
+                                              self.tr("Expression"), parent_layer=self.INPUT))
         self.addOutput(OutputVector(self.OUTPUT, self.tr('Extracted (expression)')))
 
     def processAlgorithm(self, progress):

--- a/python/plugins/processing/algs/qgis/GeometryByExpression.py
+++ b/python/plugins/processing/algs/qgis/GeometryByExpression.py
@@ -30,7 +30,7 @@ from qgis.core import QgsWkbTypes, QgsExpression, QgsExpressionContext, QgsExpre
 from processing.core.GeoAlgorithm import GeoAlgorithm
 from processing.core.GeoAlgorithmExecutionException import GeoAlgorithmExecutionException
 from processing.core.ProcessingLog import ProcessingLog
-from processing.core.parameters import ParameterVector, ParameterSelection, ParameterBoolean, ParameterString
+from processing.core.parameters import ParameterVector, ParameterSelection, ParameterBoolean, ParameterExpression
 from processing.core.outputs import OutputVector
 from processing.tools import dataobjects, vector
 
@@ -63,8 +63,8 @@ class GeometryByExpression(GeoAlgorithm):
         self.addParameter(ParameterBoolean(self.WITH_M,
                                            self.tr('Output geometry has m values'), False))
 
-        self.addParameter(ParameterString(self.EXPRESSION,
-                                          self.tr("Geometry expression"), '$geometry'))
+        self.addParameter(ParameterExpression(self.EXPRESSION,
+                                              self.tr("Geometry expression"), '$geometry', parent_layer=self.INPUT_LAYER))
 
         self.addOutput(OutputVector(self.OUTPUT_LAYER, self.tr('Modified geometry')))
 

--- a/python/plugins/processing/algs/qgis/SelectByExpression.py
+++ b/python/plugins/processing/algs/qgis/SelectByExpression.py
@@ -30,7 +30,7 @@ from processing.core.parameters import ParameterVector
 from processing.core.parameters import ParameterSelection
 from processing.core.outputs import OutputVector
 from processing.core.GeoAlgorithm import GeoAlgorithm
-from processing.core.parameters import ParameterString
+from processing.core.parameters import ParameterExpression
 from processing.tools import dataobjects
 
 
@@ -52,8 +52,8 @@ class SelectByExpression(GeoAlgorithm):
 
         self.addParameter(ParameterVector(self.LAYERNAME,
                                           self.tr('Input Layer')))
-        self.addParameter(ParameterString(self.EXPRESSION,
-                                          self.tr("Expression")))
+        self.addParameter(ParameterExpression(self.EXPRESSION,
+                                              self.tr("Expression"), parent_layer=self.LAYERNAME))
         self.addParameter(ParameterSelection(self.METHOD,
                                              self.tr('Modify current selection by'), self.methods, 0))
         self.addOutput(OutputVector(self.RESULT, self.tr('Selected (expression)'), True))

--- a/python/plugins/processing/gui/wrappers.py
+++ b/python/plugins/processing/gui/wrappers.py
@@ -36,7 +36,7 @@ from functools import cmp_to_key
 
 from qgis.core import QgsCoordinateReferenceSystem, QgsVectorLayer
 from qgis.PyQt.QtWidgets import QCheckBox, QComboBox, QLineEdit, QPlainTextEdit
-from qgis.gui import QgsFieldExpressionWidget
+from qgis.gui import QgsFieldExpressionWidget, QgsExpressionLineEdit
 from qgis.PyQt.QtCore import pyqtSignal, QObject, QVariant
 
 from processing.gui.NumberInputPanel import NumberInputPanel
@@ -714,7 +714,10 @@ class ExpressionWidgetWrapper(WidgetWrapper):
 
     def createWidget(self):
         if self.dialogType in (DIALOG_STANDARD, DIALOG_BATCH):
-            widget = QgsFieldExpressionWidget()
+            if self.param.parent_layer:
+                widget = QgsFieldExpressionWidget()
+            else:
+                widget = QgsExpressionLineEdit()
             if self.param.default:
                 widget.setExpression(self.param.default)
         else:

--- a/python/plugins/processing/gui/wrappers.py
+++ b/python/plugins/processing/gui/wrappers.py
@@ -643,7 +643,9 @@ class StringWidgetWrapper(WidgetWrapper):
             if self.param.default:
                 widget.setText(self.param.default)
         else:
-            strings = self.dialog.getAvailableValuesOfType(ParameterString, OutputString)
+            # strings, numbers, files and table fields are all allowed input types
+            strings = self.dialog.getAvailableValuesOfType([ParameterString, ParameterNumber, ParameterFile,
+                                                            ParameterTableField], OutputString)
             options = [(self.dialog.resolveValueDescription(s), s) for s in strings]
             if self.param.multiline:
                 widget = MultilineTextPanel(options)

--- a/python/plugins/processing/modeler/ModelerParameterDefinitionDialog.py
+++ b/python/plugins/processing/modeler/ModelerParameterDefinitionDialog.py
@@ -210,7 +210,8 @@ class ModelerParameterDefinitionDialog(QDialog):
 
             self.verticalLayout.addWidget(QLabel(self.tr('Parent layer')))
             self.parentCombo = QComboBox()
-            idx = 0
+            self.parentCombo.addItem(self.tr("None"), None)
+            idx = 1
             for param in list(self.alg.inputs.values()):
                 if isinstance(param.param, (ParameterVector, ParameterTable)):
                     self.parentCombo.addItem(param.param.description, param.param.name)

--- a/python/plugins/processing/modeler/ModelerParametersDialog.py
+++ b/python/plugins/processing/modeler/ModelerParametersDialog.py
@@ -261,16 +261,22 @@ class ModelerParametersDialog(QDialog):
                 self.widgets[param.name].setVisible(self.showAdvanced)
 
     def getAvailableValuesOfType(self, paramType, outType=None, dataType=None):
+        # upgrade paramType to list
+        if type(paramType) is not list:
+            paramType = [paramType]
+
         values = []
         inputs = self.model.inputs
         for i in list(inputs.values()):
             param = i.param
-            if isinstance(param, paramType):
-                if dataType is not None:
-                    if param.datatype in dataType:
+            for t in paramType:
+                if isinstance(param, t):
+                    if dataType is not None:
+                        if param.datatype in dataType:
+                            values.append(ValueFromInput(param.name))
+                    else:
                         values.append(ValueFromInput(param.name))
-                else:
-                    values.append(ValueFromInput(param.name))
+                    break
         if outType is None:
             return values
         if self._algName is None:

--- a/python/plugins/processing/tests/ModelerTest.py
+++ b/python/plugins/processing/tests/ModelerTest.py
@@ -62,6 +62,10 @@ class ModelerTest(unittest.TestCase):
         self.assertEqual(set(p.name for p in dlg.getAvailableValuesOfType(ParameterFile)),
                          set(['file']))
 
+        # test multiple types
+        self.assertEqual(set(p.name for p in dlg.getAvailableValuesOfType([ParameterString, ParameterNumber, ParameterFile])),
+                         set(['string', 'string2', 'number', 'file']))
+
 
 if __name__ == '__main__':
     unittest.main()

--- a/python/plugins/processing/tests/ParametersTest.py
+++ b/python/plugins/processing/tests/ParametersTest.py
@@ -40,7 +40,8 @@ from processing.core.parameters import (Parameter,
                                         ParameterString,
                                         ParameterVector,
                                         ParameterTableField,
-                                        ParameterSelection)
+                                        ParameterSelection,
+                                        ParameterExpression)
 from processing.tools import dataobjects
 from processing.tests.TestData import points2
 
@@ -462,7 +463,30 @@ class ParameterStringTest(unittest.TestCase):
         self.assertTrue(optionalParameter.setValue(None))
         self.assertEqual(optionalParameter.value, None)
 
-        requiredParameter = ParameterCrs('myName', 'myDesc', default='test', optional=False)
+        requiredParameter = ParameterString('myName', 'myDesc', default='test', optional=False)
+        self.assertEqual(requiredParameter.value, 'test')
+        requiredParameter.setValue('check')
+        self.assertEqual(requiredParameter.value, 'check')
+        self.assertFalse(requiredParameter.setValue(None))
+        self.assertEqual(requiredParameter.value, 'check')
+
+
+class ParameterExpressionTest(unittest.TestCase):
+
+    def testSetValue(self):
+        parameter = ParameterExpression('myName', 'myDescription')
+        self.assertTrue(parameter.setValue('\'a\' || "field"'))
+        self.assertEqual(parameter.value, '\'a\' || "field"')
+
+    def testOptional(self):
+        optionalParameter = ParameterExpression('myName', 'myDesc', default='test', optional=True)
+        self.assertEqual(optionalParameter.value, 'test')
+        optionalParameter.setValue('check')
+        self.assertEqual(optionalParameter.value, 'check')
+        self.assertTrue(optionalParameter.setValue(None))
+        self.assertEqual(optionalParameter.value, None)
+
+        requiredParameter = ParameterExpression('myName', 'myDesc', default='test', optional=False)
         self.assertEqual(requiredParameter.value, 'test')
         requiredParameter.setValue('check')
         self.assertEqual(requiredParameter.value, 'check')


### PR DESCRIPTION
This adds a new input type for expression inputs. Expression inputs can be linked to a parent layer so that the builder shows the correct fields and layer variables.

It's designed for two use cases:

1. to be used when an algorithm specifically requires users to enter an expression as an input, eg Select by Expression and Extract by Expression. In this case it has the benefit of showing the expression builder and linking it correctly with the parent layer.

2. to be potentially used as a replacement input instead of string or number literals in algorithms. Eg - if the simplify algorithm tolerance parameter was replaced with an expression parameter, then this expression would be evaluated for every feature before simplifying that feature. It would allow parameters to be calculated per feature, as opposed to the current approach of calculating
a parameter once before running the algorithm. It would also mean algorithms like "variable distance buffer" would no longer be needed, as a single "buffer" algorithm could then be used for either a fixed distance, field based, or expression based distance.

This is just a concept for now - if the processing team like this idea then i'll add unit tests + proper expression context handling, and update existing algorithms to suit.