### PR TITLE
[processing] Allow algorithms to specify tags

### DIFF
--- a/python/plugins/processing/algs/qgis/ExtentFromLayer.py
+++ b/python/plugins/processing/algs/qgis/ExtentFromLayer.py
@@ -54,6 +54,7 @@ class ExtentFromLayer(GeoAlgorithm):
     def defineCharacteristics(self):
         self.name, self.i18n_name = self.trAlgorithm('Polygon from layer extent')
         self.group, self.i18n_group = self.trAlgorithm('Vector general tools')
+        self.tags = self.tr('extent,envelope,bounds,bounding,boundary,layer')
 
         self.addParameter(ParameterVector(self.INPUT_LAYER,
                                           self.tr('Input layer')))

--- a/python/plugins/processing/algs/qgis/MergeLines.py
+++ b/python/plugins/processing/algs/qgis/MergeLines.py
@@ -51,6 +51,7 @@ class MergeLines(GeoAlgorithm):
     def defineCharacteristics(self):
         self.name, self.i18n_name = self.trAlgorithm('Merge lines')
         self.group, self.i18n_group = self.trAlgorithm('Vector geometry tools')
+        self.tags = self.tr('line,merge,join,parts')
 
         self.addParameter(ParameterVector(self.INPUT_LAYER,
                                           self.tr('Input layer'), [dataobjects.TYPE_VECTOR_LINE]))

--- a/python/plugins/processing/core/GeoAlgorithm.py
+++ b/python/plugins/processing/core/GeoAlgorithm.py
@@ -64,6 +64,9 @@ class GeoAlgorithm(object):
         self.name, self.i18n_name = '', ''
         self.group, self.i18n_group = '', ''
 
+        # Tags
+        self.tags = ''
+
         # The crs taken from input layers (if possible), and used when
         # loading output layers
         self.crs = None

--- a/python/plugins/processing/gui/ProcessingToolbox.py
+++ b/python/plugins/processing/gui/ProcessingToolbox.py
@@ -141,6 +141,7 @@ class ProcessingToolbox(BASE, WIDGET):
             item_text = [item.text(0).lower(), item.data(0, Qt.UserRole).lower()]
             if isinstance(item, TreeAlgorithmItem):
                 item_text.append(item.alg.commandLineName())
+                item_text.extend(item.data(0, Qt.UserRole + 1))
 
             hide = bool(text) and not all(
                 any(part in t for t in item_text)
@@ -355,6 +356,7 @@ class TreeAlgorithmItem(QTreeWidgetItem):
         self.setToolTip(0, name)
         self.setText(0, name)
         self.setData(0, Qt.UserRole, nameEn)
+        self.setData(0, Qt.UserRole + 1, alg.tags.split(','))
 
 
 class TreeActionItem(QTreeWidgetItem):

--- a/python/plugins/processing/modeler/ModelerDialog.py
+++ b/python/plugins/processing/modeler/ModelerDialog.py
@@ -472,6 +472,7 @@ class ModelerDialog(BASE, WIDGET):
     def fillAlgorithmTreeUsingProviders(self):
         self.algorithmTree.clear()
         text = str(self.searchBox.text())
+        search_strings = text.split(' ')
         allAlgs = algList.algs
         for providerName in list(allAlgs.keys()):
             name = 'ACTIVATE_' + providerName.upper().replace(' ', '_')
@@ -486,7 +487,15 @@ class ModelerDialog(BASE, WIDGET):
                     continue
                 if alg.commandLineName() == self.alg.commandLineName():
                     continue
-                if text == '' or text.lower() in alg.name.lower():
+
+                item_text = [alg.name.lower()]
+                item_text.extend(alg.tags.split(','))
+
+                show = not search_strings or all(
+                    any(part in t for t in item_text)
+                    for part in search_strings)
+
+                if show:
                     if alg.group in groups:
                         groupItem = groups[alg.group]
                     else:


### PR DESCRIPTION
Tags are used while searching in the toolbox. This should help with finding algorithms when the exact name is not known, eg you could search for "envelope" or "bounds" and find the 'Polygon from Layer Extent' algorithm.

At the moment it's quite hard to discover algorithms which exist when you don't know what their called and have to instead search for every possible naming variant which could exist...