### PR TITLE
[expression] strpos() and regexp_match() improvements

### DIFF
--- a/resources/function_help/json/regexp_match
+++ b/resources/function_help/json/regexp_match
@@ -1,9 +1,9 @@
 {
   "name": "regexp_match",
   "type": "function",
-  "description": "Returns true if any part of a string matches the supplied regular expression.",
+  "description": "Return the first matching position matching a regular expression within a string, or 0 if the substring is not found.",
   "arguments": [ {"arg":"input_string","description":"the string to test against the regular expression"},
   {"arg":"regex","description":"The regular expression to test against. Backslash characters must be double escaped (eg \"\\\\\\\\s\" to match a white space character)."}
   ],
-  "examples": [ { "expression":"regexp_match('QGIS ROCKS','\\\\\\\\sROCKS')", "returns":"true"}]
+  "examples": [ { "expression":"regexp_match('QGIS ROCKS','\\\\\\\\sROCKS')", "returns":"4"}]
 }

--- a/src/core/qgsexpression.cpp
+++ b/src/core/qgsexpression.cpp
@@ -1333,7 +1333,7 @@ static QVariant fcnRegexpMatch( const QVariantList& values, const QgsExpressionC
     parent->setEvalErrorString( QObject::tr( "Invalid regular expression '%1': %2" ).arg( regexp, re.errorString() ) );
     return QVariant();
   }
-  return QVariant( str.contains( re ) ? 1 : 0 );
+  return QVariant(( str.indexOf( re ) + 1 ) );
 }
 
 static QVariant fcnRegexpMatches( const QVariantList& values, const QgsExpressionContext*, QgsExpression* parent )
@@ -1529,7 +1529,7 @@ static QVariant fcnConcat( const QVariantList& values, const QgsExpressionContex
 static QVariant fcnStrpos( const QVariantList& values, const QgsExpressionContext*, QgsExpression *parent )
 {
   QString string = getStringValue( values.at( 0 ), parent );
-  return string.indexOf( QRegExp( getStringValue( values.at( 1 ), parent ) ) ) + 1;
+  return string.indexOf( getStringValue( values.at( 1 ), parent ) ) + 1;
 }
 
 static QVariant fcnRight( const QVariantList& values, const QgsExpressionContext*, QgsExpression *parent )

--- a/tests/src/core/testqgsexpression.cpp
+++ b/tests/src/core/testqgsexpression.cpp
@@ -852,6 +852,7 @@ class TestQgsExpression: public QObject
       QTest::newRow( "regexp_matches no capturing group" ) << "regexp_matches('some string','.*')" << false << QVariant( QVariantList() );
       QTest::newRow( "regexp_matches invalid" ) << "regexp_matches('invalid','(')" << true << QVariant();
       QTest::newRow( "strpos" ) << "strpos('Hello World','World')" << false << QVariant( 7 );
+      QTest::newRow( "strpos non-regexp" ) << "strpos('Hello.World','.')" << false << QVariant( 6 );
       QTest::newRow( "strpos outside" ) << "strpos('Hello World','blah')" << false << QVariant( 0 );
       QTest::newRow( "left" ) << "left('Hello World',5)" << false << QVariant( "Hello" );
       QTest::newRow( "right" ) << "right('Hello World', 5)" << false << QVariant( "World" );
@@ -911,7 +912,7 @@ class TestQgsExpression: public QObject
       QTest::newRow( "coalesce exp" ) << "coalesce(NULL, 1+1)" << false << QVariant( 2 );
       QTest::newRow( "regexp match" ) << "regexp_match('abc','.b.')" << false << QVariant( 1 );
       QTest::newRow( "regexp match invalid" ) << "regexp_match('abc DEF','[[[')" << true << QVariant();
-      QTest::newRow( "regexp match escaped" ) << "regexp_match('abc DEF','\\\\s[A-Z]+')" << false << QVariant( 1 );
+      QTest::newRow( "regexp match escaped" ) << "regexp_match('abc DEF','\\\\s[A-Z]+')" << false << QVariant( 4 );
       QTest::newRow( "regexp match false" ) << "regexp_match('abc DEF','\\\\s[a-z]+')" << false << QVariant( 0 );
       QTest::newRow( "if true" ) << "if(1=1, 1, 0)" << false << QVariant( 1 );
       QTest::newRow( "if false" ) << "if(1=2, 1, 0)" << false << QVariant( 0 );


### PR DESCRIPTION
This PR implements what was discussed in the dev mailing list yesterday (see https://lists.osgeo.org/pipermail/qgis-developer/2016-November/045703.html), namely:
- strpos() now relies on a simple string within a string search
- regexp_match() now returns pos of a matching regular expression

This change means that users using expressions such as `if(regexp_match('blah','blah') = true, ..., ...)` won't work as expected anymore, and would have to be re-written to `if(regexp_match('blah','blah'), ..., ...)`.

IMHO, since we're allowing ourselves to break stuff prior to release of version 3.0, this expression-breaking improvement is warranted 😄 