### PR TITLE
Improved default value handling (constraint handling pt 2)

### DIFF
--- a/python/core/qgsvectordataprovider.sip
+++ b/python/core/qgsvectordataprovider.sip
@@ -226,9 +226,20 @@ class QgsVectorDataProvider : QgsDataProvider
                                  const QMap<qint64, QgsGeometry> &geometry_map );
 
     /**
-     * Returns the default value for field specified by @c fieldId
+     * Returns any literal default values which are present at the provider for a specified
+     * field index.
+     * @see defaultValueClause()
      */
-    virtual QVariant defaultValue( int fieldId ) const;
+    virtual QVariant defaultValue( int fieldIndex ) const;
+
+    /**
+     * Returns any default value clauses which are present at the provider for a specified
+     * field index. These clauses are usually SQL fragments which must be evaluated by the
+     * provider, eg sequence values.
+     * @see defaultValue()
+     * @note added in QGIS 3.0
+     */
+    virtual QString defaultValueClause( int fieldIndex ) const;
 
     /**
      * Returns any constraints which are present at the provider for a specified

--- a/src/app/qgisapp.cpp
+++ b/src/app/qgisapp.cpp
@@ -6988,7 +6988,7 @@ void QgisApp::mergeAttributesOfSelectedFeatures()
       QgsField fld( vl->fields().at( i ) );
       bool isDefaultValue = vl->fields().fieldOrigin( i ) == QgsFields::OriginProvider &&
                             vl->dataProvider() &&
-                            vl->dataProvider()->defaultValue( vl->fields().fieldOriginIndex( i ) ) == val;
+                            vl->dataProvider()->defaultValueClause( vl->fields().fieldOriginIndex( i ) ) == val;
 
       // convert to destination data type
       if ( !isDefaultValue && !fld.convertCompatible( val ) )
@@ -7167,7 +7167,7 @@ void QgisApp::mergeSelectedFeatures()
     QVariant val = attrs.at( i );
     bool isDefaultValue = vl->fields().fieldOrigin( i ) == QgsFields::OriginProvider &&
                           vl->dataProvider() &&
-                          vl->dataProvider()->defaultValue( vl->fields().fieldOriginIndex( i ) ) == val;
+                          vl->dataProvider()->defaultValueClause( vl->fields().fieldOriginIndex( i ) ) == val;
 
     // convert to destination data type
     if ( !isDefaultValue && !vl->fields().at( i ).convertCompatible( val ) )
@@ -7481,7 +7481,7 @@ void QgisApp::editPaste( QgsMapLayer *destinationLayer )
       }
       else
       {
-        defVal = pasteVectorLayer->dataProvider()->defaultValue( dst );
+        defVal = pasteVectorLayer->dataProvider()->defaultValueClause( dst );
       }
 
       if ( defVal.isValid() && !defVal.isNull() )

--- a/src/app/qgsfeatureaction.cpp
+++ b/src/app/qgsfeatureaction.cpp
@@ -176,7 +176,17 @@ bool QgsFeatureAction::addFeature( const QgsAttributeMap& defaultAttributes, boo
     }
     else
     {
-      v = provider->defaultValueClause( idx );
+      QVariant defaultLiteral = mLayer->dataProvider()->defaultValue( idx );
+      if ( defaultLiteral.isValid() )
+      {
+        v = defaultLiteral;
+      }
+      else
+      {
+        QString defaultClause = provider->defaultValueClause( idx );
+        if ( !defaultClause.isEmpty() )
+          v = defaultClause;
+      }
     }
 
     mFeature->setAttribute( idx, v );

--- a/src/app/qgsfeatureaction.cpp
+++ b/src/app/qgsfeatureaction.cpp
@@ -176,7 +176,7 @@ bool QgsFeatureAction::addFeature( const QgsAttributeMap& defaultAttributes, boo
     }
     else
     {
-      v = provider->defaultValue( idx );
+      v = provider->defaultValueClause( idx );
     }
 
     mFeature->setAttribute( idx, v );

--- a/src/app/qgsidentifyresultsdialog.cpp
+++ b/src/app/qgsidentifyresultsdialog.cpp
@@ -489,7 +489,7 @@ void QgsIdentifyResultsDialog::addFeature( QgsVectorLayer *vlayer, const QgsFeat
 
     QString defVal;
     if ( fields.fieldOrigin( i ) == QgsFields::OriginProvider && vlayer->dataProvider() )
-      defVal = vlayer->dataProvider()->defaultValue( fields.fieldOriginIndex( i ) ).toString();
+      defVal = vlayer->dataProvider()->defaultValueClause( fields.fieldOriginIndex( i ) );
 
     QString value = defVal == attrs.at( i ) ? defVal : fields.at( i ).displayString( attrs.at( i ) );
     QgsTreeWidgetItem *attrItem = new QgsTreeWidgetItem( QStringList() << QString::number( i ) << value );

--- a/src/app/qgsmergeattributesdialog.cpp
+++ b/src/app/qgsmergeattributesdialog.cpp
@@ -540,7 +540,7 @@ QgsAttributes QgsMergeAttributesDialog::mergedAttributes() const
       if ( !mVectorLayer->defaultValueExpression( fieldIdx ).isEmpty() )
         results[fieldIdx] = mVectorLayer->defaultValue( fieldIdx, mFeatureList.at( 0 ), &context );
       else if ( mVectorLayer->dataProvider() )
-        results[fieldIdx] = mVectorLayer->dataProvider()->defaultValue( fieldIdx );
+        results[fieldIdx] = mVectorLayer->dataProvider()->defaultValueClause( fieldIdx );
       else
         results[fieldIdx] = QVariant();
       continue;
@@ -567,7 +567,7 @@ QgsAttributes QgsMergeAttributesDialog::mergedAttributes() const
     }
     else if ( mVectorLayer->dataProvider() )
     {
-      results[fieldIdx] = mVectorLayer->dataProvider()->defaultValue( fieldIdx );
+      results[fieldIdx] = mVectorLayer->dataProvider()->defaultValueClause( fieldIdx );
     }
     widgetIndex++;
   }

--- a/src/core/qgsofflineediting.cpp
+++ b/src/core/qgsofflineediting.cpp
@@ -793,7 +793,7 @@ void QgsOfflineEditing::applyFeaturesAdded( QgsVectorLayer* offlineLayer, QgsVec
       if ( !remoteLayer->defaultValueExpression( k ).isEmpty() )
         newAttrs[k] = remoteLayer->defaultValue( k, f, &context );
       else if ( remoteFlds.fieldOrigin( k ) == QgsFields::OriginProvider )
-        newAttrs[k] = remoteLayer->dataProvider()->defaultValue( remoteFlds.fieldOriginIndex( k ) );
+        newAttrs[k] = remoteLayer->dataProvider()->defaultValueClause( remoteFlds.fieldOriginIndex( k ) );
     }
 
     f.setAttributes( newAttrs );

--- a/src/core/qgsvectordataprovider.cpp
+++ b/src/core/qgsvectordataprovider.cpp
@@ -98,6 +98,12 @@ QVariant QgsVectorDataProvider::defaultValue( int fieldId ) const
   return QVariant();
 }
 
+QString QgsVectorDataProvider::defaultValueClause( int fieldIndex ) const
+{
+  Q_UNUSED( fieldIndex );
+  return QString();
+}
+
 QgsFieldConstraints::Constraints QgsVectorDataProvider::fieldConstraints( int fieldIndex ) const
 {
   QgsFields f = fields();

--- a/src/core/qgsvectordataprovider.h
+++ b/src/core/qgsvectordataprovider.h
@@ -277,9 +277,20 @@ class CORE_EXPORT QgsVectorDataProvider : public QgsDataProvider
                                  const QgsGeometryMap &geometry_map );
 
     /**
-     * Returns the default value for field specified by @c fieldId
+     * Returns any literal default values which are present at the provider for a specified
+     * field index.
+     * @see defaultValueClause()
      */
-    virtual QVariant defaultValue( int fieldId ) const;
+    virtual QVariant defaultValue( int fieldIndex ) const;
+
+    /**
+     * Returns any default value clauses which are present at the provider for a specified
+     * field index. These clauses are usually SQL fragments which must be evaluated by the
+     * provider, eg sequence values.
+     * @see defaultValue()
+     * @note added in QGIS 3.0
+     */
+    virtual QString defaultValueClause( int fieldIndex ) const;
 
     /**
      * Returns any constraints which are present at the provider for a specified

--- a/src/core/qgsvectorlayereditutils.cpp
+++ b/src/core/qgsvectorlayereditutils.cpp
@@ -381,7 +381,7 @@ int QgsVectorLayerEditUtils::splitFeatures( const QList<QgsPoint>& splitLine, bo
         QgsAttributes newAttributes = feat.attributes();
         Q_FOREACH ( int pkIdx, L->dataProvider()->pkAttributeIndexes() )
         {
-          const QVariant defaultValue = L->dataProvider()->defaultValue( pkIdx );
+          const QVariant defaultValue = L->dataProvider()->defaultValueClause( pkIdx );
           if ( !defaultValue.isNull() )
           {
             newAttributes[ pkIdx ] = defaultValue;

--- a/src/gui/editorwidgets/core/qgseditorwidgetfactory.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetfactory.cpp
@@ -70,7 +70,7 @@ QString QgsEditorWidgetFactory::representValue( QgsVectorLayer* vl, int fieldIdx
 
   QString defVal;
   if ( vl->fields().fieldOrigin( fieldIdx ) == QgsFields::OriginProvider && vl->dataProvider() )
-    defVal = vl->dataProvider()->defaultValue( vl->fields().fieldOriginIndex( fieldIdx ) ).toString();
+    defVal = vl->dataProvider()->defaultValueClause( vl->fields().fieldOriginIndex( fieldIdx ) );
 
   return value == defVal ? defVal : vl->fields().at( fieldIdx ).displayString( value );
 }

--- a/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
+++ b/src/gui/editorwidgets/core/qgseditorwidgetwrapper.cpp
@@ -44,7 +44,7 @@ QgsField QgsEditorWidgetWrapper::field() const
 
 QVariant QgsEditorWidgetWrapper::defaultValue() const
 {
-  mDefaultValue = layer()->dataProvider()->defaultValue( mFieldIdx );
+  mDefaultValue = layer()->dataProvider()->defaultValueClause( mFieldIdx );
 
   return mDefaultValue;
 }

--- a/src/gui/editorwidgets/qgsrangewidgetwrapper.cpp
+++ b/src/gui/editorwidgets/qgsrangewidgetwrapper.cpp
@@ -175,7 +175,7 @@ QVariant QgsRangeWidgetWrapper::value() const
   if ( mDoubleSpinBox )
   {
     value = mDoubleSpinBox->value();
-    if ( value == mDoubleSpinBox->minimum() && config( QStringLiteral( "AllowNull" ) ).toBool() )
+    if ( value == mDoubleSpinBox->minimum() && config( QStringLiteral( "AllowNull" ), true ).toBool() )
     {
       value = QVariant( field().type() );
     }
@@ -183,7 +183,7 @@ QVariant QgsRangeWidgetWrapper::value() const
   else if ( mIntSpinBox )
   {
     value = mIntSpinBox->value();
-    if ( value == mIntSpinBox->minimum() && config( QStringLiteral( "AllowNull" ) ).toBool() )
+    if ( value == mIntSpinBox->minimum() && config( QStringLiteral( "AllowNull" ), true ).toBool() )
     {
       value = QVariant( field().type() );
     }
@@ -212,7 +212,7 @@ void QgsRangeWidgetWrapper::setValue( const QVariant& value )
 {
   if ( mDoubleSpinBox )
   {
-    if ( value.isNull() && config( QStringLiteral( "AllowNull" ) ).toBool() )
+    if ( value.isNull() && config( QStringLiteral( "AllowNull" ), true ).toBool() )
     {
       mDoubleSpinBox->setValue( mDoubleSpinBox->minimum() );
     }
@@ -224,7 +224,7 @@ void QgsRangeWidgetWrapper::setValue( const QVariant& value )
 
   if ( mIntSpinBox )
   {
-    if ( value.isNull() && config( QStringLiteral( "AllowNull" ) ).toBool() )
+    if ( value.isNull() && config( QStringLiteral( "AllowNull" ), true ).toBool() )
     {
       mIntSpinBox->setValue( mIntSpinBox->minimum() );
     }

--- a/src/providers/mssql/qgsmssqlprovider.cpp
+++ b/src/providers/mssql/qgsmssqlprovider.cpp
@@ -433,7 +433,7 @@ void QgsMssqlProvider::loadFields()
 
         if ( !query.value( 12 ).isNull() )
         {
-          mDefaultValues.insert( i, query.value( 12 ) );
+          mDefaultValues.insert( i, query.value( 12 ).toString() );
         }
         ++i;
       }
@@ -501,12 +501,9 @@ QString QgsMssqlProvider::quotedValue( const QVariant& value )
   }
 }
 
-QVariant QgsMssqlProvider::defaultValue( int fieldId ) const
+QString QgsMssqlProvider::defaultValueClause( int fieldId ) const
 {
-  if ( mDefaultValues.contains( fieldId ) )
-    return mDefaultValues[fieldId];
-  else
-    return QVariant( QString::null );
+  return mDefaultValues.value( fieldId, QString() );
 }
 
 QString QgsMssqlProvider::storageType() const
@@ -815,7 +812,7 @@ bool QgsMssqlProvider::addFeatures( QgsFeatureList & flist )
       if ( fld.name().isEmpty() )
         continue; // invalid
 
-      if ( mDefaultValues.contains( i ) && mDefaultValues[i] == attrs.at( i ) )
+      if ( mDefaultValues.contains( i ) && mDefaultValues.value( i ) == attrs.at( i ).toString() )
         continue; // skip fields having default values
 
       if ( !first )
@@ -886,7 +883,7 @@ bool QgsMssqlProvider::addFeatures( QgsFeatureList & flist )
       if ( fld.name().isEmpty() )
         continue; // invalid
 
-      if ( mDefaultValues.contains( i ) && mDefaultValues[i] == attrs.at( i ) )
+      if ( mDefaultValues.contains( i ) && mDefaultValues.value( i ) == attrs.at( i ).toString() )
         continue; // skip fields having default values
 
       QVariant::Type type = fld.type();

--- a/src/providers/mssql/qgsmssqlprovider.h
+++ b/src/providers/mssql/qgsmssqlprovider.h
@@ -186,7 +186,7 @@ class QgsMssqlProvider : public QgsVectorDataProvider
     //! Convert values to quoted values for database work *
     static QString quotedValue( const QVariant& value );
 
-    QVariant defaultValue( int fieldId ) const override;
+    QString defaultValueClause( int fieldId ) const override;
 
     //! Import a vector layer into the database
     static QgsVectorLayerImport::ImportError createEmptyLayer(
@@ -212,7 +212,7 @@ class QgsMssqlProvider : public QgsVectorDataProvider
 
     //! Fields
     QgsFields mAttributeFields;
-    QMap<int, QVariant> mDefaultValues;
+    QMap<int, QString> mDefaultValues;
 
     mutable QgsMssqlGeometryParser mParser;
 

--- a/src/providers/ogr/qgsogrprovider.h
+++ b/src/providers/ogr/qgsogrprovider.h
@@ -124,6 +124,8 @@ class QgsOgrProvider : public QgsVectorDataProvider
 
     virtual QgsRectangle extent() const override;
 
+    QVariant defaultValue( int fieldId ) const override;
+
     /** Update the extents
      */
     virtual void updateExtents() override;
@@ -297,7 +299,12 @@ class QgsOgrProvider : public QgsVectorDataProvider
   private:
     unsigned char *getGeometryPointer( OGRFeatureH fet );
     QString ogrWkbGeometryTypeName( OGRwkbGeometryType type ) const;
+
     QgsFields mAttributeFields;
+
+    //! Map of field index to default value
+    QMap<int, QString> mDefaultValues;
+
     bool mFirstFieldIsFid;
     OGRDataSourceH ogrDataSource;
     mutable OGREnvelope* mExtent;

--- a/src/providers/postgres/qgspostgresprovider.h
+++ b/src/providers/postgres/qgspostgresprovider.h
@@ -160,6 +160,7 @@ class QgsPostgresProvider : public QgsVectorDataProvider
     virtual bool isSaveAndLoadStyleToDBSupported() const override { return true; }
     QgsAttributeList attributeIndexes() const override;
     QgsAttributeList pkAttributeIndexes() const override { return mPrimaryKeyAttrs; }
+    QString defaultValueClause( int fieldId ) const override;
     QVariant defaultValue( int fieldId ) const override;
 
     /** Adds a list of features

--- a/src/providers/spatialite/qgsspatialiteprovider.h
+++ b/src/providers/spatialite/qgsspatialiteprovider.h
@@ -165,6 +165,8 @@ class QgsSpatiaLiteProvider: public QgsVectorDataProvider
     //! Returns a bitmask containing the supported capabilities
     QgsVectorDataProvider::Capabilities capabilities() const override;
 
+    QVariant defaultValue( int fieldId ) const override;
+
     /** The SpatiaLite provider does its own transforms so we return
      * true for the following three functions to indicate that transforms
      * should not be handled by the QgsCoordinateTransform object. See the
@@ -338,6 +340,9 @@ class QgsSpatiaLiteProvider: public QgsVectorDataProvider
     //! Name of the geometry column in the table
     QString mGeometryColumn;
 
+    //! Map of field index to default value
+    QMap<int, QVariant> mDefaultValues;
+
     //! Name of the SpatialIndex table
     QString mIndexTable;
 
@@ -447,6 +452,8 @@ class QgsSpatiaLiteProvider: public QgsVectorDataProvider
                                   int endian_arch );
 
     void fetchConstraints();
+
+    void insertDefaultValue( int fieldIndex, QString defaultVal );
 
     enum GEOS_3D
     {

--- a/tests/src/python/test_provider_spatialite.py
+++ b/tests/src/python/test_provider_spatialite.py
@@ -139,6 +139,10 @@ class TestQgsSpatialiteProvider(unittest.TestCase, ProviderTestCase):
         sql = "CREATE TABLE test_constraints(id INTEGER PRIMARY KEY, num INTEGER NOT NULL, desc TEXT UNIQUE, desc2 TEXT, num2 INTEGER NOT NULL UNIQUE)"
         cur.execute(sql)
 
+        # simple table with defaults
+        sql = "CREATE TABLE test_defaults (id INTEGER NOT NULL PRIMARY KEY, name TEXT DEFAULT 'qgis ''is good', number INTEGER DEFAULT 5, number2 REAL DEFAULT 5.7, no_default REAL)"
+        cur.execute(sql)
+
         cur.execute("COMMIT")
         con.close()
 
@@ -460,6 +464,16 @@ class TestQgsSpatialiteProvider(unittest.TestCase, ProviderTestCase):
         self.assertTrue(f.isValid())
 
         self.assertTrue(vl.commitChanges())
+
+    def testDefaultValues(self):
+
+        l = QgsVectorLayer("dbname=%s table='test_defaults' key='id'" % self.dbname, "test_defaults", "spatialite")
+        self.assertTrue(l.isValid())
+
+        self.assertEqual(l.dataProvider().defaultValue(1), "qgis 'is good")
+        self.assertEqual(l.dataProvider().defaultValue(2), 5)
+        self.assertEqual(l.dataProvider().defaultValue(3), 5.7)
+        self.assertFalse(l.dataProvider().defaultValue(4))
 
 
 if __name__ == '__main__':

--- a/tests/src/python/test_qgsrelationeditwidget.py
+++ b/tests/src/python/test_qgsrelationeditwidget.py
@@ -153,7 +153,7 @@ class TestQgsRelationEditWidget(unittest.TestCase):
         wrapper = self.createWrapper(self.vl_a, '"name"=\'Douglas Adams\'')  # NOQA
 
         f = QgsFeature(self.vl_b.fields())
-        f.setAttributes([self.vl_b.dataProvider().defaultValue(0), 'The Hitchhiker\'s Guide to the Galaxy'])
+        f.setAttributes([self.vl_b.dataProvider().defaultValueClause(0), 'The Hitchhiker\'s Guide to the Galaxy'])
         self.vl_b.addFeature(f)
 
         def choose_linked_feature():
@@ -318,7 +318,7 @@ class VlTools(QgsVectorLayerTools):
             if v:
                 values.append(v)
             else:
-                values.append(layer.dataProvider().defaultValue(i))
+                values.append(layer.dataProvider().defaultValueClause(i))
         f = QgsFeature(layer.fields())
         f.setAttributes(self.values)
         f.setGeometry(defaultGeometry)


### PR DESCRIPTION
This PR improves default value handling, by splitting the handling of literal default values from provider side default value SQL clauses.

QgsVectorDataProvider now has two methods:

- defaultValueClause: returns a SQL fragment which must be evaluated by the provider to obtain the default value, eg sequence values
- defaultValue: returns a literal constant default value for a field

I've updated the existing provider default handling, and added default literal detection for the spatialite and OGR providers (gdal >= 2.0 only).

There's still some uses of the default clauses which should be changed to default literals, but I'll handle them in part 3...
