### PR TITLE
Don't fill cache image on rendering start

### DIFF
--- a/src/core/qgsmaprenderercustompainterjob.cpp
+++ b/src/core/qgsmaprenderercustompainterjob.cpp
@@ -244,6 +244,9 @@ void QgsMapRendererCustomPainterJob::doRender()
       QTime layerTime;
       layerTime.start();
 
+      if ( job.img )
+        job.img->fill( 0 );
+
       job.renderer->render();
 
       job.renderingTime = layerTime.elapsed();

--- a/src/core/qgsmaprendererjob.cpp
+++ b/src/core/qgsmaprendererjob.cpp
@@ -286,7 +286,6 @@ LayerRenderJobs QgsMapRendererJob::prepareJobs( QPainter* painter, QgsLabelingEn
         layerJobs.removeLast();
         continue;
       }
-      mypFlattenedImage->fill( 0 );
 
       job.img = mypFlattenedImage;
       QPainter* mypPainter = new QPainter( job.img );

--- a/src/core/qgsmaprendererparalleljob.cpp
+++ b/src/core/qgsmaprendererparalleljob.cpp
@@ -215,6 +215,9 @@ void QgsMapRendererParallelJob::renderLayerStatic( LayerRenderJob& job )
   if ( job.cached )
     return;
 
+  if ( job.img )
+    job.img->fill( 0 );
+
   QTime t;
   t.start();
   QgsDebugMsgLevel( QString( "job %1 start (layer %2)" ).arg( reinterpret_cast< ulong >( &job ), 0, 16 ).arg( job.layerId ), 2 );


### PR DESCRIPTION
Calling QImage::fill( 0 ) on rendering start takes about 40% of the
time required for setting up a new job.
Since this is done on the main thread, the interface feels more
snappy the quicker the setup process is completed.

Is there anything that depends on this (like transparency problems)?
If yes, this can potentially be moved to initialization that is performed on the rendering thread already.