### PR TITLE
[FEATURE] upgrade the substr() function

### DIFF
--- a/resources/function_help/json/substr
+++ b/resources/function_help/json/substr
@@ -2,9 +2,15 @@
   "name": "substr",
   "type": "function",
   "description": "Returns a part of a string.",
-  "arguments": [ {"arg":"input_string","description":"the full input string"},
-  {"arg":"startpos","description":"integer representing start position to extract from"},
-  {"arg":"length","description":"integer representing length of string to extract"}
+  "arguments": [ {"arg":"string","description":"the full input string"},
+  {"arg":"start","description":"integer representing start position to extract from; if start is negative, the return string will begin at the end of the string minus the start value"},
+  {"arg":"length","optional":true,"description":"integer representing length of string to extract; if length is negative, the return string will omit the given length of characters from the end of the string"}
   ],
-  "examples": [ { "expression":"substr('HELLO WORLD',3,5)", "returns":"'LLO W'"}]
+  "examples": [ { "expression":"substr('HELLO WORLD',3,5)", "returns":"'LLO W'"},
+                { "expression":"substr('HELLO WORLD',6)", "returns":"'WORLD'"},
+                { "expression":"substr('HELLO WORLD',-5)","returns":"'WORLD'"},
+                { "expression":"substr('HELLO',3,-1)", "returns":"'LL'"},
+                { "expression":"substr('HELLO WORLD',-5,2)","returns":"'WO'"},
+                { "expression":"substr('HELLO WORLD',-5,-1)","returns":"'WORL'"}
+  ]
 }

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -836,7 +836,10 @@ class TestQgsExpression: public QObject
       QTest::newRow( "regexp_replace cap group" ) << "regexp_replace('HeLLo','(eL)', 'x\\\\1x')" << false << QVariant( "HxeLxLo" );
       QTest::newRow( "regexp_replace invalid" ) << "regexp_replace('HeLLo','[[[', '-')" << true << QVariant();
       QTest::newRow( "substr" ) << "substr('HeLLo', 3,2)" << false << QVariant( "LL" );
-      QTest::newRow( "substr outside" ) << "substr('HeLLo', -5,2)" << false << QVariant( "" );
+      QTest::newRow( "substr negative start" ) << "substr('HeLLo', -4)" << false << QVariant( "eLLo" );
+      QTest::newRow( "substr negative length" ) << "substr('HeLLo', 1,-3)" << false << QVariant( "He" );
+      QTest::newRow( "substr positive start and negative length" ) << "substr('HeLLo', 3,-1)" << false << QVariant( "LL" );
+      QTest::newRow( "substr start only" ) << "substr('HeLLo', 3)" << false << QVariant( "LLo" );
       QTest::newRow( "regexp_substr" ) << "regexp_substr('abc123','(\\\\d+)')" << false << QVariant( "123" );
       QTest::newRow( "regexp_substr non-greedy" ) << "regexp_substr('abc123','(\\\\d+?)')" << false << QVariant( "1" );
       QTest::newRow( "regexp_substr no hit" ) << "regexp_substr('abcdef','(\\\\d+)')" << false << QVariant( "" );


### PR DESCRIPTION
This PR upgrades the substr() function to allow the following:
- negative start value (e.g. substr('hello',-2) returns 'lo')
- negative length value (e.g. substr('hello',3,-1) returns 'll')

It can speed up a number of scenarios by preventing the need to call length() to get a substring which relies on getting a string to the Nth number of characters from the end.

For e.g, getting a bit of text at the end of a string between parenthesis:

```
substr('my name(detail)',strpos('my name(detail)','('),-1)
```

*Also*, the substr function does _not_ require a length parameter anymore. By default, if no length is provided, the substr() function will return a string from the start position until the end of the string. For e.g. this would return 'world':

```
substr('hello world',7)
```

@nyalldawson, I hope I'm doing this correctly. I have had to rely on switch lazyEval to true to get this working.