### PR TITLE
[FEATURE] add regexp_matches() function

### DIFF
--- a/resources/function_help/json/array_to_string
+++ b/resources/function_help/json/array_to_string
@@ -5,7 +5,7 @@
   "arguments": [
     {"arg":"array", "description":"the input array"},
     {"arg":"delimiter","optional":true,"default":"','","description":"the string delimiter used to separate concatenated array elements"},
-    {"arg":"emptyvalue","optional":true,"default":"''","description":"the optional string to use as replacement to empty values"}],
+    {"arg":"empty_value","optional":true,"default":"''","description":"the optional string to use as replacement for empty (zero length) matches"}],
   "examples": [ { "expression":"array_to_string(array('1','2','3'),',')", "returns":"'1,2,3'"},
                 { "expression":"array_to_string(array('1','','3'),',','0')", "returns":"'1,0,3'"}
   ]

--- a/resources/function_help/json/regexp_matches
+++ b/resources/function_help/json/regexp_matches
@@ -1,0 +1,12 @@
+{
+  "name": "regexp_matches",
+  "type": "function",
+  "description": "Returns an array of all strings captured by capturing groups, in the order the groups themselves appear in the supplied regular expression against a string.",
+  "arguments": [
+    {"arg":"string", "description":"the string to capture groups from against the regular expression"},
+    {"arg":"regex","description":"the regular expression used to capture groups"},
+    {"arg":"empty_value","optional":true,"default":"''","description":"the optional string to use as replacement for empty (zero length) matches"}],
+  "examples": [ { "expression":"regexp_matches('qgis=>rocks','(.*)=>(.*)')", "returns":"array: 'qgis', 'rocks'"},
+                { "expression":"regexp_matches('key=>','(.*)=>(.*)','empty value')", "returns":"array: 'key', 'empty value'"}
+  ]
+}

--- a/resources/function_help/json/string_to_array
+++ b/resources/function_help/json/string_to_array
@@ -5,7 +5,7 @@
   "arguments": [
     {"arg":"string", "description":"the input string"},
     {"arg":"delimiter","optional":true,"default":"','","description":"the string delimiter used to split the input string"},
-    {"arg":"emptyvalue","optional":true,"default":"''","description":"the optional string to use as replacement to empty values"}],
+    {"arg":"empty_value","optional":true,"default":"''","description":"the optional string to use as replacement for empty (zero length) matches"}],
   "examples": [ { "expression":"string_to_array('1,2,3',',')", "returns":"array: '1', '2', '3'"},
                 { "expression":"string_to_array('1,,3',',','0')", "returns":"array: '1', '0', '3'"}
   ]

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -841,6 +841,11 @@ class TestQgsExpression: public QObject
       QTest::newRow( "regexp_substr non-greedy" ) << "regexp_substr('abc123','(\\\\d+?)')" << false << QVariant( "1" );
       QTest::newRow( "regexp_substr no hit" ) << "regexp_substr('abcdef','(\\\\d+)')" << false << QVariant( "" );
       QTest::newRow( "regexp_substr invalid" ) << "regexp_substr('abc123','([[[')" << true << QVariant();
+      QTest::newRow( "regexp_matches" ) << "array_get(regexp_matches('qgis=>rOcks;hello=>world','qgis=>(.*)[;$]'),0)" << false << QVariant( "rOcks" );
+      QTest::newRow( "regexp_matches empty custom value" ) << "array_get(regexp_matches('qgis=>;hello=>world','qgis=>(.*)[;$]','empty'),0)" << false << QVariant( "empty" );
+      QTest::newRow( "regexp_matches no match" ) << "regexp_matches('123','no()match')" << false << QVariant();
+      QTest::newRow( "regexp_matches no capturing group" ) << "regexp_matches('some string','.*')" << false << QVariant( QVariantList() );
+      QTest::newRow( "regexp_matches invalid" ) << "regexp_matches('invalid','(')" << true << QVariant();
       QTest::newRow( "strpos" ) << "strpos('Hello World','World')" << false << QVariant( 7 );
       QTest::newRow( "strpos outside" ) << "strpos('Hello World','blah')" << false << QVariant( 0 );
       QTest::newRow( "left" ) << "left('Hello World',5)" << false << QVariant( "Hello" );
@@ -2266,6 +2271,7 @@ class TestQgsExpression: public QObject
       builderExpected << "world";
       QCOMPARE( QgsExpression( "array('hello', 'world')" ).evaluate( &context ), QVariant( builderExpected ) );
       QCOMPARE( QgsExpression( "string_to_array('hello,world',',')" ).evaluate( &context ), QVariant( builderExpected ) );
+      QCOMPARE( QgsExpression( "regexp_matches('hello=>world','([A-Za-z]*)=>([A-Za-z]*)')" ).evaluate( &context ), QVariant( builderExpected ) );
 
       QCOMPARE( QgsExpression( "array_length(\"strings\")" ).evaluate( &context ), QVariant( 2 ) );
 


### PR DESCRIPTION
This new function returns an array of strings captured by capturing groups in a supplied regular expression. For e.g., the following expression `regexp_matches('"qgis"=>"rocks",\\"qgis\\"=>\\"(.*)\\"')` will return the following array: `'"qgis"=>"rocks"', 'rocks'`.

This comes in handy in a number of scenarios, including handling of OSM layers loaded through OGR, which creates a string field named  "other_tags" concatenating values for OSM tags that were not converted into fields by OGR. 

Take this "other_tags" string value: "smoothness"=>"intermediate","surface"=>"asphalt". Using this new expression, it's possible to extract - using the new regexp_matches() function coupled with array_get() - values for a given tag name:

```
array_get(regexp_matches('"smoothness"=>"intermediate","surface"=>"asphalt"','\\"surface\\"=>\\"([^\\"]*)\\"'),1)
```

_Note: as per established standards, if regexp_matches() returns an array of captured groups, the first array will contain the text that mathed the full regular expression pattern._